### PR TITLE
[Session] Root

### DIFF
--- a/src/App.native.tsx
+++ b/src/App.native.tsx
@@ -16,7 +16,6 @@ import {useQueryClient} from '@tanstack/react-query'
 
 import {Provider as StatsigProvider} from '#/lib/statsig/statsig'
 import {init as initPersistedState} from '#/state/persisted'
-import * as persisted from '#/state/persisted'
 import {Provider as LabelDefsProvider} from '#/state/preferences/label-defs'
 import {useIntentHandler} from 'lib/hooks/useIntentHandler'
 import {useOTAUpdates} from 'lib/hooks/useOTAUpdates'
@@ -33,6 +32,7 @@ import {Provider as PrefsStateProvider} from 'state/preferences'
 import {Provider as UnreadNotifsProvider} from 'state/queries/notifications/unread'
 import {
   Provider as SessionProvider,
+  readLastActiveAccount,
   useSession,
   useSessionApi,
 } from 'state/session'
@@ -66,7 +66,7 @@ function InnerApp() {
       Toast.show(_(msg`Sorry! Your session expired. Please log in again.`))
     })
 
-    const account = persisted.get('session').currentAccount
+    const account = readLastActiveAccount()
     resumeSession(account)
   }, [resumeSession, _])
 

--- a/src/App.native.tsx
+++ b/src/App.native.tsx
@@ -17,6 +17,12 @@ import {useQueryClient} from '@tanstack/react-query'
 import {Provider as StatsigProvider} from '#/lib/statsig/statsig'
 import {init as initPersistedState} from '#/state/persisted'
 import {Provider as LabelDefsProvider} from '#/state/preferences/label-defs'
+import {
+  Provider as SessionProvider,
+  useSession,
+  useSessionApi,
+} from '#/state/session'
+import {readLastActiveAccount} from '#/state/session/util'
 import {useIntentHandler} from 'lib/hooks/useIntentHandler'
 import {useOTAUpdates} from 'lib/hooks/useOTAUpdates'
 import {useNotificationsListener} from 'lib/notifications/notifications'
@@ -30,12 +36,6 @@ import {Provider as ModalStateProvider} from 'state/modals'
 import {Provider as MutedThreadsProvider} from 'state/muted-threads'
 import {Provider as PrefsStateProvider} from 'state/preferences'
 import {Provider as UnreadNotifsProvider} from 'state/queries/notifications/unread'
-import {
-  Provider as SessionProvider,
-  readLastActiveAccount,
-  useSession,
-  useSessionApi,
-} from 'state/session'
 import {Provider as ShellStateProvider} from 'state/shell'
 import {Provider as LoggedOutViewProvider} from 'state/shell/logged-out'
 import {Provider as SelectedFeedProvider} from 'state/shell/selected-feed'

--- a/src/App.web.tsx
+++ b/src/App.web.tsx
@@ -7,7 +7,6 @@ import {SafeAreaProvider} from 'react-native-safe-area-context'
 
 import {Provider as StatsigProvider} from '#/lib/statsig/statsig'
 import {init as initPersistedState} from '#/state/persisted'
-import * as persisted from '#/state/persisted'
 import {Provider as LabelDefsProvider} from '#/state/preferences/label-defs'
 import {useIntentHandler} from 'lib/hooks/useIntentHandler'
 import {QueryProvider} from 'lib/react-query'
@@ -21,6 +20,7 @@ import {Provider as PrefsStateProvider} from 'state/preferences'
 import {Provider as UnreadNotifsProvider} from 'state/queries/notifications/unread'
 import {
   Provider as SessionProvider,
+  readLastActiveAccount,
   useSession,
   useSessionApi,
 } from 'state/session'
@@ -42,7 +42,7 @@ function InnerApp() {
 
   // init
   useEffect(() => {
-    const account = persisted.get('session').currentAccount
+    const account = readLastActiveAccount()
     resumeSession(account)
   }, [resumeSession])
 

--- a/src/App.web.tsx
+++ b/src/App.web.tsx
@@ -8,6 +8,12 @@ import {SafeAreaProvider} from 'react-native-safe-area-context'
 import {Provider as StatsigProvider} from '#/lib/statsig/statsig'
 import {init as initPersistedState} from '#/state/persisted'
 import {Provider as LabelDefsProvider} from '#/state/preferences/label-defs'
+import {
+  Provider as SessionProvider,
+  useSession,
+  useSessionApi,
+} from '#/state/session'
+import {readLastActiveAccount} from '#/state/session/util'
 import {useIntentHandler} from 'lib/hooks/useIntentHandler'
 import {QueryProvider} from 'lib/react-query'
 import {ThemeProvider} from 'lib/ThemeContext'
@@ -18,12 +24,6 @@ import {Provider as ModalStateProvider} from 'state/modals'
 import {Provider as MutedThreadsProvider} from 'state/muted-threads'
 import {Provider as PrefsStateProvider} from 'state/preferences'
 import {Provider as UnreadNotifsProvider} from 'state/queries/notifications/unread'
-import {
-  Provider as SessionProvider,
-  readLastActiveAccount,
-  useSession,
-  useSessionApi,
-} from 'state/session'
 import {Provider as ShellStateProvider} from 'state/shell'
 import {Provider as LoggedOutViewProvider} from 'state/shell/logged-out'
 import {Provider as SelectedFeedProvider} from 'state/shell/selected-feed'

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -4,6 +4,7 @@ export const LOCAL_DEV_SERVICE =
   Platform.OS === 'android' ? 'http://10.0.2.2:2583' : 'http://localhost:2583'
 export const STAGING_SERVICE = 'https://staging.bsky.dev'
 export const BSKY_SERVICE = 'https://bsky.social'
+export const PUBLIC_BSKY_SERVICE = 'https://public.api.bsky.app'
 export const DEFAULT_SERVICE = BSKY_SERVICE
 const HELP_DESK_LANG = 'en-us'
 export const HELP_DESK_URL = `https://blueskyweb.zendesk.com/hc/${HELP_DESK_LANG}`

--- a/src/lib/hooks/useAccountSwitcher.ts
+++ b/src/lib/hooks/useAccountSwitcher.ts
@@ -1,11 +1,12 @@
 import {useCallback} from 'react'
 
-import {isWeb} from '#/platform/detection'
 import {useAnalytics} from '#/lib/analytics/analytics'
-import {useSessionApi, SessionAccount} from '#/state/session'
-import * as Toast from '#/view/com/util/Toast'
-import {useCloseAllActiveElements} from '#/state/util'
+import {logger} from '#/logger'
+import {isWeb} from '#/platform/detection'
+import {SessionAccount, useSessionApi} from '#/state/session'
 import {useLoggedOutViewControls} from '#/state/shell/logged-out'
+import {useCloseAllActiveElements} from '#/state/util'
+import * as Toast from '#/view/com/util/Toast'
 import {LogEvents} from '../statsig/statsig'
 
 export function useAccountSwitcher() {
@@ -44,9 +45,14 @@ export function useAccountSwitcher() {
             'circle-exclamation',
           )
         }
-      } catch (e) {
-        Toast.show('Sorry! We need you to enter your password.')
+      } catch (e: any) {
+        logger.error(`switch account: selectAccount failed`, {
+          message: e.message,
+        })
         clearCurrentAccount() // back user out to login
+        setTimeout(() => {
+          Toast.show('Sorry! We need you to enter your password.')
+        }, 100)
       }
     },
     [

--- a/src/screens/Login/ChooseAccountForm.tsx
+++ b/src/screens/Login/ChooseAccountForm.tsx
@@ -5,6 +5,7 @@ import {useLingui} from '@lingui/react'
 
 import {useAnalytics} from '#/lib/analytics/analytics'
 import {logEvent} from '#/lib/statsig/statsig'
+import {logger} from '#/logger'
 import {SessionAccount, useSession, useSessionApi} from '#/state/session'
 import {useLoggedOutViewControls} from '#/state/shell/logged-out'
 import * as Toast from '#/view/com/util/Toast'
@@ -38,15 +39,22 @@ export const ChooseAccountForm = ({
           setShowLoggedOut(false)
           Toast.show(_(msg`Already signed in as @${account.handle}`))
         } else {
-          await initSession(account)
-          logEvent('account:loggedIn', {
-            logContext: 'ChooseAccountForm',
-            withPassword: false,
-          })
-          track('Sign In', {resumedSession: true})
-          setTimeout(() => {
-            Toast.show(_(msg`Signed in as @${account.handle}`))
-          }, 100)
+          try {
+            await initSession(account)
+            logEvent('account:loggedIn', {
+              logContext: 'ChooseAccountForm',
+              withPassword: false,
+            })
+            track('Sign In', {resumedSession: true})
+            setTimeout(() => {
+              Toast.show(_(msg`Signed in as @${account.handle}`))
+            }, 100)
+          } catch (e: any) {
+            logger.error('choose account: initSession failed', {
+              message: e.message,
+            })
+            onSelectAccount(account)
+          }
         }
       } else {
         onSelectAccount(account)

--- a/src/state/persisted/index.ts
+++ b/src/state/persisted/index.ts
@@ -6,11 +6,7 @@ import {migrate} from '#/state/persisted/legacy'
 import {defaults, Schema} from '#/state/persisted/schema'
 import * as store from '#/state/persisted/store'
 
-export type {
-  PersistedAccount,
-  PersistedCurrentAccount,
-  Schema,
-} from '#/state/persisted/schema'
+export type {PersistedAccount, Schema} from '#/state/persisted/schema'
 export {defaults} from '#/state/persisted/schema'
 
 const broadcast = new BroadcastChannel('BSKY_BROADCAST_CHANNEL')

--- a/src/state/persisted/index.ts
+++ b/src/state/persisted/index.ts
@@ -1,11 +1,16 @@
 import EventEmitter from 'eventemitter3'
-import {logger} from '#/logger'
-import {defaults, Schema} from '#/state/persisted/schema'
-import {migrate} from '#/state/persisted/legacy'
-import * as store from '#/state/persisted/store'
-import BroadcastChannel from '#/lib/broadcast'
 
-export type {Schema, PersistedAccount} from '#/state/persisted/schema'
+import BroadcastChannel from '#/lib/broadcast'
+import {logger} from '#/logger'
+import {migrate} from '#/state/persisted/legacy'
+import {defaults, Schema} from '#/state/persisted/schema'
+import * as store from '#/state/persisted/store'
+
+export type {
+  PersistedAccount,
+  PersistedCurrentAccount,
+  Schema,
+} from '#/state/persisted/schema'
 export {defaults} from '#/state/persisted/schema'
 
 const broadcast = new BroadcastChannel('BSKY_BROADCAST_CHANNEL')

--- a/src/state/persisted/schema.ts
+++ b/src/state/persisted/schema.ts
@@ -1,4 +1,5 @@
 import {z} from 'zod'
+
 import {deviceLocales} from '#/platform/detection'
 
 const externalEmbedOptions = ['show', 'hide'] as const
@@ -16,12 +17,17 @@ const accountSchema = z.object({
 })
 export type PersistedAccount = z.infer<typeof accountSchema>
 
+const currentAccountSchema = z.object({
+  did: z.string(),
+})
+export type PersistedCurrentAccount = z.infer<typeof currentAccountSchema>
+
 export const schema = z.object({
   colorMode: z.enum(['system', 'light', 'dark']),
   darkTheme: z.enum(['dim', 'dark']).optional(),
   session: z.object({
     accounts: z.array(accountSchema),
-    currentAccount: accountSchema.optional(),
+    currentAccount: currentAccountSchema.optional(),
   }),
   reminders: z.object({
     lastEmailConfirm: z.string().optional(),

--- a/src/state/persisted/schema.ts
+++ b/src/state/persisted/schema.ts
@@ -4,7 +4,10 @@ import {deviceLocales} from '#/platform/detection'
 
 const externalEmbedOptions = ['show', 'hide'] as const
 
-// only data needed for rendering account page
+/**
+ * A account persisted to storage. Stored in the `accounts[]` array. Contains
+ * base account info and access tokens.
+ */
 const accountSchema = z.object({
   service: z.string(),
   did: z.string(),
@@ -17,17 +20,25 @@ const accountSchema = z.object({
 })
 export type PersistedAccount = z.infer<typeof accountSchema>
 
-const currentAccountSchema = z.object({
-  did: z.string(),
+/**
+ * The current account. Stored in the `currentAccount` field.
+ *
+ * In previous versions, this included tokens and other info. Now, it's used
+ * only to reference the `did` field, and all other fields are marked as
+ * optional. They should be considered deprecated and not used, but are kept
+ * here for backwards compat.
+ */
+const currentAccountScheme = accountSchema.extend({
+  service: z.string().optional(),
+  handle: z.string().optional(),
 })
-export type PersistedCurrentAccount = z.infer<typeof currentAccountSchema>
 
 export const schema = z.object({
   colorMode: z.enum(['system', 'light', 'dark']),
   darkTheme: z.enum(['dim', 'dark']).optional(),
   session: z.object({
     accounts: z.array(accountSchema),
-    currentAccount: currentAccountSchema.optional(),
+    currentAccount: currentAccountScheme.optional(),
   }),
   reminders: z.object({
     lastEmailConfirm: z.string().optional(),

--- a/src/state/queries/index.ts
+++ b/src/state/queries/index.ts
@@ -1,7 +1,9 @@
 import {BskyAgent} from '@atproto/api'
 
+import {PUBLIC_BSKY_SERVICE} from '#/lib/constants'
+
 export const PUBLIC_BSKY_AGENT = new BskyAgent({
-  service: 'https://public.api.bsky.app',
+  service: PUBLIC_BSKY_SERVICE,
 })
 
 export const STALE = {

--- a/src/state/session/index.tsx
+++ b/src/state/session/index.tsx
@@ -274,6 +274,9 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
         createPersistSessionHandler(
           account,
           ({expired, refreshedAccount}) => {
+            if (expired) {
+              __globalAgent = PUBLIC_BSKY_AGENT
+            }
             upsertAccount(refreshedAccount, expired)
           },
           {networkErrorCallback: clearCurrentAccount},
@@ -319,6 +322,9 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
         createPersistSessionHandler(
           account,
           ({expired, refreshedAccount}) => {
+            if (expired) {
+              __globalAgent = PUBLIC_BSKY_AGENT
+            }
             upsertAccount(refreshedAccount, expired)
           },
           {networkErrorCallback: clearCurrentAccount},
@@ -364,8 +370,13 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
         persistSession: createPersistSessionHandler(
           account,
           async ({expired, refreshedAccount}) => {
-            __globalAgent = agent
-            await configureModeration(agent, account)
+            if (expired) {
+              __globalAgent = PUBLIC_BSKY_AGENT
+            } else {
+              __globalAgent = agent
+              await configureModeration(agent, account)
+            }
+
             upsertAccount(refreshedAccount, expired)
           },
           {networkErrorCallback: clearCurrentAccount},

--- a/src/state/session/index.tsx
+++ b/src/state/session/index.tsx
@@ -578,7 +578,6 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
       setState(s => ({
         ...s,
         accounts: session.accounts,
-        currentAccount: session.currentAccount,
       }))
     })
   }, [state, setState, clearCurrentAccount, initSession])

--- a/src/state/session/index.tsx
+++ b/src/state/session/index.tsx
@@ -371,6 +371,10 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
     upsertAndPersistAccount,
   ])
 
+  const updateCurrentAccount = React.useCallback(async () => {
+    await refreshSession()
+  }, [refreshSession])
+
   const selectAccount = React.useCallback<SessionApiContext['selectAccount']>(
     async (account, logContext) => {
       setIsSwitchingAccounts(true)
@@ -504,6 +508,7 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
       selectAccount,
       refreshSession,
       clearCurrentAccount,
+      updateCurrentAccount,
     }),
     [
       createAccount,
@@ -515,6 +520,7 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
       selectAccount,
       refreshSession,
       clearCurrentAccount,
+      updateCurrentAccount,
     ],
   )
 

--- a/src/state/session/index.tsx
+++ b/src/state/session/index.tsx
@@ -12,10 +12,12 @@ import {IS_TEST_USER} from '#/lib/constants'
 import {logEvent, LogEvents} from '#/lib/statsig/statsig'
 import {hasProp} from '#/lib/type-guards'
 import {logger} from '#/logger'
+import {isWeb} from '#/platform/detection'
 import * as persisted from '#/state/persisted'
 import {PUBLIC_BSKY_AGENT} from '#/state/queries'
 import {useLoggedOutViewControls} from '#/state/shell/logged-out'
 import {useCloseAllActiveElements} from '#/state/util'
+import {IS_DEV} from '#/env'
 import {emitSessionDropped} from '../events'
 import {readLabelers} from './agent-config'
 
@@ -587,6 +589,11 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
 
   // as we migrate, continue to keep this updated
   __globalAgent = agent
+
+  if (IS_DEV && isWeb) {
+    // @ts-ignore
+    window.agent = agent
+  }
 
   return (
     <StateContext.Provider value={stateContext}>

--- a/src/state/session/index.tsx
+++ b/src/state/session/index.tsx
@@ -216,7 +216,6 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
         return
       }
 
-      // TODO this will get stale with agent.clone()
       const refreshedAccount = agentToSessionAccount(currentAgent)
 
       if (!refreshedAccount) {

--- a/src/state/session/index.tsx
+++ b/src/state/session/index.tsx
@@ -419,15 +419,9 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
           await networkRetry(1, () => agent.resumeSession(prevSession))
           setCurrentAgent(agent)
         } catch (e) {
+          // this can fail on bad connections as well, so `clearCurrentAccount`
+          // bumps them out to login, but doesn't rug tokens
           logger.error(`session: resumeSession failed`, {message: e})
-          // TODO flaky connectin could cause this too
-          setAccounts(accounts => {
-            return accounts.map(a =>
-              a.did === account.did
-                ? {...a, accessJwt: undefined, refreshJwt: undefined}
-                : a,
-            )
-          })
           clearCurrentAccount()
         }
       }

--- a/src/state/session/index.tsx
+++ b/src/state/session/index.tsx
@@ -466,11 +466,12 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
   const refreshSession = React.useCallback<
     ApiContext['refreshSession']
   >(async () => {
-    await agent.refreshSession()
+    if (!currentAccount) return
+    await agent.resumeSession(sessionAccountToAgentSession(currentAccount)!)
     persistNextUpdate()
     upsertAccount(agentToSessionAccount(agent)!)
     setAgent(agent.clone())
-  }, [agent, setAgent, persistNextUpdate, upsertAccount])
+  }, [currentAccount, agent, setAgent, persistNextUpdate, upsertAccount])
 
   const selectAccount = React.useCallback<ApiContext['selectAccount']>(
     async (account, logContext) => {

--- a/src/state/session/index.tsx
+++ b/src/state/session/index.tsx
@@ -213,6 +213,7 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
         console.log('PERSIST', window.__id, {
           event,
           refreshJwt: session?.refreshJwt?.slice(-10),
+          agent: agent.session?.refreshJwt.slice(-10),
         })
 
         const expired = event === 'expired' || event === 'create-failed'
@@ -226,7 +227,6 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
           return
         }
 
-        agent.session = session
         const refreshedAccount = agentToSessionAccount(agent)
 
         if (!refreshedAccount) {
@@ -414,19 +414,12 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
           {},
           logger.DebugContext.session,
         )
-        try {
-          // will call `persistSession` on `BskyAgent` instance above if success
-          await networkRetry(1, () => agent.resumeSession(prevSession))
-          setCurrentAgent(agent)
-        } catch (e) {
-          // this can fail on bad connections as well, so `clearCurrentAccount`
-          // bumps them out to login, but doesn't rug tokens
-          logger.error(`session: resumeSession failed`, {message: e})
-          clearCurrentAccount()
-        }
+        // will call `persistSession` on `BskyAgent` instance above if success
+        await networkRetry(1, () => agent.resumeSession(prevSession))
+        setCurrentAgent(agent)
       }
     },
-    [upsertAndPersistAccount, clearCurrentAccount, persistSession],
+    [upsertAndPersistAccount, persistSession],
   )
 
   const resumeSession = React.useCallback<ApiContext['resumeSession']>(

--- a/src/state/session/index.tsx
+++ b/src/state/session/index.tsx
@@ -192,11 +192,11 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
   )
 
   const setCurrentAccount = React.useCallback(
-    (account: SessionAccount, expired = false) => {
+    (account: SessionAccount) => {
       setStateAndPersist(s => {
         return {
           ...s,
-          currentAccount: expired ? undefined : account,
+          currentAccount: account,
           accounts: [account, ...s.accounts.filter(a => a.did !== account.did)],
         }
       })
@@ -277,8 +277,9 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
           ({expired, refreshedAccount}) => {
             if (expired) {
               clearCurrentAccount()
+            } else {
+              setCurrentAccount(refreshedAccount)
             }
-            setCurrentAccount(refreshedAccount, expired)
           },
           {networkErrorCallback: clearCurrentAccount},
         ),
@@ -325,8 +326,9 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
           ({expired, refreshedAccount}) => {
             if (expired) {
               clearCurrentAccount()
+            } else {
+              setCurrentAccount(refreshedAccount)
             }
-            setCurrentAccount(refreshedAccount, expired)
           },
           {networkErrorCallback: clearCurrentAccount},
         ),
@@ -375,7 +377,7 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
               clearCurrentAccount()
             } else {
               __globalAgent = agent
-              setCurrentAccount(refreshedAccount, expired)
+              setCurrentAccount(refreshedAccount)
             }
           },
           {networkErrorCallback: clearCurrentAccount},

--- a/src/state/session/index.tsx
+++ b/src/state/session/index.tsx
@@ -398,6 +398,13 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
           setAgent(agent)
         } catch (e) {
           logger.error(`session: resumeSession failed`, {message: e})
+          setAccounts(accounts => {
+            return accounts.map(a =>
+              a.did === account.did
+                ? {...a, accessJwt: undefined, refreshJwt: undefined}
+                : a,
+            )
+          })
           clearCurrentAccount()
         }
       }

--- a/src/state/session/types.ts
+++ b/src/state/session/types.ts
@@ -77,4 +77,12 @@ export type SessionApiContext = {
    * Refreshes the BskyAgent's session and derive a fresh `currentAccount`
    */
   refreshSession: () => void
+  /**
+   * @deprecated Use `refreshSession` instead.
+   */
+  updateCurrentAccount: (
+    account: Partial<
+      Pick<SessionAccount, 'handle' | 'email' | 'emailConfirmed'>
+    >,
+  ) => void
 }

--- a/src/state/session/types.ts
+++ b/src/state/session/types.ts
@@ -1,0 +1,80 @@
+import {BskyAgent} from '@atproto/api'
+
+import {LogEvents} from '#/lib/statsig/statsig'
+import {PersistedAccount} from '#/state/persisted'
+
+/**
+ * Alias for `PersistedAccount` from persisted storage.
+ */
+export type SessionAccount = PersistedAccount
+
+/**
+ * Subset of `SessionAccount` that excludes tokens.
+ */
+export type CurrentAccount = Omit<SessionAccount, 'accessJwt' | 'refreshJwt'>
+
+/**
+ * Context shape returned from `useSession()`
+ */
+export type SessionStateContext = {
+  currentAgent: BskyAgent
+  isInitialLoad: boolean
+  isSwitchingAccounts: boolean
+  hasSession: boolean
+  accounts: SessionAccount[]
+  /**
+   * Contains the full account object persisted to storage, minus access
+   * tokens.
+   */
+  currentAccount: CurrentAccount | undefined
+}
+
+/**
+ * Context shape returned from `useSessionApi()`
+ */
+export type SessionApiContext = {
+  createAccount: (props: {
+    service: string
+    email: string
+    password: string
+    handle: string
+    inviteCode?: string
+    verificationPhone?: string
+    verificationCode?: string
+  }) => Promise<void>
+  login: (
+    props: {
+      service: string
+      identifier: string
+      password: string
+    },
+    logContext: LogEvents['account:loggedIn']['logContext'],
+  ) => Promise<void>
+  /**
+   * A full logout. Clears the `currentAccount` from session, AND removes
+   * access tokens from all accounts, so that returning as any user will
+   * require a full login.
+   */
+  logout: (
+    logContext: LogEvents['account:loggedOut']['logContext'],
+  ) => Promise<void>
+  /**
+   * A partial logout. Clears the `currentAccount` from session, but DOES NOT
+   * clear access tokens from accounts, allowing the user to return to their
+   * other accounts without logging in.
+   *
+   * Used when adding a new account, deleting an account.
+   */
+  clearCurrentAccount: () => void
+  initSession: (account: SessionAccount) => Promise<void>
+  resumeSession: (account?: SessionAccount) => Promise<void>
+  removeAccount: (account: SessionAccount) => void
+  selectAccount: (
+    account: SessionAccount,
+    logContext: LogEvents['account:loggedIn']['logContext'],
+  ) => Promise<void>
+  /**
+   * Refreshes the BskyAgent's session and derive a fresh `currentAccount`
+   */
+  refreshSession: () => void
+}

--- a/src/state/session/util.ts
+++ b/src/state/session/util.ts
@@ -1,0 +1,179 @@
+import {BSKY_LABELER_DID, BskyAgent} from '@atproto/api'
+import {jwtDecode} from 'jwt-decode'
+
+import {IS_TEST_USER} from '#/lib/constants'
+import {hasProp} from '#/lib/type-guards'
+import {logger} from '#/logger'
+import * as persisted from '#/state/persisted'
+import {readLabelers} from '#/state/session/agent-config'
+import {SessionAccount, SessionApiContext} from '#/state/session/types'
+
+export function isSessionDeactivated(accessJwt: string | undefined) {
+  if (accessJwt) {
+    const sessData = jwtDecode(accessJwt)
+    return (
+      hasProp(sessData, 'scope') && sessData.scope === 'com.atproto.deactivated'
+    )
+  }
+  return false
+}
+
+export function readLastActiveAccount() {
+  const {currentAccount, accounts} = persisted.get('session')
+  return accounts.find(a => a.did === currentAccount?.did)
+}
+
+export function agentToSessionAccount(
+  agent: BskyAgent,
+): SessionAccount | undefined {
+  if (!agent.session) return undefined
+
+  return {
+    service: agent.service.toString(),
+    did: agent.session.did,
+    handle: agent.session.handle,
+    email: agent.session.email,
+    emailConfirmed: agent.session.emailConfirmed,
+    deactivated: isSessionDeactivated(agent.session.accessJwt),
+    refreshJwt: agent.session.refreshJwt,
+    accessJwt: agent.session.accessJwt,
+  }
+}
+
+export function sessionAccountToAgentSession(
+  account: SessionAccount,
+): BskyAgent['session'] {
+  return {
+    did: account.did,
+    handle: account.handle,
+    email: account.email,
+    emailConfirmed: account.emailConfirmed,
+    accessJwt: account.accessJwt || '',
+    refreshJwt: account.refreshJwt || '',
+  }
+}
+
+export async function configureModeration(
+  agent: BskyAgent,
+  account?: SessionAccount,
+) {
+  if (account) {
+    if (IS_TEST_USER(account.handle)) {
+      const did = (
+        await agent
+          .resolveHandle({handle: 'mod-authority.test'})
+          .catch(_ => undefined)
+      )?.data.did
+      if (did) {
+        console.warn('USING TEST ENV MODERATION')
+        BskyAgent.configure({appLabelers: [did]})
+      }
+    } else {
+      BskyAgent.configure({appLabelers: [BSKY_LABELER_DID]})
+
+      if (account) {
+        const labelerDids = await readLabelers(account.did).catch(_ => {})
+        if (labelerDids) {
+          agent.configureLabelersHeader(
+            labelerDids.filter(did => did !== BSKY_LABELER_DID),
+          )
+        }
+      }
+    }
+  } else {
+    BskyAgent.configure({appLabelers: [BSKY_LABELER_DID]})
+  }
+}
+
+export function isSessionExpired(account: SessionAccount) {
+  let canReusePrevSession = false
+  try {
+    if (account.accessJwt) {
+      const decoded = jwtDecode(account.accessJwt)
+      if (decoded.exp) {
+        const didExpire = Date.now() >= decoded.exp * 1000
+        if (!didExpire) {
+          canReusePrevSession = true
+        }
+      }
+    }
+  } catch (e) {
+    logger.error(`session: could not decode jwt`)
+  }
+
+  return !canReusePrevSession
+}
+
+export async function createAgentAndLogin({
+  service,
+  identifier,
+  password,
+}: {
+  service: string
+  identifier: string
+  password: string
+}) {
+  const agent = new BskyAgent({service})
+  await agent.login({identifier, password})
+
+  if (!agent.session) {
+    throw new Error(`session: login failed to establish a session`)
+  }
+
+  const account = agentToSessionAccount(agent)!
+  await configureModeration(agent, account)
+
+  return {
+    agent,
+    account,
+  }
+}
+
+export async function createAgentAndCreateAccount({
+  service,
+  email,
+  password,
+  handle,
+  inviteCode,
+  verificationPhone,
+  verificationCode,
+}: Parameters<SessionApiContext['createAccount']>[0]) {
+  const agent = new BskyAgent({service})
+
+  await agent.createAccount({
+    handle,
+    password,
+    email,
+    inviteCode,
+    verificationPhone,
+    verificationCode,
+  })
+
+  if (!agent.session) {
+    throw new Error(`session: createAccount failed to establish a session`)
+  }
+
+  const deactivated = isSessionDeactivated(agent.session.accessJwt)
+  if (!deactivated) {
+    /*dont await*/ agent.upsertProfile(_existing => {
+      return {
+        displayName: '',
+
+        // HACKFIX
+        // creating a bunch of identical profile objects is breaking the relay
+        // tossing this unspecced field onto it to reduce the size of the problem
+        // -prf
+        createdAt: new Date().toISOString(),
+      }
+    })
+  }
+
+  const account = agentToSessionAccount(agent)!
+
+  await configureModeration(agent, account)
+
+  return {
+    agent,
+    account,
+  }
+}

--- a/src/view/com/modals/ChangeEmail.tsx
+++ b/src/view/com/modals/ChangeEmail.tsx
@@ -27,7 +27,7 @@ export const snapPoints = ['90%']
 export function Component() {
   const pal = usePalette('default')
   const {currentAccount} = useSession()
-  const {refreshSession} = useSessionApi()
+  const {updateCurrentAccount} = useSessionApi()
   const {_} = useLingui()
   const [stage, setStage] = useState<Stages>(Stages.InputEmail)
   const [email, setEmail] = useState<string>(currentAccount?.email || '')
@@ -50,7 +50,10 @@ export function Component() {
         setStage(Stages.ConfirmCode)
       } else {
         await getAgent().com.atproto.server.updateEmail({email: email.trim()})
-        refreshSession()
+        updateCurrentAccount({
+          email: email.trim(),
+          emailConfirmed: false,
+        })
         Toast.show(_(msg`Email updated`))
         setStage(Stages.Done)
       }
@@ -79,7 +82,10 @@ export function Component() {
         email: email.trim(),
         token: confirmationCode.trim(),
       })
-      refreshSession()
+      updateCurrentAccount({
+        email: email.trim(),
+        emailConfirmed: false,
+      })
       Toast.show(_(msg`Email updated`))
       setStage(Stages.Done)
     } catch (e) {

--- a/src/view/com/modals/ChangeEmail.tsx
+++ b/src/view/com/modals/ChangeEmail.tsx
@@ -1,19 +1,20 @@
 import React, {useState} from 'react'
 import {ActivityIndicator, SafeAreaView, StyleSheet, View} from 'react-native'
-import {ScrollView, TextInput} from './util'
-import {Text} from '../util/text/Text'
-import {Button} from '../util/forms/Button'
-import {ErrorMessage} from '../util/error/ErrorMessage'
-import * as Toast from '../util/Toast'
-import {s, colors} from 'lib/styles'
+import {msg, Trans} from '@lingui/macro'
+import {useLingui} from '@lingui/react'
+
+import {useModalControls} from '#/state/modals'
+import {getAgent, useSession, useSessionApi} from '#/state/session'
 import {usePalette} from 'lib/hooks/usePalette'
-import {isWeb} from 'platform/detection'
 import {useWebMediaQueries} from 'lib/hooks/useWebMediaQueries'
 import {cleanError} from 'lib/strings/errors'
-import {Trans, msg} from '@lingui/macro'
-import {useLingui} from '@lingui/react'
-import {useModalControls} from '#/state/modals'
-import {useSession, useSessionApi, getAgent} from '#/state/session'
+import {colors, s} from 'lib/styles'
+import {isWeb} from 'platform/detection'
+import {ErrorMessage} from '../util/error/ErrorMessage'
+import {Button} from '../util/forms/Button'
+import {Text} from '../util/text/Text'
+import * as Toast from '../util/Toast'
+import {ScrollView, TextInput} from './util'
 
 enum Stages {
   InputEmail,
@@ -26,7 +27,7 @@ export const snapPoints = ['90%']
 export function Component() {
   const pal = usePalette('default')
   const {currentAccount} = useSession()
-  const {updateCurrentAccount} = useSessionApi()
+  const {refreshSession} = useSessionApi()
   const {_} = useLingui()
   const [stage, setStage] = useState<Stages>(Stages.InputEmail)
   const [email, setEmail] = useState<string>(currentAccount?.email || '')
@@ -49,10 +50,7 @@ export function Component() {
         setStage(Stages.ConfirmCode)
       } else {
         await getAgent().com.atproto.server.updateEmail({email: email.trim()})
-        updateCurrentAccount({
-          email: email.trim(),
-          emailConfirmed: false,
-        })
+        refreshSession()
         Toast.show(_(msg`Email updated`))
         setStage(Stages.Done)
       }
@@ -81,10 +79,7 @@ export function Component() {
         email: email.trim(),
         token: confirmationCode.trim(),
       })
-      updateCurrentAccount({
-        email: email.trim(),
-        emailConfirmed: false,
-      })
+      refreshSession()
       Toast.show(_(msg`Email updated`))
       setStage(Stages.Done)
     } catch (e) {

--- a/src/view/com/modals/ChangeHandle.tsx
+++ b/src/view/com/modals/ChangeHandle.tsx
@@ -72,7 +72,7 @@ export function Inner({
   const {_} = useLingui()
   const pal = usePalette('default')
   const {track} = useAnalytics()
-  const {refreshSession} = useSessionApi()
+  const {updateCurrentAccount} = useSessionApi()
   const {closeModal} = useModalControls()
   const {mutateAsync: updateHandle, isPending: isUpdateHandlePending} =
     useUpdateHandleMutation()
@@ -115,7 +115,9 @@ export function Inner({
       await updateHandle({
         handle: newHandle,
       })
-      refreshSession()
+      updateCurrentAccount({
+        handle: newHandle,
+      })
       closeModal()
       onChanged()
     } catch (err: any) {
@@ -131,7 +133,7 @@ export function Inner({
     onChanged,
     track,
     closeModal,
-    refreshSession,
+    updateCurrentAccount,
     updateHandle,
     serviceInfo,
   ])

--- a/src/view/com/modals/ChangeHandle.tsx
+++ b/src/view/com/modals/ChangeHandle.tsx
@@ -72,7 +72,7 @@ export function Inner({
   const {_} = useLingui()
   const pal = usePalette('default')
   const {track} = useAnalytics()
-  const {updateCurrentAccount} = useSessionApi()
+  const {refreshSession} = useSessionApi()
   const {closeModal} = useModalControls()
   const {mutateAsync: updateHandle, isPending: isUpdateHandlePending} =
     useUpdateHandleMutation()
@@ -115,9 +115,7 @@ export function Inner({
       await updateHandle({
         handle: newHandle,
       })
-      updateCurrentAccount({
-        handle: newHandle,
-      })
+      refreshSession()
       closeModal()
       onChanged()
     } catch (err: any) {
@@ -133,7 +131,7 @@ export function Inner({
     onChanged,
     track,
     closeModal,
-    updateCurrentAccount,
+    refreshSession,
     updateHandle,
     serviceInfo,
   ])

--- a/src/view/com/modals/VerifyEmail.tsx
+++ b/src/view/com/modals/VerifyEmail.tsx
@@ -6,23 +6,24 @@ import {
   StyleSheet,
   View,
 } from 'react-native'
-import {Svg, Circle, Path} from 'react-native-svg'
-import {ScrollView, TextInput} from './util'
+import {Circle, Path, Svg} from 'react-native-svg'
 import {FontAwesomeIcon} from '@fortawesome/react-native-fontawesome'
-import {Text} from '../util/text/Text'
-import {Button} from '../util/forms/Button'
-import {ErrorMessage} from '../util/error/ErrorMessage'
-import * as Toast from '../util/Toast'
-import {s, colors} from 'lib/styles'
+import {msg, Trans} from '@lingui/macro'
+import {useLingui} from '@lingui/react'
+
+import {logger} from '#/logger'
+import {useModalControls} from '#/state/modals'
+import {getAgent, useSession, useSessionApi} from '#/state/session'
 import {usePalette} from 'lib/hooks/usePalette'
-import {isWeb} from 'platform/detection'
 import {useWebMediaQueries} from 'lib/hooks/useWebMediaQueries'
 import {cleanError} from 'lib/strings/errors'
-import {Trans, msg} from '@lingui/macro'
-import {useLingui} from '@lingui/react'
-import {useModalControls} from '#/state/modals'
-import {useSession, useSessionApi, getAgent} from '#/state/session'
-import {logger} from '#/logger'
+import {colors, s} from 'lib/styles'
+import {isWeb} from 'platform/detection'
+import {ErrorMessage} from '../util/error/ErrorMessage'
+import {Button} from '../util/forms/Button'
+import {Text} from '../util/text/Text'
+import * as Toast from '../util/Toast'
+import {ScrollView, TextInput} from './util'
 
 export const snapPoints = ['90%']
 
@@ -35,7 +36,7 @@ enum Stages {
 export function Component({showReminder}: {showReminder?: boolean}) {
   const pal = usePalette('default')
   const {currentAccount} = useSession()
-  const {updateCurrentAccount} = useSessionApi()
+  const {refreshSession} = useSessionApi()
   const {_} = useLingui()
   const [stage, setStage] = useState<Stages>(
     showReminder ? Stages.Reminder : Stages.Email,
@@ -74,7 +75,7 @@ export function Component({showReminder}: {showReminder?: boolean}) {
         email: (currentAccount?.email || '').trim(),
         token: confirmationCode.trim(),
       })
-      updateCurrentAccount({emailConfirmed: true})
+      refreshSession()
       Toast.show(_(msg`Email verified`))
       closeModal()
     } catch (e) {

--- a/src/view/com/modals/VerifyEmail.tsx
+++ b/src/view/com/modals/VerifyEmail.tsx
@@ -36,7 +36,7 @@ enum Stages {
 export function Component({showReminder}: {showReminder?: boolean}) {
   const pal = usePalette('default')
   const {currentAccount} = useSession()
-  const {refreshSession} = useSessionApi()
+  const {updateCurrentAccount} = useSessionApi()
   const {_} = useLingui()
   const [stage, setStage] = useState<Stages>(
     showReminder ? Stages.Reminder : Stages.Email,
@@ -75,7 +75,7 @@ export function Component({showReminder}: {showReminder?: boolean}) {
         email: (currentAccount?.email || '').trim(),
         token: confirmationCode.trim(),
       })
-      refreshSession()
+      updateCurrentAccount({emailConfirmed: true})
       Toast.show(_(msg`Email verified`))
       closeModal()
     } catch (e) {


### PR DESCRIPTION
The core issue being solved here is a race condition between the update of `currentAccount` and the `__globalAgent`. #3333 set us up so that changing accounts gives us a fresh query cache, which was the impetus behind `__globalAgent` in the first place (stale closures).

This PR builds on that by deriving `currentAccount` from the currently active `BskyAgent`, removing the need to manage updates to two objects (`currentAccount` and `__globalAgent`) that have the same lifetime.

In the process, I also split out state handling into separate `useState` calls to help avoid loops and isolate updates.

- derive `currentAccount` from `BskyAgent.session` 4482cbf1436113e1a34c4903bb26635417d1a8cd
- replace mutation of this global state with a call to refresh the session and re-derive ff36564c9b9fc5776de5936e991f33487c4ceafe
- replace usages of previous mutation of global state 80b562cfacf703d2807e9c81f67e187ad43c6017
- refactored `persistSession` handler for more clarity 634995db38a2f7a3d6b4871b66cafb8480d86877

With this PR, we should now reference the active `BskyAgent` via `{ agent } = useSession()` and drop the `__globalAgent`.

Review `state/session.ts` [without whitespace](https://github.com/bluesky-social/social-app/pull/3393/files?diff=split&w=1#diff-ba67025ff0027278031f772f88a9ed2f7fa4b12421d0a423ad74b4937aa2ca53).