### PR TITLE
Remove redundant linking listeners

### DIFF
--- a/src/App.native.tsx
+++ b/src/App.native.tsx
@@ -2,7 +2,6 @@ import 'react-native-url-polyfill/auto'
 import React, {useState, useEffect} from 'react'
 import 'lib/sentry' // must be relatively on top
 import {withSentry} from 'lib/sentry'
-import {Linking} from 'react-native'
 import {RootSiblingParent} from 'react-native-root-siblings'
 import * as SplashScreen from 'expo-splash-screen'
 import {GestureHandlerRootView} from 'react-native-gesture-handler'
@@ -15,7 +14,6 @@ import {Shell} from './view/shell'
 import * as notifications from 'lib/notifications/notifications'
 import * as analytics from 'lib/analytics/analytics'
 import * as Toast from './view/com/util/Toast'
-import {handleLink} from './Navigation'
 import {QueryClientProvider} from '@tanstack/react-query'
 import {queryClient} from 'lib/react-query'
 import {TestCtrls} from 'view/com/testing/TestCtrls'
@@ -34,14 +32,6 @@ const App = observer(function AppImpl() {
       setRootStore(store)
       analytics.init(store)
       notifications.init(store)
-      Linking.getInitialURL().then((url: string | null) => {
-        if (url) {
-          handleLink(url)
-        }
-      })
-      Linking.addEventListener('url', ({url}) => {
-        handleLink(url)
-      })
       store.onSessionDropped(() => {
         Toast.show('Sorry! Your session expired. Please log in again.')
       })


### PR DESCRIPTION
This code was originally added in https://github.com/bluesky-social/social-app/commit/ed146a582c140b9a472298390dafbc07bd06cf60 which predates the move to React Navigation (https://github.com/bluesky-social/social-app/commit/56cf890debeb9872f791ccb992a5587f2c05fd9e).

The guide in https://reactnavigation.org/docs/deep-linking/ does not mention using RN `Linking` directly in the setup guide. It implies React Navigation already integrates with it by default (with ability to [override](https://reactnavigation.org/docs/deep-linking/#third-party-integrations) that).

In particular, [here](https://reactnavigation.org/docs/navigation-container/#linkinggetinitialurl):

>By default, linking integrates with React Native's Linking API and uses Linking.getInitialURL() to provide built-in support for deep linking. [...]

I think this means we can remove this completely.

## Test Plan

Deep links still work. Both for opening the app and for subsequent deep link requests while active.


https://github.com/bluesky-social/social-app/assets/810438/983f0502-3a68-40be-9d22-78edce87b442


https://github.com/bluesky-social/social-app/assets/810438/4b16a2d9-1e32-40a4-9689-07c7175f6b6c

On the web, this file is unused in the first place.