### PR TITLE
Fix RN bug that causes home feed not to load more

### DIFF
--- a/src/view/com/posts/Feed.tsx
+++ b/src/view/com/posts/Feed.tsx
@@ -98,8 +98,12 @@ export const Feed = observer(function Feed({
     )
   return (
     <View testID={testID} style={style}>
-      {feed.isLoading && !data && <PostFeedLoadingPlaceholder />}
-      {data && (
+      {feed.isLoading && data.length === 0 && (
+        <View style={{paddingTop: headerOffset}}>
+          <PostFeedLoadingPlaceholder />
+        </View>
+      )}
+      {data.length > 0 && (
         <FlatList
           ref={scrollElRef}
           data={data}


### PR DESCRIPTION
Closes #206. Also fixes home feed load view.

RN has a bug where rendering a flatlist with an empty array appears to break its virtual list windowing behaviors. See https://stackoverflow.com/a/67873596

