### PR TITLE
add Toki Pona to list of possible content languages

### DIFF
--- a/src/locale/languages.ts
+++ b/src/locale/languages.ts
@@ -528,6 +528,7 @@ export const LANGUAGES: Language[] = [
   {code3: 'tli', code2: ' ', name: 'Tlingit'},
   {code3: 'tmh', code2: ' ', name: 'Tamashek'},
   {code3: 'tog', code2: ' ', name: 'Tonga (Nyasa)'},
+  {code3: 'tok', code2: ' ', name: 'Toki Pona'},
   {code3: 'ton', code2: 'to', name: 'Tonga (Tonga Islands)'},
   {code3: 'tpi', code2: ' ', name: 'Tok Pisin'},
   {code3: 'tsi', code2: ' ', name: 'Tsimshian'},


### PR DESCRIPTION
There is an active group of users using [Toki Pona](https://en.wikipedia.org/wiki/Toki_Pona) on Bluesky yet they can't set their posts' language accordingly because the choice is missing. [Here](https://bsky.app/profile/did:plc:ikyfyphgbzu45uvrb73a3mio/feed/jan-toki) is a feed that aggregates posts in Toki Pona. I am not affiliated with it nor do I know how it works.

I have read [in the AT protocol documentation](https://atproto.com/specs/lexicon#language) that  it uses [BCP-47](https://en.wikipedia.org/wiki/IETF_language_tag) to verify language codes. Toki Pona [has been in ISO-693 since Jan 20 2022](https://iso639-3.sil.org/code/tok) which is part of BCP-47 so there shouldn't be any compatibility issues.