### PR TITLE
Validate phone number based on country

### DIFF
--- a/src/view/com/auth/create/Step2.tsx
+++ b/src/view/com/auth/create/Step2.tsx
@@ -42,10 +42,11 @@ export function Step2({
   const {isMobile} = useWebMediaQueries()
 
   const onPressRequest = React.useCallback(() => {
-    if (
-      uiState.verificationPhone.length >= 9 &&
-      parsePhoneNumber(uiState.verificationPhone, uiState.phoneCountry)
-    ) {
+    const phoneNumber = parsePhoneNumber(
+      uiState.verificationPhone,
+      uiState.phoneCountry,
+    );
+    if (phoneNumber.isValid()) {
       requestVerificationCode({uiState, uiDispatch, _})
     } else {
       uiDispatch({

--- a/src/view/com/auth/create/Step2.tsx
+++ b/src/view/com/auth/create/Step2.tsx
@@ -46,7 +46,7 @@ export function Step2({
       uiState.verificationPhone,
       uiState.phoneCountry,
     );
-    if (phoneNumber.isValid()) {
+    if (phoneNumber && phoneNumber.isValid()) {
       requestVerificationCode({uiState, uiDispatch, _})
     } else {
       uiDispatch({

--- a/src/view/com/auth/create/Step2.tsx
+++ b/src/view/com/auth/create/Step2.tsx
@@ -42,10 +42,7 @@ export function Step2({
   const {isMobile} = useWebMediaQueries()
 
   const onPressRequest = React.useCallback(() => {
-    const phoneNumber = parsePhoneNumber(
-      uiState.verificationPhone,
-      uiState.phoneCountry,
-    );
+    const phoneNumber = parsePhoneNumber(uiState.verificationPhone, uiState.phoneCountry)
     if (phoneNumber && phoneNumber.isValid()) {
       requestVerificationCode({uiState, uiDispatch, _})
     } else {


### PR DESCRIPTION
I signed up today using my Honduran phone number (8 digits) and the app showed me an error saying `here's something wrong with this number. Please choose your country and enter your full phone number!`

Given that international phone numbers are often < 9 characters in length and there's already a `parsePhoneNumber` included from `libphonenumber-js` I think it's better to use the built-in validator.