### PR TITLE
Keep pager feeds in sync with the right pane

### DIFF
--- a/src/App.native.tsx
+++ b/src/App.native.tsx
@@ -32,6 +32,7 @@ import {Provider as MutedThreadsProvider} from 'state/muted-threads'
 import {Provider as InvitesStateProvider} from 'state/invites'
 import {Provider as PrefsStateProvider} from 'state/preferences'
 import {Provider as LoggedOutViewProvider} from 'state/shell/logged-out'
+import {Provider as SelectedFeedProvider} from 'state/shell/selected-feed'
 import I18nProvider from './locale/i18nProvider'
 import {
   Provider as SessionProvider,
@@ -72,17 +73,19 @@ function InnerApp() {
             // Resets the entire tree below when it changes:
             key={currentAccount?.did}>
             <LoggedOutViewProvider>
-              <UnreadNotifsProvider>
-                <ThemeProvider theme={theme}>
-                  {/* All components should be within this provider */}
-                  <RootSiblingParent>
-                    <GestureHandlerRootView style={s.h100pct}>
-                      <TestCtrls />
-                      <Shell />
-                    </GestureHandlerRootView>
-                  </RootSiblingParent>
-                </ThemeProvider>
-              </UnreadNotifsProvider>
+              <SelectedFeedProvider>
+                <UnreadNotifsProvider>
+                  <ThemeProvider theme={theme}>
+                    {/* All components should be within this provider */}
+                    <RootSiblingParent>
+                      <GestureHandlerRootView style={s.h100pct}>
+                        <TestCtrls />
+                        <Shell />
+                      </GestureHandlerRootView>
+                    </RootSiblingParent>
+                  </ThemeProvider>
+                </UnreadNotifsProvider>
+              </SelectedFeedProvider>
             </LoggedOutViewProvider>
           </React.Fragment>
         </Splash>

--- a/src/App.web.tsx
+++ b/src/App.web.tsx
@@ -22,6 +22,7 @@ import {Provider as MutedThreadsProvider} from 'state/muted-threads'
 import {Provider as InvitesStateProvider} from 'state/invites'
 import {Provider as PrefsStateProvider} from 'state/preferences'
 import {Provider as LoggedOutViewProvider} from 'state/shell/logged-out'
+import {Provider as SelectedFeedProvider} from 'state/shell/selected-feed'
 import I18nProvider from './locale/i18nProvider'
 import {
   Provider as SessionProvider,
@@ -52,17 +53,19 @@ function InnerApp() {
         // Resets the entire tree below when it changes:
         key={currentAccount?.did}>
         <LoggedOutViewProvider>
-          <UnreadNotifsProvider>
-            <ThemeProvider theme={theme}>
-              {/* All components should be within this provider */}
-              <RootSiblingParent>
-                <SafeAreaProvider>
-                  <Shell />
-                </SafeAreaProvider>
-              </RootSiblingParent>
-              <ToastContainer />
-            </ThemeProvider>
-          </UnreadNotifsProvider>
+          <SelectedFeedProvider>
+            <UnreadNotifsProvider>
+              <ThemeProvider theme={theme}>
+                {/* All components should be within this provider */}
+                <RootSiblingParent>
+                  <SafeAreaProvider>
+                    <Shell />
+                  </SafeAreaProvider>
+                </RootSiblingParent>
+                <ToastContainer />
+              </ThemeProvider>
+            </UnreadNotifsProvider>
+          </SelectedFeedProvider>
         </LoggedOutViewProvider>
       </React.Fragment>
     </Alf>

--- a/src/state/shell/selected-feed.tsx
+++ b/src/state/shell/selected-feed.tsx
@@ -5,20 +5,31 @@ import {isWeb} from '#/platform/detection'
 type StateContext = string
 type SetContext = (v: string) => void
 
-const stateContext = React.createContext<StateContext>('Following')
+const stateContext = React.createContext<StateContext>('home')
 const setContext = React.createContext<SetContext>((_: string) => {})
 
 function getInitialFeed() {
   if (isWeb) {
-    const params = new URLSearchParams(window.location.search)
-    if (window.location.pathname === '/' && params.get('feed')) {
-      const feed = params.get('feed')
-      params.delete('feed')
-      history.replaceState(null, '', '?' + params + location.hash)
-      return feed
+    if (window.location.pathname === '/') {
+      const params = new URLSearchParams(window.location.search)
+      const feedFromUrl = params.get('feed')
+      if (feedFromUrl) {
+        // If explicitly booted from a link like /?feed=..., prefer that.
+        return feedFromUrl
+      }
+    }
+    const feedFromSession = sessionStorage.getItem('lastSelectedHomeFeed')
+    if (feedFromSession) {
+      // Fall back to a previously chosen feed for this browser tab.
+      return feedFromSession
     }
   }
-  return persisted.get('lastSelectedHomeFeed') ?? 'home'
+  const feedFromPersisted = persisted.get('lastSelectedHomeFeed')
+  if (feedFromPersisted) {
+    // Fall back to the last chosen one across all tabs.
+    return feedFromPersisted
+  }
+  return 'home'
 }
 
 export function Provider({children}: React.PropsWithChildren<{}>) {
@@ -26,6 +37,11 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
 
   const saveState = React.useCallback((feed: string) => {
     setState(feed)
+    if (isWeb) {
+      try {
+        sessionStorage.setItem('lastSelectedHomeFeed', feed)
+      } catch {}
+    }
     persisted.write('lastSelectedHomeFeed', feed)
   }, [])
 

--- a/src/state/shell/selected-feed.tsx
+++ b/src/state/shell/selected-feed.tsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import * as persisted from '#/state/persisted'
+
+type StateContext = string
+type SetContext = (v: string) => void
+
+const stateContext = React.createContext<StateContext>('Following')
+const setContext = React.createContext<SetContext>((_: string) => {})
+
+export function Provider({children}: React.PropsWithChildren<{}>) {
+  const [state, setState] = React.useState(
+    () => persisted.get('lastSelectedHomeFeed') ?? 'home',
+  )
+
+  const saveState = React.useCallback((feed: string) => {
+    setState(feed)
+    persisted.write('lastSelectedHomeFeed', feed)
+  }, [])
+
+  return (
+    <stateContext.Provider value={state}>
+      <setContext.Provider value={saveState}>{children}</setContext.Provider>
+    </stateContext.Provider>
+  )
+}
+
+export function useSelectedFeed() {
+  return React.useContext(stateContext)
+}
+
+export function useSetSelectedFeed() {
+  return React.useContext(setContext)
+}

--- a/src/state/shell/selected-feed.tsx
+++ b/src/state/shell/selected-feed.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import * as persisted from '#/state/persisted'
+import {isWeb} from '#/platform/detection'
 
 type StateContext = string
 type SetContext = (v: string) => void
@@ -7,10 +8,21 @@ type SetContext = (v: string) => void
 const stateContext = React.createContext<StateContext>('Following')
 const setContext = React.createContext<SetContext>((_: string) => {})
 
+function getInitialFeed() {
+  if (isWeb) {
+    const params = new URLSearchParams(window.location.search)
+    if (window.location.pathname === '/' && params.get('feed')) {
+      const feed = params.get('feed')
+      params.delete('feed')
+      history.replaceState(null, '', '?' + params + location.hash)
+      return feed
+    }
+  }
+  return persisted.get('lastSelectedHomeFeed') ?? 'home'
+}
+
 export function Provider({children}: React.PropsWithChildren<{}>) {
-  const [state, setState] = React.useState(
-    () => persisted.get('lastSelectedHomeFeed') ?? 'home',
-  )
+  const [state, setState] = React.useState(getInitialFeed)
 
   const saveState = React.useCallback((feed: string) => {
     setState(feed)

--- a/src/view/com/pager/Pager.web.tsx
+++ b/src/view/com/pager/Pager.web.tsx
@@ -31,7 +31,7 @@ export const Pager = React.forwardRef(function PagerImpl(
   const anchorRef = React.useRef(null)
 
   React.useImperativeHandle(ref, () => ({
-    setPage: (index: number) => setSelectedPage(index),
+    setPage: (index: number) => onTabBarSelect(index),
   }))
 
   const onTabBarSelect = React.useCallback(

--- a/src/view/screens/Home.tsx
+++ b/src/view/screens/Home.tsx
@@ -16,25 +16,19 @@ import {usePinnedFeedsInfos, FeedSourceInfo} from '#/state/queries/feed'
 import {UsePreferencesQueryResponse} from '#/state/queries/preferences/types'
 import {emitSoftReset} from '#/state/events'
 import {useSession} from '#/state/session'
-import {useWebMediaQueries} from '#/lib/hooks/useWebMediaQueries'
-import * as persisted from '#/state/persisted'
+import {useSelectedFeed, useSetSelectedFeed} from '#/state/shell/selected-feed'
 
 type Props = NativeStackScreenProps<HomeTabNavigatorParams, 'Home'>
 export function HomeScreen(props: Props) {
   const {data: preferences} = usePreferencesQuery()
   const {feeds: pinnedFeedInfos, isLoading: isPinnedFeedsLoading} =
     usePinnedFeedsInfos()
-  const {isDesktop} = useWebMediaQueries()
-  const [rawInitialFeed] = React.useState<string>(
-    () => persisted.get('lastSelectedHomeFeed') ?? 'home',
-  )
   if (preferences && pinnedFeedInfos && !isPinnedFeedsLoading) {
     return (
       <HomeScreenReady
         {...props}
         preferences={preferences}
         pinnedFeedInfos={pinnedFeedInfos}
-        rawInitialFeed={isDesktop ? 'home' : rawInitialFeed}
       />
     )
   } else {
@@ -49,11 +43,9 @@ export function HomeScreen(props: Props) {
 function HomeScreenReady({
   preferences,
   pinnedFeedInfos,
-  rawInitialFeed,
 }: Props & {
   preferences: UsePreferencesQueryResponse
   pinnedFeedInfos: FeedSourceInfo[]
-  rawInitialFeed: string
 }) {
   const allFeeds = React.useMemo(() => {
     const feeds: FeedDescriptor[] = []
@@ -68,11 +60,20 @@ function HomeScreenReady({
     return feeds
   }, [pinnedFeedInfos])
 
-  const [rawSelectedFeed, setSelectedFeed] =
-    React.useState<string>(rawInitialFeed)
+  const rawSelectedFeed = useSelectedFeed()
+  const setSelectedFeed = useSetSelectedFeed()
   const maybeFoundIndex = allFeeds.indexOf(rawSelectedFeed as FeedDescriptor)
   const selectedIndex = Math.max(0, maybeFoundIndex)
   const selectedFeed = allFeeds[selectedIndex]
+
+  const pagerRef = React.useRef(null)
+  const lastPagerReportedIndexRef = React.useRef(selectedIndex)
+  React.useLayoutEffect(() => {
+    if (selectedIndex !== lastPagerReportedIndexRef.current) {
+      lastPagerReportedIndexRef.current = selectedIndex
+      pagerRef.current?.setPage(selectedIndex)
+    }
+  }, [selectedIndex])
 
   const {hasSession} = useSession()
   const setMinimalShellMode = useSetMinimalShellMode()
@@ -93,7 +94,7 @@ function HomeScreenReady({
       setDrawerSwipeDisabled(index > 0)
       const feed = allFeeds[index]
       setSelectedFeed(feed)
-      persisted.write('lastSelectedHomeFeed', feed)
+      lastPagerReportedIndexRef.current = index
     },
     [setDrawerSwipeDisabled, setSelectedFeed, setMinimalShellMode, allFeeds],
   )
@@ -147,6 +148,7 @@ function HomeScreenReady({
   return hasSession ? (
     <Pager
       key={allFeeds.join(',')}
+      ref={pagerRef}
       testID="homeScreen"
       initialPage={selectedIndex}
       onPageSelected={onPageSelected}

--- a/src/view/screens/Home.tsx
+++ b/src/view/screens/Home.tsx
@@ -7,7 +7,7 @@ import {FollowingEmptyState} from 'view/com/posts/FollowingEmptyState'
 import {FollowingEndOfFeed} from 'view/com/posts/FollowingEndOfFeed'
 import {CustomFeedEmptyState} from 'view/com/posts/CustomFeedEmptyState'
 import {FeedsTabBar} from '../com/pager/FeedsTabBar'
-import {Pager, RenderTabBarFnProps} from 'view/com/pager/Pager'
+import {Pager, RenderTabBarFnProps, PagerRef} from 'view/com/pager/Pager'
 import {FeedPage} from 'view/com/feeds/FeedPage'
 import {HomeLoggedOutCTA} from '../com/auth/HomeLoggedOutCTA'
 import {useSetMinimalShellMode, useSetDrawerSwipeDisabled} from '#/state/shell'
@@ -66,9 +66,12 @@ function HomeScreenReady({
   const selectedIndex = Math.max(0, maybeFoundIndex)
   const selectedFeed = allFeeds[selectedIndex]
 
-  const pagerRef = React.useRef(null)
+  const pagerRef = React.useRef<PagerRef>(null)
   const lastPagerReportedIndexRef = React.useRef(selectedIndex)
   React.useLayoutEffect(() => {
+    // Since the pager is not a controlled component, adjust it imperatively
+    // if the selected index gets out of sync with what it last reported.
+    // This is supposed to only happen on the web when you use the right nav.
     if (selectedIndex !== lastPagerReportedIndexRef.current) {
       lastPagerReportedIndexRef.current = selectedIndex
       pagerRef.current?.setPage(selectedIndex)

--- a/src/view/shell/desktop/Feeds.tsx
+++ b/src/view/shell/desktop/Feeds.tsx
@@ -10,6 +10,7 @@ import {usePinnedFeedsInfos} from '#/state/queries/feed'
 import {useSelectedFeed, useSetSelectedFeed} from '#/state/shell/selected-feed'
 import {FeedDescriptor} from '#/state/queries/post-feed'
 import {NavigationProp} from 'lib/routes/types'
+import {emitSoftReset} from '#/state/events'
 
 export function DesktopFeeds() {
   const pal = usePalette('default')
@@ -48,6 +49,9 @@ export function DesktopFeeds() {
             onPress={() => {
               setSelectedFeed(feed)
               navigation.navigate('Home')
+              if (feed === selectedFeed) {
+                emitSoftReset()
+              }
             }}
           />
         )

--- a/src/view/shell/desktop/Feeds.tsx
+++ b/src/view/shell/desktop/Feeds.tsx
@@ -38,10 +38,11 @@ export function DesktopFeeds() {
         } else {
           return null
         }
+        const params = new URLSearchParams([['feed', feed]])
         return (
           <FeedItem
             key={feed}
-            href={'/'} // TODO
+            href={'/?' + params}
             title={feedInfo.displayName}
             current={route.name === 'Home' && feed === selectedFeed}
             onPress={() => {

--- a/src/view/shell/desktop/Feeds.tsx
+++ b/src/view/shell/desktop/Feeds.tsx
@@ -9,6 +9,7 @@ import {msg} from '@lingui/macro'
 import {usePinnedFeedsInfos} from '#/state/queries/feed'
 import {useSelectedFeed, useSetSelectedFeed} from '#/state/shell/selected-feed'
 import {FeedDescriptor} from '#/state/queries/post-feed'
+import {NavigationProp} from 'lib/routes/types'
 
 export function DesktopFeeds() {
   const pal = usePalette('default')
@@ -16,7 +17,7 @@ export function DesktopFeeds() {
   const {feeds: pinnedFeedInfos} = usePinnedFeedsInfos()
   const selectedFeed = useSelectedFeed()
   const setSelectedFeed = useSetSelectedFeed()
-  const navigation = useNavigation()
+  const navigation = useNavigation<NavigationProp>()
   const route = useNavigationState(state => {
     if (!state) {
       return {name: 'Home'}
@@ -38,16 +39,15 @@ export function DesktopFeeds() {
         } else {
           return null
         }
-        const params = new URLSearchParams([['feed', feed]])
         return (
           <FeedItem
             key={feed}
-            href={'/?' + params}
+            href={'/?' + new URLSearchParams([['feed', feed]])}
             title={feedInfo.displayName}
             current={route.name === 'Home' && feed === selectedFeed}
             onPress={() => {
               setSelectedFeed(feed)
-              navigation.navigate({name: 'Home'})
+              navigation.navigate('Home')
             }}
           />
         )
@@ -73,6 +73,7 @@ function FeedItem({
   title: string
   href: string
   current: boolean
+  onPress: () => void
 }) {
   const pal = usePalette('default')
   return (


### PR DESCRIPTION
Another approach to https://github.com/bluesky-social/social-app/pull/2738.

This one is a bit weird but I think it works.

The idea is to have a hierarchy:

- If opened with `/?feed=...`, prefer that. This is for "open in new tab" in the right pane.
- Otherwise, see if we have something in `sessionStorage`. This is tab-local so it ensures refreshing a tab doesn't reset the selected feed. Each browser tab tracks its own selected feed across refreshes.
- If we don't have that either, fall back to `persisted` (i.e. `localStorage`). This is for regular newly opened tabs.
- Finally, fall back to Following.

On native, there shouldn't be any changes.

I haven't tested extensively, but cursory testing seems to show this works.