### PR TITLE
Add Crimean Tatar as available content language

### DIFF
--- a/src/locale/languages.ts
+++ b/src/locale/languages.ts
@@ -112,7 +112,7 @@ export const LANGUAGES: Language[] = [
   {code3: 'cpf', code2: '', name: 'Creoles and pidgins, French-based'},
   {code3: 'cpp', code2: '', name: 'Creoles and pidgins, Portuguese-based'},
   {code3: 'cre', code2: 'cr', name: 'Cree'},
-  {code3: 'crh', code2: '', name: 'Crimean Tatar; Crimean Turkish'},
+  {code3: 'crh', code2: 'ct', name: 'Crimean Tatar; Crimean Turkish'},
   {code3: 'crp', code2: '', name: 'Creoles and pidgins'},
   {code3: 'csb', code2: '', name: 'Kashubian'},
   {code3: 'cus', code2: '', name: 'Cushitic languages'},


### PR DESCRIPTION
Add a two-letter code to Crimean Tatar language, so it shows up in the list.
There's a large Crimean Tatar community asking this for quite a while.

Note: "ct" for "Crimean Tatar" is not an official ISO_639-1 standard
However, this language code is unassigned in ISO_639-1, so it can be used safely without conflicts with existing codes:

![image](https://github.com/bluesky-social/social-app/assets/1822434/b348934a-6820-4768-9009-46acaf1f0200)

Please support indeginous people of Crimea during this horrible time of Russian occupation. They have experienced multiple ethnic cleansings and are fighting for their language and culture every day in occupation or exile. 

There's also a large Crimean Tatar community on Bluesky asking for this change:
https://bsky.app/profile/mathan.dev/post/3jzwxyx2gpw2g

We need this to build feeds and discovery for new Crimean Tatar users, joining the platform.