### PR TITLE
Mark bundle start time on web

### DIFF
--- a/index.web.js
+++ b/index.web.js
@@ -1,3 +1,5 @@
+import '#/platform/markBundleStartTime'
+
 import '#/platform/polyfills'
 import {registerRootComponent} from 'expo'
 import {doPolyfill} from '#/lib/api/api-polyfill'

--- a/src/platform/markBundleStartTime.web.ts
+++ b/src/platform/markBundleStartTime.web.ts
@@ -1,0 +1,2 @@
+// Web-only. On RN, this is set by Metro.
+window.__BUNDLE_START_TIME__ = performance.now()

--- a/src/platform/markBundleStartTime.web.ts
+++ b/src/platform/markBundleStartTime.web.ts
@@ -1,2 +1,2 @@
-// Web-only. On RN, this is set by Metro.
+// @ts-ignore Web-only. On RN, this is set by Metro.
 window.__BUNDLE_START_TIME__ = performance.now()


### PR DESCRIPTION
Fixes the initial log we show on startup with the total module start time. It's calculated based on this constant which is set on native in the Metro bundle, but is not set by Webpack. This adds some code manually setting it.

## Test Plan

We now see this on startup:

<img width="412" alt="Screenshot 2024-03-08 at 04 03 33" src="https://github.com/bluesky-social/social-app/assets/810438/81afa466-1741-4f43-b552-fea2edc53188">

The module runs early:

<img width="567" alt="Screenshot 2024-03-08 at 04 03 57" src="https://github.com/bluesky-social/social-app/assets/810438/0f94b798-cef8-411c-9213-9cc2ec3c208c">

No changes for native.