### PR TITLE
Add cursor to 'learn more' on screenhider (close #2871)

### DIFF
--- a/src/components/moderation/ScreenHider.tsx
+++ b/src/components/moderation/ScreenHider.tsx
@@ -1,27 +1,26 @@
 import React from 'react'
 import {
-  TouchableWithoutFeedback,
   StyleProp,
+  TouchableWithoutFeedback,
   View,
   ViewStyle,
 } from 'react-native'
-import {useNavigation} from '@react-navigation/native'
 import {ModerationUI} from '@atproto/api'
-import {Trans, msg} from '@lingui/macro'
+import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
+import {useNavigation} from '@react-navigation/native'
 
+import {useModerationCauseDescription} from '#/lib/moderation/useModerationCauseDescription'
 import {useWebMediaQueries} from 'lib/hooks/useWebMediaQueries'
 import {NavigationProp} from 'lib/routes/types'
-import {useModerationCauseDescription} from '#/lib/moderation/useModerationCauseDescription'
-
-import {useTheme, atoms as a} from '#/alf'
 import {CenteredView} from '#/view/com/util/Views'
-import {Text} from '#/components/Typography'
+import {atoms as a, useTheme} from '#/alf'
 import {Button, ButtonText} from '#/components/Button'
 import {
   ModerationDetailsDialog,
   useModerationDetailsDialogControl,
 } from '#/components/moderation/ModerationDetailsDialog'
+import {Text} from '#/components/Typography'
 
 export function ScreenHider({
   testID,
@@ -125,7 +124,15 @@ export function ScreenHider({
               accessibilityRole="button"
               accessibilityLabel={_(msg`Learn more about this warning`)}
               accessibilityHint="">
-              <Text style={[a.text_lg, {color: t.palette.primary_500}]}>
+              <Text
+                style={[
+                  a.text_lg,
+                  {
+                    color: t.palette.primary_500,
+                    // @ts-ignore web only -prf
+                    cursor: 'pointer',
+                  },
+                ]}>
                 <Trans>Learn More</Trans>
               </Text>
             </TouchableWithoutFeedback>


### PR DESCRIPTION
Supersedes https://github.com/bluesky-social/social-app/pull/2880, which fell out of date

Small thing -- just adds a cursor to the "Learn More" link on the screen hider. Tested by forcing a blur on the screenhider and then running on web.