### PR TITLE
Fix memo params causing tuner to lose state

### DIFF
--- a/src/state/queries/post-feed.ts
+++ b/src/state/queries/post-feed.ts
@@ -92,9 +92,11 @@ export function usePostFeedQuery(
       return new FollowingFeedAPI(agent)
     }
   }, [feedDesc, params, feedTuners, agent])
+
+  const disableTuner = !!params?.disableTuner
   const tuner = useMemo(
-    () => (params?.disableTuner ? new NoopFeedTuner() : new FeedTuner()),
-    [params],
+    () => (disableTuner ? new NoopFeedTuner() : new FeedTuner()),
+    [disableTuner],
   )
 
   const pollLatest = useCallback(async () => {


### PR DESCRIPTION
The tuner handles de-duplication. If it doesnt maintain its state properly, it can result in duplicate react keys showing in the feed.

I noticed that and tracked down that the useMemo was being too loose with the dependency.