### PR TITLE
:lipstick: Remove report option on my own post

### DIFF
--- a/src/view/com/util/forms/PostDropdownBtn.tsx
+++ b/src/view/com/util/forms/PostDropdownBtn.tsx
@@ -105,7 +105,7 @@ export function PostDropdownBtn({
     {
       label: 'separator',
     },
-    {
+    !isAuthor && {
       label: 'Report post',
       onPress() {
         store.shell.openModal({


### PR DESCRIPTION
Doesn't make a lot of sense for the author of a post to report their own post and with the dropdown growing ever so slightly, getting rid of an unnecessary item feels nice.