### PR TITLE
Remove excess l10n related markups

### DIFF
--- a/src/Navigation.tsx
+++ b/src/Navigation.tsx
@@ -144,7 +144,7 @@ function commonScreens(Stack: typeof HomeTab, unreadCountLabel?: string) {
         name="Profile"
         getComponent={() => ProfileScreen}
         options={({route}) => ({
-          title: title(msg`@${route.params.name}`),
+          title: bskyTitle(`@${route.params.name}`, unreadCountLabel),
           animation: 'none',
         })}
       />

--- a/src/view/com/modals/CreateOrEditList.tsx
+++ b/src/view/com/modals/CreateOrEditList.tsx
@@ -182,19 +182,17 @@ export function Component({
         ]}
         testID="createOrEditListModal">
         <Text style={[styles.title, pal.text]}>
-          <Trans>
-            {isCurateList ? (
-              list ? (
-                <Trans>Edit User List</Trans>
-              ) : (
-                <Trans>New User List</Trans>
-              )
-            ) : list ? (
-              <Trans>Edit Moderation List</Trans>
+          {isCurateList ? (
+            list ? (
+              <Trans>Edit User List</Trans>
             ) : (
-              <Trans>New Moderation List</Trans>
-            )}
-          </Trans>
+              <Trans>New User List</Trans>
+            )
+          ) : list ? (
+            <Trans>Edit Moderation List</Trans>
+          ) : (
+            <Trans>New Moderation List</Trans>
+          )}
         </Text>
         {error !== '' && (
           <View style={styles.errorContainer}>

--- a/src/view/screens/Search/Search.tsx
+++ b/src/view/screens/Search/Search.tsx
@@ -83,9 +83,7 @@ function EmptyState({message, error}: {message: string; error?: string}) {
         },
       ]}>
       <View style={[pal.viewLight, {padding: 18, borderRadius: 8}]}>
-        <Text style={[pal.text]}>
-          <Trans>{message}</Trans>
-        </Text>
+        <Text style={[pal.text]}>{message}</Text>
 
         {error && (
           <>

--- a/src/view/screens/Settings.tsx
+++ b/src/view/screens/Settings.tsx
@@ -291,7 +291,7 @@ export function SettingsScreen({}: Props) {
         ]}>
         <View style={{flex: 1}}>
           <Text type="title-lg" style={[pal.text, {fontWeight: 'bold'}]}>
-            <Trans>{_(msg`Settings`)}</Trans>
+            <Trans>Settings</Trans>
           </Text>
         </View>
       </SimpleViewHeader>


### PR DESCRIPTION
There are excess l10n markups which produce meaningless `msgid`/`msgstr` pairs in message catalogue.