### PR TITLE
Prefer post over quote when finding cached post

### DIFF
--- a/src/state/queries/post-feed.ts
+++ b/src/state/queries/post-feed.ts
@@ -391,6 +391,9 @@ export function* findAllPostsInQueryData(
   >({
     queryKey: ['post-feed'],
   })
+
+  let foundEmbed: AppBskyFeedDefs.PostView | undefined
+
   for (const [_queryKey, queryData] of queryDatas) {
     if (!queryData?.pages) {
       continue
@@ -402,7 +405,7 @@ export function* findAllPostsInQueryData(
         }
         const quotedPost = getEmbeddedPost(item.post.embed)
         if (quotedPost?.uri === uri) {
-          yield embedViewRecordToPostView(quotedPost)
+          foundEmbed = embedViewRecordToPostView(quotedPost)
         }
         if (
           AppBskyFeedDefs.isPostView(item.reply?.parent) &&
@@ -418,6 +421,10 @@ export function* findAllPostsInQueryData(
         }
       }
     }
+  }
+
+  if (foundEmbed) {
+    yield foundEmbed
   }
 }
 


### PR DESCRIPTION
When we open a post from the feed, we use `findAllPostsInQueryData()` to get placeholder data if we have it.

Right now, our logic searches each post *and* each post's quote (if one exists) to find this placeholder data. In most cases, this works.

However, in some cases, the post we are opening might have been quoted in another post that is inside our cache. In these cases, right now we might use the incomplete record (embed records don't have all of the information that we would like to have, such as image URIs or thumbnail URIs) as the placeholder data, even though later in the cache we do indeed have the full post view.

This is evidenced by opening post 14 on https://bsky.app/profile/dansshadow.bsky.social. Right now, we will use the incomplete quote record as a placeholder, resulting in the wrong behavior:


https://github.com/bluesky-social/social-app/assets/153161762/08299c75-299a-4d9c-ba28-495b598471ae

Instead, we want to prefer the full view if we have it and *only use the quote if we can't find the full view inside the cache*.

By preferring the view, we get the expected behavior:


https://github.com/bluesky-social/social-app/assets/153161762/f5b9fd2b-eb43-44a7-a818-8a170915228f

