### PR TITLE
Fix: don't let the toast take pointer events (close #374)

### DIFF
--- a/src/view/com/util/Toast.tsx
+++ b/src/view/com/util/Toast.tsx
@@ -39,7 +39,7 @@ function Toast({message}: {message: string}) {
 
   const opacityStyle = {opacity: interp}
   return (
-    <View style={styles.container}>
+    <View style={styles.container} pointerEvents="none">
       <Animated.View
         style={[
           pal.view,


### PR DESCRIPTION
Closes #374

Disables tap event handling on the toast to ensure it doesn't interfere with nearby elements