### PR TITLE
Update IS_PROD check

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -45,7 +45,15 @@ export function IS_STAGING(url: string) {
 }
 
 export function IS_PROD(url: string) {
-  return !IS_LOCAL_DEV(url) && !IS_STAGING(url)
+  // NOTE
+  // until open federation, "production" is defined as the main server
+  // this definition will not work once federation is enabled!
+  // -prf
+  return (
+    url.startsWith('https://bsky.social') ||
+    url.startsWith('https://api.bsky.app') ||
+    /bsky\.network\/?$/.test(url)
+  )
 }
 
 export const PROD_TEAM_HANDLES = [

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -41,7 +41,7 @@ export function IS_LOCAL_DEV(url: string) {
 }
 
 export function IS_STAGING(url: string) {
-  return url.startsWith('https://staging.bsky.app')
+  return url.startsWith('https://staging.bsky.dev')
 }
 
 export function IS_PROD(url: string) {

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -41,18 +41,11 @@ export function IS_LOCAL_DEV(url: string) {
 }
 
 export function IS_STAGING(url: string) {
-  return !IS_LOCAL_DEV(url) && !IS_PROD(url)
+  return url.startsWith('https://staging.bsky.app')
 }
 
 export function IS_PROD(url: string) {
-  // NOTE
-  // until open federation, "production" is defined as the main server
-  // this definition will not work once federation is enabled!
-  // -prf
-  return (
-    url.startsWith('https://bsky.social') ||
-    url.startsWith('https://api.bsky.app')
-  )
+  return !IS_LOCAL_DEV(url) && !IS_STAGING(url)
 }
 
 export const PROD_TEAM_HANDLES = [


### PR DESCRIPTION
Fix #2313 

What this PR does is **assumes we're in production unless we match a localhost PDS URL, OR our staging PDS URL.** This means that the SANDBOX warning labels **only show for local dev and on staging.**