### PR TITLE
Fix: Replace useWebMediaQueries().isDesktop with isWeb in DesktopWebTextLink component

### DIFF
--- a/src/view/com/util/Link.tsx
+++ b/src/view/com/util/Link.tsx
@@ -28,11 +28,10 @@ import {
   isExternalUrl,
   linkRequiresWarning,
 } from 'lib/strings/url-helpers'
-import {isAndroid} from 'platform/detection'
+import {isAndroid, isWeb} from 'platform/detection'
 import {sanitizeUrl} from '@braintree/sanitize-url'
 import {PressableWithHover} from './PressableWithHover'
 import FixedTouchableHighlight from '../pager/FixedTouchableHighlight'
-import {useWebMediaQueries} from 'lib/hooks/useWebMediaQueries'
 
 type Event =
   | React.MouseEvent<HTMLAnchorElement, MouseEvent>
@@ -246,9 +245,7 @@ export const DesktopWebTextLink = observer(function DesktopWebTextLink({
   lineHeight,
   ...props
 }: DesktopWebTextLinkProps) {
-  const {isDesktop} = useWebMediaQueries()
-
-  if (isDesktop) {
+  if (isWeb) {
     return (
       <TextLink
         testID={testID}


### PR DESCRIPTION
## Motivation

Fixes https://github.com/bluesky-social/social-app/issues/1268.

This PR addresses the issue reported in https://github.com/bluesky-social/social-app/issues/1268. The current implementation of `DesktopWebTextLink` uses `useWebMediaQueries` to achieve conditional rendering, which is influenced by media queries that can cause inconsistent behavior when the browser window's dimensions change.

## Changes 

The core change is replacing `useWebMediaQueries().isDesktop` with `isWeb` within the `DesktopWebTextLink` component. This ensures a stable judgment for link displays not affected by the media query's constant fluctuations. 

With the modifications, the `DesktopWebTextLink` component will display as a link across all web platforms, including mobile web. While it is consistent behavior, it represents a slight deviation from previous patterns.

I consider this as reasonable, given it provides more clarity in user interactions across varying web platforms.

However, this change might raise a question about the component's naming. Since `DesktopWebTextLink` would imply that this link is only for desktop web, it might now seem misleading. Therefore, it's worth discussing if we need to revise the component's name or if our requirement should be updated to mandate link behavior be exclusive to the desktop web and pure text for mobile web. Feedback and suggestions are highly appreciated. 


