### PR TITLE
Move sidebar by 10px for more even padding

### DIFF
--- a/src/view/shell/desktop/RightNav.tsx
+++ b/src/view/shell/desktop/RightNav.tsx
@@ -123,7 +123,7 @@ const styles = StyleSheet.create({
     position: 'absolute',
     top: 20,
     // @ts-ignore web only
-    left: 'calc(50vw + 310px)',
+    left: 'calc(50vw + 320px)',
     width: 304,
   },
 


### PR DESCRIPTION
Looks nicer as it adds even padding on the left relative to the main content as there is on the top. Not reflected on the left sidebar as that already has padding on each button / element.

![image](https://github.com/bluesky-social/social-app/assets/33783503/93f82013-20a8-4952-b1f2-82e1c8a1ca14)
