### PR TITLE
Fix 2231 Modal overlap on double modal open

### DIFF
--- a/src/view/com/modals/Confirm.tsx
+++ b/src/view/com/modals/Confirm.tsx
@@ -16,7 +16,7 @@ import {msg} from '@lingui/macro'
 import type {ConfirmModal} from '#/state/modals'
 import {useModalControls} from '#/state/modals'
 
-export const snapPoints = ['50%', '50%']
+export const snapPoints = ['50%']
 
 export function Component({
   title,

--- a/src/view/com/modals/Confirm.tsx
+++ b/src/view/com/modals/Confirm.tsx
@@ -16,7 +16,7 @@ import {msg} from '@lingui/macro'
 import type {ConfirmModal} from '#/state/modals'
 import {useModalControls} from '#/state/modals'
 
-export const snapPoints = ['50%']
+export const snapPoints = ['50%', '50%']
 
 export function Component({
   title,

--- a/src/view/com/modals/Modal.tsx
+++ b/src/view/com/modals/Modal.tsx
@@ -82,7 +82,7 @@ export function ModalsContainer() {
 
   useEffect(() => {
     if (isModalActive) {
-      bottomSheetRef.current?.expand()
+      bottomSheetRef.current?.snapToIndex(0)
     } else {
       bottomSheetRef.current?.close()
     }


### PR DESCRIPTION
This is a known bug. Basically the issue was that the modal was being `expanded` to the largest position. Now we just snap to the first position.

<img src="https://github.com/bluesky-social/social-app/assets/8207733/e794bece-ea2f-4071-b294-b57bc69f4464" height="300" />
