### PR TITLE
support multiple og:image tags

### DIFF
--- a/bskyweb/cmd/bskyweb/server.go
+++ b/bskyweb/cmd/bskyweb/server.go
@@ -336,7 +336,11 @@ func (srv *Server) WebPost(c echo.Context) error {
 	data["postView"] = postView
 	data["requestURI"] = fmt.Sprintf("https://%s%s", req.Host, req.URL.Path)
 	if postView.Embed != nil && postView.Embed.EmbedImages_View != nil {
-		data["imgThumbUrl"] = postView.Embed.EmbedImages_View.Images[0].Thumb
+		var thumbUrls []string
+		for i := range postView.Embed.EmbedImages_View.Images {
+			thumbUrls = append(thumbUrls, postView.Embed.EmbedImages_View.Images[i].Thumb)
+		}
+		data["imgThumbUrls"] = thumbUrls
 	}
 	return c.Render(http.StatusOK, "post.html", data)
 }

--- a/bskyweb/templates/post.html
+++ b/bskyweb/templates/post.html
@@ -25,8 +25,10 @@
   <meta name="description" content="{{ postView.Record.Val.Text }}">
   <meta property="og:description" content="{{ postView.Record.Val.Text }}">
   {% endif -%}
-  {%- if imgThumbUrl %}
+  {%- if imgThumbUrls %}
+  {% for imgThumbUrl in imgThumbUrls %}
   <meta property="og:image" content="{{ imgThumbUrl }}">
+  {% endfor %}
   <meta name="twitter:card" content="summary_large_image">
   {%- elif postView.Author.Avatar %}
   {# Don't use avatar image in cards; usually looks bad #}


### PR DESCRIPTION
in the og spec this is an array: https://ogp.me/#array

this has been used by other large sites (for example twitter, before they removed all the meta tags anyway), so it shouldn't be dangerous