### PR TITLE
basic public RSS feed for profiles

### DIFF
--- a/bskyweb/cmd/bskyweb/rss.go
+++ b/bskyweb/cmd/bskyweb/rss.go
@@ -30,27 +30,26 @@ type rss struct {
 func (srv *Server) WebProfileRSS(c echo.Context) error {
 	ctx := c.Request().Context()
 
-	handleParam := c.Param("handle")
-	handle, err := syntax.ParseHandle(handleParam)
+	didParam := c.Param("did")
+	did, err := syntax.ParseDID(didParam)
 	if err != nil {
-		return echo.NewHTTPError(400, fmt.Sprintf("not a valid handle: %s", handleParam))
+		return echo.NewHTTPError(400, fmt.Sprintf("not a valid DID: %s", didParam))
 	}
-	handle = handle.Normalize()
 
 	// check that public view is Ok
-	pv, err := appbsky.ActorGetProfile(ctx, srv.xrpcc, handle.String())
+	pv, err := appbsky.ActorGetProfile(ctx, srv.xrpcc, did.String())
 	if err != nil {
-		return echo.NewHTTPError(404, fmt.Sprintf("account not found: %s", handle))
+		return echo.NewHTTPError(404, fmt.Sprintf("account not found: %s", did))
 	}
 	for _, label := range pv.Labels {
 		if label.Src == pv.Did && label.Val == "!no-unauthenticated" {
-			return echo.NewHTTPError(403, fmt.Sprintf("account does not allow public views: %s", handle))
+			return echo.NewHTTPError(403, fmt.Sprintf("account does not allow public views: %s", did))
 		}
 	}
 
-	af, err := appbsky.FeedGetAuthorFeed(ctx, srv.xrpcc, handle.String(), "", "", 30)
+	af, err := appbsky.FeedGetAuthorFeed(ctx, srv.xrpcc, did.String(), "", "", 30)
 	if err != nil {
-		log.Warn("failed to fetch author feed", "handle", handle, "err", err)
+		log.Warn("failed to fetch author feed", "did", did, "err", err)
 		return err
 	}
 
@@ -70,15 +69,15 @@ func (srv *Server) WebProfileRSS(c echo.Context) error {
 			continue
 		}
 		posts = append(posts, Item{
-			Title:       "@" + handle.String() + " post",
-			Link:        fmt.Sprintf("https://bsky.app/profile/%s/post/%s", handle, aturi.RecordKey().String()),
+			Title:       "@" + pv.Handle + " post",
+			Link:        fmt.Sprintf("https://bsky.app/profile/%s/post/%s", pv.Handle, aturi.RecordKey().String()),
 			Description: rec.Text,
 			PubDate:     rec.CreatedAt,
 			GUID:        aturi.String(),
 		})
 	}
 
-	title := "@" + handle.String()
+	title := "@" + pv.Handle
 	if pv.DisplayName != nil {
 		title = title + " - " + *pv.DisplayName
 	}
@@ -89,7 +88,7 @@ func (srv *Server) WebProfileRSS(c echo.Context) error {
 	feed := &rss{
 		Version:     "2.0",
 		Description: desc,
-		Link:        fmt.Sprintf("https://bsky.app/profile/%s", handle.String()),
+		Link:        fmt.Sprintf("https://bsky.app/profile/%s", pv.Handle),
 		Title:       title,
 		Item:        posts,
 	}

--- a/bskyweb/cmd/bskyweb/rss.go
+++ b/bskyweb/cmd/bskyweb/rss.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+
+	appbsky "github.com/bluesky-social/indigo/api/bsky"
+	"github.com/bluesky-social/indigo/atproto/syntax"
+
+	"github.com/labstack/echo/v4"
+)
+
+type Item struct {
+	Title       string `xml:"title"`
+	Link        string `xml:"link"`
+	Description string `xml:"description"`
+	PubDate     string `xml:"pubDate"`
+	GUID        string `xml:"guid"`
+}
+
+type rss struct {
+	Version     string `xml:"version,attr"`
+	Description string `xml:"channel>description"`
+	Link        string `xml:"channel>link"`
+	Title       string `xml:"channel>title"`
+
+	Item []Item `xml:"channel>item"`
+}
+
+func (srv *Server) WebProfileRSS(c echo.Context) error {
+	ctx := c.Request().Context()
+
+	handleParam := c.Param("handle")
+	handle, err := syntax.ParseHandle(handleParam)
+	if err != nil {
+		return echo.NewHTTPError(400, fmt.Sprintf("not a valid handle: %s", handleParam))
+	}
+	handle = handle.Normalize()
+
+	// check that public view is Ok
+	pv, err := appbsky.ActorGetProfile(ctx, srv.xrpcc, handle.String())
+	if err != nil {
+		return echo.NewHTTPError(404, fmt.Sprintf("account not found: %s", handle))
+	}
+	for _, label := range pv.Labels {
+		if label.Src == pv.Did && label.Val == "!no-unauthenticated" {
+			return echo.NewHTTPError(403, fmt.Sprintf("account does not allow public views: %s", handle))
+		}
+	}
+
+	af, err := appbsky.FeedGetAuthorFeed(ctx, srv.xrpcc, handle.String(), "", "", 30)
+	if err != nil {
+		log.Warn("failed to fetch author feed", "handle", handle, "err", err)
+		return err
+	}
+
+	posts := []Item{}
+	for _, p := range af.Feed {
+		// only include author's own posts in RSS
+		if p.Post.Author.Did != pv.Did {
+			continue
+		}
+		aturi, err := syntax.ParseATURI(p.Post.Uri)
+		if err != nil {
+			return err
+		}
+		rec := p.Post.Record.Val.(*appbsky.FeedPost)
+		// only top-level posts in RSS (no replies)
+		if rec.Reply != nil {
+			continue
+		}
+		posts = append(posts, Item{
+			Title:       "@" + handle.String() + " post",
+			Link:        fmt.Sprintf("https://bsky.app/profile/%s/post/%s", handle, aturi.RecordKey().String()),
+			Description: rec.Text,
+			PubDate:     rec.CreatedAt,
+			GUID:        aturi.String(),
+		})
+	}
+
+	title := "@" + handle.String()
+	if pv.DisplayName != nil {
+		title = title + " - " + *pv.DisplayName
+	}
+	desc := ""
+	if pv.Description != nil {
+		desc = *pv.Description
+	}
+	feed := &rss{
+		Version:     "2.0",
+		Description: desc,
+		Link:        fmt.Sprintf("https://bsky.app/profile/%s", handle.String()),
+		Title:       title,
+		Item:        posts,
+	}
+	return c.XML(http.StatusOK, feed)
+}

--- a/bskyweb/cmd/bskyweb/rss.go
+++ b/bskyweb/cmd/bskyweb/rss.go
@@ -10,17 +10,20 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
+// We don't actually populate the title for "posts".
+// Some background: https://book.micro.blog/rss-for-microblogs/
 type Item struct {
-	Title       string `xml:"title"`
-	Link        string `xml:"link"`
-	Description string `xml:"description"`
-	PubDate     string `xml:"pubDate"`
-	GUID        string `xml:"guid"`
+	Title       string `xml:"title,omitempty"`
+	Link        string `xml:"link,omitempty"`
+	Description string `xml:"description,omitempty"`
+	PubDate     string `xml:"pubDate,omitempty"`
+	Author      string `xml:"author,omitempty"`
+	GUID        string `xml:"guid,omitempty"`
 }
 
 type rss struct {
 	Version     string `xml:"version,attr"`
-	Description string `xml:"channel>description"`
+	Description string `xml:"channel>description,omitempty"`
 	Link        string `xml:"channel>link"`
 	Title       string `xml:"channel>title"`
 
@@ -69,10 +72,10 @@ func (srv *Server) WebProfileRSS(c echo.Context) error {
 			continue
 		}
 		posts = append(posts, Item{
-			Title:       "@" + pv.Handle + " post",
 			Link:        fmt.Sprintf("https://bsky.app/profile/%s/post/%s", pv.Handle, aturi.RecordKey().String()),
 			Description: rec.Text,
 			PubDate:     rec.CreatedAt,
+			Author:      "@" + pv.Handle,
 			GUID:        aturi.String(),
 		})
 	}

--- a/bskyweb/cmd/bskyweb/server.go
+++ b/bskyweb/cmd/bskyweb/server.go
@@ -209,6 +209,9 @@ func serve(cctx *cli.Context) error {
 	e.GET("/profile/:handle/feed/:rkey", server.WebGeneric)
 	e.GET("/profile/:handle/feed/:rkey/liked-by", server.WebGeneric)
 
+	// profile RSS feed
+	e.GET("/profile/:handle/rss", server.WebProfileRSS)
+
 	// post endpoints; only first populates info
 	e.GET("/profile/:handle/post/:rkey", server.WebPost)
 	e.GET("/profile/:handle/post/:rkey/liked-by", server.WebGeneric)

--- a/bskyweb/cmd/bskyweb/server.go
+++ b/bskyweb/cmd/bskyweb/server.go
@@ -209,8 +209,8 @@ func serve(cctx *cli.Context) error {
 	e.GET("/profile/:handle/feed/:rkey", server.WebGeneric)
 	e.GET("/profile/:handle/feed/:rkey/liked-by", server.WebGeneric)
 
-	// profile RSS feed
-	e.GET("/profile/:handle/rss", server.WebProfileRSS)
+	// profile RSS feed (DID not handle)
+	e.GET("/profile/:did/rss", server.WebProfileRSS)
 
 	// post endpoints; only first populates info
 	e.GET("/profile/:handle/post/:rkey", server.WebPost)

--- a/bskyweb/templates/profile.html
+++ b/bskyweb/templates/profile.html
@@ -34,7 +34,7 @@
   {% endif %}
   <meta name="twitter:label1" content="Account DID">
   <meta name="twitter:value1" content="{{ profileView.Did }}">
-  <link rel="alternate" type="application/rss+xml" href="/profile/{{ profileView.Handle }}/rss">
+  <link rel="alternate" type="application/rss+xml" href="/profile/{{ profileView.Did }}/rss">
 {% endif -%}
 {%- endblock %}
 

--- a/bskyweb/templates/profile.html
+++ b/bskyweb/templates/profile.html
@@ -34,6 +34,7 @@
   {% endif %}
   <meta name="twitter:label1" content="Account DID">
   <meta name="twitter:value1" content="{{ profileView.Did }}">
+  <link rel="alternate" type="application/rss+xml" href="/profile/{{ profileView.Handle }}/rss">
 {% endif -%}
 {%- endblock %}
 


### PR DESCRIPTION
Adds a basic public RSS feed for profiles:

- RSS 2.0 (not atom)
- uses public API; no other special caching
- link is in HTML metadata, making auto-detect possible, but no visual indication in-app of course
- respects PWI opt-out
- only top-level posts from the account (eg, no re-posts)
- pretty basic formatting: facets, embeds, other metadata, pretty much just the post text
- I'm not really sure what the idiomatic way to put microblogging content in an RSS feed is: content in the description, handle in the title?
- used AT-URI as the GUID; seems like that should work?
- uses DID in the path, so handle updates don't break feeds