### PR TITLE
Connect replies from other users

### DIFF
--- a/src/lib/api/feed-manip.ts
+++ b/src/lib/api/feed-manip.ts
@@ -84,8 +84,8 @@ export class FeedViewPostsSlice {
   }
 
   insert(item: FeedViewPost) {
-    const selfReplyUri = getSelfReplyUri(item)
-    const i = this.items.findIndex(item2 => item2.post.uri === selfReplyUri)
+    const replyUri = getReplyUri(item)
+    const i = this.items.findIndex(item2 => item2.post.uri === replyUri)
     if (i !== -1) {
       this.items.splice(i + 1, 0, item)
     } else {
@@ -171,10 +171,10 @@ export class FeedTuner {
       for (let i = feed.length - 1; i >= 0; i--) {
         const item = feed[i]
 
-        const selfReplyUri = getSelfReplyUri(item)
-        if (selfReplyUri) {
+        const replyUri = getReplyUri(item)
+        if (replyUri) {
           const index = slices.findIndex(slice =>
-            slice.isNextInThread(selfReplyUri),
+            slice.isNextInThread(replyUri),
           )
 
           if (index !== -1) {
@@ -379,15 +379,13 @@ export class FeedTuner {
   }
 }
 
-function getSelfReplyUri(item: FeedViewPost): string | undefined {
+function getReplyUri(item: FeedViewPost): string | undefined {
   if (item.reply) {
     if (
       AppBskyFeedDefs.isPostView(item.reply.parent) &&
       !AppBskyFeedDefs.isReasonRepost(item.reason) // don't thread reposted self-replies
     ) {
-      return item.reply.parent.author.did === item.post.author.did
-        ? item.reply.parent.uri
-        : undefined
+      return item.reply.parent.uri
     }
   }
   return undefined

--- a/src/view/com/posts/FeedSlice.tsx
+++ b/src/view/com/posts/FeedSlice.tsx
@@ -19,6 +19,7 @@ let FeedSlice = ({
   hideTopBorder?: boolean
 }): React.ReactNode => {
   if (slice.items.length > 3) {
+    const beforeLast = slice.items.length - 2
     const last = slice.items.length - 1
     return (
       <>
@@ -36,20 +37,20 @@ let FeedSlice = ({
           hideTopBorder={hideTopBorder}
           isParentBlocked={slice.items[0].isParentBlocked}
         />
-        <FeedItem
-          key={slice.items[1]._reactKey}
-          post={slice.items[1].post}
-          record={slice.items[1].record}
-          reason={slice.items[1].reason}
-          feedContext={slice.items[1].feedContext}
-          parentAuthor={slice.items[1].parentAuthor}
-          showReplyTo={false}
-          moderation={slice.items[1].moderation}
-          isThreadParent={isThreadParentAt(slice.items, 1)}
-          isThreadChild={isThreadChildAt(slice.items, 1)}
-          isParentBlocked={slice.items[1].isParentBlocked}
-        />
         <ViewFullThread slice={slice} />
+        <FeedItem
+          key={slice.items[beforeLast]._reactKey}
+          post={slice.items[beforeLast].post}
+          record={slice.items[beforeLast].record}
+          reason={slice.items[beforeLast].reason}
+          feedContext={slice.items[beforeLast].feedContext}
+          parentAuthor={slice.items[beforeLast].parentAuthor}
+          showReplyTo={false}
+          moderation={slice.items[beforeLast].moderation}
+          isThreadParent={isThreadParentAt(slice.items, beforeLast)}
+          isThreadChild={isThreadChildAt(slice.items, beforeLast)}
+          isParentBlocked={slice.items[beforeLast].isParentBlocked}
+        />
         <FeedItem
           key={slice.items[last]._reactKey}
           post={slice.items[last].post}

--- a/src/view/com/posts/FeedSlice.tsx
+++ b/src/view/com/posts/FeedSlice.tsx
@@ -18,7 +18,7 @@ let FeedSlice = ({
   slice: FeedPostSlice
   hideTopBorder?: boolean
 }): React.ReactNode => {
-  if (slice.isThread && slice.items.length > 3) {
+  if (slice.items.length > 3) {
     const last = slice.items.length - 1
     return (
       <>


### PR DESCRIPTION
I dug up the original commit that introduced the threading, https://github.com/bluesky-social/social-app/commit/ba837ad9afd3f4faa5a47b7ea620cd633e99d9cf and there doesn't seem to be much of a reason as to why it was being done this way.

The problem is that it makes replies like this look awkward and confusing, they're part of the same reply chain, but they're being detached.

<img width=600 src=https://github.com/bluesky-social/social-app/assets/148872143/f67799a7-714f-4f07-ac85-76b7cc066b79>

If we connect it, then it's clear that it's part of the same chain.

<img width=600 src=https://github.com/bluesky-social/social-app/assets/148872143/82b47726-88b9-4720-add8-3637a27c460e>
