### PR TITLE
fix: warn on unicode domain confusion

### DIFF
--- a/__tests__/lib/strings/url-helpers.test.ts
+++ b/__tests__/lib/strings/url-helpers.test.ts
@@ -29,6 +29,7 @@ describe('linkRequiresWarning', () => {
     ['http://site.pages', 'site.pages.dev', true],
     ['http://xn--pple-43d.com', '\u0430pple.com', true],
     ['http://subdomain.xn--pple-43d.com', 'subdomain.\u0430pple.com', true],
+    ['http://notphishing.foo-xn--pple.com', 'notphishing.foo-xn--pple.com', false],
     ['http://xn--s7y.co', '短.co', true],
 
     // bad uri inputs, default to true

--- a/__tests__/lib/strings/url-helpers.test.ts
+++ b/__tests__/lib/strings/url-helpers.test.ts
@@ -28,6 +28,7 @@ describe('linkRequiresWarning', () => {
     ['http://site.pages.dev', 'site.pages', true],
     ['http://site.pages', 'site.pages.dev', true],
     ['http://xn--pple-43d.com', '\u0430pple.com', true],
+    ['http://subdomain.xn--pple-43d.com', 'subdomain.\u0430pple.com', true],
     ['http://xn--s7y.co', '短.co', true],
 
     // bad uri inputs, default to true

--- a/__tests__/lib/strings/url-helpers.test.ts
+++ b/__tests__/lib/strings/url-helpers.test.ts
@@ -27,6 +27,8 @@ describe('linkRequiresWarning', () => {
     ['http://site.pages', 'http://site.pages.dev', true],
     ['http://site.pages.dev', 'site.pages', true],
     ['http://site.pages', 'site.pages.dev', true],
+    ['http://xn--pple-43d.com', '\u0430pple.com', true],
+    ['http://xn--s7y.co', '短.co', true],
 
     // bad uri inputs, default to true
     ['', '', true],

--- a/src/lib/strings/url-helpers.ts
+++ b/src/lib/strings/url-helpers.ts
@@ -170,7 +170,7 @@ export function getYoutubeVideoId(link: string): string | undefined {
 
 export function linkRequiresWarning(uri: string, label: string) {
   const labelDomain = labelToDomain(label)
-  if (!labelDomain || /\bxn--/i.test(labelDomain)) {
+  if (!labelDomain || /(^|\.)xn--/i.test(labelDomain)) {
     return true
   }
   try {

--- a/src/lib/strings/url-helpers.ts
+++ b/src/lib/strings/url-helpers.ts
@@ -170,7 +170,7 @@ export function getYoutubeVideoId(link: string): string | undefined {
 
 export function linkRequiresWarning(uri: string, label: string) {
   const labelDomain = labelToDomain(label)
-  if (!labelDomain) {
+  if (!labelDomain || labelDomain.startsWith('xn--')) {
     return true
   }
   try {

--- a/src/lib/strings/url-helpers.ts
+++ b/src/lib/strings/url-helpers.ts
@@ -170,7 +170,7 @@ export function getYoutubeVideoId(link: string): string | undefined {
 
 export function linkRequiresWarning(uri: string, label: string) {
   const labelDomain = labelToDomain(label)
-  if (!labelDomain || labelDomain.startsWith('xn--')) {
+  if (!labelDomain || /\bxn--/i.test(labelDomain)) {
     return true
   }
   try {


### PR DESCRIPTION
Remembered about Unicode domains, and realized that JS' URL API will always normalize them to punycode form, which means that it's currently possible to do some [Unicode domain trickery](https://www.xudongz.com/blog/2017/idn-phishing/) and have it pass through the code that checks if a link is suspicious

![image](https://github.com/bluesky-social/social-app/assets/20620901/5b24c6e3-85a8-4f63-bdf3-169ed24c7252)

This pull request makes it warn on *all* Unicode domains, and adds the relevant tests for it.

This *does* mean that it would catch Japanese sites using [`.みんな` TLD](https://www.registry.google/tlds/minna/) as an example, where I'd assume that TLD would encourage having your domains be entirely in Unicode, but at the same time, the Unicode usage is concerning, perhaps we could limit the scope down to only Greek/Cyrillic letters where it's known to be actually problematic? Let me know what y'all think.