### PR TITLE
don't thread a self-repost of a self-reply

### DIFF
--- a/src/lib/api/feed-manip.ts
+++ b/src/lib/api/feed-manip.ts
@@ -281,7 +281,10 @@ export class FeedTuner {
 
 function getSelfReplyUri(item: FeedViewPost): string | undefined {
   if (item.reply) {
-    if (AppBskyFeedDefs.isPostView(item.reply.parent)) {
+    if (
+      AppBskyFeedDefs.isPostView(item.reply.parent) &&
+      !AppBskyFeedDefs.isReasonRepost(item.reason) // don't thread respoted self-replies
+    ) {
       return item.reply.parent.author.did === item.post.author.did
         ? item.reply.parent.uri
         : undefined

--- a/src/lib/api/feed-manip.ts
+++ b/src/lib/api/feed-manip.ts
@@ -283,7 +283,7 @@ function getSelfReplyUri(item: FeedViewPost): string | undefined {
   if (item.reply) {
     if (
       AppBskyFeedDefs.isPostView(item.reply.parent) &&
-      !AppBskyFeedDefs.isReasonRepost(item.reason) // don't thread respoted self-replies
+      !AppBskyFeedDefs.isReasonRepost(item.reason) // don't thread reposted self-replies
     ) {
       return item.reply.parent.author.did === item.post.author.did
         ? item.reply.parent.uri


### PR DESCRIPTION
Fixes https://github.com/bluesky-social/social-app/issues/1371

Originally thought this was a backend thing, but actually we were just mistakenly threading the reposted `reply` if the feed response didn't also contain the plain-ol' `reply` itself. See below for example:

<img width="647" alt="Screen Shot 2023-09-13 at 3 45 52 PM" src="https://github.com/bluesky-social/social-app/assets/4732330/b1abd157-6aac-420d-9d5f-6d909e8a1c76">

Whereas in the posts-and-replies view we get both the plain-ol' reply _and_ the reposted reply, so it doesn't get threaded.
<img width="655" alt="Screen Shot 2023-09-13 at 3 45 58 PM" src="https://github.com/bluesky-social/social-app/assets/4732330/094b5a47-96d0-4e04-96b8-dbf27d6d26bd">

So the fix looks like this (see last two posts in feed):
<img width="676" alt="Screen Shot 2023-09-14 at 12 28 06 PM" src="https://github.com/bluesky-social/social-app/assets/4732330/39242009-ad97-4910-8f84-e063b5a02222">
