### PR TITLE
Lookup did for my profile at screen to avoid bad actor error

### DIFF
--- a/src/Navigation.tsx
+++ b/src/Navigation.tsx
@@ -349,7 +349,6 @@ function NotificationsTabNavigator() {
 
 const MyProfileTabNavigator = observer(function MyProfileTabNavigatorImpl() {
   const contentStyle = useColorSchemeStyle(styles.bgLight, styles.bgDark)
-  const store = useStores()
   return (
     <MyProfileTab.Navigator
       screenOptions={{
@@ -364,7 +363,7 @@ const MyProfileTabNavigator = observer(function MyProfileTabNavigatorImpl() {
         // @ts-ignore // TODO: fix this broken type in ProfileScreen
         getComponent={() => ProfileScreen}
         initialParams={{
-          name: store.me.did,
+          name: 'me',
         }}
       />
       {commonScreens(MyProfileTab as typeof HomeTab)}

--- a/src/view/screens/Profile.tsx
+++ b/src/view/screens/Profile.tsx
@@ -36,6 +36,7 @@ export const ProfileScreen = withAuthRequired(
     const store = useStores()
     const {screen, track} = useAnalytics()
     const viewSelectorRef = React.useRef<ViewSelectorHandle>(null)
+    const name = route.params.name === 'me' ? store.me.did : route.params.name
 
     useEffect(() => {
       screen('Profile')
@@ -43,8 +44,8 @@ export const ProfileScreen = withAuthRequired(
 
     const [hasSetup, setHasSetup] = useState<boolean>(false)
     const uiState = React.useMemo(
-      () => new ProfileUiModel(store, {user: route.params.name}),
-      [route.params.name, store],
+      () => new ProfileUiModel(store, {user: name}),
+      [name, store],
     )
     useSetTitle(combinedDisplayName(uiState.profile))
 
@@ -54,7 +55,7 @@ export const ProfileScreen = withAuthRequired(
 
     useEffect(() => {
       setHasSetup(false)
-    }, [route.params.name])
+    }, [name])
 
     // We don't need this to be reactive, so we can just register the listeners once
     useEffect(() => {


### PR DESCRIPTION
Users who tap the "Profile" footer button while loading sometimes receive an error message that can't be replaced. This is because the DID is being passed to the profile screen via the initial params in the navigator, and if they press the button before loading finishes then it may be undefined at time of press.

This PR solves that by looking up the DID within the screen. If they happen to press it early, they'll briefly get the error, then it will correct itself.