### PR TITLE
[Experiment] Auto-expand follow suggestions on web

### DIFF
--- a/src/lib/statsig/statsig.tsx
+++ b/src/lib/statsig/statsig.tsx
@@ -78,6 +78,10 @@ function toStatsigUser(did: string | undefined) {
   return {
     userID,
     platform: Platform.OS,
+    custom: {
+      // Need to specify here too for gating.
+      platform: Platform.OS,
+    },
   }
 }
 

--- a/src/screens/Profile/Header/ProfileHeaderStandard.tsx
+++ b/src/screens/Profile/Header/ProfileHeaderStandard.tsx
@@ -10,7 +10,9 @@ import {FontAwesomeIcon} from '@fortawesome/react-native-fontawesome'
 import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
+import {useGate} from '#/lib/statsig/statsig'
 import {logger} from '#/logger'
+import {isWeb} from '#/platform/detection'
 import {Shadow} from '#/state/cache/types'
 import {useModalControls} from '#/state/modals'
 import {
@@ -78,6 +80,9 @@ let ProfileHeaderStandard = ({
     })
   }, [track, openModal, profile])
 
+  const autoExpandSuggestionsOnProfileFollow = useGate(
+    'autoexpand_suggestions_on_profile_follow',
+  )
   const onPressFollow = () => {
     requireAuth(async () => {
       try {
@@ -91,6 +96,9 @@ let ProfileHeaderStandard = ({
             )}`,
           ),
         )
+        if (isWeb && autoExpandSuggestionsOnProfileFollow) {
+          setShowSuggestedFollows(true)
+        }
       } catch (e: any) {
         if (e?.name !== 'AbortError') {
           logger.error('Failed to follow', {message: String(e)})


### PR DESCRIPTION
If you're in the `autoexpand_suggestions_on_profile_follow` gate, you'll get this behavior:

https://github.com/bluesky-social/social-app/assets/810438/08656e5c-ea18-4e5a-8745-a6ed24ea2903

It's web-only because of scrolling issues on iOS/Android.

I've gated it as web-only in the code but I also had to add web-only condition to the gate setup itself. This is because we don't want to count exposures to the flag being on unless we're actually providing the changed behavior.