### PR TITLE
pad right for treeview

### DIFF
--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -475,6 +475,7 @@ let PostThreadItemLoaded = ({
                       : 8,
                 },
               ]}>
+              {/* If we are in threaded mode, the avatar is rendered in PostMeta */}
               {!isThreadedChild && (
                 <View style={styles.layoutAvi}>
                   <PreviewableUserAvatar
@@ -502,7 +503,9 @@ let PostThreadItemLoaded = ({
 
               <View
                 style={
-                  treeView ? styles.layoutContentThreaded : styles.layoutContent
+                  isThreadedChild
+                    ? styles.layoutContentThreaded
+                    : styles.layoutContent
                 }>
                 <PostMeta
                   author={post.author}

--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -500,7 +500,10 @@ let PostThreadItemLoaded = ({
                 </View>
               )}
 
-              <View style={styles.layoutContent}>
+              <View
+                style={
+                  treeView ? styles.layoutContentThreaded : styles.layoutContent
+                }>
                 <PostMeta
                   author={post.author}
                   authorHasWarning={!!post.author.labels?.length}
@@ -708,6 +711,10 @@ const styles = StyleSheet.create({
   layoutContent: {
     flex: 1,
     marginLeft: 10,
+  },
+  layoutContentThreaded: {
+    flex: 1,
+    paddingRight: 10,
   },
   meta: {
     flexDirection: 'row',


### PR DESCRIPTION
Avatar is rendered inside of `PostMeta` in threaded mode so we don't want to apply the margin in that view.