### PR TITLE
Slightly smaller highlighted post text

### DIFF
--- a/src/lib/themes.ts
+++ b/src/lib/themes.ts
@@ -264,8 +264,8 @@ export const defaultTheme: Theme = {
       fontWeight: '400',
     },
     'post-text-lg': {
-      fontSize: 22,
-      letterSpacing: 0.4,
+      fontSize: 20,
+      letterSpacing: 0.2,
       fontWeight: '400',
     },
     'button-lg': {


### PR DESCRIPTION
Closes #1590

Shrinks the font a bit on highlighted posts. This is a design decision, so we gotta just look at the before/after and decide if we want to make this move.

## Before (larger text)

https://github.com/bluesky-social/social-app/assets/1270099/1525b7a4-7102-4aeb-85d3-58072f083cbe

## After (smaller text)

https://github.com/bluesky-social/social-app/assets/1270099/e3cd131c-4477-4b9d-aa58-bdca106f2754

