### PR TITLE
fix lightbox on search page

### DIFF
--- a/src/view/screens/Search.web.tsx
+++ b/src/view/screens/Search.web.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import {View} from 'react-native'
 import {SearchUIModel} from 'state/models/ui/search'
 import {FoafsModel} from 'state/models/discovery/foafs'
 import {SuggestedActorsModel} from 'state/models/discovery/suggested-actors'
@@ -47,7 +48,12 @@ export const SearchScreen = withAuthRequired(
     const {isDesktop} = useWebMediaQueries()
 
     if (searchUIModel) {
-      return <SearchResults model={searchUIModel} />
+      return (
+        // @ts-ignore web only
+        <View style={{height: '100%', overflow: 'auto'}}>
+          <SearchResults model={searchUIModel} />
+        </View>
+      )
     }
 
     if (!isDesktop) {

--- a/src/view/screens/Search.web.tsx
+++ b/src/view/screens/Search.web.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import {View} from 'react-native'
+import {View, StyleSheet} from 'react-native'
 import {SearchUIModel} from 'state/models/ui/search'
 import {FoafsModel} from 'state/models/discovery/foafs'
 import {SuggestedActorsModel} from 'state/models/discovery/suggested-actors'
@@ -49,17 +49,27 @@ export const SearchScreen = withAuthRequired(
 
     if (searchUIModel) {
       return (
-        // @ts-ignore web only
-        <View style={{height: '100%', overflow: 'auto'}}>
+        <View style={styles.scrollContainer}>
           <SearchResults model={searchUIModel} />
         </View>
       )
     }
 
     if (!isDesktop) {
-      return <Mobile.SearchScreen navigation={navigation} route={route} />
+      return (
+        <View style={styles.scrollContainer}>
+          <Mobile.SearchScreen navigation={navigation} route={route} />
+        </View>
+      )
     }
 
     return <Suggestions foafs={foafs} suggestedActors={suggestedActors} />
   }),
 )
+
+const styles = StyleSheet.create({
+  scrollContainer: {
+    height: '100%',
+    overflowY: 'auto',
+  },
+})


### PR DESCRIPTION
On views that use the `Feed` component and therefore `FlatList`, we have `desktopFixedHeight` that applies `height: 100vh; overflow-y: auto`. On the search page, we only load 30 posts, and so don't use the `FlatList`. The reason it's 100vh and not 100% is because it's nested deep enough in the tree that our wrapping containers that ARE 100% aren't direct parents.

I think the preferable way to fix this is to use do it as high up the tree as possible so that we can use a relative height of 100%. This PR also only applies these styles to web, which is a little nicer than having to conditionally apply them when `isWeb` within the `SearchResults` components.