### PR TITLE
keep emoji picker open when shift is pressed while selecting emoji

### DIFF
--- a/src/view/com/composer/text-input/web/EmojiPicker.web.tsx
+++ b/src/view/com/composer/text-input/web/EmojiPicker.web.tsx
@@ -58,6 +58,11 @@ export function EmojiPicker({close}: {close: () => void}) {
       if (e.key === 'Shift') {
         isShiftDown.current = false
       }
+
+      if (e.key === 'Escape') {
+        e.stopPropagation()
+        close()
+      }
     }
 
     window.addEventListener('keydown', onKeyDown, true)
@@ -67,7 +72,7 @@ export function EmojiPicker({close}: {close: () => void}) {
       window.removeEventListener('keydown', onKeyDown, true)
       window.removeEventListener('keyup', onKeyUp, true)
     }
-  }, [])
+  }, [close])
 
   const onInsert = (emoji: Emoji) => {
     textInputWebEmitter.emit('emoji-inserted', emoji)


### PR DESCRIPTION
closes https://github.com/bluesky-social/social-app/issues/2390
closes https://github.com/bluesky-social/social-app/issues/1425

simple stuff. when the emoji picker is open, listen for shift down/up. store the value in a ref, and don't close the picker on select if the ref is true. remove listeners on close.