### PR TITLE
remove trailing / on meta tags

### DIFF
--- a/bskyweb/templates/base.html
+++ b/bskyweb/templates/base.html
@@ -111,9 +111,9 @@
     }
   </style>
   {% include "scripts.html" %}
-  <link rel="apple-touch-icon" sizes="180x180" href="/static/apple-touch-icon.png"/>
-  <link rel="icon" type="image/png" sizes="32x32" href="/static/favicon-32x32.png"/>
-  <link rel="icon" type="image/png" sizes="16x16" href="/static/favicon-16x16.png"/>
+  <link rel="apple-touch-icon" sizes="180x180" href="/static/apple-touch-icon.png">
+  <link rel="icon" type="image/png" sizes="32x32" href="/static/favicon-32x32.png">
+  <link rel="icon" type="image/png" sizes="16x16" href="/static/favicon-16x16.png">
   {% block html_head_extra -%}{%- endblock %}
   <meta name="application-name" name="Bluesky">
   <meta name="generator" name="bskyweb">

--- a/bskyweb/templates/base.html
+++ b/bskyweb/templates/base.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>                                                                                          
 <html lang="en">
 <head>   
-  <meta charset="UTF-8" />
-  <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
+  <meta charset="UTF-8">
+  <meta httpEquiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, viewport-fit=cover">
   <meta name="referrer" content="origin-when-cross-origin">
   <title>{%- block head_title -%}Bluesky{%- endblock -%}</title>

--- a/bskyweb/templates/home.html
+++ b/bskyweb/templates/home.html
@@ -3,13 +3,13 @@
 {% block head_title %}Bluesky{% endblock %}
 
 {% block html_head_extra -%}
-  <meta name="description" content="See what's next."/>
-  <meta property="og:type" content="website"/>
-  <meta property="og:title" content="Bluesky Social"/>
-  <meta property="og:description" content="See what's next."/>
-  <meta property="og:image" content="/static/social-card-default.png"/>
-  <meta name="twitter:card" content="summary"/>
-  <meta name="twitter:site" content="@bluesky"/>
+  <meta name="description" content="See what's next.">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="Bluesky Social">
+  <meta property="og:description" content="See what's next.">
+  <meta property="og:image" content="/static/social-card-default.png">
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:site" content="@bluesky">
 {%- endblock %}
 
 {% block noscript_extra %}


### PR DESCRIPTION
`<meta>` & `<link>` tags are [void elements](https://html.spec.whatwg.org/multipage/syntax.html#void-elements) which means they are self closing, and do not require a closing tag, nor a trailing `/`.

The trailing `/` is something that was required in XHTML but [is ignored in HTML](https://html.spec.whatwg.org/multipage/syntax.html#start-tags). Quoth the spec:

> On void elements, [the trailing slash] does not mark the start tag as self-closing but instead is unnecessary and has no effect of any kind. For such void elements, it should be used only with caution — especially since, if directly preceded by an unquoted attribute value, it becomes part of the attribute value rather than being discarded by the parser.