### PR TITLE
Update French localization with more strings

### DIFF
--- a/src/locale/locales/fr/messages.po
+++ b/src/locale/locales/fr/messages.po
@@ -62,7 +62,7 @@ msgstr "<0/> membres"
 
 #: src/view/com/profile/ProfileHeader.tsx:634
 msgid "<0>{following} </0><1>following</1>"
-msgstr "<0>{following} </0><1>abonné·e·s</1>"
+msgstr "<0>{following} </0><1>abonnements</1>"
 
 #: src/view/com/auth/onboarding/RecommendedFeeds.tsx:30
 msgid "<0>Choose your</0><1>Recommended</1><2>Feeds</2>"
@@ -121,7 +121,7 @@ msgstr "Compte masqué"
 
 #: src/view/com/modals/ModerationDetails.tsx:72
 msgid "Account Muted by List"
-msgstr "Compte masqué par list"
+msgstr "Compte masqué par liste"
 
 #: src/view/com/util/AccountDropdownBtn.tsx:41
 msgid "Account options"
@@ -948,7 +948,7 @@ msgstr "Ignorer le brouillon"
 
 #: src/view/screens/Moderation.tsx:207
 msgid "Discourage apps from showing my account to logged-out users"
-msgstr "Empêcher les applis de montrer mon compte aux personnes déconnectées"
+msgstr "Empêcher les applis de montrer mon compte aux personnes non connectées"
 
 #: src/view/com/posts/FollowingEmptyState.tsx:74
 #: src/view/com/posts/FollowingEndOfFeed.tsx:75
@@ -1078,7 +1078,7 @@ msgstr "Modifier les fils d’actu enregistrés"
 
 #: src/view/com/modals/CreateOrEditList.tsx:188
 msgid "Edit User List"
-msgstr "Modifier la liste de compte"
+msgstr "Modifier la liste de comptes"
 
 #: src/view/com/modals/EditProfile.tsx:193
 msgid "Edit your display name"
@@ -1196,20 +1196,20 @@ msgstr "Tout le monde"
 
 #: src/view/com/modals/ChangeHandle.tsx:150
 msgid "Exits handle change process"
-msgstr "Sors du processus de changement de pseudo"
+msgstr "Sort du processus de changement de pseudo"
 
 #: src/view/com/lightbox/Lightbox.web.tsx:113
 msgid "Exits image view"
-msgstr "Sors de la vue de l’image"
+msgstr "Sort de la vue de l’image"
 
 #: src/view/com/modals/ListAddRemoveUsers.tsx:88
 #: src/view/shell/desktop/Search.tsx:182
 msgid "Exits inputting search query"
-msgstr "Sors de la saisie de la recherche"
+msgstr "Sort de la saisie de la recherche"
 
 #: src/view/com/modals/Waitlist.tsx:138
 msgid "Exits signing up for waitlist with {email}"
-msgstr "Sors de l’inscription sur la liste d’attente avec {email}"
+msgstr "Sort de l’inscription sur la liste d’attente avec {email}"
 
 #: src/view/com/lightbox/Lightbox.web.tsx:156
 msgid "Expand alt text"
@@ -1218,7 +1218,7 @@ msgstr "Développer le texte alt"
 #: src/view/com/composer/ComposerReplyTo.tsx:81
 #: src/view/com/composer/ComposerReplyTo.tsx:84
 msgid "Expand or collapse the full post you are replying to"
-msgstr "Étend ou rétrécit le post complet auquel vous répondez"
+msgstr "Développe ou réduit le post complet auquel vous répondez"
 
 #: src/view/com/modals/EmbedConsent.tsx:64
 msgid "External Media"
@@ -1294,7 +1294,7 @@ msgstr "Les fils d’actu sont créés par d’autres personnes pour rassembler 
 
 #: src/view/screens/SavedFeeds.tsx:156
 msgid "Feeds are custom algorithms that users build with a little coding expertise. <0/> for more information."
-msgstr "Les fils d’actu sont des algorithmes personnalisés qui se construisent avec un peu d’expertise en codage. <0/> pour plus d’informations."
+msgstr "Les fils d’actu sont des algorithmes personnalisés qui se construisent avec un peu d’expertise en programmation. <0/> pour plus d’informations."
 
 #: src/view/com/posts/CustomFeedEmptyState.tsx:47
 #: src/view/com/posts/FollowingEmptyState.tsx:57
@@ -1488,19 +1488,19 @@ msgstr "Masque les posts de {0} dans votre fil d’actu"
 
 #: src/view/com/posts/FeedErrorMessage.tsx:111
 msgid "Hmm, some kind of issue occurred when contacting the feed server. Please let the feed owner know about this issue."
-msgstr "Hmm, un problème s’est produit avec le serveur de fils d’actu. Veuillez informer la personne à l’origine du fil d’actu de ce problème."
+msgstr "Hmm, un problème s’est produit avec le serveur de fils d’actu. Veuillez informer la personne propriétaire du fil d’actu de ce problème."
 
 #: src/view/com/posts/FeedErrorMessage.tsx:99
 msgid "Hmm, the feed server appears to be misconfigured. Please let the feed owner know about this issue."
-msgstr "Hmm, le serveur du fils d’actu semble être mal configuré. Veuillez informer la personne à l’origine du fil d’actu de ce problème."
+msgstr "Hmm, le serveur du fils d’actu semble être mal configuré. Veuillez informer la personne propriétaire du fil d’actu de ce problème."
 
 #: src/view/com/posts/FeedErrorMessage.tsx:105
 msgid "Hmm, the feed server appears to be offline. Please let the feed owner know about this issue."
-msgstr "Mmm… le serveur de fils d’actu semble être hors ligne. Veuillez informer la personne à l’origine du fil d’actu de ce problème."
+msgstr "Mmm… le serveur de fils d’actu semble être hors ligne. Veuillez informer la personne propriétaire du fil d’actu de ce problème."
 
 #: src/view/com/posts/FeedErrorMessage.tsx:102
 msgid "Hmm, the feed server gave a bad response. Please let the feed owner know about this issue."
-msgstr "Mmm… le serveur de fils d’actu ne répond pas. Veuillez informer la personne à l’origine du fil d’actu de ce problème."
+msgstr "Mmm… le serveur de fils d’actu ne répond pas. Veuillez informer la personne propriétaire du fil d’actu de ce problème."
 
 #: src/view/com/posts/FeedErrorMessage.tsx:96
 msgid "Hmm, we're having trouble finding this feed. It may have been deleted."
@@ -1544,7 +1544,7 @@ msgstr "J’ai mon propre domaine"
 
 #: src/view/com/lightbox/Lightbox.web.tsx:158
 msgid "If alt text is long, toggles alt text expanded state"
-msgstr "Si le texte alternatif est trop long, affiche le texte alternatif complet"
+msgstr "Si le texte alternatif est trop long, change son mode d’affichage"
 
 #: src/view/com/modals/SelfLabel.tsx:127
 msgid "If none are selected, suitable for all ages."
@@ -1741,7 +1741,7 @@ msgstr "Clair"
 
 #: src/view/com/util/post-ctrls/PostCtrls.tsx:189
 msgid "Like"
-msgstr "Aimer"
+msgstr "Liker"
 
 #: src/view/screens/ProfileFeed.tsx:600
 msgid "Like this feed"
@@ -2160,7 +2160,7 @@ msgstr "Pas maintenant"
 
 #: src/view/screens/Moderation.tsx:232
 msgid "Note: Bluesky is an open and public network. This setting only limits the visibility of your content on the Bluesky app and website, and other apps may not respect this setting. Your content may still be shown to logged-out users by other apps and websites."
-msgstr "Remarque : Bluesky est un réseau ouvert et public. Ce paramètre limite uniquement la visibilité de votre contenu sur l’application et le site Web de Bluesky, et d’autres applications peuvent ne pas respecter ce paramètre. Votre contenu peut toujours être montré aux personnes déconnectées par d’autres applications et sites Web."
+msgstr "Remarque : Bluesky est un réseau ouvert et public. Ce paramètre limite uniquement la visibilité de votre contenu sur l’application et le site Web de Bluesky, et d’autres applications peuvent ne pas respecter ce paramètre. Votre contenu peut toujours être montré aux personnes non connectées par d’autres applications et sites Web."
 
 #: src/Navigation.tsx:447
 #: src/view/screens/Notifications.tsx:113
@@ -2398,7 +2398,7 @@ msgstr "Lire la vidéo"
 
 #: src/view/com/util/post-embeds/ExternalGifEmbed.tsx:110
 msgid "Plays the GIF"
-msgstr "Lis le GIF"
+msgstr "Lit le GIF"
 
 #: src/view/com/auth/create/state.ts:116
 msgid "Please choose your handle."
@@ -2628,7 +2628,7 @@ msgstr "Supprimer l’aperçu d’image"
 
 #: src/view/com/modals/Repost.tsx:47
 msgid "Remove repost"
-msgstr "Supprimer le reposts"
+msgstr "Supprimer le repost"
 
 #: src/view/com/feeds/FeedSourceCard.tsx:173
 msgid "Remove this feed from my feeds?"
@@ -2873,7 +2873,7 @@ msgstr "Recherche"
 #: src/view/com/auth/LoggedOut.tsx:105
 #: src/view/com/modals/ListAddRemoveUsers.tsx:70
 msgid "Search for users"
-msgstr "Rechercher des personnes"
+msgstr "Rechercher des comptes"
 
 #: src/view/com/modals/ChangeEmail.tsx:110
 msgid "Security Step Required"
@@ -2974,7 +2974,7 @@ msgstr "Définir un nouveau mot de passe"
 
 #: src/view/com/auth/create/Step2.tsx:133
 msgid "Set password"
-msgstr "Définis le mot de passe"
+msgstr "Définit le mot de passe"
 
 #: src/view/screens/PreferencesHomeFeed.tsx:225
 msgid "Set this setting to \"No\" to hide all quote posts from your feed. Reposts will still be visible."
@@ -2998,23 +2998,23 @@ msgstr "Choisissez « Oui » pour afficher des échantillons de vos fils d’a
 
 #: src/view/com/modals/ChangeHandle.tsx:266
 msgid "Sets Bluesky username"
-msgstr "Définis le pseudo Bluesky"
+msgstr "Définit le pseudo Bluesky"
 
 #: src/view/com/auth/login/ForgotPasswordForm.tsx:153
 msgid "Sets email for password reset"
-msgstr "Définis l’e-mail pour la réinitialisation du mot de passe"
+msgstr "Définit l’e-mail pour la réinitialisation du mot de passe"
 
 #: src/view/com/auth/login/ForgotPasswordForm.tsx:118
 msgid "Sets hosting provider for password reset"
-msgstr "Définis l’hébergeur pour la réinitialisation du mot de passe"
+msgstr "Définit l’hébergeur pour la réinitialisation du mot de passe"
 
 #: src/view/com/auth/create/Step1.tsx:143
 msgid "Sets hosting provider to {label}"
-msgstr "Définis l’hébergeur à {label}"
+msgstr "Définit l’hébergeur à {label}"
 
 #: src/view/com/auth/login/LoginForm.tsx:148
 msgid "Sets server for the Bluesky client"
-msgstr "Définis le serveur pour le client Bluesky"
+msgstr "Définit le serveur pour le client Bluesky"
 
 #: src/Navigation.tsx:136
 #: src/view/screens/Settings.tsx:287
@@ -3179,7 +3179,7 @@ msgstr "Connecté en tant que"
 
 #: src/view/com/auth/login/ChooseAccountForm.tsx:103
 msgid "Signed in as @{0}"
-msgstr "Connecté comme @{0}"
+msgstr "Connecté en tant que @{0}"
 
 #: src/view/com/modals/SwitchAccount.tsx:66
 msgid "Signs {0} out of Bluesky"
@@ -3191,11 +3191,11 @@ msgstr "Ignorer"
 
 #: src/view/com/modals/ProfilePreview.tsx:62
 msgid "Something went wrong and we're not sure what."
-msgstr "Quelque chose a échoué et on ne sait pas trop quoi."
+msgstr "Quelque chose n’a pas marché, mais on ne sait pas trop quoi."
 
 #: src/view/com/modals/Waitlist.tsx:51
 msgid "Something went wrong. Check your email and try again."
-msgstr "Quelque chose a échoué. Vérifiez vos e-mails et réessayez."
+msgstr "Quelque chose n’a pas marché. Vérifiez vos e-mails et réessayez."
 
 #: src/App.native.tsx:57
 msgid "Sorry! Your session expired. Please log in again."
@@ -3425,7 +3425,7 @@ msgstr "Ce {screenDescription} a été signalé :"
 
 #: src/view/com/util/moderation/ScreenHider.tsx:83
 msgid "This account has requested that users sign in to view their profile."
-msgstr "Ce compte a demandé aux personnes de s’identifier pour voir son profil."
+msgstr "Ce compte a demandé aux personnes de se connecter pour voir son profil."
 
 #: src/view/com/modals/EmbedConsent.tsx:68
 msgid "This content is hosted by {0}. Do you want to enable external media?"
@@ -3642,7 +3642,7 @@ msgstr "Utilisez-le pour vous connecter à l’autre application avec votre iden
 
 #: src/view/com/modals/ServerInput.tsx:105
 msgid "Use your domain as your Bluesky client service provider"
-msgstr "Utilise votre domaine comme un fournisseur de client Bluesky"
+msgstr "Utilise votre domaine comme votre fournisseur de client Bluesky"
 
 #: src/view/com/modals/InviteCodes.tsx:200
 msgid "Used by:"
@@ -3767,7 +3767,7 @@ msgstr "Nous sommes ravis de vous accueillir !"
 
 #: src/view/screens/ProfileList.tsx:83
 msgid "We're sorry, but we were unable to resolve this list. If this persists, please contact the list creator, @{handleOrDid}."
-msgstr "Nous sommes désolés, mais nous n’avons pas pu résoudre cette liste. Si cela persiste, veuillez contacter l’origine de la liste, @{handleOrDid}."
+msgstr "Nous sommes désolés, mais nous n’avons pas pu charger cette liste. Si cela persiste, veuillez contacter l’origine de la liste, @{handleOrDid}."
 
 #: src/view/screens/Search/Search.tsx:243
 msgid "We're sorry, but your search could not be completed. Please try again in a few minutes."

--- a/src/locale/locales/fr/messages.po
+++ b/src/locale/locales/fr/messages.po
@@ -13,29 +13,38 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
+#: src/view/com/modals/VerifyEmail.tsx:142
+msgid "(no email)"
+msgstr ""
+
 #: src/view/shell/desktop/RightNav.tsx:168
 msgid "{0, plural, one {# invite code available} other {# invite codes available}}"
 msgstr "{0, plural, one {# invite code available} other {# invite codes available}}"
 
-#: src/view/com/modals/Repost.tsx:44
+#: src/view/com/modals/CreateOrEditList.tsx:185
+#: src/view/screens/Settings.tsx:287
 msgid "{0}"
 msgstr "{0}"
 
 #: src/view/com/modals/CreateOrEditList.tsx:176
-msgid "{0} {purposeLabel} List"
-msgstr "{0} {purposeLabel} Liste"
+#~ msgid "{0} {purposeLabel} List"
+#~ msgstr "{0} {purposeLabel} Liste"
+
+#: src/view/com/profile/ProfileHeader.tsx:632
+msgid "{following} following"
+msgstr ""
 
 #: src/view/shell/desktop/RightNav.tsx:151
 msgid "{invitesAvailable, plural, one {Invite codes: # available} other {Invite codes: # available}}"
 msgstr "{invitesAvailable, plural, one {Invite codes: # available} other {Invite codes: # available}}"
 
-#: src/view/screens/Settings.tsx:407
-#: src/view/shell/Drawer.tsx:659
+#: src/view/screens/Settings.tsx:422
+#: src/view/shell/Drawer.tsx:661
 msgid "{invitesAvailable} invite code available"
 msgstr "{invitesAvailable} code d’invitation disponible"
 
-#: src/view/screens/Settings.tsx:409
-#: src/view/shell/Drawer.tsx:661
+#: src/view/screens/Settings.tsx:424
+#: src/view/shell/Drawer.tsx:663
 msgid "{invitesAvailable} invite codes available"
 msgstr "{invitesAvailable} codes d’invitation disponibles"
 
@@ -43,9 +52,21 @@ msgstr "{invitesAvailable} codes d’invitation disponibles"
 msgid "{message}"
 msgstr "{message}"
 
+#: src/view/shell/Drawer.tsx:440
+msgid "{numUnreadNotifications} unread"
+msgstr ""
+
+#: src/Navigation.tsx:147
+msgid "@{0}"
+msgstr ""
+
 #: src/view/com/threadgate/WhoCanReply.tsx:158
 msgid "<0/> members"
 msgstr "<0/> membres"
+
+#: src/view/com/profile/ProfileHeader.tsx:634
+msgid "<0>{following} </0><1>following</1>"
+msgstr ""
 
 #: src/view/com/auth/onboarding/RecommendedFeeds.tsx:30
 msgid "<0>Choose your</0><1>Recommended</1><2>Feeds</2>"
@@ -55,6 +76,14 @@ msgstr "<0>Choisissez vos</0><1>fils d’actualité</1><2>recommandés</2>"
 msgid "<0>Follow some</0><1>Recommended</1><2>Users</2>"
 msgstr "<0>Suivre certains</0><1>utilisateurs</1><2>recommandés</2>"
 
+#: src/view/com/auth/onboarding/WelcomeDesktop.tsx:21
+msgid "<0>Welcome to</0><1>Bluesky</1>"
+msgstr ""
+
+#: src/view/com/profile/ProfileHeader.tsx:597
+msgid "⚠Invalid Handle"
+msgstr ""
+
 #: src/view/com/util/moderation/LabelInfo.tsx:45
 msgid "A content warning has been applied to this {0}."
 msgstr "Un avertissement sur le contenu a été appliqué sur ce {0}."
@@ -63,23 +92,61 @@ msgstr "Un avertissement sur le contenu a été appliqué sur ce {0}."
 msgid "A new version of the app is available. Please update to continue using the app."
 msgstr "Une nouvelle version de l’application est disponible. Veuillez faire la mise à jour pour continuer à utiliser l’application."
 
+#: src/view/com/util/ViewHeader.tsx:83
+#: src/view/screens/Search/Search.tsx:538
+msgid "Access navigation links and settings"
+msgstr ""
+
+#: src/view/com/pager/FeedsTabBarMobile.tsx:78
+msgid "Access profile and other navigation links"
+msgstr ""
+
 #: src/view/com/modals/EditImage.tsx:299
-#: src/view/screens/Settings.tsx:417
+#: src/view/screens/Settings.tsx:432
 msgid "Accessibility"
 msgstr "Accessibilité"
 
 #: src/view/com/auth/login/LoginForm.tsx:163
-#: src/view/screens/Settings.tsx:286
+#: src/view/screens/Settings.tsx:301
 msgid "Account"
 msgstr "Compte"
+
+#: src/view/com/profile/ProfileHeader.tsx:293
+msgid "Account blocked"
+msgstr ""
+
+#: src/view/com/profile/ProfileHeader.tsx:260
+msgid "Account muted"
+msgstr ""
+
+#: src/view/com/modals/ModerationDetails.tsx:86
+msgid "Account Muted"
+msgstr ""
+
+#: src/view/com/modals/ModerationDetails.tsx:72
+msgid "Account Muted by List"
+msgstr ""
 
 #: src/view/com/util/AccountDropdownBtn.tsx:41
 msgid "Account options"
 msgstr "Options de compte"
 
+#: src/view/com/util/AccountDropdownBtn.tsx:25
+msgid "Account removed from quick access"
+msgstr ""
+
+#: src/view/com/profile/ProfileHeader.tsx:315
+msgid "Account unblocked"
+msgstr ""
+
+#: src/view/com/profile/ProfileHeader.tsx:273
+msgid "Account unmuted"
+msgstr ""
+
+#: src/view/com/auth/onboarding/RecommendedFeedsItem.tsx:150
 #: src/view/com/modals/ListAddRemoveUsers.tsx:264
-#: src/view/com/modals/UserAddRemoveLists.tsx:193
-#: src/view/screens/ProfileList.tsx:763
+#: src/view/com/modals/UserAddRemoveLists.tsx:203
+#: src/view/screens/ProfileList.tsx:791
 msgid "Add"
 msgstr "Ajouter"
 
@@ -87,12 +154,12 @@ msgstr "Ajouter"
 msgid "Add a content warning"
 msgstr "Ajouter un avertissement sur le contenu"
 
-#: src/view/screens/ProfileList.tsx:753
+#: src/view/screens/ProfileList.tsx:781
 msgid "Add a user to this list"
 msgstr "Ajouter un utilisateur à cette liste"
 
-#: src/view/screens/Settings.tsx:355
-#: src/view/screens/Settings.tsx:364
+#: src/view/screens/Settings.tsx:370
+#: src/view/screens/Settings.tsx:379
 msgid "Add account"
 msgstr "Ajouter un compte"
 
@@ -101,6 +168,12 @@ msgstr "Ajouter un compte"
 #: src/view/com/modals/AltImage.tsx:93
 msgid "Add alt text"
 msgstr "Ajouter un texte alt"
+
+#: src/view/screens/AppPasswords.tsx:102
+#: src/view/screens/AppPasswords.tsx:143
+#: src/view/screens/AppPasswords.tsx:156
+msgid "Add App Password"
+msgstr ""
 
 #: src/view/com/modals/report/InputIssueDetails.tsx:41
 #: src/view/com/modals/report/Modal.tsx:191
@@ -111,7 +184,7 @@ msgstr "Ajouter des détails"
 msgid "Add details to report"
 msgstr "Ajouter des détails au rapport"
 
-#: src/view/com/composer/Composer.tsx:447
+#: src/view/com/composer/Composer.tsx:445
 msgid "Add link card"
 msgstr "Ajouter une carte de lien"
 
@@ -119,24 +192,33 @@ msgstr "Ajouter une carte de lien"
 msgid "Add link card:"
 msgstr "Ajouter une carte de lien :"
 
-#: src/view/com/modals/ChangeHandle.tsx:415
+#: src/view/com/modals/ChangeHandle.tsx:417
 msgid "Add the following DNS record to your domain:"
 msgstr "Ajoutez l’enregistrement DNS suivant à votre domaine :"
 
-#: src/view/com/profile/ProfileHeader.tsx:353
+#: src/view/com/profile/ProfileHeader.tsx:357
 msgid "Add to Lists"
 msgstr "Ajouter aux listes"
 
-#: src/view/screens/ProfileFeed.tsx:271
+#: src/view/com/feeds/FeedSourceCard.tsx:243
+#: src/view/screens/ProfileFeed.tsx:281
 msgid "Add to my feeds"
 msgstr "Ajouter à mes fils d’actu"
+
+#: src/view/com/auth/onboarding/RecommendedFeedsItem.tsx:139
+msgid "Added"
+msgstr ""
 
 #: src/view/com/modals/ListAddRemoveUsers.tsx:191
 #: src/view/com/modals/UserAddRemoveLists.tsx:128
 msgid "Added to list"
 msgstr "Ajouté à la liste"
 
-#: src/view/screens/PreferencesHomeFeed.tsx:170
+#: src/view/com/feeds/FeedSourceCard.tsx:125
+msgid "Added to my feeds"
+msgstr ""
+
+#: src/view/screens/PreferencesHomeFeed.tsx:173
 msgid "Adjust the number of likes a reply must have to be shown in your feed."
 msgstr "Définissez le nombre de likes qu’une réponse doit avoir pour être affichée dans votre fil d’actualité."
 
@@ -144,9 +226,17 @@ msgstr "Définissez le nombre de likes qu’une réponse doit avoir pour être a
 msgid "Adult Content"
 msgstr "Contenu pour adultes"
 
-#: src/view/screens/Settings.tsx:602
+#: src/view/com/modals/ContentFilteringSettings.tsx:137
+msgid "Adult content can only be enabled via the Web at <0/>."
+msgstr ""
+
+#: src/view/screens/Settings.tsx:617
 msgid "Advanced"
 msgstr "Avancé"
+
+#: src/view/com/auth/login/ChooseAccountForm.tsx:98
+msgid "Already signed in as @{0}"
+msgstr ""
 
 #: src/view/com/composer/photos/Gallery.tsx:130
 msgid "ALT"
@@ -160,7 +250,7 @@ msgstr "Texte Alt"
 msgid "Alt text describes images for blind and low-vision users, and helps give context to everyone."
 msgstr "Le texte Alt décrit les images pour les utilisateurs aveugles et malvoyants, et aide à donner un contexte à tout le monde."
 
-#: src/view/com/modals/VerifyEmail.tsx:118
+#: src/view/com/modals/VerifyEmail.tsx:124
 msgid "An email has been sent to {0}. It includes a confirmation code which you can enter below."
 msgstr "Un e-mail a été envoyé à {0}. Il comprend un code de confirmation que vous pouvez saisir ici."
 
@@ -168,7 +258,12 @@ msgstr "Un e-mail a été envoyé à {0}. Il comprend un code de confirmation qu
 msgid "An email has been sent to your previous address, {0}. It includes a confirmation code which you can enter below."
 msgstr "Un courriel a été envoyé à votre ancienne adresse, {0}. Il comprend un code de confirmation que vous pouvez saisir ici."
 
-#: src/view/com/notifications/FeedItem.tsx:237
+#: src/view/com/profile/FollowButton.tsx:30
+#: src/view/com/profile/FollowButton.tsx:40
+msgid "An issue occurred, please try again."
+msgstr ""
+
+#: src/view/com/notifications/FeedItem.tsx:240
 #: src/view/com/threadgate/WhoCanReply.tsx:178
 msgid "and"
 msgstr "et"
@@ -177,15 +272,32 @@ msgstr "et"
 msgid "App Language"
 msgstr "Langue de l’application"
 
-#: src/view/screens/Settings.tsx:622
+#: src/view/screens/AppPasswords.tsx:228
+msgid "App password deleted"
+msgstr ""
+
+#: src/view/com/modals/AddAppPasswords.tsx:133
+msgid "App Password names can only contain letters, numbers, spaces, dashes, and underscores."
+msgstr ""
+
+#: src/view/com/modals/AddAppPasswords.tsx:98
+msgid "App Password names must be at least 4 characters long."
+msgstr ""
+
+#: src/view/screens/Settings.tsx:628
+msgid "App password settings"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:637
 msgid "App passwords"
 msgstr "Mots de passe d’application"
 
-#: src/view/screens/AppPasswords.tsx:186
+#: src/Navigation.tsx:239
+#: src/view/screens/AppPasswords.tsx:187
 msgid "App Passwords"
 msgstr "Mots de passe d’application"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:236
+#: src/view/com/util/forms/PostDropdownBtn.tsx:248
 msgid "Appeal content warning"
 msgstr "Faire appel de l’avertissement sur le contenu"
 
@@ -204,23 +316,23 @@ msgstr "Faire appel de cette décision"
 msgid "Appeal this decision."
 msgstr "Faire appel de cette décision."
 
-#: src/view/screens/Settings.tsx:432
+#: src/view/screens/Settings.tsx:447
 msgid "Appearance"
 msgstr "Affichage"
 
-#: src/view/screens/AppPasswords.tsx:223
+#: src/view/screens/AppPasswords.tsx:224
 msgid "Are you sure you want to delete the app password \"{name}\"?"
 msgstr "Êtes-vous sûr de vouloir supprimer le mot de passe de l’application « {name} » ?"
 
-#: src/view/com/composer/Composer.tsx:143
+#: src/view/com/composer/Composer.tsx:142
 msgid "Are you sure you'd like to discard this draft?"
 msgstr "Êtes-vous sûr de vouloir rejeter ce brouillon ?"
 
-#: src/view/screens/ProfileList.tsx:353
+#: src/view/screens/ProfileList.tsx:364
 msgid "Are you sure?"
 msgstr "Vous confirmez ?"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:219
+#: src/view/com/util/forms/PostDropdownBtn.tsx:231
 msgid "Are you sure? This cannot be undone."
 msgstr "Vous confirmez ? Cela ne pourra pas être annulé."
 
@@ -228,20 +340,26 @@ msgstr "Vous confirmez ? Cela ne pourra pas être annulé."
 msgid "Artistic or non-erotic nudity."
 msgstr "Nudité artistique ou non érotique."
 
+#: src/view/com/post-thread/PostThread.tsx:400
+msgctxt "action"
+msgid "Back"
+msgstr ""
+
 #: src/view/com/auth/create/CreateAccount.tsx:141
 #: src/view/com/auth/login/ChooseAccountForm.tsx:151
-#: src/view/com/auth/login/ForgotPasswordForm.tsx:166
-#: src/view/com/auth/login/LoginForm.tsx:254
-#: src/view/com/auth/login/SetNewPasswordForm.tsx:148
+#: src/view/com/auth/login/ForgotPasswordForm.tsx:170
+#: src/view/com/auth/login/LoginForm.tsx:256
+#: src/view/com/auth/login/SetNewPasswordForm.tsx:150
 #: src/view/com/modals/report/InputIssueDetails.tsx:46
-#: src/view/com/post-thread/PostThread.tsx:388
-#: src/view/com/post-thread/PostThread.tsx:438
-#: src/view/com/post-thread/PostThread.tsx:446
-#: src/view/com/profile/ProfileHeader.tsx:672
+#: src/view/com/post-thread/PostThread.tsx:392
+#: src/view/com/post-thread/PostThread.tsx:442
+#: src/view/com/post-thread/PostThread.tsx:450
+#: src/view/com/profile/ProfileHeader.tsx:688
+#: src/view/com/util/ViewHeader.tsx:81
 msgid "Back"
 msgstr "Arrière"
 
-#: src/view/screens/Settings.tsx:461
+#: src/view/screens/Settings.tsx:476
 msgid "Basics"
 msgstr "Principes de base"
 
@@ -250,36 +368,45 @@ msgstr "Principes de base"
 msgid "Birthday"
 msgstr "Date de naissance"
 
-#: src/view/screens/Settings.tsx:312
+#: src/view/screens/Settings.tsx:327
 msgid "Birthday:"
 msgstr "Date de naissance :"
 
-#: src/view/com/profile/ProfileHeader.tsx:282
-#: src/view/com/profile/ProfileHeader.tsx:389
+#: src/view/com/profile/ProfileHeader.tsx:286
+#: src/view/com/profile/ProfileHeader.tsx:393
 msgid "Block Account"
 msgstr "Bloquer ce compte"
 
-#: src/view/screens/ProfileList.tsx:523
+#: src/view/screens/ProfileList.tsx:534
 msgid "Block accounts"
 msgstr "Bloquer ces comptes"
 
-#: src/view/screens/ProfileList.tsx:473
+#: src/view/screens/ProfileList.tsx:484
 msgid "Block list"
 msgstr "Liste de blocage"
 
-#: src/view/screens/ProfileList.tsx:308
+#: src/view/screens/ProfileList.tsx:315
 msgid "Block these accounts?"
 msgstr "Bloquer ces comptes ?"
+
+#: src/view/screens/ProfileList.tsx:319
+msgid "Block this List"
+msgstr ""
+
+#: src/view/com/util/post-embeds/QuoteEmbed.tsx:57
+msgid "Blocked"
+msgstr ""
 
 #: src/view/screens/Moderation.tsx:123
 msgid "Blocked accounts"
 msgstr "Comptes bloqués"
 
+#: src/Navigation.tsx:131
 #: src/view/screens/ModerationBlockedAccounts.tsx:107
 msgid "Blocked Accounts"
 msgstr "Comptes bloqués"
 
-#: src/view/com/profile/ProfileHeader.tsx:284
+#: src/view/com/profile/ProfileHeader.tsx:288
 msgid "Blocked accounts cannot reply in your threads, mention you, or otherwise interact with you."
 msgstr "Les comptes bloqués ne peuvent pas répondre à vos discussions, vous mentionner ou interagir avec vous."
 
@@ -287,11 +414,11 @@ msgstr "Les comptes bloqués ne peuvent pas répondre à vos discussions, vous m
 msgid "Blocked accounts cannot reply in your threads, mention you, or otherwise interact with you. You will not see their content and they will be prevented from seeing yours."
 msgstr "Les comptes bloqués ne peuvent pas répondre à vos discussions, vous mentionner ou interagir avec vous. Vous ne verrez pas leur contenu et ils ne pourront pas voir le vôtre."
 
-#: src/view/com/post-thread/PostThread.tsx:250
+#: src/view/com/post-thread/PostThread.tsx:254
 msgid "Blocked post."
 msgstr "Post bloqué."
 
-#: src/view/screens/ProfileList.tsx:310
+#: src/view/screens/ProfileList.tsx:317
 msgid "Blocking is public. Blocked accounts cannot reply in your threads, mention you, or otherwise interact with you."
 msgstr "Le blocage est public. Les comptes bloqués ne peuvent pas répondre à vos discussions, vous mentionner ou interagir avec vous."
 
@@ -303,14 +430,17 @@ msgstr "Blog"
 msgid "Bluesky"
 msgstr "Bluesky"
 
+#: src/view/com/auth/onboarding/WelcomeDesktop.tsx:80
 #: src/view/com/auth/onboarding/WelcomeMobile.tsx:80
 msgid "Bluesky is flexible."
 msgstr "Bluesky est adaptable."
 
+#: src/view/com/auth/onboarding/WelcomeDesktop.tsx:69
 #: src/view/com/auth/onboarding/WelcomeMobile.tsx:69
 msgid "Bluesky is open."
 msgstr "Bluesky est ouvert."
 
+#: src/view/com/auth/onboarding/WelcomeDesktop.tsx:56
 #: src/view/com/auth/onboarding/WelcomeMobile.tsx:56
 msgid "Bluesky is public."
 msgstr "Bluesky est public."
@@ -327,7 +457,7 @@ msgstr "Bluesky n’affichera pas votre profil et vos messages à des utilisateu
 msgid "Bluesky.Social"
 msgstr "Bluesky.Social"
 
-#: src/view/screens/Settings.tsx:751
+#: src/view/screens/Settings.tsx:768
 msgid "Build version {0} {1}"
 msgstr "Version Build {0} {1}"
 
@@ -335,37 +465,64 @@ msgstr "Version Build {0} {1}"
 msgid "Business"
 msgstr "Affaires"
 
+#: src/view/com/modals/ServerInput.tsx:115
+msgid "Button disabled. Input custom domain to proceed."
+msgstr ""
+
+#: src/view/com/profile/ProfileSubpageHeader.tsx:157
+msgid "by —"
+msgstr ""
+
+#: src/view/com/auth/onboarding/RecommendedFeedsItem.tsx:100
+msgid "by {0}"
+msgstr ""
+
+#: src/view/com/profile/ProfileSubpageHeader.tsx:161
+msgid "by <0/>"
+msgstr ""
+
+#: src/view/com/profile/ProfileSubpageHeader.tsx:159
+msgid "by you"
+msgstr ""
+
 #: src/view/com/composer/photos/OpenCameraBtn.tsx:60
 #: src/view/com/util/UserAvatar.tsx:221
 #: src/view/com/util/UserBanner.tsx:38
 msgid "Camera"
 msgstr "Caméra"
 
-#: src/view/com/modals/AddAppPasswords.tsx:214
+#: src/view/com/modals/AddAppPasswords.tsx:218
 msgid "Can only contain letters, numbers, spaces, dashes, and underscores. Must be at least 4 characters long, but no more than 32 characters long."
 msgstr "Ne peut contenir que des lettres, des chiffres, des espaces, des tirets et des tirets bas. La longueur doit être d’au moins 4 caractères, mais pas plus de 32."
 
-#: src/view/com/composer/Composer.tsx:294
-#: src/view/com/composer/Composer.tsx:297
+#: src/view/com/modals/Confirm.tsx:88
+#: src/view/com/modals/Confirm.tsx:91
+#: src/view/com/modals/CreateOrEditList.tsx:293
+#: src/view/com/modals/DeleteAccount.tsx:152
+#: src/view/com/modals/DeleteAccount.tsx:227
+msgctxt "action"
+msgid "Cancel"
+msgstr ""
+
+#: src/view/com/composer/Composer.tsx:299
+#: src/view/com/composer/Composer.tsx:304
 #: src/view/com/modals/ChangeEmail.tsx:218
 #: src/view/com/modals/ChangeEmail.tsx:220
-#: src/view/com/modals/Confirm.tsx:88
-#: src/view/com/modals/CreateOrEditList.tsx:267
-#: src/view/com/modals/CreateOrEditList.tsx:272
-#: src/view/com/modals/DeleteAccount.tsx:150
-#: src/view/com/modals/DeleteAccount.tsx:223
+#: src/view/com/modals/CreateOrEditList.tsx:288
 #: src/view/com/modals/EditImage.tsx:323
-#: src/view/com/modals/EditProfile.tsx:248
+#: src/view/com/modals/EditProfile.tsx:249
 #: src/view/com/modals/LinkWarning.tsx:85
-#: src/view/com/modals/Repost.tsx:73
-#: src/view/com/modals/Waitlist.tsx:136
-#: src/view/screens/Search/Search.tsx:601
-#: src/view/shell/desktop/Search.tsx:182
+#: src/view/com/modals/Repost.tsx:87
+#: src/view/com/modals/VerifyEmail.tsx:247
+#: src/view/com/modals/VerifyEmail.tsx:253
+#: src/view/com/modals/Waitlist.tsx:142
+#: src/view/screens/Search/Search.tsx:602
+#: src/view/shell/desktop/Search.tsx:185
 msgid "Cancel"
 msgstr "Annuler"
 
-#: src/view/com/modals/DeleteAccount.tsx:146
-#: src/view/com/modals/DeleteAccount.tsx:219
+#: src/view/com/modals/DeleteAccount.tsx:148
+#: src/view/com/modals/DeleteAccount.tsx:223
 msgid "Cancel account deletion"
 msgstr "Annuler la suppression de compte"
 
@@ -381,29 +538,34 @@ msgstr "Annuler le changement de pseudo"
 msgid "Cancel image crop"
 msgstr "Annuler le recadrage de l’image"
 
-#: src/view/com/modals/EditProfile.tsx:243
+#: src/view/com/modals/EditProfile.tsx:244
 msgid "Cancel profile editing"
 msgstr "Annuler la modification du profil"
 
-#: src/view/com/modals/Repost.tsx:64
+#: src/view/com/modals/Repost.tsx:78
 msgid "Cancel quote post"
 msgstr "Annuler la citation"
 
 #: src/view/com/modals/ListAddRemoveUsers.tsx:87
-#: src/view/shell/desktop/Search.tsx:178
+#: src/view/shell/desktop/Search.tsx:181
 msgid "Cancel search"
 msgstr "Annuler la recherche"
 
-#: src/view/com/modals/Waitlist.tsx:132
+#: src/view/com/modals/Waitlist.tsx:136
 msgid "Cancel waitlist signup"
 msgstr "Annuler l’inscription sur la liste d’attente"
 
-#: src/view/screens/Settings.tsx:306
+#: src/view/screens/Settings.tsx:321
+msgctxt "action"
 msgid "Change"
-msgstr "Changer"
+msgstr ""
 
-#: src/view/screens/Settings.tsx:634
-#: src/view/screens/Settings.tsx:643
+#: src/view/screens/Settings.tsx:306
+#~ msgid "Change"
+#~ msgstr "Changer"
+
+#: src/view/screens/Settings.tsx:649
+#: src/view/screens/Settings.tsx:658
 msgid "Change handle"
 msgstr "Changer le pseudo"
 
@@ -411,7 +573,7 @@ msgstr "Changer le pseudo"
 msgid "Change Handle"
 msgstr "Changer le pseudo"
 
-#: src/view/com/modals/VerifyEmail.tsx:141
+#: src/view/com/modals/VerifyEmail.tsx:147
 msgid "Change my email"
 msgstr "Modifier mon e-mail"
 
@@ -427,7 +589,7 @@ msgstr "Consultez quelques fils d’actu recommandés. Appuyez sur + pour les aj
 msgid "Check out some recommended users. Follow them to see similar users."
 msgstr "Consultez quelques utilisateurs recommandés. Suivez-les pour voir des utilisateurs similaires."
 
-#: src/view/com/modals/DeleteAccount.tsx:163
+#: src/view/com/modals/DeleteAccount.tsx:165
 msgid "Check your inbox for an email with the confirmation code to enter below:"
 msgstr "Consultez votre boîte de réception, vous avez du recevoir un e-mail contenant un code de confirmation à saisir ci-dessous :"
 
@@ -435,10 +597,15 @@ msgstr "Consultez votre boîte de réception, vous avez du recevoir un e-mail co
 msgid "Choose \"Everybody\" or \"Nobody\""
 msgstr "Choisir « Tout le monde » ou « Personne »"
 
+#: src/view/screens/Settings.tsx:650
+msgid "Choose a new Bluesky username or create"
+msgstr ""
+
 #: src/view/com/modals/ServerInput.tsx:38
 msgid "Choose Service"
 msgstr "Choisir un service"
 
+#: src/view/com/auth/onboarding/WelcomeDesktop.tsx:83
 #: src/view/com/auth/onboarding/WelcomeMobile.tsx:83
 msgid "Choose the algorithms that power your experience with custom feeds."
 msgstr "Choisissez les algorithmes qui alimentent votre expérience avec des fils d’actualité personnalisés."
@@ -447,26 +614,32 @@ msgstr "Choisissez les algorithmes qui alimentent votre expérience avec des fil
 msgid "Choose your password"
 msgstr "Choisissez votre mot de passe"
 
-#: src/view/screens/Settings.tsx:727
+#: src/view/screens/Settings.tsx:743
+#: src/view/screens/Settings.tsx:744
 msgid "Clear all legacy storage data"
 msgstr "Effacer toutes les données de stockage existantes"
 
-#: src/view/screens/Settings.tsx:729
+#: src/view/screens/Settings.tsx:746
 msgid "Clear all legacy storage data (restart after this)"
 msgstr "Effacer toutes les données de stockage existantes (redémarrer ensuite)"
 
-#: src/view/screens/Settings.tsx:739
+#: src/view/screens/Settings.tsx:755
+#: src/view/screens/Settings.tsx:756
 msgid "Clear all storage data"
 msgstr "Effacer toutes les données de stockage"
 
-#: src/view/screens/Settings.tsx:741
+#: src/view/screens/Settings.tsx:758
 msgid "Clear all storage data (restart after this)"
 msgstr "Effacer toutes les données de stockage (redémarrer ensuite)"
 
 #: src/view/com/util/forms/SearchInput.tsx:74
-#: src/view/screens/Search/Search.tsx:582
+#: src/view/screens/Search/Search.tsx:583
 msgid "Clear search query"
 msgstr "Effacer la recherche"
+
+#: src/view/screens/Support.tsx:40
+msgid "click here"
+msgstr ""
 
 #: src/view/com/auth/login/PasswordUpdatedForm.tsx:38
 msgid "Close alert"
@@ -488,19 +661,50 @@ msgstr "Fermer la visionneuse d’images"
 msgid "Close navigation footer"
 msgstr "Fermer le pied de page de navigation"
 
+#: src/view/shell/index.web.tsx:50
+msgid "Closes bottom navigation bar"
+msgstr ""
+
+#: src/view/com/auth/login/PasswordUpdatedForm.tsx:39
+msgid "Closes password update alert"
+msgstr ""
+
+#: src/view/com/composer/Composer.tsx:301
+msgid "Closes post composer and discards post draft"
+msgstr ""
+
+#: src/view/com/lightbox/ImageViewing/components/ImageDefaultHeader.tsx:27
+msgid "Closes viewer for header image"
+msgstr ""
+
+#: src/view/com/notifications/FeedItem.tsx:321
+msgid "Collapses list of users for a given notification"
+msgstr ""
+
+#: src/Navigation.tsx:229
 #: src/view/screens/CommunityGuidelines.tsx:32
 msgid "Community Guidelines"
 msgstr "Directives communautaires"
+
+#: src/view/com/composer/Composer.tsx:416
+msgid "Compose posts up to {MAX_GRAPHEME_LENGTH} characters in length"
+msgstr ""
 
 #: src/view/com/composer/Prompt.tsx:24
 msgid "Compose reply"
 msgstr "Rédiger une réponse"
 
-#: src/view/com/modals/AppealLabel.tsx:98
 #: src/view/com/modals/Confirm.tsx:75
+#: src/view/com/modals/Confirm.tsx:78
+msgctxt "action"
+msgid "Confirm"
+msgstr ""
+
+#: src/view/com/modals/AppealLabel.tsx:98
 #: src/view/com/modals/SelfLabel.tsx:154
-#: src/view/com/modals/VerifyEmail.tsx:225
-#: src/view/screens/PreferencesHomeFeed.tsx:305
+#: src/view/com/modals/VerifyEmail.tsx:231
+#: src/view/com/modals/VerifyEmail.tsx:233
+#: src/view/screens/PreferencesHomeFeed.tsx:308
 #: src/view/screens/PreferencesThreads.tsx:159
 msgid "Confirm"
 msgstr "Confirmer"
@@ -514,18 +718,26 @@ msgstr "Confirmer le changement"
 msgid "Confirm content language settings"
 msgstr "Confirmer les paramètres de langue"
 
-#: src/view/com/modals/DeleteAccount.tsx:209
+#: src/view/com/modals/DeleteAccount.tsx:213
 msgid "Confirm delete account"
 msgstr "Confirmer la suppression du compte"
 
+#: src/view/com/modals/ContentFilteringSettings.tsx:151
+msgid "Confirm your age to enable adult content."
+msgstr ""
+
 #: src/view/com/modals/ChangeEmail.tsx:157
-#: src/view/com/modals/DeleteAccount.tsx:176
-#: src/view/com/modals/VerifyEmail.tsx:159
+#: src/view/com/modals/DeleteAccount.tsx:178
+#: src/view/com/modals/VerifyEmail.tsx:165
 msgid "Confirmation code"
 msgstr "Code de confirmation"
 
+#: src/view/com/modals/Waitlist.tsx:120
+msgid "Confirms signing up {email} to the waitlist"
+msgstr ""
+
 #: src/view/com/auth/create/CreateAccount.tsx:174
-#: src/view/com/auth/login/LoginForm.tsx:273
+#: src/view/com/auth/login/LoginForm.tsx:275
 msgid "Connecting..."
 msgstr "Connexion…"
 
@@ -542,6 +754,11 @@ msgstr "Filtrage du contenu"
 msgid "Content Languages"
 msgstr "Langues du contenu"
 
+#: src/view/com/modals/ModerationDetails.tsx:65
+msgid "Content Not Available"
+msgstr ""
+
+#: src/view/com/modals/ModerationDetails.tsx:33
 #: src/view/com/util/moderation/ScreenHider.tsx:78
 msgid "Content Warning"
 msgstr "Avertissement sur le contenu"
@@ -555,31 +772,46 @@ msgstr "Avertissements sur le contenu"
 msgid "Continue"
 msgstr "Continuer"
 
-#: src/view/com/modals/AddAppPasswords.tsx:193
-#: src/view/com/modals/InviteCodes.tsx:179
+#: src/view/com/modals/AddAppPasswords.tsx:197
+#: src/view/com/modals/InviteCodes.tsx:182
 msgid "Copied"
 msgstr "Copié"
 
-#: src/view/com/modals/AddAppPasswords.tsx:186
+#: src/view/screens/Settings.tsx:236
+msgid "Copied build version to clipboard"
+msgstr ""
+
+#: src/view/com/modals/AddAppPasswords.tsx:75
+#: src/view/com/modals/InviteCodes.tsx:152
+#: src/view/com/util/forms/PostDropdownBtn.tsx:110
+msgid "Copied to clipboard"
+msgstr ""
+
+#: src/view/com/modals/AddAppPasswords.tsx:191
+msgid "Copies app password"
+msgstr ""
+
+#: src/view/com/modals/AddAppPasswords.tsx:190
 msgid "Copy"
 msgstr "Copie"
 
-#: src/view/screens/ProfileList.tsx:385
+#: src/view/screens/ProfileList.tsx:396
 msgid "Copy link to list"
 msgstr "Copier le lien dans la liste"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:139
+#: src/view/com/util/forms/PostDropdownBtn.tsx:151
 msgid "Copy link to post"
 msgstr "Copier le lien vers le post"
 
-#: src/view/com/profile/ProfileHeader.tsx:338
+#: src/view/com/profile/ProfileHeader.tsx:342
 msgid "Copy link to profile"
 msgstr "Copier le lien sur le profil"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:125
+#: src/view/com/util/forms/PostDropdownBtn.tsx:137
 msgid "Copy post text"
 msgstr "Copier le texte du post"
 
+#: src/Navigation.tsx:234
 #: src/view/screens/CopyrightPolicy.tsx:29
 msgid "Copyright Policy"
 msgstr "Politique sur les droits d’auteur"
@@ -588,29 +820,50 @@ msgstr "Politique sur les droits d’auteur"
 msgid "Could not load feed"
 msgstr "Impossible de charger le fil d’actu"
 
-#: src/view/screens/ProfileList.tsx:839
+#: src/view/screens/ProfileList.tsx:867
 msgid "Could not load list"
 msgstr "Impossible de charger la liste"
 
 #: src/view/com/auth/HomeLoggedOutCTA.tsx:62
 #: src/view/com/auth/SplashScreen.tsx:46
+#: src/view/com/auth/SplashScreen.web.tsx:77
 msgid "Create a new account"
 msgstr "Créer un nouveau compte"
+
+#: src/view/screens/Settings.tsx:371
+msgid "Create a new Bluesky account"
+msgstr ""
 
 #: src/view/com/auth/create/CreateAccount.tsx:121
 msgid "Create Account"
 msgstr "Créer un compte"
+
+#: src/view/com/modals/AddAppPasswords.tsx:228
+msgid "Create App Password"
+msgstr ""
 
 #: src/view/com/auth/HomeLoggedOutCTA.tsx:54
 #: src/view/com/auth/SplashScreen.tsx:43
 msgid "Create new account"
 msgstr "Créer un nouveau compte"
 
-#: src/view/screens/AppPasswords.tsx:248
+#: src/view/screens/AppPasswords.tsx:249
 msgid "Created {0}"
 msgstr "{0} créé"
 
-#: src/view/com/modals/ChangeHandle.tsx:387
+#: src/view/screens/ProfileFeed.tsx:625
+msgid "Created by <0/>"
+msgstr ""
+
+#: src/view/screens/ProfileFeed.tsx:623
+msgid "Created by you"
+msgstr ""
+
+#: src/view/com/composer/Composer.tsx:447
+msgid "Creates a card with a thumbnail. The card links to {url}"
+msgstr ""
+
+#: src/view/com/modals/ChangeHandle.tsx:389
 #: src/view/com/modals/ServerInput.tsx:102
 msgid "Custom domain"
 msgstr "Domaine personnalisé"
@@ -619,11 +872,27 @@ msgstr "Domaine personnalisé"
 msgid "Customize media from external sites."
 msgstr ""
 
-#: src/view/screens/Settings.tsx:648
+#: src/view/screens/Settings.tsx:663
 msgid "Danger Zone"
 msgstr "Zone de danger"
 
-#: src/view/screens/Settings.tsx:655
+#: src/view/screens/Settings.tsx:466
+msgid "Dark"
+msgstr ""
+
+#: src/view/screens/Debug.tsx:63
+msgid "Dark mode"
+msgstr ""
+
+#: src/Navigation.tsx:204
+msgid "Debug"
+msgstr ""
+
+#: src/view/screens/Debug.tsx:83
+msgid "Debug panel"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:670
 msgid "Delete account"
 msgstr "Supprimer le compte"
 
@@ -631,40 +900,44 @@ msgstr "Supprimer le compte"
 msgid "Delete Account"
 msgstr "Supprimer le compte"
 
-#: src/view/screens/AppPasswords.tsx:221
-#: src/view/screens/AppPasswords.tsx:241
+#: src/view/screens/AppPasswords.tsx:222
+#: src/view/screens/AppPasswords.tsx:242
 msgid "Delete app password"
 msgstr "Supprimer le mot de passe de l’appli"
 
-#: src/view/screens/ProfileList.tsx:352
-#: src/view/screens/ProfileList.tsx:412
+#: src/view/screens/ProfileList.tsx:363
+#: src/view/screens/ProfileList.tsx:423
 msgid "Delete List"
 msgstr "Supprimer la liste"
 
-#: src/view/com/modals/DeleteAccount.tsx:212
+#: src/view/com/modals/DeleteAccount.tsx:216
 msgid "Delete my account"
 msgstr "Supprimer mon compte"
 
-#: src/view/screens/Settings.tsx:665
+#: src/view/screens/Settings.tsx:682
 msgid "Delete my account…"
 msgstr "Supprimer mon compte…"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:214
+#: src/view/com/util/forms/PostDropdownBtn.tsx:226
 msgid "Delete post"
 msgstr "Supprimer le post"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:218
+#: src/view/com/util/forms/PostDropdownBtn.tsx:230
 msgid "Delete this post?"
 msgstr "Supprimer ce post ?"
 
-#: src/view/com/post-thread/PostThread.tsx:242
+#: src/view/com/util/post-embeds/QuoteEmbed.tsx:66
+msgid "Deleted"
+msgstr ""
+
+#: src/view/com/post-thread/PostThread.tsx:246
 msgid "Deleted post."
 msgstr "Post supprimé."
 
-#: src/view/com/modals/CreateOrEditList.tsx:218
-#: src/view/com/modals/CreateOrEditList.tsx:234
-#: src/view/com/modals/EditProfile.tsx:197
-#: src/view/com/modals/EditProfile.tsx:209
+#: src/view/com/modals/CreateOrEditList.tsx:239
+#: src/view/com/modals/CreateOrEditList.tsx:255
+#: src/view/com/modals/EditProfile.tsx:198
+#: src/view/com/modals/EditProfile.tsx:210
 msgid "Description"
 msgstr "Description"
 
@@ -672,19 +945,19 @@ msgstr "Description"
 msgid "Dev Server"
 msgstr "Serveur de dév"
 
-#: src/view/screens/Settings.tsx:670
+#: src/view/screens/Settings.tsx:687
 msgid "Developer Tools"
 msgstr "Outils de dév"
 
-#: src/view/com/composer/Composer.tsx:211
+#: src/view/com/composer/Composer.tsx:210
 msgid "Did you want to say anything?"
 msgstr "Vous vouliez dire quelque chose ?"
 
-#: src/view/com/composer/Composer.tsx:144
+#: src/view/com/composer/Composer.tsx:143
 msgid "Discard"
 msgstr "Ignorer"
 
-#: src/view/com/composer/Composer.tsx:138
+#: src/view/com/composer/Composer.tsx:137
 msgid "Discard draft"
 msgstr "Ignorer le brouillon"
 
@@ -692,35 +965,53 @@ msgstr "Ignorer le brouillon"
 msgid "Discourage apps from showing my account to logged-out users"
 msgstr "Empêcher les applis de montrer mon compte aux utilisateurs déconnectés"
 
-#: src/view/screens/Feeds.tsx:405
+#: src/view/com/posts/FollowingEmptyState.tsx:74
+#: src/view/com/posts/FollowingEndOfFeed.tsx:75
+msgid "Discover new custom feeds"
+msgstr ""
+
+#: src/view/screens/Feeds.tsx:409
 msgid "Discover new feeds"
 msgstr "Découvrir de nouveaux fils d’actu"
 
-#: src/view/com/modals/EditProfile.tsx:191
+#: src/view/com/modals/EditProfile.tsx:192
 msgid "Display name"
 msgstr "Afficher le nom"
 
-#: src/view/com/modals/EditProfile.tsx:179
+#: src/view/com/modals/EditProfile.tsx:180
 msgid "Display Name"
 msgstr "Afficher le nom"
 
-#: src/view/com/modals/ChangeHandle.tsx:485
+#: src/view/com/modals/ChangeHandle.tsx:487
 msgid "Domain verified!"
 msgstr "Domaine vérifié !"
 
+#: src/view/com/auth/create/Step2.tsx:83
+msgid "Don't have an invite code?"
+msgstr ""
+
 #: src/view/com/auth/onboarding/RecommendedFollows.tsx:86
-#: src/view/com/modals/AltImage.tsx:115
-#: src/view/com/modals/ContentFilteringSettings.tsx:88
-#: src/view/com/modals/ContentFilteringSettings.tsx:96
-#: src/view/com/modals/crop-image/CropImage.web.tsx:152
 #: src/view/com/modals/EditImage.tsx:333
-#: src/view/com/modals/ListAddRemoveUsers.tsx:142
+#: src/view/com/modals/ListAddRemoveUsers.tsx:144
 #: src/view/com/modals/SelfLabel.tsx:157
 #: src/view/com/modals/Threadgate.tsx:129
 #: src/view/com/modals/Threadgate.tsx:132
 #: src/view/com/modals/UserAddRemoveLists.tsx:79
-#: src/view/screens/PreferencesHomeFeed.tsx:308
+#: src/view/com/modals/UserAddRemoveLists.tsx:82
 #: src/view/screens/PreferencesThreads.tsx:162
+msgctxt "action"
+msgid "Done"
+msgstr ""
+
+#: src/view/com/modals/AddAppPasswords.tsx:228
+#: src/view/com/modals/AltImage.tsx:115
+#: src/view/com/modals/ContentFilteringSettings.tsx:88
+#: src/view/com/modals/ContentFilteringSettings.tsx:96
+#: src/view/com/modals/crop-image/CropImage.web.tsx:152
+#: src/view/com/modals/InviteCodes.tsx:80
+#: src/view/com/modals/InviteCodes.tsx:123
+#: src/view/com/modals/ListAddRemoveUsers.tsx:142
+#: src/view/screens/PreferencesHomeFeed.tsx:311
 msgid "Done"
 msgstr "Terminé"
 
@@ -728,56 +1019,116 @@ msgstr "Terminé"
 msgid "Done{extraText}"
 msgstr "Terminé{extraText}"
 
-#: src/view/com/modals/InviteCodes.tsx:94
+#: src/view/com/auth/login/ChooseAccountForm.tsx:45
+msgid "Double tap to sign in"
+msgstr ""
+
+#: src/view/com/modals/EditProfile.tsx:185
+msgid "e.g. Alice Roberts"
+msgstr ""
+
+#: src/view/com/modals/EditProfile.tsx:203
+msgid "e.g. Artist, dog-lover, and avid reader."
+msgstr ""
+
+#: src/view/com/modals/CreateOrEditList.tsx:225
+msgid "e.g. Great Posters"
+msgstr ""
+
+#: src/view/com/modals/CreateOrEditList.tsx:226
+msgid "e.g. Spammers"
+msgstr ""
+
+#: src/view/com/modals/CreateOrEditList.tsx:246
+msgid "e.g. The posters who never miss."
+msgstr ""
+
+#: src/view/com/modals/CreateOrEditList.tsx:247
+msgid "e.g. Users that repeatedly reply with ads."
+msgstr ""
+
+#: src/view/com/modals/InviteCodes.tsx:96
 msgid "Each code works once. You'll receive more invite codes periodically."
 msgstr "Chaque code ne fonctionne qu’une seule fois. Vous recevrez régulièrement d’autres codes d’invitation."
+
+#: src/view/com/lists/ListMembers.tsx:149
+msgctxt "action"
+msgid "Edit"
+msgstr ""
 
 #: src/view/com/composer/photos/Gallery.tsx:144
 #: src/view/com/modals/EditImage.tsx:207
 msgid "Edit image"
 msgstr "Modifier l’image"
 
-#: src/view/screens/ProfileList.tsx:400
+#: src/view/screens/ProfileList.tsx:411
 msgid "Edit list details"
 msgstr "Modifier les infos de la liste"
 
-#: src/view/screens/Feeds.tsx:367
+#: src/view/com/modals/CreateOrEditList.tsx:193
+msgid "Edit Moderation List"
+msgstr ""
+
+#: src/Navigation.tsx:244
+#: src/view/screens/Feeds.tsx:371
 #: src/view/screens/SavedFeeds.tsx:84
 msgid "Edit My Feeds"
 msgstr "Modifier mes fils d’actu"
 
-#: src/view/com/modals/EditProfile.tsx:151
+#: src/view/com/modals/EditProfile.tsx:152
 msgid "Edit my profile"
 msgstr "Modifier mon profil"
 
-#: src/view/com/profile/ProfileHeader.tsx:453
+#: src/view/com/profile/ProfileHeader.tsx:457
 msgid "Edit profile"
 msgstr "Modifier le profil"
 
-#: src/view/com/profile/ProfileHeader.tsx:456
+#: src/view/com/profile/ProfileHeader.tsx:462
 msgid "Edit Profile"
 msgstr "Modifier le profil"
 
-#: src/view/screens/Feeds.tsx:330
+#: src/view/screens/Feeds.tsx:334
 msgid "Edit Saved Feeds"
 msgstr "Modifier les fils d’actu enregistrés"
 
+#: src/view/com/modals/CreateOrEditList.tsx:188
+msgid "Edit User List"
+msgstr ""
+
+#: src/view/com/modals/EditProfile.tsx:193
+msgid "Edit your display name"
+msgstr ""
+
+#: src/view/com/modals/EditProfile.tsx:211
+msgid "Edit your profile description"
+msgstr ""
+
 #: src/view/com/auth/create/Step2.tsx:108
-#: src/view/com/auth/login/ForgotPasswordForm.tsx:148
+#: src/view/com/auth/login/ForgotPasswordForm.tsx:152
 #: src/view/com/modals/ChangeEmail.tsx:141
 #: src/view/com/modals/Waitlist.tsx:88
 msgid "Email"
 msgstr "E-mail"
 
 #: src/view/com/auth/create/Step2.tsx:99
+#: src/view/com/auth/login/ForgotPasswordForm.tsx:143
 msgid "Email address"
 msgstr "Adresse e-mail"
+
+#: src/view/com/modals/ChangeEmail.tsx:56
+#: src/view/com/modals/ChangeEmail.tsx:88
+msgid "Email updated"
+msgstr ""
 
 #: src/view/com/modals/ChangeEmail.tsx:111
 msgid "Email Updated"
 msgstr "E-mail mis à jour"
 
-#: src/view/screens/Settings.tsx:290
+#: src/view/com/modals/VerifyEmail.tsx:78
+msgid "Email verified"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:305
 msgid "Email:"
 msgstr "E-mail :"
 
@@ -785,33 +1136,62 @@ msgstr "E-mail :"
 msgid "Enable {0} only"
 msgstr ""
 
+#: src/view/com/modals/ContentFilteringSettings.tsx:162
+msgid "Enable Adult Content"
+msgstr ""
+
 #: src/view/com/modals/EmbedConsent.tsx:97
 msgid "Enable External Media"
 msgstr ""
 
-#: src/view/screens/PreferencesHomeFeed.tsx:144
+#: src/view/screens/PreferencesExternalEmbeds.tsx:75
+msgid "Enable media players for"
+msgstr ""
+
+#: src/view/screens/PreferencesHomeFeed.tsx:147
 msgid "Enable this setting to only see replies between people you follow."
 msgstr "Activez ce paramètre pour ne voir que les réponses des personnes que vous suivez."
 
-#: src/view/screens/Profile.tsx:426
+#: src/view/screens/Profile.tsx:427
 msgid "End of feed"
 msgstr "Fin du fil d’actu"
+
+#: src/view/com/modals/AddAppPasswords.tsx:165
+msgid "Enter a name for this App Password"
+msgstr ""
+
+#: src/view/com/modals/VerifyEmail.tsx:105
+msgid "Enter Confirmation Code"
+msgstr ""
 
 #: src/view/com/auth/create/Step1.tsx:71
 msgid "Enter the address of your provider:"
 msgstr "Saisissez l’adresse de votre fournisseur :"
 
-#: src/view/com/modals/ChangeHandle.tsx:369
+#: src/view/com/modals/ChangeHandle.tsx:371
 msgid "Enter the domain you want to use"
 msgstr "Entrez le domaine que vous voulez utiliser"
 
-#: src/view/com/auth/login/ForgotPasswordForm.tsx:101
+#: src/view/com/auth/login/ForgotPasswordForm.tsx:103
 msgid "Enter the email you used to create your account. We'll send you a \"reset code\" so you can set a new password."
 msgstr "Saisissez l’e-mail que vous avez utilisé pour créer votre compte. Nous vous enverrons un « code de réinitialisation » afin changer votre mot de passe."
+
+#: src/view/com/auth/create/Step2.tsx:157
+#: src/view/com/modals/BirthDateSettings.tsx:74
+msgid "Enter your birth date"
+msgstr ""
+
+#: src/view/com/modals/Waitlist.tsx:78
+msgid "Enter your email"
+msgstr ""
 
 #: src/view/com/auth/create/Step2.tsx:104
 msgid "Enter your email address"
 msgstr "Entrez votre e-mail"
+
+#: src/view/com/modals/ChangeEmail.tsx:41
+msgid "Enter your new email above"
+msgstr ""
 
 #: src/view/com/modals/ChangeEmail.tsx:117
 msgid "Enter your new email address below."
@@ -829,9 +1209,31 @@ msgstr "Erreur :"
 msgid "Everybody"
 msgstr "Tout le monde"
 
+#: src/view/com/modals/ChangeHandle.tsx:150
+msgid "Exits handle change process"
+msgstr ""
+
+#: src/view/com/lightbox/Lightbox.web.tsx:113
+msgid "Exits image view"
+msgstr ""
+
+#: src/view/com/modals/ListAddRemoveUsers.tsx:88
+#: src/view/shell/desktop/Search.tsx:182
+msgid "Exits inputting search query"
+msgstr ""
+
+#: src/view/com/modals/Waitlist.tsx:138
+msgid "Exits signing up for waitlist with {email}"
+msgstr ""
+
 #: src/view/com/lightbox/Lightbox.web.tsx:156
 msgid "Expand alt text"
 msgstr "Développer le texte alt"
+
+#: src/view/com/composer/ComposerReplyTo.tsx:81
+#: src/view/com/composer/ComposerReplyTo.tsx:84
+msgid "Expand or collapse the full post you are replying to"
+msgstr ""
 
 #: src/view/com/modals/EmbedConsent.tsx:64
 msgid "External Media"
@@ -842,9 +1244,27 @@ msgstr ""
 msgid "External media may allow websites to collect information about you and your device. No information is sent or requested until you press the \"play\" button."
 msgstr ""
 
+#: src/Navigation.tsx:260
 #: src/view/screens/PreferencesExternalEmbeds.tsx:52
-#: src/view/screens/Settings.tsx:595
+#: src/view/screens/Settings.tsx:610
 msgid "External Media Preferences"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:601
+msgid "External media settings"
+msgstr ""
+
+#: src/view/com/modals/AddAppPasswords.tsx:114
+#: src/view/com/modals/AddAppPasswords.tsx:118
+msgid "Failed to create app password."
+msgstr ""
+
+#: src/view/com/modals/CreateOrEditList.tsx:148
+msgid "Failed to create the list. Check your internet connection and try again."
+msgstr ""
+
+#: src/view/com/util/forms/PostDropdownBtn.tsx:86
+msgid "Failed to delete post, please try again"
 msgstr ""
 
 #: src/view/com/auth/onboarding/RecommendedFeeds.tsx:109
@@ -852,7 +1272,15 @@ msgstr ""
 msgid "Failed to load recommended feeds"
 msgstr "Échec du chargement des fils d’actu recommandés"
 
-#: src/view/screens/Feeds.tsx:556
+#: src/Navigation.tsx:194
+msgid "Feed"
+msgstr ""
+
+#: src/view/com/feeds/FeedSourceCard.tsx:229
+msgid "Feed by {0}"
+msgstr ""
+
+#: src/view/screens/Feeds.tsx:560
 msgid "Feed offline"
 msgstr "Fil d’actu hors ligne"
 
@@ -865,12 +1293,13 @@ msgstr "Préférences en matière de fil d’actu"
 msgid "Feedback"
 msgstr "Feedback"
 
-#: src/view/screens/Feeds.tsx:475
+#: src/Navigation.tsx:442
+#: src/view/screens/Feeds.tsx:479
 #: src/view/screens/Profile.tsx:165
 #: src/view/shell/bottom-bar/BottomBar.tsx:181
 #: src/view/shell/desktop/LeftNav.tsx:342
-#: src/view/shell/Drawer.tsx:474
-#: src/view/shell/Drawer.tsx:475
+#: src/view/shell/Drawer.tsx:476
+#: src/view/shell/Drawer.tsx:477
 msgid "Feeds"
 msgstr "Fil d’actu"
 
@@ -881,6 +1310,12 @@ msgstr "Les fils d’actu sont créés par les utilisateurs pour rassembler du c
 #: src/view/screens/SavedFeeds.tsx:156
 msgid "Feeds are custom algorithms that users build with a little coding expertise. <0/> for more information."
 msgstr "Les fils d’actu sont des algorithmes personnalisés que les utilisateurs construisent avec un peu d’expertise en codage. <0/> pour obtenir de plus amples informations."
+
+#: src/view/com/posts/CustomFeedEmptyState.tsx:47
+#: src/view/com/posts/FollowingEmptyState.tsx:57
+#: src/view/com/posts/FollowingEndOfFeed.tsx:58
+msgid "Find accounts to follow"
+msgstr ""
 
 #: src/view/screens/Search/Search.tsx:427
 msgid "Find users on Bluesky"
@@ -894,7 +1329,7 @@ msgstr "Trouvez des utilisateurs à l’aide de l’outil de recherche, à droit
 msgid "Finding similar accounts..."
 msgstr "Recherche de comptes similaires…"
 
-#: src/view/screens/PreferencesHomeFeed.tsx:108
+#: src/view/screens/PreferencesHomeFeed.tsx:111
 msgid "Fine-tune the content you see on your home screen."
 msgstr "Affinez le contenu de votre écran d’accueil."
 
@@ -902,52 +1337,86 @@ msgstr "Affinez le contenu de votre écran d’accueil."
 msgid "Fine-tune the discussion threads."
 msgstr "Affiner les fils de discussion."
 
-#: src/view/com/profile/ProfileHeader.tsx:538
+#: src/view/com/modals/EditImage.tsx:115
+msgid "Flip horizontal"
+msgstr ""
+
+#: src/view/com/modals/EditImage.tsx:120
+#: src/view/com/modals/EditImage.tsx:287
+msgid "Flip vertically"
+msgstr ""
+
+#: src/view/com/profile/FollowButton.tsx:64
+msgctxt "action"
+msgid "Follow"
+msgstr ""
+
+#: src/view/com/profile/ProfileHeader.tsx:552
 msgid "Follow"
 msgstr "Suivre"
+
+#: src/view/com/profile/ProfileHeader.tsx:543
+msgid "Follow {0}"
+msgstr ""
 
 #: src/view/com/auth/onboarding/RecommendedFollows.tsx:64
 msgid "Follow some users to get started. We can recommend you more users based on who you find interesting."
 msgstr "Suivez quelques utilisateurs pour commencer. Nous pouvons vous recommander d’autres utilisateurs en fonction des personnes qui vous intéressent."
 
+#: src/view/com/profile/ProfileCard.tsx:194
+msgid "Followed by {0}"
+msgstr ""
+
 #: src/view/com/modals/Threadgate.tsx:98
 msgid "Followed users"
 msgstr "Utilisateurs suivis"
 
-#: src/view/screens/PreferencesHomeFeed.tsx:151
+#: src/view/screens/PreferencesHomeFeed.tsx:154
 msgid "Followed users only"
 msgstr "Utilisateurs suivis uniquement"
+
+#: src/view/com/notifications/FeedItem.tsx:166
+msgid "followed you"
+msgstr ""
 
 #: src/view/screens/ProfileFollowers.tsx:25
 msgid "Followers"
 msgstr "Followers"
 
 #: src/view/com/profile/ProfileHeader.tsx:624
-msgid "following"
-msgstr "suivi"
+#~ msgid "following"
+#~ msgstr "suivi"
 
-#: src/view/com/profile/ProfileHeader.tsx:522
+#: src/view/com/profile/ProfileHeader.tsx:534
 #: src/view/screens/ProfileFollows.tsx:25
 msgid "Following"
 msgstr "Suivi"
 
-#: src/view/com/profile/ProfileHeader.tsx:571
+#: src/view/com/profile/ProfileHeader.tsx:196
+msgid "Following {0}"
+msgstr ""
+
+#: src/view/com/profile/ProfileHeader.tsx:585
 msgid "Follows you"
 msgstr "Vous suit"
+
+#: src/view/com/profile/ProfileCard.tsx:141
+msgid "Follows You"
+msgstr ""
 
 #: src/view/com/modals/DeleteAccount.tsx:107
 msgid "For security reasons, we'll need to send a confirmation code to your email address."
 msgstr "Pour des raisons de sécurité, nous devrons envoyer un code de confirmation à votre e-mail."
 
-#: src/view/com/modals/AddAppPasswords.tsx:207
+#: src/view/com/modals/AddAppPasswords.tsx:211
 msgid "For security reasons, you won't be able to view this again. If you lose this password, you'll need to generate a new one."
 msgstr "Pour des raisons de sécurité, vous ne pourrez plus afficher ceci. Si vous perdez ce mot de passe, vous devrez en générer un autre."
 
-#: src/view/com/auth/login/LoginForm.tsx:236
+#: src/view/com/auth/login/LoginForm.tsx:238
 msgid "Forgot"
 msgstr "Oublié"
 
-#: src/view/com/auth/login/LoginForm.tsx:233
+#: src/view/com/auth/login/LoginForm.tsx:235
 msgid "Forgot password"
 msgstr "Mot de passe oublié"
 
@@ -956,11 +1425,17 @@ msgstr "Mot de passe oublié"
 msgid "Forgot Password"
 msgstr "Mot de passe oublié"
 
+#: src/view/com/posts/FeedItem.tsx:188
+msgctxt "from-feed"
+msgid "From <0/>"
+msgstr ""
+
 #: src/view/com/composer/photos/SelectPhotoBtn.tsx:43
 msgid "Gallery"
 msgstr "Galerie"
 
-#: src/view/com/modals/VerifyEmail.tsx:183
+#: src/view/com/modals/VerifyEmail.tsx:189
+#: src/view/com/modals/VerifyEmail.tsx:191
 msgid "Get Started"
 msgstr "C’est parti"
 
@@ -973,14 +1448,14 @@ msgstr "Retour"
 
 #: src/view/screens/ProfileFeed.tsx:104
 #: src/view/screens/ProfileFeed.tsx:109
-#: src/view/screens/ProfileList.tsx:848
-#: src/view/screens/ProfileList.tsx:853
+#: src/view/screens/ProfileList.tsx:876
+#: src/view/screens/ProfileList.tsx:881
 msgid "Go Back"
 msgstr "Retour"
 
-#: src/view/com/auth/login/ForgotPasswordForm.tsx:181
-#: src/view/com/auth/login/LoginForm.tsx:283
-#: src/view/com/auth/login/SetNewPasswordForm.tsx:163
+#: src/view/com/auth/login/ForgotPasswordForm.tsx:185
+#: src/view/com/auth/login/LoginForm.tsx:285
+#: src/view/com/auth/login/SetNewPasswordForm.tsx:165
 msgid "Go to next"
 msgstr "Aller à la suite"
 
@@ -993,47 +1468,64 @@ msgstr "Pseudo"
 msgid "Help"
 msgstr "Aide"
 
-#: src/view/com/modals/AddAppPasswords.tsx:148
+#: src/view/com/modals/AddAppPasswords.tsx:152
 msgid "Here is your app password."
 msgstr "Voici le mot de passe de votre appli."
 
-#: src/view/com/notifications/FeedItem.tsx:324
-#: src/view/com/util/moderation/ContentHider.tsx:103
+#: src/view/com/modals/ContentFilteringSettings.tsx:219
+#: src/view/com/notifications/FeedItem.tsx:329
+msgctxt "action"
+msgid "Hide"
+msgstr ""
+
+#: src/view/com/modals/ContentFilteringSettings.tsx:246
+#: src/view/com/util/moderation/ContentHider.tsx:105
+#: src/view/com/util/moderation/PostHider.tsx:108
 msgid "Hide"
 msgstr "Cacher"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:173
+#: src/view/com/util/forms/PostDropdownBtn.tsx:185
 msgid "Hide post"
 msgstr "Cacher ce post"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:177
+#: src/view/com/util/moderation/ContentHider.tsx:67
+#: src/view/com/util/moderation/PostHider.tsx:61
+msgid "Hide the content"
+msgstr ""
+
+#: src/view/com/util/forms/PostDropdownBtn.tsx:189
 msgid "Hide this post?"
 msgstr "Cacher ce post ?"
 
-#: src/view/com/notifications/FeedItem.tsx:316
+#: src/view/com/notifications/FeedItem.tsx:319
 msgid "Hide user list"
 msgstr "Cacher la liste des utilisateurs"
 
-#: src/view/com/posts/FeedErrorMessage.tsx:110
+#: src/view/com/profile/ProfileHeader.tsx:526
+msgid "Hides posts from {0} in your feed"
+msgstr ""
+
+#: src/view/com/posts/FeedErrorMessage.tsx:111
 msgid "Hmm, some kind of issue occurred when contacting the feed server. Please let the feed owner know about this issue."
 msgstr "Hmm, un problème s’est produit avec le serveur de fils d’actu. Veuillez informer le propriétaire du fil d’actu de ce problème."
 
-#: src/view/com/posts/FeedErrorMessage.tsx:98
+#: src/view/com/posts/FeedErrorMessage.tsx:99
 msgid "Hmm, the feed server appears to be misconfigured. Please let the feed owner know about this issue."
 msgstr "Hmm, le serveur du fils d’actu semble être mal configuré. Veuillez informer le propriétaire du fil d’actu de ce problème."
 
-#: src/view/com/posts/FeedErrorMessage.tsx:104
+#: src/view/com/posts/FeedErrorMessage.tsx:105
 msgid "Hmm, the feed server appears to be offline. Please let the feed owner know about this issue."
 msgstr "Mmm… le serveur de fils d’actu semble être hors ligne. Veuillez informer le propriétaire du fil d’actu de ce problème."
 
-#: src/view/com/posts/FeedErrorMessage.tsx:101
+#: src/view/com/posts/FeedErrorMessage.tsx:102
 msgid "Hmm, the feed server gave a bad response. Please let the feed owner know about this issue."
 msgstr "Mmm… le serveur de fils d’actu ne répond pas. Veuillez informer le propriétaire du fil d’actu de ce problème."
 
-#: src/view/com/posts/FeedErrorMessage.tsx:95
+#: src/view/com/posts/FeedErrorMessage.tsx:96
 msgid "Hmm, we're having trouble finding this feed. It may have been deleted."
 msgstr "Hmm, nous n’arrivons pas à trouver ce fils d’actu. Il a peut-être été supprimé."
 
+#: src/Navigation.tsx:432
 #: src/view/shell/bottom-bar/BottomBar.tsx:137
 #: src/view/shell/desktop/LeftNav.tsx:306
 #: src/view/shell/Drawer.tsx:398
@@ -1041,13 +1533,14 @@ msgstr "Hmm, nous n’arrivons pas à trouver ce fils d’actu. Il a peut-être 
 msgid "Home"
 msgstr "Accueil"
 
-#: src/view/com/pager/FeedsTabBarMobile.tsx:96
-#: src/view/screens/PreferencesHomeFeed.tsx:101
-#: src/view/screens/Settings.tsx:481
+#: src/Navigation.tsx:249
+#: src/view/com/pager/FeedsTabBarMobile.tsx:98
+#: src/view/screens/PreferencesHomeFeed.tsx:104
+#: src/view/screens/Settings.tsx:496
 msgid "Home Feed Preferences"
 msgstr "Préférences de fils d’actu de l’accueil"
 
-#: src/view/com/auth/login/ForgotPasswordForm.tsx:114
+#: src/view/com/auth/login/ForgotPasswordForm.tsx:116
 msgid "Hosting provider"
 msgstr "Fournisseur d’hébergement"
 
@@ -1056,17 +1549,29 @@ msgstr "Fournisseur d’hébergement"
 msgid "Hosting provider address"
 msgstr "Adresse de l’hébergeur"
 
-#: src/view/com/modals/VerifyEmail.tsx:208
+#: src/view/com/modals/VerifyEmail.tsx:214
 msgid "I have a code"
 msgstr "J’ai un code"
 
-#: src/view/com/modals/ChangeHandle.tsx:281
+#: src/view/com/modals/VerifyEmail.tsx:216
+msgid "I have a confirmation code"
+msgstr ""
+
+#: src/view/com/modals/ChangeHandle.tsx:283
 msgid "I have my own domain"
 msgstr "J’ai mon propre domaine"
+
+#: src/view/com/lightbox/Lightbox.web.tsx:158
+msgid "If alt text is long, toggles alt text expanded state"
+msgstr ""
 
 #: src/view/com/modals/SelfLabel.tsx:127
 msgid "If none are selected, suitable for all ages."
 msgstr "Si rien n’est sélectionné, il n’y a pas de restriction d’âge."
+
+#: src/view/com/util/images/Gallery.tsx:37
+msgid "Image"
+msgstr ""
 
 #: src/view/com/modals/AltImage.tsx:97
 msgid "Image alt text"
@@ -1077,19 +1582,76 @@ msgstr "Texte alt de l’image"
 msgid "Image options"
 msgstr "Options d’images"
 
+#: src/view/com/auth/login/SetNewPasswordForm.tsx:110
+msgid "Input code sent to your email for password reset"
+msgstr ""
+
+#: src/view/com/modals/DeleteAccount.tsx:180
+msgid "Input confirmation code for account deletion"
+msgstr ""
+
+#: src/view/com/auth/create/Step2.tsx:109
+msgid "Input email for Bluesky waitlist"
+msgstr ""
+
+#: src/view/com/auth/create/Step1.tsx:80
+msgid "Input hosting provider address"
+msgstr ""
+
+#: src/view/com/auth/create/Step2.tsx:73
+msgid "Input invite code to proceed"
+msgstr ""
+
+#: src/view/com/modals/AddAppPasswords.tsx:182
+msgid "Input name for app password"
+msgstr ""
+
+#: src/view/com/auth/login/SetNewPasswordForm.tsx:133
+msgid "Input new password"
+msgstr ""
+
+#: src/view/com/modals/DeleteAccount.tsx:196
+msgid "Input password for account deletion"
+msgstr ""
+
+#: src/view/com/auth/login/LoginForm.tsx:227
+msgid "Input the password tied to {identifier}"
+msgstr ""
+
+#: src/view/com/auth/login/LoginForm.tsx:194
+msgid "Input the username or email address you used at signup"
+msgstr ""
+
+#: src/view/com/modals/Waitlist.tsx:90
+msgid "Input your email to get on the Bluesky waitlist"
+msgstr ""
+
+#: src/view/com/auth/login/LoginForm.tsx:226
+msgid "Input your password"
+msgstr ""
+
+#: src/view/com/auth/create/Step3.tsx:39
+msgid "Input your user handle"
+msgstr ""
+
+#: src/view/com/post-thread/PostThreadItem.tsx:229
+msgid "Invalid or unsupported post record"
+msgstr ""
+
 #: src/view/com/auth/login/LoginForm.tsx:115
 msgid "Invalid username or password"
 msgstr "Nom d’utilisateur ou mot de passe incorrect"
 
-#: src/view/screens/Settings.tsx:383
+#: src/view/screens/Settings.tsx:398
 msgid "Invite"
 msgstr "Inviter"
 
-#: src/view/com/modals/InviteCodes.tsx:91
-#: src/view/screens/Settings.tsx:371
+#: src/view/com/modals/InviteCodes.tsx:93
+#: src/view/screens/Settings.tsx:386
 msgid "Invite a Friend"
 msgstr "Inviter un ami"
 
+#: src/view/com/auth/create/Step2.tsx:63
 #: src/view/com/auth/create/Step2.tsx:72
 msgid "Invite code"
 msgstr "Code d’invitation"
@@ -1098,9 +1660,17 @@ msgstr "Code d’invitation"
 msgid "Invite code not accepted. Check that you input it correctly and try again."
 msgstr "Code d’invitation refusé. Vérifiez que vous l’avez saisi correctement et réessayez."
 
-#: src/view/shell/Drawer.tsx:640
+#: src/view/com/modals/InviteCodes.tsx:170
+msgid "Invite codes: {0} available"
+msgstr ""
+
+#: src/view/shell/Drawer.tsx:642
 msgid "Invite codes: {invitesAvailable} available"
 msgstr "Codes d’invitation : {invitesAvailable} disponible"
+
+#: src/view/com/modals/InviteCodes.tsx:169
+msgid "Invite codes: 1 available"
+msgstr ""
 
 #: src/view/com/auth/HomeLoggedOutCTA.tsx:99
 msgid "Jobs"
@@ -1115,7 +1685,7 @@ msgstr "S’inscrire sur la liste d’attente"
 msgid "Join the waitlist."
 msgstr "S’inscrire sur la liste d’attente."
 
-#: src/view/com/modals/Waitlist.tsx:124
+#: src/view/com/modals/Waitlist.tsx:128
 msgid "Join Waitlist"
 msgstr "S’inscrire sur la liste d’attente"
 
@@ -1123,15 +1693,24 @@ msgstr "S’inscrire sur la liste d’attente"
 msgid "Language selection"
 msgstr "Sélection de la langue"
 
+#: src/view/screens/Settings.tsx:547
+msgid "Language settings"
+msgstr ""
+
+#: src/Navigation.tsx:141
 #: src/view/screens/LanguageSettings.tsx:89
 msgid "Language Settings"
 msgstr "Paramètres linguistiques"
 
-#: src/view/screens/Settings.tsx:541
+#: src/view/screens/Settings.tsx:556
 msgid "Languages"
 msgstr "Langues"
 
-#: src/view/com/util/moderation/ContentHider.tsx:101
+#: src/view/com/auth/create/StepHeader.tsx:13
+msgid "Last step!"
+msgstr ""
+
+#: src/view/com/util/moderation/ContentHider.tsx:103
 msgid "Learn more"
 msgstr "En savoir plus"
 
@@ -1141,9 +1720,9 @@ msgstr "En savoir plus"
 msgid "Learn More"
 msgstr "En savoir plus"
 
-#: src/view/com/util/moderation/ContentHider.tsx:83
+#: src/view/com/util/moderation/ContentHider.tsx:85
 #: src/view/com/util/moderation/PostAlerts.tsx:40
-#: src/view/com/util/moderation/PostHider.tsx:76
+#: src/view/com/util/moderation/PostHider.tsx:78
 #: src/view/com/util/moderation/ProfileHeaderAlerts.tsx:49
 #: src/view/com/util/moderation/ScreenHider.tsx:101
 msgid "Learn more about this warning"
@@ -1161,6 +1740,10 @@ msgstr "Si vous ne cochez rien, toutes les langues s’afficheront."
 msgid "Leaving Bluesky"
 msgstr "Quitter Bluesky"
 
+#: src/view/screens/Settings.tsx:273
+msgid "Legacy storage cleared, you need to restart the app now."
+msgstr ""
+
 #: src/view/com/auth/login/Login.tsx:128
 #: src/view/com/auth/login/Login.tsx:144
 msgid "Let's get your password reset!"
@@ -1171,36 +1754,94 @@ msgstr "Réinitialisez votre mot de passe !"
 msgid "Library"
 msgstr "Bibliothèque"
 
-#: src/view/screens/ProfileFeed.tsx:586
+#: src/view/screens/Settings.tsx:460
+msgid "Light"
+msgstr ""
+
+#: src/view/com/util/post-ctrls/PostCtrls.tsx:189
+msgid "Like"
+msgstr ""
+
+#: src/view/screens/ProfileFeed.tsx:600
 msgid "Like this feed"
 msgstr "Liker ce fil d’actu"
 
+#: src/Navigation.tsx:199
 #: src/view/screens/PostLikedBy.tsx:27
 #: src/view/screens/ProfileFeedLikedBy.tsx:27
 msgid "Liked by"
 msgstr "Liké par"
 
+#: src/view/com/feeds/FeedSourceCard.tsx:277
+msgid "Liked by {0} {1}"
+msgstr ""
+
+#: src/view/screens/ProfileFeed.tsx:615
+msgid "Liked by {likeCount} {0}"
+msgstr ""
+
+#: src/view/com/notifications/FeedItem.tsx:171
+msgid "liked your custom feed{0}"
+msgstr ""
+
+#: src/view/com/notifications/FeedItem.tsx:155
+msgid "liked your post"
+msgstr ""
+
 #: src/view/screens/Profile.tsx:164
 msgid "Likes"
 msgstr "Likes"
 
-#: src/view/com/modals/CreateOrEditList.tsx:186
+#: src/view/com/post-thread/PostThreadItem.tsx:184
+msgid "Likes on this post"
+msgstr ""
+
+#: src/Navigation.tsx:168
+msgid "List"
+msgstr ""
+
+#: src/view/com/modals/CreateOrEditList.tsx:205
 msgid "List Avatar"
 msgstr "Liste des avatars"
 
-#: src/view/com/modals/CreateOrEditList.tsx:199
+#: src/view/screens/ProfileList.tsx:323
+msgid "List blocked"
+msgstr ""
+
+#: src/view/com/feeds/FeedSourceCard.tsx:231
+msgid "List by {0}"
+msgstr ""
+
+#: src/view/screens/ProfileList.tsx:367
+msgid "List deleted"
+msgstr ""
+
+#: src/view/screens/ProfileList.tsx:282
+msgid "List muted"
+msgstr ""
+
+#: src/view/com/modals/CreateOrEditList.tsx:218
 msgid "List Name"
 msgstr "Nom de liste"
 
+#: src/view/screens/ProfileList.tsx:342
+msgid "List unblocked"
+msgstr ""
+
+#: src/view/screens/ProfileList.tsx:301
+msgid "List unmuted"
+msgstr ""
+
+#: src/Navigation.tsx:111
 #: src/view/screens/Profile.tsx:166
 #: src/view/shell/desktop/LeftNav.tsx:379
-#: src/view/shell/Drawer.tsx:490
-#: src/view/shell/Drawer.tsx:491
+#: src/view/shell/Drawer.tsx:492
+#: src/view/shell/Drawer.tsx:493
 msgid "Lists"
 msgstr "Listes"
 
-#: src/view/com/post-thread/PostThread.tsx:259
-#: src/view/com/post-thread/PostThread.tsx:267
+#: src/view/com/post-thread/PostThread.tsx:263
+#: src/view/com/post-thread/PostThread.tsx:271
 msgid "Load more posts"
 msgstr "Charger plus d’articles"
 
@@ -1208,7 +1849,10 @@ msgstr "Charger plus d’articles"
 msgid "Load new notifications"
 msgstr "Charger les nouvelles notifications"
 
-#: src/view/com/feeds/FeedPage.tsx:189
+#: src/view/com/feeds/FeedPage.tsx:190
+#: src/view/screens/Profile.tsx:412
+#: src/view/screens/ProfileFeed.tsx:503
+#: src/view/screens/ProfileList.tsx:659
 msgid "Load new posts"
 msgstr "Charger les nouveaux messages"
 
@@ -1219,6 +1863,10 @@ msgstr "Chargement…"
 #: src/view/com/modals/ServerInput.tsx:50
 msgid "Local dev server"
 msgstr "Serveur de dév local"
+
+#: src/Navigation.tsx:209
+msgid "Log"
+msgstr ""
 
 #: src/view/screens/Moderation.tsx:136
 msgid "Logged-out visibility"
@@ -1244,61 +1892,107 @@ msgstr "utilisateurs mentionnés"
 msgid "Mentioned users"
 msgstr "Utilisateurs mentionnés"
 
+#: src/view/com/util/ViewHeader.tsx:81
 #: src/view/screens/Search/Search.tsx:537
 msgid "Menu"
 msgstr "Menu"
 
 #: src/view/com/posts/FeedErrorMessage.tsx:194
-msgid "Message from server"
-msgstr "Message du serveur"
+#~ msgid "Message from server"
+#~ msgstr "Message du serveur"
 
+#: src/view/com/posts/FeedErrorMessage.tsx:197
+msgid "Message from server: {0}"
+msgstr ""
+
+#: src/Navigation.tsx:116
 #: src/view/screens/Moderation.tsx:64
-#: src/view/screens/Settings.tsx:563
+#: src/view/screens/Settings.tsx:578
 #: src/view/shell/desktop/LeftNav.tsx:397
-#: src/view/shell/Drawer.tsx:509
-#: src/view/shell/Drawer.tsx:510
+#: src/view/shell/Drawer.tsx:511
+#: src/view/shell/Drawer.tsx:512
 msgid "Moderation"
 msgstr "Modération"
+
+#: src/view/com/lists/ListCard.tsx:92
+#: src/view/com/modals/UserAddRemoveLists.tsx:190
+msgid "Moderation list by {0}"
+msgstr ""
+
+#: src/view/screens/ProfileList.tsx:753
+msgid "Moderation list by <0/>"
+msgstr ""
+
+#: src/view/com/lists/ListCard.tsx:90
+#: src/view/com/modals/UserAddRemoveLists.tsx:188
+#: src/view/screens/ProfileList.tsx:751
+msgid "Moderation list by you"
+msgstr ""
+
+#: src/view/com/modals/CreateOrEditList.tsx:139
+msgid "Moderation list created"
+msgstr ""
+
+#: src/view/com/modals/CreateOrEditList.tsx:126
+msgid "Moderation list updated"
+msgstr ""
 
 #: src/view/screens/Moderation.tsx:95
 msgid "Moderation lists"
 msgstr "Listes de modération"
 
+#: src/Navigation.tsx:121
 #: src/view/screens/ModerationModlists.tsx:58
 msgid "Moderation Lists"
 msgstr "Listes de modération"
+
+#: src/view/screens/Settings.tsx:572
+msgid "Moderation settings"
+msgstr ""
+
+#: src/view/com/modals/ModerationDetails.tsx:35
+msgid "Moderator has chosen to set a general warning on the content."
+msgstr ""
 
 #: src/view/shell/desktop/Feeds.tsx:53
 msgid "More feeds"
 msgstr "Plus de fils d’actu"
 
-#: src/view/com/profile/ProfileHeader.tsx:548
-#: src/view/screens/ProfileFeed.tsx:361
-#: src/view/screens/ProfileList.tsx:584
+#: src/view/com/profile/ProfileHeader.tsx:562
+#: src/view/screens/ProfileFeed.tsx:371
+#: src/view/screens/ProfileList.tsx:595
 msgid "More options"
 msgstr "Plus d’options"
+
+#: src/view/com/util/forms/PostDropdownBtn.tsx:268
+msgid "More post options"
+msgstr ""
 
 #: src/view/screens/PreferencesThreads.tsx:82
 msgid "Most-liked replies first"
 msgstr "Réponses les plus likées en premier"
 
-#: src/view/com/profile/ProfileHeader.tsx:370
+#: src/view/com/profile/ProfileHeader.tsx:374
 msgid "Mute Account"
 msgstr "Masquer le compte"
 
-#: src/view/screens/ProfileList.tsx:511
+#: src/view/screens/ProfileList.tsx:522
 msgid "Mute accounts"
 msgstr "Masquer les comptes"
 
-#: src/view/screens/ProfileList.tsx:458
+#: src/view/screens/ProfileList.tsx:469
 msgid "Mute list"
 msgstr "Masquer la liste"
 
-#: src/view/screens/ProfileList.tsx:271
+#: src/view/screens/ProfileList.tsx:274
 msgid "Mute these accounts?"
 msgstr "Masquer ces comptes ?"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:157
+#: src/view/screens/ProfileList.tsx:278
+msgid "Mute this List"
+msgstr ""
+
+#: src/view/com/util/forms/PostDropdownBtn.tsx:169
 msgid "Mute thread"
 msgstr "Masquer ce fil de discussion"
 
@@ -1306,6 +2000,7 @@ msgstr "Masquer ce fil de discussion"
 msgid "Muted accounts"
 msgstr "Comptes masqués"
 
+#: src/Navigation.tsx:126
 #: src/view/screens/ModerationMutedAccounts.tsx:107
 msgid "Muted Accounts"
 msgstr "Comptes masqués"
@@ -1314,7 +2009,7 @@ msgstr "Comptes masqués"
 msgid "Muted accounts have their posts removed from your feed and from your notifications. Mutes are completely private."
 msgstr "Les comptes masqués voient leurs posts supprimés de votre fil d’actualité et de vos notifications. Cette option est totalement privée."
 
-#: src/view/screens/ProfileList.tsx:273
+#: src/view/screens/ProfileList.tsx:276
 msgid "Muting is private. Muted accounts can interact with you, but you will not see their posts or receive notifications from them."
 msgstr "Ce que vous masquez reste privé. Les comptes masqués peuvent interagir avec vous, mais vous ne verrez pas leurs posts et ne recevrez pas de notifications de leur part."
 
@@ -1322,7 +2017,7 @@ msgstr "Ce que vous masquez reste privé. Les comptes masqués peuvent interagir
 msgid "My Birthday"
 msgstr "Ma date de naissance"
 
-#: src/view/screens/Feeds.tsx:363
+#: src/view/screens/Feeds.tsx:367
 msgid "My Feeds"
 msgstr "Mes fils d’actu"
 
@@ -1330,53 +2025,98 @@ msgstr "Mes fils d’actu"
 msgid "My Profile"
 msgstr "Mon profil"
 
-#: src/view/screens/Settings.tsx:520
+#: src/view/screens/Settings.tsx:535
 msgid "My Saved Feeds"
 msgstr "Mes fils d’actu enregistrés"
 
-#: src/view/com/modals/AddAppPasswords.tsx:177
-#: src/view/com/modals/CreateOrEditList.tsx:211
+#: src/view/com/modals/AddAppPasswords.tsx:181
+#: src/view/com/modals/CreateOrEditList.tsx:232
 msgid "Name"
 msgstr "Nom"
+
+#: src/view/com/modals/CreateOrEditList.tsx:108
+msgid "Name is required"
+msgstr ""
+
+#: src/view/com/auth/login/ForgotPasswordForm.tsx:186
+#: src/view/com/auth/login/LoginForm.tsx:286
+#: src/view/com/auth/login/SetNewPasswordForm.tsx:166
+msgid "Navigates to the next screen"
+msgstr ""
+
+#: src/view/shell/Drawer.tsx:71
+msgid "Navigates to your profile"
+msgstr ""
 
 #: src/view/com/modals/EmbedConsent.tsx:107
 #: src/view/com/modals/EmbedConsent.tsx:123
 msgid "Never load embeds from {0}"
 msgstr ""
 
+#: src/view/com/auth/onboarding/WelcomeDesktop.tsx:72
 #: src/view/com/auth/onboarding/WelcomeMobile.tsx:72
 msgid "Never lose access to your followers and data."
 msgstr "Ne perdez jamais l’accès à vos followers et à vos données."
 
 #: src/view/screens/Lists.tsx:76
+msgctxt "action"
+msgid "New"
+msgstr ""
+
 #: src/view/screens/ModerationModlists.tsx:78
 msgid "New"
 msgstr "Nouveau"
 
-#: src/view/com/feeds/FeedPage.tsx:200
-#: src/view/screens/Feeds.tsx:507
+#: src/view/com/modals/CreateOrEditList.tsx:195
+msgid "New Moderation List"
+msgstr ""
+
+#: src/view/com/auth/login/SetNewPasswordForm.tsx:122
+msgid "New password"
+msgstr ""
+
+#: src/view/com/feeds/FeedPage.tsx:201
+msgctxt "action"
+msgid "New post"
+msgstr ""
+
+#: src/view/screens/Feeds.tsx:511
 #: src/view/screens/Profile.tsx:354
-#: src/view/screens/ProfileFeed.tsx:431
-#: src/view/screens/ProfileList.tsx:194
-#: src/view/screens/ProfileList.tsx:222
+#: src/view/screens/ProfileFeed.tsx:441
+#: src/view/screens/ProfileList.tsx:197
+#: src/view/screens/ProfileList.tsx:225
 #: src/view/shell/desktop/LeftNav.tsx:248
 msgid "New post"
 msgstr "Nouveau post"
 
 #: src/view/shell/desktop/LeftNav.tsx:258
+msgctxt "action"
 msgid "New Post"
-msgstr "Nouveau post"
+msgstr ""
+
+#: src/view/shell/desktop/LeftNav.tsx:258
+#~ msgid "New Post"
+#~ msgstr "Nouveau post"
+
+#: src/view/com/modals/CreateOrEditList.tsx:190
+msgid "New User List"
+msgstr ""
 
 #: src/view/screens/PreferencesThreads.tsx:79
 msgid "Newest replies first"
 msgstr ""
 
+#: src/view/com/auth/onboarding/WelcomeDesktop.tsx:103
+msgctxt "action"
+msgid "Next"
+msgstr ""
+
 #: src/view/com/auth/create/CreateAccount.tsx:154
-#: src/view/com/auth/login/ForgotPasswordForm.tsx:174
-#: src/view/com/auth/login/ForgotPasswordForm.tsx:184
-#: src/view/com/auth/login/LoginForm.tsx:286
-#: src/view/com/auth/login/SetNewPasswordForm.tsx:156
-#: src/view/com/auth/login/SetNewPasswordForm.tsx:166
+#: src/view/com/auth/login/ForgotPasswordForm.tsx:178
+#: src/view/com/auth/login/ForgotPasswordForm.tsx:188
+#: src/view/com/auth/login/LoginForm.tsx:288
+#: src/view/com/auth/login/SetNewPasswordForm.tsx:158
+#: src/view/com/auth/login/SetNewPasswordForm.tsx:168
 #: src/view/com/auth/onboarding/RecommendedFeeds.tsx:79
 msgid "Next"
 msgstr "Suivant"
@@ -1385,33 +2125,42 @@ msgstr "Suivant"
 msgid "Next image"
 msgstr "Image suivante"
 
-#: src/view/screens/PreferencesHomeFeed.tsx:126
-#: src/view/screens/PreferencesHomeFeed.tsx:197
-#: src/view/screens/PreferencesHomeFeed.tsx:232
-#: src/view/screens/PreferencesHomeFeed.tsx:269
+#: src/view/screens/PreferencesHomeFeed.tsx:129
+#: src/view/screens/PreferencesHomeFeed.tsx:200
+#: src/view/screens/PreferencesHomeFeed.tsx:235
+#: src/view/screens/PreferencesHomeFeed.tsx:272
 #: src/view/screens/PreferencesThreads.tsx:106
 #: src/view/screens/PreferencesThreads.tsx:129
 msgid "No"
 msgstr "Non"
 
-#: src/view/screens/ProfileFeed.tsx:579
-#: src/view/screens/ProfileList.tsx:720
+#: src/view/screens/ProfileFeed.tsx:593
+#: src/view/screens/ProfileList.tsx:733
 msgid "No description"
 msgstr "Aucune description"
 
+#: src/view/com/profile/ProfileHeader.tsx:217
+msgid "No longer following {0}"
+msgstr ""
+
+#: src/view/com/notifications/Feed.tsx:107
+msgid "No notifications yet!"
+msgstr ""
+
 #: src/view/com/composer/text-input/mobile/Autocomplete.tsx:97
+#: src/view/com/composer/text-input/web/Autocomplete.tsx:191
 msgid "No result"
 msgstr "Aucun résultat"
 
-#: src/view/screens/Feeds.tsx:452
+#: src/view/screens/Feeds.tsx:456
 msgid "No results found for \"{query}\""
 msgstr "Aucun résultat trouvé pour « {query} »"
 
 #: src/view/com/modals/ListAddRemoveUsers.tsx:127
 #: src/view/screens/Search/Search.tsx:270
 #: src/view/screens/Search/Search.tsx:298
-#: src/view/screens/Search/Search.tsx:629
-#: src/view/shell/desktop/Search.tsx:210
+#: src/view/screens/Search/Search.tsx:630
+#: src/view/shell/desktop/Search.tsx:213
 msgid "No results found for {query}"
 msgstr "Aucun résultat trouvé pour {query}"
 
@@ -1427,10 +2176,20 @@ msgstr "Personne"
 msgid "Not Applicable."
 msgstr "Sans objet."
 
+#: src/Navigation.tsx:106
+msgid "Not Found"
+msgstr ""
+
+#: src/view/com/modals/VerifyEmail.tsx:246
+#: src/view/com/modals/VerifyEmail.tsx:252
+msgid "Not right now"
+msgstr ""
+
 #: src/view/screens/Moderation.tsx:232
 msgid "Note: Bluesky is an open and public network. This setting only limits the visibility of your content on the Bluesky app and website, and other apps may not respect this setting. Your content may still be shown to logged-out users by other apps and websites."
 msgstr "Remarque : Bluesky est un réseau ouvert et public. Ce paramètre limite uniquement la visibilité de votre contenu sur l’application et le site Web de Bluesky, et d’autres applications peuvent ne pas respecter ce paramètre. Votre contenu peut toujours être montré aux utilisateurs déconnectés par d’autres applications et sites Web."
 
+#: src/Navigation.tsx:447
 #: src/view/screens/Notifications.tsx:113
 #: src/view/screens/Notifications.tsx:137
 #: src/view/shell/bottom-bar/BottomBar.tsx:205
@@ -1439,6 +2198,10 @@ msgstr "Remarque : Bluesky est un réseau ouvert et public. Ce paramètre limit
 #: src/view/shell/Drawer.tsx:436
 msgid "Notifications"
 msgstr "Notifications"
+
+#: src/view/com/modals/SelfLabel.tsx:103
+msgid "Nudity"
+msgstr ""
 
 #: src/view/com/util/ErrorBoundary.tsx:34
 msgid "Oh no!"
@@ -1452,13 +2215,23 @@ msgstr "D’accord"
 msgid "Oldest replies first"
 msgstr "Plus anciennes réponses en premier"
 
-#: src/view/com/composer/Composer.tsx:363
+#: src/view/screens/Settings.tsx:229
+msgid "Onboarding reset"
+msgstr ""
+
+#: src/view/com/composer/Composer.tsx:374
 msgid "One or more images is missing alt text."
 msgstr "Une ou plusieurs images n’ont pas de texte alt."
 
 #: src/view/com/threadgate/WhoCanReply.tsx:100
 msgid "Only {0} can reply."
 msgstr "Seul {0} peut répondre."
+
+#: src/view/com/modals/ProfilePreview.tsx:49
+#: src/view/com/modals/ProfilePreview.tsx:61
+#: src/view/screens/AppPasswords.tsx:65
+msgid "Oops!"
+msgstr ""
 
 #: src/view/com/composer/Composer.tsx:468
 #: src/view/com/composer/Composer.tsx:469
@@ -1469,50 +2242,111 @@ msgstr "Ouvrir le sélecteur d’emoji"
 msgid "Open navigation"
 msgstr "Navigation ouverte"
 
-#: src/view/screens/Settings.tsx:533
+#: src/view/screens/Settings.tsx:713
+msgid "Open storybook page"
+msgstr ""
+
+#: src/view/com/util/forms/DropdownButton.tsx:147
+msgid "Opens {numItems} options"
+msgstr ""
+
+#: src/view/screens/Log.tsx:54
+msgid "Opens additional details for a debug entry"
+msgstr ""
+
+#: src/view/com/notifications/FeedItem.tsx:352
+msgid "Opens an expanded list of users in this notification"
+msgstr ""
+
+#: src/view/com/composer/photos/OpenCameraBtn.tsx:61
+msgid "Opens camera on device"
+msgstr ""
+
+#: src/view/com/composer/Prompt.tsx:25
+msgid "Opens composer"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:548
 msgid "Opens configurable language settings"
 msgstr "Ouvre les paramètres linguistiques configurables"
 
-#: src/view/screens/Settings.tsx:587
+#: src/view/com/composer/photos/SelectPhotoBtn.tsx:44
+msgid "Opens device photo gallery"
+msgstr ""
+
+#: src/view/com/profile/ProfileHeader.tsx:459
+msgid "Opens editor for profile display name, avatar, background image, and description"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:602
 msgid "Opens external embeds settings"
 msgstr ""
 
+#: src/view/com/profile/ProfileHeader.tsx:614
+msgid "Opens followers list"
+msgstr ""
+
+#: src/view/com/profile/ProfileHeader.tsx:633
+msgid "Opens following list"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:399
+msgid "Opens invite code list"
+msgstr ""
+
+#: src/view/com/modals/InviteCodes.tsx:172
 #: src/view/shell/desktop/RightNav.tsx:156
-#: src/view/shell/Drawer.tsx:641
+#: src/view/shell/Drawer.tsx:643
 msgid "Opens list of invite codes"
 msgstr "Ouvre la liste des codes d’invitation"
 
-#: src/view/com/modals/ChangeHandle.tsx:279
+#: src/view/screens/Settings.tsx:672
+msgid "Opens modal for account deletion confirmation. Requires email code."
+msgstr ""
+
+#: src/view/com/modals/ChangeHandle.tsx:281
 msgid "Opens modal for using custom domain"
 msgstr "Ouvre une fenêtre modale pour utiliser un domaine personnalisé"
 
-#: src/view/screens/Settings.tsx:558
+#: src/view/screens/Settings.tsx:573
 msgid "Opens moderation settings"
 msgstr "Ouvre les paramètres de modération"
 
-#: src/view/screens/Settings.tsx:514
+#: src/view/com/auth/login/LoginForm.tsx:236
+msgid "Opens password reset form"
+msgstr ""
+
+#: src/view/screens/Feeds.tsx:335
+msgid "Opens screen to edit Saved Feeds"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:529
 msgid "Opens screen with all saved feeds"
 msgstr "Ouvre l’écran avec tous les fils d’actu enregistrés"
 
-#: src/view/screens/Settings.tsx:614
+#: src/view/screens/Settings.tsx:629
 msgid "Opens the app password settings page"
 msgstr "Ouvre la page de configuration du mot de passe"
 
-#: src/view/screens/Settings.tsx:473
+#: src/view/screens/Settings.tsx:488
 msgid "Opens the home feed preferences"
 msgstr "Ouvre les préférences du fil d’accueil"
 
-#: src/view/screens/Settings.tsx:697
+#: src/view/screens/Settings.tsx:714
 msgid "Opens the storybook page"
 msgstr "Ouvre la page de l’historique"
 
-#: src/view/screens/Settings.tsx:677
+#: src/view/screens/Settings.tsx:694
 msgid "Opens the system log page"
 msgstr "Ouvre la page du journal système"
 
-#: src/view/screens/Settings.tsx:494
+#: src/view/screens/Settings.tsx:509
 msgid "Opens the threads preferences"
 msgstr "Ouvre les préférences relatives aux fils de discussion"
+
+#: src/view/com/util/forms/DropdownButton.tsx:254
+msgid "Option {0} of {numItems}"
+msgstr ""
 
 #: src/view/com/modals/Threadgate.tsx:89
 msgid "Or combine these options:"
@@ -1537,9 +2371,9 @@ msgstr "Page introuvable"
 
 #: src/view/com/auth/create/Step2.tsx:122
 #: src/view/com/auth/create/Step2.tsx:132
-#: src/view/com/auth/login/LoginForm.tsx:221
-#: src/view/com/auth/login/SetNewPasswordForm.tsx:130
-#: src/view/com/modals/DeleteAccount.tsx:191
+#: src/view/com/auth/login/LoginForm.tsx:223
+#: src/view/com/auth/login/SetNewPasswordForm.tsx:132
+#: src/view/com/modals/DeleteAccount.tsx:195
 msgid "Password"
 msgstr "Mot de passe"
 
@@ -1551,9 +2385,30 @@ msgstr "Mise à jour du mot de passe"
 msgid "Password updated!"
 msgstr "Mot de passe mis à jour !"
 
+#: src/Navigation.tsx:162
+msgid "People followed by @{0}"
+msgstr ""
+
+#: src/Navigation.tsx:155
+msgid "People following @{0}"
+msgstr ""
+
+#: src/view/com/lightbox/Lightbox.tsx:66
+msgid "Permission to access camera roll is required."
+msgstr ""
+
+#: src/view/com/lightbox/Lightbox.tsx:72
+msgid "Permission to access camera roll was denied. Please enable it in your system settings."
+msgstr ""
+
 #: src/view/com/modals/SelfLabel.tsx:121
 msgid "Pictures meant for adults."
 msgstr "Images destinées aux adultes."
+
+#: src/view/screens/ProfileFeed.tsx:362
+#: src/view/screens/ProfileList.tsx:559
+msgid "Pin to home"
+msgstr ""
 
 #: src/view/screens/SavedFeeds.tsx:88
 msgid "Pinned Feeds"
@@ -1584,7 +2439,11 @@ msgstr "Veuillez choisir votre mot de passe."
 msgid "Please confirm your email before changing it. This is a temporary requirement while email-updating tools are added, and it will soon be removed."
 msgstr "Veuillez confirmer votre e-mail avant de le modifier. Ceci est temporairement requis pendant que des outils de mise à jour d’e-mail sont ajoutés, cette étape ne sera bientôt plus nécessaire."
 
-#: src/view/com/modals/AddAppPasswords.tsx:140
+#: src/view/com/modals/AddAppPasswords.tsx:89
+msgid "Please enter a name for your app password. All spaces is not allowed."
+msgstr ""
+
+#: src/view/com/modals/AddAppPasswords.tsx:144
 msgid "Please enter a unique name for this App Password or use our randomly generated one."
 msgstr "Veuillez saisir un nom unique pour le mot de passe de l’application ou utiliser celui que nous avons généré de manière aléatoire."
 
@@ -1592,7 +2451,7 @@ msgstr "Veuillez saisir un nom unique pour le mot de passe de l’application ou
 msgid "Please enter your email."
 msgstr "Veuillez entrer votre e-mail."
 
-#: src/view/com/modals/DeleteAccount.tsx:180
+#: src/view/com/modals/DeleteAccount.tsx:184
 msgid "Please enter your password as well:"
 msgstr "Veuillez également entrer votre mot de passe :"
 
@@ -1604,17 +2463,51 @@ msgstr "Dites-nous donc pourquoi vous pensez que cet avertissement de contenu a 
 #~ msgid "Please tell us why you think this decision was incorrect."
 #~ msgstr "Dites-nous pourquoi vous pensez que cette décision était incorrecte."
 
-#: src/view/com/composer/Composer.tsx:215
+#: src/view/com/modals/VerifyEmail.tsx:101
+msgid "Please Verify Your Email"
+msgstr ""
+
+#: src/view/com/composer/Composer.tsx:214
 msgid "Please wait for your link card to finish loading"
 msgstr "Veuillez patienter le temps que votre carte de lien soit chargée"
+
+#: src/view/com/modals/SelfLabel.tsx:111
+msgid "Porn"
+msgstr ""
+
+#: src/view/com/composer/Composer.tsx:349
+#: src/view/com/composer/Composer.tsx:357
+msgctxt "action"
+msgid "Post"
+msgstr ""
+
+#: src/view/com/post-thread/PostThread.tsx:227
+#: src/view/screens/PostThread.tsx:82
+msgctxt "description"
+msgid "Post"
+msgstr ""
 
 #: src/view/com/composer/Composer.tsx:346
 #: src/view/com/post-thread/PostThread.tsx:225
 #: src/view/screens/PostThread.tsx:80
-msgid "Post"
-msgstr "Post"
+#~ msgid "Post"
+#~ msgstr "Post"
 
-#: src/view/com/post-thread/PostThread.tsx:378
+#: src/view/com/post-thread/PostThreadItem.tsx:176
+msgid "Post by {0}"
+msgstr ""
+
+#: src/Navigation.tsx:174
+#: src/Navigation.tsx:181
+#: src/Navigation.tsx:188
+msgid "Post by @{0}"
+msgstr ""
+
+#: src/view/com/util/forms/PostDropdownBtn.tsx:82
+msgid "Post deleted"
+msgstr ""
+
+#: src/view/com/post-thread/PostThread.tsx:382
 msgid "Post hidden"
 msgstr "Posts cachés"
 
@@ -1626,13 +2519,17 @@ msgstr "Langue du post"
 msgid "Post Languages"
 msgstr "Langues du post"
 
-#: src/view/com/post-thread/PostThread.tsx:430
+#: src/view/com/post-thread/PostThread.tsx:434
 msgid "Post not found"
 msgstr "Post introuvable"
 
 #: src/view/screens/Profile.tsx:161
 msgid "Posts"
 msgstr "Posts"
+
+#: src/view/com/posts/FeedErrorMessage.tsx:64
+msgid "Posts hidden"
+msgstr ""
 
 #: src/view/com/modals/LinkWarning.tsx:44
 msgid "Potentially Misleading Link"
@@ -1650,30 +2547,35 @@ msgstr "Langue principale"
 msgid "Prioritize Your Follows"
 msgstr "Définissez des priorités de vos suivis"
 
-#: src/view/screens/Settings.tsx:570
+#: src/view/screens/Settings.tsx:585
 #: src/view/shell/desktop/RightNav.tsx:84
 msgid "Privacy"
 msgstr "Vie privée"
 
+#: src/Navigation.tsx:219
 #: src/view/screens/PrivacyPolicy.tsx:29
-#: src/view/screens/Settings.tsx:783
+#: src/view/screens/Settings.tsx:800
 #: src/view/shell/Drawer.tsx:262
 msgid "Privacy Policy"
 msgstr "Charte de confidentialité"
 
-#: src/view/com/auth/login/ForgotPasswordForm.tsx:190
+#: src/view/com/auth/login/ForgotPasswordForm.tsx:194
 msgid "Processing..."
 msgstr "Traitement…"
 
 #: src/view/shell/bottom-bar/BottomBar.tsx:247
 #: src/view/shell/desktop/LeftNav.tsx:415
 #: src/view/shell/Drawer.tsx:70
-#: src/view/shell/Drawer.tsx:544
-#: src/view/shell/Drawer.tsx:545
+#: src/view/shell/Drawer.tsx:546
+#: src/view/shell/Drawer.tsx:547
 msgid "Profile"
 msgstr "Profil"
 
-#: src/view/screens/Settings.tsx:841
+#: src/view/com/modals/EditProfile.tsx:128
+msgid "Profile updated"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:858
 msgid "Protect your account by verifying your email."
 msgstr "Protégez votre compte en vérifiant votre e-mail."
 
@@ -1685,14 +2587,31 @@ msgstr "Listes publiques et partageables d’utilisateurs à masquer ou à bloqu
 msgid "Public, shareable lists which can drive feeds."
 msgstr "Les listes publiques et partageables qui peuvent alimenter les fils d’actu."
 
-#: src/view/com/modals/Repost.tsx:52
+#: src/view/com/composer/Composer.tsx:334
+msgid "Publish post"
+msgstr ""
+
+#: src/view/com/composer/Composer.tsx:334
+msgid "Publish reply"
+msgstr ""
+
+#: src/view/com/modals/Repost.tsx:65
+msgctxt "action"
+msgid "Quote post"
+msgstr ""
+
 #: src/view/com/util/post-ctrls/RepostButton.web.tsx:58
 msgid "Quote post"
 msgstr "Citer le post"
 
-#: src/view/com/modals/Repost.tsx:56
+#: src/view/com/modals/Repost.tsx:70
+msgctxt "action"
 msgid "Quote Post"
-msgstr "Citer un post"
+msgstr ""
+
+#: src/view/com/modals/Repost.tsx:56
+#~ msgid "Quote Post"
+#~ msgstr "Citer un post"
 
 #: src/view/screens/PreferencesThreads.tsx:86
 msgid "Random (aka \"Poster's Roulette\")"
@@ -1712,7 +2631,7 @@ msgstr "Utilisateurs recommandés"
 
 #: src/view/com/modals/ListAddRemoveUsers.tsx:264
 #: src/view/com/modals/SelfLabel.tsx:83
-#: src/view/com/modals/UserAddRemoveLists.tsx:193
+#: src/view/com/modals/UserAddRemoveLists.tsx:203
 #: src/view/com/util/UserAvatar.tsx:282
 #: src/view/com/util/UserBanner.tsx:89
 msgid "Remove"
@@ -1726,13 +2645,16 @@ msgstr "Supprimer {0} de mes fils d’actu ?"
 msgid "Remove account"
 msgstr "Supprimer compte"
 
-#: src/view/com/posts/FeedErrorMessage.tsx:130
+#: src/view/com/posts/FeedErrorMessage.tsx:131
+#: src/view/com/posts/FeedErrorMessage.tsx:166
 msgid "Remove feed"
 msgstr "Supprimer fil d’actu"
 
 #: src/view/com/feeds/FeedSourceCard.tsx:105
+#: src/view/com/feeds/FeedSourceCard.tsx:167
 #: src/view/com/feeds/FeedSourceCard.tsx:172
-#: src/view/screens/ProfileFeed.tsx:271
+#: src/view/com/feeds/FeedSourceCard.tsx:243
+#: src/view/screens/ProfileFeed.tsx:281
 msgid "Remove from my feeds"
 msgstr "Supprimer de mes fils d’actu"
 
@@ -1744,11 +2666,15 @@ msgstr "Supprimer l’image"
 msgid "Remove image preview"
 msgstr "Supprimer l’aperçu d’image"
 
+#: src/view/com/modals/Repost.tsx:47
+msgid "Remove repost"
+msgstr ""
+
 #: src/view/com/feeds/FeedSourceCard.tsx:173
 msgid "Remove this feed from my feeds?"
 msgstr "Supprimer ce fil d’actu ?"
 
-#: src/view/com/posts/FeedErrorMessage.tsx:131
+#: src/view/com/posts/FeedErrorMessage.tsx:132
 msgid "Remove this feed from your saved feeds?"
 msgstr "Supprimer ce fil d’actu de vos fils d’actu enregistrés ?"
 
@@ -1756,6 +2682,15 @@ msgstr "Supprimer ce fil d’actu de vos fils d’actu enregistrés ?"
 #: src/view/com/modals/UserAddRemoveLists.tsx:136
 msgid "Removed from list"
 msgstr "Supprimé de la liste"
+
+#: src/view/com/feeds/FeedSourceCard.tsx:111
+#: src/view/com/feeds/FeedSourceCard.tsx:178
+msgid "Removed from my feeds"
+msgstr ""
+
+#: src/view/com/composer/ExternalEmbed.tsx:71
+msgid "Removes default thumbnail from {0}"
+msgstr ""
 
 #: src/view/screens/Profile.tsx:162
 msgid "Replies"
@@ -1765,30 +2700,49 @@ msgstr "Réponses"
 msgid "Replies to this thread are disabled"
 msgstr "Les réponses à ce fil de discussion sont désactivées"
 
-#: src/view/screens/PreferencesHomeFeed.tsx:141
+#: src/view/com/composer/Composer.tsx:347
+msgctxt "action"
+msgid "Reply"
+msgstr ""
+
+#: src/view/screens/PreferencesHomeFeed.tsx:144
 msgid "Reply Filters"
 msgstr "Filtres de réponse"
+
+#: src/view/com/post/Post.tsx:165
+#: src/view/com/posts/FeedItem.tsx:286
+msgctxt "description"
+msgid "Reply to <0/>"
+msgstr ""
 
 #: src/view/com/modals/report/Modal.tsx:166
 msgid "Report {collectionName}"
 msgstr "Signaler {collectionName}"
 
-#: src/view/com/profile/ProfileHeader.tsx:404
+#: src/view/com/profile/ProfileHeader.tsx:408
 msgid "Report Account"
 msgstr "Signaler le compte"
 
-#: src/view/screens/ProfileFeed.tsx:291
+#: src/view/screens/ProfileFeed.tsx:301
 msgid "Report feed"
 msgstr "Signaler le fil d’actu"
 
-#: src/view/screens/ProfileList.tsx:426
+#: src/view/screens/ProfileList.tsx:437
 msgid "Report List"
 msgstr "Signaler la liste"
 
 #: src/view/com/modals/report/SendReportButton.tsx:37
-#: src/view/com/util/forms/PostDropdownBtn.tsx:196
+#: src/view/com/util/forms/PostDropdownBtn.tsx:208
 msgid "Report post"
 msgstr "Signaler le post"
+
+#: src/view/com/modals/Repost.tsx:43
+#: src/view/com/modals/Repost.tsx:48
+#: src/view/com/modals/Repost.tsx:53
+#: src/view/com/util/post-ctrls/RepostButton.tsx:61
+msgctxt "action"
+msgid "Repost"
+msgstr ""
 
 #: src/view/com/util/post-ctrls/RepostButton.web.tsx:48
 msgid "Repost"
@@ -1803,12 +2757,28 @@ msgstr "Republier ou citer"
 msgid "Reposted by"
 msgstr "Republié par"
 
+#: src/view/com/posts/FeedItem.tsx:206
+msgid "Reposted by {0})"
+msgstr ""
+
+#: src/view/com/posts/FeedItem.tsx:223
+msgid "Reposted by <0/>"
+msgstr ""
+
+#: src/view/com/notifications/FeedItem.tsx:162
+msgid "reposted your post"
+msgstr ""
+
+#: src/view/com/post-thread/PostThreadItem.tsx:189
+msgid "Reposts of this post"
+msgstr ""
+
 #: src/view/com/modals/ChangeEmail.tsx:181
 #: src/view/com/modals/ChangeEmail.tsx:183
 msgid "Request Change"
 msgstr "Demande de modification"
 
-#: src/view/screens/Settings.tsx:422
+#: src/view/screens/Settings.tsx:437
 msgid "Require alt text before posting"
 msgstr "Nécessiter un texte alt avant de publier"
 
@@ -1816,45 +2786,77 @@ msgstr "Nécessiter un texte alt avant de publier"
 msgid "Required for this provider"
 msgstr "Obligatoire pour ce fournisseur"
 
+#: src/view/com/auth/login/SetNewPasswordForm.tsx:98
 #: src/view/com/auth/login/SetNewPasswordForm.tsx:108
 msgid "Reset code"
 msgstr "Réinitialiser le code"
 
-#: src/view/screens/Settings.tsx:719
+#: src/view/screens/Settings.tsx:733
+msgid "Reset onboarding"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:736
 msgid "Reset onboarding state"
 msgstr "Réinitialisation de l’état d’accueil"
 
-#: src/view/com/auth/login/ForgotPasswordForm.tsx:98
+#: src/view/com/auth/login/ForgotPasswordForm.tsx:100
 msgid "Reset password"
 msgstr "Réinitialiser mot de passe"
 
-#: src/view/screens/Settings.tsx:709
+#: src/view/screens/Settings.tsx:723
+msgid "Reset preferences"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:726
 msgid "Reset preferences state"
 msgstr "Réinitialiser l’état des préférences"
 
-#: src/view/screens/Settings.tsx:717
+#: src/view/screens/Settings.tsx:734
 msgid "Resets the onboarding state"
 msgstr "Réinitialise l’état d’accueil"
 
-#: src/view/screens/Settings.tsx:707
+#: src/view/screens/Settings.tsx:724
 msgid "Resets the preferences state"
 msgstr "Réinitialise l’état des préférences"
 
+#: src/view/com/auth/login/LoginForm.tsx:266
+msgid "Retries login"
+msgstr ""
+
+#: src/view/com/util/error/ErrorMessage.tsx:57
+#: src/view/com/util/error/ErrorScreen.tsx:67
+msgid "Retries the last action, which errored out"
+msgstr ""
+
 #: src/view/com/auth/create/CreateAccount.tsx:163
 #: src/view/com/auth/create/CreateAccount.tsx:167
-#: src/view/com/auth/login/LoginForm.tsx:263
-#: src/view/com/auth/login/LoginForm.tsx:266
+#: src/view/com/auth/login/LoginForm.tsx:265
+#: src/view/com/auth/login/LoginForm.tsx:268
 #: src/view/com/util/error/ErrorMessage.tsx:55
 #: src/view/com/util/error/ErrorScreen.tsx:65
 msgid "Retry"
 msgstr "Réessayer"
 
+#: src/view/screens/ProfileList.tsx:877
+msgid "Return to previous page"
+msgstr ""
+
+#: src/view/shell/desktop/RightNav.tsx:59
+msgid "SANDBOX. Posts and accounts are not permanent."
+msgstr ""
+
+#: src/view/com/lightbox/Lightbox.tsx:125
+#: src/view/com/modals/CreateOrEditList.tsx:278
+msgctxt "action"
+msgid "Save"
+msgstr ""
+
 #: src/view/com/modals/BirthDateSettings.tsx:94
 #: src/view/com/modals/BirthDateSettings.tsx:97
 #: src/view/com/modals/ChangeHandle.tsx:173
-#: src/view/com/modals/CreateOrEditList.tsx:249
-#: src/view/com/modals/CreateOrEditList.tsx:257
-#: src/view/com/modals/EditProfile.tsx:223
+#: src/view/com/modals/CreateOrEditList.tsx:270
+#: src/view/com/modals/EditProfile.tsx:224
+#: src/view/screens/ProfileFeed.tsx:354
 msgid "Save"
 msgstr "Enregistrer"
 
@@ -1862,7 +2864,7 @@ msgstr "Enregistrer"
 msgid "Save alt text"
 msgstr "Enregistrer le texte alt"
 
-#: src/view/com/modals/EditProfile.tsx:231
+#: src/view/com/modals/EditProfile.tsx:232
 msgid "Save Changes"
 msgstr "Enregistrer les modifications"
 
@@ -1878,9 +2880,25 @@ msgstr "Enregistrer le recadrage de l’image"
 msgid "Saved Feeds"
 msgstr "Fils d’actu enregistrés"
 
+#: src/view/com/modals/EditProfile.tsx:225
+msgid "Saves any changes to your profile"
+msgstr ""
+
+#: src/view/com/modals/ChangeHandle.tsx:171
+msgid "Saves handle change to {handle}"
+msgstr ""
+
+#: src/view/screens/ProfileList.tsx:833
+msgid "Scroll to top"
+msgstr ""
+
+#: src/Navigation.tsx:437
+#: src/view/com/auth/LoggedOut.tsx:122
 #: src/view/com/modals/ListAddRemoveUsers.tsx:75
+#: src/view/com/util/forms/SearchInput.tsx:53
 #: src/view/com/util/forms/SearchInput.tsx:65
 #: src/view/screens/Search/Search.tsx:406
+#: src/view/screens/Search/Search.tsx:559
 #: src/view/screens/Search/Search.tsx:572
 #: src/view/shell/bottom-bar/BottomBar.tsx:159
 #: src/view/shell/desktop/LeftNav.tsx:324
@@ -1893,6 +2911,7 @@ msgstr "Recherche"
 
 #: src/view/com/auth/LoggedOut.tsx:104
 #: src/view/com/auth/LoggedOut.tsx:105
+#: src/view/com/modals/ListAddRemoveUsers.tsx:70
 msgid "Search for users"
 msgstr "Rechercher des utilisateurs"
 
@@ -1900,9 +2919,17 @@ msgstr "Rechercher des utilisateurs"
 msgid "Security Step Required"
 msgstr "Étape de sécurité requise"
 
+#: src/view/screens/SavedFeeds.tsx:163
+msgid "See this guide"
+msgstr ""
+
 #: src/view/com/auth/HomeLoggedOutCTA.tsx:39
 msgid "See what's next"
 msgstr "Voir la suite"
+
+#: src/view/com/util/Selector.tsx:106
+msgid "Select {item}"
+msgstr ""
 
 #: src/view/com/modals/ServerInput.tsx:75
 msgid "Select Bluesky Social"
@@ -1911,6 +2938,10 @@ msgstr "Sélectionner Bluesky Social"
 #: src/view/com/auth/login/Login.tsx:117
 msgid "Select from an existing account"
 msgstr "Sélectionner un compte existant"
+
+#: src/view/com/util/Selector.tsx:107
+msgid "Select option {i} of {numItems}"
+msgstr ""
 
 #: src/view/com/auth/login/LoginForm.tsx:147
 msgid "Select service"
@@ -1928,7 +2959,8 @@ msgstr "Sélectionnez la langue de votre application à afficher par défaut"
 msgid "Select your preferred language for translations in your feed."
 msgstr "Sélectionnez votre langue préférée pour traduire votre fils d’actu."
 
-#: src/view/com/modals/VerifyEmail.tsx:196
+#: src/view/com/modals/VerifyEmail.tsx:202
+#: src/view/com/modals/VerifyEmail.tsx:204
 msgid "Send Confirmation Email"
 msgstr "Envoyer un e-mail de confirmation"
 
@@ -1936,9 +2968,14 @@ msgstr "Envoyer un e-mail de confirmation"
 msgid "Send email"
 msgstr "Envoyer e-mail"
 
-#: src/view/com/modals/DeleteAccount.tsx:138
+#: src/view/com/modals/DeleteAccount.tsx:140
+msgctxt "action"
 msgid "Send Email"
-msgstr "Envoyer e-mail"
+msgstr ""
+
+#: src/view/com/modals/DeleteAccount.tsx:138
+#~ msgid "Send Email"
+#~ msgstr "Envoyer e-mail"
 
 #: src/view/shell/Drawer.tsx:295
 #: src/view/shell/Drawer.tsx:316
@@ -1949,19 +2986,49 @@ msgstr "Envoyer des commentaires"
 msgid "Send Report"
 msgstr "Envoyer le rapport"
 
+#: src/view/com/modals/DeleteAccount.tsx:129
+msgid "Sends email with confirmation code for account deletion"
+msgstr ""
+
+#: src/view/com/modals/ContentFilteringSettings.tsx:306
+msgid "Set {value} for {labelGroup} content moderation policy"
+msgstr ""
+
+#: src/view/com/modals/ContentFilteringSettings.tsx:155
+#: src/view/com/modals/ContentFilteringSettings.tsx:174
+msgctxt "action"
+msgid "Set Age"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:469
+msgid "Set color theme to dark"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:462
+msgid "Set color theme to light"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:456
+msgid "Set color theme to system setting"
+msgstr ""
+
 #: src/view/com/auth/login/SetNewPasswordForm.tsx:78
 msgid "Set new password"
 msgstr "Définir un nouveau mot de passe"
 
-#: src/view/screens/PreferencesHomeFeed.tsx:222
+#: src/view/com/auth/create/Step2.tsx:133
+msgid "Set password"
+msgstr ""
+
+#: src/view/screens/PreferencesHomeFeed.tsx:225
 msgid "Set this setting to \"No\" to hide all quote posts from your feed. Reposts will still be visible."
 msgstr "Choisissez « Non » pour cacher toutes les citations sur votre fils d’actu. Les reposts seront toujours visibles."
 
-#: src/view/screens/PreferencesHomeFeed.tsx:119
+#: src/view/screens/PreferencesHomeFeed.tsx:122
 msgid "Set this setting to \"No\" to hide all replies from your feed."
 msgstr "Choisissez « Non » pour cacher toutes les réponses dans votre fils d’actu."
 
-#: src/view/screens/PreferencesHomeFeed.tsx:188
+#: src/view/screens/PreferencesHomeFeed.tsx:191
 msgid "Set this setting to \"No\" to hide all reposts from your feed."
 msgstr "Choisissez « Non » pour cacher toutes les reposts de votre fils d’actu."
 
@@ -1969,14 +3036,35 @@ msgstr "Choisissez « Non » pour cacher toutes les reposts de votre fils d’
 msgid "Set this setting to \"Yes\" to show replies in a threaded view. This is an experimental feature."
 msgstr "Choisissez « Oui » pour afficher les réponses dans un fil de discussion. C’est une fonctionnalité expérimentale."
 
-#: src/view/screens/PreferencesHomeFeed.tsx:258
+#: src/view/screens/PreferencesHomeFeed.tsx:261
 msgid "Set this setting to \"Yes\" to show samples of your saved feeds in your following feed. This is an experimental feature."
 msgstr "Choisissez « Oui » pour afficher des échantillons de vos fils d’actu enregistrés dans votre fils d’actu suivant. C’est une fonctionnalité expérimentale."
 
-#: src/view/screens/Settings.tsx:277
+#: src/view/com/modals/ChangeHandle.tsx:266
+msgid "Sets Bluesky username"
+msgstr ""
+
+#: src/view/com/auth/login/ForgotPasswordForm.tsx:153
+msgid "Sets email for password reset"
+msgstr ""
+
+#: src/view/com/auth/login/ForgotPasswordForm.tsx:118
+msgid "Sets hosting provider for password reset"
+msgstr ""
+
+#: src/view/com/auth/create/Step1.tsx:143
+msgid "Sets hosting provider to {label}"
+msgstr ""
+
+#: src/view/com/auth/login/LoginForm.tsx:148
+msgid "Sets server for the Bluesky client"
+msgstr ""
+
+#: src/Navigation.tsx:136
+#: src/view/screens/Settings.tsx:287
 #: src/view/shell/desktop/LeftNav.tsx:433
-#: src/view/shell/Drawer.tsx:565
-#: src/view/shell/Drawer.tsx:566
+#: src/view/shell/Drawer.tsx:567
+#: src/view/shell/Drawer.tsx:568
 msgid "Settings"
 msgstr "Paramètres"
 
@@ -1984,20 +3072,31 @@ msgstr "Paramètres"
 msgid "Sexual activity or erotic nudity."
 msgstr "Activité sexuelle ou nudité érotique."
 
-#: src/view/com/profile/ProfileHeader.tsx:338
-#: src/view/com/util/forms/PostDropdownBtn.tsx:139
-#: src/view/screens/ProfileList.tsx:385
+#: src/view/com/lightbox/Lightbox.tsx:134
+msgctxt "action"
+msgid "Share"
+msgstr ""
+
+#: src/view/com/profile/ProfileHeader.tsx:342
+#: src/view/com/util/forms/PostDropdownBtn.tsx:151
+#: src/view/screens/ProfileList.tsx:396
 msgid "Share"
 msgstr "Partager"
 
-#: src/view/screens/ProfileFeed.tsx:303
+#: src/view/screens/ProfileFeed.tsx:313
 msgid "Share feed"
 msgstr "Partager le fil d’actu"
 
-#: src/view/com/util/moderation/ContentHider.tsx:105
-#: src/view/screens/Settings.tsx:316
+#: src/view/com/modals/ContentFilteringSettings.tsx:261
+#: src/view/com/util/moderation/ContentHider.tsx:107
+#: src/view/com/util/moderation/PostHider.tsx:108
+#: src/view/screens/Settings.tsx:331
 msgid "Show"
 msgstr "Afficher"
+
+#: src/view/screens/PreferencesHomeFeed.tsx:68
+msgid "Show all replies"
+msgstr ""
 
 #: src/view/com/util/moderation/ScreenHider.tsx:132
 msgid "Show anyway"
@@ -2007,15 +3106,25 @@ msgstr "Afficher quand même"
 msgid "Show embeds from {0}"
 msgstr ""
 
-#: src/view/screens/PreferencesHomeFeed.tsx:255
+#: src/view/com/profile/ProfileHeader.tsx:498
+msgid "Show follows similar to {0}"
+msgstr ""
+
+#: src/view/com/post-thread/PostThreadItem.tsx:569
+#: src/view/com/post/Post.tsx:196
+#: src/view/com/posts/FeedItem.tsx:362
+msgid "Show More"
+msgstr ""
+
+#: src/view/screens/PreferencesHomeFeed.tsx:258
 msgid "Show Posts from My Feeds"
 msgstr "Afficher les posts de mes fils d’actu"
 
-#: src/view/screens/PreferencesHomeFeed.tsx:219
+#: src/view/screens/PreferencesHomeFeed.tsx:222
 msgid "Show Quote Posts"
 msgstr "Afficher les posts de citation"
 
-#: src/view/screens/PreferencesHomeFeed.tsx:116
+#: src/view/screens/PreferencesHomeFeed.tsx:119
 msgid "Show Replies"
 msgstr "Afficher les réponses"
 
@@ -2023,13 +3132,30 @@ msgstr "Afficher les réponses"
 msgid "Show replies by people you follow before all other replies."
 msgstr "Afficher les réponses des personnes que vous suivez avant toutes les autres réponses."
 
-#: src/view/screens/PreferencesHomeFeed.tsx:185
+#: src/view/screens/PreferencesHomeFeed.tsx:70
+msgid "Show replies with at least {value} {0}"
+msgstr ""
+
+#: src/view/screens/PreferencesHomeFeed.tsx:188
 msgid "Show Reposts"
 msgstr "Afficher les reposts"
 
-#: src/view/com/notifications/FeedItem.tsx:345
+#: src/view/com/util/moderation/ContentHider.tsx:67
+#: src/view/com/util/moderation/PostHider.tsx:61
+msgid "Show the content"
+msgstr ""
+
+#: src/view/com/notifications/FeedItem.tsx:350
 msgid "Show users"
 msgstr "Afficher les utilisateurs"
+
+#: src/view/com/profile/ProfileHeader.tsx:501
+msgid "Shows a list of users similar to this user."
+msgstr ""
+
+#: src/view/com/profile/ProfileHeader.tsx:545
+msgid "Shows posts from {0} in your feed"
+msgstr ""
 
 #: src/view/com/auth/HomeLoggedOutCTA.tsx:70
 #: src/view/com/auth/login/Login.tsx:98
@@ -2065,7 +3191,9 @@ msgid "Sign into"
 msgstr "Se connecter à"
 
 #: src/view/com/modals/SwitchAccount.tsx:64
-#: src/view/com/modals/SwitchAccount.tsx:67
+#: src/view/com/modals/SwitchAccount.tsx:69
+#: src/view/screens/Settings.tsx:102
+#: src/view/screens/Settings.tsx:105
 msgid "Sign out"
 msgstr "Déconnexion"
 
@@ -2089,13 +3217,33 @@ msgstr "S’inscrire ou se connecter pour participer à la conversation"
 msgid "Sign-in Required"
 msgstr "Connexion requise"
 
-#: src/view/screens/Settings.tsx:327
+#: src/view/screens/Settings.tsx:342
 msgid "Signed in as"
 msgstr "Connecté en tant que"
+
+#: src/view/com/auth/login/ChooseAccountForm.tsx:103
+msgid "Signed in as @{0}"
+msgstr ""
+
+#: src/view/com/modals/SwitchAccount.tsx:66
+msgid "Signs {0} out of Bluesky"
+msgstr ""
 
 #: src/view/com/auth/onboarding/WelcomeMobile.tsx:33
 msgid "Skip"
 msgstr "Ignorer"
+
+#: src/view/com/modals/ProfilePreview.tsx:62
+msgid "Something went wrong and we're not sure what."
+msgstr ""
+
+#: src/view/com/modals/Waitlist.tsx:51
+msgid "Something went wrong. Check your email and try again."
+msgstr ""
+
+#: src/App.native.tsx:57
+msgid "Sorry! Your session expired. Please log in again."
+msgstr ""
 
 #: src/view/screens/PreferencesThreads.tsx:69
 msgid "Sort Replies"
@@ -2114,11 +3262,19 @@ msgstr "Carré"
 msgid "Staging"
 msgstr "Mise en scène"
 
-#: src/view/screens/Settings.tsx:763
+#: src/view/screens/Settings.tsx:780
 msgid "Status page"
 msgstr "Page de statut"
 
-#: src/view/screens/Settings.tsx:699
+#: src/view/com/auth/create/StepHeader.tsx:15
+msgid "Step {step} of 3"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:269
+msgid "Storage cleared, you need to restart the app now."
+msgstr ""
+
+#: src/view/screens/Settings.tsx:716
 msgid "Storybook"
 msgstr "Historique"
 
@@ -2126,28 +3282,59 @@ msgstr "Historique"
 msgid "Submit"
 msgstr "Envoyer"
 
-#: src/view/screens/ProfileList.tsx:575
+#: src/view/screens/ProfileList.tsx:586
 msgid "Subscribe"
 msgstr "S’abonner"
 
-#: src/view/screens/ProfileList.tsx:571
+#: src/view/screens/ProfileList.tsx:582
 msgid "Subscribe to this list"
 msgstr "S’abonner à cette liste"
+
+#: src/view/com/lists/ListCard.tsx:101
+msgid "Subscribed"
+msgstr ""
 
 #: src/view/screens/Search/Search.tsx:362
 msgid "Suggested Follows"
 msgstr "Suivis suggérés"
 
+#: src/view/com/profile/ProfileHeaderSuggestedFollows.tsx:64
+msgid "Suggested for you"
+msgstr ""
+
+#: src/view/com/modals/SelfLabel.tsx:95
+msgid "Suggestive"
+msgstr ""
+
+#: src/Navigation.tsx:214
 #: src/view/screens/Support.tsx:30
 #: src/view/screens/Support.tsx:33
 msgid "Support"
 msgstr "Soutien"
 
-#: src/view/com/modals/SwitchAccount.tsx:115
+#: src/view/com/modals/ProfilePreview.tsx:110
+msgid "Swipe up to see more"
+msgstr ""
+
+#: src/view/com/modals/SwitchAccount.tsx:117
 msgid "Switch Account"
 msgstr "Changer de compte"
 
-#: src/view/screens/Settings.tsx:679
+#: src/view/com/modals/SwitchAccount.tsx:97
+#: src/view/screens/Settings.tsx:132
+msgid "Switch to {0}"
+msgstr ""
+
+#: src/view/com/modals/SwitchAccount.tsx:98
+#: src/view/screens/Settings.tsx:133
+msgid "Switches the account you are logged in to"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:453
+msgid "System"
+msgstr ""
+
+#: src/view/screens/Settings.tsx:696
 msgid "System log"
 msgstr "Journal système"
 
@@ -2155,11 +3342,16 @@ msgstr "Journal système"
 msgid "Tall"
 msgstr "Grand"
 
+#: src/view/com/util/images/AutoSizedImage.tsx:70
+msgid "Tap to view fully"
+msgstr ""
+
 #: src/view/shell/desktop/RightNav.tsx:93
 msgid "Terms"
 msgstr "Conditions générales"
 
-#: src/view/screens/Settings.tsx:777
+#: src/Navigation.tsx:224
+#: src/view/screens/Settings.tsx:794
 #: src/view/screens/TermsOfService.tsx:29
 #: src/view/shell/Drawer.tsx:256
 msgid "Terms of Service"
@@ -2170,7 +3362,7 @@ msgstr "Conditions d’utilisation"
 msgid "Text input field"
 msgstr "Champ de saisie de texte"
 
-#: src/view/com/profile/ProfileHeader.tsx:306
+#: src/view/com/profile/ProfileHeader.tsx:310
 msgid "The account will be able to interact with you after unblocking."
 msgstr "Ce compte pourra interagir avec vous après le déblocage."
 
@@ -2182,7 +3374,7 @@ msgstr "Les lignes directrices communautaires ont été déplacées vers <0/>"
 msgid "The Copyright Policy has been moved to <0/>"
 msgstr "Notre politique de droits d’auteur a été déplacée vers <0/>"
 
-#: src/view/com/post-thread/PostThread.tsx:433
+#: src/view/com/post-thread/PostThread.tsx:437
 msgid "The post may have been deleted."
 msgstr "Ce post a peut-être été supprimé."
 
@@ -2191,12 +3383,85 @@ msgid "The Privacy Policy has been moved to <0/>"
 msgstr "Notre politique de confidentialité a été déplacée vers <0/>"
 
 #: src/view/screens/Support.tsx:36
-msgid "The support form has been moved. If you need help, please<0/> or visit {HELP_DESK_URL} to get in touch with us."
-msgstr "Le formulaire d’assistance a été déplacé. Si vous avez besoin d’aide, veuillez <0/> ou rendez-vous sur {HELP_DESK_URL} pour nous contacter."
+msgid "The support form has been moved. If you need help, please <0/> or visit {HELP_DESK_URL} to get in touch with us."
+msgstr ""
+
+#: src/view/screens/Support.tsx:36
+#~ msgid "The support form has been moved. If you need help, please<0/> or visit {HELP_DESK_URL} to get in touch with us."
+#~ msgstr "Le formulaire d’assistance a été déplacé. Si vous avez besoin d’aide, veuillez <0/> ou rendez-vous sur {HELP_DESK_URL} pour nous contacter."
 
 #: src/view/screens/TermsOfService.tsx:33
 msgid "The Terms of Service have been moved to"
 msgstr "Nos conditions d’utilisation ont été déplacées vers"
+
+#: src/view/screens/ProfileFeed.tsx:558
+msgid "There was an an issue contacting the server, please check your internet connection and try again."
+msgstr ""
+
+#: src/view/com/posts/FeedErrorMessage.tsx:139
+msgid "There was an an issue removing this feed. Please check your internet connection and try again."
+msgstr ""
+
+#: src/view/screens/ProfileFeed.tsx:218
+msgid "There was an an issue updating your feeds, please check your internet connection and try again."
+msgstr ""
+
+#: src/view/screens/ProfileFeed.tsx:245
+#: src/view/screens/ProfileList.tsx:266
+#: src/view/screens/SavedFeeds.tsx:209
+#: src/view/screens/SavedFeeds.tsx:231
+#: src/view/screens/SavedFeeds.tsx:252
+msgid "There was an issue contacting the server"
+msgstr ""
+
+#: src/view/com/auth/onboarding/RecommendedFeedsItem.tsx:57
+#: src/view/com/auth/onboarding/RecommendedFeedsItem.tsx:66
+#: src/view/com/feeds/FeedSourceCard.tsx:113
+#: src/view/com/feeds/FeedSourceCard.tsx:127
+#: src/view/com/feeds/FeedSourceCard.tsx:181
+msgid "There was an issue contacting your server"
+msgstr ""
+
+#: src/view/com/notifications/Feed.tsx:115
+msgid "There was an issue fetching notifications. Tap here to try again."
+msgstr ""
+
+#: src/view/com/posts/Feed.tsx:261
+msgid "There was an issue fetching posts. Tap here to try again."
+msgstr ""
+
+#: src/view/com/lists/ListMembers.tsx:172
+msgid "There was an issue fetching the list. Tap here to try again."
+msgstr ""
+
+#: src/view/com/feeds/ProfileFeedgens.tsx:148
+#: src/view/com/lists/ProfileLists.tsx:155
+msgid "There was an issue fetching your lists. Tap here to try again."
+msgstr ""
+
+#: src/view/com/modals/ContentFilteringSettings.tsx:126
+msgid "There was an issue syncing your preferences with the server"
+msgstr ""
+
+#: src/view/screens/AppPasswords.tsx:66
+msgid "There was an issue with fetching your app passwords"
+msgstr ""
+
+#: src/view/com/profile/ProfileHeader.tsx:204
+#: src/view/com/profile/ProfileHeader.tsx:225
+#: src/view/com/profile/ProfileHeader.tsx:264
+#: src/view/com/profile/ProfileHeader.tsx:277
+#: src/view/com/profile/ProfileHeader.tsx:297
+#: src/view/com/profile/ProfileHeader.tsx:319
+msgid "There was an issue! {0}"
+msgstr ""
+
+#: src/view/screens/ProfileList.tsx:287
+#: src/view/screens/ProfileList.tsx:306
+#: src/view/screens/ProfileList.tsx:328
+#: src/view/screens/ProfileList.tsx:347
+msgid "There was an issue. Please check your internet connection and try again."
+msgstr ""
 
 #: src/view/com/util/ErrorBoundary.tsx:35
 msgid "There was an unexpected issue in the application. Please let us know if this happened to you!"
@@ -2217,19 +3482,33 @@ msgstr "Ce compte a demandé aux utilisateurs de s’identifier pour voir son pr
 msgid "This content is hosted by {0}. Do you want to enable external media?"
 msgstr ""
 
-#: src/view/com/posts/FeedErrorMessage.tsx:107
+#: src/view/com/modals/ModerationDetails.tsx:67
+msgid "This content is not available because one of the users involved has blocked the other."
+msgstr ""
+
+#: src/view/com/posts/FeedErrorMessage.tsx:108
 msgid "This content is not viewable without a Bluesky account."
 msgstr "Ce contenu n’est pas visible sans un compte Bluesky."
 
-#: src/view/com/posts/FeedErrorMessage.tsx:113
+#: src/view/com/posts/FeedErrorMessage.tsx:114
 msgid "This feed is currently receiving high traffic and is temporarily unavailable. Please try again later."
 msgstr "Ce fil d’actu reçoit actuellement un trafic important, il est temporairement indisponible. Veuillez réessayer plus tard."
+
+#: src/view/screens/Profile.tsx:392
+#: src/view/screens/ProfileFeed.tsx:484
+#: src/view/screens/ProfileList.tsx:639
+msgid "This feed is empty!"
+msgstr ""
+
+#: src/view/com/posts/CustomFeedEmptyState.tsx:37
+msgid "This feed is empty! You may need to follow more users or tune your language settings."
+msgstr ""
 
 #: src/view/com/modals/BirthDateSettings.tsx:61
 msgid "This information is not shared with other users."
 msgstr "Ces informations ne sont pas partagées avec d’autres utilisateurs."
 
-#: src/view/com/modals/VerifyEmail.tsx:113
+#: src/view/com/modals/VerifyEmail.tsx:119
 msgid "This is important in case you ever need to change your email or reset your password."
 msgstr "Ceci est important au cas où vous auriez besoin de changer d’e-mail ou de réinitialiser votre mot de passe."
 
@@ -2241,20 +3520,40 @@ msgstr "C’est le service qui vous permet de rester en ligne."
 msgid "This link is taking you to the following website:"
 msgstr "Ce lien vous conduit au site Web suivant :"
 
+#: src/view/screens/ProfileList.tsx:813
+msgid "This list is empty!"
+msgstr ""
+
+#: src/view/com/modals/AddAppPasswords.tsx:105
+msgid "This name is already in use"
+msgstr ""
+
 #: src/view/com/post-thread/PostThreadItem.tsx:123
 msgid "This post has been deleted."
 msgstr "Ce post a été supprimé."
+
+#: src/view/com/modals/ModerationDetails.tsx:62
+msgid "This user has blocked you. You cannot view their content."
+msgstr ""
+
+#: src/view/com/modals/ModerationDetails.tsx:42
+msgid "This user is included in the <0/> list which you have blocked."
+msgstr ""
+
+#: src/view/com/modals/ModerationDetails.tsx:74
+msgid "This user is included the <0/> list which you have muted."
+msgstr ""
 
 #: src/view/com/modals/SelfLabel.tsx:137
 msgid "This warning is only available for posts with media attached."
 msgstr "Cet avertissement n’est disponible que pour les messages contenant des médias."
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:178
+#: src/view/com/util/forms/PostDropdownBtn.tsx:190
 msgid "This will hide this post from your feeds."
 msgstr "Cela va masquer ce post de vos fils d’actu."
 
 #: src/view/screens/PreferencesThreads.tsx:53
-#: src/view/screens/Settings.tsx:503
+#: src/view/screens/Settings.tsx:518
 msgid "Thread Preferences"
 msgstr "Préférences des fils de discussion"
 
@@ -2262,7 +3561,11 @@ msgstr "Préférences des fils de discussion"
 msgid "Threaded Mode"
 msgstr "Mode arborescent"
 
-#: src/view/com/util/forms/DropdownButton.tsx:230
+#: src/Navigation.tsx:254
+msgid "Threads Preferences"
+msgstr ""
+
+#: src/view/com/util/forms/DropdownButton.tsx:234
 msgid "Toggle dropdown"
 msgstr "Activer le menu déroulant"
 
@@ -2270,59 +3573,99 @@ msgstr "Activer le menu déroulant"
 msgid "Transformations"
 msgstr "Transformations"
 
-#: src/view/com/post-thread/PostThreadItem.tsx:705
-#: src/view/com/post-thread/PostThreadItem.tsx:707
-#: src/view/com/util/forms/PostDropdownBtn.tsx:111
+#: src/view/com/post-thread/PostThreadItem.tsx:710
+#: src/view/com/post-thread/PostThreadItem.tsx:712
+#: src/view/com/util/forms/PostDropdownBtn.tsx:123
 msgid "Translate"
 msgstr "Traduire"
 
-#: src/view/com/util/error/ErrorScreen.tsx:73
+#: src/view/com/util/error/ErrorScreen.tsx:75
+msgctxt "action"
 msgid "Try again"
-msgstr "Réessayer"
+msgstr ""
 
-#: src/view/screens/ProfileList.tsx:473
+#: src/view/com/util/error/ErrorScreen.tsx:73
+#~ msgid "Try again"
+#~ msgstr "Réessayer"
+
+#: src/view/screens/ProfileList.tsx:484
 msgid "Un-block list"
 msgstr "Débloquer la liste"
 
-#: src/view/screens/ProfileList.tsx:458
+#: src/view/screens/ProfileList.tsx:469
 msgid "Un-mute list"
 msgstr "Réafficher cette liste"
 
 #: src/view/com/auth/create/CreateAccount.tsx:65
+#: src/view/com/auth/login/ForgotPasswordForm.tsx:87
 #: src/view/com/auth/login/Login.tsx:76
 #: src/view/com/auth/login/LoginForm.tsx:120
 msgid "Unable to contact your service. Please check your Internet connection."
 msgstr "Impossible de contacter votre service. Veuillez vérifier votre connexion Internet."
 
-#: src/view/com/profile/ProfileHeader.tsx:466
-#: src/view/com/profile/ProfileHeader.tsx:469
+#: src/view/com/profile/ProfileHeader.tsx:475
+msgctxt "action"
+msgid "Unblock"
+msgstr ""
+
+#: src/view/com/profile/ProfileHeader.tsx:472
+#: src/view/screens/ProfileList.tsx:568
 msgid "Unblock"
 msgstr "Débloquer"
 
-#: src/view/com/profile/ProfileHeader.tsx:304
-#: src/view/com/profile/ProfileHeader.tsx:388
+#: src/view/com/profile/ProfileHeader.tsx:308
+#: src/view/com/profile/ProfileHeader.tsx:392
 msgid "Unblock Account"
 msgstr "Débloquer le compte"
 
+#: src/view/com/modals/Repost.tsx:42
+#: src/view/com/modals/Repost.tsx:55
+#: src/view/com/util/post-ctrls/RepostButton.tsx:60
 #: src/view/com/util/post-ctrls/RepostButton.web.tsx:48
 msgid "Undo repost"
 msgstr "Annuler le repost"
+
+#: src/view/com/profile/FollowButton.tsx:55
+msgctxt "action"
+msgid "Unfollow"
+msgstr ""
+
+#: src/view/com/profile/ProfileHeader.tsx:524
+msgid "Unfollow {0}"
+msgstr ""
 
 #: src/view/com/auth/create/state.ts:216
 msgid "Unfortunately, you do not meet the requirements to create an account."
 msgstr "Malheureusement, vous ne remplissez pas les conditions requises pour créer un compte."
 
-#: src/view/com/profile/ProfileHeader.tsx:369
+#: src/view/com/util/post-ctrls/PostCtrls.tsx:189
+msgid "Unlike"
+msgstr ""
+
+#: src/view/screens/ProfileList.tsx:575
+msgid "Unmute"
+msgstr ""
+
+#: src/view/com/profile/ProfileHeader.tsx:373
 msgid "Unmute Account"
 msgstr "Réafficher ce compte"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:157
+#: src/view/com/util/forms/PostDropdownBtn.tsx:169
 msgid "Unmute thread"
 msgstr "Réafficher ce fil de discussion"
 
-#: src/view/screens/ProfileList.tsx:441
+#: src/view/screens/ProfileFeed.tsx:362
+#: src/view/screens/ProfileList.tsx:559
+msgid "Unpin"
+msgstr ""
+
+#: src/view/screens/ProfileList.tsx:452
 msgid "Unpin moderation list"
 msgstr "Supprimer la liste de modération"
+
+#: src/view/screens/ProfileFeed.tsx:354
+msgid "Unsave"
+msgstr ""
 
 #: src/view/com/modals/UserAddRemoveLists.tsx:54
 msgid "Update {displayName} in Lists"
@@ -2332,33 +3675,72 @@ msgstr "Mise à jour de {displayName} dans les listes"
 msgid "Update Available"
 msgstr "Mise à jour disponible"
 
-#: src/view/com/auth/login/SetNewPasswordForm.tsx:172
+#: src/view/com/auth/login/SetNewPasswordForm.tsx:174
 msgid "Updating..."
 msgstr "Mise à jour…"
 
-#: src/view/com/modals/ChangeHandle.tsx:453
+#: src/view/com/modals/ChangeHandle.tsx:455
 msgid "Upload a text file to:"
 msgstr "Télécharger un fichier texte vers :"
 
-#: src/view/screens/AppPasswords.tsx:194
+#: src/view/screens/AppPasswords.tsx:195
 msgid "Use app passwords to login to other Bluesky clients without giving full access to your account or password."
 msgstr "Utiliser les mots de passe de l’appli pour se connecter à d’autres clients Bluesky sans donner un accès complet à votre compte ou à votre mot de passe."
 
-#: src/view/com/modals/ChangeHandle.tsx:513
+#: src/view/com/modals/ChangeHandle.tsx:515
 msgid "Use default provider"
 msgstr "Utiliser le fournisseur par défaut"
 
-#: src/view/com/modals/AddAppPasswords.tsx:150
+#: src/view/com/modals/AddAppPasswords.tsx:154
 msgid "Use this to sign into the other app along with your handle."
 msgstr "Utilisez-le pour vous connecter à l’autre application avec votre identifiant."
 
-#: src/view/com/modals/InviteCodes.tsx:197
+#: src/view/com/modals/ServerInput.tsx:105
+msgid "Use your domain as your Bluesky client service provider"
+msgstr ""
+
+#: src/view/com/modals/InviteCodes.tsx:200
 msgid "Used by:"
 msgstr "Utilisé par :"
+
+#: src/view/com/modals/ModerationDetails.tsx:54
+msgid "User Blocked"
+msgstr ""
+
+#: src/view/com/modals/ModerationDetails.tsx:40
+msgid "User Blocked by List"
+msgstr ""
+
+#: src/view/com/modals/ModerationDetails.tsx:60
+msgid "User Blocks You"
+msgstr ""
 
 #: src/view/com/auth/create/Step3.tsx:38
 msgid "User handle"
 msgstr "Pseudo utilisateur"
+
+#: src/view/com/lists/ListCard.tsx:84
+#: src/view/com/modals/UserAddRemoveLists.tsx:182
+msgid "User list by {0}"
+msgstr ""
+
+#: src/view/screens/ProfileList.tsx:741
+msgid "User list by <0/>"
+msgstr ""
+
+#: src/view/com/lists/ListCard.tsx:82
+#: src/view/com/modals/UserAddRemoveLists.tsx:180
+#: src/view/screens/ProfileList.tsx:739
+msgid "User list by you"
+msgstr ""
+
+#: src/view/com/modals/CreateOrEditList.tsx:138
+msgid "User list created"
+msgstr ""
+
+#: src/view/com/modals/CreateOrEditList.tsx:125
+msgid "User list updated"
+msgstr ""
 
 #: src/view/screens/Lists.tsx:58
 msgid "User Lists"
@@ -2369,7 +3751,7 @@ msgstr "Listes d’utilisateurs"
 msgid "Username or email address"
 msgstr "Nom d’utilisateur ou e-mail"
 
-#: src/view/screens/ProfileList.tsx:747
+#: src/view/screens/ProfileList.tsx:775
 msgid "Users"
 msgstr "Utilisateurs"
 
@@ -2381,15 +3763,15 @@ msgstr "utilisateurs suivis par <0/>"
 msgid "Users in \"{0}\""
 msgstr "Utilisateurs dans « {0} »"
 
-#: src/view/screens/Settings.tsx:802
+#: src/view/screens/Settings.tsx:819
 msgid "Verify email"
 msgstr "Confirmer l’e-mail"
 
-#: src/view/screens/Settings.tsx:827
+#: src/view/screens/Settings.tsx:844
 msgid "Verify my email"
 msgstr "Confirmer mon e-mail"
 
-#: src/view/screens/Settings.tsx:836
+#: src/view/screens/Settings.tsx:853
 msgid "Verify My Email"
 msgstr "Confirmer mon e-mail"
 
@@ -2398,9 +3780,25 @@ msgstr "Confirmer mon e-mail"
 msgid "Verify New Email"
 msgstr "Confirmer le nouvel e-mail"
 
+#: src/view/com/modals/VerifyEmail.tsx:103
+msgid "Verify Your Email"
+msgstr ""
+
+#: src/view/com/profile/ProfileHeader.tsx:701
+msgid "View {0}'s avatar"
+msgstr ""
+
 #: src/view/screens/Log.tsx:52
 msgid "View debug entry"
 msgstr "Afficher l’entrée de débogage"
+
+#: src/view/com/posts/FeedSlice.tsx:103
+msgid "View full thread"
+msgstr ""
+
+#: src/view/com/posts/FeedErrorMessage.tsx:172
+msgid "View profile"
+msgstr ""
 
 #: src/view/com/profile/ProfileSubpageHeader.tsx:128
 msgid "View the avatar"
@@ -2410,9 +3808,21 @@ msgstr "Afficher l’avatar"
 msgid "Visit Site"
 msgstr "Visiter le site"
 
+#: src/view/com/modals/ContentFilteringSettings.tsx:254
+msgid "Warn"
+msgstr ""
+
+#: src/view/com/modals/AppealLabel.tsx:48
+msgid "We'll look into your appeal promptly."
+msgstr ""
+
 #: src/view/com/auth/create/CreateAccount.tsx:122
 msgid "We're so excited to have you join us!"
 msgstr "Nous sommes ravis de vous accueillir !"
+
+#: src/view/screens/ProfileList.tsx:83
+msgid "We're sorry, but we were unable to resolve this list. If this persists, please contact the list creator, @{handleOrDid}."
+msgstr ""
 
 #: src/view/screens/Search/Search.tsx:243
 msgid "We're sorry, but your search could not be completed. Please try again in a few minutes."
@@ -2431,6 +3841,7 @@ msgid "What is the issue with this {collectionName}?"
 msgstr "Quel est le problème avec cette {collectionName} ?"
 
 #: src/view/com/auth/SplashScreen.tsx:34
+#: src/view/com/composer/Composer.tsx:278
 msgid "What's up?"
 msgstr "Quoi de neuf ?"
 
@@ -2451,22 +3862,28 @@ msgstr "Qui peut répondre ?"
 msgid "Wide"
 msgstr "Large"
 
-#: src/view/com/composer/Composer.tsx:418
+#: src/view/com/composer/Composer.tsx:414
 msgid "Write post"
 msgstr "Rédiger un post"
 
+#: src/view/com/composer/Composer.tsx:277
 #: src/view/com/composer/Prompt.tsx:33
 msgid "Write your reply"
 msgstr "Rédigez votre réponse"
 
-#: src/view/screens/PreferencesHomeFeed.tsx:126
-#: src/view/screens/PreferencesHomeFeed.tsx:198
-#: src/view/screens/PreferencesHomeFeed.tsx:233
-#: src/view/screens/PreferencesHomeFeed.tsx:268
+#: src/view/screens/PreferencesHomeFeed.tsx:129
+#: src/view/screens/PreferencesHomeFeed.tsx:201
+#: src/view/screens/PreferencesHomeFeed.tsx:236
+#: src/view/screens/PreferencesHomeFeed.tsx:271
 #: src/view/screens/PreferencesThreads.tsx:106
 #: src/view/screens/PreferencesThreads.tsx:129
 msgid "Yes"
 msgstr "Oui"
+
+#: src/view/com/posts/FollowingEmptyState.tsx:67
+#: src/view/com/posts/FollowingEndOfFeed.tsx:68
+msgid "You can also discover new Custom Feeds to follow."
+msgstr ""
 
 #: src/view/com/auth/create/Step1.tsx:106
 msgid "You can change hosting providers at any time."
@@ -2477,7 +3894,7 @@ msgstr "Vous pouvez changer d’hébergeur à tout moment."
 msgid "You can now sign in with your new password."
 msgstr "Vous pouvez maintenant vous connecter avec votre nouveau mot de passe."
 
-#: src/view/com/modals/InviteCodes.tsx:64
+#: src/view/com/modals/InviteCodes.tsx:66
 msgid "You don't have any invite codes yet! We'll send you some when you've been on Bluesky for a little longer."
 msgstr "Vous n’avez encore aucun code d’invitation ! Nous vous en enverrons lorsque vous serez sur Bluesky depuis un peu plus longtemps."
 
@@ -2485,7 +3902,7 @@ msgstr "Vous n’avez encore aucun code d’invitation ! Nous vous en enverrons
 msgid "You don't have any pinned feeds."
 msgstr "Vous n’avez encore aucun fil épinglé."
 
-#: src/view/screens/Feeds.tsx:383
+#: src/view/screens/Feeds.tsx:387
 msgid "You don't have any saved feeds!"
 msgstr "Vous n’avez encore aucun fil enregistré !"
 
@@ -2493,16 +3910,24 @@ msgstr "Vous n’avez encore aucun fil enregistré !"
 msgid "You don't have any saved feeds."
 msgstr "Vous n’avez encore aucun fil enregistré."
 
-#: src/view/com/post-thread/PostThread.tsx:381
+#: src/view/com/post-thread/PostThread.tsx:385
 msgid "You have blocked the author or you have been blocked by the author."
 msgstr "Vous avez bloqué cet auteur ou vous avez été bloqué par celui-ci."
 
-#: src/view/com/feeds/ProfileFeedgens.tsx:134
+#: src/view/com/modals/ModerationDetails.tsx:56
+msgid "You have blocked this user. You cannot view their content."
+msgstr ""
+
+#: src/view/com/modals/ModerationDetails.tsx:87
+msgid "You have muted this user."
+msgstr ""
+
+#: src/view/com/feeds/ProfileFeedgens.tsx:136
 msgid "You have no feeds."
 msgstr "Vous n’avez aucun fil."
 
 #: src/view/com/lists/MyLists.tsx:89
-#: src/view/com/lists/ProfileLists.tsx:138
+#: src/view/com/lists/ProfileLists.tsx:140
 msgid "You have no lists."
 msgstr "Vous n’avez aucune liste."
 
@@ -2510,7 +3935,7 @@ msgstr "Vous n’avez aucune liste."
 msgid "You have not blocked any accounts yet. To block an account, go to their profile and selected \"Block account\" from the menu on their account."
 msgstr "Vous n’avez pas encore bloqué de comptes. Pour bloquer un compte, accédez à son profil et sélectionnez « Bloquer le compte » dans le menu de son compte."
 
-#: src/view/screens/AppPasswords.tsx:86
+#: src/view/screens/AppPasswords.tsx:87
 msgid "You have not created any app passwords yet. You can create one by pressing the button below."
 msgstr "Vous n’avez encore créé aucun mot de passe pour l’appli. Vous pouvez en créer un en cliquant sur le bouton suivant."
 
@@ -2518,23 +3943,44 @@ msgstr "Vous n’avez encore créé aucun mot de passe pour l’appli. Vous pouv
 msgid "You have not muted any accounts yet. To mute an account, go to their profile and selected \"Mute account\" from the menu on their account."
 msgstr "Vous n’avez encore masqué aucun compte. Pour désactiver un compte, allez sur son profil et sélectionnez « Masquer le compte » dans le menu de son compte."
 
+#: src/view/com/modals/ContentFilteringSettings.tsx:170
+msgid "You must be 18 or older to enable adult content."
+msgstr ""
+
+#: src/view/com/util/forms/PostDropdownBtn.tsx:96
+msgid "You will no longer receive notifications for this thread"
+msgstr ""
+
+#: src/view/com/util/forms/PostDropdownBtn.tsx:99
+msgid "You will now receive notifications for this thread"
+msgstr ""
+
 #: src/view/com/auth/login/SetNewPasswordForm.tsx:81
 msgid "You will receive an email with a \"reset code.\" Enter that code here, then enter your new password."
 msgstr "Vous recevrez un e-mail contenant un « code de réinitialisation » Saisissez ce code ici, puis votre nouveau mot de passe."
 
+#: src/view/com/posts/FollowingEndOfFeed.tsx:48
+msgid "You've reached the end of your feed! Find some more accounts to follow."
+msgstr ""
+
 #: src/view/com/auth/create/Step2.tsx:58
 msgid "Your account"
 msgstr "Votre compte"
+
+#: src/view/com/modals/DeleteAccount.tsx:65
+msgid "Your account has been deleted"
+msgstr ""
 
 #: src/view/com/auth/create/Step2.tsx:146
 msgid "Your birth date"
 msgstr "Votre date de naissance"
 
 #: src/view/com/auth/create/state.ts:102
+#: src/view/com/auth/login/ForgotPasswordForm.tsx:70
 msgid "Your email appears to be invalid."
 msgstr "Votre e-mail semble être invalide."
 
-#: src/view/com/modals/Waitlist.tsx:107
+#: src/view/com/modals/Waitlist.tsx:109
 msgid "Your email has been saved! We'll be in touch soon."
 msgstr "Votre e-mail a été enregistré ! Nous vous contacterons bientôt."
 
@@ -2542,32 +3988,49 @@ msgstr "Votre e-mail a été enregistré ! Nous vous contacterons bientôt."
 msgid "Your email has been updated but not verified. As a next step, please verify your new email."
 msgstr "Votre e-mail a été mis à jour, mais n’a pas été vérifié. L’étape suivante consiste à vérifier votre nouvel e-mail."
 
-#: src/view/com/modals/VerifyEmail.tsx:108
+#: src/view/com/modals/VerifyEmail.tsx:114
 msgid "Your email has not yet been verified. This is an important security step which we recommend."
 msgstr "Votre e-mail n’a pas encore été vérifié. Il s’agit d’une mesure de sécurité importante que nous recommandons."
 
+#: src/view/com/posts/FollowingEmptyState.tsx:47
+msgid "Your following feed is empty! Follow more users to see what's happening."
+msgstr ""
+
 #: src/view/com/auth/create/Step3.tsx:42
-#: src/view/com/modals/ChangeHandle.tsx:270
 msgid "Your full handle will be"
 msgstr "Votre nom complet sera"
+
+#: src/view/com/modals/ChangeHandle.tsx:270
+msgid "Your full handle will be <0>@{0}</0>"
+msgstr ""
 
 #: src/view/com/auth/create/Step1.tsx:53
 msgid "Your hosting provider"
 msgstr "Votre fournisseur d’hébergement"
 
-#: src/view/screens/Settings.tsx:402
+#: src/view/screens/Settings.tsx:417
 #: src/view/shell/desktop/RightNav.tsx:137
-#: src/view/shell/Drawer.tsx:655
+#: src/view/shell/Drawer.tsx:657
 msgid "Your invite codes are hidden when logged in using an App Password"
 msgstr "Vos codes d’invitation sont cachés lorsque vous êtes connecté à l’aide d’un mot de passe d’application."
 
+#: src/view/com/composer/Composer.tsx:266
+msgid "Your post has been published"
+msgstr ""
+
+#: src/view/com/auth/onboarding/WelcomeDesktop.tsx:59
 #: src/view/com/auth/onboarding/WelcomeMobile.tsx:59
 msgid "Your posts, likes, and blocks are public. Mutes are private."
 msgstr "Vos posts, les mentions « J’aime » et les blocages sont publics. Les silences (comptes masqués) sont privés."
 
-#: src/view/com/modals/SwitchAccount.tsx:82
+#: src/view/com/modals/SwitchAccount.tsx:84
+#: src/view/screens/Settings.tsx:120
 msgid "Your profile"
 msgstr "Votre profil"
+
+#: src/view/com/composer/Composer.tsx:265
+msgid "Your reply has been published"
+msgstr ""
 
 #: src/view/com/auth/create/Step3.tsx:28
 msgid "Your user handle"

--- a/src/locale/locales/fr/messages.po
+++ b/src/locale/locales/fr/messages.po
@@ -9,34 +9,30 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
 "PO-Revision-Date: \n"
-"Last-Translator: \n"
+"Last-Translator: Stanislas Signoud (@signez.fr)\n"
 "Language-Team: \n"
 "Plural-Forms: \n"
 
 #: src/view/com/modals/VerifyEmail.tsx:142
 msgid "(no email)"
-msgstr ""
+msgstr "(pas d’e-mail)"
 
 #: src/view/shell/desktop/RightNav.tsx:168
 msgid "{0, plural, one {# invite code available} other {# invite codes available}}"
-msgstr "{0, plural, one {# invite code available} other {# invite codes available}}"
+msgstr "{0, plural, one {# code d’invitation disponible} other {# codes d’invitations disponibles}}"
 
 #: src/view/com/modals/CreateOrEditList.tsx:185
 #: src/view/screens/Settings.tsx:287
 msgid "{0}"
 msgstr "{0}"
 
-#: src/view/com/modals/CreateOrEditList.tsx:176
-#~ msgid "{0} {purposeLabel} List"
-#~ msgstr "{0} {purposeLabel} Liste"
-
 #: src/view/com/profile/ProfileHeader.tsx:632
 msgid "{following} following"
-msgstr ""
+msgstr "{following} abonnements"
 
 #: src/view/shell/desktop/RightNav.tsx:151
 msgid "{invitesAvailable, plural, one {Invite codes: # available} other {Invite codes: # available}}"
-msgstr "{invitesAvailable, plural, one {Invite codes: # available} other {Invite codes: # available}}"
+msgstr "{invitesAvailable, plural, one {Code d’invitation : # disponible} other {Codes d’invitation : # disponibles}}"
 
 #: src/view/screens/Settings.tsx:422
 #: src/view/shell/Drawer.tsx:661
@@ -54,11 +50,11 @@ msgstr "{message}"
 
 #: src/view/shell/Drawer.tsx:440
 msgid "{numUnreadNotifications} unread"
-msgstr ""
+msgstr "{numUnreadNotifications} non lus"
 
 #: src/Navigation.tsx:147
 msgid "@{0}"
-msgstr ""
+msgstr "@{0}"
 
 #: src/view/com/threadgate/WhoCanReply.tsx:158
 msgid "<0/> members"
@@ -66,7 +62,7 @@ msgstr "<0/> membres"
 
 #: src/view/com/profile/ProfileHeader.tsx:634
 msgid "<0>{following} </0><1>following</1>"
-msgstr ""
+msgstr "<0>{following} </0><1>abonné·e·s</1>"
 
 #: src/view/com/auth/onboarding/RecommendedFeeds.tsx:30
 msgid "<0>Choose your</0><1>Recommended</1><2>Feeds</2>"
@@ -74,15 +70,15 @@ msgstr "<0>Choisissez vos</0><1>fils d’actualité</1><2>recommandés</2>"
 
 #: src/view/com/auth/onboarding/RecommendedFollows.tsx:37
 msgid "<0>Follow some</0><1>Recommended</1><2>Users</2>"
-msgstr "<0>Suivre certains</0><1>utilisateurs</1><2>recommandés</2>"
+msgstr "<0>Suivre certains</0><1>comptes</1><2>recommandés</2>"
 
 #: src/view/com/auth/onboarding/WelcomeDesktop.tsx:21
 msgid "<0>Welcome to</0><1>Bluesky</1>"
-msgstr ""
+msgstr "<0>Bienvenue sur</0><1>Bluesky</1>"
 
 #: src/view/com/profile/ProfileHeader.tsx:597
 msgid "⚠Invalid Handle"
-msgstr ""
+msgstr "⚠Pseudo invalide"
 
 #: src/view/com/util/moderation/LabelInfo.tsx:45
 msgid "A content warning has been applied to this {0}."
@@ -95,11 +91,11 @@ msgstr "Une nouvelle version de l’application est disponible. Veuillez faire l
 #: src/view/com/util/ViewHeader.tsx:83
 #: src/view/screens/Search/Search.tsx:538
 msgid "Access navigation links and settings"
-msgstr ""
+msgstr "Accède aux liens de navigation et aux paramètres"
 
 #: src/view/com/pager/FeedsTabBarMobile.tsx:78
 msgid "Access profile and other navigation links"
-msgstr ""
+msgstr "Accède au profil et aux autres liens de navigation"
 
 #: src/view/com/modals/EditImage.tsx:299
 #: src/view/screens/Settings.tsx:432
@@ -113,19 +109,19 @@ msgstr "Compte"
 
 #: src/view/com/profile/ProfileHeader.tsx:293
 msgid "Account blocked"
-msgstr ""
+msgstr "Compte bloqué"
 
 #: src/view/com/profile/ProfileHeader.tsx:260
 msgid "Account muted"
-msgstr ""
+msgstr "Compte masqué"
 
 #: src/view/com/modals/ModerationDetails.tsx:86
 msgid "Account Muted"
-msgstr ""
+msgstr "Compte masqué"
 
 #: src/view/com/modals/ModerationDetails.tsx:72
 msgid "Account Muted by List"
-msgstr ""
+msgstr "Compte masqué par list"
 
 #: src/view/com/util/AccountDropdownBtn.tsx:41
 msgid "Account options"
@@ -133,15 +129,15 @@ msgstr "Options de compte"
 
 #: src/view/com/util/AccountDropdownBtn.tsx:25
 msgid "Account removed from quick access"
-msgstr ""
+msgstr "Compte supprimé de l’accès rapide"
 
 #: src/view/com/profile/ProfileHeader.tsx:315
 msgid "Account unblocked"
-msgstr ""
+msgstr "Compte débloqué"
 
 #: src/view/com/profile/ProfileHeader.tsx:273
 msgid "Account unmuted"
-msgstr ""
+msgstr "Compte démasqué"
 
 #: src/view/com/auth/onboarding/RecommendedFeedsItem.tsx:150
 #: src/view/com/modals/ListAddRemoveUsers.tsx:264
@@ -156,7 +152,7 @@ msgstr "Ajouter un avertissement sur le contenu"
 
 #: src/view/screens/ProfileList.tsx:781
 msgid "Add a user to this list"
-msgstr "Ajouter un utilisateur à cette liste"
+msgstr "Ajouter un compte à cette liste"
 
 #: src/view/screens/Settings.tsx:370
 #: src/view/screens/Settings.tsx:379
@@ -173,7 +169,7 @@ msgstr "Ajouter un texte alt"
 #: src/view/screens/AppPasswords.tsx:143
 #: src/view/screens/AppPasswords.tsx:156
 msgid "Add App Password"
-msgstr ""
+msgstr "Ajouter un mot de passe d’application"
 
 #: src/view/com/modals/report/InputIssueDetails.tsx:41
 #: src/view/com/modals/report/Modal.tsx:191
@@ -207,7 +203,7 @@ msgstr "Ajouter à mes fils d’actu"
 
 #: src/view/com/auth/onboarding/RecommendedFeedsItem.tsx:139
 msgid "Added"
-msgstr ""
+msgstr "Ajouté"
 
 #: src/view/com/modals/ListAddRemoveUsers.tsx:191
 #: src/view/com/modals/UserAddRemoveLists.tsx:128
@@ -216,7 +212,7 @@ msgstr "Ajouté à la liste"
 
 #: src/view/com/feeds/FeedSourceCard.tsx:125
 msgid "Added to my feeds"
-msgstr ""
+msgstr "Ajouté à mes fils d’actu"
 
 #: src/view/screens/PreferencesHomeFeed.tsx:173
 msgid "Adjust the number of likes a reply must have to be shown in your feed."
@@ -228,7 +224,7 @@ msgstr "Contenu pour adultes"
 
 #: src/view/com/modals/ContentFilteringSettings.tsx:137
 msgid "Adult content can only be enabled via the Web at <0/>."
-msgstr ""
+msgstr "Le contenu pour adultes ne peut être activé que via le Web à <0/>."
 
 #: src/view/screens/Settings.tsx:617
 msgid "Advanced"
@@ -236,7 +232,7 @@ msgstr "Avancé"
 
 #: src/view/com/auth/login/ChooseAccountForm.tsx:98
 msgid "Already signed in as @{0}"
-msgstr ""
+msgstr "Déjà connecté·e en tant que @{0}"
 
 #: src/view/com/composer/photos/Gallery.tsx:130
 msgid "ALT"
@@ -248,7 +244,7 @@ msgstr "Texte Alt"
 
 #: src/view/com/composer/photos/Gallery.tsx:209
 msgid "Alt text describes images for blind and low-vision users, and helps give context to everyone."
-msgstr "Le texte Alt décrit les images pour les utilisateurs aveugles et malvoyants, et aide à donner un contexte à tout le monde."
+msgstr "Le texte Alt décrit les images pour les personnes aveugles et malvoyantes, et aide à donner un contexte à tout le monde."
 
 #: src/view/com/modals/VerifyEmail.tsx:124
 msgid "An email has been sent to {0}. It includes a confirmation code which you can enter below."
@@ -261,7 +257,7 @@ msgstr "Un courriel a été envoyé à votre ancienne adresse, {0}. Il comprend 
 #: src/view/com/profile/FollowButton.tsx:30
 #: src/view/com/profile/FollowButton.tsx:40
 msgid "An issue occurred, please try again."
-msgstr ""
+msgstr "Un problème est survenu, veuillez réessayer."
 
 #: src/view/com/notifications/FeedItem.tsx:240
 #: src/view/com/threadgate/WhoCanReply.tsx:178
@@ -274,19 +270,19 @@ msgstr "Langue de l’application"
 
 #: src/view/screens/AppPasswords.tsx:228
 msgid "App password deleted"
-msgstr ""
+msgstr "Mot de passe d’application supprimé"
 
 #: src/view/com/modals/AddAppPasswords.tsx:133
 msgid "App Password names can only contain letters, numbers, spaces, dashes, and underscores."
-msgstr ""
+msgstr "Les noms de mots de passe d’application ne peuvent contenir que des lettres, des chiffres, des espaces, des tirets et des tirets bas."
 
 #: src/view/com/modals/AddAppPasswords.tsx:98
 msgid "App Password names must be at least 4 characters long."
-msgstr ""
+msgstr "Les noms de mots de passe d’application doivent comporter au moins 4 caractères."
 
 #: src/view/screens/Settings.tsx:628
 msgid "App password settings"
-msgstr ""
+msgstr "Paramètres de mot de passe d’application"
 
 #: src/view/screens/Settings.tsx:637
 msgid "App passwords"
@@ -304,9 +300,6 @@ msgstr "Faire appel de l’avertissement sur le contenu"
 #: src/view/com/modals/AppealLabel.tsx:65
 msgid "Appeal Content Warning"
 msgstr "Appel de l’avertissement sur le contenu"
-
-#~ msgid "Appeal Decision"
-#~ msgstr "Appel de la décision"
 
 #: src/view/com/util/moderation/LabelInfo.tsx:52
 msgid "Appeal this decision"
@@ -343,7 +336,7 @@ msgstr "Nudité artistique ou non érotique."
 #: src/view/com/post-thread/PostThread.tsx:400
 msgctxt "action"
 msgid "Back"
-msgstr ""
+msgstr "Retour"
 
 #: src/view/com/auth/create/CreateAccount.tsx:141
 #: src/view/com/auth/login/ChooseAccountForm.tsx:151
@@ -391,11 +384,11 @@ msgstr "Bloquer ces comptes ?"
 
 #: src/view/screens/ProfileList.tsx:319
 msgid "Block this List"
-msgstr ""
+msgstr "Bloquer cette liste"
 
 #: src/view/com/util/post-embeds/QuoteEmbed.tsx:57
 msgid "Blocked"
-msgstr ""
+msgstr "Bloqué"
 
 #: src/view/screens/Moderation.tsx:123
 msgid "Blocked accounts"
@@ -451,7 +444,7 @@ msgstr "Bluesky distribue des invitations pour construire une communauté plus s
 
 #: src/view/screens/Moderation.tsx:225
 msgid "Bluesky will not show your profile and posts to logged-out users. Other apps may not honor this request. This does not make your account private."
-msgstr "Bluesky n’affichera pas votre profil et vos messages à des utilisateurs non connectés. Il est possible que d’autres applications n’honorent pas cette demande. Cela ne privatise pas votre compte."
+msgstr "Bluesky n’affichera pas votre profil et vos messages à des personnes non connectées. Il est possible que d’autres applications n’honorent pas cette demande. Cela ne privatise pas votre compte."
 
 #: src/view/com/modals/ServerInput.tsx:78
 msgid "Bluesky.Social"
@@ -467,23 +460,23 @@ msgstr "Affaires"
 
 #: src/view/com/modals/ServerInput.tsx:115
 msgid "Button disabled. Input custom domain to proceed."
-msgstr ""
+msgstr "Bouton désactivé. Saisissez un domaine personnalisé pour continuer."
 
 #: src/view/com/profile/ProfileSubpageHeader.tsx:157
 msgid "by —"
-msgstr ""
+msgstr "par —"
 
 #: src/view/com/auth/onboarding/RecommendedFeedsItem.tsx:100
 msgid "by {0}"
-msgstr ""
+msgstr "par {0}"
 
 #: src/view/com/profile/ProfileSubpageHeader.tsx:161
 msgid "by <0/>"
-msgstr ""
+msgstr "par <0/>"
 
 #: src/view/com/profile/ProfileSubpageHeader.tsx:159
 msgid "by you"
-msgstr ""
+msgstr "par vous"
 
 #: src/view/com/composer/photos/OpenCameraBtn.tsx:60
 #: src/view/com/util/UserAvatar.tsx:221
@@ -502,7 +495,7 @@ msgstr "Ne peut contenir que des lettres, des chiffres, des espaces, des tirets 
 #: src/view/com/modals/DeleteAccount.tsx:227
 msgctxt "action"
 msgid "Cancel"
-msgstr ""
+msgstr "Annuler"
 
 #: src/view/com/composer/Composer.tsx:299
 #: src/view/com/composer/Composer.tsx:304
@@ -525,10 +518,6 @@ msgstr "Annuler"
 #: src/view/com/modals/DeleteAccount.tsx:223
 msgid "Cancel account deletion"
 msgstr "Annuler la suppression de compte"
-
-#: src/view/com/modals/AltImage.tsx:123
-#~ msgid "Cancel add image alt text"
-#~ msgstr "Annuler l’ajout d’un texte alt à l’image"
 
 #: src/view/com/modals/ChangeHandle.tsx:149
 msgid "Cancel change handle"
@@ -558,20 +547,16 @@ msgstr "Annuler l’inscription sur la liste d’attente"
 #: src/view/screens/Settings.tsx:321
 msgctxt "action"
 msgid "Change"
-msgstr ""
-
-#: src/view/screens/Settings.tsx:306
-#~ msgid "Change"
-#~ msgstr "Changer"
+msgstr "Modifier"
 
 #: src/view/screens/Settings.tsx:649
 #: src/view/screens/Settings.tsx:658
 msgid "Change handle"
-msgstr "Changer le pseudo"
+msgstr "Modifier le pseudo"
 
 #: src/view/com/modals/ChangeHandle.tsx:161
 msgid "Change Handle"
-msgstr "Changer le pseudo"
+msgstr "Modifier le pseudo"
 
 #: src/view/com/modals/VerifyEmail.tsx:147
 msgid "Change my email"
@@ -579,7 +564,7 @@ msgstr "Modifier mon e-mail"
 
 #: src/view/com/modals/ChangeEmail.tsx:109
 msgid "Change Your Email"
-msgstr "Modifiez votre e-mail"
+msgstr "Modifier votre e-mail"
 
 #: src/view/com/auth/onboarding/RecommendedFeeds.tsx:121
 msgid "Check out some recommended feeds. Tap + to add them to your list of pinned feeds."
@@ -587,7 +572,7 @@ msgstr "Consultez quelques fils d’actu recommandés. Appuyez sur + pour les aj
 
 #: src/view/com/auth/onboarding/RecommendedFollows.tsx:185
 msgid "Check out some recommended users. Follow them to see similar users."
-msgstr "Consultez quelques utilisateurs recommandés. Suivez-les pour voir des utilisateurs similaires."
+msgstr "Consultez quelques comptes recommandés. Suivez-les pour voir des personnes similaires."
 
 #: src/view/com/modals/DeleteAccount.tsx:165
 msgid "Check your inbox for an email with the confirmation code to enter below:"
@@ -599,7 +584,7 @@ msgstr "Choisir « Tout le monde » ou « Personne »"
 
 #: src/view/screens/Settings.tsx:650
 msgid "Choose a new Bluesky username or create"
-msgstr ""
+msgstr "Choisir un nouveau pseudo Bluesky ou en créer un"
 
 #: src/view/com/modals/ServerInput.tsx:38
 msgid "Choose Service"
@@ -639,7 +624,7 @@ msgstr "Effacer la recherche"
 
 #: src/view/screens/Support.tsx:40
 msgid "click here"
-msgstr ""
+msgstr "cliquez ici"
 
 #: src/view/com/auth/login/PasswordUpdatedForm.tsx:38
 msgid "Close alert"
@@ -663,23 +648,23 @@ msgstr "Fermer le pied de page de navigation"
 
 #: src/view/shell/index.web.tsx:50
 msgid "Closes bottom navigation bar"
-msgstr ""
+msgstr "Ferme la barre de navigation du bas"
 
 #: src/view/com/auth/login/PasswordUpdatedForm.tsx:39
 msgid "Closes password update alert"
-msgstr ""
+msgstr "Ferme la notification de mise à jour du mot de passe"
 
 #: src/view/com/composer/Composer.tsx:301
 msgid "Closes post composer and discards post draft"
-msgstr ""
+msgstr "Ferme la fenêtre de rédaction et supprime le brouillon"
 
 #: src/view/com/lightbox/ImageViewing/components/ImageDefaultHeader.tsx:27
 msgid "Closes viewer for header image"
-msgstr ""
+msgstr "Ferme la visionneuse pour l’image d’en-tête"
 
 #: src/view/com/notifications/FeedItem.tsx:321
 msgid "Collapses list of users for a given notification"
-msgstr ""
+msgstr "Réduit la liste des comptes pour une notification donnée"
 
 #: src/Navigation.tsx:229
 #: src/view/screens/CommunityGuidelines.tsx:32
@@ -688,7 +673,7 @@ msgstr "Directives communautaires"
 
 #: src/view/com/composer/Composer.tsx:416
 msgid "Compose posts up to {MAX_GRAPHEME_LENGTH} characters in length"
-msgstr ""
+msgstr "Permet d’écrire des messages de {MAX_GRAPHEME_LENGTH} caractères maximum"
 
 #: src/view/com/composer/Prompt.tsx:24
 msgid "Compose reply"
@@ -698,7 +683,7 @@ msgstr "Rédiger une réponse"
 #: src/view/com/modals/Confirm.tsx:78
 msgctxt "action"
 msgid "Confirm"
-msgstr ""
+msgstr "Confirmer"
 
 #: src/view/com/modals/AppealLabel.tsx:98
 #: src/view/com/modals/SelfLabel.tsx:154
@@ -724,7 +709,7 @@ msgstr "Confirmer la suppression du compte"
 
 #: src/view/com/modals/ContentFilteringSettings.tsx:151
 msgid "Confirm your age to enable adult content."
-msgstr ""
+msgstr "Confirmez votre âge pour activer le contenu pour adultes."
 
 #: src/view/com/modals/ChangeEmail.tsx:157
 #: src/view/com/modals/DeleteAccount.tsx:178
@@ -734,7 +719,7 @@ msgstr "Code de confirmation"
 
 #: src/view/com/modals/Waitlist.tsx:120
 msgid "Confirms signing up {email} to the waitlist"
-msgstr ""
+msgstr "Confirme l’inscription de {email} sur la liste d’attente"
 
 #: src/view/com/auth/create/CreateAccount.tsx:174
 #: src/view/com/auth/login/LoginForm.tsx:275
@@ -756,7 +741,7 @@ msgstr "Langues du contenu"
 
 #: src/view/com/modals/ModerationDetails.tsx:65
 msgid "Content Not Available"
-msgstr ""
+msgstr "Contenu non disponible"
 
 #: src/view/com/modals/ModerationDetails.tsx:33
 #: src/view/com/util/moderation/ScreenHider.tsx:78
@@ -779,17 +764,17 @@ msgstr "Copié"
 
 #: src/view/screens/Settings.tsx:236
 msgid "Copied build version to clipboard"
-msgstr ""
+msgstr "Version de build copiée dans le presse-papier"
 
 #: src/view/com/modals/AddAppPasswords.tsx:75
 #: src/view/com/modals/InviteCodes.tsx:152
 #: src/view/com/util/forms/PostDropdownBtn.tsx:110
 msgid "Copied to clipboard"
-msgstr ""
+msgstr "Copié dans le presse-papier"
 
 #: src/view/com/modals/AddAppPasswords.tsx:191
 msgid "Copies app password"
-msgstr ""
+msgstr "Copie le mot de passe d’application"
 
 #: src/view/com/modals/AddAppPasswords.tsx:190
 msgid "Copy"
@@ -797,7 +782,7 @@ msgstr "Copie"
 
 #: src/view/screens/ProfileList.tsx:396
 msgid "Copy link to list"
-msgstr "Copier le lien dans la liste"
+msgstr "Copier le lien vers la liste"
 
 #: src/view/com/util/forms/PostDropdownBtn.tsx:151
 msgid "Copy link to post"
@@ -805,7 +790,7 @@ msgstr "Copier le lien vers le post"
 
 #: src/view/com/profile/ProfileHeader.tsx:342
 msgid "Copy link to profile"
-msgstr "Copier le lien sur le profil"
+msgstr "Copier le lien vers le profil"
 
 #: src/view/com/util/forms/PostDropdownBtn.tsx:137
 msgid "Copy post text"
@@ -832,7 +817,7 @@ msgstr "Créer un nouveau compte"
 
 #: src/view/screens/Settings.tsx:371
 msgid "Create a new Bluesky account"
-msgstr ""
+msgstr "Créer un compte Bluesky"
 
 #: src/view/com/auth/create/CreateAccount.tsx:121
 msgid "Create Account"
@@ -840,7 +825,7 @@ msgstr "Créer un compte"
 
 #: src/view/com/modals/AddAppPasswords.tsx:228
 msgid "Create App Password"
-msgstr ""
+msgstr "Créer un mot de passe d’application"
 
 #: src/view/com/auth/HomeLoggedOutCTA.tsx:54
 #: src/view/com/auth/SplashScreen.tsx:43
@@ -853,15 +838,15 @@ msgstr "{0} créé"
 
 #: src/view/screens/ProfileFeed.tsx:625
 msgid "Created by <0/>"
-msgstr ""
+msgstr "Créée par <0/>"
 
 #: src/view/screens/ProfileFeed.tsx:623
 msgid "Created by you"
-msgstr ""
+msgstr "Créée par vous"
 
 #: src/view/com/composer/Composer.tsx:447
 msgid "Creates a card with a thumbnail. The card links to {url}"
-msgstr ""
+msgstr "Crée une carte avec une miniature. La carte pointe vers {url}"
 
 #: src/view/com/modals/ChangeHandle.tsx:389
 #: src/view/com/modals/ServerInput.tsx:102
@@ -870,7 +855,7 @@ msgstr "Domaine personnalisé"
 
 #: src/view/screens/PreferencesExternalEmbeds.tsx:55
 msgid "Customize media from external sites."
-msgstr ""
+msgstr "Personnaliser les médias provenant de sites externes."
 
 #: src/view/screens/Settings.tsx:663
 msgid "Danger Zone"
@@ -878,19 +863,19 @@ msgstr "Zone de danger"
 
 #: src/view/screens/Settings.tsx:466
 msgid "Dark"
-msgstr ""
+msgstr "Sombre"
 
 #: src/view/screens/Debug.tsx:63
 msgid "Dark mode"
-msgstr ""
+msgstr "Mode sombre"
 
 #: src/Navigation.tsx:204
 msgid "Debug"
-msgstr ""
+msgstr "Débug"
 
 #: src/view/screens/Debug.tsx:83
 msgid "Debug panel"
-msgstr ""
+msgstr "Panneau de débug"
 
 #: src/view/screens/Settings.tsx:670
 msgid "Delete account"
@@ -928,7 +913,7 @@ msgstr "Supprimer ce post ?"
 
 #: src/view/com/util/post-embeds/QuoteEmbed.tsx:66
 msgid "Deleted"
-msgstr ""
+msgstr "Supprimé"
 
 #: src/view/com/post-thread/PostThread.tsx:246
 msgid "Deleted post."
@@ -963,12 +948,12 @@ msgstr "Ignorer le brouillon"
 
 #: src/view/screens/Moderation.tsx:207
 msgid "Discourage apps from showing my account to logged-out users"
-msgstr "Empêcher les applis de montrer mon compte aux utilisateurs déconnectés"
+msgstr "Empêcher les applis de montrer mon compte aux personnes déconnectées"
 
 #: src/view/com/posts/FollowingEmptyState.tsx:74
 #: src/view/com/posts/FollowingEndOfFeed.tsx:75
 msgid "Discover new custom feeds"
-msgstr ""
+msgstr "Découvrir des fils d’actu personnalisés"
 
 #: src/view/screens/Feeds.tsx:409
 msgid "Discover new feeds"
@@ -988,7 +973,7 @@ msgstr "Domaine vérifié !"
 
 #: src/view/com/auth/create/Step2.tsx:83
 msgid "Don't have an invite code?"
-msgstr ""
+msgstr "Pas de code d’invitation ?"
 
 #: src/view/com/auth/onboarding/RecommendedFollows.tsx:86
 #: src/view/com/modals/EditImage.tsx:333
@@ -1001,7 +986,7 @@ msgstr ""
 #: src/view/screens/PreferencesThreads.tsx:162
 msgctxt "action"
 msgid "Done"
-msgstr ""
+msgstr "Terminer"
 
 #: src/view/com/modals/AddAppPasswords.tsx:228
 #: src/view/com/modals/AltImage.tsx:115
@@ -1021,31 +1006,31 @@ msgstr "Terminé{extraText}"
 
 #: src/view/com/auth/login/ChooseAccountForm.tsx:45
 msgid "Double tap to sign in"
-msgstr ""
+msgstr "Tapotez deux fois pour vous connecter"
 
 #: src/view/com/modals/EditProfile.tsx:185
 msgid "e.g. Alice Roberts"
-msgstr ""
+msgstr "ex. Alice Dupont"
 
 #: src/view/com/modals/EditProfile.tsx:203
 msgid "e.g. Artist, dog-lover, and avid reader."
-msgstr ""
+msgstr "ex. Artiste, amoureuse des chiens et lectrice passionnée."
 
 #: src/view/com/modals/CreateOrEditList.tsx:225
 msgid "e.g. Great Posters"
-msgstr ""
+msgstr "ex. Les meilleurs comptes"
 
 #: src/view/com/modals/CreateOrEditList.tsx:226
 msgid "e.g. Spammers"
-msgstr ""
+msgstr "ex. Spammeurs"
 
 #: src/view/com/modals/CreateOrEditList.tsx:246
 msgid "e.g. The posters who never miss."
-msgstr ""
+msgstr "ex. Ces comptes qui ne ratent jamais leur coup."
 
 #: src/view/com/modals/CreateOrEditList.tsx:247
 msgid "e.g. Users that repeatedly reply with ads."
-msgstr ""
+msgstr "ex. Les comptes qui répondent toujours avec des pubs."
 
 #: src/view/com/modals/InviteCodes.tsx:96
 msgid "Each code works once. You'll receive more invite codes periodically."
@@ -1054,7 +1039,7 @@ msgstr "Chaque code ne fonctionne qu’une seule fois. Vous recevrez régulière
 #: src/view/com/lists/ListMembers.tsx:149
 msgctxt "action"
 msgid "Edit"
-msgstr ""
+msgstr "Modifier"
 
 #: src/view/com/composer/photos/Gallery.tsx:144
 #: src/view/com/modals/EditImage.tsx:207
@@ -1067,7 +1052,7 @@ msgstr "Modifier les infos de la liste"
 
 #: src/view/com/modals/CreateOrEditList.tsx:193
 msgid "Edit Moderation List"
-msgstr ""
+msgstr "Modifier la liste de modération"
 
 #: src/Navigation.tsx:244
 #: src/view/screens/Feeds.tsx:371
@@ -1093,15 +1078,15 @@ msgstr "Modifier les fils d’actu enregistrés"
 
 #: src/view/com/modals/CreateOrEditList.tsx:188
 msgid "Edit User List"
-msgstr ""
+msgstr "Modifier la liste de compte"
 
 #: src/view/com/modals/EditProfile.tsx:193
 msgid "Edit your display name"
-msgstr ""
+msgstr "Modifier votre nom d’affichage"
 
 #: src/view/com/modals/EditProfile.tsx:211
 msgid "Edit your profile description"
-msgstr ""
+msgstr "Modifier votre description de profil"
 
 #: src/view/com/auth/create/Step2.tsx:108
 #: src/view/com/auth/login/ForgotPasswordForm.tsx:152
@@ -1118,7 +1103,7 @@ msgstr "Adresse e-mail"
 #: src/view/com/modals/ChangeEmail.tsx:56
 #: src/view/com/modals/ChangeEmail.tsx:88
 msgid "Email updated"
-msgstr ""
+msgstr "Adresse e-mail mise à jour"
 
 #: src/view/com/modals/ChangeEmail.tsx:111
 msgid "Email Updated"
@@ -1126,7 +1111,7 @@ msgstr "E-mail mis à jour"
 
 #: src/view/com/modals/VerifyEmail.tsx:78
 msgid "Email verified"
-msgstr ""
+msgstr "Adresse e-mail vérifiée"
 
 #: src/view/screens/Settings.tsx:305
 msgid "Email:"
@@ -1134,19 +1119,19 @@ msgstr "E-mail :"
 
 #: src/view/com/modals/EmbedConsent.tsx:113
 msgid "Enable {0} only"
-msgstr ""
+msgstr "Activer {0} uniquement"
 
 #: src/view/com/modals/ContentFilteringSettings.tsx:162
 msgid "Enable Adult Content"
-msgstr ""
+msgstr "Activer le contenu pour adultes"
 
 #: src/view/com/modals/EmbedConsent.tsx:97
 msgid "Enable External Media"
-msgstr ""
+msgstr "Activer les médias externes"
 
 #: src/view/screens/PreferencesExternalEmbeds.tsx:75
 msgid "Enable media players for"
-msgstr ""
+msgstr "Activer les lecteurs médias pour"
 
 #: src/view/screens/PreferencesHomeFeed.tsx:147
 msgid "Enable this setting to only see replies between people you follow."
@@ -1158,15 +1143,15 @@ msgstr "Fin du fil d’actu"
 
 #: src/view/com/modals/AddAppPasswords.tsx:165
 msgid "Enter a name for this App Password"
-msgstr ""
+msgstr "Entrer un nom pour ce mot de passe d’application"
 
 #: src/view/com/modals/VerifyEmail.tsx:105
 msgid "Enter Confirmation Code"
-msgstr ""
+msgstr "Entrer un code de confirmation"
 
 #: src/view/com/auth/create/Step1.tsx:71
 msgid "Enter the address of your provider:"
-msgstr "Saisissez l’adresse de votre fournisseur :"
+msgstr "Saisissez l’adresse de votre hébergeur :"
 
 #: src/view/com/modals/ChangeHandle.tsx:371
 msgid "Enter the domain you want to use"
@@ -1179,11 +1164,11 @@ msgstr "Saisissez l’e-mail que vous avez utilisé pour créer votre compte. No
 #: src/view/com/auth/create/Step2.tsx:157
 #: src/view/com/modals/BirthDateSettings.tsx:74
 msgid "Enter your birth date"
-msgstr ""
+msgstr "Saisissez votre date de naissance"
 
 #: src/view/com/modals/Waitlist.tsx:78
 msgid "Enter your email"
-msgstr ""
+msgstr "Entrez votre e-mail"
 
 #: src/view/com/auth/create/Step2.tsx:104
 msgid "Enter your email address"
@@ -1191,7 +1176,7 @@ msgstr "Entrez votre e-mail"
 
 #: src/view/com/modals/ChangeEmail.tsx:41
 msgid "Enter your new email above"
-msgstr ""
+msgstr "Entrez votre nouvel e-mail ci-dessus"
 
 #: src/view/com/modals/ChangeEmail.tsx:117
 msgid "Enter your new email address below."
@@ -1199,7 +1184,7 @@ msgstr "Entrez votre nouvelle e-mail ci-dessous."
 
 #: src/view/com/auth/login/Login.tsx:99
 msgid "Enter your username and password"
-msgstr "Entrez votre nom d’utilisateur et votre mot de passe"
+msgstr "Entrez votre pseudo et votre mot de passe"
 
 #: src/view/screens/Search/Search.tsx:105
 msgid "Error:"
@@ -1211,20 +1196,20 @@ msgstr "Tout le monde"
 
 #: src/view/com/modals/ChangeHandle.tsx:150
 msgid "Exits handle change process"
-msgstr ""
+msgstr "Sors du processus de changement de pseudo"
 
 #: src/view/com/lightbox/Lightbox.web.tsx:113
 msgid "Exits image view"
-msgstr ""
+msgstr "Sors de la vue de l’image"
 
 #: src/view/com/modals/ListAddRemoveUsers.tsx:88
 #: src/view/shell/desktop/Search.tsx:182
 msgid "Exits inputting search query"
-msgstr ""
+msgstr "Sors de la saisie de la recherche"
 
 #: src/view/com/modals/Waitlist.tsx:138
 msgid "Exits signing up for waitlist with {email}"
-msgstr ""
+msgstr "Sors de l’inscription sur la liste d’attente avec {email}"
 
 #: src/view/com/lightbox/Lightbox.web.tsx:156
 msgid "Expand alt text"
@@ -1233,39 +1218,39 @@ msgstr "Développer le texte alt"
 #: src/view/com/composer/ComposerReplyTo.tsx:81
 #: src/view/com/composer/ComposerReplyTo.tsx:84
 msgid "Expand or collapse the full post you are replying to"
-msgstr ""
+msgstr "Étend ou rétrécit le post complet auquel vous répondez"
 
 #: src/view/com/modals/EmbedConsent.tsx:64
 msgid "External Media"
-msgstr ""
+msgstr "Média externe"
 
 #: src/view/com/modals/EmbedConsent.tsx:75
 #: src/view/screens/PreferencesExternalEmbeds.tsx:66
 msgid "External media may allow websites to collect information about you and your device. No information is sent or requested until you press the \"play\" button."
-msgstr ""
+msgstr "Les médias externes peuvent permettre à des sites web de collecter des informations sur vous et votre appareil. Aucune information n’est envoyée ou demandée tant que vous n’appuyez pas sur le bouton de lecture."
 
 #: src/Navigation.tsx:260
 #: src/view/screens/PreferencesExternalEmbeds.tsx:52
 #: src/view/screens/Settings.tsx:610
 msgid "External Media Preferences"
-msgstr ""
+msgstr "Préférences sur les médias externes"
 
 #: src/view/screens/Settings.tsx:601
 msgid "External media settings"
-msgstr ""
+msgstr "Préférences sur les médias externes"
 
 #: src/view/com/modals/AddAppPasswords.tsx:114
 #: src/view/com/modals/AddAppPasswords.tsx:118
 msgid "Failed to create app password."
-msgstr ""
+msgstr "Échec de la création du mot de passe d’application."
 
 #: src/view/com/modals/CreateOrEditList.tsx:148
 msgid "Failed to create the list. Check your internet connection and try again."
-msgstr ""
+msgstr "Échec de la création de la liste. Vérifiez votre connexion Internet et réessayez."
 
 #: src/view/com/util/forms/PostDropdownBtn.tsx:86
 msgid "Failed to delete post, please try again"
-msgstr ""
+msgstr "Échec de la suppression du post, veuillez réessayer"
 
 #: src/view/com/auth/onboarding/RecommendedFeeds.tsx:109
 #: src/view/com/auth/onboarding/RecommendedFeeds.tsx:141
@@ -1274,11 +1259,11 @@ msgstr "Échec du chargement des fils d’actu recommandés"
 
 #: src/Navigation.tsx:194
 msgid "Feed"
-msgstr ""
+msgstr "Fil d’actu"
 
 #: src/view/com/feeds/FeedSourceCard.tsx:229
 msgid "Feed by {0}"
-msgstr ""
+msgstr "Fil d’actu par {0}"
 
 #: src/view/screens/Feeds.tsx:560
 msgid "Feed offline"
@@ -1305,25 +1290,25 @@ msgstr "Fil d’actu"
 
 #: src/view/com/auth/onboarding/RecommendedFeeds.tsx:57
 msgid "Feeds are created by users to curate content. Choose some feeds that you find interesting."
-msgstr "Les fils d’actu sont créés par les utilisateurs pour rassembler du contenu. Choisissez des fils d’actu qui vous intéressent."
+msgstr "Les fils d’actu sont créés par d’autres personnes pour rassembler du contenu. Choisissez des fils d’actu qui vous intéressent."
 
 #: src/view/screens/SavedFeeds.tsx:156
 msgid "Feeds are custom algorithms that users build with a little coding expertise. <0/> for more information."
-msgstr "Les fils d’actu sont des algorithmes personnalisés que les utilisateurs construisent avec un peu d’expertise en codage. <0/> pour obtenir de plus amples informations."
+msgstr "Les fils d’actu sont des algorithmes personnalisés qui se construisent avec un peu d’expertise en codage. <0/> pour plus d’informations."
 
 #: src/view/com/posts/CustomFeedEmptyState.tsx:47
 #: src/view/com/posts/FollowingEmptyState.tsx:57
 #: src/view/com/posts/FollowingEndOfFeed.tsx:58
 msgid "Find accounts to follow"
-msgstr ""
+msgstr "Trouver des comptes à suivre"
 
 #: src/view/screens/Search/Search.tsx:427
 msgid "Find users on Bluesky"
-msgstr "Trouver des utilisateurs sur Bluesky"
+msgstr "Trouver des comptes sur Bluesky"
 
 #: src/view/screens/Search/Search.tsx:425
 msgid "Find users with the search tool on the right"
-msgstr "Trouvez des utilisateurs à l’aide de l’outil de recherche, à droite"
+msgstr "Trouvez des comptes à l’aide de l’outil de recherche, à droite"
 
 #: src/view/com/auth/onboarding/RecommendedFollowsItem.tsx:150
 msgid "Finding similar accounts..."
@@ -1331,25 +1316,25 @@ msgstr "Recherche de comptes similaires…"
 
 #: src/view/screens/PreferencesHomeFeed.tsx:111
 msgid "Fine-tune the content you see on your home screen."
-msgstr "Affinez le contenu de votre écran d’accueil."
+msgstr "Affine le contenu affiché sur votre écran d’accueil."
 
 #: src/view/screens/PreferencesThreads.tsx:60
 msgid "Fine-tune the discussion threads."
-msgstr "Affiner les fils de discussion."
+msgstr "Affine les fils de discussion."
 
 #: src/view/com/modals/EditImage.tsx:115
 msgid "Flip horizontal"
-msgstr ""
+msgstr "Miroir horizontal"
 
 #: src/view/com/modals/EditImage.tsx:120
 #: src/view/com/modals/EditImage.tsx:287
 msgid "Flip vertically"
-msgstr ""
+msgstr "Miroir vertical"
 
 #: src/view/com/profile/FollowButton.tsx:64
 msgctxt "action"
 msgid "Follow"
-msgstr ""
+msgstr "Suivre"
 
 #: src/view/com/profile/ProfileHeader.tsx:552
 msgid "Follow"
@@ -1357,35 +1342,31 @@ msgstr "Suivre"
 
 #: src/view/com/profile/ProfileHeader.tsx:543
 msgid "Follow {0}"
-msgstr ""
+msgstr "Suivre {0}"
 
 #: src/view/com/auth/onboarding/RecommendedFollows.tsx:64
 msgid "Follow some users to get started. We can recommend you more users based on who you find interesting."
-msgstr "Suivez quelques utilisateurs pour commencer. Nous pouvons vous recommander d’autres utilisateurs en fonction des personnes qui vous intéressent."
+msgstr "Suivez quelques comptes pour commencer. Nous pouvons vous recommander d’autres comptes en fonction des personnes qui vous intéressent."
 
 #: src/view/com/profile/ProfileCard.tsx:194
 msgid "Followed by {0}"
-msgstr ""
+msgstr "Suivi par {0}"
 
 #: src/view/com/modals/Threadgate.tsx:98
 msgid "Followed users"
-msgstr "Utilisateurs suivis"
+msgstr "Comptes suivis"
 
 #: src/view/screens/PreferencesHomeFeed.tsx:154
 msgid "Followed users only"
-msgstr "Utilisateurs suivis uniquement"
+msgstr "Comptes suivis uniquement"
 
 #: src/view/com/notifications/FeedItem.tsx:166
 msgid "followed you"
-msgstr ""
+msgstr "vous suit"
 
 #: src/view/screens/ProfileFollowers.tsx:25
 msgid "Followers"
-msgstr "Followers"
-
-#: src/view/com/profile/ProfileHeader.tsx:624
-#~ msgid "following"
-#~ msgstr "suivi"
+msgstr "Abonné·e·s"
 
 #: src/view/com/profile/ProfileHeader.tsx:534
 #: src/view/screens/ProfileFollows.tsx:25
@@ -1394,7 +1375,7 @@ msgstr "Suivi"
 
 #: src/view/com/profile/ProfileHeader.tsx:196
 msgid "Following {0}"
-msgstr ""
+msgstr "Suit {0}"
 
 #: src/view/com/profile/ProfileHeader.tsx:585
 msgid "Follows you"
@@ -1402,7 +1383,7 @@ msgstr "Vous suit"
 
 #: src/view/com/profile/ProfileCard.tsx:141
 msgid "Follows You"
-msgstr ""
+msgstr "Vous suit"
 
 #: src/view/com/modals/DeleteAccount.tsx:107
 msgid "For security reasons, we'll need to send a confirmation code to your email address."
@@ -1428,7 +1409,7 @@ msgstr "Mot de passe oublié"
 #: src/view/com/posts/FeedItem.tsx:188
 msgctxt "from-feed"
 msgid "From <0/>"
-msgstr ""
+msgstr "Tiré de <0/>"
 
 #: src/view/com/composer/photos/SelectPhotoBtn.tsx:43
 msgid "Gallery"
@@ -1476,7 +1457,7 @@ msgstr "Voici le mot de passe de votre appli."
 #: src/view/com/notifications/FeedItem.tsx:329
 msgctxt "action"
 msgid "Hide"
-msgstr ""
+msgstr "Cacher"
 
 #: src/view/com/modals/ContentFilteringSettings.tsx:246
 #: src/view/com/util/moderation/ContentHider.tsx:105
@@ -1491,7 +1472,7 @@ msgstr "Cacher ce post"
 #: src/view/com/util/moderation/ContentHider.tsx:67
 #: src/view/com/util/moderation/PostHider.tsx:61
 msgid "Hide the content"
-msgstr ""
+msgstr "Cacher ce contenu"
 
 #: src/view/com/util/forms/PostDropdownBtn.tsx:189
 msgid "Hide this post?"
@@ -1499,31 +1480,31 @@ msgstr "Cacher ce post ?"
 
 #: src/view/com/notifications/FeedItem.tsx:319
 msgid "Hide user list"
-msgstr "Cacher la liste des utilisateurs"
+msgstr "Cacher la liste des comptes"
 
 #: src/view/com/profile/ProfileHeader.tsx:526
 msgid "Hides posts from {0} in your feed"
-msgstr ""
+msgstr "Masque les posts de {0} dans votre fil d’actu"
 
 #: src/view/com/posts/FeedErrorMessage.tsx:111
 msgid "Hmm, some kind of issue occurred when contacting the feed server. Please let the feed owner know about this issue."
-msgstr "Hmm, un problème s’est produit avec le serveur de fils d’actu. Veuillez informer le propriétaire du fil d’actu de ce problème."
+msgstr "Hmm, un problème s’est produit avec le serveur de fils d’actu. Veuillez informer la personne à l’origine du fil d’actu de ce problème."
 
 #: src/view/com/posts/FeedErrorMessage.tsx:99
 msgid "Hmm, the feed server appears to be misconfigured. Please let the feed owner know about this issue."
-msgstr "Hmm, le serveur du fils d’actu semble être mal configuré. Veuillez informer le propriétaire du fil d’actu de ce problème."
+msgstr "Hmm, le serveur du fils d’actu semble être mal configuré. Veuillez informer la personne à l’origine du fil d’actu de ce problème."
 
 #: src/view/com/posts/FeedErrorMessage.tsx:105
 msgid "Hmm, the feed server appears to be offline. Please let the feed owner know about this issue."
-msgstr "Mmm… le serveur de fils d’actu semble être hors ligne. Veuillez informer le propriétaire du fil d’actu de ce problème."
+msgstr "Mmm… le serveur de fils d’actu semble être hors ligne. Veuillez informer la personne à l’origine du fil d’actu de ce problème."
 
 #: src/view/com/posts/FeedErrorMessage.tsx:102
 msgid "Hmm, the feed server gave a bad response. Please let the feed owner know about this issue."
-msgstr "Mmm… le serveur de fils d’actu ne répond pas. Veuillez informer le propriétaire du fil d’actu de ce problème."
+msgstr "Mmm… le serveur de fils d’actu ne répond pas. Veuillez informer la personne à l’origine du fil d’actu de ce problème."
 
 #: src/view/com/posts/FeedErrorMessage.tsx:96
 msgid "Hmm, we're having trouble finding this feed. It may have been deleted."
-msgstr "Hmm, nous n’arrivons pas à trouver ce fils d’actu. Il a peut-être été supprimé."
+msgstr "Hmm, nous n’arrivons pas à trouver ce fil d’actu. Il a peut-être été supprimé."
 
 #: src/Navigation.tsx:432
 #: src/view/shell/bottom-bar/BottomBar.tsx:137
@@ -1542,7 +1523,7 @@ msgstr "Préférences de fils d’actu de l’accueil"
 
 #: src/view/com/auth/login/ForgotPasswordForm.tsx:116
 msgid "Hosting provider"
-msgstr "Fournisseur d’hébergement"
+msgstr "Hébergeur"
 
 #: src/view/com/auth/create/Step1.tsx:76
 #: src/view/com/auth/create/Step1.tsx:81
@@ -1555,7 +1536,7 @@ msgstr "J’ai un code"
 
 #: src/view/com/modals/VerifyEmail.tsx:216
 msgid "I have a confirmation code"
-msgstr ""
+msgstr "J’ai un code de confirmation"
 
 #: src/view/com/modals/ChangeHandle.tsx:283
 msgid "I have my own domain"
@@ -1563,7 +1544,7 @@ msgstr "J’ai mon propre domaine"
 
 #: src/view/com/lightbox/Lightbox.web.tsx:158
 msgid "If alt text is long, toggles alt text expanded state"
-msgstr ""
+msgstr "Si le texte alternatif est trop long, affiche le texte alternatif complet"
 
 #: src/view/com/modals/SelfLabel.tsx:127
 msgid "If none are selected, suitable for all ages."
@@ -1571,7 +1552,7 @@ msgstr "Si rien n’est sélectionné, il n’y a pas de restriction d’âge."
 
 #: src/view/com/util/images/Gallery.tsx:37
 msgid "Image"
-msgstr ""
+msgstr "Image"
 
 #: src/view/com/modals/AltImage.tsx:97
 msgid "Image alt text"
@@ -1584,63 +1565,63 @@ msgstr "Options d’images"
 
 #: src/view/com/auth/login/SetNewPasswordForm.tsx:110
 msgid "Input code sent to your email for password reset"
-msgstr ""
+msgstr "Entrez le code envoyé à votre e-mail pour réinitialiser le mot de passe"
 
 #: src/view/com/modals/DeleteAccount.tsx:180
 msgid "Input confirmation code for account deletion"
-msgstr ""
+msgstr "Entrez le code de confirmation pour supprimer le compte"
 
 #: src/view/com/auth/create/Step2.tsx:109
 msgid "Input email for Bluesky waitlist"
-msgstr ""
+msgstr "Entrez l’e-mail pour la liste d’attente de Bluesky"
 
 #: src/view/com/auth/create/Step1.tsx:80
 msgid "Input hosting provider address"
-msgstr ""
+msgstr "Entrez l’adresse de l’hébergeur"
 
 #: src/view/com/auth/create/Step2.tsx:73
 msgid "Input invite code to proceed"
-msgstr ""
+msgstr "Entrez le code d’invitation pour continuer"
 
 #: src/view/com/modals/AddAppPasswords.tsx:182
 msgid "Input name for app password"
-msgstr ""
+msgstr "Entrez le nom du mot de passe de l’appli"
 
 #: src/view/com/auth/login/SetNewPasswordForm.tsx:133
 msgid "Input new password"
-msgstr ""
+msgstr "Entrez le nouveau mot de passe"
 
 #: src/view/com/modals/DeleteAccount.tsx:196
 msgid "Input password for account deletion"
-msgstr ""
+msgstr "Entrez le mot de passe pour la suppression du compte"
 
 #: src/view/com/auth/login/LoginForm.tsx:227
 msgid "Input the password tied to {identifier}"
-msgstr ""
+msgstr "Entrez le mot de passe associé à {identifier}"
 
 #: src/view/com/auth/login/LoginForm.tsx:194
 msgid "Input the username or email address you used at signup"
-msgstr ""
+msgstr "Entrez le pseudo ou l’adresse e-mail que vous avez utilisé lors de l’inscription"
 
 #: src/view/com/modals/Waitlist.tsx:90
 msgid "Input your email to get on the Bluesky waitlist"
-msgstr ""
+msgstr "Entrez votre e-mail pour vous inscrire sur la liste d’attente de Bluesky"
 
 #: src/view/com/auth/login/LoginForm.tsx:226
 msgid "Input your password"
-msgstr ""
+msgstr "Entrez votre mot de passe"
 
 #: src/view/com/auth/create/Step3.tsx:39
 msgid "Input your user handle"
-msgstr ""
+msgstr "Entrez votre pseudo"
 
 #: src/view/com/post-thread/PostThreadItem.tsx:229
 msgid "Invalid or unsupported post record"
-msgstr ""
+msgstr "Enregistrement de post invalide ou non pris en charge"
 
 #: src/view/com/auth/login/LoginForm.tsx:115
 msgid "Invalid username or password"
-msgstr "Nom d’utilisateur ou mot de passe incorrect"
+msgstr "Pseudo ou mot de passe incorrect"
 
 #: src/view/screens/Settings.tsx:398
 msgid "Invite"
@@ -1662,15 +1643,15 @@ msgstr "Code d’invitation refusé. Vérifiez que vous l’avez saisi correctem
 
 #: src/view/com/modals/InviteCodes.tsx:170
 msgid "Invite codes: {0} available"
-msgstr ""
+msgstr "Code d’invitation : {0} disponible"
 
 #: src/view/shell/Drawer.tsx:642
 msgid "Invite codes: {invitesAvailable} available"
-msgstr "Codes d’invitation : {invitesAvailable} disponible"
+msgstr "Invitations : {invitesAvailable} codes dispo"
 
 #: src/view/com/modals/InviteCodes.tsx:169
 msgid "Invite codes: 1 available"
-msgstr ""
+msgstr "Invitations : 1 code dispo"
 
 #: src/view/com/auth/HomeLoggedOutCTA.tsx:99
 msgid "Jobs"
@@ -1695,7 +1676,7 @@ msgstr "Sélection de la langue"
 
 #: src/view/screens/Settings.tsx:547
 msgid "Language settings"
-msgstr ""
+msgstr "Préférences de langue"
 
 #: src/Navigation.tsx:141
 #: src/view/screens/LanguageSettings.tsx:89
@@ -1708,7 +1689,7 @@ msgstr "Langues"
 
 #: src/view/com/auth/create/StepHeader.tsx:13
 msgid "Last step!"
-msgstr ""
+msgstr "Dernière étape !"
 
 #: src/view/com/util/moderation/ContentHider.tsx:103
 msgid "Learn more"
@@ -1742,7 +1723,7 @@ msgstr "Quitter Bluesky"
 
 #: src/view/screens/Settings.tsx:273
 msgid "Legacy storage cleared, you need to restart the app now."
-msgstr ""
+msgstr "Stockage ancien effacé, vous devez redémarrer l’application maintenant."
 
 #: src/view/com/auth/login/Login.tsx:128
 #: src/view/com/auth/login/Login.tsx:144
@@ -1756,11 +1737,11 @@ msgstr "Bibliothèque"
 
 #: src/view/screens/Settings.tsx:460
 msgid "Light"
-msgstr ""
+msgstr "Clair"
 
 #: src/view/com/util/post-ctrls/PostCtrls.tsx:189
 msgid "Like"
-msgstr ""
+msgstr "Aimer"
 
 #: src/view/screens/ProfileFeed.tsx:600
 msgid "Like this feed"
@@ -1774,19 +1755,19 @@ msgstr "Liké par"
 
 #: src/view/com/feeds/FeedSourceCard.tsx:277
 msgid "Liked by {0} {1}"
-msgstr ""
+msgstr "Liké par {0} {1}"
 
 #: src/view/screens/ProfileFeed.tsx:615
 msgid "Liked by {likeCount} {0}"
-msgstr ""
+msgstr "Liké par {likeCount} {0}"
 
 #: src/view/com/notifications/FeedItem.tsx:171
 msgid "liked your custom feed{0}"
-msgstr ""
+msgstr "liké votre fil d’actu personnalisé{0}"
 
 #: src/view/com/notifications/FeedItem.tsx:155
 msgid "liked your post"
-msgstr ""
+msgstr "liké votre post"
 
 #: src/view/screens/Profile.tsx:164
 msgid "Likes"
@@ -1794,11 +1775,11 @@ msgstr "Likes"
 
 #: src/view/com/post-thread/PostThreadItem.tsx:184
 msgid "Likes on this post"
-msgstr ""
+msgstr "Likes sur ce post"
 
 #: src/Navigation.tsx:168
 msgid "List"
-msgstr ""
+msgstr "Liste"
 
 #: src/view/com/modals/CreateOrEditList.tsx:205
 msgid "List Avatar"
@@ -1806,19 +1787,19 @@ msgstr "Liste des avatars"
 
 #: src/view/screens/ProfileList.tsx:323
 msgid "List blocked"
-msgstr ""
+msgstr "Liste bloquée"
 
 #: src/view/com/feeds/FeedSourceCard.tsx:231
 msgid "List by {0}"
-msgstr ""
+msgstr "Liste par {0}"
 
 #: src/view/screens/ProfileList.tsx:367
 msgid "List deleted"
-msgstr ""
+msgstr "Liste supprimée"
 
 #: src/view/screens/ProfileList.tsx:282
 msgid "List muted"
-msgstr ""
+msgstr "Liste masquée"
 
 #: src/view/com/modals/CreateOrEditList.tsx:218
 msgid "List Name"
@@ -1826,11 +1807,11 @@ msgstr "Nom de liste"
 
 #: src/view/screens/ProfileList.tsx:342
 msgid "List unblocked"
-msgstr ""
+msgstr "Liste débloquée"
 
 #: src/view/screens/ProfileList.tsx:301
 msgid "List unmuted"
-msgstr ""
+msgstr "Liste démasquée"
 
 #: src/Navigation.tsx:111
 #: src/view/screens/Profile.tsx:166
@@ -1866,7 +1847,7 @@ msgstr "Serveur de dév local"
 
 #: src/Navigation.tsx:209
 msgid "Log"
-msgstr ""
+msgstr "Journaux"
 
 #: src/view/screens/Moderation.tsx:136
 msgid "Logged-out visibility"
@@ -1886,24 +1867,20 @@ msgstr "Média"
 
 #: src/view/com/threadgate/WhoCanReply.tsx:139
 msgid "mentioned users"
-msgstr "utilisateurs mentionnés"
+msgstr "comptes mentionnés"
 
 #: src/view/com/modals/Threadgate.tsx:93
 msgid "Mentioned users"
-msgstr "Utilisateurs mentionnés"
+msgstr "Comptes mentionnés"
 
 #: src/view/com/util/ViewHeader.tsx:81
 #: src/view/screens/Search/Search.tsx:537
 msgid "Menu"
 msgstr "Menu"
 
-#: src/view/com/posts/FeedErrorMessage.tsx:194
-#~ msgid "Message from server"
-#~ msgstr "Message du serveur"
-
 #: src/view/com/posts/FeedErrorMessage.tsx:197
 msgid "Message from server: {0}"
-msgstr ""
+msgstr "Message du serveur : {0}"
 
 #: src/Navigation.tsx:116
 #: src/view/screens/Moderation.tsx:64
@@ -1917,25 +1894,25 @@ msgstr "Modération"
 #: src/view/com/lists/ListCard.tsx:92
 #: src/view/com/modals/UserAddRemoveLists.tsx:190
 msgid "Moderation list by {0}"
-msgstr ""
+msgstr "Liste de modération par {0}"
 
 #: src/view/screens/ProfileList.tsx:753
 msgid "Moderation list by <0/>"
-msgstr ""
+msgstr "Liste de modération par <0/>"
 
 #: src/view/com/lists/ListCard.tsx:90
 #: src/view/com/modals/UserAddRemoveLists.tsx:188
 #: src/view/screens/ProfileList.tsx:751
 msgid "Moderation list by you"
-msgstr ""
+msgstr "Liste de modération par vous"
 
 #: src/view/com/modals/CreateOrEditList.tsx:139
 msgid "Moderation list created"
-msgstr ""
+msgstr "Liste de modération créée"
 
 #: src/view/com/modals/CreateOrEditList.tsx:126
 msgid "Moderation list updated"
-msgstr ""
+msgstr "Liste de modération mise à jour"
 
 #: src/view/screens/Moderation.tsx:95
 msgid "Moderation lists"
@@ -1948,11 +1925,11 @@ msgstr "Listes de modération"
 
 #: src/view/screens/Settings.tsx:572
 msgid "Moderation settings"
-msgstr ""
+msgstr "Paramètres de modération"
 
 #: src/view/com/modals/ModerationDetails.tsx:35
 msgid "Moderator has chosen to set a general warning on the content."
-msgstr ""
+msgstr "La modération a choisi d’ajouter un avertissement général sur le contenu."
 
 #: src/view/shell/desktop/Feeds.tsx:53
 msgid "More feeds"
@@ -1966,7 +1943,7 @@ msgstr "Plus d’options"
 
 #: src/view/com/util/forms/PostDropdownBtn.tsx:268
 msgid "More post options"
-msgstr ""
+msgstr "Plus d’options de post"
 
 #: src/view/screens/PreferencesThreads.tsx:82
 msgid "Most-liked replies first"
@@ -1990,7 +1967,7 @@ msgstr "Masquer ces comptes ?"
 
 #: src/view/screens/ProfileList.tsx:278
 msgid "Mute this List"
-msgstr ""
+msgstr "Masquer cette liste"
 
 #: src/view/com/util/forms/PostDropdownBtn.tsx:169
 msgid "Mute thread"
@@ -2036,22 +2013,22 @@ msgstr "Nom"
 
 #: src/view/com/modals/CreateOrEditList.tsx:108
 msgid "Name is required"
-msgstr ""
+msgstr "Le nom est requis"
 
 #: src/view/com/auth/login/ForgotPasswordForm.tsx:186
 #: src/view/com/auth/login/LoginForm.tsx:286
 #: src/view/com/auth/login/SetNewPasswordForm.tsx:166
 msgid "Navigates to the next screen"
-msgstr ""
+msgstr "Navigue vers le prochain écran"
 
 #: src/view/shell/Drawer.tsx:71
 msgid "Navigates to your profile"
-msgstr ""
+msgstr "Navigue vers votre profil"
 
 #: src/view/com/modals/EmbedConsent.tsx:107
 #: src/view/com/modals/EmbedConsent.tsx:123
 msgid "Never load embeds from {0}"
-msgstr ""
+msgstr "Ne jamais charger les contenus intégrés de {0}"
 
 #: src/view/com/auth/onboarding/WelcomeDesktop.tsx:72
 #: src/view/com/auth/onboarding/WelcomeMobile.tsx:72
@@ -2061,7 +2038,7 @@ msgstr "Ne perdez jamais l’accès à vos followers et à vos données."
 #: src/view/screens/Lists.tsx:76
 msgctxt "action"
 msgid "New"
-msgstr ""
+msgstr "Nouveau"
 
 #: src/view/screens/ModerationModlists.tsx:78
 msgid "New"
@@ -2069,16 +2046,16 @@ msgstr "Nouveau"
 
 #: src/view/com/modals/CreateOrEditList.tsx:195
 msgid "New Moderation List"
-msgstr ""
+msgstr "Nouvelle liste de modération"
 
 #: src/view/com/auth/login/SetNewPasswordForm.tsx:122
 msgid "New password"
-msgstr ""
+msgstr "Nouveau mot de passe"
 
 #: src/view/com/feeds/FeedPage.tsx:201
 msgctxt "action"
 msgid "New post"
-msgstr ""
+msgstr "Nouveau post"
 
 #: src/view/screens/Feeds.tsx:511
 #: src/view/screens/Profile.tsx:354
@@ -2092,24 +2069,20 @@ msgstr "Nouveau post"
 #: src/view/shell/desktop/LeftNav.tsx:258
 msgctxt "action"
 msgid "New Post"
-msgstr ""
-
-#: src/view/shell/desktop/LeftNav.tsx:258
-#~ msgid "New Post"
-#~ msgstr "Nouveau post"
+msgstr "Nouveau post"
 
 #: src/view/com/modals/CreateOrEditList.tsx:190
 msgid "New User List"
-msgstr ""
+msgstr "Nouvelle liste de comptes"
 
 #: src/view/screens/PreferencesThreads.tsx:79
 msgid "Newest replies first"
-msgstr ""
+msgstr "Réponses les plus récentes en premier"
 
 #: src/view/com/auth/onboarding/WelcomeDesktop.tsx:103
 msgctxt "action"
 msgid "Next"
-msgstr ""
+msgstr "Suivant"
 
 #: src/view/com/auth/create/CreateAccount.tsx:154
 #: src/view/com/auth/login/ForgotPasswordForm.tsx:178
@@ -2141,11 +2114,11 @@ msgstr "Aucune description"
 
 #: src/view/com/profile/ProfileHeader.tsx:217
 msgid "No longer following {0}"
-msgstr ""
+msgstr "Ne suit plus {0}"
 
 #: src/view/com/notifications/Feed.tsx:107
 msgid "No notifications yet!"
-msgstr ""
+msgstr "Pas encore de notifications !"
 
 #: src/view/com/composer/text-input/mobile/Autocomplete.tsx:97
 #: src/view/com/composer/text-input/web/Autocomplete.tsx:191
@@ -2166,7 +2139,7 @@ msgstr "Aucun résultat trouvé pour {query}"
 
 #: src/view/com/modals/EmbedConsent.tsx:129
 msgid "No thanks"
-msgstr ""
+msgstr "Non merci"
 
 #: src/view/com/modals/Threadgate.tsx:82
 msgid "Nobody"
@@ -2178,16 +2151,16 @@ msgstr "Sans objet."
 
 #: src/Navigation.tsx:106
 msgid "Not Found"
-msgstr ""
+msgstr "Introuvable"
 
 #: src/view/com/modals/VerifyEmail.tsx:246
 #: src/view/com/modals/VerifyEmail.tsx:252
 msgid "Not right now"
-msgstr ""
+msgstr "Pas maintenant"
 
 #: src/view/screens/Moderation.tsx:232
 msgid "Note: Bluesky is an open and public network. This setting only limits the visibility of your content on the Bluesky app and website, and other apps may not respect this setting. Your content may still be shown to logged-out users by other apps and websites."
-msgstr "Remarque : Bluesky est un réseau ouvert et public. Ce paramètre limite uniquement la visibilité de votre contenu sur l’application et le site Web de Bluesky, et d’autres applications peuvent ne pas respecter ce paramètre. Votre contenu peut toujours être montré aux utilisateurs déconnectés par d’autres applications et sites Web."
+msgstr "Remarque : Bluesky est un réseau ouvert et public. Ce paramètre limite uniquement la visibilité de votre contenu sur l’application et le site Web de Bluesky, et d’autres applications peuvent ne pas respecter ce paramètre. Votre contenu peut toujours être montré aux personnes déconnectées par d’autres applications et sites Web."
 
 #: src/Navigation.tsx:447
 #: src/view/screens/Notifications.tsx:113
@@ -2201,7 +2174,7 @@ msgstr "Notifications"
 
 #: src/view/com/modals/SelfLabel.tsx:103
 msgid "Nudity"
-msgstr ""
+msgstr "Nudité"
 
 #: src/view/com/util/ErrorBoundary.tsx:34
 msgid "Oh no!"
@@ -2217,7 +2190,7 @@ msgstr "Plus anciennes réponses en premier"
 
 #: src/view/screens/Settings.tsx:229
 msgid "Onboarding reset"
-msgstr ""
+msgstr "Réinitialiser le didacticiel"
 
 #: src/view/com/composer/Composer.tsx:374
 msgid "One or more images is missing alt text."
@@ -2231,7 +2204,7 @@ msgstr "Seul {0} peut répondre."
 #: src/view/com/modals/ProfilePreview.tsx:61
 #: src/view/screens/AppPasswords.tsx:65
 msgid "Oops!"
-msgstr ""
+msgstr "Oups !"
 
 #: src/view/com/composer/Composer.tsx:468
 #: src/view/com/composer/Composer.tsx:469
@@ -2244,27 +2217,27 @@ msgstr "Navigation ouverte"
 
 #: src/view/screens/Settings.tsx:713
 msgid "Open storybook page"
-msgstr ""
+msgstr "Ouvrir la page Storybook"
 
 #: src/view/com/util/forms/DropdownButton.tsx:147
 msgid "Opens {numItems} options"
-msgstr ""
+msgstr "Ouvre {numItems} options"
 
 #: src/view/screens/Log.tsx:54
 msgid "Opens additional details for a debug entry"
-msgstr ""
+msgstr "Ouvre des détails supplémentaires pour une entrée de débug"
 
 #: src/view/com/notifications/FeedItem.tsx:352
 msgid "Opens an expanded list of users in this notification"
-msgstr ""
+msgstr "Ouvre une liste étendue des comptes dans cette notification"
 
 #: src/view/com/composer/photos/OpenCameraBtn.tsx:61
 msgid "Opens camera on device"
-msgstr ""
+msgstr "Ouvre l’appareil photo de l’appareil"
 
 #: src/view/com/composer/Prompt.tsx:25
 msgid "Opens composer"
-msgstr ""
+msgstr "Ouvre le rédacteur"
 
 #: src/view/screens/Settings.tsx:548
 msgid "Opens configurable language settings"
@@ -2272,27 +2245,27 @@ msgstr "Ouvre les paramètres linguistiques configurables"
 
 #: src/view/com/composer/photos/SelectPhotoBtn.tsx:44
 msgid "Opens device photo gallery"
-msgstr ""
+msgstr "Ouvre la galerie de photos de l’appareil"
 
 #: src/view/com/profile/ProfileHeader.tsx:459
 msgid "Opens editor for profile display name, avatar, background image, and description"
-msgstr ""
+msgstr "Ouvre l’éditeur pour le nom d’affichage du profil, l’avatar, l’image d’arrière-plan et la description"
 
 #: src/view/screens/Settings.tsx:602
 msgid "Opens external embeds settings"
-msgstr ""
+msgstr "Ouvre les paramètres d’intégration externe"
 
 #: src/view/com/profile/ProfileHeader.tsx:614
 msgid "Opens followers list"
-msgstr ""
+msgstr "Ouvre la liste des comptes abonnés"
 
 #: src/view/com/profile/ProfileHeader.tsx:633
 msgid "Opens following list"
-msgstr ""
+msgstr "Ouvre la liste des abonnements"
 
 #: src/view/screens/Settings.tsx:399
 msgid "Opens invite code list"
-msgstr ""
+msgstr "Ouvre la liste des codes d’invitation"
 
 #: src/view/com/modals/InviteCodes.tsx:172
 #: src/view/shell/desktop/RightNav.tsx:156
@@ -2302,7 +2275,7 @@ msgstr "Ouvre la liste des codes d’invitation"
 
 #: src/view/screens/Settings.tsx:672
 msgid "Opens modal for account deletion confirmation. Requires email code."
-msgstr ""
+msgstr "Ouvre la fenêtre modale pour confirmer la suppression du compte. Requiert un code e-mail."
 
 #: src/view/com/modals/ChangeHandle.tsx:281
 msgid "Opens modal for using custom domain"
@@ -2314,11 +2287,11 @@ msgstr "Ouvre les paramètres de modération"
 
 #: src/view/com/auth/login/LoginForm.tsx:236
 msgid "Opens password reset form"
-msgstr ""
+msgstr "Ouvre le formulaire de réinitialisation du mot de passe"
 
 #: src/view/screens/Feeds.tsx:335
 msgid "Opens screen to edit Saved Feeds"
-msgstr ""
+msgstr "Ouvre l’écran pour modifier les fils d’actu enregistrés"
 
 #: src/view/screens/Settings.tsx:529
 msgid "Opens screen with all saved feeds"
@@ -2346,7 +2319,7 @@ msgstr "Ouvre les préférences relatives aux fils de discussion"
 
 #: src/view/com/util/forms/DropdownButton.tsx:254
 msgid "Option {0} of {numItems}"
-msgstr ""
+msgstr "Option {0} sur {numItems}"
 
 #: src/view/com/modals/Threadgate.tsx:89
 msgid "Or combine these options:"
@@ -2387,19 +2360,19 @@ msgstr "Mot de passe mis à jour !"
 
 #: src/Navigation.tsx:162
 msgid "People followed by @{0}"
-msgstr ""
+msgstr "Personnes suivies par @{0}"
 
 #: src/Navigation.tsx:155
 msgid "People following @{0}"
-msgstr ""
+msgstr "Personnes qui suivent @{0}"
 
 #: src/view/com/lightbox/Lightbox.tsx:66
 msgid "Permission to access camera roll is required."
-msgstr ""
+msgstr "Permission d’accès à la pellicule requise."
 
 #: src/view/com/lightbox/Lightbox.tsx:72
 msgid "Permission to access camera roll was denied. Please enable it in your system settings."
-msgstr ""
+msgstr "Permission d’accès à la pellicule refusée. Veuillez l’activer dans les paramètres de votre système."
 
 #: src/view/com/modals/SelfLabel.tsx:121
 msgid "Pictures meant for adults."
@@ -2408,7 +2381,7 @@ msgstr "Images destinées aux adultes."
 #: src/view/screens/ProfileFeed.tsx:362
 #: src/view/screens/ProfileList.tsx:559
 msgid "Pin to home"
-msgstr ""
+msgstr "Ajouter à l’accueil"
 
 #: src/view/screens/SavedFeeds.tsx:88
 msgid "Pinned Feeds"
@@ -2416,16 +2389,16 @@ msgstr "Fils épinglés"
 
 #: src/view/com/util/post-embeds/ExternalGifEmbed.tsx:111
 msgid "Play {0}"
-msgstr ""
+msgstr "Lire {0}"
 
 #: src/view/com/util/post-embeds/ExternalPlayerEmbed.tsx:54
 #: src/view/com/util/post-embeds/ExternalPlayerEmbed.tsx:55
 msgid "Play Video"
-msgstr ""
+msgstr "Lire la vidéo"
 
 #: src/view/com/util/post-embeds/ExternalGifEmbed.tsx:110
 msgid "Plays the GIF"
-msgstr ""
+msgstr "Lis le GIF"
 
 #: src/view/com/auth/create/state.ts:116
 msgid "Please choose your handle."
@@ -2441,7 +2414,7 @@ msgstr "Veuillez confirmer votre e-mail avant de le modifier. Ceci est temporair
 
 #: src/view/com/modals/AddAppPasswords.tsx:89
 msgid "Please enter a name for your app password. All spaces is not allowed."
-msgstr ""
+msgstr "Veuillez entrer un nom pour votre mot de passe d’application. Les espaces ne sont pas autorisés."
 
 #: src/view/com/modals/AddAppPasswords.tsx:144
 msgid "Please enter a unique name for this App Password or use our randomly generated one."
@@ -2460,12 +2433,9 @@ msgstr "Veuillez également entrer votre mot de passe :"
 msgid "Please tell us why you think this content warning was incorrectly applied!"
 msgstr "Dites-nous donc pourquoi vous pensez que cet avertissement de contenu a été appliqué à tort !"
 
-#~ msgid "Please tell us why you think this decision was incorrect."
-#~ msgstr "Dites-nous pourquoi vous pensez que cette décision était incorrecte."
-
 #: src/view/com/modals/VerifyEmail.tsx:101
 msgid "Please Verify Your Email"
-msgstr ""
+msgstr "Veuillez vérifier votre e-mail"
 
 #: src/view/com/composer/Composer.tsx:214
 msgid "Please wait for your link card to finish loading"
@@ -2473,43 +2443,37 @@ msgstr "Veuillez patienter le temps que votre carte de lien soit chargée"
 
 #: src/view/com/modals/SelfLabel.tsx:111
 msgid "Porn"
-msgstr ""
+msgstr "Porno"
 
 #: src/view/com/composer/Composer.tsx:349
 #: src/view/com/composer/Composer.tsx:357
 msgctxt "action"
 msgid "Post"
-msgstr ""
+msgstr "Poster"
 
 #: src/view/com/post-thread/PostThread.tsx:227
 #: src/view/screens/PostThread.tsx:82
 msgctxt "description"
 msgid "Post"
-msgstr ""
-
-#: src/view/com/composer/Composer.tsx:346
-#: src/view/com/post-thread/PostThread.tsx:225
-#: src/view/screens/PostThread.tsx:80
-#~ msgid "Post"
-#~ msgstr "Post"
+msgstr "Post"
 
 #: src/view/com/post-thread/PostThreadItem.tsx:176
 msgid "Post by {0}"
-msgstr ""
+msgstr "Post de {0}"
 
 #: src/Navigation.tsx:174
 #: src/Navigation.tsx:181
 #: src/Navigation.tsx:188
 msgid "Post by @{0}"
-msgstr ""
+msgstr "Post de @{0}"
 
 #: src/view/com/util/forms/PostDropdownBtn.tsx:82
 msgid "Post deleted"
-msgstr ""
+msgstr "Post supprimé"
 
 #: src/view/com/post-thread/PostThread.tsx:382
 msgid "Post hidden"
-msgstr "Posts cachés"
+msgstr "Post caché"
 
 #: src/view/com/composer/select-language/SelectLangBtn.tsx:87
 msgid "Post language"
@@ -2529,7 +2493,7 @@ msgstr "Posts"
 
 #: src/view/com/posts/FeedErrorMessage.tsx:64
 msgid "Posts hidden"
-msgstr ""
+msgstr "Posts cachés"
 
 #: src/view/com/modals/LinkWarning.tsx:44
 msgid "Potentially Misleading Link"
@@ -2573,7 +2537,7 @@ msgstr "Profil"
 
 #: src/view/com/modals/EditProfile.tsx:128
 msgid "Profile updated"
-msgstr ""
+msgstr "Profil mis à jour"
 
 #: src/view/screens/Settings.tsx:858
 msgid "Protect your account by verifying your email."
@@ -2581,7 +2545,7 @@ msgstr "Protégez votre compte en vérifiant votre e-mail."
 
 #: src/view/screens/ModerationModlists.tsx:61
 msgid "Public, shareable lists of users to mute or block in bulk."
-msgstr "Listes publiques et partageables d’utilisateurs à masquer ou à bloquer."
+msgstr "Listes publiques et partageables de comptes à masquer ou à bloquer."
 
 #: src/view/screens/Lists.tsx:61
 msgid "Public, shareable lists which can drive feeds."
@@ -2589,16 +2553,16 @@ msgstr "Les listes publiques et partageables qui peuvent alimenter les fils d’
 
 #: src/view/com/composer/Composer.tsx:334
 msgid "Publish post"
-msgstr ""
+msgstr "Publier le post"
 
 #: src/view/com/composer/Composer.tsx:334
 msgid "Publish reply"
-msgstr ""
+msgstr "Publier la réponse"
 
 #: src/view/com/modals/Repost.tsx:65
 msgctxt "action"
 msgid "Quote post"
-msgstr ""
+msgstr "Citer le post"
 
 #: src/view/com/util/post-ctrls/RepostButton.web.tsx:58
 msgid "Quote post"
@@ -2607,15 +2571,11 @@ msgstr "Citer le post"
 #: src/view/com/modals/Repost.tsx:70
 msgctxt "action"
 msgid "Quote Post"
-msgstr ""
-
-#: src/view/com/modals/Repost.tsx:56
-#~ msgid "Quote Post"
-#~ msgstr "Citer un post"
+msgstr "Citer le post"
 
 #: src/view/screens/PreferencesThreads.tsx:86
 msgid "Random (aka \"Poster's Roulette\")"
-msgstr ""
+msgstr "Aléatoire"
 
 #: src/view/com/modals/EditImage.tsx:236
 msgid "Ratios"
@@ -2627,7 +2587,7 @@ msgstr "Fils d’actu recommandés"
 
 #: src/view/com/auth/onboarding/RecommendedFollows.tsx:180
 msgid "Recommended Users"
-msgstr "Utilisateurs recommandés"
+msgstr "Comptes recommandés"
 
 #: src/view/com/modals/ListAddRemoveUsers.tsx:264
 #: src/view/com/modals/SelfLabel.tsx:83
@@ -2668,7 +2628,7 @@ msgstr "Supprimer l’aperçu d’image"
 
 #: src/view/com/modals/Repost.tsx:47
 msgid "Remove repost"
-msgstr ""
+msgstr "Supprimer le reposts"
 
 #: src/view/com/feeds/FeedSourceCard.tsx:173
 msgid "Remove this feed from my feeds?"
@@ -2686,11 +2646,11 @@ msgstr "Supprimé de la liste"
 #: src/view/com/feeds/FeedSourceCard.tsx:111
 #: src/view/com/feeds/FeedSourceCard.tsx:178
 msgid "Removed from my feeds"
-msgstr ""
+msgstr "Supprimé de mes fils d’actu"
 
 #: src/view/com/composer/ExternalEmbed.tsx:71
 msgid "Removes default thumbnail from {0}"
-msgstr ""
+msgstr "Supprime la miniature par défaut de {0}"
 
 #: src/view/screens/Profile.tsx:162
 msgid "Replies"
@@ -2703,7 +2663,7 @@ msgstr "Les réponses à ce fil de discussion sont désactivées"
 #: src/view/com/composer/Composer.tsx:347
 msgctxt "action"
 msgid "Reply"
-msgstr ""
+msgstr "Répondre"
 
 #: src/view/screens/PreferencesHomeFeed.tsx:144
 msgid "Reply Filters"
@@ -2713,7 +2673,7 @@ msgstr "Filtres de réponse"
 #: src/view/com/posts/FeedItem.tsx:286
 msgctxt "description"
 msgid "Reply to <0/>"
-msgstr ""
+msgstr "Réponse à <0/>"
 
 #: src/view/com/modals/report/Modal.tsx:166
 msgid "Report {collectionName}"
@@ -2742,7 +2702,7 @@ msgstr "Signaler le post"
 #: src/view/com/util/post-ctrls/RepostButton.tsx:61
 msgctxt "action"
 msgid "Repost"
-msgstr ""
+msgstr "Republier"
 
 #: src/view/com/util/post-ctrls/RepostButton.web.tsx:48
 msgid "Repost"
@@ -2759,19 +2719,19 @@ msgstr "Republié par"
 
 #: src/view/com/posts/FeedItem.tsx:206
 msgid "Reposted by {0})"
-msgstr ""
+msgstr "Republié par {0})"
 
 #: src/view/com/posts/FeedItem.tsx:223
 msgid "Reposted by <0/>"
-msgstr ""
+msgstr "Republié par <0/>"
 
 #: src/view/com/notifications/FeedItem.tsx:162
 msgid "reposted your post"
-msgstr ""
+msgstr "a republié votre post"
 
 #: src/view/com/post-thread/PostThreadItem.tsx:189
 msgid "Reposts of this post"
-msgstr ""
+msgstr "Reposts de ce post"
 
 #: src/view/com/modals/ChangeEmail.tsx:181
 #: src/view/com/modals/ChangeEmail.tsx:183
@@ -2784,7 +2744,7 @@ msgstr "Nécessiter un texte alt avant de publier"
 
 #: src/view/com/auth/create/Step2.tsx:68
 msgid "Required for this provider"
-msgstr "Obligatoire pour ce fournisseur"
+msgstr "Obligatoire pour cet hébergeur"
 
 #: src/view/com/auth/login/SetNewPasswordForm.tsx:98
 #: src/view/com/auth/login/SetNewPasswordForm.tsx:108
@@ -2793,11 +2753,11 @@ msgstr "Réinitialiser le code"
 
 #: src/view/screens/Settings.tsx:733
 msgid "Reset onboarding"
-msgstr ""
+msgstr "Réinitialiser le didacticiel"
 
 #: src/view/screens/Settings.tsx:736
 msgid "Reset onboarding state"
-msgstr "Réinitialisation de l’état d’accueil"
+msgstr "Réinitialisation du didacticiel"
 
 #: src/view/com/auth/login/ForgotPasswordForm.tsx:100
 msgid "Reset password"
@@ -2805,7 +2765,7 @@ msgstr "Réinitialiser mot de passe"
 
 #: src/view/screens/Settings.tsx:723
 msgid "Reset preferences"
-msgstr ""
+msgstr "Réinitialiser les préférences"
 
 #: src/view/screens/Settings.tsx:726
 msgid "Reset preferences state"
@@ -2821,12 +2781,12 @@ msgstr "Réinitialise l’état des préférences"
 
 #: src/view/com/auth/login/LoginForm.tsx:266
 msgid "Retries login"
-msgstr ""
+msgstr "Réessaye la connection"
 
 #: src/view/com/util/error/ErrorMessage.tsx:57
 #: src/view/com/util/error/ErrorScreen.tsx:67
 msgid "Retries the last action, which errored out"
-msgstr ""
+msgstr "Réessaye la dernière action, qui a échoué"
 
 #: src/view/com/auth/create/CreateAccount.tsx:163
 #: src/view/com/auth/create/CreateAccount.tsx:167
@@ -2839,17 +2799,17 @@ msgstr "Réessayer"
 
 #: src/view/screens/ProfileList.tsx:877
 msgid "Return to previous page"
-msgstr ""
+msgstr "Retourne à la page précédente"
 
 #: src/view/shell/desktop/RightNav.tsx:59
 msgid "SANDBOX. Posts and accounts are not permanent."
-msgstr ""
+msgstr "SANDBOX. Les posts et les comptes ne sont pas permanents."
 
 #: src/view/com/lightbox/Lightbox.tsx:125
 #: src/view/com/modals/CreateOrEditList.tsx:278
 msgctxt "action"
 msgid "Save"
-msgstr ""
+msgstr "Enregistrer"
 
 #: src/view/com/modals/BirthDateSettings.tsx:94
 #: src/view/com/modals/BirthDateSettings.tsx:97
@@ -2882,15 +2842,15 @@ msgstr "Fils d’actu enregistrés"
 
 #: src/view/com/modals/EditProfile.tsx:225
 msgid "Saves any changes to your profile"
-msgstr ""
+msgstr "Enregistre toutes les modifications apportées à votre profil"
 
 #: src/view/com/modals/ChangeHandle.tsx:171
 msgid "Saves handle change to {handle}"
-msgstr ""
+msgstr "Enregistre le changement de pseudo en {handle}"
 
 #: src/view/screens/ProfileList.tsx:833
 msgid "Scroll to top"
-msgstr ""
+msgstr "Remonter en haut"
 
 #: src/Navigation.tsx:437
 #: src/view/com/auth/LoggedOut.tsx:122
@@ -2913,7 +2873,7 @@ msgstr "Recherche"
 #: src/view/com/auth/LoggedOut.tsx:105
 #: src/view/com/modals/ListAddRemoveUsers.tsx:70
 msgid "Search for users"
-msgstr "Rechercher des utilisateurs"
+msgstr "Rechercher des personnes"
 
 #: src/view/com/modals/ChangeEmail.tsx:110
 msgid "Security Step Required"
@@ -2921,7 +2881,7 @@ msgstr "Étape de sécurité requise"
 
 #: src/view/screens/SavedFeeds.tsx:163
 msgid "See this guide"
-msgstr ""
+msgstr "Voir ce guide"
 
 #: src/view/com/auth/HomeLoggedOutCTA.tsx:39
 msgid "See what's next"
@@ -2929,7 +2889,7 @@ msgstr "Voir la suite"
 
 #: src/view/com/util/Selector.tsx:106
 msgid "Select {item}"
-msgstr ""
+msgstr "Sélectionner {item}"
 
 #: src/view/com/modals/ServerInput.tsx:75
 msgid "Select Bluesky Social"
@@ -2941,7 +2901,7 @@ msgstr "Sélectionner un compte existant"
 
 #: src/view/com/util/Selector.tsx:107
 msgid "Select option {i} of {numItems}"
-msgstr ""
+msgstr "Sélectionne l’option {i} sur {numItems}"
 
 #: src/view/com/auth/login/LoginForm.tsx:147
 msgid "Select service"
@@ -2949,7 +2909,7 @@ msgstr "Sélectionner un service"
 
 #: src/view/screens/LanguageSettings.tsx:281
 msgid "Select which languages you want your subscribed feeds to include. If none are selected, all languages will be shown."
-msgstr "Sélectionnez les langues que vous souhaitez voir figurer dans les fils d’actu auxquels vous êtes abonné. Si aucune langue n’est sélectionnée, toutes les langues seront affichées."
+msgstr "Sélectionnez les langues que vous souhaitez voir figurer dans les fils d’actu que vous suivez. Si aucune langue n’est sélectionnée, toutes les langues seront affichées."
 
 #: src/view/screens/LanguageSettings.tsx:98
 msgid "Select your app language for the default text to display in the app"
@@ -2971,11 +2931,7 @@ msgstr "Envoyer e-mail"
 #: src/view/com/modals/DeleteAccount.tsx:140
 msgctxt "action"
 msgid "Send Email"
-msgstr ""
-
-#: src/view/com/modals/DeleteAccount.tsx:138
-#~ msgid "Send Email"
-#~ msgstr "Envoyer e-mail"
+msgstr "Envoyer l’e-mail"
 
 #: src/view/shell/Drawer.tsx:295
 #: src/view/shell/Drawer.tsx:316
@@ -2988,29 +2944,29 @@ msgstr "Envoyer le rapport"
 
 #: src/view/com/modals/DeleteAccount.tsx:129
 msgid "Sends email with confirmation code for account deletion"
-msgstr ""
+msgstr "Envoie un e-mail avec le code de confirmation pour la suppression du compte"
 
 #: src/view/com/modals/ContentFilteringSettings.tsx:306
 msgid "Set {value} for {labelGroup} content moderation policy"
-msgstr ""
+msgstr "Choisis {value} pour la politique de modération de contenu {labelGroup}"
 
 #: src/view/com/modals/ContentFilteringSettings.tsx:155
 #: src/view/com/modals/ContentFilteringSettings.tsx:174
 msgctxt "action"
 msgid "Set Age"
-msgstr ""
+msgstr "Enregistrer l’âge"
 
 #: src/view/screens/Settings.tsx:469
 msgid "Set color theme to dark"
-msgstr ""
+msgstr "Change le thème de couleur en sombre"
 
 #: src/view/screens/Settings.tsx:462
 msgid "Set color theme to light"
-msgstr ""
+msgstr "Change le thème de couleur en clair"
 
 #: src/view/screens/Settings.tsx:456
 msgid "Set color theme to system setting"
-msgstr ""
+msgstr "Change le thème de couleur en fonction du paramètre système"
 
 #: src/view/com/auth/login/SetNewPasswordForm.tsx:78
 msgid "Set new password"
@@ -3018,7 +2974,7 @@ msgstr "Définir un nouveau mot de passe"
 
 #: src/view/com/auth/create/Step2.tsx:133
 msgid "Set password"
-msgstr ""
+msgstr "Définis le mot de passe"
 
 #: src/view/screens/PreferencesHomeFeed.tsx:225
 msgid "Set this setting to \"No\" to hide all quote posts from your feed. Reposts will still be visible."
@@ -3042,23 +2998,23 @@ msgstr "Choisissez « Oui » pour afficher des échantillons de vos fils d’a
 
 #: src/view/com/modals/ChangeHandle.tsx:266
 msgid "Sets Bluesky username"
-msgstr ""
+msgstr "Définis le pseudo Bluesky"
 
 #: src/view/com/auth/login/ForgotPasswordForm.tsx:153
 msgid "Sets email for password reset"
-msgstr ""
+msgstr "Définis l’e-mail pour la réinitialisation du mot de passe"
 
 #: src/view/com/auth/login/ForgotPasswordForm.tsx:118
 msgid "Sets hosting provider for password reset"
-msgstr ""
+msgstr "Définis l’hébergeur pour la réinitialisation du mot de passe"
 
 #: src/view/com/auth/create/Step1.tsx:143
 msgid "Sets hosting provider to {label}"
-msgstr ""
+msgstr "Définis l’hébergeur à {label}"
 
 #: src/view/com/auth/login/LoginForm.tsx:148
 msgid "Sets server for the Bluesky client"
-msgstr ""
+msgstr "Définis le serveur pour le client Bluesky"
 
 #: src/Navigation.tsx:136
 #: src/view/screens/Settings.tsx:287
@@ -3075,7 +3031,7 @@ msgstr "Activité sexuelle ou nudité érotique."
 #: src/view/com/lightbox/Lightbox.tsx:134
 msgctxt "action"
 msgid "Share"
-msgstr ""
+msgstr "Partager"
 
 #: src/view/com/profile/ProfileHeader.tsx:342
 #: src/view/com/util/forms/PostDropdownBtn.tsx:151
@@ -3096,7 +3052,7 @@ msgstr "Afficher"
 
 #: src/view/screens/PreferencesHomeFeed.tsx:68
 msgid "Show all replies"
-msgstr ""
+msgstr "Afficher toutes les réponses"
 
 #: src/view/com/util/moderation/ScreenHider.tsx:132
 msgid "Show anyway"
@@ -3104,17 +3060,17 @@ msgstr "Afficher quand même"
 
 #: src/view/com/modals/EmbedConsent.tsx:87
 msgid "Show embeds from {0}"
-msgstr ""
+msgstr "Afficher les intégrations de {0}"
 
 #: src/view/com/profile/ProfileHeader.tsx:498
 msgid "Show follows similar to {0}"
-msgstr ""
+msgstr "Afficher les suivis similaires à {0}"
 
 #: src/view/com/post-thread/PostThreadItem.tsx:569
 #: src/view/com/post/Post.tsx:196
 #: src/view/com/posts/FeedItem.tsx:362
 msgid "Show More"
-msgstr ""
+msgstr "Voir plus"
 
 #: src/view/screens/PreferencesHomeFeed.tsx:258
 msgid "Show Posts from My Feeds"
@@ -3122,7 +3078,7 @@ msgstr "Afficher les posts de mes fils d’actu"
 
 #: src/view/screens/PreferencesHomeFeed.tsx:222
 msgid "Show Quote Posts"
-msgstr "Afficher les posts de citation"
+msgstr "Afficher les citations"
 
 #: src/view/screens/PreferencesHomeFeed.tsx:119
 msgid "Show Replies"
@@ -3134,7 +3090,7 @@ msgstr "Afficher les réponses des personnes que vous suivez avant toutes les au
 
 #: src/view/screens/PreferencesHomeFeed.tsx:70
 msgid "Show replies with at least {value} {0}"
-msgstr ""
+msgstr "Afficher les réponses avec au moins {value} {0}"
 
 #: src/view/screens/PreferencesHomeFeed.tsx:188
 msgid "Show Reposts"
@@ -3143,19 +3099,19 @@ msgstr "Afficher les reposts"
 #: src/view/com/util/moderation/ContentHider.tsx:67
 #: src/view/com/util/moderation/PostHider.tsx:61
 msgid "Show the content"
-msgstr ""
+msgstr "Afficher le contenu"
 
 #: src/view/com/notifications/FeedItem.tsx:350
 msgid "Show users"
-msgstr "Afficher les utilisateurs"
+msgstr "Afficher les comptes"
 
 #: src/view/com/profile/ProfileHeader.tsx:501
 msgid "Shows a list of users similar to this user."
-msgstr ""
+msgstr "Affiche une liste de comptes similaires à ce compte."
 
 #: src/view/com/profile/ProfileHeader.tsx:545
 msgid "Shows posts from {0} in your feed"
-msgstr ""
+msgstr "Affiche les posts de {0} dans votre fil d’actu"
 
 #: src/view/com/auth/HomeLoggedOutCTA.tsx:70
 #: src/view/com/auth/login/Login.tsx:98
@@ -3223,11 +3179,11 @@ msgstr "Connecté en tant que"
 
 #: src/view/com/auth/login/ChooseAccountForm.tsx:103
 msgid "Signed in as @{0}"
-msgstr ""
+msgstr "Connecté comme @{0}"
 
 #: src/view/com/modals/SwitchAccount.tsx:66
 msgid "Signs {0} out of Bluesky"
-msgstr ""
+msgstr "Déconnecte {0} de Bluesky"
 
 #: src/view/com/auth/onboarding/WelcomeMobile.tsx:33
 msgid "Skip"
@@ -3235,15 +3191,15 @@ msgstr "Ignorer"
 
 #: src/view/com/modals/ProfilePreview.tsx:62
 msgid "Something went wrong and we're not sure what."
-msgstr ""
+msgstr "Quelque chose a échoué et on ne sait pas trop quoi."
 
 #: src/view/com/modals/Waitlist.tsx:51
 msgid "Something went wrong. Check your email and try again."
-msgstr ""
+msgstr "Quelque chose a échoué. Vérifiez vos e-mails et réessayez."
 
 #: src/App.native.tsx:57
 msgid "Sorry! Your session expired. Please log in again."
-msgstr ""
+msgstr "Désolé ! Votre session a expiré. Essayez de vous reconnecter."
 
 #: src/view/screens/PreferencesThreads.tsx:69
 msgid "Sort Replies"
@@ -3260,19 +3216,19 @@ msgstr "Carré"
 #: src/view/com/auth/create/Step1.tsx:90
 #: src/view/com/modals/ServerInput.tsx:62
 msgid "Staging"
-msgstr "Mise en scène"
+msgstr "Serveur de test"
 
 #: src/view/screens/Settings.tsx:780
 msgid "Status page"
-msgstr "Page de statut"
+msgstr "État du service"
 
 #: src/view/com/auth/create/StepHeader.tsx:15
 msgid "Step {step} of 3"
-msgstr ""
+msgstr "Étape {step} sur 3"
 
 #: src/view/screens/Settings.tsx:269
 msgid "Storage cleared, you need to restart the app now."
-msgstr ""
+msgstr "Stockage effacé, vous devez redémarrer l’application maintenant."
 
 #: src/view/screens/Settings.tsx:716
 msgid "Storybook"
@@ -3292,7 +3248,7 @@ msgstr "S’abonner à cette liste"
 
 #: src/view/com/lists/ListCard.tsx:101
 msgid "Subscribed"
-msgstr ""
+msgstr "Abonné·e"
 
 #: src/view/screens/Search/Search.tsx:362
 msgid "Suggested Follows"
@@ -3300,11 +3256,11 @@ msgstr "Suivis suggérés"
 
 #: src/view/com/profile/ProfileHeaderSuggestedFollows.tsx:64
 msgid "Suggested for you"
-msgstr ""
+msgstr "Suggérés pour vous"
 
 #: src/view/com/modals/SelfLabel.tsx:95
 msgid "Suggestive"
-msgstr ""
+msgstr "Suggestif"
 
 #: src/Navigation.tsx:214
 #: src/view/screens/Support.tsx:30
@@ -3314,7 +3270,7 @@ msgstr "Soutien"
 
 #: src/view/com/modals/ProfilePreview.tsx:110
 msgid "Swipe up to see more"
-msgstr ""
+msgstr "Glisser vers le haut pour en voir plus"
 
 #: src/view/com/modals/SwitchAccount.tsx:117
 msgid "Switch Account"
@@ -3323,16 +3279,16 @@ msgstr "Changer de compte"
 #: src/view/com/modals/SwitchAccount.tsx:97
 #: src/view/screens/Settings.tsx:132
 msgid "Switch to {0}"
-msgstr ""
+msgstr "Basculer sur {0}"
 
 #: src/view/com/modals/SwitchAccount.tsx:98
 #: src/view/screens/Settings.tsx:133
 msgid "Switches the account you are logged in to"
-msgstr ""
+msgstr "Bascule le compte auquel vous êtes connectés vers"
 
 #: src/view/screens/Settings.tsx:453
 msgid "System"
-msgstr ""
+msgstr "Système"
 
 #: src/view/screens/Settings.tsx:696
 msgid "System log"
@@ -3344,7 +3300,7 @@ msgstr "Grand"
 
 #: src/view/com/util/images/AutoSizedImage.tsx:70
 msgid "Tap to view fully"
-msgstr ""
+msgstr "Tapper pour voir en entier"
 
 #: src/view/shell/desktop/RightNav.tsx:93
 msgid "Terms"
@@ -3384,11 +3340,7 @@ msgstr "Notre politique de confidentialité a été déplacée vers <0/>"
 
 #: src/view/screens/Support.tsx:36
 msgid "The support form has been moved. If you need help, please <0/> or visit {HELP_DESK_URL} to get in touch with us."
-msgstr ""
-
-#: src/view/screens/Support.tsx:36
-#~ msgid "The support form has been moved. If you need help, please<0/> or visit {HELP_DESK_URL} to get in touch with us."
-#~ msgstr "Le formulaire d’assistance a été déplacé. Si vous avez besoin d’aide, veuillez <0/> ou rendez-vous sur {HELP_DESK_URL} pour nous contacter."
+msgstr "Le formulaire d’assistance a été déplacé. Si vous avez besoin d’aide, veuillez <0/> ou rendez-vous sur {HELP_DESK_URL} pour nous contacter."
 
 #: src/view/screens/TermsOfService.tsx:33
 msgid "The Terms of Service have been moved to"
@@ -3396,15 +3348,15 @@ msgstr "Nos conditions d’utilisation ont été déplacées vers"
 
 #: src/view/screens/ProfileFeed.tsx:558
 msgid "There was an an issue contacting the server, please check your internet connection and try again."
-msgstr ""
+msgstr "Il y a eu un problème de connexion au serveur, veuillez vérifier votre connexion Internet et réessayez."
 
 #: src/view/com/posts/FeedErrorMessage.tsx:139
 msgid "There was an an issue removing this feed. Please check your internet connection and try again."
-msgstr ""
+msgstr "Il y a eu un problème lors de la suppression du fil, veuillez vérifier votre connexion Internet et réessayez."
 
 #: src/view/screens/ProfileFeed.tsx:218
 msgid "There was an an issue updating your feeds, please check your internet connection and try again."
-msgstr ""
+msgstr "Il y a eu un problème lors de la mise à jour de vos fils d’actu, veuillez vérifier votre connexion Internet et réessayez."
 
 #: src/view/screens/ProfileFeed.tsx:245
 #: src/view/screens/ProfileList.tsx:266
@@ -3412,7 +3364,7 @@ msgstr ""
 #: src/view/screens/SavedFeeds.tsx:231
 #: src/view/screens/SavedFeeds.tsx:252
 msgid "There was an issue contacting the server"
-msgstr ""
+msgstr "Il y a eu un problème de connexion au serveur"
 
 #: src/view/com/auth/onboarding/RecommendedFeedsItem.tsx:57
 #: src/view/com/auth/onboarding/RecommendedFeedsItem.tsx:66
@@ -3420,32 +3372,32 @@ msgstr ""
 #: src/view/com/feeds/FeedSourceCard.tsx:127
 #: src/view/com/feeds/FeedSourceCard.tsx:181
 msgid "There was an issue contacting your server"
-msgstr ""
+msgstr "Il y a eu un problème de connexion à votre serveur"
 
 #: src/view/com/notifications/Feed.tsx:115
 msgid "There was an issue fetching notifications. Tap here to try again."
-msgstr ""
+msgstr "Il y a eu un problème lors de la récupération des notifications. Appuyez ici pour réessayer."
 
 #: src/view/com/posts/Feed.tsx:261
 msgid "There was an issue fetching posts. Tap here to try again."
-msgstr ""
+msgstr "Il y a eu un problème lors de la récupération des posts. Appuyez ici pour réessayer."
 
 #: src/view/com/lists/ListMembers.tsx:172
 msgid "There was an issue fetching the list. Tap here to try again."
-msgstr ""
+msgstr "Il y a eu un problème lors de la récupération de la liste. Appuyez ici pour réessayer."
 
 #: src/view/com/feeds/ProfileFeedgens.tsx:148
 #: src/view/com/lists/ProfileLists.tsx:155
 msgid "There was an issue fetching your lists. Tap here to try again."
-msgstr ""
+msgstr "Il y a eu un problème lors de la récupération de vos listes. Appuyez ici pour réessayer."
 
 #: src/view/com/modals/ContentFilteringSettings.tsx:126
 msgid "There was an issue syncing your preferences with the server"
-msgstr ""
+msgstr "Il y a eu un problème de synchronisation de vos préférences avec le serveur"
 
 #: src/view/screens/AppPasswords.tsx:66
 msgid "There was an issue with fetching your app passwords"
-msgstr ""
+msgstr "Il y a eu un problème lors de la récupération de vos mots de passe d’application"
 
 #: src/view/com/profile/ProfileHeader.tsx:204
 #: src/view/com/profile/ProfileHeader.tsx:225
@@ -3454,21 +3406,18 @@ msgstr ""
 #: src/view/com/profile/ProfileHeader.tsx:297
 #: src/view/com/profile/ProfileHeader.tsx:319
 msgid "There was an issue! {0}"
-msgstr ""
+msgstr "Il y a eu un problème ! {0}"
 
 #: src/view/screens/ProfileList.tsx:287
 #: src/view/screens/ProfileList.tsx:306
 #: src/view/screens/ProfileList.tsx:328
 #: src/view/screens/ProfileList.tsx:347
 msgid "There was an issue. Please check your internet connection and try again."
-msgstr ""
+msgstr "Il y a eu un problème. Veuillez vérifier votre connexion Internet et réessayez."
 
 #: src/view/com/util/ErrorBoundary.tsx:35
 msgid "There was an unexpected issue in the application. Please let us know if this happened to you!"
 msgstr "Un problème inattendu s’est produit dans l’application. N’hésitez pas à nous faire savoir si cela vous est arrivé !"
-
-#~ msgid "This {0} has been labeled."
-#~ msgstr "Ce {0} a été classé."
 
 #: src/view/com/util/moderation/ScreenHider.tsx:88
 msgid "This {screenDescription} has been flagged:"
@@ -3476,15 +3425,15 @@ msgstr "Ce {screenDescription} a été signalé :"
 
 #: src/view/com/util/moderation/ScreenHider.tsx:83
 msgid "This account has requested that users sign in to view their profile."
-msgstr "Ce compte a demandé aux utilisateurs de s’identifier pour voir son profil."
+msgstr "Ce compte a demandé aux personnes de s’identifier pour voir son profil."
 
 #: src/view/com/modals/EmbedConsent.tsx:68
 msgid "This content is hosted by {0}. Do you want to enable external media?"
-msgstr ""
+msgstr "Ce contenu est hébergé par {0}. Voulez-vous activer les médias externes ?"
 
 #: src/view/com/modals/ModerationDetails.tsx:67
 msgid "This content is not available because one of the users involved has blocked the other."
-msgstr ""
+msgstr "Ce contenu n’est pas disponible car l’un des comptes impliqués a bloqué l’autre."
 
 #: src/view/com/posts/FeedErrorMessage.tsx:108
 msgid "This content is not viewable without a Bluesky account."
@@ -3498,15 +3447,15 @@ msgstr "Ce fil d’actu reçoit actuellement un trafic important, il est tempora
 #: src/view/screens/ProfileFeed.tsx:484
 #: src/view/screens/ProfileList.tsx:639
 msgid "This feed is empty!"
-msgstr ""
+msgstr "Ce fil d’actu est vide !"
 
 #: src/view/com/posts/CustomFeedEmptyState.tsx:37
 msgid "This feed is empty! You may need to follow more users or tune your language settings."
-msgstr ""
+msgstr "Ce fil d’actu est vide ! Vous devriez peut-être suivre plus de comptes ou ajuster vos paramètres de langue."
 
 #: src/view/com/modals/BirthDateSettings.tsx:61
 msgid "This information is not shared with other users."
-msgstr "Ces informations ne sont pas partagées avec d’autres utilisateurs."
+msgstr "Ces informations ne sont pas partagées avec d’autres personnes."
 
 #: src/view/com/modals/VerifyEmail.tsx:119
 msgid "This is important in case you ever need to change your email or reset your password."
@@ -3522,11 +3471,11 @@ msgstr "Ce lien vous conduit au site Web suivant :"
 
 #: src/view/screens/ProfileList.tsx:813
 msgid "This list is empty!"
-msgstr ""
+msgstr "Cette liste est vide !"
 
 #: src/view/com/modals/AddAppPasswords.tsx:105
 msgid "This name is already in use"
-msgstr ""
+msgstr "Ce nom est déjà utilisé"
 
 #: src/view/com/post-thread/PostThreadItem.tsx:123
 msgid "This post has been deleted."
@@ -3534,15 +3483,15 @@ msgstr "Ce post a été supprimé."
 
 #: src/view/com/modals/ModerationDetails.tsx:62
 msgid "This user has blocked you. You cannot view their content."
-msgstr ""
+msgstr "Ce compte vous a bloqué. Vous ne pouvez pas voir son contenu."
 
 #: src/view/com/modals/ModerationDetails.tsx:42
 msgid "This user is included in the <0/> list which you have blocked."
-msgstr ""
+msgstr "Ce compte est inclus dans la liste <0/> que vous avez bloquée."
 
 #: src/view/com/modals/ModerationDetails.tsx:74
 msgid "This user is included the <0/> list which you have muted."
-msgstr ""
+msgstr "Ce compte est inclus dans la liste <0/> que vous avez masquée."
 
 #: src/view/com/modals/SelfLabel.tsx:137
 msgid "This warning is only available for posts with media attached."
@@ -3563,7 +3512,7 @@ msgstr "Mode arborescent"
 
 #: src/Navigation.tsx:254
 msgid "Threads Preferences"
-msgstr ""
+msgstr "Préférences de fils de discussion"
 
 #: src/view/com/util/forms/DropdownButton.tsx:234
 msgid "Toggle dropdown"
@@ -3582,11 +3531,7 @@ msgstr "Traduire"
 #: src/view/com/util/error/ErrorScreen.tsx:75
 msgctxt "action"
 msgid "Try again"
-msgstr ""
-
-#: src/view/com/util/error/ErrorScreen.tsx:73
-#~ msgid "Try again"
-#~ msgstr "Réessayer"
+msgstr "Réessayer"
 
 #: src/view/screens/ProfileList.tsx:484
 msgid "Un-block list"
@@ -3606,7 +3551,7 @@ msgstr "Impossible de contacter votre service. Veuillez vérifier votre connexio
 #: src/view/com/profile/ProfileHeader.tsx:475
 msgctxt "action"
 msgid "Unblock"
-msgstr ""
+msgstr "Débloquer"
 
 #: src/view/com/profile/ProfileHeader.tsx:472
 #: src/view/screens/ProfileList.tsx:568
@@ -3628,11 +3573,11 @@ msgstr "Annuler le repost"
 #: src/view/com/profile/FollowButton.tsx:55
 msgctxt "action"
 msgid "Unfollow"
-msgstr ""
+msgstr "Se désabonner"
 
 #: src/view/com/profile/ProfileHeader.tsx:524
 msgid "Unfollow {0}"
-msgstr ""
+msgstr "Se désabonner de {0}"
 
 #: src/view/com/auth/create/state.ts:216
 msgid "Unfortunately, you do not meet the requirements to create an account."
@@ -3640,11 +3585,11 @@ msgstr "Malheureusement, vous ne remplissez pas les conditions requises pour cr�
 
 #: src/view/com/util/post-ctrls/PostCtrls.tsx:189
 msgid "Unlike"
-msgstr ""
+msgstr "Déliker"
 
 #: src/view/screens/ProfileList.tsx:575
 msgid "Unmute"
-msgstr ""
+msgstr "Réafficher"
 
 #: src/view/com/profile/ProfileHeader.tsx:373
 msgid "Unmute Account"
@@ -3657,7 +3602,7 @@ msgstr "Réafficher ce fil de discussion"
 #: src/view/screens/ProfileFeed.tsx:362
 #: src/view/screens/ProfileList.tsx:559
 msgid "Unpin"
-msgstr ""
+msgstr "Désépingler"
 
 #: src/view/screens/ProfileList.tsx:452
 msgid "Unpin moderation list"
@@ -3665,7 +3610,7 @@ msgstr "Supprimer la liste de modération"
 
 #: src/view/screens/ProfileFeed.tsx:354
 msgid "Unsave"
-msgstr ""
+msgstr "Supprimer"
 
 #: src/view/com/modals/UserAddRemoveLists.tsx:54
 msgid "Update {displayName} in Lists"
@@ -3681,11 +3626,11 @@ msgstr "Mise à jour…"
 
 #: src/view/com/modals/ChangeHandle.tsx:455
 msgid "Upload a text file to:"
-msgstr "Télécharger un fichier texte vers :"
+msgstr "Envoyer un fichier texte vers :"
 
 #: src/view/screens/AppPasswords.tsx:195
 msgid "Use app passwords to login to other Bluesky clients without giving full access to your account or password."
-msgstr "Utiliser les mots de passe de l’appli pour se connecter à d’autres clients Bluesky sans donner un accès complet à votre compte ou à votre mot de passe."
+msgstr "Utilisez les mots de passe de l’appli pour se connecter à d’autres clients Bluesky sans donner un accès complet à votre compte ou à votre mot de passe."
 
 #: src/view/com/modals/ChangeHandle.tsx:515
 msgid "Use default provider"
@@ -3697,7 +3642,7 @@ msgstr "Utilisez-le pour vous connecter à l’autre application avec votre iden
 
 #: src/view/com/modals/ServerInput.tsx:105
 msgid "Use your domain as your Bluesky client service provider"
-msgstr ""
+msgstr "Utilise votre domaine comme un fournisseur de client Bluesky"
 
 #: src/view/com/modals/InviteCodes.tsx:200
 msgid "Used by:"
@@ -3705,63 +3650,63 @@ msgstr "Utilisé par :"
 
 #: src/view/com/modals/ModerationDetails.tsx:54
 msgid "User Blocked"
-msgstr ""
+msgstr "Compte bloqué"
 
 #: src/view/com/modals/ModerationDetails.tsx:40
 msgid "User Blocked by List"
-msgstr ""
+msgstr "Compte bloqué par liste"
 
 #: src/view/com/modals/ModerationDetails.tsx:60
 msgid "User Blocks You"
-msgstr ""
+msgstr "Compte qui vous bloque"
 
 #: src/view/com/auth/create/Step3.tsx:38
 msgid "User handle"
-msgstr "Pseudo utilisateur"
+msgstr "Pseudo"
 
 #: src/view/com/lists/ListCard.tsx:84
 #: src/view/com/modals/UserAddRemoveLists.tsx:182
 msgid "User list by {0}"
-msgstr ""
+msgstr "Liste de compte de {0}"
 
 #: src/view/screens/ProfileList.tsx:741
 msgid "User list by <0/>"
-msgstr ""
+msgstr "Liste de compte par <0/>"
 
 #: src/view/com/lists/ListCard.tsx:82
 #: src/view/com/modals/UserAddRemoveLists.tsx:180
 #: src/view/screens/ProfileList.tsx:739
 msgid "User list by you"
-msgstr ""
+msgstr "Liste de compte par vous"
 
 #: src/view/com/modals/CreateOrEditList.tsx:138
 msgid "User list created"
-msgstr ""
+msgstr "Liste de compte créée"
 
 #: src/view/com/modals/CreateOrEditList.tsx:125
 msgid "User list updated"
-msgstr ""
+msgstr "Liste de compte mise à jour"
 
 #: src/view/screens/Lists.tsx:58
 msgid "User Lists"
-msgstr "Listes d’utilisateurs"
+msgstr "Listes de comptes"
 
 #: src/view/com/auth/login/LoginForm.tsx:174
 #: src/view/com/auth/login/LoginForm.tsx:192
 msgid "Username or email address"
-msgstr "Nom d’utilisateur ou e-mail"
+msgstr "Pseudo ou e-mail"
 
 #: src/view/screens/ProfileList.tsx:775
 msgid "Users"
-msgstr "Utilisateurs"
+msgstr "Comptes"
 
 #: src/view/com/threadgate/WhoCanReply.tsx:143
 msgid "users followed by <0/>"
-msgstr "utilisateurs suivis par <0/>"
+msgstr "comptes suivis par <0/>"
 
 #: src/view/com/modals/Threadgate.tsx:106
 msgid "Users in \"{0}\""
-msgstr "Utilisateurs dans « {0} »"
+msgstr "Comptes dans « {0} »"
 
 #: src/view/screens/Settings.tsx:819
 msgid "Verify email"
@@ -3782,11 +3727,11 @@ msgstr "Confirmer le nouvel e-mail"
 
 #: src/view/com/modals/VerifyEmail.tsx:103
 msgid "Verify Your Email"
-msgstr ""
+msgstr "Vérifiez votre e-mail"
 
 #: src/view/com/profile/ProfileHeader.tsx:701
 msgid "View {0}'s avatar"
-msgstr ""
+msgstr "Voir l’avatar de {0}"
 
 #: src/view/screens/Log.tsx:52
 msgid "View debug entry"
@@ -3794,11 +3739,11 @@ msgstr "Afficher l’entrée de débogage"
 
 #: src/view/com/posts/FeedSlice.tsx:103
 msgid "View full thread"
-msgstr ""
+msgstr "Voir le fil de discussion entier"
 
 #: src/view/com/posts/FeedErrorMessage.tsx:172
 msgid "View profile"
-msgstr ""
+msgstr "Voir le profil"
 
 #: src/view/com/profile/ProfileSubpageHeader.tsx:128
 msgid "View the avatar"
@@ -3810,11 +3755,11 @@ msgstr "Visiter le site"
 
 #: src/view/com/modals/ContentFilteringSettings.tsx:254
 msgid "Warn"
-msgstr ""
+msgstr "Avertir"
 
 #: src/view/com/modals/AppealLabel.tsx:48
 msgid "We'll look into your appeal promptly."
-msgstr ""
+msgstr "Nous examinerons votre appel rapidement."
 
 #: src/view/com/auth/create/CreateAccount.tsx:122
 msgid "We're so excited to have you join us!"
@@ -3822,7 +3767,7 @@ msgstr "Nous sommes ravis de vous accueillir !"
 
 #: src/view/screens/ProfileList.tsx:83
 msgid "We're sorry, but we were unable to resolve this list. If this persists, please contact the list creator, @{handleOrDid}."
-msgstr ""
+msgstr "Nous sommes désolés, mais nous n’avons pas pu résoudre cette liste. Si cela persiste, veuillez contacter l’origine de la liste, @{handleOrDid}."
 
 #: src/view/screens/Search/Search.tsx:243
 msgid "We're sorry, but your search could not be completed. Please try again in a few minutes."
@@ -3883,7 +3828,7 @@ msgstr "Oui"
 #: src/view/com/posts/FollowingEmptyState.tsx:67
 #: src/view/com/posts/FollowingEndOfFeed.tsx:68
 msgid "You can also discover new Custom Feeds to follow."
-msgstr ""
+msgstr "Vous pouvez aussi découvrir de nouveaux fils d’actu personnalisés à suivre."
 
 #: src/view/com/auth/create/Step1.tsx:106
 msgid "You can change hosting providers at any time."
@@ -3916,11 +3861,11 @@ msgstr "Vous avez bloqué cet auteur ou vous avez été bloqué par celui-ci."
 
 #: src/view/com/modals/ModerationDetails.tsx:56
 msgid "You have blocked this user. You cannot view their content."
-msgstr ""
+msgstr "Vous avez bloqué ce compte. Vous ne pouvez pas voir son contenu."
 
 #: src/view/com/modals/ModerationDetails.tsx:87
 msgid "You have muted this user."
-msgstr ""
+msgstr "Vous avez masqué ce compte."
 
 #: src/view/com/feeds/ProfileFeedgens.tsx:136
 msgid "You have no feeds."
@@ -3945,15 +3890,15 @@ msgstr "Vous n’avez encore masqué aucun compte. Pour désactiver un compte, a
 
 #: src/view/com/modals/ContentFilteringSettings.tsx:170
 msgid "You must be 18 or older to enable adult content."
-msgstr ""
+msgstr "Vous devez avoir 18 ans ou plus pour activer le contenu pour adultes."
 
 #: src/view/com/util/forms/PostDropdownBtn.tsx:96
 msgid "You will no longer receive notifications for this thread"
-msgstr ""
+msgstr "Vous ne recevrez plus de notifications pour ce fil de discussion"
 
 #: src/view/com/util/forms/PostDropdownBtn.tsx:99
 msgid "You will now receive notifications for this thread"
-msgstr ""
+msgstr "Vous recevrez désormais des notifications pour ce fil de discussion"
 
 #: src/view/com/auth/login/SetNewPasswordForm.tsx:81
 msgid "You will receive an email with a \"reset code.\" Enter that code here, then enter your new password."
@@ -3961,7 +3906,7 @@ msgstr "Vous recevrez un e-mail contenant un « code de réinitialisation » S
 
 #: src/view/com/posts/FollowingEndOfFeed.tsx:48
 msgid "You've reached the end of your feed! Find some more accounts to follow."
-msgstr ""
+msgstr "Vous avez atteint la fin de votre fil d’actu ! Trouvez d’autres comptes à suivre."
 
 #: src/view/com/auth/create/Step2.tsx:58
 msgid "Your account"
@@ -3969,7 +3914,7 @@ msgstr "Votre compte"
 
 #: src/view/com/modals/DeleteAccount.tsx:65
 msgid "Your account has been deleted"
-msgstr ""
+msgstr "Votre compte a été supprimé"
 
 #: src/view/com/auth/create/Step2.tsx:146
 msgid "Your birth date"
@@ -3994,7 +3939,7 @@ msgstr "Votre e-mail n’a pas encore été vérifié. Il s’agit d’une mesur
 
 #: src/view/com/posts/FollowingEmptyState.tsx:47
 msgid "Your following feed is empty! Follow more users to see what's happening."
-msgstr ""
+msgstr "Votre fil d’actu des comptes suivis est vide ! Suivez plus de comptes pour voir ce qui se passe."
 
 #: src/view/com/auth/create/Step3.tsx:42
 msgid "Your full handle will be"
@@ -4002,11 +3947,11 @@ msgstr "Votre nom complet sera"
 
 #: src/view/com/modals/ChangeHandle.tsx:270
 msgid "Your full handle will be <0>@{0}</0>"
-msgstr ""
+msgstr "Votre pseudo complet sera <0>@{0}</0>"
 
 #: src/view/com/auth/create/Step1.tsx:53
 msgid "Your hosting provider"
-msgstr "Votre fournisseur d’hébergement"
+msgstr "Votre hébergeur"
 
 #: src/view/screens/Settings.tsx:417
 #: src/view/shell/desktop/RightNav.tsx:137
@@ -4016,12 +3961,12 @@ msgstr "Vos codes d’invitation sont cachés lorsque vous êtes connecté à l�
 
 #: src/view/com/composer/Composer.tsx:266
 msgid "Your post has been published"
-msgstr ""
+msgstr "Votre post a été publié"
 
 #: src/view/com/auth/onboarding/WelcomeDesktop.tsx:59
 #: src/view/com/auth/onboarding/WelcomeMobile.tsx:59
 msgid "Your posts, likes, and blocks are public. Mutes are private."
-msgstr "Vos posts, les mentions « J’aime » et les blocages sont publics. Les silences (comptes masqués) sont privés."
+msgstr "Vos posts, les likes et les blocages sont publics. Les silences (comptes masqués) sont privés."
 
 #: src/view/com/modals/SwitchAccount.tsx:84
 #: src/view/screens/Settings.tsx:120
@@ -4030,7 +3975,7 @@ msgstr "Votre profil"
 
 #: src/view/com/composer/Composer.tsx:265
 msgid "Your reply has been published"
-msgstr ""
+msgstr "Votre réponse a été publiée"
 
 #: src/view/com/auth/create/Step3.tsx:28
 msgid "Your user handle"


### PR DESCRIPTION
Now that we have more opportunities to insert ~~baguettes~~ French everywhere in the app, let's do it.

This should also solves #2425 (ping @fenarinarsa), by removing all usages of `utilisateur` (who implies masculine humans), substituting them by `compte` (gender-neutral) or `personne` (gender-neutral). I struggled with `abonné`, to finally use the interpunct / _point médian_, like what Mastodon does (for example, `123 followers` is now translated `123 abonné·e·s`).

Beside that, fixed a few typos, moved from `nom d'utilisateur` for _username_ to `pseudo` (same as _handle_), again to remove `utilisateur` everywhere to fix #2425.