### PR TITLE
Fix scroll jump on Back

### DIFF
--- a/src/view/com/pager/PagerWithHeader.tsx
+++ b/src/view/com/pager/PagerWithHeader.tsx
@@ -69,13 +69,19 @@ export const PagerWithHeader = React.forwardRef<PagerRef, PagerWithHeaderProps>(
     // capture the header bar sizing
     const onTabBarLayout = React.useCallback(
       (evt: LayoutChangeEvent) => {
-        setTabBarHeight(evt.nativeEvent.layout.height)
+        const height = evt.nativeEvent.layout.height
+        if (height > 0) {
+          setTabBarHeight(height)
+        }
       },
       [setTabBarHeight],
     )
     const onHeaderOnlyLayout = React.useCallback(
       (evt: LayoutChangeEvent) => {
-        setHeaderOnlyHeight(evt.nativeEvent.layout.height)
+        const height = evt.nativeEvent.layout.height
+        if (height > 0) {
+          setHeaderOnlyHeight(height)
+        }
       },
       [setHeaderOnlyHeight],
     )


### PR DESCRIPTION
When we push into the nav stack on the web, the previous page remains in the DOM. However, since the screen gets hidden, the layout re-fires with `0` as the height. We save that, which leads to destroying the feed (since we render it conditionally on non-zero height). Then, when we pop the stack, the layout would fire again with the real height, and we'd remount the feed. As a result, the feed's position gets out of sync with the header. The header is translated but the scroll got reset on remount.

There's a few things to think about here.

The simplest fix (which is what I'm doing here) is just to ignore `0` as height in layout events. It means the view is going offscreen and we don't really need to track that. So this naturally solves the issue. (We don't support zero height in this component, i.e. we already assume that both sections we measure have non-zero heights. So zero means offscreen.)

We could in principle also implement some kind of protection against the scroll target remounting. I.e. we could reset the header translation if the scroll target is destroyed and recreated. That would involve some more work though. I think I'd wait with that unless the need for it becomes apparent due to some other issue.

There's also a more general problem with this navigation approach. It's concerning that all navigated screens just stack up on the web. I.e. if I go from one profile to another to another and so on, all of that is accumulating in memory and in the DOM. I think we'd want to customize this and evict old ones. Or actually force them to delete their DOM content when they go offscreen and later restore the position. This requires more consideration so I'm not doing this for now.

## Test Plan

Verified the jump is solved in profile and lists on the web.

This also actually makes it maintain the scroll position (i.e. on pop, you land back where you pushed).

Does not affect native.