### PR TITLE
Allow back navigation to home on profile header (on empty navigation history)

### DIFF
--- a/src/view/com/profile/ProfileHeader.tsx
+++ b/src/view/com/profile/ProfileHeader.tsx
@@ -119,7 +119,11 @@ const ProfileHeaderLoaded = observer(function ProfileHeaderLoadedImpl({
   const [showSuggestedFollows, setShowSuggestedFollows] = React.useState(false)
 
   const onPressBack = React.useCallback(() => {
-    navigation.goBack()
+    if (navigation.canGoBack()) {
+      navigation.goBack()
+    } else {
+      navigation.navigate('Home')
+    }
   }, [navigation])
 
   const onPressAvi = React.useCallback(() => {


### PR DESCRIPTION
![Group 1454](https://github.com/bluesky-social/social-app/assets/9456291/ef3d1adb-9e32-4c0d-82e2-db89968d67a9)

### Problem
The back button on profile header doesn't navigate back to home if there's no navigation history. 

### To reproduce
Navigate directly to a profile on a new tab and click the back button on profile header.

### Proposed fix
We can check if we can go back (there's something to go back to), and if not, go home instead. 

A similar behaviour is currently [implemented here.](https://github.com/bluesky-social/social-app/blob/c6e28f88e5e96453005ff6f11194f3ccf091f4b6/src/view/com/post-thread/PostThread.tsx#L171)