### PR TITLE
Restore autofocus on emoji drop down

### DIFF
--- a/src/view/com/composer/text-input/web/EmojiPicker.web.tsx
+++ b/src/view/com/composer/text-input/web/EmojiPicker.web.tsx
@@ -76,7 +76,7 @@ export function EmojiPicker({close}: {close: () => void}) {
                 return (await import('./EmojiPickerData.json')).default
               }}
               onEmojiSelect={onInsert}
-              autoFocus={false}
+              autoFocus={true}
             />
           </View>
         </TouchableWithoutFeedback>


### PR DESCRIPTION
Okey, I know somebody must have explicitly turned this feature off by stating `autoFocus={false}` in the `EmojiPicker`, but as an end user it feels really weird to me not to have this auto-focus (I realized several time I was typing my search query directly in the post's content).

Maybe there is a good reason it was deactivated in one specific scenario? At least on my standard desktop browser I believe autofocus is a nicer UX.