### PR TITLE
Fix collisions in UITextView for onPress events

### DIFF
--- a/modules/react-native-ui-text-view/ios/RNUITextView.swift
+++ b/modules/react-native-ui-text-view/ios/RNUITextView.swift
@@ -108,14 +108,27 @@ class RNUITextView: UIView {
       fractionOfDistanceBetweenInsertionPoints: nil
     )
 
+    var lastUpperOffset: Int = 0
     for child in self.reactSubviews() {
       if let child = child as? RNUITextViewChild, let childText = child.text {
         let fullText = self.textView.attributedText.string
-        let range = fullText.range(of: childText)
-
+        
+        // We want to skip over the children we have already checked, otherwise we could run into
+        // collisions of similar strings (i.e. links that get shortened to the same hostname but
+        // different paths)
+        let startIndex = fullText.index(fullText.startIndex, offsetBy: lastUpperOffset)
+        let range = fullText.range(of: childText, options: [], range: startIndex..<fullText.endIndex)
+        
         if let lowerBound = range?.lowerBound, let upperBound = range?.upperBound {
-          if charIndex >= lowerBound.utf16Offset(in: fullText) && charIndex <= upperBound.utf16Offset(in: fullText) {
+          let lowerOffset = lowerBound.utf16Offset(in: fullText)
+          let upperOffset = upperBound.utf16Offset(in: fullText)
+          
+          if charIndex >= lowerOffset,
+             charIndex <= upperOffset
+          {
             return child
+          } else {
+            lastUpperOffset = upperOffset
           }
         }
       }


### PR DESCRIPTION
Right now, we find the pressed string's indices in the `NSAttributedString` with `fullText.range(of: childText)`. However, we are not taking into account situations where there may be duplicate strings as in the screenshot below. Each of these has a different `onPress` handler, and the press location will not be the same. However, we are not offsetting the search as we loop through each child.

Instead, we need to save the last offset and apply that to the search, like so:

```
let range = fullText.range(of: childText, options: [], range: startIndex..<fullText.endIndex)
```


https://github.com/bluesky-social/social-app/assets/153161762/c38be82e-0a5b-40a7-9b67-fe591ee4212e


