### PR TITLE
Use frozen lockfile for CI workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Check out Git repository
         uses: actions/checkout@v3
       - name: Yarn install
-        run: yarn
+        run: yarn --frozen-lockfile
       - name: Lint check
         run: yarn lint
       - name: Type check
@@ -33,7 +33,7 @@ jobs:
       - name: Check out Git repository
         uses: actions/checkout@v3
       - name: Yarn install
-        run: yarn
+        run: yarn --frozen-lockfile
       - name: Run tests
         run: |
           yarn test --forceExit


### PR DESCRIPTION
Currently, running `yarn` on main produces a change in `yarn.lock`. This means that our CI doesn't check whether the lockfile is matching what's in `package.json`.

I think this flag is supposed to do that. I'd like to add it, <s>verify it'll fail the CI</s> (it doesn't, maybe due to https://github.com/yarnpkg/yarn/issues/5840, but it's still right to have it on), and then merge https://github.com/bluesky-social/social-app/pull/1393 with the fix.