### PR TITLE
Fix error screen on native, use `Not Found` for profile errors instead of `Oops!`

### DIFF
--- a/src/view/com/modals/ProfilePreview.tsx
+++ b/src/view/com/modals/ProfilePreview.tsx
@@ -46,7 +46,7 @@ export function Component({did}: {did: string}) {
   if (profileError) {
     return (
       <ErrorScreen
-        title={_(msg`Oops!`)}
+        title={_(msg`Not Found`)}
         message={cleanError(profileError)}
         onPressTryAgain={refetchProfile}
       />

--- a/src/view/com/util/error/ErrorScreen.tsx
+++ b/src/view/com/util/error/ErrorScreen.tsx
@@ -11,6 +11,7 @@ import {Button} from '../forms/Button'
 import {CenteredView} from '../Views'
 import {Trans, msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
+import {ViewHeader} from 'view/com/util/ViewHeader'
 
 export function ErrorScreen({
   title,
@@ -18,66 +19,71 @@ export function ErrorScreen({
   details,
   onPressTryAgain,
   testID,
+  showHeader,
 }: {
   title: string
   message: string
   details?: string
   onPressTryAgain?: () => void
   testID?: string
+  showHeader?: boolean
 }) {
   const theme = useTheme()
   const pal = usePalette('default')
   const {_} = useLingui()
 
   return (
-    <CenteredView testID={testID} style={[styles.outer, pal.view]}>
-      <View style={styles.errorIconContainer}>
-        <View
-          style={[
-            styles.errorIcon,
-            {backgroundColor: theme.palette.inverted.background},
-          ]}>
-          <FontAwesomeIcon
-            icon="exclamation"
-            style={pal.textInverted as FontAwesomeIconStyle}
-            size={24}
-          />
-        </View>
-      </View>
-      <Text type="title-lg" style={[styles.title, pal.text]}>
-        {title}
-      </Text>
-      <Text style={[styles.message, pal.text]}>{message}</Text>
-      {details && (
-        <Text
-          testID={`${testID}-details`}
-          style={[styles.details, pal.text, pal.viewLight]}>
-          {details}
-        </Text>
-      )}
-      {onPressTryAgain && (
-        <View style={styles.btnContainer}>
-          <Button
-            testID="errorScreenTryAgainButton"
-            type="default"
-            style={[styles.btn]}
-            onPress={onPressTryAgain}
-            accessibilityLabel={_(msg`Retry`)}
-            accessibilityHint={_(
-              msg`Retries the last action, which errored out`,
-            )}>
+    <>
+      {showHeader && <ViewHeader title="Error" showBorder />}
+      <CenteredView testID={testID} style={[styles.outer, pal.view]}>
+        <View style={styles.errorIconContainer}>
+          <View
+            style={[
+              styles.errorIcon,
+              {backgroundColor: theme.palette.inverted.background},
+            ]}>
             <FontAwesomeIcon
-              icon="arrows-rotate"
-              style={pal.link as FontAwesomeIconStyle}
-              size={16}
+              icon="exclamation"
+              style={pal.textInverted as FontAwesomeIconStyle}
+              size={24}
             />
-            <Text type="button" style={[styles.btnText, pal.link]}>
-              <Trans context="action">Try again</Trans>
-            </Text>
-          </Button>
+          </View>
         </View>
-      )}
-    </CenteredView>
+        <Text type="title-lg" style={[styles.title, pal.text]}>
+          {title}
+        </Text>
+        <Text style={[styles.message, pal.text]}>{message}</Text>
+        {details && (
+          <Text
+            testID={`${testID}-details`}
+            style={[styles.details, pal.text, pal.viewLight]}>
+            {details}
+          </Text>
+        )}
+        {onPressTryAgain && (
+          <View style={styles.btnContainer}>
+            <Button
+              testID="errorScreenTryAgainButton"
+              type="default"
+              style={[styles.btn]}
+              onPress={onPressTryAgain}
+              accessibilityLabel={_(msg`Retry`)}
+              accessibilityHint={_(
+                msg`Retries the last action, which errored out`,
+              )}>
+              <FontAwesomeIcon
+                icon="arrows-rotate"
+                style={pal.link as FontAwesomeIconStyle}
+                size={16}
+              />
+              <Text type="button" style={[styles.btnText, pal.link]}>
+                <Trans context="action">Try again</Trans>
+              </Text>
+            </Button>
+          </View>
+        )}
+      </CenteredView>
+    </>
   )
 }
 

--- a/src/view/com/util/error/ErrorScreen.tsx
+++ b/src/view/com/util/error/ErrorScreen.tsx
@@ -12,6 +12,7 @@ import {CenteredView} from '../Views'
 import {Trans, msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 import {ViewHeader} from 'view/com/util/ViewHeader'
+import {useWebMediaQueries} from 'lib/hooks/useWebMediaQueries'
 
 export function ErrorScreen({
   title,
@@ -29,12 +30,13 @@ export function ErrorScreen({
   showHeader?: boolean
 }) {
   const theme = useTheme()
+  const {isMobile} = useWebMediaQueries()
   const pal = usePalette('default')
   const {_} = useLingui()
 
   return (
     <>
-      {showHeader && <ViewHeader title="Error" showBorder />}
+      {showHeader && isMobile && <ViewHeader title="Error" showBorder />}
       <CenteredView testID={testID} style={[styles.outer, pal.view]}>
         <View style={styles.errorIconContainer}>
           <View

--- a/src/view/screens/Profile.tsx
+++ b/src/view/screens/Profile.tsx
@@ -97,14 +97,12 @@ export function ProfileScreen({route}: Props) {
   }
   if (resolveError || profileError) {
     return (
-      <CenteredView>
-        <ErrorScreen
-          testID="profileErrorScreen"
-          title="Oops!"
-          message={cleanError(resolveError || profileError)}
-          onPressTryAgain={onPressTryAgain}
-        />
-      </CenteredView>
+      <ErrorScreen
+        testID="profileErrorScreen"
+        title="Oops!"
+        message={cleanError(resolveError || profileError)}
+        onPressTryAgain={onPressTryAgain}
+      />
     )
   }
   if (profile && moderationOpts) {
@@ -118,14 +116,12 @@ export function ProfileScreen({route}: Props) {
   }
   // should never happen
   return (
-    <CenteredView>
-      <ErrorScreen
-        testID="profileErrorScreen"
-        title="Oops!"
-        message="Something went wrong and we're not sure what."
-        onPressTryAgain={onPressTryAgain}
-      />
-    </CenteredView>
+    <ErrorScreen
+      testID="profileErrorScreen"
+      title="Oops!"
+      message="Something went wrong and we're not sure what."
+      onPressTryAgain={onPressTryAgain}
+    />
   )
 }
 

--- a/src/view/screens/Profile.tsx
+++ b/src/view/screens/Profile.tsx
@@ -50,6 +50,7 @@ interface SectionRef {
 
 type Props = NativeStackScreenProps<CommonNavigatorParams, 'Profile'>
 export function ProfileScreen({route}: Props) {
+  const {_} = useLingui()
   const {currentAccount} = useSession()
   const name =
     route.params.name === 'me' ? currentAccount?.did : route.params.name
@@ -99,7 +100,7 @@ export function ProfileScreen({route}: Props) {
     return (
       <ErrorScreen
         testID="profileErrorScreen"
-        title="Oops!"
+        title={profileError ? _(msg`Not Found`) : _(msg`Oops!`)}
         message={cleanError(resolveError || profileError)}
         onPressTryAgain={onPressTryAgain}
         showHeader

--- a/src/view/screens/Profile.tsx
+++ b/src/view/screens/Profile.tsx
@@ -102,6 +102,7 @@ export function ProfileScreen({route}: Props) {
         title="Oops!"
         message={cleanError(resolveError || profileError)}
         onPressTryAgain={onPressTryAgain}
+        showHeader
       />
     )
   }
@@ -121,6 +122,7 @@ export function ProfileScreen({route}: Props) {
       title="Oops!"
       message="Something went wrong and we're not sure what."
       onPressTryAgain={onPressTryAgain}
+      showHeader
     />
   )
 }


### PR DESCRIPTION
Fixes https://github.com/bluesky-social/social-app/issues/2756

Profile errors were not rendering correctly since they were accidentally wrapped inside of an additional `<CenterView>`. Also adding a view header on the error screen when rendered in `Profile` (still no header in `ProfilePreview`).


### Before

![Screenshot 2024-02-07 at 2 06 02 PM](https://github.com/bluesky-social/social-app/assets/153161762/4d84cdf1-59e2-4dc8-a177-3b1c2219f8fb)

### After

![Screenshot 2024-02-07 at 2 06 12 PM](https://github.com/bluesky-social/social-app/assets/153161762/51f810d6-6935-4ae5-bf5b-7d86b25122fb)

Also using `Not Found` for profile errors found in https://github.com/bluesky-social/atproto/blob/77118a66a7a5703e495464186246fb29fa9fa9df/packages/bsky/src/api/app/bsky/actor/getProfile.ts
