### PR TITLE
Optimize notifications rendering

### DIFF
--- a/src/view/com/notifications/FeedItem.tsx
+++ b/src/view/com/notifications/FeedItem.tsx
@@ -1,4 +1,4 @@
-import React, {useMemo, useState, useEffect} from 'react'
+import React, {memo, useMemo, useState, useEffect} from 'react'
 import {
   Animated,
   TouchableOpacity,
@@ -56,7 +56,7 @@ interface Author {
   moderation: ProfileModeration
 }
 
-export function FeedItem({
+let FeedItem = ({
   item,
   dataUpdatedAt,
   moderationOpts,
@@ -64,7 +64,7 @@ export function FeedItem({
   item: FeedNotification
   dataUpdatedAt: number
   moderationOpts: ModerationOpts
-}) {
+}): React.ReactNode => {
   const pal = usePalette('default')
   const [isAuthorsExpanded, setAuthorsExpanded] = useState<boolean>(false)
   const itemHref = useMemo(() => {
@@ -262,6 +262,8 @@ export function FeedItem({
     </Link>
   )
 }
+FeedItem = memo(FeedItem)
+export {FeedItem}
 
 function ExpandListPressable({
   hasMultipleAuthors,


### PR DESCRIPTION
## Before

Scrolling notifications with 6x CPU throttling: 700ms stall.

<img width="1063" alt="Screenshot 2023-11-17 at 17 44 07" src="https://github.com/bluesky-social/social-app/assets/810438/707343ca-721f-43cf-b0e6-b1b874123b52">

## After

Scrolling notifications with 6x CPU throttling: 30ms stall.

<img width="1039" alt="Screenshot 2023-11-17 at 17 47 15" src="https://github.com/bluesky-social/social-app/assets/810438/d2db409b-71c6-49f1-a571-4b58491e9abe">
