### PR TITLE
Image drag and drop on web composer

### DIFF
--- a/src/view/com/composer/text-input/TextInput.web.tsx
+++ b/src/view/com/composer/text-input/TextInput.web.tsx
@@ -111,24 +111,32 @@ export const TextInput = React.forwardRef(function TextInputImpl(
       event.preventDefault()
       setIsDropping(false)
     }
-    const handleDragOver = (event: DragEvent) => {
+    const handleDragEnter = (event: DragEvent) => {
       const transfer = event.dataTransfer
+
+      event.preventDefault()
       if (transfer && transfer.types.includes('Files')) {
         setIsDropping(true)
       }
     }
-    const handleDragLeave = (_event: DragEvent) => {
+    const handleDragLeave = (event: DragEvent) => {
+      event.preventDefault()
       setIsDropping(false)
+    }
+    const handleDragOver = (event: DragEvent) => {
+      event.preventDefault()
     }
 
     document.body.addEventListener('drop', handleDrop)
-    document.body.addEventListener('dragover', handleDragOver)
+    document.body.addEventListener('dragenter', handleDragEnter)
     document.body.addEventListener('dragleave', handleDragLeave)
+    document.body.addEventListener('dragover', handleDragOver)
 
     return () => {
       document.body.removeEventListener('drop', handleDrop)
-      document.body.removeEventListener('dragover', handleDragOver)
+      document.body.removeEventListener('dragenter', handleDragEnter)
       document.body.removeEventListener('dragleave', handleDragLeave)
+      document.body.removeEventListener('dragover', handleDragOver)
     }
   }, [setIsDropping])
 

--- a/src/view/com/composer/text-input/TextInput.web.tsx
+++ b/src/view/com/composer/text-input/TextInput.web.tsx
@@ -123,20 +123,17 @@ export const TextInput = React.forwardRef(function TextInputImpl(
       event.preventDefault()
       setIsDropping(false)
     }
-    const handleDragOver = (event: DragEvent) => {
-      event.preventDefault()
-    }
 
     document.body.addEventListener('drop', handleDrop)
     document.body.addEventListener('dragenter', handleDragEnter)
+    document.body.addEventListener('dragover', handleDragEnter)
     document.body.addEventListener('dragleave', handleDragLeave)
-    document.body.addEventListener('dragover', handleDragOver)
 
     return () => {
       document.body.removeEventListener('drop', handleDrop)
       document.body.removeEventListener('dragenter', handleDragEnter)
+      document.body.removeEventListener('dragover', handleDragEnter)
       document.body.removeEventListener('dragleave', handleDragLeave)
-      document.body.removeEventListener('dragover', handleDragOver)
     }
   }, [setIsDropping])
 

--- a/src/view/com/composer/text-input/TextInput.web.tsx
+++ b/src/view/com/composer/text-input/TextInput.web.tsx
@@ -298,10 +298,11 @@ const styles = StyleSheet.create({
     boxShadow: 'rgba(0, 0, 0, 0.3) 0px 5px 20px',
     padding: 8,
     borderWidth: 1,
-    borderRadius: 8,
+    borderRadius: 16,
   },
   dropText: {
-    padding: 32,
+    paddingVertical: 44,
+    paddingHorizontal: 36,
     borderStyle: 'dashed',
     borderRadius: 8,
     borderWidth: 2,

--- a/src/view/com/composer/text-input/TextInput.web.tsx
+++ b/src/view/com/composer/text-input/TextInput.web.tsx
@@ -235,11 +235,7 @@ export const TextInput = React.forwardRef(function TextInputImpl(
             <View style={[pal.view, pal.border, styles.dropModal]}>
               <Text
                 type="lg"
-                style={[
-                  pal.text,
-                  {borderColor: pal.colors.borderDark},
-                  styles.dropText,
-                ]}>
+                style={[pal.text, pal.borderDark, styles.dropText]}>
                 <Trans>Drop to add images</Trans>
               </Text>
             </View>


### PR DESCRIPTION
Fixes https://github.com/bluesky-social/social-app/issues/1257

Adds the ability to insert images by drag-and-drop.
The drop trigger covers the whole screen so you don't have to go very far to add the image.

The overlay modal has a box-shadow to compensate for reduced opacity on the backdrop, because having the backdrop opacity be the same as the composer modal seems to make it *too* dark.

![image](https://github.com/bluesky-social/social-app/assets/148872143/a9c7955f-bfff-43f9-a70c-99fea7d1657c)
![image](https://github.com/bluesky-social/social-app/assets/148872143/5e81a2d1-ffa3-4f76-8af0-120407e10864)
