### PR TITLE
Enable inline requires

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,7 +1,14 @@
 module.exports = function (api) {
   api.cache(true)
   return {
-    presets: ['babel-preset-expo'],
+    presets: [
+      [
+        'babel-preset-expo',
+        {
+          lazyImports: true,
+        },
+      ],
+    ],
     plugins: [
       [
         'module:react-native-dotenv',

--- a/metro.config.js
+++ b/metro.config.js
@@ -1,7 +1,15 @@
 // Learn more https://docs.expo.io/guides/customizing-metro
 const {getDefaultConfig} = require('expo/metro-config')
 const cfg = getDefaultConfig(__dirname)
+
 cfg.resolver.sourceExts = process.env.RN_SRC_EXT
   ? process.env.RN_SRC_EXT.split(',').concat(cfg.resolver.sourceExts)
   : cfg.resolver.sourceExts
+
+cfg.transformer.getTransformOptions = async () => ({
+  transform: {
+    inlineRequires: true,
+  },
+})
+
 module.exports = cfg


### PR DESCRIPTION
Inline requires are a (technically not entirely safe) optimization that defers module initialization until an export from that module is actually used in the code. For example:

```js
import { foo } from './foo' // DOES NOT trigger ./foo.js initialization

function doSomething() {
  console.log(foo) // TRIGGERS foo.js initialization
}
```

It's enabled in FB apps and is crucial for performance. It's not entirely safe because it relies on modules with exports not having temporal order sensitive global side effects. However, that's best practice anyway.

<s>Not sure if this actually has perf impact for us. Measurements TBD.</s>

Measurements (PROD mid/lower-range Android):

- Logged out start time: 14s -> 9s
- Logged in start time: 16s -> 11s

## TODO

- [x] Check if this applies to default exports too (https://github.com/facebook/metro/issues/909)
- [x] Check that it actually fully works as expected — yes it does
- [x] <s>Check if we should be using `experimentalImportSupport`</s> seems fine?
- [x] <s>Check if we should be using `disableImportExportTransform`</s> seems fine?
- [x] Check that it doesn't break web — it doesn't because it's Metro-only