### PR TITLE
Fix email confirmation dialog on startup

### DIFF
--- a/src/App.native.tsx
+++ b/src/App.native.tsx
@@ -11,7 +11,6 @@ import {enableFreeze} from 'react-native-screens'
 import 'view/icons'
 
 import {init as initPersistedState} from '#/state/persisted'
-import {init as initReminders} from '#/state/shell/reminders'
 import {listenSessionDropped} from './state/events'
 import {useColorMode} from 'state/shell'
 import {ThemeProvider} from 'lib/ThemeContext'
@@ -48,7 +47,6 @@ function InnerApp() {
 
   // init
   useEffect(() => {
-    initReminders()
     analytics.init()
     notifications.init(queryClient)
     listenSessionDropped(() => {

--- a/src/App.web.tsx
+++ b/src/App.web.tsx
@@ -9,7 +9,6 @@ import {enableFreeze} from 'react-native-screens'
 import 'view/icons'
 
 import {init as initPersistedState} from '#/state/persisted'
-import {init as initReminders} from '#/state/shell/reminders'
 import {useColorMode} from 'state/shell'
 import * as analytics from 'lib/analytics/analytics'
 import {Shell} from 'view/shell/index'
@@ -41,7 +40,6 @@ function InnerApp() {
 
   // init
   useEffect(() => {
-    initReminders()
     analytics.init()
     const account = persisted.get('session').currentAccount
     resumeSession(account)

--- a/src/Navigation.tsx
+++ b/src/Navigation.tsx
@@ -35,6 +35,12 @@ import {bskyTitle} from 'lib/strings/headings'
 import {JSX} from 'react/jsx-runtime'
 import {timeout} from 'lib/async/timeout'
 import {useUnreadNotifications} from './state/queries/notifications/unread'
+import {useSession} from './state/session'
+import {useModalControls} from './state/modals'
+import {
+  shouldRequestEmailConfirmation,
+  setEmailConfirmationRequested,
+} from './state/shell/reminders'
 
 import {HomeScreen} from './view/screens/Home'
 import {SearchScreen} from './view/screens/Search'
@@ -464,6 +470,16 @@ const LINKING = {
 
 function RoutesContainer({children}: React.PropsWithChildren<{}>) {
   const theme = useColorSchemeStyle(DefaultTheme, DarkTheme)
+  const {currentAccount} = useSession()
+  const {openModal} = useModalControls()
+
+  function onReady() {
+    if (currentAccount && shouldRequestEmailConfirmation(currentAccount)) {
+      openModal({name: 'verify-email', showReminder: true})
+      setEmailConfirmationRequested()
+    }
+  }
+
   return (
     <NavigationContainer
       ref={navigationRef}
@@ -472,6 +488,7 @@ function RoutesContainer({children}: React.PropsWithChildren<{}>) {
       onReady={() => {
         SplashScreen.hideAsync()
         logModuleInitTime()
+        onReady()
       }}>
       {children}
     </NavigationContainer>

--- a/src/Navigation.tsx
+++ b/src/Navigation.tsx
@@ -471,12 +471,7 @@ function RoutesContainer({children}: React.PropsWithChildren<{}>) {
       theme={theme}
       onReady={() => {
         SplashScreen.hideAsync()
-        const initMs = Math.round(
-          // @ts-ignore Emitted by Metro in the bundle prelude
-          performance.now() - global.__BUNDLE_START_TIME__,
-        )
-        console.log(`Time to first paint: ${initMs} ms`)
-        logModuleInitTrace()
+        logModuleInitTime()
       }}>
       {children}
     </NavigationContainer>
@@ -585,7 +580,17 @@ const styles = StyleSheet.create({
   },
 })
 
-function logModuleInitTrace() {
+let didInit = false
+function logModuleInitTime() {
+  if (didInit) {
+    return
+  }
+  didInit = true
+  const initMs = Math.round(
+    // @ts-ignore Emitted by Metro in the bundle prelude
+    performance.now() - global.__BUNDLE_START_TIME__,
+  )
+  console.log(`Time to first paint: ${initMs} ms`)
   if (__DEV__) {
     // This log is noisy, so keep false committed
     const shouldLog = false

--- a/src/state/shell/reminders.ts
+++ b/src/state/shell/reminders.ts
@@ -2,17 +2,6 @@ import * as persisted from '#/state/persisted'
 import {toHashCode} from 'lib/strings/helpers'
 import {isOnboardingActive} from './onboarding'
 import {SessionAccount} from '../session'
-import {listenSessionLoaded} from '../events'
-import {unstable__openModal} from '../modals'
-
-export function init() {
-  listenSessionLoaded(account => {
-    if (shouldRequestEmailConfirmation(account)) {
-      unstable__openModal({name: 'verify-email', showReminder: true})
-      setEmailConfirmationRequested()
-    }
-  })
-}
 
 export function shouldRequestEmailConfirmation(account: SessionAccount) {
   if (!account) {


### PR DESCRIPTION
This was previously crashing because `unstable__openModal` was being called too early. Also nice to move it out of the critical path. I'll probably move a few other things here too.

<img width="564" alt="Screenshot 2023-12-05 at 23 44 47" src="https://github.com/bluesky-social/social-app/assets/810438/58dcace4-f639-45f6-899c-b9c955c75fcd">
<img width="413" alt="Screenshot 2023-12-05 at 23 44 55" src="https://github.com/bluesky-social/social-app/assets/810438/b7d0a505-49c7-4de0-9edc-ac03f70f66d5">
<img width="808" alt="Screenshot 2023-12-05 at 23 45 04" src="https://github.com/bluesky-social/social-app/assets/810438/9d3b4bd1-f8f6-402a-b973-b7be1f8c69ba">
