### PR TITLE
Make terms and notices dates less ambiguous.

### DIFF
--- a/src/locale/en/community-guidelines.tsx
+++ b/src/locale/en/community-guidelines.tsx
@@ -4,7 +4,7 @@ import {H3, H4, P, UL, LI, A, EM, OL} from 'view/com/util/Html'
 export default function () {
   return (
     <>
-      <H4>Last Updated:&nbsp;2023/04/06</H4>
+      <H4>Last Updated:&nbsp;April 6, 2023</H4>
       <P>
         The Bluesky app is built on a decentralized social networking protocol,
         the AT Protocol (atproto). Atproto is an open protocol that supports

--- a/src/locale/en/copyright-policy.tsx
+++ b/src/locale/en/copyright-policy.tsx
@@ -4,7 +4,7 @@ import {H3, H4, P, UL, LI, A} from 'view/com/util/Html'
 export default function () {
   return (
     <>
-      <H4>Last Updated:&nbsp;2023/04/06</H4>
+      <H4>Last Updated:&nbsp;April 6, 2023</H4>
       <P>Notification of Copyright Infringement</P>
       <P>
         Bluesky, PBLLC d.b.a. Bluesky (&ldquo;Bluesky&rdquo;) respects the

--- a/src/locale/en/privacy-policy.tsx
+++ b/src/locale/en/privacy-policy.tsx
@@ -4,7 +4,7 @@ import {H2, H4, P, UL, LI, A} from 'view/com/util/Html'
 export default function () {
   return (
     <>
-      <H4>Last Updated:&nbsp;2023/02/02</H4>
+      <H4>Last Updated:&nbsp;February 2, 2023</H4>
       <P>
         This Privacy Policy is designed to help you understand how Bluesky,
         PBLLC d.b.a. Bluesky (“Bluesky,” &nbsp;“we,” “us,” or&nbsp;“our”)

--- a/src/locale/en/terms-of-service.tsx
+++ b/src/locale/en/terms-of-service.tsx
@@ -4,7 +4,7 @@ import {H4, P, OL, LI, A, STRONG, EM, UL} from 'view/com/util/Html'
 export default function () {
   return (
     <>
-      <H4>Last Updated:&nbsp;2023/04/06</H4>
+      <H4>Last Updated:&nbsp;April 6, 2023</H4>
       <P>
         Welcome to the Bluesky, PBLLC d.b.a. Bluesky (&ldquo;Bluesky&rdquo;,
         &ldquo;we&rdquo;, or &ldquo;us&rdquo;) website located at{' '}


### PR DESCRIPTION
The community guidelines, copyright policy, privacy policy and terms of service currently uses the YYYY/MM/DD format for their "last updated" note. To avoid ambiguity, I think a full "Month DD, YYYY" format is better. This updates all four in line with that suggestion.