### PR TITLE
Small PFP on desktop

### DIFF
--- a/src/view/shell/desktop/LeftNav.tsx
+++ b/src/view/shell/desktop/LeftNav.tsx
@@ -42,7 +42,7 @@ import {makeProfileLink} from 'lib/routes/links'
 const ProfileCard = observer(function ProfileCardImpl() {
   const store = useStores()
   const {isDesktop} = useWebMediaQueries()
-  const size = isDesktop ? 64 : 48
+  const size = isDesktop ? 32 : 48
   return store.me.handle ? (
     <Link
       href={makeProfileLink(store.me)}


### PR DESCRIPTION
Aligns with back button when visible, and generally looks less wonky in my opinion.

![image](https://github.com/bluesky-social/social-app/assets/33783503/cfe6ec81-7977-4a4c-80ec-40f6378c8f8c)

Also just about lines up with the icons for each page.