### PR TITLE
Tune the treeview mode to use larger immediate-children

### DIFF
--- a/src/view/com/composer/Prompt.tsx
+++ b/src/view/com/composer/Prompt.tsx
@@ -33,7 +33,7 @@ export function ComposePrompt({onPressCompose}: {onPressCompose: () => void}) {
 
 const styles = StyleSheet.create({
   prompt: {
-    paddingHorizontal: 20,
+    paddingHorizontal: 18,
     paddingTop: 10,
     paddingBottom: 10,
     flexDirection: 'row',

--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -470,7 +470,7 @@ export const PostThreadItem = observer(function PostThreadItem({
                 showAvatar={isThreadedChild}
                 avatarSize={26}
                 displayNameType="md-bold"
-                displayNameStyle={s.ml2}
+                displayNameStyle={isThreadedChild && s.ml2}
                 style={isThreadedChild && s.mb5}
               />
               <PostAlerts

--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -167,13 +167,13 @@ export const PostThreadItem = observer(function PostThreadItem({
       <>
         {item.rootUri !== item.uri && (
           <View style={{paddingLeft: 16, flexDirection: 'row', height: 16}}>
-            <View style={{width: 52}}>
+            <View style={{width: 38}}>
               <View
                 style={[
                   styles.replyLine,
                   {
                     flexGrow: 1,
-                    backgroundColor: pal.colors.replyLine,
+                    backgroundColor: pal.colors.border,
                   },
                 ]}
               />
@@ -392,7 +392,7 @@ export const PostThreadItem = observer(function PostThreadItem({
       </>
     )
   } else {
-    const isThreadedChild = treeView && item._depth > 0
+    const isThreadedChild = treeView && item._depth > 1
     return (
       <PostOuterWrapper
         item={item}
@@ -412,14 +412,14 @@ export const PostThreadItem = observer(function PostThreadItem({
               paddingLeft: 8,
               height: isThreadedChild ? 8 : 16,
             }}>
-            <View style={{width: 52}}>
+            <View style={{width: 38}}>
               {!isThreadedChild && item._showParentReplyLine && (
                 <View
                   style={[
                     styles.replyLine,
                     {
                       flexGrow: 1,
-                      backgroundColor: pal.colors.replyLine,
+                      backgroundColor: pal.colors.border,
                       marginBottom: 4,
                     },
                   ]}
@@ -439,7 +439,7 @@ export const PostThreadItem = observer(function PostThreadItem({
             {!isThreadedChild && (
               <View style={styles.layoutAvi}>
                 <PreviewableUserAvatar
-                  size={isThreadedChild ? 36 : 52}
+                  size={38}
                   did={item.post.author.did}
                   handle={item.post.author.handle}
                   avatar={item.post.author.avatar}
@@ -452,9 +452,7 @@ export const PostThreadItem = observer(function PostThreadItem({
                       styles.replyLine,
                       {
                         flexGrow: 1,
-                        backgroundColor: isThreadedChild
-                          ? pal.colors.border
-                          : pal.colors.replyLine,
+                        backgroundColor: pal.colors.border,
                         marginTop: 4,
                       },
                     ]}
@@ -480,11 +478,7 @@ export const PostThreadItem = observer(function PostThreadItem({
                 style={styles.alert}
               />
               {item.richText?.text ? (
-                <View
-                  style={[
-                    styles.postTextContainer,
-                    // isThreadedChild && {paddingTop: 2},
-                  ]}>
+                <View style={styles.postTextContainer}>
                   <RichText
                     type="post-text"
                     richText={item.richText}
@@ -569,7 +563,7 @@ function PostOuterWrapper({
 }>) {
   const {isMobile} = useWebMediaQueries()
   const pal = usePalette('default')
-  if (treeView && item._depth > 0) {
+  if (treeView && item._depth > 1) {
     return (
       <View
         style={[
@@ -578,7 +572,7 @@ function PostOuterWrapper({
           styles.cursor,
           {
             flexDirection: 'row',
-            paddingLeft: 10,
+            paddingLeft: 20,
             borderTopWidth: item._depth === 1 ? 1 : 0,
             paddingTop: item._depth === 1 ? 8 : 0,
           },
@@ -589,8 +583,8 @@ function PostOuterWrapper({
             style={{
               borderLeftWidth: 2,
               borderLeftColor: pal.colors.border,
-              marginLeft: isMobile ? 6 : 14,
-              paddingLeft: isMobile ? 6 : 12,
+              marginLeft: n === 0 ? 14 : isMobile ? 6 : 14,
+              paddingLeft: n === 0 ? 18 : isMobile ? 6 : 12,
             }}
           />
         ))}


### PR DESCRIPTION
Another iteration after a night of QA. We need to balance horizontal screen usage with overall visual clarity and appeal. With this update, I modified the immediate children to show as with normal linear posts, but then further children go into the thread mode. I think this feels more natural.

**Desktop**

|Before|After|
|-|-|
|![CleanShot 2023-09-21 at 10 56 05@2x](https://github.com/bluesky-social/social-app/assets/1270099/230f007b-854a-4a63-8700-9c118a43dc68)|![CleanShot 2023-09-21 at 10 55 22@2x](https://github.com/bluesky-social/social-app/assets/1270099/fdf7f8a0-78c6-4af5-a42c-973406544753)|

**Mobile**

|Before|After|
|-|-|
|![image](https://github.com/bluesky-social/social-app/assets/1270099/05952b05-d04a-40a8-8b79-648f1e216b70)|![image](https://github.com/bluesky-social/social-app/assets/1270099/4de8f273-afbc-4188-889b-ee5ccb1bb40f)|

