### PR TITLE
Improve feed scroll performance

### DIFF
--- a/src/view/com/posts/Feed.tsx
+++ b/src/view/com/posts/Feed.tsx
@@ -103,6 +103,7 @@ export const Feed = observer(function Feed({
           onScroll={onScroll}
           onRefresh={onRefresh}
           onEndReached={onEndReached}
+          removeClippedSubviews={true}
         />
       )}
     </View>

--- a/src/view/com/util/ViewSelector.tsx
+++ b/src/view/com/util/ViewSelector.tsx
@@ -100,6 +100,7 @@ export function ViewSelector({
         onRefresh={onRefresh}
         onEndReached={onEndReached}
         contentContainerStyle={s.contentContainer}
+        removeClippedSubviews={true}
       />
     </HorzSwipe>
   )


### PR DESCRIPTION
With the higher rez images, I've started to notice some scroll jank. After some googling, I saw a recommendation to enable [removeClippedSubviews](https://reactnative.dev/docs/scrollview#removeclippedsubviews). The [relevant docs](https://reactnative.dev/docs/optimizing-flatlist-configuration#removeclippedsubviews) warn that it could cause some bugs, but I haven't seen anything in testing _yet_ and the performance improvement is pretty significant.