### PR TITLE
improve drawer reflow for large text

### DIFF
--- a/src/view/shell/Drawer.tsx
+++ b/src/view/shell/Drawer.tsx
@@ -145,41 +145,45 @@ export const DrawerContent = observer(function DrawerContentImpl() {
         theme.colorScheme === 'light' ? pal.view : styles.viewDarkMode,
       ]}>
       <SafeAreaView style={s.flex1}>
-        <View style={styles.main}>
-          <TouchableOpacity
-            testID="profileCardButton"
-            accessibilityLabel="Profile"
-            accessibilityHint="Navigates to your profile"
-            onPress={onPressProfile}>
-            <UserAvatar size={80} avatar={store.me.avatar} />
-            <Text
-              type="title-lg"
-              style={[pal.text, s.bold, styles.profileCardDisplayName]}
-              numberOfLines={1}>
-              {store.me.displayName || store.me.handle}
-            </Text>
-            <Text
-              type="2xl"
-              style={[pal.textLight, styles.profileCardHandle]}
-              numberOfLines={1}>
-              @{store.me.handle}
-            </Text>
-            <Text
-              type="xl"
-              style={[pal.textLight, styles.profileCardFollowers]}>
-              <Text type="xl-medium" style={pal.text}>
-                {formatCountShortOnly(store.me.followersCount ?? 0)}
-              </Text>{' '}
-              {pluralize(store.me.followersCount || 0, 'follower')} &middot;{' '}
-              <Text type="xl-medium" style={pal.text}>
-                {formatCountShortOnly(store.me.followsCount ?? 0)}
-              </Text>{' '}
-              following
-            </Text>
-          </TouchableOpacity>
-        </View>
-        <InviteCodes />
         <ScrollView style={styles.main}>
+          <View style={{}}>
+            <TouchableOpacity
+              testID="profileCardButton"
+              accessibilityLabel="Profile"
+              accessibilityHint="Navigates to your profile"
+              onPress={onPressProfile}>
+              <UserAvatar size={80} avatar={store.me.avatar} />
+              <Text
+                type="title-lg"
+                style={[pal.text, s.bold, styles.profileCardDisplayName]}
+                numberOfLines={1}>
+                {store.me.displayName || store.me.handle}
+              </Text>
+              <Text
+                type="2xl"
+                style={[pal.textLight, styles.profileCardHandle]}
+                numberOfLines={1}>
+                @{store.me.handle}
+              </Text>
+              <Text
+                type="xl"
+                style={[pal.textLight, styles.profileCardFollowers]}>
+                <Text type="xl-medium" style={pal.text}>
+                  {formatCountShortOnly(store.me.followersCount ?? 0)}
+                </Text>{' '}
+                {pluralize(store.me.followersCount || 0, 'follower')} &middot;{' '}
+                <Text type="xl-medium" style={pal.text}>
+                  {formatCountShortOnly(store.me.followsCount ?? 0)}
+                </Text>{' '}
+                following
+              </Text>
+            </TouchableOpacity>
+          </View>
+
+          <InviteCodes style={{paddingLeft: 0}} />
+
+          <View style={{height: 10}} />
+
           <MenuItem
             icon={
               isAtSearch ? (
@@ -313,6 +317,8 @@ export const DrawerContent = observer(function DrawerContentImpl() {
             accessibilityHint=""
             onPress={onPressSettings}
           />
+
+          <View style={styles.smallSpacer} />
           <View style={styles.smallSpacer} />
         </ScrollView>
         <View style={styles.footer}>
@@ -405,7 +411,11 @@ function MenuItem({
   )
 }
 
-const InviteCodes = observer(function InviteCodesImpl() {
+const InviteCodes = observer(function InviteCodesImpl({
+  style,
+}: {
+  style?: StyleProp<ViewStyle>
+}) {
   const {track} = useAnalytics()
   const store = useStores()
   const pal = usePalette('default')
@@ -418,7 +428,7 @@ const InviteCodes = observer(function InviteCodesImpl() {
   return (
     <TouchableOpacity
       testID="menuItemInviteCodes"
-      style={[styles.inviteCodes]}
+      style={[styles.inviteCodes, style]}
       onPress={onPress}
       accessibilityRole="button"
       accessibilityLabel={
@@ -448,7 +458,6 @@ const InviteCodes = observer(function InviteCodesImpl() {
 const styles = StyleSheet.create({
   view: {
     flex: 1,
-    paddingTop: 20,
     paddingBottom: 50,
     maxWidth: 300,
   },
@@ -524,6 +533,7 @@ const styles = StyleSheet.create({
   },
 
   footer: {
+    flexWrap: 'wrap',
     flexDirection: 'row',
     gap: 8,
     paddingRight: 20,


### PR DESCRIPTION
Should help address #1297 and #1306

This PR wraps everything in the drawer in a scroll view except the footer section, and ensures that the footer buttons don't overflow the drawer and cover UI in the main feed view.


<img width="824" alt="Screen Shot 2023-09-15 at 4 51 47 PM" src="https://github.com/bluesky-social/social-app/assets/4732330/ba55d1ca-dea9-493c-adcf-bcc1e1e46a16">
<img width="824" alt="Screen Shot 2023-09-15 at 4 51 51 PM" src="https://github.com/bluesky-social/social-app/assets/4732330/a82d0699-bccb-4fee-84ed-34dd7221a737">

<img width="534" alt="Screen Shot 2023-09-15 at 4 53 58 PM" src="https://github.com/bluesky-social/social-app/assets/4732330/6240edfe-f8b3-45d3-9783-0bec32af67b4">
<img width="534" alt="Screen Shot 2023-09-15 at 4 53 46 PM" src="https://github.com/bluesky-social/social-app/assets/4732330/d66c7d24-ef80-4fe4-9ec4-032424073493">
<img width="534" alt="Screen Shot 2023-09-15 at 4 53 25 PM" src="https://github.com/bluesky-social/social-app/assets/4732330/48d2bcbc-5262-4a9f-a5f9-3c45d30be93f">
