### PR TITLE
defer loading of feeds until visible

### DIFF
--- a/src/state/models/feeds/posts.ts
+++ b/src/state/models/feeds/posts.ts
@@ -272,7 +272,7 @@ export class PostsFeedModel {
    * Check if new posts are available
    */
   async checkForLatest() {
-    if (this.hasNewLatest || this.isLoading) {
+    if (!this.hasLoaded || this.hasNewLatest || this.isLoading) {
       return
     }
     const res = await this._getFeed({limit: 1})

--- a/src/state/models/feeds/posts.ts
+++ b/src/state/models/feeds/posts.ts
@@ -31,6 +31,7 @@ type QueryParams =
 
 export class PostsFeedModel {
   // state
+  isInitialLoading = true
   isLoading = false
   isRefreshing = false
   hasNewLatest = false
@@ -99,6 +100,7 @@ export class PostsFeedModel {
    */
   clear() {
     this.rootStore.log.debug('FeedModel:clear')
+    this.isInitialLoading = true
     this.isLoading = false
     this.isRefreshing = false
     this.hasNewLatest = false
@@ -322,6 +324,7 @@ export class PostsFeedModel {
   }
 
   _xIdle(error?: any, loadMoreError?: any) {
+    this.isInitialLoading = false
     this.isLoading = false
     this.isRefreshing = false
     this.hasLoaded = true

--- a/src/state/models/feeds/posts.ts
+++ b/src/state/models/feeds/posts.ts
@@ -31,7 +31,6 @@ type QueryParams =
 
 export class PostsFeedModel {
   // state
-  isInitialLoading = true
   isLoading = false
   isRefreshing = false
   hasNewLatest = false
@@ -100,7 +99,6 @@ export class PostsFeedModel {
    */
   clear() {
     this.rootStore.log.debug('FeedModel:clear')
-    this.isInitialLoading = true
     this.isLoading = false
     this.isRefreshing = false
     this.hasNewLatest = false
@@ -324,7 +322,6 @@ export class PostsFeedModel {
   }
 
   _xIdle(error?: any, loadMoreError?: any) {
-    this.isInitialLoading = false
     this.isLoading = false
     this.isRefreshing = false
     this.hasLoaded = true

--- a/src/view/com/posts/Feed.tsx
+++ b/src/view/com/posts/Feed.tsx
@@ -69,14 +69,11 @@ export const Feed = observer(function Feed({
       if (feed.loadMoreError) {
         feedItems = feedItems.concat([LOAD_MORE_ERROR_ITEM])
       }
-    } else if (feed.isLoading) {
-      feedItems = feedItems.concat([LOADING_ITEM])
     }
     return feedItems
   }, [
     feed.hasError,
     feed.hasLoaded,
-    feed.isLoading,
     feed.isEmpty,
     feed.slices,
     feed.loadMoreError,
@@ -97,6 +94,8 @@ export const Feed = observer(function Feed({
   }, [feed, track, setIsRefreshing])
 
   const onEndReached = React.useCallback(async () => {
+    if (!feed.hasLoaded) return
+
     track('Feed:onEndReached')
     try {
       await feed.loadMore()
@@ -155,38 +154,36 @@ export const Feed = observer(function Feed({
 
   return (
     <View testID={testID} style={style}>
-      {data.length > 0 && (
-        <FlatList
-          testID={testID ? `${testID}-flatlist` : undefined}
-          ref={scrollElRef}
-          data={data}
-          keyExtractor={item => item._reactKey}
-          renderItem={renderItem}
-          ListFooterComponent={FeedFooter}
-          ListHeaderComponent={ListHeaderComponent}
-          refreshControl={
-            <RefreshControl
-              refreshing={isRefreshing}
-              onRefresh={onRefresh}
-              tintColor={pal.colors.text}
-              titleColor={pal.colors.text}
-              progressViewOffset={headerOffset}
-            />
-          }
-          contentContainerStyle={s.contentContainer}
-          style={{paddingTop: headerOffset}}
-          onScroll={onScroll}
-          scrollEventThrottle={scrollEventThrottle}
-          indicatorStyle={theme.colorScheme === 'dark' ? 'white' : 'black'}
-          onEndReached={onEndReached}
-          onEndReachedThreshold={0.6}
-          removeClippedSubviews={true}
-          contentOffset={{x: 0, y: headerOffset * -1}}
-          extraData={extraData}
-          // @ts-ignore our .web version only -prf
-          desktopFixedHeight
-        />
-      )}
+      <FlatList
+        testID={testID ? `${testID}-flatlist` : undefined}
+        ref={scrollElRef}
+        data={feed.isInitialLoading ? [LOADING_ITEM] : data}
+        keyExtractor={item => item._reactKey}
+        renderItem={renderItem}
+        ListFooterComponent={FeedFooter}
+        ListHeaderComponent={ListHeaderComponent}
+        refreshControl={
+          <RefreshControl
+            refreshing={isRefreshing}
+            onRefresh={onRefresh}
+            tintColor={pal.colors.text}
+            titleColor={pal.colors.text}
+            progressViewOffset={headerOffset}
+          />
+        }
+        contentContainerStyle={s.contentContainer}
+        style={{paddingTop: headerOffset}}
+        onScroll={onScroll}
+        scrollEventThrottle={scrollEventThrottle}
+        indicatorStyle={theme.colorScheme === 'dark' ? 'white' : 'black'}
+        onEndReached={onEndReached}
+        onEndReachedThreshold={0.6}
+        removeClippedSubviews={true}
+        contentOffset={{x: 0, y: headerOffset * -1}}
+        extraData={extraData}
+        // @ts-ignore our .web version only -prf
+        desktopFixedHeight
+      />
     </View>
   )
 })

--- a/src/view/com/posts/Feed.tsx
+++ b/src/view/com/posts/Feed.tsx
@@ -157,7 +157,7 @@ export const Feed = observer(function Feed({
       <FlatList
         testID={testID ? `${testID}-flatlist` : undefined}
         ref={scrollElRef}
-        data={feed.isInitialLoading ? [LOADING_ITEM] : data}
+        data={!feed.hasLoaded ? [LOADING_ITEM] : data}
         keyExtractor={item => item._reactKey}
         renderItem={renderItem}
         ListFooterComponent={FeedFooter}

--- a/src/view/screens/Home.tsx
+++ b/src/view/screens/Home.tsx
@@ -56,7 +56,6 @@ export const HomeScreen = withAuthRequired(
       const feeds = []
       for (const feed of pinned) {
         const model = new PostsFeedModel(store, 'custom', {feed: feed.uri})
-        model.setup()
         feeds.push(model)
       }
       pagerRef.current?.setPage(0)
@@ -168,6 +167,13 @@ const FeedPage = observer(
       onForeground: () => doPoll(true),
     })
     const isScreenFocused = useIsFocused()
+
+    React.useEffect(() => {
+      // called on first load
+      if (!feed.hasLoaded && isPageFocused) {
+        feed.setup()
+      }
+    }, [isPageFocused, feed])
 
     const doPoll = React.useCallback(
       (knownActive = false) => {


### PR DESCRIPTION
Should help #1233

Each of the tab screens renders when you open the app, so this relies on `isPageFocused` to trigger a first load of the feed itself. And since loading happens lazily, we need a loading state ready for the user on each swipe, hence the change to loading logic to show a default loading state only if `isInitialLoading = true`.

`isInitialLoading` is named after the [same feature](https://tanstack.com/query/v4/docs/react/guides/disabling-queries#isinitialloading) in React Query.