### PR TITLE
Remove dead code for optimistic updates

### DIFF
--- a/src/state/queries/profile.ts
+++ b/src/state/queries/profile.ts
@@ -149,7 +149,6 @@ export function useProfileFollowMutationQueue(
       if (shouldFollow) {
         const {uri} = await followMutation.mutateAsync({
           did,
-          skipOptimistic: true,
         })
         return uri
       } else {
@@ -157,7 +156,6 @@ export function useProfileFollowMutationQueue(
           await unfollowMutation.mutateAsync({
             did,
             followUri: prevFollowingUri,
-            skipOptimistic: true,
           })
         }
         return undefined
@@ -191,67 +189,21 @@ export function useProfileFollowMutationQueue(
 }
 
 function useProfileFollowMutation() {
-  return useMutation<
-    {uri: string; cid: string},
-    Error,
-    {did: string; skipOptimistic?: boolean}
-  >({
+  return useMutation<{uri: string; cid: string}, Error, {did: string}>({
     mutationFn: async ({did}) => {
       return await getAgent().follow(did)
     },
-    onMutate(variables) {
-      if (!variables.skipOptimistic) {
-        // optimistically update
-        updateProfileShadow(variables.did, {
-          followingUri: 'pending',
-        })
-      }
-    },
     onSuccess(data, variables) {
-      if (!variables.skipOptimistic) {
-        // finalize
-        updateProfileShadow(variables.did, {
-          followingUri: data.uri,
-        })
-        track('Profile:Follow', {username: variables.did})
-      }
-    },
-    onError(error, variables) {
-      if (!variables.skipOptimistic) {
-        // revert the optimistic update
-        updateProfileShadow(variables.did, {
-          followingUri: undefined,
-        })
-      }
+      track('Profile:Follow', {username: variables.did})
     },
   })
 }
 
 function useProfileUnfollowMutation() {
-  return useMutation<
-    void,
-    Error,
-    {did: string; followUri: string; skipOptimistic?: boolean}
-  >({
+  return useMutation<void, Error, {did: string; followUri: string}>({
     mutationFn: async ({followUri}) => {
       track('Profile:Unfollow', {username: followUri})
       return await getAgent().deleteFollow(followUri)
-    },
-    onMutate(variables) {
-      if (!variables.skipOptimistic) {
-        // optimistically update
-        updateProfileShadow(variables.did, {
-          followingUri: undefined,
-        })
-      }
-    },
-    onError(error, variables) {
-      if (!variables.skipOptimistic) {
-        // revert the optimistic update
-        updateProfileShadow(variables.did, {
-          followingUri: variables.followUri,
-        })
-      }
     },
   })
 }
@@ -270,13 +222,11 @@ export function useProfileMuteMutationQueue(
       if (shouldMute) {
         await muteMutation.mutateAsync({
           did,
-          skipOptimistic: true,
         })
         return true
       } else {
         await unmuteMutation.mutateAsync({
           did,
-          skipOptimistic: true,
         })
         return false
       }
@@ -308,56 +258,24 @@ export function useProfileMuteMutationQueue(
 
 function useProfileMuteMutation() {
   const queryClient = useQueryClient()
-  return useMutation<void, Error, {did: string; skipOptimistic?: boolean}>({
+  return useMutation<void, Error, {did: string}>({
     mutationFn: async ({did}) => {
       await getAgent().mute(did)
     },
-    onMutate(variables) {
-      if (!variables.skipOptimistic) {
-        // optimistically update
-        updateProfileShadow(variables.did, {
-          muted: true,
-        })
-      }
-    },
     onSuccess() {
       queryClient.invalidateQueries({queryKey: RQKEY_MY_MUTED()})
-    },
-    onError(error, variables) {
-      if (!variables.skipOptimistic) {
-        // revert the optimistic update
-        updateProfileShadow(variables.did, {
-          muted: false,
-        })
-      }
     },
   })
 }
 
 function useProfileUnmuteMutation() {
   const queryClient = useQueryClient()
-  return useMutation<void, Error, {did: string; skipOptimistic?: boolean}>({
+  return useMutation<void, Error, {did: string}>({
     mutationFn: async ({did}) => {
       await getAgent().unmute(did)
     },
-    onMutate(variables) {
-      if (!variables.skipOptimistic) {
-        // optimistically update
-        updateProfileShadow(variables.did, {
-          muted: false,
-        })
-      }
-    },
     onSuccess() {
       queryClient.invalidateQueries({queryKey: RQKEY_MY_MUTED()})
-    },
-    onError(error, variables) {
-      if (!variables.skipOptimistic) {
-        // revert the optimistic update
-        updateProfileShadow(variables.did, {
-          muted: true,
-        })
-      }
     },
   })
 }
@@ -376,7 +294,6 @@ export function useProfileBlockMutationQueue(
       if (shouldFollow) {
         const {uri} = await blockMutation.mutateAsync({
           did,
-          skipOptimistic: true,
         })
         return uri
       } else {
@@ -384,7 +301,6 @@ export function useProfileBlockMutationQueue(
           await unblockMutation.mutateAsync({
             did,
             blockUri: prevBlockUri,
-            skipOptimistic: true,
           })
         }
         return undefined
@@ -420,11 +336,7 @@ export function useProfileBlockMutationQueue(
 function useProfileBlockMutation() {
   const {currentAccount} = useSession()
   const queryClient = useQueryClient()
-  return useMutation<
-    {uri: string; cid: string},
-    Error,
-    {did: string; skipOptimistic?: boolean}
-  >({
+  return useMutation<{uri: string; cid: string}, Error, {did: string}>({
     mutationFn: async ({did}) => {
       if (!currentAccount) {
         throw new Error('Not signed in')
@@ -434,41 +346,15 @@ function useProfileBlockMutation() {
         {subject: did, createdAt: new Date().toISOString()},
       )
     },
-    onMutate(variables) {
-      if (!variables.skipOptimistic) {
-        // optimistically update
-        updateProfileShadow(variables.did, {
-          blockingUri: 'pending',
-        })
-      }
-    },
-    onSuccess(data, variables) {
-      if (!variables.skipOptimistic) {
-        // finalize
-        updateProfileShadow(variables.did, {
-          blockingUri: data.uri,
-        })
-      }
+    onSuccess() {
       queryClient.invalidateQueries({queryKey: RQKEY_MY_BLOCKED()})
-    },
-    onError(error, variables) {
-      if (!variables.skipOptimistic) {
-        // revert the optimistic update
-        updateProfileShadow(variables.did, {
-          blockingUri: undefined,
-        })
-      }
     },
   })
 }
 
 function useProfileUnblockMutation() {
   const {currentAccount} = useSession()
-  return useMutation<
-    void,
-    Error,
-    {did: string; blockUri: string; skipOptimistic?: boolean}
-  >({
+  return useMutation<void, Error, {did: string; blockUri: string}>({
     mutationFn: async ({blockUri}) => {
       if (!currentAccount) {
         throw new Error('Not signed in')
@@ -478,22 +364,6 @@ function useProfileUnblockMutation() {
         repo: currentAccount.did,
         rkey,
       })
-    },
-    onMutate(variables) {
-      if (!variables.skipOptimistic) {
-        // optimistically update
-        updateProfileShadow(variables.did, {
-          blockingUri: undefined,
-        })
-      }
-    },
-    onError(error, variables) {
-      if (!variables.skipOptimistic) {
-        // revert the optimistic update
-        updateProfileShadow(variables.did, {
-          blockingUri: variables.blockUri,
-        })
-      }
     },
   })
 }


### PR DESCRIPTION
In https://github.com/bluesky-social/social-app/pull/1933 I've moved the optimistic update handling from raw mutations to the "queue" methods like `useProfileFollowMutationQueue`. The individual optimistic update logic remained in the underlying mutation logic but was disabled by passing `{skipOptimistic: true}`. I left this as an option in case we want to use the raw mutations somewhere in the interface after all.

A few months later, we're still not using raw mutation methods for those toggles anywhere. And really, we shouldn't—if you're building some new UI, you should just use the queue anyway. So let's remove this option and assume it's always `true`. This lets us simplify the mutations and make it clearer what's actually going on.