### PR TITLE
Fix `aria-label` on the Share button

### DIFF
--- a/src/view/com/util/post-ctrls/PostCtrls.tsx
+++ b/src/view/com/util/post-ctrls/PostCtrls.tsx
@@ -212,9 +212,7 @@ let PostCtrls = ({
             style={[styles.btn]}
             onPress={onShare}
             accessibilityRole="button"
-            accessibilityLabel={`${
-              post.viewer?.like ? _(msg`Unlike`) : _(msg`Like`)
-            } (${post.likeCount} ${pluralize(post.likeCount || 0, 'like')})`}
+            accessibilityLabel={`${_(msg`Share`)}`}
             accessibilityHint=""
             hitSlop={big ? HITSLOP_20 : HITSLOP_10}>
             <ArrowOutOfBox style={[defaultCtrlColor, styles.mt1]} width={22} />


### PR DESCRIPTION
The `aria-label` on the Share button was the same as the one on the Like button.

Before:
![image](https://github.com/bluesky-social/social-app/assets/81575558/cb4c9dd5-7831-4221-814e-f7c598ed6743)

After:
![image](https://github.com/bluesky-social/social-app/assets/81575558/454e646a-0fa0-4ef3-afc4-3b60517e08fb)
