### PR TITLE
Dismiss keyboard when closing dialog

### DIFF
--- a/src/components/Dialog/index.tsx
+++ b/src/components/Dialog/index.tsx
@@ -1,5 +1,5 @@
 import React, {useImperativeHandle} from 'react'
-import {View, Dimensions} from 'react-native'
+import {View, Dimensions, Keyboard} from 'react-native'
 import BottomSheet, {
   BottomSheetBackdrop,
   BottomSheetScrollView,
@@ -78,6 +78,7 @@ export function Outer({
   const onChange = React.useCallback(
     (index: number) => {
       if (index === -1) {
+        Keyboard.dismiss()
         try {
           closeCallback.current?.()
         } catch (e: any) {
@@ -190,8 +191,15 @@ export function ScrollableInner({children, style}: DialogInnerProps) {
 
 export function Handle() {
   const t = useTheme()
+
+  const onTouchStart = React.useCallback(() => {
+    Keyboard.dismiss()
+  }, [])
+
   return (
-    <View style={[a.absolute, a.w_full, a.align_center, a.z_10, {height: 40}]}>
+    <View
+      style={[a.absolute, a.w_full, a.align_center, a.z_10, {height: 40}]}
+      onTouchStart={onTouchStart}>
       <View
         style={[
           a.rounded_sm,


### PR DESCRIPTION
## Why

Right now, there are two cases where the keyboard being visible when a dialog is visible causes problems.

1. When using the handle to dismiss the dialog. If we try to close the dialog while the keyboard is open, it will "bounce off" the keyboard, and will require two swipes to dismiss the dialog.
2. If we progmatically close the dialog, the keyboard will not be dismissed automatically.

## How

1. We want to dismiss the keyboard whenever we touch the handle. By dismissing in `onTouchStart`, we ensure that the keyboard is dismissed in time for us to perform the swipe down gesture on the dialog.
2. We want to dismiss the keyboard in the close callback, so that if we progmatically close the dialog, the keyboard will dismiss as well.

https://github.com/bluesky-social/social-app/assets/153161762/d473a75c-98bb-4dca-93a0-fb7420062d8d

