### PR TITLE
minor search screen ux improvements

### DIFF
--- a/src/view/com/util/forms/SearchInput.tsx
+++ b/src/view/com/util/forms/SearchInput.tsx
@@ -16,6 +16,7 @@ import {useTheme} from 'lib/ThemeContext'
 import {usePalette} from 'lib/hooks/usePalette'
 import {useLingui} from '@lingui/react'
 import {msg} from '@lingui/macro'
+import {HITSLOP_10} from 'lib/constants'
 
 interface Props {
   query: string
@@ -71,7 +72,8 @@ export function SearchInput({
           onPress={onPressCancelSearchInner}
           accessibilityRole="button"
           accessibilityLabel={_(msg`Clear search query`)}
-          accessibilityHint="">
+          accessibilityHint=""
+          hitSlop={HITSLOP_10}>
           <FontAwesomeIcon
             icon="xmark"
             size={16}

--- a/src/view/com/util/forms/SearchInput.tsx
+++ b/src/view/com/util/forms/SearchInput.tsx
@@ -11,12 +11,12 @@ import {
   FontAwesomeIcon,
   FontAwesomeIconStyle,
 } from '@fortawesome/react-native-fontawesome'
+import {HITSLOP_10} from 'lib/constants'
 import {MagnifyingGlassIcon} from 'lib/icons'
 import {useTheme} from 'lib/ThemeContext'
 import {usePalette} from 'lib/hooks/usePalette'
 import {useLingui} from '@lingui/react'
 import {msg} from '@lingui/macro'
-import {HITSLOP_10} from 'lib/constants'
 
 interface Props {
   query: string

--- a/src/view/screens/Feeds.tsx
+++ b/src/view/screens/Feeds.tsx
@@ -501,6 +501,7 @@ export function FeedsScreen(_props: Props) {
         desktopFixedHeight
         scrollIndicatorInsets={{right: 1}}
         keyboardShouldPersistTaps="handled"
+        keyboardDismissMode="on-drag"
       />
 
       {hasSession && (

--- a/src/view/screens/Feeds.tsx
+++ b/src/view/screens/Feeds.tsx
@@ -500,6 +500,7 @@ export function FeedsScreen(_props: Props) {
         // @ts-ignore our .web version only -prf
         desktopFixedHeight
         scrollIndicatorInsets={{right: 1}}
+        keyboardShouldPersistTaps="handled"
       />
 
       {hasSession && (

--- a/src/view/screens/Search/Search.tsx
+++ b/src/view/screens/Search/Search.tsx
@@ -577,7 +577,8 @@ export function SearchScreenMobile(
               onPress={onPressClearQuery}
               accessibilityRole="button"
               accessibilityLabel={_(msg`Clear search query`)}
-              accessibilityHint="">
+              accessibilityHint=""
+              hitSlop={HITSLOP_10}>
               <FontAwesomeIcon
                 icon="xmark"
                 size={16}

--- a/src/view/screens/Search/Search.tsx
+++ b/src/view/screens/Search/Search.tsx
@@ -601,7 +601,9 @@ export function SearchScreenMobile(
           {isFetching ? (
             <Loader />
           ) : (
-            <ScrollView style={{height: '100%'}}>
+            <ScrollView
+              style={{height: '100%'}}
+              keyboardShouldPersistTaps="handled">
               {searchResults.length ? (
                 searchResults.map((item, i) => (
                   <SearchResultCard

--- a/src/view/screens/Search/Search.tsx
+++ b/src/view/screens/Search/Search.tsx
@@ -609,7 +609,8 @@ export function SearchScreenMobile(
           ) : (
             <ScrollView
               style={{height: '100%'}}
-              keyboardShouldPersistTaps="handled">
+              keyboardShouldPersistTaps="handled"
+              keyboardDismissMode="on-drag">
               {searchResults.length ? (
                 searchResults.map((item, i) => (
                   <SearchResultCard

--- a/src/view/screens/Search/Search.tsx
+++ b/src/view/screens/Search/Search.tsx
@@ -590,7 +590,10 @@ export function SearchScreenMobile(
 
         {query || inputIsFocused ? (
           <View style={styles.headerCancelBtn}>
-            <Pressable onPress={onPressCancelSearch} accessibilityRole="button">
+            <Pressable
+              onPress={onPressCancelSearch}
+              accessibilityRole="button"
+              hitSlop={HITSLOP_10}>
               <Text style={[pal.text]}>
                 <Trans>Cancel</Trans>
               </Text>

--- a/src/view/screens/Search/Search.tsx
+++ b/src/view/screens/Search/Search.tsx
@@ -163,6 +163,8 @@ function SearchScreenSuggestedFollows() {
       // @ts-ignore web only -prf
       desktopFixedHeight
       contentContainerStyle={{paddingBottom: 1200}}
+      keyboardShouldPersistTaps="handled"
+      keyboardDismissMode="on-drag"
     />
   ) : (
     <CenteredView sideBorders style={[pal.border, s.hContentRegion]}>


### PR DESCRIPTION
Hopefully I am not PR spamming here...apologies if so. This is just some very minor changes but with very noticeable UX improvements:

- Add a hitslop to the cancel and clear buttons on the search screen (and the clear button on the feeds screen search). These are currently rather difficult to press
- Add `keyboardShouldPersistTaps` to`SearchScreenSuggestedFollows`, `SearchScreenMobile` (autocomplete results), and `Feeds`.  Currently you have to dismiss the keyboard before any interaction with the screen can be made.
- Dismiss the keyboard on scroll on `SearchScreenSuggestedFollows`, `SearchScreenMobile`, and `Feeds`. This resolves issues where some content is hidden below the keyboard.

On the last issue, this is certainly a good fix (both in terms of ease and feel). The alternative would be to adjust the content insets when the keyboard is visible. Unfortunately I can't seem to get that to work on `SearchScreenMobile` after the `ScrollView` re-renders. `automaticallyAdjustKeyboardInsets` is known to be a bit buggy, and there are some way better alternatives available if that's something you want to explore: See https://twitter.com/hirbod_dev/status/1668528361457451009 (sorry for bird link)

UX wise, I think that dismissing the keyboard on scroll is the most common behavior, so I don't think there's a big need in this particular case. (I also think this is default behavior on Android even without the prop, but I'm not a big Android user so don't quote me on that)

![RocketSim_Recording_iPhone_15_Pro_2023-12-21_01 11 54](https://github.com/bluesky-social/social-app/assets/153161762/21ae7261-0dc9-4b88-ba6b-c75af241d073)

![RocketSim_Recording_iPhone_15_Pro_2023-12-21_01 12 40](https://github.com/bluesky-social/social-app/assets/153161762/b6d34913-b90d-420c-a628-1cbb4de5d45a)
