### PR TITLE
Dont trim before posting (close #1621)

### DIFF
--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -94,7 +94,7 @@ export async function post(store: RootStoreModel, opts: PostOpts) {
     | undefined
   let reply
   let rt = new RichText(
-    {text: opts.rawText},
+    {text: opts.rawText.trimEnd()},
     {
       cleanNewlines: true,
     },

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -94,7 +94,7 @@ export async function post(store: RootStoreModel, opts: PostOpts) {
     | undefined
   let reply
   let rt = new RichText(
-    {text: opts.rawText.trim()},
+    {text: opts.rawText},
     {
       cleanNewlines: true,
     },

--- a/src/view/com/composer/text-input/TextInput.web.tsx
+++ b/src/view/com/composer/text-input/TextInput.web.tsx
@@ -119,7 +119,7 @@ export const TextInput = React.forwardRef(function TextInputImpl(
       onUpdate({editor: editorProp}) {
         const json = editorProp.getJSON()
 
-        const newRt = new RichText({text: editorJsonToText(json)})
+        const newRt = new RichText({text: editorJsonToText(json).trimEnd()})
         newRt.detectFacetsWithoutResolution()
         setRichText(newRt)
 

--- a/src/view/com/composer/text-input/TextInput.web.tsx
+++ b/src/view/com/composer/text-input/TextInput.web.tsx
@@ -119,7 +119,7 @@ export const TextInput = React.forwardRef(function TextInputImpl(
       onUpdate({editor: editorProp}) {
         const json = editorProp.getJSON()
 
-        const newRt = new RichText({text: editorJsonToText(json).trim()})
+        const newRt = new RichText({text: editorJsonToText(json)})
         newRt.detectFacetsWithoutResolution()
         setRichText(newRt)
 


### PR DESCRIPTION
The richtext library runs a sanitization pass that reduces excess newlines. Trimming doesnt really add anything and sometimes breaks people's posts, so this PR stops doing that.

EDIT: tweaked to still trim end, the web composer sticks empty space on the end if we dont