### PR TITLE
Improve splash display on android

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -144,6 +144,7 @@ module.exports = function (config) {
           },
         ],
         './plugins/withAndroidManifestPlugin.js',
+        './plugins/withAndroidStylesWindowBackgroundPlugin.js',
         './plugins/shareExtension/withShareExtensions.js',
       ].filter(Boolean),
       extra: {

--- a/app.config.js
+++ b/app.config.js
@@ -11,6 +11,17 @@ const DARK_SPLASH_CONFIG = {
   resizeMode: 'cover',
 }
 
+const SPLASH_CONFIG_ANDROID = {
+  backgroundColor: '#0c7cff',
+  image: './assets/splash.png',
+  resizeMode: 'cover',
+}
+const DARK_SPLASH_CONFIG_ANDROID = {
+  backgroundColor: '#0f141b',
+  image: './assets/splash-dark.png',
+  resizeMode: 'cover',
+}
+
 module.exports = function (config) {
   /**
    * App version number. Should be incremented as part of a release cycle.
@@ -70,8 +81,8 @@ module.exports = function (config) {
         },
       },
       androidStatusBar: {
-        barStyle: 'dark-content',
-        backgroundColor: '#ffffff',
+        barStyle: 'light-content',
+        backgroundColor: '#00000000',
       },
       android: {
         icon: './assets/icon.png',
@@ -101,8 +112,8 @@ module.exports = function (config) {
           },
         ],
         splash: {
-          ...SPLASH_CONFIG,
-          dark: DARK_SPLASH_CONFIG,
+          ...SPLASH_CONFIG_ANDROID,
+          dark: DARK_SPLASH_CONFIG_ANDROID,
         },
       },
       web: {

--- a/plugins/withAndroidStylesWindowBackgroundPlugin.js
+++ b/plugins/withAndroidStylesWindowBackgroundPlugin.js
@@ -1,0 +1,20 @@
+const {withAndroidStyles, AndroidConfig} = require('@expo/config-plugins')
+
+module.exports = function withAndroidStylesWindowBackgroundPlugin(appConfig) {
+  return withAndroidStyles(appConfig, function (decoratedAppConfig) {
+    try {
+      decoratedAppConfig.modResults = AndroidConfig.Styles.assignStylesValue(
+        decoratedAppConfig.modResults,
+        {
+          add: true,
+          parent: AndroidConfig.Styles.getAppThemeLightNoActionBarGroup(),
+          name: 'android:windowBackground',
+          value: '@drawable/splashscreen',
+        },
+      )
+    } catch (e) {
+      console.error(`withAndroidStylesWindowBackgroundPlugin failed`, e)
+    }
+    return decoratedAppConfig
+  })
+}

--- a/src/App.native.tsx
+++ b/src/App.native.tsx
@@ -46,6 +46,8 @@ import {Provider as PortalProvider} from '#/components/Portal'
 import {msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 import {useIntentHandler} from 'lib/hooks/useIntentHandler'
+import {StatusBar} from 'expo-status-bar'
+import {isAndroid} from 'platform/detection'
 
 SplashScreen.preventAutoHideAsync()
 
@@ -69,6 +71,7 @@ function InnerApp() {
 
   return (
     <SafeAreaProvider initialMetrics={initialWindowMetrics}>
+      {isAndroid && <StatusBar />}
       <Alf theme={theme}>
         <Splash isReady={!isInitialLoad}>
           <React.Fragment


### PR DESCRIPTION
The current Android app displays a white screen before the splash screen. A white status bar is also displayed. I think this white display degrades the user experience of the app (especially on dark mode).

![current_light](https://github.com/bluesky-social/social-app/assets/7834440/6d4e10df-9ce4-47d0-87f4-aee438dc9697) ![current_dark](https://github.com/bluesky-social/social-app/assets/7834440/17255255-b437-4ec1-bb57-d115bb59b890)

By applying this fix, white display is gone and startup and splash become more continuous and natural.

![pr_light](https://github.com/bluesky-social/social-app/assets/7834440/ba49953c-f07e-4a13-b62a-a0d9bbc9bf5d) ![pr_dark](https://github.com/bluesky-social/social-app/assets/7834440/45c972fe-6a8e-4bb1-9100-bd7a98eff95a)


Note: this fix is only for Android apps, as I don't have iOS devices. To avoid side effects to the iOS app, I have applied some conditional branches and code separation between Android and iOS. 
* Example 1: Apart from the existing `SPLASH_CONFIG` and `DARK_SPLASH_CONFIG` in `app.config.js`,
`SPLASH_CONFIG_ANDROID` and `DARK_SPLASH_CONFIG_ANDROID` added.
* Example 2: `<StatusBar />` in App.native.tsx is only added on Android.