### PR TITLE
Fix jump in suggested follows tab on blur action (Native)

### DIFF
--- a/src/view/com/profile/ProfileCard.tsx
+++ b/src/view/com/profile/ProfileCard.tsx
@@ -223,7 +223,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   layoutAvi: {
-    alignSelf: 'baseline',
+    alignSelf: 'flex-start',
     width: 54,
     paddingLeft: 4,
     paddingTop: 10,
@@ -247,6 +247,7 @@ const styles = StyleSheet.create({
     paddingLeft: 54,
     paddingRight: 10,
     paddingBottom: 10,
+    paddingTop: 15,
   },
   pills: {
     flexDirection: 'row',


### PR DESCRIPTION
`ProfileCard` item's description text jumps/flickers when blur action is executed on search input in suggested follows tab.  

### Android

https://github.com/bluesky-social/social-app/assets/61876765/e212fc72-de6c-4d54-9658-808ac1a678eb

### iOS

https://github.com/bluesky-social/social-app/assets/61876765/3bcfecd0-4041-4d6a-8c64-d525d1947603


## Result

Apparently, `alignSelf: 'baseline'` is the root cause of this issue. To address this, we could replace `baseline` with `flex-start` which ultimately aligns avatar with user's name. Furthermore, we need to add necessary `paddingTop` to add spacing between description content and top content of the `ProfileCard`.

### Android

https://github.com/bluesky-social/social-app/assets/61876765/22d14256-6cc3-42e0-ac00-921fd5da2996


### iOS

https://github.com/bluesky-social/social-app/assets/61876765/84fd4141-7034-4869-9c78-1cc08c367775

