### PR TITLE
Remove unnecessary opacity logic

### DIFF
--- a/src/view/com/lightbox/ImageViewing/index.tsx
+++ b/src/view/com/lightbox/ImageViewing/index.tsx
@@ -71,7 +71,6 @@ function ImageViewing({
   const imageList = useRef<VirtualizedList<ImageSource>>(null)
   const [isScaled, setIsScaled] = useState(false)
   const [isDragging, setIsDragging] = useState(false)
-  const [opacity, setOpacity] = useState(1)
   const [currentImageIndex, setImageIndex] = useState(imageIndex)
   const [headerTranslate] = useState(
     () => new Animated.ValueXY(INITIAL_POSITION),
@@ -98,12 +97,6 @@ function ImageViewing({
         }),
       ]).start()
     }
-  }
-
-  const onRequestCloseEnhanced = () => {
-    setOpacity(0)
-    onRequestClose()
-    setTimeout(() => setOpacity(1), 0)
   }
 
   const onScroll = (event: NativeSyntheticEvent<NativeScrollEvent>) => {
@@ -162,14 +155,14 @@ function ImageViewing({
       aria-modal
       accessibilityViewIsModal>
       <ModalsContainer />
-      <View style={[styles.container, {opacity, backgroundColor}]}>
+      <View style={[styles.container, {backgroundColor}]}>
         <Animated.View style={[styles.header, {transform: headerTransform}]}>
           {typeof HeaderComponent !== 'undefined' ? (
             React.createElement(HeaderComponent, {
               imageIndex: currentImageIndex,
             })
           ) : (
-            <ImageDefaultHeader onRequestClose={onRequestCloseEnhanced} />
+            <ImageDefaultHeader onRequestClose={onRequestClose} />
           )}
         </Animated.View>
         <VirtualizedList
@@ -191,7 +184,7 @@ function ImageViewing({
             <ImageItem
               onZoom={onZoom}
               imageSrc={imageSrc}
-              onRequestClose={onRequestCloseEnhanced}
+              onRequestClose={onRequestClose}
               pinchGestureRef={pinchGestureRefs.get(imageSrc)}
               isScrollViewBeingDragged={isDragging}
             />


### PR DESCRIPTION
This logic is inherited from https://github.com/jobtoday/react-native-image-viewing/blob/master/src/hooks/useRequestClose.ts.

I can't tell what this logic is for. I think it's not necessary so I'd like to delete it. If it turns out necessary, we'll learn something interesting (and then add it back).

Concretely, we were _first_ setting opacity to 0, then updating the state to hide the modal, then immediately setting opacity back to 1. This feels like the kind of code that would be there to trigger some kind of an animation — but we currently have none, and also setting opacity going "from 0 to 1" doesn't make sense on closing the lightbox. Another guess is maybe the author was hoping to flush the opacity change first (to quickly hide the modal) and then do potentially more expensive state update later. However, I don't think this would do anything — they get batched in React.

Let's remove it and see if anything breaks.

## Test Plan

Verified closing the lightbox either via the gesture or via the button still works on iOS and Android.