### PR TITLE
Move useWebMediaQueries() above return

### DIFF
--- a/src/view/screens/Search.web.tsx
+++ b/src/view/screens/Search.web.tsx
@@ -44,11 +44,11 @@ export const SearchScreen = withAuthRequired(
       }
     }, [foafs, suggestedActors, searchUIModel, params.q])
 
+    const {isDesktop} = useWebMediaQueries()
+
     if (searchUIModel) {
       return <SearchResults model={searchUIModel} />
     }
-
-    const {isDesktop} = useWebMediaQueries()
 
     if (!isDesktop) {
       return <Mobile.SearchScreen navigation={navigation} route={route} />


### PR DESCRIPTION
I encountered an error while using Bluesky on Web, where the search page wouldn't render if I loaded user search results, navigated away, and then loaded the page again. This is due to a difference in the number of hooks called when rendering the page depending on whether there are user search results or not (which violates [the hooks rules](https://legacy.reactjs.org/docs/hooks-rules.html)). I've modified the code to always call `useWebMediaQueries()` before any return happens accordingly.