### PR TITLE
Hackfix to composer focus on web

### DIFF
--- a/src/view/com/composer/text-input/TextInput.web.tsx
+++ b/src/view/com/composer/text-input/TextInput.web.tsx
@@ -116,6 +116,16 @@ export const TextInput = React.forwardRef(function TextInputImpl(
       autofocus: 'end',
       editable: true,
       injectCSS: true,
+      onCreate({editor: editorProp}) {
+        // HACK
+        // the 'enter' animation sometimes causes autofocus to fail
+        // (see Composer.web.tsx in shell)
+        // so we wait 200ms (the anim is 150ms) and then focus manually
+        // -prf
+        setTimeout(() => {
+          editorProp.chain().focus('end').run()
+        }, 200)
+      },
       onUpdate({editor: editorProp}) {
         const json = editorProp.getJSON()
 


### PR DESCRIPTION
The 'enter' animation sometimes causes autofocus to fail (see Composer.web.tsx in shell) so we wait 200ms (the anim is 150ms) and then focus manually