### PR TITLE
Work around a startup stall caused by expo-image on low-end Android

### DIFF
--- a/src/view/com/util/UserAvatar.tsx
+++ b/src/view/com/util/UserAvatar.tsx
@@ -1,5 +1,5 @@
 import React, {useMemo} from 'react'
-import {StyleSheet, View} from 'react-native'
+import {Image, StyleSheet, View} from 'react-native'
 import Svg, {Circle, Rect, Path} from 'react-native-svg'
 import {FontAwesomeIcon} from '@fortawesome/react-native-fontawesome'
 import {HighPriorityImage} from 'view/com/util/images/Image'
@@ -27,6 +27,7 @@ interface BaseUserAvatarProps {
 
 interface UserAvatarProps extends BaseUserAvatarProps {
   moderation?: ModerationUI
+  usePlainRNImage?: boolean
 }
 
 interface EditableUserAvatarProps extends BaseUserAvatarProps {
@@ -110,6 +111,7 @@ export function UserAvatar({
   size,
   avatar,
   moderation,
+  usePlainRNImage = false,
 }: UserAvatarProps) {
   const pal = usePalette('default')
 
@@ -146,13 +148,24 @@ export function UserAvatar({
   return avatar &&
     !((moderation?.blur && isAndroid) /* android crashes with blur */) ? (
     <View style={{width: size, height: size}}>
-      <HighPriorityImage
-        testID="userAvatarImage"
-        style={aviStyle}
-        contentFit="cover"
-        source={{uri: avatar}}
-        blurRadius={moderation?.blur ? BLUR_AMOUNT : 0}
-      />
+      {usePlainRNImage ? (
+        <Image
+          accessibilityIgnoresInvertColors
+          testID="userAvatarImage"
+          style={aviStyle}
+          resizeMode="cover"
+          source={{uri: avatar}}
+          blurRadius={moderation?.blur ? BLUR_AMOUNT : 0}
+        />
+      ) : (
+        <HighPriorityImage
+          testID="userAvatarImage"
+          style={aviStyle}
+          contentFit="cover"
+          source={{uri: avatar}}
+          blurRadius={moderation?.blur ? BLUR_AMOUNT : 0}
+        />
+      )}
       {alert}
     </View>
   ) : (

--- a/src/view/shell/Drawer.tsx
+++ b/src/view/shell/Drawer.tsx
@@ -158,7 +158,11 @@ export const DrawerContent = observer(function DrawerContentImpl() {
               accessibilityLabel="Profile"
               accessibilityHint="Navigates to your profile"
               onPress={onPressProfile}>
-              <UserAvatar size={80} avatar={store.me.avatar} />
+              <UserAvatar
+                size={80}
+                avatar={store.me.avatar}
+                usePlainRNImage={true}
+              />
               <Text
                 type="title-lg"
                 style={[pal.text, s.bold, styles.profileCardDisplayName]}

--- a/src/view/shell/Drawer.tsx
+++ b/src/view/shell/Drawer.tsx
@@ -161,6 +161,7 @@ export const DrawerContent = observer(function DrawerContentImpl() {
               <UserAvatar
                 size={80}
                 avatar={store.me.avatar}
+                // See https://github.com/bluesky-social/social-app/pull/1801:
                 usePlainRNImage={true}
               />
               <Text

--- a/src/view/shell/bottom-bar/BottomBar.tsx
+++ b/src/view/shell/bottom-bar/BottomBar.tsx
@@ -192,11 +192,19 @@ export const BottomBar = observer(function BottomBarImpl({
                   styles.onProfile,
                   {borderColor: pal.text.color},
                 ]}>
-                <UserAvatar avatar={store.me.avatar} size={27} />
+                <UserAvatar
+                  avatar={store.me.avatar}
+                  size={27}
+                  usePlainRNImage={true}
+                />
               </View>
             ) : (
               <View style={[styles.ctrlIcon, pal.text, styles.profileIcon]}>
-                <UserAvatar avatar={store.me.avatar} size={28} />
+                <UserAvatar
+                  avatar={store.me.avatar}
+                  size={28}
+                  usePlainRNImage={true}
+                />
               </View>
             )}
           </View>

--- a/src/view/shell/bottom-bar/BottomBar.tsx
+++ b/src/view/shell/bottom-bar/BottomBar.tsx
@@ -195,6 +195,7 @@ export const BottomBar = observer(function BottomBarImpl({
                 <UserAvatar
                   avatar={store.me.avatar}
                   size={27}
+                  // See https://github.com/bluesky-social/social-app/pull/1801:
                   usePlainRNImage={true}
                 />
               </View>
@@ -203,6 +204,7 @@ export const BottomBar = observer(function BottomBarImpl({
                 <UserAvatar
                   avatar={store.me.avatar}
                   size={28}
+                  // See https://github.com/bluesky-social/social-app/pull/1801:
                   usePlainRNImage={true}
                 />
               </View>


### PR DESCRIPTION
There seems to be an issue in `expo-image` that blocks the UI thread on startup on low-end Android. As a result, we get stuck on the splash screen for 5 extra seconds if even one of those is rendered. As a temporary fix, let's render the startup-blocking images (own avatars in the drawer and the tabbar) as plain RN `Image`.

This lets us hide the splash ~4.5 seconds earlier. The final time to content seems to only improve by ~2.5s, but that's harder to measure reliably because it's network-bound. (We should optimize the load time too though.)

The proper fix is to get this reported to Expo and see if it can be fixed upstream. Maybe it's something like https://github.com/expo/expo/issues/21921.

(The measurements are taken with https://github.com/bluesky-social/atproto/pull/1790 patched in since it was another cause of the slowdown.)

## Before

Time to end of splash: 8s
Time to content: 13s

https://github.com/bluesky-social/social-app/assets/810438/90e8e111-4269-4130-883b-99c55d2b7ae1

## After

Time to end of splash: ~3.5s
Time to content: ~10.5s

https://github.com/bluesky-social/social-app/assets/810438/798d1fc4-d015-46cd-98da-6d74910a6dda

## Test Plan

Verified both the drawer and the tab bar render my avatar fine on iOS, Android, and web.