### PR TITLE
Disable RQ structural sharing

### DIFF
--- a/src/lib/react-query.ts
+++ b/src/lib/react-query.ts
@@ -8,6 +8,10 @@ export const queryClient = new QueryClient({
       // so we NEVER want to enable this
       // -prf
       refetchOnWindowFocus: false,
+      // Structural sharing between responses makes it impossible to rely on
+      // "first seen" timestamps on objects to determine if they're fresh.
+      // Disable this optimization so that we can rely on "first seen" timestamps.
+      structuralSharing: false,
     },
   },
 })


### PR DESCRIPTION
React Query has an optimization called [structural sharing](https://tkdodo.eu/blog/react-query-render-optimizations#structural-sharing). When RQ receives a response, it will by default [traverse both the old and the new response](https://github.com/TanStack/query/blob/f62e079a4ff92a1580910ede560610b86d34a316/packages/query-core/src/utils.ts#L322) and try to reuse parts of the previous response if they are deeply equal to the parts of the new response at the same key paths. This is particularly useful when the data refetches often but most items don't update.

In our case, this causes a problem. We're using an (arguably hacky) approach to [track whether a piece of data is stale](https://github.com/bluesky-social/social-app/blob/b778017000eeed028edc5cd8fa89d64d4d90dc32/src/state/cache/post-shadow.ts#L26-L34) by timestamping the first time we try to render it. This usually works "fine" but here's a scenario where it doesn't:

1. "Like" a post in the first tab
2. "Unlike" it from another browser tab
3. Refetch in the first tab

Normally, our logic is supposed to throw away the "shadowed" optimistic like because there was a refetch, and we have a newer version of the content (which has a fresher timestamp). However, since RQ reuses objects between requests, it appears as if it was the old post object — and so our optimistic mutation logic thinks the mutation still happened _later_.

https://github.com/bluesky-social/social-app/assets/810438/1d9e4bb4-05fb-4270-8f8a-a08b7de145f6

With this change, a fresh response is guaranteed to bring in fresh objects.

https://github.com/bluesky-social/social-app/assets/810438/94b5b47e-b598-46f8-84d2-f29b9d0b8bce

The downside is that refetches that don't generally change content (e.g. a refetch of own profile when none of the data has changed) would now cause deeper re-renders (going into individual items). I think that's *probably* okay because they're bounded (we only refetch one page) and shouldn't be worse than the initial render anyway. Also, this doesn't make pagination or initial renders (such as push navigations) any slower, so it's just unchanging refreshes that suffer.

Alternatively, we could remove the WeakMap hack and actually put the timestamps into the responses when we parse them. However, effectively this would lead to the same outcome (deeper re-renders because the items got new timestamps) so we might as well try this first.

Regardless of the approach, the bug itself seems must-fix to me because we can't be showing stale data after refresh.