### PR TITLE
Mark `Retry` and `Go Back` buttons in Error.tsx for localisation

### DIFF
--- a/src/components/Error.tsx
+++ b/src/components/Error.tsx
@@ -1,16 +1,16 @@
 import React from 'react'
 import {View} from 'react-native'
+import {useNavigation} from '@react-navigation/core'
+import {StackActions} from '@react-navigation/native'
 import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
-import {useNavigation} from '@react-navigation/core'
-import {StackActions} from '@react-navigation/native'
+import {NavigationProp} from 'lib/routes/types'
+import {CenteredView} from 'view/com/util/Views'
 import {atoms as a, useBreakpoints, useTheme} from '#/alf'
 import {Button, ButtonText} from '#/components/Button'
 import {Text} from '#/components/Typography'
 import {router} from '#/routes'
-import {NavigationProp} from 'lib/routes/types'
-import {CenteredView} from 'view/com/util/Views'
 
 export function Error({
   title,

--- a/src/components/Error.tsx
+++ b/src/components/Error.tsx
@@ -68,21 +68,25 @@ export function Error({
           <Button
             variant="solid"
             color="primary"
-            label="Click here"
+            label={_(msg`Press to retry`)}
             onPress={onRetry}
             size="large"
             style={[a.rounded_sm, a.overflow_hidden, {paddingVertical: 10}]}>
-            Retry
+            <ButtonText>
+              <Trans>Retry</Trans>
+            </ButtonText>
           </Button>
         )}
         <Button
           variant="solid"
           color={onRetry ? 'secondary' : 'primary'}
-          label="Click here"
+          label={_(msg`Return to previous page`)}
           onPress={onGoBack}
           size="large"
           style={[a.rounded_sm, a.overflow_hidden, {paddingVertical: 10}]}>
-          Go Back
+          <ButtonText>
+            <Trans>Go Back</Trans>
+          </ButtonText>
         </Button>
       </View>
     </CenteredView>

--- a/src/components/Error.tsx
+++ b/src/components/Error.tsx
@@ -1,14 +1,16 @@
 import React from 'react'
-
-import {CenteredView} from 'view/com/util/Views'
-import {atoms as a, useBreakpoints, useTheme} from '#/alf'
-import {Text} from '#/components/Typography'
 import {View} from 'react-native'
-import {Button} from '#/components/Button'
+import {msg, Trans} from '@lingui/macro'
+import {useLingui} from '@lingui/react'
+
 import {useNavigation} from '@react-navigation/core'
-import {NavigationProp} from 'lib/routes/types'
 import {StackActions} from '@react-navigation/native'
+import {atoms as a, useBreakpoints, useTheme} from '#/alf'
+import {Button, ButtonText} from '#/components/Button'
+import {Text} from '#/components/Typography'
 import {router} from '#/routes'
+import {NavigationProp} from 'lib/routes/types'
+import {CenteredView} from 'view/com/util/Views'
 
 export function Error({
   title,
@@ -20,6 +22,7 @@ export function Error({
   onRetry?: () => unknown
 }) {
   const navigation = useNavigation<NavigationProp>()
+  const {_} = useLingui()
   const t = useTheme()
   const {gtMobile} = useBreakpoints()
 


### PR DESCRIPTION
This PR marks the `Retry` and `Go Back` buttons in Error.tsx for localisation and updates their labels.

edit: I hope I got the imports (and the `useLingui()` export) right 🤞  The linter stopped giving me errors, at least.