### PR TITLE
Fix a reference error in bottombarweb

### DIFF
--- a/src/view/shell/bottom-bar/BottomBarWeb.tsx
+++ b/src/view/shell/bottom-bar/BottomBarWeb.tsx
@@ -109,7 +109,12 @@ const NavItem: React.FC<{
   href: string
   routeName: string
 }> = ({children, href, routeName}) => {
-  const currentRoute = useNavigationState(getCurrentRoute)
+  const currentRoute = useNavigationState(state => {
+    if (!state) {
+      return {name: 'Home'}
+    }
+    return getCurrentRoute(state)
+  })
   const store = useStores()
   const isActive =
     currentRoute.name === 'Profile'


### PR DESCRIPTION
React navigation's `useNavigationState()` doesn't adhere to its type signature. It will in some cases provide `undefined` to the closure it's given. Most of our code is written to defend against that -- except for the change in this PR.

Sentry REACT-NATIVE-9D reported that `getCurrentRoute` is being given an undefined. The stack isn't definitive given our usage but matches with this, the one place we're not defending against the undefined value.