### PR TITLE
More useful block-state information in embeds

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "e2e:run": "detox test --configuration ios.sim.debug --take-screenshots all"
   },
   "dependencies": {
-    "@atproto/api": "^0.6.1",
+    "@atproto/api": "^0.6.3",
     "@bam.tech/react-native-image-resizer": "^3.0.4",
     "@braintree/sanitize-url": "^6.0.2",
     "@expo/html-elements": "^0.4.2",

--- a/src/lib/moderation.ts
+++ b/src/lib/moderation.ts
@@ -18,13 +18,13 @@ export function describeModerationCause(
   }
   if (cause.type === 'blocking') {
     return {
-      name: 'Blocked Author',
+      name: 'User Blocked',
       description: 'You have blocked this user. You cannot view their content.',
     }
   }
   if (cause.type === 'blocked-by') {
     return {
-      name: 'Blocked',
+      name: 'User Blocking You',
       description: 'This user has blocked you. You cannot view their content.',
     }
   }

--- a/src/lib/moderation.ts
+++ b/src/lib/moderation.ts
@@ -18,14 +18,21 @@ export function describeModerationCause(
   }
   if (cause.type === 'blocking') {
     return {
-      name: 'Blocked User',
+      name: 'Blocked Author',
       description: 'You have blocked this user. You cannot view their content.',
     }
   }
   if (cause.type === 'blocked-by') {
     return {
-      name: 'Blocking You',
+      name: 'Blocked',
       description: 'This user has blocked you. You cannot view their content.',
+    }
+  }
+  if (cause.type === 'block-other') {
+    return {
+      name: 'Content Not Available',
+      description:
+        'This content is not available because one of the users involved has blocked the other.',
     }
   }
   if (cause.type === 'muted') {

--- a/src/view/com/modals/ModerationDetails.tsx
+++ b/src/view/com/modals/ModerationDetails.tsx
@@ -29,11 +29,15 @@ export function Component({
     description =
       'Moderator has chosen to set a general warning on the content.'
   } else if (moderation.cause.type === 'blocking') {
-    name = 'Account Blocked'
+    name = 'User Blocked'
     description = 'You have blocked this user. You cannot view their content.'
   } else if (moderation.cause.type === 'blocked-by') {
-    name = 'Account Blocks You'
+    name = 'User Blocks You'
     description = 'This user has blocked you. You cannot view their content.'
+  } else if (moderation.cause.type === 'block-other') {
+    name = 'Content Not Available'
+    description =
+      'This content is not available because one of the users involved has blocked the other.'
   } else if (moderation.cause.type === 'muted') {
     if (moderation.cause.source.type === 'list') {
       const list = moderation.cause.source.list

--- a/src/view/com/util/moderation/ContentHider.tsx
+++ b/src/view/com/util/moderation/ContentHider.tsx
@@ -41,12 +41,23 @@ export function ContentHider({
         onPress={() => {
           if (!moderation.noOverride) {
             setOverride(v => !v)
+          } else {
+            store.shell.openModal({
+              name: 'moderation-details',
+              context: 'content',
+              moderation,
+            })
           }
         }}
         accessibilityRole="button"
         accessibilityHint={override ? 'Hide the content' : 'Show the content'}
         accessibilityLabel=""
-        style={[styles.cover, pal.viewLight]}>
+        style={[
+          styles.cover,
+          moderation.noOverride
+            ? {borderWidth: 1, borderColor: pal.colors.borderDark}
+            : pal.viewLight,
+        ]}>
         <Pressable
           onPress={() => {
             store.shell.openModal({

--- a/yarn.lock
+++ b/yarn.lock
@@ -40,10 +40,10 @@
     tlds "^1.234.0"
     typed-emitter "^2.1.0"
 
-"@atproto/api@^0.6.1":
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/@atproto/api/-/api-0.6.1.tgz#1a4794c4e379f3790dbc1c2cc69e0700c711f634"
-  integrity sha512-Fwp3GxSxy04XCScLNb7gdYuITt3beUPM2gOmAaJJ/c0muvj3BS/lGeeEqHToSMlxyirfPQYiTHDGcDZgo6EpMQ==
+"@atproto/api@^0.6.3":
+  version "0.6.3"
+  resolved "https://registry.yarnpkg.com/@atproto/api/-/api-0.6.3.tgz#2d604897df9098d84f3dfb3bffe1d4859513b1ba"
+  integrity sha512-vgwJn6M4wEyMm/oQKSATO3C0iRUZ/u5LTTl3E/MqV1mrWzvWLVhOqlATw7CDhEdzwJciO83ei72re6skhSp+Zg==
   dependencies:
     "@atproto/common-web" "*"
     "@atproto/uri" "*"


### PR DESCRIPTION
This PR updates how blocks are handled with embeds to give more information about what's going on. It also pulls in an updated SDK which causes QPs with block-states to be filtered from feeds.

There are some active discussions about how aggressive blocking should be -- it is now _extremely_ aggressive, applying to everyone (the third state below) and essentially prunes replies by blocked users from the world. These behaviors are not resolved and will get another design pass in the near future. 

# Blocked by author of quoted post

<img width="416" alt="CleanShot 2023-08-10 at 13 43 16@2x" src="https://github.com/bluesky-social/social-app/assets/1270099/b34e5008-9a79-4b6e-81a4-97e841fbfc28">
<img width="529" alt="CleanShot 2023-08-10 at 13 43 23@2x" src="https://github.com/bluesky-social/social-app/assets/1270099/a1c52723-b2f6-4173-99c1-930648db6a96">

# Blocking author of quoted post

<img width="391" alt="CleanShot 2023-08-10 at 13 43 38@2x" src="https://github.com/bluesky-social/social-app/assets/1270099/b23b3bb0-6d4d-4afd-ab97-2dbd938a6ed1">
<img width="537" alt="CleanShot 2023-08-10 at 13 43 45@2x" src="https://github.com/bluesky-social/social-app/assets/1270099/1dcc6a66-7441-48f0-a42b-da357e990551">

# Author of quoted post or of quote post block each other

<img width="381" alt="CleanShot 2023-08-10 at 13 44 04@2x" src="https://github.com/bluesky-social/social-app/assets/1270099/ddf6629b-218e-4c73-af49-09b0968b24f0">
<img width="526" alt="CleanShot 2023-08-10 at 13 44 33@2x" src="https://github.com/bluesky-social/social-app/assets/1270099/0de6fa88-268e-48e5-ad05-148866707c06">
