### PR TITLE
Toggle lightbox controls on tap

### DIFF
--- a/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.android.tsx
+++ b/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.android.tsx
@@ -34,11 +34,13 @@ const initialTransform = createTransform()
 type Props = {
   imageSrc: ImageSource
   onRequestClose: () => void
+  onTap: () => void
   onZoom: (isZoomed: boolean) => void
   isScrollViewBeingDragged: boolean
 }
 const ImageItem = ({
   imageSrc,
+  onTap,
   onZoom,
   onRequestClose,
   isScrollViewBeingDragged,
@@ -227,6 +229,10 @@ const ImageItem = ({
       panTranslation.value = {x: 0, y: 0}
     })
 
+  const singleTap = Gesture.Tap().onEnd(() => {
+    runOnJS(onTap)()
+  })
+
   const doubleTap = Gesture.Tap()
     .numberOfTaps(2)
     .onEnd(e => {
@@ -297,6 +303,7 @@ const ImageItem = ({
         dismissSwipePan,
         Gesture.Simultaneous(pinch, pan),
         doubleTap,
+        singleTap,
       )
 
   const isLoading = !isLoaded || !imageDimensions

--- a/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.tsx
+++ b/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.tsx
@@ -7,6 +7,7 @@ import {ImageSource} from '../../@types'
 type Props = {
   imageSrc: ImageSource
   onRequestClose: () => void
+  onTap: () => void
   onZoom: (scaled: boolean) => void
   isScrollViewBeingDragged: boolean
 }

--- a/src/view/com/lightbox/ImageViewing/index.tsx
+++ b/src/view/com/lightbox/ImageViewing/index.tsx
@@ -43,26 +43,34 @@ function ImageViewing({
   const [isScaled, setIsScaled] = useState(false)
   const [isDragging, setIsDragging] = useState(false)
   const [imageIndex, setImageIndex] = useState(initialImageIndex)
+  const [showControls, setShowControls] = useState(true)
 
   const animatedHeaderStyle = useAnimatedStyle(() => ({
-    opacity: withClampedSpring(isScaled ? 0 : 1),
+    opacity: withClampedSpring(showControls ? 1 : 0),
     transform: [
       {
-        translateY: withClampedSpring(isScaled ? -30 : 0),
+        translateY: withClampedSpring(showControls ? 0 : -30),
       },
     ],
   }))
   const animatedFooterStyle = useAnimatedStyle(() => ({
-    opacity: withClampedSpring(isScaled ? 0 : 1),
+    opacity: withClampedSpring(showControls ? 1 : 0),
     transform: [
       {
-        translateY: withClampedSpring(isScaled ? 30 : 0),
+        translateY: withClampedSpring(showControls ? 0 : 30),
       },
     ],
   }))
 
+  const onTap = useCallback(() => {
+    setShowControls(show => !show)
+  }, [])
+
   const onZoom = useCallback((nextIsScaled: boolean) => {
     setIsScaled(nextIsScaled)
+    if (nextIsScaled) {
+      setShowControls(false)
+    }
   }, [])
 
   const edges = useMemo(() => {
@@ -107,6 +115,7 @@ function ImageViewing({
           {images.map(imageSrc => (
             <View key={imageSrc.uri}>
               <ImageItem
+                onTap={onTap}
                 onZoom={onZoom}
                 imageSrc={imageSrc}
                 onRequestClose={onRequestClose}

--- a/src/view/com/lightbox/ImageViewing/index.tsx
+++ b/src/view/com/lightbox/ImageViewing/index.tsx
@@ -45,16 +45,18 @@ function ImageViewing({
   const [imageIndex, setImageIndex] = useState(initialImageIndex)
 
   const animatedHeaderStyle = useAnimatedStyle(() => ({
+    opacity: withClampedSpring(isScaled ? 0 : 1),
     transform: [
       {
-        translateY: withClampedSpring(isScaled ? -300 : 0),
+        translateY: withClampedSpring(isScaled ? -30 : 0),
       },
     ],
   }))
   const animatedFooterStyle = useAnimatedStyle(() => ({
+    opacity: withClampedSpring(isScaled ? 0 : 1),
     transform: [
       {
-        translateY: withClampedSpring(isScaled ? 300 : 0),
+        translateY: withClampedSpring(isScaled ? 30 : 0),
       },
     ],
   }))
@@ -161,7 +163,7 @@ const EnhancedImageViewing = (props: Props) => (
 
 function withClampedSpring(value: any) {
   'worklet'
-  return withSpring(value, {overshootClamping: true})
+  return withSpring(value, {overshootClamping: true, stiffness: 300})
 }
 
 export default EnhancedImageViewing

--- a/src/view/com/lightbox/ImageViewing/index.tsx
+++ b/src/view/com/lightbox/ImageViewing/index.tsx
@@ -46,6 +46,7 @@ function ImageViewing({
   const [showControls, setShowControls] = useState(true)
 
   const animatedHeaderStyle = useAnimatedStyle(() => ({
+    pointerEvents: showControls ? 'auto' : 'none',
     opacity: withClampedSpring(showControls ? 1 : 0),
     transform: [
       {
@@ -54,6 +55,7 @@ function ImageViewing({
     ],
   }))
   const animatedFooterStyle = useAnimatedStyle(() => ({
+    pointerEvents: showControls ? 'auto' : 'none',
     opacity: withClampedSpring(showControls ? 1 : 0),
     transform: [
       {


### PR DESCRIPTION
Closes https://github.com/bluesky-social/social-app/issues/1265.

This makes the lightbox controls (including alt text) toggle on tap, similar to the Photos app behavior:

- Initially, controls are visible.
- A single tap toggles visibility (hide -> show, show -> hide).
- Zooming in (via pinch or double tap) immediately hides controls.
- Once controls are hidden, only tap shows them again (zooming out doesn't).

Note that, of course, two quick taps (double tap to zoom) should not toggle controls there and back.

I've also tweaked the animation to feel softer, similar to https://github.com/bluesky-social/social-app/pull/1683.

## Note on reviewing

It seems like sometimes Reanimated scroll view events just stop working in the iOS simulator. I can't quite pinpoint the pattern. This doesn't seem to happen when I build for device in the Release configuration, so I presume it's DEV-only. There also seems to be a weird way to get them to unstuck: I put `console.log()` into `registerForEvents` in `node_modules/react-native-reanimated/src/reanimated2/WorkletEventHandler.ts`. This might be placebo though, I'm not sure if this is a reliable fix. So far this _seems_ to be some kind of DEV-only bug in Reanimated. I'll try to report it to them.

## iOS

https://github.com/bluesky-social/social-app/assets/810438/dded1c68-ce54-40c4-84cf-cce03345a316

## Android

https://github.com/bluesky-social/social-app/assets/810438/1a1c4eea-3bef-4a88-862d-2971f1f1973b
