### PR TITLE
add development codesigning config plugin

### DIFF
--- a/app.json
+++ b/app.json
@@ -69,6 +69,7 @@
       "url": "https://u.expo.dev/55bd077a-d905-4184-9c7f-94789ba0f302"
     },
     "plugins": [
+      ["./plugins/withIosCodeSigning", "XX11XX1XXX"],
       "expo-localization",
       "sentry-expo",
       [

--- a/plugins/withIosCodeSigning.js
+++ b/plugins/withIosCodeSigning.js
@@ -1,0 +1,54 @@
+const {IOSConfig, withXcodeProject} = require('expo/config-plugins')
+
+function mutateXcodeProjectWithAutoCodeSigningInfo({project, appleTeamId}) {
+  const targets = IOSConfig.Target.findSignableTargets(project)
+  const quotedAppleTeamId = ensureQuotes(appleTeamId)
+  for (const [nativeTargetId, nativeTarget] of targets) {
+    IOSConfig.XcodeUtils.getBuildConfigurationsForListId(
+      project,
+      nativeTarget.buildConfigurationList,
+    )
+      .filter(
+        ([, item]) => item.buildSettings.PRODUCT_NAME && item.name === 'Debug',
+      )
+      .forEach(([, item]) => {
+        item.buildSettings.DEVELOPMENT_TEAM = quotedAppleTeamId
+        item.buildSettings.CODE_SIGN_IDENTITY = '"Apple Development"'
+        item.buildSettings.CODE_SIGN_STYLE = 'Automatic'
+      })
+    Object.entries(IOSConfig.XcodeUtils.getProjectSection(project))
+      .filter(IOSConfig.XcodeUtils.isNotComment)
+      .forEach(([, item]) => {
+        if (!item.attributes.TargetAttributes) {
+          item.attributes.TargetAttributes = {}
+        }
+        if (!item.attributes.TargetAttributes[nativeTargetId]) {
+          item.attributes.TargetAttributes[nativeTargetId] = {}
+        }
+        item.attributes.TargetAttributes[nativeTargetId].DevelopmentTeam =
+          quotedAppleTeamId
+        item.attributes.TargetAttributes[nativeTargetId].ProvisioningStyle =
+          'Automatic'
+      })
+  }
+  return project
+}
+
+const ensureQuotes = value => {
+  if (!value.match(/^['"]/)) {
+    return `"${value}"`
+  }
+  return value
+}
+
+const withDevSigning = (config, teamId) => {
+  return withXcodeProject(config, config => {
+    config.modResults = mutateXcodeProjectWithAutoCodeSigningInfo({
+      project: config.modResults,
+      appleTeamId: teamId,
+    })
+    return config
+  })
+}
+
+module.exports = withDevSigning


### PR DESCRIPTION
We'll upstream this functionality in the future, but for reference, here's how you can configure your project to have development codesigning added during prebuild. Just swap out the `XX11XX1XXX` with the Apple team ID. The team ID can be located in the `ios/Bluesky.xcodeproj/project.pbxproj` file, under `DevelopmentTeam = "XX11XX1XXX";` where the `XX11XX1XXX` is your signing ID. Add this value to the `app.json` and it should always be used for development profiles.

The logic comes from [what we use](https://github.com/expo/expo/blob/main/packages/%40expo/cli/src/run/ios/codeSigning/xcodeCodeSigning.ts) in Expo CLI during `npx expo run:ios` to configure signing.