### PR TITLE
add title attr to text text links

### DIFF
--- a/src/view/com/util/Link.tsx
+++ b/src/view/com/util/Link.tsx
@@ -135,6 +135,7 @@ export const TextLink = observer(function TextLink({
   numberOfLines,
   lineHeight,
   dataSet,
+  title,
 }: {
   testID?: string
   type?: TypographyVariant
@@ -144,10 +145,12 @@ export const TextLink = observer(function TextLink({
   numberOfLines?: number
   lineHeight?: number
   dataSet?: any
+  title?: string
 } & TextProps) {
   const {...props} = useLinkProps({to: sanitizeUrl(href)})
   const store = useStores()
   const navigation = useNavigation<NavigationProp>()
+  const anchorRef = React.useRef(null)
 
   props.onPress = React.useCallback(
     (e?: Event) => {
@@ -166,8 +169,14 @@ export const TextLink = observer(function TextLink({
     return {}
   }, [href])
 
+  React.useEffect(() => {
+    // @ts-expect-error web only, shows date on hover -esb
+    anchorRef.current?.setNativeProps?.({title})
+  }, [title])
+
   return (
     <Text
+      ref={anchorRef}
       testID={testID}
       type={type}
       style={style}
@@ -197,6 +206,7 @@ interface DesktopWebTextLinkProps extends TextProps {
   accessible?: boolean
   accessibilityLabel?: string
   accessibilityHint?: string
+  title?: string
 }
 export const DesktopWebTextLink = observer(function DesktopWebTextLink({
   testID,

--- a/src/view/com/util/PostMeta.tsx
+++ b/src/view/com/util/PostMeta.tsx
@@ -79,6 +79,7 @@ export const PostMeta = observer(function (opts: PostMetaOpts) {
             lineHeight={1.2}
             text={timeElapsed}
             accessibilityLabel={niceDate(opts.timestamp)}
+            title={niceDate(opts.timestamp)}
             accessibilityHint=""
             href={opts.postHref}
           />

--- a/src/view/com/util/text/Text.tsx
+++ b/src/view/com/util/text/Text.tsx
@@ -8,19 +8,18 @@ export type CustomTextProps = TextProps & {
   lineHeight?: number
 }
 
-export function Text({
-  type = 'md',
-  children,
-  lineHeight,
-  style,
-  ...props
-}: React.PropsWithChildren<CustomTextProps>) {
-  const theme = useTheme()
-  const typography = theme.typography[type]
-  const lineHeightStyle = lineHeight ? lh(theme, type, lineHeight) : undefined
-  return (
-    <RNText style={[s.black, typography, lineHeightStyle, style]} {...props}>
-      {children}
-    </RNText>
-  )
-}
+export const Text = React.forwardRef<any, CustomTextProps>(
+  ({type = 'md', children, lineHeight, style, ...props}, ref) => {
+    const theme = useTheme()
+    const typography = theme.typography[type]
+    const lineHeightStyle = lineHeight ? lh(theme, type, lineHeight) : undefined
+    return (
+      <RNText
+        ref={ref}
+        style={[s.black, typography, lineHeightStyle, style]}
+        {...props}>
+        {children}
+      </RNText>
+    )
+  },
+)


### PR DESCRIPTION
Fixes #1226 

Sets the `title` HTML attribute so that the date shows on hover.

<img width="396" alt="Screen Shot 2023-08-21 at 10 41 05 AM" src="https://github.com/bluesky-social/social-app/assets/4732330/2b43f065-a7d2-4d66-9007-325ab641403c">
