### PR TITLE
Reorder the locales alphabetically

### DIFF
--- a/lingui.config.js
+++ b/lingui.config.js
@@ -1,6 +1,6 @@
 /** @type {import('@lingui/conf').LinguiConfig} */
 module.exports = {
-  locales: ['en', 'hi', 'ja', 'fr', 'de', 'es', 'ko', 'es', 'pt-BR', 'uk', 'id'],
+  locales: ['en', 'de', 'es', 'fr', 'hi', 'id', 'ja', 'ko', 'pt-BR', 'uk'],
   catalogs: [
     {
       path: '<rootDir>/src/locale/locales/{locale}/messages',

--- a/src/locale/helpers.ts
+++ b/src/locale/helpers.ts
@@ -113,14 +113,14 @@ export function sanitizeAppLanguageSetting(appLanguage: string): AppLanguage {
       // DISABLED until this translation is fixed -prf
       // case 'de':
       //   return AppLanguage.de
-      case 'id':
-        return AppLanguage.id
       case 'es':
         return AppLanguage.es
       case 'fr':
         return AppLanguage.fr
       case 'hi':
         return AppLanguage.hi
+      case 'id':
+        return AppLanguage.id
       case 'ja':
         return AppLanguage.ja
       case 'ko':

--- a/src/locale/i18n.ts
+++ b/src/locale/i18n.ts
@@ -27,10 +27,6 @@ export async function dynamicActivate(locale: AppLanguage) {
     //   i18n.loadAndActivate({locale, messages: messagesDe})
     //   break
     // }
-    case AppLanguage.id: {
-      i18n.loadAndActivate({locale, messages: messagesId})
-      break
-    }
     case AppLanguage.es: {
       i18n.loadAndActivate({locale, messages: messagesEs})
       break
@@ -41,6 +37,10 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.hi: {
       i18n.loadAndActivate({locale, messages: messagesHi})
+      break
+    }
+    case AppLanguage.id: {
+      i18n.loadAndActivate({locale, messages: messagesId})
       break
     }
     case AppLanguage.ja: {

--- a/src/locale/i18n.web.ts
+++ b/src/locale/i18n.web.ts
@@ -17,10 +17,6 @@ export async function dynamicActivate(locale: AppLanguage) {
     //   mod = await import(`./locales/de/messages`)
     //   break
     // }
-    case AppLanguage.id: {
-      mod = await import(`./locales/id/messages`)
-      break
-    }
     case AppLanguage.es: {
       mod = await import(`./locales/es/messages`)
       break
@@ -31,6 +27,10 @@ export async function dynamicActivate(locale: AppLanguage) {
     }
     case AppLanguage.hi: {
       mod = await import(`./locales/hi/messages`)
+      break
+    }
+    case AppLanguage.id: {
+      mod = await import(`./locales/id/messages`)
       break
     }
     case AppLanguage.ja: {

--- a/src/locale/languages.ts
+++ b/src/locale/languages.ts
@@ -8,10 +8,10 @@ export enum AppLanguage {
   en = 'en',
   // DISABLED until this translation is fixed -prf
   // de = 'de',
-  id = 'id',
   es = 'es',
   fr = 'fr',
   hi = 'hi',
+  id = 'id',
   ja = 'ja',
   ko = 'ko',
   pt_BR = 'pt-BR',
@@ -27,10 +27,10 @@ export const APP_LANGUAGES: AppLanguageConfig[] = [
   {code2: AppLanguage.en, name: 'English'},
   // DISABLED until this translation is fixed -prf
   // {code2: AppLanguage.de, name: 'Deutsch'},
-  {code2: AppLanguage.id, name: 'Indonesian'},
   {code2: AppLanguage.es, name: 'Español'},
   {code2: AppLanguage.fr, name: 'Français'},
   {code2: AppLanguage.hi, name: 'हिंदी'},
+  {code2: AppLanguage.id, name: 'Bahasa Indonesia'},
   {code2: AppLanguage.ja, name: '日本語'},
   {code2: AppLanguage.ko, name: '한국어'},
   {code2: AppLanguage.pt_BR, name: 'Português (BR)'},


### PR DESCRIPTION
I reordered the locales alphabetically.

Other fixes include:
* https://github.com/bluesky-social/social-app/blob/c75771047cb49a2cd529f72a2756a456c843a730/lingui.config.js#L3 There were two `es`, so I removed one.
* https://github.com/bluesky-social/social-app/blob/c75771047cb49a2cd529f72a2756a456c843a730/src/locale/languages.ts#L27-L37 Corrected `Indonesian` to `Bahasa Indonesia`. (since they are all written in their own language)

Thank you!