### PR TITLE
Grab-bag of post-feed improvements

### DIFF
--- a/src/lib/api/feed/merge.ts
+++ b/src/lib/api/feed/merge.ts
@@ -29,7 +29,7 @@ export class MergeFeedAPI implements FeedAPI {
     this.feedCursor = 0
     this.itemCursor = 0
     this.sampleCursor = 0
-    if (this.params.mergeFeedEnabled && this.params.mergeFeedSources) {
+    if (this.params.mergeFeedSources) {
       this.customFeeds = shuffle(
         this.params.mergeFeedSources.map(
           feedUri => new MergeFeedSource_Custom(feedUri, this.feedTuners),
@@ -108,7 +108,10 @@ export class MergeFeedAPI implements FeedAPI {
 
     // this condition establishes the frequency that custom feeds are woven into follows
     const shouldSample =
-      i >= 15 && candidateFeeds.length >= 2 && (i % 4 === 0 || i % 5 === 0)
+      this.params.mergeFeedEnabled &&
+      i >= 15 &&
+      candidateFeeds.length >= 2 &&
+      (i % 4 === 0 || i % 5 === 0)
 
     if (!canSample && !hasFollows) {
       // no data available

--- a/src/state/queries/notifications/feed.ts
+++ b/src/state/queries/notifications/feed.ts
@@ -91,11 +91,15 @@ export function useNotificationFeedQuery(opts?: {enabled?: boolean}) {
     const {isFetching, hasNextPage, data} = query
 
     let count = 0
+    let numEmpties = 0
     for (const page of data?.pages || []) {
+      if (!page.items.length) {
+        numEmpties++
+      }
       count += page.items.length
     }
 
-    if (!isFetching && hasNextPage && count < PAGE_SIZE) {
+    if (!isFetching && hasNextPage && count < PAGE_SIZE && numEmpties < 3) {
       query.fetchNextPage()
     }
   }, [query])

--- a/src/state/queries/post-feed.ts
+++ b/src/state/queries/post-feed.ts
@@ -217,13 +217,17 @@ export function usePostFeedQuery(
     const {isFetching, hasNextPage, data} = query
 
     let count = 0
+    let numEmpties = 0
     for (const page of data?.pages || []) {
+      if (page.slices.length === 0) {
+        numEmpties++
+      }
       for (const slice of page.slices) {
         count += slice.items.length
       }
     }
 
-    if (!isFetching && hasNextPage && count < PAGE_SIZE) {
+    if (!isFetching && hasNextPage && count < PAGE_SIZE && numEmpties < 3) {
       query.fetchNextPage()
     }
   }, [query])

--- a/src/view/com/posts/Feed.tsx
+++ b/src/view/com/posts/Feed.tsx
@@ -132,13 +132,20 @@ let Feed = ({
 
   React.useEffect(() => {
     // we store the interval handler in a ref to avoid needless
-    // reassignments of the interval
+    // reassignments in other effects
     checkForNewRef.current = checkForNew
   }, [checkForNew])
+  React.useEffect(() => {
+    if (enabled && checkForNewRef.current) {
+      // check for new on enable (aka on focus)
+      checkForNewRef.current()
+    }
+  }, [enabled])
   React.useEffect(() => {
     if (!pollInterval) {
       return
     }
+    // check for new on interval
     const i = setInterval(() => checkForNewRef.current?.(), pollInterval)
     return () => clearInterval(i)
   }, [pollInterval])

--- a/src/view/screens/Home.tsx
+++ b/src/view/screens/Home.tsx
@@ -175,7 +175,7 @@ function HomeScreenReady({
         key="1"
         testID="followingFeedPage"
         isPageFocused={selectedPageIndex === 0}
-        feed={homeFeedParams.mergeFeedEnabled ? 'home' : 'following'}
+        feed="home"
         feedParams={homeFeedParams}
         renderEmptyState={renderFollowingEmptyState}
         renderEndOfFeed={FollowingEndOfFeed}


### PR DESCRIPTION
- 1fede395531c4e3aa6a96c17b23c6dc1b12a52b8 fixes a case where a lot of empty pages are coming back (it can in fact happen)
- ee6709a09afadb69f192d3f475a9affce125d283 falls back to the mergefeed if the user runs out of posts from followed users (in can in fact happen, a lot more than you'd think actually)
- 9ca884b6774196df72cc43bd8190afa5c94f960f fires a "check for new" poll on feed focus, since we no longer background poll