### PR TITLE
[APP-683] Go to another custom feed from within a custom feed

### DIFF
--- a/src/view/com/feeds/CustomFeed.tsx
+++ b/src/view/com/feeds/CustomFeed.tsx
@@ -71,7 +71,7 @@ export const CustomFeed = observer(
         accessibilityRole="button"
         style={[styles.container, pal.border, style]}
         onPress={() => {
-          navigation.navigate('CustomFeed', {
+          navigation.push('CustomFeed', {
             name: item.data.creator.did,
             rkey: new AtUri(item.data.uri).rkey,
           })


### PR DESCRIPTION
Prevents this behavior and instead pushes a new screen onto the stack.


https://github.com/bluesky-social/social-app/assets/8207733/4118d53e-7b16-48e7-9467-c1e271d19546

