### PR TITLE
fix dir="auto" issue in RichText component

### DIFF
--- a/src/view/com/util/text/RichText.tsx
+++ b/src/view/com/util/text/RichText.tsx
@@ -3,7 +3,7 @@ import {TextStyle, StyleProp} from 'react-native'
 import {RichText as RichTextObj, AppBskyRichtextFacet} from '@atproto/api'
 import {TextLink} from '../Link'
 import {Text} from './Text'
-import {lh} from 'lib/styles'
+import {lh, s} from 'lib/styles'
 import {toShortUrl} from 'lib/strings/url-helpers'
 import {useTheme, TypographyVariant} from 'lib/ThemeContext'
 import {usePalette} from 'lib/hooks/usePalette'
@@ -51,7 +51,7 @@ export function RichText({
       <Text
         testID={testID}
         type={type}
-        style={[style, pal.text, lineHeightStyle]}
+        style={[style, pal.text, s.flex1, lineHeightStyle]}
         // @ts-ignore web only -prf
         dataSet={WORD_WRAP}>
         {text}

--- a/src/view/shell/desktop/RightNav.tsx
+++ b/src/view/shell/desktop/RightNav.tsx
@@ -18,6 +18,7 @@ export const DesktopRightNav = observer(function DesktopRightNav() {
   const store = useStores()
   const pal = usePalette('default')
   const mode = useColorSchemeStyle('Light', 'Dark')
+  const otherMode = mode === 'Dark' ? 'Light' : 'Dark'
 
   const onDarkmodePress = React.useCallback(() => {
     store.shell.setDarkMode(!store.shell.darkMode)
@@ -74,7 +75,7 @@ export const DesktopRightNav = observer(function DesktopRightNav() {
             <MoonIcon size={18} style={pal.textLight} />
           </View>
           <Text type="sm" style={pal.textLight}>
-            {mode} mode
+            {otherMode} mode
           </Text>
         </TouchableOpacity>
       </View>


### PR DESCRIPTION
There's a problem with dir="auto" that it doesn't work for RTL languages, by adding flex: 1 to the text component it will be fixed.

the issue:

![image](https://github.com/bluesky-social/social-app/assets/2494766/f51e7e7a-36b9-4c36-a5f2-a6d4487299ef)
![image](https://github.com/bluesky-social/social-app/assets/2494766/9bc09e01-cb43-4598-b7d0-9f0ef256292d)

fix: 

<img width="592" alt="image" src="https://github.com/bluesky-social/social-app/assets/2494766/c354d31f-9114-4a44-9201-fdd4485a7d0d">
