### PR TITLE
add `Partial<GestureResponderEvent>` to `.open()` on dialog control

### DIFF
--- a/src/components/Dialog/types.ts
+++ b/src/components/Dialog/types.ts
@@ -1,5 +1,5 @@
 import React from 'react'
-import type {AccessibilityProps} from 'react-native'
+import type {AccessibilityProps, GestureResponderEvent} from 'react-native'
 import {BottomSheetProps} from '@gorhom/bottom-sheet'
 
 import {ViewStyleProp} from '#/alf'
@@ -10,9 +10,15 @@ type A11yProps = Required<AccessibilityProps>
  * Mutated by useImperativeHandle to provide a public API for controlling the
  * dialog. The methods here will actually become the handlers defined within
  * the `Dialog.Outer` component.
+ *
+ * `Partial<GestureResponderEvent>` here allows us to add this directly to the
+ * `onPress` prop of a button, for example. If this type was not added, we
+ * would need to create a function to wrap `.open()` with.
  */
 export type DialogControlRefProps = {
-  open: (options?: DialogControlOpenOptions) => void
+  open: (
+    options?: DialogControlOpenOptions & Partial<GestureResponderEvent>,
+  ) => void
   close: (callback?: () => void) => void
 }
 


### PR DESCRIPTION
In order to facilitate easy passing of `.open` to a `Pressable` or `TouchableX` `onPress` prop, adding the `GestureResponderEvent` type to the `options` parameter is necessary.

For example right now we have to do one of the following.

```tsx
const control = useDialogControl()

const onPressTwo = React.useMemo(() => {
	control.open()
}, [])

<Pressable onPress={() => control.open()}>
	<Text>Hello</Text>
</Pressable>

<Pressable onPress={onPressTwo}>
	<Text>Hello Again</Text>
</Pressable>
```

If we add `Partial<GestureResponderEvent>` to the `options` type, we can simply use a pressable like so

```tsx
const control = useDialogControl()

<Pressable onPress={control.open}>
	<Text>Yay</Text>
</Pressable>
```

Making this `Partial` allows us to still use `.open({index: 10})` for example if we wanted to without any of the `GestureResponderEvent`s required types.