### PR TITLE
adjust line height in handle text

### DIFF
--- a/src/lib/styles.ts
+++ b/src/lib/styles.ts
@@ -236,7 +236,7 @@ export function lh(
   height: number,
 ): TextStyle {
   return {
-    lineHeight: (theme.typography[type].fontSize || 16) * height,
+    lineHeight: Math.round((theme.typography[type].fontSize || 16) * height),
   }
 }
 

--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -273,7 +273,11 @@ let PostThreadItemLoaded = ({
                     style={styles.metaItem}
                     href={authorHref}
                     title={authorTitle}>
-                    <Text type="xl-bold" style={[pal.text]} numberOfLines={1}>
+                    <Text
+                      type="xl-bold"
+                      style={[pal.text]}
+                      numberOfLines={1}
+                      lineHeight={1}>
                       {sanitizeDisplayName(
                         post.author.displayName ||
                           sanitizeHandle(post.author.handle),

--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -273,11 +273,7 @@ let PostThreadItemLoaded = ({
                     style={styles.metaItem}
                     href={authorHref}
                     title={authorTitle}>
-                    <Text
-                      type="xl-bold"
-                      style={[pal.text]}
-                      numberOfLines={1}
-                      lineHeight={1.2}>
+                    <Text type="xl-bold" style={[pal.text]} numberOfLines={1}>
                       {sanitizeDisplayName(
                         post.author.displayName ||
                           sanitizeHandle(post.author.handle),

--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -277,7 +277,7 @@ let PostThreadItemLoaded = ({
                       type="xl-bold"
                       style={[pal.text]}
                       numberOfLines={1}
-                      lineHeight={1}>
+                      lineHeight={1.2}>
                       {sanitizeDisplayName(
                         post.author.displayName ||
                           sanitizeHandle(post.author.handle),


### PR DESCRIPTION
There's a little jump in the text right now from adding this line height to the text. I suspect it's because it was a decimal value, and adding the extra content up top means we end up moving from one pixel to another.

In any case, we should avoid using decimal values for line heights. We do this in some other places but when we start moving to using ALF we can avoid this. Right now this is the most noticeable issue when opening posts, so I think we should just take care of this one.

https://github.com/bluesky-social/social-app/assets/153161762/e54ae089-d869-4bc5-95c1-9c5ff9c50457


