### PR TITLE
Fix: to post positioning after thread load

### DIFF
--- a/src/state/models/content/post-thread.ts
+++ b/src/state/models/content/post-thread.ts
@@ -2,6 +2,7 @@ import {makeAutoObservable, runInAction} from 'mobx'
 import {
   AppBskyFeedGetPostThread as GetPostThread,
   AppBskyFeedDefs,
+  AppBskyFeedPost,
   PostModeration,
 } from '@atproto/api'
 import {AtUri} from '@atproto/api'
@@ -74,6 +75,13 @@ export class PostThreadModel {
 
   get isThreadMuted() {
     return this.rootStore.mutedThreads.uris.has(this.rootUri)
+  }
+
+  get isCachedPostAReply() {
+    if (AppBskyFeedPost.isRecord(this.thread?.post.record)) {
+      return !!this.thread?.post.record.reply
+    }
+    return false
   }
 
   // public api

--- a/src/view/com/post-thread/PostThread.tsx
+++ b/src/view/com/post-thread/PostThread.tsx
@@ -367,7 +367,7 @@ export const PostThread = observer(function PostThread({
       data={posts}
       initialNumToRender={posts.length}
       maintainVisibleContentPosition={
-        isNative && view.isFromCache
+        isNative && view.isFromCache && view.isCachedPostAReply
           ? MAINTAIN_VISIBLE_CONTENT_POSITION
           : undefined
       }


### PR DESCRIPTION
I was noticing some cases where quote posts would position incorrectly after tapping them and loading their thread screen. I believe this is because the index passed to `maintainVisibleContentPosition` is correct when rendering replies but not when rendering toplevel posts (you have to do some annoying component counting to establish the index).

When viewing a toplevel post you don't need to do any scroll repositioning, so this PR checks that and disables it for non-replies.