### PR TITLE
If adding the user's post when empty, just refresh

### DIFF
--- a/src/state/models/feeds/posts.ts
+++ b/src/state/models/feeds/posts.ts
@@ -485,6 +485,9 @@ export class PostsFeedModel {
    * Used by the composer to add their new posts
    */
   async addPostToTop(uri: string) {
+    if (!this.slices.length) {
+      return this.refresh()
+    }
     try {
       const res = await this.rootStore.agent.app.bsky.feed.getPosts({
         uris: [uri],


### PR DESCRIPTION
Small bug that surfaced from past PR wouldnt trigger the repaint immediately, this fixes that