### PR TITLE
Add back ignore-filters-for behaviors

### DIFF
--- a/src/view/com/posts/Feed.tsx
+++ b/src/view/com/posts/Feed.tsx
@@ -36,6 +36,7 @@ const LOAD_MORE_ERROR_ITEM = {_reactKey: '__load_more_error__'}
 let Feed = ({
   feed,
   feedParams,
+  ignoreFilterFor,
   style,
   enabled,
   pollInterval,
@@ -53,6 +54,7 @@ let Feed = ({
 }: {
   feed: FeedDescriptor
   feedParams?: FeedParams
+  ignoreFilterFor?: string
   style?: StyleProp<ViewStyle>
   enabled?: boolean
   pollInterval?: number
@@ -202,6 +204,7 @@ let Feed = ({
           slice={item}
           // we check for this before creating the feedItems array
           moderationOpts={moderationOpts!}
+          ignoreFilterFor={ignoreFilterFor}
         />
       )
     },
@@ -212,6 +215,7 @@ let Feed = ({
       onPressRetryLoadMore,
       renderEmptyState,
       moderationOpts,
+      ignoreFilterFor,
     ],
   )
 

--- a/src/view/screens/Profile.tsx
+++ b/src/view/screens/Profile.tsx
@@ -287,6 +287,7 @@ function ProfileScreenLoaded({
             scrollElRef={
               scrollElRef as React.MutableRefObject<FlatList<any> | null>
             }
+            ignoreFilterFor={profile.did}
           />
         )}
         {showRepliesTab
@@ -307,6 +308,7 @@ function ProfileScreenLoaded({
                 scrollElRef={
                   scrollElRef as React.MutableRefObject<FlatList<any> | null>
                 }
+                ignoreFilterFor={profile.did}
               />
             )
           : null}
@@ -321,6 +323,7 @@ function ProfileScreenLoaded({
             scrollElRef={
               scrollElRef as React.MutableRefObject<FlatList<any> | null>
             }
+            ignoreFilterFor={profile.did}
           />
         )}
         {showLikesTab
@@ -341,6 +344,7 @@ function ProfileScreenLoaded({
                 scrollElRef={
                   scrollElRef as React.MutableRefObject<FlatList<any> | null>
                 }
+                ignoreFilterFor={profile.did}
               />
             )
           : null}
@@ -396,10 +400,19 @@ interface FeedSectionProps {
   isFocused: boolean
   isScrolledDown: boolean
   scrollElRef: React.MutableRefObject<FlatList<any> | null>
+  ignoreFilterFor?: string
 }
 const FeedSection = React.forwardRef<SectionRef, FeedSectionProps>(
   function FeedSectionImpl(
-    {feed, onScroll, headerHeight, isFocused, isScrolledDown, scrollElRef},
+    {
+      feed,
+      onScroll,
+      headerHeight,
+      isFocused,
+      isScrolledDown,
+      scrollElRef,
+      ignoreFilterFor,
+    },
     ref,
   ) {
     const queryClient = useQueryClient()
@@ -432,6 +445,7 @@ const FeedSection = React.forwardRef<SectionRef, FeedSectionProps>(
           renderEmptyState={renderPostsEmpty}
           headerOffset={headerHeight}
           renderEndOfFeed={ProfileEndOfFeed}
+          ignoreFilterFor={ignoreFilterFor}
         />
         {(isScrolledDown || hasNew) && (
           <LoadLatestBtn


### PR DESCRIPTION
This is an override that allows you to look at somebody's posts in their profile, eg if you've muted them. Confirmed the logic carried over from before the refactor.