### PR TITLE
Remove surrounding spaces in parentheses.

### DIFF
--- a/src/view/com/modals/InviteCodes.tsx
+++ b/src/view/com/modals/InviteCodes.tsx
@@ -57,7 +57,7 @@ export function Component({}: {}) {
         code works once!
       </Text>
       <Text type="sm" style={[styles.description, pal.textLight]}>
-        ( You'll receive one invite code every two weeks. )
+        (You'll receive one invite code every two weeks.)
       </Text>
       <ScrollView style={[styles.scrollContainer, pal.border]}>
         {store.me.invites.map((invite, i) => (


### PR DESCRIPTION
This removes the surrounding spaces inside the parentheses in the invite code dialogue, which just bugs me. If they bug you too, feel free to merge. Tested on localhost.