### PR TITLE
env-specific search endpoint (BROKEN)

### DIFF
--- a/src/lib/api/search.ts
+++ b/src/lib/api/search.ts
@@ -4,6 +4,7 @@
  */
 import {AppBskyFeedPost} from '@atproto/api'
 import {SEARCH_HOST} from 'lib/constants'
+import {RootStoreModel} from 'state/index'
 
 export interface ProfileSearchItem {
   $type: string
@@ -31,15 +32,19 @@ export interface PostSearchItem {
 }
 
 export async function searchProfiles(
+  rootStore: RootStoreModel,
   query: string,
 ): Promise<ProfileSearchItem[]> {
-  const host = SEARCH_HOST(this.rootStore.session.currentSession?.service || '')
+  const host = SEARCH_HOST(rootStore.session.currentSession?.service || '')
   const endpoint = `${host}/search/profiles`
   return await doFetch<ProfileSearchItem[]>(endpoint, query)
 }
 
-export async function searchPosts(query: string): Promise<PostSearchItem[]> {
-  const host = SEARCH_HOST(this.rootStore.session.currentSession?.service || '')
+export async function searchPosts(
+  rootStore: RootStoreModel,
+  query: string,
+): Promise<PostSearchItem[]> {
+  const host = SEARCH_HOST(rootStore.session.currentSession?.service || '')
   const endpoint = `${host}/search/posts`
   return await doFetch<PostSearchItem[]>(endpoint, query)
 }

--- a/src/lib/api/search.ts
+++ b/src/lib/api/search.ts
@@ -3,9 +3,7 @@
  * TODO removeme when we land this in proto!
  */
 import {AppBskyFeedPost} from '@atproto/api'
-
-const PROFILES_ENDPOINT = 'https://search.bsky.social/search/profiles'
-const POSTS_ENDPOINT = 'https://search.bsky.social/search/posts'
+import {SEARCH_HOST} from 'lib/constants'
 
 export interface ProfileSearchItem {
   $type: string
@@ -35,11 +33,15 @@ export interface PostSearchItem {
 export async function searchProfiles(
   query: string,
 ): Promise<ProfileSearchItem[]> {
-  return await doFetch<ProfileSearchItem[]>(PROFILES_ENDPOINT, query)
+  const host = SEARCH_HOST(this.rootStore.session.currentSession?.service || '')
+  const endpoint = `${host}/search/profiles`
+  return await doFetch<ProfileSearchItem[]>(endpoint, query)
 }
 
 export async function searchPosts(query: string): Promise<PostSearchItem[]> {
-  return await doFetch<PostSearchItem[]>(POSTS_ENDPOINT, query)
+  const host = SEARCH_HOST(this.rootStore.session.currentSession?.service || '')
+  const endpoint = `${host}/search/posts`
+  return await doFetch<PostSearchItem[]>(endpoint, query)
 }
 
 async function doFetch<T>(endpoint: string, query: string): Promise<T> {

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -86,6 +86,16 @@ export function SUGGESTED_FOLLOWS(serviceUrl: string) {
   }
 }
 
+export function SEARCH_HOST(serviceUrl: string) {
+  if (serviceUrl.includes('localhost')) {
+    return 'http://localhost:2470'
+  } else if (serviceUrl.includes('staging.bsky.dev')) {
+    return 'https://search.staging.bsky.dev'
+  } else {
+    return 'https://search.bsky.social'
+  }
+}
+
 export const POST_IMG_MAX = {
   width: 2000,
   height: 2000,

--- a/src/state/models/ui/search.ts
+++ b/src/state/models/ui/search.ts
@@ -27,8 +27,8 @@ export class SearchUIModel {
     this.isProfilesLoading = true
 
     const [postsSearch, profilesSearch] = await Promise.all([
-      searchPosts(q).catch(_e => []),
-      searchProfiles(q).catch(_e => []),
+      searchPosts(this.rootStore, q).catch(_e => []),
+      searchProfiles(this.rootStore, q).catch(_e => []),
     ])
 
     let posts: AppBskyFeedDefs.PostView[] = []


### PR DESCRIPTION
DON'T MERGE, NOT WORKING

I tried to make the search endpoint sensitive to configured environment, similar to some of the other constants.

This doesn't seem to working (all searches are broken), but I don't know enough about how the app is built and debugged to figure out why.

The localhost address I hard-coded in is the default port for running locally. Maybe that should be staging instead? Not sure.

cc: @renahlee 