### PR TITLE
Reduce the odds of false positives in the language suggester

### DIFF
--- a/src/view/com/composer/text-input/TextInput.web.tsx
+++ b/src/view/com/composer/text-input/TextInput.web.tsx
@@ -316,7 +316,6 @@ function getImageFromUri(
     const type = item.type
 
     if (type === 'text/plain') {
-      console.log('hit')
       item.getAsString(async itemString => {
         if (isUriImage(itemString)) {
           const response = await fetch(itemString)


### PR DESCRIPTION
Hopefully closes #2598 

I did more testing sessions on lande's output for given test strings. I noticed that false positives happen seem to correlate to having multiple matches with a score higher than `0.000x` (4 decimals of certainty) and so this adds logic to discard suggestions that match those conditions.