### PR TITLE
Show the splash screen during session resumption (close #186)

### DIFF
--- a/src/state/models/session.ts
+++ b/src/state/models/session.ts
@@ -43,6 +43,10 @@ export class SessionModel {
    * A listing of the currently & previous sessions
    */
   accounts: AccountData[] = []
+  /**
+   * Flag to indicate if we're doing our initial-load session resumption
+   */
+  isResumingSession = false
 
   constructor(public rootStore: RootStoreModel) {
     makeAutoObservable(this, {
@@ -114,7 +118,12 @@ export class SessionModel {
       this.rootStore.log.debug(
         'SessionModel:attemptSessionResumption found stored session',
       )
-      return this.resumeSession(sess)
+      this.isResumingSession = true
+      try {
+        return await this.resumeSession(sess)
+      } finally {
+        this.isResumingSession = false
+      }
     } else {
       this.rootStore.log.debug(
         'SessionModel:attemptSessionResumption has no session to resume',

--- a/src/view/screens/Login.tsx
+++ b/src/view/screens/Login.tsx
@@ -8,6 +8,7 @@ import {Text} from '../com/util/text/Text'
 import {ErrorBoundary} from '../com/util/ErrorBoundary'
 import {colors} from '../lib/styles'
 import {usePalette} from '../lib/hooks/usePalette'
+import {useStores} from '../../state'
 import {CLOUD_SPLASH} from '../lib/assets'
 import {useAnalytics} from '@segment/analytics-react-native'
 
@@ -59,22 +60,28 @@ const SigninOrCreateAccount = ({
 
 export const Login = observer(() => {
   const pal = usePalette('default')
+  const store = useStores()
   const [screenState, setScreenState] = useState<ScreenState>(
     ScreenState.S_SigninOrCreateAccount,
   )
 
-  if (screenState === ScreenState.S_SigninOrCreateAccount) {
+  if (
+    store.session.isResumingSession ||
+    screenState === ScreenState.S_SigninOrCreateAccount
+  ) {
     return (
       <View style={styles.container}>
         <FastImage source={CLOUD_SPLASH as FISource} style={styles.bgImg} />
         <SafeAreaView testID="noSessionView" style={styles.container}>
           <ErrorBoundary>
-            <SigninOrCreateAccount
-              onPressSignin={() => setScreenState(ScreenState.S_Signin)}
-              onPressCreateAccount={() =>
-                setScreenState(ScreenState.S_CreateAccount)
-              }
-            />
+            {!store.session.isResumingSession && (
+              <SigninOrCreateAccount
+                onPressSignin={() => setScreenState(ScreenState.S_Signin)}
+                onPressCreateAccount={() =>
+                  setScreenState(ScreenState.S_CreateAccount)
+                }
+              />
+            )}
           </ErrorBoundary>
         </SafeAreaView>
       </View>


### PR DESCRIPTION
Closes #186 

Tracks if the session is attempting its initial session resumption and renders a splash screen instead of the login screen.

https://user-images.githubusercontent.com/1270099/218878188-de9cb268-98d5-4abf-baf4-d52263a41ea2.mp4

