### PR TITLE
Use no-cors mode for fetching link-meta

### DIFF
--- a/src/lib/link-meta/link-meta.ts
+++ b/src/lib/link-meta/link-meta.ts
@@ -55,6 +55,7 @@ export async function getLinkMeta(
     const controller = new AbortController()
     const to = setTimeout(() => controller.abort(), timeout || 5e3)
     const httpRes = await fetch(url, {
+      mode: 'no-cors',
       headers: {accept: 'text/html'},
       signal: controller.signal,
     })


### PR DESCRIPTION
I don't have the full build pipeline installed to test this, but this should fix the "Failed to fetch link" errors currently experienced when embedding most links in the web app.