### PR TITLE
Fix `numberOfLines` not updating on iOS 15

### DIFF
--- a/modules/react-native-ui-text-view/ios/RNUITextViewManager.m
+++ b/modules/react-native-ui-text-view/ios/RNUITextViewManager.m
@@ -4,6 +4,7 @@
 RCT_REMAP_SHADOW_PROPERTY(numberOfLines, numberOfLines, NSInteger)
 RCT_REMAP_SHADOW_PROPERTY(allowsFontScaling, allowsFontScaling, BOOL)
 
+RCT_EXPORT_VIEW_PROPERTY(numberOfLines, NSInteger)
 RCT_EXPORT_VIEW_PROPERTY(onTextLayout, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(ellipsizeMode, NSString)
 RCT_EXPORT_VIEW_PROPERTY(selectable, BOOL)


### PR DESCRIPTION
Beats me as to why, but the main view does not have access to shadow properties on iOS 15. We instead need to have them as both a shadow property and a view property if we want to access the property from both.