### PR TITLE
Show redbox in DEV on string <View> child for web

### DIFF
--- a/src/platform/polyfills.web.ts
+++ b/src/platform/polyfills.web.ts
@@ -6,3 +6,24 @@ findLast.shim()
 
 // @ts-ignore whatever typescript wants to complain about here, I dont care about -prf
 window.setImmediate = (cb: () => void) => setTimeout(cb, 0)
+
+if (process.env.NODE_ENV !== 'production') {
+  // In development, react-native-web's <View> tries to validate that
+  // text is wrapped into <Text>. It doesn't catch all cases but is useful.
+  // Unfortunately, it only does that via console.error so it's easy to miss.
+  // This is a hack to get it showing as a redbox on the web so we catch it early.
+  const realConsoleError = console.error
+  const thrownErrors = new WeakSet()
+  console.error = function consoleErrorWrapper(msgOrError) {
+    if (
+      typeof msgOrError === 'string' &&
+      msgOrError.startsWith('Unexpected text node')
+    ) {
+      const err = new Error(msgOrError)
+      thrownErrors.add(err)
+      throw err
+    } else if (!thrownErrors.has(msgOrError)) {
+      return realConsoleError.apply(this, arguments as any)
+    }
+  }
+}


### PR DESCRIPTION
Suppose we add a string somewhere like this:

```js
<View>stuff</View>
```

On RN, this would be a crash, but it works on the web. So if you mostly develop on web, it's easy to miss.

RNW includes some basic protection against this with [this DEV-only `console.error` call](
https://github.com/necolas/react-native-web/blob/a0cd8ffba4ade1b5860164cb4ef89a652a68580f/packages/react-native-web/src/exports/View/index.js#L71-L79). Note it isn't as exhaustive as the real check RN needs because it will only catch direct `<View>` children. It's still better than nothing though.

The problem is, it's very easy to miss because we have a bunch of `console.error` console logspam on web. We should fix that logspam, but still, for this particular error we should just show the redbox in DEV on web. So we can't miss it.

This is a hack to do exactly that.

## Before

<img width="1311" alt="Screenshot 2024-04-04 at 00 11 10" src="https://github.com/bluesky-social/social-app/assets/810438/df41021e-d592-4477-8ddc-bb5f9d84e308">

## After

<img width="1141" alt="Screenshot 2024-04-04 at 00 18 16" src="https://github.com/bluesky-social/social-app/assets/810438/0bb357ee-4f05-4dac-8f37-a0350a1fffbe">

Note you can see the component stack in the console.

## Test Plan

See above.

Doesn't affect native because in `.web.ts` file.

Doesn't affect prod because in `process.env.NODE_ENV !== 'production'` block.

## Alternatives

This could be an RNW patch instead. But this seems easier. We don't need this to be a strong guarantee, let's just update it if needed. In longer term we might want to override console anyway.
