### PR TITLE
Reset button/input font set by UA

### DIFF
--- a/bskyweb/templates/base.html
+++ b/bskyweb/templates/base.html
@@ -44,6 +44,11 @@
       scrollbar-gutter: stable both-edges;
     }
 
+    /* Buttons and inputs have a font set by UA, so we'll have to reset that */
+    button, input, textarea {
+      font: inherit;
+    }
+
     /* Color theming */
     /* Default will always be white */
     :root {

--- a/bskyweb/templates/base.html
+++ b/bskyweb/templates/base.html
@@ -47,6 +47,7 @@
     /* Buttons and inputs have a font set by UA, so we'll have to reset that */
     button, input, textarea {
       font: inherit;
+      line-height: inherit;
     }
 
     /* Color theming */

--- a/web/index.html
+++ b/web/index.html
@@ -48,6 +48,11 @@
         scrollbar-gutter: stable both-edges;
       }
 
+      /* Buttons and inputs have a font set by UA, so we'll have to reset that */
+      button, input, textarea {
+        font: inherit;
+      }
+
       /* Color theming */
       /* Default will always be white */
       :root {

--- a/web/index.html
+++ b/web/index.html
@@ -51,6 +51,7 @@
       /* Buttons and inputs have a font set by UA, so we'll have to reset that */
       button, input, textarea {
         font: inherit;
+        line-height: inherit;
       }
 
       /* Color theming */


### PR DESCRIPTION
browsers/UA sets a default font on buttons and inputs, causing the following screenshot to happen where the hashtag has a completely different font than the rest of the text

![image](https://github.com/bluesky-social/social-app/assets/148872143/f97bd009-4c3e-4bfe-af39-26de6dfd2f1a)
