### PR TITLE
test: `detox` needs `tapReturnKey` after `typeText`

### DIFF
--- a/__e2e__/util.ts
+++ b/__e2e__/util.ts
@@ -42,6 +42,7 @@ export async function login(
     await device.takeScreenshot('2- opened service selector')
   }
   await element(by.id('customServerTextInput')).typeText(service)
+  await element(by.id('customServerTextInput')).tapReturnKey()
   await element(by.id('customServerSelectBtn')).tap()
   if (takeScreenshots) {
     await device.takeScreenshot('3- input custom service')


### PR DESCRIPTION
Without this, all `yarn e2e:run` tests get hung on the "input custom service" step when logging in.

Only used one machine to repro (tested all tests pass after this change and all fail before the change), so an additional repro could be useful.