### PR TITLE
Workaround Safari content-visibility bug

### DIFF
--- a/src/view/com/util/List.web.tsx
+++ b/src/view/com/util/List.web.tsx
@@ -300,6 +300,9 @@ export const List = memo(React.forwardRef(ListImpl)) as <ItemT>(
   props: ListProps<ItemT> & {ref?: React.Ref<ListMethods>},
 ) => React.ReactElement
 
+// https://stackoverflow.com/questions/7944460/detect-safari-browser
+const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent)
+
 const styles = StyleSheet.create({
   contentContainer: {
     borderLeftWidth: 1,
@@ -313,7 +316,7 @@ const styles = StyleSheet.create({
   },
   row: {
     // @ts-ignore web only
-    contentVisibility: 'auto',
+    contentVisibility: isSafari ? '' : 'auto', // Safari support for this is buggy.
   },
   minHeightViewport: {
     // @ts-ignore web only


### PR DESCRIPTION
This property should in theory be useful for improving paint perf for lists (I haven't measured but I know it can bring good results from past practice). However, it seems currently borked in Safari Technology Preview and Orion. It might be a temporary regression (they're actively landing PRs related to this property in WebKit repo) but for now let's turn it off for Safari.