### PR TITLE
Add theme-color meta tag and apply selection of theme

### DIFF
--- a/bskyweb/templates/base.html
+++ b/bskyweb/templates/base.html
@@ -2,6 +2,7 @@
 <html>
 <head>
   <meta charset="UTF-8">
+  <meta name="theme-color">
   <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, viewport-fit=cover">
   <meta name="referrer" content="origin-when-cross-origin">
   <!--

--- a/src/alf/util/useColorModeTheme.ts
+++ b/src/alf/util/useColorModeTheme.ts
@@ -46,6 +46,13 @@ function updateDocument(theme: ThemeName) {
     html.className = html.className.replace(/(theme)--\w+/g, '')
 
     html.classList.add(`theme--${theme}`)
+
+    // set color to 'theme-color' meta tag
+    const themeColor = window
+      .getComputedStyle(html)
+      .getPropertyValue('--background')
+    const meta = window.document.querySelector('meta[name="theme-color"]')
+    meta.setAttribute('content', themeColor)
   }
 }
 

--- a/web/index.html
+++ b/web/index.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <meta name="theme-color">
     <!--
       This viewport works for phones with notches.
       It's optimized for gestures by disabling global zoom.


### PR DESCRIPTION
By applying this commit, theme color users selected on settings is applied to the theme-color <meta> tag. When users install the web page, color of status bar is synchronized to the theme color.

![figure](https://github.com/bluesky-social/social-app/assets/7834440/4f4a345d-ba55-4686-9681-de9049278e0a)