### PR TITLE
Show profile icon in bottom bar of web and miscellaneous minor fixes

### DIFF
--- a/src/view/shell/bottom-bar/BottomBar.tsx
+++ b/src/view/shell/bottom-bar/BottomBar.tsx
@@ -229,12 +229,11 @@ export function BottomBar({navigation}: BottomTabBarProps) {
                         styles.ctrlIcon,
                         pal.text,
                         styles.profileIcon,
-                        styles.onProfile,
                         {borderColor: pal.text.color},
                       ]}>
                       <UserAvatar
                         avatar={profile?.avatar}
-                        size={27}
+                        size={28}
                         // See https://github.com/bluesky-social/social-app/pull/1801:
                         usePlainRNImage={true}
                         type={profile?.associated?.labeler ? 'labeler' : 'user'}

--- a/src/view/shell/bottom-bar/BottomBarStyles.tsx
+++ b/src/view/shell/bottom-bar/BottomBarStyles.tsx
@@ -1,4 +1,5 @@
 import {StyleSheet} from 'react-native'
+
 import {colors} from 'lib/styles'
 
 export const styles = StyleSheet.create({
@@ -63,10 +64,9 @@ export const styles = StyleSheet.create({
     top: -2.5,
   },
   profileIcon: {
-    top: -4,
-  },
-  onProfile: {
-    borderWidth: 1,
+    top: -6,
+    borderWidth: 2,
     borderRadius: 100,
+    borderColor: 'transparent',
   },
 })


### PR DESCRIPTION
[Note] This PR is based on [#3351](https://github.com/bluesky-social/social-app/pull/3351) . I have resolved conflict with main branch.

On current version of web, when width of browser is narrow, bottom bar is shown as follows: 

<Light, user profile not selected>
![current_light_1](https://github.com/bluesky-social/social-app/assets/7834440/e6272445-f577-4efe-907a-48b588b546d6)

<Light, user profile selected>
![current_light_2](https://github.com/bluesky-social/social-app/assets/7834440/1ab36dfc-1586-46b3-99ca-a276d1d6b140)

<Dark, user profile not selected>
![current_dark_1](https://github.com/bluesky-social/social-app/assets/7834440/319a31ca-7bff-406e-8b82-116bb612acc0)

<Dark, user profile selected>
![current_dark_2](https://github.com/bluesky-social/social-app/assets/7834440/087b65c1-3811-4946-97ae-a07a758e8ff9)

User profile icon is not shown on the bottom bar on the web version although shown on the iOS / Android version. Thus user cannot recognize current account by the profile icon.

I have implemented that user profile is shown on the web version same as iOS / Android version as follows:

<Light, user profile not selected>
![pr2_light1](https://github.com/bluesky-social/social-app/assets/7834440/fd1884fc-5d04-490d-8c0a-e84b7ce3f9da)

<Light, user profile selected>
![pr2_light2](https://github.com/bluesky-social/social-app/assets/7834440/43839e6f-6a29-42d4-8521-27b5880f51bb)

<Dark, user profile not selected>
![pr2_dark1](https://github.com/bluesky-social/social-app/assets/7834440/9285e8a7-1237-43c9-9016-c4f7e808e3ea)

<Dark, user profile selected>
![pr2_dark2](https://github.com/bluesky-social/social-app/assets/7834440/a0b16a19-0d76-4bf1-8104-fd0ec79e7c60)

Along with this fix, some additional fix has been applied as follows: 

+ I have changed the border width when a user profile is selected from 1px to 2px. This is because border do not display correctly in lower resolution environments (ex. low-end smartphones and 96dpi PCs). This change has been applied both web (`BottomBarWeb.tsx`) and app (`BottomBar.tsx`) version of bottom bar.

+ In current version, `top` style setting in `BottomBarStyles.tsx` is not applied correctly to each `<Icon>` in `BottomBarWeb.tsx`. Because `<Icon>` is rendered to `<svg>` on the web page, and `top` style setting to `<svg>` is ignored. To fix this, I have wrapped each `<Icon>` with `<View>` and apply style to the `<View>`.

+ Redundant nested `{hasSession ...` clause in `BottomBarWeb` function in `BottomBarWeb.tsx` has been deleted.

[Note] Please review and confirm this modification based on these points:

+ I have confirmed this modification on Web (PC), Android (real device) and iOS (simulator). I cannot confirm on real iOS device because I do not own it. 
+ I have confirmed by using my personal Bluesky account, but I cannot confirm by using labeler account. 