### PR TITLE
Allow blocking/muting to curational lists, unpinning to modlists

### DIFF
--- a/src/view/screens/ProfileList.tsx
+++ b/src/view/screens/ProfileList.tsx
@@ -496,12 +496,10 @@ function Header({rkey, list}: {rkey: string; list: AppBskyGraphDefs.ListView}) {
           onPress: isBlocking ? onUnsubscribeBlock : onSubscribeBlock,
           icon: {
             ios: {
-              name: isBlocking
-                ? 'exclamationmark.shield'
-                : 'exclamationmark.shield.fill',
+              name: 'person.fill.xmark',
             },
             android: '',
-            web: isBlocking ? 'shield' : 'shield',
+            web: 'user-slash',
           },
         })
       }

--- a/src/view/screens/ProfileList.tsx
+++ b/src/view/screens/ProfileList.tsx
@@ -471,6 +471,41 @@ function Header({rkey, list}: {rkey: string; list: AppBskyGraphDefs.ListView}) {
         },
       })
     }
+    if (isCurateList) {
+      items.push({label: 'separator'})
+
+      if (!isBlocking) {
+        items.push({
+          testID: 'listHeaderDropdownMuteBtn',
+          label: isMuting ? _(msg`Un-mute list`) : _(msg`Mute list`),
+          onPress: isMuting ? onUnsubscribeMute : onSubscribeMute,
+          icon: {
+            ios: {
+              name: isMuting ? 'eye' : 'eye.slash',
+            },
+            android: '',
+            web: isMuting ? 'eye' : ['far', 'eye-slash'],
+          },
+        })
+      }
+
+      if (!isMuting) {
+        items.push({
+          testID: 'listHeaderDropdownBlockBtn',
+          label: isBlocking ? _(msg`Un-block list`) : _(msg`Block list`),
+          onPress: isBlocking ? onUnsubscribeBlock : onSubscribeBlock,
+          icon: {
+            ios: {
+              name: isBlocking
+                ? 'exclamationmark.shield'
+                : 'exclamationmark.shield.fill',
+            },
+            android: '',
+            web: isBlocking ? 'shield' : 'shield',
+          },
+        })
+      }
+    }
     return items
   }, [
     isOwner,
@@ -484,6 +519,13 @@ function Header({rkey, list}: {rkey: string; list: AppBskyGraphDefs.ListView}) {
     unpinFeed,
     isPending,
     list.uri,
+    isCurateList,
+    isMuting,
+    isBlocking,
+    onUnsubscribeMute,
+    onSubscribeMute,
+    onUnsubscribeBlock,
+    onSubscribeBlock,
   ])
 
   const subscribeDropdownItems: DropdownItem[] = useMemo(() => {

--- a/src/view/screens/ProfileList.tsx
+++ b/src/view/screens/ProfileList.tsx
@@ -456,8 +456,35 @@ function Header({rkey, list}: {rkey: string; list: AppBskyGraphDefs.ListView}) {
         },
       })
     }
+    if (isModList && isPinned) {
+      items.push({label: 'separator'})
+      items.push({
+        testID: 'listHeaderDropdownUnpinBtn',
+        label: _(msg`Unpin moderation list`),
+        onPress: isPending ? undefined : () => unpinFeed({uri: list.uri}),
+        icon: {
+          ios: {
+            name: 'pin',
+          },
+          android: '',
+          web: 'thumbtack',
+        },
+      })
+    }
     return items
-  }, [isOwner, onPressShare, onPressEdit, onPressDelete, onPressReport, _])
+  }, [
+    isOwner,
+    onPressShare,
+    onPressEdit,
+    onPressDelete,
+    onPressReport,
+    _,
+    isModList,
+    isPinned,
+    unpinFeed,
+    isPending,
+    list.uri,
+  ])
 
   const subscribeDropdownItems: DropdownItem[] = useMemo(() => {
     return [


### PR DESCRIPTION
Added muting/blocking controls to the dropdown for curational lists. Since a curational list could technically get converted to a modlist, I added an option to unpin that, but no option to re-pin.

Modlist:
<img width="1574" alt="Screenshot 2023-12-06 at 5 30 57 PM" src="https://github.com/bluesky-social/social-app/assets/4732330/fb6886da-235d-42f0-9ab2-dac3236142fb">

Curational list:
<img width="1624" alt="Screenshot 2023-12-06 at 5 56 05 PM" src="https://github.com/bluesky-social/social-app/assets/4732330/89a036c0-ee6d-49fa-89b6-ac8f769bfc3a">
<img width="1624" alt="Screenshot 2023-12-06 at 5 56 14 PM" src="https://github.com/bluesky-social/social-app/assets/4732330/f6669a8a-42ee-491c-87a2-c6304a2602e9">
<img width="1624" alt="Screenshot 2023-12-06 at 5 56 26 PM" src="https://github.com/bluesky-social/social-app/assets/4732330/4ad94929-e537-4020-a2d3-0d70fc83a579">
