### PR TITLE
Fix animations and gestures getting reset on state updates in the lightbox

### DIFF
--- a/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.android.tsx
+++ b/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.android.tsx
@@ -22,7 +22,7 @@ import {Image} from 'expo-image'
 import useImageDimensions from '../../hooks/useImageDimensions'
 import usePanResponder from '../../hooks/usePanResponder'
 
-import {getImageStyles, getImageTransform} from '../../utils'
+import {getImageTransform} from '../../utils'
 import {ImageSource} from '../../@types'
 import {ImageLoading} from './ImageLoading'
 
@@ -132,5 +132,28 @@ const styles = StyleSheet.create({
     height: SCREEN_HEIGHT * 2,
   },
 })
+
+const getImageStyles = (
+  image: {width: number; height: number} | null,
+  translate: Animated.ValueXY,
+  scale?: Animated.Value,
+) => {
+  if (!image?.width || !image?.height) {
+    return {width: 0, height: 0}
+  }
+
+  const transform = translate.getTranslateTransform()
+
+  if (scale) {
+    // @ts-ignore TODO - is scale incorrect? might need to remove -prf
+    transform.push({scale}, {perspective: new Animated.Value(1000)})
+  }
+
+  return {
+    width: image.width,
+    height: image.height,
+    transform,
+  }
+}
 
 export default React.memo(ImageItem)

--- a/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.ios.tsx
+++ b/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.ios.tsx
@@ -52,23 +52,14 @@ const ImageItem = ({imageSrc, onZoom, onRequestClose}: Props) => {
   const [scaled, setScaled] = useState(false)
   const imageDimensions = useImageDimensions(imageSrc)
   const [translate, scale] = getImageTransform(imageDimensions, SCREEN)
-
-  // TODO: It's not valid to reinitialize Animated values during render.
-  // This is a bug.
-  const scrollValueY = new Animated.Value(0)
-  const scaleValue = new Animated.Value(scale || 1)
-  const translateValue = new Animated.ValueXY(translate)
+  const [scrollValueY] = useState(() => new Animated.Value(0))
   const maxScrollViewZoom = MAX_SCALE / (scale || 1)
 
   const imageOpacity = scrollValueY.interpolate({
     inputRange: [-SWIPE_CLOSE_OFFSET, 0, SWIPE_CLOSE_OFFSET],
     outputRange: [0.5, 1, 0.5],
   })
-  const imagesStyles = getImageStyles(
-    imageDimensions,
-    translateValue,
-    scaleValue,
-  )
+  const imagesStyles = getImageStyles(imageDimensions, translate, scale || 1)
   const imageStylesWithOpacity = {...imagesStyles, opacity: imageOpacity}
 
   const onScrollEndDrag = useCallback(
@@ -262,20 +253,21 @@ const getZoomRectAfterDoubleTap = (
 
 const getImageStyles = (
   image: {width: number; height: number} | null,
-  translate: Animated.ValueXY,
-  scale?: Animated.Value,
+  translate: {readonly x: number; readonly y: number} | undefined,
+  scale?: number,
 ) => {
   if (!image?.width || !image?.height) {
     return {width: 0, height: 0}
   }
-
-  const transform = translate.getTranslateTransform()
-
+  const transform = []
+  if (translate) {
+    transform.push({translateX: translate.x})
+    transform.push({translateY: translate.y})
+  }
   if (scale) {
     // @ts-ignore TODO - is scale incorrect? might need to remove -prf
     transform.push({scale}, {perspective: new Animated.Value(1000)})
   }
-
   return {
     width: image.width,
     height: image.height,

--- a/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.ios.tsx
+++ b/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.ios.tsx
@@ -23,7 +23,7 @@ import {Image} from 'expo-image'
 
 import useImageDimensions from '../../hooks/useImageDimensions'
 
-import {getImageStyles, getImageTransform} from '../../utils'
+import {getImageTransform} from '../../utils'
 import {ImageSource} from '../../@types'
 import {ImageLoading} from './ImageLoading'
 
@@ -257,6 +257,29 @@ const getZoomRectAfterDoubleTap = (
     y: rectY,
     height: rectHeight,
     width: rectWidth,
+  }
+}
+
+const getImageStyles = (
+  image: {width: number; height: number} | null,
+  translate: Animated.ValueXY,
+  scale?: Animated.Value,
+) => {
+  if (!image?.width || !image?.height) {
+    return {width: 0, height: 0}
+  }
+
+  const transform = translate.getTranslateTransform()
+
+  if (scale) {
+    // @ts-ignore TODO - is scale incorrect? might need to remove -prf
+    transform.push({scale}, {perspective: new Animated.Value(1000)})
+  }
+
+  return {
+    width: image.width,
+    height: image.height,
+    transform,
   }
 }
 

--- a/src/view/com/lightbox/ImageViewing/index.tsx
+++ b/src/view/com/lightbox/ImageViewing/index.tsx
@@ -69,11 +69,12 @@ function ImageViewing({
   const imageList = useRef<VirtualizedList<ImageSource>>(null)
   const [opacity, setOpacity] = useState(1)
   const [currentImageIndex, setImageIndex] = useState(imageIndex)
-
-  // TODO: It's not valid to reinitialize Animated values during render.
-  // This is a bug.
-  const headerTranslate = new Animated.ValueXY(INITIAL_POSITION)
-  const footerTranslate = new Animated.ValueXY(INITIAL_POSITION)
+  const [headerTranslate] = useState(
+    () => new Animated.ValueXY(INITIAL_POSITION),
+  )
+  const [footerTranslate] = useState(
+    () => new Animated.ValueXY(INITIAL_POSITION),
+  )
 
   const toggleBarsVisible = (isVisible: boolean) => {
     if (isVisible) {

--- a/src/view/com/lightbox/ImageViewing/utils.ts
+++ b/src/view/com/lightbox/ImageViewing/utils.ts
@@ -6,7 +6,6 @@
  *
  */
 
-import {Animated} from 'react-native'
 import {Dimensions, Position} from './@types'
 
 export const getImageTransform = (
@@ -23,29 +22,6 @@ export const getImageTransform = (
   const {x, y} = getImageTranslate(image, screen)
 
   return [{x, y}, scale] as const
-}
-
-export const getImageStyles = (
-  image: Dimensions | null,
-  translate: Animated.ValueXY,
-  scale?: Animated.Value,
-) => {
-  if (!image?.width || !image?.height) {
-    return {width: 0, height: 0}
-  }
-
-  const transform = translate.getTranslateTransform()
-
-  if (scale) {
-    // @ts-ignore TODO - is scale incorrect? might need to remove -prf
-    transform.push({scale}, {perspective: new Animated.Value(1000)})
-  }
-
-  return {
-    width: image.width,
-    height: image.height,
-    transform,
-  }
 }
 
 export const getImageTranslate = (


### PR DESCRIPTION
## The Problem

The way we use `Animated.Value` in the lightbox is wrong. I don't know if we have any cases where it immediately manifests in bugs, however it's hard to add code to the lightbox without breaking it. Specifically, the issue is with code like this:

```js
function SomeComponent() {
  const value = new Animated.Value(0)
```

This is not correct because it will be recreated and destroyed on every render. So any state update within the same component will screw up the in-progress animation or gesture. One easy way to simulate it is to add code like this:

```js
  const [x, setX] = useState(0)
  useEffect(() => {
    const id = setInterval(() => setX(x => x + 1), 50)
    return () => clearInterval(id)
  }, [])
```

This would force the component to re-render every 50 milliseconds.

This breaks the zoom gesture — notice how the **controls reappear although they're supposed to hide:**

https://github.com/bluesky-social/social-app/assets/810438/91568aa9-f4fb-4824-b7c2-6a042666f7fa

This also breaks the swipe gesture — notice how **the opacity resets to `1` mid-gesture, causing flicker:**

https://github.com/bluesky-social/social-app/assets/810438/d856eeee-f5c7-43be-afc3-93d756aa76bb

## The Fix

Keep `Animated.Value` in state, for example:

```js
function SomeComponent() {
  const [value] = useState(() => new Animated.Value(0))
```

This ensures it doesn't get recreated. That's the fix I did for the "zoom" gesture.

For the "swipe" gesture, I did the same fix for the `scrollValueY` animated value. However, this wasn't the correct fix for `translateValue` and `scaleValue`. This is because those variables weren't being used as Animated values _at all_ — the code relied on them always being recreated. They only existed because the `getImageStyles()` utility already took an Animated value, and so the original author must have wanted to reuse it without actually relying on any animated behaviors. I've forked this helper into Android and iOS files, and removed the Animated usage where it was inappropriate.

There are more such bugs in the Android Pan recognizer. However, I have another PR rewriting that, so I won't fix them.

Zoom gesture after the fix is resistant to state update spam:


https://github.com/bluesky-social/social-app/assets/810438/eabd669a-218c-42d0-a1d3-a26b8c55faeb


Swipe gesture after the fix is resistant to state update spam:

https://github.com/bluesky-social/social-app/assets/810438/bd0f3f18-9b00-4eb7-b2b5-ef8e50f8cc5a

## Commits

Ignore commits form https://github.com/bluesky-social/social-app/pull/1616, which this is stacked upon.

New commits:

* https://github.com/bluesky-social/social-app/pull/1618/commits/2f2193f2de7c62a1e86a1ffc65d37d4b01b11fb9: Fixes the "zoom" gesture.
* https://github.com/bluesky-social/social-app/pull/1618/commits/f73195ab6df68f5ee5337832e65fed435d354ebd: We shouldn't be reusing this function because the implementation needs to fork.
* https://github.com/bluesky-social/social-app/pull/1618/commits/faf4893c6ce084bbb8ce0dac8031e98a52539cf5: Fix the "swipe" gesture.



