### PR TITLE
make authorAvatar optional prop

### DIFF
--- a/src/view/com/util/PostMeta.tsx
+++ b/src/view/com/util/PostMeta.tsx
@@ -9,7 +9,7 @@ import {observer} from 'mobx-react-lite'
 import FollowButton from '../profile/FollowButton'
 
 interface PostMetaOpts {
-  authorAvatar: string | undefined
+  authorAvatar?: string
   authorHandle: string
   authorDisplayName: string | undefined
   timestamp: string


### PR DESCRIPTION
- use `?` instead of `string | undefined` to solve `tsc` build errors