### PR TITLE
Fix initial pager gap after fast scroll

### DIFF
--- a/src/view/com/pager/PagerWithHeader.tsx
+++ b/src/view/com/pager/PagerWithHeader.tsx
@@ -138,17 +138,20 @@ export const PagerWithHeader = React.forwardRef<PagerRef, PagerWithHeaderProps>(
       })
     }
 
+    const lastForcedScrollY = useSharedValue(0)
     const onScrollWorklet = React.useCallback(
       (e: NativeScrollEvent) => {
         'worklet'
         const nextScrollY = e.contentOffset.y
         scrollY.value = nextScrollY
 
-        if (nextScrollY < headerOnlyHeight) {
+        const forcedScrollY = Math.min(nextScrollY, headerOnlyHeight)
+        if (lastForcedScrollY.value !== forcedScrollY) {
+          lastForcedScrollY.value = forcedScrollY
           const refs = scrollRefs.value
           for (let i = 0; i < refs.length; i++) {
             if (i !== currentPage) {
-              scrollTo(refs[i], 0, nextScrollY, false)
+              scrollTo(refs[i], 0, forcedScrollY, false)
             }
           }
         }
@@ -158,7 +161,14 @@ export const PagerWithHeader = React.forwardRef<PagerRef, PagerWithHeaderProps>(
           runOnJS(setIsScrolledDown)(nextIsScrolledDown)
         }
       },
-      [currentPage, headerOnlyHeight, isScrolledDown, scrollRefs, scrollY],
+      [
+        currentPage,
+        headerOnlyHeight,
+        isScrolledDown,
+        scrollRefs,
+        scrollY,
+        lastForcedScrollY,
+      ],
     )
 
     const onPageSelectedInner = React.useCallback(


### PR DESCRIPTION
This fixes a bug in the new pager sync scrolling logic I've added in https://github.com/bluesky-social/social-app/pull/1863.

The previous code was saying: "sync scroll only if we didn't scroll past the header". The problem is that if we scroll fast, we're gonna have a large gap between the last event (which didn't reach the limit, but got synced) and the next event (which went over the limit, and didn't get synced).

Instead, let's track the last value that got synced. During every scroll, we'll calculate the new target, applying the limit. If we need to sync up the scroll, we'll do so and store the current value as the last one that got synced.

As a result, if we get an event that "overshoots" the header hiding threshold, we'll still adjust other pages to be exactly at that limit.

## Test Plan

Flicking one of the tabs down really fast no longer causes a blank space on other tabs.