### PR TITLE
Fix lint-staged not allowing edits to Markdown files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,6 +7,9 @@ module.exports = {
   ],
   parser: '@typescript-eslint/parser',
   plugins: ['@typescript-eslint', 'detox'],
+  rules: {
+    'react-native/no-inline-styles': 0,
+  },
   ignorePatterns: [
     '**/__mocks__/*.ts',
     'src/platform/polyfills.ts',
@@ -20,14 +23,5 @@ module.exports = {
     'bskyweb',
     '*.html',
     'bskyweb',
-  ],
-  overrides: [
-    {
-      files: ['*.js', '*.mjs', '*.ts', '*.tsx'],
-      rules: {
-        semi: [2, 'never'],
-        'react-native/no-inline-styles': 0,
-      },
-    },
   ],
 }

--- a/package.json
+++ b/package.json
@@ -252,6 +252,6 @@
     ]
   },
   "lint-staged": {
-    "*": "yarn eslint --ext .js,.jsx,.ts,.tsx --fix"
+    "*{.js,.jsx,.ts,.tsx}": "yarn eslint --fix"
   }
 }


### PR DESCRIPTION
I tried editing `docs/build.md` but committing it didn't work. Our lint-staged setup calls ESLint on a Markdown file, which breaks it. I've tweaked it so that we only run ESLint on the files that actually can be linted.

As a drive-by fix, noticed a seemingly unnecessary `overrides` option. I've folded it into the main config.