### PR TITLE
Update time.ts to handle very small or negative time differences

### DIFF
--- a/__tests__/lib/string.test.ts
+++ b/__tests__/lib/string.test.ts
@@ -175,6 +175,7 @@ describe('ago', () => {
     1671461038,
     '04 Dec 1995 00:12:00 GMT',
     new Date(),
+    new Date().setSeconds(new Date().getSeconds() - 10),
     new Date().setMinutes(new Date().getMinutes() - 10),
     new Date().setHours(new Date().getHours() - 1),
     new Date().setDate(new Date().getDate() - 1),
@@ -183,7 +184,8 @@ describe('ago', () => {
   const outputs = [
     new Date(1671461038).toLocaleDateString(),
     new Date('04 Dec 1995 00:12:00 GMT').toLocaleDateString(),
-    '0s',
+    'now',
+    '10s',
     '10m',
     '1h',
     '1d',

--- a/src/lib/strings/time.ts
+++ b/src/lib/strings/time.ts
@@ -1,3 +1,4 @@
+const NOW = 5
 const MINUTE = 60
 const HOUR = MINUTE * 60
 const DAY = HOUR * 24
@@ -13,7 +14,9 @@ export function ago(date: number | string | Date): string {
     ts = date
   }
   const diffSeconds = Math.floor((Date.now() - ts) / 1e3)
-  if (diffSeconds < MINUTE) {
+  if (diffSeconds < NOW) {
+    return `now`
+  } else if (diffSeconds < MINUTE) {
     return `${diffSeconds}s`
   } else if (diffSeconds < HOUR) {
     return `${Math.floor(diffSeconds / MINUTE)}m`


### PR DESCRIPTION
Right now, posts can appear to be from the future with a negative time difference (i.e. -3s appears). This change defines 'NOW' as less than 5 seconds old, and returns 'now' in that case.

It's not clear how localisation is handled - this may need translation.