### PR TITLE
Fix four gallery images for Firefox

### DIFF
--- a/src/view/com/util/images/ImageLayoutGrid.tsx
+++ b/src/view/com/util/images/ImageLayoutGrid.tsx
@@ -63,8 +63,8 @@ function ImageLayoutGridInner(props: ImageLayoutGridInnerProps) {
 
     case 4:
       return (
-        <View style={styles.flexRow}>
-          <View style={{flex: 1}}>
+        <>
+          <View style={styles.flexRow}>
             <View style={styles.smallItem}>
               <GalleryItem {...props} index={0} imageStyle={styles.image} />
             </View>
@@ -72,7 +72,7 @@ function ImageLayoutGridInner(props: ImageLayoutGridInnerProps) {
               <GalleryItem {...props} index={2} imageStyle={styles.image} />
             </View>
           </View>
-          <View style={{flex: 1}}>
+          <View style={styles.flexRow}>
             <View style={styles.smallItem}>
               <GalleryItem {...props} index={1} imageStyle={styles.image} />
             </View>
@@ -80,7 +80,7 @@ function ImageLayoutGridInner(props: ImageLayoutGridInnerProps) {
               <GalleryItem {...props} index={3} imageStyle={styles.image} />
             </View>
           </View>
-        </View>
+        </>
       )
 
     default:


### PR DESCRIPTION
Fixes https://github.com/bluesky-social/social-app/issues/1708.

This change is just for Firefox. I haven't seen any rendering differences on iOS, Android, Chrome, or Safari.

## Before

<img width="723" alt="Screenshot 2023-10-17 at 23 15 42" src="https://github.com/bluesky-social/social-app/assets/810438/9e79b268-635f-4b39-944e-03ce910f45fa">

## After

<img width="697" alt="Screenshot 2023-10-17 at 23 15 34" src="https://github.com/bluesky-social/social-app/assets/810438/fd27696b-7cf2-4f3e-98de-fab75d68c14a">
