### PR TITLE
Long press external embed to share

### DIFF
--- a/src/view/com/util/post-embeds/index.tsx
+++ b/src/view/com/util/post-embeds/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, {useCallback} from 'react'
 import {
   StyleSheet,
   StyleProp,
@@ -6,6 +6,7 @@ import {
   ViewStyle,
   Text,
   InteractionManager,
+  Share,
 } from 'react-native'
 import {Image} from 'expo-image'
 import {
@@ -29,6 +30,7 @@ import {ListEmbed} from './ListEmbed'
 import {isCauseALabelOnUri, isQuoteBlurred} from 'lib/moderation'
 import {FeedSourceCard} from 'view/com/feeds/FeedSourceCard'
 import {ContentHider} from '../moderation/ContentHider'
+import {isAndroid, isIOS} from '#/platform/detection'
 
 type Embed =
   | AppBskyEmbedRecord.View
@@ -50,6 +52,20 @@ export function PostEmbeds({
 }) {
   const pal = usePalette('default')
   const {openLightbox} = useLightboxControls()
+
+  const externalUri = AppBskyEmbedExternal.isView(embed)
+    ? embed.external.uri
+    : null
+
+  const onShareExternal = useCallback(() => {
+    if (externalUri) {
+      if (isIOS) {
+        Share.share({url: externalUri})
+      } else if (isAndroid) {
+        Share.share({message: externalUri})
+      }
+    }
+  }, [externalUri])
 
   // quote post with media
   // =
@@ -164,7 +180,8 @@ export function PostEmbeds({
         anchorNoUnderline
         href={link.uri}
         style={[styles.extOuter, pal.view, pal.borderDark, style]}
-        hoverStyle={{borderColor: pal.colors.borderLinkHover}}>
+        hoverStyle={{borderColor: pal.colors.borderLinkHover}}
+        onLongPress={onShareExternal}>
         <ExternalLinkEmbed link={link} />
       </Link>
     )

--- a/src/view/com/util/post-embeds/index.tsx
+++ b/src/view/com/util/post-embeds/index.tsx
@@ -6,7 +6,6 @@ import {
   ViewStyle,
   Text,
   InteractionManager,
-  Share,
 } from 'react-native'
 import {Image} from 'expo-image'
 import {
@@ -30,7 +29,8 @@ import {ListEmbed} from './ListEmbed'
 import {isCauseALabelOnUri, isQuoteBlurred} from 'lib/moderation'
 import {FeedSourceCard} from 'view/com/feeds/FeedSourceCard'
 import {ContentHider} from '../moderation/ContentHider'
-import {isAndroid, isIOS} from '#/platform/detection'
+import {isNative} from '#/platform/detection'
+import {shareUrl} from '#/lib/sharing'
 
 type Embed =
   | AppBskyEmbedRecord.View
@@ -58,12 +58,8 @@ export function PostEmbeds({
     : null
 
   const onShareExternal = useCallback(() => {
-    if (externalUri) {
-      if (isIOS) {
-        Share.share({url: externalUri})
-      } else if (isAndroid) {
-        Share.share({message: externalUri})
-      }
+    if (externalUri && isNative) {
+      shareUrl(externalUri)
     }
   }, [externalUri])
 


### PR DESCRIPTION
Opens the sharing menu when you long press the external link card. Only applies to native.