### PR TITLE
Fix: poll for unread notifications globally (close #303)

### DIFF
--- a/src/state/models/root-store.ts
+++ b/src/state/models/root-store.ts
@@ -158,6 +158,7 @@ export class RootStoreModel {
       return
     }
     try {
+      await this.me.notifications.loadUnreadCount()
       await this.me.follows.fetchIfNeeded()
     } catch (e: any) {
       this.log.error('Failed to fetch latest state', e)


### PR DESCRIPTION
Closes #303

Unread notifications badge will now correctly update in the footer