### PR TITLE
Work around web stale closure bug in Reanimated

### DIFF
--- a/src/lib/hooks/useAnimatedScrollHandler_FIXED.ts
+++ b/src/lib/hooks/useAnimatedScrollHandler_FIXED.ts
@@ -1,0 +1,1 @@
+export {useAnimatedScrollHandler} from 'react-native-reanimated'

--- a/src/lib/hooks/useAnimatedScrollHandler_FIXED.web.ts
+++ b/src/lib/hooks/useAnimatedScrollHandler_FIXED.web.ts
@@ -1,0 +1,44 @@
+import {useRef, useEffect} from 'react'
+import {useAnimatedScrollHandler as useAnimatedScrollHandler_BUGGY} from 'react-native-reanimated'
+
+export const useAnimatedScrollHandler: typeof useAnimatedScrollHandler_BUGGY = (
+  config,
+  deps,
+) => {
+  const ref = useRef(config)
+  useEffect(() => {
+    ref.current = config
+  })
+  return useAnimatedScrollHandler_BUGGY(
+    {
+      onBeginDrag(e) {
+        if (typeof ref.current !== 'function' && ref.current.onBeginDrag) {
+          ref.current.onBeginDrag(e)
+        }
+      },
+      onEndDrag(e) {
+        if (typeof ref.current !== 'function' && ref.current.onEndDrag) {
+          ref.current.onEndDrag(e)
+        }
+      },
+      onMomentumBegin(e) {
+        if (typeof ref.current !== 'function' && ref.current.onMomentumBegin) {
+          ref.current.onMomentumBegin(e)
+        }
+      },
+      onMomentumEnd(e) {
+        if (typeof ref.current !== 'function' && ref.current.onMomentumEnd) {
+          ref.current.onMomentumEnd(e)
+        }
+      },
+      onScroll(e) {
+        if (typeof ref.current === 'function') {
+          ref.current(e)
+        } else if (ref.current.onScroll) {
+          ref.current.onScroll(e)
+        }
+      },
+    },
+    deps,
+  )
+}

--- a/src/lib/hooks/useOnMainScroll.ts
+++ b/src/lib/hooks/useOnMainScroll.ts
@@ -4,12 +4,8 @@ import {useSetMinimalShellMode, useMinimalShellMode} from '#/state/shell'
 import {useShellLayout} from '#/state/shell/shell-layout'
 import {s} from 'lib/styles'
 import {isWeb} from 'platform/detection'
-import {
-  useAnimatedScrollHandler,
-  useSharedValue,
-  interpolate,
-  runOnJS,
-} from 'react-native-reanimated'
+import {useSharedValue, interpolate, runOnJS} from 'react-native-reanimated'
+import {useAnimatedScrollHandler} from './useAnimatedScrollHandler_FIXED'
 
 function clamp(num: number, min: number, max: number) {
   'worklet'

--- a/src/view/com/pager/PagerWithHeader.tsx
+++ b/src/view/com/pager/PagerWithHeader.tsx
@@ -3,7 +3,6 @@ import {LayoutChangeEvent, StyleSheet, View} from 'react-native'
 import Animated, {
   Easing,
   useAnimatedReaction,
-  useAnimatedScrollHandler,
   useAnimatedStyle,
   useSharedValue,
   withTiming,
@@ -13,6 +12,7 @@ import {Pager, PagerRef, RenderTabBarFnProps} from 'view/com/pager/Pager'
 import {TabBar} from './TabBar'
 import {useWebMediaQueries} from 'lib/hooks/useWebMediaQueries'
 import {OnScrollCb} from 'lib/hooks/useOnMainScroll'
+import {useAnimatedScrollHandler} from 'lib/hooks/useAnimatedScrollHandler_FIXED'
 
 const SCROLLED_DOWN_LIMIT = 200
 


### PR DESCRIPTION
Works around the "web" part of this bug: https://github.com/software-mansion/react-native-reanimated/issues/5360.

Concretely, Reanimated fails to update the event handlers, so we're going to proxy to the latest available version.

**I'm not touching the native side** because I don't know how I'd do this with worklets — also, it seems like we can avoid the bug on the native side by being careful and never passing the same handler to two views at the same time.

## Before

Notice that when you scroll back up, the button doesn't disappear. It's because `isScrolledDown` [here](https://github.com/bluesky-social/social-app/blob/487d871cfd89948f4db9944c4bb414d268a56537/src/lib/hooks/useOnMainScroll.ts#L52) forever stays `false` from the first render.

https://github.com/bluesky-social/social-app/assets/810438/41137eb0-e4ea-44b4-83c2-63493d436191

## After

The state variable has a fresh value in the event handler, so the button disappears as it should:

https://github.com/bluesky-social/social-app/assets/810438/99ee4c6c-b526-45b4-9bf2-c7f674a930bc

