### PR TITLE
:lipstick: Hide Add to List option on own profile

### DIFF
--- a/src/view/com/profile/ProfileHeader.tsx
+++ b/src/view/com/profile/ProfileHeader.tsx
@@ -250,14 +250,15 @@ const ProfileHeaderLoaded = observer(
           label: 'Share',
           onPress: onPressShare,
         },
-        {
-          testID: 'profileHeaderDropdownListAddRemoveBtn',
-          label: 'Add to Lists',
-          onPress: onPressAddRemoveLists,
-        },
       ]
       if (!isMe) {
         items.push({sep: true})
+        // Only add "Add to Lists" on other user's profiles, doesn't make sense to mute my own self!
+        items.push({
+          testID: 'profileHeaderDropdownListAddRemoveBtn',
+          label: 'Add to Lists',
+          onPress: onPressAddRemoveLists,
+        })
         if (!view.viewer.blocking) {
           items.push({
             testID: 'profileHeaderDropdownMuteBtn',


### PR DESCRIPTION
At least right now, the only type of lists we have is `Mute List` and IMO it doesn't make a lot of sense to allow my ownself to be added to a mutelist.

![On other user profile](https://github.com/bluesky-social/social-app/assets/1919066/dee4108c-1e3f-4baa-8c92-b0aedcda8951)
> On other user profile

![On my own profile](https://github.com/bluesky-social/social-app/assets/1919066/4bdeded9-b505-48ea-b2c1-aff9db640c30)
> On my own profile

