### PR TITLE
Throttle non-critical Sentry messages

### DIFF
--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -37,6 +37,7 @@ const dist = `${Platform.OS}.${release}${
 }`
 
 init({
+  autoSessionTracking: false,
   dsn: 'https://05bc3789bf994b81bd7ce20c86ccd3ae@o4505071687041024.ingest.sentry.io/4505071690514432',
   debug: false, // If `true`, Sentry will try to print out useful debugging information if something goes wrong with sending the event. Set it to `false` in production
   enableInExpoDevelopment: true,

--- a/src/logger/__tests__/logger.test.ts
+++ b/src/logger/__tests__/logger.test.ts
@@ -179,6 +179,7 @@ describe('general functionality', () => {
       level: 'debug', // Sentry bug, log becomes debug
       timestamp: sentryTimestamp,
     })
+    jest.runAllTimers()
     expect(Sentry.captureMessage).toHaveBeenCalledWith(message, {
       level: 'log',
       tags: undefined,
@@ -193,6 +194,7 @@ describe('general functionality', () => {
       level: 'warning',
       timestamp: sentryTimestamp,
     })
+    jest.runAllTimers()
     expect(Sentry.captureMessage).toHaveBeenCalledWith(message, {
       level: 'warning',
       tags: undefined,


### PR DESCRIPTION
Let's get Sentry logs out of the critical path.

Two changes:

- Non-exception messages are put in a queue throttled with a leading edge of 7 seconds. I picked a number that's likely enough to unclog the critical path on a slow network but still reasonable that the app will likely stay foregrounded etc.
- Disable [session tracking](https://docs.sentry.io/platforms/javascript/configuration/options/#auto-session-tracking) cause I don't think we care about this? This was causing an extra request at startup.

## Before (slow 3G)

<img width="879" alt="Screenshot 2023-12-06 at 16 11 38" src="https://github.com/bluesky-social/social-app/assets/810438/024f3fc3-788a-425d-8538-6635e5083ea4">


## After (slow 3G)

<img width="888" alt="Screenshot 2023-12-06 at 16 10 57" src="https://github.com/bluesky-social/social-app/assets/810438/a9d87e22-ba34-4ad9-95b2-509fa481f07a">
