### PR TITLE
Use non-pipe translation link

### DIFF
--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -99,7 +99,11 @@ export const PostThreadItem = observer(function PostThreadItem({
 
   const onOpenTranslate = React.useCallback(() => {
     Linking.openURL(
-      encodeURI(`https://translate.google.com/#auto|en|${record?.text || ''}`),
+      encodeURI(
+        `https://translate.google.com/?sl=auto&tl=en&text=${
+          record?.text || ''
+        }`,
+      ),
     )
   }, [record])
 

--- a/src/view/com/post/Post.tsx
+++ b/src/view/com/post/Post.tsx
@@ -170,7 +170,9 @@ const PostLoaded = observer(
     const onOpenTranslate = React.useCallback(() => {
       Linking.openURL(
         encodeURI(
-          `https://translate.google.com/#auto|en|${record?.text || ''}`,
+          `https://translate.google.com/?sl=auto&tl=en&text=${
+            record?.text || ''
+          }`,
         ),
       )
     }, [record])

--- a/src/view/com/posts/FeedItem.tsx
+++ b/src/view/com/posts/FeedItem.tsx
@@ -99,7 +99,11 @@ export const FeedItem = observer(function ({
 
   const onOpenTranslate = React.useCallback(() => {
     Linking.openURL(
-      encodeURI(`https://translate.google.com/#auto|en|${record?.text || ''}`),
+      encodeURI(
+        `https://translate.google.com/?sl=auto&tl=en&text=${
+          record?.text || ''
+        }`,
+      ),
     )
   }, [record])
 


### PR DESCRIPTION
### Overview

This PR:

- Updates the Google translate link so that pipe operators don't cause text to get dropped

Thank you to @mozzius for catching this!

Before:

![translation-before](https://github.com/bluesky-social/social-app/assets/12389148/2eb82786-1253-4f11-b6c6-a8660ce7c033)

After:

![translation-after](https://github.com/bluesky-social/social-app/assets/12389148/2af3f727-6f83-4e48-a783-52d72a8d53d9)
