### PR TITLE
Only re-reg push noty token when account changes

### DIFF
--- a/src/view/shell/index.tsx
+++ b/src/view/shell/index.tsx
@@ -52,6 +52,8 @@ function ShellInner() {
   const canGoBack = useNavigationState(state => !isStateAtTabRoot(state))
   const {hasSession, currentAccount} = useSession()
   const closeAnyActiveElement = useCloseAnyActiveElement()
+  // start undefined
+  const currentAccountDid = React.useRef<string | undefined>(undefined)
 
   React.useEffect(() => {
     let listener = {remove() {}}
@@ -66,13 +68,10 @@ function ShellInner() {
   }, [closeAnyActiveElement])
 
   React.useEffect(() => {
-    if (currentAccount) {
+    // only runs when did changes
+    if (currentAccount && currentAccountDid.current !== currentAccount.did) {
+      currentAccountDid.current = currentAccount.did
       notifications.requestPermissionsAndRegisterToken(currentAccount)
-    }
-  }, [currentAccount])
-
-  React.useEffect(() => {
-    if (currentAccount) {
       const unsub = notifications.registerTokenChangeHandler(currentAccount)
       return unsub
     }


### PR DESCRIPTION
`currentAccount` is mutated a couple times as we init e.g. updated the refresh token, which caused these effects to re-run 3x and register a push token 5x (since the listener was destroyed and re-instantiated also).

This PR consolidates these two effects and does a check for a did to make sure it only runs when the account did changes. So `registerPush` should only be called 2x now instead of 5x.

I considered doing this in our `session` state, but as mentioned, some props on `currentAccount` DO need to mutate. So for this use case I thought this was more direct.