### PR TITLE
Show profile icon on bottom bar of web

### DIFF
--- a/src/view/shell/bottom-bar/BottomBar.tsx
+++ b/src/view/shell/bottom-bar/BottomBar.tsx
@@ -1,42 +1,43 @@
 import React, {ComponentProps} from 'react'
 import {GestureResponderEvent, TouchableOpacity, View} from 'react-native'
 import Animated from 'react-native-reanimated'
-import {StackActions} from '@react-navigation/native'
-import {BottomTabBarProps} from '@react-navigation/bottom-tabs'
 import {useSafeAreaInsets} from 'react-native-safe-area-context'
-import {Text} from 'view/com/util/text/Text'
+import {msg, Trans} from '@lingui/macro'
+import {useLingui} from '@lingui/react'
+import {BottomTabBarProps} from '@react-navigation/bottom-tabs'
+import {StackActions} from '@react-navigation/native'
+
+import {emitSoftReset} from '#/state/events'
+import {useModalControls} from '#/state/modals'
+import {useUnreadNotifications} from '#/state/queries/notifications/unread'
+import {useProfileQuery} from '#/state/queries/profile'
+import {useSession} from '#/state/session'
+import {useLoggedOutViewControls} from '#/state/shell/logged-out'
+import {useShellLayout} from '#/state/shell/shell-layout'
+import {useCloseAllActiveElements} from '#/state/util'
 import {useAnalytics} from 'lib/analytics/analytics'
-import {clamp} from 'lib/numbers'
+import {useDedupe} from 'lib/hooks/useDedupe'
+import {useMinimalShellMode} from 'lib/hooks/useMinimalShellMode'
+import {useNavigationTabState} from 'lib/hooks/useNavigationTabState'
+import {usePalette} from 'lib/hooks/usePalette'
 import {
+  BellIcon,
+  BellIconSolid,
+  HashtagIcon,
   HomeIcon,
   HomeIconSolid,
   MagnifyingGlassIcon2,
   MagnifyingGlassIcon2Solid,
-  HashtagIcon,
-  BellIcon,
-  BellIconSolid,
 } from 'lib/icons'
-import {usePalette} from 'lib/hooks/usePalette'
+import {clamp} from 'lib/numbers'
 import {getTabState, TabState} from 'lib/routes/helpers'
-import {styles} from './BottomBarStyles'
-import {useMinimalShellMode} from 'lib/hooks/useMinimalShellMode'
-import {useNavigationTabState} from 'lib/hooks/useNavigationTabState'
-import {UserAvatar} from 'view/com/util/UserAvatar'
-import {useLingui} from '@lingui/react'
-import {msg, Trans} from '@lingui/macro'
-import {useModalControls} from '#/state/modals'
-import {useShellLayout} from '#/state/shell/shell-layout'
-import {useUnreadNotifications} from '#/state/queries/notifications/unread'
-import {emitSoftReset} from '#/state/events'
-import {useSession} from '#/state/session'
-import {useProfileQuery} from '#/state/queries/profile'
-import {useLoggedOutViewControls} from '#/state/shell/logged-out'
-import {useCloseAllActiveElements} from '#/state/util'
-import {Button} from '#/view/com/util/forms/Button'
 import {s} from 'lib/styles'
+import {Button} from '#/view/com/util/forms/Button'
 import {Logo} from '#/view/icons/Logo'
 import {Logotype} from '#/view/icons/Logotype'
-import {useDedupe} from 'lib/hooks/useDedupe'
+import {Text} from 'view/com/util/text/Text'
+import {UserAvatar} from 'view/com/util/UserAvatar'
+import {styles} from './BottomBarStyles'
 
 type TabOptions = 'Home' | 'Search' | 'Notifications' | 'MyProfile' | 'Feeds'
 
@@ -226,7 +227,7 @@ export function BottomBar({navigation}: BottomTabBarProps) {
                     ]}>
                     <UserAvatar
                       avatar={profile?.avatar}
-                      size={27}
+                      size={24}
                       // See https://github.com/bluesky-social/social-app/pull/1801:
                       usePlainRNImage={true}
                       type={profile?.associated?.labeler ? 'labeler' : 'user'}

--- a/src/view/shell/bottom-bar/BottomBarStyles.tsx
+++ b/src/view/shell/bottom-bar/BottomBarStyles.tsx
@@ -1,4 +1,5 @@
 import {StyleSheet} from 'react-native'
+
 import {colors} from 'lib/styles'
 
 export const styles = StyleSheet.create({
@@ -66,7 +67,7 @@ export const styles = StyleSheet.create({
     top: -4,
   },
   onProfile: {
-    borderWidth: 1,
+    borderWidth: 2,
     borderRadius: 100,
   },
 })

--- a/src/view/shell/bottom-bar/BottomBarWeb.tsx
+++ b/src/view/shell/bottom-bar/BottomBarWeb.tsx
@@ -1,37 +1,39 @@
 import React from 'react'
-import {usePalette} from 'lib/hooks/usePalette'
-import {useNavigationState} from '@react-navigation/native'
+import {View} from 'react-native'
 import Animated from 'react-native-reanimated'
 import {useSafeAreaInsets} from 'react-native-safe-area-context'
-import {View} from 'react-native'
 import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
-import {getCurrentRoute, isTab} from 'lib/routes/helpers'
-import {styles} from './BottomBarStyles'
-import {clamp} from 'lib/numbers'
+import {useNavigationState} from '@react-navigation/native'
+
+import {useProfileQuery} from '#/state/queries/profile'
+import {useSession} from '#/state/session'
+import {useLoggedOutViewControls} from '#/state/shell/logged-out'
+import {useCloseAllActiveElements} from '#/state/util'
+import {useMinimalShellMode} from 'lib/hooks/useMinimalShellMode'
+import {usePalette} from 'lib/hooks/usePalette'
 import {
   BellIcon,
   BellIconSolid,
+  HashtagIcon,
   HomeIcon,
   HomeIconSolid,
   MagnifyingGlassIcon2,
   MagnifyingGlassIcon2Solid,
-  HashtagIcon,
-  UserIcon,
-  UserIconSolid,
 } from 'lib/icons'
-import {Link} from 'view/com/util/Link'
-import {useMinimalShellMode} from 'lib/hooks/useMinimalShellMode'
+import {clamp} from 'lib/numbers'
+import {getCurrentRoute, isTab} from 'lib/routes/helpers'
 import {makeProfileLink} from 'lib/routes/links'
 import {CommonNavigatorParams} from 'lib/routes/types'
-import {useSession} from '#/state/session'
-import {useLoggedOutViewControls} from '#/state/shell/logged-out'
-import {useCloseAllActiveElements} from '#/state/util'
+import {s} from 'lib/styles'
 import {Button} from '#/view/com/util/forms/Button'
 import {Text} from '#/view/com/util/text/Text'
-import {s} from 'lib/styles'
 import {Logo} from '#/view/icons/Logo'
 import {Logotype} from '#/view/icons/Logotype'
+import {Link} from 'view/com/util/Link'
+import {LoadingPlaceholder} from 'view/com/util/LoadingPlaceholder'
+import {UserAvatar} from 'view/com/util/UserAvatar'
+import {styles} from './BottomBarStyles'
 
 export function BottomBarWeb() {
   const {_} = useLingui()
@@ -127,16 +129,7 @@ export function BottomBarWeb() {
                       })
                     : '/'
                 }>
-                {({isActive}) => {
-                  const Icon = isActive ? UserIconSolid : UserIcon
-                  return (
-                    <Icon
-                      size={28}
-                      strokeWidth={1.5}
-                      style={[styles.ctrlIcon, pal.text, styles.profileIcon]}
-                    />
-                  )
-                }}
+                {({isActive}) => <ProfileIcon isActive={isActive} />}
               </NavItem>
             </>
           )}
@@ -186,6 +179,44 @@ export function BottomBarWeb() {
         </>
       )}
     </Animated.View>
+  )
+}
+
+function ProfileIcon({isActive}: {isActive: boolean}) {
+  const pal = usePalette('default')
+  return isActive ? (
+    <View
+      style={[
+        styles.ctrlIcon,
+        styles.profileIcon,
+        styles.onProfile,
+        {borderColor: pal.text.color},
+      ]}>
+      <ProfileIconInner size={24} />
+    </View>
+  ) : (
+    <View style={[styles.ctrlIcon, styles.profileIcon]}>
+      <ProfileIconInner size={28} />
+    </View>
+  )
+}
+
+function ProfileIconInner({size}: {size: number}) {
+  const {currentAccount} = useSession()
+  const {isLoading, data: profile} = useProfileQuery({did: currentAccount!.did})
+
+  return !isLoading && profile ? (
+    <UserAvatar
+      avatar={profile?.avatar}
+      size={size}
+      type={profile?.associated?.labeler ? 'labeler' : 'user'}
+    />
+  ) : (
+    <LoadingPlaceholder
+      width={size}
+      height={size}
+      style={{borderRadius: size}}
+    />
   )
 }
 


### PR DESCRIPTION
On current version of web, when width of browser is narrow, bottom bar is shown as follows: 

<Light, user profile not selected>
![current_light_1](https://github.com/bluesky-social/social-app/assets/7834440/e6272445-f577-4efe-907a-48b588b546d6)

<Light, user profile selected>
![current_light_2](https://github.com/bluesky-social/social-app/assets/7834440/1ab36dfc-1586-46b3-99ca-a276d1d6b140)

<Dark, user profile not selected>
![current_dark_1](https://github.com/bluesky-social/social-app/assets/7834440/319a31ca-7bff-406e-8b82-116bb612acc0)

<Dark, user profile selected>
![current_dark_2](https://github.com/bluesky-social/social-app/assets/7834440/087b65c1-3811-4946-97ae-a07a758e8ff9)

User profile icon is not shown on the bottom bar on the web version although shown on the iOS / Android version. Thus user cannot recognize current account by the profile icon.

I have implemented that user profile is shown on the web version same as iOS / Android version as follows:

<Light, user profile not selected>
![pr_light1](https://github.com/bluesky-social/social-app/assets/7834440/313efa75-1b71-4627-a280-b016cd4582c9)

<Light, user profile selected>
![pr_light2](https://github.com/bluesky-social/social-app/assets/7834440/e21477c0-306e-4d61-b921-2c7be5e3a138)

<Dark, user profile not selected>
![pr_dark1](https://github.com/bluesky-social/social-app/assets/7834440/2ca03dd4-cfe4-4483-a41e-eab50922339e)

<Dark, user profile selected>
![pr_dark2](https://github.com/bluesky-social/social-app/assets/7834440/b137b868-8f79-4f0a-a338-358162476a8d)

Along with this fix, I have changed the border width when a user profile is selected from 1px to 2px. This is because border do not display correctly in lower resolution environments (for example, low-end smartphones and 96dpi PCs). This change has been applied both web (`BottomBarWeb.tsx`) and app (`BottomBar.tsx`) version of bottom bar.

[Note] Please review and confirm this modification based on these points:

+ I have confirmed this modification on Web (PC), Android (real device) and iOS (simulator). I cannot confirm on real iOS device because I do not own it. 
+ I have confirmed by using my personal Bluesky account, but I cannot confirm by using labeler account. 