### PR TITLE
Fix: Some display issues

### DIFF
--- a/src/view/shell/desktop/LeftNav.tsx
+++ b/src/view/shell/desktop/LeftNav.tsx
@@ -406,7 +406,7 @@ export function DesktopLeftNav() {
                 style={pal.text}
               />
             }
-            label="Profile"
+            label={_(msg`Profile`)}
           />
           <NavItem
             href="/settings"
@@ -512,7 +512,6 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
     justifyContent: 'center',
-    width: 140,
     borderRadius: 24,
     paddingTop: 10,
     paddingBottom: 12, // visually aligns the text vertically inside the button

--- a/src/view/shell/desktop/RightNav.tsx
+++ b/src/view/shell/desktop/RightNav.tsx
@@ -52,7 +52,7 @@ export function DesktopRightNav() {
               </Text>
             </View>
           ) : undefined}
-          <View style={[s.flexRow]}>
+          <View style={[{flexWrap: 'wrap'}, s.flexRow]}>
             {hasSession && (
               <>
                 <TextLink


### PR DESCRIPTION
(English ver. by BIng Translation)
cf： https://github.com/bluesky-social/social-app/pull/2209#issuecomment-1857940070 ( @tkusano )

Dear Administrators of this Repository,
Hello.

When I was working on Japanese localization ( https://github.com/bluesky-social/social-app/pull/2209#issue-2040986838 ), a colleague discovered a problem that the GUI display was distorted in the early version of Japanese and that "Profile" was not displayed in Japanese.

With this fix, "NewPost" and "Profile" will be displayed correctly in the selected language, and other languages will be served more smoothly.

I hope you will join us in Merge.
Hima


(Original (Japanese))
関連： https://github.com/bluesky-social/social-app/pull/2209#issuecomment-1857940070 ( @tkusano )

このリポジトリの管理者のみなさん
こんにちは。

日本語のローカライズ作業をしていた（ https://github.com/bluesky-social/social-app/pull/2209#issue-2040986838 ）際、日本語の初期バージョンでGUIの表示が乱れ、また"Profile"が日本語で表示されない問題を仲間が発見してくれました。

この修正により、"NewPost"と"Profile"が選択した言語で正しく表示されるようになり、また他の言語の提供もスムーズになると思われます。

ぜひ、Mergeしていただければ幸いです。
Hima