### PR TITLE
prevent duplicate pickers from opening on android

### DIFF
--- a/patches/expo-image-picker+14.7.1.patch
+++ b/patches/expo-image-picker+14.7.1.patch
@@ -1,8 +1,56 @@
+diff --git a/node_modules/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.kt b/node_modules/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.kt
+index 3f50f8c..ee47fa1 100644
+--- a/node_modules/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.kt
++++ b/node_modules/expo-image-picker/android/src/main/java/expo/modules/imagepicker/ImagePickerModule.kt
+@@ -33,7 +33,9 @@ import kotlin.coroutines.resumeWithException
+ // TODO(@bbarthec): rename to ExpoImagePicker
+ private const val moduleName = "ExponentImagePicker"
+
++
+ class ImagePickerModule : Module() {
++  private var isPickerOpen = false
+
+   override fun definition() = ModuleDefinition {
+     Name(moduleName)
+@@ -129,6 +131,11 @@ class ImagePickerModule : Module() {
+     options: ImagePickerOptions
+   ): Any {
+     return try {
++      if(isPickerOpen) {
++        return ImagePickerResponse(canceled = true)
++      }
++
++      isPickerOpen = true
+       var result = launchPicker(pickerLauncher)
+       if (
+         !options.allowsMultipleSelection &&
+@@ -143,6 +150,8 @@ class ImagePickerModule : Module() {
+       mediaHandler.readExtras(result.data, options)
+     } catch (cause: OperationCanceledException) {
+       return ImagePickerResponse(canceled = true)
++    } finally {
++      isPickerOpen = false
+     }
+   }
+
 diff --git a/node_modules/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/ImageLibraryContract.kt b/node_modules/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/ImageLibraryContract.kt
-index ff15c91..41aaf12 100644
+index ff15c91..2bf86de 100644
 --- a/node_modules/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/ImageLibraryContract.kt
 +++ b/node_modules/expo-image-picker/android/src/main/java/expo/modules/imagepicker/contracts/ImageLibraryContract.kt
-@@ -26,51 +26,26 @@ import java.io.Serializable
+@@ -5,12 +5,7 @@ import android.content.ContentResolver
+ import android.content.Context
+ import android.content.Intent
+ import android.net.Uri
+-import androidx.activity.result.PickVisualMediaRequest
+-import androidx.activity.result.contract.ActivityResultContracts.PickVisualMedia
+-import androidx.activity.result.contract.ActivityResultContracts.PickMultipleVisualMedia
+ import expo.modules.imagepicker.ImagePickerOptions
+-import expo.modules.imagepicker.MediaTypes
+-import expo.modules.imagepicker.UNLIMITED_SELECTION
+ import expo.modules.imagepicker.getAllDataUris
+ import expo.modules.imagepicker.toMediaType
+ import expo.modules.kotlin.activityresult.AppContextActivityResultContract
+@@ -26,79 +21,59 @@ import java.io.Serializable
   * @see [androidx.activity.result.contract.ActivityResultContracts.GetMultipleContents]
   */
  internal class ImageLibraryContract(
@@ -12,7 +60,7 @@ index ff15c91..41aaf12 100644
    private val contentResolver: ContentResolver
      get() = appContextProvider.appContext.reactContext?.contentResolver
        ?: throw Exceptions.ReactContextLost()
- 
+
    override fun createIntent(context: Context, input: ImageLibraryContractOptions): Intent {
 -    val request = PickVisualMediaRequest.Builder()
 -      .setMediaType(
@@ -34,7 +82,7 @@ index ff15c91..41aaf12 100644
 +    val intent = Intent(Intent.ACTION_GET_CONTENT)
 +            .addCategory(Intent.CATEGORY_OPENABLE)
 +            .setType("image/*")
- 
+
      if (input.options.allowsMultipleSelection) {
 -      val selectionLimit = input.options.selectionLimit
 -
@@ -42,23 +90,66 @@ index ff15c91..41aaf12 100644
 -        // If multiple selection is allowed but the limit is 1, we should ignore
 -        // the multiple selection flag and just treat it as a single selection.
 -        return PickVisualMedia().createIntent(context, request)
+-      }
+-
+-      if (selectionLimit > 1) {
+-        return PickMultipleVisualMedia(selectionLimit).createIntent(context, request)
 +      if(input.options.selectionLimit == 1) {
 +        return intent
        }
- 
--      if (selectionLimit > 1) {
--        return PickMultipleVisualMedia(selectionLimit).createIntent(context, request)
--      }
--
+
 -      // If the selection limit is 0, it is the same as unlimited selection.
 -      if (selectionLimit == UNLIMITED_SELECTION) {
 -        return PickMultipleVisualMedia().createIntent(context, request)
 -      }
 +      intent.putExtra(Intent.EXTRA_ALLOW_MULTIPLE, true)
      }
- 
+
 -    return PickVisualMedia().createIntent(context, request)
 +    return intent
    }
- 
-   override fun parseResult(input: ImageLibraryContractOptions, resultCode: Int, intent: Intent?) =
+
+-  override fun parseResult(input: ImageLibraryContractOptions, resultCode: Int, intent: Intent?) =
++  override fun parseResult(input: ImageLibraryContractOptions, resultCode: Int, intent: Intent?): ImagePickerContractResult {
+     if (resultCode == Activity.RESULT_CANCELED) {
+-      ImagePickerContractResult.Cancelled
++      return ImagePickerContractResult.Cancelled
+     } else {
+       intent?.takeIf { resultCode == Activity.RESULT_OK }?.getAllDataUris()?.let { uris ->
+         if (input.options.allowsMultipleSelection) {
+-          ImagePickerContractResult.Success(
+-            uris.map { uri ->
+-              uri.toMediaType(contentResolver) to uri
+-            }
++          return ImagePickerContractResult.Success(
++                  uris.map { uri ->
++                    uri.toMediaType(contentResolver) to uri
++                  }
+           )
+         } else {
+           if (intent.data != null) {
+             intent.data?.let { uri ->
+               val type = uri.toMediaType(contentResolver)
+-              ImagePickerContractResult.Success(listOf(type to uri))
++              return ImagePickerContractResult.Success(listOf(type to uri))
+             }
+           } else {
+             uris.firstOrNull()?.let { uri ->
+               val type = uri.toMediaType(contentResolver)
+-              ImagePickerContractResult.Success(listOf(type to uri))
+-            } ?: ImagePickerContractResult.Error
++              return ImagePickerContractResult.Success(listOf(type to uri))
++            }
++
++            return ImagePickerContractResult.Error
+           }
+         }
+-      } ?: ImagePickerContractResult.Error
++      }
++
++      return ImagePickerContractResult.Error
+     }
++  }
+ }
+
+ internal data class ImageLibraryContractOptions(


### PR DESCRIPTION
Fixes https://github.com/bluesky-social/social-app/issues/3236

## Why

On Android, the image picker can accidentally be opened twice by the user. This doesn't happen often, but when it does it causes a native crash. We should keep track of whether the picker is open or not before launching the picker again.

I opted to keep track of this on the native side, since if we kept track of it on the JS side we could still potentially run into async issues.

## Test Plan

Use a current build and open the picker twice by quickly pressing the image library button in the post composer. Observe that you have to close it twice, and on the second close it crashes.

Use this build and attempt to open the picker twice again, but observe it only opens once.