### PR TITLE
Dont show the reply prompt if minimal shell mode triggers (hackfix)

### DIFF
--- a/src/view/screens/PostThread.tsx
+++ b/src/view/screens/PostThread.tsx
@@ -77,7 +77,7 @@ export const PostThreadScreen = withAuthRequired(({route}: Props) => {
           treeView={store.preferences.threadTreeViewEnabled}
         />
       </View>
-      {isMobile && (
+      {isMobile && !store.shell.minimalShellMode && (
         <View
           style={[
             styles.prompt,


### PR DESCRIPTION
There's a standing issue where the "minimal shell mode" can sometimes get triggered when the thread screen is viewed. I've not been able to debug the cause of this. This can lead to an ugly situation where the "Reply prompt" hovers awkwardly above the bottom of the screen.

We should fix the root issue, but in the meantime let's at least not leave the ugly floating bar. Users can still reply by tapping the comment icon.