### PR TITLE
Improve discovery of the quick account switcher

### DIFF
--- a/src/lib/icons.tsx
+++ b/src/lib/icons.tsx
@@ -974,3 +974,32 @@ export function ListIcon({
     </Svg>
   )
 }
+
+// Copyright (c) 2020 Refactoring UI Inc.
+// https://github.com/tailwindlabs/heroicons/blob/master/LICENSE
+export function ChevronUpDownIcon({
+  style,
+  size,
+  strokeWidth = 1.5,
+}: {
+  style?: StyleProp<ViewStyle>
+  size?: string | number
+  strokeWidth?: number
+}) {
+  return (
+    <Svg
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={strokeWidth}
+      stroke="currentColor"
+      width={size}
+      height={size}
+      style={style}>
+      <Path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M8.25 15 12 18.75 15.75 15m-7.5-6L12 5.25 15.75 9"
+      />
+    </Svg>
+  )
+}

--- a/src/view/shell/bottom-bar/BottomBar.tsx
+++ b/src/view/shell/bottom-bar/BottomBar.tsx
@@ -234,7 +234,7 @@ export function BottomBar({navigation}: BottomTabBarProps) {
                       <ChevronUpDownIcon
                         size={16}
                         strokeWidth={1.9}
-                        style={[pal.text, styles.profileIconChevron]}
+                        style={[pal.textLight, styles.profileIconChevron]}
                       />
                     )}
                   </View>
@@ -251,7 +251,7 @@ export function BottomBar({navigation}: BottomTabBarProps) {
                       <ChevronUpDownIcon
                         size={16}
                         strokeWidth={1.9}
-                        style={[pal.text, styles.profileIconChevron]}
+                        style={[pal.textLight, styles.profileIconChevron]}
                       />
                     )}
                   </View>

--- a/src/view/shell/bottom-bar/BottomBar.tsx
+++ b/src/view/shell/bottom-bar/BottomBar.tsx
@@ -234,7 +234,7 @@ export function BottomBar({navigation}: BottomTabBarProps) {
                       <ChevronUpDownIcon
                         size={16}
                         strokeWidth={1.9}
-                        style={[pal.text, {marginLeft: -16, right: -16}]}
+                        style={[pal.text, styles.profileIconChevron]}
                       />
                     )}
                   </View>
@@ -251,7 +251,7 @@ export function BottomBar({navigation}: BottomTabBarProps) {
                       <ChevronUpDownIcon
                         size={16}
                         strokeWidth={1.9}
-                        style={[pal.text, {marginLeft: -16, right: -16}]}
+                        style={[pal.text, styles.profileIconChevron]}
                       />
                     )}
                   </View>

--- a/src/view/shell/bottom-bar/BottomBar.tsx
+++ b/src/view/shell/bottom-bar/BottomBar.tsx
@@ -15,6 +15,7 @@ import {
   HashtagIcon,
   BellIcon,
   BellIconSolid,
+  ChevronUpDownIcon,
 } from 'lib/icons'
 import {usePalette} from 'lib/hooks/usePalette'
 import {getTabState, TabState} from 'lib/routes/helpers'
@@ -41,7 +42,7 @@ type TabOptions = 'Home' | 'Search' | 'Notifications' | 'MyProfile' | 'Feeds'
 
 export function BottomBar({navigation}: BottomTabBarProps) {
   const {openModal} = useModalControls()
-  const {hasSession, currentAccount} = useSession()
+  const {hasSession, currentAccount, accounts} = useSession()
   const pal = usePalette('default')
   const {_} = useLingui()
   const safeAreaInsets = useSafeAreaInsets()
@@ -228,6 +229,14 @@ export function BottomBar({navigation}: BottomTabBarProps) {
                       // See https://github.com/bluesky-social/social-app/pull/1801:
                       usePlainRNImage={true}
                     />
+
+                    {accounts.length > 1 && (
+                      <ChevronUpDownIcon
+                        size={16}
+                        strokeWidth={1.9}
+                        style={[pal.text, {marginLeft: -16, right: -16}]}
+                      />
+                    )}
                   </View>
                 ) : (
                   <View style={[styles.ctrlIcon, pal.text, styles.profileIcon]}>
@@ -237,6 +246,14 @@ export function BottomBar({navigation}: BottomTabBarProps) {
                       // See https://github.com/bluesky-social/social-app/pull/1801:
                       usePlainRNImage={true}
                     />
+
+                    {accounts.length > 1 && (
+                      <ChevronUpDownIcon
+                        size={16}
+                        strokeWidth={1.9}
+                        style={[pal.text, {marginLeft: -16, right: -16}]}
+                      />
+                    )}
                   </View>
                 )}
               </View>

--- a/src/view/shell/bottom-bar/BottomBarStyles.tsx
+++ b/src/view/shell/bottom-bar/BottomBarStyles.tsx
@@ -63,6 +63,8 @@ export const styles = StyleSheet.create({
     top: -2.5,
   },
   profileIcon: {
+    flexDirection: 'row',
+    alignItems: 'center',
     top: -4,
   },
   onProfile: {

--- a/src/view/shell/bottom-bar/BottomBarStyles.tsx
+++ b/src/view/shell/bottom-bar/BottomBarStyles.tsx
@@ -67,6 +67,10 @@ export const styles = StyleSheet.create({
     alignItems: 'center',
     top: -4,
   },
+  profileIconChevron: {
+    marginLeft: -16,
+    right: -16,
+  },
   onProfile: {
     borderWidth: 1,
     borderRadius: 100,


### PR DESCRIPTION
This pull request makes the following changes:
- Show a chevron beside the profile icon to show that you can indeed, quickly switch accounts.
- ~~Only allow quick account switcher open if there's multiple accounts~~

| Light | Dim |
| --- | --- |
| <img src=https://github.com/bluesky-social/social-app/assets/148872143/92349a0b-4915-4f26-83a7-2df69531158c width=200> | <img src=https://github.com/bluesky-social/social-app/assets/148872143/b8190169-48bf-4f93-86a4-df091f273557 width=200> |

The chevron only appears if there's multiple accounts signed in, if the switcher had the ability to add new accounts I'd probably have it always shown, thoughts? I'll put it in a separate pull request if that's the direction we want.

Additionally, should this be announced in accessibility label as well?