### PR TITLE
Remove dangerous derived state from RichText

### DIFF
--- a/src/components/RichText.tsx
+++ b/src/components/RichText.tsx
@@ -31,8 +31,10 @@ export function RichText({
     enableTags?: boolean
     authorHandle?: string
   }) {
-  const [richText, _setRichText] = React.useState<RichTextAPI>(() =>
-    value instanceof RichTextAPI ? value : new RichTextAPI({text: value}),
+  const richText = React.useMemo(
+    () =>
+      value instanceof RichTextAPI ? value : new RichTextAPI({text: value}),
+    [value],
   )
   const styles = [a.leading_snug, flatten(style)]
 

--- a/src/components/RichText.tsx
+++ b/src/components/RichText.tsx
@@ -7,7 +7,6 @@ import {atoms as a, TextStyleProp, flatten, useTheme, web, native} from '#/alf'
 import {InlineLink} from '#/components/Link'
 import {Text, TextProps} from '#/components/Typography'
 import {toShortUrl} from 'lib/strings/url-helpers'
-import {getAgent} from '#/state/session'
 import {TagMenu, useTagMenuControl} from '#/components/TagMenu'
 import {isNative} from '#/platform/detection'
 import {useInteractionState} from '#/components/hooks/useInteractionState'
@@ -20,7 +19,6 @@ export function RichText({
   style,
   numberOfLines,
   disableLinks,
-  resolveFacets = false,
   selectable,
   enableTags = false,
   authorHandle,
@@ -30,30 +28,13 @@ export function RichText({
     testID?: string
     numberOfLines?: number
     disableLinks?: boolean
-    resolveFacets?: boolean
     enableTags?: boolean
     authorHandle?: string
   }) {
-  const detected = React.useRef(false)
-  const [richText, setRichText] = React.useState<RichTextAPI>(() =>
+  const [richText, _setRichText] = React.useState<RichTextAPI>(() =>
     value instanceof RichTextAPI ? value : new RichTextAPI({text: value}),
   )
   const styles = [a.leading_snug, flatten(style)]
-
-  React.useEffect(() => {
-    if (!resolveFacets) return
-
-    async function detectFacets() {
-      const rt = new RichTextAPI({text: richText.text})
-      await rt.detectFacets(getAgent())
-      setRichText(rt)
-    }
-
-    if (!detected.current) {
-      detected.current = true
-      detectFacets()
-    }
-  }, [richText, setRichText, resolveFacets])
 
   const {text, facets} = richText
 

--- a/src/view/screens/Storybook/Typography.tsx
+++ b/src/view/screens/Storybook/Typography.tsx
@@ -22,12 +22,14 @@ export function Typography() {
       <Text style={[a.text_2xs]}>atoms.text_2xs</Text>
 
       <RichText
-        resolveFacets
+        // TODO: This only supports already resolved facets.
+        // Resolving them on read is bad anyway.
         value={`This is rich text. It can have mentions like @bsky.app or links like https://bsky.social`}
       />
       <RichText
         selectable
-        resolveFacets
+        // TODO: This only supports already resolved facets.
+        // Resolving them on read is bad anyway.
         value={`This is rich text. It can have mentions like @bsky.app or links like https://bsky.social`}
         style={[a.text_xl]}
       />


### PR DESCRIPTION
Currently, `RichText` "caches" the first `value` it receives in state, and fails to update it. Combined with missing or incorrect keys, this leads to bugs like https://github.com/bluesky-social/social-app/pull/3005.

A proper way to rewrite this logic (async work dependent on a prop) would be similar to how it's done here:

https://github.com/bluesky-social/social-app/blob/603f3c0be972e013900264d706e2d28b87a93122/src/view/screens/Profile.tsx#L462-L470

However, we generally don't really want to resolve facets on read, and don't have legit cases for it except the profile bio (which in the future will be corrected on the backend). This functionality of `RichText` component isn't used anywhere so let's remove it.

This lets us replace `useState` with `useMemo`, fixing the "stuck" value.

## Test Plan

Revert https://github.com/bluesky-social/social-app/pull/3005 and https://github.com/bluesky-social/social-app/pull/3006 locally.

Apply this patch.

The problem from https://github.com/bluesky-social/social-app/pull/3005 doesn't happen.

Those fixes are still correct, but this one should fix any other cases where text lost its reactivity.