### PR TITLE
handle failed custom feeds on home screen

### DIFF
--- a/src/view/screens/Home.tsx
+++ b/src/view/screens/Home.tsx
@@ -44,9 +44,7 @@ export const HomeScreen = withAuthRequired(
 
       const feeds = []
       for (const feed of pinned) {
-        const model = new PostsFeedModel(store, 'custom', {
-          feed: feed.uri,
-        })
+        const model = new PostsFeedModel(store, 'custom', {feed: feed.uri})
         model.setup()
         feeds.push(model)
       }

--- a/src/view/screens/Home.tsx
+++ b/src/view/screens/Home.tsx
@@ -4,6 +4,7 @@ import {useFocusEffect, useIsFocused} from '@react-navigation/native'
 import {AppBskyFeedGetFeed as GetCustomFeed} from '@atproto/api'
 import {observer} from 'mobx-react-lite'
 import useAppState from 'react-native-appstate-hook'
+import isEqual from 'lodash.isequal'
 import {NativeStackScreenProps, HomeTabNavigatorParams} from 'lib/routes/types'
 import {PostsFeedModel} from 'state/models/feeds/posts'
 import {withAuthRequired} from 'view/com/auth/withAuthRequired'
@@ -35,12 +36,15 @@ export const HomeScreen = withAuthRequired(
     const pagerRef = React.useRef<PagerRef>(null)
     const [selectedPage, setSelectedPage] = React.useState(0)
     const [customFeeds, setCustomFeeds] = React.useState<PostsFeedModel[]>([])
-    const [isInitialized, setIsInitialized] = React.useState(false)
+    const [requestedCustomFeeds, setRequestedCustomFeeds] = React.useState<string[]>([])
 
     React.useEffect(() => {
-      if (isInitialized) return
-
       const {pinned} = store.me.savedFeeds
+
+      if (isEqual(pinned.map(p => p.uri), requestedCustomFeeds)) {
+        // no changes
+        return
+      }
 
       const feeds = []
       for (const feed of pinned) {
@@ -50,15 +54,15 @@ export const HomeScreen = withAuthRequired(
       }
       pagerRef.current?.setPage(0)
       setCustomFeeds(feeds)
-      setIsInitialized(true)
+      setRequestedCustomFeeds(pinned.map(p => p.uri))
     }, [
       store,
       store.me.savedFeeds.pinned,
       customFeeds,
       setCustomFeeds,
       pagerRef,
-      isInitialized,
-      setIsInitialized,
+      requestedCustomFeeds,
+      setRequestedCustomFeeds,
     ])
 
     useFocusEffect(

--- a/src/view/screens/Home.tsx
+++ b/src/view/screens/Home.tsx
@@ -36,12 +36,19 @@ export const HomeScreen = withAuthRequired(
     const pagerRef = React.useRef<PagerRef>(null)
     const [selectedPage, setSelectedPage] = React.useState(0)
     const [customFeeds, setCustomFeeds] = React.useState<PostsFeedModel[]>([])
-    const [requestedCustomFeeds, setRequestedCustomFeeds] = React.useState<string[]>([])
+    const [requestedCustomFeeds, setRequestedCustomFeeds] = React.useState<
+      string[]
+    >([])
 
     React.useEffect(() => {
       const {pinned} = store.me.savedFeeds
 
-      if (isEqual(pinned.map(p => p.uri), requestedCustomFeeds)) {
+      if (
+        isEqual(
+          pinned.map(p => p.uri),
+          requestedCustomFeeds,
+        )
+      ) {
         // no changes
         return
       }


### PR DESCRIPTION
Noticed that if the `getFeed` method throws an exception, or doesn't return data, the `isEqual` check will fail and the `useEffect` hook will run indefinitely. I was getting a max stack size error in dev, and I assume this would cause issues in production though I haven't replicated.

Since we don't await `model.setup()` here, I'm using `isInitialized` to note just that we've set up the models and don't need to run the effect again.