### PR TITLE
Small sizing tweaks to the web modal

### DIFF
--- a/src/view/com/modals/EditProfile.tsx
+++ b/src/view/com/modals/EditProfile.tsx
@@ -266,7 +266,7 @@ const styles = StyleSheet.create({
     paddingHorizontal: 12,
     paddingTop: 10,
     fontSize: 16,
-    height: 100,
+    height: 120,
     textAlignVertical: 'top',
   },
   btn: {

--- a/src/view/com/modals/Modal.web.tsx
+++ b/src/view/com/modals/Modal.web.tsx
@@ -153,11 +153,11 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
   },
   container: {
-    width: 500,
+    width: 600,
     // @ts-ignore web only
     maxWidth: '100vw',
     // @ts-ignore web only
-    maxHeight: '100vh',
+    maxHeight: '90vh',
     paddingVertical: 20,
     paddingHorizontal: 24,
     borderRadius: 8,


### PR DESCRIPTION
Supersedes #1554 

- Stops the modal from going entirely to the top/bottom edges
- Widens to modal to match the width of the content area
- Gives a little more space in the profile editor description

![CleanShot 2023-09-28 at 12 17 32@2x](https://github.com/bluesky-social/social-app/assets/1270099/ab73d460-1e8a-40b5-995a-d1a34c5b5dc9)
