### PR TITLE
Fix: Improved Accessibility and Interaction for Waitlist Link in Step2 Component

### DIFF
--- a/src/view/com/auth/create/Step2.tsx
+++ b/src/view/com/auth/create/Step2.tsx
@@ -11,6 +11,7 @@ import {TextInput} from '../util/TextInput'
 import {Policies} from './Policies'
 import {ErrorMessage} from 'view/com/util/error/ErrorMessage'
 import {useStores} from 'state/index'
+import {isWeb} from 'platform/detection'
 
 /** STEP 2: Your account
  * @field Invite code or waitlist
@@ -60,10 +61,11 @@ export const Step2 = observer(function Step2Impl({
           Don't have an invite code?{' '}
           <TouchableWithoutFeedback
             onPress={onPressWaitlist}
-            accessibilityRole="button"
-            accessibilityLabel="Waitlist"
+            accessibilityLabel="button"
             accessibilityHint="Opens Bluesky waitlist form">
-            <Text style={pal.link}>Join the waitlist.</Text>
+            <View style={styles.touchable}>
+              <Text style={pal.link}>Join the waitlist.</Text>
+            </View>
           </TouchableWithoutFeedback>
         </Text>
       ) : (
@@ -150,5 +152,9 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     borderRadius: 6,
     paddingVertical: 14,
+  },
+  // @ts-expect-error: Suppressing error due to incomplete `ViewStyle` type definition in react-native-web, missing `cursor` prop as discussed in https://github.com/necolas/react-native-web/issues/832.
+  touchable: {
+    ...(isWeb && {cursor: 'pointer'}),
   },
 })


### PR DESCRIPTION
Fixed #1635.

## Changes:
- Imported `isWeb` from `'platform/detection'` to conditionally apply a pointer cursor style for web platforms.
- Wrapped the 'Join the waitlist.' text within a `View` component and applied a conditional style using `isWeb` to change the cursor to a pointer when hovered over on web platforms.

<img width="1920" alt="image" src="https://github.com/bluesky-social/social-app/assets/38807139/e2540cb1-5722-4091-b50e-0f60c4034467">

### Further Note:
Currently, the changes are applied to the mentioned area in the issue. However, if deemed necessary, I am open to creating a wrapper around the `TouchableWithoutFeedback` component to handle cursor styling as a common component for broader use throughout the application.
