### PR TITLE
Feed bugfixes

### DIFF
--- a/src/state/queries/notifications/feed.ts
+++ b/src/state/queries/notifications/feed.ts
@@ -122,7 +122,13 @@ export function useNotificationFeedQuery(opts?: {enabled?: boolean}) {
       count += page.items.length
     }
 
-    if (!isFetching && hasNextPage && count < PAGE_SIZE && numEmpties < 3) {
+    if (
+      !isFetching &&
+      hasNextPage &&
+      count < PAGE_SIZE &&
+      numEmpties < 3 &&
+      (data?.pages.length || 0) < 6
+    ) {
       query.fetchNextPage()
     }
   }, [query])

--- a/src/state/queries/post-feed.ts
+++ b/src/state/queries/post-feed.ts
@@ -291,7 +291,13 @@ export function usePostFeedQuery(
       }
     }
 
-    if (!isFetching && hasNextPage && count < PAGE_SIZE && numEmpties < 3) {
+    if (
+      !isFetching &&
+      hasNextPage &&
+      count < PAGE_SIZE &&
+      numEmpties < 3 &&
+      (data?.pages.length || 0) < 6
+    ) {
       query.fetchNextPage()
     }
   }, [query])

--- a/src/view/com/posts/Feed.tsx
+++ b/src/view/com/posts/Feed.tsx
@@ -167,8 +167,7 @@ let Feed = ({
     if (isFetched) {
       if (isError && isEmpty) {
         arr = arr.concat([ERROR_ITEM])
-      }
-      if (isEmpty) {
+      } else if (isEmpty) {
         arr = arr.concat([EMPTY_FEED_ITEM])
       } else if (data) {
         for (const page of data?.pages) {


### PR DESCRIPTION
- f5a1f61aa7facfc802e914d42de57a26a685c1f7 Updates the post feed to not show both an error message and an empty message (block somebody and look at their profile for an example of why)
- a9b4860a7fb825774a07ee4c3c7f85bd826117d8 Adds a limit to attempts to fill the first 30 posts to 6 fetches to cap the amount of traffic we generate