### PR TITLE
Remove side borders on mobile web list

### DIFF
--- a/src/view/com/util/List.web.tsx
+++ b/src/view/com/util/List.web.tsx
@@ -172,7 +172,7 @@ function ListImpl<ItemT>(
       <View
         ref={containerRef}
         style={[
-          styles.contentContainer,
+          !isMobile && styles.sideBorders,
           contentContainerStyle,
           desktopFixedHeight ? styles.minHeightViewport : null,
           pal.border,
@@ -304,7 +304,7 @@ export const List = memo(React.forwardRef(ListImpl)) as <ItemT>(
 const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent)
 
 const styles = StyleSheet.create({
-  contentContainer: {
+  sideBorders: {
     borderLeftWidth: 1,
     borderRightWidth: 1,
   },


### PR DESCRIPTION
I must've broken it at some point.

Before:

<img width="439" alt="Screenshot 2024-02-27 at 01 20 44" src="https://github.com/bluesky-social/social-app/assets/810438/1455edec-b295-48f4-8f64-7728fc4737e9">

After:

<img width="422" alt="Screenshot 2024-02-27 at 01 20 31" src="https://github.com/bluesky-social/social-app/assets/810438/f52bcf68-b834-440a-8dc5-fea0ed16e2ed">

Same on other screens.

No changes on native or tablet/desktop layouts.