### PR TITLE
Add subpath imports

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -37,6 +37,7 @@ module.exports = function (api) {
         {
           alias: {
             // This needs to be mirrored in tsconfig.json
+            '#': './src',
             lib: './src/lib',
             platform: './src/platform',
             state: './src/state',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "jsx": "react-jsx",
     "types": ["node"],
     "paths": {
+      "#/*": ["./src/*"],
       "lib/*": ["./src/lib/*"],
       "platform/*": ["./src/platform/*"],
       "state/*": ["./src/state/*"],


### PR DESCRIPTION
Nothing PR, just didn't have an alias for the root `./src` and I think we could use one occasionally. In fact, we could really use this for all imports, but that's another thing and it's nbd.

Node introduced [subpath imports](https://nodejs.org/api/packages.html#packages_subpath_imports) a while back, which use `#` as a prefix.

I've see `@` and `~`, but both of those are overloaded by scoped npm packages and unix file system syntax, respectively.

With this PR, we can use simply `#/path/from/src` for all imports.