### PR TITLE
Add padding to bottom portal to account for safe area

### DIFF
--- a/src/screens/Onboarding/Layout.tsx
+++ b/src/screens/Onboarding/Layout.tsx
@@ -173,7 +173,7 @@ export function Layout({children}: React.PropsWithChildren<{}>) {
             ? a.py_2xl
             : {
                 paddingTop: a.pt_lg.paddingTop,
-                paddingBottom: insets.bottom,
+                paddingBottom: insets.bottom + 10,
               },
         ]}>
         <View


### PR DESCRIPTION
Add a little extra padding so the button isn't stuck to the very bottom of the safe area on android