### PR TITLE
Sync prefs, add background task provider

### DIFF
--- a/src/App.native.tsx
+++ b/src/App.native.tsx
@@ -35,6 +35,7 @@ import {
 } from 'state/session'
 import {Provider as UnreadNotifsProvider} from 'state/queries/notifications/unread'
 import * as persisted from '#/state/persisted'
+import {AccountBackgroundTaskProvider} from '#/state/AccountBackgroundTaskProvider'
 
 SplashScreen.preventAutoHideAsync()
 
@@ -69,6 +70,9 @@ function InnerApp() {
     <React.Fragment
       // Resets the entire tree below when it changes:
       key={currentAccount?.did}>
+      {/* Must live inside the tree reset above */}
+      <AccountBackgroundTaskProvider />
+
       <LoggedOutViewProvider>
         <UnreadNotifsProvider>
           <ThemeProvider theme={colorMode}>

--- a/src/App.web.tsx
+++ b/src/App.web.tsx
@@ -29,6 +29,7 @@ import {
 } from 'state/session'
 import {Provider as UnreadNotifsProvider} from 'state/queries/notifications/unread'
 import * as persisted from '#/state/persisted'
+import {AccountBackgroundTaskProvider} from '#/state/AccountBackgroundTaskProvider'
 
 function InnerApp() {
   const {isInitialLoad, currentAccount} = useSession()
@@ -56,6 +57,9 @@ function InnerApp() {
     <React.Fragment
       // Resets the entire tree below when it changes:
       key={currentAccount?.did}>
+      {/* Must live inside the tree reset above */}
+      <AccountBackgroundTaskProvider />
+
       <LoggedOutViewProvider>
         <UnreadNotifsProvider>
           <ThemeProvider theme={colorMode}>

--- a/src/state/AccountBackgroundTaskProvider.tsx
+++ b/src/state/AccountBackgroundTaskProvider.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+
+import {useSession} from '#/state/session'
+import {useSyncPreferences} from '#/state/queries/preferences'
+
+/**
+ * Must live inside our "tree-reset" fragment in App.tsx, so that when the
+ * current user changes, we clean up the intervals.
+ */
+export function AccountBackgroundTaskProvider() {
+  const {currentAccount} = useSession()
+  const syncPreferences = useSyncPreferences()
+  const preferencesSyncInterval = React.useRef<NodeJS.Timeout | undefined>(
+    undefined,
+  )
+
+  React.useEffect(() => {
+    if (!currentAccount) return
+    preferencesSyncInterval.current = setInterval(syncPreferences, 15e3)
+    return () => clearInterval(preferencesSyncInterval.current)
+  }, [currentAccount, syncPreferences])
+
+  return null
+}


### PR DESCRIPTION
Invalidates queries, but does not refetch immediately.

To test, view your Following feed. Change a setting like "Show replies" or "Show reposts". Wait for sync (15s), then nav to a different screen and go back. Your setting should be in effect and your feed should be filtering replies and/or reposts.