### PR TITLE
Use memory caching for android lightbox

### DIFF
--- a/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.android.tsx
+++ b/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.android.tsx
@@ -320,6 +320,7 @@ const ImageItem = ({
           accessibilityLabel={imageSrc.alt}
           accessibilityHint=""
           onLoad={() => setIsLoaded(true)}
+          cachePolicy="memory"
         />
       </GestureDetector>
     </Animated.View>


### PR DESCRIPTION
For some reason, avatars were not consistently showing in the lightbox. I was able to repro this by going to a profile and tapping the profile multiple times -- after the first time, it would consistently fail to show. For some reason, this doesn't happen for embedded posts.

I tried changing a number of things in the lightbox to isolate the cause, and ultimately narrowed it down to the caching behavior. No idea _why_ but memory caching solved it.