### PR TITLE
Updates InviteCodes modal to use dynamic/responsive styles on web

### DIFF
--- a/src/view/com/modals/InviteCodes.tsx
+++ b/src/view/com/modals/InviteCodes.tsx
@@ -13,12 +13,14 @@ import {useStores} from 'state/index'
 import {ScrollView} from './util'
 import {usePalette} from 'lib/hooks/usePalette'
 import {isWeb} from 'platform/detection'
+import {useWebMediaQueries} from 'lib/hooks/useWebMediaQueries'
 
 export const snapPoints = ['70%']
 
 export function Component({}: {}) {
   const pal = usePalette('default')
   const store = useStores()
+  const {isTabletOrDesktop} = useWebMediaQueries()
 
   const onClose = React.useCallback(() => {
     store.shell.closeModal()
@@ -34,7 +36,11 @@ export function Component({}: {}) {
           </Text>
         </View>
         <View style={styles.flex1} />
-        <View style={styles.btnContainer}>
+        <View
+          style={[
+            styles.btnContainer,
+            isTabletOrDesktop && styles.btnContainerDesktop,
+          ]}>
           <Button
             type="primary"
             label="Done"
@@ -185,6 +191,9 @@ const styles = StyleSheet.create({
   btnContainer: {
     flexDirection: 'row',
     justifyContent: 'center',
+  },
+  btnContainerDesktop: {
+    marginTop: 14,
   },
   btn: {
     flexDirection: 'row',


### PR DESCRIPTION
This PR introduces dynamic, responsive styles to the InviteCodes modal, improving its layout on tablet and desktop devices.

## Changes include

- Utilization of the `useWebMediaQueries` hook to detect the device type and adjust styles accordingly.
- Addition of a new style, `btnContainerDesktop`, which modifies the top margin when the device is a tablet or desktop.

These updates align the InviteCodes modal with the layout of the App Passwords page, providing consistency across different components.

Please see the attached before and after screenshots for a visual comparison of the changes.

### Before
<img width="2088" alt="Xnip2023-09-21_09-59-45" src="https://github.com/bluesky-social/social-app/assets/38807139/3c8de83c-6367-49a5-80f9-4ea843409c4d">

### After
<img width="2088" alt="Xnip2023-09-21_09-59-21" src="https://github.com/bluesky-social/social-app/assets/38807139/e743b5e5-db27-44a1-bc86-f8e03c61006f">