### PR TITLE
Add English name after endonym for app languages in Settings

### DIFF
--- a/src/locale/languages.ts
+++ b/src/locale/languages.ts
@@ -25,16 +25,16 @@ interface AppLanguageConfig {
 
 export const APP_LANGUAGES: AppLanguageConfig[] = [
   {code2: AppLanguage.en, name: 'English'},
-  {code2: AppLanguage.de, name: 'Deutsch'},
-  {code2: AppLanguage.es, name: 'Español'},
-  {code2: AppLanguage.fr, name: 'Français'},
-  {code2: AppLanguage.hi, name: 'हिंदी'},
-  {code2: AppLanguage.id, name: 'Bahasa Indonesia'},
-  {code2: AppLanguage.ja, name: '日本語'},
-  {code2: AppLanguage.ko, name: '한국어'},
-  {code2: AppLanguage.pt_BR, name: 'Português (BR)'},
-  {code2: AppLanguage.uk, name: 'Українська'},
-  {code2: AppLanguage.ca, name: 'Catalan'},
+  {code2: AppLanguage.de, name: 'Deutsch – German'},
+  {code2: AppLanguage.es, name: 'Español – Spanish'},
+  {code2: AppLanguage.fr, name: 'Français – French'},
+  {code2: AppLanguage.hi, name: 'हिंदी – Hindi'},
+  {code2: AppLanguage.id, name: 'Bahasa Indonesia – Indonesian'},
+  {code2: AppLanguage.ja, name: '日本語 – Japanese'},
+  {code2: AppLanguage.ko, name: '한국어 – Korean'},
+  {code2: AppLanguage.pt_BR, name: 'Português (BR) – Portuguese (BR)'},
+  {code2: AppLanguage.uk, name: 'Українська – Ukrainian'},
+  {code2: AppLanguage.ca, name: 'Català – Catalan'},
 ]
 
 export const LANGUAGES: Language[] = [


### PR DESCRIPTION
This PR adds the English name after the endonym for app languages in Settings and also adds the endonym for Catalan.

Please feel free to close this if it would make the UI cluttered or confusing.