### PR TITLE
Make tags in profile descriptions clickable

### DIFF
--- a/src/view/com/profile/ProfileHeader.tsx
+++ b/src/view/com/profile/ProfileHeader.tsx
@@ -613,6 +613,8 @@ let ProfileHeader = ({
                 <RichText
                   testID="profileHeaderDescription"
                   style={[a.text_md]}
+                  authorHandle={profile.handle}
+                  enableTags
                   numberOfLines={15}
                   value={descriptionRT}
                 />


### PR DESCRIPTION
Closes https://github.com/bluesky-social/social-app/issues/3081.

I've verified it works on web. Haven't confirmed on iOS and Android.

### Screenshot

![image](https://github.com/bluesky-social/social-app/assets/45890038/e6904dd1-bc2f-4a47-83f2-47e24ac094d1)
