### PR TITLE
Fabric migration - `react-native-haptic-feedback` -> `expo-haptics`

### DIFF
--- a/package.json
+++ b/package.json
@@ -151,7 +151,6 @@
     "react-native-fs": "^2.20.0",
     "react-native-gesture-handler": "~2.14.0",
     "react-native-get-random-values": "~1.8.0",
-    "react-native-haptic-feedback": "^1.14.0",
     "react-native-image-crop-picker": "^0.38.1",
     "react-native-ios-context-menu": "^1.15.3",
     "react-native-pager-view": "6.2.3",

--- a/src/lib/haptics.ts
+++ b/src/lib/haptics.ts
@@ -1,28 +1,34 @@
 import {isIOS, isWeb} from 'platform/detection'
-import ReactNativeHapticFeedback, {
-  HapticFeedbackTypes,
-} from 'react-native-haptic-feedback'
+import {
+  impactAsync,
+  ImpactFeedbackStyle,
+  notificationAsync,
+  NotificationFeedbackType,
+  selectionAsync,
+} from 'expo-haptics'
 
-const hapticImpact: HapticFeedbackTypes = isIOS ? 'impactMedium' : 'impactLight' // Users said the medium impact was too strong on Android; see APP-537s
+const hapticImpact: ImpactFeedbackStyle = isIOS
+  ? ImpactFeedbackStyle.Medium
+  : ImpactFeedbackStyle.Light // Users said the medium impact was too strong on Android; see APP-537s
 
 export class Haptics {
   static default() {
     if (isWeb) {
       return
     }
-    ReactNativeHapticFeedback.trigger(hapticImpact)
+    impactAsync(hapticImpact)
   }
-  static impact(type: HapticFeedbackTypes = hapticImpact) {
+  static impact(type: ImpactFeedbackStyle = hapticImpact) {
     if (isWeb) {
       return
     }
-    ReactNativeHapticFeedback.trigger(type)
+    impactAsync(type)
   }
   static selection() {
     if (isWeb) {
       return
     }
-    ReactNativeHapticFeedback.trigger('selection')
+    selectionAsync()
   }
   static notification = (type: 'success' | 'warning' | 'error') => {
     if (isWeb) {
@@ -30,11 +36,11 @@ export class Haptics {
     }
     switch (type) {
       case 'success':
-        return ReactNativeHapticFeedback.trigger('notificationSuccess')
+        return notificationAsync(NotificationFeedbackType.Success)
       case 'warning':
-        return ReactNativeHapticFeedback.trigger('notificationWarning')
+        return notificationAsync(NotificationFeedbackType.Warning)
       case 'error':
-        return ReactNativeHapticFeedback.trigger('notificationError')
+        return notificationAsync(NotificationFeedbackType.Error)
     }
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -18336,11 +18336,6 @@ react-native-get-random-values@~1.8.0:
   dependencies:
     fast-base64-decode "^1.0.0"
 
-react-native-haptic-feedback@^1.14.0:
-  version "1.14.0"
-  resolved "https://registry.yarnpkg.com/react-native-haptic-feedback/-/react-native-haptic-feedback-1.14.0.tgz#b50f49dedda4980b3c37c5780823f753cf3ee717"
-  integrity sha512-dSXZ6gAzl+W/L7BPjOpnT0bx0cgQiSr0sB3DjyDJbGIdVr4ISaktZC6gC9xYFTv2kMq0+KtbKi+dpd0WtxYZMw==
-
 react-native-image-crop-picker@^0.38.1:
   version "0.38.1"
   resolved "https://registry.yarnpkg.com/react-native-image-crop-picker/-/react-native-image-crop-picker-0.38.1.tgz#5973b4a8b55835b987e6be2064de411e849ac005"


### PR DESCRIPTION
### Testing requires building a client after checking out https://github.com/bluesky-social/social-app/pull/3096

This PR replaces `react-native-haptic-feedback` with `expo-haptics`. This PR is mostly just a matter of changing syntaxes, no other changes are required and all of the haptics are the same "styles" as they were before.

## Test Plan

- Like a post
- Press and hold switch account

Testing these two functions will suffice. We only use `Haptics.default()` in the app as of right now.

- [x] iOS
- [x] Android