### PR TITLE
Fix white flash on startup

### DIFF
--- a/src/App.native.tsx
+++ b/src/App.native.tsx
@@ -34,7 +34,6 @@ const App = observer(function AppImpl() {
       setRootStore(store)
       analytics.init(store)
       notifications.init(store)
-      SplashScreen.hideAsync()
       Linking.getInitialURL().then((url: string | null) => {
         if (url) {
           handleLink(url)

--- a/src/Navigation.tsx
+++ b/src/Navigation.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react'
 import {StyleSheet} from 'react-native'
+import * as SplashScreen from 'expo-splash-screen'
 import {observer} from 'mobx-react-lite'
 import {
   NavigationContainer,
@@ -462,6 +463,7 @@ function RoutesContainer({children}: React.PropsWithChildren<{}>) {
       linking={LINKING}
       theme={theme}
       onReady={() => {
+        SplashScreen.hideAsync()
         // Register the navigation container with the Sentry instrumentation (only works on native)
         if (isNative) {
           const routingInstrumentation = getRoutingInstrumentation()

--- a/src/view/shell/index.tsx
+++ b/src/view/shell/index.tsx
@@ -21,7 +21,10 @@ import {usePalette} from 'lib/hooks/usePalette'
 import * as backHandler from 'lib/routes/back-handler'
 import {RoutesContainer, TabsNavigator} from '../../Navigation'
 import {isStateAtTabRoot} from 'lib/routes/helpers'
-import {SafeAreaProvider} from 'react-native-safe-area-context'
+import {
+  SafeAreaProvider,
+  initialWindowMetrics,
+} from 'react-native-safe-area-context'
 import {useOTAUpdate} from 'lib/hooks/useOTAUpdate'
 
 const ShellInner = observer(function ShellInnerImpl() {
@@ -87,7 +90,7 @@ export const Shell: React.FC = observer(function ShellImpl() {
   const pal = usePalette('default')
   const theme = useTheme()
   return (
-    <SafeAreaProvider style={pal.view}>
+    <SafeAreaProvider initialMetrics={initialWindowMetrics} style={pal.view}>
       <View testID="mobileShellView" style={[styles.outerContainer, pal.view]}>
         <StatusBar style={theme.colorScheme === 'dark' ? 'light' : 'dark'} />
         <RoutesContainer>


### PR DESCRIPTION
Two separate problems here.

1. We need to provide `initialMetrics` for the `SafeAreaProvider`. Otherwise the first frame is empty. See [here](https://github.com/th3rdwave/react-native-safe-area-context#optimization).
2. Doing that isn't sufficient though because `NavigationContainer`, [for whatever reason](https://reactnavigation.org/docs/navigation-container/#onready), can't render in a single pass. So wait for `onReady` which, as the docs say, is a good place for "hiding your native splash screen". That's exactly what we're doing.

## Before

https://github.com/bluesky-social/social-app/assets/810438/794e7b57-0f08-4ba8-83fe-0e8b5c630aef

## After

https://github.com/bluesky-social/social-app/assets/810438/302cd600-fb0f-4cdf-988f-f84c18fae31f

## Test Plan

Verified there's no flash on iOS and Android. No behavior changes on web.