### PR TITLE
fix: patch reanimated to fix crash when using `useAnimatedScrollHandler()`

### DIFF
--- a/patches/react-native-reanimated+3.6.0.patch
+++ b/patches/react-native-reanimated+3.6.0.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/react-native-reanimated/src/reanimated2/platformFunctions/scrollTo.ts b/node_modules/react-native-reanimated/src/reanimated2/platformFunctions/scrollTo.ts
+index d7e7114..ac2ba0f 100644
+--- a/node_modules/react-native-reanimated/src/reanimated2/platformFunctions/scrollTo.ts
++++ b/node_modules/react-native-reanimated/src/reanimated2/platformFunctions/scrollTo.ts
+@@ -33,7 +33,7 @@ function scrollToPaper<T extends Component>(
+   animated: boolean
+ ) {
+   'worklet';
+-  if (!_WORKLET) {
++  if (!_WORKLET || typeof animatedRef !== 'function') {
+     return;
+   }
+ 


### PR DESCRIPTION
Small patch that makes sure `animatedRef` is a function before calling in regards to https://github.com/bluesky-social/social-app/issues/2185

This seems like a check that should be there in any case, but there could also be something else with the implementation. This is mainly just a reference as to what's causing the issue 👍 