### PR TITLE
check if a thread is muted before incrementing notif badge, filter out quotes

### DIFF
--- a/src/state/queries/notifications/unread.tsx
+++ b/src/state/queries/notifications/unread.tsx
@@ -199,7 +199,6 @@ export function useUnreadNotificationsApi() {
 function countUnread(page: FeedPage) {
   let num = 0
   for (const item of page.items) {
-    // Filter out counts
     if (!item.notification.isRead) {
       num++
     }

--- a/src/state/queries/notifications/unread.tsx
+++ b/src/state/queries/notifications/unread.tsx
@@ -136,7 +136,7 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
 
             // only fetch subjects when the page is going to be used
             // in the notifications query, otherwise skip it
-            fetchAdditionalData: true,
+            fetchAdditionalData: !!invalidate,
           })
           const unreadCount = countUnread(page)
           const unreadCountStr =

--- a/src/state/queries/notifications/unread.tsx
+++ b/src/state/queries/notifications/unread.tsx
@@ -136,7 +136,7 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
 
             // only fetch subjects when the page is going to be used
             // in the notifications query, otherwise skip it
-            fetchAdditionalData: !!invalidate,
+            fetchAdditionalData: true,
           })
           const unreadCount = countUnread(page)
           const unreadCountStr =

--- a/src/state/queries/notifications/util.ts
+++ b/src/state/queries/notifications/util.ts
@@ -223,27 +223,21 @@ function getSubjectUri(
 }
 
 export function isThreadMuted(item: FeedNotification, threadMutes: string[]) {
-  const {record} = item.notification
+  // If we have a subject we can just use that
+  if (item.subject) {
+    const r = item.subject.record as AppBskyFeedPost.Record
 
-  // We only need to check if it's a post
-  if (AppBskyFeedPost.isRecord(record)) {
-    // If the thread is muted
-    if (record.reply && threadMutes.includes(record.reply.root.uri)) {
+    if (
+      AppBskyEmbedRecord.isMain(r.embed) &&
+      threadMutes.includes(r.embed.record.uri)
+    ) {
       return true
-    }
-    // If it's a quote...
-    else if (
-      AppBskyEmbedRecord.isMain(record.embed) &&
-      threadMutes.includes(record.embed.record.uri)
+    } else if (
+      (r.reply && threadMutes.includes(r.reply.root.uri)) ||
+      (item.subject.uri && threadMutes.includes(item.subject.uri))
     ) {
       return true
     }
-  } else if (
-    AppBskyFeedRepost.isRecord(record) &&
-    threadMutes.includes(record.subject.uri)
-  ) {
-    // Same if it's a repost
-    return true
   }
 
   return false

--- a/src/state/queries/notifications/util.ts
+++ b/src/state/queries/notifications/util.ts
@@ -206,15 +206,8 @@ function getSubjectUri(
   type: NotificationType,
   notif: AppBskyNotificationListNotifications.Notification,
 ): string | undefined {
-  if (type === 'reply' || type === 'mention') {
+  if (type === 'reply' || type === 'quote' || type === 'mention') {
     return notif.uri
-  } else if (type === 'quote') {
-    if (
-      AppBskyFeedPost.isRecord(notif.record) &&
-      AppBskyEmbedRecord.isMain(notif.record.embed)
-    ) {
-      return notif.record.embed.record.uri
-    }
   } else if (type === 'post-like' || type === 'repost') {
     if (
       AppBskyFeedRepost.isRecord(notif.record) ||
@@ -237,6 +230,11 @@ export function isThreadMuted(notif: FeedNotification, threadMutes: string[]) {
     if (
       (record.reply && threadMutes.includes(record.reply.root.uri)) ||
       (notif.subject.uri && threadMutes.includes(notif.subject.uri))
+    ) {
+      return true
+    } else if (
+      AppBskyEmbedRecord.isMain(record.embed) &&
+      threadMutes.includes(record.embed.record.uri)
     ) {
       return true
     }

--- a/src/state/queries/notifications/util.ts
+++ b/src/state/queries/notifications/util.ts
@@ -111,8 +111,6 @@ function shouldFilterNotif(
       return true
     }
   }
-  // TODO: thread muting is not being applied
-  // (this requires fetching the post)
   return false
 }
 


### PR DESCRIPTION
Adding some logic to `isThreadMuted` for when we don't have a subject URI (when counting)

- We can always check if the thread itself is muted from the post
- We can check root level quotes to see if they are muted
- Same for reposts, we can check if they are muted when the repost is the root

Hopefully will cover the majority of cases for now.

https://github.com/bluesky-social/social-app/issues/2562