### PR TITLE
fix: stabilize `minimalShellMode` toggling by introducing modified thresholds

### DIFF
--- a/src/lib/hooks/useOnMainScroll.ts
+++ b/src/lib/hooks/useOnMainScroll.ts
@@ -5,6 +5,8 @@ import {s} from 'lib/styles'
 import {isDesktopWeb} from 'platform/detection'
 
 const DY_LIMIT = isDesktopWeb ? 30 : 10
+const DY_LIMIT_UP = DY_LIMIT
+const DY_LIMIT_DOWN = 150
 
 export type OnScrollCb = (
   event: NativeSyntheticEvent<NativeScrollEvent>,
@@ -22,9 +24,6 @@ export function useOnMainScroll(
         const y = event.nativeEvent.contentOffset.y
         const dy = y - (lastY.current || 0)
         lastY.current = y
-
-        const DY_LIMIT_UP = DY_LIMIT * 1.5
-        const DY_LIMIT_DOWN = DY_LIMIT
 
         if (!store.shell.minimalShellMode && dy > DY_LIMIT_DOWN) {
           store.shell.setMinimalShellMode(true)

--- a/src/lib/hooks/useOnMainScroll.ts
+++ b/src/lib/hooks/useOnMainScroll.ts
@@ -23,12 +23,12 @@ export function useOnMainScroll(
         const dy = y - (lastY.current || 0)
         lastY.current = y
 
-        if (!store.shell.minimalShellMode && y > 10 && dy > DY_LIMIT) {
+        const DY_LIMIT_UP = DY_LIMIT * 1.5
+        const DY_LIMIT_DOWN = DY_LIMIT
+
+        if (!store.shell.minimalShellMode && dy > DY_LIMIT_DOWN) {
           store.shell.setMinimalShellMode(true)
-        } else if (
-          store.shell.minimalShellMode &&
-          (y <= 10 || dy < DY_LIMIT * -1)
-        ) {
+        } else if (store.shell.minimalShellMode && dy < DY_LIMIT_UP * -1) {
           store.shell.setMinimalShellMode(false)
         }
 


### PR DESCRIPTION
This PR resolves #930.

## Problem
`minimalShellMode` keeps toggling when the current `dy` value is inverse of the previous one.

## Solution
`DY_LIMIT_UP` and `DY_LIMIT_DOWN` thresholds have been introduced to stabilize the toggling of minimalShellMode. The value of `DY_LIMIT_UP` is the same as `DY_LIMIT`, while `DY_LIMIT_DOWN` is set to `150`.

Upon investigation, it was discovered that toggling occurs when `dy` values fall roughly between `-150` and `150`. Thus, `DY_LIMIT_DOWN` has been set to `150`, taking into consideration that the scroll down velocity is usually faster.

## Test
The changes have been manually verified.