### PR TITLE
Simplify intent path logic, ensure all variations work for bluesky://, bluesky:///, and https://bsky.app/

### DIFF
--- a/src/lib/hooks/useIntentHandler.ts
+++ b/src/lib/hooks/useIntentHandler.ts
@@ -19,7 +19,7 @@ export function useIntentHandler() {
       // slashes, like bluesky:///intent/follow. However, supporting just two slashes causes us to have to take care
       // of two cases when parsing the url. If we ensure there is a third slash, we can always ensure the first
       // path parameter is in pathname rather than in hostname.
-      if (url.includes('bluesky://') && !url.includes('bluesky:///')) {
+      if (url.startsWith('bluesky://') && !url.startsWith('bluesky:///')) {
         url = url.replace('bluesky://', 'bluesky:///')
       }
 

--- a/src/lib/hooks/useIntentHandler.ts
+++ b/src/lib/hooks/useIntentHandler.ts
@@ -15,15 +15,20 @@ export function useIntentHandler() {
 
   React.useEffect(() => {
     const handleIncomingURL = (url: string) => {
+      // We want to be able to support bluesky:// deeplinks. It's unnatural for someone to use a deeplink with three
+      // slashes, like bluesky:///intent/follow. However, supporting just two slashes causes us to have to take care
+      // of two cases when parsing the url. If we ensure there is a third slash, we can always ensure the first
+      // path parameter is in pathname rather than in hostname.
+      if (url.includes('bluesky://') && !url.includes('bluesky:///')) {
+        url = url.replace('bluesky://', 'bluesky:///')
+      }
+
       const urlp = new URL(url)
-      const [_, intentTypeNative, intentTypeWeb] = urlp.pathname.split('/')
+      const [_, intent, intentType] = urlp.pathname.split('/')
 
       // On native, our links look like bluesky://intent/SomeIntent, so we have to check the hostname for the
       // intent check. On web, we have to check the first part of the path since we have an actual hostname
-      const intentType = isNative ? intentTypeNative : intentTypeWeb
-      const isIntent = isNative
-        ? urlp.hostname === 'intent'
-        : intentTypeNative === 'intent'
+      const isIntent = intent === 'intent'
       const params = urlp.searchParams
 
       if (!isIntent) return
@@ -69,10 +74,7 @@ function useComposeIntent() {
             return false
           }
           // We also should just filter out cases that don't have all the info we need
-          if (!VALID_IMAGE_REGEX.test(part)) {
-            return false
-          }
-          return true
+          return VALID_IMAGE_REGEX.test(part)
         })
         .map(part => {
           const [uri, width, height] = part.split('|')


### PR DESCRIPTION
## Why

When checking the intent path, we use `new URL(url)` to parse the url. Generally, it is awkward for someone to use `bluesky:///intent/compose` since we commonly only use two slashes in a URL scheme. However, if we use `bluesky://intent/compose`, this makes the first part of the intent the hostname rather than part of the pathname.

Right now, we work around that with an `isNative` check. However, it is also possible for Safari to deep link into our app through `https://bsky.app/`. In that case, our `isNative` check will fail since we are checking the hostname for `=== intent` rather than the first part of the path name.

## How

The best option is to ensure that `bluesky://` is converted to `bluesky:///` so that we can just always check the first part of the pathname for `=== intent` rather than having to apply `isNative` logic and possibly missing some variations of the deeplink.

## Test

To test, use both `bluesky://intent/compose?text=Test One` and `bluesky:///intent/compose?text=Test Two` from a simulator.