### PR TITLE
Improved search autocomplete view

### DIFF
--- a/src/view/screens/Search/Search.tsx
+++ b/src/view/screens/Search/Search.tsx
@@ -42,7 +42,11 @@ import {useSetDrawerOpen} from '#/state/shell'
 import {useAnalytics} from '#/lib/analytics/analytics'
 import {MagnifyingGlassIcon} from '#/lib/icons'
 import {useModerationOpts} from '#/state/queries/preferences'
-import {SearchResultCard} from '#/view/shell/desktop/Search'
+import {
+  MATCH_HANDLE,
+  SearchLinkCard,
+  SearchProfileCard,
+} from '#/view/shell/desktop/Search'
 import {useSetMinimalShellMode, useSetDrawerSwipeDisabled} from '#/state/shell'
 import {isWeb} from '#/platform/detection'
 import {listenSoftReset} from '#/state/events'
@@ -511,6 +515,11 @@ export function SearchScreen(
     onPressCancelSearch()
   }, [onPressCancelSearch])
 
+  const queryMaybeHandle = React.useMemo(() => {
+    const match = MATCH_HANDLE.exec(query)
+    return match && match[1]
+  }, [query])
+
   useFocusEffect(
     React.useCallback(() => {
       setMinimalShellMode(false)
@@ -617,18 +626,26 @@ export function SearchScreen(
               dataSet={{stableGutters: '1'}}
               keyboardShouldPersistTaps="handled"
               keyboardDismissMode="on-drag">
-              {searchResults.length ? (
-                searchResults.map((item, i) => (
-                  <SearchResultCard
-                    key={item.did}
-                    profile={item}
-                    moderation={moderateProfile(item, moderationOpts)}
-                    style={i === 0 ? {borderTopWidth: 0} : {}}
-                  />
-                ))
-              ) : (
-                <EmptyState message={_(msg`No results found for ${query}`)} />
-              )}
+              <SearchLinkCard
+                label={_(msg`Search for "${query}"`)}
+                to={`/search?q=${encodeURIComponent(query)}`}
+                style={{borderBottomWidth: 1}}
+              />
+
+              {queryMaybeHandle ? (
+                <SearchLinkCard
+                  label={_(msg`Go to @${queryMaybeHandle}`)}
+                  to={`/profile/${queryMaybeHandle}`}
+                />
+              ) : null}
+
+              {searchResults.map(item => (
+                <SearchProfileCard
+                  key={item.did}
+                  profile={item}
+                  moderation={moderateProfile(item, moderationOpts)}
+                />
+              ))}
 
               <View style={{height: 200}} />
             </ScrollView>

--- a/src/view/shell/desktop/Search.tsx
+++ b/src/view/shell/desktop/Search.tsx
@@ -29,13 +29,41 @@ import {UserAvatar} from '#/view/com/util/UserAvatar'
 import {useActorAutocompleteFn} from '#/state/queries/actor-autocomplete'
 import {useModerationOpts} from '#/state/queries/preferences'
 
-export function SearchResultCard({
-  profile,
+export const MATCH_HANDLE =
+  /@?([a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*(?:\.[a-zA-Z]{2,}))/
+
+export function SearchLinkCard({
+  label,
+  to,
   style,
+}: {
+  label: string
+  to: string
+  style?: ViewStyle
+}) {
+  const pal = usePalette('default')
+
+  return (
+    <Link href={to} asAnchor anchorNoUnderline>
+      <View
+        style={[
+          pal.border,
+          {paddingVertical: 16, paddingHorizontal: 12},
+          style,
+        ]}>
+        <Text type="md" style={[pal.text]}>
+          {label}
+        </Text>
+      </View>
+    </Link>
+  )
+}
+
+export function SearchProfileCard({
+  profile,
   moderation,
 }: {
   profile: AppBskyActorDefs.ProfileViewBasic
-  style: ViewStyle
   moderation: ProfileModeration
 }) {
   const pal = usePalette('default')
@@ -50,9 +78,7 @@ export function SearchResultCard({
       <View
         style={[
           pal.border,
-          style,
           {
-            borderTopWidth: 1,
             flexDirection: 'row',
             alignItems: 'center',
             gap: 12,
@@ -147,6 +173,11 @@ export function DesktopSearch() {
     navigation.dispatch(StackActions.push('Search', {q: query}))
   }, [query, navigation, setSearchResults])
 
+  const queryMaybeHandle = React.useMemo(() => {
+    const match = MATCH_HANDLE.exec(query)
+    return match && match[1]
+  }, [query])
+
   return (
     <View style={[styles.container, pal.view]}>
       <View
@@ -198,22 +229,26 @@ export function DesktopSearch() {
             </View>
           ) : (
             <>
-              {searchResults.length ? (
-                searchResults.map((item, i) => (
-                  <SearchResultCard
-                    key={item.did}
-                    profile={item}
-                    moderation={moderateProfile(item, moderationOpts)}
-                    style={i === 0 ? {borderTopWidth: 0} : {}}
-                  />
-                ))
-              ) : (
-                <View>
-                  <Text style={[pal.textLight, styles.noResults]}>
-                    <Trans>No results found for {query}</Trans>
-                  </Text>
-                </View>
-              )}
+              <SearchLinkCard
+                label={_(msg`Search for "${query}"`)}
+                to={`/search?q=${encodeURIComponent(query)}`}
+                style={{borderBottomWidth: 1}}
+              />
+
+              {queryMaybeHandle ? (
+                <SearchLinkCard
+                  label={_(msg`Go to @${queryMaybeHandle}`)}
+                  to={`/profile/${queryMaybeHandle}`}
+                />
+              ) : null}
+
+              {searchResults.map(item => (
+                <SearchProfileCard
+                  key={item.did}
+                  profile={item}
+                  moderation={moderateProfile(item, moderationOpts)}
+                />
+              ))}
             </>
           )}
         </View>


### PR DESCRIPTION
Users seems to be getting confused about whether they're currently in the "autocomplete view" or the actual "search view" when trying to search for posts (https://github.com/bluesky-social/social-app/issues/849#issuecomment-1888569647). This pull request improves on the UI.

Not sure about the removal of borders on profiles, thought I'd do it to make the distinction between "Search for ..." and profile suggestions even clearer.

`Go to @handle` is powered by a regex that matches domain-like substrings, when it can find one, then it's shown to the user.

---

| Before | After |
| --- | --- |
| ![image](https://github.com/bluesky-social/social-app/assets/148872143/25a24a2d-86f7-40a0-aed4-e3fb55f42a3d) | ![image](https://github.com/bluesky-social/social-app/assets/148872143/bf01c714-e14f-4d45-9daf-66c2c82be798) |
| ![image](https://github.com/bluesky-social/social-app/assets/148872143/758840d0-d365-4a6c-b8a0-249e45470fca) | ![image](https://github.com/bluesky-social/social-app/assets/148872143/dbd67c33-a1a8-4675-81cf-c5c6a7dfd0c9) |
|  ![image](https://github.com/bluesky-social/social-app/assets/148872143/c2a9079a-3d84-4395-a5c3-8be104499df2) | ![image](https://github.com/bluesky-social/social-app/assets/148872143/a8fa0a46-e747-4978-a3a3-ae22dc388000) |

---

| Before | After |
| --- | --- |
| ![image](https://github.com/bluesky-social/social-app/assets/148872143/c0a32342-b0be-4920-8949-ef9296dd07e3) | ![image](https://github.com/bluesky-social/social-app/assets/148872143/a082fb4d-5a68-4c19-8a62-58d52dcada41) |
| ![image](https://github.com/bluesky-social/social-app/assets/148872143/7bc55e5a-66bc-4e19-a09c-e10787d4c142) | ![image](https://github.com/bluesky-social/social-app/assets/148872143/c7bea37a-befc-457d-842e-a32788d0e00e)
| ![image](https://github.com/bluesky-social/social-app/assets/148872143/16717c00-2228-4125-be9c-24d597779a54) | ![image](https://github.com/bluesky-social/social-app/assets/148872143/96906091-655a-4ba7-9157-e24a867eeb8f) |
