### PR TITLE
[NOT FOR MERGE] Add instrumentation for module init

### DIFF
--- a/patches/metro-runtime+0.76.8.patch
+++ b/patches/metro-runtime+0.76.8.patch
@@ -1,0 +1,27 @@
+diff --git a/node_modules/metro-runtime/src/polyfills/require.js b/node_modules/metro-runtime/src/polyfills/require.js
+index ce67cb4..1a0a6a9 100644
+--- a/node_modules/metro-runtime/src/polyfills/require.js
++++ b/node_modules/metro-runtime/src/polyfills/require.js
+@@ -280,6 +280,7 @@ function registerSegment(segmentId, moduleDefiner, moduleIds) {
+     });
+   }
+ }
++var moduleCount = 0;
+ function loadModuleImplementation(moduleId, module) {
+   if (!module && moduleDefinersBySegmentID.length > 0) {
+     const segmentId = definingSegmentByModuleID.get(moduleId) ?? 0;
+@@ -303,7 +304,13 @@ function loadModuleImplementation(moduleId, module) {
+     throw module.error;
+   }
+   if (__DEV__) {
+-    var Systrace = requireSystrace();
++    var Systrace = {
++      beginEvent(label) {
++        moduleCount++;
++        console.log('MODULE INIT', moduleCount, label)
++      },
++      endEvent() {}
++    };
+     var Refresh = requireRefresh();
+   }
+ 


### PR DESCRIPTION
Would be nice to have some non-intrusive way to check this in under a toggleable flag but for now I'll just hardcode it. This adds instrumentation that logs when a module initializes.

<img width="1023" alt="Screenshot 2023-10-27 at 02 06 43" src="https://github.com/bluesky-social/social-app/assets/810438/5bca4c67-bd58-42ef-88a2-eb7494a5f7d4">

It's interesting that after https://github.com/bluesky-social/social-app/pull/1756, we can see lazy init in action:


https://github.com/bluesky-social/social-app/assets/810438/0d3d8d9d-1af1-43f1-933f-7fccba3e218c

