### PR TITLE
fix prefetching lightbox images

### DIFF
--- a/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.android.tsx
+++ b/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.android.tsx
@@ -17,6 +17,7 @@ import {
   NativeSyntheticEvent,
   NativeMethodsMixin,
 } from 'react-native'
+import {Image} from 'expo-image'
 
 import useImageDimensions from '../../hooks/useImageDimensions'
 import usePanResponder from '../../hooks/usePanResponder'
@@ -40,6 +41,8 @@ type Props = {
   swipeToCloseEnabled?: boolean
   doubleTapToZoomEnabled?: boolean
 }
+
+const AnimatedImage = Animated.createAnimatedComponent(Image)
 
 const ImageItem = ({
   imageSrc,
@@ -128,7 +131,7 @@ const ImageItem = ({
         onScroll,
         onScrollEndDrag,
       })}>
-      <Animated.Image
+      <AnimatedImage
         {...panHandlers}
         source={imageSrc}
         style={imageStylesWithOpacity}

--- a/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.ios.tsx
+++ b/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.ios.tsx
@@ -18,6 +18,7 @@ import {
   NativeSyntheticEvent,
   TouchableWithoutFeedback,
 } from 'react-native'
+import {Image} from 'expo-image'
 
 import useDoubleTapToZoom from '../../hooks/useDoubleTapToZoom'
 import useImageDimensions from '../../hooks/useImageDimensions'
@@ -41,6 +42,8 @@ type Props = {
   swipeToCloseEnabled?: boolean
   doubleTapToZoomEnabled?: boolean
 }
+
+const AnimatedImage = Animated.createAnimatedComponent(Image)
 
 const ImageItem = ({
   imageSrc,
@@ -131,7 +134,7 @@ const ImageItem = ({
           accessibilityRole="image"
           accessibilityLabel={imageSrc.alt}
           accessibilityHint="">
-          <Animated.Image
+          <AnimatedImage
             source={imageSrc}
             style={imageStylesWithOpacity}
             onLoad={() => setLoaded(true)}

--- a/src/view/com/util/post-embeds/index.tsx
+++ b/src/view/com/util/post-embeds/index.tsx
@@ -89,15 +89,8 @@ export function PostEmbeds({
       const openLightbox = (index: number) => {
         store.shell.openLightbox(new ImagesLightbox(items, index))
       }
-      const onPressIn = (index: number) => {
-        const firstImageToShow = items[index].uri
-        Image.prefetch(firstImageToShow)
-        items.forEach(item => {
-          if (firstImageToShow !== item.uri) {
-            // First image already prefetched above
-            Image.prefetch(item.uri)
-          }
-        })
+      const onPressIn = (_: number) => {
+        Image.prefetch(items.map(i => i.uri))
       }
 
       if (images.length === 1) {

--- a/src/view/com/util/post-embeds/index.tsx
+++ b/src/view/com/util/post-embeds/index.tsx
@@ -1,5 +1,12 @@
 import React from 'react'
-import {StyleSheet, StyleProp, View, ViewStyle, Text} from 'react-native'
+import {
+  StyleSheet,
+  StyleProp,
+  View,
+  ViewStyle,
+  Text,
+  InteractionManager,
+} from 'react-native'
 import {Image} from 'expo-image'
 import {
   AppBskyEmbedImages,
@@ -90,7 +97,9 @@ export function PostEmbeds({
         store.shell.openLightbox(new ImagesLightbox(items, index))
       }
       const onPressIn = (_: number) => {
-        Image.prefetch(items.map(i => i.uri))
+        InteractionManager.runAfterInteractions(() => {
+          Image.prefetch(items.map(i => i.uri))
+        })
       }
 
       if (images.length === 1) {

--- a/src/view/com/util/post-embeds/index.tsx
+++ b/src/view/com/util/post-embeds/index.tsx
@@ -1,12 +1,6 @@
 import React from 'react'
-import {
-  StyleSheet,
-  StyleProp,
-  View,
-  ViewStyle,
-  Image as RNImage,
-  Text,
-} from 'react-native'
+import {StyleSheet, StyleProp, View, ViewStyle, Text} from 'react-native'
+import {Image} from 'expo-image'
 import {
   AppBskyEmbedImages,
   AppBskyEmbedExternal,
@@ -97,11 +91,11 @@ export function PostEmbeds({
       }
       const onPressIn = (index: number) => {
         const firstImageToShow = items[index].uri
-        RNImage.prefetch(firstImageToShow)
+        Image.prefetch(firstImageToShow)
         items.forEach(item => {
           if (firstImageToShow !== item.uri) {
             // First image already prefetched above
-            RNImage.prefetch(item.uri)
+            Image.prefetch(item.uri)
           }
         })
       }


### PR DESCRIPTION
We switched to `expo-image` a few months ago in #452, and Expo provides its own [prefetch](https://docs.expo.dev/versions/latest/sdk/image/#prefetchurls) handling. Calling `react-native`'s built-in prefetch may be causing unnecessary calls to our CDN.