### PR TITLE
Fix: Don't flash default profile avatar and broken profile link in nav

### DIFF
--- a/src/view/shell/desktop/LeftNav.tsx
+++ b/src/view/shell/desktop/LeftNav.tsx
@@ -14,6 +14,7 @@ import {
 import {Text} from 'view/com/util/text/Text'
 import {UserAvatar} from 'view/com/util/UserAvatar'
 import {Link} from 'view/com/util/Link'
+import {LoadingPlaceholder} from 'view/com/util/LoadingPlaceholder'
 import {usePalette} from 'lib/hooks/usePalette'
 import {useStores} from 'state/index'
 import {s, colors} from 'lib/styles'
@@ -40,10 +41,14 @@ import {makeProfileLink} from 'lib/routes/links'
 
 const ProfileCard = observer(() => {
   const store = useStores()
-  return (
+  return store.me.handle ? (
     <Link href={makeProfileLink(store.me)} style={styles.profileCard} asAnchor>
       <UserAvatar avatar={store.me.avatar} size={64} />
     </Link>
+  ) : (
+    <View style={styles.profileCard}>
+      <LoadingPlaceholder width={64} height={64} style={{borderRadius: 64}} />
+    </View>
   )
 })
 


### PR DESCRIPTION
Left nav profile picture flashes for a second as a default avatar and it links to /profile (broken link) before your profile data fully loads in the store.
Make the avatar be a placeholder like in the profile view and don't link it before the data loads.

Before:
https://github.com/bluesky-social/social-app/assets/6214736/c52de5fd-82ad-42ae-9b84-ebc88239f631
Fixed:
https://github.com/bluesky-social/social-app/assets/6214736/c06b5114-b1cf-4e40-80da-43798540aa35



