### PR TITLE
Rework the me.follows cache to reduce network load (close #373)

### DIFF
--- a/src/state/models/content/profile.ts
+++ b/src/state/models/content/profile.ts
@@ -8,6 +8,7 @@ import {
 import {RootStoreModel} from '../root-store'
 import * as apilib from 'lib/api/index'
 import {cleanError} from 'lib/strings/errors'
+import {FollowState} from '../cache/my-follows'
 
 export const ACTOR_TYPE_USER = 'app.bsky.system.actorUser'
 
@@ -89,9 +90,10 @@ export class ProfileModel {
     }
 
     const follows = this.rootStore.me.follows
-    const followUri = follows.isFollowing(this.did)
-      ? follows.getFollowUri(this.did)
-      : undefined
+    const followUri =
+      (await follows.fetchFollowState(this.did)) === FollowState.Following
+        ? follows.getFollowUri(this.did)
+        : undefined
 
     // guard against this view getting out of sync with the follows cache
     if (followUri !== this.viewer.following) {

--- a/src/state/models/discovery/suggested-actors.ts
+++ b/src/state/models/discovery/suggested-actors.ts
@@ -110,7 +110,6 @@ export class SuggestedActorsModel {
     if (this.hardCodedSuggestions) {
       return
     }
-    await this.rootStore.me.follows.fetchIfNeeded()
     try {
       // clone the array so we can mutate it
       const actors = [
@@ -128,9 +127,11 @@ export class SuggestedActorsModel {
         profiles = profiles.concat(res.data.profiles)
       } while (actors.length)
 
+      this.rootStore.me.follows.hydrateProfiles(profiles)
+
       runInAction(() => {
         profiles = profiles.filter(profile => {
-          if (this.rootStore.me.follows.isFollowing(profile.did)) {
+          if (profile.viewer?.following) {
             return false
           }
           if (profile.did === this.rootStore.me.did) {

--- a/src/state/models/feeds/posts.ts
+++ b/src/state/models/feeds/posts.ts
@@ -543,6 +543,10 @@ export class PostsFeedModel {
     this.loadMoreCursor = res.data.cursor
     this.hasMore = !!this.loadMoreCursor
 
+    this.rootStore.me.follows.hydrateProfiles(
+      res.data.feed.map(item => item.post.author),
+    )
+
     const slices = this.tuner.tune(res.data.feed, this.feedTuners)
 
     const toAppend: PostsFeedSliceModel[] = []

--- a/src/state/models/lists/likes.ts
+++ b/src/state/models/lists/likes.ts
@@ -126,6 +126,9 @@ export class LikesModel {
   _appendAll(res: GetLikes.Response) {
     this.loadMoreCursor = res.data.cursor
     this.hasMore = !!this.loadMoreCursor
+    this.rootStore.me.follows.hydrateProfiles(
+      res.data.likes.map(like => like.actor),
+    )
     this.likes = this.likes.concat(res.data.likes)
   }
 }

--- a/src/state/models/me.ts
+++ b/src/state/models/me.ts
@@ -104,9 +104,6 @@ export class MeModel {
         }
       })
       this.mainFeed.clear()
-      await this.follows.fetch().catch(e => {
-        this.rootStore.log.error('Failed to load my follows', e)
-      })
       await Promise.all([
         this.mainFeed.setup().catch(e => {
           this.rootStore.log.error('Failed to setup main feed model', e)

--- a/src/state/models/root-store.ts
+++ b/src/state/models/root-store.ts
@@ -142,7 +142,6 @@ export class RootStoreModel {
     }
     try {
       await this.me.notifications.loadUnreadCount()
-      await this.me.follows.fetchIfNeeded()
     } catch (e: any) {
       this.log.error('Failed to fetch latest state', e)
     }

--- a/src/state/models/ui/search.ts
+++ b/src/state/models/ui/search.ts
@@ -43,6 +43,9 @@ export class SearchUIModel {
         profiles = profiles.concat(res.data.profiles)
       } while (profilesSearch.length)
     }
+
+    this.rootStore.me.follows.hydrateProfiles(profiles)
+
     runInAction(() => {
       this.profiles = profiles
       this.isProfilesLoading = false

--- a/src/view/com/profile/FollowButton.tsx
+++ b/src/view/com/profile/FollowButton.tsx
@@ -1,8 +1,10 @@
 import React from 'react'
+import {View} from 'react-native'
 import {observer} from 'mobx-react-lite'
 import {Button, ButtonType} from '../util/forms/Button'
 import {useStores} from 'state/index'
 import * as Toast from '../util/Toast'
+import {FollowState} from 'state/models/cache/my-follows'
 
 const FollowButton = observer(
   ({
@@ -15,10 +17,15 @@ const FollowButton = observer(
     onToggleFollow?: (v: boolean) => void
   }) => {
     const store = useStores()
-    const isFollowing = store.me.follows.isFollowing(did)
+    const followState = store.me.follows.getFollowState(did)
+
+    if (followState === FollowState.Unknown) {
+      return <View />
+    }
 
     const onToggleFollowInner = async () => {
-      if (store.me.follows.isFollowing(did)) {
+      const updatedFollowState = await store.me.follows.fetchFollowState(did)
+      if (updatedFollowState === FollowState.Following) {
         try {
           await store.agent.deleteFollow(store.me.follows.getFollowUri(did))
           store.me.follows.removeFollow(did)
@@ -27,7 +34,7 @@ const FollowButton = observer(
           store.log.error('Failed fo delete follow', e)
           Toast.show('An issue occurred, please try again.')
         }
-      } else {
+      } else if (updatedFollowState === FollowState.NotFollowing) {
         try {
           const res = await store.agent.follow(did)
           store.me.follows.addFollow(did, res.uri)
@@ -41,9 +48,9 @@ const FollowButton = observer(
 
     return (
       <Button
-        type={isFollowing ? 'default' : type}
+        type={followState === FollowState.Following ? 'default' : type}
         onPress={onToggleFollowInner}
-        label={isFollowing ? 'Unfollow' : 'Follow'}
+        label={followState === FollowState.Following ? 'Unfollow' : 'Follow'}
       />
     )
   },

--- a/src/view/com/profile/ProfileHeader.tsx
+++ b/src/view/com/profile/ProfileHeader.tsx
@@ -30,6 +30,7 @@ import {usePalette} from 'lib/hooks/usePalette'
 import {useAnalytics} from 'lib/analytics'
 import {NavigationProp} from 'lib/routes/types'
 import {isDesktopWeb} from 'platform/detection'
+import {FollowState} from 'state/models/cache/my-follows'
 
 const BACK_HITSLOP = {left: 30, top: 30, right: 30, bottom: 30}
 
@@ -219,7 +220,8 @@ const ProfileHeaderLoaded = observer(function ProfileHeaderLoaded({
             </TouchableOpacity>
           ) : (
             <>
-              {store.me.follows.isFollowing(view.did) ? (
+              {store.me.follows.getFollowState(view.did) ===
+              FollowState.Following ? (
                 <TouchableOpacity
                   testID="unfollowBtn"
                   onPress={onPressToggleFollow}

--- a/src/view/com/util/PostMeta.tsx
+++ b/src/view/com/util/PostMeta.tsx
@@ -8,6 +8,7 @@ import {useStores} from 'state/index'
 import {UserAvatar} from './UserAvatar'
 import {observer} from 'mobx-react-lite'
 import FollowButton from '../profile/FollowButton'
+import {FollowState} from 'state/models/cache/my-follows'
 
 interface PostMetaOpts {
   authorAvatar?: string
@@ -25,15 +26,22 @@ export const PostMeta = observer(function (opts: PostMetaOpts) {
   const handle = opts.authorHandle
   const store = useStores()
   const isMe = opts.did === store.me.did
-  const isFollowing =
-    typeof opts.did === 'string' && store.me.follows.isFollowing(opts.did)
+  const followState =
+    typeof opts.did === 'string'
+      ? store.me.follows.getFollowState(opts.did)
+      : FollowState.Unknown
 
   const [didFollow, setDidFollow] = React.useState(false)
   const onToggleFollow = React.useCallback(() => {
     setDidFollow(true)
   }, [setDidFollow])
 
-  if (opts.showFollowBtn && !isMe && (!isFollowing || didFollow) && opts.did) {
+  if (
+    opts.showFollowBtn &&
+    !isMe &&
+    (followState === FollowState.NotFollowing || didFollow) &&
+    opts.did
+  ) {
     // two-liner with follow button
     return (
       <View style={styles.metaTwoLine}>

--- a/src/view/screens/Home.tsx
+++ b/src/view/screens/Home.tsx
@@ -71,7 +71,7 @@ export const HomeScreen = withAuthRequired((_opts: Props) => {
     return <FollowingEmptyState />
   }, [])
 
-  const initialPage = store.me.follows.isEmpty ? 1 : 0
+  const initialPage = store.me.followsCount === 0 ? 1 : 0
   return (
     <Pager
       testID="homeScreen"


### PR DESCRIPTION
Closes #373 

This PR:

- Removes the full "follows" table fetch from init to reduce the network load during session start
- Updates the follows cache to distinguish between Following, NotFollowing, and Unknown
- Improves the hydration of the follows cache to pull from more data sources
- Updates rendering code to not show controls when they are optional & the state is Unknown