### PR TITLE
Improve emoji picker dismissability 

### DIFF
--- a/src/view/com/composer/text-input/web/EmojiPicker.web.tsx
+++ b/src/view/com/composer/text-input/web/EmojiPicker.web.tsx
@@ -50,8 +50,8 @@ export function EmojiPicker({close}: {close: () => void}) {
     textInputWebEmitter.emit('emoji-inserted', emoji)
     close()
   }
-  const reducedPadding = useMediaQuery({query: '(max-height: 750px)'})
-  const noPadding = useMediaQuery({query: '(max-height: 550px)'})
+  const reducedMargin = useMediaQuery({query: '(max-height: 750px)'})
+  const noMargin = useMediaQuery({query: '(max-height: 550px)'})
   const noPicker = useMediaQuery({query: '(max-height: 350px)'})
 
   return (
@@ -67,7 +67,7 @@ export function EmojiPicker({close}: {close: () => void}) {
             style={[
               styles.picker,
               {
-                paddingTop: noPadding ? 0 : reducedPadding ? 150 : 325,
+                marginTop: noMargin ? 0 : reducedMargin ? 150 : 325,
                 display: noPicker ? 'none' : 'flex',
               },
             ]}>

--- a/src/view/com/composer/text-input/web/EmojiPicker.web.tsx
+++ b/src/view/com/composer/text-input/web/EmojiPicker.web.tsx
@@ -50,9 +50,9 @@ export function EmojiPicker({close}: {close: () => void}) {
     textInputWebEmitter.emit('emoji-inserted', emoji)
     close()
   }
-  const reducedMargin = useMediaQuery({query: '(max-height: 750px)'})
-  const noMargin = useMediaQuery({query: '(max-height: 550px)'})
-  const noPicker = useMediaQuery({query: '(max-height: 350px)'})
+  const screenMedium = useMediaQuery({query: '(max-height: 750px)'})
+  const screenShort = useMediaQuery({query: '(max-height: 550px)'})
+  const screenTiny = useMediaQuery({query: '(max-height: 350px)'})
 
   return (
     // eslint-disable-next-line react-native-a11y/has-valid-accessibility-descriptors
@@ -67,8 +67,11 @@ export function EmojiPicker({close}: {close: () => void}) {
             style={[
               styles.picker,
               {
-                marginTop: noMargin ? 0 : reducedMargin ? 150 : 325,
-                display: noPicker ? 'none' : 'flex',
+                transform: [
+                  {translateX: -25},
+                  {translateY: screenShort ? 0 : screenMedium ? 150 : 325},
+                ],
+                display: screenTiny ? 'none' : 'flex',
               },
             ]}>
             <Picker
@@ -105,6 +108,5 @@ const styles = StyleSheet.create({
   },
   picker: {
     marginHorizontal: 'auto',
-    paddingRight: 50,
   },
 })


### PR DESCRIPTION
All credit to @Juicysteak117 in #2367 for this fix, that PR just got me thinking we could probably do this with transforms so figured I'd knock it out quick.

Picker should now be closable when clicking anywhere outside the picker itself. No visual changes from prod otherwise.