### PR TITLE
use different labels for `porn` and `sexual`

### DIFF
--- a/src/lib/moderation/useModerationCauseDescription.ts
+++ b/src/lib/moderation/useModerationCauseDescription.ts
@@ -123,10 +123,10 @@ export function useModerationCauseDescription(
           source = cause.label.src
         }
       }
-
       if (def.identifier === 'porn' || def.identifier === 'sexual') {
         strings.name = 'Adult Content'
       }
+
       return {
         icon:
           def.identifier === '!no-unauthenticated'

--- a/src/lib/moderation/useModerationCauseDescription.ts
+++ b/src/lib/moderation/useModerationCauseDescription.ts
@@ -118,10 +118,14 @@ export function useModerationCauseDescription(
         (labeler?.creator.handle ? '@' + labeler?.creator.handle : undefined)
       if (!source) {
         if (cause.label.src === BSKY_LABELER_DID) {
-          source = 'Bluesky Moderation'
+          source = 'Bluesky Moderation Service'
         } else {
           source = cause.label.src
         }
+      }
+
+      if (def.identifier === 'porn' || def.identifier === 'sexual') {
+        strings.name = 'Adult Content'
       }
       return {
         icon:

--- a/src/view/com/posts/FeedErrorMessage.tsx
+++ b/src/view/com/posts/FeedErrorMessage.tsx
@@ -46,7 +46,7 @@ export function FeedErrorMessage({
   if (
     typeof knownError !== 'undefined' &&
     knownError !== KnownError.Unknown &&
-    feedDesc.startsWith('feedgen')
+    (feedDesc.startsWith('feedgen') || knownError === KnownError.FeedNSFPublic)
   ) {
     return (
       <FeedgenErrorMessage
@@ -240,6 +240,9 @@ function detectKnownError(
   if (typeof error !== 'string') {
     error = error.toString()
   }
+  if (error.includes(KnownError.FeedNSFPublic)) {
+    return KnownError.FeedNSFPublic
+  }
   if (!feedDesc.startsWith('feedgen')) {
     return KnownError.Unknown
   }
@@ -262,9 +265,6 @@ function detectKnownError(
   }
   if (error.includes('feed provided an invalid response')) {
     return KnownError.FeedgenBadResponse
-  }
-  if (error.includes(KnownError.FeedNSFPublic)) {
-    return KnownError.FeedNSFPublic
   }
   return KnownError.FeedgenUnknown
 }


### PR DESCRIPTION
Also fixes a generic error message `FeedNSFPublic` on profiles.