### PR TITLE
Get more rigorous about getAgent() consistency

### DIFF
--- a/src/lib/api/feed/author.ts
+++ b/src/lib/api/feed/author.ts
@@ -1,18 +1,15 @@
 import {
   AppBskyFeedDefs,
   AppBskyFeedGetAuthorFeed as GetAuthorFeed,
-  BskyAgent,
 } from '@atproto/api'
 import {FeedAPI, FeedAPIResponse} from './types'
+import {getAgent} from '#/state/session'
 
 export class AuthorFeedAPI implements FeedAPI {
-  constructor(
-    public agent: BskyAgent,
-    public params: GetAuthorFeed.QueryParams,
-  ) {}
+  constructor(public params: GetAuthorFeed.QueryParams) {}
 
   async peekLatest(): Promise<AppBskyFeedDefs.FeedViewPost> {
-    const res = await this.agent.getAuthorFeed({
+    const res = await getAgent().getAuthorFeed({
       ...this.params,
       limit: 1,
     })
@@ -26,7 +23,7 @@ export class AuthorFeedAPI implements FeedAPI {
     cursor: string | undefined
     limit: number
   }): Promise<FeedAPIResponse> {
-    const res = await this.agent.getAuthorFeed({
+    const res = await getAgent().getAuthorFeed({
       ...this.params,
       cursor,
       limit,

--- a/src/lib/api/feed/custom.ts
+++ b/src/lib/api/feed/custom.ts
@@ -1,18 +1,15 @@
 import {
   AppBskyFeedDefs,
   AppBskyFeedGetFeed as GetCustomFeed,
-  BskyAgent,
 } from '@atproto/api'
 import {FeedAPI, FeedAPIResponse} from './types'
+import {getAgent} from '#/state/session'
 
 export class CustomFeedAPI implements FeedAPI {
-  constructor(
-    public agent: BskyAgent,
-    public params: GetCustomFeed.QueryParams,
-  ) {}
+  constructor(public params: GetCustomFeed.QueryParams) {}
 
   async peekLatest(): Promise<AppBskyFeedDefs.FeedViewPost> {
-    const res = await this.agent.app.bsky.feed.getFeed({
+    const res = await getAgent().app.bsky.feed.getFeed({
       ...this.params,
       limit: 1,
     })
@@ -26,7 +23,7 @@ export class CustomFeedAPI implements FeedAPI {
     cursor: string | undefined
     limit: number
   }): Promise<FeedAPIResponse> {
-    const res = await this.agent.app.bsky.feed.getFeed({
+    const res = await getAgent().app.bsky.feed.getFeed({
       ...this.params,
       cursor,
       limit,

--- a/src/lib/api/feed/following.ts
+++ b/src/lib/api/feed/following.ts
@@ -1,11 +1,12 @@
-import {AppBskyFeedDefs, BskyAgent} from '@atproto/api'
+import {AppBskyFeedDefs} from '@atproto/api'
 import {FeedAPI, FeedAPIResponse} from './types'
+import {getAgent} from '#/state/session'
 
 export class FollowingFeedAPI implements FeedAPI {
-  constructor(public agent: BskyAgent) {}
+  constructor() {}
 
   async peekLatest(): Promise<AppBskyFeedDefs.FeedViewPost> {
-    const res = await this.agent.getTimeline({
+    const res = await getAgent().getTimeline({
       limit: 1,
     })
     return res.data.feed[0]
@@ -18,7 +19,7 @@ export class FollowingFeedAPI implements FeedAPI {
     cursor: string | undefined
     limit: number
   }): Promise<FeedAPIResponse> {
-    const res = await this.agent.getTimeline({
+    const res = await getAgent().getTimeline({
       cursor,
       limit,
     })

--- a/src/lib/api/feed/likes.ts
+++ b/src/lib/api/feed/likes.ts
@@ -1,18 +1,15 @@
 import {
   AppBskyFeedDefs,
   AppBskyFeedGetActorLikes as GetActorLikes,
-  BskyAgent,
 } from '@atproto/api'
 import {FeedAPI, FeedAPIResponse} from './types'
+import {getAgent} from '#/state/session'
 
 export class LikesFeedAPI implements FeedAPI {
-  constructor(
-    public agent: BskyAgent,
-    public params: GetActorLikes.QueryParams,
-  ) {}
+  constructor(public params: GetActorLikes.QueryParams) {}
 
   async peekLatest(): Promise<AppBskyFeedDefs.FeedViewPost> {
-    const res = await this.agent.getActorLikes({
+    const res = await getAgent().getActorLikes({
       ...this.params,
       limit: 1,
     })
@@ -26,7 +23,7 @@ export class LikesFeedAPI implements FeedAPI {
     cursor: string | undefined
     limit: number
   }): Promise<FeedAPIResponse> {
-    const res = await this.agent.getActorLikes({
+    const res = await getAgent().getActorLikes({
       ...this.params,
       cursor,
       limit,

--- a/src/lib/api/feed/list.ts
+++ b/src/lib/api/feed/list.ts
@@ -1,18 +1,15 @@
 import {
   AppBskyFeedDefs,
   AppBskyFeedGetListFeed as GetListFeed,
-  BskyAgent,
 } from '@atproto/api'
 import {FeedAPI, FeedAPIResponse} from './types'
+import {getAgent} from '#/state/session'
 
 export class ListFeedAPI implements FeedAPI {
-  constructor(
-    public agent: BskyAgent,
-    public params: GetListFeed.QueryParams,
-  ) {}
+  constructor(public params: GetListFeed.QueryParams) {}
 
   async peekLatest(): Promise<AppBskyFeedDefs.FeedViewPost> {
-    const res = await this.agent.app.bsky.feed.getListFeed({
+    const res = await getAgent().app.bsky.feed.getListFeed({
       ...this.params,
       limit: 1,
     })
@@ -26,7 +23,7 @@ export class ListFeedAPI implements FeedAPI {
     cursor: string | undefined
     limit: number
   }): Promise<FeedAPIResponse> {
-    const res = await this.agent.app.bsky.feed.getListFeed({
+    const res = await getAgent().app.bsky.feed.getListFeed({
       ...this.params,
       cursor,
       limit,

--- a/src/state/queries/list.ts
+++ b/src/state/queries/list.ts
@@ -3,7 +3,6 @@ import {
   AppBskyGraphGetList,
   AppBskyGraphList,
   AppBskyGraphDefs,
-  BskyAgent,
 } from '@atproto/api'
 import {Image as RNImage} from 'react-native-image-crop-picker'
 import {useQuery, useMutation, useQueryClient} from '@tanstack/react-query'
@@ -75,13 +74,9 @@ export function useListCreateMutation() {
         )
 
         // wait for the appview to update
-        await whenAppViewReady(
-          getAgent(),
-          res.uri,
-          (v: AppBskyGraphGetList.Response) => {
-            return typeof v?.data?.list.uri === 'string'
-          },
-        )
+        await whenAppViewReady(res.uri, (v: AppBskyGraphGetList.Response) => {
+          return typeof v?.data?.list.uri === 'string'
+        })
         return res
       },
       onSuccess() {
@@ -142,16 +137,12 @@ export function useListMetadataMutation() {
       ).data
 
       // wait for the appview to update
-      await whenAppViewReady(
-        getAgent(),
-        res.uri,
-        (v: AppBskyGraphGetList.Response) => {
-          const list = v.data.list
-          return (
-            list.name === record.name && list.description === record.description
-          )
-        },
-      )
+      await whenAppViewReady(res.uri, (v: AppBskyGraphGetList.Response) => {
+        const list = v.data.list
+        return (
+          list.name === record.name && list.description === record.description
+        )
+      })
       return res
     },
     onSuccess(data, variables) {
@@ -216,13 +207,9 @@ export function useListDeleteMutation() {
       }
 
       // wait for the appview to update
-      await whenAppViewReady(
-        getAgent(),
-        uri,
-        (v: AppBskyGraphGetList.Response) => {
-          return !v?.success
-        },
-      )
+      await whenAppViewReady(uri, (v: AppBskyGraphGetList.Response) => {
+        return !v?.success
+      })
     },
     onSuccess() {
       invalidateMyLists(queryClient)
@@ -271,7 +258,6 @@ export function useListBlockMutation() {
 }
 
 async function whenAppViewReady(
-  agent: BskyAgent,
   uri: string,
   fn: (res: AppBskyGraphGetList.Response) => boolean,
 ) {
@@ -280,7 +266,7 @@ async function whenAppViewReady(
     1e3, // 1s delay between tries
     fn,
     () =>
-      agent.app.bsky.graph.getList({
+      getAgent().app.bsky.graph.getList({
         list: uri,
         limit: 1,
       }),

--- a/src/state/queries/notifications/feed.ts
+++ b/src/state/queries/notifications/feed.ts
@@ -4,7 +4,6 @@ import {
   AppBskyFeedRepost,
   AppBskyFeedLike,
   AppBskyNotificationListNotifications,
-  BskyAgent,
 } from '@atproto/api'
 import chunk from 'lodash.chunk'
 import {
@@ -84,7 +83,7 @@ export function useNotificationFeedQuery(opts?: {enabled?: boolean}) {
 
       // we fetch subjects of notifications (usually posts) now instead of lazily
       // in the UI to avoid relayouts
-      const subjects = await fetchSubjects(getAgent(), notifsGrouped)
+      const subjects = await fetchSubjects(notifsGrouped)
       for (const notif of notifsGrouped) {
         if (notif.subjectUri) {
           notif.subject = subjects.get(notif.subjectUri)
@@ -173,7 +172,6 @@ function groupNotifications(
 }
 
 async function fetchSubjects(
-  agent: BskyAgent,
   groupedNotifs: FeedNotification[],
 ): Promise<Map<string, AppBskyFeedDefs.PostView>> {
   const uris = new Set<string>()
@@ -185,7 +183,9 @@ async function fetchSubjects(
   const uriChunks = chunk(Array.from(uris), 25)
   const postsChunks = await Promise.all(
     uriChunks.map(uris =>
-      agent.app.bsky.feed.getPosts({uris}).then(res => res.data.posts),
+      getAgent()
+        .app.bsky.feed.getPosts({uris})
+        .then(res => res.data.posts),
     ),
   )
   const map = new Map<string, AppBskyFeedDefs.PostView>()

--- a/src/state/queries/notifications/unread.tsx
+++ b/src/state/queries/notifications/unread.tsx
@@ -70,12 +70,10 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
       },
 
       async checkUnread() {
-        const agent = getAgent()
-
-        if (!agent.session) return
+        if (!getAgent().session) return
 
         // count
-        const res = await agent.listNotifications({limit: 40})
+        const res = await getAgent().listNotifications({limit: 40})
         const filtered = res.data.notifications.filter(
           notif => !notif.isRead && !shouldFilterNotif(notif, moderationOpts),
         )

--- a/src/state/queries/post-feed.ts
+++ b/src/state/queries/post-feed.ts
@@ -7,7 +7,6 @@ import {
   QueryClient,
   useQueryClient,
 } from '@tanstack/react-query'
-import {getAgent, useSession} from '../session'
 import {useFeedTuners} from '../preferences/feed-tuners'
 import {FeedTuner, NoopFeedTuner} from 'lib/api/feed-manip'
 import {FeedAPI, ReasonFeedSource} from 'lib/api/feed/types'
@@ -77,33 +76,29 @@ export function usePostFeedQuery(
   const feedTuners = useFeedTuners(feedDesc)
   const enabled = opts?.enabled !== false
   const moderationOpts = useModerationOpts()
-  const {currentAccount} = useSession()
 
   const api: FeedAPI = useMemo(() => {
     if (feedDesc === 'home') {
-      return new MergeFeedAPI(getAgent(), params || {}, feedTuners)
+      return new MergeFeedAPI(params || {}, feedTuners)
     } else if (feedDesc === 'following') {
-      return new FollowingFeedAPI(getAgent())
+      return new FollowingFeedAPI()
     } else if (feedDesc.startsWith('author')) {
       const [_, actor, filter] = feedDesc.split('|')
-      return new AuthorFeedAPI(getAgent(), {actor, filter})
+      return new AuthorFeedAPI({actor, filter})
     } else if (feedDesc.startsWith('likes')) {
       const [_, actor] = feedDesc.split('|')
-      return new LikesFeedAPI(getAgent(), {actor})
+      return new LikesFeedAPI({actor})
     } else if (feedDesc.startsWith('feedgen')) {
       const [_, feed] = feedDesc.split('|')
-      return new CustomFeedAPI(getAgent(), {feed})
+      return new CustomFeedAPI({feed})
     } else if (feedDesc.startsWith('list')) {
       const [_, list] = feedDesc.split('|')
-      return new ListFeedAPI(getAgent(), {list})
+      return new ListFeedAPI({list})
     } else {
       // shouldnt happen
-      return new FollowingFeedAPI(getAgent())
+      return new FollowingFeedAPI()
     }
-    // NOTE: rule disabled so that `currentAccount.did` can trigger reruns
-    //       used as a proxy to changes with `getAgent()` -prf
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [feedDesc, params, feedTuners, currentAccount?.did])
+  }, [feedDesc, params, feedTuners])
 
   const disableTuner = !!params?.disableTuner
   const tuner = useMemo(

--- a/src/state/queries/post-feed.ts
+++ b/src/state/queries/post-feed.ts
@@ -7,7 +7,7 @@ import {
   QueryClient,
   useQueryClient,
 } from '@tanstack/react-query'
-import {getAgent} from '../session'
+import {getAgent, useSession} from '../session'
 import {useFeedTuners} from '../preferences/feed-tuners'
 import {FeedTuner, NoopFeedTuner} from 'lib/api/feed-manip'
 import {FeedAPI, ReasonFeedSource} from 'lib/api/feed/types'
@@ -77,30 +77,33 @@ export function usePostFeedQuery(
   const feedTuners = useFeedTuners(feedDesc)
   const enabled = opts?.enabled !== false
   const moderationOpts = useModerationOpts()
-  const agent = getAgent()
+  const {currentAccount} = useSession()
 
   const api: FeedAPI = useMemo(() => {
     if (feedDesc === 'home') {
-      return new MergeFeedAPI(agent, params || {}, feedTuners)
+      return new MergeFeedAPI(getAgent(), params || {}, feedTuners)
     } else if (feedDesc === 'following') {
-      return new FollowingFeedAPI(agent)
+      return new FollowingFeedAPI(getAgent())
     } else if (feedDesc.startsWith('author')) {
       const [_, actor, filter] = feedDesc.split('|')
-      return new AuthorFeedAPI(agent, {actor, filter})
+      return new AuthorFeedAPI(getAgent(), {actor, filter})
     } else if (feedDesc.startsWith('likes')) {
       const [_, actor] = feedDesc.split('|')
-      return new LikesFeedAPI(agent, {actor})
+      return new LikesFeedAPI(getAgent(), {actor})
     } else if (feedDesc.startsWith('feedgen')) {
       const [_, feed] = feedDesc.split('|')
-      return new CustomFeedAPI(agent, {feed})
+      return new CustomFeedAPI(getAgent(), {feed})
     } else if (feedDesc.startsWith('list')) {
       const [_, list] = feedDesc.split('|')
-      return new ListFeedAPI(agent, {list})
+      return new ListFeedAPI(getAgent(), {list})
     } else {
       // shouldnt happen
-      return new FollowingFeedAPI(agent)
+      return new FollowingFeedAPI(getAgent())
     }
-  }, [feedDesc, params, feedTuners, agent])
+    // NOTE: rule disabled so that `currentAccount.did` can trigger reruns
+    //       used as a proxy to changes with `getAgent()` -prf
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [feedDesc, params, feedTuners, currentAccount?.did])
 
   const disableTuner = !!params?.disableTuner
   const tuner = useMemo(

--- a/src/state/queries/profile.ts
+++ b/src/state/queries/profile.ts
@@ -4,7 +4,6 @@ import {
   AppBskyActorDefs,
   AppBskyActorProfile,
   AppBskyActorGetProfile,
-  BskyAgent,
 } from '@atproto/api'
 import {useQuery, useQueryClient, useMutation} from '@tanstack/react-query'
 import {Image as RNImage} from 'react-native-image-crop-picker'
@@ -68,7 +67,7 @@ export function useProfileUpdateMutation() {
         }
         return existing
       })
-      await whenAppViewReady(getAgent(), profile.did, res => {
+      await whenAppViewReady(profile.did, res => {
         if (typeof newUserAvatar !== 'undefined') {
           if (newUserAvatar === null && res.data.avatar) {
             // url hasnt cleared yet
@@ -464,7 +463,6 @@ function useProfileUnblockMutation() {
 }
 
 async function whenAppViewReady(
-  agent: BskyAgent,
   actor: string,
   fn: (res: AppBskyActorGetProfile.Response) => boolean,
 ) {
@@ -472,6 +470,6 @@ async function whenAppViewReady(
     5, // 5 tries
     1e3, // 1s delay between tries
     fn,
-    () => agent.app.bsky.actor.getProfile({actor}),
+    () => getAgent().app.bsky.actor.getProfile({actor}),
   )
 }

--- a/src/state/session/index.tsx
+++ b/src/state/session/index.tsx
@@ -13,6 +13,12 @@ import {useCloseAllActiveElements} from '#/state/util'
 
 let __globalAgent: BskyAgent = PUBLIC_BSKY_AGENT
 
+/**
+ * NOTE
+ * Never hold on to the object returned by this function.
+ * Call `getAgent()` at the time of invocation to ensure
+ * that you never have a stale agent.
+ */
 export function getAgent() {
   return __globalAgent
 }


### PR DESCRIPTION
The `getAgent()` is a global method that gives the current session's agent. We want to make sure to never hold onto its return value because that would enable stale agent usage. We've seen a few surprise "missing jwt" errors that suggest that stale agents are being used, so this PR gets a bit more rigorous about it.