### PR TITLE
[Statsig] Track like/follow metadata

### DIFF
--- a/src/lib/statsig/events.ts
+++ b/src/lib/statsig/events.ts
@@ -67,6 +67,7 @@ export type LogEvents = {
   'post:like': {
     doesLikerFollowPoster: boolean | undefined
     doesPosterFollowLiker: boolean | undefined
+    likerClout: number | undefined
     postClout: number | undefined
     logContext: 'FeedItem' | 'PostThreadItem' | 'Post'
   }
@@ -82,6 +83,7 @@ export type LogEvents = {
   'profile:follow': {
     didBecomeMutual: boolean | undefined
     followeeClout: number | undefined
+    followerClout: number | undefined
     logContext:
       | 'RecommendedFollowsItem'
       | 'PostThreadItem'

--- a/src/lib/statsig/events.ts
+++ b/src/lib/statsig/events.ts
@@ -77,6 +77,7 @@ export type LogEvents = {
     logContext: 'FeedItem' | 'PostThreadItem' | 'Post'
   }
   'profile:follow': {
+    didBecomeMutual: boolean | undefined
     logContext:
       | 'RecommendedFollowsItem'
       | 'PostThreadItem'

--- a/src/lib/statsig/events.ts
+++ b/src/lib/statsig/events.ts
@@ -65,6 +65,8 @@ export type LogEvents = {
     logContext: 'Composer'
   }
   'post:like': {
+    doesLikerFollowPoster: boolean | undefined
+    doesPosterFollowLiker: boolean | undefined
     logContext: 'FeedItem' | 'PostThreadItem' | 'Post'
   }
   'post:repost': {

--- a/src/lib/statsig/events.ts
+++ b/src/lib/statsig/events.ts
@@ -67,6 +67,7 @@ export type LogEvents = {
   'post:like': {
     doesLikerFollowPoster: boolean | undefined
     doesPosterFollowLiker: boolean | undefined
+    postClout: number | undefined
     logContext: 'FeedItem' | 'PostThreadItem' | 'Post'
   }
   'post:repost': {
@@ -80,6 +81,7 @@ export type LogEvents = {
   }
   'profile:follow': {
     didBecomeMutual: boolean | undefined
+    followeeClout: number | undefined
     logContext:
       | 'RecommendedFollowsItem'
       | 'PostThreadItem'

--- a/src/lib/statsig/statsig.tsx
+++ b/src/lib/statsig/statsig.tsx
@@ -43,6 +43,14 @@ export function attachRouteToLogEvents(
   getCurrentRouteName = getRouteName
 }
 
+export function toClout(n: number | null | undefined): number | undefined {
+  if (n == null) {
+    return undefined
+  } else {
+    return Math.max(0, Math.round(Math.log(n)))
+  }
+}
+
 export function logEvent<E extends keyof LogEvents>(
   eventName: E & string,
   rawMetadata: LogEvents[E] & FlatJSONRecord,

--- a/src/state/queries/post.ts
+++ b/src/state/queries/post.ts
@@ -4,7 +4,7 @@ import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query'
 
 import {track} from '#/lib/analytics/analytics'
 import {useToggleMutationQueue} from '#/lib/hooks/useToggleMutationQueue'
-import {logEvent, LogEvents} from '#/lib/statsig/statsig'
+import {logEvent, LogEvents, toClout} from '#/lib/statsig/statsig'
 import {updatePostShadow} from '#/state/cache/post-shadow'
 import {Shadow} from '#/state/cache/types'
 import {getAgent, useSession} from '#/state/session'
@@ -143,20 +143,12 @@ function usePostLikeMutation(
         doesLikerFollowPoster: postAuthor.viewer
           ? Boolean(postAuthor.viewer.following)
           : undefined,
-        likerClout:
-          ownProfile?.followersCount != null
-            ? Math.max(0, Math.round(Math.log(ownProfile.followersCount)))
-            : undefined,
+        likerClout: toClout(ownProfile?.followersCount),
         postClout:
           post.likeCount != null &&
           post.repostCount != null &&
           post.replyCount != null
-            ? Math.max(
-                0,
-                Math.round(
-                  Math.log(post.likeCount + post.repostCount + post.replyCount),
-                ),
-              )
+            ? toClout(post.likeCount + post.repostCount + post.replyCount)
             : undefined,
       })
       return getAgent().like(uri, cid)

--- a/src/state/queries/post.ts
+++ b/src/state/queries/post.ts
@@ -121,7 +121,7 @@ function usePostLikeMutation(
   logContext: LogEvents['post:like']['logContext'],
   post: Shadow<AppBskyFeedDefs.PostView>,
 ) {
-  const postAuthorViewer = post.author.viewer
+  const postAuthor = post.author
   return useMutation<
     {uri: string}, // responds with the uri of the like
     Error,
@@ -130,12 +130,23 @@ function usePostLikeMutation(
     mutationFn: ({uri, cid}) => {
       logEvent('post:like', {
         logContext,
-        doesPosterFollowLiker: postAuthorViewer
-          ? Boolean(postAuthorViewer.followedBy)
+        doesPosterFollowLiker: postAuthor.viewer
+          ? Boolean(postAuthor.viewer.followedBy)
           : undefined,
-        doesLikerFollowPoster: postAuthorViewer
-          ? Boolean(postAuthorViewer.following)
+        doesLikerFollowPoster: postAuthor.viewer
+          ? Boolean(postAuthor.viewer.following)
           : undefined,
+        postClout:
+          post.likeCount != null &&
+          post.repostCount != null &&
+          post.replyCount != null
+            ? Math.max(
+                0,
+                Math.round(
+                  Math.log(post.likeCount + post.repostCount + post.replyCount),
+                ),
+              )
+            : undefined,
       })
       return getAgent().like(uri, cid)
     },

--- a/src/state/queries/profile.ts
+++ b/src/state/queries/profile.ts
@@ -20,7 +20,7 @@ import {track} from '#/lib/analytics/analytics'
 import {uploadBlob} from '#/lib/api'
 import {until} from '#/lib/async/until'
 import {useToggleMutationQueue} from '#/lib/hooks/useToggleMutationQueue'
-import {logEvent, LogEvents} from '#/lib/statsig/statsig'
+import {logEvent, LogEvents, toClout} from '#/lib/statsig/statsig'
 import {Shadow} from '#/state/cache/types'
 import {STALE} from '#/state/queries'
 import {resetProfilePostsQueries} from '#/state/queries/post-feed'
@@ -267,14 +267,8 @@ function useProfileFollowMutation(
         didBecomeMutual: profile.viewer
           ? Boolean(profile.viewer.followedBy)
           : undefined,
-        followeeClout:
-          profile.followersCount != null
-            ? Math.max(0, Math.round(Math.log(profile.followersCount)))
-            : undefined,
-        followerClout:
-          ownProfile?.followersCount != null
-            ? Math.max(0, Math.round(Math.log(ownProfile.followersCount)))
-            : undefined,
+        followeeClout: toClout(profile.followersCount),
+        followerClout: toClout(ownProfile?.followersCount),
       })
       return await getAgent().follow(did)
     },

--- a/src/state/queries/profile.ts
+++ b/src/state/queries/profile.ts
@@ -202,7 +202,7 @@ export function useProfileFollowMutationQueue(
   const queryClient = useQueryClient()
   const did = profile.did
   const initialFollowingUri = profile.viewer?.following
-  const followMutation = useProfileFollowMutation(logContext)
+  const followMutation = useProfileFollowMutation(logContext, profile)
   const unfollowMutation = useProfileUnfollowMutation(logContext)
 
   const queueToggle = useToggleMutationQueue({
@@ -252,10 +252,16 @@ export function useProfileFollowMutationQueue(
 
 function useProfileFollowMutation(
   logContext: LogEvents['profile:follow']['logContext'],
+  profile: Shadow<AppBskyActorDefs.ProfileViewDetailed>,
 ) {
   return useMutation<{uri: string; cid: string}, Error, {did: string}>({
     mutationFn: async ({did}) => {
-      logEvent('profile:follow', {logContext})
+      logEvent('profile:follow', {
+        logContext,
+        didBecomeMutual: profile.viewer
+          ? Boolean(profile.viewer.followedBy)
+          : undefined,
+      })
       return await getAgent().follow(did)
     },
     onSuccess(data, variables) {

--- a/src/state/queries/profile.ts
+++ b/src/state/queries/profile.ts
@@ -261,6 +261,10 @@ function useProfileFollowMutation(
         didBecomeMutual: profile.viewer
           ? Boolean(profile.viewer.followedBy)
           : undefined,
+        followeeClout:
+          profile.followersCount != null
+            ? Math.max(0, Math.round(Math.log(profile.followersCount)))
+            : undefined,
       })
       return await getAgent().follow(did)
     },


### PR DESCRIPTION
For follows:

- Track whether you became mutual
- Track the "clout" level of the person you're following
- Track the "clout" level of the person who's doing the following (you)

For likes:

- Track the "clout" level of the post you're liking
- Track the "clout" level of the person who's doing the liking (you)
- Whether you follow the poster
- Whether the poster follows you

The "clout level" of `something` is defined as `Math.max(0, Math.round(Math.log(something)))`. I'm using this as a universal measure for easier grouping in stats.

When we can't grab something out of the objects we have, I send `undefined`.