### PR TITLE
set default display name to be blank

### DIFF
--- a/src/state/session/index.tsx
+++ b/src/state/session/index.tsx
@@ -236,7 +236,7 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
       if (!deactivated) {
         /*dont await*/ agent.upsertProfile(_existing => {
           return {
-            displayName: handle,
+            displayName: '',
           }
         })
       }


### PR DESCRIPTION
This fixes weirdness where if the user changes their handle after creating an account there isn't a handle/display name discrepancy.