### PR TITLE
Enhance URL parsing in regex to exclude non-Latin alphabets at the end

### DIFF
--- a/__tests__/lib/string.test.ts
+++ b/__tests__/lib/string.test.ts
@@ -50,6 +50,16 @@ describe('detectLinkables', () => {
     'punctuation https://foo.com, https://bar.com/whatever; https://baz.com.',
     'parenthetical (https://foo.com)',
     'except for https://foo.com/thing_(cool)',
+    'https://foo.com이',
+    'https://foo.com/barは',
+    'https://foo.com/bar的',
+    'https://foo.com/barは(https://foo.com이)',
+    '@foo가',
+    '@fooは',
+    '@foo的',
+    '@foo가(https://foo.com이)',
+    '@fooは(https://foo.com/barは)',
+    '@foo的(https://foo.com/bar的)',
   ]
   const outputs = [
     ['no linkable'],
@@ -114,6 +124,16 @@ describe('detectLinkables', () => {
     ],
     ['parenthetical (', {link: 'https://foo.com'}, ')'],
     ['except for ', {link: 'https://foo.com/thing_(cool)'}],
+    [{link: 'https://foo.com'}, '이'],
+    [{link: 'https://foo.com/bar'}, 'は'],
+    [{link: 'https://foo.com/bar'}, '的'],
+    [{link: 'https://foo.com/bar'}, 'は(', {link: 'https://foo.com'}, '이)'],
+    [{link: '@foo'}, '가'],
+    [{link: '@foo'}, 'は'],
+    [{link: '@foo'}, '的'],
+    [{link: '@foo'}, '가(', {link: 'https://foo.com'}, '이)'],
+    [{link: '@foo'}, 'は(', {link: 'https://foo.com/bar'}, 'は)'],
+    [{link: '@foo'}, '的(', {link: 'https://foo.com/bar'}, '的)'],
   ]
   it('correctly handles a set of text inputs', () => {
     for (let i = 0; i < inputs.length; i++) {

--- a/src/lib/strings/rich-text-detection.ts
+++ b/src/lib/strings/rich-text-detection.ts
@@ -6,7 +6,8 @@ interface DetectedLink {
 type DetectedLinkable = string | DetectedLink
 export function detectLinkables(text: string): DetectedLinkable[] {
   const re =
-    /((^|\s|\()@[a-z0-9.-]*)|((^|\s|\()https?:\/\/[\S]+)|((^|\s|\()(?<domain>[a-z][a-z0-9]*(\.[a-z0-9]+)+)[\S]*)/gi
+  /((^|\s|()@[a-z0-9.-]+)|((^|\s|()https?:\/\/[\w.-]+[a-z0-9])|((^|\s|()(?<domain>[a-z][a-z0-9]*(.[a-z0-9]+)+)[a-z0-9]))))/gi
+
   const segments = []
   let match
   let start = 0


### PR DESCRIPTION
## Description

The existing regex in function `detectLinkables` is unfortunately matches non-Latin characters if they are attached to the URL without a space. This behaviour leads to unexpected results, when dealing with Asian languages (e.g. can't open external links or userename).

Because Asian languages are mostly has a grammatical elements, which are appended some character to the end of a noun without a space.

<img width="815" alt="스크린샷 2023-07-03 오후 5 41 48" src="https://github.com/bluesky-social/social-app/assets/11853918/0fee3a93-a755-4b09-b1de-6f6c840228b3">

To solve this issue, I modified the previous regex to ensure URLs end with Latin alphabet characters or numbers. The updated regex is as follows:

```plain
/((^|\s|()@[a-z0-9.-]+)|((^|\s|()https?:\/\/[\w.-]+[a-z0-9])|((^|\s|()(?<domain>[a-z][a-z0-9]*(.[a-z0-9]+)+)[a-z0-9]))))/gi
```

<img width="1376" alt="스크린샷 2023-07-03 오후 5 42 24" src="https://github.com/bluesky-social/social-app/assets/11853918/99eead8d-59e0-45b3-a2f2-8eb6fd0ec3f8">

This regex will help to correctly parse URLs in contexts with mixed language usage.

Thanks!
