### PR TITLE
[WIP] Shadow Queue

### DIFF
--- a/src/lib/react-query.ts
+++ b/src/lib/react-query.ts
@@ -8,6 +8,10 @@ export const queryClient = new QueryClient({
       // so we NEVER want to enable this
       // -prf
       refetchOnWindowFocus: false,
+      // Structural sharing between responses makes it impossible to rely on
+      // "first seen" timestamps on objects to determine if they're fresh.
+      // Disable this optimization so that we can rely on "first seen" timestamps.
+      structuralSharing: false,
     },
   },
 })

--- a/src/state/cache/post-shadow.ts
+++ b/src/state/cache/post-shadow.ts
@@ -36,7 +36,13 @@ function getFirstSeenTS(post: AppBskyFeedDefs.PostView): number {
 export function usePostShadow(
   post: AppBskyFeedDefs.PostView,
 ): Shadow<AppBskyFeedDefs.PostView> | typeof POST_TOMBSTONE {
-  const [shadow, setShadow] = useState(null)
+  const [shadow, setShadow] = useState(() => {
+    const record = map.get(post.uri)
+    if (!record) {
+      return null
+    }
+    return record.shadow
+  })
 
   useEffect(() => {
     function onChange(s) {

--- a/src/state/cache/post-shadow.ts
+++ b/src/state/cache/post-shadow.ts
@@ -36,9 +36,11 @@ function getFirstSeenTS(post: AppBskyFeedDefs.PostView): number {
 export function usePostShadow(
   post: AppBskyFeedDefs.PostView,
 ): Shadow<AppBskyFeedDefs.PostView> | typeof POST_TOMBSTONE {
+  const [shadow, setShadow] = useState(null)
+
   useEffect(() => {
     function onChange(s) {
-      console.log('onChange', s)
+      setShadow(s)
     }
     const unsub = addListener(post.uri, onChange)
     return () => {
@@ -46,7 +48,23 @@ export function usePostShadow(
     }
   }, [post.uri])
 
-  return post
+  return mergeShadow(post, shadow)
+}
+
+function mergeShadow(post, shadow) {
+  if (!shadow) {
+    return post
+  }
+  return {
+    ...post,
+    likeCount: shadow.likeCount ?? post.likeCount,
+    repostCount: shadow.repostCount ?? post.repostCount,
+    viewer: {
+      ...(post.viewer || {}),
+      like: shadow.likeUri,
+      repost: shadow.repostUri,
+    },
+  }
 }
 
 function addListener(uri, onChange) {


### PR DESCRIPTION
Builds on top of https://github.com/bluesky-social/social-app/pull/2022.

This is a draft of an approach that attempts to fix existing bugs with the shadow logic.

## The Problem

Our current approach to optimistic mutations (with local "shadowing" of the query cache) is not very reliable because it only works for syncing views that are currently on the screen (or at least in the rendered part of the navigation stack). On the web, this breaks down on most push/pop navigations because our web router doesn't keep the entries below always rendered. On *both* mobile and web, this breaks on scenarios where you *push* a new view that contains a post that's supposed to be shadowed — our shadowing logic only works for *existing* views but not *newly mounted* ones.

For example, here's how this breaks on the web:

1. Push post
2. Like post
3. Pop to feed (expected: liked, actual: not liked)
4. Push post again (expected: liked, actual: not liked)

And here's how it breaks on mobile:

1. Push post
2. Like post
3. Pop to feed
4. Push post again (expected: liked, actual: not liked)

The exact outcome is different but the core issue is the same. We don't keep track of active shadow for newly mounted views, so they're unable to take the already committed mutations into account without an explicit refetch.

## The Proposal

This is a draft so it's a bit messy. But it's also a slightly messy solution. I'd like to give it a try though.

- There is a new concept of a "queue". A queue is a list of partial updates. Each partial update has a timestamp.
- To compute a shadow, we go over the queue and apply only the mutations *after* the post's "seen" timestamp.
- There is a top-level Map from a URI to a "record".
  - A record represents a post that's currently rendered on the screen *somewhere*, possibly more than in one place.
  - A record is refcounted, like the old event emitter approach. It gets deleted when all components for this post unmount.
  - A record contains references to two things. The listener array and the queue for this post. This enables coordination.
- By itself, this still wouldn't be enough to let components communicate with a gap in their lifetime (like push on the web).
  - This is why we also add a WeakMap from a post to a queue.
    - This adds an extra layer: we associate every post with the queue for it forever, so we can "resume" with the same queue.

So effectively the lifetime of the queue is as long as there's either components rendering these posts *or* something holds onto the old post objects (so that the queue can be "brought back from the dead" via the WeakMap when the posts mount).

In theory there is a concern that a queue for some post can grow long. This seems not super likely to me (why would you interact with some post so many times?) but in principle it can happen. Then it's not great that we keep the entire mutation queue forever. One way to address it would be to "prune" the beginning of the queue when we associate it with some post for the first time. I've made it a linked list to make this easy but I have not actually implemented this part.

This might be a bit over-engineered so I'm asking for feedback first, but I do like that it seems to cover known cases well.

## Demo

This appears to fix all the scenarios I've observed so far.

https://github.com/bluesky-social/social-app/assets/810438/9b267b24-b72b-4e1f-af6d-8e31f318cfee

https://github.com/bluesky-social/social-app/assets/810438/d0629597-8c92-47b7-b27e-8d0e25e570e2

## TODO

- [ ] Add types
- [ ] Add back memoization
- [ ] Fix lint
- [ ] (Tentative) Prune the queue
- [ ] Do this for profile shadow cache as well
- [ ] Maybe extract a shared helper so I can stop copy pasting this