### PR TITLE
show bottom bar on web tablet breakpoints when logged out (signup cta)

### DIFF
--- a/src/view/com/util/load-latest/LoadLatestBtn.tsx
+++ b/src/view/com/util/load-latest/LoadLatestBtn.tsx
@@ -10,6 +10,7 @@ import Animated from 'react-native-reanimated'
 const AnimatedTouchableOpacity =
   Animated.createAnimatedComponent(TouchableOpacity)
 import {isWeb} from 'platform/detection'
+import {useSession} from 'state/session'
 
 export function LoadLatestBtn({
   onPress,
@@ -21,8 +22,13 @@ export function LoadLatestBtn({
   showIndicator: boolean
 }) {
   const pal = usePalette('default')
-  const {isDesktop, isTablet, isMobile} = useWebMediaQueries()
+  const {hasSession} = useSession()
+  const {isDesktop, isTablet, isMobile, isTabletOrMobile} = useWebMediaQueries()
   const {fabMinimalShellTransform} = useMinimalShellMode()
+
+  // Adjust height of the fab if we have a session only on mobile web. If we don't have a session, we want to adjust
+  // it on both tablet and mobile since we are showing the bottom bar (see createNativeStackNavigatorWithAuth)
+  const showBottomBar = hasSession ? isMobile : isTabletOrMobile
 
   return (
     <AnimatedTouchableOpacity
@@ -32,7 +38,7 @@ export function LoadLatestBtn({
         isTablet && styles.loadLatestTablet,
         pal.borderDark,
         pal.view,
-        isMobile && fabMinimalShellTransform,
+        showBottomBar && fabMinimalShellTransform,
       ]}
       onPress={onPress}
       hitSlop={HITSLOP_20}

--- a/src/view/shell/createNativeStackNavigatorWithAuth.tsx
+++ b/src/view/shell/createNativeStackNavigatorWithAuth.tsx
@@ -134,10 +134,9 @@ function NativeStackNavigator({
     }
   }
 
-  // We want to show the bottom bar on web for both tablet and mobile break points whenever there is no session.
-  // This will display the logged out signup CTA
-  const showBottomBar =
-    (hasSession && isMobile) || (!hasSession && isTabletOrMobile)
+  // Show the bottom bar if we have a session only on mobile web. If we don't have a session, we want to show it
+  // on both tablet and mobile web so that we see the sign up CTA.
+  const showBottomBar = hasSession ? isMobile : isTabletOrMobile
 
   return (
     <NavigationContent>

--- a/src/view/shell/createNativeStackNavigatorWithAuth.tsx
+++ b/src/view/shell/createNativeStackNavigatorWithAuth.tsx
@@ -137,7 +137,7 @@ function NativeStackNavigator({
   // We want to show the bottom bar on web for both tablet and mobile break points whenever there is no session.
   // This will display the logged out signup CTA
   const showBottomBar =
-    isWeb && ((hasSession && isMobile) || (!hasSession && isTabletOrMobile))
+    (hasSession && isMobile) || (!hasSession && isTabletOrMobile)
 
   return (
     <NavigationContent>
@@ -148,7 +148,7 @@ function NativeStackNavigator({
         descriptors={newDescriptors}
       />
       {isWeb && showBottomBar && <BottomBarWeb />}
-      {isWeb && !isMobile && (
+      {isWeb && !showBottomBar && (
         <>
           <DesktopLeftNav />
           <DesktopRightNav routeName={activeRoute.name} />

--- a/src/view/shell/createNativeStackNavigatorWithAuth.tsx
+++ b/src/view/shell/createNativeStackNavigatorWithAuth.tsx
@@ -101,7 +101,7 @@ function NativeStackNavigator({
   const onboardingState = useOnboardingState()
   const {showLoggedOut} = useLoggedOutView()
   const {setShowLoggedOut} = useLoggedOutViewControls()
-  const {isMobile} = useWebMediaQueries()
+  const {isMobile, isTabletOrMobile} = useWebMediaQueries()
   if ((!PWI_ENABLED || activeRouteRequiresAuth) && !hasSession) {
     return <LoggedOut />
   }
@@ -134,6 +134,11 @@ function NativeStackNavigator({
     }
   }
 
+  // We want to show the bottom bar on web for both tablet and mobile break points whenever there is no session.
+  // This will display the logged out signup CTA
+  const showBottomBar =
+    isWeb && ((hasSession && isMobile) || (!hasSession && isTabletOrMobile))
+
   return (
     <NavigationContent>
       <NativeStackView
@@ -142,7 +147,7 @@ function NativeStackNavigator({
         navigation={navigation}
         descriptors={newDescriptors}
       />
-      {isWeb && isMobile && <BottomBarWeb />}
+      {isWeb && showBottomBar && <BottomBarWeb />}
       {isWeb && !isMobile && (
         <>
           <DesktopLeftNav />


### PR DESCRIPTION
Inbetween desktop and mobile breakpoints on web, we don't see anything telling the user to sign in or sign up when in the signed out view. This corrects that by showing the bottom bar on both mobile and tablet breakpoints when there is no session present.

## Before

<img width="1052" alt="Screenshot 2024-02-04 at 12 39 05 PM" src="https://github.com/bluesky-social/social-app/assets/153161762/dda8f986-3443-4389-85ce-900f636315f9">

## After

<img width="1057" alt="Screenshot 2024-02-04 at 12 27 21 PM" src="https://github.com/bluesky-social/social-app/assets/153161762/0ca02d76-9ae6-43ca-9ff2-a4c60607f96e">
