### PR TITLE
#1001 Modal content overflow

### DIFF
--- a/src/view/shell/Composer.web.tsx
+++ b/src/view/shell/Composer.web.tsx
@@ -65,6 +65,8 @@ const styles = StyleSheet.create({
     borderRadius: isMobileWeb ? 0 : 8,
     marginBottom: isMobileWeb ? BOTTOM_BAR_HEIGHT : 0,
     borderWidth: 1,
-    maxHeight: isMobileWeb ? `calc(100% - ${BOTTOM_BAR_HEIGHT}px)` : 'calc(100% - (40px * 2))',
+    maxHeight: isMobileWeb
+      ? `calc(100% - ${BOTTOM_BAR_HEIGHT}px)`
+      : 'calc(100% - (40px * 2))',
   },
 })

--- a/src/view/shell/Composer.web.tsx
+++ b/src/view/shell/Composer.web.tsx
@@ -62,8 +62,8 @@ const styles = StyleSheet.create({
     paddingVertical: 0,
     paddingHorizontal: 2,
     borderRadius: isMobileWeb ? 0 : 8,
-    marginBottom: '10vh',
+    marginBottom: isMobileWeb ? '61px' : 0,
     borderWidth: 1,
-    maxHeight: '85%',
+    maxHeight: isMobileWeb ? 'calc(100% - 61px)' : 'calc(100% - (40px * 2))',
   },
 })

--- a/src/view/shell/Composer.web.tsx
+++ b/src/view/shell/Composer.web.tsx
@@ -5,6 +5,7 @@ import {ComposePost} from '../com/composer/Composer'
 import {ComposerOpts} from 'state/models/ui/shell'
 import {usePalette} from 'lib/hooks/usePalette'
 import {isMobileWeb} from 'platform/detection'
+import {BOTTOM_BAR_HEIGHT} from 'view/shell/bottom-bar/BottomBarStyles'
 
 export const Composer = observer(
   ({
@@ -62,8 +63,8 @@ const styles = StyleSheet.create({
     paddingVertical: 0,
     paddingHorizontal: 2,
     borderRadius: isMobileWeb ? 0 : 8,
-    marginBottom: isMobileWeb ? '61px' : 0,
+    marginBottom: isMobileWeb ? BOTTOM_BAR_HEIGHT : 0,
     borderWidth: 1,
-    maxHeight: isMobileWeb ? 'calc(100% - 61px)' : 'calc(100% - (40px * 2))',
+    maxHeight: isMobileWeb ? `calc(100% - ${BOTTOM_BAR_HEIGHT}px)` : 'calc(100% - (40px * 2))',
   },
 })

--- a/src/view/shell/bottom-bar/BottomBarStyles.tsx
+++ b/src/view/shell/bottom-bar/BottomBarStyles.tsx
@@ -1,8 +1,11 @@
 import {StyleSheet} from 'react-native'
 import {colors} from 'lib/styles'
 
+export const BOTTOM_BAR_HEIGHT = 61
+
 export const styles = StyleSheet.create({
   bottomBar: {
+    height: BOTTOM_BAR_HEIGHT,
     position: 'absolute',
     bottom: 0,
     left: 0,


### PR DESCRIPTION
Fixes #1001 

Seemed to me like based on original the styles that the mobile version here was supposed to fill the screen, so that's what I did. I tried an option with a gutter all the way around the `Composer`, but decided on small devices that it was too scrunched atm.

On desktop, I chose an arbitrary gutter of 40px, lmk if we've got more specific values for this.

Screenshots ordered by increasing screen size:
![Screen Shot 2023-07-18 at 15 13 04](https://github.com/bluesky-social/social-app/assets/4732330/c9f97040-25eb-48ad-9c1e-d135ffba145f)
![Screen Shot 2023-07-18 at 15 13 28](https://github.com/bluesky-social/social-app/assets/4732330/d72ed9c2-7f42-4c88-8e97-4e9a789f37a6)
![Screen Shot 2023-07-18 at 15 13 49](https://github.com/bluesky-social/social-app/assets/4732330/7d055f2a-8d2a-4904-bf41-8243de53e067)
![Screen Shot 2023-07-18 at 15 23 04](https://github.com/bluesky-social/social-app/assets/4732330/03a7fc43-d3b2-477f-ad34-1fddc412424e)
![Screen Shot 2023-07-18 at 15 14 03](https://github.com/bluesky-social/social-app/assets/4732330/35c2e06c-08e7-462c-a8bc-acbb3c2ce494)
