### PR TITLE
Fix orphan replies in linear mode

### DIFF
--- a/src/view/com/post-thread/PostThread.tsx
+++ b/src/view/com/post-thread/PostThread.tsx
@@ -157,7 +157,11 @@ function PostThreadLoaded({
   const posts = React.useMemo(() => {
     let arr = [TOP_COMPONENT].concat(
       Array.from(
-        flattenThreadSkeleton(sortThread(thread, threadViewPrefs), hasSession),
+        flattenThreadSkeleton(
+          sortThread(thread, threadViewPrefs),
+          hasSession,
+          treeView,
+        ),
       ),
     )
     if (arr.length > maxVisible) {
@@ -167,7 +171,7 @@ function PostThreadLoaded({
       arr.push(BOTTOM_COMPONENT)
     }
     return arr
-  }, [thread, maxVisible, threadViewPrefs, hasSession])
+  }, [thread, treeView, maxVisible, threadViewPrefs, hasSession])
 
   /**
    * NOTE
@@ -468,10 +472,11 @@ function isThreadPost(v: unknown): v is ThreadPost {
 function* flattenThreadSkeleton(
   node: ThreadNode,
   hasSession: boolean,
+  treeView: boolean,
 ): Generator<YieldedItem, void> {
   if (node.type === 'post') {
     if (node.parent) {
-      yield* flattenThreadSkeleton(node.parent, hasSession)
+      yield* flattenThreadSkeleton(node.parent, hasSession, treeView)
     } else if (node.ctx.isParentLoading) {
       yield PARENT_SPINNER
     }
@@ -484,7 +489,10 @@ function* flattenThreadSkeleton(
     }
     if (node.replies?.length) {
       for (const reply of node.replies) {
-        yield* flattenThreadSkeleton(reply, hasSession)
+        yield* flattenThreadSkeleton(reply, hasSession, treeView)
+        if (!treeView && !node.ctx.isHighlightedPost) {
+          break
+        }
       }
     } else if (node.ctx.isChildLoading) {
       yield CHILD_SPINNER


### PR DESCRIPTION
The way we show replies in a linear mode isn't quite right IMO.

Consider this thread: http://bsky.app/profile/danabra.mov/post/3kjemen7ies27

Opening the root post shows replies to further posts on the same level:

<img width="577" alt="Screenshot 2024-01-19 at 23 51 40" src="https://github.com/bluesky-social/social-app/assets/810438/1266dc71-f262-4264-8f13-6319c66a7791">

This breaks the flow of conversation. You see replies out of the context to which they were replying — which is not just confusing but can also cause miscommunication (like "I agree" replying to a different post in the thread).

Instead, I think this should work like on Twitter. You only see the reply chains that are *for* the post you currently highlighted.

So on the root post I should see just this:

<img width="514" alt="Screenshot 2024-01-19 at 23 54 21" src="https://github.com/bluesky-social/social-app/assets/810438/6eee4088-3215-42b9-af7c-387d452f289d">

For the "post 1" post, I should see this:

<img width="546" alt="Screenshot 2024-01-19 at 23 54 51" src="https://github.com/bluesky-social/social-app/assets/810438/b08d1d22-8686-46cb-aefe-426d92e810dd">

And so on.

This only affects linear mode. In threaded mode, all replies are still shown.

<img width="538" alt="Screenshot 2024-01-19 at 23 55 45" src="https://github.com/bluesky-social/social-app/assets/810438/c2c320cf-2a8b-4020-b4f3-1da48579025f">
