### PR TITLE
Translate to primary language rather than just english

### DIFF
--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -97,15 +97,17 @@ export const PostThreadItem = observer(function PostThreadItem({
     Toast.show('Copied to clipboard')
   }, [record])
 
+  const primaryLanguage = store.preferences.contentLanguages[0] || 'en'
+
   const onOpenTranslate = React.useCallback(() => {
     Linking.openURL(
       encodeURI(
-        `https://translate.google.com/?sl=auto&tl=en&text=${
+        `https://translate.google.com/?sl=auto&tl=${primaryLanguage}&text=${
           record?.text || ''
         }`,
       ),
     )
-  }, [record])
+  }, [record, primaryLanguage])
 
   const onToggleThreadMute = React.useCallback(async () => {
     try {

--- a/src/view/com/post/Post.tsx
+++ b/src/view/com/post/Post.tsx
@@ -167,15 +167,17 @@ const PostLoaded = observer(
       Toast.show('Copied to clipboard')
     }, [record])
 
+    const primaryLanguage = store.preferences.contentLanguages[0] || 'en'
+
     const onOpenTranslate = React.useCallback(() => {
       Linking.openURL(
         encodeURI(
-          `https://translate.google.com/?sl=auto&tl=en&text=${
+          `https://translate.google.com/?sl=auto&tl=${primaryLanguage}&text=${
             record?.text || ''
           }`,
         ),
       )
-    }, [record])
+    }, [record, primaryLanguage])
 
     const onToggleThreadMute = React.useCallback(async () => {
       try {

--- a/src/view/com/posts/FeedItem.tsx
+++ b/src/view/com/posts/FeedItem.tsx
@@ -97,15 +97,17 @@ export const FeedItem = observer(function ({
     Toast.show('Copied to clipboard')
   }, [record])
 
+  const primaryLanguage = store.preferences.contentLanguages[0] || 'en'
+
   const onOpenTranslate = React.useCallback(() => {
     Linking.openURL(
       encodeURI(
-        `https://translate.google.com/?sl=auto&tl=en&text=${
+        `https://translate.google.com/?sl=auto&tl=${primaryLanguage}&text=${
           record?.text || ''
         }`,
       ),
     )
-  }, [record])
+  }, [record, primaryLanguage])
 
   const onToggleThreadMute = React.useCallback(async () => {
     track('FeedItem:ThreadMute')


### PR DESCRIPTION
This PR:

 - Uses the user's `contentLanguages` to determine which language to translate to when opening Google Translate. Uses the first element in the languages array, falls back on `en`.

Shout out to @renahlee :)