### PR TITLE
Fix to ordering of images in the embed grid

### DIFF
--- a/src/view/com/util/images/ImageLayoutGrid.tsx
+++ b/src/view/com/util/images/ImageLayoutGrid.tsx
@@ -158,20 +158,20 @@ function ImageLayoutGridInner({
           <View style={styles.hSpace} />
           <TouchableOpacity
             delayPressIn={DELAY_PRESS_IN}
-            onPress={() => onPress?.(1)}
-            onPressIn={() => onPressIn?.(1)}
-            onLongPress={() => onLongPress(1)}>
-            <Image source={{uri: uris[1]}} style={size1} />
+            onPress={() => onPress?.(2)}
+            onPressIn={() => onPressIn?.(2)}
+            onLongPress={() => onLongPress(2)}>
+            <Image source={{uri: uris[2]}} style={size1} />
           </TouchableOpacity>
         </View>
         <View style={styles.wSpace} />
         <View>
           <TouchableOpacity
             delayPressIn={DELAY_PRESS_IN}
-            onPress={() => onPress?.(2)}
-            onPressIn={() => onPressIn?.(2)}
-            onLongPress={() => onLongPress(2)}>
-            <Image source={{uri: uris[2]}} style={size1} />
+            onPress={() => onPress?.(1)}
+            onPressIn={() => onPressIn?.(1)}
+            onLongPress={() => onLongPress(1)}>
+            <Image source={{uri: uris[1]}} style={size1} />
           </TouchableOpacity>
           <View style={styles.hSpace} />
           <TouchableOpacity


### PR DESCRIPTION
|Before|After|
|-|-|
|<img width="392" alt="CleanShot 2023-01-31 at 10 27 31@2x" src="https://user-images.githubusercontent.com/1270099/215821058-c3e9a2a3-6da1-4ab1-88f1-960d3015f971.png">|<img width="379" alt="CleanShot 2023-01-31 at 10 28 37@2x" src="https://user-images.githubusercontent.com/1270099/215821082-5c996dec-7811-48bf-9a59-35b5fda2d4d4.png">|

