### PR TITLE
Memoize usePalette

### DIFF
--- a/src/lib/hooks/usePalette.ts
+++ b/src/lib/hooks/usePalette.ts
@@ -1,3 +1,4 @@
+import {useMemo} from 'react'
 import {TextStyle, ViewStyle} from 'react-native'
 import {useTheme, PaletteColorName, PaletteColor} from '../ThemeContext'
 
@@ -15,38 +16,41 @@ export interface UsePaletteValue {
   icon: TextStyle
 }
 export function usePalette(color: PaletteColorName): UsePaletteValue {
-  const palette = useTheme().palette[color]
-  return {
-    colors: palette,
-    view: {
-      backgroundColor: palette.background,
-    },
-    viewLight: {
-      backgroundColor: palette.backgroundLight,
-    },
-    btn: {
-      backgroundColor: palette.backgroundLight,
-    },
-    border: {
-      borderColor: palette.border,
-    },
-    borderDark: {
-      borderColor: palette.borderDark,
-    },
-    text: {
-      color: palette.text,
-    },
-    textLight: {
-      color: palette.textLight,
-    },
-    textInverted: {
-      color: palette.textInverted,
-    },
-    link: {
-      color: palette.link,
-    },
-    icon: {
-      color: palette.icon,
-    },
-  }
+  const theme = useTheme()
+  return useMemo(() => {
+    const palette = theme.palette[color]
+    return {
+      colors: palette,
+      view: {
+        backgroundColor: palette.background,
+      },
+      viewLight: {
+        backgroundColor: palette.backgroundLight,
+      },
+      btn: {
+        backgroundColor: palette.backgroundLight,
+      },
+      border: {
+        borderColor: palette.border,
+      },
+      borderDark: {
+        borderColor: palette.borderDark,
+      },
+      text: {
+        color: palette.text,
+      },
+      textLight: {
+        color: palette.textLight,
+      },
+      textInverted: {
+        color: palette.textInverted,
+      },
+      link: {
+        color: palette.link,
+      },
+      icon: {
+        color: palette.icon,
+      },
+    }
+  }, [theme, color])
 }


### PR DESCRIPTION
Easy win.

## Before

Changes in https://github.com/bluesky-social/social-app/pull/2200 weren't enough to skip Feed re-render on scroll down/up.

<img width="942" alt="Screenshot 2023-12-13 at 06 02 27" src="https://github.com/bluesky-social/social-app/assets/810438/31a0f8e9-8998-49a5-95f0-11836a3b62fb">

## After

Changes in https://github.com/bluesky-social/social-app/pull/2200 *are* enough to skip Feed re-render on scroll down/up.

<img width="919" alt="Screenshot 2023-12-13 at 06 01 47" src="https://github.com/bluesky-social/social-app/assets/810438/970cb5c1-314b-408e-a2f3-ac3412d0f0d5">
