### PR TITLE
Add alerts to embeds

### DIFF
--- a/__e2e__/mock-server.ts
+++ b/__e2e__/mock-server.ts
@@ -144,7 +144,7 @@ async function main() {
           await server.mocker.labelProfile('porn', 'porn-profile')
           await server.mocker.labelPost(
             'porn',
-            await server.mocker.createPost('porn-posts', 'porn post'),
+            await server.mocker.createImagePost('porn-posts', 'porn post'),
           )
           await server.mocker.labelPost(
             'porn',
@@ -167,7 +167,7 @@ async function main() {
           await server.mocker.labelProfile('nudity', 'nudity-profile')
           await server.mocker.labelPost(
             'nudity',
-            await server.mocker.createPost('nudity-posts', 'nudity post'),
+            await server.mocker.createImagePost('nudity-posts', 'nudity post'),
           )
           await server.mocker.labelPost(
             'nudity',

--- a/src/lib/moderation.ts
+++ b/src/lib/moderation.ts
@@ -75,3 +75,13 @@ export function getProfileModerationCauses(
     return true
   }) as ModerationCause[]
 }
+
+export function isCauseALabelOnUri(
+  cause: ModerationCause | undefined,
+  uri: string,
+): boolean {
+  if (cause?.type !== 'label') {
+    return false
+  }
+  return cause.label.uri === uri
+}

--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -269,7 +269,10 @@ export const PostThreadItem = observer(function PostThreadItem({
               ) : undefined}
               {item.post.embed && (
                 <ContentHider moderation={item.moderation.embed} style={s.mb10}>
-                  <PostEmbeds embed={item.post.embed} />
+                  <PostEmbeds
+                    embed={item.post.embed}
+                    moderation={item.moderation.embed}
+                  />
                 </ContentHider>
               )}
             </ContentHider>
@@ -428,7 +431,10 @@ export const PostThreadItem = observer(function PostThreadItem({
               ) : undefined}
               {item.post.embed && (
                 <ContentHider style={s.mb10} moderation={item.moderation.embed}>
-                  <PostEmbeds embed={item.post.embed} />
+                  <PostEmbeds
+                    embed={item.post.embed}
+                    moderation={item.moderation.embed}
+                  />
                 </ContentHider>
               )}
               {needsTranslation && (

--- a/src/view/com/post/Post.tsx
+++ b/src/view/com/post/Post.tsx
@@ -267,7 +267,10 @@ const PostLoaded = observer(
               ) : undefined}
               {item.post.embed ? (
                 <ContentHider moderation={item.moderation.embed} style={s.mb10}>
-                  <PostEmbeds embed={item.post.embed} />
+                  <PostEmbeds
+                    embed={item.post.embed}
+                    moderation={item.moderation.embed}
+                  />
                 </ContentHider>
               ) : null}
               {needsTranslation && (

--- a/src/view/com/posts/FeedItem.tsx
+++ b/src/view/com/posts/FeedItem.tsx
@@ -293,7 +293,10 @@ export const FeedItem = observer(function ({
               <ContentHider
                 moderation={item.moderation.embed}
                 style={styles.embed}>
-                <PostEmbeds embed={item.post.embed} />
+                <PostEmbeds
+                  embed={item.post.embed}
+                  moderation={item.moderation.embed}
+                />
               </ContentHider>
             ) : null}
             {needsTranslation && (

--- a/src/view/com/util/post-embeds/QuoteEmbed.tsx
+++ b/src/view/com/util/post-embeds/QuoteEmbed.tsx
@@ -5,6 +5,7 @@ import {
   AppBskyFeedPost,
   AppBskyEmbedImages,
   AppBskyEmbedRecordWithMedia,
+  ModerationUI,
 } from '@atproto/api'
 import {AtUri} from '@atproto/api'
 import {PostMeta} from '../PostMeta'
@@ -13,14 +14,17 @@ import {Text} from '../text/Text'
 import {usePalette} from 'lib/hooks/usePalette'
 import {ComposerOptsQuote} from 'state/models/ui/shell'
 import {PostEmbeds} from '.'
+import {PostAlerts} from '../moderation/PostAlerts'
 import {makeProfileLink} from 'lib/routes/links'
 import {InfoCircleIcon} from 'lib/icons'
 
 export function MaybeQuoteEmbed({
   embed,
+  moderation,
   style,
 }: {
   embed: AppBskyEmbedRecord.View
+  moderation: ModerationUI
   style?: StyleProp<ViewStyle>
 }) {
   const pal = usePalette('default')
@@ -39,6 +43,7 @@ export function MaybeQuoteEmbed({
           text: embed.record.value.text,
           embeds: embed.record.embeds,
         }}
+        moderation={moderation}
         style={style}
       />
     )
@@ -66,9 +71,11 @@ export function MaybeQuoteEmbed({
 
 export function QuoteEmbed({
   quote,
+  moderation,
   style,
 }: {
   quote: ComposerOptsQuote
+  moderation?: ModerationUI
   style?: StyleProp<ViewStyle>
 }) {
   const pal = usePalette('default')
@@ -100,6 +107,9 @@ export function QuoteEmbed({
         postHref={itemHref}
         timestamp={quote.indexedAt}
       />
+      {moderation ? (
+        <PostAlerts moderation={moderation} style={styles.alert} />
+      ) : null}
       {!isEmpty ? (
         <Text type="post-text" style={pal.text} numberOfLines={6}>
           {quote.text}
@@ -139,5 +149,8 @@ const styles = StyleSheet.create({
     paddingVertical: 14,
     paddingHorizontal: 14,
     borderWidth: 1,
+  },
+  alert: {
+    marginBottom: 6,
   },
 })

--- a/src/view/com/util/post-embeds/QuoteEmbed.tsx
+++ b/src/view/com/util/post-embeds/QuoteEmbed.tsx
@@ -116,10 +116,10 @@ export function QuoteEmbed({
         </Text>
       ) : null}
       {AppBskyEmbedImages.isView(imagesEmbed) && (
-        <PostEmbeds embed={imagesEmbed} />
+        <PostEmbeds embed={imagesEmbed} moderation={{}} />
       )}
       {AppBskyEmbedRecordWithMedia.isView(imagesEmbed) && (
-        <PostEmbeds embed={imagesEmbed.media} />
+        <PostEmbeds embed={imagesEmbed.media} moderation={{}} />
       )}
     </Link>
   )


### PR DESCRIPTION
Embeds currently don't have alerts when they should:

<img width="608" alt="CleanShot 2023-08-08 at 12 37 48@2x" src="https://github.com/bluesky-social/social-app/assets/1270099/2de59341-620e-409c-b473-7ead9c7afc0d">
<img width="608" alt="CleanShot 2023-08-08 at 12 34 11@2x" src="https://github.com/bluesky-social/social-app/assets/1270099/dc32b669-ec5e-401d-8592-98a4c0ed4ad0">

This PR fixes that:

<img width="619" alt="CleanShot 2023-08-08 at 12 33 37@2x" src="https://github.com/bluesky-social/social-app/assets/1270099/0be201a5-c0a2-4506-a18c-cc3ecd4de802">

This also applies to a "downgrading" behavior† which applies to self quote posts:

<img width="577" alt="CleanShot 2023-08-08 at 12 45 59@2x" src="https://github.com/bluesky-social/social-app/assets/1270099/2ed204ce-3fff-4eac-ae28-95984c92c9f8">

† Moderation UI "downgrades" from filters & blurs to just alerts for your own content. This is to avoid confusingly absent content, but it's currently a little inconsistent -- it correctly downgrades on quote posts but not on images. I'm going to tweak this behavior a bit, but for now it's useful to get this fix done.