### PR TITLE
Disable BlurView on android

### DIFF
--- a/src/view/com/modals/report/InputIssueDetails.tsx
+++ b/src/view/com/modals/report/InputIssueDetails.tsx
@@ -42,7 +42,8 @@ export function InputIssueDetails({
         accessibilityHint="Add more details to your report">
         <FontAwesomeIcon size={18} icon="angle-left" style={[pal.link]} />
         <Text style={[pal.text, s.f18, pal.link]}>
-          <Trans> Back</Trans>
+          {' '}
+          <Trans>Back</Trans>
         </Text>
       </TouchableOpacity>
       <View style={[pal.btn, styles.detailsInputContainer]}>

--- a/src/view/com/modals/report/InputIssueDetails.tsx
+++ b/src/view/com/modals/report/InputIssueDetails.tsx
@@ -63,7 +63,7 @@ export function InputIssueDetails({
         />
         <View style={styles.detailsInputBottomBar}>
           <View style={styles.charCounter}>
-            <CharProgress key={details} count={details?.length || 0} />
+            <CharProgress count={details?.length || 0} />
           </View>
         </View>
       </View>

--- a/src/view/com/modals/report/InputIssueDetails.tsx
+++ b/src/view/com/modals/report/InputIssueDetails.tsx
@@ -63,7 +63,7 @@ export function InputIssueDetails({
         />
         <View style={styles.detailsInputBottomBar}>
           <View style={styles.charCounter}>
-            <CharProgress count={details?.length || 0} />
+            <CharProgress key={details} count={details?.length || 0} />
           </View>
         </View>
       </View>

--- a/src/view/com/modals/report/Modal.tsx
+++ b/src/view/com/modals/report/Modal.tsx
@@ -44,9 +44,9 @@ export function Component(content: ReportComponentProps) {
   const {isMobile} = useWebMediaQueries()
   const [isProcessing, setIsProcessing] = useState(false)
   const [showDetailsInput, setShowDetailsInput] = useState(false)
-  const [error, setError] = useState<string>()
-  const [issue, setIssue] = useState<string>()
-  const [details, setDetails] = useState<string>()
+  const [error, setError] = useState<string>('')
+  const [issue, setIssue] = useState<string>('')
+  const [details, setDetails] = useState<string>('')
   const isAccountReport = 'did' in content
   const subjectKey = isAccountReport ? content.did : content.uri
   const atUri = useMemo(

--- a/src/view/com/util/BlurView.android.tsx
+++ b/src/view/com/util/BlurView.android.tsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import {StyleSheet, View, ViewProps} from 'react-native'
+import {addStyle} from 'lib/styles'
+
+type BlurViewProps = ViewProps & {
+  blurType?: 'dark' | 'light'
+  blurAmount?: number
+}
+
+export const BlurView = ({
+  style,
+  blurType,
+  ...props
+}: React.PropsWithChildren<BlurViewProps>) => {
+  if (blurType === 'dark') {
+    style = addStyle(style, styles.dark)
+  } else {
+    style = addStyle(style, styles.light)
+  }
+  return <View style={style} {...props} />
+}
+
+const styles = StyleSheet.create({
+  dark: {
+    backgroundColor: '#0008',
+  },
+  light: {
+    backgroundColor: '#fff8',
+  },
+})


### PR DESCRIPTION
Something is horribly wrong here.

We've had various reports from users that a `<TextInput>` will drop user input. Then we got #2344 reported, which gave us two lucky breaks:

1. [A video](https://www.youtube.com/watch?v=e66IKwV7vi4&t=17s)
2. I could repro it in the simulator, thank god

With the repro I massively struggled to figure out the _cause_ of this. Here are all of the bizarre behaviors:

- The input does actually occur, it's just that the text is invisible. You can actually select the invisible text.
- The `onChange` fires and the value is updated and the correct string is passed into the `<TextInput>`.
- Despite the value updating, the `<CharCounter>` wasn't updating either.

I tested a variety of possible causes. I pulled out everything to do with BottomSheet. I removed all properties on the `<TextInput>`. I turned off autocomplete, autocorrect, etc. I also googled this aggressively and tried a variety of known hackfixes. None of this had any effect.

The `<CharCounter>` failing to update despite the value changing was the final clue. That led me to do 569ce385f8870ed5f6c47fff1390bb61825a7b34 which simply sets a `key` on _any_ component in the render tree, and bizarrely that fixed both of the problems.

What this suggests to me is that somehow the render is failing to make its way through the react/react-native pipeline. I have absolutely no idea how that could be happening.

---

UPDATE

My god. I kept digging after this and discovered that running a `setInterval` in the header of a profile would show similar characteristics -- the UI would just stop updating -- but in the header of the home screen this didn't happen. Then I noticed that scrolling down a little bit in the profile fix this problem entirely.

Turns out, the `@react-native-community/blur` `<BlurView>` being used for the background of the back button was to blame. As soon as that was out of view, everything worked fine.

I need a drink.