### PR TITLE
Improve session race condition resulting in broken states

### DIFF
--- a/src/lib/hooks/useAccountSwitcher.ts
+++ b/src/lib/hooks/useAccountSwitcher.ts
@@ -1,6 +1,5 @@
 import {useCallback} from 'react'
 
-import {isWeb} from '#/platform/detection'
 import {useAnalytics} from '#/lib/analytics/analytics'
 import {useSessionApi, SessionAccount} from '#/state/session'
 import * as Toast from '#/view/com/util/Toast'
@@ -24,14 +23,6 @@ export function useAccountSwitcher() {
       try {
         if (account.accessJwt) {
           closeAllActiveElements()
-          if (isWeb) {
-            // We're switching accounts, which remounts the entire app.
-            // On mobile, this gets us Home, but on the web we also need reset the URL.
-            // We can't change the URL via a navigate() call because the navigator
-            // itself is about to unmount, and it calls pushState() too late.
-            // So we change the URL ourselves. The navigator will pick it up on remount.
-            history.pushState(null, '', '/')
-          }
           await selectAccount(account, logContext)
           setTimeout(() => {
             Toast.show(`Signed in as @${account.handle}`)

--- a/src/lib/hooks/useAccountSwitcher.ts
+++ b/src/lib/hooks/useAccountSwitcher.ts
@@ -1,10 +1,11 @@
 import {useCallback} from 'react'
 
 import {useAnalytics} from '#/lib/analytics/analytics'
-import {useSessionApi, SessionAccount} from '#/state/session'
-import * as Toast from '#/view/com/util/Toast'
-import {useCloseAllActiveElements} from '#/state/util'
+import {isWeb} from '#/platform/detection'
+import {SessionAccount, useSessionApi} from '#/state/session'
 import {useLoggedOutViewControls} from '#/state/shell/logged-out'
+import {useCloseAllActiveElements} from '#/state/util'
+import * as Toast from '#/view/com/util/Toast'
 import {LogEvents} from '../statsig/statsig'
 
 export function useAccountSwitcher() {
@@ -23,6 +24,14 @@ export function useAccountSwitcher() {
       try {
         if (account.accessJwt) {
           closeAllActiveElements()
+          if (isWeb) {
+            // We're switching accounts, which remounts the entire app.
+            // On mobile, this gets us Home, but on the web we also need reset the URL.
+            // We can't change the URL via a navigate() call because the navigator
+            // itself is about to unmount, and it calls pushState() too late.
+            // So we change the URL ourselves. The navigator will pick it up on remount.
+            history.pushState(null, '', '/')
+          }
           await selectAccount(account, logContext)
           setTimeout(() => {
             Toast.show(`Signed in as @${account.handle}`)

--- a/src/state/session/index.tsx
+++ b/src/state/session/index.tsx
@@ -211,7 +211,7 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
   const clearCurrentAccount = React.useCallback(() => {
     logger.warn(`session: clear current account`)
     __globalAgent = PUBLIC_BSKY_AGENT
-    queryClient.clear()
+    queryClient.resetQueries()
     setStateAndPersist(s => ({
       ...s,
       currentAccount: undefined,
@@ -286,7 +286,7 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
       )
 
       __globalAgent = agent
-      queryClient.clear()
+      queryClient.resetQueries()
       upsertAccount(account)
 
       logger.debug(`session: created account`, {}, logger.DebugContext.session)
@@ -334,7 +334,7 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
       __globalAgent = agent
       // @ts-ignore
       if (IS_DEV && isWeb) window.agent = agent
-      queryClient.clear()
+      queryClient.resetQueries()
       upsertAccount(account)
 
       logger.debug(`session: logged in`, {}, logger.DebugContext.session)
@@ -415,7 +415,7 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
          */
         agent.session = prevSession
         __globalAgent = agent
-        queryClient.clear()
+        queryClient.resetQueries()
         upsertAccount(account)
 
         if (prevSession.deactivated) {
@@ -436,7 +436,7 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
           })
 
           __globalAgent = PUBLIC_BSKY_AGENT
-          queryClient.clear()
+          queryClient.resetQueries()
         })
       } else {
         logger.debug(`session: attempting to resume using previous session`)
@@ -457,7 +457,7 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
 
           __globalAgent = PUBLIC_BSKY_AGENT
         } finally {
-          queryClient.clear()
+          queryClient.resetQueries()
         }
       }
 
@@ -558,14 +558,6 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
       setState(s => ({...s, isSwitchingAccounts: true}))
       try {
         await initSession(account)
-        if (isWeb) {
-          // We're switching accounts, which remounts the entire app.
-          // On mobile, this gets us Home, but on the web we also need reset the URL.
-          // We can't change the URL via a navigate() call because the navigator
-          // itself is about to unmount, and it calls pushState() too late.
-          // So we change the URL ourselves. The navigator will pick it up on remount.
-          history.pushState(null, '', '/')
-        }
         setState(s => ({...s, isSwitchingAccounts: false}))
         logEvent('account:loggedIn', {logContext, withPassword: false})
       } catch (e) {


### PR DESCRIPTION
Tl;dr this PR reduces re-renders during switching accounts /slash session resumptions, and swaps `queryClient.clear()` for `queryClient.resetQueries` to ensure we both clear the cache AND refetch active queries.

**More details:**

I think I narrowed this down to queries not refetching when the user changed. Previously we were clearing cache, but clearing cache doesn't necessarily cause a refetch to happen, it just ensures that the next refetch doesn't have a cache to pull from.

I had [started down the path](https://github.com/bluesky-social/social-app/pull/3321) of swapping out the query client entirely, but found [this issue](https://github.com/TanStack/query/issues/5458) that recommended `resetQueries`. [This method](https://tanstack.com/query/latest/docs/reference/QueryClient#queryclientresetqueries) resets cache AND triggers a refetch.

This PR contains the minimum changes needed to prevent my reproduction test case, which I _think_ mimics what's happening in production.

Note on the `history` change I had made previously: I noticed a couple times where the user wasn't kicked out to Home on web, but couldn't repro with the `history` push where it was before. So I moved that back. Originally I had moved it because it was causing a flash of Home screen while the session resumed, but now with fewer re-renders, it seems this may be fixed.

I feel this still is a "hold it just right" type of fix, and more work is probably needed here to bullet proof this. But I think it's more solid with this than it has been recently.

<details>
<summary><strong>Previous write up and findings</strong> </summary>

When switching between accounts, user's have reported that they lose their pinned feeds or they see the feeds of their other account.

I narrowed this down to being caused by switching to an account whose `accessJwt` was expired, which requires us to make a round trip to the server prior to updating the global agent with these new credentials. It's not a problem for accounts whose tokens are fresh, since that fork in logic is synchronous.

The best way to reproduce this is to drop the `accessJwt` [ttl to like 15s](https://github.com/bluesky-social/atproto/blob/main/packages/pds/src/account-manager/helpers/auth.ts#L45) and switch back and forth.

Series of events to illustrate:
- user logs in as Bob, uses app
- user switches to Alice, uses app for some time
- user switches back to Bob
- Bob's `accessJwt` is expired (`accessJwt` ttl is 2 hours)
- we reach out to server to refresh the session, and during this async request:
  - app rendering causes another preferences fetch, which uses OLD global agent, fetching Alice's preferences
  - Bob's session resolves, we update global agent
  - app renders, uses Alice's cached preferences

This PR is really only a potential bandaid on the problem, and just tries to ensure that the QueryClient cache is cleared at the correct moment so that subsequent fetches use the update global agent.

Seems to do the trick, but it's a little hard to say, since I'm not sure why this started happening recently. I'd hazard a guess that it's been happening for a while, and something just exacerbated the issue.

I think the ideal solve would be to scope all query calls to the user using `currentAccount.did` on the session context. That way, we can control exactly when we're ready for a render to start for a fresh account.


Other things
- Our post caching assumes a single user, so even if we scoped a query to a DID, shadows and cache-between-navigations would bleed between users bc we look up by URI only (doesn't account for `viewer` state)

</details>