### PR TITLE
Fix profile load issue + enhancement of profile isCurrent style

### DIFF
--- a/src/view/screens/Profile.tsx
+++ b/src/view/screens/Profile.tsx
@@ -46,7 +46,7 @@ export const ProfileScreen = withAuthRequired(
     useSetTitle(combinedDisplayName(uiState.profile))
 
     useEffect(() => {
-      setHasSetup(false);
+      setHasSetup(false)
     }, [route.params.name])
 
     useFocusEffect(

--- a/src/view/screens/Profile.tsx
+++ b/src/view/screens/Profile.tsx
@@ -45,6 +45,10 @@ export const ProfileScreen = withAuthRequired(
     )
     useSetTitle(combinedDisplayName(uiState.profile))
 
+    useEffect(() => {
+      setHasSetup(false);
+    }, [route.params.name])
+
     useFocusEffect(
       React.useCallback(() => {
         let aborted = false

--- a/src/view/shell/desktop/LeftNav.tsx
+++ b/src/view/shell/desktop/LeftNav.tsx
@@ -89,17 +89,17 @@ const NavItem = observer(
     const pal = usePalette('default')
     const store = useStores()
     const [pathName] = React.useMemo(() => router.matchPath(href), [href])
-    const currentRouteName = useNavigationState(state => {
+    const currentRouteInfo = useNavigationState(state => {
       if (!state) {
         return {name: 'Home'}
       }
       return getCurrentRoute(state)
     })
     let isCurrent =
-      currentRouteName.name === 'Profile'
-        ? isTab(currentRouteName.name, pathName) &&
-          currentRouteName.params.name === store.me.handle
-        : isTab(currentRouteName.name, pathName)
+      currentRouteInfo.name === 'Profile'
+        ? isTab(currentRouteInfo.name, pathName) &&
+          currentRouteInfo.params.name === store.me.handle
+        : isTab(currentRouteInfo.name, pathName)
     const {onPress} = useLinkProps({to: href})
     const onPressWrapped = React.useCallback(
       (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {

--- a/src/view/shell/desktop/LeftNav.tsx
+++ b/src/view/shell/desktop/LeftNav.tsx
@@ -91,12 +91,15 @@ const NavItem = observer(
     const [pathName] = React.useMemo(() => router.matchPath(href), [href])
     const currentRouteName = useNavigationState(state => {
       if (!state) {
-        return 'Home'
+        return {name: 'Home'}
       }
-      return getCurrentRoute(state).name
+      return getCurrentRoute(state)
     })
-
-    const isCurrent = isTab(currentRouteName, pathName)
+    let isCurrent =
+      currentRouteName.name === 'Profile'
+        ? isTab(currentRouteName.name, pathName) &&
+          currentRouteName.params.name === store.me.handle
+        : isTab(currentRouteName.name, pathName)
     const {onPress} = useLinkProps({to: href})
     const onPressWrapped = React.useCallback(
       (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {


### PR DESCRIPTION
Hi

1. There's a problem with the Profile link Active style, when you're visiting other profiles, the Profile link will be active too!

<img width="625" alt="image" src="https://github.com/bluesky-social/social-app/assets/2494766/c1783987-2294-4cde-a9e7-edfaea176f8b">

2. When the profile page is not loaded, and the user is visiting other profiles, the Profile page (because of isCurrent issue doesn't work, which I fixed in the first bullet) will get stuck at the skeleton view.
related issue: https://github.com/bluesky-social/social-app/issues/722

<img width="922" alt="image" src="https://github.com/bluesky-social/social-app/assets/2494766/5e9fe710-ab85-4d11-9074-2ef21ae69921">

To Reproduce:
1. Without loading your profile, Go to someone else's profile
2. Click on the "Profile" button

To Reproduce:
1. Without loading your profile, Go to someone else's profile
2. Go to the Settings page
3. Click on the "Profile" button

