### PR TITLE
Use ALF for Splashscreen

### DIFF
--- a/src/view/com/auth/SplashScreen.tsx
+++ b/src/view/com/auth/SplashScreen.tsx
@@ -1,23 +1,21 @@
 import React from 'react'
-import {StyleSheet, TouchableOpacity, View} from 'react-native'
+import {View} from 'react-native'
 import {useSafeAreaInsets} from 'react-native-safe-area-context'
-import {Text} from 'view/com/util/text/Text'
+
 import {ErrorBoundary} from 'view/com/util/ErrorBoundary'
-import {s, colors} from 'lib/styles'
-import {usePalette} from 'lib/hooks/usePalette'
 import {CenteredView} from '../util/Views'
 import {Trans, msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 import {Logo} from '#/view/icons/Logo'
 import {Logotype} from '#/view/icons/Logotype'
-import {
-  FontAwesomeIcon,
-  FontAwesomeIconStyle,
-} from '@fortawesome/react-native-fontawesome'
 import RNPickerSelect, {PickerSelectProps} from 'react-native-picker-select'
 import {sanitizeAppLanguageSetting} from '#/locale/helpers'
 import {useLanguagePrefs, useLanguagePrefsApi} from '#/state/preferences'
 import {APP_LANGUAGES} from '#/locale/languages'
+import {atoms as a, useTheme} from '#/alf'
+import {Text} from '#/components/Typography'
+import {Button, ButtonText} from '#/components/Button'
+import {ChevronBottom_Stroke2_Corner0_Rounded as ChevronDown} from '#/components/icons/Chevron'
 
 export const SplashScreen = ({
   onPressSignin,
@@ -26,7 +24,7 @@ export const SplashScreen = ({
   onPressSignin: () => void
   onPressCreateAccount: () => void
 }) => {
-  const pal = usePalette('default')
+  const t = useTheme()
   const {_} = useLingui()
 
   const langPrefs = useLanguagePrefs()
@@ -46,49 +44,62 @@ export const SplashScreen = ({
   )
 
   return (
-    <CenteredView style={[styles.container, pal.view]}>
+    <CenteredView style={[a.h_full, a.flex_1]}>
       <ErrorBoundary>
-        <View style={styles.hero}>
+        <View style={[{flex: 1}, a.justify_center, a.align_center]}>
           <Logo width={92} fill="sky" />
 
-          <View style={{paddingTop: 40, paddingBottom: 6}}>
-            <Logotype width={161} fill={pal.text.color} />
+          <View style={[a.pb_sm, a.pt_5xl]}>
+            <Logotype width={161} fill={t.atoms.text.color} />
           </View>
 
-          <Text type="lg-medium" style={[pal.textLight]}>
+          <Text
+            style={[a.text_md, a.font_semibold, t.atoms.text_contrast_medium]}>
             <Trans>What's up?</Trans>
           </Text>
         </View>
-        <View testID="signinOrCreateAccount" style={styles.btns}>
-          <TouchableOpacity
+        <View testID="signinOrCreateAccount">
+          <Button
             testID="createAccountButton"
-            style={[styles.btn, {backgroundColor: colors.blue3}]}
             onPress={onPressCreateAccount}
             accessibilityRole="button"
-            accessibilityLabel={_(msg`Create new account`)}
+            label={_(msg`Create new account`)}
             accessibilityHint={_(
               msg`Opens flow to create a new Bluesky account`,
-            )}>
-            <Text style={[s.white, styles.btnLabel]}>
+            )}
+            style={[a.mx_xl, a.mb_xl]}
+            size="large"
+            variant="solid"
+            color="primary">
+            <ButtonText>
               <Trans>Create a new account</Trans>
-            </Text>
-          </TouchableOpacity>
-          <TouchableOpacity
+            </ButtonText>
+          </Button>
+          <Button
             testID="signInButton"
-            style={[styles.btn, pal.btn]}
             onPress={onPressSignin}
-            accessibilityRole="button"
-            accessibilityLabel={_(msg`Sign in`)}
+            label={_(msg`Sign in`)}
             accessibilityHint={_(
               msg`Opens flow to sign into your existing Bluesky account`,
-            )}>
-            <Text style={[pal.text, styles.btnLabel]}>
+            )}
+            style={[a.mx_xl, a.mb_xl]}
+            size="large"
+            variant="solid"
+            color="secondary">
+            <ButtonText>
               <Trans>Sign In</Trans>
-            </Text>
-          </TouchableOpacity>
+            </ButtonText>
+          </Button>
         </View>
-        <View style={styles.footer}>
-          <View style={{position: 'relative'}}>
+        <View
+          style={[
+            a.px_lg,
+            a.pt_md,
+            a.pb_2xl,
+            a.justify_center,
+            a.align_center,
+          ]}>
+          <View style={a.relative}>
             <RNPickerSelect
               placeholder={{}}
               value={sanitizedLang}
@@ -101,33 +112,28 @@ export const SplashScreen = ({
               useNativeAndroidPickerStyle={false}
               style={{
                 inputAndroid: {
-                  color: pal.textLight.color,
+                  color: t.atoms.text_contrast_medium.color,
                   fontSize: 16,
-                  paddingRight: 10 + 4,
+                  paddingRight: 12 + 4,
                 },
                 inputIOS: {
-                  color: pal.text.color,
+                  color: t.atoms.text.color,
                   fontSize: 16,
-                  paddingRight: 10 + 4,
+                  paddingRight: 12 + 4,
                 },
               }}
             />
 
             <View
-              style={{
-                position: 'absolute',
-                top: 0,
-                right: 0,
-                bottom: 0,
-                pointerEvents: 'none',
-                alignItems: 'center',
-                justifyContent: 'center',
-              }}>
-              <FontAwesomeIcon
-                icon="chevron-down"
-                size={10}
-                style={pal.textLight as FontAwesomeIconStyle}
-              />
+              style={[
+                a.absolute,
+                a.inset_0,
+                {left: 'auto'},
+                {pointerEvents: 'none'},
+                a.align_center,
+                a.justify_center,
+              ]}>
+              <ChevronDown fill={t.atoms.text.color} size="xs" />
             </View>
           </View>
         </View>
@@ -136,44 +142,3 @@ export const SplashScreen = ({
     </CenteredView>
   )
 }
-
-const styles = StyleSheet.create({
-  container: {
-    height: '100%',
-  },
-  hero: {
-    flex: 2,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  btns: {
-    paddingBottom: 0,
-  },
-  title: {
-    textAlign: 'center',
-    fontSize: 68,
-    fontWeight: 'bold',
-  },
-  subtitle: {
-    textAlign: 'center',
-    fontSize: 42,
-    fontWeight: 'bold',
-  },
-  btn: {
-    borderRadius: 32,
-    paddingVertical: 16,
-    marginBottom: 20,
-    marginHorizontal: 20,
-  },
-  btnLabel: {
-    textAlign: 'center',
-    fontSize: 21,
-  },
-  footer: {
-    paddingHorizontal: 16,
-    paddingTop: 12,
-    paddingBottom: 24,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-})

--- a/src/view/com/auth/SplashScreen.web.tsx
+++ b/src/view/com/auth/SplashScreen.web.tsx
@@ -1,13 +1,9 @@
 import React from 'react'
-import {StyleSheet, TouchableOpacity, View, Pressable} from 'react-native'
+import {View, Pressable} from 'react-native'
 import {FontAwesomeIcon} from '@fortawesome/react-native-fontawesome'
-import {Text} from 'view/com/util/text/Text'
 import {TextLink} from '../util/Link'
 import {ErrorBoundary} from 'view/com/util/ErrorBoundary'
-import {s, colors} from 'lib/styles'
-import {usePalette} from 'lib/hooks/usePalette'
 import {CenteredView} from '../util/Views'
-import {isWeb} from 'platform/detection'
 import {useWebMediaQueries} from 'lib/hooks/useWebMediaQueries'
 import {Trans, msg} from '@lingui/macro'
 import {Logo} from '#/view/icons/Logo'
@@ -16,6 +12,10 @@ import {useLingui} from '@lingui/react'
 import {sanitizeAppLanguageSetting} from '#/locale/helpers'
 import {useLanguagePrefs, useLanguagePrefsApi} from '#/state/preferences'
 import {APP_LANGUAGES} from '#/locale/languages'
+import {atoms as a, useTheme} from '#/alf'
+import {Button, ButtonText} from '#/components/Button'
+import {ChevronBottom_Stroke2_Corner0_Rounded as ChevronDown} from '#/components/icons/Chevron'
+import {Text} from '#/components/Typography'
 
 export const SplashScreen = ({
   onDismiss,
@@ -26,10 +26,9 @@ export const SplashScreen = ({
   onPressSignin: () => void
   onPressCreateAccount: () => void
 }) => {
-  const pal = usePalette('default')
-  const {isTabletOrMobile} = useWebMediaQueries()
-  const styles = useStyles()
-  const isMobileWeb = isWeb && isTabletOrMobile
+  const {_} = useLingui()
+  const t = useTheme()
+  const {isTabletOrMobile: isMobileWeb} = useWebMediaQueries()
 
   return (
     <>
@@ -48,61 +47,89 @@ export const SplashScreen = ({
             icon="x"
             size={24}
             style={{
-              color: String(pal.text.color),
+              color: String(t.atoms.text.color),
             }}
           />
         </Pressable>
       )}
 
-      <CenteredView style={[styles.container, pal.view]}>
+      <CenteredView style={[a.h_full, a.flex_1]}>
         <View
           testID="noSessionView"
           style={[
-            styles.containerInner,
-            isMobileWeb && styles.containerInnerMobile,
-            pal.border,
-            {alignItems: 'center'},
+            a.h_full,
+            a.justify_center,
+            // @ts-ignore web only
+            {paddingBottom: '20vh'},
+            isMobileWeb && a.pb_5xl,
+            t.atoms.border_contrast_medium,
+            a.align_center,
+            a.gap_5xl,
           ]}>
           <ErrorBoundary>
-            <Logo width={92} fill="sky" />
+            <View style={[a.justify_center, a.align_center]}>
+              <Logo width={92} fill="sky" />
 
-            <View style={{paddingTop: 40, paddingBottom: 20}}>
-              <Logotype width={161} fill={pal.text.color} />
+              <View style={[a.pb_sm, a.pt_5xl]}>
+                <Logotype width={161} fill={t.atoms.text.color} />
+              </View>
+
+              <Text
+                style={[
+                  a.text_md,
+                  a.font_semibold,
+                  t.atoms.text_contrast_medium,
+                ]}>
+                <Trans>What's up?</Trans>
+              </Text>
             </View>
 
-            <View testID="signinOrCreateAccount" style={styles.btns}>
-              <TouchableOpacity
+            <View
+              testID="signinOrCreateAccount"
+              style={[a.w_full, {maxWidth: 320}]}>
+              <Button
                 testID="createAccountButton"
-                style={[styles.btn, {backgroundColor: colors.blue3}]}
                 onPress={onPressCreateAccount}
-                // TODO: web accessibility
-                accessibilityRole="button">
-                <Text style={[s.white, styles.btnLabel]}>
+                accessibilityRole="button"
+                label={_(msg`Create new account`)}
+                accessibilityHint={_(
+                  msg`Opens flow to create a new Bluesky account`,
+                )}
+                style={[a.mx_xl, a.mb_xl]}
+                size="large"
+                variant="solid"
+                color="primary">
+                <ButtonText>
                   <Trans>Create a new account</Trans>
-                </Text>
-              </TouchableOpacity>
-              <TouchableOpacity
+                </ButtonText>
+              </Button>
+              <Button
                 testID="signInButton"
-                style={[styles.btn, pal.btn]}
                 onPress={onPressSignin}
-                // TODO: web accessibility
-                accessibilityRole="button">
-                <Text style={[pal.text, styles.btnLabel]}>
+                label={_(msg`Sign in`)}
+                accessibilityHint={_(
+                  msg`Opens flow to sign into your existing Bluesky account`,
+                )}
+                style={[a.mx_xl, a.mb_xl]}
+                size="large"
+                variant="solid"
+                color="secondary">
+                <ButtonText>
                   <Trans>Sign In</Trans>
-                </Text>
-              </TouchableOpacity>
+                </ButtonText>
+              </Button>
             </View>
           </ErrorBoundary>
         </View>
-        <Footer styles={styles} />
+        <Footer />
       </CenteredView>
     </>
   )
 }
 
-function Footer({styles}: {styles: ReturnType<typeof useStyles>}) {
-  const pal = usePalette('default')
+function Footer() {
   const {_} = useLingui()
+  const t = useTheme()
 
   const langPrefs = useLanguagePrefs()
   const setLangPrefs = useLanguagePrefsApi()
@@ -122,39 +149,45 @@ function Footer({styles}: {styles: ReturnType<typeof useStyles>}) {
   )
 
   return (
-    <View style={[styles.footer, pal.view, pal.border]}>
+    <View
+      style={[
+        a.absolute,
+        a.inset_0,
+        {top: 'auto'},
+        a.p_xl,
+        a.border_t,
+        a.flex_row,
+        a.flex_wrap,
+        a.gap_xl,
+        a.flex_1,
+        t.atoms.border_contrast_medium,
+      ]}>
       <TextLink
         href="https://bsky.social"
         text={_(msg`Business`)}
-        style={[styles.footerLink, pal.link]}
+        style={{color: t.palette.primary_500}}
       />
       <TextLink
         href="https://bsky.social/about/blog"
         text={_(msg`Blog`)}
-        style={[styles.footerLink, pal.link]}
+        style={{color: t.palette.primary_500}}
       />
       <TextLink
         href="https://bsky.social/about/join"
         text={_(msg`Jobs`)}
-        style={[styles.footerLink, pal.link]}
+        style={{color: t.palette.primary_500}}
       />
 
-      <View style={styles.footerDivider} />
+      <View style={a.flex_1} />
 
-      <View
-        style={{
-          flexDirection: 'row',
-          gap: 8,
-          alignItems: 'center',
-          flexShrink: 1,
-        }}>
-        <Text aria-hidden={true} style={[pal.textLight]}>
+      <View style={[a.flex_row, a.gap_sm, a.align_center, a.flex_shrink]}>
+        <Text aria-hidden={true} style={t.atoms.text_contrast_medium}>
           {APP_LANGUAGES.find(l => l.code2 === sanitizedLang)?.name}
         </Text>
-        <FontAwesomeIcon
-          icon="chevron-down"
-          size={12}
-          style={[pal.textLight, {flexShrink: 0}]}
+        <ChevronDown
+          fill={t.atoms.text.color}
+          size="xs"
+          style={a.flex_shrink}
         />
 
         <select
@@ -182,80 +215,4 @@ function Footer({styles}: {styles: ReturnType<typeof useStyles>}) {
       </View>
     </View>
   )
-}
-const useStyles = () => {
-  return StyleSheet.create({
-    container: {
-      height: '100%',
-    },
-    containerInner: {
-      height: '100%',
-      justifyContent: 'center',
-      // @ts-ignore web only
-      paddingBottom: '20vh',
-      paddingHorizontal: 20,
-    },
-    containerInnerMobile: {
-      paddingBottom: 50,
-    },
-    title: {
-      textAlign: 'center',
-      color: colors.blue3,
-      fontSize: 68,
-      fontWeight: 'bold',
-      paddingBottom: 10,
-    },
-    titleMobile: {
-      textAlign: 'center',
-      color: colors.blue3,
-      fontSize: 58,
-      fontWeight: 'bold',
-    },
-    subtitle: {
-      textAlign: 'center',
-      color: colors.gray5,
-      fontSize: 52,
-      fontWeight: 'bold',
-      paddingBottom: 30,
-    },
-    subtitleMobile: {
-      textAlign: 'center',
-      color: colors.gray5,
-      fontSize: 42,
-      fontWeight: 'bold',
-      paddingBottom: 30,
-    },
-    btns: {
-      gap: 10,
-      justifyContent: 'center',
-      paddingBottom: 40,
-    },
-    btn: {
-      borderRadius: 30,
-      paddingHorizontal: 24,
-      paddingVertical: 12,
-      minWidth: 220,
-    },
-    btnLabel: {
-      textAlign: 'center',
-      fontSize: 18,
-    },
-    notice: {
-      paddingHorizontal: 40,
-      textAlign: 'center',
-    },
-    footer: {
-      position: 'absolute',
-      left: 0,
-      right: 0,
-      bottom: 0,
-      padding: 20,
-      borderTopWidth: 1,
-      flexDirection: 'row',
-      flexWrap: 'wrap',
-      gap: 20,
-    },
-    footerDivider: {flexGrow: 1},
-    footerLink: {},
-  })
 }

--- a/src/view/com/auth/SplashScreen.web.tsx
+++ b/src/view/com/auth/SplashScreen.web.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import {View, Pressable} from 'react-native'
 import {FontAwesomeIcon} from '@fortawesome/react-native-fontawesome'
-import {TextLink} from '../util/Link'
 import {ErrorBoundary} from 'view/com/util/ErrorBoundary'
 import {CenteredView} from '../util/Views'
 import {useWebMediaQueries} from 'lib/hooks/useWebMediaQueries'
@@ -16,6 +15,7 @@ import {atoms as a, useTheme} from '#/alf'
 import {Button, ButtonText} from '#/components/Button'
 import {ChevronBottom_Stroke2_Corner0_Rounded as ChevronDown} from '#/components/icons/Chevron'
 import {Text} from '#/components/Typography'
+import {InlineLink} from '#/components/Link'
 
 export const SplashScreen = ({
   onDismiss,
@@ -128,7 +128,6 @@ export const SplashScreen = ({
 }
 
 function Footer() {
-  const {_} = useLingui()
   const t = useTheme()
 
   const langPrefs = useLanguagePrefs()
@@ -162,21 +161,15 @@ function Footer() {
         a.flex_1,
         t.atoms.border_contrast_medium,
       ]}>
-      <TextLink
-        href="https://bsky.social"
-        text={_(msg`Business`)}
-        style={{color: t.palette.primary_500}}
-      />
-      <TextLink
-        href="https://bsky.social/about/blog"
-        text={_(msg`Blog`)}
-        style={{color: t.palette.primary_500}}
-      />
-      <TextLink
-        href="https://bsky.social/about/join"
-        text={_(msg`Jobs`)}
-        style={{color: t.palette.primary_500}}
-      />
+      <InlineLink to="https://bsky.social">
+        <Trans>Business</Trans>
+      </InlineLink>
+      <InlineLink to="https://bsky.social/about/blog">
+        <Trans>Blog</Trans>
+      </InlineLink>
+      <InlineLink to="https://bsky.social/about/join">
+        <Trans>Jobs</Trans>
+      </InlineLink>
 
       <View style={a.flex_1} />
 


### PR DESCRIPTION
Splashscreen refresh using ALF. Minor change to web - added the "What's up?" subtitle that's missing on web. Was this difference intentional? I can remove it again if so.

iOS:

![Simulator Screenshot - iPhone 15 - 2024-03-20 at 17 08 59](https://github.com/bluesky-social/social-app/assets/10959775/4fe0b1a2-886e-4998-954c-27207b67d0a2)
![Simulator Screenshot - iPhone 15 - 2024-03-20 at 17 08 42](https://github.com/bluesky-social/social-app/assets/10959775/f7f1c592-78ee-4952-a514-c94de530389e)

Web (desktop):

<img width="1435" alt="Screenshot 2024-03-20 at 17 09 19" src="https://github.com/bluesky-social/social-app/assets/10959775/ca80dfb4-a285-4eb1-8429-fc1f720ce7bb">
<img width="917" alt="Screenshot 2024-03-20 at 17 10 32" src="https://github.com/bluesky-social/social-app/assets/10959775/b839f64c-1118-40b2-b77e-9deb56cdf6f1">

Web (mobile):

![Screenshot 2024-03-20 at 17 09 58](https://github.com/bluesky-social/social-app/assets/10959775/4736d247-97a7-4e0b-a7b6-77b95e453733)
![Screenshot 2024-03-20 at 17 10 19](https://github.com/bluesky-social/social-app/assets/10959775/0d07eb78-6684-4dc0-bf69-2d66bf5f8ac9)
