### PR TITLE
Move the web composer to the top of the screen

### DIFF
--- a/src/view/shell/Composer.web.tsx
+++ b/src/view/shell/Composer.web.tsx
@@ -59,9 +59,9 @@ const styles = StyleSheet.create({
     height: '100%',
     backgroundColor: '#000c',
     alignItems: 'center',
-    justifyContent: 'center',
   },
   container: {
+    marginTop: 50,
     maxWidth: 600,
     width: '100%',
     paddingVertical: 0,


### PR DESCRIPTION
The emoji picker drops downward which can clip off the bottom of the screen, so this PR moves the composer up to the top

<img width="1800" alt="CleanShot 2023-08-25 at 10 26 34@2x" src="https://github.com/bluesky-social/social-app/assets/1270099/98cdf05e-0881-400c-aa81-020eb72ac37e">
