### PR TITLE
Password entropy check

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,9 @@
     "@tiptap/react": "^2.0.0-beta.220",
     "@tiptap/suggestion": "^2.0.0-beta.220",
     "@types/node": "^18.16.2",
+    "@zxcvbn-ts/core": "^3.0.4",
+    "@zxcvbn-ts/language-common": "^3.0.4",
+    "@zxcvbn-ts/language-en": "^3.0.2",
     "@zxing/text-encoding": "^0.9.0",
     "array.prototype.findlast": "^1.2.3",
     "await-lock": "^2.2.2",
@@ -161,6 +164,7 @@
     "react-native-safe-area-context": "4.8.2",
     "react-native-screens": "~3.29.0",
     "react-native-svg": "14.1.0",
+    "react-native-ui-text-view": "link:./modules/react-native-ui-text-view",
     "react-native-url-polyfill": "^1.3.0",
     "react-native-uuid": "^2.0.1",
     "react-native-version-number": "^0.3.6",
@@ -175,8 +179,7 @@
     "tlds": "^1.234.0",
     "use-deep-compare": "^1.1.0",
     "zeego": "^1.6.2",
-    "zod": "^3.20.2",
-    "react-native-ui-text-view": "link:./modules/react-native-ui-text-view"
+    "zod": "^3.20.2"
   },
   "devDependencies": {
     "@atproto/dev-env": "^0.2.28",

--- a/src/lib/strings/zxcvbn.ts
+++ b/src/lib/strings/zxcvbn.ts
@@ -1,0 +1,14 @@
+import {zxcvbn, zxcvbnOptions} from '@zxcvbn-ts/core'
+import * as zxcvbnCommonPackage from '@zxcvbn-ts/language-common'
+import * as zxcvbnEnPackage from '@zxcvbn-ts/language-en'
+
+zxcvbnOptions.setOptions({
+  translations: zxcvbnEnPackage.translations,
+  graphs: zxcvbnCommonPackage.adjacencyGraphs,
+  dictionary: {
+    ...zxcvbnCommonPackage.dictionary,
+    ...zxcvbnEnPackage.dictionary,
+  },
+})
+
+export {zxcvbn}

--- a/src/view/com/auth/create/Step1.tsx
+++ b/src/view/com/auth/create/Step1.tsx
@@ -22,6 +22,7 @@ import {useLingui} from '@lingui/react'
 import {useModalControls} from '#/state/modals'
 import {logger} from '#/logger'
 import {FontAwesomeIcon} from '@fortawesome/react-native-fontawesome'
+import {PasswordStrength} from '../../util/PasswordStrength'
 
 function sanitizeDate(date: Date): Date {
   if (!date || date.toString() === 'Invalid Date') {
@@ -172,6 +173,8 @@ export function Step1({
                   autoComplete="new-password"
                   autoCorrect={false}
                 />
+
+                <PasswordStrength result={uiState.passwordStrength} />
               </View>
 
               <View style={s.pb20}>

--- a/src/view/com/util/PasswordStrength.tsx
+++ b/src/view/com/util/PasswordStrength.tsx
@@ -1,0 +1,66 @@
+import React from 'react'
+import {View} from 'react-native'
+
+import {I18nContext, useLingui} from '@lingui/react'
+import {Trans, msg} from '@lingui/macro'
+
+import type {ZxcvbnResult} from '@zxcvbn-ts/core'
+
+import {usePalette} from '#/lib/hooks/usePalette'
+import {Text} from './text/Text'
+
+export function PasswordStrength({result}: {result: ZxcvbnResult | null}) {
+  const {_} = useLingui()
+
+  const pal = usePalette('default')
+
+  const score = result ? result.score : 0
+  const {color, label} = getScoreInformation(score, _)
+
+  return (
+    <View style={{marginTop: 8, gap: 4}}>
+      <View
+        style={{
+          flexDirection: 'row',
+          gap: 4,
+          borderRadius: 6,
+          overflow: 'hidden',
+        }}>
+        {Array.from({length: 4}, (_, idx) => (
+          <View
+            key={idx}
+            style={[
+              {backgroundColor: score >= idx + 1 ? color : pal.colors.border},
+              {height: 4, flexGrow: 1},
+            ]}
+          />
+        ))}
+      </View>
+
+      <View>
+        <Text type="md" style={pal.textLight}>
+          <Trans>
+            Password strength:{' '}
+            <Text style={{color: color, fontWeight: '500'}}>{label}</Text>
+          </Trans>
+        </Text>
+      </View>
+    </View>
+  )
+}
+
+function getScoreInformation(score: number, _: I18nContext['_']) {
+  if (score >= 4) {
+    return {color: '#65a30d', label: _(msg`Strong`)} // line-600
+  }
+
+  if (score >= 3) {
+    return {color: '#ca8a04', label: _(msg`Good`)} // yellow-600
+  }
+
+  if (score >= 2) {
+    return {color: '#f87171', label: _(msg`Weak`)}
+  }
+
+  return {color: '#f87171', label: _(msg`Very weak`)} // red-600
+}

--- a/src/view/com/util/PasswordStrength.tsx
+++ b/src/view/com/util/PasswordStrength.tsx
@@ -6,6 +6,7 @@ import {Trans, msg} from '@lingui/macro'
 
 import type {ZxcvbnResult} from '@zxcvbn-ts/core'
 
+import {atoms as a} from '#/alf'
 import {usePalette} from '#/lib/hooks/usePalette'
 import {Text} from './text/Text'
 
@@ -18,20 +19,15 @@ export function PasswordStrength({result}: {result: ZxcvbnResult | null}) {
   const {color, label} = getScoreInformation(score, _)
 
   return (
-    <View style={{marginTop: 8, gap: 4}}>
-      <View
-        style={{
-          flexDirection: 'row',
-          gap: 4,
-          borderRadius: 6,
-          overflow: 'hidden',
-        }}>
+    <View style={[a.mt_sm, a.gap_xs]}>
+      <View style={[a.flex_row, a.gap_xs, a.rounded_sm, a.overflow_hidden]}>
         {Array.from({length: 4}, (_, idx) => (
           <View
             key={idx}
             style={[
               {backgroundColor: score >= idx + 1 ? color : pal.colors.border},
-              {height: 4, flexGrow: 1},
+              {height: 4},
+              a.flex_grow,
             ]}
           />
         ))}

--- a/yarn.lock
+++ b/yarn.lock
@@ -8018,6 +8018,23 @@
   resolved "https://registry.yarnpkg.com/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz#e77a97fbd345b76d83245edcd17d393b1b41fb31"
   integrity sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==
 
+"@zxcvbn-ts/core@^3.0.4":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@zxcvbn-ts/core/-/core-3.0.4.tgz#c5bde72235eb6c273cec78b672bb47c0d7045cad"
+  integrity sha512-aQeiT0F09FuJaAqNrxynlAwZ2mW/1MdXakKWNmGM1Qp/VaY6CnB/GfnMS2T8gB2231Esp1/maCWd8vTG4OuShw==
+  dependencies:
+    fastest-levenshtein "1.0.16"
+
+"@zxcvbn-ts/language-common@^3.0.4":
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/@zxcvbn-ts/language-common/-/language-common-3.0.4.tgz#fa1d2a42f8c8a589555859795da90d6b8027b7c4"
+  integrity sha512-viSNNnRYtc7ULXzxrQIVUNwHAPSXRtoIwy/Tq4XQQdIknBzw4vz36lQLF6mvhMlTIlpjoN/Z1GFu/fwiAlUSsw==
+
+"@zxcvbn-ts/language-en@^3.0.2":
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/@zxcvbn-ts/language-en/-/language-en-3.0.2.tgz#162ada6b2b556444efd5a7700e70845cfde6d6ec"
+  integrity sha512-Zp+zL+I6Un2Bj0tRXNs6VUBq3Djt+hwTwUz4dkt2qgsQz47U0/XthZ4ULrT/RxjwJRl5LwiaKOOZeOtmixHnjg==
+
 "@zxing/text-encoding@0.9.0", "@zxing/text-encoding@^0.9.0":
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/@zxing/text-encoding/-/text-encoding-0.9.0.tgz#fb50ffabc6c7c66a0c96b4c03e3d9be74864b70b"
@@ -12028,7 +12045,7 @@ fast-xml-parser@^4.2.4:
   dependencies:
     strnum "^1.0.5"
 
-fastest-levenshtein@^1.0.12:
+fastest-levenshtein@1.0.16, fastest-levenshtein@^1.0.12:
   version "1.0.16"
   resolved "https://registry.yarnpkg.com/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz#210e61b6ff181de91ea9b3d1b84fdedd47e034e5"
   integrity sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==


### PR DESCRIPTION
Fixes #2727

Strength color and label needs some work but it's a start, went for custom colors here instead of relying on Alf's color tokens though.

| # | Image |
| --- | --- |
| 0 | <img src=https://github.com/bluesky-social/social-app/assets/148872143/8bb79e1d-acd2-4569-9d50-e9fcade9445b width=180> |
| 1 | <img src=https://github.com/bluesky-social/social-app/assets/148872143/72197550-182d-4e41-b331-84e360837219 width=180> |
| 2 | <img src=https://github.com/bluesky-social/social-app/assets/148872143/3c714567-c715-48d3-ba38-d268d43c0ecb width=180> |
| 3 | <img src=https://github.com/bluesky-social/social-app/assets/148872143/2330cbcb-d172-4310-a465-381e52e5120e width=180> |
| 4 | <img src=https://github.com/bluesky-social/social-app/assets/148872143/1cbf7046-1c7b-4e0d-af40-937cda5f3439 width=180> |

Beware that this pulls in around ~700 kB minzipped code, we might want to lazily-load CreateAccount and other components that may make use of it (change password, forgot password, etc) because these are pretty much code that a signed-in user won't need most of the time.

Once https://github.com/bluesky-social/social-app/pull/2730 is merged, we could extend this PR to include those flows as well, if needed.

LMK what the ideal path forward is so we can proceed with actually doing it, I just did this initial draft to get the design going.