### PR TITLE
Optimistically update the pager tab bar on swipe

### DIFF
--- a/src/view/com/pager/Pager.tsx
+++ b/src/view/com/pager/Pager.tsx
@@ -81,12 +81,14 @@ export const Pager = forwardRef<PagerRef, React.PropsWithChildren<Props>>(
         if (scrollState.current === 'settling') {
           if (lastDirection.current === -1 && offset < lastOffset.current) {
             onPageSelecting?.(position)
+            setSelectedPage(position)
             lastDirection.current = 0
           } else if (
             lastDirection.current === 1 &&
             offset > lastOffset.current
           ) {
             onPageSelecting?.(position + 1)
+            setSelectedPage(position + 1)
             lastDirection.current = 0
           }
         } else {


### PR DESCRIPTION
Uses the `onPageSelecting` logic to update the tab bar UI faster. 

# Before

https://github.com/bluesky-social/social-app/assets/1270099/71848c39-8510-4243-82ab-4f20f788b9a6

# After

https://github.com/bluesky-social/social-app/assets/1270099/1ccb941f-ea8a-4fa1-810b-dc715fb8879a


