### PR TITLE
Fix alt text selectability in lightbox on web (close #1548)

### DIFF
--- a/src/view/com/lightbox/Lightbox.web.tsx
+++ b/src/view/com/lightbox/Lightbox.web.tsx
@@ -145,7 +145,6 @@ function LightboxInner({
       {imgs[index].alt ? (
         <View style={styles.footer}>
           <Pressable
-            accessibilityRole="button"
             accessibilityLabel="Expand alt text"
             accessibilityHint="If alt text is long, toggles alt text expanded state"
             onPress={() => {


### PR DESCRIPTION
A recent upgrade to react-native-web changed how `accessibilityRole` gets interpreted and turns it into a `<button>` when the value is `"button"` which then broke the selectability of the alt text in the lightbox. This fixes that.