### PR TITLE
Synchronize the feed switcher with the feed drag gesture

### DIFF
--- a/src/view/com/pager/FeedsTabBarMobile.tsx
+++ b/src/view/com/pager/FeedsTabBarMobile.tsx
@@ -20,7 +20,6 @@ export const FeedsTabBar = observer(function FeedsTabBarImpl(
 ) {
   const store = useStores()
   const pal = usePalette('default')
-
   const brandBlue = useColorSchemeStyle(s.brandBlue, s.blue3)
   const {headerMinimalShellTransform} = useMinimalShellMode()
 
@@ -87,6 +86,7 @@ export const FeedsTabBar = observer(function FeedsTabBarImpl(
         onSelect={props.onSelect}
         testID={props.testID}
         items={items}
+        dragProgress={props.dragProgress}
         indicatorColor={pal.colors.link}
       />
     </Animated.View>

--- a/src/view/com/pager/FeedsTabBarMobile.tsx
+++ b/src/view/com/pager/FeedsTabBarMobile.tsx
@@ -87,6 +87,7 @@ export const FeedsTabBar = observer(function FeedsTabBarImpl(
         testID={props.testID}
         items={items}
         dragProgress={props.dragProgress}
+        dragState={props.dragState}
         indicatorColor={pal.colors.link}
       />
     </Animated.View>

--- a/src/view/com/pager/Pager.tsx
+++ b/src/view/com/pager/Pager.tsx
@@ -34,6 +34,7 @@ export const Pager = forwardRef<PagerRef, React.PropsWithChildren<Props>>(
       initialPage = 0,
       renderTabBar,
       onPageScroll,
+      onPageScrollStateChanged,
       onPageSelected,
       testID,
     }: React.PropsWithChildren<Props>,
@@ -74,7 +75,8 @@ export const Pager = forwardRef<PagerRef, React.PropsWithChildren<Props>>(
           style={s.h100pct}
           initialPage={initialPage}
           onPageSelected={onPageSelectedInner}
-          onPageScroll={handlePageScroll}>
+          onPageScroll={handlePageScroll}
+          onPageScrollStateChanged={onPageScrollStateChanged}>
           {children}
         </AnimatedPagerView>
         {tabBarPosition === 'bottom' &&

--- a/src/view/com/pager/Pager.web.tsx
+++ b/src/view/com/pager/Pager.web.tsx
@@ -21,6 +21,7 @@ export const Pager = React.forwardRef(function PagerImpl(
     initialPage = 0,
     renderTabBar,
     onPageSelected,
+    onPageScroll,
   }: React.PropsWithChildren<Props>,
   ref,
 ) {
@@ -34,8 +35,12 @@ export const Pager = React.forwardRef(function PagerImpl(
     (index: number) => {
       setSelectedPage(index)
       onPageSelected?.(index)
+      onPageScroll?.({
+        position: index,
+        offset: 0
+      })
     },
-    [setSelectedPage, onPageSelected],
+    [setSelectedPage, onPageSelected, onPageScroll],
   )
 
   return (

--- a/src/view/com/pager/TabBar.tsx
+++ b/src/view/com/pager/TabBar.tsx
@@ -1,6 +1,6 @@
 import React, {useMemo, useCallback, useEffect, useState} from 'react'
 import Animated, {useAnimatedReaction, useAnimatedRef, useAnimatedStyle, useDerivedValue, useSharedValue, measure, interpolate, interpolateColor, scrollTo, withSpring} from 'react-native-reanimated'
-import {Dimensions, StyleSheet, View, ScrollView, useWindowDimensions} from 'react-native'
+import {Dimensions, StyleSheet, View, ScrollView} from 'react-native'
 import {PressableWithHover} from '../util/PressableWithHover'
 import {usePalette} from 'lib/hooks/usePalette'
 import {useTheme} from 'lib/ThemeContext'
@@ -28,8 +28,8 @@ export function TabBar({
   onPressSelected,
 }: TabBarProps) {
   const pal = usePalette('default')
-  const {width: windowWidth} = useWindowDimensions()
   const contentSize = useSharedValue(0)
+  const containerSize = useSharedValue(0)
   const scrollElRef = useAnimatedRef(null)
   const {isDesktop, isTablet} = useWebMediaQueries()
   const [layouts, setLayouts] = useState([])
@@ -54,7 +54,7 @@ export function TabBar({
   const onPressItem = (index: number) => {
     if (!didScroll.value) {
       scrollElRef.current.scrollTo({
-        x: scrollX.value + ((index - selectedPage) / (items.length - 1)) * (contentSize.value - windowWidth),
+        x: scrollX.value + ((index - selectedPage) / (items.length - 1)) * (contentSize.value - containerSize.value),
         animated: true
       })
     }
@@ -66,7 +66,7 @@ export function TabBar({
   };
 
   useAnimatedReaction(() => {
-    return (dragProgress.value / (items.length - 1)) * (contentSize.value - windowWidth)
+    return (dragProgress.value / (items.length - 1)) * (contentSize.value - containerSize.value)
   }, (nextX, prevX) => {
     if (prevX !== nextX && dragState.value !== 'idle' && !didScroll.value) {
       scrollTo(scrollElRef, nextX, 0, false);
@@ -77,7 +77,7 @@ export function TabBar({
     return dragState.value
   }, (nextDragState, prevDragState) => {
     if (nextDragState === 'idle' && nextDragState !== prevDragState) {
-      const nextX = (dragProgress.value / (items.length - 1)) * (contentSize.value - windowWidth)
+      const nextX = (dragProgress.value / (items.length - 1)) * (contentSize.value - containerSize.value)
       scrollTo(scrollElRef, nextX, 0, true);
       didScroll.value = false
     }
@@ -108,6 +108,9 @@ export function TabBar({
         }}
         onScrollBeginDrag={e => {
           didScroll.value = true
+        }}
+        onLayout={e => {
+          containerSize.value = e.nativeEvent.layout.width
         }}
         onScroll={e => {
           scrollX.value = Math.round(e.nativeEvent.contentOffset.x)

--- a/src/view/com/pager/TabBar.tsx
+++ b/src/view/com/pager/TabBar.tsx
@@ -38,8 +38,13 @@ export function TabBar({
   const scrollX = useSharedValue(0)
   const didScroll = useSharedValue(false)
 
+  const didLayout = (
+    layouts.length === items.length &&
+    layouts.every(l => l !== undefined)
+  );
+
   const indicatorStyle = useAnimatedStyle(() => {
-    if (layouts.length < items.length - 1 || layouts.some(l => l === undefined)) {
+    if (!didLayout) {
       return {}
     }
     return {
@@ -113,11 +118,15 @@ export function TabBar({
         }}
         scrollEventThrottle={16}>
         {items.map((item, i) => {
+          const isSelected = i === selectedPage
           return (
             <PressableWithHover
               key={item}
               onLayout={e => onItemLayout(e, i)}
-              style={[styles.item]}
+              style={[styles.item, {
+                borderBottomColor: (!didLayout && isSelected) ? indicatorColor : 'transparent',
+                borderBottomWidth: 3
+              }]}
               hoverStyle={pal.viewLight}
               onPress={() => onPressItem(i)}>
               <MaybeHighlightedText
@@ -130,21 +139,21 @@ export function TabBar({
             </PressableWithHover>
           )
         })}
-        <Animated.View
+        {didLayout && <Animated.View
           style={[{
             position: 'absolute',
             bottom: 0,
             height: 3,
-            backgroundColor: indicatorColor || pal.colors.link,
+            backgroundColor: indicatorColor,
           }, indicatorStyle]}
-        />
+      />}
       </DraggableScrollView>
 
     </View>
   )
 }
 
-export function MaybeHighlightedText({ approxIndex, index, style, type, ...rest }) {
+export function MaybeHighlightedText({ approxIndex, index, type, ...rest }) {
   const pal = usePalette('default')
   const theme = useTheme()
   const typography = theme.typography[type]
@@ -152,7 +161,7 @@ export function MaybeHighlightedText({ approxIndex, index, style, type, ...rest 
     color: interpolateColor(Math.min(Math.abs(approxIndex.value - index), 1), [0, 1], [pal.text.color, pal.textLight.color])
   }))
   return (
-    <Animated.Text {...rest} style={[style, typography, animatedStyle]} />
+    <Animated.Text {...rest} style={[typography, animatedStyle]} />
   )
 }
 

--- a/src/view/com/pager/TabBar.tsx
+++ b/src/view/com/pager/TabBar.tsx
@@ -34,14 +34,13 @@ export function TabBar({
   const {isDesktop, isTablet} = useWebMediaQueries()
   const [layouts, setLayouts] = useState([])
 
-  const approxIndex = useDerivedValue(() => dragProgress.value * (items.length - 1))
   const indicatorStyle = useAnimatedStyle(() => {
     if (layouts.length < items.length - 1 || layouts.some(l => l === undefined)) {
       return {}
     }
     return {
-      width: interpolate(approxIndex.value, layouts.map((l, i) => i), layouts.map(l => l.width)),
-      left: interpolate(approxIndex.value, layouts.map((l, i) => i), layouts.map(l => l.x)),
+      width: interpolate(dragProgress.value, layouts.map((l, i) => i), layouts.map(l => l.width)),
+      left: interpolate(dragProgress.value, layouts.map((l, i) => i), layouts.map(l => l.x)),
     }
   })
 
@@ -56,12 +55,12 @@ export function TabBar({
   )
 
   useAnimatedReaction(() => {
-    return dragProgress.value * (contentSize.value - SCREEN.width)
+    return (dragProgress.value / (items.length - 1)) * (contentSize.value - SCREEN.width)
   }, (nextX, prevX) => {
     if (prevX !== nextX) {
       scrollTo(scrollElRef, nextX, 0, false);
     }
-  }, [dragProgress, contentSize])
+  })
 
   const onItemLayout = (e: LayoutChangeEvent, index: number) => {
     const l = e.nativeEvent.layout
@@ -97,7 +96,7 @@ export function TabBar({
               <MaybeHighlightedText
                 type={isDesktop || isTablet ? 'xl-bold' : 'lg-bold'}
                 testID={testID ? `${testID}-${item}` : undefined}
-                approxIndex={approxIndex}
+                approxIndex={dragProgress}
                 index={i}>
                 {item}
               </MaybeHighlightedText>

--- a/src/view/com/pager/TabBar.tsx
+++ b/src/view/com/pager/TabBar.tsx
@@ -1,5 +1,5 @@
-import React, {useRef, useMemo, useEffect, useState, useCallback} from 'react'
-import {StyleSheet, View, ScrollView, LayoutChangeEvent} from 'react-native'
+import React, {useRef, useMemo, useCallback} from 'react'
+import {StyleSheet, View, ScrollView} from 'react-native'
 import {Text} from '../util/text/Text'
 import {PressableWithHover} from '../util/PressableWithHover'
 import {usePalette} from 'lib/hooks/usePalette'
@@ -26,19 +26,11 @@ export function TabBar({
 }: TabBarProps) {
   const pal = usePalette('default')
   const scrollElRef = useRef<ScrollView>(null)
-  const [itemXs, setItemXs] = useState<number[]>([])
   const indicatorStyle = useMemo(
     () => ({borderBottomColor: indicatorColor || pal.colors.link}),
     [indicatorColor, pal],
   )
   const {isDesktop, isTablet} = useWebMediaQueries()
-
-  // scrolls to the selected item when the page changes
-  useEffect(() => {
-    scrollElRef.current?.scrollTo({
-      x: itemXs[selectedPage] || 0,
-    })
-  }, [scrollElRef, itemXs, selectedPage])
 
   const onPressItem = useCallback(
     (index: number) => {
@@ -48,19 +40,6 @@ export function TabBar({
       }
     },
     [onSelect, selectedPage, onPressSelected],
-  )
-
-  // calculates the x position of each item on mount and on layout change
-  const onItemLayout = React.useCallback(
-    (e: LayoutChangeEvent, index: number) => {
-      const x = e.nativeEvent.layout.x
-      setItemXs(prev => {
-        const Xs = [...prev]
-        Xs[index] = x
-        return Xs
-      })
-    },
-    [],
   )
 
   const styles = isDesktop || isTablet ? desktopStyles : mobileStyles
@@ -77,7 +56,6 @@ export function TabBar({
           return (
             <PressableWithHover
               key={item}
-              onLayout={e => onItemLayout(e, i)}
               style={[styles.item, selected && indicatorStyle]}
               hoverStyle={pal.viewLight}
               onPress={() => onPressItem(i)}>

--- a/src/view/com/pager/TabBar.tsx
+++ b/src/view/com/pager/TabBar.tsx
@@ -33,7 +33,6 @@ export function TabBar({
   const scrollElRef = useAnimatedRef(null)
   const {isDesktop, isTablet} = useWebMediaQueries()
   const [layouts, setLayouts] = useState([])
-  const shouldSync = useSharedValue(true)
   const scrollX = useSharedValue(0)
   const didScroll = useSharedValue(false)
 
@@ -69,7 +68,7 @@ export function TabBar({
   useAnimatedReaction(() => {
     return (dragProgress.value / (items.length - 1)) * (contentSize.value - windowWidth)
   }, (nextX, prevX) => {
-    if (shouldSync.value && prevX !== nextX) {
+    if (prevX !== nextX && dragState.value !== 'idle' && !didScroll.value) {
       scrollTo(scrollElRef, nextX, 0, false);
     }
   })
@@ -80,7 +79,6 @@ export function TabBar({
     if (nextDragState === 'idle' && nextDragState !== prevDragState) {
       const nextX = (dragProgress.value / (items.length - 1)) * (contentSize.value - windowWidth)
       scrollTo(scrollElRef, nextX, 0, true);
-      shouldSync.value = true
       didScroll.value = false
     }
   })
@@ -109,7 +107,6 @@ export function TabBar({
           contentSize.value = e
         }}
         onScrollBeginDrag={e => {
-          shouldSync.value = false
           didScroll.value = true
         }}
         onScroll={e => {

--- a/src/view/com/pager/TabBar.tsx
+++ b/src/view/com/pager/TabBar.tsx
@@ -1,6 +1,6 @@
 import React, {useMemo, useCallback, useEffect, useState} from 'react'
 import Animated, {useAnimatedReaction, useAnimatedRef, useAnimatedStyle, useDerivedValue, useSharedValue, measure, interpolate, interpolateColor, scrollTo, withSpring} from 'react-native-reanimated'
-import {Dimensions, StyleSheet, View, ScrollView} from 'react-native'
+import {Dimensions, StyleSheet, View, ScrollView, useWindowDimensions} from 'react-native'
 import {PressableWithHover} from '../util/PressableWithHover'
 import {usePalette} from 'lib/hooks/usePalette'
 import {useTheme} from 'lib/ThemeContext'
@@ -17,8 +17,6 @@ export interface TabBarProps {
   onPressSelected?: () => void
 }
 
-const SCREEN = Dimensions.get('screen')
-
 export function TabBar({
   testID,
   dragProgress,
@@ -30,6 +28,7 @@ export function TabBar({
   onPressSelected,
 }: TabBarProps) {
   const pal = usePalette('default')
+  const {width: windowWidth} = useWindowDimensions()
   const contentSize = useSharedValue(0)
   const scrollElRef = useAnimatedRef(null)
   const {isDesktop, isTablet} = useWebMediaQueries()
@@ -56,7 +55,7 @@ export function TabBar({
   const onPressItem = (index: number) => {
     if (!didScroll.value) {
       scrollElRef.current.scrollTo({
-        x: scrollX.value + ((index - selectedPage) / (items.length - 1)) * (contentSize.value - SCREEN.width),
+        x: scrollX.value + ((index - selectedPage) / (items.length - 1)) * (contentSize.value - windowWidth),
         animated: true
       })
     }
@@ -68,7 +67,7 @@ export function TabBar({
   };
 
   useAnimatedReaction(() => {
-    return (dragProgress.value / (items.length - 1)) * (contentSize.value - SCREEN.width)
+    return (dragProgress.value / (items.length - 1)) * (contentSize.value - windowWidth)
   }, (nextX, prevX) => {
     if (shouldSync.value && prevX !== nextX) {
       scrollTo(scrollElRef, nextX, 0, false);
@@ -79,7 +78,7 @@ export function TabBar({
     return dragState.value
   }, (nextDragState, prevDragState) => {
     if (nextDragState === 'idle' && nextDragState !== prevDragState) {
-      const nextX = (dragProgress.value / (items.length - 1)) * (contentSize.value - SCREEN.width)
+      const nextX = (dragProgress.value / (items.length - 1)) * (contentSize.value - windowWidth)
       scrollTo(scrollElRef, nextX, 0, true);
       shouldSync.value = true
       didScroll.value = false

--- a/src/view/screens/Home.tsx
+++ b/src/view/screens/Home.tsx
@@ -84,12 +84,10 @@ export const HomeScreen = withAuthRequired(
     const onPageScroll = React.useCallback(
       e => {
         'worklet'
-        if (customFeeds.length > 0) {
-          const progress = (e.offset + e.position) / customFeeds.length
-          dragProgress.value = progress
-        }
+        const progress = e.offset + e.position
+        dragProgress.value = progress
       },
-      [customFeeds, dragProgress],
+      [dragProgress],
     )
 
     const onPressSelected = React.useCallback(() => {

--- a/src/view/screens/Home.tsx
+++ b/src/view/screens/Home.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import {useWindowDimensions} from 'react-native'
 import {useFocusEffect} from '@react-navigation/native'
+import {useSharedValue} from 'react-native-reanimated'
 import {AppBskyFeedGetFeed as GetCustomFeed} from '@atproto/api'
 import {observer} from 'mobx-react-lite'
 import isEqual from 'lodash.isequal'
@@ -28,6 +29,7 @@ export const HomeScreen = withAuthRequired(
     const [requestedCustomFeeds, setRequestedCustomFeeds] = React.useState<
       string[]
     >([])
+    const dragProgress = useSharedValue(selectedPage)
 
     React.useEffect(() => {
       const {pinned} = store.me.savedFeeds
@@ -79,6 +81,12 @@ export const HomeScreen = withAuthRequired(
       [store, setSelectedPage],
     )
 
+    const onPageScroll = React.useCallback((e) => {
+      'worklet'
+      const progress = (e.offset + e.position) / customFeeds.length;
+      dragProgress.value = progress;
+    }, [customFeeds])
+
     const onPressSelected = React.useCallback(() => {
       store.emitScreenSoftReset()
     }, [store])
@@ -111,11 +119,7 @@ export const HomeScreen = withAuthRequired(
         ref={pagerRef}
         testID="homeScreen"
         onPageSelected={onPageSelected}
-        onPageScroll={(e) => {
-          'worklet'
-          const progress = (e.offset + e.position) / customFeeds.length;
-          console.log(progress)
-        }}
+        onPageScroll={onPageScroll}
         renderTabBar={renderTabBar}
         tabBarPosition="top">
         <FeedPage

--- a/src/view/screens/Home.tsx
+++ b/src/view/screens/Home.tsx
@@ -81,11 +81,16 @@ export const HomeScreen = withAuthRequired(
       [store, setSelectedPage],
     )
 
-    const onPageScroll = React.useCallback((e) => {
-      'worklet'
-      const progress = (e.offset + e.position) / customFeeds.length;
-      dragProgress.value = progress;
-    }, [customFeeds])
+    const onPageScroll = React.useCallback(
+      e => {
+        'worklet'
+        if (customFeeds.length > 0) {
+          const progress = (e.offset + e.position) / customFeeds.length
+          dragProgress.value = progress
+        }
+      },
+      [customFeeds, dragProgress],
+    )
 
     const onPressSelected = React.useCallback(() => {
       store.emitScreenSoftReset()
@@ -104,7 +109,7 @@ export const HomeScreen = withAuthRequired(
           />
         )
       },
-      [onPressSelected],
+      [dragProgress, onPressSelected],
     )
 
     const renderFollowingEmptyState = React.useCallback(() => {

--- a/src/view/screens/Home.tsx
+++ b/src/view/screens/Home.tsx
@@ -98,6 +98,7 @@ export const HomeScreen = withAuthRequired(
             key="FEEDS_TAB_BAR"
             selectedPage={props.selectedPage}
             onSelect={props.onSelect}
+            dragProgress={dragProgress}
             testID="homeScreenFeedTabs"
             onPressSelected={onPressSelected}
           />

--- a/src/view/screens/Home.tsx
+++ b/src/view/screens/Home.tsx
@@ -111,6 +111,11 @@ export const HomeScreen = withAuthRequired(
         ref={pagerRef}
         testID="homeScreen"
         onPageSelected={onPageSelected}
+        onPageScroll={(e) => {
+          'worklet'
+          const progress = (e.offset + e.position) / customFeeds.length;
+          console.log(progress)
+        }}
         renderTabBar={renderTabBar}
         tabBarPosition="top">
         <FeedPage

--- a/src/view/screens/Home.tsx
+++ b/src/view/screens/Home.tsx
@@ -30,6 +30,7 @@ export const HomeScreen = withAuthRequired(
       string[]
     >([])
     const dragProgress = useSharedValue(selectedPage)
+    const dragState = useSharedValue('idle')
 
     React.useEffect(() => {
       const {pinned} = store.me.savedFeeds
@@ -90,6 +91,10 @@ export const HomeScreen = withAuthRequired(
       [dragProgress],
     )
 
+    const onPageScrollStateChanged = React.useCallback(e => {
+      dragState.value = e.nativeEvent.pageScrollState
+    })
+
     const onPressSelected = React.useCallback(() => {
       store.emitScreenSoftReset()
     }, [store])
@@ -102,6 +107,7 @@ export const HomeScreen = withAuthRequired(
             selectedPage={props.selectedPage}
             onSelect={props.onSelect}
             dragProgress={dragProgress}
+            dragState={dragState}
             testID="homeScreenFeedTabs"
             onPressSelected={onPressSelected}
           />
@@ -124,6 +130,7 @@ export const HomeScreen = withAuthRequired(
         testID="homeScreen"
         onPageSelected={onPageSelected}
         onPageScroll={onPageScroll}
+        onPageScrollStateChanged={onPageScrollStateChanged}
         renderTabBar={renderTabBar}
         tabBarPosition="top">
         <FeedPage


### PR DESCRIPTION
WIP.

- [x] Scroll the feed switcher on drag
- [x] Interpolate the indicator to current item
- [x] Interpolate color
- [x] Fix flicker
- [x] Fix jump on drag + tap
- [x] Fix no selection on initial render
- [ ] Revert to a simpler model, this is too complicated and doesn't work
- [ ] Fix web
- [ ] What's up with that right margin
- [ ] What should happen if number of feeds changes (relayout, adjust scroll, etc)
- [ ] Types, naming, etc
