### PR TITLE
Make ALF prompt scrollable for accessibility

### DIFF
--- a/src/components/Prompt.tsx
+++ b/src/components/Prompt.tsx
@@ -3,7 +3,7 @@ import {View, PressableProps} from 'react-native'
 import {msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
-import {useTheme, atoms as a} from '#/alf'
+import {useTheme, atoms as a, useBreakpoints} from '#/alf'
 import {Text} from '#/components/Typography'
 import {Button} from '#/components/Button'
 
@@ -25,6 +25,7 @@ export function Outer({
 }: React.PropsWithChildren<{
   control: Dialog.DialogOuterProps['control']
 }>) {
+  const {gtMobile} = useBreakpoints()
   const titleId = React.useId()
   const descriptionId = React.useId()
 
@@ -38,12 +39,12 @@ export function Outer({
       <Context.Provider value={context}>
         <Dialog.Handle />
 
-        <Dialog.Inner
+        <Dialog.ScrollableInner
           accessibilityLabelledBy={titleId}
           accessibilityDescribedBy={descriptionId}
-          style={[{width: 'auto', maxWidth: 400}]}>
+          style={[gtMobile ? {width: 'auto', maxWidth: 400} : a.w_full]}>
           {children}
-        </Dialog.Inner>
+        </Dialog.ScrollableInner>
       </Context.Provider>
     </Dialog.Outer>
   )

--- a/src/components/Prompt.tsx
+++ b/src/components/Prompt.tsx
@@ -72,8 +72,17 @@ export function Description({children}: React.PropsWithChildren<{}>) {
 }
 
 export function Actions({children}: React.PropsWithChildren<{}>) {
+  const {gtMobile} = useBreakpoints()
+
   return (
-    <View style={[a.w_full, a.flex_row, a.gap_sm, a.justify_end]}>
+    <View
+      style={[
+        a.w_full,
+        a.flex_row,
+        a.gap_sm,
+        a.justify_end,
+        gtMobile && [a.pb_4xl],
+      ]}>
       {children}
     </View>
   )


### PR DESCRIPTION
One of the driving motivators of moving these modals to ALF is accessibility. If users are using a very large font size, they are currently unable to scroll down to things like "Delete Post" inside of a modal. This is also an issue with the Prompt, since we just use a `Dialog.Inner`. We should instead use a `Dialog.ScrollableInner`, so that if the font size is too large, the user can scroll to the needed button.

![Screenshot 2024-03-07 at 8 44 09 PM](https://github.com/bluesky-social/social-app/assets/153161762/949f0009-329a-42af-9d19-688a052a1706)
![Screenshot 2024-03-07 at 8 44 13 PM](https://github.com/bluesky-social/social-app/assets/153161762/5e887118-0196-4db4-bdcb-084eaf8baa2c)
