### PR TITLE
Remove duplicate modal container

### DIFF
--- a/src/view/com/lightbox/ImageViewing/index.tsx
+++ b/src/view/com/lightbox/ImageViewing/index.tsx
@@ -27,7 +27,6 @@ import {
   ModalProps,
   Platform,
 } from 'react-native'
-import {ModalsContainer} from '../../modals/Modal'
 
 import ImageItem from './components/ImageItem/ImageItem'
 import ImageDefaultHeader from './components/ImageDefaultHeader'
@@ -155,7 +154,6 @@ function ImageViewing({
       edges={edges}
       aria-modal
       accessibilityViewIsModal>
-      <ModalsContainer />
       <View style={[styles.container, {backgroundColor}]}>
         <Animated.View style={[styles.header, {transform: headerTransform}]}>
           {typeof HeaderComponent !== 'undefined' ? (


### PR DESCRIPTION
We got one here already:

https://github.com/bluesky-social/social-app/blob/d47ff542dafdb691fd492845db956dd629122a9b/src/view/shell/index.tsx#L80

The layering there is correct because we need the lightbox to appear on top of modals. E.g. if you "preview" a profile by clicking on it in feed, and then you click on the avatar, the lightbox should appear on top of the profile preview sheet.

It's unclear what the duplicate modal container _inside_ the lightbox is for. Maybe it's in case we trigger a modal inside a lightbox. However, we don't seem to have any cases like this now. And it seems confusing to have two of the same modal open regardless — if we wanted to support that, we should do this with some stateful layering in the top shell instead.

For now let's remove this.