### PR TITLE
Use `Pressable` for most links/embeds

### DIFF
--- a/src/view/com/feeds/CustomFeed.tsx
+++ b/src/view/com/feeds/CustomFeed.tsx
@@ -1,12 +1,5 @@
 import React from 'react'
-import {
-  Pressable,
-  StyleProp,
-  StyleSheet,
-  View,
-  ViewStyle,
-  TouchableOpacity,
-} from 'react-native'
+import {Pressable, StyleProp, StyleSheet, View, ViewStyle} from 'react-native'
 import {FontAwesomeIcon} from '@fortawesome/react-native-fontawesome'
 import {Text} from '../util/text/Text'
 import {usePalette} from 'lib/hooks/usePalette'
@@ -68,11 +61,10 @@ export const CustomFeed = observer(
     }, [store, item])
 
     return (
-      <TouchableOpacity
+      <Pressable
         testID={`feed-${item.displayName}`}
         accessibilityRole="button"
         style={[styles.container, pal.border, style]}
-        delayPressIn={130}
         onPress={() => {
           navigation.push('CustomFeed', {
             name: item.data.creator.did,
@@ -133,7 +125,7 @@ export const CustomFeed = observer(
             {pluralize(item.data.likeCount || 0, 'user')}
           </Text>
         ) : null}
-      </TouchableOpacity>
+      </Pressable>
     )
   },
 )

--- a/src/view/com/feeds/CustomFeed.tsx
+++ b/src/view/com/feeds/CustomFeed.tsx
@@ -72,6 +72,7 @@ export const CustomFeed = observer(
         testID={`feed-${item.displayName}`}
         accessibilityRole="button"
         style={[styles.container, pal.border, style]}
+        delayPressIn={130}
         onPress={() => {
           navigation.push('CustomFeed', {
             name: item.data.creator.did,

--- a/src/view/com/util/Link.tsx
+++ b/src/view/com/util/Link.tsx
@@ -115,6 +115,7 @@ export const Link = observer(function Link({
     <TouchableOpacity
       testID={testID}
       style={style}
+      delayPressIn={130}
       onPress={onPress}
       accessible={accessible}
       accessibilityRole="link"

--- a/src/view/com/util/Link.tsx
+++ b/src/view/com/util/Link.tsx
@@ -9,8 +9,9 @@ import {
   TextProps,
   View,
   ViewStyle,
-  TouchableOpacity,
+  Pressable,
   TouchableWithoutFeedback,
+  TouchableOpacity,
 } from 'react-native'
 import {
   useLinkProps,
@@ -112,10 +113,9 @@ export const Link = observer(function Link({
   }
 
   return (
-    <TouchableOpacity
+    <Pressable
       testID={testID}
       style={style}
-      delayPressIn={130}
       onPress={onPress}
       accessible={accessible}
       accessibilityRole="link"
@@ -123,7 +123,7 @@ export const Link = observer(function Link({
       href={asAnchor ? sanitizeUrl(href) : undefined}
       {...props}>
       {children ? children : <Text>{title || 'link'}</Text>}
-    </TouchableOpacity>
+    </Pressable>
   )
 })
 

--- a/src/view/com/util/images/AutoSizedImage.tsx
+++ b/src/view/com/util/images/AutoSizedImage.tsx
@@ -11,7 +11,7 @@ import {clamp} from 'lib/numbers'
 import {useStores} from 'state/index'
 import {Dimensions} from 'lib/media/types'
 
-export const DELAY_PRESS_IN = 500
+export const DELAY_PRESS_IN = 130
 const MIN_ASPECT_RATIO = 0.33 // 1/3
 const MAX_ASPECT_RATIO = 5 // 5/1
 

--- a/src/view/com/util/images/AutoSizedImage.tsx
+++ b/src/view/com/util/images/AutoSizedImage.tsx
@@ -1,17 +1,10 @@
 import React from 'react'
-import {
-  StyleProp,
-  StyleSheet,
-  TouchableOpacity,
-  View,
-  ViewStyle,
-} from 'react-native'
+import {StyleProp, StyleSheet, Pressable, View, ViewStyle} from 'react-native'
 import {Image} from 'expo-image'
 import {clamp} from 'lib/numbers'
 import {useStores} from 'state/index'
 import {Dimensions} from 'lib/media/types'
 
-export const DELAY_PRESS_IN = 130
 const MIN_ASPECT_RATIO = 0.33 // 1/3
 const MAX_ASPECT_RATIO = 5 // 5/1
 
@@ -57,11 +50,10 @@ export function AutoSizedImage({
 
   if (onPress || onLongPress || onPressIn) {
     return (
-      <TouchableOpacity
+      <Pressable
         onPress={onPress}
         onLongPress={onLongPress}
         onPressIn={onPressIn}
-        delayPressIn={DELAY_PRESS_IN}
         style={[styles.container, style]}
         accessible={true}
         accessibilityRole="button"
@@ -74,7 +66,7 @@ export function AutoSizedImage({
           accessibilityIgnoresInvertColors
         />
         {children}
-      </TouchableOpacity>
+      </Pressable>
     )
   }
 

--- a/src/view/com/util/images/Gallery.tsx
+++ b/src/view/com/util/images/Gallery.tsx
@@ -1,6 +1,6 @@
 import {AppBskyEmbedImages} from '@atproto/api'
 import React, {ComponentProps, FC} from 'react'
-import {StyleSheet, Text, TouchableOpacity, View} from 'react-native'
+import {StyleSheet, Text, Pressable, View} from 'react-native'
 import {Image} from 'expo-image'
 
 type EventFunction = (index: number) => void
@@ -14,8 +14,6 @@ interface GalleryItemProps {
   imageStyle: ComponentProps<typeof Image>['style']
 }
 
-const DELAY_PRESS_IN = 500
-
 export const GalleryItem: FC<GalleryItemProps> = ({
   images,
   index,
@@ -28,8 +26,7 @@ export const GalleryItem: FC<GalleryItemProps> = ({
 
   return (
     <View>
-      <TouchableOpacity
-        delayPressIn={DELAY_PRESS_IN}
+      <Pressable
         onPress={onPress ? () => onPress(index) : undefined}
         onPressIn={onPressIn ? () => onPressIn(index) : undefined}
         onLongPress={onLongPress ? () => onLongPress(index) : undefined}
@@ -44,7 +41,7 @@ export const GalleryItem: FC<GalleryItemProps> = ({
           accessibilityHint=""
           accessibilityIgnoresInvertColors
         />
-      </TouchableOpacity>
+      </Pressable>
       {image.alt === '' ? null : (
         <View style={styles.altContainer}>
           <Text style={styles.alt} accessible={false}>

--- a/src/view/com/util/post-embeds/YoutubeEmbed.tsx
+++ b/src/view/com/util/post-embeds/YoutubeEmbed.tsx
@@ -24,8 +24,7 @@ export const YoutubeEmbed = ({
   return (
     <Link
       style={[styles.extOuter, pal.view, pal.border, style]}
-      href={link.uri}
-      noFeedback>
+      href={link.uri}>
       <ExternalLinkEmbed link={link} imageChild={imageChild} />
     </Link>
   )

--- a/src/view/com/util/post-embeds/YoutubeEmbed.tsx
+++ b/src/view/com/util/post-embeds/YoutubeEmbed.tsx
@@ -23,6 +23,7 @@ export const YoutubeEmbed = ({
 
   return (
     <Link
+      asAnchor
       style={[styles.extOuter, pal.view, pal.border, style]}
       href={link.uri}>
       <ExternalLinkEmbed link={link} imageChild={imageChild} />

--- a/src/view/com/util/post-embeds/index.tsx
+++ b/src/view/com/util/post-embeds/index.tsx
@@ -150,7 +150,6 @@ export function PostEmbeds({
     return (
       <Link
         asAnchor
-        noFeedback
         style={[styles.extOuter, pal.view, pal.border, style]}
         href={link.uri}>
         <ExternalLinkEmbed link={link} />


### PR DESCRIPTION
Relates to #752, basically removes pressed styles for links/embeds.

This PR moves to using `Pressable` for interactive elements. Essentially the following is true:
- Links have a `pointer: cursor` and do NOT have a pressed style (yet)
- Links with `href` (sometimes via `asAnchor`) render as `<a>` on the web
- `noFeedback` behaves as it was

`Pressable` is RNs successor to the `Touchable*` components. We _should_ add pressed styles to some elements, but this PR does not include that, since we'll want to consider case-by-case with some of these.

A11y properties and keyboard nav still works the same afaict.