### PR TITLE
Poll for new posts on app foreground

### DIFF
--- a/src/view/com/posts/Feed.tsx
+++ b/src/view/com/posts/Feed.tsx
@@ -1,6 +1,7 @@
 import React, {memo, MutableRefObject} from 'react'
 import {
   ActivityIndicator,
+  AppState,
   Dimensions,
   RefreshControl,
   StyleProp,
@@ -142,12 +143,23 @@ let Feed = ({
     }
   }, [enabled])
   React.useEffect(() => {
-    if (!pollInterval) {
-      return
+    let cleanup1: () => void | undefined, cleanup2: () => void | undefined
+    const subscription = AppState.addEventListener('change', nextAppState => {
+      // check for new on app foreground
+      if (nextAppState === 'active') {
+        checkForNewRef.current?.()
+      }
+    })
+    cleanup1 = () => subscription.remove()
+    if (pollInterval) {
+      // check for new on interval
+      const i = setInterval(() => checkForNewRef.current?.(), pollInterval)
+      cleanup2 = () => clearInterval(i)
     }
-    // check for new on interval
-    const i = setInterval(() => checkForNewRef.current?.(), pollInterval)
-    return () => clearInterval(i)
+    return () => {
+      cleanup1?.()
+      cleanup2?.()
+    }
   }, [pollInterval])
 
   const feedItems = React.useMemo(() => {


### PR DESCRIPTION
Similar to the recent PR to poll for new posts on the feed page change, this PR polls on app foreground, ensuring we never just sit with stale posts