### PR TITLE
Make load latest centered button primary

### DIFF
--- a/src/view/com/util/load-latest/LoadLatestBtn.web.tsx
+++ b/src/view/com/util/load-latest/LoadLatestBtn.web.tsx
@@ -6,6 +6,7 @@ import {usePalette} from 'lib/hooks/usePalette'
 import {LoadLatestBtn as LoadLatestBtnMobile} from './LoadLatestBtnMobile'
 import {isMobileWeb} from 'platform/detection'
 import {HITSLOP_20} from 'lib/constants'
+import {colors} from 'lib/styles'
 
 export const LoadLatestBtn = ({
   onPress,
@@ -33,8 +34,6 @@ export const LoadLatestBtn = ({
       {showIndicator && (
         <TouchableOpacity
           style={[
-            pal.view,
-            pal.borderDark,
             styles.loadLatestCentered,
             minimalShellMode && styles.loadLatestCenteredMinimal,
           ]}
@@ -98,7 +97,7 @@ const styles = StyleSheet.create({
     paddingHorizontal: 24,
     paddingVertical: 14,
     borderRadius: 30,
-    borderWidth: 1,
+    backgroundColor: colors.blue3,
   },
   loadLatestCenteredMinimal: {
     top: 20,


### PR DESCRIPTION
"Load latest" centered button - the one displaying at the top in web whenever there are new posts/notifications available is barely visible.

Buttons that do primary actions like showing/producing new content that wasn't there before, encouraging engagement or in general making the user do something that's desired to be as often as possible should be primary - very visible.

(This is the case on _similar platforms_)

Before:
![image](https://github.com/bluesky-social/social-app/assets/6214736/a77b873b-bbb3-4548-bba5-8dc71728c1eb)
After:
![image](https://github.com/bluesky-social/social-app/assets/6214736/938d3014-8d53-478a-b91e-98d9e778b6eb)
