### PR TITLE
Fix sticky pager jumps

### DIFF
--- a/src/view/com/pager/PagerWithHeader.tsx
+++ b/src/view/com/pager/PagerWithHeader.tsx
@@ -53,12 +53,12 @@ export const PagerWithHeader = React.forwardRef<PagerRef, PagerWithHeaderProps>(
     const scrollYs = React.useRef<Record<number, number>>({})
     const scrollY = useSharedValue(scrollYs.current[currentPage] || 0)
     const [tabBarHeight, setTabBarHeight] = React.useState(0)
-    const [headerHeight, setHeaderHeight] = React.useState(0)
+    const [headerOnlyHeight, setHeaderOnlyHeight] = React.useState(0)
     const [isScrolledDown, setIsScrolledDown] = React.useState(
       scrollYs.current[currentPage] > SCROLLED_DOWN_LIMIT,
     )
 
-    const headerOnlyHeight = headerHeight - tabBarHeight
+    const headerHeight = headerOnlyHeight + tabBarHeight
 
     // react to scroll updates
     function onScrollUpdate(v: number) {
@@ -79,11 +79,11 @@ export const PagerWithHeader = React.forwardRef<PagerRef, PagerWithHeaderProps>(
       },
       [setTabBarHeight],
     )
-    const onHeaderLayout = React.useCallback(
+    const onHeaderOnlyLayout = React.useCallback(
       (evt: LayoutChangeEvent) => {
-        setHeaderHeight(evt.nativeEvent.layout.height)
+        setHeaderOnlyHeight(evt.nativeEvent.layout.height)
       },
-      [setHeaderHeight],
+      [setHeaderOnlyHeight],
     )
 
     // render the the header and tab bar
@@ -104,12 +104,11 @@ export const PagerWithHeader = React.forwardRef<PagerRef, PagerWithHeaderProps>(
       (props: RenderTabBarFnProps) => {
         return (
           <Animated.View
-            onLayout={onHeaderLayout}
             style={[
               isMobile ? styles.tabBarMobile : styles.tabBarDesktop,
               headerTransform,
             ]}>
-            {renderHeader?.()}
+            <View onLayout={onHeaderOnlyLayout}>{renderHeader?.()}</View>
             {isHeaderReady && (
               <TabBar
                 items={items}
@@ -131,7 +130,7 @@ export const PagerWithHeader = React.forwardRef<PagerRef, PagerWithHeaderProps>(
         onCurrentPageSelected,
         isMobile,
         onTabBarLayout,
-        onHeaderLayout,
+        onHeaderOnlyLayout,
       ],
     )
 

--- a/src/view/com/pager/PagerWithHeader.tsx
+++ b/src/view/com/pager/PagerWithHeader.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react'
-import {LayoutChangeEvent, StyleSheet} from 'react-native'
+import {LayoutChangeEvent, StyleSheet, View} from 'react-native'
 import Animated, {
   Easing,
   useAnimatedReaction,
@@ -28,6 +28,7 @@ export interface PagerWithHeaderProps {
     | (((props: PagerWithHeaderChildParams) => JSX.Element) | null)[]
     | ((props: PagerWithHeaderChildParams) => JSX.Element)
   items: string[]
+  isHeaderReady: boolean
   renderHeader?: () => JSX.Element
   initialPage?: number
   onPageSelected?: (index: number) => void
@@ -39,6 +40,7 @@ export const PagerWithHeader = React.forwardRef<PagerRef, PagerWithHeaderProps>(
       children,
       testID,
       items,
+      isHeaderReady,
       renderHeader,
       initialPage,
       onPageSelected,
@@ -106,18 +108,21 @@ export const PagerWithHeader = React.forwardRef<PagerRef, PagerWithHeaderProps>(
               headerTransform,
             ]}>
             {renderHeader?.()}
-            <TabBar
-              items={items}
-              selectedPage={currentPage}
-              onSelect={props.onSelect}
-              onPressSelected={onCurrentPageSelected}
-              onLayout={onTabBarLayout}
-            />
+            {isHeaderReady && (
+              <TabBar
+                items={items}
+                selectedPage={currentPage}
+                onSelect={props.onSelect}
+                onPressSelected={onCurrentPageSelected}
+                onLayout={onTabBarLayout}
+              />
+            )}
           </Animated.View>
         )
       },
       [
         items,
+        isHeaderReady,
         renderHeader,
         headerTransform,
         currentPage,
@@ -175,7 +180,12 @@ export const PagerWithHeader = React.forwardRef<PagerRef, PagerWithHeaderProps>(
         tabBarPosition="top">
         {toArray(children)
           .filter(Boolean)
-          .map(child => {
+          .map((child, i) => {
+            if (!isHeaderReady || headerHeight === 0) {
+              // Don't show content yet because it would jump down later otherwise.
+              // Pager requires that these are non-null so return an empty view.
+              return <View key={i} />
+            }
             if (child) {
               return child(childProps)
             }

--- a/src/view/com/pager/PagerWithHeader.tsx
+++ b/src/view/com/pager/PagerWithHeader.tsx
@@ -109,15 +109,21 @@ export const PagerWithHeader = React.forwardRef<PagerRef, PagerWithHeaderProps>(
               headerTransform,
             ]}>
             <View onLayout={onHeaderOnlyLayout}>{renderHeader?.()}</View>
-            {isHeaderReady && (
+            <View
+              onLayout={onTabBarLayout}
+              style={{
+                // Render it immediately to measure it early since its size doesn't depend on the content.
+                // However, keep it invisible until the header above stabilizes in order to prevent jumps.
+                opacity: isHeaderReady ? 1 : 0,
+                pointerEvents: isHeaderReady ? 'auto' : 'none',
+              }}>
               <TabBar
                 items={items}
                 selectedPage={currentPage}
                 onSelect={props.onSelect}
                 onPressSelected={onCurrentPageSelected}
-                onLayout={onTabBarLayout}
               />
-            )}
+            </View>
           </Animated.View>
         )
       },

--- a/src/view/com/pager/PagerWithHeader.tsx
+++ b/src/view/com/pager/PagerWithHeader.tsx
@@ -182,7 +182,11 @@ export const PagerWithHeader = React.forwardRef<PagerRef, PagerWithHeaderProps>(
         {toArray(children)
           .filter(Boolean)
           .map((child, i) => {
-            if (!isHeaderReady || headerHeight === 0) {
+            if (
+              !isHeaderReady ||
+              headerOnlyHeight === 0 ||
+              tabBarHeight === 0
+            ) {
               // Don't show content yet because it would jump down later otherwise.
               // Pager requires that these are non-null so return an empty view.
               return <View key={i} />

--- a/src/view/com/pager/PagerWithHeader.tsx
+++ b/src/view/com/pager/PagerWithHeader.tsx
@@ -58,10 +58,12 @@ export const PagerWithHeader = React.forwardRef<PagerRef, PagerWithHeaderProps>(
       scrollYs.current[currentPage] > SCROLLED_DOWN_LIMIT,
     )
 
+    const headerOnlyHeight = headerHeight - tabBarHeight
+
     // react to scroll updates
     function onScrollUpdate(v: number) {
       // track each page's current scroll position
-      scrollYs.current[currentPage] = Math.min(v, headerHeight - tabBarHeight)
+      scrollYs.current[currentPage] = Math.min(v, headerOnlyHeight)
       // update the 'is scrolled down' value
       setIsScrolledDown(v > SCROLLED_DOWN_LIMIT)
     }
@@ -90,7 +92,7 @@ export const PagerWithHeader = React.forwardRef<PagerRef, PagerWithHeaderProps>(
         transform: [
           {
             translateY: Math.min(
-              Math.min(scrollY.value, headerHeight - tabBarHeight) * -1,
+              Math.min(scrollY.value, headerOnlyHeight) * -1,
               0,
             ),
           },

--- a/src/view/com/pager/PagerWithHeader.tsx
+++ b/src/view/com/pager/PagerWithHeader.tsx
@@ -188,19 +188,22 @@ export const PagerWithHeader = React.forwardRef<PagerRef, PagerWithHeaderProps>(
         {toArray(children)
           .filter(Boolean)
           .map((child, i) => {
+            let output = null
             if (
-              !isHeaderReady ||
-              headerOnlyHeight === 0 ||
-              tabBarHeight === 0
+              child != null &&
+              // Defer showing content until we know it won't jump.
+              isHeaderReady &&
+              headerOnlyHeight > 0 &&
+              tabBarHeight > 0
             ) {
-              // Don't show content yet because it would jump down later otherwise.
-              // Pager requires that these are non-null so return an empty view.
-              return <View key={i} />
+              output = child(childProps)
             }
-            if (child) {
-              return child(childProps)
-            }
-            return null
+            // Pager children must be noncollapsible plain <View>s.
+            return (
+              <View key={i} collapsable={false}>
+                {output}
+              </View>
+            )
           })}
       </Pager>
     )

--- a/src/view/com/pager/TabBar.tsx
+++ b/src/view/com/pager/TabBar.tsx
@@ -14,7 +14,6 @@ export interface TabBarProps {
   indicatorColor?: string
   onSelect?: (index: number) => void
   onPressSelected?: (index: number) => void
-  onLayout?: (evt: LayoutChangeEvent) => void
 }
 
 export function TabBar({
@@ -24,7 +23,6 @@ export function TabBar({
   indicatorColor,
   onSelect,
   onPressSelected,
-  onLayout,
 }: TabBarProps) {
   const pal = usePalette('default')
   const scrollElRef = useRef<ScrollView>(null)
@@ -68,7 +66,7 @@ export function TabBar({
   const styles = isDesktop || isTablet ? desktopStyles : mobileStyles
 
   return (
-    <View testID={testID} style={[pal.view, styles.outer]} onLayout={onLayout}>
+    <View testID={testID} style={[pal.view, styles.outer]}>
       <DraggableScrollView
         horizontal={true}
         showsHorizontalScrollIndicator={false}

--- a/src/view/screens/ProfileFeed.tsx
+++ b/src/view/screens/ProfileFeed.tsx
@@ -337,7 +337,6 @@ export const ProfileFeedScreenInner = observer(
           onCurrentPageSelected={onCurrentPageSelected}>
           {({onScroll, headerHeight, isScrolledDown}) => (
             <FeedSection
-              key="1"
               ref={feedSectionRef}
               feed={feed}
               onScroll={onScroll}
@@ -347,7 +346,6 @@ export const ProfileFeedScreenInner = observer(
           )}
           {({onScroll, headerHeight}) => (
             <ScrollView
-              key="2"
               onScroll={onScroll}
               scrollEventThrottle={1}
               contentContainerStyle={{paddingTop: headerHeight}}>

--- a/src/view/screens/ProfileFeed.tsx
+++ b/src/view/screens/ProfileFeed.tsx
@@ -332,6 +332,7 @@ export const ProfileFeedScreenInner = observer(
       <View style={s.hContentRegion}>
         <PagerWithHeader
           items={SECTION_TITLES}
+          isHeaderReady={feedInfo?.hasLoaded ?? false}
           renderHeader={renderHeader}
           onCurrentPageSelected={onCurrentPageSelected}>
           {({onScroll, headerHeight, isScrolledDown}) => (

--- a/src/view/screens/ProfileList.tsx
+++ b/src/view/screens/ProfileList.tsx
@@ -165,6 +165,7 @@ export const ProfileListScreenInner = observer(
         <View style={s.hContentRegion}>
           <PagerWithHeader
             items={SECTION_TITLES_CURATE}
+            isHeaderReady={list.hasLoaded}
             renderHeader={renderHeader}
             onCurrentPageSelected={onCurrentPageSelected}>
             {({onScroll, headerHeight, isScrolledDown}) => (
@@ -215,6 +216,7 @@ export const ProfileListScreenInner = observer(
         <View style={s.hContentRegion}>
           <PagerWithHeader
             items={SECTION_TITLES_MOD}
+            isHeaderReady={list.hasLoaded}
             renderHeader={renderHeader}>
             {({onScroll, headerHeight, isScrolledDown}) => (
               <AboutSection

--- a/src/view/screens/ProfileList.tsx
+++ b/src/view/screens/ProfileList.tsx
@@ -170,7 +170,6 @@ export const ProfileListScreenInner = observer(
             onCurrentPageSelected={onCurrentPageSelected}>
             {({onScroll, headerHeight, isScrolledDown}) => (
               <FeedSection
-                key="1"
                 ref={feedSectionRef}
                 feed={feed}
                 onScroll={onScroll}
@@ -180,7 +179,6 @@ export const ProfileListScreenInner = observer(
             )}
             {({onScroll, headerHeight, isScrolledDown}) => (
               <AboutSection
-                key="2"
                 ref={aboutSectionRef}
                 list={list}
                 descriptionRT={list.descriptionRT}
@@ -220,7 +218,6 @@ export const ProfileListScreenInner = observer(
             renderHeader={renderHeader}>
             {({onScroll, headerHeight, isScrolledDown}) => (
               <AboutSection
-                key="2"
                 list={list}
                 descriptionRT={list.descriptionRT}
                 creator={list.data ? list.data.creator : undefined}


### PR DESCRIPTION
The recently introduced pager component renders three things:

- The pager "header" (e.g. list info)
- The "tab bar" below it (e.g. Posts | About)
- The "content" below both of those things

However, the loading sequence appears to be extremely janky:

https://github.com/bluesky-social/social-app/assets/810438/adc96d6b-db3c-47fd-80f4-794b980c0289

This happens for three reasons:

1. The header changes size as we load data. So if we rendered *anything* below it (tab bar and/or content) while it was still a glimmer, we're gonna have to shift those things down when it fully loads. This feels jarring visually.

2. Our logic to position the content (so that it may fluidly scroll with the tabs staying sticky) relies on knowing both the header and the tab bar height. However, initially we don't know them at all, the header size changes when it turns from glimmer into content, and also React Native `onLayout` is always async so we can't rely on that being up-to-date anyway.

3. As if that weren't enough, it seems like changing a scroll view padding on iOS on the fly can mess up the scroll position.

## The Fix

First, let's enforce that content is revealed top down. First, we reveal the header glimmer. We wait for it to "settle" which depends on loading data. Since we can't use `<Suspense>` here (which is the canonical React solution to this problem), we track this manually. Until `isHeaderReady={true}` is passed, we don't try showing anything below to the user at all.

In layout measurement code, I separated measuring "just" the header from measuring the tab bar. Previously we were measuring the header *including* the tab bar plus the tab bar separately. This made the calculation a bit confusing. Now we have two state variables that we can check for being zeroes. If either of them is zero, we're not ready to render the content.

As an optimization, we do render the tab bar a bit early with `opacity: 0`. So that we get its layout information early. We get away with it because its height is not going to change, unlike with the header.

Finally, when we know the header has settled (`isHeaderReady={true}`) and we have both `headerOnlyHeight` and `tabBarHeight` calculated, we're going to render the content (this will include the content's glimmer if it hasn't loaded yet).

## Test Plan

Feeds:

https://github.com/bluesky-social/social-app/assets/810438/70319269-0f59-4929-82a4-2f8674d94612

Lists:

https://github.com/bluesky-social/social-app/assets/810438/77d8e984-6206-41a8-8b1d-806de41404c4

Mod Lists:

https://github.com/bluesky-social/social-app/assets/810438/2075fa0a-e408-410e-88c2-0223bde932af

Renaming a list:

https://github.com/bluesky-social/social-app/assets/810438/d3c2f434-c8f9-4855-9a25-5ecc2f65c842

There is a little jump when renaming that didn't get captured on the video. However I think we can live with it.

Also went through this on Android and web.