### PR TITLE
Don't show Remove button for nonexistent avatar/banner

### DIFF
--- a/src/view/com/util/UserAvatar.tsx
+++ b/src/view/com/util/UserAvatar.tsx
@@ -163,7 +163,7 @@ export function UserAvatar({
           onSelectNewAvatar?.(croppedImage)
         },
       },
-      {
+      !!avatar && {
         testID: 'changeAvatarRemoveBtn',
         label: 'Remove',
         icon: ['far', 'trash-can'] as IconProp,
@@ -173,6 +173,7 @@ export function UserAvatar({
       },
     ],
     [
+      avatar,
       onSelectNewAvatar,
       requestCameraAccessIfNeeded,
       requestPhotoAccessIfNeeded,

--- a/src/view/com/util/UserBanner.tsx
+++ b/src/view/com/util/UserBanner.tsx
@@ -67,7 +67,7 @@ export function UserBanner({
         )
       },
     },
-    {
+    !!banner && {
       testID: 'changeBannerRemoveBtn',
       label: 'Remove',
       icon: ['far', 'trash-can'] as IconProp,


### PR DESCRIPTION
Conditionally showing the "Remove" button only if there is an existing avatar/banner on the user's profile. Closes #832.

Screenshot of new behavior:
![image](https://github.com/bluesky-social/social-app/assets/512317/31eca3dc-b62f-4a44-9239-39961a9350f6)
