### PR TITLE
Fix: include link-meta abort signal for timeout (close #1214)

### DIFF
--- a/src/lib/link-meta/link-meta.ts
+++ b/src/lib/link-meta/link-meta.ts
@@ -58,6 +58,7 @@ export async function getLinkMeta(
       `${LINK_META_PROXY(
         store.session.currentSession?.service || '',
       )}${encodeURIComponent(url)}`,
+      {signal: controller.signal},
     )
 
     const body = await response.json()


### PR DESCRIPTION
Fix to a small bug introduced a bit ago that drops the timeout for link meta fetches (thanks @mozzius!)

Closes #1214 