### PR TITLE
Fix issue where small web browsers were being miscategorized as mobile web

### DIFF
--- a/src/platform/detection.ts
+++ b/src/platform/detection.ts
@@ -10,7 +10,7 @@ function hasTouchscreen() {
   if ('maxTouchPoints' in navigator) {
     return navigator.maxTouchPoints > 0
   } else if ('msMaxTouchPoints' in navigator) {
-    // @ts-ignore navigator should exist
+    // @ts-ignore msMaxTouchPoints is nonstandard/deprecated but may exist
     return navigator.msMaxTouchPoints > 0
   } else {
     const mQ = matchMedia?.('(pointer:coarse)')
@@ -35,11 +35,10 @@ export const isAndroid = Platform.OS === 'android'
 export const isNative = isIOS || isAndroid
 export const isWeb = !isNative
 export const isMobileWebMediaQuery = 'only screen and (max-width: 1230px)'
-export const isMobileWeb =
-  isWeb &&
-  // @ts-ignore we know window exists -prf
-  global.window.matchMedia(isMobileWebMediaQuery)?.matches &&
-  hasTouchscreen()
+export const shouldUseMobileLayout = window.matchMedia(
+  isMobileWebMediaQuery,
+)?.matches
+export const isMobileWeb = isWeb && hasTouchscreen() && shouldUseMobileLayout
 export const isDesktopWeb = isWeb && !isMobileWeb
 
 export const deviceLocales = dedupArray(

--- a/src/platform/detection.ts
+++ b/src/platform/detection.ts
@@ -2,6 +2,34 @@ import {Platform} from 'react-native'
 import {getLocales} from 'expo-localization'
 import {dedupArray} from 'lib/functions'
 
+/**
+ * Attempt to ascertain if the agent is a touchscreen device.
+ * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Browser_detection_using_the_user_agent
+ */
+function hasTouchscreen() {
+  if ('maxTouchPoints' in navigator) {
+    return navigator.maxTouchPoints > 0
+  } else if ('msMaxTouchPoints' in navigator) {
+    // @ts-ignore navigator should exist
+    return navigator.msMaxTouchPoints > 0
+  } else {
+    const mQ = matchMedia?.('(pointer:coarse)')
+    if (mQ?.media === '(pointer:coarse)') {
+      return !!mQ.matches
+    } else if ('orientation' in window) {
+      return true // deprecated, but good fallback
+    } else {
+      // Only as a last resort, fall back to user agent sniffing
+      // @ts-ignore navigator should exist
+      const UA = navigator.userAgent
+      return (
+        /\b(BlackBerry|webOS|iPhone|IEMobile)\b/i.test(UA) ||
+        /\b(Android|Windows Phone|iPad|iPod)\b/i.test(UA)
+      )
+    }
+  }
+}
+
 export const isIOS = Platform.OS === 'ios'
 export const isAndroid = Platform.OS === 'android'
 export const isNative = isIOS || isAndroid
@@ -10,7 +38,8 @@ export const isMobileWebMediaQuery = 'only screen and (max-width: 1230px)'
 export const isMobileWeb =
   isWeb &&
   // @ts-ignore we know window exists -prf
-  global.window.matchMedia(isMobileWebMediaQuery)?.matches
+  global.window.matchMedia(isMobileWebMediaQuery)?.matches &&
+  hasTouchscreen()
 export const isDesktopWeb = isWeb && !isMobileWeb
 
 export const deviceLocales = dedupArray(

--- a/src/view/com/auth/SplashScreen.web.tsx
+++ b/src/view/com/auth/SplashScreen.web.tsx
@@ -6,7 +6,7 @@ import {ErrorBoundary} from 'view/com/util/ErrorBoundary'
 import {s, colors} from 'lib/styles'
 import {usePalette} from 'lib/hooks/usePalette'
 import {CenteredView} from '../util/Views'
-import {isMobileWeb} from 'platform/detection'
+import {shouldUseMobileLayout} from 'platform/detection'
 
 export const SplashScreen = ({
   onPressSignin,
@@ -23,14 +23,18 @@ export const SplashScreen = ({
         testID="noSessionView"
         style={[
           styles.containerInner,
-          isMobileWeb && styles.containerInnerMobile,
+          shouldUseMobileLayout && styles.containerInnerMobile,
           pal.border,
         ]}>
         <ErrorBoundary>
-          <Text style={isMobileWeb ? styles.titleMobile : styles.title}>
+          <Text
+            style={shouldUseMobileLayout ? styles.titleMobile : styles.title}>
             Bluesky
           </Text>
-          <Text style={isMobileWeb ? styles.subtitleMobile : styles.subtitle}>
+          <Text
+            style={
+              shouldUseMobileLayout ? styles.subtitleMobile : styles.subtitle
+            }>
             See what's next
           </Text>
           <View testID="signinOrCreateAccount" style={styles.btns}>
@@ -124,7 +128,7 @@ const styles = StyleSheet.create({
     paddingBottom: 30,
   },
   btns: {
-    flexDirection: isMobileWeb ? 'column' : 'row',
+    flexDirection: shouldUseMobileLayout ? 'column' : 'row',
     gap: 20,
     justifyContent: 'center',
     paddingBottom: 40,

--- a/src/view/com/modals/Modal.web.tsx
+++ b/src/view/com/modals/Modal.web.tsx
@@ -4,7 +4,7 @@ import {observer} from 'mobx-react-lite'
 import {useStores} from 'state/index'
 import {usePalette} from 'lib/hooks/usePalette'
 import type {Modal as ModalIface} from 'state/models/ui/shell'
-import {isMobileWeb} from 'platform/detection'
+import {shouldUseMobileLayout} from 'platform/detection'
 
 import * as ConfirmModal from './Confirm'
 import * as EditProfileModal from './EditProfile'
@@ -129,7 +129,7 @@ function Modal({modal}: {modal: ModalIface}) {
           <View
             style={[
               styles.container,
-              isMobileWeb && styles.containerMobile,
+              shouldUseMobileLayout && styles.containerMobile,
               pal.view,
               pal.border,
             ]}>

--- a/src/view/com/pager/TabBar.tsx
+++ b/src/view/com/pager/TabBar.tsx
@@ -3,7 +3,7 @@ import {StyleSheet, View, ScrollView, LayoutChangeEvent} from 'react-native'
 import {Text} from '../util/text/Text'
 import {PressableWithHover} from '../util/PressableWithHover'
 import {usePalette} from 'lib/hooks/usePalette'
-import {isDesktopWeb, isMobileWeb} from 'platform/detection'
+import {isDesktopWeb, isNative} from 'platform/detection'
 import {DraggableScrollView} from './DraggableScrollView'
 
 export interface TabBarProps {
@@ -120,15 +120,15 @@ const styles = isDesktopWeb
         maxWidth: '100%',
       },
       contentContainer: {
-        columnGap: isMobileWeb ? 0 : 20,
-        marginLeft: isMobileWeb ? 0 : 18,
-        paddingRight: isMobileWeb ? 0 : 36,
+        columnGap: !isNative ? 0 : 20,
+        marginLeft: !isNative ? 0 : 18,
+        paddingRight: !isNative ? 0 : 36,
         backgroundColor: 'transparent',
       },
       item: {
         paddingTop: 10,
         paddingBottom: 10,
-        paddingHorizontal: isMobileWeb ? 8 : 0,
+        paddingHorizontal: !isNative ? 8 : 0,
         borderBottomWidth: 3,
         borderBottomColor: 'transparent',
         justifyContent: 'center',

--- a/src/view/com/pager/TabBar.tsx
+++ b/src/view/com/pager/TabBar.tsx
@@ -3,7 +3,7 @@ import {StyleSheet, View, ScrollView, LayoutChangeEvent} from 'react-native'
 import {Text} from '../util/text/Text'
 import {PressableWithHover} from '../util/PressableWithHover'
 import {usePalette} from 'lib/hooks/usePalette'
-import {isDesktopWeb, isNative} from 'platform/detection'
+import {isNative, shouldUseMobileLayout} from 'platform/detection'
 import {DraggableScrollView} from './DraggableScrollView'
 
 export interface TabBarProps {
@@ -78,7 +78,7 @@ export function TabBar({
               hoverStyle={pal.viewLight}
               onPress={() => onPressItem(i)}>
               <Text
-                type={isDesktopWeb ? 'xl-bold' : 'lg-bold'}
+                type={shouldUseMobileLayout ? 'lg-bold' : 'xl-bold'}
                 testID={testID ? `${testID}-${item}` : undefined}
                 style={selected ? pal.text : pal.textLight}>
                 {item}
@@ -91,28 +91,8 @@ export function TabBar({
   )
 }
 
-const styles = isDesktopWeb
+const styles = shouldUseMobileLayout
   ? StyleSheet.create({
-      outer: {
-        flexDirection: 'row',
-        width: 598,
-      },
-      contentContainer: {
-        columnGap: 8,
-        marginLeft: 14,
-        paddingRight: 14,
-        backgroundColor: 'transparent',
-      },
-      item: {
-        paddingTop: 14,
-        paddingBottom: 12,
-        paddingHorizontal: 10,
-        borderBottomWidth: 3,
-        borderBottomColor: 'transparent',
-        justifyContent: 'center',
-      },
-    })
-  : StyleSheet.create({
       outer: {
         flex: 1,
         flexDirection: 'row',
@@ -129,6 +109,26 @@ const styles = isDesktopWeb
         paddingTop: 10,
         paddingBottom: 10,
         paddingHorizontal: !isNative ? 8 : 0,
+        borderBottomWidth: 3,
+        borderBottomColor: 'transparent',
+        justifyContent: 'center',
+      },
+    })
+  : StyleSheet.create({
+      outer: {
+        flexDirection: 'row',
+        width: 598,
+      },
+      contentContainer: {
+        columnGap: 8,
+        marginLeft: 14,
+        paddingRight: 14,
+        backgroundColor: 'transparent',
+      },
+      item: {
+        paddingTop: 14,
+        paddingBottom: 12,
+        paddingHorizontal: 10,
         borderBottomWidth: 3,
         borderBottomColor: 'transparent',
         justifyContent: 'center',

--- a/src/view/com/post-thread/PostThread.tsx
+++ b/src/view/com/post-thread/PostThread.tsx
@@ -20,7 +20,7 @@ import {ComposePrompt} from '../composer/Prompt'
 import {ErrorMessage} from '../util/error/ErrorMessage'
 import {Text} from '../util/text/Text'
 import {s} from 'lib/styles'
-import {isIOS, isDesktopWeb, isMobileWeb} from 'platform/detection'
+import {isIOS, isDesktopWeb, shouldUseMobileLayout} from 'platform/detection'
 import {usePalette} from 'lib/hooks/usePalette'
 import {useSetTitle} from 'lib/hooks/useSetTitle'
 import {useNavigation} from '@react-navigation/native'
@@ -194,7 +194,7 @@ export const PostThread = observer(function PostThread({
             style={[
               styles.bottomBorder,
               pal.border,
-              isMobileWeb && styles.bottomSpacer,
+              shouldUseMobileLayout && styles.bottomSpacer,
             ]}
           />
         )

--- a/src/view/com/util/fab/FABInner.tsx
+++ b/src/view/com/util/fab/FABInner.tsx
@@ -5,7 +5,7 @@ import LinearGradient from 'react-native-linear-gradient'
 import {gradients} from 'lib/styles'
 import {useAnimatedValue} from 'lib/hooks/useAnimatedValue'
 import {useStores} from 'state/index'
-import {isMobileWeb} from 'platform/detection'
+import {shouldUseMobileLayout} from 'platform/detection'
 
 export interface FABProps
   extends ComponentProps<typeof TouchableWithoutFeedback> {
@@ -30,7 +30,11 @@ export const FABInner = observer(({testID, icon, ...props}: FABProps) => {
   return (
     <TouchableWithoutFeedback testID={testID} {...props}>
       <Animated.View
-        style={[styles.outer, isMobileWeb && styles.mobileWebOuter, transform]}>
+        style={[
+          styles.outer,
+          shouldUseMobileLayout && styles.mobileWebOuter,
+          transform,
+        ]}>
         <LinearGradient
           colors={[gradients.blueLight.start, gradients.blueLight.end]}
           start={{x: 0, y: 0}}

--- a/src/view/com/util/load-latest/LoadLatestBtn.web.tsx
+++ b/src/view/com/util/load-latest/LoadLatestBtn.web.tsx
@@ -4,7 +4,7 @@ import {FontAwesomeIcon} from '@fortawesome/react-native-fontawesome'
 import {Text} from '../text/Text'
 import {usePalette} from 'lib/hooks/usePalette'
 import {LoadLatestBtn as LoadLatestBtnMobile} from './LoadLatestBtnMobile'
-import {isMobileWeb} from 'platform/detection'
+import {shouldUseMobileLayout} from 'platform/detection'
 import {HITSLOP_20} from 'lib/constants'
 
 export const LoadLatestBtn = ({
@@ -19,7 +19,7 @@ export const LoadLatestBtn = ({
   minimalShellMode?: boolean
 }) => {
   const pal = usePalette('default')
-  if (isMobileWeb) {
+  if (shouldUseMobileLayout) {
     return (
       <LoadLatestBtnMobile
         onPress={onPress}

--- a/src/view/screens/Home.tsx
+++ b/src/view/screens/Home.tsx
@@ -20,14 +20,20 @@ import {s} from 'lib/styles'
 import {useOnMainScroll} from 'lib/hooks/useOnMainScroll'
 import {useAnalytics} from 'lib/analytics/analytics'
 import {ComposeIcon2} from 'lib/icons'
-import {isDesktopWeb, isMobileWebMediaQuery, isWeb} from 'platform/detection'
+import {
+  isMobileWebMediaQuery,
+  isWeb,
+  shouldUseMobileLayout,
+} from 'platform/detection'
 
 const HEADER_OFFSET_MOBILE = 78
 const HEADER_OFFSET_DESKTOP = 50
-const HEADER_OFFSET = isDesktopWeb
-  ? HEADER_OFFSET_DESKTOP
-  : HEADER_OFFSET_MOBILE
+
 const POLL_FREQ = 30e3 // 30sec
+
+function getHeaderOffset(useMobileLayout: boolean) {
+  return useMobileLayout ? HEADER_OFFSET_MOBILE : HEADER_OFFSET_DESKTOP
+}
 
 type Props = NativeStackScreenProps<HomeTabNavigatorParams, 'Home'>
 export const HomeScreen = withAuthRequired(
@@ -162,7 +168,9 @@ const FeedPage = observer(
     const [onMainScroll, isScrolledDown, resetMainScroll] =
       useOnMainScroll(store)
     const {screen, track} = useAnalytics()
-    const [headerOffset, setHeaderOffset] = React.useState(HEADER_OFFSET)
+    const [headerOffset, setHeaderOffset] = React.useState(
+      getHeaderOffset(shouldUseMobileLayout),
+    )
     const scrollElRef = React.useRef<FlatList>(null)
     const {appState} = useAppState({
       onForeground: () => doPoll(true),
@@ -201,12 +209,10 @@ const FeedPage = observer(
 
     // listens for resize events
     const listenForResize = React.useCallback(() => {
-      // @ts-ignore we know window exists -prf
-      const isMobileWeb = global.window.matchMedia(
-        isMobileWebMediaQuery,
-      )?.matches
       setHeaderOffset(
-        isMobileWeb ? HEADER_OFFSET_MOBILE : HEADER_OFFSET_DESKTOP,
+        getHeaderOffset(
+          global.window.matchMedia(isMobileWebMediaQuery)?.matches,
+        ),
       )
     }, [])
 

--- a/src/view/shell/Composer.web.tsx
+++ b/src/view/shell/Composer.web.tsx
@@ -4,7 +4,7 @@ import {StyleSheet, View} from 'react-native'
 import {ComposePost} from '../com/composer/Composer'
 import {ComposerOpts} from 'state/models/ui/shell'
 import {usePalette} from 'lib/hooks/usePalette'
-import {isMobileWeb} from 'platform/detection'
+import {shouldUseMobileLayout} from 'platform/detection'
 
 const BOTTOM_BAR_HEIGHT = 61
 
@@ -63,10 +63,10 @@ const styles = StyleSheet.create({
     width: '100%',
     paddingVertical: 0,
     paddingHorizontal: 2,
-    borderRadius: isMobileWeb ? 0 : 8,
-    marginBottom: isMobileWeb ? BOTTOM_BAR_HEIGHT : 0,
+    borderRadius: shouldUseMobileLayout ? 0 : 8,
+    marginBottom: shouldUseMobileLayout ? BOTTOM_BAR_HEIGHT : 0,
     borderWidth: 1,
-    maxHeight: isMobileWeb
+    maxHeight: shouldUseMobileLayout
       ? `calc(100% - ${BOTTOM_BAR_HEIGHT}px)`
       : 'calc(100% - (40px * 2))',
   },


### PR DESCRIPTION
Mostly done to fix an issue where currently links don't show as / behave strictly as (no underline, no cursor change) links when the agent's viewport is smaller than 1230px, rather than if it is a mobile device by our best guess. 

Definitely will have some other changes but getting a hopefully more accurate flag in early seems worth it. A less controversial change may be to adjust `Link` to switch based on `isNative` rather than the current `isDesktopWeb` 🤷🏼.

I've been testing locally and things seem to be great after the change, but I've of course got limited context here. Thanks for the opportunity to contribute!