### PR TITLE
Fixes to feed load triggers

### DIFF
--- a/src/view/screens/Notifications.tsx
+++ b/src/view/screens/Notifications.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import {View} from 'react-native'
-import {useFocusEffect} from '@react-navigation/native'
+import {useFocusEffect, useIsFocused} from '@react-navigation/native'
 import {useQueryClient} from '@tanstack/react-query'
 import {
   NativeStackScreenProps,
@@ -46,6 +46,7 @@ export function NotificationsScreen({}: Props) {
   const unreadNotifs = useUnreadNotifications()
   const unreadApi = useUnreadNotificationsApi()
   const hasNew = !!unreadNotifs
+  const isScreenFocused = useIsFocused()
 
   // event handlers
   // =
@@ -83,8 +84,11 @@ export function NotificationsScreen({}: Props) {
     }, [screen, setMinimalShellMode]),
   )
   React.useEffect(() => {
+    if (!isScreenFocused) {
+      return
+    }
     return listenSoftReset(onPressLoadLatest)
-  }, [onPressLoadLatest])
+  }, [onPressLoadLatest, isScreenFocused])
 
   const ListHeaderComponent = React.useCallback(() => {
     if (isDesktop) {

--- a/src/view/screens/ProfileFeed.tsx
+++ b/src/view/screens/ProfileFeed.tsx
@@ -57,6 +57,7 @@ import {useLikeMutation, useUnlikeMutation} from '#/state/queries/like'
 import {useComposerControls} from '#/state/shell/composer'
 import {truncateAndInvalidate} from '#/state/queries/util'
 import {isNative} from '#/platform/detection'
+import {listenSoftReset} from '#/state/events'
 
 const SECTION_TITLES = ['Posts', 'About']
 
@@ -446,6 +447,7 @@ const FeedSection = React.forwardRef<SectionRef, FeedSectionProps>(
     const [hasNew, setHasNew] = React.useState(false)
     const [isScrolledDown, setIsScrolledDown] = React.useState(false)
     const queryClient = useQueryClient()
+    const isScreenFocused = useIsFocused()
 
     const onScrollToTop = useCallback(() => {
       scrollElRef.current?.scrollToOffset({
@@ -459,6 +461,13 @@ const FeedSection = React.forwardRef<SectionRef, FeedSectionProps>(
     React.useImperativeHandle(ref, () => ({
       scrollToTop: onScrollToTop,
     }))
+
+    React.useEffect(() => {
+      if (!isScreenFocused) {
+        return
+      }
+      return listenSoftReset(onScrollToTop)
+    }, [onScrollToTop, isScreenFocused])
 
     const renderPostsEmpty = useCallback(() => {
       return <EmptyState icon="feed" message="This feed is empty!" />

--- a/src/view/screens/ProfileList.tsx
+++ b/src/view/screens/ProfileList.tsx
@@ -57,6 +57,7 @@ import {
 } from '#/state/queries/preferences'
 import {logger} from '#/logger'
 import {useAnalytics} from '#/lib/analytics/analytics'
+import {listenSoftReset} from '#/state/events'
 
 const SECTION_TITLES_CURATE = ['Posts', 'About']
 const SECTION_TITLES_MOD = ['About']
@@ -601,6 +602,7 @@ const FeedSection = React.forwardRef<SectionRef, FeedSectionProps>(
     const queryClient = useQueryClient()
     const [hasNew, setHasNew] = React.useState(false)
     const [isScrolledDown, setIsScrolledDown] = React.useState(false)
+    const isScreenFocused = useIsFocused()
 
     const onScrollToTop = useCallback(() => {
       scrollElRef.current?.scrollToOffset({
@@ -613,6 +615,13 @@ const FeedSection = React.forwardRef<SectionRef, FeedSectionProps>(
     React.useImperativeHandle(ref, () => ({
       scrollToTop: onScrollToTop,
     }))
+
+    React.useEffect(() => {
+      if (!isScreenFocused) {
+        return
+      }
+      return listenSoftReset(onScrollToTop)
+    }, [onScrollToTop, isScreenFocused])
 
     const renderPostsEmpty = useCallback(() => {
       return <EmptyState icon="feed" message="This feed is empty!" />


### PR DESCRIPTION
- fcc6d770b71fd7a0e9a5db09429b6c6fb412037e Adds soft-reset to feeds and lists (makes it so clicking the header title works again)
- 14653ef1152f5720cda463b5a1aea7f981e2a4e4 Fixes an issue that was causing the notifications to keep listening to soft resets when not focused