### PR TITLE
use ios live text interaction in alt text modal and image viewer

### DIFF
--- a/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.ios.tsx
+++ b/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.ios.tsx
@@ -144,6 +144,7 @@ const ImageItem = ({imageSrc, onTap, onZoom, onRequestClose}: Props) => {
           accessibilityLabel={imageSrc.alt}
           accessibilityHint=""
           onLoad={() => setLoaded(true)}
+          enableLiveTextInteraction={!scaled}
         />
       </Animated.ScrollView>
     </GestureDetector>

--- a/src/view/com/modals/AltImage.tsx
+++ b/src/view/com/modals/AltImage.tsx
@@ -105,6 +105,7 @@ export function Component({image}: Props) {
             contentFit="contain"
             accessible={true}
             accessibilityIgnoresInvertColors
+            enableLiveTextInteraction
           />
         </View>
         <TextInput


### PR DESCRIPTION
It is pretty common on iOS now for images to use iOS's live text interaction feature. We can enable that in the alt text modal and in the image viewer (when the image is not scaled) with expo-image.

https://github.com/bluesky-social/social-app/assets/153161762/8733507d-de3d-447a-9485-82a0e30963ef