### PR TITLE
Fix removal of old lists from saved feeds

### DIFF
--- a/src/state/models/content/feed-source.ts
+++ b/src/state/models/content/feed-source.ts
@@ -142,7 +142,8 @@ export class FeedSourceModel {
   }
 
   async unsave() {
-    if (this.type !== 'feed-generator') {
+    // TODO TEMPORARY — see PRF's comment in content/list.ts togglePin
+    if (this.type !== 'feed-generator' && this.type !== 'list') {
       return
     }
     try {
@@ -179,7 +180,13 @@ export class FeedSourceModel {
         name: this.displayName,
         uri: this.uri,
       })
-      return this.rootStore.preferences.removePinnedFeed(this.uri)
+
+      if (this.type === 'list') {
+        // TODO TEMPORARY — see PRF's comment in content/list.ts togglePin
+        return this.unsave()
+      } else {
+        return this.rootStore.preferences.removePinnedFeed(this.uri)
+      }
     }
   }
 

--- a/src/state/models/content/list.ts
+++ b/src/state/models/content/list.ts
@@ -361,7 +361,7 @@ export class ListModel {
         name: this.data?.name || '',
         uri: this.uri,
       })
-      // TEMPORARY
+      // TODO TEMPORARY
       // lists are temporarily piggybacking on the saved/pinned feeds preferences
       // we'll eventually replace saved feeds with the bookmarks API
       // until then, we need to unsave lists instead of just unpin them

--- a/src/state/models/ui/saved-feeds.ts
+++ b/src/state/models/ui/saved-feeds.ts
@@ -38,12 +38,18 @@ export class SavedFeedsModel {
     return this.hasLoaded && !this.hasContent
   }
 
-  get pinned() {
-    return this.all.filter(feed => feed.isPinned)
+  get pinned(): FeedSourceModel[] {
+    return this.rootStore.preferences.savedFeeds
+      .filter(feed => this.rootStore.preferences.isPinnedFeed(feed))
+      .map(uri => this.all.find(f => f.uri === uri))
+      .filter(Boolean) as FeedSourceModel[]
   }
 
-  get unpinned() {
-    return this.all.filter(feed => !feed.isPinned)
+  get unpinned(): FeedSourceModel[] {
+    return this.rootStore.preferences.savedFeeds
+      .filter(feed => !this.rootStore.preferences.isPinnedFeed(feed))
+      .map(uri => this.all.find(f => f.uri === uri))
+      .filter(Boolean) as FeedSourceModel[]
   }
 
   get pinnedFeedNames() {


### PR DESCRIPTION
Noticed that the remove button did not work for user lists. This updates the `unsave` handling to include `list` type sources. It also ensures that the unpin functionality in this view works the same as the unpin handling on `ProfileList` screen. Added TODO comments in both places.

<img width="677" alt="Screenshot 2023-11-06 at 8 32 14 AM" src="https://github.com/bluesky-social/social-app/assets/4732330/1c6158bf-bf3d-4c7f-aad3-d134d3bef0a7">
