### PR TITLE
Suggest wording tweak in StepAlgoFeeds/index.tsx

### DIFF
--- a/src/screens/Onboarding/StepAlgoFeeds/index.tsx
+++ b/src/screens/Onboarding/StepAlgoFeeds/index.tsx
@@ -119,7 +119,7 @@ export function StepAlgoFeeds() {
           <FeedCard config={PRIMARY_FEEDS[0]} />
           <Text
             style={[a.text_md, a.pt_4xl, a.pb_lg, t.atoms.text_contrast_700]}>
-            <Trans>Or you can try our "Discover" algorithm:</Trans>
+            <Trans>You could also try our "Discover" algorithm:</Trans>
           </Text>
           <FeedCard config={PRIMARY_FEEDS[1]} />
         </Toggle.Group>

--- a/src/screens/Onboarding/StepAlgoFeeds/index.tsx
+++ b/src/screens/Onboarding/StepAlgoFeeds/index.tsx
@@ -119,7 +119,7 @@ export function StepAlgoFeeds() {
           <FeedCard config={PRIMARY_FEEDS[0]} />
           <Text
             style={[a.text_md, a.pt_4xl, a.pb_lg, t.atoms.text_contrast_700]}>
-            <Trans>You could also try our "Discover" algorithm:</Trans>
+            <Trans>You can also try our "Discover" algorithm:</Trans>
           </Text>
           <FeedCard config={PRIMARY_FEEDS[1]} />
         </Toggle.Group>


### PR DESCRIPTION
This PR is a suggested wording tweak in one of the onboarding screens that I think would make it a bit clearer that you can select both For You and Discover as your primary feeds, it's not either/or.