### PR TITLE
encode all unsafe characters in post text for translate URL

### DIFF
--- a/src/locale/helpers.ts
+++ b/src/locale/helpers.ts
@@ -80,5 +80,7 @@ export function isPostInLanguage(
 }
 
 export function getTranslatorLink(text: string): string {
-  return encodeURI(`https://translate.google.com/?sl=auto&text=${text}`)
+  return `https://translate.google.com/?sl=auto&text=${encodeURIComponent(
+    text,
+  )}`
 }


### PR DESCRIPTION
Addresses #1312

We weren't encoding `#` (and maybe other characters) while constructing the translate URLs. In the case of `#` it was simply being interpreted by the browser as a hash anchor and not part of the `text` query param.