### PR TITLE
Show replies in the main feed if they have 2 or more upvotes

### DIFF
--- a/src/state/models/feed-view.ts
+++ b/src/state/models/feed-view.ts
@@ -263,7 +263,8 @@ export class FeedModel {
           !item.reply || // not a reply
           isRepost || // but allow if it's a repost or thread
           item._isThreadParent ||
-          item._isThreadChild
+          item._isThreadChild ||
+          item.post.upvoteCount >= 2
         )
       })
     }


### PR DESCRIPTION
We're tuning the main feed to give a nice experience in the short term (until custom feeds land).

This update shows replies only if they've received 2 or more upvotes. The logic is that 1 upvote often comes from the person you're replying to, while 2 suggests other people thought it was good too.