### PR TITLE
[APP-682] Allow tapping on picture in notifications screen to open post

### DIFF
--- a/src/view/com/notifications/FeedItem.tsx
+++ b/src/view/com/notifications/FeedItem.tsx
@@ -165,7 +165,7 @@ export const FeedItem = observer(function ({
   }
 
   return (
-    // eslint-disable-next-line
+    // eslint-disable-next-line react-native-a11y/no-nested-touchables
     <Link
       testID={`feedItem-by-${item.author.handle}`}
       style={[

--- a/src/view/com/util/images/ImageHorzList.tsx
+++ b/src/view/com/util/images/ImageHorzList.tsx
@@ -1,50 +1,25 @@
 import React from 'react'
-import {
-  StyleProp,
-  StyleSheet,
-  TouchableWithoutFeedback,
-  View,
-  ViewStyle,
-} from 'react-native'
+import {StyleProp, StyleSheet, View, ViewStyle} from 'react-native'
 import {Image} from 'expo-image'
 import {AppBskyEmbedImages} from '@atproto/api'
 
 interface Props {
   images: AppBskyEmbedImages.ViewImage[]
-  onPress?: (index: number) => void
   style?: StyleProp<ViewStyle>
 }
 
-export function ImageHorzList({images, onPress, style}: Props) {
-  const numImages = images.length
+export function ImageHorzList({images, style}: Props) {
   return (
     <View style={[styles.flexRow, style]}>
-      {images.map(({thumb, alt}, i) => (
-        <TouchableWithoutFeedback
-          key={i}
-          onPress={() => onPress?.(i)}
+      {images.map(({thumb, alt}) => (
+        <Image
+          source={{uri: thumb}}
+          style={styles.image}
           accessible={true}
-          accessibilityLabel={`Open image ${i} of ${numImages}`}
-          accessibilityHint="Opens image in viewer"
-          accessibilityActions={[{name: 'press', label: 'Press'}]}
-          onAccessibilityAction={action => {
-            switch (action.nativeEvent.actionName) {
-              case 'press':
-                onPress?.(0)
-                break
-              default:
-                break
-            }
-          }}>
-          <Image
-            source={{uri: thumb}}
-            style={styles.image}
-            accessible={true}
-            accessibilityIgnoresInvertColors
-            accessibilityHint={alt}
-            accessibilityLabel=""
-          />
-        </TouchableWithoutFeedback>
+          accessibilityIgnoresInvertColors
+          accessibilityHint={alt}
+          accessibilityLabel=""
+        />
       ))}
     </View>
   )


### PR DESCRIPTION
Closes #778 

According to #778, I have currently made clicking any part of the post in the notifications screen, including the image, redirect to the post page. 

However, if the intended behavior is to open the image in an image view lightbox when clicked directly on the notifications screen, that is also possible. Let me know @pfrazee 