### PR TITLE
Two fixes to react-key generation

### DIFF
--- a/src/lib/api/feed-manip.ts
+++ b/src/lib/api/feed-manip.ts
@@ -19,8 +19,9 @@ export class FeedViewPostsSlice {
   constructor(public items: FeedViewPost[] = []) {}
 
   get _reactKey() {
-    return `slice-${this.items[0].post.uri}-${
-      this.items[0].reason?.indexedAt || this.items[0].post.indexedAt
+    const rootItem = this.isFlattenedReply ? this.items[1] : this.items[0]
+    return `slice-${rootItem.post.uri}-${
+      rootItem.reason?.indexedAt || rootItem.post.indexedAt
     }`
   }
 

--- a/src/view/com/lists/ListMembers.tsx
+++ b/src/view/com/lists/ListMembers.tsx
@@ -215,7 +215,7 @@ export function ListMembers({
         testID={testID ? `${testID}-flatlist` : undefined}
         ref={scrollElRef}
         data={items}
-        keyExtractor={(item: any) => item.uri || item._reactKey}
+        keyExtractor={(item: any) => item.subject?.did || item._reactKey}
         renderItem={renderItem}
         ListHeaderComponent={renderHeader}
         ListFooterComponent={Footer}


### PR DESCRIPTION
- 5c14b36b07737c362f516c18d097c596ad6f2ef7 fixes the react keys in the ListMembers component (they were undefined)
- 5201ace6c4818c3945b8c1955e998a25239c095d fixes the react keys in the posts feed (sometimes produced duplicates)