### PR TITLE
hackfix for android splashscreen on api <= 25 (white screen)

### DIFF
--- a/src/Splash.tsx
+++ b/src/Splash.tsx
@@ -137,7 +137,7 @@ export function Splash(props: React.PropsWithChildren<Props>) {
         />
       )}
 
-      {platformApiLevel && platformApiLevel <= 27 ? (
+      {platformApiLevel && platformApiLevel <= 25 ? (
         <>
           {!isAnimationComplete && (
             <View

--- a/src/Splash.tsx
+++ b/src/Splash.tsx
@@ -2,6 +2,7 @@ import React, {useCallback, useEffect} from 'react'
 import {View, StyleSheet, Image as RNImage} from 'react-native'
 import * as SplashScreen from 'expo-splash-screen'
 import {Image} from 'expo-image'
+import {platformApiLevel} from 'expo-device'
 import Animated, {
   interpolate,
   runOnJS,
@@ -136,34 +137,51 @@ export function Splash(props: React.PropsWithChildren<Props>) {
         />
       )}
 
-      <MaskedView
-        style={[StyleSheet.absoluteFillObject]}
-        maskElement={
-          <Animated.View
-            style={[
-              StyleSheet.absoluteFillObject,
-              {
-                // Transparent background because mask is based off alpha channel.
-                backgroundColor: 'transparent',
-                flex: 1,
-                justifyContent: 'center',
-                alignItems: 'center',
-                transform: [{translateY: -(insets.top / 2)}, {scale: 0.1}], // scale from 1000px to 100px
-              },
-            ]}>
-            <AnimatedLogo style={[logoAnimations]} />
+      {platformApiLevel && platformApiLevel <= 27 ? (
+        <>
+          {!isAnimationComplete && (
+            <View
+              style={[
+                StyleSheet.absoluteFillObject,
+                {backgroundColor: 'white'},
+              ]}
+            />
+          )}
+          <Animated.View style={[{flex: 1}, appAnimation]}>
+            {props.children}
           </Animated.View>
-        }>
-        {!isAnimationComplete && (
-          <View
-            style={[StyleSheet.absoluteFillObject, {backgroundColor: 'white'}]}
-          />
-        )}
-
-        <Animated.View style={[{flex: 1}, appAnimation]}>
-          {props.children}
-        </Animated.View>
-      </MaskedView>
+        </>
+      ) : (
+        <MaskedView
+          style={[StyleSheet.absoluteFillObject]}
+          maskElement={
+            <Animated.View
+              style={[
+                {
+                  // Transparent background because mask is based off alpha channel.
+                  backgroundColor: 'transparent',
+                  flex: 1,
+                  justifyContent: 'center',
+                  alignItems: 'center',
+                  transform: [{translateY: -(insets.top / 2)}, {scale: 0.1}], // scale from 1000px to 100px
+                },
+              ]}>
+              <AnimatedLogo style={[logoAnimations]} />
+            </Animated.View>
+          }>
+          {!isAnimationComplete && (
+            <View
+              style={[
+                StyleSheet.absoluteFillObject,
+                {backgroundColor: 'white'},
+              ]}
+            />
+          )}
+          <Animated.View style={[{flex: 1}, appAnimation]}>
+            {props.children}
+          </Animated.View>
+        </MaskedView>
+      )}
     </View>
   )
 }


### PR DESCRIPTION
See: https://bsky.app/profile/sndtrkng.bsky.social/post/3khr3vnm5cm2m

I ran into this while testing a different PR and marked it up as an emulator issue, but it doesn't seem to be. It actually looks like some sort of issue with `MaskedView`. On platform versions <= 25, the `maskElement` doesn't seem to work at all. I suspect it is something to do with this: https://github.com/react-native-masked-view/masked-view#androidrenderingmode

Setting that prop to `software` doesn't help though. I don't think there's a very large number of people on <= 25 so *probably* this isn't affecting too many users, but there are some. Maybe you can find a better fix 🤷‍♀️

Of note though, it doesn't matter *what* you set as the mask element. An empty `<View />` will cause the issue, so it might not be an animation issue at all. There might be some more info in that repo that could help to resolve it, unsure.

Feel free to merge or not, just wanted to point out the actual problem since I was at first thinking the animation itself needed to be debugged and wasted about 15 minutes trying that.

I'm filing this one under: "what the fuck android, why do you even exist."