### PR TITLE
Revert change to the cancel button in the composer

### DIFF
--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -230,9 +230,9 @@ export const ComposePost = observer(function ComposePost({
             onPress={hackfixOnClose}
             onAccessibilityEscape={hackfixOnClose}
             accessibilityRole="button"
-            accessibilityLabel="Discard"
+            accessibilityLabel="Cancel"
             accessibilityHint="Closes post composer and discards post draft">
-            <Text style={[pal.link, s.f18, styles.discard]}>Discard</Text>
+            <Text style={[pal.link, s.f18]}>Cancel</Text>
           </TouchableOpacity>
           <View style={s.flex1} />
           {isProcessing ? (
@@ -384,9 +384,6 @@ const styles = StyleSheet.create({
     paddingBottom: 10,
     paddingHorizontal: 20,
     height: 55,
-  },
-  discard: {
-    color: colors.red3,
   },
   postBtn: {
     borderRadius: 20,


### PR DESCRIPTION
I misunderstood the scope of https://github.com/bluesky-social/social-app/pull/912

The bulk of that PR was clearing up the copy around the confirm modal, which switched it to this (I'm good with this):

<img width="528" alt="CleanShot 2023-06-27 at 10 42 14@2x" src="https://github.com/bluesky-social/social-app/assets/1270099/534e92aa-9ef1-4e9e-8aaa-60ec3754d566">

However it also changed the cancel button to this:

<img width="283" alt="CleanShot 2023-06-27 at 10 43 27@2x" src="https://github.com/bluesky-social/social-app/assets/1270099/304cb6dc-58d9-4043-9106-695fccac91d7">

And this PR changes the cancel button back to this:

<img width="312" alt="CleanShot 2023-06-27 at 10 43 03@2x" src="https://github.com/bluesky-social/social-app/assets/1270099/6e6995db-8c15-4dd9-9d7f-e0202840b843">

There are two concerns about the red discard label:

1. Color: we have to be really conservative about button/link colors because visual divergence draws focus. Red is, in particular, extremely attention-grabbing and we don't want to use it unless it's the primary action.
2. Label: I'm more flexible on this but generally I try to use "Cancel" as the standard way to stop an action because folks are trained around it and it therefore scans quickly. The discard modal was previously botching that by giving an ambiguous confirm/cancel prompt, but there's no ambiguity here. Using "Discard" for this button label may have stronger continuity but I think it degrades how scannable the options are. Again -- not overly locked into this but that's my argument.