### PR TITLE
Fix missing error on `PostThread`

### DIFF
--- a/src/view/com/post-thread/PostThread.tsx
+++ b/src/view/com/post-thread/PostThread.tsx
@@ -371,7 +371,7 @@ export function PostThread({
   return (
     <>
       <ListMaybePlaceholder
-        isLoading={!preferences || !thread}
+        isLoading={(!preferences || !thread) && !error}
         isError={!!error}
         onRetry={refetch}
         errorTitle={error?.title}


### PR DESCRIPTION
Fixes a missing error for a deleted post on `PostThread` that would cause a spinner to not go away.