### PR TITLE
Commit to theme mode of system

### DIFF
--- a/src/Splash.tsx
+++ b/src/Splash.tsx
@@ -21,7 +21,6 @@ import {useSafeAreaInsets} from 'react-native-safe-area-context'
 import Svg, {Path, SvgProps} from 'react-native-svg'
 
 import {isAndroid} from '#/platform/detection'
-import {useThemePrefs} from 'state/shell'
 import {Logotype} from '#/view/icons/Logotype'
 
 // @ts-ignore
@@ -75,10 +74,8 @@ export function Splash(props: React.PropsWithChildren<Props>) {
     isLayoutReady &&
     reduceMotion !== undefined
 
-  const {colorMode} = useThemePrefs()
   const colorScheme = useColorScheme()
-  const themeName = colorMode === 'system' ? colorScheme : colorMode
-  const isDarkMode = themeName === 'dark'
+  const isDarkMode = colorScheme === 'dark'
 
   const logoAnimation = useAnimatedStyle(() => {
     return {


### PR DESCRIPTION
Issue: OS-level theme mode and app theme mode can be different (light or dark), which was causing the splash screen to begin in dark mode, then abruptly switch to light mode (or vice versa).

This PR makes it so that the splash screen matches whatever mode your system is set to.