### PR TITLE
Normalize relative day

### DIFF
--- a/src/lib/strings/time.ts
+++ b/src/lib/strings/time.ts
@@ -6,7 +6,7 @@ const MONTH = DAY * 28
 const YEAR = DAY * 365
 export function ago(time: number | string | Date): string {
   const base = new Date()
-  const date = time instanceof Date ? time : new Date(time)
+  const date = new Date(time)
 
   const diffSeconds = Math.floor((base.getTime() - date.getTime()) / 1e3)
 

--- a/src/lib/strings/time.ts
+++ b/src/lib/strings/time.ts
@@ -4,12 +4,16 @@ const HOUR = MINUTE * 60
 const DAY = HOUR * 24
 const MONTH = DAY * 28
 const YEAR = DAY * 365
-export function ago(time: number | string | Date): string {
-  const base = new Date()
-  const date = new Date(time)
-
-  const diffSeconds = Math.floor((base.getTime() - date.getTime()) / 1e3)
-
+export function ago(date: number | string | Date): string {
+  let ts: number
+  if (typeof date === 'string') {
+    ts = Number(new Date(date))
+  } else if (date instanceof Date) {
+    ts = Number(date)
+  } else {
+    ts = date
+  }
+  const diffSeconds = Math.floor((Date.now() - ts) / 1e3)
   if (diffSeconds < NOW) {
     return `now`
   } else if (diffSeconds < MINUTE) {
@@ -19,18 +23,11 @@ export function ago(time: number | string | Date): string {
   } else if (diffSeconds < DAY) {
     return `${Math.floor(diffSeconds / HOUR)}h`
   } else if (diffSeconds < MONTH) {
-    // normalize the time, this handles the following scenario:
-    // - 2024-02-13T09:00Z <- 2024-02-15T07:00Z = 2d (instead of 1d)
-    date.setHours(0, 0, 0, 0)
-    base.setHours(0, 0, 0, 0)
-
-    const normalizedDiff = (base.getTime() - date.getTime()) / 1e3
-
-    return `${Math.floor(normalizedDiff / DAY)}d`
+    return `${Math.round(diffSeconds / DAY)}d`
   } else if (diffSeconds < YEAR) {
     return `${Math.floor(diffSeconds / MONTH)}mo`
   } else {
-    return date.toLocaleDateString()
+    return new Date(ts).toLocaleDateString()
   }
 }
 

--- a/src/lib/strings/time.ts
+++ b/src/lib/strings/time.ts
@@ -24,7 +24,7 @@ export function ago(time: number | string | Date): string {
     date.setHours(0, 0, 0, 0)
     base.setHours(0, 0, 0, 0)
 
-    const normalizedDiff = Math.floor((base.getTime() - date.getTime()) / 1e3)
+    const normalizedDiff = (base.getTime() - date.getTime()) / 1e3
 
     return `${Math.floor(normalizedDiff / DAY)}d`
   } else if (diffSeconds < YEAR) {

--- a/src/lib/strings/time.ts
+++ b/src/lib/strings/time.ts
@@ -4,16 +4,12 @@ const HOUR = MINUTE * 60
 const DAY = HOUR * 24
 const MONTH = DAY * 28
 const YEAR = DAY * 365
-export function ago(date: number | string | Date): string {
-  let ts: number
-  if (typeof date === 'string') {
-    ts = Number(new Date(date))
-  } else if (date instanceof Date) {
-    ts = Number(date)
-  } else {
-    ts = date
-  }
-  const diffSeconds = Math.floor((Date.now() - ts) / 1e3)
+export function ago(time: number | string | Date): string {
+  const base = new Date()
+  const date = time instanceof Date ? time : new Date(time)
+
+  let diffSeconds = Math.floor((base.getTime() - date.getTime()) / 1e3)
+
   if (diffSeconds < NOW) {
     return `now`
   } else if (diffSeconds < MINUTE) {
@@ -23,11 +19,16 @@ export function ago(date: number | string | Date): string {
   } else if (diffSeconds < DAY) {
     return `${Math.floor(diffSeconds / HOUR)}h`
   } else if (diffSeconds < MONTH) {
-    return `${Math.floor(diffSeconds / DAY)}d`
+    date.setHours(0, 0, 0, 0)
+    base.setHours(0, 0, 0, 0)
+
+    const normalizedDiff = Math.floor((base.getTime() - date.getTime()) / 1e3)
+
+    return `${Math.floor(normalizedDiff / DAY)}d`
   } else if (diffSeconds < YEAR) {
     return `${Math.floor(diffSeconds / MONTH)}mo`
   } else {
-    return new Date(ts).toLocaleDateString()
+    return date.toLocaleDateString()
   }
 }
 

--- a/src/lib/strings/time.ts
+++ b/src/lib/strings/time.ts
@@ -8,7 +8,7 @@ export function ago(time: number | string | Date): string {
   const base = new Date()
   const date = time instanceof Date ? time : new Date(time)
 
-  let diffSeconds = Math.floor((base.getTime() - date.getTime()) / 1e3)
+  const diffSeconds = Math.floor((base.getTime() - date.getTime()) / 1e3)
 
   if (diffSeconds < NOW) {
     return `now`

--- a/src/lib/strings/time.ts
+++ b/src/lib/strings/time.ts
@@ -19,6 +19,8 @@ export function ago(time: number | string | Date): string {
   } else if (diffSeconds < DAY) {
     return `${Math.floor(diffSeconds / HOUR)}h`
   } else if (diffSeconds < MONTH) {
+    // normalize the time, this handles the following scenario:
+    // - 2024-02-13T09:00Z <- 2024-02-15T07:00Z = 2d (instead of 1d)
     date.setHours(0, 0, 0, 0)
     base.setHours(0, 0, 0, 0)
 


### PR DESCRIPTION
Fixes the annoying case where a diff of `2024-02-13T09:00Z` and `2024-02-15T07:00Z` is being shown as 1 day apart, despite clearly being 2 days apart.