### PR TITLE
package.json: cp --verbose doesn't exist on macos

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "android": "expo run:android",
     "ios": "expo run:ios",
     "web": "expo start --web",
-    "build-web": "expo export:web && node ./scripts/post-web-build.js && cp --verbose ./web-build/static/js/*.* ./bskyweb/static/js/",
+    "build-web": "expo export:web && node ./scripts/post-web-build.js && cp -v ./web-build/static/js/*.* ./bskyweb/static/js/",
     "build-all": "yarn intl:build && eas build --platform all",
     "start": "expo start --dev-client",
     "start:prod": "expo start --dev-client --no-dev --minify",


### PR DESCRIPTION
Tiny fix to fix this error on `yarn build-web` - `cp --verbose` doesn't exist on macos but `cp -v` does.

```
cp: illegal option -- -
usage: cp [-R [-H | -L | -P]] [-fi | -n] [-aclpsvXx] source_file target_file
       cp [-R [-H | -L | -P]] [-fi | -n] [-aclpsvXx] source_file ... target_directory
error Command failed with exit code 64.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command
```