### PR TITLE
Add bare minimum hashtags support

### DIFF
--- a/src/lib/routes/links.ts
+++ b/src/lib/routes/links.ts
@@ -27,8 +27,5 @@ export function makeListLink(did: string, rkey: string, ...segments: string[]) {
 }
 
 export function makeTagLink(did: string) {
-  // HACK: searching for "#foo" currently returns no results (#2491). This
-  // strips the "#" before searching.
-  const query = did.startsWith('#') ? did.substring(1) : did
-  return `/search?q=${encodeURIComponent(query)}`
+  return `/search?q=${encodeURIComponent(did)}`
 }

--- a/src/lib/routes/links.ts
+++ b/src/lib/routes/links.ts
@@ -25,3 +25,10 @@ export function makeCustomFeedLink(
 export function makeListLink(did: string, rkey: string, ...segments: string[]) {
   return [`/profile`, did, 'lists', rkey, ...segments].join('/')
 }
+
+export function makeTagLink(did: string) {
+  // HACK: searching for "#foo" currently returns no results (#2491). This
+  // strips the "#" before searching.
+  const query = did.startsWith('#') ? did.substring(1) : did
+  return `/search?q=${encodeURIComponent(query)}`
+}

--- a/src/view/com/util/text/RichText.tsx
+++ b/src/view/com/util/text/RichText.tsx
@@ -7,6 +7,7 @@ import {lh} from 'lib/styles'
 import {toShortUrl} from 'lib/strings/url-helpers'
 import {useTheme, TypographyVariant} from 'lib/ThemeContext'
 import {usePalette} from 'lib/hooks/usePalette'
+import {makeTagLink} from 'lib/routes/links'
 
 const WORD_WRAP = {wordWrap: 1}
 
@@ -79,6 +80,7 @@ export function RichText({
   for (const segment of richText.segments()) {
     const link = segment.link
     const mention = segment.mention
+    const tag = segment.tag
     if (
       !noLinks &&
       mention &&
@@ -112,6 +114,26 @@ export function RichText({
           />,
         )
       }
+    } else if (
+      !noLinks &&
+      tag &&
+      AppBskyRichtextFacet.validateTag(tag).success
+    ) {
+      els.push(
+        <TextLink
+          key={key}
+          type={type}
+          text={segment.text}
+          // we could also use tag.tag here, which has the leading # removed.
+          // However, this search should eventually stop removing the #, so
+          // I want to keep the removal marked as a hack. See makeTagLink's
+          // comment for details.
+          href={makeTagLink(segment.text)}
+          style={[style, lineHeightStyle, pal.link, {pointerEvents: 'auto'}]}
+          dataSet={WORD_WRAP}
+          selectable={selectable}
+        />,
+      )
     } else {
       els.push(segment.text)
     }

--- a/src/view/com/util/text/RichText.tsx
+++ b/src/view/com/util/text/RichText.tsx
@@ -124,10 +124,7 @@ export function RichText({
           key={key}
           type={type}
           text={segment.text}
-          // we could also use tag.tag here, which has the leading # removed.
-          // However, this search should eventually stop removing the #, so
-          // I want to keep the removal marked as a hack. See makeTagLink's
-          // comment for details.
+          // segment.text has the leading "#" while tag.tag does not
           href={makeTagLink(segment.text)}
           style={[style, lineHeightStyle, pal.link, {pointerEvents: 'auto'}]}
           dataSet={WORD_WRAP}


### PR DESCRIPTION
> I agree, hashtag support would be very useful precisely for the reasons you point out. Support wouldn't have to be as [detailed or as complex](https://business.twitter.com/en/blog/how-to-create-and-use-hashtags.html) as it is on, say, Twitter, just the simplest functionality mentioned to start with. It really would be a valuable feature.
>
> _Originally posted by @Luke717 in https://github.com/bluesky-social/social-app/issues/848#issuecomment-1577855453_

As atproto/api already parses hashtags, this is as simple as hooking it up like link segments.

This is "bare minimum" because:

- ~~Opening hashtag "#foo" is actually just a search for "foo" right now to work around #2491.~~ I have removed this workaround now that https://github.com/bluesky-social/indigo/issues/578 has been addressed.
- There is no integration in the composer. This hasn't stopped people from using hashtags already, and can be added later.
- This change itself only had to hook things up - thank you for having already put the hashtag parsing in place.

https://github.com/bluesky-social/social-app/assets/11722318/b3775f8e-b60e-4c16-9042-3cd60d1ace31

<details>
<summary>Screen recording of previous version with hashtag workaround</summary>
<video src="https://github.com/bluesky-social/social-app/assets/11722318/21a1d462-8285-48ce-8605-3f33388c64aa" controls="controls" muted="muted" class="d-block rounded-bottom-2 border-top width-fit" style="max-height:640px; min-height: 200px">
  </video>
</details>