### PR TITLE
Patch bad migration, sanitize bad value

### DIFF
--- a/src/locale/helpers.ts
+++ b/src/locale/helpers.ts
@@ -84,3 +84,15 @@ export function getTranslatorLink(text: string, lang: string): string {
     text,
   )}`
 }
+
+export function sanitizeAppLanguageSetting(appLanguage: string) {
+  const langs = appLanguage.split(',').filter(Boolean)
+
+  for (const lang of langs) {
+    if (['en', 'hi'].includes(lang)) {
+      return lang
+    }
+  }
+
+  return 'en'
+}

--- a/src/locale/i18n.ts
+++ b/src/locale/i18n.ts
@@ -4,6 +4,7 @@ import {i18n} from '@lingui/core'
 import {useLanguagePrefs} from '#/state/preferences'
 import {messages as messagesEn} from '#/locale/locales/en/messages'
 import {messages as messagesHi} from '#/locale/locales/hi/messages'
+import {sanitizeAppLanguageSetting} from '#/locale/helpers'
 
 export const locales = {
   en: 'English',
@@ -26,6 +27,6 @@ export async function dynamicActivate(locale: string) {
 export async function useLocaleLanguage() {
   const {appLanguage} = useLanguagePrefs()
   useEffect(() => {
-    dynamicActivate(appLanguage)
+    dynamicActivate(sanitizeAppLanguageSetting(appLanguage))
   }, [appLanguage])
 }

--- a/src/locale/i18n.web.ts
+++ b/src/locale/i18n.web.ts
@@ -2,6 +2,7 @@ import {useEffect} from 'react'
 import {i18n} from '@lingui/core'
 
 import {useLanguagePrefs} from '#/state/preferences'
+import {sanitizeAppLanguageSetting} from '#/locale/helpers'
 
 export const locales = {
   en: 'English',
@@ -29,6 +30,6 @@ export async function dynamicActivate(locale: string) {
 export async function useLocaleLanguage() {
   const {appLanguage} = useLanguagePrefs()
   useEffect(() => {
-    dynamicActivate(appLanguage)
+    dynamicActivate(sanitizeAppLanguageSetting(appLanguage))
   }, [appLanguage])
 }

--- a/src/state/persisted/legacy.ts
+++ b/src/state/persisted/legacy.ts
@@ -94,7 +94,8 @@ export function transform(legacy: Partial<LegacySchema>): Schema {
         legacy.preferences?.postLanguageHistory ||
         defaults.languagePrefs.postLanguageHistory,
       appLanguage:
-        legacy.preferences?.postLanguage || defaults.languagePrefs.appLanguage,
+        legacy.preferences?.primaryLanguage ||
+        defaults.languagePrefs.appLanguage,
     },
     requireAltTextEnabled:
       legacy.preferences?.requireAltTextEnabled ||


### PR DESCRIPTION
This is NOT done. We need to handle a comma-sep locales value in the language settings too.