### PR TITLE
Fix notification provider order, add comments

### DIFF
--- a/src/App.native.tsx
+++ b/src/App.native.tsx
@@ -72,22 +72,28 @@ const InnerApp = observer(function AppImpl() {
     return null
   }
 
+  /*
+   * Session and initial state should be loaded prior to rendering below.
+   */
+
   return (
-    <ThemeProvider theme={colorMode}>
-      <analytics.Provider>
-        <RootStoreProvider value={rootStore}>
-          <I18nProvider i18n={i18n}>
-            {/* All components should be within this provider */}
-            <RootSiblingParent>
-              <GestureHandlerRootView style={s.h100pct}>
-                <TestCtrls />
-                <Shell />
-              </GestureHandlerRootView>
-            </RootSiblingParent>
-          </I18nProvider>
-        </RootStoreProvider>
-      </analytics.Provider>
-    </ThemeProvider>
+    <UnreadNotifsProvider>
+      <ThemeProvider theme={colorMode}>
+        <analytics.Provider>
+          <RootStoreProvider value={rootStore}>
+            <I18nProvider i18n={i18n}>
+              {/* All components should be within this provider */}
+              <RootSiblingParent>
+                <GestureHandlerRootView style={s.h100pct}>
+                  <TestCtrls />
+                  <Shell />
+                </GestureHandlerRootView>
+              </RootSiblingParent>
+            </I18nProvider>
+          </RootStoreProvider>
+        </analytics.Provider>
+      </ThemeProvider>
+    </UnreadNotifsProvider>
   )
 })
 
@@ -102,19 +108,21 @@ function App() {
     return null
   }
 
+  /*
+   * NOTE: only nothing here can depend on other data or session state, since
+   * that is set up in the InnerApp component above.
+   */
   return (
     <QueryClientProvider client={queryClient}>
       <SessionProvider>
         <ShellStateProvider>
           <PrefsStateProvider>
             <MutedThreadsProvider>
-              <UnreadNotifsProvider>
-                <InvitesStateProvider>
-                  <ModalStateProvider>
-                    <InnerApp />
-                  </ModalStateProvider>
-                </InvitesStateProvider>
-              </UnreadNotifsProvider>
+              <InvitesStateProvider>
+                <ModalStateProvider>
+                  <InnerApp />
+                </ModalStateProvider>
+              </InvitesStateProvider>
             </MutedThreadsProvider>
           </PrefsStateProvider>
         </ShellStateProvider>

--- a/src/App.web.tsx
+++ b/src/App.web.tsx
@@ -60,22 +60,28 @@ const InnerApp = observer(function AppImpl() {
     return null
   }
 
+  /*
+   * Session and initial state should be loaded prior to rendering below.
+   */
+
   return (
-    <ThemeProvider theme={colorMode}>
-      <analytics.Provider>
-        <RootStoreProvider value={rootStore}>
-          <I18nProvider i18n={i18n}>
-            {/* All components should be within this provider */}
-            <RootSiblingParent>
-              <SafeAreaProvider>
-                <Shell />
-              </SafeAreaProvider>
-            </RootSiblingParent>
-          </I18nProvider>
-          <ToastContainer />
-        </RootStoreProvider>
-      </analytics.Provider>
-    </ThemeProvider>
+    <UnreadNotifsProvider>
+      <ThemeProvider theme={colorMode}>
+        <analytics.Provider>
+          <RootStoreProvider value={rootStore}>
+            <I18nProvider i18n={i18n}>
+              {/* All components should be within this provider */}
+              <RootSiblingParent>
+                <SafeAreaProvider>
+                  <Shell />
+                </SafeAreaProvider>
+              </RootSiblingParent>
+            </I18nProvider>
+            <ToastContainer />
+          </RootStoreProvider>
+        </analytics.Provider>
+      </ThemeProvider>
+    </UnreadNotifsProvider>
   )
 })
 
@@ -90,19 +96,21 @@ function App() {
     return null
   }
 
+  /*
+   * NOTE: only nothing here can depend on other data or session state, since
+   * that is set up in the InnerApp component above.
+   */
   return (
     <QueryClientProvider client={queryClient}>
       <SessionProvider>
         <ShellStateProvider>
           <PrefsStateProvider>
             <MutedThreadsProvider>
-              <UnreadNotifsProvider>
-                <InvitesStateProvider>
-                  <ModalStateProvider>
-                    <InnerApp />
-                  </ModalStateProvider>
-                </InvitesStateProvider>
-              </UnreadNotifsProvider>
+              <InvitesStateProvider>
+                <ModalStateProvider>
+                  <InnerApp />
+                </ModalStateProvider>
+              </InvitesStateProvider>
             </MutedThreadsProvider>
           </PrefsStateProvider>
         </ShellStateProvider>

--- a/src/state/queries/preferences/index.ts
+++ b/src/state/queries/preferences/index.ts
@@ -91,7 +91,6 @@ export function useModerationOpts() {
   const {currentAccount} = useSession()
   const [opts, setOpts] = useState<ModerationOpts | undefined>()
   const prefs = usePreferencesQuery()
-  console.log({preferences: prefs.data})
   useEffect(() => {
     if (!prefs.data) {
       return

--- a/src/state/queries/preferences/index.ts
+++ b/src/state/queries/preferences/index.ts
@@ -32,6 +32,7 @@ export const usePreferencesQueryKey = ['getPreferences']
 export function usePreferencesQuery() {
   const {agent, hasSession} = useSession()
   return useQuery({
+    enabled: hasSession,
     queryKey: usePreferencesQueryKey,
     queryFn: async () => {
       const res = await agent.getPreferences()
@@ -83,7 +84,6 @@ export function usePreferencesQuery() {
       }
       return preferences
     },
-    enabled: hasSession,
   })
 }
 
@@ -91,6 +91,7 @@ export function useModerationOpts() {
   const {currentAccount} = useSession()
   const [opts, setOpts] = useState<ModerationOpts | undefined>()
   const prefs = usePreferencesQuery()
+  console.log({preferences: prefs.data})
   useEffect(() => {
     if (!prefs.data) {
       return


### PR DESCRIPTION
In this case, `UnreadNotifsProvider` was calling hooks that were not pure state and relied on session data being loaded.