### PR TITLE
Prefetch profile links on web

### DIFF
--- a/src/state/queries/profile.ts
+++ b/src/state/queries/profile.ts
@@ -57,6 +57,23 @@ export function useProfilesQuery({handles}: {handles: string[]}) {
   })
 }
 
+export function usePrefetchProfileQuery() {
+  const queryClient = useQueryClient()
+  const prefetchProfileQuery = useCallback(
+    (did: string) => {
+      queryClient.prefetchQuery({
+        queryKey: RQKEY(did),
+        queryFn: async () => {
+          const res = await getAgent().getProfile({actor: did || ''})
+          return res.data
+        },
+      })
+    },
+    [queryClient],
+  )
+  return prefetchProfileQuery
+}
+
 interface ProfileUpdateParams {
   profile: AppBskyActorDefs.ProfileView
   updates:

--- a/src/view/com/util/Link.tsx
+++ b/src/view/com/util/Link.tsx
@@ -47,6 +47,7 @@ interface Props extends ComponentProps<typeof TouchableOpacity> {
   asAnchor?: boolean
   anchorNoUnderline?: boolean
   navigationAction?: 'push' | 'replace' | 'navigate'
+  onPointerEnter?: () => void
 }
 
 export const Link = memo(function Link({
@@ -264,6 +265,7 @@ interface TextLinkOnWebOnlyProps extends TextProps {
   accessibilityHint?: string
   title?: string
   navigationAction?: 'push' | 'replace' | 'navigate'
+  onPointerEnter?: () => void
 }
 export const TextLinkOnWebOnly = memo(function DesktopWebTextLink({
   testID,

--- a/src/view/com/util/PostMeta.tsx
+++ b/src/view/com/util/PostMeta.tsx
@@ -8,10 +8,11 @@ import {TypographyVariant} from 'lib/ThemeContext'
 import {UserAvatar} from './UserAvatar'
 import {sanitizeDisplayName} from 'lib/strings/display-names'
 import {sanitizeHandle} from 'lib/strings/handles'
-import {isAndroid} from 'platform/detection'
+import {isAndroid, isWeb} from 'platform/detection'
 import {TimeElapsed} from './TimeElapsed'
 import {makeProfileLink} from 'lib/routes/links'
 import {ModerationUI} from '@atproto/api'
+import {usePrefetchProfileQuery} from '#/state/queries/profile'
 
 interface PostMetaOpts {
   author: {
@@ -35,6 +36,7 @@ let PostMeta = (opts: PostMetaOpts): React.ReactNode => {
   const pal = usePalette('default')
   const displayName = opts.author.displayName || opts.author.handle
   const handle = opts.author.handle
+  const prefetchProfileQuery = usePrefetchProfileQuery()
 
   return (
     <View style={[styles.container, opts.style]}>
@@ -66,6 +68,11 @@ let PostMeta = (opts: PostMetaOpts): React.ReactNode => {
             </>
           }
           href={makeProfileLink(opts.author)}
+          onPointerEnter={() => {
+            if (isWeb) {
+              prefetchProfileQuery(opts.author.did)
+            }
+          }}
         />
       </View>
       {!isAndroid && (

--- a/src/view/com/util/UserPreviewLink.tsx
+++ b/src/view/com/util/UserPreviewLink.tsx
@@ -4,6 +4,7 @@ import {Link} from './Link'
 import {isAndroid, isWeb} from 'platform/detection'
 import {makeProfileLink} from 'lib/routes/links'
 import {useModalControls} from '#/state/modals'
+import {usePrefetchProfileQuery} from '#/state/queries/profile'
 
 interface UserPreviewLinkProps {
   did: string
@@ -14,10 +15,16 @@ export function UserPreviewLink(
   props: React.PropsWithChildren<UserPreviewLinkProps>,
 ) {
   const {openModal} = useModalControls()
+  const prefetchProfileQuery = usePrefetchProfileQuery()
 
   if (isWeb || isAndroid) {
     return (
       <Link
+        onPointerEnter={() => {
+          if (isWeb) {
+            prefetchProfileQuery(props.did)
+          }
+        }}
         href={makeProfileLink(props)}
         title={props.handle}
         asAnchor


### PR DESCRIPTION
This adds prefetching on hover for profile user avatars and profile links in post meta.

We don't need to go wild with this but it's worth doing in some places.

The goal is to instantly jump to the next page's shell.

## Before

https://github.com/bluesky-social/social-app/assets/810438/0f23b910-6d53-4a7d-bd7e-a83b9459763b

## After

https://github.com/bluesky-social/social-app/assets/810438/62ec2668-3caa-4545-a095-6bb361279b19

