### PR TITLE
Localize the option to make alt text mandatory

### DIFF
--- a/src/view/screens/Settings.tsx
+++ b/src/view/screens/Settings.tsx
@@ -419,7 +419,7 @@ export function SettingsScreen({}: Props) {
         <View style={[pal.view, styles.toggleCard]}>
           <ToggleButton
             type="default-light"
-            label="Require alt text before posting"
+            label={_(msg`Require alt text before posting`)}
             labelType="lg"
             isSelected={requireAltTextEnabled}
             onPress={() => setRequireAltTextEnabled(!requireAltTextEnabled)}


### PR DESCRIPTION
This PR adds marks for localization to the option to make alt text mandatory, which is left out of the localization in the Settings screen.

Sorry to disturb you with minor localization patches.
Many thanks!