### PR TITLE
💅 disallow overflow outside of post content area(s)

### DIFF
--- a/src/view/com/posts/FeedItem.tsx
+++ b/src/view/com/posts/FeedItem.tsx
@@ -349,6 +349,7 @@ const styles = StyleSheet.create({
     paddingLeft: 10,
     paddingRight: 15,
     cursor: 'pointer',
+    overflow: 'hidden',
   },
   outerSmallTop: {
     borderTopWidth: 0,

--- a/src/view/com/util/moderation/ContentHider.tsx
+++ b/src/view/com/util/moderation/ContentHider.tsx
@@ -29,7 +29,7 @@ export function ContentHider({
 
   if (!moderation.blur || (ignoreMute && moderation.cause?.type === 'muted')) {
     return (
-      <View testID={testID} style={style}>
+      <View testID={testID} style={[styles.outer, style]}>
         {children}
       </View>
     )
@@ -37,7 +37,7 @@ export function ContentHider({
 
   const desc = describeModerationCause(moderation.cause, 'content')
   return (
-    <View testID={testID} style={style}>
+    <View testID={testID} style={[styles.outer, style]}>
       <Pressable
         onPress={() => {
           if (!moderation.noOverride) {
@@ -90,6 +90,9 @@ export function ContentHider({
 }
 
 const styles = StyleSheet.create({
+  outer: {
+    overflow: 'hidden',
+  },
   cover: {
     flexDirection: 'row',
     alignItems: 'center',


### PR DESCRIPTION
Fixed an issue where Posts could overflow outside their content box

Adds `overflow: hidden` to Posts and post content

Previous behavior:
<img width="604" alt="Screenshot 2023-09-06 at 11 14 40 AM" src="https://github.com/bluesky-social/social-app/assets/215015/2a5fa5ca-4d3e-41e8-842e-8bcc0197d1d9">

Fixed behavior:
<img width="599" alt="Screenshot 2023-09-06 at 1 18 52 PM" src="https://github.com/bluesky-social/social-app/assets/215015/2746a880-cf3b-4580-8b7b-0c47e2b44847">

