### PR TITLE
Fix editImageModal Overflow

### DIFF
--- a/src/view/com/modals/EditImage.tsx
+++ b/src/view/com/modals/EditImage.tsx
@@ -198,6 +198,7 @@ export const Component = observer(function EditImageImpl({
         s.flex1,
         {
           paddingHorizontal: isMobile ? 16 : undefined,
+          overflowY: 'auto',
         },
       ]}>
       <Text style={[styles.title, pal.text]}>Edit image</Text>


### PR DESCRIPTION
When editImageModal **exceeds the size of its own container**, it overflows if it does not have the specified property. The `overflow-y: auto` property takes care of adding a vertical scroll bar in case the height of editImageModal is forced.

<img width="783" alt="Captura de pantalla 2023-11-05 a las 20 18 06" src="https://github.com/bluesky-social/social-app/assets/136113382/7982d35b-ecff-4aa1-b645-3dd817f7e229">

*Without `overflow-y: auto` Property.*

<img width="783" alt="Captura de pantalla 2023-11-05 a las 20 26 47" src="https://github.com/bluesky-social/social-app/assets/136113382/8df2097a-db9c-455e-9dde-e1107b61d7f2">

*With `overflow-y: auto` Property.*