### PR TITLE
Don't submit search if query is empty

### DIFF
--- a/src/view/screens/SearchMobile.tsx
+++ b/src/view/screens/SearchMobile.tsx
@@ -79,6 +79,8 @@ export const SearchScreen = withAuthRequired(
     }, [setQuery, autocompleteView, store])
 
     const onSubmitQuery = React.useCallback(() => {
+      if (query.length === 0) return
+
       const model = new SearchUIModel(store)
       model.fetch(query)
       setSearchUIModel(model)


### PR DESCRIPTION
Right now if you submit the search field on the Discover page with no content it submits an empty result, which shouldn't happen and rightly returns zero results. This PR fixes that.

| Posts | Users |
| --- | --- |
| ![Screenshot 2023-08-22 at 4 28 36 AM jpeg](https://github.com/bluesky-social/social-app/assets/8293444/51c64949-bc19-4b16-9325-d6d85b93769f) | ![Screenshot 2023-08-22 at 4 28 38 AM jpeg](https://github.com/bluesky-social/social-app/assets/8293444/7fe77a69-fef8-41e9-b349-03388eaa394a) |
