### PR TITLE
Move FollowButton to ProfileHeader

### DIFF
--- a/src/view/com/profile/FollowButton.tsx
+++ b/src/view/com/profile/FollowButton.tsx
@@ -6,6 +6,17 @@ import {Button, ButtonType} from '../util/forms/Button'
 import * as Toast from '../util/Toast'
 import {FollowState} from 'state/models/cache/my-follows'
 import {useFollowProfile} from 'lib/hooks/useFollowProfile'
+import {s} from '#/lib/styles'
+import {FontAwesomeIcon} from '@fortawesome/react-native-fontawesome'
+import {usePalette} from '#/lib/hooks/usePalette'
+
+type Props = {
+  unfollowedType?: ButtonType
+  followedType?: ButtonType
+  profile: AppBskyActorDefs.ProfileViewBasic
+  onToggleFollow?: (v: boolean) => void
+  labelStyle?: StyleProp<TextStyle>
+} & React.ComponentProps<typeof Button>
 
 export const FollowButton = observer(function FollowButtonImpl({
   unfollowedType = 'inverted',
@@ -13,13 +24,11 @@ export const FollowButton = observer(function FollowButtonImpl({
   profile,
   onToggleFollow,
   labelStyle,
-}: {
-  unfollowedType?: ButtonType
-  followedType?: ButtonType
-  profile: AppBskyActorDefs.ProfileViewBasic
-  onToggleFollow?: (v: boolean) => void
-  labelStyle?: StyleProp<TextStyle>
-}) {
+  ...rest
+}: Props) {
+  const pal = usePalette('default')
+  const palInverted = usePalette('inverted')
+
   const {state, following, toggle} = useFollowProfile(profile)
 
   const onPress = React.useCallback(async () => {
@@ -37,11 +46,19 @@ export const FollowButton = observer(function FollowButtonImpl({
 
   return (
     <Button
+      StartIcon={
+        following ? (
+          <FontAwesomeIcon icon="check" style={[pal.text, s.mr2]} size={14} />
+        ) : (
+          <FontAwesomeIcon icon="plus" style={[palInverted.text, s.mr2]} />
+        )
+      }
       type={following ? followedType : unfollowedType}
       labelStyle={labelStyle}
       onPress={onPress}
       label={following ? 'Unfollow' : 'Follow'}
       withLoading={true}
+      {...rest}
     />
   )
 })

--- a/src/view/com/profile/ProfileHeader.tsx
+++ b/src/view/com/profile/ProfileHeader.tsx
@@ -40,6 +40,7 @@ import {makeProfileLink} from 'lib/routes/links'
 import {Link} from '../util/Link'
 import {ProfileHeaderSuggestedFollows} from './ProfileHeaderSuggestedFollows'
 import {logger} from '#/logger'
+import {FollowButton} from './FollowButton'
 
 interface Props {
   view: ProfileModel
@@ -111,7 +112,6 @@ const ProfileHeaderLoaded = observer(function ProfileHeaderLoadedImpl({
   isProfilePreview,
 }: Props) {
   const pal = usePalette('default')
-  const palInverted = usePalette('inverted')
   const store = useStores()
   const navigation = useNavigation<NavigationProp>()
   const {track} = useAnalytics()
@@ -355,6 +355,8 @@ const ProfileHeaderLoaded = observer(function ProfileHeaderLoadedImpl({
   const following = formatCount(view.followsCount)
   const followers = formatCount(view.followersCount)
   const pluralizedFollowers = pluralize(view.followersCount, 'follower')
+  const isFollowing =
+    store.me.follows.getFollowState(view.did) === FollowState.Following
 
   return (
     <View style={pal.view}>
@@ -413,7 +415,7 @@ const ProfileHeaderLoaded = observer(function ProfileHeaderLoadedImpl({
                       pal.text,
                       {
                         color: showSuggestedFollows
-                          ? colors.white
+                          ? pal.textInverted.color
                           : pal.text.color,
                       },
                     ]}
@@ -422,41 +424,22 @@ const ProfileHeaderLoaded = observer(function ProfileHeaderLoadedImpl({
                 </TouchableOpacity>
               )}
 
-              {store.me.follows.getFollowState(view.did) ===
-              FollowState.Following ? (
-                <TouchableOpacity
-                  testID="unfollowBtn"
-                  onPress={onPressToggleFollow}
-                  style={[styles.btn, styles.mainBtn, pal.btn]}
-                  accessibilityRole="button"
-                  accessibilityLabel={`Unfollow ${view.handle}`}
-                  accessibilityHint={`Hides posts from ${view.handle} in your feed`}>
-                  <FontAwesomeIcon
-                    icon="check"
-                    style={[pal.text, s.mr5]}
-                    size={14}
-                  />
-                  <Text type="button" style={pal.text}>
-                    Following
-                  </Text>
-                </TouchableOpacity>
-              ) : (
-                <TouchableOpacity
-                  testID="followBtn"
-                  onPress={onPressToggleFollow}
-                  style={[styles.btn, styles.mainBtn, palInverted.view]}
-                  accessibilityRole="button"
-                  accessibilityLabel={`Follow ${view.handle}`}
-                  accessibilityHint={`Shows posts from ${view.handle} in your feed`}>
-                  <FontAwesomeIcon
-                    icon="plus"
-                    style={[palInverted.text, s.mr5]}
-                  />
-                  <Text type="button" style={[palInverted.text, s.bold]}>
-                    Follow
-                  </Text>
-                </TouchableOpacity>
-              )}
+              <FollowButton
+                style={styles.btn}
+                testID={isFollowing ? 'unfollowBtn' : 'followBtn'}
+                unfollowedType="inverted"
+                profile={view}
+                accessibilityHint={
+                  isFollowing
+                    ? `Hides posts from ${view.handle} in your feed`
+                    : `Shows posts from ${view.handle} in your feed`
+                }
+                accessibilityLabel={`${isFollowing ? 'Unfollow' : 'Follow'} ${
+                  view.handle
+                }`}
+                onToggleFollow={onPressToggleFollow}
+                followedType="default"
+              />
             </>
           ) : null}
           {dropdownItems?.length ? (

--- a/src/view/com/util/forms/Button.tsx
+++ b/src/view/com/util/forms/Button.tsx
@@ -13,6 +13,7 @@ import {
 import {Text} from '../text/Text'
 import {useTheme} from 'lib/ThemeContext'
 import {choose} from 'lib/functions'
+import {s} from '#/lib/styles'
 
 type Event =
   | React.MouseEvent<HTMLAnchorElement, MouseEvent>
@@ -42,6 +43,8 @@ export function Button({
   type = 'primary',
   label,
   style,
+  StartIcon,
+  EndIcon,
   labelContainerStyle,
   labelStyle,
   onPress,
@@ -56,6 +59,8 @@ export function Button({
   type?: ButtonType
   label?: string
   style?: StyleProp<ViewStyle>
+  StartIcon?: React.ReactElement
+  EndIcon?: React.ReactElement
   labelContainerStyle?: StyleProp<ViewStyle>
   labelStyle?: StyleProp<TextStyle>
   onPress?: () => void | Promise<void>
@@ -169,29 +174,40 @@ export function Button({
     [typeOuterStyle, style],
   )
 
-  const renderChildern = React.useCallback(() => {
+  const renderChildren = React.useCallback(() => {
     if (!label) {
       return children
     }
 
     return (
       <View style={[styles.labelContainer, labelContainerStyle]}>
+        {React.isValidElement(StartIcon) && !isLoading ? StartIcon : null}
+
         {label && withLoading && isLoading ? (
-          <ActivityIndicator size={12} color={typeLabelStyle.color} />
+          <ActivityIndicator
+            style={s.mr2}
+            size={12}
+            color={typeLabelStyle.color}
+          />
         ) : null}
+
         <Text type="button" style={[typeLabelStyle, labelStyle]}>
           {label}
         </Text>
+
+        {React.isValidElement(EndIcon) && !isLoading && EndIcon}
       </View>
     )
   }, [
-    children,
     label,
+    labelContainerStyle,
+    StartIcon,
     withLoading,
     isLoading,
-    labelContainerStyle,
     typeLabelStyle,
     labelStyle,
+    EndIcon,
+    children,
   ])
 
   return (
@@ -205,7 +221,7 @@ export function Button({
       accessibilityHint={accessibilityHint}
       accessibilityLabelledBy={accessibilityLabelledBy}
       onAccessibilityEscape={onAccessibilityEscape}>
-      {renderChildern}
+      {renderChildren}
     </Pressable>
   )
 }
@@ -217,6 +233,7 @@ const styles = StyleSheet.create({
     borderRadius: 24,
   },
   labelContainer: {
+    alignItems: 'center',
     flexDirection: 'row',
     gap: 8,
   },


### PR DESCRIPTION
## Web
https://github.com/bluesky-social/social-app/assets/61876765/61a5bfcb-4fbf-4008-9efa-d1b58d1481b6

## App
https://github.com/bluesky-social/social-app/assets/61876765/80161937-954a-48db-846b-d904bc2617ae


- In the current state, the `ProfileHeader` component uses custom `TouchableOpacity` components to display the Follow/Unfollow Action button, despite the fact that we already have a pre-existing `FollowButton` component in the app. 

- Suggested follows icon is not visible in dark mode. It is being displayed as white circle when `showSuggestFollows` is set to `true`.

- Furthermore, when the follow/unfollow action is initiated, the button interactions remain active, and there is no loading indicator displayed which may confuse the user.

To address these issues, we should:

- Utilize the existing `FollowButton` component within the `ProfileHeader`.
- Changing Suggested follows icon's color to correct one.
- Enhance the `Button` component by introducing `StartIcon` and `EndIcon` props, enabling the rendering of additional icons such as a plus sign (+) or a checkmark (✓) alongside the follow/unfollow text in `FollowButton` component. By using `Button` component, we eliminate the need of controlling loading state to disable interactions on the button since it is already being internally handled by the `Button` component itself.



## App demo after changes

https://github.com/bluesky-social/social-app/assets/61876765/040da00b-c2ab-4c3f-a47f-86c36ff8a5d4


## Web demo after changes


https://github.com/bluesky-social/social-app/assets/61876765/30aa6a74-ef39-4d4b-8f9e-4ffc39346194







