### PR TITLE
style: Fix waitlist text align on auth screen

### DIFF
--- a/src/view/com/auth/create/Step2.tsx
+++ b/src/view/com/auth/create/Step2.tsx
@@ -81,7 +81,7 @@ export function Step2({
       {!uiState.inviteCode && uiState.isInviteCodeRequired ? (
         <View style={[s.flexRow, s.alignCenter]}>
           <Text style={pal.text}>
-            <Trans>Don't have an invite code?</Trans>
+            <Trans>Don't have an invite code?</Trans>{' '}
           </Text>
           <TouchableWithoutFeedback
             onPress={onPressWaitlist}
@@ -189,6 +189,5 @@ const styles = StyleSheet.create({
   // @ts-expect-error: Suppressing error due to incomplete `ViewStyle` type definition in react-native-web, missing `cursor` prop as discussed in https://github.com/necolas/react-native-web/issues/832.
   touchable: {
     ...(isWeb && {cursor: 'pointer'}),
-    paddingLeft: 4,
   },
 })

--- a/src/view/com/auth/create/Step2.tsx
+++ b/src/view/com/auth/create/Step2.tsx
@@ -79,8 +79,10 @@ export function Step2({
       )}
 
       {!uiState.inviteCode && uiState.isInviteCodeRequired ? (
-        <Text style={[s.alignBaseline, pal.text]}>
-          <Trans>Don't have an invite code?</Trans>{' '}
+        <View style={[s.flexRow, s.alignCenter]}>
+          <Text style={pal.text}>
+            <Trans>Don't have an invite code?</Trans>
+          </Text>
           <TouchableWithoutFeedback
             onPress={onPressWaitlist}
             accessibilityLabel={_(msg`Join the waitlist.`)}
@@ -91,7 +93,7 @@ export function Step2({
               </Text>
             </View>
           </TouchableWithoutFeedback>
-        </Text>
+        </View>
       ) : (
         <>
           <View style={s.pb20}>
@@ -187,5 +189,6 @@ const styles = StyleSheet.create({
   // @ts-expect-error: Suppressing error due to incomplete `ViewStyle` type definition in react-native-web, missing `cursor` prop as discussed in https://github.com/necolas/react-native-web/issues/832.
   touchable: {
     ...(isWeb && {cursor: 'pointer'}),
+    paddingLeft: 4,
   },
 })


### PR DESCRIPTION
This pr fixes the "Join the waitlist." text align issue


Before:
<img width="415" alt="Ekran Resmi 2024-01-15 00 32 51" src="https://github.com/bluesky-social/social-app/assets/35095902/13925948-ed53-4cba-a631-1cd5855607d5">


After:
<img width="415" alt="Ekran Resmi 2024-01-15 00 32 27" src="https://github.com/bluesky-social/social-app/assets/35095902/1f546509-3b2b-481f-8130-19f243746bf0">
