### PR TITLE
Patch facebook/metro#1130 to profile module init

### DIFF
--- a/patches/metro+0.76.8.patch
+++ b/patches/metro+0.76.8.patch
@@ -1,0 +1,44 @@
+diff --git a/node_modules/metro/src/ModuleGraph/worker/JsFileWrapping.js b/node_modules/metro/src/ModuleGraph/worker/JsFileWrapping.js
+index 48a1409..ef185c9 100644
+--- a/node_modules/metro/src/ModuleGraph/worker/JsFileWrapping.js
++++ b/node_modules/metro/src/ModuleGraph/worker/JsFileWrapping.js
+@@ -70,14 +70,19 @@ function wrapModule(
+   importDefaultName,
+   importAllName,
+   dependencyMapName,
+-  globalPrefix
++  globalPrefix,
++  moduleFactoryName
+ ) {
+   const params = buildParameters(
+     importDefaultName,
+     importAllName,
+     dependencyMapName
+   );
+-  const factory = functionFromProgram(fileAst.program, params);
++  const factory = functionFromProgram(
++    fileAst.program,
++    params,
++    moduleFactoryName
++  );
+   const def = t.callExpression(t.identifier(`${globalPrefix}__d`), [factory]);
+   const ast = t.file(t.program([t.expressionStatement(def)]));
+   const requireName = renameRequires(ast);
+@@ -107,7 +112,16 @@ function wrapJson(source, globalPrefix) {
+     "});",
+   ].join("\n");
+ }
+-function functionFromProgram(program, parameters) {
++const JS_INVALID_IDENT_RE = /[^a-zA-Z0-9$_]/g;
++function functionFromProgram(program, parameters, moduleFactoryName) {
++  let identifier;
++  if (typeof moduleFactoryName === "string" && moduleFactoryName !== "") {
++    // Keep the name readable so it shows up in profiler traces.
++    // Add an unlikely suffix to avoid collisions with the module code.
++    identifier = t.identifier(
++      `${moduleFactoryName.replace(JS_INVALID_IDENT_RE, "_")}__module_factory__`
++    );
++  }
+   return t.functionExpression(
+     undefined,
+     parameters.map(makeIdentifier),

--- a/patches/metro-transform-worker+0.76.8.patch
+++ b/patches/metro-transform-worker+0.76.8.patch
@@ -1,0 +1,41 @@
+diff --git a/node_modules/metro-transform-worker/src/index.js b/node_modules/metro-transform-worker/src/index.js
+index 27d4cb3..fd71f47 100644
+--- a/node_modules/metro-transform-worker/src/index.js
++++ b/node_modules/metro-transform-worker/src/index.js
+@@ -190,6 +190,10 @@ async function transformJS(file, { config, options, projectRoot }) {
+   let dependencyMapName = "";
+   let dependencies;
+   let wrappedAst;
++  const minify =
++    options.minify &&
++    options.unstable_transformProfile !== "hermes-canary" &&
++    options.unstable_transformProfile !== "hermes-stable";
+ 
+   // If the module to transform is a script (meaning that is not part of the
+   // dependency graph and it code will just be prepended to the bundle modules),
+@@ -229,19 +233,20 @@ async function transformJS(file, { config, options, projectRoot }) {
+     if (config.unstable_disableModuleWrapping === true) {
+       wrappedAst = ast;
+     } else {
++      let moduleFactoryName;
++      if (options.dev && !minify) {
++        moduleFactoryName = file.filename;
++      }
+       ({ ast: wrappedAst } = JsFileWrapping.wrapModule(
+         ast,
+         importDefault,
+         importAll,
+         dependencyMapName,
+-        config.globalPrefix
++        config.globalPrefix,
++        moduleFactoryName
+       ));
+     }
+   }
+-  const minify =
+-    options.minify &&
+-    options.unstable_transformProfile !== "hermes-canary" &&
+-    options.unstable_transformProfile !== "hermes-stable";
+   const reserved = [];
+   if (config.unstable_dependencyMapReservedName != null) {
+     reserved.push(config.unstable_dependencyMapReservedName);


### PR DESCRIPTION
This patches https://github.com/facebook/metro/pull/1130 to give us module names in Hermes initialization traces.

I'll delete this when we update to an upstream version with the patch.

## Before

<img width="938" alt="Screenshot 2023-11-02 at 17 15 05" src="https://github.com/bluesky-social/social-app/assets/810438/6b1db561-6a21-4c94-a131-1de109869480">

## After

<img width="926" alt="Screenshot 2023-11-02 at 17 24 47" src="https://github.com/bluesky-social/social-app/assets/810438/152f8aae-c8ee-48d0-835a-cbb2983a83b1">
