### PR TITLE
Clarify MyList filter intent

### DIFF
--- a/src/state/queries/my-lists.ts
+++ b/src/state/queries/my-lists.ts
@@ -5,7 +5,11 @@ import {accumulate} from '#/lib/async/accumulate'
 import {useSession, getAgent} from '#/state/session'
 import {STALE} from '#/state/queries'
 
-export type MyListsFilter = 'all' | 'curate' | 'mod'
+export type MyListsFilter =
+  | 'all'
+  | 'curate'
+  | 'mod'
+  | 'all-including-subscribed'
 export const RQKEY = (filter: MyListsFilter) => ['my-lists', filter]
 
 export function useMyListsQuery(filter: MyListsFilter) {
@@ -29,7 +33,7 @@ export function useMyListsQuery(filter: MyListsFilter) {
             })),
         ),
       ]
-      if (filter === 'all' || filter === 'mod') {
+      if (filter === 'all-including-subscribed' || filter === 'mod') {
         promises.push(
           accumulate(cursor =>
             getAgent()


### PR DESCRIPTION
Mixed use here. What we need:
- `Lists` screen — shows all _your_ curate lists
- `ModerationModlists` screen — shows all moderation lists including _yours_ and _those you subscribe to_
- `UserAddRemoveLists` modal — all _your_ lists, NOT including lists you subscribe to
- `Threadgate` modal — all _your_ curate lists

This PR prevents `UserAddRemoveLists` from requesting `all` which previously include modlists you subscribe to (made by others). It does this by adding a new filter `all-including-subscribed` that has the same functionality as `all` did previously.

For now, `all` doesn't really do anything, bc by default this query returns only your curate/mod lists and nothing else.