### PR TITLE
Fix tab alignment on the web

### DIFF
--- a/src/view/com/pager/FeedsTabBarMobile.tsx
+++ b/src/view/com/pager/FeedsTabBarMobile.tsx
@@ -97,7 +97,6 @@ const styles = StyleSheet.create({
     right: 0,
     top: 0,
     flexDirection: 'column',
-    alignItems: 'center',
     borderBottomWidth: 1,
   },
   topBar: {


### PR DESCRIPTION
Fixes an issue @ansh pointed out in another PR.

This line seems to only affect web; I don't see any difference on iOS and Android.

It's pretty odd that none of these styles have changed in a while:

<img width="953" alt="Screenshot 2023-11-09 at 21 52 10" src="https://github.com/bluesky-social/social-app/assets/810438/94a96983-a8f7-4583-9ea5-c8600cb50d90">

So I don't know how it could have regressed recently, but whatever.

## Test Plan

Before:


https://github.com/bluesky-social/social-app/assets/810438/d245406b-e3f0-42da-ac9e-02a5b8afe7eb



After:


https://github.com/bluesky-social/social-app/assets/810438/4e9daf14-2464-4d2b-a296-8e18fd4b8c0b

