### PR TITLE
Simplify the avatar component

### DIFF
--- a/src/view/com/modals/CreateOrEditMuteList.tsx
+++ b/src/view/com/modals/CreateOrEditMuteList.tsx
@@ -18,7 +18,7 @@ import {ListModel} from 'state/models/content/list'
 import {s, colors, gradients} from 'lib/styles'
 import {enforceLen} from 'lib/strings/helpers'
 import {compressIfNeeded} from 'lib/media/manip'
-import {UserAvatar} from '../util/UserAvatar'
+import {EditableUserAvatar} from '../util/UserAvatar'
 import {usePalette} from 'lib/hooks/usePalette'
 import {useTheme} from 'lib/ThemeContext'
 import {useAnalytics} from 'lib/analytics/analytics'
@@ -148,7 +148,7 @@ export function Component({
         )}
         <Text style={[styles.label, pal.text]}>List Avatar</Text>
         <View style={[styles.avi, {borderColor: pal.colors.background}]}>
-          <UserAvatar
+          <EditableUserAvatar
             type="list"
             size={80}
             avatar={avatar}

--- a/src/view/com/modals/EditProfile.tsx
+++ b/src/view/com/modals/EditProfile.tsx
@@ -20,7 +20,7 @@ import {enforceLen} from 'lib/strings/helpers'
 import {MAX_DISPLAY_NAME, MAX_DESCRIPTION} from 'lib/constants'
 import {compressIfNeeded} from 'lib/media/manip'
 import {UserBanner} from '../util/UserBanner'
-import {UserAvatar} from '../util/UserAvatar'
+import {EditableUserAvatar} from '../util/UserAvatar'
 import {usePalette} from 'lib/hooks/usePalette'
 import {useTheme} from 'lib/ThemeContext'
 import {useAnalytics} from 'lib/analytics/analytics'
@@ -153,7 +153,7 @@ export function Component({
             onSelectNewBanner={onSelectNewBanner}
           />
           <View style={[styles.avi, {borderColor: pal.colors.background}]}>
-            <UserAvatar
+            <EditableUserAvatar
               size={80}
               avatar={userAvatar}
               onSelectNewAvatar={onSelectNewAvatar}

--- a/src/view/com/util/UserAvatar.tsx
+++ b/src/view/com/util/UserAvatar.tsx
@@ -23,18 +23,19 @@ interface BaseUserAvatarProps {
   type?: Type
   size: number
   avatar?: string | null
-  moderation?: ModerationUI
 }
 
 interface UserAvatarProps extends BaseUserAvatarProps {
+  moderation?: ModerationUI
   onSelectNewAvatar?: (img: RNImage | null) => void // TODO: Remove.
 }
 
 interface EditableUserAvatarProps extends BaseUserAvatarProps {
-  onSelectNewAvatar?: (img: RNImage | null) => void // TODO: Make required.
+  onSelectNewAvatar: (img: RNImage | null) => void
 }
 
 interface PreviewableUserAvatarProps extends BaseUserAvatarProps {
+  moderation?: ModerationUI
   did: string
   handle: string
 }
@@ -284,7 +285,6 @@ export function EditableUserAvatar({
   type = 'user',
   size,
   avatar,
-  moderation,
   onSelectNewAvatar,
 }: EditableUserAvatarProps) {
   const store = useStores()
@@ -325,7 +325,7 @@ export function EditableUserAvatar({
               return
             }
 
-            onSelectNewAvatar?.(
+            onSelectNewAvatar(
               await openCamera(store, {
                 width: 1000,
                 height: 1000,
@@ -365,7 +365,7 @@ export function EditableUserAvatar({
               path: item.path,
             })
 
-            onSelectNewAvatar?.(croppedImage)
+            onSelectNewAvatar(croppedImage)
           },
         },
         !!avatar && {
@@ -382,7 +382,7 @@ export function EditableUserAvatar({
             web: 'trash',
           },
           onPress: async () => {
-            onSelectNewAvatar?.(null)
+            onSelectNewAvatar(null)
           },
         },
       ].filter(Boolean) as DropdownItem[],
@@ -395,23 +395,7 @@ export function EditableUserAvatar({
     ],
   )
 
-  const alert = useMemo(() => {
-    if (!moderation?.alert) {
-      return null
-    }
-    return (
-      <View style={[styles.alertIconContainer, pal.view]}>
-        <FontAwesomeIcon
-          icon="exclamation-circle"
-          style={styles.alertIcon}
-          size={Math.floor(size / 3)}
-        />
-      </View>
-    )
-  }, [moderation?.alert, size, pal])
-
-  // onSelectNewAvatar is only passed as prop on the EditProfile component
-  return onSelectNewAvatar ? (
+  return (
     <NativeDropdown
       testID="changeAvatarBtn"
       items={dropdownItems}
@@ -435,23 +419,6 @@ export function EditableUserAvatar({
         />
       </View>
     </NativeDropdown>
-  ) : avatar &&
-    !((moderation?.blur && isAndroid) /* android crashes with blur */) ? (
-    <View style={{width: size, height: size}}>
-      <HighPriorityImage
-        testID="userAvatarImage"
-        style={aviStyle}
-        contentFit="cover"
-        source={{uri: avatar}}
-        blurRadius={moderation?.blur ? BLUR_AMOUNT : 0}
-      />
-      {alert}
-    </View>
-  ) : (
-    <View style={{width: size, height: size}}>
-      <DefaultAvatar type={type} size={size} />
-      {alert}
-    </View>
   )
 }
 

--- a/src/view/com/util/UserAvatar.tsx
+++ b/src/view/com/util/UserAvatar.tsx
@@ -27,7 +27,11 @@ interface BaseUserAvatarProps {
 }
 
 interface UserAvatarProps extends BaseUserAvatarProps {
-  onSelectNewAvatar?: (img: RNImage | null) => void
+  onSelectNewAvatar?: (img: RNImage | null) => void // TODO: Remove.
+}
+
+interface EditableUserAvatarProps extends BaseUserAvatarProps {
+  onSelectNewAvatar?: (img: RNImage | null) => void // TODO: Make required.
 }
 
 interface PreviewableUserAvatarProps extends BaseUserAvatarProps {
@@ -282,7 +286,7 @@ export function EditableUserAvatar({
   avatar,
   moderation,
   onSelectNewAvatar,
-}: UserAvatarProps) {
+}: EditableUserAvatarProps) {
   const store = useStores()
   const pal = usePalette('default')
   const {requestCameraAccessIfNeeded} = useCameraPermission()


### PR DESCRIPTION
We render a lot of avatar components. Especially as you navigate around.

All avatar components currently contain these Hooks:

```js
  const store = useStores()
  const {requestCameraAccessIfNeeded} = useCameraPermission()
  const {requestPhotoAccessIfNeeded} = usePhotoLibraryPermission()
  const dropdownItems = useMemo(
    () =>
    // ...
  )
```

This seems like a bunch of unnecessary overhead since these are only used for editable avatars. And as the comment says, avatars are only editable when `onSelectNewAvatar` is passed. This only happens at two callsites.

I separate the avatar component into two: `UserAvatar` and `EditableUserAvatar`. See individual commits.

I don't expect this to have a noticeable perf effect so this is just a drive-by refactor for simplicity. That said we should generally try to avoid adding a ton of logic to super commonly used leaf components.

## Before

<img width="490" alt="Screenshot 2023-10-25 at 04 22 22" src="https://github.com/bluesky-social/social-app/assets/810438/eceac1a1-f054-4fb4-9165-3bb3a17362c1">

## After

<img width="450" alt="Screenshot 2023-10-25 at 04 23 41" src="https://github.com/bluesky-social/social-app/assets/810438/16ebf486-e890-4d6b-ab13-e8664d0910dc">


## Commits

- https://github.com/bluesky-social/social-app/commit/b538115e7b421f759e36efae042d979bdd8acc13: This creates `EditableUserAvatar` by copypasting `UserAvatar` 1:1.
- 236b9330d8a69335f7b8e112c808885f8789d4ba: We only pass `onSelectNewAvatar` from two places. Make those use our new `EditableUserAvatar`.
- f87bb4e88a376e464b2cdc07a3cd1c939cf645ac: Separate TypeScript definitions for `UserAvatar` and `EditableUserAvatar` props. 
- 8e55fd25d12c39d6be66f36f96f2e9c5c637a3e5: `EditableUserAvatar` always accepts `onSelectNewAvatar`. Make it required. Remove dead code from other branches. This exposes that `moderation` prop is never used in the editable version. Remove its code and move its prop type to the `UserAvatar` type definition to make this clearer.
- https://github.com/bluesky-social/social-app/commit/5689b24ca330ae08c23577c4eea595c2acd145f3: `UserAvatar` now never accepts `onSelectNewAvatar`. Remove it from the type. Prune dead branches. 

## Test Plan

Verified avatars show up. Verified avatar editing UI still shows up and works.

The commits themselves are fairly mechanical.