### PR TITLE
Listen for error event on creating resized image

### DIFF
--- a/src/lib/media/manip.web.ts
+++ b/src/lib/media/manip.web.ts
@@ -132,6 +132,9 @@ function createResizedImage(
       ctx.drawImage(img, 0, 0, w, h)
       resolve(canvas.toDataURL('image/jpeg', quality))
     })
+    img.addEventListener('error', ev => {
+      reject(ev.error)
+    })
     img.src = dataUri
   })
 }


### PR DESCRIPTION
Partial fix for https://github.com/bluesky-social/social-app/issues/2734

It returned a broken unparseable image, and because there was no event listener to catch it, the promise is just stuck unfulfilled.

This only addresses the fact that cardyb is returning a broken image, this doesn't fix *why* cardyb is returning a broken image to begin with.