### PR TITLE
Use more beautiful title separator

### DIFF
--- a/src/lib/strings/headings.ts
+++ b/src/lib/strings/headings.ts
@@ -1,4 +1,4 @@
 export function bskyTitle(page: string, unreadCountLabel?: string) {
   const unreadPrefix = unreadCountLabel ? `(${unreadCountLabel}) ` : ''
-  return `${unreadPrefix}${page} - Bluesky`
+  return `${unreadPrefix}${page} — Bluesky`
 }


### PR DESCRIPTION
Bluesky currently uses a [hyphen](https://en.wikipedia.org/wiki/Hyphen) for separating the individual parts of its tab title in the web app:

![2023-10-20 at 19 48 03@2x](https://github.com/bluesky-social/social-app/assets/6170607/122de7db-31b8-41a6-95c6-87d6f7af492f)

As mentioned in the intro of the Wikipedia article above, hyphens are typically used for **connecting multiple words**, and therefore aren't an ideal choice for **separating multiple words** in a tab title.

I replaced the hyphen with a [dash](https://en.wikipedia.org/wiki/Dash), and more specifically an [em dash](https://en.wikipedia.org/wiki/Dash#Em_dash), which, in my opinion, is not only more typographically correct, but also looks much better:

![2023-10-20 at 19 48 28@2x](https://github.com/bluesky-social/social-app/assets/6170607/254b426f-d109-474c-9da9-d8caf3640b5a)

Also happy to add an [en dash](https://en.wikipedia.org/wiki/Dash#En_dash) instead, which is still longer than a hyphen, but shorter than a [em dash](https://en.wikipedia.org/wiki/Dash#Em_dash).