### PR TITLE
adds additional reason for reporting an account profile

### DIFF
--- a/src/view/com/modals/report/ReportAccount.tsx
+++ b/src/view/com/modals/report/ReportAccount.tsx
@@ -123,6 +123,19 @@ const SelectIssue = ({
           </View>
         ),
       },
+      {
+        key: ComAtprotoModerationDefs.REASONVIOLATION,
+        label: (
+          <View>
+            <Text style={pal.text} type="md-bold">
+              Account handle, display name or description contains terms that violate community standards.
+            </Text>
+            <Text style={pal.textLight}>
+              Violation; terms used violate community standards
+            </Text>
+          </View>
+        ),
+      },
     ],
     [pal],
   )


### PR DESCRIPTION
After spelunking in the code a bit, this seems like an existing solution to the app UI that allows people to submit offensive accounts ( handles, display names, etc ) for moderation.

This does not handle the separate issue of when users initially create a seemingly inoffensive account and then change it later, etc. This just enshrines offensive account-specific language as a reason for reporting an account.