### PR TITLE
Add largeHeap to AndroidManifest.xml

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -121,6 +121,7 @@ module.exports = function () {
             username: 'blueskysocial',
           },
         ],
+        './plugins/withAndroidManifestPlugin.js',
       ].filter(Boolean),
       extra: {
         eas: {

--- a/plugins/withAndroidManifestPlugin.js
+++ b/plugins/withAndroidManifestPlugin.js
@@ -1,0 +1,14 @@
+const {withAndroidManifest} = require('expo/config-plugins')
+
+module.exports = function withAndroidManifestPlugin(appConfig) {
+  return withAndroidManifest(appConfig, function (decoratedAppConfig) {
+    try {
+      decoratedAppConfig.modResults.manifest.application[0].$[
+        'android:largeHeap'
+      ] = 'true'
+    } catch (e) {
+      console.error(`withAndroidManifestPlugin failed`, e)
+    }
+    return decoratedAppConfig
+  })
+}


### PR DESCRIPTION
Can test with `yarn prebuild -p android` and inspect the built file.

## Background

Some android users hit this error when they try to add images to posts:

![CleanShot 2023-12-12 at 13 21 18@2x](https://github.com/bluesky-social/social-app/assets/1270099/6b6a9dc7-8c2a-4260-bc73-2ecddafb4523)

It looks like this is caused by large images running out of memory (https://github.com/expo/expo/issues/12167). Increasing the heap size [may come with downsides](https://stackoverflow.com/questions/27396892/what-are-advantages-of-setting-largeheap-to-true) but without a clear repro it's hard to establish if this is in our control. If we roll this out, it should be phased so we can monitor error rates.