### PR TITLE
Fix server icon in sign up flow not responding to dark mode

### DIFF
--- a/src/view/com/auth/create/Step1.tsx
+++ b/src/view/com/auth/create/Step1.tsx
@@ -77,7 +77,7 @@ export function Step1({
             accessibilityLabel={_(msg`Select service`)}
             accessibilityHint={_(msg`Sets server for the Bluesky client`)}
             onPress={onPressSelectService}>
-            <FontAwesomeIcon icon="server" size={21} />
+            <FontAwesomeIcon icon="server" size={21} color={pal.colors.text} />
           </Button>
         </View>
       </StepHeader>


### PR DESCRIPTION
Fixes a bug where an icon didn't respond to dark mode and thus was near impossible to see

Before:

<img width="703" alt="Screenshot 2024-01-24 at 15 31 10" src="https://github.com/bluesky-social/social-app/assets/10959775/49a25a23-91ee-42c3-ad78-f79eaadccde4">

After:

<img width="668" alt="Screenshot 2024-01-24 at 15 30 53" src="https://github.com/bluesky-social/social-app/assets/10959775/4ee44038-aedb-4270-b455-647cb866f1c7">
