### PR TITLE
Use Linking.openSettings() so it works on Android

### DIFF
--- a/src/lib/hooks/usePermissions.ts
+++ b/src/lib/hooks/usePermissions.ts
@@ -4,10 +4,6 @@ import {Linking} from 'react-native'
 import {isWeb} from 'platform/detection'
 import {Alert} from 'view/com/util/Alert'
 
-const openSettings = () => {
-  Linking.openURL('app-settings:')
-}
-
 const openPermissionAlert = (perm: string) => {
   Alert.alert(
     'Permission needed',
@@ -17,7 +13,7 @@ const openPermissionAlert = (perm: string) => {
         text: 'Cancel',
         style: 'cancel',
       },
-      {text: 'Open Settings', onPress: () => openSettings()},
+      {text: 'Open Settings', onPress: () => Linking.openSettings()},
     ],
   )
 }


### PR DESCRIPTION
Right now, if you deny permissions for e.g. your photo library when browsing a photo for your post, the app shows a modal that you need to grant permissions to the application that is supposed to link to the app settings. However, that link (using the `app-settings:` URL) only works on iOS, not Android (nothing happens there).

To fix this, I've changed it to use [`Linking.openSettings()`](https://reactnative.dev/docs/linking.html#opensettings), which was made for this purpose/to use across platforms. Verified that it now works properly in an Android emulator.