### PR TITLE
Patch `@lingui/core` to fix `unraw` import resolution error

### DIFF
--- a/patches/@lingui+core+4.5.0.patch
+++ b/patches/@lingui+core+4.5.0.patch
@@ -1,0 +1,10 @@
+diff --git a/node_modules/@lingui/core/dist/index.mjs b/node_modules/@lingui/core/dist/index.mjs
+index 9759736..881f67b 100644
+--- a/node_modules/@lingui/core/dist/index.mjs
++++ b/node_modules/@lingui/core/dist/index.mjs
+@@ -1,4 +1,4 @@
+-import unraw from 'unraw';
++import { unraw } from 'unraw';
+ import { compileMessage } from '@lingui/message-utils/compileMessage';
+ 
+ const isString = (s) => typeof s === "string";


### PR DESCRIPTION
Fixes #2535 

Temp patch, see filed issue in Lingui repo https://github.com/lingui/js-lingui/issues/1836

![CleanShot 2024-01-16 at 15 17 39@2x](https://github.com/bluesky-social/social-app/assets/4732330/8cbe8d34-2bf8-4778-8ad4-1275321220fa)
![CleanShot 2024-01-16 at 15 17 45@2x](https://github.com/bluesky-social/social-app/assets/4732330/0d15cf45-eccd-4664-b90e-1d2d282d7a34)
![CleanShot 2024-01-16 at 15 17 49@2x](https://github.com/bluesky-social/social-app/assets/4732330/54c52110-aed9-4eed-b267-f326b596632c)
