### PR TITLE
Don't inline-require Babel runtime helpers

### DIFF
--- a/patches/babel-preset-fbjs+3.4.0.patch
+++ b/patches/babel-preset-fbjs+3.4.0.patch
@@ -1,0 +1,12 @@
+diff --git a/node_modules/babel-preset-fbjs/plugins/inline-requires.js b/node_modules/babel-preset-fbjs/plugins/inline-requires.js
+index b11fc83..e18661a 100644
+--- a/node_modules/babel-preset-fbjs/plugins/inline-requires.js
++++ b/node_modules/babel-preset-fbjs/plugins/inline-requires.js
+@@ -256,6 +256,7 @@ function getInlineableModule(path, state) {
+ 
+   return moduleName == null ||
+     state.ignoredRequires.has(moduleName) ||
++    moduleName.startsWith('@babel/runtime/') ||
+     isRequireInScope
+     ? null
+     : { moduleName, requireFnName: fnName };


### PR DESCRIPTION
There's no benefit to treating Babel runtime helpers as lazy. With this change, we go back to eagerly importing them:

<img width="1114" alt="Screenshot 2023-10-31 at 00 50 14" src="https://github.com/bluesky-social/social-app/assets/810438/dc866ad9-7937-406d-a923-5676f913844b">

I sent a corresponding change upstream in https://github.com/facebook/metro/pull/1127.

If that PR doesn't survive, we can get rid of this patch. It's not super consequential in either direction but I want to remove these indirections from the render path since there's currently a lot of places where Babel generates calls to them.

## Test plan

Walked around the app. It works.