### PR TITLE
CI: run all actions on every push

### DIFF
--- a/.github/workflows/build-and-push-bskyweb-aws.yaml
+++ b/.github/workflows/build-and-push-bskyweb-aws.yaml
@@ -1,10 +1,6 @@
 name: build-and-push-bskyweb-aws
-on:
-  push:
-    branches:
-      - main
-      - traffic-reduction
-      - respect-optout-for-embeds
+on: [push]
+
 env:
   REGISTRY: ${{ secrets.AWS_ECR_REGISTRY_USEAST2_PACKAGES_REGISTRY }}
   USERNAME: ${{ secrets.AWS_ECR_REGISTRY_USEAST2_PACKAGES_USERNAME }}

--- a/.github/workflows/build-and-push-bskyweb-ghcr.yaml
+++ b/.github/workflows/build-and-push-bskyweb-ghcr.yaml
@@ -1,9 +1,6 @@
 name: build-and-push-bskyweb-ghcr
-on:
-  push:
-    branches:
-      - main
-      - jake/bskyweb-additions
+on: [push]
+
 env:
   REGISTRY: ghcr.io
   USERNAME: ${{ github.actor }}

--- a/.github/workflows/golang-test-lint.yml
+++ b/.github/workflows/golang-test-lint.yml
@@ -1,10 +1,5 @@
 name: golang
-
-on:
-  pull_request:
-  push:
-    branches:
-      - main
+on: [push]
 
 concurrency:
   group: '${{ github.workflow }}-${{ github.head_ref || github.ref }}'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,10 +1,6 @@
 name: Lint
+on: [push]
 
-on:
-  pull_request:
-  push:
-    branches:
-      - main
 concurrency:
   group: '${{ github.workflow }}-${{ github.head_ref || github.ref }}'
   cancel-in-progress: true


### PR DESCRIPTION
It sounds like from chat that maybe we *don't* actually want to do it this way for the `social-app` repo specifically, but this PR at least makes the issue clearer.

The github docs on what other "triggers" can be used to control when CI runs are here:
https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows