### PR TITLE
Fix backdrop issues by using custom logic

### DIFF
--- a/src/components/Dialog/index.tsx
+++ b/src/components/Dialog/index.tsx
@@ -9,6 +9,10 @@ import BottomSheet, {
   WINDOW_HEIGHT,
 } from '@gorhom/bottom-sheet'
 import {useSafeAreaInsets} from 'react-native-safe-area-context'
+import Animated, {
+  useAnimatedReaction,
+  useAnimatedStyle,
+} from 'react-native-reanimated'
 
 import {useTheme, atoms as a, flatten} from '#/alf'
 import {Portal} from '#/components/Portal'
@@ -22,10 +26,6 @@ import {
   DialogInnerProps,
 } from '#/components/Dialog/types'
 import {Context} from '#/components/Dialog/context'
-import Animated, {
-  useAnimatedReaction,
-  useAnimatedStyle,
-} from 'react-native-reanimated'
 
 export {useDialogControl, useDialogContext} from '#/components/Dialog/context'
 export * from '#/components/Dialog/types'

--- a/src/components/Dialog/index.tsx
+++ b/src/components/Dialog/index.tsx
@@ -9,10 +9,7 @@ import BottomSheet, {
   WINDOW_HEIGHT,
 } from '@gorhom/bottom-sheet'
 import {useSafeAreaInsets} from 'react-native-safe-area-context'
-import Animated, {
-  useAnimatedReaction,
-  useAnimatedStyle,
-} from 'react-native-reanimated'
+import Animated, {useAnimatedStyle} from 'react-native-reanimated'
 
 import {useTheme, atoms as a, flatten} from '#/alf'
 import {Portal} from '#/components/Portal'
@@ -35,11 +32,6 @@ export const Input = createInput(BottomSheetTextInput)
 function Backdrop(props: BottomSheetBackdropProps) {
   const t = useTheme()
   const bottomSheet = useBottomSheet()
-
-  useAnimatedReaction(
-    () => props.animatedPosition,
-    c => console.log({v: c.value}),
-  )
 
   const animatedStyle = useAnimatedStyle(() => {
     const opacity =

--- a/src/components/Dialog/index.tsx
+++ b/src/components/Dialog/index.tsx
@@ -1,10 +1,11 @@
 import React, {useImperativeHandle} from 'react'
 import {View, Dimensions, Keyboard} from 'react-native'
 import BottomSheet, {
-  BottomSheetBackdrop,
+  BottomSheetBackdropProps,
   BottomSheetScrollView,
   BottomSheetTextInput,
   BottomSheetView,
+  WINDOW_HEIGHT,
 } from '@gorhom/bottom-sheet'
 import {useSafeAreaInsets} from 'react-native-safe-area-context'
 
@@ -20,11 +21,50 @@ import {
   DialogInnerProps,
 } from '#/components/Dialog/types'
 import {Context} from '#/components/Dialog/context'
+import Animated, {
+  useAnimatedReaction,
+  useAnimatedStyle,
+} from 'react-native-reanimated'
 
 export {useDialogControl, useDialogContext} from '#/components/Dialog/context'
 export * from '#/components/Dialog/types'
 // @ts-ignore
 export const Input = createInput(BottomSheetTextInput)
+
+function Backdrop(props: BottomSheetBackdropProps) {
+  const t = useTheme()
+
+  useAnimatedReaction(
+    () => props.animatedPosition,
+    c => console.log({v: c.value}),
+  )
+
+  const animatedStyle = useAnimatedStyle(() => {
+    const opacity =
+      (Math.abs(WINDOW_HEIGHT - props.animatedPosition.value) - 50) / 1000
+
+    return {
+      opacity: Math.min(Math.max(opacity, 0), 0.55),
+    }
+  })
+
+  return (
+    <Animated.View
+      style={[
+        t.atoms.bg_contrast_300,
+        {
+          backgroundColor: 'red',
+          top: 0,
+          left: 0,
+          right: 0,
+          bottom: 0,
+          position: 'absolute',
+        },
+        animatedStyle,
+      ]}
+    />
+  )
+}
 
 export function Outer({
   children,
@@ -114,15 +154,7 @@ export function Outer({
           ref={sheet}
           index={openIndex}
           backgroundStyle={{backgroundColor: 'transparent'}}
-          backdropComponent={props => (
-            <BottomSheetBackdrop
-              opacity={0.4}
-              appearsOnIndex={0}
-              disappearsOnIndex={-1}
-              {...props}
-              style={[flatten(props.style), t.atoms.bg_contrast_300]}
-            />
-          )}
+          backdropComponent={Backdrop}
           handleIndicatorStyle={{backgroundColor: t.palette.primary_500}}
           handleStyle={{display: 'none'}}
           onChange={onChange}>

--- a/src/components/Dialog/index.tsx
+++ b/src/components/Dialog/index.tsx
@@ -1,10 +1,11 @@
 import React, {useImperativeHandle} from 'react'
-import {View, Dimensions, Keyboard} from 'react-native'
+import {View, Dimensions, Keyboard, Pressable} from 'react-native'
 import BottomSheet, {
   BottomSheetBackdropProps,
   BottomSheetScrollView,
   BottomSheetTextInput,
   BottomSheetView,
+  useBottomSheet,
   WINDOW_HEIGHT,
 } from '@gorhom/bottom-sheet'
 import {useSafeAreaInsets} from 'react-native-safe-area-context'
@@ -33,6 +34,7 @@ export const Input = createInput(BottomSheetTextInput)
 
 function Backdrop(props: BottomSheetBackdropProps) {
   const t = useTheme()
+  const bottomSheet = useBottomSheet()
 
   useAnimatedReaction(
     () => props.animatedPosition,
@@ -48,12 +50,15 @@ function Backdrop(props: BottomSheetBackdropProps) {
     }
   })
 
+  const onPress = React.useCallback(() => {
+    bottomSheet.close()
+  }, [bottomSheet])
+
   return (
     <Animated.View
       style={[
         t.atoms.bg_contrast_300,
         {
-          backgroundColor: 'red',
           top: 0,
           left: 0,
           right: 0,
@@ -61,8 +66,15 @@ function Backdrop(props: BottomSheetBackdropProps) {
           position: 'absolute',
         },
         animatedStyle,
-      ]}
-    />
+      ]}>
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel="Dialog backdrop"
+        accessibilityHint="Press the backdrop to close the dialog"
+        style={{flex: 1}}
+        onPress={onPress}
+      />
+    </Animated.View>
   )
 }
 


### PR DESCRIPTION
## Why

The `BottomSheetBackdrop` component has some oddities to it. For one, even if a sheet is relatively small, the backdrop will reach its full opacity as soon as it reaches the first offset's height. This causes some inconsistencies between dialogs.

Second, the current implementation doesn't work well with conditionally rendered dialogs. The backdrop will not animate in, even though it will animate out.

This create a similar component with some simple Reanimated logic.


https://github.com/bluesky-social/social-app/assets/153161762/e2dc348c-859b-4573-aecf-1c028371527f



https://github.com/bluesky-social/social-app/assets/153161762/10334fd9-d219-4604-8c4d-924189c7c14c


