### PR TITLE
Suggest post language correction

### DIFF
--- a/src/locale/helpers.ts
+++ b/src/locale/helpers.ts
@@ -22,6 +22,14 @@ export function code3ToCode2(lang: string): string {
   return lang
 }
 
+export function code3ToCode2Strict(lang: string): string | undefined {
+  if (lang.length === 3) {
+    return LANGUAGES_MAP_CODE3[lang]?.code2
+  }
+
+  return undefined
+}
+
 export function codeToLanguageName(lang: string): string {
   const lang2 = code3ToCode2(lang)
   return LANGUAGES_MAP_CODE2[lang2]?.name || lang

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -486,7 +486,7 @@ export const ComposePost = observer(function ComposePost({
           <View style={[pal.borderDark, styles.infoBar]}>
             <Text style={[pal.text, s.flex1]}>
               <Trans>
-                You seem to be writing to be in{' '}
+                You seem to be writing in{' '}
                 <Text type="sm-bold" style={pal.text}>
                   {codeToLanguageName(suggestedLanguage)}
                 </Text>

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -62,6 +62,8 @@ import {emitPostCreated} from '#/state/events'
 import {ThreadgateSetting} from '#/state/queries/threadgate'
 import {logger} from '#/logger'
 import {ComposerReplyTo} from 'view/com/composer/ComposerReplyTo'
+import lande from 'lande'
+import {code3ToCode2Strict, codeToLanguageName} from '#/locale/helpers'
 
 type Props = ComposerOpts
 export const ComposePost = observer(function ComposePost({
@@ -180,6 +182,31 @@ export const ComposePost = observer(function ComposePost({
       return () => window.removeEventListener('keydown', onEscape)
     }
   }, [onEscape])
+
+  const [suggestedLanguage, setSuggestedLanguage] = useState<string>()
+  useEffect(() => {
+    const text = richtext.text.trim()
+
+    // Don't run the language model on small posts, the results are likely
+    // to be inaccurate anyway.
+    if (text.length < 10) {
+      setSuggestedLanguage(undefined)
+      return
+    }
+
+    const idle = requestIdleCallback(() => {
+      // Only select languages that are
+      const result = lande(text).filter(
+        ([lang, value]) => value >= 0.85 && code3ToCode2Strict(lang),
+      )
+
+      setSuggestedLanguage(
+        result.length > 0 ? code3ToCode2Strict(result[0][0]) : undefined,
+      )
+    })
+
+    return () => cancelIdleCallback(idle)
+  }, [richtext])
 
   const onPressAddLinkCard = useCallback(
     (uri: string) => {
@@ -454,6 +481,39 @@ export const ComposePost = observer(function ComposePost({
               ))}
           </View>
         ) : null}
+        {suggestedLanguage &&
+        !toPostLanguages(langPrefs.postLanguage).includes(suggestedLanguage) ? (
+          <View style={[pal.borderDark, styles.infoBar]}>
+            <Text style={[pal.text, s.flex1]}>
+              <Trans>
+                You seem to be writing to be in{' '}
+                <Text type="sm-bold" style={pal.text}>
+                  {codeToLanguageName(suggestedLanguage)}
+                </Text>
+                , but your post language is currently set to{' '}
+                <Text type="sm-bold" style={pal.text}>
+                  {toPostLanguages(langPrefs.postLanguage)
+                    .map(lang => codeToLanguageName(lang))
+                    .join(', ')}
+                </Text>
+              </Trans>
+            </Text>
+
+            <TouchableOpacity
+              onPress={() => setLangPrefs.setPostLanguage(suggestedLanguage)}
+              accessibilityRole="button"
+              accessibilityLabel={_(
+                msg`Switch to ${codeToLanguageName(suggestedLanguage)}`,
+              )}
+              accessibilityHint={_(
+                msg`Switch to ${codeToLanguageName(suggestedLanguage)}`,
+              )}>
+              <Text style={pal.link}>
+                <Trans>Switch</Trans>
+              </Text>
+            </TouchableOpacity>
+          </View>
+        ) : null}
         <View style={[pal.border, styles.bottomBar]}>
           {canSelectImages ? (
             <>
@@ -564,5 +624,16 @@ const styles = StyleSheet.create({
     paddingRight: 20,
     alignItems: 'center',
     borderTopWidth: 1,
+  },
+
+  infoBar: {
+    flexDirection: 'row',
+    gap: 16,
+    borderWidth: 1,
+    borderRadius: 6,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    marginHorizontal: 10,
+    marginBottom: 10,
   },
 })


### PR DESCRIPTION
Fixes https://github.com/bluesky-social/social-app/issues/2449

- Adds `code3ToCode2Strict` mapping function because it seems that `lande` returns language codes that we don't have in our mapping, we should just filter those out. (Mixed English+Japanese seems to be returning `cmn` and I can't figure out what language is)
- It skips over short posts (currently set to length < 10) because `lande` is going to return incorrect matches for them anyway
- `lande` is being run in a `requestIdleCallback`, not sure if this is the right call, perhaps a timeout would be a better idea instead?
- I'm hoping that a threshold of 0.85 should be "correct" enough, but we could probably bump this up to 0.90

![image](https://github.com/bluesky-social/social-app/assets/148872143/4263fa40-6bf4-4054-9171-3a97fbdf3581)

