### PR TITLE
Fix to "Load new posts" showing sometimes when there's nothing new to show

### DIFF
--- a/src/lib/api/feed-manip.ts
+++ b/src/lib/api/feed-manip.ts
@@ -18,8 +18,8 @@ export class FeedViewPostsSlice {
   constructor(public items: FeedViewPost[] = []) {}
 
   get _reactKey() {
-    return `slice-${this.rootItem.post.uri}-${
-      this.rootItem.reason?.indexedAt || this.rootItem.post.indexedAt
+    return `slice-${this.items[0].post.uri}-${
+      this.items[0].reason?.indexedAt || this.items[0].post.indexedAt
     }`
   }
 

--- a/src/state/models/feeds/posts.ts
+++ b/src/state/models/feeds/posts.ts
@@ -263,7 +263,16 @@ export class PostsFeedModel {
       return
     }
     const res = await this._getFeed({limit: 1})
-    this.setHasNewLatest(res.data.feed[0]?.post.uri !== this.pollCursor)
+    if (res.data.feed[0]) {
+      const slices = this.tuner.tune(res.data.feed, this.feedTuners)
+      if (slices[0]) {
+        const sliceModel = new PostsFeedSliceModel(this.rootStore, slices[0])
+        if (sliceModel.moderation.content.filter) {
+          return
+        }
+        this.setHasNewLatest(sliceModel.uri !== this.pollCursor)
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
Closes #1028 

Just needed to run filtering logic on the server response

NOTE: The server is sometimes returning an empty array for the feed. Need to look into why because that should never happen.