### PR TITLE
Enable gzip support for serving requests

### DIFF
--- a/bskyweb/cmd/bskyweb/server.go
+++ b/bskyweb/cmd/bskyweb/server.go
@@ -101,6 +101,9 @@ func serve(cctx *cli.Context) error {
 		RedirectCode: http.StatusFound,
 	}))
 
+	// enable gzip 
+	e.Use(middleware.Gzip())
+
 	//
 	// configure routes
 	//


### PR DESCRIPTION
Inspired by discussion [here](https://bsky.app/profile/slightlyoff.bsky.social/post/3jwyvwnyoe226); whilst the point wasn't made in a great way, to say the least, it could be a quick win to reduce bandwidth for slower connections, especially pre-optimization of resources.

Completely untested, as I'm not able to create an environment right now.