### PR TITLE
Poll gate configuration changes

### DIFF
--- a/src/lib/statsig/statsig.tsx
+++ b/src/lib/statsig/statsig.tsx
@@ -48,6 +48,18 @@ export function Provider({children}: {children: React.ReactNode}) {
     () => toStatsigUser(currentAccount?.did),
     [currentAccount?.did],
   )
+
+  React.useEffect(() => {
+    function refresh() {
+      // Intentionally refetching the config using the JS SDK rather than React SDK
+      // so that the new config is stored in cache but isn't used during this session.
+      // It will kick in for the next reload.
+      Statsig.updateUser(currentStatsigUser)
+    }
+    const id = setInterval(refresh, 3 * 60e3 /* 3 min */)
+    return () => clearInterval(id)
+  }, [currentStatsigUser])
+
   return (
     <StatsigProvider
       sdkKey="client-SXJakO39w9vIhl3D44u8UupyzFl4oZ2qPIkjwcvuPsV"

--- a/src/lib/statsig/statsig.web.tsx
+++ b/src/lib/statsig/statsig.web.tsx
@@ -48,6 +48,18 @@ export function Provider({children}: {children: React.ReactNode}) {
     () => toStatsigUser(currentAccount?.did),
     [currentAccount?.did],
   )
+
+  React.useEffect(() => {
+    function refresh() {
+      // Intentionally refetching the config using the JS SDK rather than React SDK
+      // so that the new config is stored in cache but isn't used during this session.
+      // It will kick in for the next reload.
+      Statsig.updateUser(currentStatsigUser)
+    }
+    const id = setInterval(refresh, 3 * 60e3 /* 3 min */)
+    return () => clearInterval(id)
+  }, [currentStatsigUser])
+
   return (
     <StatsigProvider
       sdkKey="client-SXJakO39w9vIhl3D44u8UupyzFl4oZ2qPIkjwcvuPsV"


### PR DESCRIPTION
This sets up a polling mechanism so that we ask Statsig for new configuration once every three minutes. The new configuration would still not be reflected in the UI, but it would get stored in local storage. So it will be used on the next fresh load. Practically, this means that instead of kicking in on N+2 load (where N is when we changed setting), it kicks in on N+1.

## Test Plan

In this test, I adjusted the poll interval to be much shorter so we can observe how it works.

Verified that we periodically call `initialize` for the current user and get the config back. Verified that the config includes the latest data, but isn't reflected in the UI until next refresh. Verified updating the UI (e.g. via state updates) doesn't cause it to read new data.

https://github.com/bluesky-social/social-app/assets/810438/1d5caf7d-6e0a-4273-ac0f-370c27e5526f





