### PR TITLE
Add testnet warning

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -10,6 +10,22 @@ export const MAX_GRAPHEME_LENGTH = 300
 // but increasing limit per user feedback
 export const MAX_ALT_TEXT = 1000
 
+export function IS_LOCAL_DEV(url: string) {
+  return url.includes('localhost')
+}
+
+export function IS_STAGING(url: string) {
+  return !IS_LOCAL_DEV(url) && !IS_PROD(url)
+}
+
+export function IS_PROD(url: string) {
+  // NOTE
+  // until open federation, "production" is defined as the main server
+  // this definition will not work once federation is enabled!
+  // -prf
+  return url.startsWith('https://bsky.social')
+}
+
 export const PROD_TEAM_HANDLES = [
   'jay.bsky.social',
   'pfrazee.com',
@@ -43,14 +59,14 @@ export async function DEFAULT_FEEDS(
   serviceUrl: string,
   resolveHandle: (name: string) => Promise<string>,
 ) {
-  if (serviceUrl.includes('localhost')) {
+  if (IS_LOCAL_DEV(serviceUrl)) {
     // local dev
     const aliceDid = await resolveHandle('alice.test')
     return {
       pinned: [`at://${aliceDid}/app.bsky.feed.generator/alice-favs`],
       saved: [`at://${aliceDid}/app.bsky.feed.generator/alice-favs`],
     }
-  } else if (serviceUrl.includes('staging')) {
+  } else if (IS_STAGING(serviceUrl)) {
     // staging
     return {
       pinned: [STAGING_DEFAULT_FEED('whats-hot')],
@@ -90,9 +106,9 @@ export const STAGING_LINK_META_PROXY =
 export const PROD_LINK_META_PROXY = 'https://cardyb.bsky.app/v1/extract?url='
 
 export function LINK_META_PROXY(serviceUrl: string) {
-  if (serviceUrl.includes('localhost')) {
+  if (IS_LOCAL_DEV(serviceUrl)) {
     return STAGING_LINK_META_PROXY
-  } else if (serviceUrl.includes('staging')) {
+  } else if (IS_STAGING(serviceUrl)) {
     return STAGING_LINK_META_PROXY
   } else {
     return PROD_LINK_META_PROXY

--- a/src/state/models/session.ts
+++ b/src/state/models/session.ts
@@ -10,6 +10,7 @@ import {isObj, hasProp} from 'lib/type-guards'
 import {networkRetry} from 'lib/async/retry'
 import {z} from 'zod'
 import {RootStoreModel} from './root-store'
+import {IS_PROD} from 'lib/constants'
 
 export type ServiceDescription = DescribeServer.OutputSchema
 
@@ -102,6 +103,13 @@ export class SessionModel {
 
   get switchableAccounts() {
     return this.accounts.filter(acct => acct.did !== this.data?.did)
+  }
+
+  get isTestNetwork() {
+    if (!this.data) {
+      return false
+    }
+    return !IS_PROD(this.data.service)
   }
 
   serialize(): unknown {

--- a/src/view/com/pager/FeedsTabBarMobile.tsx
+++ b/src/view/com/pager/FeedsTabBarMobile.tsx
@@ -62,7 +62,9 @@ export const FeedsTabBar = observer(
               />
             </TouchableOpacity>
           </View>
-          <Text style={[brandBlue, s.bold, styles.title]}>Bluesky</Text>
+          <Text style={[brandBlue, s.bold, styles.title]}>
+            {store.session.isTestNetwork ? 'TEST NETWORK' : 'Bluesky'}
+          </Text>
           <View style={[pal.view]}>
             <Link
               href="/settings/saved-feeds"

--- a/src/view/shell/desktop/RightNav.tsx
+++ b/src/view/shell/desktop/RightNav.tsx
@@ -15,15 +15,24 @@ import {formatCount} from 'view/com/util/numeric/format'
 export const DesktopRightNav = observer(function DesktopRightNav() {
   const store = useStores()
   const pal = usePalette('default')
+  const palError = usePalette('error')
 
   return (
     <View style={[styles.rightNav, pal.view]}>
       {store.session.hasSession && <DesktopSearch />}
       <View style={styles.message}>
-        <Text type="md" style={[pal.textLight, styles.messageLine]}>
-          Welcome to Bluesky! This is a beta application that's still in
-          development.
-        </Text>
+        {store.session.isTestNetwork ? (
+          <View style={[palError.view, styles.messageLine, s.p10]}>
+            <Text type="md" style={[palError.text, s.bold]}>
+              TEST NETWORK. Posts and accounts are not permanent.
+            </Text>
+          </View>
+        ) : (
+          <Text type="md" style={[pal.textLight, styles.messageLine]}>
+            Welcome to Bluesky! This is a beta application that's still in
+            development.
+          </Text>
+        )}
         <View style={[s.flexRow]}>
           <TextLink
             type="md"


### PR DESCRIPTION
This is a temporary warning that we're applying prior to federation while the testnet runs. Applies when visiting any instance that's not on main.

|Web|Mobile|
|-|-|
|<img width="1195" alt="CleanShot 2023-06-14 at 17 29 23@2x" src="https://github.com/bluesky-social/social-app/assets/1270099/d5363b37-044e-4f17-81fc-c996b8983bb5">|<img width="393" alt="CleanShot 2023-06-14 at 17 29 37@2x" src="https://github.com/bluesky-social/social-app/assets/1270099/04682af7-9447-4b1a-b64b-da0554dda5d3">|
