### PR TITLE
Don't show new-content notification for reposts (close #179)

### DIFF
--- a/src/state/models/feed-view.ts
+++ b/src/state/models/feed-view.ts
@@ -406,14 +406,16 @@ export class FeedModel {
     }
     const res = await this._getFeed({limit: 1})
     const currentLatestUri = this.pollCursor
-    const receivedLatestUri = res.data.feed[0]
-      ? res.data.feed[0].post.uri
-      : undefined
-    const hasNewLatest = Boolean(
-      receivedLatestUri &&
-        (this.feed.length === 0 || receivedLatestUri !== currentLatestUri),
-    )
-    this.setHasNewLatest(hasNewLatest)
+    const item = res.data.feed[0]
+    if (!item) {
+      return
+    }
+    if (AppBskyFeedFeedViewPost.isReasonRepost(item.reason)) {
+      if (item.reason.by.did === this.rootStore.me.did) {
+        return // ignore reposts by the user
+      }
+    }
+    this.setHasNewLatest(item.post.uri !== currentLatestUri)
   }
 
   /**


### PR DESCRIPTION
Closes #179 

This PR fixes the situation where reposting something gave a "Load new posts" notification wrongly. The downside of this change is that it's possible there _has_ been new posts, it's just that your repost was at the top of the queue, but that's less of a concern than the annoying behavior this solves.