### PR TITLE
Fix autocomplete avatar alignment

### DIFF
--- a/src/view/com/composer/text-input/mobile/Autocomplete.tsx
+++ b/src/view/com/composer/text-input/mobile/Autocomplete.tsx
@@ -93,7 +93,7 @@ export const Autocomplete = observer(function AutocompleteImpl({
 
 const styles = StyleSheet.create({
   container: {
-    marginLeft: -54,
+    marginLeft: -50, // Composer avatar width
     top: 10,
     borderTopWidth: 1,
   },


### PR DESCRIPTION
Fixes https://github.com/bluesky-social/social-app/issues/1273

Although the clipping issue was Android-specific, it was misaligned on iOS too. This aligns it exactly.

## Android

<img width="413" alt="Screenshot 2023-09-08 at 13 47 50" src="https://github.com/bluesky-social/social-app/assets/810438/79cfdc48-25ae-4626-ba80-731f66e21499">

## iOS

<img width="413" alt="Screenshot 2023-09-08 at 13 47 50" src="https://github.com/bluesky-social/social-app/assets/810438/f0861696-0d2b-4484-948f-c5fe37e9eba0">
