### PR TITLE
Readd the ios universal links config (close #371)

### DIFF
--- a/ios/bluesky/bluesky.entitlements
+++ b/ios/bluesky/bluesky.entitlements
@@ -4,5 +4,9 @@
   <dict>
     <key>aps-environment</key>
     <string>development</string>
+    <key>com.apple.developer.associated-domains</key>
+    <array>
+      <string>applinks:bsky.app</string>
+    </array>
   </dict>
 </plist>


### PR DESCRIPTION
Closes #371

They're actually called "universal links." Deep links are when you have a custom scheme.