### PR TITLE
Change Handle modal DNS instruction tweaks for clarity

### DIFF
--- a/src/view/com/modals/ChangeHandle.tsx
+++ b/src/view/com/modals/ChangeHandle.tsx
@@ -418,7 +418,7 @@ function CustomHandleForm({
             </Text>
             <View style={[styles.dnsValue]}>
               <Text type="mono" style={[styles.monoText, pal.text]}>
-                _atproto.
+                _atproto
               </Text>
             </View>
             <Text type="md-medium" style={[styles.dnsLabel, pal.text]}>

--- a/src/view/com/modals/ChangeHandle.tsx
+++ b/src/view/com/modals/ChangeHandle.tsx
@@ -438,6 +438,12 @@ function CustomHandleForm({
               </Text>
             </View>
           </View>
+          <Text type="md" style={[pal.text, s.pt20, s.pl5]}>
+            This should create a domain record at:{' '}
+          </Text>
+          <Text type="mono" style={[styles.monoText, pal.text, s.pt5, s.pl5]}>
+            _atproto.{handle}
+          </Text>
         </>
       ) : (
         <>


### PR DESCRIPTION
Close #1004 by removing a (potentially) confusing period in the domain instructions
Close #1087 by giving a bit more info about the target domain (the line about "This should create a domain record at:")

<img width="398" alt="CleanShot 2023-08-21 at 19 40 54@2x" src="https://github.com/bluesky-social/social-app/assets/1270099/38a83973-1cd5-476c-b0e9-b79040929dcb">

+1?