### PR TITLE
More treeview UI tweaks

### DIFF
--- a/src/view/com/post-thread/PostThread.tsx
+++ b/src/view/com/post-thread/PostThread.tsx
@@ -280,6 +280,9 @@ function PostThreadLoaded({
         const prev = isThreadPost(posts[index - 1])
           ? (posts[index - 1] as ThreadPost)
           : undefined
+        const next = isThreadPost(posts[index - 1])
+          ? (posts[index - 1] as ThreadPost)
+          : undefined
         return (
           <View
             ref={item.ctx.isHighlightedPost ? highlightedPostRef : undefined}>
@@ -288,6 +291,8 @@ function PostThreadLoaded({
               record={item.record}
               treeView={threadViewPrefs.lab_treeViewEnabled || false}
               depth={item.ctx.depth}
+              prevPost={prev}
+              nextPost={next}
               isHighlightedPost={item.ctx.isHighlightedPost}
               hasMore={item.ctx.hasMore}
               showChildReplyLine={item.ctx.showChildReplyLine}

--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -249,7 +249,7 @@ let PostThreadItemLoaded = ({
           <View style={styles.layout}>
             <View style={[styles.layoutAvi, {paddingBottom: 8}]}>
               <PreviewableUserAvatar
-                size={52}
+                size={42}
                 did={post.author.did}
                 handle={post.author.handle}
                 avatar={post.author.avatar}
@@ -718,7 +718,7 @@ const useStyles = () => {
       paddingBottom: 2,
     },
     metaExpandedLine1: {
-      paddingTop: 5,
+      paddingTop: 0,
       paddingBottom: 0,
     },
     metaItem: {

--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -41,12 +41,15 @@ import {useLanguagePrefs} from '#/state/preferences'
 import {useComposerControls} from '#/state/shell/composer'
 import {useModerationOpts} from '#/state/queries/preferences'
 import {Shadow, usePostShadow, POST_TOMBSTONE} from '#/state/cache/post-shadow'
+import {ThreadPost} from '#/state/queries/post-thread'
 
 export function PostThreadItem({
   post,
   record,
   treeView,
   depth,
+  prevPost,
+  nextPost,
   isHighlightedPost,
   hasMore,
   showChildReplyLine,
@@ -58,6 +61,8 @@ export function PostThreadItem({
   record: AppBskyFeedPost.Record
   treeView: boolean
   depth: number
+  prevPost: ThreadPost | undefined
+  nextPost: ThreadPost | undefined
   isHighlightedPost?: boolean
   hasMore?: boolean
   showChildReplyLine?: boolean
@@ -87,6 +92,8 @@ export function PostThreadItem({
     return (
       <PostThreadItemLoaded
         post={postShadowed}
+        prevPost={prevPost}
+        nextPost={nextPost}
         record={record}
         richText={richText}
         moderation={moderation}
@@ -124,6 +131,8 @@ let PostThreadItemLoaded = ({
   moderation,
   treeView,
   depth,
+  prevPost,
+  nextPost,
   isHighlightedPost,
   hasMore,
   showChildReplyLine,
@@ -137,6 +146,8 @@ let PostThreadItemLoaded = ({
   moderation: PostModeration
   treeView: boolean
   depth: number
+  prevPost: ThreadPost | undefined
+  nextPost: ThreadPost | undefined
   isHighlightedPost?: boolean
   hasMore?: boolean
   showChildReplyLine?: boolean
@@ -418,9 +429,14 @@ let PostThreadItemLoaded = ({
     )
   } else {
     const isThreadedChild = treeView && depth > 0
+    const isThreadedChildAdjacentTop =
+      isThreadedChild && prevPost?.ctx.depth === depth
+    const isThreadedChildAdjacentBot =
+      isThreadedChild && nextPost?.ctx.depth === depth
     return (
       <PostOuterWrapper
         post={post}
+        prevPost={prevPost}
         depth={depth}
         showParentReplyLine={!!showParentReplyLine}
         treeView={treeView}
@@ -441,7 +457,7 @@ let PostThreadItemLoaded = ({
               flexDirection: 'row',
               gap: 10,
               paddingLeft: 8,
-              height: isThreadedChild ? 8 : 16,
+              height: isThreadedChildAdjacentTop ? 8 : 16,
             }}>
             <View style={{width: 38}}>
               {!isThreadedChild && showParentReplyLine && (
@@ -463,7 +479,12 @@ let PostThreadItemLoaded = ({
             style={[
               styles.layout,
               {
-                paddingBottom: showChildReplyLine && !isThreadedChild ? 0 : 8,
+                paddingBottom:
+                  showChildReplyLine && !isThreadedChild
+                    ? 0
+                    : isThreadedChildAdjacentBot
+                    ? 4
+                    : 8,
               },
             ]}>
             {!isThreadedChild && (
@@ -579,6 +600,7 @@ PostThreadItemLoaded = memo(PostThreadItemLoaded)
 
 function PostOuterWrapper({
   post,
+  prevPost,
   treeView,
   depth,
   showParentReplyLine,
@@ -586,6 +608,7 @@ function PostOuterWrapper({
   children,
 }: React.PropsWithChildren<{
   post: AppBskyFeedDefs.PostView
+  prevPost: ThreadPost | undefined
   treeView: boolean
   depth: number
   showParentReplyLine: boolean
@@ -603,12 +626,11 @@ function PostOuterWrapper({
           styles.cursor,
           {
             flexDirection: 'row',
-            paddingLeft: depth === 1 ? 10 : 20,
-            borderTopWidth: depth === 1 ? 1 : 0,
-            paddingTop: depth === 1 ? 6 : 0,
+            paddingLeft: isMobile ? 10 : 6,
+            borderTopWidth: !prevPost ? 1 : 0,
           },
         ]}>
-        {Array.from(Array(depth - 1)).map((_, n: number) => (
+        {Array.from(Array(depth)).map((_, n: number) => (
           <View
             key={`${post.uri}-padding-${n}`}
             style={{


### PR DESCRIPTION
A little more treeview UI tweaking, as a treat

- More consistent spacing
- Always include one level of "reply bar" to avoid the awkward left-edge visual flow
- Slightly shrink the expanded post's avi (Fons is going to reduce avi sizes in general with the updated designs)

|Before|After|
|-|-|
|![Simulator Screenshot - iPhone 15 Pro - 2023-12-05 at 12 31 54](https://github.com/bluesky-social/social-app/assets/1270099/d0b412ea-f5ef-40a1-9ba2-f716a24c37cd)|![Simulator Screenshot - iPhone 15 Pro - 2023-12-05 at 12 31 16](https://github.com/bluesky-social/social-app/assets/1270099/03b1b892-95e6-46bd-a2d0-171720a3bfab)|

|Before|After|
|-|-|
|![Simulator Screenshot - iPhone 15 Pro - 2023-12-05 at 12 32 03](https://github.com/bluesky-social/social-app/assets/1270099/6b0c6eca-d018-48d5-a0d0-3416bc7651a3)|![Simulator Screenshot - iPhone 15 Pro - 2023-12-05 at 12 31 41](https://github.com/bluesky-social/social-app/assets/1270099/21f1c5ec-fe6a-474d-a626-ea93675d7f5b)|

