### PR TITLE
Fix right pane Feeds selector getting out of sync with tabbar

### DIFF
--- a/src/Navigation.tsx
+++ b/src/Navigation.tsx
@@ -431,6 +431,9 @@ const FlatNavigator = () => {
         name="Home"
         getComponent={() => HomeScreen}
         options={{title: title(msg`Home`), requireAuth: true}}
+        initialParams={{
+          selectedPage: 'Following',
+        }}
       />
       <Flat.Screen
         name="Search"

--- a/src/Navigation.tsx
+++ b/src/Navigation.tsx
@@ -314,9 +314,6 @@ function HomeTabNavigator() {
         name="Home"
         getComponent={() => HomeScreen}
         options={{requireAuth: true}}
-        initialParams={{
-          selectedPage: 'Following',
-        }}
       />
       {commonScreens(HomeTab)}
     </HomeTab.Navigator>
@@ -434,9 +431,6 @@ const FlatNavigator = () => {
         name="Home"
         getComponent={() => HomeScreen}
         options={{title: title(msg`Home`), requireAuth: true}}
-        initialParams={{
-          selectedPage: 'Following',
-        }}
       />
       <Flat.Screen
         name="Search"

--- a/src/Navigation.tsx
+++ b/src/Navigation.tsx
@@ -33,6 +33,7 @@ import {JSX} from 'react/jsx-runtime'
 import {timeout} from 'lib/async/timeout'
 import {useUnreadNotifications} from './state/queries/notifications/unread'
 import {useSession} from './state/session'
+import * as persisted from './state/persisted'
 import {useModalControls} from './state/modals'
 import {
   shouldRequestEmailConfirmation,
@@ -299,6 +300,7 @@ function TabsNavigator() {
 
 function HomeTabNavigator() {
   const pal = usePalette('default')
+  const lastSelectedFeed = persisted.get('lastSelectedFeed')
 
   return (
     <HomeTab.Navigator
@@ -314,6 +316,9 @@ function HomeTabNavigator() {
         name="Home"
         getComponent={() => HomeScreen}
         options={{requireAuth: true}}
+        initialParams={{
+          feed: lastSelectedFeed || 'Following',
+        }}
       />
       {commonScreens(HomeTab)}
     </HomeTab.Navigator>
@@ -431,6 +436,8 @@ const FlatNavigator = () => {
         name="Home"
         getComponent={() => HomeScreen}
         options={{title: title(msg`Home`), requireAuth: true}}
+        // On native, we'd also pass initialParams here to restore the last selected feed.
+        // We're not gonna do that on web to prevent browser tabs from clobbering each other.
       />
       <Flat.Screen
         name="Search"

--- a/src/Navigation.tsx
+++ b/src/Navigation.tsx
@@ -314,6 +314,9 @@ function HomeTabNavigator() {
         name="Home"
         getComponent={() => HomeScreen}
         options={{requireAuth: true}}
+        initialParams={{
+          selectedPage: 'Following',
+        }}
       />
       {commonScreens(HomeTab)}
     </HomeTab.Navigator>

--- a/src/lib/routes/types.ts
+++ b/src/lib/routes/types.ts
@@ -44,7 +44,7 @@ export type BottomTabNavigatorParams = CommonNavigatorParams & {
 }
 
 export type HomeTabNavigatorParams = CommonNavigatorParams & {
-  Home: undefined
+  Home: {feed: string} | undefined
 }
 
 export type SearchTabNavigatorParams = CommonNavigatorParams & {
@@ -64,7 +64,7 @@ export type MyProfileTabNavigatorParams = CommonNavigatorParams & {
 }
 
 export type FlatNavigatorParams = CommonNavigatorParams & {
-  Home: undefined
+  Home: {feed: string} | undefined
   Search: {q?: string}
   Feeds: undefined
   Notifications: undefined

--- a/src/state/persisted/schema.ts
+++ b/src/state/persisted/schema.ts
@@ -55,6 +55,7 @@ export const schema = z.object({
   }),
   hiddenPosts: z.array(z.string()).optional(), // should move to server
   useInAppBrowser: z.boolean().optional(),
+  lastSelectedFeed: z.string().optional(),
 })
 export type Schema = z.infer<typeof schema>
 
@@ -87,4 +88,5 @@ export const defaults: Schema = {
   },
   hiddenPosts: [],
   useInAppBrowser: undefined,
+  lastSelectedFeed: undefined,
 }

--- a/src/view/screens/Home.tsx
+++ b/src/view/screens/Home.tsx
@@ -20,11 +20,14 @@ import {clamp} from '#/lib/numbers'
 
 type Props = NativeStackScreenProps<HomeTabNavigatorParams, 'Home'>
 export function HomeScreen(props: Props) {
-  const {selectedPage} = props.route.params
+  const selectedPage = props.route.params?.feed || 'Following'
+
   function onSelectPage(nextPage) {
-    props.navigation.navigate('Home', {
-      selectedPage: nextPage,
-    })
+    const params = {}
+    if (nextPage !== 'Following') {
+      params.feed = nextPage
+    }
+    props.navigation.navigate('Home', params)
   }
 
   const {data: preferences} = usePreferencesQuery()

--- a/src/view/screens/Home.tsx
+++ b/src/view/screens/Home.tsx
@@ -20,6 +20,13 @@ import {clamp} from '#/lib/numbers'
 
 type Props = NativeStackScreenProps<HomeTabNavigatorParams, 'Home'>
 export function HomeScreen(props: Props) {
+  const {selectedPage} = props.route.params
+  function onSelectPage(nextPage) {
+    props.navigation.navigate('Home', {
+      selectedPage: nextPage,
+    })
+  }
+
   const {data: preferences} = usePreferencesQuery()
   const {feeds: pinnedFeeds, isLoading: isPinnedFeedsLoading} =
     usePinnedFeedsInfos()
@@ -29,6 +36,8 @@ export function HomeScreen(props: Props) {
         {...props}
         preferences={preferences}
         pinnedFeeds={pinnedFeeds}
+        selectedPage={selectedPage}
+        onSelectPage={onSelectPage}
       />
     )
   } else {
@@ -43,6 +52,8 @@ export function HomeScreen(props: Props) {
 function HomeScreenReady({
   preferences,
   pinnedFeeds,
+  selectedPage,
+  onSelectPage,
 }: Props & {
   preferences: UsePreferencesQueryResponse
   pinnedFeeds: FeedSourceInfo[]
@@ -50,7 +61,6 @@ function HomeScreenReady({
   const {hasSession} = useSession()
   const setMinimalShellMode = useSetMinimalShellMode()
   const setDrawerSwipeDisabled = useSetDrawerSwipeDisabled()
-  const [selectedPage, setSelectedPage] = React.useState<string>('Following')
 
   /**
    * Used to ensure that we re-compute `customFeeds` AND force a re-render of
@@ -102,11 +112,11 @@ function HomeScreenReady({
       setMinimalShellMode(false)
       setDrawerSwipeDisabled(index > 0)
       const page = ['Following', ...preferences.feeds.pinned][index]
-      setSelectedPage(page)
+      onSelectPage(page)
     },
     [
       setDrawerSwipeDisabled,
-      setSelectedPage,
+      onSelectPage,
       setMinimalShellMode,
       preferences.feeds.pinned,
     ],

--- a/src/view/screens/Home.tsx
+++ b/src/view/screens/Home.tsx
@@ -17,17 +17,22 @@ import {UsePreferencesQueryResponse} from '#/state/queries/preferences/types'
 import {emitSoftReset} from '#/state/events'
 import {useSession} from '#/state/session'
 import {clamp} from '#/lib/numbers'
+import * as persisted from '#/state/persisted'
+import {isNative} from 'platform/detection'
 
 type Props = NativeStackScreenProps<HomeTabNavigatorParams, 'Home'>
 export function HomeScreen(props: Props) {
   const selectedPage = props.route.params?.feed || 'Following'
 
-  function onSelectPage(nextPage) {
+  function onSelectPage(nextSelectedPage) {
     const params = {}
-    if (nextPage !== 'Following') {
-      params.feed = nextPage
+    if (nextSelectedPage !== 'Following') {
+      params.feed = nextSelectedPage
     }
     props.navigation.navigate('Home', params)
+    if (isNative) {
+      persisted.write('lastSelectedFeed', nextSelectedPage)
+    }
   }
 
   const {data: preferences} = usePreferencesQuery()

--- a/src/view/screens/Home.tsx
+++ b/src/view/screens/Home.tsx
@@ -22,22 +22,23 @@ import {isNative} from 'platform/detection'
 
 type Props = NativeStackScreenProps<HomeTabNavigatorParams, 'Home'>
 export function HomeScreen(props: Props) {
-  const selectedPage = props.route.params?.feed || 'Following'
-
-  function onSelectPage(nextSelectedPage) {
-    const params = {}
-    if (nextSelectedPage !== 'Following') {
-      params.feed = nextSelectedPage
-    }
-    props.navigation.navigate('Home', params)
-    if (isNative) {
-      persisted.write('lastSelectedFeed', nextSelectedPage)
-    }
-  }
-
   const {data: preferences} = usePreferencesQuery()
   const {feeds: pinnedFeeds, isLoading: isPinnedFeedsLoading} =
     usePinnedFeedsInfos()
+  const selectedPage = props.route.params?.feed || 'Following'
+  const onSelectPage = React.useCallback(
+    nextSelectedPage => {
+      const params = {}
+      if (nextSelectedPage !== 'Following') {
+        params.feed = nextSelectedPage
+      }
+      props.navigation.navigate('Home', params)
+      if (isNative) {
+        persisted.write('lastSelectedFeed', nextSelectedPage)
+      }
+    },
+    [props.navigation],
+  )
   if (preferences && pinnedFeeds && !isPinnedFeedsLoading) {
     return (
       <HomeScreenReady

--- a/src/view/screens/Home.tsx
+++ b/src/view/screens/Home.tsx
@@ -27,10 +27,10 @@ export function HomeScreen(props: Props) {
     usePinnedFeedsInfos()
   const selectedPage = props.route.params?.feed || 'Following'
   const onSelectPage = React.useCallback(
-    nextSelectedPage => {
-      const params = {}
+    (nextSelectedPage: string) => {
+      let params
       if (nextSelectedPage !== 'Following') {
-        params.feed = nextSelectedPage
+        params = {feed: nextSelectedPage}
       }
       props.navigation.navigate('Home', params)
       if (isNative) {
@@ -66,6 +66,8 @@ function HomeScreenReady({
 }: Props & {
   preferences: UsePreferencesQueryResponse
   pinnedFeeds: FeedSourceInfo[]
+  selectedPage: string
+  onSelectPage: (nextSelectedPage: string) => void
 }) {
   const {hasSession} = useSession()
   const setMinimalShellMode = useSetMinimalShellMode()

--- a/src/view/shell/desktop/Feeds.tsx
+++ b/src/view/shell/desktop/Feeds.tsx
@@ -22,30 +22,19 @@ export function DesktopFeeds() {
 
   return (
     <View style={[styles.container, pal.view]}>
-      <FeedItem href="/" title="Following" current={route.name === 'Home'} />
-      {feeds
-        .filter(f => f.displayName !== 'Following')
-        .map(feed => {
-          try {
-            const params = route.params as Record<string, string>
-            const routeName =
-              feed.type === 'feed' ? 'ProfileFeed' : 'ProfileList'
-            return (
-              <FeedItem
-                key={feed.uri}
-                href={feed.route.href}
-                title={feed.displayName}
-                current={
-                  route.name === routeName &&
-                  params.name === feed.route.params.name &&
-                  params.rkey === feed.route.params.rkey
-                }
-              />
-            )
-          } catch {
-            return null
-          }
-        })}
+      {feeds.map(feed => {
+        const params = route.params as Record<string, string>
+        const selectedPage = params.selectedPage || 'Following'
+        const feedPage = feed.uri || 'Following'
+        return (
+          <FeedItem
+            key={feed.uri}
+            href={`/?selectedPage=${feedPage}`}
+            title={feed.displayName}
+            current={route.name === 'Home' && selectedPage === feedPage}
+          />
+        )
+      })}
       <View style={{paddingTop: 8, paddingBottom: 6}}>
         <TextLink
           type="lg"

--- a/src/view/shell/desktop/Feeds.tsx
+++ b/src/view/shell/desktop/Feeds.tsx
@@ -24,14 +24,15 @@ export function DesktopFeeds() {
     <View style={[styles.container, pal.view]}>
       {feeds.map(feed => {
         const params = route.params as Record<string, string>
-        const selectedPage = params.selectedPage || 'Following'
-        const feedPage = feed.uri || 'Following'
         return (
           <FeedItem
             key={feed.uri}
-            href={`/?selectedPage=${feedPage}`}
+            href={feed.uri ? `/?feed=${feed.uri}` : '/'}
             title={feed.displayName}
-            current={route.name === 'Home' && selectedPage === feedPage}
+            current={
+              route.name === 'Home' &&
+              (params?.feed || 'Following') === (feed.uri || 'Following')
+            }
           />
         )
       })}


### PR DESCRIPTION
## The Problem

If you open the app with mobile layout, you'll see the current feed in the tab bar:

<img width="954" alt="Screenshot 2024-02-03 at 02 10 58" src="https://github.com/bluesky-social/social-app/assets/810438/e7d084ef-ff4d-4b0c-b9c2-b06392137107">

If you keep expanding the browser window, we'll flip to desktop mode. Notice that it **shows the wrong feed as selected:**

<img width="1204" alt="Screenshot 2024-02-03 at 02 11 09" src="https://github.com/bluesky-social/social-app/assets/810438/be925fe1-679e-499b-bcf5-e06ce435c51f">

This is because they don't have the same source of truth.

Additionally, if you use the right pane selector, it'll switch you out of the Home feed and will navigate you to the standalone views of those individual feeds. As opposed to showing them in Home like the mobile tab bar does.

## The Solution

I'm making URL the source of truth:

- `/` shows Following (with a clean URL)
- `/?feed=<some feed URL>` shows a specific feed in Home

There is no difference in behavior between mobile and desktop views now. The tab bar always updates the URL. The right pane also always updates the URL. They stay in sync even if you render both at the same time (which we don't currently do but could in theory).

I've kept persistence for native apps, but I've restructured the data flow so that the persistence value flows into the navigator. From that point on, we're reusing the same code on all platforms.

I decided not to persist last selected tab on the web. Web already has a concept of URLs so you could bookmark a specific feed if you wanted to. Persisting the last selection doesn't play very well with that concept — it's weird if you open multiple tabs and they clobber each other's values. On the web, *navigating to* a link usually doesn't imply you want to persist that selection for future tabs. We could revisit this decision though if the difference between web and native is too jarring.

## Test Plan

- On web, click around the tabbar in mobile mode and the right pane in desktop mode.
  - Verify that they stay synchronized within a browser session.
  - Verify they respond to Back/Forward browser buttons in both layouts.
- Verify right pane can be opened in a new tab.
- Verify right pane works outside the Home tab.
- Verify refreshing preserves the selected tab.
- Verify Following always has a clean `/` URL.
- Verify unpinning and/or deleting a feed does not break either selector, and falls back to Following.
- Verify that on mobile, the last selection is still persisted between reloads.