### PR TITLE
Make sidebar avatar keyboard-clickable.

### DIFF
--- a/src/view/shell/desktop/LeftNav.tsx
+++ b/src/view/shell/desktop/LeftNav.tsx
@@ -40,7 +40,10 @@ import {router} from '../../../routes'
 const ProfileCard = observer(() => {
   const store = useStores()
   return (
-    <Link href={`/profile/${store.me.handle}`} style={styles.profileCard}>
+    <Link
+      href={`/profile/${store.me.handle}`}
+      style={styles.profileCard}
+      asAnchor>
       <UserAvatar avatar={store.me.avatar} size={64} />
     </Link>
   )


### PR DESCRIPTION
This is a fix for https://github.com/bluesky-social/social-app/issues/641 which simply adds `asAnchor` to the sidebar avatar link, making it an `a` element instead of a div, and thus also keyboard-clickable.