### PR TITLE
fix: dont display reply input before thread fetches

### DIFF
--- a/src/view/screens/PostThread.tsx
+++ b/src/view/screens/PostThread.tsx
@@ -27,6 +27,8 @@ export const PostThreadScreen = withAuthRequired(({route}: Props) => {
     [store, uri],
   )
 
+  const [thread, setThread] = React.useState<PostThreadModel['thread']>(null)
+
   useFocusEffect(
     React.useCallback(() => {
       store.shell.setMinimalShellMode(false)
@@ -34,9 +36,14 @@ export const PostThreadScreen = withAuthRequired(({route}: Props) => {
 
       InteractionManager.runAfterInteractions(() => {
         if (!view.hasLoaded && !view.isLoading) {
-          view.setup().catch(err => {
-            store.log.error('Failed to fetch thread', err)
-          })
+          view
+            .setup()
+            .then(() => {
+              setThread(view.thread)
+            })
+            .catch(err => {
+              store.log.error('Failed to fetch thread', err)
+            })
         }
       })
 
@@ -75,7 +82,7 @@ export const PostThreadScreen = withAuthRequired(({route}: Props) => {
           onPressReply={onPressReply}
         />
       </View>
-      {!isDesktopWeb && (
+      {!isDesktopWeb && thread && (
         <View
           style={[
             styles.prompt,


### PR DESCRIPTION
"Write your reply" was showing up when thread was still loading or non existent
![image](https://github.com/bluesky-social/social-app/assets/6214736/daa41652-0fd2-4b66-a0dc-ddaaef257942)
![image](https://github.com/bluesky-social/social-app/assets/6214736/3b056fe2-fe53-458d-84d2-fb1a4bb28a64)
