### PR TITLE
Replace image picker with expo-image-picker

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "expo-device": "~5.2.1",
     "expo-image": "^1.2.1",
     "expo-image-manipulator": "^11.1.1",
-    "expo-image-picker": "~14.1.1",
+    "expo-image-picker": "^14.1.1",
     "expo-localization": "~14.1.1",
     "expo-media-library": "~15.2.3",
     "expo-sharing": "~11.2.2",

--- a/src/lib/media/picker.tsx
+++ b/src/lib/media/picker.tsx
@@ -1,12 +1,16 @@
 import {
-  openPicker as openPickerFn,
   openCamera as openCameraFn,
   openCropper as openCropperFn,
-  ImageOrVideo,
+  Image as RNImage,
 } from 'react-native-image-crop-picker'
 import {RootStoreModel} from 'state/index'
-import {PickerOpts, CameraOpts, CropperOptions} from './types'
-import {Image as RNImage} from 'react-native-image-crop-picker'
+import {CameraOpts, CropperOptions} from './types'
+import {
+  ImagePickerOptions,
+  launchImageLibraryAsync,
+  MediaTypeOptions,
+} from 'expo-image-picker'
+import {getDataUriSize} from './util'
 
 /**
  * NOTE
@@ -17,29 +21,21 @@ import {Image as RNImage} from 'react-native-image-crop-picker'
  * -prf
  */
 
-export async function openPicker(
-  _store: RootStoreModel,
-  opts?: PickerOpts,
-): Promise<RNImage[]> {
-  const items = await openPickerFn({
-    mediaType: 'photo', // TODO: eventually add other media types
-    multiple: opts?.multiple,
-    maxFiles: opts?.maxFiles,
-    forceJpg: true, // ios only
-    compressImageQuality: 0.8,
+export async function openPicker(opts?: ImagePickerOptions) {
+  const response = await launchImageLibraryAsync({
+    exif: false,
+    mediaTypes: MediaTypeOptions.Images,
+    quality: 1,
+    ...opts,
   })
 
-  const toMedia = (item: ImageOrVideo) => ({
-    path: item.path,
-    mime: item.mime,
-    size: item.size,
-    width: item.width,
-    height: item.height,
-  })
-  if (Array.isArray(items)) {
-    return items.map(toMedia)
-  }
-  return [toMedia(items)]
+  return (response.assets ?? []).map(image => ({
+    mime: 'image/jpeg',
+    height: image.height,
+    width: image.width,
+    path: image.uri,
+    size: getDataUriSize(image.uri),
+  }))
 }
 
 export async function openCamera(
@@ -55,6 +51,7 @@ export async function openCamera(
     forceJpg: true, // ios only
     compressImageQuality: 0.8,
   })
+
   return {
     path: item.path,
     mime: item.mime,
@@ -64,14 +61,10 @@ export async function openCamera(
   }
 }
 
-export async function openCropper(
-  _store: RootStoreModel,
-  opts: CropperOptions,
-): Promise<RNImage> {
+export async function openCropper(opts: CropperOptions) {
   const item = await openCropperFn({
     ...opts,
     forceJpg: true, // ios only
-    compressImageQuality: 0.8,
   })
 
   return {

--- a/src/lib/media/picker.tsx
+++ b/src/lib/media/picker.tsx
@@ -21,7 +21,10 @@ import {getDataUriSize} from './util'
  * -prf
  */
 
-export async function openPicker(opts?: ImagePickerOptions) {
+export async function openPicker(
+  _store: RootStoreModel,
+  opts?: ImagePickerOptions,
+) {
   const response = await launchImageLibraryAsync({
     exif: false,
     mediaTypes: MediaTypeOptions.Images,
@@ -61,7 +64,10 @@ export async function openCamera(
   }
 }
 
-export async function openCropper(opts: CropperOptions) {
+export async function openCropper(
+  _store: RootStoreModel,
+  opts: CropperOptions,
+) {
   const item = await openCropperFn({
     ...opts,
     forceJpg: true, // ios only

--- a/src/state/models/media/gallery.ts
+++ b/src/state/models/media/gallery.ts
@@ -101,11 +101,15 @@ export class GalleryModel {
   }
 
   async pick() {
-    const images = await openPicker(this.rootStore, {
-      multiple: true,
-      maxFiles: 4 - this.images.length,
+    const images = await openPicker({
+      selectionLimit: 4 - this.size,
+      allowsMultipleSelection: true,
     })
 
-    await Promise.all(images.map(image => this.add(image)))
+    return await Promise.all(
+      images.map(image => {
+        this.add(image)
+      }),
+    )
   }
 }

--- a/src/state/models/media/gallery.ts
+++ b/src/state/models/media/gallery.ts
@@ -101,7 +101,7 @@ export class GalleryModel {
   }
 
   async pick() {
-    const images = await openPicker({
+    const images = await openPicker(this.rootStore, {
       selectionLimit: 4 - this.size,
       allowsMultipleSelection: true,
     })

--- a/src/state/models/media/image.ts
+++ b/src/state/models/media/image.ts
@@ -135,7 +135,7 @@ export class ImageModel implements RNImage {
   // Only for mobile
   async crop() {
     try {
-      const cropped = await openCropper(this.rootStore, {
+      const cropped = await openCropper({
         mediaType: 'photo',
         path: this.path,
         freeStyleCropEnabled: true,

--- a/src/view/com/modals/EditProfile.tsx
+++ b/src/view/com/modals/EditProfile.tsx
@@ -65,7 +65,7 @@ export function Component({
   }
   const onSelectNewAvatar = useCallback(
     async (img: RNImage | null) => {
-      if (!img) {
+      if (img === null) {
         setNewUserAvatar(null)
         setUserAvatar(null)
         return
@@ -81,6 +81,7 @@ export function Component({
     },
     [track, setNewUserAvatar, setUserAvatar, setError],
   )
+
   const onSelectNewBanner = useCallback(
     async (img: RNImage | null) => {
       if (!img) {
@@ -99,6 +100,7 @@ export function Component({
     },
     [track, setNewUserBanner, setUserBanner, setError],
   )
+
   const onPressSave = useCallback(async () => {
     track('EditProfile:Save')
     setProcessing(true)

--- a/src/view/com/util/UserAvatar.tsx
+++ b/src/view/com/util/UserAvatar.tsx
@@ -85,12 +85,12 @@ export function UserAvatar({
             return
           }
 
-          const items = await openPicker({
+          const items = await openPicker(store, {
             aspect: [1, 1],
           })
           const item = items[0]
 
-          const croppedImage = await openCropper({
+          const croppedImage = await openCropper(store, {
             mediaType: 'photo',
             cropperCircleOverlay: true,
             height: item.height,

--- a/src/view/com/util/UserAvatar.tsx
+++ b/src/view/com/util/UserAvatar.tsx
@@ -66,6 +66,7 @@ export function UserAvatar({
           if (!(await requestCameraAccessIfNeeded())) {
             return
           }
+
           onSelectNewAvatar?.(
             await openCamera(store, {
               width: 1000,
@@ -83,20 +84,21 @@ export function UserAvatar({
           if (!(await requestPhotoAccessIfNeeded())) {
             return
           }
-          const items = await openPicker(store, {
+
+          const items = await openPicker({
+            aspect: [1, 1],
+          })
+          const item = items[0]
+
+          const croppedImage = await openCropper({
             mediaType: 'photo',
-            multiple: false,
+            cropperCircleOverlay: true,
+            height: item.height,
+            width: item.width,
+            path: item.path,
           })
 
-          onSelectNewAvatar?.(
-            await openCropper(store, {
-              mediaType: 'photo',
-              path: items[0].path,
-              width: 1000,
-              height: 1000,
-              cropperCircleOverlay: true,
-            }),
-          )
+          onSelectNewAvatar?.(croppedImage)
         },
       },
       {

--- a/src/view/com/util/UserBanner.tsx
+++ b/src/view/com/util/UserBanner.tsx
@@ -55,10 +55,10 @@ export function UserBanner({
         if (!(await requestPhotoAccessIfNeeded())) {
           return
         }
-        const items = await openPicker()
+        const items = await openPicker(store)
 
         onSelectNewBanner?.(
-          await openCropper({
+          await openCropper(store, {
             mediaType: 'photo',
             path: items[0].path,
             width: 3000,

--- a/src/view/com/util/UserBanner.tsx
+++ b/src/view/com/util/UserBanner.tsx
@@ -55,12 +55,10 @@ export function UserBanner({
         if (!(await requestPhotoAccessIfNeeded())) {
           return
         }
-        const items = await openPicker(store, {
-          mediaType: 'photo',
-          multiple: false,
-        })
+        const items = await openPicker()
+
         onSelectNewBanner?.(
-          await openCropper(store, {
+          await openCropper({
             mediaType: 'photo',
             path: items[0].path,
             width: 3000,

--- a/yarn.lock
+++ b/yarn.lock
@@ -8731,7 +8731,7 @@ expo-image-manipulator@^11.1.1:
   dependencies:
     expo-image-loader "~4.1.0"
 
-expo-image-picker@~14.1.1:
+expo-image-picker@^14.1.1:
   version "14.1.1"
   resolved "https://registry.yarnpkg.com/expo-image-picker/-/expo-image-picker-14.1.1.tgz#181f1348ba6a43df7b87cee4a601d45c79b7c2d7"
   integrity sha512-SvWtnkLW7jp5Ntvk3lVcRQmhFYja8psmiR7O6P/+7S6f4llt3vaFwb4I3+pUXqJxxpi7BHc2+95qOLf0SFOIag==


### PR DESCRIPTION
### Overview

This PR:

- Replaces `openCropper` from [react-native-image-cropper](https://github.com/ivpusic/react-native-image-crop-picker) with [expo-image-picker](https://docs.expo.dev/versions/latest/sdk/imagepicker/)'s `launchImageLibraryAsync`
- Is intended to [address performance issues](https://github.com/ivpusic/react-native-image-crop-picker/issues/1382) that corroborate a report we have received
- Allows access to the Favorites album