### PR TITLE
Fixes msgfmt error in line 196

### DIFF
--- a/src/locale/locales/ca/messages.po
+++ b/src/locale/locales/ca/messages.po
@@ -188,12 +188,12 @@ msgstr "Contrasenyes de l'aplicació"
 
 #: src/view/com/util/forms/PostDropdownBtn.tsx:236
 msgid "Appeal content warning"
-msgstr "Afegeix una advertència de contingut"
+msgstr "Advertència d'apel·lació sobre el contingut"
 
 #: src/view/com/modals/AppealLabel.tsx:65
 msgid "Appeal Content Warning"
-msgstr "Afegeix una advertència de contingut"
-Apel·lació d'advertència sobre el contingut
+msgstr "Advertència d'apel·lació sobre el contingut"
+
 #: src/view/com/util/moderation/LabelInfo.tsx:52
 msgid "Appeal this decision"
 msgstr "Apel·la aquesta decisió"


### PR DESCRIPTION
Hello. The current PO file for Catalan language in main is incorrect, see:

msgfmt -c --statistics messages.po 
messages.po:196: keyword "Apel" unknown
messages.po:196:5: syntax error
msgfmt: found 2 fatal errors

It looks like that a last minute fixed went into the wrong line of the file. This fixes the issue:

After this fix:

msgfmt -c messages.po  --statistics 
552 translated messages.
