### PR TITLE
Two UI tweaks after recent updates

### DIFF
--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -250,13 +250,7 @@ let PostThreadItemLoaded = ({
 
         <View
           testID={`postThreadItem-by-${post.author.handle}`}
-          style={[
-            styles.outer,
-            styles.outerHighlighted,
-            rootUri === post.uri && styles.outerHighlightedRoot,
-            pal.border,
-            pal.view,
-          ]}
+          style={[styles.outer, styles.outerHighlighted, pal.border, pal.view]}
           accessible={false}>
           <PostSandboxWarning />
           <View style={styles.layout}>
@@ -732,14 +726,9 @@ const useStyles = () => {
       paddingLeft: 8,
     },
     outerHighlighted: {
-      borderTopWidth: 0,
-      paddingTop: 4,
+      paddingTop: 16,
       paddingLeft: 8,
       paddingRight: 8,
-    },
-    outerHighlightedRoot: {
-      borderTopWidth: 1,
-      paddingTop: 16,
     },
     noTopBorder: {
       borderTopWidth: 0,

--- a/src/view/com/util/LoadingPlaceholder.tsx
+++ b/src/view/com/util/LoadingPlaceholder.tsx
@@ -88,7 +88,7 @@ export function PostLoadingPlaceholder({
               strokeWidth={3}
             />
           </View>
-          <View style={{width: 30, height: 30}} />
+          <View style={styles.postCtrl} />
         </View>
       </View>
     </View>

--- a/src/view/com/util/post-ctrls/PostCtrls.tsx
+++ b/src/view/com/util/post-ctrls/PostCtrls.tsx
@@ -149,7 +149,7 @@ let PostCtrls = ({
           ) : undefined}
         </TouchableOpacity>
       </View>
-      <View style={[styles.ctrl]}>
+      <View style={styles.ctrl}>
         <RepostButton
           big={big}
           isReposted={!!post.viewer?.repost}
@@ -194,19 +194,19 @@ let PostCtrls = ({
         </TouchableOpacity>
       </View>
       {big ? undefined : (
-        <PostDropdownBtn
-          testID="postDropdownBtn"
-          postAuthor={post.author}
-          postCid={post.cid}
-          postUri={post.uri}
-          record={record}
-          richText={richText}
-          showAppealLabelItem={showAppealLabelItem}
-          style={styles.btnPad}
-        />
+        <View style={styles.ctrl}>
+          <PostDropdownBtn
+            testID="postDropdownBtn"
+            postAuthor={post.author}
+            postCid={post.cid}
+            postUri={post.uri}
+            record={record}
+            richText={richText}
+            showAppealLabelItem={showAppealLabelItem}
+            style={styles.btnPad}
+          />
+        </View>
       )}
-      {/* used for adding pad to the right side */}
-      <View />
     </View>
   )
 }


### PR DESCRIPTION
- e748eacb767b421053d1d1fe76c5ed073a7f1081 Reverts #2628 and readds the border to the top of the highlighted post in a thread, even when it's a reply
- 773ef18be2f68a5e60c12ba99e94710f63507dc9 Readds a right pad to the post controls

## Post thread border

The issue here is that when opening a reply -- especially on mobile -- the interface looks really odd without a top border. I legitimately thought it was a bug.

It might work better if the scroll position is moved up vertical to always show what it's connected to, but even then I'm somewhat skeptical.

|Before|After|
|-|-|
|![CleanShot 2024-01-26 at 09 48 31@2x](https://github.com/bluesky-social/social-app/assets/1270099/1c26b047-d8c4-4328-a76e-db1b3b634550)|![CleanShot 2024-01-26 at 09 48 17@2x](https://github.com/bluesky-social/social-app/assets/1270099/41b928a2-224b-49db-8048-e5b13c2194a2)|

## Right pad in post controls

The issue here may seem goofy but it matters. Once we moved to fixed-width containers for the post controls, we got the benefit of the buttons staying aligned in all cases, but the visual balance was severely impacted. Because of the icon sizes and the more frequent numbers being present on the repost and like controls, you get the visual impression that there is a wider gap between the reply control and the rest of them.

Readding the right pad diminishes that effect.

|Before|After|
|-|-|
|![CleanShot 2024-01-26 at 09 48 55@2x](https://github.com/bluesky-social/social-app/assets/1270099/002ba65a-3fab-4c70-a3f5-5a96d2418518)|![CleanShot 2024-01-26 at 09 49 45@2x](https://github.com/bluesky-social/social-app/assets/1270099/a302d7e2-5f88-4a53-92cc-1a818ec86a60)|

