### PR TITLE
wait for list memberships to load before becoming interactive

### DIFF
--- a/src/view/com/lists/ListsList.tsx
+++ b/src/view/com/lists/ListsList.tsx
@@ -1,6 +1,5 @@
 import React, {MutableRefObject} from 'react'
 import {
-  ActivityIndicator,
   RefreshControl,
   StyleProp,
   StyleSheet,
@@ -166,18 +165,6 @@ export const ListsList = observer(
       ],
     )
 
-    const Footer = React.useCallback(
-      () =>
-        listsList.isLoading ? (
-          <View style={styles.feedFooter}>
-            <ActivityIndicator />
-          </View>
-        ) : (
-          <View />
-        ),
-      [listsList],
-    )
-
     return (
       <View testID={testID} style={style}>
         {data.length > 0 && (
@@ -187,7 +174,6 @@ export const ListsList = observer(
             data={data}
             keyExtractor={item => item._reactKey}
             renderItem={renderItemInner}
-            ListFooterComponent={Footer}
             refreshControl={
               <RefreshControl
                 refreshing={isRefreshing}

--- a/src/view/com/modals/ListAddRemoveUser.tsx
+++ b/src/view/com/modals/ListAddRemoveUser.tsx
@@ -42,6 +42,7 @@ export const Component = observer(
       string[]
     >([])
     const [selected, setSelected] = React.useState<string[]>([])
+    const [membershipsLoaded, setMembershipsLoaded] = React.useState(false)
 
     const listsList: ListsListModel = React.useMemo(
       () => new ListsListModel(store, store.me.did),
@@ -58,12 +59,13 @@ export const Component = observer(
           const ids = memberships.memberships.map(m => m.value.list)
           setOriginalSelections(ids)
           setSelected(ids)
+          setMembershipsLoaded(true)
         },
         err => {
           store.log.error('Failed to fetch memberships', {err})
         },
       )
-    }, [memberships, listsList, store, setSelected])
+    }, [memberships, listsList, store, setSelected, setMembershipsLoaded])
 
     const onPressCancel = useCallback(() => {
       store.shell.closeModal()
@@ -107,11 +109,16 @@ export const Component = observer(
         return (
           <Pressable
             testID={`toggleBtn-${list.name}`}
-            style={[styles.listItem, pal.border]}
+            style={[
+              styles.listItem,
+              pal.border,
+              {opacity: membershipsLoaded ? 1 : 0.5},
+            ]}
             accessibilityLabel={`${isSelected ? 'Remove from' : 'Add to'} ${
               list.name
             }`}
             accessibilityHint=""
+            disabled={!membershipsLoaded}
             onPress={() => onToggleSelected(list.uri)}>
             <View style={styles.listItemAvi}>
               <UserAvatar size={40} avatar={list.avatar} />
@@ -132,23 +139,33 @@ export const Component = observer(
                   : sanitizeHandle(list.creator.handle, '@')}
               </Text>
             </View>
-            <View
-              style={
-                isSelected
-                  ? [styles.checkbox, palPrimary.border, palPrimary.view]
-                  : [styles.checkbox, pal.borderDark]
-              }>
-              {isSelected && (
-                <FontAwesomeIcon
-                  icon="check"
-                  style={palInverted.text as FontAwesomeIconStyle}
-                />
-              )}
-            </View>
+            {membershipsLoaded && (
+              <View
+                style={
+                  isSelected
+                    ? [styles.checkbox, palPrimary.border, palPrimary.view]
+                    : [styles.checkbox, pal.borderDark]
+                }>
+                {isSelected && (
+                  <FontAwesomeIcon
+                    icon="check"
+                    style={palInverted.text as FontAwesomeIconStyle}
+                  />
+                )}
+              </View>
+            )}
           </Pressable>
         )
       },
-      [pal, palPrimary, palInverted, onToggleSelected, selected, store.me.did],
+      [
+        pal,
+        palPrimary,
+        palInverted,
+        onToggleSelected,
+        selected,
+        store.me.did,
+        membershipsLoaded,
+      ],
     )
 
     const renderEmptyState = React.useCallback(() => {

--- a/src/view/com/modals/ListAddRemoveUser.tsx
+++ b/src/view/com/modals/ListAddRemoveUser.tsx
@@ -1,6 +1,6 @@
 import React, {useCallback} from 'react'
 import {observer} from 'mobx-react-lite'
-import {Pressable, StyleSheet, View} from 'react-native'
+import {Pressable, StyleSheet, View, ActivityIndicator} from 'react-native'
 import {AppBskyGraphDefs as GraphDefs} from '@atproto/api'
 import {
   FontAwesomeIcon,
@@ -217,6 +217,13 @@ export const Component = observer(
               label="Save Changes"
             />
           )}
+
+          {listsList.isLoading ||
+            (!membershipsLoaded && (
+              <View style={styles.loadingContainer}>
+                <ActivityIndicator />
+              </View>
+            ))}
         </View>
       </View>
     )
@@ -238,6 +245,7 @@ const styles = StyleSheet.create({
     borderTopWidth: 1,
   },
   btns: {
+    position: 'relative',
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'center',
@@ -279,5 +287,12 @@ const styles = StyleSheet.create({
     height: 24,
     borderRadius: 6,
     marginRight: 8,
+  },
+  loadingContainer: {
+    position: 'absolute',
+    top: 10,
+    right: 0,
+    bottom: 0,
+    justifyContent: 'center',
   },
 })

--- a/src/view/com/modals/ListAddRemoveUser.tsx
+++ b/src/view/com/modals/ListAddRemoveUser.tsx
@@ -218,12 +218,11 @@ export const Component = observer(
             />
           )}
 
-          {listsList.isLoading ||
-            (!membershipsLoaded && (
-              <View style={styles.loadingContainer}>
-                <ActivityIndicator />
-              </View>
-            ))}
+          {(listsList.isLoading || !membershipsLoaded) && (
+            <View style={styles.loadingContainer}>
+              <ActivityIndicator />
+            </View>
+          )}
         </View>
       </View>
     )


### PR DESCRIPTION
A small improvement to help address #1081 until we have time to improve the performance of this data fetching.

Adds an improved loading spinner and grays out interactive elements until everything has loaded.

This _removes_ the spinner from the `ListsList` component, which means `ModerationMuteListsScreen` loses it too (the component is reused there). However, the `FlatList` skeleton UI state already obscures the loading spinner and the spinner's disappearance was a little jumpy sometimes anyway. I actually think it's better off without it, but I may be missing an edge case.

https://github.com/bluesky-social/social-app/assets/4732330/28bac020-97a9-4c41-89a5-5eff8fb8689d

For reference, here's what the other load state now looks like:

https://github.com/bluesky-social/social-app/assets/4732330/68974a23-77f2-440d-a6fd-3399fd4c6552