### PR TITLE
Adds dark mode to delete account screen

### DIFF
--- a/src/view/com/modals/DeleteAccount.tsx
+++ b/src/view/com/modals/DeleteAccount.tsx
@@ -61,12 +61,12 @@ export function Component({}: {}) {
     <View
       style={[styles.container, {backgroundColor: pal.colors.backgroundLight}]}>
       <View style={[styles.innerContainer, pal.view]}>
-        <Text type="title-xl" style={styles.title}>
+        <Text type="title-xl" style={[styles.title, pal.text]}>
           Delete account
         </Text>
         {!isEmailSent ? (
           <>
-            <Text type="lg" style={styles.description}>
+            <Text type="lg" style={[styles.description, pal.text]}>
               For security reasons, we'll need to send a confirmation code to
               your email.
             </Text>


### PR DESCRIPTION
## Problem
* Delete account modal not readable in dark mode

## Solution
* Adds dark mode colors to delete account modal texts 

## Test
* Switch to dark mode
* Go to settings -> delete account

## Screenshot

|Before|After|
|-|-|
|<img width="300" alt="Screenshot 2023-01-25 at 2 59 54 PM" src="https://user-images.githubusercontent.com/965429/217051819-d71369de-4a4b-4d3e-89a7-a29a40259fd3.png">|<img width="300" alt="Screenshot 2023-01-25 at 2 59 28 PM" src="https://user-images.githubusercontent.com/965429/217051823-4547e0be-28a8-4abd-8a3b-850e79f93a16.png">|
