### PR TITLE
Fix missing effect cleanup

### DIFF
--- a/src/view/shell/index.web.tsx
+++ b/src/view/shell/index.web.tsx
@@ -36,9 +36,10 @@ function ShellInner() {
   useAuxClick()
 
   useEffect(() => {
-    navigator.addListener('state', () => {
+    const unsubscribe = navigator.addListener('state', () => {
       closeAllActiveElements()
     })
+    return unsubscribe
   }, [navigator, closeAllActiveElements])
 
   const showBottomBar = isMobile && !onboardingState.isActive


### PR DESCRIPTION
Random drive-by fix. I couldn't actually get a situation where this effect would re-run, but still worth cleaning up. Verified the listener itself fires like before on navigation.