### PR TITLE
Fix splash screen language picker appearance on Chrome

### DIFF
--- a/src/components/AppLanguageDropdown.web.tsx
+++ b/src/components/AppLanguageDropdown.web.tsx
@@ -42,31 +42,39 @@ export function AppLanguageDropdown() {
         // We don't have hitSlop here to increase the tap region,
         // alternative is negative margins.
         {height: 32, marginVertical: -((32 - 14) / 2)},
-        a.flex_row,
-        a.gap_sm,
-        a.align_center,
-        a.flex_shrink,
       ]}>
-      <Text aria-hidden={true} style={t.atoms.text_contrast_medium}>
-        {APP_LANGUAGES.find(l => l.code2 === sanitizedLang)?.name}
-      </Text>
-      <ChevronDown fill={t.atoms.text.color} size="xs" style={a.flex_shrink} />
+      <View
+        style={[
+          a.flex_row,
+          a.gap_sm,
+          a.align_center,
+          a.flex_shrink,
+          a.h_full,
+          t.atoms.bg,
+        ]}>
+        <Text aria-hidden={true} style={t.atoms.text_contrast_medium}>
+          {APP_LANGUAGES.find(l => l.code2 === sanitizedLang)?.name}
+        </Text>
+        <ChevronDown
+          fill={t.atoms.text.color}
+          size="xs"
+          style={a.flex_shrink}
+        />
+      </View>
 
       <select
         value={sanitizedLang}
         onChange={onChangeAppLanguage}
         style={{
+          fontSize: a.text_sm.fontSize,
+          letterSpacing: a.text_sm.letterSpacing,
           cursor: 'pointer',
-          MozAppearance: 'none',
-          WebkitAppearance: 'none',
-          appearance: 'none',
           position: 'absolute',
           inset: 0,
-          width: '100%',
-          color: 'transparent',
-          background: 'transparent',
-          border: 0,
-          padding: 0,
+          opacity: 0,
+          color: t.atoms.text.color,
+          background: t.atoms.bg.backgroundColor,
+          padding: 4,
         }}>
         {APP_LANGUAGES.filter(l => Boolean(l.code2)).map(l => (
           <option key={l.code2} value={l.code2}>

--- a/src/components/AppLanguageDropdown.web.tsx
+++ b/src/components/AppLanguageDropdown.web.tsx
@@ -55,11 +55,7 @@ export function AppLanguageDropdown() {
         <Text aria-hidden={true} style={t.atoms.text_contrast_medium}>
           {APP_LANGUAGES.find(l => l.code2 === sanitizedLang)?.name}
         </Text>
-        <ChevronDown
-          fill={t.atoms.text.color}
-          size="xs"
-          style={a.flex_shrink}
-        />
+        <ChevronDown fill={t.atoms.text.color} size="xs" style={a.flex_0} />
       </View>
 
       <select


### PR DESCRIPTION
Closes #2963

Missed this during the initial pull request, Chrome's `<select>` menu inherits background color and font styling from CSS. Using `transparent` here causes the menu to look completely blank.

<img width=300 src=https://github.com/bluesky-social/social-app/assets/148872143/5602dfec-29e3-4c53-923c-ef909142fb17>

This pull request fixes the issue by placing the `<select>` behind the view, while making the view's pointer events nulled. `<select>` has been styled such that it uses the currently selected theme palette now.

<img width=300 src=https://github.com/bluesky-social/social-app/assets/148872143/c35699e5-f2d5-4a02-90af-381786cc90cd>

(Not sure what's up with the top-left borders there, I think that's just Chrome having fractional scaling issues)
