### PR TITLE
Await `share` before closing menu

### DIFF
--- a/src/lib/sharing.ts
+++ b/src/lib/sharing.ts
@@ -12,9 +12,9 @@ import {Share} from 'react-native'
  */
 export async function shareUrl(url: string) {
   if (isAndroid) {
-    Share.share({message: url})
+    await Share.share({message: url})
   } else if (isIOS) {
-    Share.share({url})
+    await Share.share({url})
   } else {
     // React Native Share is not supported by web. Web Share API
     // has increasing but not full support, so default to clipboard


### PR DESCRIPTION
Should fix a small graphical issue when sharing on Android from the new menu popup. Right now, the dialog starts to close but freezes as the share sheet opens up. This will keep the sheet open until the sharing is complete so it doesn't look janky.