### PR TITLE
Optimize pager rendering

### DIFF
--- a/src/view/com/pager/PagerWithHeader.tsx
+++ b/src/view/com/pager/PagerWithHeader.tsx
@@ -138,7 +138,9 @@ export const PagerWithHeader = React.forwardRef<PagerRef, PagerWithHeaderProps>(
       }
     }
 
-    const throttleTimeout = React.useRef(null)
+    const throttleTimeout = React.useRef<ReturnType<typeof setTimeout> | null>(
+      null,
+    )
     const queueThrottledOnScroll = useNonReactiveCallback(() => {
       if (!throttleTimeout.current) {
         throttleTimeout.current = setTimeout(() => {
@@ -228,7 +230,7 @@ let PagerTabBar = ({
   headerOnlyHeight: number
   isHeaderReady: boolean
   items: string[]
-  testID: string
+  testID?: string
   scrollY: SharedValue<number>
   renderHeader?: () => JSX.Element
   onHeaderOnlyLayout: (e: LayoutChangeEvent) => void

--- a/src/view/com/pager/PagerWithHeader.tsx
+++ b/src/view/com/pager/PagerWithHeader.tsx
@@ -148,7 +148,9 @@ export const PagerWithHeader = React.forwardRef<PagerRef, PagerWithHeaderProps>(
 
           const nextIsScrolledDown = scrollY.value > SCROLLED_DOWN_LIMIT
           if (isScrolledDown !== nextIsScrolledDown) {
-            setIsScrolledDown(nextIsScrolledDown)
+            React.startTransition(() => {
+              setIsScrolledDown(nextIsScrolledDown)
+            })
           }
         }, 80 /* Sync often enough you're unlikely to catch it unsynced */)
       }


### PR DESCRIPTION
Some misc perf improvements.

- Pull out the tabbar into its own component so we can memo it
- This also solves the animated style being recreated too often, causing header re-renders
- Adjust the other tabs' scroll views on a throttle instead of on every frame
- Pull out the usage of `isScrolling` out of `onScroll` to avoid invalidating `onScroll` when you scroll down
- Make `isScrolling` update non-blocking

We're still managing the header positioning with JS and it's laggy.

I'm not sure if we're gonna have to change the strategy there but at least it's an incremental improvement.

### Before (6x throttled)


https://github.com/bluesky-social/social-app/assets/810438/5ea2fc27-86df-40a3-a452-ba203863170e

### After (6x throttled)


https://github.com/bluesky-social/social-app/assets/810438/299925c1-ba48-4017-8ab0-cac023a60b11

