### PR TITLE
Perf: Dont initial-render full thread on mobile

### DIFF
--- a/src/view/com/post-thread/PostThread.tsx
+++ b/src/view/com/post-thread/PostThread.tsx
@@ -322,7 +322,7 @@ function PostThreadLoaded({
     <FlatList
       ref={ref}
       data={posts}
-      initialNumToRender={posts.length}
+      initialNumToRender={!isNative ? posts.length : undefined}
       maintainVisibleContentPosition={
         !needsScrollAdjustment.current
           ? MAINTAIN_VISIBLE_CONTENT_POSITION


### PR DESCRIPTION
The PostThread's FlatList has `initialNumToRender` set to the thread length so that it can correctly scroll to the focused post when going to a reply. This is only necessary when using the `onContentSizeChange` => `scrollToOffset()` technique, which is *typically* Web. On Native, we use the `maintainVisibleContentPosition` trick (which recently landed for Android).

On large threads, this setting causes the UI thread to semi-freeze. This manifests as tapping on a thread and nothing happening for a few seconds, and then navigating. Removing this prop solves that entirely, and fortunately Web seems unbothered by the render task.

## Before

(Holy shit)

https://github.com/bluesky-social/social-app/assets/1270099/30581efa-43b0-47be-85ba-2289971bbbc2

## After

https://github.com/bluesky-social/social-app/assets/1270099/c5cc392a-fe48-4a56-a4bf-80a4f1ad096c

