### PR TITLE
Fix feeds tab bar layout shift

### DIFF
--- a/src/state/queries/feed.ts
+++ b/src/state/queries/feed.ts
@@ -14,7 +14,7 @@ import {
   AppBskyGraphDefs,
   AppBskyUnspeccedGetPopularFeedGenerators,
 } from '@atproto/api'
-
+// import {DEFAULT_LOGGED_OUT_PREFERENCES} from '#/state/queries/preferences/const'
 import {router} from '#/routes'
 import {sanitizeDisplayName} from '#/lib/strings/display-names'
 import {sanitizeHandle} from '#/lib/strings/handles'
@@ -248,7 +248,7 @@ const FOLLOWING_FEED_STUB: FeedSourceInfo = {
 
 export function usePinnedFeedsInfos(): {
   feeds: FeedSourceInfo[]
-  hasPinnedCustom: boolean
+  hasPinnedCustom: boolean | undefined
 } {
   const queryClient = useQueryClient()
   const [tabs, setTabs] = React.useState<FeedSourceInfo[]>([
@@ -256,9 +256,9 @@ export function usePinnedFeedsInfos(): {
   ])
   const {data: preferences} = usePreferencesQuery()
 
-  const hasPinnedCustom = React.useMemo<boolean>(() => {
-    return tabs.some(tab => tab !== FOLLOWING_FEED_STUB)
-  }, [tabs])
+  const [hasPinnedCustom, setHasPinnedCustom] = React.useState<
+    boolean | undefined
+  >(undefined)
 
   React.useEffect(() => {
     if (!preferences?.feeds?.pinned) return
@@ -302,10 +302,11 @@ export function usePinnedFeedsInfos(): {
       const views = await Promise.all(reqs)
 
       setTabs([FOLLOWING_FEED_STUB].concat(views))
+      setHasPinnedCustom(views.length > 0)
     }
 
     fetchFeedInfo()
-  }, [queryClient, setTabs, preferences?.feeds?.pinned])
+  }, [queryClient, setTabs, setHasPinnedCustom, preferences?.feeds?.pinned])
 
   return {feeds: tabs, hasPinnedCustom}
 }

--- a/src/state/queries/feed.ts
+++ b/src/state/queries/feed.ts
@@ -14,7 +14,6 @@ import {
   AppBskyGraphDefs,
   AppBskyUnspeccedGetPopularFeedGenerators,
 } from '@atproto/api'
-// import {DEFAULT_LOGGED_OUT_PREFERENCES} from '#/state/queries/preferences/const'
 import {router} from '#/routes'
 import {sanitizeDisplayName} from '#/lib/strings/display-names'
 import {sanitizeHandle} from '#/lib/strings/handles'

--- a/src/state/queries/preferences/const.ts
+++ b/src/state/queries/preferences/const.ts
@@ -20,11 +20,9 @@ export const DEFAULT_THREAD_VIEW_PREFS: ThreadViewPreferences = {
   lab_treeViewEnabled: false,
 }
 
-const DEFAULT_PROD_FEED_PREFIX = (rkey: string) =>
-  `at://did:plc:z72i7hdynmk6r22z27h6tvur/app.bsky.feed.generator/${rkey}`
 export const DEFAULT_PROD_FEEDS = {
-  pinned: [DEFAULT_PROD_FEED_PREFIX('whats-hot')],
-  saved: [DEFAULT_PROD_FEED_PREFIX('whats-hot')],
+  pinned: [],
+  saved: [],
 }
 
 export const DEFAULT_LOGGED_OUT_PREFERENCES: UsePreferencesQueryResponse = {

--- a/src/view/com/pager/FeedsTabBar.web.tsx
+++ b/src/view/com/pager/FeedsTabBar.web.tsx
@@ -89,7 +89,7 @@ function FeedsTabBarTablet(
   const {headerMinimalShellTransform} = useMinimalShellMode()
   const {headerHeight} = useShellLayout()
   const pinnedDisplayNames = hasSession ? feeds.map(f => f.displayName) : []
-  const showFeedsLinkInTabBar = hasSession && !hasPinnedCustom
+  const showFeedsLinkInTabBar = hasSession && hasPinnedCustom === false
   const items = showFeedsLinkInTabBar
     ? pinnedDisplayNames.concat('Feeds ✨')
     : pinnedDisplayNames

--- a/src/view/com/pager/FeedsTabBarMobile.tsx
+++ b/src/view/com/pager/FeedsTabBarMobile.tsx
@@ -35,7 +35,7 @@ export function FeedsTabBar(
   const {headerHeight} = useShellLayout()
   const {headerMinimalShellTransform} = useMinimalShellMode()
   const pinnedDisplayNames = hasSession ? feeds.map(f => f.displayName) : []
-  const showFeedsLinkInTabBar = hasSession && !hasPinnedCustom
+  const showFeedsLinkInTabBar = hasSession && hasPinnedCustom === false
   const items = showFeedsLinkInTabBar
     ? pinnedDisplayNames.concat('Feeds ✨')
     : pinnedDisplayNames


### PR DESCRIPTION
Related to issue #2061 - fixing some problems with #2033.

[c2bd86e](https://github.com/bluesky-social/social-app/pull/2063/commits/c2bd86eb61512aa0c98a3f66327a533c6b20d5ea): Make hasPinndCustom undefined until pinned feeds have been loaded and strictly check against it being false, so the Feeds ✨ button won't show until it is confirmed that the user has no pinned feeds or lists.

[041235e](https://github.com/bluesky-social/social-app/pull/2063/commits/041235e5d93e6f39f1e3dc6280da98a60f8a36f0): Removed what's-hot from being autopinned so this new button appears for new users. #2033 attempted to do this but deleted the defaults from the wrong file.

Video of the simulator before this change (look at the tab bar when it is loaded - you'll see a slight flash of "Feeds ✨" before the pinned feeds preferences loaded:
[todo]

Video after the change:
[todo]