### PR TITLE
:bug: Handle middle mouse click on feed list items

### DIFF
--- a/src/lib/hooks/useAuxClick.ts
+++ b/src/lib/hooks/useAuxClick.ts
@@ -1,0 +1,2 @@
+// does nothing in native
+export const useAuxClick = () => {}

--- a/src/lib/hooks/useAuxClick.web.ts
+++ b/src/lib/hooks/useAuxClick.web.ts
@@ -1,0 +1,43 @@
+import {useEffect} from 'react'
+
+// This is the handler for the middle mouse button click on the feed.
+// Normally, we would do this via `onAuxClick` handler on each link element
+// However, that handler is not supported on react-native-web and there are some
+// discrepancies between various browsers (i.e: safari doesn't trigger it and routes through click event)
+// So, this temporary alternative is meant to bridge the gap in an efficient way until the support improves.
+export const useAuxClick = () => {
+  const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent)
+  useEffect(() => {
+    // On the web, it should always be there but in case it gets accidentally included in native builds
+    const wrapperEl = document?.body
+
+    // Safari already handles auxclick event as click+metaKey so we need to avoid doing this there in case it becomes recursive
+    if (wrapperEl && !isSafari) {
+      const handleAuxClick = (e: MouseEvent & {target: HTMLElement}) => {
+        // Only handle the middle mouse button click
+        // Only handle if the clicked element itself or one of its ancestors is a link
+        if (
+          e.button !== 1 ||
+          e.target.closest('a') ||
+          e.target.tagName === 'A'
+        ) {
+          return
+        }
+
+        // On the original element, trigger a click event with metaKey set to true so that it triggers
+        // the browser's default behavior of opening the link in a new tab
+        e.target.dispatchEvent(
+          new MouseEvent('click', {metaKey: true, bubbles: true}),
+        )
+      }
+
+      // @ts-ignore For web only
+      wrapperEl.addEventListener('auxclick', handleAuxClick)
+
+      return () => {
+        // @ts-ignore For web only
+        wrapperEl?.removeEventListener('auxclick', handleAuxClick)
+      }
+    }
+  }, [isSafari])
+}

--- a/src/view/com/posts/Feed.tsx
+++ b/src/view/com/posts/Feed.tsx
@@ -19,7 +19,6 @@ import {s} from 'lib/styles'
 import {useAnalytics} from 'lib/analytics/analytics'
 import {usePalette} from 'lib/hooks/usePalette'
 import {useTheme} from 'lib/ThemeContext'
-import {isWeb} from 'platform/detection'
 
 const LOADING_ITEM = {_reactKey: '__loading__'}
 const EMPTY_FEED_ITEM = {_reactKey: '__empty__'}
@@ -55,7 +54,6 @@ export const Feed = observer(function Feed({
   const theme = useTheme()
   const {track} = useAnalytics()
   const [isRefreshing, setIsRefreshing] = React.useState(false)
-  const listWrapperRef = React.useRef<View>(null)
 
   const data = React.useMemo(() => {
     let feedItems: any[] = []
@@ -154,44 +152,8 @@ export const Feed = observer(function Feed({
     [feed],
   )
 
-  // This is the handler for the middle mouse button click on the feed.
-  // Normally, we would do this via `onAuxClick` handler on each link element
-  // However, that handler is not supported on react-native-web and there are some
-  // discrepancies between various browsers (i.e: safari doesn't trigger it and routes through click event)
-  // So, this temporary alternative is meant to bridge the gap in an efficient way until the support improves.
-  React.useEffect(() => {
-    if (listWrapperRef?.current && isWeb) {
-      const wrapperEl = listWrapperRef.current
-      const handleAuxClick = (e: MouseEvent & {target: HTMLElement}) => {
-        // Only handle the middle mouse button click, early exit otherwise
-        if (e.button !== 1) return
-
-        // Each feed item is wrapped by a div with a data-href attribute
-        // The value of the attr contains the link to the post
-        // Maybe this needs a better selector? in case there are nested items with links?
-        const parentWithPostLink = e.target.closest?.('div[data-href]')
-
-        // Only try to process the click if we found a parent with the data-href attr and there is a value for it
-        console.log(parentWithPostLink)
-        if (parentWithPostLink) {
-          const href = parentWithPostLink.getAttribute('data-href')
-          console.log(parentWithPostLink, href)
-          if (href) window.open(href, '_blank')
-        }
-      }
-
-      // @ts-ignore For web only
-      wrapperEl.addEventListener('auxclick', handleAuxClick)
-
-      return () => {
-        // @ts-ignore For web only
-        wrapperEl?.removeEventListener('auxclick', handleAuxClick)
-      }
-    }
-  }, [])
-
   return (
-    <View testID={testID} style={style} ref={listWrapperRef}>
+    <View testID={testID} style={style}>
       <FlatList
         testID={testID ? `${testID}-flatlist` : undefined}
         ref={scrollElRef}

--- a/src/view/com/posts/Feed.tsx
+++ b/src/view/com/posts/Feed.tsx
@@ -19,6 +19,7 @@ import {s} from 'lib/styles'
 import {useAnalytics} from 'lib/analytics/analytics'
 import {usePalette} from 'lib/hooks/usePalette'
 import {useTheme} from 'lib/ThemeContext'
+import {isWeb} from 'platform/detection'
 
 const LOADING_ITEM = {_reactKey: '__loading__'}
 const EMPTY_FEED_ITEM = {_reactKey: '__empty__'}
@@ -54,6 +55,7 @@ export const Feed = observer(function Feed({
   const theme = useTheme()
   const {track} = useAnalytics()
   const [isRefreshing, setIsRefreshing] = React.useState(false)
+  const listWrapperRef = React.useRef<View>(null)
 
   const data = React.useMemo(() => {
     let feedItems: any[] = []
@@ -152,8 +154,44 @@ export const Feed = observer(function Feed({
     [feed],
   )
 
+  // This is the handler for the middle mouse button click on the feed.
+  // Normally, we would do this via `onAuxClick` handler on each link element
+  // However, that handler is not supported on react-native-web and there are some
+  // discrepancies between various browsers (i.e: safari doesn't trigger it and routes through click event)
+  // So, this temporary alternative is meant to bridge the gap in an efficient way until the support improves.
+  React.useEffect(() => {
+    if (listWrapperRef?.current && isWeb) {
+      const wrapperEl = listWrapperRef.current
+      const handleAuxClick = (e: MouseEvent & {target: HTMLElement}) => {
+        // Only handle the middle mouse button click, early exit otherwise
+        if (e.button !== 1) return
+
+        // Each feed item is wrapped by a div with a data-href attribute
+        // The value of the attr contains the link to the post
+        // Maybe this needs a better selector? in case there are nested items with links?
+        const parentWithPostLink = e.target.closest?.('div[data-href]')
+
+        // Only try to process the click if we found a parent with the data-href attr and there is a value for it
+        console.log(parentWithPostLink)
+        if (parentWithPostLink) {
+          const href = parentWithPostLink.getAttribute('data-href')
+          console.log(parentWithPostLink, href)
+          if (href) window.open(href, '_blank')
+        }
+      }
+
+      // @ts-ignore For web only
+      wrapperEl.addEventListener('auxclick', handleAuxClick)
+
+      return () => {
+        // @ts-ignore For web only
+        wrapperEl?.removeEventListener('auxclick', handleAuxClick)
+      }
+    }
+  }, [])
+
   return (
-    <View testID={testID} style={style}>
+    <View testID={testID} style={style} ref={listWrapperRef}>
       <FlatList
         testID={testID ? `${testID}-flatlist` : undefined}
         ref={scrollElRef}

--- a/src/view/com/util/Link.tsx
+++ b/src/view/com/util/Link.tsx
@@ -24,7 +24,7 @@ import {NavigationProp} from 'lib/routes/types'
 import {router} from '../../../routes'
 import {useStores, RootStoreModel} from 'state/index'
 import {convertBskyAppUrlIfNeeded, isExternalUrl} from 'lib/strings/url-helpers'
-import {isAndroid, isDesktopWeb, isWeb} from 'platform/detection'
+import {isAndroid, isDesktopWeb} from 'platform/detection'
 import {sanitizeUrl} from '@braintree/sanitize-url'
 import FixedTouchableHighlight from '../pager/FixedTouchableHighlight'
 
@@ -95,21 +95,16 @@ export const Link = observer(function Link({
         accessibilityRole="link"
         {...props}>
         {/* @ts-ignore web only -prf */}
-        <View style={style} dataSet={{href}} href={anchorHref}>
+        <View style={style} href={anchorHref}>
           {children ? children : <Text>{title || 'link'}</Text>}
         </View>
       </TouchableWithoutFeedback>
     )
   }
 
-  // @ts-ignore web only -prf
-  props.dataSet = props.dataSet || {}
-  if (isWeb) {
-    // @ts-ignore web only
-    props.dataSet.href = href
-  }
-
   if (anchorNoUnderline) {
+    // @ts-ignore web only -prf
+    props.dataSet = props.dataSet || {}
     // @ts-ignore web only -prf
     props.dataSet.noUnderline = 1
   }

--- a/src/view/com/util/Link.tsx
+++ b/src/view/com/util/Link.tsx
@@ -24,7 +24,7 @@ import {NavigationProp} from 'lib/routes/types'
 import {router} from '../../../routes'
 import {useStores, RootStoreModel} from 'state/index'
 import {convertBskyAppUrlIfNeeded, isExternalUrl} from 'lib/strings/url-helpers'
-import {isAndroid, isDesktopWeb} from 'platform/detection'
+import {isAndroid, isDesktopWeb, isWeb} from 'platform/detection'
 import {sanitizeUrl} from '@braintree/sanitize-url'
 import FixedTouchableHighlight from '../pager/FixedTouchableHighlight'
 
@@ -57,6 +57,7 @@ export const Link = observer(function Link({
 }: Props) {
   const store = useStores()
   const navigation = useNavigation<NavigationProp>()
+  const anchorHref = asAnchor ? sanitizeUrl(href) : undefined
 
   const onPress = React.useCallback(
     (e?: Event) => {
@@ -94,16 +95,21 @@ export const Link = observer(function Link({
         accessibilityRole="link"
         {...props}>
         {/* @ts-ignore web only -prf */}
-        <View style={style} href={asAnchor ? sanitizeUrl(href) : undefined}>
+        <View style={style} dataSet={{href}} href={anchorHref}>
           {children ? children : <Text>{title || 'link'}</Text>}
         </View>
       </TouchableWithoutFeedback>
     )
   }
 
+  // @ts-ignore web only -prf
+  props.dataSet = props.dataSet || {}
+  if (isWeb) {
+    // @ts-ignore web only
+    props.dataSet.href = href
+  }
+
   if (anchorNoUnderline) {
-    // @ts-ignore web only -prf
-    props.dataSet = props.dataSet || {}
     // @ts-ignore web only -prf
     props.dataSet.noUnderline = 1
   }
@@ -120,7 +126,7 @@ export const Link = observer(function Link({
       accessible={accessible}
       accessibilityRole="link"
       // @ts-ignore web only -prf
-      href={asAnchor ? sanitizeUrl(href) : undefined}
+      href={anchorHref}
       {...props}>
       {children ? children : <Text>{title || 'link'}</Text>}
     </Pressable>

--- a/src/view/shell/index.web.tsx
+++ b/src/view/shell/index.web.tsx
@@ -16,11 +16,13 @@ import {useWebMediaQueries} from '../../lib/hooks/useWebMediaQueries'
 import {BottomBarWeb} from './bottom-bar/BottomBarWeb'
 import {useNavigation} from '@react-navigation/native'
 import {NavigationProp} from 'lib/routes/types'
+import {useAuxClick} from 'lib/hooks/useAuxClick.web'
 
 const ShellInner = observer(function ShellInnerImpl() {
   const store = useStores()
   const {isDesktop, isMobile} = useWebMediaQueries()
   const navigator = useNavigation<NavigationProp>()
+  useAuxClick()
 
   useEffect(() => {
     navigator.addListener('state', () => {

--- a/src/view/shell/index.web.tsx
+++ b/src/view/shell/index.web.tsx
@@ -16,7 +16,7 @@ import {useWebMediaQueries} from '../../lib/hooks/useWebMediaQueries'
 import {BottomBarWeb} from './bottom-bar/BottomBarWeb'
 import {useNavigation} from '@react-navigation/native'
 import {NavigationProp} from 'lib/routes/types'
-import {useAuxClick} from 'lib/hooks/useAuxClick.web'
+import {useAuxClick} from 'lib/hooks/useAuxClick'
 
 const ShellInner = observer(function ShellInnerImpl() {
   const store = useStores()


### PR DESCRIPTION
Addresses https://github.com/bluesky-social/social-app/issues/650

This is a PoC that attempts to handle middle mouse click on post feed items and opens the post in a new tab. This is default behavior when using `a` tags but on non-a tags, links only open in new tab on safari (which is an anomaly and will probably be patched down the road on safari too).

I'd imagine the handler will have to be added on other wrappers where posts are rendered.
More details on the default web-supported handler for this event https://github.com/facebook/react/pull/11571

https://github.com/bluesky-social/social-app/assets/1919066/33a3ae5f-dcb6-4a2b-965b-b3fa5cd5eaa0

