### PR TITLE
Improvements to auto-mentioning users from their profiles

### DIFF
--- a/src/view/screens/Profile.tsx
+++ b/src/view/screens/Profile.tsx
@@ -91,7 +91,10 @@ export const ProfileScreen = withAuthRequired(
     const onPressCompose = React.useCallback(() => {
       track('ProfileScreen:PressCompose')
       const mention =
-        uiState.profile.handle === store.me.handle ? '' : uiState.profile.handle
+        uiState.profile.handle === store.me.handle ||
+        uiState.profile.handle === 'handle.invalid'
+          ? undefined
+          : uiState.profile.handle
       store.shell.openComposer({mention})
     }, [store, track, uiState])
     const onSelectView = React.useCallback(

--- a/src/view/shell/desktop/LeftNav.tsx
+++ b/src/view/shell/desktop/LeftNav.tsx
@@ -188,18 +188,25 @@ function ComposeBtn() {
   const getProfileHandle = async () => {
     const {routes} = getState()
     const currentRoute = routes[routes.length - 1]
+
     if (currentRoute.name === 'Profile') {
-      const {name: handleOrDid} =
+      let handle: string | undefined = (
         currentRoute.params as CommonNavigatorParams['Profile']
-      const cached = await store.profiles.cache.get(handleOrDid)
-      const profile = cached ? cached.data : undefined
-      if (
-        profile?.handle === store.me.handle ||
-        profile?.handle === 'handle.invalid'
-      )
+      ).name
+
+      if (handle.startsWith('did:')) {
+        const cached = await store.profiles.cache.get(handle)
+        const profile = cached ? cached.data : undefined
+        // if we can't resolve handle, set to undefined
+        handle = profile?.handle || undefined
+      }
+
+      if (!handle || handle === store.me.handle || handle === 'handle.invalid')
         return undefined
-      return profile?.handle
+
+      return handle
     }
+
     return undefined
   }
 

--- a/src/view/shell/desktop/LeftNav.tsx
+++ b/src/view/shell/desktop/LeftNav.tsx
@@ -185,24 +185,26 @@ function ComposeBtn() {
   const {getState} = useNavigation()
   const {isTablet} = useWebMediaQueries()
 
-  const getProfileHandle = () => {
+  const getProfileHandle = async () => {
     const {routes} = getState()
     const currentRoute = routes[routes.length - 1]
     if (currentRoute.name === 'Profile') {
-      const {name: handle} =
+      const {name: handleOrDid} =
         currentRoute.params as CommonNavigatorParams['Profile']
-      // what if a user has a valid handle, but the URL uses the DID?
-      // the DID should not be used, but consider accessing the actual
-      // profile data instead of purely looking at the URL -sfn
-      if (handle === store.me.handle || handle.startsWith('did:'))
+      const cached = await store.profiles.cache.get(handleOrDid)
+      const profile = cached ? cached.data : undefined
+      if (
+        profile?.handle === store.me.handle ||
+        profile?.handle === 'handle.invalid'
+      )
         return undefined
-      return handle
+      return profile?.handle
     }
     return undefined
   }
 
-  const onPressCompose = () =>
-    store.shell.openComposer({mention: getProfileHandle()})
+  const onPressCompose = async () =>
+    store.shell.openComposer({mention: await getProfileHandle()})
 
   if (isTablet) {
     return null

--- a/src/view/shell/desktop/LeftNav.tsx
+++ b/src/view/shell/desktop/LeftNav.tsx
@@ -191,7 +191,11 @@ function ComposeBtn() {
     if (currentRoute.name === 'Profile') {
       const {name: handle} =
         currentRoute.params as CommonNavigatorParams['Profile']
-      if (handle === store.me.handle) return undefined
+      // what if a user has a valid handle, but the URL uses the DID?
+      // the DID should not be used, but consider accessing the actual
+      // profile data instead of purely looking at the URL -sfn
+      if (handle === store.me.handle || handle.startsWith('did:'))
+        return undefined
       return handle
     }
     return undefined


### PR DESCRIPTION
@mozzius pointed out two issues with our auto-mentioning of users when creating a new post:
- from the mobile new post button, if the user's handle was invalid we'd end up using `@handle.invalid`
- from the desktop nav, we didn't have profile UI state to check, so we ended up using the user's did

~The first is a real bug, the second technically works, but isn't a great experience.~ Edit: ope, for some reason I thought we did support linking to dids 🤔 

I pushed a commit to resolve the profile data from the cache within the desktop nav. This is just a hit to `AsyncStorage` so should typically be fast enough that users won't notice the await.

Invalid handle test profile: http://localhost:19006/profile/did:plc:3nqrhu5mthmias3zc4a2ovzj
Profile with did in url (Paul): http://localhost:19006/profile/did:plc:ragtjsm2j2vknwkz3zp4oxrd