### PR TITLE
Use percentage values to adjust PostLoadingPlaceholder

### DIFF
--- a/src/view/com/util/LoadingPlaceholder.tsx
+++ b/src/view/com/util/LoadingPlaceholder.tsx
@@ -53,7 +53,7 @@ export function PostLoadingPlaceholder({
         <LoadingPlaceholder width={'92%'} height={8} style={[s.mb5]} />
         <LoadingPlaceholder width={'93%'} height={8} style={[s.mb5]} />
         <LoadingPlaceholder width={'90%'} height={8} style={[s.mb5]} />
-        <LoadingPlaceholder width={'94%'} height={8} style={[s.mb5]} />
+        <LoadingPlaceholder width={'94%'} height={8} style={[s.mb10]} />
         <View style={s.flexRow}>
           <View style={s.flex1}>
             <FontAwesomeIcon

--- a/src/view/com/util/LoadingPlaceholder.tsx
+++ b/src/view/com/util/LoadingPlaceholder.tsx
@@ -48,10 +48,12 @@ export function PostLoadingPlaceholder({
     <View style={[styles.post, pal.view, style]}>
       <LoadingPlaceholder width={52} height={52} style={styles.avatar} />
       <View style={[s.flex1]}>
-        <LoadingPlaceholder width={100} height={8} style={[s.mb10]} />
-        <LoadingPlaceholder width={200} height={8} style={[s.mb5]} />
-        <LoadingPlaceholder width={200} height={8} style={[s.mb5]} />
-        <LoadingPlaceholder width={120} height={8} style={[s.mb10]} />
+        <LoadingPlaceholder width={'50%'} height={8} style={[s.mb10, s.mt10]} />
+        <LoadingPlaceholder width={'94%'} height={8} style={[s.mb5]} />
+        <LoadingPlaceholder width={'92%'} height={8} style={[s.mb5]} />
+        <LoadingPlaceholder width={'93%'} height={8} style={[s.mb5]} />
+        <LoadingPlaceholder width={'90%'} height={8} style={[s.mb5]} />
+        <LoadingPlaceholder width={'94%'} height={8} style={[s.mb5]} />
         <View style={s.flexRow}>
           <View style={s.flex1}>
             <FontAwesomeIcon


### PR DESCRIPTION
The current loading placeholder uses a fixed width which doesn't accurately reflect the expected skeleton of a post that is about to be loaded. This is more noticeable in larger screens. 

This change will (1) adjust the width of post loading bars to be relative to container width, and (2) add two more bars to make the loading placeholder look more like a typical post. 

### Before (small screen)
https://github.com/bluesky-social/social-app/assets/9456291/3f745d6c-01f2-4b98-ae77-ab1331aece75


### After (small screen)
https://github.com/bluesky-social/social-app/assets/9456291/f43f5712-3442-4da4-a6bb-64f35c893cca


#### Before (large screen)
https://github.com/bluesky-social/social-app/assets/9456291/802b45b4-277b-435c-87be-141d4c826bab


#### After (large screen)
https://github.com/bluesky-social/social-app/assets/9456291/15a83557-7870-4c04-ac07-d2ee7966c235

