### PR TITLE
Add alt text validation option to user preferences

### DIFF
--- a/src/state/models/ui/preferences.ts
+++ b/src/state/models/ui/preferences.ts
@@ -53,6 +53,7 @@ export class PreferencesModel {
   homeFeedRepliesThreshold: number = 2
   homeFeedRepostsEnabled: boolean = true
   homeFeedQuotePostsEnabled: boolean = true
+  requireAltTextEnabled: boolean = false
 
   // used to linearize async modifications to state
   lock = new AwaitLock()
@@ -72,6 +73,7 @@ export class PreferencesModel {
       homeFeedRepliesThreshold: this.homeFeedRepliesThreshold,
       homeFeedRepostsEnabled: this.homeFeedRepostsEnabled,
       homeFeedQuotePostsEnabled: this.homeFeedQuotePostsEnabled,
+      requireAltTextEnabled: this.requireAltTextEnabled,
     }
   }
 
@@ -151,6 +153,13 @@ export class PreferencesModel {
         typeof v.homeFeedQuotePostsEnabled === 'boolean'
       ) {
         this.homeFeedQuotePostsEnabled = v.homeFeedQuotePostsEnabled
+      }
+      // check if requiring alt text is enabled in preferences, then hydtate
+      if (
+        hasProp(v, 'requireAltTextEnabled') &&
+        typeof v.requireAltTextEnabled === 'boolean'
+      ) {
+        this.requireAltTextEnabled = v.requireAltTextEnabled
       }
     }
   }
@@ -466,5 +475,9 @@ export class PreferencesModel {
 
   toggleHomeFeedQuotePostsEnabled() {
     this.homeFeedQuotePostsEnabled = !this.homeFeedQuotePostsEnabled
+  }
+
+  toggleRequireAltTextEnabled() {
+    this.requireAltTextEnabled = !this.requireAltTextEnabled
   }
 }

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -153,6 +153,14 @@ export const ComposePost = observer(function ComposePost({
         return
       }
 
+      if (
+        store.preferences.requireAltTextEnabled &&
+        gallery.images.some(image => image.altText.trim() === "")
+      ) {
+        setError('One or more images is missing alt text')
+        return
+      }
+
       setIsProcessing(true)
 
       let createdPost

--- a/src/view/screens/Settings.tsx
+++ b/src/view/screens/Settings.tsx
@@ -315,6 +315,17 @@ export const SettingsScreen = withAuthRequired(
 
           <View style={styles.spacer20} />
           <Text type="xl-bold" style={[pal.text, styles.heading]}>
+            Accessibility
+          </Text>
+          <ToggleButton
+            type="default-light"
+            label="Require alt text on images"
+            isSelected={store.preferences.requireAltTextEnabled}
+            onPress={store.preferences.toggleRequireAltTextEnabled}
+          />
+          <View style={styles.spacer20} />
+
+          <Text type="xl-bold" style={[pal.text, styles.heading]}>
             Appearance
           </Text>
           <View>


### PR DESCRIPTION
Add in toggle to allow users to opt into requiring alt text as a validation for posts containing images. See #907 for context