### PR TITLE
Capitalize screen headers consistently

### DIFF
--- a/src/view/screens/NotFound.tsx
+++ b/src/view/screens/NotFound.tsx
@@ -39,7 +39,7 @@ export const NotFoundScreen = () => {
 
   return (
     <View testID="notFoundView" style={pal.view}>
-      <ViewHeader title={_(msg`Page not found`)} />
+      <ViewHeader title={_(msg`Page Not Found`)} />
       <View style={styles.container}>
         <Text type="title-2xl" style={[pal.text, s.mb10]}>
           <Trans>Page not found</Trans>

--- a/src/view/screens/PostLikedBy.tsx
+++ b/src/view/screens/PostLikedBy.tsx
@@ -24,7 +24,7 @@ export const PostLikedByScreen = ({route}: Props) => {
 
   return (
     <View>
-      <ViewHeader title={_(msg`Liked by`)} />
+      <ViewHeader title={_(msg`Liked By`)} />
       <PostLikedByComponent uri={uri} />
     </View>
   )

--- a/src/view/screens/PostRepostedBy.tsx
+++ b/src/view/screens/PostRepostedBy.tsx
@@ -24,7 +24,7 @@ export const PostRepostedByScreen = ({route}: Props) => {
 
   return (
     <View>
-      <ViewHeader title={_(msg`Reposted by`)} />
+      <ViewHeader title={_(msg`Reposted By`)} />
       <PostRepostedByComponent uri={uri} />
     </View>
   )

--- a/src/view/screens/ProfileFeedLikedBy.tsx
+++ b/src/view/screens/ProfileFeedLikedBy.tsx
@@ -24,7 +24,7 @@ export const ProfileFeedLikedByScreen = ({route}: Props) => {
 
   return (
     <View>
-      <ViewHeader title={_(msg`Liked by`)} />
+      <ViewHeader title={_(msg`Liked By`)} />
       <PostLikedByComponent uri={uri} />
     </View>
   )


### PR DESCRIPTION
Looks like we're using title case for these. In title case, the first and the last word should be capitalized even if they're prepositions — so "Liked By" not "Liked by".

Verified other headers already follow title case.