### PR TITLE
Fix "Cancel" button always showing on Search tab

### DIFF
--- a/src/view/screens/SearchMobile.tsx
+++ b/src/view/screens/SearchMobile.tsx
@@ -121,7 +121,7 @@ export const SearchScreen = withAuthRequired(
       <TouchableWithoutFeedback onPress={onPress} accessible={false}>
         <View style={[pal.view, styles.container]}>
           <HeaderWithInput
-            isInputFocused={true}
+            isInputFocused={isInputFocused}
             query={query}
             setIsInputFocused={setIsInputFocused}
             onChangeQuery={onChangeQuery}


### PR DESCRIPTION
Looks like `isInputFocused` wasn't being passed to `HeaderWithInput`, this PR fixes and expected functionality is returned :~)

Just to make it clear, the "Cancel" button was always visible on the Search tab, even if there was nothing to cancel. This change fixes that

| Before | After |
|--------|-------|
| ![CleanShot 2023-05-16 at 09 57 22@2x](https://github.com/bluesky-social/social-app/assets/8293444/41e195b7-b1ae-488f-8b51-f89663d3aafd) | ![CleanShot 2023-05-16 at 09 57 34@2x](https://github.com/bluesky-social/social-app/assets/8293444/9effc687-642e-4c02-a9df-f1ad6b723d6a) |