### PR TITLE
Fix: let images on desktop web take more vertical space

### DIFF
--- a/src/view/com/util/post-embeds/index.tsx
+++ b/src/view/com/util/post-embeds/index.tsx
@@ -28,6 +28,7 @@ import QuoteEmbed from './QuoteEmbed'
 import {AutoSizedImage} from '../images/AutoSizedImage'
 import {CustomFeedEmbed} from './CustomFeedEmbed'
 import {ListEmbed} from './ListEmbed'
+import {isDesktopWeb} from 'platform/detection'
 
 type Embed =
   | AppBskyEmbedRecord.View
@@ -198,7 +199,7 @@ const styles = StyleSheet.create({
   },
   singleImage: {
     borderRadius: 8,
-    maxHeight: 500,
+    maxHeight: isDesktopWeb ? 1000 : 500,
   },
   extOuter: {
     borderWidth: 1,


### PR DESCRIPTION
Our max height for post images currently seems to work for most cases on mobile, but is clipping on Web. This PR just bumps the max height on desktop so that clipping happens less frequently.