### PR TITLE
Add theme-color meta tag and apply selection of theme

### DIFF
--- a/bskyweb/templates/base.html
+++ b/bskyweb/templates/base.html
@@ -2,6 +2,7 @@
 <html>
 <head>
   <meta charset="UTF-8">
+  <meta name="theme-color">
   <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, viewport-fit=cover">
   <meta name="referrer" content="origin-when-cross-origin">
   <!--

--- a/src/alf/util/useColorModeTheme.ts
+++ b/src/alf/util/useColorModeTheme.ts
@@ -49,7 +49,7 @@ function updateDocument(theme: ThemeName) {
     html.className = html.className.replace(/(theme)--\w+/g, '')
     html.classList.add(`theme--${theme}`)
     // set color to 'theme-color' meta tag
-    meta.setAttribute('content', getBackgroundColor(theme))
+    meta?.setAttribute('content', getBackgroundColor(theme))
   }
 }
 

--- a/src/alf/util/useColorModeTheme.ts
+++ b/src/alf/util/useColorModeTheme.ts
@@ -46,6 +46,13 @@ function updateDocument(theme: ThemeName) {
     html.className = html.className.replace(/(theme)--\w+/g, '')
 
     html.classList.add(`theme--${theme}`)
+
+    // set color to 'theme-color' meta tag
+    const themeColor = window
+      .getComputedStyle(html)
+      .getPropertyValue('--background')
+    const meta = window.document.querySelector('meta[name="theme-color"]')
+    meta.setAttribute('content', themeColor)
   }
 }
 

--- a/src/alf/util/useColorModeTheme.ts
+++ b/src/alf/util/useColorModeTheme.ts
@@ -13,7 +13,7 @@ export function useColorModeTheme(): ThemeName {
   React.useLayoutEffect(() => {
     const theme = getThemeName(colorScheme, colorMode, darkTheme)
     updateDocument(theme)
-    updateSystemBackground(theme)
+    SystemUI.setBackgroundColorAsync(getBackgroundColor(theme))
   }, [colorMode, colorScheme, darkTheme])
 
   return React.useMemo(
@@ -48,24 +48,19 @@ function updateDocument(theme: ThemeName) {
     html.classList.add(`theme--${theme}`)
 
     // set color to 'theme-color' meta tag
-    const themeColor = window
-      .getComputedStyle(html)
-      .getPropertyValue('--background')
+    const themeColor = getBackgroundColor(theme)
     const meta = window.document.querySelector('meta[name="theme-color"]')
     meta.setAttribute('content', themeColor)
   }
 }
 
-function updateSystemBackground(theme: ThemeName) {
+function getBackgroundColor(theme: ThemeName): string {
   switch (theme) {
     case 'light':
-      SystemUI.setBackgroundColorAsync(light.atoms.bg.backgroundColor)
-      break
+      return light.atoms.bg.backgroundColor
     case 'dark':
-      SystemUI.setBackgroundColorAsync(dark.atoms.bg.backgroundColor)
-      break
+      return dark.atoms.bg.backgroundColor
     case 'dim':
-      SystemUI.setBackgroundColorAsync(dim.atoms.bg.backgroundColor)
-      break
+      return dim.atoms.bg.backgroundColor
   }
 }

--- a/src/alf/util/useColorModeTheme.ts
+++ b/src/alf/util/useColorModeTheme.ts
@@ -42,15 +42,14 @@ function updateDocument(theme: ThemeName) {
   if (isWeb && typeof window !== 'undefined') {
     // @ts-ignore web only
     const html = window.document.documentElement
+    // @ts-ignore web only
+    const meta = window.document.querySelector('meta[name="theme-color"]')
+
     // remove any other color mode classes
     html.className = html.className.replace(/(theme)--\w+/g, '')
-
     html.classList.add(`theme--${theme}`)
-
     // set color to 'theme-color' meta tag
-    const themeColor = getBackgroundColor(theme)
-    const meta = window.document.querySelector('meta[name="theme-color"]')
-    meta.setAttribute('content', themeColor)
+    meta.setAttribute('content', getBackgroundColor(theme))
   }
 }
 

--- a/web/index.html
+++ b/web/index.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <meta name="theme-color">
     <!--
       This viewport works for phones with notches.
       It's optimized for gestures by disabling global zoom.


### PR DESCRIPTION
By applying this commit, theme color users selected on settings is applied to the theme-color tag. When users install the web page, color of status bar is synchronized to the theme color.

![theme-color](https://github.com/bluesky-social/social-app/assets/7834440/b1742271-4d58-4cfc-95db-190e78d34fa8)
