### PR TITLE
Increase stroke width for active hashtag icon in left nav

### DIFF
--- a/src/view/shell/desktop/LeftNav.tsx
+++ b/src/view/shell/desktop/LeftNav.tsx
@@ -334,7 +334,7 @@ export function DesktopLeftNav() {
             }
             iconFilled={
               <HashtagIcon
-                strokeWidth={2.5}
+                strokeWidth={4}
                 style={pal.text as FontAwesomeIconStyle}
                 size={isDesktop ? 24 : 28}
               />


### PR DESCRIPTION
HashtagIcon's active state behaviour seems to generally be to increase the stroke width from 2.25 to 4 in most places, but in the left nav it was left as 2.25, so there was effectively no active state. This fixes that.