### PR TITLE
[APP-728] Fix reply-root reference (fixes thread muting)

### DIFF
--- a/src/state/models/content/post-thread-item.ts
+++ b/src/state/models/content/post-thread-item.ts
@@ -51,6 +51,7 @@ export class PostThreadItemModel {
   get uri() {
     return this.post.uri
   }
+
   get parentUri() {
     return this.postRecord?.reply?.parent.uri
   }

--- a/src/state/models/feeds/post.ts
+++ b/src/state/models/feeds/post.ts
@@ -76,8 +76,8 @@ export class PostsFeedItemModel {
   }
 
   get rootUri(): string {
-    if (typeof this.reply?.root.uri === 'string') {
-      return this.reply.root.uri
+    if (typeof this.postRecord?.reply?.root.uri === 'string') {
+      return this.postRecord?.reply?.root.uri
     }
     return this.post.uri
   }


### PR DESCRIPTION
Turns out we got the reply root URI reference wrong, which caused the thread mute button to apply to the current post instead of the root of the thread. This fixes that.