### PR TITLE
convert query to lowercase before performing query

### DIFF
--- a/src/state/queries/actor-autocomplete.ts
+++ b/src/state/queries/actor-autocomplete.ts
@@ -61,6 +61,7 @@ export function useActorAutocompleteFn() {
 
   return React.useCallback(
     async ({query, limit = 8}: {query: string; limit?: number}) => {
+      query = query.toLowerCase()
       let res
       if (query) {
         try {


### PR DESCRIPTION
We needed to convert the query to lowercase here before searching. Wondering if this was a v2 change?

We should do this regardless so that searching `KATIE` then a subsequently searching for `Katie` will be cached.

https://github.com/bluesky-social/social-app/issues/2430#issuecomment-1931046814