### PR TITLE
Add Spanish localization

### DIFF
--- a/lingui.config.js
+++ b/lingui.config.js
@@ -1,6 +1,6 @@
 /** @type {import('@lingui/conf').LinguiConfig} */
 module.exports = {
-  locales: ['en', 'hi', 'ja'],
+  locales: ['en', 'hi', 'ja', 'fr'],
   catalogs: [
     {
       path: '<rootDir>/src/locale/locales/{locale}/messages',

--- a/lingui.config.js
+++ b/lingui.config.js
@@ -1,6 +1,6 @@
 /** @type {import('@lingui/conf').LinguiConfig} */
 module.exports = {
-  locales: ['en', 'hi', 'ja', 'fr'],
+  locales: ['en', 'hi', 'ja', 'fr', 'de'],
   catalogs: [
     {
       path: '<rootDir>/src/locale/locales/{locale}/messages',

--- a/lingui.config.js
+++ b/lingui.config.js
@@ -1,6 +1,6 @@
 /** @type {import('@lingui/conf').LinguiConfig} */
 module.exports = {
-  locales: ['en', 'hi', 'ja', 'fr', 'de'],
+  locales: ['en', 'hi', 'ja', 'fr', 'de', 'es'],
   catalogs: [
     {
       path: '<rootDir>/src/locale/locales/{locale}/messages',

--- a/src/locale/__tests__/helpers.test.ts
+++ b/src/locale/__tests__/helpers.test.ts
@@ -7,6 +7,6 @@ test('sanitizeAppLanguageSetting', () => {
   expect(sanitizeAppLanguageSetting('en')).toBe(AppLanguage.en)
   expect(sanitizeAppLanguageSetting('hi')).toBe(AppLanguage.hi)
   expect(sanitizeAppLanguageSetting('foo')).toBe(AppLanguage.en)
-  expect(sanitizeAppLanguageSetting('en,fr')).toBe(AppLanguage.en)
-  expect(sanitizeAppLanguageSetting('fr,en')).toBe(AppLanguage.en)
+  expect(sanitizeAppLanguageSetting('en,foo')).toBe(AppLanguage.en)
+  expect(sanitizeAppLanguageSetting('foo,en')).toBe(AppLanguage.en)
 })

--- a/src/locale/helpers.ts
+++ b/src/locale/helpers.ts
@@ -114,6 +114,8 @@ export function sanitizeAppLanguageSetting(appLanguage: string): AppLanguage {
         return AppLanguage.hi
       case 'ja':
         return AppLanguage.ja
+      case 'fr':
+        return AppLanguage.fr
       default:
         continue
     }

--- a/src/locale/helpers.ts
+++ b/src/locale/helpers.ts
@@ -118,6 +118,8 @@ export function sanitizeAppLanguageSetting(appLanguage: string): AppLanguage {
         return AppLanguage.fr
       case 'de':
         return AppLanguage.de
+      case 'es':
+        return AppLanguage.es
       default:
         continue
     }

--- a/src/locale/helpers.ts
+++ b/src/locale/helpers.ts
@@ -116,6 +116,8 @@ export function sanitizeAppLanguageSetting(appLanguage: string): AppLanguage {
         return AppLanguage.ja
       case 'fr':
         return AppLanguage.fr
+      case 'de':
+        return AppLanguage.de
       default:
         continue
     }

--- a/src/locale/i18n.ts
+++ b/src/locale/i18n.ts
@@ -5,6 +5,7 @@ import {useLanguagePrefs} from '#/state/preferences'
 import {messages as messagesEn} from '#/locale/locales/en/messages'
 import {messages as messagesHi} from '#/locale/locales/hi/messages'
 import {messages as messagesJa} from '#/locale/locales/ja/messages'
+import {messages as messagesFr} from '#/locale/locales/fr/messages'
 import {sanitizeAppLanguageSetting} from '#/locale/helpers'
 import {AppLanguage} from '#/locale/languages'
 
@@ -19,6 +20,10 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.ja: {
       i18n.loadAndActivate({locale, messages: messagesJa})
+      break
+    }
+    case AppLanguage.fr: {
+      i18n.loadAndActivate({locale, messages: messagesFr})
       break
     }
     default: {

--- a/src/locale/i18n.ts
+++ b/src/locale/i18n.ts
@@ -7,6 +7,7 @@ import {messages as messagesHi} from '#/locale/locales/hi/messages'
 import {messages as messagesJa} from '#/locale/locales/ja/messages'
 import {messages as messagesFr} from '#/locale/locales/fr/messages'
 import {messages as messagesDe} from '#/locale/locales/de/messages'
+import {messages as messagesEs} from '#/locale/locales/de/messages'
 
 import {sanitizeAppLanguageSetting} from '#/locale/helpers'
 import {AppLanguage} from '#/locale/languages'
@@ -30,6 +31,10 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.de: {
       i18n.loadAndActivate({locale, messages: messagesDe})
+      break
+    }
+    case AppLanguage.es: {
+      i18n.loadAndActivate({locale, messages: messagesEs})
       break
     }
     default: {

--- a/src/locale/i18n.ts
+++ b/src/locale/i18n.ts
@@ -6,6 +6,8 @@ import {messages as messagesEn} from '#/locale/locales/en/messages'
 import {messages as messagesHi} from '#/locale/locales/hi/messages'
 import {messages as messagesJa} from '#/locale/locales/ja/messages'
 import {messages as messagesFr} from '#/locale/locales/fr/messages'
+import {messages as messagesDe} from '#/locale/locales/de/messages'
+
 import {sanitizeAppLanguageSetting} from '#/locale/helpers'
 import {AppLanguage} from '#/locale/languages'
 
@@ -24,6 +26,10 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.fr: {
       i18n.loadAndActivate({locale, messages: messagesFr})
+      break
+    }
+    case AppLanguage.de: {
+      i18n.loadAndActivate({locale, messages: messagesDe})
       break
     }
     default: {

--- a/src/locale/i18n.web.ts
+++ b/src/locale/i18n.web.ts
@@ -20,6 +20,10 @@ export async function dynamicActivate(locale: AppLanguage) {
       mod = await import(`./locales/ja/messages`)
       break
     }
+    case AppLanguage.fr: {
+      mod = await import(`./locales/fr/messages`)
+      break
+    }
     default: {
       mod = await import(`./locales/en/messages`)
       break

--- a/src/locale/i18n.web.ts
+++ b/src/locale/i18n.web.ts
@@ -28,6 +28,10 @@ export async function dynamicActivate(locale: AppLanguage) {
       mod = await import(`./locales/de/messages`)
       break
     }
+    case AppLanguage.es: {
+      mod = await import(`./locales/es/messages`)
+      break
+    }
     default: {
       mod = await import(`./locales/en/messages`)
       break

--- a/src/locale/i18n.web.ts
+++ b/src/locale/i18n.web.ts
@@ -24,6 +24,10 @@ export async function dynamicActivate(locale: AppLanguage) {
       mod = await import(`./locales/fr/messages`)
       break
     }
+    case AppLanguage.de: {
+      mod = await import(`./locales/de/messages`)
+      break
+    }
     default: {
       mod = await import(`./locales/en/messages`)
       break

--- a/src/locale/languages.ts
+++ b/src/locale/languages.ts
@@ -8,6 +8,7 @@ export enum AppLanguage {
   en = 'en',
   hi = 'hi',
   ja = 'ja',
+  fr = 'fr',
 }
 
 interface AppLanguageConfig {
@@ -19,6 +20,7 @@ export const APP_LANGUAGES: AppLanguageConfig[] = [
   {code2: AppLanguage.en, name: 'English'},
   {code2: AppLanguage.hi, name: 'हिंदी'},
   {code2: AppLanguage.ja, name: '日本語'},
+  {code2: AppLanguage.fr, name: 'Français'},
 ]
 
 export const LANGUAGES: Language[] = [

--- a/src/locale/languages.ts
+++ b/src/locale/languages.ts
@@ -10,6 +10,7 @@ export enum AppLanguage {
   ja = 'ja',
   fr = 'fr',
   de = 'de',
+  es = 'es',
 }
 
 interface AppLanguageConfig {
@@ -23,6 +24,7 @@ export const APP_LANGUAGES: AppLanguageConfig[] = [
   {code2: AppLanguage.ja, name: '日本語'},
   {code2: AppLanguage.fr, name: 'Français'},
   {code2: AppLanguage.de, name: 'Deutsch'},
+  {code2: AppLanguage.es, name: 'Español'},
 ]
 
 export const LANGUAGES: Language[] = [

--- a/src/locale/languages.ts
+++ b/src/locale/languages.ts
@@ -9,6 +9,7 @@ export enum AppLanguage {
   hi = 'hi',
   ja = 'ja',
   fr = 'fr',
+  de = 'de',
 }
 
 interface AppLanguageConfig {
@@ -21,6 +22,7 @@ export const APP_LANGUAGES: AppLanguageConfig[] = [
   {code2: AppLanguage.hi, name: 'हिंदी'},
   {code2: AppLanguage.ja, name: '日本語'},
   {code2: AppLanguage.fr, name: 'Français'},
+  {code2: AppLanguage.de, name: 'Deutsch'},
 ]
 
 export const LANGUAGES: Language[] = [

--- a/src/locale/locales/de/messages.po
+++ b/src/locale/locales/de/messages.po
@@ -15,7 +15,7 @@ msgstr ""
 
 #: src/view/shell/desktop/RightNav.tsx:160
 msgid "{0, plural, one {# invite code available} other {# invite codes available}}"
-msgstr "{0, plural, one {# invite code available} andere {# invite codes available}}"
+msgstr ""
 
 #: src/view/com/modals/Repost.tsx:44
 msgid "{0}"
@@ -27,7 +27,7 @@ msgstr "{0} {purposeLabel} Liste"
 
 #: src/view/shell/desktop/RightNav.tsx:143
 msgid "{invitesAvailable, plural, one {Invite codes: # available} other {Invite codes: # available}}"
-msgstr "{invitesAvailable, plural, one {Invite codes: # available} andere {Invite codes: # available}}"
+msgstr ""
 
 #: src/view/screens/Settings.tsx:407
 #: src/view/shell/Drawer.tsx:640

--- a/src/locale/locales/de/messages.po
+++ b/src/locale/locales/de/messages.po
@@ -15,216 +15,208 @@ msgstr ""
 
 #: src/view/shell/desktop/RightNav.tsx:160
 msgid "{0, plural, one {# invite code available} other {# invite codes available}}"
-msgstr ""
+msgstr "{0, plural, one {# invite code available} andere {# invite codes available}}"
 
 #: src/view/com/modals/Repost.tsx:44
 msgid "{0}"
-msgstr ""
+msgstr "{0}"
 
 #: src/view/com/modals/CreateOrEditList.tsx:176
 msgid "{0} {purposeLabel} List"
-msgstr ""
+msgstr "{0} {purposeLabel} Liste"
 
 #: src/view/shell/desktop/RightNav.tsx:143
 msgid "{invitesAvailable, plural, one {Invite codes: # available} other {Invite codes: # available}}"
-msgstr ""
+msgstr "{invitesAvailable, plural, one {Invite codes: # available} andere {Invite codes: # available}}"
 
 #: src/view/screens/Settings.tsx:407
 #: src/view/shell/Drawer.tsx:640
 msgid "{invitesAvailable} invite code available"
-msgstr ""
+msgstr "{invitesAvailable} Einladungscode verfügbar"
 
 #: src/view/screens/Settings.tsx:409
 #: src/view/shell/Drawer.tsx:642
 msgid "{invitesAvailable} invite codes available"
-msgstr ""
+msgstr "{invitesAvailable} Einladungscodes verfügbar"
 
 #: src/view/screens/Search/Search.tsx:88
 msgid "{message}"
-msgstr ""
+msgstr "{message}"
 
 #: src/view/com/threadgate/WhoCanReply.tsx:158
 msgid "<0/> members"
-msgstr ""
+msgstr "<0/> Mitglieder"
 
 #: src/view/com/auth/onboarding/RecommendedFeeds.tsx:30
 msgid "<0>Choose your</0><1>Recommended</1><2>Feeds</2>"
-msgstr ""
+msgstr "<0>Wählen Sie Ihre</0><1>Empfohlenes</1><2>Feeds</2>"
 
 #: src/view/com/auth/onboarding/RecommendedFollows.tsx:37
 msgid "<0>Follow some</0><1>Recommended</1><2>Users</2>"
-msgstr ""
-
-#: src/view/com/util/moderation/LabelInfo.tsx:45
-msgid "A content warning has been applied to this {0}."
-msgstr ""
+msgstr "<0>Folgen Sie einigen</0><1>Empfohlenes</1><2>Feed</2>"
 
 #: src/lib/hooks/useOTAUpdate.ts:16
 msgid "A new version of the app is available. Please update to continue using the app."
-msgstr ""
+msgstr "Eine neue Version der App ist verfügbar. Bitte aktualisieren Sie die App, um sie weiterhin nutzen zu können."
 
 #: src/view/com/modals/EditImage.tsx:299
 #: src/view/screens/Settings.tsx:417
 msgid "Accessibility"
-msgstr ""
+msgstr "Zugänglichkeit"
 
 #: src/view/com/auth/login/LoginForm.tsx:159
 #: src/view/screens/Settings.tsx:286
 msgid "Account"
-msgstr ""
+msgstr "Konto"
 
 #: src/view/com/util/AccountDropdownBtn.tsx:41
 msgid "Account options"
-msgstr ""
+msgstr "Konto Optionen"
 
 #: src/view/com/modals/ListAddRemoveUsers.tsx:264
 #: src/view/com/modals/UserAddRemoveLists.tsx:193
-#: src/view/screens/ProfileList.tsx:754
+#: src/view/screens/ProfileList.tsx:753
 msgid "Add"
-msgstr ""
+msgstr "Hinzufügen"
 
 #: src/view/com/modals/SelfLabel.tsx:56
 msgid "Add a content warning"
-msgstr ""
+msgstr "Eine Inhaltswarnung hinzufügen"
 
-#: src/view/screens/ProfileList.tsx:744
+#: src/view/screens/ProfileList.tsx:743
 msgid "Add a user to this list"
-msgstr ""
+msgstr "Einen Benutzer zu dieser Liste hinzufügen"
 
 #: src/view/screens/Settings.tsx:355
 #: src/view/screens/Settings.tsx:364
 msgid "Add account"
-msgstr ""
+msgstr "Konto hinzufügen"
 
 #: src/view/com/composer/photos/Gallery.tsx:119
 #: src/view/com/composer/photos/Gallery.tsx:180
 msgid "Add alt text"
-msgstr ""
+msgstr "Alt Text hinzufügen"
 
 #: src/view/com/modals/report/InputIssueDetails.tsx:41
 #: src/view/com/modals/report/Modal.tsx:191
 msgid "Add details"
-msgstr ""
+msgstr "Einzelheiten hinzufügen"
 
 #: src/view/com/modals/report/Modal.tsx:194
 msgid "Add details to report"
-msgstr ""
+msgstr "Einzelheiten zum Bericht hinzufügen"
 
-#: src/view/com/composer/Composer.tsx:438
+#: src/view/com/composer/Composer.tsx:432
 msgid "Add link card"
-msgstr ""
+msgstr "Link Karte hinzufügen"
 
-#: src/view/com/composer/Composer.tsx:441
+#: src/view/com/composer/Composer.tsx:435
 msgid "Add link card:"
-msgstr ""
+msgstr "Link Karte hinzufügen:"
 
 #: src/view/com/modals/ChangeHandle.tsx:415
 msgid "Add the following DNS record to your domain:"
-msgstr ""
+msgstr "Fügen Sie den folgenden DNS-Eintrag zu Ihrem Domainnamen hinzu:"
 
 #: src/view/com/profile/ProfileHeader.tsx:353
 msgid "Add to Lists"
-msgstr ""
+msgstr "Den Listen hinzufügen"
 
-#: src/view/screens/ProfileFeed.tsx:270
+#: src/view/screens/ProfileFeed.tsx:275
 msgid "Add to my feeds"
-msgstr ""
+msgstr "Zu meinen Feeds hinzufügen"
 
 #: src/view/com/modals/ListAddRemoveUsers.tsx:191
 #: src/view/com/modals/UserAddRemoveLists.tsx:128
 msgid "Added to list"
-msgstr ""
+msgstr "Den Listen hinzufügen"
 
 #: src/view/screens/PreferencesHomeFeed.tsx:164
 msgid "Adjust the number of likes a reply must have to be shown in your feed."
-msgstr ""
+msgstr "Passen Sie die Anzahl der Likes an, die eine Antwort haben muss, um in Ihrem Feed angezeigt zu werden."
 
 #: src/view/com/modals/SelfLabel.tsx:75
 msgid "Adult Content"
-msgstr ""
+msgstr "Inhalt für Erwachsene"
 
 #: src/view/screens/Settings.tsx:569
 msgid "Advanced"
-msgstr ""
+msgstr "Fortgeschrittene"
 
 #: src/view/com/composer/photos/Gallery.tsx:130
 msgid "ALT"
-msgstr ""
+msgstr "ALT"
 
 #: src/view/com/modals/EditImage.tsx:315
 msgid "Alt text"
-msgstr ""
+msgstr "Alt Text"
 
 #: src/view/com/composer/photos/Gallery.tsx:209
 msgid "Alt text describes images for blind and low-vision users, and helps give context to everyone."
-msgstr ""
+msgstr "Alt-Text beschreibt Bilder für blinde und sehbehinderte Nutzer und hilft, den Zusammenhang für alle herzustellen."
 
 #: src/view/com/modals/VerifyEmail.tsx:118
 msgid "An email has been sent to {0}. It includes a confirmation code which you can enter below."
-msgstr ""
+msgstr "Es wurde eine E-Mail an {0} gesendet. Sie enthält einen Bestätigungscode, den Sie unten eingeben können."
 
 #: src/view/com/modals/ChangeEmail.tsx:119
 msgid "An email has been sent to your previous address, {0}. It includes a confirmation code which you can enter below."
-msgstr ""
+msgstr "Es wurde eine E-Mail an Ihre frühere Adresse {0} gesendet. Sie enthält einen Bestätigungscode, den Sie unten eingeben können."
 
 #: src/view/com/notifications/FeedItem.tsx:236
 #: src/view/com/threadgate/WhoCanReply.tsx:178
 msgid "and"
-msgstr ""
+msgstr "und"
 
 #: src/view/screens/LanguageSettings.tsx:95
 msgid "App Language"
-msgstr ""
+msgstr "App Sprache"
 
 #: src/view/screens/Settings.tsx:589
 msgid "App passwords"
-msgstr ""
+msgstr "App-Passwörter"
 
 #: src/view/screens/AppPasswords.tsx:186
 msgid "App Passwords"
-msgstr ""
-
-#: src/view/com/util/forms/PostDropdownBtn.tsx:207
-msgid "Appeal content warning"
-msgstr ""
+msgstr "App-Passwörter"
 
 #: src/view/com/modals/AppealLabel.tsx:65
-msgid "Appeal Content Warning"
-msgstr ""
+msgid "Appeal Decision"
+msgstr "Berufungsentscheidung"
 
-#: src/view/com/util/moderation/LabelInfo.tsx:52
+#: src/view/com/util/moderation/LabelInfo.tsx:51
 msgid "Appeal this decision"
-msgstr ""
+msgstr "Einspruch gegen diese Entscheidung"
 
-#: src/view/com/util/moderation/LabelInfo.tsx:56
+#: src/view/com/util/moderation/LabelInfo.tsx:55
 msgid "Appeal this decision."
-msgstr ""
+msgstr "Einspruch gegen diese Entscheidung"
 
 #: src/view/screens/Settings.tsx:432
 msgid "Appearance"
-msgstr ""
+msgstr "Aussehen"
 
 #: src/view/screens/AppPasswords.tsx:223
 msgid "Are you sure you want to delete the app password \"{name}\"?"
-msgstr ""
+msgstr "Sind Sie sicher, dass Sie das App-Passwort \"{name}\" löschen möchten?"
 
-#: src/view/com/composer/Composer.tsx:142
+#: src/view/com/composer/Composer.tsx:141
 msgid "Are you sure you'd like to discard this draft?"
-msgstr ""
+msgstr "Sind Sie sicher, dass Sie diesen Entwurf verwerfen möchten?"
 
-#: src/view/screens/ProfileList.tsx:352
+#: src/view/screens/ProfileList.tsx:351
 msgid "Are you sure?"
-msgstr ""
+msgstr "Sind Sie sicher?"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:190
+#: src/view/com/util/forms/PostDropdownBtn.tsx:188
 msgid "Are you sure? This cannot be undone."
-msgstr ""
+msgstr "Sind Sie sicher? Dies kann nicht rückgängig gemacht werden"
 
 #: src/view/com/modals/SelfLabel.tsx:123
 msgid "Artistic or non-erotic nudity."
-msgstr ""
+msgstr "Künstlerische oder nicht-erotische Nacktheit."
 
-#: src/view/com/auth/create/CreateAccount.tsx:141
+#: src/view/com/auth/create/CreateAccount.tsx:145
 #: src/view/com/auth/login/ChooseAccountForm.tsx:151
 #: src/view/com/auth/login/ForgotPasswordForm.tsx:166
 #: src/view/com/auth/login/LoginForm.tsx:249
@@ -235,115 +227,115 @@ msgstr ""
 #: src/view/com/post-thread/PostThread.tsx:453
 #: src/view/com/profile/ProfileHeader.tsx:672
 msgid "Back"
-msgstr ""
+msgstr "Zurück"
 
 #: src/view/screens/Settings.tsx:461
 msgid "Basics"
-msgstr ""
+msgstr "Grundlagen"
 
 #: src/view/com/auth/create/Step2.tsx:131
 #: src/view/com/modals/BirthDateSettings.tsx:72
 msgid "Birthday"
-msgstr ""
+msgstr "Geburtstag"
 
 #: src/view/screens/Settings.tsx:312
 msgid "Birthday:"
-msgstr ""
+msgstr "Geburtstag:"
 
 #: src/view/com/profile/ProfileHeader.tsx:282
 #: src/view/com/profile/ProfileHeader.tsx:389
 msgid "Block Account"
-msgstr ""
+msgstr "Konto sperren"
 
-#: src/view/screens/ProfileList.tsx:522
+#: src/view/screens/ProfileList.tsx:521
 msgid "Block accounts"
-msgstr ""
+msgstr "Kontos sperren"
 
-#: src/view/screens/ProfileList.tsx:472
+#: src/view/screens/ProfileList.tsx:471
 msgid "Block list"
-msgstr ""
+msgstr " Liste sperren"
 
-#: src/view/screens/ProfileList.tsx:307
+#: src/view/screens/ProfileList.tsx:306
 msgid "Block these accounts?"
-msgstr ""
+msgstr "Diese Kontos sperren?"
 
 #: src/view/screens/Moderation.tsx:123
 msgid "Blocked accounts"
-msgstr ""
+msgstr "Gesperrte Konten"
 
 #: src/view/screens/ModerationBlockedAccounts.tsx:106
 msgid "Blocked Accounts"
-msgstr ""
+msgstr "Gesperrte Konten"
 
 #: src/view/com/profile/ProfileHeader.tsx:284
 msgid "Blocked accounts cannot reply in your threads, mention you, or otherwise interact with you."
-msgstr ""
+msgstr "Gesperrte Konten können nicht in Ihren Beiträgen antworten, Sie erwähnen oder anderweitig mit Ihnen interagieren."
 
 #: src/view/screens/ModerationBlockedAccounts.tsx:114
 msgid "Blocked accounts cannot reply in your threads, mention you, or otherwise interact with you. You will not see their content and they will be prevented from seeing yours."
-msgstr ""
+msgstr "Gesperrte Konten können nicht in Ihren Beiträgen antworten, Sie erwähnen oder anderweitig mit Ihnen interagieren. Sie werden ihre Inhalte nicht sehen und sie werden daran gehindert, Ihre zu sehen."
 
 #: src/view/com/post-thread/PostThread.tsx:251
 msgid "Blocked post."
-msgstr ""
+msgstr "Gesperrter Posten."
 
-#: src/view/screens/ProfileList.tsx:309
+#: src/view/screens/ProfileList.tsx:308
 msgid "Blocking is public. Blocked accounts cannot reply in your threads, mention you, or otherwise interact with you."
-msgstr ""
+msgstr "Die Sperrung ist öffentlich. Gesperrte Konten können nicht in Ihren Beiträgen antworten, Sie erwähnen oder anderweitig mit Ihnen interagieren."
 
 #: src/view/com/auth/HomeLoggedOutCTA.tsx:93
 msgid "Blog"
-msgstr ""
+msgstr "Blog"
 
 #: src/view/com/auth/HomeLoggedOutCTA.tsx:31
 msgid "Bluesky"
-msgstr ""
+msgstr "Bluesky"
 
 #: src/view/com/auth/onboarding/WelcomeMobile.tsx:80
 msgid "Bluesky is flexible."
-msgstr ""
+msgstr "Bluesky ist flexibel."
 
 #: src/view/com/auth/onboarding/WelcomeMobile.tsx:69
 msgid "Bluesky is open."
-msgstr ""
+msgstr "Bluesky ist offen."
 
 #: src/view/com/auth/onboarding/WelcomeMobile.tsx:56
 msgid "Bluesky is public."
-msgstr ""
+msgstr "Bluesky ist öffentlich zugänglich."
 
 #: src/view/com/modals/Waitlist.tsx:70
 msgid "Bluesky uses invites to build a healthier community. If you don't know anybody with an invite, you can sign up for the waitlist and we'll send one soon."
-msgstr ""
+msgstr "Bluesky verwendet Einladungen, um eine gesündere Gemeinschaft aufzubauen. Wenn du niemanden kennst, der eine Einladung hat, kannst du dich auf die Warteliste setzen lassen und wir werden dir bald eine schicken."
 
 #: src/view/screens/Moderation.tsx:225
 msgid "Bluesky will not show your profile and posts to logged-out users. Other apps may not honor this request. This does not make your account private."
-msgstr ""
+msgstr "Bluesky wird dein Profil und deine Beiträge nicht für abgemeldete Benutzer anzeigen. Andere Anwendungen erkennen diese Anforderung möglicherweise nicht an. Dies macht dein Konto nicht privat."
 
 #: src/view/com/modals/ServerInput.tsx:78
 msgid "Bluesky.Social"
-msgstr ""
+msgstr "Bluesky.Social"
 
 #: src/view/screens/Settings.tsx:718
 msgid "Build version {0} {1}"
-msgstr ""
+msgstr "Version bauen {0} {1}"
 
 #: src/view/com/auth/HomeLoggedOutCTA.tsx:87
 msgid "Business"
-msgstr ""
+msgstr "Geschäftlich"
 
 #: src/view/com/composer/photos/OpenCameraBtn.tsx:60
 #: src/view/com/util/UserAvatar.tsx:221
 #: src/view/com/util/UserBanner.tsx:38
 msgid "Camera"
-msgstr ""
+msgstr "Kamera"
 
 #: src/view/com/modals/AddAppPasswords.tsx:214
 msgid "Can only contain letters, numbers, spaces, dashes, and underscores. Must be at least 4 characters long, but no more than 32 characters long."
-msgstr ""
+msgstr "Darf nur Buchstaben, Zahlen, Leerzeichen, Bindestriche und Unterstriche enthalten. Muss mindestens 4 Zeichen lang sein, darf aber nicht länger als 32 Zeichen sein."
 
-#: src/view/com/composer/Composer.tsx:285
-#: src/view/com/composer/Composer.tsx:288
-#: src/view/com/modals/AltImage.tsx:128
+#: src/view/com/composer/Composer.tsx:279
+#: src/view/com/composer/Composer.tsx:282
+#: src/view/com/modals/AltImage.tsx:127
 #: src/view/com/modals/ChangeEmail.tsx:218
 #: src/view/com/modals/ChangeEmail.tsx:220
 #: src/view/com/modals/Confirm.tsx:88
@@ -359,135 +351,135 @@ msgstr ""
 #: src/view/screens/Search/Search.tsx:592
 #: src/view/shell/desktop/Search.tsx:182
 msgid "Cancel"
-msgstr ""
+msgstr "Abbrechen"
 
 #: src/view/com/modals/DeleteAccount.tsx:146
 #: src/view/com/modals/DeleteAccount.tsx:219
 msgid "Cancel account deletion"
-msgstr ""
+msgstr "Kontolöschung abbrechen"
 
-#: src/view/com/modals/AltImage.tsx:123
+#: src/view/com/modals/AltImage.tsx:122
 msgid "Cancel add image alt text"
-msgstr ""
+msgstr "Abbrechen Bild-Alt-Text hinzufügen"
 
 #: src/view/com/modals/ChangeHandle.tsx:149
 msgid "Cancel change handle"
-msgstr ""
+msgstr "Änderungsgriff abbrechen"
 
 #: src/view/com/modals/crop-image/CropImage.web.tsx:134
 msgid "Cancel image crop"
-msgstr ""
+msgstr "Bildausschnitt abbrechen"
 
 #: src/view/com/modals/EditProfile.tsx:243
 msgid "Cancel profile editing"
-msgstr ""
+msgstr "Profilbearbeitung abbrechen"
 
 #: src/view/com/modals/Repost.tsx:64
 msgid "Cancel quote post"
-msgstr ""
+msgstr "Angebotspost abbrechen"
 
 #: src/view/com/modals/ListAddRemoveUsers.tsx:87
 #: src/view/shell/desktop/Search.tsx:178
 msgid "Cancel search"
-msgstr ""
+msgstr "Suche abbrechen"
 
 #: src/view/com/modals/Waitlist.tsx:132
 msgid "Cancel waitlist signup"
-msgstr ""
+msgstr "Anmeldung zur Warteliste abbrechen"
 
 #: src/view/screens/Settings.tsx:306
 msgid "Change"
-msgstr ""
+msgstr "Ändern"
 
 #: src/view/screens/Settings.tsx:601
 #: src/view/screens/Settings.tsx:610
 msgid "Change handle"
-msgstr ""
+msgstr "Änderungsgriff andern"
 
 #: src/view/com/modals/ChangeHandle.tsx:161
 msgid "Change Handle"
-msgstr ""
+msgstr "Änderungsgriff andern"
 
 #: src/view/com/modals/VerifyEmail.tsx:141
 msgid "Change my email"
-msgstr ""
+msgstr "Meine E-Mail ändern"
 
 #: src/view/com/modals/ChangeEmail.tsx:109
 msgid "Change Your Email"
-msgstr ""
+msgstr "Ihre E-Mail ändern"
 
 #: src/view/com/auth/onboarding/RecommendedFeeds.tsx:121
 msgid "Check out some recommended feeds. Tap + to add them to your list of pinned feeds."
-msgstr ""
+msgstr "Sehen Sie sich einige empfohlene Feeds an. Tippen Sie auf +, um sie zu Ihrer Liste der angehefteten Feeds hinzuzufügen."
 
 #: src/view/com/auth/onboarding/RecommendedFollows.tsx:185
 msgid "Check out some recommended users. Follow them to see similar users."
-msgstr ""
+msgstr "Sehen Sie sich einige empfohlene Benutzer an. Folgen Sie ihnen, um ähnliche Benutzer zu sehen."
 
 #: src/view/com/modals/DeleteAccount.tsx:163
 msgid "Check your inbox for an email with the confirmation code to enter below:"
-msgstr ""
+msgstr "Prüfen Sie Ihren Posteingang auf eine E-Mail mit dem Bestätigungscode, den Sie unten eingeben müssen:"
 
 #: src/view/com/modals/ServerInput.tsx:38
 msgid "Choose Service"
-msgstr ""
+msgstr "Service auswählen"
 
 #: src/view/com/auth/onboarding/WelcomeMobile.tsx:83
 msgid "Choose the algorithms that power your experience with custom feeds."
-msgstr ""
+msgstr "Wählen Sie die Algorithmen, die Ihr Erlebnis mit benutzerdefinierten Feeds unterstützen."
 
 #: src/view/com/auth/create/Step2.tsx:106
 msgid "Choose your password"
-msgstr ""
+msgstr "Wählen Sie Ihr Passwort"
 
 #: src/view/screens/Settings.tsx:694
 msgid "Clear all legacy storage data"
-msgstr ""
+msgstr "Alle alten Speicherdaten löschen"
 
 #: src/view/screens/Settings.tsx:696
 msgid "Clear all legacy storage data (restart after this)"
-msgstr ""
+msgstr "Alle alten Speicherdaten löschen (danach neu starten)"
 
 #: src/view/screens/Settings.tsx:706
 msgid "Clear all storage data"
-msgstr ""
+msgstr "Alle alten Speicherdaten löschen"
 
 #: src/view/screens/Settings.tsx:708
 msgid "Clear all storage data (restart after this)"
-msgstr ""
+msgstr "Alle alten Speicherdaten löschen (danach neu starten)"
 
 #: src/view/com/util/forms/SearchInput.tsx:73
 #: src/view/screens/Search/Search.tsx:577
 msgid "Clear search query"
-msgstr ""
+msgstr "Suchanfrage löschen"
 
 #: src/view/com/auth/login/PasswordUpdatedForm.tsx:38
 msgid "Close alert"
-msgstr ""
+msgstr "Alarm schließen"
 
 #: src/view/com/util/BottomSheetCustomBackdrop.tsx:33
 msgid "Close bottom drawer"
-msgstr ""
+msgstr "Untere Schublade schließen"
 
 #: src/view/com/lightbox/ImageViewing/components/ImageDefaultHeader.tsx:26
 msgid "Close image"
-msgstr ""
+msgstr "Bild schließen"
 
 #: src/view/com/lightbox/Lightbox.web.tsx:112
 msgid "Close image viewer"
-msgstr ""
+msgstr "Bildanzeige schließen"
 
 #: src/view/shell/index.web.tsx:49
 msgid "Close navigation footer"
-msgstr ""
+msgstr "Navigationsfußzeile schließen"
 
 #: src/view/screens/CommunityGuidelines.tsx:32
 msgid "Community Guidelines"
-msgstr ""
+msgstr "Gemeinschaftliche Leitlinien"
 
 #: src/view/com/composer/Prompt.tsx:24
 msgid "Compose reply"
-msgstr ""
+msgstr "Antwort zusammenstellen"
 
 #: src/view/com/modals/AppealLabel.tsx:98
 #: src/view/com/modals/Confirm.tsx:75
@@ -496,202 +488,202 @@ msgstr ""
 #: src/view/screens/PreferencesHomeFeed.tsx:299
 #: src/view/screens/PreferencesThreads.tsx:153
 msgid "Confirm"
-msgstr ""
+msgstr "Bestätigen"
 
 #: src/view/com/modals/ChangeEmail.tsx:193
 #: src/view/com/modals/ChangeEmail.tsx:195
 msgid "Confirm Change"
-msgstr ""
+msgstr "Änderung bestätigen"
 
 #: src/view/com/modals/lang-settings/ConfirmLanguagesButton.tsx:34
 msgid "Confirm content language settings"
-msgstr ""
+msgstr "Bestätigen Sie die Spracheinstellungen für den Inhalt"
 
 #: src/view/com/modals/DeleteAccount.tsx:209
 msgid "Confirm delete account"
-msgstr ""
+msgstr "Bestätigen Sie Konto löschen"
 
 #: src/view/com/modals/ChangeEmail.tsx:157
 #: src/view/com/modals/DeleteAccount.tsx:176
 #: src/view/com/modals/VerifyEmail.tsx:159
 msgid "Confirmation code"
-msgstr ""
+msgstr "Bestätigungscode"
 
-#: src/view/com/auth/create/CreateAccount.tsx:174
+#: src/view/com/auth/create/CreateAccount.tsx:178
 #: src/view/com/auth/login/LoginForm.tsx:268
 msgid "Connecting..."
-msgstr ""
+msgstr "Verbinden..."
 
 #: src/view/screens/Moderation.tsx:81
 msgid "Content filtering"
-msgstr ""
+msgstr "Inhalt filtern"
 
 #: src/view/com/modals/ContentFilteringSettings.tsx:44
 msgid "Content Filtering"
-msgstr ""
+msgstr "Inhalt filtern"
 
 #: src/view/com/modals/lang-settings/ContentLanguagesSettings.tsx:74
 #: src/view/screens/LanguageSettings.tsx:278
 msgid "Content Languages"
-msgstr ""
+msgstr "Inhalt Sprachen"
 
 #: src/view/com/util/moderation/ScreenHider.tsx:78
 msgid "Content Warning"
-msgstr ""
+msgstr "Inhaltliche Warnung"
 
 #: src/view/com/composer/labels/LabelsBtn.tsx:31
 msgid "Content warnings"
-msgstr ""
+msgstr "Inhaltliche Warnungen"
 
 #: src/view/com/auth/onboarding/RecommendedFeeds.tsx:148
 #: src/view/com/auth/onboarding/RecommendedFollows.tsx:209
 msgid "Continue"
-msgstr ""
+msgstr "Fortsetzung"
 
 #: src/view/com/modals/AddAppPasswords.tsx:193
 #: src/view/com/modals/InviteCodes.tsx:179
 msgid "Copied"
-msgstr ""
+msgstr "Kopiert"
 
 #: src/view/com/modals/AddAppPasswords.tsx:186
 msgid "Copy"
-msgstr ""
+msgstr "Kopie"
 
-#: src/view/screens/ProfileList.tsx:384
+#: src/view/screens/ProfileList.tsx:383
 msgid "Copy link to list"
-msgstr ""
+msgstr "Link zur Liste kopieren"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:131
+#: src/view/com/util/forms/PostDropdownBtn.tsx:129
 msgid "Copy link to post"
-msgstr ""
+msgstr "Link zum Posten kopieren"
 
 #: src/view/com/profile/ProfileHeader.tsx:338
 msgid "Copy link to profile"
-msgstr ""
+msgstr "Link zum Profil kopieren"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:117
+#: src/view/com/util/forms/PostDropdownBtn.tsx:115
 msgid "Copy post text"
-msgstr ""
+msgstr "Posten Text kopieren"
 
 #: src/view/screens/CopyrightPolicy.tsx:29
 msgid "Copyright Policy"
-msgstr ""
+msgstr "Urheberrechtspolitik"
 
-#: src/view/screens/ProfileFeed.tsx:94
+#: src/view/screens/ProfileFeed.tsx:98
 msgid "Could not load feed"
-msgstr ""
+msgstr "Feed konnte nicht geladen werden"
 
-#: src/view/screens/ProfileList.tsx:830
+#: src/view/screens/ProfileList.tsx:829
 msgid "Could not load list"
-msgstr ""
+msgstr "Liste konnte nicht geladen werden"
 
 #: src/view/com/auth/HomeLoggedOutCTA.tsx:62
 #: src/view/com/auth/SplashScreen.tsx:46
 msgid "Create a new account"
-msgstr ""
+msgstr "Ein neues Konto erstellen"
 
-#: src/view/com/auth/create/CreateAccount.tsx:120
+#: src/view/com/auth/create/CreateAccount.tsx:124
 msgid "Create Account"
-msgstr ""
+msgstr "Neues Konto erstellen"
 
 #: src/view/com/auth/HomeLoggedOutCTA.tsx:54
 #: src/view/com/auth/SplashScreen.tsx:43
 msgid "Create new account"
-msgstr ""
+msgstr "Ein neues Konto erstellen"
 
 #: src/view/screens/AppPasswords.tsx:248
 msgid "Created {0}"
-msgstr ""
+msgstr "Erstellt {0}"
 
 #: src/view/com/modals/ChangeHandle.tsx:387
 #: src/view/com/modals/ServerInput.tsx:102
 msgid "Custom domain"
-msgstr ""
+msgstr "Benutzerdefinierter Bereich"
 
 #: src/view/screens/Settings.tsx:615
 msgid "Danger Zone"
-msgstr ""
+msgstr "Gefahrenzone"
 
 #: src/view/screens/Settings.tsx:622
 msgid "Delete account"
-msgstr ""
+msgstr "Konto löschen"
 
 #: src/view/com/modals/DeleteAccount.tsx:83
 msgid "Delete Account"
-msgstr ""
+msgstr "Konto löschen"
 
 #: src/view/screens/AppPasswords.tsx:221
 #: src/view/screens/AppPasswords.tsx:241
 msgid "Delete app password"
-msgstr ""
+msgstr "App-Passwort löschen"
 
-#: src/view/screens/ProfileList.tsx:351
-#: src/view/screens/ProfileList.tsx:411
+#: src/view/screens/ProfileList.tsx:350
+#: src/view/screens/ProfileList.tsx:410
 msgid "Delete List"
-msgstr ""
+msgstr "Liste löschen"
 
 #: src/view/com/modals/DeleteAccount.tsx:212
 msgid "Delete my account"
-msgstr ""
+msgstr "Mein Konto löschen"
 
 #: src/view/screens/Settings.tsx:632
 msgid "Delete my account…"
-msgstr ""
+msgstr "Mein Konto löschen..."
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:185
+#: src/view/com/util/forms/PostDropdownBtn.tsx:183
 msgid "Delete post"
-msgstr ""
+msgstr "Posten löschen"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:189
+#: src/view/com/util/forms/PostDropdownBtn.tsx:187
 msgid "Delete this post?"
-msgstr ""
+msgstr "Diesen Posten löschen?"
 
 #: src/view/com/post-thread/PostThread.tsx:243
 msgid "Deleted post."
-msgstr ""
+msgstr "Posten gelöscht."
 
 #: src/view/com/modals/CreateOrEditList.tsx:218
 #: src/view/com/modals/CreateOrEditList.tsx:234
 #: src/view/com/modals/EditProfile.tsx:197
 #: src/view/com/modals/EditProfile.tsx:209
 msgid "Description"
-msgstr ""
+msgstr "Beschreibung"
 
 #: src/view/com/auth/create/Step1.tsx:96
 msgid "Dev Server"
-msgstr ""
+msgstr "Entwicklungs-Server"
 
 #: src/view/screens/Settings.tsx:637
 msgid "Developer Tools"
-msgstr ""
+msgstr "Werkzeuge für Entwickler"
 
-#: src/view/com/composer/Composer.tsx:143
+#: src/view/com/composer/Composer.tsx:142
 msgid "Discard"
-msgstr ""
+msgstr "Verwerfen"
 
-#: src/view/com/composer/Composer.tsx:137
+#: src/view/com/composer/Composer.tsx:136
 msgid "Discard draft"
-msgstr ""
+msgstr "Verwerfen"
 
 #: src/view/screens/Moderation.tsx:207
 msgid "Discourage apps from showing my account to logged-out users"
-msgstr ""
+msgstr "Verhindern, dass Anwendungen mein Konto für abgemeldete Benutzer anzeigen"
 
 #: src/view/screens/Feeds.tsx:405
 msgid "Discover new feeds"
-msgstr ""
+msgstr "Neue Feeds entdecken"
 
 #: src/view/com/modals/EditProfile.tsx:191
 msgid "Display name"
-msgstr ""
+msgstr "Namen anzeigen"
 
 #: src/view/com/modals/EditProfile.tsx:179
 msgid "Display Name"
-msgstr ""
+msgstr "Namen anzeigen"
 
 #: src/view/com/modals/ChangeHandle.tsx:485
 msgid "Domain verified!"
-msgstr ""
+msgstr "Domain geprüft!"
 
 #: src/view/com/auth/onboarding/RecommendedFollows.tsx:86
 #: src/view/com/modals/ContentFilteringSettings.tsx:88
@@ -706,394 +698,394 @@ msgstr ""
 #: src/view/screens/PreferencesHomeFeed.tsx:302
 #: src/view/screens/PreferencesThreads.tsx:156
 msgid "Done"
-msgstr ""
+msgstr "Erledigt"
 
 #: src/view/com/modals/lang-settings/ConfirmLanguagesButton.tsx:42
 msgid "Done{extraText}"
-msgstr ""
+msgstr "Erledigt{extraText}"
 
 #: src/view/com/modals/InviteCodes.tsx:94
 msgid "Each code works once. You'll receive more invite codes periodically."
-msgstr ""
+msgstr "Jeder Code funktioniert einmal. Sie werden regelmäßig weitere Einladungscodes erhalten."
 
 #: src/view/com/composer/photos/Gallery.tsx:144
 #: src/view/com/modals/EditImage.tsx:207
 msgid "Edit image"
-msgstr ""
+msgstr "Bild bearbeiten"
 
-#: src/view/screens/ProfileList.tsx:399
+#: src/view/screens/ProfileList.tsx:398
 msgid "Edit list details"
-msgstr ""
+msgstr "Listendetails bearbeiten"
 
 #: src/view/screens/Feeds.tsx:367
 #: src/view/screens/SavedFeeds.tsx:84
 msgid "Edit My Feeds"
-msgstr ""
+msgstr "Meine Feeds bearbeiten"
 
 #: src/view/com/modals/EditProfile.tsx:151
 msgid "Edit my profile"
-msgstr ""
+msgstr "Mein Profil bearbeiten"
 
 #: src/view/com/profile/ProfileHeader.tsx:453
 msgid "Edit profile"
-msgstr ""
+msgstr "Profil bearbeiten"
 
 #: src/view/com/profile/ProfileHeader.tsx:456
 msgid "Edit Profile"
-msgstr ""
+msgstr "Profil bearbeiten"
 
 #: src/view/screens/Feeds.tsx:330
 msgid "Edit Saved Feeds"
-msgstr ""
+msgstr "Gespeicherte Feeds bearbeiten"
 
 #: src/view/com/auth/create/Step2.tsx:90
 #: src/view/com/auth/login/ForgotPasswordForm.tsx:148
 #: src/view/com/modals/ChangeEmail.tsx:141
 #: src/view/com/modals/Waitlist.tsx:88
 msgid "Email"
-msgstr ""
+msgstr "E-Mail"
 
 #: src/view/com/auth/create/Step2.tsx:81
 msgid "Email address"
-msgstr ""
+msgstr "E-Mail Adresse"
 
 #: src/view/com/modals/ChangeEmail.tsx:111
 msgid "Email Updated"
-msgstr ""
+msgstr "Email aktualiziert"
 
 #: src/view/screens/Settings.tsx:290
 msgid "Email:"
-msgstr ""
+msgstr "E-Mail:"
 
 #: src/view/screens/PreferencesHomeFeed.tsx:138
 msgid "Enable this setting to only see replies between people you follow."
-msgstr ""
+msgstr "Aktivieren Sie diese Einstellung, um nur Antworten zwischen Personen zu sehen, denen Sie folgen."
 
-#: src/view/screens/Profile.tsx:426
+#: src/view/screens/Profile.tsx:425
 msgid "End of feed"
-msgstr ""
+msgstr "Ende des Feeds"
 
 #: src/view/com/auth/create/Step1.tsx:71
 msgid "Enter the address of your provider:"
-msgstr ""
+msgstr "Geben Sie die Adresse Ihres Anbieters ein:"
 
 #: src/view/com/modals/ChangeHandle.tsx:369
 msgid "Enter the domain you want to use"
-msgstr ""
+msgstr "Geben Sie die zu verwendende Domain ein"
 
 #: src/view/com/auth/login/ForgotPasswordForm.tsx:101
 msgid "Enter the email you used to create your account. We'll send you a \"reset code\" so you can set a new password."
-msgstr ""
+msgstr "Geben Sie die E-Mail-Adresse ein, die Sie zur Erstellung Ihres Kontos verwendet haben. Wir senden Ihnen einen \"Reset-Code\" zu, mit dem Sie ein neues Passwort festlegen können."
 
 #: src/view/com/auth/create/Step2.tsx:86
 msgid "Enter your email address"
-msgstr ""
+msgstr "Geben Sie Ihre E-Mail Adresse ein"
 
 #: src/view/com/modals/ChangeEmail.tsx:117
 msgid "Enter your new email address below."
-msgstr ""
+msgstr "Geben Sie Ihre E-Mail Adresse ein"
 
 #: src/view/com/auth/login/Login.tsx:99
 msgid "Enter your username and password"
-msgstr ""
+msgstr "Geben Sie Ihren Benutzernamen und Ihr Passwort ein"
 
 #: src/view/screens/Search/Search.tsx:106
 msgid "Error:"
-msgstr ""
+msgstr "Fehler:"
 
 #: src/view/com/modals/Threadgate.tsx:76
 msgid "Everybody"
-msgstr ""
+msgstr "Alle"
 
 #: src/view/com/lightbox/Lightbox.web.tsx:156
 msgid "Expand alt text"
-msgstr ""
+msgstr "Alt-Text erweitern"
 
 #: src/view/com/auth/onboarding/RecommendedFeeds.tsx:109
 #: src/view/com/auth/onboarding/RecommendedFeeds.tsx:141
 msgid "Failed to load recommended feeds"
-msgstr ""
+msgstr "Empfohlene Feeds konnten nicht geladen werden"
 
-#: src/view/screens/Feeds.tsx:560
+#: src/view/screens/Feeds.tsx:559
 msgid "Feed offline"
-msgstr ""
+msgstr "Feed offline"
 
 #: src/view/com/feeds/FeedPage.tsx:143
 msgid "Feed Preferences"
-msgstr ""
+msgstr "Feed-Einstellungen"
 
 #: src/view/shell/desktop/RightNav.tsx:65
 #: src/view/shell/Drawer.tsx:292
 msgid "Feedback"
-msgstr ""
+msgstr "Rückmeldung"
 
 #: src/view/screens/Feeds.tsx:475
-#: src/view/screens/Profile.tsx:165
-#: src/view/shell/bottom-bar/BottomBar.tsx:181
-#: src/view/shell/desktop/LeftNav.tsx:340
+#: src/view/screens/Profile.tsx:164
+#: src/view/shell/bottom-bar/BottomBar.tsx:163
+#: src/view/shell/desktop/LeftNav.tsx:335
 #: src/view/shell/Drawer.tsx:455
 #: src/view/shell/Drawer.tsx:456
 msgid "Feeds"
-msgstr ""
+msgstr "Feeds"
 
 #: src/view/com/auth/onboarding/RecommendedFeeds.tsx:57
 msgid "Feeds are created by users to curate content. Choose some feeds that you find interesting."
-msgstr ""
+msgstr "Feeds werden von Nutzern erstellt, um Inhalte zu kuratieren. Wählen Sie einige Feeds aus, die Sie interessant finden."
 
 #: src/view/screens/SavedFeeds.tsx:156
 msgid "Feeds are custom algorithms that users build with a little coding expertise. <0/> for more information."
-msgstr ""
+msgstr "Feeds sind benutzerdefinierte Algorithmen, die von den Nutzern mit ein wenig Programmierkenntnissen erstellt werden. <0/> für weitere Informationen."
 
 #: src/view/screens/Search/Search.tsx:422
 msgid "Find users on Bluesky"
-msgstr ""
+msgstr "Benutzer auf Bluesky finden"
 
 #: src/view/screens/Search/Search.tsx:420
 msgid "Find users with the search tool on the right"
-msgstr ""
+msgstr "Benutzer mit der Suchfunktion auf der rechten Seite finden"
 
 #: src/view/com/auth/onboarding/RecommendedFollowsItem.tsx:150
 msgid "Finding similar accounts..."
-msgstr ""
+msgstr "Suche nach ähnlichen Konten..."
 
 #: src/view/screens/PreferencesHomeFeed.tsx:102
 msgid "Fine-tune the content you see on your home screen."
-msgstr ""
+msgstr "Optimieren Sie die Inhalte, die Sie auf Ihrem Startbildschirm sehen."
 
 #: src/view/screens/PreferencesThreads.tsx:60
 msgid "Fine-tune the discussion threads."
-msgstr ""
+msgstr "Feinabstimmung der Diskussionsstränge."
 
 #: src/view/com/profile/ProfileHeader.tsx:538
 msgid "Follow"
-msgstr ""
+msgstr "Folgen Sie"
 
 #: src/view/com/auth/onboarding/RecommendedFollows.tsx:64
 msgid "Follow some users to get started. We can recommend you more users based on who you find interesting."
-msgstr ""
+msgstr "Folgen Sie einigen Nutzern, um loszulegen. Wir können Ihnen weitere Nutzer empfehlen, je nachdem, wen Sie interessant finden."
 
 #: src/view/com/modals/Threadgate.tsx:98
 msgid "Followed users"
-msgstr ""
+msgstr "Verfolgte Benutzer"
 
 #: src/view/screens/PreferencesHomeFeed.tsx:145
 msgid "Followed users only"
-msgstr ""
+msgstr "Nur verfolgte Benutzer"
 
 #: src/view/screens/ProfileFollowers.tsx:25
 msgid "Followers"
-msgstr ""
+msgstr "Verfolger"
 
 #: src/view/com/profile/ProfileHeader.tsx:624
 msgid "following"
-msgstr ""
+msgstr "folgende"
 
 #: src/view/com/profile/ProfileHeader.tsx:522
 #: src/view/screens/ProfileFollows.tsx:25
 msgid "Following"
-msgstr ""
+msgstr "Folgende"
 
 #: src/view/com/profile/ProfileHeader.tsx:571
 msgid "Follows you"
-msgstr ""
+msgstr "Verfolgt Sie"
 
 #: src/view/com/modals/DeleteAccount.tsx:107
 msgid "For security reasons, we'll need to send a confirmation code to your email address."
-msgstr ""
+msgstr "Aus Sicherheitsgründen müssen wir Ihnen einen Bestätigungscode an Ihre E-Mail-Adresse senden."
 
 #: src/view/com/modals/AddAppPasswords.tsx:207
 msgid "For security reasons, you won't be able to view this again. If you lose this password, you'll need to generate a new one."
-msgstr ""
+msgstr "Aus Sicherheitsgründen können Sie es nicht mehr einsehen. Wenn Sie dieses Passwort verlieren, müssen Sie ein neues generieren."
 
 #: src/view/com/auth/login/LoginForm.tsx:231
 msgid "Forgot"
-msgstr ""
+msgstr "Vergessen"
 
 #: src/view/com/auth/login/LoginForm.tsx:228
 msgid "Forgot password"
-msgstr ""
+msgstr "Passwort vergessen"
 
 #: src/view/com/auth/login/Login.tsx:127
 #: src/view/com/auth/login/Login.tsx:143
 msgid "Forgot Password"
-msgstr ""
+msgstr "Passwort vergessen"
 
 #: src/view/com/composer/photos/SelectPhotoBtn.tsx:43
 msgid "Gallery"
-msgstr ""
+msgstr "Galerie"
 
 #: src/view/com/modals/VerifyEmail.tsx:183
 msgid "Get Started"
-msgstr ""
+msgstr "Anfangen"
 
-#: src/view/com/auth/LoggedOut.tsx:81
-#: src/view/com/auth/LoggedOut.tsx:82
+#: src/view/com/auth/LoggedOut.tsx:70
+#: src/view/com/auth/LoggedOut.tsx:71
 #: src/view/com/util/moderation/ScreenHider.tsx:123
-#: src/view/shell/desktop/LeftNav.tsx:104
+#: src/view/shell/desktop/LeftNav.tsx:103
 msgid "Go back"
-msgstr ""
+msgstr "Zurückgehen"
 
-#: src/view/screens/ProfileFeed.tsx:103
-#: src/view/screens/ProfileFeed.tsx:108
-#: src/view/screens/ProfileList.tsx:839
-#: src/view/screens/ProfileList.tsx:844
+#: src/view/screens/ProfileFeed.tsx:107
+#: src/view/screens/ProfileFeed.tsx:112
+#: src/view/screens/ProfileList.tsx:838
+#: src/view/screens/ProfileList.tsx:843
 msgid "Go Back"
-msgstr ""
+msgstr "Zurückgehen"
 
 #: src/view/com/auth/login/ForgotPasswordForm.tsx:181
 #: src/view/com/auth/login/LoginForm.tsx:278
 #: src/view/com/auth/login/SetNewPasswordForm.tsx:163
 msgid "Go to next"
-msgstr ""
+msgstr "Weiter zum nächsten"
 
 #: src/view/com/modals/ChangeHandle.tsx:265
 msgid "Handle"
-msgstr ""
+msgstr "Handgriff"
 
 #: src/view/shell/desktop/RightNav.tsx:94
 #: src/view/shell/Drawer.tsx:302
 msgid "Help"
-msgstr ""
+msgstr "Hilfe"
 
 #: src/view/com/modals/AddAppPasswords.tsx:148
 msgid "Here is your app password."
-msgstr ""
+msgstr "Hier ist Ihr App-Passwort."
 
 #: src/view/com/notifications/FeedItem.tsx:316
 #: src/view/com/util/moderation/ContentHider.tsx:103
 msgid "Hide"
-msgstr ""
+msgstr "Ausblenden"
 
 #: src/view/com/notifications/FeedItem.tsx:308
 msgid "Hide user list"
-msgstr ""
+msgstr "Benutzerliste ausblenden"
 
 #: src/view/com/posts/FeedErrorMessage.tsx:110
 msgid "Hmm, some kind of issue occurred when contacting the feed server. Please let the feed owner know about this issue."
-msgstr ""
+msgstr "Hmm, es ist ein Problem bei der Kontaktaufnahme mit dem Feed-Server aufgetreten. Bitte informieren Sie den Eigentümer des Feeds über dieses Problem."
 
 #: src/view/com/posts/FeedErrorMessage.tsx:98
 msgid "Hmm, the feed server appears to be misconfigured. Please let the feed owner know about this issue."
-msgstr ""
+msgstr "Hmm, der Feed-Server scheint falsch konfiguriert zu sein. Bitte informieren Sie den Eigentümer des Feeds über dieses Problem."
 
 #: src/view/com/posts/FeedErrorMessage.tsx:104
 msgid "Hmm, the feed server appears to be offline. Please let the feed owner know about this issue."
-msgstr ""
+msgstr "Hmm, der Feed-Server scheint falsch konfiguriert zu sein. Bitte informieren Sie den Eigentümer des Feeds über dieses Problem."
 
 #: src/view/com/posts/FeedErrorMessage.tsx:101
 msgid "Hmm, the feed server gave a bad response. Please let the feed owner know about this issue."
-msgstr ""
+msgstr "Hmm, der Feed-Server scheint falsch konfiguriert zu sein. Bitte informieren Sie den Eigentümer des Feeds über dieses Problem."
 
 #: src/view/com/posts/FeedErrorMessage.tsx:95
 msgid "Hmm, we're having trouble finding this feed. It may have been deleted."
-msgstr ""
+msgstr "Hmm, wir haben Probleme, diesen Feed zu finden. Vielleicht wurde er gelöscht."
 
-#: src/view/shell/bottom-bar/BottomBar.tsx:137
-#: src/view/shell/desktop/LeftNav.tsx:304
+#: src/view/shell/bottom-bar/BottomBar.tsx:116
+#: src/view/shell/desktop/LeftNav.tsx:297
 #: src/view/shell/Drawer.tsx:379
 #: src/view/shell/Drawer.tsx:380
 msgid "Home"
-msgstr ""
+msgstr "Startseite"
 
 #: src/view/com/pager/FeedsTabBarMobile.tsx:96
 #: src/view/screens/PreferencesHomeFeed.tsx:95
 #: src/view/screens/Settings.tsx:481
 msgid "Home Feed Preferences"
-msgstr ""
+msgstr "Startseite Feed-Einstellungen"
 
 #: src/view/com/auth/login/ForgotPasswordForm.tsx:114
 msgid "Hosting provider"
-msgstr ""
+msgstr "Hosting-Anbieter"
 
 #: src/view/com/auth/create/Step1.tsx:76
 #: src/view/com/auth/create/Step1.tsx:81
 msgid "Hosting provider address"
-msgstr ""
+msgstr "Hosting-Anbieter Adresse"
 
 #: src/view/com/modals/VerifyEmail.tsx:208
 msgid "I have a code"
-msgstr ""
+msgstr "Ich habe einen Code"
 
 #: src/view/com/modals/ChangeHandle.tsx:281
 msgid "I have my own domain"
-msgstr ""
+msgstr "Ich habe meine eigene Domain"
 
 #: src/view/com/modals/SelfLabel.tsx:127
 msgid "If none are selected, suitable for all ages."
-msgstr ""
+msgstr "Wenn keine ausgewählt werden, sind sie für alle Altersgruppen geeignet."
 
-#: src/view/com/modals/AltImage.tsx:97
+#: src/view/com/modals/AltImage.tsx:96
 msgid "Image alt text"
-msgstr ""
+msgstr "Bild-Alt-Text"
 
 #: src/view/com/util/UserAvatar.tsx:308
 #: src/view/com/util/UserBanner.tsx:116
 msgid "Image options"
-msgstr ""
+msgstr "Bild-Optionen"
 
 #: src/view/com/auth/login/LoginForm.tsx:113
 msgid "Invalid username or password"
-msgstr ""
+msgstr "Ungültiger Benutzername oder Passwort"
 
 #: src/view/screens/Settings.tsx:383
 msgid "Invite"
-msgstr ""
+msgstr "Einladung"
 
 #: src/view/com/modals/InviteCodes.tsx:91
 #: src/view/screens/Settings.tsx:371
 msgid "Invite a Friend"
-msgstr ""
+msgstr "Einen Freund einladen"
 
 #: src/view/com/auth/create/Step2.tsx:57
 msgid "Invite code"
-msgstr ""
+msgstr "Einladungscode"
 
 #: src/view/com/auth/create/state.ts:136
 msgid "Invite code not accepted. Check that you input it correctly and try again."
-msgstr ""
+msgstr "Einladungscode nicht akzeptiert. Überprüfen Sie, ob Sie ihn richtig eingegeben haben und versuchen Sie es erneut."
 
 #: src/view/shell/Drawer.tsx:621
 msgid "Invite codes: {invitesAvailable} available"
-msgstr ""
+msgstr "Codes einladen: {invitesAvailable} verfügbar"
 
 #: src/view/com/auth/HomeLoggedOutCTA.tsx:99
 msgid "Jobs"
-msgstr ""
+msgstr "Arbeitsplätze"
 
 #: src/view/com/modals/Waitlist.tsx:67
 msgid "Join the waitlist"
-msgstr ""
+msgstr "Auf die Warteliste setzen"
 
 #: src/view/com/auth/create/Step2.tsx:68
 #: src/view/com/auth/create/Step2.tsx:72
 msgid "Join the waitlist."
-msgstr ""
+msgstr "Auf die Warteliste setzen"
 
 #: src/view/com/modals/Waitlist.tsx:124
 msgid "Join Waitlist"
-msgstr ""
+msgstr "Auf die Warteliste setzen"
 
 #: src/view/com/composer/select-language/SelectLangBtn.tsx:104
 msgid "Language selection"
-msgstr ""
+msgstr "Sprachauswahl"
 
 #: src/view/screens/LanguageSettings.tsx:89
 msgid "Language Settings"
-msgstr ""
+msgstr "Spracheinstellungen"
 
 #: src/view/screens/Settings.tsx:541
 msgid "Languages"
-msgstr ""
+msgstr "Sprachen"
 
 #: src/view/com/util/moderation/ContentHider.tsx:101
 msgid "Learn more"
-msgstr ""
+msgstr "Mehr erfahren"
 
 #: src/view/com/util/moderation/PostAlerts.tsx:47
 #: src/view/com/util/moderation/ProfileHeaderAlerts.tsx:65
 #: src/view/com/util/moderation/ScreenHider.tsx:104
 msgid "Learn More"
-msgstr ""
+msgstr "Mehr erfahren"
 
 #: src/view/com/util/moderation/ContentHider.tsx:83
 #: src/view/com/util/moderation/PostAlerts.tsx:40
@@ -1101,218 +1093,223 @@ msgstr ""
 #: src/view/com/util/moderation/ProfileHeaderAlerts.tsx:49
 #: src/view/com/util/moderation/ScreenHider.tsx:101
 msgid "Learn more about this warning"
-msgstr ""
+msgstr "Erfahren Sie mehr über diese Warnung"
 
 #: src/view/screens/Moderation.tsx:242
 msgid "Learn more about what is public on Bluesky."
-msgstr ""
+msgstr "Erfahren Sie mehr darüber, was auf Bluesky öffentlich zugänglich ist."
 
 #: src/view/com/modals/lang-settings/ContentLanguagesSettings.tsx:82
 msgid "Leave them all unchecked to see any language."
-msgstr ""
+msgstr "Lassen Sie alle Kontrollkästchen deaktiviert, um alle Sprachen zu sehen."
 
 #: src/view/com/modals/LinkWarning.tsx:49
 msgid "Leaving Bluesky"
-msgstr ""
+msgstr "Bluesky verlassen"
 
 #: src/view/com/auth/login/Login.tsx:128
 #: src/view/com/auth/login/Login.tsx:144
 msgid "Let's get your password reset!"
-msgstr ""
+msgstr "Lassen Sie Ihr Passwort zurücksetzen!"
 
 #: src/view/com/util/UserAvatar.tsx:245
 #: src/view/com/util/UserBanner.tsx:60
 msgid "Library"
-msgstr ""
+msgstr "Bibliothek"
 
-#: src/view/screens/ProfileFeed.tsx:577
+#: src/view/screens/ProfileFeed.tsx:627
 msgid "Like this feed"
-msgstr ""
+msgstr "Dieser Feed gefallen"
 
 #: src/view/screens/PostLikedBy.tsx:27
 #: src/view/screens/ProfileFeedLikedBy.tsx:27
 msgid "Liked by"
-msgstr ""
+msgstr "Gefallen bei"
 
-#: src/view/screens/Profile.tsx:164
+#: src/view/screens/Profile.tsx:163
 msgid "Likes"
-msgstr ""
+msgstr "Likes"
 
 #: src/view/com/modals/CreateOrEditList.tsx:186
 msgid "List Avatar"
-msgstr ""
+msgstr "Avatar auflisten"
 
 #: src/view/com/modals/CreateOrEditList.tsx:199
 msgid "List Name"
-msgstr ""
+msgstr "Namen auflisten"
 
-#: src/view/screens/Profile.tsx:166
-#: src/view/shell/desktop/LeftNav.tsx:377
+#: src/view/screens/Profile.tsx:165
+#: src/view/shell/desktop/LeftNav.tsx:372
 #: src/view/shell/Drawer.tsx:471
 #: src/view/shell/Drawer.tsx:472
 msgid "Lists"
-msgstr ""
+msgstr "Listen"
 
 #: src/view/com/post-thread/PostThread.tsx:260
 #: src/view/com/post-thread/PostThread.tsx:268
 msgid "Load more posts"
-msgstr ""
+msgstr "Mehr Beiträge laden"
 
 #: src/view/screens/Notifications.tsx:144
 msgid "Load new notifications"
-msgstr ""
+msgstr "Neue Benachrichtigungen laden"
 
 #: src/view/com/feeds/FeedPage.tsx:189
 msgid "Load new posts"
-msgstr ""
+msgstr "Mehr Beiträge laden"
 
 #: src/view/com/composer/text-input/mobile/Autocomplete.tsx:95
 msgid "Loading..."
-msgstr ""
+msgstr "Laden..."
 
 #: src/view/com/modals/ServerInput.tsx:50
 msgid "Local dev server"
-msgstr ""
+msgstr "Lokaler Entwicklungs-Server"
 
 #: src/view/screens/Moderation.tsx:136
 msgid "Logged-out visibility"
-msgstr ""
+msgstr "Ausgeloggte Sichtbarkeit"
 
 #: src/view/com/auth/login/ChooseAccountForm.tsx:133
 msgid "Login to account that is not listed"
-msgstr ""
+msgstr "Anmeldung bei einem Konto, das nicht aufgelistet ist"
+
+#: src/view/screens/ProfileFeed.tsx:472
+msgid "Looks like this feed is only available to users with a Bluesky account. Please sign up or sign in to view this feed!"
+msgstr "Es sieht so aus, als ob dieser Feed nur für Benutzer mit einem Bluesky-Konto verfügbar ist. Bitte melde dich an oder registriere dich, um diesen Feed zu sehen!"
 
 #: src/view/com/modals/LinkWarning.tsx:63
 msgid "Make sure this is where you intend to go!"
-msgstr ""
+msgstr "Vergewissern Sie sich, dass Sie dorthin gehen wollen!"
 
-#: src/view/screens/Profile.tsx:163
+#: src/view/screens/Profile.tsx:162
 msgid "Media"
-msgstr ""
+msgstr "Medien"
 
 #: src/view/com/threadgate/WhoCanReply.tsx:139
 msgid "mentioned users"
-msgstr ""
+msgstr "genannte Nutzer"
 
 #: src/view/com/modals/Threadgate.tsx:93
 msgid "Mentioned users"
-msgstr ""
+msgstr "Genannte Nutzer"
 
 #: src/view/screens/Search/Search.tsx:537
 msgid "Menu"
-msgstr ""
+msgstr "Menü"
 
 #: src/view/com/posts/FeedErrorMessage.tsx:194
+#: src/view/screens/ProfileFeed.tsx:480
 msgid "Message from server"
-msgstr ""
+msgstr "Meldung vom Server"
 
 #: src/view/screens/Moderation.tsx:64
 #: src/view/screens/Settings.tsx:563
-#: src/view/shell/desktop/LeftNav.tsx:395
+#: src/view/shell/desktop/LeftNav.tsx:390
 #: src/view/shell/Drawer.tsx:490
 #: src/view/shell/Drawer.tsx:491
 msgid "Moderation"
-msgstr ""
+msgstr "Moderation"
 
 #: src/view/screens/Moderation.tsx:95
 msgid "Moderation lists"
-msgstr ""
+msgstr "Moderation Liste"
 
 #: src/view/screens/ModerationModlists.tsx:58
 msgid "Moderation Lists"
-msgstr ""
+msgstr "Moderation Liste"
 
 #: src/view/shell/desktop/Feeds.tsx:53
 msgid "More feeds"
-msgstr ""
+msgstr "Mehr Feeds "
 
 #: src/view/com/profile/ProfileHeader.tsx:548
-#: src/view/screens/ProfileFeed.tsx:360
-#: src/view/screens/ProfileList.tsx:583
+#: src/view/screens/ProfileFeed.tsx:365
+#: src/view/screens/ProfileList.tsx:582
 msgid "More options"
-msgstr ""
+msgstr "Mehr Optionen"
 
 #: src/view/com/profile/ProfileHeader.tsx:370
 msgid "Mute Account"
-msgstr ""
+msgstr "Stummes Konto"
 
-#: src/view/screens/ProfileList.tsx:510
+#: src/view/screens/ProfileList.tsx:509
 msgid "Mute accounts"
-msgstr ""
+msgstr "Stummes Konto"
 
-#: src/view/screens/ProfileList.tsx:457
+#: src/view/screens/ProfileList.tsx:456
 msgid "Mute list"
-msgstr ""
+msgstr "Stumme Liste"
 
-#: src/view/screens/ProfileList.tsx:270
+#: src/view/screens/ProfileList.tsx:269
 msgid "Mute these accounts?"
-msgstr ""
+msgstr "Diese Konten stummschalten?"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:149
+#: src/view/com/util/forms/PostDropdownBtn.tsx:147
 msgid "Mute thread"
-msgstr ""
+msgstr "Thema stummschalten"
 
 #: src/view/screens/Moderation.tsx:109
 msgid "Muted accounts"
-msgstr ""
+msgstr "Stumme Kontos"
 
 #: src/view/screens/ModerationMutedAccounts.tsx:106
 msgid "Muted Accounts"
-msgstr ""
+msgstr "Stumme Kontos"
 
 #: src/view/screens/ModerationMutedAccounts.tsx:114
 msgid "Muted accounts have their posts removed from your feed and from your notifications. Mutes are completely private."
-msgstr ""
+msgstr "Bei stummgeschalteten Konten werden deren Beiträge aus deinem Feed und deinen Benachrichtigungen entfernt. Stummschaltungen sind vollständig privat."
 
-#: src/view/screens/ProfileList.tsx:272
+#: src/view/screens/ProfileList.tsx:271
 msgid "Muting is private. Muted accounts can interact with you, but you will not see their posts or receive notifications from them."
-msgstr ""
+msgstr "Stummschalten ist privat. Stummgeschaltete Konten können mit Ihnen interagieren, aber Sie sehen ihre Beiträge nicht und erhalten keine Benachrichtigungen von ihnen."
 
 #: src/view/com/modals/BirthDateSettings.tsx:56
 msgid "My Birthday"
-msgstr ""
+msgstr "Mein Geburtstag"
 
 #: src/view/screens/Feeds.tsx:363
 msgid "My Feeds"
-msgstr ""
+msgstr "Meine Feeds"
 
-#: src/view/shell/desktop/LeftNav.tsx:65
+#: src/view/shell/desktop/LeftNav.tsx:64
 msgid "My Profile"
-msgstr ""
+msgstr "Mein Profil "
 
 #: src/view/screens/Settings.tsx:520
 msgid "My Saved Feeds"
-msgstr ""
+msgstr "Meine gespeicherte Feeds "
 
 #: src/view/com/modals/AddAppPasswords.tsx:177
 #: src/view/com/modals/CreateOrEditList.tsx:211
 msgid "Name"
-msgstr ""
+msgstr "Namen"
 
 #: src/view/com/auth/onboarding/WelcomeMobile.tsx:72
 msgid "Never lose access to your followers and data."
-msgstr ""
+msgstr "Verlieren Sie nie den Zugriff auf Ihre Follower und Daten."
 
 #: src/view/screens/Lists.tsx:76
 #: src/view/screens/ModerationModlists.tsx:78
 msgid "New"
-msgstr ""
+msgstr "Neu"
 
 #: src/view/com/feeds/FeedPage.tsx:200
-#: src/view/screens/Feeds.tsx:511
-#: src/view/screens/Profile.tsx:354
-#: src/view/screens/ProfileFeed.tsx:430
-#: src/view/screens/ProfileList.tsx:193
-#: src/view/screens/ProfileList.tsx:221
-#: src/view/shell/desktop/LeftNav.tsx:247
+#: src/view/screens/Feeds.tsx:510
+#: src/view/screens/Profile.tsx:353
+#: src/view/screens/ProfileFeed.tsx:441
+#: src/view/screens/ProfileList.tsx:192
+#: src/view/screens/ProfileList.tsx:220
+#: src/view/shell/desktop/LeftNav.tsx:246
 msgid "New post"
-msgstr ""
+msgstr "Neuer Posten "
 
-#: src/view/shell/desktop/LeftNav.tsx:257
+#: src/view/shell/desktop/LeftNav.tsx:256
 msgid "New Post"
-msgstr ""
+msgstr "Neuer Posten "
 
-#: src/view/com/auth/create/CreateAccount.tsx:154
+#: src/view/com/auth/create/CreateAccount.tsx:158
 #: src/view/com/auth/login/ForgotPasswordForm.tsx:174
 #: src/view/com/auth/login/ForgotPasswordForm.tsx:184
 #: src/view/com/auth/login/LoginForm.tsx:281
@@ -1320,30 +1317,30 @@ msgstr ""
 #: src/view/com/auth/login/SetNewPasswordForm.tsx:166
 #: src/view/com/auth/onboarding/RecommendedFeeds.tsx:79
 msgid "Next"
-msgstr ""
+msgstr "Nächster"
 
 #: src/view/com/lightbox/Lightbox.web.tsx:142
 msgid "Next image"
-msgstr ""
+msgstr "Nächstes Bild "
 
 #: src/view/screens/PreferencesHomeFeed.tsx:191
 #: src/view/screens/PreferencesHomeFeed.tsx:226
 #: src/view/screens/PreferencesHomeFeed.tsx:263
 msgid "No"
-msgstr ""
+msgstr "Nein"
 
-#: src/view/screens/ProfileFeed.tsx:570
-#: src/view/screens/ProfileList.tsx:711
+#: src/view/screens/ProfileFeed.tsx:620
+#: src/view/screens/ProfileList.tsx:710
 msgid "No description"
-msgstr ""
+msgstr "Ohne Beschreibung"
 
 #: src/view/com/composer/text-input/mobile/Autocomplete.tsx:97
 msgid "No result"
-msgstr ""
+msgstr "Kein Ergebnis"
 
 #: src/view/screens/Feeds.tsx:452
 msgid "No results found for \"{query}\""
-msgstr ""
+msgstr "Keine Ergebnisse gefunden für \"{query}\""
 
 #: src/view/com/modals/ListAddRemoveUsers.tsx:127
 #: src/view/screens/Search/Search.tsx:271
@@ -1351,106 +1348,106 @@ msgstr ""
 #: src/view/screens/Search/Search.tsx:615
 #: src/view/shell/desktop/Search.tsx:210
 msgid "No results found for {query}"
-msgstr ""
+msgstr "Keine Ergebnisse gefunden für {query}"
 
 #: src/view/com/modals/Threadgate.tsx:82
 msgid "Nobody"
-msgstr ""
+msgstr "Niemand"
 
 #: src/view/com/modals/SelfLabel.tsx:135
 msgid "Not Applicable."
-msgstr ""
+msgstr "Nicht anwendbar."
 
 #: src/view/screens/Moderation.tsx:232
 msgid "Note: Bluesky is an open and public network. This setting only limits the visibility of your content on the Bluesky app and website, and other apps may not respect this setting. Your content may still be shown to logged-out users by other apps and websites."
-msgstr ""
+msgstr "Hinweis: Bluesky ist ein offenes und öffentliches Netzwerk. Diese Einstellung schränkt nur die Sichtbarkeit Ihrer Inhalte auf der Bluesky-App und -Website ein, und andere Apps respektieren diese Einstellung möglicherweise nicht. Deine Inhalte können für abgemeldete Benutzer von anderen Apps und Websites weiterhin angezeigt werden."
 
 #: src/view/screens/Notifications.tsx:109
 #: src/view/screens/Notifications.tsx:133
-#: src/view/shell/bottom-bar/BottomBar.tsx:205
-#: src/view/shell/desktop/LeftNav.tsx:359
+#: src/view/shell/bottom-bar/BottomBar.tsx:187
+#: src/view/shell/desktop/LeftNav.tsx:354
 #: src/view/shell/Drawer.tsx:416
 #: src/view/shell/Drawer.tsx:417
 msgid "Notifications"
-msgstr ""
+msgstr "Benachrichtigungen "
 
 #: src/view/com/util/ErrorBoundary.tsx:34
 msgid "Oh no!"
-msgstr ""
+msgstr "Ach nein!"
 
 #: src/view/com/auth/login/PasswordUpdatedForm.tsx:41
 msgid "Okay"
-msgstr ""
+msgstr "Okay"
 
-#: src/view/com/composer/Composer.tsx:354
+#: src/view/com/composer/Composer.tsx:348
 msgid "One or more images is missing alt text."
-msgstr ""
+msgstr "Bei einem oder mehreren Bildern fehlt der Alt-Text."
 
 #: src/view/com/threadgate/WhoCanReply.tsx:100
 msgid "Only {0} can reply."
-msgstr ""
+msgstr "Nur {0} kann antworten."
 
 #: src/view/com/pager/FeedsTabBarMobile.tsx:76
 msgid "Open navigation"
-msgstr ""
+msgstr "Offene Navigation"
 
 #: src/view/screens/Settings.tsx:533
 msgid "Opens configurable language settings"
-msgstr ""
+msgstr "Öffnet die konfigurierbaren Spracheinstellungen"
 
 #: src/view/shell/desktop/RightNav.tsx:148
 #: src/view/shell/Drawer.tsx:622
 msgid "Opens list of invite codes"
-msgstr ""
+msgstr "Öffnet die Liste der Einladungscodes"
 
 #: src/view/com/modals/ChangeHandle.tsx:279
 msgid "Opens modal for using custom domain"
-msgstr ""
+msgstr "Öffnet ein Modal für die Verwendung einer benutzerdefinierten Domain"
 
 #: src/view/screens/Settings.tsx:558
 msgid "Opens moderation settings"
-msgstr ""
+msgstr "Öffnet die Moderationseinstellungen"
 
 #: src/view/screens/Settings.tsx:514
 msgid "Opens screen with all saved feeds"
-msgstr ""
+msgstr "Öffnet den Bildschirm mit allen gespeicherten Feeds"
 
 #: src/view/screens/Settings.tsx:581
 msgid "Opens the app password settings page"
-msgstr ""
+msgstr "Öffnet die Einstellungsseite für das App-Passwort"
 
 #: src/view/screens/Settings.tsx:473
 msgid "Opens the home feed preferences"
-msgstr ""
+msgstr "Öffnet die Homefeed-Einstellungen"
 
 #: src/view/screens/Settings.tsx:664
 msgid "Opens the storybook page"
-msgstr ""
+msgstr "Öffnet die Märchenbuchseite"
 
 #: src/view/screens/Settings.tsx:644
 msgid "Opens the system log page"
-msgstr ""
+msgstr "Öffnet die Systemprotokollseite"
 
 #: src/view/screens/Settings.tsx:494
 msgid "Opens the threads preferences"
-msgstr ""
+msgstr "Öffnet die Thread-Einstellungen"
 
 #: src/view/com/auth/login/ChooseAccountForm.tsx:138
 msgid "Other account"
-msgstr ""
+msgstr "Anderes Konto "
 
 #: src/view/com/modals/ServerInput.tsx:88
 msgid "Other service"
-msgstr ""
+msgstr "Anderes Service "
 
 #: src/view/com/composer/select-language/SelectLangBtn.tsx:91
 msgid "Other..."
-msgstr ""
+msgstr "Andere..."
 
 #: src/view/screens/NotFound.tsx:42
 #: src/view/screens/NotFound.tsx:45
 msgid "Page not found"
-msgstr ""
+msgstr "Seite nicht gefunden"
 
 #: src/view/com/auth/create/Step2.tsx:101
 #: src/view/com/auth/create/Step2.tsx:111
@@ -1458,147 +1455,146 @@ msgstr ""
 #: src/view/com/auth/login/SetNewPasswordForm.tsx:130
 #: src/view/com/modals/DeleteAccount.tsx:191
 msgid "Password"
-msgstr ""
+msgstr "Passwort"
 
 #: src/view/com/auth/login/Login.tsx:157
 msgid "Password updated"
-msgstr ""
+msgstr "Passwort aktualisiert"
 
 #: src/view/com/auth/login/PasswordUpdatedForm.tsx:28
 msgid "Password updated!"
-msgstr ""
+msgstr "Passwort aktualisiert!"
 
 #: src/view/com/modals/SelfLabel.tsx:121
 msgid "Pictures meant for adults."
-msgstr ""
+msgstr "Bilder, die für Erwachsene gedacht sind."
 
 #: src/view/screens/SavedFeeds.tsx:88
 msgid "Pinned Feeds"
-msgstr ""
+msgstr "Angepinnte Feeds"
 
 #: src/view/com/auth/create/state.ts:116
 msgid "Please choose your handle."
-msgstr ""
+msgstr "Bitte wählen Sie Ihren Handgriff."
 
 #: src/view/com/auth/create/state.ts:109
 msgid "Please choose your password."
-msgstr ""
+msgstr "Bitte wählen Sie Ihr Passwort."
 
 #: src/view/com/modals/ChangeEmail.tsx:67
 msgid "Please confirm your email before changing it. This is a temporary requirement while email-updating tools are added, and it will soon be removed."
-msgstr ""
+msgstr "Bitte bestätigen Sie Ihre E-Mail-Adresse, bevor Sie sie ändern. Dies ist eine vorübergehende Anforderung, während E-Mail-Aktualisierungstools hinzugefügt werden, und sie wird bald entfernt werden."
 
 #: src/view/com/modals/AddAppPasswords.tsx:140
 msgid "Please enter a unique name for this App Password or use our randomly generated one."
-msgstr ""
+msgstr "Bitte geben Sie einen eindeutigen Namen für dieses App-Passwort ein oder verwenden Sie unser zufällig generiertes Passwort."
 
 #: src/view/com/auth/create/state.ts:95
 msgid "Please enter your email."
-msgstr ""
+msgstr "Bitte geben Sie Ihre E-Mail-Adresse ein."
 
 #: src/view/com/modals/DeleteAccount.tsx:180
 msgid "Please enter your password as well:"
-msgstr ""
+msgstr "Bitte geben Sie auch Ihr Passwort ein:"
 
 #: src/view/com/modals/AppealLabel.tsx:72
 #: src/view/com/modals/AppealLabel.tsx:75
-msgid "Please tell us why you think this content warning was incorrectly applied!"
-msgstr ""
+msgid "Please tell us why you think this decision was incorrect."
+msgstr "Bitte teilen Sie uns mit, warum diese Entscheidung Ihrer Meinung nach falsch war."
 
-#: src/view/com/composer/Composer.tsx:337
+#: src/view/com/composer/Composer.tsx:331
 #: src/view/com/post-thread/PostThread.tsx:226
-#: src/view/screens/PostThread.tsx:80
+#: src/view/screens/PostThread.tsx:78
 msgid "Post"
-msgstr ""
+msgstr "Posten "
 
 #: src/view/com/post-thread/PostThread.tsx:385
 msgid "Post hidden"
-msgstr ""
+msgstr "Versteckter Posten"
 
 #: src/view/com/composer/select-language/SelectLangBtn.tsx:87
 msgid "Post language"
-msgstr ""
+msgstr "Postsprache"
 
 #: src/view/com/modals/lang-settings/PostLanguagesSettings.tsx:75
 msgid "Post Languages"
-msgstr ""
+msgstr "Postsprachen"
 
 #: src/view/com/post-thread/PostThread.tsx:437
 msgid "Post not found"
-msgstr ""
+msgstr "Posten nicht gefunden"
 
-#: src/view/screens/Profile.tsx:161
+#: src/view/screens/Profile.tsx:160
 msgid "Posts"
-msgstr ""
+msgstr "Posten "
 
 #: src/view/com/modals/LinkWarning.tsx:44
 msgid "Potentially Misleading Link"
-msgstr ""
+msgstr "Potenziell missverständlicher Link"
 
 #: src/view/com/lightbox/Lightbox.web.tsx:128
 msgid "Previous image"
-msgstr ""
+msgstr "Vorheriges Bild"
 
 #: src/view/screens/LanguageSettings.tsx:187
 msgid "Primary Language"
-msgstr ""
+msgstr "Primäre Sprache"
 
 #: src/view/screens/PreferencesThreads.tsx:91
 msgid "Prioritize Your Follows"
-msgstr ""
+msgstr "Priorisieren Sie Ihre Anhängerschaft"
 
 #: src/view/shell/desktop/RightNav.tsx:76
 msgid "Privacy"
-msgstr ""
+msgstr "Privatsphäre"
 
 #: src/view/screens/PrivacyPolicy.tsx:29
 msgid "Privacy Policy"
-msgstr ""
+msgstr "Datenschutzbestimmungen"
 
 #: src/view/com/auth/login/ForgotPasswordForm.tsx:190
 msgid "Processing..."
-msgstr ""
+msgstr "Verarbeitung..."
 
-#: src/view/shell/bottom-bar/BottomBar.tsx:247
-#: src/view/shell/desktop/LeftNav.tsx:413
+#: src/view/shell/bottom-bar/BottomBar.tsx:229
 #: src/view/shell/Drawer.tsx:69
 #: src/view/shell/Drawer.tsx:525
 #: src/view/shell/Drawer.tsx:526
 msgid "Profile"
-msgstr ""
+msgstr "Profile"
 
 #: src/view/screens/Settings.tsx:789
 msgid "Protect your account by verifying your email."
-msgstr ""
+msgstr "Schützen Sie Ihr Konto, indem Sie Ihre E-Mail verifizieren."
 
 #: src/view/screens/ModerationModlists.tsx:61
 msgid "Public, shareable lists of users to mute or block in bulk."
-msgstr ""
+msgstr "Öffentliche, gemeinsam nutzbare Listen von Nutzern zum Stummschalten oder Blockieren in großen Mengen."
 
 #: src/view/screens/Lists.tsx:61
 msgid "Public, shareable lists which can drive feeds."
-msgstr ""
+msgstr "Öffentliche, gemeinsam nutzbare Listen, die zu Feeds führen können."
 
 #: src/view/com/modals/Repost.tsx:52
 #: src/view/com/util/post-ctrls/RepostButton.web.tsx:58
 msgid "Quote post"
-msgstr ""
+msgstr "Angebotsposten"
 
 #: src/view/com/modals/Repost.tsx:56
 msgid "Quote Post"
-msgstr ""
+msgstr "Angebotsposten"
 
 #: src/view/com/modals/EditImage.tsx:236
 msgid "Ratios"
-msgstr ""
+msgstr "Verhältnisse"
 
 #: src/view/com/auth/onboarding/RecommendedFeeds.tsx:116
 msgid "Recommended Feeds"
-msgstr ""
+msgstr "Empfohlene Feeds"
 
 #: src/view/com/auth/onboarding/RecommendedFollows.tsx:180
 msgid "Recommended Users"
-msgstr ""
+msgstr "Empfohlene Benutzer"
 
 #: src/view/com/modals/ListAddRemoveUsers.tsx:264
 #: src/view/com/modals/SelfLabel.tsx:83
@@ -1606,136 +1602,136 @@ msgstr ""
 #: src/view/com/util/UserAvatar.tsx:282
 #: src/view/com/util/UserBanner.tsx:89
 msgid "Remove"
-msgstr ""
+msgstr "Entfernen Sie"
 
 #: src/view/com/feeds/FeedSourceCard.tsx:106
 msgid "Remove {0} from my feeds?"
-msgstr ""
+msgstr "{0} aus meinen Feeds entfernen?"
 
 #: src/view/com/util/AccountDropdownBtn.tsx:22
 msgid "Remove account"
-msgstr ""
+msgstr "Konto entfernen"
 
 #: src/view/com/posts/FeedErrorMessage.tsx:130
 msgid "Remove feed"
-msgstr ""
+msgstr "Feed entfernen"
 
 #: src/view/com/feeds/FeedSourceCard.tsx:105
 #: src/view/com/feeds/FeedSourceCard.tsx:172
-#: src/view/screens/ProfileFeed.tsx:270
+#: src/view/screens/ProfileFeed.tsx:275
 msgid "Remove from my feeds"
-msgstr ""
+msgstr "Aus meinen Feeds entfernen"
 
 #: src/view/com/composer/photos/Gallery.tsx:167
 msgid "Remove image"
-msgstr ""
+msgstr "Bild entfernen"
 
 #: src/view/com/composer/ExternalEmbed.tsx:70
 msgid "Remove image preview"
-msgstr ""
+msgstr "Bildvorschau entfernen"
 
 #: src/view/com/feeds/FeedSourceCard.tsx:173
 msgid "Remove this feed from my feeds?"
-msgstr ""
+msgstr "Diesen Feed aus meinen Feeds entfernen?"
 
 #: src/view/com/posts/FeedErrorMessage.tsx:131
 msgid "Remove this feed from your saved feeds?"
-msgstr ""
+msgstr "Diesen Feed aus Ihren gespeicherten Feeds entfernen?"
 
 #: src/view/com/modals/ListAddRemoveUsers.tsx:199
 #: src/view/com/modals/UserAddRemoveLists.tsx:136
 msgid "Removed from list"
-msgstr ""
+msgstr "Aus der Liste entfernt"
 
-#: src/view/screens/Profile.tsx:162
+#: src/view/screens/Profile.tsx:161
 msgid "Replies"
-msgstr ""
+msgstr "Antworten"
 
 #: src/view/com/threadgate/WhoCanReply.tsx:98
 msgid "Replies to this thread are disabled"
-msgstr ""
+msgstr "Antworten auf diesen Thread sind deaktiviert"
 
 #: src/view/screens/PreferencesHomeFeed.tsx:135
 msgid "Reply Filters"
-msgstr ""
+msgstr "Antwort-Filter"
 
 #: src/view/com/modals/report/Modal.tsx:166
 msgid "Report {collectionName}"
-msgstr ""
+msgstr "Bericht {Sammlungsname}"
 
 #: src/view/com/profile/ProfileHeader.tsx:404
 msgid "Report Account"
-msgstr ""
+msgstr "Bericht Konto"
 
-#: src/view/screens/ProfileFeed.tsx:290
+#: src/view/screens/ProfileFeed.tsx:295
 msgid "Report feed"
-msgstr ""
+msgstr "Bericht Feed"
 
-#: src/view/screens/ProfileList.tsx:425
+#: src/view/screens/ProfileList.tsx:424
 msgid "Report List"
-msgstr ""
+msgstr "Bericht Liste"
 
 #: src/view/com/modals/report/SendReportButton.tsx:37
-#: src/view/com/util/forms/PostDropdownBtn.tsx:167
+#: src/view/com/util/forms/PostDropdownBtn.tsx:165
 msgid "Report post"
-msgstr ""
+msgstr "Beitrag berichten"
 
 #: src/view/com/util/post-ctrls/RepostButton.web.tsx:48
 msgid "Repost"
-msgstr ""
+msgstr "Wiederveröffentlichung"
 
 #: src/view/com/util/post-ctrls/RepostButton.web.tsx:94
 #: src/view/com/util/post-ctrls/RepostButton.web.tsx:105
 msgid "Repost or quote post"
-msgstr ""
+msgstr "Beitrag neu posten oder zitieren"
 
 #: src/view/screens/PostRepostedBy.tsx:27
 msgid "Reposted by"
-msgstr ""
+msgstr "Nachgetragen von"
 
 #: src/view/com/modals/ChangeEmail.tsx:181
 #: src/view/com/modals/ChangeEmail.tsx:183
 msgid "Request Change"
-msgstr ""
+msgstr "Änderung beantragen"
 
 #: src/view/com/auth/create/Step2.tsx:53
 msgid "Required for this provider"
-msgstr ""
+msgstr "Für diesen Anbieter erforderlich"
 
 #: src/view/com/auth/login/SetNewPasswordForm.tsx:108
 msgid "Reset code"
-msgstr ""
+msgstr "Code zurücksetzen"
 
 #: src/view/screens/Settings.tsx:686
 msgid "Reset onboarding state"
-msgstr ""
+msgstr "Onboarding-Status zurücksetzen"
 
 #: src/view/com/auth/login/ForgotPasswordForm.tsx:98
 msgid "Reset password"
-msgstr ""
+msgstr "Passwort zurücksetzen"
 
 #: src/view/screens/Settings.tsx:676
 msgid "Reset preferences state"
-msgstr ""
+msgstr "Einstellungen zurücksetzen"
 
 #: src/view/screens/Settings.tsx:684
 msgid "Resets the onboarding state"
-msgstr ""
+msgstr "Onboarding-Status zurücksetzen"
 
 #: src/view/screens/Settings.tsx:674
 msgid "Resets the preferences state"
-msgstr ""
+msgstr "Setzt den Zustand der Einstellungen zurück"
 
-#: src/view/com/auth/create/CreateAccount.tsx:163
 #: src/view/com/auth/create/CreateAccount.tsx:167
+#: src/view/com/auth/create/CreateAccount.tsx:171
 #: src/view/com/auth/login/LoginForm.tsx:258
 #: src/view/com/auth/login/LoginForm.tsx:261
 #: src/view/com/util/error/ErrorMessage.tsx:55
 #: src/view/com/util/error/ErrorScreen.tsx:65
 msgid "Retry"
-msgstr ""
+msgstr "Wiederholung"
 
-#: src/view/com/modals/AltImage.tsx:115
+#: src/view/com/modals/AltImage.tsx:114
 #: src/view/com/modals/BirthDateSettings.tsx:93
 #: src/view/com/modals/BirthDateSettings.tsx:96
 #: src/view/com/modals/ChangeHandle.tsx:173
@@ -1743,699 +1739,686 @@ msgstr ""
 #: src/view/com/modals/CreateOrEditList.tsx:257
 #: src/view/com/modals/EditProfile.tsx:223
 msgid "Save"
-msgstr ""
+msgstr "Speichern"
 
-#: src/view/com/modals/AltImage.tsx:106
+#: src/view/com/modals/AltImage.tsx:105
 msgid "Save alt text"
-msgstr ""
+msgstr "Alt-Text speichern"
 
 #: src/view/com/modals/EditProfile.tsx:231
 msgid "Save Changes"
-msgstr ""
+msgstr "Änderung speichern"
 
 #: src/view/com/modals/ChangeHandle.tsx:170
 msgid "Save handle change"
-msgstr ""
+msgstr "Griffänderung speichern"
 
 #: src/view/com/modals/crop-image/CropImage.web.tsx:144
 msgid "Save image crop"
-msgstr ""
+msgstr "Bildausschnitt speichern"
 
 #: src/view/screens/SavedFeeds.tsx:122
 msgid "Saved Feeds"
-msgstr ""
+msgstr "Gespeicherte Feeds"
 
 #: src/view/com/modals/ListAddRemoveUsers.tsx:75
 #: src/view/com/util/forms/SearchInput.tsx:64
 #: src/view/screens/Search/Search.tsx:401
 #: src/view/screens/Search/Search.tsx:567
-#: src/view/shell/bottom-bar/BottomBar.tsx:159
-#: src/view/shell/desktop/LeftNav.tsx:322
+#: src/view/shell/bottom-bar/BottomBar.tsx:138
+#: src/view/shell/desktop/LeftNav.tsx:315
 #: src/view/shell/desktop/Search.tsx:161
 #: src/view/shell/desktop/Search.tsx:170
 #: src/view/shell/Drawer.tsx:343
 #: src/view/shell/Drawer.tsx:344
 msgid "Search"
-msgstr ""
-
-#: src/view/com/auth/LoggedOut.tsx:104
-#: src/view/com/auth/LoggedOut.tsx:105
-msgid "Search for users"
-msgstr ""
+msgstr "Suche"
 
 #: src/view/com/modals/ChangeEmail.tsx:110
 msgid "Security Step Required"
-msgstr ""
+msgstr "Sicherheitsstufe erforderlich"
 
 #: src/view/com/auth/HomeLoggedOutCTA.tsx:39
 msgid "See what's next"
-msgstr ""
+msgstr "Was kommt als Nächstes?"
 
 #: src/view/com/modals/ServerInput.tsx:75
 msgid "Select Bluesky Social"
-msgstr ""
+msgstr "Wählen Sie Bluesky Social"
 
 #: src/view/com/auth/login/Login.tsx:117
 msgid "Select from an existing account"
-msgstr ""
+msgstr "Aus einem bestehenden Konto auswählen"
 
 #: src/view/com/auth/login/LoginForm.tsx:143
 msgid "Select service"
-msgstr ""
+msgstr "Dienst auswählen"
 
 #: src/view/screens/LanguageSettings.tsx:281
 msgid "Select which languages you want your subscribed feeds to include. If none are selected, all languages will be shown."
-msgstr ""
+msgstr "Wählen Sie aus, welche Sprachen Ihre abonnierten Feeds enthalten sollen. Wenn Sie keine auswählen, werden alle Sprachen angezeigt."
 
 #: src/view/screens/LanguageSettings.tsx:98
 msgid "Select your app language for the default text to display in the app"
-msgstr ""
+msgstr "Wählen Sie Ihre App-Sprache für den Standardtext, der in der App angezeigt werden soll"
 
 #: src/view/screens/LanguageSettings.tsx:190
 msgid "Select your preferred language for translations in your feed."
-msgstr ""
+msgstr "Wählen Sie Ihre bevorzugte Sprache für Übersetzungen in Ihrem Feed."
 
 #: src/view/com/modals/VerifyEmail.tsx:196
 msgid "Send Confirmation Email"
-msgstr ""
+msgstr "Bestätigungs-E-Mail senden"
 
 #: src/view/com/modals/DeleteAccount.tsx:127
 msgid "Send email"
-msgstr ""
+msgstr "E-Mail senden"
 
 #: src/view/com/modals/DeleteAccount.tsx:138
 msgid "Send Email"
-msgstr ""
+msgstr "E-Mail senden"
 
 #: src/view/shell/Drawer.tsx:276
 #: src/view/shell/Drawer.tsx:297
 msgid "Send feedback"
-msgstr ""
+msgstr "Rückmeldung senden"
 
 #: src/view/com/modals/report/SendReportButton.tsx:45
 msgid "Send Report"
-msgstr ""
+msgstr "Bericht senden"
 
 #: src/view/com/auth/login/SetNewPasswordForm.tsx:78
 msgid "Set new password"
-msgstr ""
+msgstr "Neues Passwort festlegen"
 
 #: src/view/screens/PreferencesHomeFeed.tsx:216
 msgid "Set this setting to \"No\" to hide all quote posts from your feed. Reposts will still be visible."
-msgstr ""
+msgstr "Setzen Sie diese Einstellung auf \"Nein\", um alle zitierten Beiträge aus Ihrem Feed auszublenden. Neu eingestellte Beiträge sind weiterhin sichtbar."
 
 #: src/view/screens/PreferencesHomeFeed.tsx:113
 msgid "Set this setting to \"No\" to hide all replies from your feed."
-msgstr ""
+msgstr "Setzen Sie diese Einstellung auf \"Nein\", um alle Antworten aus Ihrem Feed auszublenden."
 
 #: src/view/screens/PreferencesHomeFeed.tsx:182
 msgid "Set this setting to \"No\" to hide all reposts from your feed."
-msgstr ""
+msgstr "Setzen Sie diese Einstellung auf \"Nein\", um alle wieder geposteten Beiträge aus Ihrem Feed auszublenden."
 
 #: src/view/screens/PreferencesThreads.tsx:116
 msgid "Set this setting to \"Yes\" to show replies in a threaded view. This is an experimental feature."
-msgstr ""
+msgstr "Setzen Sie diese Einstellung auf \"Ja\", um Antworten in einer Thread-Ansicht anzuzeigen. Dies ist eine experimentelle Funktion."
 
 #: src/view/screens/PreferencesHomeFeed.tsx:252
 msgid "Set this setting to \"Yes\" to show samples of your saved feeds in your following feed. This is an experimental feature."
-msgstr ""
+msgstr "Setzen Sie diese Einstellung auf \"Ja\", um Beispiele für Ihre gespeicherten Feeds in Ihrem folgenden Feed anzuzeigen. Dies ist eine experimentelle Funktion."
 
 #: src/view/screens/Settings.tsx:277
-#: src/view/shell/desktop/LeftNav.tsx:431
+#: src/view/shell/desktop/LeftNav.tsx:426
 #: src/view/shell/Drawer.tsx:546
 #: src/view/shell/Drawer.tsx:547
 msgid "Settings"
-msgstr ""
+msgstr "Einstellungen"
 
 #: src/view/com/modals/SelfLabel.tsx:125
 msgid "Sexual activity or erotic nudity."
-msgstr ""
+msgstr "Sexuelle Aktivitäten oder erotische Nacktheit."
 
 #: src/view/com/profile/ProfileHeader.tsx:338
-#: src/view/com/util/forms/PostDropdownBtn.tsx:131
-#: src/view/screens/ProfileList.tsx:384
+#: src/view/com/util/forms/PostDropdownBtn.tsx:129
+#: src/view/screens/ProfileList.tsx:383
 msgid "Share"
-msgstr ""
+msgstr "Teilen"
 
-#: src/view/screens/ProfileFeed.tsx:302
+#: src/view/screens/ProfileFeed.tsx:307
 msgid "Share feed"
-msgstr ""
+msgstr "Feeds teilen"
 
 #: src/view/com/util/moderation/ContentHider.tsx:105
 #: src/view/screens/Settings.tsx:316
 msgid "Show"
-msgstr ""
+msgstr "Zeigen"
 
 #: src/view/com/util/moderation/ScreenHider.tsx:132
 msgid "Show anyway"
-msgstr ""
+msgstr "Trotzdem anzeigen"
 
 #: src/view/screens/PreferencesHomeFeed.tsx:249
 msgid "Show Posts from My Feeds"
-msgstr ""
+msgstr "Beiträge von My Feeds anzeigen"
 
 #: src/view/screens/PreferencesHomeFeed.tsx:213
 msgid "Show Quote Posts"
-msgstr ""
+msgstr "Angebotsposten zeigen"
 
 #: src/view/screens/PreferencesHomeFeed.tsx:110
 msgid "Show Replies"
-msgstr ""
+msgstr "Antworten zeigen"
 
 #: src/view/screens/PreferencesThreads.tsx:94
 msgid "Show replies by people you follow before all other replies."
-msgstr ""
+msgstr "Antworten von Personen, denen Sie folgen, vor allen anderen Antworten anzeigen."
 
 #: src/view/screens/PreferencesHomeFeed.tsx:179
 msgid "Show Reposts"
-msgstr ""
+msgstr "Wiederholungen anzeigen"
 
 #: src/view/com/notifications/FeedItem.tsx:337
 msgid "Show users"
-msgstr ""
+msgstr "Benutzer zeigen"
 
 #: src/view/com/auth/HomeLoggedOutCTA.tsx:70
 #: src/view/com/auth/login/Login.tsx:98
 #: src/view/com/auth/SplashScreen.tsx:54
-#: src/view/shell/bottom-bar/BottomBar.tsx:285
-#: src/view/shell/bottom-bar/BottomBar.tsx:286
-#: src/view/shell/bottom-bar/BottomBar.tsx:288
-#: src/view/shell/bottom-bar/BottomBarWeb.tsx:177
-#: src/view/shell/bottom-bar/BottomBarWeb.tsx:178
-#: src/view/shell/bottom-bar/BottomBarWeb.tsx:180
 #: src/view/shell/NavSignupCard.tsx:58
 #: src/view/shell/NavSignupCard.tsx:59
 msgid "Sign in"
-msgstr ""
+msgstr "Eintragen"
 
 #: src/view/com/auth/HomeLoggedOutCTA.tsx:78
 #: src/view/com/auth/SplashScreen.tsx:57
 #: src/view/com/auth/SplashScreen.web.tsx:87
 msgid "Sign In"
-msgstr ""
+msgstr "Eintragen"
 
 #: src/view/com/auth/login/ChooseAccountForm.tsx:44
 msgid "Sign in as {0}"
-msgstr ""
+msgstr "Eintragen als {0}"
 
 #: src/view/com/auth/login/ChooseAccountForm.tsx:118
 #: src/view/com/auth/login/Login.tsx:116
 msgid "Sign in as..."
-msgstr ""
+msgstr "Eintragen als..."
 
 #: src/view/com/auth/login/LoginForm.tsx:130
 msgid "Sign into"
-msgstr ""
+msgstr "Anmelden"
 
 #: src/view/com/modals/SwitchAccount.tsx:64
 #: src/view/com/modals/SwitchAccount.tsx:67
 msgid "Sign out"
-msgstr ""
+msgstr "Ausmelden"
 
-#: src/view/shell/bottom-bar/BottomBar.tsx:275
-#: src/view/shell/bottom-bar/BottomBar.tsx:276
-#: src/view/shell/bottom-bar/BottomBar.tsx:278
-#: src/view/shell/bottom-bar/BottomBarWeb.tsx:167
-#: src/view/shell/bottom-bar/BottomBarWeb.tsx:168
-#: src/view/shell/bottom-bar/BottomBarWeb.tsx:170
 #: src/view/shell/NavSignupCard.tsx:49
 #: src/view/shell/NavSignupCard.tsx:50
 #: src/view/shell/NavSignupCard.tsx:52
 msgid "Sign up"
-msgstr ""
+msgstr "Einmelden"
 
 #: src/view/shell/NavSignupCard.tsx:42
 msgid "Sign up or sign in to join the conversation"
-msgstr ""
+msgstr "Registrieren Sie sich oder melden Sie sich an, um an der Diskussion teilzunehmen"
 
 #: src/view/com/util/moderation/ScreenHider.tsx:76
 msgid "Sign-in Required"
-msgstr ""
+msgstr "Anmeldung erforderlich"
 
 #: src/view/screens/Settings.tsx:327
 msgid "Signed in as"
-msgstr ""
+msgstr "Eintragen als"
 
 #: src/view/com/auth/onboarding/WelcomeMobile.tsx:33
 msgid "Skip"
-msgstr ""
+msgstr "Überspringen"
 
 #: src/view/screens/PreferencesThreads.tsx:69
 msgid "Sort Replies"
-msgstr ""
+msgstr "Antworten sortieren"
 
 #: src/view/screens/PreferencesThreads.tsx:72
 msgid "Sort replies to the same post by:"
-msgstr ""
+msgstr "Antworten auf denselben Beitrag sortieren nach:"
 
 #: src/view/com/modals/crop-image/CropImage.web.tsx:122
 msgid "Square"
-msgstr ""
+msgstr "Platz"
 
 #: src/view/com/auth/create/Step1.tsx:90
 #: src/view/com/modals/ServerInput.tsx:62
 msgid "Staging"
-msgstr ""
+msgstr "Aufführung"
 
 #: src/view/screens/Settings.tsx:730
 msgid "Status page"
-msgstr ""
+msgstr "Status-Seite"
 
 #: src/view/screens/Settings.tsx:666
 msgid "Storybook"
-msgstr ""
+msgstr "Märchenbuch"
 
 #: src/view/com/modals/AppealLabel.tsx:101
 msgid "Submit"
-msgstr ""
+msgstr "Einreichen"
 
-#: src/view/screens/ProfileList.tsx:574
+#: src/view/screens/ProfileList.tsx:573
 msgid "Subscribe"
-msgstr ""
+msgstr "Abonnieren"
 
-#: src/view/screens/ProfileList.tsx:570
+#: src/view/screens/ProfileList.tsx:569
 msgid "Subscribe to this list"
-msgstr ""
+msgstr "Abonnieren Sie diese Liste"
 
 #: src/view/screens/Search/Search.tsx:357
 msgid "Suggested Follows"
-msgstr ""
+msgstr "Vorgeschlagene Followerliste"
 
 #: src/view/screens/Support.tsx:30
 #: src/view/screens/Support.tsx:33
 msgid "Support"
-msgstr ""
+msgstr "Unterstützung"
 
 #: src/view/com/modals/SwitchAccount.tsx:115
 msgid "Switch Account"
-msgstr ""
+msgstr "Konto wechseln"
 
 #: src/view/screens/Settings.tsx:646
 msgid "System log"
-msgstr ""
+msgstr "System-Protokoll"
 
 #: src/view/com/modals/crop-image/CropImage.web.tsx:112
 msgid "Tall"
-msgstr ""
+msgstr "Groß"
 
 #: src/view/shell/desktop/RightNav.tsx:85
 msgid "Terms"
-msgstr ""
+msgstr "Bedingungen"
 
 #: src/view/screens/TermsOfService.tsx:29
 msgid "Terms of Service"
-msgstr ""
+msgstr "Bedingungen der Dienstleistung"
 
 #: src/view/com/modals/AppealLabel.tsx:70
 #: src/view/com/modals/report/InputIssueDetails.tsx:50
 msgid "Text input field"
-msgstr ""
+msgstr "Text-Eingabefeld"
 
 #: src/view/com/profile/ProfileHeader.tsx:306
 msgid "The account will be able to interact with you after unblocking."
-msgstr ""
+msgstr "Das Konto kann nach der Entsperrung mit Ihnen interagieren."
 
 #: src/view/screens/CommunityGuidelines.tsx:36
 msgid "The Community Guidelines have been moved to <0/>"
-msgstr ""
+msgstr "Die Gemeinschaftsrichtlinien wurden nach <0/> verschoben."
 
 #: src/view/screens/CopyrightPolicy.tsx:33
 msgid "The Copyright Policy has been moved to <0/>"
-msgstr ""
+msgstr "Die Urheberrechtspolitik wurde nach <0/> verschoben."
 
 #: src/view/com/post-thread/PostThread.tsx:440
 msgid "The post may have been deleted."
-msgstr ""
+msgstr "Der Beitrag kann gelöscht worden sein."
 
 #: src/view/screens/PrivacyPolicy.tsx:33
 msgid "The Privacy Policy has been moved to <0/>"
-msgstr ""
+msgstr "Die Datenschutzrichtlinie wurde nach <0/> verschoben."
 
 #: src/view/screens/Support.tsx:36
 msgid "The support form has been moved. If you need help, please<0/> or visit {HELP_DESK_URL} to get in touch with us."
-msgstr ""
+msgstr "Das Support-Formular wurde verschoben. Wenn Sie Hilfe benötigen, wenden Sie sich bitte an<0/> oder besuchen Sie {HELP_DESK_URL}, um mit uns in Kontakt zu treten."
 
 #: src/view/screens/TermsOfService.tsx:33
 msgid "The Terms of Service have been moved to"
-msgstr ""
+msgstr "Die Allgemeinen Geschäftsbedingungen wurden verschoben nach"
 
 #: src/view/com/util/ErrorBoundary.tsx:35
 msgid "There was an unexpected issue in the application. Please let us know if this happened to you!"
-msgstr ""
+msgstr "Es gab ein unerwartetes Problem in der Anwendung. Bitte teilen Sie uns mit, wenn dies bei Ihnen der Fall ist!"
+
+#: src/view/com/util/moderation/LabelInfo.tsx:45
+msgid "This {0} has been labeled."
+msgstr "Dieser {0} wurde gekennzeichnet."
 
 #: src/view/com/util/moderation/ScreenHider.tsx:88
 msgid "This {screenDescription} has been flagged:"
-msgstr ""
+msgstr "Diese {screenDescription} wurde markiert:"
 
 #: src/view/com/util/moderation/ScreenHider.tsx:83
 msgid "This account has requested that users sign in to view their profile."
-msgstr ""
+msgstr "Dieses Konto hat die Benutzer aufgefordert, sich anzumelden, um ihr Profil zu sehen."
 
 #: src/view/com/posts/FeedErrorMessage.tsx:107
 msgid "This content is not viewable without a Bluesky account."
-msgstr ""
+msgstr "Dieser Inhalt kann ohne Bluesky-Konto nicht angezeigt werden."
 
 #: src/view/com/posts/FeedErrorMessage.tsx:113
 msgid "This feed is currently receiving high traffic and is temporarily unavailable. Please try again later."
-msgstr ""
+msgstr "Dieser Feed wird derzeit stark frequentiert und ist vorübergehend nicht verfügbar. Bitte versuchen Sie es später erneut."
 
 #: src/view/com/modals/BirthDateSettings.tsx:61
 msgid "This information is not shared with other users."
-msgstr ""
+msgstr "Diese Informationen werden nicht an andere Nutzer weitergegeben."
 
 #: src/view/com/modals/VerifyEmail.tsx:113
 msgid "This is important in case you ever need to change your email or reset your password."
-msgstr ""
+msgstr "Dies ist wichtig für den Fall, dass Sie Ihre E-Mail-Adresse ändern oder Ihr Passwort zurücksetzen müssen."
 
 #: src/view/com/auth/create/Step1.tsx:55
 msgid "This is the service that keeps you online."
-msgstr ""
+msgstr "Das ist der Dienst, der Sie online hält."
 
 #: src/view/com/modals/LinkWarning.tsx:56
 msgid "This link is taking you to the following website:"
-msgstr ""
+msgstr "Dieser Link führt Sie auf die folgende Website:"
 
-#: src/view/com/post-thread/PostThreadItem.tsx:123
+#: src/view/com/post-thread/PostThreadItem.tsx:124
 msgid "This post has been deleted."
-msgstr ""
+msgstr "Dieser Beitrag wurde gelöscht."
 
 #: src/view/com/modals/SelfLabel.tsx:137
 msgid "This warning is only available for posts with media attached."
-msgstr ""
+msgstr "Diese Warnung ist nur für Beiträge mit angehängten Medien verfügbar."
 
 #: src/view/screens/PreferencesThreads.tsx:53
 #: src/view/screens/Settings.tsx:503
 msgid "Thread Preferences"
-msgstr ""
+msgstr "Einstellungen zum Thema"
 
 #: src/view/screens/PreferencesThreads.tsx:113
 msgid "Threaded Mode"
-msgstr ""
+msgstr "Gewindemodus"
 
 #: src/view/com/util/forms/DropdownButton.tsx:230
 msgid "Toggle dropdown"
-msgstr ""
+msgstr "Dropdown umschalten"
 
 #: src/view/com/modals/EditImage.tsx:271
 msgid "Transformations"
-msgstr ""
+msgstr "Verwandlungen"
 
-#: src/view/com/post-thread/PostThreadItem.tsx:704
 #: src/view/com/post-thread/PostThreadItem.tsx:706
-#: src/view/com/util/forms/PostDropdownBtn.tsx:103
+#: src/view/com/post-thread/PostThreadItem.tsx:708
+#: src/view/com/util/forms/PostDropdownBtn.tsx:101
 msgid "Translate"
-msgstr ""
+msgstr "Übersetze"
 
 #: src/view/com/util/error/ErrorScreen.tsx:73
 msgid "Try again"
-msgstr ""
+msgstr "Nochmals versuchen"
 
-#: src/view/screens/ProfileList.tsx:472
+#: src/view/screens/ProfileList.tsx:471
 msgid "Un-block list"
-msgstr ""
+msgstr "Liste freigeben"
 
-#: src/view/screens/ProfileList.tsx:457
+#: src/view/screens/ProfileList.tsx:456
 msgid "Un-mute list"
-msgstr ""
+msgstr "Stummschaltliste aufheben"
 
 #: src/view/com/auth/create/CreateAccount.tsx:64
 #: src/view/com/auth/login/Login.tsx:76
 #: src/view/com/auth/login/LoginForm.tsx:117
 msgid "Unable to contact your service. Please check your Internet connection."
-msgstr ""
+msgstr "Sie können Ihren Dienst nicht kontaktieren. Bitte überprüfen Sie Ihre Internetverbindung."
 
 #: src/view/com/profile/ProfileHeader.tsx:466
 #: src/view/com/profile/ProfileHeader.tsx:469
 msgid "Unblock"
-msgstr ""
+msgstr "Freischalten"
 
 #: src/view/com/profile/ProfileHeader.tsx:304
 #: src/view/com/profile/ProfileHeader.tsx:388
 msgid "Unblock Account"
-msgstr ""
+msgstr "Konto freischalten"
 
 #: src/view/com/util/post-ctrls/RepostButton.web.tsx:48
 msgid "Undo repost"
-msgstr ""
+msgstr "Umbuchung rückgängig machen"
 
 #: src/view/com/auth/create/state.ts:210
 msgid "Unfortunately, you do not meet the requirements to create an account."
-msgstr ""
+msgstr "Leider erfüllen Sie nicht die Voraussetzungen, um ein Konto zu erstellen."
 
 #: src/view/com/profile/ProfileHeader.tsx:369
 msgid "Unmute Account"
-msgstr ""
+msgstr "Konto entstören"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:149
+#: src/view/com/util/forms/PostDropdownBtn.tsx:147
 msgid "Unmute thread"
-msgstr ""
+msgstr "Thema aufheben"
 
-#: src/view/screens/ProfileList.tsx:440
+#: src/view/screens/ProfileList.tsx:439
 msgid "Unpin moderation list"
-msgstr ""
+msgstr "Moderation Liste"
 
 #: src/view/com/modals/UserAddRemoveLists.tsx:54
 msgid "Update {displayName} in Lists"
-msgstr ""
+msgstr "Aktualisieren Sie {displayName} in Listen"
 
 #: src/lib/hooks/useOTAUpdate.ts:15
 msgid "Update Available"
-msgstr ""
+msgstr "Aktualisierung verfügbar"
 
 #: src/view/com/auth/login/SetNewPasswordForm.tsx:172
 msgid "Updating..."
-msgstr ""
+msgstr "Aktualisieren..."
 
 #: src/view/com/modals/ChangeHandle.tsx:453
 msgid "Upload a text file to:"
-msgstr ""
+msgstr "Laden Sie eine Textdatei hoch:"
 
 #: src/view/screens/AppPasswords.tsx:194
 msgid "Use app passwords to login to other Bluesky clients without giving full access to your account or password."
-msgstr ""
+msgstr "Verwende App-Passwörter, um dich bei anderen Bluesky-Clients anzumelden, ohne dass du vollen Zugang zu deinem Konto oder Passwort hast."
 
 #: src/view/com/modals/ChangeHandle.tsx:513
 msgid "Use default provider"
-msgstr ""
+msgstr "Standardanbieter verwenden"
 
 #: src/view/com/modals/AddAppPasswords.tsx:150
 msgid "Use this to sign into the other app along with your handle."
-msgstr ""
+msgstr "Verwenden Sie dies, um sich mit Ihrem Handle bei der anderen App anzumelden."
 
 #: src/view/com/modals/InviteCodes.tsx:197
 msgid "Used by:"
-msgstr ""
+msgstr "Verwendet von:"
 
 #: src/view/com/auth/create/Step3.tsx:38
 msgid "User handle"
-msgstr ""
+msgstr "Benutzerhandgriff"
 
 #: src/view/screens/Lists.tsx:58
 msgid "User Lists"
-msgstr ""
+msgstr "Benutzer Liste"
 
 #: src/view/com/auth/login/LoginForm.tsx:170
 #: src/view/com/auth/login/LoginForm.tsx:187
 msgid "Username or email address"
-msgstr ""
+msgstr "Benutzername oder E-Mail Adresse"
 
-#: src/view/screens/ProfileList.tsx:738
+#: src/view/screens/ProfileList.tsx:737
 msgid "Users"
-msgstr ""
+msgstr "Benutzer"
 
 #: src/view/com/threadgate/WhoCanReply.tsx:143
 msgid "users followed by <0/>"
-msgstr ""
+msgstr "Benutzer gefolgt von <0/>"
 
 #: src/view/com/modals/Threadgate.tsx:106
 msgid "Users in \"{0}\""
-msgstr ""
+msgstr "Benutzer in \"{0}\""
 
 #: src/view/screens/Settings.tsx:750
 msgid "Verify email"
-msgstr ""
+msgstr "E-Mail überprüfen"
 
 #: src/view/screens/Settings.tsx:775
 msgid "Verify my email"
-msgstr ""
+msgstr "E-Mail überprüfen"
 
 #: src/view/screens/Settings.tsx:784
 msgid "Verify My Email"
-msgstr ""
+msgstr "E-Mail überprüfen"
 
 #: src/view/com/modals/ChangeEmail.tsx:205
 #: src/view/com/modals/ChangeEmail.tsx:207
 msgid "Verify New Email"
-msgstr ""
+msgstr "Neuer E-Mail überprüfen"
 
 #: src/view/screens/Log.tsx:52
 msgid "View debug entry"
-msgstr ""
+msgstr "Debug-Eintrag anzeigen"
 
 #: src/view/com/profile/ProfileSubpageHeader.tsx:128
 msgid "View the avatar"
-msgstr ""
+msgstr "Avatar sehen"
 
 #: src/view/com/modals/LinkWarning.tsx:73
 msgid "Visit Site"
-msgstr ""
+msgstr "Seite besuchen"
 
-#: src/view/com/auth/create/CreateAccount.tsx:121
+#: src/view/com/auth/create/CreateAccount.tsx:125
 msgid "We're so excited to have you join us!"
-msgstr ""
+msgstr "Wir freuen uns, Sie bei uns begrüßen zu dürfen!"
 
 #: src/view/screens/Search/Search.tsx:238
 msgid "We're sorry, but your search could not be completed. Please try again in a few minutes."
-msgstr ""
+msgstr "Es tut uns leid, aber Ihre Suche konnte nicht abgeschlossen werden. Bitte versuchen Sie es in ein paar Minuten erneut."
 
 #: src/view/screens/NotFound.tsx:48
 msgid "We're sorry! We can't find the page you were looking for."
-msgstr ""
+msgstr "Es tut uns leid! Wir können die Seite, die Sie suchen, nicht finden."
 
 #: src/view/com/auth/onboarding/WelcomeMobile.tsx:46
 msgid "Welcome to <0>Bluesky</0>"
-msgstr ""
+msgstr "Willkommen bei <0>Bluesky</0>"
 
 #: src/view/com/modals/report/Modal.tsx:169
 msgid "What is the issue with this {collectionName}?"
-msgstr ""
+msgstr "Was ist das Problem mit dieser {collectionName}?"
 
 #: src/view/com/auth/SplashScreen.tsx:34
-msgid "What's up?"
-msgstr ""
+msgid "What's next?"
+msgstr "Was kommt als Nächstes?"
 
 #: src/view/com/modals/lang-settings/PostLanguagesSettings.tsx:78
 msgid "Which languages are used in this post?"
-msgstr ""
+msgstr "Welche Sprachen werden in diesem Beitrag verwendet?"
 
 #: src/view/com/modals/lang-settings/ContentLanguagesSettings.tsx:77
 msgid "Which languages would you like to see in your algorithmic feeds?"
-msgstr ""
+msgstr "Welche Sprachen würden Sie gerne in Ihren algorithmischen Feeds sehen?"
 
 #: src/view/com/composer/threadgate/ThreadgateBtn.tsx:47
 #: src/view/com/modals/Threadgate.tsx:66
 msgid "Who can reply"
-msgstr ""
+msgstr "Wer kann antworten."
 
 #: src/view/com/modals/crop-image/CropImage.web.tsx:102
 msgid "Wide"
-msgstr ""
+msgstr "Breit"
 
-#: src/view/com/composer/Composer.tsx:409
+#: src/view/com/composer/Composer.tsx:403
 msgid "Write post"
-msgstr ""
+msgstr "Posten schreiben"
 
 #: src/view/com/composer/Prompt.tsx:33
 msgid "Write your reply"
-msgstr ""
+msgstr "Schreiben Sie Ihre Antwort"
 
 #: src/view/screens/PreferencesHomeFeed.tsx:192
 #: src/view/screens/PreferencesHomeFeed.tsx:227
 #: src/view/screens/PreferencesHomeFeed.tsx:262
 msgid "Yes"
-msgstr ""
+msgstr "Ja"
 
 #: src/view/com/auth/create/Step1.tsx:106
 msgid "You can change hosting providers at any time."
-msgstr ""
+msgstr "Sie können den Hosting-Anbieter jederzeit wechseln."
 
 #: src/view/com/auth/login/Login.tsx:158
 #: src/view/com/auth/login/PasswordUpdatedForm.tsx:31
 msgid "You can now sign in with your new password."
-msgstr ""
+msgstr "Sie können sich jetzt mit Ihrem neuen Passwort anmelden."
 
 #: src/view/com/modals/InviteCodes.tsx:64
 msgid "You don't have any invite codes yet! We'll send you some when you've been on Bluesky for a little longer."
-msgstr ""
+msgstr "Du hast noch keine Einladungscodes! Wir schicken dir welche, wenn du schon etwas länger bei Bluesky bist."
 
 #: src/view/screens/SavedFeeds.tsx:102
 msgid "You don't have any pinned feeds."
-msgstr ""
+msgstr "Sie haben keine angehefteten Feeds."
 
 #: src/view/screens/Feeds.tsx:383
 msgid "You don't have any saved feeds!"
-msgstr ""
+msgstr "Sie haben keine gespeicherte Feeds!"
 
 #: src/view/screens/SavedFeeds.tsx:135
 msgid "You don't have any saved feeds."
-msgstr ""
+msgstr "Sie haben keine gespeicherte Feeds."
 
 #: src/view/com/post-thread/PostThread.tsx:388
 msgid "You have blocked the author or you have been blocked by the author."
-msgstr ""
+msgstr "Sie haben den Verfasser blockiert oder Sie wurden vom Verfasser blockiert."
 
 #: src/view/com/feeds/ProfileFeedgens.tsx:141
 msgid "You have no feeds."
-msgstr ""
+msgstr "Sie haben keine Feeds."
 
 #: src/view/com/lists/MyLists.tsx:89
 #: src/view/com/lists/ProfileLists.tsx:145
 msgid "You have no lists."
-msgstr ""
+msgstr "Sie haben keine Listen."
 
 #: src/view/screens/ModerationBlockedAccounts.tsx:131
 msgid "You have not blocked any accounts yet. To block an account, go to their profile and selected \"Block account\" from the menu on their account."
-msgstr ""
+msgstr "Sie haben noch keine Konten gesperrt. Um ein Konto zu sperren, gehen Sie zu seinem Profil und wählen Sie \"Konto sperren\" aus dem Menü auf seinem Konto."
 
 #: src/view/screens/AppPasswords.tsx:86
 msgid "You have not created any app passwords yet. You can create one by pressing the button below."
-msgstr ""
+msgstr "Sie haben noch kein Kennwort für eine Anwendung erstellt. Sie können eines erstellen, indem Sie auf die Schaltfläche unten drücken."
 
 #: src/view/screens/ModerationMutedAccounts.tsx:130
 msgid "You have not muted any accounts yet. To mute an account, go to their profile and selected \"Mute account\" from the menu on their account."
-msgstr ""
+msgstr "Sie haben noch keine Konten stummgeschaltet. Um ein Konto stumm zu schalten, gehen Sie zu seinem Profil und wählen Sie \"Konto stumm schalten\" aus dem Menü auf seinem Konto."
 
 #: src/view/com/auth/login/SetNewPasswordForm.tsx:81
 msgid "You will receive an email with a \"reset code.\" Enter that code here, then enter your new password."
-msgstr ""
+msgstr "Sie erhalten eine E-Mail mit einem \"Reset-Code\". Geben Sie diesen Code hier ein und geben Sie dann Ihr neues Passwort ein."
 
 #: src/view/com/auth/create/Step2.tsx:43
 msgid "Your account"
-msgstr ""
+msgstr "Ihr Konto"
 
 #: src/view/com/auth/create/Step2.tsx:122
 msgid "Your birth date"
-msgstr ""
+msgstr "Ihr Geburtsdatum"
 
 #: src/view/com/auth/create/state.ts:102
 msgid "Your email appears to be invalid."
-msgstr ""
+msgstr "Ihre E-Mail scheint ungültig zu sein."
 
 #: src/view/com/modals/Waitlist.tsx:107
 msgid "Your email has been saved! We'll be in touch soon."
-msgstr ""
+msgstr "Ihre E-Mail wurde gespeichert! Wir werden Sie bald kontaktieren."
 
 #: src/view/com/modals/ChangeEmail.tsx:125
 msgid "Your email has been updated but not verified. As a next step, please verify your new email."
-msgstr ""
+msgstr "Ihre E-Mail wurde aktualisiert, aber nicht verifiziert. Als nächsten Schritt verifizieren Sie bitte Ihre neue E-Mail."
 
 #: src/view/com/modals/VerifyEmail.tsx:108
 msgid "Your email has not yet been verified. This is an important security step which we recommend."
-msgstr ""
+msgstr "Ihre E-Mail ist noch nicht verifiziert worden. Dies ist ein wichtiger Sicherheitsschritt, den wir empfehlen."
 
 #: src/view/com/auth/create/Step3.tsx:42
 #: src/view/com/modals/ChangeHandle.tsx:270
 msgid "Your full handle will be"
-msgstr ""
+msgstr "Ihr vollständiger Name lautet"
 
 #: src/view/com/auth/create/Step1.tsx:53
 msgid "Your hosting provider"
-msgstr ""
+msgstr "Hosting-Anbieter"
 
 #: src/view/screens/Settings.tsx:402
 #: src/view/shell/desktop/RightNav.tsx:129
 #: src/view/shell/Drawer.tsx:636
 msgid "Your invite codes are hidden when logged in using an App Password"
-msgstr ""
+msgstr "Ihre Einladungscodes werden ausgeblendet, wenn Sie sich mit einem App-Passwort anmelden."
 
 #: src/view/com/auth/onboarding/WelcomeMobile.tsx:59
 msgid "Your posts, likes, and blocks are public. Mutes are private."
-msgstr ""
+msgstr "Deine Beiträge, Likes und Blocks sind öffentlich. Stummschaltungen sind privat."
 
 #: src/view/com/modals/SwitchAccount.tsx:82
 msgid "Your profile"
-msgstr ""
+msgstr "Ihr Profil"
 
 #: src/view/com/auth/create/Step3.tsx:28
 msgid "Your user handle"
-msgstr ""
+msgstr "Ihr Benutzerhandgriff"

--- a/src/locale/locales/de/messages.po
+++ b/src/locale/locales/de/messages.po
@@ -1,0 +1,2441 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2023-12-22 01:46+0530\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: de\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+#: src/view/shell/desktop/RightNav.tsx:160
+msgid "{0, plural, one {# invite code available} other {# invite codes available}}"
+msgstr ""
+
+#: src/view/com/modals/Repost.tsx:44
+msgid "{0}"
+msgstr ""
+
+#: src/view/com/modals/CreateOrEditList.tsx:176
+msgid "{0} {purposeLabel} List"
+msgstr ""
+
+#: src/view/shell/desktop/RightNav.tsx:143
+msgid "{invitesAvailable, plural, one {Invite codes: # available} other {Invite codes: # available}}"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:407
+#: src/view/shell/Drawer.tsx:640
+msgid "{invitesAvailable} invite code available"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:409
+#: src/view/shell/Drawer.tsx:642
+msgid "{invitesAvailable} invite codes available"
+msgstr ""
+
+#: src/view/screens/Search/Search.tsx:88
+msgid "{message}"
+msgstr ""
+
+#: src/view/com/threadgate/WhoCanReply.tsx:158
+msgid "<0/> members"
+msgstr ""
+
+#: src/view/com/auth/onboarding/RecommendedFeeds.tsx:30
+msgid "<0>Choose your</0><1>Recommended</1><2>Feeds</2>"
+msgstr ""
+
+#: src/view/com/auth/onboarding/RecommendedFollows.tsx:37
+msgid "<0>Follow some</0><1>Recommended</1><2>Users</2>"
+msgstr ""
+
+#: src/view/com/util/moderation/LabelInfo.tsx:45
+msgid "A content warning has been applied to this {0}."
+msgstr ""
+
+#: src/lib/hooks/useOTAUpdate.ts:16
+msgid "A new version of the app is available. Please update to continue using the app."
+msgstr ""
+
+#: src/view/com/modals/EditImage.tsx:299
+#: src/view/screens/Settings.tsx:417
+msgid "Accessibility"
+msgstr ""
+
+#: src/view/com/auth/login/LoginForm.tsx:159
+#: src/view/screens/Settings.tsx:286
+msgid "Account"
+msgstr ""
+
+#: src/view/com/util/AccountDropdownBtn.tsx:41
+msgid "Account options"
+msgstr ""
+
+#: src/view/com/modals/ListAddRemoveUsers.tsx:264
+#: src/view/com/modals/UserAddRemoveLists.tsx:193
+#: src/view/screens/ProfileList.tsx:754
+msgid "Add"
+msgstr ""
+
+#: src/view/com/modals/SelfLabel.tsx:56
+msgid "Add a content warning"
+msgstr ""
+
+#: src/view/screens/ProfileList.tsx:744
+msgid "Add a user to this list"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:355
+#: src/view/screens/Settings.tsx:364
+msgid "Add account"
+msgstr ""
+
+#: src/view/com/composer/photos/Gallery.tsx:119
+#: src/view/com/composer/photos/Gallery.tsx:180
+msgid "Add alt text"
+msgstr ""
+
+#: src/view/com/modals/report/InputIssueDetails.tsx:41
+#: src/view/com/modals/report/Modal.tsx:191
+msgid "Add details"
+msgstr ""
+
+#: src/view/com/modals/report/Modal.tsx:194
+msgid "Add details to report"
+msgstr ""
+
+#: src/view/com/composer/Composer.tsx:438
+msgid "Add link card"
+msgstr ""
+
+#: src/view/com/composer/Composer.tsx:441
+msgid "Add link card:"
+msgstr ""
+
+#: src/view/com/modals/ChangeHandle.tsx:415
+msgid "Add the following DNS record to your domain:"
+msgstr ""
+
+#: src/view/com/profile/ProfileHeader.tsx:353
+msgid "Add to Lists"
+msgstr ""
+
+#: src/view/screens/ProfileFeed.tsx:270
+msgid "Add to my feeds"
+msgstr ""
+
+#: src/view/com/modals/ListAddRemoveUsers.tsx:191
+#: src/view/com/modals/UserAddRemoveLists.tsx:128
+msgid "Added to list"
+msgstr ""
+
+#: src/view/screens/PreferencesHomeFeed.tsx:164
+msgid "Adjust the number of likes a reply must have to be shown in your feed."
+msgstr ""
+
+#: src/view/com/modals/SelfLabel.tsx:75
+msgid "Adult Content"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:569
+msgid "Advanced"
+msgstr ""
+
+#: src/view/com/composer/photos/Gallery.tsx:130
+msgid "ALT"
+msgstr ""
+
+#: src/view/com/modals/EditImage.tsx:315
+msgid "Alt text"
+msgstr ""
+
+#: src/view/com/composer/photos/Gallery.tsx:209
+msgid "Alt text describes images for blind and low-vision users, and helps give context to everyone."
+msgstr ""
+
+#: src/view/com/modals/VerifyEmail.tsx:118
+msgid "An email has been sent to {0}. It includes a confirmation code which you can enter below."
+msgstr ""
+
+#: src/view/com/modals/ChangeEmail.tsx:119
+msgid "An email has been sent to your previous address, {0}. It includes a confirmation code which you can enter below."
+msgstr ""
+
+#: src/view/com/notifications/FeedItem.tsx:236
+#: src/view/com/threadgate/WhoCanReply.tsx:178
+msgid "and"
+msgstr ""
+
+#: src/view/screens/LanguageSettings.tsx:95
+msgid "App Language"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:589
+msgid "App passwords"
+msgstr ""
+
+#: src/view/screens/AppPasswords.tsx:186
+msgid "App Passwords"
+msgstr ""
+
+#: src/view/com/util/forms/PostDropdownBtn.tsx:207
+msgid "Appeal content warning"
+msgstr ""
+
+#: src/view/com/modals/AppealLabel.tsx:65
+msgid "Appeal Content Warning"
+msgstr ""
+
+#: src/view/com/util/moderation/LabelInfo.tsx:52
+msgid "Appeal this decision"
+msgstr ""
+
+#: src/view/com/util/moderation/LabelInfo.tsx:56
+msgid "Appeal this decision."
+msgstr ""
+
+#: src/view/screens/Settings.tsx:432
+msgid "Appearance"
+msgstr ""
+
+#: src/view/screens/AppPasswords.tsx:223
+msgid "Are you sure you want to delete the app password \"{name}\"?"
+msgstr ""
+
+#: src/view/com/composer/Composer.tsx:142
+msgid "Are you sure you'd like to discard this draft?"
+msgstr ""
+
+#: src/view/screens/ProfileList.tsx:352
+msgid "Are you sure?"
+msgstr ""
+
+#: src/view/com/util/forms/PostDropdownBtn.tsx:190
+msgid "Are you sure? This cannot be undone."
+msgstr ""
+
+#: src/view/com/modals/SelfLabel.tsx:123
+msgid "Artistic or non-erotic nudity."
+msgstr ""
+
+#: src/view/com/auth/create/CreateAccount.tsx:141
+#: src/view/com/auth/login/ChooseAccountForm.tsx:151
+#: src/view/com/auth/login/ForgotPasswordForm.tsx:166
+#: src/view/com/auth/login/LoginForm.tsx:249
+#: src/view/com/auth/login/SetNewPasswordForm.tsx:148
+#: src/view/com/modals/report/InputIssueDetails.tsx:45
+#: src/view/com/post-thread/PostThread.tsx:395
+#: src/view/com/post-thread/PostThread.tsx:445
+#: src/view/com/post-thread/PostThread.tsx:453
+#: src/view/com/profile/ProfileHeader.tsx:672
+msgid "Back"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:461
+msgid "Basics"
+msgstr ""
+
+#: src/view/com/auth/create/Step2.tsx:131
+#: src/view/com/modals/BirthDateSettings.tsx:72
+msgid "Birthday"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:312
+msgid "Birthday:"
+msgstr ""
+
+#: src/view/com/profile/ProfileHeader.tsx:282
+#: src/view/com/profile/ProfileHeader.tsx:389
+msgid "Block Account"
+msgstr ""
+
+#: src/view/screens/ProfileList.tsx:522
+msgid "Block accounts"
+msgstr ""
+
+#: src/view/screens/ProfileList.tsx:472
+msgid "Block list"
+msgstr ""
+
+#: src/view/screens/ProfileList.tsx:307
+msgid "Block these accounts?"
+msgstr ""
+
+#: src/view/screens/Moderation.tsx:123
+msgid "Blocked accounts"
+msgstr ""
+
+#: src/view/screens/ModerationBlockedAccounts.tsx:106
+msgid "Blocked Accounts"
+msgstr ""
+
+#: src/view/com/profile/ProfileHeader.tsx:284
+msgid "Blocked accounts cannot reply in your threads, mention you, or otherwise interact with you."
+msgstr ""
+
+#: src/view/screens/ModerationBlockedAccounts.tsx:114
+msgid "Blocked accounts cannot reply in your threads, mention you, or otherwise interact with you. You will not see their content and they will be prevented from seeing yours."
+msgstr ""
+
+#: src/view/com/post-thread/PostThread.tsx:251
+msgid "Blocked post."
+msgstr ""
+
+#: src/view/screens/ProfileList.tsx:309
+msgid "Blocking is public. Blocked accounts cannot reply in your threads, mention you, or otherwise interact with you."
+msgstr ""
+
+#: src/view/com/auth/HomeLoggedOutCTA.tsx:93
+msgid "Blog"
+msgstr ""
+
+#: src/view/com/auth/HomeLoggedOutCTA.tsx:31
+msgid "Bluesky"
+msgstr ""
+
+#: src/view/com/auth/onboarding/WelcomeMobile.tsx:80
+msgid "Bluesky is flexible."
+msgstr ""
+
+#: src/view/com/auth/onboarding/WelcomeMobile.tsx:69
+msgid "Bluesky is open."
+msgstr ""
+
+#: src/view/com/auth/onboarding/WelcomeMobile.tsx:56
+msgid "Bluesky is public."
+msgstr ""
+
+#: src/view/com/modals/Waitlist.tsx:70
+msgid "Bluesky uses invites to build a healthier community. If you don't know anybody with an invite, you can sign up for the waitlist and we'll send one soon."
+msgstr ""
+
+#: src/view/screens/Moderation.tsx:225
+msgid "Bluesky will not show your profile and posts to logged-out users. Other apps may not honor this request. This does not make your account private."
+msgstr ""
+
+#: src/view/com/modals/ServerInput.tsx:78
+msgid "Bluesky.Social"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:718
+msgid "Build version {0} {1}"
+msgstr ""
+
+#: src/view/com/auth/HomeLoggedOutCTA.tsx:87
+msgid "Business"
+msgstr ""
+
+#: src/view/com/composer/photos/OpenCameraBtn.tsx:60
+#: src/view/com/util/UserAvatar.tsx:221
+#: src/view/com/util/UserBanner.tsx:38
+msgid "Camera"
+msgstr ""
+
+#: src/view/com/modals/AddAppPasswords.tsx:214
+msgid "Can only contain letters, numbers, spaces, dashes, and underscores. Must be at least 4 characters long, but no more than 32 characters long."
+msgstr ""
+
+#: src/view/com/composer/Composer.tsx:285
+#: src/view/com/composer/Composer.tsx:288
+#: src/view/com/modals/AltImage.tsx:128
+#: src/view/com/modals/ChangeEmail.tsx:218
+#: src/view/com/modals/ChangeEmail.tsx:220
+#: src/view/com/modals/Confirm.tsx:88
+#: src/view/com/modals/CreateOrEditList.tsx:267
+#: src/view/com/modals/CreateOrEditList.tsx:272
+#: src/view/com/modals/DeleteAccount.tsx:150
+#: src/view/com/modals/DeleteAccount.tsx:223
+#: src/view/com/modals/EditImage.tsx:323
+#: src/view/com/modals/EditProfile.tsx:248
+#: src/view/com/modals/LinkWarning.tsx:85
+#: src/view/com/modals/Repost.tsx:73
+#: src/view/com/modals/Waitlist.tsx:136
+#: src/view/screens/Search/Search.tsx:592
+#: src/view/shell/desktop/Search.tsx:182
+msgid "Cancel"
+msgstr ""
+
+#: src/view/com/modals/DeleteAccount.tsx:146
+#: src/view/com/modals/DeleteAccount.tsx:219
+msgid "Cancel account deletion"
+msgstr ""
+
+#: src/view/com/modals/AltImage.tsx:123
+msgid "Cancel add image alt text"
+msgstr ""
+
+#: src/view/com/modals/ChangeHandle.tsx:149
+msgid "Cancel change handle"
+msgstr ""
+
+#: src/view/com/modals/crop-image/CropImage.web.tsx:134
+msgid "Cancel image crop"
+msgstr ""
+
+#: src/view/com/modals/EditProfile.tsx:243
+msgid "Cancel profile editing"
+msgstr ""
+
+#: src/view/com/modals/Repost.tsx:64
+msgid "Cancel quote post"
+msgstr ""
+
+#: src/view/com/modals/ListAddRemoveUsers.tsx:87
+#: src/view/shell/desktop/Search.tsx:178
+msgid "Cancel search"
+msgstr ""
+
+#: src/view/com/modals/Waitlist.tsx:132
+msgid "Cancel waitlist signup"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:306
+msgid "Change"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:601
+#: src/view/screens/Settings.tsx:610
+msgid "Change handle"
+msgstr ""
+
+#: src/view/com/modals/ChangeHandle.tsx:161
+msgid "Change Handle"
+msgstr ""
+
+#: src/view/com/modals/VerifyEmail.tsx:141
+msgid "Change my email"
+msgstr ""
+
+#: src/view/com/modals/ChangeEmail.tsx:109
+msgid "Change Your Email"
+msgstr ""
+
+#: src/view/com/auth/onboarding/RecommendedFeeds.tsx:121
+msgid "Check out some recommended feeds. Tap + to add them to your list of pinned feeds."
+msgstr ""
+
+#: src/view/com/auth/onboarding/RecommendedFollows.tsx:185
+msgid "Check out some recommended users. Follow them to see similar users."
+msgstr ""
+
+#: src/view/com/modals/DeleteAccount.tsx:163
+msgid "Check your inbox for an email with the confirmation code to enter below:"
+msgstr ""
+
+#: src/view/com/modals/ServerInput.tsx:38
+msgid "Choose Service"
+msgstr ""
+
+#: src/view/com/auth/onboarding/WelcomeMobile.tsx:83
+msgid "Choose the algorithms that power your experience with custom feeds."
+msgstr ""
+
+#: src/view/com/auth/create/Step2.tsx:106
+msgid "Choose your password"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:694
+msgid "Clear all legacy storage data"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:696
+msgid "Clear all legacy storage data (restart after this)"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:706
+msgid "Clear all storage data"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:708
+msgid "Clear all storage data (restart after this)"
+msgstr ""
+
+#: src/view/com/util/forms/SearchInput.tsx:73
+#: src/view/screens/Search/Search.tsx:577
+msgid "Clear search query"
+msgstr ""
+
+#: src/view/com/auth/login/PasswordUpdatedForm.tsx:38
+msgid "Close alert"
+msgstr ""
+
+#: src/view/com/util/BottomSheetCustomBackdrop.tsx:33
+msgid "Close bottom drawer"
+msgstr ""
+
+#: src/view/com/lightbox/ImageViewing/components/ImageDefaultHeader.tsx:26
+msgid "Close image"
+msgstr ""
+
+#: src/view/com/lightbox/Lightbox.web.tsx:112
+msgid "Close image viewer"
+msgstr ""
+
+#: src/view/shell/index.web.tsx:49
+msgid "Close navigation footer"
+msgstr ""
+
+#: src/view/screens/CommunityGuidelines.tsx:32
+msgid "Community Guidelines"
+msgstr ""
+
+#: src/view/com/composer/Prompt.tsx:24
+msgid "Compose reply"
+msgstr ""
+
+#: src/view/com/modals/AppealLabel.tsx:98
+#: src/view/com/modals/Confirm.tsx:75
+#: src/view/com/modals/SelfLabel.tsx:154
+#: src/view/com/modals/VerifyEmail.tsx:225
+#: src/view/screens/PreferencesHomeFeed.tsx:299
+#: src/view/screens/PreferencesThreads.tsx:153
+msgid "Confirm"
+msgstr ""
+
+#: src/view/com/modals/ChangeEmail.tsx:193
+#: src/view/com/modals/ChangeEmail.tsx:195
+msgid "Confirm Change"
+msgstr ""
+
+#: src/view/com/modals/lang-settings/ConfirmLanguagesButton.tsx:34
+msgid "Confirm content language settings"
+msgstr ""
+
+#: src/view/com/modals/DeleteAccount.tsx:209
+msgid "Confirm delete account"
+msgstr ""
+
+#: src/view/com/modals/ChangeEmail.tsx:157
+#: src/view/com/modals/DeleteAccount.tsx:176
+#: src/view/com/modals/VerifyEmail.tsx:159
+msgid "Confirmation code"
+msgstr ""
+
+#: src/view/com/auth/create/CreateAccount.tsx:174
+#: src/view/com/auth/login/LoginForm.tsx:268
+msgid "Connecting..."
+msgstr ""
+
+#: src/view/screens/Moderation.tsx:81
+msgid "Content filtering"
+msgstr ""
+
+#: src/view/com/modals/ContentFilteringSettings.tsx:44
+msgid "Content Filtering"
+msgstr ""
+
+#: src/view/com/modals/lang-settings/ContentLanguagesSettings.tsx:74
+#: src/view/screens/LanguageSettings.tsx:278
+msgid "Content Languages"
+msgstr ""
+
+#: src/view/com/util/moderation/ScreenHider.tsx:78
+msgid "Content Warning"
+msgstr ""
+
+#: src/view/com/composer/labels/LabelsBtn.tsx:31
+msgid "Content warnings"
+msgstr ""
+
+#: src/view/com/auth/onboarding/RecommendedFeeds.tsx:148
+#: src/view/com/auth/onboarding/RecommendedFollows.tsx:209
+msgid "Continue"
+msgstr ""
+
+#: src/view/com/modals/AddAppPasswords.tsx:193
+#: src/view/com/modals/InviteCodes.tsx:179
+msgid "Copied"
+msgstr ""
+
+#: src/view/com/modals/AddAppPasswords.tsx:186
+msgid "Copy"
+msgstr ""
+
+#: src/view/screens/ProfileList.tsx:384
+msgid "Copy link to list"
+msgstr ""
+
+#: src/view/com/util/forms/PostDropdownBtn.tsx:131
+msgid "Copy link to post"
+msgstr ""
+
+#: src/view/com/profile/ProfileHeader.tsx:338
+msgid "Copy link to profile"
+msgstr ""
+
+#: src/view/com/util/forms/PostDropdownBtn.tsx:117
+msgid "Copy post text"
+msgstr ""
+
+#: src/view/screens/CopyrightPolicy.tsx:29
+msgid "Copyright Policy"
+msgstr ""
+
+#: src/view/screens/ProfileFeed.tsx:94
+msgid "Could not load feed"
+msgstr ""
+
+#: src/view/screens/ProfileList.tsx:830
+msgid "Could not load list"
+msgstr ""
+
+#: src/view/com/auth/HomeLoggedOutCTA.tsx:62
+#: src/view/com/auth/SplashScreen.tsx:46
+msgid "Create a new account"
+msgstr ""
+
+#: src/view/com/auth/create/CreateAccount.tsx:120
+msgid "Create Account"
+msgstr ""
+
+#: src/view/com/auth/HomeLoggedOutCTA.tsx:54
+#: src/view/com/auth/SplashScreen.tsx:43
+msgid "Create new account"
+msgstr ""
+
+#: src/view/screens/AppPasswords.tsx:248
+msgid "Created {0}"
+msgstr ""
+
+#: src/view/com/modals/ChangeHandle.tsx:387
+#: src/view/com/modals/ServerInput.tsx:102
+msgid "Custom domain"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:615
+msgid "Danger Zone"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:622
+msgid "Delete account"
+msgstr ""
+
+#: src/view/com/modals/DeleteAccount.tsx:83
+msgid "Delete Account"
+msgstr ""
+
+#: src/view/screens/AppPasswords.tsx:221
+#: src/view/screens/AppPasswords.tsx:241
+msgid "Delete app password"
+msgstr ""
+
+#: src/view/screens/ProfileList.tsx:351
+#: src/view/screens/ProfileList.tsx:411
+msgid "Delete List"
+msgstr ""
+
+#: src/view/com/modals/DeleteAccount.tsx:212
+msgid "Delete my account"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:632
+msgid "Delete my account…"
+msgstr ""
+
+#: src/view/com/util/forms/PostDropdownBtn.tsx:185
+msgid "Delete post"
+msgstr ""
+
+#: src/view/com/util/forms/PostDropdownBtn.tsx:189
+msgid "Delete this post?"
+msgstr ""
+
+#: src/view/com/post-thread/PostThread.tsx:243
+msgid "Deleted post."
+msgstr ""
+
+#: src/view/com/modals/CreateOrEditList.tsx:218
+#: src/view/com/modals/CreateOrEditList.tsx:234
+#: src/view/com/modals/EditProfile.tsx:197
+#: src/view/com/modals/EditProfile.tsx:209
+msgid "Description"
+msgstr ""
+
+#: src/view/com/auth/create/Step1.tsx:96
+msgid "Dev Server"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:637
+msgid "Developer Tools"
+msgstr ""
+
+#: src/view/com/composer/Composer.tsx:143
+msgid "Discard"
+msgstr ""
+
+#: src/view/com/composer/Composer.tsx:137
+msgid "Discard draft"
+msgstr ""
+
+#: src/view/screens/Moderation.tsx:207
+msgid "Discourage apps from showing my account to logged-out users"
+msgstr ""
+
+#: src/view/screens/Feeds.tsx:405
+msgid "Discover new feeds"
+msgstr ""
+
+#: src/view/com/modals/EditProfile.tsx:191
+msgid "Display name"
+msgstr ""
+
+#: src/view/com/modals/EditProfile.tsx:179
+msgid "Display Name"
+msgstr ""
+
+#: src/view/com/modals/ChangeHandle.tsx:485
+msgid "Domain verified!"
+msgstr ""
+
+#: src/view/com/auth/onboarding/RecommendedFollows.tsx:86
+#: src/view/com/modals/ContentFilteringSettings.tsx:88
+#: src/view/com/modals/ContentFilteringSettings.tsx:96
+#: src/view/com/modals/crop-image/CropImage.web.tsx:152
+#: src/view/com/modals/EditImage.tsx:333
+#: src/view/com/modals/ListAddRemoveUsers.tsx:142
+#: src/view/com/modals/SelfLabel.tsx:157
+#: src/view/com/modals/Threadgate.tsx:129
+#: src/view/com/modals/Threadgate.tsx:132
+#: src/view/com/modals/UserAddRemoveLists.tsx:79
+#: src/view/screens/PreferencesHomeFeed.tsx:302
+#: src/view/screens/PreferencesThreads.tsx:156
+msgid "Done"
+msgstr ""
+
+#: src/view/com/modals/lang-settings/ConfirmLanguagesButton.tsx:42
+msgid "Done{extraText}"
+msgstr ""
+
+#: src/view/com/modals/InviteCodes.tsx:94
+msgid "Each code works once. You'll receive more invite codes periodically."
+msgstr ""
+
+#: src/view/com/composer/photos/Gallery.tsx:144
+#: src/view/com/modals/EditImage.tsx:207
+msgid "Edit image"
+msgstr ""
+
+#: src/view/screens/ProfileList.tsx:399
+msgid "Edit list details"
+msgstr ""
+
+#: src/view/screens/Feeds.tsx:367
+#: src/view/screens/SavedFeeds.tsx:84
+msgid "Edit My Feeds"
+msgstr ""
+
+#: src/view/com/modals/EditProfile.tsx:151
+msgid "Edit my profile"
+msgstr ""
+
+#: src/view/com/profile/ProfileHeader.tsx:453
+msgid "Edit profile"
+msgstr ""
+
+#: src/view/com/profile/ProfileHeader.tsx:456
+msgid "Edit Profile"
+msgstr ""
+
+#: src/view/screens/Feeds.tsx:330
+msgid "Edit Saved Feeds"
+msgstr ""
+
+#: src/view/com/auth/create/Step2.tsx:90
+#: src/view/com/auth/login/ForgotPasswordForm.tsx:148
+#: src/view/com/modals/ChangeEmail.tsx:141
+#: src/view/com/modals/Waitlist.tsx:88
+msgid "Email"
+msgstr ""
+
+#: src/view/com/auth/create/Step2.tsx:81
+msgid "Email address"
+msgstr ""
+
+#: src/view/com/modals/ChangeEmail.tsx:111
+msgid "Email Updated"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:290
+msgid "Email:"
+msgstr ""
+
+#: src/view/screens/PreferencesHomeFeed.tsx:138
+msgid "Enable this setting to only see replies between people you follow."
+msgstr ""
+
+#: src/view/screens/Profile.tsx:426
+msgid "End of feed"
+msgstr ""
+
+#: src/view/com/auth/create/Step1.tsx:71
+msgid "Enter the address of your provider:"
+msgstr ""
+
+#: src/view/com/modals/ChangeHandle.tsx:369
+msgid "Enter the domain you want to use"
+msgstr ""
+
+#: src/view/com/auth/login/ForgotPasswordForm.tsx:101
+msgid "Enter the email you used to create your account. We'll send you a \"reset code\" so you can set a new password."
+msgstr ""
+
+#: src/view/com/auth/create/Step2.tsx:86
+msgid "Enter your email address"
+msgstr ""
+
+#: src/view/com/modals/ChangeEmail.tsx:117
+msgid "Enter your new email address below."
+msgstr ""
+
+#: src/view/com/auth/login/Login.tsx:99
+msgid "Enter your username and password"
+msgstr ""
+
+#: src/view/screens/Search/Search.tsx:106
+msgid "Error:"
+msgstr ""
+
+#: src/view/com/modals/Threadgate.tsx:76
+msgid "Everybody"
+msgstr ""
+
+#: src/view/com/lightbox/Lightbox.web.tsx:156
+msgid "Expand alt text"
+msgstr ""
+
+#: src/view/com/auth/onboarding/RecommendedFeeds.tsx:109
+#: src/view/com/auth/onboarding/RecommendedFeeds.tsx:141
+msgid "Failed to load recommended feeds"
+msgstr ""
+
+#: src/view/screens/Feeds.tsx:560
+msgid "Feed offline"
+msgstr ""
+
+#: src/view/com/feeds/FeedPage.tsx:143
+msgid "Feed Preferences"
+msgstr ""
+
+#: src/view/shell/desktop/RightNav.tsx:65
+#: src/view/shell/Drawer.tsx:292
+msgid "Feedback"
+msgstr ""
+
+#: src/view/screens/Feeds.tsx:475
+#: src/view/screens/Profile.tsx:165
+#: src/view/shell/bottom-bar/BottomBar.tsx:181
+#: src/view/shell/desktop/LeftNav.tsx:340
+#: src/view/shell/Drawer.tsx:455
+#: src/view/shell/Drawer.tsx:456
+msgid "Feeds"
+msgstr ""
+
+#: src/view/com/auth/onboarding/RecommendedFeeds.tsx:57
+msgid "Feeds are created by users to curate content. Choose some feeds that you find interesting."
+msgstr ""
+
+#: src/view/screens/SavedFeeds.tsx:156
+msgid "Feeds are custom algorithms that users build with a little coding expertise. <0/> for more information."
+msgstr ""
+
+#: src/view/screens/Search/Search.tsx:422
+msgid "Find users on Bluesky"
+msgstr ""
+
+#: src/view/screens/Search/Search.tsx:420
+msgid "Find users with the search tool on the right"
+msgstr ""
+
+#: src/view/com/auth/onboarding/RecommendedFollowsItem.tsx:150
+msgid "Finding similar accounts..."
+msgstr ""
+
+#: src/view/screens/PreferencesHomeFeed.tsx:102
+msgid "Fine-tune the content you see on your home screen."
+msgstr ""
+
+#: src/view/screens/PreferencesThreads.tsx:60
+msgid "Fine-tune the discussion threads."
+msgstr ""
+
+#: src/view/com/profile/ProfileHeader.tsx:538
+msgid "Follow"
+msgstr ""
+
+#: src/view/com/auth/onboarding/RecommendedFollows.tsx:64
+msgid "Follow some users to get started. We can recommend you more users based on who you find interesting."
+msgstr ""
+
+#: src/view/com/modals/Threadgate.tsx:98
+msgid "Followed users"
+msgstr ""
+
+#: src/view/screens/PreferencesHomeFeed.tsx:145
+msgid "Followed users only"
+msgstr ""
+
+#: src/view/screens/ProfileFollowers.tsx:25
+msgid "Followers"
+msgstr ""
+
+#: src/view/com/profile/ProfileHeader.tsx:624
+msgid "following"
+msgstr ""
+
+#: src/view/com/profile/ProfileHeader.tsx:522
+#: src/view/screens/ProfileFollows.tsx:25
+msgid "Following"
+msgstr ""
+
+#: src/view/com/profile/ProfileHeader.tsx:571
+msgid "Follows you"
+msgstr ""
+
+#: src/view/com/modals/DeleteAccount.tsx:107
+msgid "For security reasons, we'll need to send a confirmation code to your email address."
+msgstr ""
+
+#: src/view/com/modals/AddAppPasswords.tsx:207
+msgid "For security reasons, you won't be able to view this again. If you lose this password, you'll need to generate a new one."
+msgstr ""
+
+#: src/view/com/auth/login/LoginForm.tsx:231
+msgid "Forgot"
+msgstr ""
+
+#: src/view/com/auth/login/LoginForm.tsx:228
+msgid "Forgot password"
+msgstr ""
+
+#: src/view/com/auth/login/Login.tsx:127
+#: src/view/com/auth/login/Login.tsx:143
+msgid "Forgot Password"
+msgstr ""
+
+#: src/view/com/composer/photos/SelectPhotoBtn.tsx:43
+msgid "Gallery"
+msgstr ""
+
+#: src/view/com/modals/VerifyEmail.tsx:183
+msgid "Get Started"
+msgstr ""
+
+#: src/view/com/auth/LoggedOut.tsx:81
+#: src/view/com/auth/LoggedOut.tsx:82
+#: src/view/com/util/moderation/ScreenHider.tsx:123
+#: src/view/shell/desktop/LeftNav.tsx:104
+msgid "Go back"
+msgstr ""
+
+#: src/view/screens/ProfileFeed.tsx:103
+#: src/view/screens/ProfileFeed.tsx:108
+#: src/view/screens/ProfileList.tsx:839
+#: src/view/screens/ProfileList.tsx:844
+msgid "Go Back"
+msgstr ""
+
+#: src/view/com/auth/login/ForgotPasswordForm.tsx:181
+#: src/view/com/auth/login/LoginForm.tsx:278
+#: src/view/com/auth/login/SetNewPasswordForm.tsx:163
+msgid "Go to next"
+msgstr ""
+
+#: src/view/com/modals/ChangeHandle.tsx:265
+msgid "Handle"
+msgstr ""
+
+#: src/view/shell/desktop/RightNav.tsx:94
+#: src/view/shell/Drawer.tsx:302
+msgid "Help"
+msgstr ""
+
+#: src/view/com/modals/AddAppPasswords.tsx:148
+msgid "Here is your app password."
+msgstr ""
+
+#: src/view/com/notifications/FeedItem.tsx:316
+#: src/view/com/util/moderation/ContentHider.tsx:103
+msgid "Hide"
+msgstr ""
+
+#: src/view/com/notifications/FeedItem.tsx:308
+msgid "Hide user list"
+msgstr ""
+
+#: src/view/com/posts/FeedErrorMessage.tsx:110
+msgid "Hmm, some kind of issue occurred when contacting the feed server. Please let the feed owner know about this issue."
+msgstr ""
+
+#: src/view/com/posts/FeedErrorMessage.tsx:98
+msgid "Hmm, the feed server appears to be misconfigured. Please let the feed owner know about this issue."
+msgstr ""
+
+#: src/view/com/posts/FeedErrorMessage.tsx:104
+msgid "Hmm, the feed server appears to be offline. Please let the feed owner know about this issue."
+msgstr ""
+
+#: src/view/com/posts/FeedErrorMessage.tsx:101
+msgid "Hmm, the feed server gave a bad response. Please let the feed owner know about this issue."
+msgstr ""
+
+#: src/view/com/posts/FeedErrorMessage.tsx:95
+msgid "Hmm, we're having trouble finding this feed. It may have been deleted."
+msgstr ""
+
+#: src/view/shell/bottom-bar/BottomBar.tsx:137
+#: src/view/shell/desktop/LeftNav.tsx:304
+#: src/view/shell/Drawer.tsx:379
+#: src/view/shell/Drawer.tsx:380
+msgid "Home"
+msgstr ""
+
+#: src/view/com/pager/FeedsTabBarMobile.tsx:96
+#: src/view/screens/PreferencesHomeFeed.tsx:95
+#: src/view/screens/Settings.tsx:481
+msgid "Home Feed Preferences"
+msgstr ""
+
+#: src/view/com/auth/login/ForgotPasswordForm.tsx:114
+msgid "Hosting provider"
+msgstr ""
+
+#: src/view/com/auth/create/Step1.tsx:76
+#: src/view/com/auth/create/Step1.tsx:81
+msgid "Hosting provider address"
+msgstr ""
+
+#: src/view/com/modals/VerifyEmail.tsx:208
+msgid "I have a code"
+msgstr ""
+
+#: src/view/com/modals/ChangeHandle.tsx:281
+msgid "I have my own domain"
+msgstr ""
+
+#: src/view/com/modals/SelfLabel.tsx:127
+msgid "If none are selected, suitable for all ages."
+msgstr ""
+
+#: src/view/com/modals/AltImage.tsx:97
+msgid "Image alt text"
+msgstr ""
+
+#: src/view/com/util/UserAvatar.tsx:308
+#: src/view/com/util/UserBanner.tsx:116
+msgid "Image options"
+msgstr ""
+
+#: src/view/com/auth/login/LoginForm.tsx:113
+msgid "Invalid username or password"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:383
+msgid "Invite"
+msgstr ""
+
+#: src/view/com/modals/InviteCodes.tsx:91
+#: src/view/screens/Settings.tsx:371
+msgid "Invite a Friend"
+msgstr ""
+
+#: src/view/com/auth/create/Step2.tsx:57
+msgid "Invite code"
+msgstr ""
+
+#: src/view/com/auth/create/state.ts:136
+msgid "Invite code not accepted. Check that you input it correctly and try again."
+msgstr ""
+
+#: src/view/shell/Drawer.tsx:621
+msgid "Invite codes: {invitesAvailable} available"
+msgstr ""
+
+#: src/view/com/auth/HomeLoggedOutCTA.tsx:99
+msgid "Jobs"
+msgstr ""
+
+#: src/view/com/modals/Waitlist.tsx:67
+msgid "Join the waitlist"
+msgstr ""
+
+#: src/view/com/auth/create/Step2.tsx:68
+#: src/view/com/auth/create/Step2.tsx:72
+msgid "Join the waitlist."
+msgstr ""
+
+#: src/view/com/modals/Waitlist.tsx:124
+msgid "Join Waitlist"
+msgstr ""
+
+#: src/view/com/composer/select-language/SelectLangBtn.tsx:104
+msgid "Language selection"
+msgstr ""
+
+#: src/view/screens/LanguageSettings.tsx:89
+msgid "Language Settings"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:541
+msgid "Languages"
+msgstr ""
+
+#: src/view/com/util/moderation/ContentHider.tsx:101
+msgid "Learn more"
+msgstr ""
+
+#: src/view/com/util/moderation/PostAlerts.tsx:47
+#: src/view/com/util/moderation/ProfileHeaderAlerts.tsx:65
+#: src/view/com/util/moderation/ScreenHider.tsx:104
+msgid "Learn More"
+msgstr ""
+
+#: src/view/com/util/moderation/ContentHider.tsx:83
+#: src/view/com/util/moderation/PostAlerts.tsx:40
+#: src/view/com/util/moderation/PostHider.tsx:76
+#: src/view/com/util/moderation/ProfileHeaderAlerts.tsx:49
+#: src/view/com/util/moderation/ScreenHider.tsx:101
+msgid "Learn more about this warning"
+msgstr ""
+
+#: src/view/screens/Moderation.tsx:242
+msgid "Learn more about what is public on Bluesky."
+msgstr ""
+
+#: src/view/com/modals/lang-settings/ContentLanguagesSettings.tsx:82
+msgid "Leave them all unchecked to see any language."
+msgstr ""
+
+#: src/view/com/modals/LinkWarning.tsx:49
+msgid "Leaving Bluesky"
+msgstr ""
+
+#: src/view/com/auth/login/Login.tsx:128
+#: src/view/com/auth/login/Login.tsx:144
+msgid "Let's get your password reset!"
+msgstr ""
+
+#: src/view/com/util/UserAvatar.tsx:245
+#: src/view/com/util/UserBanner.tsx:60
+msgid "Library"
+msgstr ""
+
+#: src/view/screens/ProfileFeed.tsx:577
+msgid "Like this feed"
+msgstr ""
+
+#: src/view/screens/PostLikedBy.tsx:27
+#: src/view/screens/ProfileFeedLikedBy.tsx:27
+msgid "Liked by"
+msgstr ""
+
+#: src/view/screens/Profile.tsx:164
+msgid "Likes"
+msgstr ""
+
+#: src/view/com/modals/CreateOrEditList.tsx:186
+msgid "List Avatar"
+msgstr ""
+
+#: src/view/com/modals/CreateOrEditList.tsx:199
+msgid "List Name"
+msgstr ""
+
+#: src/view/screens/Profile.tsx:166
+#: src/view/shell/desktop/LeftNav.tsx:377
+#: src/view/shell/Drawer.tsx:471
+#: src/view/shell/Drawer.tsx:472
+msgid "Lists"
+msgstr ""
+
+#: src/view/com/post-thread/PostThread.tsx:260
+#: src/view/com/post-thread/PostThread.tsx:268
+msgid "Load more posts"
+msgstr ""
+
+#: src/view/screens/Notifications.tsx:144
+msgid "Load new notifications"
+msgstr ""
+
+#: src/view/com/feeds/FeedPage.tsx:189
+msgid "Load new posts"
+msgstr ""
+
+#: src/view/com/composer/text-input/mobile/Autocomplete.tsx:95
+msgid "Loading..."
+msgstr ""
+
+#: src/view/com/modals/ServerInput.tsx:50
+msgid "Local dev server"
+msgstr ""
+
+#: src/view/screens/Moderation.tsx:136
+msgid "Logged-out visibility"
+msgstr ""
+
+#: src/view/com/auth/login/ChooseAccountForm.tsx:133
+msgid "Login to account that is not listed"
+msgstr ""
+
+#: src/view/com/modals/LinkWarning.tsx:63
+msgid "Make sure this is where you intend to go!"
+msgstr ""
+
+#: src/view/screens/Profile.tsx:163
+msgid "Media"
+msgstr ""
+
+#: src/view/com/threadgate/WhoCanReply.tsx:139
+msgid "mentioned users"
+msgstr ""
+
+#: src/view/com/modals/Threadgate.tsx:93
+msgid "Mentioned users"
+msgstr ""
+
+#: src/view/screens/Search/Search.tsx:537
+msgid "Menu"
+msgstr ""
+
+#: src/view/com/posts/FeedErrorMessage.tsx:194
+msgid "Message from server"
+msgstr ""
+
+#: src/view/screens/Moderation.tsx:64
+#: src/view/screens/Settings.tsx:563
+#: src/view/shell/desktop/LeftNav.tsx:395
+#: src/view/shell/Drawer.tsx:490
+#: src/view/shell/Drawer.tsx:491
+msgid "Moderation"
+msgstr ""
+
+#: src/view/screens/Moderation.tsx:95
+msgid "Moderation lists"
+msgstr ""
+
+#: src/view/screens/ModerationModlists.tsx:58
+msgid "Moderation Lists"
+msgstr ""
+
+#: src/view/shell/desktop/Feeds.tsx:53
+msgid "More feeds"
+msgstr ""
+
+#: src/view/com/profile/ProfileHeader.tsx:548
+#: src/view/screens/ProfileFeed.tsx:360
+#: src/view/screens/ProfileList.tsx:583
+msgid "More options"
+msgstr ""
+
+#: src/view/com/profile/ProfileHeader.tsx:370
+msgid "Mute Account"
+msgstr ""
+
+#: src/view/screens/ProfileList.tsx:510
+msgid "Mute accounts"
+msgstr ""
+
+#: src/view/screens/ProfileList.tsx:457
+msgid "Mute list"
+msgstr ""
+
+#: src/view/screens/ProfileList.tsx:270
+msgid "Mute these accounts?"
+msgstr ""
+
+#: src/view/com/util/forms/PostDropdownBtn.tsx:149
+msgid "Mute thread"
+msgstr ""
+
+#: src/view/screens/Moderation.tsx:109
+msgid "Muted accounts"
+msgstr ""
+
+#: src/view/screens/ModerationMutedAccounts.tsx:106
+msgid "Muted Accounts"
+msgstr ""
+
+#: src/view/screens/ModerationMutedAccounts.tsx:114
+msgid "Muted accounts have their posts removed from your feed and from your notifications. Mutes are completely private."
+msgstr ""
+
+#: src/view/screens/ProfileList.tsx:272
+msgid "Muting is private. Muted accounts can interact with you, but you will not see their posts or receive notifications from them."
+msgstr ""
+
+#: src/view/com/modals/BirthDateSettings.tsx:56
+msgid "My Birthday"
+msgstr ""
+
+#: src/view/screens/Feeds.tsx:363
+msgid "My Feeds"
+msgstr ""
+
+#: src/view/shell/desktop/LeftNav.tsx:65
+msgid "My Profile"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:520
+msgid "My Saved Feeds"
+msgstr ""
+
+#: src/view/com/modals/AddAppPasswords.tsx:177
+#: src/view/com/modals/CreateOrEditList.tsx:211
+msgid "Name"
+msgstr ""
+
+#: src/view/com/auth/onboarding/WelcomeMobile.tsx:72
+msgid "Never lose access to your followers and data."
+msgstr ""
+
+#: src/view/screens/Lists.tsx:76
+#: src/view/screens/ModerationModlists.tsx:78
+msgid "New"
+msgstr ""
+
+#: src/view/com/feeds/FeedPage.tsx:200
+#: src/view/screens/Feeds.tsx:511
+#: src/view/screens/Profile.tsx:354
+#: src/view/screens/ProfileFeed.tsx:430
+#: src/view/screens/ProfileList.tsx:193
+#: src/view/screens/ProfileList.tsx:221
+#: src/view/shell/desktop/LeftNav.tsx:247
+msgid "New post"
+msgstr ""
+
+#: src/view/shell/desktop/LeftNav.tsx:257
+msgid "New Post"
+msgstr ""
+
+#: src/view/com/auth/create/CreateAccount.tsx:154
+#: src/view/com/auth/login/ForgotPasswordForm.tsx:174
+#: src/view/com/auth/login/ForgotPasswordForm.tsx:184
+#: src/view/com/auth/login/LoginForm.tsx:281
+#: src/view/com/auth/login/SetNewPasswordForm.tsx:156
+#: src/view/com/auth/login/SetNewPasswordForm.tsx:166
+#: src/view/com/auth/onboarding/RecommendedFeeds.tsx:79
+msgid "Next"
+msgstr ""
+
+#: src/view/com/lightbox/Lightbox.web.tsx:142
+msgid "Next image"
+msgstr ""
+
+#: src/view/screens/PreferencesHomeFeed.tsx:191
+#: src/view/screens/PreferencesHomeFeed.tsx:226
+#: src/view/screens/PreferencesHomeFeed.tsx:263
+msgid "No"
+msgstr ""
+
+#: src/view/screens/ProfileFeed.tsx:570
+#: src/view/screens/ProfileList.tsx:711
+msgid "No description"
+msgstr ""
+
+#: src/view/com/composer/text-input/mobile/Autocomplete.tsx:97
+msgid "No result"
+msgstr ""
+
+#: src/view/screens/Feeds.tsx:452
+msgid "No results found for \"{query}\""
+msgstr ""
+
+#: src/view/com/modals/ListAddRemoveUsers.tsx:127
+#: src/view/screens/Search/Search.tsx:271
+#: src/view/screens/Search/Search.tsx:299
+#: src/view/screens/Search/Search.tsx:615
+#: src/view/shell/desktop/Search.tsx:210
+msgid "No results found for {query}"
+msgstr ""
+
+#: src/view/com/modals/Threadgate.tsx:82
+msgid "Nobody"
+msgstr ""
+
+#: src/view/com/modals/SelfLabel.tsx:135
+msgid "Not Applicable."
+msgstr ""
+
+#: src/view/screens/Moderation.tsx:232
+msgid "Note: Bluesky is an open and public network. This setting only limits the visibility of your content on the Bluesky app and website, and other apps may not respect this setting. Your content may still be shown to logged-out users by other apps and websites."
+msgstr ""
+
+#: src/view/screens/Notifications.tsx:109
+#: src/view/screens/Notifications.tsx:133
+#: src/view/shell/bottom-bar/BottomBar.tsx:205
+#: src/view/shell/desktop/LeftNav.tsx:359
+#: src/view/shell/Drawer.tsx:416
+#: src/view/shell/Drawer.tsx:417
+msgid "Notifications"
+msgstr ""
+
+#: src/view/com/util/ErrorBoundary.tsx:34
+msgid "Oh no!"
+msgstr ""
+
+#: src/view/com/auth/login/PasswordUpdatedForm.tsx:41
+msgid "Okay"
+msgstr ""
+
+#: src/view/com/composer/Composer.tsx:354
+msgid "One or more images is missing alt text."
+msgstr ""
+
+#: src/view/com/threadgate/WhoCanReply.tsx:100
+msgid "Only {0} can reply."
+msgstr ""
+
+#: src/view/com/pager/FeedsTabBarMobile.tsx:76
+msgid "Open navigation"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:533
+msgid "Opens configurable language settings"
+msgstr ""
+
+#: src/view/shell/desktop/RightNav.tsx:148
+#: src/view/shell/Drawer.tsx:622
+msgid "Opens list of invite codes"
+msgstr ""
+
+#: src/view/com/modals/ChangeHandle.tsx:279
+msgid "Opens modal for using custom domain"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:558
+msgid "Opens moderation settings"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:514
+msgid "Opens screen with all saved feeds"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:581
+msgid "Opens the app password settings page"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:473
+msgid "Opens the home feed preferences"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:664
+msgid "Opens the storybook page"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:644
+msgid "Opens the system log page"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:494
+msgid "Opens the threads preferences"
+msgstr ""
+
+#: src/view/com/auth/login/ChooseAccountForm.tsx:138
+msgid "Other account"
+msgstr ""
+
+#: src/view/com/modals/ServerInput.tsx:88
+msgid "Other service"
+msgstr ""
+
+#: src/view/com/composer/select-language/SelectLangBtn.tsx:91
+msgid "Other..."
+msgstr ""
+
+#: src/view/screens/NotFound.tsx:42
+#: src/view/screens/NotFound.tsx:45
+msgid "Page not found"
+msgstr ""
+
+#: src/view/com/auth/create/Step2.tsx:101
+#: src/view/com/auth/create/Step2.tsx:111
+#: src/view/com/auth/login/LoginForm.tsx:216
+#: src/view/com/auth/login/SetNewPasswordForm.tsx:130
+#: src/view/com/modals/DeleteAccount.tsx:191
+msgid "Password"
+msgstr ""
+
+#: src/view/com/auth/login/Login.tsx:157
+msgid "Password updated"
+msgstr ""
+
+#: src/view/com/auth/login/PasswordUpdatedForm.tsx:28
+msgid "Password updated!"
+msgstr ""
+
+#: src/view/com/modals/SelfLabel.tsx:121
+msgid "Pictures meant for adults."
+msgstr ""
+
+#: src/view/screens/SavedFeeds.tsx:88
+msgid "Pinned Feeds"
+msgstr ""
+
+#: src/view/com/auth/create/state.ts:116
+msgid "Please choose your handle."
+msgstr ""
+
+#: src/view/com/auth/create/state.ts:109
+msgid "Please choose your password."
+msgstr ""
+
+#: src/view/com/modals/ChangeEmail.tsx:67
+msgid "Please confirm your email before changing it. This is a temporary requirement while email-updating tools are added, and it will soon be removed."
+msgstr ""
+
+#: src/view/com/modals/AddAppPasswords.tsx:140
+msgid "Please enter a unique name for this App Password or use our randomly generated one."
+msgstr ""
+
+#: src/view/com/auth/create/state.ts:95
+msgid "Please enter your email."
+msgstr ""
+
+#: src/view/com/modals/DeleteAccount.tsx:180
+msgid "Please enter your password as well:"
+msgstr ""
+
+#: src/view/com/modals/AppealLabel.tsx:72
+#: src/view/com/modals/AppealLabel.tsx:75
+msgid "Please tell us why you think this content warning was incorrectly applied!"
+msgstr ""
+
+#: src/view/com/composer/Composer.tsx:337
+#: src/view/com/post-thread/PostThread.tsx:226
+#: src/view/screens/PostThread.tsx:80
+msgid "Post"
+msgstr ""
+
+#: src/view/com/post-thread/PostThread.tsx:385
+msgid "Post hidden"
+msgstr ""
+
+#: src/view/com/composer/select-language/SelectLangBtn.tsx:87
+msgid "Post language"
+msgstr ""
+
+#: src/view/com/modals/lang-settings/PostLanguagesSettings.tsx:75
+msgid "Post Languages"
+msgstr ""
+
+#: src/view/com/post-thread/PostThread.tsx:437
+msgid "Post not found"
+msgstr ""
+
+#: src/view/screens/Profile.tsx:161
+msgid "Posts"
+msgstr ""
+
+#: src/view/com/modals/LinkWarning.tsx:44
+msgid "Potentially Misleading Link"
+msgstr ""
+
+#: src/view/com/lightbox/Lightbox.web.tsx:128
+msgid "Previous image"
+msgstr ""
+
+#: src/view/screens/LanguageSettings.tsx:187
+msgid "Primary Language"
+msgstr ""
+
+#: src/view/screens/PreferencesThreads.tsx:91
+msgid "Prioritize Your Follows"
+msgstr ""
+
+#: src/view/shell/desktop/RightNav.tsx:76
+msgid "Privacy"
+msgstr ""
+
+#: src/view/screens/PrivacyPolicy.tsx:29
+msgid "Privacy Policy"
+msgstr ""
+
+#: src/view/com/auth/login/ForgotPasswordForm.tsx:190
+msgid "Processing..."
+msgstr ""
+
+#: src/view/shell/bottom-bar/BottomBar.tsx:247
+#: src/view/shell/desktop/LeftNav.tsx:413
+#: src/view/shell/Drawer.tsx:69
+#: src/view/shell/Drawer.tsx:525
+#: src/view/shell/Drawer.tsx:526
+msgid "Profile"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:789
+msgid "Protect your account by verifying your email."
+msgstr ""
+
+#: src/view/screens/ModerationModlists.tsx:61
+msgid "Public, shareable lists of users to mute or block in bulk."
+msgstr ""
+
+#: src/view/screens/Lists.tsx:61
+msgid "Public, shareable lists which can drive feeds."
+msgstr ""
+
+#: src/view/com/modals/Repost.tsx:52
+#: src/view/com/util/post-ctrls/RepostButton.web.tsx:58
+msgid "Quote post"
+msgstr ""
+
+#: src/view/com/modals/Repost.tsx:56
+msgid "Quote Post"
+msgstr ""
+
+#: src/view/com/modals/EditImage.tsx:236
+msgid "Ratios"
+msgstr ""
+
+#: src/view/com/auth/onboarding/RecommendedFeeds.tsx:116
+msgid "Recommended Feeds"
+msgstr ""
+
+#: src/view/com/auth/onboarding/RecommendedFollows.tsx:180
+msgid "Recommended Users"
+msgstr ""
+
+#: src/view/com/modals/ListAddRemoveUsers.tsx:264
+#: src/view/com/modals/SelfLabel.tsx:83
+#: src/view/com/modals/UserAddRemoveLists.tsx:193
+#: src/view/com/util/UserAvatar.tsx:282
+#: src/view/com/util/UserBanner.tsx:89
+msgid "Remove"
+msgstr ""
+
+#: src/view/com/feeds/FeedSourceCard.tsx:106
+msgid "Remove {0} from my feeds?"
+msgstr ""
+
+#: src/view/com/util/AccountDropdownBtn.tsx:22
+msgid "Remove account"
+msgstr ""
+
+#: src/view/com/posts/FeedErrorMessage.tsx:130
+msgid "Remove feed"
+msgstr ""
+
+#: src/view/com/feeds/FeedSourceCard.tsx:105
+#: src/view/com/feeds/FeedSourceCard.tsx:172
+#: src/view/screens/ProfileFeed.tsx:270
+msgid "Remove from my feeds"
+msgstr ""
+
+#: src/view/com/composer/photos/Gallery.tsx:167
+msgid "Remove image"
+msgstr ""
+
+#: src/view/com/composer/ExternalEmbed.tsx:70
+msgid "Remove image preview"
+msgstr ""
+
+#: src/view/com/feeds/FeedSourceCard.tsx:173
+msgid "Remove this feed from my feeds?"
+msgstr ""
+
+#: src/view/com/posts/FeedErrorMessage.tsx:131
+msgid "Remove this feed from your saved feeds?"
+msgstr ""
+
+#: src/view/com/modals/ListAddRemoveUsers.tsx:199
+#: src/view/com/modals/UserAddRemoveLists.tsx:136
+msgid "Removed from list"
+msgstr ""
+
+#: src/view/screens/Profile.tsx:162
+msgid "Replies"
+msgstr ""
+
+#: src/view/com/threadgate/WhoCanReply.tsx:98
+msgid "Replies to this thread are disabled"
+msgstr ""
+
+#: src/view/screens/PreferencesHomeFeed.tsx:135
+msgid "Reply Filters"
+msgstr ""
+
+#: src/view/com/modals/report/Modal.tsx:166
+msgid "Report {collectionName}"
+msgstr ""
+
+#: src/view/com/profile/ProfileHeader.tsx:404
+msgid "Report Account"
+msgstr ""
+
+#: src/view/screens/ProfileFeed.tsx:290
+msgid "Report feed"
+msgstr ""
+
+#: src/view/screens/ProfileList.tsx:425
+msgid "Report List"
+msgstr ""
+
+#: src/view/com/modals/report/SendReportButton.tsx:37
+#: src/view/com/util/forms/PostDropdownBtn.tsx:167
+msgid "Report post"
+msgstr ""
+
+#: src/view/com/util/post-ctrls/RepostButton.web.tsx:48
+msgid "Repost"
+msgstr ""
+
+#: src/view/com/util/post-ctrls/RepostButton.web.tsx:94
+#: src/view/com/util/post-ctrls/RepostButton.web.tsx:105
+msgid "Repost or quote post"
+msgstr ""
+
+#: src/view/screens/PostRepostedBy.tsx:27
+msgid "Reposted by"
+msgstr ""
+
+#: src/view/com/modals/ChangeEmail.tsx:181
+#: src/view/com/modals/ChangeEmail.tsx:183
+msgid "Request Change"
+msgstr ""
+
+#: src/view/com/auth/create/Step2.tsx:53
+msgid "Required for this provider"
+msgstr ""
+
+#: src/view/com/auth/login/SetNewPasswordForm.tsx:108
+msgid "Reset code"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:686
+msgid "Reset onboarding state"
+msgstr ""
+
+#: src/view/com/auth/login/ForgotPasswordForm.tsx:98
+msgid "Reset password"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:676
+msgid "Reset preferences state"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:684
+msgid "Resets the onboarding state"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:674
+msgid "Resets the preferences state"
+msgstr ""
+
+#: src/view/com/auth/create/CreateAccount.tsx:163
+#: src/view/com/auth/create/CreateAccount.tsx:167
+#: src/view/com/auth/login/LoginForm.tsx:258
+#: src/view/com/auth/login/LoginForm.tsx:261
+#: src/view/com/util/error/ErrorMessage.tsx:55
+#: src/view/com/util/error/ErrorScreen.tsx:65
+msgid "Retry"
+msgstr ""
+
+#: src/view/com/modals/AltImage.tsx:115
+#: src/view/com/modals/BirthDateSettings.tsx:93
+#: src/view/com/modals/BirthDateSettings.tsx:96
+#: src/view/com/modals/ChangeHandle.tsx:173
+#: src/view/com/modals/CreateOrEditList.tsx:249
+#: src/view/com/modals/CreateOrEditList.tsx:257
+#: src/view/com/modals/EditProfile.tsx:223
+msgid "Save"
+msgstr ""
+
+#: src/view/com/modals/AltImage.tsx:106
+msgid "Save alt text"
+msgstr ""
+
+#: src/view/com/modals/EditProfile.tsx:231
+msgid "Save Changes"
+msgstr ""
+
+#: src/view/com/modals/ChangeHandle.tsx:170
+msgid "Save handle change"
+msgstr ""
+
+#: src/view/com/modals/crop-image/CropImage.web.tsx:144
+msgid "Save image crop"
+msgstr ""
+
+#: src/view/screens/SavedFeeds.tsx:122
+msgid "Saved Feeds"
+msgstr ""
+
+#: src/view/com/modals/ListAddRemoveUsers.tsx:75
+#: src/view/com/util/forms/SearchInput.tsx:64
+#: src/view/screens/Search/Search.tsx:401
+#: src/view/screens/Search/Search.tsx:567
+#: src/view/shell/bottom-bar/BottomBar.tsx:159
+#: src/view/shell/desktop/LeftNav.tsx:322
+#: src/view/shell/desktop/Search.tsx:161
+#: src/view/shell/desktop/Search.tsx:170
+#: src/view/shell/Drawer.tsx:343
+#: src/view/shell/Drawer.tsx:344
+msgid "Search"
+msgstr ""
+
+#: src/view/com/auth/LoggedOut.tsx:104
+#: src/view/com/auth/LoggedOut.tsx:105
+msgid "Search for users"
+msgstr ""
+
+#: src/view/com/modals/ChangeEmail.tsx:110
+msgid "Security Step Required"
+msgstr ""
+
+#: src/view/com/auth/HomeLoggedOutCTA.tsx:39
+msgid "See what's next"
+msgstr ""
+
+#: src/view/com/modals/ServerInput.tsx:75
+msgid "Select Bluesky Social"
+msgstr ""
+
+#: src/view/com/auth/login/Login.tsx:117
+msgid "Select from an existing account"
+msgstr ""
+
+#: src/view/com/auth/login/LoginForm.tsx:143
+msgid "Select service"
+msgstr ""
+
+#: src/view/screens/LanguageSettings.tsx:281
+msgid "Select which languages you want your subscribed feeds to include. If none are selected, all languages will be shown."
+msgstr ""
+
+#: src/view/screens/LanguageSettings.tsx:98
+msgid "Select your app language for the default text to display in the app"
+msgstr ""
+
+#: src/view/screens/LanguageSettings.tsx:190
+msgid "Select your preferred language for translations in your feed."
+msgstr ""
+
+#: src/view/com/modals/VerifyEmail.tsx:196
+msgid "Send Confirmation Email"
+msgstr ""
+
+#: src/view/com/modals/DeleteAccount.tsx:127
+msgid "Send email"
+msgstr ""
+
+#: src/view/com/modals/DeleteAccount.tsx:138
+msgid "Send Email"
+msgstr ""
+
+#: src/view/shell/Drawer.tsx:276
+#: src/view/shell/Drawer.tsx:297
+msgid "Send feedback"
+msgstr ""
+
+#: src/view/com/modals/report/SendReportButton.tsx:45
+msgid "Send Report"
+msgstr ""
+
+#: src/view/com/auth/login/SetNewPasswordForm.tsx:78
+msgid "Set new password"
+msgstr ""
+
+#: src/view/screens/PreferencesHomeFeed.tsx:216
+msgid "Set this setting to \"No\" to hide all quote posts from your feed. Reposts will still be visible."
+msgstr ""
+
+#: src/view/screens/PreferencesHomeFeed.tsx:113
+msgid "Set this setting to \"No\" to hide all replies from your feed."
+msgstr ""
+
+#: src/view/screens/PreferencesHomeFeed.tsx:182
+msgid "Set this setting to \"No\" to hide all reposts from your feed."
+msgstr ""
+
+#: src/view/screens/PreferencesThreads.tsx:116
+msgid "Set this setting to \"Yes\" to show replies in a threaded view. This is an experimental feature."
+msgstr ""
+
+#: src/view/screens/PreferencesHomeFeed.tsx:252
+msgid "Set this setting to \"Yes\" to show samples of your saved feeds in your following feed. This is an experimental feature."
+msgstr ""
+
+#: src/view/screens/Settings.tsx:277
+#: src/view/shell/desktop/LeftNav.tsx:431
+#: src/view/shell/Drawer.tsx:546
+#: src/view/shell/Drawer.tsx:547
+msgid "Settings"
+msgstr ""
+
+#: src/view/com/modals/SelfLabel.tsx:125
+msgid "Sexual activity or erotic nudity."
+msgstr ""
+
+#: src/view/com/profile/ProfileHeader.tsx:338
+#: src/view/com/util/forms/PostDropdownBtn.tsx:131
+#: src/view/screens/ProfileList.tsx:384
+msgid "Share"
+msgstr ""
+
+#: src/view/screens/ProfileFeed.tsx:302
+msgid "Share feed"
+msgstr ""
+
+#: src/view/com/util/moderation/ContentHider.tsx:105
+#: src/view/screens/Settings.tsx:316
+msgid "Show"
+msgstr ""
+
+#: src/view/com/util/moderation/ScreenHider.tsx:132
+msgid "Show anyway"
+msgstr ""
+
+#: src/view/screens/PreferencesHomeFeed.tsx:249
+msgid "Show Posts from My Feeds"
+msgstr ""
+
+#: src/view/screens/PreferencesHomeFeed.tsx:213
+msgid "Show Quote Posts"
+msgstr ""
+
+#: src/view/screens/PreferencesHomeFeed.tsx:110
+msgid "Show Replies"
+msgstr ""
+
+#: src/view/screens/PreferencesThreads.tsx:94
+msgid "Show replies by people you follow before all other replies."
+msgstr ""
+
+#: src/view/screens/PreferencesHomeFeed.tsx:179
+msgid "Show Reposts"
+msgstr ""
+
+#: src/view/com/notifications/FeedItem.tsx:337
+msgid "Show users"
+msgstr ""
+
+#: src/view/com/auth/HomeLoggedOutCTA.tsx:70
+#: src/view/com/auth/login/Login.tsx:98
+#: src/view/com/auth/SplashScreen.tsx:54
+#: src/view/shell/bottom-bar/BottomBar.tsx:285
+#: src/view/shell/bottom-bar/BottomBar.tsx:286
+#: src/view/shell/bottom-bar/BottomBar.tsx:288
+#: src/view/shell/bottom-bar/BottomBarWeb.tsx:177
+#: src/view/shell/bottom-bar/BottomBarWeb.tsx:178
+#: src/view/shell/bottom-bar/BottomBarWeb.tsx:180
+#: src/view/shell/NavSignupCard.tsx:58
+#: src/view/shell/NavSignupCard.tsx:59
+msgid "Sign in"
+msgstr ""
+
+#: src/view/com/auth/HomeLoggedOutCTA.tsx:78
+#: src/view/com/auth/SplashScreen.tsx:57
+#: src/view/com/auth/SplashScreen.web.tsx:87
+msgid "Sign In"
+msgstr ""
+
+#: src/view/com/auth/login/ChooseAccountForm.tsx:44
+msgid "Sign in as {0}"
+msgstr ""
+
+#: src/view/com/auth/login/ChooseAccountForm.tsx:118
+#: src/view/com/auth/login/Login.tsx:116
+msgid "Sign in as..."
+msgstr ""
+
+#: src/view/com/auth/login/LoginForm.tsx:130
+msgid "Sign into"
+msgstr ""
+
+#: src/view/com/modals/SwitchAccount.tsx:64
+#: src/view/com/modals/SwitchAccount.tsx:67
+msgid "Sign out"
+msgstr ""
+
+#: src/view/shell/bottom-bar/BottomBar.tsx:275
+#: src/view/shell/bottom-bar/BottomBar.tsx:276
+#: src/view/shell/bottom-bar/BottomBar.tsx:278
+#: src/view/shell/bottom-bar/BottomBarWeb.tsx:167
+#: src/view/shell/bottom-bar/BottomBarWeb.tsx:168
+#: src/view/shell/bottom-bar/BottomBarWeb.tsx:170
+#: src/view/shell/NavSignupCard.tsx:49
+#: src/view/shell/NavSignupCard.tsx:50
+#: src/view/shell/NavSignupCard.tsx:52
+msgid "Sign up"
+msgstr ""
+
+#: src/view/shell/NavSignupCard.tsx:42
+msgid "Sign up or sign in to join the conversation"
+msgstr ""
+
+#: src/view/com/util/moderation/ScreenHider.tsx:76
+msgid "Sign-in Required"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:327
+msgid "Signed in as"
+msgstr ""
+
+#: src/view/com/auth/onboarding/WelcomeMobile.tsx:33
+msgid "Skip"
+msgstr ""
+
+#: src/view/screens/PreferencesThreads.tsx:69
+msgid "Sort Replies"
+msgstr ""
+
+#: src/view/screens/PreferencesThreads.tsx:72
+msgid "Sort replies to the same post by:"
+msgstr ""
+
+#: src/view/com/modals/crop-image/CropImage.web.tsx:122
+msgid "Square"
+msgstr ""
+
+#: src/view/com/auth/create/Step1.tsx:90
+#: src/view/com/modals/ServerInput.tsx:62
+msgid "Staging"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:730
+msgid "Status page"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:666
+msgid "Storybook"
+msgstr ""
+
+#: src/view/com/modals/AppealLabel.tsx:101
+msgid "Submit"
+msgstr ""
+
+#: src/view/screens/ProfileList.tsx:574
+msgid "Subscribe"
+msgstr ""
+
+#: src/view/screens/ProfileList.tsx:570
+msgid "Subscribe to this list"
+msgstr ""
+
+#: src/view/screens/Search/Search.tsx:357
+msgid "Suggested Follows"
+msgstr ""
+
+#: src/view/screens/Support.tsx:30
+#: src/view/screens/Support.tsx:33
+msgid "Support"
+msgstr ""
+
+#: src/view/com/modals/SwitchAccount.tsx:115
+msgid "Switch Account"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:646
+msgid "System log"
+msgstr ""
+
+#: src/view/com/modals/crop-image/CropImage.web.tsx:112
+msgid "Tall"
+msgstr ""
+
+#: src/view/shell/desktop/RightNav.tsx:85
+msgid "Terms"
+msgstr ""
+
+#: src/view/screens/TermsOfService.tsx:29
+msgid "Terms of Service"
+msgstr ""
+
+#: src/view/com/modals/AppealLabel.tsx:70
+#: src/view/com/modals/report/InputIssueDetails.tsx:50
+msgid "Text input field"
+msgstr ""
+
+#: src/view/com/profile/ProfileHeader.tsx:306
+msgid "The account will be able to interact with you after unblocking."
+msgstr ""
+
+#: src/view/screens/CommunityGuidelines.tsx:36
+msgid "The Community Guidelines have been moved to <0/>"
+msgstr ""
+
+#: src/view/screens/CopyrightPolicy.tsx:33
+msgid "The Copyright Policy has been moved to <0/>"
+msgstr ""
+
+#: src/view/com/post-thread/PostThread.tsx:440
+msgid "The post may have been deleted."
+msgstr ""
+
+#: src/view/screens/PrivacyPolicy.tsx:33
+msgid "The Privacy Policy has been moved to <0/>"
+msgstr ""
+
+#: src/view/screens/Support.tsx:36
+msgid "The support form has been moved. If you need help, please<0/> or visit {HELP_DESK_URL} to get in touch with us."
+msgstr ""
+
+#: src/view/screens/TermsOfService.tsx:33
+msgid "The Terms of Service have been moved to"
+msgstr ""
+
+#: src/view/com/util/ErrorBoundary.tsx:35
+msgid "There was an unexpected issue in the application. Please let us know if this happened to you!"
+msgstr ""
+
+#: src/view/com/util/moderation/ScreenHider.tsx:88
+msgid "This {screenDescription} has been flagged:"
+msgstr ""
+
+#: src/view/com/util/moderation/ScreenHider.tsx:83
+msgid "This account has requested that users sign in to view their profile."
+msgstr ""
+
+#: src/view/com/posts/FeedErrorMessage.tsx:107
+msgid "This content is not viewable without a Bluesky account."
+msgstr ""
+
+#: src/view/com/posts/FeedErrorMessage.tsx:113
+msgid "This feed is currently receiving high traffic and is temporarily unavailable. Please try again later."
+msgstr ""
+
+#: src/view/com/modals/BirthDateSettings.tsx:61
+msgid "This information is not shared with other users."
+msgstr ""
+
+#: src/view/com/modals/VerifyEmail.tsx:113
+msgid "This is important in case you ever need to change your email or reset your password."
+msgstr ""
+
+#: src/view/com/auth/create/Step1.tsx:55
+msgid "This is the service that keeps you online."
+msgstr ""
+
+#: src/view/com/modals/LinkWarning.tsx:56
+msgid "This link is taking you to the following website:"
+msgstr ""
+
+#: src/view/com/post-thread/PostThreadItem.tsx:123
+msgid "This post has been deleted."
+msgstr ""
+
+#: src/view/com/modals/SelfLabel.tsx:137
+msgid "This warning is only available for posts with media attached."
+msgstr ""
+
+#: src/view/screens/PreferencesThreads.tsx:53
+#: src/view/screens/Settings.tsx:503
+msgid "Thread Preferences"
+msgstr ""
+
+#: src/view/screens/PreferencesThreads.tsx:113
+msgid "Threaded Mode"
+msgstr ""
+
+#: src/view/com/util/forms/DropdownButton.tsx:230
+msgid "Toggle dropdown"
+msgstr ""
+
+#: src/view/com/modals/EditImage.tsx:271
+msgid "Transformations"
+msgstr ""
+
+#: src/view/com/post-thread/PostThreadItem.tsx:704
+#: src/view/com/post-thread/PostThreadItem.tsx:706
+#: src/view/com/util/forms/PostDropdownBtn.tsx:103
+msgid "Translate"
+msgstr ""
+
+#: src/view/com/util/error/ErrorScreen.tsx:73
+msgid "Try again"
+msgstr ""
+
+#: src/view/screens/ProfileList.tsx:472
+msgid "Un-block list"
+msgstr ""
+
+#: src/view/screens/ProfileList.tsx:457
+msgid "Un-mute list"
+msgstr ""
+
+#: src/view/com/auth/create/CreateAccount.tsx:64
+#: src/view/com/auth/login/Login.tsx:76
+#: src/view/com/auth/login/LoginForm.tsx:117
+msgid "Unable to contact your service. Please check your Internet connection."
+msgstr ""
+
+#: src/view/com/profile/ProfileHeader.tsx:466
+#: src/view/com/profile/ProfileHeader.tsx:469
+msgid "Unblock"
+msgstr ""
+
+#: src/view/com/profile/ProfileHeader.tsx:304
+#: src/view/com/profile/ProfileHeader.tsx:388
+msgid "Unblock Account"
+msgstr ""
+
+#: src/view/com/util/post-ctrls/RepostButton.web.tsx:48
+msgid "Undo repost"
+msgstr ""
+
+#: src/view/com/auth/create/state.ts:210
+msgid "Unfortunately, you do not meet the requirements to create an account."
+msgstr ""
+
+#: src/view/com/profile/ProfileHeader.tsx:369
+msgid "Unmute Account"
+msgstr ""
+
+#: src/view/com/util/forms/PostDropdownBtn.tsx:149
+msgid "Unmute thread"
+msgstr ""
+
+#: src/view/screens/ProfileList.tsx:440
+msgid "Unpin moderation list"
+msgstr ""
+
+#: src/view/com/modals/UserAddRemoveLists.tsx:54
+msgid "Update {displayName} in Lists"
+msgstr ""
+
+#: src/lib/hooks/useOTAUpdate.ts:15
+msgid "Update Available"
+msgstr ""
+
+#: src/view/com/auth/login/SetNewPasswordForm.tsx:172
+msgid "Updating..."
+msgstr ""
+
+#: src/view/com/modals/ChangeHandle.tsx:453
+msgid "Upload a text file to:"
+msgstr ""
+
+#: src/view/screens/AppPasswords.tsx:194
+msgid "Use app passwords to login to other Bluesky clients without giving full access to your account or password."
+msgstr ""
+
+#: src/view/com/modals/ChangeHandle.tsx:513
+msgid "Use default provider"
+msgstr ""
+
+#: src/view/com/modals/AddAppPasswords.tsx:150
+msgid "Use this to sign into the other app along with your handle."
+msgstr ""
+
+#: src/view/com/modals/InviteCodes.tsx:197
+msgid "Used by:"
+msgstr ""
+
+#: src/view/com/auth/create/Step3.tsx:38
+msgid "User handle"
+msgstr ""
+
+#: src/view/screens/Lists.tsx:58
+msgid "User Lists"
+msgstr ""
+
+#: src/view/com/auth/login/LoginForm.tsx:170
+#: src/view/com/auth/login/LoginForm.tsx:187
+msgid "Username or email address"
+msgstr ""
+
+#: src/view/screens/ProfileList.tsx:738
+msgid "Users"
+msgstr ""
+
+#: src/view/com/threadgate/WhoCanReply.tsx:143
+msgid "users followed by <0/>"
+msgstr ""
+
+#: src/view/com/modals/Threadgate.tsx:106
+msgid "Users in \"{0}\""
+msgstr ""
+
+#: src/view/screens/Settings.tsx:750
+msgid "Verify email"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:775
+msgid "Verify my email"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:784
+msgid "Verify My Email"
+msgstr ""
+
+#: src/view/com/modals/ChangeEmail.tsx:205
+#: src/view/com/modals/ChangeEmail.tsx:207
+msgid "Verify New Email"
+msgstr ""
+
+#: src/view/screens/Log.tsx:52
+msgid "View debug entry"
+msgstr ""
+
+#: src/view/com/profile/ProfileSubpageHeader.tsx:128
+msgid "View the avatar"
+msgstr ""
+
+#: src/view/com/modals/LinkWarning.tsx:73
+msgid "Visit Site"
+msgstr ""
+
+#: src/view/com/auth/create/CreateAccount.tsx:121
+msgid "We're so excited to have you join us!"
+msgstr ""
+
+#: src/view/screens/Search/Search.tsx:238
+msgid "We're sorry, but your search could not be completed. Please try again in a few minutes."
+msgstr ""
+
+#: src/view/screens/NotFound.tsx:48
+msgid "We're sorry! We can't find the page you were looking for."
+msgstr ""
+
+#: src/view/com/auth/onboarding/WelcomeMobile.tsx:46
+msgid "Welcome to <0>Bluesky</0>"
+msgstr ""
+
+#: src/view/com/modals/report/Modal.tsx:169
+msgid "What is the issue with this {collectionName}?"
+msgstr ""
+
+#: src/view/com/auth/SplashScreen.tsx:34
+msgid "What's up?"
+msgstr ""
+
+#: src/view/com/modals/lang-settings/PostLanguagesSettings.tsx:78
+msgid "Which languages are used in this post?"
+msgstr ""
+
+#: src/view/com/modals/lang-settings/ContentLanguagesSettings.tsx:77
+msgid "Which languages would you like to see in your algorithmic feeds?"
+msgstr ""
+
+#: src/view/com/composer/threadgate/ThreadgateBtn.tsx:47
+#: src/view/com/modals/Threadgate.tsx:66
+msgid "Who can reply"
+msgstr ""
+
+#: src/view/com/modals/crop-image/CropImage.web.tsx:102
+msgid "Wide"
+msgstr ""
+
+#: src/view/com/composer/Composer.tsx:409
+msgid "Write post"
+msgstr ""
+
+#: src/view/com/composer/Prompt.tsx:33
+msgid "Write your reply"
+msgstr ""
+
+#: src/view/screens/PreferencesHomeFeed.tsx:192
+#: src/view/screens/PreferencesHomeFeed.tsx:227
+#: src/view/screens/PreferencesHomeFeed.tsx:262
+msgid "Yes"
+msgstr ""
+
+#: src/view/com/auth/create/Step1.tsx:106
+msgid "You can change hosting providers at any time."
+msgstr ""
+
+#: src/view/com/auth/login/Login.tsx:158
+#: src/view/com/auth/login/PasswordUpdatedForm.tsx:31
+msgid "You can now sign in with your new password."
+msgstr ""
+
+#: src/view/com/modals/InviteCodes.tsx:64
+msgid "You don't have any invite codes yet! We'll send you some when you've been on Bluesky for a little longer."
+msgstr ""
+
+#: src/view/screens/SavedFeeds.tsx:102
+msgid "You don't have any pinned feeds."
+msgstr ""
+
+#: src/view/screens/Feeds.tsx:383
+msgid "You don't have any saved feeds!"
+msgstr ""
+
+#: src/view/screens/SavedFeeds.tsx:135
+msgid "You don't have any saved feeds."
+msgstr ""
+
+#: src/view/com/post-thread/PostThread.tsx:388
+msgid "You have blocked the author or you have been blocked by the author."
+msgstr ""
+
+#: src/view/com/feeds/ProfileFeedgens.tsx:141
+msgid "You have no feeds."
+msgstr ""
+
+#: src/view/com/lists/MyLists.tsx:89
+#: src/view/com/lists/ProfileLists.tsx:145
+msgid "You have no lists."
+msgstr ""
+
+#: src/view/screens/ModerationBlockedAccounts.tsx:131
+msgid "You have not blocked any accounts yet. To block an account, go to their profile and selected \"Block account\" from the menu on their account."
+msgstr ""
+
+#: src/view/screens/AppPasswords.tsx:86
+msgid "You have not created any app passwords yet. You can create one by pressing the button below."
+msgstr ""
+
+#: src/view/screens/ModerationMutedAccounts.tsx:130
+msgid "You have not muted any accounts yet. To mute an account, go to their profile and selected \"Mute account\" from the menu on their account."
+msgstr ""
+
+#: src/view/com/auth/login/SetNewPasswordForm.tsx:81
+msgid "You will receive an email with a \"reset code.\" Enter that code here, then enter your new password."
+msgstr ""
+
+#: src/view/com/auth/create/Step2.tsx:43
+msgid "Your account"
+msgstr ""
+
+#: src/view/com/auth/create/Step2.tsx:122
+msgid "Your birth date"
+msgstr ""
+
+#: src/view/com/auth/create/state.ts:102
+msgid "Your email appears to be invalid."
+msgstr ""
+
+#: src/view/com/modals/Waitlist.tsx:107
+msgid "Your email has been saved! We'll be in touch soon."
+msgstr ""
+
+#: src/view/com/modals/ChangeEmail.tsx:125
+msgid "Your email has been updated but not verified. As a next step, please verify your new email."
+msgstr ""
+
+#: src/view/com/modals/VerifyEmail.tsx:108
+msgid "Your email has not yet been verified. This is an important security step which we recommend."
+msgstr ""
+
+#: src/view/com/auth/create/Step3.tsx:42
+#: src/view/com/modals/ChangeHandle.tsx:270
+msgid "Your full handle will be"
+msgstr ""
+
+#: src/view/com/auth/create/Step1.tsx:53
+msgid "Your hosting provider"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:402
+#: src/view/shell/desktop/RightNav.tsx:129
+#: src/view/shell/Drawer.tsx:636
+msgid "Your invite codes are hidden when logged in using an App Password"
+msgstr ""
+
+#: src/view/com/auth/onboarding/WelcomeMobile.tsx:59
+msgid "Your posts, likes, and blocks are public. Mutes are private."
+msgstr ""
+
+#: src/view/com/modals/SwitchAccount.tsx:82
+msgid "Your profile"
+msgstr ""
+
+#: src/view/com/auth/create/Step3.tsx:28
+msgid "Your user handle"
+msgstr ""

--- a/src/locale/locales/de/messages.po
+++ b/src/locale/locales/de/messages.po
@@ -55,6 +55,10 @@ msgstr "<0>Wählen Sie Ihre</0><1>Empfohlenes</1><2>Feeds</2>"
 msgid "<0>Follow some</0><1>Recommended</1><2>Users</2>"
 msgstr "<0>Folgen Sie einigen</0><1>Empfohlenes</1><2>Feed</2>"
 
+#: src/view/com/util/moderation/LabelInfo.tsx:45
+msgid "A content warning has been applied to this {0}."
+msgstr ""
+
 #: src/lib/hooks/useOTAUpdate.ts:16
 msgid "A new version of the app is available. Please update to continue using the app."
 msgstr "Eine neue Version der App ist verfügbar. Bitte aktualisieren Sie die App, um sie weiterhin nutzen zu können."
@@ -75,7 +79,7 @@ msgstr "Konto Optionen"
 
 #: src/view/com/modals/ListAddRemoveUsers.tsx:264
 #: src/view/com/modals/UserAddRemoveLists.tsx:193
-#: src/view/screens/ProfileList.tsx:753
+#: src/view/screens/ProfileList.tsx:754
 msgid "Add"
 msgstr "Hinzufügen"
 
@@ -83,7 +87,7 @@ msgstr "Hinzufügen"
 msgid "Add a content warning"
 msgstr "Eine Inhaltswarnung hinzufügen"
 
-#: src/view/screens/ProfileList.tsx:743
+#: src/view/screens/ProfileList.tsx:744
 msgid "Add a user to this list"
 msgstr "Einen Benutzer zu dieser Liste hinzufügen"
 
@@ -106,11 +110,11 @@ msgstr "Einzelheiten hinzufügen"
 msgid "Add details to report"
 msgstr "Einzelheiten zum Bericht hinzufügen"
 
-#: src/view/com/composer/Composer.tsx:432
+#: src/view/com/composer/Composer.tsx:438
 msgid "Add link card"
 msgstr "Link Karte hinzufügen"
 
-#: src/view/com/composer/Composer.tsx:435
+#: src/view/com/composer/Composer.tsx:441
 msgid "Add link card:"
 msgstr "Link Karte hinzufügen:"
 
@@ -122,7 +126,7 @@ msgstr "Fügen Sie den folgenden DNS-Eintrag zu Ihrem Domainnamen hinzu:"
 msgid "Add to Lists"
 msgstr "Den Listen hinzufügen"
 
-#: src/view/screens/ProfileFeed.tsx:275
+#: src/view/screens/ProfileFeed.tsx:270
 msgid "Add to my feeds"
 msgstr "Zu meinen Feeds hinzufügen"
 
@@ -180,15 +184,23 @@ msgstr "App-Passwörter"
 msgid "App Passwords"
 msgstr "App-Passwörter"
 
-#: src/view/com/modals/AppealLabel.tsx:65
-msgid "Appeal Decision"
-msgstr "Berufungsentscheidung"
+#: src/view/com/util/forms/PostDropdownBtn.tsx:207
+msgid "Appeal content warning"
+msgstr ""
 
-#: src/view/com/util/moderation/LabelInfo.tsx:51
+#: src/view/com/modals/AppealLabel.tsx:65
+msgid "Appeal Content Warning"
+msgstr ""
+
+#: src/view/com/modals/AppealLabel.tsx:65
+#~ msgid "Appeal Decision"
+#~ msgstr "Berufungsentscheidung"
+
+#: src/view/com/util/moderation/LabelInfo.tsx:52
 msgid "Appeal this decision"
 msgstr "Einspruch gegen diese Entscheidung"
 
-#: src/view/com/util/moderation/LabelInfo.tsx:55
+#: src/view/com/util/moderation/LabelInfo.tsx:56
 msgid "Appeal this decision."
 msgstr "Einspruch gegen diese Entscheidung"
 
@@ -200,15 +212,15 @@ msgstr "Aussehen"
 msgid "Are you sure you want to delete the app password \"{name}\"?"
 msgstr "Sind Sie sicher, dass Sie das App-Passwort \"{name}\" löschen möchten?"
 
-#: src/view/com/composer/Composer.tsx:141
+#: src/view/com/composer/Composer.tsx:142
 msgid "Are you sure you'd like to discard this draft?"
 msgstr "Sind Sie sicher, dass Sie diesen Entwurf verwerfen möchten?"
 
-#: src/view/screens/ProfileList.tsx:351
+#: src/view/screens/ProfileList.tsx:352
 msgid "Are you sure?"
 msgstr "Sind Sie sicher?"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:188
+#: src/view/com/util/forms/PostDropdownBtn.tsx:190
 msgid "Are you sure? This cannot be undone."
 msgstr "Sind Sie sicher? Dies kann nicht rückgängig gemacht werden"
 
@@ -216,7 +228,7 @@ msgstr "Sind Sie sicher? Dies kann nicht rückgängig gemacht werden"
 msgid "Artistic or non-erotic nudity."
 msgstr "Künstlerische oder nicht-erotische Nacktheit."
 
-#: src/view/com/auth/create/CreateAccount.tsx:145
+#: src/view/com/auth/create/CreateAccount.tsx:141
 #: src/view/com/auth/login/ChooseAccountForm.tsx:151
 #: src/view/com/auth/login/ForgotPasswordForm.tsx:166
 #: src/view/com/auth/login/LoginForm.tsx:249
@@ -247,15 +259,15 @@ msgstr "Geburtstag:"
 msgid "Block Account"
 msgstr "Konto sperren"
 
-#: src/view/screens/ProfileList.tsx:521
+#: src/view/screens/ProfileList.tsx:522
 msgid "Block accounts"
 msgstr "Kontos sperren"
 
-#: src/view/screens/ProfileList.tsx:471
+#: src/view/screens/ProfileList.tsx:472
 msgid "Block list"
 msgstr " Liste sperren"
 
-#: src/view/screens/ProfileList.tsx:306
+#: src/view/screens/ProfileList.tsx:307
 msgid "Block these accounts?"
 msgstr "Diese Kontos sperren?"
 
@@ -279,7 +291,7 @@ msgstr "Gesperrte Konten können nicht in Ihren Beiträgen antworten, Sie erwäh
 msgid "Blocked post."
 msgstr "Gesperrter Posten."
 
-#: src/view/screens/ProfileList.tsx:308
+#: src/view/screens/ProfileList.tsx:309
 msgid "Blocking is public. Blocked accounts cannot reply in your threads, mention you, or otherwise interact with you."
 msgstr "Die Sperrung ist öffentlich. Gesperrte Konten können nicht in Ihren Beiträgen antworten, Sie erwähnen oder anderweitig mit Ihnen interagieren."
 
@@ -333,9 +345,9 @@ msgstr "Kamera"
 msgid "Can only contain letters, numbers, spaces, dashes, and underscores. Must be at least 4 characters long, but no more than 32 characters long."
 msgstr "Darf nur Buchstaben, Zahlen, Leerzeichen, Bindestriche und Unterstriche enthalten. Muss mindestens 4 Zeichen lang sein, darf aber nicht länger als 32 Zeichen sein."
 
-#: src/view/com/composer/Composer.tsx:279
-#: src/view/com/composer/Composer.tsx:282
-#: src/view/com/modals/AltImage.tsx:127
+#: src/view/com/composer/Composer.tsx:285
+#: src/view/com/composer/Composer.tsx:288
+#: src/view/com/modals/AltImage.tsx:128
 #: src/view/com/modals/ChangeEmail.tsx:218
 #: src/view/com/modals/ChangeEmail.tsx:220
 #: src/view/com/modals/Confirm.tsx:88
@@ -358,7 +370,7 @@ msgstr "Abbrechen"
 msgid "Cancel account deletion"
 msgstr "Kontolöschung abbrechen"
 
-#: src/view/com/modals/AltImage.tsx:122
+#: src/view/com/modals/AltImage.tsx:123
 msgid "Cancel add image alt text"
 msgstr "Abbrechen Bild-Alt-Text hinzufügen"
 
@@ -509,7 +521,7 @@ msgstr "Bestätigen Sie Konto löschen"
 msgid "Confirmation code"
 msgstr "Bestätigungscode"
 
-#: src/view/com/auth/create/CreateAccount.tsx:178
+#: src/view/com/auth/create/CreateAccount.tsx:174
 #: src/view/com/auth/login/LoginForm.tsx:268
 msgid "Connecting..."
 msgstr "Verbinden..."
@@ -549,11 +561,11 @@ msgstr "Kopiert"
 msgid "Copy"
 msgstr "Kopie"
 
-#: src/view/screens/ProfileList.tsx:383
+#: src/view/screens/ProfileList.tsx:384
 msgid "Copy link to list"
 msgstr "Link zur Liste kopieren"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:129
+#: src/view/com/util/forms/PostDropdownBtn.tsx:131
 msgid "Copy link to post"
 msgstr "Link zum Posten kopieren"
 
@@ -561,7 +573,7 @@ msgstr "Link zum Posten kopieren"
 msgid "Copy link to profile"
 msgstr "Link zum Profil kopieren"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:115
+#: src/view/com/util/forms/PostDropdownBtn.tsx:117
 msgid "Copy post text"
 msgstr "Posten Text kopieren"
 
@@ -569,11 +581,11 @@ msgstr "Posten Text kopieren"
 msgid "Copyright Policy"
 msgstr "Urheberrechtspolitik"
 
-#: src/view/screens/ProfileFeed.tsx:98
+#: src/view/screens/ProfileFeed.tsx:94
 msgid "Could not load feed"
 msgstr "Feed konnte nicht geladen werden"
 
-#: src/view/screens/ProfileList.tsx:829
+#: src/view/screens/ProfileList.tsx:830
 msgid "Could not load list"
 msgstr "Liste konnte nicht geladen werden"
 
@@ -582,7 +594,7 @@ msgstr "Liste konnte nicht geladen werden"
 msgid "Create a new account"
 msgstr "Ein neues Konto erstellen"
 
-#: src/view/com/auth/create/CreateAccount.tsx:124
+#: src/view/com/auth/create/CreateAccount.tsx:120
 msgid "Create Account"
 msgstr "Neues Konto erstellen"
 
@@ -617,8 +629,8 @@ msgstr "Konto löschen"
 msgid "Delete app password"
 msgstr "App-Passwort löschen"
 
-#: src/view/screens/ProfileList.tsx:350
-#: src/view/screens/ProfileList.tsx:410
+#: src/view/screens/ProfileList.tsx:351
+#: src/view/screens/ProfileList.tsx:411
 msgid "Delete List"
 msgstr "Liste löschen"
 
@@ -630,11 +642,11 @@ msgstr "Mein Konto löschen"
 msgid "Delete my account…"
 msgstr "Mein Konto löschen..."
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:183
+#: src/view/com/util/forms/PostDropdownBtn.tsx:185
 msgid "Delete post"
 msgstr "Posten löschen"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:187
+#: src/view/com/util/forms/PostDropdownBtn.tsx:189
 msgid "Delete this post?"
 msgstr "Diesen Posten löschen?"
 
@@ -657,11 +669,11 @@ msgstr "Entwicklungs-Server"
 msgid "Developer Tools"
 msgstr "Werkzeuge für Entwickler"
 
-#: src/view/com/composer/Composer.tsx:142
+#: src/view/com/composer/Composer.tsx:143
 msgid "Discard"
 msgstr "Verwerfen"
 
-#: src/view/com/composer/Composer.tsx:136
+#: src/view/com/composer/Composer.tsx:137
 msgid "Discard draft"
 msgstr "Verwerfen"
 
@@ -713,7 +725,7 @@ msgstr "Jeder Code funktioniert einmal. Sie werden regelmäßig weitere Einladun
 msgid "Edit image"
 msgstr "Bild bearbeiten"
 
-#: src/view/screens/ProfileList.tsx:398
+#: src/view/screens/ProfileList.tsx:399
 msgid "Edit list details"
 msgstr "Listendetails bearbeiten"
 
@@ -761,7 +773,7 @@ msgstr "E-Mail:"
 msgid "Enable this setting to only see replies between people you follow."
 msgstr "Aktivieren Sie diese Einstellung, um nur Antworten zwischen Personen zu sehen, denen Sie folgen."
 
-#: src/view/screens/Profile.tsx:425
+#: src/view/screens/Profile.tsx:426
 msgid "End of feed"
 msgstr "Ende des Feeds"
 
@@ -806,7 +818,7 @@ msgstr "Alt-Text erweitern"
 msgid "Failed to load recommended feeds"
 msgstr "Empfohlene Feeds konnten nicht geladen werden"
 
-#: src/view/screens/Feeds.tsx:559
+#: src/view/screens/Feeds.tsx:560
 msgid "Feed offline"
 msgstr "Feed offline"
 
@@ -820,9 +832,9 @@ msgid "Feedback"
 msgstr "Rückmeldung"
 
 #: src/view/screens/Feeds.tsx:475
-#: src/view/screens/Profile.tsx:164
-#: src/view/shell/bottom-bar/BottomBar.tsx:163
-#: src/view/shell/desktop/LeftNav.tsx:335
+#: src/view/screens/Profile.tsx:165
+#: src/view/shell/bottom-bar/BottomBar.tsx:181
+#: src/view/shell/desktop/LeftNav.tsx:340
 #: src/view/shell/Drawer.tsx:455
 #: src/view/shell/Drawer.tsx:456
 msgid "Feeds"
@@ -918,17 +930,17 @@ msgstr "Galerie"
 msgid "Get Started"
 msgstr "Anfangen"
 
-#: src/view/com/auth/LoggedOut.tsx:70
-#: src/view/com/auth/LoggedOut.tsx:71
+#: src/view/com/auth/LoggedOut.tsx:81
+#: src/view/com/auth/LoggedOut.tsx:82
 #: src/view/com/util/moderation/ScreenHider.tsx:123
-#: src/view/shell/desktop/LeftNav.tsx:103
+#: src/view/shell/desktop/LeftNav.tsx:104
 msgid "Go back"
 msgstr "Zurückgehen"
 
-#: src/view/screens/ProfileFeed.tsx:107
-#: src/view/screens/ProfileFeed.tsx:112
-#: src/view/screens/ProfileList.tsx:838
-#: src/view/screens/ProfileList.tsx:843
+#: src/view/screens/ProfileFeed.tsx:103
+#: src/view/screens/ProfileFeed.tsx:108
+#: src/view/screens/ProfileList.tsx:839
+#: src/view/screens/ProfileList.tsx:844
 msgid "Go Back"
 msgstr "Zurückgehen"
 
@@ -980,8 +992,8 @@ msgstr "Hmm, der Feed-Server scheint falsch konfiguriert zu sein. Bitte informie
 msgid "Hmm, we're having trouble finding this feed. It may have been deleted."
 msgstr "Hmm, wir haben Probleme, diesen Feed zu finden. Vielleicht wurde er gelöscht."
 
-#: src/view/shell/bottom-bar/BottomBar.tsx:116
-#: src/view/shell/desktop/LeftNav.tsx:297
+#: src/view/shell/bottom-bar/BottomBar.tsx:137
+#: src/view/shell/desktop/LeftNav.tsx:304
 #: src/view/shell/Drawer.tsx:379
 #: src/view/shell/Drawer.tsx:380
 msgid "Home"
@@ -1014,7 +1026,7 @@ msgstr "Ich habe meine eigene Domain"
 msgid "If none are selected, suitable for all ages."
 msgstr "Wenn keine ausgewählt werden, sind sie für alle Altersgruppen geeignet."
 
-#: src/view/com/modals/AltImage.tsx:96
+#: src/view/com/modals/AltImage.tsx:97
 msgid "Image alt text"
 msgstr "Bild-Alt-Text"
 
@@ -1117,7 +1129,7 @@ msgstr "Lassen Sie Ihr Passwort zurücksetzen!"
 msgid "Library"
 msgstr "Bibliothek"
 
-#: src/view/screens/ProfileFeed.tsx:627
+#: src/view/screens/ProfileFeed.tsx:577
 msgid "Like this feed"
 msgstr "Dieser Feed gefallen"
 
@@ -1126,7 +1138,7 @@ msgstr "Dieser Feed gefallen"
 msgid "Liked by"
 msgstr "Gefallen bei"
 
-#: src/view/screens/Profile.tsx:163
+#: src/view/screens/Profile.tsx:164
 msgid "Likes"
 msgstr "Likes"
 
@@ -1138,8 +1150,8 @@ msgstr "Avatar auflisten"
 msgid "List Name"
 msgstr "Namen auflisten"
 
-#: src/view/screens/Profile.tsx:165
-#: src/view/shell/desktop/LeftNav.tsx:372
+#: src/view/screens/Profile.tsx:166
+#: src/view/shell/desktop/LeftNav.tsx:377
 #: src/view/shell/Drawer.tsx:471
 #: src/view/shell/Drawer.tsx:472
 msgid "Lists"
@@ -1175,14 +1187,14 @@ msgid "Login to account that is not listed"
 msgstr "Anmeldung bei einem Konto, das nicht aufgelistet ist"
 
 #: src/view/screens/ProfileFeed.tsx:472
-msgid "Looks like this feed is only available to users with a Bluesky account. Please sign up or sign in to view this feed!"
-msgstr "Es sieht so aus, als ob dieser Feed nur für Benutzer mit einem Bluesky-Konto verfügbar ist. Bitte melde dich an oder registriere dich, um diesen Feed zu sehen!"
+#~ msgid "Looks like this feed is only available to users with a Bluesky account. Please sign up or sign in to view this feed!"
+#~ msgstr "Es sieht so aus, als ob dieser Feed nur für Benutzer mit einem Bluesky-Konto verfügbar ist. Bitte melde dich an oder registriere dich, um diesen Feed zu sehen!"
 
 #: src/view/com/modals/LinkWarning.tsx:63
 msgid "Make sure this is where you intend to go!"
 msgstr "Vergewissern Sie sich, dass Sie dorthin gehen wollen!"
 
-#: src/view/screens/Profile.tsx:162
+#: src/view/screens/Profile.tsx:163
 msgid "Media"
 msgstr "Medien"
 
@@ -1199,13 +1211,12 @@ msgid "Menu"
 msgstr "Menü"
 
 #: src/view/com/posts/FeedErrorMessage.tsx:194
-#: src/view/screens/ProfileFeed.tsx:480
 msgid "Message from server"
 msgstr "Meldung vom Server"
 
 #: src/view/screens/Moderation.tsx:64
 #: src/view/screens/Settings.tsx:563
-#: src/view/shell/desktop/LeftNav.tsx:390
+#: src/view/shell/desktop/LeftNav.tsx:395
 #: src/view/shell/Drawer.tsx:490
 #: src/view/shell/Drawer.tsx:491
 msgid "Moderation"
@@ -1224,8 +1235,8 @@ msgid "More feeds"
 msgstr "Mehr Feeds "
 
 #: src/view/com/profile/ProfileHeader.tsx:548
-#: src/view/screens/ProfileFeed.tsx:365
-#: src/view/screens/ProfileList.tsx:582
+#: src/view/screens/ProfileFeed.tsx:360
+#: src/view/screens/ProfileList.tsx:583
 msgid "More options"
 msgstr "Mehr Optionen"
 
@@ -1233,19 +1244,19 @@ msgstr "Mehr Optionen"
 msgid "Mute Account"
 msgstr "Stummes Konto"
 
-#: src/view/screens/ProfileList.tsx:509
+#: src/view/screens/ProfileList.tsx:510
 msgid "Mute accounts"
 msgstr "Stummes Konto"
 
-#: src/view/screens/ProfileList.tsx:456
+#: src/view/screens/ProfileList.tsx:457
 msgid "Mute list"
 msgstr "Stumme Liste"
 
-#: src/view/screens/ProfileList.tsx:269
+#: src/view/screens/ProfileList.tsx:270
 msgid "Mute these accounts?"
 msgstr "Diese Konten stummschalten?"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:147
+#: src/view/com/util/forms/PostDropdownBtn.tsx:149
 msgid "Mute thread"
 msgstr "Thema stummschalten"
 
@@ -1261,7 +1272,7 @@ msgstr "Stumme Kontos"
 msgid "Muted accounts have their posts removed from your feed and from your notifications. Mutes are completely private."
 msgstr "Bei stummgeschalteten Konten werden deren Beiträge aus deinem Feed und deinen Benachrichtigungen entfernt. Stummschaltungen sind vollständig privat."
 
-#: src/view/screens/ProfileList.tsx:271
+#: src/view/screens/ProfileList.tsx:272
 msgid "Muting is private. Muted accounts can interact with you, but you will not see their posts or receive notifications from them."
 msgstr "Stummschalten ist privat. Stummgeschaltete Konten können mit Ihnen interagieren, aber Sie sehen ihre Beiträge nicht und erhalten keine Benachrichtigungen von ihnen."
 
@@ -1273,7 +1284,7 @@ msgstr "Mein Geburtstag"
 msgid "My Feeds"
 msgstr "Meine Feeds"
 
-#: src/view/shell/desktop/LeftNav.tsx:64
+#: src/view/shell/desktop/LeftNav.tsx:65
 msgid "My Profile"
 msgstr "Mein Profil "
 
@@ -1296,20 +1307,20 @@ msgid "New"
 msgstr "Neu"
 
 #: src/view/com/feeds/FeedPage.tsx:200
-#: src/view/screens/Feeds.tsx:510
-#: src/view/screens/Profile.tsx:353
-#: src/view/screens/ProfileFeed.tsx:441
-#: src/view/screens/ProfileList.tsx:192
-#: src/view/screens/ProfileList.tsx:220
-#: src/view/shell/desktop/LeftNav.tsx:246
+#: src/view/screens/Feeds.tsx:511
+#: src/view/screens/Profile.tsx:354
+#: src/view/screens/ProfileFeed.tsx:430
+#: src/view/screens/ProfileList.tsx:193
+#: src/view/screens/ProfileList.tsx:221
+#: src/view/shell/desktop/LeftNav.tsx:247
 msgid "New post"
 msgstr "Neuer Posten "
 
-#: src/view/shell/desktop/LeftNav.tsx:256
+#: src/view/shell/desktop/LeftNav.tsx:257
 msgid "New Post"
 msgstr "Neuer Posten "
 
-#: src/view/com/auth/create/CreateAccount.tsx:158
+#: src/view/com/auth/create/CreateAccount.tsx:154
 #: src/view/com/auth/login/ForgotPasswordForm.tsx:174
 #: src/view/com/auth/login/ForgotPasswordForm.tsx:184
 #: src/view/com/auth/login/LoginForm.tsx:281
@@ -1329,8 +1340,8 @@ msgstr "Nächstes Bild "
 msgid "No"
 msgstr "Nein"
 
-#: src/view/screens/ProfileFeed.tsx:620
-#: src/view/screens/ProfileList.tsx:710
+#: src/view/screens/ProfileFeed.tsx:570
+#: src/view/screens/ProfileList.tsx:711
 msgid "No description"
 msgstr "Ohne Beschreibung"
 
@@ -1364,8 +1375,8 @@ msgstr "Hinweis: Bluesky ist ein offenes und öffentliches Netzwerk. Diese Einst
 
 #: src/view/screens/Notifications.tsx:109
 #: src/view/screens/Notifications.tsx:133
-#: src/view/shell/bottom-bar/BottomBar.tsx:187
-#: src/view/shell/desktop/LeftNav.tsx:354
+#: src/view/shell/bottom-bar/BottomBar.tsx:205
+#: src/view/shell/desktop/LeftNav.tsx:359
 #: src/view/shell/Drawer.tsx:416
 #: src/view/shell/Drawer.tsx:417
 msgid "Notifications"
@@ -1379,7 +1390,7 @@ msgstr "Ach nein!"
 msgid "Okay"
 msgstr "Okay"
 
-#: src/view/com/composer/Composer.tsx:348
+#: src/view/com/composer/Composer.tsx:354
 msgid "One or more images is missing alt text."
 msgstr "Bei einem oder mehreren Bildern fehlt der Alt-Text."
 
@@ -1499,12 +1510,17 @@ msgstr "Bitte geben Sie auch Ihr Passwort ein:"
 
 #: src/view/com/modals/AppealLabel.tsx:72
 #: src/view/com/modals/AppealLabel.tsx:75
-msgid "Please tell us why you think this decision was incorrect."
-msgstr "Bitte teilen Sie uns mit, warum diese Entscheidung Ihrer Meinung nach falsch war."
+msgid "Please tell us why you think this content warning was incorrectly applied!"
+msgstr ""
 
-#: src/view/com/composer/Composer.tsx:331
+#: src/view/com/modals/AppealLabel.tsx:72
+#: src/view/com/modals/AppealLabel.tsx:75
+#~ msgid "Please tell us why you think this decision was incorrect."
+#~ msgstr "Bitte teilen Sie uns mit, warum diese Entscheidung Ihrer Meinung nach falsch war."
+
+#: src/view/com/composer/Composer.tsx:337
 #: src/view/com/post-thread/PostThread.tsx:226
-#: src/view/screens/PostThread.tsx:78
+#: src/view/screens/PostThread.tsx:80
 msgid "Post"
 msgstr "Posten "
 
@@ -1524,7 +1540,7 @@ msgstr "Postsprachen"
 msgid "Post not found"
 msgstr "Posten nicht gefunden"
 
-#: src/view/screens/Profile.tsx:160
+#: src/view/screens/Profile.tsx:161
 msgid "Posts"
 msgstr "Posten "
 
@@ -1556,7 +1572,8 @@ msgstr "Datenschutzbestimmungen"
 msgid "Processing..."
 msgstr "Verarbeitung..."
 
-#: src/view/shell/bottom-bar/BottomBar.tsx:229
+#: src/view/shell/bottom-bar/BottomBar.tsx:247
+#: src/view/shell/desktop/LeftNav.tsx:413
 #: src/view/shell/Drawer.tsx:69
 #: src/view/shell/Drawer.tsx:525
 #: src/view/shell/Drawer.tsx:526
@@ -1618,7 +1635,7 @@ msgstr "Feed entfernen"
 
 #: src/view/com/feeds/FeedSourceCard.tsx:105
 #: src/view/com/feeds/FeedSourceCard.tsx:172
-#: src/view/screens/ProfileFeed.tsx:275
+#: src/view/screens/ProfileFeed.tsx:270
 msgid "Remove from my feeds"
 msgstr "Aus meinen Feeds entfernen"
 
@@ -1643,7 +1660,7 @@ msgstr "Diesen Feed aus Ihren gespeicherten Feeds entfernen?"
 msgid "Removed from list"
 msgstr "Aus der Liste entfernt"
 
-#: src/view/screens/Profile.tsx:161
+#: src/view/screens/Profile.tsx:162
 msgid "Replies"
 msgstr "Antworten"
 
@@ -1663,16 +1680,16 @@ msgstr "Bericht {Sammlungsname}"
 msgid "Report Account"
 msgstr "Bericht Konto"
 
-#: src/view/screens/ProfileFeed.tsx:295
+#: src/view/screens/ProfileFeed.tsx:290
 msgid "Report feed"
 msgstr "Bericht Feed"
 
-#: src/view/screens/ProfileList.tsx:424
+#: src/view/screens/ProfileList.tsx:425
 msgid "Report List"
 msgstr "Bericht Liste"
 
 #: src/view/com/modals/report/SendReportButton.tsx:37
-#: src/view/com/util/forms/PostDropdownBtn.tsx:165
+#: src/view/com/util/forms/PostDropdownBtn.tsx:167
 msgid "Report post"
 msgstr "Beitrag berichten"
 
@@ -1722,8 +1739,8 @@ msgstr "Onboarding-Status zurücksetzen"
 msgid "Resets the preferences state"
 msgstr "Setzt den Zustand der Einstellungen zurück"
 
+#: src/view/com/auth/create/CreateAccount.tsx:163
 #: src/view/com/auth/create/CreateAccount.tsx:167
-#: src/view/com/auth/create/CreateAccount.tsx:171
 #: src/view/com/auth/login/LoginForm.tsx:258
 #: src/view/com/auth/login/LoginForm.tsx:261
 #: src/view/com/util/error/ErrorMessage.tsx:55
@@ -1731,7 +1748,7 @@ msgstr "Setzt den Zustand der Einstellungen zurück"
 msgid "Retry"
 msgstr "Wiederholung"
 
-#: src/view/com/modals/AltImage.tsx:114
+#: src/view/com/modals/AltImage.tsx:115
 #: src/view/com/modals/BirthDateSettings.tsx:93
 #: src/view/com/modals/BirthDateSettings.tsx:96
 #: src/view/com/modals/ChangeHandle.tsx:173
@@ -1741,7 +1758,7 @@ msgstr "Wiederholung"
 msgid "Save"
 msgstr "Speichern"
 
-#: src/view/com/modals/AltImage.tsx:105
+#: src/view/com/modals/AltImage.tsx:106
 msgid "Save alt text"
 msgstr "Alt-Text speichern"
 
@@ -1765,14 +1782,19 @@ msgstr "Gespeicherte Feeds"
 #: src/view/com/util/forms/SearchInput.tsx:64
 #: src/view/screens/Search/Search.tsx:401
 #: src/view/screens/Search/Search.tsx:567
-#: src/view/shell/bottom-bar/BottomBar.tsx:138
-#: src/view/shell/desktop/LeftNav.tsx:315
+#: src/view/shell/bottom-bar/BottomBar.tsx:159
+#: src/view/shell/desktop/LeftNav.tsx:322
 #: src/view/shell/desktop/Search.tsx:161
 #: src/view/shell/desktop/Search.tsx:170
 #: src/view/shell/Drawer.tsx:343
 #: src/view/shell/Drawer.tsx:344
 msgid "Search"
 msgstr "Suche"
+
+#: src/view/com/auth/LoggedOut.tsx:104
+#: src/view/com/auth/LoggedOut.tsx:105
+msgid "Search for users"
+msgstr ""
 
 #: src/view/com/modals/ChangeEmail.tsx:110
 msgid "Security Step Required"
@@ -1852,7 +1874,7 @@ msgid "Set this setting to \"Yes\" to show samples of your saved feeds in your f
 msgstr "Setzen Sie diese Einstellung auf \"Ja\", um Beispiele für Ihre gespeicherten Feeds in Ihrem folgenden Feed anzuzeigen. Dies ist eine experimentelle Funktion."
 
 #: src/view/screens/Settings.tsx:277
-#: src/view/shell/desktop/LeftNav.tsx:426
+#: src/view/shell/desktop/LeftNav.tsx:431
 #: src/view/shell/Drawer.tsx:546
 #: src/view/shell/Drawer.tsx:547
 msgid "Settings"
@@ -1863,12 +1885,12 @@ msgid "Sexual activity or erotic nudity."
 msgstr "Sexuelle Aktivitäten oder erotische Nacktheit."
 
 #: src/view/com/profile/ProfileHeader.tsx:338
-#: src/view/com/util/forms/PostDropdownBtn.tsx:129
-#: src/view/screens/ProfileList.tsx:383
+#: src/view/com/util/forms/PostDropdownBtn.tsx:131
+#: src/view/screens/ProfileList.tsx:384
 msgid "Share"
 msgstr "Teilen"
 
-#: src/view/screens/ProfileFeed.tsx:307
+#: src/view/screens/ProfileFeed.tsx:302
 msgid "Share feed"
 msgstr "Feeds teilen"
 
@@ -1908,6 +1930,12 @@ msgstr "Benutzer zeigen"
 #: src/view/com/auth/HomeLoggedOutCTA.tsx:70
 #: src/view/com/auth/login/Login.tsx:98
 #: src/view/com/auth/SplashScreen.tsx:54
+#: src/view/shell/bottom-bar/BottomBar.tsx:285
+#: src/view/shell/bottom-bar/BottomBar.tsx:286
+#: src/view/shell/bottom-bar/BottomBar.tsx:288
+#: src/view/shell/bottom-bar/BottomBarWeb.tsx:177
+#: src/view/shell/bottom-bar/BottomBarWeb.tsx:178
+#: src/view/shell/bottom-bar/BottomBarWeb.tsx:180
 #: src/view/shell/NavSignupCard.tsx:58
 #: src/view/shell/NavSignupCard.tsx:59
 msgid "Sign in"
@@ -1937,6 +1965,12 @@ msgstr "Anmelden"
 msgid "Sign out"
 msgstr "Ausmelden"
 
+#: src/view/shell/bottom-bar/BottomBar.tsx:275
+#: src/view/shell/bottom-bar/BottomBar.tsx:276
+#: src/view/shell/bottom-bar/BottomBar.tsx:278
+#: src/view/shell/bottom-bar/BottomBarWeb.tsx:167
+#: src/view/shell/bottom-bar/BottomBarWeb.tsx:168
+#: src/view/shell/bottom-bar/BottomBarWeb.tsx:170
 #: src/view/shell/NavSignupCard.tsx:49
 #: src/view/shell/NavSignupCard.tsx:50
 #: src/view/shell/NavSignupCard.tsx:52
@@ -1988,11 +2022,11 @@ msgstr "Märchenbuch"
 msgid "Submit"
 msgstr "Einreichen"
 
-#: src/view/screens/ProfileList.tsx:573
+#: src/view/screens/ProfileList.tsx:574
 msgid "Subscribe"
 msgstr "Abonnieren"
 
-#: src/view/screens/ProfileList.tsx:569
+#: src/view/screens/ProfileList.tsx:570
 msgid "Subscribe to this list"
 msgstr "Abonnieren Sie diese Liste"
 
@@ -2063,8 +2097,8 @@ msgid "There was an unexpected issue in the application. Please let us know if t
 msgstr "Es gab ein unerwartetes Problem in der Anwendung. Bitte teilen Sie uns mit, wenn dies bei Ihnen der Fall ist!"
 
 #: src/view/com/util/moderation/LabelInfo.tsx:45
-msgid "This {0} has been labeled."
-msgstr "Dieser {0} wurde gekennzeichnet."
+#~ msgid "This {0} has been labeled."
+#~ msgstr "Dieser {0} wurde gekennzeichnet."
 
 #: src/view/com/util/moderation/ScreenHider.tsx:88
 msgid "This {screenDescription} has been flagged:"
@@ -2098,7 +2132,7 @@ msgstr "Das ist der Dienst, der Sie online hält."
 msgid "This link is taking you to the following website:"
 msgstr "Dieser Link führt Sie auf die folgende Website:"
 
-#: src/view/com/post-thread/PostThreadItem.tsx:124
+#: src/view/com/post-thread/PostThreadItem.tsx:123
 msgid "This post has been deleted."
 msgstr "Dieser Beitrag wurde gelöscht."
 
@@ -2123,9 +2157,9 @@ msgstr "Dropdown umschalten"
 msgid "Transformations"
 msgstr "Verwandlungen"
 
+#: src/view/com/post-thread/PostThreadItem.tsx:704
 #: src/view/com/post-thread/PostThreadItem.tsx:706
-#: src/view/com/post-thread/PostThreadItem.tsx:708
-#: src/view/com/util/forms/PostDropdownBtn.tsx:101
+#: src/view/com/util/forms/PostDropdownBtn.tsx:103
 msgid "Translate"
 msgstr "Übersetze"
 
@@ -2133,11 +2167,11 @@ msgstr "Übersetze"
 msgid "Try again"
 msgstr "Nochmals versuchen"
 
-#: src/view/screens/ProfileList.tsx:471
+#: src/view/screens/ProfileList.tsx:472
 msgid "Un-block list"
 msgstr "Liste freigeben"
 
-#: src/view/screens/ProfileList.tsx:456
+#: src/view/screens/ProfileList.tsx:457
 msgid "Un-mute list"
 msgstr "Stummschaltliste aufheben"
 
@@ -2169,11 +2203,11 @@ msgstr "Leider erfüllen Sie nicht die Voraussetzungen, um ein Konto zu erstelle
 msgid "Unmute Account"
 msgstr "Konto entstören"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:147
+#: src/view/com/util/forms/PostDropdownBtn.tsx:149
 msgid "Unmute thread"
 msgstr "Thema aufheben"
 
-#: src/view/screens/ProfileList.tsx:439
+#: src/view/screens/ProfileList.tsx:440
 msgid "Unpin moderation list"
 msgstr "Moderation Liste"
 
@@ -2222,7 +2256,7 @@ msgstr "Benutzer Liste"
 msgid "Username or email address"
 msgstr "Benutzername oder E-Mail Adresse"
 
-#: src/view/screens/ProfileList.tsx:737
+#: src/view/screens/ProfileList.tsx:738
 msgid "Users"
 msgstr "Benutzer"
 
@@ -2263,7 +2297,7 @@ msgstr "Avatar sehen"
 msgid "Visit Site"
 msgstr "Seite besuchen"
 
-#: src/view/com/auth/create/CreateAccount.tsx:125
+#: src/view/com/auth/create/CreateAccount.tsx:121
 msgid "We're so excited to have you join us!"
 msgstr "Wir freuen uns, Sie bei uns begrüßen zu dürfen!"
 
@@ -2284,8 +2318,12 @@ msgid "What is the issue with this {collectionName}?"
 msgstr "Was ist das Problem mit dieser {collectionName}?"
 
 #: src/view/com/auth/SplashScreen.tsx:34
-msgid "What's next?"
-msgstr "Was kommt als Nächstes?"
+#~ msgid "What's next?"
+#~ msgstr "Was kommt als Nächstes?"
+
+#: src/view/com/auth/SplashScreen.tsx:34
+msgid "What's up?"
+msgstr ""
 
 #: src/view/com/modals/lang-settings/PostLanguagesSettings.tsx:78
 msgid "Which languages are used in this post?"
@@ -2304,7 +2342,7 @@ msgstr "Wer kann antworten."
 msgid "Wide"
 msgstr "Breit"
 
-#: src/view/com/composer/Composer.tsx:403
+#: src/view/com/composer/Composer.tsx:409
 msgid "Write post"
 msgstr "Posten schreiben"
 

--- a/src/locale/locales/en/messages.po
+++ b/src/locale/locales/en/messages.po
@@ -375,7 +375,7 @@ msgstr ""
 
 #: src/view/com/composer/Composer.tsx:285
 #: src/view/com/composer/Composer.tsx:288
-#: src/view/com/modals/AltImage.tsx:127
+#: src/view/com/modals/AltImage.tsx:128
 #: src/view/com/modals/ChangeEmail.tsx:218
 #: src/view/com/modals/ChangeEmail.tsx:220
 #: src/view/com/modals/Confirm.tsx:88
@@ -398,7 +398,7 @@ msgstr ""
 msgid "Cancel account deletion"
 msgstr ""
 
-#: src/view/com/modals/AltImage.tsx:122
+#: src/view/com/modals/AltImage.tsx:123
 msgid "Cancel add image alt text"
 msgstr ""
 
@@ -809,7 +809,7 @@ msgstr ""
 msgid "Enable this setting to only see replies between people you follow."
 msgstr ""
 
-#: src/view/screens/Profile.tsx:425
+#: src/view/screens/Profile.tsx:426
 msgid "End of feed"
 msgstr ""
 
@@ -854,7 +854,7 @@ msgstr ""
 msgid "Failed to load recommended feeds"
 msgstr ""
 
-#: src/view/screens/Feeds.tsx:559
+#: src/view/screens/Feeds.tsx:560
 msgid "Feed offline"
 msgstr ""
 
@@ -868,9 +868,9 @@ msgid "Feedback"
 msgstr ""
 
 #: src/view/screens/Feeds.tsx:475
-#: src/view/screens/Profile.tsx:164
+#: src/view/screens/Profile.tsx:165
 #: src/view/shell/bottom-bar/BottomBar.tsx:181
-#: src/view/shell/desktop/LeftNav.tsx:339
+#: src/view/shell/desktop/LeftNav.tsx:340
 #: src/view/shell/Drawer.tsx:455
 #: src/view/shell/Drawer.tsx:456
 msgid "Feeds"
@@ -973,7 +973,7 @@ msgstr ""
 #: src/view/com/auth/LoggedOut.tsx:81
 #: src/view/com/auth/LoggedOut.tsx:82
 #: src/view/com/util/moderation/ScreenHider.tsx:123
-#: src/view/shell/desktop/LeftNav.tsx:103
+#: src/view/shell/desktop/LeftNav.tsx:104
 msgid "Go back"
 msgstr ""
 
@@ -1041,7 +1041,7 @@ msgstr ""
 #~ msgstr ""
 
 #: src/view/shell/bottom-bar/BottomBar.tsx:137
-#: src/view/shell/desktop/LeftNav.tsx:303
+#: src/view/shell/desktop/LeftNav.tsx:304
 #: src/view/shell/Drawer.tsx:379
 #: src/view/shell/Drawer.tsx:380
 msgid "Home"
@@ -1074,7 +1074,7 @@ msgstr ""
 msgid "If none are selected, suitable for all ages."
 msgstr ""
 
-#: src/view/com/modals/AltImage.tsx:96
+#: src/view/com/modals/AltImage.tsx:97
 msgid "Image alt text"
 msgstr ""
 
@@ -1195,7 +1195,7 @@ msgstr ""
 msgid "Liked by"
 msgstr ""
 
-#: src/view/screens/Profile.tsx:163
+#: src/view/screens/Profile.tsx:164
 msgid "Likes"
 msgstr ""
 
@@ -1215,8 +1215,8 @@ msgstr ""
 msgid "List Name"
 msgstr ""
 
-#: src/view/screens/Profile.tsx:165
-#: src/view/shell/desktop/LeftNav.tsx:376
+#: src/view/screens/Profile.tsx:166
+#: src/view/shell/desktop/LeftNav.tsx:377
 #: src/view/shell/Drawer.tsx:471
 #: src/view/shell/Drawer.tsx:472
 msgid "Lists"
@@ -1263,7 +1263,7 @@ msgstr ""
 msgid "Make sure this is where you intend to go!"
 msgstr ""
 
-#: src/view/screens/Profile.tsx:162
+#: src/view/screens/Profile.tsx:163
 msgid "Media"
 msgstr ""
 
@@ -1285,7 +1285,7 @@ msgstr ""
 
 #: src/view/screens/Moderation.tsx:64
 #: src/view/screens/Settings.tsx:563
-#: src/view/shell/desktop/LeftNav.tsx:394
+#: src/view/shell/desktop/LeftNav.tsx:395
 #: src/view/shell/Drawer.tsx:490
 #: src/view/shell/Drawer.tsx:491
 msgid "Moderation"
@@ -1361,7 +1361,7 @@ msgstr ""
 msgid "My Feeds"
 msgstr ""
 
-#: src/view/shell/desktop/LeftNav.tsx:64
+#: src/view/shell/desktop/LeftNav.tsx:65
 msgid "My Profile"
 msgstr ""
 
@@ -1384,16 +1384,16 @@ msgid "New"
 msgstr ""
 
 #: src/view/com/feeds/FeedPage.tsx:200
-#: src/view/screens/Feeds.tsx:510
-#: src/view/screens/Profile.tsx:353
+#: src/view/screens/Feeds.tsx:511
+#: src/view/screens/Profile.tsx:354
 #: src/view/screens/ProfileFeed.tsx:430
 #: src/view/screens/ProfileList.tsx:193
 #: src/view/screens/ProfileList.tsx:221
-#: src/view/shell/desktop/LeftNav.tsx:246
+#: src/view/shell/desktop/LeftNav.tsx:247
 msgid "New post"
 msgstr ""
 
-#: src/view/shell/desktop/LeftNav.tsx:256
+#: src/view/shell/desktop/LeftNav.tsx:257
 msgid "New Post"
 msgstr ""
 
@@ -1470,7 +1470,7 @@ msgstr ""
 #: src/view/screens/Notifications.tsx:109
 #: src/view/screens/Notifications.tsx:133
 #: src/view/shell/bottom-bar/BottomBar.tsx:205
-#: src/view/shell/desktop/LeftNav.tsx:358
+#: src/view/shell/desktop/LeftNav.tsx:359
 #: src/view/shell/Drawer.tsx:416
 #: src/view/shell/Drawer.tsx:417
 msgid "Notifications"
@@ -1634,7 +1634,7 @@ msgstr ""
 msgid "Post not found"
 msgstr ""
 
-#: src/view/screens/Profile.tsx:160
+#: src/view/screens/Profile.tsx:161
 msgid "Posts"
 msgstr ""
 
@@ -1667,7 +1667,7 @@ msgid "Processing..."
 msgstr ""
 
 #: src/view/shell/bottom-bar/BottomBar.tsx:247
-#: src/view/shell/desktop/LeftNav.tsx:412
+#: src/view/shell/desktop/LeftNav.tsx:413
 #: src/view/shell/Drawer.tsx:69
 #: src/view/shell/Drawer.tsx:525
 #: src/view/shell/Drawer.tsx:526
@@ -1759,7 +1759,7 @@ msgstr ""
 msgid "Removed from list"
 msgstr ""
 
-#: src/view/screens/Profile.tsx:161
+#: src/view/screens/Profile.tsx:162
 msgid "Replies"
 msgstr ""
 
@@ -1859,7 +1859,7 @@ msgstr ""
 #~ msgid "Retry change handle"
 #~ msgstr ""
 
-#: src/view/com/modals/AltImage.tsx:114
+#: src/view/com/modals/AltImage.tsx:115
 #: src/view/com/modals/BirthDateSettings.tsx:93
 #: src/view/com/modals/BirthDateSettings.tsx:96
 #: src/view/com/modals/ChangeHandle.tsx:173
@@ -1869,7 +1869,7 @@ msgstr ""
 msgid "Save"
 msgstr ""
 
-#: src/view/com/modals/AltImage.tsx:105
+#: src/view/com/modals/AltImage.tsx:106
 msgid "Save alt text"
 msgstr ""
 
@@ -1898,7 +1898,7 @@ msgstr ""
 #: src/view/screens/Search/Search.tsx:401
 #: src/view/screens/Search/Search.tsx:567
 #: src/view/shell/bottom-bar/BottomBar.tsx:159
-#: src/view/shell/desktop/LeftNav.tsx:321
+#: src/view/shell/desktop/LeftNav.tsx:322
 #: src/view/shell/desktop/Search.tsx:161
 #: src/view/shell/desktop/Search.tsx:170
 #: src/view/shell/Drawer.tsx:343
@@ -1993,7 +1993,7 @@ msgid "Set this setting to \"Yes\" to show samples of your saved feeds in your f
 msgstr ""
 
 #: src/view/screens/Settings.tsx:277
-#: src/view/shell/desktop/LeftNav.tsx:430
+#: src/view/shell/desktop/LeftNav.tsx:431
 #: src/view/shell/Drawer.tsx:546
 #: src/view/shell/Drawer.tsx:547
 msgid "Settings"

--- a/src/locale/locales/es/messages.po
+++ b/src/locale/locales/es/messages.po
@@ -1,0 +1,2435 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2023-12-22 01:56+0530\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: es\n"
+
+#: src/view/shell/desktop/RightNav.tsx:160
+msgid "{0, plural, one {# invite code available} other {# invite codes available}}"
+msgstr ""
+
+#: src/view/com/modals/Repost.tsx:44
+msgid "{0}"
+msgstr ""
+
+#: src/view/com/modals/CreateOrEditList.tsx:176
+msgid "{0} {purposeLabel} List"
+msgstr ""
+
+#: src/view/shell/desktop/RightNav.tsx:143
+msgid "{invitesAvailable, plural, one {Invite codes: # available} other {Invite codes: # available}}"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:407
+#: src/view/shell/Drawer.tsx:640
+msgid "{invitesAvailable} invite code available"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:409
+#: src/view/shell/Drawer.tsx:642
+msgid "{invitesAvailable} invite codes available"
+msgstr ""
+
+#: src/view/screens/Search/Search.tsx:88
+msgid "{message}"
+msgstr ""
+
+#: src/view/com/threadgate/WhoCanReply.tsx:158
+msgid "<0/> members"
+msgstr ""
+
+#: src/view/com/auth/onboarding/RecommendedFeeds.tsx:30
+msgid "<0>Choose your</0><1>Recommended</1><2>Feeds</2>"
+msgstr ""
+
+#: src/view/com/auth/onboarding/RecommendedFollows.tsx:37
+msgid "<0>Follow some</0><1>Recommended</1><2>Users</2>"
+msgstr ""
+
+#: src/view/com/util/moderation/LabelInfo.tsx:45
+msgid "A content warning has been applied to this {0}."
+msgstr ""
+
+#: src/lib/hooks/useOTAUpdate.ts:16
+msgid "A new version of the app is available. Please update to continue using the app."
+msgstr ""
+
+#: src/view/com/modals/EditImage.tsx:299
+#: src/view/screens/Settings.tsx:417
+msgid "Accessibility"
+msgstr ""
+
+#: src/view/com/auth/login/LoginForm.tsx:159
+#: src/view/screens/Settings.tsx:286
+msgid "Account"
+msgstr ""
+
+#: src/view/com/util/AccountDropdownBtn.tsx:41
+msgid "Account options"
+msgstr ""
+
+#: src/view/com/modals/ListAddRemoveUsers.tsx:264
+#: src/view/com/modals/UserAddRemoveLists.tsx:193
+#: src/view/screens/ProfileList.tsx:754
+msgid "Add"
+msgstr ""
+
+#: src/view/com/modals/SelfLabel.tsx:56
+msgid "Add a content warning"
+msgstr ""
+
+#: src/view/screens/ProfileList.tsx:744
+msgid "Add a user to this list"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:355
+#: src/view/screens/Settings.tsx:364
+msgid "Add account"
+msgstr ""
+
+#: src/view/com/composer/photos/Gallery.tsx:119
+#: src/view/com/composer/photos/Gallery.tsx:180
+msgid "Add alt text"
+msgstr ""
+
+#: src/view/com/modals/report/InputIssueDetails.tsx:41
+#: src/view/com/modals/report/Modal.tsx:191
+msgid "Add details"
+msgstr ""
+
+#: src/view/com/modals/report/Modal.tsx:194
+msgid "Add details to report"
+msgstr ""
+
+#: src/view/com/composer/Composer.tsx:438
+msgid "Add link card"
+msgstr ""
+
+#: src/view/com/composer/Composer.tsx:441
+msgid "Add link card:"
+msgstr ""
+
+#: src/view/com/modals/ChangeHandle.tsx:415
+msgid "Add the following DNS record to your domain:"
+msgstr ""
+
+#: src/view/com/profile/ProfileHeader.tsx:353
+msgid "Add to Lists"
+msgstr ""
+
+#: src/view/screens/ProfileFeed.tsx:270
+msgid "Add to my feeds"
+msgstr ""
+
+#: src/view/com/modals/ListAddRemoveUsers.tsx:191
+#: src/view/com/modals/UserAddRemoveLists.tsx:128
+msgid "Added to list"
+msgstr ""
+
+#: src/view/screens/PreferencesHomeFeed.tsx:164
+msgid "Adjust the number of likes a reply must have to be shown in your feed."
+msgstr ""
+
+#: src/view/com/modals/SelfLabel.tsx:75
+msgid "Adult Content"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:569
+msgid "Advanced"
+msgstr ""
+
+#: src/view/com/composer/photos/Gallery.tsx:130
+msgid "ALT"
+msgstr ""
+
+#: src/view/com/modals/EditImage.tsx:315
+msgid "Alt text"
+msgstr ""
+
+#: src/view/com/composer/photos/Gallery.tsx:209
+msgid "Alt text describes images for blind and low-vision users, and helps give context to everyone."
+msgstr ""
+
+#: src/view/com/modals/VerifyEmail.tsx:118
+msgid "An email has been sent to {0}. It includes a confirmation code which you can enter below."
+msgstr ""
+
+#: src/view/com/modals/ChangeEmail.tsx:119
+msgid "An email has been sent to your previous address, {0}. It includes a confirmation code which you can enter below."
+msgstr ""
+
+#: src/view/com/notifications/FeedItem.tsx:236
+#: src/view/com/threadgate/WhoCanReply.tsx:178
+msgid "and"
+msgstr ""
+
+#: src/view/screens/LanguageSettings.tsx:95
+msgid "App Language"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:589
+msgid "App passwords"
+msgstr ""
+
+#: src/view/screens/AppPasswords.tsx:186
+msgid "App Passwords"
+msgstr ""
+
+#: src/view/com/util/forms/PostDropdownBtn.tsx:207
+msgid "Appeal content warning"
+msgstr ""
+
+#: src/view/com/modals/AppealLabel.tsx:65
+msgid "Appeal Content Warning"
+msgstr ""
+
+#: src/view/com/util/moderation/LabelInfo.tsx:52
+msgid "Appeal this decision"
+msgstr ""
+
+#: src/view/com/util/moderation/LabelInfo.tsx:56
+msgid "Appeal this decision."
+msgstr ""
+
+#: src/view/screens/Settings.tsx:432
+msgid "Appearance"
+msgstr ""
+
+#: src/view/screens/AppPasswords.tsx:223
+msgid "Are you sure you want to delete the app password \"{name}\"?"
+msgstr ""
+
+#: src/view/com/composer/Composer.tsx:142
+msgid "Are you sure you'd like to discard this draft?"
+msgstr ""
+
+#: src/view/screens/ProfileList.tsx:352
+msgid "Are you sure?"
+msgstr ""
+
+#: src/view/com/util/forms/PostDropdownBtn.tsx:190
+msgid "Are you sure? This cannot be undone."
+msgstr ""
+
+#: src/view/com/modals/SelfLabel.tsx:123
+msgid "Artistic or non-erotic nudity."
+msgstr ""
+
+#: src/view/com/auth/create/CreateAccount.tsx:141
+#: src/view/com/auth/login/ChooseAccountForm.tsx:151
+#: src/view/com/auth/login/ForgotPasswordForm.tsx:166
+#: src/view/com/auth/login/LoginForm.tsx:249
+#: src/view/com/auth/login/SetNewPasswordForm.tsx:148
+#: src/view/com/modals/report/InputIssueDetails.tsx:45
+#: src/view/com/post-thread/PostThread.tsx:395
+#: src/view/com/post-thread/PostThread.tsx:445
+#: src/view/com/post-thread/PostThread.tsx:453
+#: src/view/com/profile/ProfileHeader.tsx:672
+msgid "Back"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:461
+msgid "Basics"
+msgstr ""
+
+#: src/view/com/auth/create/Step2.tsx:131
+#: src/view/com/modals/BirthDateSettings.tsx:72
+msgid "Birthday"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:312
+msgid "Birthday:"
+msgstr ""
+
+#: src/view/com/profile/ProfileHeader.tsx:282
+#: src/view/com/profile/ProfileHeader.tsx:389
+msgid "Block Account"
+msgstr ""
+
+#: src/view/screens/ProfileList.tsx:522
+msgid "Block accounts"
+msgstr ""
+
+#: src/view/screens/ProfileList.tsx:472
+msgid "Block list"
+msgstr ""
+
+#: src/view/screens/ProfileList.tsx:307
+msgid "Block these accounts?"
+msgstr ""
+
+#: src/view/screens/Moderation.tsx:123
+msgid "Blocked accounts"
+msgstr ""
+
+#: src/view/screens/ModerationBlockedAccounts.tsx:106
+msgid "Blocked Accounts"
+msgstr ""
+
+#: src/view/com/profile/ProfileHeader.tsx:284
+msgid "Blocked accounts cannot reply in your threads, mention you, or otherwise interact with you."
+msgstr ""
+
+#: src/view/screens/ModerationBlockedAccounts.tsx:114
+msgid "Blocked accounts cannot reply in your threads, mention you, or otherwise interact with you. You will not see their content and they will be prevented from seeing yours."
+msgstr ""
+
+#: src/view/com/post-thread/PostThread.tsx:251
+msgid "Blocked post."
+msgstr ""
+
+#: src/view/screens/ProfileList.tsx:309
+msgid "Blocking is public. Blocked accounts cannot reply in your threads, mention you, or otherwise interact with you."
+msgstr ""
+
+#: src/view/com/auth/HomeLoggedOutCTA.tsx:93
+msgid "Blog"
+msgstr ""
+
+#: src/view/com/auth/HomeLoggedOutCTA.tsx:31
+msgid "Bluesky"
+msgstr ""
+
+#: src/view/com/auth/onboarding/WelcomeMobile.tsx:80
+msgid "Bluesky is flexible."
+msgstr ""
+
+#: src/view/com/auth/onboarding/WelcomeMobile.tsx:69
+msgid "Bluesky is open."
+msgstr ""
+
+#: src/view/com/auth/onboarding/WelcomeMobile.tsx:56
+msgid "Bluesky is public."
+msgstr ""
+
+#: src/view/com/modals/Waitlist.tsx:70
+msgid "Bluesky uses invites to build a healthier community. If you don't know anybody with an invite, you can sign up for the waitlist and we'll send one soon."
+msgstr ""
+
+#: src/view/screens/Moderation.tsx:225
+msgid "Bluesky will not show your profile and posts to logged-out users. Other apps may not honor this request. This does not make your account private."
+msgstr ""
+
+#: src/view/com/modals/ServerInput.tsx:78
+msgid "Bluesky.Social"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:718
+msgid "Build version {0} {1}"
+msgstr ""
+
+#: src/view/com/auth/HomeLoggedOutCTA.tsx:87
+msgid "Business"
+msgstr ""
+
+#: src/view/com/composer/photos/OpenCameraBtn.tsx:60
+#: src/view/com/util/UserAvatar.tsx:221
+#: src/view/com/util/UserBanner.tsx:38
+msgid "Camera"
+msgstr ""
+
+#: src/view/com/modals/AddAppPasswords.tsx:214
+msgid "Can only contain letters, numbers, spaces, dashes, and underscores. Must be at least 4 characters long, but no more than 32 characters long."
+msgstr ""
+
+#: src/view/com/composer/Composer.tsx:285
+#: src/view/com/composer/Composer.tsx:288
+#: src/view/com/modals/AltImage.tsx:128
+#: src/view/com/modals/ChangeEmail.tsx:218
+#: src/view/com/modals/ChangeEmail.tsx:220
+#: src/view/com/modals/Confirm.tsx:88
+#: src/view/com/modals/CreateOrEditList.tsx:267
+#: src/view/com/modals/CreateOrEditList.tsx:272
+#: src/view/com/modals/DeleteAccount.tsx:150
+#: src/view/com/modals/DeleteAccount.tsx:223
+#: src/view/com/modals/EditImage.tsx:323
+#: src/view/com/modals/EditProfile.tsx:248
+#: src/view/com/modals/LinkWarning.tsx:85
+#: src/view/com/modals/Repost.tsx:73
+#: src/view/com/modals/Waitlist.tsx:136
+#: src/view/screens/Search/Search.tsx:592
+#: src/view/shell/desktop/Search.tsx:182
+msgid "Cancel"
+msgstr ""
+
+#: src/view/com/modals/DeleteAccount.tsx:146
+#: src/view/com/modals/DeleteAccount.tsx:219
+msgid "Cancel account deletion"
+msgstr ""
+
+#: src/view/com/modals/AltImage.tsx:123
+msgid "Cancel add image alt text"
+msgstr ""
+
+#: src/view/com/modals/ChangeHandle.tsx:149
+msgid "Cancel change handle"
+msgstr ""
+
+#: src/view/com/modals/crop-image/CropImage.web.tsx:134
+msgid "Cancel image crop"
+msgstr ""
+
+#: src/view/com/modals/EditProfile.tsx:243
+msgid "Cancel profile editing"
+msgstr ""
+
+#: src/view/com/modals/Repost.tsx:64
+msgid "Cancel quote post"
+msgstr ""
+
+#: src/view/com/modals/ListAddRemoveUsers.tsx:87
+#: src/view/shell/desktop/Search.tsx:178
+msgid "Cancel search"
+msgstr ""
+
+#: src/view/com/modals/Waitlist.tsx:132
+msgid "Cancel waitlist signup"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:306
+msgid "Change"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:601
+#: src/view/screens/Settings.tsx:610
+msgid "Change handle"
+msgstr ""
+
+#: src/view/com/modals/ChangeHandle.tsx:161
+msgid "Change Handle"
+msgstr ""
+
+#: src/view/com/modals/VerifyEmail.tsx:141
+msgid "Change my email"
+msgstr ""
+
+#: src/view/com/modals/ChangeEmail.tsx:109
+msgid "Change Your Email"
+msgstr ""
+
+#: src/view/com/auth/onboarding/RecommendedFeeds.tsx:121
+msgid "Check out some recommended feeds. Tap + to add them to your list of pinned feeds."
+msgstr ""
+
+#: src/view/com/auth/onboarding/RecommendedFollows.tsx:185
+msgid "Check out some recommended users. Follow them to see similar users."
+msgstr ""
+
+#: src/view/com/modals/DeleteAccount.tsx:163
+msgid "Check your inbox for an email with the confirmation code to enter below:"
+msgstr ""
+
+#: src/view/com/modals/ServerInput.tsx:38
+msgid "Choose Service"
+msgstr ""
+
+#: src/view/com/auth/onboarding/WelcomeMobile.tsx:83
+msgid "Choose the algorithms that power your experience with custom feeds."
+msgstr ""
+
+#: src/view/com/auth/create/Step2.tsx:106
+msgid "Choose your password"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:694
+msgid "Clear all legacy storage data"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:696
+msgid "Clear all legacy storage data (restart after this)"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:706
+msgid "Clear all storage data"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:708
+msgid "Clear all storage data (restart after this)"
+msgstr ""
+
+#: src/view/com/util/forms/SearchInput.tsx:73
+#: src/view/screens/Search/Search.tsx:577
+msgid "Clear search query"
+msgstr ""
+
+#: src/view/com/auth/login/PasswordUpdatedForm.tsx:38
+msgid "Close alert"
+msgstr ""
+
+#: src/view/com/util/BottomSheetCustomBackdrop.tsx:33
+msgid "Close bottom drawer"
+msgstr ""
+
+#: src/view/com/lightbox/ImageViewing/components/ImageDefaultHeader.tsx:26
+msgid "Close image"
+msgstr ""
+
+#: src/view/com/lightbox/Lightbox.web.tsx:112
+msgid "Close image viewer"
+msgstr ""
+
+#: src/view/shell/index.web.tsx:49
+msgid "Close navigation footer"
+msgstr ""
+
+#: src/view/screens/CommunityGuidelines.tsx:32
+msgid "Community Guidelines"
+msgstr ""
+
+#: src/view/com/composer/Prompt.tsx:24
+msgid "Compose reply"
+msgstr ""
+
+#: src/view/com/modals/AppealLabel.tsx:98
+#: src/view/com/modals/Confirm.tsx:75
+#: src/view/com/modals/SelfLabel.tsx:154
+#: src/view/com/modals/VerifyEmail.tsx:225
+#: src/view/screens/PreferencesHomeFeed.tsx:299
+#: src/view/screens/PreferencesThreads.tsx:153
+msgid "Confirm"
+msgstr ""
+
+#: src/view/com/modals/ChangeEmail.tsx:193
+#: src/view/com/modals/ChangeEmail.tsx:195
+msgid "Confirm Change"
+msgstr ""
+
+#: src/view/com/modals/lang-settings/ConfirmLanguagesButton.tsx:34
+msgid "Confirm content language settings"
+msgstr ""
+
+#: src/view/com/modals/DeleteAccount.tsx:209
+msgid "Confirm delete account"
+msgstr ""
+
+#: src/view/com/modals/ChangeEmail.tsx:157
+#: src/view/com/modals/DeleteAccount.tsx:176
+#: src/view/com/modals/VerifyEmail.tsx:159
+msgid "Confirmation code"
+msgstr ""
+
+#: src/view/com/auth/create/CreateAccount.tsx:174
+#: src/view/com/auth/login/LoginForm.tsx:268
+msgid "Connecting..."
+msgstr ""
+
+#: src/view/screens/Moderation.tsx:81
+msgid "Content filtering"
+msgstr ""
+
+#: src/view/com/modals/ContentFilteringSettings.tsx:44
+msgid "Content Filtering"
+msgstr ""
+
+#: src/view/com/modals/lang-settings/ContentLanguagesSettings.tsx:74
+#: src/view/screens/LanguageSettings.tsx:278
+msgid "Content Languages"
+msgstr ""
+
+#: src/view/com/util/moderation/ScreenHider.tsx:78
+msgid "Content Warning"
+msgstr ""
+
+#: src/view/com/composer/labels/LabelsBtn.tsx:31
+msgid "Content warnings"
+msgstr ""
+
+#: src/view/com/auth/onboarding/RecommendedFeeds.tsx:148
+#: src/view/com/auth/onboarding/RecommendedFollows.tsx:209
+msgid "Continue"
+msgstr ""
+
+#: src/view/com/modals/AddAppPasswords.tsx:193
+#: src/view/com/modals/InviteCodes.tsx:179
+msgid "Copied"
+msgstr ""
+
+#: src/view/com/modals/AddAppPasswords.tsx:186
+msgid "Copy"
+msgstr ""
+
+#: src/view/screens/ProfileList.tsx:384
+msgid "Copy link to list"
+msgstr ""
+
+#: src/view/com/util/forms/PostDropdownBtn.tsx:131
+msgid "Copy link to post"
+msgstr ""
+
+#: src/view/com/profile/ProfileHeader.tsx:338
+msgid "Copy link to profile"
+msgstr ""
+
+#: src/view/com/util/forms/PostDropdownBtn.tsx:117
+msgid "Copy post text"
+msgstr ""
+
+#: src/view/screens/CopyrightPolicy.tsx:29
+msgid "Copyright Policy"
+msgstr ""
+
+#: src/view/screens/ProfileFeed.tsx:94
+msgid "Could not load feed"
+msgstr ""
+
+#: src/view/screens/ProfileList.tsx:830
+msgid "Could not load list"
+msgstr ""
+
+#: src/view/com/auth/HomeLoggedOutCTA.tsx:62
+#: src/view/com/auth/SplashScreen.tsx:46
+msgid "Create a new account"
+msgstr ""
+
+#: src/view/com/auth/create/CreateAccount.tsx:120
+msgid "Create Account"
+msgstr ""
+
+#: src/view/com/auth/HomeLoggedOutCTA.tsx:54
+#: src/view/com/auth/SplashScreen.tsx:43
+msgid "Create new account"
+msgstr ""
+
+#: src/view/screens/AppPasswords.tsx:248
+msgid "Created {0}"
+msgstr ""
+
+#: src/view/com/modals/ChangeHandle.tsx:387
+#: src/view/com/modals/ServerInput.tsx:102
+msgid "Custom domain"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:615
+msgid "Danger Zone"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:622
+msgid "Delete account"
+msgstr ""
+
+#: src/view/com/modals/DeleteAccount.tsx:83
+msgid "Delete Account"
+msgstr ""
+
+#: src/view/screens/AppPasswords.tsx:221
+#: src/view/screens/AppPasswords.tsx:241
+msgid "Delete app password"
+msgstr ""
+
+#: src/view/screens/ProfileList.tsx:351
+#: src/view/screens/ProfileList.tsx:411
+msgid "Delete List"
+msgstr ""
+
+#: src/view/com/modals/DeleteAccount.tsx:212
+msgid "Delete my account"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:632
+msgid "Delete my account…"
+msgstr ""
+
+#: src/view/com/util/forms/PostDropdownBtn.tsx:185
+msgid "Delete post"
+msgstr ""
+
+#: src/view/com/util/forms/PostDropdownBtn.tsx:189
+msgid "Delete this post?"
+msgstr ""
+
+#: src/view/com/post-thread/PostThread.tsx:243
+msgid "Deleted post."
+msgstr ""
+
+#: src/view/com/modals/CreateOrEditList.tsx:218
+#: src/view/com/modals/CreateOrEditList.tsx:234
+#: src/view/com/modals/EditProfile.tsx:197
+#: src/view/com/modals/EditProfile.tsx:209
+msgid "Description"
+msgstr ""
+
+#: src/view/com/auth/create/Step1.tsx:96
+msgid "Dev Server"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:637
+msgid "Developer Tools"
+msgstr ""
+
+#: src/view/com/composer/Composer.tsx:143
+msgid "Discard"
+msgstr ""
+
+#: src/view/com/composer/Composer.tsx:137
+msgid "Discard draft"
+msgstr ""
+
+#: src/view/screens/Moderation.tsx:207
+msgid "Discourage apps from showing my account to logged-out users"
+msgstr ""
+
+#: src/view/screens/Feeds.tsx:405
+msgid "Discover new feeds"
+msgstr ""
+
+#: src/view/com/modals/EditProfile.tsx:191
+msgid "Display name"
+msgstr ""
+
+#: src/view/com/modals/EditProfile.tsx:179
+msgid "Display Name"
+msgstr ""
+
+#: src/view/com/modals/ChangeHandle.tsx:485
+msgid "Domain verified!"
+msgstr ""
+
+#: src/view/com/auth/onboarding/RecommendedFollows.tsx:86
+#: src/view/com/modals/ContentFilteringSettings.tsx:88
+#: src/view/com/modals/ContentFilteringSettings.tsx:96
+#: src/view/com/modals/crop-image/CropImage.web.tsx:152
+#: src/view/com/modals/EditImage.tsx:333
+#: src/view/com/modals/ListAddRemoveUsers.tsx:142
+#: src/view/com/modals/SelfLabel.tsx:157
+#: src/view/com/modals/Threadgate.tsx:129
+#: src/view/com/modals/Threadgate.tsx:132
+#: src/view/com/modals/UserAddRemoveLists.tsx:79
+#: src/view/screens/PreferencesHomeFeed.tsx:302
+#: src/view/screens/PreferencesThreads.tsx:156
+msgid "Done"
+msgstr ""
+
+#: src/view/com/modals/lang-settings/ConfirmLanguagesButton.tsx:42
+msgid "Done{extraText}"
+msgstr ""
+
+#: src/view/com/modals/InviteCodes.tsx:94
+msgid "Each code works once. You'll receive more invite codes periodically."
+msgstr ""
+
+#: src/view/com/composer/photos/Gallery.tsx:144
+#: src/view/com/modals/EditImage.tsx:207
+msgid "Edit image"
+msgstr ""
+
+#: src/view/screens/ProfileList.tsx:399
+msgid "Edit list details"
+msgstr ""
+
+#: src/view/screens/Feeds.tsx:367
+#: src/view/screens/SavedFeeds.tsx:84
+msgid "Edit My Feeds"
+msgstr ""
+
+#: src/view/com/modals/EditProfile.tsx:151
+msgid "Edit my profile"
+msgstr ""
+
+#: src/view/com/profile/ProfileHeader.tsx:453
+msgid "Edit profile"
+msgstr ""
+
+#: src/view/com/profile/ProfileHeader.tsx:456
+msgid "Edit Profile"
+msgstr ""
+
+#: src/view/screens/Feeds.tsx:330
+msgid "Edit Saved Feeds"
+msgstr ""
+
+#: src/view/com/auth/create/Step2.tsx:90
+#: src/view/com/auth/login/ForgotPasswordForm.tsx:148
+#: src/view/com/modals/ChangeEmail.tsx:141
+#: src/view/com/modals/Waitlist.tsx:88
+msgid "Email"
+msgstr ""
+
+#: src/view/com/auth/create/Step2.tsx:81
+msgid "Email address"
+msgstr ""
+
+#: src/view/com/modals/ChangeEmail.tsx:111
+msgid "Email Updated"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:290
+msgid "Email:"
+msgstr ""
+
+#: src/view/screens/PreferencesHomeFeed.tsx:138
+msgid "Enable this setting to only see replies between people you follow."
+msgstr ""
+
+#: src/view/screens/Profile.tsx:426
+msgid "End of feed"
+msgstr ""
+
+#: src/view/com/auth/create/Step1.tsx:71
+msgid "Enter the address of your provider:"
+msgstr ""
+
+#: src/view/com/modals/ChangeHandle.tsx:369
+msgid "Enter the domain you want to use"
+msgstr ""
+
+#: src/view/com/auth/login/ForgotPasswordForm.tsx:101
+msgid "Enter the email you used to create your account. We'll send you a \"reset code\" so you can set a new password."
+msgstr ""
+
+#: src/view/com/auth/create/Step2.tsx:86
+msgid "Enter your email address"
+msgstr ""
+
+#: src/view/com/modals/ChangeEmail.tsx:117
+msgid "Enter your new email address below."
+msgstr ""
+
+#: src/view/com/auth/login/Login.tsx:99
+msgid "Enter your username and password"
+msgstr ""
+
+#: src/view/screens/Search/Search.tsx:106
+msgid "Error:"
+msgstr ""
+
+#: src/view/com/modals/Threadgate.tsx:76
+msgid "Everybody"
+msgstr ""
+
+#: src/view/com/lightbox/Lightbox.web.tsx:156
+msgid "Expand alt text"
+msgstr ""
+
+#: src/view/com/auth/onboarding/RecommendedFeeds.tsx:109
+#: src/view/com/auth/onboarding/RecommendedFeeds.tsx:141
+msgid "Failed to load recommended feeds"
+msgstr ""
+
+#: src/view/screens/Feeds.tsx:560
+msgid "Feed offline"
+msgstr ""
+
+#: src/view/com/feeds/FeedPage.tsx:143
+msgid "Feed Preferences"
+msgstr ""
+
+#: src/view/shell/desktop/RightNav.tsx:65
+#: src/view/shell/Drawer.tsx:292
+msgid "Feedback"
+msgstr ""
+
+#: src/view/screens/Feeds.tsx:475
+#: src/view/screens/Profile.tsx:165
+#: src/view/shell/bottom-bar/BottomBar.tsx:181
+#: src/view/shell/desktop/LeftNav.tsx:340
+#: src/view/shell/Drawer.tsx:455
+#: src/view/shell/Drawer.tsx:456
+msgid "Feeds"
+msgstr ""
+
+#: src/view/com/auth/onboarding/RecommendedFeeds.tsx:57
+msgid "Feeds are created by users to curate content. Choose some feeds that you find interesting."
+msgstr ""
+
+#: src/view/screens/SavedFeeds.tsx:156
+msgid "Feeds are custom algorithms that users build with a little coding expertise. <0/> for more information."
+msgstr ""
+
+#: src/view/screens/Search/Search.tsx:422
+msgid "Find users on Bluesky"
+msgstr ""
+
+#: src/view/screens/Search/Search.tsx:420
+msgid "Find users with the search tool on the right"
+msgstr ""
+
+#: src/view/com/auth/onboarding/RecommendedFollowsItem.tsx:150
+msgid "Finding similar accounts..."
+msgstr ""
+
+#: src/view/screens/PreferencesHomeFeed.tsx:102
+msgid "Fine-tune the content you see on your home screen."
+msgstr ""
+
+#: src/view/screens/PreferencesThreads.tsx:60
+msgid "Fine-tune the discussion threads."
+msgstr ""
+
+#: src/view/com/profile/ProfileHeader.tsx:538
+msgid "Follow"
+msgstr ""
+
+#: src/view/com/auth/onboarding/RecommendedFollows.tsx:64
+msgid "Follow some users to get started. We can recommend you more users based on who you find interesting."
+msgstr ""
+
+#: src/view/com/modals/Threadgate.tsx:98
+msgid "Followed users"
+msgstr ""
+
+#: src/view/screens/PreferencesHomeFeed.tsx:145
+msgid "Followed users only"
+msgstr ""
+
+#: src/view/screens/ProfileFollowers.tsx:25
+msgid "Followers"
+msgstr ""
+
+#: src/view/com/profile/ProfileHeader.tsx:624
+msgid "following"
+msgstr ""
+
+#: src/view/com/profile/ProfileHeader.tsx:522
+#: src/view/screens/ProfileFollows.tsx:25
+msgid "Following"
+msgstr ""
+
+#: src/view/com/profile/ProfileHeader.tsx:571
+msgid "Follows you"
+msgstr ""
+
+#: src/view/com/modals/DeleteAccount.tsx:107
+msgid "For security reasons, we'll need to send a confirmation code to your email address."
+msgstr ""
+
+#: src/view/com/modals/AddAppPasswords.tsx:207
+msgid "For security reasons, you won't be able to view this again. If you lose this password, you'll need to generate a new one."
+msgstr ""
+
+#: src/view/com/auth/login/LoginForm.tsx:231
+msgid "Forgot"
+msgstr ""
+
+#: src/view/com/auth/login/LoginForm.tsx:228
+msgid "Forgot password"
+msgstr ""
+
+#: src/view/com/auth/login/Login.tsx:127
+#: src/view/com/auth/login/Login.tsx:143
+msgid "Forgot Password"
+msgstr ""
+
+#: src/view/com/composer/photos/SelectPhotoBtn.tsx:43
+msgid "Gallery"
+msgstr ""
+
+#: src/view/com/modals/VerifyEmail.tsx:183
+msgid "Get Started"
+msgstr ""
+
+#: src/view/com/auth/LoggedOut.tsx:81
+#: src/view/com/auth/LoggedOut.tsx:82
+#: src/view/com/util/moderation/ScreenHider.tsx:123
+#: src/view/shell/desktop/LeftNav.tsx:104
+msgid "Go back"
+msgstr ""
+
+#: src/view/screens/ProfileFeed.tsx:103
+#: src/view/screens/ProfileFeed.tsx:108
+#: src/view/screens/ProfileList.tsx:839
+#: src/view/screens/ProfileList.tsx:844
+msgid "Go Back"
+msgstr ""
+
+#: src/view/com/auth/login/ForgotPasswordForm.tsx:181
+#: src/view/com/auth/login/LoginForm.tsx:278
+#: src/view/com/auth/login/SetNewPasswordForm.tsx:163
+msgid "Go to next"
+msgstr ""
+
+#: src/view/com/modals/ChangeHandle.tsx:265
+msgid "Handle"
+msgstr ""
+
+#: src/view/shell/desktop/RightNav.tsx:94
+#: src/view/shell/Drawer.tsx:302
+msgid "Help"
+msgstr ""
+
+#: src/view/com/modals/AddAppPasswords.tsx:148
+msgid "Here is your app password."
+msgstr ""
+
+#: src/view/com/notifications/FeedItem.tsx:316
+#: src/view/com/util/moderation/ContentHider.tsx:103
+msgid "Hide"
+msgstr ""
+
+#: src/view/com/notifications/FeedItem.tsx:308
+msgid "Hide user list"
+msgstr ""
+
+#: src/view/com/posts/FeedErrorMessage.tsx:110
+msgid "Hmm, some kind of issue occurred when contacting the feed server. Please let the feed owner know about this issue."
+msgstr ""
+
+#: src/view/com/posts/FeedErrorMessage.tsx:98
+msgid "Hmm, the feed server appears to be misconfigured. Please let the feed owner know about this issue."
+msgstr ""
+
+#: src/view/com/posts/FeedErrorMessage.tsx:104
+msgid "Hmm, the feed server appears to be offline. Please let the feed owner know about this issue."
+msgstr ""
+
+#: src/view/com/posts/FeedErrorMessage.tsx:101
+msgid "Hmm, the feed server gave a bad response. Please let the feed owner know about this issue."
+msgstr ""
+
+#: src/view/com/posts/FeedErrorMessage.tsx:95
+msgid "Hmm, we're having trouble finding this feed. It may have been deleted."
+msgstr ""
+
+#: src/view/shell/bottom-bar/BottomBar.tsx:137
+#: src/view/shell/desktop/LeftNav.tsx:304
+#: src/view/shell/Drawer.tsx:379
+#: src/view/shell/Drawer.tsx:380
+msgid "Home"
+msgstr ""
+
+#: src/view/com/pager/FeedsTabBarMobile.tsx:96
+#: src/view/screens/PreferencesHomeFeed.tsx:95
+#: src/view/screens/Settings.tsx:481
+msgid "Home Feed Preferences"
+msgstr ""
+
+#: src/view/com/auth/login/ForgotPasswordForm.tsx:114
+msgid "Hosting provider"
+msgstr ""
+
+#: src/view/com/auth/create/Step1.tsx:76
+#: src/view/com/auth/create/Step1.tsx:81
+msgid "Hosting provider address"
+msgstr ""
+
+#: src/view/com/modals/VerifyEmail.tsx:208
+msgid "I have a code"
+msgstr ""
+
+#: src/view/com/modals/ChangeHandle.tsx:281
+msgid "I have my own domain"
+msgstr ""
+
+#: src/view/com/modals/SelfLabel.tsx:127
+msgid "If none are selected, suitable for all ages."
+msgstr ""
+
+#: src/view/com/modals/AltImage.tsx:97
+msgid "Image alt text"
+msgstr ""
+
+#: src/view/com/util/UserAvatar.tsx:308
+#: src/view/com/util/UserBanner.tsx:116
+msgid "Image options"
+msgstr ""
+
+#: src/view/com/auth/login/LoginForm.tsx:113
+msgid "Invalid username or password"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:383
+msgid "Invite"
+msgstr ""
+
+#: src/view/com/modals/InviteCodes.tsx:91
+#: src/view/screens/Settings.tsx:371
+msgid "Invite a Friend"
+msgstr ""
+
+#: src/view/com/auth/create/Step2.tsx:57
+msgid "Invite code"
+msgstr ""
+
+#: src/view/com/auth/create/state.ts:136
+msgid "Invite code not accepted. Check that you input it correctly and try again."
+msgstr ""
+
+#: src/view/shell/Drawer.tsx:621
+msgid "Invite codes: {invitesAvailable} available"
+msgstr ""
+
+#: src/view/com/auth/HomeLoggedOutCTA.tsx:99
+msgid "Jobs"
+msgstr ""
+
+#: src/view/com/modals/Waitlist.tsx:67
+msgid "Join the waitlist"
+msgstr ""
+
+#: src/view/com/auth/create/Step2.tsx:68
+#: src/view/com/auth/create/Step2.tsx:72
+msgid "Join the waitlist."
+msgstr ""
+
+#: src/view/com/modals/Waitlist.tsx:124
+msgid "Join Waitlist"
+msgstr ""
+
+#: src/view/com/composer/select-language/SelectLangBtn.tsx:104
+msgid "Language selection"
+msgstr ""
+
+#: src/view/screens/LanguageSettings.tsx:89
+msgid "Language Settings"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:541
+msgid "Languages"
+msgstr ""
+
+#: src/view/com/util/moderation/ContentHider.tsx:101
+msgid "Learn more"
+msgstr ""
+
+#: src/view/com/util/moderation/PostAlerts.tsx:47
+#: src/view/com/util/moderation/ProfileHeaderAlerts.tsx:65
+#: src/view/com/util/moderation/ScreenHider.tsx:104
+msgid "Learn More"
+msgstr ""
+
+#: src/view/com/util/moderation/ContentHider.tsx:83
+#: src/view/com/util/moderation/PostAlerts.tsx:40
+#: src/view/com/util/moderation/PostHider.tsx:76
+#: src/view/com/util/moderation/ProfileHeaderAlerts.tsx:49
+#: src/view/com/util/moderation/ScreenHider.tsx:101
+msgid "Learn more about this warning"
+msgstr ""
+
+#: src/view/screens/Moderation.tsx:242
+msgid "Learn more about what is public on Bluesky."
+msgstr ""
+
+#: src/view/com/modals/lang-settings/ContentLanguagesSettings.tsx:82
+msgid "Leave them all unchecked to see any language."
+msgstr ""
+
+#: src/view/com/modals/LinkWarning.tsx:49
+msgid "Leaving Bluesky"
+msgstr ""
+
+#: src/view/com/auth/login/Login.tsx:128
+#: src/view/com/auth/login/Login.tsx:144
+msgid "Let's get your password reset!"
+msgstr ""
+
+#: src/view/com/util/UserAvatar.tsx:245
+#: src/view/com/util/UserBanner.tsx:60
+msgid "Library"
+msgstr ""
+
+#: src/view/screens/ProfileFeed.tsx:577
+msgid "Like this feed"
+msgstr ""
+
+#: src/view/screens/PostLikedBy.tsx:27
+#: src/view/screens/ProfileFeedLikedBy.tsx:27
+msgid "Liked by"
+msgstr ""
+
+#: src/view/screens/Profile.tsx:164
+msgid "Likes"
+msgstr ""
+
+#: src/view/com/modals/CreateOrEditList.tsx:186
+msgid "List Avatar"
+msgstr ""
+
+#: src/view/com/modals/CreateOrEditList.tsx:199
+msgid "List Name"
+msgstr ""
+
+#: src/view/screens/Profile.tsx:166
+#: src/view/shell/desktop/LeftNav.tsx:377
+#: src/view/shell/Drawer.tsx:471
+#: src/view/shell/Drawer.tsx:472
+msgid "Lists"
+msgstr ""
+
+#: src/view/com/post-thread/PostThread.tsx:260
+#: src/view/com/post-thread/PostThread.tsx:268
+msgid "Load more posts"
+msgstr ""
+
+#: src/view/screens/Notifications.tsx:144
+msgid "Load new notifications"
+msgstr ""
+
+#: src/view/com/feeds/FeedPage.tsx:189
+msgid "Load new posts"
+msgstr ""
+
+#: src/view/com/composer/text-input/mobile/Autocomplete.tsx:95
+msgid "Loading..."
+msgstr ""
+
+#: src/view/com/modals/ServerInput.tsx:50
+msgid "Local dev server"
+msgstr ""
+
+#: src/view/screens/Moderation.tsx:136
+msgid "Logged-out visibility"
+msgstr ""
+
+#: src/view/com/auth/login/ChooseAccountForm.tsx:133
+msgid "Login to account that is not listed"
+msgstr ""
+
+#: src/view/com/modals/LinkWarning.tsx:63
+msgid "Make sure this is where you intend to go!"
+msgstr ""
+
+#: src/view/screens/Profile.tsx:163
+msgid "Media"
+msgstr ""
+
+#: src/view/com/threadgate/WhoCanReply.tsx:139
+msgid "mentioned users"
+msgstr ""
+
+#: src/view/com/modals/Threadgate.tsx:93
+msgid "Mentioned users"
+msgstr ""
+
+#: src/view/screens/Search/Search.tsx:537
+msgid "Menu"
+msgstr ""
+
+#: src/view/com/posts/FeedErrorMessage.tsx:194
+msgid "Message from server"
+msgstr ""
+
+#: src/view/screens/Moderation.tsx:64
+#: src/view/screens/Settings.tsx:563
+#: src/view/shell/desktop/LeftNav.tsx:395
+#: src/view/shell/Drawer.tsx:490
+#: src/view/shell/Drawer.tsx:491
+msgid "Moderation"
+msgstr ""
+
+#: src/view/screens/Moderation.tsx:95
+msgid "Moderation lists"
+msgstr ""
+
+#: src/view/screens/ModerationModlists.tsx:58
+msgid "Moderation Lists"
+msgstr ""
+
+#: src/view/shell/desktop/Feeds.tsx:53
+msgid "More feeds"
+msgstr ""
+
+#: src/view/com/profile/ProfileHeader.tsx:548
+#: src/view/screens/ProfileFeed.tsx:360
+#: src/view/screens/ProfileList.tsx:583
+msgid "More options"
+msgstr ""
+
+#: src/view/com/profile/ProfileHeader.tsx:370
+msgid "Mute Account"
+msgstr ""
+
+#: src/view/screens/ProfileList.tsx:510
+msgid "Mute accounts"
+msgstr ""
+
+#: src/view/screens/ProfileList.tsx:457
+msgid "Mute list"
+msgstr ""
+
+#: src/view/screens/ProfileList.tsx:270
+msgid "Mute these accounts?"
+msgstr ""
+
+#: src/view/com/util/forms/PostDropdownBtn.tsx:149
+msgid "Mute thread"
+msgstr ""
+
+#: src/view/screens/Moderation.tsx:109
+msgid "Muted accounts"
+msgstr ""
+
+#: src/view/screens/ModerationMutedAccounts.tsx:106
+msgid "Muted Accounts"
+msgstr ""
+
+#: src/view/screens/ModerationMutedAccounts.tsx:114
+msgid "Muted accounts have their posts removed from your feed and from your notifications. Mutes are completely private."
+msgstr ""
+
+#: src/view/screens/ProfileList.tsx:272
+msgid "Muting is private. Muted accounts can interact with you, but you will not see their posts or receive notifications from them."
+msgstr ""
+
+#: src/view/com/modals/BirthDateSettings.tsx:56
+msgid "My Birthday"
+msgstr ""
+
+#: src/view/screens/Feeds.tsx:363
+msgid "My Feeds"
+msgstr ""
+
+#: src/view/shell/desktop/LeftNav.tsx:65
+msgid "My Profile"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:520
+msgid "My Saved Feeds"
+msgstr ""
+
+#: src/view/com/modals/AddAppPasswords.tsx:177
+#: src/view/com/modals/CreateOrEditList.tsx:211
+msgid "Name"
+msgstr ""
+
+#: src/view/com/auth/onboarding/WelcomeMobile.tsx:72
+msgid "Never lose access to your followers and data."
+msgstr ""
+
+#: src/view/screens/Lists.tsx:76
+#: src/view/screens/ModerationModlists.tsx:78
+msgid "New"
+msgstr ""
+
+#: src/view/com/feeds/FeedPage.tsx:200
+#: src/view/screens/Feeds.tsx:511
+#: src/view/screens/Profile.tsx:354
+#: src/view/screens/ProfileFeed.tsx:430
+#: src/view/screens/ProfileList.tsx:193
+#: src/view/screens/ProfileList.tsx:221
+#: src/view/shell/desktop/LeftNav.tsx:247
+msgid "New post"
+msgstr ""
+
+#: src/view/shell/desktop/LeftNav.tsx:257
+msgid "New Post"
+msgstr ""
+
+#: src/view/com/auth/create/CreateAccount.tsx:154
+#: src/view/com/auth/login/ForgotPasswordForm.tsx:174
+#: src/view/com/auth/login/ForgotPasswordForm.tsx:184
+#: src/view/com/auth/login/LoginForm.tsx:281
+#: src/view/com/auth/login/SetNewPasswordForm.tsx:156
+#: src/view/com/auth/login/SetNewPasswordForm.tsx:166
+#: src/view/com/auth/onboarding/RecommendedFeeds.tsx:79
+msgid "Next"
+msgstr ""
+
+#: src/view/com/lightbox/Lightbox.web.tsx:142
+msgid "Next image"
+msgstr ""
+
+#: src/view/screens/PreferencesHomeFeed.tsx:191
+#: src/view/screens/PreferencesHomeFeed.tsx:226
+#: src/view/screens/PreferencesHomeFeed.tsx:263
+msgid "No"
+msgstr ""
+
+#: src/view/screens/ProfileFeed.tsx:570
+#: src/view/screens/ProfileList.tsx:711
+msgid "No description"
+msgstr ""
+
+#: src/view/com/composer/text-input/mobile/Autocomplete.tsx:97
+msgid "No result"
+msgstr ""
+
+#: src/view/screens/Feeds.tsx:452
+msgid "No results found for \"{query}\""
+msgstr ""
+
+#: src/view/com/modals/ListAddRemoveUsers.tsx:127
+#: src/view/screens/Search/Search.tsx:271
+#: src/view/screens/Search/Search.tsx:299
+#: src/view/screens/Search/Search.tsx:615
+#: src/view/shell/desktop/Search.tsx:210
+msgid "No results found for {query}"
+msgstr ""
+
+#: src/view/com/modals/Threadgate.tsx:82
+msgid "Nobody"
+msgstr ""
+
+#: src/view/com/modals/SelfLabel.tsx:135
+msgid "Not Applicable."
+msgstr ""
+
+#: src/view/screens/Moderation.tsx:232
+msgid "Note: Bluesky is an open and public network. This setting only limits the visibility of your content on the Bluesky app and website, and other apps may not respect this setting. Your content may still be shown to logged-out users by other apps and websites."
+msgstr ""
+
+#: src/view/screens/Notifications.tsx:109
+#: src/view/screens/Notifications.tsx:133
+#: src/view/shell/bottom-bar/BottomBar.tsx:205
+#: src/view/shell/desktop/LeftNav.tsx:359
+#: src/view/shell/Drawer.tsx:416
+#: src/view/shell/Drawer.tsx:417
+msgid "Notifications"
+msgstr ""
+
+#: src/view/com/util/ErrorBoundary.tsx:34
+msgid "Oh no!"
+msgstr ""
+
+#: src/view/com/auth/login/PasswordUpdatedForm.tsx:41
+msgid "Okay"
+msgstr ""
+
+#: src/view/com/composer/Composer.tsx:354
+msgid "One or more images is missing alt text."
+msgstr ""
+
+#: src/view/com/threadgate/WhoCanReply.tsx:100
+msgid "Only {0} can reply."
+msgstr ""
+
+#: src/view/com/pager/FeedsTabBarMobile.tsx:76
+msgid "Open navigation"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:533
+msgid "Opens configurable language settings"
+msgstr ""
+
+#: src/view/shell/desktop/RightNav.tsx:148
+#: src/view/shell/Drawer.tsx:622
+msgid "Opens list of invite codes"
+msgstr ""
+
+#: src/view/com/modals/ChangeHandle.tsx:279
+msgid "Opens modal for using custom domain"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:558
+msgid "Opens moderation settings"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:514
+msgid "Opens screen with all saved feeds"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:581
+msgid "Opens the app password settings page"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:473
+msgid "Opens the home feed preferences"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:664
+msgid "Opens the storybook page"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:644
+msgid "Opens the system log page"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:494
+msgid "Opens the threads preferences"
+msgstr ""
+
+#: src/view/com/auth/login/ChooseAccountForm.tsx:138
+msgid "Other account"
+msgstr ""
+
+#: src/view/com/modals/ServerInput.tsx:88
+msgid "Other service"
+msgstr ""
+
+#: src/view/com/composer/select-language/SelectLangBtn.tsx:91
+msgid "Other..."
+msgstr ""
+
+#: src/view/screens/NotFound.tsx:42
+#: src/view/screens/NotFound.tsx:45
+msgid "Page not found"
+msgstr ""
+
+#: src/view/com/auth/create/Step2.tsx:101
+#: src/view/com/auth/create/Step2.tsx:111
+#: src/view/com/auth/login/LoginForm.tsx:216
+#: src/view/com/auth/login/SetNewPasswordForm.tsx:130
+#: src/view/com/modals/DeleteAccount.tsx:191
+msgid "Password"
+msgstr ""
+
+#: src/view/com/auth/login/Login.tsx:157
+msgid "Password updated"
+msgstr ""
+
+#: src/view/com/auth/login/PasswordUpdatedForm.tsx:28
+msgid "Password updated!"
+msgstr ""
+
+#: src/view/com/modals/SelfLabel.tsx:121
+msgid "Pictures meant for adults."
+msgstr ""
+
+#: src/view/screens/SavedFeeds.tsx:88
+msgid "Pinned Feeds"
+msgstr ""
+
+#: src/view/com/auth/create/state.ts:116
+msgid "Please choose your handle."
+msgstr ""
+
+#: src/view/com/auth/create/state.ts:109
+msgid "Please choose your password."
+msgstr ""
+
+#: src/view/com/modals/ChangeEmail.tsx:67
+msgid "Please confirm your email before changing it. This is a temporary requirement while email-updating tools are added, and it will soon be removed."
+msgstr ""
+
+#: src/view/com/modals/AddAppPasswords.tsx:140
+msgid "Please enter a unique name for this App Password or use our randomly generated one."
+msgstr ""
+
+#: src/view/com/auth/create/state.ts:95
+msgid "Please enter your email."
+msgstr ""
+
+#: src/view/com/modals/DeleteAccount.tsx:180
+msgid "Please enter your password as well:"
+msgstr ""
+
+#: src/view/com/modals/AppealLabel.tsx:72
+#: src/view/com/modals/AppealLabel.tsx:75
+msgid "Please tell us why you think this content warning was incorrectly applied!"
+msgstr ""
+
+#: src/view/com/composer/Composer.tsx:337
+#: src/view/com/post-thread/PostThread.tsx:226
+#: src/view/screens/PostThread.tsx:80
+msgid "Post"
+msgstr ""
+
+#: src/view/com/post-thread/PostThread.tsx:385
+msgid "Post hidden"
+msgstr ""
+
+#: src/view/com/composer/select-language/SelectLangBtn.tsx:87
+msgid "Post language"
+msgstr ""
+
+#: src/view/com/modals/lang-settings/PostLanguagesSettings.tsx:75
+msgid "Post Languages"
+msgstr ""
+
+#: src/view/com/post-thread/PostThread.tsx:437
+msgid "Post not found"
+msgstr ""
+
+#: src/view/screens/Profile.tsx:161
+msgid "Posts"
+msgstr ""
+
+#: src/view/com/modals/LinkWarning.tsx:44
+msgid "Potentially Misleading Link"
+msgstr ""
+
+#: src/view/com/lightbox/Lightbox.web.tsx:128
+msgid "Previous image"
+msgstr ""
+
+#: src/view/screens/LanguageSettings.tsx:187
+msgid "Primary Language"
+msgstr ""
+
+#: src/view/screens/PreferencesThreads.tsx:91
+msgid "Prioritize Your Follows"
+msgstr ""
+
+#: src/view/shell/desktop/RightNav.tsx:76
+msgid "Privacy"
+msgstr ""
+
+#: src/view/screens/PrivacyPolicy.tsx:29
+msgid "Privacy Policy"
+msgstr ""
+
+#: src/view/com/auth/login/ForgotPasswordForm.tsx:190
+msgid "Processing..."
+msgstr ""
+
+#: src/view/shell/bottom-bar/BottomBar.tsx:247
+#: src/view/shell/desktop/LeftNav.tsx:413
+#: src/view/shell/Drawer.tsx:69
+#: src/view/shell/Drawer.tsx:525
+#: src/view/shell/Drawer.tsx:526
+msgid "Profile"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:789
+msgid "Protect your account by verifying your email."
+msgstr ""
+
+#: src/view/screens/ModerationModlists.tsx:61
+msgid "Public, shareable lists of users to mute or block in bulk."
+msgstr ""
+
+#: src/view/screens/Lists.tsx:61
+msgid "Public, shareable lists which can drive feeds."
+msgstr ""
+
+#: src/view/com/modals/Repost.tsx:52
+#: src/view/com/util/post-ctrls/RepostButton.web.tsx:58
+msgid "Quote post"
+msgstr ""
+
+#: src/view/com/modals/Repost.tsx:56
+msgid "Quote Post"
+msgstr ""
+
+#: src/view/com/modals/EditImage.tsx:236
+msgid "Ratios"
+msgstr ""
+
+#: src/view/com/auth/onboarding/RecommendedFeeds.tsx:116
+msgid "Recommended Feeds"
+msgstr ""
+
+#: src/view/com/auth/onboarding/RecommendedFollows.tsx:180
+msgid "Recommended Users"
+msgstr ""
+
+#: src/view/com/modals/ListAddRemoveUsers.tsx:264
+#: src/view/com/modals/SelfLabel.tsx:83
+#: src/view/com/modals/UserAddRemoveLists.tsx:193
+#: src/view/com/util/UserAvatar.tsx:282
+#: src/view/com/util/UserBanner.tsx:89
+msgid "Remove"
+msgstr ""
+
+#: src/view/com/feeds/FeedSourceCard.tsx:106
+msgid "Remove {0} from my feeds?"
+msgstr ""
+
+#: src/view/com/util/AccountDropdownBtn.tsx:22
+msgid "Remove account"
+msgstr ""
+
+#: src/view/com/posts/FeedErrorMessage.tsx:130
+msgid "Remove feed"
+msgstr ""
+
+#: src/view/com/feeds/FeedSourceCard.tsx:105
+#: src/view/com/feeds/FeedSourceCard.tsx:172
+#: src/view/screens/ProfileFeed.tsx:270
+msgid "Remove from my feeds"
+msgstr ""
+
+#: src/view/com/composer/photos/Gallery.tsx:167
+msgid "Remove image"
+msgstr ""
+
+#: src/view/com/composer/ExternalEmbed.tsx:70
+msgid "Remove image preview"
+msgstr ""
+
+#: src/view/com/feeds/FeedSourceCard.tsx:173
+msgid "Remove this feed from my feeds?"
+msgstr ""
+
+#: src/view/com/posts/FeedErrorMessage.tsx:131
+msgid "Remove this feed from your saved feeds?"
+msgstr ""
+
+#: src/view/com/modals/ListAddRemoveUsers.tsx:199
+#: src/view/com/modals/UserAddRemoveLists.tsx:136
+msgid "Removed from list"
+msgstr ""
+
+#: src/view/screens/Profile.tsx:162
+msgid "Replies"
+msgstr ""
+
+#: src/view/com/threadgate/WhoCanReply.tsx:98
+msgid "Replies to this thread are disabled"
+msgstr ""
+
+#: src/view/screens/PreferencesHomeFeed.tsx:135
+msgid "Reply Filters"
+msgstr ""
+
+#: src/view/com/modals/report/Modal.tsx:166
+msgid "Report {collectionName}"
+msgstr ""
+
+#: src/view/com/profile/ProfileHeader.tsx:404
+msgid "Report Account"
+msgstr ""
+
+#: src/view/screens/ProfileFeed.tsx:290
+msgid "Report feed"
+msgstr ""
+
+#: src/view/screens/ProfileList.tsx:425
+msgid "Report List"
+msgstr ""
+
+#: src/view/com/modals/report/SendReportButton.tsx:37
+#: src/view/com/util/forms/PostDropdownBtn.tsx:167
+msgid "Report post"
+msgstr ""
+
+#: src/view/com/util/post-ctrls/RepostButton.web.tsx:48
+msgid "Repost"
+msgstr ""
+
+#: src/view/com/util/post-ctrls/RepostButton.web.tsx:94
+#: src/view/com/util/post-ctrls/RepostButton.web.tsx:105
+msgid "Repost or quote post"
+msgstr ""
+
+#: src/view/screens/PostRepostedBy.tsx:27
+msgid "Reposted by"
+msgstr ""
+
+#: src/view/com/modals/ChangeEmail.tsx:181
+#: src/view/com/modals/ChangeEmail.tsx:183
+msgid "Request Change"
+msgstr ""
+
+#: src/view/com/auth/create/Step2.tsx:53
+msgid "Required for this provider"
+msgstr ""
+
+#: src/view/com/auth/login/SetNewPasswordForm.tsx:108
+msgid "Reset code"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:686
+msgid "Reset onboarding state"
+msgstr ""
+
+#: src/view/com/auth/login/ForgotPasswordForm.tsx:98
+msgid "Reset password"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:676
+msgid "Reset preferences state"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:684
+msgid "Resets the onboarding state"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:674
+msgid "Resets the preferences state"
+msgstr ""
+
+#: src/view/com/auth/create/CreateAccount.tsx:163
+#: src/view/com/auth/create/CreateAccount.tsx:167
+#: src/view/com/auth/login/LoginForm.tsx:258
+#: src/view/com/auth/login/LoginForm.tsx:261
+#: src/view/com/util/error/ErrorMessage.tsx:55
+#: src/view/com/util/error/ErrorScreen.tsx:65
+msgid "Retry"
+msgstr ""
+
+#: src/view/com/modals/AltImage.tsx:115
+#: src/view/com/modals/BirthDateSettings.tsx:93
+#: src/view/com/modals/BirthDateSettings.tsx:96
+#: src/view/com/modals/ChangeHandle.tsx:173
+#: src/view/com/modals/CreateOrEditList.tsx:249
+#: src/view/com/modals/CreateOrEditList.tsx:257
+#: src/view/com/modals/EditProfile.tsx:223
+msgid "Save"
+msgstr ""
+
+#: src/view/com/modals/AltImage.tsx:106
+msgid "Save alt text"
+msgstr ""
+
+#: src/view/com/modals/EditProfile.tsx:231
+msgid "Save Changes"
+msgstr ""
+
+#: src/view/com/modals/ChangeHandle.tsx:170
+msgid "Save handle change"
+msgstr ""
+
+#: src/view/com/modals/crop-image/CropImage.web.tsx:144
+msgid "Save image crop"
+msgstr ""
+
+#: src/view/screens/SavedFeeds.tsx:122
+msgid "Saved Feeds"
+msgstr ""
+
+#: src/view/com/modals/ListAddRemoveUsers.tsx:75
+#: src/view/com/util/forms/SearchInput.tsx:64
+#: src/view/screens/Search/Search.tsx:401
+#: src/view/screens/Search/Search.tsx:567
+#: src/view/shell/bottom-bar/BottomBar.tsx:159
+#: src/view/shell/desktop/LeftNav.tsx:322
+#: src/view/shell/desktop/Search.tsx:161
+#: src/view/shell/desktop/Search.tsx:170
+#: src/view/shell/Drawer.tsx:343
+#: src/view/shell/Drawer.tsx:344
+msgid "Search"
+msgstr ""
+
+#: src/view/com/auth/LoggedOut.tsx:104
+#: src/view/com/auth/LoggedOut.tsx:105
+msgid "Search for users"
+msgstr ""
+
+#: src/view/com/modals/ChangeEmail.tsx:110
+msgid "Security Step Required"
+msgstr ""
+
+#: src/view/com/auth/HomeLoggedOutCTA.tsx:39
+msgid "See what's next"
+msgstr ""
+
+#: src/view/com/modals/ServerInput.tsx:75
+msgid "Select Bluesky Social"
+msgstr ""
+
+#: src/view/com/auth/login/Login.tsx:117
+msgid "Select from an existing account"
+msgstr ""
+
+#: src/view/com/auth/login/LoginForm.tsx:143
+msgid "Select service"
+msgstr ""
+
+#: src/view/screens/LanguageSettings.tsx:281
+msgid "Select which languages you want your subscribed feeds to include. If none are selected, all languages will be shown."
+msgstr ""
+
+#: src/view/screens/LanguageSettings.tsx:98
+msgid "Select your app language for the default text to display in the app"
+msgstr ""
+
+#: src/view/screens/LanguageSettings.tsx:190
+msgid "Select your preferred language for translations in your feed."
+msgstr ""
+
+#: src/view/com/modals/VerifyEmail.tsx:196
+msgid "Send Confirmation Email"
+msgstr ""
+
+#: src/view/com/modals/DeleteAccount.tsx:127
+msgid "Send email"
+msgstr ""
+
+#: src/view/com/modals/DeleteAccount.tsx:138
+msgid "Send Email"
+msgstr ""
+
+#: src/view/shell/Drawer.tsx:276
+#: src/view/shell/Drawer.tsx:297
+msgid "Send feedback"
+msgstr ""
+
+#: src/view/com/modals/report/SendReportButton.tsx:45
+msgid "Send Report"
+msgstr ""
+
+#: src/view/com/auth/login/SetNewPasswordForm.tsx:78
+msgid "Set new password"
+msgstr ""
+
+#: src/view/screens/PreferencesHomeFeed.tsx:216
+msgid "Set this setting to \"No\" to hide all quote posts from your feed. Reposts will still be visible."
+msgstr ""
+
+#: src/view/screens/PreferencesHomeFeed.tsx:113
+msgid "Set this setting to \"No\" to hide all replies from your feed."
+msgstr ""
+
+#: src/view/screens/PreferencesHomeFeed.tsx:182
+msgid "Set this setting to \"No\" to hide all reposts from your feed."
+msgstr ""
+
+#: src/view/screens/PreferencesThreads.tsx:116
+msgid "Set this setting to \"Yes\" to show replies in a threaded view. This is an experimental feature."
+msgstr ""
+
+#: src/view/screens/PreferencesHomeFeed.tsx:252
+msgid "Set this setting to \"Yes\" to show samples of your saved feeds in your following feed. This is an experimental feature."
+msgstr ""
+
+#: src/view/screens/Settings.tsx:277
+#: src/view/shell/desktop/LeftNav.tsx:431
+#: src/view/shell/Drawer.tsx:546
+#: src/view/shell/Drawer.tsx:547
+msgid "Settings"
+msgstr ""
+
+#: src/view/com/modals/SelfLabel.tsx:125
+msgid "Sexual activity or erotic nudity."
+msgstr ""
+
+#: src/view/com/profile/ProfileHeader.tsx:338
+#: src/view/com/util/forms/PostDropdownBtn.tsx:131
+#: src/view/screens/ProfileList.tsx:384
+msgid "Share"
+msgstr ""
+
+#: src/view/screens/ProfileFeed.tsx:302
+msgid "Share feed"
+msgstr ""
+
+#: src/view/com/util/moderation/ContentHider.tsx:105
+#: src/view/screens/Settings.tsx:316
+msgid "Show"
+msgstr ""
+
+#: src/view/com/util/moderation/ScreenHider.tsx:132
+msgid "Show anyway"
+msgstr ""
+
+#: src/view/screens/PreferencesHomeFeed.tsx:249
+msgid "Show Posts from My Feeds"
+msgstr ""
+
+#: src/view/screens/PreferencesHomeFeed.tsx:213
+msgid "Show Quote Posts"
+msgstr ""
+
+#: src/view/screens/PreferencesHomeFeed.tsx:110
+msgid "Show Replies"
+msgstr ""
+
+#: src/view/screens/PreferencesThreads.tsx:94
+msgid "Show replies by people you follow before all other replies."
+msgstr ""
+
+#: src/view/screens/PreferencesHomeFeed.tsx:179
+msgid "Show Reposts"
+msgstr ""
+
+#: src/view/com/notifications/FeedItem.tsx:337
+msgid "Show users"
+msgstr ""
+
+#: src/view/com/auth/HomeLoggedOutCTA.tsx:70
+#: src/view/com/auth/login/Login.tsx:98
+#: src/view/com/auth/SplashScreen.tsx:54
+#: src/view/shell/bottom-bar/BottomBar.tsx:285
+#: src/view/shell/bottom-bar/BottomBar.tsx:286
+#: src/view/shell/bottom-bar/BottomBar.tsx:288
+#: src/view/shell/bottom-bar/BottomBarWeb.tsx:177
+#: src/view/shell/bottom-bar/BottomBarWeb.tsx:178
+#: src/view/shell/bottom-bar/BottomBarWeb.tsx:180
+#: src/view/shell/NavSignupCard.tsx:58
+#: src/view/shell/NavSignupCard.tsx:59
+msgid "Sign in"
+msgstr ""
+
+#: src/view/com/auth/HomeLoggedOutCTA.tsx:78
+#: src/view/com/auth/SplashScreen.tsx:57
+#: src/view/com/auth/SplashScreen.web.tsx:87
+msgid "Sign In"
+msgstr ""
+
+#: src/view/com/auth/login/ChooseAccountForm.tsx:44
+msgid "Sign in as {0}"
+msgstr ""
+
+#: src/view/com/auth/login/ChooseAccountForm.tsx:118
+#: src/view/com/auth/login/Login.tsx:116
+msgid "Sign in as..."
+msgstr ""
+
+#: src/view/com/auth/login/LoginForm.tsx:130
+msgid "Sign into"
+msgstr ""
+
+#: src/view/com/modals/SwitchAccount.tsx:64
+#: src/view/com/modals/SwitchAccount.tsx:67
+msgid "Sign out"
+msgstr ""
+
+#: src/view/shell/bottom-bar/BottomBar.tsx:275
+#: src/view/shell/bottom-bar/BottomBar.tsx:276
+#: src/view/shell/bottom-bar/BottomBar.tsx:278
+#: src/view/shell/bottom-bar/BottomBarWeb.tsx:167
+#: src/view/shell/bottom-bar/BottomBarWeb.tsx:168
+#: src/view/shell/bottom-bar/BottomBarWeb.tsx:170
+#: src/view/shell/NavSignupCard.tsx:49
+#: src/view/shell/NavSignupCard.tsx:50
+#: src/view/shell/NavSignupCard.tsx:52
+msgid "Sign up"
+msgstr ""
+
+#: src/view/shell/NavSignupCard.tsx:42
+msgid "Sign up or sign in to join the conversation"
+msgstr ""
+
+#: src/view/com/util/moderation/ScreenHider.tsx:76
+msgid "Sign-in Required"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:327
+msgid "Signed in as"
+msgstr ""
+
+#: src/view/com/auth/onboarding/WelcomeMobile.tsx:33
+msgid "Skip"
+msgstr ""
+
+#: src/view/screens/PreferencesThreads.tsx:69
+msgid "Sort Replies"
+msgstr ""
+
+#: src/view/screens/PreferencesThreads.tsx:72
+msgid "Sort replies to the same post by:"
+msgstr ""
+
+#: src/view/com/modals/crop-image/CropImage.web.tsx:122
+msgid "Square"
+msgstr ""
+
+#: src/view/com/auth/create/Step1.tsx:90
+#: src/view/com/modals/ServerInput.tsx:62
+msgid "Staging"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:730
+msgid "Status page"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:666
+msgid "Storybook"
+msgstr ""
+
+#: src/view/com/modals/AppealLabel.tsx:101
+msgid "Submit"
+msgstr ""
+
+#: src/view/screens/ProfileList.tsx:574
+msgid "Subscribe"
+msgstr ""
+
+#: src/view/screens/ProfileList.tsx:570
+msgid "Subscribe to this list"
+msgstr ""
+
+#: src/view/screens/Search/Search.tsx:357
+msgid "Suggested Follows"
+msgstr ""
+
+#: src/view/screens/Support.tsx:30
+#: src/view/screens/Support.tsx:33
+msgid "Support"
+msgstr ""
+
+#: src/view/com/modals/SwitchAccount.tsx:115
+msgid "Switch Account"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:646
+msgid "System log"
+msgstr ""
+
+#: src/view/com/modals/crop-image/CropImage.web.tsx:112
+msgid "Tall"
+msgstr ""
+
+#: src/view/shell/desktop/RightNav.tsx:85
+msgid "Terms"
+msgstr ""
+
+#: src/view/screens/TermsOfService.tsx:29
+msgid "Terms of Service"
+msgstr ""
+
+#: src/view/com/modals/AppealLabel.tsx:70
+#: src/view/com/modals/report/InputIssueDetails.tsx:50
+msgid "Text input field"
+msgstr ""
+
+#: src/view/com/profile/ProfileHeader.tsx:306
+msgid "The account will be able to interact with you after unblocking."
+msgstr ""
+
+#: src/view/screens/CommunityGuidelines.tsx:36
+msgid "The Community Guidelines have been moved to <0/>"
+msgstr ""
+
+#: src/view/screens/CopyrightPolicy.tsx:33
+msgid "The Copyright Policy has been moved to <0/>"
+msgstr ""
+
+#: src/view/com/post-thread/PostThread.tsx:440
+msgid "The post may have been deleted."
+msgstr ""
+
+#: src/view/screens/PrivacyPolicy.tsx:33
+msgid "The Privacy Policy has been moved to <0/>"
+msgstr ""
+
+#: src/view/screens/Support.tsx:36
+msgid "The support form has been moved. If you need help, please<0/> or visit {HELP_DESK_URL} to get in touch with us."
+msgstr ""
+
+#: src/view/screens/TermsOfService.tsx:33
+msgid "The Terms of Service have been moved to"
+msgstr ""
+
+#: src/view/com/util/ErrorBoundary.tsx:35
+msgid "There was an unexpected issue in the application. Please let us know if this happened to you!"
+msgstr ""
+
+#: src/view/com/util/moderation/ScreenHider.tsx:88
+msgid "This {screenDescription} has been flagged:"
+msgstr ""
+
+#: src/view/com/util/moderation/ScreenHider.tsx:83
+msgid "This account has requested that users sign in to view their profile."
+msgstr ""
+
+#: src/view/com/posts/FeedErrorMessage.tsx:107
+msgid "This content is not viewable without a Bluesky account."
+msgstr ""
+
+#: src/view/com/posts/FeedErrorMessage.tsx:113
+msgid "This feed is currently receiving high traffic and is temporarily unavailable. Please try again later."
+msgstr ""
+
+#: src/view/com/modals/BirthDateSettings.tsx:61
+msgid "This information is not shared with other users."
+msgstr ""
+
+#: src/view/com/modals/VerifyEmail.tsx:113
+msgid "This is important in case you ever need to change your email or reset your password."
+msgstr ""
+
+#: src/view/com/auth/create/Step1.tsx:55
+msgid "This is the service that keeps you online."
+msgstr ""
+
+#: src/view/com/modals/LinkWarning.tsx:56
+msgid "This link is taking you to the following website:"
+msgstr ""
+
+#: src/view/com/post-thread/PostThreadItem.tsx:123
+msgid "This post has been deleted."
+msgstr ""
+
+#: src/view/com/modals/SelfLabel.tsx:137
+msgid "This warning is only available for posts with media attached."
+msgstr ""
+
+#: src/view/screens/PreferencesThreads.tsx:53
+#: src/view/screens/Settings.tsx:503
+msgid "Thread Preferences"
+msgstr ""
+
+#: src/view/screens/PreferencesThreads.tsx:113
+msgid "Threaded Mode"
+msgstr ""
+
+#: src/view/com/util/forms/DropdownButton.tsx:230
+msgid "Toggle dropdown"
+msgstr ""
+
+#: src/view/com/modals/EditImage.tsx:271
+msgid "Transformations"
+msgstr ""
+
+#: src/view/com/post-thread/PostThreadItem.tsx:704
+#: src/view/com/post-thread/PostThreadItem.tsx:706
+#: src/view/com/util/forms/PostDropdownBtn.tsx:103
+msgid "Translate"
+msgstr ""
+
+#: src/view/com/util/error/ErrorScreen.tsx:73
+msgid "Try again"
+msgstr ""
+
+#: src/view/screens/ProfileList.tsx:472
+msgid "Un-block list"
+msgstr ""
+
+#: src/view/screens/ProfileList.tsx:457
+msgid "Un-mute list"
+msgstr ""
+
+#: src/view/com/auth/create/CreateAccount.tsx:64
+#: src/view/com/auth/login/Login.tsx:76
+#: src/view/com/auth/login/LoginForm.tsx:117
+msgid "Unable to contact your service. Please check your Internet connection."
+msgstr ""
+
+#: src/view/com/profile/ProfileHeader.tsx:466
+#: src/view/com/profile/ProfileHeader.tsx:469
+msgid "Unblock"
+msgstr ""
+
+#: src/view/com/profile/ProfileHeader.tsx:304
+#: src/view/com/profile/ProfileHeader.tsx:388
+msgid "Unblock Account"
+msgstr ""
+
+#: src/view/com/util/post-ctrls/RepostButton.web.tsx:48
+msgid "Undo repost"
+msgstr ""
+
+#: src/view/com/auth/create/state.ts:210
+msgid "Unfortunately, you do not meet the requirements to create an account."
+msgstr ""
+
+#: src/view/com/profile/ProfileHeader.tsx:369
+msgid "Unmute Account"
+msgstr ""
+
+#: src/view/com/util/forms/PostDropdownBtn.tsx:149
+msgid "Unmute thread"
+msgstr ""
+
+#: src/view/screens/ProfileList.tsx:440
+msgid "Unpin moderation list"
+msgstr ""
+
+#: src/view/com/modals/UserAddRemoveLists.tsx:54
+msgid "Update {displayName} in Lists"
+msgstr ""
+
+#: src/lib/hooks/useOTAUpdate.ts:15
+msgid "Update Available"
+msgstr ""
+
+#: src/view/com/auth/login/SetNewPasswordForm.tsx:172
+msgid "Updating..."
+msgstr ""
+
+#: src/view/com/modals/ChangeHandle.tsx:453
+msgid "Upload a text file to:"
+msgstr ""
+
+#: src/view/screens/AppPasswords.tsx:194
+msgid "Use app passwords to login to other Bluesky clients without giving full access to your account or password."
+msgstr ""
+
+#: src/view/com/modals/ChangeHandle.tsx:513
+msgid "Use default provider"
+msgstr ""
+
+#: src/view/com/modals/AddAppPasswords.tsx:150
+msgid "Use this to sign into the other app along with your handle."
+msgstr ""
+
+#: src/view/com/modals/InviteCodes.tsx:197
+msgid "Used by:"
+msgstr ""
+
+#: src/view/com/auth/create/Step3.tsx:38
+msgid "User handle"
+msgstr ""
+
+#: src/view/screens/Lists.tsx:58
+msgid "User Lists"
+msgstr ""
+
+#: src/view/com/auth/login/LoginForm.tsx:170
+#: src/view/com/auth/login/LoginForm.tsx:187
+msgid "Username or email address"
+msgstr ""
+
+#: src/view/screens/ProfileList.tsx:738
+msgid "Users"
+msgstr ""
+
+#: src/view/com/threadgate/WhoCanReply.tsx:143
+msgid "users followed by <0/>"
+msgstr ""
+
+#: src/view/com/modals/Threadgate.tsx:106
+msgid "Users in \"{0}\""
+msgstr ""
+
+#: src/view/screens/Settings.tsx:750
+msgid "Verify email"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:775
+msgid "Verify my email"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:784
+msgid "Verify My Email"
+msgstr ""
+
+#: src/view/com/modals/ChangeEmail.tsx:205
+#: src/view/com/modals/ChangeEmail.tsx:207
+msgid "Verify New Email"
+msgstr ""
+
+#: src/view/screens/Log.tsx:52
+msgid "View debug entry"
+msgstr ""
+
+#: src/view/com/profile/ProfileSubpageHeader.tsx:128
+msgid "View the avatar"
+msgstr ""
+
+#: src/view/com/modals/LinkWarning.tsx:73
+msgid "Visit Site"
+msgstr ""
+
+#: src/view/com/auth/create/CreateAccount.tsx:121
+msgid "We're so excited to have you join us!"
+msgstr ""
+
+#: src/view/screens/Search/Search.tsx:238
+msgid "We're sorry, but your search could not be completed. Please try again in a few minutes."
+msgstr ""
+
+#: src/view/screens/NotFound.tsx:48
+msgid "We're sorry! We can't find the page you were looking for."
+msgstr ""
+
+#: src/view/com/auth/onboarding/WelcomeMobile.tsx:46
+msgid "Welcome to <0>Bluesky</0>"
+msgstr ""
+
+#: src/view/com/modals/report/Modal.tsx:169
+msgid "What is the issue with this {collectionName}?"
+msgstr ""
+
+#: src/view/com/auth/SplashScreen.tsx:34
+msgid "What's up?"
+msgstr ""
+
+#: src/view/com/modals/lang-settings/PostLanguagesSettings.tsx:78
+msgid "Which languages are used in this post?"
+msgstr ""
+
+#: src/view/com/modals/lang-settings/ContentLanguagesSettings.tsx:77
+msgid "Which languages would you like to see in your algorithmic feeds?"
+msgstr ""
+
+#: src/view/com/composer/threadgate/ThreadgateBtn.tsx:47
+#: src/view/com/modals/Threadgate.tsx:66
+msgid "Who can reply"
+msgstr ""
+
+#: src/view/com/modals/crop-image/CropImage.web.tsx:102
+msgid "Wide"
+msgstr ""
+
+#: src/view/com/composer/Composer.tsx:409
+msgid "Write post"
+msgstr ""
+
+#: src/view/com/composer/Prompt.tsx:33
+msgid "Write your reply"
+msgstr ""
+
+#: src/view/screens/PreferencesHomeFeed.tsx:192
+#: src/view/screens/PreferencesHomeFeed.tsx:227
+#: src/view/screens/PreferencesHomeFeed.tsx:262
+msgid "Yes"
+msgstr ""
+
+#: src/view/com/auth/create/Step1.tsx:106
+msgid "You can change hosting providers at any time."
+msgstr ""
+
+#: src/view/com/auth/login/Login.tsx:158
+#: src/view/com/auth/login/PasswordUpdatedForm.tsx:31
+msgid "You can now sign in with your new password."
+msgstr ""
+
+#: src/view/com/modals/InviteCodes.tsx:64
+msgid "You don't have any invite codes yet! We'll send you some when you've been on Bluesky for a little longer."
+msgstr ""
+
+#: src/view/screens/SavedFeeds.tsx:102
+msgid "You don't have any pinned feeds."
+msgstr ""
+
+#: src/view/screens/Feeds.tsx:383
+msgid "You don't have any saved feeds!"
+msgstr ""
+
+#: src/view/screens/SavedFeeds.tsx:135
+msgid "You don't have any saved feeds."
+msgstr ""
+
+#: src/view/com/post-thread/PostThread.tsx:388
+msgid "You have blocked the author or you have been blocked by the author."
+msgstr ""
+
+#: src/view/com/feeds/ProfileFeedgens.tsx:141
+msgid "You have no feeds."
+msgstr ""
+
+#: src/view/com/lists/MyLists.tsx:89
+#: src/view/com/lists/ProfileLists.tsx:145
+msgid "You have no lists."
+msgstr ""
+
+#: src/view/screens/ModerationBlockedAccounts.tsx:131
+msgid "You have not blocked any accounts yet. To block an account, go to their profile and selected \"Block account\" from the menu on their account."
+msgstr ""
+
+#: src/view/screens/AppPasswords.tsx:86
+msgid "You have not created any app passwords yet. You can create one by pressing the button below."
+msgstr ""
+
+#: src/view/screens/ModerationMutedAccounts.tsx:130
+msgid "You have not muted any accounts yet. To mute an account, go to their profile and selected \"Mute account\" from the menu on their account."
+msgstr ""
+
+#: src/view/com/auth/login/SetNewPasswordForm.tsx:81
+msgid "You will receive an email with a \"reset code.\" Enter that code here, then enter your new password."
+msgstr ""
+
+#: src/view/com/auth/create/Step2.tsx:43
+msgid "Your account"
+msgstr ""
+
+#: src/view/com/auth/create/Step2.tsx:122
+msgid "Your birth date"
+msgstr ""
+
+#: src/view/com/auth/create/state.ts:102
+msgid "Your email appears to be invalid."
+msgstr ""
+
+#: src/view/com/modals/Waitlist.tsx:107
+msgid "Your email has been saved! We'll be in touch soon."
+msgstr ""
+
+#: src/view/com/modals/ChangeEmail.tsx:125
+msgid "Your email has been updated but not verified. As a next step, please verify your new email."
+msgstr ""
+
+#: src/view/com/modals/VerifyEmail.tsx:108
+msgid "Your email has not yet been verified. This is an important security step which we recommend."
+msgstr ""
+
+#: src/view/com/auth/create/Step3.tsx:42
+#: src/view/com/modals/ChangeHandle.tsx:270
+msgid "Your full handle will be"
+msgstr ""
+
+#: src/view/com/auth/create/Step1.tsx:53
+msgid "Your hosting provider"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:402
+#: src/view/shell/desktop/RightNav.tsx:129
+#: src/view/shell/Drawer.tsx:636
+msgid "Your invite codes are hidden when logged in using an App Password"
+msgstr ""
+
+#: src/view/com/auth/onboarding/WelcomeMobile.tsx:59
+msgid "Your posts, likes, and blocks are public. Mutes are private."
+msgstr ""
+
+#: src/view/com/modals/SwitchAccount.tsx:82
+msgid "Your profile"
+msgstr ""
+
+#: src/view/com/auth/create/Step3.tsx:28
+msgid "Your user handle"
+msgstr ""

--- a/src/locale/locales/es/messages.po
+++ b/src/locale/locales/es/messages.po
@@ -6,6 +6,12 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: @lingui/cli\n"
 "Language: es\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
 
 #: src/view/shell/desktop/RightNav.tsx:160
 msgid "{0, plural, one {# invite code available} other {# invite codes available}}"
@@ -13,11 +19,11 @@ msgstr ""
 
 #: src/view/com/modals/Repost.tsx:44
 msgid "{0}"
-msgstr ""
+msgstr "{0}"
 
 #: src/view/com/modals/CreateOrEditList.tsx:176
 msgid "{0} {purposeLabel} List"
-msgstr ""
+msgstr "Lista {purposeLabel} {0}"
 
 #: src/view/shell/desktop/RightNav.tsx:143
 msgid "{invitesAvailable, plural, one {Invite codes: # available} other {Invite codes: # available}}"
@@ -26,28 +32,28 @@ msgstr ""
 #: src/view/screens/Settings.tsx:407
 #: src/view/shell/Drawer.tsx:640
 msgid "{invitesAvailable} invite code available"
-msgstr ""
+msgstr "{invitesAvailable} código de invitación disponible"
 
 #: src/view/screens/Settings.tsx:409
 #: src/view/shell/Drawer.tsx:642
 msgid "{invitesAvailable} invite codes available"
-msgstr ""
+msgstr "{invitesAvailable} códigos de invitación disponibles"
 
 #: src/view/screens/Search/Search.tsx:88
 msgid "{message}"
-msgstr ""
+msgstr "{message}"
 
 #: src/view/com/threadgate/WhoCanReply.tsx:158
 msgid "<0/> members"
-msgstr ""
+msgstr "<0/> miembros"
 
 #: src/view/com/auth/onboarding/RecommendedFeeds.tsx:30
 msgid "<0>Choose your</0><1>Recommended</1><2>Feeds</2>"
-msgstr ""
+msgstr "<0>Elije tus</0><1>publicaciones</1><2>recomendadas</2>"
 
 #: src/view/com/auth/onboarding/RecommendedFollows.tsx:37
 msgid "<0>Follow some</0><1>Recommended</1><2>Users</2>"
-msgstr ""
+msgstr "<0>Sigue a algunos</0><1>usuarios</1><2>recomendados</2>"
 
 #: src/view/com/util/moderation/LabelInfo.tsx:45
 msgid "A content warning has been applied to this {0}."
@@ -55,128 +61,128 @@ msgstr ""
 
 #: src/lib/hooks/useOTAUpdate.ts:16
 msgid "A new version of the app is available. Please update to continue using the app."
-msgstr ""
+msgstr "Ya está disponible una nueva versión de la aplicación. Actualízala para seguir utilizándola."
 
 #: src/view/com/modals/EditImage.tsx:299
 #: src/view/screens/Settings.tsx:417
 msgid "Accessibility"
-msgstr ""
+msgstr "Accesibilidad"
 
 #: src/view/com/auth/login/LoginForm.tsx:159
 #: src/view/screens/Settings.tsx:286
 msgid "Account"
-msgstr ""
+msgstr "Cuenta"
 
 #: src/view/com/util/AccountDropdownBtn.tsx:41
 msgid "Account options"
-msgstr ""
+msgstr "Opciones de la cuenta"
 
 #: src/view/com/modals/ListAddRemoveUsers.tsx:264
 #: src/view/com/modals/UserAddRemoveLists.tsx:193
 #: src/view/screens/ProfileList.tsx:754
 msgid "Add"
-msgstr ""
+msgstr "Agregar"
 
 #: src/view/com/modals/SelfLabel.tsx:56
 msgid "Add a content warning"
-msgstr ""
+msgstr "Agregar una advertencia de cuenta"
 
 #: src/view/screens/ProfileList.tsx:744
 msgid "Add a user to this list"
-msgstr ""
+msgstr "Agregar un usuario a esta lista"
 
 #: src/view/screens/Settings.tsx:355
 #: src/view/screens/Settings.tsx:364
 msgid "Add account"
-msgstr ""
+msgstr "Agregar una cuenta"
 
 #: src/view/com/composer/photos/Gallery.tsx:119
 #: src/view/com/composer/photos/Gallery.tsx:180
 msgid "Add alt text"
-msgstr ""
+msgstr "Agregar texto alt"
 
 #: src/view/com/modals/report/InputIssueDetails.tsx:41
 #: src/view/com/modals/report/Modal.tsx:191
 msgid "Add details"
-msgstr ""
+msgstr "Agregar detalles"
 
 #: src/view/com/modals/report/Modal.tsx:194
 msgid "Add details to report"
-msgstr ""
+msgstr "Agregar detalles al informe"
 
 #: src/view/com/composer/Composer.tsx:438
 msgid "Add link card"
-msgstr ""
+msgstr "Agregar una tarjeta de enlace"
 
 #: src/view/com/composer/Composer.tsx:441
 msgid "Add link card:"
-msgstr ""
+msgstr "Agregar una tarjeta de enlace:"
 
 #: src/view/com/modals/ChangeHandle.tsx:415
 msgid "Add the following DNS record to your domain:"
-msgstr ""
+msgstr "Añade el siguiente registro DNS a tu dominio:"
 
 #: src/view/com/profile/ProfileHeader.tsx:353
 msgid "Add to Lists"
-msgstr ""
+msgstr "Agregar a listas"
 
 #: src/view/screens/ProfileFeed.tsx:270
 msgid "Add to my feeds"
-msgstr ""
+msgstr "Agregar a mis noticias"
 
 #: src/view/com/modals/ListAddRemoveUsers.tsx:191
 #: src/view/com/modals/UserAddRemoveLists.tsx:128
 msgid "Added to list"
-msgstr ""
+msgstr "Agregar a una lista"
 
 #: src/view/screens/PreferencesHomeFeed.tsx:164
 msgid "Adjust the number of likes a reply must have to be shown in your feed."
-msgstr ""
+msgstr "Ajusta el número de Me gusta que debe tener una respuesta para que se muestre en tus noticias."
 
 #: src/view/com/modals/SelfLabel.tsx:75
 msgid "Adult Content"
-msgstr ""
+msgstr "Contenido para adultos"
 
 #: src/view/screens/Settings.tsx:569
 msgid "Advanced"
-msgstr ""
+msgstr "Avanzado"
 
 #: src/view/com/composer/photos/Gallery.tsx:130
 msgid "ALT"
-msgstr ""
+msgstr "ALT"
 
 #: src/view/com/modals/EditImage.tsx:315
 msgid "Alt text"
-msgstr ""
+msgstr "Texto alt"
 
 #: src/view/com/composer/photos/Gallery.tsx:209
 msgid "Alt text describes images for blind and low-vision users, and helps give context to everyone."
-msgstr ""
+msgstr "El texto alternativo describe las imágenes para los usuarios ciegos y con baja visión, y ayuda a dar contexto a todos."
 
 #: src/view/com/modals/VerifyEmail.tsx:118
 msgid "An email has been sent to {0}. It includes a confirmation code which you can enter below."
-msgstr ""
+msgstr "Se ha enviado un correo electrónico a {0}. Incluye un código de confirmación que puedes introducir a continuación."
 
 #: src/view/com/modals/ChangeEmail.tsx:119
 msgid "An email has been sent to your previous address, {0}. It includes a confirmation code which you can enter below."
-msgstr ""
+msgstr "Se ha enviado un correo electrónico a tu dirección previa, {0}. Incluye un código de confirmación que puedes introducir a continuación."
 
 #: src/view/com/notifications/FeedItem.tsx:236
 #: src/view/com/threadgate/WhoCanReply.tsx:178
 msgid "and"
-msgstr ""
+msgstr "y"
 
 #: src/view/screens/LanguageSettings.tsx:95
 msgid "App Language"
-msgstr ""
+msgstr "Lenguaje de app"
 
 #: src/view/screens/Settings.tsx:589
 msgid "App passwords"
-msgstr ""
+msgstr "Contraseñas de la app"
 
 #: src/view/screens/AppPasswords.tsx:186
 msgid "App Passwords"
-msgstr ""
+msgstr "Contraseñas de la app"
 
 #: src/view/com/util/forms/PostDropdownBtn.tsx:207
 msgid "Appeal content warning"
@@ -186,37 +192,41 @@ msgstr ""
 msgid "Appeal Content Warning"
 msgstr ""
 
+#: src/view/com/modals/AppealLabel.tsx:65
+#~ msgid "Appeal Decision"
+#~ msgstr "Decisión de apelación"
+
 #: src/view/com/util/moderation/LabelInfo.tsx:52
 msgid "Appeal this decision"
-msgstr ""
+msgstr "Apelar esta decisión"
 
 #: src/view/com/util/moderation/LabelInfo.tsx:56
 msgid "Appeal this decision."
-msgstr ""
+msgstr "Apelar esta decisión."
 
 #: src/view/screens/Settings.tsx:432
 msgid "Appearance"
-msgstr ""
+msgstr "Aspecto exterior"
 
 #: src/view/screens/AppPasswords.tsx:223
 msgid "Are you sure you want to delete the app password \"{name}\"?"
-msgstr ""
+msgstr "¿Estás seguro de que quieres eliminar la contraseña de la app \"{name}\"?"
 
 #: src/view/com/composer/Composer.tsx:142
 msgid "Are you sure you'd like to discard this draft?"
-msgstr ""
+msgstr "¿Estás seguro de que quieres descartar este borrador?"
 
 #: src/view/screens/ProfileList.tsx:352
 msgid "Are you sure?"
-msgstr ""
+msgstr "¿Estás seguro?"
 
 #: src/view/com/util/forms/PostDropdownBtn.tsx:190
 msgid "Are you sure? This cannot be undone."
-msgstr ""
+msgstr "¿Estás seguro? Esto no puede deshacerse,"
 
 #: src/view/com/modals/SelfLabel.tsx:123
 msgid "Artistic or non-erotic nudity."
-msgstr ""
+msgstr "Desnudez artística o no erótica."
 
 #: src/view/com/auth/create/CreateAccount.tsx:141
 #: src/view/com/auth/login/ChooseAccountForm.tsx:151
@@ -229,111 +239,111 @@ msgstr ""
 #: src/view/com/post-thread/PostThread.tsx:453
 #: src/view/com/profile/ProfileHeader.tsx:672
 msgid "Back"
-msgstr ""
+msgstr "Regresar"
 
 #: src/view/screens/Settings.tsx:461
 msgid "Basics"
-msgstr ""
+msgstr "Conceptos básicos"
 
 #: src/view/com/auth/create/Step2.tsx:131
 #: src/view/com/modals/BirthDateSettings.tsx:72
 msgid "Birthday"
-msgstr ""
+msgstr "Cumpleaños"
 
 #: src/view/screens/Settings.tsx:312
 msgid "Birthday:"
-msgstr ""
+msgstr "Cumpleaños:"
 
 #: src/view/com/profile/ProfileHeader.tsx:282
 #: src/view/com/profile/ProfileHeader.tsx:389
 msgid "Block Account"
-msgstr ""
+msgstr "Bloquear una cuenta"
 
 #: src/view/screens/ProfileList.tsx:522
 msgid "Block accounts"
-msgstr ""
+msgstr "Bloquear cuentas"
 
 #: src/view/screens/ProfileList.tsx:472
 msgid "Block list"
-msgstr ""
+msgstr "Bloquear una lista"
 
 #: src/view/screens/ProfileList.tsx:307
 msgid "Block these accounts?"
-msgstr ""
+msgstr "¿Bloquear estas cuentas?"
 
 #: src/view/screens/Moderation.tsx:123
 msgid "Blocked accounts"
-msgstr ""
+msgstr "Cuentas bloqueadas"
 
 #: src/view/screens/ModerationBlockedAccounts.tsx:106
 msgid "Blocked Accounts"
-msgstr ""
+msgstr "Cuentas bloqueadas"
 
 #: src/view/com/profile/ProfileHeader.tsx:284
 msgid "Blocked accounts cannot reply in your threads, mention you, or otherwise interact with you."
-msgstr ""
+msgstr "Las cuentas bloqueadas no pueden responder en tus hilos, mencionarte ni interactuar contigo de ninguna otra forma."
 
 #: src/view/screens/ModerationBlockedAccounts.tsx:114
 msgid "Blocked accounts cannot reply in your threads, mention you, or otherwise interact with you. You will not see their content and they will be prevented from seeing yours."
-msgstr ""
+msgstr "Las cuentas bloqueadas no pueden responder en tus hilos, mencionarte ni interactuar contigo de ninguna otra forma. Tú no verás su contenido y ellos no podrán ver el tuyo."
 
 #: src/view/com/post-thread/PostThread.tsx:251
 msgid "Blocked post."
-msgstr ""
+msgstr "Publicación bloqueada"
 
 #: src/view/screens/ProfileList.tsx:309
 msgid "Blocking is public. Blocked accounts cannot reply in your threads, mention you, or otherwise interact with you."
-msgstr ""
+msgstr "El bloque es público. Las cuentas bloqueadas no pueden responder en tus hilos, mencionarte ni interactuar contigo de ninguna otra forma."
 
 #: src/view/com/auth/HomeLoggedOutCTA.tsx:93
 msgid "Blog"
-msgstr ""
+msgstr "Blog"
 
 #: src/view/com/auth/HomeLoggedOutCTA.tsx:31
 msgid "Bluesky"
-msgstr ""
+msgstr "Bluesky"
 
 #: src/view/com/auth/onboarding/WelcomeMobile.tsx:80
 msgid "Bluesky is flexible."
-msgstr ""
+msgstr "Bluesky es flexible."
 
 #: src/view/com/auth/onboarding/WelcomeMobile.tsx:69
 msgid "Bluesky is open."
-msgstr ""
+msgstr "Bluesky es abierto."
 
 #: src/view/com/auth/onboarding/WelcomeMobile.tsx:56
 msgid "Bluesky is public."
-msgstr ""
+msgstr "Bluesky es público."
 
 #: src/view/com/modals/Waitlist.tsx:70
 msgid "Bluesky uses invites to build a healthier community. If you don't know anybody with an invite, you can sign up for the waitlist and we'll send one soon."
-msgstr ""
+msgstr "Bluesky utiliza las invitaciones para construir una comunidad más saludable. Si no conoces a nadie con una invitación, puedes apuntarte a la lista de espera y te enviaremos una en breve."
 
 #: src/view/screens/Moderation.tsx:225
 msgid "Bluesky will not show your profile and posts to logged-out users. Other apps may not honor this request. This does not make your account private."
-msgstr ""
+msgstr "Bluesky no mostrará tu perfil ni tus publicaciones a los usuarios que hayan cerrado sesión. Es posible que otras aplicaciones no acepten esta solicitud. Esto no hace que tu cuenta sea privada."
 
 #: src/view/com/modals/ServerInput.tsx:78
 msgid "Bluesky.Social"
-msgstr ""
+msgstr "Bluesky.Social"
 
 #: src/view/screens/Settings.tsx:718
 msgid "Build version {0} {1}"
-msgstr ""
+msgstr "Versión {0} {1}"
 
 #: src/view/com/auth/HomeLoggedOutCTA.tsx:87
 msgid "Business"
-msgstr ""
+msgstr "Negocios"
 
 #: src/view/com/composer/photos/OpenCameraBtn.tsx:60
 #: src/view/com/util/UserAvatar.tsx:221
 #: src/view/com/util/UserBanner.tsx:38
 msgid "Camera"
-msgstr ""
+msgstr "Cámara"
 
 #: src/view/com/modals/AddAppPasswords.tsx:214
 msgid "Can only contain letters, numbers, spaces, dashes, and underscores. Must be at least 4 characters long, but no more than 32 characters long."
-msgstr ""
+msgstr "Sólo puede contener letras, números, espacios, guiones y guiones bajos. Debe tener al menos 4 caracteres, pero no más de 32."
 
 #: src/view/com/composer/Composer.tsx:285
 #: src/view/com/composer/Composer.tsx:288
@@ -353,135 +363,135 @@ msgstr ""
 #: src/view/screens/Search/Search.tsx:592
 #: src/view/shell/desktop/Search.tsx:182
 msgid "Cancel"
-msgstr ""
+msgstr "Cancelar"
 
 #: src/view/com/modals/DeleteAccount.tsx:146
 #: src/view/com/modals/DeleteAccount.tsx:219
 msgid "Cancel account deletion"
-msgstr ""
+msgstr "Cancelar la eliminación de la cuenta"
 
 #: src/view/com/modals/AltImage.tsx:123
 msgid "Cancel add image alt text"
-msgstr ""
+msgstr "Cancelar añadir texto alternativo a la imagen"
 
 #: src/view/com/modals/ChangeHandle.tsx:149
 msgid "Cancel change handle"
-msgstr ""
+msgstr "Cancelar identificador de cambio"
 
 #: src/view/com/modals/crop-image/CropImage.web.tsx:134
 msgid "Cancel image crop"
-msgstr ""
+msgstr "Cancelar recorte de imagen"
 
 #: src/view/com/modals/EditProfile.tsx:243
 msgid "Cancel profile editing"
-msgstr ""
+msgstr "Cancelar la edición de perfil"
 
 #: src/view/com/modals/Repost.tsx:64
 msgid "Cancel quote post"
-msgstr ""
+msgstr "Cancelar la publicación de un presupuesto"
 
 #: src/view/com/modals/ListAddRemoveUsers.tsx:87
 #: src/view/shell/desktop/Search.tsx:178
 msgid "Cancel search"
-msgstr ""
+msgstr "Cancelar búsqueda"
 
 #: src/view/com/modals/Waitlist.tsx:132
 msgid "Cancel waitlist signup"
-msgstr ""
+msgstr "Cancelar la inscripción en la lista de espera"
 
 #: src/view/screens/Settings.tsx:306
 msgid "Change"
-msgstr ""
+msgstr "Cambiar"
 
 #: src/view/screens/Settings.tsx:601
 #: src/view/screens/Settings.tsx:610
 msgid "Change handle"
-msgstr ""
+msgstr "Cambiar el identificador"
 
 #: src/view/com/modals/ChangeHandle.tsx:161
 msgid "Change Handle"
-msgstr ""
+msgstr "Cambiar el identificador"
 
 #: src/view/com/modals/VerifyEmail.tsx:141
 msgid "Change my email"
-msgstr ""
+msgstr "Cambiar mi correo electrónico"
 
 #: src/view/com/modals/ChangeEmail.tsx:109
 msgid "Change Your Email"
-msgstr ""
+msgstr "Cambiar tu correo electrónico"
 
 #: src/view/com/auth/onboarding/RecommendedFeeds.tsx:121
 msgid "Check out some recommended feeds. Tap + to add them to your list of pinned feeds."
-msgstr ""
+msgstr "Echa un vistazo a algunas publicaciones recomendadas. Pulsa + para añadirlos a tu lista de publicaciones ancladas."
 
 #: src/view/com/auth/onboarding/RecommendedFollows.tsx:185
 msgid "Check out some recommended users. Follow them to see similar users."
-msgstr ""
+msgstr "Echa un vistazo a algunos usuarios recomendados. Síguelos para ver usuarios similares."
 
 #: src/view/com/modals/DeleteAccount.tsx:163
 msgid "Check your inbox for an email with the confirmation code to enter below:"
-msgstr ""
+msgstr "Consulta tu bandeja de entrada para recibir un correo electrónico con el código de confirmación que debes introducir a continuación:"
 
 #: src/view/com/modals/ServerInput.tsx:38
 msgid "Choose Service"
-msgstr ""
+msgstr "Elige un Servicio"
 
 #: src/view/com/auth/onboarding/WelcomeMobile.tsx:83
 msgid "Choose the algorithms that power your experience with custom feeds."
-msgstr ""
+msgstr "Elige los algoritmos que potencian tu experiencia con publicaciones personalizadas."
 
 #: src/view/com/auth/create/Step2.tsx:106
 msgid "Choose your password"
-msgstr ""
+msgstr "Elige tu contraseña"
 
 #: src/view/screens/Settings.tsx:694
 msgid "Clear all legacy storage data"
-msgstr ""
+msgstr "Borrar todos los datos de almacenamiento heredados"
 
 #: src/view/screens/Settings.tsx:696
 msgid "Clear all legacy storage data (restart after this)"
-msgstr ""
+msgstr "Borrar todos los datos de almacenamiento heredados (reiniciar después de esto)"
 
 #: src/view/screens/Settings.tsx:706
 msgid "Clear all storage data"
-msgstr ""
+msgstr "Borrar todos los datos de almacenamiento"
 
 #: src/view/screens/Settings.tsx:708
 msgid "Clear all storage data (restart after this)"
-msgstr ""
+msgstr "Borrar todos los datos de almacenamiento (reiniciar después de esto)"
 
 #: src/view/com/util/forms/SearchInput.tsx:73
 #: src/view/screens/Search/Search.tsx:577
 msgid "Clear search query"
-msgstr ""
+msgstr "Borrar consulta de búsqueda"
 
 #: src/view/com/auth/login/PasswordUpdatedForm.tsx:38
 msgid "Close alert"
-msgstr ""
+msgstr "Cerrar la alerta"
 
 #: src/view/com/util/BottomSheetCustomBackdrop.tsx:33
 msgid "Close bottom drawer"
-msgstr ""
+msgstr "Cierra el cajón inferior"
 
 #: src/view/com/lightbox/ImageViewing/components/ImageDefaultHeader.tsx:26
 msgid "Close image"
-msgstr ""
+msgstr "Cerrar la imagen"
 
 #: src/view/com/lightbox/Lightbox.web.tsx:112
 msgid "Close image viewer"
-msgstr ""
+msgstr "Cerrar el visor de imagen"
 
 #: src/view/shell/index.web.tsx:49
 msgid "Close navigation footer"
-msgstr ""
+msgstr "Cerrar el pie de página de navegación"
 
 #: src/view/screens/CommunityGuidelines.tsx:32
 msgid "Community Guidelines"
-msgstr ""
+msgstr "Directrices de la comunidad"
 
 #: src/view/com/composer/Prompt.tsx:24
 msgid "Compose reply"
-msgstr ""
+msgstr "Redactar la respuesta"
 
 #: src/view/com/modals/AppealLabel.tsx:98
 #: src/view/com/modals/Confirm.tsx:75
@@ -490,202 +500,202 @@ msgstr ""
 #: src/view/screens/PreferencesHomeFeed.tsx:299
 #: src/view/screens/PreferencesThreads.tsx:153
 msgid "Confirm"
-msgstr ""
+msgstr "Confirmar"
 
 #: src/view/com/modals/ChangeEmail.tsx:193
 #: src/view/com/modals/ChangeEmail.tsx:195
 msgid "Confirm Change"
-msgstr ""
+msgstr "Confirmar el cambio"
 
 #: src/view/com/modals/lang-settings/ConfirmLanguagesButton.tsx:34
 msgid "Confirm content language settings"
-msgstr ""
+msgstr "Confirmar la configuración del idioma del contenido"
 
 #: src/view/com/modals/DeleteAccount.tsx:209
 msgid "Confirm delete account"
-msgstr ""
+msgstr "Confirmar eliminación de cuenta"
 
 #: src/view/com/modals/ChangeEmail.tsx:157
 #: src/view/com/modals/DeleteAccount.tsx:176
 #: src/view/com/modals/VerifyEmail.tsx:159
 msgid "Confirmation code"
-msgstr ""
+msgstr "Código de confirmación"
 
 #: src/view/com/auth/create/CreateAccount.tsx:174
 #: src/view/com/auth/login/LoginForm.tsx:268
 msgid "Connecting..."
-msgstr ""
+msgstr "Conectando..."
 
 #: src/view/screens/Moderation.tsx:81
 msgid "Content filtering"
-msgstr ""
+msgstr "Filtro de contenido"
 
 #: src/view/com/modals/ContentFilteringSettings.tsx:44
 msgid "Content Filtering"
-msgstr ""
+msgstr "Filtro de contenido"
 
 #: src/view/com/modals/lang-settings/ContentLanguagesSettings.tsx:74
 #: src/view/screens/LanguageSettings.tsx:278
 msgid "Content Languages"
-msgstr ""
+msgstr "Lenguajes de contenido"
 
 #: src/view/com/util/moderation/ScreenHider.tsx:78
 msgid "Content Warning"
-msgstr ""
+msgstr "Advertencia de contenido"
 
 #: src/view/com/composer/labels/LabelsBtn.tsx:31
 msgid "Content warnings"
-msgstr ""
+msgstr "Advertencias de contenido"
 
 #: src/view/com/auth/onboarding/RecommendedFeeds.tsx:148
 #: src/view/com/auth/onboarding/RecommendedFollows.tsx:209
 msgid "Continue"
-msgstr ""
+msgstr "Continuar"
 
 #: src/view/com/modals/AddAppPasswords.tsx:193
 #: src/view/com/modals/InviteCodes.tsx:179
 msgid "Copied"
-msgstr ""
+msgstr "Copiado"
 
 #: src/view/com/modals/AddAppPasswords.tsx:186
 msgid "Copy"
-msgstr ""
+msgstr "Copiar"
 
 #: src/view/screens/ProfileList.tsx:384
 msgid "Copy link to list"
-msgstr ""
+msgstr "Copia el enlace a la lista"
 
 #: src/view/com/util/forms/PostDropdownBtn.tsx:131
 msgid "Copy link to post"
-msgstr ""
+msgstr "Copia el enlace a la publicación"
 
 #: src/view/com/profile/ProfileHeader.tsx:338
 msgid "Copy link to profile"
-msgstr ""
+msgstr "Copia el enlace al perfil"
 
 #: src/view/com/util/forms/PostDropdownBtn.tsx:117
 msgid "Copy post text"
-msgstr ""
+msgstr "Copiar el texto de la publicación"
 
 #: src/view/screens/CopyrightPolicy.tsx:29
 msgid "Copyright Policy"
-msgstr ""
+msgstr "Política de derechos de autor"
 
 #: src/view/screens/ProfileFeed.tsx:94
 msgid "Could not load feed"
-msgstr ""
+msgstr "No se ha podido cargar las publicaciones"
 
 #: src/view/screens/ProfileList.tsx:830
 msgid "Could not load list"
-msgstr ""
+msgstr "No se ha podido cargar la lista"
 
 #: src/view/com/auth/HomeLoggedOutCTA.tsx:62
 #: src/view/com/auth/SplashScreen.tsx:46
 msgid "Create a new account"
-msgstr ""
+msgstr "Crear una cuenta nueva"
 
 #: src/view/com/auth/create/CreateAccount.tsx:120
 msgid "Create Account"
-msgstr ""
+msgstr "Crear una cuenta"
 
 #: src/view/com/auth/HomeLoggedOutCTA.tsx:54
 #: src/view/com/auth/SplashScreen.tsx:43
 msgid "Create new account"
-msgstr ""
+msgstr "Crear una cuenta nueva"
 
 #: src/view/screens/AppPasswords.tsx:248
 msgid "Created {0}"
-msgstr ""
+msgstr "Creado {0}"
 
 #: src/view/com/modals/ChangeHandle.tsx:387
 #: src/view/com/modals/ServerInput.tsx:102
 msgid "Custom domain"
-msgstr ""
+msgstr "Dominio personalizado"
 
 #: src/view/screens/Settings.tsx:615
 msgid "Danger Zone"
-msgstr ""
+msgstr "Zona de peligro"
 
 #: src/view/screens/Settings.tsx:622
 msgid "Delete account"
-msgstr ""
+msgstr "Borrar la cuenta"
 
 #: src/view/com/modals/DeleteAccount.tsx:83
 msgid "Delete Account"
-msgstr ""
+msgstr "Borrar la cuenta"
 
 #: src/view/screens/AppPasswords.tsx:221
 #: src/view/screens/AppPasswords.tsx:241
 msgid "Delete app password"
-msgstr ""
+msgstr "Borrar la contraseña de la app"
 
 #: src/view/screens/ProfileList.tsx:351
 #: src/view/screens/ProfileList.tsx:411
 msgid "Delete List"
-msgstr ""
+msgstr "Borrar la lista"
 
 #: src/view/com/modals/DeleteAccount.tsx:212
 msgid "Delete my account"
-msgstr ""
+msgstr "Borrar mi cuenta"
 
 #: src/view/screens/Settings.tsx:632
 msgid "Delete my account…"
-msgstr ""
+msgstr "Borrar mi cuenta..."
 
 #: src/view/com/util/forms/PostDropdownBtn.tsx:185
 msgid "Delete post"
-msgstr ""
+msgstr "Borrar una publicación"
 
 #: src/view/com/util/forms/PostDropdownBtn.tsx:189
 msgid "Delete this post?"
-msgstr ""
+msgstr "¿Borrar esta publicación?"
 
 #: src/view/com/post-thread/PostThread.tsx:243
 msgid "Deleted post."
-msgstr ""
+msgstr "Se borró la publicación."
 
 #: src/view/com/modals/CreateOrEditList.tsx:218
 #: src/view/com/modals/CreateOrEditList.tsx:234
 #: src/view/com/modals/EditProfile.tsx:197
 #: src/view/com/modals/EditProfile.tsx:209
 msgid "Description"
-msgstr ""
+msgstr "Descripción"
 
 #: src/view/com/auth/create/Step1.tsx:96
 msgid "Dev Server"
-msgstr ""
+msgstr "Servidor de desarrollo"
 
 #: src/view/screens/Settings.tsx:637
 msgid "Developer Tools"
-msgstr ""
+msgstr "Herramientas de desarrollador"
 
 #: src/view/com/composer/Composer.tsx:143
 msgid "Discard"
-msgstr ""
+msgstr "Descartar"
 
 #: src/view/com/composer/Composer.tsx:137
 msgid "Discard draft"
-msgstr ""
+msgstr "Descartar el borrador"
 
 #: src/view/screens/Moderation.tsx:207
 msgid "Discourage apps from showing my account to logged-out users"
-msgstr ""
+msgstr "Evitar que las aplicaciones muestren mi cuenta a los usuarios desconectados"
 
 #: src/view/screens/Feeds.tsx:405
 msgid "Discover new feeds"
-msgstr ""
+msgstr "Descubrir nuevas publicaciones"
 
 #: src/view/com/modals/EditProfile.tsx:191
 msgid "Display name"
-msgstr ""
+msgstr "Mostrar el nombre"
 
 #: src/view/com/modals/EditProfile.tsx:179
 msgid "Display Name"
-msgstr ""
+msgstr "Mostrar el nombre"
 
 #: src/view/com/modals/ChangeHandle.tsx:485
 msgid "Domain verified!"
-msgstr ""
+msgstr "¡Dominio verificado!"
 
 #: src/view/com/auth/onboarding/RecommendedFollows.tsx:86
 #: src/view/com/modals/ContentFilteringSettings.tsx:88
@@ -700,126 +710,126 @@ msgstr ""
 #: src/view/screens/PreferencesHomeFeed.tsx:302
 #: src/view/screens/PreferencesThreads.tsx:156
 msgid "Done"
-msgstr ""
+msgstr "Listo"
 
 #: src/view/com/modals/lang-settings/ConfirmLanguagesButton.tsx:42
 msgid "Done{extraText}"
-msgstr ""
+msgstr "Listo{extraText}"
 
 #: src/view/com/modals/InviteCodes.tsx:94
 msgid "Each code works once. You'll receive more invite codes periodically."
-msgstr ""
+msgstr "Cada código funciona una vez. Recibirás más códigos de invitación periódicamente."
 
 #: src/view/com/composer/photos/Gallery.tsx:144
 #: src/view/com/modals/EditImage.tsx:207
 msgid "Edit image"
-msgstr ""
+msgstr "Editar la imagen"
 
 #: src/view/screens/ProfileList.tsx:399
 msgid "Edit list details"
-msgstr ""
+msgstr "Editar los detalles de la lista"
 
 #: src/view/screens/Feeds.tsx:367
 #: src/view/screens/SavedFeeds.tsx:84
 msgid "Edit My Feeds"
-msgstr ""
+msgstr "Editar mis noticias"
 
 #: src/view/com/modals/EditProfile.tsx:151
 msgid "Edit my profile"
-msgstr ""
+msgstr "Editar mi perfil"
 
 #: src/view/com/profile/ProfileHeader.tsx:453
 msgid "Edit profile"
-msgstr ""
+msgstr "Editar el perfil"
 
 #: src/view/com/profile/ProfileHeader.tsx:456
 msgid "Edit Profile"
-msgstr ""
+msgstr "Editar el perfil"
 
 #: src/view/screens/Feeds.tsx:330
 msgid "Edit Saved Feeds"
-msgstr ""
+msgstr "Editar mis noticias guardadas"
 
 #: src/view/com/auth/create/Step2.tsx:90
 #: src/view/com/auth/login/ForgotPasswordForm.tsx:148
 #: src/view/com/modals/ChangeEmail.tsx:141
 #: src/view/com/modals/Waitlist.tsx:88
 msgid "Email"
-msgstr ""
+msgstr "Correo electrónico"
 
 #: src/view/com/auth/create/Step2.tsx:81
 msgid "Email address"
-msgstr ""
+msgstr "Dirección de correo electrónico"
 
 #: src/view/com/modals/ChangeEmail.tsx:111
 msgid "Email Updated"
-msgstr ""
+msgstr "Correo electrónico actualizado"
 
 #: src/view/screens/Settings.tsx:290
 msgid "Email:"
-msgstr ""
+msgstr "Correo electrónico:"
 
 #: src/view/screens/PreferencesHomeFeed.tsx:138
 msgid "Enable this setting to only see replies between people you follow."
-msgstr ""
+msgstr "Activa esta opción para ver sólo las respuestas de las personas a las que sigues."
 
 #: src/view/screens/Profile.tsx:426
 msgid "End of feed"
-msgstr ""
+msgstr "Fin de noticias"
 
 #: src/view/com/auth/create/Step1.tsx:71
 msgid "Enter the address of your provider:"
-msgstr ""
+msgstr "Introduce la dirección de tu proveedor:"
 
 #: src/view/com/modals/ChangeHandle.tsx:369
 msgid "Enter the domain you want to use"
-msgstr ""
+msgstr "Introduce el dominio que quieres utilizar"
 
 #: src/view/com/auth/login/ForgotPasswordForm.tsx:101
 msgid "Enter the email you used to create your account. We'll send you a \"reset code\" so you can set a new password."
-msgstr ""
+msgstr "Introduce el correo electrónico que utilizaste para crear tu cuenta. Te enviaremos un \"código de restablecimiento\" para que puedas establecer una nueva contraseña."
 
 #: src/view/com/auth/create/Step2.tsx:86
 msgid "Enter your email address"
-msgstr ""
+msgstr "Introduce la dirección de correo electrónico"
 
 #: src/view/com/modals/ChangeEmail.tsx:117
 msgid "Enter your new email address below."
-msgstr ""
+msgstr "Introduce tu nueva dirección de correo electrónico a continuación."
 
 #: src/view/com/auth/login/Login.tsx:99
 msgid "Enter your username and password"
-msgstr ""
+msgstr "Introduce tu nombre de usuario y contraseña"
 
 #: src/view/screens/Search/Search.tsx:106
 msgid "Error:"
-msgstr ""
+msgstr "Error:"
 
 #: src/view/com/modals/Threadgate.tsx:76
 msgid "Everybody"
-msgstr ""
+msgstr "Todos"
 
 #: src/view/com/lightbox/Lightbox.web.tsx:156
 msgid "Expand alt text"
-msgstr ""
+msgstr "Expandir el texto alt"
 
 #: src/view/com/auth/onboarding/RecommendedFeeds.tsx:109
 #: src/view/com/auth/onboarding/RecommendedFeeds.tsx:141
 msgid "Failed to load recommended feeds"
-msgstr ""
+msgstr "Error al cargar las noticias recomendadas"
 
 #: src/view/screens/Feeds.tsx:560
 msgid "Feed offline"
-msgstr ""
+msgstr "Noticias fuera de línea"
 
 #: src/view/com/feeds/FeedPage.tsx:143
 msgid "Feed Preferences"
-msgstr ""
+msgstr "Preferencias de noticias"
 
 #: src/view/shell/desktop/RightNav.tsx:65
 #: src/view/shell/Drawer.tsx:292
 msgid "Feedback"
-msgstr ""
+msgstr "Comentarios"
 
 #: src/view/screens/Feeds.tsx:475
 #: src/view/screens/Profile.tsx:165
@@ -828,266 +838,266 @@ msgstr ""
 #: src/view/shell/Drawer.tsx:455
 #: src/view/shell/Drawer.tsx:456
 msgid "Feeds"
-msgstr ""
+msgstr "Noticias"
 
 #: src/view/com/auth/onboarding/RecommendedFeeds.tsx:57
 msgid "Feeds are created by users to curate content. Choose some feeds that you find interesting."
-msgstr ""
+msgstr "Se crean las noticias por los usuarios para crear colecciones de contenidos. Elige algunas noticias que te parezcan interesantes."
 
 #: src/view/screens/SavedFeeds.tsx:156
 msgid "Feeds are custom algorithms that users build with a little coding expertise. <0/> for more information."
-msgstr ""
+msgstr "Las noticias son algoritmos personalizados que los usuarios construyen con un poco de experiencia en codificación. <0/> para más información."
 
 #: src/view/screens/Search/Search.tsx:422
 msgid "Find users on Bluesky"
-msgstr ""
+msgstr "Encontrar usuarios en Bluesky"
 
 #: src/view/screens/Search/Search.tsx:420
 msgid "Find users with the search tool on the right"
-msgstr ""
+msgstr "Encuentra usuarios con la herramienta de búsqueda de la derecha"
 
 #: src/view/com/auth/onboarding/RecommendedFollowsItem.tsx:150
 msgid "Finding similar accounts..."
-msgstr ""
+msgstr "Encontrar cuentas similares..."
 
 #: src/view/screens/PreferencesHomeFeed.tsx:102
 msgid "Fine-tune the content you see on your home screen."
-msgstr ""
+msgstr "Ajusta el contenido que ves en tu pantalla de inicio."
 
 #: src/view/screens/PreferencesThreads.tsx:60
 msgid "Fine-tune the discussion threads."
-msgstr ""
+msgstr "Ajusta los hilos de discusión."
 
 #: src/view/com/profile/ProfileHeader.tsx:538
 msgid "Follow"
-msgstr ""
+msgstr "Seguir"
 
 #: src/view/com/auth/onboarding/RecommendedFollows.tsx:64
 msgid "Follow some users to get started. We can recommend you more users based on who you find interesting."
-msgstr ""
+msgstr "Sigue a algunos usuarios para empezar. Podemos recomendarte más usuarios en función de los que te parezcan interesantes."
 
 #: src/view/com/modals/Threadgate.tsx:98
 msgid "Followed users"
-msgstr ""
+msgstr "Usuarios seguidos"
 
 #: src/view/screens/PreferencesHomeFeed.tsx:145
 msgid "Followed users only"
-msgstr ""
+msgstr "Solo usuarios seguidos"
 
 #: src/view/screens/ProfileFollowers.tsx:25
 msgid "Followers"
-msgstr ""
+msgstr "Seguidores"
 
 #: src/view/com/profile/ProfileHeader.tsx:624
 msgid "following"
-msgstr ""
+msgstr "siguiendo"
 
 #: src/view/com/profile/ProfileHeader.tsx:522
 #: src/view/screens/ProfileFollows.tsx:25
 msgid "Following"
-msgstr ""
+msgstr "Siguiendo"
 
 #: src/view/com/profile/ProfileHeader.tsx:571
 msgid "Follows you"
-msgstr ""
+msgstr "Te siguen"
 
 #: src/view/com/modals/DeleteAccount.tsx:107
 msgid "For security reasons, we'll need to send a confirmation code to your email address."
-msgstr ""
+msgstr "Por razones de seguridad, tendremos que enviarte un código de confirmación a tu dirección de correo electrónico."
 
 #: src/view/com/modals/AddAppPasswords.tsx:207
 msgid "For security reasons, you won't be able to view this again. If you lose this password, you'll need to generate a new one."
-msgstr ""
+msgstr "Por razones de seguridad, no podrás volver a verla. Si pierdes esta contraseña, tendrás que generar una nueva."
 
 #: src/view/com/auth/login/LoginForm.tsx:231
 msgid "Forgot"
-msgstr ""
+msgstr "Lo olvidé"
 
 #: src/view/com/auth/login/LoginForm.tsx:228
 msgid "Forgot password"
-msgstr ""
+msgstr "Olvidé mi contraseña"
 
 #: src/view/com/auth/login/Login.tsx:127
 #: src/view/com/auth/login/Login.tsx:143
 msgid "Forgot Password"
-msgstr ""
+msgstr "Olvidé mi contraseña"
 
 #: src/view/com/composer/photos/SelectPhotoBtn.tsx:43
 msgid "Gallery"
-msgstr ""
+msgstr "Galería"
 
 #: src/view/com/modals/VerifyEmail.tsx:183
 msgid "Get Started"
-msgstr ""
+msgstr "Comenzar"
 
 #: src/view/com/auth/LoggedOut.tsx:81
 #: src/view/com/auth/LoggedOut.tsx:82
 #: src/view/com/util/moderation/ScreenHider.tsx:123
 #: src/view/shell/desktop/LeftNav.tsx:104
 msgid "Go back"
-msgstr ""
+msgstr "Regresar"
 
 #: src/view/screens/ProfileFeed.tsx:103
 #: src/view/screens/ProfileFeed.tsx:108
 #: src/view/screens/ProfileList.tsx:839
 #: src/view/screens/ProfileList.tsx:844
 msgid "Go Back"
-msgstr ""
+msgstr "Regresar"
 
 #: src/view/com/auth/login/ForgotPasswordForm.tsx:181
 #: src/view/com/auth/login/LoginForm.tsx:278
 #: src/view/com/auth/login/SetNewPasswordForm.tsx:163
 msgid "Go to next"
-msgstr ""
+msgstr "Ir al siguiente"
 
 #: src/view/com/modals/ChangeHandle.tsx:265
 msgid "Handle"
-msgstr ""
+msgstr "Identificador"
 
 #: src/view/shell/desktop/RightNav.tsx:94
 #: src/view/shell/Drawer.tsx:302
 msgid "Help"
-msgstr ""
+msgstr "Ayuda"
 
 #: src/view/com/modals/AddAppPasswords.tsx:148
 msgid "Here is your app password."
-msgstr ""
+msgstr "Aquí tienes tu contraseña de la app."
 
 #: src/view/com/notifications/FeedItem.tsx:316
 #: src/view/com/util/moderation/ContentHider.tsx:103
 msgid "Hide"
-msgstr ""
+msgstr "Ocultar"
 
 #: src/view/com/notifications/FeedItem.tsx:308
 msgid "Hide user list"
-msgstr ""
+msgstr "Ocultar la lista de usuarios"
 
 #: src/view/com/posts/FeedErrorMessage.tsx:110
 msgid "Hmm, some kind of issue occurred when contacting the feed server. Please let the feed owner know about this issue."
-msgstr ""
+msgstr "Se ha producido algún problema al contactar con el servidor de noticias. Por favor, informa al propietario de la noticia sobre este problema."
 
 #: src/view/com/posts/FeedErrorMessage.tsx:98
 msgid "Hmm, the feed server appears to be misconfigured. Please let the feed owner know about this issue."
-msgstr ""
+msgstr "Parece que el servidor de noticias está mal configurado. Por favor, informa al propietario de la noticia sobre este problema."
 
 #: src/view/com/posts/FeedErrorMessage.tsx:104
 msgid "Hmm, the feed server appears to be offline. Please let the feed owner know about this issue."
-msgstr ""
+msgstr "Parece que el servidor de noticias está fuera de línea. Por favor, informa al propietario de la noticia sobre este problema."
 
 #: src/view/com/posts/FeedErrorMessage.tsx:101
 msgid "Hmm, the feed server gave a bad response. Please let the feed owner know about this issue."
-msgstr ""
+msgstr "El servidor de noticias ha respondido de forma incorrecta. Por favor, informa al propietario de la noticia sobre este problema."
 
 #: src/view/com/posts/FeedErrorMessage.tsx:95
 msgid "Hmm, we're having trouble finding this feed. It may have been deleted."
-msgstr ""
+msgstr "Tenemos problemas para encontrar esta noticia. Puede que la hayan borrado."
 
 #: src/view/shell/bottom-bar/BottomBar.tsx:137
 #: src/view/shell/desktop/LeftNav.tsx:304
 #: src/view/shell/Drawer.tsx:379
 #: src/view/shell/Drawer.tsx:380
 msgid "Home"
-msgstr ""
+msgstr "Página inicial"
 
 #: src/view/com/pager/FeedsTabBarMobile.tsx:96
 #: src/view/screens/PreferencesHomeFeed.tsx:95
 #: src/view/screens/Settings.tsx:481
 msgid "Home Feed Preferences"
-msgstr ""
+msgstr "Preferencias de noticias de la página inicial"
 
 #: src/view/com/auth/login/ForgotPasswordForm.tsx:114
 msgid "Hosting provider"
-msgstr ""
+msgstr "Proveedor de alojamiento"
 
 #: src/view/com/auth/create/Step1.tsx:76
 #: src/view/com/auth/create/Step1.tsx:81
 msgid "Hosting provider address"
-msgstr ""
+msgstr "Dirección del proveedor de alojamiento"
 
 #: src/view/com/modals/VerifyEmail.tsx:208
 msgid "I have a code"
-msgstr ""
+msgstr "Tengo un código"
 
 #: src/view/com/modals/ChangeHandle.tsx:281
 msgid "I have my own domain"
-msgstr ""
+msgstr "Tengo mi propio dominio"
 
 #: src/view/com/modals/SelfLabel.tsx:127
 msgid "If none are selected, suitable for all ages."
-msgstr ""
+msgstr "Si no se selecciona ninguno, es apto para todas las edades."
 
 #: src/view/com/modals/AltImage.tsx:97
 msgid "Image alt text"
-msgstr ""
+msgstr "Texto alt de la imagen"
 
 #: src/view/com/util/UserAvatar.tsx:308
 #: src/view/com/util/UserBanner.tsx:116
 msgid "Image options"
-msgstr ""
+msgstr "Opciones de la imagen"
 
 #: src/view/com/auth/login/LoginForm.tsx:113
 msgid "Invalid username or password"
-msgstr ""
+msgstr "Nombre de usuario o contraseña no válidos"
 
 #: src/view/screens/Settings.tsx:383
 msgid "Invite"
-msgstr ""
+msgstr "Invitar"
 
 #: src/view/com/modals/InviteCodes.tsx:91
 #: src/view/screens/Settings.tsx:371
 msgid "Invite a Friend"
-msgstr ""
+msgstr "Invitar a un amigo"
 
 #: src/view/com/auth/create/Step2.tsx:57
 msgid "Invite code"
-msgstr ""
+msgstr "Código de invitación"
 
 #: src/view/com/auth/create/state.ts:136
 msgid "Invite code not accepted. Check that you input it correctly and try again."
-msgstr ""
+msgstr "No se acepta el código de invitación. Comprueba que lo has introducido correctamente e inténtalo de nuevo."
 
 #: src/view/shell/Drawer.tsx:621
 msgid "Invite codes: {invitesAvailable} available"
-msgstr ""
+msgstr "Códigos de invitación: {invitesAvailable} disponibles"
 
 #: src/view/com/auth/HomeLoggedOutCTA.tsx:99
 msgid "Jobs"
-msgstr ""
+msgstr "Tareas"
 
 #: src/view/com/modals/Waitlist.tsx:67
 msgid "Join the waitlist"
-msgstr ""
+msgstr "Únete a la lista de espera"
 
 #: src/view/com/auth/create/Step2.tsx:68
 #: src/view/com/auth/create/Step2.tsx:72
 msgid "Join the waitlist."
-msgstr ""
+msgstr "Únete a la lista de espera."
 
 #: src/view/com/modals/Waitlist.tsx:124
 msgid "Join Waitlist"
-msgstr ""
+msgstr "Únete a la lista de espera"
 
 #: src/view/com/composer/select-language/SelectLangBtn.tsx:104
 msgid "Language selection"
-msgstr ""
+msgstr "Escoger el idioma"
 
 #: src/view/screens/LanguageSettings.tsx:89
 msgid "Language Settings"
-msgstr ""
+msgstr "Configuración del idioma"
 
 #: src/view/screens/Settings.tsx:541
 msgid "Languages"
-msgstr ""
+msgstr "Idiomas"
 
 #: src/view/com/util/moderation/ContentHider.tsx:101
 msgid "Learn more"
-msgstr ""
+msgstr "Aprender más"
 
 #: src/view/com/util/moderation/PostAlerts.tsx:47
 #: src/view/com/util/moderation/ProfileHeaderAlerts.tsx:65
 #: src/view/com/util/moderation/ScreenHider.tsx:104
 msgid "Learn More"
-msgstr ""
+msgstr "Aprender más"
 
 #: src/view/com/util/moderation/ContentHider.tsx:83
 #: src/view/com/util/moderation/PostAlerts.tsx:40
@@ -1095,110 +1105,114 @@ msgstr ""
 #: src/view/com/util/moderation/ProfileHeaderAlerts.tsx:49
 #: src/view/com/util/moderation/ScreenHider.tsx:101
 msgid "Learn more about this warning"
-msgstr ""
+msgstr "Aprender más acerca de esta advertencia"
 
 #: src/view/screens/Moderation.tsx:242
 msgid "Learn more about what is public on Bluesky."
-msgstr ""
+msgstr "Más información sobre lo que es público en Bluesky."
 
 #: src/view/com/modals/lang-settings/ContentLanguagesSettings.tsx:82
 msgid "Leave them all unchecked to see any language."
-msgstr ""
+msgstr "Déjalos todos sin marcar para ver cualquier idioma."
 
 #: src/view/com/modals/LinkWarning.tsx:49
 msgid "Leaving Bluesky"
-msgstr ""
+msgstr "Salir de Bluesky"
 
 #: src/view/com/auth/login/Login.tsx:128
 #: src/view/com/auth/login/Login.tsx:144
 msgid "Let's get your password reset!"
-msgstr ""
+msgstr "¡Vamos a restablecer tu contraseña!"
 
 #: src/view/com/util/UserAvatar.tsx:245
 #: src/view/com/util/UserBanner.tsx:60
 msgid "Library"
-msgstr ""
+msgstr "Librería"
 
 #: src/view/screens/ProfileFeed.tsx:577
 msgid "Like this feed"
-msgstr ""
+msgstr "Dar «me gusta» a esta noticia"
 
 #: src/view/screens/PostLikedBy.tsx:27
 #: src/view/screens/ProfileFeedLikedBy.tsx:27
 msgid "Liked by"
-msgstr ""
+msgstr "Le ha gustado a"
 
 #: src/view/screens/Profile.tsx:164
 msgid "Likes"
-msgstr ""
+msgstr "Cantidad de «Me gusta»"
 
 #: src/view/com/modals/CreateOrEditList.tsx:186
 msgid "List Avatar"
-msgstr ""
+msgstr "Avatar de la lista"
 
 #: src/view/com/modals/CreateOrEditList.tsx:199
 msgid "List Name"
-msgstr ""
+msgstr "Nombre de la lista"
 
 #: src/view/screens/Profile.tsx:166
 #: src/view/shell/desktop/LeftNav.tsx:377
 #: src/view/shell/Drawer.tsx:471
 #: src/view/shell/Drawer.tsx:472
 msgid "Lists"
-msgstr ""
+msgstr "Listas"
 
 #: src/view/com/post-thread/PostThread.tsx:260
 #: src/view/com/post-thread/PostThread.tsx:268
 msgid "Load more posts"
-msgstr ""
+msgstr "Cargar más publicaciones"
 
 #: src/view/screens/Notifications.tsx:144
 msgid "Load new notifications"
-msgstr ""
+msgstr "Cargar notificaciones nuevas"
 
 #: src/view/com/feeds/FeedPage.tsx:189
 msgid "Load new posts"
-msgstr ""
+msgstr "Cargar publicaciones nuevas"
 
 #: src/view/com/composer/text-input/mobile/Autocomplete.tsx:95
 msgid "Loading..."
-msgstr ""
+msgstr "Cargando..."
 
 #: src/view/com/modals/ServerInput.tsx:50
 msgid "Local dev server"
-msgstr ""
+msgstr "Servidor de desarrollo local"
 
 #: src/view/screens/Moderation.tsx:136
 msgid "Logged-out visibility"
-msgstr ""
+msgstr "Visibilidad de desconexión"
 
 #: src/view/com/auth/login/ChooseAccountForm.tsx:133
 msgid "Login to account that is not listed"
-msgstr ""
+msgstr "Acceder a una cuenta que no está en la lista"
+
+#: src/view/screens/ProfileFeed.tsx:472
+#~ msgid "Looks like this feed is only available to users with a Bluesky account. Please sign up or sign in to view this feed!"
+#~ msgstr "Parece que este canal de noticias sólo está disponible para usuarios con una cuenta Bluesky. Por favor, ¡regístrate o inicia sesión para ver este canal!"
 
 #: src/view/com/modals/LinkWarning.tsx:63
 msgid "Make sure this is where you intend to go!"
-msgstr ""
+msgstr "¡Asegúrate de que es aquí a donde pretendes ir!"
 
 #: src/view/screens/Profile.tsx:163
 msgid "Media"
-msgstr ""
+msgstr "Medios"
 
 #: src/view/com/threadgate/WhoCanReply.tsx:139
 msgid "mentioned users"
-msgstr ""
+msgstr "usuarios mencionados"
 
 #: src/view/com/modals/Threadgate.tsx:93
 msgid "Mentioned users"
-msgstr ""
+msgstr "Usuarios mencionados"
 
 #: src/view/screens/Search/Search.tsx:537
 msgid "Menu"
-msgstr ""
+msgstr "Menú"
 
 #: src/view/com/posts/FeedErrorMessage.tsx:194
 msgid "Message from server"
-msgstr ""
+msgstr "Mensaje del servidor"
 
 #: src/view/screens/Moderation.tsx:64
 #: src/view/screens/Settings.tsx:563
@@ -1206,91 +1220,91 @@ msgstr ""
 #: src/view/shell/Drawer.tsx:490
 #: src/view/shell/Drawer.tsx:491
 msgid "Moderation"
-msgstr ""
+msgstr "Moderación"
 
 #: src/view/screens/Moderation.tsx:95
 msgid "Moderation lists"
-msgstr ""
+msgstr "Listas de moderación"
 
 #: src/view/screens/ModerationModlists.tsx:58
 msgid "Moderation Lists"
-msgstr ""
+msgstr "Listas de moderación"
 
 #: src/view/shell/desktop/Feeds.tsx:53
 msgid "More feeds"
-msgstr ""
+msgstr "Más canales de noticias"
 
 #: src/view/com/profile/ProfileHeader.tsx:548
 #: src/view/screens/ProfileFeed.tsx:360
 #: src/view/screens/ProfileList.tsx:583
 msgid "More options"
-msgstr ""
+msgstr "Más opciones"
 
 #: src/view/com/profile/ProfileHeader.tsx:370
 msgid "Mute Account"
-msgstr ""
+msgstr "Silenciar la cuenta"
 
 #: src/view/screens/ProfileList.tsx:510
 msgid "Mute accounts"
-msgstr ""
+msgstr "Silenciar las cuentas"
 
 #: src/view/screens/ProfileList.tsx:457
 msgid "Mute list"
-msgstr ""
+msgstr "Silenciar la lista"
 
 #: src/view/screens/ProfileList.tsx:270
 msgid "Mute these accounts?"
-msgstr ""
+msgstr "¿Silenciar estas cuentas?"
 
 #: src/view/com/util/forms/PostDropdownBtn.tsx:149
 msgid "Mute thread"
-msgstr ""
+msgstr "Silenciar el hilo"
 
 #: src/view/screens/Moderation.tsx:109
 msgid "Muted accounts"
-msgstr ""
+msgstr "Cuentas silenciadas"
 
 #: src/view/screens/ModerationMutedAccounts.tsx:106
 msgid "Muted Accounts"
-msgstr ""
+msgstr "Cuentas silenciadas"
 
 #: src/view/screens/ModerationMutedAccounts.tsx:114
 msgid "Muted accounts have their posts removed from your feed and from your notifications. Mutes are completely private."
-msgstr ""
+msgstr "Las cuentas silenciadas eliminan sus publicaciones de tu canal de noticias y de tus notificaciones. Las cuentas silenciadas son completamente privadas."
 
 #: src/view/screens/ProfileList.tsx:272
 msgid "Muting is private. Muted accounts can interact with you, but you will not see their posts or receive notifications from them."
-msgstr ""
+msgstr "Silenciar es privado. Las cuentas silenciadas pueden interactuar contigo, pero no verás sus publicaciones ni recibirás notificaciones suyas."
 
 #: src/view/com/modals/BirthDateSettings.tsx:56
 msgid "My Birthday"
-msgstr ""
+msgstr "Mi cumpleaños"
 
 #: src/view/screens/Feeds.tsx:363
 msgid "My Feeds"
-msgstr ""
+msgstr "Mis canales de noticias"
 
 #: src/view/shell/desktop/LeftNav.tsx:65
 msgid "My Profile"
-msgstr ""
+msgstr "Mi perfil"
 
 #: src/view/screens/Settings.tsx:520
 msgid "My Saved Feeds"
-msgstr ""
+msgstr "Mis canales de noticias guardados"
 
 #: src/view/com/modals/AddAppPasswords.tsx:177
 #: src/view/com/modals/CreateOrEditList.tsx:211
 msgid "Name"
-msgstr ""
+msgstr "Nombre"
 
 #: src/view/com/auth/onboarding/WelcomeMobile.tsx:72
 msgid "Never lose access to your followers and data."
-msgstr ""
+msgstr "No pierdas nunca el acceso a tus seguidores y datos."
 
 #: src/view/screens/Lists.tsx:76
 #: src/view/screens/ModerationModlists.tsx:78
 msgid "New"
-msgstr ""
+msgstr "Nuevo"
 
 #: src/view/com/feeds/FeedPage.tsx:200
 #: src/view/screens/Feeds.tsx:511
@@ -1300,11 +1314,11 @@ msgstr ""
 #: src/view/screens/ProfileList.tsx:221
 #: src/view/shell/desktop/LeftNav.tsx:247
 msgid "New post"
-msgstr ""
+msgstr "Publicación nueva"
 
 #: src/view/shell/desktop/LeftNav.tsx:257
 msgid "New Post"
-msgstr ""
+msgstr "Publicación nueva"
 
 #: src/view/com/auth/create/CreateAccount.tsx:154
 #: src/view/com/auth/login/ForgotPasswordForm.tsx:174
@@ -1314,30 +1328,30 @@ msgstr ""
 #: src/view/com/auth/login/SetNewPasswordForm.tsx:166
 #: src/view/com/auth/onboarding/RecommendedFeeds.tsx:79
 msgid "Next"
-msgstr ""
+msgstr "Siguiente"
 
 #: src/view/com/lightbox/Lightbox.web.tsx:142
 msgid "Next image"
-msgstr ""
+msgstr "Imagen nueva"
 
 #: src/view/screens/PreferencesHomeFeed.tsx:191
 #: src/view/screens/PreferencesHomeFeed.tsx:226
 #: src/view/screens/PreferencesHomeFeed.tsx:263
 msgid "No"
-msgstr ""
+msgstr "No"
 
 #: src/view/screens/ProfileFeed.tsx:570
 #: src/view/screens/ProfileList.tsx:711
 msgid "No description"
-msgstr ""
+msgstr "Sin descripción"
 
 #: src/view/com/composer/text-input/mobile/Autocomplete.tsx:97
 msgid "No result"
-msgstr ""
+msgstr "Sin resultados"
 
 #: src/view/screens/Feeds.tsx:452
 msgid "No results found for \"{query}\""
-msgstr ""
+msgstr "No se han encontrado resultados para \"{query}\""
 
 #: src/view/com/modals/ListAddRemoveUsers.tsx:127
 #: src/view/screens/Search/Search.tsx:271
@@ -1345,19 +1359,19 @@ msgstr ""
 #: src/view/screens/Search/Search.tsx:615
 #: src/view/shell/desktop/Search.tsx:210
 msgid "No results found for {query}"
-msgstr ""
+msgstr "No se han encontrado resultados para {query}"
 
 #: src/view/com/modals/Threadgate.tsx:82
 msgid "Nobody"
-msgstr ""
+msgstr "Nadie"
 
 #: src/view/com/modals/SelfLabel.tsx:135
 msgid "Not Applicable."
-msgstr ""
+msgstr "No aplicable."
 
 #: src/view/screens/Moderation.tsx:232
 msgid "Note: Bluesky is an open and public network. This setting only limits the visibility of your content on the Bluesky app and website, and other apps may not respect this setting. Your content may still be shown to logged-out users by other apps and websites."
-msgstr ""
+msgstr "Nota: Bluesky es una red abierta y pública. Esta configuración sólo limita la visibilidad de tu contenido en la aplicación y el sitio web de Bluesky, y es posible que otras aplicaciones no respeten esta configuración. Otras aplicaciones y sitios web pueden seguir mostrando tu contenido a los usuarios que hayan cerrado sesión."
 
 #: src/view/screens/Notifications.tsx:109
 #: src/view/screens/Notifications.tsx:133
@@ -1366,85 +1380,85 @@ msgstr ""
 #: src/view/shell/Drawer.tsx:416
 #: src/view/shell/Drawer.tsx:417
 msgid "Notifications"
-msgstr ""
+msgstr "Notificaciones"
 
 #: src/view/com/util/ErrorBoundary.tsx:34
 msgid "Oh no!"
-msgstr ""
+msgstr "¡Qué problema!"
 
 #: src/view/com/auth/login/PasswordUpdatedForm.tsx:41
 msgid "Okay"
-msgstr ""
+msgstr "Está bien"
 
 #: src/view/com/composer/Composer.tsx:354
 msgid "One or more images is missing alt text."
-msgstr ""
+msgstr "Falta el texto alternativo en una o varias imágenes."
 
 #: src/view/com/threadgate/WhoCanReply.tsx:100
 msgid "Only {0} can reply."
-msgstr ""
+msgstr "Solo {0} puede responder."
 
 #: src/view/com/pager/FeedsTabBarMobile.tsx:76
 msgid "Open navigation"
-msgstr ""
+msgstr "Abrir navegación"
 
 #: src/view/screens/Settings.tsx:533
 msgid "Opens configurable language settings"
-msgstr ""
+msgstr "Abrir la configuración del idioma que se puede ajustar"
 
 #: src/view/shell/desktop/RightNav.tsx:148
 #: src/view/shell/Drawer.tsx:622
 msgid "Opens list of invite codes"
-msgstr ""
+msgstr "Abre la lista de códigos de invitación"
 
 #: src/view/com/modals/ChangeHandle.tsx:279
 msgid "Opens modal for using custom domain"
-msgstr ""
+msgstr "Abre el modal para usar el dominio personalizado"
 
 #: src/view/screens/Settings.tsx:558
 msgid "Opens moderation settings"
-msgstr ""
+msgstr "Abre la configuración de moderación"
 
 #: src/view/screens/Settings.tsx:514
 msgid "Opens screen with all saved feeds"
-msgstr ""
+msgstr "Abre la pantalla con todas las noticias guardadas"
 
 #: src/view/screens/Settings.tsx:581
 msgid "Opens the app password settings page"
-msgstr ""
+msgstr "Abre la página de configuración de la contraseña de la app"
 
 #: src/view/screens/Settings.tsx:473
 msgid "Opens the home feed preferences"
-msgstr ""
+msgstr "Abre las preferencias de noticias de la página inicial"
 
 #: src/view/screens/Settings.tsx:664
 msgid "Opens the storybook page"
-msgstr ""
+msgstr "Abre la página del libro de cuentos"
 
 #: src/view/screens/Settings.tsx:644
 msgid "Opens the system log page"
-msgstr ""
+msgstr "Abre la página de la bitácora del sistema"
 
 #: src/view/screens/Settings.tsx:494
 msgid "Opens the threads preferences"
-msgstr ""
+msgstr "Abre las preferencias de hilos"
 
 #: src/view/com/auth/login/ChooseAccountForm.tsx:138
 msgid "Other account"
-msgstr ""
+msgstr "Otra cuenta"
 
 #: src/view/com/modals/ServerInput.tsx:88
 msgid "Other service"
-msgstr ""
+msgstr "Otro servicio"
 
 #: src/view/com/composer/select-language/SelectLangBtn.tsx:91
 msgid "Other..."
-msgstr ""
+msgstr "Otro..."
 
 #: src/view/screens/NotFound.tsx:42
 #: src/view/screens/NotFound.tsx:45
 msgid "Page not found"
-msgstr ""
+msgstr "Página no encontrada"
 
 #: src/view/com/auth/create/Step2.tsx:101
 #: src/view/com/auth/create/Step2.tsx:111
@@ -1452,106 +1466,111 @@ msgstr ""
 #: src/view/com/auth/login/SetNewPasswordForm.tsx:130
 #: src/view/com/modals/DeleteAccount.tsx:191
 msgid "Password"
-msgstr ""
+msgstr "Contraseña"
 
 #: src/view/com/auth/login/Login.tsx:157
 msgid "Password updated"
-msgstr ""
+msgstr "Contraseña actualizada"
 
 #: src/view/com/auth/login/PasswordUpdatedForm.tsx:28
 msgid "Password updated!"
-msgstr ""
+msgstr "¡Contraseña actualizada!"
 
 #: src/view/com/modals/SelfLabel.tsx:121
 msgid "Pictures meant for adults."
-msgstr ""
+msgstr "Imágenes destinadas a adultos."
 
 #: src/view/screens/SavedFeeds.tsx:88
 msgid "Pinned Feeds"
-msgstr ""
+msgstr "Canales de noticias anclados"
 
 #: src/view/com/auth/create/state.ts:116
 msgid "Please choose your handle."
-msgstr ""
+msgstr "Por favor, elige tu identificador."
 
 #: src/view/com/auth/create/state.ts:109
 msgid "Please choose your password."
-msgstr ""
+msgstr "Por favor, elige tu contraseña."
 
 #: src/view/com/modals/ChangeEmail.tsx:67
 msgid "Please confirm your email before changing it. This is a temporary requirement while email-updating tools are added, and it will soon be removed."
-msgstr ""
+msgstr "Por favor, confirma tu correo electrónico antes de cambiarlo. Se trata de un requisito temporal mientras se añaden herramientas de actualización de correo electrónico, y pronto se eliminará."
 
 #: src/view/com/modals/AddAppPasswords.tsx:140
 msgid "Please enter a unique name for this App Password or use our randomly generated one."
-msgstr ""
+msgstr "Introduce un nombre único para la contraseña de esta app o utiliza una generada aleatoriamente."
 
 #: src/view/com/auth/create/state.ts:95
 msgid "Please enter your email."
-msgstr ""
+msgstr "Introduce tu correo electrónico."
 
 #: src/view/com/modals/DeleteAccount.tsx:180
 msgid "Please enter your password as well:"
-msgstr ""
+msgstr "Introduce tu contraseña, también:"
 
 #: src/view/com/modals/AppealLabel.tsx:72
 #: src/view/com/modals/AppealLabel.tsx:75
 msgid "Please tell us why you think this content warning was incorrectly applied!"
 msgstr ""
 
+#: src/view/com/modals/AppealLabel.tsx:72
+#: src/view/com/modals/AppealLabel.tsx:75
+#~ msgid "Please tell us why you think this decision was incorrect."
+#~ msgstr "Por favor, dinos por qué crees que esta decisión fue incorrecta."
+
 #: src/view/com/composer/Composer.tsx:337
 #: src/view/com/post-thread/PostThread.tsx:226
 #: src/view/screens/PostThread.tsx:80
 msgid "Post"
-msgstr ""
+msgstr "Publicación"
 
 #: src/view/com/post-thread/PostThread.tsx:385
 msgid "Post hidden"
-msgstr ""
+msgstr "Publicación oculta"
 
 #: src/view/com/composer/select-language/SelectLangBtn.tsx:87
 msgid "Post language"
-msgstr ""
+msgstr "Lenguaje de la publicación"
 
 #: src/view/com/modals/lang-settings/PostLanguagesSettings.tsx:75
 msgid "Post Languages"
-msgstr ""
+msgstr "Lenguajes de la publicación"
 
 #: src/view/com/post-thread/PostThread.tsx:437
 msgid "Post not found"
-msgstr ""
+msgstr "Publicación no encontrada"
 
 #: src/view/screens/Profile.tsx:161
 msgid "Posts"
-msgstr ""
+msgstr "Publicaciones"
 
 #: src/view/com/modals/LinkWarning.tsx:44
 msgid "Potentially Misleading Link"
-msgstr ""
+msgstr "Enlace potencialmente engañoso"
 
 #: src/view/com/lightbox/Lightbox.web.tsx:128
 msgid "Previous image"
-msgstr ""
+msgstr "Imagen previa"
 
 #: src/view/screens/LanguageSettings.tsx:187
 msgid "Primary Language"
-msgstr ""
+msgstr "Lenguajes primarios"
 
 #: src/view/screens/PreferencesThreads.tsx:91
 msgid "Prioritize Your Follows"
-msgstr ""
+msgstr "Priorizar los usuarios a los que sigue"
 
 #: src/view/shell/desktop/RightNav.tsx:76
 msgid "Privacy"
-msgstr ""
+msgstr "Privacidad"
 
 #: src/view/screens/PrivacyPolicy.tsx:29
 msgid "Privacy Policy"
-msgstr ""
+msgstr "Política de privacidad"
 
 #: src/view/com/auth/login/ForgotPasswordForm.tsx:190
 msgid "Processing..."
-msgstr ""
+msgstr "Procesando..."
 
 #: src/view/shell/bottom-bar/BottomBar.tsx:247
 #: src/view/shell/desktop/LeftNav.tsx:413
@@ -1559,40 +1578,40 @@ msgstr ""
 #: src/view/shell/Drawer.tsx:525
 #: src/view/shell/Drawer.tsx:526
 msgid "Profile"
-msgstr ""
+msgstr "Perfil"
 
 #: src/view/screens/Settings.tsx:789
 msgid "Protect your account by verifying your email."
-msgstr ""
+msgstr "Protege tu cuenta verificando tu correo electrónico."
 
 #: src/view/screens/ModerationModlists.tsx:61
 msgid "Public, shareable lists of users to mute or block in bulk."
-msgstr ""
+msgstr "Listas públicas y compartibles de usuarios para silenciar o bloquear en bloque."
 
 #: src/view/screens/Lists.tsx:61
 msgid "Public, shareable lists which can drive feeds."
-msgstr ""
+msgstr "Listas públicas y compartibles que pueden impulsar las noticias."
 
 #: src/view/com/modals/Repost.tsx:52
 #: src/view/com/util/post-ctrls/RepostButton.web.tsx:58
 msgid "Quote post"
-msgstr ""
+msgstr "Citar una publicación"
 
 #: src/view/com/modals/Repost.tsx:56
 msgid "Quote Post"
-msgstr ""
+msgstr "Citar una publicación"
 
 #: src/view/com/modals/EditImage.tsx:236
 msgid "Ratios"
-msgstr ""
+msgstr "Proporciones"
 
 #: src/view/com/auth/onboarding/RecommendedFeeds.tsx:116
 msgid "Recommended Feeds"
-msgstr ""
+msgstr "Canales de noticias recomendados"
 
 #: src/view/com/auth/onboarding/RecommendedFollows.tsx:180
 msgid "Recommended Users"
-msgstr ""
+msgstr "Usuarios recomendados"
 
 #: src/view/com/modals/ListAddRemoveUsers.tsx:264
 #: src/view/com/modals/SelfLabel.tsx:83
@@ -1600,125 +1619,125 @@ msgstr ""
 #: src/view/com/util/UserAvatar.tsx:282
 #: src/view/com/util/UserBanner.tsx:89
 msgid "Remove"
-msgstr ""
+msgstr "Eliminar"
 
 #: src/view/com/feeds/FeedSourceCard.tsx:106
 msgid "Remove {0} from my feeds?"
-msgstr ""
+msgstr "¿Eliminar {0} de mis canales de noticias?"
 
 #: src/view/com/util/AccountDropdownBtn.tsx:22
 msgid "Remove account"
-msgstr ""
+msgstr "Eliminar la cuenta"
 
 #: src/view/com/posts/FeedErrorMessage.tsx:130
 msgid "Remove feed"
-msgstr ""
+msgstr "Eliminar el canal de noticias"
 
 #: src/view/com/feeds/FeedSourceCard.tsx:105
 #: src/view/com/feeds/FeedSourceCard.tsx:172
 #: src/view/screens/ProfileFeed.tsx:270
 msgid "Remove from my feeds"
-msgstr ""
+msgstr "Eliminar de mis canales de noticias"
 
 #: src/view/com/composer/photos/Gallery.tsx:167
 msgid "Remove image"
-msgstr ""
+msgstr "Eliminar la imagen"
 
 #: src/view/com/composer/ExternalEmbed.tsx:70
 msgid "Remove image preview"
-msgstr ""
+msgstr "Eliminar la vista previa de la imagen"
 
 #: src/view/com/feeds/FeedSourceCard.tsx:173
 msgid "Remove this feed from my feeds?"
-msgstr ""
+msgstr "¿Eliminar este canal de mis canales de noticias?"
 
 #: src/view/com/posts/FeedErrorMessage.tsx:131
 msgid "Remove this feed from your saved feeds?"
-msgstr ""
+msgstr "¿Eliminar este canal de mis canales de noticias guardados?"
 
 #: src/view/com/modals/ListAddRemoveUsers.tsx:199
 #: src/view/com/modals/UserAddRemoveLists.tsx:136
 msgid "Removed from list"
-msgstr ""
+msgstr "Eliminar de la lista"
 
 #: src/view/screens/Profile.tsx:162
 msgid "Replies"
-msgstr ""
+msgstr "Respuestas"
 
 #: src/view/com/threadgate/WhoCanReply.tsx:98
 msgid "Replies to this thread are disabled"
-msgstr ""
+msgstr "Las respuestas a este hilo están desactivadas"
 
 #: src/view/screens/PreferencesHomeFeed.tsx:135
 msgid "Reply Filters"
-msgstr ""
+msgstr "Filtros de respuestas"
 
 #: src/view/com/modals/report/Modal.tsx:166
 msgid "Report {collectionName}"
-msgstr ""
+msgstr "Informe de {collectionName}"
 
 #: src/view/com/profile/ProfileHeader.tsx:404
 msgid "Report Account"
-msgstr ""
+msgstr "Informe de la cuenta"
 
 #: src/view/screens/ProfileFeed.tsx:290
 msgid "Report feed"
-msgstr ""
+msgstr "Informe del canal de noticias"
 
 #: src/view/screens/ProfileList.tsx:425
 msgid "Report List"
-msgstr ""
+msgstr "Informe de la lista"
 
 #: src/view/com/modals/report/SendReportButton.tsx:37
 #: src/view/com/util/forms/PostDropdownBtn.tsx:167
 msgid "Report post"
-msgstr ""
+msgstr "Informe de la publicación"
 
 #: src/view/com/util/post-ctrls/RepostButton.web.tsx:48
 msgid "Repost"
-msgstr ""
+msgstr "Volver a publicar"
 
 #: src/view/com/util/post-ctrls/RepostButton.web.tsx:94
 #: src/view/com/util/post-ctrls/RepostButton.web.tsx:105
 msgid "Repost or quote post"
-msgstr ""
+msgstr "Volver a publicar o citar publicación"
 
 #: src/view/screens/PostRepostedBy.tsx:27
 msgid "Reposted by"
-msgstr ""
+msgstr "Vuelto a publicar por"
 
 #: src/view/com/modals/ChangeEmail.tsx:181
 #: src/view/com/modals/ChangeEmail.tsx:183
 msgid "Request Change"
-msgstr ""
+msgstr "Solicitar un cambio"
 
 #: src/view/com/auth/create/Step2.tsx:53
 msgid "Required for this provider"
-msgstr ""
+msgstr "Requerido para este proveedor"
 
 #: src/view/com/auth/login/SetNewPasswordForm.tsx:108
 msgid "Reset code"
-msgstr ""
+msgstr "Restablecer el código"
 
 #: src/view/screens/Settings.tsx:686
 msgid "Reset onboarding state"
-msgstr ""
+msgstr "Restablecer el estado de incorporación"
 
 #: src/view/com/auth/login/ForgotPasswordForm.tsx:98
 msgid "Reset password"
-msgstr ""
+msgstr "Restablecer la contraseña"
 
 #: src/view/screens/Settings.tsx:676
 msgid "Reset preferences state"
-msgstr ""
+msgstr "Restablecer el estado de preferencias"
 
 #: src/view/screens/Settings.tsx:684
 msgid "Resets the onboarding state"
-msgstr ""
+msgstr "Restablece el estado de incorporación"
 
 #: src/view/screens/Settings.tsx:674
 msgid "Resets the preferences state"
-msgstr ""
+msgstr "Restablecer el estado de preferencias"
 
 #: src/view/com/auth/create/CreateAccount.tsx:163
 #: src/view/com/auth/create/CreateAccount.tsx:167
@@ -1727,7 +1746,7 @@ msgstr ""
 #: src/view/com/util/error/ErrorMessage.tsx:55
 #: src/view/com/util/error/ErrorScreen.tsx:65
 msgid "Retry"
-msgstr ""
+msgstr "Volver a intentar"
 
 #: src/view/com/modals/AltImage.tsx:115
 #: src/view/com/modals/BirthDateSettings.tsx:93
@@ -1737,27 +1756,27 @@ msgstr ""
 #: src/view/com/modals/CreateOrEditList.tsx:257
 #: src/view/com/modals/EditProfile.tsx:223
 msgid "Save"
-msgstr ""
+msgstr "Guardar"
 
 #: src/view/com/modals/AltImage.tsx:106
 msgid "Save alt text"
-msgstr ""
+msgstr "Guardar el texto alt"
 
 #: src/view/com/modals/EditProfile.tsx:231
 msgid "Save Changes"
-msgstr ""
+msgstr "Guardar cambios"
 
 #: src/view/com/modals/ChangeHandle.tsx:170
 msgid "Save handle change"
-msgstr ""
+msgstr "Guardar el cambio de identificador"
 
 #: src/view/com/modals/crop-image/CropImage.web.tsx:144
 msgid "Save image crop"
-msgstr ""
+msgstr "Guardar el recorte de imagen"
 
 #: src/view/screens/SavedFeeds.tsx:122
 msgid "Saved Feeds"
-msgstr ""
+msgstr "Guardar canales de noticias"
 
 #: src/view/com/modals/ListAddRemoveUsers.tsx:75
 #: src/view/com/util/forms/SearchInput.tsx:64
@@ -1770,7 +1789,7 @@ msgstr ""
 #: src/view/shell/Drawer.tsx:343
 #: src/view/shell/Drawer.tsx:344
 msgid "Search"
-msgstr ""
+msgstr "Buscar"
 
 #: src/view/com/auth/LoggedOut.tsx:104
 #: src/view/com/auth/LoggedOut.tsx:105
@@ -1779,134 +1798,134 @@ msgstr ""
 
 #: src/view/com/modals/ChangeEmail.tsx:110
 msgid "Security Step Required"
-msgstr ""
+msgstr "Se requiere un paso de seguridad"
 
 #: src/view/com/auth/HomeLoggedOutCTA.tsx:39
 msgid "See what's next"
-msgstr ""
+msgstr "Ver lo que sigue"
 
 #: src/view/com/modals/ServerInput.tsx:75
 msgid "Select Bluesky Social"
-msgstr ""
+msgstr "Seleccionar Bluesky Social"
 
 #: src/view/com/auth/login/Login.tsx:117
 msgid "Select from an existing account"
-msgstr ""
+msgstr "Selecciona de una cuenta existente"
 
 #: src/view/com/auth/login/LoginForm.tsx:143
 msgid "Select service"
-msgstr ""
+msgstr "Selecciona el servicio"
 
 #: src/view/screens/LanguageSettings.tsx:281
 msgid "Select which languages you want your subscribed feeds to include. If none are selected, all languages will be shown."
-msgstr ""
+msgstr "Selecciona qué idiomas quieres que incluyan tus canales de noticias suscritos. Si no seleccionas ninguno, se mostrarán todos los idiomas."
 
 #: src/view/screens/LanguageSettings.tsx:98
 msgid "Select your app language for the default text to display in the app"
-msgstr ""
+msgstr "Selecciona el idioma de tu app para el texto que se mostrará por defecto en la app"
 
 #: src/view/screens/LanguageSettings.tsx:190
 msgid "Select your preferred language for translations in your feed."
-msgstr ""
+msgstr "Selecciona el idioma que prefieras para las traducciones de tus noticias."
 
 #: src/view/com/modals/VerifyEmail.tsx:196
 msgid "Send Confirmation Email"
-msgstr ""
+msgstr "Enviar el mensaje de confirmación"
 
 #: src/view/com/modals/DeleteAccount.tsx:127
 msgid "Send email"
-msgstr ""
+msgstr "Enviar el mensaje"
 
 #: src/view/com/modals/DeleteAccount.tsx:138
 msgid "Send Email"
-msgstr ""
+msgstr "Enviar el mensaje"
 
 #: src/view/shell/Drawer.tsx:276
 #: src/view/shell/Drawer.tsx:297
 msgid "Send feedback"
-msgstr ""
+msgstr "Enviar comentarios"
 
 #: src/view/com/modals/report/SendReportButton.tsx:45
 msgid "Send Report"
-msgstr ""
+msgstr "Enviar el informe"
 
 #: src/view/com/auth/login/SetNewPasswordForm.tsx:78
 msgid "Set new password"
-msgstr ""
+msgstr "Establecer la contraseña nueva"
 
 #: src/view/screens/PreferencesHomeFeed.tsx:216
 msgid "Set this setting to \"No\" to hide all quote posts from your feed. Reposts will still be visible."
-msgstr ""
+msgstr "Establece este ajuste en \"No\" para ocultar todas las publicaciones de citas de tus noticias. Las repeticiones seguirán siendo visibles."
 
 #: src/view/screens/PreferencesHomeFeed.tsx:113
 msgid "Set this setting to \"No\" to hide all replies from your feed."
-msgstr ""
+msgstr "Establece este ajuste en \"No\" para ocultar todas las respuestas de tus noticias."
 
 #: src/view/screens/PreferencesHomeFeed.tsx:182
 msgid "Set this setting to \"No\" to hide all reposts from your feed."
-msgstr ""
+msgstr "Establece este ajuste en \"No\" para ocultar todas las veces que se han vuelto a publicar desde tus noticias."
 
 #: src/view/screens/PreferencesThreads.tsx:116
 msgid "Set this setting to \"Yes\" to show replies in a threaded view. This is an experimental feature."
-msgstr ""
+msgstr "Establece este ajuste en \"Sí\" para mostrar las respuestas en una vista de hilos. Se trata de una función experimental."
 
 #: src/view/screens/PreferencesHomeFeed.tsx:252
 msgid "Set this setting to \"Yes\" to show samples of your saved feeds in your following feed. This is an experimental feature."
-msgstr ""
+msgstr "Establece este ajuste en \"Sí\" para mostrar muestras de tus noticias guardadas en tu siguiente canal de noticias. Se trata de una función experimental."
 
 #: src/view/screens/Settings.tsx:277
 #: src/view/shell/desktop/LeftNav.tsx:431
 #: src/view/shell/Drawer.tsx:546
 #: src/view/shell/Drawer.tsx:547
 msgid "Settings"
-msgstr ""
+msgstr "Configuraciones"
 
 #: src/view/com/modals/SelfLabel.tsx:125
 msgid "Sexual activity or erotic nudity."
-msgstr ""
+msgstr "Actividad sexual o desnudez erótica."
 
 #: src/view/com/profile/ProfileHeader.tsx:338
 #: src/view/com/util/forms/PostDropdownBtn.tsx:131
 #: src/view/screens/ProfileList.tsx:384
 msgid "Share"
-msgstr ""
+msgstr "Compartir"
 
 #: src/view/screens/ProfileFeed.tsx:302
 msgid "Share feed"
-msgstr ""
+msgstr "Compartir las noticias"
 
 #: src/view/com/util/moderation/ContentHider.tsx:105
 #: src/view/screens/Settings.tsx:316
 msgid "Show"
-msgstr ""
+msgstr "Mostrar"
 
 #: src/view/com/util/moderation/ScreenHider.tsx:132
 msgid "Show anyway"
-msgstr ""
+msgstr "Mostrar de todas maneras"
 
 #: src/view/screens/PreferencesHomeFeed.tsx:249
 msgid "Show Posts from My Feeds"
-msgstr ""
+msgstr "Mostrar publicaciones de mis noticias"
 
 #: src/view/screens/PreferencesHomeFeed.tsx:213
 msgid "Show Quote Posts"
-msgstr ""
+msgstr "Mostrar publicaciones de citas"
 
 #: src/view/screens/PreferencesHomeFeed.tsx:110
 msgid "Show Replies"
-msgstr ""
+msgstr "Mostrar respuestas"
 
 #: src/view/screens/PreferencesThreads.tsx:94
 msgid "Show replies by people you follow before all other replies."
-msgstr ""
+msgstr "Mostrar las respuestas de las personas a quienes sigues antes que el resto de respuestas."
 
 #: src/view/screens/PreferencesHomeFeed.tsx:179
 msgid "Show Reposts"
-msgstr ""
+msgstr "Mostrar publicaciones que se han publicado nuevamente"
 
 #: src/view/com/notifications/FeedItem.tsx:337
 msgid "Show users"
-msgstr ""
+msgstr "Mostrar usuarios"
 
 #: src/view/com/auth/HomeLoggedOutCTA.tsx:70
 #: src/view/com/auth/login/Login.tsx:98
@@ -1920,31 +1939,31 @@ msgstr ""
 #: src/view/shell/NavSignupCard.tsx:58
 #: src/view/shell/NavSignupCard.tsx:59
 msgid "Sign in"
-msgstr ""
+msgstr "Iniciar sesión"
 
 #: src/view/com/auth/HomeLoggedOutCTA.tsx:78
 #: src/view/com/auth/SplashScreen.tsx:57
 #: src/view/com/auth/SplashScreen.web.tsx:87
 msgid "Sign In"
-msgstr ""
+msgstr "Iniciar sesión"
 
 #: src/view/com/auth/login/ChooseAccountForm.tsx:44
 msgid "Sign in as {0}"
-msgstr ""
+msgstr "Iniciar sesión como {0}"
 
 #: src/view/com/auth/login/ChooseAccountForm.tsx:118
 #: src/view/com/auth/login/Login.tsx:116
 msgid "Sign in as..."
-msgstr ""
+msgstr "Iniciar sesión como ..."
 
 #: src/view/com/auth/login/LoginForm.tsx:130
 msgid "Sign into"
-msgstr ""
+msgstr "Iniciar sesión en"
 
 #: src/view/com/modals/SwitchAccount.tsx:64
 #: src/view/com/modals/SwitchAccount.tsx:67
 msgid "Sign out"
-msgstr ""
+msgstr "Cerrar sesión"
 
 #: src/view/shell/bottom-bar/BottomBar.tsx:275
 #: src/view/shell/bottom-bar/BottomBar.tsx:276
@@ -1956,343 +1975,351 @@ msgstr ""
 #: src/view/shell/NavSignupCard.tsx:50
 #: src/view/shell/NavSignupCard.tsx:52
 msgid "Sign up"
-msgstr ""
+msgstr "Inscribirse"
 
 #: src/view/shell/NavSignupCard.tsx:42
 msgid "Sign up or sign in to join the conversation"
-msgstr ""
+msgstr "Regístrate o inicia sesión para unirte a la conversación"
 
 #: src/view/com/util/moderation/ScreenHider.tsx:76
 msgid "Sign-in Required"
-msgstr ""
+msgstr "Se requiere iniciar sesión"
 
 #: src/view/screens/Settings.tsx:327
 msgid "Signed in as"
-msgstr ""
+msgstr "Se inició sesión como"
 
 #: src/view/com/auth/onboarding/WelcomeMobile.tsx:33
 msgid "Skip"
-msgstr ""
+msgstr "Saltarse este paso"
 
 #: src/view/screens/PreferencesThreads.tsx:69
 msgid "Sort Replies"
-msgstr ""
+msgstr "Clasificar respuestas"
 
 #: src/view/screens/PreferencesThreads.tsx:72
 msgid "Sort replies to the same post by:"
-msgstr ""
+msgstr "Ordenar las respuestas a un mismo mensaje por:"
 
 #: src/view/com/modals/crop-image/CropImage.web.tsx:122
 msgid "Square"
-msgstr ""
+msgstr "Cuadrado"
 
 #: src/view/com/auth/create/Step1.tsx:90
 #: src/view/com/modals/ServerInput.tsx:62
 msgid "Staging"
-msgstr ""
+msgstr "Puesta en escena"
 
 #: src/view/screens/Settings.tsx:730
 msgid "Status page"
-msgstr ""
+msgstr "Página de estado"
 
 #: src/view/screens/Settings.tsx:666
 msgid "Storybook"
-msgstr ""
+msgstr "Libro de cuentos"
 
 #: src/view/com/modals/AppealLabel.tsx:101
 msgid "Submit"
-msgstr ""
+msgstr "Enviar"
 
 #: src/view/screens/ProfileList.tsx:574
 msgid "Subscribe"
-msgstr ""
+msgstr "Suscribirse"
 
 #: src/view/screens/ProfileList.tsx:570
 msgid "Subscribe to this list"
-msgstr ""
+msgstr "Suscribirse a esta lista"
 
 #: src/view/screens/Search/Search.tsx:357
 msgid "Suggested Follows"
-msgstr ""
+msgstr "Usuarios sugeridos a seguir"
 
 #: src/view/screens/Support.tsx:30
 #: src/view/screens/Support.tsx:33
 msgid "Support"
-msgstr ""
+msgstr "Soporte"
 
 #: src/view/com/modals/SwitchAccount.tsx:115
 msgid "Switch Account"
-msgstr ""
+msgstr "Cambiar a otra cuenta"
 
 #: src/view/screens/Settings.tsx:646
 msgid "System log"
-msgstr ""
+msgstr "Bitácora del sistema"
 
 #: src/view/com/modals/crop-image/CropImage.web.tsx:112
 msgid "Tall"
-msgstr ""
+msgstr "Alto"
 
 #: src/view/shell/desktop/RightNav.tsx:85
 msgid "Terms"
-msgstr ""
+msgstr "Condiciones"
 
 #: src/view/screens/TermsOfService.tsx:29
 msgid "Terms of Service"
-msgstr ""
+msgstr "Condiciones de servicio"
 
 #: src/view/com/modals/AppealLabel.tsx:70
 #: src/view/com/modals/report/InputIssueDetails.tsx:50
 msgid "Text input field"
-msgstr ""
+msgstr "Campo de introducción de texto"
 
 #: src/view/com/profile/ProfileHeader.tsx:306
 msgid "The account will be able to interact with you after unblocking."
-msgstr ""
+msgstr "La cuenta podrá interactuar contigo tras el desbloqueo."
 
 #: src/view/screens/CommunityGuidelines.tsx:36
 msgid "The Community Guidelines have been moved to <0/>"
-msgstr ""
+msgstr "Las Directrices Comunitarias se ha trasladado a <0/>"
 
 #: src/view/screens/CopyrightPolicy.tsx:33
 msgid "The Copyright Policy has been moved to <0/>"
-msgstr ""
+msgstr "La Política de derechos de autor se han trasladado a <0/>"
 
 #: src/view/com/post-thread/PostThread.tsx:440
 msgid "The post may have been deleted."
-msgstr ""
+msgstr "Es posible que se haya borrado la publicación."
 
 #: src/view/screens/PrivacyPolicy.tsx:33
 msgid "The Privacy Policy has been moved to <0/>"
-msgstr ""
+msgstr "La Política de privacidad se ha trasladado a <0/>"
 
 #: src/view/screens/Support.tsx:36
 msgid "The support form has been moved. If you need help, please<0/> or visit {HELP_DESK_URL} to get in touch with us."
-msgstr ""
+msgstr "Se ha movido el formulario de soporte. Si necesitas ayuda, por favor<0/> o visita {HELP_DESK_URL} para ponerte en contacto con nosotros."
 
 #: src/view/screens/TermsOfService.tsx:33
 msgid "The Terms of Service have been moved to"
-msgstr ""
+msgstr "Las condiciones de servicio se han trasladado a"
 
 #: src/view/com/util/ErrorBoundary.tsx:35
 msgid "There was an unexpected issue in the application. Please let us know if this happened to you!"
-msgstr ""
+msgstr "Se ha producido un problema inesperado en la aplicación. Por favor, ¡avísanos si te ha ocurrido esto!"
+
+#: src/view/com/util/moderation/LabelInfo.tsx:45
+#~ msgid "This {0} has been labeled."
+#~ msgstr "Este {0} ha sido etiquetado."
 
 #: src/view/com/util/moderation/ScreenHider.tsx:88
 msgid "This {screenDescription} has been flagged:"
-msgstr ""
+msgstr "Esta {screenDescription} ha sido marcada:"
 
 #: src/view/com/util/moderation/ScreenHider.tsx:83
 msgid "This account has requested that users sign in to view their profile."
-msgstr ""
+msgstr "Esta cuenta ha solicitado que los usuarios inicien sesión para ver su perfil."
 
 #: src/view/com/posts/FeedErrorMessage.tsx:107
 msgid "This content is not viewable without a Bluesky account."
-msgstr ""
+msgstr "Este contenido no se puede ver sin una cuenta Bluesky."
 
 #: src/view/com/posts/FeedErrorMessage.tsx:113
 msgid "This feed is currently receiving high traffic and is temporarily unavailable. Please try again later."
-msgstr ""
+msgstr "Este canal de noticias está recibiendo mucho tráfico y no está disponible temporalmente. Vuelve a intentarlo más tarde."
 
 #: src/view/com/modals/BirthDateSettings.tsx:61
 msgid "This information is not shared with other users."
-msgstr ""
+msgstr "Esta información no se comparte con otros usuarios."
 
 #: src/view/com/modals/VerifyEmail.tsx:113
 msgid "This is important in case you ever need to change your email or reset your password."
-msgstr ""
+msgstr "Esto es importante por si alguna vez necesitas cambiar tu correo electrónico o restablecer tu contraseña."
 
 #: src/view/com/auth/create/Step1.tsx:55
 msgid "This is the service that keeps you online."
-msgstr ""
+msgstr "Es el servicio que te mantiene en línea."
 
 #: src/view/com/modals/LinkWarning.tsx:56
 msgid "This link is taking you to the following website:"
-msgstr ""
+msgstr "Este enlace te lleva al siguiente sitio web:"
 
 #: src/view/com/post-thread/PostThreadItem.tsx:123
 msgid "This post has been deleted."
-msgstr ""
+msgstr "Esta publicación ha sido eliminada."
 
 #: src/view/com/modals/SelfLabel.tsx:137
 msgid "This warning is only available for posts with media attached."
-msgstr ""
+msgstr "Esta advertencia sólo está disponible para las publicaciones con medios adjuntos."
 
 #: src/view/screens/PreferencesThreads.tsx:53
 #: src/view/screens/Settings.tsx:503
 msgid "Thread Preferences"
-msgstr ""
+msgstr "Preferencias de hilos"
 
 #: src/view/screens/PreferencesThreads.tsx:113
 msgid "Threaded Mode"
-msgstr ""
+msgstr "Modo con hilos"
 
 #: src/view/com/util/forms/DropdownButton.tsx:230
 msgid "Toggle dropdown"
-msgstr ""
+msgstr "Conmutar el menú desplegable"
 
 #: src/view/com/modals/EditImage.tsx:271
 msgid "Transformations"
-msgstr ""
+msgstr "Transformaciones"
 
 #: src/view/com/post-thread/PostThreadItem.tsx:704
 #: src/view/com/post-thread/PostThreadItem.tsx:706
 #: src/view/com/util/forms/PostDropdownBtn.tsx:103
 msgid "Translate"
-msgstr ""
+msgstr "Traducir"
 
 #: src/view/com/util/error/ErrorScreen.tsx:73
 msgid "Try again"
-msgstr ""
+msgstr "Intentar nuevamente"
 
 #: src/view/screens/ProfileList.tsx:472
 msgid "Un-block list"
-msgstr ""
+msgstr "Desbloquear una lista"
 
 #: src/view/screens/ProfileList.tsx:457
 msgid "Un-mute list"
-msgstr ""
+msgstr "Desactivar la opción de silenciar la lista"
 
 #: src/view/com/auth/create/CreateAccount.tsx:64
 #: src/view/com/auth/login/Login.tsx:76
 #: src/view/com/auth/login/LoginForm.tsx:117
 msgid "Unable to contact your service. Please check your Internet connection."
-msgstr ""
+msgstr "No se puede contactar con tu servicio. Comprueba tu conexión a Internet."
 
 #: src/view/com/profile/ProfileHeader.tsx:466
 #: src/view/com/profile/ProfileHeader.tsx:469
 msgid "Unblock"
-msgstr ""
+msgstr "Desbloquear"
 
 #: src/view/com/profile/ProfileHeader.tsx:304
 #: src/view/com/profile/ProfileHeader.tsx:388
 msgid "Unblock Account"
-msgstr ""
+msgstr "Desbloquear una cuenta"
 
 #: src/view/com/util/post-ctrls/RepostButton.web.tsx:48
 msgid "Undo repost"
-msgstr ""
+msgstr "Deshacer esta publicación"
 
 #: src/view/com/auth/create/state.ts:210
 msgid "Unfortunately, you do not meet the requirements to create an account."
-msgstr ""
+msgstr "Lamentablemente, no cumples los requisitos para crear una cuenta."
 
 #: src/view/com/profile/ProfileHeader.tsx:369
 msgid "Unmute Account"
-msgstr ""
+msgstr "Desactivar la opción de silenciar la cuenta"
 
 #: src/view/com/util/forms/PostDropdownBtn.tsx:149
 msgid "Unmute thread"
-msgstr ""
+msgstr "Desactivar la opción de silenciar el hilo"
 
 #: src/view/screens/ProfileList.tsx:440
 msgid "Unpin moderation list"
-msgstr ""
+msgstr "Desanclar la lista de moderación"
 
 #: src/view/com/modals/UserAddRemoveLists.tsx:54
 msgid "Update {displayName} in Lists"
-msgstr ""
+msgstr "Actualizar {displayName} en Listas"
 
 #: src/lib/hooks/useOTAUpdate.ts:15
 msgid "Update Available"
-msgstr ""
+msgstr "Actualización disponible"
 
 #: src/view/com/auth/login/SetNewPasswordForm.tsx:172
 msgid "Updating..."
-msgstr ""
+msgstr "Actualizando..."
 
 #: src/view/com/modals/ChangeHandle.tsx:453
 msgid "Upload a text file to:"
-msgstr ""
+msgstr "Carga un archivo de texto en:"
 
 #: src/view/screens/AppPasswords.tsx:194
 msgid "Use app passwords to login to other Bluesky clients without giving full access to your account or password."
-msgstr ""
+msgstr "Utiliza las contraseñas de la app para iniciar sesión en otros clientes Bluesky sin dar acceso completo a tu cuenta o contraseña."
 
 #: src/view/com/modals/ChangeHandle.tsx:513
 msgid "Use default provider"
-msgstr ""
+msgstr "Utiliza un proveedor predeterminado"
 
 #: src/view/com/modals/AddAppPasswords.tsx:150
 msgid "Use this to sign into the other app along with your handle."
-msgstr ""
+msgstr "Utilízalo para iniciar sesión en la otra aplicación junto con tu identificador."
 
 #: src/view/com/modals/InviteCodes.tsx:197
 msgid "Used by:"
-msgstr ""
+msgstr "Usado por:"
 
 #: src/view/com/auth/create/Step3.tsx:38
 msgid "User handle"
-msgstr ""
+msgstr "Identificador del usuario"
 
 #: src/view/screens/Lists.tsx:58
 msgid "User Lists"
-msgstr ""
+msgstr "Listas de usuarios"
 
 #: src/view/com/auth/login/LoginForm.tsx:170
 #: src/view/com/auth/login/LoginForm.tsx:187
 msgid "Username or email address"
-msgstr ""
+msgstr "Nombre de usuario o dirección de correo electrónico"
 
 #: src/view/screens/ProfileList.tsx:738
 msgid "Users"
-msgstr ""
+msgstr "Usuarios"
 
 #: src/view/com/threadgate/WhoCanReply.tsx:143
 msgid "users followed by <0/>"
-msgstr ""
+msgstr "usuarios seguidos por <0/>"
 
 #: src/view/com/modals/Threadgate.tsx:106
 msgid "Users in \"{0}\""
-msgstr ""
+msgstr "Usuarios en «{0}»"
 
 #: src/view/screens/Settings.tsx:750
 msgid "Verify email"
-msgstr ""
+msgstr "Verificar el correo electrónico"
 
 #: src/view/screens/Settings.tsx:775
 msgid "Verify my email"
-msgstr ""
+msgstr "Verificar mi correo electrónico"
 
 #: src/view/screens/Settings.tsx:784
 msgid "Verify My Email"
-msgstr ""
+msgstr "Verificar mi correo electrónico"
 
 #: src/view/com/modals/ChangeEmail.tsx:205
 #: src/view/com/modals/ChangeEmail.tsx:207
 msgid "Verify New Email"
-msgstr ""
+msgstr "Verificar el correo electrónico nuevo"
 
 #: src/view/screens/Log.tsx:52
 msgid "View debug entry"
-msgstr ""
+msgstr "Ver entrada de depuración"
 
 #: src/view/com/profile/ProfileSubpageHeader.tsx:128
 msgid "View the avatar"
-msgstr ""
+msgstr "Ver el avatar"
 
 #: src/view/com/modals/LinkWarning.tsx:73
 msgid "Visit Site"
-msgstr ""
+msgstr "Visitar el sitio"
 
 #: src/view/com/auth/create/CreateAccount.tsx:121
 msgid "We're so excited to have you join us!"
-msgstr ""
+msgstr "¡Nos hace mucha ilusión que te unas a nosotros!"
 
 #: src/view/screens/Search/Search.tsx:238
 msgid "We're sorry, but your search could not be completed. Please try again in a few minutes."
-msgstr ""
+msgstr "Lo sentimos, pero no se ha podido completar tu búsqueda. Vuelve a intentarlo dentro de unos minutos."
 
 #: src/view/screens/NotFound.tsx:48
 msgid "We're sorry! We can't find the page you were looking for."
-msgstr ""
+msgstr "Lo sentimos. No encontramos la página que buscabas."
 
 #: src/view/com/auth/onboarding/WelcomeMobile.tsx:46
 msgid "Welcome to <0>Bluesky</0>"
-msgstr ""
+msgstr "Bienvenido a <0>Bluesky</0>"
 
 #: src/view/com/modals/report/Modal.tsx:169
 msgid "What is the issue with this {collectionName}?"
-msgstr ""
+msgstr "¿Cuál es el problema con esta {collectionName}?"
+
+#: src/view/com/auth/SplashScreen.tsx:34
+#~ msgid "What's next?"
+#~ msgstr "¿Qué sigue?"
 
 #: src/view/com/auth/SplashScreen.tsx:34
 msgid "What's up?"
@@ -2300,136 +2327,136 @@ msgstr ""
 
 #: src/view/com/modals/lang-settings/PostLanguagesSettings.tsx:78
 msgid "Which languages are used in this post?"
-msgstr ""
+msgstr "¿Qué idiomas se utilizan en esta publicación?"
 
 #: src/view/com/modals/lang-settings/ContentLanguagesSettings.tsx:77
 msgid "Which languages would you like to see in your algorithmic feeds?"
-msgstr ""
+msgstr "¿Qué idiomas te gustaría ver en tus noticias algorítmicas?"
 
 #: src/view/com/composer/threadgate/ThreadgateBtn.tsx:47
 #: src/view/com/modals/Threadgate.tsx:66
 msgid "Who can reply"
-msgstr ""
+msgstr "Quién puede responder"
 
 #: src/view/com/modals/crop-image/CropImage.web.tsx:102
 msgid "Wide"
-msgstr ""
+msgstr "Ancho"
 
 #: src/view/com/composer/Composer.tsx:409
 msgid "Write post"
-msgstr ""
+msgstr "Redactar una publicación"
 
 #: src/view/com/composer/Prompt.tsx:33
 msgid "Write your reply"
-msgstr ""
+msgstr "Redactar tu respuesta"
 
 #: src/view/screens/PreferencesHomeFeed.tsx:192
 #: src/view/screens/PreferencesHomeFeed.tsx:227
 #: src/view/screens/PreferencesHomeFeed.tsx:262
 msgid "Yes"
-msgstr ""
+msgstr "Sí"
 
 #: src/view/com/auth/create/Step1.tsx:106
 msgid "You can change hosting providers at any time."
-msgstr ""
+msgstr "Puedes cambiar de proveedor de alojamiento en cualquier momento."
 
 #: src/view/com/auth/login/Login.tsx:158
 #: src/view/com/auth/login/PasswordUpdatedForm.tsx:31
 msgid "You can now sign in with your new password."
-msgstr ""
+msgstr "Ahora puedes iniciar sesión con tu nueva contraseña."
 
 #: src/view/com/modals/InviteCodes.tsx:64
 msgid "You don't have any invite codes yet! We'll send you some when you've been on Bluesky for a little longer."
-msgstr ""
+msgstr "¡Aún no tienes códigos de invitación! Te enviaremos algunos cuando lleves un poco más de tiempo en Bluesky."
 
 #: src/view/screens/SavedFeeds.tsx:102
 msgid "You don't have any pinned feeds."
-msgstr ""
+msgstr "No tienes ninguna noticia anclada."
 
 #: src/view/screens/Feeds.tsx:383
 msgid "You don't have any saved feeds!"
-msgstr ""
+msgstr "¡No tienes ninguna noticia guardada!"
 
 #: src/view/screens/SavedFeeds.tsx:135
 msgid "You don't have any saved feeds."
-msgstr ""
+msgstr "No tienes ninguna noticia guardada."
 
 #: src/view/com/post-thread/PostThread.tsx:388
 msgid "You have blocked the author or you have been blocked by the author."
-msgstr ""
+msgstr "Has bloqueado al autor o has sido bloqueado por el autor."
 
 #: src/view/com/feeds/ProfileFeedgens.tsx:141
 msgid "You have no feeds."
-msgstr ""
+msgstr "No tienes noticias."
 
 #: src/view/com/lists/MyLists.tsx:89
 #: src/view/com/lists/ProfileLists.tsx:145
 msgid "You have no lists."
-msgstr ""
+msgstr "No tienes listas."
 
 #: src/view/screens/ModerationBlockedAccounts.tsx:131
 msgid "You have not blocked any accounts yet. To block an account, go to their profile and selected \"Block account\" from the menu on their account."
-msgstr ""
+msgstr "Aún no has bloqueado ninguna cuenta. Para bloquear una cuenta, ve a su perfil y selecciona \"Bloquear cuenta\" en el menú de su cuenta."
 
 #: src/view/screens/AppPasswords.tsx:86
 msgid "You have not created any app passwords yet. You can create one by pressing the button below."
-msgstr ""
+msgstr "Aún no has creado ninguna contraseña de aplicación. Puedes crear una pulsando el botón de abajo."
 
 #: src/view/screens/ModerationMutedAccounts.tsx:130
 msgid "You have not muted any accounts yet. To mute an account, go to their profile and selected \"Mute account\" from the menu on their account."
-msgstr ""
+msgstr "Aún no has silenciado ninguna cuenta. Para silenciar una cuenta, ve a su perfil y selecciona \"Silenciar cuenta\" en el menú de su cuenta."
 
 #: src/view/com/auth/login/SetNewPasswordForm.tsx:81
 msgid "You will receive an email with a \"reset code.\" Enter that code here, then enter your new password."
-msgstr ""
+msgstr "Recibirás un correo electrónico con un \"código de restablecimiento\". Introduce ese código aquí y, a continuación, introduce tu nueva contraseña."
 
 #: src/view/com/auth/create/Step2.tsx:43
 msgid "Your account"
-msgstr ""
+msgstr "Tu cuenta"
 
 #: src/view/com/auth/create/Step2.tsx:122
 msgid "Your birth date"
-msgstr ""
+msgstr "Tu fecha de nacimiento"
 
 #: src/view/com/auth/create/state.ts:102
 msgid "Your email appears to be invalid."
-msgstr ""
+msgstr "Tu correo electrónico parece no ser válido."
 
 #: src/view/com/modals/Waitlist.tsx:107
 msgid "Your email has been saved! We'll be in touch soon."
-msgstr ""
+msgstr "¡Hemos guardado tu correo electrónico! Pronto nos pondremos en contacto contigo."
 
 #: src/view/com/modals/ChangeEmail.tsx:125
 msgid "Your email has been updated but not verified. As a next step, please verify your new email."
-msgstr ""
+msgstr "Tu correo electrónico ha sido actualizado pero no verificado. Como siguiente paso, verifica tu nuevo correo electrónico."
 
 #: src/view/com/modals/VerifyEmail.tsx:108
 msgid "Your email has not yet been verified. This is an important security step which we recommend."
-msgstr ""
+msgstr "Tu correo electrónico aún no ha sido verificado. Este es un paso de seguridad importante que te recomendamos."
 
 #: src/view/com/auth/create/Step3.tsx:42
 #: src/view/com/modals/ChangeHandle.tsx:270
 msgid "Your full handle will be"
-msgstr ""
+msgstr "Tu identificador completo será"
 
 #: src/view/com/auth/create/Step1.tsx:53
 msgid "Your hosting provider"
-msgstr ""
+msgstr "Tu proveedor de alojamiento"
 
 #: src/view/screens/Settings.tsx:402
 #: src/view/shell/desktop/RightNav.tsx:129
 #: src/view/shell/Drawer.tsx:636
 msgid "Your invite codes are hidden when logged in using an App Password"
-msgstr ""
+msgstr "Tus códigos de invitación están ocultos cuando inicias sesión con una contraseña de la app"
 
 #: src/view/com/auth/onboarding/WelcomeMobile.tsx:59
 msgid "Your posts, likes, and blocks are public. Mutes are private."
-msgstr ""
+msgstr "Tus publicaciones, Me gustas y bloqueos son públicos. Las cuentas silenciadas son privadas."
 
 #: src/view/com/modals/SwitchAccount.tsx:82
 msgid "Your profile"
-msgstr ""
+msgstr "Tu perfil"
 
 #: src/view/com/auth/create/Step3.tsx:28
 msgid "Your user handle"
-msgstr ""
+msgstr "Tu identificador del usuario"

--- a/src/locale/locales/fr/messages.po
+++ b/src/locale/locales/fr/messages.po
@@ -1,0 +1,2462 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2023-12-20 21:42+0530\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: fr\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+#: src/view/shell/desktop/RightNav.tsx:160
+msgid "{0, plural, one {# invite code available} other {# invite codes available}}"
+msgstr "{0, plural, one {# invite code available} autre {# invite codes available}}"
+
+#: src/view/com/modals/Repost.tsx:44
+msgid "{0}"
+msgstr "{0}"
+
+#: src/view/com/modals/CreateOrEditList.tsx:176
+msgid "{0} {purposeLabel} List"
+msgstr "{0} {purposeLabel} Liste"
+
+#: src/view/shell/desktop/RightNav.tsx:143
+msgid "{invitesAvailable, plural, one {Invite codes: # available} other {Invite codes: # available}}"
+msgstr "{invitesAvailable, plural, one {Invite codes: # available} autre {Invite codes: # available}}"
+
+#: src/view/screens/Settings.tsx:407
+#: src/view/shell/Drawer.tsx:640
+msgid "{invitesAvailable} invite code available"
+msgstr "{invitesAvailable} code d’invitation disponible"
+
+#: src/view/screens/Settings.tsx:409
+#: src/view/shell/Drawer.tsx:642
+msgid "{invitesAvailable} invite codes available"
+msgstr "{invitesAvailable} codes d’invitation disponibles"
+
+#: src/view/screens/Search/Search.tsx:88
+msgid "{message}"
+msgstr "{message}"
+
+#: src/view/com/threadgate/WhoCanReply.tsx:158
+msgid "<0/> members"
+msgstr "<0/> membres"
+
+#: src/view/com/auth/onboarding/RecommendedFeeds.tsx:30
+msgid "<0>Choose your</0><1>Recommended</1><2>Feeds</2>"
+msgstr "<0>Choisissez vos</0><1>fils d’actualité</1><2>recommandés</2>"
+
+#: src/view/com/auth/onboarding/RecommendedFollows.tsx:37
+msgid "<0>Follow some</0><1>Recommended</1><2>Users</2>"
+msgstr "<0>Suivre certains</0><1>utilisateurs</1><2>recommandés</2>"
+
+#: src/view/com/util/moderation/LabelInfo.tsx:45
+msgid "A content warning has been applied to this {0}."
+msgstr ""
+
+#: src/lib/hooks/useOTAUpdate.ts:16
+msgid "A new version of the app is available. Please update to continue using the app."
+msgstr "Une nouvelle version de l’application est disponible. Veuillez faire la mise à jour pour continuer à utiliser l’application."
+
+#: src/view/com/modals/EditImage.tsx:299
+#: src/view/screens/Settings.tsx:417
+msgid "Accessibility"
+msgstr "Accessibilité"
+
+#: src/view/com/auth/login/LoginForm.tsx:159
+#: src/view/screens/Settings.tsx:286
+msgid "Account"
+msgstr "Compte"
+
+#: src/view/com/util/AccountDropdownBtn.tsx:41
+msgid "Account options"
+msgstr "Options de compte"
+
+#: src/view/com/modals/ListAddRemoveUsers.tsx:264
+#: src/view/com/modals/UserAddRemoveLists.tsx:193
+#: src/view/screens/ProfileList.tsx:754
+msgid "Add"
+msgstr "Ajouter"
+
+#: src/view/com/modals/SelfLabel.tsx:56
+msgid "Add a content warning"
+msgstr "Ajouter un avertissement sur le contenu"
+
+#: src/view/screens/ProfileList.tsx:744
+msgid "Add a user to this list"
+msgstr "Ajouter un utilisateur à cette liste"
+
+#: src/view/screens/Settings.tsx:355
+#: src/view/screens/Settings.tsx:364
+msgid "Add account"
+msgstr "Ajouter un compte"
+
+#: src/view/com/composer/photos/Gallery.tsx:119
+#: src/view/com/composer/photos/Gallery.tsx:180
+msgid "Add alt text"
+msgstr "Ajouter un texte alt"
+
+#: src/view/com/modals/report/InputIssueDetails.tsx:41
+#: src/view/com/modals/report/Modal.tsx:191
+msgid "Add details"
+msgstr "Ajouter des détails"
+
+#: src/view/com/modals/report/Modal.tsx:194
+msgid "Add details to report"
+msgstr "Ajouter des détails au rapport"
+
+#: src/view/com/composer/Composer.tsx:438
+msgid "Add link card"
+msgstr "Ajouter une carte link card"
+
+#: src/view/com/composer/Composer.tsx:441
+msgid "Add link card:"
+msgstr "Ajouter une carte link card :"
+
+#: src/view/com/modals/ChangeHandle.tsx:415
+msgid "Add the following DNS record to your domain:"
+msgstr "Ajoutez le registre DNS suivant à votre domaine :"
+
+#: src/view/com/profile/ProfileHeader.tsx:353
+msgid "Add to Lists"
+msgstr "Ajouter aux listes"
+
+#: src/view/screens/ProfileFeed.tsx:270
+msgid "Add to my feeds"
+msgstr "Ajouter à mes fils d’actu"
+
+#: src/view/com/modals/ListAddRemoveUsers.tsx:191
+#: src/view/com/modals/UserAddRemoveLists.tsx:128
+msgid "Added to list"
+msgstr "Ajouté à la liste"
+
+#: src/view/screens/PreferencesHomeFeed.tsx:164
+msgid "Adjust the number of likes a reply must have to be shown in your feed."
+msgstr "Définissez le nombre de likes qu’une réponse doit avoir pour être affichée dans votre fil d’actualité."
+
+#: src/view/com/modals/SelfLabel.tsx:75
+msgid "Adult Content"
+msgstr "Contenu pour adultes"
+
+#: src/view/screens/Settings.tsx:569
+msgid "Advanced"
+msgstr "Avancé"
+
+#: src/view/com/composer/photos/Gallery.tsx:130
+msgid "ALT"
+msgstr "ALT"
+
+#: src/view/com/modals/EditImage.tsx:315
+msgid "Alt text"
+msgstr "Texte Alt"
+
+#: src/view/com/composer/photos/Gallery.tsx:209
+msgid "Alt text describes images for blind and low-vision users, and helps give context to everyone."
+msgstr "Le texte Alt décrit les images pour les utilisateurs aveugles et malvoyants, et aide à donner un contexte à tout le monde."
+
+#: src/view/com/modals/VerifyEmail.tsx:118
+msgid "An email has been sent to {0}. It includes a confirmation code which you can enter below."
+msgstr "Un e-mail a été envoyé à {0}. Il comprend un code de confirmation que vous pouvez saisir ici."
+
+#: src/view/com/modals/ChangeEmail.tsx:119
+msgid "An email has been sent to your previous address, {0}. It includes a confirmation code which you can enter below."
+msgstr "Un courriel a été envoyé à votre ancienne adresse, {0}. Il comprend un code de confirmation que vous pouvez saisir ici."
+
+#: src/view/com/notifications/FeedItem.tsx:236
+#: src/view/com/threadgate/WhoCanReply.tsx:178
+msgid "and"
+msgstr "et"
+
+#: src/view/screens/LanguageSettings.tsx:95
+msgid "App Language"
+msgstr "Langue de l’application"
+
+#: src/view/screens/Settings.tsx:589
+msgid "App passwords"
+msgstr "Mots de passe des applications"
+
+#: src/view/screens/AppPasswords.tsx:186
+msgid "App Passwords"
+msgstr "Mots de passe des applications"
+
+#: src/view/com/util/forms/PostDropdownBtn.tsx:207
+msgid "Appeal content warning"
+msgstr ""
+
+#: src/view/com/modals/AppealLabel.tsx:65
+msgid "Appeal Content Warning"
+msgstr ""
+
+#: src/view/com/modals/AppealLabel.tsx:65
+#~ msgid "Appeal Decision"
+#~ msgstr "Appel de la décision"
+
+#: src/view/com/util/moderation/LabelInfo.tsx:52
+msgid "Appeal this decision"
+msgstr "Faire appel de cette décision"
+
+#: src/view/com/util/moderation/LabelInfo.tsx:56
+msgid "Appeal this decision."
+msgstr "Faire appel de cette décision."
+
+#: src/view/screens/Settings.tsx:432
+msgid "Appearance"
+msgstr "Affichage"
+
+#: src/view/screens/AppPasswords.tsx:223
+msgid "Are you sure you want to delete the app password \"{name}\"?"
+msgstr "Êtes-vous sûr de vouloir supprimer le mot de passe de l’application \"{name}\" ?"
+
+#: src/view/com/composer/Composer.tsx:142
+msgid "Are you sure you'd like to discard this draft?"
+msgstr "Êtes-vous sûr de vouloir rejeter ce brouillon ?"
+
+#: src/view/screens/ProfileList.tsx:352
+msgid "Are you sure?"
+msgstr "Vous confirmez ?"
+
+#: src/view/com/util/forms/PostDropdownBtn.tsx:190
+msgid "Are you sure? This cannot be undone."
+msgstr "Vous confirmez ? Cela ne pourra pas être annulé."
+
+#: src/view/com/modals/SelfLabel.tsx:123
+msgid "Artistic or non-erotic nudity."
+msgstr "Nudité artistique ou non érotique."
+
+#: src/view/com/auth/create/CreateAccount.tsx:141
+#: src/view/com/auth/login/ChooseAccountForm.tsx:151
+#: src/view/com/auth/login/ForgotPasswordForm.tsx:166
+#: src/view/com/auth/login/LoginForm.tsx:249
+#: src/view/com/auth/login/SetNewPasswordForm.tsx:148
+#: src/view/com/modals/report/InputIssueDetails.tsx:45
+#: src/view/com/post-thread/PostThread.tsx:395
+#: src/view/com/post-thread/PostThread.tsx:445
+#: src/view/com/post-thread/PostThread.tsx:453
+#: src/view/com/profile/ProfileHeader.tsx:672
+msgid "Back"
+msgstr "Arrière"
+
+#: src/view/screens/Settings.tsx:461
+msgid "Basics"
+msgstr "Principes de base"
+
+#: src/view/com/auth/create/Step2.tsx:131
+#: src/view/com/modals/BirthDateSettings.tsx:72
+msgid "Birthday"
+msgstr "Date de naissance"
+
+#: src/view/screens/Settings.tsx:312
+msgid "Birthday:"
+msgstr "Date de naissance :"
+
+#: src/view/com/profile/ProfileHeader.tsx:282
+#: src/view/com/profile/ProfileHeader.tsx:389
+msgid "Block Account"
+msgstr "Bloquer ce compte"
+
+#: src/view/screens/ProfileList.tsx:522
+msgid "Block accounts"
+msgstr "Bloquer ces comptes"
+
+#: src/view/screens/ProfileList.tsx:472
+msgid "Block list"
+msgstr "Liste de blocage"
+
+#: src/view/screens/ProfileList.tsx:307
+msgid "Block these accounts?"
+msgstr "Bloquer ces comptes ?"
+
+#: src/view/screens/Moderation.tsx:123
+msgid "Blocked accounts"
+msgstr "Comptes bloqués"
+
+#: src/view/screens/ModerationBlockedAccounts.tsx:106
+msgid "Blocked Accounts"
+msgstr "Comptes bloqués"
+
+#: src/view/com/profile/ProfileHeader.tsx:284
+msgid "Blocked accounts cannot reply in your threads, mention you, or otherwise interact with you."
+msgstr "Les comptes bloqués ne peuvent pas répondre à vos discussions, vous mentionner ou interagir avec vous."
+
+#: src/view/screens/ModerationBlockedAccounts.tsx:114
+msgid "Blocked accounts cannot reply in your threads, mention you, or otherwise interact with you. You will not see their content and they will be prevented from seeing yours."
+msgstr "Les comptes bloqués ne peuvent pas répondre à vos discussions, vous mentionner ou interagir avec vous. Vous ne verrez pas leur contenu et ils ne pourront pas voir le vôtre."
+
+#: src/view/com/post-thread/PostThread.tsx:251
+msgid "Blocked post."
+msgstr "Publication bloquée."
+
+#: src/view/screens/ProfileList.tsx:309
+msgid "Blocking is public. Blocked accounts cannot reply in your threads, mention you, or otherwise interact with you."
+msgstr "Le blocage est public. Les comptes bloqués ne peuvent pas répondre à vos discussions, vous mentionner ou interagir avec vous."
+
+#: src/view/com/auth/HomeLoggedOutCTA.tsx:93
+msgid "Blog"
+msgstr "Blog"
+
+#: src/view/com/auth/HomeLoggedOutCTA.tsx:31
+msgid "Bluesky"
+msgstr "Bluesky"
+
+#: src/view/com/auth/onboarding/WelcomeMobile.tsx:80
+msgid "Bluesky is flexible."
+msgstr "Bluesky est adaptable."
+
+#: src/view/com/auth/onboarding/WelcomeMobile.tsx:69
+msgid "Bluesky is open."
+msgstr "Bluesky est ouvert."
+
+#: src/view/com/auth/onboarding/WelcomeMobile.tsx:56
+msgid "Bluesky is public."
+msgstr "Bluesky est public."
+
+#: src/view/com/modals/Waitlist.tsx:70
+msgid "Bluesky uses invites to build a healthier community. If you don't know anybody with an invite, you can sign up for the waitlist and we'll send one soon."
+msgstr "Bluesky distribue des invitations pour construire une communauté plus saine. Si personne ne peut vous donner une invitation, vous pouvez vous inscrire sur notre liste d’attente et nous vous en enverrons une bientôt."
+
+#: src/view/screens/Moderation.tsx:225
+msgid "Bluesky will not show your profile and posts to logged-out users. Other apps may not honor this request. This does not make your account private."
+msgstr "Bluesky n’affichera pas votre profil et vos messages à des utilisateurs non connectés. Il est possible que d’autres applications n’honorent pas cette demande. Cela ne privatise pas votre compte."
+
+#: src/view/com/modals/ServerInput.tsx:78
+msgid "Bluesky.Social"
+msgstr "Bluesky.Social"
+
+#: src/view/screens/Settings.tsx:718
+msgid "Build version {0} {1}"
+msgstr "Version Build {0} {1}"
+
+#: src/view/com/auth/HomeLoggedOutCTA.tsx:87
+msgid "Business"
+msgstr "Affaires"
+
+#: src/view/com/composer/photos/OpenCameraBtn.tsx:60
+#: src/view/com/util/UserAvatar.tsx:221
+#: src/view/com/util/UserBanner.tsx:38
+msgid "Camera"
+msgstr "Caméra"
+
+#: src/view/com/modals/AddAppPasswords.tsx:214
+msgid "Can only contain letters, numbers, spaces, dashes, and underscores. Must be at least 4 characters long, but no more than 32 characters long."
+msgstr "Ne peut contenir que des lettres, des chiffres, des espaces, des tirets et des tirets bas. La longueur doit être d’au moins 4 caractères, mais pas plus de 32."
+
+#: src/view/com/composer/Composer.tsx:285
+#: src/view/com/composer/Composer.tsx:288
+#: src/view/com/modals/AltImage.tsx:127
+#: src/view/com/modals/ChangeEmail.tsx:218
+#: src/view/com/modals/ChangeEmail.tsx:220
+#: src/view/com/modals/Confirm.tsx:88
+#: src/view/com/modals/CreateOrEditList.tsx:267
+#: src/view/com/modals/CreateOrEditList.tsx:272
+#: src/view/com/modals/DeleteAccount.tsx:150
+#: src/view/com/modals/DeleteAccount.tsx:223
+#: src/view/com/modals/EditImage.tsx:323
+#: src/view/com/modals/EditProfile.tsx:248
+#: src/view/com/modals/LinkWarning.tsx:85
+#: src/view/com/modals/Repost.tsx:73
+#: src/view/com/modals/Waitlist.tsx:136
+#: src/view/screens/Search/Search.tsx:592
+#: src/view/shell/desktop/Search.tsx:182
+msgid "Cancel"
+msgstr "Annuler"
+
+#: src/view/com/modals/DeleteAccount.tsx:146
+#: src/view/com/modals/DeleteAccount.tsx:219
+msgid "Cancel account deletion"
+msgstr "Annuler suppression de compte"
+
+#: src/view/com/modals/AltImage.tsx:122
+msgid "Cancel add image alt text"
+msgstr "Annuler l’ajout d’un texte alt à l’image"
+
+#: src/view/com/modals/ChangeHandle.tsx:149
+msgid "Cancel change handle"
+msgstr "Annuler changement pseudo"
+
+#: src/view/com/modals/crop-image/CropImage.web.tsx:134
+msgid "Cancel image crop"
+msgstr "Annuler recadrage de l’image"
+
+#: src/view/com/modals/EditProfile.tsx:243
+msgid "Cancel profile editing"
+msgstr "Annuler modification du profil"
+
+#: src/view/com/modals/Repost.tsx:64
+msgid "Cancel quote post"
+msgstr "Annuler la citation"
+
+#: src/view/com/modals/ListAddRemoveUsers.tsx:87
+#: src/view/shell/desktop/Search.tsx:178
+msgid "Cancel search"
+msgstr "Annuler la recherche"
+
+#: src/view/com/modals/Waitlist.tsx:132
+msgid "Cancel waitlist signup"
+msgstr "Annuler l’inscription sur la liste d’attente"
+
+#: src/view/screens/Settings.tsx:306
+msgid "Change"
+msgstr "Changer"
+
+#: src/view/screens/Settings.tsx:601
+#: src/view/screens/Settings.tsx:610
+msgid "Change handle"
+msgstr "Changer pseudo"
+
+#: src/view/com/modals/ChangeHandle.tsx:161
+msgid "Change Handle"
+msgstr "Changer Pseudo"
+
+#: src/view/com/modals/VerifyEmail.tsx:141
+msgid "Change my email"
+msgstr "Modifier mon e-mail"
+
+#: src/view/com/modals/ChangeEmail.tsx:109
+msgid "Change Your Email"
+msgstr "Modifiez votre e-mail"
+
+#: src/view/com/auth/onboarding/RecommendedFeeds.tsx:121
+msgid "Check out some recommended feeds. Tap + to add them to your list of pinned feeds."
+msgstr "Consultez quelques fils d’actu recommandés. Appuyez sur + pour les ajouter à votre liste de fils d’actualité."
+
+#: src/view/com/auth/onboarding/RecommendedFollows.tsx:185
+msgid "Check out some recommended users. Follow them to see similar users."
+msgstr "Consultez quelques utilisateurs recommandés. Suivez-les pour voir des utilisateurs similaires."
+
+#: src/view/com/modals/DeleteAccount.tsx:163
+msgid "Check your inbox for an email with the confirmation code to enter below:"
+msgstr "Consultez votre boîte de réception, vous avez du recevoir un e-mail contenant un code de confirmation à saisir ci-dessous :"
+
+#: src/view/com/modals/ServerInput.tsx:38
+msgid "Choose Service"
+msgstr "Choisir un service"
+
+#: src/view/com/auth/onboarding/WelcomeMobile.tsx:83
+msgid "Choose the algorithms that power your experience with custom feeds."
+msgstr "Choisissez les algorithmes qui alimentent votre expérience avec des fils d’actualité personnalisés."
+
+#: src/view/com/auth/create/Step2.tsx:106
+msgid "Choose your password"
+msgstr "Choisissez votre mot de passe"
+
+#: src/view/screens/Settings.tsx:694
+msgid "Clear all legacy storage data"
+msgstr "Effacer toutes les données de stockage existantes"
+
+#: src/view/screens/Settings.tsx:696
+msgid "Clear all legacy storage data (restart after this)"
+msgstr "Effacer toutes les données de stockage existantes (redémarrer ensuite)"
+
+#: src/view/screens/Settings.tsx:706
+msgid "Clear all storage data"
+msgstr "Effacer toutes les données de stockage"
+
+#: src/view/screens/Settings.tsx:708
+msgid "Clear all storage data (restart after this)"
+msgstr "Effacer toutes les données de stockage (redémarrer ensuite)"
+
+#: src/view/com/util/forms/SearchInput.tsx:73
+#: src/view/screens/Search/Search.tsx:577
+msgid "Clear search query"
+msgstr "Effacer la recherche"
+
+#: src/view/com/auth/login/PasswordUpdatedForm.tsx:38
+msgid "Close alert"
+msgstr "Fermer l’alerte"
+
+#: src/view/com/util/BottomSheetCustomBackdrop.tsx:33
+msgid "Close bottom drawer"
+msgstr "Fermer le tiroir du bas"
+
+#: src/view/com/lightbox/ImageViewing/components/ImageDefaultHeader.tsx:26
+msgid "Close image"
+msgstr "Fermer l’image"
+
+#: src/view/com/lightbox/Lightbox.web.tsx:112
+msgid "Close image viewer"
+msgstr "Fermer la visionneuse d’images"
+
+#: src/view/shell/index.web.tsx:49
+msgid "Close navigation footer"
+msgstr "Fermer le pied de page de navigation"
+
+#: src/view/screens/CommunityGuidelines.tsx:32
+msgid "Community Guidelines"
+msgstr "Directives communautaires"
+
+#: src/view/com/composer/Prompt.tsx:24
+msgid "Compose reply"
+msgstr "Rédiger une réponse"
+
+#: src/view/com/modals/AppealLabel.tsx:98
+#: src/view/com/modals/Confirm.tsx:75
+#: src/view/com/modals/SelfLabel.tsx:154
+#: src/view/com/modals/VerifyEmail.tsx:225
+#: src/view/screens/PreferencesHomeFeed.tsx:299
+#: src/view/screens/PreferencesThreads.tsx:153
+msgid "Confirm"
+msgstr "Confirmer"
+
+#: src/view/com/modals/ChangeEmail.tsx:193
+#: src/view/com/modals/ChangeEmail.tsx:195
+msgid "Confirm Change"
+msgstr "Confirmer le changement"
+
+#: src/view/com/modals/lang-settings/ConfirmLanguagesButton.tsx:34
+msgid "Confirm content language settings"
+msgstr "Confirmer les paramètres de langue"
+
+#: src/view/com/modals/DeleteAccount.tsx:209
+msgid "Confirm delete account"
+msgstr "Confirmer la suppression du compte"
+
+#: src/view/com/modals/ChangeEmail.tsx:157
+#: src/view/com/modals/DeleteAccount.tsx:176
+#: src/view/com/modals/VerifyEmail.tsx:159
+msgid "Confirmation code"
+msgstr "Code de confirmation"
+
+#: src/view/com/auth/create/CreateAccount.tsx:174
+#: src/view/com/auth/login/LoginForm.tsx:268
+msgid "Connecting..."
+msgstr "Connexion..."
+
+#: src/view/screens/Moderation.tsx:81
+msgid "Content filtering"
+msgstr "Filtrage du contenu"
+
+#: src/view/com/modals/ContentFilteringSettings.tsx:44
+msgid "Content Filtering"
+msgstr "Filtrage du contenu"
+
+#: src/view/com/modals/lang-settings/ContentLanguagesSettings.tsx:74
+#: src/view/screens/LanguageSettings.tsx:278
+msgid "Content Languages"
+msgstr "Langues du contenu"
+
+#: src/view/com/util/moderation/ScreenHider.tsx:78
+msgid "Content Warning"
+msgstr "Avertissement sur le contenu"
+
+#: src/view/com/composer/labels/LabelsBtn.tsx:31
+msgid "Content warnings"
+msgstr "Avertissements sur le contenu"
+
+#: src/view/com/auth/onboarding/RecommendedFeeds.tsx:148
+#: src/view/com/auth/onboarding/RecommendedFollows.tsx:209
+msgid "Continue"
+msgstr "Continuer"
+
+#: src/view/com/modals/AddAppPasswords.tsx:193
+#: src/view/com/modals/InviteCodes.tsx:179
+msgid "Copied"
+msgstr "Copié"
+
+#: src/view/com/modals/AddAppPasswords.tsx:186
+msgid "Copy"
+msgstr "Copie"
+
+#: src/view/screens/ProfileList.tsx:384
+msgid "Copy link to list"
+msgstr "Copier le lien dans la liste"
+
+#: src/view/com/util/forms/PostDropdownBtn.tsx:131
+msgid "Copy link to post"
+msgstr "Copier le lien dans la publication"
+
+#: src/view/com/profile/ProfileHeader.tsx:338
+msgid "Copy link to profile"
+msgstr "Copier le lien sur le profil"
+
+#: src/view/com/util/forms/PostDropdownBtn.tsx:117
+msgid "Copy post text"
+msgstr "Copier le texte de la publication"
+
+#: src/view/screens/CopyrightPolicy.tsx:29
+msgid "Copyright Policy"
+msgstr "Politique sur les droits d’auteur"
+
+#: src/view/screens/ProfileFeed.tsx:94
+msgid "Could not load feed"
+msgstr "Impossible de charger le fil d’actu"
+
+#: src/view/screens/ProfileList.tsx:830
+msgid "Could not load list"
+msgstr "Impossible de charger la liste"
+
+#: src/view/com/auth/HomeLoggedOutCTA.tsx:62
+#: src/view/com/auth/SplashScreen.tsx:46
+msgid "Create a new account"
+msgstr "Créer un nouveau compte"
+
+#: src/view/com/auth/create/CreateAccount.tsx:120
+msgid "Create Account"
+msgstr "Créer un compte"
+
+#: src/view/com/auth/HomeLoggedOutCTA.tsx:54
+#: src/view/com/auth/SplashScreen.tsx:43
+msgid "Create new account"
+msgstr "Créer un nouveau compte"
+
+#: src/view/screens/AppPasswords.tsx:248
+msgid "Created {0}"
+msgstr "{0} créé"
+
+#: src/view/com/modals/ChangeHandle.tsx:387
+#: src/view/com/modals/ServerInput.tsx:102
+msgid "Custom domain"
+msgstr "Domaine personnalisé"
+
+#: src/view/screens/Settings.tsx:615
+msgid "Danger Zone"
+msgstr "Zone de danger"
+
+#: src/view/screens/Settings.tsx:622
+msgid "Delete account"
+msgstr "Supprimer compte"
+
+#: src/view/com/modals/DeleteAccount.tsx:83
+msgid "Delete Account"
+msgstr "Supprimer compte"
+
+#: src/view/screens/AppPasswords.tsx:221
+#: src/view/screens/AppPasswords.tsx:241
+msgid "Delete app password"
+msgstr "Supprimer le mot de passe de l’appli"
+
+#: src/view/screens/ProfileList.tsx:351
+#: src/view/screens/ProfileList.tsx:411
+msgid "Delete List"
+msgstr "Supprimer la liste"
+
+#: src/view/com/modals/DeleteAccount.tsx:212
+msgid "Delete my account"
+msgstr "Supprimer mon compte"
+
+#: src/view/screens/Settings.tsx:632
+msgid "Delete my account…"
+msgstr "Supprimer mon compte..."
+
+#: src/view/com/util/forms/PostDropdownBtn.tsx:185
+msgid "Delete post"
+msgstr "Supprimer publication"
+
+#: src/view/com/util/forms/PostDropdownBtn.tsx:189
+msgid "Delete this post?"
+msgstr "Supprimer cette publication ?"
+
+#: src/view/com/post-thread/PostThread.tsx:243
+msgid "Deleted post."
+msgstr "Publication supprimée."
+
+#: src/view/com/modals/CreateOrEditList.tsx:218
+#: src/view/com/modals/CreateOrEditList.tsx:234
+#: src/view/com/modals/EditProfile.tsx:197
+#: src/view/com/modals/EditProfile.tsx:209
+msgid "Description"
+msgstr "Description"
+
+#: src/view/com/auth/create/Step1.tsx:96
+msgid "Dev Server"
+msgstr "Serveur de dév"
+
+#: src/view/screens/Settings.tsx:637
+msgid "Developer Tools"
+msgstr "Outils du dév"
+
+#: src/view/com/composer/Composer.tsx:143
+msgid "Discard"
+msgstr "Ignorer"
+
+#: src/view/com/composer/Composer.tsx:137
+msgid "Discard draft"
+msgstr "Ignorer brouillon"
+
+#: src/view/screens/Moderation.tsx:207
+msgid "Discourage apps from showing my account to logged-out users"
+msgstr "Empêcher les appli de montrer mon compte aux utilisateurs déconnectés"
+
+#: src/view/screens/Feeds.tsx:405
+msgid "Discover new feeds"
+msgstr "Découvrir de nouveaux fils d’actu"
+
+#: src/view/com/modals/EditProfile.tsx:191
+msgid "Display name"
+msgstr "Afficher nom"
+
+#: src/view/com/modals/EditProfile.tsx:179
+msgid "Display Name"
+msgstr "Afficher nom"
+
+#: src/view/com/modals/ChangeHandle.tsx:485
+msgid "Domain verified!"
+msgstr "Domaine vérifié !"
+
+#: src/view/com/auth/onboarding/RecommendedFollows.tsx:86
+#: src/view/com/modals/ContentFilteringSettings.tsx:88
+#: src/view/com/modals/ContentFilteringSettings.tsx:96
+#: src/view/com/modals/crop-image/CropImage.web.tsx:152
+#: src/view/com/modals/EditImage.tsx:333
+#: src/view/com/modals/ListAddRemoveUsers.tsx:142
+#: src/view/com/modals/SelfLabel.tsx:157
+#: src/view/com/modals/Threadgate.tsx:129
+#: src/view/com/modals/Threadgate.tsx:132
+#: src/view/com/modals/UserAddRemoveLists.tsx:79
+#: src/view/screens/PreferencesHomeFeed.tsx:302
+#: src/view/screens/PreferencesThreads.tsx:156
+msgid "Done"
+msgstr "Terminé"
+
+#: src/view/com/modals/lang-settings/ConfirmLanguagesButton.tsx:42
+msgid "Done{extraText}"
+msgstr "Terminé{extraText}"
+
+#: src/view/com/modals/InviteCodes.tsx:94
+msgid "Each code works once. You'll receive more invite codes periodically."
+msgstr "Chaque code ne fonctionne qu’une seule fois. Vous recevrez régulièrement d’autres codes d’invitation."
+
+#: src/view/com/composer/photos/Gallery.tsx:144
+#: src/view/com/modals/EditImage.tsx:207
+msgid "Edit image"
+msgstr "Modifier l’image"
+
+#: src/view/screens/ProfileList.tsx:399
+msgid "Edit list details"
+msgstr "Modifier les infos de la liste"
+
+#: src/view/screens/Feeds.tsx:367
+#: src/view/screens/SavedFeeds.tsx:84
+msgid "Edit My Feeds"
+msgstr "Modifier mes fils d’actu"
+
+#: src/view/com/modals/EditProfile.tsx:151
+msgid "Edit my profile"
+msgstr "Modifier mon profil"
+
+#: src/view/com/profile/ProfileHeader.tsx:453
+msgid "Edit profile"
+msgstr "Modifier profil"
+
+#: src/view/com/profile/ProfileHeader.tsx:456
+msgid "Edit Profile"
+msgstr "Modifier profil"
+
+#: src/view/screens/Feeds.tsx:330
+msgid "Edit Saved Feeds"
+msgstr "Modifier les fils d’actu enregistrés"
+
+#: src/view/com/auth/create/Step2.tsx:90
+#: src/view/com/auth/login/ForgotPasswordForm.tsx:148
+#: src/view/com/modals/ChangeEmail.tsx:141
+#: src/view/com/modals/Waitlist.tsx:88
+msgid "Email"
+msgstr "E-mail"
+
+#: src/view/com/auth/create/Step2.tsx:81
+msgid "Email address"
+msgstr "Adresse e-mail"
+
+#: src/view/com/modals/ChangeEmail.tsx:111
+msgid "Email Updated"
+msgstr "E-mail mis à jour"
+
+#: src/view/screens/Settings.tsx:290
+msgid "Email:"
+msgstr "E-mail :"
+
+#: src/view/screens/PreferencesHomeFeed.tsx:138
+msgid "Enable this setting to only see replies between people you follow."
+msgstr "Activez ce paramètre pour ne voir que les réponses des personnes que vous suivez."
+
+#: src/view/screens/Profile.tsx:425
+msgid "End of feed"
+msgstr "Fin du fil d’actu"
+
+#: src/view/com/auth/create/Step1.tsx:71
+msgid "Enter the address of your provider:"
+msgstr "Saisissez l’adresse de votre fournisseur :"
+
+#: src/view/com/modals/ChangeHandle.tsx:369
+msgid "Enter the domain you want to use"
+msgstr "Entrez le domaine que vous voulez utiliser"
+
+#: src/view/com/auth/login/ForgotPasswordForm.tsx:101
+msgid "Enter the email you used to create your account. We'll send you a \"reset code\" so you can set a new password."
+msgstr "Saisissez l’e-mail que vous avez utilisé pour créer votre compte. Nous vous enverrons un « code de réinitialisation » afin changer votre mot de passe."
+
+#: src/view/com/auth/create/Step2.tsx:86
+msgid "Enter your email address"
+msgstr "Entrez votre e-mail"
+
+#: src/view/com/modals/ChangeEmail.tsx:117
+msgid "Enter your new email address below."
+msgstr "Entrez votre nouvelle e-mail ci-dessous."
+
+#: src/view/com/auth/login/Login.tsx:99
+msgid "Enter your username and password"
+msgstr "Entrez votre nom d’utilisateur et votre mot de passe"
+
+#: src/view/screens/Search/Search.tsx:106
+msgid "Error:"
+msgstr "Erreur :"
+
+#: src/view/com/modals/Threadgate.tsx:76
+msgid "Everybody"
+msgstr "Tout le monde"
+
+#: src/view/com/lightbox/Lightbox.web.tsx:156
+msgid "Expand alt text"
+msgstr "Développer le texte alt"
+
+#: src/view/com/auth/onboarding/RecommendedFeeds.tsx:109
+#: src/view/com/auth/onboarding/RecommendedFeeds.tsx:141
+msgid "Failed to load recommended feeds"
+msgstr "Échec du chargement des fils d’actu recommandés"
+
+#: src/view/screens/Feeds.tsx:559
+msgid "Feed offline"
+msgstr "Fil d’actu hors ligne"
+
+#: src/view/com/feeds/FeedPage.tsx:143
+msgid "Feed Preferences"
+msgstr "Préférences en matière de fil d’actu"
+
+#: src/view/shell/desktop/RightNav.tsx:65
+#: src/view/shell/Drawer.tsx:292
+msgid "Feedback"
+msgstr "Feedback"
+
+#: src/view/screens/Feeds.tsx:475
+#: src/view/screens/Profile.tsx:164
+#: src/view/shell/bottom-bar/BottomBar.tsx:181
+#: src/view/shell/desktop/LeftNav.tsx:339
+#: src/view/shell/Drawer.tsx:455
+#: src/view/shell/Drawer.tsx:456
+msgid "Feeds"
+msgstr "Fil d’actu"
+
+#: src/view/com/auth/onboarding/RecommendedFeeds.tsx:57
+msgid "Feeds are created by users to curate content. Choose some feeds that you find interesting."
+msgstr "Les fils d’actu sont créés par les utilisateurs pour rassembler du contenu. Choisissez des fils d’actu qui vous intéressent."
+
+#: src/view/screens/SavedFeeds.tsx:156
+msgid "Feeds are custom algorithms that users build with a little coding expertise. <0/> for more information."
+msgstr "Les fils d’actu sont des algorithmes personnalisés que les utilisateurs construisent avec un peu d’expertise en codage. <0/> pour obtenir de plus amples informations."
+
+#: src/view/screens/Search/Search.tsx:422
+msgid "Find users on Bluesky"
+msgstr "Trouver des utilisateurs sur Bluesky"
+
+#: src/view/screens/Search/Search.tsx:420
+msgid "Find users with the search tool on the right"
+msgstr "Trouvez des utilisateurs à l’aide de l’outil de recherche, à droite."
+
+#: src/view/com/auth/onboarding/RecommendedFollowsItem.tsx:150
+msgid "Finding similar accounts..."
+msgstr "Recherche de comptes similaires..."
+
+#: src/view/screens/PreferencesHomeFeed.tsx:102
+msgid "Fine-tune the content you see on your home screen."
+msgstr "Affinez le contenu de votre écran d’accueil."
+
+#: src/view/screens/PreferencesThreads.tsx:60
+msgid "Fine-tune the discussion threads."
+msgstr "Affiner les fils de discussion."
+
+#: src/view/com/profile/ProfileHeader.tsx:538
+msgid "Follow"
+msgstr "Suivre"
+
+#: src/view/com/auth/onboarding/RecommendedFollows.tsx:64
+msgid "Follow some users to get started. We can recommend you more users based on who you find interesting."
+msgstr "Suivez quelques utilisateurs pour commencer. Nous pouvons vous recommander d’autres utilisateurs en fonction des personnes qui vous intéressent."
+
+#: src/view/com/modals/Threadgate.tsx:98
+msgid "Followed users"
+msgstr "Utilisateurs suivis"
+
+#: src/view/screens/PreferencesHomeFeed.tsx:145
+msgid "Followed users only"
+msgstr "Utilisateurs suivis uniquement"
+
+#: src/view/screens/ProfileFollowers.tsx:25
+msgid "Followers"
+msgstr "Followers"
+
+#: src/view/com/profile/ProfileHeader.tsx:624
+msgid "following"
+msgstr "suivi"
+
+#: src/view/com/profile/ProfileHeader.tsx:522
+#: src/view/screens/ProfileFollows.tsx:25
+msgid "Following"
+msgstr "Suivi"
+
+#: src/view/com/profile/ProfileHeader.tsx:571
+msgid "Follows you"
+msgstr "Vous suit"
+
+#: src/view/com/modals/DeleteAccount.tsx:107
+msgid "For security reasons, we'll need to send a confirmation code to your email address."
+msgstr "Pour des raisons de sécurité, nous devrons envoyer un code de confirmation à votre e-mail."
+
+#: src/view/com/modals/AddAppPasswords.tsx:207
+msgid "For security reasons, you won't be able to view this again. If you lose this password, you'll need to generate a new one."
+msgstr "Pour des raisons de sécurité, vous ne pourrez plus afficher ceci. Si vous perdez ce mot de passe, vous devrez en générer un autre."
+
+#: src/view/com/auth/login/LoginForm.tsx:231
+msgid "Forgot"
+msgstr "Oublié"
+
+#: src/view/com/auth/login/LoginForm.tsx:228
+msgid "Forgot password"
+msgstr "Mot de passe oublié"
+
+#: src/view/com/auth/login/Login.tsx:127
+#: src/view/com/auth/login/Login.tsx:143
+msgid "Forgot Password"
+msgstr "Mot de passe oublié"
+
+#: src/view/com/composer/photos/SelectPhotoBtn.tsx:43
+msgid "Gallery"
+msgstr "Galerie"
+
+#: src/view/com/modals/VerifyEmail.tsx:183
+msgid "Get Started"
+msgstr "C’est parti"
+
+#: src/view/com/auth/LoggedOut.tsx:81
+#: src/view/com/auth/LoggedOut.tsx:82
+#: src/view/com/util/moderation/ScreenHider.tsx:123
+#: src/view/shell/desktop/LeftNav.tsx:103
+msgid "Go back"
+msgstr "Retour"
+
+#: src/view/screens/ProfileFeed.tsx:103
+#: src/view/screens/ProfileFeed.tsx:108
+#: src/view/screens/ProfileList.tsx:839
+#: src/view/screens/ProfileList.tsx:844
+msgid "Go Back"
+msgstr "Retour"
+
+#: src/view/com/auth/login/ForgotPasswordForm.tsx:181
+#: src/view/com/auth/login/LoginForm.tsx:278
+#: src/view/com/auth/login/SetNewPasswordForm.tsx:163
+msgid "Go to next"
+msgstr "Aller à la suite"
+
+#: src/view/com/modals/ChangeHandle.tsx:265
+msgid "Handle"
+msgstr "Pseudo"
+
+#: src/view/shell/desktop/RightNav.tsx:94
+#: src/view/shell/Drawer.tsx:302
+msgid "Help"
+msgstr "Aide"
+
+#: src/view/com/modals/AddAppPasswords.tsx:148
+msgid "Here is your app password."
+msgstr "Voici le mot de passe de votre appli."
+
+#: src/view/com/notifications/FeedItem.tsx:316
+#: src/view/com/util/moderation/ContentHider.tsx:103
+msgid "Hide"
+msgstr "Masquer"
+
+#: src/view/com/notifications/FeedItem.tsx:308
+msgid "Hide user list"
+msgstr "Masquer la liste des utilisateurs"
+
+#: src/view/com/posts/FeedErrorMessage.tsx:110
+msgid "Hmm, some kind of issue occurred when contacting the feed server. Please let the feed owner know about this issue."
+msgstr "Hmm, un problème s’est produit avec le serveur de fils d’actu. Veuillez informer le propriétaire du fil d’actu de ce problème."
+
+#: src/view/com/posts/FeedErrorMessage.tsx:98
+msgid "Hmm, the feed server appears to be misconfigured. Please let the feed owner know about this issue."
+msgstr "Hmm, le serveur du fils d’actu semble être mal configuré. Veuillez informer le propriétaire du fil d’actu de ce problème."
+
+#: src/view/com/posts/FeedErrorMessage.tsx:104
+msgid "Hmm, the feed server appears to be offline. Please let the feed owner know about this issue."
+msgstr "Mmm... le serveur de fils d’actu semble être hors ligne. Veuillez informer le propriétaire du fil d’actu de ce problème."
+
+#: src/view/com/posts/FeedErrorMessage.tsx:101
+msgid "Hmm, the feed server gave a bad response. Please let the feed owner know about this issue."
+msgstr "Mmm... le serveur de fils d’actu ne répond pas. Veuillez informer le propriétaire du fil d’actu de ce problème."
+
+#: src/view/com/posts/FeedErrorMessage.tsx:95
+msgid "Hmm, we're having trouble finding this feed. It may have been deleted."
+msgstr "Hmm, nous n’arrivons pas à trouver ce fils d’actu. Il a peut-être été supprimé."
+
+#: src/view/shell/bottom-bar/BottomBar.tsx:137
+#: src/view/shell/desktop/LeftNav.tsx:303
+#: src/view/shell/Drawer.tsx:379
+#: src/view/shell/Drawer.tsx:380
+msgid "Home"
+msgstr "Accueil"
+
+#: src/view/com/pager/FeedsTabBarMobile.tsx:96
+#: src/view/screens/PreferencesHomeFeed.tsx:95
+#: src/view/screens/Settings.tsx:481
+msgid "Home Feed Preferences"
+msgstr "Préférences de fils d’actu de l’accueil"
+
+#: src/view/com/auth/login/ForgotPasswordForm.tsx:114
+msgid "Hosting provider"
+msgstr "Fournisseur d’hébergement"
+
+#: src/view/com/auth/create/Step1.tsx:76
+#: src/view/com/auth/create/Step1.tsx:81
+msgid "Hosting provider address"
+msgstr "Adresse de l’hébergeur"
+
+#: src/view/com/modals/VerifyEmail.tsx:208
+msgid "I have a code"
+msgstr "J’ai un code"
+
+#: src/view/com/modals/ChangeHandle.tsx:281
+msgid "I have my own domain"
+msgstr "J’ai mon propre domaine"
+
+#: src/view/com/modals/SelfLabel.tsx:127
+msgid "If none are selected, suitable for all ages."
+msgstr "Si rien n’est sélectionné, il n’y a pas de restriction d’âge."
+
+#: src/view/com/modals/AltImage.tsx:96
+msgid "Image alt text"
+msgstr "Texte alt de l’image"
+
+#: src/view/com/util/UserAvatar.tsx:308
+#: src/view/com/util/UserBanner.tsx:116
+msgid "Image options"
+msgstr "Options d’images"
+
+#: src/view/com/auth/login/LoginForm.tsx:113
+msgid "Invalid username or password"
+msgstr "Nom d’utilisateur ou mot de passe incorrect"
+
+#: src/view/screens/Settings.tsx:383
+msgid "Invite"
+msgstr "Inviter"
+
+#: src/view/com/modals/InviteCodes.tsx:91
+#: src/view/screens/Settings.tsx:371
+msgid "Invite a Friend"
+msgstr "Inviter un ami"
+
+#: src/view/com/auth/create/Step2.tsx:57
+msgid "Invite code"
+msgstr "Code d’invitation"
+
+#: src/view/com/auth/create/state.ts:136
+msgid "Invite code not accepted. Check that you input it correctly and try again."
+msgstr "Code d’invitation refusé. Vérifiez que vous l’avez saisi correctement et réessayez."
+
+#: src/view/shell/Drawer.tsx:621
+msgid "Invite codes: {invitesAvailable} available"
+msgstr "Codes d’invitation : {invitesAvailable} disponible"
+
+#: src/view/com/auth/HomeLoggedOutCTA.tsx:99
+msgid "Jobs"
+msgstr "Emplois"
+
+#: src/view/com/modals/Waitlist.tsx:67
+msgid "Join the waitlist"
+msgstr "S’inscrire sur la liste d’attente"
+
+#: src/view/com/auth/create/Step2.tsx:68
+#: src/view/com/auth/create/Step2.tsx:72
+msgid "Join the waitlist."
+msgstr "S’inscrire sur la liste d’attente."
+
+#: src/view/com/modals/Waitlist.tsx:124
+msgid "Join Waitlist"
+msgstr "S’inscrire sur la liste d’attente"
+
+#: src/view/com/composer/select-language/SelectLangBtn.tsx:104
+msgid "Language selection"
+msgstr "Sélection de la langue"
+
+#: src/view/screens/LanguageSettings.tsx:89
+msgid "Language Settings"
+msgstr "Paramètres linguistiques"
+
+#: src/view/screens/Settings.tsx:541
+msgid "Languages"
+msgstr "Langues"
+
+#: src/view/com/util/moderation/ContentHider.tsx:101
+msgid "Learn more"
+msgstr "En savoir plus"
+
+#: src/view/com/util/moderation/PostAlerts.tsx:47
+#: src/view/com/util/moderation/ProfileHeaderAlerts.tsx:65
+#: src/view/com/util/moderation/ScreenHider.tsx:104
+msgid "Learn More"
+msgstr "En savoir plus"
+
+#: src/view/com/util/moderation/ContentHider.tsx:83
+#: src/view/com/util/moderation/PostAlerts.tsx:40
+#: src/view/com/util/moderation/PostHider.tsx:76
+#: src/view/com/util/moderation/ProfileHeaderAlerts.tsx:49
+#: src/view/com/util/moderation/ScreenHider.tsx:101
+msgid "Learn more about this warning"
+msgstr "En savoir plus sur cet avertissement"
+
+#: src/view/screens/Moderation.tsx:242
+msgid "Learn more about what is public on Bluesky."
+msgstr "En savoir plus sur ce qui est public sur Bluesky."
+
+#: src/view/com/modals/lang-settings/ContentLanguagesSettings.tsx:82
+msgid "Leave them all unchecked to see any language."
+msgstr "Si vous ne cochez rien, toutes les langues s’afficheront."
+
+#: src/view/com/modals/LinkWarning.tsx:49
+msgid "Leaving Bluesky"
+msgstr "Quitter Bluesky"
+
+#: src/view/com/auth/login/Login.tsx:128
+#: src/view/com/auth/login/Login.tsx:144
+msgid "Let's get your password reset!"
+msgstr "Réinitialisez votre mot de passe !"
+
+#: src/view/com/util/UserAvatar.tsx:245
+#: src/view/com/util/UserBanner.tsx:60
+msgid "Library"
+msgstr "Bibliothèque"
+
+#: src/view/screens/ProfileFeed.tsx:577
+msgid "Like this feed"
+msgstr "Likez ce fils d’actu"
+
+#: src/view/screens/PostLikedBy.tsx:27
+#: src/view/screens/ProfileFeedLikedBy.tsx:27
+msgid "Liked by"
+msgstr "Liké par"
+
+#: src/view/screens/Profile.tsx:163
+msgid "Likes"
+msgstr "Likes"
+
+#: src/view/com/modals/CreateOrEditList.tsx:186
+msgid "List Avatar"
+msgstr "Liste des avatars"
+
+#: src/view/com/modals/CreateOrEditList.tsx:199
+msgid "List Name"
+msgstr "Nom de liste"
+
+#: src/view/screens/Profile.tsx:165
+#: src/view/shell/desktop/LeftNav.tsx:376
+#: src/view/shell/Drawer.tsx:471
+#: src/view/shell/Drawer.tsx:472
+msgid "Lists"
+msgstr "Listes"
+
+#: src/view/com/post-thread/PostThread.tsx:260
+#: src/view/com/post-thread/PostThread.tsx:268
+msgid "Load more posts"
+msgstr "Charger plus d’articles"
+
+#: src/view/screens/Notifications.tsx:144
+msgid "Load new notifications"
+msgstr "Charger les nouvelles notifications"
+
+#: src/view/com/feeds/FeedPage.tsx:189
+msgid "Load new posts"
+msgstr "Charger les nouveaux messages"
+
+#: src/view/com/composer/text-input/mobile/Autocomplete.tsx:95
+msgid "Loading..."
+msgstr "Chargement..."
+
+#: src/view/com/modals/ServerInput.tsx:50
+msgid "Local dev server"
+msgstr "Serveur de dév local"
+
+#: src/view/screens/Moderation.tsx:136
+msgid "Logged-out visibility"
+msgstr "Visibilité déconnectée"
+
+#: src/view/com/auth/login/ChooseAccountForm.tsx:133
+msgid "Login to account that is not listed"
+msgstr "Se connecter à un compte qui n’est pas listé"
+
+#: src/view/screens/ProfileFeed.tsx:472
+#~ msgid "Looks like this feed is only available to users with a Bluesky account. Please sign up or sign in to view this feed!"
+#~ msgstr "On dirait que ce fils d’actu n’est disponible que pour les utilisateurs disposant d’un compte Bluesky. Veuillez vous inscrire ou vous connecter pour voir ce fils d’actu !"
+
+#: src/view/com/modals/LinkWarning.tsx:63
+msgid "Make sure this is where you intend to go!"
+msgstr "Assurez-vous que c’est bien là que vous avez l’intention d’aller !"
+
+#: src/view/screens/Profile.tsx:162
+msgid "Media"
+msgstr "Média"
+
+#: src/view/com/threadgate/WhoCanReply.tsx:139
+msgid "mentioned users"
+msgstr "utilisateurs mentionnés"
+
+#: src/view/com/modals/Threadgate.tsx:93
+msgid "Mentioned users"
+msgstr "Utilisateurs mentionnés"
+
+#: src/view/screens/Search/Search.tsx:537
+msgid "Menu"
+msgstr "Menu"
+
+#: src/view/com/posts/FeedErrorMessage.tsx:194
+msgid "Message from server"
+msgstr "Message du serveur"
+
+#: src/view/screens/Moderation.tsx:64
+#: src/view/screens/Settings.tsx:563
+#: src/view/shell/desktop/LeftNav.tsx:394
+#: src/view/shell/Drawer.tsx:490
+#: src/view/shell/Drawer.tsx:491
+msgid "Moderation"
+msgstr "Modération"
+
+#: src/view/screens/Moderation.tsx:95
+msgid "Moderation lists"
+msgstr "Listes de modération"
+
+#: src/view/screens/ModerationModlists.tsx:58
+msgid "Moderation Lists"
+msgstr "Listes de modération"
+
+#: src/view/shell/desktop/Feeds.tsx:53
+msgid "More feeds"
+msgstr "Plus de fils d’actu"
+
+#: src/view/com/profile/ProfileHeader.tsx:548
+#: src/view/screens/ProfileFeed.tsx:360
+#: src/view/screens/ProfileList.tsx:583
+msgid "More options"
+msgstr "Plus d’options"
+
+#: src/view/com/profile/ProfileHeader.tsx:370
+msgid "Mute Account"
+msgstr "Compte en sourdine"
+
+#: src/view/screens/ProfileList.tsx:510
+msgid "Mute accounts"
+msgstr "Comptes en sourdine"
+
+#: src/view/screens/ProfileList.tsx:457
+msgid "Mute list"
+msgstr "Mettre en sourdine"
+
+#: src/view/screens/ProfileList.tsx:270
+msgid "Mute these accounts?"
+msgstr "Mettre ces comptes en sourdine ?"
+
+#: src/view/com/util/forms/PostDropdownBtn.tsx:149
+msgid "Mute thread"
+msgstr "Mettre fil en sourdine"
+
+#: src/view/screens/Moderation.tsx:109
+msgid "Muted accounts"
+msgstr "Comptes en sourdine"
+
+#: src/view/screens/ModerationMutedAccounts.tsx:106
+msgid "Muted Accounts"
+msgstr "Comptes en sourdine"
+
+#: src/view/screens/ModerationMutedAccounts.tsx:114
+msgid "Muted accounts have their posts removed from your feed and from your notifications. Mutes are completely private."
+msgstr "Les comptes mis en sourdine voient leurs publications supprimées de votre fil d’actualité et de vos notifications. Cette option est totalement privée."
+
+#: src/view/screens/ProfileList.tsx:272
+msgid "Muting is private. Muted accounts can interact with you, but you will not see their posts or receive notifications from them."
+msgstr "Ce que vous mettez en sourdine reste privé. Les comptes en sourdine peuvent interagir avec vous, mais vous ne verrez pas leurs publications et ne recevrez pas de notifications de leur part."
+
+#: src/view/com/modals/BirthDateSettings.tsx:56
+msgid "My Birthday"
+msgstr "Ma date de naissance"
+
+#: src/view/screens/Feeds.tsx:363
+msgid "My Feeds"
+msgstr "Mes fils d’actu"
+
+#: src/view/shell/desktop/LeftNav.tsx:64
+msgid "My Profile"
+msgstr "Mon profil"
+
+#: src/view/screens/Settings.tsx:520
+msgid "My Saved Feeds"
+msgstr "Mes fils d’actu enregistrés"
+
+#: src/view/com/modals/AddAppPasswords.tsx:177
+#: src/view/com/modals/CreateOrEditList.tsx:211
+msgid "Name"
+msgstr "Nom"
+
+#: src/view/com/auth/onboarding/WelcomeMobile.tsx:72
+msgid "Never lose access to your followers and data."
+msgstr "Ne perdez jamais l’accès à vos followers et à vos données."
+
+#: src/view/screens/Lists.tsx:76
+#: src/view/screens/ModerationModlists.tsx:78
+msgid "New"
+msgstr "Nouveau"
+
+#: src/view/com/feeds/FeedPage.tsx:200
+#: src/view/screens/Feeds.tsx:510
+#: src/view/screens/Profile.tsx:353
+#: src/view/screens/ProfileFeed.tsx:430
+#: src/view/screens/ProfileList.tsx:193
+#: src/view/screens/ProfileList.tsx:221
+#: src/view/shell/desktop/LeftNav.tsx:246
+msgid "New post"
+msgstr "Nouvelle publication"
+
+#: src/view/shell/desktop/LeftNav.tsx:256
+msgid "New Post"
+msgstr "Nouvelle publication"
+
+#: src/view/com/auth/create/CreateAccount.tsx:154
+#: src/view/com/auth/login/ForgotPasswordForm.tsx:174
+#: src/view/com/auth/login/ForgotPasswordForm.tsx:184
+#: src/view/com/auth/login/LoginForm.tsx:281
+#: src/view/com/auth/login/SetNewPasswordForm.tsx:156
+#: src/view/com/auth/login/SetNewPasswordForm.tsx:166
+#: src/view/com/auth/onboarding/RecommendedFeeds.tsx:79
+msgid "Next"
+msgstr "Suivant"
+
+#: src/view/com/lightbox/Lightbox.web.tsx:142
+msgid "Next image"
+msgstr "Image suivante"
+
+#: src/view/screens/PreferencesHomeFeed.tsx:191
+#: src/view/screens/PreferencesHomeFeed.tsx:226
+#: src/view/screens/PreferencesHomeFeed.tsx:263
+msgid "No"
+msgstr "Non"
+
+#: src/view/screens/ProfileFeed.tsx:570
+#: src/view/screens/ProfileList.tsx:711
+msgid "No description"
+msgstr "Aucune description"
+
+#: src/view/com/composer/text-input/mobile/Autocomplete.tsx:97
+msgid "No result"
+msgstr "Aucun résultat"
+
+#: src/view/screens/Feeds.tsx:452
+msgid "No results found for \"{query}\""
+msgstr "Aucun résultat trouvé pour \"{query}\""
+
+#: src/view/com/modals/ListAddRemoveUsers.tsx:127
+#: src/view/screens/Search/Search.tsx:271
+#: src/view/screens/Search/Search.tsx:299
+#: src/view/screens/Search/Search.tsx:615
+#: src/view/shell/desktop/Search.tsx:210
+msgid "No results found for {query}"
+msgstr "Aucun résultat trouvé pour {query}"
+
+#: src/view/com/modals/Threadgate.tsx:82
+msgid "Nobody"
+msgstr "Personne"
+
+#: src/view/com/modals/SelfLabel.tsx:135
+msgid "Not Applicable."
+msgstr "Sans objet."
+
+#: src/view/screens/Moderation.tsx:232
+msgid "Note: Bluesky is an open and public network. This setting only limits the visibility of your content on the Bluesky app and website, and other apps may not respect this setting. Your content may still be shown to logged-out users by other apps and websites."
+msgstr "Remarque : Bluesky est un réseau ouvert et public. Ce paramètre limite uniquement la visibilité de votre contenu sur l’application et le site Web de Bluesky, et d’autres applications peuvent ne pas respecter ce paramètre. Votre contenu peut toujours être montré aux utilisateurs déconnectés par d’autres applications et sites Web."
+
+#: src/view/screens/Notifications.tsx:109
+#: src/view/screens/Notifications.tsx:133
+#: src/view/shell/bottom-bar/BottomBar.tsx:205
+#: src/view/shell/desktop/LeftNav.tsx:358
+#: src/view/shell/Drawer.tsx:416
+#: src/view/shell/Drawer.tsx:417
+msgid "Notifications"
+msgstr "Notifications"
+
+#: src/view/com/util/ErrorBoundary.tsx:34
+msgid "Oh no!"
+msgstr "Oh non !"
+
+#: src/view/com/auth/login/PasswordUpdatedForm.tsx:41
+msgid "Okay"
+msgstr "D’accord"
+
+#: src/view/com/composer/Composer.tsx:354
+msgid "One or more images is missing alt text."
+msgstr "Une ou plusieurs images n’ont pas de texte alt."
+
+#: src/view/com/threadgate/WhoCanReply.tsx:100
+msgid "Only {0} can reply."
+msgstr "Seul {0} peut répondre."
+
+#: src/view/com/pager/FeedsTabBarMobile.tsx:76
+msgid "Open navigation"
+msgstr "Navigation ouverte"
+
+#: src/view/screens/Settings.tsx:533
+msgid "Opens configurable language settings"
+msgstr "Ouvre les paramètres linguistiques configurables"
+
+#: src/view/shell/desktop/RightNav.tsx:148
+#: src/view/shell/Drawer.tsx:622
+msgid "Opens list of invite codes"
+msgstr "Ouvre la liste des codes d’invitation"
+
+#: src/view/com/modals/ChangeHandle.tsx:279
+msgid "Opens modal for using custom domain"
+msgstr "Ouvre une fenêtre modale pour utiliser un domaine personnalisé"
+
+#: src/view/screens/Settings.tsx:558
+msgid "Opens moderation settings"
+msgstr "Ouvre les paramètres de modération"
+
+#: src/view/screens/Settings.tsx:514
+msgid "Opens screen with all saved feeds"
+msgstr "Ouvre l’écran avec tous les fils d’actu enregistrés"
+
+#: src/view/screens/Settings.tsx:581
+msgid "Opens the app password settings page"
+msgstr "Ouvre la page de configuration du mot de passe"
+
+#: src/view/screens/Settings.tsx:473
+msgid "Opens the home feed preferences"
+msgstr "Ouvre les préférences du fil d’accueil"
+
+#: src/view/screens/Settings.tsx:664
+msgid "Opens the storybook page"
+msgstr "Ouvre la page de l’historique"
+
+#: src/view/screens/Settings.tsx:644
+msgid "Opens the system log page"
+msgstr "Ouvre la page du journal système"
+
+#: src/view/screens/Settings.tsx:494
+msgid "Opens the threads preferences"
+msgstr "Ouvre les préférences relatives aux fils de discussion"
+
+#: src/view/com/auth/login/ChooseAccountForm.tsx:138
+msgid "Other account"
+msgstr "Autre compte"
+
+#: src/view/com/modals/ServerInput.tsx:88
+msgid "Other service"
+msgstr "Autre service"
+
+#: src/view/com/composer/select-language/SelectLangBtn.tsx:91
+msgid "Other..."
+msgstr "Autre..."
+
+#: src/view/screens/NotFound.tsx:42
+#: src/view/screens/NotFound.tsx:45
+msgid "Page not found"
+msgstr "Page introuvable"
+
+#: src/view/com/auth/create/Step2.tsx:101
+#: src/view/com/auth/create/Step2.tsx:111
+#: src/view/com/auth/login/LoginForm.tsx:216
+#: src/view/com/auth/login/SetNewPasswordForm.tsx:130
+#: src/view/com/modals/DeleteAccount.tsx:191
+msgid "Password"
+msgstr "Mot de passe"
+
+#: src/view/com/auth/login/Login.tsx:157
+msgid "Password updated"
+msgstr "Mise à jour du mot de passe"
+
+#: src/view/com/auth/login/PasswordUpdatedForm.tsx:28
+msgid "Password updated!"
+msgstr "Mot de passe mis à jour !"
+
+#: src/view/com/modals/SelfLabel.tsx:121
+msgid "Pictures meant for adults."
+msgstr "Images destinées aux adultes."
+
+#: src/view/screens/SavedFeeds.tsx:88
+msgid "Pinned Feeds"
+msgstr "Fils épinglés"
+
+#: src/view/com/auth/create/state.ts:116
+msgid "Please choose your handle."
+msgstr "Veuillez choisir votre pseudo."
+
+#: src/view/com/auth/create/state.ts:109
+msgid "Please choose your password."
+msgstr "Veuillez choisir votre mot de passe."
+
+#: src/view/com/modals/ChangeEmail.tsx:67
+msgid "Please confirm your email before changing it. This is a temporary requirement while email-updating tools are added, and it will soon be removed."
+msgstr "Veuillez confirmer votre e-mail avant de le modifier. Ceci est temporairement requis pendant que des outils de mise à jour d’e-mail sont ajoutés, cette étape ne sera bientôt plus nécessaire."
+
+#: src/view/com/modals/AddAppPasswords.tsx:140
+msgid "Please enter a unique name for this App Password or use our randomly generated one."
+msgstr "Veuillez saisir un nom unique pour le mot de passe de l’application ou utiliser celui que nous avons généré de manière aléatoire."
+
+#: src/view/com/auth/create/state.ts:95
+msgid "Please enter your email."
+msgstr "Veuillez entrer votre e-mail."
+
+#: src/view/com/modals/DeleteAccount.tsx:180
+msgid "Please enter your password as well:"
+msgstr "Veuillez également entrer votre mot de passe :"
+
+#: src/view/com/modals/AppealLabel.tsx:72
+#: src/view/com/modals/AppealLabel.tsx:75
+msgid "Please tell us why you think this content warning was incorrectly applied!"
+msgstr ""
+
+#: src/view/com/modals/AppealLabel.tsx:72
+#: src/view/com/modals/AppealLabel.tsx:75
+#~ msgid "Please tell us why you think this decision was incorrect."
+#~ msgstr "Dites-nous pourquoi vous pensez que cette décision était incorrecte."
+
+#: src/view/com/composer/Composer.tsx:337
+#: src/view/com/post-thread/PostThread.tsx:226
+#: src/view/screens/PostThread.tsx:80
+msgid "Post"
+msgstr "Publication"
+
+#: src/view/com/post-thread/PostThread.tsx:385
+msgid "Post hidden"
+msgstr "Publications cachées"
+
+#: src/view/com/composer/select-language/SelectLangBtn.tsx:87
+msgid "Post language"
+msgstr "Langue de publication"
+
+#: src/view/com/modals/lang-settings/PostLanguagesSettings.tsx:75
+msgid "Post Languages"
+msgstr "Langues de publication"
+
+#: src/view/com/post-thread/PostThread.tsx:437
+msgid "Post not found"
+msgstr "Publication introuvable"
+
+#: src/view/screens/Profile.tsx:160
+msgid "Posts"
+msgstr "Publications"
+
+#: src/view/com/modals/LinkWarning.tsx:44
+msgid "Potentially Misleading Link"
+msgstr "Lien potentiellement trompeur"
+
+#: src/view/com/lightbox/Lightbox.web.tsx:128
+msgid "Previous image"
+msgstr "Image précédente"
+
+#: src/view/screens/LanguageSettings.tsx:187
+msgid "Primary Language"
+msgstr "Langue principale"
+
+#: src/view/screens/PreferencesThreads.tsx:91
+msgid "Prioritize Your Follows"
+msgstr "Définissez des priorités de vos suivis"
+
+#: src/view/shell/desktop/RightNav.tsx:76
+msgid "Privacy"
+msgstr "Vie privée"
+
+#: src/view/screens/PrivacyPolicy.tsx:29
+msgid "Privacy Policy"
+msgstr "Charte de confidentialité"
+
+#: src/view/com/auth/login/ForgotPasswordForm.tsx:190
+msgid "Processing..."
+msgstr "Traitement..."
+
+#: src/view/shell/bottom-bar/BottomBar.tsx:247
+#: src/view/shell/desktop/LeftNav.tsx:412
+#: src/view/shell/Drawer.tsx:69
+#: src/view/shell/Drawer.tsx:525
+#: src/view/shell/Drawer.tsx:526
+msgid "Profile"
+msgstr "Profil"
+
+#: src/view/screens/Settings.tsx:789
+msgid "Protect your account by verifying your email."
+msgstr "Protégez votre compte en vérifiant votre e-mail."
+
+#: src/view/screens/ModerationModlists.tsx:61
+msgid "Public, shareable lists of users to mute or block in bulk."
+msgstr "Listes publiques et partageables d’utilisateurs à mettre en sourdine ou à bloquer."
+
+#: src/view/screens/Lists.tsx:61
+msgid "Public, shareable lists which can drive feeds."
+msgstr "Les listes publiques et partageables qui peuvent alimenter les fils d’actu."
+
+#: src/view/com/modals/Repost.tsx:52
+#: src/view/com/util/post-ctrls/RepostButton.web.tsx:58
+msgid "Quote post"
+msgstr "Citer une publication"
+
+#: src/view/com/modals/Repost.tsx:56
+msgid "Quote Post"
+msgstr "Citer une publication"
+
+#: src/view/com/modals/EditImage.tsx:236
+msgid "Ratios"
+msgstr "Ratios"
+
+#: src/view/com/auth/onboarding/RecommendedFeeds.tsx:116
+msgid "Recommended Feeds"
+msgstr "Fils d’actu recommandés"
+
+#: src/view/com/auth/onboarding/RecommendedFollows.tsx:180
+msgid "Recommended Users"
+msgstr "Utilisateurs recommandés"
+
+#: src/view/com/modals/ListAddRemoveUsers.tsx:264
+#: src/view/com/modals/SelfLabel.tsx:83
+#: src/view/com/modals/UserAddRemoveLists.tsx:193
+#: src/view/com/util/UserAvatar.tsx:282
+#: src/view/com/util/UserBanner.tsx:89
+msgid "Remove"
+msgstr "Supprimer"
+
+#: src/view/com/feeds/FeedSourceCard.tsx:106
+msgid "Remove {0} from my feeds?"
+msgstr "Supprimer {0} de mes fils d’actu ?"
+
+#: src/view/com/util/AccountDropdownBtn.tsx:22
+msgid "Remove account"
+msgstr "Supprimer compte"
+
+#: src/view/com/posts/FeedErrorMessage.tsx:130
+msgid "Remove feed"
+msgstr "Supprimer fil d’actu"
+
+#: src/view/com/feeds/FeedSourceCard.tsx:105
+#: src/view/com/feeds/FeedSourceCard.tsx:172
+#: src/view/screens/ProfileFeed.tsx:270
+msgid "Remove from my feeds"
+msgstr "Supprimer de mes fils d’actu"
+
+#: src/view/com/composer/photos/Gallery.tsx:167
+msgid "Remove image"
+msgstr "Supprimer image"
+
+#: src/view/com/composer/ExternalEmbed.tsx:70
+msgid "Remove image preview"
+msgstr "Supprimer aperçu d’image"
+
+#: src/view/com/feeds/FeedSourceCard.tsx:173
+msgid "Remove this feed from my feeds?"
+msgstr "Supprimer ce fils d’actu ?"
+
+#: src/view/com/posts/FeedErrorMessage.tsx:131
+msgid "Remove this feed from your saved feeds?"
+msgstr "Supprimer ce fils d’actu de vos fils d’actu enregistrés ?"
+
+#: src/view/com/modals/ListAddRemoveUsers.tsx:199
+#: src/view/com/modals/UserAddRemoveLists.tsx:136
+msgid "Removed from list"
+msgstr "Supprimé de la liste"
+
+#: src/view/screens/Profile.tsx:161
+msgid "Replies"
+msgstr "Réponses"
+
+#: src/view/com/threadgate/WhoCanReply.tsx:98
+msgid "Replies to this thread are disabled"
+msgstr "Les réponses à ce fil de discussion sont désactivées"
+
+#: src/view/screens/PreferencesHomeFeed.tsx:135
+msgid "Reply Filters"
+msgstr "Filtres de réponse"
+
+#: src/view/com/modals/report/Modal.tsx:166
+msgid "Report {collectionName}"
+msgstr "Signaler {collectionName}"
+
+#: src/view/com/profile/ProfileHeader.tsx:404
+msgid "Report Account"
+msgstr "Signaler Compte"
+
+#: src/view/screens/ProfileFeed.tsx:290
+msgid "Report feed"
+msgstr "Signaler fil d’actu"
+
+#: src/view/screens/ProfileList.tsx:425
+msgid "Report List"
+msgstr "Signaler Liste"
+
+#: src/view/com/modals/report/SendReportButton.tsx:37
+#: src/view/com/util/forms/PostDropdownBtn.tsx:167
+msgid "Report post"
+msgstr "Signaler publication"
+
+#: src/view/com/util/post-ctrls/RepostButton.web.tsx:48
+msgid "Repost"
+msgstr "Republier"
+
+#: src/view/com/util/post-ctrls/RepostButton.web.tsx:94
+#: src/view/com/util/post-ctrls/RepostButton.web.tsx:105
+msgid "Repost or quote post"
+msgstr "Republier ou citer"
+
+#: src/view/screens/PostRepostedBy.tsx:27
+msgid "Reposted by"
+msgstr "Republié par"
+
+#: src/view/com/modals/ChangeEmail.tsx:181
+#: src/view/com/modals/ChangeEmail.tsx:183
+msgid "Request Change"
+msgstr "Demande de modification"
+
+#: src/view/com/auth/create/Step2.tsx:53
+msgid "Required for this provider"
+msgstr "Obligatoire pour ce fournisseur"
+
+#: src/view/com/auth/login/SetNewPasswordForm.tsx:108
+msgid "Reset code"
+msgstr "Réinitialiser code"
+
+#: src/view/screens/Settings.tsx:686
+msgid "Reset onboarding state"
+msgstr "Réinitialisation de l’état d’accueil"
+
+#: src/view/com/auth/login/ForgotPasswordForm.tsx:98
+msgid "Reset password"
+msgstr "Réinitialiser mot de passe"
+
+#: src/view/screens/Settings.tsx:676
+msgid "Reset preferences state"
+msgstr "Réinitialiser l’état des préférences"
+
+#: src/view/screens/Settings.tsx:684
+msgid "Resets the onboarding state"
+msgstr "Réinitialise l’état d’accueil"
+
+#: src/view/screens/Settings.tsx:674
+msgid "Resets the preferences state"
+msgstr "Réinitialise l’état des préférences"
+
+#: src/view/com/auth/create/CreateAccount.tsx:163
+#: src/view/com/auth/create/CreateAccount.tsx:167
+#: src/view/com/auth/login/LoginForm.tsx:258
+#: src/view/com/auth/login/LoginForm.tsx:261
+#: src/view/com/util/error/ErrorMessage.tsx:55
+#: src/view/com/util/error/ErrorScreen.tsx:65
+msgid "Retry"
+msgstr "Réessayer"
+
+#: src/view/com/modals/AltImage.tsx:114
+#: src/view/com/modals/BirthDateSettings.tsx:93
+#: src/view/com/modals/BirthDateSettings.tsx:96
+#: src/view/com/modals/ChangeHandle.tsx:173
+#: src/view/com/modals/CreateOrEditList.tsx:249
+#: src/view/com/modals/CreateOrEditList.tsx:257
+#: src/view/com/modals/EditProfile.tsx:223
+msgid "Save"
+msgstr "Enregistrer"
+
+#: src/view/com/modals/AltImage.tsx:105
+msgid "Save alt text"
+msgstr "Enregistrer texte alt"
+
+#: src/view/com/modals/EditProfile.tsx:231
+msgid "Save Changes"
+msgstr "Enregistrer modifications"
+
+#: src/view/com/modals/ChangeHandle.tsx:170
+msgid "Save handle change"
+msgstr "Enregistrer le changement de pseudo"
+
+#: src/view/com/modals/crop-image/CropImage.web.tsx:144
+msgid "Save image crop"
+msgstr "Enregistrer le recadrage de l’image"
+
+#: src/view/screens/SavedFeeds.tsx:122
+msgid "Saved Feeds"
+msgstr "Fils d’actu enregistrés"
+
+#: src/view/com/modals/ListAddRemoveUsers.tsx:75
+#: src/view/com/util/forms/SearchInput.tsx:64
+#: src/view/screens/Search/Search.tsx:401
+#: src/view/screens/Search/Search.tsx:567
+#: src/view/shell/bottom-bar/BottomBar.tsx:159
+#: src/view/shell/desktop/LeftNav.tsx:321
+#: src/view/shell/desktop/Search.tsx:161
+#: src/view/shell/desktop/Search.tsx:170
+#: src/view/shell/Drawer.tsx:343
+#: src/view/shell/Drawer.tsx:344
+msgid "Search"
+msgstr "Recherche"
+
+#: src/view/com/auth/LoggedOut.tsx:104
+#: src/view/com/auth/LoggedOut.tsx:105
+msgid "Search for users"
+msgstr ""
+
+#: src/view/com/modals/ChangeEmail.tsx:110
+msgid "Security Step Required"
+msgstr "Étape de sécurité requise"
+
+#: src/view/com/auth/HomeLoggedOutCTA.tsx:39
+msgid "See what's next"
+msgstr "Voir la suite"
+
+#: src/view/com/modals/ServerInput.tsx:75
+msgid "Select Bluesky Social"
+msgstr "Sélectionner Bluesky Social"
+
+#: src/view/com/auth/login/Login.tsx:117
+msgid "Select from an existing account"
+msgstr "Sélectionner un compte existant"
+
+#: src/view/com/auth/login/LoginForm.tsx:143
+msgid "Select service"
+msgstr "Sélectionner un service"
+
+#: src/view/screens/LanguageSettings.tsx:281
+msgid "Select which languages you want your subscribed feeds to include. If none are selected, all languages will be shown."
+msgstr "Sélectionnez les langues que vous souhaitez voir figurer dans les fils d’actu auxquels vous êtes abonné. Si aucune langue n’est sélectionnée, toutes les langues seront affichées."
+
+#: src/view/screens/LanguageSettings.tsx:98
+msgid "Select your app language for the default text to display in the app"
+msgstr "Sélectionnez la langue de votre application à afficher par défaut"
+
+#: src/view/screens/LanguageSettings.tsx:190
+msgid "Select your preferred language for translations in your feed."
+msgstr "Sélectionnez votre langue préférée pour traduire votre fils d’actu."
+
+#: src/view/com/modals/VerifyEmail.tsx:196
+msgid "Send Confirmation Email"
+msgstr "Envoyer un e-mail de confirmation"
+
+#: src/view/com/modals/DeleteAccount.tsx:127
+msgid "Send email"
+msgstr "Envoyer e-mail"
+
+#: src/view/com/modals/DeleteAccount.tsx:138
+msgid "Send Email"
+msgstr "Envoyer e-mail"
+
+#: src/view/shell/Drawer.tsx:276
+#: src/view/shell/Drawer.tsx:297
+msgid "Send feedback"
+msgstr "Envoyer commentaire"
+
+#: src/view/com/modals/report/SendReportButton.tsx:45
+msgid "Send Report"
+msgstr "Envoyer rapport"
+
+#: src/view/com/auth/login/SetNewPasswordForm.tsx:78
+msgid "Set new password"
+msgstr "Définir un nouveau mot de passe"
+
+#: src/view/screens/PreferencesHomeFeed.tsx:216
+msgid "Set this setting to \"No\" to hide all quote posts from your feed. Reposts will still be visible."
+msgstr "Choisissez « Non » pour masquer toutes les citations sur votre fils d’actu. Les republications seront toujours visibles."
+
+#: src/view/screens/PreferencesHomeFeed.tsx:113
+msgid "Set this setting to \"No\" to hide all replies from your feed."
+msgstr "Choisissez « Non » pour masquer toutes les réponses dans votre fils d’actu."
+
+#: src/view/screens/PreferencesHomeFeed.tsx:182
+msgid "Set this setting to \"No\" to hide all reposts from your feed."
+msgstr "Choisissez « Non » pour masquer toutes les republications de votre fils d’actu."
+
+#: src/view/screens/PreferencesThreads.tsx:116
+msgid "Set this setting to \"Yes\" to show replies in a threaded view. This is an experimental feature."
+msgstr "Choisissez « Oui » pour afficher les réponses dans un fil de discussion. C’est une fonctionnalité expérimentale."
+
+#: src/view/screens/PreferencesHomeFeed.tsx:252
+msgid "Set this setting to \"Yes\" to show samples of your saved feeds in your following feed. This is an experimental feature."
+msgstr "Choisissez « Oui » pour afficher des échantillons de vos fils d’actu enregistrés dans votre fils d’actu suivant. C’est une fonctionnalité expérimentale."
+
+#: src/view/screens/Settings.tsx:277
+#: src/view/shell/desktop/LeftNav.tsx:430
+#: src/view/shell/Drawer.tsx:546
+#: src/view/shell/Drawer.tsx:547
+msgid "Settings"
+msgstr "Paramètres"
+
+#: src/view/com/modals/SelfLabel.tsx:125
+msgid "Sexual activity or erotic nudity."
+msgstr "Activité sexuelle ou nudité érotique."
+
+#: src/view/com/profile/ProfileHeader.tsx:338
+#: src/view/com/util/forms/PostDropdownBtn.tsx:131
+#: src/view/screens/ProfileList.tsx:384
+msgid "Share"
+msgstr "Partager"
+
+#: src/view/screens/ProfileFeed.tsx:302
+msgid "Share feed"
+msgstr "Partager fils d’actu"
+
+#: src/view/com/util/moderation/ContentHider.tsx:105
+#: src/view/screens/Settings.tsx:316
+msgid "Show"
+msgstr "Afficher"
+
+#: src/view/com/util/moderation/ScreenHider.tsx:132
+msgid "Show anyway"
+msgstr "Afficher quand même"
+
+#: src/view/screens/PreferencesHomeFeed.tsx:249
+msgid "Show Posts from My Feeds"
+msgstr "Afficher les Publications de Mes fils d’actu"
+
+#: src/view/screens/PreferencesHomeFeed.tsx:213
+msgid "Show Quote Posts"
+msgstr "Afficher les Publications de citation"
+
+#: src/view/screens/PreferencesHomeFeed.tsx:110
+msgid "Show Replies"
+msgstr "Afficher réponses"
+
+#: src/view/screens/PreferencesThreads.tsx:94
+msgid "Show replies by people you follow before all other replies."
+msgstr "Afficher les réponses des personnes que vous suivez avant toutes les autres réponses."
+
+#: src/view/screens/PreferencesHomeFeed.tsx:179
+msgid "Show Reposts"
+msgstr "Afficher les republications"
+
+#: src/view/com/notifications/FeedItem.tsx:337
+msgid "Show users"
+msgstr "Afficher les utilisateurs"
+
+#: src/view/com/auth/HomeLoggedOutCTA.tsx:70
+#: src/view/com/auth/login/Login.tsx:98
+#: src/view/com/auth/SplashScreen.tsx:54
+#: src/view/shell/bottom-bar/BottomBar.tsx:285
+#: src/view/shell/bottom-bar/BottomBar.tsx:286
+#: src/view/shell/bottom-bar/BottomBar.tsx:288
+#: src/view/shell/bottom-bar/BottomBarWeb.tsx:177
+#: src/view/shell/bottom-bar/BottomBarWeb.tsx:178
+#: src/view/shell/bottom-bar/BottomBarWeb.tsx:180
+#: src/view/shell/NavSignupCard.tsx:58
+#: src/view/shell/NavSignupCard.tsx:59
+msgid "Sign in"
+msgstr "Connexion"
+
+#: src/view/com/auth/HomeLoggedOutCTA.tsx:78
+#: src/view/com/auth/SplashScreen.tsx:57
+#: src/view/com/auth/SplashScreen.web.tsx:87
+msgid "Sign In"
+msgstr "Connexion"
+
+#: src/view/com/auth/login/ChooseAccountForm.tsx:44
+msgid "Sign in as {0}"
+msgstr "Se connecter en tant que {0}"
+
+#: src/view/com/auth/login/ChooseAccountForm.tsx:118
+#: src/view/com/auth/login/Login.tsx:116
+msgid "Sign in as..."
+msgstr "Se connecter en tant que..."
+
+#: src/view/com/auth/login/LoginForm.tsx:130
+msgid "Sign into"
+msgstr "Se connecter à"
+
+#: src/view/com/modals/SwitchAccount.tsx:64
+#: src/view/com/modals/SwitchAccount.tsx:67
+msgid "Sign out"
+msgstr "Déconnexion"
+
+#: src/view/shell/bottom-bar/BottomBar.tsx:275
+#: src/view/shell/bottom-bar/BottomBar.tsx:276
+#: src/view/shell/bottom-bar/BottomBar.tsx:278
+#: src/view/shell/bottom-bar/BottomBarWeb.tsx:167
+#: src/view/shell/bottom-bar/BottomBarWeb.tsx:168
+#: src/view/shell/bottom-bar/BottomBarWeb.tsx:170
+#: src/view/shell/NavSignupCard.tsx:49
+#: src/view/shell/NavSignupCard.tsx:50
+#: src/view/shell/NavSignupCard.tsx:52
+msgid "Sign up"
+msgstr "S’inscrire"
+
+#: src/view/shell/NavSignupCard.tsx:42
+msgid "Sign up or sign in to join the conversation"
+msgstr "S’inscrire ou se connecter pour participer à la conversation"
+
+#: src/view/com/util/moderation/ScreenHider.tsx:76
+msgid "Sign-in Required"
+msgstr "Connexion requise"
+
+#: src/view/screens/Settings.tsx:327
+msgid "Signed in as"
+msgstr "Connecté en tant que"
+
+#: src/view/com/auth/onboarding/WelcomeMobile.tsx:33
+msgid "Skip"
+msgstr "Ignorer"
+
+#: src/view/screens/PreferencesThreads.tsx:69
+msgid "Sort Replies"
+msgstr "Trier réponses"
+
+#: src/view/screens/PreferencesThreads.tsx:72
+msgid "Sort replies to the same post by:"
+msgstr "Trier les réponses à la même publication par :"
+
+#: src/view/com/modals/crop-image/CropImage.web.tsx:122
+msgid "Square"
+msgstr "Carré"
+
+#: src/view/com/auth/create/Step1.tsx:90
+#: src/view/com/modals/ServerInput.tsx:62
+msgid "Staging"
+msgstr "Mise en scène"
+
+#: src/view/screens/Settings.tsx:730
+msgid "Status page"
+msgstr "Page de statut"
+
+#: src/view/screens/Settings.tsx:666
+msgid "Storybook"
+msgstr "Historique"
+
+#: src/view/com/modals/AppealLabel.tsx:101
+msgid "Submit"
+msgstr "Envoyer"
+
+#: src/view/screens/ProfileList.tsx:574
+msgid "Subscribe"
+msgstr "S’abonner"
+
+#: src/view/screens/ProfileList.tsx:570
+msgid "Subscribe to this list"
+msgstr "S’abonner à cette liste"
+
+#: src/view/screens/Search/Search.tsx:357
+msgid "Suggested Follows"
+msgstr "Suivis suggérés"
+
+#: src/view/screens/Support.tsx:30
+#: src/view/screens/Support.tsx:33
+msgid "Support"
+msgstr "Soutien"
+
+#: src/view/com/modals/SwitchAccount.tsx:115
+msgid "Switch Account"
+msgstr "Changer de compte"
+
+#: src/view/screens/Settings.tsx:646
+msgid "System log"
+msgstr "Journal système"
+
+#: src/view/com/modals/crop-image/CropImage.web.tsx:112
+msgid "Tall"
+msgstr "Grand"
+
+#: src/view/shell/desktop/RightNav.tsx:85
+msgid "Terms"
+msgstr "Conditions générales"
+
+#: src/view/screens/TermsOfService.tsx:29
+msgid "Terms of Service"
+msgstr "Conditions d’utilisation"
+
+#: src/view/com/modals/AppealLabel.tsx:70
+#: src/view/com/modals/report/InputIssueDetails.tsx:50
+msgid "Text input field"
+msgstr "Champ de saisie de texte"
+
+#: src/view/com/profile/ProfileHeader.tsx:306
+msgid "The account will be able to interact with you after unblocking."
+msgstr "Ce compte pourra interagir avec vous après le déblocage."
+
+#: src/view/screens/CommunityGuidelines.tsx:36
+msgid "The Community Guidelines have been moved to <0/>"
+msgstr "Les lignes directrices communautaires ont été déplacées vers <0/>"
+
+#: src/view/screens/CopyrightPolicy.tsx:33
+msgid "The Copyright Policy has been moved to <0/>"
+msgstr "Notre politique de droits d’auteur a été déplacée vers <0/>"
+
+#: src/view/com/post-thread/PostThread.tsx:440
+msgid "The post may have been deleted."
+msgstr "Cette publication a peut-être été supprimée."
+
+#: src/view/screens/PrivacyPolicy.tsx:33
+msgid "The Privacy Policy has been moved to <0/>"
+msgstr "Notre politique de confidentialité a été déplacée vers <0/>"
+
+#: src/view/screens/Support.tsx:36
+msgid "The support form has been moved. If you need help, please<0/> or visit {HELP_DESK_URL} to get in touch with us."
+msgstr "Le formulaire d’assistance a été déplacé. Si vous avez besoin d’aide, veuillez <0/> ou rendez-vous {HELP_DESK_URL} pour nous contacter."
+
+#: src/view/screens/TermsOfService.tsx:33
+msgid "The Terms of Service have been moved to"
+msgstr "Nos conditions d’utilisation ont été déplacées vers"
+
+#: src/view/com/util/ErrorBoundary.tsx:35
+msgid "There was an unexpected issue in the application. Please let us know if this happened to you!"
+msgstr "Un problème inattendu s’est produit dans l’application. N’hésitez pas à nous faire savoir si cela vous est arrivé !"
+
+#: src/view/com/util/moderation/LabelInfo.tsx:45
+#~ msgid "This {0} has been labeled."
+#~ msgstr "Ce {0} a été classé."
+
+#: src/view/com/util/moderation/ScreenHider.tsx:88
+msgid "This {screenDescription} has been flagged:"
+msgstr "Ce {screenDescription} a été signalé :"
+
+#: src/view/com/util/moderation/ScreenHider.tsx:83
+msgid "This account has requested that users sign in to view their profile."
+msgstr "Ce compte a demandé aux utilisateurs de s’identifier pour voir son profil."
+
+#: src/view/com/posts/FeedErrorMessage.tsx:107
+msgid "This content is not viewable without a Bluesky account."
+msgstr "Ce contenu n’est pas visible sans un compte Bluesky."
+
+#: src/view/com/posts/FeedErrorMessage.tsx:113
+msgid "This feed is currently receiving high traffic and is temporarily unavailable. Please try again later."
+msgstr "Ce fil d’actu reçoit actuellement un trafic important, il est temporairement indisponible. Veuillez réessayer plus tard."
+
+#: src/view/com/modals/BirthDateSettings.tsx:61
+msgid "This information is not shared with other users."
+msgstr "Ces informations ne sont pas partagées avec d’autres utilisateurs."
+
+#: src/view/com/modals/VerifyEmail.tsx:113
+msgid "This is important in case you ever need to change your email or reset your password."
+msgstr "Ceci est important au cas où vous auriez besoin de changer d’e-mail ou de réinitialiser votre mot de passe."
+
+#: src/view/com/auth/create/Step1.tsx:55
+msgid "This is the service that keeps you online."
+msgstr "C’est le service qui vous permet de rester en ligne."
+
+#: src/view/com/modals/LinkWarning.tsx:56
+msgid "This link is taking you to the following website:"
+msgstr "Ce lien vous conduit au site Web suivant :"
+
+#: src/view/com/post-thread/PostThreadItem.tsx:123
+msgid "This post has been deleted."
+msgstr "Cette publication a été supprimée."
+
+#: src/view/com/modals/SelfLabel.tsx:137
+msgid "This warning is only available for posts with media attached."
+msgstr "Cet avertissement n’est disponible que pour les messages contenant des médias."
+
+#: src/view/screens/PreferencesThreads.tsx:53
+#: src/view/screens/Settings.tsx:503
+msgid "Thread Preferences"
+msgstr "Préférences des fils de discussion"
+
+#: src/view/screens/PreferencesThreads.tsx:113
+msgid "Threaded Mode"
+msgstr "Mode arborescent"
+
+#: src/view/com/util/forms/DropdownButton.tsx:230
+msgid "Toggle dropdown"
+msgstr "Basculer menu déroulant"
+
+#: src/view/com/modals/EditImage.tsx:271
+msgid "Transformations"
+msgstr "Transformations"
+
+#: src/view/com/post-thread/PostThreadItem.tsx:704
+#: src/view/com/post-thread/PostThreadItem.tsx:706
+#: src/view/com/util/forms/PostDropdownBtn.tsx:103
+msgid "Translate"
+msgstr "Traduire"
+
+#: src/view/com/util/error/ErrorScreen.tsx:73
+msgid "Try again"
+msgstr "Réessayer"
+
+#: src/view/screens/ProfileList.tsx:472
+msgid "Un-block list"
+msgstr "Débloquer liste"
+
+#: src/view/screens/ProfileList.tsx:457
+msgid "Un-mute list"
+msgstr "Désactiver sourdine sur cette liste"
+
+#: src/view/com/auth/create/CreateAccount.tsx:64
+#: src/view/com/auth/login/Login.tsx:76
+#: src/view/com/auth/login/LoginForm.tsx:117
+msgid "Unable to contact your service. Please check your Internet connection."
+msgstr "Impossible de contacter votre service. Veuillez vérifier votre connexion Internet."
+
+#: src/view/com/profile/ProfileHeader.tsx:466
+#: src/view/com/profile/ProfileHeader.tsx:469
+msgid "Unblock"
+msgstr "Débloquer"
+
+#: src/view/com/profile/ProfileHeader.tsx:304
+#: src/view/com/profile/ProfileHeader.tsx:388
+msgid "Unblock Account"
+msgstr "Débloquer compte"
+
+#: src/view/com/util/post-ctrls/RepostButton.web.tsx:48
+msgid "Undo repost"
+msgstr "Annuler transfert"
+
+#: src/view/com/auth/create/state.ts:210
+msgid "Unfortunately, you do not meet the requirements to create an account."
+msgstr "Malheureusement, vous ne remplissez pas les conditions requises pour créer un compte."
+
+#: src/view/com/profile/ProfileHeader.tsx:369
+msgid "Unmute Account"
+msgstr "Désactiver sourdine sur ce compte"
+
+#: src/view/com/util/forms/PostDropdownBtn.tsx:149
+msgid "Unmute thread"
+msgstr "Désactiver sourdine sur ce fil de discussion"
+
+#: src/view/screens/ProfileList.tsx:440
+msgid "Unpin moderation list"
+msgstr "Supprimer la liste de modération"
+
+#: src/view/com/modals/UserAddRemoveLists.tsx:54
+msgid "Update {displayName} in Lists"
+msgstr "Mise à jour de {displayName} dans les listes"
+
+#: src/lib/hooks/useOTAUpdate.ts:15
+msgid "Update Available"
+msgstr "Mise à jour disponible"
+
+#: src/view/com/auth/login/SetNewPasswordForm.tsx:172
+msgid "Updating..."
+msgstr "Mise à jour..."
+
+#: src/view/com/modals/ChangeHandle.tsx:453
+msgid "Upload a text file to:"
+msgstr "Télécharger un fichier texte vers :"
+
+#: src/view/screens/AppPasswords.tsx:194
+msgid "Use app passwords to login to other Bluesky clients without giving full access to your account or password."
+msgstr "Utiliser les mots de passe de l’application pour se connecter à d’autres clients Bluesky sans donner un accès complet à votre compte ou à votre mot de passe."
+
+#: src/view/com/modals/ChangeHandle.tsx:513
+msgid "Use default provider"
+msgstr "Utiliser le fournisseur par défaut"
+
+#: src/view/com/modals/AddAppPasswords.tsx:150
+msgid "Use this to sign into the other app along with your handle."
+msgstr "Utilisez-le pour vous connecter à l’autre application avec votre identifiant."
+
+#: src/view/com/modals/InviteCodes.tsx:197
+msgid "Used by:"
+msgstr "Utilisé par :"
+
+#: src/view/com/auth/create/Step3.tsx:38
+msgid "User handle"
+msgstr "Pseudo utilisateur"
+
+#: src/view/screens/Lists.tsx:58
+msgid "User Lists"
+msgstr "Listes d’utilisateurs"
+
+#: src/view/com/auth/login/LoginForm.tsx:170
+#: src/view/com/auth/login/LoginForm.tsx:187
+msgid "Username or email address"
+msgstr "Nom d’utilisateur ou e-mail"
+
+#: src/view/screens/ProfileList.tsx:738
+msgid "Users"
+msgstr "Utilisateurs"
+
+#: src/view/com/threadgate/WhoCanReply.tsx:143
+msgid "users followed by <0/>"
+msgstr "utilisateurs suivis par <0/>"
+
+#: src/view/com/modals/Threadgate.tsx:106
+msgid "Users in \"{0}\""
+msgstr "Utilisateurs dans \"{0}\""
+
+#: src/view/screens/Settings.tsx:750
+msgid "Verify email"
+msgstr "Confirmer e-mail"
+
+#: src/view/screens/Settings.tsx:775
+msgid "Verify my email"
+msgstr "Confirmer mon e-mail"
+
+#: src/view/screens/Settings.tsx:784
+msgid "Verify My Email"
+msgstr "Confirmer mon e-mail"
+
+#: src/view/com/modals/ChangeEmail.tsx:205
+#: src/view/com/modals/ChangeEmail.tsx:207
+msgid "Verify New Email"
+msgstr "Confirmer nouvel e-mail"
+
+#: src/view/screens/Log.tsx:52
+msgid "View debug entry"
+msgstr "Afficher l’entrée de débogage"
+
+#: src/view/com/profile/ProfileSubpageHeader.tsx:128
+msgid "View the avatar"
+msgstr "Afficher avatar"
+
+#: src/view/com/modals/LinkWarning.tsx:73
+msgid "Visit Site"
+msgstr "Visiter le site"
+
+#: src/view/com/auth/create/CreateAccount.tsx:121
+msgid "We're so excited to have you join us!"
+msgstr "Nous sommes ravis de vous accueillir !"
+
+#: src/view/screens/Search/Search.tsx:238
+msgid "We're sorry, but your search could not be completed. Please try again in a few minutes."
+msgstr "Nous sommes désolés, mais votre recherche a été annulée. Veuillez réessayer dans quelques minutes."
+
+#: src/view/screens/NotFound.tsx:48
+msgid "We're sorry! We can't find the page you were looking for."
+msgstr "Nous sommes désolés ! La page que vous recherchez est introuvable."
+
+#: src/view/com/auth/onboarding/WelcomeMobile.tsx:46
+msgid "Welcome to <0>Bluesky</0>"
+msgstr "Bienvenue sur <0>Bluesky</0>"
+
+#: src/view/com/modals/report/Modal.tsx:169
+msgid "What is the issue with this {collectionName}?"
+msgstr "Quel est le problème avec cette {collectionName} ?"
+
+#: src/view/com/auth/SplashScreen.tsx:34
+#~ msgid "What's next?"
+#~ msgstr "Et après ?"
+
+#: src/view/com/auth/SplashScreen.tsx:34
+msgid "What's up?"
+msgstr ""
+
+#: src/view/com/modals/lang-settings/PostLanguagesSettings.tsx:78
+msgid "Which languages are used in this post?"
+msgstr "Quelles sont les langues utilisées dans cette publication ?"
+
+#: src/view/com/modals/lang-settings/ContentLanguagesSettings.tsx:77
+msgid "Which languages would you like to see in your algorithmic feeds?"
+msgstr "Quelles langues aimeriez-vous voir apparaître dans vos flux algorithmiques ?"
+
+#: src/view/com/composer/threadgate/ThreadgateBtn.tsx:47
+#: src/view/com/modals/Threadgate.tsx:66
+msgid "Who can reply"
+msgstr "Qui peut répondre ?"
+
+#: src/view/com/modals/crop-image/CropImage.web.tsx:102
+msgid "Wide"
+msgstr "Large"
+
+#: src/view/com/composer/Composer.tsx:409
+msgid "Write post"
+msgstr "Rédiger une publication"
+
+#: src/view/com/composer/Prompt.tsx:33
+msgid "Write your reply"
+msgstr "Rédigez votre réponse"
+
+#: src/view/screens/PreferencesHomeFeed.tsx:192
+#: src/view/screens/PreferencesHomeFeed.tsx:227
+#: src/view/screens/PreferencesHomeFeed.tsx:262
+msgid "Yes"
+msgstr "Oui"
+
+#: src/view/com/auth/create/Step1.tsx:106
+msgid "You can change hosting providers at any time."
+msgstr "Vous pouvez changer d’hébergeur à tout moment."
+
+#: src/view/com/auth/login/Login.tsx:158
+#: src/view/com/auth/login/PasswordUpdatedForm.tsx:31
+msgid "You can now sign in with your new password."
+msgstr "Vous pouvez maintenant vous connecter avec votre nouveau mot de passe."
+
+#: src/view/com/modals/InviteCodes.tsx:64
+msgid "You don't have any invite codes yet! We'll send you some when you've been on Bluesky for a little longer."
+msgstr "Vous n’avez encore aucun code d’invitation ! Nous vous en enverrons lorsque vous serez sur Bluesky depuis un peu plus longtemps."
+
+#: src/view/screens/SavedFeeds.tsx:102
+msgid "You don't have any pinned feeds."
+msgstr "Vous n’avez encore aucun fil épinglé."
+
+#: src/view/screens/Feeds.tsx:383
+msgid "You don't have any saved feeds!"
+msgstr "Vous n’avez encore aucun fil enregistré !"
+
+#: src/view/screens/SavedFeeds.tsx:135
+msgid "You don't have any saved feeds."
+msgstr "Vous n’avez encore aucun fil enregistré."
+
+#: src/view/com/post-thread/PostThread.tsx:388
+msgid "You have blocked the author or you have been blocked by the author."
+msgstr "Vous avez bloqué cet auteur ou il/elle vous a bloqué."
+
+#: src/view/com/feeds/ProfileFeedgens.tsx:141
+msgid "You have no feeds."
+msgstr "Vous n’avez aucun fil."
+
+#: src/view/com/lists/MyLists.tsx:89
+#: src/view/com/lists/ProfileLists.tsx:145
+msgid "You have no lists."
+msgstr "Vous n’avez aucune liste."
+
+#: src/view/screens/ModerationBlockedAccounts.tsx:131
+msgid "You have not blocked any accounts yet. To block an account, go to their profile and selected \"Block account\" from the menu on their account."
+msgstr "Vous n’avez pas encore bloqué de comptes. Pour bloquer un compte, accédez à son profil et sélectionnez « Bloquer compte » dans le menu de son compte."
+
+#: src/view/screens/AppPasswords.tsx:86
+msgid "You have not created any app passwords yet. You can create one by pressing the button below."
+msgstr "Vous n’avez encore créé aucun mot de passe pour l’appli. Vous pouvez en créer un en cliquant sur le bouton suivant."
+
+#: src/view/screens/ModerationMutedAccounts.tsx:130
+msgid "You have not muted any accounts yet. To mute an account, go to their profile and selected \"Mute account\" from the menu on their account."
+msgstr "Vous n’avez encore mis aucun compte en sourdine. Pour désactiver un compte, allez sur son profil et sélectionnez « Désactiver compte » dans le menu de son compte."
+
+#: src/view/com/auth/login/SetNewPasswordForm.tsx:81
+msgid "You will receive an email with a \"reset code.\" Enter that code here, then enter your new password."
+msgstr "Vous recevrez un e-mail contenant un « code de réinitialisation » Saisissez ce code ici, puis votre nouveau mot de passe."
+
+#: src/view/com/auth/create/Step2.tsx:43
+msgid "Your account"
+msgstr "Votre compte"
+
+#: src/view/com/auth/create/Step2.tsx:122
+msgid "Your birth date"
+msgstr "Votre date de naissance"
+
+#: src/view/com/auth/create/state.ts:102
+msgid "Your email appears to be invalid."
+msgstr "Votre e-mail semble être invalide."
+
+#: src/view/com/modals/Waitlist.tsx:107
+msgid "Your email has been saved! We'll be in touch soon."
+msgstr "Votre e-mail a été enregistré ! Nous vous contacterons bientôt."
+
+#: src/view/com/modals/ChangeEmail.tsx:125
+msgid "Your email has been updated but not verified. As a next step, please verify your new email."
+msgstr "Votre e-mail a été mis à jour, mais n’a pas été vérifié. L’étape suivante consiste à vérifier votre nouvel e-mail."
+
+#: src/view/com/modals/VerifyEmail.tsx:108
+msgid "Your email has not yet been verified. This is an important security step which we recommend."
+msgstr "Votre e-mail n’a pas encore été vérifié. Il s’agit d’une mesure de sécurité importante que nous recommandons."
+
+#: src/view/com/auth/create/Step3.tsx:42
+#: src/view/com/modals/ChangeHandle.tsx:270
+msgid "Your full handle will be"
+msgstr "Votre nom complet sera"
+
+#: src/view/com/auth/create/Step1.tsx:53
+msgid "Your hosting provider"
+msgstr "Votre fournisseur d’hébergement"
+
+#: src/view/screens/Settings.tsx:402
+#: src/view/shell/desktop/RightNav.tsx:129
+#: src/view/shell/Drawer.tsx:636
+msgid "Your invite codes are hidden when logged in using an App Password"
+msgstr "Vos codes d’invitation sont cachés lorsque vous êtes connecté à l’aide d’un mot de passe d’application."
+
+#: src/view/com/auth/onboarding/WelcomeMobile.tsx:59
+msgid "Your posts, likes, and blocks are public. Mutes are private."
+msgstr "Vos publications, les mentions « J’aime » et les blocages sont publics. Les sourdines sont privées."
+
+#: src/view/com/modals/SwitchAccount.tsx:82
+msgid "Your profile"
+msgstr "Votre profil"
+
+#: src/view/com/auth/create/Step3.tsx:28
+msgid "Your user handle"
+msgstr "Votre pseudo"

--- a/src/locale/locales/fr/messages.po
+++ b/src/locale/locales/fr/messages.po
@@ -15,7 +15,7 @@ msgstr ""
 
 #: src/view/shell/desktop/RightNav.tsx:160
 msgid "{0, plural, one {# invite code available} other {# invite codes available}}"
-msgstr "{0, plural, one {# invite code available} autre {# invite codes available}}"
+msgstr "{0, plural, one {# invite code available} other {# invite codes available}}"
 
 #: src/view/com/modals/Repost.tsx:44
 msgid "{0}"
@@ -27,7 +27,7 @@ msgstr "{0} {purposeLabel} Liste"
 
 #: src/view/shell/desktop/RightNav.tsx:143
 msgid "{invitesAvailable, plural, one {Invite codes: # available} other {Invite codes: # available}}"
-msgstr "{invitesAvailable, plural, one {Invite codes: # available} autre {Invite codes: # available}}"
+msgstr "{invitesAvailable, plural, one {Invite codes: # available} other {Invite codes: # available}}"
 
 #: src/view/screens/Settings.tsx:407
 #: src/view/shell/Drawer.tsx:640
@@ -178,11 +178,11 @@ msgstr "Langue de l’application"
 
 #: src/view/screens/Settings.tsx:589
 msgid "App passwords"
-msgstr "Mots de passe des applications"
+msgstr "Mots de passe de l’appli"
 
 #: src/view/screens/AppPasswords.tsx:186
 msgid "App Passwords"
-msgstr "Mots de passe des applications"
+msgstr "Mots de passe de l’appli"
 
 #: src/view/com/util/forms/PostDropdownBtn.tsx:207
 msgid "Appeal content warning"
@@ -2229,7 +2229,7 @@ msgstr "Télécharger un fichier texte vers :"
 
 #: src/view/screens/AppPasswords.tsx:194
 msgid "Use app passwords to login to other Bluesky clients without giving full access to your account or password."
-msgstr "Utiliser les mots de passe de l’application pour se connecter à d’autres clients Bluesky sans donner un accès complet à votre compte ou à votre mot de passe."
+msgstr "Utiliser les mots de passe de l’appli pour se connecter à d’autres clients Bluesky sans donner un accès complet à votre compte ou à votre mot de passe."
 
 #: src/view/com/modals/ChangeHandle.tsx:513
 msgid "Use default provider"

--- a/src/locale/locales/fr/messages.po
+++ b/src/locale/locales/fr/messages.po
@@ -347,7 +347,7 @@ msgstr "Ne peut contenir que des lettres, des chiffres, des espaces, des tirets 
 
 #: src/view/com/composer/Composer.tsx:285
 #: src/view/com/composer/Composer.tsx:288
-#: src/view/com/modals/AltImage.tsx:127
+#: src/view/com/modals/AltImage.tsx:128
 #: src/view/com/modals/ChangeEmail.tsx:218
 #: src/view/com/modals/ChangeEmail.tsx:220
 #: src/view/com/modals/Confirm.tsx:88
@@ -370,7 +370,7 @@ msgstr "Annuler"
 msgid "Cancel account deletion"
 msgstr "Annuler suppression de compte"
 
-#: src/view/com/modals/AltImage.tsx:122
+#: src/view/com/modals/AltImage.tsx:123
 msgid "Cancel add image alt text"
 msgstr "Annuler l’ajout d’un texte alt à l’image"
 
@@ -773,7 +773,7 @@ msgstr "E-mail :"
 msgid "Enable this setting to only see replies between people you follow."
 msgstr "Activez ce paramètre pour ne voir que les réponses des personnes que vous suivez."
 
-#: src/view/screens/Profile.tsx:425
+#: src/view/screens/Profile.tsx:426
 msgid "End of feed"
 msgstr "Fin du fil d’actu"
 
@@ -818,7 +818,7 @@ msgstr "Développer le texte alt"
 msgid "Failed to load recommended feeds"
 msgstr "Échec du chargement des fils d’actu recommandés"
 
-#: src/view/screens/Feeds.tsx:559
+#: src/view/screens/Feeds.tsx:560
 msgid "Feed offline"
 msgstr "Fil d’actu hors ligne"
 
@@ -832,9 +832,9 @@ msgid "Feedback"
 msgstr "Feedback"
 
 #: src/view/screens/Feeds.tsx:475
-#: src/view/screens/Profile.tsx:164
+#: src/view/screens/Profile.tsx:165
 #: src/view/shell/bottom-bar/BottomBar.tsx:181
-#: src/view/shell/desktop/LeftNav.tsx:339
+#: src/view/shell/desktop/LeftNav.tsx:340
 #: src/view/shell/Drawer.tsx:455
 #: src/view/shell/Drawer.tsx:456
 msgid "Feeds"
@@ -933,7 +933,7 @@ msgstr "C’est parti"
 #: src/view/com/auth/LoggedOut.tsx:81
 #: src/view/com/auth/LoggedOut.tsx:82
 #: src/view/com/util/moderation/ScreenHider.tsx:123
-#: src/view/shell/desktop/LeftNav.tsx:103
+#: src/view/shell/desktop/LeftNav.tsx:104
 msgid "Go back"
 msgstr "Retour"
 
@@ -993,7 +993,7 @@ msgid "Hmm, we're having trouble finding this feed. It may have been deleted."
 msgstr "Hmm, nous n’arrivons pas à trouver ce fils d’actu. Il a peut-être été supprimé."
 
 #: src/view/shell/bottom-bar/BottomBar.tsx:137
-#: src/view/shell/desktop/LeftNav.tsx:303
+#: src/view/shell/desktop/LeftNav.tsx:304
 #: src/view/shell/Drawer.tsx:379
 #: src/view/shell/Drawer.tsx:380
 msgid "Home"
@@ -1026,7 +1026,7 @@ msgstr "J’ai mon propre domaine"
 msgid "If none are selected, suitable for all ages."
 msgstr "Si rien n’est sélectionné, il n’y a pas de restriction d’âge."
 
-#: src/view/com/modals/AltImage.tsx:96
+#: src/view/com/modals/AltImage.tsx:97
 msgid "Image alt text"
 msgstr "Texte alt de l’image"
 
@@ -1138,7 +1138,7 @@ msgstr "Likez ce fils d’actu"
 msgid "Liked by"
 msgstr "Liké par"
 
-#: src/view/screens/Profile.tsx:163
+#: src/view/screens/Profile.tsx:164
 msgid "Likes"
 msgstr "Likes"
 
@@ -1150,8 +1150,8 @@ msgstr "Liste des avatars"
 msgid "List Name"
 msgstr "Nom de liste"
 
-#: src/view/screens/Profile.tsx:165
-#: src/view/shell/desktop/LeftNav.tsx:376
+#: src/view/screens/Profile.tsx:166
+#: src/view/shell/desktop/LeftNav.tsx:377
 #: src/view/shell/Drawer.tsx:471
 #: src/view/shell/Drawer.tsx:472
 msgid "Lists"
@@ -1194,7 +1194,7 @@ msgstr "Se connecter à un compte qui n’est pas listé"
 msgid "Make sure this is where you intend to go!"
 msgstr "Assurez-vous que c’est bien là que vous avez l’intention d’aller !"
 
-#: src/view/screens/Profile.tsx:162
+#: src/view/screens/Profile.tsx:163
 msgid "Media"
 msgstr "Média"
 
@@ -1216,7 +1216,7 @@ msgstr "Message du serveur"
 
 #: src/view/screens/Moderation.tsx:64
 #: src/view/screens/Settings.tsx:563
-#: src/view/shell/desktop/LeftNav.tsx:394
+#: src/view/shell/desktop/LeftNav.tsx:395
 #: src/view/shell/Drawer.tsx:490
 #: src/view/shell/Drawer.tsx:491
 msgid "Moderation"
@@ -1284,7 +1284,7 @@ msgstr "Ma date de naissance"
 msgid "My Feeds"
 msgstr "Mes fils d’actu"
 
-#: src/view/shell/desktop/LeftNav.tsx:64
+#: src/view/shell/desktop/LeftNav.tsx:65
 msgid "My Profile"
 msgstr "Mon profil"
 
@@ -1307,16 +1307,16 @@ msgid "New"
 msgstr "Nouveau"
 
 #: src/view/com/feeds/FeedPage.tsx:200
-#: src/view/screens/Feeds.tsx:510
-#: src/view/screens/Profile.tsx:353
+#: src/view/screens/Feeds.tsx:511
+#: src/view/screens/Profile.tsx:354
 #: src/view/screens/ProfileFeed.tsx:430
 #: src/view/screens/ProfileList.tsx:193
 #: src/view/screens/ProfileList.tsx:221
-#: src/view/shell/desktop/LeftNav.tsx:246
+#: src/view/shell/desktop/LeftNav.tsx:247
 msgid "New post"
 msgstr "Nouvelle publication"
 
-#: src/view/shell/desktop/LeftNav.tsx:256
+#: src/view/shell/desktop/LeftNav.tsx:257
 msgid "New Post"
 msgstr "Nouvelle publication"
 
@@ -1376,7 +1376,7 @@ msgstr "Remarque : Bluesky est un réseau ouvert et public. Ce paramètre limit
 #: src/view/screens/Notifications.tsx:109
 #: src/view/screens/Notifications.tsx:133
 #: src/view/shell/bottom-bar/BottomBar.tsx:205
-#: src/view/shell/desktop/LeftNav.tsx:358
+#: src/view/shell/desktop/LeftNav.tsx:359
 #: src/view/shell/Drawer.tsx:416
 #: src/view/shell/Drawer.tsx:417
 msgid "Notifications"
@@ -1540,7 +1540,7 @@ msgstr "Langues de publication"
 msgid "Post not found"
 msgstr "Publication introuvable"
 
-#: src/view/screens/Profile.tsx:160
+#: src/view/screens/Profile.tsx:161
 msgid "Posts"
 msgstr "Publications"
 
@@ -1573,7 +1573,7 @@ msgid "Processing..."
 msgstr "Traitement..."
 
 #: src/view/shell/bottom-bar/BottomBar.tsx:247
-#: src/view/shell/desktop/LeftNav.tsx:412
+#: src/view/shell/desktop/LeftNav.tsx:413
 #: src/view/shell/Drawer.tsx:69
 #: src/view/shell/Drawer.tsx:525
 #: src/view/shell/Drawer.tsx:526
@@ -1660,7 +1660,7 @@ msgstr "Supprimer ce fils d’actu de vos fils d’actu enregistrés ?"
 msgid "Removed from list"
 msgstr "Supprimé de la liste"
 
-#: src/view/screens/Profile.tsx:161
+#: src/view/screens/Profile.tsx:162
 msgid "Replies"
 msgstr "Réponses"
 
@@ -1748,7 +1748,7 @@ msgstr "Réinitialise l’état des préférences"
 msgid "Retry"
 msgstr "Réessayer"
 
-#: src/view/com/modals/AltImage.tsx:114
+#: src/view/com/modals/AltImage.tsx:115
 #: src/view/com/modals/BirthDateSettings.tsx:93
 #: src/view/com/modals/BirthDateSettings.tsx:96
 #: src/view/com/modals/ChangeHandle.tsx:173
@@ -1758,7 +1758,7 @@ msgstr "Réessayer"
 msgid "Save"
 msgstr "Enregistrer"
 
-#: src/view/com/modals/AltImage.tsx:105
+#: src/view/com/modals/AltImage.tsx:106
 msgid "Save alt text"
 msgstr "Enregistrer texte alt"
 
@@ -1783,7 +1783,7 @@ msgstr "Fils d’actu enregistrés"
 #: src/view/screens/Search/Search.tsx:401
 #: src/view/screens/Search/Search.tsx:567
 #: src/view/shell/bottom-bar/BottomBar.tsx:159
-#: src/view/shell/desktop/LeftNav.tsx:321
+#: src/view/shell/desktop/LeftNav.tsx:322
 #: src/view/shell/desktop/Search.tsx:161
 #: src/view/shell/desktop/Search.tsx:170
 #: src/view/shell/Drawer.tsx:343
@@ -1874,7 +1874,7 @@ msgid "Set this setting to \"Yes\" to show samples of your saved feeds in your f
 msgstr "Choisissez « Oui » pour afficher des échantillons de vos fils d’actu enregistrés dans votre fils d’actu suivant. C’est une fonctionnalité expérimentale."
 
 #: src/view/screens/Settings.tsx:277
-#: src/view/shell/desktop/LeftNav.tsx:430
+#: src/view/shell/desktop/LeftNav.tsx:431
 #: src/view/shell/Drawer.tsx:546
 #: src/view/shell/Drawer.tsx:547
 msgid "Settings"

--- a/src/locale/locales/hi/messages.po
+++ b/src/locale/locales/hi/messages.po
@@ -375,7 +375,7 @@ msgstr "केवल अक्षर, संख्या, रिक्त स्
 
 #: src/view/com/composer/Composer.tsx:285
 #: src/view/com/composer/Composer.tsx:288
-#: src/view/com/modals/AltImage.tsx:127
+#: src/view/com/modals/AltImage.tsx:128
 #: src/view/com/modals/ChangeEmail.tsx:218
 #: src/view/com/modals/ChangeEmail.tsx:220
 #: src/view/com/modals/Confirm.tsx:88
@@ -398,7 +398,7 @@ msgstr "कैंसिल"
 msgid "Cancel account deletion"
 msgstr "अकाउंट बंद मत करो"
 
-#: src/view/com/modals/AltImage.tsx:122
+#: src/view/com/modals/AltImage.tsx:123
 msgid "Cancel add image alt text"
 msgstr "ऑल्ट टेक्स्ट मत जोड़ें"
 
@@ -805,7 +805,7 @@ msgstr "ईमेल:"
 msgid "Enable this setting to only see replies between people you follow."
 msgstr "इस सेटिंग को केवल उन लोगों के बीच जवाब देखने में सक्षम करें जिन्हें आप फॉलो करते हैं।।"
 
-#: src/view/screens/Profile.tsx:425
+#: src/view/screens/Profile.tsx:426
 msgid "End of feed"
 msgstr ""
 
@@ -850,7 +850,7 @@ msgstr "ऑल्ट टेक्स्ट"
 msgid "Failed to load recommended feeds"
 msgstr "अनुशंसित फ़ीड लोड करने में विफल"
 
-#: src/view/screens/Feeds.tsx:559
+#: src/view/screens/Feeds.tsx:560
 msgid "Feed offline"
 msgstr "फ़ीड ऑफ़लाइन है"
 
@@ -864,9 +864,9 @@ msgid "Feedback"
 msgstr "प्रतिक्रिया"
 
 #: src/view/screens/Feeds.tsx:475
-#: src/view/screens/Profile.tsx:164
+#: src/view/screens/Profile.tsx:165
 #: src/view/shell/bottom-bar/BottomBar.tsx:181
-#: src/view/shell/desktop/LeftNav.tsx:339
+#: src/view/shell/desktop/LeftNav.tsx:340
 #: src/view/shell/Drawer.tsx:455
 #: src/view/shell/Drawer.tsx:456
 msgid "Feeds"
@@ -965,7 +965,7 @@ msgstr "प्रारंभ करें"
 #: src/view/com/auth/LoggedOut.tsx:81
 #: src/view/com/auth/LoggedOut.tsx:82
 #: src/view/com/util/moderation/ScreenHider.tsx:123
-#: src/view/shell/desktop/LeftNav.tsx:103
+#: src/view/shell/desktop/LeftNav.tsx:104
 msgid "Go back"
 msgstr "वापस जाओ"
 
@@ -1033,7 +1033,7 @@ msgstr ""
 #~ msgstr ""
 
 #: src/view/shell/bottom-bar/BottomBar.tsx:137
-#: src/view/shell/desktop/LeftNav.tsx:303
+#: src/view/shell/desktop/LeftNav.tsx:304
 #: src/view/shell/Drawer.tsx:379
 #: src/view/shell/Drawer.tsx:380
 msgid "Home"
@@ -1066,7 +1066,7 @@ msgstr "मेरे पास अपना डोमेन है"
 msgid "If none are selected, suitable for all ages."
 msgstr "यदि किसी को चुना जाता है, तो सभी उम्र के लिए उपयुक्त है।।"
 
-#: src/view/com/modals/AltImage.tsx:96
+#: src/view/com/modals/AltImage.tsx:97
 msgid "Image alt text"
 msgstr "छवि alt पाठ"
 
@@ -1187,7 +1187,7 @@ msgstr "इस फ़ीड को लाइक करो"
 msgid "Liked by"
 msgstr "इन यूजर ने लाइक किया है"
 
-#: src/view/screens/Profile.tsx:163
+#: src/view/screens/Profile.tsx:164
 msgid "Likes"
 msgstr ""
 
@@ -1207,8 +1207,8 @@ msgstr "सूची अवतार"
 msgid "List Name"
 msgstr "सूची का नाम"
 
-#: src/view/screens/Profile.tsx:165
-#: src/view/shell/desktop/LeftNav.tsx:376
+#: src/view/screens/Profile.tsx:166
+#: src/view/shell/desktop/LeftNav.tsx:377
 #: src/view/shell/Drawer.tsx:471
 #: src/view/shell/Drawer.tsx:472
 msgid "Lists"
@@ -1255,7 +1255,7 @@ msgstr "उस खाते में लॉग इन करें जो स�
 msgid "Make sure this is where you intend to go!"
 msgstr "यह सुनिश्चित करने के लिए कि आप कहाँ जाना चाहते हैं!"
 
-#: src/view/screens/Profile.tsx:162
+#: src/view/screens/Profile.tsx:163
 msgid "Media"
 msgstr ""
 
@@ -1277,7 +1277,7 @@ msgstr ""
 
 #: src/view/screens/Moderation.tsx:64
 #: src/view/screens/Settings.tsx:563
-#: src/view/shell/desktop/LeftNav.tsx:394
+#: src/view/shell/desktop/LeftNav.tsx:395
 #: src/view/shell/Drawer.tsx:490
 #: src/view/shell/Drawer.tsx:491
 msgid "Moderation"
@@ -1353,7 +1353,7 @@ msgstr "जन्मदिन"
 msgid "My Feeds"
 msgstr "मेरी फ़ीड"
 
-#: src/view/shell/desktop/LeftNav.tsx:64
+#: src/view/shell/desktop/LeftNav.tsx:65
 msgid "My Profile"
 msgstr "मेरी प्रोफाइल"
 
@@ -1376,16 +1376,16 @@ msgid "New"
 msgstr "नया"
 
 #: src/view/com/feeds/FeedPage.tsx:200
-#: src/view/screens/Feeds.tsx:510
-#: src/view/screens/Profile.tsx:353
+#: src/view/screens/Feeds.tsx:511
+#: src/view/screens/Profile.tsx:354
 #: src/view/screens/ProfileFeed.tsx:430
 #: src/view/screens/ProfileList.tsx:193
 #: src/view/screens/ProfileList.tsx:221
-#: src/view/shell/desktop/LeftNav.tsx:246
+#: src/view/shell/desktop/LeftNav.tsx:247
 msgid "New post"
 msgstr "नई पोस्ट"
 
-#: src/view/shell/desktop/LeftNav.tsx:256
+#: src/view/shell/desktop/LeftNav.tsx:257
 msgid "New Post"
 msgstr "नई पोस्ट"
 
@@ -1462,7 +1462,7 @@ msgstr ""
 #: src/view/screens/Notifications.tsx:109
 #: src/view/screens/Notifications.tsx:133
 #: src/view/shell/bottom-bar/BottomBar.tsx:205
-#: src/view/shell/desktop/LeftNav.tsx:358
+#: src/view/shell/desktop/LeftNav.tsx:359
 #: src/view/shell/Drawer.tsx:416
 #: src/view/shell/Drawer.tsx:417
 msgid "Notifications"
@@ -1626,7 +1626,7 @@ msgstr "पोस्ट भाषा"
 msgid "Post not found"
 msgstr "पोस्ट नहीं मिला"
 
-#: src/view/screens/Profile.tsx:160
+#: src/view/screens/Profile.tsx:161
 msgid "Posts"
 msgstr ""
 
@@ -1659,7 +1659,7 @@ msgid "Processing..."
 msgstr "प्रसंस्करण..."
 
 #: src/view/shell/bottom-bar/BottomBar.tsx:247
-#: src/view/shell/desktop/LeftNav.tsx:412
+#: src/view/shell/desktop/LeftNav.tsx:413
 #: src/view/shell/Drawer.tsx:69
 #: src/view/shell/Drawer.tsx:525
 #: src/view/shell/Drawer.tsx:526
@@ -1751,7 +1751,7 @@ msgstr "इस फ़ीड को सहेजे गए फ़ीड से �
 msgid "Removed from list"
 msgstr ""
 
-#: src/view/screens/Profile.tsx:161
+#: src/view/screens/Profile.tsx:162
 msgid "Replies"
 msgstr ""
 
@@ -1851,7 +1851,7 @@ msgstr "फिर से कोशिश करो"
 #~ msgid "Retry change handle"
 #~ msgstr "हैंडल बदलना फिर से कोशिश करो"
 
-#: src/view/com/modals/AltImage.tsx:114
+#: src/view/com/modals/AltImage.tsx:115
 #: src/view/com/modals/BirthDateSettings.tsx:93
 #: src/view/com/modals/BirthDateSettings.tsx:96
 #: src/view/com/modals/ChangeHandle.tsx:173
@@ -1861,7 +1861,7 @@ msgstr "फिर से कोशिश करो"
 msgid "Save"
 msgstr "सेव करो"
 
-#: src/view/com/modals/AltImage.tsx:105
+#: src/view/com/modals/AltImage.tsx:106
 msgid "Save alt text"
 msgstr "सेव ऑल्ट टेक्स्ट"
 
@@ -1890,7 +1890,7 @@ msgstr "सहेजे गए फ़ीड"
 #: src/view/screens/Search/Search.tsx:401
 #: src/view/screens/Search/Search.tsx:567
 #: src/view/shell/bottom-bar/BottomBar.tsx:159
-#: src/view/shell/desktop/LeftNav.tsx:321
+#: src/view/shell/desktop/LeftNav.tsx:322
 #: src/view/shell/desktop/Search.tsx:161
 #: src/view/shell/desktop/Search.tsx:170
 #: src/view/shell/Drawer.tsx:343
@@ -1985,7 +1985,7 @@ msgid "Set this setting to \"Yes\" to show samples of your saved feeds in your f
 msgstr "इस सेटिंग को अपने निम्नलिखित फ़ीड में अपने सहेजे गए फ़ीड के नमूने दिखाने के लिए \"हाँ\" पर सेट करें। यह एक प्रयोगात्मक विशेषता है।।"
 
 #: src/view/screens/Settings.tsx:277
-#: src/view/shell/desktop/LeftNav.tsx:430
+#: src/view/shell/desktop/LeftNav.tsx:431
 #: src/view/shell/Drawer.tsx:546
 #: src/view/shell/Drawer.tsx:547
 msgid "Settings"

--- a/src/locale/locales/ja/messages.po
+++ b/src/locale/locales/ja/messages.po
@@ -347,7 +347,7 @@ msgstr "文字、数字、スペース、ハイフン、およびアンダース
 
 #: src/view/com/composer/Composer.tsx:285
 #: src/view/com/composer/Composer.tsx:288
-#: src/view/com/modals/AltImage.tsx:127
+#: src/view/com/modals/AltImage.tsx:128
 #: src/view/com/modals/ChangeEmail.tsx:218
 #: src/view/com/modals/ChangeEmail.tsx:220
 #: src/view/com/modals/Confirm.tsx:88
@@ -370,7 +370,7 @@ msgstr "キャンセル"
 msgid "Cancel account deletion"
 msgstr "アカウントの削除をキャンセル"
 
-#: src/view/com/modals/AltImage.tsx:122
+#: src/view/com/modals/AltImage.tsx:123
 msgid "Cancel add image alt text"
 msgstr "画像のALTテキストの追加をキャンセル"
 
@@ -773,7 +773,7 @@ msgstr "メールアドレス："
 msgid "Enable this setting to only see replies between people you follow."
 msgstr "この設定を有効にすると、フォローしているユーザー間の返信だけが表示されます。"
 
-#: src/view/screens/Profile.tsx:425
+#: src/view/screens/Profile.tsx:426
 msgid "End of feed"
 msgstr "フィードの終わり"
 
@@ -818,7 +818,7 @@ msgstr "ALTテキストを展開"
 msgid "Failed to load recommended feeds"
 msgstr "おすすめのフィードのロードに失敗しました"
 
-#: src/view/screens/Feeds.tsx:559
+#: src/view/screens/Feeds.tsx:560
 msgid "Feed offline"
 msgstr "フィードはオフラインです"
 
@@ -832,9 +832,9 @@ msgid "Feedback"
 msgstr "フィードバック"
 
 #: src/view/screens/Feeds.tsx:475
-#: src/view/screens/Profile.tsx:164
+#: src/view/screens/Profile.tsx:165
 #: src/view/shell/bottom-bar/BottomBar.tsx:181
-#: src/view/shell/desktop/LeftNav.tsx:339
+#: src/view/shell/desktop/LeftNav.tsx:340
 #: src/view/shell/Drawer.tsx:455
 #: src/view/shell/Drawer.tsx:456
 msgid "Feeds"
@@ -933,7 +933,7 @@ msgstr "はじめに"
 #: src/view/com/auth/LoggedOut.tsx:81
 #: src/view/com/auth/LoggedOut.tsx:82
 #: src/view/com/util/moderation/ScreenHider.tsx:123
-#: src/view/shell/desktop/LeftNav.tsx:103
+#: src/view/shell/desktop/LeftNav.tsx:104
 msgid "Go back"
 msgstr "戻る"
 
@@ -993,7 +993,7 @@ msgid "Hmm, we're having trouble finding this feed. It may have been deleted."
 msgstr "このフィードが見つからないようです。もしかしたら削除されたのかもしれません。"
 
 #: src/view/shell/bottom-bar/BottomBar.tsx:137
-#: src/view/shell/desktop/LeftNav.tsx:303
+#: src/view/shell/desktop/LeftNav.tsx:304
 #: src/view/shell/Drawer.tsx:379
 #: src/view/shell/Drawer.tsx:380
 msgid "Home"
@@ -1026,7 +1026,7 @@ msgstr "自分のドメインを持っています"
 msgid "If none are selected, suitable for all ages."
 msgstr "選択されていない場合は、すべての年齢に適しています。"
 
-#: src/view/com/modals/AltImage.tsx:96
+#: src/view/com/modals/AltImage.tsx:97
 msgid "Image alt text"
 msgstr "画像のALTテキスト"
 
@@ -1138,7 +1138,7 @@ msgstr "このフィードをいいね"
 msgid "Liked by"
 msgstr "いいねした人"
 
-#: src/view/screens/Profile.tsx:163
+#: src/view/screens/Profile.tsx:164
 msgid "Likes"
 msgstr "いいね"
 
@@ -1154,8 +1154,8 @@ msgstr "リストアバター"
 msgid "List Name"
 msgstr "リストの名前"
 
-#: src/view/screens/Profile.tsx:165
-#: src/view/shell/desktop/LeftNav.tsx:376
+#: src/view/screens/Profile.tsx:166
+#: src/view/shell/desktop/LeftNav.tsx:377
 #: src/view/shell/Drawer.tsx:471
 #: src/view/shell/Drawer.tsx:472
 msgid "Lists"
@@ -1202,7 +1202,7 @@ msgstr "リストにないアカウントにログイン"
 msgid "Make sure this is where you intend to go!"
 msgstr "意図した場所であることを確認してください！"
 
-#: src/view/screens/Profile.tsx:162
+#: src/view/screens/Profile.tsx:163
 msgid "Media"
 msgstr "メディア"
 
@@ -1224,7 +1224,7 @@ msgstr "サーバーからのメッセージ"
 
 #: src/view/screens/Moderation.tsx:64
 #: src/view/screens/Settings.tsx:563
-#: src/view/shell/desktop/LeftNav.tsx:394
+#: src/view/shell/desktop/LeftNav.tsx:395
 #: src/view/shell/Drawer.tsx:490
 #: src/view/shell/Drawer.tsx:491
 msgid "Moderation"
@@ -1292,7 +1292,7 @@ msgstr "誕生日"
 msgid "My Feeds"
 msgstr "マイフィード"
 
-#: src/view/shell/desktop/LeftNav.tsx:64
+#: src/view/shell/desktop/LeftNav.tsx:65
 msgid "My Profile"
 msgstr "マイプロフィール"
 
@@ -1315,16 +1315,16 @@ msgid "New"
 msgstr "新規"
 
 #: src/view/com/feeds/FeedPage.tsx:200
-#: src/view/screens/Feeds.tsx:510
-#: src/view/screens/Profile.tsx:353
+#: src/view/screens/Feeds.tsx:511
+#: src/view/screens/Profile.tsx:354
 #: src/view/screens/ProfileFeed.tsx:430
 #: src/view/screens/ProfileList.tsx:193
 #: src/view/screens/ProfileList.tsx:221
-#: src/view/shell/desktop/LeftNav.tsx:246
+#: src/view/shell/desktop/LeftNav.tsx:247
 msgid "New post"
 msgstr "新しい投稿"
 
-#: src/view/shell/desktop/LeftNav.tsx:256
+#: src/view/shell/desktop/LeftNav.tsx:257
 msgid "New Post"
 msgstr "新しい投稿"
 
@@ -1388,7 +1388,7 @@ msgstr "注記：Blueskyはオープンでパブリックなネットワーク�
 #: src/view/screens/Notifications.tsx:109
 #: src/view/screens/Notifications.tsx:133
 #: src/view/shell/bottom-bar/BottomBar.tsx:205
-#: src/view/shell/desktop/LeftNav.tsx:358
+#: src/view/shell/desktop/LeftNav.tsx:359
 #: src/view/shell/Drawer.tsx:416
 #: src/view/shell/Drawer.tsx:417
 msgid "Notifications"
@@ -1552,7 +1552,7 @@ msgstr "投稿の言語"
 msgid "Post not found"
 msgstr "投稿が見つかりません"
 
-#: src/view/screens/Profile.tsx:160
+#: src/view/screens/Profile.tsx:161
 msgid "Posts"
 msgstr "投稿"
 
@@ -1585,7 +1585,7 @@ msgid "Processing..."
 msgstr "処理中..."
 
 #: src/view/shell/bottom-bar/BottomBar.tsx:247
-#: src/view/shell/desktop/LeftNav.tsx:412
+#: src/view/shell/desktop/LeftNav.tsx:413
 #: src/view/shell/Drawer.tsx:69
 #: src/view/shell/Drawer.tsx:525
 #: src/view/shell/Drawer.tsx:526
@@ -1672,7 +1672,7 @@ msgstr "保存したフィードからこのフィードを削除しますか？
 msgid "Removed from list"
 msgstr "リストから削除されました"
 
-#: src/view/screens/Profile.tsx:161
+#: src/view/screens/Profile.tsx:162
 msgid "Replies"
 msgstr "返信"
 
@@ -1760,7 +1760,7 @@ msgstr "設定の状態をリセット"
 msgid "Retry"
 msgstr "再試行"
 
-#: src/view/com/modals/AltImage.tsx:114
+#: src/view/com/modals/AltImage.tsx:115
 #: src/view/com/modals/BirthDateSettings.tsx:93
 #: src/view/com/modals/BirthDateSettings.tsx:96
 #: src/view/com/modals/ChangeHandle.tsx:173
@@ -1770,7 +1770,7 @@ msgstr "再試行"
 msgid "Save"
 msgstr "保存"
 
-#: src/view/com/modals/AltImage.tsx:105
+#: src/view/com/modals/AltImage.tsx:106
 msgid "Save alt text"
 msgstr "ALTテキストを保存"
 
@@ -1795,7 +1795,7 @@ msgstr "保存されたフィード"
 #: src/view/screens/Search/Search.tsx:401
 #: src/view/screens/Search/Search.tsx:567
 #: src/view/shell/bottom-bar/BottomBar.tsx:159
-#: src/view/shell/desktop/LeftNav.tsx:321
+#: src/view/shell/desktop/LeftNav.tsx:322
 #: src/view/shell/desktop/Search.tsx:161
 #: src/view/shell/desktop/Search.tsx:170
 #: src/view/shell/Drawer.tsx:343
@@ -1890,7 +1890,7 @@ msgid "Set this setting to \"Yes\" to show samples of your saved feeds in your f
 msgstr "保存されたフィードのサンプルを次のフィードに表示するには、この設定を「はい」にします。これは実験的な機能です。"
 
 #: src/view/screens/Settings.tsx:277
-#: src/view/shell/desktop/LeftNav.tsx:430
+#: src/view/shell/desktop/LeftNav.tsx:431
 #: src/view/shell/Drawer.tsx:546
 #: src/view/shell/Drawer.tsx:547
 msgid "Settings"


### PR DESCRIPTION
This PR enables Spanish (`es`) localization for the Bluesky app. These translations have been verified internally, although we are open to any community feedback as we work to support the Bluesky app in multiple languges.