### PR TITLE
convert prefix to lowercase in actor autocomplete query

### DIFF
--- a/src/state/queries/actor-autocomplete.ts
+++ b/src/state/queries/actor-autocomplete.ts
@@ -24,6 +24,8 @@ export function useActorAutocompleteQuery(prefix: string) {
   const {data: follows, isFetching} = useMyFollowsQuery()
   const moderationOpts = useModerationOpts()
 
+  prefix = prefix.toLowerCase()
+
   return useQuery<AppBskyActorDefs.ProfileViewBasic[]>({
     staleTime: STALE.MINUTES.ONE,
     queryKey: RQKEY(prefix || ''),


### PR DESCRIPTION
Case shouldn't matter when making autocomplete suggestions, and followed users should be prioritized but without converting the prefix to lowercase, they are not.

Here, convert the prefix to lowercase in the respective query. 

Before:

<img width="200" src="https://github.com/bluesky-social/social-app/assets/153161762/3772ea77-f1b7-4816-8a8e-343858475853">

After: 
<img src="https://github.com/bluesky-social/social-app/assets/153161762/d57157e6-1630-4c42-b90d-d5a1d8d1fdf7" width="200">

fixes https://github.com/bluesky-social/social-app/issues/2430