### PR TITLE
gzip middleware

### DIFF
--- a/bskyweb/cmd/bskyweb/server.go
+++ b/bskyweb/cmd/bskyweb/server.go
@@ -101,6 +101,9 @@ func serve(cctx *cli.Context) error {
 		RedirectCode: http.StatusFound,
 	}))
 
+	// enable gzip 
+	e.Use(middleware.Gzip())
+
 	//
 	// configure routes
 	//

--- a/bskyweb/cmd/bskyweb/server.go
+++ b/bskyweb/cmd/bskyweb/server.go
@@ -101,8 +101,19 @@ func serve(cctx *cli.Context) error {
 		RedirectCode: http.StatusFound,
 	}))
 
-	// enable gzip 
-	e.Use(middleware.Gzip())
+	// gzip transport compression for most responses.
+	// echo middleware is pretty naive, defaults to compressing every response,
+	// of any mimetype or size. we configure to skip some cases, but this is a
+	// pretty incomplete set of patterns.
+	e.Use(middleware.GzipWithConfig(middleware.GzipConfig{
+		Skipper: func(c echo.Context) bool {
+			// don't compress PNG files, specifically
+			return strings.HasSuffix(c.Request().URL.Path, ".png")
+		},
+		Level: -1, // default
+		// TODO: https://github.com/labstack/echo/pull/2267
+		//MinLength: 1024, // default is "0"
+	}))
 
 	//
 	// configure routes


### PR DESCRIPTION
This pulls in @cloudhunter's patch to add echo gzip middleware, then extends with a bit of skip config.

Ideally we would use the new `MinLength` param, but that just got merged to upstream echo 20 hours ago (!), and isn't available in a tagged release yet. When it is, we can quickly update to only do compression on responses of 1024 bytes or more.

cc: @Jacob2161 for review. maybe we actually want to do this at the load-balancer?