### PR TITLE
Fix layout shift for multi-image posts

### DIFF
--- a/src/view/com/util/images/Gallery.tsx
+++ b/src/view/com/util/images/Gallery.tsx
@@ -1,5 +1,5 @@
 import {AppBskyEmbedImages} from '@atproto/api'
-import React, {FC} from 'react'
+import React, {ComponentProps, FC} from 'react'
 import {StyleSheet, Text, Pressable, View} from 'react-native'
 import {Image} from 'expo-image'
 
@@ -11,11 +11,13 @@ interface GalleryItemProps {
   onPress?: EventFunction
   onLongPress?: EventFunction
   onPressIn?: EventFunction
+  imageStyle: ComponentProps<typeof Image>['style']
 }
 
 export const GalleryItem: FC<GalleryItemProps> = ({
   images,
   index,
+  imageStyle,
   onPress,
   onPressIn,
   onLongPress,
@@ -33,7 +35,7 @@ export const GalleryItem: FC<GalleryItemProps> = ({
         accessibilityHint="">
         <Image
           source={{uri: image.thumb}}
-          style={styles.image}
+          style={[styles.image, imageStyle]}
           accessible={true}
           accessibilityLabel={image.alt}
           accessibilityHint=""

--- a/src/view/com/util/images/Gallery.tsx
+++ b/src/view/com/util/images/Gallery.tsx
@@ -67,8 +67,8 @@ const styles = StyleSheet.create({
     paddingHorizontal: 6,
     paddingVertical: 3,
     position: 'absolute',
-    left: 6,
-    bottom: 6,
+    left: 8,
+    bottom: 8,
   },
   alt: {
     color: 'white',

--- a/src/view/com/util/images/Gallery.tsx
+++ b/src/view/com/util/images/Gallery.tsx
@@ -1,5 +1,5 @@
 import {AppBskyEmbedImages} from '@atproto/api'
-import React, {ComponentProps, FC} from 'react'
+import React, {FC} from 'react'
 import {StyleSheet, Text, Pressable, View} from 'react-native'
 import {Image} from 'expo-image'
 
@@ -11,31 +11,29 @@ interface GalleryItemProps {
   onPress?: EventFunction
   onLongPress?: EventFunction
   onPressIn?: EventFunction
-  imageStyle: ComponentProps<typeof Image>['style']
 }
 
 export const GalleryItem: FC<GalleryItemProps> = ({
   images,
   index,
-  imageStyle,
   onPress,
   onPressIn,
   onLongPress,
 }) => {
   const image = images[index]
-
   return (
-    <View>
+    <View style={styles.fullWidth}>
       <Pressable
         onPress={onPress ? () => onPress(index) : undefined}
         onPressIn={onPressIn ? () => onPressIn(index) : undefined}
         onLongPress={onLongPress ? () => onLongPress(index) : undefined}
+        style={styles.fullWidth}
         accessibilityRole="button"
         accessibilityLabel={image.alt || 'Image'}
         accessibilityHint="">
         <Image
           source={{uri: image.thumb}}
-          style={imageStyle}
+          style={styles.image}
           accessible={true}
           accessibilityLabel={image.alt}
           accessibilityHint=""
@@ -54,6 +52,13 @@ export const GalleryItem: FC<GalleryItemProps> = ({
 }
 
 const styles = StyleSheet.create({
+  fullWidth: {
+    flex: 1,
+  },
+  image: {
+    flex: 1,
+    borderRadius: 4,
+  },
   altContainer: {
     backgroundColor: 'rgba(0, 0, 0, 0.75)',
     borderRadius: 6,

--- a/src/view/com/util/images/ImageLayoutGrid.tsx
+++ b/src/view/com/util/images/ImageLayoutGrid.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import {Platform, StyleProp, StyleSheet, View, ViewStyle} from 'react-native'
+import {StyleProp, StyleSheet, View, ViewStyle} from 'react-native'
 import {AppBskyEmbedImages} from '@atproto/api'
 import {GalleryItem} from './Gallery'
 
@@ -14,7 +14,9 @@ interface ImageLayoutGridProps {
 export function ImageLayoutGrid({style, ...props}: ImageLayoutGridProps) {
   return (
     <View style={style}>
-      <ImageLayoutGridInner {...props} />
+      <View style={styles.container}>
+        <ImageLayoutGridInner {...props} />
+      </View>
     </View>
   )
 }
@@ -34,28 +36,26 @@ function ImageLayoutGridInner(props: ImageLayoutGridInnerProps) {
       return (
         <View style={styles.flexRow}>
           <View style={styles.smallItem}>
-            <GalleryItem index={0} {...props} />
+            <GalleryItem {...props} index={0} imageStyle={styles.image} />
           </View>
           <View style={styles.smallItem}>
-            <GalleryItem index={1} {...props} />
+            <GalleryItem {...props} index={1} imageStyle={styles.image} />
           </View>
         </View>
       )
 
     case 3:
-      // Work around https://github.com/facebook/react-native/issues/40802
-      const flexProp = Platform.OS === 'web' ? 'flex' : 'flexGrow'
       return (
         <View style={styles.flexRow}>
-          <View style={{[flexProp]: 2, aspectRatio: 1}}>
-            <GalleryItem index={0} {...props} />
+          <View style={{flex: 2, aspectRatio: 1}}>
+            <GalleryItem {...props} index={0} imageStyle={styles.image} />
           </View>
-          <View style={{[flexProp]: 1, gap: 5}}>
+          <View style={{flex: 1}}>
             <View style={styles.smallItem}>
-              <GalleryItem index={1} {...props} />
+              <GalleryItem {...props} index={1} imageStyle={styles.image} />
             </View>
             <View style={styles.smallItem}>
-              <GalleryItem index={2} {...props} />
+              <GalleryItem {...props} index={2} imageStyle={styles.image} />
             </View>
           </View>
         </View>
@@ -64,20 +64,20 @@ function ImageLayoutGridInner(props: ImageLayoutGridInnerProps) {
     case 4:
       return (
         <View style={styles.flexRow}>
-          <View style={{flex: 1, gap: 5}}>
+          <View style={{flex: 1}}>
             <View style={styles.smallItem}>
-              <GalleryItem index={0} {...props} />
+              <GalleryItem {...props} index={0} imageStyle={styles.image} />
             </View>
             <View style={styles.smallItem}>
-              <GalleryItem index={2} {...props} />
+              <GalleryItem {...props} index={2} imageStyle={styles.image} />
             </View>
           </View>
-          <View style={{flex: 1, gap: 5}}>
+          <View style={{flex: 1}}>
             <View style={styles.smallItem}>
-              <GalleryItem index={1} {...props} />
+              <GalleryItem {...props} index={1} imageStyle={styles.image} />
             </View>
             <View style={styles.smallItem}>
-              <GalleryItem index={3} {...props} />
+              <GalleryItem {...props} index={3} imageStyle={styles.image} />
             </View>
           </View>
         </View>
@@ -88,7 +88,18 @@ function ImageLayoutGridInner(props: ImageLayoutGridInnerProps) {
   }
 }
 
+// This is used to compute margins (rather than flexbox gap) due to Yoga bugs:
+// https://github.com/facebook/yoga/issues/1418
+const IMAGE_GAP = 5
+
 const styles = StyleSheet.create({
-  flexRow: {flexDirection: 'row', gap: 5},
+  container: {
+    marginHorizontal: -IMAGE_GAP / 2,
+    marginVertical: -IMAGE_GAP / 2,
+  },
+  flexRow: {flexDirection: 'row'},
   smallItem: {flex: 1, aspectRatio: 1},
+  image: {
+    margin: IMAGE_GAP / 2,
+  },
 })

--- a/src/view/com/util/images/ImageLayoutGrid.tsx
+++ b/src/view/com/util/images/ImageLayoutGrid.tsx
@@ -1,13 +1,5 @@
-import React, {useMemo, useState} from 'react'
-import {
-  LayoutChangeEvent,
-  StyleProp,
-  StyleSheet,
-  View,
-  ViewStyle,
-} from 'react-native'
-import {ImageStyle} from 'expo-image'
-import {Dimensions} from 'lib/media/types'
+import React from 'react'
+import {Platform, StyleProp, StyleSheet, View, ViewStyle} from 'react-native'
 import {AppBskyEmbedImages} from '@atproto/api'
 import {GalleryItem} from './Gallery'
 
@@ -20,21 +12,9 @@ interface ImageLayoutGridProps {
 }
 
 export function ImageLayoutGrid({style, ...props}: ImageLayoutGridProps) {
-  const [containerInfo, setContainerInfo] = useState<Dimensions | undefined>()
-
-  const onLayout = (evt: LayoutChangeEvent) => {
-    const {width, height} = evt.nativeEvent.layout
-    setContainerInfo({
-      width,
-      height,
-    })
-  }
-
   return (
-    <View style={style} onLayout={onLayout}>
-      {containerInfo ? (
-        <ImageLayoutGridInner {...props} containerInfo={containerInfo} />
-      ) : undefined}
+    <View style={style}>
+      <ImageLayoutGridInner {...props} />
     </View>
   )
 }
@@ -44,64 +24,64 @@ interface ImageLayoutGridInnerProps {
   onPress?: (index: number) => void
   onLongPress?: (index: number) => void
   onPressIn?: (index: number) => void
-  containerInfo: Dimensions
 }
 
-function ImageLayoutGridInner({
-  containerInfo,
-  ...props
-}: ImageLayoutGridInnerProps) {
+function ImageLayoutGridInner(props: ImageLayoutGridInnerProps) {
   const count = props.images.length
-  const size1 = useMemo<ImageStyle>(() => {
-    if (count === 3) {
-      const size = (containerInfo.width - 10) / 3
-      return {width: size, height: size, resizeMode: 'cover', borderRadius: 4}
-    } else {
-      const size = (containerInfo.width - 5) / 2
-      return {width: size, height: size, resizeMode: 'cover', borderRadius: 4}
-    }
-  }, [count, containerInfo])
-  const size2 = React.useMemo<ImageStyle>(() => {
-    if (count === 3) {
-      const size = ((containerInfo.width - 10) / 3) * 2 + 5
-      return {width: size, height: size, resizeMode: 'cover', borderRadius: 4}
-    } else {
-      const size = (containerInfo.width - 5) / 2
-      return {width: size, height: size, resizeMode: 'cover', borderRadius: 4}
-    }
-  }, [count, containerInfo])
 
   switch (count) {
     case 2:
       return (
         <View style={styles.flexRow}>
-          <GalleryItem index={0} {...props} imageStyle={size1} />
-          <GalleryItem index={1} {...props} imageStyle={size1} />
-        </View>
-      )
-    case 3:
-      return (
-        <View style={styles.flexRow}>
-          <GalleryItem index={0} {...props} imageStyle={size2} />
-          <View style={styles.flexColumn}>
-            <GalleryItem index={1} {...props} imageStyle={size1} />
-            <GalleryItem index={2} {...props} imageStyle={size1} />
+          <View style={styles.smallItem}>
+            <GalleryItem index={0} {...props} />
+          </View>
+          <View style={styles.smallItem}>
+            <GalleryItem index={1} {...props} />
           </View>
         </View>
       )
+
+    case 3:
+      const flexProp = Platform.OS === 'web' ? 'flex' : 'flexGrow'
+      return (
+        <View style={styles.flexRow}>
+          <View style={{[flexProp]: 2, aspectRatio: 1}}>
+            <GalleryItem index={0} {...props} />
+          </View>
+          <View style={{[flexProp]: 1, gap: 5}}>
+            <View style={styles.smallItem}>
+              <GalleryItem index={1} {...props} />
+            </View>
+            <View style={styles.smallItem}>
+              <GalleryItem index={2} {...props} />
+            </View>
+          </View>
+        </View>
+      )
+
     case 4:
       return (
         <View style={styles.flexRow}>
-          <View style={styles.flexColumn}>
-            <GalleryItem index={0} {...props} imageStyle={size1} />
-            <GalleryItem index={2} {...props} imageStyle={size1} />
+          <View style={{flex: 1, gap: 5}}>
+            <View style={styles.smallItem}>
+              <GalleryItem index={0} {...props} />
+            </View>
+            <View style={styles.smallItem}>
+              <GalleryItem index={2} {...props} />
+            </View>
           </View>
-          <View style={styles.flexColumn}>
-            <GalleryItem index={1} {...props} imageStyle={size1} />
-            <GalleryItem index={3} {...props} imageStyle={size1} />
+          <View style={{flex: 1, gap: 5}}>
+            <View style={styles.smallItem}>
+              <GalleryItem index={1} {...props} />
+            </View>
+            <View style={styles.smallItem}>
+              <GalleryItem index={3} {...props} />
+            </View>
           </View>
         </View>
       )
+
     default:
       return null
   }
@@ -109,5 +89,5 @@ function ImageLayoutGridInner({
 
 const styles = StyleSheet.create({
   flexRow: {flexDirection: 'row', gap: 5},
-  flexColumn: {flexDirection: 'column', gap: 5},
+  smallItem: {flex: 1, aspectRatio: 1},
 })

--- a/src/view/com/util/images/ImageLayoutGrid.tsx
+++ b/src/view/com/util/images/ImageLayoutGrid.tsx
@@ -43,6 +43,7 @@ function ImageLayoutGridInner(props: ImageLayoutGridInnerProps) {
       )
 
     case 3:
+      // Work around https://github.com/facebook/react-native/issues/40802
       const flexProp = Platform.OS === 'web' ? 'flex' : 'flexGrow'
       return (
         <View style={styles.flexRow}>


### PR DESCRIPTION
This has been bugging me for a while.

When we encounter a post with a gallery in feed (or profile — anywhere we display posts), we try to render it without images first, then measure the container's width, and then relayout images based on that width. As a result, there is a noticeable layout shift after the first render — even though the actual layout is entirely dependent on its container and doesn't *even* depend on the image sizes.

This shift is very bad both because it's visually noticeable (the screen always paints first with empty images) and because it screws the perf — everything below has to relayout again.

The fix is to use flexbox instead of manual calculations. I don't actually _know_ flexbox so I had some help from ChatGPT with this. I *might* have uncovered a potential RN bug with how the `gap` property works, so there's a bit of a hack in the code. I've checked iOS, Android, and web (Chrome, FF, Safari), and the hack seems to work.

## Before

Notice the layout jump *after* the glimmer. 

https://github.com/bluesky-social/social-app/assets/810438/c227db79-ffd4-45df-84ab-ff476bfc2b34

## After

No layout jump after the glimmer. 

https://github.com/bluesky-social/social-app/assets/810438/58e49a38-a988-4e35-8e6d-dc5e6a0bd2a4

