### PR TITLE
Filter muted words from all feeds

### DIFF
--- a/src/state/queries/post-feed.ts
+++ b/src/state/queries/post-feed.ts
@@ -255,6 +255,12 @@ export function usePostFeedQuery(
                       slice.items[i].post.author.did !== ignoreFilterFor
                     ) {
                       return undefined
+                    } else if (
+                      moderations[i]?.content.filter &&
+                      // @ts-ignore temporary extension
+                      moderations[i]?.content.cause?.type === 'muted-word'
+                    ) {
+                      return undefined
                     }
                   }
 


### PR DESCRIPTION
Since mute words are so new, the case where users desire muted words to filter out from _all_ feeds is not currently supported by our moderation system. We're in the process of rewriting the mod system for greater flexibility, so we need to discuss this change and determine if we want to hack it like this, or wait until a proper handling is in place.