### PR TITLE
[APP-729] Replace the ImageHider blurring effect with a simpler and more reliable card

### DIFF
--- a/src/view/com/util/moderation/ImageHider.tsx
+++ b/src/view/com/util/moderation/ImageHider.tsx
@@ -9,13 +9,11 @@ export function ImageHider({
   testID,
   moderation,
   style,
-  containerStyle,
   children,
 }: React.PropsWithChildren<{
   testID?: string
   moderation: ModerationBehavior
   style?: StyleProp<ViewStyle>
-  containerStyle?: StyleProp<ViewStyle>
 }>) {
   const pal = usePalette('default')
   const [override, setOverride] = React.useState(false)
@@ -39,9 +37,9 @@ export function ImageHider({
   }
 
   return (
-    <View style={[styles.container, containerStyle]}>
+    <View testID={testID} style={style}>
       {override ? (
-        <View testID={testID} style={[style]}>
+        <View>
           <Pressable
             onPress={onPressHide}
             style={[styles.hideBtn, pal.viewLight]}
@@ -74,10 +72,6 @@ export function ImageHider({
 }
 
 const styles = StyleSheet.create({
-  container: {
-    position: 'relative',
-    marginBottom: 10,
-  },
   overrideContainer: {
     paddingHorizontal: 8,
     paddingTop: 8,
@@ -90,6 +84,7 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
     aspectRatio: isDesktopWeb ? 2 : 1.5,
+    marginBottom: 10,
   },
   coverOpen: {
     borderRadius: 8,

--- a/src/view/com/util/moderation/ImageHider.tsx
+++ b/src/view/com/util/moderation/ImageHider.tsx
@@ -72,7 +72,7 @@ const styles = StyleSheet.create({
     gap: 8,
     alignItems: 'center',
     paddingHorizontal: isDesktopWeb ? 24 : 20,
-    paddingVertical: isDesktopWeb ? 24 : 18,
+    paddingVertical: isDesktopWeb ? 20 : 18,
   },
   flex1: {
     flex: 1,

--- a/src/view/com/util/moderation/ImageHider.tsx
+++ b/src/view/com/util/moderation/ImageHider.tsx
@@ -4,6 +4,8 @@ import {usePalette} from 'lib/hooks/usePalette'
 import {Text} from '../text/Text'
 import {ModerationBehavior, ModerationBehaviorCode} from 'lib/labeling/types'
 import {isDesktopWeb} from 'platform/detection'
+import {FontAwesomeIcon} from '@fortawesome/react-native-fontawesome'
+import {FontAwesomeIconStyle} from '@fortawesome/react-native-fontawesome'
 
 export function ImageHider({
   testID,
@@ -17,11 +19,8 @@ export function ImageHider({
 }>) {
   const pal = usePalette('default')
   const [override, setOverride] = React.useState(false)
-  const onPressShow = React.useCallback(() => {
-    setOverride(true)
-  }, [setOverride])
-  const onPressHide = React.useCallback(() => {
-    setOverride(false)
+  const onPressToggle = React.useCallback(() => {
+    setOverride(v => !v)
   }, [setOverride])
 
   if (moderation.behavior === ModerationBehaviorCode.Hide) {
@@ -38,73 +37,44 @@ export function ImageHider({
 
   return (
     <View testID={testID} style={style}>
-      {override ? (
-        <View>
-          <Pressable
-            onPress={onPressHide}
-            style={[styles.hideBtn, pal.viewLight]}
-            accessibilityLabel="Hide image"
-            accessibilityHint="">
-            <Text type="xl-bold" style={pal.link}>
-              Hide
-            </Text>
-          </Pressable>
-          {children}
-        </View>
-      ) : (
-        <View style={[styles.cover, pal.viewLight]}>
-          <Pressable
-            onPress={onPressShow}
-            style={[styles.showBtn, pal.view]}
-            accessibilityLabel="Show image"
-            accessibilityHint="">
-            <Text type="xl" style={pal.text}>
-              {moderation.reason || 'Content warning'}
-            </Text>
-            <Text type="xl-bold" style={pal.link}>
-              Show
-            </Text>
-          </Pressable>
-        </View>
-      )}
+      <View style={[styles.cover, pal.viewLight]}>
+        <Pressable
+          onPress={onPressToggle}
+          style={[styles.toggleBtn]}
+          accessibilityLabel="Show image"
+          accessibilityHint="">
+          <FontAwesomeIcon
+            icon={override ? 'eye' : ['far', 'eye-slash']}
+            size={24}
+            style={pal.text as FontAwesomeIconStyle}
+          />
+          <Text type="lg" style={pal.text}>
+            {moderation.reason || 'Content warning'}
+          </Text>
+          <View style={styles.flex1} />
+          <Text type="xl-bold" style={pal.link}>
+            {override ? 'Hide' : 'Show'}
+          </Text>
+        </Pressable>
+      </View>
+      {override && children}
     </View>
   )
 }
 
 const styles = StyleSheet.create({
-  overrideContainer: {
-    paddingHorizontal: 8,
-    paddingTop: 8,
-    paddingBottom: 2,
-    borderRadius: 12,
-    borderWidth: 1,
-  },
   cover: {
     borderRadius: 8,
-    justifyContent: 'center',
-    alignItems: 'center',
-    aspectRatio: isDesktopWeb ? 2 : 1.5,
-    marginBottom: 10,
+    marginTop: 4,
   },
-  coverOpen: {
-    borderRadius: 8,
-    justifyContent: 'center',
-    alignItems: 'center',
-    paddingVertical: 8,
-  },
-  showBtn: {
+  toggleBtn: {
     flexDirection: 'row',
     gap: 8,
-    paddingHorizontal: 18,
-    paddingVertical: 14,
-    borderRadius: 24,
-  },
-  hideBtn: {
-    flexDirection: 'row',
-    justifyContent: 'center',
     alignItems: 'center',
-    gap: 8,
-    paddingVertical: 10,
-    borderRadius: 8,
+    paddingHorizontal: isDesktopWeb ? 24 : 20,
+    paddingVertical: isDesktopWeb ? 24 : 18,
+  },
+  flex1: {
+    flex: 1,
   },
 })

--- a/src/view/com/util/moderation/ImageHider.tsx
+++ b/src/view/com/util/moderation/ImageHider.tsx
@@ -2,9 +2,8 @@ import React from 'react'
 import {Pressable, StyleProp, StyleSheet, View, ViewStyle} from 'react-native'
 import {usePalette} from 'lib/hooks/usePalette'
 import {Text} from '../text/Text'
-import {BlurView} from '../BlurView'
 import {ModerationBehavior, ModerationBehaviorCode} from 'lib/labeling/types'
-import {isAndroid} from 'platform/detection'
+import {isDesktopWeb} from 'platform/detection'
 
 export function ImageHider({
   testID,
@@ -41,48 +40,34 @@ export function ImageHider({
 
   return (
     <View style={[styles.container, containerStyle]}>
-      <View testID={testID} style={style}>
-        {children}
-      </View>
       {override ? (
-        <Pressable
-          onPress={onPressHide}
-          style={[styles.hideBtn, pal.view]}
-          accessibilityLabel="Hide image"
-          accessibilityHint="Rehides the image">
-          <Text type="xl-bold" style={pal.link}>
-            Hide
-          </Text>
-        </Pressable>
+        <View testID={testID} style={[style]}>
+          <Pressable
+            onPress={onPressHide}
+            style={[styles.hideBtn, pal.viewLight]}
+            accessibilityLabel="Hide image"
+            accessibilityHint="">
+            <Text type="xl-bold" style={pal.link}>
+              Hide
+            </Text>
+          </Pressable>
+          {children}
+        </View>
       ) : (
-        <>
-          {isAndroid ? (
-            /* android has an issue that breaks the blurview */
-            /* see https://github.com/Kureev/react-native-blur/issues/486 */
-            <View style={[pal.viewLight, styles.overlay, styles.coverView]} />
-          ) : (
-            <BlurView
-              style={[styles.overlay, styles.blurView]}
-              blurType="light"
-              blurAmount={100}
-              reducedTransparencyFallbackColor="white"
-            />
-          )}
-          <View style={[styles.overlay, styles.info]}>
-            <Pressable
-              onPress={onPressShow}
-              style={[styles.showBtn, pal.view]}
-              accessibilityLabel="Show image"
-              accessibilityHint="Shows image hidden based on your moderation settings">
-              <Text type="xl" style={pal.text}>
-                {moderation.reason || 'Content warning'}
-              </Text>
-              <Text type="xl-bold" style={pal.link}>
-                Show
-              </Text>
-            </Pressable>
-          </View>
-        </>
+        <View style={[styles.cover, pal.viewLight]}>
+          <Pressable
+            onPress={onPressShow}
+            style={[styles.showBtn, pal.view]}
+            accessibilityLabel="Show image"
+            accessibilityHint="">
+            <Text type="xl" style={pal.text}>
+              {moderation.reason || 'Content warning'}
+            </Text>
+            <Text type="xl-bold" style={pal.link}>
+              Show
+            </Text>
+          </Pressable>
+        </View>
       )}
     </View>
   )
@@ -93,22 +78,24 @@ const styles = StyleSheet.create({
     position: 'relative',
     marginBottom: 10,
   },
-  overlay: {
-    position: 'absolute',
-    left: 0,
-    top: 0,
-    right: 0,
-    bottom: 0,
+  overrideContainer: {
+    paddingHorizontal: 8,
+    paddingTop: 8,
+    paddingBottom: 2,
+    borderRadius: 12,
+    borderWidth: 1,
   },
-  blurView: {
+  cover: {
     borderRadius: 8,
-  },
-  coverView: {
-    borderRadius: 8,
-  },
-  info: {
     justifyContent: 'center',
     alignItems: 'center',
+    aspectRatio: isDesktopWeb ? 2 : 1.5,
+  },
+  coverOpen: {
+    borderRadius: 8,
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingVertical: 8,
   },
   showBtn: {
     flexDirection: 'row',
@@ -118,11 +105,11 @@ const styles = StyleSheet.create({
     borderRadius: 24,
   },
   hideBtn: {
-    position: 'absolute',
-    left: 8,
-    bottom: 20,
-    paddingHorizontal: 8,
-    paddingVertical: 6,
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+    gap: 8,
+    paddingVertical: 10,
     borderRadius: 8,
   },
 })


### PR DESCRIPTION
The existing ImageHider is using a blurring effect which has some issues

- On firefox it's inconsistent about actually covering the full image
- It's kind of an eye-grabbing visual that draws attention when viewed over the shoulder
- The way it's applied causes the element to be rather large
- The "Hide" element is often mispositioned

This PR replaces it with something much simpler and more reliable

|Before (covered)|Before (uncovered)|After (covered)|After (uncovered)|
|-|-|-|-|
|<img width="597" alt="CleanShot 2023-07-03 at 17 56 08@2x" src="https://github.com/bluesky-social/social-app/assets/1270099/4ceaac7f-4609-4068-8a5a-f4f49cf47544">|<img width="604" alt="CleanShot 2023-07-03 at 17 56 29@2x" src="https://github.com/bluesky-social/social-app/assets/1270099/f353abf4-d50e-4c2d-8999-a46d90fb7faa">|<img width="610" alt="CleanShot 2023-07-03 at 17 56 51@2x" src="https://github.com/bluesky-social/social-app/assets/1270099/9c7ad680-ae60-429c-a060-eef9f084f1df">|<img width="602" alt="CleanShot 2023-07-03 at 17 58 23@2x" src="https://github.com/bluesky-social/social-app/assets/1270099/90efd784-705a-40e3-bcbb-9895e11571ac">|

