### PR TITLE
[Statsig] Protect against early logEvent call crashing

### DIFF
--- a/src/lib/statsig/statsig.tsx
+++ b/src/lib/statsig/statsig.tsx
@@ -40,12 +40,20 @@ export function logEvent<E extends keyof LogEvents>(
   eventName: E & string,
   rawMetadata: LogEvents[E] & FlatJSONRecord,
 ) {
-  const fullMetadata = {
-    ...rawMetadata,
-  } as Record<string, string> // Statsig typings are unnecessarily strict here.
-  fullMetadata.routeName = getCurrentRouteName() ?? '(Uninitialized)'
-  if (Statsig.initializeCalled()) {
-    Statsig.logEvent(eventName, null, fullMetadata)
+  try {
+    const fullMetadata = {
+      ...rawMetadata,
+    } as Record<string, string> // Statsig typings are unnecessarily strict here.
+    fullMetadata.routeName = getCurrentRouteName() ?? '(Uninitialized)'
+    if (Statsig.initializeCalled()) {
+      Statsig.logEvent(eventName, null, fullMetadata)
+    }
+  } catch (e) {
+    // A log should never interrupt the calling code, whatever happens.
+    // Rethrow on a clean stack.
+    setTimeout(() => {
+      throw e
+    })
   }
 }
 

--- a/src/lib/statsig/statsig.tsx
+++ b/src/lib/statsig/statsig.tsx
@@ -1,13 +1,14 @@
 import React from 'react'
 import {Platform} from 'react-native'
+import {AppState, AppStateStatus} from 'react-native'
+import {sha256} from 'js-sha256'
 import {
   Statsig,
   StatsigProvider,
   useGate as useStatsigGate,
 } from 'statsig-react-native-expo'
-import {AppState, AppStateStatus} from 'react-native'
+
 import {useSession} from '../../state/session'
-import {sha256} from 'js-sha256'
 import {LogEvents} from './events'
 
 export type {LogEvents}
@@ -43,7 +44,9 @@ export function logEvent<E extends keyof LogEvents>(
     ...rawMetadata,
   } as Record<string, string> // Statsig typings are unnecessarily strict here.
   fullMetadata.routeName = getCurrentRouteName() ?? '(Uninitialized)'
-  Statsig.logEvent(eventName, null, fullMetadata)
+  if (Statsig.initializeCalled()) {
+    Statsig.logEvent(eventName, null, fullMetadata)
+  }
 }
 
 export function useGate(gateName: string) {


### PR DESCRIPTION
[Review without whitespace](https://github.com/bluesky-social/social-app/pull/3315/files?w=1)

Apparently `logEvent` can throw otherwise. (To repro, remove the provider.) This adds a safeguard.

In practice the only way this can happen right now is via the `AppState` listener that is setup early.

I've also added a try-catch with a rethrow inside `setTimeout` so that this can never happen again.

Fixes this:

![Screenshot_20240321-104656](https://github.com/bluesky-social/social-app/assets/810438/d71513b6-1207-4c09-9f85-b7e8f4ae8b2c)
