### PR TITLE
Fix text color on waitlist join

### DIFF
--- a/src/view/com/modals/Waitlist.tsx
+++ b/src/view/com/modals/Waitlist.tsx
@@ -96,7 +96,7 @@ export function Component({}: {}) {
               icon="check"
               style={pal.text as FontAwesomeIconStyle}
             />
-            <Text style={s.ml10}>
+            <Text style={[s.ml10, pal.text]}>
               Your email has been saved! We&apos;ll be in touch soon.
             </Text>
           </View>


### PR DESCRIPTION
The text was not visible before so it was hard to know when you joined a waitlist successfully on dark mode.