### PR TITLE
Additional reductions in request traffic

### DIFF
--- a/src/state/queries/notifications/feed.ts
+++ b/src/state/queries/notifications/feed.ts
@@ -76,6 +76,7 @@ export function useNotificationFeedQuery(opts?: {enabled?: boolean}) {
           queryClient,
           moderationOpts,
           threadMutes,
+          fetchAdditionalData: true,
         })
       }
 

--- a/src/state/queries/notifications/unread.tsx
+++ b/src/state/queries/notifications/unread.tsx
@@ -102,6 +102,10 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
             queryClient,
             moderationOpts,
             threadMutes,
+
+            // only fetch subjects when the page is going to be used
+            // in the notifications query, otherwise skip it
+            fetchAdditionalData: !!invalidate,
           })
           const unreadCount = countUnread(page)
           const unreadCountStr =

--- a/src/state/queries/notifications/util.ts
+++ b/src/state/queries/notifications/util.ts
@@ -27,12 +27,14 @@ export async function fetchPage({
   queryClient,
   moderationOpts,
   threadMutes,
+  fetchAdditionalData,
 }: {
   cursor: string | undefined
   limit: number
   queryClient: QueryClient
   moderationOpts: ModerationOpts | undefined
   threadMutes: string[]
+  fetchAdditionalData: boolean
 }): Promise<FeedPage> {
   const res = await getAgent().listNotifications({
     limit,
@@ -49,12 +51,14 @@ export async function fetchPage({
 
   // we fetch subjects of notifications (usually posts) now instead of lazily
   // in the UI to avoid relayouts
-  const subjects = await fetchSubjects(notifsGrouped)
-  for (const notif of notifsGrouped) {
-    if (notif.subjectUri) {
-      notif.subject = subjects.get(notif.subjectUri)
-      if (notif.subject) {
-        precacheResolvedUri(queryClient, notif.subject.author) // precache the handle->did resolution
+  if (fetchAdditionalData) {
+    const subjects = await fetchSubjects(notifsGrouped)
+    for (const notif of notifsGrouped) {
+      if (notif.subjectUri) {
+        notif.subject = subjects.get(notif.subjectUri)
+        if (notif.subject) {
+          precacheResolvedUri(queryClient, notif.subject.author) // precache the handle->did resolution
+        }
       }
     }
   }

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -14,7 +14,7 @@ import {
 import {useSafeAreaInsets} from 'react-native-safe-area-context'
 import LinearGradient from 'react-native-linear-gradient'
 import {FontAwesomeIcon} from '@fortawesome/react-native-fontawesome'
-import {AppBskyFeedGetPosts, RichText} from '@atproto/api'
+import {RichText} from '@atproto/api'
 import {useAnalytics} from 'lib/analytics/analytics'
 import {useIsKeyboardVisible} from 'lib/hooks/useIsKeyboardVisible'
 import {ExternalEmbed} from './ExternalEmbed'
@@ -60,7 +60,6 @@ import {
 import {useSession, getAgent} from '#/state/session'
 import {useProfileQuery} from '#/state/queries/profile'
 import {useComposerControls} from '#/state/shell/composer'
-import {until} from '#/lib/async/until'
 import {emitPostCreated} from '#/state/events'
 import {ThreadgateSetting} from '#/state/queries/threadgate'
 
@@ -246,9 +245,7 @@ export const ComposePost = observer(function ComposePost({
       if (replyTo && replyTo.uri) track('Post:Reply')
     }
     if (postUri && !replyTo) {
-      whenAppViewReady(postUri).then(() => {
-        emitPostCreated()
-      })
+      emitPostCreated()
     }
     setLangPrefs.savePostLanguageToHistory()
     onPost?.()
@@ -553,15 +550,3 @@ const styles = StyleSheet.create({
     borderTopWidth: 1,
   },
 })
-
-async function whenAppViewReady(uri: string) {
-  await until(
-    5, // 5 tries
-    1e3, // 1s delay between tries
-    (res: AppBskyFeedGetPosts.Response) => !!res.data.posts[0],
-    () =>
-      getAgent().getPosts({
-        uris: [uri],
-      }),
-  )
-}

--- a/src/view/screens/Profile.tsx
+++ b/src/view/screens/Profile.tsx
@@ -441,7 +441,6 @@ const FeedSection = React.forwardRef<SectionRef, FeedSectionProps>(
           testID="postsFeed"
           enabled={isFocused}
           feed={feed}
-          pollInterval={30e3}
           scrollElRef={scrollElRef}
           onHasNew={setHasNew}
           onScroll={onScroll}


### PR DESCRIPTION
- 6282452911f30fe2f682d7553bf6724ee690556e Don't poll for new posts on profiles. This is a nice-to-have, and the extra load isn't worth it right now.
- 4a0cc3048e36475980779a1dcce9cec361f951c1 Don't confirm new posts have hydrated in the appview. This won't cause any errors; it just means that in the case when a new post is meant to automatically load into the feed view, there is the potential that it won't if the appview hasn't hydrated in time.
- 99557568b02ff6bfa52a420b8e7fe85b940bccb8 No-change-to-behavior optimization, just updates the notifications background query so that it doesn't `getPosts` needlessly.