### PR TITLE
Dedicated screen for hashtags, POC ALF list

### DIFF
--- a/bskyweb/cmd/bskyweb/server.go
+++ b/bskyweb/cmd/bskyweb/server.go
@@ -180,6 +180,7 @@ func serve(cctx *cli.Context) error {
 	e.GET("/", server.WebHome)
 
 	// generic routes
+	e.GET("/hashtag", server.WebGeneric)
 	e.GET("/search", server.WebGeneric)
 	e.GET("/feeds", server.WebGeneric)
 	e.GET("/notifications", server.WebGeneric)

--- a/bskyweb/cmd/bskyweb/server.go
+++ b/bskyweb/cmd/bskyweb/server.go
@@ -180,7 +180,7 @@ func serve(cctx *cli.Context) error {
 	e.GET("/", server.WebHome)
 
 	// generic routes
-	e.GET("/hashtag", server.WebGeneric)
+	e.GET("/hashtag/:tag", server.WebGeneric)
 	e.GET("/search", server.WebGeneric)
 	e.GET("/feeds", server.WebGeneric)
 	e.GET("/notifications", server.WebGeneric)

--- a/src/Navigation.tsx
+++ b/src/Navigation.tsx
@@ -77,6 +77,7 @@ import {PreferencesExternalEmbeds} from '#/view/screens/PreferencesExternalEmbed
 import {createNativeStackNavigatorWithAuth} from './view/shell/createNativeStackNavigatorWithAuth'
 import {msg} from '@lingui/macro'
 import {i18n, MessageDescriptor} from '@lingui/core'
+import HashtagScreen from '#/screens/Hashtag'
 
 const navigationRef = createNavigationContainerRef<AllNavigatorParams>()
 
@@ -261,6 +262,11 @@ function commonScreens(Stack: typeof HomeTab, unreadCountLabel?: string) {
           title: title(msg`External Media Preferences`),
           requireAuth: true,
         }}
+      />
+      <Stack.Screen
+        name="Hashtag"
+        getComponent={() => HashtagScreen}
+        options={{title: title(msg`Hashtag`)}}
       />
     </>
   )

--- a/src/components/Lists.tsx
+++ b/src/components/Lists.tsx
@@ -1,0 +1,126 @@
+import React from 'react'
+import {atoms as a, useTheme} from '#/alf'
+import {Text, View} from 'react-native'
+import {Loader} from '#/components/Loader'
+import {Trans} from '@lingui/macro'
+import {cleanError} from 'lib/strings/errors'
+import {useWebMediaQueries} from 'lib/hooks/useWebMediaQueries'
+import {Button} from '#/components/Button'
+
+export function ListFooter({
+  isFetching,
+  isError,
+  error,
+  onRetry,
+}: {
+  isFetching: boolean
+  isError: boolean
+  error?: string
+  onRetry?: () => Promise<unknown>
+}) {
+  const t = useTheme()
+
+  return (
+    <View
+      style={[
+        a.w_full,
+        a.align_center,
+        a.justify_center,
+        a.border_t,
+        t.atoms.border_contrast_low,
+        {height: 100},
+      ]}>
+      {isFetching ? (
+        <Loader size="xl" />
+      ) : (
+        <ListFooterMaybeError
+          isError={isError}
+          error={error}
+          onRetry={onRetry}
+        />
+      )}
+    </View>
+  )
+}
+
+function ListFooterMaybeError({
+  isError,
+  error,
+  onRetry,
+}: {
+  isError: boolean
+  error?: string
+  onRetry?: () => Promise<unknown>
+}) {
+  const t = useTheme()
+
+  if (!isError) return null
+
+  return (
+    <View style={[a.w_full, a.px_lg]}>
+      <View
+        style={[
+          a.flex_row,
+          a.gap_md,
+          a.p_md,
+          a.rounded_sm,
+          a.align_center,
+          t.atoms.bg_contrast_25,
+        ]}>
+        <Text
+          style={[a.flex_1, a.text_sm, t.atoms.text_contrast_medium]}
+          numberOfLines={2}>
+          {error ? (
+            cleanError(error)
+          ) : (
+            <Trans>Oops, something went wrong!</Trans>
+          )}
+        </Text>
+        <Button
+          variant="gradient"
+          label="Press to retry"
+          style={[
+            a.align_center,
+            a.justify_center,
+            a.rounded_sm,
+            a.overflow_hidden,
+            a.px_md,
+            a.py_sm,
+          ]}
+          onPress={onRetry}>
+          Retry
+        </Button>
+      </View>
+    </View>
+  )
+}
+export function ListMaybeLoading({isLoading}: {isLoading: boolean}) {
+  if (!isLoading) return
+  return (
+    <View style={[a.w_full, a.align_center, {top: 100}]}>
+      <Loader size="xl" />
+    </View>
+  )
+}
+
+export function ListHeaderDesktop({
+  title,
+  subtitle,
+}: {
+  title: string
+  subtitle?: string
+}) {
+  const {isDesktop} = useWebMediaQueries()
+  const t = useTheme()
+
+  if (!isDesktop) return null
+
+  return (
+    <View style={[a.w_full, a.py_lg, a.px_xl, a.gap_xs]}>
+      <Text style={[a.text_3xl, a.font_bold, t.atoms.text]}>{title}</Text>
+      {subtitle ? (
+        <Text style={[a.text_md, t.atoms.text]}>{subtitle}</Text>
+      ) : undefined}
+    </View>
+  )
+}

--- a/src/components/Lists.tsx
+++ b/src/components/Lists.tsx
@@ -1,10 +1,9 @@
 import React from 'react'
-import {atoms as a, useTheme} from '#/alf'
+import {atoms as a, useBreakpoints, useTheme} from '#/alf'
 import {View} from 'react-native'
 import {Loader} from '#/components/Loader'
 import {Trans} from '@lingui/macro'
 import {cleanError} from 'lib/strings/errors'
-import {useWebMediaQueries} from 'lib/hooks/useWebMediaQueries'
 import {Button} from '#/components/Button'
 import {Text} from '#/components/Typography'
 import {StackActions} from '@react-navigation/native'
@@ -106,10 +105,10 @@ export function ListHeaderDesktop({
   title: string
   subtitle?: string
 }) {
-  const {isDesktop} = useWebMediaQueries()
+  const {gtTablet} = useBreakpoints()
   const t = useTheme()
 
-  if (!isDesktop) return null
+  if (!gtTablet) return null
 
   return (
     <View style={[a.w_full, a.py_lg, a.px_xl, a.gap_xs]}>

--- a/src/components/Lists.tsx
+++ b/src/components/Lists.tsx
@@ -123,15 +123,6 @@ export function ListHeaderDesktop({
   )
 }
 
-function ListMaybeLoading({isLoading}: {isLoading: boolean}) {
-  if (!isLoading) return
-  return (
-    <View style={[a.w_full, a.align_center, {top: 100}]}>
-      <Loader size="xl" />
-    </View>
-  )
-}
-
 export function ListMaybePlaceholder({
   isLoading,
   isEmpty,
@@ -162,10 +153,6 @@ export function ListMaybePlaceholder({
 
   if (!isEmpty) return null
 
-  if (isLoading) {
-    return <ListMaybeLoading isLoading={isLoading} />
-  }
-
   return (
     <View
       style={[
@@ -176,46 +163,67 @@ export function ListMaybePlaceholder({
         t.atoms.border_contrast_low,
         {paddingTop: 175, paddingBottom: 110},
       ]}>
-      <View style={[a.w_full, a.align_center, a.gap_lg]}>
-        <Text style={[a.font_bold, a.text_3xl]}>
-          <Trans>Page not found</Trans>
-        </Text>
-        {isEmpty && (
-          <Text style={[a.text_md, a.text_center, t.atoms.text_contrast_high]}>
-            {empty ? (
-              empty
-            ) : (
-              <Trans>
-                We're sorry! We can't find the page you were looking for.
-              </Trans>
+      {isLoading ? (
+        <View style={[a.w_full, a.align_center, {top: 100}]}>
+          <Loader size="xl" />
+        </View>
+      ) : (
+        <>
+          <View style={[a.w_full, a.align_center, a.gap_lg]}>
+            <Text style={[a.font_bold, a.text_3xl]}>
+              {isError ? (
+                <Trans>Oops!</Trans>
+              ) : isEmpty ? (
+                <Trans>Page not found</Trans>
+              ) : undefined}
+            </Text>
+
+            {isError ? (
+              <Text
+                style={[a.text_md, a.text_center, t.atoms.text_contrast_high]}>
+                {error ? error : <Trans>Something went wrong!</Trans>}
+              </Text>
+            ) : isEmpty ? (
+              <Text
+                style={[a.text_md, a.text_center, t.atoms.text_contrast_high]}>
+                {empty ? (
+                  empty
+                ) : (
+                  <Trans>
+                    We're sorry! We can't find the page you were looking for.
+                  </Trans>
+                )}
+              </Text>
+            ) : undefined}
+          </View>
+          <View style={[a.w_full, a.px_lg, a.gap_md]}>
+            {isError && onRetry && (
+              <Button
+                variant="solid"
+                color="primary"
+                label="Click here"
+                onPress={onRetry}
+                size="large"
+                style={[
+                  a.rounded_sm,
+                  a.overflow_hidden,
+                  {paddingVertical: 10},
+                ]}>
+                Retry
+              </Button>
             )}
-          </Text>
-        )}
-        {isError && (
-          <Text style={[a.text_md]}>
-            {error ? error : <Trans>Something went wrong!</Trans>}
-          </Text>
-        )}
-      </View>
-      <View style={[a.w_full, a.px_lg]}>
-        {isError && onRetry && (
-          <Button
-            variant="solid"
-            color="primary"
-            size="large"
-            label="Click here">
-            Go Back
-          </Button>
-        )}
-        <Button
-          variant="solid"
-          color={isError && onRetry ? 'secondary' : 'primary'}
-          size="large"
-          label="Click here"
-          onPress={onGoBack}>
-          Go Back
-        </Button>
-      </View>
+            <Button
+              variant="solid"
+              color={isError && onRetry ? 'secondary' : 'primary'}
+              label="Click here"
+              onPress={onGoBack}
+              size="large"
+              style={[a.rounded_sm, a.overflow_hidden, {paddingVertical: 10}]}>
+              Go Back
+            </Button>
+          </View>
+        </>
+      )}
     </View>
   )
 }

--- a/src/components/TagMenu/index.tsx
+++ b/src/components/TagMenu/index.tsx
@@ -93,12 +93,8 @@ export function TagMenu({
                     e.preventDefault()
 
                     control.close(() => {
-                      // @ts-ignore :ron_swanson: "I know more than you"
-                      navigation.navigate('SearchTab', {
-                        screen: 'Search',
-                        params: {
-                          q: tag,
-                        },
+                      navigation.push('Hashtag', {
+                        tag: tag.replace('#', ''),
                       })
                     })
 
@@ -149,14 +145,9 @@ export function TagMenu({
                         e.preventDefault()
 
                         control.close(() => {
-                          // @ts-ignore :ron_swanson: "I know more than you"
-                          navigation.navigate('SearchTab', {
-                            screen: 'Search',
-                            params: {
-                              q:
-                                tag +
-                                (authorHandle ? ` from:${authorHandle}` : ''),
-                            },
+                          navigation.push('Hashtag', {
+                            tag: tag.replace('#', ''),
+                            author: authorHandle,
                           })
                         })
 

--- a/src/components/TagMenu/index.tsx
+++ b/src/components/TagMenu/index.tsx
@@ -94,7 +94,7 @@ export function TagMenu({
 
                     control.close(() => {
                       navigation.push('Hashtag', {
-                        tag: tag.replace('#', ''),
+                        tag: tag.slice(1).replaceAll('#', '%23'),
                       })
                     })
 
@@ -146,7 +146,7 @@ export function TagMenu({
 
                         control.close(() => {
                           navigation.push('Hashtag', {
-                            tag: tag.replace('#', ''),
+                            tag: tag.slice(1).replaceAll('#', '%23'),
                             author: authorHandle,
                           })
                         })

--- a/src/components/TagMenu/index.web.tsx
+++ b/src/components/TagMenu/index.web.tsx
@@ -49,8 +49,8 @@ export function TagMenu({
       {
         label: _(msg`See ${truncatedTag} posts`),
         onPress() {
-          navigation.navigate('Search', {
-            q: tag,
+          navigation.push('Hashtag', {
+            tag: tag.replace('#', ''),
           })
         },
         testID: 'tagMenuSearch',
@@ -66,11 +66,9 @@ export function TagMenu({
         !isInvalidHandle(authorHandle) && {
           label: _(msg`See ${truncatedTag} posts by user`),
           onPress() {
-            navigation.navigate({
-              name: 'Search',
-              params: {
-                q: tag + (authorHandle ? ` from:${authorHandle}` : ''),
-              },
+            navigation.push('Hashtag', {
+              tag: tag.replace('#', ''),
+              author: authorHandle,
             })
           },
           testID: 'tagMenuSeachByUser',

--- a/src/components/TagMenu/index.web.tsx
+++ b/src/components/TagMenu/index.web.tsx
@@ -50,7 +50,7 @@ export function TagMenu({
         label: _(msg`See ${truncatedTag} posts`),
         onPress() {
           navigation.push('Hashtag', {
-            tag: tag.replace('#', ''),
+            tag: tag.slice(1).replaceAll('#', '%23'),
           })
         },
         testID: 'tagMenuSearch',
@@ -67,7 +67,7 @@ export function TagMenu({
           label: _(msg`See ${truncatedTag} posts by user`),
           onPress() {
             navigation.push('Hashtag', {
-              tag: tag.replace('#', ''),
+              tag: tag.slice(1).replaceAll('#', '%23'),
               author: authorHandle,
             })
           },

--- a/src/lib/routes/types.ts
+++ b/src/lib/routes/types.ts
@@ -34,6 +34,7 @@ export type CommonNavigatorParams = {
   PreferencesThreads: undefined
   PreferencesExternalEmbeds: undefined
   Search: {q?: string}
+  Hashtag: {tag: string; author?: string}
 }
 
 export type BottomTabNavigatorParams = CommonNavigatorParams & {
@@ -69,6 +70,7 @@ export type FlatNavigatorParams = CommonNavigatorParams & {
   Search: {q?: string}
   Feeds: undefined
   Notifications: undefined
+  Hashtag: {tag: string; author?: string}
 }
 
 export type AllNavigatorParams = CommonNavigatorParams & {
@@ -81,6 +83,7 @@ export type AllNavigatorParams = CommonNavigatorParams & {
   NotificationsTab: undefined
   Notifications: undefined
   MyProfileTab: undefined
+  Hashtag: {tag: string; author?: string}
 }
 
 // NOTE

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -33,4 +33,5 @@ export const router = new Router({
   TermsOfService: '/support/tos',
   CommunityGuidelines: '/support/community-guidelines',
   CopyrightPolicy: '/support/copyright',
+  Hashtag: '/hashtag/:tag',
 })

--- a/src/screens/Hashtag.tsx
+++ b/src/screens/Hashtag.tsx
@@ -32,20 +32,22 @@ const keyExtractor = (item: PostView, index: number) => {
 export default function HashtagScreen({
   route,
 }: NativeStackScreenProps<CommonNavigatorParams, 'Hashtag'>) {
-  const {tag, author} = route.params
+  const {tag: routeTag, author} = route.params
   const setMinimalShellMode = useSetMinimalShellMode()
   const {_} = useLingui()
   const [isPTR, setIsPTR] = React.useState(false)
 
-  const query = React.useMemo(() => {
-    const queryTag = !tag.startsWith('#') ? `#${tag}` : tag
+  const tag = React.useMemo(() => {
+    return routeTag.replace('%23', '#')
+  }, [routeTag])
 
-    if (!author) return queryTag
-    return `${queryTag} from:${sanitizeHandle(author)}`
+  const queryParam = React.useMemo(() => {
+    if (!author) return tag
+    return `${tag} from:${sanitizeHandle(tag)}`
   }, [tag, author])
 
   const headerTitle = React.useMemo(() => {
-    return `#${enforceLen(tag.toLowerCase(), 24, true, 'middle')}`
+    return enforceLen(tag.toLowerCase(), 24, true, 'middle')
   }, [tag])
 
   const {
@@ -58,7 +60,7 @@ export default function HashtagScreen({
     refetch,
     fetchNextPage,
     hasNextPage,
-  } = useSearchPostsQuery({query})
+  } = useSearchPostsQuery({query: queryParam})
 
   const posts = React.useMemo(() => {
     return data?.pages.flatMap(page => page.posts) || []
@@ -85,9 +87,7 @@ export default function HashtagScreen({
     <CenteredView style={a.flex_1}>
       <ViewHeader
         title={headerTitle}
-        subtitle={
-          author ? `${_(msg`From`)} @${sanitizeHandle(author)}` : undefined
-        }
+        subtitle={author ? _(msg`From @${sanitizeHandle(author)}`) : undefined}
         canGoBack={true}
       />
       <ListMaybePlaceholder
@@ -112,9 +112,7 @@ export default function HashtagScreen({
             <ListHeaderDesktop
               title={headerTitle}
               subtitle={
-                author
-                  ? `${_(msg`From`)} @${sanitizeHandle(author)}`
-                  : undefined
+                author ? _(msg`From @${sanitizeHandle(author)}`) : undefined
               }
             />
           }

--- a/src/screens/Hashtag.tsx
+++ b/src/screens/Hashtag.tsx
@@ -92,11 +92,12 @@ export default function HashtagScreen({
       />
       <ListMaybePlaceholder
         isLoading={isLoading || isRefetching}
-        isError={true}
-        isEmpty={posts.length < 2}
+        isError={isError}
+        isEmpty={posts.length < 1}
         onRetry={refetch}
+        empty={_(msg`We couldn't find any results for that hashtag.`)}
       />
-      {!isLoading && posts.length > 1 && (
+      {!isLoading && posts.length > 0 && (
         <List<PostView>
           data={posts}
           renderItem={renderItem}

--- a/src/screens/Hashtag.tsx
+++ b/src/screens/Hashtag.tsx
@@ -120,7 +120,7 @@ export default function HashtagScreen({
           }
           ListFooterComponent={
             <ListFooter
-              isFetching={isFetching}
+              isFetching={isFetching && !isRefetching}
               isError={isError}
               error={error?.name}
               onRetry={fetchNextPage}

--- a/src/screens/Hashtag.tsx
+++ b/src/screens/Hashtag.tsx
@@ -38,7 +38,7 @@ export default function HashtagScreen({
   const [isPTR, setIsPTR] = React.useState(false)
 
   const fullTag = React.useMemo(() => {
-    return `#${tag.replace('%23', '#')}`
+    return `#${tag.replaceAll('%23', '#')}`
   }, [tag])
 
   const queryParam = React.useMemo(() => {

--- a/src/screens/Hashtag.tsx
+++ b/src/screens/Hashtag.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import {ListRenderItemInfo} from 'react-native'
+import {ListRenderItemInfo, Pressable} from 'react-native'
 import {atoms as a} from '#/alf'
 import {useFocusEffect} from '@react-navigation/native'
 import {useSetMinimalShellMode} from 'state/shell'
@@ -20,6 +20,9 @@ import {msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 import {sanitizeHandle} from 'lib/strings/handles'
 import {CenteredView} from 'view/com/util/Views'
+import {ArrowOutOfBox_Stroke2_Corner0_Rounded} from '#/components/icons/ArrowOutOfBox'
+import {shareUrl} from 'lib/sharing'
+import {HITSLOP_10} from 'lib/constants'
 
 const renderItem = ({item}: ListRenderItemInfo<PostView>) => {
   return <Post post={item} />
@@ -77,6 +80,15 @@ export default function HashtagScreen({
     }, [setMinimalShellMode]),
   )
 
+  const onShare = React.useCallback(() => {
+    const url = new URL('https://bsky.app')
+    url.pathname = `/hashtag/${tag}`
+    if (author) {
+      url.searchParams.set('author', author)
+    }
+    shareUrl(url.toString())
+  }, [tag, author])
+
   const onRefresh = React.useCallback(async () => {
     setIsPTR(true)
     await refetch()
@@ -94,6 +106,17 @@ export default function HashtagScreen({
         title={headerTitle}
         subtitle={author ? _(msg`From @${sanitizedAuthor}`) : undefined}
         canGoBack={true}
+        renderButton={() => (
+          <Pressable
+            accessibilityRole="button"
+            onPress={onShare}
+            hitSlop={HITSLOP_10}>
+            <ArrowOutOfBox_Stroke2_Corner0_Rounded
+              size="lg"
+              onPress={onShare}
+            />
+          </Pressable>
+        )}
       />
       <ListMaybePlaceholder
         isLoading={isLoading || isRefetching}

--- a/src/screens/Hashtag.tsx
+++ b/src/screens/Hashtag.tsx
@@ -50,6 +50,11 @@ export default function HashtagScreen({
     return enforceLen(fullTag.toLowerCase(), 24, true, 'middle')
   }, [fullTag])
 
+  const sanitizedAuthor = React.useMemo(() => {
+    if (!author) return
+    return sanitizeHandle(author)
+  }, [author])
+
   const {
     data,
     isFetching,
@@ -87,7 +92,7 @@ export default function HashtagScreen({
     <CenteredView style={a.flex_1}>
       <ViewHeader
         title={headerTitle}
-        subtitle={author ? _(msg`From @${sanitizeHandle(author)}`) : undefined}
+        subtitle={author ? _(msg`From @${sanitizedAuthor}`) : undefined}
         canGoBack={true}
       />
       <ListMaybePlaceholder
@@ -111,9 +116,7 @@ export default function HashtagScreen({
           ListHeaderComponent={
             <ListHeaderDesktop
               title={headerTitle}
-              subtitle={
-                author ? _(msg`From @${sanitizeHandle(author)}`) : undefined
-              }
+              subtitle={author ? _(msg`From @${sanitizedAuthor}`) : undefined}
             />
           }
           ListFooterComponent={

--- a/src/screens/Hashtag.tsx
+++ b/src/screens/Hashtag.tsx
@@ -13,7 +13,7 @@ import {enforceLen} from 'lib/strings/helpers'
 import {
   ListFooter,
   ListHeaderDesktop,
-  ListMaybeLoading,
+  ListMaybePlaceholder,
 } from '#/components/Lists'
 import {List} from 'view/com/util/List'
 import {msg} from '@lingui/macro'
@@ -85,8 +85,12 @@ export default function HashtagScreen({
         subtitle={author ? `${_(msg`By`)} ${author}` : undefined}
         canGoBack={true}
       />
-      <ListMaybeLoading isLoading={isLoading} />
-      {!isLoading && (
+      <ListMaybePlaceholder
+        isLoading={isLoading}
+        isError={isError}
+        isEmpty={posts.length < 2}
+      />
+      {!isLoading && posts.length > 1 && (
         <List<PostView>
           data={posts}
           renderItem={renderItem}

--- a/src/screens/Hashtag.tsx
+++ b/src/screens/Hashtag.tsx
@@ -18,6 +18,7 @@ import {
 import {List} from 'view/com/util/List'
 import {msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
+import {sanitizeHandle} from 'lib/strings/handles'
 
 const renderItem = ({item}: ListRenderItemInfo<PostView>) => {
   return <Post post={item} />
@@ -39,7 +40,7 @@ export default function HashtagScreen({
     const queryTag = !tag.startsWith('#') ? `#${tag}` : tag
 
     if (!author) return queryTag
-    return `${queryTag} from:${author}`
+    return `${queryTag} from:${sanitizeHandle(author)}`
   }, [tag, author])
 
   const headerTitle = React.useMemo(() => {
@@ -83,7 +84,9 @@ export default function HashtagScreen({
     <View style={a.flex_1}>
       <ViewHeader
         title={headerTitle}
-        subtitle={author ? `${_(msg`By`)} ${author}` : undefined}
+        subtitle={
+          author ? `${_(msg`By`)} ${sanitizeHandle(author)}` : undefined
+        }
         canGoBack={true}
       />
       <ListMaybePlaceholder
@@ -106,7 +109,9 @@ export default function HashtagScreen({
           ListHeaderComponent={
             <ListHeaderDesktop
               title={headerTitle}
-              subtitle={author ? `${_(msg`By`)} ${author}` : undefined}
+              subtitle={
+                author ? `${_(msg`By`)} ${sanitizeHandle(author)}` : undefined
+              }
             />
           }
           ListFooterComponent={

--- a/src/screens/Hashtag.tsx
+++ b/src/screens/Hashtag.tsx
@@ -45,7 +45,7 @@ export default function HashtagScreen({
   }, [tag, author])
 
   const headerTitle = React.useMemo(() => {
-    return `#${enforceLen(tag.toLowerCase(), 24)}`
+    return `#${enforceLen(tag.toLowerCase(), 24, true, 'middle')}`
   }, [tag])
 
   const {
@@ -86,7 +86,7 @@ export default function HashtagScreen({
       <ViewHeader
         title={headerTitle}
         subtitle={
-          author ? `${_(msg`By`)} ${sanitizeHandle(author)}` : undefined
+          author ? `${_(msg`From`)} @${sanitizeHandle(author)}` : undefined
         }
         canGoBack={true}
       />
@@ -112,7 +112,9 @@ export default function HashtagScreen({
             <ListHeaderDesktop
               title={headerTitle}
               subtitle={
-                author ? `${_(msg`By`)} ${sanitizeHandle(author)}` : undefined
+                author
+                  ? `${_(msg`From`)} @${sanitizeHandle(author)}`
+                  : undefined
               }
             />
           }

--- a/src/screens/Hashtag.tsx
+++ b/src/screens/Hashtag.tsx
@@ -1,0 +1,115 @@
+import React from 'react'
+import {ListRenderItemInfo, View} from 'react-native'
+import {atoms as a} from '#/alf'
+import {useFocusEffect} from '@react-navigation/native'
+import {useSetMinimalShellMode} from 'state/shell'
+import {ViewHeader} from 'view/com/util/ViewHeader'
+import {NativeStackScreenProps} from '@react-navigation/native-stack'
+import {CommonNavigatorParams} from 'lib/routes/types'
+import {useSearchPostsQuery} from 'state/queries/search-posts'
+import {Post} from 'view/com/post/Post'
+import {PostView} from '@atproto/api/dist/client/types/app/bsky/feed/defs'
+import {enforceLen} from 'lib/strings/helpers'
+import {
+  ListFooter,
+  ListHeaderDesktop,
+  ListMaybeLoading,
+} from '#/components/Lists'
+import {List} from 'view/com/util/List'
+
+const renderItem = ({item}: ListRenderItemInfo<PostView>) => {
+  return <Post post={item} />
+}
+
+const keyExtractor = (item: PostView, index: number) => {
+  return `${item.uri}-${index}`
+}
+
+export default function HashtagScreen({
+  route,
+}: NativeStackScreenProps<CommonNavigatorParams, 'Hashtag'>) {
+  const {tag, author} = route.params
+  const setMinimalShellMode = useSetMinimalShellMode()
+  const [isPTR, setIsPTR] = React.useState(false)
+
+  const query = React.useMemo(() => {
+    const queryTag = !tag.startsWith('#') ? `#${tag}` : tag
+
+    if (!author) return queryTag
+    return `${queryTag} from:${author}`
+  }, [tag, author])
+
+  const headerTitle = React.useMemo(() => {
+    return `#${enforceLen(tag.toLowerCase(), 24)}`
+  }, [tag])
+
+  const {
+    data,
+    isFetching,
+    isLoading,
+    isError,
+    error,
+    refetch,
+    fetchNextPage,
+    hasNextPage,
+  } = useSearchPostsQuery({query})
+
+  const posts = React.useMemo(() => {
+    return data?.pages.flatMap(page => page.posts) || []
+  }, [data])
+
+  useFocusEffect(
+    React.useCallback(() => {
+      setMinimalShellMode(false)
+    }, [setMinimalShellMode]),
+  )
+
+  const onRefresh = React.useCallback(async () => {
+    setIsPTR(true)
+    await refetch()
+    setIsPTR(false)
+  }, [refetch])
+
+  const onEndReached = React.useCallback(() => {
+    if (isFetching || !hasNextPage || error) return
+    fetchNextPage()
+  }, [isFetching, hasNextPage, error, fetchNextPage])
+
+  return (
+    <View style={a.flex_1}>
+      <ViewHeader
+        title={headerTitle}
+        subtitle={author ? `By ${author}` : undefined}
+        canGoBack={true}
+      />
+      <ListMaybeLoading isLoading={isLoading} />
+      {!isLoading && (
+        <List<PostView>
+          data={posts}
+          renderItem={renderItem}
+          keyExtractor={keyExtractor}
+          refreshing={isPTR}
+          onRefresh={onRefresh}
+          onEndReached={onEndReached}
+          onEndReachedThreshold={4}
+          // @ts-ignore web only -prf
+          desktopFixedHeight
+          ListHeaderComponent={
+            <ListHeaderDesktop
+              title={headerTitle}
+              subtitle={author ? `By ${author}` : undefined}
+            />
+          }
+          ListFooterComponent={
+            <ListFooter
+              isFetching={isFetching}
+              isError={isError}
+              error={error?.name}
+              onRetry={hasNextPage ? fetchNextPage : refetch}
+            />
+          }
+        />
+      )}
+    </View>
+  )
+}

--- a/src/screens/Hashtag.tsx
+++ b/src/screens/Hashtag.tsx
@@ -32,23 +32,23 @@ const keyExtractor = (item: PostView, index: number) => {
 export default function HashtagScreen({
   route,
 }: NativeStackScreenProps<CommonNavigatorParams, 'Hashtag'>) {
-  const {tag: routeTag, author} = route.params
+  const {tag, author} = route.params
   const setMinimalShellMode = useSetMinimalShellMode()
   const {_} = useLingui()
   const [isPTR, setIsPTR] = React.useState(false)
 
-  const tag = React.useMemo(() => {
-    return routeTag.replace('%23', '#')
-  }, [routeTag])
+  const fullTag = React.useMemo(() => {
+    return `#${tag.replace('%23', '#')}`
+  }, [tag])
 
   const queryParam = React.useMemo(() => {
-    if (!author) return tag
-    return `${tag} from:${sanitizeHandle(tag)}`
-  }, [tag, author])
+    if (!author) return fullTag
+    return `${fullTag} from:${sanitizeHandle(author)}`
+  }, [fullTag, author])
 
   const headerTitle = React.useMemo(() => {
-    return enforceLen(tag.toLowerCase(), 24, true, 'middle')
-  }, [tag])
+    return enforceLen(fullTag.toLowerCase(), 24, true, 'middle')
+  }, [fullTag])
 
   const {
     data,

--- a/src/screens/Hashtag.tsx
+++ b/src/screens/Hashtag.tsx
@@ -50,6 +50,7 @@ export default function HashtagScreen({
     data,
     isFetching,
     isLoading,
+    isRefetching,
     isError,
     error,
     refetch,
@@ -86,9 +87,10 @@ export default function HashtagScreen({
         canGoBack={true}
       />
       <ListMaybePlaceholder
-        isLoading={isLoading}
-        isError={isError}
+        isLoading={isLoading || isRefetching}
+        isError={true}
         isEmpty={posts.length < 2}
+        onRetry={refetch}
       />
       {!isLoading && posts.length > 1 && (
         <List<PostView>
@@ -112,7 +114,7 @@ export default function HashtagScreen({
               isFetching={isFetching}
               isError={isError}
               error={error?.name}
-              onRetry={hasNextPage ? fetchNextPage : refetch}
+              onRetry={fetchNextPage}
             />
           }
         />

--- a/src/screens/Hashtag.tsx
+++ b/src/screens/Hashtag.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import {ListRenderItemInfo, View} from 'react-native'
+import {ListRenderItemInfo} from 'react-native'
 import {atoms as a} from '#/alf'
 import {useFocusEffect} from '@react-navigation/native'
 import {useSetMinimalShellMode} from 'state/shell'
@@ -19,6 +19,7 @@ import {List} from 'view/com/util/List'
 import {msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 import {sanitizeHandle} from 'lib/strings/handles'
+import {CenteredView} from 'view/com/util/Views'
 
 const renderItem = ({item}: ListRenderItemInfo<PostView>) => {
   return <Post post={item} />
@@ -81,7 +82,7 @@ export default function HashtagScreen({
   }, [isFetching, hasNextPage, error, fetchNextPage])
 
   return (
-    <View style={a.flex_1}>
+    <CenteredView style={a.flex_1}>
       <ViewHeader
         title={headerTitle}
         subtitle={
@@ -124,6 +125,6 @@ export default function HashtagScreen({
           }
         />
       )}
-    </View>
+    </CenteredView>
   )
 }

--- a/src/screens/Hashtag.tsx
+++ b/src/screens/Hashtag.tsx
@@ -16,6 +16,8 @@ import {
   ListMaybeLoading,
 } from '#/components/Lists'
 import {List} from 'view/com/util/List'
+import {msg} from '@lingui/macro'
+import {useLingui} from '@lingui/react'
 
 const renderItem = ({item}: ListRenderItemInfo<PostView>) => {
   return <Post post={item} />
@@ -30,6 +32,7 @@ export default function HashtagScreen({
 }: NativeStackScreenProps<CommonNavigatorParams, 'Hashtag'>) {
   const {tag, author} = route.params
   const setMinimalShellMode = useSetMinimalShellMode()
+  const {_} = useLingui()
   const [isPTR, setIsPTR] = React.useState(false)
 
   const query = React.useMemo(() => {
@@ -79,7 +82,7 @@ export default function HashtagScreen({
     <View style={a.flex_1}>
       <ViewHeader
         title={headerTitle}
-        subtitle={author ? `By ${author}` : undefined}
+        subtitle={author ? `${_(msg`By`)} ${author}` : undefined}
         canGoBack={true}
       />
       <ListMaybeLoading isLoading={isLoading} />
@@ -97,7 +100,7 @@ export default function HashtagScreen({
           ListHeaderComponent={
             <ListHeaderDesktop
               title={headerTitle}
-              subtitle={author ? `By ${author}` : undefined}
+              subtitle={author ? `${_(msg`By`)} ${author}` : undefined}
             />
           }
           ListFooterComponent={

--- a/src/state/util.ts
+++ b/src/state/util.ts
@@ -3,6 +3,7 @@ import {useLightboxControls} from './lightbox'
 import {useModalControls} from './modals'
 import {useComposerControls} from './shell/composer'
 import {useSetDrawerOpen} from './shell/drawer-open'
+import {useDialogStateControlContext} from 'state/dialogs'
 
 /**
  * returns true if something was closed
@@ -35,11 +36,19 @@ export function useCloseAllActiveElements() {
   const {closeLightbox} = useLightboxControls()
   const {closeAllModals} = useModalControls()
   const {closeComposer} = useComposerControls()
+  const {closeAllDialogs: closeAlfDialogs} = useDialogStateControlContext()
   const setDrawerOpen = useSetDrawerOpen()
   return useCallback(() => {
     closeLightbox()
     closeAllModals()
     closeComposer()
+    closeAlfDialogs()
     setDrawerOpen(false)
-  }, [closeLightbox, closeAllModals, closeComposer, setDrawerOpen])
+  }, [
+    closeLightbox,
+    closeAllModals,
+    closeComposer,
+    closeAlfDialogs,
+    setDrawerOpen,
+  ])
 }

--- a/src/view/com/util/ViewHeader.tsx
+++ b/src/view/com/util/ViewHeader.tsx
@@ -13,6 +13,7 @@ import Animated from 'react-native-reanimated'
 import {useSetDrawerOpen} from '#/state/shell'
 import {msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
+import {useTheme} from '#/alf'
 
 const BACK_HITSLOP = {left: 20, top: 20, right: 50, bottom: 20}
 
@@ -41,6 +42,7 @@ export function ViewHeader({
   const navigation = useNavigation<NavigationProp>()
   const {track} = useAnalytics()
   const {isDesktop, isTablet} = useWebMediaQueries()
+  const t = useTheme()
 
   const onPressBack = React.useCallback(() => {
     if (navigation.canGoBack()) {
@@ -116,7 +118,14 @@ export function ViewHeader({
             <View
               style={[styles.titleContainer, {marginTop: -3}]}
               pointerEvents="auto">
-              <Text style={[pal.text, styles.subtitle]}>{subtitle}</Text>
+              <Text
+                style={[
+                  pal.text,
+                  styles.subtitle,
+                  t.atoms.text_contrast_medium,
+                ]}>
+                {subtitle}
+              </Text>
             </View>
           ) : undefined}
         </View>

--- a/src/view/com/util/ViewHeader.tsx
+++ b/src/view/com/util/ViewHeader.tsx
@@ -117,7 +117,7 @@ export function ViewHeader({
           {subtitle ? (
             <View
               style={[styles.titleContainer, {marginTop: -3}]}
-              pointerEvents="auto">
+              pointerEvents="none">
               <Text
                 style={[
                   pal.text,

--- a/src/view/com/util/ViewHeader.tsx
+++ b/src/view/com/util/ViewHeader.tsx
@@ -18,6 +18,7 @@ const BACK_HITSLOP = {left: 20, top: 20, right: 50, bottom: 20}
 
 export function ViewHeader({
   title,
+  subtitle,
   canGoBack,
   showBackButton = true,
   hideOnScroll,
@@ -26,6 +27,7 @@ export function ViewHeader({
   renderButton,
 }: {
   title: string
+  subtitle?: string
   canGoBack?: boolean
   showBackButton?: boolean
   hideOnScroll?: boolean
@@ -71,42 +73,53 @@ export function ViewHeader({
 
     return (
       <Container hideOnScroll={hideOnScroll || false} showBorder={showBorder}>
-        {showBackButton ? (
-          <TouchableOpacity
-            testID="viewHeaderDrawerBtn"
-            onPress={canGoBack ? onPressBack : onPressMenu}
-            hitSlop={BACK_HITSLOP}
-            style={canGoBack ? styles.backBtn : styles.backBtnWide}
-            accessibilityRole="button"
-            accessibilityLabel={canGoBack ? _(msg`Back`) : _(msg`Menu`)}
-            accessibilityHint={
-              canGoBack ? '' : _(msg`Access navigation links and settings`)
-            }>
-            {canGoBack ? (
-              <FontAwesomeIcon
-                size={18}
-                icon="angle-left"
-                style={[styles.backIcon, pal.text]}
-              />
-            ) : !isTablet ? (
-              <FontAwesomeIcon
-                size={18}
-                icon="bars"
-                style={[styles.backIcon, pal.textLight]}
-              />
+        <View style={{flex: 1}}>
+          <View style={{flexDirection: 'row', alignItems: 'center'}}>
+            {showBackButton ? (
+              <TouchableOpacity
+                testID="viewHeaderDrawerBtn"
+                onPress={canGoBack ? onPressBack : onPressMenu}
+                hitSlop={BACK_HITSLOP}
+                style={canGoBack ? styles.backBtn : styles.backBtnWide}
+                accessibilityRole="button"
+                accessibilityLabel={canGoBack ? _(msg`Back`) : _(msg`Menu`)}
+                accessibilityHint={
+                  canGoBack ? '' : _(msg`Access navigation links and settings`)
+                }>
+                {canGoBack ? (
+                  <FontAwesomeIcon
+                    size={18}
+                    icon="angle-left"
+                    style={[styles.backIcon, pal.text]}
+                  />
+                ) : !isTablet ? (
+                  <FontAwesomeIcon
+                    size={18}
+                    icon="bars"
+                    style={[styles.backIcon, pal.textLight]}
+                  />
+                ) : null}
+              </TouchableOpacity>
             ) : null}
-          </TouchableOpacity>
-        ) : null}
-        <View style={styles.titleContainer} pointerEvents="none">
-          <Text type="title" style={[pal.text, styles.title]}>
-            {title}
-          </Text>
+            <View style={styles.titleContainer} pointerEvents="none">
+              <Text type="title" style={[pal.text, styles.title]}>
+                {title}
+              </Text>
+            </View>
+            {renderButton ? (
+              renderButton()
+            ) : showBackButton ? (
+              <View style={canGoBack ? styles.backBtn : styles.backBtnWide} />
+            ) : null}
+          </View>
+          {subtitle ? (
+            <View
+              style={[styles.titleContainer, {marginTop: -3}]}
+              pointerEvents="auto">
+              <Text style={[pal.text, styles.subtitle]}>{subtitle}</Text>
+            </View>
+          ) : undefined}
         </View>
-        {renderButton ? (
-          renderButton()
-        ) : showBackButton ? (
-          <View style={canGoBack ? styles.backBtn : styles.backBtnWide} />
-        ) : null}
       </Container>
     )
   }
@@ -185,7 +198,6 @@ function Container({
 const styles = StyleSheet.create({
   header: {
     flexDirection: 'row',
-    alignItems: 'center',
     paddingHorizontal: 12,
     paddingVertical: 6,
     width: '100%',
@@ -207,12 +219,14 @@ const styles = StyleSheet.create({
   titleContainer: {
     marginLeft: 'auto',
     marginRight: 'auto',
-    paddingRight: 10,
+    alignItems: 'center',
   },
   title: {
     fontWeight: 'bold',
   },
-
+  subtitle: {
+    fontSize: 13,
+  },
   backBtn: {
     width: 30,
     height: 30,


### PR DESCRIPTION
Got slightly carried away with ALF here, as you know, ALF is very persuasive.

<img src="https://github.com/bluesky-social/social-app/assets/153161762/73194ae8-8807-4cce-a547-5f224586eb88" width="40">

We can hold off on the ALF stuff if we want, it's pretty small though and we should probably start normalizing our lists, list footers, etc anyay. This is an example of how we can do that.


## Why

The current behavior of switching to the Search tab is a bit awkward. You cannot easily use native gestures on iOS to swipe back, and there are no animations that show the intended action of "pushing". We should prefer to move forward in the stack rather than switch tabs.

Adding a few components that can be reused in lists elsewhere that all use ALF will make the continual migration fairly easy. These are mainly just spinner components, one for the footer and one for the empty, loading state. This will also let us maintain styles between each screen. Right now, we have varying views for different screens. These should all be the same across every screen.

Another small fix removes some ghost padding from the `ViewHeader` that caused the title to not be aligned correctly in the center of the screen.

## What

- Create a new route specifically for hashtags instead of switching to the search tab
- Update the `RichTextTag` dropdown items to push to this screen
- Update `server.go` with the new route
- Create an ALF list footer for a spinner, errors, etc.
- Create an ALF "empty state" spinner
- Create an ALF desktop header
- Use `https://bsky.app/hashtag/{HASHTAG}` for route. Handle can optionally be applied with `?author={HANDLE}`.
- Adjust `ViewHeader` to ensure all items are centered correctly in all cases

## Testing

- Verify that `http://localhost:19006/hashtag/hashtags` displays hashtags for #hashtags
- Verify that `http://localhost:19006/hashtag/hashtags?author=bsky.app` displays hashtags only for @bsky.app
- Verify that `http://localhost:19006/hashtag/#somehashtag` returns not found. The router strips the # symbol out of the URL, so we can't use that.
- Verify that `http://localhost:19006/hashtag` returns not found.
- Verify that opening a hashtag from the feed, profile, etc. on different platforms works correctly by pushing to the proper screen, and that it applies the author filter when selected.

## List with error

<img src="https://github.com/bluesky-social/social-app/assets/153161762/96a9895c-e79d-4835-9399-58d7e53174a3" width="400">

![Screenshot 2024-02-29 at 9 01 52 AM](https://github.com/bluesky-social/social-app/assets/153161762/fb9e5340-2932-4753-b860-cb01b30c7b0e)

## Hashtag search by user

<img src="https://github.com/bluesky-social/social-app/assets/153161762/58dddeb2-3f14-455d-b091-7e9c16ac4513" width="400">

## Basic search

<img src="https://github.com/bluesky-social/social-app/assets/153161762/73df0f54-c1eb-4405-ab43-e600d4d0c04a" width="400">

## Web

https://github.com/bluesky-social/social-app/assets/153161762/ec3df535-fd72-4e9c-b5ae-e376ed137c72

## Empty/Error State Screens

![Screenshot 2024-02-29 at 2 22 12 PM](https://github.com/bluesky-social/social-app/assets/153161762/d8f9ebba-6471-4e46-b71e-71dc08e530bf)
![Screenshot 2024-02-29 at 2 22 33 PM](https://github.com/bluesky-social/social-app/assets/153161762/13d6ac02-5683-49a8-943d-de8f38710b01)
![Screenshot 2024-02-29 at 2 23 12 PM](https://github.com/bluesky-social/social-app/assets/153161762/b4b1054d-4155-4ec9-9fc0-a3072d63a755)
![Screenshot 2024-02-29 at 2 23 16 PM](https://github.com/bluesky-social/social-app/assets/153161762/e1b82e44-e0be-4559-a84a-65c9643e94fa)

