### PR TITLE
Remove the attempts to make the language filter more lenient

### DIFF
--- a/src/lib/api/feed-manip.ts
+++ b/src/lib/api/feed-manip.ts
@@ -214,18 +214,8 @@ export class FeedTuner {
           ) {
             const res = lande(item.post.record.text)
 
-            // require at least 70% confidence; otherwise, roll with it
-            if (res[0][1] <= 0.7) {
+            if (langsCode3.includes(res[0][0])) {
               hasPreferredLang = true
-              break
-            }
-
-            // if the user's languages are in the top 5 guesses, roll with it
-            for (let j = 0; j < 5 && j < res.length; j++) {
-              hasPreferredLang =
-                hasPreferredLang || langsCode3.includes(res[i][0])
-            }
-            if (hasPreferredLang) {
               break
             }
           } else {


### PR DESCRIPTION
We actually broke the filter when we snuck in a change to the iteration variable

But the increased tolerance was just making it useless after I fixed it and I can't seem to find a tuning that really helps, so I'm just putting it back until we do the real fix (language metadata on posts)