### PR TITLE
Fix line breaks on sidebar links

### DIFF
--- a/src/view/shell/desktop/RightNav.tsx
+++ b/src/view/shell/desktop/RightNav.tsx
@@ -99,7 +99,7 @@ const styles = StyleSheet.create({
     position: 'absolute',
     top: 20,
     left: 'calc(50vw + 330px)',
-    width: 300,
+    width: 304,
   },
 
   message: {


### PR DESCRIPTION
This fixes some line breaks in the sidebar on Firefox.

**Before**

![Screenshot 2023-05-31 at 13 16 16](https://github.com/bluesky-social/social-app/assets/6617432/6776ff4d-795a-4c9c-aebb-fe11260f89ee)

**After**

![Screenshot 2023-05-31 at 13 16 09](https://github.com/bluesky-social/social-app/assets/6617432/777214b4-2731-43db-af8a-1e3bad19e803)
