### PR TITLE
Removes white space from around images

### DIFF
--- a/src/view/com/composer/SelectedPhoto.tsx
+++ b/src/view/com/composer/SelectedPhoto.tsx
@@ -89,5 +89,7 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     backgroundColor: colors.black,
     zIndex: 1,
+    borderColor: colors.gray4,
+    borderWidth: 0.5,
   },
 })


### PR DESCRIPTION
## Problem
* #75 


## Solution
* Remove the whitespace around images
* Added a subtile border around the 'x' button (as it doesn't have the contrast with the white padding anymore)
* Made all images to be previewed as squares similar to the image carousel at the bottom of the same page and image preview on the main user feed

## Testing
* Try uploading several images with differentiating aspect ratios
* Observe that all images appear with no padding around them in the preview section at the top
* Observe that you can successfully upload images similar to before

## Screenshots


|Before|After|
|-|-|
|![before - dark - single](https://user-images.githubusercontent.com/965429/214094929-cc48096f-3e2a-4c80-9392-e673b08a0300.png)|![after - dark - single](https://user-images.githubusercontent.com/965429/214094913-7835a77f-09aa-4b71-9d43-38949d51badf.png)|
|![before - dark - multiple](https://user-images.githubusercontent.com/965429/214094927-d316d35c-4f67-4a8a-859a-9f9e8aabd77a.png)|![after - dark - multiple](https://user-images.githubusercontent.com/965429/214094909-70e75245-2d9e-4579-915c-f04a7a4dd198.png)|
|![before - light - multiple](https://user-images.githubusercontent.com/965429/214094923-a7847290-8944-45c6-9340-7087d63231b1.png)|![after - light - multiple](https://user-images.githubusercontent.com/965429/214094918-22efb0fc-a5cb-47d9-8080-58620903f283.png)|



