### PR TITLE
patch expo-image-picker to support "browse" on android

### DIFF
--- a/patches/expo-image-picker+14.7.1.patch
+++ b/patches/expo-image-picker+14.7.1.patch
@@ -1,0 +1,64 @@
+diff --git a/node_modules/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/ImageLibraryContract.kt b/node_modules/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/ImageLibraryContract.kt
+index ff15c91..bc868d1 100644
+--- a/node_modules/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/ImageLibraryContract.kt
++++ b/node_modules/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/ImageLibraryContract.kt
+@@ -26,30 +26,16 @@ import java.io.Serializable
+  * @see [androidx.activity.result.contract.ActivityResultContracts.GetMultipleContents]
+  */
+ internal class ImageLibraryContract(
+-  private val appContextProvider: AppContextProvider
++  private val appContextProvider: AppContextProvider,
+ ) : AppContextActivityResultContract<ImageLibraryContractOptions, ImagePickerContractResult> {
+   private val contentResolver: ContentResolver
+     get() = appContextProvider.appContext.reactContext?.contentResolver
+       ?: throw Exceptions.ReactContextLost()
+ 
+   override fun createIntent(context: Context, input: ImageLibraryContractOptions): Intent {
+-    val request = PickVisualMediaRequest.Builder()
+-      .setMediaType(
+-        when (input.options.mediaTypes) {
+-          MediaTypes.VIDEOS -> {
+-            PickVisualMedia.VideoOnly
+-          }
+-
+-          MediaTypes.IMAGES -> {
+-            PickVisualMedia.ImageOnly
+-          }
+-
+-          else -> {
+-            PickVisualMedia.ImageAndVideo
+-          }
+-        }
+-      )
+-      .build()
++    val intent = Intent(Intent.ACTION_GET_CONTENT)
++            .addCategory(Intent.CATEGORY_OPENABLE)
++            .setType("image/*")
+ 
+     if (input.options.allowsMultipleSelection) {
+       val selectionLimit = input.options.selectionLimit
+@@ -57,20 +43,20 @@ internal class ImageLibraryContract(
+       if (selectionLimit == 1) {
+         // If multiple selection is allowed but the limit is 1, we should ignore
+         // the multiple selection flag and just treat it as a single selection.
+-        return PickVisualMedia().createIntent(context, request)
++        intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, 1)
+       }
+ 
+       if (selectionLimit > 1) {
+-        return PickMultipleVisualMedia(selectionLimit).createIntent(context, request)
++        intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, selectionLimit)
+       }
+ 
+       // If the selection limit is 0, it is the same as unlimited selection.
+       if (selectionLimit == UNLIMITED_SELECTION) {
+-        return PickMultipleVisualMedia().createIntent(context, request)
++        intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true)
+       }
+     }
+ 
+-    return PickVisualMedia().createIntent(context, request)
++    return intent
+   }
+ 
+   override fun parseResult(input: ImageLibraryContractOptions, resultCode: Int, intent: Intent?) =

--- a/patches/expo-image-picker+14.7.1.patch
+++ b/patches/expo-image-picker+14.7.1.patch
@@ -1,8 +1,1287 @@
+diff --git a/node_modules/expo-image-picker/android/build/.transforms/54f160321aabf84ba1261ef99240b1d4/results.bin b/node_modules/expo-image-picker/android/build/.transforms/54f160321aabf84ba1261ef99240b1d4/results.bin
+new file mode 100644
+index 0000000..61a58fa
+--- /dev/null
++++ b/node_modules/expo-image-picker/android/build/.transforms/54f160321aabf84ba1261ef99240b1d4/results.bin
+@@ -0,0 +1 @@
++i/classes_dex
+diff --git a/node_modules/expo-image-picker/android/build/.transforms/5eb5c83568b220f4a5aabe44f90ea803/results.bin b/node_modules/expo-image-picker/android/build/.transforms/5eb5c83568b220f4a5aabe44f90ea803/results.bin
+new file mode 100644
+index 0000000..e3f0ff0
+--- /dev/null
++++ b/node_modules/expo-image-picker/android/build/.transforms/5eb5c83568b220f4a5aabe44f90ea803/results.bin
+@@ -0,0 +1 @@
++i/classes_global-synthetics
+diff --git a/node_modules/expo-image-picker/android/build/.transforms/b1869b7bbefffaeda4e3781b9873b757/results.bin b/node_modules/expo-image-picker/android/build/.transforms/b1869b7bbefffaeda4e3781b9873b757/results.bin
+new file mode 100644
+index 0000000..28bb879
+--- /dev/null
++++ b/node_modules/expo-image-picker/android/build/.transforms/b1869b7bbefffaeda4e3781b9873b757/results.bin
+@@ -0,0 +1 @@
++o/classes.jar
+diff --git a/node_modules/expo-image-picker/android/build/.transforms/b1869b7bbefffaeda4e3781b9873b757/transformed/classes.jar b/node_modules/expo-image-picker/android/build/.transforms/b1869b7bbefffaeda4e3781b9873b757/transformed/classes.jar
+new file mode 100644
+index 0000000..6a26189
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/.transforms/b1869b7bbefffaeda4e3781b9873b757/transformed/classes.jar differ
+diff --git a/node_modules/expo-image-picker/android/build/.transforms/b7e7c9414109b0293abaf28b7bcb21a6/results.bin b/node_modules/expo-image-picker/android/build/.transforms/b7e7c9414109b0293abaf28b7bcb21a6/results.bin
+new file mode 100644
+index 0000000..0d259dd
+--- /dev/null
++++ b/node_modules/expo-image-picker/android/build/.transforms/b7e7c9414109b0293abaf28b7bcb21a6/results.bin
+@@ -0,0 +1 @@
++o/classes
+diff --git a/node_modules/expo-image-picker/android/build/.transforms/b7e7c9414109b0293abaf28b7bcb21a6/transformed/classes/classes_dex/classes.dex b/node_modules/expo-image-picker/android/build/.transforms/b7e7c9414109b0293abaf28b7bcb21a6/transformed/classes/classes_dex/classes.dex
+new file mode 100644
+index 0000000..30c848d
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/.transforms/b7e7c9414109b0293abaf28b7bcb21a6/transformed/classes/classes_dex/classes.dex differ
+diff --git a/node_modules/expo-image-picker/android/build/generated/source/buildConfig/debug/expo/modules/imagepicker/BuildConfig.java b/node_modules/expo-image-picker/android/build/generated/source/buildConfig/debug/expo/modules/imagepicker/BuildConfig.java
+new file mode 100644
+index 0000000..c084b78
+--- /dev/null
++++ b/node_modules/expo-image-picker/android/build/generated/source/buildConfig/debug/expo/modules/imagepicker/BuildConfig.java
+@@ -0,0 +1,10 @@
++/**
++ * Automatically generated file. DO NOT MODIFY
++ */
++package expo.modules.imagepicker;
++
++public final class BuildConfig {
++  public static final boolean DEBUG = Boolean.parseBoolean("true");
++  public static final String LIBRARY_PACKAGE_NAME = "expo.modules.imagepicker";
++  public static final String BUILD_TYPE = "debug";
++}
+diff --git a/node_modules/expo-image-picker/android/build/intermediates/aapt_friendly_merged_manifests/debug/aapt/AndroidManifest.xml b/node_modules/expo-image-picker/android/build/intermediates/aapt_friendly_merged_manifests/debug/aapt/AndroidManifest.xml
+new file mode 100644
+index 0000000..6ced075
+--- /dev/null
++++ b/node_modules/expo-image-picker/android/build/intermediates/aapt_friendly_merged_manifests/debug/aapt/AndroidManifest.xml
+@@ -0,0 +1,59 @@
++<?xml version="1.0" encoding="utf-8"?>
++<manifest xmlns:android="http://schemas.android.com/apk/res/android"
++    xmlns:tools="http://schemas.android.com/tools"
++    package="expo.modules.imagepicker" >
++
++    <uses-sdk android:minSdkVersion="21" />
++    <!-- Required for picking images from camera directly -->
++    <uses-permission android:name="android.permission.CAMERA" />
++
++    <!-- Required for picking images from camera roll -->
++    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
++    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
++    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
++    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
++
++    <queries>
++        <intent>
++
++            <!-- Required for picking images from the camera roll if targeting API 30 -->
++            <action android:name="android.media.action.IMAGE_CAPTURE" />
++        </intent>
++        <intent>
++
++            <!-- Required for picking images from the camera if targeting API 30 -->
++            <action android:name="android.media.action.ACTION_VIDEO_CAPTURE" />
++        </intent>
++    </queries>
++
++    <application>
++        <service
++            android:name="com.google.android.gms.metadata.ModuleDependencies"
++            android:enabled="false"
++            android:exported="false"
++            tools:ignore="MissingClass" >
++            <intent-filter>
++                <action android:name="com.google.android.gms.metadata.MODULE_DEPENDENCIES" />
++            </intent-filter>
++
++            <meta-data
++                android:name="photopicker_activity:0:required"
++                android:value="" />
++        </service>
++
++        <activity
++            android:name="com.canhub.cropper.CropImageActivity"
++            android:theme="@style/Base.Theme.AppCompat" />
++        <!-- https://developer.android.com/guide/topics/manifest/provider-element.html -->
++        <provider
++            android:name="expo.modules.imagepicker.fileprovider.ImagePickerFileProvider"
++            android:authorities="dollar_openBracket_applicationId_closeBracket.ImagePickerFileProvider"
++            android:exported="false"
++            android:grantUriPermissions="true" >
++            <meta-data
++                android:name="android.support.FILE_PROVIDER_PATHS"
++                android:resource="@xml/image_picker_provider_paths" />
++        </provider>
++    </application>
++
++</manifest>
+\ No newline at end of file
+diff --git a/node_modules/expo-image-picker/android/build/intermediates/aapt_friendly_merged_manifests/debug/aapt/output-metadata.json b/node_modules/expo-image-picker/android/build/intermediates/aapt_friendly_merged_manifests/debug/aapt/output-metadata.json
+new file mode 100644
+index 0000000..694308a
+--- /dev/null
++++ b/node_modules/expo-image-picker/android/build/intermediates/aapt_friendly_merged_manifests/debug/aapt/output-metadata.json
+@@ -0,0 +1,18 @@
++{
++  "version": 3,
++  "artifactType": {
++    "type": "AAPT_FRIENDLY_MERGED_MANIFESTS",
++    "kind": "Directory"
++  },
++  "applicationId": "expo.modules.imagepicker",
++  "variantName": "debug",
++  "elements": [
++    {
++      "type": "SINGLE",
++      "filters": [],
++      "attributes": [],
++      "outputFile": "AndroidManifest.xml"
++    }
++  ],
++  "elementType": "File"
++}
+\ No newline at end of file
+diff --git a/node_modules/expo-image-picker/android/build/intermediates/aar_metadata/debug/aar-metadata.properties b/node_modules/expo-image-picker/android/build/intermediates/aar_metadata/debug/aar-metadata.properties
+new file mode 100644
+index 0000000..776557e
+--- /dev/null
++++ b/node_modules/expo-image-picker/android/build/intermediates/aar_metadata/debug/aar-metadata.properties
+@@ -0,0 +1,5 @@
++aarFormatVersion=1.0
++aarMetadataVersion=1.0
++minCompileSdk=1
++minCompileSdkExtension=0
++minAndroidGradlePluginVersion=1.0.0
+diff --git a/node_modules/expo-image-picker/android/build/intermediates/annotation_processor_list/debug/annotationProcessors.json b/node_modules/expo-image-picker/android/build/intermediates/annotation_processor_list/debug/annotationProcessors.json
+new file mode 100644
+index 0000000..9e26dfe
+--- /dev/null
++++ b/node_modules/expo-image-picker/android/build/intermediates/annotation_processor_list/debug/annotationProcessors.json
+@@ -0,0 +1 @@
++{}
+\ No newline at end of file
+diff --git a/node_modules/expo-image-picker/android/build/intermediates/compile_library_classes_jar/debug/classes.jar b/node_modules/expo-image-picker/android/build/intermediates/compile_library_classes_jar/debug/classes.jar
+new file mode 100644
+index 0000000..1403112
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/intermediates/compile_library_classes_jar/debug/classes.jar differ
+diff --git a/node_modules/expo-image-picker/android/build/intermediates/compile_r_class_jar/debug/R.jar b/node_modules/expo-image-picker/android/build/intermediates/compile_r_class_jar/debug/R.jar
+new file mode 100644
+index 0000000..35338b2
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/intermediates/compile_r_class_jar/debug/R.jar differ
+diff --git a/node_modules/expo-image-picker/android/build/intermediates/compile_symbol_list/debug/R.txt b/node_modules/expo-image-picker/android/build/intermediates/compile_symbol_list/debug/R.txt
+new file mode 100644
+index 0000000..41f932b
+--- /dev/null
++++ b/node_modules/expo-image-picker/android/build/intermediates/compile_symbol_list/debug/R.txt
+@@ -0,0 +1 @@
++int xml image_picker_provider_paths 0x0
+diff --git a/node_modules/expo-image-picker/android/build/intermediates/compiled_local_resources/debug/out/xml_image_picker_provider_paths.xml.flat b/node_modules/expo-image-picker/android/build/intermediates/compiled_local_resources/debug/out/xml_image_picker_provider_paths.xml.flat
+new file mode 100644
+index 0000000..f26d7f0
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/intermediates/compiled_local_resources/debug/out/xml_image_picker_provider_paths.xml.flat differ
+diff --git a/node_modules/expo-image-picker/android/build/intermediates/incremental/debug/packageDebugResources/compile-file-map.properties b/node_modules/expo-image-picker/android/build/intermediates/incremental/debug/packageDebugResources/compile-file-map.properties
+new file mode 100644
+index 0000000..0c5ebe0
+--- /dev/null
++++ b/node_modules/expo-image-picker/android/build/intermediates/incremental/debug/packageDebugResources/compile-file-map.properties
+@@ -0,0 +1,2 @@
++#Sun Dec 24 17:59:41 PST 2023
++expo.modules.imagepicker.expo-image-picker-main-6\:/xml/image_picker_provider_paths.xml=/Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/build/intermediates/packaged_res/debug/xml/image_picker_provider_paths.xml
+diff --git a/node_modules/expo-image-picker/android/build/intermediates/incremental/debug/packageDebugResources/merger.xml b/node_modules/expo-image-picker/android/build/intermediates/incremental/debug/packageDebugResources/merger.xml
+new file mode 100644
+index 0000000..1f6a787
+--- /dev/null
++++ b/node_modules/expo-image-picker/android/build/intermediates/incremental/debug/packageDebugResources/merger.xml
+@@ -0,0 +1,2 @@
++<?xml version="1.0" encoding="utf-8"?>
++<merger version="3"><dataSet aapt-namespace="http://schemas.android.com/apk/res-auto" config="main$Generated" generated="true" ignore_pattern="!.svn:!.git:!.ds_store:!*.scc:.*:&lt;dir>_*:!CVS:!thumbs.db:!picasa.ini:!*~"><source path="/Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/res"/></dataSet><dataSet aapt-namespace="http://schemas.android.com/apk/res-auto" config="main" generated-set="main$Generated" ignore_pattern="!.svn:!.git:!.ds_store:!*.scc:.*:&lt;dir>_*:!CVS:!thumbs.db:!picasa.ini:!*~"><source path="/Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/res"><file name="image_picker_provider_paths" path="/Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/res/xml/image_picker_provider_paths.xml" qualifiers="" type="xml"/></source></dataSet><dataSet aapt-namespace="http://schemas.android.com/apk/res-auto" config="debug$Generated" generated="true" ignore_pattern="!.svn:!.git:!.ds_store:!*.scc:.*:&lt;dir>_*:!CVS:!thumbs.db:!picasa.ini:!*~"><source path="/Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/debug/res"/></dataSet><dataSet aapt-namespace="http://schemas.android.com/apk/res-auto" config="debug" generated-set="debug$Generated" ignore_pattern="!.svn:!.git:!.ds_store:!*.scc:.*:&lt;dir>_*:!CVS:!thumbs.db:!picasa.ini:!*~"><source path="/Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/debug/res"/></dataSet><dataSet aapt-namespace="http://schemas.android.com/apk/res-auto" config="generated$Generated" generated="true" ignore_pattern="!.svn:!.git:!.ds_store:!*.scc:.*:&lt;dir>_*:!CVS:!thumbs.db:!picasa.ini:!*~"><source path="/Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/build/generated/res/resValues/debug"/></dataSet><dataSet aapt-namespace="http://schemas.android.com/apk/res-auto" config="generated" generated-set="generated$Generated" ignore_pattern="!.svn:!.git:!.ds_store:!*.scc:.*:&lt;dir>_*:!CVS:!thumbs.db:!picasa.ini:!*~"><source path="/Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/build/generated/res/resValues/debug"/></dataSet><mergedItems/></merger>
+\ No newline at end of file
+diff --git a/node_modules/expo-image-picker/android/build/intermediates/java_res/debug/out/META-INF/expo-image-picker_debug.kotlin_module b/node_modules/expo-image-picker/android/build/intermediates/java_res/debug/out/META-INF/expo-image-picker_debug.kotlin_module
+new file mode 100644
+index 0000000..d9206b6
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/intermediates/java_res/debug/out/META-INF/expo-image-picker_debug.kotlin_module differ
+diff --git a/node_modules/expo-image-picker/android/build/intermediates/javac/debug/classes/expo/modules/imagepicker/BuildConfig.class b/node_modules/expo-image-picker/android/build/intermediates/javac/debug/classes/expo/modules/imagepicker/BuildConfig.class
+new file mode 100644
+index 0000000..a18a322
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/intermediates/javac/debug/classes/expo/modules/imagepicker/BuildConfig.class differ
+diff --git a/node_modules/expo-image-picker/android/build/intermediates/local_only_symbol_list/debug/R-def.txt b/node_modules/expo-image-picker/android/build/intermediates/local_only_symbol_list/debug/R-def.txt
+new file mode 100644
+index 0000000..69743a7
+--- /dev/null
++++ b/node_modules/expo-image-picker/android/build/intermediates/local_only_symbol_list/debug/R-def.txt
+@@ -0,0 +1,3 @@
++R_DEF: Internal format may change without notice
++local
++xml image_picker_provider_paths
+diff --git a/node_modules/expo-image-picker/android/build/intermediates/manifest_merge_blame_file/debug/manifest-merger-blame-debug-report.txt b/node_modules/expo-image-picker/android/build/intermediates/manifest_merge_blame_file/debug/manifest-merger-blame-debug-report.txt
+new file mode 100644
+index 0000000..9cf9e0c
+--- /dev/null
++++ b/node_modules/expo-image-picker/android/build/intermediates/manifest_merge_blame_file/debug/manifest-merger-blame-debug-report.txt
+@@ -0,0 +1,99 @@
++1<?xml version="1.0" encoding="utf-8"?>
++2<manifest xmlns:android="http://schemas.android.com/apk/res/android"
++3    xmlns:tools="http://schemas.android.com/tools"
++4    package="expo.modules.imagepicker" >
++5
++6    <uses-sdk android:minSdkVersion="21" />
++7    <!-- Required for picking images from camera directly -->
++8    <uses-permission android:name="android.permission.CAMERA" />
++8-->/Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:4:3-63
++8-->/Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:4:20-60
++9
++10    <!-- Required for picking images from camera roll -->
++11    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
++11-->/Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:7:3-79
++11-->/Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:7:20-76
++12    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
++12-->/Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:8:3-78
++12-->/Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:8:20-75
++13    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
++13-->/Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:9:3-74
++13-->/Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:9:20-71
++14    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
++14-->/Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:10:3-73
++14-->/Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:10:20-70
++15
++16    <queries>
++16-->/Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:41:3-50:13
++17        <intent>
++17-->/Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:42:5-45:14
++18
++19            <!-- Required for picking images from the camera roll if targeting API 30 -->
++20            <action android:name="android.media.action.IMAGE_CAPTURE" />
++20-->/Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:44:7-67
++20-->/Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:44:15-64
++21        </intent>
++22        <intent>
++22-->/Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:46:5-49:14
++23
++24            <!-- Required for picking images from the camera if targeting API 30 -->
++25            <action android:name="android.media.action.ACTION_VIDEO_CAPTURE" />
++25-->/Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:48:7-74
++25-->/Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:48:15-71
++26        </intent>
++27    </queries>
++28
++29    <application>
++29-->/Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:12:3-39:17
++30        <service
++30-->/Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:13:5-24:15
++31            android:name="com.google.android.gms.metadata.ModuleDependencies"
++31-->/Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:14:7-72
++32            android:enabled="false"
++32-->/Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:15:7-30
++33            android:exported="false"
++33-->/Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:16:7-31
++34            tools:ignore="MissingClass" >
++34-->/Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:17:7-34
++35            <intent-filter>
++35-->/Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:18:7-20:23
++36                <action android:name="com.google.android.gms.metadata.MODULE_DEPENDENCIES" />
++36-->/Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:19:9-86
++36-->/Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:19:17-83
++37            </intent-filter>
++38
++39            <meta-data
++39-->/Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:21:7-23:28
++40                android:name="photopicker_activity:0:required"
++40-->/Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:22:9-55
++41                android:value="" />
++41-->/Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:23:9-25
++42        </service>
++43
++44        <activity
++44-->/Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:26:5-28:53
++45            android:name="com.canhub.cropper.CropImageActivity"
++45-->/Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:27:7-58
++46            android:theme="@style/Base.Theme.AppCompat" />
++46-->/Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:28:7-50
++47        <!-- https://developer.android.com/guide/topics/manifest/provider-element.html -->
++48        <provider
++48-->/Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:30:5-38:16
++49            android:name="expo.modules.imagepicker.fileprovider.ImagePickerFileProvider"
++49-->/Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:31:7-59
++50            android:authorities="${applicationId}.ImagePickerFileProvider"
++50-->/Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:32:7-69
++51            android:exported="false"
++51-->/Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:33:7-31
++52            android:grantUriPermissions="true" >
++52-->/Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:34:7-41
++53            <meta-data
++53-->/Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:35:7-37:63
++54                android:name="android.support.FILE_PROVIDER_PATHS"
++54-->/Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:36:9-59
++55                android:resource="@xml/image_picker_provider_paths" />
++55-->/Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:37:9-60
++56        </provider>
++57    </application>
++58
++59</manifest>
+diff --git a/node_modules/expo-image-picker/android/build/intermediates/merged_manifest/debug/AndroidManifest.xml b/node_modules/expo-image-picker/android/build/intermediates/merged_manifest/debug/AndroidManifest.xml
+new file mode 100644
+index 0000000..e22f8d2
+--- /dev/null
++++ b/node_modules/expo-image-picker/android/build/intermediates/merged_manifest/debug/AndroidManifest.xml
+@@ -0,0 +1,59 @@
++<?xml version="1.0" encoding="utf-8"?>
++<manifest xmlns:android="http://schemas.android.com/apk/res/android"
++    xmlns:tools="http://schemas.android.com/tools"
++    package="expo.modules.imagepicker" >
++
++    <uses-sdk android:minSdkVersion="21" />
++    <!-- Required for picking images from camera directly -->
++    <uses-permission android:name="android.permission.CAMERA" />
++
++    <!-- Required for picking images from camera roll -->
++    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
++    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
++    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
++    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
++
++    <queries>
++        <intent>
++
++            <!-- Required for picking images from the camera roll if targeting API 30 -->
++            <action android:name="android.media.action.IMAGE_CAPTURE" />
++        </intent>
++        <intent>
++
++            <!-- Required for picking images from the camera if targeting API 30 -->
++            <action android:name="android.media.action.ACTION_VIDEO_CAPTURE" />
++        </intent>
++    </queries>
++
++    <application>
++        <service
++            android:name="com.google.android.gms.metadata.ModuleDependencies"
++            android:enabled="false"
++            android:exported="false"
++            tools:ignore="MissingClass" >
++            <intent-filter>
++                <action android:name="com.google.android.gms.metadata.MODULE_DEPENDENCIES" />
++            </intent-filter>
++
++            <meta-data
++                android:name="photopicker_activity:0:required"
++                android:value="" />
++        </service>
++
++        <activity
++            android:name="com.canhub.cropper.CropImageActivity"
++            android:theme="@style/Base.Theme.AppCompat" />
++        <!-- https://developer.android.com/guide/topics/manifest/provider-element.html -->
++        <provider
++            android:name="expo.modules.imagepicker.fileprovider.ImagePickerFileProvider"
++            android:authorities="${applicationId}.ImagePickerFileProvider"
++            android:exported="false"
++            android:grantUriPermissions="true" >
++            <meta-data
++                android:name="android.support.FILE_PROVIDER_PATHS"
++                android:resource="@xml/image_picker_provider_paths" />
++        </provider>
++    </application>
++
++</manifest>
+\ No newline at end of file
+diff --git a/node_modules/expo-image-picker/android/build/intermediates/navigation_json/debug/navigation.json b/node_modules/expo-image-picker/android/build/intermediates/navigation_json/debug/navigation.json
+new file mode 100644
+index 0000000..0637a08
+--- /dev/null
++++ b/node_modules/expo-image-picker/android/build/intermediates/navigation_json/debug/navigation.json
+@@ -0,0 +1 @@
++[]
+\ No newline at end of file
+diff --git a/node_modules/expo-image-picker/android/build/intermediates/packaged_res/debug/xml/image_picker_provider_paths.xml b/node_modules/expo-image-picker/android/build/intermediates/packaged_res/debug/xml/image_picker_provider_paths.xml
+new file mode 100644
+index 0000000..975823c
+--- /dev/null
++++ b/node_modules/expo-image-picker/android/build/intermediates/packaged_res/debug/xml/image_picker_provider_paths.xml
+@@ -0,0 +1,6 @@
++<?xml version="1.0" encoding="utf-8"?>
++<paths>
++  <files-path name="expo_files" path="." />
++  <cache-path name="cached_expo_files" path="." />
++</paths>
++
+diff --git a/node_modules/expo-image-picker/android/build/intermediates/runtime_library_classes_jar/debug/classes.jar b/node_modules/expo-image-picker/android/build/intermediates/runtime_library_classes_jar/debug/classes.jar
+new file mode 100644
+index 0000000..827f6a6
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/intermediates/runtime_library_classes_jar/debug/classes.jar differ
+diff --git a/node_modules/expo-image-picker/android/build/intermediates/symbol_list_with_package_name/debug/package-aware-r.txt b/node_modules/expo-image-picker/android/build/intermediates/symbol_list_with_package_name/debug/package-aware-r.txt
+new file mode 100644
+index 0000000..14c08a2
+--- /dev/null
++++ b/node_modules/expo-image-picker/android/build/intermediates/symbol_list_with_package_name/debug/package-aware-r.txt
+@@ -0,0 +1,2 @@
++expo.modules.imagepicker
++xml image_picker_provider_paths
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/inputs/source-to-output.tab b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/inputs/source-to-output.tab
+new file mode 100644
+index 0000000..e985e45
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/inputs/source-to-output.tab differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/inputs/source-to-output.tab.keystream b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/inputs/source-to-output.tab.keystream
+new file mode 100644
+index 0000000..5522b5a
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/inputs/source-to-output.tab.keystream differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/inputs/source-to-output.tab.keystream.len b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/inputs/source-to-output.tab.keystream.len
+new file mode 100644
+index 0000000..0d5f119
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/inputs/source-to-output.tab.keystream.len differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/inputs/source-to-output.tab.len b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/inputs/source-to-output.tab.len
+new file mode 100644
+index 0000000..cf8a30a
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/inputs/source-to-output.tab.len differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/inputs/source-to-output.tab.values.at b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/inputs/source-to-output.tab.values.at
+new file mode 100644
+index 0000000..695b4ed
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/inputs/source-to-output.tab.values.at differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/inputs/source-to-output.tab_i b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/inputs/source-to-output.tab_i
+new file mode 100644
+index 0000000..fcd7532
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/inputs/source-to-output.tab_i differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/inputs/source-to-output.tab_i.len b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/inputs/source-to-output.tab_i.len
+new file mode 100644
+index 0000000..131e265
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/inputs/source-to-output.tab_i.len differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/class-attributes.tab b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/class-attributes.tab
+new file mode 100644
+index 0000000..b176bc1
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/class-attributes.tab differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/class-attributes.tab.keystream b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/class-attributes.tab.keystream
+new file mode 100644
+index 0000000..4654a88
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/class-attributes.tab.keystream differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/class-attributes.tab.keystream.len b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/class-attributes.tab.keystream.len
+new file mode 100644
+index 0000000..288d1b3
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/class-attributes.tab.keystream.len differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/class-attributes.tab.len b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/class-attributes.tab.len
+new file mode 100644
+index 0000000..b67c227
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/class-attributes.tab.len differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/class-attributes.tab.values.at b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/class-attributes.tab.values.at
+new file mode 100644
+index 0000000..77edd30
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/class-attributes.tab.values.at differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/class-attributes.tab_i b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/class-attributes.tab_i
+new file mode 100644
+index 0000000..c6d029d
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/class-attributes.tab_i differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/class-attributes.tab_i.len b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/class-attributes.tab_i.len
+new file mode 100644
+index 0000000..131e265
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/class-attributes.tab_i.len differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/class-fq-name-to-source.tab b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/class-fq-name-to-source.tab
+new file mode 100644
+index 0000000..d0a7867
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/class-fq-name-to-source.tab differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/class-fq-name-to-source.tab.keystream b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/class-fq-name-to-source.tab.keystream
+new file mode 100644
+index 0000000..4654a88
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/class-fq-name-to-source.tab.keystream differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/class-fq-name-to-source.tab.keystream.len b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/class-fq-name-to-source.tab.keystream.len
+new file mode 100644
+index 0000000..288d1b3
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/class-fq-name-to-source.tab.keystream.len differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/class-fq-name-to-source.tab.len b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/class-fq-name-to-source.tab.len
+new file mode 100644
+index 0000000..b67c227
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/class-fq-name-to-source.tab.len differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/class-fq-name-to-source.tab.values.at b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/class-fq-name-to-source.tab.values.at
+new file mode 100644
+index 0000000..b3d7590
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/class-fq-name-to-source.tab.values.at differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/class-fq-name-to-source.tab_i b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/class-fq-name-to-source.tab_i
+new file mode 100644
+index 0000000..c6d029d
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/class-fq-name-to-source.tab_i differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/class-fq-name-to-source.tab_i.len b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/class-fq-name-to-source.tab_i.len
+new file mode 100644
+index 0000000..131e265
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/class-fq-name-to-source.tab_i.len differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/constants.tab b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/constants.tab
+new file mode 100644
+index 0000000..b69d9dd
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/constants.tab differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/constants.tab.keystream b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/constants.tab.keystream
+new file mode 100644
+index 0000000..38206fe
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/constants.tab.keystream differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/constants.tab.keystream.len b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/constants.tab.keystream.len
+new file mode 100644
+index 0000000..05301cb
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/constants.tab.keystream.len differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/constants.tab.len b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/constants.tab.len
+new file mode 100644
+index 0000000..a9f80ae
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/constants.tab.len differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/constants.tab.values.at b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/constants.tab.values.at
+new file mode 100644
+index 0000000..5cd5146
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/constants.tab.values.at differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/constants.tab_i b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/constants.tab_i
+new file mode 100644
+index 0000000..cbdfdfa
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/constants.tab_i differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/constants.tab_i.len b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/constants.tab_i.len
+new file mode 100644
+index 0000000..131e265
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/constants.tab_i.len differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/internal-name-to-source.tab b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/internal-name-to-source.tab
+new file mode 100644
+index 0000000..89e8172
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/internal-name-to-source.tab differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/internal-name-to-source.tab.keystream b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/internal-name-to-source.tab.keystream
+new file mode 100644
+index 0000000..1a42195
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/internal-name-to-source.tab.keystream differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/internal-name-to-source.tab.keystream.len b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/internal-name-to-source.tab.keystream.len
+new file mode 100644
+index 0000000..a57ce6c
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/internal-name-to-source.tab.keystream.len differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/internal-name-to-source.tab.len b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/internal-name-to-source.tab.len
+new file mode 100644
+index 0000000..68c8906
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/internal-name-to-source.tab.len differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/internal-name-to-source.tab.values.at b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/internal-name-to-source.tab.values.at
+new file mode 100644
+index 0000000..0e7cee8
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/internal-name-to-source.tab.values.at differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/internal-name-to-source.tab_i b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/internal-name-to-source.tab_i
+new file mode 100644
+index 0000000..08088ff
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/internal-name-to-source.tab_i differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/internal-name-to-source.tab_i.len b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/internal-name-to-source.tab_i.len
+new file mode 100644
+index 0000000..131e265
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/internal-name-to-source.tab_i.len differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/package-parts.tab b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/package-parts.tab
+new file mode 100644
+index 0000000..6bc1f56
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/package-parts.tab differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/package-parts.tab.keystream b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/package-parts.tab.keystream
+new file mode 100644
+index 0000000..e540dad
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/package-parts.tab.keystream differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/package-parts.tab.keystream.len b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/package-parts.tab.keystream.len
+new file mode 100644
+index 0000000..b701bcc
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/package-parts.tab.keystream.len differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/package-parts.tab.len b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/package-parts.tab.len
+new file mode 100644
+index 0000000..a9f80ae
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/package-parts.tab.len differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/package-parts.tab.values.at b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/package-parts.tab.values.at
+new file mode 100644
+index 0000000..33c7d6c
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/package-parts.tab.values.at differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/package-parts.tab_i b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/package-parts.tab_i
+new file mode 100644
+index 0000000..d8d9406
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/package-parts.tab_i differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/package-parts.tab_i.len b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/package-parts.tab_i.len
+new file mode 100644
+index 0000000..131e265
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/package-parts.tab_i.len differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/proto.tab b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/proto.tab
+new file mode 100644
+index 0000000..4b68038
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/proto.tab differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/proto.tab.keystream b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/proto.tab.keystream
+new file mode 100644
+index 0000000..cfe2ca9
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/proto.tab.keystream differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/proto.tab.keystream.len b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/proto.tab.keystream.len
+new file mode 100644
+index 0000000..6a5a0bc
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/proto.tab.keystream.len differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/proto.tab.len b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/proto.tab.len
+new file mode 100644
+index 0000000..709f734
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/proto.tab.len differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/proto.tab.values.at b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/proto.tab.values.at
+new file mode 100644
+index 0000000..5abaaac
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/proto.tab.values.at differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/proto.tab_i b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/proto.tab_i
+new file mode 100644
+index 0000000..14c229c
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/proto.tab_i differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/proto.tab_i.len b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/proto.tab_i.len
+new file mode 100644
+index 0000000..131e265
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/proto.tab_i.len differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/source-to-classes.tab b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/source-to-classes.tab
+new file mode 100644
+index 0000000..0e02fb1
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/source-to-classes.tab differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/source-to-classes.tab.keystream b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/source-to-classes.tab.keystream
+new file mode 100644
+index 0000000..871d04f
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/source-to-classes.tab.keystream differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/source-to-classes.tab.keystream.len b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/source-to-classes.tab.keystream.len
+new file mode 100644
+index 0000000..0d5f119
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/source-to-classes.tab.keystream.len differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/source-to-classes.tab.len b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/source-to-classes.tab.len
+new file mode 100644
+index 0000000..cf8a30a
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/source-to-classes.tab.len differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/source-to-classes.tab.values.at b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/source-to-classes.tab.values.at
+new file mode 100644
+index 0000000..18566ed
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/source-to-classes.tab.values.at differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/source-to-classes.tab_i b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/source-to-classes.tab_i
+new file mode 100644
+index 0000000..cb42cd2
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/source-to-classes.tab_i differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/source-to-classes.tab_i.len b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/source-to-classes.tab_i.len
+new file mode 100644
+index 0000000..131e265
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/source-to-classes.tab_i.len differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/subtypes.tab b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/subtypes.tab
+new file mode 100644
+index 0000000..37fe89e
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/subtypes.tab differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/subtypes.tab.keystream b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/subtypes.tab.keystream
+new file mode 100644
+index 0000000..e5f1cff
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/subtypes.tab.keystream differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/subtypes.tab.keystream.len b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/subtypes.tab.keystream.len
+new file mode 100644
+index 0000000..fd3b477
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/subtypes.tab.keystream.len differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/subtypes.tab.len b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/subtypes.tab.len
+new file mode 100644
+index 0000000..fd5292d
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/subtypes.tab.len differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/subtypes.tab.values.at b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/subtypes.tab.values.at
+new file mode 100644
+index 0000000..64528ae
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/subtypes.tab.values.at differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/subtypes.tab_i b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/subtypes.tab_i
+new file mode 100644
+index 0000000..07a816a
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/subtypes.tab_i differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/subtypes.tab_i.len b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/subtypes.tab_i.len
+new file mode 100644
+index 0000000..131e265
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/subtypes.tab_i.len differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/supertypes.tab b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/supertypes.tab
+new file mode 100644
+index 0000000..87df8bd
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/supertypes.tab differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/supertypes.tab.keystream b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/supertypes.tab.keystream
+new file mode 100644
+index 0000000..63c62aa
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/supertypes.tab.keystream differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/supertypes.tab.keystream.len b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/supertypes.tab.keystream.len
+new file mode 100644
+index 0000000..ef07157
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/supertypes.tab.keystream.len differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/supertypes.tab.len b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/supertypes.tab.len
+new file mode 100644
+index 0000000..575d132
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/supertypes.tab.len differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/supertypes.tab.values.at b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/supertypes.tab.values.at
+new file mode 100644
+index 0000000..350411b
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/supertypes.tab.values.at differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/supertypes.tab_i b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/supertypes.tab_i
+new file mode 100644
+index 0000000..d32fe82
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/supertypes.tab_i differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/supertypes.tab_i.len b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/supertypes.tab_i.len
+new file mode 100644
+index 0000000..131e265
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/jvm/kotlin/supertypes.tab_i.len differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/lookups/counters.tab b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/lookups/counters.tab
+new file mode 100644
+index 0000000..4fef5ef
+--- /dev/null
++++ b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/lookups/counters.tab
+@@ -0,0 +1,2 @@
++15
++0
+\ No newline at end of file
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/lookups/file-to-id.tab b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/lookups/file-to-id.tab
+new file mode 100644
+index 0000000..5cab27a
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/lookups/file-to-id.tab differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/lookups/file-to-id.tab.keystream b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/lookups/file-to-id.tab.keystream
+new file mode 100644
+index 0000000..871d04f
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/lookups/file-to-id.tab.keystream differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/lookups/file-to-id.tab.keystream.len b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/lookups/file-to-id.tab.keystream.len
+new file mode 100644
+index 0000000..0d5f119
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/lookups/file-to-id.tab.keystream.len differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/lookups/file-to-id.tab.len b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/lookups/file-to-id.tab.len
+new file mode 100644
+index 0000000..cf8a30a
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/lookups/file-to-id.tab.len differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/lookups/file-to-id.tab.values.at b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/lookups/file-to-id.tab.values.at
+new file mode 100644
+index 0000000..3763557
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/lookups/file-to-id.tab.values.at differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/lookups/file-to-id.tab_i b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/lookups/file-to-id.tab_i
+new file mode 100644
+index 0000000..d006df3
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/lookups/file-to-id.tab_i differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/lookups/file-to-id.tab_i.len b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/lookups/file-to-id.tab_i.len
+new file mode 100644
+index 0000000..131e265
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/lookups/file-to-id.tab_i.len differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/lookups/id-to-file.tab b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/lookups/id-to-file.tab
+new file mode 100644
+index 0000000..e2335ca
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/lookups/id-to-file.tab differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/lookups/id-to-file.tab.keystream b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/lookups/id-to-file.tab.keystream
+new file mode 100644
+index 0000000..fbebe84
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/lookups/id-to-file.tab.keystream differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/lookups/id-to-file.tab.keystream.len b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/lookups/id-to-file.tab.keystream.len
+new file mode 100644
+index 0000000..933d553
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/lookups/id-to-file.tab.keystream.len differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/lookups/id-to-file.tab.len b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/lookups/id-to-file.tab.len
+new file mode 100644
+index 0000000..cf8a30a
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/lookups/id-to-file.tab.len differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/lookups/id-to-file.tab.values.at b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/lookups/id-to-file.tab.values.at
+new file mode 100644
+index 0000000..50a5434
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/lookups/id-to-file.tab.values.at differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/lookups/id-to-file.tab_i b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/lookups/id-to-file.tab_i
+new file mode 100644
+index 0000000..0c98456
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/lookups/id-to-file.tab_i differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/lookups/id-to-file.tab_i.len b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/lookups/id-to-file.tab_i.len
+new file mode 100644
+index 0000000..131e265
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/lookups/id-to-file.tab_i.len differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/lookups/lookups.tab b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/lookups/lookups.tab
+new file mode 100644
+index 0000000..8b40cf4
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/lookups/lookups.tab differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/lookups/lookups.tab.keystream b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/lookups/lookups.tab.keystream
+new file mode 100644
+index 0000000..44e3774
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/lookups/lookups.tab.keystream differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/lookups/lookups.tab.keystream.len b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/lookups/lookups.tab.keystream.len
+new file mode 100644
+index 0000000..4325453
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/lookups/lookups.tab.keystream.len differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/lookups/lookups.tab.len b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/lookups/lookups.tab.len
+new file mode 100644
+index 0000000..9c73053
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/lookups/lookups.tab.len differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/lookups/lookups.tab.values.at b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/lookups/lookups.tab.values.at
+new file mode 100644
+index 0000000..08a6731
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/lookups/lookups.tab.values.at differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/lookups/lookups.tab_i b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/lookups/lookups.tab_i
+new file mode 100644
+index 0000000..4d3c569
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/lookups/lookups.tab_i differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/lookups/lookups.tab_i.len b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/lookups/lookups.tab_i.len
+new file mode 100644
+index 0000000..131e265
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/caches-jvm/lookups/lookups.tab_i.len differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/last-build.bin b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/last-build.bin
+new file mode 100644
+index 0000000..b62326e
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/cacheable/last-build.bin differ
+diff --git a/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/local-state/build-history.bin b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/local-state/build-history.bin
+new file mode 100644
+index 0000000..6dee0d1
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/kotlin/compileDebugKotlin/local-state/build-history.bin differ
+diff --git a/node_modules/expo-image-picker/android/build/outputs/logs/manifest-merger-debug-report.txt b/node_modules/expo-image-picker/android/build/outputs/logs/manifest-merger-debug-report.txt
+new file mode 100644
+index 0000000..ff82936
+--- /dev/null
++++ b/node_modules/expo-image-picker/android/build/outputs/logs/manifest-merger-debug-report.txt
+@@ -0,0 +1,98 @@
++-- Merging decision tree log ---
++manifest
++ADDED from /Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:1:1-51:12
++INJECTED from /Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:1:1-51:12
++	package
++		INJECTED from /Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml
++	xmlns:tools
++		ADDED from /Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:2:3-49
++	xmlns:android
++		ADDED from /Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:1:11-69
++uses-permission#android.permission.CAMERA
++ADDED from /Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:4:3-63
++	android:name
++		ADDED from /Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:4:20-60
++uses-permission#android.permission.WRITE_EXTERNAL_STORAGE
++ADDED from /Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:7:3-79
++	android:name
++		ADDED from /Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:7:20-76
++uses-permission#android.permission.READ_EXTERNAL_STORAGE
++ADDED from /Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:8:3-78
++	android:name
++		ADDED from /Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:8:20-75
++uses-permission#android.permission.READ_MEDIA_IMAGES
++ADDED from /Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:9:3-74
++	android:name
++		ADDED from /Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:9:20-71
++uses-permission#android.permission.READ_MEDIA_VIDEO
++ADDED from /Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:10:3-73
++	android:name
++		ADDED from /Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:10:20-70
++application
++ADDED from /Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:12:3-39:17
++service#com.google.android.gms.metadata.ModuleDependencies
++ADDED from /Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:13:5-24:15
++	android:enabled
++		ADDED from /Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:15:7-30
++	android:exported
++		ADDED from /Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:16:7-31
++	tools:ignore
++		ADDED from /Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:17:7-34
++	android:name
++		ADDED from /Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:14:7-72
++intent-filter#action:name:com.google.android.gms.metadata.MODULE_DEPENDENCIES
++ADDED from /Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:18:7-20:23
++action#com.google.android.gms.metadata.MODULE_DEPENDENCIES
++ADDED from /Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:19:9-86
++	android:name
++		ADDED from /Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:19:17-83
++meta-data#photopicker_activity:0:required
++ADDED from /Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:21:7-23:28
++	android:value
++		ADDED from /Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:23:9-25
++	android:name
++		ADDED from /Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:22:9-55
++activity#com.canhub.cropper.CropImageActivity
++ADDED from /Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:26:5-28:53
++	android:theme
++		ADDED from /Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:28:7-50
++	android:name
++		ADDED from /Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:27:7-58
++provider#expo.modules.imagepicker.fileprovider.ImagePickerFileProvider
++ADDED from /Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:30:5-38:16
++	android:grantUriPermissions
++		ADDED from /Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:34:7-41
++	android:authorities
++		ADDED from /Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:32:7-69
++	android:exported
++		ADDED from /Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:33:7-31
++	android:name
++		ADDED from /Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:31:7-59
++meta-data#android.support.FILE_PROVIDER_PATHS
++ADDED from /Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:35:7-37:63
++	android:resource
++		ADDED from /Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:37:9-60
++	android:name
++		ADDED from /Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:36:9-59
++queries
++ADDED from /Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:41:3-50:13
++intent#action:name:android.media.action.IMAGE_CAPTURE
++ADDED from /Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:42:5-45:14
++action#android.media.action.IMAGE_CAPTURE
++ADDED from /Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:44:7-67
++	android:name
++		ADDED from /Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:44:15-64
++intent#action:name:android.media.action.ACTION_VIDEO_CAPTURE
++ADDED from /Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:46:5-49:14
++action#android.media.action.ACTION_VIDEO_CAPTURE
++ADDED from /Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:48:7-74
++	android:name
++		ADDED from /Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml:48:15-71
++uses-sdk
++INJECTED from /Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml reason: use-sdk injection requested
++INJECTED from /Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml
++INJECTED from /Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml
++	android:targetSdkVersion
++		INJECTED from /Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml
++	android:minSdkVersion
++		INJECTED from /Users/hailey/Projects/social-app/node_modules/expo-image-picker/android/src/main/AndroidManifest.xml
+diff --git a/node_modules/expo-image-picker/android/build/tmp/compileDebugJavaWithJavac/previous-compilation-data.bin b/node_modules/expo-image-picker/android/build/tmp/compileDebugJavaWithJavac/previous-compilation-data.bin
+new file mode 100644
+index 0000000..d9da117
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/compileDebugJavaWithJavac/previous-compilation-data.bin differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/META-INF/expo-image-picker_debug.kotlin_module b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/META-INF/expo-image-picker_debug.kotlin_module
+new file mode 100644
+index 0000000..d9206b6
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/META-INF/expo-image-picker_debug.kotlin_module differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/AdditionalFileData.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/AdditionalFileData.class
+new file mode 100644
+index 0000000..29c4c36
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/AdditionalFileData.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/CameraType.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/CameraType.class
+new file mode 100644
+index 0000000..e67c990
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/CameraType.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/FailedToCreateFileException.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/FailedToCreateFileException.class
+new file mode 100644
+index 0000000..cc5abc7
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/FailedToCreateFileException.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/FailedToDeduceTypeException.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/FailedToDeduceTypeException.class
+new file mode 100644
+index 0000000..5f76e0c
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/FailedToDeduceTypeException.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/FailedToExtractVideoMetadataException.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/FailedToExtractVideoMetadataException.class
+new file mode 100644
+index 0000000..84ccf7f
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/FailedToExtractVideoMetadataException.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/FailedToPickMediaException.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/FailedToPickMediaException.class
+new file mode 100644
+index 0000000..4ea9586
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/FailedToPickMediaException.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/FailedToReadFileException.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/FailedToReadFileException.class
+new file mode 100644
+index 0000000..0a7f6e8
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/FailedToReadFileException.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/FailedToWriteExifDataToFileException.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/FailedToWriteExifDataToFileException.class
+new file mode 100644
+index 0000000..bc25e2a
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/FailedToWriteExifDataToFileException.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/FailedToWriteFileException.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/FailedToWriteFileException.class
+new file mode 100644
+index 0000000..3ab5458
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/FailedToWriteFileException.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerAsset.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerAsset.class
+new file mode 100644
+index 0000000..3cb3c4a
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerAsset.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerConstants$EXIF_TAGS$1.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerConstants$EXIF_TAGS$1.class
+new file mode 100644
+index 0000000..ba11497
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerConstants$EXIF_TAGS$1.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerConstants.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerConstants.class
+new file mode 100644
+index 0000000..3c690bb
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerConstants.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$1$5$1.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$1$5$1.class
+new file mode 100644
+index 0000000..9c42071
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$1$5$1.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$1$6$1.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$1$6$1.class
+new file mode 100644
+index 0000000..155f61b
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$1$6$1.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$1$8$1.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$1$8$1.class
+new file mode 100644
+index 0000000..1c93c0c
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$1$8$1.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$1$8$2.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$1$8$2.class
+new file mode 100644
+index 0000000..75ea01c
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$1$8$2.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$1$8$3.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$1$8$3.class
+new file mode 100644
+index 0000000..2006e87
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$1$8$3.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$1$8.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$1$8.class
+new file mode 100644
+index 0000000..7ab31da
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$1$8.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$lambda$7$$inlined$AsyncFunction$1.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$lambda$7$$inlined$AsyncFunction$1.class
+new file mode 100644
+index 0000000..2780147
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$lambda$7$$inlined$AsyncFunction$1.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$lambda$7$$inlined$AsyncFunction$10.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$lambda$7$$inlined$AsyncFunction$10.class
+new file mode 100644
+index 0000000..6092397
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$lambda$7$$inlined$AsyncFunction$10.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$lambda$7$$inlined$AsyncFunction$11.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$lambda$7$$inlined$AsyncFunction$11.class
+new file mode 100644
+index 0000000..2ed22da
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$lambda$7$$inlined$AsyncFunction$11.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$lambda$7$$inlined$AsyncFunction$12.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$lambda$7$$inlined$AsyncFunction$12.class
+new file mode 100644
+index 0000000..cf9affd
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$lambda$7$$inlined$AsyncFunction$12.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$lambda$7$$inlined$AsyncFunction$13.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$lambda$7$$inlined$AsyncFunction$13.class
+new file mode 100644
+index 0000000..0e14ea2
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$lambda$7$$inlined$AsyncFunction$13.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$lambda$7$$inlined$AsyncFunction$14.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$lambda$7$$inlined$AsyncFunction$14.class
+new file mode 100644
+index 0000000..4573f32
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$lambda$7$$inlined$AsyncFunction$14.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$lambda$7$$inlined$AsyncFunction$15.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$lambda$7$$inlined$AsyncFunction$15.class
+new file mode 100644
+index 0000000..24e8508
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$lambda$7$$inlined$AsyncFunction$15.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$lambda$7$$inlined$AsyncFunction$16.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$lambda$7$$inlined$AsyncFunction$16.class
+new file mode 100644
+index 0000000..195b81d
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$lambda$7$$inlined$AsyncFunction$16.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$lambda$7$$inlined$AsyncFunction$2.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$lambda$7$$inlined$AsyncFunction$2.class
+new file mode 100644
+index 0000000..4a95be0
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$lambda$7$$inlined$AsyncFunction$2.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$lambda$7$$inlined$AsyncFunction$3.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$lambda$7$$inlined$AsyncFunction$3.class
+new file mode 100644
+index 0000000..09adc6b
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$lambda$7$$inlined$AsyncFunction$3.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$lambda$7$$inlined$AsyncFunction$4.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$lambda$7$$inlined$AsyncFunction$4.class
+new file mode 100644
+index 0000000..cc44444
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$lambda$7$$inlined$AsyncFunction$4.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$lambda$7$$inlined$AsyncFunction$5.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$lambda$7$$inlined$AsyncFunction$5.class
+new file mode 100644
+index 0000000..e8b1ed6
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$lambda$7$$inlined$AsyncFunction$5.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$lambda$7$$inlined$AsyncFunction$6.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$lambda$7$$inlined$AsyncFunction$6.class
+new file mode 100644
+index 0000000..efb5420
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$lambda$7$$inlined$AsyncFunction$6.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$lambda$7$$inlined$AsyncFunction$7.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$lambda$7$$inlined$AsyncFunction$7.class
+new file mode 100644
+index 0000000..f761d29
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$lambda$7$$inlined$AsyncFunction$7.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$lambda$7$$inlined$AsyncFunction$8.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$lambda$7$$inlined$AsyncFunction$8.class
+new file mode 100644
+index 0000000..8708ec9
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$lambda$7$$inlined$AsyncFunction$8.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$lambda$7$$inlined$AsyncFunction$9.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$lambda$7$$inlined$AsyncFunction$9.class
+new file mode 100644
+index 0000000..ac1bfe2
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$lambda$7$$inlined$AsyncFunction$9.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$lambda$7$$inlined$Coroutine$1.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$lambda$7$$inlined$Coroutine$1.class
+new file mode 100644
+index 0000000..255f100
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$lambda$7$$inlined$Coroutine$1.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$lambda$7$$inlined$Coroutine$2.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$lambda$7$$inlined$Coroutine$2.class
+new file mode 100644
+index 0000000..2a37986
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$lambda$7$$inlined$Coroutine$2.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$lambda$7$$inlined$Coroutine$3.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$lambda$7$$inlined$Coroutine$3.class
+new file mode 100644
+index 0000000..5385e02
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$lambda$7$$inlined$Coroutine$3.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$lambda$7$$inlined$Coroutine$4.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$lambda$7$$inlined$Coroutine$4.class
+new file mode 100644
+index 0000000..bfb5990
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$lambda$7$$inlined$Coroutine$4.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$lambda$7$$inlined$Coroutine$5.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$lambda$7$$inlined$Coroutine$5.class
+new file mode 100644
+index 0000000..8c08fde
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$definition$lambda$7$$inlined$Coroutine$5.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$ensureCameraPermissionsAreGranted$2$1.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$ensureCameraPermissionsAreGranted$2$1.class
+new file mode 100644
+index 0000000..9aa2203
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$ensureCameraPermissionsAreGranted$2$1.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$launchContract$1.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$launchContract$1.class
+new file mode 100644
+index 0000000..8c00e00
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$launchContract$1.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$launchContract$2.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$launchContract$2.class
+new file mode 100644
+index 0000000..9e70e41
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$launchContract$2.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$launchPicker$2.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$launchPicker$2.class
+new file mode 100644
+index 0000000..acae345
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule$launchPicker$2.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule.class
+new file mode 100644
+index 0000000..a5d3b75
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModule.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModuleKt.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModuleKt.class
+new file mode 100644
+index 0000000..84bcc9d
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerModuleKt.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerOptions.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerOptions.class
+new file mode 100644
+index 0000000..e8cacff
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerOptions.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerOptionsKt.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerOptionsKt.class
+new file mode 100644
+index 0000000..57619fb
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerOptionsKt.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerResponse.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerResponse.class
+new file mode 100644
+index 0000000..36e9b07
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerResponse.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerUtilsKt$WhenMappings.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerUtilsKt$WhenMappings.class
+new file mode 100644
+index 0000000..158b981
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerUtilsKt$WhenMappings.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerUtilsKt$copyExifData$2.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerUtilsKt$copyExifData$2.class
+new file mode 100644
+index 0000000..d6eec57
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerUtilsKt$copyExifData$2.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerUtilsKt$copyFile$2.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerUtilsKt$copyFile$2.class
+new file mode 100644
+index 0000000..05fce03
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerUtilsKt$copyFile$2.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerUtilsKt$items$1$iterator$1.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerUtilsKt$items$1$iterator$1.class
+new file mode 100644
+index 0000000..e888969
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerUtilsKt$items$1$iterator$1.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerUtilsKt$items$1.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerUtilsKt$items$1.class
+new file mode 100644
+index 0000000..202a0ea
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerUtilsKt$items$1.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerUtilsKt.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerUtilsKt.class
+new file mode 100644
+index 0000000..3a61baa
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/ImagePickerUtilsKt.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/MediaHandler$WhenMappings.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/MediaHandler$WhenMappings.class
+new file mode 100644
+index 0000000..054a08e
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/MediaHandler$WhenMappings.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/MediaHandler$handleImage$1.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/MediaHandler$handleImage$1.class
+new file mode 100644
+index 0000000..840bc0a
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/MediaHandler$handleImage$1.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/MediaHandler$handleVideo$1.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/MediaHandler$handleVideo$1.class
+new file mode 100644
+index 0000000..0e75c70
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/MediaHandler$handleVideo$1.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/MediaHandler$readExtras$1.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/MediaHandler$readExtras$1.class
+new file mode 100644
+index 0000000..1fd6419
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/MediaHandler$readExtras$1.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/MediaHandler.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/MediaHandler.class
+new file mode 100644
+index 0000000..4e2c9c4
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/MediaHandler.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/MediaType.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/MediaType.class
+new file mode 100644
+index 0000000..fa6ab72
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/MediaType.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/MediaTypes$Companion.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/MediaTypes$Companion.class
+new file mode 100644
+index 0000000..60c7730
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/MediaTypes$Companion.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/MediaTypes$WhenMappings.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/MediaTypes$WhenMappings.class
+new file mode 100644
+index 0000000..00e9ae9
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/MediaTypes$WhenMappings.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/MediaTypes.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/MediaTypes.class
+new file mode 100644
+index 0000000..e7f0623
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/MediaTypes.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/MissingActivityToHandleIntent.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/MissingActivityToHandleIntent.class
+new file mode 100644
+index 0000000..328f6cb
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/MissingActivityToHandleIntent.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/MissingCurrentActivityException.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/MissingCurrentActivityException.class
+new file mode 100644
+index 0000000..9e646d3
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/MissingCurrentActivityException.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/MissingModuleException.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/MissingModuleException.class
+new file mode 100644
+index 0000000..656b423
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/MissingModuleException.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/PendingMediaPickingResult.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/PendingMediaPickingResult.class
+new file mode 100644
+index 0000000..9880991
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/PendingMediaPickingResult.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/UserRejectedPermissionsException.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/UserRejectedPermissionsException.class
+new file mode 100644
+index 0000000..ba88d5b
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/UserRejectedPermissionsException.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/contracts/CameraContract.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/contracts/CameraContract.class
+new file mode 100644
+index 0000000..62fe5ed
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/contracts/CameraContract.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/contracts/CameraContractOptions.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/contracts/CameraContractOptions.class
+new file mode 100644
+index 0000000..e8fddd3
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/contracts/CameraContractOptions.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/contracts/CropImageContract$parseResult$1.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/contracts/CropImageContract$parseResult$1.class
+new file mode 100644
+index 0000000..d83278c
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/contracts/CropImageContract$parseResult$1.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/contracts/CropImageContract.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/contracts/CropImageContract.class
+new file mode 100644
+index 0000000..a9ecf12
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/contracts/CropImageContract.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/contracts/CropImageContractOptions.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/contracts/CropImageContractOptions.class
+new file mode 100644
+index 0000000..03a69bd
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/contracts/CropImageContractOptions.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/contracts/ImageLibraryContract.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/contracts/ImageLibraryContract.class
+new file mode 100644
+index 0000000..3838a8a
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/contracts/ImageLibraryContract.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/contracts/ImageLibraryContractOptions.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/contracts/ImageLibraryContractOptions.class
+new file mode 100644
+index 0000000..fcddffb
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/contracts/ImageLibraryContractOptions.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/contracts/ImagePickerContractResult$Cancelled.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/contracts/ImagePickerContractResult$Cancelled.class
+new file mode 100644
+index 0000000..472d641
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/contracts/ImagePickerContractResult$Cancelled.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/contracts/ImagePickerContractResult$Error.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/contracts/ImagePickerContractResult$Error.class
+new file mode 100644
+index 0000000..1680608
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/contracts/ImagePickerContractResult$Error.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/contracts/ImagePickerContractResult$Success.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/contracts/ImagePickerContractResult$Success.class
+new file mode 100644
+index 0000000..429c1e2
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/contracts/ImagePickerContractResult$Success.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/contracts/ImagePickerContractResult.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/contracts/ImagePickerContractResult.class
+new file mode 100644
+index 0000000..fc70315
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/contracts/ImagePickerContractResult.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/exporters/CompressionImageExporter$exportAsync$1.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/exporters/CompressionImageExporter$exportAsync$1.class
+new file mode 100644
+index 0000000..bffee09
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/exporters/CompressionImageExporter$exportAsync$1.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/exporters/CompressionImageExporter$exportAsync$2.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/exporters/CompressionImageExporter$exportAsync$2.class
+new file mode 100644
+index 0000000..11b48e8
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/exporters/CompressionImageExporter$exportAsync$2.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/exporters/CompressionImageExporter$readBitmap$1.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/exporters/CompressionImageExporter$readBitmap$1.class
+new file mode 100644
+index 0000000..7282c7f
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/exporters/CompressionImageExporter$readBitmap$1.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/exporters/CompressionImageExporter$readBitmap$2.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/exporters/CompressionImageExporter$readBitmap$2.class
+new file mode 100644
+index 0000000..6fc077b
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/exporters/CompressionImageExporter$readBitmap$2.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/exporters/CompressionImageExporter$writeImage$2.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/exporters/CompressionImageExporter$writeImage$2.class
+new file mode 100644
+index 0000000..45925a1
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/exporters/CompressionImageExporter$writeImage$2.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/exporters/CompressionImageExporter.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/exporters/CompressionImageExporter.class
+new file mode 100644
+index 0000000..dc9d51d
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/exporters/CompressionImageExporter.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/exporters/ImageExportResult$data$2.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/exporters/ImageExportResult$data$2.class
+new file mode 100644
+index 0000000..4edcac9
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/exporters/ImageExportResult$data$2.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/exporters/ImageExportResult$exif$2.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/exporters/ImageExportResult$exif$2.class
+new file mode 100644
+index 0000000..8417050
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/exporters/ImageExportResult$exif$2.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/exporters/ImageExportResult.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/exporters/ImageExportResult.class
+new file mode 100644
+index 0000000..bb84177
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/exporters/ImageExportResult.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/exporters/ImageExporter.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/exporters/ImageExporter.class
+new file mode 100644
+index 0000000..afd5871
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/exporters/ImageExporter.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/exporters/RawImageExporter$exportAsync$1.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/exporters/RawImageExporter$exportAsync$1.class
+new file mode 100644
+index 0000000..1915121
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/exporters/RawImageExporter$exportAsync$1.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/exporters/RawImageExporter.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/exporters/RawImageExporter.class
+new file mode 100644
+index 0000000..dca80ae
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/exporters/RawImageExporter.class differ
+diff --git a/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/fileprovider/ImagePickerFileProvider.class b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/fileprovider/ImagePickerFileProvider.class
+new file mode 100644
+index 0000000..9f91bb9
+Binary files /dev/null and b/node_modules/expo-image-picker/android/build/tmp/kotlin-classes/debug/expo/modules/imagepicker/fileprovider/ImagePickerFileProvider.class differ
 diff --git a/node_modules/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/ImageLibraryContract.kt b/node_modules/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/ImageLibraryContract.kt
-index ff15c91..bc868d1 100644
+index ff15c91..41aaf12 100644
 --- a/node_modules/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/ImageLibraryContract.kt
 +++ b/node_modules/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/ImageLibraryContract.kt
-@@ -26,30 +26,16 @@ import java.io.Serializable
+@@ -26,51 +26,26 @@ import java.io.Serializable
   * @see [androidx.activity.result.contract.ActivityResultContracts.GetMultipleContents]
   */
  internal class ImageLibraryContract(
@@ -36,25 +1315,25 @@ index ff15c91..bc868d1 100644
 +            .setType("image/*")
  
      if (input.options.allowsMultipleSelection) {
-       val selectionLimit = input.options.selectionLimit
-@@ -57,20 +43,20 @@ internal class ImageLibraryContract(
-       if (selectionLimit == 1) {
-         // If multiple selection is allowed but the limit is 1, we should ignore
-         // the multiple selection flag and just treat it as a single selection.
+-      val selectionLimit = input.options.selectionLimit
+-
+-      if (selectionLimit == 1) {
+-        // If multiple selection is allowed but the limit is 1, we should ignore
+-        // the multiple selection flag and just treat it as a single selection.
 -        return PickVisualMedia().createIntent(context, request)
-+        intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, 1)
++      if(input.options.selectionLimit == 1) {
++        return intent
        }
  
-       if (selectionLimit > 1) {
+-      if (selectionLimit > 1) {
 -        return PickMultipleVisualMedia(selectionLimit).createIntent(context, request)
-+        intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, selectionLimit)
-       }
- 
-       // If the selection limit is 0, it is the same as unlimited selection.
-       if (selectionLimit == UNLIMITED_SELECTION) {
+-      }
+-
+-      // If the selection limit is 0, it is the same as unlimited selection.
+-      if (selectionLimit == UNLIMITED_SELECTION) {
 -        return PickMultipleVisualMedia().createIntent(context, request)
-+        intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true)
-       }
+-      }
++      intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true)
      }
  
 -    return PickVisualMedia().createIntent(context, request)

--- a/src/lib/media/picker.shared.ts
+++ b/src/lib/media/picker.shared.ts
@@ -4,6 +4,7 @@ import {
   MediaTypeOptions,
 } from 'expo-image-picker'
 import {getDataUriSize} from './util'
+import * as Toast from 'view/com/util/Toast'
 
 export async function openPicker(opts?: ImagePickerOptions) {
   const response = await launchImageLibraryAsync({
@@ -13,7 +14,11 @@ export async function openPicker(opts?: ImagePickerOptions) {
     ...opts,
   })
 
-  return (response.assets ?? []).map(image => ({
+  if (response.assets && response.assets.length > 4) {
+    Toast.show('You may only select up to 4 images')
+  }
+
+  return (response.assets ?? []).slice(0, 4).map(image => ({
     mime: 'image/jpeg',
     height: image.height,
     width: image.width,


### PR DESCRIPTION
fixes https://github.com/bluesky-social/social-app/issues/1617

Right now, expo-image-picker is using `PickVisualMedia`. This does not support the "Browse" option to select files elsewhere on the device except the gallery. Instead, we want to use `GetContent`. See https://android-developers.googleblog.com/2023/04/photo-picker-everywhere.html

This patches expo-image-picker to do so. Tested on SDK 34, 28, and ~~23~~  25. Tested accessing images from files as well as Google Drive with good success.

This is meant to be a temporary fix, and I didn't implement the logic for selecting videos. It's only a few extra lines, however we have to be careful that we properly create the intent (the mime can't be anything other than `image/*` or `video/*` otherwise it won't use the image picker).

We also have to use `Intent.EXTRA_ALLOW_MULTIPLE` which only accepts a boolean, not a limit. To that end, I've made a minor change in `picker.shared.ts` to slice the result and make sure we only return four images. Not the most ideal option, but I think the benefits of fixing this seemingly annoying issue outweigh that. To try and make it clear to the user, we present a toast if they select more than four images.

Of course whenever multiple is disabled we still only allow the selection of one file.

I think Google's intent is to make `PickVisualMedia` work in the future in the same way, so hopefully this isn't something that will need to be in the codebase for too long. They said by the end of the year though and...here we are 🙃