### PR TITLE
Refactor profile screen to use new pager and react-query

### DIFF
--- a/src/state/cache/profile-shadow.ts
+++ b/src/state/cache/profile-shadow.ts
@@ -1,0 +1,88 @@
+import {useEffect, useState, useCallback, useRef} from 'react'
+import EventEmitter from 'eventemitter3'
+import {AppBskyActorDefs} from '@atproto/api'
+
+const emitter = new EventEmitter()
+
+export interface ProfileShadow {
+  followingUri: string | undefined
+  muted: boolean | undefined
+  blockingUri: string | undefined
+}
+
+interface CacheEntry {
+  ts: number
+  value: ProfileShadow
+}
+
+type ProfileView =
+  | AppBskyActorDefs.ProfileView
+  | AppBskyActorDefs.ProfileViewBasic
+  | AppBskyActorDefs.ProfileViewDetailed
+
+export function useProfileShadow<T extends ProfileView>(
+  profile: T,
+  ifAfterTS: number,
+): T {
+  const [state, setState] = useState<CacheEntry>({
+    ts: Date.now(),
+    value: fromProfile(profile),
+  })
+  const firstRun = useRef(true)
+
+  const onUpdate = useCallback(
+    (value: Partial<ProfileShadow>) => {
+      setState(s => ({ts: Date.now(), value: {...s.value, ...value}}))
+    },
+    [setState],
+  )
+
+  // react to shadow updates
+  useEffect(() => {
+    emitter.addListener(profile.did, onUpdate)
+    return () => {
+      emitter.removeListener(profile.did, onUpdate)
+    }
+  }, [profile.did, onUpdate])
+
+  // react to profile updates
+  useEffect(() => {
+    // dont fire on first run to avoid needless re-renders
+    if (!firstRun.current) {
+      setState({ts: Date.now(), value: fromProfile(profile)})
+    }
+    firstRun.current = false
+  }, [profile])
+
+  return state.ts > ifAfterTS ? mergeShadow(profile, state.value) : profile
+}
+
+export function updateProfileShadow(
+  uri: string,
+  value: Partial<ProfileShadow>,
+) {
+  emitter.emit(uri, value)
+}
+
+function fromProfile(profile: ProfileView): ProfileShadow {
+  return {
+    followingUri: profile.viewer?.following,
+    muted: profile.viewer?.muted,
+    blockingUri: profile.viewer?.blocking,
+  }
+}
+
+function mergeShadow<T extends ProfileView>(
+  profile: T,
+  shadow: ProfileShadow,
+): T {
+  return {
+    ...profile,
+    viewer: {
+      ...(profile.viewer || {}),
+      following: shadow.followingUri,
+      muted: shadow.muted,
+      blocking: shadow.blockingUri,
+    },
+  }
+}

--- a/src/state/queries/profile.ts
+++ b/src/state/queries/profile.ts
@@ -1,13 +1,118 @@
-import {useQuery} from '@tanstack/react-query'
+import {AtUri} from '@atproto/api'
+import {useQuery, useQueryClient, useMutation} from '@tanstack/react-query'
+import {useSession} from '../session'
 
-import {PUBLIC_BSKY_AGENT} from '#/state/queries'
-
-export function useProfileQuery({did}: {did: string}) {
+export function useProfileQuery({did}: {did: string | undefined}) {
+  const {agent} = useSession()
   return useQuery({
-    queryKey: ['getProfile', did],
+    queryKey: ['profile', did],
     queryFn: async () => {
-      const res = await PUBLIC_BSKY_AGENT.getProfile({actor: did})
+      const res = await agent.getProfile({actor: did || ''})
       return res.data
+    },
+    enabled: !!did,
+  })
+}
+
+export function useProfileFollowMutation() {
+  const {agent} = useSession()
+  const queryClient = useQueryClient()
+  return useMutation<{uri: string; cid: string}, Error, {did: string}>({
+    mutationFn: async ({did}) => {
+      return await agent.follow(did)
+    },
+    onSuccess(data, variables) {
+      queryClient.invalidateQueries({
+        queryKey: ['profile', variables.did],
+      })
+    },
+  })
+}
+
+export function useProfileUnfollowMutation() {
+  const {agent} = useSession()
+  const queryClient = useQueryClient()
+  return useMutation<void, Error, {did: string; followUri: string}>({
+    mutationFn: async ({followUri}) => {
+      return await agent.deleteFollow(followUri)
+    },
+    onSuccess(data, variables) {
+      queryClient.invalidateQueries({
+        queryKey: ['profile', variables.did],
+      })
+    },
+  })
+}
+
+export function useProfileMuteMutation() {
+  const {agent} = useSession()
+  const queryClient = useQueryClient()
+  return useMutation<void, Error, {did: string}>({
+    mutationFn: async ({did}) => {
+      await agent.mute(did)
+    },
+    onSuccess(data, variables) {
+      queryClient.invalidateQueries({
+        queryKey: ['profile', variables.did],
+      })
+    },
+  })
+}
+
+export function useProfileUnmuteMutation() {
+  const {agent} = useSession()
+  const queryClient = useQueryClient()
+  return useMutation<void, Error, {did: string}>({
+    mutationFn: async ({did}) => {
+      await agent.unmute(did)
+    },
+    onSuccess(data, variables) {
+      queryClient.invalidateQueries({
+        queryKey: ['profile', variables.did],
+      })
+    },
+  })
+}
+
+export function useProfileBlockMutation() {
+  const {agent, currentAccount} = useSession()
+  const queryClient = useQueryClient()
+  return useMutation<{uri: string; cid: string}, Error, {did: string}>({
+    mutationFn: async ({did}) => {
+      if (!currentAccount) {
+        throw new Error('Not signed in')
+      }
+      return await agent.app.bsky.graph.block.create(
+        {repo: currentAccount.did},
+        {subject: did, createdAt: new Date().toISOString()},
+      )
+    },
+    onSuccess(data, variables) {
+      queryClient.invalidateQueries({
+        queryKey: ['profile', variables.did],
+      })
+    },
+  })
+}
+
+export function useProfileUnblockMutation() {
+  const {agent, currentAccount} = useSession()
+  const queryClient = useQueryClient()
+  return useMutation<void, Error, {did: string; blockUri: string}>({
+    mutationFn: async ({blockUri}) => {
+      if (!currentAccount) {
+        throw new Error('Not signed in')
+      }
+      const {rkey} = new AtUri(blockUri)
+      await agent.app.bsky.graph.block.delete({
+        repo: currentAccount.did,
+        rkey,
+      })
+    },
+    onSuccess(data, variables) {
+      queryClient.invalidateQueries({
+        queryKey: ['profile', variables.did],
+      })
     },
   })
 }

--- a/src/state/queries/profile.ts
+++ b/src/state/queries/profile.ts
@@ -3,10 +3,12 @@ import {useQuery, useMutation} from '@tanstack/react-query'
 import {useSession} from '../session'
 import {updateProfileShadow} from '../cache/profile-shadow'
 
+export const RQKEY = (did: string) => ['profile', did]
+
 export function useProfileQuery({did}: {did: string | undefined}) {
   const {agent} = useSession()
   return useQuery({
-    queryKey: ['profile', did],
+    queryKey: RQKEY(did),
     queryFn: async () => {
       const res = await agent.getProfile({actor: did || ''})
       return res.data

--- a/src/view/com/posts/FeedErrorMessage.tsx
+++ b/src/view/com/posts/FeedErrorMessage.tsx
@@ -13,6 +13,7 @@ import {logger} from '#/logger'
 import {useModalControls} from '#/state/modals'
 import {FeedDescriptor} from '#/state/queries/post-feed'
 import {EmptyState} from '../util/EmptyState'
+import {cleanError} from '#/lib/strings/errors'
 
 enum KnownError {
   Block,
@@ -69,7 +70,12 @@ export function FeedErrorMessage({
     )
   }
 
-  return <ErrorMessage message={error} onPressTryAgain={onPressTryAgain} />
+  return (
+    <ErrorMessage
+      message={cleanError(error)}
+      onPressTryAgain={onPressTryAgain}
+    />
+  )
 }
 
 function FeedgenErrorMessage({

--- a/src/view/com/profile/ProfileHeader.tsx
+++ b/src/view/com/profile/ProfileHeader.tsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import {observer} from 'mobx-react-lite'
 import {
   StyleSheet,
   TouchableOpacity,
@@ -8,15 +7,17 @@ import {
 } from 'react-native'
 import {FontAwesomeIcon} from '@fortawesome/react-native-fontawesome'
 import {useNavigation} from '@react-navigation/native'
+import {
+  AppBskyActorDefs,
+  ProfileModeration,
+  RichText as RichTextAPI,
+} from '@atproto/api'
+import {Trans, msg} from '@lingui/macro'
+import {useLingui} from '@lingui/react'
+import {NavigationProp} from 'lib/routes/types'
+import {isNative} from 'platform/detection'
 import {BlurView} from '../util/BlurView'
-import {ProfileModel} from 'state/models/content/profile'
-import {useStores} from 'state/index'
 import {ProfileImageLightbox} from 'state/models/ui/shell'
-import {pluralize} from 'lib/strings/helpers'
-import {toShareUrl} from 'lib/strings/url-helpers'
-import {sanitizeDisplayName} from 'lib/strings/display-names'
-import {sanitizeHandle} from 'lib/strings/handles'
-import {s, colors} from 'lib/styles'
 import * as Toast from '../util/Toast'
 import {LoadingPlaceholder} from '../util/LoadingPlaceholder'
 import {Text} from '../util/text/Text'
@@ -25,34 +26,48 @@ import {RichText} from '../util/text/RichText'
 import {UserAvatar} from '../util/UserAvatar'
 import {UserBanner} from '../util/UserBanner'
 import {ProfileHeaderAlerts} from '../util/moderation/ProfileHeaderAlerts'
+import {formatCount} from '../util/numeric/format'
+import {NativeDropdown, DropdownItem} from '../util/forms/NativeDropdown'
+import {Link} from '../util/Link'
+import {ProfileHeaderSuggestedFollows} from './ProfileHeaderSuggestedFollows'
+import {useStores} from 'state/index'
+import {FollowState} from 'state/models/cache/my-follows'
+import {useModalControls} from '#/state/modals'
+import {
+  useProfileFollowMutation,
+  useProfileUnfollowMutation,
+  useProfileMuteMutation,
+  useProfileUnmuteMutation,
+  useProfileBlockMutation,
+  useProfileUnblockMutation,
+} from '#/state/queries/profile'
 import {usePalette} from 'lib/hooks/usePalette'
 import {useAnalytics} from 'lib/analytics/analytics'
 import {useWebMediaQueries} from 'lib/hooks/useWebMediaQueries'
-import {NavigationProp} from 'lib/routes/types'
-import {isNative} from 'platform/detection'
-import {FollowState} from 'state/models/cache/my-follows'
-import {shareUrl} from 'lib/sharing'
-import {formatCount} from '../util/numeric/format'
-import {NativeDropdown, DropdownItem} from '../util/forms/NativeDropdown'
 import {BACK_HITSLOP} from 'lib/constants'
 import {isInvalidHandle} from 'lib/strings/handles'
 import {makeProfileLink} from 'lib/routes/links'
-import {Link} from '../util/Link'
-import {ProfileHeaderSuggestedFollows} from './ProfileHeaderSuggestedFollows'
+import {pluralize} from 'lib/strings/helpers'
+import {toShareUrl} from 'lib/strings/url-helpers'
+import {sanitizeDisplayName} from 'lib/strings/display-names'
+import {sanitizeHandle} from 'lib/strings/handles'
+import {shareUrl} from 'lib/sharing'
+import {s, colors} from 'lib/styles'
 import {logger} from '#/logger'
-import {Trans, msg} from '@lingui/macro'
-import {useLingui} from '@lingui/react'
-import {useModalControls} from '#/state/modals'
+import {UseMutationResult} from '@tanstack/react-query'
+import {useSession} from '#/state/session'
 
 interface Props {
-  view: ProfileModel
+  profile: AppBskyActorDefs.ProfileViewDetailed
+  moderation: ProfileModeration
   onRefreshAll: () => void
   hideBackButton?: boolean
   isProfilePreview?: boolean
 }
 
-export const ProfileHeader = observer(function ProfileHeaderImpl({
-  view,
+export function ProfileHeader({
+  profile,
+  moderation,
   onRefreshAll,
   hideBackButton = false,
   isProfilePreview,
@@ -61,7 +76,7 @@ export const ProfileHeader = observer(function ProfileHeaderImpl({
 
   // loading
   // =
-  if (!view || !view.hasLoaded) {
+  if (!profile) {
     return (
       <View style={pal.view}>
         <LoadingPlaceholder width="100%" height={153} />
@@ -75,22 +90,10 @@ export const ProfileHeader = observer(function ProfileHeaderImpl({
           </View>
           <View>
             <Text type="title-2xl" style={[pal.text, styles.title]}>
-              {sanitizeDisplayName(
-                view.displayName || sanitizeHandle(view.handle),
-              )}
+              <Trans>Loading...</Trans>
             </Text>
           </View>
         </View>
-      </View>
-    )
-  }
-
-  // error
-  // =
-  if (view.hasError) {
-    return (
-      <View testID="profileHeaderHasError">
-        <Text>{view.error}</Text>
       </View>
     )
   }
@@ -99,16 +102,18 @@ export const ProfileHeader = observer(function ProfileHeaderImpl({
   // =
   return (
     <ProfileHeaderLoaded
-      view={view}
+      profile={profile}
+      moderation={moderation}
       onRefreshAll={onRefreshAll}
       hideBackButton={hideBackButton}
       isProfilePreview={isProfilePreview}
     />
   )
-})
+}
 
-const ProfileHeaderLoaded = observer(function ProfileHeaderLoadedImpl({
-  view,
+function ProfileHeaderLoaded({
+  profile,
+  moderation,
   onRefreshAll,
   hideBackButton = false,
   isProfilePreview,
@@ -116,13 +121,52 @@ const ProfileHeaderLoaded = observer(function ProfileHeaderLoadedImpl({
   const pal = usePalette('default')
   const palInverted = usePalette('inverted')
   const store = useStores()
+  const {currentAccount} = useSession()
   const {_} = useLingui()
   const {openModal} = useModalControls()
   const navigation = useNavigation<NavigationProp>()
   const {track} = useAnalytics()
-  const invalidHandle = isInvalidHandle(view.handle)
+  const invalidHandle = isInvalidHandle(profile.handle)
   const {isDesktop} = useWebMediaQueries()
   const [showSuggestedFollows, setShowSuggestedFollows] = React.useState(false)
+  const descriptionRT = React.useMemo(
+    () =>
+      profile.description
+        ? new RichTextAPI({text: profile.description})
+        : undefined,
+    [profile],
+  )
+  const followMutation = useProfileFollowMutation()
+  const unfollowMutation = useProfileUnfollowMutation()
+  const muteMutation = useProfileMuteMutation()
+  const unmuteMutation = useProfileUnmuteMutation()
+  const blockMutation = useProfileBlockMutation()
+  const unblockMutation = useProfileUnblockMutation()
+
+  const optimistic = (
+    setMutation: {isPending: boolean},
+    unsetMutation: {isPending: boolean},
+    v: boolean,
+  ) => {
+    if (setMutation.isPending) return true
+    if (unsetMutation.isPending) return false
+    return v
+  }
+  const isFollowing = optimistic(
+    followMutation,
+    unfollowMutation,
+    !!profile.viewer?.following,
+  )
+  const isMuting = optimistic(
+    muteMutation,
+    unmuteMutation,
+    !!profile.viewer?.muted,
+  )
+  const isBlocking = optimistic(
+    blockMutation,
+    unblockMutation,
+    !!profile.viewer?.blocking,
+  )
 
   const onPressBack = React.useCallback(() => {
     if (navigation.canGoBack()) {
@@ -134,86 +178,96 @@ const ProfileHeaderLoaded = observer(function ProfileHeaderLoadedImpl({
 
   const onPressAvi = React.useCallback(() => {
     if (
-      view.avatar &&
-      !(view.moderation.avatar.blur && view.moderation.avatar.noOverride)
+      profile.avatar &&
+      !(moderation.avatar.blur && moderation.avatar.noOverride)
     ) {
-      store.shell.openLightbox(new ProfileImageLightbox(view))
+      store.shell.openLightbox(new ProfileImageLightbox(profile))
     }
-  }, [store, view])
+  }, [store, profile, moderation])
 
-  const onPressToggleFollow = React.useCallback(() => {
-    view?.toggleFollowing().then(
-      () => {
-        setShowSuggestedFollows(Boolean(view.viewer.following))
-        Toast.show(
-          `${
-            view.viewer.following ? 'Following' : 'No longer following'
-          } ${sanitizeDisplayName(view.displayName || view.handle)}`,
-        )
-        track(
-          view.viewer.following
-            ? 'ProfileHeader:FollowButtonClicked'
-            : 'ProfileHeader:UnfollowButtonClicked',
-        )
-      },
-      err => logger.error('Failed to toggle follow', {error: err}),
-    )
-  }, [track, view, setShowSuggestedFollows])
+  const onPressFollow = React.useCallback(async () => {
+    if (profile.viewer?.following) {
+      return
+    }
+    try {
+      track('ProfileHeader:FollowButtonClicked')
+      await followMutation.mutateAsync({did: profile.did})
+      Toast.show(
+        `Following ${sanitizeDisplayName(
+          profile.displayName || profile.handle,
+        )}`,
+      )
+    } catch (e) {
+      logger.error('Failed to follow', {error: String(e)})
+      Toast.show(`There was an issue! ${e.toString()}`)
+    }
+  }, [followMutation, profile, track])
+
+  const onPressUnfollow = React.useCallback(async () => {
+    if (!profile.viewer?.following) {
+      return
+    }
+    try {
+      track('ProfileHeader:UnfollowButtonClicked')
+      await unfollowMutation.mutateAsync({
+        did: profile.did,
+        followUri: profile.viewer?.following,
+      })
+      Toast.show(
+        `No longer following ${sanitizeDisplayName(
+          profile.displayName || profile.handle,
+        )}`,
+      )
+    } catch (e) {
+      logger.error('Failed to unfollow', {error: String(e)})
+      Toast.show(`There was an issue! ${e.toString()}`)
+    }
+  }, [unfollowMutation, profile, track])
 
   const onPressEditProfile = React.useCallback(() => {
     track('ProfileHeader:EditProfileButtonClicked')
     openModal({
       name: 'edit-profile',
-      profileView: view,
+      profileView: profile,
       onUpdate: onRefreshAll,
     })
-  }, [track, openModal, view, onRefreshAll])
-
-  const trackPress = React.useCallback(
-    (f: 'Followers' | 'Follows') => {
-      track(`ProfileHeader:${f}ButtonClicked`, {
-        handle: view.handle,
-      })
-    },
-    [track, view],
-  )
+  }, [track, openModal, profile, onRefreshAll])
 
   const onPressShare = React.useCallback(() => {
     track('ProfileHeader:ShareButtonClicked')
-    const url = toShareUrl(makeProfileLink(view))
-    shareUrl(url)
-  }, [track, view])
+    shareUrl(toShareUrl(makeProfileLink(profile)))
+  }, [track, profile])
 
   const onPressAddRemoveLists = React.useCallback(() => {
     track('ProfileHeader:AddToListsButtonClicked')
     openModal({
       name: 'user-add-remove-lists',
-      subject: view.did,
-      displayName: view.displayName || view.handle,
+      subject: profile.did,
+      displayName: profile.displayName || profile.handle,
     })
-  }, [track, view, openModal])
+  }, [track, profile, openModal])
 
   const onPressMuteAccount = React.useCallback(async () => {
     track('ProfileHeader:MuteAccountButtonClicked')
     try {
-      await view.muteAccount()
+      await muteMutation.mutateAsync({did: profile.did})
       Toast.show('Account muted')
     } catch (e: any) {
       logger.error('Failed to mute account', {error: e})
       Toast.show(`There was an issue! ${e.toString()}`)
     }
-  }, [track, view])
+  }, [track, muteMutation, profile])
 
   const onPressUnmuteAccount = React.useCallback(async () => {
     track('ProfileHeader:UnmuteAccountButtonClicked')
     try {
-      await view.unmuteAccount()
+      await unmuteMutation.mutateAsync({did: profile.did})
       Toast.show('Account unmuted')
     } catch (e: any) {
       logger.error('Failed to unmute account', {error: e})
       Toast.show(`There was an issue! ${e.toString()}`)
     }
-  }, [track, view])
+  }, [track, unmuteMutation, profile])
 
   const onPressBlockAccount = React.useCallback(async () => {
     track('ProfileHeader:BlockAccountButtonClicked')
@@ -223,8 +277,11 @@ const ProfileHeaderLoaded = observer(function ProfileHeaderLoadedImpl({
       message:
         'Blocked accounts cannot reply in your threads, mention you, or otherwise interact with you.',
       onPressConfirm: async () => {
+        if (profile.viewer?.blocking) {
+          return
+        }
         try {
-          await view.blockAccount()
+          await blockMutation.mutateAsync({did: profile.did})
           onRefreshAll()
           Toast.show('Account blocked')
         } catch (e: any) {
@@ -233,7 +290,7 @@ const ProfileHeaderLoaded = observer(function ProfileHeaderLoadedImpl({
         }
       },
     })
-  }, [track, view, openModal, onRefreshAll])
+  }, [track, blockMutation, profile, openModal, onRefreshAll])
 
   const onPressUnblockAccount = React.useCallback(async () => {
     track('ProfileHeader:UnblockAccountButtonClicked')
@@ -243,8 +300,14 @@ const ProfileHeaderLoaded = observer(function ProfileHeaderLoadedImpl({
       message:
         'The account will be able to interact with you after unblocking.',
       onPressConfirm: async () => {
+        if (!profile.viewer?.blocking) {
+          return
+        }
         try {
-          await view.unblockAccount()
+          await unblockMutation.mutateAsync({
+            did: profile.did,
+            blockUri: profile.viewer.blocking,
+          })
           onRefreshAll()
           Toast.show('Account unblocked')
         } catch (e: any) {
@@ -253,19 +316,19 @@ const ProfileHeaderLoaded = observer(function ProfileHeaderLoadedImpl({
         }
       },
     })
-  }, [track, view, openModal, onRefreshAll])
+  }, [track, unblockMutation, profile, openModal, onRefreshAll])
 
   const onPressReportAccount = React.useCallback(() => {
     track('ProfileHeader:ReportAccountButtonClicked')
     openModal({
       name: 'report',
-      did: view.did,
+      did: profile.did,
     })
-  }, [track, openModal, view])
+  }, [track, openModal, profile])
 
   const isMe = React.useMemo(
-    () => store.me.did === view.did,
-    [store.me.did, view.did],
+    () => currentAccount?.did === profile.did,
+    [currentAccount, profile],
   )
   const dropdownItems: DropdownItem[] = React.useMemo(() => {
     let items: DropdownItem[] = [
@@ -296,13 +359,11 @@ const ProfileHeaderLoaded = observer(function ProfileHeaderLoadedImpl({
       },
     })
     if (!isMe) {
-      if (!view.viewer.blocking) {
+      if (!isBlocking) {
         items.push({
           testID: 'profileHeaderDropdownMuteBtn',
-          label: view.viewer.muted ? 'Unmute Account' : 'Mute Account',
-          onPress: view.viewer.muted
-            ? onPressUnmuteAccount
-            : onPressMuteAccount,
+          label: isMuting ? 'Unmute Account' : 'Mute Account',
+          onPress: isMuting ? onPressUnmuteAccount : onPressMuteAccount,
           icon: {
             ios: {
               name: 'speaker.slash',
@@ -312,13 +373,11 @@ const ProfileHeaderLoaded = observer(function ProfileHeaderLoadedImpl({
           },
         })
       }
-      if (!view.viewer.blockingByList) {
+      if (!profile.viewer?.blockingByList) {
         items.push({
           testID: 'profileHeaderDropdownBlockBtn',
-          label: view.viewer.blocking ? 'Unblock Account' : 'Block Account',
-          onPress: view.viewer.blocking
-            ? onPressUnblockAccount
-            : onPressBlockAccount,
+          label: isBlocking ? 'Unblock Account' : 'Block Account',
+          onPress: isBlocking ? onPressUnblockAccount : onPressBlockAccount,
           icon: {
             ios: {
               name: 'person.fill.xmark',
@@ -344,9 +403,9 @@ const ProfileHeaderLoaded = observer(function ProfileHeaderLoadedImpl({
     return items
   }, [
     isMe,
-    view.viewer.muted,
-    view.viewer.blocking,
-    view.viewer.blockingByList,
+    isMuting,
+    isBlocking,
+    profile.viewer?.blockingByList,
     onPressShare,
     onPressUnmuteAccount,
     onPressMuteAccount,
@@ -356,14 +415,14 @@ const ProfileHeaderLoaded = observer(function ProfileHeaderLoadedImpl({
     onPressAddRemoveLists,
   ])
 
-  const blockHide = !isMe && (view.viewer.blocking || view.viewer.blockedBy)
-  const following = formatCount(view.followsCount)
-  const followers = formatCount(view.followersCount)
-  const pluralizedFollowers = pluralize(view.followersCount, 'follower')
+  const blockHide = !isMe && (isBlocking || profile.viewer?.blockedBy)
+  const following = formatCount(profile.followsCount || 0)
+  const followers = formatCount(profile.followersCount || 0)
+  const pluralizedFollowers = pluralize(profile.followersCount || 0, 'follower')
 
   return (
     <View style={pal.view}>
-      <UserBanner banner={view.banner} moderation={view.moderation.avatar} />
+      <UserBanner banner={profile.banner} moderation={moderation.avatar} />
       <View style={styles.content}>
         <View style={[styles.buttonsLine]}>
           {isMe ? (
@@ -378,8 +437,8 @@ const ProfileHeaderLoaded = observer(function ProfileHeaderLoadedImpl({
                 <Trans>Edit Profile</Trans>
               </Text>
             </TouchableOpacity>
-          ) : view.viewer.blocking ? (
-            view.viewer.blockingByList ? null : (
+          ) : isBlocking ? (
+            profile.viewer?.blockingByList ? null : (
               <TouchableOpacity
                 testID="unblockBtn"
                 onPress={onPressUnblockAccount}
@@ -392,7 +451,7 @@ const ProfileHeaderLoaded = observer(function ProfileHeaderLoadedImpl({
                 </Text>
               </TouchableOpacity>
             )
-          ) : !view.viewer.blockedBy ? (
+          ) : !profile.viewer?.blockedBy ? (
             <>
               {!isProfilePreview && (
                 <TouchableOpacity
@@ -410,7 +469,7 @@ const ProfileHeaderLoaded = observer(function ProfileHeaderLoadedImpl({
                     },
                   ]}
                   accessibilityRole="button"
-                  accessibilityLabel={`Show follows similar to ${view.handle}`}
+                  accessibilityLabel={`Show follows similar to ${profile.handle}`}
                   accessibilityHint={`Shows a list of users similar to this user.`}>
                   <FontAwesomeIcon
                     icon="user-plus"
@@ -427,15 +486,14 @@ const ProfileHeaderLoaded = observer(function ProfileHeaderLoadedImpl({
                 </TouchableOpacity>
               )}
 
-              {store.me.follows.getFollowState(view.did) ===
-              FollowState.Following ? (
+              {isFollowing ? (
                 <TouchableOpacity
                   testID="unfollowBtn"
-                  onPress={onPressToggleFollow}
+                  onPress={onPressUnfollow}
                   style={[styles.btn, styles.mainBtn, pal.btn]}
                   accessibilityRole="button"
-                  accessibilityLabel={`Unfollow ${view.handle}`}
-                  accessibilityHint={`Hides posts from ${view.handle} in your feed`}>
+                  accessibilityLabel={`Unfollow ${profile.handle}`}
+                  accessibilityHint={`Hides posts from ${profile.handle} in your feed`}>
                   <FontAwesomeIcon
                     icon="check"
                     style={[pal.text, s.mr5]}
@@ -448,11 +506,11 @@ const ProfileHeaderLoaded = observer(function ProfileHeaderLoadedImpl({
               ) : (
                 <TouchableOpacity
                   testID="followBtn"
-                  onPress={onPressToggleFollow}
+                  onPress={onPressFollow}
                   style={[styles.btn, styles.mainBtn, palInverted.view]}
                   accessibilityRole="button"
-                  accessibilityLabel={`Follow ${view.handle}`}
-                  accessibilityHint={`Shows posts from ${view.handle} in your feed`}>
+                  accessibilityLabel={`Follow ${profile.handle}`}
+                  accessibilityHint={`Shows posts from ${profile.handle} in your feed`}>
                   <FontAwesomeIcon
                     icon="plus"
                     style={[palInverted.text, s.mr5]}
@@ -482,13 +540,13 @@ const ProfileHeaderLoaded = observer(function ProfileHeaderLoadedImpl({
             type="title-2xl"
             style={[pal.text, styles.title]}>
             {sanitizeDisplayName(
-              view.displayName || sanitizeHandle(view.handle),
-              view.moderation.profile,
+              profile.displayName || sanitizeHandle(profile.handle),
+              moderation.profile,
             )}
           </Text>
         </View>
         <View style={styles.handleLine}>
-          {view.viewer.followedBy && !blockHide ? (
+          {profile.viewer?.followedBy && !blockHide ? (
             <View style={[styles.pill, pal.btn, s.mr5]}>
               <Text type="xs" style={[pal.text]}>
                 <Trans>Follows you</Trans>
@@ -503,7 +561,7 @@ const ProfileHeaderLoaded = observer(function ProfileHeaderLoadedImpl({
               invalidHandle ? styles.invalidHandle : undefined,
               styles.handle,
             ]}>
-            {invalidHandle ? '⚠Invalid Handle' : `@${view.handle}`}
+            {invalidHandle ? '⚠Invalid Handle' : `@${profile.handle}`}
           </ThemedText>
         </View>
         {!blockHide && (
@@ -512,8 +570,12 @@ const ProfileHeaderLoaded = observer(function ProfileHeaderLoadedImpl({
               <Link
                 testID="profileHeaderFollowersButton"
                 style={[s.flexRow, s.mr10]}
-                href={makeProfileLink(view, 'followers')}
-                onPressOut={() => trackPress('Followers')}
+                href={makeProfileLink(profile, 'followers')}
+                onPressOut={() =>
+                  track(`ProfileHeader:FollowersButtonClicked`, {
+                    handle: profile.handle,
+                  })
+                }
                 asAnchor
                 accessibilityLabel={`${followers} ${pluralizedFollowers}`}
                 accessibilityHint={'Opens followers list'}>
@@ -527,8 +589,12 @@ const ProfileHeaderLoaded = observer(function ProfileHeaderLoadedImpl({
               <Link
                 testID="profileHeaderFollowsButton"
                 style={[s.flexRow, s.mr10]}
-                href={makeProfileLink(view, 'follows')}
-                onPressOut={() => trackPress('Follows')}
+                href={makeProfileLink(profile, 'follows')}
+                onPressOut={() =>
+                  track(`ProfileHeader:FollowsButtonClicked`, {
+                    handle: profile.handle,
+                  })
+                }
                 asAnchor
                 accessibilityLabel={`${following} following`}
                 accessibilityHint={'Opens following list'}>
@@ -540,30 +606,28 @@ const ProfileHeaderLoaded = observer(function ProfileHeaderLoadedImpl({
                 </Text>
               </Link>
               <Text type="md" style={[s.bold, pal.text]}>
-                {formatCount(view.postsCount)}{' '}
+                {formatCount(profile.postsCount || 0)}{' '}
                 <Text type="md" style={[pal.textLight]}>
-                  {pluralize(view.postsCount, 'post')}
+                  {pluralize(profile.postsCount || 0, 'post')}
                 </Text>
               </Text>
             </View>
-            {view.description &&
-            view.descriptionRichText &&
-            !view.moderation.profile.blur ? (
+            {descriptionRT && !moderation.profile.blur ? (
               <RichText
                 testID="profileHeaderDescription"
                 style={[styles.description, pal.text]}
                 numberOfLines={15}
-                richText={view.descriptionRichText}
+                richText={descriptionRT}
               />
             ) : undefined}
           </>
         )}
-        <ProfileHeaderAlerts moderation={view.moderation} />
+        <ProfileHeaderAlerts moderation={moderation} />
       </View>
 
       {!isProfilePreview && (
         <ProfileHeaderSuggestedFollows
-          actorDid={view.did}
+          actorDid={profile.did}
           active={showSuggestedFollows}
           requestDismiss={() => setShowSuggestedFollows(!showSuggestedFollows)}
         />
@@ -588,20 +652,20 @@ const ProfileHeaderLoaded = observer(function ProfileHeaderLoadedImpl({
         testID="profileHeaderAviButton"
         onPress={onPressAvi}
         accessibilityRole="image"
-        accessibilityLabel={`View ${view.handle}'s avatar`}
+        accessibilityLabel={`View ${profile.handle}'s avatar`}
         accessibilityHint="">
         <View
           style={[pal.view, {borderColor: pal.colors.background}, styles.avi]}>
           <UserAvatar
             size={80}
-            avatar={view.avatar}
-            moderation={view.moderation.avatar}
+            avatar={profile.avatar}
+            moderation={moderation.avatar}
           />
         </View>
       </TouchableWithoutFeedback>
     </View>
   )
-})
+}
 
 const styles = StyleSheet.create({
   banner: {

--- a/src/view/com/profile/ProfileHeader.tsx
+++ b/src/view/com/profile/ProfileHeader.tsx
@@ -31,7 +31,6 @@ import {NativeDropdown, DropdownItem} from '../util/forms/NativeDropdown'
 import {Link} from '../util/Link'
 import {ProfileHeaderSuggestedFollows} from './ProfileHeaderSuggestedFollows'
 import {useStores} from 'state/index'
-import {FollowState} from 'state/models/cache/my-follows'
 import {useModalControls} from '#/state/modals'
 import {
   useProfileFollowMutation,
@@ -59,7 +58,6 @@ import {useSession} from '#/state/session'
 interface Props {
   profile: AppBskyActorDefs.ProfileViewDetailed
   moderation: ProfileModeration
-  onRefreshAll: () => void
   hideBackButton?: boolean
   isProfilePreview?: boolean
 }
@@ -67,7 +65,6 @@ interface Props {
 export function ProfileHeader({
   profile,
   moderation,
-  onRefreshAll,
   hideBackButton = false,
   isProfilePreview,
 }: Props) {
@@ -103,7 +100,6 @@ export function ProfileHeader({
     <ProfileHeaderLoaded
       profile={profile}
       moderation={moderation}
-      onRefreshAll={onRefreshAll}
       hideBackButton={hideBackButton}
       isProfilePreview={isProfilePreview}
     />
@@ -113,7 +109,6 @@ export function ProfileHeader({
 function ProfileHeaderLoaded({
   profile,
   moderation,
-  onRefreshAll,
   hideBackButton = false,
   isProfilePreview,
 }: Props) {
@@ -203,9 +198,8 @@ function ProfileHeaderLoaded({
     openModal({
       name: 'edit-profile',
       profileView: profile,
-      onUpdate: onRefreshAll,
     })
-  }, [track, openModal, profile, onRefreshAll])
+  }, [track, openModal, profile])
 
   const onPressShare = React.useCallback(() => {
     track('ProfileHeader:ShareButtonClicked')
@@ -256,7 +250,6 @@ function ProfileHeaderLoaded({
         }
         try {
           await blockMutation.mutateAsync({did: profile.did})
-          onRefreshAll()
           Toast.show('Account blocked')
         } catch (e: any) {
           logger.error('Failed to block account', {error: e})
@@ -264,7 +257,7 @@ function ProfileHeaderLoaded({
         }
       },
     })
-  }, [track, blockMutation, profile, openModal, onRefreshAll])
+  }, [track, blockMutation, profile, openModal])
 
   const onPressUnblockAccount = React.useCallback(async () => {
     track('ProfileHeader:UnblockAccountButtonClicked')
@@ -282,7 +275,6 @@ function ProfileHeaderLoaded({
             did: profile.did,
             blockUri: profile.viewer.blocking,
           })
-          onRefreshAll()
           Toast.show('Account unblocked')
         } catch (e: any) {
           logger.error('Failed to unblock account', {error: e})
@@ -290,7 +282,7 @@ function ProfileHeaderLoaded({
         }
       },
     })
-  }, [track, unblockMutation, profile, openModal, onRefreshAll])
+  }, [track, unblockMutation, profile, openModal])
 
   const onPressReportAccount = React.useCallback(() => {
     track('ProfileHeader:ReportAccountButtonClicked')

--- a/src/view/screens/PostThread.tsx
+++ b/src/view/screens/PostThread.tsx
@@ -49,7 +49,7 @@ export const PostThreadScreen = withAuthRequired(
         return
       }
       const thread = queryClient.getQueryData<ThreadNode>(
-        POST_THREAD_RQKEY(resolvedUri),
+        POST_THREAD_RQKEY(resolvedUri.uri),
       )
       if (thread?.type !== 'post') {
         return
@@ -67,7 +67,7 @@ export const PostThreadScreen = withAuthRequired(
         },
         onPost: () =>
           queryClient.invalidateQueries({
-            queryKey: POST_THREAD_RQKEY(resolvedUri || ''),
+            queryKey: POST_THREAD_RQKEY(resolvedUri.uri || ''),
           }),
       })
     }, [store, queryClient, resolvedUri])
@@ -82,7 +82,7 @@ export const PostThreadScreen = withAuthRequired(
             </CenteredView>
           ) : (
             <PostThreadComponent
-              uri={resolvedUri}
+              uri={resolvedUri?.uri}
               onPressReply={onPressReply}
               treeView={!!store.preferences.thread.lab_treeViewEnabled}
             />

--- a/src/view/screens/Profile.tsx
+++ b/src/view/screens/Profile.tsx
@@ -1,7 +1,9 @@
 import React, {useEffect, useMemo, useState} from 'react'
 import {ActivityIndicator, StyleSheet, View} from 'react-native'
-import {observer} from 'mobx-react-lite'
 import {useFocusEffect} from '@react-navigation/native'
+import {AppBskyActorDefs, moderateProfile, ModerationOpts} from '@atproto/api'
+import {Trans, msg} from '@lingui/macro'
+import {useLingui} from '@lingui/react'
 import {NativeStackScreenProps, CommonNavigatorParams} from 'lib/routes/types'
 import {withAuthRequired} from 'view/com/auth/withAuthRequired'
 import {ViewSelector, ViewSelectorHandle} from '../com/util/ViewSelector'
@@ -31,262 +33,215 @@ import {FeedSourceModel} from 'state/models/content/feed-source'
 import {useSetTitle} from 'lib/hooks/useSetTitle'
 import {combinedDisplayName} from 'lib/strings/display-names'
 import {logger} from '#/logger'
-import {useAnimatedScrollHandler} from 'react-native-reanimated'
-
-import {ProfileModel} from 'state/models/content/profile'
-import {PostsFeedModel} from 'state/models/feeds/posts'
-import {ActorFeedsModel} from 'state/models/lists/actor-feeds'
-import {ListsListModel} from 'state/models/lists-list'
+import {OnScrollHandler} from '#/lib/hooks/useOnMainScroll'
+import {FeedDescriptor} from '#/state/queries/post-feed'
+import {useResolveDidQuery} from '#/state/queries/resolve-uri'
+import {useProfileQuery} from '#/state/queries/profile'
+import {useSession} from '#/state/session'
+import {useModerationOpts} from '#/state/queries/preferences'
+import {useSetDrawerSwipeDisabled, useSetMinimalShellMode} from '#/state/shell'
+import {cleanError} from '#/lib/strings/errors'
 
 const SECTION_TITLES_PROFILE = ['Posts', 'Posts & Replies', 'Media', 'Likes']
 
-import {Trans, msg} from '@lingui/macro'
-import {useLingui} from '@lingui/react'
-import {useSetDrawerSwipeDisabled, useSetMinimalShellMode} from '#/state/shell'
-import {OnScrollCb} from '#/lib/hooks/useOnMainScroll'
-
 type Props = NativeStackScreenProps<CommonNavigatorParams, 'Profile'>
-export const ProfileScreen = withAuthRequired(
-  observer(function ProfileScreenImpl({route}: Props) {
-    const store = useStores()
-    const setMinimalShellMode = useSetMinimalShellMode()
-    const {screen, track} = useAnalytics()
-    const [currentPage, setCurrentPage] = React.useState(0)
-    const {_} = useLingui()
-    const viewSelectorRef = React.useRef<ViewSelectorHandle>(null)
-    const setDrawerSwipeDisabled = useSetDrawerSwipeDisabled()
-    const name = route.params.name === 'me' ? store.me.did : route.params.name
+export const ProfileScreen = withAuthRequired(function ProfileScreenImpl({
+  route,
+}: Props) {
+  const {currentAccount} = useSession()
+  const name =
+    route.params.name === 'me' ? currentAccount?.did : route.params.name
+  const moderationOpts = useModerationOpts()
+  const {data: resolvedDid, error: resolveError} = useResolveDidQuery(name)
+  const {data: profile, error: profileError} = useProfileQuery({
+    did: resolvedDid?.did,
+  })
+  if (resolveError || profileError) {
+    return (
+      <CenteredView>
+        <ErrorScreen
+          testID="profileErrorScreen"
+          title="Oops!"
+          message={cleanError(resolveError || profileError)}
+        />
+      </CenteredView>
+    )
+  }
+  if (profile && moderationOpts) {
+    return (
+      <ProfileScreenLoaded
+        profile={profile}
+        moderationOpts={moderationOpts}
+        hideBackButton={!!route.params.hideBackButton}
+      />
+    )
+  }
+  return (
+    <CenteredView>
+      <View style={s.p20}>
+        <ActivityIndicator size="large" />
+      </View>
+    </CenteredView>
+  )
+})
 
-    const profile = useMemo(() => {
-      const model = new ProfileModel(store, {actor: name})
-      model.setup() // TODO
-      return model
-    }, [name, store])
+function ProfileScreenLoaded({
+  profile,
+  moderationOpts,
+  hideBackButton,
+}: {
+  profile: AppBskyActorDefs.ProfileViewDetailed
+  moderationOpts: ModerationOpts
+  hideBackButton: boolean
+}) {
+  const store = useStores()
+  const {currentAccount} = useSession()
+  const setMinimalShellMode = useSetMinimalShellMode()
+  const {screen, track} = useAnalytics()
+  const [currentPage, setCurrentPage] = React.useState(0)
+  const {_} = useLingui()
+  const viewSelectorRef = React.useRef<ViewSelectorHandle>(null)
+  const setDrawerSwipeDisabled = useSetDrawerSwipeDisabled()
 
-    const postsFeed = useMemo(() => {
-      const model = new PostsFeedModel(store, 'author', {
-        actor: name,
-        limit: 10,
-        filter: 'posts_no_replies',
-      })
-      return model
-    }, [name, store])
+  const moderation = useMemo(
+    () => moderateProfile(profile, moderationOpts),
+    [profile, moderationOpts],
+  )
 
-    const postsWithRepliesFeed = useMemo(() => {
-      const model = new PostsFeedModel(store, 'author', {
-        actor: name,
-        limit: 10,
-        filter: 'posts_with_replies',
-      })
-      return model
-    }, [name, store])
-
-    const postsWithMediaFeed = useMemo(() => {
-      const model = new PostsFeedModel(store, 'author', {
-        actor: name,
-        limit: 10,
-        filter: 'posts_with_media',
-      })
-      return model
-    }, [name, store])
-
-    const likesFeed = useMemo(() => {
-      const model = new PostsFeedModel(
-        store,
-        'likes',
-        {
-          actor: name,
-          limit: 10,
-        },
-        {
-          isSimpleFeed: true,
-        },
-      )
-      return model
-    }, [name, store])
-
-    useEffect(() => {
-      switch (currentPage) {
-        case 0: {
-          postsFeed.setup()
-          break
-        }
-        case 1: {
-          postsWithRepliesFeed.setup()
-          break
-        }
-        case 2: {
-          postsWithMediaFeed.setup()
-          break
-        }
-        case 3: {
-          likesFeed.setup()
-          break
-        }
-      }
-    }, [currentPage, postsFeed, postsWithRepliesFeed, postsWithMediaFeed, likesFeed])
-
-    /*
+  /*
     - todo
         - feeds
         - lists
     */
 
-    useFocusEffect(
-      React.useCallback(() => {
-        setMinimalShellMode(false)
-        const softResetSub = store.onScreenSoftReset(() => {
-          viewSelectorRef.current?.scrollToTop()
-        })
-        return () => softResetSub.remove()
-      }, [store, viewSelectorRef, setMinimalShellMode]),
-    )
+  useFocusEffect(
+    React.useCallback(() => {
+      setMinimalShellMode(false)
+      const softResetSub = store.onScreenSoftReset(() => {
+        viewSelectorRef.current?.scrollToTop()
+      })
+      return () => softResetSub.remove()
+    }, [store, viewSelectorRef, setMinimalShellMode]),
+  )
 
-    useFocusEffect(
-      React.useCallback(() => {
-        setDrawerSwipeDisabled(currentPage > 0)
-        return () => {
-          setDrawerSwipeDisabled(false)
-        }
-      }, [setDrawerSwipeDisabled, currentPage]),
-    )
+  useFocusEffect(
+    React.useCallback(() => {
+      setDrawerSwipeDisabled(currentPage > 0)
+      return () => {
+        setDrawerSwipeDisabled(false)
+      }
+    }, [setDrawerSwipeDisabled, currentPage]),
+  )
 
-    useFocusEffect(
-      React.useCallback(() => {
-        const subs = []
-        subs.push(postsFeed.registerListeners())
-        subs.push(postsWithRepliesFeed.registerListeners())
-        subs.push(postsWithMediaFeed.registerListeners())
-        subs.push(likesFeed.registerListeners())
-        return () => {
-          subs.forEach(unsub => unsub())
-        }
-      }, [postsFeed, postsWithRepliesFeed, postsWithMediaFeed, likesFeed]),
-    )
+  // events
+  // =
 
-    // events
-    // =
+  const onPressCompose = React.useCallback(() => {
+    track('ProfileScreen:PressCompose')
+    const mention =
+      profile.handle === currentAccount?.handle ||
+      profile.handle === 'handle.invalid'
+        ? undefined
+        : profile.handle
+    store.shell.openComposer({mention})
+  }, [store, currentAccount, track, profile])
 
-    const onPressCompose = React.useCallback(() => {
-      track('ProfileScreen:PressCompose')
-      const mention =
-        profile.handle === store.me.handle ||
-        profile.handle === 'handle.invalid'
-          ? undefined
-          : profile.handle
-      store.shell.openComposer({mention})
-    }, [store, track, profile])
+  const onRefresh = React.useCallback(() => {
+    // TODO
+  }, [])
 
-    const onRefresh = React.useCallback(() => {
-      // TODO
-    }, [])
+  const onPressTryAgain = React.useCallback(() => {
+    // TODO
+  }, [])
 
-    const onPressTryAgain = React.useCallback(() => {
-      // TODO
-    }, [])
+  const onPageSelected = React.useCallback(
+    i => {
+      setCurrentPage(i)
+    },
+    [setCurrentPage],
+  )
 
-    const onPageSelected = React.useCallback(
-      i => {
-        setCurrentPage(i)
-      },
-      [setCurrentPage],
-    )
+  // rendering
+  // =
 
-    // rendering
-    // =
-
-    const renderHeader = React.useCallback(() => {
-      return (
-        <ProfileHeader
-          view={profile}
-          onRefreshAll={onRefresh}
-          hideBackButton={route.params.hideBackButton}
-        />
-      )
-    }, [profile, onRefresh, route.params.hideBackButton])
-
+  const renderHeader = React.useCallback(() => {
     return (
-      <ScreenHider
-        testID="profileView"
-        style={styles.container}
-        screenDescription="profile"
-        moderation={profile.moderation.account}>
-        {profile.hasError ? (
-          <ErrorScreen
-            testID="profileErrorScreen"
-            title="Failed to load profile"
-            message={profile.error}
-            onPressTryAgain={onPressTryAgain}
-          />
-        ) : (
-          <View
-            style={{
-              flex: 1,
-            }}>
-            <PagerWithHeader
-              isHeaderReady={profile.hasLoaded}
-              items={SECTION_TITLES_PROFILE}
-              onPageSelected={onPageSelected}
-              renderHeader={renderHeader}>
-              {({onScroll, headerHeight, isScrolledDown, scrollElRef}) => (
-                <FeedSection
-                  ref={null}
-                  feed={postsFeed}
-                  onScroll={onScroll}
-                  headerHeight={headerHeight}
-                  isScrolledDown={isScrolledDown}
-                  scrollElRef={scrollElRef}
-                />
-              )}
-              {({onScroll, headerHeight, isScrolledDown, scrollElRef}) => (
-                <FeedSection
-                  ref={null}
-                  feed={postsWithRepliesFeed}
-                  onScroll={onScroll}
-                  headerHeight={headerHeight}
-                  isScrolledDown={isScrolledDown}
-                  scrollElRef={scrollElRef}
-                />
-              )}
-              {({onScroll, headerHeight, isScrolledDown, scrollElRef}) => (
-                <FeedSection
-                  ref={null}
-                  feed={postsWithMediaFeed}
-                  onScroll={onScroll}
-                  headerHeight={headerHeight}
-                  isScrolledDown={isScrolledDown}
-                  scrollElRef={scrollElRef}
-                />
-              )}
-              {({onScroll, headerHeight, isScrolledDown, scrollElRef}) => (
-                <FeedSection
-                  ref={null}
-                  feed={likesFeed}
-                  onScroll={onScroll}
-                  headerHeight={headerHeight}
-                  isScrolledDown={isScrolledDown}
-                  scrollElRef={scrollElRef}
-                />
-              )}
-            </PagerWithHeader>
-          </View>
-        )}
-        <FAB
-          testID="composeFAB"
-          onPress={onPressCompose}
-          icon={<ComposeIcon2 strokeWidth={1.5} size={29} style={s.white} />}
-          accessibilityRole="button"
-          accessibilityLabel={_(msg`New post`)}
-          accessibilityHint=""
-        />
-      </ScreenHider>
+      <ProfileHeader
+        profile={profile}
+        moderation={moderation}
+        onRefreshAll={onRefresh}
+        hideBackButton={hideBackButton}
+      />
     )
-  }),
-)
+  }, [profile, moderation, onRefresh, hideBackButton])
+
+  return (
+    <ScreenHider
+      testID="profileView"
+      style={styles.container}
+      screenDescription="profile"
+      moderation={moderation.account}>
+      <PagerWithHeader
+        isHeaderReady={true}
+        items={SECTION_TITLES_PROFILE}
+        onPageSelected={onPageSelected}
+        renderHeader={renderHeader}>
+        {({onScroll, headerHeight, isScrolledDown, scrollElRef}) => (
+          <FeedSection
+            ref={null}
+            feed={`author|${profile.did}|posts_no_replies`}
+            onScroll={onScroll}
+            headerHeight={headerHeight}
+            isScrolledDown={isScrolledDown}
+            scrollElRef={scrollElRef}
+          />
+        )}
+        {({onScroll, headerHeight, isScrolledDown, scrollElRef}) => (
+          <FeedSection
+            ref={null}
+            feed={`author|${profile.did}|posts_with_replies`}
+            onScroll={onScroll}
+            headerHeight={headerHeight}
+            isScrolledDown={isScrolledDown}
+            scrollElRef={scrollElRef}
+          />
+        )}
+        {({onScroll, headerHeight, isScrolledDown, scrollElRef}) => (
+          <FeedSection
+            ref={null}
+            feed={`author|${profile.did}|posts_with_media`}
+            onScroll={onScroll}
+            headerHeight={headerHeight}
+            isScrolledDown={isScrolledDown}
+            scrollElRef={scrollElRef}
+          />
+        )}
+        {({onScroll, headerHeight, isScrolledDown, scrollElRef}) => (
+          <FeedSection
+            ref={null}
+            feed={`likes|${profile.did}`}
+            onScroll={onScroll}
+            headerHeight={headerHeight}
+            isScrolledDown={isScrolledDown}
+            scrollElRef={scrollElRef}
+          />
+        )}
+      </PagerWithHeader>
+      <FAB
+        testID="composeFAB"
+        onPress={onPressCompose}
+        icon={<ComposeIcon2 strokeWidth={1.5} size={29} style={s.white} />}
+        accessibilityRole="button"
+        accessibilityLabel={_(msg`New post`)}
+        accessibilityHint=""
+      />
+    </ScreenHider>
+  )
+}
 
 interface FeedSectionProps {
-  feed: PostsFeedModel
-  onScroll: OnScrollCb
+  feed: FeedDescriptor
+  onScroll: OnScrollHandler
   headerHeight: number
   isScrolledDown: boolean
   scrollElRef: any /* TODO */
@@ -296,11 +251,11 @@ const FeedSection = React.forwardRef<SectionRef, FeedSectionProps>(
     {feed, onScroll, headerHeight, isScrolledDown, scrollElRef},
     ref,
   ) {
-    const hasNew = feed.hasNewLatest && !feed.isRefreshing
+    const hasNew = TODO //feed.hasNewLatest && !feed.isRefreshing
 
     const onScrollToTop = React.useCallback(() => {
       scrollElRef.current?.scrollToOffset({offset: -headerHeight})
-      feed.refresh()
+      // feed.refresh() TODO
     }, [feed, scrollElRef, headerHeight])
     React.useImperativeHandle(ref, () => ({
       scrollToTop: onScrollToTop,

--- a/src/view/screens/ProfileList.tsx
+++ b/src/view/screens/ProfileList.tsx
@@ -70,7 +70,7 @@ export const ProfileListScreen = withAuthRequired(
     const {data: resolvedUri, error: resolveError} = useResolveUriQuery(
       AtUri.make(handleOrDid, 'app.bsky.graph.list', rkey).toString(),
     )
-    const {data: list, error: listError} = useListQuery(resolvedUri)
+    const {data: list, error: listError} = useListQuery(resolvedUri?.uri)
 
     if (resolveError) {
       return (

--- a/src/view/shell/desktop/LeftNav.tsx
+++ b/src/view/shell/desktop/LeftNav.tsx
@@ -251,7 +251,7 @@ function ComposeBtn() {
 }
 
 export const DesktopLeftNav = observer(function DesktopLeftNav() {
-  const store = useStores()
+  const {currentAccount} = useSession()
   const pal = usePalette('default')
   const {isDesktop, isTablet} = useWebMediaQueries()
   const numUnread = useUnreadNotifications()
@@ -370,7 +370,7 @@ export const DesktopLeftNav = observer(function DesktopLeftNav() {
         label="Moderation"
       />
       <NavItem
-        href={makeProfileLink(store.me)}
+        href={makeProfileLink(currentAccount)}
         icon={
           <UserIcon
             strokeWidth={1.75}


### PR DESCRIPTION
- Updates profile screen to use the new `<PagerWithHeader>`
- Updates profile screen to use react-query
- Introduces a profile shadow cache, similar to the posts shadow cache

Still todo in followup PRs:

- [ ] Profile preview
- [ ] Edit profile modal
- [ ] Profile avatar lightbox
- [ ] Dynamic tabs
- [ ] Feed tab behaviors
- [ ] Lists tab
- [ ] Feeds tab