### PR TITLE
Adjust FlatList performance in main feeds

### DIFF
--- a/src/lib/hooks/useInitialNumToRender.ts
+++ b/src/lib/hooks/useInitialNumToRender.ts
@@ -1,0 +1,13 @@
+import React from 'react'
+import {useWindowDimensions} from 'react-native'
+
+const MIN_POST_HEIGHT = 100
+
+export function useInitialNumToRender(minItemHeight: number = MIN_POST_HEIGHT) {
+  const {height: screenHeight} = useWindowDimensions()
+
+  return React.useMemo(
+    () => Math.ceil(screenHeight / minItemHeight) + 1,
+    [screenHeight, minItemHeight],
+  )
+}

--- a/src/lib/hooks/useInitialNumToRender.ts
+++ b/src/lib/hooks/useInitialNumToRender.ts
@@ -1,13 +1,11 @@
 import React from 'react'
-import {useWindowDimensions} from 'react-native'
+import {Dimensions} from 'react-native'
 
 const MIN_POST_HEIGHT = 100
 
 export function useInitialNumToRender(minItemHeight: number = MIN_POST_HEIGHT) {
-  const {height: screenHeight} = useWindowDimensions()
-
-  return React.useMemo(
-    () => Math.ceil(screenHeight / minItemHeight) + 1,
-    [screenHeight, minItemHeight],
-  )
+  return React.useMemo(() => {
+    const screenHeight = Dimensions.get('window').height
+    return Math.ceil(screenHeight / minItemHeight) + 1
+  }, [minItemHeight])
 }

--- a/src/screens/Hashtag.tsx
+++ b/src/screens/Hashtag.tsx
@@ -157,7 +157,7 @@ export default function HashtagScreen({
             />
           }
           initialNumToRender={initialNumToRender}
-          windowSize={9}
+          windowSize={11}
         />
       )}
     </>

--- a/src/screens/Hashtag.tsx
+++ b/src/screens/Hashtag.tsx
@@ -154,6 +154,8 @@ export default function HashtagScreen({
               onRetry={fetchNextPage}
             />
           }
+          windowSize={9}
+          initialNumToRender={7}
         />
       )}
     </>

--- a/src/screens/Hashtag.tsx
+++ b/src/screens/Hashtag.tsx
@@ -22,6 +22,7 @@ import {ArrowOutOfBox_Stroke2_Corner0_Rounded} from '#/components/icons/ArrowOut
 import {shareUrl} from 'lib/sharing'
 import {HITSLOP_10} from 'lib/constants'
 import {isNative} from 'platform/detection'
+import {useInitialNumToRender} from 'lib/hooks/useInitialNumToRender'
 
 const renderItem = ({item}: ListRenderItemInfo<PostView>) => {
   return <Post post={item} />
@@ -37,6 +38,7 @@ export default function HashtagScreen({
   const {tag, author} = route.params
   const setMinimalShellMode = useSetMinimalShellMode()
   const {_} = useLingui()
+  const initialNumToRender = useInitialNumToRender()
   const [isPTR, setIsPTR] = React.useState(false)
 
   const fullTag = React.useMemo(() => {
@@ -154,8 +156,8 @@ export default function HashtagScreen({
               onRetry={fetchNextPage}
             />
           }
+          initialNumToRender={initialNumToRender}
           windowSize={9}
-          initialNumToRender={7}
         />
       )}
     </>

--- a/src/view/com/posts/Feed.tsx
+++ b/src/view/com/posts/Feed.tsx
@@ -327,6 +327,8 @@ let Feed = ({
         desktopFixedHeight={
           desktopFixedHeightOffset ? desktopFixedHeightOffset : true
         }
+        initialNumToRender={7}
+        windowSize={9}
       />
     </View>
   )

--- a/src/view/com/posts/Feed.tsx
+++ b/src/view/com/posts/Feed.tsx
@@ -330,7 +330,7 @@ let Feed = ({
           desktopFixedHeightOffset ? desktopFixedHeightOffset : true
         }
         initialNumToRender={initialNumToRender}
-        windowSize={9}
+        windowSize={11}
       />
     </View>
   )

--- a/src/view/com/posts/Feed.tsx
+++ b/src/view/com/posts/Feed.tsx
@@ -32,6 +32,7 @@ import {msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 import {DiscoverFallbackHeader} from './DiscoverFallbackHeader'
 import {FALLBACK_MARKER_POST} from '#/lib/api/feed/home'
+import {useInitialNumToRender} from 'lib/hooks/useInitialNumToRender'
 
 const LOADING_ITEM = {_reactKey: '__loading__'}
 const EMPTY_FEED_ITEM = {_reactKey: '__empty__'}
@@ -84,6 +85,7 @@ let Feed = ({
   const {_} = useLingui()
   const queryClient = useQueryClient()
   const {currentAccount} = useSession()
+  const initialNumToRender = useInitialNumToRender()
   const [isPTRing, setIsPTRing] = React.useState(false)
   const checkForNewRef = React.useRef<(() => void) | null>(null)
   const lastFetchRef = React.useRef<number>(Date.now())
@@ -327,7 +329,7 @@ let Feed = ({
         desktopFixedHeight={
           desktopFixedHeightOffset ? desktopFixedHeightOffset : true
         }
-        initialNumToRender={7}
+        initialNumToRender={initialNumToRender}
         windowSize={9}
       />
     </View>


### PR DESCRIPTION
## Why

This is the first step of working to improve FlatList performance. There's a couple of different parts that need to be fixed up, but this one addresses window size and the initial render.

### Current Behavior

![Screenshot 2024-03-06 at 2 10 04 PM](https://github.com/bluesky-social/social-app/assets/153161762/4a68f3d1-0ba8-46c3-8a86-150d0db78f0b)

The behavior right now renders 10 posts initially (10 posts here means 10 `FeedItem`s, not 10 individual posts, but that is a separate issue). After those ten posts, we fill ten more viewports worth of posts.

Window Size: https://reactnative.dev/docs/optimizing-flatlist-configuration#windowsize
Initial Number: https://reactnative.dev/docs/optimizing-flatlist-configuration#initialnumtorender

In the average feed, we will see between 4-6 posts. On some of the largest screens, the largest number of posts that we will be able to see on the initial render is eight. (There's also a somewhat relevant correlation between screen size and device performance, although that's not a solid test and shouldn't be relied on)

#### Maximum viewable posts
<img src="https://github.com/bluesky-social/social-app/assets/153161762/3d136649-bb14-42f4-80a0-6d04e2f6a3a0" width="300">

We also see that there is a _very_ large number of posts rendered after those initial posts. In this screenshot, the number is 30 posts that are rendered. (This number varies as FlatList determines the number of posts that are necessary to fill the viewport. Shorter posts will result in a higher number of posts being rendered, and vice versa. The main point is that it prepares - by default - ten viewports for scrolling).

## Solution

### initialNumToRender

In this first part of the solution (that would need to be applied in the different list implementations throughout the app, for now only implemented in the main `Feed` component and `Hashtag` for more testing), we create a `useInitialNumToRender()` hook that determines the appropriate number of posts to render initially for that specific device.

#### What we know

- We only want to render what we need
- We want to make sure that if a post is cut off at the bottom but not fully visible, we want that post to be rendered
- We want to add a bit more wiggle room, so we should add one more post on to the initial render.
- The screen size determines the number of posts that will be required to fill the viewport
- **The minimum height of a post is 100 pixels**

With these constraints in mind, we can reliably calculate the number of posts that a user needs for their viewport by simply taking taking the ceiling of `SCREEN_HEIGHT` * `MINIMUM_ITEM_HEIGHT` and adding one to that value.

### windowSize

This is the same adjustment that we made to post threads. During testing, we have not seen any issues in decreasing the window size from 21 to 11 (so, 5 viewports above, 5 below, and one in the middle). This applies the same adjustment to the feeds.

## Results

On the feeds screen, we end up doing significantly less work to display the user's feed.
![Screenshot 2024-03-06 at 2 11 27 PM](https://github.com/bluesky-social/social-app/assets/153161762/b22a02d1-c976-4370-94d7-8932d3d1195c)

Another way to look at it is the significantly lower amount of upfront CPU cycles on the render (top is before, bottom is after)

<img src="https://github.com/bluesky-social/social-app/assets/153161762/4fc428ed-d86b-4ef4-9cb4-8e490537f976" height="400">


We can use the hashtags screen to see the results of scroll performance, before and after

https://github.com/bluesky-social/social-app/assets/153161762/9bece367-f0a4-4b6a-ac5c-f165efb47988

## Next steps

Note in the Feed renders, some items have two items being rendered inside of them. This is because of how we are creating a <FeedItemGroup> (or similar name, cannot remember off the top of my head). This isn't ideal, as we're essentially rendering (as of right now) up to 20 posts for the initial render, whenever a _maximum_ of 4 might be required (again, dependent on screen size). Ideally we would have each of these be its own item given to the FlatList.