### PR TITLE
bskyweb: switch from PDS backend to AppView backend

### DIFF
--- a/bskyweb/cmd/bskyweb/main.go
+++ b/bskyweb/cmd/bskyweb/main.go
@@ -34,22 +34,11 @@ func run(args []string) {
 			Action: serve,
 			Flags: []cli.Flag{
 				&cli.StringFlag{
-					Name:    "pds-host",
-					Usage:   "method, hostname, and port of PDS instance",
-					Value:   "http://localhost:4849",
-					EnvVars: []string{"ATP_PDS_HOST"},
-				},
-				&cli.StringFlag{
-					Name:     "handle",
-					Usage:    "for PDS login",
-					Required: true,
-					EnvVars:  []string{"ATP_AUTH_HANDLE"},
-				},
-				&cli.StringFlag{
-					Name:     "password",
-					Usage:    "for PDS login",
-					Required: true,
-					EnvVars:  []string{"ATP_AUTH_PASSWORD"},
+					Name:  "appview-host",
+					Usage: "method, hostname, and port of PDS instance",
+					Value: "http://localhost:2584",
+					// retain old PDS env var for easy transition
+					EnvVars: []string{"ATP_APPVIEW_HOST", "ATP_PDS_HOST"},
 				},
 				&cli.StringFlag{
 					Name:     "mailmodo-api-key",

--- a/bskyweb/cmd/bskyweb/server.go
+++ b/bskyweb/cmd/bskyweb/server.go
@@ -14,7 +14,6 @@ import (
 	"syscall"
 	"time"
 
-	comatproto "github.com/bluesky-social/indigo/api/atproto"
 	appbsky "github.com/bluesky-social/indigo/api/bsky"
 	cliutil "github.com/bluesky-social/indigo/cmd/gosky/util"
 	"github.com/bluesky-social/indigo/xrpc"
@@ -38,9 +37,7 @@ type Server struct {
 func serve(cctx *cli.Context) error {
 	debug := cctx.Bool("debug")
 	httpAddress := cctx.String("http-address")
-	pdsHost := cctx.String("pds-host")
-	atpHandle := cctx.String("handle")
-	atpPassword := cctx.String("password")
+	appviewHost := cctx.String("appview-host")
 	mailmodoAPIKey := cctx.String("mailmodo-api-key")
 	mailmodoListName := cctx.String("mailmodo-list-name")
 
@@ -50,27 +47,11 @@ func serve(cctx *cli.Context) error {
 	// Mailmodo client.
 	mailmodo := NewMailmodo(mailmodoAPIKey, mailmodoListName)
 
-	// create a new session
-	// TODO: does this work with no auth at all?
+	// create a new session (no auth)
 	xrpcc := &xrpc.Client{
 		Client: cliutil.NewHttpClient(),
-		Host:   pdsHost,
-		Auth: &xrpc.AuthInfo{
-			Handle: atpHandle,
-		},
+		Host:   appviewHost,
 	}
-
-	auth, err := comatproto.ServerCreateSession(context.TODO(), xrpcc, &comatproto.ServerCreateSession_Input{
-		Identifier: xrpcc.Auth.Handle,
-		Password:   atpPassword,
-	})
-	if err != nil {
-		return err
-	}
-	xrpcc.Auth.AccessJwt = auth.AccessJwt
-	xrpcc.Auth.RefreshJwt = auth.RefreshJwt
-	xrpcc.Auth.Did = auth.Did
-	xrpcc.Auth.Handle = auth.Handle
 
 	// httpd
 	var (

--- a/bskyweb/example.dev.env
+++ b/bskyweb/example.dev.env
@@ -1,4 +1,2 @@
 GOLOG_LOG_LEVEL=info
-ATP_PDS_HOST=http://localhost:2583
-ATP_AUTH_HANDLE="admin.test"
-ATP_AUTH_PASSWORD="admin"
+ATP_APPVIEW_HOST=http://localhost:2584

--- a/bskyweb/example.env
+++ b/bskyweb/example.env
@@ -1,4 +1,2 @@
 GOLOG_LOG_LEVEL=info
-ATP_PDS_HOST=https://bsky.social
-ATP_AUTH_HANDLE=TODO
-ATP_AUTH_PASSWORD=TODO
+ATP_APPVIEW_HOST=https://api.bsky.app


### PR DESCRIPTION
Removes XRPC client auth stuff, and just connects to AppView backend, which serves up both profile views and thread views without auth. This is in contrast to the PDS, which requires auth for those endpoints. This will also make stuff Just Work Right with federation.

This fixes part of https://github.com/bluesky-social/social-app/issues/983, though not the labeling part.

Tested locally, against prod appview, and seems to work. Should test in staging as well.

Deploy checklist:

- [ ] add appview config envvar (`ATP_APPVIEW_HOST`) to pulumi config, with per-env appropriate name configs. this isn't a secret value, just config.
- [ ] ensure that bskyweb can punch through ratelimits for appview (might be new work, with the new app-level ratelimit stuff?)