### PR TITLE
Shadow refactoring and improvements

### DIFF
--- a/src/lib/batchedUpdates.ts
+++ b/src/lib/batchedUpdates.ts
@@ -1,0 +1,1 @@
+export {unstable_batchedUpdates as batchedUpdates} from 'react-native'

--- a/src/lib/batchedUpdates.web.ts
+++ b/src/lib/batchedUpdates.web.ts
@@ -1,0 +1,2 @@
+// @ts-ignore
+export {unstable_batchedUpdates as batchedUpdates} from 'react-dom'

--- a/src/state/cache/post-shadow.ts
+++ b/src/state/cache/post-shadow.ts
@@ -1,6 +1,7 @@
 import {useEffect, useState, useMemo, useCallback} from 'react'
 import EventEmitter from 'eventemitter3'
 import {AppBskyFeedDefs} from '@atproto/api'
+import {batchedUpdates} from '#/lib/batchedUpdates'
 import {Shadow, castAsShadow} from './types'
 export type {Shadow} from './types'
 
@@ -64,8 +65,11 @@ export function usePostShadow(
 }
 
 export function updatePostShadow(uri: string, value: Partial<PostShadow>) {
-  emitter.emit(uri, value)
+  batchedUpdates(() => {
+    emitter.emit(uri, value)
+  })
 }
+
 function fromPost(post: AppBskyFeedDefs.PostView): PostShadow {
   return {
     likeUri: post.viewer?.like,

--- a/src/state/cache/post-shadow.ts
+++ b/src/state/cache/post-shadow.ts
@@ -25,10 +25,10 @@ export function usePostShadow(
   post: AppBskyFeedDefs.PostView,
   ifAfterTS: number,
 ): Shadow<AppBskyFeedDefs.PostView> | typeof POST_TOMBSTONE {
-  const [state, setState] = useState<CacheEntry>({
+  const [state, setState] = useState<CacheEntry>(() => ({
     ts: Date.now(),
     value: fromPost(post),
-  })
+  }))
   const firstRun = useRef(true)
 
   const onUpdate = useCallback(

--- a/src/state/cache/post-shadow.ts
+++ b/src/state/cache/post-shadow.ts
@@ -1,7 +1,7 @@
 import {useEffect, useState, useMemo, useCallback, useRef} from 'react'
 import EventEmitter from 'eventemitter3'
 import {AppBskyFeedDefs} from '@atproto/api'
-import {Shadow} from './types'
+import {Shadow, castAsShadow} from './types'
 export type {Shadow} from './types'
 
 const emitter = new EventEmitter()
@@ -58,20 +58,13 @@ export function usePostShadow(
   return useMemo(() => {
     return state.ts > ifAfterTS
       ? mergeShadow(post, state.value)
-      : {...post, isShadowed: true}
+      : castAsShadow(post)
   }, [post, state, ifAfterTS])
 }
 
 export function updatePostShadow(uri: string, value: Partial<PostShadow>) {
   emitter.emit(uri, value)
 }
-
-export function isPostShadowed(
-  v: AppBskyFeedDefs.PostView | Shadow<AppBskyFeedDefs.PostView>,
-): v is Shadow<AppBskyFeedDefs.PostView> {
-  return 'isShadowed' in v && !!v.isShadowed
-}
-
 function fromPost(post: AppBskyFeedDefs.PostView): PostShadow {
   return {
     likeUri: post.viewer?.like,
@@ -89,7 +82,7 @@ function mergeShadow(
   if (shadow.isDeleted) {
     return POST_TOMBSTONE
   }
-  return {
+  return castAsShadow({
     ...post,
     likeCount: shadow.likeCount,
     repostCount: shadow.repostCount,
@@ -98,6 +91,5 @@ function mergeShadow(
       like: shadow.likeUri,
       repost: shadow.repostUri,
     },
-    isShadowed: true,
-  }
+  })
 }

--- a/src/state/cache/profile-shadow.ts
+++ b/src/state/cache/profile-shadow.ts
@@ -37,7 +37,7 @@ function getFirstSeenTS(profile: ProfileView): number {
 export function useProfileShadow(profile: ProfileView): Shadow<ProfileView> {
   const profileSeenTS = getFirstSeenTS(profile)
   const [state, setState] = useState<CacheEntry>(() => ({
-    ts: getFirstSeenTS(profile),
+    ts: profileSeenTS,
     value: fromProfile(profile),
   }))
 

--- a/src/state/cache/profile-shadow.ts
+++ b/src/state/cache/profile-shadow.ts
@@ -1,6 +1,7 @@
 import {useEffect, useState, useMemo, useCallback} from 'react'
 import EventEmitter from 'eventemitter3'
 import {AppBskyActorDefs} from '@atproto/api'
+import {batchedUpdates} from '#/lib/batchedUpdates'
 import {Shadow, castAsShadow} from './types'
 export type {Shadow} from './types'
 
@@ -68,7 +69,9 @@ export function updateProfileShadow(
   uri: string,
   value: Partial<ProfileShadow>,
 ) {
-  emitter.emit(uri, value)
+  batchedUpdates(() => {
+    emitter.emit(uri, value)
+  })
 }
 
 function fromProfile(profile: ProfileView): ProfileShadow {

--- a/src/state/cache/profile-shadow.ts
+++ b/src/state/cache/profile-shadow.ts
@@ -1,7 +1,7 @@
 import {useEffect, useState, useMemo, useCallback, useRef} from 'react'
 import EventEmitter from 'eventemitter3'
 import {AppBskyActorDefs} from '@atproto/api'
-import {Shadow} from './types'
+import {Shadow, castAsShadow} from './types'
 export type {Shadow} from './types'
 
 const emitter = new EventEmitter()
@@ -59,7 +59,7 @@ export function useProfileShadow(
   return useMemo(() => {
     return state.ts > ifAfterTS
       ? mergeShadow(profile, state.value)
-      : {...profile, isShadowed: true}
+      : castAsShadow(profile)
   }, [profile, state, ifAfterTS])
 }
 
@@ -68,12 +68,6 @@ export function updateProfileShadow(
   value: Partial<ProfileShadow>,
 ) {
   emitter.emit(uri, value)
-}
-
-export function isProfileShadowed<T extends ProfileView>(
-  v: T | Shadow<T>,
-): v is Shadow<T> {
-  return 'isShadowed' in v && !!v.isShadowed
 }
 
 function fromProfile(profile: ProfileView): ProfileShadow {
@@ -88,7 +82,7 @@ function mergeShadow(
   profile: ProfileView,
   shadow: ProfileShadow,
 ): Shadow<ProfileView> {
-  return {
+  return castAsShadow({
     ...profile,
     viewer: {
       ...(profile.viewer || {}),
@@ -96,6 +90,5 @@ function mergeShadow(
       muted: shadow.muted,
       blocking: shadow.blockingUri,
     },
-    isShadowed: true,
-  }
+  })
 }

--- a/src/state/cache/profile-shadow.ts
+++ b/src/state/cache/profile-shadow.ts
@@ -26,10 +26,10 @@ export function useProfileShadow(
   profile: ProfileView,
   ifAfterTS: number,
 ): Shadow<ProfileView> {
-  const [state, setState] = useState<CacheEntry>({
+  const [state, setState] = useState<CacheEntry>(() => ({
     ts: Date.now(),
     value: fromProfile(profile),
-  })
+  }))
   const firstRun = useRef(true)
 
   const onUpdate = useCallback(

--- a/src/state/cache/types.ts
+++ b/src/state/cache/types.ts
@@ -1,1 +1,7 @@
-export type Shadow<T> = T & {isShadowed: true}
+// This isn't a real property, but it prevents T being compatible with Shadow<T>.
+declare const shadowTag: unique symbol
+export type Shadow<T> = T & {[shadowTag]: true}
+
+export function castAsShadow<T>(value: T): Shadow<T> {
+  return value as any as Shadow<T>
+}

--- a/src/view/com/auth/onboarding/RecommendedFollows.tsx
+++ b/src/view/com/auth/onboarding/RecommendedFollows.tsx
@@ -24,7 +24,7 @@ export function RecommendedFollows({next}: Props) {
   const pal = usePalette('default')
   const {_} = useLingui()
   const {isTabletOrMobile} = useWebMediaQueries()
-  const {data: suggestedFollows, dataUpdatedAt} = useSuggestedFollowsQuery()
+  const {data: suggestedFollows} = useSuggestedFollowsQuery()
   const getSuggestedFollowsByActor = useGetSuggestedFollowersByActor()
   const [additionalSuggestions, setAdditionalSuggestions] = React.useState<{
     [did: string]: AppBskyActorDefs.ProfileView[]
@@ -162,7 +162,6 @@ export function RecommendedFollows({next}: Props) {
               renderItem={({item}) => (
                 <RecommendedFollowsItem
                   profile={item}
-                  dataUpdatedAt={dataUpdatedAt}
                   onFollowStateChange={onFollowStateChange}
                   moderation={moderateProfile(item, moderationOpts)}
                 />
@@ -197,7 +196,6 @@ export function RecommendedFollows({next}: Props) {
               renderItem={({item}) => (
                 <RecommendedFollowsItem
                   profile={item}
-                  dataUpdatedAt={dataUpdatedAt}
                   onFollowStateChange={onFollowStateChange}
                   moderation={moderateProfile(item, moderationOpts)}
                 />

--- a/src/view/com/auth/onboarding/RecommendedFollowsItem.tsx
+++ b/src/view/com/auth/onboarding/RecommendedFollowsItem.tsx
@@ -18,7 +18,6 @@ import {logger} from '#/logger'
 
 type Props = {
   profile: AppBskyActorDefs.ProfileViewBasic
-  dataUpdatedAt: number
   moderation: ProfileModeration
   onFollowStateChange: (props: {
     did: string
@@ -28,13 +27,12 @@ type Props = {
 
 export function RecommendedFollowsItem({
   profile,
-  dataUpdatedAt,
   moderation,
   onFollowStateChange,
 }: React.PropsWithChildren<Props>) {
   const pal = usePalette('default')
   const {isMobile} = useWebMediaQueries()
-  const shadowedProfile = useProfileShadow(profile, dataUpdatedAt)
+  const shadowedProfile = useProfileShadow(profile)
 
   return (
     <Animated.View

--- a/src/view/com/lists/ListMembers.tsx
+++ b/src/view/com/lists/ListMembers.tsx
@@ -64,7 +64,6 @@ export function ListMembers({
 
   const {
     data,
-    dataUpdatedAt,
     isFetching,
     isFetched,
     isError,
@@ -185,7 +184,6 @@ export function ListMembers({
             (item as AppBskyGraphDefs.ListItemView).subject.handle
           }`}
           profile={(item as AppBskyGraphDefs.ListItemView).subject}
-          dataUpdatedAt={dataUpdatedAt}
           renderButton={renderMemberButton}
           style={{paddingHorizontal: isMobile ? 8 : 14, paddingVertical: 4}}
         />
@@ -198,7 +196,6 @@ export function ListMembers({
       onPressTryAgain,
       onPressRetryLoadMore,
       isMobile,
-      dataUpdatedAt,
     ],
   )
 

--- a/src/view/com/modals/ProfilePreview.tsx
+++ b/src/view/com/modals/ProfilePreview.tsx
@@ -22,7 +22,6 @@ export function Component({did}: {did: string}) {
   const moderationOpts = useModerationOpts()
   const {
     data: profile,
-    dataUpdatedAt,
     error: profileError,
     refetch: refetchProfile,
     isFetching: isFetchingProfile,
@@ -51,13 +50,7 @@ export function Component({did}: {did: string}) {
     )
   }
   if (profile && moderationOpts) {
-    return (
-      <ComponentLoaded
-        profile={profile}
-        dataUpdatedAt={dataUpdatedAt}
-        moderationOpts={moderationOpts}
-      />
-    )
+    return <ComponentLoaded profile={profile} moderationOpts={moderationOpts} />
   }
   // should never happen
   return (
@@ -71,15 +64,13 @@ export function Component({did}: {did: string}) {
 
 function ComponentLoaded({
   profile: profileUnshadowed,
-  dataUpdatedAt,
   moderationOpts,
 }: {
   profile: AppBskyActorDefs.ProfileViewDetailed
-  dataUpdatedAt: number
   moderationOpts: ModerationOpts
 }) {
   const pal = usePalette('default')
-  const profile = useProfileShadow(profileUnshadowed, dataUpdatedAt)
+  const profile = useProfileShadow(profileUnshadowed)
   const {screen} = useAnalytics()
   const moderation = React.useMemo(
     () => moderateProfile(profile, moderationOpts),

--- a/src/view/com/notifications/Feed.tsx
+++ b/src/view/com/notifications/Feed.tsx
@@ -38,7 +38,6 @@ export function Feed({
   const {markAllRead} = useUnreadNotificationsApi()
   const {
     data,
-    dataUpdatedAt,
     isLoading,
     isFetching,
     isFetched,
@@ -132,15 +131,9 @@ export function Feed({
       } else if (item === LOADING_ITEM) {
         return <NotificationFeedLoadingPlaceholder />
       }
-      return (
-        <FeedItem
-          item={item}
-          dataUpdatedAt={dataUpdatedAt}
-          moderationOpts={moderationOpts!}
-        />
-      )
+      return <FeedItem item={item} moderationOpts={moderationOpts!} />
     },
-    [onPressRetryLoadMore, dataUpdatedAt, moderationOpts],
+    [onPressRetryLoadMore, moderationOpts],
   )
 
   const showHeaderSpinner = !isPTRing && isFetching && !isLoading

--- a/src/view/com/notifications/FeedItem.tsx
+++ b/src/view/com/notifications/FeedItem.tsx
@@ -58,11 +58,9 @@ interface Author {
 
 let FeedItem = ({
   item,
-  dataUpdatedAt,
   moderationOpts,
 }: {
   item: FeedNotification
-  dataUpdatedAt: number
   moderationOpts: ModerationOpts
 }): React.ReactNode => {
   const pal = usePalette('default')
@@ -135,7 +133,6 @@ let FeedItem = ({
         accessible={false}>
         <Post
           post={item.subject}
-          dataUpdatedAt={dataUpdatedAt}
           style={
             item.notification.isRead
               ? undefined

--- a/src/view/com/post-thread/PostLikedBy.tsx
+++ b/src/view/com/post-thread/PostLikedBy.tsx
@@ -20,7 +20,6 @@ export function PostLikedBy({uri}: {uri: string}) {
   } = useResolveUriQuery(uri)
   const {
     data,
-    dataUpdatedAt,
     isFetching,
     isFetched,
     isFetchingNextPage,
@@ -55,18 +54,11 @@ export function PostLikedBy({uri}: {uri: string}) {
     }
   }, [isFetching, hasNextPage, isError, fetchNextPage])
 
-  const renderItem = useCallback(
-    ({item}: {item: GetLikes.Like}) => {
-      return (
-        <ProfileCardWithFollowBtn
-          key={item.actor.did}
-          profile={item.actor}
-          dataUpdatedAt={dataUpdatedAt}
-        />
-      )
-    },
-    [dataUpdatedAt],
-  )
+  const renderItem = useCallback(({item}: {item: GetLikes.Like}) => {
+    return (
+      <ProfileCardWithFollowBtn key={item.actor.did} profile={item.actor} />
+    )
+  }, [])
 
   if (isFetchingResolvedUri || !isFetched) {
     return (

--- a/src/view/com/post-thread/PostRepostedBy.tsx
+++ b/src/view/com/post-thread/PostRepostedBy.tsx
@@ -20,7 +20,6 @@ export function PostRepostedBy({uri}: {uri: string}) {
   } = useResolveUriQuery(uri)
   const {
     data,
-    dataUpdatedAt,
     isFetching,
     isFetched,
     isFetchingNextPage,
@@ -57,15 +56,9 @@ export function PostRepostedBy({uri}: {uri: string}) {
 
   const renderItem = useCallback(
     ({item}: {item: ActorDefs.ProfileViewBasic}) => {
-      return (
-        <ProfileCardWithFollowBtn
-          key={item.did}
-          profile={item}
-          dataUpdatedAt={dataUpdatedAt}
-        />
-      )
+      return <ProfileCardWithFollowBtn key={item.did} profile={item} />
     },
-    [dataUpdatedAt],
+    [],
   )
 
   if (isFetchingResolvedUri || !isFetched) {

--- a/src/view/com/post-thread/PostThread.tsx
+++ b/src/view/com/post-thread/PostThread.tsx
@@ -73,7 +73,6 @@ export function PostThread({
     refetch,
     isRefetching,
     data: thread,
-    dataUpdatedAt,
   } = usePostThreadQuery(uri)
   const {data: preferences} = usePreferencesQuery()
   const rootPost = thread?.type === 'post' ? thread.post : undefined
@@ -111,7 +110,6 @@ export function PostThread({
     <PostThreadLoaded
       thread={thread}
       isRefetching={isRefetching}
-      dataUpdatedAt={dataUpdatedAt}
       threadViewPrefs={preferences.threadViewPrefs}
       onRefresh={refetch}
       onPressReply={onPressReply}
@@ -122,14 +120,12 @@ export function PostThread({
 function PostThreadLoaded({
   thread,
   isRefetching,
-  dataUpdatedAt,
   threadViewPrefs,
   onRefresh,
   onPressReply,
 }: {
   thread: ThreadNode
   isRefetching: boolean
-  dataUpdatedAt: number
   threadViewPrefs: UsePreferencesQueryResponse['threadViewPrefs']
   onRefresh: () => void
   onPressReply: () => void
@@ -295,7 +291,6 @@ function PostThreadLoaded({
           <PostThreadItem
             post={item.post}
             record={item.record}
-            dataUpdatedAt={dataUpdatedAt}
             treeView={threadViewPrefs.lab_treeViewEnabled || false}
             depth={item.ctx.depth}
             isHighlightedPost={item.ctx.isHighlightedPost}
@@ -322,7 +317,6 @@ function PostThreadLoaded({
       posts,
       onRefresh,
       threadViewPrefs.lab_treeViewEnabled,
-      dataUpdatedAt,
       _,
     ],
   )

--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -45,7 +45,6 @@ import {Shadow, usePostShadow, POST_TOMBSTONE} from '#/state/cache/post-shadow'
 export function PostThreadItem({
   post,
   record,
-  dataUpdatedAt,
   treeView,
   depth,
   isHighlightedPost,
@@ -57,7 +56,6 @@ export function PostThreadItem({
 }: {
   post: AppBskyFeedDefs.PostView
   record: AppBskyFeedPost.Record
-  dataUpdatedAt: number
   treeView: boolean
   depth: number
   isHighlightedPost?: boolean
@@ -68,7 +66,7 @@ export function PostThreadItem({
   onPostReply: () => void
 }) {
   const moderationOpts = useModerationOpts()
-  const postShadowed = usePostShadow(post, dataUpdatedAt)
+  const postShadowed = usePostShadow(post)
   const richText = useMemo(
     () =>
       new RichTextAPI({

--- a/src/view/com/post/Post.tsx
+++ b/src/view/com/post/Post.tsx
@@ -30,12 +30,10 @@ import {Shadow, usePostShadow, POST_TOMBSTONE} from '#/state/cache/post-shadow'
 
 export function Post({
   post,
-  dataUpdatedAt,
   showReplyLine,
   style,
 }: {
   post: AppBskyFeedDefs.PostView
-  dataUpdatedAt: number
   showReplyLine?: boolean
   style?: StyleProp<ViewStyle>
 }) {
@@ -48,7 +46,7 @@ export function Post({
         : undefined,
     [post],
   )
-  const postShadowed = usePostShadow(post, dataUpdatedAt)
+  const postShadowed = usePostShadow(post)
   const richText = useMemo(
     () =>
       record

--- a/src/view/com/posts/Feed.tsx
+++ b/src/view/com/posts/Feed.tsx
@@ -76,7 +76,6 @@ let Feed = ({
   const opts = React.useMemo(() => ({enabled}), [enabled])
   const {
     data,
-    dataUpdatedAt,
     isFetching,
     isFetched,
     isError,
@@ -200,7 +199,6 @@ let Feed = ({
       return (
         <FeedSlice
           slice={item}
-          dataUpdatedAt={dataUpdatedAt}
           // we check for this before creating the feedItems array
           moderationOpts={moderationOpts!}
         />
@@ -208,7 +206,6 @@ let Feed = ({
     },
     [
       feed,
-      dataUpdatedAt,
       error,
       onPressTryAgain,
       onPressRetryLoadMore,

--- a/src/view/com/posts/FeedItem.tsx
+++ b/src/view/com/posts/FeedItem.tsx
@@ -40,7 +40,6 @@ export function FeedItem({
   record,
   reason,
   moderation,
-  dataUpdatedAt,
   isThreadChild,
   isThreadLastChild,
   isThreadParent,
@@ -49,12 +48,11 @@ export function FeedItem({
   record: AppBskyFeedPost.Record
   reason: AppBskyFeedDefs.ReasonRepost | ReasonFeedSource | undefined
   moderation: PostModeration
-  dataUpdatedAt: number
   isThreadChild?: boolean
   isThreadLastChild?: boolean
   isThreadParent?: boolean
 }) {
-  const postShadowed = usePostShadow(post, dataUpdatedAt)
+  const postShadowed = usePostShadow(post)
   const richText = useMemo(
     () =>
       new RichTextAPI({

--- a/src/view/com/posts/FeedSlice.tsx
+++ b/src/view/com/posts/FeedSlice.tsx
@@ -11,12 +11,10 @@ import {makeProfileLink} from 'lib/routes/links'
 
 let FeedSlice = ({
   slice,
-  dataUpdatedAt,
   ignoreFilterFor,
   moderationOpts,
 }: {
   slice: FeedPostSlice
-  dataUpdatedAt: number
   ignoreFilterFor?: string
   moderationOpts: ModerationOpts
 }): React.ReactNode => {
@@ -44,7 +42,6 @@ let FeedSlice = ({
           record={slice.items[0].record}
           reason={slice.items[0].reason}
           moderation={moderations[0]}
-          dataUpdatedAt={dataUpdatedAt}
           isThreadParent={isThreadParentAt(slice.items, 0)}
           isThreadChild={isThreadChildAt(slice.items, 0)}
         />
@@ -54,7 +51,6 @@ let FeedSlice = ({
           record={slice.items[1].record}
           reason={slice.items[1].reason}
           moderation={moderations[1]}
-          dataUpdatedAt={dataUpdatedAt}
           isThreadParent={isThreadParentAt(slice.items, 1)}
           isThreadChild={isThreadChildAt(slice.items, 1)}
         />
@@ -65,7 +61,6 @@ let FeedSlice = ({
           record={slice.items[last].record}
           reason={slice.items[last].reason}
           moderation={moderations[last]}
-          dataUpdatedAt={dataUpdatedAt}
           isThreadParent={isThreadParentAt(slice.items, last)}
           isThreadChild={isThreadChildAt(slice.items, last)}
           isThreadLastChild
@@ -83,7 +78,6 @@ let FeedSlice = ({
           record={slice.items[i].record}
           reason={slice.items[i].reason}
           moderation={moderations[i]}
-          dataUpdatedAt={dataUpdatedAt}
           isThreadParent={isThreadParentAt(slice.items, i)}
           isThreadChild={isThreadChildAt(slice.items, i)}
           isThreadLastChild={

--- a/src/view/com/profile/ProfileCard.tsx
+++ b/src/view/com/profile/ProfileCard.tsx
@@ -27,7 +27,6 @@ import {useSession} from '#/state/session'
 export function ProfileCard({
   testID,
   profile: profileUnshadowed,
-  dataUpdatedAt,
   noBg,
   noBorder,
   followers,
@@ -36,7 +35,6 @@ export function ProfileCard({
 }: {
   testID?: string
   profile: AppBskyActorDefs.ProfileViewBasic
-  dataUpdatedAt: number
   noBg?: boolean
   noBorder?: boolean
   followers?: AppBskyActorDefs.ProfileView[] | undefined
@@ -46,7 +44,7 @@ export function ProfileCard({
   style?: StyleProp<ViewStyle>
 }) {
   const pal = usePalette('default')
-  const profile = useProfileShadow(profileUnshadowed, dataUpdatedAt)
+  const profile = useProfileShadow(profileUnshadowed)
   const moderationOpts = useModerationOpts()
   if (!moderationOpts) {
     return null
@@ -202,13 +200,11 @@ export function ProfileCardWithFollowBtn({
   noBg,
   noBorder,
   followers,
-  dataUpdatedAt,
 }: {
   profile: AppBskyActorDefs.ProfileViewBasic
   noBg?: boolean
   noBorder?: boolean
   followers?: AppBskyActorDefs.ProfileView[] | undefined
-  dataUpdatedAt: number
 }) {
   const {currentAccount} = useSession()
   const isMe = profile.did === currentAccount?.did
@@ -224,7 +220,6 @@ export function ProfileCardWithFollowBtn({
           ? undefined
           : profileShadow => <FollowButton profile={profileShadow} />
       }
-      dataUpdatedAt={dataUpdatedAt}
     />
   )
 }

--- a/src/view/com/profile/ProfileFollowers.tsx
+++ b/src/view/com/profile/ProfileFollowers.tsx
@@ -20,7 +20,6 @@ export function ProfileFollowers({name}: {name: string}) {
   } = useResolveDidQuery(name)
   const {
     data,
-    dataUpdatedAt,
     isFetching,
     isFetched,
     isFetchingNextPage,
@@ -58,13 +57,9 @@ export function ProfileFollowers({name}: {name: string}) {
 
   const renderItem = React.useCallback(
     ({item}: {item: ActorDefs.ProfileViewBasic}) => (
-      <ProfileCardWithFollowBtn
-        key={item.did}
-        profile={item}
-        dataUpdatedAt={dataUpdatedAt}
-      />
+      <ProfileCardWithFollowBtn key={item.did} profile={item} />
     ),
-    [dataUpdatedAt],
+    [],
   )
 
   if (isFetchingDid || !isFetched) {

--- a/src/view/com/profile/ProfileFollows.tsx
+++ b/src/view/com/profile/ProfileFollows.tsx
@@ -20,7 +20,6 @@ export function ProfileFollows({name}: {name: string}) {
   } = useResolveDidQuery(name)
   const {
     data,
-    dataUpdatedAt,
     isFetching,
     isFetched,
     isFetchingNextPage,
@@ -58,13 +57,9 @@ export function ProfileFollows({name}: {name: string}) {
 
   const renderItem = React.useCallback(
     ({item}: {item: ActorDefs.ProfileViewBasic}) => (
-      <ProfileCardWithFollowBtn
-        key={item.did}
-        profile={item}
-        dataUpdatedAt={dataUpdatedAt}
-      />
+      <ProfileCardWithFollowBtn key={item.did} profile={item} />
     ),
-    [dataUpdatedAt],
+    [],
   )
 
   if (isFetchingDid || !isFetched) {

--- a/src/view/com/profile/ProfileHeaderSuggestedFollows.tsx
+++ b/src/view/com/profile/ProfileHeaderSuggestedFollows.tsx
@@ -65,7 +65,7 @@ export function ProfileHeaderSuggestedFollows({
     }
   }, [active, animatedHeight, track])
 
-  const {isLoading, data, dataUpdatedAt} = useSuggestedFollowsByActorQuery({
+  const {isLoading, data} = useSuggestedFollowsByActorQuery({
     did: actorDid,
   })
 
@@ -127,11 +127,7 @@ export function ProfileHeaderSuggestedFollows({
               </>
             ) : data ? (
               data.suggestions.map(profile => (
-                <SuggestedFollow
-                  key={profile.did}
-                  profile={profile}
-                  dataUpdatedAt={dataUpdatedAt}
-                />
+                <SuggestedFollow key={profile.did} profile={profile} />
               ))
             ) : (
               <View />
@@ -196,15 +192,13 @@ function SuggestedFollowSkeleton() {
 
 function SuggestedFollow({
   profile: profileUnshadowed,
-  dataUpdatedAt,
 }: {
   profile: AppBskyActorDefs.ProfileView
-  dataUpdatedAt: number
 }) {
   const {track} = useAnalytics()
   const pal = usePalette('default')
   const moderationOpts = useModerationOpts()
-  const profile = useProfileShadow(profileUnshadowed, dataUpdatedAt)
+  const profile = useProfileShadow(profileUnshadowed)
   const [queueFollow, queueUnfollow] = useProfileFollowMutationQueue(profile)
 
   const onPressFollow = React.useCallback(async () => {

--- a/src/view/screens/ModerationBlockedAccounts.tsx
+++ b/src/view/screens/ModerationBlockedAccounts.tsx
@@ -40,7 +40,6 @@ export const ModerationBlockedAccounts = withAuthRequired(
     const [isPTRing, setIsPTRing] = React.useState(false)
     const {
       data,
-      dataUpdatedAt,
       isFetching,
       isError,
       error,
@@ -95,7 +94,6 @@ export const ModerationBlockedAccounts = withAuthRequired(
         testID={`blockedAccount-${index}`}
         key={item.did}
         profile={item}
-        dataUpdatedAt={dataUpdatedAt}
       />
     )
     return (

--- a/src/view/screens/ModerationMutedAccounts.tsx
+++ b/src/view/screens/ModerationMutedAccounts.tsx
@@ -40,7 +40,6 @@ export const ModerationMutedAccounts = withAuthRequired(
     const [isPTRing, setIsPTRing] = React.useState(false)
     const {
       data,
-      dataUpdatedAt,
       isFetching,
       isError,
       error,
@@ -95,7 +94,6 @@ export const ModerationMutedAccounts = withAuthRequired(
         testID={`mutedAccount-${index}`}
         key={item.did}
         profile={item}
-        dataUpdatedAt={dataUpdatedAt}
       />
     )
     return (

--- a/src/view/screens/Profile.tsx
+++ b/src/view/screens/Profile.tsx
@@ -58,7 +58,6 @@ export const ProfileScreen = withAuthRequired(function ProfileScreenImpl({
   } = useResolveDidQuery(name)
   const {
     data: profile,
-    dataUpdatedAt,
     error: profileError,
     refetch: refetchProfile,
     isFetching: isFetchingProfile,
@@ -101,7 +100,6 @@ export const ProfileScreen = withAuthRequired(function ProfileScreenImpl({
     return (
       <ProfileScreenLoaded
         profile={profile}
-        dataUpdatedAt={dataUpdatedAt}
         moderationOpts={moderationOpts}
         hideBackButton={!!route.params.hideBackButton}
       />
@@ -122,16 +120,14 @@ export const ProfileScreen = withAuthRequired(function ProfileScreenImpl({
 
 function ProfileScreenLoaded({
   profile: profileUnshadowed,
-  dataUpdatedAt,
   moderationOpts,
   hideBackButton,
 }: {
   profile: AppBskyActorDefs.ProfileViewDetailed
-  dataUpdatedAt: number
   moderationOpts: ModerationOpts
   hideBackButton: boolean
 }) {
-  const profile = useProfileShadow(profileUnshadowed, dataUpdatedAt)
+  const profile = useProfileShadow(profileUnshadowed)
   const {currentAccount} = useSession()
   const setMinimalShellMode = useSetMinimalShellMode()
   const {openComposer} = useComposerControls()

--- a/src/view/screens/Search/Search.tsx
+++ b/src/view/screens/Search/Search.tsx
@@ -111,7 +111,6 @@ function EmptyState({message, error}: {message: string; error?: string}) {
 function SearchScreenSuggestedFollows() {
   const pal = usePalette('default')
   const {currentAccount} = useSession()
-  const [dataUpdatedAt, setDataUpdatedAt] = React.useState(0)
   const [suggestions, setSuggestions] = React.useState<
     AppBskyActorDefs.ProfileViewBasic[]
   >([])
@@ -141,7 +140,6 @@ function SearchScreenSuggestedFollows() {
       )
 
       setSuggestions(Array.from(friendsOfFriends.values()))
-      setDataUpdatedAt(Date.now())
     }
 
     try {
@@ -151,23 +149,12 @@ function SearchScreenSuggestedFollows() {
         error: e,
       })
     }
-  }, [
-    currentAccount,
-    setSuggestions,
-    setDataUpdatedAt,
-    getSuggestedFollowsByActor,
-  ])
+  }, [currentAccount, setSuggestions, getSuggestedFollowsByActor])
 
   return suggestions.length ? (
     <FlatList
       data={suggestions}
-      renderItem={({item}) => (
-        <ProfileCardWithFollowBtn
-          profile={item}
-          noBg
-          dataUpdatedAt={dataUpdatedAt}
-        />
-      )}
+      renderItem={({item}) => <ProfileCardWithFollowBtn profile={item} noBg />}
       keyExtractor={item => item.did}
       // @ts-ignore web only -prf
       desktopFixedHeight
@@ -205,7 +192,6 @@ function SearchScreenPostResults({query}: {query: string}) {
     fetchNextPage,
     isFetchingNextPage,
     hasNextPage,
-    dataUpdatedAt,
   } = useSearchPostsQuery({query})
 
   const onPullToRefresh = React.useCallback(async () => {
@@ -258,7 +244,7 @@ function SearchScreenPostResults({query}: {query: string}) {
               data={items}
               renderItem={({item}) => {
                 if (item.type === 'post') {
-                  return <Post post={item.post} dataUpdatedAt={dataUpdatedAt} />
+                  return <Post post={item.post} />
                 } else {
                   return <Loader />
                 }
@@ -291,7 +277,6 @@ function SearchScreenPostResults({query}: {query: string}) {
 function SearchScreenUserResults({query}: {query: string}) {
   const {_} = useLingui()
   const [isFetched, setIsFetched] = React.useState(false)
-  const [dataUpdatedAt, setDataUpdatedAt] = React.useState(0)
   const [results, setResults] = React.useState<
     AppBskyActorDefs.ProfileViewBasic[]
   >([])
@@ -302,7 +287,6 @@ function SearchScreenUserResults({query}: {query: string}) {
       const searchResults = await search({query, limit: 30})
 
       if (searchResults) {
-        setDataUpdatedAt(Date.now())
         setResults(results)
         setIsFetched(true)
       }
@@ -314,7 +298,7 @@ function SearchScreenUserResults({query}: {query: string}) {
       setResults([])
       setIsFetched(false)
     }
-  }, [query, setDataUpdatedAt, search, results])
+  }, [query, search, results])
 
   return isFetched ? (
     <>
@@ -322,11 +306,7 @@ function SearchScreenUserResults({query}: {query: string}) {
         <FlatList
           data={results}
           renderItem={({item}) => (
-            <ProfileCardWithFollowBtn
-              profile={item}
-              noBg
-              dataUpdatedAt={dataUpdatedAt}
-            />
+            <ProfileCardWithFollowBtn profile={item} noBg />
           )}
           keyExtractor={item => item.did}
           // @ts-ignore web only -prf


### PR DESCRIPTION
## Part 1

Small refactor to how shadows work. This isn't supposed to *significantly* change anything but might improve perf a bit.

- fa334350fb04d3ede175829cb9a2723155826bc6: This removes the `isShadowed` field from the runtime. This lets us avoid doing an extra object copy for each post (even before it gets shadowed). Theoretically this also might help with monomorphism (avoiding all the methods below from dealing with differently-shaped objects) though in practice probably not. To enforce that you can't can't make a shadow out of thin air, I used [this trick](https://evertpot.com/opaque-ts-types/).
- 0128feefd4012f16984f231235fb74a1d66a95d9: Just preventing creating a few unnecessary objects on every render.
- 67cf7a5824ae8fcdd7274a8949fe836da4d0a9ed: This applies [this technique](https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes) to adjust state during render instead of in an effect. That allows us to do this without waiting for a whole tree to complete first, i.e. avoids a cascading change. Should be faster.
- f10ed66d5f3983d73b6e43e6003d521f5c152e1e: Process updates to multiple components (if there are multiple) in a batch. The API says `unstable_` but it's actually very stable and will even be the default behavior in the future anyway.

## Part 2

I pushed to the same PR but these are more serious changes.

- cbf813f20810fc6b337af4c57d597b878d3f53e7: Introduces a WeakMap where we track the first time we see a post/profile. This assumes the object travels down unchanged from RQ. The "first seen" timestamp for a given object will never change. The idea is simple: if a mutation was done _after_ we've first seen _that particular_ object, we apply the shadow. Otherwise we don't. This lets us...
- 90af3df2afa461920c4b2af760eed2a0fe790545: Rip out the passing of `dataUpdatedAt` all the way down. This was causing unnecessary re-renders for all the previous pages when the next page is fetched. It also wasn't correct anyway because fetching a new page doesn't make the *previous* pages any less stale.

## Test Plan

### Correctness

Liked my own post in one tab, checked it's liked in another tab. Unliked it in the browser (a different device) and verified that PTR in the app also reset it to unliked despite what the shadow said. 

### Performance

#### Before

Feed item re-render batches are getting larger on scroll:

https://github.com/bluesky-social/social-app/assets/810438/47d75509-3654-4df8-a270-93bb189f98cc

Same for notifications:

https://github.com/bluesky-social/social-app/assets/810438/3996b2d5-146b-43f3-9123-da9ce6c4b15e


#### After

Feed item render batches are bounded to the new pages:

https://github.com/bluesky-social/social-app/assets/810438/5534e0ff-0aee-4c15-b627-94c6ea0850de

Same for notifications:

https://github.com/bluesky-social/social-app/assets/810438/597f8308-8339-43c5-8946-d98b8a7346e0

