### PR TITLE
Fix Obscured Timestamp Tooltip in Notifications Page

### DIFF
--- a/src/view/com/notifications/Feed.tsx
+++ b/src/view/com/notifications/Feed.tsx
@@ -1,7 +1,14 @@
-import React, {MutableRefObject} from 'react'
+import React, {MutableRefObject, PropsWithChildren} from 'react'
 import {observer} from 'mobx-react-lite'
 import {CenteredView, FlatList} from '../util/Views'
-import {ActivityIndicator, RefreshControl, StyleSheet, View} from 'react-native'
+import {
+  ActivityIndicator,
+  RefreshControl,
+  StyleProp,
+  StyleSheet,
+  View,
+  ViewStyle,
+} from 'react-native'
 import {NotificationsFeedModel} from 'state/models/feeds/notifications'
 import {FeedItem} from './FeedItem'
 import {NotificationFeedLoadingPlaceholder} from '../util/LoadingPlaceholder'
@@ -112,6 +119,27 @@ export const Feed = observer(function Feed({
     [onPressRetryLoadMore],
   )
 
+  // Ref: https://github.com/hossein-zare/react-native-dropdown-picker/issues/376#issuecomment-1717443831
+  const renderCell = React.useCallback(
+    ({
+      children,
+      index,
+      style,
+      ...props
+    }: PropsWithChildren<{
+      style: StyleProp<ViewStyle>
+      [key: string]: any
+    }>) => {
+      return (
+        // static value didn't work, somehow using the dynamic index makes it work
+        <View style={[style, {zIndex: -1 * index}]} {...props}>
+          {children}
+        </View>
+      )
+    },
+    [],
+  )
+
   const FeedFooter = React.useCallback(
     () =>
       view.isLoading ? (
@@ -144,6 +172,7 @@ export const Feed = observer(function Feed({
           data={data}
           keyExtractor={item => item._reactKey}
           renderItem={renderItem}
+          CellRendererComponent={renderCell}
           ListHeaderComponent={ListHeaderComponent}
           ListFooterComponent={FeedFooter}
           refreshControl={


### PR DESCRIPTION
This PR addresses an issue observed in the Notifications Page of our Bluesky Web Interface, where the timestamp tooltip was obscured when trying to view it. This behavior diminished the overall user experience, as users had trouble reading the timestamp which is crucial to understand the chronological context of the notification.

Fix: https://github.com/bluesky-social/social-app/issues/1754

## Context

The root of this problem is traced back to an inherent issue with React Native `FlatList` component. Upon further investigation, similar concerns have been discussed widely in the React Native community. For reference, the following are related issues:

- [Issue #376 on hossein-zare/react-native-dropdown-picker](https://github.com/hossein-zare/react-native-dropdown-picker/issues/376)
- [Issue #18616 on facebook/react-native](https://github.com/facebook/react-native/issues/18616)
- [Issue #1903 on necolas/react-native-web](https://github.com/necolas/react-native-web/issues/1903)

## Solution

To resolve this, the PR [includes a workaround](https://github.com/hossein-zare/react-native-dropdown-picker/issues/376#issuecomment-1717443831) of applying a dynamic z-index to the `CellRendererComponent` by using `index` value from `props`.

```
CellRendererComponent={({children, index, style, ...props}) => {
    return (
        <View style={[style, {zIndex: -1 * index}]} index={index} {...props}>
            {children}
        </View>
    );
}}
```

<img width="1179" alt="image" src="https://github.com/bluesky-social/social-app/assets/38807139/b5fccea0-e432-4707-8e0a-e792ae4c51ba">

This change effectively brings the tooltip to the forefront, improving its visibility and thereby enhancing the overall user experience.