### PR TITLE
Fix load spinner positioning (close #415)

### DIFF
--- a/src/view/com/posts/Feed.tsx
+++ b/src/view/com/posts/Feed.tsx
@@ -169,6 +169,7 @@ export const Feed = observer(function Feed({
               onRefresh={onRefresh}
               tintColor={pal.colors.text}
               titleColor={pal.colors.text}
+              progressViewOffset={headerOffset}
             />
           }
           contentContainerStyle={s.contentContainer}
@@ -178,7 +179,6 @@ export const Feed = observer(function Feed({
           removeClippedSubviews={true}
           contentInset={{top: headerOffset}}
           contentOffset={{x: 0, y: headerOffset * -1}}
-          progressViewOffset={headerOffset}
         />
       )}
     </View>


### PR DESCRIPTION
Closes #415 

This gets the loading spinner out from under the header