### PR TITLE
Avatar type for Feed check

### DIFF
--- a/src/state/queries/feed.ts
+++ b/src/state/queries/feed.ts
@@ -136,6 +136,10 @@ export function getFeedTypeFromUri(uri: string) {
   return pathname.includes(feedSourceNSIDs.feed) ? 'feed' : 'list'
 }
 
+export function getAvatarTypeFromUri(uri: string) {
+  return getFeedTypeFromUri(uri) === 'feed' ? 'algo' : 'list'
+}
+
 export function useFeedSourceInfoQuery({uri}: {uri: string}) {
   const type = getFeedTypeFromUri(uri)
 

--- a/src/view/screens/Feeds.tsx
+++ b/src/view/screens/Feeds.tsx
@@ -582,7 +582,7 @@ function SavedFeed({feedUri}: {feedUri: string}) {
           />
         </View>
       ) : (
-        <UserAvatar type="algo" size={28} avatar={info.avatar} />
+        <UserAvatar type="list" size={28} avatar={info.avatar} />
       )}
       <View
         style={{flex: 1, flexDirection: 'row', gap: 8, alignItems: 'center'}}>

--- a/src/view/screens/Feeds.tsx
+++ b/src/view/screens/Feeds.tsx
@@ -30,6 +30,7 @@ import {
   useFeedSourceInfoQuery,
   useGetPopularFeedsQuery,
   useSearchPopularFeedsMutation,
+  getAvatarTypeFromUri,
 } from '#/state/queries/feed'
 import {cleanError} from 'lib/strings/errors'
 import {useComposerControls} from '#/state/shell/composer'
@@ -555,6 +556,7 @@ function SavedFeed({feedUri}: {feedUri: string}) {
   const pal = usePalette('default')
   const {isMobile} = useWebMediaQueries()
   const {data: info, error} = useFeedSourceInfoQuery({uri: feedUri})
+  const typeAvatar = getAvatarTypeFromUri(feedUri)
 
   if (!info)
     return (
@@ -582,7 +584,7 @@ function SavedFeed({feedUri}: {feedUri: string}) {
           />
         </View>
       ) : (
-        <UserAvatar type="list" size={28} avatar={info.avatar} />
+        <UserAvatar type={typeAvatar} size={28} avatar={info.avatar} />
       )}
       <View
         style={{flex: 1, flexDirection: 'row', gap: 8, alignItems: 'center'}}>


### PR DESCRIPTION
Fixes #2648 

~~To keep consistency with the other screens where the User Lists are displayed, the type of Avatar needs to be changed from 'algo' to 'list' in Feeds.~~

Since feeds can also lack an image, the fix has been changed into a function that returns the type of avatar for each feed element.

After:
![image](https://github.com/bluesky-social/social-app/assets/32964925/8f6f16db-8138-4ffe-b36b-85561add0dd5)
