### PR TITLE
Eric/app 745 handle custom feed failure cases

### DIFF
--- a/src/lib/hooks/useCustomFeed.ts
+++ b/src/lib/hooks/useCustomFeed.ts
@@ -7,11 +7,16 @@ export function useCustomFeed(uri: string): CustomFeedModel | undefined {
   const [item, setItem] = useState<CustomFeedModel | undefined>()
   useEffect(() => {
     async function fetchView() {
-      const res = await store.agent.app.bsky.feed.getFeedGenerator({
-        feed: uri,
-      })
-      const view = res.data.view
-      return view
+      try {
+        const res = await store.agent.app.bsky.feed.getFeedGenerator({
+          feed: uri,
+        })
+        const view = res.data.view
+        return view
+      } catch (e) {
+        store.log.error('useCustomFeed failed to getFeedGenerator', e)
+        return undefined
+      }
     }
     async function buildFeedItem() {
       const view = await fetchView()

--- a/src/lib/strings/errors.ts
+++ b/src/lib/strings/errors.ts
@@ -22,6 +22,7 @@ export function isNetworkError(e: unknown) {
   return (
     str.includes('Abort') ||
     str.includes('Network request failed') ||
-    str.includes('Failed to fetch')
+    str.includes('Failed to fetch') ||
+    str.includes('NetworkError when attempting to fetch resource')
   )
 }

--- a/src/state/models/feeds/posts.ts
+++ b/src/state/models/feeds/posts.ts
@@ -298,7 +298,7 @@ export class PostsFeedModel {
     this.isBlocking = error instanceof GetAuthorFeed.BlockedActorError
     this.isBlockedBy = error instanceof GetAuthorFeed.BlockedByActorError
     this.error = cleanError(error)
-    this.loadMoreError = cleanError(loadMoreError) // TODO
+    this.loadMoreError = cleanError(loadMoreError)
     this.cleanError = this.error ? this._cleanError(this.error) : undefined
     if (error) {
       this.rootStore.log.error('Posts feed request failed', error)

--- a/src/view/com/feeds/CustomFeedContextMenu.tsx
+++ b/src/view/com/feeds/CustomFeedContextMenu.tsx
@@ -1,0 +1,168 @@
+import React from 'react'
+import {useNavigation} from '@react-navigation/native'
+import {AtUri} from '@atproto/api'
+
+import {Haptics} from 'lib/haptics'
+import {NativeDropdown, DropdownItem} from 'view/com/util/forms/NativeDropdown'
+import {CustomFeedModel} from 'state/models/feeds/custom-feed'
+import {useStores} from 'state/index'
+import {NavigationProp} from 'lib/routes/types'
+import {toShareUrl} from 'lib/strings/url-helpers'
+import {shareUrl} from 'lib/sharing'
+import {useAnalytics} from 'lib/analytics/analytics'
+import * as Toast from 'view/com/util/Toast'
+
+export function CustomFeedContextMenu({
+  children,
+  feed,
+  ...rest
+}: React.PropsWithChildren<
+  {feed: CustomFeedModel} & Omit<
+    React.ComponentProps<typeof NativeDropdown>,
+    'items'
+  >
+>) {
+  const store = useStores()
+  const navigation = useNavigation<NavigationProp>()
+  const handleOrDid = feed?.data?.creator?.handle || feed?.data?.creator?.did
+  const {track} = useAnalytics()
+
+  const onPressAbout = React.useCallback(() => {
+    store.shell.openModal({
+      name: 'confirm',
+      title: feed?.displayName || '',
+      message: feed?.data.description || 'This feed has no description.',
+      confirmBtnText: 'Close',
+      onPressConfirm() {},
+    })
+  }, [store, feed])
+
+  const onPressViewAuthor = React.useCallback(() => {
+    navigation.navigate('Profile', {name: handleOrDid})
+  }, [handleOrDid, navigation])
+
+  const onPressShare = React.useCallback(() => {
+    const {rkey} = new AtUri(feed.uri)
+    const url = toShareUrl(`/profile/${handleOrDid}/feed/${rkey}`)
+    shareUrl(url)
+    track('CustomFeed:Share')
+  }, [feed.uri, handleOrDid, track])
+
+  const onPressReport = React.useCallback(() => {
+    if (!feed) return
+    store.shell.openModal({
+      name: 'report',
+      uri: feed.uri,
+      cid: feed.data.cid,
+    })
+  }, [store, feed])
+
+  const onToggleSaved = React.useCallback(async () => {
+    try {
+      Haptics.default()
+      if (feed?.isSaved) {
+        await feed?.unsave()
+      } else {
+        await feed?.save()
+      }
+    } catch (err) {
+      Toast.show(
+        'There was an an issue updating your feeds, please check your internet connection and try again.',
+      )
+      store.log.error('Failed up update feeds', {err})
+    }
+  }, [store, feed])
+
+  const dropdownItems: DropdownItem[] = React.useMemo(() => {
+    return [
+      feed
+        ? {
+            testID: 'feedHeaderDropdownAboutBtn',
+            label: 'About this feed',
+            onPress: onPressAbout,
+            icon: {
+              ios: {
+                name: 'info.circle',
+              },
+              android: '',
+              web: 'info',
+            },
+          }
+        : undefined,
+      {
+        testID: 'feedHeaderDropdownViewAuthorBtn',
+        label: 'View author',
+        onPress: onPressViewAuthor,
+        icon: {
+          ios: {
+            name: 'person',
+          },
+          android: '',
+          web: ['far', 'user'],
+        },
+      },
+      {
+        testID: 'feedHeaderDropdownToggleSavedBtn',
+        label: feed?.isSaved ? 'Remove from my feeds' : 'Add to my feeds',
+        onPress: onToggleSaved,
+        icon: feed?.isSaved
+          ? {
+              ios: {
+                name: 'trash',
+              },
+              android: 'ic_delete',
+              web: 'trash',
+            }
+          : {
+              ios: {
+                name: 'plus',
+              },
+              android: '',
+              web: 'plus',
+            },
+      },
+      {
+        testID: 'feedHeaderDropdownReportBtn',
+        label: 'Report feed',
+        onPress: onPressReport,
+        icon: {
+          ios: {
+            name: 'exclamationmark.triangle',
+          },
+          android: 'ic_menu_report_image',
+          web: 'circle-exclamation',
+        },
+      },
+      {
+        testID: 'feedHeaderDropdownShareBtn',
+        label: 'Share link',
+        onPress: onPressShare,
+        icon: {
+          ios: {
+            name: 'square.and.arrow.up',
+          },
+          android: 'ic_menu_share',
+          web: 'share',
+        },
+      },
+    ].filter(Boolean) as DropdownItem[]
+  }, [
+    feed,
+    onPressAbout,
+    onToggleSaved,
+    onPressReport,
+    onPressShare,
+    onPressViewAuthor,
+  ])
+
+  return (
+    <NativeDropdown
+      testID="feedHeaderDropdownBtn"
+      items={dropdownItems}
+      accessibilityLabel="More options"
+      accessibilityHint=""
+      {...rest}>
+      {children}
+    </NativeDropdown>
+  )
+}

--- a/src/view/com/posts/Feed.tsx
+++ b/src/view/com/posts/Feed.tsx
@@ -8,10 +8,15 @@ import {
   View,
   ViewStyle,
 } from 'react-native'
+import {FontAwesomeIcon} from '@fortawesome/react-native-fontawesome'
+import {AtUri, AppBskyFeedGetFeed} from '@atproto/api'
+
+import {toShareUrl} from 'lib/strings/url-helpers'
+import {useWebMediaQueries} from 'lib/hooks/useWebMediaQueries'
+import {useCustomFeed} from 'lib/hooks/useCustomFeed'
 import {FlatList} from '../util/Views'
 import {PostFeedLoadingPlaceholder} from '../util/LoadingPlaceholder'
-import {ErrorMessage} from '../util/error/ErrorMessage'
-import {PostsFeedModel} from 'state/models/feeds/posts'
+import {PostsFeedModel, PostsFeedModelError} from 'state/models/feeds/posts'
 import {FeedSlice} from './FeedSlice'
 import {LoadMoreRetryBtn} from '../util/LoadMoreRetryBtn'
 import {OnScrollCb} from 'lib/hooks/useOnMainScroll'
@@ -19,11 +24,18 @@ import {s} from 'lib/styles'
 import {useAnalytics} from 'lib/analytics/analytics'
 import {usePalette} from 'lib/hooks/usePalette'
 import {useTheme} from 'lib/ThemeContext'
+import {Text} from 'view/com/util/text/Text'
+import {TextLink} from '../util/Link'
+import {makeRecordUri} from 'lib/strings/url-helpers'
+import {Button} from 'view/com/util/forms/Button'
+import {CustomFeedContextMenu} from 'view/com/feeds/CustomFeedContextMenu'
 
 const LOADING_ITEM = {_reactKey: '__loading__'}
 const EMPTY_FEED_ITEM = {_reactKey: '__empty__'}
 const ERROR_ITEM = {_reactKey: '__error__'}
 const LOAD_MORE_ERROR_ITEM = {_reactKey: '__load_more_error__'}
+const FEED_INNER_HEADER = {_reactKey: '__feedInnerHeader__'}
+const FEED_INNER_HEADER_LOADING = {_reactKey: '__feedInnerHeaderLoading__'}
 
 export const Feed = observer(function Feed({
   feed,
@@ -38,6 +50,7 @@ export const Feed = observer(function Feed({
   headerOffset = 0,
   ListHeaderComponent,
   extraData,
+  showFeedHeaderContextMenu,
 }: {
   feed: PostsFeedModel
   style?: StyleProp<ViewStyle>
@@ -51,16 +64,23 @@ export const Feed = observer(function Feed({
   headerOffset?: number
   ListHeaderComponent?: () => JSX.Element
   extraData?: any
+  showFeedHeaderContextMenu?: boolean
 }) {
   const pal = usePalette('default')
   const theme = useTheme()
   const {track} = useAnalytics()
   const [isRefreshing, setIsRefreshing] = React.useState(false)
+  const params = feed.params as AppBskyFeedGetFeed.QueryParams
+  const isCustomFeed = Boolean(params.feed)
 
   const data = React.useMemo(() => {
     let feedItems: any[] = []
     if (feed.hasLoaded) {
-      if (feed.hasError) {
+      if (isCustomFeed) {
+        feedItems.push(FEED_INNER_HEADER)
+      }
+      if (feed.hasError && !isCustomFeed) {
+        // applies to our internal algo feeds only
         feedItems = feedItems.concat([ERROR_ITEM])
       }
       if (feed.isEmpty) {
@@ -79,6 +99,7 @@ export const Feed = observer(function Feed({
     feed.isEmpty,
     feed.slices,
     feed.loadMoreError,
+    isCustomFeed,
   ])
 
   // events
@@ -115,15 +136,20 @@ export const Feed = observer(function Feed({
 
   const renderItem = React.useCallback(
     ({item}: {item: any}) => {
-      if (item === EMPTY_FEED_ITEM) {
-        return renderEmptyState()
-      } else if (item === ERROR_ITEM) {
+      if (item === FEED_INNER_HEADER_LOADING) {
+        return <FeedHeaderLoading />
+      } else if (item === FEED_INNER_HEADER) {
         return (
-          <ErrorMessage
-            message={feed.error}
-            onPressTryAgain={onPressTryAgain}
+          <FeedInnerHeader
+            showContextMenu={showFeedHeaderContextMenu}
+            error={feed.cleanError}
+            params={params}
           />
         )
+      } else if (item === EMPTY_FEED_ITEM) {
+        return renderEmptyState()
+      } else if (item === ERROR_ITEM) {
+        return <ErrorMessage feed={feed} onPress={onPressTryAgain} />
       } else if (item === LOAD_MORE_ERROR_ITEM) {
         return (
           <LoadMoreRetryBtn
@@ -136,7 +162,14 @@ export const Feed = observer(function Feed({
       }
       return <FeedSlice slice={item} />
     },
-    [feed, onPressTryAgain, onPressRetryLoadMore, renderEmptyState],
+    [
+      feed,
+      params,
+      showFeedHeaderContextMenu,
+      onPressTryAgain,
+      onPressRetryLoadMore,
+      renderEmptyState,
+    ],
   )
 
   const FeedFooter = React.useCallback(
@@ -158,7 +191,13 @@ export const Feed = observer(function Feed({
       <FlatList
         testID={testID ? `${testID}-flatlist` : undefined}
         ref={scrollElRef}
-        data={!feed.hasLoaded ? [LOADING_ITEM] : data}
+        data={
+          !feed.hasLoaded
+            ? isCustomFeed
+              ? [FEED_INNER_HEADER_LOADING, LOADING_ITEM]
+              : [LOADING_ITEM]
+            : data
+        }
         keyExtractor={item => item._reactKey}
         renderItem={renderItem}
         ListFooterComponent={FeedFooter}
@@ -188,6 +227,142 @@ export const Feed = observer(function Feed({
     </View>
   )
 })
+
+function ErrorMessage({
+  feed,
+  onPress,
+}: {
+  feed: PostsFeedModel
+  onPress?: () => void
+}) {
+  const pal = usePalette('default')
+  return (
+    <View
+      style={[
+        pal.viewLight,
+        {
+          flexDirection: 'row',
+          alignItems: 'flex-start',
+          paddingHorizontal: 18,
+          paddingVertical: 12,
+        },
+      ]}>
+      <Text style={{paddingRight: 18}}>
+        {feed.cleanError?.message || feed.error}
+      </Text>
+      <Button type="default-light" onPress={onPress}>
+        Try again
+      </Button>
+    </View>
+  )
+}
+
+function FeedHeaderLoading() {
+  const pal = usePalette('default')
+  return (
+    <View
+      style={[
+        pal.viewLight,
+        {
+          width: '100%',
+          paddingHorizontal: 18,
+          paddingVertical: 18,
+        },
+      ]}
+    />
+  )
+}
+
+function FeedInnerHeader({
+  error,
+  params,
+  showContextMenu = true,
+}: {
+  error?: PostsFeedModelError
+  params: AppBskyFeedGetFeed.QueryParams
+  showContextMenu?: boolean
+}) {
+  const pal = usePalette('default')
+  const {host, rkey} = new AtUri(params.feed)
+  const uri = makeRecordUri(host, 'app.bsky.feed.generator', rkey)
+  const feed = useCustomFeed(uri)
+  const author = feed?.data?.creator?.handle
+  const {isDesktop} = useWebMediaQueries()
+  const shareUrl = toShareUrl(`/profile/${host}`)
+
+  return (
+    <View
+      style={[
+        pal.viewLight,
+        {
+          width: '100%',
+          paddingHorizontal: 18,
+        },
+      ]}>
+      <View
+        style={{
+          flexDirection: 'row',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          paddingVertical: 8,
+        }}>
+        <Text>
+          <Text style={[pal.textLight]}>By&nbsp;</Text>
+          {author ? (
+            <TextLink href={shareUrl} text={'@' + author} />
+          ) : (
+            <Text style={[pal.textLight]}>...</Text>
+          )}
+        </Text>
+
+        {author && showContextMenu && !isDesktop ? (
+          <CustomFeedContextMenu feed={feed}>
+            <View
+              style={{
+                height: 24,
+                width: 24,
+                paddingTop: 1,
+                borderRadius: 24,
+                backgroundColor: pal.view.backgroundColor,
+                justifyContent: 'center',
+                alignItems: 'center',
+              }}>
+              <FontAwesomeIcon
+                icon="ellipsis"
+                size={18}
+                color={pal.colors.textLight}
+              />
+            </View>
+          </CustomFeedContextMenu>
+        ) : (
+          <View style={{height: 24}} />
+        )}
+      </View>
+
+      {error?.message && (
+        <>
+          <View style={[pal.view, {height: 1}]} />
+
+          <View
+            style={{
+              flexDirection: 'row',
+              flexWrap: 'wrap',
+              justifyContent: 'flex-end',
+              paddingVertical: 12,
+            }}>
+            <Text style={{width: '100%'}}>{error.message}</Text>
+
+            {error.type === 'upstream' ? (
+              <Button type="default-light" style={{marginTop: 12}}>
+                Remove from my feeds
+              </Button>
+            ) : null}
+          </View>
+        </>
+      )}
+    </View>
+  )
+}
 
 const styles = StyleSheet.create({
   feedFooter: {paddingTop: 20},

--- a/src/view/com/posts/Feed.tsx
+++ b/src/view/com/posts/Feed.tsx
@@ -250,7 +250,11 @@ function ErrorMessage({
       <Text style={{paddingRight: 18}}>
         {feed.cleanError?.message || feed.error}
       </Text>
-      <Button type="default-light" onPress={onPress}>
+      <Button
+        type="default-light"
+        onPress={onPress}
+        accessibilityLabel="Retry"
+        accessibilityHint="Retries the last action, which errored out">
         Try again
       </Button>
     </View>
@@ -353,7 +357,11 @@ function FeedInnerHeader({
             <Text style={{width: '100%'}}>{error.message}</Text>
 
             {error.type === 'upstream' ? (
-              <Button type="default-light" style={{marginTop: 12}}>
+              <Button
+                type="default-light"
+                style={{marginTop: 12}}
+                accessibilityLabel="Remove from my feeds"
+                accessibilityHint="Un-pin and remove this feed from your home screen feeds.">
                 Remove from my feeds
               </Button>
             ) : null}

--- a/src/view/screens/CustomFeed.tsx
+++ b/src/view/screens/CustomFeed.tsx
@@ -209,12 +209,8 @@ export const CustomFeedScreenInner = observer(
     }, [store, onSoftReset, isScreenFocused])
 
     const renderEmptyState = React.useCallback(() => {
-      return (
-        <View style={[pal.border, {borderTopWidth: 1, paddingTop: 20}]}>
-          <EmptyState icon="feed" message="This feed is empty!" />
-        </View>
-      )
-    }, [pal.border])
+      return <EmptyState icon="feed" message="This feed is empty!" />
+    }, [])
 
     return (
       <View style={s.hContentRegion}>


### PR DESCRIPTION
Adds an "inner" header to custom feeds that showcases the author and provides a context menu in places there wasn't one before. Also revises how errors are rendered in these cases.

https://github.com/bluesky-social/social-app/assets/4732330/2b803a74-5da9-47d1-a903-3f6e6591f8b8

<img width="1592" alt="Screenshot 2023-10-31 at 1 50 38 PM" src="https://github.com/bluesky-social/social-app/assets/4732330/31c5c48f-aee5-44d2-9cfb-57387d0eb643">
<img width="1338" alt="Screenshot 2023-10-31 at 1 56 25 PM" src="https://github.com/bluesky-social/social-app/assets/4732330/b426bb51-a788-4081-a0e4-32152229aa34">
<img width="1576" alt="Screenshot 2023-10-31 at 1 56 41 PM" src="https://github.com/bluesky-social/social-app/assets/4732330/eb693ac2-d4a9-4b94-8080-f65d7a40e81f">
<img width="1576" alt="Screenshot 2023-10-31 at 1 57 47 PM" src="https://github.com/bluesky-social/social-app/assets/4732330/f17364fa-3999-4c69-83f3-7a8d25a4c3eb">
