### PR TITLE
Make shell hide/show animation smoother

### DIFF
--- a/src/lib/hooks/useMinimalShellMode.tsx
+++ b/src/lib/hooks/useMinimalShellMode.tsx
@@ -7,21 +7,22 @@ export function useMinimalShellMode() {
   const store = useStores()
   const minimalShellInterp = useAnimatedValue(0)
   const footerMinimalShellTransform = {
-    transform: [{translateY: Animated.multiply(minimalShellInterp, 100)}],
+    opacity: Animated.subtract(1, minimalShellInterp),
+    transform: [{translateY: Animated.multiply(minimalShellInterp, 50)}],
   }
 
   React.useEffect(() => {
     if (store.shell.minimalShellMode) {
       Animated.timing(minimalShellInterp, {
         toValue: 1,
-        duration: 100,
+        duration: 150,
         useNativeDriver: true,
         isInteraction: false,
       }).start()
     } else {
       Animated.timing(minimalShellInterp, {
         toValue: 0,
-        duration: 100,
+        duration: 150,
         useNativeDriver: true,
         isInteraction: false,
       }).start()

--- a/src/view/com/pager/FeedsTabBarMobile.tsx
+++ b/src/view/com/pager/FeedsTabBarMobile.tsx
@@ -24,13 +24,14 @@ export const FeedsTabBar = observer(function FeedsTabBarImpl(
   React.useEffect(() => {
     Animated.timing(interp, {
       toValue: store.shell.minimalShellMode ? 1 : 0,
-      duration: 100,
+      duration: 150,
       useNativeDriver: true,
       isInteraction: false,
     }).start()
   }, [interp, store.shell.minimalShellMode])
   const transform = {
-    transform: [{translateY: Animated.multiply(interp, -100)}],
+    opacity: Animated.subtract(1, interp),
+    transform: [{translateY: Animated.multiply(interp, -50)}],
   }
 
   const brandBlue = useColorSchemeStyle(s.brandBlue, s.blue3)

--- a/src/view/com/util/load-latest/LoadLatestBtn.tsx
+++ b/src/view/com/util/load-latest/LoadLatestBtn.tsx
@@ -10,6 +10,10 @@ import {colors} from 'lib/styles'
 import {HITSLOP_20} from 'lib/constants'
 import {isWeb} from 'platform/detection'
 import {clamp} from 'lib/numbers'
+import Animated, {useAnimatedStyle, withTiming} from 'react-native-reanimated'
+
+const AnimatedTouchableOpacity =
+  Animated.createAnimatedComponent(TouchableOpacity)
 
 export const LoadLatestBtn = observer(function LoadLatestBtnImpl({
   onPress,
@@ -30,15 +34,18 @@ export const LoadLatestBtn = observer(function LoadLatestBtnImpl({
     ? 50
     : (minMode || isDesktop ? 16 : 60) +
       (isWeb ? 20 : clamp(safeAreaInsets.bottom, 15, 60))
+  const animatedStyle = useAnimatedStyle(() => ({
+    bottom: withTiming(bottom, {duration: 150}),
+  }))
   return (
-    <TouchableOpacity
+    <AnimatedTouchableOpacity
       style={[
         styles.loadLatest,
         isDesktop && styles.loadLatestDesktop,
         isTablet && styles.loadLatestTablet,
         pal.borderDark,
         pal.view,
-        {bottom},
+        animatedStyle,
       ]}
       onPress={onPress}
       hitSlop={HITSLOP_20}
@@ -47,7 +54,7 @@ export const LoadLatestBtn = observer(function LoadLatestBtnImpl({
       accessibilityHint="">
       <FontAwesomeIcon icon="angle-up" color={pal.colors.text} size={19} />
       {showIndicator && <View style={[styles.indicator, pal.borderDark]} />}
-    </TouchableOpacity>
+    </AnimatedTouchableOpacity>
   )
 })
 


### PR DESCRIPTION
This animation was too jumpy. I believe the reason is that we've set the distance pretty high, but the duration pretty low. So even if the device is powerful, each frame it has to travel "too much" resulting in jerkiness. Additionally, things "going offscreen" always feel jarring — usually this is solved by fading things out.

I've changed the animation to travel a smaller distance over a slightly longer time, plus added opacity.

## Before

https://github.com/bluesky-social/social-app/assets/810438/4a74aaa8-fecc-4d7f-a513-4d0c459a218b

## After

https://github.com/bluesky-social/social-app/assets/810438/537f90dc-8bee-4669-995c-bec67afff5c2


