### PR TITLE
Disable react-native-screen freezing to test performance implications

### DIFF
--- a/src/App.native.tsx
+++ b/src/App.native.tsx
@@ -6,7 +6,6 @@ import {RootSiblingParent} from 'react-native-root-siblings'
 import * as SplashScreen from 'expo-splash-screen'
 import {GestureHandlerRootView} from 'react-native-gesture-handler'
 import {QueryClientProvider} from '@tanstack/react-query'
-import {enableFreeze} from 'react-native-screens'
 
 import 'view/icons'
 
@@ -37,7 +36,6 @@ import {
 import {Provider as UnreadNotifsProvider} from 'state/queries/notifications/unread'
 import * as persisted from '#/state/persisted'
 
-enableFreeze(true)
 SplashScreen.preventAutoHideAsync()
 
 function InnerApp() {

--- a/src/App.web.tsx
+++ b/src/App.web.tsx
@@ -4,7 +4,6 @@ import React, {useState, useEffect} from 'react'
 import {QueryClientProvider} from '@tanstack/react-query'
 import {SafeAreaProvider} from 'react-native-safe-area-context'
 import {RootSiblingParent} from 'react-native-root-siblings'
-import {enableFreeze} from 'react-native-screens'
 
 import 'view/icons'
 
@@ -30,8 +29,6 @@ import {
 } from 'state/session'
 import {Provider as UnreadNotifsProvider} from 'state/queries/notifications/unread'
 import * as persisted from '#/state/persisted'
-
-enableFreeze(true)
 
 function InnerApp() {
   const {isInitialLoad, currentAccount} = useSession()


### PR DESCRIPTION
We're seeing some signs that screen freezing causes pending work to queue up, which then introduces rendering delays when the screen unfreezes. I want to test this in the TF