### PR TITLE
rss: filter out replies server-side (tiny PR)

### DIFF
--- a/bskyweb/cmd/bskyweb/rss.go
+++ b/bskyweb/cmd/bskyweb/rss.go
@@ -80,7 +80,7 @@ func (srv *Server) WebProfileRSS(c echo.Context) error {
 		}
 	}
 
-	af, err := appbsky.FeedGetAuthorFeed(ctx, srv.xrpcc, did.String(), "", "", 30)
+	af, err := appbsky.FeedGetAuthorFeed(ctx, srv.xrpcc, did.String(), "", "posts_no_replies", 30)
 	if err != nil {
 		log.Warn("failed to fetch author feed", "did", did, "err", err)
 		return err


### PR DESCRIPTION
Small efficiency enhancement, to filter out replies server-side. The main behavior change will be that RSS feeds have more actual posts in them (longer set), as we don't currently paginated until we have a full set, just filter out replies and reposts.

We'll also want to filter out reposts server-side, but that will require https://github.com/bluesky-social/atproto/issues/2048