### PR TITLE
do not thread author media filtered feed

### DIFF
--- a/src/state/models/feeds/posts.ts
+++ b/src/state/models/feeds/posts.ts
@@ -11,8 +11,17 @@ import {cleanError} from 'lib/strings/errors'
 import {FeedTuner} from 'lib/api/feed-manip'
 import {PostsFeedSliceModel} from './posts-slice'
 import {track} from 'lib/analytics/analytics'
+import {FeedViewPostsSlice} from 'lib/api/feed-manip'
 
 const PAGE_SIZE = 30
+
+type Options = {
+  /**
+   * Formats the feed in a flat array with no threading of replies, just
+   * top-level posts.
+   */
+  isSimpleFeed?: boolean
+}
 
 type QueryParams =
   | GetTimeline.QueryParams
@@ -35,6 +44,7 @@ export class PostsFeedModel {
   pollCursor: string | undefined
   tuner = new FeedTuner()
   pageSize = PAGE_SIZE
+  options: Options = {}
 
   // used to linearize async modifications to state
   lock = new AwaitLock()
@@ -49,6 +59,7 @@ export class PostsFeedModel {
     public rootStore: RootStoreModel,
     public feedType: 'home' | 'author' | 'custom',
     params: QueryParams,
+    options?: Options,
   ) {
     makeAutoObservable(
       this,
@@ -60,6 +71,7 @@ export class PostsFeedModel {
       {autoBind: true},
     )
     this.params = params
+    this.options = options || {}
   }
 
   get hasContent() {
@@ -354,7 +366,9 @@ export class PostsFeedModel {
       this.rootStore.posts.fromFeedItem(item)
     }
 
-    const slices = this.tuner.tune(res.data.feed, this.feedTuners)
+    const slices = this.options.isSimpleFeed
+      ? res.data.feed.map(item => new FeedViewPostsSlice([item]))
+      : this.tuner.tune(res.data.feed, this.feedTuners)
 
     const toAppend: PostsFeedSliceModel[] = []
     for (const slice of slices) {

--- a/src/state/models/ui/profile.ts
+++ b/src/state/models/ui/profile.ts
@@ -176,11 +176,18 @@ export class ProfileUiModel {
       filter = 'posts_with_media'
     }
 
-    this.feed = new PostsFeedModel(this.rootStore, 'author', {
-      actor: this.params.user,
-      limit: 10,
-      filter,
-    })
+    this.feed = new PostsFeedModel(
+      this.rootStore,
+      'author',
+      {
+        actor: this.params.user,
+        limit: 10,
+        filter,
+      },
+      {
+        isSimpleFeed: ['posts_with_media'].includes(filter),
+      },
+    )
 
     if (this.currentView instanceof PostsFeedModel) {
       this.feed.setup()


### PR DESCRIPTION
Fixes #1212 

Adds an options object to the `PostsFeedModel` so that we can specify feeds that should display as a flat array of posts and not be threaded in situ into replies.

This will be useful for the upcoming Likes tab as well.