### PR TITLE
Hotfix: Android app crashed when opening settings with Appview debug

### DIFF
--- a/src/lib/api/debug-appview-proxy-header.ts
+++ b/src/lib/api/debug-appview-proxy-header.ts
@@ -16,6 +16,9 @@ export function useDebugHeaderSetting(agent: BskyAgent): [boolean, () => void] {
   const [enabled, setEnabled] = useState<boolean>(isEnabled())
 
   const toggle = useCallback(() => {
+    if (!isWeb || typeof window === 'undefined') {
+      return
+    }
     if (!enabled) {
       localStorage.setItem('set-header-x-appview-proxy', 'yes')
       agent.api.xrpc.setHeader('x-appview-proxy', 'true')
@@ -31,7 +34,7 @@ export function useDebugHeaderSetting(agent: BskyAgent): [boolean, () => void] {
 }
 
 export function setDebugHeader(agent: BskyAgent, enabled: boolean) {
-  if (!isWeb) {
+  if (!isWeb || typeof window === 'undefined') {
     return
   }
   if (enabled) {
@@ -53,5 +56,8 @@ export function applyDebugHeader(agent: BskyAgent) {
 }
 
 function isEnabled() {
+  if (!isWeb || typeof window === 'undefined') {
+    return false
+  }
   return localStorage.getItem('set-header-x-appview-proxy') === 'yes'
 }


### PR DESCRIPTION
Repro steps:
- `git checkout main`
- `git pull`
- Run app on Android
- Open sidebar, go to settings
- App will crash with the following error
- Only happens on Android (iOS is totally fine)
<img width="551" alt="CleanShot 2023-06-14 at 15 15 49@2x" src="https://github.com/bluesky-social/social-app/assets/8207733/4435f5bd-dd58-4f98-954a-c78e4831e2b0">
