### PR TITLE
Allow removing user lists from saved feeds

### DIFF
--- a/src/view/com/feeds/FeedSourceCard.tsx
+++ b/src/view/com/feeds/FeedSourceCard.tsx
@@ -96,8 +96,7 @@ export function FeedSourceCardLoaded({
   const isSaved = Boolean(preferences?.feeds?.saved?.includes(feed?.uri || ''))
 
   const onToggleSaved = React.useCallback(async () => {
-    // Only feeds can be un/saved, lists are handled elsewhere
-    if (feed?.type !== 'feed') return
+    if (!feed) return
 
     if (isSaved) {
       openModal({
@@ -233,7 +232,7 @@ export function FeedSourceCardLoaded({
           </Text>
         </View>
 
-        {showSaveBtn && feed.type === 'feed' && (
+        {showSaveBtn && (
           <View style={[s.justifyCenter]}>
             <Pressable
               testID={`feed-${feed.displayName}-toggleSave`}


### PR DESCRIPTION
Contrary to the comment, the lists doesn't seem to be handled elsewhere. This is preventing me from removing user lists from saved feeds because the list header only has an option to pin/unpin, not save/unsave. (I'd address that separately, it seems weird given that feeds has the option for both)

I checked, it seems to be working as expected for lists (shouldn't be any different since we're just adding/removing URIs to an array)