### PR TITLE
Move analytics out of critical path

### DIFF
--- a/src/App.native.tsx
+++ b/src/App.native.tsx
@@ -16,7 +16,6 @@ import {ThemeProvider} from 'lib/ThemeContext'
 import {s} from 'lib/styles'
 import {Shell} from 'view/shell'
 import * as notifications from 'lib/notifications/notifications'
-import {Provider as AnalyticsProvider} from 'lib/analytics/analytics'
 import * as Toast from 'view/com/util/Toast'
 import {queryClient} from 'lib/react-query'
 import {TestCtrls} from 'view/com/testing/TestCtrls'
@@ -71,15 +70,13 @@ function InnerApp() {
       <LoggedOutViewProvider>
         <UnreadNotifsProvider>
           <ThemeProvider theme={colorMode}>
-            <AnalyticsProvider>
-              {/* All components should be within this provider */}
-              <RootSiblingParent>
-                <GestureHandlerRootView style={s.h100pct}>
-                  <TestCtrls />
-                  <Shell />
-                </GestureHandlerRootView>
-              </RootSiblingParent>
-            </AnalyticsProvider>
+            {/* All components should be within this provider */}
+            <RootSiblingParent>
+              <GestureHandlerRootView style={s.h100pct}>
+                <TestCtrls />
+                <Shell />
+              </GestureHandlerRootView>
+            </RootSiblingParent>
           </ThemeProvider>
         </UnreadNotifsProvider>
       </LoggedOutViewProvider>

--- a/src/App.web.tsx
+++ b/src/App.web.tsx
@@ -9,7 +9,6 @@ import 'view/icons'
 
 import {init as initPersistedState} from '#/state/persisted'
 import {useColorMode} from 'state/shell'
-import {Provider as AnalyticsProvider} from 'lib/analytics/analytics'
 import {Shell} from 'view/shell/index'
 import {ToastContainer} from 'view/com/util/Toast.web'
 import {ThemeProvider} from 'lib/ThemeContext'
@@ -58,15 +57,13 @@ function InnerApp() {
       <LoggedOutViewProvider>
         <UnreadNotifsProvider>
           <ThemeProvider theme={colorMode}>
-            <AnalyticsProvider>
-              {/* All components should be within this provider */}
-              <RootSiblingParent>
-                <SafeAreaProvider>
-                  <Shell />
-                </SafeAreaProvider>
-              </RootSiblingParent>
-              <ToastContainer />
-            </AnalyticsProvider>
+            {/* All components should be within this provider */}
+            <RootSiblingParent>
+              <SafeAreaProvider>
+                <Shell />
+              </SafeAreaProvider>
+            </RootSiblingParent>
+            <ToastContainer />
           </ThemeProvider>
         </UnreadNotifsProvider>
       </LoggedOutViewProvider>

--- a/src/lib/analytics/analytics.tsx
+++ b/src/lib/analytics/analytics.tsx
@@ -20,7 +20,9 @@ const segmentClient = createClient({
   proxy: 'https://api.events.bsky.app/v1',
 })
 
-export const track = segmentClient?.track?.bind?.(segmentClient) as TrackEvent
+export const track: TrackEvent = async (...args) => {
+  await segmentClient.track(...args)
+}
 
 export function useAnalytics(): AnalyticsMethods {
   const {hasSession} = useSession()

--- a/src/lib/analytics/analytics.web.tsx
+++ b/src/lib/analytics/analytics.web.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import {createClient} from '@segment/analytics-react'
 import {sha256} from 'js-sha256'
-import {AnalyticsMethods} from './types'
+import {TrackEvent, AnalyticsMethods} from './types'
 
 import {useSession, SessionAccount} from '#/state/session'
 import {logger} from '#/logger'
@@ -18,7 +18,10 @@ const segmentClient = createClient(
     },
   },
 )
-export const track = segmentClient?.track?.bind?.(segmentClient)
+
+export const track: TrackEvent = async (...args) => {
+  await segmentClient.track(...args)
+}
 
 export function useAnalytics(): AnalyticsMethods {
   const {hasSession} = useSession()

--- a/src/lib/analytics/types.ts
+++ b/src/lib/analytics/types.ts
@@ -7,6 +7,7 @@ export type ScreenEvent = (
   name: keyof ScreenPropertiesMap,
   properties?: ScreenPropertiesMap[keyof ScreenPropertiesMap],
 ) => Promise<void>
+
 interface TrackPropertiesMap {
   // LOGIN / SIGN UP events
   'Sign In': {resumedSession: boolean} // CAN BE SERVER
@@ -149,4 +150,9 @@ interface ScreenPropertiesMap {
   BlockedAccounts: {}
   MutedAccounts: {}
   SavedFeeds: {}
+}
+
+export type AnalyticsMethods = {
+  screen: ScreenEvent
+  track: TrackEvent
 }

--- a/src/view/com/feeds/FeedPage.tsx
+++ b/src/view/com/feeds/FeedPage.tsx
@@ -4,7 +4,7 @@ import {
   FontAwesomeIconStyle,
 } from '@fortawesome/react-native-fontawesome'
 import {useNavigation} from '@react-navigation/native'
-import {useAnalytics} from '@segment/analytics-react-native'
+import {useAnalytics} from 'lib/analytics/analytics'
 import {useQueryClient} from '@tanstack/react-query'
 import {RQKEY as FEED_RQKEY} from '#/state/queries/post-feed'
 import {useOnMainScroll} from 'lib/hooks/useOnMainScroll'


### PR DESCRIPTION
Simplifies our analytics wiring and moves them out of the blocking startup path.

The provider and the Hook provided by the Segment client don't do anything special or particularly useful. They're just proxying to the client methods. We already have the client right here so we might as well use it directly. The methods exposed by the native and the browser versions of the client, and their signatures, are slightly different. We only use two methods anyway. And we use our custom types for them. So I narrowed down the methods we use to those two methods.

Now that the abstraction is out of the way, we have more control. I use this to make creation of the client lazy. It's created on first use. Since https://github.com/bluesky-social/social-app/pull/2115, that first use is after the module init is done.

So now we can move Segment code out of the blocking module init path.

[Review without whitespace](https://github.com/bluesky-social/social-app/pull/2117/files?w=1)

## Before

1485 modules blocking startup. A bunch are from `@segment`:

<img width="500" alt="Screenshot 2023-12-06 at 20 36 19" src="https://github.com/bluesky-social/social-app/assets/810438/aa55994b-d80c-465c-a615-a0c44820511d">

## After

1435 modules loaded at startup. No matches for `@segment`.

<img width="500" alt="Screenshot 2023-12-06 at 20 36 49" src="https://github.com/bluesky-social/social-app/assets/810438/9a6ec901-db75-4b9c-a424-6f5b024e2f0a">

This is ~50ms startup win on low-end Android.