### PR TITLE
clear cache when blocking/unblocking and whenever we get blocked, better invalidation logic for `useProfileQuery`

### DIFF
--- a/src/state/queries/post-feed.ts
+++ b/src/state/queries/post-feed.ts
@@ -28,6 +28,7 @@ import {getModerationOpts} from '#/state/queries/preferences/moderation'
 import {KnownError} from '#/view/com/posts/FeedErrorMessage'
 import {embedViewRecordToPostView, getEmbeddedPost} from './util'
 import {useModerationOpts} from './preferences'
+import {queryClient} from 'lib/react-query'
 
 type ActorDid = string
 type AuthorFilter =
@@ -443,4 +444,16 @@ function assertSomePostsPassModeration(feed: AppBskyFeedDefs.FeedViewPost[]) {
   if (!somePostsPassModeration) {
     throw new Error(KnownError.FeedNSFPublic)
   }
+}
+
+export function resetProfilePostsQueries(did: string, timeout = 0) {
+  setTimeout(() => {
+    queryClient.resetQueries({
+      predicate: query =>
+        !!(
+          query.queryKey[0] === 'post-feed' &&
+          (query.queryKey[1] as string)?.includes(did)
+        ),
+    })
+  }, timeout)
 }

--- a/src/state/queries/profile.ts
+++ b/src/state/queries/profile.ts
@@ -17,12 +17,12 @@ import {updateProfileShadow} from '../cache/profile-shadow'
 import {uploadBlob} from '#/lib/api'
 import {until} from '#/lib/async/until'
 import {Shadow} from '#/state/cache/types'
+import {resetProfilePostsQueries} from '#/state/queries/post-feed'
 import {useToggleMutationQueue} from '#/lib/hooks/useToggleMutationQueue'
 import {RQKEY as RQKEY_MY_MUTED} from './my-muted-accounts'
 import {RQKEY as RQKEY_MY_BLOCKED} from './my-blocked-accounts'
 import {STALE} from '#/state/queries'
 import {track} from '#/lib/analytics/analytics'
-import {queryClient} from '#/lib/react-query'
 
 export const RQKEY = (did: string) => ['profile', did]
 export const profilesQueryKey = (handles: string[]) => ['profiles', handles]
@@ -433,16 +433,4 @@ export function* findAllProfilesInQueryData(
       yield queryData
     }
   }
-}
-
-export function resetProfilePostsQueries(did: string, timeout = 0) {
-  setTimeout(() => {
-    queryClient.resetQueries({
-      predicate: query =>
-        !!(
-          query.queryKey[0] === 'post-feed' &&
-          (query.queryKey[1] as string)?.includes(did)
-        ),
-    })
-  }, timeout)
 }

--- a/src/state/queries/profile.ts
+++ b/src/state/queries/profile.ts
@@ -29,17 +29,17 @@ export const profilesQueryKey = (handles: string[]) => ['profiles', handles]
 
 export function useProfileQuery({
   did,
-  dontInvalidate,
+  staleTime = STALE.SECONDS.FIFTEEN,
 }: {
   did: string | undefined
-  dontInvalidate?: boolean
+  staleTime?: number
 }) {
   return useQuery({
     // WARNING
     // this staleTime is load-bearing
     // if you remove it, the UI infinite-loops
     // -prf
-    staleTime: dontInvalidate ? STALE.INFINITY : STALE.SECONDS.FIFTEEN,
+    staleTime,
     refetchOnWindowFocus: true,
     queryKey: RQKEY(did || ''),
     queryFn: async () => {

--- a/src/state/queries/profile.ts
+++ b/src/state/queries/profile.ts
@@ -27,16 +27,19 @@ import {queryClient} from '#/lib/react-query'
 export const RQKEY = (did: string) => ['profile', did]
 export const profilesQueryKey = (handles: string[]) => ['profiles', handles]
 
-export function useProfileQuery({did}: {did: string | undefined}) {
-  const {currentAccount} = useSession()
-  const isCurrentAccount = did === currentAccount?.did
-
+export function useProfileQuery({
+  did,
+  dontInvalidate,
+}: {
+  did: string | undefined
+  dontInvalidate?: boolean
+}) {
   return useQuery({
     // WARNING
     // this staleTime is load-bearing
     // if you remove it, the UI infinite-loops
     // -prf
-    staleTime: isCurrentAccount ? STALE.SECONDS.THIRTY : STALE.MINUTES.FIVE,
+    staleTime: dontInvalidate ? STALE.INFINITY : STALE.SECONDS.FIFTEEN,
     refetchOnWindowFocus: true,
     queryKey: RQKEY(did || ''),
     queryFn: async () => {

--- a/src/view/com/modals/ProfilePreview.tsx
+++ b/src/view/com/modals/ProfilePreview.tsx
@@ -27,12 +27,12 @@ export function Component({did}: {did: string}) {
     data: profile,
     error: profileError,
     refetch: refetchProfile,
-    isLoading,
+    isLoading: isLoadingProfile,
   } = useProfileQuery({
     did: did,
   })
 
-  if (isLoading || !moderationOpts) {
+  if (isLoadingProfile || !moderationOpts) {
     return (
       <CenteredView style={[pal.view, s.flex1]}>
         <ProfileHeader

--- a/src/view/com/modals/ProfilePreview.tsx
+++ b/src/view/com/modals/ProfilePreview.tsx
@@ -27,12 +27,12 @@ export function Component({did}: {did: string}) {
     data: profile,
     error: profileError,
     refetch: refetchProfile,
-    isFetching: isFetchingProfile,
+    isLoading,
   } = useProfileQuery({
     did: did,
   })
 
-  if (isFetchingProfile || !moderationOpts) {
+  if (isLoading || !moderationOpts) {
     return (
       <CenteredView style={[pal.view, s.flex1]}>
         <ProfileHeader

--- a/src/view/com/util/UserInfoText.tsx
+++ b/src/view/com/util/UserInfoText.tsx
@@ -9,6 +9,7 @@ import {sanitizeDisplayName} from 'lib/strings/display-names'
 import {sanitizeHandle} from 'lib/strings/handles'
 import {makeProfileLink} from 'lib/routes/links'
 import {useProfileQuery} from '#/state/queries/profile'
+import {STALE} from '#/state/queries'
 
 export function UserInfoText({
   type = 'md',
@@ -29,7 +30,10 @@ export function UserInfoText({
   attr = attr || 'handle'
   failed = failed || 'user'
 
-  const {data: profile, isError} = useProfileQuery({did, dontInvalidate: true})
+  const {data: profile, isError} = useProfileQuery({
+    did,
+    staleTime: STALE.INFINITY,
+  })
 
   let inner
   if (isError) {

--- a/src/view/com/util/UserInfoText.tsx
+++ b/src/view/com/util/UserInfoText.tsx
@@ -29,7 +29,7 @@ export function UserInfoText({
   attr = attr || 'handle'
   failed = failed || 'user'
 
-  const {data: profile, isError} = useProfileQuery({did})
+  const {data: profile, isError} = useProfileQuery({did, dontInvalidate: true})
 
   let inner
   if (isError) {

--- a/src/view/screens/Profile.tsx
+++ b/src/view/screens/Profile.tsx
@@ -21,12 +21,12 @@ import {useAnalytics} from 'lib/analytics/analytics'
 import {ComposeIcon2} from 'lib/icons'
 import {useSetTitle} from 'lib/hooks/useSetTitle'
 import {combinedDisplayName} from 'lib/strings/display-names'
-import {FeedDescriptor} from '#/state/queries/post-feed'
-import {useResolveDidQuery} from '#/state/queries/resolve-uri'
 import {
+  FeedDescriptor,
   resetProfilePostsQueries,
-  useProfileQuery,
-} from '#/state/queries/profile'
+} from '#/state/queries/post-feed'
+import {useResolveDidQuery} from '#/state/queries/resolve-uri'
+import {useProfileQuery} from '#/state/queries/profile'
 import {useProfileShadow} from '#/state/cache/profile-shadow'
 import {useSession} from '#/state/session'
 import {useModerationOpts} from '#/state/queries/preferences'

--- a/src/view/screens/Profile.tsx
+++ b/src/view/screens/Profile.tsx
@@ -58,13 +58,13 @@ export function ProfileScreen({route}: Props) {
     data: resolvedDid,
     error: resolveError,
     refetch: refetchDid,
-    isInitialLoading: isInitialLoadingDid,
+    isLoading: isLoadingDid,
   } = useResolveDidQuery(name)
   const {
     data: profile,
     error: profileError,
     refetch: refetchProfile,
-    isInitialLoading: isInitialLoadingProfile,
+    isLoading: isLoadingProfile,
   } = useProfileQuery({
     did: resolvedDid,
   })
@@ -84,7 +84,7 @@ export function ProfileScreen({route}: Props) {
     }
   }, [profile?.viewer?.blockedBy, resolvedDid])
 
-  if (isInitialLoadingDid || isInitialLoadingProfile || !moderationOpts) {
+  if (isLoadingDid || isLoadingProfile || !moderationOpts) {
     return (
       <CenteredView>
         <ProfileHeader

--- a/src/view/screens/Profile.tsx
+++ b/src/view/screens/Profile.tsx
@@ -23,7 +23,10 @@ import {useSetTitle} from 'lib/hooks/useSetTitle'
 import {combinedDisplayName} from 'lib/strings/display-names'
 import {FeedDescriptor} from '#/state/queries/post-feed'
 import {useResolveDidQuery} from '#/state/queries/resolve-uri'
-import {useProfileQuery} from '#/state/queries/profile'
+import {
+  resetProfilePostsQueries,
+  useProfileQuery,
+} from '#/state/queries/profile'
 import {useProfileShadow} from '#/state/cache/profile-shadow'
 import {useSession} from '#/state/session'
 import {useModerationOpts} from '#/state/queries/preferences'
@@ -73,6 +76,13 @@ export function ProfileScreen({route}: Props) {
       refetchProfile()
     }
   }, [resolveError, refetchDid, refetchProfile])
+
+  // When we open the profile, we want to reset the posts query if we are blocked.
+  React.useEffect(() => {
+    if (resolvedDid && profile?.viewer?.blockedBy) {
+      resetProfilePostsQueries(resolvedDid)
+    }
+  }, [profile?.viewer?.blockedBy, resolvedDid])
 
   if (isInitialLoadingDid || isInitialLoadingProfile || !moderationOpts) {
     return (


### PR DESCRIPTION
Right now we don't clear the post cache at all whenever we block/unblock someone or they block us. We might visit a profile and see that we are blocked since the avatar is blurred and we get the blocked label in the bio, but the posts are still visible. Instead, if we are blocked we should reset the posts query to ensure we can't see any content there.

Same for when we block someone. We technically shouldn't be still seeing the content from the user, rather it should be removed as soon as we block. Here we need to wait a moment for the AppView to receive the block.

We also don't need to invalidate profile queries if they are only for display name resolution. By setting those queries to not invalidate, we can set all the others to a lower 15 seconds ensuring we always have the most recent block state.

No extra queries are getting made in the feed:

https://github.com/bluesky-social/social-app/assets/153161762/e6b2cc3d-088e-4ebc-a7bd-c099e8142688

Profile and posts invalidate after blocks:

https://github.com/bluesky-social/social-app/assets/153161762/e0f63f82-0130-47c3-a6ab-ff1c385ceb74