### PR TITLE
Fix: update posts rendered in notifs on refresh (close #1196)

### DIFF
--- a/src/state/models/feeds/notifications.ts
+++ b/src/state/models/feeds/notifications.ts
@@ -225,10 +225,22 @@ export class NotificationsFeedItemModel {
   }
 
   setAdditionalData(additionalPost: AppBskyFeedDefs.PostView) {
-    this.additionalPost = PostThreadModel.fromPostView(
-      this.rootStore,
-      additionalPost,
-    )
+    if (this.additionalPost) {
+      this.additionalPost._replaceAll({
+        success: true,
+        headers: {},
+        data: {
+          thread: {
+            post: additionalPost,
+          },
+        },
+      })
+    } else {
+      this.additionalPost = PostThreadModel.fromPostView(
+        this.rootStore,
+        additionalPost,
+      )
+    }
   }
 }
 

--- a/src/view/com/post/Post.tsx
+++ b/src/view/com/post/Post.tsx
@@ -51,12 +51,15 @@ export const Post = observer(function Post({
 
   useEffect(() => {
     if (initView || view?.params.uri === uri) {
-      return // no change needed? or trigger refresh?
+      if (initView !== view) {
+        setView(initView)
+      }
+      return
     }
     const newView = new PostThreadModel(store, {uri, depth: 0})
     setView(newView)
     newView.setup().catch(err => store.log.error('Failed to fetch post', err))
-  }, [initView, uri, view?.params.uri, store])
+  }, [initView, setView, uri, view, view?.params.uri, store])
 
   // deleted
   // =


### PR DESCRIPTION
Closes #1196 

Ensures that the posts in the notifications re-render upon fetch