### PR TITLE
Don't interpolate rkey for custom feed notification

### DIFF
--- a/src/view/com/notifications/FeedItem.tsx
+++ b/src/view/com/notifications/FeedItem.tsx
@@ -167,9 +167,7 @@ let FeedItem = ({
     icon = 'user-plus'
     iconStyle = [s.blue3 as FontAwesomeIconStyle]
   } else if (item.type === 'feedgen-like') {
-    action = item.subjectUri
-      ? _(msg`liked your custom feed '${new AtUri(item.subjectUri).rkey}'`)
-      : _(msg`liked your custom feed`)
+    action = _(msg`liked your custom feed`)
     icon = 'HeartIconSolid'
     iconStyle = [
       s.likeColor as FontAwesomeIconStyle,


### PR DESCRIPTION
Proposal: not sure how useful the `rkey` is here, since feed card shows below anyway. I can only repro the interpolation failure on mobile.

This PR changes what you see below to simply read "liked your custom feed".

![CleanShot 2024-01-30 at 16 14 34@2x](https://github.com/bluesky-social/social-app/assets/4732330/9b5871c9-1169-403c-b767-6958661b1743)
