### PR TITLE
Only warn on links to bsky.app if it represents itself as another url

### DIFF
--- a/__tests__/lib/strings/url-helpers.test.ts
+++ b/__tests__/lib/strings/url-helpers.test.ts
@@ -27,6 +27,42 @@ describe('linkRequiresWarning', () => {
     ['http://site.pages', 'http://site.pages.dev', true],
     ['http://site.pages.dev', 'site.pages', true],
     ['http://site.pages', 'site.pages.dev', true],
+    ['http://bsky.app/profile/bob.test/post/3kbeuduu7m22v', 'my post', false],
+    ['https://bsky.app/profile/bob.test/post/3kbeuduu7m22v', 'my post', false],
+    ['http://bsky.app/', 'bluesky', false],
+    ['https://bsky.app/', 'bluesky', false],
+    [
+      'http://bsky.app/profile/bob.test/post/3kbeuduu7m22v',
+      'http://bsky.app/profile/bob.test/post/3kbeuduu7m22v',
+      false,
+    ],
+    [
+      'https://bsky.app/profile/bob.test/post/3kbeuduu7m22v',
+      'http://bsky.app/profile/bob.test/post/3kbeuduu7m22v',
+      false,
+    ],
+    [
+      'http://bsky.app/',
+      'http://bsky.app/profile/bob.test/post/3kbeuduu7m22v',
+      false,
+    ],
+    [
+      'https://bsky.app/',
+      'http://bsky.app/profile/bob.test/post/3kbeuduu7m22v',
+      false,
+    ],
+    [
+      'http://bsky.app/profile/bob.test/post/3kbeuduu7m22v',
+      'https://google.com',
+      true,
+    ],
+    [
+      'https://bsky.app/profile/bob.test/post/3kbeuduu7m22v',
+      'https://google.com',
+      true,
+    ],
+    ['http://bsky.app/', 'https://google.com', true],
+    ['https://bsky.app/', 'https://google.com', true],
 
     // bad uri inputs, default to true
     ['', '', true],

--- a/src/lib/strings/url-helpers.ts
+++ b/src/lib/strings/url-helpers.ts
@@ -194,11 +194,7 @@ export function linkRequiresWarning(uri: string, label: string) {
     if (!labelDomain) {
       return true
     }
-    try {
-      return labelDomain !== urip.hostname
-    } catch {
-      return true
-    }
+    return labelDomain !== urip.hostname
   }
 }
 

--- a/src/lib/strings/url-helpers.ts
+++ b/src/lib/strings/url-helpers.ts
@@ -170,14 +170,35 @@ export function getYoutubeVideoId(link: string): string | undefined {
 
 export function linkRequiresWarning(uri: string, label: string) {
   const labelDomain = labelToDomain(label)
-  if (!labelDomain) {
-    return true
-  }
+  let urip
   try {
-    const urip = new URL(uri)
-    return labelDomain !== urip.hostname
+    urip = new URL(uri)
   } catch {
     return true
+  }
+
+  if (urip.hostname === 'bsky.app') {
+    // if this is a link to internal content,
+    // warn if it represents itself as a URL to another app
+    if (
+      labelDomain &&
+      labelDomain !== 'bsky.app' &&
+      isPossiblyAUrl(labelDomain)
+    ) {
+      return true
+    }
+    return false
+  } else {
+    // if this is a link to external content,
+    // warn if the label doesnt match the target
+    if (!labelDomain) {
+      return true
+    }
+    try {
+      return labelDomain !== urip.hostname
+    } catch {
+      return true
+    }
   }
 }
 

--- a/src/state/models/root-store.ts
+++ b/src/state/models/root-store.ts
@@ -223,6 +223,7 @@ export class RootStoreModel {
   }
   emitSessionReady() {
     DeviceEventEmitter.emit('session-ready')
+    window.agent = this.agent
   }
 
   // the session was dropped due to bad/expired refresh tokens

--- a/src/state/models/root-store.ts
+++ b/src/state/models/root-store.ts
@@ -223,7 +223,6 @@ export class RootStoreModel {
   }
   emitSessionReady() {
     DeviceEventEmitter.emit('session-ready')
-    window.agent = this.agent
   }
 
   // the session was dropped due to bad/expired refresh tokens


### PR DESCRIPTION
Closes #1652

Updates the link-warning interstitial to only trigger for `bsky.app` links if the richtext represents itself as another URL. 

![CleanShot 2023-10-10 at 12 26 10@2x](https://github.com/bluesky-social/social-app/assets/1270099/218f5478-8e67-4edb-88fd-aa3186aacebf)
![CleanShot 2023-10-10 at 12 26 18@2x](https://github.com/bluesky-social/social-app/assets/1270099/bd62eba4-c450-460c-8a49-fbbe2d6a723b)
