### PR TITLE
Restore post-thread caching behaviors (react-query refactor)

### DIFF
--- a/src/state/queries/notifications/feed.ts
+++ b/src/state/queries/notifications/feed.ts
@@ -12,6 +12,7 @@ import {
   InfiniteData,
   QueryKey,
   useQueryClient,
+  QueryClient,
 } from '@tanstack/react-query'
 import {getAgent} from '../../session'
 import {useModerationOpts} from '../preferences'
@@ -107,6 +108,32 @@ export function useNotificationFeedQuery(opts?: {enabled?: boolean}) {
     getNextPageParam: lastPage => lastPage.cursor,
     enabled,
   })
+}
+
+/**
+ * This helper is used by the post-thread placeholder function to
+ * find a post in the query-data cache
+ */
+export function findPostInQueryData(
+  queryClient: QueryClient,
+  uri: string,
+): AppBskyFeedDefs.PostView | undefined {
+  const queryDatas = queryClient.getQueriesData<InfiniteData<FeedPage>>({
+    queryKey: ['notification-feed'],
+  })
+  for (const [_queryKey, queryData] of queryDatas) {
+    if (!queryData?.pages) {
+      continue
+    }
+    for (const page of queryData?.pages) {
+      for (const item of page.items) {
+        if (item.subject?.uri === uri) {
+          return item.subject
+        }
+      }
+    }
+  }
+  return undefined
 }
 
 function groupNotifications(

--- a/src/state/queries/post-feed.ts
+++ b/src/state/queries/post-feed.ts
@@ -188,3 +188,31 @@ export function usePostFeedQuery(
 
   return {...out, pollLatest}
 }
+
+/**
+ * This helper is used by the post-thread placeholder function to
+ * find a post in the query-data cache
+ */
+export function findPostInQueryData(
+  queryClient: QueryClient,
+  uri: string,
+): FeedPostSliceItem | undefined {
+  const queryDatas = queryClient.getQueriesData<InfiniteData<FeedPage>>({
+    queryKey: ['post-feed'],
+  })
+  for (const [_queryKey, queryData] of queryDatas) {
+    if (!queryData?.pages) {
+      continue
+    }
+    for (const page of queryData?.pages) {
+      for (const slice of page.slices) {
+        for (const item of slice.items) {
+          if (item.uri === uri) {
+            return item
+          }
+        }
+      }
+    }
+  }
+  return undefined
+}

--- a/src/state/queries/post-feed.ts
+++ b/src/state/queries/post-feed.ts
@@ -161,7 +161,6 @@ export function usePostFeedQuery(
             slice.items.every(
               item => item.post.author.did === slice.items[0].post.author.did,
             ),
-          source: undefined, // TODO
           items: slice.items
             .map((item, i) => {
               if (

--- a/src/state/queries/post-thread.ts
+++ b/src/state/queries/post-thread.ts
@@ -80,24 +80,20 @@ export function usePostThreadQuery(uri: string | undefined) {
     enabled: !!uri,
     placeholderData: () => {
       if (!uri) {
-        console.log('bombed here')
         return undefined
       }
       {
         const item = findPostInFeedQueryData(queryClient, uri)
         if (item) {
-          console.log('using cache')
           return feedItemToPlaceholderThread(item)
         }
       }
       {
         const item = findPostInNotifsQueryData(queryClient, uri)
         if (item) {
-          console.log('using cache 2')
           return postViewToPlaceholderThread(item)
         }
       }
-      console.log('no cache')
       return undefined
     },
   })

--- a/src/state/queries/post-thread.ts
+++ b/src/state/queries/post-thread.ts
@@ -208,7 +208,7 @@ function responseToThreadNodes(
 function feedItemToPlaceholderThread(item: FeedPostSliceItem): ThreadNode {
   return {
     type: 'post',
-    _reactKey: post.uri,
+    _reactKey: item.post.uri,
     uri: item.post.uri,
     post: item.post,
     record: item.record,

--- a/src/state/queries/post-thread.ts
+++ b/src/state/queries/post-thread.ts
@@ -24,6 +24,8 @@ export interface ThreadCtx {
   hasMore?: boolean
   showChildReplyLine?: boolean
   showParentReplyLine?: boolean
+  isParentLoading?: boolean
+  isChildLoading?: boolean
 }
 
 export type ThreadPost = {
@@ -221,6 +223,8 @@ function feedItemToPlaceholderThread(item: FeedPostSliceItem): ThreadNode {
       hasMore: false,
       showChildReplyLine: false,
       showParentReplyLine: false,
+      isParentLoading: !!item.record.reply,
+      isChildLoading: !!item.post.replyCount,
     },
   }
 }
@@ -243,6 +247,8 @@ function postViewToPlaceholderThread(
       hasMore: false,
       showChildReplyLine: false,
       showParentReplyLine: false,
+      isParentLoading: !!(post.record as AppBskyFeedPost.Record).reply,
+      isChildLoading: !!post.replyCount,
     },
   }
 }

--- a/src/state/queries/resolve-uri.ts
+++ b/src/state/queries/resolve-uri.ts
@@ -1,27 +1,39 @@
-import {useQuery} from '@tanstack/react-query'
+import {useQuery, UseQueryResult} from '@tanstack/react-query'
 import {AtUri} from '@atproto/api'
 
 import {getAgent} from '#/state/session'
 import {STALE} from '#/state/queries'
 
-export const RQKEY = (uri: string) => ['resolved-uri', uri]
+export const RQKEY = (didOrHandle: string) => ['resolved-did', didOrHandle]
 
-export function useResolveUriQuery(uri: string | undefined) {
-  return useQuery<{uri: string; did: string}, Error>({
-    staleTime: STALE.INFINITY,
-    queryKey: RQKEY(uri || ''),
-    async queryFn() {
-      const urip = new AtUri(uri || '')
-      if (!urip.host.startsWith('did:')) {
-        const res = await getAgent().resolveHandle({handle: urip.host})
-        urip.host = res.data.did
-      }
-      return {did: urip.host, uri: urip.toString()}
-    },
-    enabled: !!uri,
-  })
+type UriUseQueryResult = UseQueryResult<{did: string; uri: string}, Error>
+export function useResolveUriQuery(uri: string | undefined): UriUseQueryResult {
+  const urip = new AtUri(uri || '')
+  const res = useResolveDidQuery(urip.host)
+  if (res.data) {
+    urip.host = res.data
+    return {
+      ...res,
+      data: {did: urip.host, uri: urip.toString()},
+    } as UriUseQueryResult
+  }
+  return res as UriUseQueryResult
 }
 
 export function useResolveDidQuery(didOrHandle: string | undefined) {
-  return useResolveUriQuery(didOrHandle ? `at://${didOrHandle}/` : undefined)
+  return useQuery<string, Error>({
+    staleTime: STALE.INFINITY,
+    queryKey: RQKEY(didOrHandle || ''),
+    async queryFn() {
+      if (!didOrHandle) {
+        return ''
+      }
+      if (!didOrHandle.startsWith('did:')) {
+        const res = await getAgent().resolveHandle({handle: didOrHandle})
+        didOrHandle = res.data.did
+      }
+      return didOrHandle
+    },
+    enabled: !!didOrHandle,
+  })
 }

--- a/src/view/com/post-thread/PostThread.tsx
+++ b/src/view/com/post-thread/PostThread.tsx
@@ -465,6 +465,8 @@ function* flattenThreadSkeleton(
   if (node.type === 'post') {
     if (node.parent) {
       yield* flattenThreadSkeleton(node.parent)
+    } else if (node.ctx.isParentLoading) {
+      yield PARENT_SPINNER
     }
     yield node
     if (node.ctx.isHighlightedPost) {
@@ -474,6 +476,8 @@ function* flattenThreadSkeleton(
       for (const reply of node.replies) {
         yield* flattenThreadSkeleton(reply)
       }
+    } else if (node.ctx.isChildLoading) {
+      yield CHILD_SPINNER
     }
   } else if (node.type === 'not-found') {
     yield DELETED

--- a/src/view/com/post-thread/PostThread.tsx
+++ b/src/view/com/post-thread/PostThread.tsx
@@ -39,8 +39,10 @@ import {
   usePreferencesQuery,
 } from '#/state/queries/preferences'
 import {useSession} from '#/state/session'
+import {isNative} from '#/platform/detection'
+import {logger} from '#/logger'
 
-// const MAINTAIN_VISIBLE_CONTENT_POSITION = {minIndexForVisible: 2} TODO
+const MAINTAIN_VISIBLE_CONTENT_POSITION = {minIndexForVisible: 2}
 
 const TOP_COMPONENT = {_reactKey: '__top_component__'}
 const PARENT_SPINNER = {_reactKey: '__parent_spinner__'}
@@ -72,7 +74,6 @@ export function PostThread({
     isError,
     error,
     refetch,
-    isRefetching,
     data: thread,
   } = usePostThreadQuery(uri)
   const {data: preferences} = usePreferencesQuery()
@@ -110,7 +111,6 @@ export function PostThread({
   return (
     <PostThreadLoaded
       thread={thread}
-      isRefetching={isRefetching}
       threadViewPrefs={preferences.threadViewPrefs}
       onRefresh={refetch}
       onPressReply={onPressReply}
@@ -120,13 +120,11 @@ export function PostThread({
 
 function PostThreadLoaded({
   thread,
-  isRefetching,
   threadViewPrefs,
   onRefresh,
   onPressReply,
 }: {
   thread: ThreadNode
-  isRefetching: boolean
   threadViewPrefs: UsePreferencesQueryResponse['threadViewPrefs']
   onRefresh: () => void
   onPressReply: () => void
@@ -136,29 +134,15 @@ function PostThreadLoaded({
   const pal = usePalette('default')
   const {isTablet, isDesktop} = useWebMediaQueries()
   const ref = useRef<FlatList>(null)
-  // const hasScrolledIntoView = useRef<boolean>(false) TODO
+  const highlightedPostRef = useRef<View | null>(null)
+  const needsScrollAdjustment = useRef<boolean>(
+    !isNative || // web always uses scroll adjustment
+      (thread.type === 'post' && !thread.ctx.isParentLoading), // native only does it when not loading from placeholder
+  )
   const [maxVisible, setMaxVisible] = React.useState(100)
+  const [isPTRing, setIsPTRing] = React.useState(false)
 
-  // TODO
-  // const posts = React.useMemo(() => {
-  //   if (view.thread) {
-  //     let arr = [TOP_COMPONENT].concat(Array.from(flattenThread(view.thread)))
-  //     if (arr.length > maxVisible) {
-  //       arr = arr.slice(0, maxVisible).concat([LOAD_MORE])
-  //     }
-  //     if (view.isLoadingFromCache) {
-  //       if (view.thread?.postRecord?.reply) {
-  //         arr.unshift(PARENT_SPINNER)
-  //       }
-  //       arr.push(CHILD_SPINNER)
-  //     } else {
-  //       arr.push(BOTTOM_COMPONENT)
-  //     }
-  //     return arr
-  //   }
-  //   return []
-  // }, [view.isLoadingFromCache, view.thread, maxVisible])
-  // const highlightedPostIndex = posts.findIndex(post => post._isHighlightedPost)
+  // construct content
   const posts = React.useMemo(() => {
     let arr = [TOP_COMPONENT].concat(
       Array.from(flattenThreadSkeleton(sortThread(thread, threadViewPrefs))),
@@ -170,50 +154,55 @@ function PostThreadLoaded({
     return arr
   }, [thread, maxVisible, threadViewPrefs])
 
-  // TODO
-  /*const onContentSizeChange = React.useCallback(() => {
+  /**
+   * NOTE
+   * Scroll positioning
+   *
+   * This callback is run if needsScrollAdjustment.current == true, which is...
+   *  - On web: always
+   *  - On native: when the placeholder cache is not being used
+   *
+   * It then only runs when viewing a reply, and the goal is to scroll the
+   * reply into view.
+   *
+   * On native, if the placeholder cache is being used then maintainVisibleContentPosition
+   * is a more effective solution, so we use that. Otherwise, typically we're loading from
+   * the react-query cache, so we just need to immediately scroll down to the post.
+   *
+   * On desktop, maintainVisibleContentPosition isn't supported so we just always use
+   * this technique.
+   *
+   * -prf
+   */
+  const onContentSizeChange = React.useCallback(() => {
     // only run once
-    if (hasScrolledIntoView.current) {
+    if (!needsScrollAdjustment.current) {
       return
     }
 
     // wait for loading to finish
-    if (
-      !view.hasContent ||
-      (view.isFromCache && view.isLoadingFromCache) ||
-      view.isLoading
-    ) {
-      return
+    if (thread.type === 'post' && !!thread.parent) {
+      highlightedPostRef.current?.measure(
+        (_x, _y, _width, _height, _pageX, pageY) => {
+          ref.current?.scrollToOffset({
+            animated: false,
+            offset: pageY - (isDesktop ? 0 : 50),
+          })
+        },
+      )
+      needsScrollAdjustment.current = false
     }
+  }, [thread, isDesktop])
 
-    if (highlightedPostIndex !== -1) {
-      ref.current?.scrollToIndex({
-        index: highlightedPostIndex,
-        animated: false,
-        viewPosition: 0,
-      })
-      hasScrolledIntoView.current = true
+  const onPTR = React.useCallback(async () => {
+    setIsPTRing(true)
+    try {
+      await onRefresh()
+    } catch (err) {
+      logger.error('Failed to refresh posts thread', {error: err})
     }
-  }, [
-    highlightedPostIndex,
-    view.hasContent,
-    view.isFromCache,
-    view.isLoadingFromCache,
-    view.isLoading,
-  ])*/
-  const onScrollToIndexFailed = React.useCallback(
-    (info: {
-      index: number
-      highestMeasuredFrameIndex: number
-      averageItemLength: number
-    }) => {
-      ref.current?.scrollToOffset({
-        animated: false,
-        offset: info.averageItemLength * info.index,
-      })
-    },
-    [ref],
-  )
+    setIsPTRing(false)
+  }, [setIsPTRing, onRefresh])
 
   const renderItem = React.useCallback(
     ({item, index}: {item: YieldedItem; index: number}) => {
@@ -290,18 +279,21 @@ function PostThreadLoaded({
           ? (posts[index - 1] as ThreadPost)
           : undefined
         return (
-          <PostThreadItem
-            post={item.post}
-            record={item.record}
-            treeView={threadViewPrefs.lab_treeViewEnabled || false}
-            depth={item.ctx.depth}
-            isHighlightedPost={item.ctx.isHighlightedPost}
-            hasMore={item.ctx.hasMore}
-            showChildReplyLine={item.ctx.showChildReplyLine}
-            showParentReplyLine={item.ctx.showParentReplyLine}
-            hasPrecedingItem={!!prev?.ctx.showChildReplyLine}
-            onPostReply={onRefresh}
-          />
+          <View
+            ref={item.ctx.isHighlightedPost ? highlightedPostRef : undefined}>
+            <PostThreadItem
+              post={item.post}
+              record={item.record}
+              treeView={threadViewPrefs.lab_treeViewEnabled || false}
+              depth={item.ctx.depth}
+              isHighlightedPost={item.ctx.isHighlightedPost}
+              hasMore={item.ctx.hasMore}
+              showChildReplyLine={item.ctx.showChildReplyLine}
+              showParentReplyLine={item.ctx.showParentReplyLine}
+              hasPrecedingItem={!!prev?.ctx.showChildReplyLine}
+              onPostReply={onRefresh}
+            />
+          </View>
         )
       }
       return null
@@ -330,25 +322,21 @@ function PostThreadLoaded({
       data={posts}
       initialNumToRender={posts.length}
       maintainVisibleContentPosition={
-        undefined // TODO
-        // isNative && view.isFromCache && view.isCachedPostAReply
-        //   ? MAINTAIN_VISIBLE_CONTENT_POSITION
-        //   : undefined
+        !needsScrollAdjustment.current
+          ? MAINTAIN_VISIBLE_CONTENT_POSITION
+          : undefined
       }
       keyExtractor={item => item._reactKey}
       renderItem={renderItem}
       refreshControl={
         <RefreshControl
-          refreshing={isRefetching}
-          onRefresh={onRefresh}
+          refreshing={isPTRing}
+          onRefresh={onPTR}
           tintColor={pal.colors.text}
           titleColor={pal.colors.text}
         />
       }
-      onContentSizeChange={
-        undefined //TODOisNative && view.isFromCache ? undefined : onContentSizeChange
-      }
-      onScrollToIndexFailed={onScrollToIndexFailed}
+      onContentSizeChange={onContentSizeChange}
       style={s.hContentRegion}
       // @ts-ignore our .web version only -prf
       desktopFixedHeight

--- a/src/view/com/profile/ProfileFollowers.tsx
+++ b/src/view/com/profile/ProfileFollowers.tsx
@@ -28,7 +28,7 @@ export function ProfileFollowers({name}: {name: string}) {
     isError,
     error,
     refetch,
-  } = useProfileFollowersQuery(resolvedDid?.did)
+  } = useProfileFollowersQuery(resolvedDid)
 
   const followers = React.useMemo(() => {
     if (data?.pages) {

--- a/src/view/com/profile/ProfileFollows.tsx
+++ b/src/view/com/profile/ProfileFollows.tsx
@@ -28,7 +28,7 @@ export function ProfileFollows({name}: {name: string}) {
     isError,
     error,
     refetch,
-  } = useProfileFollowsQuery(resolvedDid?.did)
+  } = useProfileFollowsQuery(resolvedDid)
 
   const follows = React.useMemo(() => {
     if (data?.pages) {

--- a/src/view/screens/Profile.tsx
+++ b/src/view/screens/Profile.tsx
@@ -58,7 +58,7 @@ export function ProfileScreen({route}: Props) {
     refetch: refetchProfile,
     isFetching: isFetchingProfile,
   } = useProfileQuery({
-    did: resolvedDid?.did,
+    did: resolvedDid,
   })
 
   const onPressTryAgain = React.useCallback(() => {


### PR DESCRIPTION
- c643d70be5fc38275fa85daa0afa7fed9d086e66 Reworks `useResolveUriQuery` and `useResolveDidQuery` to be smarter about caching. Originally `useResolveUriQuery` was the main query being used with the DID variant piggy-backing. This was silly because it meant we were caching against URIs, but all we want to cache against is the handles and their resolutions. This commit reverses them.
- d197b288f73c489a8ac45f31ef57f2aae84a17f2 Adds "precaching" to the resolve uri/did queries, pre-filling the query data when we receive user profiles.
- e12b2da46397591810f4f5b920a6ce610c82d04b Uses the `placeholderData` react-query mechanism to pre-fill the post thread output. It does this by searching the cached feed and notification queries.
- 125b831d479c2f5abff17b740a52c02de3f62ea1 and 732ab792d265bab27d63e9182bea8aede84d3fb7 restore the rendering and scroll-positioning behaviors of the thread rendering