### PR TITLE
Fix View Full Thread

### DIFF
--- a/src/lib/routes/links.ts
+++ b/src/lib/routes/links.ts
@@ -7,11 +7,11 @@ export function makeProfileLink(
   },
   ...segments: string[]
 ) {
-  return [
-    `/profile`,
-    `${isInvalidHandle(info.handle) ? info.did : info.handle}`,
-    ...segments,
-  ].join('/')
+  let handleSegment = info.did
+  if (info.handle && !isInvalidHandle(info.handle)) {
+    handleSegment = info.handle
+  }
+  return [`/profile`, handleSegment, ...segments].join('/')
 }
 
 export function makeCustomFeedLink(


### PR DESCRIPTION
This was broken because we pass `''` in one case (from `FeedSlice`), and `isInvalidHandle('')` is `true`. I figured I'd fix it here since `isInvalidHandle` seems to be about a very specific concept that's distinct.