### PR TITLE
feat: Adds QoL community improvement with writing prompt deescalation

### DIFF
--- a/src/lib/strings/prompts.ts
+++ b/src/lib/strings/prompts.ts
@@ -1,0 +1,24 @@
+const replyPrompts = [
+  'Write your reply',
+  'Add to the conversation',
+  'Be authentic',
+  'Join in and contribute',
+  "Don't be mean here",
+]
+
+export function replyToPrompt(originText?: string) {
+  // prefer random reply prompt if no text
+  if (!originText) {
+    return replyPrompts[Math.floor(Math.random() * replyPrompts.length)]
+  }
+
+  // offer consistent text for good UX
+  const hash = Math.abs(
+    originText.split('').reduce((hc, curr) => {
+      hc = curr.charCodeAt(0) + (hc << 6) + (hc << 16) - hc
+      return hc
+    }, 0),
+  )
+
+  return replyPrompts[hash % replyPrompts.length]
+}

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -37,6 +37,7 @@ import {useExternalLinkFetch} from './useExternalLinkFetch'
 import {isDesktopWeb, isAndroid} from 'platform/detection'
 import {GalleryModel} from 'state/models/media/gallery'
 import {Gallery} from './photos/Gallery'
+import {replyToPrompt} from '../../../lib/strings/prompts'
 
 const MAX_GRAPHEME_LENGTH = 300
 
@@ -200,7 +201,9 @@ export const ComposePost = observer(function ComposePost({
 
   const canPost = graphemeLength <= MAX_GRAPHEME_LENGTH
 
-  const selectTextInputPlaceholder = replyTo ? 'Write your reply' : "What's up?"
+  const selectTextInputPlaceholder = replyTo
+    ? replyToPrompt(replyTo.text)
+    : "What's up?"
 
   const canSelectImages = gallery.size < 4
   const viewStyles = {

--- a/src/view/com/composer/Prompt.tsx
+++ b/src/view/com/composer/Prompt.tsx
@@ -5,6 +5,7 @@ import {Text} from '../util/text/Text'
 import {usePalette} from 'lib/hooks/usePalette'
 import {useStores} from 'state/index'
 import {isDesktopWeb} from 'platform/detection'
+import {replyToPrompt} from '../../../lib/strings/prompts'
 
 export function ComposePrompt({onPressCompose}: {onPressCompose: () => void}) {
   const store = useStores()
@@ -24,7 +25,7 @@ export function ComposePrompt({onPressCompose}: {onPressCompose: () => void}) {
           pal.text,
           isDesktopWeb ? styles.labelDesktopWeb : styles.labelMobile,
         ]}>
-        Write your reply
+        {replyToPrompt()}
       </Text>
     </TouchableOpacity>
   )


### PR DESCRIPTION
Fixes #766 

This is a PR for a set of string changes that update "Write your reply" to a set of phrases that encourage contribution, while also steering individuals to post within the bounds of Bluesky's community guidelines. As a reference implementation, this would also encourage other app developers to think about these kinds of concerns in their own clients.

Code Overview:
This is a string change. For a consistent UX, the reply text is hashed to select the same "prompt" on subsequent replies. This makes the experience a little less jarring if you open/close the reply dialog without adding any content.

While this is English only, the placement into lib/strings makes it a straightforward candidate in the future if i18n becomes a requirement.

Tests Ran:
* `yarn test` (a few errors unrelated to the string change)