### PR TITLE
Fix jumpy moderation icon on desktop

### DIFF
--- a/src/view/shell/desktop/LeftNav.tsx
+++ b/src/view/shell/desktop/LeftNav.tsx
@@ -391,7 +391,7 @@ export function DesktopLeftNav() {
               <FontAwesomeIcon
                 icon="hand"
                 style={pal.text as FontAwesomeIconStyle}
-                size={isDesktop ? 20 : 26}
+                size={isDesktop ? 23 : 26}
               />
             }
             label={_(msg`Moderation`)}


### PR DESCRIPTION
Initially I tried to make a solid version of the same icon but it didn't look good. So I'm just adjusting the existing one to better match in sizing.

The tablet/mobile versions are fine so didn't change those.

## Before

https://github.com/bluesky-social/social-app/assets/810438/6fa49259-71f8-496b-b9f1-b9dfec30360a

## After


https://github.com/bluesky-social/social-app/assets/810438/82e5ed5c-5f91-415c-9bf5-d426b828af7e

