### PR TITLE
fix RendererLoader.Abs

### DIFF
--- a/bskyweb/cmd/bskyweb/renderer.go
+++ b/bskyweb/cmd/bskyweb/renderer.go
@@ -23,13 +23,9 @@ func NewRendererLoader(prefix string, fs *embed.FS) pongo2.TemplateLoader {
 		fs:     fs,
 	}
 }
-func (l *RendererLoader) Abs(_, name string) string {
-	// TODO: remove this workaround
-	// Figure out why this method is being called
-	// twice on template names resulting in a failure to resolve
-	// the template name.
-	if filepath.HasPrefix(name, l.prefix) {
-		return name
+func (l *RendererLoader) Abs(base, name string) string {
+	if base != "" {
+		return filepath.Join(filepath.Dir(base), name)
 	}
 	return filepath.Join(l.prefix, name)
 }


### PR DESCRIPTION
When evaluating `extends` tag, [pongo2](https://github.com/flosch/pongo2) package's `resolveFilename` and `FromFile` are called, and in both cases, the `Abs` method of `TemplateLoader` is invoked ([ref](https://github.com/flosch/pongo2/blob/c84aecb5fa79a9c0feec284a7bf4f0536c6a6e99/tags_extends.go#L26-L30)).
If there are no existing workarounds, the problem is that the `l.prefix` is always being joined due to the `Abs` called again inside `FromFile` for the path "template/base.html" obtained from the result of `resolveFilename`.

I think a solution here is to join the `l.prefix` only when the argument `base` given to `Abs` is empty, and in other cases, join the directory name obtained from `base`.