### PR TITLE
Filter out bad mentions instead of erroring during post (close #391)

### DIFF
--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -3,6 +3,7 @@ import {
   AppBskyEmbedExternal,
   AppBskyEmbedRecord,
   AppBskyEmbedRecordWithMedia,
+  AppBskyRichtextFacet,
   ComAtprotoRepoUploadBlob,
   RichText,
 } from '@atproto/api'
@@ -82,6 +83,17 @@ export async function post(store: RootStoreModel, opts: PostOpts) {
 
   opts.onStateChange?.('Processing...')
   await rt.detectFacets(store.agent)
+
+  // filter out any mention facets that didn't map to a user
+  rt.facets = rt.facets?.filter(facet => {
+    const mention = facet.features.find(feature =>
+      AppBskyRichtextFacet.isMention(feature),
+    )
+    if (mention && !mention.did) {
+      return false
+    }
+    return true
+  })
 
   if (opts.quote) {
     embed = {


### PR DESCRIPTION
Currently the "detectFacets" API will leave bad mentions in the output if resolveHandle fails. This then causes the post upload to fail validation and give the user a cryptic message.

Probably should fix that in the API but for now we'll filter out the bad mention facets here.