### PR TITLE
[Not for merge] [Statsig] Proxy events

### DIFF
--- a/src/lib/statsig/statsig.tsx
+++ b/src/lib/statsig/statsig.tsx
@@ -15,6 +15,7 @@ import {LogEvents} from './events'
 export type {LogEvents}
 
 const statsigOptions = {
+  eventLoggingApi: 'https://api.events.bsky.app/v2',
   environment: {
     tier: process.env.NODE_ENV === 'development' ? 'development' : 'production',
   },


### PR DESCRIPTION
Sends events through a server proxy so we can apply downsampling if needed.

The endpoint is not implemented.