### PR TITLE
Fix to embed labels lookup

### DIFF
--- a/src/lib/labeling/helpers.ts
+++ b/src/lib/labeling/helpers.ts
@@ -309,9 +309,10 @@ function warnContent(reason: string) {
   }
 }
 
-function warnImages(reason: string) {
-  return {
-    behavior: ModerationBehaviorCode.WarnImages,
-    reason,
-  }
-}
+// TODO
+// function warnImages(reason: string) {
+//   return {
+//     behavior: ModerationBehaviorCode.WarnImages,
+//     reason,
+//   }
+// }


### PR DESCRIPTION
This lookup was wrong, causing labels on quoted items not to propagate up properly