### PR TITLE
ALT text entered in the compose dialog is erased when you press "Edit" again

### DIFF
--- a/src/view/com/modals/EditImage.tsx
+++ b/src/view/com/modals/EditImage.tsx
@@ -62,7 +62,7 @@ export const Component = observer(function ({image, gallery}: Props) {
   const [position, setPosition] = useState<Position | undefined>(
     image.attributes.position,
   )
-  const [altText, setAltText] = useState('')
+  const [altText, setAltText] = useState(image?.altText ?? '')
 
   const onFlipHorizontal = useCallback(() => {
     image.flipHorizontal()


### PR DESCRIPTION
### Demo video

https://jam.dev/c/5677d210-5e4f-4941-9af4-0f60f00e482f

---
This code was written and reviewed by GitStart Community. Growing great engineers, one PR at a time.
