### PR TITLE
fix rendering of external in quote embeds

### DIFF
--- a/src/view/com/util/post-embeds/QuoteEmbed.tsx
+++ b/src/view/com/util/post-embeds/QuoteEmbed.tsx
@@ -6,6 +6,7 @@ import {
   AppBskyEmbedImages,
   AppBskyEmbedRecordWithMedia,
   ModerationUI,
+  AppBskyEmbedExternal,
 } from '@atproto/api'
 import {AtUri} from '@atproto/api'
 import {PostMeta} from '../PostMeta'
@@ -87,15 +88,19 @@ export function QuoteEmbed({
     () => quote.text.trim().length === 0,
     [quote.text],
   )
-  const imagesEmbed = React.useMemo(
-    () =>
-      quote.embeds?.find(
-        embed =>
-          AppBskyEmbedImages.isView(embed) ||
-          AppBskyEmbedRecordWithMedia.isView(embed),
-      ),
-    [quote.embeds],
-  )
+  const embed = React.useMemo(() => {
+    const e = quote.embeds?.[0]
+
+    if (AppBskyEmbedImages.isView(e) || AppBskyEmbedExternal.isView(e)) {
+      return e
+    } else if (
+      AppBskyEmbedRecordWithMedia.isView(e) &&
+      (AppBskyEmbedImages.isView(e.media) ||
+        AppBskyEmbedExternal.isView(e.media))
+    ) {
+      return e.media
+    }
+  }, [quote.embeds])
   return (
     <Link
       style={[styles.container, pal.borderDark, style]}
@@ -117,12 +122,7 @@ export function QuoteEmbed({
           {quote.text}
         </Text>
       ) : null}
-      {AppBskyEmbedImages.isView(imagesEmbed) && (
-        <PostEmbeds embed={imagesEmbed} moderation={{}} />
-      )}
-      {AppBskyEmbedRecordWithMedia.isView(imagesEmbed) && (
-        <PostEmbeds embed={imagesEmbed.media} moderation={{}} />
-      )}
+      {embed && <PostEmbeds embed={embed} moderation={{}} />}
     </Link>
   )
 }


### PR DESCRIPTION
External embeds are not currently displayed in a quote post, which results in context loss.

I also think it makes more sense here to remove the `.find()` since - unless this is done in anticipation of future changes - there will never be more than a single embed for a post: https://github.com/bluesky-social/atproto/blob/50f70453a9e49621956e4e820226c0e220fe138e/packages/bsky/src/services/feed/views.ts#L434 (thanks @mary-ext). Instead we just need to get the first possible embed from the array.

We do still need to check for types, since we don't want to show a quote's quote.

![RocketSim_Recording_iPhone_15_Pro_6 1_2024-01-09_18 36 15](https://github.com/bluesky-social/social-app/assets/153161762/dc3226b6-ddee-4407-b8dc-f571ee98245f)

Of course we could add
```tsx
  const externalEmbed = React.useMemo(
    () =>
      quote.embeds?.find(
        embed =>
          AppBskyEmbedExternal.isView(embed)
      ),
    [quote.embeds],
  )
```
but this feels like some additional logic that isn't needed. Correct me if wrong.