### PR TITLE
Set crop mode to None by default

### DIFF
--- a/src/state/models/media/image.ts
+++ b/src/state/models/media/image.ts
@@ -32,7 +32,7 @@ export class ImageModel implements Omit<RNImage, 'size'> {
   // Web manipulation
   prev?: RNImage
   attributes: ImageManipulationAttributes = {
-    aspectRatio: '1:1',
+    aspectRatio: 'None',
     scale: 1,
     flipHorizontal: false,
     flipVertical: false,


### PR DESCRIPTION
Fixes #1263

Previously, opening the crop tool had 1:1 selected by default. So if you opened it and pressed Done without changing anything, it would format the image as 1:1.

After this change, None is selected by default. So if you open the crop tool and press Done without changing anything, nothing will change.