### PR TITLE
post composer: inhibit Cmd-Enter from inputting newline

### DIFF
--- a/src/view/com/composer/text-input/TextInput.web.tsx
+++ b/src/view/com/composer/text-input/TextInput.web.tsx
@@ -103,6 +103,7 @@ export const TextInput = React.forwardRef(function TextInputImpl(
         handleKeyDown: (_, event) => {
           if ((event.metaKey || event.ctrlKey) && event.code === 'Enter') {
             textInputWebEmitter.emit('publish')
+            return true
           }
         },
       },


### PR DESCRIPTION
Hi, something I’ve found quite jarring in the implementation of the post composer is that pressing Cmd-Enter (or Ctrl-Enter) causes a newline to be entered into the input area, which always makes me double-guess if that newline has made it into the post I’ve just posted. (It never does, but the visuals speak to me otherwise.) So here I return `true` in the event handler to prevent this from happening :)

(PS. I’ve read your contribution guidelines but thought this was a small enough patch that I should be fine submitting it as-is.)