### PR TITLE
Composer prefilled mention - handle edge cases with DID URLs and users with invalid handles

### DIFF
--- a/src/view/screens/Profile.tsx
+++ b/src/view/screens/Profile.tsx
@@ -91,7 +91,10 @@ export const ProfileScreen = withAuthRequired(
     const onPressCompose = React.useCallback(() => {
       track('ProfileScreen:PressCompose')
       const mention =
-        uiState.profile.handle === store.me.handle ? '' : uiState.profile.handle
+        uiState.profile.handle === store.me.handle ||
+        uiState.profile.handle === 'handle.invalid'
+          ? undefined
+          : uiState.profile.handle
       store.shell.openComposer({mention})
     }, [store, track, uiState])
     const onSelectView = React.useCallback(

--- a/src/view/shell/desktop/LeftNav.tsx
+++ b/src/view/shell/desktop/LeftNav.tsx
@@ -191,7 +191,10 @@ function ComposeBtn() {
     if (currentRoute.name === 'Profile') {
       const {name: handle} =
         currentRoute.params as CommonNavigatorParams['Profile']
-      if (handle === store.me.handle || handle === 'handle.invalid')
+      // what if a user has a valid handle, but the URL uses the DID?
+      // the DID should not be used, but consider accessing the actual
+      // profile data instead of purely looking at the URL -sfn
+      if (handle === store.me.handle || handle.startsWith('did:'))
         return undefined
       return handle
     }

--- a/src/view/shell/desktop/LeftNav.tsx
+++ b/src/view/shell/desktop/LeftNav.tsx
@@ -191,7 +191,8 @@ function ComposeBtn() {
     if (currentRoute.name === 'Profile') {
       const {name: handle} =
         currentRoute.params as CommonNavigatorParams['Profile']
-      if (handle === store.me.handle) return undefined
+      if (handle === store.me.handle || handle === 'handle.invalid')
+        return undefined
       return handle
     }
     return undefined


### PR DESCRIPTION
I found that the behaviour of the composer where it prefills a mention when viewing a user's profile was producing incorrect behaviour when viewing a user with an invalid handle. This manifests in two bugs:

mobile: composer is prefilled with `@invalid.handle`

web: composer is prefilled with `@did:plc...`

![Screenshot 2023-09-27 at 10 25 07](https://github.com/bluesky-social/social-app/assets/10959775/e83422f7-2db6-4604-ba80-f7b1aebe7000)

This is because the compose button simply looks at the URL - this would happen when viewing a profile with a valid handle too if the DID URL is used

For the first bug, I simply added a check for `handle === 'handle.invalid'`. For the second one, I added a check for `handle.startsWith('did:')` - this is not a great solution because this does not handle accounts with valid handles viewed with their DID in the URL, but it's better than the current, broken behaviour.

Profile used for testing:
https://bsky.app/profile/did:plc:3nqrhu5mthmias3zc4a2ovzj

