### PR TITLE
definitely broken fix for rendering of old threads

### DIFF
--- a/src/lib/api/feed-manip.ts
+++ b/src/lib/api/feed-manip.ts
@@ -25,7 +25,7 @@ export class FeedViewPostsSlice {
     if (this.items[0].reason?.indexedAt) {
       return this.items[0].reason.indexedAt as string
     }
-    return this.items[0].post.indexedAt
+    return this.items[this.items.length-1].post.indexedAt // ordering should depend on the most recent item in a slice
   }
 
   get isThread() {
@@ -35,10 +35,6 @@ export class FeedViewPostsSlice {
         item => item.post.author.did === this.items[0].post.author.did,
       )
     )
-  }
-
-  get isFullThread() {
-    return this.isThread && !this.items[0].reply
   }
 
   get rootItem() {
@@ -183,7 +179,14 @@ export class FeedTuner {
   ): FeedViewPostsSlice[] {
     // remove any replies without at least 2 likes
     for (let i = slices.length - 1; i >= 0; i--) {
-      if (slices[i].isFullThread || !slices[i].isReply) {
+      // I can't figure out how to make this work when there's a *single* reply
+      // to an older post in a thread. It's not "a thread" because it doesn't
+      // have more than one item in the slice. But it is a reply. I'm not sure
+      // how to reliably determine if something is a thread.
+      //
+      // isFullThread was always problematic, because frequently you don't have
+      // a root on an old thread
+      if (slices[i].isThread || !slices[i].isReply) { // leave threads and root posts
         continue
       }
 

--- a/src/state/models/feeds/posts.ts
+++ b/src/state/models/feeds/posts.ts
@@ -397,6 +397,7 @@ export class PostsFeedModel {
       ]
     }
     if (this.feedType === 'home') {
+      // removing likedRepliesOnly will definitely show threads, but obviously it'll show unliked replies also
       return [FeedTuner.dedupReposts, FeedTuner.likedRepliesOnly]
     }
     return []


### PR DESCRIPTION
This is mostly a discussion of #746 that doesn't actually fully fix it, because I couldn't quite figure out how to fully fix this.

But: replies to old threads are getting filtered out for two reasons that I can tell:

1. `likedRepliesOnly` is actually enforcing two likes in order to display the replies, because `isThread` isn't working correctly, and
2. sorting by the root's timestamp (instead of the most recent post in a thread) sends the reply waaay down the timeline, never to be seen again.

Note that the replies are in the body of `getTimeline`, which I've pasted at the bottom (look for cid `bafyreieb2oy7sr6cld4lcoq5m5tnv5cym5sjinf776qalk6fwam3shs3fy` for the "six" post, for example). This means this is a client-side issue.

I've annotated the code a bit, and for sure it will fix _this_ issue if you change the sort order AND remove the `likedRepliesOnly` tuner from the home feed. I'm just not sure if that's a good idea, and I couldn't figure out how to leave `likedRepliesOnly` but properly detect self-replies.

Keep in mind: you may have only a single self-reply available, because it may be a reply to a really old thread, and the other replies don't show up in the body of `getTimeline`.

```json
{
    "feed": [
        {
            "post": {
                "uri": "at://did:plc:2zwqewi6t7coiohtmpfzz2wd/app.bsky.feed.post/3jw2d4ctcvt2e",
                "cid": "bafyreibo4rtqwlay542wl27egl45r32s7zsf4vcrssjjpizkvthpticptm",
                "author": {
                    "did": "did:plc:2zwqewi6t7coiohtmpfzz2wd",
                    "handle": "brandon.dimcheff.com",
                    "displayName": "brandon",
                    "avatar": "https://cdn.bsky.social/imgproxy/mAn-pSrjPdcm1edwNwTZEoZHsCa2_wYIS0_VsQhe130/rs:fill:1000:1000:1:0/plain/bafkreicelgx2oyillfhgclomvwquqjowdiqe5pod47xl3cam3mzezlniym@jpeg",
                    "viewer": {
                        "muted": false,
                        "blockedBy": false,
                        "following": "at://did:plc:mt43vjwo3f7ebvkjjxsoao7h/app.bsky.graph.follow/3jvsxzglfmk2u",
                        "followedBy": "at://did:plc:2zwqewi6t7coiohtmpfzz2wd/app.bsky.graph.follow/3juzqz7uuf42j"
                    },
                    "labels": []
                },
                "record": {
                    "text": "ok FINE don’t ignore",
                    "$type": "app.bsky.feed.post",
                    "reply": {
                        "root": {
                            "cid": "bafyreife2v5spmvampiyco5lrpetxizhdjoxhu6yismduz3x44tqvqkpze",
                            "uri": "at://did:plc:2zwqewi6t7coiohtmpfzz2wd/app.bsky.feed.post/3jw2cr6jgkk27"
                        },
                        "parent": {
                            "cid": "bafyreie26jh4n55paewbwrc5gbtw4lo6k76pvsxuqkvqvhbifsuusv7nlm",
                            "uri": "at://did:plc:mysrkgyhbquq63swfobjsv3y/app.bsky.feed.post/3jw2cwoah3c27"
                        }
                    },
                    "createdAt": "2023-05-19T01:59:13.727Z"
                },
                "replyCount": 0,
                "repostCount": 0,
                "likeCount": 0,
                "indexedAt": "2023-05-19T01:59:13.772Z",
                "viewer": {},
                "labels": []
            },
            "reply": {
                "root": {
                    "uri": "at://did:plc:2zwqewi6t7coiohtmpfzz2wd/app.bsky.feed.post/3jw2cr6jgkk27",
                    "cid": "bafyreife2v5spmvampiyco5lrpetxizhdjoxhu6yismduz3x44tqvqkpze",
                    "author": {
                        "did": "did:plc:2zwqewi6t7coiohtmpfzz2wd",
                        "handle": "brandon.dimcheff.com",
                        "displayName": "brandon",
                        "avatar": "https://cdn.bsky.social/imgproxy/mAn-pSrjPdcm1edwNwTZEoZHsCa2_wYIS0_VsQhe130/rs:fill:1000:1000:1:0/plain/bafkreicelgx2oyillfhgclomvwquqjowdiqe5pod47xl3cam3mzezlniym@jpeg",
                        "viewer": {
                            "muted": false,
                            "blockedBy": false,
                            "following": "at://did:plc:mt43vjwo3f7ebvkjjxsoao7h/app.bsky.graph.follow/3jvsxzglfmk2u",
                            "followedBy": "at://did:plc:2zwqewi6t7coiohtmpfzz2wd/app.bsky.graph.follow/3juzqz7uuf42j"
                        },
                        "labels": []
                    },
                    "record": {
                        "text": "test please ignore",
                        "$type": "app.bsky.feed.post",
                        "createdAt": "2023-05-19T01:52:59.985Z"
                    },
                    "replyCount": 1,
                    "repostCount": 0,
                    "likeCount": 3,
                    "indexedAt": "2023-05-19T01:53:00.187Z",
                    "viewer": {},
                    "labels": []
                },
                "parent": {
                    "uri": "at://did:plc:mysrkgyhbquq63swfobjsv3y/app.bsky.feed.post/3jw2cwoah3c27",
                    "cid": "bafyreie26jh4n55paewbwrc5gbtw4lo6k76pvsxuqkvqvhbifsuusv7nlm",
                    "author": {
                        "did": "did:plc:mysrkgyhbquq63swfobjsv3y",
                        "handle": "allen.baranov.will-totally.over-th.ink",
                        "displayName": "Allen Baranov ✅",
                        "avatar": "https://cdn.bsky.social/imgproxy/WUyuxMTSszTK_lJIpWHIq5hdw_ty4nvufNB_RJkWPfk/rs:fill:1000:1000:1:0/plain/bafkreie2jtge32sntijqm4elu7sfrkys7c5k35phyawybwyg4fexvawmqa@jpeg",
                        "viewer": {
                            "muted": false,
                            "blockedBy": false
                        },
                        "labels": []
                    },
                    "record": {
                        "text": "\"Don't think of an elephant\"",
                        "$type": "app.bsky.feed.post",
                        "reply": {
                            "root": {
                                "cid": "bafyreife2v5spmvampiyco5lrpetxizhdjoxhu6yismduz3x44tqvqkpze",
                                "uri": "at://did:plc:2zwqewi6t7coiohtmpfzz2wd/app.bsky.feed.post/3jw2cr6jgkk27"
                            },
                            "parent": {
                                "cid": "bafyreicumg5a3b3i4dqgwr3kphr5mcidymu5avkxleqxiwi7773ip7wz4e",
                                "uri": "at://did:plc:nwezu57qz7slxdmtugdn5dx3/app.bsky.feed.post/3jw2ctfp7a227"
                            }
                        },
                        "createdAt": "2023-05-19T01:56:04.430Z"
                    },
                    "replyCount": 1,
                    "repostCount": 0,
                    "likeCount": 1,
                    "indexedAt": "2023-05-19T01:56:04.431Z",
                    "viewer": {},
                    "labels": []
                }
            }
        },
        {
            "post": {
                "uri": "at://did:plc:2zwqewi6t7coiohtmpfzz2wd/app.bsky.feed.post/3jw2cr6jgkk27",
                "cid": "bafyreife2v5spmvampiyco5lrpetxizhdjoxhu6yismduz3x44tqvqkpze",
                "author": {
                    "did": "did:plc:2zwqewi6t7coiohtmpfzz2wd",
                    "handle": "brandon.dimcheff.com",
                    "displayName": "brandon",
                    "avatar": "https://cdn.bsky.social/imgproxy/mAn-pSrjPdcm1edwNwTZEoZHsCa2_wYIS0_VsQhe130/rs:fill:1000:1000:1:0/plain/bafkreicelgx2oyillfhgclomvwquqjowdiqe5pod47xl3cam3mzezlniym@jpeg",
                    "viewer": {
                        "muted": false,
                        "blockedBy": false,
                        "following": "at://did:plc:mt43vjwo3f7ebvkjjxsoao7h/app.bsky.graph.follow/3jvsxzglfmk2u",
                        "followedBy": "at://did:plc:2zwqewi6t7coiohtmpfzz2wd/app.bsky.graph.follow/3juzqz7uuf42j"
                    },
                    "labels": []
                },
                "record": {
                    "text": "test please ignore",
                    "$type": "app.bsky.feed.post",
                    "createdAt": "2023-05-19T01:52:59.985Z"
                },
                "replyCount": 1,
                "repostCount": 0,
                "likeCount": 3,
                "indexedAt": "2023-05-19T01:53:00.187Z",
                "viewer": {},
                "labels": []
            }
        },
        {
            "post": {
                "uri": "at://did:plc:mt43vjwo3f7ebvkjjxsoao7h/app.bsky.feed.post/3jw2cn7h6gs2c",
                "cid": "bafyreieb2oy7sr6cld4lcoq5m5tnv5cym5sjinf776qalk6fwam3shs3fy",
                "author": {
                    "did": "did:plc:mt43vjwo3f7ebvkjjxsoao7h",
                    "handle": "brandon-test.bsky.social",
                    "viewer": {
                        "muted": false,
                        "blockedBy": false
                    },
                    "labels": []
                },
                "record": {
                    "text": "six",
                    "$type": "app.bsky.feed.post",
                    "reply": {
                        "root": {
                            "cid": "bafyreici6xkywegjpbuskuht35yyfskgpkvbpl6r6qj7oz6sq65nwugnmu",
                            "uri": "at://did:plc:mt43vjwo3f7ebvkjjxsoao7h/app.bsky.feed.post/3juzr2acndk2c"
                        },
                        "parent": {
                            "cid": "bafyreidepy2oswxbiqa4lpxiairnwu7a3lrf6awi644bnsev2z7iiqrvcm",
                            "uri": "at://did:plc:mt43vjwo3f7ebvkjjxsoao7h/app.bsky.feed.post/3jw26gacmok2u"
                        }
                    },
                    "createdAt": "2023-05-19T01:50:46.764Z"
                },
                "replyCount": 0,
                "repostCount": 0,
                "likeCount": 0,
                "indexedAt": "2023-05-19T01:50:46.905Z",
                "viewer": {},
                "labels": []
            },
            "reply": {
                "root": {
                    "uri": "at://did:plc:mt43vjwo3f7ebvkjjxsoao7h/app.bsky.feed.post/3juzr2acndk2c",
                    "cid": "bafyreici6xkywegjpbuskuht35yyfskgpkvbpl6r6qj7oz6sq65nwugnmu",
                    "author": {
                        "did": "did:plc:mt43vjwo3f7ebvkjjxsoao7h",
                        "handle": "brandon-test.bsky.social",
                        "viewer": {
                            "muted": false,
                            "blockedBy": false
                        },
                        "labels": []
                    },
                    "record": {
                        "text": "this is a test abc123pleaseignore",
                        "$type": "app.bsky.feed.post",
                        "createdAt": "2023-05-06T03:10:44.776Z"
                    },
                    "replyCount": 1,
                    "repostCount": 0,
                    "likeCount": 0,
                    "indexedAt": "2023-05-06T03:10:45.028Z",
                    "viewer": {},
                    "labels": []
                },
                "parent": {
                    "uri": "at://did:plc:mt43vjwo3f7ebvkjjxsoao7h/app.bsky.feed.post/3jw26gacmok2u",
                    "cid": "bafyreidepy2oswxbiqa4lpxiairnwu7a3lrf6awi644bnsev2z7iiqrvcm",
                    "author": {
                        "did": "did:plc:mt43vjwo3f7ebvkjjxsoao7h",
                        "handle": "brandon-test.bsky.social",
                        "viewer": {
                            "muted": false,
                            "blockedBy": false
                        },
                        "labels": []
                    },
                    "record": {
                        "text": "five",
                        "$type": "app.bsky.feed.post",
                        "reply": {
                            "root": {
                                "cid": "bafyreici6xkywegjpbuskuht35yyfskgpkvbpl6r6qj7oz6sq65nwugnmu",
                                "uri": "at://did:plc:mt43vjwo3f7ebvkjjxsoao7h/app.bsky.feed.post/3juzr2acndk2c"
                            },
                            "parent": {
                                "cid": "bafyreielm2tbmhbucnxaxfpwgmbs7ghgdcgi2p6r7vff7yytntxvliv4wu",
                                "uri": "at://did:plc:mt43vjwo3f7ebvkjjxsoao7h/app.bsky.feed.post/3jw26g47xzc2c"
                            }
                        },
                        "createdAt": "2023-05-19T00:35:17.808Z"
                    },
                    "replyCount": 1,
                    "repostCount": 0,
                    "likeCount": 0,
                    "indexedAt": "2023-05-19T00:35:17.957Z",
                    "viewer": {},
                    "labels": []
                }
            }
        },
   ...
}
```
