### PR TITLE
[APP-609] Open in new tab in safari 

### DIFF
--- a/src/lib/strings/url-helpers.ts
+++ b/src/lib/strings/url-helpers.ts
@@ -66,6 +66,10 @@ export function isBskyAppUrl(url: string): boolean {
   return url.startsWith('https://bsky.app/')
 }
 
+export function isExternalUrl(url: string): boolean {
+  return !isBskyAppUrl(url) && url.startsWith('http')
+}
+
 export function isBskyPostUrl(url: string): boolean {
   if (isBskyAppUrl(url)) {
     try {

--- a/src/view/com/util/Link.tsx
+++ b/src/view/com/util/Link.tsx
@@ -1,4 +1,4 @@
-import React, {ComponentProps} from 'react'
+import React, {ComponentProps, useMemo} from 'react'
 import {observer} from 'mobx-react-lite'
 import {
   Linking,
@@ -21,7 +21,7 @@ import {TypographyVariant} from 'lib/ThemeContext'
 import {NavigationProp} from 'lib/routes/types'
 import {router} from '../../../routes'
 import {useStores, RootStoreModel} from 'state/index'
-import {convertBskyAppUrlIfNeeded} from 'lib/strings/url-helpers'
+import {convertBskyAppUrlIfNeeded, isExternalUrl} from 'lib/strings/url-helpers'
 import {isDesktopWeb} from 'platform/detection'
 import {sanitizeUrl} from '@braintree/sanitize-url'
 
@@ -132,6 +132,16 @@ export const TextLink = observer(function TextLink({
     },
     [store, navigation, href],
   )
+  const hrefAttrs = useMemo(() => {
+    const isExternal = isExternalUrl(href)
+    if (isExternal) {
+      return {
+        target: '_blank',
+        // rel: 'noopener noreferrer',
+      }
+    }
+    return {}
+  }, [href])
 
   return (
     <Text
@@ -142,6 +152,8 @@ export const TextLink = observer(function TextLink({
       lineHeight={lineHeight}
       // @ts-ignore web only -prf
       dataSet={dataSet}
+      // @ts-ignore web only -prf
+      hrefAttrs={hrefAttrs} // hack to get open in new tab to work on safari. without this, safari will open in a new window
       {...props}>
       {text}
     </Text>


### PR DESCRIPTION
It previously did not work due to Safari being a browser that defies all norms.

Added a hack to get `target="_blank"` to work on Safari