### PR TITLE
Add PWI opt-out toggle

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "intl:compile": "lingui compile"
   },
   "dependencies": {
-    "@atproto/api": "^0.6.23",
+    "@atproto/api": "^0.7.0",
     "@bam.tech/react-native-image-resizer": "^3.0.4",
     "@braintree/sanitize-url": "^6.0.2",
     "@emoji-mart/react": "^1.1.1",

--- a/src/locale/locales/cs/messages.po
+++ b/src/locale/locales/cs/messages.po
@@ -68,8 +68,8 @@ msgstr ""
 #~ msgstr ""
 
 #: src/view/screens/Moderation.tsx:212
-msgid "<0>Note: Your profile and posts will remain publicly available. Third-party apps that display Bluesky content may not respect this setting.</0>"
-msgstr ""
+#~ msgid "<0>Note: Your profile and posts will remain publicly available. Third-party apps that display Bluesky content may not respect this setting.</0>"
+#~ msgstr ""
 
 #: src/lib/hooks/useOTAUpdate.ts:16
 msgid "A new version of the app is available. Please update to continue using the app."
@@ -200,8 +200,8 @@ msgid "Appearance"
 msgstr ""
 
 #: src/view/screens/Moderation.tsx:206
-msgid "Apps that respect this setting, including the official Bluesky app and bsky.app website, won't show your content to logged out users."
-msgstr ""
+#~ msgid "Apps that respect this setting, including the official Bluesky app and bsky.app website, won't show your content to logged out users."
+#~ msgstr ""
 
 #: src/view/screens/AppPasswords.tsx:223
 msgid "Are you sure you want to delete the app password \"{name}\"?"
@@ -224,8 +224,8 @@ msgid "Artistic or non-erotic nudity."
 msgstr ""
 
 #: src/view/screens/Moderation.tsx:189
-msgid "Ask apps to limit the visibility of my account"
-msgstr ""
+#~ msgid "Ask apps to limit the visibility of my account"
+#~ msgstr ""
 
 #: src/view/com/auth/create/CreateAccount.tsx:145
 #: src/view/com/auth/login/ChooseAccountForm.tsx:151
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Learn more about this warning"
 msgstr ""
 
-#: src/view/screens/Moderation.tsx:223
+#: src/view/screens/Moderation.tsx:235
 msgid "Learn more about what is public on Bluesky."
 msgstr ""
 
@@ -1113,6 +1113,10 @@ msgstr ""
 #: src/view/screens/PostLikedBy.tsx:27
 #: src/view/screens/ProfileFeedLikedBy.tsx:27
 msgid "Liked by"
+msgstr ""
+
+#: src/view/screens/Moderation.tsx:203
+msgid "Limit the visibility of my account"
 msgstr ""
 
 #: src/view/com/modals/CreateOrEditList.tsx:186
@@ -1148,6 +1152,10 @@ msgstr ""
 
 #: src/view/com/modals/ServerInput.tsx:50
 msgid "Local dev server"
+msgstr ""
+
+#: src/view/screens/Moderation.tsx:134
+msgid "Logged-out users"
 msgstr ""
 
 #: src/view/com/auth/login/ChooseAccountForm.tsx:133
@@ -1234,8 +1242,8 @@ msgid "Muting is private. Muted accounts can interact with you, but you will not
 msgstr ""
 
 #: src/view/screens/Moderation.tsx:134
-msgid "My Account"
-msgstr ""
+#~ msgid "My Account"
+#~ msgstr ""
 
 #: src/view/com/modals/BirthDateSettings.tsx:56
 msgid "My Birthday"
@@ -1333,6 +1341,10 @@ msgstr ""
 
 #: src/view/com/modals/SelfLabel.tsx:135
 msgid "Not Applicable."
+msgstr ""
+
+#: src/view/screens/Moderation.tsx:227
+msgid "Note: Third-party apps that display Bluesky content may not respect this setting."
 msgstr ""
 
 #: src/view/screens/Notifications.tsx:96
@@ -2361,6 +2373,10 @@ msgstr ""
 #: src/view/screens/Moderation.tsx:205
 #~ msgid "Your profile and account will not be visible to anyone visiting the Bluesky app without an account, or to account holders who are not logged in. Enabling this will not make your profile private."
 #~ msgstr ""
+
+#: src/view/screens/Moderation.tsx:220
+msgid "Your profile and content will not be visible to anyone visiting the Bluesky app without an account. Enabling this will not make your profile private."
+msgstr ""
 
 #: src/view/com/auth/create/Step3.tsx:28
 msgid "Your user handle"

--- a/src/locale/locales/cs/messages.po
+++ b/src/locale/locales/cs/messages.po
@@ -38,12 +38,12 @@ msgid "{invitesAvailable, plural, one {Invite codes: # available} other {Invite 
 msgstr ""
 
 #: src/view/screens/Settings.tsx:407
-#: src/view/shell/Drawer.tsx:521
+#: src/view/shell/Drawer.tsx:648
 msgid "{invitesAvailable} invite code available"
 msgstr ""
 
 #: src/view/screens/Settings.tsx:409
-#: src/view/shell/Drawer.tsx:523
+#: src/view/shell/Drawer.tsx:650
 msgid "{invitesAvailable} invite codes available"
 msgstr ""
 
@@ -63,6 +63,14 @@ msgstr ""
 #~ msgid "<0>Here is your app password.</0> Use this to sign into the other app along with your handle."
 #~ msgstr ""
 
+#: src/view/screens/Moderation.tsx:212
+#~ msgid "<0>Note: This setting may not be respected by third-party apps that display Bluesky content.</0>"
+#~ msgstr ""
+
+#: src/view/screens/Moderation.tsx:212
+msgid "<0>Note: Your profile and posts will remain publicly available. Third-party apps that display Bluesky content may not respect this setting.</0>"
+msgstr ""
+
 #: src/lib/hooks/useOTAUpdate.ts:16
 msgid "A new version of the app is available. Please update to continue using the app."
 msgstr ""
@@ -72,7 +80,7 @@ msgstr ""
 msgid "Accessibility"
 msgstr ""
 
-#: src/view/com/auth/login/LoginForm.tsx:161
+#: src/view/com/auth/login/LoginForm.tsx:159
 #: src/view/screens/Settings.tsx:286
 msgid "Account"
 msgstr ""
@@ -82,8 +90,8 @@ msgid "Account options"
 msgstr ""
 
 #: src/view/com/modals/ListAddRemoveUsers.tsx:264
-#: src/view/com/modals/UserAddRemoveLists.tsx:192
-#: src/view/screens/ProfileList.tsx:702
+#: src/view/com/modals/UserAddRemoveLists.tsx:193
+#: src/view/screens/ProfileList.tsx:710
 msgid "Add"
 msgstr ""
 
@@ -91,7 +99,7 @@ msgstr ""
 msgid "Add a content warning"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:692
+#: src/view/screens/ProfileList.tsx:700
 msgid "Add a user to this list"
 msgstr ""
 
@@ -135,7 +143,7 @@ msgid "Add to my feeds"
 msgstr ""
 
 #: src/view/com/modals/ListAddRemoveUsers.tsx:191
-#: src/view/com/modals/UserAddRemoveLists.tsx:127
+#: src/view/com/modals/UserAddRemoveLists.tsx:128
 msgid "Added to list"
 msgstr ""
 
@@ -191,6 +199,10 @@ msgstr ""
 msgid "Appearance"
 msgstr ""
 
+#: src/view/screens/Moderation.tsx:206
+msgid "Apps that respect this setting, including the official Bluesky app and bsky.app website, won't show your content to logged out users."
+msgstr ""
+
 #: src/view/screens/AppPasswords.tsx:223
 msgid "Are you sure you want to delete the app password \"{name}\"?"
 msgstr ""
@@ -199,7 +211,7 @@ msgstr ""
 msgid "Are you sure you'd like to discard this draft?"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:369
+#: src/view/screens/ProfileList.tsx:375
 msgid "Are you sure?"
 msgstr ""
 
@@ -211,10 +223,14 @@ msgstr ""
 msgid "Artistic or non-erotic nudity."
 msgstr ""
 
+#: src/view/screens/Moderation.tsx:189
+msgid "Ask apps to limit the visibility of my account"
+msgstr ""
+
 #: src/view/com/auth/create/CreateAccount.tsx:145
 #: src/view/com/auth/login/ChooseAccountForm.tsx:151
 #: src/view/com/auth/login/ForgotPasswordForm.tsx:166
-#: src/view/com/auth/login/LoginForm.tsx:251
+#: src/view/com/auth/login/LoginForm.tsx:249
 #: src/view/com/auth/login/SetNewPasswordForm.tsx:148
 #: src/view/com/modals/report/InputIssueDetails.tsx:45
 #: src/view/com/post-thread/PostThread.tsx:381
@@ -242,15 +258,15 @@ msgstr ""
 msgid "Block Account"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:470
+#: src/view/screens/ProfileList.tsx:478
 msgid "Block accounts"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:326
+#: src/view/screens/ProfileList.tsx:330
 msgid "Block these accounts?"
 msgstr ""
 
-#: src/view/screens/Moderation.tsx:109
+#: src/view/screens/Moderation.tsx:121
 msgid "Blocked accounts"
 msgstr ""
 
@@ -270,7 +286,7 @@ msgstr ""
 msgid "Blocked post."
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:328
+#: src/view/screens/ProfileList.tsx:332
 msgid "Blocking is public. Blocked accounts cannot reply in your threads, mention you, or otherwise interact with you."
 msgstr ""
 
@@ -492,11 +508,11 @@ msgid "Confirmation code"
 msgstr ""
 
 #: src/view/com/auth/create/CreateAccount.tsx:178
-#: src/view/com/auth/login/LoginForm.tsx:270
+#: src/view/com/auth/login/LoginForm.tsx:268
 msgid "Connecting..."
 msgstr ""
 
-#: src/view/screens/Moderation.tsx:67
+#: src/view/screens/Moderation.tsx:79
 msgid "Content filtering"
 msgstr ""
 
@@ -531,7 +547,7 @@ msgstr ""
 msgid "Copy"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:399
+#: src/view/screens/ProfileList.tsx:407
 msgid "Copy link to list"
 msgstr ""
 
@@ -555,7 +571,7 @@ msgstr ""
 msgid "Could not load feed"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:779
+#: src/view/screens/ProfileList.tsx:787
 msgid "Could not load list"
 msgstr ""
 
@@ -601,8 +617,8 @@ msgstr ""
 msgid "Delete app password"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:368
-#: src/view/screens/ProfileList.tsx:426
+#: src/view/screens/ProfileList.tsx:374
+#: src/view/screens/ProfileList.tsx:434
 msgid "Delete List"
 msgstr ""
 
@@ -672,7 +688,7 @@ msgstr ""
 #: src/view/com/modals/EditImage.tsx:333
 #: src/view/com/modals/ListAddRemoveUsers.tsx:142
 #: src/view/com/modals/SelfLabel.tsx:157
-#: src/view/com/modals/UserAddRemoveLists.tsx:78
+#: src/view/com/modals/UserAddRemoveLists.tsx:79
 #: src/view/screens/PreferencesHomeFeed.tsx:302
 #: src/view/screens/PreferencesThreads.tsx:156
 msgid "Done"
@@ -691,7 +707,7 @@ msgstr ""
 msgid "Edit image"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:414
+#: src/view/screens/ProfileList.tsx:422
 msgid "Edit list details"
 msgstr ""
 
@@ -789,15 +805,15 @@ msgid "Feed Preferences"
 msgstr ""
 
 #: src/view/shell/desktop/RightNav.tsx:64
-#: src/view/shell/Drawer.tsx:410
+#: src/view/shell/Drawer.tsx:300
 msgid "Feedback"
 msgstr ""
 
 #: src/view/screens/Feeds.tsx:475
 #: src/view/shell/bottom-bar/BottomBar.tsx:168
 #: src/view/shell/desktop/LeftNav.tsx:341
-#: src/view/shell/Drawer.tsx:327
-#: src/view/shell/Drawer.tsx:328
+#: src/view/shell/Drawer.tsx:463
+#: src/view/shell/Drawer.tsx:464
 msgid "Feeds"
 msgstr ""
 
@@ -862,11 +878,11 @@ msgstr ""
 msgid "For security reasons, you won't be able to view this again. If you lose this password, you'll need to generate a new one."
 msgstr ""
 
-#: src/view/com/auth/login/LoginForm.tsx:233
+#: src/view/com/auth/login/LoginForm.tsx:231
 msgid "Forgot"
 msgstr ""
 
-#: src/view/com/auth/login/LoginForm.tsx:230
+#: src/view/com/auth/login/LoginForm.tsx:228
 msgid "Forgot password"
 msgstr ""
 
@@ -892,13 +908,13 @@ msgstr ""
 
 #: src/view/screens/ProfileFeed.tsx:111
 #: src/view/screens/ProfileFeed.tsx:116
-#: src/view/screens/ProfileList.tsx:788
-#: src/view/screens/ProfileList.tsx:793
+#: src/view/screens/ProfileList.tsx:796
+#: src/view/screens/ProfileList.tsx:801
 msgid "Go Back"
 msgstr ""
 
 #: src/view/com/auth/login/ForgotPasswordForm.tsx:181
-#: src/view/com/auth/login/LoginForm.tsx:280
+#: src/view/com/auth/login/LoginForm.tsx:278
 #: src/view/com/auth/login/SetNewPasswordForm.tsx:163
 msgid "Go to next"
 msgstr ""
@@ -908,7 +924,7 @@ msgid "Handle"
 msgstr ""
 
 #: src/view/shell/desktop/RightNav.tsx:93
-#: src/view/shell/Drawer.tsx:420
+#: src/view/shell/Drawer.tsx:310
 msgid "Help"
 msgstr ""
 
@@ -954,8 +970,8 @@ msgstr ""
 
 #: src/view/shell/bottom-bar/BottomBar.tsx:124
 #: src/view/shell/desktop/LeftNav.tsx:305
-#: src/view/shell/Drawer.tsx:274
-#: src/view/shell/Drawer.tsx:275
+#: src/view/shell/Drawer.tsx:387
+#: src/view/shell/Drawer.tsx:388
 msgid "Home"
 msgstr ""
 
@@ -1021,7 +1037,7 @@ msgstr ""
 msgid "Invite code not accepted. Check that you input it correctly and try again."
 msgstr ""
 
-#: src/view/shell/Drawer.tsx:502
+#: src/view/shell/Drawer.tsx:629
 msgid "Invite codes: {invitesAvailable} available"
 msgstr ""
 
@@ -1064,6 +1080,10 @@ msgstr ""
 msgid "Learn more about this warning"
 msgstr ""
 
+#: src/view/screens/Moderation.tsx:223
+msgid "Learn more about what is public on Bluesky."
+msgstr ""
+
 #: src/view/com/modals/lang-settings/ContentLanguagesSettings.tsx:82
 msgid "Leave them all unchecked to see any language."
 msgstr ""
@@ -1086,7 +1106,7 @@ msgstr ""
 #~ msgid "Light"
 #~ msgstr ""
 
-#: src/view/screens/ProfileFeed.tsx:637
+#: src/view/screens/ProfileFeed.tsx:639
 msgid "Like this feed"
 msgstr ""
 
@@ -1104,8 +1124,8 @@ msgid "List Name"
 msgstr ""
 
 #: src/view/shell/desktop/LeftNav.tsx:381
-#: src/view/shell/Drawer.tsx:338
-#: src/view/shell/Drawer.tsx:339
+#: src/view/shell/Drawer.tsx:479
+#: src/view/shell/Drawer.tsx:480
 msgid "Lists"
 msgstr ""
 
@@ -1151,15 +1171,15 @@ msgstr ""
 msgid "Message from server"
 msgstr ""
 
-#: src/view/screens/Moderation.tsx:51
+#: src/view/screens/Moderation.tsx:63
 #: src/view/screens/Settings.tsx:563
 #: src/view/shell/desktop/LeftNav.tsx:399
-#: src/view/shell/Drawer.tsx:345
-#: src/view/shell/Drawer.tsx:346
+#: src/view/shell/Drawer.tsx:498
+#: src/view/shell/Drawer.tsx:499
 msgid "Moderation"
 msgstr ""
 
-#: src/view/screens/Moderation.tsx:81
+#: src/view/screens/Moderation.tsx:93
 msgid "Moderation lists"
 msgstr ""
 
@@ -1173,7 +1193,7 @@ msgstr ""
 
 #: src/view/com/profile/ProfileHeader.tsx:523
 #: src/view/screens/ProfileFeed.tsx:369
-#: src/view/screens/ProfileList.tsx:531
+#: src/view/screens/ProfileList.tsx:539
 msgid "More options"
 msgstr ""
 
@@ -1185,11 +1205,11 @@ msgstr ""
 msgid "Mute Account"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:458
+#: src/view/screens/ProfileList.tsx:466
 msgid "Mute accounts"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:291
+#: src/view/screens/ProfileList.tsx:293
 msgid "Mute these accounts?"
 msgstr ""
 
@@ -1197,7 +1217,7 @@ msgstr ""
 msgid "Mute thread"
 msgstr ""
 
-#: src/view/screens/Moderation.tsx:95
+#: src/view/screens/Moderation.tsx:107
 msgid "Muted accounts"
 msgstr ""
 
@@ -1209,8 +1229,12 @@ msgstr ""
 msgid "Muted accounts have their posts removed from your feed and from your notifications. Mutes are completely private."
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:293
+#: src/view/screens/ProfileList.tsx:295
 msgid "Muting is private. Muted accounts can interact with you, but you will not see their posts or receive notifications from them."
+msgstr ""
+
+#: src/view/screens/Moderation.tsx:134
+msgid "My Account"
 msgstr ""
 
 #: src/view/com/modals/BirthDateSettings.tsx:56
@@ -1247,8 +1271,8 @@ msgstr ""
 #: src/view/screens/Feeds.tsx:510
 #: src/view/screens/Profile.tsx:388
 #: src/view/screens/ProfileFeed.tsx:450
-#: src/view/screens/ProfileList.tsx:211
-#: src/view/screens/ProfileList.tsx:243
+#: src/view/screens/ProfileList.tsx:212
+#: src/view/screens/ProfileList.tsx:244
 #: src/view/shell/desktop/LeftNav.tsx:254
 msgid "New post"
 msgstr ""
@@ -1260,7 +1284,7 @@ msgstr ""
 #: src/view/com/auth/create/CreateAccount.tsx:158
 #: src/view/com/auth/login/ForgotPasswordForm.tsx:174
 #: src/view/com/auth/login/ForgotPasswordForm.tsx:184
-#: src/view/com/auth/login/LoginForm.tsx:283
+#: src/view/com/auth/login/LoginForm.tsx:281
 #: src/view/com/auth/login/SetNewPasswordForm.tsx:156
 #: src/view/com/auth/login/SetNewPasswordForm.tsx:166
 #: src/view/com/auth/onboarding/RecommendedFeeds.tsx:79
@@ -1277,8 +1301,8 @@ msgstr ""
 msgid "No"
 msgstr "<<<<<<< HEAD"
 
-#: src/view/screens/ProfileFeed.tsx:630
-#: src/view/screens/ProfileList.tsx:659
+#: src/view/screens/ProfileFeed.tsx:632
+#: src/view/screens/ProfileList.tsx:667
 msgid "No description"
 msgstr ""
 
@@ -1315,8 +1339,8 @@ msgstr ""
 #: src/view/screens/Notifications.tsx:120
 #: src/view/shell/bottom-bar/BottomBar.tsx:195
 #: src/view/shell/desktop/LeftNav.tsx:363
-#: src/view/shell/Drawer.tsx:298
-#: src/view/shell/Drawer.tsx:299
+#: src/view/shell/Drawer.tsx:424
+#: src/view/shell/Drawer.tsx:425
 msgid "Notifications"
 msgstr ""
 
@@ -1341,7 +1365,7 @@ msgid "Opens configurable language settings"
 msgstr ""
 
 #: src/view/shell/desktop/RightNav.tsx:146
-#: src/view/shell/Drawer.tsx:503
+#: src/view/shell/Drawer.tsx:630
 msgid "Opens list of invite codes"
 msgstr ""
 
@@ -1396,7 +1420,7 @@ msgstr ""
 
 #: src/view/com/auth/create/Step2.tsx:101
 #: src/view/com/auth/create/Step2.tsx:111
-#: src/view/com/auth/login/LoginForm.tsx:218
+#: src/view/com/auth/login/LoginForm.tsx:216
 #: src/view/com/auth/login/SetNewPasswordForm.tsx:130
 #: src/view/com/modals/DeleteAccount.tsx:191
 msgid "Password"
@@ -1494,8 +1518,8 @@ msgstr ""
 
 #: src/view/shell/bottom-bar/BottomBar.tsx:237
 #: src/view/shell/Drawer.tsx:72
-#: src/view/shell/Drawer.tsx:366
-#: src/view/shell/Drawer.tsx:367
+#: src/view/shell/Drawer.tsx:533
+#: src/view/shell/Drawer.tsx:534
 msgid "Profile"
 msgstr ""
 
@@ -1539,7 +1563,7 @@ msgstr ""
 
 #: src/view/com/modals/ListAddRemoveUsers.tsx:264
 #: src/view/com/modals/SelfLabel.tsx:83
-#: src/view/com/modals/UserAddRemoveLists.tsx:192
+#: src/view/com/modals/UserAddRemoveLists.tsx:193
 #: src/view/com/util/UserAvatar.tsx:278
 #: src/view/com/util/UserBanner.tsx:89
 msgid "Remove"
@@ -1575,7 +1599,7 @@ msgid "Remove this feed from your saved feeds?"
 msgstr ""
 
 #: src/view/com/modals/ListAddRemoveUsers.tsx:199
-#: src/view/com/modals/UserAddRemoveLists.tsx:135
+#: src/view/com/modals/UserAddRemoveLists.tsx:136
 msgid "Removed from list"
 msgstr ""
 
@@ -1595,7 +1619,7 @@ msgstr ""
 msgid "Report feed"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:440
+#: src/view/screens/ProfileList.tsx:448
 msgid "Report List"
 msgstr ""
 
@@ -1621,6 +1645,10 @@ msgstr ""
 #: src/view/com/modals/ChangeEmail.tsx:183
 msgid "Request Change"
 msgstr ""
+
+#: src/view/screens/Moderation.tsx:188
+#~ msgid "Request to limit the visibility of my account"
+#~ msgstr ""
 
 #: src/view/screens/Settings.tsx:382
 #~ msgid "Require alt text before posting"
@@ -1656,8 +1684,8 @@ msgstr ""
 
 #: src/view/com/auth/create/CreateAccount.tsx:167
 #: src/view/com/auth/create/CreateAccount.tsx:171
-#: src/view/com/auth/login/LoginForm.tsx:260
-#: src/view/com/auth/login/LoginForm.tsx:263
+#: src/view/com/auth/login/LoginForm.tsx:258
+#: src/view/com/auth/login/LoginForm.tsx:261
 #: src/view/com/util/error/ErrorMessage.tsx:55
 #: src/view/com/util/error/ErrorScreen.tsx:65
 msgid "Retry"
@@ -1709,8 +1737,8 @@ msgstr ""
 #: src/view/shell/desktop/LeftNav.tsx:323
 #: src/view/shell/desktop/Search.tsx:161
 #: src/view/shell/desktop/Search.tsx:170
-#: src/view/shell/Drawer.tsx:252
-#: src/view/shell/Drawer.tsx:253
+#: src/view/shell/Drawer.tsx:351
+#: src/view/shell/Drawer.tsx:352
 msgid "Search"
 msgstr ""
 
@@ -1734,7 +1762,7 @@ msgstr ""
 msgid "Select from an existing account"
 msgstr ""
 
-#: src/view/com/auth/login/LoginForm.tsx:145
+#: src/view/com/auth/login/LoginForm.tsx:143
 msgid "Select service"
 msgstr ""
 
@@ -1762,8 +1790,8 @@ msgstr ""
 msgid "Send Email"
 msgstr ""
 
-#: src/view/shell/Drawer.tsx:394
-#: src/view/shell/Drawer.tsx:415
+#: src/view/shell/Drawer.tsx:284
+#: src/view/shell/Drawer.tsx:305
 msgid "Send feedback"
 msgstr ""
 
@@ -1797,8 +1825,8 @@ msgstr ""
 
 #: src/view/screens/Settings.tsx:277
 #: src/view/shell/desktop/LeftNav.tsx:435
-#: src/view/shell/Drawer.tsx:379
-#: src/view/shell/Drawer.tsx:380
+#: src/view/shell/Drawer.tsx:554
+#: src/view/shell/Drawer.tsx:555
 msgid "Settings"
 msgstr ""
 
@@ -1808,7 +1836,7 @@ msgstr ""
 
 #: src/view/com/profile/ProfileHeader.tsx:313
 #: src/view/com/util/forms/PostDropdownBtn.tsx:126
-#: src/view/screens/ProfileList.tsx:399
+#: src/view/screens/ProfileList.tsx:407
 msgid "Share"
 msgstr ""
 
@@ -1873,7 +1901,7 @@ msgstr ""
 msgid "Sign in as..."
 msgstr ""
 
-#: src/view/com/auth/login/LoginForm.tsx:132
+#: src/view/com/auth/login/LoginForm.tsx:130
 msgid "Sign into"
 msgstr ""
 
@@ -1925,11 +1953,11 @@ msgstr ""
 msgid "Storybook"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:522
+#: src/view/screens/ProfileList.tsx:530
 msgid "Subscribe"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:518
+#: src/view/screens/ProfileList.tsx:526
 msgid "Subscribe to this list"
 msgstr ""
 
@@ -2137,12 +2165,12 @@ msgstr ""
 msgid "User Lists"
 msgstr ""
 
-#: src/view/com/auth/login/LoginForm.tsx:172
-#: src/view/com/auth/login/LoginForm.tsx:189
+#: src/view/com/auth/login/LoginForm.tsx:170
+#: src/view/com/auth/login/LoginForm.tsx:187
 msgid "Username or email address"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:686
+#: src/view/screens/ProfileList.tsx:694
 msgid "Users"
 msgstr ""
 
@@ -2262,7 +2290,7 @@ msgstr ""
 msgid "You have no feeds."
 msgstr ""
 
-#: src/view/com/lists/MyLists.tsx:88
+#: src/view/com/lists/MyLists.tsx:89
 #: src/view/com/lists/ProfileLists.tsx:154
 msgid "You have no lists."
 msgstr ""
@@ -2318,7 +2346,7 @@ msgstr ""
 
 #: src/view/screens/Settings.tsx:402
 #: src/view/shell/desktop/RightNav.tsx:127
-#: src/view/shell/Drawer.tsx:517
+#: src/view/shell/Drawer.tsx:644
 msgid "Your invite codes are hidden when logged in using an App Password"
 msgstr ""
 
@@ -2329,6 +2357,10 @@ msgstr ""
 #: src/view/com/modals/SwitchAccount.tsx:78
 msgid "Your profile"
 msgstr ""
+
+#: src/view/screens/Moderation.tsx:205
+#~ msgid "Your profile and account will not be visible to anyone visiting the Bluesky app without an account, or to account holders who are not logged in. Enabling this will not make your profile private."
+#~ msgstr ""
 
 #: src/view/com/auth/create/Step3.tsx:28
 msgid "Your user handle"

--- a/src/locale/locales/en/messages.po
+++ b/src/locale/locales/en/messages.po
@@ -68,8 +68,8 @@ msgstr ""
 #~ msgstr ""
 
 #: src/view/screens/Moderation.tsx:212
-msgid "<0>Note: Your profile and posts will remain publicly available. Third-party apps that display Bluesky content may not respect this setting.</0>"
-msgstr ""
+#~ msgid "<0>Note: Your profile and posts will remain publicly available. Third-party apps that display Bluesky content may not respect this setting.</0>"
+#~ msgstr ""
 
 #: src/lib/hooks/useOTAUpdate.ts:16
 msgid "A new version of the app is available. Please update to continue using the app."
@@ -200,8 +200,8 @@ msgid "Appearance"
 msgstr ""
 
 #: src/view/screens/Moderation.tsx:206
-msgid "Apps that respect this setting, including the official Bluesky app and bsky.app website, won't show your content to logged out users."
-msgstr ""
+#~ msgid "Apps that respect this setting, including the official Bluesky app and bsky.app website, won't show your content to logged out users."
+#~ msgstr ""
 
 #: src/view/screens/AppPasswords.tsx:223
 msgid "Are you sure you want to delete the app password \"{name}\"?"
@@ -224,8 +224,8 @@ msgid "Artistic or non-erotic nudity."
 msgstr ""
 
 #: src/view/screens/Moderation.tsx:189
-msgid "Ask apps to limit the visibility of my account"
-msgstr ""
+#~ msgid "Ask apps to limit the visibility of my account"
+#~ msgstr ""
 
 #: src/view/com/auth/create/CreateAccount.tsx:145
 #: src/view/com/auth/login/ChooseAccountForm.tsx:151
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Learn more about this warning"
 msgstr ""
 
-#: src/view/screens/Moderation.tsx:223
+#: src/view/screens/Moderation.tsx:235
 msgid "Learn more about what is public on Bluesky."
 msgstr ""
 
@@ -1113,6 +1113,10 @@ msgstr ""
 #: src/view/screens/PostLikedBy.tsx:27
 #: src/view/screens/ProfileFeedLikedBy.tsx:27
 msgid "Liked by"
+msgstr ""
+
+#: src/view/screens/Moderation.tsx:203
+msgid "Limit the visibility of my account"
 msgstr ""
 
 #: src/view/com/modals/CreateOrEditList.tsx:186
@@ -1148,6 +1152,10 @@ msgstr ""
 
 #: src/view/com/modals/ServerInput.tsx:50
 msgid "Local dev server"
+msgstr ""
+
+#: src/view/screens/Moderation.tsx:134
+msgid "Logged-out users"
 msgstr ""
 
 #: src/view/com/auth/login/ChooseAccountForm.tsx:133
@@ -1234,8 +1242,8 @@ msgid "Muting is private. Muted accounts can interact with you, but you will not
 msgstr ""
 
 #: src/view/screens/Moderation.tsx:134
-msgid "My Account"
-msgstr ""
+#~ msgid "My Account"
+#~ msgstr ""
 
 #: src/view/com/modals/BirthDateSettings.tsx:56
 msgid "My Birthday"
@@ -1333,6 +1341,10 @@ msgstr ""
 
 #: src/view/com/modals/SelfLabel.tsx:135
 msgid "Not Applicable."
+msgstr ""
+
+#: src/view/screens/Moderation.tsx:227
+msgid "Note: Third-party apps that display Bluesky content may not respect this setting."
 msgstr ""
 
 #: src/view/screens/Notifications.tsx:96
@@ -2361,6 +2373,10 @@ msgstr ""
 #: src/view/screens/Moderation.tsx:205
 #~ msgid "Your profile and account will not be visible to anyone visiting the Bluesky app without an account, or to account holders who are not logged in. Enabling this will not make your profile private."
 #~ msgstr ""
+
+#: src/view/screens/Moderation.tsx:220
+msgid "Your profile and content will not be visible to anyone visiting the Bluesky app without an account. Enabling this will not make your profile private."
+msgstr ""
 
 #: src/view/com/auth/create/Step3.tsx:28
 msgid "Your user handle"

--- a/src/locale/locales/en/messages.po
+++ b/src/locale/locales/en/messages.po
@@ -38,12 +38,12 @@ msgid "{invitesAvailable, plural, one {Invite codes: # available} other {Invite 
 msgstr ""
 
 #: src/view/screens/Settings.tsx:407
-#: src/view/shell/Drawer.tsx:521
+#: src/view/shell/Drawer.tsx:648
 msgid "{invitesAvailable} invite code available"
 msgstr ""
 
 #: src/view/screens/Settings.tsx:409
-#: src/view/shell/Drawer.tsx:523
+#: src/view/shell/Drawer.tsx:650
 msgid "{invitesAvailable} invite codes available"
 msgstr ""
 
@@ -63,6 +63,14 @@ msgstr ""
 #~ msgid "<0>Here is your app password.</0> Use this to sign into the other app along with your handle."
 #~ msgstr ""
 
+#: src/view/screens/Moderation.tsx:212
+#~ msgid "<0>Note: This setting may not be respected by third-party apps that display Bluesky content.</0>"
+#~ msgstr ""
+
+#: src/view/screens/Moderation.tsx:212
+msgid "<0>Note: Your profile and posts will remain publicly available. Third-party apps that display Bluesky content may not respect this setting.</0>"
+msgstr ""
+
 #: src/lib/hooks/useOTAUpdate.ts:16
 msgid "A new version of the app is available. Please update to continue using the app."
 msgstr ""
@@ -72,7 +80,7 @@ msgstr ""
 msgid "Accessibility"
 msgstr ""
 
-#: src/view/com/auth/login/LoginForm.tsx:161
+#: src/view/com/auth/login/LoginForm.tsx:159
 #: src/view/screens/Settings.tsx:286
 msgid "Account"
 msgstr ""
@@ -82,8 +90,8 @@ msgid "Account options"
 msgstr ""
 
 #: src/view/com/modals/ListAddRemoveUsers.tsx:264
-#: src/view/com/modals/UserAddRemoveLists.tsx:192
-#: src/view/screens/ProfileList.tsx:702
+#: src/view/com/modals/UserAddRemoveLists.tsx:193
+#: src/view/screens/ProfileList.tsx:710
 msgid "Add"
 msgstr ""
 
@@ -91,7 +99,7 @@ msgstr ""
 msgid "Add a content warning"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:692
+#: src/view/screens/ProfileList.tsx:700
 msgid "Add a user to this list"
 msgstr ""
 
@@ -135,7 +143,7 @@ msgid "Add to my feeds"
 msgstr ""
 
 #: src/view/com/modals/ListAddRemoveUsers.tsx:191
-#: src/view/com/modals/UserAddRemoveLists.tsx:127
+#: src/view/com/modals/UserAddRemoveLists.tsx:128
 msgid "Added to list"
 msgstr ""
 
@@ -191,6 +199,10 @@ msgstr ""
 msgid "Appearance"
 msgstr ""
 
+#: src/view/screens/Moderation.tsx:206
+msgid "Apps that respect this setting, including the official Bluesky app and bsky.app website, won't show your content to logged out users."
+msgstr ""
+
 #: src/view/screens/AppPasswords.tsx:223
 msgid "Are you sure you want to delete the app password \"{name}\"?"
 msgstr ""
@@ -199,7 +211,7 @@ msgstr ""
 msgid "Are you sure you'd like to discard this draft?"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:369
+#: src/view/screens/ProfileList.tsx:375
 msgid "Are you sure?"
 msgstr ""
 
@@ -211,10 +223,14 @@ msgstr ""
 msgid "Artistic or non-erotic nudity."
 msgstr ""
 
+#: src/view/screens/Moderation.tsx:189
+msgid "Ask apps to limit the visibility of my account"
+msgstr ""
+
 #: src/view/com/auth/create/CreateAccount.tsx:145
 #: src/view/com/auth/login/ChooseAccountForm.tsx:151
 #: src/view/com/auth/login/ForgotPasswordForm.tsx:166
-#: src/view/com/auth/login/LoginForm.tsx:251
+#: src/view/com/auth/login/LoginForm.tsx:249
 #: src/view/com/auth/login/SetNewPasswordForm.tsx:148
 #: src/view/com/modals/report/InputIssueDetails.tsx:45
 #: src/view/com/post-thread/PostThread.tsx:381
@@ -242,15 +258,15 @@ msgstr ""
 msgid "Block Account"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:470
+#: src/view/screens/ProfileList.tsx:478
 msgid "Block accounts"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:326
+#: src/view/screens/ProfileList.tsx:330
 msgid "Block these accounts?"
 msgstr ""
 
-#: src/view/screens/Moderation.tsx:109
+#: src/view/screens/Moderation.tsx:121
 msgid "Blocked accounts"
 msgstr ""
 
@@ -270,7 +286,7 @@ msgstr ""
 msgid "Blocked post."
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:328
+#: src/view/screens/ProfileList.tsx:332
 msgid "Blocking is public. Blocked accounts cannot reply in your threads, mention you, or otherwise interact with you."
 msgstr ""
 
@@ -492,11 +508,11 @@ msgid "Confirmation code"
 msgstr ""
 
 #: src/view/com/auth/create/CreateAccount.tsx:178
-#: src/view/com/auth/login/LoginForm.tsx:270
+#: src/view/com/auth/login/LoginForm.tsx:268
 msgid "Connecting..."
 msgstr ""
 
-#: src/view/screens/Moderation.tsx:67
+#: src/view/screens/Moderation.tsx:79
 msgid "Content filtering"
 msgstr ""
 
@@ -531,7 +547,7 @@ msgstr ""
 msgid "Copy"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:399
+#: src/view/screens/ProfileList.tsx:407
 msgid "Copy link to list"
 msgstr ""
 
@@ -555,7 +571,7 @@ msgstr ""
 msgid "Could not load feed"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:779
+#: src/view/screens/ProfileList.tsx:787
 msgid "Could not load list"
 msgstr ""
 
@@ -601,8 +617,8 @@ msgstr ""
 msgid "Delete app password"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:368
-#: src/view/screens/ProfileList.tsx:426
+#: src/view/screens/ProfileList.tsx:374
+#: src/view/screens/ProfileList.tsx:434
 msgid "Delete List"
 msgstr ""
 
@@ -672,7 +688,7 @@ msgstr ""
 #: src/view/com/modals/EditImage.tsx:333
 #: src/view/com/modals/ListAddRemoveUsers.tsx:142
 #: src/view/com/modals/SelfLabel.tsx:157
-#: src/view/com/modals/UserAddRemoveLists.tsx:78
+#: src/view/com/modals/UserAddRemoveLists.tsx:79
 #: src/view/screens/PreferencesHomeFeed.tsx:302
 #: src/view/screens/PreferencesThreads.tsx:156
 msgid "Done"
@@ -691,7 +707,7 @@ msgstr ""
 msgid "Edit image"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:414
+#: src/view/screens/ProfileList.tsx:422
 msgid "Edit list details"
 msgstr ""
 
@@ -789,15 +805,15 @@ msgid "Feed Preferences"
 msgstr ""
 
 #: src/view/shell/desktop/RightNav.tsx:64
-#: src/view/shell/Drawer.tsx:410
+#: src/view/shell/Drawer.tsx:300
 msgid "Feedback"
 msgstr ""
 
 #: src/view/screens/Feeds.tsx:475
 #: src/view/shell/bottom-bar/BottomBar.tsx:168
 #: src/view/shell/desktop/LeftNav.tsx:341
-#: src/view/shell/Drawer.tsx:327
-#: src/view/shell/Drawer.tsx:328
+#: src/view/shell/Drawer.tsx:463
+#: src/view/shell/Drawer.tsx:464
 msgid "Feeds"
 msgstr ""
 
@@ -862,11 +878,11 @@ msgstr ""
 msgid "For security reasons, you won't be able to view this again. If you lose this password, you'll need to generate a new one."
 msgstr ""
 
-#: src/view/com/auth/login/LoginForm.tsx:233
+#: src/view/com/auth/login/LoginForm.tsx:231
 msgid "Forgot"
 msgstr ""
 
-#: src/view/com/auth/login/LoginForm.tsx:230
+#: src/view/com/auth/login/LoginForm.tsx:228
 msgid "Forgot password"
 msgstr ""
 
@@ -892,13 +908,13 @@ msgstr ""
 
 #: src/view/screens/ProfileFeed.tsx:111
 #: src/view/screens/ProfileFeed.tsx:116
-#: src/view/screens/ProfileList.tsx:788
-#: src/view/screens/ProfileList.tsx:793
+#: src/view/screens/ProfileList.tsx:796
+#: src/view/screens/ProfileList.tsx:801
 msgid "Go Back"
 msgstr ""
 
 #: src/view/com/auth/login/ForgotPasswordForm.tsx:181
-#: src/view/com/auth/login/LoginForm.tsx:280
+#: src/view/com/auth/login/LoginForm.tsx:278
 #: src/view/com/auth/login/SetNewPasswordForm.tsx:163
 msgid "Go to next"
 msgstr ""
@@ -908,7 +924,7 @@ msgid "Handle"
 msgstr ""
 
 #: src/view/shell/desktop/RightNav.tsx:93
-#: src/view/shell/Drawer.tsx:420
+#: src/view/shell/Drawer.tsx:310
 msgid "Help"
 msgstr ""
 
@@ -954,8 +970,8 @@ msgstr ""
 
 #: src/view/shell/bottom-bar/BottomBar.tsx:124
 #: src/view/shell/desktop/LeftNav.tsx:305
-#: src/view/shell/Drawer.tsx:274
-#: src/view/shell/Drawer.tsx:275
+#: src/view/shell/Drawer.tsx:387
+#: src/view/shell/Drawer.tsx:388
 msgid "Home"
 msgstr ""
 
@@ -1021,7 +1037,7 @@ msgstr ""
 msgid "Invite code not accepted. Check that you input it correctly and try again."
 msgstr ""
 
-#: src/view/shell/Drawer.tsx:502
+#: src/view/shell/Drawer.tsx:629
 msgid "Invite codes: {invitesAvailable} available"
 msgstr ""
 
@@ -1064,6 +1080,10 @@ msgstr ""
 msgid "Learn more about this warning"
 msgstr ""
 
+#: src/view/screens/Moderation.tsx:223
+msgid "Learn more about what is public on Bluesky."
+msgstr ""
+
 #: src/view/com/modals/lang-settings/ContentLanguagesSettings.tsx:82
 msgid "Leave them all unchecked to see any language."
 msgstr ""
@@ -1086,7 +1106,7 @@ msgstr ""
 #~ msgid "Light"
 #~ msgstr ""
 
-#: src/view/screens/ProfileFeed.tsx:637
+#: src/view/screens/ProfileFeed.tsx:639
 msgid "Like this feed"
 msgstr ""
 
@@ -1104,8 +1124,8 @@ msgid "List Name"
 msgstr ""
 
 #: src/view/shell/desktop/LeftNav.tsx:381
-#: src/view/shell/Drawer.tsx:338
-#: src/view/shell/Drawer.tsx:339
+#: src/view/shell/Drawer.tsx:479
+#: src/view/shell/Drawer.tsx:480
 msgid "Lists"
 msgstr ""
 
@@ -1151,15 +1171,15 @@ msgstr ""
 msgid "Message from server"
 msgstr ""
 
-#: src/view/screens/Moderation.tsx:51
+#: src/view/screens/Moderation.tsx:63
 #: src/view/screens/Settings.tsx:563
 #: src/view/shell/desktop/LeftNav.tsx:399
-#: src/view/shell/Drawer.tsx:345
-#: src/view/shell/Drawer.tsx:346
+#: src/view/shell/Drawer.tsx:498
+#: src/view/shell/Drawer.tsx:499
 msgid "Moderation"
 msgstr ""
 
-#: src/view/screens/Moderation.tsx:81
+#: src/view/screens/Moderation.tsx:93
 msgid "Moderation lists"
 msgstr ""
 
@@ -1173,7 +1193,7 @@ msgstr ""
 
 #: src/view/com/profile/ProfileHeader.tsx:523
 #: src/view/screens/ProfileFeed.tsx:369
-#: src/view/screens/ProfileList.tsx:531
+#: src/view/screens/ProfileList.tsx:539
 msgid "More options"
 msgstr ""
 
@@ -1185,11 +1205,11 @@ msgstr ""
 msgid "Mute Account"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:458
+#: src/view/screens/ProfileList.tsx:466
 msgid "Mute accounts"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:291
+#: src/view/screens/ProfileList.tsx:293
 msgid "Mute these accounts?"
 msgstr ""
 
@@ -1197,7 +1217,7 @@ msgstr ""
 msgid "Mute thread"
 msgstr ""
 
-#: src/view/screens/Moderation.tsx:95
+#: src/view/screens/Moderation.tsx:107
 msgid "Muted accounts"
 msgstr ""
 
@@ -1209,8 +1229,12 @@ msgstr ""
 msgid "Muted accounts have their posts removed from your feed and from your notifications. Mutes are completely private."
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:293
+#: src/view/screens/ProfileList.tsx:295
 msgid "Muting is private. Muted accounts can interact with you, but you will not see their posts or receive notifications from them."
+msgstr ""
+
+#: src/view/screens/Moderation.tsx:134
+msgid "My Account"
 msgstr ""
 
 #: src/view/com/modals/BirthDateSettings.tsx:56
@@ -1247,8 +1271,8 @@ msgstr ""
 #: src/view/screens/Feeds.tsx:510
 #: src/view/screens/Profile.tsx:388
 #: src/view/screens/ProfileFeed.tsx:450
-#: src/view/screens/ProfileList.tsx:211
-#: src/view/screens/ProfileList.tsx:243
+#: src/view/screens/ProfileList.tsx:212
+#: src/view/screens/ProfileList.tsx:244
 #: src/view/shell/desktop/LeftNav.tsx:254
 msgid "New post"
 msgstr ""
@@ -1260,7 +1284,7 @@ msgstr ""
 #: src/view/com/auth/create/CreateAccount.tsx:158
 #: src/view/com/auth/login/ForgotPasswordForm.tsx:174
 #: src/view/com/auth/login/ForgotPasswordForm.tsx:184
-#: src/view/com/auth/login/LoginForm.tsx:283
+#: src/view/com/auth/login/LoginForm.tsx:281
 #: src/view/com/auth/login/SetNewPasswordForm.tsx:156
 #: src/view/com/auth/login/SetNewPasswordForm.tsx:166
 #: src/view/com/auth/onboarding/RecommendedFeeds.tsx:79
@@ -1277,8 +1301,8 @@ msgstr ""
 msgid "No"
 msgstr "<<<<<<< HEAD"
 
-#: src/view/screens/ProfileFeed.tsx:630
-#: src/view/screens/ProfileList.tsx:659
+#: src/view/screens/ProfileFeed.tsx:632
+#: src/view/screens/ProfileList.tsx:667
 msgid "No description"
 msgstr ""
 
@@ -1315,8 +1339,8 @@ msgstr ""
 #: src/view/screens/Notifications.tsx:120
 #: src/view/shell/bottom-bar/BottomBar.tsx:195
 #: src/view/shell/desktop/LeftNav.tsx:363
-#: src/view/shell/Drawer.tsx:298
-#: src/view/shell/Drawer.tsx:299
+#: src/view/shell/Drawer.tsx:424
+#: src/view/shell/Drawer.tsx:425
 msgid "Notifications"
 msgstr ""
 
@@ -1341,7 +1365,7 @@ msgid "Opens configurable language settings"
 msgstr ""
 
 #: src/view/shell/desktop/RightNav.tsx:146
-#: src/view/shell/Drawer.tsx:503
+#: src/view/shell/Drawer.tsx:630
 msgid "Opens list of invite codes"
 msgstr ""
 
@@ -1396,7 +1420,7 @@ msgstr ""
 
 #: src/view/com/auth/create/Step2.tsx:101
 #: src/view/com/auth/create/Step2.tsx:111
-#: src/view/com/auth/login/LoginForm.tsx:218
+#: src/view/com/auth/login/LoginForm.tsx:216
 #: src/view/com/auth/login/SetNewPasswordForm.tsx:130
 #: src/view/com/modals/DeleteAccount.tsx:191
 msgid "Password"
@@ -1494,8 +1518,8 @@ msgstr ""
 
 #: src/view/shell/bottom-bar/BottomBar.tsx:237
 #: src/view/shell/Drawer.tsx:72
-#: src/view/shell/Drawer.tsx:366
-#: src/view/shell/Drawer.tsx:367
+#: src/view/shell/Drawer.tsx:533
+#: src/view/shell/Drawer.tsx:534
 msgid "Profile"
 msgstr ""
 
@@ -1539,7 +1563,7 @@ msgstr ""
 
 #: src/view/com/modals/ListAddRemoveUsers.tsx:264
 #: src/view/com/modals/SelfLabel.tsx:83
-#: src/view/com/modals/UserAddRemoveLists.tsx:192
+#: src/view/com/modals/UserAddRemoveLists.tsx:193
 #: src/view/com/util/UserAvatar.tsx:278
 #: src/view/com/util/UserBanner.tsx:89
 msgid "Remove"
@@ -1575,7 +1599,7 @@ msgid "Remove this feed from your saved feeds?"
 msgstr ""
 
 #: src/view/com/modals/ListAddRemoveUsers.tsx:199
-#: src/view/com/modals/UserAddRemoveLists.tsx:135
+#: src/view/com/modals/UserAddRemoveLists.tsx:136
 msgid "Removed from list"
 msgstr ""
 
@@ -1595,7 +1619,7 @@ msgstr ""
 msgid "Report feed"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:440
+#: src/view/screens/ProfileList.tsx:448
 msgid "Report List"
 msgstr ""
 
@@ -1621,6 +1645,10 @@ msgstr ""
 #: src/view/com/modals/ChangeEmail.tsx:183
 msgid "Request Change"
 msgstr ""
+
+#: src/view/screens/Moderation.tsx:188
+#~ msgid "Request to limit the visibility of my account"
+#~ msgstr ""
 
 #: src/view/screens/Settings.tsx:382
 #~ msgid "Require alt text before posting"
@@ -1656,8 +1684,8 @@ msgstr ""
 
 #: src/view/com/auth/create/CreateAccount.tsx:167
 #: src/view/com/auth/create/CreateAccount.tsx:171
-#: src/view/com/auth/login/LoginForm.tsx:260
-#: src/view/com/auth/login/LoginForm.tsx:263
+#: src/view/com/auth/login/LoginForm.tsx:258
+#: src/view/com/auth/login/LoginForm.tsx:261
 #: src/view/com/util/error/ErrorMessage.tsx:55
 #: src/view/com/util/error/ErrorScreen.tsx:65
 msgid "Retry"
@@ -1709,8 +1737,8 @@ msgstr ""
 #: src/view/shell/desktop/LeftNav.tsx:323
 #: src/view/shell/desktop/Search.tsx:161
 #: src/view/shell/desktop/Search.tsx:170
-#: src/view/shell/Drawer.tsx:252
-#: src/view/shell/Drawer.tsx:253
+#: src/view/shell/Drawer.tsx:351
+#: src/view/shell/Drawer.tsx:352
 msgid "Search"
 msgstr ""
 
@@ -1734,7 +1762,7 @@ msgstr ""
 msgid "Select from an existing account"
 msgstr ""
 
-#: src/view/com/auth/login/LoginForm.tsx:145
+#: src/view/com/auth/login/LoginForm.tsx:143
 msgid "Select service"
 msgstr ""
 
@@ -1762,8 +1790,8 @@ msgstr ""
 msgid "Send Email"
 msgstr ""
 
-#: src/view/shell/Drawer.tsx:394
-#: src/view/shell/Drawer.tsx:415
+#: src/view/shell/Drawer.tsx:284
+#: src/view/shell/Drawer.tsx:305
 msgid "Send feedback"
 msgstr ""
 
@@ -1797,8 +1825,8 @@ msgstr ""
 
 #: src/view/screens/Settings.tsx:277
 #: src/view/shell/desktop/LeftNav.tsx:435
-#: src/view/shell/Drawer.tsx:379
-#: src/view/shell/Drawer.tsx:380
+#: src/view/shell/Drawer.tsx:554
+#: src/view/shell/Drawer.tsx:555
 msgid "Settings"
 msgstr ""
 
@@ -1808,7 +1836,7 @@ msgstr ""
 
 #: src/view/com/profile/ProfileHeader.tsx:313
 #: src/view/com/util/forms/PostDropdownBtn.tsx:126
-#: src/view/screens/ProfileList.tsx:399
+#: src/view/screens/ProfileList.tsx:407
 msgid "Share"
 msgstr ""
 
@@ -1873,7 +1901,7 @@ msgstr ""
 msgid "Sign in as..."
 msgstr ""
 
-#: src/view/com/auth/login/LoginForm.tsx:132
+#: src/view/com/auth/login/LoginForm.tsx:130
 msgid "Sign into"
 msgstr ""
 
@@ -1925,11 +1953,11 @@ msgstr ""
 msgid "Storybook"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:522
+#: src/view/screens/ProfileList.tsx:530
 msgid "Subscribe"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:518
+#: src/view/screens/ProfileList.tsx:526
 msgid "Subscribe to this list"
 msgstr ""
 
@@ -2137,12 +2165,12 @@ msgstr ""
 msgid "User Lists"
 msgstr ""
 
-#: src/view/com/auth/login/LoginForm.tsx:172
-#: src/view/com/auth/login/LoginForm.tsx:189
+#: src/view/com/auth/login/LoginForm.tsx:170
+#: src/view/com/auth/login/LoginForm.tsx:187
 msgid "Username or email address"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:686
+#: src/view/screens/ProfileList.tsx:694
 msgid "Users"
 msgstr ""
 
@@ -2262,7 +2290,7 @@ msgstr ""
 msgid "You have no feeds."
 msgstr ""
 
-#: src/view/com/lists/MyLists.tsx:88
+#: src/view/com/lists/MyLists.tsx:89
 #: src/view/com/lists/ProfileLists.tsx:154
 msgid "You have no lists."
 msgstr ""
@@ -2318,7 +2346,7 @@ msgstr ""
 
 #: src/view/screens/Settings.tsx:402
 #: src/view/shell/desktop/RightNav.tsx:127
-#: src/view/shell/Drawer.tsx:517
+#: src/view/shell/Drawer.tsx:644
 msgid "Your invite codes are hidden when logged in using an App Password"
 msgstr ""
 
@@ -2329,6 +2357,10 @@ msgstr ""
 #: src/view/com/modals/SwitchAccount.tsx:78
 msgid "Your profile"
 msgstr ""
+
+#: src/view/screens/Moderation.tsx:205
+#~ msgid "Your profile and account will not be visible to anyone visiting the Bluesky app without an account, or to account holders who are not logged in. Enabling this will not make your profile private."
+#~ msgstr ""
 
 #: src/view/com/auth/create/Step3.tsx:28
 msgid "Your user handle"

--- a/src/locale/locales/es/messages.po
+++ b/src/locale/locales/es/messages.po
@@ -68,8 +68,8 @@ msgstr ""
 #~ msgstr ""
 
 #: src/view/screens/Moderation.tsx:212
-msgid "<0>Note: Your profile and posts will remain publicly available. Third-party apps that display Bluesky content may not respect this setting.</0>"
-msgstr ""
+#~ msgid "<0>Note: Your profile and posts will remain publicly available. Third-party apps that display Bluesky content may not respect this setting.</0>"
+#~ msgstr ""
 
 #: src/lib/hooks/useOTAUpdate.ts:16
 msgid "A new version of the app is available. Please update to continue using the app."
@@ -200,8 +200,8 @@ msgid "Appearance"
 msgstr ""
 
 #: src/view/screens/Moderation.tsx:206
-msgid "Apps that respect this setting, including the official Bluesky app and bsky.app website, won't show your content to logged out users."
-msgstr ""
+#~ msgid "Apps that respect this setting, including the official Bluesky app and bsky.app website, won't show your content to logged out users."
+#~ msgstr ""
 
 #: src/view/screens/AppPasswords.tsx:223
 msgid "Are you sure you want to delete the app password \"{name}\"?"
@@ -224,8 +224,8 @@ msgid "Artistic or non-erotic nudity."
 msgstr ""
 
 #: src/view/screens/Moderation.tsx:189
-msgid "Ask apps to limit the visibility of my account"
-msgstr ""
+#~ msgid "Ask apps to limit the visibility of my account"
+#~ msgstr ""
 
 #: src/view/com/auth/create/CreateAccount.tsx:145
 #: src/view/com/auth/login/ChooseAccountForm.tsx:151
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Learn more about this warning"
 msgstr ""
 
-#: src/view/screens/Moderation.tsx:223
+#: src/view/screens/Moderation.tsx:235
 msgid "Learn more about what is public on Bluesky."
 msgstr ""
 
@@ -1113,6 +1113,10 @@ msgstr ""
 #: src/view/screens/PostLikedBy.tsx:27
 #: src/view/screens/ProfileFeedLikedBy.tsx:27
 msgid "Liked by"
+msgstr ""
+
+#: src/view/screens/Moderation.tsx:203
+msgid "Limit the visibility of my account"
 msgstr ""
 
 #: src/view/com/modals/CreateOrEditList.tsx:186
@@ -1148,6 +1152,10 @@ msgstr ""
 
 #: src/view/com/modals/ServerInput.tsx:50
 msgid "Local dev server"
+msgstr ""
+
+#: src/view/screens/Moderation.tsx:134
+msgid "Logged-out users"
 msgstr ""
 
 #: src/view/com/auth/login/ChooseAccountForm.tsx:133
@@ -1234,8 +1242,8 @@ msgid "Muting is private. Muted accounts can interact with you, but you will not
 msgstr ""
 
 #: src/view/screens/Moderation.tsx:134
-msgid "My Account"
-msgstr ""
+#~ msgid "My Account"
+#~ msgstr ""
 
 #: src/view/com/modals/BirthDateSettings.tsx:56
 msgid "My Birthday"
@@ -1333,6 +1341,10 @@ msgstr ""
 
 #: src/view/com/modals/SelfLabel.tsx:135
 msgid "Not Applicable."
+msgstr ""
+
+#: src/view/screens/Moderation.tsx:227
+msgid "Note: Third-party apps that display Bluesky content may not respect this setting."
 msgstr ""
 
 #: src/view/screens/Notifications.tsx:96
@@ -2361,6 +2373,10 @@ msgstr ""
 #: src/view/screens/Moderation.tsx:205
 #~ msgid "Your profile and account will not be visible to anyone visiting the Bluesky app without an account, or to account holders who are not logged in. Enabling this will not make your profile private."
 #~ msgstr ""
+
+#: src/view/screens/Moderation.tsx:220
+msgid "Your profile and content will not be visible to anyone visiting the Bluesky app without an account. Enabling this will not make your profile private."
+msgstr ""
 
 #: src/view/com/auth/create/Step3.tsx:28
 msgid "Your user handle"

--- a/src/locale/locales/es/messages.po
+++ b/src/locale/locales/es/messages.po
@@ -38,12 +38,12 @@ msgid "{invitesAvailable, plural, one {Invite codes: # available} other {Invite 
 msgstr ""
 
 #: src/view/screens/Settings.tsx:407
-#: src/view/shell/Drawer.tsx:521
+#: src/view/shell/Drawer.tsx:648
 msgid "{invitesAvailable} invite code available"
 msgstr ""
 
 #: src/view/screens/Settings.tsx:409
-#: src/view/shell/Drawer.tsx:523
+#: src/view/shell/Drawer.tsx:650
 msgid "{invitesAvailable} invite codes available"
 msgstr ""
 
@@ -63,6 +63,14 @@ msgstr ""
 #~ msgid "<0>Here is your app password.</0> Use this to sign into the other app along with your handle."
 #~ msgstr ""
 
+#: src/view/screens/Moderation.tsx:212
+#~ msgid "<0>Note: This setting may not be respected by third-party apps that display Bluesky content.</0>"
+#~ msgstr ""
+
+#: src/view/screens/Moderation.tsx:212
+msgid "<0>Note: Your profile and posts will remain publicly available. Third-party apps that display Bluesky content may not respect this setting.</0>"
+msgstr ""
+
 #: src/lib/hooks/useOTAUpdate.ts:16
 msgid "A new version of the app is available. Please update to continue using the app."
 msgstr ""
@@ -72,7 +80,7 @@ msgstr ""
 msgid "Accessibility"
 msgstr ""
 
-#: src/view/com/auth/login/LoginForm.tsx:161
+#: src/view/com/auth/login/LoginForm.tsx:159
 #: src/view/screens/Settings.tsx:286
 msgid "Account"
 msgstr ""
@@ -82,8 +90,8 @@ msgid "Account options"
 msgstr ""
 
 #: src/view/com/modals/ListAddRemoveUsers.tsx:264
-#: src/view/com/modals/UserAddRemoveLists.tsx:192
-#: src/view/screens/ProfileList.tsx:702
+#: src/view/com/modals/UserAddRemoveLists.tsx:193
+#: src/view/screens/ProfileList.tsx:710
 msgid "Add"
 msgstr ""
 
@@ -91,7 +99,7 @@ msgstr ""
 msgid "Add a content warning"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:692
+#: src/view/screens/ProfileList.tsx:700
 msgid "Add a user to this list"
 msgstr ""
 
@@ -135,7 +143,7 @@ msgid "Add to my feeds"
 msgstr ""
 
 #: src/view/com/modals/ListAddRemoveUsers.tsx:191
-#: src/view/com/modals/UserAddRemoveLists.tsx:127
+#: src/view/com/modals/UserAddRemoveLists.tsx:128
 msgid "Added to list"
 msgstr ""
 
@@ -191,6 +199,10 @@ msgstr ""
 msgid "Appearance"
 msgstr ""
 
+#: src/view/screens/Moderation.tsx:206
+msgid "Apps that respect this setting, including the official Bluesky app and bsky.app website, won't show your content to logged out users."
+msgstr ""
+
 #: src/view/screens/AppPasswords.tsx:223
 msgid "Are you sure you want to delete the app password \"{name}\"?"
 msgstr ""
@@ -199,7 +211,7 @@ msgstr ""
 msgid "Are you sure you'd like to discard this draft?"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:369
+#: src/view/screens/ProfileList.tsx:375
 msgid "Are you sure?"
 msgstr ""
 
@@ -211,10 +223,14 @@ msgstr ""
 msgid "Artistic or non-erotic nudity."
 msgstr ""
 
+#: src/view/screens/Moderation.tsx:189
+msgid "Ask apps to limit the visibility of my account"
+msgstr ""
+
 #: src/view/com/auth/create/CreateAccount.tsx:145
 #: src/view/com/auth/login/ChooseAccountForm.tsx:151
 #: src/view/com/auth/login/ForgotPasswordForm.tsx:166
-#: src/view/com/auth/login/LoginForm.tsx:251
+#: src/view/com/auth/login/LoginForm.tsx:249
 #: src/view/com/auth/login/SetNewPasswordForm.tsx:148
 #: src/view/com/modals/report/InputIssueDetails.tsx:45
 #: src/view/com/post-thread/PostThread.tsx:381
@@ -242,15 +258,15 @@ msgstr ""
 msgid "Block Account"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:470
+#: src/view/screens/ProfileList.tsx:478
 msgid "Block accounts"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:326
+#: src/view/screens/ProfileList.tsx:330
 msgid "Block these accounts?"
 msgstr ""
 
-#: src/view/screens/Moderation.tsx:109
+#: src/view/screens/Moderation.tsx:121
 msgid "Blocked accounts"
 msgstr ""
 
@@ -270,7 +286,7 @@ msgstr ""
 msgid "Blocked post."
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:328
+#: src/view/screens/ProfileList.tsx:332
 msgid "Blocking is public. Blocked accounts cannot reply in your threads, mention you, or otherwise interact with you."
 msgstr ""
 
@@ -492,11 +508,11 @@ msgid "Confirmation code"
 msgstr ""
 
 #: src/view/com/auth/create/CreateAccount.tsx:178
-#: src/view/com/auth/login/LoginForm.tsx:270
+#: src/view/com/auth/login/LoginForm.tsx:268
 msgid "Connecting..."
 msgstr ""
 
-#: src/view/screens/Moderation.tsx:67
+#: src/view/screens/Moderation.tsx:79
 msgid "Content filtering"
 msgstr ""
 
@@ -531,7 +547,7 @@ msgstr ""
 msgid "Copy"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:399
+#: src/view/screens/ProfileList.tsx:407
 msgid "Copy link to list"
 msgstr ""
 
@@ -555,7 +571,7 @@ msgstr ""
 msgid "Could not load feed"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:779
+#: src/view/screens/ProfileList.tsx:787
 msgid "Could not load list"
 msgstr ""
 
@@ -601,8 +617,8 @@ msgstr ""
 msgid "Delete app password"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:368
-#: src/view/screens/ProfileList.tsx:426
+#: src/view/screens/ProfileList.tsx:374
+#: src/view/screens/ProfileList.tsx:434
 msgid "Delete List"
 msgstr ""
 
@@ -672,7 +688,7 @@ msgstr ""
 #: src/view/com/modals/EditImage.tsx:333
 #: src/view/com/modals/ListAddRemoveUsers.tsx:142
 #: src/view/com/modals/SelfLabel.tsx:157
-#: src/view/com/modals/UserAddRemoveLists.tsx:78
+#: src/view/com/modals/UserAddRemoveLists.tsx:79
 #: src/view/screens/PreferencesHomeFeed.tsx:302
 #: src/view/screens/PreferencesThreads.tsx:156
 msgid "Done"
@@ -691,7 +707,7 @@ msgstr ""
 msgid "Edit image"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:414
+#: src/view/screens/ProfileList.tsx:422
 msgid "Edit list details"
 msgstr ""
 
@@ -789,15 +805,15 @@ msgid "Feed Preferences"
 msgstr ""
 
 #: src/view/shell/desktop/RightNav.tsx:64
-#: src/view/shell/Drawer.tsx:410
+#: src/view/shell/Drawer.tsx:300
 msgid "Feedback"
 msgstr ""
 
 #: src/view/screens/Feeds.tsx:475
 #: src/view/shell/bottom-bar/BottomBar.tsx:168
 #: src/view/shell/desktop/LeftNav.tsx:341
-#: src/view/shell/Drawer.tsx:327
-#: src/view/shell/Drawer.tsx:328
+#: src/view/shell/Drawer.tsx:463
+#: src/view/shell/Drawer.tsx:464
 msgid "Feeds"
 msgstr ""
 
@@ -862,11 +878,11 @@ msgstr ""
 msgid "For security reasons, you won't be able to view this again. If you lose this password, you'll need to generate a new one."
 msgstr ""
 
-#: src/view/com/auth/login/LoginForm.tsx:233
+#: src/view/com/auth/login/LoginForm.tsx:231
 msgid "Forgot"
 msgstr ""
 
-#: src/view/com/auth/login/LoginForm.tsx:230
+#: src/view/com/auth/login/LoginForm.tsx:228
 msgid "Forgot password"
 msgstr ""
 
@@ -892,13 +908,13 @@ msgstr ""
 
 #: src/view/screens/ProfileFeed.tsx:111
 #: src/view/screens/ProfileFeed.tsx:116
-#: src/view/screens/ProfileList.tsx:788
-#: src/view/screens/ProfileList.tsx:793
+#: src/view/screens/ProfileList.tsx:796
+#: src/view/screens/ProfileList.tsx:801
 msgid "Go Back"
 msgstr ""
 
 #: src/view/com/auth/login/ForgotPasswordForm.tsx:181
-#: src/view/com/auth/login/LoginForm.tsx:280
+#: src/view/com/auth/login/LoginForm.tsx:278
 #: src/view/com/auth/login/SetNewPasswordForm.tsx:163
 msgid "Go to next"
 msgstr ""
@@ -908,7 +924,7 @@ msgid "Handle"
 msgstr ""
 
 #: src/view/shell/desktop/RightNav.tsx:93
-#: src/view/shell/Drawer.tsx:420
+#: src/view/shell/Drawer.tsx:310
 msgid "Help"
 msgstr ""
 
@@ -954,8 +970,8 @@ msgstr ""
 
 #: src/view/shell/bottom-bar/BottomBar.tsx:124
 #: src/view/shell/desktop/LeftNav.tsx:305
-#: src/view/shell/Drawer.tsx:274
-#: src/view/shell/Drawer.tsx:275
+#: src/view/shell/Drawer.tsx:387
+#: src/view/shell/Drawer.tsx:388
 msgid "Home"
 msgstr ""
 
@@ -1021,7 +1037,7 @@ msgstr ""
 msgid "Invite code not accepted. Check that you input it correctly and try again."
 msgstr ""
 
-#: src/view/shell/Drawer.tsx:502
+#: src/view/shell/Drawer.tsx:629
 msgid "Invite codes: {invitesAvailable} available"
 msgstr ""
 
@@ -1064,6 +1080,10 @@ msgstr ""
 msgid "Learn more about this warning"
 msgstr ""
 
+#: src/view/screens/Moderation.tsx:223
+msgid "Learn more about what is public on Bluesky."
+msgstr ""
+
 #: src/view/com/modals/lang-settings/ContentLanguagesSettings.tsx:82
 msgid "Leave them all unchecked to see any language."
 msgstr ""
@@ -1086,7 +1106,7 @@ msgstr ""
 #~ msgid "Light"
 #~ msgstr ""
 
-#: src/view/screens/ProfileFeed.tsx:637
+#: src/view/screens/ProfileFeed.tsx:639
 msgid "Like this feed"
 msgstr ""
 
@@ -1104,8 +1124,8 @@ msgid "List Name"
 msgstr ""
 
 #: src/view/shell/desktop/LeftNav.tsx:381
-#: src/view/shell/Drawer.tsx:338
-#: src/view/shell/Drawer.tsx:339
+#: src/view/shell/Drawer.tsx:479
+#: src/view/shell/Drawer.tsx:480
 msgid "Lists"
 msgstr ""
 
@@ -1151,15 +1171,15 @@ msgstr ""
 msgid "Message from server"
 msgstr ""
 
-#: src/view/screens/Moderation.tsx:51
+#: src/view/screens/Moderation.tsx:63
 #: src/view/screens/Settings.tsx:563
 #: src/view/shell/desktop/LeftNav.tsx:399
-#: src/view/shell/Drawer.tsx:345
-#: src/view/shell/Drawer.tsx:346
+#: src/view/shell/Drawer.tsx:498
+#: src/view/shell/Drawer.tsx:499
 msgid "Moderation"
 msgstr ""
 
-#: src/view/screens/Moderation.tsx:81
+#: src/view/screens/Moderation.tsx:93
 msgid "Moderation lists"
 msgstr ""
 
@@ -1173,7 +1193,7 @@ msgstr ""
 
 #: src/view/com/profile/ProfileHeader.tsx:523
 #: src/view/screens/ProfileFeed.tsx:369
-#: src/view/screens/ProfileList.tsx:531
+#: src/view/screens/ProfileList.tsx:539
 msgid "More options"
 msgstr ""
 
@@ -1185,11 +1205,11 @@ msgstr ""
 msgid "Mute Account"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:458
+#: src/view/screens/ProfileList.tsx:466
 msgid "Mute accounts"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:291
+#: src/view/screens/ProfileList.tsx:293
 msgid "Mute these accounts?"
 msgstr ""
 
@@ -1197,7 +1217,7 @@ msgstr ""
 msgid "Mute thread"
 msgstr ""
 
-#: src/view/screens/Moderation.tsx:95
+#: src/view/screens/Moderation.tsx:107
 msgid "Muted accounts"
 msgstr ""
 
@@ -1209,8 +1229,12 @@ msgstr ""
 msgid "Muted accounts have their posts removed from your feed and from your notifications. Mutes are completely private."
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:293
+#: src/view/screens/ProfileList.tsx:295
 msgid "Muting is private. Muted accounts can interact with you, but you will not see their posts or receive notifications from them."
+msgstr ""
+
+#: src/view/screens/Moderation.tsx:134
+msgid "My Account"
 msgstr ""
 
 #: src/view/com/modals/BirthDateSettings.tsx:56
@@ -1247,8 +1271,8 @@ msgstr ""
 #: src/view/screens/Feeds.tsx:510
 #: src/view/screens/Profile.tsx:388
 #: src/view/screens/ProfileFeed.tsx:450
-#: src/view/screens/ProfileList.tsx:211
-#: src/view/screens/ProfileList.tsx:243
+#: src/view/screens/ProfileList.tsx:212
+#: src/view/screens/ProfileList.tsx:244
 #: src/view/shell/desktop/LeftNav.tsx:254
 msgid "New post"
 msgstr ""
@@ -1260,7 +1284,7 @@ msgstr ""
 #: src/view/com/auth/create/CreateAccount.tsx:158
 #: src/view/com/auth/login/ForgotPasswordForm.tsx:174
 #: src/view/com/auth/login/ForgotPasswordForm.tsx:184
-#: src/view/com/auth/login/LoginForm.tsx:283
+#: src/view/com/auth/login/LoginForm.tsx:281
 #: src/view/com/auth/login/SetNewPasswordForm.tsx:156
 #: src/view/com/auth/login/SetNewPasswordForm.tsx:166
 #: src/view/com/auth/onboarding/RecommendedFeeds.tsx:79
@@ -1277,8 +1301,8 @@ msgstr ""
 msgid "No"
 msgstr "<<<<<<< HEAD"
 
-#: src/view/screens/ProfileFeed.tsx:630
-#: src/view/screens/ProfileList.tsx:659
+#: src/view/screens/ProfileFeed.tsx:632
+#: src/view/screens/ProfileList.tsx:667
 msgid "No description"
 msgstr ""
 
@@ -1315,8 +1339,8 @@ msgstr ""
 #: src/view/screens/Notifications.tsx:120
 #: src/view/shell/bottom-bar/BottomBar.tsx:195
 #: src/view/shell/desktop/LeftNav.tsx:363
-#: src/view/shell/Drawer.tsx:298
-#: src/view/shell/Drawer.tsx:299
+#: src/view/shell/Drawer.tsx:424
+#: src/view/shell/Drawer.tsx:425
 msgid "Notifications"
 msgstr ""
 
@@ -1341,7 +1365,7 @@ msgid "Opens configurable language settings"
 msgstr ""
 
 #: src/view/shell/desktop/RightNav.tsx:146
-#: src/view/shell/Drawer.tsx:503
+#: src/view/shell/Drawer.tsx:630
 msgid "Opens list of invite codes"
 msgstr ""
 
@@ -1396,7 +1420,7 @@ msgstr ""
 
 #: src/view/com/auth/create/Step2.tsx:101
 #: src/view/com/auth/create/Step2.tsx:111
-#: src/view/com/auth/login/LoginForm.tsx:218
+#: src/view/com/auth/login/LoginForm.tsx:216
 #: src/view/com/auth/login/SetNewPasswordForm.tsx:130
 #: src/view/com/modals/DeleteAccount.tsx:191
 msgid "Password"
@@ -1494,8 +1518,8 @@ msgstr ""
 
 #: src/view/shell/bottom-bar/BottomBar.tsx:237
 #: src/view/shell/Drawer.tsx:72
-#: src/view/shell/Drawer.tsx:366
-#: src/view/shell/Drawer.tsx:367
+#: src/view/shell/Drawer.tsx:533
+#: src/view/shell/Drawer.tsx:534
 msgid "Profile"
 msgstr ""
 
@@ -1539,7 +1563,7 @@ msgstr ""
 
 #: src/view/com/modals/ListAddRemoveUsers.tsx:264
 #: src/view/com/modals/SelfLabel.tsx:83
-#: src/view/com/modals/UserAddRemoveLists.tsx:192
+#: src/view/com/modals/UserAddRemoveLists.tsx:193
 #: src/view/com/util/UserAvatar.tsx:278
 #: src/view/com/util/UserBanner.tsx:89
 msgid "Remove"
@@ -1575,7 +1599,7 @@ msgid "Remove this feed from your saved feeds?"
 msgstr ""
 
 #: src/view/com/modals/ListAddRemoveUsers.tsx:199
-#: src/view/com/modals/UserAddRemoveLists.tsx:135
+#: src/view/com/modals/UserAddRemoveLists.tsx:136
 msgid "Removed from list"
 msgstr ""
 
@@ -1595,7 +1619,7 @@ msgstr ""
 msgid "Report feed"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:440
+#: src/view/screens/ProfileList.tsx:448
 msgid "Report List"
 msgstr ""
 
@@ -1621,6 +1645,10 @@ msgstr ""
 #: src/view/com/modals/ChangeEmail.tsx:183
 msgid "Request Change"
 msgstr ""
+
+#: src/view/screens/Moderation.tsx:188
+#~ msgid "Request to limit the visibility of my account"
+#~ msgstr ""
 
 #: src/view/screens/Settings.tsx:382
 #~ msgid "Require alt text before posting"
@@ -1656,8 +1684,8 @@ msgstr ""
 
 #: src/view/com/auth/create/CreateAccount.tsx:167
 #: src/view/com/auth/create/CreateAccount.tsx:171
-#: src/view/com/auth/login/LoginForm.tsx:260
-#: src/view/com/auth/login/LoginForm.tsx:263
+#: src/view/com/auth/login/LoginForm.tsx:258
+#: src/view/com/auth/login/LoginForm.tsx:261
 #: src/view/com/util/error/ErrorMessage.tsx:55
 #: src/view/com/util/error/ErrorScreen.tsx:65
 msgid "Retry"
@@ -1709,8 +1737,8 @@ msgstr ""
 #: src/view/shell/desktop/LeftNav.tsx:323
 #: src/view/shell/desktop/Search.tsx:161
 #: src/view/shell/desktop/Search.tsx:170
-#: src/view/shell/Drawer.tsx:252
-#: src/view/shell/Drawer.tsx:253
+#: src/view/shell/Drawer.tsx:351
+#: src/view/shell/Drawer.tsx:352
 msgid "Search"
 msgstr ""
 
@@ -1734,7 +1762,7 @@ msgstr ""
 msgid "Select from an existing account"
 msgstr ""
 
-#: src/view/com/auth/login/LoginForm.tsx:145
+#: src/view/com/auth/login/LoginForm.tsx:143
 msgid "Select service"
 msgstr ""
 
@@ -1762,8 +1790,8 @@ msgstr ""
 msgid "Send Email"
 msgstr ""
 
-#: src/view/shell/Drawer.tsx:394
-#: src/view/shell/Drawer.tsx:415
+#: src/view/shell/Drawer.tsx:284
+#: src/view/shell/Drawer.tsx:305
 msgid "Send feedback"
 msgstr ""
 
@@ -1797,8 +1825,8 @@ msgstr ""
 
 #: src/view/screens/Settings.tsx:277
 #: src/view/shell/desktop/LeftNav.tsx:435
-#: src/view/shell/Drawer.tsx:379
-#: src/view/shell/Drawer.tsx:380
+#: src/view/shell/Drawer.tsx:554
+#: src/view/shell/Drawer.tsx:555
 msgid "Settings"
 msgstr ""
 
@@ -1808,7 +1836,7 @@ msgstr ""
 
 #: src/view/com/profile/ProfileHeader.tsx:313
 #: src/view/com/util/forms/PostDropdownBtn.tsx:126
-#: src/view/screens/ProfileList.tsx:399
+#: src/view/screens/ProfileList.tsx:407
 msgid "Share"
 msgstr ""
 
@@ -1873,7 +1901,7 @@ msgstr ""
 msgid "Sign in as..."
 msgstr ""
 
-#: src/view/com/auth/login/LoginForm.tsx:132
+#: src/view/com/auth/login/LoginForm.tsx:130
 msgid "Sign into"
 msgstr ""
 
@@ -1925,11 +1953,11 @@ msgstr ""
 msgid "Storybook"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:522
+#: src/view/screens/ProfileList.tsx:530
 msgid "Subscribe"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:518
+#: src/view/screens/ProfileList.tsx:526
 msgid "Subscribe to this list"
 msgstr ""
 
@@ -2137,12 +2165,12 @@ msgstr ""
 msgid "User Lists"
 msgstr ""
 
-#: src/view/com/auth/login/LoginForm.tsx:172
-#: src/view/com/auth/login/LoginForm.tsx:189
+#: src/view/com/auth/login/LoginForm.tsx:170
+#: src/view/com/auth/login/LoginForm.tsx:187
 msgid "Username or email address"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:686
+#: src/view/screens/ProfileList.tsx:694
 msgid "Users"
 msgstr ""
 
@@ -2262,7 +2290,7 @@ msgstr ""
 msgid "You have no feeds."
 msgstr ""
 
-#: src/view/com/lists/MyLists.tsx:88
+#: src/view/com/lists/MyLists.tsx:89
 #: src/view/com/lists/ProfileLists.tsx:154
 msgid "You have no lists."
 msgstr ""
@@ -2318,7 +2346,7 @@ msgstr ""
 
 #: src/view/screens/Settings.tsx:402
 #: src/view/shell/desktop/RightNav.tsx:127
-#: src/view/shell/Drawer.tsx:517
+#: src/view/shell/Drawer.tsx:644
 msgid "Your invite codes are hidden when logged in using an App Password"
 msgstr ""
 
@@ -2329,6 +2357,10 @@ msgstr ""
 #: src/view/com/modals/SwitchAccount.tsx:78
 msgid "Your profile"
 msgstr ""
+
+#: src/view/screens/Moderation.tsx:205
+#~ msgid "Your profile and account will not be visible to anyone visiting the Bluesky app without an account, or to account holders who are not logged in. Enabling this will not make your profile private."
+#~ msgstr ""
 
 #: src/view/com/auth/create/Step3.tsx:28
 msgid "Your user handle"

--- a/src/locale/locales/fr/messages.po
+++ b/src/locale/locales/fr/messages.po
@@ -68,8 +68,8 @@ msgstr ""
 #~ msgstr ""
 
 #: src/view/screens/Moderation.tsx:212
-msgid "<0>Note: Your profile and posts will remain publicly available. Third-party apps that display Bluesky content may not respect this setting.</0>"
-msgstr ""
+#~ msgid "<0>Note: Your profile and posts will remain publicly available. Third-party apps that display Bluesky content may not respect this setting.</0>"
+#~ msgstr ""
 
 #: src/lib/hooks/useOTAUpdate.ts:16
 msgid "A new version of the app is available. Please update to continue using the app."
@@ -200,8 +200,8 @@ msgid "Appearance"
 msgstr ""
 
 #: src/view/screens/Moderation.tsx:206
-msgid "Apps that respect this setting, including the official Bluesky app and bsky.app website, won't show your content to logged out users."
-msgstr ""
+#~ msgid "Apps that respect this setting, including the official Bluesky app and bsky.app website, won't show your content to logged out users."
+#~ msgstr ""
 
 #: src/view/screens/AppPasswords.tsx:223
 msgid "Are you sure you want to delete the app password \"{name}\"?"
@@ -224,8 +224,8 @@ msgid "Artistic or non-erotic nudity."
 msgstr ""
 
 #: src/view/screens/Moderation.tsx:189
-msgid "Ask apps to limit the visibility of my account"
-msgstr ""
+#~ msgid "Ask apps to limit the visibility of my account"
+#~ msgstr ""
 
 #: src/view/com/auth/create/CreateAccount.tsx:145
 #: src/view/com/auth/login/ChooseAccountForm.tsx:151
@@ -1080,7 +1080,7 @@ msgstr ""
 msgid "Learn more about this warning"
 msgstr ""
 
-#: src/view/screens/Moderation.tsx:223
+#: src/view/screens/Moderation.tsx:235
 msgid "Learn more about what is public on Bluesky."
 msgstr ""
 
@@ -1113,6 +1113,10 @@ msgstr ""
 #: src/view/screens/PostLikedBy.tsx:27
 #: src/view/screens/ProfileFeedLikedBy.tsx:27
 msgid "Liked by"
+msgstr ""
+
+#: src/view/screens/Moderation.tsx:203
+msgid "Limit the visibility of my account"
 msgstr ""
 
 #: src/view/com/modals/CreateOrEditList.tsx:186
@@ -1148,6 +1152,10 @@ msgstr ""
 
 #: src/view/com/modals/ServerInput.tsx:50
 msgid "Local dev server"
+msgstr ""
+
+#: src/view/screens/Moderation.tsx:134
+msgid "Logged-out users"
 msgstr ""
 
 #: src/view/com/auth/login/ChooseAccountForm.tsx:133
@@ -1234,8 +1242,8 @@ msgid "Muting is private. Muted accounts can interact with you, but you will not
 msgstr ""
 
 #: src/view/screens/Moderation.tsx:134
-msgid "My Account"
-msgstr ""
+#~ msgid "My Account"
+#~ msgstr ""
 
 #: src/view/com/modals/BirthDateSettings.tsx:56
 msgid "My Birthday"
@@ -1333,6 +1341,10 @@ msgstr ""
 
 #: src/view/com/modals/SelfLabel.tsx:135
 msgid "Not Applicable."
+msgstr ""
+
+#: src/view/screens/Moderation.tsx:227
+msgid "Note: Third-party apps that display Bluesky content may not respect this setting."
 msgstr ""
 
 #: src/view/screens/Notifications.tsx:96
@@ -2361,6 +2373,10 @@ msgstr ""
 #: src/view/screens/Moderation.tsx:205
 #~ msgid "Your profile and account will not be visible to anyone visiting the Bluesky app without an account, or to account holders who are not logged in. Enabling this will not make your profile private."
 #~ msgstr ""
+
+#: src/view/screens/Moderation.tsx:220
+msgid "Your profile and content will not be visible to anyone visiting the Bluesky app without an account. Enabling this will not make your profile private."
+msgstr ""
 
 #: src/view/com/auth/create/Step3.tsx:28
 msgid "Your user handle"

--- a/src/locale/locales/fr/messages.po
+++ b/src/locale/locales/fr/messages.po
@@ -38,12 +38,12 @@ msgid "{invitesAvailable, plural, one {Invite codes: # available} other {Invite 
 msgstr ""
 
 #: src/view/screens/Settings.tsx:407
-#: src/view/shell/Drawer.tsx:521
+#: src/view/shell/Drawer.tsx:648
 msgid "{invitesAvailable} invite code available"
 msgstr ""
 
 #: src/view/screens/Settings.tsx:409
-#: src/view/shell/Drawer.tsx:523
+#: src/view/shell/Drawer.tsx:650
 msgid "{invitesAvailable} invite codes available"
 msgstr ""
 
@@ -63,6 +63,14 @@ msgstr ""
 #~ msgid "<0>Here is your app password.</0> Use this to sign into the other app along with your handle."
 #~ msgstr ""
 
+#: src/view/screens/Moderation.tsx:212
+#~ msgid "<0>Note: This setting may not be respected by third-party apps that display Bluesky content.</0>"
+#~ msgstr ""
+
+#: src/view/screens/Moderation.tsx:212
+msgid "<0>Note: Your profile and posts will remain publicly available. Third-party apps that display Bluesky content may not respect this setting.</0>"
+msgstr ""
+
 #: src/lib/hooks/useOTAUpdate.ts:16
 msgid "A new version of the app is available. Please update to continue using the app."
 msgstr ""
@@ -72,7 +80,7 @@ msgstr ""
 msgid "Accessibility"
 msgstr ""
 
-#: src/view/com/auth/login/LoginForm.tsx:161
+#: src/view/com/auth/login/LoginForm.tsx:159
 #: src/view/screens/Settings.tsx:286
 msgid "Account"
 msgstr ""
@@ -82,8 +90,8 @@ msgid "Account options"
 msgstr ""
 
 #: src/view/com/modals/ListAddRemoveUsers.tsx:264
-#: src/view/com/modals/UserAddRemoveLists.tsx:192
-#: src/view/screens/ProfileList.tsx:702
+#: src/view/com/modals/UserAddRemoveLists.tsx:193
+#: src/view/screens/ProfileList.tsx:710
 msgid "Add"
 msgstr ""
 
@@ -91,7 +99,7 @@ msgstr ""
 msgid "Add a content warning"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:692
+#: src/view/screens/ProfileList.tsx:700
 msgid "Add a user to this list"
 msgstr ""
 
@@ -135,7 +143,7 @@ msgid "Add to my feeds"
 msgstr ""
 
 #: src/view/com/modals/ListAddRemoveUsers.tsx:191
-#: src/view/com/modals/UserAddRemoveLists.tsx:127
+#: src/view/com/modals/UserAddRemoveLists.tsx:128
 msgid "Added to list"
 msgstr ""
 
@@ -191,6 +199,10 @@ msgstr ""
 msgid "Appearance"
 msgstr ""
 
+#: src/view/screens/Moderation.tsx:206
+msgid "Apps that respect this setting, including the official Bluesky app and bsky.app website, won't show your content to logged out users."
+msgstr ""
+
 #: src/view/screens/AppPasswords.tsx:223
 msgid "Are you sure you want to delete the app password \"{name}\"?"
 msgstr ""
@@ -199,7 +211,7 @@ msgstr ""
 msgid "Are you sure you'd like to discard this draft?"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:369
+#: src/view/screens/ProfileList.tsx:375
 msgid "Are you sure?"
 msgstr ""
 
@@ -211,10 +223,14 @@ msgstr ""
 msgid "Artistic or non-erotic nudity."
 msgstr ""
 
+#: src/view/screens/Moderation.tsx:189
+msgid "Ask apps to limit the visibility of my account"
+msgstr ""
+
 #: src/view/com/auth/create/CreateAccount.tsx:145
 #: src/view/com/auth/login/ChooseAccountForm.tsx:151
 #: src/view/com/auth/login/ForgotPasswordForm.tsx:166
-#: src/view/com/auth/login/LoginForm.tsx:251
+#: src/view/com/auth/login/LoginForm.tsx:249
 #: src/view/com/auth/login/SetNewPasswordForm.tsx:148
 #: src/view/com/modals/report/InputIssueDetails.tsx:45
 #: src/view/com/post-thread/PostThread.tsx:381
@@ -242,15 +258,15 @@ msgstr ""
 msgid "Block Account"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:470
+#: src/view/screens/ProfileList.tsx:478
 msgid "Block accounts"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:326
+#: src/view/screens/ProfileList.tsx:330
 msgid "Block these accounts?"
 msgstr ""
 
-#: src/view/screens/Moderation.tsx:109
+#: src/view/screens/Moderation.tsx:121
 msgid "Blocked accounts"
 msgstr ""
 
@@ -270,7 +286,7 @@ msgstr ""
 msgid "Blocked post."
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:328
+#: src/view/screens/ProfileList.tsx:332
 msgid "Blocking is public. Blocked accounts cannot reply in your threads, mention you, or otherwise interact with you."
 msgstr ""
 
@@ -492,11 +508,11 @@ msgid "Confirmation code"
 msgstr ""
 
 #: src/view/com/auth/create/CreateAccount.tsx:178
-#: src/view/com/auth/login/LoginForm.tsx:270
+#: src/view/com/auth/login/LoginForm.tsx:268
 msgid "Connecting..."
 msgstr ""
 
-#: src/view/screens/Moderation.tsx:67
+#: src/view/screens/Moderation.tsx:79
 msgid "Content filtering"
 msgstr ""
 
@@ -531,7 +547,7 @@ msgstr ""
 msgid "Copy"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:399
+#: src/view/screens/ProfileList.tsx:407
 msgid "Copy link to list"
 msgstr ""
 
@@ -555,7 +571,7 @@ msgstr ""
 msgid "Could not load feed"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:779
+#: src/view/screens/ProfileList.tsx:787
 msgid "Could not load list"
 msgstr ""
 
@@ -601,8 +617,8 @@ msgstr ""
 msgid "Delete app password"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:368
-#: src/view/screens/ProfileList.tsx:426
+#: src/view/screens/ProfileList.tsx:374
+#: src/view/screens/ProfileList.tsx:434
 msgid "Delete List"
 msgstr ""
 
@@ -672,7 +688,7 @@ msgstr ""
 #: src/view/com/modals/EditImage.tsx:333
 #: src/view/com/modals/ListAddRemoveUsers.tsx:142
 #: src/view/com/modals/SelfLabel.tsx:157
-#: src/view/com/modals/UserAddRemoveLists.tsx:78
+#: src/view/com/modals/UserAddRemoveLists.tsx:79
 #: src/view/screens/PreferencesHomeFeed.tsx:302
 #: src/view/screens/PreferencesThreads.tsx:156
 msgid "Done"
@@ -691,7 +707,7 @@ msgstr ""
 msgid "Edit image"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:414
+#: src/view/screens/ProfileList.tsx:422
 msgid "Edit list details"
 msgstr ""
 
@@ -789,15 +805,15 @@ msgid "Feed Preferences"
 msgstr ""
 
 #: src/view/shell/desktop/RightNav.tsx:64
-#: src/view/shell/Drawer.tsx:410
+#: src/view/shell/Drawer.tsx:300
 msgid "Feedback"
 msgstr ""
 
 #: src/view/screens/Feeds.tsx:475
 #: src/view/shell/bottom-bar/BottomBar.tsx:168
 #: src/view/shell/desktop/LeftNav.tsx:341
-#: src/view/shell/Drawer.tsx:327
-#: src/view/shell/Drawer.tsx:328
+#: src/view/shell/Drawer.tsx:463
+#: src/view/shell/Drawer.tsx:464
 msgid "Feeds"
 msgstr ""
 
@@ -862,11 +878,11 @@ msgstr ""
 msgid "For security reasons, you won't be able to view this again. If you lose this password, you'll need to generate a new one."
 msgstr ""
 
-#: src/view/com/auth/login/LoginForm.tsx:233
+#: src/view/com/auth/login/LoginForm.tsx:231
 msgid "Forgot"
 msgstr ""
 
-#: src/view/com/auth/login/LoginForm.tsx:230
+#: src/view/com/auth/login/LoginForm.tsx:228
 msgid "Forgot password"
 msgstr ""
 
@@ -892,13 +908,13 @@ msgstr ""
 
 #: src/view/screens/ProfileFeed.tsx:111
 #: src/view/screens/ProfileFeed.tsx:116
-#: src/view/screens/ProfileList.tsx:788
-#: src/view/screens/ProfileList.tsx:793
+#: src/view/screens/ProfileList.tsx:796
+#: src/view/screens/ProfileList.tsx:801
 msgid "Go Back"
 msgstr ""
 
 #: src/view/com/auth/login/ForgotPasswordForm.tsx:181
-#: src/view/com/auth/login/LoginForm.tsx:280
+#: src/view/com/auth/login/LoginForm.tsx:278
 #: src/view/com/auth/login/SetNewPasswordForm.tsx:163
 msgid "Go to next"
 msgstr ""
@@ -908,7 +924,7 @@ msgid "Handle"
 msgstr ""
 
 #: src/view/shell/desktop/RightNav.tsx:93
-#: src/view/shell/Drawer.tsx:420
+#: src/view/shell/Drawer.tsx:310
 msgid "Help"
 msgstr ""
 
@@ -954,8 +970,8 @@ msgstr ""
 
 #: src/view/shell/bottom-bar/BottomBar.tsx:124
 #: src/view/shell/desktop/LeftNav.tsx:305
-#: src/view/shell/Drawer.tsx:274
-#: src/view/shell/Drawer.tsx:275
+#: src/view/shell/Drawer.tsx:387
+#: src/view/shell/Drawer.tsx:388
 msgid "Home"
 msgstr ""
 
@@ -1021,7 +1037,7 @@ msgstr ""
 msgid "Invite code not accepted. Check that you input it correctly and try again."
 msgstr ""
 
-#: src/view/shell/Drawer.tsx:502
+#: src/view/shell/Drawer.tsx:629
 msgid "Invite codes: {invitesAvailable} available"
 msgstr ""
 
@@ -1064,6 +1080,10 @@ msgstr ""
 msgid "Learn more about this warning"
 msgstr ""
 
+#: src/view/screens/Moderation.tsx:223
+msgid "Learn more about what is public on Bluesky."
+msgstr ""
+
 #: src/view/com/modals/lang-settings/ContentLanguagesSettings.tsx:82
 msgid "Leave them all unchecked to see any language."
 msgstr ""
@@ -1086,7 +1106,7 @@ msgstr ""
 #~ msgid "Light"
 #~ msgstr ""
 
-#: src/view/screens/ProfileFeed.tsx:637
+#: src/view/screens/ProfileFeed.tsx:639
 msgid "Like this feed"
 msgstr ""
 
@@ -1104,8 +1124,8 @@ msgid "List Name"
 msgstr ""
 
 #: src/view/shell/desktop/LeftNav.tsx:381
-#: src/view/shell/Drawer.tsx:338
-#: src/view/shell/Drawer.tsx:339
+#: src/view/shell/Drawer.tsx:479
+#: src/view/shell/Drawer.tsx:480
 msgid "Lists"
 msgstr ""
 
@@ -1151,15 +1171,15 @@ msgstr ""
 msgid "Message from server"
 msgstr ""
 
-#: src/view/screens/Moderation.tsx:51
+#: src/view/screens/Moderation.tsx:63
 #: src/view/screens/Settings.tsx:563
 #: src/view/shell/desktop/LeftNav.tsx:399
-#: src/view/shell/Drawer.tsx:345
-#: src/view/shell/Drawer.tsx:346
+#: src/view/shell/Drawer.tsx:498
+#: src/view/shell/Drawer.tsx:499
 msgid "Moderation"
 msgstr ""
 
-#: src/view/screens/Moderation.tsx:81
+#: src/view/screens/Moderation.tsx:93
 msgid "Moderation lists"
 msgstr ""
 
@@ -1173,7 +1193,7 @@ msgstr ""
 
 #: src/view/com/profile/ProfileHeader.tsx:523
 #: src/view/screens/ProfileFeed.tsx:369
-#: src/view/screens/ProfileList.tsx:531
+#: src/view/screens/ProfileList.tsx:539
 msgid "More options"
 msgstr ""
 
@@ -1185,11 +1205,11 @@ msgstr ""
 msgid "Mute Account"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:458
+#: src/view/screens/ProfileList.tsx:466
 msgid "Mute accounts"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:291
+#: src/view/screens/ProfileList.tsx:293
 msgid "Mute these accounts?"
 msgstr ""
 
@@ -1197,7 +1217,7 @@ msgstr ""
 msgid "Mute thread"
 msgstr ""
 
-#: src/view/screens/Moderation.tsx:95
+#: src/view/screens/Moderation.tsx:107
 msgid "Muted accounts"
 msgstr ""
 
@@ -1209,8 +1229,12 @@ msgstr ""
 msgid "Muted accounts have their posts removed from your feed and from your notifications. Mutes are completely private."
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:293
+#: src/view/screens/ProfileList.tsx:295
 msgid "Muting is private. Muted accounts can interact with you, but you will not see their posts or receive notifications from them."
+msgstr ""
+
+#: src/view/screens/Moderation.tsx:134
+msgid "My Account"
 msgstr ""
 
 #: src/view/com/modals/BirthDateSettings.tsx:56
@@ -1247,8 +1271,8 @@ msgstr ""
 #: src/view/screens/Feeds.tsx:510
 #: src/view/screens/Profile.tsx:388
 #: src/view/screens/ProfileFeed.tsx:450
-#: src/view/screens/ProfileList.tsx:211
-#: src/view/screens/ProfileList.tsx:243
+#: src/view/screens/ProfileList.tsx:212
+#: src/view/screens/ProfileList.tsx:244
 #: src/view/shell/desktop/LeftNav.tsx:254
 msgid "New post"
 msgstr ""
@@ -1260,7 +1284,7 @@ msgstr ""
 #: src/view/com/auth/create/CreateAccount.tsx:158
 #: src/view/com/auth/login/ForgotPasswordForm.tsx:174
 #: src/view/com/auth/login/ForgotPasswordForm.tsx:184
-#: src/view/com/auth/login/LoginForm.tsx:283
+#: src/view/com/auth/login/LoginForm.tsx:281
 #: src/view/com/auth/login/SetNewPasswordForm.tsx:156
 #: src/view/com/auth/login/SetNewPasswordForm.tsx:166
 #: src/view/com/auth/onboarding/RecommendedFeeds.tsx:79
@@ -1277,8 +1301,8 @@ msgstr ""
 msgid "No"
 msgstr "<<<<<<< HEAD"
 
-#: src/view/screens/ProfileFeed.tsx:630
-#: src/view/screens/ProfileList.tsx:659
+#: src/view/screens/ProfileFeed.tsx:632
+#: src/view/screens/ProfileList.tsx:667
 msgid "No description"
 msgstr ""
 
@@ -1315,8 +1339,8 @@ msgstr ""
 #: src/view/screens/Notifications.tsx:120
 #: src/view/shell/bottom-bar/BottomBar.tsx:195
 #: src/view/shell/desktop/LeftNav.tsx:363
-#: src/view/shell/Drawer.tsx:298
-#: src/view/shell/Drawer.tsx:299
+#: src/view/shell/Drawer.tsx:424
+#: src/view/shell/Drawer.tsx:425
 msgid "Notifications"
 msgstr ""
 
@@ -1341,7 +1365,7 @@ msgid "Opens configurable language settings"
 msgstr ""
 
 #: src/view/shell/desktop/RightNav.tsx:146
-#: src/view/shell/Drawer.tsx:503
+#: src/view/shell/Drawer.tsx:630
 msgid "Opens list of invite codes"
 msgstr ""
 
@@ -1396,7 +1420,7 @@ msgstr ""
 
 #: src/view/com/auth/create/Step2.tsx:101
 #: src/view/com/auth/create/Step2.tsx:111
-#: src/view/com/auth/login/LoginForm.tsx:218
+#: src/view/com/auth/login/LoginForm.tsx:216
 #: src/view/com/auth/login/SetNewPasswordForm.tsx:130
 #: src/view/com/modals/DeleteAccount.tsx:191
 msgid "Password"
@@ -1494,8 +1518,8 @@ msgstr ""
 
 #: src/view/shell/bottom-bar/BottomBar.tsx:237
 #: src/view/shell/Drawer.tsx:72
-#: src/view/shell/Drawer.tsx:366
-#: src/view/shell/Drawer.tsx:367
+#: src/view/shell/Drawer.tsx:533
+#: src/view/shell/Drawer.tsx:534
 msgid "Profile"
 msgstr ""
 
@@ -1539,7 +1563,7 @@ msgstr ""
 
 #: src/view/com/modals/ListAddRemoveUsers.tsx:264
 #: src/view/com/modals/SelfLabel.tsx:83
-#: src/view/com/modals/UserAddRemoveLists.tsx:192
+#: src/view/com/modals/UserAddRemoveLists.tsx:193
 #: src/view/com/util/UserAvatar.tsx:278
 #: src/view/com/util/UserBanner.tsx:89
 msgid "Remove"
@@ -1575,7 +1599,7 @@ msgid "Remove this feed from your saved feeds?"
 msgstr ""
 
 #: src/view/com/modals/ListAddRemoveUsers.tsx:199
-#: src/view/com/modals/UserAddRemoveLists.tsx:135
+#: src/view/com/modals/UserAddRemoveLists.tsx:136
 msgid "Removed from list"
 msgstr ""
 
@@ -1595,7 +1619,7 @@ msgstr ""
 msgid "Report feed"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:440
+#: src/view/screens/ProfileList.tsx:448
 msgid "Report List"
 msgstr ""
 
@@ -1621,6 +1645,10 @@ msgstr ""
 #: src/view/com/modals/ChangeEmail.tsx:183
 msgid "Request Change"
 msgstr ""
+
+#: src/view/screens/Moderation.tsx:188
+#~ msgid "Request to limit the visibility of my account"
+#~ msgstr ""
 
 #: src/view/screens/Settings.tsx:382
 #~ msgid "Require alt text before posting"
@@ -1656,8 +1684,8 @@ msgstr ""
 
 #: src/view/com/auth/create/CreateAccount.tsx:167
 #: src/view/com/auth/create/CreateAccount.tsx:171
-#: src/view/com/auth/login/LoginForm.tsx:260
-#: src/view/com/auth/login/LoginForm.tsx:263
+#: src/view/com/auth/login/LoginForm.tsx:258
+#: src/view/com/auth/login/LoginForm.tsx:261
 #: src/view/com/util/error/ErrorMessage.tsx:55
 #: src/view/com/util/error/ErrorScreen.tsx:65
 msgid "Retry"
@@ -1709,8 +1737,8 @@ msgstr ""
 #: src/view/shell/desktop/LeftNav.tsx:323
 #: src/view/shell/desktop/Search.tsx:161
 #: src/view/shell/desktop/Search.tsx:170
-#: src/view/shell/Drawer.tsx:252
-#: src/view/shell/Drawer.tsx:253
+#: src/view/shell/Drawer.tsx:351
+#: src/view/shell/Drawer.tsx:352
 msgid "Search"
 msgstr ""
 
@@ -1734,7 +1762,7 @@ msgstr ""
 msgid "Select from an existing account"
 msgstr ""
 
-#: src/view/com/auth/login/LoginForm.tsx:145
+#: src/view/com/auth/login/LoginForm.tsx:143
 msgid "Select service"
 msgstr ""
 
@@ -1762,8 +1790,8 @@ msgstr ""
 msgid "Send Email"
 msgstr ""
 
-#: src/view/shell/Drawer.tsx:394
-#: src/view/shell/Drawer.tsx:415
+#: src/view/shell/Drawer.tsx:284
+#: src/view/shell/Drawer.tsx:305
 msgid "Send feedback"
 msgstr ""
 
@@ -1797,8 +1825,8 @@ msgstr ""
 
 #: src/view/screens/Settings.tsx:277
 #: src/view/shell/desktop/LeftNav.tsx:435
-#: src/view/shell/Drawer.tsx:379
-#: src/view/shell/Drawer.tsx:380
+#: src/view/shell/Drawer.tsx:554
+#: src/view/shell/Drawer.tsx:555
 msgid "Settings"
 msgstr ""
 
@@ -1808,7 +1836,7 @@ msgstr ""
 
 #: src/view/com/profile/ProfileHeader.tsx:313
 #: src/view/com/util/forms/PostDropdownBtn.tsx:126
-#: src/view/screens/ProfileList.tsx:399
+#: src/view/screens/ProfileList.tsx:407
 msgid "Share"
 msgstr ""
 
@@ -1873,7 +1901,7 @@ msgstr ""
 msgid "Sign in as..."
 msgstr ""
 
-#: src/view/com/auth/login/LoginForm.tsx:132
+#: src/view/com/auth/login/LoginForm.tsx:130
 msgid "Sign into"
 msgstr ""
 
@@ -1925,11 +1953,11 @@ msgstr ""
 msgid "Storybook"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:522
+#: src/view/screens/ProfileList.tsx:530
 msgid "Subscribe"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:518
+#: src/view/screens/ProfileList.tsx:526
 msgid "Subscribe to this list"
 msgstr ""
 
@@ -2137,12 +2165,12 @@ msgstr ""
 msgid "User Lists"
 msgstr ""
 
-#: src/view/com/auth/login/LoginForm.tsx:172
-#: src/view/com/auth/login/LoginForm.tsx:189
+#: src/view/com/auth/login/LoginForm.tsx:170
+#: src/view/com/auth/login/LoginForm.tsx:187
 msgid "Username or email address"
 msgstr ""
 
-#: src/view/screens/ProfileList.tsx:686
+#: src/view/screens/ProfileList.tsx:694
 msgid "Users"
 msgstr ""
 
@@ -2262,7 +2290,7 @@ msgstr ""
 msgid "You have no feeds."
 msgstr ""
 
-#: src/view/com/lists/MyLists.tsx:88
+#: src/view/com/lists/MyLists.tsx:89
 #: src/view/com/lists/ProfileLists.tsx:154
 msgid "You have no lists."
 msgstr ""
@@ -2318,7 +2346,7 @@ msgstr ""
 
 #: src/view/screens/Settings.tsx:402
 #: src/view/shell/desktop/RightNav.tsx:127
-#: src/view/shell/Drawer.tsx:517
+#: src/view/shell/Drawer.tsx:644
 msgid "Your invite codes are hidden when logged in using an App Password"
 msgstr ""
 
@@ -2329,6 +2357,10 @@ msgstr ""
 #: src/view/com/modals/SwitchAccount.tsx:78
 msgid "Your profile"
 msgstr ""
+
+#: src/view/screens/Moderation.tsx:205
+#~ msgid "Your profile and account will not be visible to anyone visiting the Bluesky app without an account, or to account holders who are not logged in. Enabling this will not make your profile private."
+#~ msgstr ""
 
 #: src/view/com/auth/create/Step3.tsx:28
 msgid "Your user handle"

--- a/src/locale/locales/hi/messages.po
+++ b/src/locale/locales/hi/messages.po
@@ -68,8 +68,8 @@ msgstr "<0>कुछ</0><1>पसंदीदा उपयोगकर्ता�
 #~ msgstr ""
 
 #: src/view/screens/Moderation.tsx:212
-msgid "<0>Note: Your profile and posts will remain publicly available. Third-party apps that display Bluesky content may not respect this setting.</0>"
-msgstr ""
+#~ msgid "<0>Note: Your profile and posts will remain publicly available. Third-party apps that display Bluesky content may not respect this setting.</0>"
+#~ msgstr ""
 
 #: src/lib/hooks/useOTAUpdate.ts:16
 msgid "A new version of the app is available. Please update to continue using the app."
@@ -200,8 +200,8 @@ msgid "Appearance"
 msgstr "दिखावट"
 
 #: src/view/screens/Moderation.tsx:206
-msgid "Apps that respect this setting, including the official Bluesky app and bsky.app website, won't show your content to logged out users."
-msgstr ""
+#~ msgid "Apps that respect this setting, including the official Bluesky app and bsky.app website, won't show your content to logged out users."
+#~ msgstr ""
 
 #: src/view/screens/AppPasswords.tsx:223
 msgid "Are you sure you want to delete the app password \"{name}\"?"
@@ -224,8 +224,8 @@ msgid "Artistic or non-erotic nudity."
 msgstr "कलात्मक या गैर-कामुक नग्नता।।"
 
 #: src/view/screens/Moderation.tsx:189
-msgid "Ask apps to limit the visibility of my account"
-msgstr ""
+#~ msgid "Ask apps to limit the visibility of my account"
+#~ msgstr ""
 
 #: src/view/com/auth/create/CreateAccount.tsx:145
 #: src/view/com/auth/login/ChooseAccountForm.tsx:151
@@ -1072,7 +1072,7 @@ msgstr "अधिक जानें"
 msgid "Learn more about this warning"
 msgstr "इस चेतावनी के बारे में अधिक जानें"
 
-#: src/view/screens/Moderation.tsx:223
+#: src/view/screens/Moderation.tsx:235
 msgid "Learn more about what is public on Bluesky."
 msgstr ""
 
@@ -1106,6 +1106,10 @@ msgstr "इस फ़ीड को लाइक करो"
 #: src/view/screens/ProfileFeedLikedBy.tsx:27
 msgid "Liked by"
 msgstr "इन यूजर ने लाइक किया है"
+
+#: src/view/screens/Moderation.tsx:203
+msgid "Limit the visibility of my account"
+msgstr ""
 
 #: src/view/com/modals/CreateOrEditList.tsx:186
 msgid "List Avatar"
@@ -1141,6 +1145,10 @@ msgstr ""
 #: src/view/com/modals/ServerInput.tsx:50
 msgid "Local dev server"
 msgstr "स्थानीय देव सर्वर"
+
+#: src/view/screens/Moderation.tsx:134
+msgid "Logged-out users"
+msgstr ""
 
 #: src/view/com/auth/login/ChooseAccountForm.tsx:133
 msgid "Login to account that is not listed"
@@ -1226,8 +1234,8 @@ msgid "Muting is private. Muted accounts can interact with you, but you will not
 msgstr "म्यूट करना निजी है. म्यूट किए गए खाते आपके साथ इंटरैक्ट कर सकते हैं, लेकिन आप उनकी पोस्ट नहीं देखेंगे या उनसे सूचनाएं प्राप्त नहीं करेंगे।"
 
 #: src/view/screens/Moderation.tsx:134
-msgid "My Account"
-msgstr ""
+#~ msgid "My Account"
+#~ msgstr ""
 
 #: src/view/com/modals/BirthDateSettings.tsx:56
 msgid "My Birthday"
@@ -1326,6 +1334,10 @@ msgstr ""
 #: src/view/com/modals/SelfLabel.tsx:135
 msgid "Not Applicable."
 msgstr "लागू नहीं।"
+
+#: src/view/screens/Moderation.tsx:227
+msgid "Note: Third-party apps that display Bluesky content may not respect this setting."
+msgstr ""
 
 #: src/view/screens/Notifications.tsx:96
 #: src/view/screens/Notifications.tsx:120
@@ -2353,6 +2365,10 @@ msgstr "आपकी प्रोफ़ाइल"
 #: src/view/screens/Moderation.tsx:205
 #~ msgid "Your profile and account will not be visible to anyone visiting the Bluesky app without an account, or to account holders who are not logged in. Enabling this will not make your profile private."
 #~ msgstr ""
+
+#: src/view/screens/Moderation.tsx:220
+msgid "Your profile and content will not be visible to anyone visiting the Bluesky app without an account. Enabling this will not make your profile private."
+msgstr ""
 
 #: src/view/com/auth/create/Step3.tsx:28
 msgid "Your user handle"

--- a/src/locale/locales/hi/messages.po
+++ b/src/locale/locales/hi/messages.po
@@ -38,12 +38,12 @@ msgid "{invitesAvailable, plural, one {Invite codes: # available} other {Invite 
 msgstr ""
 
 #: src/view/screens/Settings.tsx:407
-#: src/view/shell/Drawer.tsx:521
+#: src/view/shell/Drawer.tsx:648
 msgid "{invitesAvailable} invite code available"
 msgstr ""
 
 #: src/view/screens/Settings.tsx:409
-#: src/view/shell/Drawer.tsx:523
+#: src/view/shell/Drawer.tsx:650
 msgid "{invitesAvailable} invite codes available"
 msgstr ""
 
@@ -63,6 +63,14 @@ msgstr "<0>कुछ</0><1>पसंदीदा उपयोगकर्ता�
 #~ msgid "<0>Here is your app password.</0> Use this to sign into the other app along with your handle."
 #~ msgstr "<0>इधर आपका ऐप पासवर्ड है।</0> इसे अपने हैंडल के साथ दूसरे ऐप में साइन करने के लिए उपयोग करें।।"
 
+#: src/view/screens/Moderation.tsx:212
+#~ msgid "<0>Note: This setting may not be respected by third-party apps that display Bluesky content.</0>"
+#~ msgstr ""
+
+#: src/view/screens/Moderation.tsx:212
+msgid "<0>Note: Your profile and posts will remain publicly available. Third-party apps that display Bluesky content may not respect this setting.</0>"
+msgstr ""
+
 #: src/lib/hooks/useOTAUpdate.ts:16
 msgid "A new version of the app is available. Please update to continue using the app."
 msgstr "ऐप का एक नया संस्करण उपलब्ध है. कृपया ऐप का उपयोग जारी रखने के लिए अपडेट करें।"
@@ -72,7 +80,7 @@ msgstr "ऐप का एक नया संस्करण उपलब्ध 
 msgid "Accessibility"
 msgstr "प्रवेर्शयोग्यता"
 
-#: src/view/com/auth/login/LoginForm.tsx:161
+#: src/view/com/auth/login/LoginForm.tsx:159
 #: src/view/screens/Settings.tsx:286
 msgid "Account"
 msgstr "अकाउंट"
@@ -82,8 +90,8 @@ msgid "Account options"
 msgstr "अकाउंट के विकल्प"
 
 #: src/view/com/modals/ListAddRemoveUsers.tsx:264
-#: src/view/com/modals/UserAddRemoveLists.tsx:192
-#: src/view/screens/ProfileList.tsx:702
+#: src/view/com/modals/UserAddRemoveLists.tsx:193
+#: src/view/screens/ProfileList.tsx:710
 msgid "Add"
 msgstr "ऐड करो"
 
@@ -91,7 +99,7 @@ msgstr "ऐड करो"
 msgid "Add a content warning"
 msgstr "सामग्री चेतावनी जोड़ें"
 
-#: src/view/screens/ProfileList.tsx:692
+#: src/view/screens/ProfileList.tsx:700
 msgid "Add a user to this list"
 msgstr "इस सूची में किसी को जोड़ें"
 
@@ -135,7 +143,7 @@ msgid "Add to my feeds"
 msgstr "इस फ़ीड को सहेजें"
 
 #: src/view/com/modals/ListAddRemoveUsers.tsx:191
-#: src/view/com/modals/UserAddRemoveLists.tsx:127
+#: src/view/com/modals/UserAddRemoveLists.tsx:128
 msgid "Added to list"
 msgstr ""
 
@@ -191,6 +199,10 @@ msgstr "ऐप पासवर्ड"
 msgid "Appearance"
 msgstr "दिखावट"
 
+#: src/view/screens/Moderation.tsx:206
+msgid "Apps that respect this setting, including the official Bluesky app and bsky.app website, won't show your content to logged out users."
+msgstr ""
+
 #: src/view/screens/AppPasswords.tsx:223
 msgid "Are you sure you want to delete the app password \"{name}\"?"
 msgstr "क्या आप वाकई ऐप पासवर्ड \"{name}\" हटाना चाहते हैं?"
@@ -199,7 +211,7 @@ msgstr "क्या आप वाकई ऐप पासवर्ड \"{name}\"
 msgid "Are you sure you'd like to discard this draft?"
 msgstr "क्या आप वाकई इस ड्राफ्ट को हटाना करना चाहेंगे?"
 
-#: src/view/screens/ProfileList.tsx:369
+#: src/view/screens/ProfileList.tsx:375
 msgid "Are you sure?"
 msgstr "क्या आप वास्तव में इसे करना चाहते हैं?"
 
@@ -211,10 +223,14 @@ msgstr "क्या आप वास्तव में इसे करना 
 msgid "Artistic or non-erotic nudity."
 msgstr "कलात्मक या गैर-कामुक नग्नता।।"
 
+#: src/view/screens/Moderation.tsx:189
+msgid "Ask apps to limit the visibility of my account"
+msgstr ""
+
 #: src/view/com/auth/create/CreateAccount.tsx:145
 #: src/view/com/auth/login/ChooseAccountForm.tsx:151
 #: src/view/com/auth/login/ForgotPasswordForm.tsx:166
-#: src/view/com/auth/login/LoginForm.tsx:251
+#: src/view/com/auth/login/LoginForm.tsx:249
 #: src/view/com/auth/login/SetNewPasswordForm.tsx:148
 #: src/view/com/modals/report/InputIssueDetails.tsx:45
 #: src/view/com/post-thread/PostThread.tsx:381
@@ -242,15 +258,15 @@ msgstr "जन्मदिन:"
 msgid "Block Account"
 msgstr "खाता ब्लॉक करें"
 
-#: src/view/screens/ProfileList.tsx:470
+#: src/view/screens/ProfileList.tsx:478
 msgid "Block accounts"
 msgstr "खाता ब्लॉक करें"
 
-#: src/view/screens/ProfileList.tsx:326
+#: src/view/screens/ProfileList.tsx:330
 msgid "Block these accounts?"
 msgstr "खाता ब्लॉक करें?"
 
-#: src/view/screens/Moderation.tsx:109
+#: src/view/screens/Moderation.tsx:121
 msgid "Blocked accounts"
 msgstr "ब्लॉक किए गए खाते"
 
@@ -270,7 +286,7 @@ msgstr "अवरुद्ध खाते आपके थ्रेड्स �
 msgid "Blocked post."
 msgstr "ब्लॉक पोस्ट।"
 
-#: src/view/screens/ProfileList.tsx:328
+#: src/view/screens/ProfileList.tsx:332
 msgid "Blocking is public. Blocked accounts cannot reply in your threads, mention you, or otherwise interact with you."
 msgstr "अवरोधन सार्वजनिक है. अवरुद्ध खाते आपके थ्रेड्स में उत्तर नहीं दे सकते, आपका उल्लेख नहीं कर सकते, या अन्यथा आपके साथ बातचीत नहीं कर सकते।"
 
@@ -488,11 +504,11 @@ msgid "Confirmation code"
 msgstr "OTP कोड"
 
 #: src/view/com/auth/create/CreateAccount.tsx:178
-#: src/view/com/auth/login/LoginForm.tsx:270
+#: src/view/com/auth/login/LoginForm.tsx:268
 msgid "Connecting..."
 msgstr "कनेक्टिंग ..।"
 
-#: src/view/screens/Moderation.tsx:67
+#: src/view/screens/Moderation.tsx:79
 msgid "Content filtering"
 msgstr "सामग्री फ़िल्टरिंग"
 
@@ -527,7 +543,7 @@ msgstr "कॉपी कर ली"
 msgid "Copy"
 msgstr "कॉपी"
 
-#: src/view/screens/ProfileList.tsx:399
+#: src/view/screens/ProfileList.tsx:407
 msgid "Copy link to list"
 msgstr ""
 
@@ -551,7 +567,7 @@ msgstr "कॉपीराइट नीति"
 msgid "Could not load feed"
 msgstr "फ़ीड लोड नहीं कर सकता"
 
-#: src/view/screens/ProfileList.tsx:779
+#: src/view/screens/ProfileList.tsx:787
 msgid "Could not load list"
 msgstr "सूची लोड नहीं कर सकता"
 
@@ -597,8 +613,8 @@ msgstr "खाता हटाएं"
 msgid "Delete app password"
 msgstr "अप्प पासवर्ड हटाएं"
 
-#: src/view/screens/ProfileList.tsx:368
-#: src/view/screens/ProfileList.tsx:426
+#: src/view/screens/ProfileList.tsx:374
+#: src/view/screens/ProfileList.tsx:434
 msgid "Delete List"
 msgstr "सूची हटाएँ"
 
@@ -668,7 +684,7 @@ msgstr "डोमेन सत्यापित!"
 #: src/view/com/modals/EditImage.tsx:333
 #: src/view/com/modals/ListAddRemoveUsers.tsx:142
 #: src/view/com/modals/SelfLabel.tsx:157
-#: src/view/com/modals/UserAddRemoveLists.tsx:78
+#: src/view/com/modals/UserAddRemoveLists.tsx:79
 #: src/view/screens/PreferencesHomeFeed.tsx:302
 #: src/view/screens/PreferencesThreads.tsx:156
 msgid "Done"
@@ -687,7 +703,7 @@ msgstr "प्रत्येक कोड एक बार काम करत�
 msgid "Edit image"
 msgstr "छवि संपादित करें"
 
-#: src/view/screens/ProfileList.tsx:414
+#: src/view/screens/ProfileList.tsx:422
 msgid "Edit list details"
 msgstr "सूची विवरण संपादित करें"
 
@@ -785,15 +801,15 @@ msgid "Feed Preferences"
 msgstr "फ़ीड प्राथमिकता"
 
 #: src/view/shell/desktop/RightNav.tsx:64
-#: src/view/shell/Drawer.tsx:410
+#: src/view/shell/Drawer.tsx:300
 msgid "Feedback"
 msgstr "प्रतिक्रिया"
 
 #: src/view/screens/Feeds.tsx:475
 #: src/view/shell/bottom-bar/BottomBar.tsx:168
 #: src/view/shell/desktop/LeftNav.tsx:341
-#: src/view/shell/Drawer.tsx:327
-#: src/view/shell/Drawer.tsx:328
+#: src/view/shell/Drawer.tsx:463
+#: src/view/shell/Drawer.tsx:464
 msgid "Feeds"
 msgstr "सभी फ़ीड"
 
@@ -854,11 +870,11 @@ msgstr "सुरक्षा कारणों के लिए, हमें 
 msgid "For security reasons, you won't be able to view this again. If you lose this password, you'll need to generate a new one."
 msgstr "सुरक्षा कारणों के लिए, आप इसे फिर से देखने में सक्षम नहीं होंगे। यदि आप इस पासवर्ड को खो देते हैं, तो आपको एक नया उत्पन्न करना होगा।।"
 
-#: src/view/com/auth/login/LoginForm.tsx:233
+#: src/view/com/auth/login/LoginForm.tsx:231
 msgid "Forgot"
 msgstr "भूल"
 
-#: src/view/com/auth/login/LoginForm.tsx:230
+#: src/view/com/auth/login/LoginForm.tsx:228
 msgid "Forgot password"
 msgstr "पासवर्ड भूल गए"
 
@@ -884,13 +900,13 @@ msgstr "वापस जाओ"
 
 #: src/view/screens/ProfileFeed.tsx:111
 #: src/view/screens/ProfileFeed.tsx:116
-#: src/view/screens/ProfileList.tsx:788
-#: src/view/screens/ProfileList.tsx:793
+#: src/view/screens/ProfileList.tsx:796
+#: src/view/screens/ProfileList.tsx:801
 msgid "Go Back"
 msgstr "वापस जाओ"
 
 #: src/view/com/auth/login/ForgotPasswordForm.tsx:181
-#: src/view/com/auth/login/LoginForm.tsx:280
+#: src/view/com/auth/login/LoginForm.tsx:278
 #: src/view/com/auth/login/SetNewPasswordForm.tsx:163
 msgid "Go to next"
 msgstr "अगला"
@@ -900,7 +916,7 @@ msgid "Handle"
 msgstr "हैंडल"
 
 #: src/view/shell/desktop/RightNav.tsx:93
-#: src/view/shell/Drawer.tsx:420
+#: src/view/shell/Drawer.tsx:310
 msgid "Help"
 msgstr "सहायता"
 
@@ -946,8 +962,8 @@ msgstr ""
 
 #: src/view/shell/bottom-bar/BottomBar.tsx:124
 #: src/view/shell/desktop/LeftNav.tsx:305
-#: src/view/shell/Drawer.tsx:274
-#: src/view/shell/Drawer.tsx:275
+#: src/view/shell/Drawer.tsx:387
+#: src/view/shell/Drawer.tsx:388
 msgid "Home"
 msgstr "होम फीड"
 
@@ -1013,7 +1029,7 @@ msgstr "आमंत्रण कोड"
 msgid "Invite code not accepted. Check that you input it correctly and try again."
 msgstr ""
 
-#: src/view/shell/Drawer.tsx:502
+#: src/view/shell/Drawer.tsx:629
 msgid "Invite codes: {invitesAvailable} available"
 msgstr ""
 
@@ -1056,6 +1072,10 @@ msgstr "अधिक जानें"
 msgid "Learn more about this warning"
 msgstr "इस चेतावनी के बारे में अधिक जानें"
 
+#: src/view/screens/Moderation.tsx:223
+msgid "Learn more about what is public on Bluesky."
+msgstr ""
+
 #: src/view/com/modals/lang-settings/ContentLanguagesSettings.tsx:82
 msgid "Leave them all unchecked to see any language."
 msgstr "उन्हें किसी भी भाषा को देखने के लिए अनचेक छोड़ दें।।"
@@ -1078,7 +1098,7 @@ msgstr "चित्र पुस्तकालय"
 #~ msgid "Light"
 #~ msgstr "लाइट मोड"
 
-#: src/view/screens/ProfileFeed.tsx:637
+#: src/view/screens/ProfileFeed.tsx:639
 msgid "Like this feed"
 msgstr "इस फ़ीड को लाइक करो"
 
@@ -1096,8 +1116,8 @@ msgid "List Name"
 msgstr "सूची का नाम"
 
 #: src/view/shell/desktop/LeftNav.tsx:381
-#: src/view/shell/Drawer.tsx:338
-#: src/view/shell/Drawer.tsx:339
+#: src/view/shell/Drawer.tsx:479
+#: src/view/shell/Drawer.tsx:480
 msgid "Lists"
 msgstr "सूची"
 
@@ -1143,15 +1163,15 @@ msgstr "मेनू"
 msgid "Message from server"
 msgstr ""
 
-#: src/view/screens/Moderation.tsx:51
+#: src/view/screens/Moderation.tsx:63
 #: src/view/screens/Settings.tsx:563
 #: src/view/shell/desktop/LeftNav.tsx:399
-#: src/view/shell/Drawer.tsx:345
-#: src/view/shell/Drawer.tsx:346
+#: src/view/shell/Drawer.tsx:498
+#: src/view/shell/Drawer.tsx:499
 msgid "Moderation"
 msgstr "मॉडरेशन"
 
-#: src/view/screens/Moderation.tsx:81
+#: src/view/screens/Moderation.tsx:93
 msgid "Moderation lists"
 msgstr "मॉडरेशन सूचियाँ"
 
@@ -1165,7 +1185,7 @@ msgstr "अधिक फ़ीड"
 
 #: src/view/com/profile/ProfileHeader.tsx:523
 #: src/view/screens/ProfileFeed.tsx:369
-#: src/view/screens/ProfileList.tsx:531
+#: src/view/screens/ProfileList.tsx:539
 msgid "More options"
 msgstr "अधिक विकल्प"
 
@@ -1177,11 +1197,11 @@ msgstr "अधिक विकल्प"
 msgid "Mute Account"
 msgstr "खाता म्यूट करें"
 
-#: src/view/screens/ProfileList.tsx:458
+#: src/view/screens/ProfileList.tsx:466
 msgid "Mute accounts"
 msgstr "खातों को म्यूट करें"
 
-#: src/view/screens/ProfileList.tsx:291
+#: src/view/screens/ProfileList.tsx:293
 msgid "Mute these accounts?"
 msgstr "इन खातों को म्यूट करें?"
 
@@ -1189,7 +1209,7 @@ msgstr "इन खातों को म्यूट करें?"
 msgid "Mute thread"
 msgstr "थ्रेड म्यूट करें"
 
-#: src/view/screens/Moderation.tsx:95
+#: src/view/screens/Moderation.tsx:107
 msgid "Muted accounts"
 msgstr "म्यूट किए गए खाते"
 
@@ -1201,9 +1221,13 @@ msgstr "म्यूट किए गए खाते"
 msgid "Muted accounts have their posts removed from your feed and from your notifications. Mutes are completely private."
 msgstr "म्यूट किए गए खातों की पोस्ट आपके फ़ीड और आपकी सूचनाओं से हटा दी जाती हैं। म्यूट पूरी तरह से निजी हैं."
 
-#: src/view/screens/ProfileList.tsx:293
+#: src/view/screens/ProfileList.tsx:295
 msgid "Muting is private. Muted accounts can interact with you, but you will not see their posts or receive notifications from them."
 msgstr "म्यूट करना निजी है. म्यूट किए गए खाते आपके साथ इंटरैक्ट कर सकते हैं, लेकिन आप उनकी पोस्ट नहीं देखेंगे या उनसे सूचनाएं प्राप्त नहीं करेंगे।"
+
+#: src/view/screens/Moderation.tsx:134
+msgid "My Account"
+msgstr ""
 
 #: src/view/com/modals/BirthDateSettings.tsx:56
 msgid "My Birthday"
@@ -1239,8 +1263,8 @@ msgstr "नया"
 #: src/view/screens/Feeds.tsx:510
 #: src/view/screens/Profile.tsx:388
 #: src/view/screens/ProfileFeed.tsx:450
-#: src/view/screens/ProfileList.tsx:211
-#: src/view/screens/ProfileList.tsx:243
+#: src/view/screens/ProfileList.tsx:212
+#: src/view/screens/ProfileList.tsx:244
 #: src/view/shell/desktop/LeftNav.tsx:254
 msgid "New post"
 msgstr "नई पोस्ट"
@@ -1252,7 +1276,7 @@ msgstr "नई पोस्ट"
 #: src/view/com/auth/create/CreateAccount.tsx:158
 #: src/view/com/auth/login/ForgotPasswordForm.tsx:174
 #: src/view/com/auth/login/ForgotPasswordForm.tsx:184
-#: src/view/com/auth/login/LoginForm.tsx:283
+#: src/view/com/auth/login/LoginForm.tsx:281
 #: src/view/com/auth/login/SetNewPasswordForm.tsx:156
 #: src/view/com/auth/login/SetNewPasswordForm.tsx:166
 #: src/view/com/auth/onboarding/RecommendedFeeds.tsx:79
@@ -1269,8 +1293,8 @@ msgstr "अगली फोटो"
 msgid "No"
 msgstr "नहीं<<<<<<< HEAD"
 
-#: src/view/screens/ProfileFeed.tsx:630
-#: src/view/screens/ProfileList.tsx:659
+#: src/view/screens/ProfileFeed.tsx:632
+#: src/view/screens/ProfileList.tsx:667
 msgid "No description"
 msgstr "कोई विवरण नहीं"
 
@@ -1307,8 +1331,8 @@ msgstr "लागू नहीं।"
 #: src/view/screens/Notifications.tsx:120
 #: src/view/shell/bottom-bar/BottomBar.tsx:195
 #: src/view/shell/desktop/LeftNav.tsx:363
-#: src/view/shell/Drawer.tsx:298
-#: src/view/shell/Drawer.tsx:299
+#: src/view/shell/Drawer.tsx:424
+#: src/view/shell/Drawer.tsx:425
 msgid "Notifications"
 msgstr "सूचनाएं"
 
@@ -1333,7 +1357,7 @@ msgid "Opens configurable language settings"
 msgstr "भाषा सेटिंग्स खोलें"
 
 #: src/view/shell/desktop/RightNav.tsx:146
-#: src/view/shell/Drawer.tsx:503
+#: src/view/shell/Drawer.tsx:630
 msgid "Opens list of invite codes"
 msgstr ""
 
@@ -1388,7 +1412,7 @@ msgstr "पृष्ठ नहीं मिला"
 
 #: src/view/com/auth/create/Step2.tsx:101
 #: src/view/com/auth/create/Step2.tsx:111
-#: src/view/com/auth/login/LoginForm.tsx:218
+#: src/view/com/auth/login/LoginForm.tsx:216
 #: src/view/com/auth/login/SetNewPasswordForm.tsx:130
 #: src/view/com/modals/DeleteAccount.tsx:191
 msgid "Password"
@@ -1486,8 +1510,8 @@ msgstr "प्रसंस्करण..."
 
 #: src/view/shell/bottom-bar/BottomBar.tsx:237
 #: src/view/shell/Drawer.tsx:72
-#: src/view/shell/Drawer.tsx:366
-#: src/view/shell/Drawer.tsx:367
+#: src/view/shell/Drawer.tsx:533
+#: src/view/shell/Drawer.tsx:534
 msgid "Profile"
 msgstr "प्रोफ़ाइल"
 
@@ -1531,7 +1555,7 @@ msgstr "अनुशंसित लोग"
 
 #: src/view/com/modals/ListAddRemoveUsers.tsx:264
 #: src/view/com/modals/SelfLabel.tsx:83
-#: src/view/com/modals/UserAddRemoveLists.tsx:192
+#: src/view/com/modals/UserAddRemoveLists.tsx:193
 #: src/view/com/util/UserAvatar.tsx:278
 #: src/view/com/util/UserBanner.tsx:89
 msgid "Remove"
@@ -1567,7 +1591,7 @@ msgid "Remove this feed from your saved feeds?"
 msgstr "इस फ़ीड को सहेजे गए फ़ीड से हटा दें?"
 
 #: src/view/com/modals/ListAddRemoveUsers.tsx:199
-#: src/view/com/modals/UserAddRemoveLists.tsx:135
+#: src/view/com/modals/UserAddRemoveLists.tsx:136
 msgid "Removed from list"
 msgstr ""
 
@@ -1587,7 +1611,7 @@ msgstr "रिपोर्ट"
 msgid "Report feed"
 msgstr "रिपोर्ट फ़ीड"
 
-#: src/view/screens/ProfileList.tsx:440
+#: src/view/screens/ProfileList.tsx:448
 msgid "Report List"
 msgstr "रिपोर्ट सूची"
 
@@ -1613,6 +1637,10 @@ msgstr "द्वारा दोबारा पोस्ट किया ग�
 #: src/view/com/modals/ChangeEmail.tsx:183
 msgid "Request Change"
 msgstr "अनुरोध बदलें"
+
+#: src/view/screens/Moderation.tsx:188
+#~ msgid "Request to limit the visibility of my account"
+#~ msgstr ""
 
 #: src/view/screens/Settings.tsx:382
 #~ msgid "Require alt text before posting"
@@ -1648,8 +1676,8 @@ msgstr "प्राथमिकताओं की स्थिति को �
 
 #: src/view/com/auth/create/CreateAccount.tsx:167
 #: src/view/com/auth/create/CreateAccount.tsx:171
-#: src/view/com/auth/login/LoginForm.tsx:260
-#: src/view/com/auth/login/LoginForm.tsx:263
+#: src/view/com/auth/login/LoginForm.tsx:258
+#: src/view/com/auth/login/LoginForm.tsx:261
 #: src/view/com/util/error/ErrorMessage.tsx:55
 #: src/view/com/util/error/ErrorScreen.tsx:65
 msgid "Retry"
@@ -1701,8 +1729,8 @@ msgstr "सहेजे गए फ़ीड"
 #: src/view/shell/desktop/LeftNav.tsx:323
 #: src/view/shell/desktop/Search.tsx:161
 #: src/view/shell/desktop/Search.tsx:170
-#: src/view/shell/Drawer.tsx:252
-#: src/view/shell/Drawer.tsx:253
+#: src/view/shell/Drawer.tsx:351
+#: src/view/shell/Drawer.tsx:352
 msgid "Search"
 msgstr "खोज"
 
@@ -1726,7 +1754,7 @@ msgstr "Bluesky Social का चयन करें"
 msgid "Select from an existing account"
 msgstr "मौजूदा खाते से चुनें"
 
-#: src/view/com/auth/login/LoginForm.tsx:145
+#: src/view/com/auth/login/LoginForm.tsx:143
 msgid "Select service"
 msgstr "सेवा चुनें"
 
@@ -1754,8 +1782,8 @@ msgstr "ईमेल भेजें"
 msgid "Send Email"
 msgstr "ईमेल भेजें"
 
-#: src/view/shell/Drawer.tsx:394
-#: src/view/shell/Drawer.tsx:415
+#: src/view/shell/Drawer.tsx:284
+#: src/view/shell/Drawer.tsx:305
 msgid "Send feedback"
 msgstr "प्रतिक्रिया भेजें"
 
@@ -1789,8 +1817,8 @@ msgstr "इस सेटिंग को अपने निम्नलिख�
 
 #: src/view/screens/Settings.tsx:277
 #: src/view/shell/desktop/LeftNav.tsx:435
-#: src/view/shell/Drawer.tsx:379
-#: src/view/shell/Drawer.tsx:380
+#: src/view/shell/Drawer.tsx:554
+#: src/view/shell/Drawer.tsx:555
 msgid "Settings"
 msgstr "सेटिंग्स"
 
@@ -1800,7 +1828,7 @@ msgstr "यौन गतिविधि या कामुक नग्नत�
 
 #: src/view/com/profile/ProfileHeader.tsx:313
 #: src/view/com/util/forms/PostDropdownBtn.tsx:126
-#: src/view/screens/ProfileList.tsx:399
+#: src/view/screens/ProfileList.tsx:407
 msgid "Share"
 msgstr "शेयर"
 
@@ -1865,7 +1893,7 @@ msgstr "{0} के रूप में साइन इन करें"
 msgid "Sign in as..."
 msgstr "... के रूप में साइन इन करें"
 
-#: src/view/com/auth/login/LoginForm.tsx:132
+#: src/view/com/auth/login/LoginForm.tsx:130
 msgid "Sign into"
 msgstr "साइन इन करें"
 
@@ -1917,11 +1945,11 @@ msgstr "स्थिति पृष्ठ"
 msgid "Storybook"
 msgstr "Storybook"
 
-#: src/view/screens/ProfileList.tsx:522
+#: src/view/screens/ProfileList.tsx:530
 msgid "Subscribe"
 msgstr "सब्सक्राइब"
 
-#: src/view/screens/ProfileList.tsx:518
+#: src/view/screens/ProfileList.tsx:526
 msgid "Subscribe to this list"
 msgstr "इस सूची को सब्सक्राइब करें"
 
@@ -2129,12 +2157,12 @@ msgstr "यूजर हैंडल"
 msgid "User Lists"
 msgstr "लोग सूचियाँ"
 
-#: src/view/com/auth/login/LoginForm.tsx:172
-#: src/view/com/auth/login/LoginForm.tsx:189
+#: src/view/com/auth/login/LoginForm.tsx:170
+#: src/view/com/auth/login/LoginForm.tsx:187
 msgid "Username or email address"
 msgstr "यूजर नाम या ईमेल पता"
 
-#: src/view/screens/ProfileList.tsx:686
+#: src/view/screens/ProfileList.tsx:694
 msgid "Users"
 msgstr "यूजर लोग"
 
@@ -2254,7 +2282,7 @@ msgstr "आपने लेखक को अवरुद्ध किया ह�
 msgid "You have no feeds."
 msgstr ""
 
-#: src/view/com/lists/MyLists.tsx:88
+#: src/view/com/lists/MyLists.tsx:89
 #: src/view/com/lists/ProfileLists.tsx:154
 msgid "You have no lists."
 msgstr "आपके पास कोई सूची नहीं है।।"
@@ -2310,7 +2338,7 @@ msgstr "आपका होस्टिंग प्रदाता"
 
 #: src/view/screens/Settings.tsx:402
 #: src/view/shell/desktop/RightNav.tsx:127
-#: src/view/shell/Drawer.tsx:517
+#: src/view/shell/Drawer.tsx:644
 msgid "Your invite codes are hidden when logged in using an App Password"
 msgstr ""
 
@@ -2321,6 +2349,10 @@ msgstr "आपकी पोस्ट, पसंद और ब्लॉक सा
 #: src/view/com/modals/SwitchAccount.tsx:78
 msgid "Your profile"
 msgstr "आपकी प्रोफ़ाइल"
+
+#: src/view/screens/Moderation.tsx:205
+#~ msgid "Your profile and account will not be visible to anyone visiting the Bluesky app without an account, or to account holders who are not logged in. Enabling this will not make your profile private."
+#~ msgstr ""
 
 #: src/view/com/auth/create/Step3.tsx:28
 msgid "Your user handle"

--- a/src/state/queries/post-thread.ts
+++ b/src/state/queries/post-thread.ts
@@ -34,7 +34,6 @@ export type ThreadPost = {
   record: AppBskyFeedPost.Record
   parent?: ThreadNode
   replies?: ThreadNode[]
-  viewer?: AppBskyFeedDefs.ViewerThreadState
   ctx: ThreadCtx
 }
 
@@ -188,7 +187,6 @@ function responseToThreadNodes(
               // do not show blocked posts in replies
               .filter(node => node.type !== 'blocked')
           : undefined,
-      viewer: node.viewer,
       ctx: {
         depth,
         isHighlightedPost: depth === 0,
@@ -276,7 +274,6 @@ function threadNodeToPlaceholderThread(
     record: node.record,
     parent: undefined,
     replies: undefined,
-    viewer: node.viewer,
     ctx: {
       depth: 0,
       isHighlightedPost: true,
@@ -300,7 +297,6 @@ function postViewToPlaceholderThread(
     record: post.record as AppBskyFeedPost.Record, // validated in notifs
     parent: undefined,
     replies: undefined,
-    viewer: post.viewer,
     ctx: {
       depth: 0,
       isHighlightedPost: true,
@@ -331,7 +327,6 @@ function embedViewRecordToPlaceholderThread(
     record: record.value as AppBskyFeedPost.Record, // validated in getEmbeddedPost
     parent: undefined,
     replies: undefined,
-    viewer: undefined, // not available
     ctx: {
       depth: 0,
       isHighlightedPost: true,

--- a/src/view/screens/Moderation.tsx
+++ b/src/view/screens/Moderation.tsx
@@ -182,14 +182,15 @@ function PwiOptOut() {
 
   return (
     <View style={[pal.view, styles.toggleCard]}>
-      <View style={{flexDirection: 'row', alignItems: 'center'}}>
+      <View
+        style={{flexDirection: 'row', alignItems: 'center', paddingRight: 14}}>
         <ToggleButton
           type="default-light"
           label={_(msg`Request to limit the visibility of my account`)}
           labelType="lg"
           isSelected={isOptedOut}
           onPress={canToggle ? onToggleOptOut : undefined}
-          style={canToggle ? undefined : {opacity: 0.5}}
+          style={[canToggle ? undefined : {opacity: 0.5}, {flex: 1}]}
         />
         {updateProfile.isPending && <ActivityIndicator />}
       </View>

--- a/src/view/screens/Moderation.tsx
+++ b/src/view/screens/Moderation.tsx
@@ -186,7 +186,7 @@ function PwiOptOut() {
         style={{flexDirection: 'row', alignItems: 'center', paddingRight: 14}}>
         <ToggleButton
           type="default-light"
-          label={_(msg`Request to limit the visibility of my account`)}
+          label={_(msg`Ask apps to limit the visibility of my account`)}
           labelType="lg"
           isSelected={isOptedOut}
           onPress={canToggle ? onToggleOptOut : undefined}
@@ -204,16 +204,16 @@ function PwiOptOut() {
         }}>
         <Text style={pal.textLight}>
           <Trans>
-            Your profile and account will not be visible to anyone visiting the
-            Bluesky app without an account, or to account holders who are not
-            logged in. Enabling this will not make your profile private.
+            Apps that respect this setting, including the official Bluesky app
+            and bsky.app website, won't show your content to logged out users.
           </Trans>
         </Text>
         <Text style={pal.textLight}>
           <Trans>
             <Text style={[pal.textLight, {fontWeight: '600'}]}>
-              Note: This setting may not be respected by third-party apps that
-              display Bluesky content.
+              Note: Your profile and posts will remain publicly available.
+              Third-party apps that display Bluesky content may not respect this
+              setting.
             </Text>{' '}
           </Trans>
         </Text>

--- a/src/view/screens/Moderation.tsx
+++ b/src/view/screens/Moderation.tsx
@@ -15,7 +15,7 @@ import {NativeStackScreenProps, CommonNavigatorParams} from 'lib/routes/types'
 import {s} from 'lib/styles'
 import {CenteredView} from '../com/util/Views'
 import {ViewHeader} from '../com/util/ViewHeader'
-import {Link} from '../com/util/Link'
+import {Link, TextLink} from '../com/util/Link'
 import {Text} from '../com/util/text/Text'
 import {usePalette} from 'lib/hooks/usePalette'
 import {useAnalytics} from 'lib/analytics/analytics'
@@ -185,7 +185,7 @@ function PwiOptOut() {
       <View style={{flexDirection: 'row', alignItems: 'center'}}>
         <ToggleButton
           type="default-light"
-          label={_(msg`Hide my account from logged-out users`)}
+          label={_(msg`Request to limit the visibility of my account`)}
           labelType="lg"
           isSelected={isOptedOut}
           onPress={canToggle ? onToggleOptOut : undefined}
@@ -203,16 +203,24 @@ function PwiOptOut() {
         }}>
         <Text style={pal.textLight}>
           <Trans>
-            Enabling this will not make your profile private, but it will hide
-            your profile and content from logged-out users.
+            Your profile and account will not be visible to anyone visiting the
+            Bluesky app without an account, or to account holders who are not
+            logged in. Enabling this will not make your profile private.
           </Trans>
         </Text>
         <Text style={pal.textLight}>
           <Trans>
-            Bluesky is an open network. Your profile and content are publicly
-            available. Other apps on the network may not respect this setting.
+            <Text style={[pal.textLight, {fontWeight: '600'}]}>
+              Note: This setting may not be respected by third-party apps that
+              display Bluesky content.
+            </Text>{' '}
           </Trans>
         </Text>
+        <TextLink
+          style={pal.link}
+          href="https://blueskyweb.zendesk.com/hc/en-us/articles/15835264007693-Data-Privacy"
+          text={_(msg`Learn more about what is public on Bluesky.`)}
+        />
       </View>
     </View>
   )

--- a/src/view/screens/Moderation.tsx
+++ b/src/view/screens/Moderation.tsx
@@ -131,7 +131,7 @@ export function ModerationScreen({}: Props) {
             paddingBottom: 6,
           },
         ]}>
-        <Trans>My Account</Trans>
+        <Trans>Logged-out users</Trans>
       </Text>
       <PwiOptOut />
     </CenteredView>
@@ -200,7 +200,7 @@ function PwiOptOut() {
         style={{flexDirection: 'row', alignItems: 'center', paddingRight: 14}}>
         <ToggleButton
           type="default-light"
-          label={_(msg`Ask apps to limit the visibility of my account`)}
+          label={_(msg`Limit the visibility of my account`)}
           labelType="lg"
           isSelected={isOptedOut}
           onPress={canToggle ? onToggleOptOut : undefined}
@@ -213,22 +213,20 @@ function PwiOptOut() {
           flexDirection: 'column',
           gap: 10,
           paddingLeft: 66,
-          paddingRight: 8,
+          paddingRight: 12,
           paddingBottom: 10,
         }}>
         <Text style={pal.textLight}>
           <Trans>
-            Apps that respect this setting, including the official Bluesky app
-            and bsky.app website, won't show your content to logged out users.
+            Your profile and content will not be visible to anyone visiting the
+            Bluesky app without an account. Enabling this will not make your
+            profile private.
           </Trans>
         </Text>
-        <Text style={pal.textLight}>
+        <Text style={[pal.textLight, {fontWeight: '500'}]}>
           <Trans>
-            <Text style={[pal.textLight, {fontWeight: '600'}]}>
-              Note: Your profile and posts will remain publicly available.
-              Third-party apps that display Bluesky content may not respect this
-              setting.
-            </Text>{' '}
+            Note: Third-party apps that display Bluesky content may not respect
+            this setting.
           </Trans>
         </Text>
         <TextLink
@@ -258,6 +256,7 @@ const styles = StyleSheet.create({
   },
   toggleCard: {
     paddingVertical: 8,
+    paddingTop: 2,
     paddingHorizontal: 6,
     marginBottom: 1,
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -34,24 +34,24 @@
     jsonpointer "^5.0.0"
     leven "^3.1.0"
 
-"@atproto/api@^0.6.23":
-  version "0.6.23"
-  resolved "https://registry.yarnpkg.com/@atproto/api/-/api-0.6.23.tgz#1c475ce505a7029733bdcb4a0f77e8000a735f67"
-  integrity sha512-DUaoMv3Uu/WUNIoLk1OGYmsXNXnu8fKJmma7wbftiWmCiXqE5wiO3GHg3V8Zq6TXSiaQ9C+xcwx5/eMBnz1BsA==
+"@atproto/api@^0.6.24":
+  version "0.6.24"
+  resolved "https://registry.yarnpkg.com/@atproto/api/-/api-0.6.24.tgz#79753f82649baa2993677645d809708dd5796e0a"
+  integrity sha512-y3gz0F5wYAtaZ5XYL8FqXW90sOnXHlh4Cir+hjrlSftSoNJcTVR+6dKT5m0ZTqqvFoFryTPKs6BEQy/VBCsNxg==
   dependencies:
     "@atproto/common-web" "^0.2.3"
-    "@atproto/lexicon" "^0.3.0"
-    "@atproto/syntax" "^0.1.4"
-    "@atproto/xrpc" "^0.4.0"
+    "@atproto/lexicon" "^0.3.1"
+    "@atproto/syntax" "^0.1.5"
+    "@atproto/xrpc" "^0.4.1"
     multiformats "^9.9.0"
     tlds "^1.234.0"
     typed-emitter "^2.1.0"
     zod "^3.21.4"
 
-"@atproto/api@^0.6.24":
-  version "0.6.24"
-  resolved "https://registry.yarnpkg.com/@atproto/api/-/api-0.6.24.tgz#79753f82649baa2993677645d809708dd5796e0a"
-  integrity sha512-y3gz0F5wYAtaZ5XYL8FqXW90sOnXHlh4Cir+hjrlSftSoNJcTVR+6dKT5m0ZTqqvFoFryTPKs6BEQy/VBCsNxg==
+"@atproto/api@^0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@atproto/api/-/api-0.7.0.tgz#8cdc9613a3ddd390073b3e8d6ac56e9df04d833b"
+  integrity sha512-1iW/RctVLi74axkXRgou52GjuqnYRSHgZi48hF9aqIR4ukONX+5FU7ALjPAz8c+0KZQXFQyY28fB+FnPNGVCig==
   dependencies:
     "@atproto/common-web" "^0.2.3"
     "@atproto/lexicon" "^0.3.1"
@@ -210,17 +210,6 @@
     "@atproto/crypto" "^0.3.0"
     axios "^0.27.2"
 
-"@atproto/lexicon@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@atproto/lexicon/-/lexicon-0.3.0.tgz#dce33e686789aeddca89980a2661922ffa92552c"
-  integrity sha512-0yxHcgfdIrs1Dlg0uFe53NL65kiz+AlkQhAvcEOiU7CKZxUI0Iwae9FCmP0+3ptcGMYD8X6OrZTHsfw/s4BglA==
-  dependencies:
-    "@atproto/common-web" "^0.2.3"
-    "@atproto/syntax" "^0.1.4"
-    iso-datestring-validator "^2.2.2"
-    multiformats "^9.9.0"
-    zod "^3.21.4"
-
 "@atproto/lexicon@^0.3.1":
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/@atproto/lexicon/-/lexicon-0.3.1.tgz#5d7275d041883a1c930404e3274a6fe7affc151f"
@@ -292,13 +281,6 @@
     uint8arrays "3.0.0"
     zod "^3.21.4"
 
-"@atproto/syntax@^0.1.4":
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/@atproto/syntax/-/syntax-0.1.4.tgz#f5569bb4e87f61407d42c37766cf0c2a83ce0b26"
-  integrity sha512-+18HKNJsMQfjlcn62Z9daK8wC/inuqEYXY2FHEd5cNnCt808x2lWLSHB32I6iYEib0d7XDdnaHimBFzWge/C1Q==
-  dependencies:
-    "@atproto/common-web" "^0.2.3"
-
 "@atproto/syntax@^0.1.5":
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/@atproto/syntax/-/syntax-0.1.5.tgz#85b6488a33da3b864e8ac22a61b5586b271206ee"
@@ -321,14 +303,6 @@
     rate-limiter-flexible "^2.4.1"
     uint8arrays "3.0.0"
     ws "^8.12.0"
-    zod "^3.21.4"
-
-"@atproto/xrpc@^0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@atproto/xrpc/-/xrpc-0.4.0.tgz#8911fabcc7d34e140ef03d90d41b763116fc813a"
-  integrity sha512-R73eC1bQyigsKDx7h8Wk8ah7812d24fZV8RAnjkdzfecWMyDBFbJEG5MCC1AEtkGz4YbfwAHMOQe2J1Av9z0RA==
-  dependencies:
-    "@atproto/lexicon" "^0.3.0"
     zod "^3.21.4"
 
 "@atproto/xrpc@^0.4.1":


### PR DESCRIPTION
This just adds the opt-out toggle. The behaviors for handling the opt-out can come in a follow-up PR (not a blocker until we enable the PWI).

- Added to the moderation screen
- Open to discussing the copy, but we need to settle it by Friday

## Current copy

![CleanShot 2023-12-06 at 18 45 17@2x](https://github.com/bluesky-social/social-app/assets/1270099/a8212da7-d2e7-44a8-bbf7-3f6ef33f603d)

## Previous iterations (no longer current)

![CleanShot 2023-12-06 at 16 12 39@2x](https://github.com/bluesky-social/social-app/assets/1270099/293eabef-f773-4826-98ff-d2c0c31a1443)

