### PR TITLE
Add `yarn intl:compile` to postinstall hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "prepare": "is-ci || husky install",
-    "postinstall": "patch-package",
+    "postinstall": "patch-package && yarn intl:compile",
     "prebuild": "expo prebuild --clean",
     "android": "expo run:android",
     "ios": "expo run:ios",


### PR DESCRIPTION
This PR adds `yarn intl:compile` to the postinstall hook.

```diff
-    "postinstall": "patch-package",
+    "postinstall": "patch-package && yarn intl:compile",
```

This trips me up every time - hoping that this reduces the fricton of the i18n stuff for new contributors.