### PR TITLE
Fix default-banner sizing & positioning

### DIFF
--- a/src/view/com/util/UserBanner.tsx
+++ b/src/view/com/util/UserBanner.tsx
@@ -82,12 +82,6 @@ export function UserBanner({
     },
   ]
 
-  const renderSvg = () => (
-    <Svg width="100%" height="150" viewBox="0 0 400 150">
-      <Rect x="0" y="0" width="400" height="150" fill="#0070ff" />
-    </Svg>
-  )
-
   // setUserBanner is only passed as prop on the EditProfile component
   return onSelectNewBanner ? (
     <DropdownButton
@@ -118,7 +112,7 @@ export function UserBanner({
       source={{uri: banner}}
     />
   ) : (
-    renderSvg()
+    <View style={[styles.bannerImage, styles.defaultBanner]} />
   )
 }
 
@@ -137,5 +131,8 @@ const styles = StyleSheet.create({
   bannerImage: {
     width: '100%',
     height: 150,
+  },
+  defaultBanner: {
+    backgroundColor: '#0070ff',
   },
 })


### PR DESCRIPTION
Issue:

<img width="642" alt="CleanShot 2023-03-21 at 12 59 40@2x" src="https://user-images.githubusercontent.com/1270099/226700680-ddaca63b-baa7-4e36-b642-a177d702611b.png">

Not sure why I can't seem to make an SVG work for this but the original reasons for using an SVG no longer apply, so this PR fixes it by just using a View with a background color.