### PR TITLE
#984 Updating `indexedAt` timestamps

### DIFF
--- a/src/state/models/ui/shell.ts
+++ b/src/state/models/ui/shell.ts
@@ -224,6 +224,7 @@ export class ShellUiModel {
   activeLightbox: ProfileImageLightbox | ImagesLightbox | null = null
   isComposerActive = false
   composerOpts: ComposerOpts | undefined
+  tickEveryMinute = Date.now()
 
   constructor(public rootStore: RootStoreModel) {
     makeAutoObservable(this, {
@@ -231,6 +232,8 @@ export class ShellUiModel {
       rootStore: false,
       hydrate: false,
     })
+
+    this.setupClock()
   }
 
   serialize(): unknown {
@@ -340,5 +343,11 @@ export class ShellUiModel {
   closeComposer() {
     this.isComposerActive = false
     this.composerOpts = undefined
+  }
+
+  setupClock() {
+    setInterval(() => {
+      this.tickEveryMinute = Date.now()
+    }, 60_000)
   }
 }

--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -192,7 +192,7 @@ export const PostThreadItem = observer(function PostThreadItem({
                 <Text type="md" style={[styles.metaItem, pal.textLight]}>
                   &middot;&nbsp;
                   <TimeElapsed timestamp={item.post.indexedAt}>
-                    {({elapsedTime}) => <>{elapsedTime}</>}
+                    {({timeElapsed}) => <>{timeElapsed}</>}
                   </TimeElapsed>
                 </Text>
               </View>

--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -15,7 +15,7 @@ import {PostDropdownBtn} from '../util/forms/DropdownButton'
 import * as Toast from '../util/Toast'
 import {PreviewableUserAvatar} from '../util/UserAvatar'
 import {s} from 'lib/styles'
-import {ago, niceDate} from 'lib/strings/time'
+import {niceDate} from 'lib/strings/time'
 import {sanitizeDisplayName} from 'lib/strings/display-names'
 import {pluralize} from 'lib/strings/helpers'
 import {getTranslatorLink, isPostInLanguage} from '../../../locale/helpers'
@@ -30,6 +30,7 @@ import {PostSandboxWarning} from '../util/PostSandboxWarning'
 import {ErrorMessage} from '../util/error/ErrorMessage'
 import {usePalette} from 'lib/hooks/usePalette'
 import {formatCount} from '../util/numeric/format'
+import {TimeElapsed} from 'view/com/util/TimeElapsed'
 
 const PARENT_REPLY_LINE_LENGTH = 8
 
@@ -189,7 +190,10 @@ export const PostThreadItem = observer(function PostThreadItem({
                   </Text>
                 </Link>
                 <Text type="md" style={[styles.metaItem, pal.textLight]}>
-                  &middot; {ago(item.post.indexedAt)}
+                  &middot;&nbsp;
+                  <TimeElapsed timestamp={item.post.indexedAt}>
+                    {({elapsedTime}) => <>{elapsedTime}</>}
+                  </TimeElapsed>
                 </Text>
               </View>
               <View style={s.flex1} />

--- a/src/view/com/util/PostMeta.tsx
+++ b/src/view/com/util/PostMeta.tsx
@@ -66,12 +66,12 @@ export const PostMeta = observer(function (opts: PostMetaOpts) {
         </Text>
       )}
       <TimeElapsed timestamp={opts.timestamp}>
-        {({elapsedTime}) => (
+        {({timeElapsed}) => (
           <DesktopWebTextLink
             type="md"
             style={pal.textLight}
             lineHeight={1.2}
-            text={elapsedTime}
+            text={timeElapsed}
             accessibilityLabel={niceDate(opts.timestamp)}
             accessibilityHint=""
             href={opts.postHref}

--- a/src/view/com/util/PostMeta.tsx
+++ b/src/view/com/util/PostMeta.tsx
@@ -2,12 +2,13 @@ import React from 'react'
 import {StyleSheet, View} from 'react-native'
 import {Text} from './text/Text'
 import {DesktopWebTextLink} from './Link'
-import {ago, niceDate} from 'lib/strings/time'
+import {niceDate} from 'lib/strings/time'
 import {usePalette} from 'lib/hooks/usePalette'
 import {UserAvatar} from './UserAvatar'
 import {observer} from 'mobx-react-lite'
 import {sanitizeDisplayName} from 'lib/strings/display-names'
 import {isAndroid} from 'platform/detection'
+import {TimeElapsed} from './TimeElapsed'
 
 interface PostMetaOpts {
   authorAvatar?: string
@@ -64,15 +65,19 @@ export const PostMeta = observer(function (opts: PostMetaOpts) {
           &middot;
         </Text>
       )}
-      <DesktopWebTextLink
-        type="md"
-        style={pal.textLight}
-        lineHeight={1.2}
-        text={ago(opts.timestamp)}
-        accessibilityLabel={niceDate(opts.timestamp)}
-        accessibilityHint=""
-        href={opts.postHref}
-      />
+      <TimeElapsed timestamp={opts.timestamp}>
+        {({elapsedTime}) => (
+          <DesktopWebTextLink
+            type="md"
+            style={pal.textLight}
+            lineHeight={1.2}
+            text={elapsedTime}
+            accessibilityLabel={niceDate(opts.timestamp)}
+            accessibilityHint=""
+            href={opts.postHref}
+          />
+        )}
+      </TimeElapsed>
     </View>
   )
 })

--- a/src/view/com/util/TimeElapsed.tsx
+++ b/src/view/com/util/TimeElapsed.tsx
@@ -6,9 +6,9 @@ export function TimeElapsed({
   children,
 }: {
   timestamp: string
-  children: ({elapsedTime}: {elapsedTime: string}) => JSX.Element
+  children: ({timeElapsed}: {timeElapsed: string}) => JSX.Element
 }) {
-  const [elapsedTime, setTimeAgo] = React.useState(ago(timestamp))
+  const [timeElapsed, setTimeAgo] = React.useState(ago(timestamp))
 
   React.useEffect(() => {
     const interval = setInterval(() => {
@@ -18,5 +18,5 @@ export function TimeElapsed({
     return () => clearInterval(interval)
   }, [timestamp, setTimeAgo])
 
-  return children({elapsedTime})
+  return children({timeElapsed})
 }

--- a/src/view/com/util/TimeElapsed.tsx
+++ b/src/view/com/util/TimeElapsed.tsx
@@ -1,22 +1,21 @@
 import React from 'react'
+import {observer} from 'mobx-react-lite'
 import {ago} from 'lib/strings/time'
+import {useStores} from 'state/index'
 
-export function TimeElapsed({
+export const TimeElapsed = observer(function TimeElapsed({
   timestamp,
   children,
 }: {
   timestamp: string
   children: ({timeElapsed}: {timeElapsed: string}) => JSX.Element
 }) {
+  const stores = useStores()
   const [timeElapsed, setTimeAgo] = React.useState(ago(timestamp))
 
   React.useEffect(() => {
-    const interval = setInterval(() => {
-      setTimeAgo(ago(timestamp))
-    }, 60_000)
-
-    return () => clearInterval(interval)
-  }, [timestamp, setTimeAgo])
+    setTimeAgo(ago(timestamp))
+  }, [timestamp, setTimeAgo, stores.shell.tickEveryMinute])
 
   return children({timeElapsed})
-}
+})

--- a/src/view/com/util/TimeElapsed.tsx
+++ b/src/view/com/util/TimeElapsed.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import {ago} from 'lib/strings/time'
+
+export function TimeElapsed({
+  timestamp,
+  children,
+}: {
+  timestamp: string
+  children: ({elapsedTime}: {elapsedTime: string}) => JSX.Element
+}) {
+  const [elapsedTime, setTimeAgo] = React.useState(ago(timestamp))
+
+  React.useEffect(() => {
+    const interval = setInterval(() => {
+      setTimeAgo(ago(timestamp))
+    }, 60_000)
+
+    return () => clearInterval(interval)
+  }, [timestamp, setTimeAgo])
+
+  return children({elapsedTime})
+}


### PR DESCRIPTION
Fixes #984

This PR provides a little util component that updates a "time ago" value based on an initial starting timestamp.

I also considered using a single global `setInterval` in a mobx store — or using an event emitter — and subscribe to tick events, but decided this was simpler. I'm not sure of the perf difference between 100 `setIntervals` and 100 event subscribers, but I'd guess it's not a significant difference. Lmk if y'all disagree ✌️ 