### PR TITLE
CI: run on all PRs, and on main (after merge/push)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,8 +2,12 @@ name: Lint
 
 on:
   pull_request:
+  push:
     branches:
       - main
+concurrency:
+  group: '${{ github.workflow }}-${{ github.head_ref || github.ref }}'
+  cancel-in-progress: true
 
 jobs:
   linting:


### PR DESCRIPTION
This updates the `lint` github action to match the behavior of the `atproto` repo, described here: https://github.com/bluesky-social/atproto/pull/669

The original motivation was to support third-party contributions better. This repo isn't open right now, but might become open in the future and want to knock this off now while doing the others.

In this repo the checks were already running in some cases. I think this PR should make that more consistent, and the "concurrency" control stuff prevents double-runs of the same commit.