### PR TITLE
Use expo prebuild --clean

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "prepare": "is-ci || husky install",
     "postinstall": "patch-package",
-    "prebuild": "expo prebuild",
+    "prebuild": "expo prebuild --clean",
     "android": "expo run:android",
     "ios": "expo run:ios",
     "web": "expo start --web",


### PR DESCRIPTION
We already leave `android/` and `ios/` gitignored. This means we can use the [clean](https://docs.expo.dev/workflow/prebuild/#clean) workflow ("generally recommended in most cases" per the docs) where `prebuild` _always_ regenerates stuff from scratch. In practice I've run into weird errors that I couldn't resolve otherwise, and this would have caught that. In general it's nice to enforce clean predictable builds.

The downside is that _if nothing has actually changed_ and you ran `yarn prebuild`, it'll take an extra minute for next `yarn prebuild + yarn ios`. If this gets really annoying in practice we can add another script that just does `expo prebuild` but for now I didn't cause I don't know if we'll actually need it.

Let's give this a try?