### PR TITLE
Add the appropriate color-scheme for dark mode

### DIFF
--- a/bskyweb/templates/base.html
+++ b/bskyweb/templates/base.html
@@ -49,6 +49,7 @@
       --text: white;
       --background: black;
       --backgroundLight: #26272D;
+      color-scheme: dark;
     }
     @media (prefers-color-scheme: light) {
       html.colorMode--system {
@@ -62,6 +63,7 @@
         --text: white;
         --background: black;
         --backgroundLight: #26272D;
+        color-scheme: dark;
       }
     }
 

--- a/web/index.html
+++ b/web/index.html
@@ -53,6 +53,7 @@
         --text: white;
         --background: black;
         --backgroundLight: #26272D;
+        color-scheme: dark;
       }
       @media (prefers-color-scheme: light) {
         html.colorMode--system {
@@ -66,6 +67,7 @@
           --text: white;
           --background: black;
           --backgroundLight: #26272D;
+          color-scheme: dark;
         }
       }
 


### PR DESCRIPTION
Fixes https://github.com/bluesky-social/social-app/issues/2463

Adds `color-scheme: dark` when dark theme is used, this turns scrollbars and native input elements to the appropriate dark-theme versions.