### PR TITLE
Hotfix mobile web styling issues

### DIFF
--- a/src/view/com/pager/TabBar.tsx
+++ b/src/view/com/pager/TabBar.tsx
@@ -117,6 +117,7 @@ const styles = isDesktopWeb
         flex: 1,
         flexDirection: 'row',
         backgroundColor: 'transparent',
+        maxWidth: '100%',
       },
       contentContainer: {
         columnGap: isMobileWeb ? 0 : 20,

--- a/src/view/shell/Composer.web.tsx
+++ b/src/view/shell/Composer.web.tsx
@@ -5,7 +5,8 @@ import {ComposePost} from '../com/composer/Composer'
 import {ComposerOpts} from 'state/models/ui/shell'
 import {usePalette} from 'lib/hooks/usePalette'
 import {isMobileWeb} from 'platform/detection'
-import {BOTTOM_BAR_HEIGHT} from 'view/shell/bottom-bar/BottomBarStyles'
+
+const BOTTOM_BAR_HEIGHT = 61
 
 export const Composer = observer(
   ({

--- a/src/view/shell/bottom-bar/BottomBarStyles.tsx
+++ b/src/view/shell/bottom-bar/BottomBarStyles.tsx
@@ -1,11 +1,8 @@
 import {StyleSheet} from 'react-native'
 import {colors} from 'lib/styles'
 
-export const BOTTOM_BAR_HEIGHT = 61
-
 export const styles = StyleSheet.create({
   bottomBar: {
-    height: BOTTOM_BAR_HEIGHT,
     position: 'absolute',
     bottom: 0,
     left: 0,


### PR DESCRIPTION
Two fixes:

1) Bottom bar size changed:
<img width="305" alt="CleanShot 2023-07-19 at 14 37 22@2x" src="https://github.com/bluesky-social/social-app/assets/8207733/a179200e-70d7-4b79-8c07-b78f0febc5d6">

2) Feeds tab bar was overflowing on mobile web
<img width="316" alt="CleanShot 2023-07-19 at 14 57 11@2x" src="https://github.com/bluesky-social/social-app/assets/8207733/1d3b2e59-e019-4f4d-971a-057d31d3e8b8">
