### PR TITLE
Remove: Load new posts shadow

### DIFF
--- a/src/view/com/util/load-latest/LoadLatestBtnMobile.tsx
+++ b/src/view/com/util/load-latest/LoadLatestBtnMobile.tsx
@@ -46,9 +46,6 @@ const styles = StyleSheet.create({
     position: 'absolute',
     left: 20,
     bottom: 35,
-    shadowColor: '#000',
-    shadowOpacity: 0.3,
-    shadowOffset: {width: 0, height: 1},
   },
   loadLatestInner: {
     flexDirection: 'row',


### PR DESCRIPTION
Removed the presence of unnatural lines on the `Load new posts` button on vertical screens.

# Before
![before](https://github.com/bluesky-social/social-app/assets/93961902/e3b75fff-2d7b-47db-a83d-6401886bf475)

# After

![after](https://github.com/bluesky-social/social-app/assets/93961902/2d5be6cd-6d0a-42e4-a51a-d0eabc495122)
