### PR TITLE
[Statsig] Track likes, reposts, follows

### DIFF
--- a/src/lib/statsig/events.ts
+++ b/src/lib/statsig/events.ts
@@ -1,4 +1,4 @@
-export type Events = {
+export type LogEvents = {
   init: {
     initMs: number
   }

--- a/src/lib/statsig/events.ts
+++ b/src/lib/statsig/events.ts
@@ -2,4 +2,10 @@ export type Events = {
   init: {
     initMs: number
   }
+  'post:like': {
+    logContext: 'FeedItem' | 'PostThreadItem' | 'Post'
+  }
+  'post:unlike': {
+    logContext: 'FeedItem' | 'PostThreadItem' | 'Post'
+  }
 }

--- a/src/lib/statsig/events.ts
+++ b/src/lib/statsig/events.ts
@@ -14,4 +14,22 @@ export type Events = {
   'post:unrepost': {
     logContext: 'FeedItem' | 'PostThreadItem' | 'Post'
   }
+  'profile:follow': {
+    logContext:
+      | 'RecommendedFollowsItem'
+      | 'PostThreadItem'
+      | 'ProfileCard'
+      | 'ProfileHeader'
+      | 'ProfileHeaderSuggestedFollows'
+      | 'ProfileMenu'
+  }
+  'profile:unfollow': {
+    logContext:
+      | 'RecommendedFollowsItem'
+      | 'ProfileCard'
+      | 'PostThreadItem'
+      | 'ProfileHeader'
+      | 'ProfileHeaderSuggestedFollows'
+      | 'ProfileMenu'
+  }
 }

--- a/src/lib/statsig/events.ts
+++ b/src/lib/statsig/events.ts
@@ -26,8 +26,8 @@ export type LogEvents = {
   'profile:unfollow': {
     logContext:
       | 'RecommendedFollowsItem'
-      | 'ProfileCard'
       | 'PostThreadItem'
+      | 'ProfileCard'
       | 'ProfileHeader'
       | 'ProfileHeaderSuggestedFollows'
       | 'ProfileMenu'

--- a/src/lib/statsig/events.ts
+++ b/src/lib/statsig/events.ts
@@ -5,7 +5,13 @@ export type Events = {
   'post:like': {
     logContext: 'FeedItem' | 'PostThreadItem' | 'Post'
   }
+  'post:repost': {
+    logContext: 'FeedItem' | 'PostThreadItem' | 'Post'
+  }
   'post:unlike': {
+    logContext: 'FeedItem' | 'PostThreadItem' | 'Post'
+  }
+  'post:unrepost': {
     logContext: 'FeedItem' | 'PostThreadItem' | 'Post'
   }
 }

--- a/src/lib/statsig/statsig.tsx
+++ b/src/lib/statsig/statsig.tsx
@@ -33,7 +33,7 @@ export function attachRouteToLogEvents(
 
 export function logEvent<E extends keyof Events>(
   eventName: E & string,
-  rawMetadata?: Events[E] & FlatJSONRecord,
+  rawMetadata: Events[E] & FlatJSONRecord,
 ) {
   const fullMetadata = {
     ...rawMetadata,

--- a/src/lib/statsig/statsig.tsx
+++ b/src/lib/statsig/statsig.tsx
@@ -6,7 +6,9 @@ import {
 } from 'statsig-react-native-expo'
 import {useSession} from '../../state/session'
 import {sha256} from 'js-sha256'
-import {Events} from './events'
+import {LogEvents} from './events'
+
+export type {LogEvents}
 
 const statsigOptions = {
   environment: {
@@ -31,9 +33,9 @@ export function attachRouteToLogEvents(
   getCurrentRouteName = getRouteName
 }
 
-export function logEvent<E extends keyof Events>(
+export function logEvent<E extends keyof LogEvents>(
   eventName: E & string,
-  rawMetadata: Events[E] & FlatJSONRecord,
+  rawMetadata: LogEvents[E] & FlatJSONRecord,
 ) {
   const fullMetadata = {
     ...rawMetadata,

--- a/src/state/queries/post.ts
+++ b/src/state/queries/post.ts
@@ -5,7 +5,7 @@ import {Shadow} from '#/state/cache/types'
 import {getAgent} from '#/state/session'
 import {updatePostShadow} from '#/state/cache/post-shadow'
 import {track} from '#/lib/analytics/analytics'
-import {logEvent} from '#/lib/statsig/statsig'
+import {logEvent, LogEvents} from '#/lib/statsig/statsig'
 import {useToggleMutationQueue} from '#/lib/hooks/useToggleMutationQueue'
 
 export const RQKEY = (postUri: string) => ['post', postUri]
@@ -59,7 +59,8 @@ export function useGetPost() {
 
 export function usePostLikeMutationQueue(
   post: Shadow<AppBskyFeedDefs.PostView>,
-  logContext: 'FeedItem' | 'PostThreadItem' | 'Post',
+  logContext: LogEvents['post:like']['logContext'] &
+    LogEvents['post:unlike']['logContext'],
 ) {
   const postUri = post.uri
   const postCid = post.cid
@@ -113,9 +114,7 @@ export function usePostLikeMutationQueue(
   return [queueLike, queueUnlike]
 }
 
-function usePostLikeMutation(
-  logContext: 'FeedItem' | 'PostThreadItem' | 'Post',
-) {
+function usePostLikeMutation(logContext: LogEvents['post:like']['logContext']) {
   return useMutation<
     {uri: string}, // responds with the uri of the like
     Error,
@@ -132,7 +131,7 @@ function usePostLikeMutation(
 }
 
 function usePostUnlikeMutation(
-  logContext: 'FeedItem' | 'PostThreadItem' | 'Post',
+  logContext: LogEvents['post:unlike']['logContext'],
 ) {
   return useMutation<void, Error, {postUri: string; likeUri: string}>({
     mutationFn: ({likeUri}) => {
@@ -147,7 +146,8 @@ function usePostUnlikeMutation(
 
 export function usePostRepostMutationQueue(
   post: Shadow<AppBskyFeedDefs.PostView>,
-  logContext: 'FeedItem' | 'PostThreadItem' | 'Post',
+  logContext: LogEvents['post:repost']['logContext'] &
+    LogEvents['post:unrepost']['logContext'],
 ) {
   const postUri = post.uri
   const postCid = post.cid
@@ -202,7 +202,7 @@ export function usePostRepostMutationQueue(
 }
 
 function usePostRepostMutation(
-  logContext: 'FeedItem' | 'PostThreadItem' | 'Post',
+  logContext: LogEvents['post:repost']['logContext'],
 ) {
   return useMutation<
     {uri: string}, // responds with the uri of the repost
@@ -220,7 +220,7 @@ function usePostRepostMutation(
 }
 
 function usePostUnrepostMutation(
-  logContext: 'FeedItem' | 'PostThreadItem' | 'Post',
+  logContext: LogEvents['post:unrepost']['logContext'],
 ) {
   return useMutation<void, Error, {postUri: string; repostUri: string}>({
     mutationFn: ({repostUri}) => {

--- a/src/state/queries/post.ts
+++ b/src/state/queries/post.ts
@@ -121,10 +121,12 @@ function usePostLikeMutation(
     Error,
     {uri: string; cid: string} // the post's uri and cid
   >({
-    mutationFn: post => getAgent().like(post.uri, post.cid),
+    mutationFn: post => {
+      logEvent('post:like', {logContext})
+      return getAgent().like(post.uri, post.cid)
+    },
     onSuccess() {
       track('Post:Like')
-      logEvent('post:like', {logContext})
     },
   })
 }
@@ -133,10 +135,12 @@ function usePostUnlikeMutation(
   logContext: 'FeedItem' | 'PostThreadItem' | 'Post',
 ) {
   return useMutation<void, Error, {postUri: string; likeUri: string}>({
-    mutationFn: ({likeUri}) => getAgent().deleteLike(likeUri),
+    mutationFn: ({likeUri}) => {
+      logEvent('post:unlike', {logContext})
+      return getAgent().deleteLike(likeUri)
+    },
     onSuccess() {
       track('Post:Unlike')
-      logEvent('post:unlike', {logContext})
     },
   })
 }

--- a/src/state/queries/profile.ts
+++ b/src/state/queries/profile.ts
@@ -26,7 +26,7 @@ import {RQKEY as RQKEY_MY_MUTED} from './my-muted-accounts'
 import {RQKEY as RQKEY_MY_BLOCKED} from './my-blocked-accounts'
 import {STALE} from '#/state/queries'
 import {track} from '#/lib/analytics/analytics'
-import {logEvent} from '#/lib/statsig/statsig'
+import {logEvent, LogEvents} from '#/lib/statsig/statsig'
 import {ThreadNode} from './post-thread'
 
 export const RQKEY = (did: string) => ['profile', did]
@@ -187,13 +187,8 @@ export function useProfileUpdateMutation() {
 
 export function useProfileFollowMutationQueue(
   profile: Shadow<AppBskyActorDefs.ProfileViewDetailed>,
-  logContext:
-    | 'RecommendedFollowsItem'
-    | 'PostThreadItem'
-    | 'ProfileCard'
-    | 'ProfileHeader'
-    | 'ProfileHeaderSuggestedFollows'
-    | 'ProfileMenu',
+  logContext: LogEvents['profile:follow']['logContext'] &
+    LogEvents['profile:unfollow']['logContext'],
 ) {
   const did = profile.did
   const initialFollowingUri = profile.viewer?.following
@@ -246,13 +241,7 @@ export function useProfileFollowMutationQueue(
 }
 
 function useProfileFollowMutation(
-  logContext:
-    | 'RecommendedFollowsItem'
-    | 'PostThreadItem'
-    | 'ProfileCard'
-    | 'ProfileHeader'
-    | 'ProfileHeaderSuggestedFollows'
-    | 'ProfileMenu',
+  logContext: LogEvents['profile:follow']['logContext'],
 ) {
   return useMutation<{uri: string; cid: string}, Error, {did: string}>({
     mutationFn: async ({did}) => {
@@ -266,13 +255,7 @@ function useProfileFollowMutation(
 }
 
 function useProfileUnfollowMutation(
-  logContext:
-    | 'RecommendedFollowsItem'
-    | 'PostThreadItem'
-    | 'ProfileCard'
-    | 'ProfileHeader'
-    | 'ProfileHeaderSuggestedFollows'
-    | 'ProfileMenu',
+  logContext: LogEvents['profile:unfollow']['logContext'],
 ) {
   return useMutation<void, Error, {did: string; followUri: string}>({
     mutationFn: async ({followUri}) => {

--- a/src/state/queries/profile.ts
+++ b/src/state/queries/profile.ts
@@ -26,6 +26,7 @@ import {RQKEY as RQKEY_MY_MUTED} from './my-muted-accounts'
 import {RQKEY as RQKEY_MY_BLOCKED} from './my-blocked-accounts'
 import {STALE} from '#/state/queries'
 import {track} from '#/lib/analytics/analytics'
+import {logEvent} from '#/lib/statsig/statsig'
 import {ThreadNode} from './post-thread'
 
 export const RQKEY = (did: string) => ['profile', did]
@@ -186,11 +187,18 @@ export function useProfileUpdateMutation() {
 
 export function useProfileFollowMutationQueue(
   profile: Shadow<AppBskyActorDefs.ProfileViewDetailed>,
+  logContext:
+    | 'RecommendedFollowsItem'
+    | 'PostThreadItem'
+    | 'ProfileCard'
+    | 'ProfileHeader'
+    | 'ProfileHeaderSuggestedFollows'
+    | 'ProfileMenu',
 ) {
   const did = profile.did
   const initialFollowingUri = profile.viewer?.following
-  const followMutation = useProfileFollowMutation()
-  const unfollowMutation = useProfileUnfollowMutation()
+  const followMutation = useProfileFollowMutation(logContext)
+  const unfollowMutation = useProfileUnfollowMutation(logContext)
 
   const queueToggle = useToggleMutationQueue({
     initialState: initialFollowingUri,
@@ -237,9 +245,18 @@ export function useProfileFollowMutationQueue(
   return [queueFollow, queueUnfollow]
 }
 
-function useProfileFollowMutation() {
+function useProfileFollowMutation(
+  logContext:
+    | 'RecommendedFollowsItem'
+    | 'PostThreadItem'
+    | 'ProfileCard'
+    | 'ProfileHeader'
+    | 'ProfileHeaderSuggestedFollows'
+    | 'ProfileMenu',
+) {
   return useMutation<{uri: string; cid: string}, Error, {did: string}>({
     mutationFn: async ({did}) => {
+      logEvent('profile:follow', {logContext})
       return await getAgent().follow(did)
     },
     onSuccess(data, variables) {
@@ -248,9 +265,18 @@ function useProfileFollowMutation() {
   })
 }
 
-function useProfileUnfollowMutation() {
+function useProfileUnfollowMutation(
+  logContext:
+    | 'RecommendedFollowsItem'
+    | 'PostThreadItem'
+    | 'ProfileCard'
+    | 'ProfileHeader'
+    | 'ProfileHeaderSuggestedFollows'
+    | 'ProfileMenu',
+) {
   return useMutation<void, Error, {did: string; followUri: string}>({
     mutationFn: async ({followUri}) => {
+      logEvent('profile:unfollow', {logContext})
       track('Profile:Unfollow', {username: followUri})
       return await getAgent().deleteFollow(followUri)
     },

--- a/src/view/com/auth/onboarding/RecommendedFollowsItem.tsx
+++ b/src/view/com/auth/onboarding/RecommendedFollowsItem.tsx
@@ -56,7 +56,7 @@ export function RecommendedFollowsItem({
   )
 }
 
-export function ProfileCard({
+function ProfileCard({
   profile,
   onFollowStateChange,
   moderation,
@@ -72,7 +72,10 @@ export function ProfileCard({
   const pal = usePalette('default')
   const [addingMoreSuggestions, setAddingMoreSuggestions] =
     React.useState(false)
-  const [queueFollow, queueUnfollow] = useProfileFollowMutationQueue(profile)
+  const [queueFollow, queueUnfollow] = useProfileFollowMutationQueue(
+    profile,
+    'RecommendedFollowsItem',
+  )
 
   const onToggleFollow = React.useCallback(async () => {
     try {

--- a/src/view/com/post-thread/PostThreadFollowBtn.tsx
+++ b/src/view/com/post-thread/PostThreadFollowBtn.tsx
@@ -42,7 +42,10 @@ function PostThreadFollowBtnLoaded({
   const {isTabletOrDesktop} = useWebMediaQueries()
   const profile: Shadow<AppBskyActorDefs.ProfileViewBasic> =
     useProfileShadow(profileUnshadowed)
-  const [queueFollow, queueUnfollow] = useProfileFollowMutationQueue(profile)
+  const [queueFollow, queueUnfollow] = useProfileFollowMutationQueue(
+    profile,
+    'PostThreadItem',
+  )
   const requireAuth = useRequireAuth()
 
   const isFollowing = !!profile.viewer?.following

--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -407,6 +407,7 @@ let PostThreadItemLoaded = ({
                 record={record}
                 richText={richText}
                 onPressReply={onPressReply}
+                logContext="PostThreadItem"
               />
             </View>
           </View>
@@ -560,6 +561,7 @@ let PostThreadItemLoaded = ({
                   record={record}
                   richText={richText}
                   onPressReply={onPressReply}
+                  logContext="PostThreadItem"
                 />
               </View>
             </View>

--- a/src/view/com/post/Post.tsx
+++ b/src/view/com/post/Post.tsx
@@ -220,6 +220,7 @@ function PostInner({
             record={record}
             richText={richText}
             onPressReply={onPressReply}
+            logContext="Post"
           />
         </View>
       </View>

--- a/src/view/com/posts/FeedItem.tsx
+++ b/src/view/com/posts/FeedItem.tsx
@@ -310,6 +310,7 @@ let FeedItemInner = ({
             showAppealLabelItem={
               post.author.did === currentAccount?.did && isModeratedPost
             }
+            logContext="FeedItem"
           />
         </View>
       </View>

--- a/src/view/com/profile/FollowButton.tsx
+++ b/src/view/com/profile/FollowButton.tsx
@@ -13,13 +13,18 @@ export function FollowButton({
   followedType = 'default',
   profile,
   labelStyle,
+  logContext,
 }: {
   unfollowedType?: ButtonType
   followedType?: ButtonType
   profile: Shadow<AppBskyActorDefs.ProfileViewBasic>
   labelStyle?: StyleProp<TextStyle>
+  logContext: 'ProfileCard'
 }) {
-  const [queueFollow, queueUnfollow] = useProfileFollowMutationQueue(profile)
+  const [queueFollow, queueUnfollow] = useProfileFollowMutationQueue(
+    profile,
+    logContext,
+  )
   const {_} = useLingui()
 
   const onPressFollow = async () => {

--- a/src/view/com/profile/ProfileCard.tsx
+++ b/src/view/com/profile/ProfileCard.tsx
@@ -230,7 +230,9 @@ export function ProfileCardWithFollowBtn({
       renderButton={
         isMe
           ? undefined
-          : profileShadow => <FollowButton profile={profileShadow} />
+          : profileShadow => (
+              <FollowButton profile={profileShadow} logContext="ProfileCard" />
+            )
       }
     />
   )

--- a/src/view/com/profile/ProfileHeader.tsx
+++ b/src/view/com/profile/ProfileHeader.tsx
@@ -103,7 +103,10 @@ let ProfileHeader = ({
   const invalidHandle = isInvalidHandle(profile.handle)
   const {isDesktop} = useWebMediaQueries()
   const [showSuggestedFollows, setShowSuggestedFollows] = React.useState(false)
-  const [queueFollow, queueUnfollow] = useProfileFollowMutationQueue(profile)
+  const [queueFollow, queueUnfollow] = useProfileFollowMutationQueue(
+    profile,
+    'ProfileHeader',
+  )
   const [__, queueUnblock] = useProfileBlockMutationQueue(profile)
   const unblockPromptControl = Prompt.usePromptControl()
   const moderation = useMemo(

--- a/src/view/com/profile/ProfileHeaderSuggestedFollows.tsx
+++ b/src/view/com/profile/ProfileHeaderSuggestedFollows.tsx
@@ -170,7 +170,10 @@ function SuggestedFollow({
   const pal = usePalette('default')
   const moderationOpts = useModerationOpts()
   const profile = useProfileShadow(profileUnshadowed)
-  const [queueFollow, queueUnfollow] = useProfileFollowMutationQueue(profile)
+  const [queueFollow, queueUnfollow] = useProfileFollowMutationQueue(
+    profile,
+    'ProfileHeaderSuggestedFollows',
+  )
 
   const onPressFollow = React.useCallback(async () => {
     try {

--- a/src/view/com/profile/ProfileMenu.tsx
+++ b/src/view/com/profile/ProfileMenu.tsx
@@ -52,7 +52,10 @@ let ProfileMenu = ({
 
   const [queueMute, queueUnmute] = useProfileMuteMutationQueue(profile)
   const [queueBlock, queueUnblock] = useProfileBlockMutationQueue(profile)
-  const [, queueUnfollow] = useProfileFollowMutationQueue(profile)
+  const [, queueUnfollow] = useProfileFollowMutationQueue(
+    profile,
+    'ProfileMenu',
+  )
 
   const blockPromptControl = Prompt.usePromptControl()
 

--- a/src/view/com/util/post-ctrls/PostCtrls.tsx
+++ b/src/view/com/util/post-ctrls/PostCtrls.tsx
@@ -60,7 +60,10 @@ let PostCtrls = ({
   const {openComposer} = useComposerControls()
   const {closeModal} = useModalControls()
   const [queueLike, queueUnlike] = usePostLikeMutationQueue(post, logContext)
-  const [queueRepost, queueUnrepost] = usePostRepostMutationQueue(post)
+  const [queueRepost, queueUnrepost] = usePostRepostMutationQueue(
+    post,
+    logContext,
+  )
   const requireAuth = useRequireAuth()
 
   const defaultCtrlColor = React.useMemo(

--- a/src/view/com/util/post-ctrls/PostCtrls.tsx
+++ b/src/view/com/util/post-ctrls/PostCtrls.tsx
@@ -44,6 +44,7 @@ let PostCtrls = ({
   showAppealLabelItem,
   style,
   onPressReply,
+  logContext,
 }: {
   big?: boolean
   post: Shadow<AppBskyFeedDefs.PostView>
@@ -52,12 +53,13 @@ let PostCtrls = ({
   showAppealLabelItem?: boolean
   style?: StyleProp<ViewStyle>
   onPressReply: () => void
+  logContext: 'FeedItem' | 'PostThreadItem' | 'Post'
 }): React.ReactNode => {
   const theme = useTheme()
   const {_} = useLingui()
   const {openComposer} = useComposerControls()
   const {closeModal} = useModalControls()
-  const [queueLike, queueUnlike] = usePostLikeMutationQueue(post)
+  const [queueLike, queueUnlike] = usePostLikeMutationQueue(post, logContext)
   const [queueRepost, queueUnrepost] = usePostRepostMutationQueue(post)
   const requireAuth = useRequireAuth()
 


### PR DESCRIPTION
## What

Adds `post:like` and `post:unlike` events, similar to our Segment setup. Using lowercase for the new ones to distinguish from existing Segment events, as I don't aim to port them 1:1.

I'm introducing the notion of "log context", in the sense of which-part-of-the-UI-the-action-originated-from. It will be a required parameter for most mutations. Open to other names but I want to keep it relatively short, have "log" in the name to discourage any other attempts to use this information, and something to imply it's contextual to the UI.

I'm using component names here. I didn't reify this in an explicit type which is maybe a bad idea but I want to see how far we can take it with just copy paste / find-and-replace. We don't change the fundamental product UI structure that much.

I decided against inferring this "log context" automatically (e.g. via React context) to prevent refactor hazards. E.g. you don't want a refactor that moves `useMutation` hook up the tree to start losing the log context. So it's threaded through at every level and you can see what it is.

I used component names for the values of log context but they could've been something more specific too. E.g. we could do something like `PostThreadItem[highlighted]`. Or some kind of breadcrumbs. I think this is an ok start. I don't know what will be useful.

I made log context required so that if you're adding a new call to the mutation, you're forced to figure out what it should be. I kept the existing decision to fire events in mutations because this ensures we wouldn't miss them.

I'm keeping the Segment events as is for now. The new stuff is additive.

## Test Plan

Like and unlike a post. Observe the events.

<img width="385" alt="Screenshot 2024-03-13 at 03 50 48" src="https://github.com/bluesky-social/social-app/assets/810438/560a729d-f3ec-4742-8011-70b9858069f5">
