### PR TITLE
Show text cursor on web bio

### DIFF
--- a/src/view/com/profile/ProfileHeader.tsx
+++ b/src/view/com/profile/ProfileHeader.tsx
@@ -673,7 +673,7 @@ let ProfileHeaderLoaded = ({
               </Text>
             </View>
             {descriptionRT && !moderation.profile.blur ? (
-              <View pointerEvents={isNative ? 'auto' : 'none'}>
+              <View pointerEvents="auto">
                 <RichText
                   testID="profileHeaderDescription"
                   style={[styles.description, pal.text]}


### PR DESCRIPTION
Makes bio more obviously selectable on the web (it now shows a caret on hover on the web), see https://github.com/bluesky-social/social-app/issues/2429#issuecomment-1924183432. We couldn't do this before web layout, but now the pointer events stuff isn't needed on the web at all.

I haven't removed it elsewhere but here it's an easy win.