### PR TITLE
Drive-by lightbox refactors

### DIFF
--- a/src/view/com/lightbox/ImageViewing/hooks/useImageDimensions.ts
+++ b/src/view/com/lightbox/ImageViewing/hooks/useImageDimensions.ts
@@ -39,29 +39,10 @@ const useImageDimensions = (image: ImageSource): Dimensions | null => {
   // eslint-disable-next-line @typescript-eslint/no-shadow
   const getImageDimensions = (image: ImageSource): Promise<Dimensions> => {
     return new Promise(resolve => {
-      if (typeof image === 'number') {
-        const cacheKey = `${image}`
-        let imageDimensions = imageDimensionsCache.get(cacheKey)
-
-        if (!imageDimensions) {
-          const {width, height} = Image.resolveAssetSource(image)
-          imageDimensions = {width, height}
-          imageDimensionsCache.set(cacheKey, imageDimensions)
-        }
-
-        resolve(imageDimensions)
-
-        return
-      }
-
-      // @ts-ignore
       if (image.uri) {
         const source = image as ImageURISource
-
         const cacheKey = source.uri as string
-
         const imageDimensions = imageDimensionsCache.get(cacheKey)
-
         if (imageDimensions) {
           resolve(imageDimensions)
         } else {

--- a/src/view/com/lightbox/ImageViewing/index.tsx
+++ b/src/view/com/lightbox/ImageViewing/index.tsx
@@ -38,7 +38,6 @@ import {Edge, SafeAreaView} from 'react-native-safe-area-context'
 
 type Props = {
   images: ImageSource[]
-  keyExtractor?: (imageSrc: ImageSource, index: number) => string
   imageIndex: number
   visible: boolean
   onRequestClose: () => void
@@ -60,7 +59,6 @@ const ANIMATION_CONFIG = {
 
 function ImageViewing({
   images,
-  keyExtractor,
   imageIndex,
   visible,
   onRequestClose,
@@ -205,14 +203,7 @@ function ImageViewing({
             setIsScaled(false)
             onScroll(e)
           }}
-          //@ts-ignore
-          keyExtractor={(imageSrc, index) =>
-            keyExtractor
-              ? keyExtractor(imageSrc, index)
-              : typeof imageSrc === 'number'
-              ? `${imageSrc}`
-              : imageSrc.uri
-          }
+          keyExtractor={imageSrc => imageSrc.uri}
         />
         {typeof FooterComponent !== 'undefined' && (
           <Animated.View style={[styles.footer, {transform: footerTransform}]}>

--- a/src/view/com/lightbox/ImageViewing/index.tsx
+++ b/src/view/com/lightbox/ImageViewing/index.tsx
@@ -38,7 +38,7 @@ import {Edge, SafeAreaView} from 'react-native-safe-area-context'
 
 type Props = {
   images: ImageSource[]
-  imageIndex: number
+  initialImageIndex: number
   visible: boolean
   onRequestClose: () => void
   presentationStyle?: ModalProps['presentationStyle']
@@ -59,7 +59,7 @@ const ANIMATION_CONFIG = {
 
 function ImageViewing({
   images,
-  imageIndex,
+  initialImageIndex,
   visible,
   onRequestClose,
   backgroundColor = DEFAULT_BG_COLOR,
@@ -69,7 +69,7 @@ function ImageViewing({
   const imageList = useRef<VirtualizedList<ImageSource>>(null)
   const [isScaled, setIsScaled] = useState(false)
   const [isDragging, setIsDragging] = useState(false)
-  const [currentImageIndex, setImageIndex] = useState(imageIndex)
+  const [currentImageIndex, setImageIndex] = useState(initialImageIndex)
   const [headerTranslate] = useState(
     () => new Animated.ValueXY(INITIAL_POSITION),
   )
@@ -123,10 +123,13 @@ function ImageViewing({
   }, [])
 
   const onLayout = useCallback(() => {
-    if (imageIndex) {
-      imageList.current?.scrollToIndex({index: imageIndex, animated: false})
+    if (initialImageIndex) {
+      imageList.current?.scrollToIndex({
+        index: initialImageIndex,
+        animated: false,
+      })
     }
-  }, [imageList, imageIndex])
+  }, [imageList, initialImageIndex])
 
   // This is a hack.
   // RNGH doesn't have an easy way to express that pinch of individual items
@@ -241,7 +244,7 @@ const styles = StyleSheet.create({
 })
 
 const EnhancedImageViewing = (props: Props) => (
-  <ImageViewing key={props.imageIndex} {...props} />
+  <ImageViewing key={props.initialImageIndex} {...props} />
 )
 
 export default EnhancedImageViewing

--- a/src/view/com/lightbox/ImageViewing/index.tsx
+++ b/src/view/com/lightbox/ImageViewing/index.tsx
@@ -69,7 +69,7 @@ function ImageViewing({
   const imageList = useRef<VirtualizedList<ImageSource>>(null)
   const [isScaled, setIsScaled] = useState(false)
   const [isDragging, setIsDragging] = useState(false)
-  const [currentImageIndex, setImageIndex] = useState(initialImageIndex)
+  const [imageIndex, setImageIndex] = useState(initialImageIndex)
   const [headerTranslate] = useState(
     () => new Animated.ValueXY(INITIAL_POSITION),
   )
@@ -160,7 +160,7 @@ function ImageViewing({
         <Animated.View style={[styles.header, {transform: headerTransform}]}>
           {typeof HeaderComponent !== 'undefined' ? (
             React.createElement(HeaderComponent, {
-              imageIndex: currentImageIndex,
+              imageIndex,
             })
           ) : (
             <ImageDefaultHeader onRequestClose={onRequestClose} />
@@ -211,7 +211,7 @@ function ImageViewing({
         {typeof FooterComponent !== 'undefined' && (
           <Animated.View style={[styles.footer, {transform: footerTransform}]}>
             {React.createElement(FooterComponent, {
-              imageIndex: currentImageIndex,
+              imageIndex,
             })}
           </Animated.View>
         )}

--- a/src/view/com/lightbox/Lightbox.tsx
+++ b/src/view/com/lightbox/Lightbox.tsx
@@ -26,7 +26,7 @@ export const Lightbox = observer(function Lightbox() {
     return (
       <ImageView
         images={[{uri: opts.profileView.avatar || ''}]}
-        imageIndex={0}
+        initialImageIndex={0}
         visible
         onRequestClose={onClose}
         FooterComponent={LightboxFooter}
@@ -37,7 +37,7 @@ export const Lightbox = observer(function Lightbox() {
     return (
       <ImageView
         images={opts.images.map(img => ({...img}))}
-        imageIndex={opts.index}
+        initialImageIndex={opts.index}
         visible
         onRequestClose={onClose}
         FooterComponent={LightboxFooter}


### PR DESCRIPTION
No behavior change, just cleaning up before more significant changes.

- https://github.com/bluesky-social/social-app/commit/b274de6757aa86ed4e4102371c45b589fc6a6af1: Removes support for passing a number as image source. This used to be a lie in the types, and we don't use this feature anyway. (In the original library, this was used to support showing local images from disk.) Also removes the `keyExtractor` prop which we're not using anywhere.
- https://github.com/bluesky-social/social-app/commit/2464c8fca8ed84afd820913c82da0b69a30aa56a: Renames the prop to clarify it's only used to seed the initial state.
- https://github.com/bluesky-social/social-app/commit/bd7ef0cec5ed9c0c5b6be8ff69a9aa2ac0b5a513: Renames the state variable.