### PR TITLE
Fix string in onboarding screens in fr/messages.po

### DIFF
--- a/src/locale/locales/fr/messages.po
+++ b/src/locale/locales/fr/messages.po
@@ -3561,7 +3561,7 @@ msgstr "État du service"
 
 #: src/view/com/auth/create/StepHeader.tsx:22
 msgid "Step {0} of {numSteps}"
-msgstr "Étape {step} sur {numSteps}"
+msgstr "Étape {0} sur {numSteps}"
 
 #: src/view/screens/Settings.tsx:276
 msgid "Storage cleared, you need to restart the app now."


### PR DESCRIPTION
This is a very small follow-up PR to #2709. I messed up one of the strings in the French translation of the string for number of steps on the onboarding screens, sorry.