### PR TITLE
Don't validate embeds when traversing cache

### DIFF
--- a/src/state/queries/util.ts
+++ b/src/state/queries/util.ts
@@ -25,26 +25,18 @@ export function truncateAndInvalidate<T = any>(
 export function getEmbeddedPost(
   v: unknown,
 ): AppBskyEmbedRecord.ViewRecord | undefined {
-  if (
-    AppBskyEmbedRecord.isView(v) &&
-    AppBskyEmbedRecord.validateView(v).success
-  ) {
+  if (AppBskyEmbedRecord.isView(v)) {
     if (
       AppBskyEmbedRecord.isViewRecord(v.record) &&
-      AppBskyFeedPost.isRecord(v.record.value) &&
-      AppBskyFeedPost.validateRecord(v.record.value).success
+      AppBskyFeedPost.isRecord(v.record.value)
     ) {
       return v.record
     }
   }
-  if (
-    AppBskyEmbedRecordWithMedia.isView(v) &&
-    AppBskyEmbedRecordWithMedia.validateView(v).success
-  ) {
+  if (AppBskyEmbedRecordWithMedia.isView(v)) {
     if (
       AppBskyEmbedRecord.isViewRecord(v.record.record) &&
-      AppBskyFeedPost.isRecord(v.record.record.value) &&
-      AppBskyFeedPost.validateRecord(v.record.record.value).success
+      AppBskyFeedPost.isRecord(v.record.record.value)
     ) {
       return v.record.record
     }


### PR DESCRIPTION
This was showing up in profiles.

## Before

<img width="541" alt="Screenshot 2023-12-11 at 22 23 31" src="https://github.com/bluesky-social/social-app/assets/810438/2a8dce5c-936e-4727-91b7-ea1b8f1268cc">

## After


<img width="307" alt="Screenshot 2023-12-11 at 22 26 02" src="https://github.com/bluesky-social/social-app/assets/810438/4c489256-92fa-4ed7-ba11-69bfdb3182da">
