### PR TITLE
ci: golang version as string, not number

### DIFF
--- a/.github/workflows/golang-test-lint.yml
+++ b/.github/workflows/golang-test-lint.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go tooling
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20
+          go-version: '1.20'
       - name: Dummy JS File
         run: touch bskyweb/static/js/blah.js
       - name: Check
@@ -36,7 +36,7 @@ jobs:
       - name: Set up Go tooling
         uses: actions/setup-go@v3
         with:
-          go-version: 1.20
+          go-version: '1.20'
       - name: Dummy JS File
         run: touch bskyweb/static/js/blah.js
       - name: Lint


### PR DESCRIPTION
`1.20` was getting parsed as `1.2`, needed to make it `"1.20"`.