### PR TITLE
Format count and fix type warning

### DIFF
--- a/src/view/com/notifications/FeedItem.tsx
+++ b/src/view/com/notifications/FeedItem.tsx
@@ -34,6 +34,7 @@ import {
   getProfileModeration,
 } from 'lib/labeling/helpers'
 import {ProfileModeration} from 'lib/labeling/types'
+import {formatCount} from '../util/numeric/format'
 
 const MAX_AUTHORS = 5
 
@@ -218,7 +219,8 @@ export const FeedItem = observer(function ({
               <>
                 <Text style={[pal.text]}> and </Text>
                 <Text style={[pal.text, s.bold]}>
-                  {authors.length - 1} {pluralize(authors.length - 1, 'other')}
+                  {formatCount(authors.length - 1)}{' '}
+                  {pluralize(authors.length - 1, 'other')}
                 </Text>
               </>
             ) : undefined}

--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -26,6 +26,7 @@ import {PostHider} from '../util/moderation/PostHider'
 import {ContentHider} from '../util/moderation/ContentHider'
 import {ErrorMessage} from '../util/error/ErrorMessage'
 import {usePalette} from 'lib/hooks/usePalette'
+import {formatCount} from '../util/numeric/format'
 
 const PARENT_REPLY_LINE_LENGTH = 8
 
@@ -247,7 +248,7 @@ export const PostThreadItem = observer(function PostThreadItem({
                   title={repostsTitle}>
                   <Text testID="repostCount" type="lg" style={pal.textLight}>
                     <Text type="xl-bold" style={pal.text}>
-                      {item.post.repostCount}
+                      {formatCount(item.post.repostCount)}
                     </Text>{' '}
                     {pluralize(item.post.repostCount, 'repost')}
                   </Text>
@@ -262,7 +263,7 @@ export const PostThreadItem = observer(function PostThreadItem({
                   title={likesTitle}>
                   <Text testID="likeCount" type="lg" style={pal.textLight}>
                     <Text type="xl-bold" style={pal.text}>
-                      {item.post.likeCount}
+                      {formatCount(item.post.likeCount)}
                     </Text>{' '}
                     {pluralize(item.post.likeCount, 'like')}
                   </Text>

--- a/src/view/com/profile/ProfileHeader.tsx
+++ b/src/view/com/profile/ProfileHeader.tsx
@@ -401,7 +401,7 @@ const ProfileHeaderLoaded = observer(
                   </Text>
                 </TouchableOpacity>
                 <Text type="md" style={[s.bold, pal.text]}>
-                  {view.postsCount}{' '}
+                  {formatCount(view.postsCount)}{' '}
                   <Text type="md" style={[pal.textLight]}>
                     {pluralize(view.postsCount, 'post')}
                   </Text>

--- a/src/view/screens/Settings.tsx
+++ b/src/view/screens/Settings.tsx
@@ -36,6 +36,7 @@ import {useAnalytics} from 'lib/analytics'
 import {NavigationProp} from 'lib/routes/types'
 import {isDesktopWeb} from 'platform/detection'
 import {pluralize} from 'lib/strings/helpers'
+import {formatCount} from 'view/com/util/numeric/format'
 
 type Props = NativeStackScreenProps<CommonNavigatorParams, 'Settings'>
 export const SettingsScreen = withAuthRequired(
@@ -153,18 +154,22 @@ export const SettingsScreen = withAuthRequired(
           contentContainerStyle={!isDesktopWeb && pal.viewLight}
           scrollIndicatorInsets={{right: 1}}>
           <View style={styles.spacer20} />
-          <Text type="xl-bold" style={[pal.text, styles.heading]}>
-            Account
-          </Text>
-          <View style={[styles.infoLine]}>
-            <Text type="lg-medium" style={pal.text}>
-              Email:{' '}
-              <Text type="lg" style={pal.text}>
-                {store.session.currentSession.email}
+          {store.session.currentSession !== undefined ? (
+            <>
+              <Text type="xl-bold" style={[pal.text, styles.heading]}>
+                Account
               </Text>
-            </Text>
-          </View>
-          <View style={styles.spacer20} />
+              <View style={[styles.infoLine]}>
+                <Text type="lg-medium" style={pal.text}>
+                  Email:{' '}
+                  <Text type="lg" style={pal.text}>
+                    {store.session.currentSession?.email}
+                  </Text>
+                </Text>
+              </View>
+              <View style={styles.spacer20} />
+            </>
+          ) : null}
           <View style={[s.flexRow, styles.heading]}>
             <Text type="xl-bold" style={pal.text}>
               Signed in as
@@ -275,7 +280,7 @@ export const SettingsScreen = withAuthRequired(
             <Text
               type="lg"
               style={store.me.invitesAvailable > 0 ? pal.link : pal.text}>
-              {store.me.invitesAvailable} invite{' '}
+              {formatCount(store.me.invitesAvailable)} invite{' '}
               {pluralize(store.me.invitesAvailable, 'code')} available
             </Text>
           </TouchableOpacity>

--- a/src/view/shell/Drawer.tsx
+++ b/src/view/shell/Drawer.tsx
@@ -392,7 +392,7 @@ const InviteCodes = observer(() => {
       <Text
         type="lg-medium"
         style={store.me.invitesAvailable > 0 ? pal.link : pal.textLight}>
-        {store.me.invitesAvailable} invite{' '}
+        {formatCount(store.me.invitesAvailable)} invite{' '}
         {pluralize(store.me.invitesAvailable, 'code')}
       </Text>
     </TouchableOpacity>

--- a/src/view/shell/desktop/RightNav.tsx
+++ b/src/view/shell/desktop/RightNav.tsx
@@ -12,6 +12,7 @@ import {useStores} from 'state/index'
 import {pluralize} from 'lib/strings/helpers'
 import {useColorSchemeStyle} from 'lib/hooks/useColorSchemeStyle'
 import {MoonIcon} from 'lib/icons'
+import {formatCount} from 'view/com/util/numeric/format'
 
 export const DesktopRightNav = observer(function DesktopRightNav() {
   const store = useStores()
@@ -112,7 +113,7 @@ const InviteCodes = observer(() => {
       <Text
         type="md-medium"
         style={store.me.invitesAvailable > 0 ? pal.link : pal.textLight}>
-        {store.me.invitesAvailable} invite{' '}
+        {formatCount(store.me.invitesAvailable)} invite{' '}
         {pluralize(store.me.invitesAvailable, 'code')} available
       </Text>
     </TouchableOpacity>


### PR DESCRIPTION
This PR:

- Updates callsites that leverage `pluralize` and formats the count
- Fixes the type where `currentSession` may not be defined and updates the corresponding null view

Looks like:

<img width="350" alt="Screen Shot 2023-05-08 at 12 09 44 PM" src="https://user-images.githubusercontent.com/12389148/236912131-16a6d407-e7c5-49d8-a294-be6d3d168636.png">

<img width="350" alt="Screen Shot 2023-05-08 at 12 15 07 PM" src="https://user-images.githubusercontent.com/12389148/236912384-b666e4de-12b3-4a2b-8458-e44077c61d4e.png">