### PR TITLE
use theme's color scheme in in-app browser

### DIFF
--- a/src/state/preferences/in-app-browser.tsx
+++ b/src/state/preferences/in-app-browser.tsx
@@ -4,6 +4,7 @@ import {Linking} from 'react-native'
 import * as WebBrowser from 'expo-web-browser'
 import {isNative} from '#/platform/detection'
 import {useModalControls} from '../modals'
+import {usePalette} from 'lib/hooks/usePalette'
 
 type StateContext = persisted.Schema['useInAppBrowser']
 type SetContext = (v: persisted.Schema['useInAppBrowser']) => void
@@ -52,6 +53,7 @@ export function useSetInAppBrowser() {
 export function useOpenLink() {
   const {openModal} = useModalControls()
   const enabled = useInAppBrowser()
+  const pal = usePalette('default')
 
   const openLink = React.useCallback(
     (url: string, override?: boolean) => {
@@ -66,13 +68,14 @@ export function useOpenLink() {
           WebBrowser.openBrowserAsync(url, {
             presentationStyle:
               WebBrowser.WebBrowserPresentationStyle.FULL_SCREEN,
+            toolbarColor: pal.colors.backgroundLight,
           })
           return
         }
       }
       Linking.openURL(url)
     },
-    [enabled, openModal],
+    [enabled, openModal, pal.colors.backgroundLight],
   )
 
   return openLink


### PR DESCRIPTION
instead of using the system's color scheme, use the user's selected color scheme for the in-app browser

![RocketSim_Recording_iPhone_15_Pro_6 1_2024-01-19_16 17 05](https://github.com/bluesky-social/social-app/assets/153161762/5a089277-4dba-4631-b97c-5b1ada8f724f)
