### PR TITLE
adjust `app.config.js` to prevent development manifest error

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -130,11 +130,15 @@ module.exports = function (config) {
         // TestFlight builds
         enabled: IS_TESTFLIGHT,
         fallbackToCacheTimeout: 30000,
-        codeSigningCertificate: './code-signing/certificate.pem',
-        codeSigningMetadata: {
-          keyid: 'main',
-          alg: 'rsa-v1_5-sha256',
-        },
+        codeSigningCertificate: IS_TESTFLIGHT
+          ? './code-signing/certificate.pem'
+          : undefined,
+        codeSigningMetadata: IS_TESTFLIGHT
+          ? {
+              keyid: 'main',
+              alg: 'rsa-v1_5-sha256',
+            }
+          : undefined,
         checkAutomatically: 'NEVER',
         channel: UPDATES_CHANNEL,
       },


### PR DESCRIPTION
We don't want to enable code signing in development, so we can set `codeSigningCertificate` and `codeSigningMetadata` to `undefined`.

Once we actually start using this in prod, we can probably simplify this down to just only adding the `updates` block when `EXPO_PUBLIC_ENV` is not `development`. However, because we will be incrementally testing changes in production, we want to leave the updates block here regardless of whether they are enabled or not.