### PR TITLE
Attempt Android crash fix

### DIFF
--- a/src/view/com/util/UserPreviewLink.tsx
+++ b/src/view/com/util/UserPreviewLink.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import {Pressable, StyleProp, ViewStyle} from 'react-native'
 import {Link} from './Link'
-import {isWeb} from 'platform/detection'
+import {isAndroid, isWeb} from 'platform/detection'
 import {makeProfileLink} from 'lib/routes/links'
 import {useModalControls} from '#/state/modals'
 
@@ -15,7 +15,7 @@ export function UserPreviewLink(
 ) {
   const {openModal} = useModalControls()
 
-  if (isWeb) {
+  if (isWeb || isAndroid) {
     return (
       <Link
         href={makeProfileLink(props)}


### PR DESCRIPTION
What this PR does:

It adds a check for `isAndroid` in the `UserPreviewLink` component which means that there will no longer be a profile modal preview on Android devices.

Success criteria:

After this PR is merged, we would like to see a reduction crash rate back to baseline as observed on Play Store Console. Currently, it is 1-2 standard deviations above baseline.