### PR TITLE
#995 use `asAnchor` on external embeds

### DIFF
--- a/src/view/com/util/Link.tsx
+++ b/src/view/com/util/Link.tsx
@@ -89,12 +89,11 @@ export const Link = observer(function Link({
       <TouchableWithoutFeedback
         testID={testID}
         onPress={onPress}
-        // @ts-ignore web only -prf
-        href={asAnchor ? sanitizeUrl(href) : undefined}
         accessible={accessible}
         accessibilityRole="link"
         {...props}>
-        <View style={style}>
+        {/* @ts-ignore web only -prf */}
+        <View style={style} href={asAnchor ? sanitizeUrl(href) : undefined}>
           {children ? children : <Text>{title || 'link'}</Text>}
         </View>
       </TouchableWithoutFeedback>

--- a/src/view/com/util/post-embeds/index.tsx
+++ b/src/view/com/util/post-embeds/index.tsx
@@ -182,6 +182,7 @@ export function PostEmbeds({
     return (
       <Link
         asAnchor
+        noFeedback
         style={[styles.extOuter, pal.view, pal.border, style]}
         href={link.uri}>
         <ExternalLinkEmbed link={link} />

--- a/src/view/com/util/post-embeds/index.tsx
+++ b/src/view/com/util/post-embeds/index.tsx
@@ -181,9 +181,9 @@ export function PostEmbeds({
 
     return (
       <Link
+        asAnchor
         style={[styles.extOuter, pal.view, pal.border, style]}
-        href={link.uri}
-        noFeedback>
+        href={link.uri}>
         <ExternalLinkEmbed link={link} />
       </Link>
     )


### PR DESCRIPTION
Fixes #995 

We were missing `asAnchor`, which adds an `href` and is converted to a link by `react-native-web`. Also, `TouchableWithoutFeedback` doesn't appear to pass down the `href` prop, but it works when applied to its immediate child, [as suggested here](https://github.com/necolas/react-native-web/issues/1692#issuecomment-668721415).

Looks like there is some prior work done in #750 (reported in #752). I believe this should work for the case of no-feedback-and-cursor-pointer, which mirrors what we have right now. Will follow up on the related work soon 👍 