### PR TITLE
Fix: re-add the scroll boundary to avoid minimal shell at top of screen

### DIFF
--- a/src/lib/hooks/useOnMainScroll.ts
+++ b/src/lib/hooks/useOnMainScroll.ts
@@ -6,6 +6,7 @@ import {isDesktopWeb} from 'platform/detection'
 
 const DY_LIMIT_UP = isDesktopWeb ? 30 : 10
 const DY_LIMIT_DOWN = isDesktopWeb ? 150 : 10
+const Y_LIMIT = 10
 
 export type OnScrollCb = (
   event: NativeSyntheticEvent<NativeScrollEvent>,
@@ -24,9 +25,16 @@ export function useOnMainScroll(
         const dy = y - (lastY.current || 0)
         lastY.current = y
 
-        if (!store.shell.minimalShellMode && dy > DY_LIMIT_DOWN) {
+        if (
+          !store.shell.minimalShellMode &&
+          dy > DY_LIMIT_DOWN &&
+          y > Y_LIMIT
+        ) {
           store.shell.setMinimalShellMode(true)
-        } else if (store.shell.minimalShellMode && dy < DY_LIMIT_UP * -1) {
+        } else if (
+          store.shell.minimalShellMode &&
+          (dy < DY_LIMIT_UP * -1 || y <= Y_LIMIT)
+        ) {
           store.shell.setMinimalShellMode(false)
         }
 


### PR DESCRIPTION
In https://github.com/bluesky-social/social-app/pull/942 we changed thresholds depending on the platform to avoid the dancy header issue with minimal shell mode. The minimum `y` threshold also got dropped, but this fails with iOS because the scroll bounce causes a `dy` that retriggers minimal shell mode.

This PR restores that minimum `y`