### PR TITLE
Bump `async-storage` to comply with App Store guidelines

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "@mattermost/react-native-paste-input": "^0.6.4",
     "@miblanchard/react-native-slider": "^2.3.1",
     "@radix-ui/react-dropdown-menu": "^2.0.6",
-    "@react-native-async-storage/async-storage": "1.21.0",
+    "@react-native-async-storage/async-storage": "1.23.1",
     "@react-native-masked-view/masked-view": "0.3.0",
     "@react-native-menu/menu": "^0.8.0",
     "@react-native-picker/picker": "2.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4836,10 +4836,10 @@
   dependencies:
     "@babel/runtime" "^7.13.10"
 
-"@react-native-async-storage/async-storage@1.21.0":
-  version "1.21.0"
-  resolved "https://registry.yarnpkg.com/@react-native-async-storage/async-storage/-/async-storage-1.21.0.tgz#d7e370028e228ab84637016ceeb495878b7a44c8"
-  integrity sha512-JL0w36KuFHFCvnbOXRekqVAUplmOyT/OuCQkogo6X98MtpSaJOKEAeZnYO8JB0U/RIEixZaGI5px73YbRm/oag==
+"@react-native-async-storage/async-storage@1.23.1":
+  version "1.23.1"
+  resolved "https://registry.yarnpkg.com/@react-native-async-storage/async-storage/-/async-storage-1.23.1.tgz#cad3cd4fab7dacfe9838dce6ecb352f79150c883"
+  integrity sha512-Qd2kQ3yi6Y3+AcUlrHxSLlnBvpdCEMVGFlVBneVOjaFaPU61g1huc38g339ysXspwY1QZA2aNhrk/KlHGO+ewA==
   dependencies:
     merge-options "^3.0.4"
 


### PR DESCRIPTION
## Why

Apple recently added some requires for accessing some native API categories. One of those API categories is `NSPrivacyAccessedAPICategoryFileTimestamp`, which is used by the `async-storage` package. This was added here.

https://github.com/react-native-async-storage/async-storage/pull/1075

There are still some APIs that we will need to either manually add declarations for or upgrade packages for when possible. Will keep an eye on those.

## Test Plan

The only changes between `1.21` and `1.23.1` are some bug fixes and some changes for the new architecture. We shouldn't run into any issues with this change. I have built the app for iOS without issue.