### PR TITLE
Add follow button to highlighted post

### DIFF
--- a/src/view/com/post-thread/PostThreadFollowBtn.tsx
+++ b/src/view/com/post-thread/PostThreadFollowBtn.tsx
@@ -110,8 +110,6 @@ function PostThreadFollowBtnLoaded({
     }
   }, [isFollowing, requireAuth, queueFollow, _, queueUnfollow])
 
-  if (!showFollowBtn) return null
-
   return (
     <View style={styles.container}>
       {showFollowBtn && (
@@ -149,7 +147,7 @@ function PostThreadFollowBtnLoaded({
 
 const styles = StyleSheet.create({
   container: {
-    width: 95,
+    width: 100,
   },
   btnOuter: {
     marginLeft: 'auto',

--- a/src/view/com/post-thread/PostThreadFollowBtn.tsx
+++ b/src/view/com/post-thread/PostThreadFollowBtn.tsx
@@ -1,0 +1,188 @@
+import React from 'react'
+import {StyleSheet, TouchableOpacity} from 'react-native'
+import Animated, {FadeOut} from 'react-native-reanimated'
+import {useFocusEffect} from '@react-navigation/native'
+import {AppBskyActorDefs} from '@atproto/api'
+import {msg, Trans} from '@lingui/macro'
+import {useLingui} from '@lingui/react'
+import {FontAwesomeIcon} from '@fortawesome/react-native-fontawesome'
+
+import {logger} from '#/logger'
+import {Text} from 'view/com/util/text/Text'
+import * as Toast from 'view/com/util/Toast'
+import {s} from 'lib/styles'
+import {usePalette} from 'lib/hooks/usePalette'
+import {useWebMediaQueries} from 'lib/hooks/useWebMediaQueries'
+import {sanitizeDisplayName} from 'lib/strings/display-names'
+import {Shadow, useProfileShadow} from 'state/cache/profile-shadow'
+import {track} from 'lib/analytics/analytics'
+import {
+  useProfileFollowMutationQueue,
+  useProfileQuery,
+} from 'state/queries/profile'
+import {useRequireAuth} from 'state/session'
+
+export function PostThreadFollowBtn({did}: {did: string}) {
+  const {data: profile, isLoading} = useProfileQuery({did})
+
+  // We will never hit this - the profile will always be cached or loaded above
+  // but it keeps the typechecker happy
+  if (isLoading || !profile) return null
+
+  return <PostThreadFollowBtnLoaded profile={profile} />
+}
+
+function PostThreadFollowBtnLoaded({
+  profile: profileUnshadowed,
+}: {
+  profile: AppBskyActorDefs.ProfileViewDetailed
+}) {
+  const {_} = useLingui()
+  const pal = usePalette('default')
+  const palInverted = usePalette('inverted')
+  const {isTabletOrDesktop} = useWebMediaQueries()
+  const profile: Shadow<AppBskyActorDefs.ProfileViewBasic> =
+    useProfileShadow(profileUnshadowed)
+  const [queueFollow, queueUnfollow] = useProfileFollowMutationQueue(profile)
+  const requireAuth = useRequireAuth()
+
+  // We use this so we can control how long until the button disappears
+  const [showFollowBtn, setShowFollowBtn] = React.useState(
+    !profile.viewer?.following,
+  )
+  // Store the initial following state for our timeout
+  const wasFollowing = React.useRef(profile.viewer?.following)
+  const isFollowing = profile.viewer?.following
+
+  React.useEffect(() => {
+    let timeout: NodeJS.Timeout
+    // If we were not initially following and the following state changes, we
+    // want to set a timeout to remove the follow button
+    if (!wasFollowing.current && isFollowing) {
+      timeout = setTimeout(() => {
+        setShowFollowBtn(false)
+      }, 3000)
+    }
+
+    // If the follow state changes again we need to clear the timeout so it
+    // doesn't disappear
+    return () => {
+      clearTimeout(timeout)
+    }
+  }, [isFollowing])
+
+  // We this effect to run even when we come back. It needs to display the follow button again
+  // if we unfollow from the profile screen
+  useFocusEffect(
+    React.useCallback(() => {
+      if (!isFollowing && !showFollowBtn) {
+        setShowFollowBtn(true)
+      }
+    }, [isFollowing, showFollowBtn]),
+  )
+
+  const onPress = React.useCallback(() => {
+    if (!isFollowing) {
+      requireAuth(async () => {
+        try {
+          track('ProfileHeader:FollowButtonClicked')
+          await queueFollow()
+          Toast.show(
+            _(
+              msg`Following ${sanitizeDisplayName(
+                profile.displayName || profile.handle,
+              )}`,
+            ),
+          )
+        } catch (e: any) {
+          if (e?.name !== 'AbortError') {
+            logger.error('Failed to follow', {message: String(e)})
+            Toast.show(_(msg`There was an issue! ${e.toString()}`))
+          }
+        }
+      })
+    } else {
+      requireAuth(async () => {
+        try {
+          track('ProfileHeader:UnfollowButtonClicked')
+          await queueUnfollow()
+          Toast.show(
+            _(
+              msg`No longer following ${sanitizeDisplayName(
+                profile.displayName || profile.handle,
+              )}`,
+            ),
+          )
+        } catch (e: any) {
+          if (e?.name !== 'AbortError') {
+            logger.error('Failed to unfollow', {message: String(e)})
+            Toast.show(_(msg`There was an issue! ${e.toString()}`))
+          }
+        }
+      })
+    }
+  }, [
+    isFollowing,
+    requireAuth,
+    queueFollow,
+    _,
+    profile.displayName,
+    profile.handle,
+    queueUnfollow,
+  ])
+
+  if (!showFollowBtn) return null
+
+  return (
+    <Animated.View style={styles.container} exiting={FadeOut}>
+      <TouchableOpacity
+        testID="followBtn"
+        onPress={onPress}
+        style={[
+          styles.btn,
+          !isFollowing ? palInverted.view : pal.viewLight,
+          isTabletOrDesktop && {paddingHorizontal: 24},
+        ]}
+        accessibilityRole="button"
+        accessibilityLabel={_(msg`Follow ${profile.handle}`)}
+        accessibilityHint={_(
+          msg`Shows posts from ${profile.handle} in your feed`,
+        )}>
+        {isTabletOrDesktop ? (
+          <>
+            <FontAwesomeIcon
+              icon={!isFollowing ? 'plus' : 'check'}
+              style={[!isFollowing ? palInverted.text : pal.text, s.mr5]}
+            />
+            <Text
+              type="button"
+              style={[!isFollowing ? palInverted.text : pal.text, s.bold]}>
+              {!isFollowing ? <Trans>Follow</Trans> : <Trans>Following</Trans>}
+            </Text>
+          </>
+        ) : (
+          <FontAwesomeIcon
+            icon={!isFollowing ? 'user-plus' : 'user-minus'}
+            style={[pal.text, !isFollowing ? palInverted.text : pal.text]}
+            size={14}
+          />
+        )}
+      </TouchableOpacity>
+    </Animated.View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    marginLeft: 'auto',
+    marginRight: 7,
+    marginTop: 5,
+  },
+  btn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: 50,
+    padding: 8,
+  },
+})

--- a/src/view/com/post-thread/PostThreadFollowBtn.tsx
+++ b/src/view/com/post-thread/PostThreadFollowBtn.tsx
@@ -21,6 +21,7 @@ import {
   useProfileQuery,
 } from 'state/queries/profile'
 import {useRequireAuth} from 'state/session'
+import {isWeb} from 'platform/detection'
 
 export function PostThreadFollowBtn({did}: {did: string}) {
   const {data: profile, isLoading} = useProfileQuery({did})
@@ -51,7 +52,7 @@ function PostThreadFollowBtnLoaded({
     !profile.viewer?.following,
   )
   // Store the initial following state for our timeout
-  const wasFollowing = React.useRef(profile.viewer?.following)
+  const wasFollowing = React.useRef(!!profile.viewer?.following)
   const isFollowing = profile.viewer?.following
 
   React.useEffect(() => {
@@ -77,6 +78,7 @@ function PostThreadFollowBtnLoaded({
     React.useCallback(() => {
       if (!isFollowing && !showFollowBtn) {
         setShowFollowBtn(true)
+        wasFollowing.current = false
       }
     }, [isFollowing, showFollowBtn]),
   )
@@ -134,7 +136,12 @@ function PostThreadFollowBtnLoaded({
   if (!showFollowBtn) return null
 
   return (
-    <Animated.View style={styles.container} exiting={FadeOut}>
+    <Animated.View
+      style={[
+        styles.container,
+        isTabletOrDesktop && styles.containerTabletDesktop,
+      ]}
+      exiting={FadeOut}>
       <TouchableOpacity
         testID="followBtn"
         onPress={onPress}
@@ -177,6 +184,16 @@ const styles = StyleSheet.create({
     marginLeft: 'auto',
     marginRight: 7,
     marginTop: 5,
+    // We have to use absolute position for this, otherwise the animation doesn't
+    // work on web
+    ...(isWeb && {
+      position: 'absolute',
+      right: 0,
+      width: 30,
+    }),
+  },
+  containerTabletDesktop: {
+    width: 150,
   },
   btn: {
     flexDirection: 'row',

--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -262,10 +262,7 @@ let PostThreadItemLoaded = ({
             <View style={styles.layoutContent}>
               <View
                 style={[styles.meta, styles.metaExpandedLine1, {zIndex: 1}]}>
-                <Link
-                  style={styles.metaItem}
-                  href={authorHref}
-                  title={authorTitle}>
+                <Link style={s.flex1} href={authorHref} title={authorTitle}>
                   <Text
                     type="xl-bold"
                     style={[pal.text]}
@@ -303,10 +300,7 @@ let PostThreadItemLoaded = ({
                     </Text>
                   </View>
                 )}
-                <Link
-                  style={styles.metaItem}
-                  href={authorHref}
-                  title={authorTitle}>
+                <Link style={s.flex1} href={authorHref} title={authorTitle}>
                   <Text type="md" style={[pal.textLight]} numberOfLines={1}>
                     {sanitizeHandle(post.author.handle, '@')}
                   </Text>
@@ -721,10 +715,6 @@ const styles = StyleSheet.create({
   },
   metaExpandedLine1: {
     paddingVertical: 0,
-  },
-  metaItem: {
-    flex: 1,
-    paddingRight: 20,
   },
   alert: {
     marginBottom: 6,

--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -114,7 +114,6 @@ export function PostThreadItem({
 }
 
 function PostThreadItemDeleted() {
-  const styles = useStyles()
   const pal = usePalette('default')
   return (
     <View style={[styles.outer, pal.border, pal.view, s.p20, s.flexRow]}>
@@ -164,7 +163,6 @@ let PostThreadItemLoaded = ({
   const [limitLines, setLimitLines] = React.useState(
     () => countLines(richText?.text) >= MAX_POST_LINES,
   )
-  const styles = useStyles()
   const {currentAccount} = useSession()
   const hasEngagement = post.likeCount || post.repostCount
 
@@ -264,23 +262,21 @@ let PostThreadItemLoaded = ({
             <View style={styles.layoutContent}>
               <View
                 style={[styles.meta, styles.metaExpandedLine1, {zIndex: 1}]}>
-                <View style={[s.flexRow]}>
-                  <Link
-                    style={styles.metaItem}
-                    href={authorHref}
-                    title={authorTitle}>
-                    <Text
-                      type="xl-bold"
-                      style={[pal.text]}
-                      numberOfLines={1}
-                      lineHeight={1.2}>
-                      {sanitizeDisplayName(
-                        post.author.displayName ||
-                          sanitizeHandle(post.author.handle),
-                      )}
-                    </Text>
-                  </Link>
-                </View>
+                <Link
+                  style={styles.metaItem}
+                  href={authorHref}
+                  title={authorTitle}>
+                  <Text
+                    type="xl-bold"
+                    style={[pal.text]}
+                    numberOfLines={1}
+                    lineHeight={1.2}>
+                    {sanitizeDisplayName(
+                      post.author.displayName ||
+                        sanitizeHandle(post.author.handle),
+                    )}
+                  </Text>
+                </Link>
               </View>
               <View style={styles.meta}>
                 {isAuthorMuted && (
@@ -621,7 +617,6 @@ function PostOuterWrapper({
 }>) {
   const {isMobile} = useWebMediaQueries()
   const pal = usePalette('default')
-  const styles = useStyles()
   if (treeView && depth > 0) {
     return (
       <View
@@ -698,92 +693,88 @@ function ExpandedPostDetails({
   )
 }
 
-const useStyles = () => {
-  const {isTabletOrDesktop} = useWebMediaQueries()
-  return StyleSheet.create({
-    outer: {
-      borderTopWidth: 1,
-      paddingLeft: 8,
-    },
-    outerHighlighted: {
-      paddingTop: 16,
-      paddingLeft: 8,
-      paddingRight: 8,
-    },
-    noTopBorder: {
-      borderTopWidth: 0,
-    },
-    layout: {
-      flexDirection: 'row',
-      paddingHorizontal: 8,
-    },
-    layoutAvi: {},
-    layoutContent: {
-      flex: 1,
-      marginLeft: 10,
-    },
-    meta: {
-      flexDirection: 'row',
-      paddingTop: 2,
-      paddingBottom: 2,
-    },
-    metaExpandedLine1: {
-      paddingTop: 0,
-      paddingBottom: 0,
-    },
-    metaItem: {
-      maxWidth: isTabletOrDesktop ? 380 : 220,
-    },
-    alert: {
-      marginBottom: 6,
-    },
-    postTextContainer: {
-      flexDirection: 'row',
-      alignItems: 'center',
-      flexWrap: 'wrap',
-      paddingBottom: 4,
-      paddingRight: 10,
-    },
-    postTextLargeContainer: {
-      paddingHorizontal: 0,
-      paddingRight: 0,
-      paddingBottom: 10,
-    },
-    translateLink: {
-      marginBottom: 6,
-    },
-    contentHider: {
-      marginBottom: 6,
-    },
-    contentHiderChild: {
-      marginTop: 6,
-    },
-    expandedInfo: {
-      flexDirection: 'row',
-      padding: 10,
-      borderTopWidth: 1,
-      borderBottomWidth: 1,
-      marginTop: 5,
-      marginBottom: 15,
-    },
-    expandedInfoItem: {
-      marginRight: 10,
-    },
-    loadMore: {
-      flexDirection: 'row',
-      alignItems: 'center',
-      justifyContent: 'flex-start',
-      gap: 4,
-      paddingHorizontal: 20,
-    },
-    replyLine: {
-      width: 2,
-      marginLeft: 'auto',
-      marginRight: 'auto',
-    },
-    cursor: {
-      // @ts-ignore web only
-      cursor: 'pointer',
-    },
-  })
-}
+const styles = StyleSheet.create({
+  outer: {
+    borderTopWidth: 1,
+    paddingLeft: 8,
+  },
+  outerHighlighted: {
+    paddingTop: 16,
+    paddingLeft: 8,
+    paddingRight: 8,
+  },
+  noTopBorder: {
+    borderTopWidth: 0,
+  },
+  layout: {
+    flexDirection: 'row',
+    paddingHorizontal: 8,
+  },
+  layoutAvi: {},
+  layoutContent: {
+    flex: 1,
+    marginLeft: 10,
+  },
+  meta: {
+    flexDirection: 'row',
+    paddingVertical: 2,
+  },
+  metaExpandedLine1: {
+    paddingVertical: 0,
+  },
+  metaItem: {
+    flex: 1,
+    paddingRight: 20,
+  },
+  alert: {
+    marginBottom: 6,
+  },
+  postTextContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+    paddingBottom: 4,
+    paddingRight: 10,
+  },
+  postTextLargeContainer: {
+    paddingHorizontal: 0,
+    paddingRight: 0,
+    paddingBottom: 10,
+  },
+  translateLink: {
+    marginBottom: 6,
+  },
+  contentHider: {
+    marginBottom: 6,
+  },
+  contentHiderChild: {
+    marginTop: 6,
+  },
+  expandedInfo: {
+    flexDirection: 'row',
+    padding: 10,
+    borderTopWidth: 1,
+    borderBottomWidth: 1,
+    marginTop: 5,
+    marginBottom: 15,
+  },
+  expandedInfoItem: {
+    marginRight: 10,
+  },
+  loadMore: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'flex-start',
+    gap: 4,
+    paddingHorizontal: 20,
+  },
+  replyLine: {
+    width: 2,
+    marginLeft: 'auto',
+    marginRight: 'auto',
+  },
+  cursor: {
+    // @ts-ignore web only
+    cursor: 'pointer',
+  },
+})

--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -31,7 +31,6 @@ import {PostSandboxWarning} from '../util/PostSandboxWarning'
 import {ErrorMessage} from '../util/error/ErrorMessage'
 import {usePalette} from 'lib/hooks/usePalette'
 import {formatCount} from '../util/numeric/format'
-import {TimeElapsed} from 'view/com/util/TimeElapsed'
 import {makeProfileLink} from 'lib/routes/links'
 import {useWebMediaQueries} from 'lib/hooks/useWebMediaQueries'
 import {MAX_POST_LINES} from 'lib/constants'
@@ -281,16 +280,6 @@ let PostThreadItemLoaded = ({
                       )}
                     </Text>
                   </Link>
-                  <TimeElapsed timestamp={post.indexedAt}>
-                    {({timeElapsed}) => (
-                      <Text
-                        type="md"
-                        style={[styles.metaItem, pal.textLight]}
-                        title={niceDate(post.indexedAt)}>
-                        &middot;&nbsp;{timeElapsed}
-                      </Text>
-                    )}
-                  </TimeElapsed>
                 </View>
               </View>
               <View style={styles.meta}>
@@ -710,7 +699,7 @@ function ExpandedPostDetails({
 }
 
 const useStyles = () => {
-  const {isDesktop} = useWebMediaQueries()
+  const {isTabletOrDesktop} = useWebMediaQueries()
   return StyleSheet.create({
     outer: {
       borderTopWidth: 1,
@@ -726,13 +715,12 @@ const useStyles = () => {
     },
     layout: {
       flexDirection: 'row',
-      gap: 10,
-      paddingLeft: 8,
+      paddingHorizontal: 8,
     },
     layoutAvi: {},
     layoutContent: {
       flex: 1,
-      paddingRight: 10,
+      marginLeft: 10,
     },
     meta: {
       flexDirection: 'row',
@@ -744,8 +732,7 @@ const useStyles = () => {
       paddingBottom: 0,
     },
     metaItem: {
-      paddingRight: 5,
-      maxWidth: isDesktop ? 380 : 220,
+      maxWidth: isTabletOrDesktop ? 380 : 220,
     },
     alert: {
       marginBottom: 6,

--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -9,6 +9,7 @@ import {
 } from '@atproto/api'
 import {moderatePost_wrapped as moderatePost} from '#/lib/moderatePost_wrapped'
 import {FontAwesomeIcon} from '@fortawesome/react-native-fontawesome'
+import {PostThreadFollowBtn} from 'view/com/post-thread/PostThreadFollowBtn'
 import {Link, TextLink} from '../util/Link'
 import {RichText} from '../util/text/RichText'
 import {Text} from '../util/text/Text'
@@ -42,6 +43,7 @@ import {useModerationOpts} from '#/state/queries/preferences'
 import {useOpenLink} from '#/state/preferences/in-app-browser'
 import {Shadow, usePostShadow, POST_TOMBSTONE} from '#/state/cache/post-shadow'
 import {ThreadPost} from '#/state/queries/post-thread'
+import {useSession} from 'state/session'
 import {WhoCanReply} from '../threadgate/WhoCanReply'
 
 export function PostThreadItem({
@@ -164,6 +166,7 @@ let PostThreadItemLoaded = ({
     () => countLines(richText?.text) >= MAX_POST_LINES,
   )
   const styles = useStyles()
+  const {currentAccount} = useSession()
   const hasEngagement = post.likeCount || post.repostCount
 
   const rootUri = record.reply?.root?.uri || post.uri
@@ -249,7 +252,7 @@ let PostThreadItemLoaded = ({
           style={[styles.outer, styles.outerHighlighted, pal.border, pal.view]}
           accessible={false}>
           <PostSandboxWarning />
-          <View style={styles.layout}>
+          <View style={[styles.layout]}>
             <View style={[styles.layoutAvi, {paddingBottom: 8}]}>
               <PreviewableUserAvatar
                 size={42}
@@ -325,6 +328,9 @@ let PostThreadItemLoaded = ({
                 </Link>
               </View>
             </View>
+            {currentAccount?.did !== post.author.did && (
+              <PostThreadFollowBtn did={post.author.did} />
+            )}
           </View>
           <View style={[s.pl10, s.pr10, s.pb10]}>
             <ContentHider

--- a/src/view/icons/index.tsx
+++ b/src/view/icons/index.tsx
@@ -97,6 +97,7 @@ import {faUsers} from '@fortawesome/free-solid-svg-icons/faUsers'
 import {faUserCheck} from '@fortawesome/free-solid-svg-icons/faUserCheck'
 import {faUserSlash} from '@fortawesome/free-solid-svg-icons/faUserSlash'
 import {faUserPlus} from '@fortawesome/free-solid-svg-icons/faUserPlus'
+import {faUserMinus} from '@fortawesome/free-solid-svg-icons/faUserMinus'
 import {faUserXmark} from '@fortawesome/free-solid-svg-icons/faUserXmark'
 import {faUsersSlash} from '@fortawesome/free-solid-svg-icons/faUsersSlash'
 import {faX} from '@fortawesome/free-solid-svg-icons/faX'
@@ -198,6 +199,7 @@ library.add(
   faUserCheck,
   faUserSlash,
   faUserPlus,
+  faUserMinus,
   faUserXmark,
   faUsersSlash,
   faThumbtack,

--- a/src/view/icons/index.tsx
+++ b/src/view/icons/index.tsx
@@ -97,7 +97,6 @@ import {faUsers} from '@fortawesome/free-solid-svg-icons/faUsers'
 import {faUserCheck} from '@fortawesome/free-solid-svg-icons/faUserCheck'
 import {faUserSlash} from '@fortawesome/free-solid-svg-icons/faUserSlash'
 import {faUserPlus} from '@fortawesome/free-solid-svg-icons/faUserPlus'
-import {faUserMinus} from '@fortawesome/free-solid-svg-icons/faUserMinus'
 import {faUserXmark} from '@fortawesome/free-solid-svg-icons/faUserXmark'
 import {faUsersSlash} from '@fortawesome/free-solid-svg-icons/faUsersSlash'
 import {faX} from '@fortawesome/free-solid-svg-icons/faX'
@@ -199,7 +198,6 @@ library.add(
   faUserCheck,
   faUserSlash,
   faUserPlus,
-  faUserMinus,
   faUserXmark,
   faUsersSlash,
   faThumbtack,


### PR DESCRIPTION
Doing some modifications on the highlighted post.

1. Adding a follow button
  - Button is initially visible if the user is not being followed.
  - The button stays visible even after the user is followed until the user leaves the screen
  - The button will be removed/added both on blur and on focus, so it will maintain visibility with the `viewer` in the profile's shadow
2. Remove the `TimeElappsed` from the highlighted post. We are displaying the timestamp below, and having this there is hindering us having the button there. This is the common behavior in other apps as well.
3. Removing static width on the display name and handle. We flex these properly now so that they take up the full line instead of being truncated. This prevents  some issues that we were seeing with longer display names (especially whenever using larger font sizes)

https://github.com/bluesky-social/social-app/assets/153161762/55be7ef1-4ae7-4abf-ac3c-988b8a8a6ed7
