### PR TITLE
add expandable context to composer when replying to post

### DIFF
--- a/src/state/shell/composer.tsx
+++ b/src/state/shell/composer.tsx
@@ -11,6 +11,7 @@ export interface ComposerOptsPostRef {
     displayName?: string
     avatar?: string
   }
+  embed?: AppBskyEmbedRecord.ViewRecord['embed']
 }
 export interface ComposerOptsQuote {
   uri: string

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -5,7 +5,9 @@ import {
   BackHandler,
   Keyboard,
   KeyboardAvoidingView,
+  LayoutAnimation,
   Platform,
+  Pressable,
   ScrollView,
   StyleSheet,
   TouchableOpacity,
@@ -109,6 +111,7 @@ export const ComposePost = observer(function ComposePost({
   const [labels, setLabels] = useState<string[]>([])
   const [threadgate, setThreadgate] = useState<ThreadgateSetting[]>([])
   const [suggestedLinks, setSuggestedLinks] = useState<Set<string>>(new Set())
+  const [showFullReplyTo, setShowFullReplyTo] = useState(false)
   const gallery = useMemo(() => new GalleryModel(), [])
   const onClose = useCallback(() => {
     closeComposer()
@@ -263,6 +266,15 @@ export const ComposePost = observer(function ComposePost({
     Toast.show(`Your ${replyTo ? 'reply' : 'post'} has been published`)
   }
 
+  const onReplyToPress = useCallback(() => {
+    LayoutAnimation.configureNext({
+      ...LayoutAnimation.Presets.spring,
+      duration: 350,
+      update: {type: 'spring', springDamping: 0.7},
+    })
+    setShowFullReplyTo(prev => !prev)
+  }, [])
+
   const canPost = useMemo(
     () =>
       graphemeLength <= MAX_GRAPHEME_LENGTH &&
@@ -375,7 +387,16 @@ export const ComposePost = observer(function ComposePost({
           style={styles.scrollView}
           keyboardShouldPersistTaps="always">
           {replyTo ? (
-            <View style={[pal.border, styles.replyToLayout]}>
+            <Pressable
+              style={[pal.border, styles.replyToLayout]}
+              onPress={onReplyToPress}
+              accessibilityRole="button"
+              accessibilityLabel={_(
+                msg`Expand or collapse the full post you are replying to`,
+              )}
+              accessibilityHint={_(
+                msg`Expand or collapse the full post you are replying to`,
+              )}>
               <UserAvatar avatar={replyTo.author.avatar} size={50} />
               <View style={styles.replyToPost}>
                 <Text type="xl-medium" style={[pal.text]}>
@@ -384,11 +405,14 @@ export const ComposePost = observer(function ComposePost({
                       sanitizeHandle(replyTo.author.handle),
                   )}
                 </Text>
-                <Text type="post-text" style={pal.text} numberOfLines={6}>
+                <Text
+                  type="post-text"
+                  style={pal.text}
+                  numberOfLines={!showFullReplyTo ? 6 : undefined}>
                   {replyTo.text}
                 </Text>
               </View>
-            </View>
+            </Pressable>
           ) : undefined}
 
           <View

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -5,7 +5,6 @@ import {
   BackHandler,
   Keyboard,
   KeyboardAvoidingView,
-  LayoutAnimation,
   Platform,
   Pressable,
   ScrollView,
@@ -30,8 +29,6 @@ import {UserAvatar} from '../util/UserAvatar'
 import * as apilib from 'lib/api/index'
 import {ComposerOpts} from 'state/shell/composer'
 import {s, colors, gradients} from 'lib/styles'
-import {sanitizeDisplayName} from 'lib/strings/display-names'
-import {sanitizeHandle} from 'lib/strings/handles'
 import {cleanError} from 'lib/strings/errors'
 import {shortenLinks} from 'lib/strings/rich-text-manip'
 import {toShortUrl} from 'lib/strings/url-helpers'
@@ -64,6 +61,7 @@ import {useComposerControls} from '#/state/shell/composer'
 import {emitPostCreated} from '#/state/events'
 import {ThreadgateSetting} from '#/state/queries/threadgate'
 import {logger} from '#/logger'
+import {ComposerReplyTo} from 'view/com/composer/ComposerReplyTo'
 
 type Props = ComposerOpts
 export const ComposePost = observer(function ComposePost({
@@ -111,7 +109,6 @@ export const ComposePost = observer(function ComposePost({
   const [labels, setLabels] = useState<string[]>([])
   const [threadgate, setThreadgate] = useState<ThreadgateSetting[]>([])
   const [suggestedLinks, setSuggestedLinks] = useState<Set<string>>(new Set())
-  const [showFullReplyTo, setShowFullReplyTo] = useState(false)
   const gallery = useMemo(() => new GalleryModel(), [])
   const onClose = useCallback(() => {
     closeComposer()
@@ -266,15 +263,6 @@ export const ComposePost = observer(function ComposePost({
     Toast.show(`Your ${replyTo ? 'reply' : 'post'} has been published`)
   }
 
-  const onReplyToPress = useCallback(() => {
-    LayoutAnimation.configureNext({
-      ...LayoutAnimation.Presets.spring,
-      duration: 350,
-      update: {type: 'spring', springDamping: 0.7},
-    })
-    setShowFullReplyTo(prev => !prev)
-  }, [])
-
   const canPost = useMemo(
     () =>
       graphemeLength <= MAX_GRAPHEME_LENGTH &&
@@ -390,34 +378,7 @@ export const ComposePost = observer(function ComposePost({
         <ScrollView
           style={styles.scrollView}
           keyboardShouldPersistTaps="always">
-          {replyTo ? (
-            <Pressable
-              style={[pal.border, styles.replyToLayout]}
-              onPress={onReplyToPress}
-              accessibilityRole="button"
-              accessibilityLabel={_(
-                msg`Expand or collapse the full post you are replying to`,
-              )}
-              accessibilityHint={_(
-                msg`Expand or collapse the full post you are replying to`,
-              )}>
-              <UserAvatar avatar={replyTo.author.avatar} size={50} />
-              <View style={styles.replyToPost}>
-                <Text type="xl-medium" style={[pal.text]}>
-                  {sanitizeDisplayName(
-                    replyTo.author.displayName ||
-                      sanitizeHandle(replyTo.author.handle),
-                  )}
-                </Text>
-                <Text
-                  type="post-text"
-                  style={pal.text}
-                  numberOfLines={!showFullReplyTo ? 6 : undefined}>
-                  {replyTo.text}
-                </Text>
-              </View>
-            </Pressable>
-          ) : undefined}
+          {replyTo ? <ComposerReplyTo replyTo={replyTo} /> : undefined}
 
           <View
             style={[
@@ -571,17 +532,6 @@ const styles = StyleSheet.create({
   },
   textInputLayoutMobile: {
     flex: 1,
-  },
-  replyToLayout: {
-    flexDirection: 'row',
-    borderTopWidth: 1,
-    paddingTop: 16,
-    paddingBottom: 16,
-  },
-  replyToPost: {
-    flex: 1,
-    paddingLeft: 13,
-    paddingRight: 8,
   },
   addExtLinkBtn: {
     borderWidth: 1,

--- a/src/view/com/composer/ComposerReplyTo.tsx
+++ b/src/view/com/composer/ComposerReplyTo.tsx
@@ -91,19 +91,19 @@ export function ComposerReplyTo({replyTo}: {replyTo: ComposerOptsPostRef}) {
           )}
         </Text>
         <View style={styles.replyToBody}>
-          <View style={styles.flex}>
+          <View style={styles.replyToText}>
             <Text
               type="post-text"
               style={pal.text}
               numberOfLines={!showFull ? 6 : undefined}>
               {replyTo.text}
             </Text>
-            {showFull && quote && <QuoteEmbed quote={quote} />}
           </View>
           {images && (
             <ComposerReplyToImages images={images} showFull={showFull} />
           )}
         </View>
+        {showFull && quote && <QuoteEmbed quote={quote} />}
       </View>
     </Pressable>
   )
@@ -209,10 +209,6 @@ function ComposerReplyToImages({
 }
 
 const styles = StyleSheet.create({
-  flex: {
-    flex: 1,
-    flexGrow: 1,
-  },
   replyToLayout: {
     flexDirection: 'row',
     borderTopWidth: 1,
@@ -227,6 +223,10 @@ const styles = StyleSheet.create({
   replyToBody: {
     flexDirection: 'row',
     gap: 4,
+  },
+  replyToText: {
+    flex: 1,
+    flexGrow: 1,
   },
   imagesContainer: {
     borderRadius: 6,

--- a/src/view/com/composer/ComposerReplyTo.tsx
+++ b/src/view/com/composer/ComposerReplyTo.tsx
@@ -222,7 +222,7 @@ const styles = StyleSheet.create({
   },
   replyToBody: {
     flexDirection: 'row',
-    gap: 4,
+    gap: 10,
   },
   replyToText: {
     flex: 1,

--- a/src/view/com/composer/ComposerReplyTo.tsx
+++ b/src/view/com/composer/ComposerReplyTo.tsx
@@ -6,6 +6,7 @@ import {LayoutAnimation, Pressable, StyleSheet, View} from 'react-native'
 import {
   AppBskyEmbedImages,
   AppBskyEmbedRecord,
+  AppBskyEmbedRecordWithMedia,
   AppBskyFeedPost,
 } from '@atproto/api'
 import {msg} from '@lingui/macro'
@@ -45,13 +46,29 @@ export function ComposerReplyTo({replyTo}: {replyTo: ComposerOptsPostRef}) {
         indexedAt: embed.record.indexedAt,
         text: embed.record.value.text,
       }
+    } else if (
+      AppBskyEmbedRecordWithMedia.isView(embed) &&
+      AppBskyEmbedRecord.isViewRecord(embed.record.record) &&
+      AppBskyFeedPost.isRecord(embed.record.record.value)
+    ) {
+      return {
+        author: embed.record.record.author,
+        cid: embed.record.record.cid,
+        uri: embed.record.record.uri,
+        indexedAt: embed.record.record.indexedAt,
+        text: embed.record.record.value.text,
+      }
     }
   }, [embed])
 
   const images = React.useMemo(() => {
     if (AppBskyEmbedImages.isView(embed)) {
-      console.log(embed.images)
       return embed.images
+    } else if (
+      AppBskyEmbedRecordWithMedia.isView(embed) &&
+      AppBskyEmbedImages.isView(embed.media)
+    ) {
+      return embed.media.images
     }
   }, [embed])
 
@@ -83,7 +100,6 @@ export function ComposerReplyTo({replyTo}: {replyTo: ComposerOptsPostRef}) {
             </Text>
             {showFull && quote && <QuoteEmbed quote={quote} />}
           </View>
-
           {images && (
             <ComposerReplyToImages images={images} showFull={showFull} />
           )}
@@ -99,8 +115,6 @@ function ComposerReplyToImages({
   images: AppBskyEmbedImages.ViewImage[]
   showFull: boolean
 }) {
-  images = images.slice(0, 4)
-
   return (
     <View
       style={{
@@ -195,6 +209,10 @@ function ComposerReplyToImages({
 }
 
 const styles = StyleSheet.create({
+  flex: {
+    flex: 1,
+    flexGrow: 1,
+  },
   replyToLayout: {
     flexDirection: 'row',
     borderTopWidth: 1,
@@ -211,18 +229,15 @@ const styles = StyleSheet.create({
     gap: 4,
   },
   imagesContainer: {
-    flexWrap: 'wrap',
     borderRadius: 6,
     overflow: 'hidden',
+    marginTop: 2,
   },
   imagesInner: {
     gap: 2,
   },
   imagesRow: {
     flexDirection: 'row',
-  },
-  flex: {
-    flex: 1,
   },
   singleImage: {
     width: 65,

--- a/src/view/com/composer/ComposerReplyTo.tsx
+++ b/src/view/com/composer/ComposerReplyTo.tsx
@@ -1,21 +1,21 @@
-import {ComposerOptsPostRef} from 'state/shell/composer'
-import {usePalette} from 'lib/hooks/usePalette'
-import {useLingui} from '@lingui/react'
 import React from 'react'
 import {LayoutAnimation, Pressable, StyleSheet, View} from 'react-native'
+import {Image} from 'expo-image'
+import {useLingui} from '@lingui/react'
+import {msg} from '@lingui/macro'
 import {
   AppBskyEmbedImages,
   AppBskyEmbedRecord,
   AppBskyEmbedRecordWithMedia,
   AppBskyFeedPost,
 } from '@atproto/api'
-import {msg} from '@lingui/macro'
-import {UserAvatar} from 'view/com/util/UserAvatar'
-import {Text} from 'view/com/util/text/Text'
+import {ComposerOptsPostRef} from 'state/shell/composer'
+import {usePalette} from 'lib/hooks/usePalette'
 import {sanitizeDisplayName} from 'lib/strings/display-names'
 import {sanitizeHandle} from 'lib/strings/handles'
+import {UserAvatar} from 'view/com/util/UserAvatar'
+import {Text} from 'view/com/util/text/Text'
 import QuoteEmbed from 'view/com/util/post-embeds/QuoteEmbed'
-import {Image} from 'expo-image'
 
 export function ComposerReplyTo({replyTo}: {replyTo: ComposerOptsPostRef}) {
   const pal = usePalette('default')

--- a/src/view/com/composer/ComposerReplyTo.tsx
+++ b/src/view/com/composer/ComposerReplyTo.tsx
@@ -1,0 +1,239 @@
+import {ComposerOptsPostRef} from 'state/shell/composer'
+import {usePalette} from 'lib/hooks/usePalette'
+import {useLingui} from '@lingui/react'
+import React from 'react'
+import {LayoutAnimation, Pressable, StyleSheet, View} from 'react-native'
+import {
+  AppBskyEmbedImages,
+  AppBskyEmbedRecord,
+  AppBskyFeedPost,
+} from '@atproto/api'
+import {msg} from '@lingui/macro'
+import {UserAvatar} from 'view/com/util/UserAvatar'
+import {Text} from 'view/com/util/text/Text'
+import {sanitizeDisplayName} from 'lib/strings/display-names'
+import {sanitizeHandle} from 'lib/strings/handles'
+import QuoteEmbed from 'view/com/util/post-embeds/QuoteEmbed'
+import {Image} from 'expo-image'
+
+export function ComposerReplyTo({replyTo}: {replyTo: ComposerOptsPostRef}) {
+  const pal = usePalette('default')
+  const {_} = useLingui()
+  const {embed} = replyTo
+
+  const [showFull, setShowFull] = React.useState(false)
+
+  const onPress = React.useCallback(() => {
+    setShowFull(prev => !prev)
+    LayoutAnimation.configureNext({
+      duration: 350,
+      update: {type: 'spring', springDamping: 0.7},
+    })
+  }, [])
+
+  const quote = React.useMemo(() => {
+    if (
+      AppBskyEmbedRecord.isView(embed) &&
+      AppBskyEmbedRecord.isViewRecord(embed.record) &&
+      AppBskyFeedPost.isRecord(embed.record.value)
+    ) {
+      // Not going to include the images right now
+      return {
+        author: embed.record.author,
+        cid: embed.record.cid,
+        uri: embed.record.uri,
+        indexedAt: embed.record.indexedAt,
+        text: embed.record.value.text,
+      }
+    }
+  }, [embed])
+
+  const images = React.useMemo(() => {
+    if (AppBskyEmbedImages.isView(embed)) {
+      console.log(embed.images)
+      return embed.images
+    }
+  }, [embed])
+
+  return (
+    <Pressable
+      style={[pal.border, styles.replyToLayout]}
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityLabel={_(
+        msg`Expand or collapse the full post you are replying to`,
+      )}
+      accessibilityHint={_(
+        msg`Expand or collapse the full post you are replying to`,
+      )}>
+      <UserAvatar avatar={replyTo.author.avatar} size={50} />
+      <View style={styles.replyToPost}>
+        <Text type="xl-medium" style={[pal.text]}>
+          {sanitizeDisplayName(
+            replyTo.author.displayName || sanitizeHandle(replyTo.author.handle),
+          )}
+        </Text>
+        <View style={styles.replyToBody}>
+          <View style={styles.flex}>
+            <Text
+              type="post-text"
+              style={pal.text}
+              numberOfLines={!showFull ? 6 : undefined}>
+              {replyTo.text}
+            </Text>
+            {showFull && quote && <QuoteEmbed quote={quote} />}
+          </View>
+
+          {images && (
+            <ComposerReplyToImages images={images} showFull={showFull} />
+          )}
+        </View>
+      </View>
+    </Pressable>
+  )
+}
+
+function ComposerReplyToImages({
+  images,
+}: {
+  images: AppBskyEmbedImages.ViewImage[]
+  showFull: boolean
+}) {
+  images = images.slice(0, 4)
+
+  return (
+    <View
+      style={{
+        width: 65,
+        flexDirection: 'column',
+        alignItems: 'center',
+      }}>
+      <View style={styles.imagesContainer}>
+        {(images.length === 1 && (
+          <Image
+            source={{uri: images[0].thumb}}
+            style={styles.singleImage}
+            cachePolicy="memory-disk"
+            accessibilityIgnoresInvertColors
+          />
+        )) ||
+          (images.length === 2 && (
+            <View style={[styles.imagesInner, styles.imagesRow]}>
+              <Image
+                source={{uri: images[0].thumb}}
+                style={styles.doubleImageTall}
+                cachePolicy="memory-disk"
+                accessibilityIgnoresInvertColors
+              />
+              <Image
+                source={{uri: images[1].thumb}}
+                style={styles.doubleImageTall}
+                cachePolicy="memory-disk"
+                accessibilityIgnoresInvertColors
+              />
+            </View>
+          )) ||
+          (images.length === 3 && (
+            <View style={[styles.imagesInner, styles.imagesRow]}>
+              <Image
+                source={{uri: images[0].thumb}}
+                style={styles.doubleImageTall}
+                cachePolicy="memory-disk"
+                accessibilityIgnoresInvertColors
+              />
+              <View style={styles.imagesInner}>
+                <Image
+                  source={{uri: images[1].thumb}}
+                  style={styles.doubleImage}
+                  cachePolicy="memory-disk"
+                  accessibilityIgnoresInvertColors
+                />
+                <Image
+                  source={{uri: images[2].thumb}}
+                  style={styles.doubleImage}
+                  cachePolicy="memory-disk"
+                  accessibilityIgnoresInvertColors
+                />
+              </View>
+            </View>
+          )) ||
+          (images.length === 4 && (
+            <View style={styles.imagesInner}>
+              <View style={[styles.imagesInner, styles.imagesRow]}>
+                <Image
+                  source={{uri: images[0].thumb}}
+                  style={styles.doubleImage}
+                  cachePolicy="memory-disk"
+                  accessibilityIgnoresInvertColors
+                />
+                <Image
+                  source={{uri: images[1].thumb}}
+                  style={styles.doubleImage}
+                  cachePolicy="memory-disk"
+                  accessibilityIgnoresInvertColors
+                />
+              </View>
+              <View style={[styles.imagesInner, styles.imagesRow]}>
+                <Image
+                  source={{uri: images[2].thumb}}
+                  style={styles.doubleImage}
+                  cachePolicy="memory-disk"
+                  accessibilityIgnoresInvertColors
+                />
+                <Image
+                  source={{uri: images[3].thumb}}
+                  style={styles.doubleImage}
+                  cachePolicy="memory-disk"
+                  accessibilityIgnoresInvertColors
+                />
+              </View>
+            </View>
+          ))}
+      </View>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  replyToLayout: {
+    flexDirection: 'row',
+    borderTopWidth: 1,
+    paddingTop: 16,
+    paddingBottom: 16,
+  },
+  replyToPost: {
+    flex: 1,
+    paddingLeft: 13,
+    paddingRight: 8,
+  },
+  replyToBody: {
+    flexDirection: 'row',
+    gap: 4,
+  },
+  imagesContainer: {
+    flexWrap: 'wrap',
+    borderRadius: 6,
+    overflow: 'hidden',
+  },
+  imagesInner: {
+    gap: 2,
+  },
+  imagesRow: {
+    flexDirection: 'row',
+  },
+  flex: {
+    flex: 1,
+  },
+  singleImage: {
+    width: 65,
+    height: 65,
+  },
+  doubleImageTall: {
+    width: 32.5,
+    height: 65,
+  },
+  doubleImage: {
+    width: 32.5,
+    height: 32.5,
+  },
+})

--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -214,6 +214,7 @@ let PostThreadItemLoaded = ({
           displayName: post.author.displayName,
           avatar: post.author.avatar,
         },
+        embed: post.embed,
       },
       onPost: onPostReply,
     })

--- a/src/view/com/post/Post.tsx
+++ b/src/view/com/post/Post.tsx
@@ -118,6 +118,7 @@ function PostInner({
           displayName: post.author.displayName,
           avatar: post.author.avatar,
         },
+        embed: post.embed,
       },
     })
   }, [openComposer, post, record])

--- a/src/view/com/posts/FeedItem.tsx
+++ b/src/view/com/posts/FeedItem.tsx
@@ -131,6 +131,7 @@ let FeedItemInner = ({
           displayName: post.author.displayName,
           avatar: post.author.avatar,
         },
+        embed: post.embed,
       },
     })
   }, [post, record, openComposer])

--- a/src/view/screens/PostThread.tsx
+++ b/src/view/screens/PostThread.tsx
@@ -67,6 +67,7 @@ export function PostThreadScreen({route}: Props) {
           displayName: thread.post.author.displayName,
           avatar: thread.post.author.avatar,
         },
+        embed: thread.post.embed,
       },
       onPost: () =>
         queryClient.invalidateQueries({


### PR DESCRIPTION
Small addition for something that really bothers me. When replying to a larger post, we lose the ability to see the full context of the post. Sometimes I find myself needing to copy my reply and discard it real quick to see the full post...

This just makes the reply to area a pressable and adds a little `LayoutAnimation` to the expand/collapse so it looks pretty. Also displays images in a square similar to how Twitter does when applicable, as well as shows the text of the quoted post.

<img src="https://github.com/bluesky-social/social-app/assets/153161762/27cf1927-57e6-426a-86fc-d9d7488c67b6" width="300">

https://github.com/bluesky-social/social-app/assets/153161762/961c163d-d8f5-48cc-b3f8-a26c0b3ebccc

https://github.com/bluesky-social/social-app/assets/153161762/3ca6559e-b3bf-4e3e-9d8c-072920a7538b

