### PR TITLE
Fix scuffed web styles caused by overlapping viewport breakpoint boundaries

### DIFF
--- a/src/lib/hooks/useWebMediaQueries.tsx
+++ b/src/lib/hooks/useWebMediaQueries.tsx
@@ -3,7 +3,7 @@ import {isNative} from 'platform/detection'
 
 export function useWebMediaQueries() {
   const isDesktop = useMediaQuery({minWidth: 1300})
-  const isTablet = useMediaQuery({minWidth: 800, maxWidth: 1300})
+  const isTablet = useMediaQuery({minWidth: 800, maxWidth: 1299})
   const isMobile = useMediaQuery({maxWidth: 800})
   const isTabletOrMobile = isMobile || isTablet
   const isTabletOrDesktop = isDesktop || isTablet

--- a/src/lib/hooks/useWebMediaQueries.tsx
+++ b/src/lib/hooks/useWebMediaQueries.tsx
@@ -3,8 +3,8 @@ import {isNative} from 'platform/detection'
 
 export function useWebMediaQueries() {
   const isDesktop = useMediaQuery({minWidth: 1300})
-  const isTablet = useMediaQuery({minWidth: 800, maxWidth: 1299})
-  const isMobile = useMediaQuery({maxWidth: 799})
+  const isTablet = useMediaQuery({minWidth: 800, maxWidth: 1300 - 1})
+  const isMobile = useMediaQuery({maxWidth: 800 - 1})
   const isTabletOrMobile = isMobile || isTablet
   const isTabletOrDesktop = isDesktop || isTablet
   if (isNative) {

--- a/src/lib/hooks/useWebMediaQueries.tsx
+++ b/src/lib/hooks/useWebMediaQueries.tsx
@@ -4,7 +4,7 @@ import {isNative} from 'platform/detection'
 export function useWebMediaQueries() {
   const isDesktop = useMediaQuery({minWidth: 1300})
   const isTablet = useMediaQuery({minWidth: 800, maxWidth: 1299})
-  const isMobile = useMediaQuery({maxWidth: 800})
+  const isMobile = useMediaQuery({maxWidth: 799})
   const isTabletOrMobile = isMobile || isTablet
   const isTabletOrDesktop = isDesktop || isTablet
   if (isNative) {

--- a/src/view/com/util/layouts/Breakpoints.web.tsx
+++ b/src/view/com/util/layouts/Breakpoints.web.tsx
@@ -8,13 +8,13 @@ export const TabletOrDesktop = ({children}: React.PropsWithChildren<{}>) => (
   <MediaQuery minWidth={800}>{children}</MediaQuery>
 )
 export const Tablet = ({children}: React.PropsWithChildren<{}>) => (
-  <MediaQuery minWidth={800} maxWidth={1299}>
+  <MediaQuery minWidth={800} maxWidth={1300 - 1}>
     {children}
   </MediaQuery>
 )
 export const TabletOrMobile = ({children}: React.PropsWithChildren<{}>) => (
-  <MediaQuery maxWidth={1299}>{children}</MediaQuery>
+  <MediaQuery maxWidth={1300 - 1}>{children}</MediaQuery>
 )
 export const Mobile = ({children}: React.PropsWithChildren<{}>) => (
-  <MediaQuery maxWidth={799}>{children}</MediaQuery>
+  <MediaQuery maxWidth={800 - 1}>{children}</MediaQuery>
 )

--- a/src/view/com/util/layouts/Breakpoints.web.tsx
+++ b/src/view/com/util/layouts/Breakpoints.web.tsx
@@ -16,5 +16,5 @@ export const TabletOrMobile = ({children}: React.PropsWithChildren<{}>) => (
   <MediaQuery maxWidth={1299}>{children}</MediaQuery>
 )
 export const Mobile = ({children}: React.PropsWithChildren<{}>) => (
-  <MediaQuery maxWidth={800}>{children}</MediaQuery>
+  <MediaQuery maxWidth={799}>{children}</MediaQuery>
 )

--- a/src/view/com/util/layouts/Breakpoints.web.tsx
+++ b/src/view/com/util/layouts/Breakpoints.web.tsx
@@ -8,12 +8,12 @@ export const TabletOrDesktop = ({children}: React.PropsWithChildren<{}>) => (
   <MediaQuery minWidth={800}>{children}</MediaQuery>
 )
 export const Tablet = ({children}: React.PropsWithChildren<{}>) => (
-  <MediaQuery minWidth={800} maxWidth={1300}>
+  <MediaQuery minWidth={800} maxWidth={1299}>
     {children}
   </MediaQuery>
 )
 export const TabletOrMobile = ({children}: React.PropsWithChildren<{}>) => (
-  <MediaQuery maxWidth={1300}>{children}</MediaQuery>
+  <MediaQuery maxWidth={1299}>{children}</MediaQuery>
 )
 export const Mobile = ({children}: React.PropsWithChildren<{}>) => (
   <MediaQuery maxWidth={800}>{children}</MediaQuery>


### PR DESCRIPTION
The breakpoints for the `tablet` and `mobile` viewports are scuffed because some breakpoints have their `minWidth` set to a value of `800` and `1300` respectively while other breakpoints use the same values for their `maxWidth` which causes styles to overlap and look weird.

I changed the relevant `maxWidth` values to `799` and `1299` respectively so that the styles do not overlap anymore.

I got some screenshots of the local development environment here. It's not set up enough to be fully functional, but it was enough to test the fix. 🙂

## Tablet
### Broken:
| `1299px` | `1300px` | `1301px`
|---|---|---
| ![1299px](https://github.com/bluesky-social/social-app/assets/5056880/f5955acf-8170-480d-97dd-485d255deb46) | ![1300px broken](https://github.com/bluesky-social/social-app/assets/5056880/612444e3-e31a-416f-8d59-203c74d367f1) | ![1301px](https://github.com/bluesky-social/social-app/assets/5056880/2408d577-c019-4313-995c-28821feafc22)

### Fixed:
| `1299px` | `1300px` | `1301px`
|---|---|---
| ![1299px](https://github.com/bluesky-social/social-app/assets/5056880/f5955acf-8170-480d-97dd-485d255deb46) | ![1300px fixed](https://github.com/bluesky-social/social-app/assets/5056880/78beb9a6-e58f-462d-bc7e-eab6379ff536) | ![1301px](https://github.com/bluesky-social/social-app/assets/5056880/2408d577-c019-4313-995c-28821feafc22)

## Mobile
### Broken:
| `799px` | `800px` | `801px`
|---|---|---
| ![799px](https://github.com/bluesky-social/social-app/assets/5056880/bfb8a9a9-3a12-474a-a978-16b496c0e1b1)| ![800px broken](https://github.com/bluesky-social/social-app/assets/5056880/d57e7b53-4886-417b-9b12-5be8086130bb) | ![801px](https://github.com/bluesky-social/social-app/assets/5056880/4e255975-e414-4c8c-9121-a163f96c0109)

### Fixed:
| `799px` | `800px` | `801px`
|---|---|---
| ![799px](https://github.com/bluesky-social/social-app/assets/5056880/bfb8a9a9-3a12-474a-a978-16b496c0e1b1) | ![800px fixed](https://github.com/bluesky-social/social-app/assets/5056880/ca54cd62-a9aa-4655-bdb5-1cb137f05c47) | ![801px](https://github.com/bluesky-social/social-app/assets/5056880/4e255975-e414-4c8c-9121-a163f96c0109)

You can also verify this on Bluesky right now.
![image](https://github.com/bluesky-social/social-app/assets/5056880/ba6d0dcc-e6c5-4324-b7a6-92cf948a63a2)


If I'm missing anything that might be affected by changing these vew , please let me know. 🙂