### PR TITLE
Measure header layout reliably

### DIFF
--- a/src/view/com/pager/PagerWithHeader.tsx
+++ b/src/view/com/pager/PagerWithHeader.tsx
@@ -246,14 +246,14 @@ let PagerTabBar = ({
             onHeaderOnlyLayout(e.nativeEvent.layout.height)
             pendingHeaderHeight.current = null
           } else {
-            // Stash it away in case `isReady` turns `true` later.
+            // Stash it away for when `isHeaderReady` turns `true` later.
             pendingHeaderHeight.current = e.nativeEvent.layout.height
           }
         }}>
         {renderHeader?.()}
         {
           // When `isHeaderReady` turns `true`, we want to send the parent layout.
-          // However, if it didn't lead to a layout change, parent `onLayout` won't get called again.
+          // However, if that didn't lead to a layout change, parent `onLayout` wouldn't get called again.
           // We're conditionally rendering an empty view so that we can send the last measurement.
           isHeaderReady && (
             <View

--- a/src/view/com/pager/PagerWithHeader.tsx
+++ b/src/view/com/pager/PagerWithHeader.tsx
@@ -233,35 +233,40 @@ let PagerTabBar = ({
       },
     ],
   }))
-  const headerRef = React.useRef(null)
-  React.useEffect(() => {
-    // Fire when layout *becomes* ready.
-    // We can't rely on onLayout alone because it won't fire if layout is the same.
-    // We can't rely on this effect alone because it won't fire if layout changes later.
-    if (isHeaderReady) {
-      // @ts-ignore
-      headerRef.current!.measure(
-        (_x: number, _y: number, _width: number, height: number) => {
-          onHeaderOnlyLayout(height)
-        },
-      )
-    }
-  }, [isHeaderReady, onHeaderOnlyLayout])
-
+  const pendingHeaderHeight = React.useRef<null | number>(null)
   return (
     <Animated.View
       pointerEvents="box-none"
       style={[styles.tabBarMobile, headerTransform]}>
       <View
-        ref={headerRef}
         pointerEvents="box-none"
         collapsable={false}
         onLayout={e => {
           if (isHeaderReady) {
             onHeaderOnlyLayout(e.nativeEvent.layout.height)
+            pendingHeaderHeight.current = null
+          } else {
+            // Stash it away in case `isReady` turns `true` later.
+            pendingHeaderHeight.current = e.nativeEvent.layout.height
           }
         }}>
         {renderHeader?.()}
+        {
+          // When `isHeaderReady` turns `true`, we want to send the parent layout.
+          // However, if it didn't lead to a layout change, parent `onLayout` won't get called again.
+          // We're conditionally rendering an empty view so that we can send the last measurement.
+          isHeaderReady && (
+            <View
+              onLayout={() => {
+                // We're assuming the parent `onLayout` already ran (parent -> child ordering).
+                if (pendingHeaderHeight.current !== null) {
+                  onHeaderOnlyLayout(pendingHeaderHeight.current)
+                  pendingHeaderHeight.current = null
+                }
+              }}
+            />
+          )
+        }
       </View>
       <View
         onLayout={onTabBarLayout}


### PR DESCRIPTION
Better approach than https://github.com/bluesky-social/social-app/pull/2816.

Believe it or not, the timing of React layout effects in RN isn't well-defined ([yet](https://github.com/rubennorte/discussions-and-proposals/blob/proposal-event-loop/proposals/0744-well-defined-event-loop.md)) with regards to layout. (Oops.)

Instead let's rely on parent-child `onLayout` ordering which in my understanding and testing is reliable.

This works well in my testing.