### PR TITLE
revert change for closing composer on web only

### DIFF
--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -508,7 +508,11 @@ export const ComposePost = observer(function ComposePost({
         title={_(msg`Discard draft?`)}
         description={_(msg`Are you sure you'd like to discard this draft?`)}
         onConfirm={() => {
-          discardPromptControl.close(onClose)
+          if (isWeb) {
+            onClose()
+          } else {
+            discardPromptControl.close(onClose)
+          }
         }}
         confirmButtonCta={_(msg`Discard`)}
         confirmButtonColor="negative"


### PR DESCRIPTION
This is a temporary fix for closing the composer on web. We should not rely on this and should re-evaluate a few things about the dialogs and the callbacks here.

The `PromptControl` allows for passing a callback that runs after closing the dialog. This works fine on native but does not work on mobile. If we do the opposite and just use `onClose` as the callback to `onConfirm`, it breaks the Android back button. We should do a deeper investigation on this @estrattonbailey 