### PR TITLE
Work around GitHub false-positive for passing secret to another action

### DIFF
--- a/.github/workflows/build-submit-android.yml
+++ b/.github/workflows/build-submit-android.yml
@@ -8,6 +8,7 @@ on:
         type: choice
         description: Build profile to use
         options:
+          - testflight-android
           - production
 
 jobs:
@@ -59,7 +60,41 @@ jobs:
           echo "$json" > google-services.json
 
       - name: 🏗️ EAS Build
-        run: yarn use-build-number-with-bump eas build -p android --profile production --local --output build.aab --non-interactive
+        run: yarn use-build-number-with-bump eas build -p android --profile ${{ inputs.profile || 'testflight-android' }} --local --output build.aab --non-interactive
 
       - name: 🚀 Deploy
+        if: ${{ inputs.profile == 'production' }}
         run: eas submit -p android --non-interactive --path build.aab
+
+      - name: ✍️ Rename bundle
+        if: ${{ inputs.profile != 'production' }}
+        run: mv build.aab build.apk
+
+      - name: ⏰ Get a timestamp
+        id: timestamp
+        if: ${{ inputs.profile != 'production' }}
+        uses: nanzm/get-time-action@master
+        with:
+          format: 'MM-DD-HH-mm-ss'
+
+      - name: 🚀 Upload Artifact
+        id: upload-artifact
+        if: ${{ inputs.profile != 'production' }}
+        uses: actions/upload-artifact@v4
+        with:
+          retention-days: 30
+          compression-level: 0
+          name: build-${{ steps.timestamp.outputs.time }}.apk
+          path: build.apk
+
+      - name: 🔔 Notify Slack
+        if: ${{ inputs.profile != 'production' }}
+        uses: slackapi/slack-github-action@v1.25.0
+        with:
+          payload: |
+            {
+              "text": "Android build is ready for testing. Download the artifact here: ${{ steps.upload-artifact.outputs.artifact-url }}"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_CLIENT_ALERT_WEBHOOK }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK

--- a/.github/workflows/bundle-deploy-eas-update.yml
+++ b/.github/workflows/bundle-deploy-eas-update.yml
@@ -46,6 +46,7 @@ jobs:
           fetch-depth: 100
 
       - name: ⬇️ Fetch commits from base branch
+        if: ${{ github.ref != 'refs/heads/main' }}
         run: git fetch origin main:main --depth 100
 
       # This should get the current production release's commit's hash to see if the update is compatible

--- a/.github/workflows/bundle-deploy-eas-update.yml
+++ b/.github/workflows/bundle-deploy-eas-update.yml
@@ -2,6 +2,9 @@
 name: Bundle and Deploy EAS Update
 
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       channel:

--- a/.github/workflows/bundle-deploy-eas-update.yml
+++ b/.github/workflows/bundle-deploy-eas-update.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - hailey/add-testflight-build-option-android
   workflow_dispatch:
     inputs:
       channel:
@@ -23,7 +24,8 @@ jobs:
     name: Bundle and Deploy EAS Update
     runs-on: ubuntu-latest
     outputs:
-      fingerprint-diff: ${{ steps.fingerprint.outputs.fingerprint-diff }}
+      fingerprint-is-different: ${{ steps.fingerprint-debug.outputs.fingerprint-is-different }}
+
     steps:
       - name: Check for EXPO_TOKEN
         run: >
@@ -83,9 +85,17 @@ jobs:
           previous-git-commit: ${{ steps.base-commit.outputs.base-commit }}
 
       - name: 👀 Debug fingerprint
+        id: fingerprint-debug
         run: |
+          echo "fingerprint-diff=${{ steps.fingerprint.outputs.fingerprint-diff }}"
           echo "previousGitCommit=${{ steps.fingerprint.outputs.previous-git-commit }} currentGitCommit=${{ steps.fingerprint.outputs.current-git-commit }}"
           echo "isPreviousFingerprintEmpty=${{ steps.fingerprint.outputs.previous-fingerprint == '' }}"
+          
+          if [ "${{ steps.fingerprint.outputs.fingerprint-diff }}" != '[]' ]; then
+            echo fingerprint-is-different="true" >> "$GITHUB_OUTPUT"
+          else
+            echo fingerprint-is-different="false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: 🔨 Setup EAS
         uses: expo/expo-github-action@v8
@@ -126,6 +136,7 @@ jobs:
           RUNTIME_VERSION: ${{ inputs.runtimeVersion }}
           CHANNEL_NAME: ${{ inputs.channel || 'testflight' }}
 
+
   # GitHub actions are horrible so let's just copy paste this in
   buildIfNecessaryIOS:
     name: Build and Submit iOS
@@ -133,7 +144,7 @@ jobs:
     needs: [bundleDeploy]
     # Gotta check if its NOT '[]' because any md5 hash in the outputs is detected as a possible secret and won't be
     # available here
-    if: ${{ inputs.channel != 'production' && needs.bundleDeploy.outputs.fingerprint-diff != '[]' }}
+    if: ${{ inputs.channel != 'production' && needs.bundleDeploy.outputs.fingerprint-is-different == 'true' }}
     steps:
       - name: Check for EXPO_TOKEN
         run: >
@@ -198,7 +209,7 @@ jobs:
     needs: [ bundleDeploy ]
     # Gotta check if its NOT '[]' because any md5 hash in the outputs is detected as a possible secret and won't be
     # available here
-    if: ${{ inputs.channel != 'production' && needs.bundleDeploy.outputs.fingerprint-diff != '[]' }}
+    if: ${{ inputs.channel != 'production' && needs.bundleDeploy.outputs.fingerprint-is-different == 'true' }}
 
     steps:
       - name: Check for EXPO_TOKEN

--- a/.github/workflows/bundle-deploy-eas-update.yml
+++ b/.github/workflows/bundle-deploy-eas-update.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - hailey/add-testflight-build-option-android
   workflow_dispatch:
     inputs:
       channel:


### PR DESCRIPTION
Infuriatingly, GitHub thinks that the string `[]` _or_ any string containing any sort of hash contains a secret. Therefore, we can't just simply pass `[]` to the outputs of the first job in the workflow.

This is a little hack to output either the string "true" or the string "false" instead.

Also, just updating the base android build script to support manual deployment of a testflight client for Android.