### PR TITLE
feat(Login): allow submitting on password field

### DIFF
--- a/src/view/com/auth/login/Login.tsx
+++ b/src/view/com/auth/login/Login.tsx
@@ -420,6 +420,7 @@ const LoginForm = ({
             textContentType="oneTimeCode"
             value={password}
             onChangeText={setPassword}
+            onSubmitEditing={onPressNext}
             editable={!isProcessing}
             accessibilityLabel="Password"
             accessibilityHint={


### PR DESCRIPTION
# Why

Currently, logging in requires mouse interaction on web and an additional finger movement on mobile.

# How

This process can be improved by adding `onSubmitEditing` prop to the password field, which on web allow to simulate form submit event when pressing <kbd>Enter</kbd> on the password field and on mobile pressing <kbd>return</kbd> key will attempt to perform login.

# Preview

https://github.com/bluesky-social/social-app/assets/719641/fa4982c5-3cbd-46e3-94ab-da4186388408

