### PR TITLE
Apply delay for updating `theme-color` meta tag

### DIFF
--- a/src/alf/util/useColorModeTheme.ts
+++ b/src/alf/util/useColorModeTheme.ts
@@ -51,7 +51,7 @@ function updateDocument(theme: ThemeName) {
     // set color to 'theme-color' meta tag
     setTimeout(() => {
       meta?.setAttribute('content', getBackgroundColor(theme))
-    }, 100)
+    }, 500)
   }
 }
 

--- a/src/alf/util/useColorModeTheme.ts
+++ b/src/alf/util/useColorModeTheme.ts
@@ -49,7 +49,9 @@ function updateDocument(theme: ThemeName) {
     html.className = html.className.replace(/(theme)--\w+/g, '')
     html.classList.add(`theme--${theme}`)
     // set color to 'theme-color' meta tag
-    meta?.setAttribute('content', getBackgroundColor(theme))
+    setTimeout(() => {
+      meta?.setAttribute('content', getBackgroundColor(theme))
+    }, 100)
   }
 }
 


### PR DESCRIPTION
I have found that status bar theme color of web application implemented at https://github.com/bluesky-social/social-app/pull/2918 is reset after the web page is reloaded. Update of `<meta name="theme-color">` is not applied correctly to the browser after reload. To fix this, I have added some delay in updating of `<meta name="theme-color">`.