### PR TITLE
Show original query in error message when using "from:me"

### DIFF
--- a/src/view/screens/Search/Search.tsx
+++ b/src/view/screens/Search/Search.tsx
@@ -190,7 +190,13 @@ type SearchResultSlice =
 
 function SearchScreenPostResults({query}: {query: string}) {
   const {_} = useLingui()
+  const {currentAccount} = useSession()
   const [isPTR, setIsPTR] = React.useState(false)
+
+  const augmentedQuery = React.useMemo(() => {
+    return augmentSearchQuery(query || '', {did: currentAccount?.did})
+  }, [query, currentAccount])
+
   const {
     isFetched,
     data: results,
@@ -200,7 +206,7 @@ function SearchScreenPostResults({query}: {query: string}) {
     fetchNextPage,
     isFetchingNextPage,
     hasNextPage,
-  } = useSearchPostsQuery({query})
+  } = useSearchPostsQuery({query: augmentedQuery})
 
   const onPullToRefresh = React.useCallback(async () => {
     setIsPTR(true)
@@ -319,12 +325,8 @@ export function SearchScreenInner({
   const pal = usePalette('default')
   const setMinimalShellMode = useSetMinimalShellMode()
   const setDrawerSwipeDisabled = useSetDrawerSwipeDisabled()
-  const {hasSession, currentAccount} = useSession()
+  const {hasSession} = useSession()
   const {isDesktop} = useWebMediaQueries()
-
-  const augmentedQuery = React.useMemo(() => {
-    return augmentSearchQuery(query || '', {did: currentAccount?.did})
-  }, [query, currentAccount])
 
   const onPageSelected = React.useCallback(
     (index: number) => {
@@ -348,7 +350,7 @@ export function SearchScreenInner({
         )}
         initialPage={0}>
         <View>
-          <SearchScreenPostResults query={augmentedQuery} />
+          <SearchScreenPostResults query={query} />
         </View>
         <View>
           <SearchScreenUserResults query={query} />


### PR DESCRIPTION
Currently, the error message shows the query *after* it's been transformed, resulting in the DID being visible in the error message:

<img width="617" alt="Screenshot 2024-02-05 at 09 58 55" src="https://github.com/bluesky-social/social-app/assets/10959775/e5894a16-3c22-4fda-82ee-ee2c4df8bf5b">

It seems like there's a general aim to avoid DIDs being surfaced in the UI where possible, so I don't think this behaviour is ideal.

This PR shows the original query in the error message, only using the augmented query for the actual seach request.

<img width="610" alt="Screenshot 2024-02-05 at 09 58 32" src="https://github.com/bluesky-social/social-app/assets/10959775/3c00ab85-62dd-46c7-9de2-e5f27c65af22">
