### PR TITLE
always show appeal content label, show notice when post is moderated

### DIFF
--- a/src/lib/moderatePost_wrapped.ts
+++ b/src/lib/moderatePost_wrapped.ts
@@ -69,14 +69,15 @@ export function checkIsModerated(post: AppBskyFeedDefs.PostView): boolean {
   }
 
   // If there are labels on the post and none on the record, it is moderated
-  if (!Array.isArray(post.record.labels?.values)) {
+  const labelValues = post.record.labels?.values
+  if (!Array.isArray(labelValues) || labelValues.length === 0) {
     return true
   }
 
   // If there's a label that exists in the labels but not on the record, then
   // we want to be able to appeal it
   // TODO what happens with 3p-labelers?
-  const recordLabels = post.record.labels.values as SelfLabel[]
+  const recordLabels = labelValues as SelfLabel[]
   for (const label of post.labels) {
     if (!recordLabels.some(l => l.val === label.val)) {
       return true

--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -192,8 +192,10 @@ let PostThreadItemLoaded = ({
     return makeProfileLink(post.author, 'post', urip.rkey, 'reposted-by')
   }, [post.uri, post.author])
   const repostsTitle = _(msg`Reposts of this post`)
-  const isOwnPost = post.author.did === currentAccount?.did
-  const isModeratedPost = isOwnPost && checkIsModerated(post)
+  const isModeratedPost = React.useMemo(
+    () => post.author.did === currentAccount?.did && checkIsModerated(post),
+    [post, currentAccount?.did],
+  )
 
   const translatorUrl = getTranslatorLink(
     record?.text || '',

--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -192,7 +192,8 @@ let PostThreadItemLoaded = ({
     return makeProfileLink(post.author, 'post', urip.rkey, 'reposted-by')
   }, [post.uri, post.author])
   const repostsTitle = _(msg`Reposts of this post`)
-  const isModeratedPost = checkIsModerated(post)
+  const isOwnPost = post.author.did === currentAccount?.did
+  const isModeratedPost = isOwnPost && checkIsModerated(post)
 
   const translatorUrl = getTranslatorLink(
     record?.text || '',
@@ -340,9 +341,7 @@ let PostThreadItemLoaded = ({
               postUri={post.uri}
               record={record}
               richText={richText}
-              showAppealLabelItem={
-                post.author.did === currentAccount?.did && isModeratedPost
-              }
+              showAppealLabelItem={isModeratedPost}
               style={{
                 paddingVertical: 6,
                 paddingHorizontal: 10,

--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -7,7 +7,10 @@ import {
   RichText as RichTextAPI,
   PostModeration,
 } from '@atproto/api'
-import {moderatePost_wrapped as moderatePost} from '#/lib/moderatePost_wrapped'
+import {
+  checkIsModerated,
+  moderatePost_wrapped as moderatePost,
+} from '#/lib/moderatePost_wrapped'
 import {FontAwesomeIcon} from '@fortawesome/react-native-fontawesome'
 import {Link, TextLink} from '../util/Link'
 import {RichText} from '../util/text/RichText'
@@ -188,9 +191,7 @@ let PostThreadItemLoaded = ({
     return makeProfileLink(post.author, 'post', urip.rkey, 'reposted-by')
   }, [post.uri, post.author])
   const repostsTitle = _(msg`Reposts of this post`)
-  const isModeratedPost =
-    moderation.decisions.post.cause?.type === 'label' &&
-    moderation.decisions.post.cause.label.src !== currentAccount?.did
+  const isModeratedPost = checkIsModerated(post)
 
   const translatorUrl = getTranslatorLink(
     record?.text || '',

--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -48,6 +48,7 @@ import {Shadow, usePostShadow, POST_TOMBSTONE} from '#/state/cache/post-shadow'
 import {ThreadPost} from '#/state/queries/post-thread'
 import {useSession} from '#/state/session'
 import {WhoCanReply} from '../threadgate/WhoCanReply'
+import {LabelInfo} from 'view/com/util/moderation/LabelInfo'
 
 export function PostThreadItem({
   post,
@@ -351,6 +352,12 @@ let PostThreadItemLoaded = ({
             />
           </View>
           <View style={[s.pl10, s.pr10, s.pb10]}>
+            {isModeratedPost && (
+              <LabelInfo
+                details={{uri: post.uri, cid: post.cid}}
+                labels={post.labels}
+              />
+            )}
             <ContentHider
               moderation={moderation.content}
               ignoreMute

--- a/src/view/com/posts/FeedItem.tsx
+++ b/src/view/com/posts/FeedItem.tsx
@@ -112,8 +112,10 @@ let FeedItemInner = ({
     const urip = new AtUri(post.uri)
     return makeProfileLink(post.author, 'post', urip.rkey)
   }, [post.uri, post.author])
-  const isOwnPost = post.author.did === currentAccount?.did
-  const isModeratedPost = isOwnPost && checkIsModerated(post)
+  const isModeratedPost = React.useMemo(
+    () => post.author.did === currentAccount?.did && checkIsModerated(post),
+    [post, currentAccount?.did],
+  )
 
   const replyAuthorDid = useMemo(() => {
     if (!record?.reply) {

--- a/src/view/com/posts/FeedItem.tsx
+++ b/src/view/com/posts/FeedItem.tsx
@@ -113,7 +113,7 @@ let FeedItemInner = ({
     return makeProfileLink(post.author, 'post', urip.rkey)
   }, [post.uri, post.author])
   const isOwnPost = post.author.did === currentAccount?.did
-  const isModeratedPost = checkIsModerated(post)
+  const isModeratedPost = isOwnPost && checkIsModerated(post)
 
   const replyAuthorDid = useMemo(() => {
     if (!record?.reply) {
@@ -307,7 +307,7 @@ let FeedItemInner = ({
             record={record}
             richText={richText}
             onPressReply={onPressReply}
-            showAppealLabelItem={isOwnPost && isModeratedPost}
+            showAppealLabelItem={isModeratedPost}
           />
         </View>
       </View>

--- a/src/view/com/posts/FeedItem.tsx
+++ b/src/view/com/posts/FeedItem.tsx
@@ -37,6 +37,7 @@ import {FeedNameText} from '../util/FeedInfoText'
 import {useSession} from '#/state/session'
 import {Trans, msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
+import {checkIsModerated} from 'lib/moderatePost_wrapped'
 
 export function FeedItem({
   post,
@@ -111,9 +112,8 @@ let FeedItemInner = ({
     const urip = new AtUri(post.uri)
     return makeProfileLink(post.author, 'post', urip.rkey)
   }, [post.uri, post.author])
-  const isModeratedPost =
-    moderation.decisions.post.cause?.type === 'label' &&
-    moderation.decisions.post.cause.label.src !== currentAccount?.did
+  const isOwnPost = post.author.did === currentAccount?.did
+  const isModeratedPost = checkIsModerated(post)
 
   const replyAuthorDid = useMemo(() => {
     if (!record?.reply) {
@@ -307,9 +307,7 @@ let FeedItemInner = ({
             record={record}
             richText={richText}
             onPressReply={onPressReply}
-            showAppealLabelItem={
-              post.author.did === currentAccount?.did && isModeratedPost
-            }
+            showAppealLabelItem={isOwnPost && isModeratedPost}
           />
         </View>
       </View>


### PR DESCRIPTION
fixes https://github.com/bluesky-social/social-app/issues/2740
fixes https://github.com/bluesky-social/social-app/issues/2286

Right now, we are not showing any info if a post has been auto-moderated. The only way that someone can see if their post was auto-modded is by checking the dropdown and seeing if the `Appeal Content Warning` option is shown.

We also are not showing the option at all if the user has that particular label set to `Show`, so there's no way for them to know if their post got labelled nor to appeal it without changing that option to `Warn`.

This fixes both problems by doing a little logic on the `PostView` itself.

1. If there are no labels on the `PostView` at all, then it isn't moderated
2. If there are labels on the post but none in the record, then we know it is moderated
3. Finally, if there are labels in both we just check if any of the app view's labels are not on the post record.

Also, since this logic will return false if the post is self labeled, we can add back the `LabelInfo` component to post thread items.

![Screenshot 2024-02-03 at 5 08 34 PM](https://github.com/bluesky-social/social-app/assets/153161762/37850f1d-bc80-41c4-98f0-6d484e3e6103)
![Screenshot 2024-02-03 at 5 09 05 PM](https://github.com/bluesky-social/social-app/assets/153161762/0cd1f6ac-5c74-4ab8-b32e-4fbdbbca2283)
![Screenshot 2024-02-03 at 5 09 34 PM](https://github.com/bluesky-social/social-app/assets/153161762/6c9faa7b-2fb6-4b30-9162-bd0666cbeff4)
