### PR TITLE
Remove MobX from Link

### DIFF
--- a/src/view/com/util/Link.tsx
+++ b/src/view/com/util/Link.tsx
@@ -1,4 +1,4 @@
-import React, {ComponentProps, useMemo} from 'react'
+import React, {ComponentProps, memo, useMemo} from 'react'
 import {
   Linking,
   GestureResponderEvent,
@@ -49,7 +49,7 @@ interface Props extends ComponentProps<typeof TouchableOpacity> {
   anchorNoUnderline?: boolean
 }
 
-export function Link({
+export const Link = memo(function Link({
   testID,
   style,
   href,
@@ -133,9 +133,9 @@ export function Link({
       {children ? children : <Text>{title || 'link'}</Text>}
     </Com>
   )
-}
+})
 
-export function TextLink({
+export const TextLink = memo(function TextLink({
   testID,
   type = 'md',
   style,
@@ -217,7 +217,7 @@ export function TextLink({
       {text}
     </Text>
   )
-}
+})
 
 /**
  * Only acts as a link on desktop web
@@ -235,7 +235,7 @@ interface DesktopWebTextLinkProps extends TextProps {
   accessibilityHint?: string
   title?: string
 }
-export function DesktopWebTextLink({
+export const DesktopWebTextLink = memo(function DesktopWebTextLink({
   testID,
   type = 'md',
   style,
@@ -274,7 +274,7 @@ export function DesktopWebTextLink({
       {text}
     </Text>
   )
-}
+})
 
 // NOTE
 // we can't use the onPress given by useLinkProps because it will

--- a/src/view/com/util/Link.tsx
+++ b/src/view/com/util/Link.tsx
@@ -1,5 +1,4 @@
 import React, {ComponentProps, useMemo} from 'react'
-import {observer} from 'mobx-react-lite'
 import {
   Linking,
   GestureResponderEvent,
@@ -50,7 +49,7 @@ interface Props extends ComponentProps<typeof TouchableOpacity> {
   anchorNoUnderline?: boolean
 }
 
-export const Link = observer(function Link({
+export function Link({
   testID,
   style,
   href,
@@ -134,9 +133,9 @@ export const Link = observer(function Link({
       {children ? children : <Text>{title || 'link'}</Text>}
     </Com>
   )
-})
+}
 
-export const TextLink = observer(function TextLink({
+export function TextLink({
   testID,
   type = 'md',
   style,
@@ -218,7 +217,7 @@ export const TextLink = observer(function TextLink({
       {text}
     </Text>
   )
-})
+}
 
 /**
  * Only acts as a link on desktop web
@@ -236,7 +235,7 @@ interface DesktopWebTextLinkProps extends TextProps {
   accessibilityHint?: string
   title?: string
 }
-export const DesktopWebTextLink = observer(function DesktopWebTextLink({
+export function DesktopWebTextLink({
   testID,
   type = 'md',
   style,
@@ -275,7 +274,7 @@ export const DesktopWebTextLink = observer(function DesktopWebTextLink({
       {text}
     </Text>
   )
-})
+}
 
 // NOTE
 // we can't use the onPress given by useLinkProps because it will


### PR DESCRIPTION
We should try to keep very commonly used components lightweight. E.g. avoid unnecessary Effects and subscriptions. Especially when they don't really "change" since this influences the init cost.

I don't see a reason for Link components to be MobX observers. They do reference the `store` but only to call `store.shell.openModal` and `store.shell.closeModal` so I don't think they require listening to `store` changes.

## Test plan

Clicked around. Links seem to work.

## Methodology

I set up a small logpoint tracking which observers exist on the page

<img width="500" alt="Screenshot 2023-10-25 at 04 52 57" src="https://github.com/bluesky-social/social-app/assets/810438/015122e4-f47a-4bcd-be9c-e5cf746100f1">

## Before

Feed has ~160 observers:

<img width="500" alt="Screenshot 2023-10-25 at 05 04 06" src="https://github.com/bluesky-social/social-app/assets/810438/5fde2ab9-71ef-4441-8eeb-f9f85a90d172">

## After

Feed has ~100 observers:

<img width="500" alt="Screenshot 2023-10-25 at 05 03 48" src="https://github.com/bluesky-social/social-app/assets/810438/8eec3a5a-bced-406e-95a1-d1703e7fc680">
