### PR TITLE
feat: add basic visual feedback on Button interactions

### DIFF
--- a/src/view/com/util/forms/Button.tsx
+++ b/src/view/com/util/forms/Button.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, {useState} from 'react'
 import {
   GestureResponderEvent,
   StyleProp,
@@ -52,6 +52,7 @@ export function Button({
   onAccessibilityEscape?: () => void
 }>) {
   const theme = useTheme()
+  const [opacity, setOpacity] = useState(1)
   const typeOuterStyle = choose<ViewStyle, Record<ButtonType, ViewStyle>>(
     type,
     {
@@ -138,7 +139,11 @@ export function Button({
   )
   return (
     <Pressable
-      style={[typeOuterStyle, styles.outer, style]}
+      style={[typeOuterStyle, styles.outer, {opacity}, style]}
+      onPressIn={() => setOpacity(0.6)}
+      onPressOut={() => setOpacity(1)}
+      onHoverIn={() => setOpacity(0.8)}
+      onHoverOut={() => setOpacity(1)}
       onPress={onPressWrapped}
       testID={testID}
       accessibilityRole="button"


### PR DESCRIPTION
# Why

While using BSky app, the one thing which lead to triggering multiple follows and unfollows in a row for me was lack of visual indication for the Button interactions (since the actions could take a second or two, I often thought that I have missed the button).

# How

This PR adds the very basic visual interaction feedback for user, when pressing or hovering the Buttons. Opacity value can be tweak as you wish. Definitely it's not a robust and ideal solution, but it should be a good beginning for UX improvements when it comes to the intractable components.

# Preview

https://github.com/bluesky-social/social-app/assets/719641/876a678e-0400-4777-8a04-198a5c6a1cb3

