### PR TITLE
Fix image is cropped in alt text modal

### DIFF
--- a/src/view/com/modals/AltImage.tsx
+++ b/src/view/com/modals/AltImage.tsx
@@ -80,6 +80,7 @@ export function Component({image}: Props) {
               source={{
                 uri: image.cropped?.path ?? image.path,
               }}
+              contentFit="contain"
               accessible={true}
               accessibilityIgnoresInvertColors
             />


### PR DESCRIPTION
This fixes that the preview image in the alt text modal is cropped if it doesn’t fit the outer box. That makes writing an alt text, especially if it is text-only (such as in the example below), a lot easier.

The fix is done by changing the `contentFit` on the preview image [from the default](https://docs.expo.dev/versions/latest/sdk/image/#contentfit) (`cover`) to `contain`.

## Screenshots

| Device | Before | After |
| --- | --- | --- |
| Mobile | ![image](https://github.com/bluesky-social/social-app/assets/28510368/a6c4269a-a5ee-4ba9-a026-568f7e8c8ac4) | ![image](https://github.com/bluesky-social/social-app/assets/28510368/3f9eb155-f989-41cc-88bf-9c6c81c9652a) |
| Desktop | ![image](https://github.com/bluesky-social/social-app/assets/28510368/4116c7d2-f8b1-44b3-a508-00597c24438f) | ![image](https://github.com/bluesky-social/social-app/assets/28510368/77b9621a-e836-4fb1-87f1-8ddc94cdb41f) |

## How to test?

1. Go to the Home page
2. Click on the **New Post** button
3. Add an image to the post composer (such as [the image used as example above](https://cdn.bsky.app/img/feed_fullsize/plain/did:plc:vqtakzi5bityrtbjj4cfan4l/bafkreigo4x5qtvvrb4pc3fo5x34qqlbchtg7fjzb7snybdd4ew6l4eext4@jpeg)) that would be cut off in the alt text modal
4. Click on the **ALT** icon
5. See that the image is now fully visible