### PR TITLE
bskyweb: middleware to remove trailing /

### DIFF
--- a/bskyweb/cmd/bskyweb/server.go
+++ b/bskyweb/cmd/bskyweb/server.go
@@ -92,6 +92,12 @@ func serve(cctx *cli.Context) error {
 	e.Renderer = NewRenderer("templates/", &bskyweb.TemplateFS, debug)
 	e.HTTPErrorHandler = customHTTPErrorHandler
 
+	// redirect trailing slash to non-trailing slash.
+	// all of our current endpoints have no trailing slash.
+	e.Use(middleware.RemoveTrailingSlashWithConfig(middleware.TrailingSlashConfig{
+		RedirectCode: http.StatusFound,
+	}))
+
 	// configure routes
 	e.GET("/robots.txt", echo.WrapHandler(staticHandler))
 	e.GET("/static/*", echo.WrapHandler(http.StripPrefix("/static/", staticHandler)))


### PR DESCRIPTION
Tested a bit locally, seems to work fine.

This *could* cause a footgun at some point if we start having routes with an actual trailing slash intentionally, but we don't have any right now.

Assigning @pfrazee on this one in case there is some footgun with react-native-web i'm not thinking of.

closes: #571 