### PR TITLE
Enable gating and experimentation on native, send init event

### DIFF
--- a/src/Navigation.tsx
+++ b/src/Navigation.tsx
@@ -78,6 +78,7 @@ import {createNativeStackNavigatorWithAuth} from './view/shell/createNativeStack
 import {msg} from '@lingui/macro'
 import {i18n, MessageDescriptor} from '@lingui/core'
 import HashtagScreen from '#/screens/Hashtag'
+import {logEvent} from './lib/statsig/statsig'
 
 const navigationRef = createNavigationContainerRef<AllNavigatorParams>()
 
@@ -649,11 +650,14 @@ function logModuleInitTime() {
     return
   }
   didInit = true
+
   const initMs = Math.round(
     // @ts-ignore Emitted by Metro in the bundle prelude
     performance.now() - global.__BUNDLE_START_TIME__,
   )
   console.log(`Time to first paint: ${initMs} ms`)
+  logEvent('init', initMs)
+
   if (__DEV__) {
     // This log is noisy, so keep false committed
     const shouldLog = false

--- a/src/lib/statsig/statsig.tsx
+++ b/src/lib/statsig/statsig.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import {
+  Statsig,
   StatsigProvider,
   useGate as useStatsigGate,
 } from 'statsig-react-native-expo'
@@ -14,6 +15,14 @@ const statsigOptions = {
   // This ensures the UI is always consistent and doesn't update mid-session.
   // Note this makes cold load (no local storage) and private mode return `false` for all gates.
   initTimeoutMs: 1,
+}
+
+export function logEvent(
+  eventName: string,
+  value?: string | number | null,
+  metadata?: Record<string, string> | null,
+) {
+  Statsig.logEvent(eventName, value, metadata)
 }
 
 export function useGate(gateName: string) {

--- a/src/lib/statsig/statsig.tsx
+++ b/src/lib/statsig/statsig.tsx
@@ -1,11 +1,54 @@
 import React from 'react'
+import {
+  StatsigProvider,
+  useGate as useStatsigGate,
+} from 'statsig-react-native-expo'
+import {useSession} from '../../state/session'
+import {sha256} from 'js-sha256'
 
-export function useGate(_gateName: string) {
-  // Not enabled for native yet.
-  return false
+const statsigOptions = {
+  environment: {
+    tier: process.env.NODE_ENV === 'development' ? 'development' : 'production',
+  },
+  // Don't block on waiting for network. The fetched config will kick in on next load.
+  // This ensures the UI is always consistent and doesn't update mid-session.
+  // Note this makes cold load (no local storage) and private mode return `false` for all gates.
+  initTimeoutMs: 1,
+}
+
+export function useGate(gateName: string) {
+  const {isLoading, value} = useStatsigGate(gateName)
+  if (isLoading) {
+    // This should not happen because of waitForInitialization={true}.
+    console.error('Did not expected isLoading to ever be true.')
+  }
+  return value
+}
+
+function toStatsigUser(did: string | undefined) {
+  let userID: string | undefined
+  if (did) {
+    userID = sha256(did)
+  }
+  return {userID}
 }
 
 export function Provider({children}: {children: React.ReactNode}) {
-  // Not enabled for native yet.
-  return children
+  const {currentAccount} = useSession()
+  const currentStatsigUser = React.useMemo(
+    () => toStatsigUser(currentAccount?.did),
+    [currentAccount?.did],
+  )
+  return (
+    <StatsigProvider
+      sdkKey="client-SXJakO39w9vIhl3D44u8UupyzFl4oZ2qPIkjwcvuPsV"
+      mountKey={currentStatsigUser.userID}
+      user={currentStatsigUser}
+      // This isn't really blocking due to short initTimeoutMs above.
+      // However, it ensures `isLoading` is always `false`.
+      waitForInitialization={true}
+      options={statsigOptions}>
+      {children}
+    </StatsigProvider>
+  )
 }

--- a/src/lib/statsig/statsig.web.tsx
+++ b/src/lib/statsig/statsig.web.tsx
@@ -1,5 +1,9 @@
 import React from 'react'
-import {StatsigProvider, useGate as useStatsigGate} from 'statsig-react'
+import {
+  Statsig,
+  StatsigProvider,
+  useGate as useStatsigGate,
+} from 'statsig-react'
 import {useSession} from '../../state/session'
 import {sha256} from 'js-sha256'
 
@@ -11,6 +15,14 @@ const statsigOptions = {
   // This ensures the UI is always consistent and doesn't update mid-session.
   // Note this makes cold load (no local storage) and private mode return `false` for all gates.
   initTimeoutMs: 1,
+}
+
+export function logEvent(
+  eventName: string,
+  value?: string | number | null,
+  metadata?: Record<string, string> | null,
+) {
+  Statsig.logEvent(eventName, value, metadata)
 }
 
 export function useGate(gateName: string) {


### PR DESCRIPTION
In the first commit, I copypasted `statsig.web.tsx` into `statsig.tsx` but replaced the SDK with the Expo version. The code is the same otherwise. We could also in principle use the Expo version in both places but I wanted to avoid an extra wrapper on the web so we have a bit more control there. We will unify them later on if this is not needed.

In the second commit, I added an explicit `init` event that's sent unconditionally from the navigator `onReady`. This kickstarts built-in Statsig metrics. Otherwise it doesn't count it as a visit. This also lets us send the time we spent executing the startup-blocking modules (which after https://github.com/bluesky-social/social-app/pull/3147 works on the web too) — so that'll be our first explicit perf metric.

Note any gates will only re-evaluate after you quit the app twice (once to make the config refetched, and once to make the updated config applied). I'll improve this later on; for now it's the same behavior as on the web (but with app reloads rather than page reloads).

## Test Plan

Web:

<img width="614" alt="Screenshot 2024-03-08 at 04 18 13" src="https://github.com/bluesky-social/social-app/assets/810438/117ceb56-1ce0-4be3-9fcd-e8bac2336ece">

iOS:

<img width="529" alt="Screenshot 2024-03-08 at 04 19 38" src="https://github.com/bluesky-social/social-app/assets/810438/e6963bc5-de58-4259-a670-90aa41b1a121">

Android:

<img width="473" alt="Screenshot 2024-03-08 at 04 20 55" src="https://github.com/bluesky-social/social-app/assets/810438/8d722306-5faf-46a6-8809-710c3db1001c">
