### PR TITLE
Use consistent font weight for repost count

### DIFF
--- a/src/view/com/util/post-ctrls/RepostButton.web.tsx
+++ b/src/view/com/util/post-ctrls/RepostButton.web.tsx
@@ -60,7 +60,7 @@ export const RepostButton = ({
         {typeof repostCount !== 'undefined' ? (
           <Text
             testID="repostCount"
-            type={isReposted ? 'md-bold' : 'md-medium'}
+            type={isReposted ? 'md-bold' : 'md'}
             style={styles.repostCount}>
             {repostCount ?? 0}
           </Text>


### PR DESCRIPTION
This fixes a web UI bug where the repost count is rendering with `font-weight: 500` (the `md-medium` style) while the reply and like counts get `font-weight: 400`.

<img width="1206" alt="image" src="https://github.com/bluesky-social/social-app/assets/6905903/f6fb1acc-d786-4e6e-8295-a76ae0417c71">
