### PR TITLE
Completely disable the RQ cache in post-thread

### DIFF
--- a/src/state/queries/post-thread.ts
+++ b/src/state/queries/post-thread.ts
@@ -66,6 +66,7 @@ export type ThreadNode =
 export function usePostThreadQuery(uri: string | undefined) {
   const queryClient = useQueryClient()
   return useQuery<ThreadNode, Error>({
+    gcTime: 0,
     queryKey: RQKEY(uri || ''),
     async queryFn() {
       const res = await getAgent().getPostThread({uri: uri!})


### PR DESCRIPTION
The post-thread query works like this:

```
usePostThreadQuery mounts
  fetch is triggered
    if cached data is available, display
    if placeholder data is available, display
  fetch resolves
    display result
```

When the placeholder renders, it looks like this:

```
+-------------------+       
|     spinner       |       
+-------------------+       
|                   |       
|    target post    |       
|                   |       
+-------------------+       
|     spinner       |       
+-------------------+ 
```

When the full data loads, it becomes this

```
+-------------------+       
|       post        |       
+-------------------+       
|       post        |       
+-------------------+       
|                   |       
|    target post    |       
|                   |       
+-------------------+       
|       post        |       
+-------------------+ 
|       post        |       
+-------------------+ 
```

On mobile, we use `maintainVisibleContentPosition` to make sure that "target post" stays in the same place when the spinners are replaced. This is _extremely_ reliable and seamless.

On Web, we manually measure where "target post" is in the scroll and then scroll to it. This is janky but fairly reliable on Web; on mobile, it completely fails.

When RQ has a cached query, it skips the placeholder step entirely. This causes the `maintainVisibleContentPosition` method to be ineffective; the target post just doesn't load. To fix this, we have two options:

1. Detect when placeholder isn't used an set the scroll position.
2. Always use the placeholder by disabling the cache.

Both are decent options, but I went with 2 because it's the simplest and most reliable approach. We always have placeholders available and the same number of requests are fired (the RQ cache still invalidates in the background). The downside is that there are more loading states than might otherwise exist, but this is extremely minor. I'd strongly suggest with go with 2 for now, and consider 1 if we want to invest the time.

## Before

https://github.com/bluesky-social/social-app/assets/1270099/2118b918-81f2-4fba-90da-cb0f8430b318


## After

https://github.com/bluesky-social/social-app/assets/1270099/647178cf-053f-40e1-bb16-f5d94185ff7b

