### PR TITLE
Keep each deployment job in a separate concurrency group

### DIFF
--- a/.github/workflows/bundle-deploy-eas-update.yml
+++ b/.github/workflows/bundle-deploy-eas-update.yml
@@ -18,14 +18,13 @@ on:
         description: Runtime version (in x.x.x format) that this update is for
         required: true
 
-concurrency:
-    group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
-    cancel-in-progress: true
-
 jobs:
   bundleDeploy:
     name: Bundle and Deploy EAS Update
     runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}-deploy
+      cancel-in-progress: true
     outputs:
       fingerprint-is-different: ${{ steps.fingerprint-debug.outputs.fingerprint-is-different }}
 
@@ -166,6 +165,9 @@ jobs:
   buildIfNecessaryIOS:
     name: Build and Submit iOS
     runs-on: macos-14
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}-build-ios
+      cancel-in-progress: false
     needs: [bundleDeploy]
     # Gotta check if its NOT '[]' because any md5 hash in the outputs is detected as a possible secret and won't be
     # available here
@@ -231,6 +233,9 @@ jobs:
   buildIfNecessaryAndroid:
     name: Build and Submit Android
     runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}-build-android
+      cancel-in-progress: false
     needs: [ bundleDeploy ]
     # Gotta check if its NOT '[]' because any md5 hash in the outputs is detected as a possible secret and won't be
     # available here


### PR DESCRIPTION
One more small change to the bundle/deploy action. Because building of a new IPA/APK can be slow, we don't want to cancel this whole workflow if another change gets merged into main. Instead, we only want to cancel the deploy script. Any new builds that have been started should be kept running.