### PR TITLE
Reduce web requests

### DIFF
--- a/src/state/queries/app-passwords.ts
+++ b/src/state/queries/app-passwords.ts
@@ -9,7 +9,6 @@ export const RQKEY = () => ['app-passwords']
 export function useAppPasswordsQuery() {
   return useQuery({
     staleTime: STALE.MINUTES.FIVE,
-    refetchInterval: STALE.MINUTES.ONE,
     queryKey: RQKEY(),
     queryFn: async () => {
       const res = await getAgent().com.atproto.server.listAppPasswords({})

--- a/src/state/queries/invites.ts
+++ b/src/state/queries/invites.ts
@@ -16,7 +16,6 @@ export type InviteCodesQueryResponse = Exclude<
 export function useInviteCodesQuery() {
   return useQuery({
     staleTime: STALE.MINUTES.FIVE,
-    refetchInterval: STALE.MINUTES.FIVE,
     queryKey: ['inviteCodes'],
     queryFn: async () => {
       const res = await getAgent()

--- a/src/state/queries/notifications/unread.tsx
+++ b/src/state/queries/notifications/unread.tsx
@@ -15,6 +15,7 @@ import {useMutedThreads} from '#/state/muted-threads'
 import {RQKEY as RQKEY_NOTIFS} from './feed'
 import {logger} from '#/logger'
 import {truncateAndInvalidate} from '../util'
+import {AppState} from 'react-native'
 
 const UPDATE_INTERVAL = 30 * 1e3 // 30sec
 
@@ -97,6 +98,9 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
       async checkUnread({invalidate}: {invalidate?: boolean} = {}) {
         try {
           if (!getAgent().session) return
+          if (AppState.currentState !== 'active') {
+            return
+          }
 
           // count
           const page = await fetchPage({

--- a/src/state/queries/post-feed.ts
+++ b/src/state/queries/post-feed.ts
@@ -1,4 +1,5 @@
 import React, {useCallback, useEffect, useRef} from 'react'
+import {AppState} from 'react-native'
 import {AppBskyFeedDefs, AppBskyFeedPost, PostModeration} from '@atproto/api'
 import {
   useInfiniteQuery,
@@ -311,6 +312,9 @@ export function usePostFeedQuery(
 export async function pollLatest(page: FeedPage | undefined) {
   if (!page) {
     return false
+  }
+  if (AppState.currentState !== 'active') {
+    return
   }
 
   logger.debug('usePostFeedQuery: pollLatest')


### PR DESCRIPTION
We're still trying to track down the excessive web traffic. This PR makes two changes:

- 4e7c886fb2c21497b48e00325ae5bc0a97b0796d Stop auto-refetching app passwords and invites on an interval
- bd62ce7668b1ea57654a5dede4990ef738dabcae Stop polling posts and notifications when the tab is backgrounded

The second commit is likely to reduce traffic dramatically on web, where people often have multiple tabs open