### PR TITLE
Press search tab again to focus on search input

### DIFF
--- a/src/state/events.ts
+++ b/src/state/events.ts
@@ -29,3 +29,16 @@ export function listenPostCreated(fn: () => void): UnlistenFn {
   emitter.on('post-created', fn)
   return () => emitter.off('post-created', fn)
 }
+
+/**
+ * Notify listener to focus on a search input, returns a boolean that indicates
+ * if it's been captured by one.
+ */
+export function emitSearchTrigger() {
+  emitter.emit('search-trigger')
+  return emitter.listenerCount('search-trigger') > 0
+}
+export function listenSearchTrigger(fn: () => void): UnlistenFn {
+  emitter.on('search-trigger', fn)
+  return () => emitter.off('search-trigger', fn)
+}

--- a/src/view/screens/Search/Search.tsx
+++ b/src/view/screens/Search/Search.tsx
@@ -49,7 +49,7 @@ import {
 } from '#/view/shell/desktop/Search'
 import {useSetMinimalShellMode, useSetDrawerSwipeDisabled} from '#/state/shell'
 import {isNative, isWeb} from '#/platform/detection'
-import {listenSoftReset} from '#/state/events'
+import {listenSearchTrigger, listenSoftReset} from '#/state/events'
 import {s} from '#/lib/styles'
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import {augmentSearchQuery} from '#/lib/strings/helpers'
@@ -529,6 +529,15 @@ export function SearchScreen(
     setQuery('')
     setShowAutocompleteResults(false)
   }, [setQuery])
+
+  useFocusEffect(
+    React.useCallback(() => {
+      return listenSearchTrigger(() => {
+        // This needs to be delayed by one (macro)tick for some reason.
+        setTimeout(() => textInput.current?.focus(), 1)
+      })
+    }, [textInput]),
+  )
 
   const onChangeText = React.useCallback(
     async (text: string) => {

--- a/src/view/shell/bottom-bar/BottomBar.tsx
+++ b/src/view/shell/bottom-bar/BottomBar.tsx
@@ -85,6 +85,9 @@ export function BottomBar({navigation}: BottomTabBarProps) {
   const onPressSearch = React.useCallback(() => {
     const captured = emitSearchTrigger()
 
+    // We don't want to do the navigation if the trigger has been captured,
+    // as that would reset the search page and you'll lose the search results
+    // you were looking at before.
     if (!captured) {
       onPressTab('Search')
     }

--- a/src/view/shell/bottom-bar/BottomBar.tsx
+++ b/src/view/shell/bottom-bar/BottomBar.tsx
@@ -27,7 +27,7 @@ import {msg, Trans} from '@lingui/macro'
 import {useModalControls} from '#/state/modals'
 import {useShellLayout} from '#/state/shell/shell-layout'
 import {useUnreadNotifications} from '#/state/queries/notifications/unread'
-import {emitSoftReset} from '#/state/events'
+import {emitSearchTrigger, emitSoftReset} from '#/state/events'
 import {useSession} from '#/state/session'
 import {useProfileQuery} from '#/state/queries/profile'
 import {useLoggedOutViewControls} from '#/state/shell/logged-out'
@@ -82,10 +82,13 @@ export function BottomBar({navigation}: BottomTabBarProps) {
     [track, navigation],
   )
   const onPressHome = React.useCallback(() => onPressTab('Home'), [onPressTab])
-  const onPressSearch = React.useCallback(
-    () => onPressTab('Search'),
-    [onPressTab],
-  )
+  const onPressSearch = React.useCallback(() => {
+    const captured = emitSearchTrigger()
+
+    if (!captured) {
+      onPressTab('Search')
+    }
+  }, [onPressTab])
   const onPressFeeds = React.useCallback(
     () => onPressTab('Feeds'),
     [onPressTab],


### PR DESCRIPTION
The search bar can be pretty tough to reach with how tall screens are now, some apps mitigate this by allowing you to tap on the search tab again to focus on the search input. This pull request implements that exact functionality.

Someone mentioned that Instagram allows you to do a long-tap as well, but I'm not sure how good of an idea that is, so I left it as is.
