### PR TITLE
rm 'pornography' label wording

### DIFF
--- a/src/lib/moderation/useGlobalLabelStrings.ts
+++ b/src/lib/moderation/useGlobalLabelStrings.ts
@@ -1,6 +1,6 @@
+import {useMemo} from 'react'
 import {msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
-import {useMemo} from 'react'
 
 export type GlobalLabelStrings = Record<
   string,
@@ -31,7 +31,7 @@ export function useGlobalLabelStrings(): GlobalLabelStrings {
         ),
       },
       porn: {
-        name: _(msg`Pornography`),
+        name: _(msg`Adult Content`),
         description: _(msg`Explicit sexual images.`),
       },
       sexual: {

--- a/src/lib/moderation/useReportOptions.ts
+++ b/src/lib/moderation/useReportOptions.ts
@@ -1,7 +1,7 @@
-import {msg} from '@lingui/macro'
-import {useLingui} from '@lingui/react'
 import {useMemo} from 'react'
 import {ComAtprotoModerationDefs} from '@atproto/api'
+import {msg} from '@lingui/macro'
+import {useLingui} from '@lingui/react'
 
 export interface ReportOption {
   reason: string
@@ -68,7 +68,7 @@ export function useReportOptions(): ReportOptions {
         {
           reason: ComAtprotoModerationDefs.REASONSEXUAL,
           title: _(msg`Unwanted Sexual Content`),
-          description: _(msg`Nudity or pornography not labeled as such`),
+          description: _(msg`Nudity not labeled as such`),
         },
         ...common,
       ],

--- a/src/lib/moderation/useReportOptions.ts
+++ b/src/lib/moderation/useReportOptions.ts
@@ -68,7 +68,7 @@ export function useReportOptions(): ReportOptions {
         {
           reason: ComAtprotoModerationDefs.REASONSEXUAL,
           title: _(msg`Unwanted Sexual Content`),
-          description: _(msg`Nudity not labeled as such`),
+          description: _(msg`Nudity or adult content not labeled as such`),
         },
         ...common,
       ],


### PR DESCRIPTION
This is a follow up to https://github.com/bluesky-social/social-app/pull/3282 where we reverted the change to the "Adult Content". The appeals screen still shows "Pornography", so this PR replaces that with "Adult Content" again.