### PR TITLE
Fix `lineHeight` problems on native with new `Text`

### DIFF
--- a/src/components/Typography.tsx
+++ b/src/components/Typography.tsx
@@ -3,7 +3,7 @@ import {Text as RNText, TextStyle, TextProps as RNTextProps} from 'react-native'
 import {UITextView} from 'react-native-ui-text-view'
 
 import {useTheme, atoms, web, flatten} from '#/alf'
-import {isIOS} from '#/platform/detection'
+import {isIOS, isNative} from '#/platform/detection'
 
 export type TextProps = RNTextProps & {
   /**
@@ -40,11 +40,11 @@ function normalizeTextStyles(styles: TextStyle[]) {
   const fontSize = s.fontSize || atoms.text_md.fontSize
 
   if (s?.lineHeight) {
-    if (s.lineHeight <= 2) {
+    if (s.lineHeight !== 0 && s.lineHeight <= 2) {
       s.lineHeight = Math.round(fontSize * s.lineHeight)
     }
-  } else {
-    s.lineHeight = fontSize
+  } else if (!isNative) {
+    s.lineHeight = s.fontSize
   }
 
   return s


### PR DESCRIPTION
On native, setting the `lineHeight` to the `fontSize` adds a bit of extra height that we don't want, preventing us from properly aligning text in some cases. Instead, let's only apply that on web (during testing, it *does* seem to help on web to do this). On native, if the line height is undefined or zero, don't change it.

## Before
![Screenshot 2024-03-11 at 12 41 35 PM](https://github.com/bluesky-social/social-app/assets/153161762/1f090257-a81f-4733-a85d-cb45a746b6ff)


## After
![Screenshot 2024-03-11 at 12 41 56 PM](https://github.com/bluesky-social/social-app/assets/153161762/159bf465-a01b-45df-bbe0-0862eac7c6c5)