### PR TITLE
Update feeds on post created

### DIFF
--- a/src/state/events.ts
+++ b/src/state/events.ts
@@ -36,3 +36,11 @@ export function listenSessionDropped(fn: () => void): UnlistenFn {
   emitter.on('session-dropped', fn)
   return () => emitter.off('session-dropped', fn)
 }
+
+export function emitPostCreated() {
+  emitter.emit('post-created')
+}
+export function listenPostCreated(fn: () => void): UnlistenFn {
+  emitter.on('post-created', fn)
+  return () => emitter.off('post-created', fn)
+}

--- a/src/state/queries/post-feed.ts
+++ b/src/state/queries/post-feed.ts
@@ -248,7 +248,7 @@ export function findPostInQueryData(
 export function* findAllPostsInQueryData(
   queryClient: QueryClient,
   uri: string,
-): Generator<AppBskyFeedDefs.PostView, void> {
+): Generator<AppBskyFeedDefs.PostView, undefined> {
   const queryDatas = queryClient.getQueriesData<
     InfiniteData<FeedPageUnselected>
   >({


### PR DESCRIPTION
This one is a little tricky

- After post, have to wait for appview to update
- In feed, only invalidate the cache _if_ just one page of data is loaded. This is really to act as a proxy to a UI issue that react-native can have with flatlists; if the user is scrolled far down, prepending data can cause the scroll position to begin vacillating wildly. Of course, RN doesn't give us a way to just get the scroll position, so this will have to do.