### PR TITLE
Freeze inactive screens

### DIFF
--- a/src/App.native.tsx
+++ b/src/App.native.tsx
@@ -6,6 +6,7 @@ import {RootSiblingParent} from 'react-native-root-siblings'
 import * as SplashScreen from 'expo-splash-screen'
 import {GestureHandlerRootView} from 'react-native-gesture-handler'
 import {QueryClientProvider} from '@tanstack/react-query'
+import {enableFreeze} from 'react-native-screens'
 
 import 'view/icons'
 
@@ -40,6 +41,7 @@ import {messages} from './locale/locales/en/messages'
 i18n.load('en', messages)
 i18n.activate('en')
 
+enableFreeze(true)
 SplashScreen.preventAutoHideAsync()
 
 function InnerApp() {

--- a/src/App.web.tsx
+++ b/src/App.web.tsx
@@ -4,6 +4,7 @@ import React, {useState, useEffect} from 'react'
 import {QueryClientProvider} from '@tanstack/react-query'
 import {SafeAreaProvider} from 'react-native-safe-area-context'
 import {RootSiblingParent} from 'react-native-root-siblings'
+import {enableFreeze} from 'react-native-screens'
 
 import 'view/icons'
 
@@ -31,6 +32,8 @@ import {
 } from 'state/session'
 import {Provider as UnreadNotifsProvider} from 'state/queries/notifications/unread'
 import * as persisted from '#/state/persisted'
+
+enableFreeze(true)
 
 function InnerApp() {
   const {isInitialLoad} = useSession()


### PR DESCRIPTION
This enables https://github.com/software-mansion/react-freeze. Not sure if anything will break but if we're doing big changes anyway why not give it a try.

Essentially, this "pauses" screens that are inactive. There's a [manual API for it](https://github.com/software-mansion/react-freeze#quick-start---using-freeze-directly-react-and-react-native-) but it also integrates into React Navigation automatically, which is the part this PR enables. (For the manual part, we need to play with integrating it into the pager.)

Only screens "more than one nav pop away" get frozen by default, so it mostly helps when you push deeper into the stack. Concretely, "freezing" means React will deprioritize updates to them and will process their state updates after they're unfrozen (i.e. when you pop the nav stack).

The solution itself is a bit hacky but it relies on a legit React feature. There'll eventually be a first-class API for it.

## Test Plan

Walk around the app. Seems to work.

Add a console log to `TimeElapsed` render and make the tick interval faster so it's easier to check. Navigate deeper into the stack (e.g. click into a post, then into a profile, then into a post).

Observe that before this PR, all timestamps (even in other tabs, or up the nav stack — at least on mobile) re-render on tick. After this PR, there are far fewer of them re-rendering on tick. However, they "wake up" as you pop the nav stack.