### PR TITLE
top-level Makefile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,9 +35,6 @@ RUN \. "$NVM_DIR/nvm.sh" && \
 # DEBUG
 RUN find ./bskyweb/static && find ./web-build/static
 
-# Copy the bundle js files.
-RUN cp --verbose ./web-build/static/js/*.* ./bskyweb/static/js/
-
 #
 # Generate the bksyweb Go binary.
 #

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,6 @@ help: ## Print info about all commands
 .PHONY: build-web
 build-web: ## Compile web bundle, copy to bskyweb directory
 	yarn build-web
-	cp ./web-build/static/js/*.* ./bskyweb/static/js/
 
 .PHONY: test
 test: ## Run all tests

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "android": "expo run:android",
     "ios": "expo run:ios",
     "web": "expo start --web",
-    "build-web": "expo export:web && node ./scripts/post-web-build.js",
+    "build-web": "expo export:web && node ./scripts/post-web-build.js && cp --verbose ./web-build/static/js/*.* ./bskyweb/static/js/",
     "start": "expo start --dev-client",
     "clean-cache": "rm -rf node_modules/.cache/babel-loader/*",
     "test": "jest --forceExit --testTimeout=20000 --bail",


### PR DESCRIPTION
The primary motivation here is the `build-web` command, which calls the yarn build and then also copies over JS files. The Dockerfile does this and I always forget when doing it manually.

Assigning @renahlee b/c you just touched this typescript/golang stuff.