### PR TITLE
Bump replies

### DIFF
--- a/src/lib/api/feed-manip.ts
+++ b/src/lib/api/feed-manip.ts
@@ -177,8 +177,11 @@ export class FeedTuner {
 
             parent.insert(item)
 
-            slices.splice(index, 1)
-            slices.unshift(parent)
+            // If our slice isn't currently on the top, reinsert it to the top.
+            if (index !== 0) {
+              slices.splice(index, 1)
+              slices.unshift(parent)
+            }
 
             continue
           }

--- a/src/lib/api/feed-manip.ts
+++ b/src/lib/api/feed-manip.ts
@@ -168,14 +168,22 @@ export class FeedTuner {
 
         const selfReplyUri = getSelfReplyUri(item)
         if (selfReplyUri) {
-          const parent = slices.find(item2 =>
-            item2.isNextInThread(selfReplyUri),
+          const index = slices.findIndex(slice =>
+            slice.isNextInThread(selfReplyUri),
           )
-          if (parent) {
+
+          if (index !== -1) {
+            const parent = slices[index]
+
             parent.insert(item)
+
+            slices.splice(index, 1)
+            slices.unshift(parent)
+
             continue
           }
         }
+
         slices.unshift(new FeedViewPostsSlice([item]))
       }
     }


### PR DESCRIPTION
Fixes https://github.com/bluesky-social/social-app/issues/875

This partly addresses the complaints of low engagements on replies by bumping the entire slice up to the top of timeline. Given that we're requesting 60 posts at a time in the following feed, this means that threads can be much further apart and still be eligible for bumping.

It's somewhat open for abuse, but I don't think it should be an issue.

| Before | After |
| --- | --- |
| <img width=200 src=https://github.com/bluesky-social/social-app/assets/148872143/bc604551-746b-4740-aa95-4ced8acde3f3> | <img width=200 src=https://github.com/bluesky-social/social-app/assets/148872143/322b3356-6976-4477-8294-45b6ae435660> |
