### PR TITLE
Improved mute alerting

### DIFF
--- a/src/lib/embeds.ts
+++ b/src/lib/embeds.ts
@@ -1,0 +1,21 @@
+import {
+  AppBskyFeedDefs,
+  AppBskyEmbedRecord,
+  AppBskyEmbedRecordWithMedia,
+} from '@atproto/api'
+
+export function isEmbedByEmbedder(
+  embed: AppBskyFeedDefs.PostView['embed'],
+  did: string,
+): boolean {
+  if (AppBskyEmbedRecord.isViewRecord(embed.record)) {
+    return embed.record.author.did === did
+  }
+  if (
+    AppBskyEmbedRecordWithMedia.isView(embed) &&
+    AppBskyEmbedRecord.isViewRecord(embed.record.record)
+  ) {
+    return embed.record.record.author.did === did
+  }
+  return true
+}

--- a/src/lib/embeds.ts
+++ b/src/lib/embeds.ts
@@ -8,6 +8,9 @@ export function isEmbedByEmbedder(
   embed: AppBskyFeedDefs.PostView['embed'],
   did: string,
 ): boolean {
+  if (!embed) {
+    return false
+  }
   if (AppBskyEmbedRecord.isViewRecord(embed.record)) {
     return embed.record.author.did === did
   }

--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -59,6 +59,7 @@ export const PostThreadItem = observer(function PostThreadItem({
   const itemTitle = `Post by ${item.post.author.handle}`
   const authorHref = makeProfileLink(item.post.author)
   const authorTitle = item.post.author.handle
+  const isAuthorMuted = item.post.author.viewer?.muted
   const likesHref = React.useMemo(() => {
     const urip = new AtUri(item.post.uri)
     return makeProfileLink(item.post.author, 'post', urip.rkey, 'liked-by')
@@ -224,6 +225,30 @@ export const PostThreadItem = observer(function PostThreadItem({
                 </View>
               </View>
               <View style={styles.meta}>
+                {isAuthorMuted && (
+                  <View
+                    style={[
+                      pal.viewLight,
+                      {
+                        flexDirection: 'row',
+                        alignItems: 'center',
+                        gap: 4,
+                        borderRadius: 6,
+                        paddingHorizontal: 6,
+                        paddingVertical: 2,
+                        marginRight: 4,
+                      },
+                    ]}>
+                    <FontAwesomeIcon
+                      icon={['far', 'eye-slash']}
+                      size={12}
+                      color={pal.colors.textLight}
+                    />
+                    <Text type="sm-medium" style={pal.textLight}>
+                      Muted
+                    </Text>
+                  </View>
+                )}
                 <Link
                   style={styles.metaItem}
                   href={authorHref}

--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -19,6 +19,7 @@ import {niceDate} from 'lib/strings/time'
 import {sanitizeDisplayName} from 'lib/strings/display-names'
 import {sanitizeHandle} from 'lib/strings/handles'
 import {pluralize} from 'lib/strings/helpers'
+import {isEmbedByEmbedder} from 'lib/embeds'
 import {getTranslatorLink, isPostInLanguage} from '../../../locale/helpers'
 import {useStores} from 'state/index'
 import {PostMeta} from '../util/PostMeta'
@@ -305,7 +306,13 @@ export const PostThreadItem = observer(function PostThreadItem({
                 </View>
               ) : undefined}
               {item.post.embed && (
-                <ContentHider moderation={item.moderation.embed} style={s.mb10}>
+                <ContentHider
+                  moderation={item.moderation.embed}
+                  ignoreMute={isEmbedByEmbedder(
+                    item.post.embed,
+                    item.post.author.did,
+                  )}
+                  style={s.mb10}>
                   <PostEmbeds
                     embed={item.post.embed}
                     moderation={item.moderation.embed}

--- a/src/view/com/posts/FeedItem.tsx
+++ b/src/view/com/posts/FeedItem.tsx
@@ -28,6 +28,7 @@ import {sanitizeDisplayName} from 'lib/strings/display-names'
 import {sanitizeHandle} from 'lib/strings/handles'
 import {getTranslatorLink, isPostInLanguage} from '../../../locale/helpers'
 import {makeProfileLink} from 'lib/routes/links'
+import {isEmbedByEmbedder} from 'lib/embeds'
 
 export const FeedItem = observer(function ({
   item,
@@ -292,6 +293,10 @@ export const FeedItem = observer(function ({
               <ContentHider
                 testID="contentHider-embed"
                 moderation={item.moderation.embed}
+                ignoreMute={isEmbedByEmbedder(
+                  item.post.embed,
+                  item.post.author.did,
+                )}
                 style={styles.embed}>
                 <PostEmbeds
                   embed={item.post.embed}

--- a/src/view/com/util/moderation/PostAlerts.tsx
+++ b/src/view/com/util/moderation/PostAlerts.tsx
@@ -9,7 +9,6 @@ import {useStores} from 'state/index'
 
 export function PostAlerts({
   moderation,
-  includeMute,
   style,
 }: {
   moderation: ModerationUI
@@ -19,10 +18,7 @@ export function PostAlerts({
   const store = useStores()
   const pal = usePalette('default')
 
-  const shouldAlert =
-    !!moderation.cause &&
-    (moderation.alert ||
-      (includeMute && moderation.blur && moderation.cause?.type === 'muted'))
+  const shouldAlert = !!moderation.cause && moderation.alert
   if (!shouldAlert) {
     return null
   }


### PR DESCRIPTION
When viewing a post by a muted user, we want to show that they're muted but what currently happens is intense. Not only is the alert overkill, it treats self-QPs as something to mask:

<img width="594" alt="CleanShot 2023-08-31 at 21 36 23@2x" src="https://github.com/bluesky-social/social-app/assets/1270099/73b3bae8-019a-4327-b5a2-40d78eb2ff88">

This PR gives a more suitable UI warning and also stops the self-QP scenario:

<img width="605" alt="CleanShot 2023-08-31 at 21 35 26@2x" src="https://github.com/bluesky-social/social-app/assets/1270099/3d0a7a81-9052-4316-9a65-72ebc099a3d8">
