### PR TITLE
Fix profile layout shift

### DIFF
--- a/src/view/com/util/ViewSelector.tsx
+++ b/src/view/com/util/ViewSelector.tsx
@@ -144,8 +144,6 @@ export function Selector({
   items: string[]
   onSelect?: (index: number) => void
 }) {
-  const [height, setHeight] = useState(0)
-
   const pal = usePalette('default')
   const borderColor = useColorSchemeStyle(
     {borderColor: colors.black},
@@ -160,22 +158,13 @@ export function Selector({
     <View
       style={{
         width: '100%',
-        position: 'relative',
-        overflow: 'hidden',
-        height,
         backgroundColor: pal.colors.background,
       }}>
       <ScrollView
         testID="selector"
         horizontal
-        showsHorizontalScrollIndicator={false}
-        style={{position: 'absolute'}}>
-        <View
-          style={[pal.view, styles.outer]}
-          onLayout={e => {
-            const {height: layoutHeight} = e.nativeEvent.layout
-            setHeight(layoutHeight || 60)
-          }}>
+        showsHorizontalScrollIndicator={false}>
+        <View style={[pal.view, styles.outer]}>
           {items.map((item, i) => {
             const selected = i === selectedIndex
             return (


### PR DESCRIPTION
There's currently a jump whenever we navigate to profile because the tab selector initially renders with zero height.

This regression was initially added in https://github.com/bluesky-social/social-app/commit/e11168f76868daffff06ac2ccb202b83c21dcbfc#diff-94c6bb36a43b7684db3e0fba9c828d055f9c26101bf0837ef16ce8b7b9c1e945R178 as an attempt to use absolute positioning to hide scrollbars.

Later, https://github.com/bluesky-social/social-app/commit/6964382bad7d4d53b7b6f685190c873cda2d100f applied a better fix for that, but the original layout hack was not removed.

This removes the layout hack — fixing the jump.

Thanks to @estrattonbailey for a hint on how to fix this.

## Before

Observe the shift.

https://github.com/bluesky-social/social-app/assets/810438/d4484fd1-1bf4-43da-8ac4-3531a1b3c59e

## After

Observe no shift.

https://github.com/bluesky-social/social-app/assets/810438/991913c9-6a05-494f-8398-fd3d82727faf

