### PR TITLE
Enable structural sharing for preference query

### DIFF
--- a/src/state/queries/preferences/index.ts
+++ b/src/state/queries/preferences/index.ts
@@ -29,6 +29,7 @@ export const preferencesQueryKey = ['getPreferences']
 export function usePreferencesQuery() {
   return useQuery({
     staleTime: STALE.MINUTES.ONE,
+    structuralSharing: true,
     queryKey: preferencesQueryKey,
     queryFn: async () => {
       const agent = getAgent()


### PR DESCRIPTION
There's no rich entities using shadows inside, and we're planning to refetch this fairly often, and everything reads it, so it's a good idea here.