### PR TITLE
Fix various issues with screen dimension detection in external player

### DIFF
--- a/src/view/com/util/post-embeds/ExternalPlayerEmbed.tsx
+++ b/src/view/com/util/post-embeds/ExternalPlayerEmbed.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import {
   ActivityIndicator,
-  Dimensions,
   GestureResponderEvent,
   Pressable,
   StyleSheet,
+  useWindowDimensions,
   View,
 } from 'react-native'
 import {Image} from 'expo-image'
@@ -118,6 +118,7 @@ export function ExternalPlayer({
 }) {
   const navigation = useNavigation<NavigationProp>()
   const insets = useSafeAreaInsets()
+  const windowDims = useWindowDimensions()
 
   const [isPlayerActive, setPlayerActive] = React.useState(false)
   const [isLoading, setIsLoading] = React.useState(true)
@@ -141,22 +142,23 @@ export function ExternalPlayer({
 
     const interval = setInterval(() => {
       viewRef.current?.measure((x, y, w, h, pageX, pageY) => {
-        const {height: screenHeight, width: screenWidth} =
-          Dimensions.get('window')
+        const {height: winHeight, width: winWidth} = windowDims
 
         // Get the proper screen height depending on what is going on
-        const realScreenHeight = isNative // If it is native, we always want the larger number
-          ? screenHeight > screenWidth
-            ? screenHeight
-            : screenWidth
-          : screenHeight // On web, we always want the actual screen height
+        const realWinHeight = isNative // If it is native, we always want the larger number
+          ? winHeight > winWidth
+            ? winHeight
+            : winWidth
+          : winHeight // On web, we always want the actual screen height
+
+        console.log(realWinHeight)
 
         const top = pageY
         const bot = pageY + h
 
         // We can use the same logic on all platforms against the screenHeight that we get above
         const isVisible =
-          top <= realScreenHeight - insets.bottom && bot >= insets.top
+          top <= realWinHeight - insets.bottom && bot >= insets.top
         if (!isVisible) {
           setPlayerActive(false)
         }
@@ -167,7 +169,7 @@ export function ExternalPlayer({
       unsubscribe()
       clearInterval(interval)
     }
-  }, [viewRef, navigation, isPlayerActive, insets])
+  }, [viewRef, navigation, isPlayerActive, windowDims, insets])
 
   // calculate height for the player and the screen size
   const height = React.useMemo(

--- a/src/view/com/util/post-embeds/ExternalPlayerEmbed.tsx
+++ b/src/view/com/util/post-embeds/ExternalPlayerEmbed.tsx
@@ -151,8 +151,6 @@ export function ExternalPlayer({
             : winWidth
           : winHeight // On web, we always want the actual screen height
 
-        console.log(realWinHeight)
-
         const top = pageY
         const bot = pageY + h
 


### PR DESCRIPTION
This resolves https://github.com/bluesky-social/social-app/issues/2326 as well as normalizes the active/inactive logic on all platforms.

1. The position of the item in the feed never actually changes on native, since landscape is disabled in the app. Therefore, when the screen rotates in the native full screen player, we need to take that into account. Here we will use either the window height when in portrait or the window width when in landscape to get the "real height" of the feed. Desktop behavior stays the same. This is working on both iOS and Android now.
2. Instead of checking against static values like 0 and screenHeight when determining whether or not to dismiss the player, we instead use the safe area insets.
 - If the bottom of the player reaches the top of the safe area, then we dismiss. Likewise, if the top reaches the bottom of the safe area we do the same.
 - This normalizes dismiss behavior on all platforms. Currently on Android, the video may dismiss even if it is just *barely* off screen. On web, the player would sometimes not dismiss until significant scrolling had occurred.
 - This logic works on all platforms, so the only platform-specific check that has to be done is the check from # 1
3. Stop running the interval if the player isn't actually active.

If we were only concerned with native, we could have just used the static `Dimensions.get('window')` outside of the component and it would remain stable, removing the need to check. This won't work on web though since the user can resize their window as they desire.