### PR TITLE
Fix blank feed

### DIFF
--- a/src/view/screens/Home.tsx
+++ b/src/view/screens/Home.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import {View, ActivityIndicator, StyleSheet} from 'react-native'
 import {useFocusEffect} from '@react-navigation/native'
 import {NativeStackScreenProps, HomeTabNavigatorParams} from 'lib/routes/types'
 import {FeedDescriptor, FeedParams} from '#/state/queries/post-feed'
@@ -22,7 +23,11 @@ export const HomeScreen = withAuthRequired(function HomeScreenImpl(
   if (preferences) {
     return <HomeScreenReady {...props} preferences={preferences} />
   } else {
-    return null // TODO
+    return (
+      <View style={styles.loading}>
+        <ActivityIndicator size="large" />
+      </View>
+    )
   }
 })
 
@@ -140,3 +145,12 @@ function HomeScreenReady({
     </Pager>
   )
 }
+
+const styles = StyleSheet.create({
+  loading: {
+    height: '100%',
+    alignContent: 'center',
+    justifyContent: 'center',
+    paddingBottom: 100,
+  },
+})

--- a/src/view/screens/Home.tsx
+++ b/src/view/screens/Home.tsx
@@ -7,7 +7,7 @@ import {FollowingEmptyState} from 'view/com/posts/FollowingEmptyState'
 import {FollowingEndOfFeed} from 'view/com/posts/FollowingEndOfFeed'
 import {CustomFeedEmptyState} from 'view/com/posts/CustomFeedEmptyState'
 import {FeedsTabBar} from '../com/pager/FeedsTabBar'
-import {Pager, PagerRef, RenderTabBarFnProps} from 'view/com/pager/Pager'
+import {Pager, RenderTabBarFnProps} from 'view/com/pager/Pager'
 import {FeedPage} from 'view/com/feeds/FeedPage'
 import {useSetMinimalShellMode, useSetDrawerSwipeDisabled} from '#/state/shell'
 import {usePreferencesQuery} from '#/state/queries/preferences'
@@ -33,17 +33,11 @@ function HomeScreenReady({
 }) {
   const setMinimalShellMode = useSetMinimalShellMode()
   const setDrawerSwipeDisabled = useSetDrawerSwipeDisabled()
-  const pagerRef = React.useRef<PagerRef>(null)
   const [selectedPage, setSelectedPage] = React.useState(0)
-  const [customFeeds, setCustomFeeds] = React.useState<FeedDescriptor[]>([])
 
-  React.useEffect(() => {
-    if (!preferences.feeds.pinned) return
-
+  const customFeeds = React.useMemo(() => {
     const pinned = preferences.feeds.pinned
-
     const feeds: FeedDescriptor[] = []
-
     for (const uri of pinned) {
       if (uri.includes('app.bsky.feed.generator')) {
         feeds.push(`feedgen|${uri}`)
@@ -51,11 +45,8 @@ function HomeScreenReady({
         feeds.push(`list|${uri}`)
       }
     }
-
-    setCustomFeeds(feeds)
-
-    pagerRef.current?.setPage(0)
-  }, [preferences.feeds?.pinned, setCustomFeeds, pagerRef])
+    return feeds
+  }, [preferences.feeds.pinned])
 
   const homeFeedParams = React.useMemo<FeedParams>(() => {
     return {
@@ -121,7 +112,6 @@ function HomeScreenReady({
 
   return (
     <Pager
-      ref={pagerRef}
       testID="homeScreen"
       onPageSelected={onPageSelected}
       onPageScrollStateChanged={onPageScrollStateChanged}

--- a/src/view/screens/Home.tsx
+++ b/src/view/screens/Home.tsx
@@ -11,19 +11,34 @@ import {Pager, PagerRef, RenderTabBarFnProps} from 'view/com/pager/Pager'
 import {FeedPage} from 'view/com/feeds/FeedPage'
 import {useSetMinimalShellMode, useSetDrawerSwipeDisabled} from '#/state/shell'
 import {usePreferencesQuery} from '#/state/queries/preferences'
+import {UsePreferencesQueryResponse} from '#/state/queries/preferences/types'
 import {emitSoftReset} from '#/state/events'
 
 type Props = NativeStackScreenProps<HomeTabNavigatorParams, 'Home'>
-export const HomeScreen = withAuthRequired(function HomeScreenImpl({}: Props) {
+export const HomeScreen = withAuthRequired(function HomeScreenImpl(
+  props: Props,
+) {
+  const {data: preferences} = usePreferencesQuery()
+  if (preferences) {
+    return <HomeScreenReady {...props} preferences={preferences} />
+  } else {
+    return null // TODO
+  }
+})
+
+function HomeScreenReady({
+  preferences,
+}: Props & {
+  preferences: UsePreferencesQueryResponse
+}) {
   const setMinimalShellMode = useSetMinimalShellMode()
   const setDrawerSwipeDisabled = useSetDrawerSwipeDisabled()
   const pagerRef = React.useRef<PagerRef>(null)
   const [selectedPage, setSelectedPage] = React.useState(0)
   const [customFeeds, setCustomFeeds] = React.useState<FeedDescriptor[]>([])
-  const {data: preferences} = usePreferencesQuery()
 
   React.useEffect(() => {
-    if (!preferences?.feeds?.pinned) return
+    if (!preferences.feeds.pinned) return
 
     const pinned = preferences.feeds.pinned
 
@@ -40,11 +55,9 @@ export const HomeScreen = withAuthRequired(function HomeScreenImpl({}: Props) {
     setCustomFeeds(feeds)
 
     pagerRef.current?.setPage(0)
-  }, [preferences?.feeds?.pinned, setCustomFeeds, pagerRef])
+  }, [preferences.feeds?.pinned, setCustomFeeds, pagerRef])
 
   const homeFeedParams = React.useMemo<FeedParams>(() => {
-    if (!preferences) return {}
-
     return {
       mergeFeedEnabled: Boolean(preferences.feedViewPrefs.lab_mergeFeedEnabled),
       mergeFeedSources: preferences.feeds.saved,
@@ -136,4 +149,4 @@ export const HomeScreen = withAuthRequired(function HomeScreenImpl({}: Props) {
       })}
     </Pager>
   )
-})
+}


### PR DESCRIPTION
The issue was the feed tuner marking all feed items as stale because we've "seen" them. We've "seen" the initial feed fetch was immediately superseded by a second one. That happened because the pinned feeds (which are part of the parameters) were not immediately available, so loading them caused the query to refetch. The fix is to block on the prefs query.