### PR TITLE
Revert "Fix 1338 mark notifications read with timeout and on app state change"

### DIFF
--- a/src/view/screens/Notifications.tsx
+++ b/src/view/screens/Notifications.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import {AppState, FlatList, View} from 'react-native'
+import {FlatList, View} from 'react-native'
 import {useFocusEffect} from '@react-navigation/native'
 import {observer} from 'mobx-react-lite'
 import {
@@ -18,7 +18,6 @@ import {s} from 'lib/styles'
 import {useAnalytics} from 'lib/analytics/analytics'
 import {isWeb} from 'platform/detection'
 
-const NOTIFICATION_MARK_READ_TIMEOUT = 5000
 type Props = NativeStackScreenProps<
   NotificationsTabNavigatorParams,
   'Notifications'
@@ -56,22 +55,10 @@ export const NotificationsScreen = withAuthRequired(
         const softResetSub = store.onScreenSoftReset(onPressLoadLatest)
         store.me.notifications.update()
         screen('Notifications')
-        // marks notifications read if the user opens the notifications tab for x seconds
-        // but doesn't open any notifications or any other tab
-        const markReadTimeout = setTimeout(() => {
-          store.me.notifications.markAllRead()
-        }, NOTIFICATION_MARK_READ_TIMEOUT) // mark all notifications as read after 3s
-        // marks notification read if the user suspends the app while in the notification tab
-        // then opens the app into the notification tab and then closes the app again
-        const markReadOnBlur = AppState.addEventListener('change', event => {
-          if (event === 'background') store.me.notifications.markAllRead()
-        })
 
         return () => {
           softResetSub.remove()
-          markReadOnBlur.remove()
           store.me.notifications.markAllRead()
-          clearTimeout(markReadTimeout) // in case we unmount before the timeout fires
         }
       }, [store, screen, onPressLoadLatest]),
     )


### PR DESCRIPTION
Reverts bluesky-social/social-app#1340

This change really hasn't been working, and I think it does the wrong thing relative to the request. I think what people want is for the notification _counter_ to clear. What 1340 did was clear the unread state entirely, making you lose track of new items.

I spent a couple minutes seeing if I could just update the counter, but it wasn't super easy. If you call `updateSeenNotifications` then any notifications you load during pagination will start to come in as "read" even if they're new. So the solution to this is going to have to be a new approach to the unread counter that divorces itself from the server state. It's doable, but not in time for today's release, so I want to revert this change.