### PR TITLE
Add language selection on splash screen

### DIFF
--- a/src/view/com/auth/SplashScreen.tsx
+++ b/src/view/com/auth/SplashScreen.tsx
@@ -9,6 +9,14 @@ import {Trans, msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 import {Logo} from '#/view/icons/Logo'
 import {Logotype} from '#/view/icons/Logotype'
+import {
+  FontAwesomeIcon,
+  FontAwesomeIconStyle,
+} from '@fortawesome/react-native-fontawesome'
+import RNPickerSelect, {PickerSelectProps} from 'react-native-picker-select'
+import {sanitizeAppLanguageSetting} from '#/locale/helpers'
+import {useLanguagePrefs, useLanguagePrefsApi} from '#/state/preferences'
+import {APP_LANGUAGES} from '#/locale/languages'
 
 export const SplashScreen = ({
   onPressSignin,
@@ -19,6 +27,21 @@ export const SplashScreen = ({
 }) => {
   const pal = usePalette('default')
   const {_} = useLingui()
+
+  const langPrefs = useLanguagePrefs()
+  const setLangPrefs = useLanguagePrefsApi()
+
+  const sanitizedLang = sanitizeAppLanguageSetting(langPrefs.appLanguage)
+
+  const onChangeAppLanguage = React.useCallback(
+    (value: Parameters<PickerSelectProps['onValueChange']>[0]) => {
+      if (!value) return
+      if (sanitizedLang !== value) {
+        setLangPrefs.setAppLanguage(sanitizeAppLanguageSetting(value))
+      }
+    },
+    [sanitizedLang, setLangPrefs],
+  )
 
   return (
     <CenteredView style={[styles.container, pal.view]}>
@@ -58,6 +81,51 @@ export const SplashScreen = ({
             </Text>
           </TouchableOpacity>
         </View>
+        <View style={styles.footer}>
+          <View style={{position: 'relative'}}>
+            <RNPickerSelect
+              placeholder={{}}
+              value={sanitizedLang}
+              onValueChange={onChangeAppLanguage}
+              items={APP_LANGUAGES.filter(l => Boolean(l.code2)).map(l => ({
+                label: l.name,
+                value: l.code2,
+                key: l.code2,
+              }))}
+              useNativeAndroidPickerStyle={false}
+              style={{
+                inputAndroid: {
+                  color: pal.textLight.color,
+                  fontSize: 16,
+                  paddingRight: 10 + 4,
+                },
+                inputIOS: {
+                  color: pal.text.color,
+                  fontSize: 14,
+                  paddingRight: 10 + 4,
+                },
+              }}
+            />
+
+            <View
+              style={{
+                position: 'absolute',
+                top: 0,
+                right: 0,
+                bottom: 0,
+                width: 10,
+                pointerEvents: 'none',
+                alignItems: 'center',
+                justifyContent: 'center',
+              }}>
+              <FontAwesomeIcon
+                icon="chevron-down"
+                size={10}
+                style={pal.textLight as FontAwesomeIconStyle}
+              />
+            </View>
+          </View>
+        </View>
       </ErrorBoundary>
     </CenteredView>
   )
@@ -73,7 +141,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   btns: {
-    paddingBottom: 40,
+    paddingBottom: 0,
   },
   title: {
     textAlign: 'center',
@@ -94,5 +162,11 @@ const styles = StyleSheet.create({
   btnLabel: {
     textAlign: 'center',
     fontSize: 21,
+  },
+  footer: {
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    justifyContent: 'center',
+    alignItems: 'center',
   },
 })

--- a/src/view/com/auth/SplashScreen.tsx
+++ b/src/view/com/auth/SplashScreen.tsx
@@ -101,7 +101,7 @@ export const SplashScreen = ({
                 },
                 inputIOS: {
                   color: pal.text.color,
-                  fontSize: 14,
+                  fontSize: 16,
                   paddingRight: 10 + 4,
                 },
               }}
@@ -113,7 +113,6 @@ export const SplashScreen = ({
                 top: 0,
                 right: 0,
                 bottom: 0,
-                width: 10,
                 pointerEvents: 'none',
                 alignItems: 'center',
                 justifyContent: 'center',

--- a/src/view/com/auth/SplashScreen.web.tsx
+++ b/src/view/com/auth/SplashScreen.web.tsx
@@ -9,9 +9,10 @@ import {usePalette} from 'lib/hooks/usePalette'
 import {CenteredView} from '../util/Views'
 import {isWeb} from 'platform/detection'
 import {useWebMediaQueries} from 'lib/hooks/useWebMediaQueries'
-import {Trans} from '@lingui/macro'
+import {Trans, msg} from '@lingui/macro'
 import {Logo} from '#/view/icons/Logo'
 import {Logotype} from '#/view/icons/Logotype'
+import {useLingui} from '@lingui/react'
 
 export const SplashScreen = ({
   onDismiss,
@@ -98,22 +99,23 @@ export const SplashScreen = ({
 
 function Footer({styles}: {styles: ReturnType<typeof useStyles>}) {
   const pal = usePalette('default')
+  const {_} = useLingui()
 
   return (
     <View style={[styles.footer, pal.view, pal.border]}>
       <TextLink
         href="https://bsky.social"
-        text="Business"
+        text={_(msg`Business`)}
         style={[styles.footerLink, pal.link]}
       />
       <TextLink
         href="https://bsky.social/about/blog"
-        text="Blog"
+        text={_(msg`Blog`)}
         style={[styles.footerLink, pal.link]}
       />
       <TextLink
         href="https://bsky.social/about/join"
-        text="Jobs"
+        text={_(msg`Jobs`)}
         style={[styles.footerLink, pal.link]}
       />
     </View>

--- a/src/view/com/auth/SplashScreen.web.tsx
+++ b/src/view/com/auth/SplashScreen.web.tsx
@@ -153,7 +153,8 @@ function Footer({styles}: {styles: ReturnType<typeof useStyles>}) {
         </Text>
         <FontAwesomeIcon
           icon="chevron-down"
-          style={[pal.textLight, {width: 12, flexShrink: 0}]}
+          size={12}
+          style={[pal.textLight, {flexShrink: 0}]}
         />
 
         <select

--- a/src/view/com/auth/SplashScreen.web.tsx
+++ b/src/view/com/auth/SplashScreen.web.tsx
@@ -169,7 +169,6 @@ function Footer({styles}: {styles: ReturnType<typeof useStyles>}) {
             width: '100%',
             color: 'transparent',
             background: 'transparent',
-            outline: 0,
             border: 0,
             padding: 0,
           }}>

--- a/src/view/com/auth/SplashScreen.web.tsx
+++ b/src/view/com/auth/SplashScreen.web.tsx
@@ -13,6 +13,9 @@ import {Trans, msg} from '@lingui/macro'
 import {Logo} from '#/view/icons/Logo'
 import {Logotype} from '#/view/icons/Logotype'
 import {useLingui} from '@lingui/react'
+import {sanitizeAppLanguageSetting} from '#/locale/helpers'
+import {useLanguagePrefs, useLanguagePrefsApi} from '#/state/preferences'
+import {APP_LANGUAGES} from '#/locale/languages'
 
 export const SplashScreen = ({
   onDismiss,
@@ -101,6 +104,23 @@ function Footer({styles}: {styles: ReturnType<typeof useStyles>}) {
   const pal = usePalette('default')
   const {_} = useLingui()
 
+  const langPrefs = useLanguagePrefs()
+  const setLangPrefs = useLanguagePrefsApi()
+
+  const sanitizedLang = sanitizeAppLanguageSetting(langPrefs.appLanguage)
+
+  const onChangeAppLanguage = React.useCallback(
+    (ev: React.ChangeEvent<HTMLSelectElement>) => {
+      const value = ev.target.value
+
+      if (!value) return
+      if (sanitizedLang !== value) {
+        setLangPrefs.setAppLanguage(sanitizeAppLanguageSetting(value))
+      }
+    },
+    [sanitizedLang, setLangPrefs],
+  )
+
   return (
     <View style={[styles.footer, pal.view, pal.border]}>
       <TextLink
@@ -118,6 +138,48 @@ function Footer({styles}: {styles: ReturnType<typeof useStyles>}) {
         text={_(msg`Jobs`)}
         style={[styles.footerLink, pal.link]}
       />
+
+      <View style={styles.footerDivider} />
+
+      <View
+        style={{
+          flexDirection: 'row',
+          gap: 8,
+          alignItems: 'center',
+          flexShrink: 1,
+        }}>
+        <Text aria-hidden={true} style={[pal.textLight]}>
+          {APP_LANGUAGES.find(l => l.code2 === sanitizedLang)?.name}
+        </Text>
+        <FontAwesomeIcon
+          icon="chevron-down"
+          style={[pal.textLight, {width: 12, flexShrink: 0}]}
+        />
+
+        <select
+          value={sanitizedLang}
+          onChange={onChangeAppLanguage}
+          style={{
+            cursor: 'pointer',
+            MozAppearance: 'none',
+            WebkitAppearance: 'none',
+            appearance: 'none',
+            position: 'absolute',
+            inset: 0,
+            width: '100%',
+            color: 'transparent',
+            background: 'transparent',
+            outline: 0,
+            border: 0,
+            padding: 0,
+          }}>
+          {APP_LANGUAGES.filter(l => Boolean(l.code2)).map(l => (
+            <option key={l.code2} value={l.code2}>
+              {l.name}
+            </option>
+          ))}
+        </select>
+      </View>
     </View>
   )
 }
@@ -190,9 +252,10 @@ const useStyles = () => {
       padding: 20,
       borderTopWidth: 1,
       flexDirection: 'row',
+      flexWrap: 'wrap',
+      gap: 20,
     },
-    footerLink: {
-      marginRight: 20,
-    },
+    footerDivider: {flexGrow: 1},
+    footerLink: {},
   })
 }


### PR DESCRIPTION
This pull request adds language selection on the splash screen

Fixes https://github.com/bluesky-social/social-app/issues/2801

### Web

This took a bit of wrangling due to `<select>` auto-sizing to fit the longest-name option, we only want the input to fit the currently selected option instead.

| Viewport | English | Chinese (Simplified) |
| --- | --- | --- |
| Desktop | <img width=200 src=https://github.com/bluesky-social/social-app/assets/148872143/88bf3db8-e1a9-4025-8f34-9ad8a5ed62a9> | <img width=200 src=https://github.com/bluesky-social/social-app/assets/148872143/e2f57eb7-32ea-4306-bf53-1497d968674a> |
| Mobile | <img width=200 src=https://github.com/bluesky-social/social-app/assets/148872143/ff9c6416-620a-4ecb-b86f-4f01b509f227> | <img width=200 src=https://github.com/bluesky-social/social-app/assets/148872143/5c60303b-c509-45ba-a10a-a43a4e79f2ed> |

### Android

| English | Japanese |
| --- | --- |
| <img width=200 src=https://github.com/bluesky-social/social-app/assets/148872143/01fba9b9-04a8-4fd4-909c-088f77733eb9> | <img width=200 src=https://github.com/bluesky-social/social-app/assets/148872143/a3a910fe-2f74-4834-8c1c-e1c2ceb1cbed> |

### iOS

Untested due to lack of hardware
