### PR TITLE
bskyweb: iterate on HTML card metadata

### DIFF
--- a/bskyweb/cmd/bskyweb/server.go
+++ b/bskyweb/cmd/bskyweb/server.go
@@ -185,7 +185,13 @@ func (srv *Server) WebPost(c echo.Context) error {
 			if err != nil {
 				log.Warnf("failed to fetch post: %s\t%v", uri, err)
 			} else {
-				data["postView"] = tpv.Thread.FeedDefs_ThreadViewPost.Post
+				req := c.Request()
+				postView := tpv.Thread.FeedDefs_ThreadViewPost.Post
+				data["postView"] = postView
+				data["requestURI"] = fmt.Sprintf("https://%s%s", req.Host, req.URL.Path)
+				if postView.Embed != nil && postView.Embed.EmbedImages_View != nil {
+					data["imgThumbUrl"] = postView.Embed.EmbedImages_View.Images[0].Thumb
+				}
 			}
 		}
 
@@ -203,7 +209,9 @@ func (srv *Server) WebProfile(c echo.Context) error {
 		if err != nil {
 			log.Warnf("failed to fetch handle: %s\t%v", handle, err)
 		} else {
+			req := c.Request()
 			data["profileView"] = pv
+			data["requestURI"] = fmt.Sprintf("https://%s%s", req.Host, req.URL.Path)
 		}
 	}
 

--- a/bskyweb/templates/home.html
+++ b/bskyweb/templates/home.html
@@ -3,14 +3,12 @@
 {% block head_title %}Bluesky{% endblock %}
 
 {% block html_head_extra -%}
+  <meta name="description" content="See what's next."/>
+  <meta property="og:type" content="website"/>
   <meta property="og:title" content="Bluesky Social"/>
   <meta property="og:description" content="See what's next."/>
-  <meta property="og:type" content="article"/>
-  <meta property="og:image" content="/static/default-social-card.png"/>
-  <meta name="twitter:title" content="Bluesky Social"/>
-  <meta name="twitter:description" content="See what&#x27;s next."/>
-  <meta name="twitter:image" content="/static/default-social-card.png"/>
-  <meta name="twitter:card" content="summary_large_image"/>
+  <meta property="og:image" content="/static/social-card-default.png"/>
+  <meta name="twitter:card" content="summary"/>
   <meta name="twitter:site" content="@bluesky"/>
 {%- endblock %}
 

--- a/bskyweb/templates/post.html
+++ b/bskyweb/templates/post.html
@@ -1,23 +1,39 @@
 {% extends "base.html" %}
 
-{# TODO: link rel=canonical #}
-{# TODO: "same as" #}
+{% block head_title %}
+{%- if postView -%}
+  @{{ postView.Author.Handle }} on Bluesky
+{%- else -%}
+  Bluesky
+{%- endif -%}
+{% endblock %}
+
 {% block html_head_extra -%}
-{%- if postView %}
-  <meta property="og:type" content="article"/>
-  <meta name="twitter:card" content="summary"/>
-  <meta property="og:title" content="{{ postView.Author.Handle }} - Bluesky"/>
-  <meta name="twitter:title" content="{{ postView.Author.Handle }} - Bluesky"/>
-  {%- if postView.Author.Avatar %}
-  <meta property="og:image" content="{{ postView.Author.Avatar }}"/>
-  <meta name="twitter:image" content="{{ postView.Author.Avatar }}"/>
+{%- if postView -%}
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Bluesky Social">
+  {%- if requestURI %}
+  <meta property="og:url" content="{{ requestURI }}">
   {% endif -%}
-  {%- if postView.Record.Text %}
-  <meta property="og:description" content="{{ postView.Record.Text }}"/>
-  <meta name="twitter:description" content="{{ postView.Record.Text }}"/>
+  {%- if postView.Author.DisplayName %}
+  <meta property="og:title" content="{{ postView.Author.DisplayName }} (@{{ postView.Author.Handle }})">
+  {% else %}
+  <meta property="og:title" content="@{{ postView.Author.Handle }}">
   {% endif -%}
-  <meta name="twitter:label1" content="Author DID">
-  <meta name="twitter:value1" content="{{ postView.Author.Did }}">
+  {%- if postView.Record.Val.Text %}
+  <meta name="description" content="{{ postView.Record.Val.Text }}">
+  <meta property="og:description" content="{{ postView.Record.Val.Text }}">
+  {% endif -%}
+  {%- if imgThumbUrl %}
+  <meta property="og:image" content="{{ imgThumbUrl }}">
+  <meta name="twitter:card" content="summary_large_image">
+  {%- elif postView.Author.Avatar %}
+  {# Don't use avatar image in cards; usually looks bad #}
+  <meta name="twitter:card" content="summary">
+  {% endif %}
+  <meta name="twitter:label1" content="Posted At">
+  <meta name="twitter:value1" content="{{ postView.CreatedAt }}">
+  <meta name="twitter:site" content="@bluesky">
 {% endif -%}
 {%- endblock %}
 

--- a/bskyweb/templates/profile.html
+++ b/bskyweb/templates/profile.html
@@ -1,24 +1,40 @@
 {% extends "base.html" %}
 
-{# TODO: "same as" indication with DID? #}
-{# TODO: could work in profileView.DisplayName here, conditionally? #}
+{% block head_title %}
+{%- if profileView -%}
+  @{{ profileView.Handle }} on Bluesky
+{%- else -%}
+  Bluesky
+{%- endif -%}
+{% endblock %}
+
 {% block html_head_extra -%}
 {%- if profileView -%}
-  <meta property="og:type" content="article"/>
-  <meta name="twitter:card" content="summary"/>
-  <meta property="og:title" content="{{ profileView.Handle }} - Bluesky"/>
-  <meta name="twitter:title" content="{{ profileView.Handle}} - Bluesky"/>
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="Bluesky Social">
+  {%- if requestURI %}
+  <meta property="og:url" content="{{ requestURI }}">
+  {% endif -%}
+  {%- if profileView.DisplayName %}
+  <meta property="og:title" content="{{ profileView.DisplayName }} (@{{ profileView.Handle }})">
+  {% else %}
+  <meta property="og:title" content="{{ profileView.Handle }}">
+  {% endif -%}
   {%- if profileView.Description %}
-  <meta property="og:description" content="{{ profileView.Description }}"/>
-  <meta name="twitter:description" content="{{ profileView.Description }}"/>
+  <meta name="description" content="{{ profileView.Description }}">
+  <meta property="og:description" content="{{ profileView.Description }}">
   {% endif -%}
-  {%- if profileView.Avatar %}
-  <meta property="og:image" content="{{ profileView.Avatar }}"/>
-  <meta name="twitter:image" content="{{ profileView.Avatar }}"/>
-  {% endif -%}
-  <meta name="twitter:label1" content="Author DID">
+  {%- if profileView.Banner %}
+  <meta property="og:image" content="{{ profileView.Banner }}">
+  <meta name="twitter:card" content="summary_large_image">
+  {%- elif profileView.Avatar -%}
+  {# Don't use avatar image in cards; usually looks bad #}
+  <meta name="twitter:card" content="summary">
+  {% endif %}
+  <meta name="twitter:label1" content="Account DID">
   <meta name="twitter:value1" content="{{ profileView.Did }}">
-{%- endif -%}
+  <meta name="twitter:site" content="@bluesky">
+{% endif -%}
 {%- endblock %}
 
 {% block noscript_extra -%}


### PR DESCRIPTION
Probably still not perfect, but better.

- don't user avatar image. use banner for profile and post img, or nothing
- most twitter metadata fields were redundant; twitter will parse out opengraph ("og:"), so don't duplicate those
- add regular HTML description (for google, etc)
- include URI
- actually include text

We might want to actually consider *not* making social cards public, until we do some public messaging and have "purge" (rebase) in the app. If we decide to do that, I can wrap these in "if false" to return no metadata for now.

FWIW, I'll admit the iteration cycle on these is very slow. I'm mostly following docs/specs; difficult to test with slack/twitter/etc until changes hit at least staging (.bsky.dev).