### PR TITLE
Add from:me search functionality

### DIFF
--- a/src/lib/strings/helpers.ts
+++ b/src/lib/strings/helpers.ts
@@ -37,3 +37,27 @@ export function countLines(str: string | undefined): number {
   if (!str) return 0
   return str.match(/\n/g)?.length ?? 0
 }
+
+// Augments search query with additional syntax like `from:me`
+export function augmentSearchQuery(query: string, {did}: {did?: string}) {
+  // Don't do anything if there's no DID
+  if (!did) {
+    return query
+  }
+
+  // We don't want to replace substrings that are being "quoted" because those
+  // are exact string matches, so what we'll do here is to split them apart
+
+  // Even-indexed strings are unquoted, odd-indexed strings are quoted
+  const splits = query.split(/("(?:[^"\\]|\\.)*")/g)
+
+  return splits
+    .map((str, idx) => {
+      if (idx % 2 === 0) {
+        return str.replaceAll(/(^|\s)from:me(\s|$)/g, `$1${did}$2`)
+      }
+
+      return str
+    })
+    .join('')
+}

--- a/src/view/screens/Search/Search.tsx
+++ b/src/view/screens/Search/Search.tsx
@@ -47,6 +47,7 @@ import {useSetMinimalShellMode, useSetDrawerSwipeDisabled} from '#/state/shell'
 import {isWeb} from '#/platform/detection'
 import {listenSoftReset} from '#/state/events'
 import {s} from '#/lib/styles'
+import {augmentSearchQuery} from '#/lib/strings/helpers'
 
 function Loader() {
   const pal = usePalette('default')
@@ -315,8 +316,12 @@ export function SearchScreenInner({
   const pal = usePalette('default')
   const setMinimalShellMode = useSetMinimalShellMode()
   const setDrawerSwipeDisabled = useSetDrawerSwipeDisabled()
-  const {hasSession} = useSession()
+  const {hasSession, currentAccount} = useSession()
   const {isDesktop} = useWebMediaQueries()
+
+  const augmentedQuery = React.useMemo(() => {
+    return augmentSearchQuery(query || '', {did: currentAccount?.did})
+  }, [query, currentAccount])
 
   const onPageSelected = React.useCallback(
     (index: number) => {
@@ -338,7 +343,7 @@ export function SearchScreenInner({
         )}
         initialPage={0}>
         <View>
-          <SearchScreenPostResults query={query} />
+          <SearchScreenPostResults query={augmentedQuery} />
         </View>
         <View>
           <SearchScreenUserResults query={query} />


### PR DESCRIPTION
Addresses https://github.com/bluesky-social/social-app/issues/849#issuecomment-1876982941
nit: we should probably close that issue already since it's been fixed for a while now

Adds the ability to search for your own posts using the `from:me` search syntax, this is done by replacing instances of `from:me` with account's DID, special care is taken to avoid string replacements inside quotes, because quotes are exact search matches

![image](https://github.com/bluesky-social/social-app/assets/148872143/a751a533-73a6-4cca-8887-d097346f2d1d)
