### PR TITLE
Add fallback to email reminder modal

### DIFF
--- a/src/state/session/index.tsx
+++ b/src/state/session/index.tsx
@@ -372,6 +372,9 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
         resumeSessionWithFreshAccount()
           .then(freshAccount => {
             if (JSON.stringify(account) !== JSON.stringify(freshAccount)) {
+              logger.info(
+                `session: reuse of previous session returned a fresh account, upserting`,
+              )
               upsertAccount(freshAccount)
             }
           })

--- a/src/state/session/index.tsx
+++ b/src/state/session/index.tsx
@@ -361,6 +361,8 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
       }
 
       if (canReusePrevSession) {
+        logger.info(`session: attempting to reuse previous session`)
+
         agent.session = prevSession
         __globalAgent = agent
         queryClient.clear()
@@ -385,6 +387,8 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
             __globalAgent = PUBLIC_BSKY_AGENT
           })
       } else {
+        logger.info(`session: attempting to resume using previous session`)
+
         try {
           const freshAccount = await resumeSessionWithFreshAccount()
           __globalAgent = agent
@@ -404,6 +408,8 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
       }
 
       async function resumeSessionWithFreshAccount(): Promise<SessionAccount> {
+        logger.info(`session: resumeSessionWithFreshAccount`)
+
         await networkRetry(1, () => agent.resumeSession(prevSession))
 
         /*

--- a/src/view/com/modals/VerifyEmail.tsx
+++ b/src/view/com/modals/VerifyEmail.tsx
@@ -22,6 +22,7 @@ import {Trans, msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 import {useModalControls} from '#/state/modals'
 import {useSession, useSessionApi, getAgent} from '#/state/session'
+import {logger} from '#/logger'
 
 export const snapPoints = ['90%']
 
@@ -44,6 +45,13 @@ export function Component({showReminder}: {showReminder?: boolean}) {
   const [error, setError] = useState<string>('')
   const {isMobile} = useWebMediaQueries()
   const {openModal, closeModal} = useModalControls()
+
+  React.useEffect(() => {
+    if (!currentAccount) {
+      logger.error(`VerifyEmail modal opened without currentAccount`)
+      closeModal()
+    }
+  }, [currentAccount, closeModal])
 
   const onSendEmail = async () => {
     setError('')


### PR DESCRIPTION
Adds an effect that closes this modal if it's opened without a `currentAccount`. I added some logs too that should help us diagnose if we ever see this again.