### PR TITLE
use `onClose` instead of `onChange` for close callback

### DIFF
--- a/src/components/Dialog/index.tsx
+++ b/src/components/Dialog/index.tsx
@@ -119,27 +119,21 @@ export function Outer({
     [open, close],
   )
 
-  const onChange = React.useCallback(
-    (index: number) => {
-      if (index === -1) {
-        Keyboard.dismiss()
-        try {
-          closeCallback.current?.()
-        } catch (e: any) {
-          logger.error(`Dialog closeCallback failed`, {
-            message: e.message,
-          })
-        } finally {
-          closeCallback.current = undefined
-        }
-
-        setDialogIsOpen(control.id, false)
-        onClose?.()
-        setOpenIndex(-1)
-      }
-    },
-    [onClose, setOpenIndex, setDialogIsOpen, control.id],
-  )
+  const onCloseInner = React.useCallback(() => {
+    Keyboard.dismiss()
+    try {
+      closeCallback.current?.()
+    } catch (e: any) {
+      logger.error(`Dialog closeCallback failed`, {
+        message: e.message,
+      })
+    } finally {
+      closeCallback.current = undefined
+    }
+    setDialogIsOpen(control.id, false)
+    onClose?.()
+    setOpenIndex(-1)
+  }, [control.id, onClose, setDialogIsOpen])
 
   const context = React.useMemo(() => ({close}), [close])
 
@@ -167,7 +161,7 @@ export function Outer({
             backdropComponent={Backdrop}
             handleIndicatorStyle={{backgroundColor: t.palette.primary_500}}
             handleStyle={{display: 'none'}}
-            onChange={onChange}>
+            onClose={onCloseInner}>
             <Context.Provider value={context}>
               <View
                 style={[


### PR DESCRIPTION
## Why

We currently use `onChange` to determine if the dialog has closed or not. This works fine in most cases, however, there is the possibility that if we close the dialog too quickly - i.e. before it has fully opened by pressing on the backdrop - that the `onChange` callback won't be fired. The callback is not fired until it has _fully_ transitioned to the new state. Since the dialog doesn't ever open to it's full state to initially change the `index`, it won't fire when it closes since the index remains unchanged.

The solution is to use `onClose` instead of `onChange` for handling our sheet close behavior.

https://github.com/bluesky-social/social-app/assets/153161762/1387103e-6c08-4996-81ab-6683c44c12bf

## Test

- Observe current behavior. Open a dialog and quickly close it by pressing on the backdrop.
- Checkout this PR. Open a dialog and quickly close it, observe that you can open the dialog again, keep scrolling, etc.