### PR TITLE
Fix bottom space on feeds

### DIFF
--- a/src/locale/locales/cs/messages.po
+++ b/src/locale/locales/cs/messages.po
@@ -83,7 +83,7 @@ msgstr ""
 
 #: src/view/com/modals/ListAddRemoveUsers.tsx:264
 #: src/view/com/modals/UserAddRemoveLists.tsx:187
-#: src/view/screens/ProfileList.tsx:675
+#: src/view/screens/ProfileList.tsx:684
 msgid "Add"
 msgstr ""
 
@@ -91,7 +91,7 @@ msgstr ""
 msgid "Add a content warning"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:665
+#: src/view/screens/ProfileList.tsx:674
 msgid "Add a user to this list"
 msgstr ""
 
@@ -199,7 +199,7 @@ msgstr ""
 msgid "Are you sure you'd like to discard this draft?"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:345
+#: src/view/screens/ProfileList.tsx:352
 msgid "Are you sure?"
 msgstr ""
 
@@ -242,11 +242,11 @@ msgstr ""
 msgid "Block Account"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:446
+#: src/view/screens/ProfileList.tsx:453
 msgid "Block accounts"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:302
+#: src/view/screens/ProfileList.tsx:309
 msgid "Block these accounts?"
 msgstr ""
 
@@ -270,7 +270,7 @@ msgstr ""
 msgid "Blocked post."
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:304
+#: src/view/screens/ProfileList.tsx:311
 msgid "Blocking is public. Blocked accounts cannot reply in your threads, mention you, or otherwise interact with you."
 msgstr ""
 
@@ -531,7 +531,7 @@ msgstr ""
 msgid "Copy"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:375
+#: src/view/screens/ProfileList.tsx:382
 msgid "Copy link to list"
 msgstr ""
 
@@ -555,7 +555,7 @@ msgstr ""
 msgid "Could not load feed"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:752
+#: src/view/screens/ProfileList.tsx:761
 msgid "Could not load list"
 msgstr ""
 
@@ -601,8 +601,8 @@ msgstr ""
 msgid "Delete app password"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:344
-#: src/view/screens/ProfileList.tsx:402
+#: src/view/screens/ProfileList.tsx:351
+#: src/view/screens/ProfileList.tsx:409
 msgid "Delete List"
 msgstr ""
 
@@ -691,7 +691,7 @@ msgstr ""
 msgid "Edit image"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:390
+#: src/view/screens/ProfileList.tsx:397
 msgid "Edit list details"
 msgstr ""
 
@@ -737,6 +737,10 @@ msgstr ""
 
 #: src/view/screens/PreferencesHomeFeed.tsx:138
 msgid "Enable this setting to only see replies between people you follow."
+msgstr ""
+
+#: src/view/screens/Profile.tsx:454
+msgid "End of feed"
 msgstr ""
 
 #: src/view/com/auth/create/Step1.tsx:71
@@ -888,8 +892,8 @@ msgstr ""
 
 #: src/view/screens/ProfileFeed.tsx:111
 #: src/view/screens/ProfileFeed.tsx:116
-#: src/view/screens/ProfileList.tsx:761
-#: src/view/screens/ProfileList.tsx:766
+#: src/view/screens/ProfileList.tsx:770
+#: src/view/screens/ProfileList.tsx:775
 msgid "Go Back"
 msgstr ""
 
@@ -1074,7 +1078,7 @@ msgstr ""
 #~ msgid "Light"
 #~ msgstr ""
 
-#: src/view/screens/ProfileFeed.tsx:627
+#: src/view/screens/ProfileFeed.tsx:630
 msgid "Like this feed"
 msgstr ""
 
@@ -1122,7 +1126,7 @@ msgstr ""
 msgid "Login to account that is not listed"
 msgstr ""
 
-#: src/view/screens/ProfileFeed.tsx:479
+#: src/view/screens/ProfileFeed.tsx:480
 msgid "Looks like this feed is only available to users with a Bluesky account. Please sign up or sign in to view this feed!"
 msgstr ""
 
@@ -1152,7 +1156,7 @@ msgstr ""
 
 #: src/view/com/profile/ProfileHeader.tsx:520
 #: src/view/screens/ProfileFeed.tsx:369
-#: src/view/screens/ProfileList.tsx:506
+#: src/view/screens/ProfileList.tsx:513
 msgid "More options"
 msgstr ""
 
@@ -1164,11 +1168,11 @@ msgstr ""
 msgid "Mute Account"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:434
+#: src/view/screens/ProfileList.tsx:441
 msgid "Mute accounts"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:267
+#: src/view/screens/ProfileList.tsx:274
 msgid "Mute these accounts?"
 msgstr ""
 
@@ -1188,7 +1192,7 @@ msgstr ""
 msgid "Muted accounts have their posts removed from your feed and from your notifications. Mutes are completely private."
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:269
+#: src/view/screens/ProfileList.tsx:276
 msgid "Muting is private. Muted accounts can interact with you, but you will not see their posts or receive notifications from them."
 msgstr ""
 
@@ -1223,10 +1227,10 @@ msgstr ""
 
 #: src/view/com/feeds/FeedPage.tsx:188
 #: src/view/screens/Feeds.tsx:510
-#: src/view/screens/Profile.tsx:382
-#: src/view/screens/ProfileFeed.tsx:449
-#: src/view/screens/ProfileList.tsx:199
-#: src/view/screens/ProfileList.tsx:231
+#: src/view/screens/Profile.tsx:384
+#: src/view/screens/ProfileFeed.tsx:450
+#: src/view/screens/ProfileList.tsx:206
+#: src/view/screens/ProfileList.tsx:238
 #: src/view/shell/desktop/LeftNav.tsx:254
 msgid "New post"
 msgstr ""
@@ -1255,8 +1259,8 @@ msgstr ""
 msgid "No"
 msgstr ""
 
-#: src/view/screens/ProfileFeed.tsx:620
-#: src/view/screens/ProfileList.tsx:632
+#: src/view/screens/ProfileFeed.tsx:623
+#: src/view/screens/ProfileList.tsx:641
 msgid "No description"
 msgstr ""
 
@@ -1569,7 +1573,7 @@ msgstr ""
 msgid "Report feed"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:416
+#: src/view/screens/ProfileList.tsx:423
 msgid "Report List"
 msgstr ""
 
@@ -1782,7 +1786,7 @@ msgstr ""
 
 #: src/view/com/profile/ProfileHeader.tsx:312
 #: src/view/com/util/forms/PostDropdownBtn.tsx:126
-#: src/view/screens/ProfileList.tsx:375
+#: src/view/screens/ProfileList.tsx:382
 msgid "Share"
 msgstr ""
 
@@ -1899,11 +1903,11 @@ msgstr ""
 msgid "Storybook"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:497
+#: src/view/screens/ProfileList.tsx:504
 msgid "Subscribe"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:493
+#: src/view/screens/ProfileList.tsx:500
 msgid "Subscribe to this list"
 msgstr ""
 
@@ -2108,7 +2112,7 @@ msgstr ""
 msgid "Username or email address"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:659
+#: src/view/screens/ProfileList.tsx:668
 msgid "Users"
 msgstr ""
 

--- a/src/locale/locales/en/messages.po
+++ b/src/locale/locales/en/messages.po
@@ -83,7 +83,7 @@ msgstr ""
 
 #: src/view/com/modals/ListAddRemoveUsers.tsx:264
 #: src/view/com/modals/UserAddRemoveLists.tsx:187
-#: src/view/screens/ProfileList.tsx:675
+#: src/view/screens/ProfileList.tsx:684
 msgid "Add"
 msgstr ""
 
@@ -91,7 +91,7 @@ msgstr ""
 msgid "Add a content warning"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:665
+#: src/view/screens/ProfileList.tsx:674
 msgid "Add a user to this list"
 msgstr ""
 
@@ -199,7 +199,7 @@ msgstr ""
 msgid "Are you sure you'd like to discard this draft?"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:345
+#: src/view/screens/ProfileList.tsx:352
 msgid "Are you sure?"
 msgstr ""
 
@@ -242,11 +242,11 @@ msgstr ""
 msgid "Block Account"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:446
+#: src/view/screens/ProfileList.tsx:453
 msgid "Block accounts"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:302
+#: src/view/screens/ProfileList.tsx:309
 msgid "Block these accounts?"
 msgstr ""
 
@@ -270,7 +270,7 @@ msgstr ""
 msgid "Blocked post."
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:304
+#: src/view/screens/ProfileList.tsx:311
 msgid "Blocking is public. Blocked accounts cannot reply in your threads, mention you, or otherwise interact with you."
 msgstr ""
 
@@ -531,7 +531,7 @@ msgstr ""
 msgid "Copy"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:375
+#: src/view/screens/ProfileList.tsx:382
 msgid "Copy link to list"
 msgstr ""
 
@@ -555,7 +555,7 @@ msgstr ""
 msgid "Could not load feed"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:752
+#: src/view/screens/ProfileList.tsx:761
 msgid "Could not load list"
 msgstr ""
 
@@ -601,8 +601,8 @@ msgstr ""
 msgid "Delete app password"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:344
-#: src/view/screens/ProfileList.tsx:402
+#: src/view/screens/ProfileList.tsx:351
+#: src/view/screens/ProfileList.tsx:409
 msgid "Delete List"
 msgstr ""
 
@@ -691,7 +691,7 @@ msgstr ""
 msgid "Edit image"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:390
+#: src/view/screens/ProfileList.tsx:397
 msgid "Edit list details"
 msgstr ""
 
@@ -737,6 +737,10 @@ msgstr ""
 
 #: src/view/screens/PreferencesHomeFeed.tsx:138
 msgid "Enable this setting to only see replies between people you follow."
+msgstr ""
+
+#: src/view/screens/Profile.tsx:454
+msgid "End of feed"
 msgstr ""
 
 #: src/view/com/auth/create/Step1.tsx:71
@@ -888,8 +892,8 @@ msgstr ""
 
 #: src/view/screens/ProfileFeed.tsx:111
 #: src/view/screens/ProfileFeed.tsx:116
-#: src/view/screens/ProfileList.tsx:761
-#: src/view/screens/ProfileList.tsx:766
+#: src/view/screens/ProfileList.tsx:770
+#: src/view/screens/ProfileList.tsx:775
 msgid "Go Back"
 msgstr ""
 
@@ -1074,7 +1078,7 @@ msgstr ""
 #~ msgid "Light"
 #~ msgstr ""
 
-#: src/view/screens/ProfileFeed.tsx:627
+#: src/view/screens/ProfileFeed.tsx:630
 msgid "Like this feed"
 msgstr ""
 
@@ -1122,7 +1126,7 @@ msgstr ""
 msgid "Login to account that is not listed"
 msgstr ""
 
-#: src/view/screens/ProfileFeed.tsx:479
+#: src/view/screens/ProfileFeed.tsx:480
 msgid "Looks like this feed is only available to users with a Bluesky account. Please sign up or sign in to view this feed!"
 msgstr ""
 
@@ -1152,7 +1156,7 @@ msgstr ""
 
 #: src/view/com/profile/ProfileHeader.tsx:520
 #: src/view/screens/ProfileFeed.tsx:369
-#: src/view/screens/ProfileList.tsx:506
+#: src/view/screens/ProfileList.tsx:513
 msgid "More options"
 msgstr ""
 
@@ -1164,11 +1168,11 @@ msgstr ""
 msgid "Mute Account"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:434
+#: src/view/screens/ProfileList.tsx:441
 msgid "Mute accounts"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:267
+#: src/view/screens/ProfileList.tsx:274
 msgid "Mute these accounts?"
 msgstr ""
 
@@ -1188,7 +1192,7 @@ msgstr ""
 msgid "Muted accounts have their posts removed from your feed and from your notifications. Mutes are completely private."
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:269
+#: src/view/screens/ProfileList.tsx:276
 msgid "Muting is private. Muted accounts can interact with you, but you will not see their posts or receive notifications from them."
 msgstr ""
 
@@ -1223,10 +1227,10 @@ msgstr ""
 
 #: src/view/com/feeds/FeedPage.tsx:188
 #: src/view/screens/Feeds.tsx:510
-#: src/view/screens/Profile.tsx:382
-#: src/view/screens/ProfileFeed.tsx:449
-#: src/view/screens/ProfileList.tsx:199
-#: src/view/screens/ProfileList.tsx:231
+#: src/view/screens/Profile.tsx:384
+#: src/view/screens/ProfileFeed.tsx:450
+#: src/view/screens/ProfileList.tsx:206
+#: src/view/screens/ProfileList.tsx:238
 #: src/view/shell/desktop/LeftNav.tsx:254
 msgid "New post"
 msgstr ""
@@ -1255,8 +1259,8 @@ msgstr ""
 msgid "No"
 msgstr ""
 
-#: src/view/screens/ProfileFeed.tsx:620
-#: src/view/screens/ProfileList.tsx:632
+#: src/view/screens/ProfileFeed.tsx:623
+#: src/view/screens/ProfileList.tsx:641
 msgid "No description"
 msgstr ""
 
@@ -1569,7 +1573,7 @@ msgstr ""
 msgid "Report feed"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:416
+#: src/view/screens/ProfileList.tsx:423
 msgid "Report List"
 msgstr ""
 
@@ -1782,7 +1786,7 @@ msgstr ""
 
 #: src/view/com/profile/ProfileHeader.tsx:312
 #: src/view/com/util/forms/PostDropdownBtn.tsx:126
-#: src/view/screens/ProfileList.tsx:375
+#: src/view/screens/ProfileList.tsx:382
 msgid "Share"
 msgstr ""
 
@@ -1899,11 +1903,11 @@ msgstr ""
 msgid "Storybook"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:497
+#: src/view/screens/ProfileList.tsx:504
 msgid "Subscribe"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:493
+#: src/view/screens/ProfileList.tsx:500
 msgid "Subscribe to this list"
 msgstr ""
 
@@ -2108,7 +2112,7 @@ msgstr ""
 msgid "Username or email address"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:659
+#: src/view/screens/ProfileList.tsx:668
 msgid "Users"
 msgstr ""
 

--- a/src/locale/locales/es/messages.po
+++ b/src/locale/locales/es/messages.po
@@ -83,7 +83,7 @@ msgstr ""
 
 #: src/view/com/modals/ListAddRemoveUsers.tsx:264
 #: src/view/com/modals/UserAddRemoveLists.tsx:187
-#: src/view/screens/ProfileList.tsx:675
+#: src/view/screens/ProfileList.tsx:684
 msgid "Add"
 msgstr ""
 
@@ -91,7 +91,7 @@ msgstr ""
 msgid "Add a content warning"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:665
+#: src/view/screens/ProfileList.tsx:674
 msgid "Add a user to this list"
 msgstr ""
 
@@ -199,7 +199,7 @@ msgstr ""
 msgid "Are you sure you'd like to discard this draft?"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:345
+#: src/view/screens/ProfileList.tsx:352
 msgid "Are you sure?"
 msgstr ""
 
@@ -242,11 +242,11 @@ msgstr ""
 msgid "Block Account"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:446
+#: src/view/screens/ProfileList.tsx:453
 msgid "Block accounts"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:302
+#: src/view/screens/ProfileList.tsx:309
 msgid "Block these accounts?"
 msgstr ""
 
@@ -270,7 +270,7 @@ msgstr ""
 msgid "Blocked post."
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:304
+#: src/view/screens/ProfileList.tsx:311
 msgid "Blocking is public. Blocked accounts cannot reply in your threads, mention you, or otherwise interact with you."
 msgstr ""
 
@@ -531,7 +531,7 @@ msgstr ""
 msgid "Copy"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:375
+#: src/view/screens/ProfileList.tsx:382
 msgid "Copy link to list"
 msgstr ""
 
@@ -555,7 +555,7 @@ msgstr ""
 msgid "Could not load feed"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:752
+#: src/view/screens/ProfileList.tsx:761
 msgid "Could not load list"
 msgstr ""
 
@@ -601,8 +601,8 @@ msgstr ""
 msgid "Delete app password"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:344
-#: src/view/screens/ProfileList.tsx:402
+#: src/view/screens/ProfileList.tsx:351
+#: src/view/screens/ProfileList.tsx:409
 msgid "Delete List"
 msgstr ""
 
@@ -691,7 +691,7 @@ msgstr ""
 msgid "Edit image"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:390
+#: src/view/screens/ProfileList.tsx:397
 msgid "Edit list details"
 msgstr ""
 
@@ -737,6 +737,10 @@ msgstr ""
 
 #: src/view/screens/PreferencesHomeFeed.tsx:138
 msgid "Enable this setting to only see replies between people you follow."
+msgstr ""
+
+#: src/view/screens/Profile.tsx:454
+msgid "End of feed"
 msgstr ""
 
 #: src/view/com/auth/create/Step1.tsx:71
@@ -888,8 +892,8 @@ msgstr ""
 
 #: src/view/screens/ProfileFeed.tsx:111
 #: src/view/screens/ProfileFeed.tsx:116
-#: src/view/screens/ProfileList.tsx:761
-#: src/view/screens/ProfileList.tsx:766
+#: src/view/screens/ProfileList.tsx:770
+#: src/view/screens/ProfileList.tsx:775
 msgid "Go Back"
 msgstr ""
 
@@ -1074,7 +1078,7 @@ msgstr ""
 #~ msgid "Light"
 #~ msgstr ""
 
-#: src/view/screens/ProfileFeed.tsx:627
+#: src/view/screens/ProfileFeed.tsx:630
 msgid "Like this feed"
 msgstr ""
 
@@ -1122,7 +1126,7 @@ msgstr ""
 msgid "Login to account that is not listed"
 msgstr ""
 
-#: src/view/screens/ProfileFeed.tsx:479
+#: src/view/screens/ProfileFeed.tsx:480
 msgid "Looks like this feed is only available to users with a Bluesky account. Please sign up or sign in to view this feed!"
 msgstr ""
 
@@ -1152,7 +1156,7 @@ msgstr ""
 
 #: src/view/com/profile/ProfileHeader.tsx:520
 #: src/view/screens/ProfileFeed.tsx:369
-#: src/view/screens/ProfileList.tsx:506
+#: src/view/screens/ProfileList.tsx:513
 msgid "More options"
 msgstr ""
 
@@ -1164,11 +1168,11 @@ msgstr ""
 msgid "Mute Account"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:434
+#: src/view/screens/ProfileList.tsx:441
 msgid "Mute accounts"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:267
+#: src/view/screens/ProfileList.tsx:274
 msgid "Mute these accounts?"
 msgstr ""
 
@@ -1188,7 +1192,7 @@ msgstr ""
 msgid "Muted accounts have their posts removed from your feed and from your notifications. Mutes are completely private."
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:269
+#: src/view/screens/ProfileList.tsx:276
 msgid "Muting is private. Muted accounts can interact with you, but you will not see their posts or receive notifications from them."
 msgstr ""
 
@@ -1223,10 +1227,10 @@ msgstr ""
 
 #: src/view/com/feeds/FeedPage.tsx:188
 #: src/view/screens/Feeds.tsx:510
-#: src/view/screens/Profile.tsx:382
-#: src/view/screens/ProfileFeed.tsx:449
-#: src/view/screens/ProfileList.tsx:199
-#: src/view/screens/ProfileList.tsx:231
+#: src/view/screens/Profile.tsx:384
+#: src/view/screens/ProfileFeed.tsx:450
+#: src/view/screens/ProfileList.tsx:206
+#: src/view/screens/ProfileList.tsx:238
 #: src/view/shell/desktop/LeftNav.tsx:254
 msgid "New post"
 msgstr ""
@@ -1255,8 +1259,8 @@ msgstr ""
 msgid "No"
 msgstr ""
 
-#: src/view/screens/ProfileFeed.tsx:620
-#: src/view/screens/ProfileList.tsx:632
+#: src/view/screens/ProfileFeed.tsx:623
+#: src/view/screens/ProfileList.tsx:641
 msgid "No description"
 msgstr ""
 
@@ -1569,7 +1573,7 @@ msgstr ""
 msgid "Report feed"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:416
+#: src/view/screens/ProfileList.tsx:423
 msgid "Report List"
 msgstr ""
 
@@ -1782,7 +1786,7 @@ msgstr ""
 
 #: src/view/com/profile/ProfileHeader.tsx:312
 #: src/view/com/util/forms/PostDropdownBtn.tsx:126
-#: src/view/screens/ProfileList.tsx:375
+#: src/view/screens/ProfileList.tsx:382
 msgid "Share"
 msgstr ""
 
@@ -1899,11 +1903,11 @@ msgstr ""
 msgid "Storybook"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:497
+#: src/view/screens/ProfileList.tsx:504
 msgid "Subscribe"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:493
+#: src/view/screens/ProfileList.tsx:500
 msgid "Subscribe to this list"
 msgstr ""
 
@@ -2108,7 +2112,7 @@ msgstr ""
 msgid "Username or email address"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:659
+#: src/view/screens/ProfileList.tsx:668
 msgid "Users"
 msgstr ""
 

--- a/src/locale/locales/fr/messages.po
+++ b/src/locale/locales/fr/messages.po
@@ -83,7 +83,7 @@ msgstr ""
 
 #: src/view/com/modals/ListAddRemoveUsers.tsx:264
 #: src/view/com/modals/UserAddRemoveLists.tsx:187
-#: src/view/screens/ProfileList.tsx:675
+#: src/view/screens/ProfileList.tsx:684
 msgid "Add"
 msgstr ""
 
@@ -91,7 +91,7 @@ msgstr ""
 msgid "Add a content warning"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:665
+#: src/view/screens/ProfileList.tsx:674
 msgid "Add a user to this list"
 msgstr ""
 
@@ -199,7 +199,7 @@ msgstr ""
 msgid "Are you sure you'd like to discard this draft?"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:345
+#: src/view/screens/ProfileList.tsx:352
 msgid "Are you sure?"
 msgstr ""
 
@@ -242,11 +242,11 @@ msgstr ""
 msgid "Block Account"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:446
+#: src/view/screens/ProfileList.tsx:453
 msgid "Block accounts"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:302
+#: src/view/screens/ProfileList.tsx:309
 msgid "Block these accounts?"
 msgstr ""
 
@@ -270,7 +270,7 @@ msgstr ""
 msgid "Blocked post."
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:304
+#: src/view/screens/ProfileList.tsx:311
 msgid "Blocking is public. Blocked accounts cannot reply in your threads, mention you, or otherwise interact with you."
 msgstr ""
 
@@ -531,7 +531,7 @@ msgstr ""
 msgid "Copy"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:375
+#: src/view/screens/ProfileList.tsx:382
 msgid "Copy link to list"
 msgstr ""
 
@@ -555,7 +555,7 @@ msgstr ""
 msgid "Could not load feed"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:752
+#: src/view/screens/ProfileList.tsx:761
 msgid "Could not load list"
 msgstr ""
 
@@ -601,8 +601,8 @@ msgstr ""
 msgid "Delete app password"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:344
-#: src/view/screens/ProfileList.tsx:402
+#: src/view/screens/ProfileList.tsx:351
+#: src/view/screens/ProfileList.tsx:409
 msgid "Delete List"
 msgstr ""
 
@@ -691,7 +691,7 @@ msgstr ""
 msgid "Edit image"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:390
+#: src/view/screens/ProfileList.tsx:397
 msgid "Edit list details"
 msgstr ""
 
@@ -737,6 +737,10 @@ msgstr ""
 
 #: src/view/screens/PreferencesHomeFeed.tsx:138
 msgid "Enable this setting to only see replies between people you follow."
+msgstr ""
+
+#: src/view/screens/Profile.tsx:454
+msgid "End of feed"
 msgstr ""
 
 #: src/view/com/auth/create/Step1.tsx:71
@@ -888,8 +892,8 @@ msgstr ""
 
 #: src/view/screens/ProfileFeed.tsx:111
 #: src/view/screens/ProfileFeed.tsx:116
-#: src/view/screens/ProfileList.tsx:761
-#: src/view/screens/ProfileList.tsx:766
+#: src/view/screens/ProfileList.tsx:770
+#: src/view/screens/ProfileList.tsx:775
 msgid "Go Back"
 msgstr ""
 
@@ -1074,7 +1078,7 @@ msgstr ""
 #~ msgid "Light"
 #~ msgstr ""
 
-#: src/view/screens/ProfileFeed.tsx:627
+#: src/view/screens/ProfileFeed.tsx:630
 msgid "Like this feed"
 msgstr ""
 
@@ -1122,7 +1126,7 @@ msgstr ""
 msgid "Login to account that is not listed"
 msgstr ""
 
-#: src/view/screens/ProfileFeed.tsx:479
+#: src/view/screens/ProfileFeed.tsx:480
 msgid "Looks like this feed is only available to users with a Bluesky account. Please sign up or sign in to view this feed!"
 msgstr ""
 
@@ -1152,7 +1156,7 @@ msgstr ""
 
 #: src/view/com/profile/ProfileHeader.tsx:520
 #: src/view/screens/ProfileFeed.tsx:369
-#: src/view/screens/ProfileList.tsx:506
+#: src/view/screens/ProfileList.tsx:513
 msgid "More options"
 msgstr ""
 
@@ -1164,11 +1168,11 @@ msgstr ""
 msgid "Mute Account"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:434
+#: src/view/screens/ProfileList.tsx:441
 msgid "Mute accounts"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:267
+#: src/view/screens/ProfileList.tsx:274
 msgid "Mute these accounts?"
 msgstr ""
 
@@ -1188,7 +1192,7 @@ msgstr ""
 msgid "Muted accounts have their posts removed from your feed and from your notifications. Mutes are completely private."
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:269
+#: src/view/screens/ProfileList.tsx:276
 msgid "Muting is private. Muted accounts can interact with you, but you will not see their posts or receive notifications from them."
 msgstr ""
 
@@ -1223,10 +1227,10 @@ msgstr ""
 
 #: src/view/com/feeds/FeedPage.tsx:188
 #: src/view/screens/Feeds.tsx:510
-#: src/view/screens/Profile.tsx:382
-#: src/view/screens/ProfileFeed.tsx:449
-#: src/view/screens/ProfileList.tsx:199
-#: src/view/screens/ProfileList.tsx:231
+#: src/view/screens/Profile.tsx:384
+#: src/view/screens/ProfileFeed.tsx:450
+#: src/view/screens/ProfileList.tsx:206
+#: src/view/screens/ProfileList.tsx:238
 #: src/view/shell/desktop/LeftNav.tsx:254
 msgid "New post"
 msgstr ""
@@ -1255,8 +1259,8 @@ msgstr ""
 msgid "No"
 msgstr ""
 
-#: src/view/screens/ProfileFeed.tsx:620
-#: src/view/screens/ProfileList.tsx:632
+#: src/view/screens/ProfileFeed.tsx:623
+#: src/view/screens/ProfileList.tsx:641
 msgid "No description"
 msgstr ""
 
@@ -1569,7 +1573,7 @@ msgstr ""
 msgid "Report feed"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:416
+#: src/view/screens/ProfileList.tsx:423
 msgid "Report List"
 msgstr ""
 
@@ -1782,7 +1786,7 @@ msgstr ""
 
 #: src/view/com/profile/ProfileHeader.tsx:312
 #: src/view/com/util/forms/PostDropdownBtn.tsx:126
-#: src/view/screens/ProfileList.tsx:375
+#: src/view/screens/ProfileList.tsx:382
 msgid "Share"
 msgstr ""
 
@@ -1899,11 +1903,11 @@ msgstr ""
 msgid "Storybook"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:497
+#: src/view/screens/ProfileList.tsx:504
 msgid "Subscribe"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:493
+#: src/view/screens/ProfileList.tsx:500
 msgid "Subscribe to this list"
 msgstr ""
 
@@ -2108,7 +2112,7 @@ msgstr ""
 msgid "Username or email address"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:659
+#: src/view/screens/ProfileList.tsx:668
 msgid "Users"
 msgstr ""
 

--- a/src/locale/locales/hi/messages.po
+++ b/src/locale/locales/hi/messages.po
@@ -83,7 +83,7 @@ msgstr "अकाउंट के विकल्प"
 
 #: src/view/com/modals/ListAddRemoveUsers.tsx:264
 #: src/view/com/modals/UserAddRemoveLists.tsx:187
-#: src/view/screens/ProfileList.tsx:675
+#: src/view/screens/ProfileList.tsx:684
 msgid "Add"
 msgstr "ऐड करो"
 
@@ -91,7 +91,7 @@ msgstr "ऐड करो"
 msgid "Add a content warning"
 msgstr "सामग्री चेतावनी जोड़ें"
 
-#: src/view/screens/ProfileList.tsx:665
+#: src/view/screens/ProfileList.tsx:674
 msgid "Add a user to this list"
 msgstr "इस सूची में किसी को जोड़ें"
 
@@ -199,7 +199,7 @@ msgstr "क्या आप वाकई ऐप पासवर्ड \"{name}\"
 msgid "Are you sure you'd like to discard this draft?"
 msgstr "क्या आप वाकई इस ड्राफ्ट को हटाना करना चाहेंगे?"
 
-#: src/view/screens/ProfileList.tsx:345
+#: src/view/screens/ProfileList.tsx:352
 msgid "Are you sure?"
 msgstr "क्या आप वास्तव में इसे करना चाहते हैं?"
 
@@ -242,11 +242,11 @@ msgstr "जन्मदिन:"
 msgid "Block Account"
 msgstr "खाता ब्लॉक करें"
 
-#: src/view/screens/ProfileList.tsx:446
+#: src/view/screens/ProfileList.tsx:453
 msgid "Block accounts"
 msgstr "खाता ब्लॉक करें"
 
-#: src/view/screens/ProfileList.tsx:302
+#: src/view/screens/ProfileList.tsx:309
 msgid "Block these accounts?"
 msgstr "खाता ब्लॉक करें?"
 
@@ -270,7 +270,7 @@ msgstr "अवरुद्ध खाते आपके थ्रेड्स �
 msgid "Blocked post."
 msgstr "ब्लॉक पोस्ट।"
 
-#: src/view/screens/ProfileList.tsx:304
+#: src/view/screens/ProfileList.tsx:311
 msgid "Blocking is public. Blocked accounts cannot reply in your threads, mention you, or otherwise interact with you."
 msgstr "अवरोधन सार्वजनिक है. अवरुद्ध खाते आपके थ्रेड्स में उत्तर नहीं दे सकते, आपका उल्लेख नहीं कर सकते, या अन्यथा आपके साथ बातचीत नहीं कर सकते।"
 
@@ -527,7 +527,7 @@ msgstr "कॉपी कर ली"
 msgid "Copy"
 msgstr "कॉपी"
 
-#: src/view/screens/ProfileList.tsx:375
+#: src/view/screens/ProfileList.tsx:382
 msgid "Copy link to list"
 msgstr ""
 
@@ -551,7 +551,7 @@ msgstr "कॉपीराइट नीति"
 msgid "Could not load feed"
 msgstr "फ़ीड लोड नहीं कर सकता"
 
-#: src/view/screens/ProfileList.tsx:752
+#: src/view/screens/ProfileList.tsx:761
 msgid "Could not load list"
 msgstr "सूची लोड नहीं कर सकता"
 
@@ -597,8 +597,8 @@ msgstr "खाता हटाएं"
 msgid "Delete app password"
 msgstr "अप्प पासवर्ड हटाएं"
 
-#: src/view/screens/ProfileList.tsx:344
-#: src/view/screens/ProfileList.tsx:402
+#: src/view/screens/ProfileList.tsx:351
+#: src/view/screens/ProfileList.tsx:409
 msgid "Delete List"
 msgstr "सूची हटाएँ"
 
@@ -687,7 +687,7 @@ msgstr "प्रत्येक कोड एक बार काम करत�
 msgid "Edit image"
 msgstr "छवि संपादित करें"
 
-#: src/view/screens/ProfileList.tsx:390
+#: src/view/screens/ProfileList.tsx:397
 msgid "Edit list details"
 msgstr "सूची विवरण संपादित करें"
 
@@ -734,6 +734,10 @@ msgstr "ईमेल:"
 #: src/view/screens/PreferencesHomeFeed.tsx:138
 msgid "Enable this setting to only see replies between people you follow."
 msgstr "इस सेटिंग को केवल उन लोगों के बीच जवाब देखने में सक्षम करें जिन्हें आप फॉलो करते हैं।।"
+
+#: src/view/screens/Profile.tsx:454
+msgid "End of feed"
+msgstr ""
 
 #: src/view/com/auth/create/Step1.tsx:71
 msgid "Enter the address of your provider:"
@@ -880,8 +884,8 @@ msgstr "वापस जाओ"
 
 #: src/view/screens/ProfileFeed.tsx:111
 #: src/view/screens/ProfileFeed.tsx:116
-#: src/view/screens/ProfileList.tsx:761
-#: src/view/screens/ProfileList.tsx:766
+#: src/view/screens/ProfileList.tsx:770
+#: src/view/screens/ProfileList.tsx:775
 msgid "Go Back"
 msgstr "वापस जाओ"
 
@@ -1066,7 +1070,7 @@ msgstr "चित्र पुस्तकालय"
 #~ msgid "Light"
 #~ msgstr "लाइट मोड"
 
-#: src/view/screens/ProfileFeed.tsx:627
+#: src/view/screens/ProfileFeed.tsx:630
 msgid "Like this feed"
 msgstr "इस फ़ीड को लाइक करो"
 
@@ -1114,7 +1118,7 @@ msgstr "स्थानीय देव सर्वर"
 msgid "Login to account that is not listed"
 msgstr "उस खाते में लॉग इन करें जो सूचीबद्ध नहीं है"
 
-#: src/view/screens/ProfileFeed.tsx:479
+#: src/view/screens/ProfileFeed.tsx:480
 msgid "Looks like this feed is only available to users with a Bluesky account. Please sign up or sign in to view this feed!"
 msgstr ""
 
@@ -1144,7 +1148,7 @@ msgstr "अधिक फ़ीड"
 
 #: src/view/com/profile/ProfileHeader.tsx:520
 #: src/view/screens/ProfileFeed.tsx:369
-#: src/view/screens/ProfileList.tsx:506
+#: src/view/screens/ProfileList.tsx:513
 msgid "More options"
 msgstr "अधिक विकल्प"
 
@@ -1156,11 +1160,11 @@ msgstr "अधिक विकल्प"
 msgid "Mute Account"
 msgstr "खाता म्यूट करें"
 
-#: src/view/screens/ProfileList.tsx:434
+#: src/view/screens/ProfileList.tsx:441
 msgid "Mute accounts"
 msgstr "खातों को म्यूट करें"
 
-#: src/view/screens/ProfileList.tsx:267
+#: src/view/screens/ProfileList.tsx:274
 msgid "Mute these accounts?"
 msgstr "इन खातों को म्यूट करें?"
 
@@ -1180,7 +1184,7 @@ msgstr "म्यूट किए गए खाते"
 msgid "Muted accounts have their posts removed from your feed and from your notifications. Mutes are completely private."
 msgstr "म्यूट किए गए खातों की पोस्ट आपके फ़ीड और आपकी सूचनाओं से हटा दी जाती हैं। म्यूट पूरी तरह से निजी हैं."
 
-#: src/view/screens/ProfileList.tsx:269
+#: src/view/screens/ProfileList.tsx:276
 msgid "Muting is private. Muted accounts can interact with you, but you will not see their posts or receive notifications from them."
 msgstr "म्यूट करना निजी है. म्यूट किए गए खाते आपके साथ इंटरैक्ट कर सकते हैं, लेकिन आप उनकी पोस्ट नहीं देखेंगे या उनसे सूचनाएं प्राप्त नहीं करेंगे।"
 
@@ -1215,10 +1219,10 @@ msgstr "नया"
 
 #: src/view/com/feeds/FeedPage.tsx:188
 #: src/view/screens/Feeds.tsx:510
-#: src/view/screens/Profile.tsx:382
-#: src/view/screens/ProfileFeed.tsx:449
-#: src/view/screens/ProfileList.tsx:199
-#: src/view/screens/ProfileList.tsx:231
+#: src/view/screens/Profile.tsx:384
+#: src/view/screens/ProfileFeed.tsx:450
+#: src/view/screens/ProfileList.tsx:206
+#: src/view/screens/ProfileList.tsx:238
 #: src/view/shell/desktop/LeftNav.tsx:254
 msgid "New post"
 msgstr "नई पोस्ट"
@@ -1247,8 +1251,8 @@ msgstr "अगली फोटो"
 msgid "No"
 msgstr "नहीं"
 
-#: src/view/screens/ProfileFeed.tsx:620
-#: src/view/screens/ProfileList.tsx:632
+#: src/view/screens/ProfileFeed.tsx:623
+#: src/view/screens/ProfileList.tsx:641
 msgid "No description"
 msgstr "कोई विवरण नहीं"
 
@@ -1561,7 +1565,7 @@ msgstr "रिपोर्ट"
 msgid "Report feed"
 msgstr "रिपोर्ट फ़ीड"
 
-#: src/view/screens/ProfileList.tsx:416
+#: src/view/screens/ProfileList.tsx:423
 msgid "Report List"
 msgstr "रिपोर्ट सूची"
 
@@ -1774,7 +1778,7 @@ msgstr "यौन गतिविधि या कामुक नग्नत�
 
 #: src/view/com/profile/ProfileHeader.tsx:312
 #: src/view/com/util/forms/PostDropdownBtn.tsx:126
-#: src/view/screens/ProfileList.tsx:375
+#: src/view/screens/ProfileList.tsx:382
 msgid "Share"
 msgstr "शेयर"
 
@@ -1891,11 +1895,11 @@ msgstr "स्थिति पृष्ठ"
 msgid "Storybook"
 msgstr "Storybook"
 
-#: src/view/screens/ProfileList.tsx:497
+#: src/view/screens/ProfileList.tsx:504
 msgid "Subscribe"
 msgstr "सब्सक्राइब"
 
-#: src/view/screens/ProfileList.tsx:493
+#: src/view/screens/ProfileList.tsx:500
 msgid "Subscribe to this list"
 msgstr "इस सूची को सब्सक्राइब करें"
 
@@ -2100,7 +2104,7 @@ msgstr "लोग सूचियाँ"
 msgid "Username or email address"
 msgstr "यूजर नाम या ईमेल पता"
 
-#: src/view/screens/ProfileList.tsx:659
+#: src/view/screens/ProfileList.tsx:668
 msgid "Users"
 msgstr "यूजर लोग"
 

--- a/src/view/com/posts/Feed.tsx
+++ b/src/view/com/posts/Feed.tsx
@@ -216,19 +216,25 @@ let Feed = ({
 
   const shouldRenderEndOfFeed =
     !hasNextPage && !isEmpty && !isFetching && !isError && !!renderEndOfFeed
-  const FeedFooter = React.useCallback(
-    () =>
-      isFetchingNextPage ? (
-        <View style={styles.feedFooter}>
-          <ActivityIndicator />
-        </View>
-      ) : shouldRenderEndOfFeed ? (
-        renderEndOfFeed()
-      ) : (
-        <View />
-      ),
-    [isFetchingNextPage, shouldRenderEndOfFeed, renderEndOfFeed],
-  )
+  const FeedFooter = React.useCallback(() => {
+    /**
+     * A bit of padding at the bottom of the feed as you scroll and when you
+     * reach the end, so that content isn't cut off by the bottom of the
+     * screen.
+     */
+    const offset = headerOffset * 2
+
+    return isFetchingNextPage ? (
+      <View style={styles.feedFooter}>
+        <ActivityIndicator />
+        <View style={{minHeight: offset}} />
+      </View>
+    ) : shouldRenderEndOfFeed ? (
+      <View style={{minHeight: offset}}>{renderEndOfFeed()}</View>
+    ) : (
+      <View style={{minHeight: offset}} />
+    )
+  }, [isFetchingNextPage, shouldRenderEndOfFeed, renderEndOfFeed, headerOffset])
 
   const scrollHandler = useAnimatedScrollHandler(onScroll || {})
   return (

--- a/src/view/com/posts/Feed.tsx
+++ b/src/view/com/posts/Feed.tsx
@@ -26,6 +26,7 @@ import {
   pollLatest,
 } from '#/state/queries/post-feed'
 import {useModerationOpts} from '#/state/queries/preferences'
+import {isWeb} from '#/platform/detection'
 
 const LOADING_ITEM = {_reactKey: '__loading__'}
 const EMPTY_FEED_ITEM = {_reactKey: '__empty__'}
@@ -222,17 +223,17 @@ let Feed = ({
      * reach the end, so that content isn't cut off by the bottom of the
      * screen.
      */
-    const offset = headerOffset * 2
+    const offset = Math.max(headerOffset, 32) * (isWeb ? 1 : 2)
 
     return isFetchingNextPage ? (
-      <View style={styles.feedFooter}>
+      <View style={[styles.feedFooter]}>
         <ActivityIndicator />
-        <View style={{minHeight: offset}} />
+        <View style={{height: offset}} />
       </View>
     ) : shouldRenderEndOfFeed ? (
       <View style={{minHeight: offset}}>{renderEndOfFeed()}</View>
     ) : (
-      <View style={{minHeight: offset}} />
+      <View style={{height: offset}} />
     )
   }, [isFetchingNextPage, shouldRenderEndOfFeed, renderEndOfFeed, headerOffset])
 

--- a/src/view/com/posts/FollowingEndOfFeed.tsx
+++ b/src/view/com/posts/FollowingEndOfFeed.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import {StyleSheet, View} from 'react-native'
+import {StyleSheet, View, Dimensions} from 'react-native'
 import {useNavigation} from '@react-navigation/native'
 import {
   FontAwesomeIcon,
@@ -36,7 +36,12 @@ export function FollowingEndOfFeed() {
   }, [navigation])
 
   return (
-    <View style={[styles.container, pal.border]}>
+    <View
+      style={[
+        styles.container,
+        pal.border,
+        {minHeight: Dimensions.get('window').height * 0.75},
+      ]}>
       <View style={styles.inner}>
         <Text type="xl-medium" style={[s.textCenter, pal.text]}>
           You've reached the end of your feed! Find some more accounts to

--- a/src/view/screens/Profile.tsx
+++ b/src/view/screens/Profile.tsx
@@ -36,6 +36,8 @@ import {useQueryClient} from '@tanstack/react-query'
 import {useComposerControls} from '#/state/shell/composer'
 import {listenSoftReset} from '#/state/events'
 import {truncateAndInvalidate} from '#/state/queries/util'
+import {Text} from '#/view/com/util/text/Text'
+import {usePalette} from 'lib/hooks/usePalette'
 
 interface SectionRef {
   scrollToTop: () => void
@@ -429,6 +431,7 @@ const FeedSection = React.forwardRef<SectionRef, FeedSectionProps>(
           scrollEventThrottle={1}
           renderEmptyState={renderPostsEmpty}
           headerOffset={headerHeight}
+          renderEndOfFeed={ProfileEndOfFeed}
         />
         {(isScrolledDown || hasNew) && (
           <LoadLatestBtn
@@ -441,6 +444,18 @@ const FeedSection = React.forwardRef<SectionRef, FeedSectionProps>(
     )
   },
 )
+
+function ProfileEndOfFeed() {
+  const pal = usePalette('default')
+
+  return (
+    <View style={[pal.border, {paddingTop: 32, borderTopWidth: 1}]}>
+      <Text style={[pal.textLight, pal.border, {textAlign: 'center'}]}>
+        End of feed
+      </Text>
+    </View>
+  )
+}
 
 const styles = StyleSheet.create({
   container: {

--- a/src/view/screens/Profile.tsx
+++ b/src/view/screens/Profile.tsx
@@ -2,7 +2,7 @@ import React, {useMemo} from 'react'
 import {StyleSheet, View} from 'react-native'
 import {useFocusEffect} from '@react-navigation/native'
 import {AppBskyActorDefs, moderateProfile, ModerationOpts} from '@atproto/api'
-import {msg} from '@lingui/macro'
+import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 import {NativeStackScreenProps, CommonNavigatorParams} from 'lib/routes/types'
 import {CenteredView, FlatList} from '../com/util/Views'
@@ -451,7 +451,7 @@ function ProfileEndOfFeed() {
   return (
     <View style={[pal.border, {paddingTop: 32, borderTopWidth: 1}]}>
       <Text style={[pal.textLight, pal.border, {textAlign: 'center'}]}>
-        End of feed
+        <Trans>End of feed</Trans>
       </Text>
     </View>
   )


### PR DESCRIPTION
This is what the end of a profile feed looked like (test with `test.esb.lol`):
<img width="549" alt="Screenshot 2023-12-04 at 9 45 38 AM" src="https://github.com/bluesky-social/social-app/assets/4732330/bc353882-f82a-4773-9ec9-de9eb08d964c">

So I added a spacer:
<img width="549" alt="Screenshot 2023-12-04 at 9 45 44 AM" src="https://github.com/bluesky-social/social-app/assets/4732330/2ef80154-d35d-4a11-9a54-8cf7c3479faa">

And then figured we might as well tell the user what's up:
<img width="549" alt="Screenshot 2023-12-04 at 9 44 38 AM" src="https://github.com/bluesky-social/social-app/assets/4732330/2e791afa-fedc-41d7-af4d-5e3d52c6da8a">

While scrolling, I noticed the loader was cut off, and you couldn't even see if before. Now looks like this (had to cut my internet to get this shot, hence no images):
<img width="549" alt="Screenshot 2023-12-04 at 9 52 28 AM" src="https://github.com/bluesky-social/social-app/assets/4732330/88898596-eb71-4b4c-b4dc-6254a3af17eb">

And also noticed that the empty state at the bottom of following feed looked like this:
<img width="549" alt="Screenshot 2023-12-04 at 9 40 03 AM" src="https://github.com/bluesky-social/social-app/assets/4732330/8a9d4742-1498-4059-a52f-64cfcddcd9f3">

So I also added some min-spacing to that:
<img width="549" alt="Screenshot 2023-12-04 at 9 48 21 AM" src="https://github.com/bluesky-social/social-app/assets/4732330/0e13be2b-c241-42c5-a0fa-ac8a8ba9e04c">
