### PR TITLE
disable inline predictions to prevent ios composer jank

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bsky.app",
-  "version": "1.75.0",
+  "version": "1.76.0",
   "private": true,
   "engines": {
     "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bsky.app",
-  "version": "1.76.0",
+  "version": "1.75.0",
   "private": true,
   "engines": {
     "node": ">=18"

--- a/patches/@mattermost+react-native-paste-input+0.6.4.patch
+++ b/patches/@mattermost+react-native-paste-input+0.6.4.patch
@@ -3594,3 +3594,19 @@ index 19b61ff..04a9951 100644
  PasteInput_compileSdkVersion=30
  PasteInput_buildToolsVersion=30.0.2
  PasteInput_targetSdkVersion=30
+diff --git a/node_modules/@mattermost/react-native-paste-input/ios/PasteInputView.m b/node_modules/@mattermost/react-native-paste-input/ios/PasteInputView.m
+index e916023..0564d97 100644
+--- a/node_modules/@mattermost/react-native-paste-input/ios/PasteInputView.m
++++ b/node_modules/@mattermost/react-native-paste-input/ios/PasteInputView.m
+@@ -22,6 +22,11 @@ - (instancetype)initWithBridge:(RCTBridge *)bridge
+     _backedTextInputView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
+     _backedTextInputView.textInputDelegate = self;
+     
++    // Disable inline predictions to prevent jank in the composer
++    if (@available(iOS 17.0, *)) {
++      _backedTextInputView.inlinePredictionType = UITextInlinePredictionTypeNo;
++    }
++
+     [self addSubview:_backedTextInputView];
+   }
+ 


### PR DESCRIPTION
## Why

Inline predictions are causing some pretty bad jank with the post composer. This patch disables those suggestions. This is fairly common on other apps, so disabling it should not cause any issues for users.