### PR TITLE
Fix: correctly identify if the screen is focused when handling soft resets

### DIFF
--- a/src/lib/routes/helpers.ts
+++ b/src/lib/routes/helpers.ts
@@ -1,4 +1,14 @@
+import {NavigationProp} from '@react-navigation/native'
 import {State, RouteParams} from './types'
+
+export function getRootNavigation<T>(
+  nav: NavigationProp<T>,
+): NavigationProp<T> {
+  while (nav.getParent()) {
+    nav = nav.getParent()
+  }
+  return nav
+}
 
 export function getCurrentRoute(state: State) {
   let node = state.routes[state.index || 0]

--- a/src/state/queries/post-feed.ts
+++ b/src/state/queries/post-feed.ts
@@ -98,7 +98,7 @@ export function usePostFeedQuery(
     staleTime: STALE.INFINITY,
     queryKey: RQKEY(feedDesc, params),
     async queryFn({pageParam}: {pageParam: RQPageParam}) {
-      logger.debug('usePostFeedQuery', {feedDesc, pageParam})
+      logger.debug('usePostFeedQuery', {feedDesc, cursor: pageParam?.cursor})
 
       const {api, cursor} = pageParam
         ? pageParam

--- a/src/view/screens/Home.tsx
+++ b/src/view/screens/Home.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import {View, ActivityIndicator, StyleSheet} from 'react-native'
-import {useFocusEffect, useIsFocused} from '@react-navigation/native'
+import {useFocusEffect} from '@react-navigation/native'
 import {NativeStackScreenProps, HomeTabNavigatorParams} from 'lib/routes/types'
 import {FeedDescriptor, FeedParams} from '#/state/queries/post-feed'
 import {FollowingEmptyState} from 'view/com/posts/FollowingEmptyState'
@@ -65,7 +65,6 @@ function HomeScreenReady({
   const {hasSession} = useSession()
   const setMinimalShellMode = useSetMinimalShellMode()
   const setDrawerSwipeDisabled = useSetDrawerSwipeDisabled()
-  const isPageFocused = useIsFocused()
   const [selectedPage, setSelectedPage] = React.useState<string>(initialPage)
 
   /**
@@ -175,7 +174,7 @@ function HomeScreenReady({
       <FeedPage
         key="1"
         testID="followingFeedPage"
-        isPageFocused={selectedPageIndex === 0 && isPageFocused}
+        isPageFocused={selectedPageIndex === 0}
         feed={homeFeedParams.mergeFeedEnabled ? 'home' : 'following'}
         feedParams={homeFeedParams}
         renderEmptyState={renderFollowingEmptyState}
@@ -186,7 +185,7 @@ function HomeScreenReady({
           <FeedPage
             key={f}
             testID="customFeedPage"
-            isPageFocused={selectedPageIndex === 1 + index && isPageFocused}
+            isPageFocused={selectedPageIndex === 1 + index}
             feed={f}
             renderEmptyState={renderCustomFeedEmptyState}
           />
@@ -202,7 +201,7 @@ function HomeScreenReady({
       tabBarPosition="top">
       <FeedPage
         testID="customFeedPage"
-        isPageFocused={isPageFocused}
+        isPageFocused={true}
         feed={`feedgen|at://did:plc:z72i7hdynmk6r22z27h6tvur/app.bsky.feed.generator/whats-hot`}
         renderEmptyState={renderCustomFeedEmptyState}
       />


### PR DESCRIPTION
This seems to solve a case of scroll position loss on other tabs (mobile). Here's the deal:

React state updates aren't triggering after the screen loses its focus because of the react-native-screen "freeze" setting. This means that the various `isFocused` values won't be updated by blur, and so the "soft reset" call is getting triggered for the Home screen's feeds when it's off-screen.

About the solution: React navigation has a wildly finicky API. It's _designed_ to scope knowledge of the router to a given component to improve composition, so when you call things like `useNavigation` or `useNavigationState`, it doesn't give you the root navigator. Instead, it gives you the leaf navigator -- which, in the case of mobile, is the stack navigator you're currently on rather than the surrounding tab navigator. This is why, when trying to establish the current tab, you have to use the `getRootNavigation()` method which I just introduced.

