### PR TITLE
Add `Menu` component

### DIFF
--- a/bskyweb/templates/base.html
+++ b/bskyweb/templates/base.html
@@ -213,6 +213,7 @@
     }
 
     /* NativeDropdown component */
+    .radix-dropdown-item:focus,
     .nativeDropdown-item:focus {
       outline: none;
     }

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@lingui/react": "^4.5.0",
     "@mattermost/react-native-paste-input": "^0.6.4",
     "@miblanchard/react-native-slider": "^2.3.1",
+    "@radix-ui/react-dropdown-menu": "^2.0.6",
     "@react-native-async-storage/async-storage": "1.21.0",
     "@react-native-camera-roll/camera-roll": "^5.2.2",
     "@react-native-clipboard/clipboard": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -149,6 +149,7 @@
     "react-avatar-editor": "^13.0.0",
     "react-circular-progressbar": "^2.1.0",
     "react-dom": "^18.2.0",
+    "react-keyed-flatten-children": "^3.0.0",
     "react-native": "0.73.2",
     "react-native-appstate-hook": "^1.0.6",
     "react-native-drawer-layout": "^4.0.0-alpha.3",

--- a/src/components/Dialog/context.ts
+++ b/src/components/Dialog/context.ts
@@ -21,7 +21,8 @@ export function useDialogControl(): DialogOuterProps['control'] {
     open: () => {},
     close: () => {},
   })
-  const {activeDialogs} = useDialogStateContext()
+  const {activeDialogs, openDialogs} = useDialogStateContext()
+  const isOpen = openDialogs.includes(id)
 
   React.useEffect(() => {
     activeDialogs.current.set(id, control)
@@ -31,14 +32,18 @@ export function useDialogControl(): DialogOuterProps['control'] {
     }
   }, [id, activeDialogs])
 
-  return {
-    id,
-    ref: control,
-    open: () => {
-      control.current.open()
-    },
-    close: cb => {
-      control.current.close(cb)
-    },
-  }
+  return React.useMemo<DialogOuterProps['control']>(
+    () => ({
+      id,
+      ref: control,
+      isOpen,
+      open: () => {
+        control.current.open()
+      },
+      close: cb => {
+        control.current.close(cb)
+      },
+    }),
+    [id, control, isOpen],
+  )
 }

--- a/src/components/Dialog/types.ts
+++ b/src/components/Dialog/types.ts
@@ -22,6 +22,7 @@ export type DialogControlRefProps = {
 export type DialogControlProps = DialogControlRefProps & {
   id: string
   ref: React.RefObject<DialogControlRefProps>
+  isOpen: boolean
 }
 
 export type DialogContextProps = {

--- a/src/components/Menu/context.tsx
+++ b/src/components/Menu/context.tsx
@@ -1,0 +1,8 @@
+import React from 'react'
+
+import type {ContextType} from '#/components/Menu/types'
+
+export const Context = React.createContext<ContextType>({
+  // @ts-ignore
+  control: null,
+})

--- a/src/components/Menu/context.tsx
+++ b/src/components/Menu/context.tsx
@@ -3,6 +3,5 @@ import React from 'react'
 import type {ContextType} from '#/components/Menu/types'
 
 export const Context = React.createContext<ContextType>({
-  // @ts-ignore
   control: null,
 })

--- a/src/components/Menu/context.tsx
+++ b/src/components/Menu/context.tsx
@@ -3,5 +3,6 @@ import React from 'react'
 import type {ContextType} from '#/components/Menu/types'
 
 export const Context = React.createContext<ContextType>({
+  // @ts-ignore
   control: null,
 })

--- a/src/components/Menu/index.tsx
+++ b/src/components/Menu/index.tsx
@@ -166,9 +166,7 @@ export function Group({children, style}: GroupProps) {
         style,
       ]}>
       {flattenReactChildren(children).map((child, i) => {
-        // ignore null children, like Dividers
-        // @ts-ignore
-        return React.isValidElement(child) && child.props?.children ? (
+        return React.isValidElement(child) && child.type === Item ? (
           <React.Fragment key={i}>
             {i > 0 ? (
               <View style={[a.border_b, t.atoms.border_contrast_low]} />

--- a/src/components/Menu/index.tsx
+++ b/src/components/Menu/index.tsx
@@ -18,6 +18,10 @@ import {
 
 export {useDialogControl as useMenuControl} from '#/components/Dialog'
 
+export function useMemoControlContext() {
+  return React.useContext(Context)
+}
+
 export function Root({
   children,
   control,
@@ -157,7 +161,7 @@ export function Group({children, style}: GroupProps) {
       {React.Children.toArray(children).map((child, i) => {
         // ignore null children, like Dividers
         return React.isValidElement(child) && child.props.children ? (
-          <React.Fragment>
+          <React.Fragment key={i}>
             {i > 0 ? (
               <View style={[a.border_b, t.atoms.border_contrast_low]} />
             ) : null}

--- a/src/components/Menu/index.tsx
+++ b/src/components/Menu/index.tsx
@@ -1,10 +1,20 @@
 import React from 'react'
+import {View, Pressable} from 'react-native'
 
+import {atoms as a, useTheme, ViewStyleProp} from '#/alf'
 import * as Dialog from '#/components/Dialog'
 import {useInteractionState} from '#/components/hooks/useInteractionState'
+import {Text} from '#/components/Typography'
 
-import {ContextType, TriggerChildProps} from '#/components/Menu/types'
 import {Context} from '#/components/Menu/context'
+import {
+  ContextType,
+  TriggerChildProps,
+  ItemProps,
+  GroupProps,
+  ItemTextProps,
+  ItemIconProps,
+} from '#/components/Menu/types'
 
 export {useDialogControl as useMenuControl} from '#/components/Dialog'
 
@@ -27,7 +37,7 @@ export function Root({
 
 export function Trigger({
   children,
-}: {
+}: ViewStyleProp & {
   children(props: TriggerChildProps): React.ReactNode
 }) {
   const {control} = React.useContext(Context)
@@ -71,10 +81,99 @@ export function Outer({children}: React.PropsWithChildren<{}>) {
     <Dialog.Outer control={control}>
       <Dialog.Handle />
       <Dialog.ScrollableInner label="Menu TODO">
-        {children}
+        <View style={[a.gap_lg]}>{children}</View>
+        <View style={{height: a.gap_lg.gap}} />
       </Dialog.ScrollableInner>
     </Dialog.Outer>
   )
 }
 
-export function Button({}: {}) {}
+export function Item({children, label, style, onPress}: ItemProps) {
+  const t = useTheme()
+  const {state: focused, onIn: onFocus, onOut: onBlur} = useInteractionState()
+  const {
+    state: pressed,
+    onIn: onPressIn,
+    onOut: onPressOut,
+  } = useInteractionState()
+
+  return (
+    <Pressable
+      accessibilityHint=""
+      accessibilityLabel={label}
+      onPress={onPress}
+      onFocus={onFocus}
+      onBlur={onBlur}
+      onPressIn={onPressIn}
+      onPressOut={onPressOut}
+      style={[
+        a.flex_row,
+        a.align_center,
+        a.gap_sm,
+        a.p_md,
+        a.rounded_md,
+        t.atoms.bg_contrast_25,
+        {minHeight: 48},
+        style,
+        (focused || pressed) && [t.atoms.bg_contrast_50],
+      ]}>
+      {children}
+    </Pressable>
+  )
+}
+
+export function ItemText({children, style}: ItemTextProps) {
+  const t = useTheme()
+  return (
+    <Text
+      style={[
+        a.text_md,
+        a.font_bold,
+        t.atoms.text_contrast_medium,
+        {paddingTop: 2},
+        style,
+      ]}>
+      {children}
+    </Text>
+  )
+}
+
+export function ItemIcon({icon: Comp}: ItemIconProps) {
+  const t = useTheme()
+  return <Comp size="lg" fill={t.atoms.text_contrast_medium.color} />
+}
+
+export function Group({children, style}: GroupProps) {
+  const t = useTheme()
+  return (
+    <View
+      style={[
+        a.rounded_md,
+        a.overflow_hidden,
+        a.border,
+        t.atoms.border_contrast_low,
+        style,
+      ]}>
+      {React.Children.toArray(children).map((child, i) => {
+        // ignore null children, like Dividers
+        return React.isValidElement(child) && child.props.children ? (
+          <React.Fragment>
+            {i > 0 ? (
+              <View style={[a.border_b, t.atoms.border_contrast_low]} />
+            ) : null}
+            {React.cloneElement(child, {
+              // @ts-ignore
+              style: {
+                borderRadius: 0,
+              },
+            })}
+          </React.Fragment>
+        ) : null
+      })}
+    </View>
+  )
+}
+
+export function Divider() {
+  return null
+}

--- a/src/components/Menu/index.tsx
+++ b/src/components/Menu/index.tsx
@@ -117,7 +117,9 @@ export function Item({children, label, style, onPress}: ItemProps) {
         a.gap_sm,
         a.p_md,
         a.rounded_md,
+        a.border,
         t.atoms.bg_contrast_25,
+        t.atoms.border_contrast_low,
         {minHeight: 48},
         style,
         (focused || pressed) && [t.atoms.bg_contrast_50],
@@ -135,7 +137,7 @@ export function ItemText({children, style}: ItemTextProps) {
         a.text_md,
         a.font_bold,
         t.atoms.text_contrast_medium,
-        {paddingTop: 2},
+        {paddingTop: 3},
         style,
       ]}>
       {children}
@@ -170,6 +172,7 @@ export function Group({children, style}: GroupProps) {
               // @ts-ignore
               style: {
                 borderRadius: 0,
+                borderWidth: 0,
               },
             })}
           </React.Fragment>

--- a/src/components/Menu/index.tsx
+++ b/src/components/Menu/index.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
 import {View, Pressable} from 'react-native'
 
-import {atoms as a, useTheme, ViewStyleProp} from '#/alf'
+import {logger} from '#/logger'
+import {atoms as a, useTheme} from '#/alf'
 import * as Dialog from '#/components/Dialog'
 import {useInteractionState} from '#/components/hooks/useInteractionState'
 import {Text} from '#/components/Typography'
@@ -9,7 +10,7 @@ import {Text} from '#/components/Typography'
 import {Context} from '#/components/Menu/context'
 import {
   ContextType,
-  TriggerChildProps,
+  TriggerProps,
   ItemProps,
   GroupProps,
   ItemTextProps,
@@ -39,11 +40,7 @@ export function Root({
   return <Context.Provider value={context}>{children}</Context.Provider>
 }
 
-export function Trigger({
-  children,
-}: ViewStyleProp & {
-  children(props: TriggerChildProps): React.ReactNode
-}) {
+export function Trigger({children, label}: TriggerProps) {
   const {control} = React.useContext(Context)
   const {state: focused, onIn: onFocus, onOut: onBlur} = useInteractionState()
   const {
@@ -52,11 +49,7 @@ export function Trigger({
     onOut: onPressOut,
   } = useInteractionState()
 
-  if (!control) {
-    throw new Error('Menu.Trigger must be used within a Menu.Root')
-  }
-
-  return children({
+  const child = children({
     isNative: true,
     control,
     state: {
@@ -72,14 +65,22 @@ export function Trigger({
       onPressOut,
     },
   })
+
+  if (!React.isValidElement(child)) {
+    logger.error(
+      'Menu.Trigger children must be a function that returns a valid element',
+    )
+    return null
+  }
+
+  return React.cloneElement(child, {
+    ...child.props,
+    accessibilityLabel: label,
+  })
 }
 
 export function Outer({children}: React.PropsWithChildren<{}>) {
   const {control} = React.useContext(Context)
-
-  if (!control) {
-    throw new Error('Menu.Outer must be used within a Menu.Root')
-  }
 
   return (
     <Dialog.Outer control={control}>

--- a/src/components/Menu/index.tsx
+++ b/src/components/Menu/index.tsx
@@ -1,0 +1,80 @@
+import React from 'react'
+
+import * as Dialog from '#/components/Dialog'
+import {useInteractionState} from '#/components/hooks/useInteractionState'
+
+import {ContextType, TriggerChildProps} from '#/components/Menu/types'
+import {Context} from '#/components/Menu/context'
+
+export {useDialogControl as useMenuControl} from '#/components/Dialog'
+
+export function Root({
+  children,
+  control,
+}: React.PropsWithChildren<{
+  control?: Dialog.DialogOuterProps['control']
+}>) {
+  const defaultControl = Dialog.useDialogControl()
+  const context = React.useMemo<ContextType>(
+    () => ({
+      control: control || defaultControl,
+    }),
+    [control, defaultControl],
+  )
+
+  return <Context.Provider value={context}>{children}</Context.Provider>
+}
+
+export function Trigger({
+  children,
+}: {
+  children(props: TriggerChildProps): React.ReactNode
+}) {
+  const {control} = React.useContext(Context)
+  const {state: focused, onIn: onFocus, onOut: onBlur} = useInteractionState()
+  const {
+    state: pressed,
+    onIn: onPressIn,
+    onOut: onPressOut,
+  } = useInteractionState()
+
+  if (!control) {
+    throw new Error('Menu.Trigger must be used within a Menu.Root')
+  }
+
+  return children({
+    isNative: true,
+    control,
+    state: {
+      hovered: false,
+      focused,
+      pressed,
+    },
+    handlers: {
+      onPress: control.open,
+      onFocus,
+      onBlur,
+      onPressIn,
+      onPressOut,
+    },
+  })
+}
+
+export function Outer({children}: React.PropsWithChildren<{}>) {
+  const {control} = React.useContext(Context)
+
+  if (!control) {
+    throw new Error('Menu.Outer must be used within a Menu.Root')
+  }
+
+  return (
+    <Dialog.Outer control={control}>
+      <Dialog.Handle />
+      <Dialog.ScrollableInner label="Menu TODO">
+        {children}
+      </Dialog.ScrollableInner>
+    </Dialog.Outer>
+  )
+}
+
+export function Button({}: {}) {}

--- a/src/components/Menu/index.tsx
+++ b/src/components/Menu/index.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import {View, Pressable} from 'react-native'
 import flattenReactChildren from 'react-keyed-flatten-children'
 
-import {logger} from '#/logger'
 import {atoms as a, useTheme} from '#/alf'
 import * as Dialog from '#/components/Dialog'
 import {useInteractionState} from '#/components/hooks/useInteractionState'
@@ -50,7 +49,7 @@ export function Trigger({children, label}: TriggerProps) {
     onOut: onPressOut,
   } = useInteractionState()
 
-  const child = children({
+  return children({
     isNative: true,
     control,
     state: {
@@ -58,25 +57,14 @@ export function Trigger({children, label}: TriggerProps) {
       focused,
       pressed,
     },
-    handlers: {
+    props: {
       onPress: control.open,
       onFocus,
       onBlur,
       onPressIn,
       onPressOut,
+      accessibilityLabel: label,
     },
-  })
-
-  if (!React.isValidElement(child)) {
-    logger.error(
-      'Menu.Trigger children must be a function that returns a valid element',
-    )
-    return null
-  }
-
-  return React.cloneElement(child, {
-    ...child.props,
-    accessibilityLabel: label,
   })
 }
 

--- a/src/components/Menu/index.tsx
+++ b/src/components/Menu/index.tsx
@@ -167,7 +167,8 @@ export function Group({children, style}: GroupProps) {
       ]}>
       {flattenReactChildren(children).map((child, i) => {
         // ignore null children, like Dividers
-        return React.isValidElement(child) && child.props.children ? (
+        // @ts-ignore
+        return React.isValidElement(child) && child.props?.children ? (
           <React.Fragment key={i}>
             {i > 0 ? (
               <View style={[a.border_b, t.atoms.border_contrast_low]} />

--- a/src/components/Menu/index.web.tsx
+++ b/src/components/Menu/index.web.tsx
@@ -170,6 +170,7 @@ export function Item({children, label, onPress, ...rest}: ItemProps) {
         }}
         onFocus={onFocus}
         onBlur={onBlur}
+        // need `flatten` here for Radix compat
         style={flatten([
           a.flex_row,
           a.align_center,

--- a/src/components/Menu/index.web.tsx
+++ b/src/components/Menu/index.web.tsx
@@ -125,7 +125,7 @@ export function Outer({children}: React.PropsWithChildren<{}>) {
           style={[
             a.rounded_sm,
             a.p_xs,
-            t.atoms.bg_contrast_50,
+            t.name === 'light' ? t.atoms.bg : t.atoms.bg_contrast_25,
             t.atoms.shadow_md,
           ]}>
           {children}
@@ -133,7 +133,10 @@ export function Outer({children}: React.PropsWithChildren<{}>) {
 
         <DropdownMenu.Arrow
           className="DropdownMenuArrow"
-          fill={t.atoms.bg_contrast_50.backgroundColor}
+          fill={
+            (t.name === 'light' ? t.atoms.bg : t.atoms.bg_contrast_25)
+              .backgroundColor
+          }
         />
       </DropdownMenu.Content>
     </DropdownMenu.Portal>
@@ -181,7 +184,9 @@ export function Item({children, label, onPress, ...rest}: ItemProps) {
           web({outline: 0}),
           (hovered || focused) && [
             web({outline: '0 !important'}),
-            t.atoms.bg_contrast_25,
+            t.name === 'light'
+              ? t.atoms.bg_contrast_25
+              : t.atoms.bg_contrast_50,
           ],
         ])}
         {...web({

--- a/src/components/Menu/index.web.tsx
+++ b/src/components/Menu/index.web.tsx
@@ -121,7 +121,13 @@ export function Outer({children}: React.PropsWithChildren<{}>) {
   return (
     <DropdownMenu.Portal>
       <DropdownMenu.Content sideOffset={5} loop aria-label="Test">
-        <View style={[a.rounded_sm, a.p_xs, t.atoms.bg_contrast_50]}>
+        <View
+          style={[
+            a.rounded_sm,
+            a.p_xs,
+            t.atoms.bg_contrast_50,
+            t.atoms.shadow_md,
+          ]}>
           {children}
         </View>
 

--- a/src/components/Menu/index.web.tsx
+++ b/src/components/Menu/index.web.tsx
@@ -53,17 +53,10 @@ export function Trigger({
     onOut: onMouseLeave,
   } = useInteractionState()
   const {state: focused, onIn: onFocus, onOut: onBlur} = useInteractionState()
-  const {
-    state: pressed,
-    onIn: onPressIn,
-    onOut: onPressOut,
-  } = useInteractionState()
 
   return (
     <DropdownMenu.Trigger asChild>
       <Pressable
-        onPressIn={onPressIn}
-        onPressOut={onPressOut}
         onFocus={onFocus}
         onBlur={onBlur}
         style={flatten([web({outline: 0})])}
@@ -77,7 +70,7 @@ export function Trigger({
           state: {
             hovered,
             focused,
-            pressed,
+            pressed: false,
           },
           handlers: {},
         })}

--- a/src/components/Menu/index.web.tsx
+++ b/src/components/Menu/index.web.tsx
@@ -1,12 +1,20 @@
 import React from 'react'
-import {Pressable} from 'react-native'
+import {View, Pressable} from 'react-native'
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
 
 import * as Dialog from '#/components/Dialog'
 import {useInteractionState} from '#/components/hooks/useInteractionState'
-import {flatten, web} from '#/alf'
+import {atoms as a, useTheme, flatten, web, ViewStyleProp} from '#/alf'
+import {Text} from '#/components/Typography'
 
-import {ContextType, TriggerChildProps} from '#/components/Menu/types'
+import {
+  ContextType,
+  TriggerChildProps,
+  ItemProps,
+  GroupProps,
+  ItemTextProps,
+  ItemIconProps,
+} from '#/components/Menu/types'
 import {Context} from '#/components/Menu/context'
 
 export function useMenuControl(): Dialog.DialogControlProps {
@@ -44,7 +52,8 @@ export function Root({
 
 export function Trigger({
   children,
-}: {
+  style,
+}: ViewStyleProp & {
   children(props: TriggerChildProps): React.ReactNode
 }) {
   const {
@@ -59,7 +68,7 @@ export function Trigger({
       <Pressable
         onFocus={onFocus}
         onBlur={onBlur}
-        style={flatten([web({outline: 0})])}
+        style={flatten([style, web({outline: 0})])}
         {...web({
           onMouseEnter,
           onMouseLeave,
@@ -79,16 +88,105 @@ export function Trigger({
   )
 }
 
-export function Outer(_props: React.PropsWithChildren<{}>) {
+export function Outer({children}: React.PropsWithChildren<{}>) {
+  const t = useTheme()
+
   return (
     <DropdownMenu.Portal>
-      <DropdownMenu.Content sideOffset={5}>
-        <DropdownMenu.Item>
-          New Tab <div className="RightSlot">⌘+T</div>
-        </DropdownMenu.Item>
+      <DropdownMenu.Content sideOffset={5} loop>
+        <View style={[a.rounded_sm, t.atoms.bg_contrast_50, {padding: 6}]}>
+          {children}
+        </View>
+
+        <DropdownMenu.Arrow
+          className="DropdownMenuArrow"
+          fill={t.atoms.bg_contrast_50.backgroundColor}
+        />
       </DropdownMenu.Content>
     </DropdownMenu.Portal>
   )
 }
 
-export function Button({}: {}) {}
+export function Item({children, label, onPress}: ItemProps) {
+  const t = useTheme()
+  const {
+    state: hovered,
+    onIn: onMouseEnter,
+    onOut: onMouseLeave,
+  } = useInteractionState()
+  const {state: focused, onIn: onFocus, onOut: onBlur} = useInteractionState()
+
+  return (
+    <DropdownMenu.Item asChild onSelect={onPress}>
+      <Pressable
+        className="radix-dropdown-item"
+        accessibilityHint=""
+        accessibilityLabel={label}
+        onFocus={onFocus}
+        onBlur={onBlur}
+        style={flatten([
+          a.flex_row,
+          a.align_center,
+          a.gap_sm,
+          a.py_sm,
+          a.px_md,
+          a.rounded_xs,
+          {minHeight: 36},
+          web({outline: 0}),
+          (hovered || focused) && [
+            web({outline: '0 !important'}),
+            t.atoms.bg_contrast_25,
+          ],
+        ])}
+        {...web({
+          onMouseEnter,
+          onMouseLeave,
+        })}>
+        {children}
+      </Pressable>
+    </DropdownMenu.Item>
+  )
+}
+
+export function ItemText({children, style}: ItemTextProps) {
+  const t = useTheme()
+  return (
+    <Text style={[a.font_bold, t.atoms.text_contrast_high, style]}>
+      {children}
+    </Text>
+  )
+}
+
+export function ItemIcon({icon: Comp, position = 'left'}: ItemIconProps) {
+  const t = useTheme()
+  return (
+    <Comp
+      size="md"
+      fill={t.atoms.text_contrast_medium.color}
+      style={[
+        {
+          marginLeft: position === 'left' ? -2 : 0,
+          marginRight: position === 'right' ? -2 : 0,
+        },
+      ]}
+    />
+  )
+}
+
+export function Group({children}: GroupProps) {
+  return children
+}
+
+export function Divider() {
+  const t = useTheme()
+  return (
+    <DropdownMenu.Separator
+      style={{
+        height: 1,
+        backgroundColor: t.atoms.bg_contrast_100.backgroundColor,
+        marginTop: 6,
+        marginBottom: 6,
+      }}
+    />
+  )
+}

--- a/src/components/Menu/index.web.tsx
+++ b/src/components/Menu/index.web.tsx
@@ -140,8 +140,9 @@ export function Outer({children}: React.PropsWithChildren<{}>) {
   )
 }
 
-export function Item({children, label, onPress}: ItemProps) {
+export function Item({children, label, onPress, ...rest}: ItemProps) {
   const t = useTheme()
+  const {control} = React.useContext(Context)
   const {
     state: hovered,
     onIn: onMouseEnter,
@@ -150,12 +151,23 @@ export function Item({children, label, onPress}: ItemProps) {
   const {state: focused, onIn: onFocus, onOut: onBlur} = useInteractionState()
 
   return (
-    <DropdownMenu.Item asChild onSelect={onPress}>
+    <DropdownMenu.Item asChild>
       <Pressable
+        {...rest}
         className="radix-dropdown-item"
         accessibilityHint=""
         accessibilityLabel={label}
-        onPress={onPress}
+        onPress={e => {
+          onPress(e)
+
+          /**
+           * Ported forward from Radix
+           * @see https://www.radix-ui.com/primitives/docs/components/dropdown-menu#item
+           */
+          if (!e.defaultPrevented) {
+            control.close()
+          }
+        }}
         onFocus={onFocus}
         onBlur={onBlur}
         style={flatten([
@@ -163,9 +175,8 @@ export function Item({children, label, onPress}: ItemProps) {
           a.align_center,
           a.gap_sm,
           a.py_sm,
-          a.px_sm,
           a.rounded_xs,
-          {minHeight: 36},
+          {minHeight: 32, paddingHorizontal: 10},
           web({outline: 0}),
           (hovered || focused) && [
             web({outline: '0 !important'}),
@@ -185,7 +196,7 @@ export function Item({children, label, onPress}: ItemProps) {
 export function ItemText({children, style}: ItemTextProps) {
   const t = useTheme()
   return (
-    <Text style={[a.font_bold, t.atoms.text_contrast_high, style]}>
+    <Text style={[a.flex_1, a.font_bold, t.atoms.text_contrast_high, style]}>
       {children}
     </Text>
   )
@@ -198,9 +209,12 @@ export function ItemIcon({icon: Comp, position = 'left'}: ItemIconProps) {
       size="md"
       fill={t.atoms.text_contrast_medium.color}
       style={[
-        {
-          marginLeft: position === 'left' ? -2 : 0,
-          marginRight: position === 'right' ? -2 : 0,
+        position === 'left' && {
+          marginLeft: -2,
+        },
+        position === 'right' && {
+          marginRight: -2,
+          marginLeft: 12,
         },
       ]}
     />

--- a/src/components/Menu/index.web.tsx
+++ b/src/components/Menu/index.web.tsx
@@ -108,7 +108,7 @@ export function Trigger({children, label, style}: TriggerProps) {
             focused,
             pressed: false,
           },
-          handlers: {},
+          props: {},
         })}
       </Pressable>
     </DropdownMenu.Trigger>

--- a/src/components/Menu/index.web.tsx
+++ b/src/components/Menu/index.web.tsx
@@ -1,0 +1,101 @@
+import React from 'react'
+import {Pressable} from 'react-native'
+import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
+
+import * as Dialog from '#/components/Dialog'
+import {useInteractionState} from '#/components/hooks/useInteractionState'
+import {flatten, web} from '#/alf'
+
+import {ContextType, TriggerChildProps} from '#/components/Menu/types'
+import {Context} from '#/components/Menu/context'
+
+export function useMenuControl(): Dialog.DialogControlProps {
+  return {
+    id: '',
+    // @ts-ignore
+    ref: null,
+    open: () => {
+      throw new Error(`Menu controls are only available on native platforms`)
+    },
+    close: () => {
+      throw new Error(`Menu controls are only available on native platforms`)
+    },
+  }
+}
+
+export function Root({
+  children,
+}: React.PropsWithChildren<{
+  control?: Dialog.DialogOuterProps['control']
+}>) {
+  const context = React.useMemo<ContextType>(
+    () => ({
+      control: null,
+    }),
+    [],
+  )
+
+  return (
+    <Context.Provider value={context}>
+      <DropdownMenu.Root>{children}</DropdownMenu.Root>
+    </Context.Provider>
+  )
+}
+
+export function Trigger({
+  children,
+}: {
+  children(props: TriggerChildProps): React.ReactNode
+}) {
+  const {
+    state: hovered,
+    onIn: onMouseEnter,
+    onOut: onMouseLeave,
+  } = useInteractionState()
+  const {state: focused, onIn: onFocus, onOut: onBlur} = useInteractionState()
+  const {
+    state: pressed,
+    onIn: onPressIn,
+    onOut: onPressOut,
+  } = useInteractionState()
+
+  return (
+    <DropdownMenu.Trigger asChild>
+      <Pressable
+        onPressIn={onPressIn}
+        onPressOut={onPressOut}
+        onFocus={onFocus}
+        onBlur={onBlur}
+        style={flatten([web({outline: 0})])}
+        {...web({
+          onMouseEnter,
+          onMouseLeave,
+        })}>
+        {children({
+          isNative: false,
+          control: null,
+          state: {
+            hovered,
+            focused,
+            pressed,
+          },
+          handlers: {},
+        })}
+      </Pressable>
+    </DropdownMenu.Trigger>
+  )
+}
+
+export function Outer(_props: React.PropsWithChildren<{}>) {
+  return (
+    <DropdownMenu.Portal>
+      <DropdownMenu.Content sideOffset={5}>
+        <DropdownMenu.Item>
+          New Tab <div className="RightSlot">⌘+T</div>
+        </DropdownMenu.Item>
+      </DropdownMenu.Content>
+    </DropdownMenu.Portal>
+  )
+}
+
+export function Button({}: {}) {}

--- a/src/components/Menu/index.web.tsx
+++ b/src/components/Menu/index.web.tsx
@@ -4,12 +4,12 @@ import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
 
 import * as Dialog from '#/components/Dialog'
 import {useInteractionState} from '#/components/hooks/useInteractionState'
-import {atoms as a, useTheme, flatten, web, ViewStyleProp} from '#/alf'
+import {atoms as a, useTheme, flatten, web} from '#/alf'
 import {Text} from '#/components/Typography'
 
 import {
   ContextType,
-  TriggerChildProps,
+  TriggerProps,
   ItemProps,
   GroupProps,
   ItemTextProps,
@@ -76,12 +76,7 @@ export function Root({
   )
 }
 
-export function Trigger({
-  children,
-  style,
-}: ViewStyleProp & {
-  children(props: TriggerChildProps): React.ReactNode
-}) {
+export function Trigger({children, label, style}: TriggerProps) {
   const {control} = React.useContext(Context)
   const {
     state: hovered,
@@ -93,6 +88,8 @@ export function Trigger({
   return (
     <DropdownMenu.Trigger asChild>
       <Pressable
+        accessibilityHint=""
+        accessibilityLabel={label}
         onFocus={onFocus}
         onBlur={onBlur}
         style={flatten([style, web({outline: 0})])}
@@ -123,7 +120,7 @@ export function Outer({children}: React.PropsWithChildren<{}>) {
 
   return (
     <DropdownMenu.Portal>
-      <DropdownMenu.Content sideOffset={5} loop>
+      <DropdownMenu.Content sideOffset={5} loop aria-label="Test">
         <View style={[a.rounded_sm, a.p_xs, t.atoms.bg_contrast_50]}>
           {children}
         </View>

--- a/src/components/Menu/types.ts
+++ b/src/components/Menu/types.ts
@@ -8,6 +8,10 @@ export type ContextType = {
   control: Dialog.DialogOuterProps['control']
 }
 
+export type TriggerProps = ViewStyleProp & {
+  children(props: TriggerChildProps): React.ReactNode
+  label: string
+}
 export type TriggerChildProps =
   | {
       isNative: true

--- a/src/components/Menu/types.ts
+++ b/src/components/Menu/types.ts
@@ -25,12 +25,20 @@ export type TriggerChildProps =
         focused: boolean
         pressed: boolean
       }
-      handlers: {
+      /**
+       * We don't necessarily know what these will be spread on to, so we
+       * should add props one-by-one.
+       *
+       * On web, these properties are applied to a parent `Pressable`, so this
+       * object is empty.
+       */
+      props: {
         onPress: () => void
         onFocus: () => void
         onBlur: () => void
         onPressIn: () => void
         onPressOut: () => void
+        accessibilityLabel: string
       }
     }
   | {
@@ -44,7 +52,7 @@ export type TriggerChildProps =
          */
         pressed: false
       }
-      handlers: {}
+      props: {}
     }
 
 // TODO test id

--- a/src/components/Menu/types.ts
+++ b/src/components/Menu/types.ts
@@ -1,6 +1,7 @@
 import React from 'react'
-import {Props as SVGIconProps} from '#/components/icons/common'
+import {GestureResponderEvent, PressableProps} from 'react-native'
 
+import {Props as SVGIconProps} from '#/components/icons/common'
 import * as Dialog from '#/components/Dialog'
 import {TextStyleProp, ViewStyleProp} from '#/alf'
 
@@ -46,11 +47,13 @@ export type TriggerChildProps =
       handlers: {}
     }
 
+// TODO test id
 export type ItemProps = React.PropsWithChildren<
-  ViewStyleProp & {
-    label: string
-    onPress: () => void
-  }
+  Omit<PressableProps, 'style'> &
+    ViewStyleProp & {
+      label: string
+      onPress: (e: GestureResponderEvent) => void
+    }
 >
 
 export type ItemTextProps = React.PropsWithChildren<TextStyleProp & {}>

--- a/src/components/Menu/types.ts
+++ b/src/components/Menu/types.ts
@@ -5,7 +5,7 @@ import * as Dialog from '#/components/Dialog'
 import {TextStyleProp, ViewStyleProp} from '#/alf'
 
 export type ContextType = {
-  control: Dialog.DialogOuterProps['control'] | null
+  control: Dialog.DialogOuterProps['control']
 }
 
 export type TriggerChildProps =
@@ -30,7 +30,7 @@ export type TriggerChildProps =
     }
   | {
       isNative: false
-      control: null
+      control: Dialog.DialogOuterProps['control']
       state: {
         hovered: boolean
         focused: boolean

--- a/src/components/Menu/types.ts
+++ b/src/components/Menu/types.ts
@@ -1,4 +1,8 @@
+import React from 'react'
+import {Props as SVGIconProps} from '#/components/icons/common'
+
 import * as Dialog from '#/components/Dialog'
+import {TextStyleProp, ViewStyleProp} from '#/alf'
 
 export type ContextType = {
   control: Dialog.DialogOuterProps['control'] | null
@@ -37,3 +41,18 @@ export type TriggerChildProps =
       }
       handlers: {}
     }
+
+export type ItemProps = React.PropsWithChildren<
+  ViewStyleProp & {
+    label: string
+    onPress: () => void
+  }
+>
+
+export type ItemTextProps = React.PropsWithChildren<TextStyleProp & {}>
+export type ItemIconProps = React.PropsWithChildren<{
+  icon: React.ComponentType<SVGIconProps>
+  position?: 'left' | 'right'
+}>
+
+export type GroupProps = React.PropsWithChildren<ViewStyleProp & {}>

--- a/src/components/Menu/types.ts
+++ b/src/components/Menu/types.ts
@@ -9,6 +9,9 @@ export type TriggerChildProps =
       isNative: true
       control: Dialog.DialogOuterProps['control']
       state: {
+        /**
+         * Web only, `false` on native
+         */
         hovered: false
         focused: boolean
         pressed: boolean
@@ -27,7 +30,10 @@ export type TriggerChildProps =
       state: {
         hovered: boolean
         focused: boolean
-        pressed: boolean
+        /**
+         * Native only, `false` on web
+         */
+        pressed: false
       }
       handlers: {}
     }

--- a/src/components/Menu/types.ts
+++ b/src/components/Menu/types.ts
@@ -1,0 +1,33 @@
+import * as Dialog from '#/components/Dialog'
+
+export type ContextType = {
+  control: Dialog.DialogOuterProps['control'] | null
+}
+
+export type TriggerChildProps =
+  | {
+      isNative: true
+      control: Dialog.DialogOuterProps['control']
+      state: {
+        hovered: false
+        focused: boolean
+        pressed: boolean
+      }
+      handlers: {
+        onPress: () => void
+        onFocus: () => void
+        onBlur: () => void
+        onPressIn: () => void
+        onPressOut: () => void
+      }
+    }
+  | {
+      isNative: false
+      control: null
+      state: {
+        hovered: boolean
+        focused: boolean
+        pressed: boolean
+      }
+      handlers: {}
+    }

--- a/src/components/Menu/types.ts
+++ b/src/components/Menu/types.ts
@@ -55,7 +55,6 @@ export type TriggerChildProps =
       props: {}
     }
 
-// TODO test id
 export type ItemProps = React.PropsWithChildren<
   Omit<PressableProps, 'style'> &
     ViewStyleProp & {

--- a/src/view/screens/Storybook/Menus.tsx
+++ b/src/view/screens/Storybook/Menus.tsx
@@ -43,7 +43,20 @@ export function Menus() {
                 <Menu.ItemText>Click me</Menu.ItemText>
               </Menu.Item>
 
-              <Menu.Divider />
+              <Menu.Item
+                label="Another item"
+                onPress={() => menuControl.close()}>
+                <Menu.ItemText>Another item</Menu.ItemText>
+              </Menu.Item>
+            </Menu.Group>
+
+            <Menu.Divider />
+
+            <Menu.Group>
+              <Menu.Item label="Click me" onPress={() => {}}>
+                <Menu.ItemIcon icon={Search} />
+                <Menu.ItemText>Click me</Menu.ItemText>
+              </Menu.Item>
 
               <Menu.Item
                 label="Another item"
@@ -51,6 +64,13 @@ export function Menus() {
                 <Menu.ItemText>Another item</Menu.ItemText>
               </Menu.Item>
             </Menu.Group>
+
+            <Menu.Divider />
+
+            <Menu.Item label="Click me" onPress={() => {}}>
+              <Menu.ItemIcon icon={Search} />
+              <Menu.ItemText>Click me</Menu.ItemText>
+            </Menu.Item>
           </Menu.Outer>
         </Menu.Root>
       </View>

--- a/src/view/screens/Storybook/Menus.tsx
+++ b/src/view/screens/Storybook/Menus.tsx
@@ -14,7 +14,7 @@ export function Menus() {
       <Menu.Root>
         <Menu.Trigger>
           {({state, handlers}) => {
-            console.log(state)
+            console.log(state.hovered, state.focused, state.pressed)
             return <Text {...handlers}>Open</Text>
           }}
         </Menu.Trigger>

--- a/src/view/screens/Storybook/Menus.tsx
+++ b/src/view/screens/Storybook/Menus.tsx
@@ -16,7 +16,7 @@ export function Menus() {
     <View style={[a.gap_md]}>
       <View style={[a.flex_row, a.align_start]}>
         <Menu.Root control={menuControl}>
-          <Menu.Trigger style={[a.flex_1]}>
+          <Menu.Trigger label="Open basic menu" style={[a.flex_1]}>
             {({state, handlers}) => {
               return (
                 <Text

--- a/src/view/screens/Storybook/Menus.tsx
+++ b/src/view/screens/Storybook/Menus.tsx
@@ -1,22 +1,38 @@
 import React from 'react'
 import {View} from 'react-native'
 
-import {atoms as a} from '#/alf'
+import {atoms as a, useTheme} from '#/alf'
 import {Text} from '#/components/Typography'
 import * as Menu from '#/components/Menu'
 import {MagnifyingGlass2_Stroke2_Corner0_Rounded as Search} from '#/components/icons/MagnifyingGlass2'
 // import {useDialogStateControlContext} from '#/state/dialogs'
 
 export function Menus() {
+  const t = useTheme()
+  const menuControl = Menu.useMenuControl()
   // const {closeAllDialogs} = useDialogStateControlContext()
 
   return (
     <View style={[a.gap_md]}>
       <View style={[a.flex_row, a.align_start]}>
-        <Menu.Root>
+        <Menu.Root control={menuControl}>
           <Menu.Trigger style={[a.flex_1]}>
-            {({handlers}) => {
-              return <Text {...handlers}>Open</Text>
+            {({state, handlers}) => {
+              return (
+                <Text
+                  {...handlers}
+                  style={[
+                    a.py_sm,
+                    a.px_md,
+                    a.rounded_sm,
+                    t.atoms.bg_contrast_50,
+                    (state.hovered || state.focused || state.pressed) && [
+                      t.atoms.bg_contrast_200,
+                    ],
+                  ]}>
+                  Open
+                </Text>
+              )
             }}
           </Menu.Trigger>
 
@@ -29,7 +45,9 @@ export function Menus() {
 
               <Menu.Divider />
 
-              <Menu.Item label="Another item" onPress={() => {}}>
+              <Menu.Item
+                label="Another item"
+                onPress={() => menuControl.close()}>
                 <Menu.ItemText>Another item</Menu.ItemText>
               </Menu.Item>
             </Menu.Group>

--- a/src/view/screens/Storybook/Menus.tsx
+++ b/src/view/screens/Storybook/Menus.tsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import {View} from 'react-native'
+
+import {atoms as a} from '#/alf'
+import {Text} from '#/components/Typography'
+import * as Menu from '#/components/Menu'
+// import {useDialogStateControlContext} from '#/state/dialogs'
+
+export function Menus() {
+  // const {closeAllDialogs} = useDialogStateControlContext()
+
+  return (
+    <View style={[a.gap_md]}>
+      <Menu.Root>
+        <Menu.Trigger>
+          {({state, handlers}) => {
+            console.log(state)
+            return <Text {...handlers}>Open</Text>
+          }}
+        </Menu.Trigger>
+
+        <Menu.Outer>
+          <Text>Open</Text>
+        </Menu.Outer>
+      </Menu.Root>
+    </View>
+  )
+}

--- a/src/view/screens/Storybook/Menus.tsx
+++ b/src/view/screens/Storybook/Menus.tsx
@@ -17,10 +17,10 @@ export function Menus() {
       <View style={[a.flex_row, a.align_start]}>
         <Menu.Root control={menuControl}>
           <Menu.Trigger label="Open basic menu" style={[a.flex_1]}>
-            {({state, handlers}) => {
+            {({state, props}) => {
               return (
                 <Text
-                  {...handlers}
+                  {...props}
                   style={[
                     a.py_sm,
                     a.px_md,

--- a/src/view/screens/Storybook/Menus.tsx
+++ b/src/view/screens/Storybook/Menus.tsx
@@ -4,6 +4,7 @@ import {View} from 'react-native'
 import {atoms as a} from '#/alf'
 import {Text} from '#/components/Typography'
 import * as Menu from '#/components/Menu'
+import {MagnifyingGlass2_Stroke2_Corner0_Rounded as Search} from '#/components/icons/MagnifyingGlass2'
 // import {useDialogStateControlContext} from '#/state/dialogs'
 
 export function Menus() {
@@ -11,18 +12,30 @@ export function Menus() {
 
   return (
     <View style={[a.gap_md]}>
-      <Menu.Root>
-        <Menu.Trigger>
-          {({state, handlers}) => {
-            console.log(state.hovered, state.focused, state.pressed)
-            return <Text {...handlers}>Open</Text>
-          }}
-        </Menu.Trigger>
+      <View style={[a.flex_row, a.align_start]}>
+        <Menu.Root>
+          <Menu.Trigger style={[a.flex_1]}>
+            {({handlers}) => {
+              return <Text {...handlers}>Open</Text>
+            }}
+          </Menu.Trigger>
 
-        <Menu.Outer>
-          <Text>Open</Text>
-        </Menu.Outer>
-      </Menu.Root>
+          <Menu.Outer>
+            <Menu.Group>
+              <Menu.Item label="Click me" onPress={() => {}}>
+                <Menu.ItemIcon icon={Search} />
+                <Menu.ItemText>Click me</Menu.ItemText>
+              </Menu.Item>
+
+              <Menu.Divider />
+
+              <Menu.Item label="Another item" onPress={() => {}}>
+                <Menu.ItemText>Another item</Menu.ItemText>
+              </Menu.Item>
+            </Menu.Group>
+          </Menu.Outer>
+        </Menu.Root>
+      </View>
     </View>
   )
 }

--- a/src/view/screens/Storybook/index.tsx
+++ b/src/view/screens/Storybook/index.tsx
@@ -16,6 +16,7 @@ import {Dialogs} from './Dialogs'
 import {Breakpoints} from './Breakpoints'
 import {Shadows} from './Shadows'
 import {Icons} from './Icons'
+import {Menus} from './Menus'
 
 export function Storybook() {
   const t = useTheme()
@@ -65,6 +66,7 @@ export function Storybook() {
               Dark
             </Button>
           </View>
+          <Menus />
 
           <ThemeProvider theme="light">
             <Theming />

--- a/src/view/screens/Storybook/index.tsx
+++ b/src/view/screens/Storybook/index.tsx
@@ -66,7 +66,6 @@ export function Storybook() {
               Dark
             </Button>
           </View>
-          <Menus />
 
           <ThemeProvider theme="light">
             <Theming />
@@ -86,6 +85,7 @@ export function Storybook() {
           <Links />
           <Forms />
           <Dialogs />
+          <Menus />
           <Breakpoints />
         </View>
       </CenteredView>

--- a/web/index.html
+++ b/web/index.html
@@ -217,6 +217,7 @@
       }
 
       /* NativeDropdown component */
+      .radix-dropdown-item:focus,
       .nativeDropdown-item:focus {
         outline: none;
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -18458,6 +18458,13 @@ react-is@^17.0.1:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
+react-keyed-flatten-children@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/react-keyed-flatten-children/-/react-keyed-flatten-children-3.0.0.tgz#b6ad0bde437d3ab86c8af3a1902d164be2a29d67"
+  integrity sha512-tSH6gvOyQjt3qtjG+kU9sTypclL1672yjpVufcE3aHNM0FhvjBUQZqsb/awIux4zEuVC3k/DP4p0GdTT/QUt/Q==
+  dependencies:
+    react-is "^18.2.0"
+
 react-native-appstate-hook@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/react-native-appstate-hook/-/react-native-appstate-hook-1.0.6.tgz#cbc16e7b89cfaea034cabd999f00e99053cabd06"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4467,6 +4467,18 @@
     "@radix-ui/react-use-callback-ref" "1.0.1"
     "@radix-ui/react-use-escape-keydown" "1.0.3"
 
+"@radix-ui/react-dismissable-layer@1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.0.5.tgz#3f98425b82b9068dfbab5db5fff3df6ebf48b9d4"
+  integrity sha512-aJeDjQhywg9LBu2t/At58hCvr7pEm0o2Ke1x33B+MhjNmmZ17sy4KImo0KPLgsnc/zN7GPdce8Cnn0SWvwZO7g==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.1"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-use-callback-ref" "1.0.1"
+    "@radix-ui/react-use-escape-keydown" "1.0.3"
+
 "@radix-ui/react-dropdown-menu@^2.0.1":
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.0.5.tgz#19bf4de8ffa348b4eb6a86842f14eff93d741170"
@@ -4481,6 +4493,20 @@
     "@radix-ui/react-primitive" "1.0.3"
     "@radix-ui/react-use-controllable-state" "1.0.1"
 
+"@radix-ui/react-dropdown-menu@^2.0.6":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.0.6.tgz#cdf13c956c5e263afe4e5f3587b3071a25755b63"
+  integrity sha512-i6TuFOoWmLWq+M/eCLGd/bQ2HfAX1RJgvrBQ6AQLmzfvsLdefxbWu8G9zczcPFfcSPehz9GcpF6K9QYreFV8hA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.1"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-context" "1.0.1"
+    "@radix-ui/react-id" "1.0.1"
+    "@radix-ui/react-menu" "2.0.6"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-use-controllable-state" "1.0.1"
+
 "@radix-ui/react-focus-guards@1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-focus-guards/-/react-focus-guards-1.0.1.tgz#1ea7e32092216b946397866199d892f71f7f98ad"
@@ -4492,6 +4518,16 @@
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-focus-scope/-/react-focus-scope-1.0.3.tgz#9c2e8d4ed1189a1d419ee61edd5c1828726472f9"
   integrity sha512-upXdPfqI4islj2CslyfUBNlaJCPybbqRHAi1KER7Isel9Q2AtSJ0zRBZv8mWQiFXD2nyAJ4BhC3yXgZ6kMBSrQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-use-callback-ref" "1.0.1"
+
+"@radix-ui/react-focus-scope@1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-focus-scope/-/react-focus-scope-1.0.4.tgz#2ac45fce8c5bb33eb18419cdc1905ef4f1906525"
+  integrity sha512-sL04Mgvf+FmyvZeYfNu1EPAaaxD+aw7cYeIB9L9Fvq8+urhltTRaEo5ysKOpHuKPclsZcSUMKlN05x4u+CINpA==
   dependencies:
     "@babel/runtime" "^7.13.10"
     "@radix-ui/react-compose-refs" "1.0.1"
@@ -4531,6 +4567,31 @@
     aria-hidden "^1.1.1"
     react-remove-scroll "2.5.5"
 
+"@radix-ui/react-menu@2.0.6":
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-menu/-/react-menu-2.0.6.tgz#2c9e093c1a5d5daa87304b2a2f884e32288ae79e"
+  integrity sha512-BVkFLS+bUC8HcImkRKPSiVumA1VPOOEC5WBMiT+QAVsPzW1FJzI9KnqgGxVDPBcql5xXrHkD3JOVoXWEXD8SYA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "1.0.1"
+    "@radix-ui/react-collection" "1.0.3"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-context" "1.0.1"
+    "@radix-ui/react-direction" "1.0.1"
+    "@radix-ui/react-dismissable-layer" "1.0.5"
+    "@radix-ui/react-focus-guards" "1.0.1"
+    "@radix-ui/react-focus-scope" "1.0.4"
+    "@radix-ui/react-id" "1.0.1"
+    "@radix-ui/react-popper" "1.1.3"
+    "@radix-ui/react-portal" "1.0.4"
+    "@radix-ui/react-presence" "1.0.1"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-roving-focus" "1.0.4"
+    "@radix-ui/react-slot" "1.0.2"
+    "@radix-ui/react-use-callback-ref" "1.0.1"
+    aria-hidden "^1.1.1"
+    react-remove-scroll "2.5.5"
+
 "@radix-ui/react-popper@1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-popper/-/react-popper-1.1.2.tgz#4c0b96fcd188dc1f334e02dba2d538973ad842e9"
@@ -4548,10 +4609,35 @@
     "@radix-ui/react-use-size" "1.0.1"
     "@radix-ui/rect" "1.0.1"
 
+"@radix-ui/react-popper@1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-popper/-/react-popper-1.1.3.tgz#24c03f527e7ac348fabf18c89795d85d21b00b42"
+  integrity sha512-cKpopj/5RHZWjrbF2846jBNacjQVwkP068DfmgrNJXpvVWrOvlAmE9xSiy5OqeE+Gi8D9fP+oDhUnPqNMY8/5w==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@floating-ui/react-dom" "^2.0.0"
+    "@radix-ui/react-arrow" "1.0.3"
+    "@radix-ui/react-compose-refs" "1.0.1"
+    "@radix-ui/react-context" "1.0.1"
+    "@radix-ui/react-primitive" "1.0.3"
+    "@radix-ui/react-use-callback-ref" "1.0.1"
+    "@radix-ui/react-use-layout-effect" "1.0.1"
+    "@radix-ui/react-use-rect" "1.0.1"
+    "@radix-ui/react-use-size" "1.0.1"
+    "@radix-ui/rect" "1.0.1"
+
 "@radix-ui/react-portal@1.0.3":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-portal/-/react-portal-1.0.3.tgz#ffb961244c8ed1b46f039e6c215a6c4d9989bda1"
   integrity sha512-xLYZeHrWoPmA5mEKEfZZevoVRK/Q43GfzRXkWV6qawIWWK8t6ifIiLQdd7rmQ4Vk1bmI21XhqF9BN3jWf+phpA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/react-primitive" "1.0.3"
+
+"@radix-ui/react-portal@1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-portal/-/react-portal-1.0.4.tgz#df4bfd353db3b1e84e639e9c63a5f2565fb00e15"
+  integrity sha512-Qki+C/EuGUVCQTOTD5vzJzJuMUlewbzuKyUy+/iHM2uwGiru9gZeBJtHAPKAEkB5KWGi9mP/CHKcY0wt1aW45Q==
   dependencies:
     "@babel/runtime" "^7.13.10"
     "@radix-ui/react-primitive" "1.0.3"


### PR DESCRIPTION
This PR adds a new abstraction to replace Zeego and the native context menus. It provides essentially the same interface as our `NativeDropdown` wrapper, but replaces the Radix dropdown on web, and uses a bottom sheet on native.

Usage looks like this:
```tsx
        <Menu.Root control={menuControl}>
          <Menu.Trigger label="Open menu" style={[a.flex_1]}>
            {({state, props}) => {
              return (
                <Text {...props}>Open menu</Text>
              )
            }}
          </Menu.Trigger>

          <Menu.Outer>
            <Menu.Group>
              <Menu.Item label="Click me" onPress={() => {}}>
                <Menu.ItemIcon icon={Search} />
                <Menu.ItemText>Click me</Menu.ItemText>
              </Menu.Item>

              <Menu.Divider />

              <Menu.Item
                label="Another item"
                onPress={() => menuControl.close()}>
                <Menu.ItemText>Another item</Menu.ItemText>
              </Menu.Item>
            </Menu.Group>
          </Menu.Outer>
        </Menu.Root>

```

![CleanShot 2024-03-05 at 13 44 53@2x](https://github.com/bluesky-social/social-app/assets/4732330/dc51194f-876b-46ec-8cbb-e0432464611a)

![CleanShot 2024-03-05 at 14 17 55@2x](https://github.com/bluesky-social/social-app/assets/4732330/22648a6f-96a2-4c8a-ba94-a3e32d2ea131)
