### PR TITLE
Don't compile Hermes-supported features with Babel

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -8,6 +8,9 @@ module.exports = function (api) {
         {
           lazyImports: true,
           native: {
+            // We should be able to remove this after upgrading Expo
+            // to a version that includes https://github.com/expo/expo/pull/24672.
+            unstable_transformProfile: 'hermes-stable',
             // Disable ESM -> CJS compilation because Metro takes care of it.
             // However, we need it in Jest tests since those run without Metro.
             disableImportExportTransform: !isTestEnv,

--- a/patches/babel-preset-expo+9.5.2.patch
+++ b/patches/babel-preset-expo+9.5.2.patch
@@ -1,0 +1,14 @@
+diff --git a/node_modules/babel-preset-expo/index.js b/node_modules/babel-preset-expo/index.js
+index 2099ee3..2b9e092 100644
+--- a/node_modules/babel-preset-expo/index.js
++++ b/node_modules/babel-preset-expo/index.js
+@@ -105,7 +105,8 @@ module.exports = function (api, options = {}) {
+       ],
+     ],
+     plugins: [
+-      getObjectRestSpreadPlugin(),
++      // - dan: This will be disabled anyway when we upgrade Expo, but let's do it now.
++      // getObjectRestSpreadPlugin(),
+       ...extraPlugins,
+       getAliasPlugin(),
+       [require.resolve('@babel/plugin-proposal-decorators'), { legacy: true }],


### PR DESCRIPTION
This simplifies the generated code to be closer to the code we actually write.

Concretely:

- Hermes already supports a bunch of features that we're currently compiling with Babel. Pass an option to target the subset needed by Hermes specifically, and let Hermes handle the rest.
- Although Hermes supports object spread, the Expo preset adds it back. Explicitly patch the Expo preset to disable it.

We will be able to remove both of these overrides when we upgrade Expo:

- The transform profile is being [auto-detected](https://github.com/expo/expo/blob/8156a6ff57353fc50f02537d0b6aefd1033c9f29/packages/babel-preset-expo/src/index.ts#L55) now.
- The object spread plugin is [conditional](https://github.com/expo/expo/blob/8156a6ff57353fc50f02537d0b6aefd1033c9f29/packages/babel-preset-expo/src/index.ts#L65) now.

However, I don't know when we'll get to updating, so why not fix this now.

## Test plan

Walked around the app. App seems to work. Equivalent changes being in newer Expo releases give some confidence.

## Bundle output changes

Glance over the bundle diff.

Function names are now implied (since Hermes can do this):

<img width="783" alt="Screenshot 2023-10-30 at 23 49 46" src="https://github.com/bluesky-social/social-app/assets/810438/2b9b059c-950a-4577-90b8-3880c3a6e1ed">

Native support for `??` and `?.` and friends:

<img width="865" alt="Screenshot 2023-10-30 at 23 50 00" src="https://github.com/bluesky-social/social-app/assets/810438/cd889048-518c-49cc-8d8f-9d9d3fb8014e">

No runtime code needed for rest/spread:

<img width="779" alt="Screenshot 2023-10-30 at 23 49 51" src="https://github.com/bluesky-social/social-app/assets/810438/f6c78c33-15a0-48a0-a29c-052542d732be">

Also, we finally get rid of this `_objectSpread` helper:

<img width="720" alt="Screenshot 2023-10-30 at 23 52 35" src="https://github.com/bluesky-social/social-app/assets/810438/7cc82e11-cda6-4b61-9e08-c1a862e3b770">

Fun fact: this `_objectSpread` helper was duplicated in our bundle almost three thousand times.

Total minified PROD bundle went down from 8.9 MB to 8.6 MB.

Spreads in particular are very common so having them go through fewer indirections is nice.