### PR TITLE
Add missing top border to notifications loading state

### DIFF
--- a/src/view/com/notifications/Feed.tsx
+++ b/src/view/com/notifications/Feed.tsx
@@ -15,6 +15,7 @@ import {useModerationOpts} from '#/state/queries/preferences'
 import {List, ListRef} from '../util/List'
 import {useLingui} from '@lingui/react'
 import {msg} from '@lingui/macro'
+import {usePalette} from '#/lib/hooks/usePalette'
 
 const EMPTY_FEED_ITEM = {_reactKey: '__empty__'}
 const LOAD_MORE_ERROR_ITEM = {_reactKey: '__load_more_error__'}
@@ -32,6 +33,7 @@ export function Feed({
   ListHeaderComponent?: () => JSX.Element
 }) {
   const [isPTRing, setIsPTRing] = React.useState(false)
+  const pal = usePalette('default')
 
   const {_} = useLingui()
   const moderationOpts = useModerationOpts()
@@ -118,11 +120,15 @@ export function Feed({
           />
         )
       } else if (item === LOADING_ITEM) {
-        return <NotificationFeedLoadingPlaceholder />
+        return (
+          <View style={[pal.border, {borderTopWidth: 1}]}>
+            <NotificationFeedLoadingPlaceholder />
+          </View>
+        )
       }
       return <FeedItem item={item} moderationOpts={moderationOpts!} />
     },
-    [onPressRetryLoadMore, moderationOpts, _],
+    [onPressRetryLoadMore, moderationOpts, _, pal.border],
   )
 
   const FeedFooter = React.useCallback(


### PR DESCRIPTION
## Before

<img width="736" alt="Screenshot 2024-01-26 at 02 59 22" src="https://github.com/bluesky-social/social-app/assets/810438/2059cb58-dc61-496d-8ffe-b05d01b6f441">

## After

<img width="737" alt="Screenshot 2024-01-26 at 03 00 31" src="https://github.com/bluesky-social/social-app/assets/810438/8fcc4228-40a6-4802-ac07-dbf04aa43635">
