### PR TITLE
Move label appeal to post dropdown

### DIFF
--- a/src/locale/locales/en/messages.po
+++ b/src/locale/locales/en/messages.po
@@ -75,6 +75,10 @@ msgstr ""
 #~ msgid "<0>Note: Your profile and posts will remain publicly available. Third-party apps that display Bluesky content may not respect this setting.</0>"
 #~ msgstr ""
 
+#: src/view/com/util/moderation/LabelInfo.tsx:45
+msgid "A content warning has been applied to this {0}."
+msgstr ""
+
 #: src/lib/hooks/useOTAUpdate.ts:16
 msgid "A new version of the app is available. Please update to continue using the app."
 msgstr ""
@@ -200,15 +204,19 @@ msgstr ""
 msgid "App Passwords"
 msgstr ""
 
+#: src/view/com/util/forms/PostDropdownBtn.tsx:207
+msgid "Appeal content warning"
+msgstr ""
+
 #: src/view/com/modals/AppealLabel.tsx:65
 msgid "Appeal Decision"
 msgstr ""
 
-#: src/view/com/util/moderation/LabelInfo.tsx:51
+#: src/view/com/util/moderation/LabelInfo.tsx:52
 msgid "Appeal this decision"
 msgstr ""
 
-#: src/view/com/util/moderation/LabelInfo.tsx:55
+#: src/view/com/util/moderation/LabelInfo.tsx:56
 msgid "Appeal this decision."
 msgstr ""
 
@@ -232,7 +240,7 @@ msgstr ""
 msgid "Are you sure?"
 msgstr ""
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:188
+#: src/view/com/util/forms/PostDropdownBtn.tsx:190
 msgid "Are you sure? This cannot be undone."
 msgstr ""
 
@@ -585,7 +593,7 @@ msgstr ""
 msgid "Copy link to list"
 msgstr ""
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:129
+#: src/view/com/util/forms/PostDropdownBtn.tsx:131
 msgid "Copy link to post"
 msgstr ""
 
@@ -593,7 +601,7 @@ msgstr ""
 msgid "Copy link to profile"
 msgstr ""
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:115
+#: src/view/com/util/forms/PostDropdownBtn.tsx:117
 msgid "Copy post text"
 msgstr ""
 
@@ -666,11 +674,11 @@ msgstr ""
 msgid "Delete my account…"
 msgstr ""
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:183
+#: src/view/com/util/forms/PostDropdownBtn.tsx:185
 msgid "Delete post"
 msgstr ""
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:187
+#: src/view/com/util/forms/PostDropdownBtn.tsx:189
 msgid "Delete this post?"
 msgstr ""
 
@@ -1317,7 +1325,7 @@ msgstr ""
 msgid "Mute these accounts?"
 msgstr ""
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:147
+#: src/view/com/util/forms/PostDropdownBtn.tsx:149
 msgid "Mute thread"
 msgstr ""
 
@@ -1771,7 +1779,7 @@ msgid "Report List"
 msgstr ""
 
 #: src/view/com/modals/report/SendReportButton.tsx:37
-#: src/view/com/util/forms/PostDropdownBtn.tsx:165
+#: src/view/com/util/forms/PostDropdownBtn.tsx:167
 msgid "Report post"
 msgstr ""
 
@@ -1982,7 +1990,7 @@ msgid "Sexual activity or erotic nudity."
 msgstr ""
 
 #: src/view/com/profile/ProfileHeader.tsx:338
-#: src/view/com/util/forms/PostDropdownBtn.tsx:129
+#: src/view/com/util/forms/PostDropdownBtn.tsx:131
 #: src/view/screens/ProfileList.tsx:384
 msgid "Share"
 msgstr ""
@@ -2202,8 +2210,8 @@ msgid "There was an unexpected issue in the application. Please let us know if t
 msgstr ""
 
 #: src/view/com/util/moderation/LabelInfo.tsx:45
-msgid "This {0} has been labeled."
-msgstr ""
+#~ msgid "This {0} has been labeled."
+#~ msgstr ""
 
 #: src/view/com/util/moderation/ScreenHider.tsx:88
 msgid "This {screenDescription} has been flagged:"
@@ -2262,9 +2270,9 @@ msgstr ""
 msgid "Transformations"
 msgstr ""
 
-#: src/view/com/post-thread/PostThreadItem.tsx:706
-#: src/view/com/post-thread/PostThreadItem.tsx:708
-#: src/view/com/util/forms/PostDropdownBtn.tsx:101
+#: src/view/com/post-thread/PostThreadItem.tsx:703
+#: src/view/com/post-thread/PostThreadItem.tsx:705
+#: src/view/com/util/forms/PostDropdownBtn.tsx:103
 msgid "Translate"
 msgstr ""
 
@@ -2308,7 +2316,7 @@ msgstr ""
 msgid "Unmute Account"
 msgstr ""
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:147
+#: src/view/com/util/forms/PostDropdownBtn.tsx:149
 msgid "Unmute thread"
 msgstr ""
 

--- a/src/locale/locales/en/messages.po
+++ b/src/locale/locales/en/messages.po
@@ -209,8 +209,12 @@ msgid "Appeal content warning"
 msgstr ""
 
 #: src/view/com/modals/AppealLabel.tsx:65
-msgid "Appeal Decision"
+msgid "Appeal Content Warning"
 msgstr ""
+
+#: src/view/com/modals/AppealLabel.tsx:65
+#~ msgid "Appeal Decision"
+#~ msgstr ""
 
 #: src/view/com/util/moderation/LabelInfo.tsx:52
 msgid "Appeal this decision"
@@ -1600,8 +1604,13 @@ msgstr ""
 
 #: src/view/com/modals/AppealLabel.tsx:72
 #: src/view/com/modals/AppealLabel.tsx:75
-msgid "Please tell us why you think this decision was incorrect."
+msgid "Please tell us why you think this content warning was incorrectly applied!"
 msgstr ""
+
+#: src/view/com/modals/AppealLabel.tsx:72
+#: src/view/com/modals/AppealLabel.tsx:75
+#~ msgid "Please tell us why you think this decision was incorrect."
+#~ msgstr ""
 
 #: src/view/com/composer/Composer.tsx:337
 #: src/view/com/post-thread/PostThread.tsx:226
@@ -2245,7 +2254,7 @@ msgstr ""
 msgid "This link is taking you to the following website:"
 msgstr ""
 
-#: src/view/com/post-thread/PostThreadItem.tsx:124
+#: src/view/com/post-thread/PostThreadItem.tsx:123
 msgid "This post has been deleted."
 msgstr ""
 
@@ -2270,8 +2279,8 @@ msgstr ""
 msgid "Transformations"
 msgstr ""
 
-#: src/view/com/post-thread/PostThreadItem.tsx:703
-#: src/view/com/post-thread/PostThreadItem.tsx:705
+#: src/view/com/post-thread/PostThreadItem.tsx:704
+#: src/view/com/post-thread/PostThreadItem.tsx:706
 #: src/view/com/util/forms/PostDropdownBtn.tsx:103
 msgid "Translate"
 msgstr ""

--- a/src/locale/locales/hi/messages.po
+++ b/src/locale/locales/hi/messages.po
@@ -209,8 +209,12 @@ msgid "Appeal content warning"
 msgstr ""
 
 #: src/view/com/modals/AppealLabel.tsx:65
-msgid "Appeal Decision"
+msgid "Appeal Content Warning"
 msgstr ""
+
+#: src/view/com/modals/AppealLabel.tsx:65
+#~ msgid "Appeal Decision"
+#~ msgstr ""
 
 #: src/view/com/util/moderation/LabelInfo.tsx:52
 msgid "Appeal this decision"
@@ -1592,8 +1596,13 @@ msgstr "कृपया अपना पासवर्ड भी दर्ज �
 
 #: src/view/com/modals/AppealLabel.tsx:72
 #: src/view/com/modals/AppealLabel.tsx:75
-msgid "Please tell us why you think this decision was incorrect."
+msgid "Please tell us why you think this content warning was incorrectly applied!"
 msgstr ""
+
+#: src/view/com/modals/AppealLabel.tsx:72
+#: src/view/com/modals/AppealLabel.tsx:75
+#~ msgid "Please tell us why you think this decision was incorrect."
+#~ msgstr ""
 
 #: src/view/com/composer/Composer.tsx:337
 #: src/view/com/post-thread/PostThread.tsx:226
@@ -2237,7 +2246,7 @@ msgstr "यह वह सेवा है जो आपको ऑनलाइन
 msgid "This link is taking you to the following website:"
 msgstr "यह लिंक आपको निम्नलिखित वेबसाइट पर ले जा रहा है:"
 
-#: src/view/com/post-thread/PostThreadItem.tsx:124
+#: src/view/com/post-thread/PostThreadItem.tsx:123
 msgid "This post has been deleted."
 msgstr "इस पोस्ट को हटा दिया गया है।।"
 
@@ -2262,8 +2271,8 @@ msgstr "ड्रॉपडाउन टॉगल करें"
 msgid "Transformations"
 msgstr "परिवर्तन"
 
-#: src/view/com/post-thread/PostThreadItem.tsx:703
-#: src/view/com/post-thread/PostThreadItem.tsx:705
+#: src/view/com/post-thread/PostThreadItem.tsx:704
+#: src/view/com/post-thread/PostThreadItem.tsx:706
 #: src/view/com/util/forms/PostDropdownBtn.tsx:103
 msgid "Translate"
 msgstr "अनुवाद"

--- a/src/locale/locales/hi/messages.po
+++ b/src/locale/locales/hi/messages.po
@@ -75,6 +75,10 @@ msgstr "<0>कुछ</0><1>पसंदीदा उपयोगकर्ता�
 #~ msgid "<0>Note: Your profile and posts will remain publicly available. Third-party apps that display Bluesky content may not respect this setting.</0>"
 #~ msgstr ""
 
+#: src/view/com/util/moderation/LabelInfo.tsx:45
+msgid "A content warning has been applied to this {0}."
+msgstr ""
+
 #: src/lib/hooks/useOTAUpdate.ts:16
 msgid "A new version of the app is available. Please update to continue using the app."
 msgstr "ऐप का एक नया संस्करण उपलब्ध है. कृपया ऐप का उपयोग जारी रखने के लिए अपडेट करें।"
@@ -200,15 +204,19 @@ msgstr "ऐप पासवर्ड"
 msgid "App Passwords"
 msgstr "ऐप पासवर्ड"
 
+#: src/view/com/util/forms/PostDropdownBtn.tsx:207
+msgid "Appeal content warning"
+msgstr ""
+
 #: src/view/com/modals/AppealLabel.tsx:65
 msgid "Appeal Decision"
 msgstr ""
 
-#: src/view/com/util/moderation/LabelInfo.tsx:51
+#: src/view/com/util/moderation/LabelInfo.tsx:52
 msgid "Appeal this decision"
 msgstr ""
 
-#: src/view/com/util/moderation/LabelInfo.tsx:55
+#: src/view/com/util/moderation/LabelInfo.tsx:56
 msgid "Appeal this decision."
 msgstr ""
 
@@ -232,7 +240,7 @@ msgstr "क्या आप वाकई इस ड्राफ्ट को ह
 msgid "Are you sure?"
 msgstr "क्या आप वास्तव में इसे करना चाहते हैं?"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:188
+#: src/view/com/util/forms/PostDropdownBtn.tsx:190
 msgid "Are you sure? This cannot be undone."
 msgstr "क्या आप वास्तव में इसे करना चाहते हैं? इसे असंपादित नहीं किया जा सकता है।"
 
@@ -581,7 +589,7 @@ msgstr "कॉपी"
 msgid "Copy link to list"
 msgstr ""
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:129
+#: src/view/com/util/forms/PostDropdownBtn.tsx:131
 msgid "Copy link to post"
 msgstr ""
 
@@ -589,7 +597,7 @@ msgstr ""
 msgid "Copy link to profile"
 msgstr ""
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:115
+#: src/view/com/util/forms/PostDropdownBtn.tsx:117
 msgid "Copy post text"
 msgstr "पोस्ट टेक्स्ट कॉपी करें"
 
@@ -662,11 +670,11 @@ msgstr "मेरा खाता हटाएं"
 msgid "Delete my account…"
 msgstr "मेरा खाता हटाएं…"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:183
+#: src/view/com/util/forms/PostDropdownBtn.tsx:185
 msgid "Delete post"
 msgstr "पोस्ट को हटाएं"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:187
+#: src/view/com/util/forms/PostDropdownBtn.tsx:189
 msgid "Delete this post?"
 msgstr "इस पोस्ट को डीलीट करें?"
 
@@ -1309,7 +1317,7 @@ msgstr ""
 msgid "Mute these accounts?"
 msgstr "इन खातों को म्यूट करें?"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:147
+#: src/view/com/util/forms/PostDropdownBtn.tsx:149
 msgid "Mute thread"
 msgstr "थ्रेड म्यूट करें"
 
@@ -1763,7 +1771,7 @@ msgid "Report List"
 msgstr "रिपोर्ट सूची"
 
 #: src/view/com/modals/report/SendReportButton.tsx:37
-#: src/view/com/util/forms/PostDropdownBtn.tsx:165
+#: src/view/com/util/forms/PostDropdownBtn.tsx:167
 msgid "Report post"
 msgstr "रिपोर्ट पोस्ट"
 
@@ -1974,7 +1982,7 @@ msgid "Sexual activity or erotic nudity."
 msgstr "यौन गतिविधि या कामुक नग्नता।।"
 
 #: src/view/com/profile/ProfileHeader.tsx:338
-#: src/view/com/util/forms/PostDropdownBtn.tsx:129
+#: src/view/com/util/forms/PostDropdownBtn.tsx:131
 #: src/view/screens/ProfileList.tsx:384
 msgid "Share"
 msgstr "शेयर"
@@ -2194,8 +2202,8 @@ msgid "There was an unexpected issue in the application. Please let us know if t
 msgstr "एप्लिकेशन में एक अप्रत्याशित समस्या थी. कृपया हमें बताएं कि क्या आपके साथ ऐसा हुआ है!"
 
 #: src/view/com/util/moderation/LabelInfo.tsx:45
-msgid "This {0} has been labeled."
-msgstr ""
+#~ msgid "This {0} has been labeled."
+#~ msgstr ""
 
 #: src/view/com/util/moderation/ScreenHider.tsx:88
 msgid "This {screenDescription} has been flagged:"
@@ -2254,9 +2262,9 @@ msgstr "ड्रॉपडाउन टॉगल करें"
 msgid "Transformations"
 msgstr "परिवर्तन"
 
-#: src/view/com/post-thread/PostThreadItem.tsx:706
-#: src/view/com/post-thread/PostThreadItem.tsx:708
-#: src/view/com/util/forms/PostDropdownBtn.tsx:101
+#: src/view/com/post-thread/PostThreadItem.tsx:703
+#: src/view/com/post-thread/PostThreadItem.tsx:705
+#: src/view/com/util/forms/PostDropdownBtn.tsx:103
 msgid "Translate"
 msgstr "अनुवाद"
 
@@ -2300,7 +2308,7 @@ msgstr ""
 msgid "Unmute Account"
 msgstr "अनम्यूट खाता"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:147
+#: src/view/com/util/forms/PostDropdownBtn.tsx:149
 msgid "Unmute thread"
 msgstr "थ्रेड को अनम्यूट करें"
 

--- a/src/locale/locales/ja/messages.po
+++ b/src/locale/locales/ja/messages.po
@@ -55,6 +55,10 @@ msgstr "<1>おすすめの</1><2>フィード</2><0>を選択</0>"
 msgid "<0>Follow some</0><1>Recommended</1><2>Users</2>"
 msgstr "<1>おすすめの</1><2>ユーザー</2><0>をフォロー</0>"
 
+#: src/view/com/util/moderation/LabelInfo.tsx:45
+msgid "A content warning has been applied to this {0}."
+msgstr ""
+
 #: src/lib/hooks/useOTAUpdate.ts:16
 msgid "A new version of the app is available. Please update to continue using the app."
 msgstr "新しいバージョンのアプリが利用可能です。継続して使用するためにはアップデートしてください。"
@@ -180,15 +184,19 @@ msgstr "アプリパスワード"
 msgid "App Passwords"
 msgstr "アプリパスワード"
 
+#: src/view/com/util/forms/PostDropdownBtn.tsx:207
+msgid "Appeal content warning"
+msgstr ""
+
 #: src/view/com/modals/AppealLabel.tsx:65
 msgid "Appeal Decision"
 msgstr "判断に異議"
 
-#: src/view/com/util/moderation/LabelInfo.tsx:51
+#: src/view/com/util/moderation/LabelInfo.tsx:52
 msgid "Appeal this decision"
 msgstr "この判断に異議を申し立てる"
 
-#: src/view/com/util/moderation/LabelInfo.tsx:55
+#: src/view/com/util/moderation/LabelInfo.tsx:56
 msgid "Appeal this decision."
 msgstr "この判断に異議を申し立てる"
 
@@ -208,7 +216,7 @@ msgstr "本当にこの下書きを破棄しますか？"
 msgid "Are you sure?"
 msgstr "本当によろしいですか？"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:188
+#: src/view/com/util/forms/PostDropdownBtn.tsx:190
 msgid "Are you sure? This cannot be undone."
 msgstr "本当によろしいですか？これは元に戻せません。"
 
@@ -553,7 +561,7 @@ msgstr "コピー"
 msgid "Copy link to list"
 msgstr "リストへのリンクをコピー"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:129
+#: src/view/com/util/forms/PostDropdownBtn.tsx:131
 msgid "Copy link to post"
 msgstr "投稿へのリンクをコピー"
 
@@ -561,7 +569,7 @@ msgstr "投稿へのリンクをコピー"
 msgid "Copy link to profile"
 msgstr "プロフィールへのリンクをコピー"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:115
+#: src/view/com/util/forms/PostDropdownBtn.tsx:117
 msgid "Copy post text"
 msgstr "投稿のテキストをコピー"
 
@@ -630,11 +638,11 @@ msgstr "マイアカウントを削除"
 msgid "Delete my account…"
 msgstr "マイアカウントを削除…"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:183
+#: src/view/com/util/forms/PostDropdownBtn.tsx:185
 msgid "Delete post"
 msgstr "投稿を削除"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:187
+#: src/view/com/util/forms/PostDropdownBtn.tsx:189
 msgid "Delete this post?"
 msgstr "この投稿を削除しますか？"
 
@@ -1252,7 +1260,7 @@ msgstr "リストをミュート"
 msgid "Mute these accounts?"
 msgstr "これらのアカウントをミュートしますか？"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:147
+#: src/view/com/util/forms/PostDropdownBtn.tsx:149
 msgid "Mute thread"
 msgstr "スレッドをミュート"
 
@@ -1684,7 +1692,7 @@ msgid "Report List"
 msgstr "リストを報告"
 
 #: src/view/com/modals/report/SendReportButton.tsx:37
-#: src/view/com/util/forms/PostDropdownBtn.tsx:165
+#: src/view/com/util/forms/PostDropdownBtn.tsx:167
 msgid "Report post"
 msgstr "投稿を報告"
 
@@ -1879,7 +1887,7 @@ msgid "Sexual activity or erotic nudity."
 msgstr "性的行為または性的なヌード。"
 
 #: src/view/com/profile/ProfileHeader.tsx:338
-#: src/view/com/util/forms/PostDropdownBtn.tsx:129
+#: src/view/com/util/forms/PostDropdownBtn.tsx:131
 #: src/view/screens/ProfileList.tsx:384
 msgid "Share"
 msgstr "共有"
@@ -2091,8 +2099,8 @@ msgid "There was an unexpected issue in the application. Please let us know if t
 msgstr "アプリケーションに予期しない問題が発生しました。このようなことがありましたらお知らせください！"
 
 #: src/view/com/util/moderation/LabelInfo.tsx:45
-msgid "This {0} has been labeled."
-msgstr "この{0}にはラベルが貼られています"
+#~ msgid "This {0} has been labeled."
+#~ msgstr "この{0}にはラベルが貼られています"
 
 #: src/view/com/util/moderation/ScreenHider.tsx:88
 msgid "This {screenDescription} has been flagged:"
@@ -2151,9 +2159,9 @@ msgstr "ドロップダウンをトグル"
 msgid "Transformations"
 msgstr "変換"
 
-#: src/view/com/post-thread/PostThreadItem.tsx:706
-#: src/view/com/post-thread/PostThreadItem.tsx:708
-#: src/view/com/util/forms/PostDropdownBtn.tsx:101
+#: src/view/com/post-thread/PostThreadItem.tsx:703
+#: src/view/com/post-thread/PostThreadItem.tsx:705
+#: src/view/com/util/forms/PostDropdownBtn.tsx:103
 msgid "Translate"
 msgstr "翻訳"
 
@@ -2197,7 +2205,7 @@ msgstr "残念ながら、アカウントを作成するための要件を満た
 msgid "Unmute Account"
 msgstr "アカウントのミュートを解除"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:147
+#: src/view/com/util/forms/PostDropdownBtn.tsx:149
 msgid "Unmute thread"
 msgstr "スレッドのミュートを解除"
 

--- a/src/locale/locales/ja/messages.po
+++ b/src/locale/locales/ja/messages.po
@@ -189,8 +189,12 @@ msgid "Appeal content warning"
 msgstr ""
 
 #: src/view/com/modals/AppealLabel.tsx:65
-msgid "Appeal Decision"
-msgstr "判断に異議"
+msgid "Appeal Content Warning"
+msgstr ""
+
+#: src/view/com/modals/AppealLabel.tsx:65
+#~ msgid "Appeal Decision"
+#~ msgstr "判断に異議"
 
 #: src/view/com/util/moderation/LabelInfo.tsx:52
 msgid "Appeal this decision"
@@ -1518,8 +1522,13 @@ msgstr "パスワードも入力してください："
 
 #: src/view/com/modals/AppealLabel.tsx:72
 #: src/view/com/modals/AppealLabel.tsx:75
-msgid "Please tell us why you think this decision was incorrect."
-msgstr "この判断が誤っていると考える理由を教えてください。"
+msgid "Please tell us why you think this content warning was incorrectly applied!"
+msgstr ""
+
+#: src/view/com/modals/AppealLabel.tsx:72
+#: src/view/com/modals/AppealLabel.tsx:75
+#~ msgid "Please tell us why you think this decision was incorrect."
+#~ msgstr "この判断が誤っていると考える理由を教えてください。"
 
 #: src/view/com/composer/Composer.tsx:337
 #: src/view/com/post-thread/PostThread.tsx:226
@@ -2134,7 +2143,7 @@ msgstr "これはオンラインを維持するためのサービスです。"
 msgid "This link is taking you to the following website:"
 msgstr "このリンクは次のウェブサイトへリンクしています："
 
-#: src/view/com/post-thread/PostThreadItem.tsx:124
+#: src/view/com/post-thread/PostThreadItem.tsx:123
 msgid "This post has been deleted."
 msgstr "この投稿は削除されました。"
 
@@ -2159,8 +2168,8 @@ msgstr "ドロップダウンをトグル"
 msgid "Transformations"
 msgstr "変換"
 
-#: src/view/com/post-thread/PostThreadItem.tsx:703
-#: src/view/com/post-thread/PostThreadItem.tsx:705
+#: src/view/com/post-thread/PostThreadItem.tsx:704
+#: src/view/com/post-thread/PostThreadItem.tsx:706
 #: src/view/com/util/forms/PostDropdownBtn.tsx:103
 msgid "Translate"
 msgstr "翻訳"

--- a/src/view/com/modals/AppealLabel.tsx
+++ b/src/view/com/modals/AppealLabel.tsx
@@ -62,17 +62,17 @@ export function Component(props: ReportComponentProps) {
       <Text
         type="2xl-bold"
         style={[pal.text, s.textCenter, {paddingBottom: 8}]}>
-        <Trans>Appeal Decision</Trans>
+        <Trans>Appeal Content Warning</Trans>
       </Text>
       <ScrollView>
         <View style={[pal.btn, styles.detailsInputContainer]}>
           <TextInput
             accessibilityLabel={_(msg`Text input field`)}
             accessibilityHint={_(
-              msg`Please tell us why you think this decision was incorrect.`,
+              msg`Please tell us why you think this content warning was incorrectly applied!`,
             )}
             placeholder={_(
-              msg`Please tell us why you think this decision was incorrect.`,
+              msg`Please tell us why you think this content warning was incorrectly applied!`,
             )}
             placeholderTextColor={pal.textLight.color}
             value={details}

--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -42,7 +42,6 @@ import {useComposerControls} from '#/state/shell/composer'
 import {useModerationOpts} from '#/state/queries/preferences'
 import {Shadow, usePostShadow, POST_TOMBSTONE} from '#/state/cache/post-shadow'
 import {ThreadPost} from '#/state/queries/post-thread'
-import {LabelInfo} from '../util/moderation/LabelInfo'
 import {useSession} from '#/state/session'
 import {WhoCanReply} from '../threadgate/WhoCanReply'
 
@@ -335,6 +334,9 @@ let PostThreadItemLoaded = ({
               postCid={post.cid}
               postUri={post.uri}
               record={record}
+              showAppealLabelItem={
+                post.author.did === currentAccount?.did && !isSelfLabeledPost
+              }
               style={{
                 paddingVertical: 6,
                 paddingHorizontal: 10,
@@ -354,13 +356,6 @@ let PostThreadItemLoaded = ({
                 includeMute
                 style={styles.alert}
               />
-              {post.author.did === currentAccount?.did && !isSelfLabeledPost ? (
-                <LabelInfo
-                  details={{uri: post.uri, cid: post.cid}}
-                  labels={post.labels}
-                  style={{marginBottom: 8}}
-                />
-              ) : null}
               {richText?.text ? (
                 <View
                   style={[

--- a/src/view/com/util/forms/PostDropdownBtn.tsx
+++ b/src/view/com/util/forms/PostDropdownBtn.tsx
@@ -31,6 +31,7 @@ let PostDropdownBtn = ({
   postUri,
   record,
   style,
+  showAppealLabelItem,
 }: {
   testID: string
   postAuthor: AppBskyActorDefs.ProfileViewBasic
@@ -38,6 +39,7 @@ let PostDropdownBtn = ({
   postUri: string
   record: AppBskyFeedPost.Record
   style?: StyleProp<ViewStyle>
+  showAppealLabelItem?: boolean
 }): React.ReactNode => {
   const {hasSession, currentAccount} = useSession()
   const theme = useTheme()
@@ -196,6 +198,23 @@ let PostDropdownBtn = ({
         },
         android: 'ic_menu_delete',
         web: ['far', 'trash-can'],
+      },
+    },
+    showAppealLabelItem && {
+      label: 'separator',
+    },
+    showAppealLabelItem && {
+      label: _(msg`Appeal content warning`),
+      onPress() {
+        openModal({name: 'appeal-label', uri: postUri, cid: postCid})
+      },
+      testID: 'postDropdownAppealBtn',
+      icon: {
+        ios: {
+          name: 'exclamationmark.triangle',
+        },
+        android: 'ic_menu_report_image',
+        web: 'circle-exclamation',
       },
     },
   ].filter(Boolean) as NativeDropdownItem[]


### PR DESCRIPTION
Applies for the highlighted post in a thread only. Other post views do not allow appealing their labels.