### PR TITLE
87 dark mode edit profile

### DIFF
--- a/src/view/com/modals/EditProfile.tsx
+++ b/src/view/com/modals/EditProfile.tsx
@@ -139,7 +139,7 @@ export function Component({
           <BottomSheetTextInput
             style={[styles.textInput, pal.text]}
             placeholder="e.g. Alice Roberts"
-            placeholderTextColor={pal.textLight}
+            placeholderTextColor={colors.gray4}
             value={displayName}
             onChangeText={v => setDisplayName(enforceLen(v, MAX_DISPLAY_NAME))}
           />


### PR DESCRIPTION
## Problem
* #157 

## Solution
* Adds darkmode to the description field

## Testing
* Go to edit profile
* Try typing a description

## Screenshots


Without Text:
|Before|After|
|-|-|
|<img width="300" alt="Screenshot 2023-01-25 at 2 59 54 PM" src="https://user-images.githubusercontent.com/965429/217063621-3b19b231-653e-446f-888d-1d5e3bce3892.png">|<img width="300" alt="Screenshot 2023-01-25 at 2 59 28 PM" src="https://user-images.githubusercontent.com/965429/217063710-bf355cc5-d62d-4c90-b923-65953ca9c710.png">|
|<img width="300" alt="Screenshot 2023-01-25 at 2 59 54 PM" src="https://user-images.githubusercontent.com/965429/217063991-64caceb7-5498-4c0b-a9ec-c46ac6ef95b1.png">|<img width="300" alt="Screenshot 2023-01-25 at 2 59 28 PM" src="https://user-images.githubusercontent.com/965429/217063994-b38a4381-d2df-42b3-8965-e96d233f8991.png">|




With Text (light mode is unchanged):
|Before|After|
|-|-|
|<img width="300" alt="Screenshot 2023-01-25 at 2 59 54 PM" src="https://user-images.githubusercontent.com/965429/217063292-72360b7b-f5e1-4948-a92e-d58b7ca0025f.png">|<img width="300" alt="Screenshot 2023-01-25 at 2 59 28 PM" src="https://user-images.githubusercontent.com/965429/217063193-5ed9dc21-4c41-455b-9e87-29dfc2a00691.png">|


