### PR TITLE
Update `blueskyweb.xyz` links to `bsky.social`

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Get the app itself:
 
 - **Web: [bsky.app](https://bsky.app)**
 - **iOS: [App Store](https://apps.apple.com/us/app/bluesky-social/id6444370199)**
-- **Android: [Play Store](https://play.google.com/store/apps/details?id=xyz.blueskyweb.app&hl=en_US&gl=US)**
+- **Android: [Play Store](https://play.google.com/store/apps/details?id=xyz.blueskyweb.app)**
 
 ## Development Resources
 
@@ -21,7 +21,7 @@ The Authenticated Transfer Protocol ("AT Protocol" or "atproto") is a decentrali
 - [Overview and Guides](https://atproto.com/guides/overview)
 - [Github Discussions](https://github.com/bluesky-social/atproto/discussions) 👈 Great place to ask questions
 - [Protocol Specifications](https://atproto.com/specs/atp)
-- [Blogpost on self-authenticating data structures](https://blueskyweb.xyz/blog/3-6-2022-a-self-authenticating-social-protocol)
+- [Blogpost on self-authenticating data structures](https://bsky.social/about/blog/3-6-2022-a-self-authenticating-social-protocol)
 
 The Bluesky Social application encompasses a set of schemas and APIs built in the overall AT Protocol framework. The namespace for these "Lexicons" is `app.bsky.*`.
 

--- a/bskyweb/templates/base.html
+++ b/bskyweb/templates/base.html
@@ -219,7 +219,7 @@
     <noscript>
       <h1 lang="en">JavaScript Required</h1>
       <p lang="en">This is a heavily interactive web application, and JavaScript is required. Simple HTML interfaces are possible, but that is not what this is.
-      <p lang="en">Learn more about Bluesky at <a href="https://blueskyweb.xyz">blueskyweb.xyz</a> and <a href="https://atproto.com">atproto.com</a>.
+      <p lang="en">Learn more about Bluesky at <a href="https://bsky.social">bsky.social</a> and <a href="https://atproto.com">atproto.com</a>.
 			{% block noscript_extra %}{% endblock %}
     </noscript>
 {% endblock -%}

--- a/src/view/com/auth/HomeLoggedOutCTA.tsx
+++ b/src/view/com/auth/HomeLoggedOutCTA.tsx
@@ -83,19 +83,19 @@ export function HomeLoggedOutCTA() {
       <View style={[styles.footer, pal.view, pal.border]}>
         <TextLink
           type="2xl"
-          href="https://blueskyweb.xyz"
+          href="https://bsky.social"
           text={_(msg`Business`)}
           style={[styles.footerLink, pal.link]}
         />
         <TextLink
           type="2xl"
-          href="https://blueskyweb.xyz/blog"
+          href="https://bsky.social/about/blog"
           text={_(msg`Blog`)}
           style={[styles.footerLink, pal.link]}
         />
         <TextLink
           type="2xl"
-          href="https://blueskyweb.xyz/join"
+          href="https://bsky.social/about/join"
           text={_(msg`Jobs`)}
           style={[styles.footerLink, pal.link]}
         />

--- a/src/view/com/auth/SplashScreen.web.tsx
+++ b/src/view/com/auth/SplashScreen.web.tsx
@@ -102,17 +102,17 @@ function Footer({styles}: {styles: ReturnType<typeof useStyles>}) {
   return (
     <View style={[styles.footer, pal.view, pal.border]}>
       <TextLink
-        href="https://blueskyweb.xyz"
+        href="https://bsky.social"
         text="Business"
         style={[styles.footerLink, pal.link]}
       />
       <TextLink
-        href="https://blueskyweb.xyz/blog"
+        href="https://bsky.social/about/blog"
         text="Blog"
         style={[styles.footerLink, pal.link]}
       />
       <TextLink
-        href="https://blueskyweb.xyz/join"
+        href="https://bsky.social/about/join"
         text="Jobs"
         style={[styles.footerLink, pal.link]}
       />

--- a/src/view/com/modals/report/Modal.tsx
+++ b/src/view/com/modals/report/Modal.tsx
@@ -18,7 +18,7 @@ import {useLingui} from '@lingui/react'
 import {useModalControls} from '#/state/modals'
 import {getAgent} from '#/state/session'
 
-const DMCA_LINK = 'https://blueskyweb.xyz/support/copyright'
+const DMCA_LINK = 'https://bsky.social/about/support/copyright'
 
 export const snapPoints = [575]
 

--- a/src/view/screens/CommunityGuidelines.tsx
+++ b/src/view/screens/CommunityGuidelines.tsx
@@ -37,8 +37,8 @@ export const CommunityGuidelinesScreen = (_props: Props) => {
               The Community Guidelines have been moved to{' '}
               <TextLink
                 style={pal.link}
-                href="https://blueskyweb.xyz/support/community-guidelines"
-                text="blueskyweb.xyz/support/community-guidelines"
+                href="https://bsky.social/about/support/community-guidelines"
+                text="bsky.social/about/support/community-guidelines"
               />
             </Trans>
           </Text>

--- a/src/view/screens/CopyrightPolicy.tsx
+++ b/src/view/screens/CopyrightPolicy.tsx
@@ -34,8 +34,8 @@ export const CopyrightPolicyScreen = (_props: Props) => {
               The Copyright Policy has been moved to{' '}
               <TextLink
                 style={pal.link}
-                href="https://blueskyweb.xyz/support/community-guidelines"
-                text="blueskyweb.xyz/support/community-guidelines"
+                href="https://bsky.social/about/support/copyright"
+                text="bsky.social/about/support/copyright"
               />
             </Trans>
           </Text>

--- a/src/view/screens/PrivacyPolicy.tsx
+++ b/src/view/screens/PrivacyPolicy.tsx
@@ -34,8 +34,8 @@ export const PrivacyPolicyScreen = (_props: Props) => {
               The Privacy Policy has been moved to{' '}
               <TextLink
                 style={pal.link}
-                href="https://blueskyweb.xyz/support/privacy-policy"
-                text="blueskyweb.xyz/support/privacy-policy"
+                href="https://bsky.social/about/support/privacy-policy"
+                text="bsky.social/about/support/privacy-policy"
               />
             </Trans>
           </Text>

--- a/src/view/screens/Settings.tsx
+++ b/src/view/screens/Settings.tsx
@@ -863,13 +863,13 @@ export function SettingsScreen({}: Props) {
           <TextLink
             type="md"
             style={pal.link}
-            href="https://blueskyweb.xyz/support/tos"
+            href="https://bsky.social/about/support/tos"
             text={_(msg`Terms of Service`)}
           />
           <TextLink
             type="md"
             style={pal.link}
-            href="https://blueskyweb.xyz/support/privacy-policy"
+            href="https://bsky.social/about/support/privacy-policy"
             text={_(msg`Privacy Policy`)}
           />
         </View>

--- a/src/view/screens/Storybook/Links.tsx
+++ b/src/view/screens/Storybook/Links.tsx
@@ -14,19 +14,19 @@ export function Links() {
 
       <View style={[a.gap_md, a.align_start]}>
         <InlineLink
-          to="https://blueskyweb.xyz"
+          to="https://bsky.social"
           warnOnMismatchingTextChild
           style={[a.text_md]}>
           External
         </InlineLink>
-        <InlineLink to="https://blueskyweb.xyz" style={[a.text_md]}>
+        <InlineLink to="https://bsky.social" style={[a.text_md]}>
           <H3>External with custom children</H3>
         </InlineLink>
         <InlineLink
-          to="https://blueskyweb.xyz"
+          to="https://bsky.social"
           warnOnMismatchingTextChild
           style={[a.text_lg]}>
-          https://blueskyweb.xyz
+          https://bsky.social
         </InlineLink>
         <InlineLink
           to="https://bsky.app/profile/bsky.app"

--- a/src/view/screens/Storybook/Typography.tsx
+++ b/src/view/screens/Storybook/Typography.tsx
@@ -21,11 +21,11 @@ export function Typography() {
 
       <RichText
         resolveFacets
-        value={`This is rich text. It can have mentions like @bsky.app or links like https://blueskyweb.xyz`}
+        value={`This is rich text. It can have mentions like @bsky.app or links like https://bsky.social`}
       />
       <RichText
         resolveFacets
-        value={`This is rich text. It can have mentions like @bsky.app or links like https://blueskyweb.xyz`}
+        value={`This is rich text. It can have mentions like @bsky.app or links like https://bsky.social`}
         style={[a.text_xl]}
       />
     </View>

--- a/src/view/screens/TermsOfService.tsx
+++ b/src/view/screens/TermsOfService.tsx
@@ -33,8 +33,8 @@ export const TermsOfServiceScreen = (_props: Props) => {
             <Trans>The Terms of Service have been moved to</Trans>{' '}
             <TextLink
               style={pal.link}
-              href="https://blueskyweb.xyz/support/tos"
-              text="blueskyweb.xyz/support/tos"
+              href="https://bsky.social/about/support/tos"
+              text="bsky.social/about/support/tos"
             />
           </Text>
         </View>

--- a/src/view/shell/Drawer.tsx
+++ b/src/view/shell/Drawer.tsx
@@ -255,13 +255,13 @@ let DrawerContent = ({}: {}): React.ReactNode => {
             <TextLink
               type="md"
               style={pal.link}
-              href="https://blueskyweb.xyz/support/tos"
+              href="https://bsky.social/about/support/tos"
               text={_(msg`Terms of Service`)}
             />
             <TextLink
               type="md"
               style={pal.link}
-              href="https://blueskyweb.xyz/support/privacy-policy"
+              href="https://bsky.social/about/support/privacy-policy"
               text={_(msg`Privacy Policy`)}
             />
           </View>

--- a/src/view/shell/desktop/RightNav.tsx
+++ b/src/view/shell/desktop/RightNav.tsx
@@ -80,7 +80,7 @@ export function DesktopRightNav({routeName}: {routeName: string}) {
             <TextLink
               type="md"
               style={pal.link}
-              href="https://blueskyweb.xyz/support/privacy-policy"
+              href="https://bsky.social/about/support/privacy-policy"
               text={_(msg`Privacy`)}
             />
             <Text type="md" style={pal.textLight}>
@@ -89,7 +89,7 @@ export function DesktopRightNav({routeName}: {routeName: string}) {
             <TextLink
               type="md"
               style={pal.link}
-              href="https://blueskyweb.xyz/support/tos"
+              href="https://bsky.social/about/support/tos"
               text={_(msg`Terms`)}
             />
             <Text type="md" style={pal.textLight}>


### PR DESCRIPTION
This PR updates links to `blueskyweb.xyz` found in various places to the equivalent URLs on `bsky.social`.

It makes two other minor changes:

- The superfluous localisation parameters at the end of the Play Store link in README.md are removed.
- The link in `CopyrightPolicy.tsx` which currently points to the Community Guidelines has been changed to point directly to the Copyright Policy (which I'm assuming is the intended location?)

This PR does not, of course, make any changes to any references to `blueskyweb.xyz` relating to how the app is identified for the purposes of the app stores etc.