### PR TITLE
Don't set autocomplete on search input

### DIFF
--- a/src/view/screens/Search/Search.tsx
+++ b/src/view/screens/Search/Search.tsx
@@ -572,6 +572,7 @@ export function SearchScreen(
             accessibilityLabel={_(msg`Search`)}
             accessibilityHint=""
             autoCorrect={false}
+            autoComplete="off"
             autoCapitalize="none"
           />
           {query ? (

--- a/src/view/shell/desktop/Search.tsx
+++ b/src/view/shell/desktop/Search.tsx
@@ -169,6 +169,9 @@ export function DesktopSearch() {
             accessibilityRole="search"
             accessibilityLabel={_(msg`Search`)}
             accessibilityHint=""
+            autoCorrect={false}
+            autoComplete="off"
+            autoCapitalize="none"
           />
           {query ? (
             <View style={styles.cancelBtn}>


### PR DESCRIPTION
Potentially fixes https://github.com/bluesky-social/social-app/issues/2443
Potentially fixes https://github.com/bluesky-social/social-app/issues/1648

I can't reproduce this, but `autocomplete=on` was being put on text inputs, that means the browser gets to make its own judgement on what it should be autocompleting, so let's turn it off and see if this magically solves the issue.