### PR TITLE
Add scroll-to-top for all screens

### DIFF
--- a/__mocks__/state-mock.ts
+++ b/__mocks__/state-mock.ts
@@ -658,6 +658,7 @@ export const mockedRootStore = {
   profiles: mockedProfilesStore,
   linkMetas: mockedLinkMetasStore,
   log: mockedLogStore,
+  onScreenSoftReset: jest.fn().mockReturnValue({remove: jest.fn()}),
 } as RootStoreModel
 
 export const mockedProfileUiStore = {

--- a/src/state/models/root-store.ts
+++ b/src/state/models/root-store.ts
@@ -166,6 +166,16 @@ export class RootStoreModel {
     DeviceEventEmitter.emit('navigation')
   }
 
+  // a "soft reset" typically means scrolling to top and loading latest
+  // but it can depend on the screen
+  onScreenSoftReset(handler: () => void): EmitterSubscription {
+    return DeviceEventEmitter.addListener('screen-soft-reset', handler)
+  }
+
+  emitScreenSoftReset() {
+    DeviceEventEmitter.emit('screen-soft-reset')
+  }
+
   // background fetch
   // =
   // - we use this to poll for unread notifications, which is not "ideal" behavior but

--- a/src/view/com/notifications/Feed.tsx
+++ b/src/view/com/notifications/Feed.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, {MutableRefObject} from 'react'
 import {observer} from 'mobx-react-lite'
 import {FlatList, StyleSheet, View} from 'react-native'
 import {NotificationsViewModel} from '../../../state/models/notifications-view'
@@ -13,10 +13,12 @@ const EMPTY_FEED_ITEM = {_reactKey: '__empty__'}
 
 export const Feed = observer(function Feed({
   view,
+  scrollElRef,
   onPressTryAgain,
   onScroll,
 }: {
   view: NotificationsViewModel
+  scrollElRef?: MutableRefObject<FlatList<any> | null>
   onPressTryAgain?: () => void
   onScroll?: OnScrollCb
 }) {
@@ -66,6 +68,7 @@ export const Feed = observer(function Feed({
       )}
       {data && (
         <FlatList
+          ref={scrollElRef}
           data={data}
           keyExtractor={item => item._reactKey}
           renderItem={renderItem}

--- a/src/view/routes.ts
+++ b/src/view/routes.ts
@@ -1,5 +1,4 @@
-import React, {MutableRefObject} from 'react'
-import {FlatList} from 'react-native'
+import React from 'react'
 import {IconProp} from '@fortawesome/fontawesome-svg-core'
 import {Home} from './screens/Home'
 import {Contacts} from './screens/Contacts'
@@ -21,7 +20,6 @@ export type ScreenParams = {
   navIdx: string
   params: Record<string, any>
   visible: boolean
-  scrollElRef?: MutableRefObject<FlatList<any> | undefined>
 }
 export type Route = [React.FC<ScreenParams>, string, IconProp, RegExp]
 export type MatchResult = {

--- a/src/view/screens/Search.tsx
+++ b/src/view/screens/Search.tsx
@@ -29,6 +29,7 @@ export const Search = observer(({navIdx, visible, params}: ScreenParams) => {
   const pal = usePalette('default')
   const store = useStores()
   const {track} = useAnalytics()
+  const scrollElRef = React.useRef<ScrollView>(null)
   const textInput = React.useRef<TextInput>(null)
   const [lastRenderTime, setRenderTime] = React.useState<number>(0) // used to trigger reloads
   const [isInputFocused, setIsInputFocused] = React.useState<boolean>(false)
@@ -39,7 +40,16 @@ export const Search = observer(({navIdx, visible, params}: ScreenParams) => {
   )
   const {name} = params
 
+  const onSoftReset = () => {
+    scrollElRef.current?.scrollTo({x: 0, y: 0})
+  }
+
   React.useEffect(() => {
+    const softResetSub = store.onScreenSoftReset(onSoftReset)
+    const cleanup = () => {
+      softResetSub.remove()
+    }
+
     if (visible) {
       const now = Date.now()
       if (lastRenderTime - now > FIVE_MIN) {
@@ -49,6 +59,7 @@ export const Search = observer(({navIdx, visible, params}: ScreenParams) => {
       autocompleteView.setup()
       store.nav.setTitle(navIdx, 'Search')
     }
+    return cleanup
   }, [store, visible, name, navIdx, autocompleteView, lastRenderTime])
 
   const onPressMenu = () => {
@@ -143,7 +154,7 @@ export const Search = observer(({navIdx, visible, params}: ScreenParams) => {
               </Text>
             </View>
           ) : (
-            <ScrollView onScroll={Keyboard.dismiss}>
+            <ScrollView onScroll={Keyboard.dismiss} ref={scrollElRef}>
               <WhoToFollow key={`wtf-${lastRenderTime}`} />
               <SuggestedPosts key={`sp-${lastRenderTime}`} />
               <View style={s.footerSpacer} />

--- a/src/view/shell/mobile/index.tsx
+++ b/src/view/shell/mobile/index.tsx
@@ -1,9 +1,8 @@
-import React, {useState, useEffect, useRef} from 'react'
+import React, {useState, useEffect} from 'react'
 import {observer} from 'mobx-react-lite'
 import {
   Animated,
   Easing,
-  FlatList,
   GestureResponderEvent,
   StatusBar,
   StyleSheet,
@@ -148,7 +147,6 @@ export const MobileShell: React.FC = observer(() => {
   const pal = usePalette('default')
   const store = useStores()
   const [isTabsSelectorActive, setTabsSelectorActive] = useState(false)
-  const scrollElRef = useRef<FlatList | undefined>()
   const winDim = useWindowDimensions()
   const [menuSwipingDirection, setMenuSwipingDirection] = useState(0)
   const swipeGestureInterp = useAnimatedValue(0)
@@ -164,8 +162,8 @@ export const MobileShell: React.FC = observer(() => {
   const onPressHome = () => {
     track('MobileShell:HomeButtonPressed')
     if (store.nav.tab.fixedTabPurpose === TabPurpose.Default) {
-      if (store.nav.tab.current.url === '/') {
-        scrollElRef.current?.scrollToOffset({offset: 0})
+      if (!store.nav.tab.canGoBack) {
+        store.emitScreenSoftReset()
       } else {
         store.nav.tab.fixedTabReset()
       }
@@ -179,8 +177,8 @@ export const MobileShell: React.FC = observer(() => {
   const onPressSearch = () => {
     track('MobileShell:SearchButtonPressed')
     if (store.nav.tab.fixedTabPurpose === TabPurpose.Search) {
-      if (store.nav.tab.current.url === '/') {
-        scrollElRef.current?.scrollToOffset({offset: 0})
+      if (!store.nav.tab.canGoBack) {
+        store.emitScreenSoftReset()
       } else {
         store.nav.tab.fixedTabReset()
       }
@@ -194,7 +192,11 @@ export const MobileShell: React.FC = observer(() => {
   const onPressNotifications = () => {
     track('MobileShell:NotificationsButtonPressed')
     if (store.nav.tab.fixedTabPurpose === TabPurpose.Notifs) {
-      store.nav.tab.fixedTabReset()
+      if (!store.nav.tab.canGoBack) {
+        store.emitScreenSoftReset()
+      } else {
+        store.nav.tab.fixedTabReset()
+      }
     } else {
       store.nav.switchTo(TabPurpose.Notifs, false)
       if (store.nav.tab.index === 0) {
@@ -444,7 +446,6 @@ export const MobileShell: React.FC = observer(() => {
                           params={params}
                           navIdx={navIdx}
                           visible={current}
-                          scrollElRef={current ? scrollElRef : undefined}
                         />
                       </ErrorBoundary>
                     </Animated.View>


### PR DESCRIPTION
Tapping a footer menu icon should scroll you to the top of the screen if you're already on that screen. This behavior was implemented on home but not search or notifications.

This PR adds the behavior to search and notifications and switches from threading a ref from the shell to using the global event bus.