### PR TITLE
Calculate image aspect ratio on load

### DIFF
--- a/src/view/com/util/images/Image.tsx
+++ b/src/view/com/util/images/Image.tsx
@@ -5,6 +5,9 @@ import {DELAY_PRESS_IN} from './constants'
 import {LOADING} from '../../../lib/assets'
 import {clamp} from '../../../../lib/numbers'
 
+const MIN_ASPECT_RATIO = 0.33 // 1/3
+const MAX_ASPECT_RATIO = 5 // 5/1
+
 export function Image({
   uri,
   onPress,
@@ -20,7 +23,13 @@ export function Image({
 }) {
   const [aspectRatio, setAspectRatio] = React.useState<number>(1)
   const onLoad = (e: OnLoadEvent) => {
-    setAspectRatio(clamp(e.nativeEvent.width / e.nativeEvent.height, 0.33, 5))
+    setAspectRatio(
+      clamp(
+        e.nativeEvent.width / e.nativeEvent.height,
+        MIN_ASPECT_RATIO,
+        MAX_ASPECT_RATIO,
+      ),
+    )
   }
   return (
     <TouchableOpacity


### PR DESCRIPTION
Closes #145

Problem: Images were using the 1/1 aspect ratio in all cases. We have to set an aspect ratio to get images to fill the available width, but the aspect ratio calculates off the layout and _not_ the image dimensions, so a 1/1 ratio in a 500px width space sets the height to 500px.

Solution: Grab the width & height on load and set the aspect ratio to match the image, using a clamp to avoid extreme ratios.

|Before|After|
|-|-|
|<img width="389" alt="image" src="https://user-images.githubusercontent.com/1270099/216650334-a7e06f62-223a-4464-b185-a4b56ec574d5.png">|<img width="389" alt="image" src="https://user-images.githubusercontent.com/1270099/216650271-643a2dd0-c581-481c-9a3c-cdff5a892df9.png">|