### PR TITLE
Fix: correctly partial-match when calling truncateAndInvalidate()

### DIFF
--- a/src/state/queries/util.ts
+++ b/src/state/queries/util.ts
@@ -2,9 +2,9 @@ import {QueryClient, QueryKey, InfiniteData} from '@tanstack/react-query'
 
 export function truncateAndInvalidate<T = any>(
   queryClient: QueryClient,
-  querykey: QueryKey,
+  queryKey: QueryKey,
 ) {
-  queryClient.setQueryData<InfiniteData<T>>(querykey, data => {
+  queryClient.setQueriesData<InfiniteData<T>>({queryKey}, data => {
     if (data) {
       return {
         pageParams: data.pageParams.slice(0, 1),
@@ -13,5 +13,5 @@ export function truncateAndInvalidate<T = any>(
     }
     return data
   })
-  queryClient.invalidateQueries({queryKey: querykey})
+  queryClient.invalidateQueries({queryKey})
 }


### PR DESCRIPTION
It turns out that `setQueryData` relies on an exact match for the react-key but `setQueriesData` can do partial matches (which sort of makes sense). This meant that the post feeds were still fetching all subsequent pages -- not truncating.