### PR TITLE
Fix click targets for post controls (#332)

### DIFF
--- a/src/view/com/util/PostCtrls.tsx
+++ b/src/view/com/util/PostCtrls.tsx
@@ -321,6 +321,8 @@ export function PostCtrls(opts: PostCtrlsOpts) {
           </PostDropdownBtn>
         )}
       </View>
+      {/* used for adding pad to the right side */}
+      <View />
     </View>
   )
 }


### PR DESCRIPTION
Makes the elements that are clicked not take up all available space:

<img width="610" alt="image" src="https://user-images.githubusercontent.com/767070/228106684-e96ed89e-3f78-4860-9e92-168f0d20a989.png">

Also adds a `5px` buffer around the clickable target so that it _feels_ more natural to click. Offsets it with a `-5px` margin

<img width="607" alt="image" src="https://user-images.githubusercontent.com/767070/228106716-2a67bd47-758a-4432-a697-bd89ada10aed.png">

Closes #332 