### PR TITLE
Mark `under13` and `Next` and `Back` buttons in signup for localisation

### DIFF
--- a/src/screens/Signup/StepInfo/Policies.tsx
+++ b/src/screens/Signup/StepInfo/Policies.tsx
@@ -76,9 +76,7 @@ export const Policies = ({
 
       {under13 ? (
         <Text style={[a.font_bold, a.leading_snug, t.atoms.text_contrast_high]}>
-          <Trans>
-          You must be 13 years of age or older to sign up.
-          </Trans>
+          <Trans>You must be 13 years of age or older to sign up.</Trans>
         </Text>
       ) : needsGuardian ? (
         <Text style={[a.font_bold, a.leading_snug, t.atoms.text_contrast_high]}>

--- a/src/screens/Signup/StepInfo/Policies.tsx
+++ b/src/screens/Signup/StepInfo/Policies.tsx
@@ -76,7 +76,9 @@ export const Policies = ({
 
       {under13 ? (
         <Text style={[a.font_bold, a.leading_snug, t.atoms.text_contrast_high]}>
-          You must be 13 years of age or older to sign up.
+          <Trans>
+            You must be 13 years of age or older to sign up.
+          </Trans>
         </Text>
       ) : needsGuardian ? (
         <Text style={[a.font_bold, a.leading_snug, t.atoms.text_contrast_high]}>

--- a/src/screens/Signup/StepInfo/Policies.tsx
+++ b/src/screens/Signup/StepInfo/Policies.tsx
@@ -77,7 +77,7 @@ export const Policies = ({
       {under13 ? (
         <Text style={[a.font_bold, a.leading_snug, t.atoms.text_contrast_high]}>
           <Trans>
-            You must be 13 years of age or older to sign up.
+          You must be 13 years of age or older to sign up.
           </Trans>
         </Text>
       ) : needsGuardian ? (

--- a/src/screens/Signup/index.tsx
+++ b/src/screens/Signup/index.tsx
@@ -170,34 +170,36 @@ export function Signup({onPressBack}: {onPressBack: () => void}) {
 
             <View style={[a.flex_row, a.justify_between, a.pb_lg]}>
               <Button
-                label="Back"
+                label={_(msg`Go back to previous step`)}
                 variant="solid"
                 color="secondary"
                 size="medium"
                 onPress={onBackPress}>
-                Back
+                <Trans>Back</Trans>
               </Button>
               {state.activeStep !== SignupStep.CAPTCHA && (
                 <>
                   {isError ? (
                     <Button
-                      label="Retry"
+                      label={_(msg`Press to retry`)}
                       variant="solid"
                       color="primary"
                       size="medium"
                       disabled={state.isLoading}
                       onPress={() => refetch()}>
-                      Retry
+                      <Trans>Retry</Trans>
                     </Button>
                   ) : (
                     <Button
-                      label="Next"
+                      label={_(msg`Continue to the next step`)}
                       variant="solid"
                       color="primary"
                       size="medium"
                       disabled={!state.canNext || state.isLoading}
                       onPress={onNextPress}>
-                      <ButtonText>Next</ButtonText>
+                      <ButtonText>
+                        <Trans>Next</Trans>
+                      </ButtonText>
                     </Button>
                   )}
                 </>

--- a/src/screens/Signup/index.tsx
+++ b/src/screens/Signup/index.tsx
@@ -191,7 +191,7 @@ export function Signup({onPressBack}: {onPressBack: () => void}) {
                     </Button>
                   ) : (
                     <Button
-                      label={_(msg`Continue to the next step`)}
+                      label={_(msg`Continue to next step`)}
                       variant="solid"
                       color="primary"
                       size="medium"

--- a/src/screens/Signup/index.tsx
+++ b/src/screens/Signup/index.tsx
@@ -175,7 +175,9 @@ export function Signup({onPressBack}: {onPressBack: () => void}) {
                 color="secondary"
                 size="medium"
                 onPress={onBackPress}>
-                <Trans>Back</Trans>
+                <ButtonText>
+                  <Trans>Back</Trans>
+                </ButtonText>
               </Button>
               {state.activeStep !== SignupStep.CAPTCHA && (
                 <>
@@ -187,7 +189,9 @@ export function Signup({onPressBack}: {onPressBack: () => void}) {
                       size="medium"
                       disabled={state.isLoading}
                       onPress={() => refetch()}>
-                      <Trans>Retry</Trans>
+                      <ButtonText>
+                        <Trans>Retry</Trans>
+                      </ButtonText>
                     </Button>
                   ) : (
                     <Button


### PR DESCRIPTION
This PR marks the `under13` string and the `Next` and `Back` buttons (and their labels) in the signup flow for translation.