### PR TITLE
Refresh on scroll-to-top by active section press

### DIFF
--- a/src/view/screens/ProfileFeed.tsx
+++ b/src/view/screens/ProfileFeed.tsx
@@ -393,12 +393,8 @@ const FeedSection = React.forwardRef<SectionRef, FeedSectionProps>(
 
     const onScrollToTop = useCallback(() => {
       scrollElRef.current?.scrollToOffset({offset: -headerHeight})
-    }, [scrollElRef, headerHeight])
-
-    const onPressLoadLatest = React.useCallback(() => {
-      onScrollToTop()
       feed.refresh()
-    }, [feed, onScrollToTop])
+    }, [feed, scrollElRef, headerHeight])
 
     React.useImperativeHandle(ref, () => ({
       scrollToTop: onScrollToTop,
@@ -420,7 +416,7 @@ const FeedSection = React.forwardRef<SectionRef, FeedSectionProps>(
         />
         {(isScrolledDown || hasNew) && (
           <LoadLatestBtn
-            onPress={onPressLoadLatest}
+            onPress={onScrollToTop}
             label="Load new posts"
             showIndicator={hasNew}
           />

--- a/src/view/screens/ProfileList.tsx
+++ b/src/view/screens/ProfileList.tsx
@@ -595,13 +595,8 @@ const FeedSection = React.forwardRef<SectionRef, FeedSectionProps>(
 
     const onScrollToTop = useCallback(() => {
       scrollElRef.current?.scrollToOffset({offset: -headerHeight})
-    }, [scrollElRef, headerHeight])
-
-    const onPressLoadLatest = React.useCallback(() => {
-      onScrollToTop()
       feed.refresh()
-    }, [feed, onScrollToTop])
-
+    }, [feed, scrollElRef, headerHeight])
     React.useImperativeHandle(ref, () => ({
       scrollToTop: onScrollToTop,
     }))
@@ -623,7 +618,7 @@ const FeedSection = React.forwardRef<SectionRef, FeedSectionProps>(
         />
         {(isScrolledDown || hasNew) && (
           <LoadLatestBtn
-            onPress={onPressLoadLatest}
+            onPress={onScrollToTop}
             label="Load new posts"
             showIndicator={hasNew}
           />


### PR DESCRIPTION
When user presses the "Posts" tab while scrolled down, it scrolls to top. This PR makes it refresh the content too so that the user gets the latest.