### PR TITLE
Fix refetching a timeline leading to a wrong reply author being displayed

### DIFF
--- a/src/state/queries/post-feed.ts
+++ b/src/state/queries/post-feed.ts
@@ -276,7 +276,7 @@ export function usePostFeedQuery(
                             .success
                         ) {
                           return {
-                            _reactKey: `${slice._reactKey}-${i}`,
+                            _reactKey: `${slice._reactKey}-${i}-${item.post.uri}`,
                             uri: item.post.uri,
                             post: item.post,
                             record: item.post.record,


### PR DESCRIPTION
Fixes an issue that caused wrong attribution for reply threads on refresh.

This may be an overly conservative fix:

1) If slice items are always [rendered here](https://github.com/bluesky-social/social-app/blob/d451f82f54974b7b3da1477a7e1f221628860f62/src/view/com/posts/FeedSlice.tsx#L13), there should be no reason to include the slice's key itself. It's enough to distinguish the children.
2) If slice items are guaranteed to be unique posts, then there's no reason to include the index. It should be enough to include the post URI.

 I think (1) probably holds true, while (2) may not necessarily. Regardless, this fix works in either case.

## Test Plan

Courtesy of @haileyok.

1. Set Home to a List that includes yourself.

2. Reply to someone's post in another tab.

3. "Press" on the list to refresh it. You should see your reply.

4. Reply to your the post you just did in another tab.

5. "Press" on the list to refresh it. You should see your reply.

  - At this stage, before the fix, the earlier reply should display incorrect author.
  - After the fix, it displays the correct author.