### PR TITLE
Include expanded urls in social cards

### DIFF
--- a/bskyweb/templates/post.html
+++ b/bskyweb/templates/post.html
@@ -22,8 +22,8 @@
   <meta property="og:title" content="@{{ postView.Author.Handle }}">
   {% endif -%}
   {%- if postView.Record.Val.Text %}
-  <meta name="description" content="{{ postView.Record.Val.Text }}">
-  <meta property="og:description" content="{{ postView.Record.Val.Text }}">
+  <meta name="description" content="{{ postText }}">
+  <meta property="og:description" content="{{ postText }}">
   {% endif -%}
   {%- if imgThumbUrls %}
   {% for imgThumbUrl in imgThumbUrls %}
@@ -47,7 +47,7 @@
   <p id="bsky_display_name">{{ postView.Author.DisplayName }}</p>
   <p id="bsky_handle">{{ postView.Author.Handle }}</p>
   <p id="bsky_did">{{ postView.Author.Did }}</p>
-  <p id="bsky_post_text">{{ postView.Record.Val.Text }}</p>
+  <p id="bsky_post_text">{{ postText }}</p>
   <p id="bsky_post_indexedat">{{ postView.IndexedAt }}</p>
 </div>
 {% endif -%}

--- a/bskyweb/templates/post.html
+++ b/bskyweb/templates/post.html
@@ -21,7 +21,7 @@
   {% else %}
   <meta property="og:title" content="@{{ postView.Author.Handle }}">
   {% endif -%}
-  {%- if postView.Record.Val.Text %}
+  {%- if postText %}
   <meta name="description" content="{{ postText }}">
   <meta property="og:description" content="{{ postText }}">
   {% endif -%}


### PR DESCRIPTION
#1188 had the side effect that post social cards have truncated links, which means that bsky posts displayed in Slack, among other places, display non-functional URLs. This is increasingly a problem with broader sharing of publicly viewable posts from the web interface. For example:

<img src="https://github.com/bluesky-social/social-app/assets/918245/8eb4511a-4e9e-4d5a-ad82-44a116553b0f" width=400 />
<img src="https://github.com/bluesky-social/social-app/assets/918245/ae4128ea-5afa-4e2a-86b2-2c6aba6540da" width=400 />

This PR undoes the effect of shortenLinks() when formatting social cards, expanding these truncated urls back to their original content from the post's facets. Additionally, posts with embedded links get the url of the embedded link appended to the end of the social card if it's not already included in the post so those posts don't appear without their links.

Full disclosure: I don't know much Go and this is my first bluesky-social PR. I've tested this pretty extensively locally, including with multibyte emoji, posts with multiple links, and a wide variety of posts on the live site, but someone who knows the language and the codebase should please let me know if I've missed anything non-obvious or made a mess of it.

**Before**:
<img src="https://github.com/bluesky-social/social-app/assets/918245/1771c8a9-92ce-4463-9c78-38d459904c5e" width=800 />


**After**:
<img src="https://github.com/bluesky-social/social-app/assets/918245/21e63fdf-6b15-4ce5-a09f-effb03b2fbe6" width=800 />
