### PR TITLE
Suggest post language correction

### DIFF
--- a/src/locale/helpers.ts
+++ b/src/locale/helpers.ts
@@ -22,6 +22,14 @@ export function code3ToCode2(lang: string): string {
   return lang
 }
 
+export function code3ToCode2Strict(lang: string): string | undefined {
+  if (lang.length === 3) {
+    return LANGUAGES_MAP_CODE3[lang]?.code2
+  }
+
+  return undefined
+}
+
 export function codeToLanguageName(lang: string): string {
   const lang2 = code3ToCode2(lang)
   return LANGUAGES_MAP_CODE2[lang2]?.name || lang

--- a/src/view/com/composer/select-language/SuggestedLanguage.tsx
+++ b/src/view/com/composer/select-language/SuggestedLanguage.tsx
@@ -1,0 +1,93 @@
+import React, {useEffect, useState} from 'react'
+import {StyleSheet, TouchableOpacity, View} from 'react-native'
+import lande from 'lande'
+import {Trans, msg} from '@lingui/macro'
+import {useLingui} from '@lingui/react'
+import {Text} from '../../util/text/Text'
+import {code3ToCode2Strict, codeToLanguageName} from '#/locale/helpers'
+import {
+  toPostLanguages,
+  useLanguagePrefs,
+  useLanguagePrefsApi,
+} from '#/state/preferences/languages'
+import {usePalette} from '#/lib/hooks/usePalette'
+import {s} from '#/lib/styles'
+
+export function SuggestedLanguage({text}: {text: string}) {
+  const [suggestedLanguage, setSuggestedLanguage] = useState<string>()
+  const langPrefs = useLanguagePrefs()
+  const setLangPrefs = useLanguagePrefsApi()
+  const pal = usePalette('default')
+  const {_} = useLingui()
+
+  useEffect(() => {
+    const textTrimmed = text.trim()
+
+    // Don't run the language model on small posts, the results are likely
+    // to be inaccurate anyway.
+    if (textTrimmed.length < 10) {
+      setSuggestedLanguage(undefined)
+      return
+    }
+
+    const idle = requestIdleCallback(() => {
+      // Only select languages that are
+      const result = lande(textTrimmed).filter(
+        ([lang, value]) => value >= 0.85 && code3ToCode2Strict(lang),
+      )
+
+      setSuggestedLanguage(
+        result.length > 0 ? code3ToCode2Strict(result[0][0]) : undefined,
+      )
+    })
+
+    return () => cancelIdleCallback(idle)
+  }, [text])
+
+  return suggestedLanguage &&
+    !toPostLanguages(langPrefs.postLanguage).includes(suggestedLanguage) ? (
+    <View style={[pal.borderDark, styles.infoBar]}>
+      <Text style={[pal.text, s.flex1]}>
+        <Trans>
+          You seem to be writing in{' '}
+          <Text type="sm-bold" style={pal.text}>
+            {codeToLanguageName(suggestedLanguage)}
+          </Text>
+          , but your post language is currently set to{' '}
+          <Text type="sm-bold" style={pal.text}>
+            {toPostLanguages(langPrefs.postLanguage)
+              .map(lang => codeToLanguageName(lang))
+              .join(', ')}
+          </Text>
+        </Trans>
+      </Text>
+
+      <TouchableOpacity
+        onPress={() => setLangPrefs.setPostLanguage(suggestedLanguage)}
+        accessibilityRole="button"
+        accessibilityLabel={_(
+          msg`Switch to ${codeToLanguageName(suggestedLanguage)}`,
+        )}
+        accessibilityHint={_(
+          msg`Switch to ${codeToLanguageName(suggestedLanguage)}`,
+        )}>
+        <Text style={pal.link}>
+          <Trans>Switch</Trans>
+        </Text>
+      </TouchableOpacity>
+    </View>
+  ) : null
+}
+
+const styles = StyleSheet.create({
+  infoBar: {
+    flexDirection: 'row',
+    gap: 16,
+    borderWidth: 1,
+    borderRadius: 6,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    marginHorizontal: 10,
+    marginBottom: 10,
+  },
+})


### PR DESCRIPTION
Building on #2484

- Factors out into a separate component
- Tunes the lande confidence to reduce false positives

Copying over original description:

Fixes https://github.com/bluesky-social/social-app/issues/2449

- Adds `code3ToCode2Strict` mapping function because it seems that `lande` returns language codes that we don't have in our mapping, we should just filter those out. (Mixed English+Japanese seems to be returning `cmn` and I can't figure out what language is)
- It skips over short posts (currently set to length < 10) because `lande` is going to return incorrect matches for them anyway
- `lande` is being run in a `requestIdleCallback`, not sure if this is the right call, perhaps a timeout would be a better idea instead?
- I'm hoping that a threshold of 0.85 should be "correct" enough, but we could probably bump this up to 0.90

![image](https://github.com/bluesky-social/social-app/assets/148872143/4263fa40-6bf4-4054-9171-3a97fbdf3581)

