### PR TITLE
add padding to user's lists/feeds scrollviews

### DIFF
--- a/src/view/com/feeds/ProfileFeedgens.tsx
+++ b/src/view/com/feeds/ProfileFeedgens.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import {Dimensions, StyleProp, StyleSheet, View, ViewStyle} from 'react-native'
+import {StyleProp, StyleSheet, View, ViewStyle} from 'react-native'
 import {useQueryClient} from '@tanstack/react-query'
 import {List, ListRef} from '../util/List'
 import {FeedSourceCardLoaded} from './FeedSourceCard'
@@ -180,9 +180,7 @@ export const ProfileFeedgens = React.forwardRef<
         refreshing={isPTRing}
         onRefresh={onRefresh}
         headerOffset={headerOffset}
-        contentContainerStyle={{
-          minHeight: Dimensions.get('window').height * 1.5,
-        }}
+        ListFooterComponent={<View style={styles.container} />}
         indicatorStyle={theme.colorScheme === 'dark' ? 'white' : 'black'}
         removeClippedSubviews={true}
         // @ts-ignore our .web version only -prf
@@ -196,5 +194,8 @@ export const ProfileFeedgens = React.forwardRef<
 const styles = StyleSheet.create({
   item: {
     paddingHorizontal: 18,
+  },
+  container: {
+    height: 600,
   },
 })

--- a/src/view/com/feeds/ProfileFeedgens.tsx
+++ b/src/view/com/feeds/ProfileFeedgens.tsx
@@ -180,7 +180,7 @@ export const ProfileFeedgens = React.forwardRef<
         refreshing={isPTRing}
         onRefresh={onRefresh}
         headerOffset={headerOffset}
-        ListFooterComponent={<View style={styles.container} />}
+        contentContainerStyle={isNative && {paddingBottom: headerOffset + 100}}
         indicatorStyle={theme.colorScheme === 'dark' ? 'white' : 'black'}
         removeClippedSubviews={true}
         // @ts-ignore our .web version only -prf
@@ -194,8 +194,5 @@ export const ProfileFeedgens = React.forwardRef<
 const styles = StyleSheet.create({
   item: {
     paddingHorizontal: 18,
-  },
-  container: {
-    height: 600,
   },
 })

--- a/src/view/com/lists/ProfileLists.tsx
+++ b/src/view/com/lists/ProfileLists.tsx
@@ -182,7 +182,9 @@ export const ProfileLists = React.forwardRef<SectionRef, ProfileListsProps>(
           refreshing={isPTRing}
           onRefresh={onRefresh}
           headerOffset={headerOffset}
-          contentContainerStyle={isNative && styles.container}
+          contentContainerStyle={
+            isNative && {paddingBottom: headerOffset + 100}
+          }
           indicatorStyle={theme.colorScheme === 'dark' ? 'white' : 'black'}
           removeClippedSubviews={true}
           // @ts-ignore our .web version only -prf
@@ -197,8 +199,5 @@ export const ProfileLists = React.forwardRef<SectionRef, ProfileListsProps>(
 const styles = StyleSheet.create({
   item: {
     paddingHorizontal: 18,
-  },
-  container: {
-    paddingBottom: 600,
   },
 })

--- a/src/view/com/lists/ProfileLists.tsx
+++ b/src/view/com/lists/ProfileLists.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import {Dimensions, StyleProp, StyleSheet, View, ViewStyle} from 'react-native'
+import {StyleProp, StyleSheet, View, ViewStyle} from 'react-native'
 import {useQueryClient} from '@tanstack/react-query'
 import {List, ListRef} from '../util/List'
 import {ListCard} from './ListCard'
@@ -182,9 +182,7 @@ export const ProfileLists = React.forwardRef<SectionRef, ProfileListsProps>(
           refreshing={isPTRing}
           onRefresh={onRefresh}
           headerOffset={headerOffset}
-          contentContainerStyle={{
-            minHeight: Dimensions.get('window').height * 1.5,
-          }}
+          contentContainerStyle={isNative && styles.container}
           indicatorStyle={theme.colorScheme === 'dark' ? 'white' : 'black'}
           removeClippedSubviews={true}
           // @ts-ignore our .web version only -prf
@@ -199,5 +197,8 @@ export const ProfileLists = React.forwardRef<SectionRef, ProfileListsProps>(
 const styles = StyleSheet.create({
   item: {
     paddingHorizontal: 18,
+  },
+  container: {
+    paddingBottom: 600,
   },
 })


### PR DESCRIPTION
Original issue in https://github.com/bluesky-social/social-app/issues/1876 isn't reproducible as a padding/margin issue on any platform. Seems that the `ListFooterComponent` always adds the appropriate amount of padding to the view...

This does fix issues where a large list of lists/feeds isn't scrollable on user profiles though, since there was no accounting for the header offset on those tabs. Will keep playing with different follower screens to see if it is ever reproducible.