### PR TITLE
Implement our own lifecycle tracking to ensure it never fires while the app is backgrounded

### DIFF
--- a/src/App.native.tsx
+++ b/src/App.native.tsx
@@ -14,7 +14,7 @@ import {RootStoreModel, setupState, RootStoreProvider} from './state'
 import {MobileShell} from './view/shell/mobile'
 import {s} from './view/lib/styles'
 import notifee, {EventType} from '@notifee/react-native'
-import {segmentClient} from './lib/segmentClient'
+import * as analytics from './lib/analytics'
 import * as Toast from './view/com/util/Toast'
 
 const App = observer(() => {
@@ -26,9 +26,10 @@ const App = observer(() => {
   // init
   useEffect(() => {
     view.setup()
-    setSegment(segmentClient)
+    setSegment(analytics.segmentClient)
     setupState().then(store => {
       setRootStore(store)
+      analytics.init(store)
       SplashScreen.hide()
       Linking.getInitialURL().then((url: string | null) => {
         if (url) {

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,68 @@
+import {AppState, AppStateStatus} from 'react-native'
+import {createClient} from '@segment/analytics-react-native'
+import {RootStoreModel, AppInfo} from '../state/models/root-store'
+// import {createLogger} from './logger'
+
+export const segmentClient = createClient({
+  writeKey: '8I6DsgfiSLuoONyaunGoiQM7A6y2ybdI',
+  trackAppLifecycleEvents: false,
+  // Uncomment to debug:
+  // logger: createLogger(),
+})
+
+export function init(store: RootStoreModel) {
+  // NOTE
+  // this method is a copy of segment's own lifecycle event tracking
+  // we handle it manually to ensure that it never fires while the app is backgrounded
+  // -prf
+  segmentClient.onContextLoaded(() => {
+    if (AppState.currentState !== 'active') {
+      store.log.debug('Prevented a metrics ping while the app was backgrounded')
+      return
+    }
+    const context = segmentClient.context.get()
+    if (typeof context?.app === 'undefined') {
+      store.log.debug('Aborted metrics ping due to unavailable context')
+      return
+    }
+
+    const oldAppInfo = store.appInfo
+    const newAppInfo = context.app as AppInfo
+    store.setAppInfo(newAppInfo)
+    store.log.debug('Recording app info', {new: newAppInfo, old: oldAppInfo})
+
+    if (typeof oldAppInfo === 'undefined') {
+      segmentClient.track('Application Installed', {
+        version: newAppInfo.version,
+        build: newAppInfo.build,
+      })
+    } else if (newAppInfo.version !== oldAppInfo.version) {
+      segmentClient.track('Application Updated', {
+        version: newAppInfo.version,
+        build: newAppInfo.build,
+        previous_version: oldAppInfo.version,
+        previous_build: oldAppInfo.build,
+      })
+    }
+    segmentClient.track('Application Opened', {
+      from_background: false,
+      version: newAppInfo.version,
+      build: newAppInfo.build,
+    })
+  })
+
+  let lastState: AppStateStatus = AppState.currentState
+  AppState.addEventListener('change', (state: AppStateStatus) => {
+    if (state === 'active' && lastState !== 'active') {
+      const context = segmentClient.context.get()
+      segmentClient.track('Application Opened', {
+        from_background: true,
+        version: context?.app?.version,
+        build: context?.app?.build,
+      })
+    } else if (state !== 'active' && lastState === 'active') {
+      segmentClient.track('Application Backgrounded')
+    }
+    lastState = state
+  })
+}

--- a/src/lib/segmentClient.ts
+++ b/src/lib/segmentClient.ts
@@ -1,9 +1,0 @@
-import {createClient} from '@segment/analytics-react-native'
-// import {createLogger} from './logger'
-
-export const segmentClient = createClient({
-  writeKey: '8I6DsgfiSLuoONyaunGoiQM7A6y2ybdI',
-  trackAppLifecycleEvents: true,
-  // Uncomment to debug:
-  // logger: createLogger(),
-})

--- a/src/state/models/navigation.ts
+++ b/src/state/models/navigation.ts
@@ -1,7 +1,7 @@
 import {RootStoreModel} from './root-store'
 import {makeAutoObservable} from 'mobx'
 import {TABS_ENABLED} from '../../build-flags'
-import {segmentClient} from '../../lib/segmentClient'
+import {segmentClient} from '../../lib/analytics'
 
 let __id = 0
 function genId() {


### PR DESCRIPTION
Closes #193.

Copies the lifecycle tracking from segment's module but adds some guards to ensure that a ping _never_ occurs while the app is backgrounded. It's not fully clear yet that pings are misfiring, but when reviewing the code it seemed possible to me that it could happen if the javascript context was unloaded between bg-fetch tasks.

NOTE: After this goes live, because the state-tracking changed, we'll see a bunch of incorrect "install" events for the pre-existing users.