### PR TITLE
Fix typos and suggested punctuation tweak in StepSuggestedAccounts/index.tsx

### DIFF
--- a/src/screens/Onboarding/StepSuggestedAccounts/index.tsx
+++ b/src/screens/Onboarding/StepSuggestedAccounts/index.tsx
@@ -135,7 +135,7 @@ export function StepSuggestedAccounts() {
         {state.interestsStepResults.selectedInterests.length ? (
           <Trans>Based on your interest in {interestsText}</Trans>
         ) : (
-          <Trans>These are some popular accounts you might like:</Trans>
+          <Trans>These are popular accounts you might like:</Trans>
         )}
       </Description>
 

--- a/src/screens/Onboarding/StepSuggestedAccounts/index.tsx
+++ b/src/screens/Onboarding/StepSuggestedAccounts/index.tsx
@@ -129,7 +129,7 @@ export function StepSuggestedAccounts() {
       <IconCircle icon={At} style={[a.mb_2xl]} />
 
       <Title>
-        <Trans>Here are some accounts for your to follow</Trans>
+        <Trans>Here are some accounts for you to follow</Trans>
       </Title>
       <Description>
         {state.interestsStepResults.selectedInterests.length ? (
@@ -171,7 +171,7 @@ export function StepSuggestedAccounts() {
             color="gradient_sky"
             size="large"
             label={_(
-              msg`Follow selected accounts and continue to then next step`,
+              msg`Follow selected accounts and continue to the next step`,
             )}
             onPress={handleContinue}>
             <ButtonText>

--- a/src/screens/Onboarding/StepSuggestedAccounts/index.tsx
+++ b/src/screens/Onboarding/StepSuggestedAccounts/index.tsx
@@ -135,7 +135,7 @@ export function StepSuggestedAccounts() {
         {state.interestsStepResults.selectedInterests.length ? (
           <Trans>Based on your interest in {interestsText}</Trans>
         ) : (
-          <Trans>These are popular accounts you might like.</Trans>
+          <Trans>These are some popular accounts you might like:</Trans>
         )}
       </Description>
 


### PR DESCRIPTION
Fix a couple of typos in StepSuggestedAccounts/index.tsx.

Edited to add:
After trying out the new onboarding, also a suggested punctuation tweak: changing the period/full stop to a colon.