### PR TITLE
Change old `blueskyweb.xyz` links to `bsky.social` links

### DIFF
--- a/src/view/screens/CommunityGuidelines.tsx
+++ b/src/view/screens/CommunityGuidelines.tsx
@@ -37,8 +37,8 @@ export const CommunityGuidelinesScreen = (_props: Props) => {
               The Community Guidelines have been moved to{' '}
               <TextLink
                 style={pal.link}
-                href="https://blueskyweb.xyz/support/community-guidelines"
-                text="blueskyweb.xyz/support/community-guidelines"
+                href="https://bsky.social/about/support/community-guidelines"
+                text="bsky.social/about/support/community-guidelines"
               />
             </Trans>
           </Text>

--- a/src/view/screens/CopyrightPolicy.tsx
+++ b/src/view/screens/CopyrightPolicy.tsx
@@ -34,8 +34,8 @@ export const CopyrightPolicyScreen = (_props: Props) => {
               The Copyright Policy has been moved to{' '}
               <TextLink
                 style={pal.link}
-                href="https://blueskyweb.xyz/support/community-guidelines"
-                text="blueskyweb.xyz/support/community-guidelines"
+                href="https://bsky.social/about/support/community-guidelines"
+                text="bsky.social/about/support/community-guidelines"
               />
             </Trans>
           </Text>

--- a/src/view/screens/PrivacyPolicy.tsx
+++ b/src/view/screens/PrivacyPolicy.tsx
@@ -34,8 +34,8 @@ export const PrivacyPolicyScreen = (_props: Props) => {
               The Privacy Policy has been moved to{' '}
               <TextLink
                 style={pal.link}
-                href="https://blueskyweb.xyz/support/privacy-policy"
-                text="blueskyweb.xyz/support/privacy-policy"
+                href="https://bsky.social/about/support/privacy-policy"
+                text="bsky.social/about/support/privacy-policy"
               />
             </Trans>
           </Text>

--- a/src/view/screens/Settings.tsx
+++ b/src/view/screens/Settings.tsx
@@ -863,13 +863,13 @@ export function SettingsScreen({}: Props) {
           <TextLink
             type="md"
             style={pal.link}
-            href="https://blueskyweb.xyz/support/tos"
+            href="https://bsky.social/about/support/tos"
             text={_(msg`Terms of Service`)}
           />
           <TextLink
             type="md"
             style={pal.link}
-            href="https://blueskyweb.xyz/support/privacy-policy"
+            href="https://bsky.social/about/support/privacy-policy"
             text={_(msg`Privacy Policy`)}
           />
         </View>

--- a/src/view/screens/TermsOfService.tsx
+++ b/src/view/screens/TermsOfService.tsx
@@ -33,8 +33,8 @@ export const TermsOfServiceScreen = (_props: Props) => {
             <Trans>The Terms of Service have been moved to</Trans>{' '}
             <TextLink
               style={pal.link}
-              href="https://blueskyweb.xyz/support/tos"
-              text="blueskyweb.xyz/support/tos"
+              href="https://bsky.social/about/support/tos"
+              text="bsky.social/about/support/tos"
             />
           </Text>
         </View>


### PR DESCRIPTION
This PR fixes links to important articles, such as the Terms of Service, Privacy Policy, and the Community Guidelines.