### PR TITLE
New user home feed fixes

### DIFF
--- a/src/lib/api/feed/merge.ts
+++ b/src/lib/api/feed/merge.ts
@@ -98,7 +98,7 @@ export class MergeFeedAPI implements FeedAPI {
     }
 
     return {
-      cursor: posts.length ? String(this.itemCursor) : undefined,
+      cursor: String(this.itemCursor),
       feed: posts,
     }
   }

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -117,8 +117,8 @@ export async function DEFAULT_FEEDS(
   } else {
     // production
     return {
-      pinned: [],
-      saved: [],
+      pinned: [PROD_DEFAULT_FEED('whats-hot')],
+      saved: [PROD_DEFAULT_FEED('whats-hot')],
     }
   }
 }

--- a/src/view/screens/Home.tsx
+++ b/src/view/screens/Home.tsx
@@ -19,6 +19,7 @@ import {useSession} from '#/state/session'
 import {loadString, saveString} from '#/lib/storage'
 import {useWebMediaQueries} from '#/lib/hooks/useWebMediaQueries'
 import {clamp} from '#/lib/numbers'
+import {PROD_DEFAULT_FEED} from '#/lib/constants'
 
 type Props = NativeStackScreenProps<HomeTabNavigatorParams, 'Home'>
 export function HomeScreen(props: Props) {
@@ -109,7 +110,9 @@ function HomeScreenReady({
   const homeFeedParams = React.useMemo<FeedParams>(() => {
     return {
       mergeFeedEnabled: Boolean(preferences.feedViewPrefs.lab_mergeFeedEnabled),
-      mergeFeedSources: preferences.feeds.saved,
+      mergeFeedSources: preferences.feedViewPrefs.lab_mergeFeedEnabled
+        ? preferences.feeds.saved
+        : [PROD_DEFAULT_FEED('whats-hot')],
     }
   }, [preferences])
 


### PR DESCRIPTION
- 7bd9d9ebc01f4b7e10a1f35a6eb48ac8a4f5ca90 Restores discover to default feeds for new users (should not have been removed)
- 1cb9abad3544c2367fdd3ffd2b18f7079e29229b Updates the mergefeed emergency fallback to only source from discover
- 736aeca7f93f226548631a056eddc2da34be02d4 Makes sure the mergefeed always returns a cursor, which protects against a case where the emergency mergefeed might give the "end of feed" condition prematurely. That has the potential to create an endless spinner if the mergefeed is actually out of posts, but that's very unlikely with multiple custom feeds, while the more likely issue is that the emergency mergefeed will glitch out.

All of this is a temporary solution to ensuring that new users get content after signup. We will replace all of this in the near future.