### PR TITLE
Reduce calls to getFeedGenerator and getFeed

### DIFF
--- a/src/lib/api/feed/merge.ts
+++ b/src/lib/api/feed/merge.ts
@@ -62,7 +62,7 @@ export class MergeFeedAPI implements FeedAPI {
 
     // always keep following topped up
     if (this.following.numReady < limit) {
-      promises.push(this.following.fetchNext(60))
+      await this.following.fetchNext(60)
     }
 
     // pick the next feeds to sample from
@@ -73,9 +73,13 @@ export class MergeFeedAPI implements FeedAPI {
     }
 
     // top up the feeds
-    for (const feed of feeds) {
-      if (feed.numReady < 5) {
-        promises.push(feed.fetchNext(10))
+    const outOfFollows =
+      !this.following.hasMore && this.following.numReady < limit
+    if (this.params.mergeFeedEnabled || outOfFollows) {
+      for (const feed of feeds) {
+        if (feed.numReady < 5) {
+          promises.push(feed.fetchNext(10))
+        }
       }
     }
 

--- a/src/lib/api/feed/merge.ts
+++ b/src/lib/api/feed/merge.ts
@@ -216,22 +216,10 @@ class MergeFeedSource_Custom extends MergeFeedSource {
     super(feedTuners)
     this.sourceInfo = {
       $type: 'reasonFeedSource',
-      displayName: feedUri.split('/').pop() || '',
-      uri: feedUriToHref(feedUri),
+      uri: feedUri,
+      href: feedUriToHref(feedUri),
     }
     this.minDate = new Date(Date.now() - POST_AGE_CUTOFF)
-    getAgent()
-      .app.bsky.feed.getFeedGenerator({
-        feed: feedUri,
-      })
-      .then(
-        res => {
-          if (this.sourceInfo) {
-            this.sourceInfo.displayName = res.data.view.displayName
-          }
-        },
-        _err => {},
-      )
   }
 
   protected async _getFeed(

--- a/src/lib/api/feed/types.ts
+++ b/src/lib/api/feed/types.ts
@@ -19,7 +19,7 @@ export interface FeedAPI {
 export interface ReasonFeedSource {
   $type: 'reasonFeedSource'
   uri: string
-  displayName: string
+  href: string
 }
 
 export function isReasonFeedSource(v: unknown): v is ReasonFeedSource {

--- a/src/view/com/posts/FeedItem.tsx
+++ b/src/view/com/posts/FeedItem.tsx
@@ -33,6 +33,7 @@ import {MAX_POST_LINES} from 'lib/constants'
 import {countLines} from 'lib/strings/helpers'
 import {useComposerControls} from '#/state/shell/composer'
 import {Shadow, usePostShadow, POST_TOMBSTONE} from '#/state/cache/post-shadow'
+import {FeedNameText} from '../util/FeedInfoText'
 
 export function FeedItem({
   post,
@@ -177,22 +178,20 @@ let FeedItemInner = ({
 
         <View style={{paddingTop: 12, flexShrink: 1}}>
           {isReasonFeedSource(reason) ? (
-            <Link
-              title={sanitizeDisplayName(reason.displayName)}
-              href={reason.uri}>
+            <Link href={reason.href}>
               <Text
                 type="sm-bold"
                 style={pal.textLight}
                 lineHeight={1.2}
                 numberOfLines={1}>
                 From{' '}
-                <TextLinkOnWebOnly
+                <FeedNameText
                   type="sm-bold"
-                  style={pal.textLight}
+                  uri={reason.uri}
+                  href={reason.href}
                   lineHeight={1.2}
                   numberOfLines={1}
-                  text={sanitizeDisplayName(reason.displayName)}
-                  href={reason.uri}
+                  style={pal.textLight}
                 />
               </Text>
             </Link>

--- a/src/view/com/util/FeedInfoText.tsx
+++ b/src/view/com/util/FeedInfoText.tsx
@@ -1,0 +1,54 @@
+import React from 'react'
+import {StyleProp, StyleSheet, TextStyle} from 'react-native'
+import {TextLinkOnWebOnly} from './Link'
+import {LoadingPlaceholder} from './LoadingPlaceholder'
+import {TypographyVariant} from 'lib/ThemeContext'
+import {sanitizeDisplayName} from 'lib/strings/display-names'
+import {useFeedSourceInfoQuery} from '#/state/queries/feed'
+
+export function FeedNameText({
+  type = 'md',
+  uri,
+  href,
+  lineHeight,
+  numberOfLines,
+  style,
+}: {
+  type?: TypographyVariant
+  uri: string
+  href: string
+  lineHeight?: number
+  numberOfLines?: number
+  style?: StyleProp<TextStyle>
+}) {
+  const {data, isError} = useFeedSourceInfoQuery({uri})
+
+  let inner
+  if (data?.displayName || isError) {
+    const displayName = data?.displayName || uri.split('/').pop() || ''
+    inner = (
+      <TextLinkOnWebOnly
+        type={type}
+        style={style}
+        lineHeight={lineHeight}
+        numberOfLines={numberOfLines}
+        href={href}
+        text={sanitizeDisplayName(displayName)}
+      />
+    )
+  } else {
+    inner = (
+      <LoadingPlaceholder
+        width={80}
+        height={8}
+        style={styles.loadingPlaceholder}
+      />
+    )
+  }
+
+  return inner
+}
+
+const styles = StyleSheet.create({
+  loadingPlaceholder: {position: 'relative', top: 1, left: 2},
+})


### PR DESCRIPTION
- 80da8911d25e3cf1e5f37e1dea0500e31452421f Introduces a `FeedNameText` component similar to get `UserInfoText` to ensure that we only ask for the feed info when we need it
- 045fc19da4803acdada9ee86a740bc307c643d3d Fixes a logical error with the "mergefeed when you run out of follow posts" which was causing `getFeed` to call on all saved feeds for all users looking at Following