### PR TITLE
small label updates

### DIFF
--- a/src/lib/labeling/const.ts
+++ b/src/lib/labeling/const.ts
@@ -74,7 +74,7 @@ export const CONFIGURABLE_LABEL_GROUPS: Record<
   spam: {
     id: 'spam',
     title: 'Spam',
-    subtitle: 'Excessive low-quality posts',
+    subtitle: 'Excessive unwanted interactions',
     warning: 'Spam',
     values: ['spam'],
   },


### PR DESCRIPTION
Split in to individual commits so we can shuffle/remove these as desired.

These are relatively non-controversial, I think. Not "subjective" ones being added in this PR.

I *hope* the `nsfl` ("not safe for life") being in two categories will work. The intention is that if either category is filter/warn behavior, then that content would get warned.