### PR TITLE
Close active elements on state change

### DIFF
--- a/src/view/com/lightbox/Lightbox.web.tsx
+++ b/src/view/com/lightbox/Lightbox.web.tsx
@@ -21,6 +21,9 @@ interface Img {
 
 export const Lightbox = observer(function Lightbox() {
   const store = useStores()
+
+  const onClose = useCallback(() => store.shell.closeLightbox(), [store.shell])
+
   if (!store.shell.isLightboxActive) {
     return null
   }
@@ -28,8 +31,6 @@ export const Lightbox = observer(function Lightbox() {
   const activeLightbox = store.shell.activeLightbox
   const initialIndex =
     activeLightbox instanceof models.ImagesLightbox ? activeLightbox.index : 0
-
-  const onClose = () => store.shell.closeLightbox()
 
   let imgs: Img[] | undefined
   if (activeLightbox instanceof models.ProfileImageLightbox) {

--- a/src/view/shell/index.web.tsx
+++ b/src/view/shell/index.web.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, {useEffect} from 'react'
 import {observer} from 'mobx-react-lite'
 import {View, StyleSheet, TouchableOpacity} from 'react-native'
 import {useStores} from 'state/index'
@@ -14,10 +14,20 @@ import {RoutesContainer, FlatNavigator} from '../../Navigation'
 import {DrawerContent} from './Drawer'
 import {useWebMediaQueries} from '../../lib/hooks/useWebMediaQueries'
 import {BottomBarWeb} from './bottom-bar/BottomBarWeb'
+import {useNavigation} from '@react-navigation/native'
+import {NavigationProp} from 'lib/routes/types'
 
 const ShellInner = observer(() => {
   const store = useStores()
   const {isDesktop} = useWebMediaQueries()
+
+  const navigator = useNavigation<NavigationProp>()
+
+  useEffect(() => {
+    navigator.addListener('state', () => {
+      store.shell.closeAnyActiveElement()
+    })
+  }, [navigator, store.shell])
 
   return (
     <>


### PR DESCRIPTION
### Overview

This PR:

- Closes modals / lightboxes when a user swipes back in browser

Known issues:

- [`beforeRemove` event not fired on browser back button](https://github.com/react-navigation/react-navigation/issues/9031)
- Modals and lightboxes precede introduction of `react-navigation` into the codebase, hence going back from a modal does not return the user to what is, by their definition, the previous screen. [This is likely the desired approach moving forward](https://reactnavigation.org/docs/modal/#creating-a-stack-with-modal-screens) but the changes in this PR are sufficient for now.