### PR TITLE
Prevent post meta misclicks in QT

### DIFF
--- a/src/view/com/util/post-embeds/QuoteEmbed.tsx
+++ b/src/view/com/util/post-embeds/QuoteEmbed.tsx
@@ -113,13 +113,15 @@ export function QuoteEmbed({
       hoverStyle={{borderColor: pal.colors.borderLinkHover}}
       href={itemHref}
       title={itemTitle}>
-      <PostMeta
-        author={quote.author}
-        showAvatar
-        authorHasWarning={false}
-        postHref={itemHref}
-        timestamp={quote.indexedAt}
-      />
+      <View pointerEvents="none">
+        <PostMeta
+          author={quote.author}
+          showAvatar
+          authorHasWarning={false}
+          postHref={itemHref}
+          timestamp={quote.indexedAt}
+        />
+      </View>
       {moderation ? (
         <PostAlerts moderation={moderation} style={styles.alert} />
       ) : null}


### PR DESCRIPTION
I often accidentally click on the author when attempting to click on the embedded post. This is hard to get muscle memory for because the author name is dynamic and the click area is often very small.

<img width="360" alt="Screenshot 2024-01-31 at 03 46 20" src="https://github.com/bluesky-social/social-app/assets/810438/9b898a79-70e9-449f-970d-d014ceffb85d">

I'd argue that this direct click-through is unnecessary, and it's ok if clicking the meta always lands you on the quoted post. From there you can click into the author. (That's how it works on Twitter.)

That's what this PR does.