### PR TITLE
Ensure sessions and tokens are synced between tabs

### DIFF
--- a/src/state/session/index.tsx
+++ b/src/state/session/index.tsx
@@ -193,11 +193,7 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
   )
 
   const clearCurrentAccount = React.useCallback(() => {
-    logger.debug(
-      `session: clear current account`,
-      {},
-      logger.DebugContext.session,
-    )
+    logger.warn(`session: clear current account`)
     __globalAgent = PUBLIC_BSKY_AGENT
     queryClient.clear()
     setStateAndPersist(s => ({
@@ -322,8 +318,8 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
   )
 
   const logout = React.useCallback<ApiContext['logout']>(async () => {
+    logger.info(`session: logout`)
     clearCurrentAccount()
-    logger.debug(`session: logout`, {}, logger.DebugContext.session)
     setStateAndPersist(s => {
       return {
         ...s,


### PR DESCRIPTION
This should address the multiple reports of unexpected signouts.

The issue was with users using multiple tabs on web. Both tabs would retain the same `refreshJwt` in memory, and refresh tokens can be used only once. So once a refresh token was rotated in tab A, the tab B _was_ notified but did not update that token on the `agent`, and so when tab B tried to get a new access token, `refreshSession` would fail.

This was a little tricky to pinpoint because if both tabs were periodically reloaded within the access token expiry window, our session handling would pick up the new refresh token from storage and continue as normal for a time. So this issue only existed in long-running multi-tab sessions.