### PR TITLE
Fix to the list header rich text rendering

### DIFF
--- a/src/view/com/lists/ListItems.tsx
+++ b/src/view/com/lists/ListItems.tsx
@@ -284,7 +284,10 @@ const ListHeader = observer(function ListHeaderImpl({
   const descriptionRT = React.useMemo(
     () =>
       list?.description &&
-      new RichText({text: list.description, facets: list.descriptionFacets}),
+      new RichText({
+        text: list.description,
+        facets: (list.descriptionFacets || [])?.slice(),
+      }),
     [list],
   )
   return (


### PR DESCRIPTION
Turns out the `RichText` constructor runs `sort()` on the facets parameter without slicing first (whoops) and this makes mobx mad, so this fixes that