### PR TITLE
Adjust `windowSize` on `PostThread` `FlatList`

### DIFF
--- a/src/view/com/post-thread/PostThread.tsx
+++ b/src/view/com/post-thread/PostThread.tsx
@@ -437,7 +437,6 @@ function PostThreadLoaded({
       // @ts-ignore our .web version only -prf
       desktopFixedHeight
       removeClippedSubviews={isAndroid ? false : undefined}
-      updateCellsBatchingPeriod={100}
       windowSize={11}
     />
   )

--- a/src/view/com/post-thread/PostThread.tsx
+++ b/src/view/com/post-thread/PostThread.tsx
@@ -437,6 +437,8 @@ function PostThreadLoaded({
       // @ts-ignore our .web version only -prf
       desktopFixedHeight
       removeClippedSubviews={isAndroid ? false : undefined}
+      updateCellsBatchingPeriod={100}
+      windowSize={11}
     />
   )
 }


### PR DESCRIPTION
Small changes to the performance props on our `FlatList` in `PostThread`. Right now, we are using the defaults for these two props which are `21` and `50` respectively.

If we adjust the `windowSize` to `11`, we will always have one page rendered in the middle (the visible page), five pages above, and five pages below. This is down from the default of ten on top and ten on the bottom.

https://reactnative.dev/docs/optimizing-flatlist-configuration#windowsize

When opening larger threads right now, even in production there are times where there seems to be a noticeable freeze when rendering. By effectively halving the number of items we render, we can probably clean this up.

## Before
![Screenshot 2024-02-26 at 2 16 49 PM](https://github.com/bluesky-social/social-app/assets/153161762/3dde19a9-4af8-4603-b7f8-811c9e21b05c)

## After
![Screenshot 2024-02-26 at 2 17 18 PM](https://github.com/bluesky-social/social-app/assets/153161762/d0100dbb-776a-435e-bfc0-7fbdf08b9205)


