### PR TITLE
Prefer full posts for post thread placeholder

### DIFF
--- a/src/state/queries/notifications/feed.ts
+++ b/src/state/queries/notifications/feed.ts
@@ -133,23 +133,6 @@ export function useNotificationFeedQuery(opts?: {enabled?: boolean}) {
   return query
 }
 
-/**
- * This helper is used by the post-thread placeholder function to
- * find a post in the query-data cache
- */
-export function findPostInQueryData(
-  queryClient: QueryClient,
-  uri: string,
-): AppBskyFeedDefs.PostView | undefined {
-  const generator = findAllPostsInQueryData(queryClient, uri)
-  const result = generator.next()
-  if (result.done) {
-    return undefined
-  } else {
-    return result.value
-  }
-}
-
 export function* findAllPostsInQueryData(
   queryClient: QueryClient,
   uri: string,

--- a/src/state/queries/post-feed.ts
+++ b/src/state/queries/post-feed.ts
@@ -365,23 +365,6 @@ function createApi(
   }
 }
 
-/**
- * This helper is used by the post-thread placeholder function to
- * find a post in the query-data cache
- */
-export function findPostInQueryData(
-  queryClient: QueryClient,
-  uri: string,
-): AppBskyFeedDefs.PostView | undefined {
-  const generator = findAllPostsInQueryData(queryClient, uri)
-  const result = generator.next()
-  if (result.done) {
-    return undefined
-  } else {
-    return result.value
-  }
-}
-
 export function* findAllPostsInQueryData(
   queryClient: QueryClient,
   uri: string,

--- a/src/state/queries/post-feed.ts
+++ b/src/state/queries/post-feed.ts
@@ -391,9 +391,6 @@ export function* findAllPostsInQueryData(
   >({
     queryKey: ['post-feed'],
   })
-
-  let foundEmbed: AppBskyFeedDefs.PostView | undefined
-
   for (const [_queryKey, queryData] of queryDatas) {
     if (!queryData?.pages) {
       continue
@@ -405,7 +402,7 @@ export function* findAllPostsInQueryData(
         }
         const quotedPost = getEmbeddedPost(item.post.embed)
         if (quotedPost?.uri === uri) {
-          foundEmbed = embedViewRecordToPostView(quotedPost)
+          yield embedViewRecordToPostView(quotedPost)
         }
         if (
           AppBskyFeedDefs.isPostView(item.reply?.parent) &&
@@ -421,10 +418,6 @@ export function* findAllPostsInQueryData(
         }
       }
     }
-  }
-
-  if (foundEmbed) {
-    yield foundEmbed
   }
 }
 

--- a/src/state/queries/post-thread.ts
+++ b/src/state/queries/post-thread.ts
@@ -8,8 +8,8 @@ import {useQuery, useQueryClient, QueryClient} from '@tanstack/react-query'
 
 import {getAgent} from '#/state/session'
 import {UsePreferencesQueryResponse} from '#/state/queries/preferences/types'
-import {findPostInQueryData as findPostInFeedQueryData} from './post-feed'
-import {findPostInQueryData as findPostInNotifsQueryData} from './notifications/feed'
+import {findAllPostsInQueryData as findAllPostsInFeedQueryData} from './post-feed'
+import {findAllPostsInQueryData as findAllPostsInNotifsQueryData} from './notifications/feed'
 import {precacheThreadPostProfiles} from './profile'
 import {getEmbeddedPost} from './util'
 
@@ -82,21 +82,9 @@ export function usePostThreadQuery(uri: string | undefined) {
         return undefined
       }
       {
-        const item = findPostInQueryData(queryClient, uri)
-        if (item) {
-          return threadNodeToPlaceholderThread(item)
-        }
-      }
-      {
-        const item = findPostInFeedQueryData(queryClient, uri)
-        if (item) {
-          return postViewToPlaceholderThread(item)
-        }
-      }
-      {
-        const item = findPostInNotifsQueryData(queryClient, uri)
-        if (item) {
-          return postViewToPlaceholderThread(item)
+        const post = findPostInQueryData(queryClient, uri)
+        if (post) {
+          return post
         }
       }
       return undefined
@@ -213,14 +201,17 @@ function responseToThreadNodes(
 function findPostInQueryData(
   queryClient: QueryClient,
   uri: string,
-): ThreadNode | undefined {
-  const generator = findAllPostsInQueryData(queryClient, uri)
-  const result = generator.next()
-  if (result.done) {
-    return undefined
-  } else {
-    return result.value
+): ThreadNode | void {
+  let partial
+  for (let item of findAllPostsInQueryData(queryClient, uri)) {
+    if (item.type === 'post' && item.post.likeCount != null) {
+      return item
+    } else {
+      partial = item
+      // Keep searching, we might still find a full post in the cache.
+    }
   }
+  return partial
 }
 
 export function* findAllPostsInQueryData(
@@ -236,7 +227,10 @@ export function* findAllPostsInQueryData(
     }
     for (const item of traverseThread(queryData)) {
       if (item.uri === uri) {
-        yield item
+        const placeholder = threadNodeToPlaceholderThread(item)
+        if (placeholder) {
+          yield placeholder
+        }
       }
       const quotedPost =
         item.type === 'post' ? getEmbeddedPost(item.post.embed) : undefined
@@ -244,6 +238,12 @@ export function* findAllPostsInQueryData(
         yield embedViewRecordToPlaceholderThread(quotedPost)
       }
     }
+  }
+  for (let post of findAllPostsInFeedQueryData(queryClient, uri)) {
+    yield postViewToPlaceholderThread(post)
+  }
+  for (let post of findAllPostsInNotifsQueryData(queryClient, uri)) {
+    yield postViewToPlaceholderThread(post)
   }
 }
 

--- a/src/state/queries/post-thread.ts
+++ b/src/state/queries/post-thread.ts
@@ -204,11 +204,18 @@ function findPostInQueryData(
 ): ThreadNode | void {
   let partial
   for (let item of findAllPostsInQueryData(queryClient, uri)) {
-    if (item.type === 'post' && item.post.likeCount != null) {
-      return item
-    } else {
-      partial = item
-      // Keep searching, we might still find a full post in the cache.
+    if (item.type === 'post') {
+      // Currently, the backend doesn't send full post info in some cases
+      // (for example, for quoted posts). We use missing `likeCount`
+      // as a way to detect that. In the future, we should fix this on
+      // the backend, which will let us always stop on the first result.
+      const hasAllInfo = item.post.likeCount != null
+      if (hasAllInfo) {
+        return item
+      } else {
+        partial = item
+        // Keep searching, we might still find a full post in the cache.
+      }
     }
   }
   return partial


### PR DESCRIPTION
This reverts https://github.com/bluesky-social/social-app/pull/2935 and applies an equivalent fix in a different place.

The issue we're solving is that, when constructing a PostThread placeholder, we want to reuse the data from cache. The data from cache can include both complete posts (i.e. with like counts and other info) and partial posts (i.e. without like counts and other info).

In https://github.com/bluesky-social/social-app/pull/2935, we changed the logic so that a complete post is preferred. However, we only did it for one source (post thread cache) without accounting for other sources (such as the feed cache). So this fix would not apply to the same situation when the post is retrieved from the feed cache. Additionally, we should consistently prefer full posts no matter which order the caches were searched in — i.e. a partial match in a cache we search earlier (e.g. post thread cache) shouldn't "get in front of" a full match in a cache we search later (e.g. the feed cache).

In this PR, the approach is to move the decision over which post to pick close to where it's actually needed. Individual caches expose functions that search over them, but don't expose functions that pick the winner. The post thread logic now does the iteration and picks the first full match _or_ a partial match if no full matches were found.

## Test Plan

Navigate around the threads. Notice that the first commit (the revert) no longer passes the test plan in https://github.com/bluesky-social/social-app/pull/2935, but the second commit makes that test plan pass again.