### PR TITLE
Fix jump for web pager

### DIFF
--- a/src/view/com/util/Views.web.tsx
+++ b/src/view/com/util/Views.web.tsx
@@ -108,9 +108,9 @@ export const FlatList = React.forwardRef(function FlatListImpl<ItemT>(
     <Animated.FlatList
       ref={ref}
       contentContainerStyle={[
+        styles.contentContainer,
         contentContainerStyle,
         pal.border,
-        styles.contentContainer,
       ]}
       style={style}
       contentOffset={contentOffset}
@@ -135,9 +135,9 @@ export const ScrollView = React.forwardRef(function ScrollViewImpl(
   return (
     <Animated.ScrollView
       contentContainerStyle={[
+        styles.contentContainer,
         contentContainerStyle,
         pal.border,
-        styles.contentContainer,
       ]}
       // @ts-ignore something is wrong with the reanimated types -prf
       ref={ref}


### PR DESCRIPTION
Fixes the issue @estrattonbailey saw. I forgot to test web for https://github.com/bluesky-social/social-app/pull/1869.

The problem was that my `minHeight` style was being overwritten due to stylesheet ordering. I think custom passed props should take precedence so I swapped the order. I did some grepping and didn't find anything that would change behavior in a conflicting way.

## Test Plan

No longer jumpy when switching tabs. Ignore the empty content — that's due to main being broken.

https://github.com/bluesky-social/social-app/assets/810438/a7d9e3c6-9e19-4856-abc9-aba508313a61

