### PR TITLE
Fix some account filtering behaviors

### DIFF
--- a/src/state/queries/actor-autocomplete.ts
+++ b/src/state/queries/actor-autocomplete.ts
@@ -112,7 +112,7 @@ function computeSuggestions(
   }
   return items.filter(profile => {
     const mod = moderateProfile(profile, moderationOpts)
-    return !mod.account.filter
+    return !mod.account.filter && mod.account.cause?.type !== 'muted'
   })
 }
 

--- a/src/view/com/lists/ListMembers.tsx
+++ b/src/view/com/lists/ListMembers.tsx
@@ -180,6 +180,7 @@ export function ListMembers({
           profile={(item as AppBskyGraphDefs.ListItemView).subject}
           renderButton={renderMemberButton}
           style={{paddingHorizontal: isMobile ? 8 : 14, paddingVertical: 4}}
+          noModFilter
         />
       )
     },

--- a/src/view/com/profile/ProfileCard.tsx
+++ b/src/view/com/profile/ProfileCard.tsx
@@ -27,6 +27,7 @@ import {useSession} from '#/state/session'
 export function ProfileCard({
   testID,
   profile: profileUnshadowed,
+  noModFilter,
   noBg,
   noBorder,
   followers,
@@ -35,6 +36,7 @@ export function ProfileCard({
 }: {
   testID?: string
   profile: AppBskyActorDefs.ProfileViewBasic
+  noModFilter?: boolean
   noBg?: boolean
   noBorder?: boolean
   followers?: AppBskyActorDefs.ProfileView[] | undefined
@@ -50,7 +52,7 @@ export function ProfileCard({
     return null
   }
   const moderation = moderateProfile(profile, moderationOpts)
-  if (moderation.account.filter) {
+  if (!noModFilter && moderation.account.filter) {
     return null
   }
 

--- a/src/view/com/profile/ProfileCard.tsx
+++ b/src/view/com/profile/ProfileCard.tsx
@@ -52,7 +52,11 @@ export function ProfileCard({
     return null
   }
   const moderation = moderateProfile(profile, moderationOpts)
-  if (!noModFilter && moderation.account.filter) {
+  if (
+    !noModFilter &&
+    moderation.account.filter &&
+    moderation.account.cause?.type !== 'muted'
+  ) {
     return null
   }
 

--- a/src/view/screens/ModerationBlockedAccounts.tsx
+++ b/src/view/screens/ModerationBlockedAccounts.tsx
@@ -92,6 +92,7 @@ export function ModerationBlockedAccounts({}: Props) {
       testID={`blockedAccount-${index}`}
       key={item.did}
       profile={item}
+      noModFilter
     />
   )
   return (

--- a/src/view/screens/ModerationMutedAccounts.tsx
+++ b/src/view/screens/ModerationMutedAccounts.tsx
@@ -92,6 +92,7 @@ export function ModerationMutedAccounts({}: Props) {
       testID={`mutedAccount-${index}`}
       key={item.did}
       profile={item}
+      noModFilter
     />
   )
   return (


### PR DESCRIPTION
I hastily added a moderation filter on profile cards while adding the PWI behaviors. This missed that we don't want this behavior in 3 settings:

1. Muted users list
2. Blocked users list
3. Curation/moderation user lists

This PR fixes that. I also reviewed the other cases ProfileCard is used and I believe we do want this filter in all of them.

Additionally, the `moderation.account.filter` is true when users are muted, and in some cases that's too extensive (autocomplete, any user listing) so this relaxes that as well.