### PR TITLE
Tune treeview thread mode to have consistent spacing

### DIFF
--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -414,7 +414,7 @@ let PostThreadItemLoaded = ({
       </>
     )
   } else {
-    const isThreadedChild = treeView && depth > 1
+    const isThreadedChild = treeView && depth > 0
     return (
       <PostOuterWrapper
         post={post}
@@ -491,10 +491,10 @@ let PostThreadItemLoaded = ({
                 timestamp={post.indexedAt}
                 postHref={postHref}
                 showAvatar={isThreadedChild}
-                avatarSize={26}
+                avatarSize={20}
                 displayNameType="md-bold"
                 displayNameStyle={isThreadedChild && s.ml2}
-                style={isThreadedChild && s.mb5}
+                style={isThreadedChild && s.mb2}
               />
               <PostAlerts
                 moderation={moderation.content}
@@ -583,7 +583,7 @@ function PostOuterWrapper({
   const {isMobile} = useWebMediaQueries()
   const pal = usePalette('default')
   const styles = useStyles()
-  if (treeView && depth > 1) {
+  if (treeView && depth > 0) {
     return (
       <View
         style={[
@@ -592,9 +592,9 @@ function PostOuterWrapper({
           styles.cursor,
           {
             flexDirection: 'row',
-            paddingLeft: 20,
+            paddingLeft: depth === 1 ? 10 : 20,
             borderTopWidth: depth === 1 ? 1 : 0,
-            paddingTop: depth === 1 ? 8 : 0,
+            paddingTop: depth === 1 ? 6 : 0,
           },
         ]}>
         {Array.from(Array(depth - 1)).map((_, n: number) => (
@@ -603,8 +603,8 @@ function PostOuterWrapper({
             style={{
               borderLeftWidth: 2,
               borderLeftColor: pal.colors.border,
-              marginLeft: n === 0 ? 14 : isMobile ? 6 : 14,
-              paddingLeft: n === 0 ? 18 : isMobile ? 6 : 12,
+              marginLeft: isMobile ? 6 : 14,
+              paddingLeft: isMobile ? 6 : 12,
             }}
           />
         ))}


### PR DESCRIPTION
I'm a little torn about this one. It does two things:

- Changes all replies to be the "small header" form (where previously the first-level replies were "big header" form). This causes all the left-hand spacing to be consistent, fixing the most obnoxious issue.
- Shrinks the avi in the "small header" form, trading legibility of the avis for more consistent spacing.

![CleanShot 2023-12-03 at 09 18 56@2x](https://github.com/bluesky-social/social-app/assets/1270099/2e2aba74-3e2e-49fc-b5d2-87415e8b1430)

Comparison shots:

|Before|After|
|-|-|
|![Simulator Screenshot - iPhone 15 Pro - 2023-12-03 at 09 13 22](https://github.com/bluesky-social/social-app/assets/1270099/b652d3c0-f480-46db-a5d8-73c73c54f061)|![Simulator Screenshot - iPhone 15 Pro - 2023-12-03 at 09 11 05](https://github.com/bluesky-social/social-app/assets/1270099/a4f5c56c-fb0d-4dc3-86b9-339ccc19bb1b)|

|Before|After|
|-|-|
|![Simulator Screenshot - iPhone 15 Pro - 2023-12-03 at 09 12 40](https://github.com/bluesky-social/social-app/assets/1270099/70fff4db-7b0f-4295-9efa-4323e865ede3)|![Simulator Screenshot - iPhone 15 Pro - 2023-12-03 at 09 11 59](https://github.com/bluesky-social/social-app/assets/1270099/2906b9bb-2d1b-4040-b806-de0dba0ab98c)|
