### PR TITLE
Move the alt text indicator off of the images

### DIFF
--- a/src/view/com/util/images/Gallery.tsx
+++ b/src/view/com/util/images/Gallery.tsx
@@ -1,6 +1,6 @@
 import {AppBskyEmbedImages} from '@atproto/api'
 import React, {ComponentProps, FC} from 'react'
-import {StyleSheet, Text, Pressable, View} from 'react-native'
+import {StyleSheet, Pressable, View} from 'react-native'
 import {Image} from 'expo-image'
 
 type EventFunction = (index: number) => void
@@ -42,13 +42,6 @@ export const GalleryItem: FC<GalleryItemProps> = ({
           accessibilityIgnoresInvertColors
         />
       </Pressable>
-      {image.alt === '' ? null : (
-        <View style={styles.altContainer}>
-          <Text style={styles.alt} accessible={false}>
-            ALT
-          </Text>
-        </View>
-      )}
     </View>
   )
 }
@@ -60,19 +53,5 @@ const styles = StyleSheet.create({
   image: {
     flex: 1,
     borderRadius: 4,
-  },
-  altContainer: {
-    backgroundColor: 'rgba(0, 0, 0, 0.75)',
-    borderRadius: 6,
-    paddingHorizontal: 6,
-    paddingVertical: 3,
-    position: 'absolute',
-    left: 8,
-    bottom: 8,
-  },
-  alt: {
-    color: 'white',
-    fontSize: 10,
-    fontWeight: 'bold',
   },
 })

--- a/src/view/com/util/post-embeds/index.tsx
+++ b/src/view/com/util/post-embeds/index.tsx
@@ -6,6 +6,7 @@ import {
   ViewStyle,
   Text,
   InteractionManager,
+  Pressable,
 } from 'react-native'
 import {Image} from 'expo-image'
 import {
@@ -122,18 +123,20 @@ export function PostEmbeds({
               dimensionsHint={aspectRatio}
               onPress={() => _openLightbox(0)}
               onPressIn={() => onPressIn(0)}
-              style={[
-                styles.singleImage,
-                isMobile && styles.singleImageMobile,
-              ]}>
-              {alt === '' ? null : (
-                <View style={styles.altContainer}>
-                  <Text style={styles.alt} accessible={false}>
+              style={[styles.singleImage, isMobile && styles.singleImageMobile]}
+            />
+            {alt === '' ? null : (
+              <View style={{flexDirection: 'row', marginTop: 4}}>
+                <Pressable
+                  style={[styles.altContainer, pal.viewLight]}
+                  accessibilityRole="button"
+                  onPress={() => _openLightbox(0)}>
+                  <Text style={[styles.alt, pal.textLight]} accessible={false}>
                     ALT
                   </Text>
-                </View>
-              )}
-            </AutoSizedImage>
+                </Pressable>
+              </View>
+            )}
           </View>
         )
       }
@@ -150,6 +153,18 @@ export function PostEmbeds({
                 : undefined
             }
           />
+          {embed.images.find(img => img.alt !== '') ? (
+            <View style={{flexDirection: 'row', marginTop: 4}}>
+              <Pressable
+                style={[styles.altContainer, pal.viewLight]}
+                accessibilityRole="button"
+                onPress={() => _openLightbox(0)}>
+                <Text style={[styles.alt, pal.textLight]} accessible={false}>
+                  ALT
+                </Text>
+              </Pressable>
+            </View>
+          ) : null}
         </View>
       )
     }
@@ -198,16 +213,11 @@ const styles = StyleSheet.create({
     marginTop: 4,
   },
   altContainer: {
-    backgroundColor: 'rgba(0, 0, 0, 0.75)',
-    borderRadius: 6,
+    borderRadius: 8,
     paddingHorizontal: 6,
     paddingVertical: 3,
-    position: 'absolute',
-    left: 6,
-    bottom: 6,
   },
   alt: {
-    color: 'white',
     fontSize: 10,
     fontWeight: 'bold',
   },


### PR DESCRIPTION
The "ALT" indicator has a bad habit of covering up parts of the image, which seems counter-productive. I tried a couple of other ways to do it, this is what I found. Thoughts?

|Grid|Single|
|-|-|
|![CleanShot 2023-12-02 at 17 46 39@2x](https://github.com/bluesky-social/social-app/assets/1270099/32b76552-cf8b-40e1-af9f-5c43d3dbd861)|![CleanShot 2023-12-02 at 17 46 25@2x](https://github.com/bluesky-social/social-app/assets/1270099/13c60b3b-bc49-448b-aaa8-b4ee7dba5149)|
