### PR TITLE
[971] Adding ViewHeader to Notifications desktop

### DIFF
--- a/src/view/com/notifications/Feed.tsx
+++ b/src/view/com/notifications/Feed.tsx
@@ -155,7 +155,7 @@ export const Feed = observer(function Feed({
           onEndReachedThreshold={0.6}
           onScroll={onScroll}
           scrollEventThrottle={100}
-          contentContainerStyle={s.contentContainer}
+          contentContainerStyle={[s.contentContainer, styles.containerStyle]}
         />
       ) : null}
     </View>
@@ -168,4 +168,5 @@ const styles = StyleSheet.create({
   },
   feedFooter: {paddingTop: 20},
   emptyState: {paddingVertical: 40},
+  containerStyle: {borderLeftWidth: 0, borderRightWidth: 0},
 })

--- a/src/view/com/util/Views.web.tsx
+++ b/src/view/com/util/Views.web.tsx
@@ -72,9 +72,9 @@ export const FlatList = React.forwardRef(function <ItemT>(
     <RNFlatList
       ref={ref}
       contentContainerStyle={[
-        contentContainerStyle,
         pal.border,
         styles.contentContainer,
+        contentContainerStyle,
       ]}
       style={style}
       contentOffset={contentOffset}

--- a/src/view/screens/Notifications.tsx
+++ b/src/view/screens/Notifications.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import {FlatList, View} from 'react-native'
+import {FlatList, StyleSheet, View} from 'react-native'
 import {useFocusEffect} from '@react-navigation/native'
 import {observer} from 'mobx-react-lite'
 import {
@@ -17,6 +17,9 @@ import {useTabFocusEffect} from 'lib/hooks/useTabFocusEffect'
 import {s} from 'lib/styles'
 import {useAnalytics} from 'lib/analytics/analytics'
 import {isWeb} from 'platform/detection'
+import {isDesktopWeb} from 'platform/detection'
+import {usePalette} from 'lib/hooks/usePalette'
+import {CenteredView} from 'view/com/util/Views'
 
 type Props = NativeStackScreenProps<
   NotificationsTabNavigatorParams,
@@ -24,6 +27,7 @@ type Props = NativeStackScreenProps<
 >
 export const NotificationsScreen = withAuthRequired(
   observer(({}: Props) => {
+    const pal = usePalette('default')
     const store = useStores()
     const [onMainScroll, isScrolledDown, resetMainScroll] =
       useOnMainScroll(store)
@@ -92,8 +96,14 @@ export const NotificationsScreen = withAuthRequired(
       store.me.notifications.hasNewLatest &&
       !store.me.notifications.isRefreshing
     return (
-      <View testID="notificationsScreen" style={s.hContentRegion}>
-        <ViewHeader title="Notifications" canGoBack={false} />
+      <CenteredView
+        testID="notificationsScreen"
+        style={[
+          s.hContentRegion,
+          pal.border,
+          isDesktopWeb ? styles.desktopContainer : pal.viewLight,
+        ]}>
+        <ViewHeader title="Notifications" showOnDesktop canGoBack={false} />
         <InvitedUsers />
         <Feed
           view={store.me.notifications}
@@ -109,7 +119,14 @@ export const NotificationsScreen = withAuthRequired(
             minimalShellMode={true}
           />
         )}
-      </View>
+      </CenteredView>
     )
   }),
 )
+
+const styles = StyleSheet.create({
+  desktopContainer: {
+    borderLeftWidth: 1,
+    borderRightWidth: 1,
+  },
+})


### PR DESCRIPTION
As clearly stated in https://github.com/bluesky-social/social-app/issues/971, we are missing a ViewHeader in Notifications page on desktop.

Because of the many hard-coded styles in some common layout components, I needed to change some stuff to be able to override those styles like order of the applied styles.

Before:
<img width="618" alt="image" src="https://github.com/bluesky-social/social-app/assets/26525137/67363945-8079-487e-885f-0e9fe4fa9352">

After:
<img width="612" alt="image" src="https://github.com/bluesky-social/social-app/assets/26525137/6d8d48bf-4971-40c8-81ff-f2b941097071">
