### PR TITLE
labels: add 'corpse' to 'violent' category

### DIFF
--- a/src/lib/labeling/const.ts
+++ b/src/lib/labeling/const.ts
@@ -62,7 +62,7 @@ export const CONFIGURABLE_LABEL_GROUPS: Record<
     title: 'Violent / Bloody',
     subtitle: 'Gore, self-harm, torture',
     warning: 'Violence',
-    values: ['gore', 'self-harm', 'torture', 'nsfl'],
+    values: ['gore', 'self-harm', 'torture', 'nsfl', 'corpse'],
     isAdultImagery: true,
   },
   hate: {


### PR DESCRIPTION
Overlooked this when the label was added earlier.