### PR TITLE
Fix: close keyboard when viewing the self-label modal

### DIFF
--- a/src/view/com/composer/labels/LabelsBtn.tsx
+++ b/src/view/com/composer/labels/LabelsBtn.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import {StyleSheet} from 'react-native'
+import {Keyboard, StyleSheet} from 'react-native'
 import {observer} from 'mobx-react-lite'
 import {Button} from 'view/com/util/forms/Button'
 import {usePalette} from 'lib/hooks/usePalette'
@@ -7,6 +7,7 @@ import {useStores} from 'state/index'
 import {ShieldExclamation} from 'lib/icons'
 import {FontAwesomeIcon} from '@fortawesome/react-native-fontawesome'
 import {FontAwesomeIconStyle} from '@fortawesome/react-native-fontawesome'
+import {isNative} from 'platform/detection'
 
 export const LabelsBtn = observer(function LabelsBtn({
   labels,
@@ -25,9 +26,14 @@ export const LabelsBtn = observer(function LabelsBtn({
       style={styles.button}
       accessibilityLabel="Content warnings"
       accessibilityHint=""
-      onPress={() =>
+      onPress={() => {
+        if (isNative) {
+          if (Keyboard.isVisible()) {
+            Keyboard.dismiss()
+          }
+        }
         store.shell.openModal({name: 'self-label', labels, onChange})
-      }>
+      }}>
       <ShieldExclamation style={pal.link} size={26} />
       {labels.length > 0 ? (
         <FontAwesomeIcon


### PR DESCRIPTION
The modal was opening behind the keyboard. This fixes that issue.