### PR TITLE
Adds respots under the 'post' tab under profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@
 
 ## Various notes
 
+### Debugging
+
+- Note that since 0.70, debugging using the old debugger (which shows up using CMD+D) doesn't work anymore. Follow the instructions below to debug the code: https://reactnative.dev/docs/next/hermes#debugging-js-on-hermes-using-google-chromes-devtools
+
 ### Running E2E Tests
 
 - Make sure you've setup your environment following above

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -13,9 +13,9 @@ PODS:
     - ReactCommon/turbomodule/core (= 0.71.1)
   - fmt (6.2.1)
   - glog (0.3.5)
-  - hermes-engine (0.71.0):
-    - hermes-engine/Pre-built (= 0.71.0)
-  - hermes-engine/Pre-built (0.71.0)
+  - hermes-engine (0.71.1):
+    - hermes-engine/Pre-built (= 0.71.1)
+  - hermes-engine/Pre-built (0.71.1)
   - libevent (2.1.12)
   - libwebp (1.2.4):
     - libwebp/demux (= 1.2.4)
@@ -637,14 +637,14 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/yoga"
 
 SPEC CHECKSUMS:
-  boost: a7c83b31436843459a1961bfd74b96033dc77234
+  boost: 57d2868c099736d80fcd648bf211b4431e51a558
   BVLinearGradient: 34a999fda29036898a09c6a6b728b0b4189e1a44
-  DoubleConversion: 831926d9b8bf8166fd87886c4abab286c2422662
+  DoubleConversion: 5189b271737e1565bdce30deb4a08d647e3f5f54
   FBLazyVector: ad72713385db5289b19f1ead07e8e4aa26dcb01d
   FBReactNativeSpec: df2602c11e33d310433496e28a48b4b2be652a61
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
-  glog: 476ee3e89abb49e07f822b48323c51c57124b572
-  hermes-engine: f6e715aa6c8bd38de6c13bc85e07b0a337edaa89
+  glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
+  hermes-engine: 922ccd744f50d9bfde09e9677bf0f3b562ea5fb9
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   libwebp: f62cb61d0a484ba548448a4bd52aabf150ff6eef
   Permission-Camera: bf6791b17c7f614b6826019fcfdcc286d3a107f6

--- a/src/state/models/feed-view.ts
+++ b/src/state/models/feed-view.ts
@@ -229,13 +229,22 @@ export class FeedModel {
   }
 
   get nonReplyFeed() {
-    return this.feed.filter(
-      item =>
+    const nonReplyFeed = this.feed.filter(item => {
+      const params = this.params as GetAuthorFeed.QueryParams
+      const isRepost =
+        item.reply &&
+        (item?.reasonRepost?.by?.handle === params.author ||
+          item?.reasonRepost?.by?.did === params.author)
+
+      return (
         !item.reply || // not a reply
+        isRepost ||
         ((item._isThreadParent || // but allow if it's a thread by the user
           item._isThreadChild) &&
-          item.reply?.root.author.did === item.post.author.did),
-    )
+          item.reply?.root.author.did === item.post.author.did)
+      )
+    })
+    return nonReplyFeed
   }
 
   setHasNewLatest(v: boolean) {


### PR DESCRIPTION
## Problem 
#113 

## Solution
* Don't filter out reposts from the posts tab
* This PR also adds some missing instructions to the readme, and fixes Hermes versionsing 

## To test
* Login as user A
* Repost something
* Login as user B
* Go to user A's profile
* On master the repost wont show under `post` but on this branch it should

## Screenshots


|Before|After|
|-|-|
|<img width="300" alt="Screenshot 2023-01-25 at 2 59 54 PM" src="https://user-images.githubusercontent.com/965429/217050660-5bdbe22e-ecdf-432c-8fc4-bda669ad66bc.png">|<img width="300" alt="Screenshot 2023-01-25 at 2 59 28 PM" src="https://user-images.githubusercontent.com/965429/217050649-d82d8d77-2dff-42cc-91d5-84e5c6035a8d.png">|
