### PR TITLE
Bluesky's link cards are frequently using the og:twitter metas

### DIFF
--- a/src/lib/link-meta/html.ts
+++ b/src/lib/link-meta/html.ts
@@ -43,16 +43,16 @@ export const extractHtmlMeta = ({
       case 'title':
       case 'og:title':
       case 'twitter:title':
-        res.title = propValue?.trim()
+        res.title = res.title || propValue?.trim()
         break
       case 'description':
       case 'og:description':
       case 'twitter:description':
-        res.description = propValue?.trim()
+        res.description = res.description || propValue?.trim()
         break
       case 'og:image':
       case 'twitter:image':
-        res.image = propValue?.trim()
+        res.image = res.image || propValue?.trim()
         break
     }
   }


### PR DESCRIPTION
Bluesky's link cards pick multiple meta properties from the html for the title, description and image. The current implementation is frequently using the og:twitter data (usually the last metas in the html), which is odd. This PR makes it stop at the first hit.