### PR TITLE
Send route name with Statsig events

### DIFF
--- a/src/Navigation.tsx
+++ b/src/Navigation.tsx
@@ -656,7 +656,9 @@ function logModuleInitTime() {
     performance.now() - global.__BUNDLE_START_TIME__,
   )
   console.log(`Time to first paint: ${initMs} ms`)
-  logEvent('init', initMs)
+  logEvent('init', {
+    initMs,
+  })
 
   if (__DEV__) {
     // This log is noisy, so keep false committed

--- a/src/Navigation.tsx
+++ b/src/Navigation.tsx
@@ -78,7 +78,7 @@ import {createNativeStackNavigatorWithAuth} from './view/shell/createNativeStack
 import {msg} from '@lingui/macro'
 import {i18n, MessageDescriptor} from '@lingui/core'
 import HashtagScreen from '#/screens/Hashtag'
-import {logEvent} from './lib/statsig/statsig'
+import {logEvent, attachRouteToLogEvents} from './lib/statsig/statsig'
 
 const navigationRef = createNavigationContainerRef<AllNavigatorParams>()
 
@@ -543,12 +543,17 @@ function RoutesContainer({children}: React.PropsWithChildren<{}>) {
       linking={LINKING}
       theme={theme}
       onReady={() => {
+        attachRouteToLogEvents(getCurrentRouteName)
         logModuleInitTime()
         onReady()
       }}>
       {children}
     </NavigationContainer>
   )
+}
+
+function getCurrentRouteName() {
+  return navigationRef.getCurrentRoute()?.name
 }
 
 /**

--- a/src/lib/statsig/events.ts
+++ b/src/lib/statsig/events.ts
@@ -1,0 +1,5 @@
+export type Events = {
+  init: {
+    initMs: number
+  }
+}

--- a/src/lib/statsig/statsig.tsx
+++ b/src/lib/statsig/statsig.tsx
@@ -6,6 +6,7 @@ import {
 } from 'statsig-react-native-expo'
 import {useSession} from '../../state/session'
 import {sha256} from 'js-sha256'
+import {Events} from './events'
 
 const statsigOptions = {
   environment: {
@@ -17,12 +18,20 @@ const statsigOptions = {
   initTimeoutMs: 1,
 }
 
-export function logEvent(
-  eventName: string,
-  value?: string | number | null,
-  metadata?: Record<string, string> | null,
+type FlatJSONRecord = Record<
+  string,
+  string | number | boolean | null | undefined
+>
+
+export function logEvent<E extends keyof Events>(
+  eventName: E & string,
+  metadata: Events[E] & FlatJSONRecord,
 ) {
-  Statsig.logEvent(eventName, value, metadata)
+  Statsig.logEvent(
+    eventName,
+    null,
+    metadata as Record<string, string>, // Close enough and it works.
+  )
 }
 
 export function useGate(gateName: string) {


### PR DESCRIPTION
## What

- Add typed event names/metadata for Statsig calls. Similar to how our Segment setup works. I'm starting from scratch so we can vet them again. For now I'm adding just typing `init`.
- Automatically include the current route name with every event. This is distinct from page URL — it's our router's "route name" concept. Might help track which features are used from which screens.

## Test Plan

Checked on web and iOS.

<img width="444" alt="Screenshot 2024-03-13 at 02 59 38" src="https://github.com/bluesky-social/social-app/assets/810438/85da5407-99ab-40ce-93ee-88aefcbe8b13">
