### PR TITLE
European (Danish) phone numbers often just 8 digits.

### DIFF
--- a/src/view/com/auth/create/Step2.tsx
+++ b/src/view/com/auth/create/Step2.tsx
@@ -43,7 +43,7 @@ export function Step2({
 
   const onPressRequest = React.useCallback(() => {
     if (
-      uiState.verificationPhone.length >= 9 &&
+      uiState.verificationPhone.length >= 8 &&
       parsePhoneNumber(uiState.verificationPhone, uiState.phoneCountry)
     ) {
       requestVerificationCode({uiState, uiDispatch, _})


### PR DESCRIPTION
When not counting the country code the number is most often 8 digits in Denmark.