### PR TITLE
Fix blank screen condition in lightbox rendering

### DIFF
--- a/src/view/com/lightbox/ImageViewing/index.tsx
+++ b/src/view/com/lightbox/ImageViewing/index.tsx
@@ -86,12 +86,18 @@ function ImageViewing({
     [toggleBarsVisible],
   )
 
+  const onLayout = useCallback(() => {
+    if (imageIndex) {
+      imageList.current?.scrollToIndex({index: imageIndex, animated: false})
+    }
+  }, [imageList, imageIndex])
+
   if (!visible) {
     return null
   }
 
   return (
-    <View style={styles.screen}>
+    <View style={styles.screen} onLayout={onLayout}>
       <Modal />
       <View style={[styles.container, {opacity, backgroundColor}]}>
         <Animated.View style={[styles.header, {transform: headerTransform}]}>
@@ -110,7 +116,6 @@ function ImageViewing({
           pagingEnabled
           showsHorizontalScrollIndicator={false}
           showsVerticalScrollIndicator={false}
-          initialScrollIndex={imageIndex}
           getItem={(_, index) => images[index]}
           getItemCount={() => images.length}
           getItemLayout={(_, index) => ({


### PR DESCRIPTION
We had another case where the lightbox would show a blank screen. If you jump to an image in a list that's not the first and then scroll backwards, you got the blank screen.

This appears to be another react issue: https://stackoverflow.com/questions/44540621/initialscrollindex-not-working-for-flatlist-react-native

Switching to an imperative scroll() call after render fixes it.