### PR TITLE
Adding a link to the top of the feed once the end is reached

### DIFF
--- a/src/view/screens/Profile.tsx
+++ b/src/view/screens/Profile.tsx
@@ -27,6 +27,7 @@ import {useAnalytics} from 'lib/analytics'
 import {ComposeIcon2} from 'lib/icons'
 import {useSetTitle} from 'lib/hooks/useSetTitle'
 import {combinedDisplayName} from 'lib/strings/display-names'
+import { Link } from 'view/com/util/Link'
 
 type Props = NativeStackScreenProps<CommonNavigatorParams, 'Profile'>
 export const ProfileScreen = withAuthRequired(
@@ -144,7 +145,11 @@ export const ProfileScreen = withAuthRequired(
           }
         } else {
           if (item === ProfileUiModel.END_ITEM) {
-            return <Text style={styles.endItem}>- end of feed -</Text>
+            return(
+              <Link href={`/profile/${store.me.handle}`} style={styles.endItem}>
+                End of feed - Back to top
+              </Link>
+            ) 
           } else if (item === ProfileUiModel.LOADING_ITEM) {
             return <PostFeedLoadingPlaceholder />
           } else if (item._reactKey === '__error__') {


### PR DESCRIPTION
I realize there was a disclaimer to not PR features. I think this is helpful, and it would be an honor to get a little code into BlueSky.

![End of feed link](https://github.com/bluesky-social/social-app/assets/79339849/6bd1a0f9-6e03-4b5f-a05c-d26b216e7a39)
