### PR TITLE
Unify spacing of FollowersButton and FollowsButton of ProfileHeader

### DIFF
--- a/src/view/com/profile/ProfileHeader.tsx
+++ b/src/view/com/profile/ProfileHeader.tsx
@@ -470,8 +470,8 @@ const ProfileHeaderLoaded = observer(
                   accessibilityRole="button"
                   accessibilityLabel={`${followers} ${pluralizedFollowers}`}
                   accessibilityHint={'Opens followers list'}>
-                  <Text type="md" style={[s.bold, s.mr2, pal.text]}>
-                    {followers}
+                  <Text type="md" style={[s.bold, pal.text]}>
+                    {followers}{' '}
                   </Text>
                   <Text type="md" style={[pal.textLight]}>
                     {pluralizedFollowers}
@@ -484,8 +484,8 @@ const ProfileHeaderLoaded = observer(
                   accessibilityRole="button"
                   accessibilityLabel={`${following} following`}
                   accessibilityHint={'Opens following list'}>
-                  <Text type="md" style={[s.bold, s.mr2, pal.text]}>
-                    {following}
+                  <Text type="md" style={[s.bold, pal.text]}>
+                    {following}{' '}
                   </Text>
                   <Text type="md" style={[pal.textLight]}>
                     following


### PR DESCRIPTION
Fix #1388.

Change the spacing of the FollowersButton and FollowsButton to be the same as postsCount.