### PR TITLE
Improve dialogs issue

### DIFF
--- a/src/components/Dialog/index.tsx
+++ b/src/components/Dialog/index.tsx
@@ -83,6 +83,7 @@ export function Outer({
     isOpen && (
       <Portal>
         <BottomSheet
+          animateOnMount
           enableDynamicSizing={!hasSnapPoints}
           enablePanDownToClose
           keyboardBehavior="interactive"
@@ -90,6 +91,7 @@ export function Outer({
           keyboardBlurBehavior="restore"
           topInset={insets.top}
           {...sheetOptions}
+          snapPoints={sheetOptions.snapPoints || ['100%']}
           ref={sheet}
           index={openIndex}
           backgroundStyle={{backgroundColor: 'transparent'}}
@@ -99,6 +101,7 @@ export function Outer({
               appearsOnIndex={0}
               disappearsOnIndex={-1}
               {...props}
+              style={[flatten(props.style), t.atoms.bg_contrast_300]}
             />
           )}
           handleIndicatorStyle={{backgroundColor: t.palette.primary_500}}
@@ -114,10 +117,11 @@ export function Outer({
                   borderTopLeftRadius: 40,
                   borderTopRightRadius: 40,
                   height: Dimensions.get('window').height * 2,
+                  pointerEvents: 'none',
                 },
               ]}
             />
-            {hasSnapPoints ? children : <View>{children}</View>}
+            {children}
           </Context.Provider>
         </BottomSheet>
       </Portal>

--- a/src/components/Dialog/index.tsx
+++ b/src/components/Dialog/index.tsx
@@ -116,7 +116,6 @@ export function Outer({
                   borderTopLeftRadius: 40,
                   borderTopRightRadius: 40,
                   height: Dimensions.get('window').height * 2,
-                  pointerEvents: 'none',
                 },
               ]}
             />

--- a/src/components/Dialog/index.tsx
+++ b/src/components/Dialog/index.tsx
@@ -83,7 +83,6 @@ export function Outer({
     isOpen && (
       <Portal>
         <BottomSheet
-          animateOnMount
           enableDynamicSizing={!hasSnapPoints}
           enablePanDownToClose
           keyboardBehavior="interactive"

--- a/src/view/screens/Storybook/Dialogs.tsx
+++ b/src/view/screens/Storybook/Dialogs.tsx
@@ -9,7 +9,8 @@ import * as Prompt from '#/components/Prompt'
 import {useDialogStateControlContext} from '#/state/dialogs'
 
 export function Dialogs() {
-  const control = Dialog.useDialogControl()
+  const scrollable = Dialog.useDialogControl()
+  const basic = Dialog.useDialogControl()
   const prompt = Prompt.usePromptControl()
   const {closeAllDialogs} = useDialogStateControlContext()
 
@@ -20,8 +21,31 @@ export function Dialogs() {
         color="secondary"
         size="small"
         onPress={() => {
-          control.open()
+          scrollable.open()
           prompt.open()
+          basic.open()
+        }}
+        label="Open basic dialog">
+        Open all dialogs
+      </Button>
+
+      <Button
+        variant="outline"
+        color="secondary"
+        size="small"
+        onPress={() => {
+          scrollable.open()
+        }}
+        label="Open basic dialog">
+        Open scrollable dialog
+      </Button>
+
+      <Button
+        variant="outline"
+        color="secondary"
+        size="small"
+        onPress={() => {
+          basic.open()
         }}
         label="Open basic dialog">
         Open basic dialog
@@ -48,8 +72,17 @@ export function Dialogs() {
         </Prompt.Actions>
       </Prompt.Outer>
 
+      <Dialog.Outer control={basic}>
+        <Dialog.Handle />
+
+        <Dialog.Inner label="test">
+          <H3 nativeID="dialog-title">Dialog</H3>
+          <P nativeID="dialog-description">A basic dialog</P>
+        </Dialog.Inner>
+      </Dialog.Outer>
+
       <Dialog.Outer
-        control={control}
+        control={scrollable}
         nativeOptions={{sheet: {snapPoints: ['100%']}}}>
         <Dialog.Handle />
 
@@ -77,9 +110,9 @@ export function Dialogs() {
                 variant="outline"
                 color="primary"
                 size="small"
-                onPress={() => control.close()}
+                onPress={() => scrollable.close()}
                 label="Open basic dialog">
-                Close basic dialog
+                Close dialog
               </Button>
             </View>
           </View>

--- a/src/view/screens/Storybook/index.tsx
+++ b/src/view/screens/Storybook/index.tsx
@@ -65,6 +65,7 @@ export function Storybook() {
               Dark
             </Button>
           </View>
+          <Dialogs />
 
           <ThemeProvider theme="light">
             <Theming />
@@ -83,7 +84,6 @@ export function Storybook() {
           <Icons />
           <Links />
           <Forms />
-          <Dialogs />
           <Breakpoints />
         </View>
       </CenteredView>

--- a/src/view/screens/Storybook/index.tsx
+++ b/src/view/screens/Storybook/index.tsx
@@ -65,7 +65,6 @@ export function Storybook() {
               Dark
             </Button>
           </View>
-          <Dialogs />
 
           <ThemeProvider theme="light">
             <Theming />
@@ -84,6 +83,7 @@ export function Storybook() {
           <Icons />
           <Links />
           <Forms />
+          <Dialogs />
           <Breakpoints />
         </View>
       </CenteredView>


### PR DESCRIPTION
Fixes the main issue I was seeing yesterday, where the content of the dialog would collapse in some circumstances.

I discovered by accident that a dynamically sized dialog with one default snap point at 100% seemed to size just fine. `enableDynamicSizing` inserts a `snapPoint` into your array of snap points, so in this case it results in snap points of `[<dynamic>, '100%']`. This has no effect on other dialogs, or dialogs where we explicitly pass in snap points of our own.

So what this means for dynamically sized dialogs (like Prompt) is that they initially open to whatever natural height they are, but then they can be dragged open to 100% too. Seems like an ok compromise for now.

This PR also improves the backdrop color so that stacked dialogs have sufficient contrast to be clearly visible.
![CleanShot 2024-02-20 at 09 45 53@2x](https://github.com/bluesky-social/social-app/assets/4732330/cd9913b6-e70e-405c-84c4-7e5e745dcebc)
![CleanShot 2024-02-20 at 09 46 04@2x](https://github.com/bluesky-social/social-app/assets/4732330/6f977a14-3108-49d8-8311-02649a2750f8)
