### PR TITLE
Add manual per-page memoization to post select

### DIFF
--- a/src/state/queries/post-feed.ts
+++ b/src/state/queries/post-feed.ts
@@ -1,4 +1,4 @@
-import {useCallback, useEffect} from 'react'
+import React, {useCallback, useEffect} from 'react'
 import {
   AppBskyFeedDefs,
   AppBskyFeedPost,
@@ -97,6 +97,22 @@ export function usePostFeedQuery(
   const feedTuners = useFeedTuners(feedDesc)
   const moderationOpts = useModerationOpts()
   const enabled = opts?.enabled !== false && Boolean(moderationOpts)
+  const lastRun = React.useRef<{
+    data: InfiniteData<FeedPageUnselected>
+    args: typeof selectArgs
+    result: InfiniteData<FeedPage>
+  } | null>(null)
+
+  // Make sure this doesn't invalidate unless really needed.
+  const selectArgs = React.useMemo(
+    () => ({
+      feedTuners,
+      disableTuner: params?.disableTuner,
+      moderationOpts,
+      ignoreFilterFor: opts?.ignoreFilterFor,
+    }),
+    [feedTuners, params?.disableTuner, moderationOpts, opts?.ignoreFilterFor],
+  )
 
   const query = useInfiniteQuery<
     FeedPageUnselected,
@@ -147,69 +163,116 @@ export function usePostFeedQuery(
         : undefined,
     select: useCallback(
       (data: InfiniteData<FeedPageUnselected, RQPageParam>) => {
-        const tuner = params?.disableTuner
+        // If the selection depends on some data, that data should
+        // be included in the selectArgs object and read here.
+        const {feedTuners, disableTuner, moderationOpts, ignoreFilterFor} =
+          selectArgs
+
+        const tuner = disableTuner
           ? new NoopFeedTuner()
           : new FeedTuner(feedTuners)
-        return {
-          pageParams: data.pageParams,
-          pages: data.pages.map(page => ({
-            api: page.api,
-            tuner,
-            cursor: page.cursor,
-            slices: tuner
-              .tune(page.feed)
-              .map(slice => {
-                const moderations = slice.items.map(item =>
-                  moderatePost(item.post, moderationOpts!),
-                )
 
-                // apply moderation filter
-                for (let i = 0; i < slice.items.length; i++) {
-                  if (
-                    moderations[i]?.content.filter &&
-                    slice.items[i].post.author.did !== opts?.ignoreFilterFor
-                  ) {
-                    return undefined
-                  }
-                }
-
-                return {
-                  _reactKey: slice._reactKey,
-                  rootUri: slice.rootItem.post.uri,
-                  isThread:
-                    slice.items.length > 1 &&
-                    slice.items.every(
-                      item =>
-                        item.post.author.did === slice.items[0].post.author.did,
-                    ),
-                  items: slice.items
-                    .map((item, i) => {
-                      if (
-                        AppBskyFeedPost.isRecord(item.post.record) &&
-                        AppBskyFeedPost.validateRecord(item.post.record).success
-                      ) {
-                        return {
-                          _reactKey: `${slice._reactKey}-${i}`,
-                          uri: item.post.uri,
-                          post: item.post,
-                          record: item.post.record,
-                          reason:
-                            i === 0 && slice.source
-                              ? slice.source
-                              : item.reason,
-                          moderation: moderations[i],
-                        }
-                      }
-                      return undefined
-                    })
-                    .filter(Boolean) as FeedPostSliceItem[],
-                }
-              })
-              .filter(Boolean) as FeedPostSlice[],
-          })),
+        // Keep track of the last run and whether we can reuse
+        // some already selected pages from there.
+        let reusedPages = []
+        if (lastRun.current) {
+          const {
+            data: lastData,
+            args: lastArgs,
+            result: lastResult,
+          } = lastRun.current
+          let canReuse = true
+          for (let key in selectArgs) {
+            if (selectArgs.hasOwnProperty(key)) {
+              if ((selectArgs as any)[key] !== (lastArgs as any)[key]) {
+                // Can't do reuse anything if any input has changed.
+                canReuse = false
+                break
+              }
+            }
+          }
+          if (canReuse) {
+            for (let i = 0; i < data.pages.length; i++) {
+              if (data.pages[i] && lastData.pages[i] === data.pages[i]) {
+                reusedPages.push(lastResult.pages[i])
+                // Keep the tuner in sync so that the end result is deterministic.
+                tuner.tune(lastData.pages[i].feed)
+                continue
+              }
+              // Stop as soon as pages stop matching up.
+              break
+            }
+          }
         }
+
+        const result = {
+          pageParams: data.pageParams,
+          pages: [
+            ...reusedPages,
+            ...data.pages.slice(reusedPages.length).map(page => ({
+              api: page.api,
+              tuner,
+              cursor: page.cursor,
+              slices: tuner
+                .tune(page.feed)
+                .map(slice => {
+                  const moderations = slice.items.map(item =>
+                    moderatePost(item.post, moderationOpts!),
+                  )
+
+                  // apply moderation filter
+                  for (let i = 0; i < slice.items.length; i++) {
+                    if (
+                      moderations[i]?.content.filter &&
+                      slice.items[i].post.author.did !== ignoreFilterFor
+                    ) {
+                      return undefined
+                    }
+                  }
+
+                  return {
+                    _reactKey: slice._reactKey,
+                    rootUri: slice.rootItem.post.uri,
+                    isThread:
+                      slice.items.length > 1 &&
+                      slice.items.every(
+                        item =>
+                          item.post.author.did ===
+                          slice.items[0].post.author.did,
+                      ),
+                    items: slice.items
+                      .map((item, i) => {
+                        if (
+                          AppBskyFeedPost.isRecord(item.post.record) &&
+                          AppBskyFeedPost.validateRecord(item.post.record)
+                            .success
+                        ) {
+                          return {
+                            _reactKey: `${slice._reactKey}-${i}`,
+                            uri: item.post.uri,
+                            post: item.post,
+                            record: item.post.record,
+                            reason:
+                              i === 0 && slice.source
+                                ? slice.source
+                                : item.reason,
+                            moderation: moderations[i],
+                          }
+                        }
+                        return undefined
+                      })
+                      .filter(Boolean) as FeedPostSliceItem[],
+                  }
+                })
+                .filter(Boolean) as FeedPostSlice[],
+            })),
+          ],
+        }
+        // Save for memoization.
+        lastRun.current = {data, result, args: selectArgs}
+        return result
       },
-      [feedTuners, params?.disableTuner, moderationOpts, opts?.ignoreFilterFor],
+      [selectArgs /* Don't change. Everything needs to go into selectArgs. */],
     ),
   })
 


### PR DESCRIPTION
## What?

We're always regenerating new data in `select()` so every real re-render with new data would lead to recalculation of all slices and blow away our memoization. Let's add a manual memoization step that reuses pages from the previous selection (which in many cases will work out — notably for pagination). I'm assuming pages are immutable (I think so).

Note that we need to advance the tuner while going over the reused pages.

Also note `structuralSharing` wouldn't help us here because the issue is with the pages that were *not* refetched.

[Review without whitespace.](https://github.com/bluesky-social/social-app/pull/2146/files?w=1)

## Before

Every time you fetch a new page, all previous items re-render.

First commit (extraneous and slow -- all pages):

<img width="460" alt="Screenshot 2023-12-08 at 04 40 07" src="https://github.com/bluesky-social/social-app/assets/810438/ed89a165-3ea6-457a-bbfb-c9ed43ec6e9e">

Second commit (expected:

<img width="434" alt="Screenshot 2023-12-08 at 04 40 16" src="https://github.com/bluesky-social/social-app/assets/810438/9e3e9b0b-347f-4da4-a044-9274387adf30">

## After

When you fetch a new page, only items for that page render (for the first time). 

There's just one commit (it was second in "Before") which only touches the new items.

<img width="499" alt="Screenshot 2023-12-08 at 04 39 12" src="https://github.com/bluesky-social/social-app/assets/810438/8c997e19-36c0-43bf-8be8-15d24bc2ca97">
