### PR TITLE
fix: expo-image build issue on ios 

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "expo-constants": "~14.2.1",
     "expo-dev-client": "~2.1.1",
     "expo-device": "~5.2.1",
-    "expo-image": "^1.2.1",
+    "expo-image": "^1.2.3",
     "expo-image-manipulator": "^11.1.1",
     "expo-image-picker": "~14.1.1",
     "expo-localization": "~14.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8738,10 +8738,10 @@ expo-image-picker@~14.1.1:
   dependencies:
     expo-image-loader "~4.1.0"
 
-expo-image@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/expo-image/-/expo-image-1.2.1.tgz#3f377cb3142de2107903f4e4f88a7f44785dee18"
-  integrity sha512-pYZFN0ctuIBA+sqUiw70rHQQ04WDyEcF549ObArdj0MNgSUCBJMFmu/jrWDmxOpEMF40lfLVIZKigJT7Bw+GYA==
+expo-image@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/expo-image/-/expo-image-1.2.3.tgz#f3582d725ffb7437f8ce946ad44fe33f0aa0603d"
+  integrity sha512-+Mnx6rcneWSUGfHkUDV3cQ3R4lVwoIDFs/tcXVqnlxyNJdNxpW2cge9pS2Hpj3UDoZVhZPLR8LHS8E9wEaC0NA==
 
 expo-json-utils@~0.5.0:
   version "0.5.1"


### PR DESCRIPTION
Update expo-image to 1.2.3

Issue: https://github.com/expo/expo/pull/22491