### PR TITLE
Specify package manager in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "engines": {
     "node": ">=18"
   },
+  "packageManager": "yarn@1.22.19",
   "scripts": {
     "prepare": "is-ci || husky install",
     "postinstall": "patch-package && yarn intl:compile",


### PR DESCRIPTION
I'm not sure if it's yarn or node, but something keep trying to add this field automatically. I think its probably good to have anyway, so why not.