### PR TITLE
Fix google translate appear

### DIFF
--- a/bskyweb/templates/base.html
+++ b/bskyweb/templates/base.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html>
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, viewport-fit=cover">
@@ -217,9 +217,9 @@
 {%- block body_all %}
 	<div id="root"></div>
     <noscript>
-      <h1>JavaScript Required</h1>
-      <p>This is a heavily interactive web application, and JavaScript is required. Simple HTML interfaces are possible, but that is not what this is.
-      <p>Learn more about Bluesky at <a href="https://blueskyweb.xyz">blueskyweb.xyz</a> and <a href="https://atproto.com">atproto.com</a>.
+      <h1 lang="en">JavaScript Required</h1>
+      <p lang="en">This is a heavily interactive web application, and JavaScript is required. Simple HTML interfaces are possible, but that is not what this is.
+      <p lang="en">Learn more about Bluesky at <a href="https://blueskyweb.xyz">blueskyweb.xyz</a> and <a href="https://atproto.com">atproto.com</a>.
 			{% block noscript_extra %}{% endblock %}
     </noscript>
 {% endblock -%}

--- a/web/index.html
+++ b/web/index.html
@@ -1,8 +1,7 @@
 <!DOCTYPE html>
-<html lang="%LANG_ISO_CODE%">
+<html>
   <head>
-    <meta charset="utf-8" />
-    <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
+    <meta charset="utf-8">
     <!--
       This viewport works for phones with notches.
       It's optimized for gestures by disabling global zoom.
@@ -234,8 +233,8 @@
             width: 80%;
           "
         >
-          <p>Oh no! It looks like JavaScript is not enabled in your browser.</p>
-          <p style="margin: 20px 0;">
+          <p lang="en">Oh no! It looks like JavaScript is not enabled in your browser.</p>
+          <p lang="en" style="margin: 20px 0;">
             <button
               type="submit"
               style="


### PR DESCRIPTION
![screenshot 2024-02-07 234059](https://github.com/bluesky-social/social-app/assets/56965274/cc458760-8649-471a-b7e9-5f1968b91bdb)

On non-English Windows Chrome, Google Translate appears as shown in the image above. This PR fixes this. Also, we've removed the X-UA-Compatible code as IE support has now ended.