### PR TITLE
tweak social card meta yet again

### DIFF
--- a/bskyweb/templates/home.html
+++ b/bskyweb/templates/home.html
@@ -8,6 +8,7 @@
   <meta property="og:title" content="Bluesky Social">
   <meta property="og:description" content="See what's next.">
   <meta property="og:image" content="/static/social-card-default.png">
+  <meta property="og:site_name" content="Bluesky Social">
   <meta name="twitter:card" content="summary">
   <meta name="twitter:site" content="@bluesky">
 {%- endblock %}

--- a/bskyweb/templates/post.html
+++ b/bskyweb/templates/post.html
@@ -10,8 +10,9 @@
 
 {% block html_head_extra -%}
 {%- if postView -%}
-  <meta property="og:type" content="website">
   <meta property="og:site_name" content="Bluesky Social">
+  <meta property="og:type" content="article">
+  <meta property="profile:username" content="{{ profileView.Handle }}">
   {%- if requestURI %}
   <meta property="og:url" content="{{ requestURI }}">
   {% endif -%}
@@ -32,17 +33,20 @@
   <meta name="twitter:card" content="summary">
   {% endif %}
   <meta name="twitter:label1" content="Posted At">
-  <meta name="twitter:value1" content="{{ postView.CreatedAt }}">
-  <meta name="twitter:site" content="@bluesky">
+  <meta name="twitter:value1" content="{{ postView.IndexedAt }}">
+  <meta name="article:published_time" content="{{ postView.IndexedAt }}">
 {% endif -%}
 {%- endblock %}
 
 {% block noscript_extra -%}
+{%- if postView -%}
 <div id="bsky_post_summary">
   <h3>Post</h3>
   <p id="bsky_display_name">{{ postView.Author.DisplayName }}</p>
   <p id="bsky_handle">{{ postView.Author.Handle }}</p>
   <p id="bsky_did">{{ postView.Author.Did }}</p>
   <p id="bsky_post_text">{{ postView.Record.Val.Text }}</p>
+  <p id="bsky_post_indexedat">{{ postView.IndexedAt }}</p>
 </div>
+{% endif -%}
 {%- endblock %}

--- a/bskyweb/templates/profile.html
+++ b/bskyweb/templates/profile.html
@@ -10,8 +10,9 @@
 
 {% block html_head_extra -%}
 {%- if profileView -%}
-  <meta property="og:type" content="website">
   <meta property="og:site_name" content="Bluesky Social">
+  <meta property="og:type" content="profile">
+  <meta property="profile:username" content="{{ profileView.Handle }}">
   {%- if requestURI %}
   <meta property="og:url" content="{{ requestURI }}">
   {% endif -%}
@@ -33,11 +34,11 @@
   {% endif %}
   <meta name="twitter:label1" content="Account DID">
   <meta name="twitter:value1" content="{{ profileView.Did }}">
-  <meta name="twitter:site" content="@bluesky">
 {% endif -%}
 {%- endblock %}
 
 {% block noscript_extra -%}
+{%- if profileView -%}
 <div id="bsky_profile_summary">
   <h3>Profile</h3>
   <p id="bsky_display_name">{{ profileView.DisplayName }}</p>
@@ -45,4 +46,5 @@
   <p id="bsky_did">{{ profileView.Did }}</p>
   <p id="bsky_profile_description">{{ profileView.Description }}</p>
 </div>
+{% endif -%}
 {%- endblock %}


### PR DESCRIPTION
- handle missing content (PWI opt-out) better
- use opengraph "article" and "profile" types, not just website for everything
- fix timestamps, and used indexed at not created at
- remove site-level twitter handle from most card meta

This is golang HTML template code (using django/jinja2 template language), but I hope should be easy to review what it is doing.