### PR TITLE
Enable tags inside of quotes

### DIFF
--- a/src/components/RichText.tsx
+++ b/src/components/RichText.tsx
@@ -78,41 +78,32 @@ export function RichText({
     const link = segment.link
     const mention = segment.mention
     const tag = segment.tag
-    if (
-      mention &&
-      AppBskyRichtextFacet.validateMention(mention).success &&
-      !disableLinks
-    ) {
+    if (mention && AppBskyRichtextFacet.validateMention(mention).success) {
       els.push(
         <InlineLink
           selectable={selectable}
           key={key}
           to={`/profile/${mention.did}`}
-          style={[...styles, {pointerEvents: 'auto'}]}
+          style={[...styles, {pointerEvents: disableLinks ? 'none' : 'auto'}]}
           // @ts-ignore TODO
           dataSet={WORD_WRAP}>
           {segment.text}
         </InlineLink>,
       )
     } else if (link && AppBskyRichtextFacet.validateLink(link).success) {
-      if (disableLinks) {
-        els.push(toShortUrl(segment.text))
-      } else {
-        els.push(
-          <InlineLink
-            selectable={selectable}
-            key={key}
-            to={link.uri}
-            style={[...styles, {pointerEvents: 'auto'}]}
-            // @ts-ignore TODO
-            dataSet={WORD_WRAP}
-            warnOnMismatchingLabel>
-            {toShortUrl(segment.text)}
-          </InlineLink>,
-        )
-      }
+      els.push(
+        <InlineLink
+          selectable={selectable}
+          key={key}
+          to={link.uri}
+          style={[...styles, {pointerEvents: disableLinks ? 'none' : 'auto'}]}
+          // @ts-ignore TODO
+          dataSet={WORD_WRAP}
+          warnOnMismatchingLabel>
+          {toShortUrl(segment.text)}
+        </InlineLink>,
+      )
     } else if (
-      !disableLinks &&
       enableTags &&
       tag &&
       AppBskyRichtextFacet.validateTag(tag).success
@@ -124,6 +115,7 @@ export function RichText({
           style={styles}
           selectable={selectable}
           authorHandle={authorHandle}
+          disableLinks={disableLinks}
         />,
       )
     } else {
@@ -136,7 +128,7 @@ export function RichText({
     <Text
       selectable={selectable}
       testID={testID}
-      style={styles}
+      style={[styles, {pointerEvents: disableLinks ? 'none' : 'auto'}]}
       numberOfLines={numberOfLines}
       // @ts-ignore web only -prf
       dataSet={WORD_WRAP}>
@@ -150,10 +142,12 @@ function RichTextTag({
   style,
   selectable,
   authorHandle,
+  disableLinks,
 }: {
   text: string
   selectable?: boolean
   authorHandle?: string
+  disableLinks?: boolean
 } & TextStyleProp) {
   const t = useTheme()
   const {_} = useLingui()
@@ -202,7 +196,7 @@ function RichTextTag({
           style={[
             style,
             {
-              pointerEvents: 'auto',
+              pointerEvents: disableLinks ? 'none' : 'auto',
               color: t.palette.primary_500,
             },
             web({

--- a/src/view/com/util/post-embeds/QuoteEmbed.tsx
+++ b/src/view/com/util/post-embeds/QuoteEmbed.tsx
@@ -93,7 +93,9 @@ export function QuoteEmbed({
       quote.text.trim()
         ? new RichTextAPI({
             text: quote.text,
-            facets: quote.facets?.filter(f => !!f.features[0].tag),
+            facets: quote.facets?.filter(
+              f => !!f.features[0].tag || !!f.features[0].did,
+            ),
           })
         : undefined,
     [quote.text, quote.facets],

--- a/src/view/com/util/post-embeds/QuoteEmbed.tsx
+++ b/src/view/com/util/post-embeds/QuoteEmbed.tsx
@@ -130,15 +130,14 @@ export function QuoteEmbed({
         <PostAlerts moderation={moderation} style={styles.alert} />
       ) : null}
       {richText ? (
-        <View pointerEvents="none">
-          <RichText
-            enableTags
-            value={richText}
-            style={[a.text_md]}
-            numberOfLines={20}
-            authorHandle={quote.author.handle}
-          />
-        </View>
+        <RichText
+          enableTags
+          disableLinks
+          value={richText}
+          style={[a.text_md]}
+          numberOfLines={20}
+          authorHandle={quote.author.handle}
+        />
       ) : null}
       {embed && <PostEmbeds embed={embed} moderation={{}} />}
     </Link>

--- a/src/view/com/util/post-embeds/QuoteEmbed.tsx
+++ b/src/view/com/util/post-embeds/QuoteEmbed.tsx
@@ -132,10 +132,10 @@ export function QuoteEmbed({
       {richText ? (
         <RichText
           enableTags
-          disableLinks
           value={richText}
           style={[a.text_md]}
           numberOfLines={20}
+          disableLinks
           authorHandle={quote.author.handle}
         />
       ) : null}

--- a/src/view/com/util/post-embeds/QuoteEmbed.tsx
+++ b/src/view/com/util/post-embeds/QuoteEmbed.tsx
@@ -91,7 +91,10 @@ export function QuoteEmbed({
   const richText = React.useMemo(
     () =>
       quote.text.trim()
-        ? new RichTextAPI({text: quote.text, facets: quote.facets})
+        ? new RichTextAPI({
+            text: quote.text,
+            facets: quote.facets?.filter(f => !!f.features[0].tag),
+          })
         : undefined,
     [quote.text, quote.facets],
   )
@@ -132,7 +135,6 @@ export function QuoteEmbed({
           value={richText}
           style={[a.text_md]}
           numberOfLines={20}
-          disableLinks
           authorHandle={quote.author.handle}
         />
       ) : null}

--- a/src/view/com/util/post-embeds/QuoteEmbed.tsx
+++ b/src/view/com/util/post-embeds/QuoteEmbed.tsx
@@ -93,9 +93,7 @@ export function QuoteEmbed({
       quote.text.trim()
         ? new RichTextAPI({
             text: quote.text,
-            facets: quote.facets?.filter(
-              f => !!f.features[0].tag || !!f.features[0].did,
-            ),
+            facets: quote.facets,
           })
         : undefined,
     [quote.text, quote.facets],
@@ -132,13 +130,15 @@ export function QuoteEmbed({
         <PostAlerts moderation={moderation} style={styles.alert} />
       ) : null}
       {richText ? (
-        <RichText
-          enableTags
-          value={richText}
-          style={[a.text_md]}
-          numberOfLines={20}
-          authorHandle={quote.author.handle}
-        />
+        <View pointerEvents="none">
+          <RichText
+            enableTags
+            value={richText}
+            style={[a.text_md]}
+            numberOfLines={20}
+            authorHandle={quote.author.handle}
+          />
+        </View>
       ) : null}
       {embed && <PostEmbeds embed={embed} moderation={{}} />}
     </Link>


### PR DESCRIPTION
Highlighting tags, links, etc. in quotes but keeping them unpressable. We should discuss if we actually want to do this though.

![Screenshot 2024-02-28 at 7 01 37 PM](https://github.com/bluesky-social/social-app/assets/153161762/615a48ba-8e0b-4eae-a4cf-5ddb3651cbc3)

![Screenshot 2024-02-28 at 7 05 29 PM](https://github.com/bluesky-social/social-app/assets/153161762/0acf5d63-ae97-4d3f-becc-a095fac6f8eb)
