### PR TITLE
Add alt text validation option to user preferences (supersedes #913)

### DIFF
--- a/src/state/models/media/gallery.ts
+++ b/src/state/models/media/gallery.ts
@@ -23,6 +23,10 @@ export class GalleryModel {
     return this.images.length
   }
 
+  get needsAltText() {
+    return this.images.some(image => image.altText.trim() === '')
+  }
+
   async add(image_: Omit<RNImage, 'size'>) {
     if (this.size >= 4) {
       return

--- a/src/state/models/ui/preferences.ts
+++ b/src/state/models/ui/preferences.ts
@@ -53,6 +53,7 @@ export class PreferencesModel {
   homeFeedRepliesThreshold: number = 2
   homeFeedRepostsEnabled: boolean = true
   homeFeedQuotePostsEnabled: boolean = true
+  requireAltTextEnabled: boolean = false
 
   // used to linearize async modifications to state
   lock = new AwaitLock()
@@ -72,6 +73,7 @@ export class PreferencesModel {
       homeFeedRepliesThreshold: this.homeFeedRepliesThreshold,
       homeFeedRepostsEnabled: this.homeFeedRepostsEnabled,
       homeFeedQuotePostsEnabled: this.homeFeedQuotePostsEnabled,
+      requireAltTextEnabled: this.requireAltTextEnabled,
     }
   }
 
@@ -151,6 +153,13 @@ export class PreferencesModel {
         typeof v.homeFeedQuotePostsEnabled === 'boolean'
       ) {
         this.homeFeedQuotePostsEnabled = v.homeFeedQuotePostsEnabled
+      }
+      // check if requiring alt text is enabled in preferences, then hydtate
+      if (
+        hasProp(v, 'requireAltTextEnabled') &&
+        typeof v.requireAltTextEnabled === 'boolean'
+      ) {
+        this.requireAltTextEnabled = v.requireAltTextEnabled
       }
     }
   }
@@ -466,5 +475,9 @@ export class PreferencesModel {
 
   toggleHomeFeedQuotePostsEnabled() {
     this.homeFeedQuotePostsEnabled = !this.homeFeedQuotePostsEnabled
+  }
+
+  toggleRequireAltTextEnabled() {
+    this.requireAltTextEnabled = !this.requireAltTextEnabled
   }
 }

--- a/src/state/models/ui/preferences.ts
+++ b/src/state/models/ui/preferences.ts
@@ -154,7 +154,7 @@ export class PreferencesModel {
       ) {
         this.homeFeedQuotePostsEnabled = v.homeFeedQuotePostsEnabled
       }
-      // check if requiring alt text is enabled in preferences, then hydtate
+      // check if requiring alt text is enabled in preferences, then hydrate
       if (
         hasProp(v, 'requireAltTextEnabled') &&
         typeof v.requireAltTextEnabled === 'boolean'

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -166,7 +166,7 @@ export const ComposePost = observer(function ComposePost({
 
       if (
         store.preferences.requireAltTextEnabled &&
-        gallery.images.some(image => image.altText.trim() === "")
+        gallery.images.some(image => image.altText.trim() === '')
       ) {
         setError('One or more images is missing alt text')
         return

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -164,6 +164,14 @@ export const ComposePost = observer(function ComposePost({
         return
       }
 
+      if (
+        store.preferences.requireAltTextEnabled &&
+        gallery.images.some(image => image.altText.trim() === "")
+      ) {
+        setError('One or more images is missing alt text')
+        return
+      }
+
       setIsProcessing(true)
 
       let createdPost

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -156,19 +156,14 @@ export const ComposePost = observer(function ComposePost({
       if (isProcessing || rt.graphemeLength > MAX_GRAPHEME_LENGTH) {
         return
       }
+      if (store.preferences.requireAltTextEnabled && gallery.needsAltText) {
+        return
+      }
 
       setError('')
 
       if (rt.text.trim().length === 0 && gallery.isEmpty) {
         setError('Did you want to say anything?')
-        return
-      }
-
-      if (
-        store.preferences.requireAltTextEnabled &&
-        gallery.images.some(image => image.altText.trim() === '')
-      ) {
-        setError('One or more images is missing alt text')
         return
       }
 
@@ -228,8 +223,14 @@ export const ComposePost = observer(function ComposePost({
   )
 
   const canPost = useMemo(
-    () => graphemeLength <= MAX_GRAPHEME_LENGTH,
-    [graphemeLength],
+    () =>
+      graphemeLength <= MAX_GRAPHEME_LENGTH &&
+      (!store.preferences.requireAltTextEnabled || !gallery.needsAltText),
+    [
+      graphemeLength,
+      store.preferences.requireAltTextEnabled,
+      gallery.needsAltText,
+    ],
   )
   const selectTextInputPlaceholder = replyTo ? 'Write your reply' : `What's up?`
 
@@ -290,6 +291,20 @@ export const ComposePost = observer(function ComposePost({
             <Text style={pal.text}>{processingState}</Text>
           </View>
         ) : undefined}
+        {store.preferences.requireAltTextEnabled && gallery.needsAltText && (
+          <View style={[styles.reminderLine, pal.viewLight]}>
+            <View style={styles.errorIcon}>
+              <FontAwesomeIcon
+                icon="exclamation"
+                style={{color: colors.red4}}
+                size={10}
+              />
+            </View>
+            <Text style={[pal.text, s.flex1]}>
+              One or more images is missing alt text.
+            </Text>
+          </View>
+        )}
         {error !== '' && (
           <View style={styles.errorLine}>
             <View style={styles.errorIcon}>
@@ -422,6 +437,15 @@ const styles = StyleSheet.create({
     paddingHorizontal: 8,
     paddingVertical: 6,
     marginVertical: 6,
+  },
+  reminderLine: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    borderRadius: 6,
+    marginHorizontal: 15,
+    paddingHorizontal: 8,
+    paddingVertical: 6,
+    marginBottom: 6,
   },
   errorIcon: {
     borderWidth: 1,

--- a/src/view/com/util/forms/ToggleButton.tsx
+++ b/src/view/com/util/forms/ToggleButton.tsx
@@ -5,18 +5,21 @@ import {Button, ButtonType} from './Button'
 import {useTheme} from 'lib/ThemeContext'
 import {choose} from 'lib/functions'
 import {colors} from 'lib/styles'
+import {TypographyVariant} from 'lib/ThemeContext'
 
 export function ToggleButton({
   type = 'default-light',
   label,
   isSelected,
   style,
+  labelType,
   onPress,
 }: {
   type?: ButtonType
   label: string
   isSelected: boolean
   style?: StyleProp<ViewStyle>
+  labelType?: TypographyVariant
   onPress?: () => void
 }) {
   const theme = useTheme()
@@ -143,7 +146,7 @@ export function ToggleButton({
           />
         </View>
         {label === '' ? null : (
-          <Text type="button" style={[labelStyle, styles.label]}>
+          <Text type={labelType || 'button'} style={[labelStyle, styles.label]}>
             {label}
           </Text>
         )}

--- a/src/view/screens/Settings.tsx
+++ b/src/view/screens/Settings.tsx
@@ -330,15 +330,20 @@ export const SettingsScreen = withAuthRequired(
           </TouchableOpacity>
 
           <View style={styles.spacer20} />
+
           <Text type="xl-bold" style={[pal.text, styles.heading]}>
             Accessibility
           </Text>
-          <ToggleButton
-            type="default-light"
-            label="Require alt text on images"
-            isSelected={store.preferences.requireAltTextEnabled}
-            onPress={store.preferences.toggleRequireAltTextEnabled}
-          />
+          <View style={[pal.view, styles.toggleCard]}>
+            <ToggleButton
+              type="default-light"
+              label="Require alt text on images"
+              labelType="lg"
+              isSelected={store.preferences.requireAltTextEnabled}
+              onPress={store.preferences.toggleRequireAltTextEnabled}
+            />
+          </View>
+
           <View style={styles.spacer20} />
 
           <Text type="xl-bold" style={[pal.text, styles.heading]}>
@@ -642,6 +647,11 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     paddingVertical: 20,
     paddingHorizontal: 18,
+    marginBottom: 1,
+  },
+  toggleCard: {
+    paddingVertical: 8,
+    paddingHorizontal: 6,
     marginBottom: 1,
   },
   avi: {

--- a/src/view/screens/Settings.tsx
+++ b/src/view/screens/Settings.tsx
@@ -331,6 +331,17 @@ export const SettingsScreen = withAuthRequired(
 
           <View style={styles.spacer20} />
           <Text type="xl-bold" style={[pal.text, styles.heading]}>
+            Accessibility
+          </Text>
+          <ToggleButton
+            type="default-light"
+            label="Require alt text on images"
+            isSelected={store.preferences.requireAltTextEnabled}
+            onPress={store.preferences.toggleRequireAltTextEnabled}
+          />
+          <View style={styles.spacer20} />
+
+          <Text type="xl-bold" style={[pal.text, styles.heading]}>
             Appearance
           </Text>
           <View>


### PR DESCRIPTION
Supersedes #913. Closes #907 

Builds on the PR by updating the UI of the toggle

<img width="395" alt="CleanShot 2023-06-27 at 10 05 53@2x" src="https://github.com/bluesky-social/social-app/assets/1270099/6d73ac83-32bc-4e20-893d-88ba8a5423c7">
