### PR TITLE
Fix missing post text in noscript post view

### DIFF
--- a/bskyweb/templates/post.html
+++ b/bskyweb/templates/post.html
@@ -43,6 +43,6 @@
   <p id="bsky_display_name">{{ postView.Author.DisplayName }}</p>
   <p id="bsky_handle">{{ postView.Author.Handle }}</p>
   <p id="bsky_did">{{ postView.Author.Did }}</p>
-  <p id="bsky_post_text">{{ postView.Record.Text }}</p>
+  <p id="bsky_post_text">{{ postView.Record.Val.Text }}</p>
 </div>
 {%- endblock %}


### PR DESCRIPTION
The Go generated post page is missing the post text due to an incorrect variable name. The variable is correct in the meta tags.