### PR TITLE
Fix potential issues with promise guards when an error occurs

### DIFF
--- a/src/state/models/feed-view.ts
+++ b/src/state/models/feed-view.ts
@@ -187,10 +187,11 @@ export class FeedModel {
   hasMore = true
   loadMoreCursor: string | undefined
   pollCursor: string | undefined
-  _loadPromise: Promise<void> | undefined
-  _loadMorePromise: Promise<void> | undefined
-  _loadLatestPromise: Promise<void> | undefined
-  _updatePromise: Promise<void> | undefined
+
+  private _loadPromise: Promise<void> | undefined
+  private _loadMorePromise: Promise<void> | undefined
+  private _loadLatestPromise: Promise<void> | undefined
+  private _updatePromise: Promise<void> | undefined
 
   // data
   feed: FeedItemModel[] = []
@@ -206,10 +207,6 @@ export class FeedModel {
         rootStore: false,
         params: false,
         loadMoreCursor: false,
-        _loadPromise: false,
-        _loadMorePromise: false,
-        _loadLatestPromise: false,
-        _updatePromise: false,
       },
       {autoBind: true},
     )
@@ -284,8 +281,11 @@ export class FeedModel {
     await this._pendingWork()
     this.setHasNewLatest(false)
     this._loadPromise = this._initialLoad(isRefreshing)
-    await this._loadPromise
-    this._loadPromise = undefined
+    try {
+      await this._loadPromise
+    } finally {
+      this._loadPromise = undefined
+    }
   }
 
   /**
@@ -312,8 +312,11 @@ export class FeedModel {
     }
     await this._pendingWork()
     this._loadMorePromise = this._loadMore()
-    await this._loadMorePromise
-    this._loadMorePromise = undefined
+    try {
+      await this._loadMorePromise
+    } finally {
+      this._loadMorePromise = undefined
+    }
   }
 
   /**
@@ -326,8 +329,11 @@ export class FeedModel {
     await this._pendingWork()
     this.setHasNewLatest(false)
     this._loadLatestPromise = this._loadLatest()
-    await this._loadLatestPromise
-    this._loadLatestPromise = undefined
+    try {
+      await this._loadLatestPromise
+    } finally {
+      this._loadLatestPromise = undefined
+    }
   }
 
   /**
@@ -339,8 +345,11 @@ export class FeedModel {
     }
     await this._pendingWork()
     this._updatePromise = this._update()
-    await this._updatePromise
-    this._updatePromise = undefined
+    try {
+      await this._updatePromise
+    } finally {
+      this._updatePromise = undefined
+    }
   }
 
   /**

--- a/src/state/models/notifications-view.ts
+++ b/src/state/models/notifications-view.ts
@@ -190,9 +190,10 @@ export class NotificationsViewModel {
   params: ListNotifications.QueryParams
   hasMore = true
   loadMoreCursor?: string
-  _loadPromise: Promise<void> | undefined
-  _loadMorePromise: Promise<void> | undefined
-  _updatePromise: Promise<void> | undefined
+
+  private _loadPromise: Promise<void> | undefined
+  private _loadMorePromise: Promise<void> | undefined
+  private _updatePromise: Promise<void> | undefined
 
   // data
   notifications: NotificationsViewItemModel[] = []
@@ -210,9 +211,6 @@ export class NotificationsViewModel {
         rootStore: false,
         params: false,
         mostRecentNotification: false,
-        _loadPromise: false,
-        _loadMorePromise: false,
-        _updatePromise: false,
       },
       {autoBind: true},
     )
@@ -282,8 +280,11 @@ export class NotificationsViewModel {
     }
     await this._pendingWork()
     this._loadMorePromise = this._loadMore()
-    await this._loadMorePromise
-    this._loadMorePromise = undefined
+    try {
+      await this._loadMorePromise
+    } finally {
+      this._loadMorePromise = undefined
+    }
   }
 
   /**
@@ -295,8 +296,11 @@ export class NotificationsViewModel {
     }
     await this._pendingWork()
     this._updatePromise = this._update()
-    await this._updatePromise
-    this._updatePromise = undefined
+    try {
+      await this._updatePromise
+    } finally {
+      this._updatePromise = undefined
+    }
   }
 
   /**

--- a/src/state/models/reposted-by-view.ts
+++ b/src/state/models/reposted-by-view.ts
@@ -64,8 +64,11 @@ export class RepostedByViewModel {
       return this._loadMorePromise
     }
     this._loadMorePromise = this._load(isRefreshing)
-    await this._loadMorePromise
-    this._loadMorePromise = undefined
+    try {
+      await this._loadMorePromise
+    } finally {
+      this._loadMorePromise = undefined
+    }
   }
 
   // state transitions

--- a/src/state/models/suggested-actors-view.ts
+++ b/src/state/models/suggested-actors-view.ts
@@ -54,8 +54,11 @@ export class SuggestedActorsViewModel {
       return this._loadMorePromise
     }
     this._loadMorePromise = this._load(isRefreshing)
-    await this._loadMorePromise
-    this._loadMorePromise = undefined
+    try {
+      await this._loadMorePromise
+    } finally {
+      this._loadMorePromise = undefined
+    }
   }
 
   // state transitions

--- a/src/state/models/user-followers-view.ts
+++ b/src/state/models/user-followers-view.ts
@@ -68,8 +68,11 @@ export class UserFollowersViewModel {
       return this._loadMorePromise
     }
     this._loadMorePromise = this._load(isRefreshing)
-    await this._loadMorePromise
-    this._loadMorePromise = undefined
+    try {
+      await this._loadMorePromise
+    } finally {
+      this._loadMorePromise = undefined
+    }
   }
 
   // state transitions

--- a/src/state/models/user-follows-view.ts
+++ b/src/state/models/user-follows-view.ts
@@ -68,8 +68,11 @@ export class UserFollowsViewModel {
       return this._loadMorePromise
     }
     this._loadMorePromise = this._load(isRefreshing)
-    await this._loadMorePromise
-    this._loadMorePromise = undefined
+    try {
+      await this._loadMorePromise
+    } finally {
+      this._loadMorePromise = undefined
+    }
   }
 
   // state transitions

--- a/src/state/models/votes-view.ts
+++ b/src/state/models/votes-view.ts
@@ -61,8 +61,11 @@ export class VotesViewModel {
       return this._loadMorePromise
     }
     this._loadMorePromise = this._load(isRefreshing)
-    await this._loadMorePromise
-    this._loadMorePromise = undefined
+    try {
+      await this._loadMorePromise
+    } finally {
+      this._loadMorePromise = undefined
+    }
   }
 
   // state transitions


### PR DESCRIPTION
This pattern -- which I call "promise guards" but I dont know what other folks call it -- is used to ensure only one call of a function is in-flight at a time.

This PR fixes a potential issue that could occur if the inner promise rejects. Prior to this PR a rejection would cause all future requests to fail with the same error. (Testing confirms that's the case so I'm surprised we've never seen this happen before.)