### PR TITLE
fix: make alt text selectable in Lightbox

### DIFF
--- a/src/view/com/lightbox/Lightbox.tsx
+++ b/src/view/com/lightbox/Lightbox.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import {Pressable, StyleSheet, View} from 'react-native'
+import {StyleSheet, View, Pressable} from 'react-native'
 import {FontAwesomeIcon} from '@fortawesome/react-native-fontawesome'
 import ImageView from './ImageViewing'
 import {shareImageModal, saveImageToMediaLibrary} from 'lib/media/manip'
@@ -107,12 +107,16 @@ function LightboxFooter({imageIndex}: {imageIndex: number}) {
       {altText ? (
         <Pressable
           onPress={() => setAltExpanded(!isAltExpanded)}
+          onLongPress={() => {}}
           accessibilityRole="button">
-          <Text
-            style={[s.gray3, styles.footerText]}
-            numberOfLines={isAltExpanded ? undefined : 3}>
-            {altText}
-          </Text>
+          <View>
+            <Text
+              selectable
+              style={[s.gray3, styles.footerText]}
+              numberOfLines={isAltExpanded ? undefined : 3}>
+              {altText}
+            </Text>
+          </View>
         </Pressable>
       ) : null}
       <View style={styles.footerBtns}>


### PR DESCRIPTION
fixes #2293 
| Android | iOS |
| ------- | --- |
| ![Android](https://github.com/bluesky-social/social-app/assets/34245032/d80defd6-c0a2-4aff-85b5-bc7ee832be3f) | ![iOS](https://github.com/bluesky-social/social-app/assets/34245032/b263caa7-1bd8-41bb-8013-41dfe0b04af5) |