### PR TITLE
Fix caret jumps for web composer

### DIFF
--- a/src/view/com/composer/text-input/TextInput.web.tsx
+++ b/src/view/com/composer/text-input/TextInput.web.tsx
@@ -111,7 +111,7 @@ export const TextInput = React.forwardRef(
           },
         },
         content: textToEditorJson(richtext.text.toString()),
-        autofocus: true,
+        autofocus: 'end',
         editable: true,
         injectCSS: true,
         onUpdate({editor: editorProp}) {

--- a/src/view/com/composer/text-input/TextInput.web.tsx
+++ b/src/view/com/composer/text-input/TextInput.web.tsx
@@ -111,9 +111,6 @@ export const TextInput = React.forwardRef(
           },
         },
         content: textToEditorJson(richtext.text.toString()),
-        onFocus: ({editor: e}) => {
-          e.chain().focus().setTextSelection(richtext.text.length).run() // focus to the end of the text
-        },
         autofocus: true,
         editable: true,
         injectCSS: true,
@@ -146,7 +143,7 @@ export const TextInput = React.forwardRef(
 
     const onEmojiInserted = React.useCallback(
       (emoji: Emoji) => {
-        editor?.chain().focus('end').insertContent(emoji.native).run()
+        editor?.chain().focus().insertContent(emoji.native).run()
       },
       [editor],
     )


### PR DESCRIPTION
- Fixes https://github.com/bluesky-social/social-app/issues/1300
- Fixes caret jumping to the end when inserting an emoji in the middle of the post using our picker 
- Fixes caret jumping to the end when blurring out of the composer and focusing it back again (maybe controversial)

---

See https://github.com/bluesky-social/social-app/issues/1300#issuecomment-1705753534 for an explanation. TLDR:
- We shouldn't be jumping the caret when the user picks an emoji. They might be in the middle of the post anyway.
- We should not be reading mutable `.length` in order to "jump" the caret to the end — it appears that our text editing library does not guarantee whether the new value is flushed yet by the time `onFocus` fires.
  - Although we *could* have fixed that by using `focus('end')` instead of `focus().setTextSelection(...)`, we probably shouldn't be jumping the caret to the end _at all_ on focus anyway — since it's not what you actually want e.g. when inserting an emoji in the middle of the text. So I removed that line altogether unless we have some motivation to keep it. <s>I haven't found a case where it's needed yet.</s> (Edit: it was needed for first focus, so I fixed it [like this](https://github.com/bluesky-social/social-app/pull/1374#issuecomment-1705788704) instead.)

This might need a review from someone familiar with #1241 and #1254.
