### PR TITLE
Invalid handle autocomplete

### DIFF
--- a/src/state/queries/actor-autocomplete.ts
+++ b/src/state/queries/actor-autocomplete.ts
@@ -11,6 +11,7 @@ import {
   getModerationOpts,
   useModerationOpts,
 } from './preferences'
+import {isInvalidHandle} from '#/lib/strings/handles'
 
 const DEFAULT_MOD_OPTS = getModerationOpts({
   userDid: '',
@@ -119,7 +120,7 @@ function prefixMatch(
   prefix: string,
   info: AppBskyActorDefs.ProfileViewBasic,
 ): boolean {
-  if (info.handle.includes(prefix)) {
+  if (!isInvalidHandle(info.handle) && info.handle.includes(prefix)) {
     return true
   }
   if (info.displayName?.toLocaleLowerCase().includes(prefix)) {

--- a/src/view/screens/Profile.tsx
+++ b/src/view/screens/Profile.tsx
@@ -39,6 +39,7 @@ import {truncateAndInvalidate} from '#/state/queries/util'
 import {Text} from '#/view/com/util/text/Text'
 import {usePalette} from 'lib/hooks/usePalette'
 import {isNative} from '#/platform/detection'
+import {isInvalidHandle} from '#/lib/strings/handles'
 
 interface SectionRef {
   scrollToTop: () => void
@@ -231,7 +232,7 @@ function ProfileScreenLoaded({
     track('ProfileScreen:PressCompose')
     const mention =
       profile.handle === currentAccount?.handle ||
-      profile.handle === 'handle.invalid'
+      isInvalidHandle(profile.handle)
         ? undefined
         : profile.handle
     openComposer({mention})

--- a/src/view/shell/desktop/LeftNav.tsx
+++ b/src/view/shell/desktop/LeftNav.tsx
@@ -46,6 +46,7 @@ import {useComposerControls} from '#/state/shell/composer'
 import {useFetchHandle} from '#/state/queries/handle'
 import {emitSoftReset} from '#/state/events'
 import {NavSignupCard} from '#/view/shell/NavSignupCard'
+import {isInvalidHandle} from '#/lib/strings/handles'
 
 function ProfileCard() {
   const {currentAccount} = useSession()
@@ -221,7 +222,7 @@ function ComposeBtn() {
       if (
         !handle ||
         handle === currentAccount?.handle ||
-        handle === 'handle.invalid'
+        isInvalidHandle(handle)
       )
         return undefined
 


### PR DESCRIPTION
Fixes autosuggestion so it doesn't match on `'invalid.handle'` if the user has an invalid handle.

Before:
![Screenshot 2023-12-20 at 10 04 58](https://github.com/bluesky-social/social-app/assets/10959775/0e8fc4b1-2d56-42c4-86f8-ad48103c3f29)

After:
![Screenshot 2023-12-20 at 10 05 04](https://github.com/bluesky-social/social-app/assets/10959775/8fd07796-3aa0-4782-a9d9-29e62e993696)

I also found a couple of places where a comparison was done to `'invalid.handle'` and replaced it with the `isInvalidHandle` utility.