### PR TITLE
moderate avatars and embeds in composer reply to

### DIFF
--- a/src/state/shell/composer.tsx
+++ b/src/state/shell/composer.tsx
@@ -31,7 +31,6 @@ export interface ComposerOptsQuote {
     avatar?: string
   }
   embeds?: AppBskyEmbedRecord.ViewRecord['embeds']
-  moderation?: PostModeration
 }
 export interface ComposerOpts {
   replyTo?: ComposerOptsPostRef

--- a/src/state/shell/composer.tsx
+++ b/src/state/shell/composer.tsx
@@ -1,5 +1,9 @@
 import React from 'react'
-import {AppBskyEmbedRecord, AppBskyRichtextFacet} from '@atproto/api'
+import {
+  AppBskyEmbedRecord,
+  AppBskyRichtextFacet,
+  PostModeration,
+} from '@atproto/api'
 import {useNonReactiveCallback} from '#/lib/hooks/useNonReactiveCallback'
 
 export interface ComposerOptsPostRef {
@@ -12,6 +16,7 @@ export interface ComposerOptsPostRef {
     avatar?: string
   }
   embed?: AppBskyEmbedRecord.ViewRecord['embed']
+  moderation?: PostModeration
 }
 export interface ComposerOptsQuote {
   uri: string
@@ -26,6 +31,7 @@ export interface ComposerOptsQuote {
     avatar?: string
   }
   embeds?: AppBskyEmbedRecord.ViewRecord['embeds']
+  moderation?: PostModeration
 }
 export interface ComposerOpts {
   replyTo?: ComposerOptsPostRef

--- a/src/view/com/composer/ComposerReplyTo.tsx
+++ b/src/view/com/composer/ComposerReplyTo.tsx
@@ -83,7 +83,11 @@ export function ComposerReplyTo({replyTo}: {replyTo: ComposerOptsPostRef}) {
       accessibilityHint={_(
         msg`Expand or collapse the full post you are replying to`,
       )}>
-      <UserAvatar avatar={replyTo.author.avatar} size={50} />
+      <UserAvatar
+        avatar={replyTo.author.avatar}
+        size={50}
+        moderation={replyTo.moderation?.avatar}
+      />
       <View style={styles.replyToPost}>
         <Text type="xl-medium" style={[pal.text]}>
           {sanitizeDisplayName(
@@ -99,7 +103,7 @@ export function ComposerReplyTo({replyTo}: {replyTo: ComposerOptsPostRef}) {
               {replyTo.text}
             </Text>
           </View>
-          {images && (
+          {images && replyTo.moderation?.embed.blur && (
             <ComposerReplyToImages images={images} showFull={showFull} />
           )}
         </View>

--- a/src/view/com/composer/ComposerReplyTo.tsx
+++ b/src/view/com/composer/ComposerReplyTo.tsx
@@ -103,7 +103,7 @@ export function ComposerReplyTo({replyTo}: {replyTo: ComposerOptsPostRef}) {
               {replyTo.text}
             </Text>
           </View>
-          {images && replyTo.moderation?.embed.blur && (
+          {images && !replyTo.moderation?.embed.blur && (
             <ComposerReplyToImages images={images} showFull={showFull} />
           )}
         </View>

--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -216,10 +216,11 @@ let PostThreadItemLoaded = ({
           avatar: post.author.avatar,
         },
         embed: post.embed,
+        moderation,
       },
       onPost: onPostReply,
     })
-  }, [openComposer, post, record, onPostReply])
+  }, [openComposer, post, record, onPostReply, moderation])
 
   const onPressShowMore = React.useCallback(() => {
     setLimitLines(false)

--- a/src/view/com/post/Post.tsx
+++ b/src/view/com/post/Post.tsx
@@ -122,9 +122,10 @@ function PostInner({
           avatar: post.author.avatar,
         },
         embed: post.embed,
+        moderation,
       },
     })
-  }, [openComposer, post, record])
+  }, [openComposer, post, record, moderation])
 
   const onPressShowMore = React.useCallback(() => {
     setLimitLines(false)

--- a/src/view/com/posts/FeedItem.tsx
+++ b/src/view/com/posts/FeedItem.tsx
@@ -135,9 +135,10 @@ let FeedItemInner = ({
           avatar: post.author.avatar,
         },
         embed: post.embed,
+        moderation,
       },
     })
-  }, [post, record, openComposer])
+  }, [post, record, openComposer, moderation])
 
   const outerStyles = [
     styles.outer,


### PR DESCRIPTION
fixes https://github.com/bluesky-social/social-app/issues/2656

pass `PostModeration` into composer `replyTo` and:

- blur avatars if needed
- hide image embeds if needed

![Screenshot 2024-01-28 at 5 03 03 PM](https://github.com/bluesky-social/social-app/assets/153161762/1073e9d8-0fb2-40ee-820b-78f45eadc394)
