### PR TITLE
Remove ability for Post component to load from URI (close #1302)

### DIFF
--- a/src/view/com/notifications/FeedItem.tsx
+++ b/src/view/com/notifications/FeedItem.tsx
@@ -122,7 +122,7 @@ export const FeedItem = observer(function ({
   }
 
   if (item.isReply || item.isMention || item.isQuote) {
-    if (item.additionalPost?.error) {
+    if (!item.additionalPost || item.additionalPost?.error) {
       // hide errors - it doesnt help the user to show them
       return <View />
     }
@@ -134,8 +134,7 @@ export const FeedItem = observer(function ({
         noFeedback
         accessible={false}>
         <Post
-          uri={item.uri}
-          initView={item.additionalPost}
+          view={item.additionalPost}
           style={
             item.isRead
               ? undefined

--- a/src/view/com/post/Post.tsx
+++ b/src/view/com/post/Post.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useState, useMemo} from 'react'
+import React, {useState, useMemo} from 'react'
 import {
   ActivityIndicator,
   Linking,
@@ -32,34 +32,18 @@ import {getTranslatorLink, isPostInLanguage} from '../../../locale/helpers'
 import {makeProfileLink} from 'lib/routes/links'
 
 export const Post = observer(function Post({
-  uri,
-  initView,
+  view,
   showReplyLine,
   hideError,
   style,
 }: {
-  uri: string
-  initView?: PostThreadModel
+  view: PostThreadModel
   showReplyLine?: boolean
   hideError?: boolean
   style?: StyleProp<ViewStyle>
 }) {
   const pal = usePalette('default')
-  const store = useStores()
-  const [view, setView] = useState<PostThreadModel | undefined>(initView)
   const [deleted, setDeleted] = useState(false)
-
-  useEffect(() => {
-    if (initView || view?.params.uri === uri) {
-      if (initView !== view) {
-        setView(initView)
-      }
-      return
-    }
-    const newView = new PostThreadModel(store, {uri, depth: 0})
-    setView(newView)
-    newView.setup().catch(err => store.log.error('Failed to fetch post', err))
-  }, [initView, setView, uri, view, view?.params.uri, store])
 
   // deleted
   // =
@@ -69,11 +53,7 @@ export const Post = observer(function Post({
 
   // loading
   // =
-  if (
-    !view ||
-    (!view.hasContent && view.isLoading) ||
-    view.params.uri !== uri
-  ) {
+  if (!view.hasContent && view.isLoading) {
     return (
       <View style={pal.view}>
         <ActivityIndicator />

--- a/src/view/com/search/SearchResults.tsx
+++ b/src/view/com/search/SearchResults.tsx
@@ -72,12 +72,7 @@ const PostResults = observer(({model}: {model: SearchUIModel}) => {
   return (
     <ScrollView style={[pal.view]}>
       {model.posts.map(post => (
-        <Post
-          key={post.resolvedUri}
-          uri={post.resolvedUri}
-          initView={post}
-          hideError
-        />
+        <Post key={post.resolvedUri} view={post} hideError />
       ))}
       <View style={s.footerSpacer} />
       <View style={s.footerSpacer} />


### PR DESCRIPTION
The `<Post>` component had old logic for passing in a `uri` to load from as an alternative to using the supplied view. This was a pretty poorly thought-out piece of code (by me) to begin with, but I made it worse when I modified it in #1243. Since it's not actually used now, it's good to remove.

I didn't create a repro to confirm this caused #1302 and I can't quite find the logical pathway for for non-termination. I assume the issue arises if `initView` is ever undefined or if `uri` ever changes. 