### PR TITLE
[APP-736] Clarify hate-group moderation as it's currently used

### DIFF
--- a/src/lib/labeling/const.ts
+++ b/src/lib/labeling/const.ts
@@ -67,8 +67,9 @@ export const CONFIGURABLE_LABEL_GROUPS: Record<
   },
   hate: {
     id: 'hate',
-    title: 'Political Hate-Groups',
-    warning: 'Hate',
+    title: 'Hate Group Iconography',
+    subtitle: 'Images of terror groups, articles covering events, etc',
+    warning: 'Hate Groups',
     values: ['icon-kkk', 'icon-nazi', 'icon-intolerant', 'behavior-intolerant'],
   },
   spam: {

--- a/src/lib/labeling/const.ts
+++ b/src/lib/labeling/const.ts
@@ -68,7 +68,7 @@ export const CONFIGURABLE_LABEL_GROUPS: Record<
   hate: {
     id: 'hate',
     title: 'Hate Group Iconography',
-    subtitle: 'Images of terror groups, articles covering events, etc',
+    subtitle: 'Images of terror groups, articles covering events, etc.',
     warning: 'Hate Groups',
     values: ['icon-kkk', 'icon-nazi', 'icon-intolerant', 'behavior-intolerant'],
   },


### PR DESCRIPTION
Changes the "Hate Group" content filter to be more clear about how we're using it:

<img width="405" alt="CleanShot 2023-07-06 at 15 16 08@2x" src="https://github.com/bluesky-social/social-app/assets/1270099/411f36ab-b5dd-4fe3-9e03-852c85e8868f">
