### PR TITLE
[APP-608] Fix drawer crash Android

### DIFF
--- a/src/view/shell/index.tsx
+++ b/src/view/shell/index.tsx
@@ -16,6 +16,7 @@ import {usePalette} from 'lib/hooks/usePalette'
 import * as backHandler from 'lib/routes/back-handler'
 import {RoutesContainer, TabsNavigator} from '../../Navigation'
 import {isStateAtTabRoot} from 'lib/routes/helpers'
+import {isAndroid} from 'platform/detection'
 
 const ShellInner = observer(() => {
   const store = useStores()
@@ -49,6 +50,7 @@ const ShellInner = observer(() => {
             onOpen={onOpenDrawer}
             onClose={onCloseDrawer}
             swipeEdgeWidth={winDim.width / 2}
+            useLegacyImplementation={isAndroid ? true : false} // we need to use legacy implementation on Android https://github.com/software-mansion/react-native-reanimated/issues/3049
             swipeEnabled={
               !canGoBack &&
               store.session.hasSession &&


### PR DESCRIPTION
There is a known issue with `react-native-drawer-layout` (aka `@react-navigation/drawer`) because it uses `reanimated` v2

However, there is a workaround with `useLegacyImplementation` that uses `reanimated` v1. I have enabled this work around for Android devices and it seems to fix the issue. 

Here is the related discussion on Github: https://github.com/software-mansion/react-native-reanimated/issues/3049