### PR TITLE
remove X-UA-Compatible meta tag

### DIFF
--- a/bskyweb/templates/base.html
+++ b/bskyweb/templates/base.html
@@ -2,7 +2,6 @@
 <html lang="en">
 <head>   
   <meta charset="UTF-8" />
-  <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, viewport-fit=cover">
   <meta name="referrer" content="origin-when-cross-origin">
   <title>{%- block head_title -%}Bluesky{%- endblock -%}</title>


### PR DESCRIPTION
This meta tag allows Internet Explorer 7 through 11 to change which document mode they would use. As of 2013, however, [Microsoft Edge would ignore this value except under strict circumstances](https://learn.microsoft.com/en-gb/archive/blogs/ie/living-on-the-edge-our-next-step-in-helping-the-web-just-work). This meta tag is ignored in modern versions of Edge (Chromium based).

[Internet Explorer 11 reached EOL in June 2022](https://blogs.windows.com/windowsexperience/2022/06/15/internet-explorer-11-has-retired-and-is-officially-out-of-support-what-you-need-to-know/) and today makes up an exceedingly small proportion of internet traffic.

It's unlikely that anyone is browsing on Internet Explorer, and less likely that they're browsing on IE<11, which makes this tag redundant.