### PR TITLE
Remove Button error boundary

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -14,7 +14,6 @@ import {
 import LinearGradient from 'react-native-linear-gradient'
 import {Trans} from '@lingui/macro'
 
-import {logger} from '#/logger'
 import {android, atoms as a, flatten, tokens, useTheme} from '#/alf'
 import {Props as SVGIconProps} from '#/components/icons/common'
 import {normalizeTextStyles} from '#/components/Typography'
@@ -405,49 +404,18 @@ export function Button({
         </View>
       )}
       <Context.Provider value={context}>
-        <ButtonTextErrorBoundary>
-          {/* @ts-ignore */}
-          {typeof children === 'string' || children?.type === Trans ? (
-            /* @ts-ignore */
-            <ButtonText>{children}</ButtonText>
-          ) : typeof children === 'function' ? (
-            children(context)
-          ) : (
-            children
-          )}
-        </ButtonTextErrorBoundary>
+        {/* @ts-ignore */}
+        {typeof children === 'string' || children?.type === Trans ? (
+          /* @ts-ignore */
+          <ButtonText>{children}</ButtonText>
+        ) : typeof children === 'function' ? (
+          children(context)
+        ) : (
+          children
+        )}
       </Context.Provider>
     </Pressable>
   )
-}
-
-export class ButtonTextErrorBoundary extends React.Component<
-  React.PropsWithChildren<{}>,
-  {hasError: boolean; error: Error | undefined}
-> {
-  public state = {
-    hasError: false,
-    error: undefined,
-  }
-
-  public static getDerivedStateFromError(error: Error) {
-    return {hasError: true, error}
-  }
-
-  public componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
-    logger.error('ButtonTextErrorBoundary caught an error', {
-      message: error.message,
-      errorInfo,
-    })
-  }
-
-  public render() {
-    if (this.state.hasError) {
-      return <ButtonText>ERROR</ButtonText>
-    }
-
-    return this.props.children
-  }
 }
 
 export function useSharedButtonTextStyles() {


### PR DESCRIPTION
We've added an error boundary _inside_ each button in https://github.com/bluesky-social/social-app/pull/3340 in case there are some existing places in the app where we accidentally render raw text inside (not wrapped in `<ButtonText>`) which would lead to a crash. In that case, the error boundary would display "ERROR" inside the button instead. 

Let's remove this.

## Why it's ok to remove now

The release including this fix has largely propagated:

<img width="723" alt="Screenshot 2024-04-01 at 19 02 57" src="https://github.com/bluesky-social/social-app/assets/810438/0048e966-8ac5-44cd-97b7-82fc7c766c15">

We are not observing any related logs in Sentry:

<img width="973" alt="Screenshot 2024-04-01 at 19 03 34" src="https://github.com/bluesky-social/social-app/assets/810438/e5f63d10-057e-4ac3-80aa-7ca8c3c4b6b4">

## Why we shouldn't re-add this

It's confusing if a button just says `ERROR`. You might even do a destructive action (e.g. deletion) because you're not aware what the button actually does. We shouldn't be showing buttons without real labels:

<img width="608" alt="Screenshot 2024-04-01 at 19 35 53" src="https://github.com/bluesky-social/social-app/assets/810438/411c9b69-752f-4293-a528-3681039f17e9">

<img width="622" alt="Screenshot 2024-04-01 at 19 37 06" src="https://github.com/bluesky-social/social-app/assets/810438/1d8ae610-a217-441c-94d7-84ece02bb921">

In general, defensive coding can be helpful for working around issues in short term, but it makes it harder to understand where the points of failure are, and gradually leads to more bugs being introduced unknowingly.

And of course this doesn't catch issues with any other components so it's a pretty narrow fix.

Instead, there are a few things we could do:

- Add sensible error boundaries for major UI elements. E.g. "something went wrong" around big screen areas. This requires some design consideration because they actually need to look decent in the UI.
- (Maybe:) Stop using `<Trans>` in favor of `_(msg``)`. The benefit of this is that strings will be typed as strings, instead of being sometimes strings and sometimes React elements (as it happens now). This would let us start enforcing that some components don't take strings as children. It's still not protecting against extracting `<Foo>` which then returns raw text, but it's a decent start which should catch most cases.
- We could also use linting more heavily, for example we could adapt [this rule](https://github.com/Intellicode/eslint-plugin-react-native/blob/master/lib/rules/no-raw-text.js) or [this rule](https://www.npmjs.com/package/eslint-plugin-lingui#no-unlocalized-strings) to our needs. There may be some simple middle ground where we don't try to catch all cases but instead make our own rule that's specific to some convention that we use in our design components.

I think none of this should be blocking the removal of the error boundary though.