### PR TITLE
Fix flash when pressing into just-created post

### DIFF
--- a/src/state/queries/post-thread.ts
+++ b/src/state/queries/post-thread.ts
@@ -159,11 +159,18 @@ function responseToThreadNodes(
     AppBskyFeedPost.isRecord(node.post.record) &&
     AppBskyFeedPost.validateRecord(node.post.record).success
   ) {
+    const post = node.post
+    // These should normally be present. They're missing only for
+    // posts that were *just* created. Ideally, the backend would
+    // know to return zeros. Fill them in manually to compensate.
+    post.replyCount ??= 0
+    post.likeCount ??= 0
+    post.repostCount ??= 0
     return {
       type: 'post',
       _reactKey: node.post.uri,
       uri: node.post.uri,
-      post: node.post,
+      post: post,
       record: node.post.record,
       parent:
         node.parent && direction !== 'down'


### PR DESCRIPTION
In https://github.com/bluesky-social/social-app/pull/2878, I added a shimmer for the metrics when we don't know them to avoid a layout shift. I made the assumption that usually the post you're opening would have some engagement already (that's vastly more common for the posts you're consuming from Feeds or QTs). So by default you see the shimmer, and it goes away if the post has zero likes and reposts.

This backfired a little bit for just-posted posts.

Observe what happens when you navigate into one:

https://github.com/bluesky-social/social-app/assets/810438/63dfaefe-a1a5-4e69-af9b-7054ca42e9da

You now see the shimmer show up for a fraction of a second.

But shouldn't we already have the information about the like count being zero in post thread replies? Normally we do, but currently app view doesn't give us that for just-inserted posts. Probably due to the response being optimistic.

We know that if you just posted something, no one could have liked/reposted it yet, so let's fill it in ourselves.

https://github.com/bluesky-social/social-app/assets/810438/0e30f5ae-11ac-4f7d-9d13-a4ae09756120

This prevents the flash. I think this particular flash is worth the hack because you see it every time you add to a thread (which is very often if you're a poster).