### PR TITLE
Add Shadow type

### DIFF
--- a/src/state/cache/types.ts
+++ b/src/state/cache/types.ts
@@ -1,0 +1,1 @@
+export type Shadow<T> = T & {isShadowed: true}

--- a/src/view/com/auth/onboarding/RecommendedFollowsItem.tsx
+++ b/src/view/com/auth/onboarding/RecommendedFollowsItem.tsx
@@ -13,7 +13,7 @@ import Animated, {FadeInRight} from 'react-native-reanimated'
 import {useWebMediaQueries} from 'lib/hooks/useWebMediaQueries'
 import {useAnalytics} from 'lib/analytics/analytics'
 import {Trans} from '@lingui/macro'
-import {useProfileShadow} from '#/state/cache/profile-shadow'
+import {Shadow, useProfileShadow} from '#/state/cache/profile-shadow'
 import {
   useProfileFollowMutation,
   useProfileUnfollowMutation,
@@ -66,7 +66,14 @@ export function ProfileCard({
   profile,
   onFollowStateChange,
   moderation,
-}: Omit<Props, 'dataUpdatedAt'>) {
+}: {
+  profile: Shadow<SuggestedActor>
+  moderation: ProfileModeration
+  onFollowStateChange: (props: {
+    did: string
+    following: boolean
+  }) => Promise<void>
+}) {
   const {track} = useAnalytics()
   const pal = usePalette('default')
   const [addingMoreSuggestions, setAddingMoreSuggestions] =

--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -37,9 +37,9 @@ import {useWebMediaQueries} from 'lib/hooks/useWebMediaQueries'
 import {MAX_POST_LINES} from 'lib/constants'
 import {Trans} from '@lingui/macro'
 import {useLanguagePrefs} from '#/state/preferences'
-import {usePostShadow, POST_TOMBSTONE} from '#/state/cache/post-shadow'
 import {useComposerControls} from '#/state/shell/composer'
 import {useModerationOpts} from '#/state/queries/preferences'
+import {Shadow, usePostShadow, POST_TOMBSTONE} from '#/state/cache/post-shadow'
 
 export function PostThreadItem({
   post,
@@ -132,7 +132,7 @@ function PostThreadItemLoaded({
   hasPrecedingItem,
   onPostReply,
 }: {
-  post: AppBskyFeedDefs.PostView
+  post: Shadow<AppBskyFeedDefs.PostView>
   record: AppBskyFeedPost.Record
   richText: RichTextAPI
   moderation: PostModeration

--- a/src/view/com/post/Post.tsx
+++ b/src/view/com/post/Post.tsx
@@ -25,8 +25,8 @@ import {makeProfileLink} from 'lib/routes/links'
 import {MAX_POST_LINES} from 'lib/constants'
 import {countLines} from 'lib/strings/helpers'
 import {useModerationOpts} from '#/state/queries/preferences'
-import {usePostShadow, POST_TOMBSTONE} from '#/state/cache/post-shadow'
 import {useComposerControls} from '#/state/shell/composer'
+import {Shadow, usePostShadow, POST_TOMBSTONE} from '#/state/cache/post-shadow'
 
 export function Post({
   post,
@@ -89,7 +89,7 @@ function PostInner({
   showReplyLine,
   style,
 }: {
-  post: AppBskyFeedDefs.PostView
+  post: Shadow<AppBskyFeedDefs.PostView>
   record: AppBskyFeedPost.Record
   richText: RichTextAPI
   moderation: PostModeration

--- a/src/view/com/posts/FeedItem.tsx
+++ b/src/view/com/posts/FeedItem.tsx
@@ -32,8 +32,8 @@ import {makeProfileLink} from 'lib/routes/links'
 import {isEmbedByEmbedder} from 'lib/embeds'
 import {MAX_POST_LINES} from 'lib/constants'
 import {countLines} from 'lib/strings/helpers'
-import {usePostShadow, POST_TOMBSTONE} from '#/state/cache/post-shadow'
 import {useComposerControls} from '#/state/shell/composer'
+import {Shadow, usePostShadow, POST_TOMBSTONE} from '#/state/cache/post-shadow'
 
 export function FeedItem({
   post,
@@ -93,7 +93,7 @@ function FeedItemInner({
   isThreadLastChild,
   isThreadParent,
 }: {
-  post: AppBskyFeedDefs.PostView
+  post: Shadow<AppBskyFeedDefs.PostView>
   record: AppBskyFeedPost.Record
   reason: AppBskyFeedDefs.ReasonRepost | ReasonFeedSource | undefined
   richText: RichTextAPI

--- a/src/view/com/profile/ProfileHeader.tsx
+++ b/src/view/com/profile/ProfileHeader.tsx
@@ -54,9 +54,10 @@ import {shareUrl} from 'lib/sharing'
 import {s, colors} from 'lib/styles'
 import {logger} from '#/logger'
 import {useSession} from '#/state/session'
+import {Shadow} from '#/state/cache/types'
 
 interface Props {
-  profile: AppBskyActorDefs.ProfileViewDetailed
+  profile: Shadow<AppBskyActorDefs.ProfileViewDetailed>
   moderation: ProfileModeration
   hideBackButton?: boolean
   isProfilePreview?: boolean

--- a/src/view/com/util/forms/PostDropdownBtn.tsx
+++ b/src/view/com/util/forms/PostDropdownBtn.tsx
@@ -20,6 +20,7 @@ import {usePostDeleteMutation} from '#/state/queries/post'
 import {useMutedThreads, useToggleThreadMute} from '#/state/muted-threads'
 import {useLanguagePrefs} from '#/state/preferences'
 import {logger} from '#/logger'
+import {Shadow} from '#/state/cache/types'
 
 export function PostDropdownBtn({
   testID,
@@ -28,7 +29,7 @@ export function PostDropdownBtn({
   style,
 }: {
   testID: string
-  post: AppBskyFeedDefs.PostView
+  post: Shadow<AppBskyFeedDefs.PostView>
   record: AppBskyFeedPost.Record
   style?: StyleProp<ViewStyle>
 }) {

--- a/src/view/com/util/post-ctrls/PostCtrls.tsx
+++ b/src/view/com/util/post-ctrls/PostCtrls.tsx
@@ -24,6 +24,7 @@ import {
   usePostUnrepostMutation,
 } from '#/state/queries/post'
 import {useComposerControls} from '#/state/shell/composer'
+import {Shadow} from '#/state/cache/types'
 
 export function PostCtrls({
   big,
@@ -33,7 +34,7 @@ export function PostCtrls({
   onPressReply,
 }: {
   big?: boolean
-  post: AppBskyFeedDefs.PostView
+  post: Shadow<AppBskyFeedDefs.PostView>
   record: AppBskyFeedPost.Record
   style?: StyleProp<ViewStyle>
   onPressReply: () => void


### PR DESCRIPTION
We use a "shadow cache" for profiles and posts to ensure synchronized state across views and to handle optimistic updates. As we've begun passing around the shadowed values, we noticed that it's easy to miss when a component depends on the shadowing. This is a problem because passing unshadowed posts/profiles will cause the component to break.

This PR adds a `Shadow<T>` type to help avoid that footgun.