### PR TITLE
Hide normal mute if muted by list, and invalidate profile query upon list mute

### DIFF
--- a/src/view/screens/Profile.tsx
+++ b/src/view/screens/Profile.tsx
@@ -50,13 +50,13 @@ export function ProfileScreen({route}: Props) {
     data: resolvedDid,
     error: resolveError,
     refetch: refetchDid,
-    isFetching: isFetchingDid,
+    isInitialLoading: isInitialLoadingDid,
   } = useResolveDidQuery(name)
   const {
     data: profile,
     error: profileError,
     refetch: refetchProfile,
-    isFetching: isFetchingProfile,
+    isInitialLoading: isInitialLoadingProfile,
   } = useProfileQuery({
     did: resolvedDid,
   })
@@ -69,7 +69,7 @@ export function ProfileScreen({route}: Props) {
     }
   }, [resolveError, refetchDid, refetchProfile])
 
-  if (isFetchingDid || isFetchingProfile || !moderationOpts) {
+  if (isInitialLoadingDid || isInitialLoadingProfile || !moderationOpts) {
     return (
       <CenteredView>
         <ProfileHeader


### PR DESCRIPTION
It's not perfect — we don't currently have a way to wait for list records to be commited to the repo, so we use a timeout — but it's a step in the right direction.

Also noticed a flicker when invalidating profile query that I fixed by only showing load state on a cold hit. Once cached (stale time is 5 min now), it just replaces data in background. See before, after:


https://github.com/bluesky-social/social-app/assets/4732330/2a5f49b4-c649-4c5f-a4c2-1ae4e062d273


https://github.com/bluesky-social/social-app/assets/4732330/50618d2b-03fc-4ffb-ab53-f1ded8fba43b

