### PR TITLE
Fix Profile tab switch jumps on Chrome

### DIFF
--- a/src/view/screens/Profile.tsx
+++ b/src/view/screens/Profile.tsx
@@ -491,6 +491,8 @@ const styles = StyleSheet.create({
   container: {
     flexDirection: 'column',
     height: '100%',
+    // @ts-ignore Web-only.
+    overflowAnchor: 'none', // Fixes jumps when switching tabs while scrolled down.
   },
   loading: {
     paddingVertical: 10,


### PR DESCRIPTION
## Before

https://github.com/bluesky-social/social-app/assets/810438/92cce5c2-8658-49b8-96f2-caa029b20ce4

## After

https://github.com/bluesky-social/social-app/assets/810438/7a5555b3-3811-455e-843d-714f76d7efa4

## ???

I know, right? It [seems](https://stackoverflow.com/a/42562623) like this may be [this](https://developer.chrome.com/blog/scroll-anchoring) but honestly idk.

I'm not sure why this wasn't happening in my initial web layout PR.

No effect in other browsers.

(╯°□°)╯︵ ┻━┻
