### PR TITLE
Disable scroll on the composer TextInput (close #2413)

### DIFF
--- a/src/view/com/composer/text-input/TextInput.tsx
+++ b/src/view/com/composer/text-input/TextInput.tsx
@@ -217,6 +217,7 @@ export const TextInput = forwardRef(function TextInputImpl(
         autoFocus={true}
         allowFontScaling
         multiline
+        scrollEnabled={false}
         numberOfLines={4}
         style={[
           pal.text,


### PR DESCRIPTION
In iOS, a multiline textinput has a scrolling behavior of its own. This created a scrollview-within-scrollview problem on iOS, because we embed the entire composer in a scrollview.

Disabling the scrolling behavior on the textinput solves this issue.

Closes #2413