### PR TITLE
Bluesky:  Compat with React 19 types

### DIFF
--- a/package.json
+++ b/package.json
@@ -221,7 +221,7 @@
     "@types/lodash.shuffle": "^4.2.7",
     "@types/psl": "^1.1.1",
     "@types/react-avatar-editor": "^13.0.0",
-    "@types/react-dom": "^18.2.18",
+    "@types/react-dom": "npm:types-react-dom@19.0.0",
     "@types/react-responsive": "^8.0.5",
     "@types/react-test-renderer": "^17.0.1",
     "@typescript-eslint/eslint-plugin": "^5.48.2",
@@ -261,7 +261,8 @@
     "webpack-dev-server": "^4.11.1"
   },
   "resolutions": {
-    "@types/react": "^18",
+    "@types/react": "npm:types-react@19.0.0",
+    "@types/react-dom": "npm:types-react-dom@19.0.0",
     "**/zeed-dom": "0.10.9"
   },
   "jest": {

--- a/src/components/Dialog/index.tsx
+++ b/src/components/Dialog/index.tsx
@@ -83,7 +83,7 @@ export function Outer({
   const sheetOptions = nativeOptions?.sheet || {}
   const hasSnapPoints = !!sheetOptions.snapPoints
   const insets = useSafeAreaInsets()
-  const closeCallback = React.useRef<() => void>()
+  const closeCallback = React.useRef<() => void>(undefined)
   const {setDialogIsOpen} = useDialogStateControlContext()
 
   /*

--- a/src/components/Dialog/types.ts
+++ b/src/components/Dialog/types.ts
@@ -31,7 +31,7 @@ export type DialogControlRefProps = {
  */
 export type DialogControlProps = DialogControlRefProps & {
   id: string
-  ref: React.RefObject<DialogControlRefProps>
+  ref: React.RefObject<DialogControlRefProps | null>
   isOpen?: boolean
 }
 

--- a/src/components/forms/InputGroup.tsx
+++ b/src/components/forms/InputGroup.tsx
@@ -13,7 +13,7 @@ export function InputGroup(props: React.PropsWithChildren<{}>) {
   return (
     <View style={[atoms.w_full]}>
       {children.map((child, i) => {
-        return React.isValidElement(child) ? (
+        return React.isValidElement<{style: unknown}>(child) ? (
           <React.Fragment key={i}>
             {i > 0 ? (
               <View

--- a/src/components/forms/TextField.tsx
+++ b/src/components/forms/TextField.tsx
@@ -17,7 +17,7 @@ import {Props as SVGIconProps} from '#/components/icons/common'
 import {Text} from '#/components/Typography'
 
 const Context = React.createContext<{
-  inputRef: React.RefObject<TextInput> | null
+  inputRef: React.RefObject<TextInput | null> | null
   isInvalid: boolean
   hovered: boolean
   onHoverIn: () => void
@@ -129,7 +129,7 @@ export type InputProps = Omit<TextInputProps, 'value' | 'onChangeText'> & {
   value?: string
   onChangeText?: (value: string) => void
   isInvalid?: boolean
-  inputRef?: React.RefObject<TextInput>
+  inputRef?: React.RefObject<TextInput | null>
 }
 
 export function createInput(Component: typeof TextInput) {

--- a/src/lib/hooks/useAnimatedValue.ts
+++ b/src/lib/hooks/useAnimatedValue.ts
@@ -2,7 +2,7 @@ import * as React from 'react'
 import {Animated} from 'react-native'
 
 export function useAnimatedValue(initialValue: number) {
-  const lazyRef = React.useRef<Animated.Value>()
+  const lazyRef = React.useRef<Animated.Value>(undefined)
 
   if (lazyRef.current === undefined) {
     lazyRef.current = new Animated.Value(initialValue)

--- a/src/lib/merge-refs.ts
+++ b/src/lib/merge-refs.ts
@@ -13,7 +13,7 @@
  * returns a ref callback function that can be used to merge multiple refs into a single ref.
  */
 export function mergeRefs<T = any>(
-  refs: Array<React.MutableRefObject<T> | React.LegacyRef<T>>,
+  refs: Array<React.MutableRefObject<T> | React.Ref<T>>,
 ): React.RefCallback<T> {
   return value => {
     refs.forEach(ref => {

--- a/src/view/com/feeds/FeedPage.tsx
+++ b/src/view/com/feeds/FeedPage.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { type JSX } from 'react';
 import {useNavigation} from '@react-navigation/native'
 import {useAnalytics} from 'lib/analytics/analytics'
 import {useQueryClient} from '@tanstack/react-query'

--- a/src/view/com/home/HomeHeaderLayout.web.tsx
+++ b/src/view/com/home/HomeHeaderLayout.web.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { type JSX } from 'react';
 import {StyleSheet, View} from 'react-native'
 import Animated from 'react-native-reanimated'
 import {usePalette} from 'lib/hooks/usePalette'

--- a/src/view/com/home/HomeHeaderLayoutMobile.tsx
+++ b/src/view/com/home/HomeHeaderLayoutMobile.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { type JSX } from 'react';
 import {StyleSheet, TouchableOpacity, View} from 'react-native'
 import {usePalette} from 'lib/hooks/usePalette'
 import {Link} from '../util/Link'

--- a/src/view/com/lists/ListCard.tsx
+++ b/src/view/com/lists/ListCard.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { type JSX } from 'react';
 import {StyleProp, StyleSheet, View, ViewStyle} from 'react-native'
 import {AtUri, AppBskyGraphDefs, RichText} from '@atproto/api'
 import {Link} from '../util/Link'

--- a/src/view/com/lists/ListMembers.tsx
+++ b/src/view/com/lists/ListMembers.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { type JSX } from 'react';
 import {
   ActivityIndicator,
   Dimensions,

--- a/src/view/com/lists/MyLists.tsx
+++ b/src/view/com/lists/MyLists.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { type JSX } from 'react';
 import {
   ActivityIndicator,
   FlatList as RNFlatList,

--- a/src/view/com/notifications/Feed.tsx
+++ b/src/view/com/notifications/Feed.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { type JSX } from 'react';
 import {CenteredView} from '../util/Views'
 import {ActivityIndicator, StyleSheet, View} from 'react-native'
 import {FeedItem} from './FeedItem'

--- a/src/view/com/pager/Pager.tsx
+++ b/src/view/com/pager/Pager.tsx
@@ -1,4 +1,4 @@
-import React, {forwardRef} from 'react'
+import React, { forwardRef, type JSX } from 'react';
 import {Animated, View} from 'react-native'
 import PagerView, {
   PagerViewOnPageSelectedEvent,

--- a/src/view/com/pager/Pager.web.tsx
+++ b/src/view/com/pager/Pager.web.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { type JSX } from 'react';
 import {flushSync} from 'react-dom'
 import {View} from 'react-native'
 import {s} from 'lib/styles'

--- a/src/view/com/pager/PagerWithHeader.tsx
+++ b/src/view/com/pager/PagerWithHeader.tsx
@@ -22,6 +22,8 @@ import {useNonReactiveCallback} from '#/lib/hooks/useNonReactiveCallback'
 import {ListMethods} from '../util/List'
 import {ScrollProvider} from '#/lib/ScrollContext'
 
+import type { JSX } from "react";
+
 export interface PagerWithHeaderChildParams {
   headerHeight: number
   isFocused: boolean

--- a/src/view/com/pager/PagerWithHeader.web.tsx
+++ b/src/view/com/pager/PagerWithHeader.web.tsx
@@ -7,6 +7,8 @@ import {usePalette} from '#/lib/hooks/usePalette'
 import {useWebMediaQueries} from '#/lib/hooks/useWebMediaQueries'
 import {ListMethods} from '../util/List'
 
+import type { JSX } from "react";
+
 export interface PagerWithHeaderChildParams {
   headerHeight: number
   isFocused: boolean

--- a/src/view/com/posts/Feed.tsx
+++ b/src/view/com/posts/Feed.tsx
@@ -1,4 +1,4 @@
-import React, {memo} from 'react'
+import React, { memo, type JSX } from 'react';
 import {
   ActivityIndicator,
   AppState,

--- a/src/view/com/util/Link.tsx
+++ b/src/view/com/util/Link.tsx
@@ -1,4 +1,4 @@
-import React, {ComponentProps, memo, useMemo} from 'react'
+import React, { ComponentProps, memo, useMemo, type JSX } from 'react';
 import {
   GestureResponderEvent,
   Platform,

--- a/src/view/com/util/Link.tsx
+++ b/src/view/com/util/Link.tsx
@@ -1,4 +1,4 @@
-import React, { ComponentProps, memo, useMemo, type JSX } from 'react';
+import React, {ComponentProps, memo, useMemo, type JSX} from 'react'
 import {
   GestureResponderEvent,
   Platform,
@@ -35,7 +35,7 @@ type Event =
   | React.MouseEvent<HTMLAnchorElement, MouseEvent>
   | GestureResponderEvent
 
-interface Props extends ComponentProps<typeof TouchableOpacity> {
+interface Props extends Omit<ComponentProps<typeof TouchableOpacity>, 'ref'> {
   testID?: string
   style?: StyleProp<ViewStyle>
   href?: string

--- a/src/view/com/util/List.web.tsx
+++ b/src/view/com/util/List.web.tsx
@@ -1,4 +1,4 @@
-import React, {isValidElement, memo, useRef, startTransition} from 'react'
+import React, { isValidElement, memo, useRef, startTransition, type JSX } from 'react';
 import {FlatListProps, StyleSheet, View, ViewProps} from 'react-native'
 import {addStyle} from 'lib/styles'
 import {usePalette} from 'lib/hooks/usePalette'
@@ -204,7 +204,7 @@ function ListImpl<ItemT>(
 }
 
 function useResizeObserver(
-  ref: React.RefObject<Element>,
+  ref: React.RefObject<Element | null>,
   onResize: undefined | ((w: number, h: number) => void),
 ) {
   const handleResize = useNonReactiveCallback(onResize ?? (() => {}))

--- a/src/view/com/util/TimeElapsed.tsx
+++ b/src/view/com/util/TimeElapsed.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { type JSX } from 'react';
 import {ago} from 'lib/strings/time'
 import {useTickEveryMinute} from '#/state/shell'
 

--- a/src/view/com/util/ViewHeader.tsx
+++ b/src/view/com/util/ViewHeader.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { type JSX } from 'react';
 import {StyleSheet, TouchableOpacity, View} from 'react-native'
 import {FontAwesomeIcon} from '@fortawesome/react-native-fontawesome'
 import {useNavigation} from '@react-navigation/native'

--- a/src/view/com/util/ViewSelector.tsx
+++ b/src/view/com/util/ViewSelector.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useState} from 'react'
+import React, { useEffect, useState, type JSX } from 'react';
 import {
   NativeSyntheticEvent,
   NativeScrollEvent,

--- a/src/view/com/util/fab/FABInner.tsx
+++ b/src/view/com/util/fab/FABInner.tsx
@@ -1,4 +1,4 @@
-import React, {ComponentProps} from 'react'
+import React, { ComponentProps, type JSX } from 'react';
 import {StyleSheet, TouchableWithoutFeedback} from 'react-native'
 import LinearGradient from 'react-native-linear-gradient'
 import {gradients} from 'lib/styles'

--- a/src/view/com/util/forms/RadioButton.tsx
+++ b/src/view/com/util/forms/RadioButton.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { type JSX } from 'react';
 import {StyleProp, StyleSheet, TextStyle, View, ViewStyle} from 'react-native'
 import {Text} from '../text/Text'
 import {Button, ButtonType} from './Button'

--- a/src/view/com/util/forms/RadioGroup.tsx
+++ b/src/view/com/util/forms/RadioGroup.tsx
@@ -1,4 +1,4 @@
-import React, {useState} from 'react'
+import React, { useState, type JSX } from 'react';
 import {View} from 'react-native'
 import {RadioButton} from './RadioButton'
 import {ButtonType} from './Button'

--- a/src/view/com/util/layouts/TitleColumnLayout.tsx
+++ b/src/view/com/util/layouts/TitleColumnLayout.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { type JSX } from 'react';
 import {StyleProp, StyleSheet, View, ViewStyle} from 'react-native'
 import {usePalette} from 'lib/hooks/usePalette'
 import {useColorSchemeStyle} from 'lib/hooks/useColorSchemeStyle'

--- a/src/view/shell/Drawer.tsx
+++ b/src/view/shell/Drawer.tsx
@@ -1,4 +1,4 @@
-import React, {ComponentProps} from 'react'
+import React, { ComponentProps, type JSX } from 'react';
 import {
   Linking,
   SafeAreaView,

--- a/src/view/shell/bottom-bar/BottomBar.tsx
+++ b/src/view/shell/bottom-bar/BottomBar.tsx
@@ -1,4 +1,4 @@
-import React, {ComponentProps} from 'react'
+import React, { ComponentProps, type JSX } from 'react';
 import {GestureResponderEvent, TouchableOpacity, View} from 'react-native'
 import Animated from 'react-native-reanimated'
 import {StackActions} from '@react-navigation/native'

--- a/src/view/shell/bottom-bar/BottomBarWeb.tsx
+++ b/src/view/shell/bottom-bar/BottomBarWeb.tsx
@@ -190,7 +190,7 @@ export function BottomBarWeb() {
 }
 
 const NavItem: React.FC<{
-  children: (props: {isActive: boolean}) => React.ReactChild
+  children: (props: {isActive: boolean}) => React.ReactElement | number | string
   href: string
   routeName: string
 }> = ({children, href, routeName}) => {

--- a/src/view/shell/desktop/LeftNav.tsx
+++ b/src/view/shell/desktop/LeftNav.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { type JSX } from 'react';
 import {StyleSheet, TouchableOpacity, View} from 'react-native'
 import {PressableWithHover} from 'view/com/util/PressableWithHover'
 import {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7792,11 +7792,6 @@
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.7.3.tgz#3e51a17e291d01d17d3fc61422015a933af7a08f"
   integrity sha512-+68kP9yzs4LMp7VNh8gdzMSPZFL44MLGqiHWvttYJe+6qnuVr4Ek9wSBQoveqY/r+LwjCcU29kNVkidwim+kYA==
 
-"@types/prop-types@*":
-  version "15.7.5"
-  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.5.tgz#5f19d2b85a98e9558036f6a3cacc8819420f05cf"
-  integrity sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==
-
 "@types/psl@^1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/psl/-/psl-1.1.1.tgz#3ba9e6d4bd2a32652a639fd5df7e539151d0a3b2"
@@ -7824,10 +7819,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-dom@^18.2.18":
-  version "18.2.18"
-  resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.2.18.tgz#16946e6cd43971256d874bc3d0a72074bb8571dd"
-  integrity sha512-TJxDm6OfAX2KJWJdMEVTwWke5Sc/E/RlnPGvGfS0W7+6ocy2xhDVQVh/KvC2Uf7kACs+gDytdusDSdWfWkaNzw==
+"@types/react-dom@npm:types-react-dom@19.0.0":
+  version "19.0.0"
+  resolved "https://registry.yarnpkg.com/types-react-dom/-/types-react-dom-19.0.0.tgz#48286ba504ac48e9345cc860f76845344c5a633a"
+  integrity sha512-qtWBYduBCmrgf4wqnTrGttEJJSZ6cTGmzuvmWd/34TJNKz/Pp69Islc1+txHF3nRxSuRvmhxztFXvLyxhp8G2w==
   dependencies:
     "@types/react" "*"
 
@@ -7845,12 +7840,11 @@
   dependencies:
     "@types/react" "^17"
 
-"@types/react@*", "@types/react@^17", "@types/react@^18":
-  version "18.2.20"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-18.2.20.tgz#1605557a83df5c8a2cc4eeb743b3dfc0eb6aaeb2"
-  integrity sha512-WKNtmsLWJM/3D5mG4U84cysVY31ivmyw85dE84fOCk5Hx78wezB/XEjVPWl2JTZ5FkEeaTJf+VgUAUn3PE7Isw==
+"@types/react@*", "@types/react@^17", "@types/react@npm:types-react@19.0.0":
+  version "19.0.0"
+  resolved "https://registry.yarnpkg.com/types-react/-/types-react-19.0.0.tgz#36ac2d736c33a6331ec48d50f347248bf6335741"
+  integrity sha512-4hwzwaxNhdHXNhGJ819IMghtTlc/NcUGHcH1IhIU0WOQLKhzRldCJdTga+CvzTt2ugyLw0IBkhoaOsXssAPeFg==
   dependencies:
-    "@types/prop-types" "*"
     "@types/scheduler" "*"
     csstype "^3.0.2"
 


### PR DESCRIPTION
## Changes

Two non-codemoddable changes:
- one `ReactElement<unknown>`
- one manual replacement of `React.ReactChild` due to a parser bug: https://github.com/eps1lon/types-react-codemod/issues/374

## New issues

- https://github.com/eps1lon/DefinitelyTyped/issues/27

## Unresolved issues

- `node_modules/@discord/bottom-sheet/src/hooks/useStableCallback.ts` has missing default value in `useRef`: `const callbackRef = useRef<Callback>();`
- `node_modules/@discord/bottom-sheet/src/hooks/useStableCallback.ts` has implicit return in callback ref 	