### PR TITLE
Simplify the after-post logic to avoid a UI bug (the "zoomies")

### DIFF
--- a/src/state/models/feeds/posts.ts
+++ b/src/state/models/feeds/posts.ts
@@ -8,7 +8,7 @@ import AwaitLock from 'await-lock'
 import {bundleAsync} from 'lib/async/bundle'
 import {RootStoreModel} from '../root-store'
 import {cleanError} from 'lib/strings/errors'
-import {FeedTuner, FeedViewPostsSlice} from 'lib/api/feed-manip'
+import {FeedTuner} from 'lib/api/feed-manip'
 import {PostsFeedSliceModel} from './posts-slice'
 import {track} from 'lib/analytics/analytics'
 
@@ -286,27 +286,13 @@ export class PostsFeedModel {
   }
 
   /**
-   * Fetches the given post and adds it to the top
-   * Used by the composer to add their new posts
+   * Updates the UI after the user has created a post
    */
-  async addPostToTop(uri: string) {
+  onPostCreated() {
     if (!this.slices.length) {
       return this.refresh()
-    }
-    try {
-      const res = await this.rootStore.agent.app.bsky.feed.getPosts({
-        uris: [uri],
-      })
-      const toPrepend = new PostsFeedSliceModel(
-        this.rootStore,
-        uri,
-        new FeedViewPostsSlice(res.data.posts.map(post => ({post}))),
-      )
-      runInAction(() => {
-        this.slices = [toPrepend].concat(this.slices)
-      })
-    } catch (e) {
-      this.rootStore.log.error('Failed to load post to prepend', {e})
+    } else {
+      this.setHasNewLatest(true)
     }
   }
 

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -163,9 +163,8 @@ export const ComposePost = observer(function ComposePost({
 
       setIsProcessing(true)
 
-      let createdPost
       try {
-        createdPost = await apilib.post(store, {
+        await apilib.post(store, {
           rawText: rt.text,
           replyTo: replyTo?.uri,
           images: gallery.images,
@@ -193,7 +192,7 @@ export const ComposePost = observer(function ComposePost({
         if (replyTo && replyTo.uri) track('Post:Reply')
       }
       if (!replyTo) {
-        await store.me.mainFeed.addPostToTop(createdPost.uri)
+        store.me.mainFeed.onPostCreated()
       }
       onPost?.()
       onClose()


### PR DESCRIPTION
Manipulating the feed's previous posts can trigger runaway scrolling. This PR changes the after-post logic to prompt the user to load rather than immediately showing the post.