### PR TITLE
Change paddingTop to marginTop for web emoji picker (EmojiPicker.web.tsx)

### DIFF
--- a/src/view/com/composer/text-input/web/EmojiPicker.web.tsx
+++ b/src/view/com/composer/text-input/web/EmojiPicker.web.tsx
@@ -50,8 +50,8 @@ export function EmojiPicker({close}: {close: () => void}) {
     textInputWebEmitter.emit('emoji-inserted', emoji)
     close()
   }
-  const reducedPadding = useMediaQuery({query: '(max-height: 750px)'})
-  const noPadding = useMediaQuery({query: '(max-height: 550px)'})
+  const reducedMargin = useMediaQuery({query: '(max-height: 750px)'})
+  const noMargin = useMediaQuery({query: '(max-height: 550px)'})
   const noPicker = useMediaQuery({query: '(max-height: 350px)'})
 
   return (
@@ -67,7 +67,7 @@ export function EmojiPicker({close}: {close: () => void}) {
             style={[
               styles.picker,
               {
-                paddingTop: noPadding ? 0 : reducedPadding ? 150 : 325,
+                marginTop: noMargin ? 0 : reducedMargin ? 150 : 325,
                 display: noPicker ? 'none' : 'flex',
               },
             ]}>


### PR DESCRIPTION
I was going to open an issue, but I figured this would be a quick CSS fix I could do. Currently when opening the emoji picker on web, you can't close it in a significant amount of screen space due to the `padding` lacking pointer events. See attached screenshot. There's a `padding-right: 50px` as well that seems unavoidable regarding `marginHorizontal: auto` without something hacky to my hobby-level CSS knowledge in order to get the emoji picker to line up, but changing the `padding-top` to `margin-top` mostly resolves the issue. There are no secondary effects that I can tell due to the vertically fixed position of the emoji picker and post composer.

As a side note, it'd be nice if SHIFT+LMB did not close the emoji picker in order to allow for multiple emojis to be selected similar to how it works in Discord, but I don't know enough about the libraries to tweak `onEmojiSelect` or `onInsert` confidently. 

![image](https://github.com/bluesky-social/social-app/assets/20595808/89de9526-5bca-4c79-a5cf-a3a7a4396ca2)
