### PR TITLE
Fix overflow of PWI opt out label

### DIFF
--- a/src/screens/Moderation/index.tsx
+++ b/src/screens/Moderation/index.tsx
@@ -378,7 +378,9 @@ export function ModerationScreenInner({
       </Text>
 
       {isLabelersLoading ? (
-        <Loader />
+        <View style={[a.w_full, a.align_center, a.p_lg]}>
+          <Loader size="xl" />
+        </View>
       ) : labelersError || !labelers ? (
         <View style={[a.p_lg, a.rounded_sm, t.atoms.bg_contrast_25]}>
           <Text>
@@ -513,11 +515,12 @@ function PwiOptOut() {
           value={isOptedOut}
           onChange={onToggleOptOut}
           name="logged_out_visibility"
+          style={a.flex_1}
           label={_(
             msg`Discourage apps from showing my account to logged-out users`,
           )}>
           <Toggle.Switch />
-          <Toggle.Label style={[a.text_md]}>
+          <Toggle.Label style={[a.text_md, a.flex_1]}>
             <Trans>
               Discourage apps from showing my account to logged-out users
             </Trans>


### PR DESCRIPTION
Also, fixed the loading spinner not being centred.

Before:

<img width="429" alt="Screenshot 2024-03-19 at 15 57 23" src="https://github.com/bluesky-social/social-app/assets/10959775/cf2770dc-1471-4440-a831-f341cc7f631b">

![Screenshot 2024-03-19 at 15 57 10](https://github.com/bluesky-social/social-app/assets/10959775/dfe405af-716b-43b1-94a4-2a81c04d44db)

After:

<img width="430" alt="Screenshot 2024-03-19 at 15 56 35" src="https://github.com/bluesky-social/social-app/assets/10959775/186df6c2-2f09-43f5-9215-a4c6fe9bcba5">

![Screenshot 2024-03-19 at 15 55 46](https://github.com/bluesky-social/social-app/assets/10959775/ecb1cc09-88f2-430c-b432-cf28adab3d3b)
