### PR TITLE
Allow click-outside to dismiss composer on web

### DIFF
--- a/src/view/shell/Composer.web.tsx
+++ b/src/view/shell/Composer.web.tsx
@@ -84,6 +84,12 @@ function Inner({state}: {state: ComposerOpts}) {
           if (!isModalActive) {
             ref.current?.onPressCancel()
           }
+        }}
+        onPointerDown={evt => {
+          // Dismiss when clicking the backdrop (not the inner composer)
+          if (evt.target === evt.currentTarget && !isModalActive) {
+            ref.current?.onPressCancel()
+          }
         }}>
         <View
           style={[


### PR DESCRIPTION
Adds backdrop click-to-dismiss for the web composer. Clicking the dark overlay behind the composer triggers the same cancel flow as pressing Escape (showing a discard confirmation if there's unsaved content).

The composer uses Radix's `DismissableLayer` as a full-screen overlay, so `onInteractOutside` never fires — there is no "outside." Instead, this adds an `onPointerDown` handler with a `target === currentTarget` check to detect clicks on the backdrop itself.

Closes #712.