### PR TITLE
Quickly fix Japanese mistranslation of "Suggestive"

### DIFF
--- a/src/locale/locales/ja/messages.po
+++ b/src/locale/locales/ja/messages.po
@@ -3837,7 +3837,7 @@ msgstr "あなたへのおすすめ"
 
 #: src/view/com/modals/SelfLabel.tsx:95
 msgid "Suggestive"
-msgstr "提案"
+msgstr "色気"
 
 #: src/Navigation.tsx:213
 #: src/view/screens/Support.tsx:30


### PR DESCRIPTION
The word used in the previous translation ([提案](https://dictionary.goo.ne.jp/word/en/提案/)) means "an offer", and has not at all the meaning it needs to have. Switch to [色気](https://dictionary.goo.ne.jp/word/en/色気/)[^1] which is specific to "sex appeal".

[^1]: don't be misled by the first couple example sentences as they show the word being used in the *negative*.

