### PR TITLE
hide "report button" on own post

### DIFF
--- a/src/view/com/util/forms/DropdownButton.tsx
+++ b/src/view/com/util/forms/DropdownButton.tsx
@@ -209,7 +209,7 @@ export function PostDropdownBtn({
       },
     },
     {sep: true},
-    {
+    !isAuthor && {
       testID: 'postDropdownReportBtn',
       icon: 'circle-exclamation',
       label: 'Report post',


### PR DESCRIPTION
this will hide "report post" option for viewing posts where you are the author (similar to delete post functionality but only shows if you are NOT the author as oppose to if you are) 