### PR TITLE
Only give the loading spinner on the home feed during PTR

### DIFF
--- a/src/view/com/posts/Feed.tsx
+++ b/src/view/com/posts/Feed.tsx
@@ -1,4 +1,4 @@
-import React, {MutableRefObject, useEffect} from 'react'
+import React, {MutableRefObject} from 'react'
 import {observer} from 'mobx-react-lite'
 import {
   ActivityIndicator,
@@ -38,8 +38,9 @@ export const Feed = observer(function Feed({
   headerOffset?: number
 }) {
   const {screen, track} = useAnalytics()
+  const [isRefreshing, setIsRefreshing] = React.useState(false)
 
-  useEffect(() => {
+  React.useEffect(() => {
     screen('Feed')
   }, [screen])
 
@@ -63,19 +64,23 @@ export const Feed = observer(function Feed({
     }
     return <FeedItem item={item} />
   }
-  const onRefresh = () => {
+  const onRefresh = async () => {
     track('Feed:onRefresh')
-    feed
-      .refresh()
-      .catch(err =>
-        feed.rootStore.log.error('Failed to refresh posts feed', err),
-      )
+    setIsRefreshing(true)
+    try {
+      await feed.refresh()
+    } catch (err) {
+      feed.rootStore.log.error('Failed to refresh posts feed', err)
+    }
+    setIsRefreshing(false)
   }
-  const onEndReached = () => {
+  const onEndReached = async () => {
     track('Feed:onEndReached')
-    feed
-      .loadMore()
-      .catch(err => feed.rootStore.log.error('Failed to load more posts', err))
+    try {
+      await feed.loadMore()
+    } catch (err) {
+      feed.rootStore.log.error('Failed to load more posts', err)
+    }
   }
   let data: any[] = []
   if (feed.hasError) {
@@ -106,7 +111,7 @@ export const Feed = observer(function Feed({
           keyExtractor={item => item._reactKey}
           renderItem={renderItem}
           ListFooterComponent={FeedFooter}
-          refreshing={feed.isRefreshing}
+          refreshing={isRefreshing}
           contentContainerStyle={s.contentContainer}
           onScroll={onScroll}
           onRefresh={onRefresh}


### PR DESCRIPTION
Closes #70 

The loading spinner was getting shown more than it needed to and giving weird little jogs to the home feed. This PR changes the feed so only shows the spinner during a PTR. 