### PR TITLE
Fix imprecise header height calculation

### DIFF
--- a/src/view/com/feeds/FeedPage.tsx
+++ b/src/view/com/feeds/FeedPage.tsx
@@ -200,21 +200,13 @@ export function FeedPage({
 function useHeaderOffset() {
   const {isDesktop, isTablet} = useWebMediaQueries()
   const {fontScale} = useWindowDimensions()
-  const {hasSession} = useSession()
   if (isDesktop || isTablet) {
     return 0
   }
-  if (hasSession) {
-    const navBarPad = 16
-    const navBarText = 21 * fontScale
-    const tabBarPad = 20 + 3 // nav bar padding + border
-    const tabBarText = 16 * fontScale
-    const magic = 7 * fontScale
-    return navBarPad + navBarText + tabBarPad + tabBarText + magic
-  } else {
-    const navBarPad = 16
-    const navBarText = 21 * fontScale
-    const magic = 4 * fontScale
-    return navBarPad + navBarText + magic
-  }
+  const navBarPad = 16
+  const navBarText = 21 * fontScale
+  const tabBarPad = 20 + 3 // nav bar padding + border
+  const tabBarText = 16 * fontScale
+  const magic = 7 * fontScale
+  return navBarPad + navBarText + tabBarPad + tabBarText + magic
 }

--- a/src/view/com/feeds/FeedPage.tsx
+++ b/src/view/com/feeds/FeedPage.tsx
@@ -203,10 +203,9 @@ function useHeaderOffset() {
   if (isDesktop || isTablet) {
     return 0
   }
-  const navBarPad = 16
-  const navBarText = 21 * fontScale
-  const tabBarPad = 20 + 3 // nav bar padding + border
-  const tabBarText = 16 * fontScale
-  const magic = 7 * fontScale
-  return navBarPad + navBarText + tabBarPad + tabBarText + magic
+  const navBarHeight = 42
+  const tabBarPad = 10 + 10 + 3 // padding + border
+  const normalLineHeight = 1.2
+  const tabBarText = 16 * normalLineHeight * fontScale
+  return navBarHeight + tabBarPad + tabBarText
 }


### PR DESCRIPTION
The calculation wasn't precise, causing double borders on large system font sizes.

Verified small and normal text still works well, too.

### Before

<img width="504" alt="Screenshot 2024-02-27 at 02 22 29" src="https://github.com/bluesky-social/social-app/assets/810438/9a46327e-c057-4244-979c-47baa8d718c9">

<img width="331" alt="Screenshot 2024-02-27 at 02 25 22" src="https://github.com/bluesky-social/social-app/assets/810438/d0451404-3555-4332-9481-3c138c51b122">

### After

<img width="504" alt="Screenshot 2024-02-27 at 02 21 54" src="https://github.com/bluesky-social/social-app/assets/810438/a2687c55-55bb-4b83-bfb6-ca147bc4a3e7">

<img width="336" alt="Screenshot 2024-02-27 at 02 25 36" src="https://github.com/bluesky-social/social-app/assets/810438/99834958-7f3b-46cb-a4df-93956c3c1a55">

