### PR TITLE
Don't re-render bars when showing/hiding them

### DIFF
--- a/src/lib/hooks/useMinimalShellMode.tsx
+++ b/src/lib/hooks/useMinimalShellMode.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import {reaction} from 'mobx'
 import {useStores} from 'state/index'
 import {Animated} from 'react-native'
 import {useAnimatedValue} from 'lib/hooks/useAnimatedValue'
@@ -12,22 +13,27 @@ export function useMinimalShellMode() {
   }
 
   React.useEffect(() => {
-    if (store.shell.minimalShellMode) {
-      Animated.timing(minimalShellInterp, {
-        toValue: 1,
-        duration: 150,
-        useNativeDriver: true,
-        isInteraction: false,
-      }).start()
-    } else {
-      Animated.timing(minimalShellInterp, {
-        toValue: 0,
-        duration: 150,
-        useNativeDriver: true,
-        isInteraction: false,
-      }).start()
-    }
-  }, [minimalShellInterp, store.shell.minimalShellMode])
+    return reaction(
+      () => store.shell.minimalShellMode,
+      isMinimalShell => {
+        if (isMinimalShell) {
+          Animated.timing(minimalShellInterp, {
+            toValue: 1,
+            duration: 150,
+            useNativeDriver: true,
+            isInteraction: false,
+          }).start()
+        } else {
+          Animated.timing(minimalShellInterp, {
+            toValue: 0,
+            duration: 150,
+            useNativeDriver: true,
+            isInteraction: false,
+          }).start()
+        }
+      },
+    )
+  }, [minimalShellInterp, store])
 
   return {footerMinimalShellTransform}
 }

--- a/src/view/com/pager/FeedsTabBarMobile.tsx
+++ b/src/view/com/pager/FeedsTabBarMobile.tsx
@@ -1,6 +1,7 @@
 import React, {useMemo} from 'react'
 import {Animated, StyleSheet, TouchableOpacity, View} from 'react-native'
 import {observer} from 'mobx-react-lite'
+import {reaction} from 'mobx'
 import {TabBar} from 'view/com/pager/TabBar'
 import {RenderTabBarFnProps} from 'view/com/pager/Pager'
 import {useStores} from 'state/index'
@@ -22,13 +23,18 @@ export const FeedsTabBar = observer(function FeedsTabBarImpl(
   const interp = useAnimatedValue(0)
 
   React.useEffect(() => {
-    Animated.timing(interp, {
-      toValue: store.shell.minimalShellMode ? 1 : 0,
-      duration: 150,
-      useNativeDriver: true,
-      isInteraction: false,
-    }).start()
-  }, [interp, store.shell.minimalShellMode])
+    return reaction(
+      () => store.shell.minimalShellMode,
+      isMinimalShell => {
+        Animated.timing(interp, {
+          toValue: isMinimalShell ? 1 : 0,
+          duration: 150,
+          useNativeDriver: true,
+          isInteraction: false,
+        }).start()
+      },
+    )
+  }, [interp, store])
   const transform = {
     opacity: Animated.subtract(1, interp),
     transform: [{translateY: Animated.multiply(interp, -50)}],


### PR DESCRIPTION
Currently, when we show/hide bars on scroll, there is a React re-render for both of them. However, that's unnecessary because we only use that React re-render for an Effect which triggers a chance in the Animated value.

Let's just use a MobX reaction here. (In the future, we'll replace this with a Reanimated style so this won't happen anyway.)