### PR TITLE
Fix to react-key uniqueness in feeds

### DIFF
--- a/src/lib/api/feed-manip.ts
+++ b/src/lib/api/feed-manip.ts
@@ -17,6 +17,12 @@ export class FeedViewPostsSlice {
 
   constructor(public items: FeedViewPost[] = []) {}
 
+  get _reactKey() {
+    return `slice-${this.rootItem.post.uri}-${
+      this.rootItem.reason?.indexedAt || this.rootItem.post.indexedAt
+    }`
+  }
+
   get uri() {
     if (this.isFlattenedReply) {
       return this.items[1].post.uri

--- a/src/state/models/feeds/posts-slice.ts
+++ b/src/state/models/feeds/posts-slice.ts
@@ -11,7 +11,7 @@ export class PostsFeedSliceModel {
   items: PostsFeedItemModel[] = []
 
   constructor(public rootStore: RootStoreModel, slice: FeedViewPostsSlice) {
-    this._reactKey = `slice-${slice.uri}`
+    this._reactKey = slice._reactKey
     for (let i = 0; i < slice.items.length; i++) {
       this.items.push(
         new PostsFeedItemModel(


### PR DESCRIPTION
Turns out the react key I chose for https://github.com/bluesky-social/social-app/pull/1113 wasn't unique enough (it shows up in profile pages when people repost themselves). This fixes that, unless somebody manages to repost themselves with the exact same timestamp.