### PR TITLE
Move the current agent to a global and reset RQ queries on agent change (react-query refactor)

### DIFF
--- a/src/state/queries/actor-autocomplete.ts
+++ b/src/state/queries/actor-autocomplete.ts
@@ -3,14 +3,13 @@ import {AppBskyActorDefs} from '@atproto/api'
 import {useQuery, useQueryClient} from '@tanstack/react-query'
 
 import {logger} from '#/logger'
-import {useSession} from '#/state/session'
+import {getAgent} from '#/state/session'
 import {useMyFollowsQuery} from '#/state/queries/my-follows'
 import {STALE} from '#/state/queries'
 
 export const RQKEY = (prefix: string) => ['actor-autocomplete', prefix]
 
 export function useActorAutocompleteQuery(prefix: string) {
-  const {agent} = useSession()
   const {data: follows, isFetching} = useMyFollowsQuery()
 
   return useQuery<AppBskyActorDefs.ProfileViewBasic[]>({
@@ -18,7 +17,7 @@ export function useActorAutocompleteQuery(prefix: string) {
     queryKey: RQKEY(prefix || ''),
     async queryFn() {
       const res = prefix
-        ? await agent.searchActorsTypeahead({
+        ? await getAgent().searchActorsTypeahead({
             term: prefix,
             limit: 8,
           })
@@ -32,7 +31,6 @@ export function useActorAutocompleteQuery(prefix: string) {
 export type ActorAutocompleteFn = ReturnType<typeof useActorAutocompleteFn>
 export function useActorAutocompleteFn() {
   const queryClient = useQueryClient()
-  const {agent} = useSession()
   const {data: follows} = useMyFollowsQuery()
 
   return React.useCallback(
@@ -44,7 +42,7 @@ export function useActorAutocompleteFn() {
             staleTime: STALE.MINUTES.ONE,
             queryKey: RQKEY(query || ''),
             queryFn: () =>
-              agent.searchActorsTypeahead({
+              getAgent().searchActorsTypeahead({
                 term: query,
                 limit,
               }),
@@ -58,7 +56,7 @@ export function useActorAutocompleteFn() {
 
       return computeSuggestions(query, follows, res?.data.actors)
     },
-    [agent, follows, queryClient],
+    [follows, queryClient],
   )
 }
 

--- a/src/state/queries/app-passwords.ts
+++ b/src/state/queries/app-passwords.ts
@@ -1,25 +1,23 @@
 import {ComAtprotoServerCreateAppPassword} from '@atproto/api'
 import {useQuery, useQueryClient, useMutation} from '@tanstack/react-query'
 
-import {useSession} from '#/state/session'
 import {STALE} from '#/state/queries'
+import {getAgent} from '../session'
 
 export const RQKEY = () => ['app-passwords']
 
 export function useAppPasswordsQuery() {
-  const {agent} = useSession()
   return useQuery({
     staleTime: STALE.MINUTES.ONE,
     queryKey: RQKEY(),
     queryFn: async () => {
-      const res = await agent.com.atproto.server.listAppPasswords({})
+      const res = await getAgent().com.atproto.server.listAppPasswords({})
       return res.data.passwords
     },
   })
 }
 
 export function useAppPasswordCreateMutation() {
-  const {agent} = useSession()
   const queryClient = useQueryClient()
   return useMutation<
     ComAtprotoServerCreateAppPassword.OutputSchema,
@@ -28,7 +26,7 @@ export function useAppPasswordCreateMutation() {
   >({
     mutationFn: async ({name}) => {
       return (
-        await agent.com.atproto.server.createAppPassword({
+        await getAgent().com.atproto.server.createAppPassword({
           name,
         })
       ).data
@@ -42,11 +40,10 @@ export function useAppPasswordCreateMutation() {
 }
 
 export function useAppPasswordDeleteMutation() {
-  const {agent} = useSession()
   const queryClient = useQueryClient()
   return useMutation<void, Error, {name: string}>({
     mutationFn: async ({name}) => {
-      await agent.com.atproto.server.revokeAppPassword({
+      await getAgent().com.atproto.server.revokeAppPassword({
         name,
       })
     },

--- a/src/state/queries/feed.ts
+++ b/src/state/queries/feed.ts
@@ -18,7 +18,7 @@ import {
 import {router} from '#/routes'
 import {sanitizeDisplayName} from '#/lib/strings/display-names'
 import {sanitizeHandle} from '#/lib/strings/handles'
-import {useSession} from '#/state/session'
+import {getAgent} from '#/state/session'
 import {usePreferencesQuery} from '#/state/queries/preferences'
 import {STALE} from '#/state/queries'
 
@@ -136,7 +136,6 @@ export function getFeedTypeFromUri(uri: string) {
 }
 
 export function useFeedSourceInfoQuery({uri}: {uri: string}) {
-  const {agent} = useSession()
   const type = getFeedTypeFromUri(uri)
 
   return useQuery({
@@ -146,10 +145,10 @@ export function useFeedSourceInfoQuery({uri}: {uri: string}) {
       let view: FeedSourceInfo
 
       if (type === 'feed') {
-        const res = await agent.app.bsky.feed.getFeedGenerator({feed: uri})
+        const res = await getAgent().app.bsky.feed.getFeedGenerator({feed: uri})
         view = hydrateFeedGenerator(res.data.view)
       } else {
-        const res = await agent.app.bsky.graph.getList({
+        const res = await getAgent().app.bsky.graph.getList({
           list: uri,
           limit: 1,
         })
@@ -164,8 +163,6 @@ export function useFeedSourceInfoQuery({uri}: {uri: string}) {
 export const useGetPopularFeedsQueryKey = ['getPopularFeeds']
 
 export function useGetPopularFeedsQuery() {
-  const {agent} = useSession()
-
   return useInfiniteQuery<
     AppBskyUnspeccedGetPopularFeedGenerators.OutputSchema,
     Error,
@@ -175,7 +172,7 @@ export function useGetPopularFeedsQuery() {
   >({
     queryKey: useGetPopularFeedsQueryKey,
     queryFn: async ({pageParam}) => {
-      const res = await agent.app.bsky.unspecced.getPopularFeedGenerators({
+      const res = await getAgent().app.bsky.unspecced.getPopularFeedGenerators({
         limit: 10,
         cursor: pageParam,
       })
@@ -187,11 +184,9 @@ export function useGetPopularFeedsQuery() {
 }
 
 export function useSearchPopularFeedsMutation() {
-  const {agent} = useSession()
-
   return useMutation({
     mutationFn: async (query: string) => {
-      const res = await agent.app.bsky.unspecced.getPopularFeedGenerators({
+      const res = await getAgent().app.bsky.unspecced.getPopularFeedGenerators({
         limit: 10,
         query: query,
       })
@@ -220,7 +215,6 @@ const FOLLOWING_FEED_STUB: FeedSourceInfo = {
 }
 
 export function usePinnedFeedsInfos(): FeedSourceInfo[] {
-  const {agent} = useSession()
   const queryClient = useQueryClient()
   const [tabs, setTabs] = React.useState<FeedSourceInfo[]>([
     FOLLOWING_FEED_STUB,
@@ -250,12 +244,12 @@ export function usePinnedFeedsInfos(): FeedSourceInfo[] {
                 const type = getFeedTypeFromUri(uri)
 
                 if (type === 'feed') {
-                  const res = await agent.app.bsky.feed.getFeedGenerator({
+                  const res = await getAgent().app.bsky.feed.getFeedGenerator({
                     feed: uri,
                   })
                   return hydrateFeedGenerator(res.data.view)
                 } else {
-                  const res = await agent.app.bsky.graph.getList({
+                  const res = await getAgent().app.bsky.graph.getList({
                     list: uri,
                     limit: 1,
                   })
@@ -274,7 +268,6 @@ export function usePinnedFeedsInfos(): FeedSourceInfo[] {
 
     fetchFeedInfo()
   }, [
-    agent,
     queryClient,
     setTabs,
     preferences?.feeds?.pinned,

--- a/src/state/queries/handle.ts
+++ b/src/state/queries/handle.ts
@@ -1,14 +1,13 @@
 import React from 'react'
 import {useQueryClient, useMutation} from '@tanstack/react-query'
 
-import {useSession} from '#/state/session'
+import {getAgent} from '#/state/session'
 import {STALE} from '#/state/queries'
 
 const fetchHandleQueryKey = (handleOrDid: string) => ['handle', handleOrDid]
 const fetchDidQueryKey = (handleOrDid: string) => ['did', handleOrDid]
 
 export function useFetchHandle() {
-  const {agent} = useSession()
   const queryClient = useQueryClient()
 
   return React.useCallback(
@@ -17,23 +16,22 @@ export function useFetchHandle() {
         const res = await queryClient.fetchQuery({
           staleTime: STALE.MINUTES.FIVE,
           queryKey: fetchHandleQueryKey(handleOrDid),
-          queryFn: () => agent.getProfile({actor: handleOrDid}),
+          queryFn: () => getAgent().getProfile({actor: handleOrDid}),
         })
         return res.data.handle
       }
       return handleOrDid
     },
-    [agent, queryClient],
+    [queryClient],
   )
 }
 
 export function useUpdateHandleMutation() {
-  const {agent} = useSession()
   const queryClient = useQueryClient()
 
   return useMutation({
     mutationFn: async ({handle}: {handle: string}) => {
-      await agent.updateHandle({handle})
+      await getAgent().updateHandle({handle})
     },
     onSuccess(_data, variables) {
       queryClient.invalidateQueries({
@@ -44,7 +42,6 @@ export function useUpdateHandleMutation() {
 }
 
 export function useFetchDid() {
-  const {agent} = useSession()
   const queryClient = useQueryClient()
 
   return React.useCallback(
@@ -55,13 +52,13 @@ export function useFetchDid() {
         queryFn: async () => {
           let identifier = handleOrDid
           if (!identifier.startsWith('did:')) {
-            const res = await agent.resolveHandle({handle: identifier})
+            const res = await getAgent().resolveHandle({handle: identifier})
             identifier = res.data.did
           }
           return identifier
         },
       })
     },
-    [agent, queryClient],
+    [queryClient],
   )
 }

--- a/src/state/queries/invites.ts
+++ b/src/state/queries/invites.ts
@@ -1,7 +1,7 @@
 import {ComAtprotoServerDefs} from '@atproto/api'
 import {useQuery} from '@tanstack/react-query'
 
-import {useSession} from '#/state/session'
+import {getAgent} from '#/state/session'
 import {STALE} from '#/state/queries'
 
 function isInviteAvailable(invite: ComAtprotoServerDefs.InviteCode): boolean {
@@ -13,13 +13,11 @@ export type InviteCodesQueryResponse = Exclude<
   undefined
 >
 export function useInviteCodesQuery() {
-  const {agent} = useSession()
-
   return useQuery({
     staleTime: STALE.HOURS.ONE,
     queryKey: ['inviteCodes'],
     queryFn: async () => {
-      const res = await agent.com.atproto.server.getAccountInviteCodes({})
+      const res = await getAgent().com.atproto.server.getAccountInviteCodes({})
 
       if (!res.data?.codes) {
         throw new Error(`useInviteCodesQuery: no codes returned`)

--- a/src/state/queries/like.ts
+++ b/src/state/queries/like.ts
@@ -1,24 +1,20 @@
 import {useMutation} from '@tanstack/react-query'
 
-import {useSession} from '#/state/session'
+import {getAgent} from '#/state/session'
 
 export function useLikeMutation() {
-  const {agent} = useSession()
-
   return useMutation({
     mutationFn: async ({uri, cid}: {uri: string; cid: string}) => {
-      const res = await agent.like(uri, cid)
+      const res = await getAgent().like(uri, cid)
       return {uri: res.uri}
     },
   })
 }
 
 export function useUnlikeMutation() {
-  const {agent} = useSession()
-
   return useMutation({
     mutationFn: async ({uri}: {uri: string}) => {
-      await agent.deleteLike(uri)
+      await getAgent().deleteLike(uri)
     },
   })
 }

--- a/src/state/queries/list-members.ts
+++ b/src/state/queries/list-members.ts
@@ -1,7 +1,7 @@
 import {AppBskyGraphGetList} from '@atproto/api'
 import {useInfiniteQuery, InfiniteData, QueryKey} from '@tanstack/react-query'
 
-import {useSession} from '#/state/session'
+import {getAgent} from '#/state/session'
 import {STALE} from '#/state/queries'
 
 const PAGE_SIZE = 30
@@ -10,7 +10,6 @@ type RQPageParam = string | undefined
 export const RQKEY = (uri: string) => ['list-members', uri]
 
 export function useListMembersQuery(uri: string) {
-  const {agent} = useSession()
   return useInfiniteQuery<
     AppBskyGraphGetList.OutputSchema,
     Error,
@@ -21,7 +20,7 @@ export function useListMembersQuery(uri: string) {
     staleTime: STALE.MINUTES.ONE,
     queryKey: RQKEY(uri),
     async queryFn({pageParam}: {pageParam: RQPageParam}) {
-      const res = await agent.app.bsky.graph.getList({
+      const res = await getAgent().app.bsky.graph.getList({
         list: uri,
         limit: PAGE_SIZE,
         cursor: pageParam,

--- a/src/state/queries/list-memberships.ts
+++ b/src/state/queries/list-memberships.ts
@@ -17,7 +17,7 @@
 import {AtUri} from '@atproto/api'
 import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query'
 
-import {useSession} from '#/state/session'
+import {useSession, getAgent} from '#/state/session'
 import {RQKEY as LIST_MEMBERS_RQKEY} from '#/state/queries/list-members'
 import {STALE} from '#/state/queries'
 
@@ -38,7 +38,7 @@ export interface ListMembersip {
  * This API is dangerous! Read the note above!
  */
 export function useDangerousListMembershipsQuery() {
-  const {agent, currentAccount} = useSession()
+  const {currentAccount} = useSession()
   return useQuery<ListMembersip[]>({
     staleTime: STALE.MINUTES.FIVE,
     queryKey: RQKEY(),
@@ -49,7 +49,7 @@ export function useDangerousListMembershipsQuery() {
       let cursor
       let arr: ListMembersip[] = []
       for (let i = 0; i < SANITY_PAGE_LIMIT; i++) {
-        const res = await agent.app.bsky.graph.listitem.list({
+        const res = await getAgent().app.bsky.graph.listitem.list({
           repo: currentAccount.did,
           limit: PAGE_SIZE,
           cursor,
@@ -89,7 +89,7 @@ export function getMembership(
 }
 
 export function useListMembershipAddMutation() {
-  const {agent, currentAccount} = useSession()
+  const {currentAccount} = useSession()
   const queryClient = useQueryClient()
   return useMutation<
     {uri: string; cid: string},
@@ -100,7 +100,7 @@ export function useListMembershipAddMutation() {
       if (!currentAccount) {
         throw new Error('Not logged in')
       }
-      const res = await agent.app.bsky.graph.listitem.create(
+      const res = await getAgent().app.bsky.graph.listitem.create(
         {repo: currentAccount.did},
         {
           subject: actorDid,
@@ -147,7 +147,7 @@ export function useListMembershipAddMutation() {
 }
 
 export function useListMembershipRemoveMutation() {
-  const {agent, currentAccount} = useSession()
+  const {currentAccount} = useSession()
   const queryClient = useQueryClient()
   return useMutation<
     void,
@@ -159,7 +159,7 @@ export function useListMembershipRemoveMutation() {
         throw new Error('Not logged in')
       }
       const membershipUrip = new AtUri(membershipUri)
-      await agent.app.bsky.graph.listitem.delete({
+      await getAgent().app.bsky.graph.listitem.delete({
         repo: currentAccount.did,
         rkey: membershipUrip.rkey,
       })

--- a/src/state/queries/my-blocked-accounts.ts
+++ b/src/state/queries/my-blocked-accounts.ts
@@ -1,14 +1,13 @@
 import {AppBskyGraphGetBlocks} from '@atproto/api'
 import {useInfiniteQuery, InfiniteData, QueryKey} from '@tanstack/react-query'
 
-import {useSession} from '#/state/session'
+import {getAgent} from '#/state/session'
 import {STALE} from '#/state/queries'
 
 export const RQKEY = () => ['my-blocked-accounts']
 type RQPageParam = string | undefined
 
 export function useMyBlockedAccountsQuery() {
-  const {agent} = useSession()
   return useInfiniteQuery<
     AppBskyGraphGetBlocks.OutputSchema,
     Error,
@@ -19,7 +18,7 @@ export function useMyBlockedAccountsQuery() {
     staleTime: STALE.MINUTES.ONE,
     queryKey: RQKEY(),
     async queryFn({pageParam}: {pageParam: RQPageParam}) {
-      const res = await agent.app.bsky.graph.getBlocks({
+      const res = await getAgent().app.bsky.graph.getBlocks({
         limit: 30,
         cursor: pageParam,
       })

--- a/src/state/queries/my-follows.ts
+++ b/src/state/queries/my-follows.ts
@@ -1,6 +1,6 @@
 import {AppBskyActorDefs} from '@atproto/api'
 import {useQuery} from '@tanstack/react-query'
-import {useSession} from '../session'
+import {useSession, getAgent} from '../session'
 import {STALE} from '#/state/queries'
 
 // sanity limit is SANITY_PAGE_LIMIT*PAGE_SIZE total records
@@ -11,7 +11,7 @@ const PAGE_SIZE = 100
 export const RQKEY = () => ['my-follows']
 
 export function useMyFollowsQuery() {
-  const {agent, currentAccount} = useSession()
+  const {currentAccount} = useSession()
   return useQuery<AppBskyActorDefs.ProfileViewBasic[]>({
     staleTime: STALE.MINUTES.ONE,
     queryKey: RQKEY(),
@@ -22,7 +22,7 @@ export function useMyFollowsQuery() {
       let cursor
       let arr: AppBskyActorDefs.ProfileViewBasic[] = []
       for (let i = 0; i < SANITY_PAGE_LIMIT; i++) {
-        const res = await agent.getFollows({
+        const res = await getAgent().getFollows({
           actor: currentAccount.did,
           cursor,
           limit: PAGE_SIZE,

--- a/src/state/queries/my-lists.ts
+++ b/src/state/queries/my-lists.ts
@@ -2,14 +2,14 @@ import {AppBskyGraphDefs} from '@atproto/api'
 import {useQuery, QueryClient} from '@tanstack/react-query'
 
 import {accumulate} from '#/lib/async/accumulate'
-import {useSession} from '#/state/session'
+import {useSession, getAgent} from '#/state/session'
 import {STALE} from '#/state/queries'
 
 export type MyListsFilter = 'all' | 'curate' | 'mod'
 export const RQKEY = (filter: MyListsFilter) => ['my-lists', filter]
 
 export function useMyListsQuery(filter: MyListsFilter) {
-  const {agent, currentAccount} = useSession()
+  const {currentAccount} = useSession()
   return useQuery<AppBskyGraphDefs.ListView[]>({
     staleTime: STALE.MINUTES.ONE,
     queryKey: RQKEY(filter),
@@ -17,8 +17,8 @@ export function useMyListsQuery(filter: MyListsFilter) {
       let lists: AppBskyGraphDefs.ListView[] = []
       const promises = [
         accumulate(cursor =>
-          agent.app.bsky.graph
-            .getLists({
+          getAgent()
+            .app.bsky.graph.getLists({
               actor: currentAccount!.did,
               cursor,
               limit: 50,
@@ -32,8 +32,8 @@ export function useMyListsQuery(filter: MyListsFilter) {
       if (filter === 'all' || filter === 'mod') {
         promises.push(
           accumulate(cursor =>
-            agent.app.bsky.graph
-              .getListMutes({
+            getAgent()
+              .app.bsky.graph.getListMutes({
                 cursor,
                 limit: 50,
               })
@@ -45,8 +45,8 @@ export function useMyListsQuery(filter: MyListsFilter) {
         )
         promises.push(
           accumulate(cursor =>
-            agent.app.bsky.graph
-              .getListBlocks({
+            getAgent()
+              .app.bsky.graph.getListBlocks({
                 cursor,
                 limit: 50,
               })

--- a/src/state/queries/my-muted-accounts.ts
+++ b/src/state/queries/my-muted-accounts.ts
@@ -1,14 +1,13 @@
 import {AppBskyGraphGetMutes} from '@atproto/api'
 import {useInfiniteQuery, InfiniteData, QueryKey} from '@tanstack/react-query'
 
-import {useSession} from '#/state/session'
+import {getAgent} from '#/state/session'
 import {STALE} from '#/state/queries'
 
 export const RQKEY = () => ['my-muted-accounts']
 type RQPageParam = string | undefined
 
 export function useMyMutedAccountsQuery() {
-  const {agent} = useSession()
   return useInfiniteQuery<
     AppBskyGraphGetMutes.OutputSchema,
     Error,
@@ -19,7 +18,7 @@ export function useMyMutedAccountsQuery() {
     staleTime: STALE.MINUTES.ONE,
     queryKey: RQKEY(),
     async queryFn({pageParam}: {pageParam: RQPageParam}) {
-      const res = await agent.app.bsky.graph.getMutes({
+      const res = await getAgent().app.bsky.graph.getMutes({
         limit: 30,
         cursor: pageParam,
       })

--- a/src/state/queries/notifications/feed.ts
+++ b/src/state/queries/notifications/feed.ts
@@ -8,7 +8,7 @@ import {
 } from '@atproto/api'
 import chunk from 'lodash.chunk'
 import {useInfiniteQuery, InfiniteData, QueryKey} from '@tanstack/react-query'
-import {useSession} from '../../session'
+import {getAgent} from '../../session'
 import {useModerationOpts} from '../preferences'
 import {shouldFilterNotif} from './util'
 import {useMutedThreads} from '#/state/muted-threads'
@@ -49,7 +49,6 @@ export interface FeedPage {
 }
 
 export function useNotificationFeedQuery(opts?: {enabled?: boolean}) {
-  const {agent} = useSession()
   const moderationOpts = useModerationOpts()
   const threadMutes = useMutedThreads()
   const enabled = opts?.enabled !== false
@@ -64,7 +63,7 @@ export function useNotificationFeedQuery(opts?: {enabled?: boolean}) {
     staleTime: STALE.INFINITY,
     queryKey: RQKEY(),
     async queryFn({pageParam}: {pageParam: RQPageParam}) {
-      const res = await agent.listNotifications({
+      const res = await getAgent().listNotifications({
         limit: PAGE_SIZE,
         cursor: pageParam,
       })
@@ -79,7 +78,7 @@ export function useNotificationFeedQuery(opts?: {enabled?: boolean}) {
 
       // we fetch subjects of notifications (usually posts) now instead of lazily
       // in the UI to avoid relayouts
-      const subjects = await fetchSubjects(agent, notifsGrouped)
+      const subjects = await fetchSubjects(getAgent(), notifsGrouped)
       for (const notif of notifsGrouped) {
         if (notif.subjectUri) {
           notif.subject = subjects.get(notif.subjectUri)

--- a/src/state/queries/notifications/unread.tsx
+++ b/src/state/queries/notifications/unread.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import * as Notifications from 'expo-notifications'
 import BroadcastChannel from '#/lib/broadcast'
-import {useSession} from '#/state/session'
+import {useSession, getAgent} from '#/state/session'
 import {useModerationOpts} from '../preferences'
 import {shouldFilterNotif} from './util'
 import {isNative} from '#/platform/detection'
@@ -25,7 +25,7 @@ const apiContext = React.createContext<ApiContext>({
 })
 
 export function Provider({children}: React.PropsWithChildren<{}>) {
-  const {hasSession, agent} = useSession()
+  const {hasSession} = useSession()
   const moderationOpts = useModerationOpts()
 
   const [numUnread, setNumUnread] = React.useState('')
@@ -60,7 +60,9 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
     return {
       async markAllRead() {
         // update server
-        await agent.updateSeenNotifications(lastSyncRef.current.toISOString())
+        await getAgent().updateSeenNotifications(
+          lastSyncRef.current.toISOString(),
+        )
 
         // update & broadcast
         setNumUnread('')
@@ -69,7 +71,7 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
 
       async checkUnread() {
         // count
-        const res = await agent.listNotifications({limit: 40})
+        const res = await getAgent().listNotifications({limit: 40})
         const filtered = res.data.notifications.filter(
           notif => !notif.isRead && !shouldFilterNotif(notif, moderationOpts),
         )
@@ -94,7 +96,7 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
         broadcast.postMessage({event: num})
       },
     }
-  }, [setNumUnread, agent, moderationOpts])
+  }, [setNumUnread, moderationOpts])
   checkUnreadRef.current = api.checkUnread
 
   return (

--- a/src/state/queries/post-feed.ts
+++ b/src/state/queries/post-feed.ts
@@ -1,7 +1,7 @@
 import {useCallback, useMemo} from 'react'
 import {AppBskyFeedDefs, AppBskyFeedPost, moderatePost} from '@atproto/api'
 import {useInfiniteQuery, InfiniteData, QueryKey} from '@tanstack/react-query'
-import {useSession} from '../session'
+import {getAgent} from '../session'
 import {useFeedTuners} from '../preferences/feed-tuners'
 import {FeedTuner, NoopFeedTuner} from 'lib/api/feed-manip'
 import {FeedAPI, ReasonFeedSource} from 'lib/api/feed/types'
@@ -66,10 +66,10 @@ export function usePostFeedQuery(
   params?: FeedParams,
   opts?: {enabled?: boolean},
 ) {
-  const {agent} = useSession()
   const feedTuners = useFeedTuners(feedDesc)
   const enabled = opts?.enabled !== false
   const moderationOpts = useModerationOpts()
+  const agent = getAgent()
 
   const api: FeedAPI = useMemo(() => {
     if (feedDesc === 'home') {

--- a/src/state/queries/post-liked-by.ts
+++ b/src/state/queries/post-liked-by.ts
@@ -1,7 +1,7 @@
 import {AppBskyFeedGetLikes} from '@atproto/api'
 import {useInfiniteQuery, InfiniteData, QueryKey} from '@tanstack/react-query'
 
-import {useSession} from '#/state/session'
+import {getAgent} from '#/state/session'
 import {STALE} from '#/state/queries'
 
 const PAGE_SIZE = 30
@@ -11,7 +11,6 @@ type RQPageParam = string | undefined
 export const RQKEY = (resolvedUri: string) => ['post-liked-by', resolvedUri]
 
 export function usePostLikedByQuery(resolvedUri: string | undefined) {
-  const {agent} = useSession()
   return useInfiniteQuery<
     AppBskyFeedGetLikes.OutputSchema,
     Error,
@@ -22,7 +21,7 @@ export function usePostLikedByQuery(resolvedUri: string | undefined) {
     staleTime: STALE.MINUTES.ONE,
     queryKey: RQKEY(resolvedUri || ''),
     async queryFn({pageParam}: {pageParam: RQPageParam}) {
-      const res = await agent.getLikes({
+      const res = await getAgent().getLikes({
         uri: resolvedUri || '',
         limit: PAGE_SIZE,
         cursor: pageParam,

--- a/src/state/queries/post-reposted-by.ts
+++ b/src/state/queries/post-reposted-by.ts
@@ -1,7 +1,7 @@
 import {AppBskyFeedGetRepostedBy} from '@atproto/api'
 import {useInfiniteQuery, InfiniteData, QueryKey} from '@tanstack/react-query'
 
-import {useSession} from '#/state/session'
+import {getAgent} from '#/state/session'
 import {STALE} from '#/state/queries'
 
 const PAGE_SIZE = 30
@@ -11,7 +11,6 @@ type RQPageParam = string | undefined
 export const RQKEY = (resolvedUri: string) => ['post-reposted-by', resolvedUri]
 
 export function usePostRepostedByQuery(resolvedUri: string | undefined) {
-  const {agent} = useSession()
   return useInfiniteQuery<
     AppBskyFeedGetRepostedBy.OutputSchema,
     Error,
@@ -22,7 +21,7 @@ export function usePostRepostedByQuery(resolvedUri: string | undefined) {
     staleTime: STALE.MINUTES.ONE,
     queryKey: RQKEY(resolvedUri || ''),
     async queryFn({pageParam}: {pageParam: RQPageParam}) {
-      const res = await agent.getRepostedBy({
+      const res = await getAgent().getRepostedBy({
         uri: resolvedUri || '',
         limit: PAGE_SIZE,
         cursor: pageParam,

--- a/src/state/queries/post-thread.ts
+++ b/src/state/queries/post-thread.ts
@@ -5,7 +5,7 @@ import {
 } from '@atproto/api'
 import {useQuery} from '@tanstack/react-query'
 
-import {useSession} from '#/state/session'
+import {getAgent} from '#/state/session'
 import {UsePreferencesQueryResponse} from '#/state/queries/preferences/types'
 import {STALE} from '#/state/queries'
 
@@ -58,12 +58,11 @@ export type ThreadNode =
   | ThreadUnknown
 
 export function usePostThreadQuery(uri: string | undefined) {
-  const {agent} = useSession()
   return useQuery<ThreadNode, Error>({
     staleTime: STALE.MINUTES.ONE,
     queryKey: RQKEY(uri || ''),
     async queryFn() {
-      const res = await agent.getPostThread({uri: uri!})
+      const res = await getAgent().getPostThread({uri: uri!})
       if (res.success) {
         return responseToThreadNodes(res.data.thread)
       }

--- a/src/state/queries/preferences/index.ts
+++ b/src/state/queries/preferences/index.ts
@@ -9,7 +9,7 @@ import isEqual from 'lodash.isequal'
 
 import {track} from '#/lib/analytics/analytics'
 import {getAge} from '#/lib/strings/time'
-import {useSession} from '#/state/session'
+import {useSession, getAgent} from '#/state/session'
 import {DEFAULT_LABEL_PREFERENCES} from '#/state/queries/preferences/moderation'
 import {
   ConfigurableLabelGroup,
@@ -31,13 +31,13 @@ export * from '#/state/queries/preferences/const'
 export const usePreferencesQueryKey = ['getPreferences']
 
 export function usePreferencesQuery() {
-  const {agent, hasSession} = useSession()
+  const {hasSession} = useSession()
   return useQuery({
     enabled: hasSession,
     staleTime: STALE.MINUTES.ONE,
     queryKey: usePreferencesQueryKey,
     queryFn: async () => {
-      const res = await agent.getPreferences()
+      const res = await getAgent().getPreferences()
       const preferences: UsePreferencesQueryResponse = {
         ...res,
         feeds: {
@@ -110,12 +110,11 @@ export function useModerationOpts() {
 }
 
 export function useClearPreferencesMutation() {
-  const {agent} = useSession()
   const queryClient = useQueryClient()
 
   return useMutation({
     mutationFn: async () => {
-      await agent.app.bsky.actor.putPreferences({preferences: []})
+      await getAgent().app.bsky.actor.putPreferences({preferences: []})
       // triggers a refetch
       await queryClient.invalidateQueries({
         queryKey: usePreferencesQueryKey,
@@ -125,7 +124,6 @@ export function useClearPreferencesMutation() {
 }
 
 export function usePreferencesSetContentLabelMutation() {
-  const {agent} = useSession()
   const queryClient = useQueryClient()
 
   return useMutation<
@@ -134,7 +132,7 @@ export function usePreferencesSetContentLabelMutation() {
     {labelGroup: ConfigurableLabelGroup; visibility: LabelPreference}
   >({
     mutationFn: async ({labelGroup, visibility}) => {
-      await agent.setContentLabelPref(labelGroup, visibility)
+      await getAgent().setContentLabelPref(labelGroup, visibility)
       // triggers a refetch
       await queryClient.invalidateQueries({
         queryKey: usePreferencesQueryKey,
@@ -144,12 +142,11 @@ export function usePreferencesSetContentLabelMutation() {
 }
 
 export function usePreferencesSetAdultContentMutation() {
-  const {agent} = useSession()
   const queryClient = useQueryClient()
 
   return useMutation<void, unknown, {enabled: boolean}>({
     mutationFn: async ({enabled}) => {
-      await agent.setAdultContentEnabled(enabled)
+      await getAgent().setAdultContentEnabled(enabled)
       // triggers a refetch
       await queryClient.invalidateQueries({
         queryKey: usePreferencesQueryKey,
@@ -159,12 +156,11 @@ export function usePreferencesSetAdultContentMutation() {
 }
 
 export function usePreferencesSetBirthDateMutation() {
-  const {agent} = useSession()
   const queryClient = useQueryClient()
 
   return useMutation<void, unknown, {birthDate: Date}>({
     mutationFn: async ({birthDate}: {birthDate: Date}) => {
-      await agent.setPersonalDetails({birthDate})
+      await getAgent().setPersonalDetails({birthDate})
       // triggers a refetch
       await queryClient.invalidateQueries({
         queryKey: usePreferencesQueryKey,
@@ -174,12 +170,11 @@ export function usePreferencesSetBirthDateMutation() {
 }
 
 export function useSetFeedViewPreferencesMutation() {
-  const {agent} = useSession()
   const queryClient = useQueryClient()
 
   return useMutation<void, unknown, Partial<BskyFeedViewPreference>>({
     mutationFn: async prefs => {
-      await agent.setFeedViewPrefs('home', prefs)
+      await getAgent().setFeedViewPrefs('home', prefs)
       // triggers a refetch
       await queryClient.invalidateQueries({
         queryKey: usePreferencesQueryKey,
@@ -189,12 +184,11 @@ export function useSetFeedViewPreferencesMutation() {
 }
 
 export function useSetThreadViewPreferencesMutation() {
-  const {agent} = useSession()
   const queryClient = useQueryClient()
 
   return useMutation<void, unknown, Partial<ThreadViewPreferences>>({
     mutationFn: async prefs => {
-      await agent.setThreadViewPrefs(prefs)
+      await getAgent().setThreadViewPrefs(prefs)
       // triggers a refetch
       await queryClient.invalidateQueries({
         queryKey: usePreferencesQueryKey,
@@ -204,7 +198,6 @@ export function useSetThreadViewPreferencesMutation() {
 }
 
 export function useSetSaveFeedsMutation() {
-  const {agent} = useSession()
   const queryClient = useQueryClient()
 
   return useMutation<
@@ -213,7 +206,7 @@ export function useSetSaveFeedsMutation() {
     Pick<UsePreferencesQueryResponse['feeds'], 'saved' | 'pinned'>
   >({
     mutationFn: async ({saved, pinned}) => {
-      await agent.setSavedFeeds(saved, pinned)
+      await getAgent().setSavedFeeds(saved, pinned)
       // triggers a refetch
       await queryClient.invalidateQueries({
         queryKey: usePreferencesQueryKey,
@@ -223,12 +216,11 @@ export function useSetSaveFeedsMutation() {
 }
 
 export function useSaveFeedMutation() {
-  const {agent} = useSession()
   const queryClient = useQueryClient()
 
   return useMutation<void, unknown, {uri: string}>({
     mutationFn: async ({uri}) => {
-      await agent.addSavedFeed(uri)
+      await getAgent().addSavedFeed(uri)
       track('CustomFeed:Save')
       // triggers a refetch
       await queryClient.invalidateQueries({
@@ -239,12 +231,11 @@ export function useSaveFeedMutation() {
 }
 
 export function useRemoveFeedMutation() {
-  const {agent} = useSession()
   const queryClient = useQueryClient()
 
   return useMutation<void, unknown, {uri: string}>({
     mutationFn: async ({uri}) => {
-      await agent.removeSavedFeed(uri)
+      await getAgent().removeSavedFeed(uri)
       track('CustomFeed:Unsave')
       // triggers a refetch
       await queryClient.invalidateQueries({
@@ -255,12 +246,11 @@ export function useRemoveFeedMutation() {
 }
 
 export function usePinFeedMutation() {
-  const {agent} = useSession()
   const queryClient = useQueryClient()
 
   return useMutation<void, unknown, {uri: string}>({
     mutationFn: async ({uri}) => {
-      await agent.addPinnedFeed(uri)
+      await getAgent().addPinnedFeed(uri)
       track('CustomFeed:Pin', {uri})
       // triggers a refetch
       await queryClient.invalidateQueries({
@@ -271,12 +261,11 @@ export function usePinFeedMutation() {
 }
 
 export function useUnpinFeedMutation() {
-  const {agent} = useSession()
   const queryClient = useQueryClient()
 
   return useMutation<void, unknown, {uri: string}>({
     mutationFn: async ({uri}) => {
-      await agent.removePinnedFeed(uri)
+      await getAgent().removePinnedFeed(uri)
       track('CustomFeed:Unpin', {uri})
       // triggers a refetch
       await queryClient.invalidateQueries({

--- a/src/state/queries/profile-extra-info.ts
+++ b/src/state/queries/profile-extra-info.ts
@@ -1,6 +1,6 @@
 import {useQuery} from '@tanstack/react-query'
 
-import {useSession} from '#/state/session'
+import {getAgent} from '#/state/session'
 import {STALE} from '#/state/queries'
 
 // TODO refactor invalidate on mutate?
@@ -11,17 +11,16 @@ export const RQKEY = (did: string) => ['profile-extra-info', did]
  * is not available in the API's ProfileView
  */
 export function useProfileExtraInfoQuery(did: string) {
-  const {agent} = useSession()
   return useQuery({
     staleTime: STALE.MINUTES.ONE,
     queryKey: RQKEY(did),
     async queryFn() {
       const [listsRes, feedsRes] = await Promise.all([
-        agent.app.bsky.graph.getLists({
+        getAgent().app.bsky.graph.getLists({
           actor: did,
           limit: 1,
         }),
-        agent.app.bsky.feed.getActorFeeds({
+        getAgent().app.bsky.feed.getActorFeeds({
           actor: did,
           limit: 1,
         }),

--- a/src/state/queries/profile-feedgens.ts
+++ b/src/state/queries/profile-feedgens.ts
@@ -1,7 +1,7 @@
 import {AppBskyFeedGetActorFeeds} from '@atproto/api'
 import {useInfiniteQuery, InfiniteData, QueryKey} from '@tanstack/react-query'
 
-import {useSession} from '#/state/session'
+import {getAgent} from '#/state/session'
 import {STALE} from '#/state/queries'
 
 const PAGE_SIZE = 30
@@ -14,7 +14,6 @@ export function useProfileFeedgensQuery(
   did: string,
   opts?: {enabled?: boolean},
 ) {
-  const {agent} = useSession()
   const enabled = opts?.enabled !== false
   return useInfiniteQuery<
     AppBskyFeedGetActorFeeds.OutputSchema,
@@ -26,7 +25,7 @@ export function useProfileFeedgensQuery(
     staleTime: STALE.MINUTES.ONE,
     queryKey: RQKEY(did),
     async queryFn({pageParam}: {pageParam: RQPageParam}) {
-      const res = await agent.app.bsky.feed.getActorFeeds({
+      const res = await getAgent().app.bsky.feed.getActorFeeds({
         actor: did,
         limit: PAGE_SIZE,
         cursor: pageParam,

--- a/src/state/queries/profile-followers.ts
+++ b/src/state/queries/profile-followers.ts
@@ -1,7 +1,7 @@
 import {AppBskyGraphGetFollowers} from '@atproto/api'
 import {useInfiniteQuery, InfiniteData, QueryKey} from '@tanstack/react-query'
 
-import {useSession} from '#/state/session'
+import {getAgent} from '#/state/session'
 import {STALE} from '#/state/queries'
 
 const PAGE_SIZE = 30
@@ -10,7 +10,6 @@ type RQPageParam = string | undefined
 export const RQKEY = (did: string) => ['profile-followers', did]
 
 export function useProfileFollowersQuery(did: string | undefined) {
-  const {agent} = useSession()
   return useInfiniteQuery<
     AppBskyGraphGetFollowers.OutputSchema,
     Error,
@@ -21,7 +20,7 @@ export function useProfileFollowersQuery(did: string | undefined) {
     staleTime: STALE.MINUTES.FIVE,
     queryKey: RQKEY(did || ''),
     async queryFn({pageParam}: {pageParam: RQPageParam}) {
-      const res = await agent.app.bsky.graph.getFollowers({
+      const res = await getAgent().app.bsky.graph.getFollowers({
         actor: did || '',
         limit: PAGE_SIZE,
         cursor: pageParam,

--- a/src/state/queries/profile-follows.ts
+++ b/src/state/queries/profile-follows.ts
@@ -1,7 +1,7 @@
 import {AppBskyGraphGetFollows} from '@atproto/api'
 import {useInfiniteQuery, InfiniteData, QueryKey} from '@tanstack/react-query'
 
-import {useSession} from '#/state/session'
+import {getAgent} from '#/state/session'
 import {STALE} from '#/state/queries'
 
 const PAGE_SIZE = 30
@@ -11,7 +11,6 @@ type RQPageParam = string | undefined
 export const RQKEY = (did: string) => ['profile-follows', did]
 
 export function useProfileFollowsQuery(did: string | undefined) {
-  const {agent} = useSession()
   return useInfiniteQuery<
     AppBskyGraphGetFollows.OutputSchema,
     Error,
@@ -22,7 +21,7 @@ export function useProfileFollowsQuery(did: string | undefined) {
     staleTime: STALE.MINUTES.ONE,
     queryKey: RQKEY(did || ''),
     async queryFn({pageParam}: {pageParam: RQPageParam}) {
-      const res = await agent.app.bsky.graph.getFollows({
+      const res = await getAgent().app.bsky.graph.getFollows({
         actor: did || '',
         limit: PAGE_SIZE,
         cursor: pageParam,

--- a/src/state/queries/profile-lists.ts
+++ b/src/state/queries/profile-lists.ts
@@ -1,7 +1,7 @@
 import {AppBskyGraphGetLists} from '@atproto/api'
 import {useInfiniteQuery, InfiniteData, QueryKey} from '@tanstack/react-query'
 
-import {useSession} from '#/state/session'
+import {getAgent} from '#/state/session'
 import {STALE} from '#/state/queries'
 
 const PAGE_SIZE = 30
@@ -10,7 +10,6 @@ type RQPageParam = string | undefined
 export const RQKEY = (did: string) => ['profile-lists', did]
 
 export function useProfileListsQuery(did: string, opts?: {enabled?: boolean}) {
-  const {agent} = useSession()
   const enabled = opts?.enabled !== false
   return useInfiniteQuery<
     AppBskyGraphGetLists.OutputSchema,
@@ -22,7 +21,7 @@ export function useProfileListsQuery(did: string, opts?: {enabled?: boolean}) {
     staleTime: STALE.MINUTES.ONE,
     queryKey: RQKEY(did),
     async queryFn({pageParam}: {pageParam: RQPageParam}) {
-      const res = await agent.app.bsky.graph.getLists({
+      const res = await getAgent().app.bsky.graph.getLists({
         actor: did,
         limit: PAGE_SIZE,
         cursor: pageParam,

--- a/src/state/queries/resolve-uri.ts
+++ b/src/state/queries/resolve-uri.ts
@@ -1,20 +1,19 @@
 import {useQuery} from '@tanstack/react-query'
 import {AtUri} from '@atproto/api'
 
-import {useSession} from '#/state/session'
+import {getAgent} from '#/state/session'
 import {STALE} from '#/state/queries'
 
 export const RQKEY = (uri: string) => ['resolved-uri', uri]
 
 export function useResolveUriQuery(uri: string | undefined) {
-  const {agent} = useSession()
   return useQuery<{uri: string; did: string}, Error>({
     staleTime: STALE.INFINITY,
     queryKey: RQKEY(uri || ''),
     async queryFn() {
       const urip = new AtUri(uri || '')
       if (!urip.host.startsWith('did:')) {
-        const res = await agent.resolveHandle({handle: urip.host})
+        const res = await getAgent().resolveHandle({handle: urip.host})
         urip.host = res.data.did
       }
       return {did: urip.host, uri: urip.toString()}

--- a/src/state/queries/search-posts.ts
+++ b/src/state/queries/search-posts.ts
@@ -1,7 +1,7 @@
 import {AppBskyFeedSearchPosts} from '@atproto/api'
 import {useInfiniteQuery, InfiniteData, QueryKey} from '@tanstack/react-query'
 
-import {useSession} from '#/state/session'
+import {getAgent} from '#/state/session'
 
 const searchPostsQueryKey = ({query}: {query: string}) => [
   'search-posts',
@@ -9,8 +9,6 @@ const searchPostsQueryKey = ({query}: {query: string}) => [
 ]
 
 export function useSearchPostsQuery({query}: {query: string}) {
-  const {agent} = useSession()
-
   return useInfiniteQuery<
     AppBskyFeedSearchPosts.OutputSchema,
     Error,
@@ -20,7 +18,7 @@ export function useSearchPostsQuery({query}: {query: string}) {
   >({
     queryKey: searchPostsQueryKey({query}),
     queryFn: async () => {
-      const res = await agent.app.bsky.feed.searchPosts({
+      const res = await getAgent().app.bsky.feed.searchPosts({
         q: query,
         limit: 25,
       })

--- a/src/state/queries/suggested-feeds.ts
+++ b/src/state/queries/suggested-feeds.ts
@@ -1,14 +1,12 @@
 import {useInfiniteQuery, InfiniteData, QueryKey} from '@tanstack/react-query'
 import {AppBskyFeedGetSuggestedFeeds} from '@atproto/api'
 
-import {useSession} from '#/state/session'
+import {getAgent} from '#/state/session'
 import {STALE} from '#/state/queries'
 
 export const suggestedFeedsQueryKey = ['suggestedFeeds']
 
 export function useSuggestedFeedsQuery() {
-  const {agent} = useSession()
-
   return useInfiniteQuery<
     AppBskyFeedGetSuggestedFeeds.OutputSchema,
     Error,
@@ -19,7 +17,7 @@ export function useSuggestedFeedsQuery() {
     staleTime: STALE.HOURS.ONE,
     queryKey: suggestedFeedsQueryKey,
     queryFn: async ({pageParam}) => {
-      const res = await agent.app.bsky.feed.getSuggestedFeeds({
+      const res = await getAgent().app.bsky.feed.getSuggestedFeeds({
         limit: 10,
         cursor: pageParam,
       })

--- a/src/state/queries/suggested-follows.ts
+++ b/src/state/queries/suggested-follows.ts
@@ -12,7 +12,7 @@ import {
   QueryKey,
 } from '@tanstack/react-query'
 
-import {useSession} from '#/state/session'
+import {useSession, getAgent} from '#/state/session'
 import {useModerationOpts} from '#/state/queries/preferences'
 import {STALE} from '#/state/queries'
 
@@ -23,7 +23,7 @@ const suggestedFollowsByActorQueryKey = (did: string) => [
 ]
 
 export function useSuggestedFollowsQuery() {
-  const {agent, currentAccount} = useSession()
+  const {currentAccount} = useSession()
   const moderationOpts = useModerationOpts()
 
   return useInfiniteQuery<
@@ -37,7 +37,7 @@ export function useSuggestedFollowsQuery() {
     staleTime: STALE.HOURS.ONE,
     queryKey: suggestedFollowsQueryKey,
     queryFn: async ({pageParam}) => {
-      const res = await agent.app.bsky.actor.getSuggestions({
+      const res = await getAgent().app.bsky.actor.getSuggestions({
         limit: 25,
         cursor: pageParam,
       })
@@ -73,12 +73,10 @@ export function useSuggestedFollowsQuery() {
 }
 
 export function useSuggestedFollowsByActorQuery({did}: {did: string}) {
-  const {agent} = useSession()
-
   return useQuery<AppBskyGraphGetSuggestedFollowsByActor.OutputSchema, Error>({
     queryKey: suggestedFollowsByActorQueryKey(did),
     queryFn: async () => {
-      const res = await agent.app.bsky.graph.getSuggestedFollowsByActor({
+      const res = await getAgent().app.bsky.graph.getSuggestedFollowsByActor({
         actor: did,
       })
       return res.data
@@ -87,7 +85,6 @@ export function useSuggestedFollowsByActorQuery({did}: {did: string}) {
 }
 
 export function useGetSuggestedFollowersByActor() {
-  const {agent} = useSession()
   const queryClient = useQueryClient()
 
   return React.useCallback(
@@ -96,15 +93,16 @@ export function useGetSuggestedFollowersByActor() {
         staleTime: 60 * 1000,
         queryKey: suggestedFollowsByActorQueryKey(actor),
         queryFn: async () => {
-          const res = await agent.app.bsky.graph.getSuggestedFollowsByActor({
-            actor: actor,
-          })
+          const res =
+            await getAgent().app.bsky.graph.getSuggestedFollowsByActor({
+              actor: actor,
+            })
           return res.data
         },
       })
 
       return res
     },
-    [agent, queryClient],
+    [queryClient],
   )
 }

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -56,7 +56,7 @@ import {
   useLanguagePrefsApi,
   toPostLanguages,
 } from '#/state/preferences/languages'
-import {useSession} from '#/state/session'
+import {useSession, getAgent} from '#/state/session'
 import {useProfileQuery} from '#/state/queries/profile'
 import {useComposerControls} from '#/state/shell/composer'
 
@@ -67,7 +67,7 @@ export const ComposePost = observer(function ComposePost({
   quote: initQuote,
   mention: initMention,
 }: Props) {
-  const {agent, currentAccount} = useSession()
+  const {currentAccount} = useSession()
   const {data: currentProfile} = useProfileQuery({did: currentAccount!.did})
   const {activeModals} = useModals()
   const {openModal, closeModal} = useModalControls()
@@ -209,7 +209,7 @@ export const ComposePost = observer(function ComposePost({
     setIsProcessing(true)
 
     try {
-      await apilib.post(agent, {
+      await apilib.post(getAgent(), {
         rawText: richtext.text,
         replyTo: replyTo?.uri,
         images: gallery.images,

--- a/src/view/com/composer/useExternalLinkFetch.ts
+++ b/src/view/com/composer/useExternalLinkFetch.ts
@@ -16,7 +16,7 @@ import {
 import {ComposerOpts} from 'state/shell/composer'
 import {POST_IMG_MAX} from 'lib/constants'
 import {logger} from '#/logger'
-import {useSession} from '#/state/session'
+import {getAgent} from '#/state/session'
 import {useGetPost} from '#/state/queries/post'
 
 export function useExternalLinkFetch({
@@ -24,7 +24,6 @@ export function useExternalLinkFetch({
 }: {
   setQuote: (opts: ComposerOpts['quote']) => void
 }) {
-  const {agent} = useSession()
   const [extLink, setExtLink] = useState<apilib.ExternalEmbedDraft | undefined>(
     undefined,
   )
@@ -56,7 +55,7 @@ export function useExternalLinkFetch({
           },
         )
       } else if (isBskyCustomFeedUrl(extLink.uri)) {
-        getFeedAsEmbed(agent, extLink.uri).then(
+        getFeedAsEmbed(getAgent(), extLink.uri).then(
           ({embed, meta}) => {
             if (aborted) {
               return
@@ -74,7 +73,7 @@ export function useExternalLinkFetch({
           },
         )
       } else if (isBskyListUrl(extLink.uri)) {
-        getListAsEmbed(agent, extLink.uri).then(
+        getListAsEmbed(getAgent(), extLink.uri).then(
           ({embed, meta}) => {
             if (aborted) {
               return
@@ -92,7 +91,7 @@ export function useExternalLinkFetch({
           },
         )
       } else {
-        getLinkMeta(agent, extLink.uri).then(meta => {
+        getLinkMeta(getAgent(), extLink.uri).then(meta => {
           if (aborted) {
             return
           }
@@ -134,7 +133,7 @@ export function useExternalLinkFetch({
       })
     }
     return cleanup
-  }, [agent, extLink, setQuote, getPost])
+  }, [extLink, setQuote, getPost])
 
   return {extLink, setExtLink}
 }

--- a/src/view/com/modals/ChangeEmail.tsx
+++ b/src/view/com/modals/ChangeEmail.tsx
@@ -13,7 +13,7 @@ import {cleanError} from 'lib/strings/errors'
 import {Trans, msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 import {useModalControls} from '#/state/modals'
-import {useSession, useSessionApi} from '#/state/session'
+import {useSession, useSessionApi, getAgent} from '#/state/session'
 
 enum Stages {
   InputEmail,
@@ -25,7 +25,7 @@ export const snapPoints = ['90%']
 
 export function Component() {
   const pal = usePalette('default')
-  const {agent, currentAccount} = useSession()
+  const {currentAccount} = useSession()
   const {updateCurrentAccount} = useSessionApi()
   const {_} = useLingui()
   const [stage, setStage] = useState<Stages>(Stages.InputEmail)
@@ -44,11 +44,11 @@ export function Component() {
     setError('')
     setIsProcessing(true)
     try {
-      const res = await agent.com.atproto.server.requestEmailUpdate()
+      const res = await getAgent().com.atproto.server.requestEmailUpdate()
       if (res.data.tokenRequired) {
         setStage(Stages.ConfirmCode)
       } else {
-        await agent.com.atproto.server.updateEmail({email: email.trim()})
+        await getAgent().com.atproto.server.updateEmail({email: email.trim()})
         updateCurrentAccount({
           email: email.trim(),
           emailConfirmed: false,
@@ -77,7 +77,7 @@ export function Component() {
     setError('')
     setIsProcessing(true)
     try {
-      await agent.com.atproto.server.updateEmail({
+      await getAgent().com.atproto.server.updateEmail({
         email: email.trim(),
         token: confirmationCode.trim(),
       })

--- a/src/view/com/modals/ChangeHandle.tsx
+++ b/src/view/com/modals/ChangeHandle.tsx
@@ -26,19 +26,24 @@ import {useLingui} from '@lingui/react'
 import {useModalControls} from '#/state/modals'
 import {useServiceQuery} from '#/state/queries/service'
 import {useUpdateHandleMutation, useFetchDid} from '#/state/queries/handle'
-import {useSession, useSessionApi, SessionAccount} from '#/state/session'
+import {
+  useSession,
+  useSessionApi,
+  SessionAccount,
+  getAgent,
+} from '#/state/session'
 
 export const snapPoints = ['100%']
 
 export type Props = {onChanged: () => void}
 
 export function Component(props: Props) {
-  const {agent, currentAccount} = useSession()
+  const {currentAccount} = useSession()
   const {
     isLoading,
     data: serviceInfo,
     error: serviceInfoError,
-  } = useServiceQuery(agent.service.toString())
+  } = useServiceQuery(getAgent().service.toString())
 
   return isLoading || !currentAccount ? (
     <View style={{padding: 18}}>

--- a/src/view/com/modals/DeleteAccount.tsx
+++ b/src/view/com/modals/DeleteAccount.tsx
@@ -19,14 +19,14 @@ import {resetToTab} from '../../../Navigation'
 import {Trans, msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 import {useModalControls} from '#/state/modals'
-import {useSession, useSessionApi} from '#/state/session'
+import {useSession, useSessionApi, getAgent} from '#/state/session'
 
 export const snapPoints = ['60%']
 
 export function Component({}: {}) {
   const pal = usePalette('default')
   const theme = useTheme()
-  const {agent, currentAccount} = useSession()
+  const {currentAccount} = useSession()
   const {clearCurrentAccount, removeAccount} = useSessionApi()
   const {_} = useLingui()
   const {closeModal} = useModalControls()
@@ -40,7 +40,7 @@ export function Component({}: {}) {
     setError('')
     setIsProcessing(true)
     try {
-      await agent.com.atproto.server.requestAccountDelete()
+      await getAgent().com.atproto.server.requestAccountDelete()
       setIsEmailSent(true)
     } catch (e: any) {
       setError(cleanError(e))
@@ -57,7 +57,7 @@ export function Component({}: {}) {
     const token = confirmCode.replace(/\s/g, '')
 
     try {
-      await agent.com.atproto.server.deleteAccount({
+      await getAgent().com.atproto.server.deleteAccount({
         did: currentAccount.did,
         password,
         token,

--- a/src/view/com/modals/VerifyEmail.tsx
+++ b/src/view/com/modals/VerifyEmail.tsx
@@ -21,7 +21,7 @@ import {cleanError} from 'lib/strings/errors'
 import {Trans, msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 import {useModalControls} from '#/state/modals'
-import {useSession, useSessionApi} from '#/state/session'
+import {useSession, useSessionApi, getAgent} from '#/state/session'
 
 export const snapPoints = ['90%']
 
@@ -33,7 +33,7 @@ enum Stages {
 
 export function Component({showReminder}: {showReminder?: boolean}) {
   const pal = usePalette('default')
-  const {agent, currentAccount} = useSession()
+  const {currentAccount} = useSession()
   const {updateCurrentAccount} = useSessionApi()
   const {_} = useLingui()
   const [stage, setStage] = useState<Stages>(
@@ -49,7 +49,7 @@ export function Component({showReminder}: {showReminder?: boolean}) {
     setError('')
     setIsProcessing(true)
     try {
-      await agent.com.atproto.server.requestEmailConfirmation()
+      await getAgent().com.atproto.server.requestEmailConfirmation()
       setStage(Stages.ConfirmCode)
     } catch (e) {
       setError(cleanError(String(e)))
@@ -62,7 +62,7 @@ export function Component({showReminder}: {showReminder?: boolean}) {
     setError('')
     setIsProcessing(true)
     try {
-      await agent.com.atproto.server.confirmEmail({
+      await getAgent().com.atproto.server.confirmEmail({
         email: (currentAccount?.email || '').trim(),
         token: confirmationCode.trim(),
       })

--- a/src/view/com/modals/report/Modal.tsx
+++ b/src/view/com/modals/report/Modal.tsx
@@ -16,7 +16,7 @@ import {CollectionId} from './types'
 import {Trans, msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 import {useModalControls} from '#/state/modals'
-import {useSession} from '#/state/session'
+import {getAgent} from '#/state/session'
 
 const DMCA_LINK = 'https://blueskyweb.xyz/support/copyright'
 
@@ -39,7 +39,6 @@ type ReportComponentProps =
     }
 
 export function Component(content: ReportComponentProps) {
-  const {agent} = useSession()
   const {closeModal} = useModalControls()
   const pal = usePalette('default')
   const {isMobile} = useWebMediaQueries()
@@ -70,7 +69,7 @@ export function Component(content: ReportComponentProps) {
       const $type = !isAccountReport
         ? 'com.atproto.repo.strongRef'
         : 'com.atproto.admin.defs#repoRef'
-      await agent.createModerationReport({
+      await getAgent().createModerationReport({
         reasonType: issue,
         subject: {
           $type,

--- a/src/view/screens/Settings.tsx
+++ b/src/view/screens/Settings.tsx
@@ -55,7 +55,12 @@ import {
   useRequireAltTextEnabled,
   useSetRequireAltTextEnabled,
 } from '#/state/preferences'
-import {useSession, useSessionApi, SessionAccount} from '#/state/session'
+import {
+  useSession,
+  useSessionApi,
+  SessionAccount,
+  getAgent,
+} from '#/state/session'
 import {useProfileQuery} from '#/state/queries/profile'
 import {useClearPreferencesMutation} from '#/state/queries/preferences'
 import {useInviteCodesQuery} from '#/state/queries/invites'
@@ -148,9 +153,11 @@ export const SettingsScreen = withAuthRequired(function Settings({}: Props) {
   const {isMobile} = useWebMediaQueries()
   const {screen, track} = useAnalytics()
   const {openModal} = useModalControls()
-  const {isSwitchingAccounts, accounts, currentAccount, agent} = useSession()
+  const {isSwitchingAccounts, accounts, currentAccount} = useSession()
   const {clearCurrentAccount} = useSessionApi()
-  const [debugHeaderEnabled, toggleDebugHeader] = useDebugHeaderSetting(agent)
+  const [debugHeaderEnabled, toggleDebugHeader] = useDebugHeaderSetting(
+    getAgent(),
+  )
   const {mutate: clearPreferences} = useClearPreferencesMutation()
   const {data: invites} = useInviteCodesQuery()
   const invitesAvailable = invites?.available?.length ?? 0


### PR DESCRIPTION
In a turn of events I can only describe as "fuckin weak" it looks like we made a bad assumption about how react-query handles data passed into the `queryFn` closure; specifically, it doesn't seem to redefine and rerun the query in the way you'd expect with react. This means that _any_ state passed in via a closure has some risk of being stale; I've not yet been able to establish what the rules are, but I have a theory that it may be stale for as long as the RQ hook is mounted.

This PR:

- Moves the current agent to a global, which appears to be [the predominant wisdom for dealing with this](https://twitter.com/TkDodo/status/1649470851429834753)
- Clears the query state on account change

This causes account/session changes to work as expected. Future PRs may need to:

- Add `getCurrentAccount()` to session for any time an RQ closure needs to access it (other cases continue to use `useSession`)
- Rework any other queries that depend on closures, or at least give them a look (especially the post and notif feed queries)