### PR TITLE
Fix memory leak on mobile web tab navigation

### DIFF
--- a/src/view/shell/bottom-bar/BottomBarWeb.tsx
+++ b/src/view/shell/bottom-bar/BottomBarWeb.tsx
@@ -137,7 +137,7 @@ const NavItem: React.FC<{
       : isTab(currentRoute.name, routeName)
 
   return (
-    <Link href={href} style={styles.ctrl}>
+    <Link href={href} style={styles.ctrl} navigationAction="navigate">
       {children({isActive})}
     </Link>
   )


### PR DESCRIPTION
When we explicitly use the `push` action, and our router config never specifies `getId` (it doesn't), pushing [always creates a new top-level screen](https://github.com/react-navigation/react-navigation/blob/99f00d2c89e3e46004303336543d2d3dba03fdf4/packages/routers/src/StackRouter.tsx#L292-L305). This causes a very bad memory leak because every tab button navigation creates a new screen:

https://github.com/bluesky-social/social-app/assets/810438/9d18d38a-2647-4fdd-8533-a42f9f620cba

I'm not sure what the idiomatic way to fix this is, but we can use the `navigate` action instead which will [check if the same route exists in the stack and reuse it](https://github.com/react-navigation/react-navigation/blob/99f00d2c89e3e46004303336543d2d3dba03fdf4/packages/routers/src/StackRouter.tsx#L358-L392). This fixes the issue:

https://github.com/bluesky-social/social-app/assets/810438/269ca7da-4d1d-46dd-8ebc-d8213228471c

The desired behavior depends on the specific link, not on the route itself. (For example, a link to profile inside a profile should always "push", even if it's the same profile.) So I made this configurable as a prop on the link.

Note that in the future, this special `navigate` behavior [will be going away](https://github.com/react-navigation/react-navigation/commit/c9c2163d28da963bd760cf395d17efe9b851f531) so we'll need to think again about what we want to achieve here. Maybe explicitly specifying `getId` would be the right approach. There's still going to be [`navigateDeprecated`](https://github.com/react-navigation/react-navigation/commit/8ea6dc793d8596da5e6052dbbae2e4825578dc50) though so we could use that until we settle.

This did not affect desktop web tab nav because it uses `useLinkProps` which has `useLinkTo` which does `navigation.navigate` under the hood already.