### PR TITLE
Handle long feed listings on the right nav with scrolling

### DIFF
--- a/src/view/shell/desktop/Feeds.tsx
+++ b/src/view/shell/desktop/Feeds.tsx
@@ -82,11 +82,12 @@ function FeedItem({
 
 const styles = StyleSheet.create({
   container: {
-    position: 'relative',
+    flex: 1,
+    overflowY: 'auto',
     width: 300,
     paddingHorizontal: 12,
+    paddingVertical: 18,
     borderTopWidth: 1,
     borderBottomWidth: 1,
-    paddingVertical: 18,
   },
 })

--- a/src/view/shell/desktop/RightNav.tsx
+++ b/src/view/shell/desktop/RightNav.tsx
@@ -125,6 +125,8 @@ const styles = StyleSheet.create({
     // @ts-ignore web only
     left: 'calc(50vw + 310px)',
     width: 304,
+    // @ts-ignore web only
+    maxHeight: '90vh',
   },
 
   message: {


### PR DESCRIPTION
Users with a lot of feeds were having their right nav overflow. This solves it by setting a max height and scrolling behavior

<img width="406" alt="CleanShot 2023-09-28 at 08 59 58@2x" src="https://github.com/bluesky-social/social-app/assets/1270099/6b620b41-50a5-4782-895d-0d0e6d2ecd79">
