### PR TITLE
Allow saving user lists without pinning

### DIFF
--- a/src/view/screens/ProfileList.tsx
+++ b/src/view/screens/ProfileList.tsx
@@ -491,12 +491,12 @@ function Header({rkey, list}: {rkey: string; list: AppBskyGraphDefs.ListView}) {
         },
       })
     }
-    if (isModList && isPinned) {
+    if (isModList && isSaved) {
       items.push({label: 'separator'})
       items.push({
         testID: 'listHeaderDropdownUnpinBtn',
-        label: _(msg`Unpin moderation list`),
-        onPress: isPinning ? undefined : () => unpinFeed({uri: list.uri}),
+        label: _(msg`Unsave moderation list`),
+        onPress: isSaving ? undefined : () => removeFeed({uri: list.uri}),
         icon: {
           ios: {
             name: 'pin',
@@ -548,9 +548,9 @@ function Header({rkey, list}: {rkey: string; list: AppBskyGraphDefs.ListView}) {
     onPressReport,
     _,
     isModList,
-    isPinned,
-    unpinFeed,
-    isPinning,
+    isSaved,
+    isSaving,
+    removeFeed,
     list.uri,
     isCurateList,
     isMuting,

--- a/src/view/screens/ProfileList.tsx
+++ b/src/view/screens/ProfileList.tsx
@@ -260,8 +260,12 @@ function Header({rkey, list}: {rkey: string; list: AppBskyGraphDefs.ListView}) {
   const {mutate: setSavedFeeds} = useSetSaveFeedsMutation()
   const {track} = useAnalytics()
 
-  const isPinned = preferences?.feeds?.pinned?.includes(list.uri)
-  const isSaved = preferences?.feeds?.saved?.includes(list.uri)
+  const isPinned =
+    isPinPending ||
+    (!isUnpinPending && preferences?.feeds?.pinned?.includes(list.uri))
+  const isSaved =
+    isSavePending ||
+    (!isRemovePending && preferences?.feeds?.saved?.includes(list.uri))
 
   const onToggleSaved = React.useCallback(async () => {
     Haptics.default()

--- a/src/view/screens/ProfileList.tsx
+++ b/src/view/screens/ProfileList.tsx
@@ -608,6 +608,7 @@ function Header({rkey, list}: {rkey: string; list: AppBskyGraphDefs.ListView}) {
           label={isSaved ? _(msg`Unsave`) : _(msg`Save`)}
           onPress={onToggleSaved}
           disabled={isSaving}
+          style={styles.btn}
         />
       )}
       {isCurateList && (
@@ -617,6 +618,7 @@ function Header({rkey, list}: {rkey: string; list: AppBskyGraphDefs.ListView}) {
           label={isPinned ? _(msg`Unpin`) : _(msg`Pin to home`)}
           onPress={onTogglePinned}
           disabled={isPinning}
+          style={styles.btn}
         />
       )}
       {isModList && !isSaved ? (
@@ -626,6 +628,7 @@ function Header({rkey, list}: {rkey: string; list: AppBskyGraphDefs.ListView}) {
             type="default"
             label={_(msg`Unblock`)}
             onPress={onUnsubscribeBlock}
+            style={styles.btn}
           />
         ) : isMuting ? (
           <Button
@@ -633,6 +636,7 @@ function Header({rkey, list}: {rkey: string; list: AppBskyGraphDefs.ListView}) {
             type="default"
             label={_(msg`Unmute`)}
             onPress={onUnsubscribeMute}
+            style={styles.btn}
           />
         ) : (
           <NativeDropdown


### PR DESCRIPTION
Pull request makes the following changes

- Adds the ability to save user lists without pinning
- Drive-by change to allow removing moderation lists from saved feeds instead of just unpinning it
- Have the buttons make use of the button styles it's supposed to use