### PR TITLE
Do less work during rendering (part 1)

### DIFF
--- a/src/state/cache/post-shadow.ts
+++ b/src/state/cache/post-shadow.ts
@@ -1,4 +1,4 @@
-import {useEffect, useState, useCallback, useRef} from 'react'
+import {useEffect, useState, useMemo, useCallback, useRef} from 'react'
 import EventEmitter from 'eventemitter3'
 import {AppBskyFeedDefs} from '@atproto/api'
 import {Shadow} from './types'
@@ -55,9 +55,11 @@ export function usePostShadow(
     firstRun.current = false
   }, [post])
 
-  return state.ts > ifAfterTS
-    ? mergeShadow(post, state.value)
-    : {...post, isShadowed: true}
+  return useMemo(() => {
+    return state.ts > ifAfterTS
+      ? mergeShadow(post, state.value)
+      : {...post, isShadowed: true}
+  }, [post, state, ifAfterTS])
 }
 
 export function updatePostShadow(uri: string, value: Partial<PostShadow>) {

--- a/src/state/cache/profile-shadow.ts
+++ b/src/state/cache/profile-shadow.ts
@@ -1,4 +1,4 @@
-import {useEffect, useState, useCallback, useRef} from 'react'
+import {useEffect, useState, useMemo, useCallback, useRef} from 'react'
 import EventEmitter from 'eventemitter3'
 import {AppBskyActorDefs} from '@atproto/api'
 import {Shadow} from './types'
@@ -56,9 +56,11 @@ export function useProfileShadow(
     firstRun.current = false
   }, [profile])
 
-  return state.ts > ifAfterTS
-    ? mergeShadow(profile, state.value)
-    : {...profile, isShadowed: true}
+  return useMemo(() => {
+    return state.ts > ifAfterTS
+      ? mergeShadow(profile, state.value)
+      : {...profile, isShadowed: true}
+  }, [profile, state, ifAfterTS])
 }
 
 export function updateProfileShadow(

--- a/src/state/queries/preferences/index.ts
+++ b/src/state/queries/preferences/index.ts
@@ -1,11 +1,6 @@
-import {useEffect, useState} from 'react'
+import {useMemo} from 'react'
 import {useQuery, useMutation, useQueryClient} from '@tanstack/react-query'
-import {
-  LabelPreference,
-  BskyFeedViewPreference,
-  ModerationOpts,
-} from '@atproto/api'
-import isEqual from 'lodash.isequal'
+import {LabelPreference, BskyFeedViewPreference} from '@atproto/api'
 
 import {track} from '#/lib/analytics/analytics'
 import {getAge} from '#/lib/strings/time'
@@ -91,21 +86,16 @@ export function usePreferencesQuery() {
 
 export function useModerationOpts() {
   const {currentAccount} = useSession()
-  const [opts, setOpts] = useState<ModerationOpts | undefined>()
   const prefs = usePreferencesQuery()
-  useEffect(() => {
+  const opts = useMemo(() => {
     if (!prefs.data) {
       return
     }
-    // only update this hook when the moderation options change
-    const newOpts = getModerationOpts({
+    return getModerationOpts({
       userDid: currentAccount?.did || '',
       preferences: prefs.data,
     })
-    if (!isEqual(opts, newOpts)) {
-      setOpts(newOpts)
-    }
-  }, [prefs.data, currentAccount, opts, setOpts])
+  }, [currentAccount?.did, prefs.data])
   return opts
 }
 

--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -1,4 +1,4 @@
-import React, {useMemo} from 'react'
+import React, {memo, useMemo} from 'react'
 import {StyleSheet, View} from 'react-native'
 import {
   AtUri,
@@ -118,7 +118,7 @@ function PostThreadItemDeleted() {
   )
 }
 
-function PostThreadItemLoaded({
+let PostThreadItemLoaded = ({
   post,
   record,
   richText,
@@ -144,12 +144,12 @@ function PostThreadItemLoaded({
   showParentReplyLine?: boolean
   hasPrecedingItem: boolean
   onPostReply: () => void
-}) {
+}): React.ReactNode => {
   const pal = usePalette('default')
   const langPrefs = useLanguagePrefs()
   const {openComposer} = useComposerControls()
   const [limitLines, setLimitLines] = React.useState(
-    countLines(richText?.text) >= MAX_POST_LINES,
+    () => countLines(richText?.text) >= MAX_POST_LINES,
   )
   const styles = useStyles()
   const hasEngagement = post.likeCount || post.repostCount
@@ -565,6 +565,7 @@ function PostThreadItemLoaded({
     )
   }
 }
+PostThreadItemLoaded = memo(PostThreadItemLoaded)
 
 function PostOuterWrapper({
   post,

--- a/src/view/com/post/Post.tsx
+++ b/src/view/com/post/Post.tsx
@@ -99,7 +99,7 @@ function PostInner({
   const pal = usePalette('default')
   const {openComposer} = useComposerControls()
   const [limitLines, setLimitLines] = useState(
-    countLines(richText?.text) >= MAX_POST_LINES,
+    () => countLines(richText?.text) >= MAX_POST_LINES,
   )
   const itemUrip = new AtUri(post.uri)
   const itemHref = makeProfileLink(post.author, 'post', itemUrip.rkey)

--- a/src/view/com/posts/FeedItem.tsx
+++ b/src/view/com/posts/FeedItem.tsx
@@ -106,7 +106,7 @@ let FeedItemInner = ({
   const pal = usePalette('default')
   const {track} = useAnalytics()
   const [limitLines, setLimitLines] = useState(
-    countLines(richText.text) >= MAX_POST_LINES,
+    () => countLines(richText.text) >= MAX_POST_LINES,
   )
 
   const href = useMemo(() => {


### PR DESCRIPTION
Let's fix a bunch of regressions that crept in with the state refactor.

- We should [avoid `setState` in `useEffect`](https://react.dev/learn/you-might-not-need-an-effect#caching-expensive-calculations) like plague. To avoid recalculations, `useMemo`. 
- If we're calculating something just for the initial state, put `() =>` before it to [avoid running it again](https://react.dev/reference/react/useState#avoiding-recreating-the-initial-state).
- Don't recreate a bunch of objects that have the same content every time. Especially when they're being passed down later. Then add some memoization to take advantage of that.

## Before


https://github.com/bluesky-social/social-app/assets/810438/1df1513a-169c-410b-a388-2000067cbc4c

With 6x CPU throttling, scrolling a post thread stalls for two seconds:

<img width="743" alt="Screenshot 2023-11-17 at 17 23 00" src="https://github.com/bluesky-social/social-app/assets/810438/9d32fe06-8c71-4438-a3eb-4348a59b74bb">


## After


https://github.com/bluesky-social/social-app/assets/810438/57613d05-deb2-4f9b-b9de-89cf428b9104

With 6x CPU throttling, scrolling a post thread stalls for 60 milliseconds (~30x faster):

<img width="756" alt="Screenshot 2023-11-17 at 17 21 30" src="https://github.com/bluesky-social/social-app/assets/810438/e8c7f4f5-7031-4e9f-ad1d-4bc41ffa4fa4">

