### PR TITLE
Add a preference for showing replies among followed users only

### DIFF
--- a/src/lib/api/feed-manip.ts
+++ b/src/lib/api/feed-manip.ts
@@ -97,6 +97,23 @@ export class FeedViewPostsSlice {
       }
     }
   }
+
+  isFollowingAllAuthors(userDid: string) {
+    const item = this.rootItem
+    if (item.post.author.did === userDid) {
+      return true
+    }
+    if (AppBskyFeedDefs.isPostView(item.reply?.parent)) {
+      const parent = item.reply?.parent
+      if (parent?.author.did === userDid) {
+        return true
+      }
+      return (
+        parent?.author.viewer?.following && item.post.author.viewer?.following
+      )
+    }
+    return false
+  }
 }
 
 export class FeedTuner {
@@ -228,20 +245,34 @@ export class FeedTuner {
     return slices
   }
 
-  static likedRepliesOnly({repliesThreshold}: {repliesThreshold: number}) {
+  static thresholdRepliesOnly({
+    userDid,
+    minLikes,
+    followedOnly,
+  }: {
+    userDid: string
+    minLikes: number
+    followedOnly: boolean
+  }) {
     return (
       tuner: FeedTuner,
       slices: FeedViewPostsSlice[],
     ): FeedViewPostsSlice[] => {
-      // remove any replies without at least repliesThreshold likes
+      // remove any replies without at least minLikes likes
       for (let i = slices.length - 1; i >= 0; i--) {
-        if (slices[i].isFullThread || !slices[i].isReply) {
+        const slice = slices[i]
+        if (slice.isFullThread || !slice.isReply) {
           continue
         }
 
-        const item = slices[i].rootItem
+        const item = slice.rootItem
         const isRepost = Boolean(item.reason)
-        if (!isRepost && (item.post.likeCount || 0) < repliesThreshold) {
+        if (isRepost) {
+          continue
+        }
+        if ((item.post.likeCount || 0) < minLikes) {
+          slices.splice(i, 1)
+        } else if (followedOnly && !slice.isFollowingAllAuthors(userDid)) {
           slices.splice(i, 1)
         }
       }

--- a/src/state/models/feeds/posts.ts
+++ b/src/state/models/feeds/posts.ts
@@ -141,8 +141,8 @@ export class PostsFeedModel {
 
   get feedTuners() {
     const areRepliesEnabled = this.rootStore.preferences.homeFeedRepliesEnabled
-    const areRepliesFollowedOnlyEnabled =
-      this.rootStore.preferences.homeFeedRepliesFollowedOnlyEnabled
+    const areRepliesByFollowedOnlyEnabled =
+      this.rootStore.preferences.homeFeedRepliesByFollowedOnlyEnabled
     const repliesThreshold = this.rootStore.preferences.homeFeedRepliesThreshold
     const areRepostsEnabled = this.rootStore.preferences.homeFeedRepostsEnabled
     const areQuotePostsEnabled =
@@ -170,7 +170,7 @@ export class PostsFeedModel {
           FeedTuner.thresholdRepliesOnly({
             userDid: this.rootStore.session.data?.did || '',
             minLikes: repliesThreshold,
-            followedOnly: areRepliesFollowedOnlyEnabled,
+            followedOnly: areRepliesByFollowedOnlyEnabled,
           }),
         )
       } else {

--- a/src/state/models/feeds/posts.ts
+++ b/src/state/models/feeds/posts.ts
@@ -141,6 +141,8 @@ export class PostsFeedModel {
 
   get feedTuners() {
     const areRepliesEnabled = this.rootStore.preferences.homeFeedRepliesEnabled
+    const areRepliesFollowedOnlyEnabled =
+      this.rootStore.preferences.homeFeedRepliesFollowedOnlyEnabled
     const repliesThreshold = this.rootStore.preferences.homeFeedRepliesThreshold
     const areRepostsEnabled = this.rootStore.preferences.homeFeedRepostsEnabled
     const areQuotePostsEnabled =
@@ -164,7 +166,13 @@ export class PostsFeedModel {
       }
 
       if (areRepliesEnabled) {
-        feedTuners.push(FeedTuner.likedRepliesOnly({repliesThreshold}))
+        feedTuners.push(
+          FeedTuner.thresholdRepliesOnly({
+            userDid: this.rootStore.session.data?.did || '',
+            minLikes: repliesThreshold,
+            followedOnly: areRepliesFollowedOnlyEnabled,
+          }),
+        )
       } else {
         feedTuners.push(FeedTuner.removeReplies)
       }

--- a/src/state/models/ui/preferences.ts
+++ b/src/state/models/ui/preferences.ts
@@ -12,7 +12,6 @@ import {LANGUAGES} from '../../../locale/languages'
 
 // TEMP we need to permanently convert 'show' to 'ignore', for now we manually convert -prf
 export type LabelPreference = APILabelPreference | 'show'
-type HomeFeedRepliesMode = 'yes' | 'followed-only' | 'no'
 const LABEL_GROUPS = [
   'nsfw',
   'nudity',
@@ -51,8 +50,8 @@ export class PreferencesModel {
   pinnedFeeds: string[] = []
   birthDate: Date | undefined = undefined
   homeFeedRepliesEnabled: boolean = true
-  homeFeedRepliesFollowedOnlyEnabled: boolean = true
-  homeFeedRepliesThreshold: number = 2
+  homeFeedRepliesByFollowedOnlyEnabled: boolean = true
+  homeFeedRepliesThreshold: number = 0
   homeFeedRepostsEnabled: boolean = true
   homeFeedQuotePostsEnabled: boolean = true
   homeFeedMergeFeedEnabled: boolean = false
@@ -72,17 +71,6 @@ export class PreferencesModel {
     return getAge(this.birthDate)
   }
 
-  get homeFeedRepliesMode(): HomeFeedRepliesMode {
-    if (this.homeFeedRepliesEnabled) {
-      if (this.homeFeedRepliesFollowedOnlyEnabled) {
-        return 'followed-only'
-      } else {
-        return 'yes'
-      }
-    }
-    return 'no'
-  }
-
   serialize() {
     return {
       contentLanguages: this.contentLanguages,
@@ -92,8 +80,8 @@ export class PreferencesModel {
       savedFeeds: this.savedFeeds,
       pinnedFeeds: this.pinnedFeeds,
       homeFeedRepliesEnabled: this.homeFeedRepliesEnabled,
-      homeFeedRepliesFollowedOnlyEnabled:
-        this.homeFeedRepliesFollowedOnlyEnabled,
+      homeFeedRepliesByFollowedOnlyEnabled:
+        this.homeFeedRepliesByFollowedOnlyEnabled,
       homeFeedRepliesThreshold: this.homeFeedRepliesThreshold,
       homeFeedRepostsEnabled: this.homeFeedRepostsEnabled,
       homeFeedQuotePostsEnabled: this.homeFeedQuotePostsEnabled,
@@ -167,11 +155,11 @@ export class PreferencesModel {
       }
       // check if home feed replies "followed only" are enabled in preferences, then hydrate
       if (
-        hasProp(v, 'homeFeedRepliesFollowedOnlyEnabled') &&
-        typeof v.homeFeedRepliesFollowedOnlyEnabled === 'boolean'
+        hasProp(v, 'homeFeedRepliesByFollowedOnlyEnabled') &&
+        typeof v.homeFeedRepliesByFollowedOnlyEnabled === 'boolean'
       ) {
-        this.homeFeedRepliesFollowedOnlyEnabled =
-          v.homeFeedRepliesFollowedOnlyEnabled
+        this.homeFeedRepliesByFollowedOnlyEnabled =
+          v.homeFeedRepliesByFollowedOnlyEnabled
       }
       // check if home feed replies threshold is enabled in preferences, then hydrate
       if (
@@ -477,17 +465,13 @@ export class PreferencesModel {
     await this.rootStore.agent.setPersonalDetails({birthDate})
   }
 
-  setHomeFeedRepliesMode(v: string) {
-    if (v === 'yes') {
-      this.homeFeedRepliesEnabled = true
-      this.homeFeedRepliesFollowedOnlyEnabled = false
-    } else if (v === 'followed-only') {
-      this.homeFeedRepliesEnabled = true
-      this.homeFeedRepliesFollowedOnlyEnabled = true
-    } else {
-      this.homeFeedRepliesEnabled = false
-      this.homeFeedRepliesFollowedOnlyEnabled = false
-    }
+  toggleHomeFeedRepliesEnabled() {
+    this.homeFeedRepliesEnabled = !this.homeFeedRepliesEnabled
+  }
+
+  toggleHomeFeedRepliesByFollowedOnlyEnabled() {
+    this.homeFeedRepliesByFollowedOnlyEnabled =
+      !this.homeFeedRepliesByFollowedOnlyEnabled
   }
 
   setHomeFeedRepliesThreshold(threshold: number) {

--- a/src/view/com/posts/FeedSlice.tsx
+++ b/src/view/com/posts/FeedSlice.tsx
@@ -56,7 +56,7 @@ export const FeedSlice = observer(function FeedSliceImpl({
         <FeedItem
           key={item._reactKey}
           item={item}
-          source={slice.source}
+          source={i === 0 ? slice.source : undefined}
           isThreadParent={slice.isThreadParentAt(i)}
           isThreadChild={slice.isThreadChildAt(i)}
           isThreadLastChild={

--- a/src/view/screens/PreferencesHomeFeed.tsx
+++ b/src/view/screens/PreferencesHomeFeed.tsx
@@ -9,7 +9,6 @@ import {usePalette} from 'lib/hooks/usePalette'
 import {useWebMediaQueries} from 'lib/hooks/useWebMediaQueries'
 import {isWeb} from 'platform/detection'
 import {ToggleButton} from 'view/com/util/forms/ToggleButton'
-import {RadioGroup} from 'view/com/util/forms/RadioGroup'
 import {CommonNavigatorParams, NativeStackScreenProps} from 'lib/routes/types'
 import {ViewHeader} from 'view/com/util/ViewHeader'
 import {CenteredView} from 'view/com/util/Views'
@@ -20,14 +19,7 @@ function RepliesThresholdInput({enabled}: {enabled: boolean}) {
   const [value, setValue] = useState(store.preferences.homeFeedRepliesThreshold)
 
   return (
-    <View style={[s.mt10, !enabled && styles.dimmed]}>
-      <Text type="xs" style={pal.text}>
-        {value === 0
-          ? `Show all replies`
-          : `Show replies with at least ${value} ${
-              value > 1 ? `likes` : `like`
-            }`}
-      </Text>
+    <View style={[!enabled && styles.dimmed]}>
       <Slider
         value={value}
         onValueChange={(v: number | number[]) => {
@@ -41,6 +33,13 @@ function RepliesThresholdInput({enabled}: {enabled: boolean}) {
         disabled={!enabled}
         thumbTintColor={colors.blue3}
       />
+      <Text type="xs" style={pal.text}>
+        {value === 0
+          ? `Show all replies`
+          : `Show replies with at least ${value} ${
+              value > 1 ? `likes` : `like`
+            }`}
+      </Text>
     </View>
   )
 }
@@ -80,26 +79,41 @@ export const PreferencesHomeFeed = observer(function PreferencesHomeFeedImpl({
               Show Replies
             </Text>
             <Text style={[pal.text, s.pb10]}>
-              Set this setting to "No" to never see replies.
+              Set this setting to "No" to hide all replies from your feed.
             </Text>
-            <View
-              style={[
-                pal.view,
-                {borderRadius: 18, paddingVertical: 6, marginBottom: 10},
-              ]}>
-              <RadioGroup
-                type="default-light"
-                items={[
-                  {key: 'yes', label: 'Yes'},
-                  {key: 'followed-only', label: 'Between followed users only'},
-                  {key: 'no', label: 'No'},
-                ]}
-                initialSelection={store.preferences.homeFeedRepliesMode}
-                onSelect={store.preferences.setHomeFeedRepliesMode}
-              />
-            </View>
-
-            <Text style={[pal.text, s.pb5]}>
+            <ToggleButton
+              type="default-light"
+              label={store.preferences.homeFeedRepliesEnabled ? 'Yes' : 'No'}
+              isSelected={store.preferences.homeFeedRepliesEnabled}
+              onPress={store.preferences.toggleHomeFeedRepliesEnabled}
+            />
+          </View>
+          <View
+            style={[
+              pal.viewLight,
+              styles.card,
+              !store.preferences.homeFeedRepliesEnabled && styles.dimmed,
+            ]}>
+            <Text type="title-sm" style={[pal.text, s.pb5]}>
+              Reply Filters
+            </Text>
+            <Text style={[pal.text, s.pb10]}>
+              Enable this setting to only see replies between people you follow.
+            </Text>
+            <ToggleButton
+              type="default-light"
+              label="Followed users only"
+              isSelected={
+                store.preferences.homeFeedRepliesByFollowedOnlyEnabled
+              }
+              onPress={
+                store.preferences.homeFeedRepliesEnabled
+                  ? store.preferences.toggleHomeFeedRepliesByFollowedOnlyEnabled
+                  : undefined
+              }
+              style={[s.mb10]}
+            />
+            <Text style={[pal.text]}>
               Adjust the number of likes a reply must have to be shown in your
               feed.
             </Text>

--- a/src/view/screens/PreferencesHomeFeed.tsx
+++ b/src/view/screens/PreferencesHomeFeed.tsx
@@ -9,6 +9,7 @@ import {usePalette} from 'lib/hooks/usePalette'
 import {useWebMediaQueries} from 'lib/hooks/useWebMediaQueries'
 import {isWeb} from 'platform/detection'
 import {ToggleButton} from 'view/com/util/forms/ToggleButton'
+import {RadioGroup} from 'view/com/util/forms/RadioGroup'
 import {CommonNavigatorParams, NativeStackScreenProps} from 'lib/routes/types'
 import {ViewHeader} from 'view/com/util/ViewHeader'
 import {CenteredView} from 'view/com/util/Views'
@@ -79,16 +80,29 @@ export const PreferencesHomeFeed = observer(function PreferencesHomeFeedImpl({
               Show Replies
             </Text>
             <Text style={[pal.text, s.pb10]}>
+              Set this setting to "No" to never see replies.
+            </Text>
+            <View
+              style={[
+                pal.view,
+                {borderRadius: 18, paddingVertical: 6, marginBottom: 10},
+              ]}>
+              <RadioGroup
+                type="default-light"
+                items={[
+                  {key: 'yes', label: 'Yes'},
+                  {key: 'followed-only', label: 'Between followed users only'},
+                  {key: 'no', label: 'No'},
+                ]}
+                initialSelection={store.preferences.homeFeedRepliesMode}
+                onSelect={store.preferences.setHomeFeedRepliesMode}
+              />
+            </View>
+
+            <Text style={[pal.text, s.pb5]}>
               Adjust the number of likes a reply must have to be shown in your
               feed.
             </Text>
-            <ToggleButton
-              type="default-light"
-              label={store.preferences.homeFeedRepliesEnabled ? 'Yes' : 'No'}
-              isSelected={store.preferences.homeFeedRepliesEnabled}
-              onPress={store.preferences.toggleHomeFeedRepliesEnabled}
-            />
-
             <RepliesThresholdInput
               enabled={store.preferences.homeFeedRepliesEnabled}
             />


### PR DESCRIPTION
Adds a preference for filtering replies to only show between followed users. Open to suggestions on code _and_ UI, this is a bit yolo.
<img width="579" alt="CleanShot 2023-09-13 at 19 10 00@2x" src="https://github.com/bluesky-social/social-app/assets/1270099/40a45e99-b429-43b8-afbe-35b5d4aae4e1">
