### PR TITLE
Show composer reply prompt on tablet

### DIFF
--- a/src/view/com/post-thread/PostThread.tsx
+++ b/src/view/com/post-thread/PostThread.tsx
@@ -152,7 +152,7 @@ function PostThreadLoaded({
   const {hasSession} = useSession()
   const {_} = useLingui()
   const pal = usePalette('default')
-  const {isTablet, isDesktop, isTabletOrMobile} = useWebMediaQueries()
+  const {isTablet, isMobile, isDesktop, isTabletOrMobile} = useWebMediaQueries()
   const ref = useRef<ListMethods>(null)
   const highlightedPostRef = useRef<View | null>(null)
   const needsScrollAdjustment = useRef<boolean>(
@@ -271,7 +271,7 @@ function PostThreadLoaded({
       } else if (item === REPLY_PROMPT && hasSession) {
         return (
           <View>
-            {isDesktop && <ComposePrompt onPressCompose={onPressReply} />}
+            {!isMobile && <ComposePrompt onPressCompose={onPressReply} />}
           </View>
         )
       } else if (item === DELETED) {
@@ -362,7 +362,7 @@ function PostThreadLoaded({
     [
       hasSession,
       isTablet,
-      isDesktop,
+      isMobile,
       onPressReply,
       pal.border,
       pal.viewLight,


### PR DESCRIPTION
On mobile, it's always at the bottom. On desktop, it's always inline. But on tablet sizes, we didn't show it at all. This makes the interface feel read-only. This change makes the tablet behavior the same as desktop — it's shown inline.

## Before

<img width="1020" alt="Screenshot 2024-01-25 at 13 26 48" src="https://github.com/bluesky-social/social-app/assets/810438/eac8fddc-1706-4b84-b705-493934d5a66b">


## After

<img width="1002" alt="Screenshot 2024-01-25 at 13 26 56" src="https://github.com/bluesky-social/social-app/assets/810438/a9aac09f-9712-4ca9-8c39-9db0923f4ec5">
