### PR TITLE
Clicking in search box selects entire text #3349

### DIFF
--- a/src/view/com/util/forms/SearchInput.tsx
+++ b/src/view/com/util/forms/SearchInput.tsx
@@ -66,7 +66,7 @@ export const SearchInput = React.forwardRef<SearchInputRef, Props>(
           ref={textInput}
           placeholder={_(msg`Search`)}
           placeholderTextColor={pal.colors.textLight}
-          selectTextOnFocus
+          // selectTextOnFocus
           returnKeyType="search"
           value={query}
           style={[pal.text, styles.input]}


### PR DESCRIPTION
clicking inside the search box should no longer select the entire text, and it should behave as expected, placing the cursor at the clicked position.