### PR TITLE
Run `extract` and `compile` when building for web

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN \. "$NVM_DIR/nvm.sh" && \
   nvm use $NODE_VERSION && \
   npm install --global yarn && \
   yarn && \
-  yarn intl:compile && \
+  yarn intl:build && \
   yarn build-web
 
 # DEBUG


### PR DESCRIPTION
We need to run `extract` and `compile` when building for web, not just `compile` otherwise we might have outdated localizations.

This is mainly needed now because we are not continuously updating the .po files for releases, since the deploy process has changed. Web gets left out of the mix because of this.