### PR TITLE
Add a mutation queue to fix race conditions in toggles

### DIFF
--- a/src/lib/hooks/useToggleMutationQueue.ts
+++ b/src/lib/hooks/useToggleMutationQueue.ts
@@ -1,0 +1,77 @@
+import {useState} from 'react'
+
+type Task<TServerState> = {
+  isOn: boolean
+  resolve: (serverState: TServerState) => void
+  reject: (e: unknown) => void
+}
+
+type TaskQueue<TServerState> = {
+  activeTask: Task<TServerState> | null
+  queuedTask: Task<TServerState> | null
+}
+
+export function useToggleMutationQueue<TServerState>({
+  initialState,
+  runMutation,
+  onSuccess,
+}: {
+  initialState: TServerState
+  runMutation: (
+    prevState: TServerState,
+    nextIsOn: boolean,
+  ) => Promise<TServerState>
+  onSuccess: (finalState: TServerState) => void
+}) {
+  // We use the queue as a mutable object.
+  // This is safe becuase it is not used for rendering.
+  const [queue] = useState<TaskQueue<TServerState>>({
+    activeTask: null,
+    queuedTask: null,
+  })
+
+  async function processQueue() {
+    if (queue.activeTask) {
+      // There is another active processQueue call iterating over tasks.
+      // It will handle any newly added tasks, so we should exit early.
+      return
+    }
+    // To avoid relying on the rendered state, capture it once at the start.
+    // From that point on, and until the queue is drained, we'll use the real server state.
+    let confirmedState: TServerState = initialState
+    try {
+      while (queue.queuedTask) {
+        const prevTask = queue.activeTask
+        const nextTask = queue.queuedTask
+        queue.activeTask = nextTask
+        queue.queuedTask = null
+        if (prevTask?.isOn === nextTask.isOn) {
+          // Skip multiple requests to update to the same value in a row.
+          continue
+        }
+        try {
+          // The state received from the server feeds into the next task.
+          // This lets us queue deletions of not-yet-created resources.
+          confirmedState = await runMutation(confirmedState, nextTask.isOn)
+          nextTask.resolve(confirmedState)
+        } catch (e) {
+          nextTask.reject(e)
+        }
+      }
+    } finally {
+      onSuccess(confirmedState)
+      queue.activeTask = null
+      queue.queuedTask = null
+    }
+  }
+
+  function queueToggle(isOn: boolean): Promise<TServerState> {
+    return new Promise((resolve, reject) => {
+      // This is a toggle, so the next queued value can safely replace the queued one.
+      queue.queuedTask = {isOn, resolve, reject}
+      processQueue()
+    })
+  }
+
+  return queueToggle
+}

--- a/src/lib/hooks/useToggleMutationQueue.ts
+++ b/src/lib/hooks/useToggleMutationQueue.ts
@@ -1,4 +1,4 @@
-import {useState} from 'react'
+import {useState, useRef, useEffect, useCallback} from 'react'
 
 type Task<TServerState> = {
   isOn: boolean
@@ -73,5 +73,16 @@ export function useToggleMutationQueue<TServerState>({
     })
   }
 
-  return queueToggle
+  const queueToggleRef = useRef(queueToggle)
+  useEffect(() => {
+    queueToggleRef.current = queueToggle
+  })
+  const queueToggleStable = useCallback(
+    (isOn: boolean): Promise<TServerState> => {
+      const queueToggleLatest = queueToggleRef.current
+      return queueToggleLatest(isOn)
+    },
+    [],
+  )
+  return queueToggleStable
 }

--- a/src/state/queries/profile.ts
+++ b/src/state/queries/profile.ts
@@ -1,3 +1,4 @@
+import {useCallback} from 'react'
 import {
   AtUri,
   AppBskyActorDefs,
@@ -136,15 +137,15 @@ export function useProfileFollowMutationQueue(
     },
   })
 
-  async function queueFollow() {
+  const queueFollow = useCallback(() => {
     updateProfileShadow(did, {followingUri: 'pending'})
     return queueToggle(true)
-  }
+  }, [did, queueToggle])
 
-  async function queueUnfollow() {
+  const queueUnfollow = useCallback(() => {
     updateProfileShadow(did, {followingUri: undefined})
     return queueToggle(false)
-  }
+  }, [did, queueToggle])
 
   return [queueFollow, queueUnfollow]
 }

--- a/src/state/queries/profile.ts
+++ b/src/state/queries/profile.ts
@@ -157,7 +157,7 @@ export function useProfileFollowMutationQueue(
   return [queueFollow, queueUnfollow]
 }
 
-export function useProfileFollowMutation() {
+function useProfileFollowMutation() {
   const {agent} = useSession()
   return useMutation<
     {uri: string; cid: string},
@@ -194,7 +194,7 @@ export function useProfileFollowMutation() {
   })
 }
 
-export function useProfileUnfollowMutation() {
+function useProfileUnfollowMutation() {
   const {agent} = useSession()
   return useMutation<
     void,
@@ -273,7 +273,7 @@ export function useProfileMuteMutationQueue(
   return [queueMute, queueUnmute]
 }
 
-export function useProfileMuteMutation() {
+function useProfileMuteMutation() {
   const {agent} = useSession()
   const queryClient = useQueryClient()
   return useMutation<void, Error, {did: string; skipOptimistic?: boolean}>({
@@ -302,7 +302,7 @@ export function useProfileMuteMutation() {
   })
 }
 
-export function useProfileUnmuteMutation() {
+function useProfileUnmuteMutation() {
   const {agent} = useSession()
   return useMutation<void, Error, {did: string; skipOptimistic?: boolean}>({
     mutationFn: async ({did}) => {
@@ -382,7 +382,7 @@ export function useProfileBlockMutationQueue(
   return [queueBlock, queueUnblock]
 }
 
-export function useProfileBlockMutation() {
+function useProfileBlockMutation() {
   const {agent, currentAccount} = useSession()
   const queryClient = useQueryClient()
   return useMutation<
@@ -427,7 +427,7 @@ export function useProfileBlockMutation() {
   })
 }
 
-export function useProfileUnblockMutation() {
+function useProfileUnblockMutation() {
   const {agent, currentAccount} = useSession()
   return useMutation<
     void,

--- a/src/state/queries/profile.ts
+++ b/src/state/queries/profile.ts
@@ -108,38 +108,38 @@ export function useProfileFollowMutationQueue(profile) {
   const followingUri = profile.viewer?.following
 
   const [queue] = useState({
-    nextAction: null,
-    isBusy: false,
+    currentAction: null,
+    pendingAction: null,
   })
 
   function queueFollow() {
-    queue.nextAction = {type: 'follow'}
+    queue.pendingAction = {type: 'follow'}
     updateProfileShadow(did, {followingUri: 'pending'})
     processQueue()
   }
 
   function queueUnfollow() {
-    queue.nextAction = {type: 'unfollow'}
+    queue.pendingAction = {type: 'unfollow'}
     updateProfileShadow(did, {followingUri: undefined})
     processQueue()
   }
 
   async function processQueue() {
-    if (queue.isBusy) {
+    if (queue.currentAction) {
       return
     }
-    queue.isBusy = true
     try {
-      while (queue.nextAction) {
-        const action = queue.nextAction
-        queue.nextAction = null
+      while (queue.pendingAction) {
+        const action = queue.pendingAction
+        queue.pendingAction = null
+        queue.currentAction = action
         const result = await runAction(action)
       }
       // commit success
     } catch {
       // rollback?
     } finally {
-      queue.isBusy = false
+      queue.currentAction = null
     }
   }
 

--- a/src/state/queries/profile.ts
+++ b/src/state/queries/profile.ts
@@ -138,12 +138,13 @@ export function useProfileFollowMutationQueue(profile) {
     if (queue.currentAction) {
       return
     }
+    queue.confirmedState = {followingUri}
     try {
       while (queue.pendingAction) {
         const action = queue.pendingAction
         queue.currentAction = action
         queue.pendingAction = null
-        queue.confirmedState = await runAction(action)
+        queue.confirmedState = await runAction(queue.confirmedState, action)
       }
     } catch {
       // rollback?
@@ -157,12 +158,12 @@ export function useProfileFollowMutationQueue(profile) {
     }
   }
 
-  async function runAction(action) {
+  async function runAction(state, action) {
     if (action === 'follow') {
       const {uri} = await followMutation.mutateAsync({did})
       return {followingUri: uri}
     } else if (action === 'unfollow') {
-      await unfollowMutation.mutateAsync({did, followUri: followingUri})
+      await unfollowMutation.mutateAsync({did, followUri: state.followingUri})
       return {followingUri: undefined}
     }
   }

--- a/src/state/queries/profile.ts
+++ b/src/state/queries/profile.ts
@@ -358,7 +358,7 @@ export function useProfileBlockMutationQueue(
     onSuccess(finalBlockingUri) {
       // finalize
       updateProfileShadow(did, {
-        followingUri: finalBlockingUri,
+        blockingUri: finalBlockingUri,
       })
     },
   })

--- a/src/view/com/auth/onboarding/RecommendedFollowsItem.tsx
+++ b/src/view/com/auth/onboarding/RecommendedFollowsItem.tsx
@@ -87,8 +87,12 @@ export function ProfileCard({
         setAddingMoreSuggestions(false)
         track('Onboarding:SuggestedFollowFollowed')
       }
-    } catch (e) {
-      logger.error('RecommendedFollows: failed to toggle following', {error: e})
+    } catch (e: any) {
+      if (e?.name !== 'AbortError') {
+        logger.error('RecommendedFollows: failed to toggle following', {
+          error: e,
+        })
+      }
     } finally {
       setAddingMoreSuggestions(false)
     }

--- a/src/view/com/profile/FollowButton.tsx
+++ b/src/view/com/profile/FollowButton.tsx
@@ -23,7 +23,9 @@ export function FollowButton({
     try {
       await queueFollow()
     } catch (e: any) {
-      Toast.show(`An issue occurred, please try again.`)
+      if (e?.name !== 'AbortError') {
+        Toast.show(`An issue occurred, please try again.`)
+      }
     }
   }
 
@@ -31,7 +33,9 @@ export function FollowButton({
     try {
       await queueUnfollow()
     } catch (e: any) {
-      Toast.show(`An issue occurred, please try again.`)
+      if (e?.name !== 'AbortError') {
+        Toast.show(`An issue occurred, please try again.`)
+      }
     }
   }
 

--- a/src/view/com/profile/FollowButton.tsx
+++ b/src/view/com/profile/FollowButton.tsx
@@ -3,10 +3,7 @@ import {StyleProp, TextStyle, View} from 'react-native'
 import {AppBskyActorDefs} from '@atproto/api'
 import {Button, ButtonType} from '../util/forms/Button'
 import * as Toast from '../util/Toast'
-import {
-  useProfileFollowMutation,
-  useProfileUnfollowMutation,
-} from '#/state/queries/profile'
+import {useProfileFollowMutationQueue} from '#/state/queries/profile'
 import {Shadow} from '#/state/cache/types'
 
 export function FollowButton({
@@ -20,29 +17,19 @@ export function FollowButton({
   profile: Shadow<AppBskyActorDefs.ProfileViewBasic>
   labelStyle?: StyleProp<TextStyle>
 }) {
-  const followMutation = useProfileFollowMutation()
-  const unfollowMutation = useProfileUnfollowMutation()
+  const [queueFollow, queueUnfollow] = useProfileFollowMutationQueue(profile)
 
   const onPressFollow = async () => {
-    if (profile.viewer?.following) {
-      return
-    }
     try {
-      await followMutation.mutateAsync({did: profile.did})
+      await queueFollow()
     } catch (e: any) {
       Toast.show(`An issue occurred, please try again.`)
     }
   }
 
   const onPressUnfollow = async () => {
-    if (!profile.viewer?.following) {
-      return
-    }
     try {
-      await unfollowMutation.mutateAsync({
-        did: profile.did,
-        followUri: profile.viewer?.following,
-      })
+      await queueUnfollow()
     } catch (e: any) {
       Toast.show(`An issue occurred, please try again.`)
     }
@@ -59,7 +46,6 @@ export function FollowButton({
         labelStyle={labelStyle}
         onPress={onPressUnfollow}
         label="Unfollow"
-        withLoading={true}
       />
     )
   } else {
@@ -69,7 +55,6 @@ export function FollowButton({
         labelStyle={labelStyle}
         onPress={onPressFollow}
         label="Follow"
-        withLoading={true}
       />
     )
   }

--- a/src/view/com/profile/ProfileHeader.tsx
+++ b/src/view/com/profile/ProfileHeader.tsx
@@ -158,8 +158,10 @@ function ProfileHeaderLoaded({
         )}`,
       )
     } catch (e: any) {
-      logger.error('Failed to follow', {error: String(e)})
-      Toast.show(`There was an issue! ${e.toString()}`)
+      if (e?.name !== 'AbortError') {
+        logger.error('Failed to follow', {error: String(e)})
+        Toast.show(`There was an issue! ${e.toString()}`)
+      }
     }
   }
 
@@ -173,8 +175,10 @@ function ProfileHeaderLoaded({
         )}`,
       )
     } catch (e: any) {
-      logger.error('Failed to unfollow', {error: String(e)})
-      Toast.show(`There was an issue! ${e.toString()}`)
+      if (e?.name !== 'AbortError') {
+        logger.error('Failed to unfollow', {error: String(e)})
+        Toast.show(`There was an issue! ${e.toString()}`)
+      }
     }
   }
 
@@ -206,8 +210,10 @@ function ProfileHeaderLoaded({
       await queueMute()
       Toast.show('Account muted')
     } catch (e: any) {
-      logger.error('Failed to mute account', {error: e})
-      Toast.show(`There was an issue! ${e.toString()}`)
+      if (e?.name !== 'AbortError') {
+        logger.error('Failed to mute account', {error: e})
+        Toast.show(`There was an issue! ${e.toString()}`)
+      }
     }
   }, [track, queueMute])
 
@@ -217,8 +223,10 @@ function ProfileHeaderLoaded({
       await queueUnmute()
       Toast.show('Account unmuted')
     } catch (e: any) {
-      logger.error('Failed to unmute account', {error: e})
-      Toast.show(`There was an issue! ${e.toString()}`)
+      if (e?.name !== 'AbortError') {
+        logger.error('Failed to unmute account', {error: e})
+        Toast.show(`There was an issue! ${e.toString()}`)
+      }
     }
   }, [track, queueUnmute])
 
@@ -234,8 +242,10 @@ function ProfileHeaderLoaded({
           await queueBlock()
           Toast.show('Account blocked')
         } catch (e: any) {
-          logger.error('Failed to block account', {error: e})
-          Toast.show(`There was an issue! ${e.toString()}`)
+          if (e?.name !== 'AbortError') {
+            logger.error('Failed to block account', {error: e})
+            Toast.show(`There was an issue! ${e.toString()}`)
+          }
         }
       },
     })
@@ -253,8 +263,10 @@ function ProfileHeaderLoaded({
           await queueUnblock()
           Toast.show('Account unblocked')
         } catch (e: any) {
-          logger.error('Failed to unblock account', {error: e})
-          Toast.show(`There was an issue! ${e.toString()}`)
+          if (e?.name !== 'AbortError') {
+            logger.error('Failed to unblock account', {error: e})
+            Toast.show(`There was an issue! ${e.toString()}`)
+          }
         }
       },
     })

--- a/src/view/com/profile/ProfileHeader.tsx
+++ b/src/view/com/profile/ProfileHeader.tsx
@@ -32,8 +32,6 @@ import {ProfileHeaderSuggestedFollows} from './ProfileHeaderSuggestedFollows'
 import {useModalControls} from '#/state/modals'
 import {useLightboxControls, ProfileImageLightbox} from '#/state/lightbox'
 import {
-  useProfileFollowMutation,
-  useProfileUnfollowMutation,
   useProfileMuteMutation,
   useProfileUnmuteMutation,
   useProfileBlockMutation,
@@ -131,8 +129,7 @@ function ProfileHeaderLoaded({
         : undefined,
     [profile],
   )
-  const followMutation = useProfileFollowMutation()
-  const unfollowMutation = useProfileUnfollowMutation()
+  const [queueFollow, queueUnfollow] = useProfileFollowMutationQueue(profile)
   const muteMutation = useProfileMuteMutation()
   const unmuteMutation = useProfileUnmuteMutation()
   const blockMutation = useProfileBlockMutation()
@@ -154,8 +151,6 @@ function ProfileHeaderLoaded({
       openLightbox(new ProfileImageLightbox(profile))
     }
   }, [openLightbox, profile, moderation])
-
-  const [queueFollow, queueUnfollow] = useProfileFollowMutationQueue(profile)
 
   const onPressFollow = async () => {
     try {

--- a/src/view/com/profile/ProfileHeader.tsx
+++ b/src/view/com/profile/ProfileHeader.tsx
@@ -32,8 +32,7 @@ import {ProfileHeaderSuggestedFollows} from './ProfileHeaderSuggestedFollows'
 import {useModalControls} from '#/state/modals'
 import {useLightboxControls, ProfileImageLightbox} from '#/state/lightbox'
 import {
-  useProfileMuteMutation,
-  useProfileUnmuteMutation,
+  useProfileMuteMutationQueue,
   useProfileBlockMutation,
   useProfileUnblockMutation,
   useProfileFollowMutationQueue,
@@ -130,8 +129,7 @@ function ProfileHeaderLoaded({
     [profile],
   )
   const [queueFollow, queueUnfollow] = useProfileFollowMutationQueue(profile)
-  const muteMutation = useProfileMuteMutation()
-  const unmuteMutation = useProfileUnmuteMutation()
+  const [queueMute, queueUnmute] = useProfileMuteMutationQueue(profile)
   const blockMutation = useProfileBlockMutation()
   const unblockMutation = useProfileUnblockMutation()
 
@@ -207,24 +205,24 @@ function ProfileHeaderLoaded({
   const onPressMuteAccount = React.useCallback(async () => {
     track('ProfileHeader:MuteAccountButtonClicked')
     try {
-      await muteMutation.mutateAsync({did: profile.did})
+      await queueMute()
       Toast.show('Account muted')
     } catch (e: any) {
       logger.error('Failed to mute account', {error: e})
       Toast.show(`There was an issue! ${e.toString()}`)
     }
-  }, [track, muteMutation, profile])
+  }, [track, queueMute])
 
   const onPressUnmuteAccount = React.useCallback(async () => {
     track('ProfileHeader:UnmuteAccountButtonClicked')
     try {
-      await unmuteMutation.mutateAsync({did: profile.did})
+      await queueUnmute()
       Toast.show('Account unmuted')
     } catch (e: any) {
       logger.error('Failed to unmute account', {error: e})
       Toast.show(`There was an issue! ${e.toString()}`)
     }
-  }, [track, unmuteMutation, profile])
+  }, [track, queueUnmute])
 
   const onPressBlockAccount = React.useCallback(async () => {
     track('ProfileHeader:BlockAccountButtonClicked')

--- a/src/view/com/profile/ProfileHeaderSuggestedFollows.tsx
+++ b/src/view/com/profile/ProfileHeaderSuggestedFollows.tsx
@@ -212,7 +212,9 @@ function SuggestedFollow({
       track('ProfileHeader:SuggestedFollowFollowed')
       await queueFollow()
     } catch (e: any) {
-      Toast.show('An issue occurred, please try again.')
+      if (e?.name !== 'AbortError') {
+        Toast.show('An issue occurred, please try again.')
+      }
     }
   }, [queueFollow, track])
 
@@ -220,7 +222,9 @@ function SuggestedFollow({
     try {
       await queueUnfollow()
     } catch (e: any) {
-      Toast.show('An issue occurred, please try again.')
+      if (e?.name !== 'AbortError') {
+        Toast.show('An issue occurred, please try again.')
+      }
     }
   }, [queueUnfollow])
 

--- a/src/view/com/profile/ProfileHeaderSuggestedFollows.tsx
+++ b/src/view/com/profile/ProfileHeaderSuggestedFollows.tsx
@@ -26,10 +26,7 @@ import {isWeb} from 'platform/detection'
 import {useModerationOpts} from '#/state/queries/preferences'
 import {useSuggestedFollowsByActorQuery} from '#/state/queries/suggested-follows'
 import {useProfileShadow} from '#/state/cache/profile-shadow'
-import {
-  useProfileFollowMutation,
-  useProfileUnfollowMutation,
-} from '#/state/queries/profile'
+import {useProfileFollowMutationQueue} from '#/state/queries/profile'
 
 const OUTER_PADDING = 10
 const INNER_PADDING = 14
@@ -208,34 +205,24 @@ function SuggestedFollow({
   const pal = usePalette('default')
   const moderationOpts = useModerationOpts()
   const profile = useProfileShadow(profileUnshadowed, dataUpdatedAt)
-  const followMutation = useProfileFollowMutation()
-  const unfollowMutation = useProfileUnfollowMutation()
+  const [queueFollow, queueUnfollow] = useProfileFollowMutationQueue(profile)
 
   const onPressFollow = React.useCallback(async () => {
-    if (profile.viewer?.following) {
-      return
-    }
     try {
       track('ProfileHeader:SuggestedFollowFollowed')
-      await followMutation.mutateAsync({did: profile.did})
+      await queueFollow()
     } catch (e: any) {
       Toast.show('An issue occurred, please try again.')
     }
-  }, [followMutation, profile, track])
+  }, [queueFollow, track])
 
   const onPressUnfollow = React.useCallback(async () => {
-    if (!profile.viewer?.following) {
-      return
-    }
     try {
-      await unfollowMutation.mutateAsync({
-        did: profile.did,
-        followUri: profile.viewer?.following,
-      })
+      await queueUnfollow()
     } catch (e: any) {
       Toast.show('An issue occurred, please try again.')
     }
-  }, [unfollowMutation, profile])
+  }, [queueUnfollow])
 
   if (!moderationOpts) {
     return null
@@ -284,7 +271,6 @@ function SuggestedFollow({
           type="inverted"
           labelStyle={{textAlign: 'center'}}
           onPress={following ? onPressUnfollow : onPressFollow}
-          withLoading
         />
       </View>
     </Link>


### PR DESCRIPTION
This introduces a helper that lets us run "toggle" mutations (e.g. Follow/Unfollow) without races.

Currently, our approach is to treat each mutation as independent. However, their optimistic updates can clobber each other — e.g. if you press Follow immediately after Unfollow, you can't predict in which order they'll get to the server, or in which order they will come back. Our existing code did not deal with that.

Additionally, our API treats Unfollow/Unblock/Unmute as deletions of a record and requires a record URI. However, if you press Follow immediately followed by Unfollow (haha), it's "too early" to send the Unfollow request because we don't have any record URI for it yet. Our existing code tried to deal with that by guarding event handlers so that you _can't_ Unfollow until Follow comes through — but that wasn't being applied consistently. And even if it was, you want to be able to "undo" an accidental Follow immediately.

In this PR, we take the following approach. The user is expected to be able to press the toggle as much as they like. The changes are applied immediately through our existing optimistic mutation mechanism. We still fire the underlying mutations via RQ. However, we don't "commit" or "rollback" the response immediately.

Instead, if you fire off multiple mutations immediately one after another, they run via a state machine that carries the returned server state through all the queued up actions one by one. This lets us feed the resource URI returned by the Follow action right into the pending Unfollow action. I chose to do it this way instead of reading the current shadow because I don't want to rely on the timing of React rendering (and updating the state) when orchestrating mutations. The state of the queue is reset when the queue is drained. So it only lives for as long as you keep smashing the button. This should reduce the surface area for bugs.

The queue automatically deduplicates pending actions. If you spam the button (e.g. Follow -> Unfollow -> Follow -> Unfollow -> Follow), as soon as it's done with the current request, it will apply at most one request if necessary. E.g. if we're waiting for Follow and the final requested state is also Follow, then there's nothing left to do. But if we're waiting for Follow and you requested Unfollow -> Follow -> Unfollow, the final Unfollow is still necessary — so we will apply just the one last Unfollow, and drop the intermediate actions.

API-wise, I opted to wrap our existing RQ mutations so that, if this abstraction is bad, it should be easy to rip out. At the callsites, I've removed the guards that protect against missing URIs (since the queue handles this now), but kept the overall structure the same. The individual Promises from queued calls resolve as the queue progresses, so we can still show toasts as individual requests come through, even if the entire queue is not drained yet. This provides feedback on slow network. I've ripped out spinners in the UI because now you can press Follow/Unfollow anytime and expect to get to the final state.

For testing, it might be helpful to turn on 3G emulation or to add manual Promise delays.

I only tested the web so far.

**[Review without whitespace](https://github.com/bluesky-social/social-app/pull/1933/files?w=1)**

---

https://github.com/bluesky-social/social-app/assets/810438/4bb4c629-6c73-4457-b8de-6523864b14af

