### PR TITLE
Allow touch at the top of the lightbox

### DIFF
--- a/src/view/com/lightbox/ImageViewing/components/ImageDefaultHeader.tsx
+++ b/src/view/com/lightbox/ImageViewing/components/ImageDefaultHeader.tsx
@@ -34,6 +34,7 @@ const ImageDefaultHeader = ({onRequestClose}: Props) => (
 const styles = StyleSheet.create({
   root: {
     alignItems: 'flex-end',
+    pointerEvents: 'box-none',
   },
   closeButton: {
     marginRight: 8,

--- a/src/view/com/lightbox/ImageViewing/index.tsx
+++ b/src/view/com/lightbox/ImageViewing/index.tsx
@@ -189,6 +189,7 @@ const styles = StyleSheet.create({
     width: '100%',
     zIndex: 1,
     top: 0,
+    pointerEvents: 'box-none',
   },
   footer: {
     position: 'absolute',


### PR DESCRIPTION
## What

The lightbox top bar (which contains the close button) was eating touch even outside the close button tap area.

This was confusing because the top bar is invisible.

Let's fix it so that it doesn't eat touch.

Verified close button still works.

## Before


https://github.com/bluesky-social/social-app/assets/810438/f8039da1-341b-44e0-9d92-0e84b5b91432


## After


https://github.com/bluesky-social/social-app/assets/810438/97fde8b3-5d30-4112-a4c9-f0ad0d717a7b

