### PR TITLE
Fix Voice Control input on iOS (closes #891)

### DIFF
--- a/patches/react-native+0.71.8.patch
+++ b/patches/react-native+0.71.8.patch
@@ -1,0 +1,25 @@
+diff --git a/node_modules/react-native/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.m b/node_modules/react-native/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.m
+index 1c8f8e0..090bda5 100644
+--- a/node_modules/react-native/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.m
++++ b/node_modules/react-native/Libraries/Text/TextInput/RCTBackedTextInputDelegateAdapter.m
+@@ -256,7 +256,7 @@ static void *TextFieldSelectionObservingContext = &TextFieldSelectionObservingCo
+ 
+ - (void)textViewDidChange:(__unused UITextView *)textView
+ {
+-  if (_ignoreNextTextInputCall) {
++  if (_ignoreNextTextInputCall && [_lastStringStateWasUpdatedWith isEqual:_backedTextInputView.attributedText]) {
+     _ignoreNextTextInputCall = NO;
+     return;
+   }
+@@ -266,11 +266,10 @@ static void *TextFieldSelectionObservingContext = &TextFieldSelectionObservingCo
+ 
+ - (void)textViewDidChangeSelection:(__unused UITextView *)textView
+ {
+-  if (_lastStringStateWasUpdatedWith && ![_lastStringStateWasUpdatedWith isEqual:_backedTextInputView.attributedText]) {
++  if (![_lastStringStateWasUpdatedWith isEqual:_backedTextInputView.attributedText]) {
+     [self textViewDidChange:_backedTextInputView];
+     _ignoreNextTextInputCall = YES;
+   }
+-  _lastStringStateWasUpdatedWith = _backedTextInputView.attributedText;
+   [self textViewProbablyDidChangeSelection];
+ }

--- a/patches/react-native+0.71.8.patch
+++ b/patches/react-native+0.71.8.patch
@@ -23,3 +23,4 @@ index 1c8f8e0..090bda5 100644
 -  _lastStringStateWasUpdatedWith = _backedTextInputView.attributedText;
    [self textViewProbablyDidChangeSelection];
  }
+ 


### PR DESCRIPTION
Applies a patch to react-native to revert https://github.com/facebook/react-native/commit/a804c0f22b4b11b3d9632dc59a6da14f6c4325e3 which is being tracked at https://github.com/facebook/react-native/issues/37991. When that issue resolves we can drop this patch.

Fixes https://github.com/bluesky-social/social-app/issues/891