### PR TITLE
Fix self-threads filter logic

### DIFF
--- a/src/lib/api/feed/author.ts
+++ b/src/lib/api/feed/author.ts
@@ -60,13 +60,13 @@ function isAuthorReplyChain(
   posts: AppBskyFeedDefs.FeedViewPost[],
 ): boolean {
   // current post is by a different user (shouldn't happen)
-  if (post.post.author.handle !== actor) return false
+  if (post.post.author.did !== actor) return false
 
   const replyParent = post.reply?.parent
 
   if (AppBskyFeedDefs.isPostView(replyParent)) {
     // reply parent is by a different user
-    if (replyParent.author.handle !== actor) return false
+    if (replyParent.author.did !== actor) return false
 
     // A top-level post that matches the parent of the current post.
     const parentPost = posts.find(p => p.post.uri === replyParent.uri)


### PR DESCRIPTION
Builds on #1757 but updates to use `did` instead of `handle` since that's what we're passing into this query now. Tested with [the up-to-date backend PR](https://github.com/bluesky-social/atproto/pull/1776) 👍 