### PR TITLE
Fix onboarding `FeedCard` text overflow

### DIFF
--- a/src/screens/Onboarding/StepAlgoFeeds/FeedCard.tsx
+++ b/src/screens/Onboarding/StepAlgoFeeds/FeedCard.tsx
@@ -238,13 +238,14 @@ function FeedCardInner({feed}: {feed: FeedSourceInfo; config: FeedConfig}) {
           />
         </View>
 
-        <View style={[a.pt_2xs, a.flex_grow]}>
+        <View style={[a.pt_2xs, a.flex_1, a.flex_grow]}>
           <Text
             style={[
               a.text_md,
               a.font_bold,
               ctx.selected && styles.textSelected,
-            ]}>
+            ]}
+            numberOfLines={1}>
             {feed.displayName}
           </Text>
           <Text


### PR DESCRIPTION
Just adding `flex_1` to the wrapper and `numberOfLines` to the feed title.

## Before
![Screenshot 2024-03-11 at 12 37 30 PM](https://github.com/bluesky-social/social-app/assets/153161762/1c4df4a1-aea7-46ca-80ac-e876dfc343e3)


## After
![Screenshot 2024-03-11 at 12 47 25 PM](https://github.com/bluesky-social/social-app/assets/153161762/d88a044e-57af-4a10-9636-80d9aed9179a)
