### PR TITLE
Resolve handle in feed/list URLs

### DIFF
--- a/src/lib/link-meta/bsky.ts
+++ b/src/lib/link-meta/bsky.ts
@@ -5,6 +5,7 @@ import {LikelyType, LinkMeta} from './link-meta'
 import {convertBskyAppUrlIfNeeded, makeRecordUri} from '../strings/url-helpers'
 import {ComposerOptsQuote} from 'state/shell/composer'
 import {useGetPost} from '#/state/queries/post'
+import {useFetchDid} from '#/state/queries/handle'
 
 // TODO
 // import {Home} from 'view/screens/Home'
@@ -120,11 +121,13 @@ export async function getPostAsQuote(
 
 export async function getFeedAsEmbed(
   agent: BskyAgent,
+  fetchDid: ReturnType<typeof useFetchDid>,
   url: string,
 ): Promise<apilib.ExternalEmbedDraft> {
   url = convertBskyAppUrlIfNeeded(url)
-  const [_0, user, _1, rkey] = url.split('/').filter(Boolean)
-  const feed = makeRecordUri(user, 'app.bsky.feed.generator', rkey)
+  const [_0, handleOrDid, _1, rkey] = url.split('/').filter(Boolean)
+  const did = await fetchDid(handleOrDid)
+  const feed = makeRecordUri(did, 'app.bsky.feed.generator', rkey)
   const res = await agent.app.bsky.feed.getFeedGenerator({feed})
   return {
     isLoading: false,
@@ -146,11 +149,13 @@ export async function getFeedAsEmbed(
 
 export async function getListAsEmbed(
   agent: BskyAgent,
+  fetchDid: ReturnType<typeof useFetchDid>,
   url: string,
 ): Promise<apilib.ExternalEmbedDraft> {
   url = convertBskyAppUrlIfNeeded(url)
-  const [_0, user, _1, rkey] = url.split('/').filter(Boolean)
-  const list = makeRecordUri(user, 'app.bsky.graph.list', rkey)
+  const [_0, handleOrDid, _1, rkey] = url.split('/').filter(Boolean)
+  const did = await fetchDid(handleOrDid)
+  const list = makeRecordUri(did, 'app.bsky.graph.list', rkey)
   const res = await agent.app.bsky.graph.getList({list})
   return {
     isLoading: false,

--- a/src/view/com/composer/useExternalLinkFetch.ts
+++ b/src/view/com/composer/useExternalLinkFetch.ts
@@ -18,6 +18,7 @@ import {POST_IMG_MAX} from 'lib/constants'
 import {logger} from '#/logger'
 import {getAgent} from '#/state/session'
 import {useGetPost} from '#/state/queries/post'
+import {useFetchDid} from '#/state/queries/handle'
 
 export function useExternalLinkFetch({
   setQuote,
@@ -28,6 +29,7 @@ export function useExternalLinkFetch({
     undefined,
   )
   const getPost = useGetPost()
+  const fetchDid = useFetchDid()
 
   useEffect(() => {
     let aborted = false
@@ -55,7 +57,7 @@ export function useExternalLinkFetch({
           },
         )
       } else if (isBskyCustomFeedUrl(extLink.uri)) {
-        getFeedAsEmbed(getAgent(), extLink.uri).then(
+        getFeedAsEmbed(getAgent(), fetchDid, extLink.uri).then(
           ({embed, meta}) => {
             if (aborted) {
               return
@@ -73,7 +75,7 @@ export function useExternalLinkFetch({
           },
         )
       } else if (isBskyListUrl(extLink.uri)) {
-        getListAsEmbed(getAgent(), extLink.uri).then(
+        getListAsEmbed(getAgent(), fetchDid, extLink.uri).then(
           ({embed, meta}) => {
             if (aborted) {
               return
@@ -133,7 +135,7 @@ export function useExternalLinkFetch({
       })
     }
     return cleanup
-  }, [extLink, setQuote, getPost])
+  }, [extLink, setQuote, getPost, fetchDid])
 
   return {extLink, setExtLink}
 }


### PR DESCRIPTION
Fixes https://github.com/bluesky-social/social-app/issues/1846

It looks like the new feed/list pages are able to resolve the handle without issues unlike before, should we make the "Share feed" and "Share list" menu items use the handle instead of DID for the URL?