### PR TITLE
Fix #1359 share mute list link with did not handle

### DIFF
--- a/src/state/models/content/list.ts
+++ b/src/state/models/content/list.ts
@@ -103,6 +103,10 @@ export class ListModel {
     return this.list?.viewer?.muted
   }
 
+  get creatorDid() {
+    return this.list?.creator.did
+  }
+
   // public api
   // =
 

--- a/src/view/screens/ProfileList.tsx
+++ b/src/view/screens/ProfileList.tsx
@@ -97,9 +97,9 @@ export const ProfileListScreen = withAuthRequired(
     }, [store, list])
 
     const onPressShareList = React.useCallback(() => {
-      const url = toShareUrl(`/profile/${name}/lists/${rkey}`)
+      const url = toShareUrl(`/profile/${list.creatorDid}/lists/${rkey}`)
       shareUrl(url)
-    }, [name, rkey])
+    }, [list.creatorDid, rkey])
 
     const renderEmptyState = React.useCallback(() => {
       return <EmptyState icon="users-slash" message="This list is empty!" />


### PR DESCRIPTION
Fixes #1359 

Right now I made it so that the share button shares the link of the mute list with the `did` instead of the `handle`

However, we should probably fix the `getLists` endpoint on the graph service to resolve when using handles as well as dids for a better user experience since some users might just copy the link from the address bar on browsers

<img width="635" alt="CleanShot 2023-09-12 at 17 20 26@2x" src="https://github.com/bluesky-social/social-app/assets/8207733/1b301aba-691e-499a-91d7-f36f24df574a">
<img width="638" alt="CleanShot 2023-09-12 at 17 20 46@2x" src="https://github.com/bluesky-social/social-app/assets/8207733/a84221ed-71f0-4d7c-b248-a0f5c212747d">
