### PR TITLE
Add back isInitialLoad to session

### DIFF
--- a/src/App.native.tsx
+++ b/src/App.native.tsx
@@ -39,7 +39,7 @@ SplashScreen.preventAutoHideAsync()
 
 function InnerApp() {
   const colorMode = useColorMode()
-  const {currentAccount} = useSession()
+  const {isInitialLoad, currentAccount} = useSession()
   const {resumeSession} = useSessionApi()
 
   // init
@@ -52,6 +52,9 @@ function InnerApp() {
     const account = persisted.get('session').currentAccount
     resumeSession(account)
   }, [resumeSession])
+
+  // wait for session to resume
+  if (isInitialLoad) return null
 
   return (
     <React.Fragment

--- a/src/App.web.tsx
+++ b/src/App.web.tsx
@@ -30,7 +30,7 @@ import {Provider as UnreadNotifsProvider} from 'state/queries/notifications/unre
 import * as persisted from '#/state/persisted'
 
 function InnerApp() {
-  const {currentAccount} = useSession()
+  const {isInitialLoad, currentAccount} = useSession()
   const {resumeSession} = useSessionApi()
   const colorMode = useColorMode()
 
@@ -39,6 +39,9 @@ function InnerApp() {
     const account = persisted.get('session').currentAccount
     resumeSession(account)
   }, [resumeSession])
+
+  // wait for session to resume
+  if (isInitialLoad) return null
 
   return (
     <React.Fragment

--- a/src/state/session/index.tsx
+++ b/src/state/session/index.tsx
@@ -28,6 +28,7 @@ export function getAgent() {
 export type SessionAccount = persisted.PersistedAccount
 
 export type SessionState = {
+  isInitialLoad: boolean
   isSwitchingAccounts: boolean
   accounts: SessionAccount[]
   currentAccount: SessionAccount | undefined
@@ -75,6 +76,7 @@ export type ApiContext = {
 }
 
 const StateContext = React.createContext<StateContext>({
+  isInitialLoad: true,
   isSwitchingAccounts: false,
   accounts: [],
   currentAccount: undefined,
@@ -150,6 +152,7 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
   const queryClient = useQueryClient()
   const isDirty = React.useRef(false)
   const [state, setState] = React.useState<SessionState>({
+    isInitialLoad: true,
     isSwitchingAccounts: false,
     accounts: persisted.get('session').accounts,
     currentAccount: undefined, // assume logged out to start
@@ -434,6 +437,11 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
         }
       } catch (e) {
         logger.error(`session: resumeSession failed`, {error: e})
+      } finally {
+        setState(s => ({
+          ...s,
+          isInitialLoad: false,
+        }))
       }
     },
     [initSession],


### PR DESCRIPTION
I [was wrong](https://github.com/bluesky-social/social-app/pull/2129#discussion_r1419286474), we still need this when we DO need to refresh the session.