### PR TITLE
Implement back button fix for all places in the app

### DIFF
--- a/src/components/Dialog/context.ts
+++ b/src/components/Dialog/context.ts
@@ -39,7 +39,8 @@ export function useDialogControl(): DialogOuterProps['control'] {
         control.current.open()
       },
       close: cb => {
-        control.current.close(cb)
+        control.current.close()
+        cb?.()
       },
     }),
     [id, control],


### PR DESCRIPTION
This follows up https://github.com/bluesky-social/social-app/pull/3428

We fixed the Android back button in the previous PR, but it breaks the way we were using the callback in the post composer. This fixes the issue so that our prompts close properly _everywhere_ and the back button works _everywhere_.

I don't totally understand what is going on here though. I think maybe there's a wrong type here, or the `control` ref is getting updated somewhere. Supposedly `control.close()` accepts a callback, however I don't see anywhere that is used. I want to take a better pass at that, or at least figure out why this was so borked in the first place.

## Test

### Web

- Attempt to discard a post
- Hide a post

### Android (same for iOS minus the back button)

- Attempt to discard a post
- Hide a post
- Visit another post
- Use the back button to verify it still works