### PR TITLE
prevent deployment race conditions

### DIFF
--- a/.github/workflows/bundle-deploy-eas-update.yml
+++ b/.github/workflows/bundle-deploy-eas-update.yml
@@ -18,6 +18,10 @@ on:
         description: Runtime version (in x.x.x format) that this update is for
         required: true
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
   bundleDeploy:
     name: Bundle and Deploy EAS Update
@@ -44,7 +48,18 @@ jobs:
       - name: ⬇️ Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 100
+          fetch-depth: 0
+
+      - name: ⬇️ Get last successful deployment commit from the cache
+        id: get-base-commit
+        uses: actions/cache@v4
+        with:
+          path: last-successful-commit-hash.txt
+          key: last-successful-deployment-commit-${{ github.ref_name }}
+
+      - name: Add the last successful deployment commit to the output
+        id: last-successful-commit
+        run: echo base-commit=$(cat last-successful-commit-hash.txt) >> "$GITHUB_OUTPUT"
 
       - name: ⬇️ Fetch commits from base branch
         if: ${{ github.ref != 'refs/heads/main' }}
@@ -57,12 +72,12 @@ jobs:
           if [ -z "${{ inputs.channel == 'production' }}" ]; then
             echo base-commit=$(git show-ref -s ${{ inputs.runtimeVersion }}) >> "$GITHUB_OUTPUT"
           else
-            echo base-commit=$(git log -n 1 --skip 1 main --pretty=format:'%H') >> "$GITHUB_OUTPUT"
+            echo base-commit=${{ steps.last-successful-commit.base-commit }} >> "$GITHUB_OUTPUT"
           fi
 
       - name: ✓ Make sure we found a base commit
         run: |
-          if [ -z "${{ steps.base-commit.outputs.base-commit }}" ]; then
+          if [ -z "${{ steps.base-commit.outputs.base-commit }}" && ${{ inputs.channel == 'production' }} ]; then
             echo "Could not find a base commit for this release. Exiting."
             exit 1
           fi
@@ -82,7 +97,6 @@ jobs:
         uses: expo/expo-github-action/fingerprint@main
         with:
           previous-git-commit: ${{ steps.base-commit.outputs.base-commit }}
-          args:
 
       - name: 👀 Debug fingerprint
         id: fingerprint-debug
@@ -90,7 +104,8 @@ jobs:
           echo "previousGitCommit=${{ steps.fingerprint.outputs.previous-git-commit }} currentGitCommit=${{ steps.fingerprint.outputs.current-git-commit }}"
           echo "isPreviousFingerprintEmpty=${{ steps.fingerprint.outputs.previous-fingerprint == '' }}"
           
-          fingerprintDiff="${{ steps.fingerprint.outputs.fingerprint-diff }}"
+          fingerprintDiff='$(echo "${{ steps.fingerprint.outputs.fingerprint-diff }}")'
+          
           if [[ $fingerprintDiff =~ "bareRncliAutolinking" || $fingerprintDiff =~ "expoAutolinkingAndroid" || $fingerprintDiff =~ "expoAutolinkingIos" ]]; then
             echo fingerprint-is-different="true" >> "$GITHUB_OUTPUT"
           else
@@ -136,6 +151,8 @@ jobs:
           RUNTIME_VERSION: ${{ inputs.runtimeVersion }}
           CHANNEL_NAME: ${{ inputs.channel || 'testflight' }}
 
+      - name: Save successful deployment commit hash
+        run: echo ${{ steps.fingerprint.outputs.current-git-commit }} > last-successful-commit-hash.txt
 
   # GitHub actions are horrible so let's just copy paste this in
   buildIfNecessaryIOS:

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "e2e:run": "NODE_ENV=test detox test --configuration ios.sim.debug --take-screenshots all",
     "perf:test": "NODE_ENV=test maestro test",
     "perf:test:run": "NODE_ENV=test maestro test __e2e__/maestro/scroll.yaml",
-    "perf:test:measure": "NODE_ENV=test flashlight test --bundleId xyz.blueskyweb.app --testCommand 'yarn perf:test' --duration 150000 --resultsFilePath .perf/results.json",
+    "perf:test:measure": "NODE_ENV=test flashlight test --bundleId xyz.blueskyweb.app --testCommand \"yarn perf:test\" --duration 150000 --resultsFilePath .perf/results.json",
     "perf:test:results": "NODE_ENV=test flashlight report .perf/results.json",
     "perf:measure": "NODE_ENV=test flashlight measure",
     "intl:build": "yarn intl:extract && yarn intl:compile",


### PR DESCRIPTION
Because merges can happen quickly, we need to make sure that the previous commit hash we use belongs to the ***last successfully deployed update*** for internal builds, not just the previous commit.

This PR simply adds a GitHub action cache that contains the commit of the last successfully deployed update. It is restored from the cache on build for comparison and is updated at the end of the run.

Also properly handles JSON in the diff variable. Because JSON uses `"` and we surrounded the variable name with `"`, bash was unhappy. Instead, we surround the JSON with `'` since it will not include single quotes.