### PR TITLE
Clean up the post controls UI

### DIFF
--- a/src/view/com/util/LoadingPlaceholder.tsx
+++ b/src/view/com/util/LoadingPlaceholder.tsx
@@ -6,8 +6,12 @@ import {
   ViewStyle,
   DimensionValue,
 } from 'react-native'
-import {FontAwesomeIcon} from '@fortawesome/react-native-fontawesome'
-import {HeartIcon, HeartIconSolid} from 'lib/icons'
+import {
+  HeartIcon,
+  HeartIconSolid,
+  CommentBottomArrow,
+  RepostIcon,
+} from 'lib/icons'
 import {s} from 'lib/styles'
 import {useTheme} from 'lib/ThemeContext'
 import {usePalette} from 'lib/hooks/usePalette'
@@ -61,30 +65,30 @@ export function PostLoadingPlaceholder({
         <LoadingPlaceholder width={100} height={6} style={{marginBottom: 10}} />
         <LoadingPlaceholder width="95%" height={6} style={{marginBottom: 8}} />
         <LoadingPlaceholder width="95%" height={6} style={{marginBottom: 8}} />
-        <LoadingPlaceholder width="80%" height={6} style={{marginBottom: 15}} />
-        <View style={s.flexRow}>
-          <View style={s.flex1}>
-            <FontAwesomeIcon
-              style={{color: theme.palette.default.icon}}
-              icon={['far', 'comment']}
-              size={14}
+        <LoadingPlaceholder width="80%" height={6} style={{marginBottom: 11}} />
+        <View style={styles.postCtrls}>
+          <View style={[styles.postCtrl, {paddingLeft: 0}]}>
+            <CommentBottomArrow
+              style={[{color: theme.palette.default.icon, marginTop: 1}]}
+              strokeWidth={3}
+              size={15}
             />
           </View>
-          <View style={s.flex1}>
-            <FontAwesomeIcon
+          <View style={styles.postCtrl}>
+            <RepostIcon
               style={{color: theme.palette.default.icon}}
-              icon="retweet"
-              size={18}
+              strokeWidth={3}
+              size={20}
             />
           </View>
-          <View style={s.flex1}>
+          <View style={styles.postCtrl}>
             <HeartIcon
               style={{color: theme.palette.default.icon} as ViewStyle}
-              size={17}
-              strokeWidth={1.7}
+              size={16}
+              strokeWidth={3}
             />
           </View>
-          <View style={s.flex1} />
+          <View style={{width: 30, height: 30}} />
         </View>
       </View>
     </View>
@@ -267,6 +271,18 @@ const styles = StyleSheet.create({
     paddingHorizontal: 10,
     paddingTop: 20,
     paddingBottom: 5,
+    paddingRight: 15,
+  },
+  postCtrls: {
+    opacity: 0.5,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+  },
+  postCtrl: {
+    padding: 5,
+    flex: 1,
+    flexDirection: 'row',
+    alignItems: 'center',
   },
   avatar: {
     borderRadius: 26,

--- a/src/view/com/util/post-ctrls/PostCtrls.tsx
+++ b/src/view/com/util/post-ctrls/PostCtrls.tsx
@@ -171,13 +171,15 @@ let PostCtrls = ({
           </Text>
         ) : undefined}
       </TouchableOpacity>
-      <RepostButton
-        big={big}
-        isReposted={!!post.viewer?.repost}
-        repostCount={post.repostCount}
-        onRepost={onRepost}
-        onQuote={onQuote}
-      />
+      <View style={[styles.ctrl, !big && styles.ctrlPad]}>
+        <RepostButton
+          big={big}
+          isReposted={!!post.viewer?.repost}
+          repostCount={post.repostCount}
+          onRepost={onRepost}
+          onQuote={onQuote}
+        />
+      </View>
       <TouchableOpacity
         testID="likeBtn"
         style={[styles.ctrl, !big && styles.ctrlPad]}
@@ -237,6 +239,7 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
   },
   ctrl: {
+    flex: 1,
     flexDirection: 'row',
     alignItems: 'center',
   },

--- a/src/view/com/util/post-ctrls/PostCtrls.tsx
+++ b/src/view/com/util/post-ctrls/PostCtrls.tsx
@@ -165,7 +165,7 @@ let PostCtrls = ({
           strokeWidth={3}
           size={big ? 20 : 15}
         />
-        {typeof post.replyCount !== 'undefined' ? (
+        {typeof post.replyCount !== 'undefined' && post.replyCount > 0 ? (
           <Text style={[defaultCtrlColor, s.ml5, s.f15]}>
             {post.replyCount}
           </Text>
@@ -199,7 +199,7 @@ let PostCtrls = ({
             size={big ? 20 : 16}
           />
         )}
-        {typeof post.likeCount !== 'undefined' ? (
+        {typeof post.likeCount !== 'undefined' && post.likeCount > 0 ? (
           <Text
             testID="likeCount"
             style={

--- a/src/view/com/util/post-ctrls/RepostButton.tsx
+++ b/src/view/com/util/post-ctrls/RepostButton.tsx
@@ -53,7 +53,7 @@ let RepostButton = ({
       onPress={() => {
         requireAuth(() => onPressToggleRepostWrapper())
       }}
-      style={[styles.control, !big && styles.controlPad]}
+      style={[styles.container]}
       accessibilityRole="button"
       accessibilityLabel={`${
         isReposted
@@ -89,7 +89,7 @@ RepostButton = memo(RepostButton)
 export {RepostButton}
 
 const styles = StyleSheet.create({
-  control: {
+  container: {
     flexDirection: 'row',
     alignItems: 'center',
   },

--- a/src/view/com/util/post-ctrls/RepostButton.tsx
+++ b/src/view/com/util/post-ctrls/RepostButton.tsx
@@ -71,7 +71,7 @@ let RepostButton = ({
         strokeWidth={2.4}
         size={big ? 24 : 20}
       />
-      {typeof repostCount !== 'undefined' ? (
+      {typeof repostCount !== 'undefined' && repostCount > 0 ? (
         <Text
           testID="repostCount"
           style={

--- a/src/view/com/util/post-ctrls/RepostButton.tsx
+++ b/src/view/com/util/post-ctrls/RepostButton.tsx
@@ -93,9 +93,6 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     alignItems: 'center',
   },
-  controlPad: {
-    padding: 5,
-  },
   reposted: {
     color: colors.green3,
   },

--- a/src/view/com/util/post-ctrls/RepostButton.web.tsx
+++ b/src/view/com/util/post-ctrls/RepostButton.web.tsx
@@ -110,7 +110,6 @@ export const RepostButton = ({
 
 const styles = StyleSheet.create({
   container: {
-    display: 'flex',
     flexDirection: 'row',
     alignItems: 'center',
     gap: 4,

--- a/src/view/com/util/post-ctrls/RepostButton.web.tsx
+++ b/src/view/com/util/post-ctrls/RepostButton.web.tsx
@@ -76,12 +76,12 @@ export const RepostButton = ({
           : defaultControlColor) as StyleProp<ViewStyle>,
       ]}>
       <RepostIcon strokeWidth={2.2} size={big ? 24 : 20} />
-      {typeof repostCount !== 'undefined' ? (
+      {typeof repostCount !== 'undefined' && repostCount > 0 ? (
         <Text
           testID="repostCount"
           type={isReposted ? 'md-bold' : 'md'}
           style={styles.repostCount}>
-          {repostCount ?? 0}
+          {repostCount}
         </Text>
       ) : undefined}
     </View>

--- a/src/view/com/util/post-ctrls/RepostButton.web.tsx
+++ b/src/view/com/util/post-ctrls/RepostButton.web.tsx
@@ -69,8 +69,7 @@ export const RepostButton = ({
   const inner = (
     <View
       style={[
-        styles.control,
-        !big && styles.controlPad,
+        styles.container,
         (isReposted
           ? styles.reposted
           : defaultControlColor) as StyleProp<ViewStyle>,
@@ -110,14 +109,11 @@ export const RepostButton = ({
 }
 
 const styles = StyleSheet.create({
-  control: {
+  container: {
     display: 'flex',
     flexDirection: 'row',
     alignItems: 'center',
     gap: 4,
-  },
-  controlPad: {
-    padding: 5,
   },
   reposted: {
     color: colors.green3,


### PR DESCRIPTION
## Before

- Numbers were shown even when zero.
- Buttons were subtle misaligned between different posts.

<img width="773" alt="Screenshot 2024-01-25 at 00 18 56" src="https://github.com/bluesky-social/social-app/assets/810438/88855a91-2e4c-4424-8f5e-13bc1c832137">

- Liking a post was shifting the repost button.

https://github.com/bluesky-social/social-app/assets/810438/cce01bc1-0cca-4dad-b0fa-165cd10f7f5b

- Loading shim was using different icons and spacing than the actual content.

https://github.com/bluesky-social/social-app/assets/810438/01d4f379-fc2f-47a9-834a-0a9dc201e5ae

## After

- The number zero is no longer displayed at all.
- Buttons are aligned between different posts.

<img width="769" alt="Screenshot 2024-01-25 at 00 18 26" src="https://github.com/bluesky-social/social-app/assets/810438/e08a3236-1ee9-4158-a07d-76dbfc6e3eae">

- Liking a post no longer shifts the repost button.

https://github.com/bluesky-social/social-app/assets/810438/5296cebf-172b-40ec-a6d5-cce71f9a987c

- Loading shim uses the same icons and spacing as the actual content.

https://github.com/bluesky-social/social-app/assets/810438/0a912e6c-7ad7-4711-8b9e-ade730324818

---

Verified web and iOS. My Android emulator got borked.