### PR TITLE
[APP-773] Change waitlist explainer copy

### DIFF
--- a/src/view/com/auth/SplashScreen.web.tsx
+++ b/src/view/com/auth/SplashScreen.web.tsx
@@ -5,7 +5,6 @@ import {TextLink} from '../util/Link'
 import {ErrorBoundary} from 'view/com/util/ErrorBoundary'
 import {s, colors} from 'lib/styles'
 import {usePalette} from 'lib/hooks/usePalette'
-import {useStores} from 'state/index'
 import {CenteredView} from '../util/Views'
 import {isMobileWeb} from 'platform/detection'
 
@@ -17,11 +16,6 @@ export const SplashScreen = ({
   onPressCreateAccount: () => void
 }) => {
   const pal = usePalette('default')
-  const store = useStores()
-
-  const onPressWaitlist = React.useCallback(() => {
-    store.shell.openModal({name: 'waitlist'})
-  }, [store])
 
   return (
     <CenteredView style={[styles.container, pal.view]}>
@@ -59,21 +53,6 @@ export const SplashScreen = ({
               <Text style={[pal.text, styles.btnLabel]}>Sign In</Text>
             </TouchableOpacity>
           </View>
-          <Text
-            type="xl"
-            style={[styles.notice, pal.textLight]}
-            lineHeight={1.3}>
-            Bluesky will launch soon.{' '}
-            <TouchableOpacity
-              onPress={onPressWaitlist}
-              // TODO: web accessibility
-              accessibilityRole="button">
-              <Text type="xl" style={pal.link}>
-                Join the waitlist
-              </Text>
-            </TouchableOpacity>{' '}
-            to try the beta before it's publicly available.
-          </Text>
         </ErrorBoundary>
       </View>
       <Footer />

--- a/src/view/com/auth/create/Step2.tsx
+++ b/src/view/com/auth/create/Step2.tsx
@@ -53,7 +53,7 @@ export const Step2 = observer(({model}: {model: CreateAccountModel}) => {
             accessibilityHint="Opens Bluesky waitlist form">
             <Text style={pal.link}>Join the waitlist</Text>
           </TouchableWithoutFeedback>{' '}
-          to try the beta before it's publicly available.
+          to receive an invite when seats are available.
         </Text>
       ) : (
         <>

--- a/src/view/com/modals/Waitlist.tsx
+++ b/src/view/com/modals/Waitlist.tsx
@@ -19,7 +19,7 @@ import {useTheme} from 'lib/ThemeContext'
 import {ErrorMessage} from '../util/error/ErrorMessage'
 import {cleanError} from 'lib/strings/errors'
 
-export const snapPoints = ['80%']
+export const snapPoints = ['60%']
 
 export function Component({}: {}) {
   const pal = usePalette('default')
@@ -58,15 +58,17 @@ export function Component({}: {}) {
   }
 
   return (
-    <View
-      style={[styles.container, {backgroundColor: pal.colors.backgroundLight}]}>
+    <View style={[styles.container, pal.view]}>
       <View style={[styles.innerContainer, pal.view]}>
         <Text type="title-xl" style={[styles.title, pal.text]}>
           Join the waitlist
         </Text>
+        <Text type="lg" style={[styles.description, s.bold, pal.text]}>
+          Bluesky uses a invite system to build a healthier community.
+        </Text>
         <Text type="lg" style={[styles.description, pal.text]}>
-          Bluesky will launch soon. Join the waitlist to try the beta before
-          it's publicly available.
+          If you don't know anybody with invites, you can sign up for the
+          waitlist and we'll send you an invite when there are seats available.
         </Text>
         <TextInput
           style={[styles.textInput, pal.borderDark, pal.text, s.mb10, s.mt10]}

--- a/src/view/shell/desktop/RightNav.tsx
+++ b/src/view/shell/desktop/RightNav.tsx
@@ -27,12 +27,7 @@ export const DesktopRightNav = observer(function DesktopRightNav() {
               SANDBOX. Posts and accounts are not permanent.
             </Text>
           </View>
-        ) : (
-          <Text type="md" style={[pal.textLight, styles.messageLine]}>
-            Welcome to Bluesky! This is a beta application that's still in
-            development.
-          </Text>
-        )}
+        ) : undefined}
         <View style={[s.flexRow]}>
           <TextLink
             type="md"


### PR DESCRIPTION
This PR updates the waitlist copy to explain why we use invite codes.

<img width="400" alt="CleanShot 2023-07-17 at 15 08 54@2x" src="https://github.com/bluesky-social/social-app/assets/1270099/0436d4b4-ab7c-4bac-aca0-5902133320b5">
<img width="410" alt="CleanShot 2023-07-17 at 15 09 08@2x" src="https://github.com/bluesky-social/social-app/assets/1270099/45073a6d-95a8-40a4-920b-d5b6d03ac757">
