### PR TITLE
Fix: dont incorrectly mark a feed empty based only on the first page (close #2296)

### DIFF
--- a/src/view/com/posts/Feed.tsx
+++ b/src/view/com/posts/Feed.tsx
@@ -95,10 +95,13 @@ let Feed = ({
     isFetchingNextPage,
     fetchNextPage,
   } = usePostFeedQuery(feed, feedParams, opts)
-  const isEmpty = !isFetching && !data?.pages[0]?.slices.length
   if (data?.pages[0]) {
     lastFetchRef.current = data?.pages[0].fetchedAt
   }
+  const isEmpty = React.useMemo(
+    () => !isFetching && !data?.pages?.some(page => page.slices.length),
+    [isFetching, data],
+  )
 
   const checkForNew = React.useCallback(async () => {
     if (!data?.pages[0] || isFetching || !onHasNew || !enabled) {


### PR DESCRIPTION
Closes #2296 

The feed component was only looking at the first page of posts to establish if a feed is empty. If somebody has been replying a lot, their profile's main tab will filter out that entire first page, leading that `isEmpty` to be true. Other code, however, uses more complete is-empty logic, causing the UI state to vacillate between the empty behavior and the fetch more behavior.

Making the `isEmpty` check more complete fixes that.