### PR TITLE
Fix: dont use profile preview modal on mobile web

### DIFF
--- a/src/view/com/util/UserPreviewLink.tsx
+++ b/src/view/com/util/UserPreviewLink.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import {Pressable, StyleProp, ViewStyle} from 'react-native'
 import {useStores} from 'state/index'
 import {Link} from './Link'
-import {isDesktopWeb} from 'platform/detection'
+import {isWeb} from 'platform/detection'
 import {makeProfileLink} from 'lib/routes/links'
 
 interface UserPreviewLinkProps {
@@ -15,7 +15,7 @@ export function UserPreviewLink(
 ) {
   const store = useStores()
 
-  if (isDesktopWeb) {
+  if (isWeb) {
     return (
       <Link
         href={makeProfileLink(props)}


### PR DESCRIPTION
The profile preview modal now depends on a swipe gesture which web doesnt support. This PR just disables it on mobile web.