### PR TITLE
feat: add basic visual feedback on Button interactions

### DIFF
--- a/src/view/com/util/forms/Button.tsx
+++ b/src/view/com/util/forms/Button.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react'
+import React from 'react'
 import {
   GestureResponderEvent,
   StyleProp,
@@ -52,7 +52,6 @@ export function Button({
   onAccessibilityEscape?: () => void
 }>) {
   const theme = useTheme()
-  const [opacity, setOpacity] = useState(1)
   const typeOuterStyle = choose<ViewStyle, Record<ButtonType, ViewStyle>>(
     type,
     {
@@ -129,6 +128,7 @@ export function Button({
       },
     },
   )
+
   const onPressWrapped = React.useCallback(
     (event: Event) => {
       event.stopPropagation()
@@ -137,13 +137,23 @@ export function Button({
     },
     [onPress],
   )
+
+  const getStyle = React.useCallback(
+    state => {
+      const arr = [typeOuterStyle, styles.outer, style]
+      if (state.pressed) {
+        arr.push({opacity: 0.6})
+      } else if (state.hovered) {
+        arr.push({opacity: 0.8})
+      }
+      return arr
+    },
+    [typeOuterStyle, style],
+  )
+
   return (
     <Pressable
-      style={[typeOuterStyle, styles.outer, {opacity}, style]}
-      onPressIn={() => setOpacity(0.6)}
-      onPressOut={() => setOpacity(1)}
-      onHoverIn={() => setOpacity(0.8)}
-      onHoverOut={() => setOpacity(1)}
+      style={getStyle}
       onPress={onPressWrapped}
       testID={testID}
       accessibilityRole="button"

--- a/src/view/shell/desktop/RightNav.tsx
+++ b/src/view/shell/desktop/RightNav.tsx
@@ -18,7 +18,7 @@ export const DesktopRightNav = observer(function DesktopRightNav() {
   const store = useStores()
   const pal = usePalette('default')
   const mode = useColorSchemeStyle('Light', 'Dark')
-  const otherMode = mode === 'Dark' ? 'Light' : 'Dark';
+  const otherMode = mode === 'Dark' ? 'Light' : 'Dark'
 
   const onDarkmodePress = React.useCallback(() => {
     store.shell.setDarkMode(!store.shell.darkMode)
@@ -72,12 +72,11 @@ export const DesktopRightNav = observer(function DesktopRightNav() {
               : 'Sets display to dark mode'
           }>
           <View style={[pal.viewLight, styles.darkModeToggleIcon]}>
-            {
-              mode === 'Dark' ?
+            {mode === 'Dark' ? (
               <SunIcon size={18} style={pal.textLight} />
-              :
+            ) : (
               <MoonIcon size={18} style={pal.textLight} />
-            }
+            )}
           </View>
           <Text type="sm" style={pal.textLight}>
             {otherMode} mode


### PR DESCRIPTION
Supercedes  #701

Adds visual feedback to the hover & press state of buttons. This PR uses a single callback instead of a state hook which should be a little more efficient.