### PR TITLE
Test suite improvements & tests for the mergefeed

### DIFF
--- a/.detoxrc.js
+++ b/.detoxrc.js
@@ -41,7 +41,7 @@ module.exports = {
     simulator: {
       type: 'ios.simulator',
       device: {
-        type: 'iPhone 14',
+        type: 'iPhone 15',
       },
     },
     attached: {

--- a/__e2e__/tests/composer.test.ts
+++ b/__e2e__/tests/composer.test.ts
@@ -1,18 +1,17 @@
 /* eslint-env detox/detox */
 
-import {openApp, login, createServer, sleep} from '../util'
+import {openApp, loginAsAlice, createServer, sleep} from '../util'
 
 describe('Composer', () => {
-  let service: string
   beforeAll(async () => {
-    service = await createServer('?users')
+    await createServer('?users')
     await openApp({
       permissions: {notifications: 'YES', medialibrary: 'YES', photos: 'YES'},
     })
   })
 
   it('Login', async () => {
-    await login(service, 'alice', 'hunter2')
+    await loginAsAlice()
     await element(by.id('homeScreenFeedTabs-Following')).tap()
   })
 

--- a/__e2e__/tests/home-screen.test.ts
+++ b/__e2e__/tests/home-screen.test.ts
@@ -1,16 +1,15 @@
 /* eslint-env detox/detox */
 
-import {openApp, login, createServer} from '../util'
+import {openApp, loginAsAlice, createServer} from '../util'
 
 describe('Home screen', () => {
-  let service: string
   beforeAll(async () => {
-    service = await createServer('?users&follows&posts')
+    await createServer('?users&follows&posts')
     await openApp({permissions: {notifications: 'YES'}})
   })
 
   it('Login', async () => {
-    await login(service, 'alice', 'hunter2')
+    await loginAsAlice()
     await element(by.id('homeScreenFeedTabs-Following')).tap()
   })
 

--- a/__e2e__/tests/invite-codes.test-skip.ts
+++ b/__e2e__/tests/invite-codes.test-skip.ts
@@ -1,6 +1,11 @@
 /* eslint-env detox/detox */
 
-import {openApp, login, createServer} from '../util'
+/**
+ * This test is being skipped until we can resolve the detox crash issue
+ * with the side drawer.
+ */
+
+import {openApp, loginAsAlice, createServer} from '../util'
 
 describe('invite-codes', () => {
   let service: string
@@ -12,7 +17,7 @@ describe('invite-codes', () => {
 
   it('I can fetch invite codes', async () => {
     await expect(element(by.id('signInButton'))).toBeVisible()
-    await login(service, 'alice', 'hunter2')
+    await loginAsAlice()
     await element(by.id('viewHeaderDrawerBtn')).tap()
     await expect(element(by.id('drawer'))).toBeVisible()
     await element(by.id('menuItemInviteCodes')).tap()
@@ -47,15 +52,10 @@ describe('invite-codes', () => {
     await expect(element(by.id('recommendedFeedsOnboarding'))).toBeVisible()
     await element(by.id('continueBtn')).tap()
     await expect(element(by.id('homeScreen'))).toBeVisible()
-    await element(by.id('viewHeaderDrawerBtn')).tap()
-    await element(by.id('menuItemButton-Settings')).tap()
-    await element(by.id('signOutBtn')).tap()
   })
 
   it('I get a notification for the new user', async () => {
-    await expect(element(by.id('signInButton'))).toBeVisible()
-    await login(service, 'alice', 'hunter2')
-    await element(by.id('viewHeaderDrawerBtn')).tap()
+    await loginAsAlice()
     await element(by.id('menuItemButton-Notifications')).tap()
     await expect(element(by.id('invitedUser'))).toBeVisible()
   })

--- a/__e2e__/tests/merge-feed.test.ts
+++ b/__e2e__/tests/merge-feed.test.ts
@@ -1,0 +1,31 @@
+/* eslint-env detox/detox */
+
+import {openApp, loginAsAlice, createServer} from '../util'
+
+describe('Home screen', () => {
+  beforeAll(async () => {
+    await createServer('?users&follows&posts')
+    await openApp({permissions: {notifications: 'YES'}})
+  })
+
+  it('Login', async () => {
+    await loginAsAlice()
+    await element(by.id('homeScreenFeedTabs-Following')).tap()
+    await element(by.id('e2eToggleMergefeed')).tap()
+  })
+
+  it('Can like posts', async () => {
+    const carlaPosts = by.id('feedItem-by-carla.test')
+    await expect(
+      element(by.id('likeCount').withAncestor(carlaPosts)).atIndex(0),
+    ).toHaveText('0')
+    await element(by.id('likeBtn').withAncestor(carlaPosts)).atIndex(0).tap()
+    await expect(
+      element(by.id('likeCount').withAncestor(carlaPosts)).atIndex(0),
+    ).toHaveText('1')
+    await element(by.id('likeBtn').withAncestor(carlaPosts)).atIndex(0).tap()
+    await expect(
+      element(by.id('likeCount').withAncestor(carlaPosts)).atIndex(0),
+    ).toHaveText('0')
+  })
+})

--- a/__e2e__/tests/merge-feed.test.ts
+++ b/__e2e__/tests/merge-feed.test.ts
@@ -2,30 +2,156 @@
 
 import {openApp, loginAsAlice, createServer} from '../util'
 
-describe('Home screen', () => {
+describe('Mergefeed', () => {
   beforeAll(async () => {
-    await createServer('?users&follows&posts')
+    await createServer('?mergefeed')
     await openApp({permissions: {notifications: 'YES'}})
   })
 
   it('Login', async () => {
     await loginAsAlice()
-    await element(by.id('homeScreenFeedTabs-Following')).tap()
     await element(by.id('e2eToggleMergefeed')).tap()
   })
 
-  it('Can like posts', async () => {
-    const carlaPosts = by.id('feedItem-by-carla.test')
+  it('Sees the expected mix of posts with default filters', async () => {
+    await element(by.id('followingFeedPage-feed-flatlist')).swipe(
+      'down',
+      'slow',
+      1,
+      0.5,
+      0.5,
+    )
+    // followed users
     await expect(
-      element(by.id('likeCount').withAncestor(carlaPosts)).atIndex(0),
-    ).toHaveText('0')
-    await element(by.id('likeBtn').withAncestor(carlaPosts)).atIndex(0).tap()
+      element(
+        by.id('postText').withAncestor(by.id('feedItem-by-carla.test')),
+      ).atIndex(0),
+    ).toHaveText('Post 9')
     await expect(
-      element(by.id('likeCount').withAncestor(carlaPosts)).atIndex(0),
-    ).toHaveText('1')
-    await element(by.id('likeBtn').withAncestor(carlaPosts)).atIndex(0).tap()
+      element(
+        by.id('postText').withAncestor(by.id('feedItem-by-bob.test')),
+      ).atIndex(0),
+    ).toHaveText('Post 9')
+    await element(by.id('followingFeedPage-feed-flatlist')).swipe(
+      'up',
+      'fast',
+      1,
+      0.5,
+      0.5,
+    )
+    // feed users
     await expect(
-      element(by.id('likeCount').withAncestor(carlaPosts)).atIndex(0),
-    ).toHaveText('0')
+      element(
+        by.id('postText').withAncestor(by.id('feedItem-by-dan.test')),
+      ).atIndex(0),
+    ).toHaveText('Post 0')
+  })
+
+  it('Sees the expected mix of posts with replies disabled', async () => {
+    await element(by.id('followingFeedPage-feed-flatlist')).swipe(
+      'down',
+      'fast',
+      1,
+      0.5,
+      0.5,
+    )
+    await element(by.id('followingFeedPage-feed-flatlist')).swipe(
+      'down',
+      'fast',
+      1,
+      0.5,
+      0.5,
+    )
+    await element(by.id('viewHeaderHomeFeedPrefsBtn')).tap()
+    await element(by.id('toggleRepliesBtn')).tap()
+    await element(by.id('confirmBtn')).tap()
+    await element(by.id('followingFeedPage-feed-flatlist')).swipe(
+      'down',
+      'slow',
+      1,
+      0.5,
+      0.5,
+    )
+
+    // followed users
+    await expect(
+      element(
+        by.id('postText').withAncestor(by.id('feedItem-by-carla.test')),
+      ).atIndex(0),
+    ).toHaveText('Post 9')
+    await expect(
+      element(
+        by.id('postText').withAncestor(by.id('feedItem-by-bob.test')),
+      ).atIndex(0),
+    ).toHaveText('Post 9')
+    await element(by.id('followingFeedPage-feed-flatlist')).swipe(
+      'up',
+      'fast',
+      1,
+      0.5,
+      0.5,
+    )
+
+    // feed users
+    await expect(
+      element(
+        by.id('postText').withAncestor(by.id('feedItem-by-dan.test')),
+      ).atIndex(0),
+    ).toHaveText('Post 0')
+  })
+
+  it('Sees the expected mix of posts with no follows', async () => {
+    await element(by.id('followingFeedPage-feed-flatlist')).swipe(
+      'down',
+      'fast',
+      1,
+      0.5,
+      0.5,
+    )
+
+    await element(by.id('bottomBarSearchBtn')).tap()
+    await element(by.id('searchTextInput')).typeText('bob')
+    await element(by.id('searchAutoCompleteResult-bob.test')).tap()
+    await expect(element(by.id('profileView'))).toBeVisible()
+    await element(by.id('unfollowBtn')).tap()
+    await element(by.id('profileHeaderBackBtn')).tap()
+
+    // have to wait for the toast to clear
+    await waitFor(element(by.id('searchTextInputClearBtn')))
+      .toBeVisible()
+      .withTimeout(5000)
+    await element(by.id('searchTextInputClearBtn')).tap()
+    await element(by.id('searchTextInput')).typeText('carla')
+    await element(by.id('searchAutoCompleteResult-carla.test')).tap()
+    await expect(element(by.id('profileView'))).toBeVisible()
+    await element(by.id('unfollowBtn')).tap()
+    await element(by.id('profileHeaderBackBtn')).tap()
+
+    await element(by.id('bottomBarHomeBtn')).tap()
+    await element(by.id('followingFeedPage-feed-flatlist')).swipe(
+      'down',
+      'slow',
+      1,
+      0.5,
+      0.5,
+    )
+    await element(by.id('followingFeedPage-feed-flatlist')).swipe(
+      'down',
+      'slow',
+      1,
+      0.5,
+      0.5,
+    )
+
+    // followed users NOT present
+    await expect(element(by.id('feedItem-by-carla.test'))).not.toExist()
+    await expect(element(by.id('feedItem-by-bob.test'))).not.toExist()
+
+    // feed users
+    await expect(
+      element(
+        by.id('postText').withAncestor(by.id('feedItem-by-dan.test')),
+      ).atIndex(0),
+    ).toHaveText('Post 0')
   })
 })

--- a/__e2e__/tests/mute-lists.test.ts
+++ b/__e2e__/tests/mute-lists.test.ts
@@ -1,11 +1,10 @@
 /* eslint-env detox/detox */
 
-import {openApp, login, createServer, sleep} from '../util'
+import {openApp, loginAsAlice, loginAsBob, createServer, sleep} from '../util'
 
 describe('Mute lists', () => {
-  let service: string
   beforeAll(async () => {
-    service = await createServer('?users&follows&labels')
+    await createServer('?users&follows&labels')
     await openApp({
       permissions: {notifications: 'YES', medialibrary: 'YES', photos: 'YES'},
     })
@@ -13,10 +12,8 @@ describe('Mute lists', () => {
 
   it('Login and view my mutelists', async () => {
     await expect(element(by.id('signInButton'))).toBeVisible()
-    await login(service, 'alice', 'hunter2')
-    await element(by.id('viewHeaderDrawerBtn')).tap()
-    await expect(element(by.id('drawer'))).toBeVisible()
-    await element(by.id('menuItemButton-Moderation')).tap()
+    await loginAsAlice()
+    await element(by.id('e2eGotoModeration')).tap()
     await element(by.id('mutelistsBtn')).tap()
     await expect(element(by.id('list-Muted Users'))).toBeVisible()
     await element(by.id('list-Muted Users')).tap()
@@ -141,19 +138,9 @@ describe('Mute lists', () => {
   })
 
   it('Can report a mute list', async () => {
-    await element(by.id('bottomBarHomeBtn')).tap()
-    // Last test leaves us in the list view so we are going back 1 screen to the lists list screen
-    await element(by.id('viewHeaderDrawerBtn')).tap()
-    // then to the moderation screen
-    await element(by.id('viewHeaderDrawerBtn')).tap()
-    // then to the home screen
-    await element(by.id('viewHeaderDrawerBtn')).tap()
-    // then open the drawer to go to settings
-    await element(by.id('viewHeaderDrawerBtn')).tap()
-    await element(by.id('menuItemButton-Settings')).tap()
+    await element(by.id('e2eGotoSettings')).tap()
     await element(by.id('signOutBtn')).tap()
-    await expect(element(by.id('signInButton'))).toBeVisible()
-    await login(service, 'bob.test', 'hunter2')
+    await loginAsBob()
     await element(by.id('bottomBarSearchBtn')).tap()
     await element(by.id('searchTextInput')).typeText('alice')
     await element(by.id('searchAutoCompleteResult-alice.test')).tap()

--- a/__e2e__/tests/profile-screen.test.ts
+++ b/__e2e__/tests/profile-screen.test.ts
@@ -1,11 +1,10 @@
 /* eslint-env detox/detox */
 
-import {openApp, login, createServer, sleep} from '../util'
+import {openApp, loginAsAlice, createServer, sleep} from '../util'
 
 describe('Profile screen', () => {
-  let service: string
   beforeAll(async () => {
-    service = await createServer('?users&posts&feeds')
+    await createServer('?users&posts&feeds')
     await openApp({
       permissions: {notifications: 'YES', medialibrary: 'YES', photos: 'YES'},
     })
@@ -13,7 +12,7 @@ describe('Profile screen', () => {
 
   it('Login and navigate to my profile', async () => {
     await expect(element(by.id('signInButton'))).toBeVisible()
-    await login(service, 'alice', 'hunter2')
+    await loginAsAlice()
     await element(by.id('bottomBarProfileBtn')).tap()
   })
 

--- a/__e2e__/tests/search-screen.test.ts
+++ b/__e2e__/tests/search-screen.test.ts
@@ -1,18 +1,17 @@
 /* eslint-env detox/detox */
 
-import {openApp, login, createServer} from '../util'
+import {openApp, loginAsAlice, createServer} from '../util'
 
 describe('Search screen', () => {
-  let service: string
   beforeAll(async () => {
-    service = await createServer('?users')
+    await createServer('?users')
     await openApp({
       permissions: {notifications: 'YES', medialibrary: 'YES', photos: 'YES'},
     })
   })
 
   it('Login', async () => {
-    await login(service, 'alice', 'hunter2')
+    await loginAsAlice()
   })
 
   it('Navigate to another user profile via autocomplete', async () => {

--- a/__e2e__/tests/self-labeling.test.ts
+++ b/__e2e__/tests/self-labeling.test.ts
@@ -1,18 +1,17 @@
 /* eslint-env detox/detox */
 
-import {openApp, login, createServer, sleep} from '../util'
+import {openApp, loginAsAlice, createServer, sleep} from '../util'
 
 describe('Self-labeling', () => {
-  let service: string
   beforeAll(async () => {
-    service = await createServer('?users')
+    await createServer('?users')
     await openApp({
       permissions: {notifications: 'YES', medialibrary: 'YES', photos: 'YES'},
     })
   })
 
   it('Login', async () => {
-    await login(service, 'alice', 'hunter2')
+    await loginAsAlice()
     await element(by.id('homeScreenFeedTabs-Following')).tap()
   })
 

--- a/__e2e__/tests/shell.test.ts
+++ b/__e2e__/tests/shell.test.ts
@@ -1,16 +1,15 @@
 /* eslint-env detox/detox */
 
-import {openApp, login, createServer} from '../util'
+import {openApp, loginAsAlice, createServer} from '../util'
 
 describe('Shell', () => {
-  let service: string
   beforeAll(async () => {
-    service = await createServer('?users')
+    await createServer('?users')
     await openApp({permissions: {notifications: 'YES'}})
   })
 
   it('Login', async () => {
-    await login(service, 'alice', 'hunter2')
+    await loginAsAlice()
     await element(by.id('homeScreenFeedTabs-Following')).tap()
   })
 

--- a/__e2e__/tests/thread-muting.test.ts
+++ b/__e2e__/tests/thread-muting.test.ts
@@ -1,42 +1,34 @@
 /* eslint-env detox/detox */
 
-import {openApp, login, createServer} from '../util'
+import {openApp, loginAsAlice, loginAsBob, createServer} from '../util'
 
 describe('Thread muting', () => {
-  let service: string
   beforeAll(async () => {
-    service = await createServer('?users&follows')
+    await createServer('?users&follows')
     await openApp({permissions: {notifications: 'YES'}})
   })
 
   it('Login, create a thread, and log out', async () => {
-    await login(service, 'alice', 'hunter2')
+    await loginAsAlice()
     await element(by.id('homeScreenFeedTabs-Following')).tap()
     await element(by.id('composeFAB')).tap()
     await element(by.id('composerTextInput')).typeText('Test thread')
     await element(by.id('composerPublishBtn')).tap()
     await expect(element(by.id('composeFAB'))).toBeVisible()
-    await element(by.id('viewHeaderDrawerBtn')).tap()
-    await element(by.id('menuItemButton-Settings')).tap()
-    await element(by.id('signOutBtn')).tap()
   })
 
   it('Login, reply to the thread, and log out', async () => {
-    await login(service, 'bob', 'hunter2')
+    await loginAsBob()
     await element(by.id('homeScreenFeedTabs-Following')).tap()
     const alicePosts = by.id('feedItem-by-alice.test')
     await element(by.id('replyBtn').withAncestor(alicePosts)).atIndex(0).tap()
     await element(by.id('composerTextInput')).typeText('Reply 1')
     await element(by.id('composerPublishBtn')).tap()
     await expect(element(by.id('composeFAB'))).toBeVisible()
-    await element(by.id('viewHeaderDrawerBtn')).tap()
-    await element(by.id('menuItemButton-Settings')).tap()
-    await element(by.id('signOutBtn')).tap()
   })
 
   it('Login, confirm notification exists, mute thread, and log out', async () => {
-    await login(service, 'alice', 'hunter2')
-
+    await loginAsAlice()
     await element(by.id('bottomBarNotificationsBtn')).tap()
     const bobNotifs = by.id('feedItem-by-bob.test')
     await expect(
@@ -50,14 +42,10 @@ describe('Thread muting', () => {
     await waitFor(element(by.id('viewHeaderDrawerBtn')))
       .toBeVisible()
       .withTimeout(5000)
-
-    await element(by.id('viewHeaderDrawerBtn')).tap()
-    await element(by.id('menuItemButton-Settings')).tap()
-    await element(by.id('signOutBtn')).tap()
   })
 
   it('Login, reply to the thread twice, and log out', async () => {
-    await login(service, 'bob', 'hunter2')
+    await loginAsBob()
 
     await element(by.id('bottomBarProfileBtn')).tap()
     await element(by.id('selector-1')).tap()
@@ -74,13 +62,10 @@ describe('Thread muting', () => {
     await expect(element(by.id('composeFAB'))).toBeVisible()
 
     await element(by.id('bottomBarHomeBtn')).tap()
-    await element(by.id('viewHeaderDrawerBtn')).tap()
-    await element(by.id('menuItemButton-Settings')).tap()
-    await element(by.id('signOutBtn')).tap()
   })
 
   it('Login, confirm notifications dont exist, unmute the thread, confirm notifications exist', async () => {
-    await login(service, 'alice', 'hunter2')
+    await loginAsAlice()
 
     await element(by.id('bottomBarNotificationsBtn')).tap()
     const bobNotifs = by.id('feedItem-by-bob.test')
@@ -93,7 +78,7 @@ describe('Thread muting', () => {
     await element(by.id('postDropdownBtn').withAncestor(alicePosts))
       .atIndex(0)
       .tap()
-    await element(by.text('Mute thread')).tap()
+    await element(by.text('Unmute thread')).tap()
 
     // TODO
     // the swipe down to trigger PTR isnt working and I dont want to block on this

--- a/__e2e__/tests/thread-screen.test.ts
+++ b/__e2e__/tests/thread-screen.test.ts
@@ -1,16 +1,15 @@
 /* eslint-env detox/detox */
 
-import {openApp, login, createServer} from '../util'
+import {openApp, loginAsAlice, createServer} from '../util'
 
 describe('Thread screen', () => {
-  let service: string
   beforeAll(async () => {
-    service = await createServer('?users&follows&thread')
+    await createServer('?users&follows&thread')
     await openApp({permissions: {notifications: 'YES'}})
   })
 
   it('Login & navigate to thread', async () => {
-    await login(service, 'alice', 'hunter2')
+    await loginAsAlice()
     await element(by.id('homeScreenFeedTabs-Following')).tap()
     await element(by.id('feedItem-by-bob.test')).atIndex(0).tap()
     await expect(

--- a/__e2e__/util.ts
+++ b/__e2e__/util.ts
@@ -69,6 +69,14 @@ export async function login(
   await element(by.id('loginNextButton')).tap()
 }
 
+export async function loginAsAlice() {
+  await element(by.id('e2eSignInAlice')).tap()
+}
+
+export async function loginAsBob() {
+  await element(by.id('e2eSignInBob')).tap()
+}
+
 async function openAppForDebugBuild(platform: string, opts: any) {
   const deepLinkUrl = // Local testing with packager
     /*process.env.EXPO_USE_UPDATES

--- a/src/App.native.tsx
+++ b/src/App.native.tsx
@@ -18,6 +18,7 @@ import * as Toast from './view/com/util/Toast'
 import {handleLink} from './Navigation'
 import {QueryClientProvider} from '@tanstack/react-query'
 import {queryClient} from 'lib/react-query'
+import {TestCtrls} from 'view/com/testing/TestCtrls'
 
 SplashScreen.preventAutoHideAsync()
 
@@ -59,6 +60,7 @@ const App = observer(function AppImpl() {
           <analytics.Provider>
             <RootStoreProvider value={rootStore}>
               <GestureHandlerRootView style={s.h100pct}>
+                <TestCtrls />
                 <Shell />
               </GestureHandlerRootView>
             </RootStoreProvider>

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -83,8 +83,14 @@ export async function DEFAULT_FEEDS(
     // local dev
     const aliceDid = await resolveHandle('alice.test')
     return {
-      pinned: [`at://${aliceDid}/app.bsky.feed.generator/alice-favs`],
-      saved: [`at://${aliceDid}/app.bsky.feed.generator/alice-favs`],
+      pinned: [
+        `at://${aliceDid}/app.bsky.feed.generator/alice-favs`,
+        `at://${aliceDid}/app.bsky.feed.generator/alice-favs2`,
+      ],
+      saved: [
+        `at://${aliceDid}/app.bsky.feed.generator/alice-favs`,
+        `at://${aliceDid}/app.bsky.feed.generator/alice-favs2`,
+      ],
     }
   } else if (IS_STAGING(serviceUrl)) {
     // staging

--- a/src/view/com/modals/ProfilePreview.tsx
+++ b/src/view/com/modals/ProfilePreview.tsx
@@ -35,7 +35,7 @@ export const Component = observer(function ProfilePreviewImpl({
   }, [model, screen])
 
   return (
-    <View style={[pal.view, s.flex1]}>
+    <View testID="profilePreview" style={[pal.view, s.flex1]}>
       <View
         style={[
           styles.headerWrapper,

--- a/src/view/com/pager/FeedsTabBarMobile.tsx
+++ b/src/view/com/pager/FeedsTabBarMobile.tsx
@@ -67,6 +67,7 @@ export const FeedsTabBar = observer(function FeedsTabBarImpl(
         </Text>
         <View style={[pal.view]}>
           <Link
+            testID="viewHeaderHomeFeedPrefsBtn"
             href="/settings/home-feed"
             hitSlop={HITSLOP_10}
             accessibilityRole="button"

--- a/src/view/com/posts/FeedItem.tsx
+++ b/src/view/com/posts/FeedItem.tsx
@@ -299,6 +299,7 @@ export const FeedItem = observer(function FeedItemImpl({
             {item.richText?.text ? (
               <View style={styles.postTextContainer}>
                 <RichText
+                  testID="postText"
                   type="post-text"
                   richText={item.richText}
                   lineHeight={1.3}

--- a/src/view/com/profile/ProfileHeader.tsx
+++ b/src/view/com/profile/ProfileHeader.tsx
@@ -506,6 +506,7 @@ const ProfileHeaderLoaded = observer(function ProfileHeaderLoadedImpl({
       </View>
       {!isDesktop && !hideBackButton && (
         <TouchableWithoutFeedback
+          testID="profileHeaderBackBtn"
           onPress={onPressBack}
           hitSlop={BACK_HITSLOP}
           accessibilityRole="button"

--- a/src/view/com/search/HeaderWithInput.tsx
+++ b/src/view/com/search/HeaderWithInput.tsx
@@ -102,6 +102,7 @@ export function HeaderWithInput({
         />
         {query ? (
           <TouchableOpacity
+            testID="searchTextInputClearBtn"
             onPress={onPressClearQuery}
             accessibilityRole="button"
             accessibilityLabel="Clear search query"

--- a/src/view/com/testing/TestCtrls.e2e.tsx
+++ b/src/view/com/testing/TestCtrls.e2e.tsx
@@ -28,7 +28,7 @@ export function TestCtrls() {
     })
   }
   return (
-    <View style={{position: 'absolute', top: 100, left: 0, zIndex: 100}}>
+    <View style={{position: 'absolute', top: 100, right: 0, zIndex: 100}}>
       <Pressable
         testID="e2eSignInAlice"
         onPress={onPressSignInAlice}
@@ -62,6 +62,12 @@ export function TestCtrls() {
       <Pressable
         testID="e2eToggleMergefeed"
         onPress={() => store.preferences.toggleHomeFeedMergeFeedEnabled()}
+        accessibilityRole="button"
+        style={BTN}
+      />
+      <Pressable
+        testID="e2eRefreshHome"
+        onPress={() => store.me.mainFeed.refresh()}
         accessibilityRole="button"
         style={BTN}
       />

--- a/src/view/com/testing/TestCtrls.e2e.tsx
+++ b/src/view/com/testing/TestCtrls.e2e.tsx
@@ -1,0 +1,70 @@
+import React from 'react'
+import {Pressable, View} from 'react-native'
+import {useStores} from 'state/index'
+import {navigate} from '../../../Navigation'
+
+/**
+ * This utility component is only included in the test simulator
+ * build. It gives some quick triggers which help improve the pace
+ * of the tests dramatically.
+ */
+
+const BTN = {height: 1, width: 1, backgroundColor: 'red'}
+
+export function TestCtrls() {
+  const store = useStores()
+  const onPressSignInAlice = async () => {
+    await store.session.login({
+      service: 'http://localhost:3000',
+      identifier: 'alice.test',
+      password: 'hunter2',
+    })
+  }
+  const onPressSignInBob = async () => {
+    await store.session.login({
+      service: 'http://localhost:3000',
+      identifier: 'bob.test',
+      password: 'hunter2',
+    })
+  }
+  return (
+    <View style={{position: 'absolute', top: 100, left: 0, zIndex: 100}}>
+      <Pressable
+        testID="e2eSignInAlice"
+        onPress={onPressSignInAlice}
+        accessibilityRole="button"
+        style={BTN}
+      />
+      <Pressable
+        testID="e2eSignInBob"
+        onPress={onPressSignInBob}
+        accessibilityRole="button"
+        style={BTN}
+      />
+      <Pressable
+        testID="e2eGotoHome"
+        onPress={() => navigate('Home')}
+        accessibilityRole="button"
+        style={BTN}
+      />
+      <Pressable
+        testID="e2eGotoSettings"
+        onPress={() => navigate('Settings')}
+        accessibilityRole="button"
+        style={BTN}
+      />
+      <Pressable
+        testID="e2eGotoModeration"
+        onPress={() => navigate('Moderation')}
+        accessibilityRole="button"
+        style={BTN}
+      />
+      <Pressable
+        testID="e2eToggleMergefeed"
+        onPress={() => store.preferences.toggleHomeFeedMergeFeedEnabled()}
+        accessibilityRole="button"
+        style={BTN}
+      />
+    </View>
+  )
+}

--- a/src/view/com/testing/TestCtrls.tsx
+++ b/src/view/com/testing/TestCtrls.tsx
@@ -1,0 +1,3 @@
+export function TestCtrls() {
+  return null
+}

--- a/src/view/com/util/forms/ToggleButton.tsx
+++ b/src/view/com/util/forms/ToggleButton.tsx
@@ -8,6 +8,7 @@ import {colors} from 'lib/styles'
 import {TypographyVariant} from 'lib/ThemeContext'
 
 export function ToggleButton({
+  testID,
   type = 'default-light',
   label,
   isSelected,
@@ -15,6 +16,7 @@ export function ToggleButton({
   labelType,
   onPress,
 }: {
+  testID?: string
   type?: ButtonType
   label: string
   isSelected: boolean
@@ -134,7 +136,7 @@ export function ToggleButton({
     },
   })
   return (
-    <Button type={type} onPress={onPress} style={style}>
+    <Button testID={testID} type={type} onPress={onPress} style={style}>
       <View style={styles.outer}>
         <View style={[circleStyle, styles.circle]}>
           <View

--- a/src/view/screens/PreferencesHomeFeed.tsx
+++ b/src/view/screens/PreferencesHomeFeed.tsx
@@ -86,6 +86,7 @@ export const PreferencesHomeFeed = observer(function PreferencesHomeFeedImpl({
               Set this setting to "No" to hide all replies from your feed.
             </Text>
             <ToggleButton
+              testID="toggleRepliesBtn"
               type="default-light"
               label={store.preferences.homeFeedRepliesEnabled ? 'Yes' : 'No'}
               isSelected={store.preferences.homeFeedRepliesEnabled}


### PR DESCRIPTION
- Adds a `<TestCtrls>` component which only renders in the e2e sim build and provides some fast actions, dramatically improving the execution time of tests.
- Disables the invite codes test temporarily due to the drawer crash issue.
- Adds mergefeed tests.