### PR TITLE
android alt text selection fix for expandable alt

### DIFF
--- a/src/view/com/lightbox/Lightbox.tsx
+++ b/src/view/com/lightbox/Lightbox.tsx
@@ -116,7 +116,8 @@ function LightboxFooter({imageIndex}: {imageIndex: number}) {
                 update: {type: 'spring', springDamping: 0.7},
               })
               setAltExpanded(prev => !prev)
-            }}>
+            }}
+            onLongPress={() => {}}>
             {altText}
           </Text>
         </View>


### PR DESCRIPTION
fixes https://github.com/bluesky-social/social-app/issues/2592

tested on device, alt text is selectable now regardless of whether it is expandable or not. right now, since RN handles the selection long press as a press regardless of length, it expands/collapses the text upon selection which is obviously janky.

similar to what was done in https://github.com/bluesky-social/social-app/pull/2563 except we needed to apply it to the `Text` instead of `Pressable`. Also verified that things still work fine on both other platforms.