### PR TITLE
Fix image-only posts not being visible in custom feeds.

### DIFF
--- a/src/lib/api/feed-manip.ts
+++ b/src/lib/api/feed-manip.ts
@@ -213,6 +213,12 @@ export class FeedTuner {
             hasProp(item.post.record, 'text') &&
             typeof item.post.record.text === 'string'
           ) {
+            // Treat empty text the same as no text.
+            if (item.post.record.text.length === 0) {
+              hasPreferredLang = true
+              break
+            }
+
             const res = lande(item.post.record.text)
 
             if (langsCode3.includes(res[0][0])) {


### PR DESCRIPTION
Currently, image-only posts are not visible in custom feeds, because language detection is attempted at them (and always fails to match any preferred language) even if there is no text. This adds a simple check for empty text before doing a language check and treats it like when there is no text attached at all.

The issue is described in more detail here: https://github.com/bluesky-social/social-app/issues/787