### PR TITLE
Fix post controls tap areas

### DIFF
--- a/src/view/com/util/post-ctrls/PostCtrls.tsx
+++ b/src/view/com/util/post-ctrls/PostCtrls.tsx
@@ -141,37 +141,38 @@ let PostCtrls = ({
 
   return (
     <View style={[styles.ctrls, style]}>
-      <TouchableOpacity
-        testID="replyBtn"
+      <View
         style={[
           styles.ctrl,
-          !big && styles.ctrlPad,
-          {paddingLeft: 0},
           post.viewer?.replyDisabled ? {opacity: 0.5} : undefined,
-        ]}
-        onPress={() => {
-          if (!post.viewer?.replyDisabled) {
-            requireAuth(() => onPressReply())
-          }
-        }}
-        accessibilityRole="button"
-        accessibilityLabel={`Reply (${post.replyCount} ${
-          post.replyCount === 1 ? 'reply' : 'replies'
-        })`}
-        accessibilityHint=""
-        hitSlop={big ? HITSLOP_20 : HITSLOP_10}>
-        <CommentBottomArrow
-          style={[defaultCtrlColor, big ? s.mt2 : styles.mt1]}
-          strokeWidth={3}
-          size={big ? 20 : 15}
-        />
-        {typeof post.replyCount !== 'undefined' && post.replyCount > 0 ? (
-          <Text style={[defaultCtrlColor, s.ml5, s.f15]}>
-            {post.replyCount}
-          </Text>
-        ) : undefined}
-      </TouchableOpacity>
-      <View style={[styles.ctrl, !big && styles.ctrlPad]}>
+        ]}>
+        <TouchableOpacity
+          testID="replyBtn"
+          style={[styles.btn, !big && styles.btnPad, {paddingLeft: 0}]}
+          onPress={() => {
+            if (!post.viewer?.replyDisabled) {
+              requireAuth(() => onPressReply())
+            }
+          }}
+          accessibilityRole="button"
+          accessibilityLabel={`Reply (${post.replyCount} ${
+            post.replyCount === 1 ? 'reply' : 'replies'
+          })`}
+          accessibilityHint=""
+          hitSlop={big ? HITSLOP_20 : HITSLOP_10}>
+          <CommentBottomArrow
+            style={[defaultCtrlColor, big ? s.mt2 : styles.mt1]}
+            strokeWidth={3}
+            size={big ? 20 : 15}
+          />
+          {typeof post.replyCount !== 'undefined' && post.replyCount > 0 ? (
+            <Text style={[defaultCtrlColor, s.ml5, s.f15]}>
+              {post.replyCount}
+            </Text>
+          ) : undefined}
+        </TouchableOpacity>
+      </View>
+      <View style={[styles.ctrl]}>
         <RepostButton
           big={big}
           isReposted={!!post.viewer?.repost}
@@ -180,39 +181,41 @@ let PostCtrls = ({
           onQuote={onQuote}
         />
       </View>
-      <TouchableOpacity
-        testID="likeBtn"
-        style={[styles.ctrl, !big && styles.ctrlPad]}
-        onPress={() => {
-          requireAuth(() => onPressToggleLike())
-        }}
-        accessibilityRole="button"
-        accessibilityLabel={`${
-          post.viewer?.like ? _(msg`Unlike`) : _(msg`Like`)
-        } (${post.likeCount} ${pluralize(post.likeCount || 0, 'like')})`}
-        accessibilityHint=""
-        hitSlop={big ? HITSLOP_20 : HITSLOP_10}>
-        {post.viewer?.like ? (
-          <HeartIconSolid style={s.likeColor} size={big ? 22 : 16} />
-        ) : (
-          <HeartIcon
-            style={[defaultCtrlColor, big ? styles.mt1 : undefined]}
-            strokeWidth={3}
-            size={big ? 20 : 16}
-          />
-        )}
-        {typeof post.likeCount !== 'undefined' && post.likeCount > 0 ? (
-          <Text
-            testID="likeCount"
-            style={
-              post.viewer?.like
-                ? [s.bold, s.likeColor, s.f15, s.ml5]
-                : [defaultCtrlColor, s.f15, s.ml5]
-            }>
-            {post.likeCount}
-          </Text>
-        ) : undefined}
-      </TouchableOpacity>
+      <View style={styles.ctrl}>
+        <TouchableOpacity
+          testID="likeBtn"
+          style={[styles.btn, !big && styles.btnPad]}
+          onPress={() => {
+            requireAuth(() => onPressToggleLike())
+          }}
+          accessibilityRole="button"
+          accessibilityLabel={`${
+            post.viewer?.like ? _(msg`Unlike`) : _(msg`Like`)
+          } (${post.likeCount} ${pluralize(post.likeCount || 0, 'like')})`}
+          accessibilityHint=""
+          hitSlop={big ? HITSLOP_20 : HITSLOP_10}>
+          {post.viewer?.like ? (
+            <HeartIconSolid style={s.likeColor} size={big ? 22 : 16} />
+          ) : (
+            <HeartIcon
+              style={[defaultCtrlColor, big ? styles.mt1 : undefined]}
+              strokeWidth={3}
+              size={big ? 20 : 16}
+            />
+          )}
+          {typeof post.likeCount !== 'undefined' && post.likeCount > 0 ? (
+            <Text
+              testID="likeCount"
+              style={
+                post.viewer?.like
+                  ? [s.bold, s.likeColor, s.f15, s.ml5]
+                  : [defaultCtrlColor, s.f15, s.ml5]
+              }>
+              {post.likeCount}
+            </Text>
+          ) : undefined}
+        </TouchableOpacity>
+      </View>
       {big ? undefined : (
         <PostDropdownBtn
           testID="postDropdownBtn"
@@ -222,7 +225,7 @@ let PostCtrls = ({
           record={record}
           richText={richText}
           showAppealLabelItem={showAppealLabelItem}
-          style={styles.ctrlPad}
+          style={styles.btnPad}
         />
       )}
       {/* used for adding pad to the right side */}
@@ -237,13 +240,17 @@ const styles = StyleSheet.create({
   ctrls: {
     flexDirection: 'row',
     justifyContent: 'space-between',
+    alignItems: 'center',
   },
   ctrl: {
     flex: 1,
+    alignItems: 'flex-start',
+  },
+  btn: {
     flexDirection: 'row',
     alignItems: 'center',
   },
-  ctrlPad: {
+  btnPad: {
     paddingTop: 5,
     paddingBottom: 5,
     paddingLeft: 5,

--- a/src/view/com/util/post-ctrls/RepostButton.tsx
+++ b/src/view/com/util/post-ctrls/RepostButton.tsx
@@ -53,7 +53,7 @@ let RepostButton = ({
       onPress={() => {
         requireAuth(() => onPressToggleRepostWrapper())
       }}
-      style={[styles.container]}
+      style={[styles.btn, !big && styles.btnPad]}
       accessibilityRole="button"
       accessibilityLabel={`${
         isReposted
@@ -89,9 +89,15 @@ RepostButton = memo(RepostButton)
 export {RepostButton}
 
 const styles = StyleSheet.create({
-  container: {
+  btn: {
     flexDirection: 'row',
     alignItems: 'center',
+  },
+  btnPad: {
+    paddingTop: 5,
+    paddingBottom: 5,
+    paddingLeft: 5,
+    paddingRight: 5,
   },
   reposted: {
     color: colors.green3,

--- a/src/view/com/util/post-ctrls/RepostButton.web.tsx
+++ b/src/view/com/util/post-ctrls/RepostButton.web.tsx
@@ -69,7 +69,8 @@ export const RepostButton = ({
   const inner = (
     <View
       style={[
-        styles.container,
+        styles.btn,
+        !big && styles.btnPad,
         (isReposted
           ? styles.reposted
           : defaultControlColor) as StyleProp<ViewStyle>,
@@ -109,10 +110,16 @@ export const RepostButton = ({
 }
 
 const styles = StyleSheet.create({
-  container: {
+  btn: {
     flexDirection: 'row',
     alignItems: 'center',
     gap: 4,
+  },
+  btnPad: {
+    paddingTop: 5,
+    paddingBottom: 5,
+    paddingLeft: 5,
+    paddingRight: 5,
   },
   reposted: {
     color: colors.green3,


### PR DESCRIPTION
Fixes a regression I introduced in https://github.com/bluesky-social/social-app/pull/2614.

Tap areas accidentally got stretched there.

This gets them back to the size of the buttons + paddings.

Best [reviewed without whitespace](https://github.com/bluesky-social/social-app/pull/2627/files?w=1).

## Test Plan

Clicking around the buttons no longer triggers them.

https://github.com/bluesky-social/social-app/assets/810438/e526a52b-5525-4a5c-ad03-5ba943e874c1

