### PR TITLE
Present highlighted post as part of the thread

### DIFF
--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -250,7 +250,13 @@ let PostThreadItemLoaded = ({
 
         <View
           testID={`postThreadItem-by-${post.author.handle}`}
-          style={[styles.outer, styles.outerHighlighted, pal.border, pal.view]}
+          style={[
+            styles.outer,
+            styles.outerHighlighted,
+            rootUri === post.uri && styles.outerHighlightedRoot,
+            pal.border,
+            pal.view,
+          ]}
           accessible={false}>
           <PostSandboxWarning />
           <View style={styles.layout}>
@@ -726,9 +732,14 @@ const useStyles = () => {
       paddingLeft: 8,
     },
     outerHighlighted: {
-      paddingTop: 16,
+      borderTopWidth: 0,
+      paddingTop: 4,
       paddingLeft: 8,
       paddingRight: 8,
+    },
+    outerHighlightedRoot: {
+      borderTopWidth: 1,
+      paddingTop: 16,
     },
     noTopBorder: {
       borderTopWidth: 0,


### PR DESCRIPTION
I meant to include it in https://github.com/bluesky-social/social-app/pull/2625 but lost the change somehow.

The highlighted post is "the end of the thread so far" so it should stay avatar-connected to the parent ones.

## Before

<img width="680" alt="Screenshot 2024-01-25 at 21 40 37" src="https://github.com/bluesky-social/social-app/assets/810438/713122a1-dec4-4809-ac1c-241dce14583d">


## After

<img width="674" alt="Screenshot 2024-01-25 at 21 40 25" src="https://github.com/bluesky-social/social-app/assets/810438/a3cf09c9-bb60-42bc-b949-dea03436b45d">

