### PR TITLE
Fix: consistently give suggestions in search

### DIFF
--- a/src/view/com/search/Suggestions.tsx
+++ b/src/view/com/search/Suggestions.tsx
@@ -91,7 +91,7 @@ export const Suggestions = observer(
         for (const source of foafs.sources) {
           const item = foafs.foafs.get(source)
           if (!item || item.follows.length === 0) {
-            return
+            continue
           }
           items = items
             .concat([


### PR DESCRIPTION
Stupid bug that got introduced when I switched from a `.forEach()` closer to a `for` loop