### PR TITLE
Add embed to post view when converting from embed view

### DIFF
--- a/src/state/queries/util.ts
+++ b/src/state/queries/util.ts
@@ -53,5 +53,6 @@ export function embedViewRecordToPostView(
     record: v.value,
     indexedAt: v.indexedAt,
     labels: v.labels,
+    embed: v.embeds?.[0],
   }
 }


### PR DESCRIPTION
Quick one line to add the embed when converting an embed view to a post view. Still will have issues in some cases if the quote's embed is a quote as well as discussed.

If we don't include the embeds, when we open the quote there will be a jump after the image or link embed is loaded.

Re why this is an array: https://github.com/bluesky-social/social-app/pull/2464#issuecomment-1886382953

It is guaranteed to only be a single item if it is defined: https://github.com/bluesky-social/atproto/blob/50f70453a9e49621956e4e820226c0e220fe138e/packages/bsky/src/services/feed/views.ts#L434

## Before 

https://github.com/bluesky-social/social-app/assets/153161762/9bb4ca8d-5d77-4f9d-a7d8-ca1d33b67332

## After

https://github.com/bluesky-social/social-app/assets/153161762/e6b5d986-05d2-4bf4-aec5-57c83e8a3955