### PR TITLE
don't fetch from origin if unnecessary when performing OTA deploy

### DIFF
--- a/.github/workflows/bundle-deploy-eas-update.yml
+++ b/.github/workflows/bundle-deploy-eas-update.yml
@@ -46,6 +46,7 @@ jobs:
           fetch-depth: 100
 
       - name: ⬇️ Fetch commits from base branch
+        if: ${{ github.ref != 'refs/heads/main' }}
         run: git fetch origin main:main --depth 100
 
       # This should get the current production release's commit's hash to see if the update is compatible

--- a/.github/workflows/bundle-deploy-eas-update.yml
+++ b/.github/workflows/bundle-deploy-eas-update.yml
@@ -2,6 +2,9 @@
 name: Bundle and Deploy EAS Update
 
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       channel:


### PR DESCRIPTION
We don't need to fetch from origin/main if we are already on the main branch. This results in an error if we try to.

Eventually we can actually just remove this step completely, but I want to leave it here as we continue testing since we might have separate branches that we want the action to run on.