### PR TITLE
remove line height from text input for composer on ios

### DIFF
--- a/src/view/com/composer/text-input/TextInput.tsx
+++ b/src/view/com/composer/text-input/TextInput.tsx
@@ -28,6 +28,7 @@ import {useTheme} from 'lib/ThemeContext'
 import {isUriImage} from 'lib/media/util'
 import {downloadAndResize} from 'lib/media/manip'
 import {POST_IMG_MAX} from 'lib/constants'
+import {isIOS} from 'platform/detection'
 
 export interface TextInputRef {
   focus: () => void
@@ -252,5 +253,7 @@ const styles = StyleSheet.create({
     fontSize: 18,
     letterSpacing: 0.2,
     fontWeight: '400',
+    // This is broken on ios right now, so don't set it there.
+    lineHeight: isIOS ? undefined : 23.4, // 1.3*16
   },
 })

--- a/src/view/com/composer/text-input/TextInput.tsx
+++ b/src/view/com/composer/text-input/TextInput.tsx
@@ -252,6 +252,5 @@ const styles = StyleSheet.create({
     fontSize: 18,
     letterSpacing: 0.2,
     fontWeight: '400',
-    lineHeight: 23.4, // 1.3*16
   },
 })


### PR DESCRIPTION
Again addressing RN weirdness with line height in the text composer. This only applies on iOS, there are no visible issues on android using `lineHeight` styles.

The previous patch for this fixed the line height from causing the text to continue off the screen, however, it seems to have introduced a small movement on the first line of text. I think until RN merges a full fix for this the best option is to just not apply a line height on iOS.

Before and after:


https://github.com/bluesky-social/social-app/assets/153161762/48b67175-3838-43ae-aac9-fb3b75da1cc8

