### PR TITLE
Fabric migration - `react-native-version-number` -> `expo-application`

### DIFF
--- a/package.json
+++ b/package.json
@@ -164,7 +164,6 @@
     "react-native-ui-text-view": "link:./modules/react-native-ui-text-view",
     "react-native-url-polyfill": "^1.3.0",
     "react-native-uuid": "^2.0.1",
-    "react-native-version-number": "^0.3.6",
     "react-native-web": "~0.19.6",
     "react-native-web-webview": "^1.0.2",
     "react-native-webview": "13.6.4",

--- a/src/lib/app-info.ts
+++ b/src/lib/app-info.ts
@@ -1,5 +1,4 @@
-import VersionNumber from 'react-native-version-number'
-import * as Updates from 'expo-updates'
-export const updateChannel = Updates.channel
-
-export const appVersion = `${VersionNumber.appVersion} (${VersionNumber.buildVersion})`
+import {nativeBuildVersion, nativeApplicationVersion} from 'expo-application'
+import {channel} from 'expo-updates'
+export const updateChannel = channel
+export const appVersion = `${nativeApplicationVersion} (${nativeBuildVersion})`

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -4,9 +4,9 @@
  */
 
 import {Platform} from 'react-native'
-import app from 'react-native-version-number'
 import * as info from 'expo-updates'
 import {init} from 'sentry-expo'
+import {nativeApplicationVersion, nativeBuildVersion} from 'expo-application'
 
 /**
  * Matches the build profile `channel` props in `eas.json`
@@ -21,7 +21,7 @@ const buildChannel = (info.channel || 'development') as
  * - `dev`
  * - `1.57.0`
  */
-const release = app.appVersion ?? 'dev'
+const release = nativeApplicationVersion ?? 'dev'
 
 /**
  * Examples:
@@ -33,7 +33,7 @@ const release = app.appVersion ?? 'dev'
  * - `android.1.57.0.46`
  */
 const dist = `${Platform.OS}.${release}${
-  app.buildVersion ? `.${app.buildVersion}` : ''
+  nativeBuildVersion ? `.${nativeBuildVersion}` : ''
 }`
 
 init({

--- a/yarn.lock
+++ b/yarn.lock
@@ -18419,11 +18419,6 @@ react-native-uuid@^2.0.1:
   resolved "https://registry.yarnpkg.com/react-native-uuid/-/react-native-uuid-2.0.1.tgz#ed4e2dfb1683eddb66967eb5dca140dfe1abddb9"
   integrity sha512-cptnoIbL53GTCrWlb/+jrDC6tvb7ypIyzbXNJcpR3Vab0mkeaaVd5qnB3f0whXYzS+SMoSQLcUUB0gEWqkPC0g==
 
-react-native-version-number@^0.3.6:
-  version "0.3.6"
-  resolved "https://registry.yarnpkg.com/react-native-version-number/-/react-native-version-number-0.3.6.tgz#dd8b1435fc217df0a166d7e4a61fdc993f3e7437"
-  integrity sha512-TdyXiK90NiwmSbmAUlUBOV6WI1QGoqtvZZzI5zQY4fKl67B3ZrZn/h+Wy/OYIKKFMfePSiyfeIs8LtHGOZ/NgA==
-
 react-native-web-webview@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/react-native-web-webview/-/react-native-web-webview-1.0.2.tgz#c215efa70c17589f2c8d640b1f1dc669b18c6e02"


### PR DESCRIPTION
### Testing requires building a client after checking out https://github.com/bluesky-social/social-app/pull/3096

Note: This relies on the expo package upgrades from https://github.com/bluesky-social/social-app/pull/3096

This PR removes `react-native-version-number` and uses `expo-application` to retrieve the same values. Tested on all platforms and the outputs line up with each other.

## Test Plan

Open the settings screen, scroll to bottom, see that the "Build Version" is still correct (it should be 1.71.0 (1) on native, 1.71.0 on web)

- [x] iOS
- [x] Android
- [x] Web