### PR TITLE
Fix open-in-new-tab for TextLink

### DIFF
--- a/src/view/com/util/Link.tsx
+++ b/src/view/com/util/Link.tsx
@@ -197,6 +197,15 @@ export const TextLink = memo(function TextLink({
           href,
         })
       }
+      if (
+        isWeb &&
+        href !== '#' &&
+        e != null &&
+        isModifiedEvent(e as React.MouseEvent)
+      ) {
+        // Let the browser handle opening in new tab etc.
+        return
+      }
       if (onPress) {
         e?.preventDefault?.()
         // @ts-ignore function signature differs by platform -prf
@@ -381,4 +390,17 @@ function onPressInner(
       }
     }
   }
+}
+
+function isModifiedEvent(e: React.MouseEvent): boolean {
+  const eventTarget = e.currentTarget as HTMLAnchorElement
+  const target = eventTarget.getAttribute('target')
+  return (
+    (target && target !== '_self') ||
+    e.metaKey ||
+    e.ctrlKey ||
+    e.shiftKey ||
+    e.altKey ||
+    (e.nativeEvent && e.nativeEvent.which === 2)
+  )
 }


### PR DESCRIPTION
On the web, I want to be able to cmd+click a `TextLink`. This currently works if it has no `onPress` handler, but if `onPress` handler is specified, the browser behavior will not be respected. This isn't very good. Ideally, we should *still* let the browser handle in these cases. (Unless its `href` is invalid.)

I've manually searched through all usages to `TextLink` to confirm the new behavior makes sense. E.g. you're now able to cmd+click on a List's title header to open it in a new tab. Same with "Bluesky" header at the top of the feed. The few cases where it didn't made sense had `href="#"` so I explicitly check for that.

I know we have some similar code within `onPressInner`. I didn't touch it because by the time it runs, it's already too late — the custom `onPress` has executed. I don't want to touch the logic there cause it's pretty intricate. It's easier to add an early exit with a clear condition.