### PR TITLE
Make choose account form scrollable

### DIFF
--- a/src/view/com/auth/login/Login.tsx
+++ b/src/view/com/auth/login/Login.tsx
@@ -3,6 +3,7 @@ import {
   ActivityIndicator,
   Keyboard,
   KeyboardAvoidingView,
+  ScrollView,
   StyleSheet,
   TextInput,
   TouchableOpacity,
@@ -202,7 +203,7 @@ const ChooseAccountForm = ({
   }
 
   return (
-    <View testID="chooseAccountForm">
+    <ScrollView testID="chooseAccountForm">
       <Text
         type="2xl-medium"
         style={[pal.text, styles.groupLabel, s.mt5, s.mb10]}>
@@ -267,7 +268,7 @@ const ChooseAccountForm = ({
         <View style={s.flex1} />
         {isProcessing && <ActivityIndicator />}
       </View>
-    </View>
+    </ScrollView>
   )
 }
 


### PR DESCRIPTION
If you have more than ~10 logins, the Sign in as form fills up the screen and you cannot access "Other account" or "Back". This should be made scrollable 