### PR TITLE
Add avatar to mobile autocomplete and create grapheme hook

### DIFF
--- a/src/view/com/composer/text-input/hooks/useGrapheme.tsx
+++ b/src/view/com/composer/text-input/hooks/useGrapheme.tsx
@@ -8,18 +8,15 @@ export const useGrapheme = () => {
     (name: string, length: number) => {
       let remainingCharacters = 0
 
-      // Heuristic value based on max display name and handle lengths
       if (name.length > length) {
         const graphemes = splitter.splitGraphemes(name)
 
         if (graphemes.length > length) {
-          if (graphemes.length > length) {
-            remainingCharacters = 0
-            name = `${graphemes.slice(0, length).join('')}...`
-          } else {
-            remainingCharacters = length - graphemes.length
-            name = graphemes.join('')
-          }
+          remainingCharacters = 0
+          name = `${graphemes.slice(0, length).join('')}...`
+        } else {
+          remainingCharacters = length - graphemes.length
+          name = graphemes.join('')
         }
       } else {
         remainingCharacters = length - name.length

--- a/src/view/com/composer/text-input/mobile/Autocomplete.tsx
+++ b/src/view/com/composer/text-input/mobile/Autocomplete.tsx
@@ -6,7 +6,7 @@ import {useAnimatedValue} from 'lib/hooks/useAnimatedValue'
 import {usePalette} from 'lib/hooks/usePalette'
 import {Text} from 'view/com/util/text/Text'
 import {UserAvatar} from 'view/com/util/UserAvatar'
-import {useGrapheme} from '../hooks/useDisplayName'
+import {useGrapheme} from '../hooks/useGrapheme'
 
 export const Autocomplete = observer(
   ({

--- a/src/view/com/composer/text-input/web/Autocomplete.tsx
+++ b/src/view/com/composer/text-input/web/Autocomplete.tsx
@@ -16,7 +16,7 @@ import {UserAutocompleteModel} from 'state/models/discovery/user-autocomplete'
 import {usePalette} from 'lib/hooks/usePalette'
 import {Text} from 'view/com/util/text/Text'
 import {UserAvatar} from 'view/com/util/UserAvatar'
-import {useGrapheme} from '../hooks/useDisplayName'
+import {useGrapheme} from '../hooks/useGrapheme'
 
 interface MentionListRef {
   onKeyDown: (props: SuggestionKeyDownProps) => boolean


### PR DESCRIPTION
This PR:

- Adds visual updates to the mobile autocomplete
- Extracts the prior grapheme length checking logic into a hook
- Adds a null state and prepends `@` to the handle in web autocomplete display for parity with mobile

<img width=350 src="https://user-images.githubusercontent.com/12389148/236960146-cbf27453-646f-4176-b6d0-147d3cd4395d.PNG" />
<img width=350 src="https://user-images.githubusercontent.com/12389148/236960150-0cfccef8-f274-4a88-b626-15e1a9cee017.PNG" />
<img width=350 src="https://user-images.githubusercontent.com/12389148/236960156-01a078cc-c308-4288-b2b1-3c7af162a9f8.PNG" />
<img width=350 src="https://user-images.githubusercontent.com/12389148/236960160-6aed67c5-a61d-4856-9d78-e94d6619763b.PNG" />
<img width=350 src="https://user-images.githubusercontent.com/12389148/236960163-88d756a5-683d-4aa1-89db-35acb4687d61.PNG" />