### PR TITLE
Apply feed preferences (react-query refactor)

### DIFF
--- a/src/state/preferences/feed-tuners.tsx
+++ b/src/state/preferences/feed-tuners.tsx
@@ -2,9 +2,13 @@ import {useMemo} from 'react'
 import {FeedTuner} from '#/lib/api/feed-manip'
 import {FeedDescriptor} from '../queries/post-feed'
 import {useLanguagePrefs} from './languages'
+import {usePreferencesQuery} from '../queries/preferences'
+import {useSession} from '../session'
 
 export function useFeedTuners(feedDesc: FeedDescriptor) {
   const langPrefs = useLanguagePrefs()
+  const {data: preferences} = usePreferencesQuery()
+  const {currentAccount} = useSession()
 
   return useMemo(() => {
     if (feedDesc.startsWith('feedgen')) {
@@ -19,30 +23,30 @@ export function useFeedTuners(feedDesc: FeedDescriptor) {
     if (feedDesc === 'home' || feedDesc === 'following') {
       const feedTuners = []
 
-      if (false /*TODOthis.homeFeed.hideReposts*/) {
+      if (preferences?.feedViewPrefs.hideReposts) {
         feedTuners.push(FeedTuner.removeReposts)
       } else {
         feedTuners.push(FeedTuner.dedupReposts)
       }
 
-      if (true /*TODOthis.homeFeed.hideReplies*/) {
+      if (preferences?.feedViewPrefs.hideReplies) {
         feedTuners.push(FeedTuner.removeReplies)
-      } /* TODO else {
+      } else {
         feedTuners.push(
           FeedTuner.thresholdRepliesOnly({
-            userDid: this.rootStore.session.data?.did || '',
-            minLikes: this.homeFeed.hideRepliesByLikeCount,
-            followedOnly: !!this.homeFeed.hideRepliesByUnfollowed,
+            userDid: currentAccount?.did || '',
+            minLikes: preferences?.feedViewPrefs.hideRepliesByLikeCount || 0,
+            followedOnly: !!preferences?.feedViewPrefs.hideRepliesByUnfollowed,
           }),
         )
-      }*/
+      }
 
-      if (false /*TODOthis.homeFeed.hideQuotePosts*/) {
+      if (preferences?.feedViewPrefs.hideQuotePosts) {
         feedTuners.push(FeedTuner.removeQuotePosts)
       }
 
       return feedTuners
     }
     return []
-  }, [feedDesc, langPrefs])
+  }, [feedDesc, currentAccount, preferences, langPrefs])
 }

--- a/src/state/queries/post-thread.ts
+++ b/src/state/queries/post-thread.ts
@@ -8,10 +8,7 @@ import {useQuery, useQueryClient, QueryClient} from '@tanstack/react-query'
 import {getAgent} from '#/state/session'
 import {UsePreferencesQueryResponse} from '#/state/queries/preferences/types'
 import {STALE} from '#/state/queries'
-import {
-  findPostInQueryData as findPostInFeedQueryData,
-  FeedPostSliceItem,
-} from './post-feed'
+import {findPostInQueryData as findPostInFeedQueryData} from './post-feed'
 import {findPostInQueryData as findPostInNotifsQueryData} from './notifications/feed'
 import {precacheThreadPosts as precacheResolvedUris} from './resolve-uri'
 
@@ -93,7 +90,7 @@ export function usePostThreadQuery(uri: string | undefined) {
       {
         const item = findPostInFeedQueryData(queryClient, uri)
         if (item) {
-          return feedItemToPlaceholderThread(item)
+          return feedViewPostToPlaceholderThread(item)
         }
       }
       {
@@ -275,13 +272,15 @@ function threadNodeToPlaceholderThread(
   }
 }
 
-function feedItemToPlaceholderThread(item: FeedPostSliceItem): ThreadNode {
+function feedViewPostToPlaceholderThread(
+  item: AppBskyFeedDefs.FeedViewPost,
+): ThreadNode {
   return {
     type: 'post',
     _reactKey: item.post.uri,
     uri: item.post.uri,
     post: item.post,
-    record: item.record,
+    record: item.post.record as AppBskyFeedPost.Record, // validated in post-feed
     parent: undefined,
     replies: undefined,
     viewer: item.post.viewer,
@@ -291,7 +290,7 @@ function feedItemToPlaceholderThread(item: FeedPostSliceItem): ThreadNode {
       hasMore: false,
       showChildReplyLine: false,
       showParentReplyLine: false,
-      isParentLoading: !!item.record.reply,
+      isParentLoading: !!(item.post.record as AppBskyFeedPost.Record).reply,
       isChildLoading: !!item.post.replyCount,
     },
   }
@@ -305,7 +304,7 @@ function postViewToPlaceholderThread(
     _reactKey: post.uri,
     uri: post.uri,
     post: post,
-    record: post.record as AppBskyFeedPost.Record, // validate in notifs
+    record: post.record as AppBskyFeedPost.Record, // validated in notifs
     parent: undefined,
     replies: undefined,
     viewer: post.viewer,


### PR DESCRIPTION
- 20b3ff3d10183dbb87ef0f1ec85a348a5204d887 Updates the feed tuners hook to use preferences
- 4be86293c56d0ae79c0022fa1618332259e8bdd1 Moves the application of the feed tuner into the `select()` stage of react-query

It turns out that the `queryFn` closure does, in fact, go stale in some cases. Even more interestingly, values passed in through `meta` also go stale. Once the hook was implemented correctly, the updates just didn't pass into the hook. What's strange is that I've also seen the `queryFn` update its closure, so I haven't been able to suss out the behavior.

Interestingly, the `select` function _does_ get redefined on every call, and so it's quite a good place to handle these kinds of things. An added bonus is, this means a change to the preferences which modifies the feed tuners can apply immediately within the feed without a refetch.