### PR TITLE
Fix button widths in the Settings on web

### DIFF
--- a/src/view/com/util/forms/SelectableBtn.tsx
+++ b/src/view/com/util/forms/SelectableBtn.tsx
@@ -57,6 +57,7 @@ const styles = StyleSheet.create({
   btn: {
     flexDirection: 'row',
     justifyContent: 'center',
+    flexGrow: 1,
     borderWidth: 1,
     borderLeftWidth: 0,
     paddingHorizontal: 10,

--- a/src/view/screens/Settings/index.tsx
+++ b/src/view/screens/Settings/index.tsx
@@ -473,14 +473,14 @@ export function SettingsScreen({}: Props) {
               left
               onSelect={() => setColorMode('system')}
               accessibilityHint={_(msg`Set color theme to system setting`)}
-              style={{width: '33.33333333333333333333%'}}
+              style={{width: '33.33%'}}
             />
             <SelectableBtn
               selected={colorMode === 'light'}
               label={_(msg`Light`)}
               onSelect={() => setColorMode('light')}
               accessibilityHint={_(msg`Set color theme to light`)}
-              style={{width: '33.33333333333333333333%'}}
+              style={{width: '33.33%'}}
             />
             <SelectableBtn
               selected={colorMode === 'dark'}
@@ -488,7 +488,7 @@ export function SettingsScreen({}: Props) {
               right
               onSelect={() => setColorMode('dark')}
               accessibilityHint={_(msg`Set color theme to dark`)}
-              style={{width: '33.33333333333333333333%'}}
+              style={{width: '33.33%'}}
             />
           </View>
         </View>

--- a/src/view/screens/Settings/index.tsx
+++ b/src/view/screens/Settings/index.tsx
@@ -473,14 +473,12 @@ export function SettingsScreen({}: Props) {
               left
               onSelect={() => setColorMode('system')}
               accessibilityHint={_(msg`Set color theme to system setting`)}
-              style={{width: '33.33%'}}
             />
             <SelectableBtn
               selected={colorMode === 'light'}
               label={_(msg`Light`)}
               onSelect={() => setColorMode('light')}
               accessibilityHint={_(msg`Set color theme to light`)}
-              style={{width: '33.33%'}}
             />
             <SelectableBtn
               selected={colorMode === 'dark'}
@@ -488,7 +486,6 @@ export function SettingsScreen({}: Props) {
               right
               onSelect={() => setColorMode('dark')}
               accessibilityHint={_(msg`Set color theme to dark`)}
-              style={{width: '33.33%'}}
             />
           </View>
         </View>
@@ -508,7 +505,6 @@ export function SettingsScreen({}: Props) {
                   left
                   onSelect={() => setDarkTheme('dim')}
                   accessibilityHint={_(msg`Set dark theme to the dim theme`)}
-                  style={{width: '50%'}}
                 />
                 <SelectableBtn
                   selected={darkTheme === 'dark'}
@@ -516,7 +512,6 @@ export function SettingsScreen({}: Props) {
                   right
                   onSelect={() => setDarkTheme('dark')}
                   accessibilityHint={_(msg`Set dark theme to the dark theme`)}
-                  style={{width: '50%'}}
                 />
               </View>
             </View>

--- a/src/view/screens/Settings/index.tsx
+++ b/src/view/screens/Settings/index.tsx
@@ -473,14 +473,14 @@ export function SettingsScreen({}: Props) {
               left
               onSelect={() => setColorMode('system')}
               accessibilityHint={_(msg`Set color theme to system setting`)}
-              style={styles.textBtns}
+              style={{width: '33.33333333333333333333%'}}
             />
             <SelectableBtn
               selected={colorMode === 'light'}
               label={_(msg`Light`)}
               onSelect={() => setColorMode('light')}
               accessibilityHint={_(msg`Set color theme to light`)}
-              style={styles.textBtns}
+              style={{width: '33.33333333333333333333%'}}
             />
             <SelectableBtn
               selected={colorMode === 'dark'}
@@ -488,7 +488,7 @@ export function SettingsScreen({}: Props) {
               right
               onSelect={() => setColorMode('dark')}
               accessibilityHint={_(msg`Set color theme to dark`)}
-              style={styles.textBtns}
+              style={{width: '33.33333333333333333333%'}}
             />
           </View>
         </View>
@@ -508,7 +508,7 @@ export function SettingsScreen({}: Props) {
                   left
                   onSelect={() => setDarkTheme('dim')}
                   accessibilityHint={_(msg`Set dark theme to the dim theme`)}
-                  style={styles.textBtns}
+                  style={{width: '50%'}}
                 />
                 <SelectableBtn
                   selected={darkTheme === 'dark'}
@@ -516,7 +516,7 @@ export function SettingsScreen({}: Props) {
                   right
                   onSelect={() => setDarkTheme('dark')}
                   accessibilityHint={_(msg`Set dark theme to the dark theme`)}
-                  style={styles.textBtns}
+                  style={{width: '50%'}}
                 />
               </View>
             </View>
@@ -1023,10 +1023,6 @@ const styles = StyleSheet.create({
 
   selectableBtns: {
     flexDirection: 'row',
-  },
-
-  textBtns: {
-    boxSizing: 'content-box',
   },
 
   btn: {

--- a/src/view/screens/Settings/index.tsx
+++ b/src/view/screens/Settings/index.tsx
@@ -473,12 +473,14 @@ export function SettingsScreen({}: Props) {
               left
               onSelect={() => setColorMode('system')}
               accessibilityHint={_(msg`Set color theme to system setting`)}
+              style={styles.textBtns}
             />
             <SelectableBtn
               selected={colorMode === 'light'}
               label={_(msg`Light`)}
               onSelect={() => setColorMode('light')}
               accessibilityHint={_(msg`Set color theme to light`)}
+              style={styles.textBtns}
             />
             <SelectableBtn
               selected={colorMode === 'dark'}
@@ -486,6 +488,7 @@ export function SettingsScreen({}: Props) {
               right
               onSelect={() => setColorMode('dark')}
               accessibilityHint={_(msg`Set color theme to dark`)}
+              style={styles.textBtns}
             />
           </View>
         </View>
@@ -505,6 +508,7 @@ export function SettingsScreen({}: Props) {
                   left
                   onSelect={() => setDarkTheme('dim')}
                   accessibilityHint={_(msg`Set dark theme to the dim theme`)}
+                  style={styles.textBtns}
                 />
                 <SelectableBtn
                   selected={darkTheme === 'dark'}
@@ -512,6 +516,7 @@ export function SettingsScreen({}: Props) {
                   right
                   onSelect={() => setDarkTheme('dark')}
                   accessibilityHint={_(msg`Set dark theme to the dark theme`)}
+                  style={styles.textBtns}
                 />
               </View>
             </View>
@@ -1018,6 +1023,10 @@ const styles = StyleSheet.create({
 
   selectableBtns: {
     flexDirection: 'row',
+  },
+
+  textBtns: {
+    boxSizing: 'content-box',
   },
 
   btn: {


### PR DESCRIPTION
Make the buttons full width in settings so it supports longer strings in other languages.

This is the least bad solution with the current constraints per my research. This would be solved neatly if RN would support `box-sizing: content-box` but it does not.

It's possible there is a more elegant solution, I'm not a CSS expert but I did spend quite a bit googling about this.

Before:
![image](https://github.com/bluesky-social/social-app/assets/81575558/60d8cad1-1a9c-43ab-9eaa-278363f3e8e2)

After:
![image](https://github.com/bluesky-social/social-app/assets/81575558/afd4de23-b930-4b86-91f1-c8586869a969)



Fixes #3060.