### PR TITLE
[APP-599] Fix confirm profile sizing for blocks

### DIFF
--- a/src/view/com/modals/Confirm.tsx
+++ b/src/view/com/modals/Confirm.tsx
@@ -13,7 +13,7 @@ import {cleanError} from 'lib/strings/errors'
 import {usePalette} from 'lib/hooks/usePalette'
 import {isDesktopWeb} from 'platform/detection'
 
-export const snapPoints = [300]
+export const snapPoints = ['50%']
 
 export function Component({
   title,

--- a/src/view/com/profile/ProfileHeader.tsx
+++ b/src/view/com/profile/ProfileHeader.tsx
@@ -180,7 +180,7 @@ const ProfileHeaderLoaded = observer(
         name: 'confirm',
         title: 'Block Account',
         message:
-          'Blocked accounts cannot reply in your threads, mention you, or otherwise interact with you. You will not see their content and they will be prevented from seeing yours.',
+          'Blocked accounts cannot reply in your threads, mention you, or otherwise interact with you.',
         onPressConfirm: async () => {
           try {
             await view.blockAccount()
@@ -200,7 +200,7 @@ const ProfileHeaderLoaded = observer(
         name: 'confirm',
         title: 'Unblock Account',
         message:
-          'The account will be able to interact with you after unblocking. (You can always block again in the future.)',
+          'The account will be able to interact with you after unblocking.',
         onPressConfirm: async () => {
           try {
             await view.unblockAccount()


### PR DESCRIPTION
Reduces the text and increases the height of the confirm modal to make sure this doesnt spill off the page