### PR TITLE
Add a11y details to profile page compose button.

### DIFF
--- a/src/view/screens/Profile.tsx
+++ b/src/view/screens/Profile.tsx
@@ -273,6 +273,9 @@ export const ProfileScreen = withAuthRequired(
           testID="composeFAB"
           onPress={onPressCompose}
           icon={<ComposeIcon2 strokeWidth={1.5} size={29} style={s.white} />}
+          accessibilityRole="button"
+          accessibilityLabel="Compose post"
+          accessibilityHint=""
         />
       </ScreenHider>
     )


### PR DESCRIPTION
This adds accessibility role, label and hint to the compose button on profile pages, to match the same button in all other views. Fixes https://github.com/bluesky-social/social-app/issues/695.