### PR TITLE
Check if external embed link is present in rich text

### DIFF
--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -383,6 +383,7 @@ let PostThreadItemLoaded = ({
                   ignoreQuoteDecisions
                   style={s.mb10}>
                   <PostEmbeds
+                    record={record}
                     embed={post.embed}
                     moderation={moderation.embed}
                     moderationDecisions={moderation.decisions}
@@ -582,6 +583,7 @@ let PostThreadItemLoaded = ({
                     ignoreMute={isEmbedByEmbedder(post.embed, post.author.did)}
                     ignoreQuoteDecisions>
                     <PostEmbeds
+                      record={record}
                       embed={post.embed}
                       moderation={moderation.embed}
                       moderationDecisions={moderation.decisions}

--- a/src/view/com/post/Post.tsx
+++ b/src/view/com/post/Post.tsx
@@ -207,6 +207,7 @@ function PostInner({
                 ignoreQuoteDecisions
                 style={styles.contentHider}>
                 <PostEmbeds
+                  record={record}
                   embed={post.embed}
                   moderation={moderation.embed}
                   moderationDecisions={moderation.decisions}

--- a/src/view/com/posts/FeedItem.tsx
+++ b/src/view/com/posts/FeedItem.tsx
@@ -297,6 +297,7 @@ let FeedItemInner = ({
             </View>
           )}
           <PostContent
+            record={record}
             moderation={moderation}
             richText={richText}
             postEmbed={post.embed}
@@ -319,11 +320,13 @@ let FeedItemInner = ({
 FeedItemInner = memo(FeedItemInner)
 
 let PostContent = ({
+  record,
   moderation,
   richText,
   postEmbed,
   postAuthor,
 }: {
+  record: AppBskyFeedPost.Record
   moderation: PostModeration
   richText: RichTextAPI
   postEmbed: AppBskyFeedDefs.PostView['embed']
@@ -375,6 +378,7 @@ let PostContent = ({
           ignoreQuoteDecisions
           style={styles.embed}>
           <PostEmbeds
+            record={record}
             embed={postEmbed}
             moderation={moderation.embed}
             moderationDecisions={moderation.decisions}

--- a/src/view/com/util/Link.tsx
+++ b/src/view/com/util/Link.tsx
@@ -62,6 +62,7 @@ export const Link = memo(function Link({
   accessible,
   anchorNoUnderline,
   navigationAction,
+  onPress: onPressOuter,
   ...props
 }: Props) {
   const {closeModal} = useModalControls()
@@ -70,8 +71,16 @@ export const Link = memo(function Link({
   const openLink = useOpenLink()
 
   const onPress = React.useCallback(
-    (e?: Event) => {
+    (e: GestureResponderEvent) => {
       if (typeof href === 'string') {
+        if (onPressOuter) {
+          onPressOuter(e)
+
+          if (e.defaultPrevented) {
+            return
+          }
+        }
+
         return onPressInner(
           closeModal,
           navigation,
@@ -82,7 +91,7 @@ export const Link = memo(function Link({
         )
       }
     },
-    [closeModal, navigation, navigationAction, href, openLink],
+    [closeModal, navigation, navigationAction, href, openLink, onPressOuter],
   )
 
   if (noFeedback) {

--- a/src/view/com/util/post-embeds/QuoteEmbed.tsx
+++ b/src/view/com/util/post-embeds/QuoteEmbed.tsx
@@ -134,7 +134,7 @@ export function QuoteEmbed({
           noLinks
         />
       ) : null}
-      {embed && <PostEmbeds embed={embed} moderation={{}} />}
+      {embed && <PostEmbeds record={quote} embed={embed} moderation={{}} />}
     </Link>
   )
 }

--- a/src/view/com/util/post-embeds/index.tsx
+++ b/src/view/com/util/post-embeds/index.tsx
@@ -49,7 +49,7 @@ export function PostEmbeds({
   moderationDecisions,
   style,
 }: {
-  record: {facets?: AppBskyRichtextFacet.Main[]}
+  record: {text: string; facets?: AppBskyRichtextFacet.Main[]}
   embed?: Embed
   moderation: ModerationUI
   moderationDecisions?: PostModeration['decisions']
@@ -71,19 +71,16 @@ export function PostEmbeds({
 
   const onExternalPress = useCallback(
     (e: GestureResponderEvent) => {
-      if (!externalUri) {
+      if (!externalUri || record.text.trim().length === 0) {
         return
       }
 
-      const links = record.facets?.flatMap(facet =>
+      const facets = record.facets || []
+      const links = facets.flatMap(facet =>
         facet.features.filter((feature): feature is AppBskyRichtextFacet.Link =>
           AppBskyRichtextFacet.isLink(feature),
         ),
       )
-
-      if (!links || links.length === 0) {
-        return
-      }
 
       if (!links.some(link => link.uri === externalUri)) {
         e.preventDefault()


### PR DESCRIPTION
Addresses the security issue that was presented a while back where an adversary can craft an arbitrary external link embed (hopefully?)

This pull request adds in the following check:

- Grab the link facets contained in the record
- Check if external embed URL matches with any of them
- If so, check if the facet's text is misleading and warn if it is
- If not, show a warning since it doesn't match with any

Check is skipped if the text is empty as the composer allows doing so