### PR TITLE
Fix: fetch follows on desktop search for typeahead

### DIFF
--- a/src/state/models/cache/my-follows.ts
+++ b/src/state/models/cache/my-follows.ts
@@ -5,6 +5,7 @@ import {
   moderateProfile,
 } from '@atproto/api'
 import {RootStoreModel} from '../root-store'
+import {bundleAsync} from 'lib/async/bundle'
 
 const MAX_SYNC_PAGES = 10
 const SYNC_TTL = 60e3 * 10 // 10 minutes
@@ -56,7 +57,7 @@ export class MyFollowsCache {
    * Syncs a subset of the user's follows
    * for performance reasons, caps out at 1000 follows
    */
-  async syncIfNeeded() {
+  syncIfNeeded = bundleAsync(async () => {
     if (this.lastSync > Date.now() - SYNC_TTL) {
       return
     }
@@ -81,7 +82,7 @@ export class MyFollowsCache {
     }
 
     this.lastSync = Date.now()
-  }
+  })
 
   getFollowState(did: string): FollowState {
     if (typeof this.byDid[did] === 'undefined') {

--- a/src/view/shell/desktop/Search.tsx
+++ b/src/view/shell/desktop/Search.tsx
@@ -22,6 +22,13 @@ export const DesktopSearch = observer(function DesktopSearch() {
   )
   const navigation = useNavigation<NavigationProp>()
 
+  // initial setup
+  React.useEffect(() => {
+    if (store.me.did) {
+      autocompleteView.setup()
+    }
+  }, [autocompleteView, store.me.did])
+
   const onChangeQuery = React.useCallback(
     (text: string) => {
       setQuery(text)


### PR DESCRIPTION
Noticed that the typeahead search improvements weren't working consistently on desktop's search. Turns out it's because the autocomplete setup call wasn't getting hit, meaning the fetch wasn't occurring in all cases.