### PR TITLE
Fix detection of !no-unauthenticated

### DIFF
--- a/src/components/moderation/ScreenHider.tsx
+++ b/src/components/moderation/ScreenHider.tsx
@@ -56,7 +56,8 @@ export function ScreenHider({
 
   const isNoPwi = !!modui.blurs.find(
     cause =>
-      cause.type === 'label' && cause.labelDef.id === '!no-unauthenticated',
+      cause.type === 'label' &&
+      cause.labelDef.identifier === '!no-unauthenticated',
   )
   return (
     <CenteredView

--- a/src/view/com/post-thread/PostThread.tsx
+++ b/src/view/com/post-thread/PostThread.tsx
@@ -108,7 +108,8 @@ export function PostThread({
       ?.ui('contentList')
       .blurs.find(
         cause =>
-          cause.type === 'label' && cause.labelDef.id === '!no-unauthenticated',
+          cause.type === 'label' &&
+          cause.labelDef.identifier === '!no-unauthenticated',
       )
   }, [rootPost, moderationOpts])
 


### PR DESCRIPTION
Was causing us to show a content warning screen rather than this:

![CleanShot 2024-03-19 at 14 40 05@2x](https://github.com/bluesky-social/social-app/assets/1270099/a0c6550e-f508-4e8d-87e1-234ea3d40798)
