### PR TITLE
Fix accidental unwrapped strings

### DIFF
--- a/src/view/com/composer/ExternalEmbed.tsx
+++ b/src/view/com/composer/ExternalEmbed.tsx
@@ -51,14 +51,14 @@ export const ExternalEmbed = ({
             {link.meta.description}
           </Text>
         )}
-        {!!link.meta?.error && (
+        {link.meta?.error ? (
           <Text
             type="sm"
             numberOfLines={2}
             style={[{color: palError.colors.background}, styles.description]}>
             {link.meta.error}
           </Text>
-        )}
+        ) : null}
       </View>
       <TouchableOpacity
         style={styles.removeBtn}

--- a/src/view/com/modals/ChangeHandle.tsx
+++ b/src/view/com/modals/ChangeHandle.tsx
@@ -484,13 +484,13 @@ function CustomHandleForm({
           </Text>
         </View>
       )}
-      {error && (
+      {error ? (
         <View style={[styles.message, palError.view]}>
           <Text type="md-medium" style={palError.text}>
             {error}
           </Text>
         </View>
-      )}
+      ) : null}
       <Button
         type="primary"
         style={[s.p20, isVerifying && styles.dimmed]}

--- a/src/view/screens/Feeds.tsx
+++ b/src/view/screens/Feeds.tsx
@@ -284,13 +284,13 @@ function SavedFeed({feed}: {feed: FeedSourceModel}) {
         <Text type="lg-medium" style={pal.text} numberOfLines={1}>
           {feed.displayName}
         </Text>
-        {feed.error && (
+        {feed.error ? (
           <View style={[styles.offlineSlug, pal.borderDark]}>
             <Text type="xs" style={pal.textLight}>
               Feed offline
             </Text>
           </View>
-        )}
+        ) : null}
       </View>
       {isMobile && (
         <FontAwesomeIcon

--- a/src/view/screens/ProfileList.tsx
+++ b/src/view/screens/ProfileList.tsx
@@ -250,7 +250,7 @@ export const ProfileListScreenInner = observer(
     return (
       <CenteredView sideBorders style={s.hContentRegion}>
         <Header rkey={rkey} list={list} />
-        {list.error && <ErrorScreen error={list.error} />}
+        {list.error ? <ErrorScreen error={list.error} /> : null}
       </CenteredView>
     )
   },


### PR DESCRIPTION
Noticed this on the list page on the web:

<img width="579" alt="Screenshot 2023-11-06 at 22 34 21" src="https://github.com/bluesky-social/social-app/assets/810438/f7123c6d-c32c-4490-baaa-5a5e7f559e10">

The issue is a pattern like `foo.error && <Bla />` where `foo.error` can be `0` or an empty string.

If it's an empty string, React no longer throws (it did in the past), so we actually "get away" with it. But `0` could still be an issue in theory, plus we don't want to see warning messages, so let's just write this explicitly.