### PR TITLE
Safeguard posts from clobbered state

### DIFF
--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -94,6 +94,8 @@ export function PostThreadItem({
   if (richText && moderation) {
     return (
       <PostThreadItemLoaded
+        // Safeguard from clobbering per-post state below:
+        key={postShadowed.uri}
         post={postShadowed}
         prevPost={prevPost}
         nextPost={nextPost}

--- a/src/view/com/posts/FeedItem.tsx
+++ b/src/view/com/posts/FeedItem.tsx
@@ -70,6 +70,8 @@ export function FeedItem({
   if (richText && moderation) {
     return (
       <FeedItemInner
+        // Safeguard from clobbering per-post state below:
+        key={postShadowed.uri}
         post={postShadowed}
         record={record}
         reason={reason}


### PR DESCRIPTION
Future-proofs posts so that bugs like https://github.com/bluesky-social/social-app/pull/3005 can't happen. A post should never "receive" a post with a different URL. Even if the parent component accidentally causes that, we should force a remount in this case.

## Test Plan

Revert https://github.com/bluesky-social/social-app/pull/3005, verify its test plan still passes.

(Don't actually revert it tho)