### PR TITLE
Add composer button to Notifications

### DIFF
--- a/src/view/screens/Notifications.tsx
+++ b/src/view/screens/Notifications.tsx
@@ -29,6 +29,9 @@ import {listenSoftReset, emitSoftReset} from '#/state/events'
 import {truncateAndInvalidate} from '#/state/queries/util'
 import {useNonReactiveCallback} from '#/lib/hooks/useNonReactiveCallback'
 import {isNative} from '#/platform/detection'
+import {FAB} from '../com/util/fab/FAB'
+import {ComposeIcon2} from 'lib/icons'
+import {useComposerControls} from '#/state/shell/composer'
 
 type Props = NativeStackScreenProps<
   NotificationsTabNavigatorParams,
@@ -47,6 +50,7 @@ export function NotificationsScreen({}: Props) {
   const unreadApi = useUnreadNotificationsApi()
   const hasNew = !!unreadNotifs
   const isScreenFocused = useIsFocused()
+  const {openComposer} = useComposerControls()
 
   // event handlers
   // =
@@ -156,6 +160,14 @@ export function NotificationsScreen({}: Props) {
           showIndicator={hasNew}
         />
       )}
+      <FAB
+        testID="composeFAB"
+        onPress={() => openComposer({})}
+        icon={<ComposeIcon2 strokeWidth={1.5} size={29} style={s.white} />}
+        accessibilityRole="button"
+        accessibilityLabel={_(msg`New post`)}
+        accessibilityHint=""
+      />
     </View>
   )
 }


### PR DESCRIPTION
I often have a thought while reading notifications — let's add the button there.

(I considered adding to Search too but it wouldn't work super well in our layout due to overlapping Follow and Compose buttons. Maybe we can do that if we redesign a bit.)

Notifications is logged in only so I didn't add a session check.

<img width="690" alt="Screenshot 2024-02-08 at 17 30 16" src="https://github.com/bluesky-social/social-app/assets/810438/ea4e2008-2f6a-47ee-9a22-b5e403af8132">
<img width="690" alt="Screenshot 2024-02-08 at 17 30 19" src="https://github.com/bluesky-social/social-app/assets/810438/bc4bbad2-2250-4c59-bcd2-e6fab00dfdb7">
<img width="543" alt="Screenshot 2024-02-08 at 17 30 49" src="https://github.com/bluesky-social/social-app/assets/810438/7d4d6103-fd0b-43da-b7d9-08b35b94ff20">
<img width="344" alt="Screenshot 2024-02-08 at 17 34 14" src="https://github.com/bluesky-social/social-app/assets/810438/7fa0c43e-3368-4139-b1d4-aa23584859e9">
