### PR TITLE
Fix 1365 wrap impersonation text

### DIFF
--- a/src/view/com/util/moderation/PostAlerts.tsx
+++ b/src/view/com/util/moderation/PostAlerts.tsx
@@ -38,11 +38,11 @@ export function PostAlerts({
       accessibilityHint=""
       style={[styles.container, pal.viewLight, style]}>
       <ShieldExclamation style={pal.text} size={16} />
-      <Text type="lg" style={pal.text}>
-        {desc.name}
-      </Text>
-      <Text type="lg" style={[pal.link, styles.learnMoreBtn]}>
-        Learn More
+      <Text type="lg" style={[pal.text]}>
+        {desc.name}{' '}
+        <Text type="lg" style={[pal.link, styles.learnMoreBtn]}>
+          Learn More
+        </Text>
       </Text>
     </Pressable>
   )


### PR DESCRIPTION
Fixes #1365 

BEFORE
![image](https://github.com/bluesky-social/social-app/assets/8207733/45e1ed85-61e2-482a-9469-1c1eece505ed)

AFTER
<img width="486" alt="CleanShot 2023-09-13 at 23 22 24@2x" src="https://github.com/bluesky-social/social-app/assets/8207733/c5b25086-2e8a-4a20-b3b4-f1577516e8ae">

<img width="493" alt="CleanShot 2023-09-13 at 23 22 34@2x" src="https://github.com/bluesky-social/social-app/assets/8207733/cc2a33b1-b6d0-48dd-bcb2-01f6bceaa266">
