### PR TITLE
remove unnecessary right padding in main thread item (fixes weird android cutoff)

### DIFF
--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -775,6 +775,7 @@ const useStyles = () => {
     },
     postTextLargeContainer: {
       paddingHorizontal: 0,
+      paddingRight: 0,
       paddingBottom: 10,
     },
     translateLink: {


### PR DESCRIPTION
fixes https://github.com/bluesky-social/social-app/issues/2522 (?)

Very specific case where Android on a Pixel 4a and platform 31 (yea, that specific...probably related to that precise screen size) doesn't want to render text when we add the additional padding to the main post. I'm not actually sure that this is a real "fix" as far as it never happening again (I'm inclined to think its an Android bug in text measurement), but it does fix this particular case to remove the padding.

Tested a ton of posts by removing the padding, if anything the visual affect is a bit better. Right now text kind of line breaks a bit too early, removing that bit of padding helps a good deal from all the posts I opened up.

We could say forget it too and just mark it up as an OS bug, but I don't see the harm in removing this anyway.