### PR TITLE
Adds darkmode support for "Liked by" screen

### DIFF
--- a/src/view/com/post-thread/PostVotedBy.tsx
+++ b/src/view/com/post-thread/PostVotedBy.tsx
@@ -77,11 +77,11 @@ export const PostVotedBy = observer(function PostVotedBy({
 })
 
 const LikedByItem = ({item}: {item: VotesItem}) => {
-  const palette = usePalette('default')
+  const pal = usePalette('default')
 
   return (
     <Link
-      style={[styles.outer, palette.view]}
+      style={[styles.outer, pal.view]}
       href={`/profile/${item.actor.handle}`}
       title={item.actor.handle}
       noFeedback>
@@ -95,10 +95,10 @@ const LikedByItem = ({item}: {item: VotesItem}) => {
           />
         </View>
         <View style={styles.layoutContent}>
-          <Text style={[s.f15, s.bold, palette.text]}>
+          <Text style={[s.f15, s.bold, pal.text]}>
             {item.actor.displayName || item.actor.handle}
           </Text>
-          <Text style={[s.f14, s.gray5, palette.textLight]}>
+          <Text style={[s.f14, s.gray5, pal.textLight]}>
             @{item.actor.handle}
           </Text>
         </View>


### PR DESCRIPTION
## Problem
* #78 


## Solution
* Use `pallete` for Liked By screen

## Testing
* Scroll to a post with multiple likes, click on the post and then on the like number


## Screenshots
Light mode is unchanged

|Before|After|
|-|-|
|<img width="440" alt="Screenshot 2023-01-25 at 2 59 54 PM" src="https://user-images.githubusercontent.com/965429/214677399-23228a34-573f-4ce7-b678-65128be0c70f.png">|<img width="440" alt="Screenshot 2023-01-25 at 2 59 28 PM" src="https://user-images.githubusercontent.com/965429/214677400-b23276a0-0ad1-4fce-a49f-39ab0da93efc.png">|
|<img width="441" alt="Screenshot 2023-01-25 at 3 03 17 PM" src="https://user-images.githubusercontent.com/965429/214677394-e66b03ef-fddd-4d15-add2-f03fc100c644.png">|<img width="442" alt="Screenshot 2023-01-25 at 3 00 18 PM" src="https://user-images.githubusercontent.com/965429/214677397-c808dec8-2967-4c4d-a235-6a0d36801b89.png">|


