### PR TITLE
fix web thumbnail resizing

### DIFF
--- a/src/lib/media/manip.web.ts
+++ b/src/lib/media/manip.web.ts
@@ -117,9 +117,6 @@ function createResizedImage(
         return reject(new Error('Failed to resize image'))
       }
 
-      canvas.width = width
-      canvas.height = height
-
       let scale = 1
       if (mode === 'cover') {
         scale = img.width < img.height ? width / img.width : height / img.height
@@ -128,10 +125,11 @@ function createResizedImage(
       }
       let w = img.width * scale
       let h = img.height * scale
-      let x = (width - w) / 2
-      let y = (height - h) / 2
 
-      ctx.drawImage(img, x, y, w, h)
+      canvas.width = w
+      canvas.height = h
+
+      ctx.drawImage(img, 0, 0, w, h)
       resolve(canvas.toDataURL('image/jpeg', quality))
     })
     img.src = dataUri

--- a/src/view/com/util/post-embeds/ExternalLinkEmbed.tsx
+++ b/src/view/com/util/post-embeds/ExternalLinkEmbed.tsx
@@ -90,8 +90,7 @@ export const ExternalLinkEmbed = ({
 
 const styles = StyleSheet.create({
   extImage: {
-    width: '100%',
-    height: 200,
+    flex: 1,
   },
   extUri: {
     marginTop: 2,


### PR DESCRIPTION
Right now when resizing thumbnails on web, the image gets drawn to a canvas that starts the drawing at a y or x value based on the scale of the image. In some cases where images are landscape, this is problematic. See: https://bsky.app/profile/retr0.id/post/3khpgllcczr2j

We should always set the x and y axes to start drawing at (0,0). The height and width of the canvas should be set to the scaled height and width of the image.

Before: 
![Screenshot 2023-12-29 at 3 49 17 PM](https://github.com/bluesky-social/social-app/assets/153161762/4c38aef2-aa2f-4493-a367-a26501b2eb21)

After: 
![Screenshot 2023-12-29 at 3 58 22 PM](https://github.com/bluesky-social/social-app/assets/153161762/ec724082-38a6-4f4d-856f-fe5268d023f1)

Note still though that the image is a bit too zoomed in. This was an error in the styles. Right now, there's a style applied to the image that sets the height to 200 regardless of platform, while the container is set to 200 on native and 120 on web. I fixed that by just applying `flex: 1` to the image so it conforms to the correct bounds on all platforms.

Now they resize correctly and appear correctly on both platforms.

![Screenshot 2023-12-29 at 4 44 32 PM](https://github.com/bluesky-social/social-app/assets/153161762/5b4261be-02b6-4809-9220-1b051f27c0a7)
