### PR TITLE
Show profile icon in bottom bar of web and miscellaneous minor fixes

### DIFF
--- a/src/view/shell/bottom-bar/BottomBar.tsx
+++ b/src/view/shell/bottom-bar/BottomBar.tsx
@@ -1,42 +1,43 @@
 import React, {ComponentProps} from 'react'
 import {GestureResponderEvent, TouchableOpacity, View} from 'react-native'
 import Animated from 'react-native-reanimated'
-import {StackActions} from '@react-navigation/native'
-import {BottomTabBarProps} from '@react-navigation/bottom-tabs'
 import {useSafeAreaInsets} from 'react-native-safe-area-context'
-import {Text} from 'view/com/util/text/Text'
+import {msg, Trans} from '@lingui/macro'
+import {useLingui} from '@lingui/react'
+import {BottomTabBarProps} from '@react-navigation/bottom-tabs'
+import {StackActions} from '@react-navigation/native'
+
+import {emitSoftReset} from '#/state/events'
+import {useModalControls} from '#/state/modals'
+import {useUnreadNotifications} from '#/state/queries/notifications/unread'
+import {useProfileQuery} from '#/state/queries/profile'
+import {useSession} from '#/state/session'
+import {useLoggedOutViewControls} from '#/state/shell/logged-out'
+import {useShellLayout} from '#/state/shell/shell-layout'
+import {useCloseAllActiveElements} from '#/state/util'
 import {useAnalytics} from 'lib/analytics/analytics'
-import {clamp} from 'lib/numbers'
+import {useDedupe} from 'lib/hooks/useDedupe'
+import {useMinimalShellMode} from 'lib/hooks/useMinimalShellMode'
+import {useNavigationTabState} from 'lib/hooks/useNavigationTabState'
+import {usePalette} from 'lib/hooks/usePalette'
 import {
+  BellIcon,
+  BellIconSolid,
+  HashtagIcon,
   HomeIcon,
   HomeIconSolid,
   MagnifyingGlassIcon2,
   MagnifyingGlassIcon2Solid,
-  HashtagIcon,
-  BellIcon,
-  BellIconSolid,
 } from 'lib/icons'
-import {usePalette} from 'lib/hooks/usePalette'
+import {clamp} from 'lib/numbers'
 import {getTabState, TabState} from 'lib/routes/helpers'
-import {styles} from './BottomBarStyles'
-import {useMinimalShellMode} from 'lib/hooks/useMinimalShellMode'
-import {useNavigationTabState} from 'lib/hooks/useNavigationTabState'
-import {UserAvatar} from 'view/com/util/UserAvatar'
-import {useLingui} from '@lingui/react'
-import {msg, Trans} from '@lingui/macro'
-import {useModalControls} from '#/state/modals'
-import {useShellLayout} from '#/state/shell/shell-layout'
-import {useUnreadNotifications} from '#/state/queries/notifications/unread'
-import {emitSoftReset} from '#/state/events'
-import {useSession} from '#/state/session'
-import {useProfileQuery} from '#/state/queries/profile'
-import {useLoggedOutViewControls} from '#/state/shell/logged-out'
-import {useCloseAllActiveElements} from '#/state/util'
-import {Button} from '#/view/com/util/forms/Button'
 import {s} from 'lib/styles'
+import {Button} from '#/view/com/util/forms/Button'
 import {Logo} from '#/view/icons/Logo'
 import {Logotype} from '#/view/icons/Logotype'
-import {useDedupe} from 'lib/hooks/useDedupe'
+import {Text} from 'view/com/util/text/Text'
+import {UserAvatar} from 'view/com/util/UserAvatar'
+import {styles} from './BottomBarStyles'
 
 type TabOptions = 'Home' | 'Search' | 'Notifications' | 'MyProfile' | 'Feeds'
 
@@ -226,7 +227,7 @@ export function BottomBar({navigation}: BottomTabBarProps) {
                     ]}>
                     <UserAvatar
                       avatar={profile?.avatar}
-                      size={27}
+                      size={24}
                       // See https://github.com/bluesky-social/social-app/pull/1801:
                       usePlainRNImage={true}
                       type={profile?.associated?.labeler ? 'labeler' : 'user'}

--- a/src/view/shell/bottom-bar/BottomBar.tsx
+++ b/src/view/shell/bottom-bar/BottomBar.tsx
@@ -222,12 +222,11 @@ export function BottomBar({navigation}: BottomTabBarProps) {
                       styles.ctrlIcon,
                       pal.text,
                       styles.profileIcon,
-                      styles.onProfile,
                       {borderColor: pal.text.color},
                     ]}>
                     <UserAvatar
                       avatar={profile?.avatar}
-                      size={24}
+                      size={28}
                       // See https://github.com/bluesky-social/social-app/pull/1801:
                       usePlainRNImage={true}
                       type={profile?.associated?.labeler ? 'labeler' : 'user'}

--- a/src/view/shell/bottom-bar/BottomBarStyles.tsx
+++ b/src/view/shell/bottom-bar/BottomBarStyles.tsx
@@ -16,7 +16,6 @@ export const styles = StyleSheet.create({
   bottomBarWeb: {
     // @ts-ignore web-only
     position: 'fixed',
-    height: 60,
   },
   ctrl: {
     flex: 1,
@@ -65,10 +64,9 @@ export const styles = StyleSheet.create({
     top: -2.5,
   },
   profileIcon: {
-    top: -4,
-  },
-  onProfile: {
+    top: -6,
     borderWidth: 2,
     borderRadius: 100,
+    borderColor: 'transparent',
   },
 })

--- a/src/view/shell/bottom-bar/BottomBarStyles.tsx
+++ b/src/view/shell/bottom-bar/BottomBarStyles.tsx
@@ -1,4 +1,5 @@
 import {StyleSheet} from 'react-native'
+
 import {colors} from 'lib/styles'
 
 export const styles = StyleSheet.create({
@@ -66,7 +67,7 @@ export const styles = StyleSheet.create({
     top: -4,
   },
   onProfile: {
-    borderWidth: 1,
+    borderWidth: 2,
     borderRadius: 100,
   },
 })

--- a/src/view/shell/bottom-bar/BottomBarStyles.tsx
+++ b/src/view/shell/bottom-bar/BottomBarStyles.tsx
@@ -16,6 +16,7 @@ export const styles = StyleSheet.create({
   bottomBarWeb: {
     // @ts-ignore web-only
     position: 'fixed',
+    height: 60,
   },
   ctrl: {
     flex: 1,

--- a/src/view/shell/bottom-bar/BottomBarWeb.tsx
+++ b/src/view/shell/bottom-bar/BottomBarWeb.tsx
@@ -1,37 +1,39 @@
 import React from 'react'
-import {usePalette} from 'lib/hooks/usePalette'
-import {useNavigationState} from '@react-navigation/native'
+import {View} from 'react-native'
 import Animated from 'react-native-reanimated'
 import {useSafeAreaInsets} from 'react-native-safe-area-context'
-import {View} from 'react-native'
 import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
-import {getCurrentRoute, isTab} from 'lib/routes/helpers'
-import {styles} from './BottomBarStyles'
-import {clamp} from 'lib/numbers'
+import {useNavigationState} from '@react-navigation/native'
+
+import {useProfileQuery} from '#/state/queries/profile'
+import {useSession} from '#/state/session'
+import {useLoggedOutViewControls} from '#/state/shell/logged-out'
+import {useCloseAllActiveElements} from '#/state/util'
+import {useMinimalShellMode} from 'lib/hooks/useMinimalShellMode'
+import {usePalette} from 'lib/hooks/usePalette'
 import {
   BellIcon,
   BellIconSolid,
+  HashtagIcon,
   HomeIcon,
   HomeIconSolid,
   MagnifyingGlassIcon2,
   MagnifyingGlassIcon2Solid,
-  HashtagIcon,
-  UserIcon,
-  UserIconSolid,
 } from 'lib/icons'
-import {Link} from 'view/com/util/Link'
-import {useMinimalShellMode} from 'lib/hooks/useMinimalShellMode'
+import {clamp} from 'lib/numbers'
+import {getCurrentRoute, isTab} from 'lib/routes/helpers'
 import {makeProfileLink} from 'lib/routes/links'
 import {CommonNavigatorParams} from 'lib/routes/types'
-import {useSession} from '#/state/session'
-import {useLoggedOutViewControls} from '#/state/shell/logged-out'
-import {useCloseAllActiveElements} from '#/state/util'
+import {s} from 'lib/styles'
 import {Button} from '#/view/com/util/forms/Button'
 import {Text} from '#/view/com/util/text/Text'
-import {s} from 'lib/styles'
 import {Logo} from '#/view/icons/Logo'
 import {Logotype} from '#/view/icons/Logotype'
+import {Link} from 'view/com/util/Link'
+import {LoadingPlaceholder} from 'view/com/util/LoadingPlaceholder'
+import {UserAvatar} from 'view/com/util/UserAvatar'
+import {styles} from './BottomBarStyles'
 
 export function BottomBarWeb() {
   const {_} = useLingui()
@@ -127,16 +129,7 @@ export function BottomBarWeb() {
                       })
                     : '/'
                 }>
-                {({isActive}) => {
-                  const Icon = isActive ? UserIconSolid : UserIcon
-                  return (
-                    <Icon
-                      size={28}
-                      strokeWidth={1.5}
-                      style={[styles.ctrlIcon, pal.text, styles.profileIcon]}
-                    />
-                  )
-                }}
+                {({isActive}) => <ProfileIcon isActive={isActive} />}
               </NavItem>
             </>
           )}
@@ -186,6 +179,44 @@ export function BottomBarWeb() {
         </>
       )}
     </Animated.View>
+  )
+}
+
+function ProfileIcon({isActive}: {isActive: boolean}) {
+  const pal = usePalette('default')
+  return isActive ? (
+    <View
+      style={[
+        styles.ctrlIcon,
+        styles.profileIcon,
+        styles.onProfile,
+        {borderColor: pal.text.color},
+      ]}>
+      <ProfileIconInner size={24} />
+    </View>
+  ) : (
+    <View style={[styles.ctrlIcon, styles.profileIcon]}>
+      <ProfileIconInner size={28} />
+    </View>
+  )
+}
+
+function ProfileIconInner({size}: {size: number}) {
+  const {currentAccount} = useSession()
+  const {isLoading, data: profile} = useProfileQuery({did: currentAccount!.did})
+
+  return !isLoading && profile ? (
+    <UserAvatar
+      avatar={profile?.avatar}
+      size={size}
+      type={profile?.associated?.labeler ? 'labeler' : 'user'}
+    />
+  ) : (
+    <LoadingPlaceholder
+      width={size}
+      height={size}
+      style={{borderRadius: size}}
+    />
   )
 }
 

--- a/src/view/shell/bottom-bar/BottomBarWeb.tsx
+++ b/src/view/shell/bottom-bar/BottomBarWeb.tsx
@@ -177,10 +177,9 @@ function ProfileIcon({isActive}: {isActive: boolean}) {
       style={[
         styles.ctrlIcon,
         styles.profileIcon,
-        styles.onProfile,
         {borderColor: pal.text.color},
       ]}>
-      <ProfileIconInner size={24} />
+      <ProfileIconInner size={28} />
     </View>
   ) : (
     <View style={[styles.ctrlIcon, styles.profileIcon]}>

--- a/src/view/shell/bottom-bar/BottomBarWeb.tsx
+++ b/src/view/shell/bottom-bar/BottomBarWeb.tsx
@@ -172,18 +172,22 @@ export function BottomBarWeb() {
 
 function ProfileIcon({isActive}: {isActive: boolean}) {
   const pal = usePalette('default')
-  return isActive ? (
-    <View
-      style={[
-        styles.ctrlIcon,
-        styles.profileIcon,
-        {borderColor: pal.text.color},
-      ]}>
-      <ProfileIconInner size={28} />
-    </View>
-  ) : (
-    <View style={[styles.ctrlIcon, styles.profileIcon]}>
-      <ProfileIconInner size={28} />
+  return (
+    <View style={styles.ctrlIconSizingWrapper}>
+      {isActive ? (
+        <View
+          style={[
+            styles.ctrlIcon,
+            styles.profileIcon,
+            {borderColor: pal.text.color},
+          ]}>
+          <ProfileIconInner size={28} />
+        </View>
+      ) : (
+        <View style={[styles.ctrlIcon, styles.profileIcon]}>
+          <ProfileIconInner size={28} />
+        </View>
+      )}
     </View>
   )
 }

--- a/src/view/shell/bottom-bar/BottomBarWeb.tsx
+++ b/src/view/shell/bottom-bar/BottomBarWeb.tsx
@@ -71,11 +71,9 @@ export function BottomBarWeb() {
             {({isActive}) => {
               const Icon = isActive ? HomeIconSolid : HomeIcon
               return (
-                <Icon
-                  strokeWidth={4}
-                  size={24}
-                  style={[styles.ctrlIcon, pal.text, styles.homeIcon]}
-                />
+                <View style={[styles.ctrlIcon, pal.text, styles.homeIcon]}>
+                  <Icon strokeWidth={4} size={24} />
+                </View>
               )
             }}
           </NavItem>
@@ -85,54 +83,44 @@ export function BottomBarWeb() {
                 ? MagnifyingGlassIcon2Solid
                 : MagnifyingGlassIcon2
               return (
-                <Icon
-                  size={25}
-                  style={[styles.ctrlIcon, pal.text, styles.searchIcon]}
-                  strokeWidth={1.8}
-                />
+                <View style={[styles.ctrlIcon, pal.text, styles.searchIcon]}>
+                  <Icon size={25} strokeWidth={1.8} />
+                </View>
               )
             }}
           </NavItem>
 
-          {hasSession && (
-            <>
-              <NavItem routeName="Feeds" href="/feeds">
-                {({isActive}) => {
-                  return (
-                    <HashtagIcon
-                      size={22}
-                      style={[styles.ctrlIcon, pal.text, styles.feedsIcon]}
-                      strokeWidth={isActive ? 4 : 2.5}
-                    />
-                  )
-                }}
-              </NavItem>
-              <NavItem routeName="Notifications" href="/notifications">
-                {({isActive}) => {
-                  const Icon = isActive ? BellIconSolid : BellIcon
-                  return (
-                    <Icon
-                      size={24}
-                      strokeWidth={1.9}
-                      style={[styles.ctrlIcon, pal.text, styles.bellIcon]}
-                    />
-                  )
-                }}
-              </NavItem>
-              <NavItem
-                routeName="Profile"
-                href={
-                  currentAccount
-                    ? makeProfileLink({
-                        did: currentAccount.did,
-                        handle: currentAccount.handle,
-                      })
-                    : '/'
-                }>
-                {({isActive}) => <ProfileIcon isActive={isActive} />}
-              </NavItem>
-            </>
-          )}
+          <NavItem routeName="Feeds" href="/feeds">
+            {({isActive}) => {
+              return (
+                <View style={[styles.ctrlIcon, pal.text, styles.feedsIcon]}>
+                  <HashtagIcon size={22} strokeWidth={isActive ? 4 : 2.5} />
+                </View>
+              )
+            }}
+          </NavItem>
+          <NavItem routeName="Notifications" href="/notifications">
+            {({isActive}) => {
+              const Icon = isActive ? BellIconSolid : BellIcon
+              return (
+                <View style={[styles.ctrlIcon, pal.text, styles.bellIcon]}>
+                  <Icon size={24} strokeWidth={1.9} />
+                </View>
+              )
+            }}
+          </NavItem>
+          <NavItem
+            routeName="Profile"
+            href={
+              currentAccount
+                ? makeProfileLink({
+                    did: currentAccount.did,
+                    handle: currentAccount.handle,
+                  })
+                : '/'
+            }>
+            {({isActive}) => <ProfileIcon isActive={isActive} />}
+          </NavItem>
         </>
       ) : (
         <>


### PR DESCRIPTION
On current version of web, when width of browser is narrow, bottom bar is shown as follows: 

<Light, user profile not selected>
![current_light_1](https://github.com/bluesky-social/social-app/assets/7834440/e6272445-f577-4efe-907a-48b588b546d6)

<Light, user profile selected>
![current_light_2](https://github.com/bluesky-social/social-app/assets/7834440/1ab36dfc-1586-46b3-99ca-a276d1d6b140)

<Dark, user profile not selected>
![current_dark_1](https://github.com/bluesky-social/social-app/assets/7834440/319a31ca-7bff-406e-8b82-116bb612acc0)

<Dark, user profile selected>
![current_dark_2](https://github.com/bluesky-social/social-app/assets/7834440/087b65c1-3811-4946-97ae-a07a758e8ff9)

User profile icon is not shown on the bottom bar on the web version although shown on the iOS / Android version. Thus user cannot recognize current account by the profile icon.

I have implemented that user profile is shown on the web version same as iOS / Android version as follows:

<Light, user profile not selected>
![pr2_light1](https://github.com/bluesky-social/social-app/assets/7834440/fd1884fc-5d04-490d-8c0a-e84b7ce3f9da)

<Light, user profile selected>
![pr2_light2](https://github.com/bluesky-social/social-app/assets/7834440/43839e6f-6a29-42d4-8521-27b5880f51bb)

<Dark, user profile not selected>
![pr2_dark1](https://github.com/bluesky-social/social-app/assets/7834440/9285e8a7-1237-43c9-9016-c4f7e808e3ea)

<Dark, user profile selected>
![pr2_dark2](https://github.com/bluesky-social/social-app/assets/7834440/a0b16a19-0d76-4bf1-8104-fd0ec79e7c60)

Along with this fix, some additional fix has been applied as follows: 

+ I have changed the border width when a user profile is selected from 1px to 2px. This is because border do not display correctly in lower resolution environments (ex. low-end smartphones and 96dpi PCs). This change has been applied both web (`BottomBarWeb.tsx`) and app (`BottomBar.tsx`) version of bottom bar.

+ In current version, `top` style setting in `BottomBarStyles.tsx` is not applied correctly to each `<Icon>` in `BottomBarWeb.tsx`. Because `<Icon>` is rendered to `<svg>` on the web page, and `top` style setting to `<svg>` is ignored. To fix this, I have wrapped each `<Icon>` with `<View>` and apply style to the `<View>`.

+ Redundant nested `{hasSession ...` clause in `BottomBarWeb` function in `BottomBarWeb.tsx` has been deleted.

+ ~~Behavior that height of bottom bar vary slightly by selecting icon buttons has been observerd in some environment (ex. my Lenovo IdeaPad Duet Chromebook). To fix it, height of bottom bar has been specified explicitly with `bottomBarWeb` in `BottomBarStyles.tsx`.~~
-> As a result of fine tune, explicit definition of height is not needed now. 

[Note] Please review and confirm this modification based on these points:

+ I have confirmed this modification on Web (PC), Android (real device) and iOS (simulator). I cannot confirm on real iOS device because I do not own it. 
+ I have confirmed by using my personal Bluesky account, but I cannot confirm by using labeler account. 