### PR TITLE
resolve did before loading feed

### DIFF
--- a/src/view/screens/CustomFeed.tsx
+++ b/src/view/screens/CustomFeed.tsx
@@ -7,7 +7,7 @@ import {CommonNavigatorParams} from 'lib/routes/types'
 import {makeRecordUri} from 'lib/strings/url-helpers'
 import {colors, s} from 'lib/styles'
 import {observer} from 'mobx-react-lite'
-import {FlatList, StyleSheet, View} from 'react-native'
+import {FlatList, StyleSheet, View, ActivityIndicator} from 'react-native'
 import {useStores} from 'state/index'
 import {PostsFeedModel} from 'state/models/feeds/posts'
 import {useCustomFeed} from 'lib/hooks/useCustomFeed'
@@ -39,6 +39,7 @@ import {resolveName} from 'lib/api'
 type Props = NativeStackScreenProps<CommonNavigatorParams, 'CustomFeed'>
 
 export const CustomFeedScreen = observer((props: Props) => {
+  const pal = usePalette('default')
   const store = useStores()
   const {name: handleOrDid} = props.route.params
   const [feedOwnerDid, setFeedOwnerDid] = React.useState<string | undefined>()
@@ -57,7 +58,11 @@ export const CustomFeedScreen = observer((props: Props) => {
 
   return feedOwnerDid ? (
     <CustomFeedScreenInner {...props} feedOwnerDid={feedOwnerDid} />
-  ) : null
+  ) : (
+    <View style={[styles.loading, pal.view]}>
+      <ActivityIndicator size="large" />
+    </View>
+  )
 })
 
 export const CustomFeedScreenInner = withAuthRequired(
@@ -453,5 +458,11 @@ const styles = StyleSheet.create({
   top2: {
     position: 'relative',
     top: 2,
+  },
+  loading: {
+    height: '100%',
+    alignContent: 'center',
+    justifyContent: 'center',
+    paddingBottom: 100,
   },
 })


### PR DESCRIPTION
Fixes #1088

The `Feed` component has a nice skeleton loading state, but handling DID resolution in the main body of the inner component results in a lot of conditionals and updates to allow undefined values (see `PostsFeedModel` and `useCustomFeed` params for example).

Handling it before this component even renders is a simpler data flow, but with the drawback of a small loading state prior to the main feed loading state.

Both loading and error state were lifted from the main post screen.

https://github.com/bluesky-social/social-app/assets/4732330/e0343a39-0bf8-4b1a-8237-7568681e876d

<img width="1492" alt="Screen Shot 2023-08-03 at 11 35 45 AM" src="https://github.com/bluesky-social/social-app/assets/4732330/59c1de4a-ef93-4359-8d2d-3ed45037e8fa">
<img width="562" alt="Screen Shot 2023-08-03 at 11 35 53 AM" src="https://github.com/bluesky-social/social-app/assets/4732330/542bd924-7d25-4a99-b957-3a694d90f276">

