### PR TITLE
Fix typo in ca/messages.po

### DIFF
--- a/src/locale/locales/ca/messages.po
+++ b/src/locale/locales/ca/messages.po
@@ -2639,7 +2639,7 @@ msgstr "Persones seguides per @{0}"
 
 #: src/Navigation.tsx:154
 msgid "People following @{0}"
-msgstr "Oersones seguint a @{0}"
+msgstr "Persones seguint a @{0}"
 
 #: src/view/com/lightbox/Lightbox.tsx:66
 msgid "Permission to access camera roll is required."


### PR DESCRIPTION
A tiny PR to fix a typo in the recently-updated Catalan translation, changing a single 'O' to 'P' (they're right next to each other on the keyboard ofc).