### PR TITLE
"Fix issue #3366:Populate the search box

### DIFF
--- a/src/view/screens/Search/Search.tsx
+++ b/src/view/screens/Search/Search.tsx
@@ -678,7 +678,7 @@ export function SearchScreen(
               // HACK
               // give 100ms to not stop click handlers in the search history
               // -prf
-              setTimeout(() => setInputIsFocused(false), 100)
+              setTimeout(() => setInputIsFocused(false), 250)
             }}
             onChangeText={onChangeText}
             onSubmitEditing={onSubmit}

--- a/src/view/screens/Search/Search.tsx
+++ b/src/view/screens/Search/Search.tsx
@@ -668,7 +668,7 @@ export function SearchScreen(
             ref={textInput}
             placeholder={_(msg`Search`)}
             placeholderTextColor={pal.colors.textLight}
-            selectTextOnFocus
+            
             returnKeyType="search"
             value={query}
             style={[pal.text, styles.headerSearchInput]}


### PR DESCRIPTION
The search page will be populated with the selected search terms and a search begins.

 clicking the x to delete the entry  work fine now.
 
 The issue was that as soon as the button or the link was clicked the setIsFocussed became false, which resulted in unexpected behaviour.
 
 Solution : Increased the time of the setIsFocussed to 250ms  instead of 100ms.