### PR TITLE
improve external link design

### DIFF
--- a/src/view/com/util/post-embeds/ExternalLinkEmbed.tsx
+++ b/src/view/com/util/post-embeds/ExternalLinkEmbed.tsx
@@ -32,7 +32,7 @@ export const ExternalLinkEmbed = ({
     <View style={styles.container}>
       {link.thumb && !embedPlayerParams ? (
         <Image
-          style={{height: isMobile ? 150 : 250, width: '100%'}}
+          style={{height: isMobile ? 180 : 250, width: '100%'}}
           source={{uri: link.thumb}}
           accessibilityIgnoresInvertColors
         />
@@ -51,10 +51,7 @@ export const ExternalLinkEmbed = ({
           {toNiceDomain(link.uri)}
         </Text>
         {!embedPlayerParams?.isGif && (
-          <Text
-            type="lg-bold"
-            numberOfLines={link.thumb ? 2 : 3}
-            style={[pal.text]}>
+          <Text type="lg-bold" numberOfLines={3} style={[pal.text]}>
             {link.title || link.uri}
           </Text>
         )}

--- a/src/view/com/util/post-embeds/ExternalLinkEmbed.tsx
+++ b/src/view/com/util/post-embeds/ExternalLinkEmbed.tsx
@@ -29,22 +29,13 @@ export const ExternalLinkEmbed = ({
   }, [link.uri, externalEmbedPrefs])
 
   return (
-    <View style={{flexDirection: 'column'}}>
+    <View style={styles.container}>
       {link.thumb && !embedPlayerParams ? (
-        <View
-          style={{
-            borderTopLeftRadius: 6,
-            borderTopRightRadius: 6,
-            width: '100%',
-            height: isMobile ? 200 : 300,
-            overflow: 'hidden',
-          }}>
-          <Image
-            style={styles.extImage}
-            source={{uri: link.thumb}}
-            accessibilityIgnoresInvertColors
-          />
-        </View>
+        <Image
+          style={{height: isMobile ? 150 : 250, width: '100%'}}
+          source={{uri: link.thumb}}
+          accessibilityIgnoresInvertColors
+        />
       ) : undefined}
       {(embedPlayerParams?.isGif && (
         <ExternalGifEmbed link={link} params={embedPlayerParams} />
@@ -52,12 +43,7 @@ export const ExternalLinkEmbed = ({
         (embedPlayerParams && (
           <ExternalPlayer link={link} params={embedPlayerParams} />
         ))}
-      <View
-        style={{
-          paddingHorizontal: isMobile ? 10 : 14,
-          paddingTop: 8,
-          paddingBottom: 10,
-        }}>
+      <View style={[styles.info, {paddingHorizontal: isMobile ? 10 : 14}]}>
         <Text
           type="sm"
           numberOfLines={1}
@@ -65,14 +51,17 @@ export const ExternalLinkEmbed = ({
           {toNiceDomain(link.uri)}
         </Text>
         {!embedPlayerParams?.isGif && (
-          <Text type="lg-bold" numberOfLines={4} style={[pal.text]}>
+          <Text
+            type="lg-bold"
+            numberOfLines={link.thumb ? 2 : 3}
+            style={[pal.text]}>
             {link.title || link.uri}
           </Text>
         )}
         {link.description && !embedPlayerParams?.hideDetails ? (
           <Text
             type="md"
-            numberOfLines={4}
+            numberOfLines={link.thumb ? 2 : 4}
             style={[pal.text, styles.extDescription]}>
             {link.description}
           </Text>
@@ -83,8 +72,16 @@ export const ExternalLinkEmbed = ({
 }
 
 const styles = StyleSheet.create({
-  extImage: {
-    flex: 1,
+  container: {
+    flexDirection: 'column',
+    borderRadius: 6,
+    overflow: 'hidden',
+  },
+  info: {
+    width: '100%',
+    bottom: 0,
+    paddingTop: 8,
+    paddingBottom: 10,
   },
   extUri: {
     marginTop: 2,

--- a/src/view/com/util/post-embeds/ExternalLinkEmbed.tsx
+++ b/src/view/com/util/post-embeds/ExternalLinkEmbed.tsx
@@ -32,7 +32,7 @@ export const ExternalLinkEmbed = ({
     <View style={styles.container}>
       {link.thumb && !embedPlayerParams ? (
         <Image
-          style={{height: isMobile ? 180 : 250, width: '100%'}}
+          style={{aspectRatio: 1.91}}
           source={{uri: link.thumb}}
           accessibilityIgnoresInvertColors
         />


### PR DESCRIPTION
fixes https://github.com/bluesky-social/social-app/issues/2556
fixes https://github.com/bluesky-social/social-app/issues/2555

Improves the sizing of external embeds so they don't take up so much screen space.

- Reduce thumb size on mobile from 200 to 180
- Reduce thumb size on web from 300 to 250
- Reduce number of description lines from 4 to 2 unless there is no thumbnail
- Cleanup unnecessary styles and move everything to the stylesheet

https://github.com/bluesky-social/social-app/assets/153161762/dec24810-ae9e-4715-bd8f-10186c822e1b

