### PR TITLE
Stop using the cached notification page

### DIFF
--- a/src/state/queries/notifications/feed.ts
+++ b/src/state/queries/notifications/feed.ts
@@ -60,20 +60,13 @@ export function useNotificationFeedQuery(opts?: {enabled?: boolean}) {
     staleTime: STALE.INFINITY,
     queryKey: RQKEY(),
     async queryFn({pageParam}: {pageParam: RQPageParam}) {
-      let page
-      if (!pageParam) {
-        // for the first page, we check the cached page held by the unread-checker first
-        page = unreads.getCachedUnreadPage()
-      }
-      if (!page) {
-        page = await fetchPage({
-          limit: PAGE_SIZE,
-          cursor: pageParam,
-          queryClient,
-          moderationOpts,
-          threadMutes,
-        })
-      }
+      let page = await fetchPage({
+        limit: PAGE_SIZE,
+        cursor: pageParam,
+        queryClient,
+        moderationOpts,
+        threadMutes,
+      })
 
       // if the first page has an unread, mark all read
       if (!pageParam && page.items[0] && !page.items[0].notification.isRead) {


### PR DESCRIPTION
This is an optimization I introduced before we discovered that RQ was fetching all the pages, which made this seem more necessary.

The optimization has one strong downside: it manages to dodge the shadow cache due to the timings with weakmaps, and since it's background cached it has a habit of dropping recent likes.

There are also some odd "surprise load" moments while scrolling the feed and I'm vaguely curious if this optimization was to blame somehow, though I haven't tracked down the cause of that issue yet.