### PR TITLE
Dont reposition load latest button on desktop

### DIFF
--- a/src/view/com/util/load-latest/LoadLatestBtn.tsx
+++ b/src/view/com/util/load-latest/LoadLatestBtn.tsx
@@ -28,7 +28,8 @@ export const LoadLatestBtn = observer(function LoadLatestBtnImpl({
   const minMode = store.shell.minimalShellMode
   const bottom = isTablet
     ? 50
-    : (minMode ? 16 : 60) + (isWeb ? 20 : clamp(safeAreaInsets.bottom, 15, 60))
+    : (minMode || isDesktop ? 16 : 60) +
+      (isWeb ? 20 : clamp(safeAreaInsets.bottom, 15, 60))
   return (
     <TouchableOpacity
       style={[


### PR DESCRIPTION
Stupid bugfix, desktop doesnt use minimal shell mode so it shouldnt move the load latest btn around