### PR TITLE
Refactor models to use bundleAsync and lock regions

### DIFF
--- a/__tests__/lib/async/bundle.test.ts
+++ b/__tests__/lib/async/bundle.test.ts
@@ -1,0 +1,47 @@
+import {bundleAsync} from '../../../src/lib/async/bundle'
+
+describe('bundle', () => {
+  it('bundles multiple simultaneous calls into one execution', async () => {
+    let calls = 0
+    const fn = bundleAsync(async () => {
+      calls++
+      await new Promise(r => setTimeout(r, 1))
+      return 'hello'
+    })
+    const [res1, res2, res3] = await Promise.all([fn(), fn(), fn()])
+    expect(calls).toEqual(1)
+    expect(res1).toEqual('hello')
+    expect(res2).toEqual('hello')
+    expect(res3).toEqual('hello')
+  })
+  it('does not bundle non-simultaneous calls', async () => {
+    let calls = 0
+    const fn = bundleAsync(async () => {
+      calls++
+      await new Promise(r => setTimeout(r, 1))
+      return 'hello'
+    })
+    const res1 = await fn()
+    const res2 = await fn()
+    const res3 = await fn()
+    expect(calls).toEqual(3)
+    expect(res1).toEqual('hello')
+    expect(res2).toEqual('hello')
+    expect(res3).toEqual('hello')
+  })
+  it('is not affected by rejections', async () => {
+    let calls = 0
+    const fn = bundleAsync(async () => {
+      calls++
+      await new Promise(r => setTimeout(r, 1))
+      throw new Error()
+    })
+    const res1 = await fn().catch(() => 'reject')
+    const res2 = await fn().catch(() => 'reject')
+    const res3 = await fn().catch(() => 'reject')
+    expect(calls).toEqual(3)
+    expect(res1).toEqual('reject')
+    expect(res2).toEqual('reject')
+    expect(res3).toEqual('reject')
+  })
+})

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@segment/analytics-react-native": "^2.10.1",
     "@segment/sovran-react-native": "^0.4.5",
     "@zxing/text-encoding": "^0.9.0",
+    "await-lock": "^2.2.2",
     "base64-js": "^1.5.1",
     "email-validator": "^2.0.4",
     "he": "^1.2.0",

--- a/src/lib/async/bundle.ts
+++ b/src/lib/async/bundle.ts
@@ -1,0 +1,24 @@
+type BundledFn<Args extends readonly unknown[], Res> = (
+  ...args: Args
+) => Promise<Res>
+
+/**
+ * A helper which ensures that multiple calls to an async function
+ * only produces one in-flight request at a time.
+ */
+export function bundleAsync<Args extends readonly unknown[], Res>(
+  fn: BundledFn<Args, Res>,
+): BundledFn<Args, Res> {
+  let promise: Promise<Res> | undefined
+  return async (...args) => {
+    if (promise) {
+      return promise
+    }
+    promise = fn(...args)
+    try {
+      return await promise
+    } finally {
+      promise = undefined
+    }
+  }
+}

--- a/src/state/models/user-followers-view.ts
+++ b/src/state/models/user-followers-view.ts
@@ -5,6 +5,7 @@ import {
 } from '@atproto/api'
 import {RootStoreModel} from './root-store'
 import {cleanError} from '../../lib/strings'
+import {bundleAsync} from '../../lib/async/bundle'
 
 const PAGE_SIZE = 30
 
@@ -19,7 +20,6 @@ export class UserFollowersViewModel {
   params: GetFollowers.QueryParams
   hasMore = true
   loadMoreCursor?: string
-  private _loadMorePromise: Promise<void> | undefined
 
   // data
   subject: ActorRef.WithInfo = {
@@ -63,17 +63,27 @@ export class UserFollowersViewModel {
     return this.loadMore(true)
   }
 
-  async loadMore(isRefreshing = false) {
-    if (this._loadMorePromise) {
-      return this._loadMorePromise
+  loadMore = bundleAsync(async (replace: boolean = false) => {
+    if (!replace && !this.hasMore) {
+      return
     }
-    this._loadMorePromise = this._load(isRefreshing)
+    this._xLoading(replace)
     try {
-      await this._loadMorePromise
-    } finally {
-      this._loadMorePromise = undefined
+      const params = Object.assign({}, this.params, {
+        limit: PAGE_SIZE,
+        before: replace ? undefined : this.loadMoreCursor,
+      })
+      const res = await this.rootStore.api.app.bsky.graph.getFollowers(params)
+      if (replace) {
+        this._replaceAll(res)
+      } else {
+        this._appendAll(res)
+      }
+      this._xIdle()
+    } catch (e: any) {
+      this._xIdle(e)
     }
-  }
+  })
 
   // state transitions
   // =
@@ -94,30 +104,8 @@ export class UserFollowersViewModel {
     }
   }
 
-  // loader functions
+  // helper functions
   // =
-
-  private async _load(replace = false) {
-    if (!replace && !this.hasMore) {
-      return
-    }
-    this._xLoading(replace)
-    try {
-      const params = Object.assign({}, this.params, {
-        limit: PAGE_SIZE,
-        before: replace ? undefined : this.loadMoreCursor,
-      })
-      const res = await this.rootStore.api.app.bsky.graph.getFollowers(params)
-      if (replace) {
-        this._replaceAll(res)
-      } else {
-        this._appendAll(res)
-      }
-      this._xIdle()
-    } catch (e: any) {
-      this._xIdle(e)
-    }
-  }
 
   private _replaceAll(res: GetFollowers.Response) {
     this.followers = []

--- a/yarn.lock
+++ b/yarn.lock
@@ -3712,6 +3712,11 @@ autoprefixer@^10.4.13:
     picocolors "^1.0.0"
     postcss-value-parser "^4.2.0"
 
+await-lock@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/await-lock/-/await-lock-2.2.2.tgz#a95a9b269bfd2f69d22b17a321686f551152bcef"
+  integrity sha512-aDczADvlvTGajTDjcjpJMqRkOF6Qdz3YbPZm/PyW6tKPkx2hlYBzxMhEywM/tU72HrVZjgl5VCdRuMlA7pZ8Gw==
+
 axe-core@^4.4.3:
   version "4.6.1"
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.6.1.tgz#79cccdee3e3ab61a8f42c458d4123a6768e6fbce"


### PR DESCRIPTION
This PR does a little cleanup around how models are managing async linearization. The behavior isn't changed, but hopefully the semantics are clearer.

- Introduces `bundleAsync`, a wrapper method that ensures multiple calls to an async method will reuse any existing async in progress.
- Introduces `AwaitLock`, a helper for introducing lock regions across multiple functions.