### PR TITLE
fix 'Reposted by' text overflow

### DIFF
--- a/src/view/com/posts/FeedItem.tsx
+++ b/src/view/com/posts/FeedItem.tsx
@@ -178,7 +178,7 @@ export const FeedItem = observer(function FeedItemImpl({
           )}
         </View>
 
-        <View style={{paddingTop: 12}}>
+        <View style={{paddingTop: 12, flexShrink: 1}}>
           {source ? (
             <Link
               title={sanitizeDisplayName(source.displayName)}
@@ -211,6 +211,7 @@ export const FeedItem = observer(function FeedItemImpl({
                 style={{
                   marginRight: 4,
                   color: pal.colors.textLight,
+                  minWidth: 16,
                 }}
               />
               <Text


### PR DESCRIPTION
(Extra "Reposted by" text just for testing)

Looks like this now:
<img width="553" alt="Screen Shot 2023-09-26 at 10 17 59 AM" src="https://github.com/bluesky-social/social-app/assets/4732330/aa526478-d32f-417b-944b-0e6fbe963677">

Prev:
![image](https://github.com/bluesky-social/social-app/assets/4732330/2303a137-b233-4e12-aeaa-52861407c498)

