### PR TITLE
Fix crash when scrolling down on the web

### DIFF
--- a/src/view/com/util/load-latest/LoadLatestBtn.tsx
+++ b/src/view/com/util/load-latest/LoadLatestBtn.tsx
@@ -74,14 +74,12 @@ const styles = StyleSheet.create({
   loadLatestTablet: {
     // @ts-ignore web only
     left: '50vw',
-    // @ts-ignore web only -prf
-    transform: 'translateX(-282px)',
+    transform: [{translateX: -282}],
   },
   loadLatestDesktop: {
     // @ts-ignore web only
     left: '50vw',
-    // @ts-ignore web only -prf
-    transform: 'translateX(-382px)',
+    transform: [{translateX: -382}],
   },
   indicator: {
     position: 'absolute',


### PR DESCRIPTION
Fixes a crash I introduced in https://github.com/bluesky-social/social-app/pull/1683. The repro is to scroll down on the web in desktop mode. The crash was happening because the animation runtime was iterating over the transforms, and one of them was a string. The fix is to use the RN object style API (which works on the web too).