### PR TITLE
ALF confirmation dialog, update Delete Post dialog for accessibility

### DIFF
--- a/src/components/Dialog/index.tsx
+++ b/src/components/Dialog/index.tsx
@@ -21,6 +21,7 @@ import {
   DialogOuterProps,
   DialogControlProps,
   DialogInnerProps,
+  DialogExtraOpts,
 } from '#/components/Dialog/types'
 import {Context} from '#/components/Dialog/context'
 
@@ -70,12 +71,12 @@ function Backdrop(props: BottomSheetBackdropProps) {
   )
 }
 
-export function Outer({
+export function Outer<T extends DialogExtraOpts<T> = {}>({
   children,
   control,
   onClose,
   nativeOptions,
-}: React.PropsWithChildren<DialogOuterProps>) {
+}: React.PropsWithChildren<DialogOuterProps<T>>) {
   const t = useTheme()
   const sheet = React.useRef<BottomSheet>(null)
   const sheetOptions = nativeOptions?.sheet || {}

--- a/src/components/Dialog/index.web.tsx
+++ b/src/components/Dialog/index.web.tsx
@@ -8,7 +8,11 @@ import {useLingui} from '@lingui/react'
 import {useTheme, atoms as a, useBreakpoints, web, flatten} from '#/alf'
 import {Portal} from '#/components/Portal'
 
-import {DialogOuterProps, DialogInnerProps} from '#/components/Dialog/types'
+import {
+  DialogOuterProps,
+  DialogInnerProps,
+  DialogExtraOpts,
+} from '#/components/Dialog/types'
 import {Context} from '#/components/Dialog/context'
 import {Button, ButtonIcon} from '#/components/Button'
 import {TimesLarge_Stroke2_Corner0_Rounded as X} from '#/components/icons/Times'
@@ -20,11 +24,11 @@ export {Input} from '#/components/forms/TextField'
 
 const stopPropagation = (e: any) => e.stopPropagation()
 
-export function Outer({
+export function Outer<T extends DialogExtraOpts<T> = {}>({
   children,
   control,
   onClose,
-}: React.PropsWithChildren<DialogOuterProps>) {
+}: React.PropsWithChildren<DialogOuterProps<T>>) {
   const {_} = useLingui()
   const t = useTheme()
   const {gtMobile} = useBreakpoints()

--- a/src/components/Dialog/types.ts
+++ b/src/components/Dialog/types.ts
@@ -6,30 +6,36 @@ import {ViewStyleProp} from '#/alf'
 
 type A11yProps = Required<AccessibilityProps>
 
+export type DialogExtraOpts<T> = {
+  [K in keyof T]?: any
+}
+
 /**
  * Mutated by useImperativeHandle to provide a public API for controlling the
  * dialog. The methods here will actually become the handlers defined within
  * the `Dialog.Outer` component.
  */
-export type DialogControlRefProps = {
-  open: (options?: DialogControlOpenOptions) => void
+export type DialogControlRefProps<T extends DialogExtraOpts<T> = {}> = {
+  open: (options?: DialogControlOpenOptions<T>) => void
   close: (callback?: () => void) => void
 }
 
 /**
  * The return type of the useDialogControl hook.
  */
-export type DialogControlProps = DialogControlRefProps & {
-  id: string
-  ref: React.RefObject<DialogControlRefProps>
-  isOpen: boolean
-}
+export type DialogControlProps<T extends DialogExtraOpts<T> = {}> =
+  DialogControlRefProps<T> & {
+    id: string
+    ref: React.RefObject<DialogControlRefProps<T>>
+    isOpen: boolean
+    options: T
+  }
 
 export type DialogContextProps = {
   close: DialogControlProps['close']
 }
 
-export type DialogControlOpenOptions = {
+export type DialogControlOpenOptions<T extends DialogExtraOpts<T> = {}> = {
   /**
    * NATIVE ONLY
    *
@@ -37,10 +43,10 @@ export type DialogControlOpenOptions = {
    * 0, which is the first snap point (i.e. "open").
    */
   index?: number
-}
+} & T
 
-export type DialogOuterProps = {
-  control: DialogControlProps
+export type DialogOuterProps<T extends DialogExtraOpts<T> = {}> = {
+  control: DialogControlProps<T>
   onClose?: () => void
   nativeOptions?: {
     sheet?: Omit<BottomSheetProps, 'children'>

--- a/src/components/Menu/index.web.tsx
+++ b/src/components/Menu/index.web.tsx
@@ -32,6 +32,7 @@ export function useMenuControl(): Dialog.DialogControlProps {
       close() {
         setIsOpen(false)
       },
+      options: {},
     }),
     [id, isOpen, setIsOpen],
   )

--- a/src/components/Prompt.tsx
+++ b/src/components/Prompt.tsx
@@ -5,7 +5,7 @@ import {useLingui} from '@lingui/react'
 
 import {useTheme, atoms as a} from '#/alf'
 import {Text} from '#/components/Typography'
-import {Button} from '#/components/Button'
+import {Button, ButtonColor} from '#/components/Button'
 
 import * as Dialog from '#/components/Dialog'
 import {DialogExtraOpts} from '#/components/Dialog'
@@ -71,7 +71,7 @@ export function Description({children}: React.PropsWithChildren<{}>) {
   )
 }
 
-export function Actions({children}: React.PropsWithChildren<{}>) {
+export function Actions({children}: React.PropsWithChildren) {
   return (
     <View style={[a.w_full, a.flex_row, a.gap_sm, a.justify_end]}>
       {children}
@@ -98,8 +98,9 @@ export function Cancel({
 
 export function Action({
   children,
+  color = 'primary',
   onPress,
-}: React.PropsWithChildren<{onPress?: () => void}>) {
+}: React.PropsWithChildren<{onPress?: () => void; color?: ButtonColor}>) {
   const {_} = useLingui()
   const {close} = Dialog.useDialogContext()
   const handleOnPress = React.useCallback(() => {
@@ -109,7 +110,7 @@ export function Action({
   return (
     <Button
       variant="solid"
-      color="primary"
+      color={color}
       size="small"
       label={_(msg`Confirm`)}
       onPress={handleOnPress}>

--- a/src/components/Prompt.tsx
+++ b/src/components/Prompt.tsx
@@ -8,6 +8,7 @@ import {Text} from '#/components/Typography'
 import {Button} from '#/components/Button'
 
 import * as Dialog from '#/components/Dialog'
+import {DialogExtraOpts} from '#/components/Dialog'
 
 export {useDialogControl as usePromptControl} from '#/components/Dialog'
 
@@ -19,11 +20,11 @@ const Context = React.createContext<{
   descriptionId: '',
 })
 
-export function Outer({
+export function Outer<T extends DialogExtraOpts<T>>({
   children,
   control,
 }: React.PropsWithChildren<{
-  control: Dialog.DialogOuterProps['control']
+  control: Dialog.DialogOuterProps<T>['control']
 }>) {
   const titleId = React.useId()
   const descriptionId = React.useId()
@@ -34,7 +35,7 @@ export function Outer({
   )
 
   return (
-    <Dialog.Outer control={control}>
+    <Dialog.Outer<T> control={control}>
       <Context.Provider value={context}>
         <Dialog.Handle />
 

--- a/src/components/dialogs/ConfirmDialog.tsx
+++ b/src/components/dialogs/ConfirmDialog.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import * as Prompt from '#/components/Prompt'
+import {useGlobalDialogsControlContext} from '#/components/dialogs/Context'
+import {Trans} from '@lingui/macro'
+import {ConfirmDialogOptions} from '#/components/dialogs/DialogOptions'
+
+export function ConfirmDialog() {
+  const {confirmDialogControl} = useGlobalDialogsControlContext()
+  const {options} = confirmDialogControl
+
+  return (
+    <Prompt.Outer<ConfirmDialogOptions> control={confirmDialogControl}>
+      <Prompt.Title>{options.title}</Prompt.Title>
+      <Prompt.Description>
+        {options.description ? (
+          options.description
+        ) : (
+          <Trans>Are you sure you want to perform this action?</Trans>
+        )}
+      </Prompt.Description>
+      <Prompt.Actions>
+        <Prompt.Cancel>Cancel</Prompt.Cancel>
+        <Prompt.Action onPress={options?.onConfirm}>
+          {options.confirm ? options.confirm : <Trans>Confirm</Trans>}
+        </Prompt.Action>
+      </Prompt.Actions>
+    </Prompt.Outer>
+  )
+}

--- a/src/components/dialogs/ConfirmDialog.tsx
+++ b/src/components/dialogs/ConfirmDialog.tsx
@@ -20,7 +20,9 @@ export function ConfirmDialog() {
       </Prompt.Description>
       <Prompt.Actions>
         <Prompt.Cancel>Cancel</Prompt.Cancel>
-        <Prompt.Action onPress={options?.onConfirm}>
+        <Prompt.Action
+          onPress={options?.onConfirm}
+          color={options.confirmColor}>
           {options.confirm ? options.confirm : <Trans>Confirm</Trans>}
         </Prompt.Action>
       </Prompt.Actions>

--- a/src/components/dialogs/Context.tsx
+++ b/src/components/dialogs/Context.tsx
@@ -1,15 +1,19 @@
 import React from 'react'
 
 import * as Dialog from '#/components/Dialog'
+import {ConfirmDialogOptions} from '#/components/dialogs/DialogOptions'
 
-type Control = Dialog.DialogOuterProps['control']
+type Control<T extends Dialog.DialogExtraOpts<T> = {}> =
+  Dialog.DialogOuterProps<T>['control']
 
 type ControlsContext = {
   mutedWordsDialogControl: Control
+  confirmDialogControl: Control<ConfirmDialogOptions>
 }
 
 const ControlsContext = React.createContext({
   mutedWordsDialogControl: {} as Control,
+  confirmDialogControl: {} as Control<ConfirmDialogOptions>,
 })
 
 export function useGlobalDialogsControlContext() {
@@ -17,10 +21,11 @@ export function useGlobalDialogsControlContext() {
 }
 
 export function Provider({children}: React.PropsWithChildren<{}>) {
-  const mutedWordsDialogControl = Dialog.useDialogControl()
+  const mutedWordsDialogControl = Dialog.useDialogControl({})
+  const confirmDialogControl = Dialog.useDialogControl<ConfirmDialogOptions>()
   const ctx = React.useMemo(
-    () => ({mutedWordsDialogControl}),
-    [mutedWordsDialogControl],
+    () => ({mutedWordsDialogControl, confirmDialogControl}),
+    [confirmDialogControl, mutedWordsDialogControl],
   )
 
   return (

--- a/src/components/dialogs/DialogOptions.ts
+++ b/src/components/dialogs/DialogOptions.ts
@@ -1,7 +1,10 @@
+import {ButtonColor} from '#/components/Button'
+
 export interface ConfirmDialogOptions {
   title: string
   description?: string
   cancel?: string
   confirm?: string
+  confirmColor?: ButtonColor
   onConfirm?: () => unknown
 }

--- a/src/components/dialogs/DialogOptions.ts
+++ b/src/components/dialogs/DialogOptions.ts
@@ -1,0 +1,7 @@
+export interface ConfirmDialogOptions {
+  title: string
+  description?: string
+  cancel?: string
+  confirm?: string
+  onConfirm?: () => unknown
+}

--- a/src/state/dialogs/index.tsx
+++ b/src/state/dialogs/index.tsx
@@ -7,7 +7,7 @@ const DialogContext = React.createContext<{
    * The currently active `useDialogControl` hooks.
    */
   activeDialogs: React.MutableRefObject<
-    Map<string, React.MutableRefObject<DialogControlRefProps>>
+    Map<string, React.MutableRefObject<DialogControlRefProps<any>>>
   >
   /**
    * The currently open dialogs, referenced by their IDs, generated from

--- a/src/view/com/util/forms/PostDropdownBtn.tsx
+++ b/src/view/com/util/forms/PostDropdownBtn.tsx
@@ -278,7 +278,8 @@ let PostDropdownBtn = ({
           description: _(
             msg`If you delete this post, you won't be able to recover it.`,
           ),
-          confirm: _(msg`Delete Post`),
+          confirm: _(msg`Delete`),
+          confirmColor: 'negative',
           onConfirm: onDeletePost,
         })
       },

--- a/src/view/com/util/forms/PostDropdownBtn.tsx
+++ b/src/view/com/util/forms/PostDropdownBtn.tsx
@@ -68,7 +68,8 @@ let PostDropdownBtn = ({
   const {hidePost} = useHiddenPostsApi()
   const openLink = useOpenLink()
   const navigation = useNavigation()
-  const {mutedWordsDialogControl} = useGlobalDialogsControlContext()
+  const {mutedWordsDialogControl, confirmDialogControl} =
+    useGlobalDialogsControlContext()
 
   const rootUri = record.reply?.root?.uri || postUri
   const isThreadMuted = mutedThreads.includes(rootUri)
@@ -272,11 +273,13 @@ let PostDropdownBtn = ({
     isAuthor && {
       label: _(msg`Delete post`),
       onPress() {
-        openModal({
-          name: 'confirm',
+        confirmDialogControl.open({
           title: _(msg`Delete this post?`),
-          message: _(msg`Are you sure? This cannot be undone.`),
-          onPressConfirm: onDeletePost,
+          description: _(
+            msg`If you delete this post, you won't be able to recover it.`,
+          ),
+          confirm: _(msg`Delete Post`),
+          onConfirm: onDeletePost,
         })
       },
       testID: 'postDropdownDeleteBtn',

--- a/src/view/shell/index.tsx
+++ b/src/view/shell/index.tsx
@@ -30,6 +30,7 @@ import {useCloseAnyActiveElement} from '#/state/util'
 import * as notifications from 'lib/notifications/notifications'
 import {Outlet as PortalOutlet} from '#/components/Portal'
 import {MutedWordsDialog} from '#/components/dialogs/MutedWords'
+import {ConfirmDialog} from '#/components/dialogs/ConfirmDialog'
 import {useDialogStateContext} from '#/state/dialogs'
 
 function ShellInner() {
@@ -109,6 +110,7 @@ function ShellInner() {
       </View>
       <Composer winHeight={winDim.height} />
       <ModalsContainer />
+      <ConfirmDialog />
       <MutedWordsDialog />
       <PortalOutlet />
       <Lightbox />

--- a/src/view/shell/index.web.tsx
+++ b/src/view/shell/index.web.tsx
@@ -17,6 +17,7 @@ import {useCloseAllActiveElements} from '#/state/util'
 import {useWebBodyScrollLock} from '#/lib/hooks/useWebBodyScrollLock'
 import {Outlet as PortalOutlet} from '#/components/Portal'
 import {MutedWordsDialog} from '#/components/dialogs/MutedWords'
+import {ConfirmDialog} from '#/components/dialogs/ConfirmDialog'
 
 function ShellInner() {
   const isDrawerOpen = useIsDrawerOpen()
@@ -42,6 +43,7 @@ function ShellInner() {
       <Composer winHeight={0} />
       <ModalsContainer />
       <MutedWordsDialog />
+      <ConfirmDialog />
       <PortalOutlet />
       <Lightbox />
       {!isDesktop && isDrawerOpen && (


### PR DESCRIPTION
We need to fix a good number of our dialogs for cases where accessible font sizes are used. Some dialogs that need to be scrollable are not, which results in some users not being able to do things like delete posts. In an effort to fix a number of accessibility problems with the old Modals, this PR creates a "Confirmation Prompt" that can be re-used.

<img src="https://github.com/bluesky-social/social-app/assets/153161762/8d69778d-15df-40eb-9b0f-e4bf3c68c311" width="400">

![Screenshot 2024-03-06 at 8 02 52 PM](https://github.com/bluesky-social/social-app/assets/153161762/05b7a2ca-a646-4b85-aac8-ab06094deaa9)

