### PR TITLE
[APP-620] Add icon-intolerant and behavior-intolerant to the political hategroup category

### DIFF
--- a/src/lib/labeling/const.ts
+++ b/src/lib/labeling/const.ts
@@ -57,7 +57,7 @@ export const CONFIGURABLE_LABEL_GROUPS: Record<
     id: 'hate',
     title: 'Political Hate-Groups',
     warning: 'Hate',
-    values: ['icon-kkk', 'icon-nazi'],
+    values: ['icon-kkk', 'icon-nazi', 'icon-intolerant', 'behavior-intolerant'],
     imagesOnly: false,
   },
   spam: {


### PR DESCRIPTION
Adds two labels to the political hategroup category

- `icon-intolerant`
- `behavior-intolerant`