### PR TITLE
No need to await follows anymore, fix cold load search

### DIFF
--- a/src/view/screens/Search/Search.tsx
+++ b/src/view/screens/Search/Search.tsx
@@ -33,7 +33,6 @@ import {useWebMediaQueries} from 'lib/hooks/useWebMediaQueries'
 import {usePalette} from '#/lib/hooks/usePalette'
 import {useTheme} from 'lib/ThemeContext'
 import {useSession} from '#/state/session'
-import {useMyFollowsQuery} from '#/state/queries/my-follows'
 import {useGetSuggestedFollowersByActor} from '#/state/queries/suggested-follows'
 import {useSearchPostsQuery} from '#/state/queries/search-posts'
 import {useActorAutocompleteFn} from '#/state/queries/actor-autocomplete'
@@ -295,8 +294,6 @@ function SearchScreenUserResults({query}: {query: string}) {
     AppBskyActorDefs.ProfileViewBasic[]
   >([])
   const search = useActorAutocompleteFn()
-  // fuzzy search relies on followers
-  const {isFetched: isFollowsFetched} = useMyFollowsQuery()
 
   React.useEffect(() => {
     async function getResults() {
@@ -309,13 +306,13 @@ function SearchScreenUserResults({query}: {query: string}) {
       }
     }
 
-    if (query && isFollowsFetched) {
+    if (query) {
       getResults()
     } else {
       setResults([])
       setIsFetched(false)
     }
-  }, [query, isFollowsFetched, setDataUpdatedAt, search])
+  }, [query, setDataUpdatedAt, search])
 
   return isFetched ? (
     <>
@@ -410,7 +407,7 @@ export function SearchScreenDesktop(
 }
 
 export function SearchScreenMobile(
-  _props: NativeStackScreenProps<SearchTabNavigatorParams, 'Search'>,
+  props: NativeStackScreenProps<SearchTabNavigatorParams, 'Search'>,
 ) {
   const theme = useTheme()
   const textInput = React.useRef<TextInput>(null)
@@ -428,7 +425,7 @@ export function SearchScreenMobile(
     undefined,
   )
   const [isFetching, setIsFetching] = React.useState<boolean>(false)
-  const [query, setQuery] = React.useState<string>('')
+  const [query, setQuery] = React.useState<string>(props.route?.params?.q || '')
   const [searchResults, setSearchResults] = React.useState<
     AppBskyActorDefs.ProfileViewBasic[]
   >([])


### PR DESCRIPTION
- was previously checking for follows before searching so that the prev functionality would work as best it could, but Paul's changes make this unnecessary
- on cold load we should set an initial value for query so that you can see results right away