### PR TITLE
Improve Device Detection For Better Responsiveness

### DIFF
--- a/src/platform/detection.ts
+++ b/src/platform/detection.ts
@@ -12,7 +12,6 @@ export const isMobileWeb =
   isWeb &&
   // @ts-ignore we know window exists -prf
   global.window.matchMedia(isMobileWebMediaQuery)?.matches
-export const isDesktopWeb = isWeb && !isMobileWeb
 
 export const deviceLocales = dedupArray(
   getLocales?.().map?.(locale => locale.languageCode),

--- a/src/view/com/auth/SplashScreen.web.tsx
+++ b/src/view/com/auth/SplashScreen.web.tsx
@@ -6,7 +6,8 @@ import {ErrorBoundary} from 'view/com/util/ErrorBoundary'
 import {s, colors} from 'lib/styles'
 import {usePalette} from 'lib/hooks/usePalette'
 import {CenteredView} from '../util/Views'
-import {isMobileWeb} from 'platform/detection'
+import {isWeb} from 'platform/detection'
+import {useWebMediaQueries} from 'lib/hooks/useWebMediaQueries'
 
 export const SplashScreen = ({
   onPressSignin,
@@ -16,6 +17,9 @@ export const SplashScreen = ({
   onPressCreateAccount: () => void
 }) => {
   const pal = usePalette('default')
+  const {isTabletOrMobile} = useWebMediaQueries()
+  const styles = useStyles()
+  const isMobileWeb = isWeb && isTabletOrMobile
 
   return (
     <CenteredView style={[styles.container, pal.view]}>
@@ -55,13 +59,14 @@ export const SplashScreen = ({
           </View>
         </ErrorBoundary>
       </View>
-      <Footer />
+      <Footer styles={styles} />
     </CenteredView>
   )
 }
 
-function Footer() {
+function Footer({styles}: {styles: ReturnType<typeof useStyles>}) {
   const pal = usePalette('default')
+
   return (
     <View style={[styles.footer, pal.view, pal.border]}>
       <TextLink
@@ -82,78 +87,81 @@ function Footer() {
     </View>
   )
 }
-
-const styles = StyleSheet.create({
-  container: {
-    height: '100%',
-  },
-  containerInner: {
-    height: '100%',
-    justifyContent: 'center',
-    // @ts-ignore web only
-    paddingBottom: '20vh',
-    paddingHorizontal: 20,
-  },
-  containerInnerMobile: {
-    paddingBottom: 50,
-  },
-  title: {
-    textAlign: 'center',
-    color: colors.blue3,
-    fontSize: 68,
-    fontWeight: 'bold',
-    paddingBottom: 10,
-  },
-  titleMobile: {
-    textAlign: 'center',
-    color: colors.blue3,
-    fontSize: 58,
-    fontWeight: 'bold',
-  },
-  subtitle: {
-    textAlign: 'center',
-    color: colors.gray5,
-    fontSize: 52,
-    fontWeight: 'bold',
-    paddingBottom: 30,
-  },
-  subtitleMobile: {
-    textAlign: 'center',
-    color: colors.gray5,
-    fontSize: 42,
-    fontWeight: 'bold',
-    paddingBottom: 30,
-  },
-  btns: {
-    flexDirection: isMobileWeb ? 'column' : 'row',
-    gap: 20,
-    justifyContent: 'center',
-    paddingBottom: 40,
-  },
-  btn: {
-    borderRadius: 30,
-    paddingHorizontal: 24,
-    paddingVertical: 12,
-    minWidth: 220,
-  },
-  btnLabel: {
-    textAlign: 'center',
-    fontSize: 18,
-  },
-  notice: {
-    paddingHorizontal: 40,
-    textAlign: 'center',
-  },
-  footer: {
-    position: 'absolute',
-    left: 0,
-    right: 0,
-    bottom: 0,
-    padding: 20,
-    borderTopWidth: 1,
-    flexDirection: 'row',
-  },
-  footerLink: {
-    marginRight: 20,
-  },
-})
+const useStyles = () => {
+  const {isTabletOrMobile} = useWebMediaQueries()
+  const isMobileWeb = isWeb && isTabletOrMobile
+  return StyleSheet.create({
+    container: {
+      height: '100%',
+    },
+    containerInner: {
+      height: '100%',
+      justifyContent: 'center',
+      // @ts-ignore web only
+      paddingBottom: '20vh',
+      paddingHorizontal: 20,
+    },
+    containerInnerMobile: {
+      paddingBottom: 50,
+    },
+    title: {
+      textAlign: 'center',
+      color: colors.blue3,
+      fontSize: 68,
+      fontWeight: 'bold',
+      paddingBottom: 10,
+    },
+    titleMobile: {
+      textAlign: 'center',
+      color: colors.blue3,
+      fontSize: 58,
+      fontWeight: 'bold',
+    },
+    subtitle: {
+      textAlign: 'center',
+      color: colors.gray5,
+      fontSize: 52,
+      fontWeight: 'bold',
+      paddingBottom: 30,
+    },
+    subtitleMobile: {
+      textAlign: 'center',
+      color: colors.gray5,
+      fontSize: 42,
+      fontWeight: 'bold',
+      paddingBottom: 30,
+    },
+    btns: {
+      flexDirection: isMobileWeb ? 'column' : 'row',
+      gap: 20,
+      justifyContent: 'center',
+      paddingBottom: 40,
+    },
+    btn: {
+      borderRadius: 30,
+      paddingHorizontal: 24,
+      paddingVertical: 12,
+      minWidth: 220,
+    },
+    btnLabel: {
+      textAlign: 'center',
+      fontSize: 18,
+    },
+    notice: {
+      paddingHorizontal: 40,
+      textAlign: 'center',
+    },
+    footer: {
+      position: 'absolute',
+      left: 0,
+      right: 0,
+      bottom: 0,
+      padding: 20,
+      borderTopWidth: 1,
+      flexDirection: 'row',
+    },
+    footerLink: {
+      marginRight: 20,
+    },
+  })
+}

--- a/src/view/com/composer/photos/OpenCameraBtn.tsx
+++ b/src/view/com/composer/photos/OpenCameraBtn.tsx
@@ -7,11 +7,11 @@ import {
 import {usePalette} from 'lib/hooks/usePalette'
 import {useAnalytics} from 'lib/analytics/analytics'
 import {useStores} from 'state/index'
-import {isDesktopWeb} from 'platform/detection'
 import {openCamera} from 'lib/media/picker'
 import {useCameraPermission} from 'lib/hooks/usePermissions'
 import {HITSLOP_10, POST_IMG_MAX} from 'lib/constants'
 import {GalleryModel} from 'state/models/media/gallery'
+import {useWebMediaQueries} from 'lib/hooks/useWebMediaQueries'
 
 type Props = {
   gallery: GalleryModel
@@ -22,6 +22,7 @@ export function OpenCameraBtn({gallery}: Props) {
   const {track} = useAnalytics()
   const store = useStores()
   const {requestCameraAccessIfNeeded} = useCameraPermission()
+  const {isDesktop} = useWebMediaQueries()
 
   const onPressTakePicture = useCallback(async () => {
     track('Composer:CameraOpened')
@@ -43,7 +44,7 @@ export function OpenCameraBtn({gallery}: Props) {
     }
   }, [gallery, track, store, requestCameraAccessIfNeeded])
 
-  if (isDesktopWeb) {
+  if (isDesktop) {
     return null
   }
 

--- a/src/view/com/composer/photos/OpenCameraBtn.tsx
+++ b/src/view/com/composer/photos/OpenCameraBtn.tsx
@@ -11,7 +11,7 @@ import {openCamera} from 'lib/media/picker'
 import {useCameraPermission} from 'lib/hooks/usePermissions'
 import {HITSLOP_10, POST_IMG_MAX} from 'lib/constants'
 import {GalleryModel} from 'state/models/media/gallery'
-import {useWebMediaQueries} from 'lib/hooks/useWebMediaQueries'
+import {isMobileWeb, isNative} from 'platform/detection'
 
 type Props = {
   gallery: GalleryModel
@@ -22,7 +22,6 @@ export function OpenCameraBtn({gallery}: Props) {
   const {track} = useAnalytics()
   const store = useStores()
   const {requestCameraAccessIfNeeded} = useCameraPermission()
-  const {isDesktop} = useWebMediaQueries()
 
   const onPressTakePicture = useCallback(async () => {
     track('Composer:CameraOpened')
@@ -44,7 +43,8 @@ export function OpenCameraBtn({gallery}: Props) {
     }
   }, [gallery, track, store, requestCameraAccessIfNeeded])
 
-  if (isDesktop) {
+  const shouldShowCameraButton = isNative || isMobileWeb
+  if (!shouldShowCameraButton) {
     return null
   }
 

--- a/src/view/com/composer/photos/SelectPhotoBtn.tsx
+++ b/src/view/com/composer/photos/SelectPhotoBtn.tsx
@@ -23,7 +23,7 @@ export function SelectPhotoBtn({gallery}: Props) {
   const onPressSelectPhotos = useCallback(async () => {
     track('Composer:GalleryOpened')
 
-    if (!isNative && !(await requestPhotoAccessIfNeeded())) {
+    if (isNative && !(await requestPhotoAccessIfNeeded())) {
       return
     }
 

--- a/src/view/com/composer/photos/SelectPhotoBtn.tsx
+++ b/src/view/com/composer/photos/SelectPhotoBtn.tsx
@@ -6,10 +6,10 @@ import {
 } from '@fortawesome/react-native-fontawesome'
 import {usePalette} from 'lib/hooks/usePalette'
 import {useAnalytics} from 'lib/analytics/analytics'
-import {isDesktopWeb} from 'platform/detection'
 import {usePhotoLibraryPermission} from 'lib/hooks/usePermissions'
 import {GalleryModel} from 'state/models/media/gallery'
 import {HITSLOP_10} from 'lib/constants'
+import {useWebMediaQueries} from 'lib/hooks/useWebMediaQueries'
 
 type Props = {
   gallery: GalleryModel
@@ -19,16 +19,17 @@ export function SelectPhotoBtn({gallery}: Props) {
   const pal = usePalette('default')
   const {track} = useAnalytics()
   const {requestPhotoAccessIfNeeded} = usePhotoLibraryPermission()
+  const {isDesktop} = useWebMediaQueries()
 
   const onPressSelectPhotos = useCallback(async () => {
     track('Composer:GalleryOpened')
 
-    if (!isDesktopWeb && !(await requestPhotoAccessIfNeeded())) {
+    if (!isDesktop && !(await requestPhotoAccessIfNeeded())) {
       return
     }
 
     gallery.pick()
-  }, [track, gallery, requestPhotoAccessIfNeeded])
+  }, [track, isDesktop, requestPhotoAccessIfNeeded, gallery])
 
   return (
     <TouchableOpacity

--- a/src/view/com/composer/photos/SelectPhotoBtn.tsx
+++ b/src/view/com/composer/photos/SelectPhotoBtn.tsx
@@ -9,7 +9,7 @@ import {useAnalytics} from 'lib/analytics/analytics'
 import {usePhotoLibraryPermission} from 'lib/hooks/usePermissions'
 import {GalleryModel} from 'state/models/media/gallery'
 import {HITSLOP_10} from 'lib/constants'
-import {useWebMediaQueries} from 'lib/hooks/useWebMediaQueries'
+import {isNative} from 'platform/detection'
 
 type Props = {
   gallery: GalleryModel
@@ -19,17 +19,16 @@ export function SelectPhotoBtn({gallery}: Props) {
   const pal = usePalette('default')
   const {track} = useAnalytics()
   const {requestPhotoAccessIfNeeded} = usePhotoLibraryPermission()
-  const {isDesktop} = useWebMediaQueries()
 
   const onPressSelectPhotos = useCallback(async () => {
     track('Composer:GalleryOpened')
 
-    if (!isDesktop && !(await requestPhotoAccessIfNeeded())) {
+    if (!isNative && !(await requestPhotoAccessIfNeeded())) {
       return
     }
 
     gallery.pick()
-  }, [track, isDesktop, requestPhotoAccessIfNeeded, gallery])
+  }, [track, requestPhotoAccessIfNeeded, gallery])
 
   return (
     <TouchableOpacity

--- a/src/view/com/post-thread/PostThread.tsx
+++ b/src/view/com/post-thread/PostThread.tsx
@@ -23,7 +23,7 @@ import {ViewHeader} from '../util/ViewHeader'
 import {ErrorMessage} from '../util/error/ErrorMessage'
 import {Text} from '../util/text/Text'
 import {s} from 'lib/styles'
-import {isNative, isDesktopWeb} from 'platform/detection'
+import {isNative} from 'platform/detection'
 import {usePalette} from 'lib/hooks/usePalette'
 import {useSetTitle} from 'lib/hooks/useSetTitle'
 import {useNavigation} from '@react-navigation/native'
@@ -78,7 +78,7 @@ export const PostThread = observer(function PostThread({
   treeView: boolean
 }) {
   const pal = usePalette('default')
-  const {isTablet} = useWebMediaQueries()
+  const {isTablet, isDesktop} = useWebMediaQueries()
   const ref = useRef<FlatList>(null)
   const hasScrolledIntoView = useRef<boolean>(false)
   const [isRefreshing, setIsRefreshing] = React.useState(false)
@@ -189,7 +189,7 @@ export const PostThread = observer(function PostThread({
       } else if (item === REPLY_PROMPT) {
         return (
           <View>
-            {isDesktopWeb && <ComposePrompt onPressCompose={onPressReply} />}
+            {isDesktop && <ComposePrompt onPressCompose={onPressReply} />}
           </View>
         )
       } else if (item === DELETED) {
@@ -261,7 +261,20 @@ export const PostThread = observer(function PostThread({
       }
       return <></>
     },
-    [onRefresh, onPressReply, pal, posts, isTablet, treeView],
+    [
+      isTablet,
+      isDesktop,
+      onPressReply,
+      pal.border,
+      pal.viewLight,
+      pal.textLight,
+      pal.view,
+      pal.text,
+      pal.colors.border,
+      posts,
+      onRefresh,
+      treeView,
+    ],
   )
 
   // loading

--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -34,7 +34,6 @@ import {usePalette} from 'lib/hooks/usePalette'
 import {formatCount} from '../util/numeric/format'
 import {TimeElapsed} from 'view/com/util/TimeElapsed'
 import {makeProfileLink} from 'lib/routes/links'
-import {isDesktopWeb} from 'platform/detection'
 import {useWebMediaQueries} from 'lib/hooks/useWebMediaQueries'
 
 export const PostThreadItem = observer(function PostThreadItem({
@@ -51,6 +50,7 @@ export const PostThreadItem = observer(function PostThreadItem({
   const pal = usePalette('default')
   const store = useStores()
   const [deleted, setDeleted] = React.useState(false)
+  const styles = useStyles()
   const record = item.postRecord
   const hasEngagement = item.post.likeCount || item.post.repostCount
 
@@ -568,6 +568,7 @@ function PostOuterWrapper({
 }>) {
   const {isMobile} = useWebMediaQueries()
   const pal = usePalette('default')
+  const styles = useStyles()
   if (treeView && item._depth > 1) {
     return (
       <View
@@ -636,90 +637,93 @@ function ExpandedPostDetails({
   )
 }
 
-const styles = StyleSheet.create({
-  outer: {
-    borderTopWidth: 1,
-    paddingLeft: 8,
-  },
-  outerHighlighted: {
-    paddingTop: 16,
-    paddingLeft: 8,
-    paddingRight: 8,
-  },
-  noTopBorder: {
-    borderTopWidth: 0,
-  },
-  layout: {
-    flexDirection: 'row',
-    gap: 10,
-    paddingLeft: 8,
-  },
-  layoutAvi: {},
-  layoutContent: {
-    flex: 1,
-    paddingRight: 10,
-  },
-  meta: {
-    flexDirection: 'row',
-    paddingTop: 2,
-    paddingBottom: 2,
-  },
-  metaExpandedLine1: {
-    paddingTop: 5,
-    paddingBottom: 0,
-  },
-  metaItem: {
-    paddingRight: 5,
-    maxWidth: isDesktopWeb ? 380 : 220,
-  },
-  alert: {
-    marginBottom: 6,
-  },
-  postTextContainer: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    flexWrap: 'wrap',
-    paddingBottom: 4,
-    paddingRight: 10,
-  },
-  postTextLargeContainer: {
-    paddingHorizontal: 0,
-    paddingBottom: 10,
-  },
-  translateLink: {
-    marginBottom: 6,
-  },
-  contentHider: {
-    marginBottom: 6,
-  },
-  contentHiderChild: {
-    marginTop: 6,
-  },
-  expandedInfo: {
-    flexDirection: 'row',
-    padding: 10,
-    borderTopWidth: 1,
-    borderBottomWidth: 1,
-    marginTop: 5,
-    marginBottom: 15,
-  },
-  expandedInfoItem: {
-    marginRight: 10,
-  },
-  loadMore: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'flex-start',
-    gap: 4,
-    paddingHorizontal: 20,
-  },
-  replyLine: {
-    width: 2,
-    marginLeft: 'auto',
-    marginRight: 'auto',
-  },
-  cursor: {
-    // @ts-ignore web only
-    cursor: 'pointer',
-  },
-})
+const useStyles = () => {
+  const {isDesktop} = useWebMediaQueries()
+  return StyleSheet.create({
+    outer: {
+      borderTopWidth: 1,
+      paddingLeft: 8,
+    },
+    outerHighlighted: {
+      paddingTop: 16,
+      paddingLeft: 8,
+      paddingRight: 8,
+    },
+    noTopBorder: {
+      borderTopWidth: 0,
+    },
+    layout: {
+      flexDirection: 'row',
+      gap: 10,
+      paddingLeft: 8,
+    },
+    layoutAvi: {},
+    layoutContent: {
+      flex: 1,
+      paddingRight: 10,
+    },
+    meta: {
+      flexDirection: 'row',
+      paddingTop: 2,
+      paddingBottom: 2,
+    },
+    metaExpandedLine1: {
+      paddingTop: 5,
+      paddingBottom: 0,
+    },
+    metaItem: {
+      paddingRight: 5,
+      maxWidth: isDesktop ? 380 : 220,
+    },
+    alert: {
+      marginBottom: 6,
+    },
+    postTextContainer: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      flexWrap: 'wrap',
+      paddingBottom: 4,
+      paddingRight: 10,
+    },
+    postTextLargeContainer: {
+      paddingHorizontal: 0,
+      paddingBottom: 10,
+    },
+    translateLink: {
+      marginBottom: 6,
+    },
+    contentHider: {
+      marginBottom: 6,
+    },
+    contentHiderChild: {
+      marginTop: 6,
+    },
+    expandedInfo: {
+      flexDirection: 'row',
+      padding: 10,
+      borderTopWidth: 1,
+      borderBottomWidth: 1,
+      marginTop: 5,
+      marginBottom: 15,
+    },
+    expandedInfoItem: {
+      marginRight: 10,
+    },
+    loadMore: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'flex-start',
+      gap: 4,
+      paddingHorizontal: 20,
+    },
+    replyLine: {
+      width: 2,
+      marginLeft: 'auto',
+      marginRight: 'auto',
+    },
+    cursor: {
+      // @ts-ignore web only
+      cursor: 'pointer',
+    },
+  })
+}

--- a/src/view/com/util/Html.tsx
+++ b/src/view/com/util/Html.tsx
@@ -4,13 +4,13 @@ import {usePalette} from 'lib/hooks/usePalette'
 import {useTheme} from 'lib/ThemeContext'
 import {Text} from './text/Text'
 import {TextLink} from './Link'
-import {isDesktopWeb} from 'platform/detection'
 import {
   H1 as ExpoH1,
   H2 as ExpoH2,
   H3 as ExpoH3,
   H4 as ExpoH4,
 } from '@expo/html-elements'
+import {useWebMediaQueries} from 'lib/hooks/useWebMediaQueries'
 
 /**
  * These utilities are used to define long documents in an html-like
@@ -27,30 +27,35 @@ interface IsChildProps {
 //   | React.ReactNode
 
 export function H1({children}: React.PropsWithChildren<{}>) {
+  const styles = useStyles()
   const pal = usePalette('default')
   const typography = useTheme().typography['title-xl']
   return <ExpoH1 style={[typography, pal.text, styles.h1]}>{children}</ExpoH1>
 }
 
 export function H2({children}: React.PropsWithChildren<{}>) {
+  const styles = useStyles()
   const pal = usePalette('default')
   const typography = useTheme().typography['title-lg']
   return <ExpoH2 style={[typography, pal.text, styles.h2]}>{children}</ExpoH2>
 }
 
 export function H3({children}: React.PropsWithChildren<{}>) {
+  const styles = useStyles()
   const pal = usePalette('default')
   const typography = useTheme().typography.title
   return <ExpoH3 style={[typography, pal.text, styles.h3]}>{children}</ExpoH3>
 }
 
 export function H4({children}: React.PropsWithChildren<{}>) {
+  const styles = useStyles()
   const pal = usePalette('default')
   const typography = useTheme().typography['title-sm']
   return <ExpoH4 style={[typography, pal.text, styles.h4]}>{children}</ExpoH4>
 }
 
 export function P({children}: React.PropsWithChildren<{}>) {
+  const styles = useStyles()
   const pal = usePalette('default')
   return (
     <Text type="md" style={[pal.text, styles.p]}>
@@ -60,6 +65,7 @@ export function P({children}: React.PropsWithChildren<{}>) {
 }
 
 export function UL({children, isChild}: React.PropsWithChildren<IsChildProps>) {
+  const styles = useStyles()
   return (
     <View style={[styles.ul, isChild && styles.ulChild]}>
       {markChildProps(children)}
@@ -68,6 +74,7 @@ export function UL({children, isChild}: React.PropsWithChildren<IsChildProps>) {
 }
 
 export function OL({children, isChild}: React.PropsWithChildren<IsChildProps>) {
+  const styles = useStyles()
   return (
     <View style={[styles.ol, isChild && styles.olChild]}>
       {markChildProps(children)}
@@ -79,6 +86,7 @@ export function LI({
   children,
   value,
 }: React.PropsWithChildren<{value?: string}>) {
+  const styles = useStyles()
   const pal = usePalette('default')
   return (
     <View style={styles.li}>
@@ -91,6 +99,7 @@ export function LI({
 }
 
 export function A({children, href}: React.PropsWithChildren<{href: string}>) {
+  const styles = useStyles()
   const pal = usePalette('default')
   return (
     <TextLink
@@ -112,6 +121,7 @@ export function STRONG({children}: React.PropsWithChildren<{}>) {
 }
 
 export function EM({children}: React.PropsWithChildren<{}>) {
+  const styles = useStyles()
   const pal = usePalette('default')
   return (
     <Text type="md" style={[pal.text, styles.em]}>
@@ -132,58 +142,61 @@ function markChildProps(children: React.ReactNode) {
   })
 }
 
-const styles = StyleSheet.create({
-  h1: {
-    marginTop: 20,
-    marginBottom: 10,
-    letterSpacing: 0.8,
-  },
-  h2: {
-    marginTop: 20,
-    marginBottom: 10,
-    letterSpacing: 0.8,
-  },
-  h3: {
-    marginTop: 0,
-    marginBottom: 10,
-  },
-  h4: {
-    marginTop: 0,
-    marginBottom: 10,
-    fontWeight: 'bold',
-  },
-  p: {
-    marginBottom: 10,
-  },
-  ul: {
-    marginBottom: 10,
-    paddingLeft: isDesktopWeb ? 18 : 4,
-  },
-  ulChild: {
-    paddingTop: 10,
-    marginBottom: 0,
-  },
-  ol: {
-    marginBottom: 10,
-    paddingLeft: isDesktopWeb ? 18 : 4,
-  },
-  olChild: {
-    paddingTop: 10,
-    marginBottom: 0,
-  },
-  li: {
-    flexDirection: 'row',
-    paddingRight: 20,
-    marginBottom: 10,
-  },
-  liBullet: {
-    paddingRight: 10,
-  },
-  liText: {},
-  a: {
-    marginBottom: 10,
-  },
-  em: {
-    fontStyle: 'italic',
-  },
-})
+const useStyles = () => {
+  const {isDesktop} = useWebMediaQueries()
+  return StyleSheet.create({
+    h1: {
+      marginTop: 20,
+      marginBottom: 10,
+      letterSpacing: 0.8,
+    },
+    h2: {
+      marginTop: 20,
+      marginBottom: 10,
+      letterSpacing: 0.8,
+    },
+    h3: {
+      marginTop: 0,
+      marginBottom: 10,
+    },
+    h4: {
+      marginTop: 0,
+      marginBottom: 10,
+      fontWeight: 'bold',
+    },
+    p: {
+      marginBottom: 10,
+    },
+    ul: {
+      marginBottom: 10,
+      paddingLeft: isDesktop ? 18 : 4,
+    },
+    ulChild: {
+      paddingTop: 10,
+      marginBottom: 0,
+    },
+    ol: {
+      marginBottom: 10,
+      paddingLeft: isDesktop ? 18 : 4,
+    },
+    olChild: {
+      paddingTop: 10,
+      marginBottom: 0,
+    },
+    li: {
+      flexDirection: 'row',
+      paddingRight: 20,
+      marginBottom: 10,
+    },
+    liBullet: {
+      paddingRight: 10,
+    },
+    liText: {},
+    a: {
+      marginBottom: 10,
+    },
+    em: {
+      fontStyle: 'italic',
+    },
+  })
+}

--- a/src/view/com/util/Link.tsx
+++ b/src/view/com/util/Link.tsx
@@ -24,10 +24,11 @@ import {NavigationProp} from 'lib/routes/types'
 import {router} from '../../../routes'
 import {useStores, RootStoreModel} from 'state/index'
 import {convertBskyAppUrlIfNeeded, isExternalUrl} from 'lib/strings/url-helpers'
-import {isAndroid, isDesktopWeb} from 'platform/detection'
+import {isAndroid} from 'platform/detection'
 import {sanitizeUrl} from '@braintree/sanitize-url'
 import {PressableWithHover} from './PressableWithHover'
 import FixedTouchableHighlight from '../pager/FixedTouchableHighlight'
+import {useWebMediaQueries} from 'lib/hooks/useWebMediaQueries'
 
 type Event =
   | React.MouseEvent<HTMLAnchorElement, MouseEvent>
@@ -224,7 +225,9 @@ export const DesktopWebTextLink = observer(function DesktopWebTextLink({
   lineHeight,
   ...props
 }: DesktopWebTextLinkProps) {
-  if (isDesktopWeb) {
+  const {isDesktop} = useWebMediaQueries()
+
+  if (isDesktop) {
     return (
       <TextLink
         testID={testID}


### PR DESCRIPTION
## Motivation

The creation of this Pull Request was motivated by the need to address a particular issue, as referenced in the issue https://github.com/bluesky-social/social-app/issues/1268. 

After further investigation, I found that when users adjust the size of their desktop browser, [a specific variable `isDesktopWeb` will erroneously return `false`](https://github.com/bluesky-social/social-app/blob/3c4899b3c4ae55285559215023a25e365c9f4e30/src/view/com/util/Link.tsx#L225). At the same time, I also noticed that `isDesktopWeb` is used in many places in the project, which may cause some style issues because `isDesktopWeb` does not perform responsive updates.

Then I found [`useWebMediaQueries` hook](https://github.com/bluesky-social/social-app/blob/764c7cd5694a41c98d8543b68d7791fa90db4291/src/lib/hooks/useWebMediaQueries.tsx#L4) in the project. This Hook integrates responsive updates in device detection and represents a marked improvement over the existing method. Hence, in this pull request, I propose using this Hook as a replacement for the current logic.

## Changes

### https://github.com/bluesky-social/social-app/commit/d83738a0e709bbb407a53fba37b014a26251925e
  - Replace static `isDesktopWeb` with `useWebMediaQueries` hook to enable dynamic device type detection.
  - Create `useDeviceLimits` hook to dynamically determine `DY_LIMIT_UP` and `DY_LIMIT_DOWN` based on device type.
  - Update dependency arrays for the `useCallback` hooks to include new dynamic variables.
  

### https://github.com/bluesky-social/social-app/commit/63521ce896e675e311b9a24ec2c3b9b71455cd12
  - Create `useStyles` hook that generates styles object based on device type detected from `useWebMediaQueries`.
  - Replace static styles object with dynamic styles object generated from `useStyles` hook in components.
  - This allows `paddingLeft` values for 'ul' and 'ol' styles to adapt to device type dynamically.
  - This allows `maxWidth` values for 'metaItem'' styles to adapt to device type dynamically.
  
### https://github.com/bluesky-social/social-app/commit/61f68711d2842c50630e43202590680382102960
  - Removed the unused `isDesktopWeb` from _src/platform/detection.ts_.
  - Replaced `isDesktopWeb` with `useWebMediaQueries().isDesktop` in the remaining React components. 

### https://github.com/bluesky-social/social-app/commit/20251c6843d142244196d0884744068b2f864ae8
 - Replaced the usage of `isMobileWeb` exported from _src/platform/detection.ts_ in `SplashScreen` component with `isWeb && useWebMediaQueries().isTabletOrMobile`.

## Others

1. This does not solve issue https://github.com/bluesky-social/social-app/issues/1268 as using Media Query inside `DesktopWebTextLink` to determine if it is desktop web is fundamentally inappropriate. User Agent would be more reasonable for such a purpose. Considering the complexity, should we consider introducing [react-device-detect](https://www.npmjs.com/package/react-device-detect)?

2. There is still [one location where `isMobileWeb`](https://github.com/bluesky-social/social-app/blob/49356700c31a1cb34c252e3aecf18561114916b9/src/lib/styles.ts#L176) is being used that hasn't been replaced. As it affects a wide range of areas, careful planning and consideration are required for this task.