### PR TITLE
Filter non-self threads from profile view

### DIFF
--- a/src/lib/api/feed/author.ts
+++ b/src/lib/api/feed/author.ts
@@ -35,11 +35,57 @@ export class AuthorFeedAPI implements FeedAPI {
       this.cursor = res.data.cursor
       return {
         cursor: res.data.cursor,
-        feed: res.data.feed,
+        feed: this._filter(res.data.feed),
       }
     }
     return {
       feed: [],
     }
   }
+
+  _filter(feed: AppBskyFeedDefs.FeedViewPost[]) {
+    if (this.params.filter === 'posts_no_replies') {
+      return feed.filter(post => {
+        const isReply = post.reply
+        const isRepost = AppBskyFeedDefs.isReasonRepost(post.reason)
+        if (!isReply) return true
+        if (isRepost) return true
+        return isReply && isAuthorReplyChain(this.params.actor, post, feed)
+      })
+    }
+
+    return feed
+  }
+}
+
+function isAuthorReplyChain(
+  actor: string,
+  post: AppBskyFeedDefs.FeedViewPost,
+  posts: AppBskyFeedDefs.FeedViewPost[],
+): boolean {
+  // current post is by a different user (shouldn't happen)
+  if (post.post.author.handle !== actor) return false
+
+  const replyParent = post.reply?.parent
+
+  if (AppBskyFeedDefs.isPostView(replyParent)) {
+    // reply parent is by a different user
+    if (replyParent.author.handle !== actor) return false
+
+    // A top-level post that matches the parent of the current post.
+    const parentPost = posts.find(p => p.post.uri === replyParent.uri)
+
+    /*
+     * Either we haven't fetched the parent at the top level, or the only
+     * record we have is on feedItem.reply.parent, which we've already checked
+     * above.
+     */
+    if (!parentPost) return true
+
+    // Walk up to parent
+    return isAuthorReplyChain(actor, parentPost, posts)
+  }
+
+  // Just default to showing it
+  return true
 }


### PR DESCRIPTION
Fixes #1166

Frontend component to https://github.com/bluesky-social/atproto/pull/1776. This logic walks the reply chain to ensure that all replies (available on this page of results, anyway) are by the `actor` and in reply to a post by the `actor`.

Example below. See the second image "Posts and replies" for the full picture. "Posts" shows ONLY if those replies that are (1) by the author you're viewing and (2) their reply root is a post by the author you're viewing.

<img width="640" alt="Screenshot 2023-10-26 at 3 11 10 PM" src="https://github.com/bluesky-social/social-app/assets/4732330/a1fffc66-29df-4d12-a74d-ea2f2e58f6fc">
<img width="592" alt="Screenshot 2023-10-26 at 3 11 24 PM" src="https://github.com/bluesky-social/social-app/assets/4732330/6d4771c1-15b1-4dca-929b-5121faca0d67">
