### PR TITLE
Add missing word in ModerationDetails.tsx

### DIFF
--- a/src/view/com/modals/ModerationDetails.tsx
+++ b/src/view/com/modals/ModerationDetails.tsx
@@ -72,7 +72,7 @@ export function Component({
       name = _(msg`Account Muted by List`)
       description = (
         <Trans>
-          This user is included the{' '}
+          This user is included in the{' '}
           <TextLink
             type="2xl"
             href={listUriToHref(list.uri)}


### PR DESCRIPTION
This very small PR adds the missing word 'in' to the message:

"This user is included the [listname] list which you have muted."

to follow the equivalent message on L43:

"This user is included **in** the [listname] list which you have blocked."