### PR TITLE
[APP-798] add key to `ProfileCardPills` render method

### DIFF
--- a/src/lib/moderation.ts
+++ b/src/lib/moderation.ts
@@ -92,3 +92,16 @@ export function isCauseALabelOnUri(
   }
   return cause.label.uri === uri
 }
+
+export function getModerationCauseKey(cause: ModerationCause): string {
+  const source =
+    cause.source.type === 'labeler'
+      ? cause.source.labeler.did
+      : cause.source.type === 'list'
+      ? cause.source.list.uri
+      : 'user'
+  if (cause.type === 'label') {
+    return `label:${cause.label.val}:${source}`
+  }
+  return `${cause.type}:${source}`
+}

--- a/src/view/com/profile/ProfileCard.tsx
+++ b/src/view/com/profile/ProfileCard.tsx
@@ -131,7 +131,9 @@ function ProfileCardPills({
       {causes.map(cause => {
         const desc = describeModerationCause(cause, 'account')
         return (
-          <View style={[s.mt5, pal.btn, styles.pill]}>
+          <View
+            style={[s.mt5, pal.btn, styles.pill]}
+            key={moderation.decisions.account.did}>
             <Text type="xs" style={pal.text}>
               {cause?.type === 'label' ? '⚠' : ''}
               {desc.name}

--- a/src/view/com/profile/ProfileCard.tsx
+++ b/src/view/com/profile/ProfileCard.tsx
@@ -19,6 +19,7 @@ import {makeProfileLink} from 'lib/routes/links'
 import {
   describeModerationCause,
   getProfileModerationCauses,
+  getModerationCauseKey,
 } from 'lib/moderation'
 
 export const ProfileCard = observer(
@@ -133,7 +134,7 @@ function ProfileCardPills({
         return (
           <View
             style={[s.mt5, pal.btn, styles.pill]}
-            key={moderation.decisions.account.did}>
+            key={getModerationCauseKey(cause)}>
             <Text type="xs" style={pal.text}>
               {cause?.type === 'label' ? '⚠' : ''}
               {desc.name}


### PR DESCRIPTION
Was getting this error when `ProfileCardPills` was used

```
Warning: Each child in a list should have a unique "key" prop.

Check the render method of `ProfileCardPills`. 
```

This just fixes that.