### PR TITLE
fix: Make BlurView blur things in Safari

### DIFF
--- a/src/view/com/util/BlurView.web.tsx
+++ b/src/view/com/util/BlurView.web.tsx
@@ -14,7 +14,8 @@ export const BlurView = ({
   ...props
 }: React.PropsWithChildren<BlurViewProps>) => {
   // @ts-ignore using an RNW-specific attribute here -prf
-  style = addStyle(style, {backdropFilter: `blur(${blurAmount || 10}px`})
+  let blur = `blur(${blurAmount || 10}px`
+  style = addStyle(style, {backdropFilter: blur, WebkitBackdropFilter: blur})
   if (blurType === 'dark') {
     style = addStyle(style, styles.dark)
   } else {


### PR DESCRIPTION
Fixes https://staging.bsky.app/profile/favreau.bsky.social/post/3jvujbuvwnb2j by adding a webkit vendor prefixed version of `backdrop-filter` to BlurView.web.tsx.

Previously in Safari: 
<img src="https://github.com/bluesky-social/social-app/assets/921683/c18ae792-fb8d-4517-ad98-39b643b64fa0" width="400"/>

Fix in Safari: 
<img src="https://github.com/bluesky-social/social-app/assets/921683/6ea831fa-a691-40e0-bae3-5eefd1f0d834" width="400" /> 
