### PR TITLE
Improve consistency of floating button positioning

### DIFF
--- a/src/view/com/util/fab/FABInner.tsx
+++ b/src/view/com/util/fab/FABInner.tsx
@@ -6,7 +6,8 @@ import {gradients} from 'lib/styles'
 import {useAnimatedValue} from 'lib/hooks/useAnimatedValue'
 import {useStores} from 'state/index'
 import {useWebMediaQueries} from 'lib/hooks/useWebMediaQueries'
-import {isWeb} from 'platform/detection'
+import {useSafeAreaInsets} from 'react-native-safe-area-context'
+import {clamp} from 'lib/numbers'
 
 export interface FABProps
   extends ComponentProps<typeof TouchableWithoutFeedback> {
@@ -19,12 +20,13 @@ export const FABInner = observer(function FABInnerImpl({
   icon,
   ...props
 }: FABProps) {
+  const insets = useSafeAreaInsets()
   const {isTablet} = useWebMediaQueries()
   const store = useStores()
   const interp = useAnimatedValue(0)
   React.useEffect(() => {
     Animated.timing(interp, {
-      toValue: store.shell.minimalShellMode ? 1 : 0,
+      toValue: store.shell.minimalShellMode ? 0 : 1,
       duration: 100,
       useNativeDriver: true,
       isInteraction: false,
@@ -33,25 +35,14 @@ export const FABInner = observer(function FABInnerImpl({
   const transform = isTablet
     ? undefined
     : {
-        transform: [{translateY: Animated.multiply(interp, 60)}],
+        transform: [{translateY: Animated.multiply(interp, -44)}],
       }
   const size = isTablet ? styles.sizeLarge : styles.sizeRegular
+  const right = isTablet ? 50 : 24
+  const bottom = isTablet ? 50 : clamp(insets.bottom, 15, 60) + 15
   return (
     <TouchableWithoutFeedback testID={testID} {...props}>
-      <Animated.View
-        style={[
-          styles.outer,
-          size,
-          isWeb && isTablet
-            ? {
-                right: 50,
-                bottom: 50,
-              }
-            : {
-                bottom: 114,
-              },
-          transform,
-        ]}>
+      <Animated.View style={[styles.outer, size, {right, bottom}, transform]}>
         <LinearGradient
           colors={[gradients.blueLight.start, gradients.blueLight.end]}
           start={{x: 0, y: 0}}
@@ -78,8 +69,6 @@ const styles = StyleSheet.create({
   outer: {
     position: 'absolute',
     zIndex: 1,
-    right: 24,
-    bottom: 94,
   },
   inner: {
     justifyContent: 'center',

--- a/src/view/com/util/load-latest/LoadLatestBtn.tsx
+++ b/src/view/com/util/load-latest/LoadLatestBtn.tsx
@@ -3,12 +3,13 @@ import {StyleSheet, TouchableOpacity, View} from 'react-native'
 import {observer} from 'mobx-react-lite'
 import {FontAwesomeIcon} from '@fortawesome/react-native-fontawesome'
 import {useSafeAreaInsets} from 'react-native-safe-area-context'
-import {clamp} from 'lodash'
 import {useStores} from 'state/index'
 import {usePalette} from 'lib/hooks/usePalette'
 import {useWebMediaQueries} from 'lib/hooks/useWebMediaQueries'
 import {colors} from 'lib/styles'
 import {HITSLOP_20} from 'lib/constants'
+import {isWeb} from 'platform/detection'
+import {clamp} from 'lib/numbers'
 
 export const LoadLatestBtn = observer(function LoadLatestBtnImpl({
   onPress,
@@ -22,8 +23,12 @@ export const LoadLatestBtn = observer(function LoadLatestBtnImpl({
 }) {
   const store = useStores()
   const pal = usePalette('default')
-  const {isDesktop, isTablet, isMobile} = useWebMediaQueries()
+  const {isDesktop, isTablet} = useWebMediaQueries()
   const safeAreaInsets = useSafeAreaInsets()
+  const minMode = store.shell.minimalShellMode
+  const bottom = isTablet
+    ? 50
+    : (minMode ? 16 : 60) + (isWeb ? 20 : clamp(safeAreaInsets.bottom, 15, 60))
   return (
     <TouchableOpacity
       style={[
@@ -32,10 +37,7 @@ export const LoadLatestBtn = observer(function LoadLatestBtnImpl({
         isTablet && styles.loadLatestTablet,
         pal.borderDark,
         pal.view,
-        isMobile &&
-          !store.shell.minimalShellMode && {
-            bottom: 60 + clamp(safeAreaInsets.bottom, 15, 30),
-          },
+        {bottom},
       ]}
       onPress={onPress}
       hitSlop={HITSLOP_20}
@@ -52,7 +54,7 @@ const styles = StyleSheet.create({
   loadLatest: {
     position: 'absolute',
     left: 18,
-    bottom: 35,
+    bottom: 44,
     borderWidth: 1,
     width: 52,
     height: 52,


### PR DESCRIPTION
The floating buttons were positioned inconsistently across platforms. This fixes that.

**Web**

|Before|After|
|-|-|
|<img width="622" alt="CleanShot 2023-09-20 at 19 00 03@2x" src="https://github.com/bluesky-social/social-app/assets/1270099/c551801c-f559-4824-97a9-951f7c957643">|<img width="626" alt="CleanShot 2023-09-20 at 18 58 57@2x" src="https://github.com/bluesky-social/social-app/assets/1270099/35ad7563-7d89-4310-9d6a-f5411afe9cb4">|

**iOS**

|Before|After|
|-|-|
|<img width="884" alt="CleanShot 2023-09-20 at 19 03 28@2x" src="https://github.com/bluesky-social/social-app/assets/1270099/e2e7fc68-14e1-40b8-a637-04b45546512a">|<img width="888" alt="CleanShot 2023-09-20 at 19 04 56@2x" src="https://github.com/bluesky-social/social-app/assets/1270099/2bfac664-b44e-421c-ba87-e35f893b8a01">|

**Android**

|Before|After|
|-|-|
|<img width="873" alt="CleanShot 2023-09-20 at 19 09 43@2x" src="https://github.com/bluesky-social/social-app/assets/1270099/1d4d23de-7ec5-4cd7-8d1e-e527efa20673">|<img width="867" alt="CleanShot 2023-09-20 at 19 08 17@2x" src="https://github.com/bluesky-social/social-app/assets/1270099/9ba56db3-8fd7-4363-81d7-1992b95ef135">|


