### PR TITLE
Tweak label categories: new anti-social; rephrase political violence; remove impersonation config

### DIFF
--- a/src/lib/labeling/const.ts
+++ b/src/lib/labeling/const.ts
@@ -19,7 +19,7 @@ export const ALWAYS_WARN_LABEL_GROUP: LabelValGroup = {
   id: 'always-warn',
   title: 'Content Warning',
   warning: 'Content Warning',
-  values: ['!warn', 'account-security'],
+  values: ['!warn', 'account-security', 'impersonation'],
 }
 
 export const UNKNOWN_LABEL_GROUP: LabelValGroup = {
@@ -78,13 +78,6 @@ export const CONFIGURABLE_LABEL_GROUPS: Record<
     subtitle: 'Excessive unwanted interactions',
     warning: 'Spam',
     values: ['spam'],
-  },
-  impersonation: {
-    id: 'impersonation',
-    title: 'Impersonation',
-    subtitle: 'Accounts falsely claiming to be people or orgs',
-    warning: 'Impersonation',
-    values: ['impersonation'],
   },
   antisocial: {
     id: 'antisocial',

--- a/src/lib/labeling/const.ts
+++ b/src/lib/labeling/const.ts
@@ -86,4 +86,11 @@ export const CONFIGURABLE_LABEL_GROUPS: Record<
     warning: 'Impersonation',
     values: ['impersonation'],
   },
+  antisocial: {
+    id: 'antisocial',
+    title: 'Anti-Social Behavior',
+    subtitle: 'Harassment, trolling, intolerant behavior',
+    warning: 'Anti-Social',
+    values: ['troll', 'threat', 'intolerant', 'misleading', 'scam'],
+  },
 }

--- a/src/lib/labeling/const.ts
+++ b/src/lib/labeling/const.ts
@@ -67,9 +67,10 @@ export const CONFIGURABLE_LABEL_GROUPS: Record<
   },
   hate: {
     id: 'hate',
-    title: 'Political Hate-Groups',
-    warning: 'Hate',
-    values: ['icon-kkk', 'icon-nazi', 'icon-intolerant', 'behavior-intolerant'],
+    title: 'Political Violence',
+    subtitle: 'Terrorist, hate, supremacist groups',
+    warning: 'Policital Violence',
+    values: ['icon-kkk', 'icon-nazi', 'icon-intolerant', 'intolerant-group'],
   },
   spam: {
     id: 'spam',

--- a/src/lib/labeling/const.ts
+++ b/src/lib/labeling/const.ts
@@ -69,7 +69,7 @@ export const CONFIGURABLE_LABEL_GROUPS: Record<
     id: 'hate',
     title: 'Political Violence',
     subtitle: 'Terrorist, hate, supremacist groups',
-    warning: 'Policital Violence',
+    warning: 'Political Violence',
     values: ['icon-kkk', 'icon-nazi', 'icon-intolerant', 'intolerant-group'],
   },
   spam: {

--- a/src/state/models/ui/preferences.ts
+++ b/src/state/models/ui/preferences.ts
@@ -24,6 +24,7 @@ export class LabelPreferencesModel {
   hate: LabelPreference = 'hide'
   spam: LabelPreference = 'hide'
   impersonation: LabelPreference = 'warn'
+  antisocial: LabelPreference = 'warn'
 
   constructor() {
     makeAutoObservable(this, {}, {autoBind: true})

--- a/src/state/models/ui/preferences.ts
+++ b/src/state/models/ui/preferences.ts
@@ -23,7 +23,6 @@ export class LabelPreferencesModel {
   gore: LabelPreference = 'warn'
   hate: LabelPreference = 'hide'
   spam: LabelPreference = 'hide'
-  impersonation: LabelPreference = 'warn'
   antisocial: LabelPreference = 'warn'
 
   constructor() {

--- a/src/view/com/modals/ContentFilteringSettings.tsx
+++ b/src/view/com/modals/ContentFilteringSettings.tsx
@@ -43,7 +43,6 @@ export function Component({}: {}) {
         <ContentLabelPref group="hate" />
         <ContentLabelPref group="spam" />
         <ContentLabelPref group="antisocial" subjective={true} />
-        <ContentLabelPref group="impersonation" />
         <View style={styles.bottomSpacer} />
       </ScrollView>
       <View style={[styles.btnContainer, pal.borderDark]}>

--- a/src/view/com/modals/ContentFilteringSettings.tsx
+++ b/src/view/com/modals/ContentFilteringSettings.tsx
@@ -42,7 +42,7 @@ export function Component({}: {}) {
         />
         <ContentLabelPref group="hate" />
         <ContentLabelPref group="spam" />
-        <ContentLabelPref group="antisocial" />
+        <ContentLabelPref group="antisocial" subjective={true} />
         <ContentLabelPref group="impersonation" />
         <View style={styles.bottomSpacer} />
       </ScrollView>
@@ -71,9 +71,11 @@ const ContentLabelPref = observer(
   ({
     group,
     disabled,
+    subjective,
   }: {
     group: keyof typeof CONFIGURABLE_LABEL_GROUPS
     disabled?: boolean
+    subjective?: boolean
   }) => {
     const store = useStores()
     const pal = usePalette('default')
@@ -98,6 +100,7 @@ const ContentLabelPref = observer(
             current={store.preferences.contentLabels[group]}
             onChange={v => store.preferences.setContentLabelPref(group, v)}
             group={group}
+            subjective={subjective}
           />
         )}
       </View>
@@ -109,15 +112,16 @@ interface SelectGroupProps {
   current: LabelPreference
   onChange: (v: LabelPreference) => void
   group: keyof typeof CONFIGURABLE_LABEL_GROUPS
+  subjective?: boolean
 }
 
-function SelectGroup({current, onChange, group}: SelectGroupProps) {
+function SelectGroup({current, onChange, group, subjective}: SelectGroupProps) {
   return (
     <View style={styles.selectableBtns}>
       <SelectableBtn
         current={current}
         value="hide"
-        label="Hide"
+        label={subjective ? 'Calm' : 'Hide'}
         left
         onChange={onChange}
         group={group}
@@ -125,14 +129,14 @@ function SelectGroup({current, onChange, group}: SelectGroupProps) {
       <SelectableBtn
         current={current}
         value="warn"
-        label="Warn"
+        label={subjective ? 'Default' : 'Warn'}
         onChange={onChange}
         group={group}
       />
       <SelectableBtn
         current={current}
         value="show"
-        label="Show"
+        label={subjective ? 'Unfiltered' : 'Show'}
         right
         onChange={onChange}
         group={group}

--- a/src/view/com/modals/ContentFilteringSettings.tsx
+++ b/src/view/com/modals/ContentFilteringSettings.tsx
@@ -42,6 +42,7 @@ export function Component({}: {}) {
         />
         <ContentLabelPref group="hate" />
         <ContentLabelPref group="spam" />
+        <ContentLabelPref group="antisocial" />
         <ContentLabelPref group="impersonation" />
         <View style={styles.bottomSpacer} />
       </ScrollView>


### PR DESCRIPTION
Commit names are descriptive, and can be rebased/reverted as needed.

Summary:
- new "Anti-Social" bucket for trolling, intolerant, other behavioral and content issues
- re-word "Political Violence" category, add a couple more labels
- have "impersonation" be an always-warn thing, not configurable. motivations are both to reduce config complexity; and to treat this as less of a subjective/perspective issue. does make it impossible to "filter", as a downside
- change the toggle names for "anti-social" specifically, in to "calm/default/unfiltered". This is surface-only for now, but could have specific labels have different behaviors in those categories, different from all treated "show/warn/filter" all together

Separate PR forthcoming with new reporting category