### PR TITLE
Make like colour consistent across the app

### DIFF
--- a/src/view/com/util/post-ctrls/PostCtrls.tsx
+++ b/src/view/com/util/post-ctrls/PostCtrls.tsx
@@ -10,7 +10,7 @@ import {AppBskyFeedDefs, AppBskyFeedPost} from '@atproto/api'
 import {Text} from '../text/Text'
 import {PostDropdownBtn} from '../forms/PostDropdownBtn'
 import {HeartIcon, HeartIconSolid, CommentBottomArrow} from 'lib/icons'
-import {s, colors} from 'lib/styles'
+import {s} from 'lib/styles'
 import {pluralize} from 'lib/strings/helpers'
 import {useTheme} from 'lib/ThemeContext'
 import {RepostButton} from './RepostButton'
@@ -180,7 +180,7 @@ let PostCtrls = ({
         accessibilityHint=""
         hitSlop={big ? HITSLOP_20 : HITSLOP_10}>
         {post.viewer?.like ? (
-          <HeartIconSolid style={styles.ctrlIconLiked} size={big ? 22 : 16} />
+          <HeartIconSolid style={s.likeColor} size={big ? 22 : 16} />
         ) : (
           <HeartIcon
             style={[defaultCtrlColor, big ? styles.mt1 : undefined]}
@@ -193,7 +193,7 @@ let PostCtrls = ({
             testID="likeCount"
             style={
               post.viewer?.like
-                ? [s.bold, s.red3, s.f15, s.ml5]
+                ? [s.bold, s.likeColor, s.f15, s.ml5]
                 : [defaultCtrlColor, s.f15, s.ml5]
             }>
             {post.likeCount}
@@ -232,9 +232,6 @@ const styles = StyleSheet.create({
     paddingBottom: 5,
     paddingLeft: 5,
     paddingRight: 5,
-  },
-  ctrlIconLiked: {
-    color: colors.like,
   },
   mt1: {
     marginTop: 1,

--- a/src/view/screens/ProfileFeed.tsx
+++ b/src/view/screens/ProfileFeed.tsx
@@ -8,7 +8,7 @@ import {HeartIcon, HeartIconSolid} from 'lib/icons'
 import {FontAwesomeIcon} from '@fortawesome/react-native-fontawesome'
 import {CommonNavigatorParams} from 'lib/routes/types'
 import {makeRecordUri} from 'lib/strings/url-helpers'
-import {colors, s} from 'lib/styles'
+import {s} from 'lib/styles'
 import {FeedDescriptor} from '#/state/queries/post-feed'
 import {PagerWithHeader} from 'view/com/pager/PagerWithHeader'
 import {ProfileSubpageHeader} from 'view/com/profile/ProfileSubpageHeader'
@@ -580,7 +580,7 @@ function AboutSection({
             onPress={onToggleLiked}
             style={{paddingHorizontal: 10}}>
             {isLiked ? (
-              <HeartIconSolid size={19} style={styles.liked} />
+              <HeartIconSolid size={19} style={s.likeColor} />
             ) : (
               <HeartIcon strokeWidth={3} size={19} style={pal.textLight} />
             )}
@@ -622,9 +622,6 @@ const styles = StyleSheet.create({
     paddingHorizontal: 14,
     borderRadius: 50,
     marginLeft: 6,
-  },
-  liked: {
-    color: colors.red3,
   },
   notFoundContainer: {
     margin: 10,


### PR DESCRIPTION
There are some instances where `colors.red3` is used instead of `colors.like`, which results in a much-complained-about difference between the heart icon and the text next to it when a post is liked.

This PR uses `s.likeColor` everywhere, increasing consistency.

Fixes #2223 