### PR TITLE
Instrument module init in DEV

### DIFF
--- a/patches/metro-runtime+0.76.8.patch
+++ b/patches/metro-runtime+0.76.8.patch
@@ -1,0 +1,50 @@
+diff --git a/node_modules/metro-runtime/src/polyfills/require.js b/node_modules/metro-runtime/src/polyfills/require.js
+index ce67cb4..eeeae84 100644
+--- a/node_modules/metro-runtime/src/polyfills/require.js
++++ b/node_modules/metro-runtime/src/polyfills/require.js
+@@ -22,6 +22,13 @@ global.__c = clear;
+ global.__registerSegment = registerSegment;
+ var modules = clear();
+ 
++if (__DEV__) {
++  // Added by Dan for module init logging.
++  global.__INIT_LOGS__ = []
++  var initModuleCounter = 0
++  var initModuleStack = []
++}
++
+ // Don't use a Symbol here, it would pull in an extra polyfill with all sorts of
+ // additional stuff (e.g. Array.from).
+ const EMPTY = {};
+@@ -303,7 +310,30 @@ function loadModuleImplementation(moduleId, module) {
+     throw module.error;
+   }
+   if (__DEV__) {
+-    var Systrace = requireSystrace();
++    // Added by Dan for module init logging.
++    var Systrace = {
++      beginEvent(label) {
++        let fullLabel = initModuleCounter++ + ' ' + label
++        global.__INIT_LOGS__.push(
++          ' '.repeat(initModuleStack.length) +
++          ' ENTER ' + fullLabel
++        )
++        initModuleStack.push({
++          fullLabel,
++          startTime: nativePerformanceNow(),
++        })
++      },
++      endEvent() {
++        const res = initModuleStack.pop()
++        const fullLabel = res.fullLabel
++        const startTime = res.startTime
++        const timeElapsed = Math.round(nativePerformanceNow() - startTime)
++        global.__INIT_LOGS__.push(
++          ' '.repeat(initModuleStack.length) +
++            ' LEAVE ' + fullLabel + ' [' + timeElapsed + 'ms]',
++        )
++      }
++    };
+     var Refresh = requireRefresh();
+   }
+ 

--- a/src/Navigation.tsx
+++ b/src/Navigation.tsx
@@ -472,6 +472,7 @@ function RoutesContainer({children}: React.PropsWithChildren<{}>) {
           performance.now() - global.__BUNDLE_START_TIME__,
         )
         console.log(`Time to first paint: ${initMs} ms`)
+        logModuleInitTrace()
 
         // Register the navigation container with the Sentry instrumentation (only works on native)
         if (isNative) {
@@ -585,6 +586,18 @@ const styles = StyleSheet.create({
     backgroundColor: colors.white,
   },
 })
+
+function logModuleInitTrace() {
+  if (__DEV__) {
+    // This log is noisy, so keep false committed
+    const shouldLog = false
+    // Relies on our patch to polyfill.js in metro-runtime
+    const initLogs = (global as any).__INIT_LOGS__
+    if (shouldLog && Array.isArray(initLogs)) {
+      console.log(initLogs.join('\n'))
+    }
+  }
+}
 
 export {
   navigate,


### PR DESCRIPTION
I end up hacking ad-hoc versions of this into the build all the time so let's just add it as a DEV-only patch. That Metro file barely ever changes so it shouldn't be a burden.

## Test plan

Change `shouldLog` to `true` locally. Observe the output:

<img width="929" alt="Screenshot 2023-11-01 at 13 39 26" src="https://github.com/bluesky-social/social-app/assets/810438/2c1b4505-bb98-44b3-9d38-79cad5b18283">
