### PR TITLE
Fix notification mark-read behaviors

### DIFF
--- a/src/state/queries/notifications/feed.ts
+++ b/src/state/queries/notifications/feed.ts
@@ -78,7 +78,7 @@ export function useNotificationFeedQuery(opts?: {enabled?: boolean}) {
       }
 
       // if the first page has an unread, mark all read
-      if (!pageParam && page.items[0] && !page.items[0].notification.isRead) {
+      if (!pageParam) {
         unreads.markAllRead()
       }
 

--- a/src/state/queries/notifications/feed.ts
+++ b/src/state/queries/notifications/feed.ts
@@ -67,14 +67,16 @@ export function useNotificationFeedQuery(opts?: {enabled?: boolean}) {
         page = unreads.getCachedUnreadPage()
       }
       if (!page) {
-        page = await fetchPage({
-          limit: PAGE_SIZE,
-          cursor: pageParam,
-          queryClient,
-          moderationOpts,
-          threadMutes,
-          fetchAdditionalData: true,
-        })
+        page = (
+          await fetchPage({
+            limit: PAGE_SIZE,
+            cursor: pageParam,
+            queryClient,
+            moderationOpts,
+            threadMutes,
+            fetchAdditionalData: true,
+          })
+        ).page
       }
 
       // if the first page has an unread, mark all read

--- a/src/state/queries/notifications/unread.tsx
+++ b/src/state/queries/notifications/unread.tsx
@@ -127,7 +127,7 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
           }
 
           // count
-          const page = await fetchPage({
+          const {page, indexedAt: lastIndexed} = await fetchPage({
             cursor: undefined,
             limit: 40,
             queryClient,
@@ -151,12 +151,14 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
 
           // track last sync
           const now = new Date()
-          const lastIndexed =
-            page.items[0] && new Date(page.items[0].notification.indexedAt)
+          const lastIndexedDate = lastIndexed
+            ? new Date(lastIndexed)
+            : undefined
           cacheRef.current = {
             usableInFeed: !!invalidate, // will be used immediately
             data: page,
-            syncedAt: !lastIndexed || now > lastIndexed ? now : lastIndexed,
+            syncedAt:
+              !lastIndexedDate || now > lastIndexedDate ? now : lastIndexedDate,
             unreadCount,
           }
 

--- a/src/state/queries/notifications/util.ts
+++ b/src/state/queries/notifications/util.ts
@@ -36,11 +36,12 @@ export async function fetchPage({
   moderationOpts: ModerationOpts | undefined
   threadMutes: string[]
   fetchAdditionalData: boolean
-}): Promise<FeedPage> {
+}): Promise<{page: FeedPage; indexedAt: string | undefined}> {
   const res = await getAgent().listNotifications({
     limit,
     cursor,
   })
+  const indexedAt = res.data.notifications[0]?.indexedAt
 
   // filter out notifs by mod rules
   const notifs = res.data.notifications.filter(
@@ -75,9 +76,12 @@ export async function fetchPage({
   }
 
   return {
-    cursor: res.data.cursor,
-    seenAt,
-    items: notifsGrouped,
+    page: {
+      cursor: res.data.cursor,
+      seenAt,
+      items: notifsGrouped,
+    },
+    indexedAt,
   }
 }
 


### PR DESCRIPTION
Noticed these when testing the thread muting

Essentially the notification filtering was interrupting the correct `markAllRead` behavior. We need to be using the `indexedAt` of the most recent notification in `updateSeen`, and so we need to capture that timestamp prior to filtering. I also removed an optimization that assumed that you'd never filter out a whole page of notifs, which you indeed can with a thread mute