### PR TITLE
Only allow one close draft confirmation at a time

### DIFF
--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -108,7 +108,7 @@ export const ComposePost = observer(function ComposePost({
         })
       }
     },
-    [store.shell, onClose],
+    [store, onClose],
   )
 
   useEffect(() => {


### PR DESCRIPTION
### Overview

This PR:

- Prevents multiple confirmation modals from being triggered when closing the composer

Known issue: we can't escape out of the confirmation modal but let's re-think keyboard shortcuts in the future 🙌 