### PR TITLE
Don't include `localhost:19006` as intent filter in production

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -40,6 +40,8 @@ module.exports = function (config) {
       ? process.env.BSKY_ANDROID_VERSION_CODE
       : process.env.BSKY_IOS_BUILD_NUMBER
 
+  const IS_DEV = process.env.EXPO_PUBLIC_ENV === 'development'
+
   return {
     expo: {
       version: VERSION,
@@ -103,7 +105,7 @@ module.exports = function (config) {
                 scheme: 'https',
                 host: 'bsky.app',
               },
-              {
+              IS_DEV && {
                 scheme: 'http',
                 host: 'localhost:19006',
               },


### PR DESCRIPTION
Apparently this shows up as a possible intent filter on Android, so we can limit it to only being applicable for development.