### PR TITLE
Go back to content-driven slice keys in feeds

### DIFF
--- a/src/lib/api/feed-manip.ts
+++ b/src/lib/api/feed-manip.ts
@@ -14,9 +14,15 @@ export type FeedTunerFn = (
 ) => FeedViewPostsSlice[]
 
 export class FeedViewPostsSlice {
+  _reactKey: string
   isFlattenedReply = false
 
-  constructor(public items: FeedViewPost[], public _reactKey: string) {}
+  constructor(public items: FeedViewPost[]) {
+    const item = items[0]
+    this._reactKey = `slice-${item.post.uri}-${
+      item.reason?.indexedAt || item.post.indexedAt
+    }`
+  }
 
   get uri() {
     if (this.isFlattenedReply) {
@@ -120,9 +126,7 @@ export class NoopFeedTuner {
     feed: FeedViewPost[],
     _opts?: {dryRun: boolean; maintainOrder: boolean},
   ): FeedViewPostsSlice[] {
-    return feed.map(
-      item => new FeedViewPostsSlice([item], `slice-${this.keyCounter++}`),
-    )
+    return feed.map(item => new FeedViewPostsSlice([item]))
   }
 }
 
@@ -160,9 +164,7 @@ export class FeedTuner {
     })
 
     if (maintainOrder) {
-      slices = feed.map(
-        item => new FeedViewPostsSlice([item], `slice-${this.keyCounter++}`),
-      )
+      slices = feed.map(item => new FeedViewPostsSlice([item]))
     } else {
       // arrange the posts into thread slices
       for (let i = feed.length - 1; i >= 0; i--) {
@@ -178,9 +180,7 @@ export class FeedTuner {
             continue
           }
         }
-        slices.unshift(
-          new FeedViewPostsSlice([item], `slice-${this.keyCounter++}`),
-        )
+        slices.unshift(new FeedViewPostsSlice([item]))
       }
     }
 

--- a/src/lib/api/feed/custom.ts
+++ b/src/lib/api/feed/custom.ts
@@ -37,7 +37,7 @@ export class CustomFeedAPI implements FeedAPI {
         res.data.feed = res.data.feed.slice(0, limit)
       }
       return {
-        cursor: res.data.cursor,
+        cursor: res.data.feed.length ? res.data.cursor : undefined,
         feed: res.data.feed,
       }
     }


### PR DESCRIPTION
Keys were changed to be auto-numbered in an attempt to ensure we never hit duplicate react keys. That approach unfortunately hurt performance and led to state corruption as react would reuse state across components that have the same key.

The change was done out of an abundance of caution. I'm still not 100% sure we never duplicate react keys but I wasnt able to trigger it, whereas the state corruption is happening a lot, so this is the move.