### PR TITLE
Add time to app password and fix related text wrapping

### DIFF
--- a/src/view/screens/AppPasswords.tsx
+++ b/src/view/screens/AppPasswords.tsx
@@ -180,21 +180,35 @@ function AppPassword({
     )
   }, [store, name])
 
+  const {contentLanguages} = store.preferences
+
+  const primaryLocale =
+    contentLanguages.length > 0 ? contentLanguages[0] : 'en-US'
+
   return (
     <TouchableOpacity
       testID={testID}
       style={[styles.item, pal.border]}
       onPress={onDelete}
       accessibilityRole="button"
-      accessibilityLabel="Delete"
-      accessibilityHint="Deletes app password">
-      <Text type="md-bold" style={pal.text}>
-        {name}
-      </Text>
-      <View style={styles.flex1} />
-      <Text type="md" style={[pal.text, styles.pr10]}>
-        {new Date(createdAt).toDateString()}
-      </Text>
+      accessibilityLabel="Delete app password"
+      accessibilityHint="">
+      <View>
+        <Text type="md-bold" style={pal.text}>
+          {name}
+        </Text>
+        <Text type="md" style={[pal.text, styles.pr10]} numberOfLines={1}>
+          Created{' '}
+          {Intl.DateTimeFormat(primaryLocale, {
+            year: 'numeric',
+            month: 'numeric',
+            day: 'numeric',
+            hour: '2-digit',
+            minute: '2-digit',
+            second: '2-digit',
+          }).format(new Date(createdAt))}
+        </Text>
+      </View>
       <FontAwesomeIcon icon={['far', 'trash-can']} style={styles.trashIcon} />
     </TouchableOpacity>
   )
@@ -246,6 +260,7 @@ const styles = StyleSheet.create({
   item: {
     flexDirection: 'row',
     alignItems: 'center',
+    justifyContent: 'space-between',
     borderBottomWidth: 1,
     paddingHorizontal: 20,
     paddingVertical: 14,


### PR DESCRIPTION
### Overview

This PR:

- Updates created time formatting for app passwords to use the first locale or default to US (open to feedback here)
- Cascades date to the second line as a way of addressing text overflow

**Before / after**

<table>
<tbody>
<tr>
<td>
<img width=350 src="https://user-images.githubusercontent.com/12389148/236999071-c8dc15cf-a624-416c-9014-22440f0cbb56.jpeg" />
</td>

<td>
<img width=350 src="https://user-images.githubusercontent.com/12389148/236999085-35b5fb33-8886-49b8-835a-960024c2b811.jpeg" />
</td>
</tr>
</tbody>
</table>
