### PR TITLE
Fix dark mode detection on mobile

### DIFF
--- a/app.json
+++ b/app.json
@@ -10,7 +10,7 @@
     },
     "orientation": "portrait",
     "icon": "./assets/icon.png",
-    "userInterfaceStyle": "light",
+    "userInterfaceStyle": "automatic",
     "splash": {
       "image": "./assets/cloud-splash.png",
       "resizeMode": "cover",


### PR DESCRIPTION
Fix dark mode detection on mobile by setting `userInterfaceStyle` to `automatic`,  per [these instructions](https://docs.expo.dev/develop/user-interface/color-themes/#configuration). Closes #845.

From my local Android emulator:
![image](https://github.com/bluesky-social/social-app/assets/512317/8bf0c7b5-0994-4bed-8c99-29154db78701)
