### PR TITLE
Tune up the external link card

### DIFF
--- a/src/lib/strings/url-helpers.ts
+++ b/src/lib/strings/url-helpers.ts
@@ -30,7 +30,7 @@ export function toNiceDomain(url: string): string {
     if (`https://${urlp.host}` === PROD_SERVICE) {
       return 'Bluesky Social'
     }
-    return urlp.host
+    return urlp.host ? urlp.host : url
   } catch (e) {
     return url
   }

--- a/src/view/com/util/post-embeds/ExternalLinkEmbed.tsx
+++ b/src/view/com/util/post-embeds/ExternalLinkEmbed.tsx
@@ -4,6 +4,8 @@ import {Text} from '../text/Text'
 import {StyleSheet, View} from 'react-native'
 import {usePalette} from 'lib/hooks/usePalette'
 import {AppBskyEmbedExternal} from '@atproto/api'
+import {isDesktopWeb} from 'platform/detection'
+import {toNiceDomain} from 'lib/strings/url-helpers'
 
 export const ExternalLinkEmbed = ({
   link,
@@ -14,7 +16,7 @@ export const ExternalLinkEmbed = ({
 }) => {
   const pal = usePalette('default')
   return (
-    <>
+    <View style={styles.extContainer}>
       {link.thumb ? (
         <View style={styles.extImageContainer}>
           <Image
@@ -26,39 +28,56 @@ export const ExternalLinkEmbed = ({
         </View>
       ) : undefined}
       <View style={styles.extInner}>
-        <Text type="md-bold" numberOfLines={2} style={[pal.text]}>
-          {link.title || link.uri}
-        </Text>
         <Text
           type="sm"
           numberOfLines={1}
           style={[pal.textLight, styles.extUri]}>
-          {link.uri}
+          {toNiceDomain(link.uri)}
+        </Text>
+        <Text
+          type={isDesktopWeb ? 'xl-bold' : 'lg-bold'}
+          numberOfLines={isDesktopWeb ? 2 : 4}
+          style={[pal.text]}>
+          {link.title || link.uri}
         </Text>
         {link.description ? (
           <Text
-            type="sm"
-            numberOfLines={2}
+            type={isDesktopWeb ? 'lg' : 'md'}
+            numberOfLines={isDesktopWeb ? 2 : 4}
             style={[pal.text, styles.extDescription]}>
             {link.description}
           </Text>
         ) : undefined}
       </View>
-    </>
+    </View>
   )
 }
 
 const styles = StyleSheet.create({
+  extContainer: {
+    flexDirection: isDesktopWeb ? 'row' : 'column',
+  },
   extInner: {
-    padding: 10,
+    paddingHorizontal: isDesktopWeb ? 14 : 10,
+    paddingTop: 8,
+    paddingBottom: 10,
+    flex: isDesktopWeb ? 1 : undefined,
   },
-  extImageContainer: {
-    borderTopLeftRadius: 6,
-    borderTopRightRadius: 6,
-    width: '100%',
-    height: 200,
-    overflow: 'hidden',
-  },
+  extImageContainer: isDesktopWeb
+    ? {
+        borderTopLeftRadius: 6,
+        borderBottomLeftRadius: 6,
+        width: 120,
+        aspectRatio: 1,
+        overflow: 'hidden',
+      }
+    : {
+        borderTopLeftRadius: 6,
+        borderTopRightRadius: 6,
+        width: '100%',
+        height: 200,
+        overflow: 'hidden',
+      },
   extImage: {
     width: '100%',
     height: 200,


### PR DESCRIPTION
Updates the link card to look nicer, show more info, and layout horizontally on web to user space more nicely. Closes #1118 (in my opinion)

# Mobile

Enlarges the fonts, moves the URL up to the top and gives just the domain, and allows up to 3 lines for the title and description.

<img width="395" alt="CleanShot 2023-08-15 at 18 18 33@2x" src="https://github.com/bluesky-social/social-app/assets/1270099/b76bfc8c-6448-4b2f-8a85-c3dd8bfe2163">

# Desktop

Same as mobile, but moves the image to the left side and keeps the number of lines shown to 2.

<img width="594" alt="CleanShot 2023-08-15 at 18 19 33@2x" src="https://github.com/bluesky-social/social-app/assets/1270099/d3821f5b-841c-4438-b5d0-bf30a38a1608">

More examples of desktop web:

<img width="611" alt="CleanShot 2023-08-15 at 18 20 33@2x" src="https://github.com/bluesky-social/social-app/assets/1270099/9e9c2b10-03d4-41d0-bd12-1d2741a84fe9">
<img width="593" alt="CleanShot 2023-08-15 at 18 20 45@2x" src="https://github.com/bluesky-social/social-app/assets/1270099/4df074e4-f731-46b5-a96d-cb0b8cb410cf">
<img width="606" alt="CleanShot 2023-08-15 at 18 20 56@2x" src="https://github.com/bluesky-social/social-app/assets/1270099/03d65da0-0fd7-46ef-af53-e73cbf2f8367">
