### PR TITLE
Onboarding moderation improvements

### DIFF
--- a/src/screens/Onboarding/StepModeration/AdultContentEnabledPref.tsx
+++ b/src/screens/Onboarding/StepModeration/AdultContentEnabledPref.tsx
@@ -13,6 +13,7 @@ import {CircleInfo_Stroke2_Corner0_Rounded as CircleInfo} from '#/components/ico
 import * as Prompt from '#/components/Prompt'
 import {InlineLink} from '#/components/Link'
 import {UseMutateFunction} from '@tanstack/react-query'
+import {isIOS} from 'platform/detection'
 
 function Card({children}: React.PropsWithChildren<{}>) {
   const t = useTheme()
@@ -49,19 +50,15 @@ export function AdultContentEnabledPref({
   const {data: preferences} = usePreferencesQuery()
 
   const onToggleAdultContent = React.useCallback(async () => {
-    // if (isIOS) {
-    //   prompt.open()
-    //   return
-    // }
+    if (isIOS) {
+      prompt.open()
+      return
+    }
 
     try {
       mutate({
         enabled: !(variables?.enabled ?? preferences?.adultContentEnabled),
       })
-      // if (isAndroid) {
-      //   UIManager.setLayoutAnimationEnabledExperimental(true)
-      // }
-      // LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut)
     } catch (e) {
       Toast.show(
         _(msg`There was an issue syncing your preferences with the server`),

--- a/src/screens/Onboarding/StepModeration/AdultContentEnabledPref.tsx
+++ b/src/screens/Onboarding/StepModeration/AdultContentEnabledPref.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import {LayoutAnimation, View} from 'react-native'
+import {View} from 'react-native'
 import {useLingui} from '@lingui/react'
 import {msg, Trans} from '@lingui/macro'
 
@@ -49,7 +49,6 @@ export function AdultContentEnabledPref({
   const {data: preferences} = usePreferencesQuery()
 
   const onToggleAdultContent = React.useCallback(async () => {
-    // TODO re-enable this
     // if (isIOS) {
     //   prompt.open()
     //   return
@@ -59,7 +58,10 @@ export function AdultContentEnabledPref({
       mutate({
         enabled: !(variables?.enabled ?? preferences?.adultContentEnabled),
       })
-      LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut)
+      // if (isAndroid) {
+      //   UIManager.setLayoutAnimationEnabledExperimental(true)
+      // }
+      // LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut)
     } catch (e) {
       Toast.show(
         _(msg`There was an issue syncing your preferences with the server`),

--- a/src/screens/Onboarding/StepModeration/AdultContentEnabledPref.tsx
+++ b/src/screens/Onboarding/StepModeration/AdultContentEnabledPref.tsx
@@ -1,20 +1,18 @@
 import React from 'react'
-import {View} from 'react-native'
+import {LayoutAnimation, View} from 'react-native'
 import {useLingui} from '@lingui/react'
 import {msg, Trans} from '@lingui/macro'
 
-import {isIOS} from '#/platform/detection'
 import * as Toast from '#/view/com/util/Toast'
 import {atoms as a, useTheme} from '#/alf'
-import {
-  usePreferencesQuery,
-  usePreferencesSetAdultContentMutation,
-} from '#/state/queries/preferences'
+import {usePreferencesQuery} from '#/state/queries/preferences'
 import {logger} from '#/logger'
 import {Text} from '#/components/Typography'
-import {InlineLink} from '#/components/Link'
 import * as Toggle from '#/components/forms/Toggle'
 import {CircleInfo_Stroke2_Corner0_Rounded as CircleInfo} from '#/components/icons/CircleInfo'
+import * as Prompt from '#/components/Prompt'
+import {InlineLink} from '#/components/Link'
+import {UseMutateFunction} from '@tanstack/react-query'
 
 function Card({children}: React.PropsWithChildren<{}>) {
   const t = useTheme()
@@ -36,36 +34,65 @@ function Card({children}: React.PropsWithChildren<{}>) {
   )
 }
 
-export function AdultContentEnabledPref() {
+export function AdultContentEnabledPref({
+  mutate,
+  variables,
+}: {
+  mutate: UseMutateFunction<void, unknown, {enabled: boolean}, unknown>
+  variables: {enabled: boolean} | undefined
+}) {
   const {_} = useLingui()
   const t = useTheme()
+  const prompt = Prompt.usePromptControl()
 
   // Reuse logic here form ContentFilteringSettings.tsx
   const {data: preferences} = usePreferencesQuery()
-  const {mutate, variables} = usePreferencesSetAdultContentMutation()
 
   const onToggleAdultContent = React.useCallback(async () => {
-    if (isIOS) return
+    // TODO re-enable this
+    // if (isIOS) {
+    //   prompt.open()
+    //   return
+    // }
 
     try {
       mutate({
         enabled: !(variables?.enabled ?? preferences?.adultContentEnabled),
       })
+      LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut)
     } catch (e) {
       Toast.show(
         _(msg`There was an issue syncing your preferences with the server`),
       )
       logger.error('Failed to update preferences with server', {error: e})
     }
-  }, [variables, preferences, mutate, _])
+  }, [variables, preferences, mutate, _, prompt])
 
   if (!preferences) return null
 
-  if (isIOS) {
-    if (preferences?.adultContentEnabled === true) {
-      return null
-    } else {
-      return (
+  return (
+    <>
+      {preferences.userAge && preferences.userAge >= 18 ? (
+        <View style={[a.w_full, a.px_xs]}>
+          <Toggle.Item
+            name={_(msg`Enable adult content in your feeds`)}
+            label={_(msg`Enable adult content in your feeds`)}
+            value={variables?.enabled ?? preferences?.adultContentEnabled}
+            onChange={onToggleAdultContent}>
+            <View
+              style={[
+                a.flex_row,
+                a.w_full,
+                a.justify_between,
+                a.align_center,
+                a.py_md,
+              ]}>
+              <Text style={[a.font_bold]}>Enable Adult Content</Text>
+              <Toggle.Switch />
+            </View>
+          </Toggle.Item>
+        </View>
+      ) : (
         <Card>
           <CircleInfo size="sm" fill={t.palette.contrast_500} />
           <Text
@@ -75,61 +102,27 @@ export function AdultContentEnabledPref() {
               a.leading_snug,
               {paddingTop: 1},
             ]}>
-            <Trans>
-              Adult content can only be enabled via the Web at{' '}
-              <InlineLink style={[a.leading_snug]} to="https://bsky.app">
-                bsky.app
-              </InlineLink>
-              .
-            </Trans>
+            <Trans>You must be 18 years or older to enable adult content</Trans>
           </Text>
         </Card>
-      )
-    }
-  } else {
-    if (preferences?.userAge) {
-      if (preferences.userAge >= 18) {
-        return (
-          <View style={[a.w_full]}>
-            <Toggle.Item
-              name={_(msg`Enable adult content in your feeds`)}
-              label={_(msg`Enable adult content in your feeds`)}
-              value={variables?.enabled ?? preferences?.adultContentEnabled}
-              onChange={onToggleAdultContent}>
-              <View
-                style={[
-                  a.flex_row,
-                  a.w_full,
-                  a.justify_between,
-                  a.align_center,
-                  a.py_md,
-                ]}>
-                <Text style={[a.font_bold]}>Enable Adult Content</Text>
-                <Toggle.Switch />
-              </View>
-            </Toggle.Item>
-          </View>
-        )
-      } else {
-        return (
-          <Card>
-            <CircleInfo size="sm" fill={t.palette.contrast_500} />
-            <Text
-              style={[
-                a.flex_1,
-                t.atoms.text_contrast_700,
-                a.leading_snug,
-                {paddingTop: 1},
-              ]}>
-              <Trans>
-                You must be 18 years or older to enable adult content
-              </Trans>
-            </Text>
-          </Card>
-        )
-      }
-    }
+      )}
 
-    return null
-  }
+      <Prompt.Outer control={prompt}>
+        <Prompt.Title>Adult Content</Prompt.Title>
+        <Prompt.Description>
+          {/* TODO Update this to provide info about why you can't enable on ios */}
+          <Trans>
+            Adult content can only be enabled via the Web at{' '}
+            <InlineLink style={[a.leading_snug]} to="https://bsky.app">
+              bsky.app
+            </InlineLink>
+            .
+          </Trans>
+        </Prompt.Description>
+        <Prompt.Actions>
+          <Prompt.Action onPress={prompt.close}>OK</Prompt.Action>
+        </Prompt.Actions>
+      </Prompt.Outer>
+    </>
+  )
 }

--- a/src/screens/Onboarding/StepModeration/AdultContentEnabledPref.tsx
+++ b/src/screens/Onboarding/StepModeration/AdultContentEnabledPref.tsx
@@ -11,7 +11,6 @@ import {Text} from '#/components/Typography'
 import * as Toggle from '#/components/forms/Toggle'
 import {CircleInfo_Stroke2_Corner0_Rounded as CircleInfo} from '#/components/icons/CircleInfo'
 import * as Prompt from '#/components/Prompt'
-import {InlineLink} from '#/components/Link'
 import {UseMutateFunction} from '@tanstack/react-query'
 import {isIOS} from 'platform/detection'
 
@@ -109,13 +108,9 @@ export function AdultContentEnabledPref({
       <Prompt.Outer control={prompt}>
         <Prompt.Title>Adult Content</Prompt.Title>
         <Prompt.Description>
-          {/* TODO Update this to provide info about why you can't enable on ios */}
           <Trans>
-            Adult content can only be enabled via the Web at{' '}
-            <InlineLink style={[a.leading_snug]} to="https://bsky.app">
-              bsky.app
-            </InlineLink>
-            .
+            Due to Apple policies, adult content can only be enabled on the web
+            after completing sign up.
           </Trans>
         </Prompt.Description>
         <Prompt.Actions>

--- a/src/screens/Onboarding/StepModeration/AdultContentEnabledPref.tsx
+++ b/src/screens/Onboarding/StepModeration/AdultContentEnabledPref.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import {View} from 'react-native'
 import {useLingui} from '@lingui/react'
 import {msg, Trans} from '@lingui/macro'
+import {UseMutateFunction} from '@tanstack/react-query'
 
 import * as Toast from '#/view/com/util/Toast'
 import {atoms as a, useTheme} from '#/alf'
@@ -11,8 +12,7 @@ import {Text} from '#/components/Typography'
 import * as Toggle from '#/components/forms/Toggle'
 import {CircleInfo_Stroke2_Corner0_Rounded as CircleInfo} from '#/components/icons/CircleInfo'
 import * as Prompt from '#/components/Prompt'
-import {UseMutateFunction} from '@tanstack/react-query'
-import {isIOS} from 'platform/detection'
+import {isIOS} from '#/platform/detection'
 
 function Card({children}: React.PropsWithChildren<{}>) {
   const t = useTheme()

--- a/src/screens/Onboarding/StepModeration/ModerationOption.tsx
+++ b/src/screens/Onboarding/StepModeration/ModerationOption.tsx
@@ -17,8 +17,10 @@ import * as ToggleButton from '#/components/forms/ToggleButton'
 
 export function ModerationOption({
   labelGroup,
+  isMounted,
 }: {
   labelGroup: ConfigurableLabelGroup
+  isMounted: React.MutableRefObject<boolean>
 }) {
   const {_} = useLingui()
   const t = useTheme()
@@ -52,7 +54,7 @@ export function ModerationOption({
         a.align_center,
       ]}
       layout={Layout.easing(Easing.ease).duration(200)}
-      entering={groupInfo.isAdultImagery ? FadeIn : undefined}>
+      entering={isMounted.current ? FadeIn : undefined}>
       <View style={[a.gap_xs, {width: '50%'}]}>
         <Text style={[a.font_bold]}>{groupInfo.title}</Text>
         <Text style={[t.atoms.text_contrast_700, a.leading_snug]}>

--- a/src/screens/Onboarding/StepModeration/ModerationOption.tsx
+++ b/src/screens/Onboarding/StepModeration/ModerationOption.tsx
@@ -57,28 +57,22 @@ export function ModerationOption({
         </Text>
       </View>
       <View style={[a.justify_center, {minHeight: 35}]}>
-        {!preferences?.adultContentEnabled && groupInfo.isAdultImagery ? (
-          <View style={[a.justify_center, {minHeight: 40}]}>
-            <Text style={[a.font_bold]}>{labels.hide}</Text>
-          </View>
-        ) : (
-          <ToggleButton.Group
-            label={_(
-              msg`Configure content filtering setting for category: ${groupInfo.title.toLowerCase()}`,
-            )}
-            values={[visibility ?? 'hide']}
-            onChange={onChange}>
-            <ToggleButton.Button name="hide" label={labels.hide}>
-              {labels.hide}
-            </ToggleButton.Button>
-            <ToggleButton.Button name="warn" label={labels.warn}>
-              {labels.warn}
-            </ToggleButton.Button>
-            <ToggleButton.Button name="ignore" label={labels.show}>
-              {labels.show}
-            </ToggleButton.Button>
-          </ToggleButton.Group>
-        )}
+        <ToggleButton.Group
+          label={_(
+            msg`Configure content filtering setting for category: ${groupInfo.title.toLowerCase()}`,
+          )}
+          values={[visibility ?? 'hide']}
+          onChange={onChange}>
+          <ToggleButton.Button name="hide" label={labels.hide}>
+            {labels.hide}
+          </ToggleButton.Button>
+          <ToggleButton.Button name="warn" label={labels.warn}>
+            {labels.warn}
+          </ToggleButton.Button>
+          <ToggleButton.Button name="ignore" label={labels.show}>
+            {labels.show}
+          </ToggleButton.Button>
+        </ToggleButton.Group>
       </View>
     </View>
   )

--- a/src/screens/Onboarding/StepModeration/ModerationOption.tsx
+++ b/src/screens/Onboarding/StepModeration/ModerationOption.tsx
@@ -3,6 +3,7 @@ import {View} from 'react-native'
 import {LabelPreference} from '@atproto/api'
 import {useLingui} from '@lingui/react'
 import {msg} from '@lingui/macro'
+import Animated, {Easing, Layout, FadeIn} from 'react-native-reanimated'
 
 import {
   CONFIGURABLE_LABEL_GROUPS,
@@ -41,7 +42,7 @@ export function ModerationOption({
   }
 
   return (
-    <View
+    <Animated.View
       style={[
         a.flex_row,
         a.justify_between,
@@ -49,7 +50,9 @@ export function ModerationOption({
         a.py_xs,
         a.px_xs,
         a.align_center,
-      ]}>
+      ]}
+      layout={Layout.easing(Easing.ease).duration(200)}
+      entering={groupInfo.isAdultImagery ? FadeIn : undefined}>
       <View style={[a.gap_xs, {width: '50%'}]}>
         <Text style={[a.font_bold]}>{groupInfo.title}</Text>
         <Text style={[t.atoms.text_contrast_700, a.leading_snug]}>
@@ -74,6 +77,6 @@ export function ModerationOption({
           </ToggleButton.Button>
         </ToggleButton.Group>
       </View>
-    </View>
+    </Animated.View>
   )
 }

--- a/src/screens/Onboarding/StepModeration/index.tsx
+++ b/src/screens/Onboarding/StepModeration/index.tsx
@@ -34,6 +34,11 @@ export function StepModeration() {
   const {data: preferences} = usePreferencesQuery()
   const {mutate, variables} = usePreferencesSetAdultContentMutation()
 
+  const adultContentEnabled = !!(
+    (variables && variables.enabled) ||
+    (!variables && preferences?.adultContentEnabled)
+  )
+
   const onContinue = React.useCallback(() => {
     dispatch({type: 'next'})
     track('OnboardingV2:StepModeration:End')
@@ -65,8 +70,7 @@ export function StepModeration() {
           <AdultContentEnabledPref mutate={mutate} variables={variables} />
 
           <View style={[a.gap_sm, a.w_full]}>
-            {((variables && variables.enabled) ||
-              preferences.adultContentEnabled) &&
+            {adultContentEnabled &&
               configurableAdultLabelGroups.map((g, index) => (
                 <React.Fragment key={index}>
                   {index === 0 && <Divider />}
@@ -77,7 +81,7 @@ export function StepModeration() {
 
             {configurableOtherLabelGroups.map((g, index) => (
               <React.Fragment key={index}>
-                {!preferences.adultContentEnabled && index === 0 && <Divider />}
+                {!adultContentEnabled && index === 0 && <Divider />}
                 <ModerationOption labelGroup={g} />
                 <Divider />
               </React.Fragment>

--- a/src/screens/Onboarding/StepModeration/index.tsx
+++ b/src/screens/Onboarding/StepModeration/index.tsx
@@ -4,7 +4,10 @@ import {useLingui} from '@lingui/react'
 import {msg, Trans} from '@lingui/macro'
 
 import {atoms as a} from '#/alf'
-import {configurableLabelGroups} from 'state/queries/preferences'
+import {
+  configurableAdultLabelGroups,
+  configurableOtherLabelGroups,
+} from 'state/queries/preferences'
 import {Divider} from '#/components/Divider'
 import {Button, ButtonIcon, ButtonText} from '#/components/Button'
 import {ChevronRight_Stroke2_Corner0_Rounded as ChevronRight} from '#/components/icons/Chevron'
@@ -60,9 +63,18 @@ export function StepModeration() {
           <AdultContentEnabledPref />
 
           <View style={[a.gap_sm, a.w_full]}>
-            {configurableLabelGroups.map((g, index) => (
+            {preferences.adultContentEnabled &&
+              configurableAdultLabelGroups.map((g, index) => (
+                <React.Fragment key={index}>
+                  {index === 0 && <Divider />}
+                  <ModerationOption labelGroup={g} />
+                  <Divider />
+                </React.Fragment>
+              ))}
+
+            {configurableOtherLabelGroups.map((g, index) => (
               <React.Fragment key={index}>
-                {index === 0 && <Divider />}
+                {!preferences.adultContentEnabled && index === 0 && <Divider />}
                 <ModerationOption labelGroup={g} />
                 <Divider />
               </React.Fragment>

--- a/src/screens/Onboarding/StepModeration/index.tsx
+++ b/src/screens/Onboarding/StepModeration/index.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import {View} from 'react-native'
 import {useLingui} from '@lingui/react'
 import {msg, Trans} from '@lingui/macro'
+import Animated, {Easing, Layout} from 'react-native-reanimated'
 
 import {atoms as a} from '#/alf'
 import {
@@ -26,6 +27,14 @@ import {ModerationOption} from '#/screens/Onboarding/StepModeration/ModerationOp
 import {AdultContentEnabledPref} from '#/screens/Onboarding/StepModeration/AdultContentEnabledPref'
 import {Context} from '#/screens/Onboarding/state'
 import {IconCircle} from '#/screens/Onboarding/IconCircle'
+
+function AnimatedDivider() {
+  return (
+    <Animated.View layout={Layout.easing(Easing.ease).duration(200)}>
+      <Divider />
+    </Animated.View>
+  )
+}
 
 export function StepModeration() {
   const {_} = useLingui()
@@ -73,17 +82,17 @@ export function StepModeration() {
             {adultContentEnabled &&
               configurableAdultLabelGroups.map((g, index) => (
                 <React.Fragment key={index}>
-                  {index === 0 && <Divider />}
+                  {index === 0 && <AnimatedDivider />}
                   <ModerationOption labelGroup={g} />
-                  <Divider />
+                  <AnimatedDivider />
                 </React.Fragment>
               ))}
 
             {configurableOtherLabelGroups.map((g, index) => (
               <React.Fragment key={index}>
-                {!adultContentEnabled && index === 0 && <Divider />}
+                {!adultContentEnabled && index === 0 && <AnimatedDivider />}
                 <ModerationOption labelGroup={g} />
-                <Divider />
+                <AnimatedDivider />
               </React.Fragment>
             ))}
           </View>

--- a/src/screens/Onboarding/StepModeration/index.tsx
+++ b/src/screens/Onboarding/StepModeration/index.tsx
@@ -7,6 +7,7 @@ import {atoms as a} from '#/alf'
 import {
   configurableAdultLabelGroups,
   configurableOtherLabelGroups,
+  usePreferencesSetAdultContentMutation,
 } from 'state/queries/preferences'
 import {Divider} from '#/components/Divider'
 import {Button, ButtonIcon, ButtonText} from '#/components/Button'
@@ -31,6 +32,7 @@ export function StepModeration() {
   const {track} = useAnalytics()
   const {state, dispatch} = React.useContext(Context)
   const {data: preferences} = usePreferencesQuery()
+  const {mutate, variables} = usePreferencesSetAdultContentMutation()
 
   const onContinue = React.useCallback(() => {
     dispatch({type: 'next'})
@@ -60,10 +62,11 @@ export function StepModeration() {
         </View>
       ) : (
         <>
-          <AdultContentEnabledPref />
+          <AdultContentEnabledPref mutate={mutate} variables={variables} />
 
           <View style={[a.gap_sm, a.w_full]}>
-            {preferences.adultContentEnabled &&
+            {((variables && variables.enabled) ||
+              preferences.adultContentEnabled) &&
               configurableAdultLabelGroups.map((g, index) => (
                 <React.Fragment key={index}>
                   {index === 0 && <Divider />}

--- a/src/screens/Onboarding/StepModeration/index.tsx
+++ b/src/screens/Onboarding/StepModeration/index.tsx
@@ -43,6 +43,13 @@ export function StepModeration() {
   const {data: preferences} = usePreferencesQuery()
   const {mutate, variables} = usePreferencesSetAdultContentMutation()
 
+  // We need to know if the screen is mounted so we know if we want to run entering animations
+  // https://github.com/software-mansion/react-native-reanimated/discussions/2513
+  const isMounted = React.useRef(false)
+  React.useLayoutEffect(() => {
+    isMounted.current = true
+  }, [])
+
   const adultContentEnabled = !!(
     (variables && variables.enabled) ||
     (!variables && preferences?.adultContentEnabled)
@@ -83,7 +90,7 @@ export function StepModeration() {
               configurableAdultLabelGroups.map((g, index) => (
                 <React.Fragment key={index}>
                   {index === 0 && <AnimatedDivider />}
-                  <ModerationOption labelGroup={g} />
+                  <ModerationOption labelGroup={g} isMounted={isMounted} />
                   <AnimatedDivider />
                 </React.Fragment>
               ))}
@@ -91,7 +98,7 @@ export function StepModeration() {
             {configurableOtherLabelGroups.map((g, index) => (
               <React.Fragment key={index}>
                 {!adultContentEnabled && index === 0 && <AnimatedDivider />}
-                <ModerationOption labelGroup={g} />
+                <ModerationOption labelGroup={g} isMounted={isMounted} />
                 <AnimatedDivider />
               </React.Fragment>
             ))}

--- a/src/state/queries/preferences/types.ts
+++ b/src/state/queries/preferences/types.ts
@@ -5,14 +5,22 @@ import {
   BskyFeedViewPreference,
 } from '@atproto/api'
 
-export const configurableLabelGroups = [
+export const configurableAdultLabelGroups = [
   'nsfw',
   'nudity',
   'suggestive',
   'gore',
+] as const
+
+export const configurableOtherLabelGroups = [
   'hate',
   'spam',
   'impersonation',
+] as const
+
+export const configurableLabelGroups = [
+  ...configurableAdultLabelGroups,
+  ...configurableOtherLabelGroups,
 ] as const
 export type ConfigurableLabelGroup = (typeof configurableLabelGroups)[number]
 


### PR DESCRIPTION
Improving the moderation configuration:

- Always show the enable toggle
- On iOS where users must use the web to enable adult content, still show the toggle but display a dialog explaining when the user tries to toggle it
- Improve the wording of the requirement to use web to enable
- Don't display the adult content label options if "enable adult content" is disabled.
- Animate in/out those settings

https://github.com/bluesky-social/social-app/assets/153161762/4ad80b82-efe3-4e37-a49f-08d2423581a8
