### PR TITLE
Fix: add padding to the spinner bottom while loading threads

### DIFF
--- a/src/view/com/post-thread/PostThread.tsx
+++ b/src/view/com/post-thread/PostThread.tsx
@@ -439,5 +439,7 @@ const styles = StyleSheet.create({
   parentSpinner: {
     paddingVertical: 10,
   },
-  childSpinner: {},
+  childSpinner: {
+    paddingBottom: 200,
+  },
 })


### PR DESCRIPTION
Recent UI change lost the bottom spacing during the loading state, which causes the UI to get covered by the bottom bar. This fixes that.