### PR TITLE
Improve feeds page load time

### DIFF
--- a/src/state/models/me.ts
+++ b/src/state/models/me.ts
@@ -6,6 +6,7 @@ import {
 import {RootStoreModel} from './root-store'
 import {PostsFeedModel} from './feeds/posts'
 import {NotificationsFeedModel} from './feeds/notifications'
+import {MyFeedsUIModel} from './ui/my-feeds'
 import {MyFollowsCache} from './cache/my-follows'
 import {isObj, hasProp} from 'lib/type-guards'
 
@@ -22,6 +23,7 @@ export class MeModel {
   followersCount: number | undefined
   mainFeed: PostsFeedModel
   notifications: NotificationsFeedModel
+  myFeeds: MyFeedsUIModel
   follows: MyFollowsCache
   invites: ComAtprotoServerDefs.InviteCode[] = []
   appPasswords: ComAtprotoServerListAppPasswords.AppPassword[] = []
@@ -42,12 +44,14 @@ export class MeModel {
       algorithm: 'reverse-chronological',
     })
     this.notifications = new NotificationsFeedModel(this.rootStore)
+    this.myFeeds = new MyFeedsUIModel(this.rootStore)
     this.follows = new MyFollowsCache(this.rootStore)
   }
 
   clear() {
     this.mainFeed.clear()
     this.notifications.clear()
+    this.myFeeds.clear()
     this.follows.clear()
     this.rootStore.profiles.cache.clear()
     this.rootStore.posts.cache.clear()
@@ -111,6 +115,11 @@ export class MeModel {
       /* dont await */ this.notifications.setup().catch(e => {
         this.rootStore.log.error('Failed to setup notifications model', e)
       })
+      /* dont await */ this.notifications.setup().catch(e => {
+        this.rootStore.log.error('Failed to setup notifications model', e)
+      })
+      this.myFeeds.clear()
+      /* dont await */ this.myFeeds.saved.refresh()
       this.rootStore.emitSessionLoaded()
       await this.fetchInviteCodes()
       await this.fetchAppPasswords()

--- a/src/state/models/ui/my-feeds.ts
+++ b/src/state/models/ui/my-feeds.ts
@@ -77,6 +77,11 @@ export class MyFeedsUIModel {
     }
   }
 
+  clear() {
+    this.saved.clear()
+    this.discovery.clear()
+  }
+
   registerListeners() {
     const dispose1 = reaction(
       () => this.rootStore.preferences.savedFeeds,
@@ -107,7 +112,7 @@ export class MyFeedsUIModel {
       _reactKey: '__saved_feeds_header__',
       type: 'saved-feeds-header',
     })
-    if (this.saved.isLoading) {
+    if (this.saved.isLoading && !this.saved.hasContent) {
       items.push({
         _reactKey: '__saved_feeds_loading__',
         type: 'saved-feeds-loading',

--- a/src/state/models/ui/saved-feeds.ts
+++ b/src/state/models/ui/saved-feeds.ts
@@ -52,6 +52,10 @@ export class SavedFeedsModel {
   // public api
   // =
 
+  clear() {
+    this.all = []
+  }
+
   /**
    * Refresh the preferences then reload all feed infos
    */

--- a/src/view/screens/Feeds.tsx
+++ b/src/view/screens/Feeds.tsx
@@ -22,7 +22,7 @@ import {
 import {ErrorMessage} from 'view/com/util/error/ErrorMessage'
 import debounce from 'lodash.debounce'
 import {Text} from 'view/com/util/text/Text'
-import {MyFeedsUIModel, MyFeedsItem} from 'state/models/ui/my-feeds'
+import {MyFeedsItem} from 'state/models/ui/my-feeds'
 import {FeedSourceModel} from 'state/models/content/feed-source'
 import {FlatList} from 'view/com/util/Views'
 import {useFocusEffect} from '@react-navigation/native'
@@ -34,7 +34,7 @@ export const FeedsScreen = withAuthRequired(
     const pal = usePalette('default')
     const store = useStores()
     const {isMobile, isTabletOrDesktop} = useWebMediaQueries()
-    const myFeeds = React.useMemo(() => new MyFeedsUIModel(store), [store])
+    const myFeeds = store.me.myFeeds
     const [query, setQuery] = React.useState<string>('')
     const debouncedSearchFeeds = React.useMemo(
       () => debounce(q => myFeeds.discovery.search(q), 500), // debounce for 500ms


### PR DESCRIPTION
The "Feeds" screen needs to give the user quick access to their content or else users won't bother. Right now the load time is bad; this PR moves the saved-feeds state to the root store so that it can be loaded during session init.

## Before

https://github.com/bluesky-social/social-app/assets/1270099/badf1ec0-fc42-49b5-a689-927ccb59d7f7

## After

https://github.com/bluesky-social/social-app/assets/1270099/ed2ee4e6-1a99-4e79-8654-3f99f150b19f

