### PR TITLE
Added contextual image to AltImage

### DIFF
--- a/src/view/com/modals/AltImage.tsx
+++ b/src/view/com/modals/AltImage.tsx
@@ -1,17 +1,17 @@
-import React, { useCallback, useState, useEffect } from 'react'
-import { StyleSheet, TextInput, TouchableOpacity, View } from 'react-native'
-import { usePalette } from 'lib/hooks/usePalette'
-import { gradients, s } from 'lib/styles'
-import { enforceLen } from 'lib/strings/helpers'
-import { MAX_ALT_TEXT } from 'lib/constants'
-import { useTheme } from 'lib/ThemeContext'
-import { Text } from '../util/text/Text'
-import { Image } from 'expo-image'
+import React, {useCallback, useState, useEffect} from 'react'
+import {StyleSheet, TextInput, TouchableOpacity, View} from 'react-native'
+import {usePalette} from 'lib/hooks/usePalette'
+import {gradients, s} from 'lib/styles'
+import {enforceLen} from 'lib/strings/helpers'
+import {MAX_ALT_TEXT} from 'lib/constants'
+import {useTheme} from 'lib/ThemeContext'
+import {Text} from '../util/text/Text'
+import {Image} from 'expo-image'
 import LinearGradient from 'react-native-linear-gradient'
-import { useStores } from 'state/index'
-import { isDesktopWeb } from 'platform/detection'
-import { ImageModel } from 'state/models/media/image'
-import { ImageStyle, Keyboard } from 'react-native'
+import {useStores} from 'state/index'
+import {isDesktopWeb} from 'platform/detection'
+import {ImageModel} from 'state/models/media/image'
+import {ImageStyle, Keyboard} from 'react-native'
 
 export const snapPoints = ['fullscreen']
 
@@ -19,7 +19,7 @@ interface Props {
   image: ImageModel
 }
 
-export function Component({ image }: Props) {
+export function Component({image}: Props) {
   const pal = usePalette('default')
   const store = useStores()
   const theme = useTheme()
@@ -97,8 +97,8 @@ export function Component({ image }: Props) {
           accessibilityRole="button">
           <LinearGradient
             colors={[gradients.blueLight.start, gradients.blueLight.end]}
-            start={{ x: 0, y: 0 }}
-            end={{ x: 1, y: 1 }}
+            start={{x: 0, y: 0}}
+            end={{x: 1, y: 1}}
             style={[styles.button]}>
             <Text type="button-lg" style={[s.white, s.bold]}>
               Save

--- a/src/view/com/modals/AltImage.tsx
+++ b/src/view/com/modals/AltImage.tsx
@@ -1,15 +1,17 @@
-import React, {useCallback, useState} from 'react'
-import {StyleSheet, TextInput, TouchableOpacity, View} from 'react-native'
-import {usePalette} from 'lib/hooks/usePalette'
-import {gradients, s} from 'lib/styles'
-import {enforceLen} from 'lib/strings/helpers'
-import {MAX_ALT_TEXT} from 'lib/constants'
-import {useTheme} from 'lib/ThemeContext'
-import {Text} from '../util/text/Text'
+import React, { useCallback, useState, useEffect } from 'react'
+import { StyleSheet, TextInput, TouchableOpacity, View } from 'react-native'
+import { usePalette } from 'lib/hooks/usePalette'
+import { gradients, s } from 'lib/styles'
+import { enforceLen } from 'lib/strings/helpers'
+import { MAX_ALT_TEXT } from 'lib/constants'
+import { useTheme } from 'lib/ThemeContext'
+import { Text } from '../util/text/Text'
+import { Image } from 'expo-image'
 import LinearGradient from 'react-native-linear-gradient'
-import {useStores} from 'state/index'
-import {isDesktopWeb} from 'platform/detection'
-import {ImageModel} from 'state/models/media/image'
+import { useStores } from 'state/index'
+import { isDesktopWeb } from 'platform/detection'
+import { ImageModel } from 'state/models/media/image'
+import { ImageStyle, Keyboard } from 'react-native'
 
 export const snapPoints = ['fullscreen']
 
@@ -17,11 +19,37 @@ interface Props {
   image: ImageModel
 }
 
-export function Component({image}: Props) {
+export function Component({ image }: Props) {
   const pal = usePalette('default')
   const store = useStores()
   const theme = useTheme()
   const [altText, setAltText] = useState(image.altText)
+  const [keyboardVisible, setKeyboardVisible] = useState(false)
+
+  useEffect(() => {
+    const keyboardActiveListener = Keyboard.addListener(
+      'keyboardDidShow',
+      () => {
+        setKeyboardVisible(true) // or some other action
+      },
+    )
+    const keyboardInactiveListener = Keyboard.addListener(
+      'keyboardDidHide',
+      () => {
+        setKeyboardVisible(false) // or some other action
+      },
+    )
+    return () => {
+      keyboardInactiveListener.remove()
+      keyboardActiveListener.remove()
+    }
+  }, [])
+
+  const getImageSize = function () {
+    return {
+      maxHeight: keyboardVisible ? 100 : '100%',
+    }
+  }
 
   const onPressSave = useCallback(() => {
     image.setAltText(altText)
@@ -38,6 +66,17 @@ export function Component({image}: Props) {
       style={[pal.view, styles.container, s.flex1]}
       nativeID="imageAltText">
       <Text style={[styles.title, pal.text]}>Add alt text</Text>
+      {image.compressed !== undefined && (
+        <Image
+          testID="selectedPhotoImage"
+          style={[styles.image, getImageSize()] as ImageStyle}
+          source={{
+            uri: image.compressed.path,
+          }}
+          accessible={true}
+          accessibilityIgnoresInvertColors
+        />
+      )}
       <TextInput
         testID="altTextImageInput"
         style={[styles.textArea, pal.border, pal.text]}
@@ -58,8 +97,8 @@ export function Component({image}: Props) {
           accessibilityRole="button">
           <LinearGradient
             colors={[gradients.blueLight.start, gradients.blueLight.end]}
-            start={{x: 0, y: 0}}
-            end={{x: 1, y: 1}}
+            start={{ x: 0, y: 0 }}
+            end={{ x: 1, y: 1 }}
             style={[styles.button]}>
             <Text type="button-lg" style={[s.white, s.bold]}>
               Save
@@ -116,5 +155,8 @@ const styles = StyleSheet.create({
   },
   buttonControls: {
     gap: 8,
+  },
+  image: {
+    flex: 1,
   },
 })


### PR DESCRIPTION
Adds a feature that allows users to see the image they are adding alt text to as described in #658 

By default the image in the Alt Text modal will be shown fully and then it's height will be collapsed so the user can partially see the image, text box, and keyboard, along with the CTAs.

<img width="348" alt="image" src="https://github.com/bluesky-social/social-app/assets/4733032/2715dc45-4140-418a-b1dd-5c0b43580561">
<img width="340" alt="image" src="https://github.com/bluesky-social/social-app/assets/4733032/4904b77e-e6d7-43da-a936-9a62950dae3e">
