### PR TITLE
Log time to first paint

### DIFF
--- a/src/Navigation.tsx
+++ b/src/Navigation.tsx
@@ -467,6 +467,11 @@ function RoutesContainer({children}: React.PropsWithChildren<{}>) {
       theme={theme}
       onReady={() => {
         SplashScreen.hideAsync()
+        const initMs = Math.round(
+          performance.now() - global.__BUNDLE_START_TIME__,
+        )
+        console.log(`Time to first paint: ${initMs} ms`)
+
         // Register the navigation container with the Sentry instrumentation (only works on native)
         if (isNative) {
           const routingInstrumentation = getRoutingInstrumentation()

--- a/src/Navigation.tsx
+++ b/src/Navigation.tsx
@@ -468,6 +468,7 @@ function RoutesContainer({children}: React.PropsWithChildren<{}>) {
       onReady={() => {
         SplashScreen.hideAsync()
         const initMs = Math.round(
+          // @ts-ignore Emitted by Metro in the bundle prelude
           performance.now() - global.__BUNDLE_START_TIME__,
         )
         console.log(`Time to first paint: ${initMs} ms`)


### PR DESCRIPTION
The bundle produced by Metro always starts with capturing `__BUNDLE_START_TIME__`, so let's use this as the starting point. Then, let's use the moment we call `SplashScreen.hideAsync` as the end point. This gives us the actionable JS init time during which we're showing the splash screen. This is the time we can drive down by shifting and reducing module init code.

I opted to use `console.log` for simplicity, e.g. having dependency on the `store` or MobX-using `Log` doesn't feel right to me here since both of these might eventually get shifted down from the init path.

Note that to use this for production profiling, you still have to comment out the `transform-remove-console` in Babel config. That seems fair. Although we could evade the console call detection, I don't want to risk in case calling it does have a nontrivial cost on lower end devices. (I don't know.)

On logged out Android, this currently gives me 3755 ms. The actual time measured from first SoLoader log is 4460ms so there's ~700ms unactionable delay before JS bundle starts running (probably native initialization + JS parsing).