### PR TITLE
Don't use mask for android at all

### DIFF
--- a/src/Splash.tsx
+++ b/src/Splash.tsx
@@ -2,7 +2,6 @@ import React, {useCallback, useEffect} from 'react'
 import {View, StyleSheet, Image as RNImage} from 'react-native'
 import * as SplashScreen from 'expo-splash-screen'
 import {Image} from 'expo-image'
-import {platformApiLevel} from 'expo-device'
 import Animated, {
   interpolate,
   runOnJS,
@@ -55,7 +54,6 @@ export function Splash(props: React.PropsWithChildren<Props>) {
   const [isImageLoaded, setIsImageLoaded] = React.useState(false)
   const [isLayoutReady, setIsLayoutReady] = React.useState(false)
   const isReady = props.isReady && isImageLoaded && isLayoutReady
-  const isOldAndroid = platformApiLevel && platformApiLevel <= 25
 
   const logoAnimation = useAnimatedStyle(() => {
     return {
@@ -150,7 +148,7 @@ export function Splash(props: React.PropsWithChildren<Props>) {
         />
       )}
 
-      {isAndroid || isOldAndroid ? (
+      {isAndroid ? (
         // Use a simple fade on older versions of android (work around a bug)
         <>
           <Animated.View style={[{flex: 1}, appAnimation]}>


### PR DESCRIPTION
This PR abandons the mask in Android entirely. I tweaked the animation speed a bit to look better without the mask, looks good with mask (iOS) too.

Android:

https://github.com/bluesky-social/social-app/assets/4732330/05ac5fe5-8c7f-448e-8c05-9139ec6f7d6f

iOS:

https://github.com/bluesky-social/social-app/assets/4732330/cbdaf55d-f62e-4064-96a8-e3538df2972c

