### PR TITLE
add `newArchEnabled: false` flag to app.config.js

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -121,12 +121,14 @@ module.exports = function (config) {
           {
             ios: {
               deploymentTarget: '13.4',
+              newArchEnabled: false,
             },
             android: {
               compileSdkVersion: 34,
               targetSdkVersion: 34,
               buildToolsVersion: '34.0.0',
               kotlinVersion: '1.8.0',
+              newArchEnabled: false,
             },
           },
         ],


### PR DESCRIPTION
Small one. Just adding a value for `newArchEnabled` to our `app.config.js`. As we start testing Fabric, the `app.config.js` will need to have `newArchEnabled` set to true. We will also need to re-run `yarn prebuild` and builds when switching between the two.

Because the flag add some environment variables that are "sticky", it's difficult to get rid of the flag unless you explicitly set it to `false` after you've enabled it. This just adds a `false` value so we don't have to worry about weirdness.