### PR TITLE
Require bluesky-social/social-app for .github/workflows/build-and-push-*

### DIFF
--- a/.github/workflows/build-and-push-bskyweb-aws.yaml
+++ b/.github/workflows/build-and-push-bskyweb-aws.yaml
@@ -12,6 +12,7 @@ env:
 
 jobs:
   bskyweb-container-aws:
+    if: github.repository == 'bluesky-social/social-app'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/build-and-push-bskyweb-ghcr.yaml
+++ b/.github/workflows/build-and-push-bskyweb-ghcr.yaml
@@ -14,6 +14,7 @@ env:
 
 jobs:
   bskyweb-container-ghcr:
+    if: github.repository == 'bluesky-social/social-app'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Counterpart: https://github.com/bluesky-social/atproto/pull/1460

This PR runs the actions only for the original `bluesky-social/social-app` repository.

Do not merge if you wish to build and push main branches from other repositories.