### PR TITLE
Set numberOfLines for Android text input

### DIFF
--- a/src/view/com/composer/text-input/TextInput.tsx
+++ b/src/view/com/composer/text-input/TextInput.tsx
@@ -215,7 +215,7 @@ export const TextInput = forwardRef(function TextInputImpl(
         autoFocus={true}
         allowFontScaling
         multiline
-        numberOfLines={6}
+        numberOfLines={4}
         style={[
           pal.text,
           styles.textInput,

--- a/src/view/com/composer/text-input/TextInput.tsx
+++ b/src/view/com/composer/text-input/TextInput.tsx
@@ -215,7 +215,13 @@ export const TextInput = forwardRef(function TextInputImpl(
         autoFocus={true}
         allowFontScaling
         multiline
-        style={[pal.text, styles.textInput, styles.textInputFormatting]}
+        numberOfLines={6}
+        style={[
+          pal.text,
+          styles.textInput,
+          styles.textInputFormatting,
+          {textAlignVertical: 'top'},
+        ]}
         {...props}>
         {textDecorated}
       </PasteInput>


### PR DESCRIPTION
Followed docs to set a fixed # of lines. I used a red background to view changes in the inputs height, and on small phones and a link card, the input does get squished. This ensures there's always at least 4 lines of space.

As per docs, this also required adding the `textAlignVertical` for Android.

<img width="452" alt="Screenshot 2023-12-18 at 2 21 00 PM" src="https://github.com/bluesky-social/social-app/assets/4732330/78e0cb1e-62f9-42b2-a437-559dde08ea6c">
