### PR TITLE
Fix image order in 4-image post embeds (close #1895)

### DIFF
--- a/src/view/com/util/images/ImageLayoutGrid.tsx
+++ b/src/view/com/util/images/ImageLayoutGrid.tsx
@@ -69,12 +69,12 @@ function ImageLayoutGridInner(props: ImageLayoutGridInnerProps) {
               <GalleryItem {...props} index={0} imageStyle={styles.image} />
             </View>
             <View style={styles.smallItem}>
-              <GalleryItem {...props} index={2} imageStyle={styles.image} />
+              <GalleryItem {...props} index={1} imageStyle={styles.image} />
             </View>
           </View>
           <View style={styles.flexRow}>
             <View style={styles.smallItem}>
-              <GalleryItem {...props} index={1} imageStyle={styles.image} />
+              <GalleryItem {...props} index={2} imageStyle={styles.image} />
             </View>
             <View style={styles.smallItem}>
               <GalleryItem {...props} index={3} imageStyle={styles.image} />


### PR DESCRIPTION
# Before

![image](https://github.com/bluesky-social/social-app/assets/1270099/093a52a2-30a9-4bcf-aae8-a81ff1a7f129)

# After

![CleanShot 2023-11-14 at 12 14 26@2x](https://github.com/bluesky-social/social-app/assets/1270099/6b3536fa-a79e-4dee-9e63-cb03b7580bbf)
