### PR TITLE
Fix the fallback to discover behavior on the home feed

### DIFF
--- a/src/lib/api/feed/home.ts
+++ b/src/lib/api/feed/home.ts
@@ -68,7 +68,8 @@ export class HomeFeedAPI implements FeedAPI {
       const res = await this.following.fetch({cursor, limit})
       returnCursor = res.cursor
       posts = posts.concat(res.feed)
-      if (res.feed.length === 0 || !cursor) {
+      if (!returnCursor) {
+        cursor = ''
         posts.push(FALLBACK_MARKER_POST)
         this.usingDiscover = true
       }


### PR DESCRIPTION
There were in fact TWO bugs that didn't reveal themselves, and one bad logical choice

1. We were checking `cursor` instead of `returnCursor` (bug)
2. We werent resetting the `cursor` when switching to discover (bug)
3. We were checking the feed length, which is not the definitive "end of feed" condition