### PR TITLE
Correct the country code name of Taiwan

### DIFF
--- a/src/lib/country-codes.ts
+++ b/src/lib/country-codes.ts
@@ -219,7 +219,7 @@ export const COUNTRY_CODES: CountryCodeMap[] = [
   {code2: 'SE', name: 'Sweden (+46)'},
   {code2: 'CH', name: 'Switzerland (+41)'},
   {code2: 'SY', name: 'Syrian Arab Republic (+963)'},
-  {code2: 'TW', name: 'Taiwan, Province of China (+886)'},
+  {code2: 'TW', name: 'Taiwan (+886)'},
   {code2: 'TJ', name: 'Tajikistan (+992)'},
   {code2: 'TZ', name: 'Tanzania, United Republic of (+255)'},
   {code2: 'TH', name: 'Thailand (+66)'},


### PR DESCRIPTION
Correct the country code name of Taiwan.

Reference:

- Google Ads API Country Codes: https://developers.google.com/google-ads/api/data/codes-formats#country-codes
- PayPal API Country Codes: https://developer.paypal.com/api/rest/reference/country-codes/
- Shopify GraphGL Admin API Country Code: https://shopify.dev/docs/api/admin-graphql/2024-01/enums/CountryCode
- AT&T Country Code List: https://www.att.com/support_media/images/pdf/Country_Code_List.pdf