### PR TITLE
fix: remove `noFeedback` from external link embeds, add divider

### DIFF
--- a/src/view/com/composer/ExternalEmbed.tsx
+++ b/src/view/com/composer/ExternalEmbed.tsx
@@ -32,7 +32,10 @@ export const ExternalEmbed = ({
           <ActivityIndicator size="large" style={styles.spinner} />
         </View>
       ) : link.localThumb ? (
-        <AutoSizedImage uri={link.localThumb.path} style={styles.image} />
+        <AutoSizedImage
+          uri={link.localThumb.path}
+          style={[pal.border, styles.image]}
+        />
       ) : undefined}
       <View style={styles.inner}>
         {!!link.meta?.title && (
@@ -86,6 +89,7 @@ const styles = StyleSheet.create({
   image: {
     borderTopLeftRadius: 6,
     borderTopRightRadius: 6,
+    borderBottomWidth: 1,
     width: '100%',
     maxHeight: 200,
   },

--- a/src/view/com/util/Link.tsx
+++ b/src/view/com/util/Link.tsx
@@ -91,6 +91,7 @@ export const Link = observer(function Link({
   return (
     <TouchableOpacity
       testID={testID}
+      delayPressIn={130}
       style={style}
       onPress={onPress}
       accessible={accessible}

--- a/src/view/com/util/post-embeds/ExternalLinkEmbed.tsx
+++ b/src/view/com/util/post-embeds/ExternalLinkEmbed.tsx
@@ -16,7 +16,7 @@ export const ExternalLinkEmbed = ({
   return (
     <>
       {link.thumb ? (
-        <AutoSizedImage uri={link.thumb} style={styles.extImage}>
+        <AutoSizedImage uri={link.thumb} style={[pal.border, styles.extImage]}>
           {imageChild}
         </AutoSizedImage>
       ) : undefined}
@@ -50,6 +50,7 @@ const styles = StyleSheet.create({
   extImage: {
     borderTopLeftRadius: 6,
     borderTopRightRadius: 6,
+    borderBottomWidth: 1,
     width: '100%',
     maxHeight: 200,
   },

--- a/src/view/com/util/post-embeds/index.tsx
+++ b/src/view/com/util/post-embeds/index.tsx
@@ -146,9 +146,10 @@ export function PostEmbeds({
 
     return (
       <Link
+        asAnchor
+        anchorNoUnderline
         style={[styles.extOuter, pal.view, pal.border, style]}
-        href={link.uri}
-        noFeedback>
+        href={link.uri}>
         <ExternalLinkEmbed link={link} />
       </Link>
     )


### PR DESCRIPTION
Otherwise it looks like a picture instead of a link embed. Closes #752 