### PR TITLE
Use min height for pager lists and increase it

### DIFF
--- a/src/view/com/lists/ListItems.tsx
+++ b/src/view/com/lists/ListItems.tsx
@@ -227,7 +227,7 @@ export const ListItems = observer(function ListItemsImpl({
           />
         }
         contentContainerStyle={{
-          paddingBottom: Dimensions.get('window').height - headerOffset,
+          minHeight: Dimensions.get('window').height * 1.5,
         }}
         style={{paddingTop: headerOffset}}
         onScroll={scrollHandler}

--- a/src/view/com/posts/Feed.tsx
+++ b/src/view/com/posts/Feed.tsx
@@ -179,7 +179,7 @@ export const Feed = observer(function Feed({
           />
         }
         contentContainerStyle={{
-          paddingBottom: Dimensions.get('window').height - headerOffset,
+          minHeight: Dimensions.get('window').height * 1.5,
         }}
         style={{paddingTop: headerOffset}}
         onScroll={onScroll != null ? scrollHandler : undefined}

--- a/src/view/screens/ProfileFeed.tsx
+++ b/src/view/screens/ProfileFeed.tsx
@@ -474,7 +474,7 @@ const AboutSection = observer(function AboutPageImpl({
       scrollEventThrottle={1}
       contentContainerStyle={{
         paddingTop: headerHeight,
-        paddingBottom: Dimensions.get('window').height - headerHeight,
+        minHeight: Dimensions.get('window').height * 1.5,
       }}
       onScroll={scrollHandler}>
       <View


### PR DESCRIPTION
For pager pages, we need to pad out enough space so that even if the pager is scrolled down, switching tabs does not cause a jump. The previous calculation I used didn't really make sense — it was too small in some cases.

I don't know the science behind which number to pick because it doesn't seem to actually correspond to the scrolled distance. Something's up with layout there. So I picked 1.5 screen heights which seems to be enough in my testing.

Also, it should be min height rather than bottom padding so that when the content is loaded, it doesn't stay at the tail.

¯\\_(ツ)_/¯