### PR TITLE
Remove top border from highlighted post when there's a parent, connect line to avatar (with better centering)

### DIFF
--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -228,7 +228,13 @@ let PostThreadItemLoaded = ({
     return (
       <>
         {rootUri !== post.uri && (
-          <View style={{paddingLeft: 16, flexDirection: 'row', height: 24}}>
+          <View
+            style={{
+              paddingLeft: 16,
+              flexDirection: 'row',
+              height: 26,
+              paddingBottom: 3,
+            }}>
             <View style={{width: 38}}>
               <View
                 style={[

--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -228,7 +228,7 @@ let PostThreadItemLoaded = ({
     return (
       <>
         {rootUri !== post.uri && (
-          <View style={{paddingLeft: 16, flexDirection: 'row', height: 16}}>
+          <View style={{paddingLeft: 16, flexDirection: 'row', height: 24}}>
             <View style={{width: 38}}>
               <View
                 style={[
@@ -245,7 +245,13 @@ let PostThreadItemLoaded = ({
 
         <View
           testID={`postThreadItem-by-${post.author.handle}`}
-          style={[styles.outer, styles.outerHighlighted, pal.border, pal.view]}
+          style={[
+            styles.outer,
+            styles.outerHighlighted,
+            rootUri !== post.uri && styles.outerHighlightedWithParent,
+            pal.border,
+            pal.view,
+          ]}
           accessible={false}>
           <View style={[styles.layout]}>
             <View style={[styles.layoutAvi, {paddingBottom: 8}]}>
@@ -693,8 +699,12 @@ const styles = StyleSheet.create({
   },
   outerHighlighted: {
     paddingTop: 16,
-    paddingLeft: 8,
+    paddingLeft: 6,
     paddingRight: 8,
+  },
+  outerHighlightedWithParent: {
+    paddingTop: 0,
+    borderTopWidth: 0,
   },
   noTopBorder: {
     borderTopWidth: 0,


### PR DESCRIPTION
Right now it's not always obvious that there are parents when we open a post with parents

![image](https://github.com/bluesky-social/social-app/assets/153161762/fff9309e-f49f-48e1-9d7a-a536373470a6)

This makes it more obvious that there's a parent by making the line connect to the avatar
![Screenshot 2024-02-23 at 1 36 00 PM](https://github.com/bluesky-social/social-app/assets/153161762/e63f5444-dff1-4c2f-9d3a-9d48421cf896)

Still looks the same when we scroll up as well
![Screenshot 2024-02-23 at 1 36 17 PM](https://github.com/bluesky-social/social-app/assets/153161762/d0236872-7796-4b51-8981-b1111f393700)

And we don't make any changes if there are no parents
![Screenshot 2024-02-23 at 1 36 29 PM](https://github.com/bluesky-social/social-app/assets/153161762/44b3b310-9a66-4f17-a0b5-dc01fc30deb7)
