### PR TITLE
Post verb vs. noun differentiation in localization

### DIFF
--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -342,7 +342,7 @@ export const ComposePost = observer(function ComposePost({
               ) : (
                 <View style={[styles.postBtn, pal.btn]}>
                   <Text style={[pal.textLight, s.f16, s.bold]}>
-                    <Trans>Post</Trans>
+                    <Trans context="action">Post</Trans>
                   </Text>
                 </View>
               )}


### PR DESCRIPTION
1. Rerun `yarn intl:build`
2. Add `context` to `<Trans>` to differentiate between post verb and noun