### PR TITLE
Remove special cases for some buttons with text

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -34,7 +34,6 @@ module.exports = {
           'P',
           'Prompt.Cancel', // TODO: Not always safe.
           'Prompt.Action', // TODO: Not always safe.
-          'ToggleButton.Button', // TODO: Not always safe.
         ],
         impliedTextProps: [],
       },

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -32,8 +32,6 @@ module.exports = {
           'H5',
           'H6',
           'P',
-          'Prompt.Cancel', // TODO: Not always safe.
-          'Prompt.Action', // TODO: Not always safe.
         ],
         impliedTextProps: [],
       },

--- a/src/components/Prompt.tsx
+++ b/src/components/Prompt.tsx
@@ -91,15 +91,13 @@ export function Actions({children}: React.PropsWithChildren<{}>) {
 }
 
 export function Cancel({
-  children,
   cta,
-}: React.PropsWithChildren<{
+}: {
   /**
-   * Optional i18n string, used in lieu of `children` for simple buttons. If
-   * undefined (and `children` is undefined), it will default to "Cancel".
+   * Optional i18n string. If undefined, it will default to "Cancel".
    */
   cta?: string
-}>) {
+}) {
   const {_} = useLingui()
   const {gtMobile} = useBreakpoints()
   const {close} = Dialog.useDialogContext()
@@ -114,27 +112,25 @@ export function Cancel({
       size={gtMobile ? 'small' : 'medium'}
       label={cta || _(msg`Cancel`)}
       onPress={onPress}>
-      {children ? children : <ButtonText>{cta || _(msg`Cancel`)}</ButtonText>}
+      <ButtonText>{cta || _(msg`Cancel`)}</ButtonText>
     </Button>
   )
 }
 
 export function Action({
-  children,
   onPress,
   color = 'primary',
   cta,
   testID,
-}: React.PropsWithChildren<{
+}: {
   onPress: () => void
   color?: ButtonColor
   /**
-   * Optional i18n string, used in lieu of `children` for simple buttons. If
-   * undefined (and `children` is undefined), it will default to "Confirm".
+   * Optional i18n string. If undefined, it will default to "Confirm".
    */
   cta?: string
   testID?: string
-}>) {
+}) {
   const {_} = useLingui()
   const {gtMobile} = useBreakpoints()
   const {close} = Dialog.useDialogContext()
@@ -151,7 +147,7 @@ export function Action({
       label={cta || _(msg`Confirm`)}
       onPress={handleOnPress}
       testID={testID}>
-      {children ? children : <ButtonText>{cta || _(msg`Confirm`)}</ButtonText>}
+      <ButtonText>{cta || _(msg`Confirm`)}</ButtonText>
     </Button>
   )
 }

--- a/src/components/forms/ToggleButton.tsx
+++ b/src/components/forms/ToggleButton.tsx
@@ -7,6 +7,7 @@ import {Text} from '#/components/Typography'
 
 type ItemProps = Omit<Toggle.ItemProps, 'style' | 'role' | 'children'> &
   AccessibilityProps & {
+    children: React.ReactElement
     testID?: string
   }
 
@@ -33,12 +34,7 @@ export function Group({children, multiple, ...props}: GroupProps) {
   )
 }
 
-export function Button({
-  children,
-  ...props
-}: ItemProps & {
-  children: React.ReactElement
-}) {
+export function Button({children, ...props}: ItemProps) {
   return (
     <Toggle.Item {...props} style={[a.flex_grow]}>
       <ButtonInner>{children}</ButtonInner>

--- a/src/components/forms/ToggleButton.tsx
+++ b/src/components/forms/ToggleButton.tsx
@@ -33,19 +33,6 @@ export function Group({children, multiple, ...props}: GroupProps) {
   )
 }
 
-export function ButtonWithText({
-  children,
-  ...props
-}: ItemProps & {
-  children: React.ReactNode
-}) {
-  return (
-    <Button {...props}>
-      <ButtonText>{children}</ButtonText>
-    </Button>
-  )
-}
-
 export function Button({
   children,
   ...props

--- a/src/components/forms/ToggleButton.tsx
+++ b/src/components/forms/ToggleButton.tsx
@@ -1,16 +1,14 @@
 import React from 'react'
-import {View, AccessibilityProps, TextStyle, ViewStyle} from 'react-native'
+import {AccessibilityProps, TextStyle, View, ViewStyle} from 'react-native'
 
-import {atoms as a, useTheme, native} from '#/alf'
+import {atoms as a, native, useTheme} from '#/alf'
+import * as Toggle from '#/components/forms/Toggle'
 import {Text} from '#/components/Typography'
 
-import * as Toggle from '#/components/forms/Toggle'
-
-export type ItemProps = Omit<Toggle.ItemProps, 'style' | 'role' | 'children'> &
-  AccessibilityProps &
-  React.PropsWithChildren<{
+type ItemProps = Omit<Toggle.ItemProps, 'style' | 'role' | 'children'> &
+  AccessibilityProps & {
     testID?: string
-  }>
+  }
 
 export type GroupProps = Omit<Toggle.GroupProps, 'style' | 'type'> & {
   multiple?: boolean
@@ -35,7 +33,25 @@ export function Group({children, multiple, ...props}: GroupProps) {
   )
 }
 
-export function Button({children, ...props}: ItemProps) {
+export function ButtonWithText({
+  children,
+  ...props
+}: ItemProps & {
+  children: React.ReactNode
+}) {
+  return (
+    <Button {...props}>
+      <ButtonText>{children}</ButtonText>
+    </Button>
+  )
+}
+
+export function Button({
+  children,
+  ...props
+}: ItemProps & {
+  children: React.ReactElement
+}) {
   return (
     <Toggle.Item {...props} style={[a.flex_grow]}>
       <ButtonInner>{children}</ButtonInner>
@@ -43,53 +59,76 @@ export function Button({children, ...props}: ItemProps) {
   )
 }
 
+export function ButtonText({children}: {children: React.ReactNode}) {
+  const t = useTheme()
+  const state = Toggle.useItemContext()
+
+  const textStyles = React.useMemo(() => {
+    const text: TextStyle[] = []
+    if (state.selected) {
+      text.push(t.atoms.text_inverted)
+    }
+    if (state.disabled) {
+      text.push({
+        opacity: 0.5,
+      })
+    }
+    return text
+  }, [t, state])
+
+  return (
+    <Text
+      style={[
+        a.text_center,
+        a.font_bold,
+        t.atoms.text_contrast_medium,
+        textStyles,
+      ]}>
+      {children}
+    </Text>
+  )
+}
+
 function ButtonInner({children}: React.PropsWithChildren<{}>) {
   const t = useTheme()
   const state = Toggle.useItemContext()
 
-  const {baseStyles, hoverStyles, activeStyles, textStyles} =
-    React.useMemo(() => {
-      const base: ViewStyle[] = []
-      const hover: ViewStyle[] = []
-      const active: ViewStyle[] = []
-      const text: TextStyle[] = []
+  const {baseStyles, hoverStyles, activeStyles} = React.useMemo(() => {
+    const base: ViewStyle[] = []
+    const hover: ViewStyle[] = []
+    const active: ViewStyle[] = []
 
-      hover.push(
-        t.name === 'light' ? t.atoms.bg_contrast_100 : t.atoms.bg_contrast_25,
-      )
+    hover.push(
+      t.name === 'light' ? t.atoms.bg_contrast_100 : t.atoms.bg_contrast_25,
+    )
 
-      if (state.selected) {
-        active.push({
-          backgroundColor: t.palette.contrast_800,
-        })
-        text.push(t.atoms.text_inverted)
-        hover.push({
-          backgroundColor: t.palette.contrast_800,
-        })
-
-        if (state.disabled) {
-          active.push({
-            backgroundColor: t.palette.contrast_500,
-          })
-        }
-      }
+    if (state.selected) {
+      active.push({
+        backgroundColor: t.palette.contrast_800,
+      })
+      hover.push({
+        backgroundColor: t.palette.contrast_800,
+      })
 
       if (state.disabled) {
-        base.push({
-          backgroundColor: t.palette.contrast_100,
-        })
-        text.push({
-          opacity: 0.5,
+        active.push({
+          backgroundColor: t.palette.contrast_500,
         })
       }
+    }
 
-      return {
-        baseStyles: base,
-        hoverStyles: hover,
-        activeStyles: active,
-        textStyles: text,
-      }
-    }, [t, state])
+    if (state.disabled) {
+      base.push({
+        backgroundColor: t.palette.contrast_100,
+      })
+    }
+
+    return {
+      baseStyles: base,
+      hoverStyles: hover,
+      activeStyles: active,
+    }
+  }, [t, state])
 
   return (
     <View
@@ -110,19 +149,7 @@ function ButtonInner({children}: React.PropsWithChildren<{}>) {
         activeStyles,
         (state.hovered || state.pressed) && hoverStyles,
       ]}>
-      {typeof children === 'string' ? (
-        <Text
-          style={[
-            a.text_center,
-            a.font_bold,
-            t.atoms.text_contrast_medium,
-            textStyles,
-          ]}>
-          {children}
-        </Text>
-      ) : (
-        children
-      )}
+      {children}
     </View>
   )
 }

--- a/src/components/forms/ToggleButton.tsx
+++ b/src/components/forms/ToggleButton.tsx
@@ -59,36 +59,6 @@ export function Button({
   )
 }
 
-export function ButtonText({children}: {children: React.ReactNode}) {
-  const t = useTheme()
-  const state = Toggle.useItemContext()
-
-  const textStyles = React.useMemo(() => {
-    const text: TextStyle[] = []
-    if (state.selected) {
-      text.push(t.atoms.text_inverted)
-    }
-    if (state.disabled) {
-      text.push({
-        opacity: 0.5,
-      })
-    }
-    return text
-  }, [t, state])
-
-  return (
-    <Text
-      style={[
-        a.text_center,
-        a.font_bold,
-        t.atoms.text_contrast_medium,
-        textStyles,
-      ]}>
-      {children}
-    </Text>
-  )
-}
-
 function ButtonInner({children}: React.PropsWithChildren<{}>) {
   const t = useTheme()
   const state = Toggle.useItemContext()
@@ -151,5 +121,35 @@ function ButtonInner({children}: React.PropsWithChildren<{}>) {
       ]}>
       {children}
     </View>
+  )
+}
+
+export function ButtonText({children}: {children: React.ReactNode}) {
+  const t = useTheme()
+  const state = Toggle.useItemContext()
+
+  const textStyles = React.useMemo(() => {
+    const text: TextStyle[] = []
+    if (state.selected) {
+      text.push(t.atoms.text_inverted)
+    }
+    if (state.disabled) {
+      text.push({
+        opacity: 0.5,
+      })
+    }
+    return text
+  }, [t, state])
+
+  return (
+    <Text
+      style={[
+        a.text_center,
+        a.font_bold,
+        t.atoms.text_contrast_medium,
+        textStyles,
+      ]}>
+      {children}
+    </Text>
   )
 }

--- a/src/components/moderation/LabelPreference.tsx
+++ b/src/components/moderation/LabelPreference.tsx
@@ -83,19 +83,19 @@ export function Buttons({
         values={values}
         onChange={onChange}>
         {ignoreLabel && (
-          <ToggleButton.Button name="ignore" label={ignoreLabel}>
+          <ToggleButton.ButtonWithText name="ignore" label={ignoreLabel}>
             {ignoreLabel}
-          </ToggleButton.Button>
+          </ToggleButton.ButtonWithText>
         )}
         {warnLabel && (
-          <ToggleButton.Button name="warn" label={warnLabel}>
+          <ToggleButton.ButtonWithText name="warn" label={warnLabel}>
             {warnLabel}
-          </ToggleButton.Button>
+          </ToggleButton.ButtonWithText>
         )}
         {hideLabel && (
-          <ToggleButton.Button name="hide" label={hideLabel}>
+          <ToggleButton.ButtonWithText name="hide" label={hideLabel}>
             {hideLabel}
-          </ToggleButton.Button>
+          </ToggleButton.ButtonWithText>
         )}
       </ToggleButton.Group>
     </View>

--- a/src/components/moderation/LabelPreference.tsx
+++ b/src/components/moderation/LabelPreference.tsx
@@ -83,19 +83,19 @@ export function Buttons({
         values={values}
         onChange={onChange}>
         {ignoreLabel && (
-          <ToggleButton.ButtonWithText name="ignore" label={ignoreLabel}>
-            {ignoreLabel}
-          </ToggleButton.ButtonWithText>
+          <ToggleButton.Button name="ignore" label={ignoreLabel}>
+            <ToggleButton.ButtonText>{ignoreLabel}</ToggleButton.ButtonText>
+          </ToggleButton.Button>
         )}
         {warnLabel && (
-          <ToggleButton.ButtonWithText name="warn" label={warnLabel}>
-            {warnLabel}
-          </ToggleButton.ButtonWithText>
+          <ToggleButton.Button name="warn" label={warnLabel}>
+            <ToggleButton.ButtonText>{warnLabel}</ToggleButton.ButtonText>
+          </ToggleButton.Button>
         )}
         {hideLabel && (
-          <ToggleButton.ButtonWithText name="hide" label={hideLabel}>
-            {hideLabel}
-          </ToggleButton.ButtonWithText>
+          <ToggleButton.Button name="hide" label={hideLabel}>
+            <ToggleButton.ButtonText>{hideLabel}</ToggleButton.ButtonText>
+          </ToggleButton.Button>
         )}
       </ToggleButton.Group>
     </View>

--- a/src/screens/Onboarding/StepModeration/ModerationOption.tsx
+++ b/src/screens/Onboarding/StepModeration/ModerationOption.tsx
@@ -82,15 +82,15 @@ export function ModerationOption({
             )}
             values={[visibility ?? 'hide']}
             onChange={onChange}>
-            <ToggleButton.ButtonWithText name="ignore" label={labels.show}>
-              {labels.show}
-            </ToggleButton.ButtonWithText>
-            <ToggleButton.ButtonWithText name="warn" label={labels.warn}>
-              {labels.warn}
-            </ToggleButton.ButtonWithText>
-            <ToggleButton.ButtonWithText name="hide" label={labels.hide}>
-              {labels.hide}
-            </ToggleButton.ButtonWithText>
+            <ToggleButton.Button name="ignore" label={labels.show}>
+              <ToggleButton.ButtonText>{labels.show}</ToggleButton.ButtonText>
+            </ToggleButton.Button>
+            <ToggleButton.Button name="warn" label={labels.warn}>
+              <ToggleButton.ButtonText>{labels.warn}</ToggleButton.ButtonText>
+            </ToggleButton.Button>
+            <ToggleButton.Button name="hide" label={labels.hide}>
+              <ToggleButton.ButtonText>{labels.hide}</ToggleButton.ButtonText>
+            </ToggleButton.Button>
           </ToggleButton.Group>
         )}
       </View>

--- a/src/screens/Onboarding/StepModeration/ModerationOption.tsx
+++ b/src/screens/Onboarding/StepModeration/ModerationOption.tsx
@@ -1,17 +1,17 @@
 import React from 'react'
 import {View} from 'react-native'
-import {LabelPreference, InterpretedLabelValueDefinition} from '@atproto/api'
-import {useLingui} from '@lingui/react'
+import {InterpretedLabelValueDefinition, LabelPreference} from '@atproto/api'
 import {msg, Trans} from '@lingui/macro'
+import {useLingui} from '@lingui/react'
 
+import {useGlobalLabelStrings} from '#/lib/moderation/useGlobalLabelStrings'
 import {
   usePreferencesQuery,
   usePreferencesSetContentLabelMutation,
 } from '#/state/queries/preferences'
 import {atoms as a, useTheme} from '#/alf'
-import {Text} from '#/components/Typography'
 import * as ToggleButton from '#/components/forms/ToggleButton'
-import {useGlobalLabelStrings} from '#/lib/moderation/useGlobalLabelStrings'
+import {Text} from '#/components/Typography'
 
 export function ModerationOption({
   labelValueDefinition,
@@ -82,15 +82,15 @@ export function ModerationOption({
             )}
             values={[visibility ?? 'hide']}
             onChange={onChange}>
-            <ToggleButton.Button name="ignore" label={labels.show}>
+            <ToggleButton.ButtonWithText name="ignore" label={labels.show}>
               {labels.show}
-            </ToggleButton.Button>
-            <ToggleButton.Button name="warn" label={labels.warn}>
+            </ToggleButton.ButtonWithText>
+            <ToggleButton.ButtonWithText name="warn" label={labels.warn}>
               {labels.warn}
-            </ToggleButton.Button>
-            <ToggleButton.Button name="hide" label={labels.hide}>
+            </ToggleButton.ButtonWithText>
+            <ToggleButton.ButtonWithText name="hide" label={labels.hide}>
               {labels.hide}
-            </ToggleButton.Button>
+            </ToggleButton.ButtonWithText>
           </ToggleButton.Group>
         )}
       </View>

--- a/src/view/com/auth/server-input/index.tsx
+++ b/src/view/com/auth/server-input/index.tsx
@@ -86,15 +86,17 @@ export function ServerInputDialog({
             label="Preferences"
             values={fixedOption}
             onChange={setFixedOption}>
-            <ToggleButton.Button name={BSKY_SERVICE} label={_(msg`Bluesky`)}>
+            <ToggleButton.ButtonWithText
+              name={BSKY_SERVICE}
+              label={_(msg`Bluesky`)}>
               {_(msg`Bluesky`)}
-            </ToggleButton.Button>
-            <ToggleButton.Button
+            </ToggleButton.ButtonWithText>
+            <ToggleButton.ButtonWithText
               testID="customSelectBtn"
               name="custom"
               label={_(msg`Custom`)}>
               {_(msg`Custom`)}
-            </ToggleButton.Button>
+            </ToggleButton.ButtonWithText>
           </ToggleButton.Group>
 
           {fixedOption[0] === 'custom' && (

--- a/src/view/com/auth/server-input/index.tsx
+++ b/src/view/com/auth/server-input/index.tsx
@@ -86,17 +86,19 @@ export function ServerInputDialog({
             label="Preferences"
             values={fixedOption}
             onChange={setFixedOption}>
-            <ToggleButton.ButtonWithText
-              name={BSKY_SERVICE}
-              label={_(msg`Bluesky`)}>
-              {_(msg`Bluesky`)}
-            </ToggleButton.ButtonWithText>
-            <ToggleButton.ButtonWithText
+            <ToggleButton.Button name={BSKY_SERVICE} label={_(msg`Bluesky`)}>
+              <ToggleButton.ButtonText>
+                {_(msg`Bluesky`)}
+              </ToggleButton.ButtonText>
+            </ToggleButton.Button>
+            <ToggleButton.Button
               testID="customSelectBtn"
               name="custom"
               label={_(msg`Custom`)}>
-              {_(msg`Custom`)}
-            </ToggleButton.ButtonWithText>
+              <ToggleButton.ButtonText>
+                {_(msg`Custom`)}
+              </ToggleButton.ButtonText>
+            </ToggleButton.Button>
           </ToggleButton.Group>
 
           {fixedOption[0] === 'custom' && (

--- a/src/view/screens/DebugMod.tsx
+++ b/src/view/screens/DebugMod.tsx
@@ -273,15 +273,15 @@ export const DebugModScreen = ({}: NativeStackScreenProps<
             label="Scenario"
             values={scenario}
             onChange={setScenario}>
-            <ToggleButton.ButtonWithText name="label" label="Label">
-              Label
-            </ToggleButton.ButtonWithText>
-            <ToggleButton.ButtonWithText name="block" label="Block">
-              Block
-            </ToggleButton.ButtonWithText>
-            <ToggleButton.ButtonWithText name="mute" label="Mute">
-              Mute
-            </ToggleButton.ButtonWithText>
+            <ToggleButton.Button name="label" label="Label">
+              <ToggleButton.ButtonText>Label</ToggleButton.ButtonText>
+            </ToggleButton.Button>
+            <ToggleButton.Button name="block" label="Block">
+              <ToggleButton.ButtonText>Block</ToggleButton.ButtonText>
+            </ToggleButton.Button>
+            <ToggleButton.Button name="mute" label="Mute">
+              <ToggleButton.ButtonText>Mute</ToggleButton.ButtonText>
+            </ToggleButton.Button>
           </ToggleButton.Group>
 
           {scenario[0] === 'label' && (
@@ -473,20 +473,18 @@ export const DebugModScreen = ({}: NativeStackScreenProps<
           <Heading title="" subtitle="Results" />
 
           <ToggleButton.Group label="Results" values={view} onChange={setView}>
-            <ToggleButton.ButtonWithText name="post" label="Post">
-              Post
-            </ToggleButton.ButtonWithText>
-            <ToggleButton.ButtonWithText
-              name="notifications"
-              label="Notifications">
-              Notifications
-            </ToggleButton.ButtonWithText>
-            <ToggleButton.ButtonWithText name="account" label="Account">
-              Account
-            </ToggleButton.ButtonWithText>
-            <ToggleButton.ButtonWithText name="data" label="Data">
-              Data
-            </ToggleButton.ButtonWithText>
+            <ToggleButton.Button name="post" label="Post">
+              <ToggleButton.ButtonText>Post</ToggleButton.ButtonText>
+            </ToggleButton.Button>
+            <ToggleButton.Button name="notifications" label="Notifications">
+              <ToggleButton.ButtonText>Notifications</ToggleButton.ButtonText>
+            </ToggleButton.Button>
+            <ToggleButton.Button name="account" label="Account">
+              <ToggleButton.ButtonText>Account</ToggleButton.ButtonText>
+            </ToggleButton.Button>
+            <ToggleButton.Button name="data" label="Data">
+              <ToggleButton.ButtonText>Data</ToggleButton.ButtonText>
+            </ToggleButton.Button>
           </ToggleButton.Group>
 
           <View

--- a/src/view/screens/DebugMod.tsx
+++ b/src/view/screens/DebugMod.tsx
@@ -273,15 +273,15 @@ export const DebugModScreen = ({}: NativeStackScreenProps<
             label="Scenario"
             values={scenario}
             onChange={setScenario}>
-            <ToggleButton.Button name="label" label="Label">
+            <ToggleButton.ButtonWithText name="label" label="Label">
               Label
-            </ToggleButton.Button>
-            <ToggleButton.Button name="block" label="Block">
+            </ToggleButton.ButtonWithText>
+            <ToggleButton.ButtonWithText name="block" label="Block">
               Block
-            </ToggleButton.Button>
-            <ToggleButton.Button name="mute" label="Mute">
+            </ToggleButton.ButtonWithText>
+            <ToggleButton.ButtonWithText name="mute" label="Mute">
               Mute
-            </ToggleButton.Button>
+            </ToggleButton.ButtonWithText>
           </ToggleButton.Group>
 
           {scenario[0] === 'label' && (
@@ -473,18 +473,20 @@ export const DebugModScreen = ({}: NativeStackScreenProps<
           <Heading title="" subtitle="Results" />
 
           <ToggleButton.Group label="Results" values={view} onChange={setView}>
-            <ToggleButton.Button name="post" label="Post">
+            <ToggleButton.ButtonWithText name="post" label="Post">
               Post
-            </ToggleButton.Button>
-            <ToggleButton.Button name="notifications" label="Notifications">
+            </ToggleButton.ButtonWithText>
+            <ToggleButton.ButtonWithText
+              name="notifications"
+              label="Notifications">
               Notifications
-            </ToggleButton.Button>
-            <ToggleButton.Button name="account" label="Account">
+            </ToggleButton.ButtonWithText>
+            <ToggleButton.ButtonWithText name="account" label="Account">
               Account
-            </ToggleButton.Button>
-            <ToggleButton.Button name="data" label="Data">
+            </ToggleButton.ButtonWithText>
+            <ToggleButton.ButtonWithText name="data" label="Data">
               Data
-            </ToggleButton.Button>
+            </ToggleButton.ButtonWithText>
           </ToggleButton.Group>
 
           <View

--- a/src/view/screens/Storybook/Dialogs.tsx
+++ b/src/view/screens/Storybook/Dialogs.tsx
@@ -67,8 +67,8 @@ export function Dialogs() {
           description, as well as two actions.
         </Prompt.DescriptionText>
         <Prompt.Actions>
-          <Prompt.Cancel>Cancel</Prompt.Cancel>
-          <Prompt.Action onPress={() => {}}>Confirm</Prompt.Action>
+          <Prompt.Cancel />
+          <Prompt.Action cta="Confirm" onPress={() => {}} />
         </Prompt.Actions>
       </Prompt.Outer>
 

--- a/src/view/screens/Storybook/Forms.tsx
+++ b/src/view/screens/Storybook/Forms.tsx
@@ -201,15 +201,15 @@ export function Forms() {
           label="Preferences"
           values={toggleGroupDValues}
           onChange={setToggleGroupDValues}>
-          <ToggleButton.Button name="hide" label="Hide">
+          <ToggleButton.ButtonWithText name="hide" label="Hide">
             Hide
-          </ToggleButton.Button>
-          <ToggleButton.Button name="warn" label="Warn">
+          </ToggleButton.ButtonWithText>
+          <ToggleButton.ButtonWithText name="warn" label="Warn">
             Warn
-          </ToggleButton.Button>
-          <ToggleButton.Button name="show" label="Show">
+          </ToggleButton.ButtonWithText>
+          <ToggleButton.ButtonWithText name="show" label="Show">
             Show
-          </ToggleButton.Button>
+          </ToggleButton.ButtonWithText>
         </ToggleButton.Group>
 
         <View>
@@ -217,15 +217,15 @@ export function Forms() {
             label="Preferences"
             values={toggleGroupDValues}
             onChange={setToggleGroupDValues}>
-            <ToggleButton.Button name="hide" label="Hide">
+            <ToggleButton.ButtonWithText name="hide" label="Hide">
               Hide
-            </ToggleButton.Button>
-            <ToggleButton.Button name="warn" label="Warn">
+            </ToggleButton.ButtonWithText>
+            <ToggleButton.ButtonWithText name="warn" label="Warn">
               Warn
-            </ToggleButton.Button>
-            <ToggleButton.Button name="show" label="Show">
+            </ToggleButton.ButtonWithText>
+            <ToggleButton.ButtonWithText name="show" label="Show">
               Show
-            </ToggleButton.Button>
+            </ToggleButton.ButtonWithText>
           </ToggleButton.Group>
         </View>
       </View>

--- a/src/view/screens/Storybook/Forms.tsx
+++ b/src/view/screens/Storybook/Forms.tsx
@@ -201,15 +201,15 @@ export function Forms() {
           label="Preferences"
           values={toggleGroupDValues}
           onChange={setToggleGroupDValues}>
-          <ToggleButton.ButtonWithText name="hide" label="Hide">
-            Hide
-          </ToggleButton.ButtonWithText>
-          <ToggleButton.ButtonWithText name="warn" label="Warn">
-            Warn
-          </ToggleButton.ButtonWithText>
-          <ToggleButton.ButtonWithText name="show" label="Show">
-            Show
-          </ToggleButton.ButtonWithText>
+          <ToggleButton.Button name="hide" label="Hide">
+            <ToggleButton.ButtonText>Hide</ToggleButton.ButtonText>
+          </ToggleButton.Button>
+          <ToggleButton.Button name="warn" label="Warn">
+            <ToggleButton.ButtonText>Warn</ToggleButton.ButtonText>
+          </ToggleButton.Button>
+          <ToggleButton.Button name="show" label="Show">
+            <ToggleButton.ButtonText>Show</ToggleButton.ButtonText>
+          </ToggleButton.Button>
         </ToggleButton.Group>
 
         <View>
@@ -217,15 +217,15 @@ export function Forms() {
             label="Preferences"
             values={toggleGroupDValues}
             onChange={setToggleGroupDValues}>
-            <ToggleButton.ButtonWithText name="hide" label="Hide">
-              Hide
-            </ToggleButton.ButtonWithText>
-            <ToggleButton.ButtonWithText name="warn" label="Warn">
-              Warn
-            </ToggleButton.ButtonWithText>
-            <ToggleButton.ButtonWithText name="show" label="Show">
-              Show
-            </ToggleButton.ButtonWithText>
+            <ToggleButton.Button name="hide" label="Hide">
+              <ToggleButton.ButtonText>Hide</ToggleButton.ButtonText>
+            </ToggleButton.Button>
+            <ToggleButton.Button name="warn" label="Warn">
+              <ToggleButton.ButtonText>Warn</ToggleButton.ButtonText>
+            </ToggleButton.Button>
+            <ToggleButton.Button name="show" label="Show">
+              <ToggleButton.ButtonText>Show</ToggleButton.ButtonText>
+            </ToggleButton.Button>
           </ToggleButton.Group>
         </View>
       </View>


### PR DESCRIPTION
Follow-up to https://github.com/bluesky-social/social-app/pull/3407.

I'm continuing removing special cases so that we can confidently render stuff and know whether it supports text or not.

- `Prompt.Cancel` and `Prompt.Action`: Those are barely used, and all usages are text-only. I'm just enforcing that they _don't_ take `children`. The `cta` prop is then sufficient. (Side note: We should really stop using `PropsWithChildren`.)
- `Toggle.Button` -> `Toggle.ButtonWithText`: This case is more interesting. I settled on a convention:
  - `Button` is a raw vanilla button with no opinion on children. Can't nest strings there (lint rule would flag it).
  - `ButtonText` is a button-specific text component. Similar to `ButtonText` in normal buttons.
  - <s>`ButtonWithText` **(new!)** combines them as a shortcut. The suffix means the lint rule would let you nest text there.</s>
    - This didn't fit very well, see below. We can make it work but doesn't seem worth it. If we hate the long names, can rename to `ToggleButton.Text` and do the same for others but I didn't do it here.

The strategy for `Toggle.Button` seems viable for the main `Button` as well. But I won't do it here.

## Test Plan

Storybook.

Would appreciate someone checking the UI.

<img width="450" alt="Screenshot 2024-04-04 at 22 53 38" src="https://github.com/bluesky-social/social-app/assets/810438/c012ea35-3c98-4db5-88f9-09b238bdf488">


<img width="620" alt="Screenshot 2024-04-04 at 22 35 16" src="https://github.com/bluesky-social/social-app/assets/810438/6b838b86-0fa5-4d55-b96f-667bbeedd5ff">
