### PR TITLE
Fixes vertical alignment in feed tab bar when emoji present in feed names

### DIFF
--- a/src/view/com/pager/TabBar.tsx
+++ b/src/view/com/pager/TabBar.tsx
@@ -109,6 +109,7 @@ const styles = isDesktopWeb
         paddingHorizontal: 10,
         borderBottomWidth: 3,
         borderBottomColor: 'transparent',
+        justifyContent: 'center'
       },
     })
   : StyleSheet.create({
@@ -129,5 +130,6 @@ const styles = isDesktopWeb
         paddingHorizontal: isMobileWeb ? 8 : 0,
         borderBottomWidth: 3,
         borderBottomColor: 'transparent',
+        justifyContent: 'center'
       },
     })


### PR DESCRIPTION
The tab bar items need `justify-content: center` on them or else they can appear unaligned when a feed name has an emoji character in it.

![image](https://github.com/bluesky-social/social-app/assets/185041/2c296308-c8f3-4c49-bed8-d19ac1037cee)

Please test this before deploying, this was an off-the-cuff PR I made by playing with Chrome Dev Tools, I haven't run the webapp locally.

See also: https://bsky.app/profile/aendra.bsky.social/post/3jzpdnkpmss2t