### PR TITLE
Hide/show header and footer without re-renders, take two

### DIFF
--- a/src/lib/hooks/useMinimalShellMode.tsx
+++ b/src/lib/hooks/useMinimalShellMode.tsx
@@ -1,57 +1,60 @@
-import React from 'react'
 import {
-  Easing,
+  AnimatableValue,
   interpolate,
   useAnimatedStyle,
-  useSharedValue,
   withTiming,
+  Easing,
 } from 'react-native-reanimated'
 
 import {useMinimalShellMode as useMinimalShellModeState} from '#/state/shell/minimal-mode'
 
+function withShellTiming<T extends AnimatableValue>(value: T): T {
+  'worklet'
+  return withTiming(value, {
+    duration: 125,
+    easing: Easing.bezier(0.25, 0.1, 0.25, 1),
+  })
+}
+
 export function useMinimalShellMode() {
-  const minimalShellMode = useMinimalShellModeState()
-  const minimalShellInterp = useSharedValue(0)
+  const mode = useMinimalShellModeState()
   const footerMinimalShellTransform = useAnimatedStyle(() => {
     return {
-      pointerEvents: minimalShellInterp.value === 0 ? 'auto' : 'none',
-      opacity: interpolate(minimalShellInterp.value, [0, 1], [1, 0]),
+      pointerEvents: mode.value ? 'none' : 'auto',
+      opacity: withShellTiming(interpolate(mode.value ? 1 : 0, [0, 1], [1, 0])),
       transform: [
-        {translateY: interpolate(minimalShellInterp.value, [0, 1], [0, 25])},
+        {
+          translateY: withShellTiming(
+            interpolate(mode.value ? 1 : 0, [0, 1], [0, 25]),
+          ),
+        },
       ],
     }
   })
   const headerMinimalShellTransform = useAnimatedStyle(() => {
     return {
-      pointerEvents: minimalShellInterp.value === 0 ? 'auto' : 'none',
-      opacity: interpolate(minimalShellInterp.value, [0, 1], [1, 0]),
+      pointerEvents: mode.value ? 'none' : 'auto',
+      opacity: withShellTiming(interpolate(mode.value ? 1 : 0, [0, 1], [1, 0])),
       transform: [
-        {translateY: interpolate(minimalShellInterp.value, [0, 1], [0, -25])},
+        {
+          translateY: withShellTiming(
+            interpolate(mode.value ? 1 : 0, [0, 1], [0, -25]),
+          ),
+        },
       ],
     }
   })
   const fabMinimalShellTransform = useAnimatedStyle(() => {
     return {
       transform: [
-        {translateY: interpolate(minimalShellInterp.value, [0, 1], [-44, 0])},
+        {
+          translateY: withShellTiming(
+            interpolate(mode.value ? 1 : 0, [0, 1], [-44, 0]),
+          ),
+        },
       ],
     }
   })
-
-  React.useEffect(() => {
-    if (minimalShellMode) {
-      minimalShellInterp.value = withTiming(1, {
-        duration: 125,
-        easing: Easing.bezier(0.25, 0.1, 0.25, 1),
-      })
-    } else {
-      minimalShellInterp.value = withTiming(0, {
-        duration: 125,
-        easing: Easing.bezier(0.25, 0.1, 0.25, 1),
-      })
-    }
-  }, [minimalShellInterp, minimalShellMode])
-
   return {
     footerMinimalShellTransform,
     headerMinimalShellTransform,

--- a/src/lib/hooks/useMinimalShellMode.tsx
+++ b/src/lib/hooks/useMinimalShellMode.tsx
@@ -15,6 +15,7 @@ export function useMinimalShellMode() {
   const minimalShellInterp = useSharedValue(0)
   const footerMinimalShellTransform = useAnimatedStyle(() => {
     return {
+      pointerEvents: minimalShellMode ? 'none' : 'auto',
       opacity: interpolate(minimalShellInterp.value, [0, 1], [1, 0]),
       transform: [
         {translateY: interpolate(minimalShellInterp.value, [0, 1], [0, 25])},
@@ -23,6 +24,7 @@ export function useMinimalShellMode() {
   })
   const headerMinimalShellTransform = useAnimatedStyle(() => {
     return {
+      pointerEvents: minimalShellMode ? 'none' : 'auto',
       opacity: interpolate(minimalShellInterp.value, [0, 1], [1, 0]),
       transform: [
         {translateY: interpolate(minimalShellInterp.value, [0, 1], [0, -25])},
@@ -54,7 +56,6 @@ export function useMinimalShellMode() {
   }, [minimalShellInterp, minimalShellMode])
 
   return {
-    minimalShellMode,
     footerMinimalShellTransform,
     headerMinimalShellTransform,
     fabMinimalShellTransform,

--- a/src/lib/hooks/useMinimalShellMode.tsx
+++ b/src/lib/hooks/useMinimalShellMode.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import {autorun} from 'mobx'
 import {
   Easing,
   interpolate,
@@ -15,7 +14,7 @@ export function useMinimalShellMode() {
   const minimalShellInterp = useSharedValue(0)
   const footerMinimalShellTransform = useAnimatedStyle(() => {
     return {
-      pointerEvents: minimalShellMode ? 'none' : 'auto',
+      pointerEvents: minimalShellInterp.value === 0 ? 'auto' : 'none',
       opacity: interpolate(minimalShellInterp.value, [0, 1], [1, 0]),
       transform: [
         {translateY: interpolate(minimalShellInterp.value, [0, 1], [0, 25])},
@@ -24,7 +23,7 @@ export function useMinimalShellMode() {
   })
   const headerMinimalShellTransform = useAnimatedStyle(() => {
     return {
-      pointerEvents: minimalShellMode ? 'none' : 'auto',
+      pointerEvents: minimalShellInterp.value === 0 ? 'auto' : 'none',
       opacity: interpolate(minimalShellInterp.value, [0, 1], [1, 0]),
       transform: [
         {translateY: interpolate(minimalShellInterp.value, [0, 1], [0, -25])},
@@ -40,19 +39,17 @@ export function useMinimalShellMode() {
   })
 
   React.useEffect(() => {
-    return autorun(() => {
-      if (minimalShellMode) {
-        minimalShellInterp.value = withTiming(1, {
-          duration: 125,
-          easing: Easing.bezier(0.25, 0.1, 0.25, 1),
-        })
-      } else {
-        minimalShellInterp.value = withTiming(0, {
-          duration: 125,
-          easing: Easing.bezier(0.25, 0.1, 0.25, 1),
-        })
-      }
-    })
+    if (minimalShellMode) {
+      minimalShellInterp.value = withTiming(1, {
+        duration: 125,
+        easing: Easing.bezier(0.25, 0.1, 0.25, 1),
+      })
+    } else {
+      minimalShellInterp.value = withTiming(0, {
+        duration: 125,
+        easing: Easing.bezier(0.25, 0.1, 0.25, 1),
+      })
+    }
   }, [minimalShellInterp, minimalShellMode])
 
   return {

--- a/src/lib/hooks/useOnMainScroll.ts
+++ b/src/lib/hooks/useOnMainScroll.ts
@@ -33,9 +33,12 @@ export function useOnMainScroll(): [OnScrollCb, boolean, ResetCb] {
         const dy = y - (lastY.current || 0)
         lastY.current = y
 
-        if (!minimalShellMode && dy > dyLimitDown && y > Y_LIMIT) {
+        if (!minimalShellMode.value && dy > dyLimitDown && y > Y_LIMIT) {
           setMinimalShellMode(true)
-        } else if (minimalShellMode && (dy < dyLimitUp * -1 || y <= Y_LIMIT)) {
+        } else if (
+          minimalShellMode.value &&
+          (dy < dyLimitUp * -1 || y <= Y_LIMIT)
+        ) {
           setMinimalShellMode(false)
         }
 

--- a/src/state/shell/minimal-mode.tsx
+++ b/src/state/shell/minimal-mode.tsx
@@ -1,16 +1,28 @@
 import React from 'react'
+import {useSharedValue, SharedValue} from 'react-native-reanimated'
 
-type StateContext = boolean
+type StateContext = SharedValue<boolean>
 type SetContext = (v: boolean) => void
 
-const stateContext = React.createContext<StateContext>(false)
+const stateContext = React.createContext<StateContext>({
+  value: false,
+  addListener() {},
+  removeListener() {},
+  modify() {},
+})
 const setContext = React.createContext<SetContext>((_: boolean) => {})
 
 export function Provider({children}: React.PropsWithChildren<{}>) {
-  const [state, setState] = React.useState(false)
+  const mode = useSharedValue(false)
+  const setMode = React.useCallback(
+    (v: boolean) => {
+      mode.value = v
+    },
+    [mode],
+  )
   return (
-    <stateContext.Provider value={state}>
-      <setContext.Provider value={setState}>{children}</setContext.Provider>
+    <stateContext.Provider value={mode}>
+      <setContext.Provider value={setMode}>{children}</setContext.Provider>
     </stateContext.Provider>
   )
 }

--- a/src/view/com/pager/FeedsTabBarMobile.tsx
+++ b/src/view/com/pager/FeedsTabBarMobile.tsx
@@ -25,7 +25,7 @@ export const FeedsTabBar = observer(function FeedsTabBarImpl(
   const setDrawerOpen = useSetDrawerOpen()
   const items = useHomeTabs(store.preferences.pinnedFeeds)
   const brandBlue = useColorSchemeStyle(s.brandBlue, s.blue3)
-  const {minimalShellMode, headerMinimalShellTransform} = useMinimalShellMode()
+  const {headerMinimalShellTransform} = useMinimalShellMode()
 
   const onPressAvi = React.useCallback(() => {
     setDrawerOpen(true)
@@ -38,7 +38,6 @@ export const FeedsTabBar = observer(function FeedsTabBarImpl(
         pal.border,
         styles.tabBar,
         headerMinimalShellTransform,
-        minimalShellMode && styles.disabled,
       ]}>
       <View style={[pal.view, styles.topBar]}>
         <View style={[pal.view]}>
@@ -109,8 +108,5 @@ const styles = StyleSheet.create({
   },
   title: {
     fontSize: 21,
-  },
-  disabled: {
-    pointerEvents: 'none',
   },
 })

--- a/src/view/screens/PostThread.tsx
+++ b/src/view/screens/PostThread.tsx
@@ -19,13 +19,11 @@ import {logger} from '#/logger'
 import {useMinimalShellMode} from 'lib/hooks/useMinimalShellMode'
 import {useSetMinimalShellMode} from '#/state/shell'
 
-const SHELL_FOOTER_HEIGHT = 44
-
 type Props = NativeStackScreenProps<CommonNavigatorParams, 'PostThread'>
 export const PostThreadScreen = withAuthRequired(
   observer(function PostThreadScreenImpl({route}: Props) {
     const store = useStores()
-    // const {} = useMinimalShellMode()
+    const {fabMinimalShellTransform} = useMinimalShellMode()
     const setMinimalShellMode = useSetMinimalShellMode()
     const safeAreaInsets = useSafeAreaInsets()
     const {name, rkey} = route.params
@@ -89,10 +87,9 @@ export const PostThreadScreen = withAuthRequired(
           <Animated.View
             style={[
               styles.prompt,
-              // TODO: minimal shell mode ajustment
+              fabMinimalShellTransform,
               {
-                bottom:
-                  SHELL_FOOTER_HEIGHT + clamp(safeAreaInsets.bottom, 15, 30),
+                bottom: clamp(safeAreaInsets.bottom, 15, 30),
               },
             ]}>
             <ComposePrompt onPressCompose={onPressReply} />

--- a/src/view/screens/PostThread.tsx
+++ b/src/view/screens/PostThread.tsx
@@ -1,5 +1,6 @@
 import React, {useMemo} from 'react'
 import {InteractionManager, StyleSheet, View} from 'react-native'
+import Animated from 'react-native-reanimated'
 import {useFocusEffect} from '@react-navigation/native'
 import {observer} from 'mobx-react-lite'
 import {NativeStackScreenProps, CommonNavigatorParams} from 'lib/routes/types'
@@ -15,7 +16,8 @@ import {useSafeAreaInsets} from 'react-native-safe-area-context'
 import {clamp} from 'lodash'
 import {useWebMediaQueries} from 'lib/hooks/useWebMediaQueries'
 import {logger} from '#/logger'
-import {useMinimalShellMode, useSetMinimalShellMode} from '#/state/shell'
+import {useMinimalShellMode} from 'lib/hooks/useMinimalShellMode'
+import {useSetMinimalShellMode} from '#/state/shell'
 
 const SHELL_FOOTER_HEIGHT = 44
 
@@ -23,7 +25,7 @@ type Props = NativeStackScreenProps<CommonNavigatorParams, 'PostThread'>
 export const PostThreadScreen = withAuthRequired(
   observer(function PostThreadScreenImpl({route}: Props) {
     const store = useStores()
-    const minimalShellMode = useMinimalShellMode()
+    // const {} = useMinimalShellMode()
     const setMinimalShellMode = useSetMinimalShellMode()
     const safeAreaInsets = useSafeAreaInsets()
     const {name, rkey} = route.params
@@ -83,17 +85,18 @@ export const PostThreadScreen = withAuthRequired(
             treeView={!!store.preferences.thread.lab_treeViewEnabled}
           />
         </View>
-        {isMobile && !minimalShellMode && (
-          <View
+        {isMobile && (
+          <Animated.View
             style={[
               styles.prompt,
+              // TODO: minimal shell mode ajustment
               {
                 bottom:
                   SHELL_FOOTER_HEIGHT + clamp(safeAreaInsets.bottom, 15, 30),
               },
             ]}>
             <ComposePrompt onPressCompose={onPressReply} />
-          </View>
+          </Animated.View>
         )}
       </View>
     )

--- a/src/view/shell/bottom-bar/BottomBar.tsx
+++ b/src/view/shell/bottom-bar/BottomBar.tsx
@@ -39,7 +39,7 @@ export const BottomBar = observer(function BottomBarImpl({
   const {isAtHome, isAtSearch, isAtFeeds, isAtNotifications, isAtMyProfile} =
     useNavigationTabState()
 
-  const {minimalShellMode, footerMinimalShellTransform} = useMinimalShellMode()
+  const {footerMinimalShellTransform} = useMinimalShellMode()
   const {notifications} = store.me
 
   const onPressTab = React.useCallback(
@@ -85,7 +85,6 @@ export const BottomBar = observer(function BottomBarImpl({
         pal.border,
         {paddingBottom: clamp(safeAreaInsets.bottom, 15, 30)},
         footerMinimalShellTransform,
-        minimalShellMode && styles.disabled,
       ]}>
       <Btn
         testID="bottomBarHomeBtn"

--- a/src/view/shell/bottom-bar/BottomBarStyles.tsx
+++ b/src/view/shell/bottom-bar/BottomBarStyles.tsx
@@ -65,7 +65,4 @@ export const styles = StyleSheet.create({
     borderWidth: 1,
     borderRadius: 100,
   },
-  disabled: {
-    pointerEvents: 'none',
-  },
 })


### PR DESCRIPTION
Re-doing the fix from https://github.com/bluesky-social/social-app/pull/1691 which regressed in https://github.com/bluesky-social/social-app/pull/1676.

This time it's easier to fix at the source. Now that we've moved the shell state into React, I've changed the source of truth to be an Animated value. We can change it directly and make all animations derived from it.

In the future, we should also change this to update with scroll but for now I left it discrete.

## Verification

```diff
// ReactNativeRenderer-dev.js
+let RENDERS = []
    
+setInterval(() => {
+  console.log('new renders:', RENDERS.join(', '))
+  RENDERS = []
+}, 1000)
    
function renderWithHooks(
  current,
  workInProgress,
  Component,
  props,
  secondArg,
  nextRenderLanes
) {
+  RENDERS.push(Component.name)
```

### Before

https://github.com/bluesky-social/social-app/assets/810438/08fd683e-f3cd-4769-814e-9dc6911924a8

### After

https://github.com/bluesky-social/social-app/assets/810438/d18fb4bb-b37d-4e22-b3c7-fa85591cb88d

## Impact

Low/mid-range Android.

### Before

https://github.com/bluesky-social/social-app/assets/810438/be57d152-d1e8-4bc3-9a2d-b5161c2ac63d

### After

https://github.com/bluesky-social/social-app/assets/810438/1a74a3bf-b871-40d6-9eb0-e30a818268b0

## Test Plan

Verified these elements hide/show as expected:

- Top bar
- Bottom bar
- FAB
- Load latest
- Sticky "reply to thread"

