### PR TITLE
Fix scrollbar gutters on web

### DIFF
--- a/bskyweb/templates/base.html
+++ b/bskyweb/templates/base.html
@@ -91,6 +91,9 @@
     *[data-word-wrap] {
       word-break: break-word;
     }
+    *[data-stable-gutters] {
+      scrollbar-gutter: stable both-edges;
+    }
 
     /* ProseMirror */
     .ProseMirror {

--- a/src/view/com/pager/FeedsTabBar.web.tsx
+++ b/src/view/com/pager/FeedsTabBar.web.tsx
@@ -73,8 +73,4 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
   },
-  tabBarAvi: {
-    marginTop: 1,
-    marginRight: 18,
-  },
 })

--- a/src/view/com/util/Views.web.tsx
+++ b/src/view/com/util/Views.web.tsx
@@ -78,7 +78,9 @@ export const FlatList = React.forwardRef(function <ItemT>(
       // around this, we set data-stable-gutters which can then be
       // styled in our external CSS.
       // -prf
+      // @ts-ignore web only -prf
       props.dataSet = props.dataSet || {}
+      // @ts-ignore web only -prf
       props.dataSet.stableGutters = '1'
     }
   }

--- a/src/view/com/util/Views.web.tsx
+++ b/src/view/com/util/Views.web.tsx
@@ -70,10 +70,16 @@ export const FlatList = React.forwardRef(function <ItemT>(
   if (desktopFixedHeight) {
     style = addStyle(style, styles.fixedHeight)
     if (!isMobile) {
-      contentContainerStyle = addStyle(
-        contentContainerStyle,
-        styles.stableGutters,
-      )
+      // NOTE
+      // react native web produces *three* wrapping divs
+      // the first two use the `style` prop and the innermost uses the
+      // `contentContainerStyle`. Unfortunately the stable-gutter style
+      // needs to be applied to only the "middle" of these. To hack
+      // around this, we set data-stable-gutters which can then be
+      // styled in our external CSS.
+      // -prf
+      props.dataSet = props.dataSet || {}
+      props.dataSet.stableGutters = '1'
     }
   }
   return (
@@ -136,9 +142,5 @@ const styles = StyleSheet.create({
   fixedHeight: {
     // @ts-ignore web only
     height: '100vh',
-  },
-  stableGutters: {
-    // @ts-ignore web only -prf
-    scrollbarGutter: 'stable both-edges',
   },
 })

--- a/web/index.html
+++ b/web/index.html
@@ -95,6 +95,9 @@
       *[data-word-wrap] {
         word-break: break-word;
       }
+      *[data-stable-gutters] {
+        scrollbar-gutter: stable both-edges;
+      }
 
       /* ProseMirror */
       .ProseMirror {


### PR DESCRIPTION
This got broken with a "fix" I snuck into the responsive layout, but this finally fixes it for real. (See the comment for an explanation.)

Before:

<img width="679" alt="CleanShot 2023-09-06 at 17 19 46@2x" src="https://github.com/bluesky-social/social-app/assets/1270099/ec7a7db7-c015-4d2a-b503-d529e9aff80d">

After:

<img width="645" alt="CleanShot 2023-09-06 at 17 19 31@2x" src="https://github.com/bluesky-social/social-app/assets/1270099/059134cf-cb95-46c8-8f60-b6031a98dba0">
