### PR TITLE
fix accessibility in AutoSizedImage

### DIFF
--- a/src/view/com/util/images/AutoSizedImage.tsx
+++ b/src/view/com/util/images/AutoSizedImage.tsx
@@ -63,7 +63,7 @@ export function AutoSizedImage({
           accessible={true} // Must set for `accessibilityLabel` to work
           accessibilityIgnoresInvertColors
           accessibilityLabel={alt}
-          accessibilityHint=""
+          accessibilityHint="Tap to view fully"
         />
         {children}
       </Pressable>

--- a/src/view/com/util/images/AutoSizedImage.tsx
+++ b/src/view/com/util/images/AutoSizedImage.tsx
@@ -56,16 +56,14 @@ export function AutoSizedImage({
         onPress={onPress}
         onLongPress={onLongPress}
         onPressIn={onPressIn}
-        style={[styles.container, style]}
-        accessible={true}
-        accessibilityRole="button"
-        accessibilityLabel={alt || 'Image'}
-        accessibilityHint="Tap to view fully">
+        style={[styles.container, style]}>
         <Image
           style={[styles.image, {aspectRatio}]}
           source={uri}
-          accessible={false} // Must set for `accessibilityLabel` to work
+          accessible={true} // Must set for `accessibilityLabel` to work
           accessibilityIgnoresInvertColors
+          accessibilityLabel={alt}
+          accessibilityHint=""
         />
         {children}
       </Pressable>


### PR DESCRIPTION
setting the alt tag on the parent component (the `Pressable`) won't apply to divs on web. the image should receive the alt tag.

additionally, [VoiceOver Recognition](https://support.apple.com/en-us/HT211899) uses on-device machine learning to detect what an image is depicting, so it's probably not necessary to state that it's an image (which is what the purpose of the role is). I don't think TalkBack has this functionality but I might be wrong there.