### PR TITLE
Fix mismatching button label for speech recognition

### DIFF
--- a/src/view/screens/CustomFeed.tsx
+++ b/src/view/screens/CustomFeed.tsx
@@ -508,7 +508,7 @@ export const CustomFeedScreenInner = observer(
           onPress={onPressCompose}
           icon={<ComposeIcon2 strokeWidth={1.5} size={29} style={s.white} />}
           accessibilityRole="button"
-          accessibilityLabel="Compose post"
+          accessibilityLabel="New post"
           accessibilityHint=""
         />
       </View>

--- a/src/view/screens/Feeds.tsx
+++ b/src/view/screens/Feeds.tsx
@@ -125,7 +125,7 @@ export const FeedsScreen = withAuthRequired(
           onPress={onPressCompose}
           icon={<ComposeIcon2 strokeWidth={1.5} size={29} style={s.white} />}
           accessibilityRole="button"
-          accessibilityLabel="Compose post"
+          accessibilityLabel="New post"
           accessibilityHint=""
         />
       </View>

--- a/src/view/screens/Home.tsx
+++ b/src/view/screens/Home.tsx
@@ -298,7 +298,7 @@ const FeedPage = observer(
           onPress={onPressCompose}
           icon={<ComposeIcon2 strokeWidth={1.5} size={29} style={s.white} />}
           accessibilityRole="button"
-          accessibilityLabel="Compose post"
+          accessibilityLabel="New post"
           accessibilityHint=""
         />
       </View>

--- a/src/view/screens/Profile.tsx
+++ b/src/view/screens/Profile.tsx
@@ -284,7 +284,7 @@ export const ProfileScreen = withAuthRequired(
           onPress={onPressCompose}
           icon={<ComposeIcon2 strokeWidth={1.5} size={29} style={s.white} />}
           accessibilityRole="button"
-          accessibilityLabel="Compose post"
+          accessibilityLabel="New post"
           accessibilityHint=""
         />
       </ScreenHider>

--- a/src/view/shell/desktop/LeftNav.tsx
+++ b/src/view/shell/desktop/LeftNav.tsx
@@ -177,7 +177,7 @@ function ComposeBtn() {
       style={[styles.newPostBtn]}
       onPress={onPressCompose}
       accessibilityRole="button"
-      accessibilityLabel="Compose post"
+      accessibilityLabel="New post"
       accessibilityHint="">
       <View style={styles.newPostBtnIconWrapper}>
         <ComposeIcon2


### PR DESCRIPTION
Fixes https://github.com/bluesky-social/social-app/issues/1298 based on @ashleemboyer's suggestion. Thanks @ewaccess for extra repro and testing tips.

The first commit changes left sidebar "Compose post" desktop web a11y label to "New post", resolving the original issue:

https://github.com/bluesky-social/social-app/assets/810438/9ea7be2a-6cec-4772-8153-7fa2c230564c

I opted to keep the explicit label though happy to remove it too.

In the second commit, I update other compose buttons (which don't have text labels) to also use "New post". This is to ensure it works on mobile layouts on the web, as well as to have consistency in the voice control wording between the platforms. (Note this may be disruptive to people already used to "compose". Alternatively, we could change the desktop label to "Compose post", but I opted not to.)

https://github.com/bluesky-social/social-app/assets/810438/c11373dc-70a2-4480-a7c8-075dfeb3c87c

Verified no surprises on iOS.

<img width="941" alt="Screenshot 2023-09-04 at 20 50 48" src="https://github.com/bluesky-social/social-app/assets/810438/4db2fdc3-9918-45c9-a47d-56ad56eb7024">

Assuming Android is fine, the change is trivial.