### PR TITLE
Fix UITextView line height adjustment for DynamicType, always use the max width for the view

### DIFF
--- a/modules/react-native-ui-text-view/ios/RNUITextViewShadow.swift
+++ b/modules/react-native-ui-text-view/ios/RNUITextViewShadow.swift
@@ -100,18 +100,25 @@ class RNUITextViewShadow: RCTShadowView {
       // Create the attributed string with the generic attributes
       let string = NSMutableAttributedString(string: child.text, attributes: attributes)
 
-      // Set the paragraph style attributes if necessary
+      // Set the paragraph style attributes if necessary. We can check this by seeing if the provided
+      // line height is not 0.0.
       let paragraphStyle = NSMutableParagraphStyle()
       if child.lineHeight != 0.0 {
-        paragraphStyle.minimumLineHeight = child.lineHeight
-        paragraphStyle.maximumLineHeight = child.lineHeight
+        // Whenever we change the line height for the text, we are also removing the DynamicType
+        // adjustment for line height. We need to get the multiplier and apply that to the
+        // line height.
+        let scaleMultiplier = scaledFontSize / child.fontSize
+        paragraphStyle.minimumLineHeight = child.lineHeight * scaleMultiplier
+        paragraphStyle.maximumLineHeight = child.lineHeight * scaleMultiplier
+
         string.addAttribute(
           NSAttributedString.Key.paragraphStyle,
           value: paragraphStyle,
           range: NSMakeRange(0, string.length)
         )
 
-        // Store that height
+        // To calcualte the size of the text without creating a new UILabel or UITextView, we have
+        // to store this line height for later.
         self.lineHeight = child.lineHeight
       } else {
         self.lineHeight = font.lineHeight


### PR DESCRIPTION
Fixing an accessibility issue here as well as a rare issue where some posts would get cut off.

## DynamicType

We use `NSParagraphStyle` to adjust line height on our text. However, whenever we adjust it, we were not taking into consideration that the line height also needs to be multiplied by the DynamicType multiplier. We can get the multiplier by dividing the scaled font size by the base font size, and times the line height by that value.

### Before

<img src="https://github.com/bluesky-social/social-app/assets/153161762/6f436004-f346-4b2a-a40a-541fdfcbd8ea" width="200">

### After

<img src="https://github.com/bluesky-social/social-app/assets/153161762/f5cb6e05-7321-42be-906f-7d3935e61c25" width="200">

## Post Cutoff

In rare cases, a post like this would be cut off prematurely:

```
This is a test post.
First line is short.
Rest are shorter.
```

If the first line does not extend to be the entire width of the screen, then the final line of the text would be cut off. This was pretty rare, because it would only happen if the first line *also* ended in a period. Seems like a weird issue with `boundingRect` on `NSAttributedString`.

The fix is to just always use the max width available to the view for the `UITextView`. We should probably be doing this anyway.

### Before

![Screenshot 2024-02-18 at 5 43 34 PM](https://github.com/bluesky-social/social-app/assets/153161762/0dedf4c1-2bb9-4484-be0f-d2712e26aa9e)

### After

![image](https://github.com/bluesky-social/social-app/assets/153161762/ba870307-b2d4-47bc-a3b4-246811cb12eb)

