### PR TITLE
Prevent duplicate image pastes in composer on iOS

### DIFF
--- a/src/state/models/media/gallery.ts
+++ b/src/state/models/media/gallery.ts
@@ -8,6 +8,7 @@ interface InitialImageUri {
   uri: string
   width: number
   height: number
+  hash?: string
 }
 
 export class GalleryModel {
@@ -48,7 +49,7 @@ export class GalleryModel {
     }
   }
 
-  async paste(uri: string) {
+  async paste(uri: string, hash?: string) {
     if (this.size >= 4) {
       return
     }
@@ -60,11 +61,14 @@ export class GalleryModel {
       height,
       width,
       mime: 'image/jpeg',
+      hash,
     }
 
-    runInAction(() => {
-      this.add(image)
-    })
+    if (!this.images.some(i => i.hash === hash)) {
+      runInAction(() => {
+        this.add(image)
+      })
+    }
   }
 
   setAltText(image: ImageModel, altText: string) {

--- a/src/state/models/media/image.ts
+++ b/src/state/models/media/image.ts
@@ -21,7 +21,11 @@ export interface ImageManipulationAttributes {
 
 const MAX_IMAGE_SIZE_IN_BYTES = 976560
 
-export class ImageModel implements Omit<RNImage, 'size'> {
+interface Image extends Omit<RNImage, 'size'> {
+  hash?: string
+}
+
+export class ImageModel implements Image {
   path: string
   mime = 'image/jpeg'
   width: number
@@ -29,6 +33,7 @@ export class ImageModel implements Omit<RNImage, 'size'> {
   altText = ''
   cropped?: RNImage = undefined
   compressed?: RNImage = undefined
+  hash?: string = ''
 
   // Web manipulation
   prev?: RNImage
@@ -41,12 +46,13 @@ export class ImageModel implements Omit<RNImage, 'size'> {
   }
   prevAttributes: ImageManipulationAttributes = {}
 
-  constructor(image: Omit<RNImage, 'size'>) {
+  constructor(image: Image) {
     makeAutoObservable(this)
 
     this.path = image.path
     this.width = image.width
     this.height = image.height
+    this.hash = image.hash
   }
 
   setRatio(aspectRatio: ImageManipulationAttributes['aspectRatio']) {

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -197,9 +197,11 @@ export const ComposePost = observer(function ComposePost({
   )
 
   const onPhotoPasted = useCallback(
-    async (uri: string) => {
+    async (uri: string, hash?: string) => {
       track('Composer:PastedPhotos')
-      await gallery.paste(uri)
+      if (!gallery.images.some(image => image.hash === hash)) {
+        await gallery.paste(uri, hash)
+      }
     },
     [gallery, track],
   )
@@ -423,6 +425,7 @@ export const ComposePost = observer(function ComposePost({
               accessibilityHint={_(
                 msg`Compose posts up to ${MAX_GRAPHEME_LENGTH} characters in length`,
               )}
+              gallery={gallery}
             />
           </View>
 

--- a/src/view/com/composer/text-input/TextInput.tsx
+++ b/src/view/com/composer/text-input/TextInput.tsx
@@ -167,7 +167,7 @@ export const TextInput = forwardRef(function TextInputImpl(
 
       const uris = files.map(f => f.uri)
       const uri = uris.find(isUriImage)
-      console.log('onPaste', uri, uris, files)
+
       if (uri) {
         onPhotoPasted(uri)
       }


### PR DESCRIPTION
A pass at resolving #1716 , preventing an image URL in the Composer from being downloaded and attached to a message mutliple times on iOS.

We keep track of a hash of a pasted image's URL in the gallery and check existing hashes before initiating a new download.