### PR TITLE
Fix rendering of feed and list post-embeds (close #1131)

### DIFF
--- a/src/view/com/util/post-embeds/index.tsx
+++ b/src/view/com/util/post-embeds/index.tsx
@@ -57,9 +57,20 @@ export function PostEmbeds({
     )
   }
 
-  // quote post
-  // =
   if (AppBskyEmbedRecord.isView(embed)) {
+    // custom feed embed (i.e. generator view)
+    // =
+    if (AppBskyFeedDefs.isGeneratorView(embed.record)) {
+      return <CustomFeedEmbed record={embed.record} />
+    }
+
+    // list embed (e.g. mute lists; i.e. ListView)
+    if (AppBskyGraphDefs.isListView(embed.record)) {
+      return <ListEmbed item={embed.record} />
+    }
+
+    // quote post
+    // =
     return <MaybeQuoteEmbed embed={embed} style={style} />
   }
 
@@ -117,23 +128,6 @@ export function PostEmbeds({
         </View>
       )
     }
-  }
-
-  // custom feed embed (i.e. generator view)
-  // =
-  if (
-    AppBskyEmbedRecord.isView(embed) &&
-    AppBskyFeedDefs.isGeneratorView(embed.record)
-  ) {
-    return <CustomFeedEmbed record={embed.record} />
-  }
-
-  // list embed (e.g. mute lists; i.e. ListView)
-  if (
-    AppBskyEmbedRecord.isView(embed) &&
-    AppBskyGraphDefs.isListView(embed.record)
-  ) {
-    return <ListEmbed item={embed.record} />
   }
 
   // external link embed


### PR DESCRIPTION
Bug introduced by the switch to the `<MaybeQuoteEmbed>` component which didn't account for the fact that feeds and lists use the same record embed type. This PR restores the rendering of feed and list cards