### PR TITLE
only run labelers for core team

### DIFF
--- a/.github/workflows/pull-request-commit.yml
+++ b/.github/workflows/pull-request-commit.yml
@@ -6,20 +6,24 @@ name: PR labeler
 on:
   push:
     branches: [main]
-  pull_request:
-    types: [opened, synchronize]
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  pull-requests: write
+  actions: write
+  contents: read
+
 jobs:
   webpack-analyzer:
     runs-on: ubuntu-22.04
     if: ${{ github.event_name == 'pull_request' }}
-    permissions:
-      pull-requests: write
-      actions: write
     steps:
       - name: ⬇️ Checkout
         uses: actions/checkout@v4
@@ -96,9 +100,6 @@ jobs:
     runs-on: ubuntu-22.04
     if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
     concurrency: fingerprint-${{ github.event_name != 'pull_request' && 'main' || github.run_id }}
-    permissions:
-      pull-requests: write
-      actions: write
     steps:
       - name: ⬇️ Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/pull-request-commit.yml
+++ b/.github/workflows/pull-request-commit.yml
@@ -6,7 +6,8 @@ name: PR labeler
 on:
   push:
     branches: [main]
-  pull_request_target:
+  pull_request:
+    types: [opened, synchronize]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
@@ -20,7 +21,7 @@ permissions:
 jobs:
   webpack-analyzer:
     runs-on: ubuntu-22.04
-    if: ${{ github.event_name == 'pull_request' }}
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     steps:
       - name: ⬇️ Checkout
         uses: actions/checkout@v4
@@ -95,7 +96,7 @@ jobs:
 
   test-suite-fingerprint:
     runs-on: ubuntu-22.04
-    if: ${{ github.event_name == 'pull_request' || github.event_name == 'push' }}
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'push' }}
     concurrency: fingerprint-${{ github.event_name != 'pull_request' && 'main' || github.run_id }}
     steps:
       - name: ⬇️ Checkout

--- a/.github/workflows/pull-request-commit.yml
+++ b/.github/workflows/pull-request-commit.yml
@@ -7,9 +7,6 @@ on:
   push:
     branches: [main]
   pull_request_target:
-    types:
-      - opened
-      - synchronize
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}


### PR DESCRIPTION
In the neverending battle against GitHub actions, I stumbled across this issue https://github.com/marocchino/sticky-pull-request-comment/issues/930

It looks like the proper `on` event to use is `pull_request_target` rather than `pull_request` 🤯 