### PR TITLE
[Experiment] Ignore the persisted tab

### DIFF
--- a/src/state/shell/selected-feed.tsx
+++ b/src/state/shell/selected-feed.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
-import * as persisted from '#/state/persisted'
+
+import {useGate} from '#/lib/statsig/statsig'
 import {isWeb} from '#/platform/detection'
+import * as persisted from '#/state/persisted'
 
 type StateContext = string
 type SetContext = (v: string) => void
@@ -8,7 +10,7 @@ type SetContext = (v: string) => void
 const stateContext = React.createContext<StateContext>('home')
 const setContext = React.createContext<SetContext>((_: string) => {})
 
-function getInitialFeed() {
+function getInitialFeed(startSessionWithFollowing: boolean) {
   if (isWeb) {
     if (window.location.pathname === '/') {
       const params = new URLSearchParams(window.location.search)
@@ -24,16 +26,21 @@ function getInitialFeed() {
       return feedFromSession
     }
   }
-  const feedFromPersisted = persisted.get('lastSelectedHomeFeed')
-  if (feedFromPersisted) {
-    // Fall back to the last chosen one across all tabs.
-    return feedFromPersisted
+  if (!startSessionWithFollowing) {
+    const feedFromPersisted = persisted.get('lastSelectedHomeFeed')
+    if (feedFromPersisted) {
+      // Fall back to the last chosen one across all tabs.
+      return feedFromPersisted
+    }
   }
   return 'home'
 }
 
 export function Provider({children}: React.PropsWithChildren<{}>) {
-  const [state, setState] = React.useState(getInitialFeed)
+  const startSessionWithFollowing = useGate('start_session_with_following')
+  const [state, setState] = React.useState(() =>
+    getInitialFeed(startSessionWithFollowing),
+  )
 
   const saveState = React.useCallback((feed: string) => {
     setState(feed)


### PR DESCRIPTION
We currently always persist the last selected tab between reloads. I think this more obviously makes sense when you only have two such tabs (like For You vs Following), but it might be easy to miss where you landed when you open the app.

We previously used to persist on mobile but reset to Following on web.

I want to run an experiment where we always put you into Following when reloading the app. On the web, this would be if you open a new browser tab (or a window). Reloads within the current tab would still preserve the selected tab until it's closed. This might be a little bit annoying, or a little bit helpful, or some unfortunate mix of those.

Let's give it a try under a gate?

## Test Plan

Flipped the gate. New window started from Following.

Same on mobile after quitting the app — getting Following.