### PR TITLE
Clear caches on session change (close #1177)

### DIFF
--- a/src/state/models/me.ts
+++ b/src/state/models/me.ts
@@ -52,6 +52,8 @@ export class MeModel {
     this.mainFeed.clear()
     this.notifications.clear()
     this.follows.clear()
+    this.rootStore.profiles.cache.clear()
+    this.rootStore.posts.cache.clear()
     this.did = ''
     this.handle = ''
     this.displayName = ''


### PR DESCRIPTION
Closes #1177

Ensures profile and post caches clear on session change to avoid carrying over session-specific state