### PR TITLE
Derive shadow like/repost count

### DIFF
--- a/src/state/cache/post-shadow.ts
+++ b/src/state/cache/post-shadow.ts
@@ -12,9 +12,7 @@ export type {Shadow} from './types'
 
 export interface PostShadow {
   likeUri: string | undefined
-  likeCount: number | undefined
   repostUri: string | undefined
-  repostCount: number | undefined
   isDeleted: boolean
 }
 
@@ -62,11 +60,31 @@ function mergeShadow(
   if (shadow.isDeleted) {
     return POST_TOMBSTONE
   }
+
+  const wasLiked = !!post.viewer?.like
+  const isLiked = !!shadow.likeUri
+  let likeCount = post.likeCount ?? 0
+  if (wasLiked && !isLiked) {
+    likeCount--
+  } else if (!wasLiked && isLiked) {
+    likeCount++
+  }
+  likeCount = Math.max(0, likeCount)
+
+  const wasReposted = !!post.viewer?.repost
+  const isReposted = !!shadow.repostUri
+  let repostCount = post.repostCount ?? 0
+  if (wasReposted && !isReposted) {
+    repostCount--
+  } else if (!wasReposted && isReposted) {
+    repostCount++
+  }
+  repostCount = Math.max(0, repostCount)
+
   return castAsShadow({
     ...post,
-    likeCount: 'likeCount' in shadow ? shadow.likeCount : post.likeCount,
-    repostCount:
-      'repostCount' in shadow ? shadow.repostCount : post.repostCount,
+    likeCount: likeCount,
+    repostCount: repostCount,
     viewer: {
       ...(post.viewer || {}),
       like: 'likeUri' in shadow ? shadow.likeUri : post.viewer?.like,

--- a/src/state/queries/post.ts
+++ b/src/state/queries/post.ts
@@ -59,13 +59,12 @@ export function usePostLikeMutation() {
   return useMutation<
     {uri: string}, // responds with the uri of the like
     Error,
-    {uri: string; cid: string; likeCount: number} // the post's uri, cid, and likes
+    {uri: string; cid: string} // the post's uri and cid
   >({
     mutationFn: post => getAgent().like(post.uri, post.cid),
     onMutate(variables) {
       // optimistically update the post-shadow
       updatePostShadow(variables.uri, {
-        likeCount: variables.likeCount + 1,
         likeUri: 'pending',
       })
     },
@@ -79,7 +78,6 @@ export function usePostLikeMutation() {
     onError(error, variables) {
       // revert the optimistic update
       updatePostShadow(variables.uri, {
-        likeCount: variables.likeCount,
         likeUri: undefined,
       })
     },
@@ -87,11 +85,7 @@ export function usePostLikeMutation() {
 }
 
 export function usePostUnlikeMutation() {
-  return useMutation<
-    void,
-    Error,
-    {postUri: string; likeUri: string; likeCount: number}
-  >({
+  return useMutation<void, Error, {postUri: string; likeUri: string}>({
     mutationFn: async ({likeUri}) => {
       await getAgent().deleteLike(likeUri)
       track('Post:Unlike')
@@ -99,14 +93,12 @@ export function usePostUnlikeMutation() {
     onMutate(variables) {
       // optimistically update the post-shadow
       updatePostShadow(variables.postUri, {
-        likeCount: variables.likeCount - 1,
         likeUri: undefined,
       })
     },
     onError(error, variables) {
       // revert the optimistic update
       updatePostShadow(variables.postUri, {
-        likeCount: variables.likeCount,
         likeUri: variables.likeUri,
       })
     },
@@ -117,13 +109,12 @@ export function usePostRepostMutation() {
   return useMutation<
     {uri: string}, // responds with the uri of the repost
     Error,
-    {uri: string; cid: string; repostCount: number} // the post's uri, cid, and reposts
+    {uri: string; cid: string} // the post's uri and cid
   >({
     mutationFn: post => getAgent().repost(post.uri, post.cid),
     onMutate(variables) {
       // optimistically update the post-shadow
       updatePostShadow(variables.uri, {
-        repostCount: variables.repostCount + 1,
         repostUri: 'pending',
       })
     },
@@ -137,7 +128,6 @@ export function usePostRepostMutation() {
     onError(error, variables) {
       // revert the optimistic update
       updatePostShadow(variables.uri, {
-        repostCount: variables.repostCount,
         repostUri: undefined,
       })
     },
@@ -145,11 +135,7 @@ export function usePostRepostMutation() {
 }
 
 export function usePostUnrepostMutation() {
-  return useMutation<
-    void,
-    Error,
-    {postUri: string; repostUri: string; repostCount: number}
-  >({
+  return useMutation<void, Error, {postUri: string; repostUri: string}>({
     mutationFn: async ({repostUri}) => {
       await getAgent().deleteRepost(repostUri)
       track('Post:Unrepost')
@@ -157,14 +143,12 @@ export function usePostUnrepostMutation() {
     onMutate(variables) {
       // optimistically update the post-shadow
       updatePostShadow(variables.postUri, {
-        repostCount: variables.repostCount - 1,
         repostUri: undefined,
       })
     },
     onError(error, variables) {
       // revert the optimistic update
       updatePostShadow(variables.postUri, {
-        repostCount: variables.repostCount,
         repostUri: variables.repostUri,
       })
     },

--- a/src/view/com/util/post-ctrls/PostCtrls.tsx
+++ b/src/view/com/util/post-ctrls/PostCtrls.tsx
@@ -73,20 +73,17 @@ let PostCtrls = ({
       postLikeMutation.mutate({
         uri: post.uri,
         cid: post.cid,
-        likeCount: post.likeCount || 0,
       })
     } else {
       postUnlikeMutation.mutate({
         postUri: post.uri,
         likeUri: post.viewer.like,
-        likeCount: post.likeCount || 0,
       })
     }
   }, [
     post.viewer?.like,
     post.uri,
     post.cid,
-    post.likeCount,
     postLikeMutation,
     postUnlikeMutation,
   ])
@@ -98,20 +95,17 @@ let PostCtrls = ({
       postRepostMutation.mutate({
         uri: post.uri,
         cid: post.cid,
-        repostCount: post.repostCount || 0,
       })
     } else {
       postUnrepostMutation.mutate({
         postUri: post.uri,
         repostUri: post.viewer.repost,
-        repostCount: post.repostCount || 0,
       })
     }
   }, [
     post.uri,
     post.cid,
     post.viewer?.repost,
-    post.repostCount,
     closeModal,
     postRepostMutation,
     postUnrepostMutation,


### PR DESCRIPTION
This is a simplification meant to avoid potential bugs. Not sure if it uncovers any bugs right now.

In principle we should always be able to derive the shadow like count instead of explicitly tracking it. Shadow like count should be `post.likeCount + 1` when `!wasLiked && isLiked`, `post.likeCount - 1` when `wasLiked && !isLiked`, or `post.likeCount` otherwise. A larger divergence than +/– 1 should not be possible because we only use the shadow for optimistic updates. So if it ever happened in practice, it would be due to a bug. Let's make this bug impossible.