### PR TITLE
[APP-633] Improve some behaviors around desktop leftnav

### DIFF
--- a/src/view/shell/desktop/LeftNav.tsx
+++ b/src/view/shell/desktop/LeftNav.tsx
@@ -114,9 +114,6 @@ const NavItem = observer(
         style={styles.navItemWrapper}
         hoverStyle={pal.viewLight}
         onPress={onPressWrapped}
-        // @ts-ignore web only -prf
-        href={href}
-        dataSet={{noUnderline: 1}}
         accessibilityRole="tab"
         accessibilityLabel={label}
         accessibilityHint="">
@@ -128,7 +125,11 @@ const NavItem = observer(
             </Text>
           ) : null}
         </View>
-        <Text type="title" style={[isCurrent ? s.bold : s.normal, pal.text]}>
+        <Text
+          type="title"
+          style={[isCurrent ? s.bold : s.normal, pal.text]}
+          href={href}
+          dataSet={{noUnderline: 1}}>
           {label}
         </Text>
       </PressableWithHover>


### PR DESCRIPTION
Previously tapping on the notifications item in the desktop leftnav would cause it to poll for latest. I'm not sure how that behavior got lost, but this PR solves it and a bit more

1. Turns the leftnav into links so they can get middle clicked (yay)
2. Triggers the soft reset on secondary clicks so that the current screen can reload