### PR TITLE
Add credits to localization doc

### DIFF
--- a/docs/localization.md
+++ b/docs/localization.md
@@ -111,3 +111,9 @@ export function Welcome() {
   return <div>{welcome}</div>;
 }
 ```
+
+
+### Credits
+Please check each individual `messages.po` file for the credits of the translators. We are very grateful for their help! 
+
+If you would like to translate the Bluesky app into your language, please open a PR or issue on this repo.

--- a/src/locale/locales/en/messages.po
+++ b/src/locale/locales/en/messages.po
@@ -1650,6 +1650,7 @@ msgid "Processing..."
 msgstr ""
 
 #: src/view/shell/bottom-bar/BottomBar.tsx:247
+#: src/view/shell/desktop/LeftNav.tsx:412
 #: src/view/shell/Drawer.tsx:69
 #: src/view/shell/Drawer.tsx:525
 #: src/view/shell/Drawer.tsx:526

--- a/src/locale/locales/hi/messages.po
+++ b/src/locale/locales/hi/messages.po
@@ -1642,6 +1642,7 @@ msgid "Processing..."
 msgstr "प्रसंस्करण..."
 
 #: src/view/shell/bottom-bar/BottomBar.tsx:247
+#: src/view/shell/desktop/LeftNav.tsx:412
 #: src/view/shell/Drawer.tsx:69
 #: src/view/shell/Drawer.tsx:525
 #: src/view/shell/Drawer.tsx:526

--- a/src/locale/locales/ja/messages.po
+++ b/src/locale/locales/ja/messages.po
@@ -1568,6 +1568,7 @@ msgid "Processing..."
 msgstr "処理中..."
 
 #: src/view/shell/bottom-bar/BottomBar.tsx:247
+#: src/view/shell/desktop/LeftNav.tsx:412
 #: src/view/shell/Drawer.tsx:69
 #: src/view/shell/Drawer.tsx:525
 #: src/view/shell/Drawer.tsx:526


### PR DESCRIPTION
- Change file name to `localization.md` in the docs folder
- Add a section on where to find credits for our amazing community contributors who helped refine the translations for certain files
- Run `intl:build` again