### PR TITLE
emoji picker improvements

### DIFF
--- a/src/state/shell/composer.tsx
+++ b/src/state/shell/composer.tsx
@@ -30,6 +30,7 @@ export interface ComposerOpts {
   onPost?: () => void
   quote?: ComposerOptsQuote
   mention?: string // handle of user to mention
+  openPicker?: (pos: DOMRect | undefined) => void
 }
 
 type StateContext = ComposerOpts | undefined

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -6,6 +6,7 @@ import {
   Keyboard,
   KeyboardAvoidingView,
   Platform,
+  Pressable,
   ScrollView,
   StyleSheet,
   TouchableOpacity,
@@ -46,7 +47,6 @@ import {Gallery} from './photos/Gallery'
 import {MAX_GRAPHEME_LENGTH} from 'lib/constants'
 import {LabelsBtn} from './labels/LabelsBtn'
 import {SelectLangBtn} from './select-language/SelectLangBtn'
-import {EmojiPickerButton} from './text-input/web/EmojiPicker.web'
 import {insertMentionAt} from 'lib/strings/mention-manip'
 import {Trans, msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
@@ -70,6 +70,7 @@ export const ComposePost = observer(function ComposePost({
   onPost,
   quote: initQuote,
   mention: initMention,
+  openPicker,
 }: Props) {
   const {currentAccount} = useSession()
   const {data: currentProfile} = useProfileQuery({did: currentAccount!.did})
@@ -274,6 +275,10 @@ export const ComposePost = observer(function ComposePost({
   const canSelectImages = useMemo(() => gallery.size < 4, [gallery.size])
   const hasMedia = gallery.size > 0 || Boolean(extLink)
 
+  const onEmojiButtonPress = useCallback(() => {
+    openPicker?.(textInput.current?.getCursorPosition())
+  }, [openPicker])
+
   return (
     <KeyboardAvoidingView
       testID="composePostView"
@@ -456,7 +461,15 @@ export const ComposePost = observer(function ComposePost({
               <OpenCameraBtn gallery={gallery} />
             </>
           ) : null}
-          {!isMobile ? <EmojiPickerButton /> : null}
+          {!isMobile ? (
+            <Pressable accessibilityRole="button" onPress={onEmojiButtonPress}>
+              <FontAwesomeIcon
+                icon={['far', 'face-smile']}
+                color={pal.colors.link}
+                size={22}
+              />
+            </Pressable>
+          ) : null}
           <View style={s.flex1} />
           <SelectLangBtn />
           <CharProgress count={graphemeLength} />

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -462,7 +462,11 @@ export const ComposePost = observer(function ComposePost({
             </>
           ) : null}
           {!isMobile ? (
-            <Pressable accessibilityRole="button" onPress={onEmojiButtonPress}>
+            <Pressable
+              onPress={onEmojiButtonPress}
+              accessibilityRole="button"
+              accessibilityLabel={_(msg`Open emoji picker`)}
+              accessibilityHint={_(msg`Open emoji picker`)}>
               <FontAwesomeIcon
                 icon={['far', 'face-smile']}
                 color={pal.colors.link}

--- a/src/view/com/composer/text-input/TextInput.tsx
+++ b/src/view/com/composer/text-input/TextInput.tsx
@@ -32,6 +32,7 @@ import {POST_IMG_MAX} from 'lib/constants'
 export interface TextInputRef {
   focus: () => void
   blur: () => void
+  getCursorPosition: () => DOMRect | undefined
 }
 
 interface TextInputProps extends ComponentProps<typeof RNTextInput> {
@@ -74,6 +75,7 @@ export const TextInput = forwardRef(function TextInputImpl(
     blur: () => {
       textInput.current?.blur()
     },
+    getCursorPosition: () => undefined, // Not implemented on native
   }))
 
   const onChangeText = useCallback(

--- a/src/view/com/composer/text-input/TextInput.web.tsx
+++ b/src/view/com/composer/text-input/TextInput.web.tsx
@@ -22,6 +22,7 @@ import {useActorAutocompleteFn} from '#/state/queries/actor-autocomplete'
 export interface TextInputRef {
   focus: () => void
   blur: () => void
+  getCursorPosition: () => DOMRect | undefined
 }
 
 interface TextInputProps {
@@ -169,6 +170,10 @@ export const TextInput = React.forwardRef(function TextInputImpl(
   React.useImperativeHandle(ref, () => ({
     focus: () => {}, // TODO
     blur: () => {}, // TODO
+    getCursorPosition: () => {
+      const pos = editor?.state.selection.$anchor.pos
+      return pos ? editor?.view.coordsAtPos(pos) : undefined
+    },
   }))
 
   return (

--- a/src/view/com/composer/text-input/web/EmojiPicker.web.tsx
+++ b/src/view/com/composer/text-input/web/EmojiPicker.web.tsx
@@ -42,7 +42,7 @@ export function EmojiPicker({state, close}: IProps) {
   const position = React.useMemo(() => {
     const fitsBelow = state.pos.top + PICKER_HEIGHT < height
     const fitsAbove = PICKER_HEIGHT < state.pos.top
-    const placeOnLeft = state.pos.left > width / 2
+    const placeOnLeft = PICKER_WIDTH < state.pos.left
     const screenYMiddle = height / 2 - PICKER_HEIGHT / 2
 
     if (fitsBelow) {

--- a/src/view/com/composer/text-input/web/EmojiPicker.web.tsx
+++ b/src/view/com/composer/text-input/web/EmojiPicker.web.tsx
@@ -1,11 +1,7 @@
 import React from 'react'
 import Picker from '@emoji-mart/react'
 import {StyleSheet, TouchableWithoutFeedback, View} from 'react-native'
-import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
 import {textInputWebEmitter} from '../TextInput.web'
-import {FontAwesomeIcon} from '@fortawesome/react-native-fontawesome'
-import {usePalette} from 'lib/hooks/usePalette'
-import {useMediaQuery} from 'react-responsive'
 
 export type Emoji = {
   aliases?: string[]
@@ -18,59 +14,61 @@ export type Emoji = {
   unified: string
 }
 
-export function EmojiPickerButton() {
-  const pal = usePalette('default')
-  const [open, setOpen] = React.useState(false)
-  const onOpenChange = (o: boolean) => {
-    setOpen(o)
-  }
-  const close = () => {
-    setOpen(false)
-  }
-
-  return (
-    <DropdownMenu.Root open={open} onOpenChange={onOpenChange}>
-      <DropdownMenu.Trigger style={styles.trigger}>
-        <FontAwesomeIcon
-          icon={['far', 'face-smile']}
-          color={pal.colors.link}
-          size={22}
-        />
-      </DropdownMenu.Trigger>
-
-      <DropdownMenu.Portal>
-        <EmojiPicker close={close} />
-      </DropdownMenu.Portal>
-    </DropdownMenu.Root>
-  )
+export interface EmojiPickerState {
+  isOpen: boolean
+  top: number
 }
 
-export function EmojiPicker({close}: {close: () => void}) {
+interface IProps {
+  state: EmojiPickerState
+  close: () => void
+}
+
+export function EmojiPicker({state, close}: IProps) {
+  const isShiftDown = React.useRef(false)
+
+  React.useEffect(() => {
+    if (!state.isOpen) return
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Shift') {
+        isShiftDown.current = true
+      }
+    }
+    const onKeyUp = (e: KeyboardEvent) => {
+      if (e.key === 'Shift') {
+        isShiftDown.current = false
+      }
+    }
+    window.addEventListener('keydown', onKeyDown, true)
+    window.addEventListener('keyup', onKeyUp, true)
+
+    return () => {
+      window.removeEventListener('keydown', onKeyDown, true)
+      window.removeEventListener('keyup', onKeyUp, true)
+    }
+  }, [state.isOpen])
+
   const onInsert = (emoji: Emoji) => {
     textInputWebEmitter.emit('emoji-inserted', emoji)
-    close()
+
+    if (!isShiftDown.current) {
+      close()
+    }
   }
-  const reducedPadding = useMediaQuery({query: '(max-height: 750px)'})
-  const noPadding = useMediaQuery({query: '(max-height: 550px)'})
-  const noPicker = useMediaQuery({query: '(max-height: 350px)'})
+
+  if (!state.isOpen) return null
 
   return (
-    // eslint-disable-next-line react-native-a11y/has-valid-accessibility-descriptors
-    <TouchableWithoutFeedback onPress={close} accessibilityViewIsModal>
+    <TouchableWithoutFeedback
+      accessibilityRole="button"
+      onPress={close}
+      accessibilityViewIsModal>
       <View style={styles.mask}>
-        {/* eslint-disable-next-line react-native-a11y/has-valid-accessibility-descriptors */}
         <TouchableWithoutFeedback
-          onPress={e => {
-            e.stopPropagation() // prevent event from bubbling up to the mask
-          }}>
-          <View
-            style={[
-              styles.picker,
-              {
-                paddingTop: noPadding ? 0 : reducedPadding ? 150 : 325,
-                display: noPicker ? 'none' : 'flex',
-              },
-            ]}>
+          accessibilityRole="button"
+          onPress={e => e.stopPropagation()}>
+          <View style={[{position: 'absolute', top: state.top}]}>
             <Picker
               data={async () => {
                 return (await import('./EmojiPickerData.json')).default
@@ -93,15 +91,7 @@ const styles = StyleSheet.create({
     right: 0,
     width: '100%',
     height: '100%',
-  },
-  trigger: {
-    backgroundColor: 'transparent',
-    // @ts-ignore web only -prf
-    border: 'none',
-    paddingTop: 4,
-    paddingLeft: 12,
-    paddingRight: 12,
-    cursor: 'pointer',
+    alignItems: 'center',
   },
   picker: {
     marginHorizontal: 'auto',

--- a/src/view/com/composer/text-input/web/EmojiPicker.web.tsx
+++ b/src/view/com/composer/text-input/web/EmojiPicker.web.tsx
@@ -102,9 +102,8 @@ export function EmojiPicker({state, close}: IProps) {
       onPress={close}
       accessibilityViewIsModal>
       <View style={styles.mask}>
-        <TouchableWithoutFeedback
-          accessibilityRole="button"
-          onPress={e => e.stopPropagation()}>
+        {/* eslint-disable-next-line react-native-a11y/has-valid-accessibility-descriptors */}
+        <TouchableWithoutFeedback onPress={e => e.stopPropagation()}>
           <View style={[{position: 'absolute'}, position]}>
             <Picker
               data={async () => {

--- a/src/view/shell/Composer.web.tsx
+++ b/src/view/shell/Composer.web.tsx
@@ -19,14 +19,14 @@ export function Composer({}: {winHeight: number}) {
 
   const [pickerState, setPickerState] = React.useState<EmojiPickerState>({
     isOpen: false,
-    top: 0,
+    pos: {top: 0, left: 0, right: 0, bottom: 0},
   })
 
   const onOpenPicker = React.useCallback((pos: DOMRect | undefined) => {
     if (!pos) return
     setPickerState({
       isOpen: true,
-      top: pos.top + 40,
+      pos,
     })
   }, [])
 

--- a/src/view/shell/Composer.web.tsx
+++ b/src/view/shell/Composer.web.tsx
@@ -5,6 +5,10 @@ import {ComposePost} from '../com/composer/Composer'
 import {useComposerState} from 'state/shell/composer'
 import {usePalette} from 'lib/hooks/usePalette'
 import {useWebMediaQueries} from 'lib/hooks/useWebMediaQueries'
+import {
+  EmojiPicker,
+  EmojiPickerState,
+} from 'view/com/composer/text-input/web/EmojiPicker.web.tsx'
 
 const BOTTOM_BAR_HEIGHT = 61
 
@@ -12,6 +16,26 @@ export function Composer({}: {winHeight: number}) {
   const pal = usePalette('default')
   const {isMobile} = useWebMediaQueries()
   const state = useComposerState()
+
+  const [pickerState, setPickerState] = React.useState<EmojiPickerState>({
+    isOpen: false,
+    top: 0,
+  })
+
+  const onOpenPicker = React.useCallback((pos: DOMRect | undefined) => {
+    if (!pos) return
+    setPickerState({
+      isOpen: true,
+      top: pos.top + 40,
+    })
+  }, [])
+
+  const onClosePicker = React.useCallback(() => {
+    setPickerState(prev => ({
+      ...prev,
+      isOpen: false,
+    }))
+  }, [])
 
   // rendering
   // =
@@ -41,8 +65,10 @@ export function Composer({}: {winHeight: number}) {
           quote={state.quote}
           onPost={state.onPost}
           mention={state.mention}
+          openPicker={onOpenPicker}
         />
       </Animated.View>
+      <EmojiPicker state={pickerState} close={onClosePicker} />
     </Animated.View>
   )
 }


### PR DESCRIPTION
Fixes: https://github.com/bluesky-social/social-app/issues/2390
Fixes: https://github.com/bluesky-social/social-app/issues/2389
Fixes: https://github.com/bluesky-social/social-app/issues/1425

Demo: https://www.youtube.com/watch?v=eGJY9y7i4BY&feature=youtu.be

## Problem

Right now the picker is being presented as a button dropdown. This limits the "mobility" of the picker, as we cannot control where it's going to be displayed at on the screen.

![Screenshot 2023-12-30 at 6 41 21 PM](https://github.com/bluesky-social/social-app/assets/153161762/eee3878e-be88-467b-87b0-c873b9bd3181)

This creates some issues like what we see here: https://github.com/bluesky-social/social-app/issues/2389

Instead, we want the picker to be movable about the entirety of the screen so that we can adjust to the position of the cursor.

## How

First, we need to move the picker outside of the composer modal so that we can set the position to anywhere on the screen. We do so by placing it inside of `Composer.web.tsx`.

To control the picker, we have a small state object with `isOpen` and `top`. The top value is the y position of the text input cursor plus 50 pixels, so that it will always be visible no matter where the picker is. This also gives us room to make further adjustments such as moving it to the left of the text on smaller screens where the entire picker can't show up. I.e., right now it gets a bit messy:

![Screenshot 2023-12-30 at 6 45 38 PM](https://github.com/bluesky-social/social-app/assets/153161762/7e7b9209-40b5-4793-86fb-cd581f726b26)

To get the current cursor, we can use tiptap's editor state to do this. We add `getCursorPosition()` to `TextInput`'s methods:

```tsx
    getCursorPosition: () => {
      const pos = editor?.state.selection.$anchor.pos
      return pos ? editor?.view.coordsAtPos(pos) : undefined
    }
```

Now when we press the emoji button, we just call `openPicker(textInput.current?.getCursorPosition())`.

A little bit of logic can tell us where we need to place the picker:

```tsx
  const position = React.useMemo(() => {
    const fitsBelow = state.pos.top + PICKER_HEIGHT < height
    const fitsAbove = PICKER_HEIGHT < state.pos.top
    const placeOnLeft = PICKER_WIDTH < state.pos.left
    const screenYMiddle = height / 2 - PICKER_HEIGHT / 2

    if (fitsBelow) {
      return {
        top: state.pos.top + HEIGHT_OFFSET,
      }
    } else if (fitsAbove) {
      return {
        bottom: height - state.pos.bottom + HEIGHT_OFFSET,
      }
    } else {
      return {
        top: screenYMiddle,
        left: placeOnLeft ? state.pos.left - PICKER_WIDTH : undefined,
        right: !placeOnLeft
          ? width - state.pos.right - PICKER_WIDTH
          : undefined,
      }
    }
  }, [state.pos, height, width])
```

Examples: 

Space below:
![Screenshot 2023-12-30 at 7 37 10 PM](https://github.com/bluesky-social/social-app/assets/153161762/1487c83c-2ec3-4f20-9b0b-abd35b5df7e1)

Space above:
![Screenshot 2023-12-30 at 7 37 29 PM](https://github.com/bluesky-social/social-app/assets/153161762/92d3c579-396b-44ef-a31f-8a99b0c77d14)

Space to the left (always prefer the left if there is space):
![Screenshot 2023-12-30 at 7 37 43 PM](https://github.com/bluesky-social/social-app/assets/153161762/6e16cf13-cda8-40c3-95a9-ea7c34ed85fe)

No space on the left so we move to the right:
![Screenshot 2023-12-30 at 7 38 10 PM](https://github.com/bluesky-social/social-app/assets/153161762/0118a84d-e337-4c11-9ea1-35649f0772b9)


## Don't close while pressing shift

Simple event listener for shift up/down. Don't close the picker when pressing shift so we can select multiple emojis.