### PR TITLE
Set document lang attribute to the app language

### DIFF
--- a/src/locale/i18n.web.ts
+++ b/src/locale/i18n.web.ts
@@ -62,6 +62,9 @@ export async function dynamicActivate(locale: AppLanguage) {
 export async function useLocaleLanguage() {
   const {appLanguage} = useLanguagePrefs()
   useEffect(() => {
-    dynamicActivate(sanitizeAppLanguageSetting(appLanguage))
+    const sanitizedLanguage = sanitizeAppLanguageSetting(appLanguage)
+
+    document.documentElement.lang = sanitizedLanguage
+    dynamicActivate(sanitizedLanguage)
   }, [appLanguage])
 }


### PR DESCRIPTION
Fixes https://github.com/bluesky-social/social-app/issues/2303

Wanted to do it in `src/state/preferences/languages.tsx` to match `src/state/shell/color-mode.tsx` but that would've meant setting an unsanitized value which might be incorrect as translations changes/gets removed/etc