### PR TITLE
Fix Create Account metrics

### DIFF
--- a/src/lib/analytics/types.ts
+++ b/src/lib/analytics/types.ts
@@ -13,7 +13,6 @@ interface TrackPropertiesMap {
   'Sign In': {resumedSession: boolean} // CAN BE SERVER
   'Create Account': {} // CAN BE SERVER
   'Try Create Account': {}
-  'Create Account Successfully': {}
   'Signin:PressedForgotPassword': {}
   'Signin:PressedSelectService': {}
   // COMPOSER / CREATE POST events

--- a/src/state/session/index.tsx
+++ b/src/state/session/index.tsx
@@ -189,6 +189,7 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
         },
         logger.DebugContext.session,
       )
+      track('Try Create Account')
 
       const agent = new BskyAgent({service})
 
@@ -231,6 +232,7 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
         },
         logger.DebugContext.session,
       )
+      track('Create Account')
     },
     [upsertAccount, queryClient],
   )

--- a/src/view/com/auth/create/CreateAccount.tsx
+++ b/src/view/com/auth/create/CreateAccount.tsx
@@ -30,7 +30,7 @@ import {Step2} from './Step2'
 import {Step3} from './Step3'
 
 export function CreateAccount({onPressBack}: {onPressBack: () => void}) {
-  const {track, screen} = useAnalytics()
+  const {screen} = useAnalytics()
   const pal = usePalette('default')
   const {_} = useLingui()
   const [uiState, uiDispatch] = useCreateAccount()
@@ -93,21 +93,17 @@ export function CreateAccount({onPressBack}: {onPressBack: () => void}) {
           uiDispatch,
           _,
         })
-        track('Create Account')
         setBirthDate({birthDate: uiState.birthDate})
         if (IS_PROD(uiState.serviceUrl)) {
           setSavedFeeds(DEFAULT_PROD_FEEDS)
         }
       } catch {
         // dont need to handle here
-      } finally {
-        track('Try Create Account')
       }
     }
   }, [
     uiState,
     uiDispatch,
-    track,
     onboardingDispatch,
     createAccount,
     setBirthDate,


### PR DESCRIPTION
The `track` function for Create Account is moved to the actual function where the account is created and now fires reliably.

`Create Account` has been used in favor of `Create Account Successfully` which has been dropped.

`Try Create Account` is also being tracked