### PR TITLE
Move href back to link

### DIFF
--- a/src/view/shell/desktop/LeftNav.tsx
+++ b/src/view/shell/desktop/LeftNav.tsx
@@ -99,6 +99,9 @@ const NavItem = observer(
     const {onPress} = useLinkProps({to: href})
     const onPressWrapped = React.useCallback(
       (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
+        if (e.ctrlKey || e.metaKey || e.altKey) {
+          return
+        }
         e.preventDefault()
         if (isCurrent) {
           store.emitScreenSoftReset()
@@ -113,8 +116,8 @@ const NavItem = observer(
       <PressableWithHover
         style={styles.navItemWrapper}
         hoverStyle={pal.viewLight}
-        // @ts-ignore web only -prf
         onPress={onPressWrapped}
+        // @ts-ignore web only -prf
         href={href}
         dataSet={{noUnderline: 1}}
         accessibilityRole="tab"


### PR DESCRIPTION
Observed some differences in focus tabbing between Arc, Chrome, and Firefox. Since Chrome is more widely used, we can fix Firefox another time.