### PR TITLE
Bump react-native-paste-input; remove hack

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@fortawesome/free-solid-svg-icons": "^6.1.1",
     "@fortawesome/react-native-fontawesome": "^0.3.0",
     "@gorhom/bottom-sheet": "^4.4.7",
-    "@mattermost/react-native-paste-input": "^0.6.0",
+    "@mattermost/react-native-paste-input": "^0.6.4",
     "@miblanchard/react-native-slider": "^2.2.0",
     "@notifee/react-native": "^7.4.0",
     "@react-native-async-storage/async-storage": "^1.17.6",

--- a/patches/@mattermost+react-native-paste-input+0.6.4.patch
+++ b/patches/@mattermost+react-native-paste-input+0.6.4.patch
@@ -51,8 +51,7 @@ index 0000000..8c9c699
 +minAndroidGradlePluginVersion=1.0.0
 diff --git a/node_modules/@mattermost/react-native-paste-input/android/build/intermediates/compile_r_class_jar/debug/R.jar b/node_modules/@mattermost/react-native-paste-input/android/build/intermediates/compile_r_class_jar/debug/R.jar
 new file mode 100644
-index 0000000..c0106e0
-Binary files /dev/null and b/node_modules/@mattermost/react-native-paste-input/android/build/intermediates/compile_r_class_jar/debug/R.jar differ
+index 0000000..e69de29
 diff --git a/node_modules/@mattermost/react-native-paste-input/android/build/intermediates/compile_symbol_list/debug/R.txt b/node_modules/@mattermost/react-native-paste-input/android/build/intermediates/compile_symbol_list/debug/R.txt
 new file mode 100644
 index 0000000..7c9d30e

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -84,16 +84,6 @@ export const ComposePost = observer(function ComposePost({
     [insets, isKeyboardVisible],
   )
 
-  // HACK
-  // there's a bug with @mattermost/react-native-paste-input where if the input
-  // is focused during unmount, an exception will throw (seems that a blur method isn't implemented)
-  // manually blurring before closing gets around that
-  // -prf
-  const hackfixOnClose = useCallback(() => {
-    textInput.current?.blur()
-    onClose()
-  }, [textInput, onClose])
-
   const onPressCancel = useCallback(() => {
     if (graphemeLength > 0 || !gallery.isEmpty) {
       if (store.shell.activeModals.some(modal => modal.name === 'confirm')) {
@@ -105,7 +95,7 @@ export const ComposePost = observer(function ComposePost({
       store.shell.openModal({
         name: 'confirm',
         title: 'Discard draft',
-        onPressConfirm: hackfixOnClose,
+        onPressConfirm: onClose,
         onPressCancel: () => {
           store.shell.closeModal()
         },
@@ -114,9 +104,9 @@ export const ComposePost = observer(function ComposePost({
         confirmBtnStyle: {backgroundColor: colors.red4},
       })
     } else {
-      hackfixOnClose()
+      onClose()
     }
-  }, [store, hackfixOnClose, graphemeLength, gallery])
+  }, [store, onClose, graphemeLength, gallery])
 
   // initial setup
   useEffect(() => {
@@ -205,7 +195,7 @@ export const ComposePost = observer(function ComposePost({
         await store.me.mainFeed.addPostToTop(createdPost.uri)
       }
       onPost?.()
-      hackfixOnClose()
+      onClose()
       Toast.show(`Your ${replyTo ? 'reply' : 'post'} has been published`)
     },
     [
@@ -215,7 +205,7 @@ export const ComposePost = observer(function ComposePost({
       replyTo,
       autocompleteView.knownHandles,
       extLink,
-      hackfixOnClose,
+      onClose,
       onPost,
       quote,
       setExtLink,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3906,12 +3906,12 @@
   dependencies:
     "@lukeed/csprng" "^1.1.0"
 
-"@mattermost/react-native-paste-input@^0.6.0":
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/@mattermost/react-native-paste-input/-/react-native-paste-input-0.6.2.tgz#783779bc60758927781270293f35d6b4f937cd07"
-  integrity sha512-+92KQfHytTdVzKzydkJQetyLy8H91uwCoDxKswJ4+fK4f4zNJpF/10LrHL+/aijcy0vJG+6gUC8zXvyLzv6wCw==
+"@mattermost/react-native-paste-input@^0.6.4":
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/@mattermost/react-native-paste-input/-/react-native-paste-input-0.6.4.tgz#0b51dacc525849c3f8350d43bf7057d17724b9b5"
+  integrity sha512-EJ/CTm97pe7u1GnrUFaVaP5j6i57GHPFpnUDdc+r7tLYa2T4LN0oR09KYbr1INcTMz//MqVMz4GYUVFMMN0Xmw==
   dependencies:
-    semver "7.3.8"
+    semver "7.5.4"
 
 "@miblanchard/react-native-slider@^2.2.0":
   version "2.3.1"
@@ -17609,10 +17609,10 @@ semver@7.3.2:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
   integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
 
-semver@7.3.8, semver@~7.3.2:
-  version "7.3.8"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.8.tgz#07a78feafb3f7b32347d725e33de7e2a2df67798"
-  integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==
+semver@7.5.4:
+  version "7.5.4"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
+  integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
   dependencies:
     lru-cache "^6.0.0"
 
@@ -17630,6 +17630,13 @@ semver@^7.0.0, semver@^7.3.2, semver@^7.3.5, semver@^7.3.7, semver@^7.3.8:
   version "7.5.3"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.3.tgz#161ce8c2c6b4b3bdca6caadc9fa3317a4c4fe88e"
   integrity sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==
+  dependencies:
+    lru-cache "^6.0.0"
+
+semver@~7.3.2:
+  version "7.3.8"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.8.tgz#07a78feafb3f7b32347d725e33de7e2a2df67798"
+  integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==
   dependencies:
     lru-cache "^6.0.0"
 


### PR DESCRIPTION
Bumping `react-native-paste-input` to 0.6.4 to pull in [my fix for the blur issue on unmount](https://github.com/mattermost/react-native-paste-input/pull/20), which had led to a hack that's no longer needed.