### PR TITLE
Fix full thread SVG dots not rendering (#346)

### DIFF
--- a/src/view/com/posts/FeedSlice.tsx
+++ b/src/view/com/posts/FeedSlice.tsx
@@ -85,9 +85,9 @@ function ViewFullThread({slice}: {slice: FeedSliceModel}) {
             stroke={pal.colors.replyLine}
             strokeWidth="2"
           />
-          <Circle x="2" y="16" r="1.5" fill={pal.colors.replyLineDot} />
-          <Circle x="2" y="22" r="1.5" fill={pal.colors.replyLineDot} />
-          <Circle x="2" y="28" r="1.5" fill={pal.colors.replyLineDot} />
+          <Circle cx="2" cy="16" r="1.5" fill={pal.colors.replyLineDot} />
+          <Circle cx="2" cy="22" r="1.5" fill={pal.colors.replyLineDot} />
+          <Circle cx="2" cy="28" r="1.5" fill={pal.colors.replyLineDot} />
         </Svg>
       </View>
       <Text type="md" style={pal.link}>


### PR DESCRIPTION
Closes #346 

<img width="641" alt="image" src="https://user-images.githubusercontent.com/767070/228120325-acd1ee1a-3061-437a-ae5b-87c20536a6c8.png">

Seems the issue is that the icon was using `x` and `y` instead of `cx` and `cy`