### PR TITLE
Fix false positive DEV check

### DIFF
--- a/src/platform/polyfills.web.ts
+++ b/src/platform/polyfills.web.ts
@@ -19,6 +19,14 @@ if (process.env.NODE_ENV !== 'production') {
       typeof msgOrError === 'string' &&
       msgOrError.startsWith('Unexpected text node')
     ) {
+      if (
+        msgOrError ===
+        'Unexpected text node: . A text node cannot be a child of a <View>.'
+      ) {
+        // This is due to a stray empty string.
+        // React already handles this fine, so RNW warning is a false positive. Ignore.
+        return
+      }
       const err = new Error(msgOrError)
       thrownErrors.add(err)
       throw err


### PR DESCRIPTION
Follow-up to https://github.com/bluesky-social/social-app/pull/3394.

React can already handle stray _empty_ strings just fine, so the `console.error` from RNW is overzelaous.

Let's silence it to match the actual behavior.

## Test Plan

Moderation -> Muted words and tags

No longer crashes in DEV on web.