### PR TITLE
Image alt reminder

### DIFF
--- a/src/state/persisted/schema.ts
+++ b/src/state/persisted/schema.ts
@@ -33,7 +33,7 @@ export const schema = z.object({
     postLanguageHistory: z.array(z.string()),
     appLanguage: z.string(),
   }),
-  requireAltTextEnabled: z.boolean(), // should move to server
+  requireAltTextEnabled: z.union([z.boolean(), z.literal('remind')]), // should move to server
   externalEmbeds: z
     .object({
       giphy: z.enum(externalEmbedOptions).optional(),
@@ -80,7 +80,7 @@ export const defaults: Schema = {
       .slice(0, 6),
     appLanguage: deviceLocales[0] || 'en',
   },
-  requireAltTextEnabled: false,
+  requireAltTextEnabled: 'remind',
   externalEmbeds: {},
   mutedThreads: [],
   invites: {

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -63,9 +63,9 @@ import {emitPostCreated} from '#/state/events'
 import {ThreadgateSetting} from '#/state/queries/threadgate'
 import {logger} from '#/logger'
 import {ComposerReplyTo} from 'view/com/composer/ComposerReplyTo'
-import {useDialogControl} from '#/components/Dialog'
 import {ImageAltReminderDialog} from './ImageAltReminderDialog'
 import {useNonReactiveCallback} from '#/lib/hooks/useNonReactiveCallback'
+import {usePromptControl} from '#/components/Prompt'
 
 type Props = ComposerOpts
 export const ComposePost = observer(function ComposePost({
@@ -114,7 +114,7 @@ export const ComposePost = observer(function ComposePost({
   const [threadgate, setThreadgate] = useState<ThreadgateSetting[]>([])
   const [suggestedLinks, setSuggestedLinks] = useState<Set<string>>(new Set())
   const gallery = useMemo(() => new GalleryModel(), [])
-  const altReminderControl = useDialogControl()
+  const altReminderControl = usePromptControl()
   const onClose = useCallback(() => {
     closeComposer()
   }, [closeComposer])

--- a/src/view/com/composer/ImageAltReminderDialog.tsx
+++ b/src/view/com/composer/ImageAltReminderDialog.tsx
@@ -1,0 +1,78 @@
+import React from 'react'
+import {View} from 'react-native'
+import {useLingui} from '@lingui/react'
+import {Trans, msg} from '@lingui/macro'
+
+import {atoms as a, useBreakpoints} from '#/alf'
+import * as Dialog from '#/components/Dialog'
+import {Text, P} from '#/components/Typography'
+import {Button} from '#/components/Button'
+
+export const ImageAltReminderDialog = React.memo(
+  function ImageAltReminderDialog({
+    control,
+    onContinue,
+  }: {
+    control: Dialog.DialogOuterProps['control']
+    onContinue: () => void
+  }) {
+    const {_} = useLingui()
+    const {gtMobile} = useBreakpoints()
+
+    return (
+      <Dialog.Outer control={control}>
+        <Dialog.Handle />
+
+        <Dialog.ScrollableInner
+          accessibilityDescribedBy="dialog-description-1 dialog-description-2"
+          accessibilityLabelledBy="dialog-title">
+          <View style={[a.relative, a.gap_md, a.w_full]}>
+            <Text nativeID="dialog-title" style={[a.text_2xl, a.font_bold]}>
+              <Trans>Don't forget to make your image accessible</Trans>
+            </Text>
+
+            <P nativeID="dialog-description-1" style={[a.text_sm]}>
+              <Trans>
+                Alt text describes images for blind and low-vision users, and
+                helps give context to everyone. Good alt text are concise yet
+                detailed, with text in the image being written out or
+                summarized.
+              </Trans>
+            </P>
+
+            <P nativeID="dialog-description-2" style={[a.text_sm]}>
+              <Trans>
+                You can turn this reminder off in Accessibility settings.
+              </Trans>
+            </P>
+
+            <View
+              style={[gtMobile && {flexDirection: 'row-reverse'}, a.gap_md]}>
+              <Button
+                variant="solid"
+                color="primary"
+                size={gtMobile ? 'small' : 'large'}
+                onPress={() => control.close()}
+                label={_(msg`Add description`)}>
+                {_(msg`Add description`)}
+              </Button>
+              <Button
+                variant="outline"
+                color="primary"
+                size={gtMobile ? 'small' : 'large'}
+                onPress={() => {
+                  control.close()
+                  onContinue()
+                }}
+                label={_(msg`Not this time`)}>
+                {_(msg`Not this time`)}
+              </Button>
+            </View>
+
+            {!gtMobile && <View style={{height: 40}} />}
+          </View>
+        </Dialog.ScrollableInner>
+      </Dialog.Outer>
+    )
+  },
+)

--- a/src/view/com/composer/ImageAltReminderDialog.tsx
+++ b/src/view/com/composer/ImageAltReminderDialog.tsx
@@ -3,9 +3,9 @@ import {View} from 'react-native'
 import {useLingui} from '@lingui/react'
 import {Trans, msg} from '@lingui/macro'
 
-import {atoms as a, useBreakpoints} from '#/alf'
+import {atoms as a} from '#/alf'
 import * as Dialog from '#/components/Dialog'
-import {Text, P} from '#/components/Typography'
+import * as Prompt from '#/components/Prompt'
 import {Button} from '#/components/Button'
 
 export const ImageAltReminderDialog = React.memo(
@@ -17,62 +17,39 @@ export const ImageAltReminderDialog = React.memo(
     onContinue: () => void
   }) {
     const {_} = useLingui()
-    const {gtMobile} = useBreakpoints()
 
     return (
-      <Dialog.Outer control={control}>
-        <Dialog.Handle />
-
-        <Dialog.ScrollableInner
-          accessibilityDescribedBy="dialog-description-1 dialog-description-2"
-          accessibilityLabelledBy="dialog-title">
-          <View style={[a.relative, a.gap_md, a.w_full]}>
-            <Text nativeID="dialog-title" style={[a.text_2xl, a.font_bold]}>
-              <Trans>Don't forget to make your image accessible</Trans>
-            </Text>
-
-            <P nativeID="dialog-description-1" style={[a.text_sm]}>
-              <Trans>
-                Alt text describes images for blind and low-vision users, and
-                helps give context to everyone. Good alt text are concise yet
-                detailed, with text in the image being written out or
-                summarized.
-              </Trans>
-            </P>
-
-            <P nativeID="dialog-description-2" style={[a.text_sm]}>
-              <Trans>
-                You can turn this reminder off in Accessibility settings.
-              </Trans>
-            </P>
-
-            <View
-              style={[gtMobile && {flexDirection: 'row-reverse'}, a.gap_md]}>
-              <Button
-                variant="solid"
-                color="primary"
-                size={gtMobile ? 'small' : 'large'}
-                onPress={() => control.close()}
-                label={_(msg`Add description`)}>
-                {_(msg`Add description`)}
-              </Button>
-              <Button
-                variant="outline"
-                color="primary"
-                size={gtMobile ? 'small' : 'large'}
-                onPress={() => {
-                  control.close()
-                  onContinue()
-                }}
-                label={_(msg`Not this time`)}>
-                {_(msg`Not this time`)}
-              </Button>
-            </View>
-
-            {!gtMobile && <View style={{height: 40}} />}
-          </View>
-        </Dialog.ScrollableInner>
-      </Dialog.Outer>
+      <Prompt.Outer control={control}>
+        <Prompt.Title>Don't forget to make your image accessible.</Prompt.Title>
+        <Prompt.Description>
+          <Trans>
+            Alt text describes images for blind and low-vision users, and helps
+            give context to everyone. Good alt text are concise yet detailed,
+            with text in the image being written out or summarized.
+          </Trans>
+        </Prompt.Description>
+        <View style={[a.w_full, {flexDirection: 'row-reverse'}, a.gap_sm]}>
+          <Button
+            variant="solid"
+            color="primary"
+            size="small"
+            onPress={() => control.close()}
+            label={_(msg`Add description`)}>
+            {_(msg`Add description`)}
+          </Button>
+          <Button
+            variant="outline"
+            color="primary"
+            size="small"
+            onPress={() => {
+              control.close()
+              onContinue()
+            }}
+            label={_(msg`Not this time`)}>
+            {_(msg`Not this time`)}
+          </Button>
+        </View>
+      </Prompt.Outer>
     )
   },
 )

--- a/src/view/screens/Settings/index.tsx
+++ b/src/view/screens/Settings/index.tsx
@@ -455,7 +455,7 @@ export function SettingsScreen({}: Props) {
             type="default-light"
             label={_(msg`Require alt text before posting`)}
             labelType="lg"
-            isSelected={requireAltTextEnabled}
+            isSelected={requireAltTextEnabled === true}
             onPress={() => setRequireAltTextEnabled(!requireAltTextEnabled)}
           />
         </View>


### PR DESCRIPTION
Forcing the use of alt text encourages bad alt text, but it would be nice to at least have some push towards adding one. This pull request proposes that idea as a third option.

There isn't a UI to enable this third option yet, let me know what you think because I think this is a much better push than a little footnote that nods towards alt text.