### PR TITLE
Fix magnify icon

### DIFF
--- a/src/lib/icons.tsx
+++ b/src/lib/icons.tsx
@@ -141,8 +141,8 @@ export function MagnifyingGlassIcon2({
       width={size || 24}
       height={size || 24}
       style={style}>
-      <Ellipse cx="12" cy="11" rx="9" ry="9" />
-      <Line x1="19" y1="17.3" x2="23.5" y2="21" strokeLinecap="round" />
+      <Ellipse cx="12" cy="10.5" rx="8.5" ry="8.5" />
+      <Line x1="18" y1="16.5" x2="22" y2="20.5" strokeLinecap="round" />
     </Svg>
   )
 }
@@ -167,14 +167,14 @@ export function MagnifyingGlassIcon2Solid({
       style={style}>
       <Ellipse
         cx="12"
-        cy="11"
-        rx="7"
-        ry="7"
+        cy="10.5"
+        rx="6.5"
+        ry="6.5"
         stroke="none"
         fill="currentColor"
       />
-      <Ellipse cx="12" cy="11" rx="9" ry="9" />
-      <Line x1="19" y1="17.3" x2="23.5" y2="21" strokeLinecap="round" />
+      <Ellipse cx="12" cy="10.5" rx="8.5" ry="8.5" />
+      <Line x1="18" y1="16.5" x2="22" y2="20.5" strokeLinecap="round" />
     </Svg>
   )
 }

--- a/src/lib/icons.tsx
+++ b/src/lib/icons.tsx
@@ -141,8 +141,8 @@ export function MagnifyingGlassIcon2({
       width={size || 24}
       height={size || 24}
       style={style}>
-      <Ellipse cx="12" cy="10.5" rx="8.5" ry="8.5" />
-      <Line x1="18" y1="16.5" x2="22" y2="20.5" strokeLinecap="round" />
+      <Ellipse cx="12" cy="10.5" rx="9" ry="9" />
+      <Line x1="18.5" y1="17" x2="22" y2="20.5" strokeLinecap="round" />
     </Svg>
   )
 }
@@ -173,8 +173,8 @@ export function MagnifyingGlassIcon2Solid({
         stroke="none"
         fill="currentColor"
       />
-      <Ellipse cx="12" cy="10.5" rx="8.5" ry="8.5" />
-      <Line x1="18" y1="16.5" x2="22" y2="20.5" strokeLinecap="round" />
+      <Ellipse cx="12" cy="10.5" rx="9" ry="9" />
+      <Line x1="18.5" y1="17" x2="22" y2="20.5" strokeLinecap="round" />
     </Svg>
   )
 }


### PR DESCRIPTION
Fixes the icons `MagnifyingGlassIcon2` and `MagnifyingGlassIcon2Solid`. Closes #2893.

| Before | After |
|--------|-------|
| <img width="155" alt="스크린샷 2024-03-20 22 17 38" src="https://github.com/bluesky-social/social-app/assets/11014257/94b9b833-9334-4895-9546-417655f78c2f"> | <img width="155" alt="스크린샷 2024-03-20 22 24 55" src="https://github.com/bluesky-social/social-app/assets/11014257/f6205003-960a-457a-9877-67f93ce879f9"> |
| <img width="247" alt="스크린샷 2024-03-20 22 29 08" src="https://github.com/bluesky-social/social-app/assets/11014257/df60056e-7540-44f5-92f8-2ed7de97c506"> | <img width="247" alt="스크린샷 2024-03-20 22 26 43" src="https://github.com/bluesky-social/social-app/assets/11014257/f01dbe40-bdd5-4943-b434-40bdb00f5a64"> |