### PR TITLE
Fix root sibling context issue

### DIFF
--- a/src/App.native.tsx
+++ b/src/App.native.tsx
@@ -74,18 +74,19 @@ const InnerApp = observer(function AppImpl() {
 
   return (
     <ThemeProvider theme={colorMode}>
-      <RootSiblingParent>
-        <analytics.Provider>
-          <RootStoreProvider value={rootStore}>
-            <I18nProvider i18n={i18n}>
+      <analytics.Provider>
+        <RootStoreProvider value={rootStore}>
+          <I18nProvider i18n={i18n}>
+            {/* All components should be within this provider */}
+            <RootSiblingParent>
               <GestureHandlerRootView style={s.h100pct}>
                 <TestCtrls />
                 <Shell />
               </GestureHandlerRootView>
-            </I18nProvider>
-          </RootStoreProvider>
-        </analytics.Provider>
-      </RootSiblingParent>
+            </RootSiblingParent>
+          </I18nProvider>
+        </RootStoreProvider>
+      </analytics.Provider>
     </ThemeProvider>
   )
 })

--- a/src/App.web.tsx
+++ b/src/App.web.tsx
@@ -62,18 +62,19 @@ const InnerApp = observer(function AppImpl() {
 
   return (
     <ThemeProvider theme={colorMode}>
-      <RootSiblingParent>
-        <analytics.Provider>
-          <RootStoreProvider value={rootStore}>
-            <I18nProvider i18n={i18n}>
+      <analytics.Provider>
+        <RootStoreProvider value={rootStore}>
+          <I18nProvider i18n={i18n}>
+            {/* All components should be within this provider */}
+            <RootSiblingParent>
               <SafeAreaProvider>
                 <Shell />
               </SafeAreaProvider>
-            </I18nProvider>
-            <ToastContainer />
-          </RootStoreProvider>
-        </analytics.Provider>
-      </RootSiblingParent>
+            </RootSiblingParent>
+          </I18nProvider>
+          <ToastContainer />
+        </RootStoreProvider>
+      </analytics.Provider>
     </ThemeProvider>
   )
 })


### PR DESCRIPTION
Noticed that the language selector in the composer broke bc of no access to i18n context. I moved any non-component-related providers higher up.