### PR TITLE
fix left swipe on android

### DIFF
--- a/src/view/com/util/images/Gallery.tsx
+++ b/src/view/com/util/images/Gallery.tsx
@@ -4,6 +4,7 @@ import {StyleSheet, Text, Pressable, View} from 'react-native'
 import {Image} from 'expo-image'
 import {msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
+import {isWeb} from 'platform/detection'
 
 type EventFunction = (index: number) => void
 
@@ -70,8 +71,8 @@ const styles = StyleSheet.create({
     paddingHorizontal: 6,
     paddingVertical: 3,
     position: 'absolute',
-    left: 8,
-    bottom: 8,
+    left: isWeb ? 8 : 5,
+    bottom: isWeb ? 8 : 5,
   },
   alt: {
     color: 'white',

--- a/src/view/com/util/images/Gallery.tsx
+++ b/src/view/com/util/images/Gallery.tsx
@@ -71,6 +71,8 @@ const styles = StyleSheet.create({
     paddingHorizontal: 6,
     paddingVertical: 3,
     position: 'absolute',
+    // Related to margin/gap hack. This keeps the alt label in the same position
+    // on all platforms
     left: isWeb ? 8 : 5,
     bottom: isWeb ? 8 : 5,
   },

--- a/src/view/com/util/images/ImageLayoutGrid.tsx
+++ b/src/view/com/util/images/ImageLayoutGrid.tsx
@@ -51,7 +51,7 @@ function ImageLayoutGridInner(props: ImageLayoutGridInnerProps) {
           <View style={{flex: 2, aspectRatio: isWeb ? 1 : undefined}}>
             <GalleryItem {...props} index={0} imageStyle={styles.image} />
           </View>
-          <View style={{flex: 1, gap: !isWeb ? 5 : undefined}}>
+          <View style={{flex: 1, gap: !isWeb ? IMAGE_GAP : undefined}}>
             <View style={styles.smallItem}>
               <GalleryItem {...props} index={1} imageStyle={styles.image} />
             </View>

--- a/src/view/com/util/images/ImageLayoutGrid.tsx
+++ b/src/view/com/util/images/ImageLayoutGrid.tsx
@@ -48,10 +48,10 @@ function ImageLayoutGridInner(props: ImageLayoutGridInnerProps) {
     case 3:
       return (
         <View style={styles.flexRow}>
-          <View style={{flex: 2, aspectRatio: isWeb ? 1 : undefined}}>
+          <View style={styles.threeSingle}>
             <GalleryItem {...props} index={0} imageStyle={styles.image} />
           </View>
-          <View style={{flex: 1, gap: !isWeb ? IMAGE_GAP : undefined}}>
+          <View style={styles.threeDouble}>
             <View style={styles.smallItem}>
               <GalleryItem {...props} index={1} imageStyle={styles.image} />
             </View>
@@ -94,6 +94,9 @@ function ImageLayoutGridInner(props: ImageLayoutGridInnerProps) {
 const IMAGE_GAP = 5
 
 const styles = StyleSheet.create({
+  flexRow: {flexDirection: 'row', gap: !isWeb ? IMAGE_GAP : undefined},
+  smallItem: {flex: 1, aspectRatio: 1},
+
   container: isWeb
     ? {
         marginHorizontal: -IMAGE_GAP / 2,
@@ -102,11 +105,17 @@ const styles = StyleSheet.create({
     : {
         gap: IMAGE_GAP,
       },
-  flexRow: {flexDirection: 'row', gap: !isWeb ? IMAGE_GAP : undefined},
-  smallItem: {flex: 1, aspectRatio: 1},
   image: isWeb
     ? {
         margin: IMAGE_GAP / 2,
       }
     : {},
+  threeSingle: {
+    flex: 1,
+    gap: isWeb ? undefined : IMAGE_GAP,
+  },
+  threeDouble: {
+    flex: 1,
+    gap: isWeb ? undefined : IMAGE_GAP,
+  },
 })

--- a/src/view/com/util/images/ImageLayoutGrid.tsx
+++ b/src/view/com/util/images/ImageLayoutGrid.tsx
@@ -111,8 +111,8 @@ const styles = StyleSheet.create({
       }
     : {},
   threeSingle: {
-    flex: 1,
-    gap: isWeb ? undefined : IMAGE_GAP,
+    flex: 2,
+    aspectRatio: isWeb ? 1 : undefined,
   },
   threeDouble: {
     flex: 1,

--- a/src/view/com/util/images/ImageLayoutGrid.tsx
+++ b/src/view/com/util/images/ImageLayoutGrid.tsx
@@ -89,14 +89,14 @@ function ImageLayoutGridInner(props: ImageLayoutGridInnerProps) {
   }
 }
 
-// This is used to compute margins (rather than flexbox gap) due to Yoga bugs:
+// On web we use margin to calculate gap, as aspectRatio does not properly size
+// all images on web. On native though we cannot rely on margin, since the
+// negative margin interferes with the swipe controls on pagers.
 // https://github.com/facebook/yoga/issues/1418
+// https://github.com/bluesky-social/social-app/issues/2601
 const IMAGE_GAP = 5
 
 const styles = StyleSheet.create({
-  flexRow: {flexDirection: 'row', gap: !isWeb ? IMAGE_GAP : undefined},
-  smallItem: {flex: 1, aspectRatio: 1},
-
   container: isWeb
     ? {
         marginHorizontal: -IMAGE_GAP / 2,
@@ -105,6 +105,11 @@ const styles = StyleSheet.create({
     : {
         gap: IMAGE_GAP,
       },
+  flexRow: {
+    flexDirection: 'row',
+    gap: isWeb ? undefined : IMAGE_GAP,
+  },
+  smallItem: {flex: 1, aspectRatio: 1},
   image: isWeb
     ? {
         margin: IMAGE_GAP / 2,

--- a/src/view/com/util/images/ImageLayoutGrid.tsx
+++ b/src/view/com/util/images/ImageLayoutGrid.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import {StyleProp, StyleSheet, View, ViewStyle} from 'react-native'
 import {AppBskyEmbedImages} from '@atproto/api'
 import {GalleryItem} from './Gallery'
+import {isWeb} from 'platform/detection'
 
 interface ImageLayoutGridProps {
   images: AppBskyEmbedImages.ViewImage[]
@@ -47,10 +48,10 @@ function ImageLayoutGridInner(props: ImageLayoutGridInnerProps) {
     case 3:
       return (
         <View style={styles.flexRow}>
-          <View style={{flex: 2, aspectRatio: 1}}>
+          <View style={{flex: 2, aspectRatio: isWeb ? 1 : undefined}}>
             <GalleryItem {...props} index={0} imageStyle={styles.image} />
           </View>
-          <View style={{flex: 1}}>
+          <View style={{flex: 1, gap: !isWeb ? 5 : undefined}}>
             <View style={styles.smallItem}>
               <GalleryItem {...props} index={1} imageStyle={styles.image} />
             </View>
@@ -93,13 +94,19 @@ function ImageLayoutGridInner(props: ImageLayoutGridInnerProps) {
 const IMAGE_GAP = 5
 
 const styles = StyleSheet.create({
-  container: {
-    marginHorizontal: -IMAGE_GAP / 2,
-    marginVertical: -IMAGE_GAP / 2,
-  },
-  flexRow: {flexDirection: 'row'},
+  container: isWeb
+    ? {
+        marginHorizontal: -IMAGE_GAP / 2,
+        marginVertical: -IMAGE_GAP / 2,
+      }
+    : {
+        gap: IMAGE_GAP,
+      },
+  flexRow: {flexDirection: 'row', gap: !isWeb ? IMAGE_GAP : undefined},
   smallItem: {flex: 1, aspectRatio: 1},
-  image: {
-    margin: IMAGE_GAP / 2,
-  },
+  image: isWeb
+    ? {
+        margin: IMAGE_GAP / 2,
+      }
+    : {},
 })


### PR DESCRIPTION
fixes https://github.com/bluesky-social/social-app/issues/2601

Optimistic that we can use `gap` on native. Removing the negative margins from the container is the key to fixing the swipe issue, and looks like we were using that because of the yoga issue.

Noted that on web, using `gap` with `aspectRatio` definitely didn't work right for 3 images, but it seems to be okay on native. We don't need `aspectRatio` there because expo-image handles the sizing (based on the containers height from the other two images with `aspectRatio: 1`, whereas it looks like on web it doesn't.

Did have to slightly adjust the alt text label as well, since removing that margin moved it in a bit.