### PR TITLE
Fix jump when opening last post in thread

### DIFF
--- a/src/view/com/post-thread/PostThread.tsx
+++ b/src/view/com/post-thread/PostThread.tsx
@@ -298,8 +298,10 @@ function PostThreadLoaded({
         // -prf
         return (
           <View
+            // @ts-ignore web-only
             style={{
-              height: 400,
+              // Leave enough space below that the scroll doesn't jump
+              height: isNative ? 400 : '100vh',
               borderTopWidth: 1,
               borderColor: pal.colors.border,
             }}


### PR DESCRIPTION
There wasn't enough space at the bottom, so clicking on a post _sometimes_ jumps scroll. With this change, it doesn't. The problem was web-only; on native, the scroll position is respected but it will bounce a bit upwards when you try scrolling. Which IMO is fine so I didn't change the native number.

## Before

https://github.com/bluesky-social/social-app/assets/810438/e8003111-9788-49de-b6cc-df3464887b73

## After

https://github.com/bluesky-social/social-app/assets/810438/9ab4c462-6d75-4bf8-8f41-f087eea73fc8

