### PR TITLE
flex and truncate content hider text

### DIFF
--- a/src/view/com/util/moderation/ContentHider.tsx
+++ b/src/view/com/util/moderation/ContentHider.tsx
@@ -94,7 +94,7 @@ export function ContentHider({
             <ShieldExclamation size={18} style={pal.textLight} />
           )}
         </Pressable>
-        <Text type="md" style={pal.text}>
+        <Text type="md" style={[pal.text, {flex: 1}]} numberOfLines={2}>
           {desc.name}
         </Text>
         <View style={styles.showBtn}>
@@ -131,7 +131,7 @@ const styles = StyleSheet.create({
   cover: {
     flexDirection: 'row',
     alignItems: 'center',
-    gap: 4,
+    gap: 6,
     borderRadius: 8,
     marginTop: 4,
     paddingVertical: 14,


### PR DESCRIPTION
![IMG_4754](https://github.com/bluesky-social/social-app/assets/153161762/85298a29-77dd-4978-a905-d542b86bb766)

![Screenshot 2024-01-19 at 1 40 01 AM](https://github.com/bluesky-social/social-app/assets/153161762/4dbb0119-2317-4f35-b6b3-80ea08d067b2)

caps line count to two. could go to one, but better to err on side of showing more context