### PR TITLE
Add example google-services file

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -8,6 +8,7 @@
   - brew tap wix/brew
   - brew install applesimutils
 - After initial setup:
+  - Copy `google-services.json.example` to `google-services.json` or provide your own `google-services.json`. (A real firebase project is NOT required)
   - `npx expo prebuild` -> you will also need to run this anytime `app.json` or native `package.json` deps change
 - Start the dev servers
   - `git clone git@github.com:bluesky-social/atproto.git`
@@ -119,6 +120,7 @@ upload-sourcemaps \
 dist/bundles/main.jsbundle dist/bundles/ios-<hash>.map`
 
 ### OTA updates
+
 To create OTA updates, run `eas update` along with the `--branch` flag to indicate which branch you want to push the update to, and the `--message` flag to indicate a message for yourself and your team that shows up on https://expo.dev. ALl the channels (which make up the options for the `--branch` flag) are given in `eas.json`. [See more here](https://docs.expo.dev/eas-update/getting-started/)
 
 The clients which can receive an OTA update is governed by the `runtimeVersion` property in `app.json`. Right now, it is set so that only apps with the same `appVersion` (same as `version` property in `app.json`) can receive the update and install it. However, we can manually set `"runtimeVersion": "1.34.0"` or anything along those lines as well. This is useful if very little native code changes from update-to-update. If we are manually setting `runtimeVersion`, we should increment the version each time native code is changed. [See more here](https://docs.expo.dev/eas-update/runtime-versions/)

--- a/google-services.json.example
+++ b/google-services.json.example
@@ -1,0 +1,41 @@
+{
+  "project_info": {
+    "project_id": "blueskyweb-example",
+    "project_number": "100000000000",
+    "firebase_url": "https://blueskyweb-example.firebaseio.com"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:123456789000:android:f1bf012572b04063",
+        "android_client_info": {
+          "package_name": "xyz.blueskyweb.app"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "123456789000.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "123456789000"
+        }
+      ],
+      "services": {
+        "analytics_service": {
+          "status": 1
+        },
+        "appinvite_service": {
+          "status": 1,
+          "other_platform_oauth_client": []
+        },
+        "ads_service": {
+          "status": 2
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}


### PR DESCRIPTION
As an external contributor trying to build the app for the first time on Android throws a few errors due to a missing google-services.json.

<img width="1293" alt="image" src="https://github.com/bluesky-social/social-app/assets/11707729/1f570e56-3e1e-439f-af8f-257418b5c11b">

This PR adds an example google-services.json file that users can use as a base to build the app on Android. We can't simply use an empty JSON since Google enforces validation on specific fields within it. 

Note: all values used in this file are mocked and are not related to any existing Firebase projects 
 
