### PR TITLE
Disable events on hidden bars

### DIFF
--- a/src/view/com/pager/FeedsTabBarMobile.tsx
+++ b/src/view/com/pager/FeedsTabBarMobile.tsx
@@ -46,7 +46,14 @@ export const FeedsTabBar = observer(function FeedsTabBarImpl(
   )
 
   return (
-    <Animated.View style={[pal.view, pal.border, styles.tabBar, transform]}>
+    <Animated.View
+      style={[
+        pal.view,
+        pal.border,
+        styles.tabBar,
+        transform,
+        store.shell.minimalShellMode && styles.disabled,
+      ]}>
       <View style={[pal.view, styles.topBar]}>
         <View style={[pal.view]}>
           <TouchableOpacity
@@ -113,5 +120,8 @@ const styles = StyleSheet.create({
   },
   title: {
     fontSize: 21,
+  },
+  disabled: {
+    pointerEvents: 'none',
   },
 })

--- a/src/view/shell/bottom-bar/BottomBar.tsx
+++ b/src/view/shell/bottom-bar/BottomBar.tsx
@@ -87,6 +87,7 @@ export const BottomBar = observer(function BottomBarImpl({
         pal.border,
         {paddingBottom: clamp(safeAreaInsets.bottom, 15, 30)},
         footerMinimalShellTransform,
+        store.shell.minimalShellMode && styles.disabled,
       ]}>
       <Btn
         testID="bottomBarHomeBtn"

--- a/src/view/shell/bottom-bar/BottomBarStyles.tsx
+++ b/src/view/shell/bottom-bar/BottomBarStyles.tsx
@@ -65,4 +65,7 @@ export const styles = StyleSheet.create({
     borderWidth: 1,
     borderRadius: 100,
   },
+  disabled: {
+    pointerEvents: 'none',
+  },
 })


### PR DESCRIPTION
Fixes a regression I introduced in https://github.com/bluesky-social/social-app/pull/1683.

Since we're keeping these in the viewport, we need to disable events on them in the hidden state.
Otherwise, they'd react to taps etc.

Verified they don't react to events anymore while hidden.