### PR TITLE
Adjust the positioning of Right-To-Left language posts to ensure proper alignment

### DIFF
--- a/src/view/com/util/text/RichText.tsx
+++ b/src/view/com/util/text/RichText.tsx
@@ -3,7 +3,7 @@ import {TextStyle, StyleProp} from 'react-native'
 import {RichText as RichTextObj, AppBskyRichtextFacet} from '@atproto/api'
 import {TextLink} from '../Link'
 import {Text} from './Text'
-import {lh} from 'lib/styles'
+import {lh, s} from 'lib/styles'
 import {toShortUrl} from 'lib/strings/url-helpers'
 import {useTheme, TypographyVariant} from 'lib/ThemeContext'
 import {usePalette} from 'lib/hooks/usePalette'
@@ -41,8 +41,11 @@ export function RichText({
         lineHeight: 30,
       }
       return (
-        // @ts-ignore web only -prf
-        <Text testID={testID} style={[style, pal.text]} dataSet={WORD_WRAP}>
+        <Text
+          testID={testID}
+          style={[style, pal.text, s.w100pct]}
+          // @ts-ignore web only -prf
+          dataSet={WORD_WRAP}>
           {text}
         </Text>
       )
@@ -51,7 +54,7 @@ export function RichText({
       <Text
         testID={testID}
         type={type}
-        style={[style, pal.text, lineHeightStyle]}
+        style={[style, pal.text, lineHeightStyle, s.w100pct]}
         // @ts-ignore web only -prf
         dataSet={WORD_WRAP}>
         {text}
@@ -100,7 +103,7 @@ export function RichText({
     <Text
       testID={testID}
       type={type}
-      style={[style, pal.text, lineHeightStyle]}
+      style={[style, pal.text, lineHeightStyle, s.w100pct]}
       numberOfLines={numberOfLines}
       // @ts-ignore web only -prf
       dataSet={WORD_WRAP}>


### PR DESCRIPTION
For right-to-left languages, when a post's text doesn't fill an entire line, it appears on the left side because the width isn't set to 100%, which is not very appealing. However, this issue can be resolved by setting the width to 100%.

Before:
<img width="593" alt="Screenshot 1402-02-27 at 16 35 27" src="https://github.com/bluesky-social/social-app/assets/66924476/0d7a80ac-388e-4f69-9bc1-aa028e7793bf">

After:
<img width="593" alt="Screenshot 1402-02-27 at 16 35 42" src="https://github.com/bluesky-social/social-app/assets/66924476/7a0ee2d5-b664-45fc-8e79-b0876eb89e8a">
