### PR TITLE
Notifs refresh improvement

### DIFF
--- a/src/view/com/notifications/Feed.tsx
+++ b/src/view/com/notifications/Feed.tsx
@@ -143,12 +143,12 @@ export function Feed({
   const FeedHeader = React.useCallback(
     () => (
       <View>
+        {ListHeaderComponent ? <ListHeaderComponent /> : null}
         {showHeaderSpinner ? (
           <View style={{padding: 10}}>
             <ActivityIndicator />
           </View>
         ) : null}
-        {ListHeaderComponent ? <ListHeaderComponent /> : null}
       </View>
     ),
     [ListHeaderComponent, showHeaderSpinner],

--- a/src/view/com/notifications/Feed.tsx
+++ b/src/view/com/notifications/Feed.tsx
@@ -139,6 +139,21 @@ export function Feed({
     [onPressRetryLoadMore, dataUpdatedAt, moderationOpts],
   )
 
+  const showHeaderSpinner = !isPTRing && isFetching
+  const FeedHeader = React.useCallback(
+    () => (
+      <View>
+        {showHeaderSpinner ? (
+          <View style={{padding: 10}}>
+            <ActivityIndicator />
+          </View>
+        ) : null}
+        {ListHeaderComponent ? <ListHeaderComponent /> : null}
+      </View>
+    ),
+    [ListHeaderComponent, showHeaderSpinner],
+  )
+
   const FeedFooter = React.useCallback(
     () =>
       isFetchingNextPage ? (
@@ -168,7 +183,7 @@ export function Feed({
         data={items}
         keyExtractor={item => item._reactKey}
         renderItem={renderItem}
-        ListHeaderComponent={ListHeaderComponent}
+        ListHeaderComponent={FeedHeader}
         ListFooterComponent={FeedFooter}
         refreshControl={
           <RefreshControl

--- a/src/view/com/notifications/Feed.tsx
+++ b/src/view/com/notifications/Feed.tsx
@@ -39,6 +39,7 @@ export function Feed({
   const {
     data,
     dataUpdatedAt,
+    isLoading,
     isFetching,
     isFetched,
     isError,
@@ -139,7 +140,7 @@ export function Feed({
     [onPressRetryLoadMore, dataUpdatedAt, moderationOpts],
   )
 
-  const showHeaderSpinner = !isPTRing && isFetching
+  const showHeaderSpinner = !isPTRing && isFetching && !isLoading
   const FeedHeader = React.useCallback(
     () => (
       <View>

--- a/src/view/screens/Notifications.tsx
+++ b/src/view/screens/Notifications.tsx
@@ -47,7 +47,10 @@ export const NotificationsScreen = withAuthRequired(
 
     const onPressLoadLatest = React.useCallback(() => {
       scrollToTop()
-      queryClient.invalidateQueries({queryKey: NOTIFS_RQKEY()})
+      queryClient.invalidateQueries({
+        queryKey: NOTIFS_RQKEY(),
+        refetchType: 'all',
+      })
     }, [scrollToTop, queryClient])
 
     // on-visible setup

--- a/src/view/screens/Notifications.tsx
+++ b/src/view/screens/Notifications.tsx
@@ -49,7 +49,6 @@ export const NotificationsScreen = withAuthRequired(
       scrollToTop()
       queryClient.invalidateQueries({
         queryKey: NOTIFS_RQKEY(),
-        refetchType: 'all',
       })
     }, [scrollToTop, queryClient])
 


### PR DESCRIPTION
1. Lack of visual feedback on notifs refetch was feeling off. This adds a spinner which could use visual improvements but does the job for now.
2. Turns out invalidation wasn't always triggering, you need `refetchType: 'all'` to ensure it happens