### PR TITLE
UI/UX improvements in Edit profile screen

### DIFF
--- a/src/view/com/modals/EditProfile.tsx
+++ b/src/view/com/modals/EditProfile.tsx
@@ -25,6 +25,10 @@ import {usePalette} from 'lib/hooks/usePalette'
 import {useTheme} from 'lib/ThemeContext'
 import {useAnalytics} from 'lib/analytics/analytics'
 import {cleanError, isNetworkError} from 'lib/strings/errors'
+import Animated, {FadeOut} from 'react-native-reanimated'
+
+const AnimatedTouchableOpacity =
+  Animated.createAnimatedComponent(TouchableOpacity)
 
 export const snapPoints = ['fullscreen']
 
@@ -219,18 +223,21 @@ export function Component({
               </LinearGradient>
             </TouchableOpacity>
           )}
-          <TouchableOpacity
-            testID="editProfileCancelBtn"
-            style={s.mt5}
-            onPress={onPressCancel}
-            accessibilityRole="button"
-            accessibilityLabel="Cancel profile editing"
-            accessibilityHint=""
-            onAccessibilityEscape={onPressCancel}>
-            <View style={[styles.btn]}>
-              <Text style={[s.black, s.bold, pal.text]}>Cancel</Text>
-            </View>
-          </TouchableOpacity>
+          {!isProcessing && (
+            <AnimatedTouchableOpacity
+              exiting={FadeOut}
+              testID="editProfileCancelBtn"
+              style={s.mt5}
+              onPress={onPressCancel}
+              accessibilityRole="button"
+              accessibilityLabel="Cancel profile editing"
+              accessibilityHint=""
+              onAccessibilityEscape={onPressCancel}>
+              <View style={[styles.btn]}>
+                <Text style={[s.black, s.bold, pal.text]}>Cancel</Text>
+              </View>
+            </AnimatedTouchableOpacity>
+          )}
         </View>
       </ScrollView>
     </KeyboardAvoidingView>

--- a/src/view/com/modals/EditProfile.tsx
+++ b/src/view/com/modals/EditProfile.tsx
@@ -26,6 +26,7 @@ import {useTheme} from 'lib/ThemeContext'
 import {useAnalytics} from 'lib/analytics/analytics'
 import {cleanError, isNetworkError} from 'lib/strings/errors'
 import Animated, {FadeOut} from 'react-native-reanimated'
+import {isWeb} from 'platform/detection'
 
 const AnimatedTouchableOpacity =
   Animated.createAnimatedComponent(TouchableOpacity)
@@ -225,7 +226,7 @@ export function Component({
           )}
           {!isProcessing && (
             <AnimatedTouchableOpacity
-              exiting={FadeOut}
+              exiting={!isWeb ? FadeOut : undefined}
               testID="editProfileCancelBtn"
               style={s.mt5}
               onPress={onPressCancel}

--- a/src/view/com/modals/EditProfile.tsx
+++ b/src/view/com/modals/EditProfile.tsx
@@ -144,7 +144,7 @@ export function Component({
   ])
 
   return (
-    <KeyboardAvoidingView behavior="height">
+    <KeyboardAvoidingView style={s.flex1} behavior="height">
       <ScrollView style={[pal.view]} testID="editProfileModal">
         <Text style={[styles.title, pal.text]}>Edit my profile</Text>
         <View style={styles.photos}>


### PR DESCRIPTION
## Issues
- When user scrolls `EditProfile` screen to the bottom direction, there will be a cropped area as can be seen in the video below: 

https://github.com/bluesky-social/social-app/assets/61876765/95e28716-6503-4dac-8a1e-33a9af3e6e3b

- User is able to press cancel when there is an ongoing save process in `EditProfile` screen.


https://github.com/bluesky-social/social-app/assets/61876765/d6270217-b217-4cda-8633-de3b3834c059



## Fixes
- Adding `flex:1` to `KeyboardAvoidingView` component. There will not be any cropped area at the bottom of the screen.

https://github.com/bluesky-social/social-app/assets/61876765/f5d5f457-81f1-45cd-9f94-5cf89e8953cc


- We can hide the `Cancel` button in `EditProfile` screen when there is an ongoing process. Alternatively, we can utilize `react-native-reanimated`'s `FadeOut` animation for native platform. Since, [`react-native-reanimated` is not configured for web yet](https://docs.swmansion.com/react-native-reanimated/docs/2.x/fundamentals/web-support/).


https://github.com/bluesky-social/social-app/assets/61876765/956579c0-d5b9-4625-8e00-35e8688b12fe



