### PR TITLE
handle stuck state with granular android permissions

### DIFF
--- a/src/lib/hooks/usePermissions.ts
+++ b/src/lib/hooks/usePermissions.ts
@@ -29,9 +29,14 @@ export function usePhotoLibraryPermission() {
 
     if (res?.granted) {
       return true
-    } else if (!res || res?.status === 'undetermined' || res?.canAskAgain) {
-      const updatedRes = await requestPermission()
-      return updatedRes?.granted
+    } else if (!res || res.status === 'undetermined' || res?.canAskAgain) {
+      const {canAskAgain, granted, status} = await requestPermission()
+
+      if (!canAskAgain && status === 'undetermined') {
+        openPermissionAlert('photo library')
+      }
+
+      return granted
     } else {
       openPermissionAlert('photo library')
       return false


### PR DESCRIPTION
Fixes [an issue](https://bsky.app/profile/hugelgupf.bsky.social/post/3k5xf4hh5v52y) where Android 13 users would get into a stuck state with partial permissions. Expo will probably handle this differently ([open Issue](https://github.com/expo/expo/issues/24122)) in the future, but for now this is a pretty good solve I think.

No changes to iOS or web.

See here how partial permissions will result in `undetermined` status, and once we can't ask again we push them to settings instead of doing nothing.

https://github.com/bluesky-social/social-app/assets/4732330/426e2351-63fd-4f83-835a-ace2e63665b0


