### PR TITLE
Improvements to feed assembly to avoid possible state issues

### DIFF
--- a/src/lib/api/feed-manip.ts
+++ b/src/lib/api/feed-manip.ts
@@ -105,6 +105,7 @@ export class FeedTuner {
   tune(
     feed: FeedViewPost[],
     tunerFns: FeedTunerFn[] = [],
+    {dryRun}: {dryRun: boolean} = {dryRun: false},
   ): FeedViewPostsSlice[] {
     let slices: FeedViewPostsSlice[] = []
 
@@ -156,9 +157,11 @@ export class FeedTuner {
       }
     }
 
-    for (const slice of slices) {
-      for (const item of slice.items) {
-        this.seenUris.add(item.post.uri)
+    if (!dryRun) {
+      for (const slice of slices) {
+        for (const item of slice.items) {
+          this.seenUris.add(item.post.uri)
+        }
       }
     }
 

--- a/src/state/models/feeds/posts.ts
+++ b/src/state/models/feeds/posts.ts
@@ -376,6 +376,15 @@ export class PostsFeedModel {
     const toAppend: PostsFeedSliceModel[] = []
     for (const slice of slices) {
       const sliceModel = new PostsFeedSliceModel(this.rootStore, slice)
+      const dupTest = (item: PostsFeedSliceModel) =>
+        item._reactKey === sliceModel._reactKey
+      // sanity check
+      // if a duplicate _reactKey passes through, the UI breaks hard
+      if (!replace) {
+        if (this.slices.find(dupTest) || toAppend.find(dupTest)) {
+          continue
+        }
+      }
       toAppend.push(sliceModel)
     }
     runInAction(() => {

--- a/src/state/models/feeds/posts.ts
+++ b/src/state/models/feeds/posts.ts
@@ -277,7 +277,9 @@ export class PostsFeedModel {
     }
     const res = await this._getFeed({limit: 1})
     if (res.data.feed[0]) {
-      const slices = this.tuner.tune(res.data.feed, this.feedTuners)
+      const slices = this.tuner.tune(res.data.feed, this.feedTuners, {
+        dryRun: true,
+      })
       if (slices[0]) {
         const sliceModel = new PostsFeedSliceModel(this.rootStore, slices[0])
         if (sliceModel.moderation.content.filter) {


### PR DESCRIPTION
The first commit is not strictly necessary but wise to do -- the feed tuner is stateful and the `checkForLatest()` call was modifying that state. That state resets whenever "load new posts" is pressed so it didn't manifest as a bug, but it's still smart to avoid issues.

The second commit is a somewhat gross sanity check to ensure that we never let a duplicate react-key through. Because a duplicate react key is _disastrous_ to rendering, I think this is worth doing. 