### PR TITLE
Apply notification icon settings of FCM on Android

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -140,10 +140,11 @@ module.exports = function (config) {
           'expo-notifications',
           {
             icon: './assets/icon-android-notification.png',
-            color: '#ffffff',
+            color: '#1185fe',
           },
         ],
         './plugins/withAndroidManifestPlugin.js',
+        './plugins/withAndroidManifestFCMIconPlugin.js',
         './plugins/shareExtension/withShareExtensions.js',
       ].filter(Boolean),
       extra: {

--- a/plugins/withAndroidManifestFCMIconPlugin.js
+++ b/plugins/withAndroidManifestFCMIconPlugin.js
@@ -1,0 +1,37 @@
+const {withAndroidManifest} = require('expo/config-plugins')
+
+module.exports = function withAndroidManifestFCMIconPlugin(appConfig) {
+  return withAndroidManifest(appConfig, function (decoratedAppConfig) {
+    try {
+      function addOrModifyMetaData(metaData, name, resource) {
+        const elem = metaData.find(elem => elem.$['android:name'] === name)
+        if (elem === undefined) {
+          metaData.push({
+            $: {
+              'android:name': name,
+              'android:resource': resource,
+            },
+          })
+        } else {
+          elem.$['android:resource'] = resource
+        }
+      }
+      const androidManifest = decoratedAppConfig.modResults.manifest
+      const metaData = androidManifest.application[0]['meta-data']
+      addOrModifyMetaData(
+        metaData,
+        'com.google.firebase.messaging.default_notification_color',
+        '@color/notification_icon_color',
+      )
+      addOrModifyMetaData(
+        metaData,
+        'com.google.firebase.messaging.default_notification_icon',
+        '@drawable/notification_icon',
+      )
+      return decoratedAppConfig
+    } catch (e) {
+      console.error(`withAndroidManifestFCMIconPlugin failed`, e)
+    }
+    return decoratedAppConfig
+  })
+}


### PR DESCRIPTION
In the issue https://github.com/bluesky-social/social-app/issues/2983 , problem about notification icon on Android has been reported.  Although project has resource of notification icon for Android (`assets/icon-android-notification.png`), Is is not shown to real notification. I have built private android app from source code and confirmed this issue.

![current_notification](https://github.com/bluesky-social/social-app/assets/7834440/6e08e3f9-551f-464c-8e59-327ab9803308)

I think this issue is due to payload sent from FCM. `expo-notifications` library requires ONLY `data` payload. If `notification` payload exists, FCM directly shows notification without process of `expo-notification`. Currently, the app has no settings for FCM icons, so the default app icon appears unexpectedly. Refer the document about expo-notifications.

https://docs.expo.dev/versions/latest/sdk/notifications/#android-push-notification-payload-specification

The sender of push notification should send only `data` payload, but currently `notification` payload is also sent. I understand the fix of server program to send push notification is not easy. Thus I propose to add settings about FCM icon.

In this fix, FCM-related settings is added to `AndroidManifest.xml` by new plugin as follows:

```
<meta-data android:name="com.google.firebase.messaging.default_notification_color" android:resource="@color/notification_icon_color"/>
<meta-data android:name="com.google.firebase.messaging.default_notification_icon" android:resource="@drawable/notification_icon"/>
```

By these settings, notification icon shows correctly as follows: 

![pr_notification](https://github.com/bluesky-social/social-app/assets/7834440/7f50d345-0630-4488-ac43-d06c8cd52bb5)

Note: I have also set color of notification icon from app icon (`assets/default-avatar.png`).