### PR TITLE
[Statsig] Instrument feed display

### DIFF
--- a/src/lib/statsig/events.ts
+++ b/src/lib/statsig/events.ts
@@ -44,6 +44,12 @@ export type LogEvents = {
   }
   'onboarding:moderation:nextPressed': {}
   'onboarding:finished:nextPressed': {}
+  'home:feedDisplayed': {
+    feedUrl: string
+    feedType: string
+    index: number
+    reason: 'focus' | 'tabbar-click' | 'pager-swipe' | 'desktop-sidebar-click'
+  }
   'feed:endReached': {
     feedUrl: string
     feedType: string

--- a/src/view/screens/Home.tsx
+++ b/src/view/screens/Home.tsx
@@ -2,8 +2,9 @@ import React from 'react'
 import {ActivityIndicator, AppState, StyleSheet, View} from 'react-native'
 import {useFocusEffect} from '@react-navigation/native'
 
+import {useNonReactiveCallback} from '#/lib/hooks/useNonReactiveCallback'
 import {useSetTitle} from '#/lib/hooks/useSetTitle'
-import {useGate} from '#/lib/statsig/statsig'
+import {logEvent, LogEvents, useGate} from '#/lib/statsig/statsig'
 import {emitSoftReset} from '#/state/events'
 import {FeedSourceInfo, usePinnedFeedsInfos} from '#/state/queries/feed'
 import {FeedDescriptor, FeedParams} from '#/state/queries/post-feed'
@@ -79,7 +80,7 @@ function HomeScreenReady({
     // This is supposed to only happen on the web when you use the right nav.
     if (selectedIndex !== lastPagerReportedIndexRef.current) {
       lastPagerReportedIndexRef.current = selectedIndex
-      pagerRef.current?.setPage(selectedIndex)
+      pagerRef.current?.setPage(selectedIndex, 'desktop-sidebar-click')
     }
   }, [selectedIndex])
 
@@ -94,6 +95,17 @@ function HomeScreenReady({
         setDrawerSwipeDisabled(false)
       }
     }, [setDrawerSwipeDisabled, selectedIndex, setMinimalShellMode]),
+  )
+
+  useFocusEffect(
+    useNonReactiveCallback(() => {
+      logEvent('home:feedDisplayed', {
+        index: selectedIndex,
+        feedType: selectedFeed.split('|')[0],
+        feedUrl: selectedFeed,
+        reason: 'focus',
+      })
+    }),
   )
 
   const disableMinShellOnForegrounding = useGate(
@@ -116,11 +128,26 @@ function HomeScreenReady({
     (index: number) => {
       setMinimalShellMode(false)
       setDrawerSwipeDisabled(index > 0)
-      const feed = allFeeds[index]
-      setSelectedFeed(feed)
-      lastPagerReportedIndexRef.current = index
+      if (lastPagerReportedIndexRef.current !== index) {
+        lastPagerReportedIndexRef.current = index
+        const feed = allFeeds[index]
+        setSelectedFeed(feed)
+      }
     },
     [setDrawerSwipeDisabled, setSelectedFeed, setMinimalShellMode, allFeeds],
+  )
+
+  const onPageSelecting = React.useCallback(
+    (index: number, reason: LogEvents['home:feedDisplayed']['reason']) => {
+      const feed = allFeeds[index]
+      logEvent('home:feedDisplayed', {
+        index,
+        feedType: feed.split('|')[0],
+        feedUrl: feed,
+        reason,
+      })
+    },
+    [allFeeds],
   )
 
   const onPressSelected = React.useCallback(() => {
@@ -175,6 +202,7 @@ function HomeScreenReady({
       ref={pagerRef}
       testID="homeScreen"
       initialPage={selectedIndex}
+      onPageSelecting={onPageSelecting}
       onPageSelected={onPageSelected}
       onPageScrollStateChanged={onPageScrollStateChanged}
       renderTabBar={renderTabBar}>

--- a/src/view/screens/Home.tsx
+++ b/src/view/screens/Home.tsx
@@ -128,11 +128,9 @@ function HomeScreenReady({
     (index: number) => {
       setMinimalShellMode(false)
       setDrawerSwipeDisabled(index > 0)
-      if (lastPagerReportedIndexRef.current !== index) {
-        lastPagerReportedIndexRef.current = index
-        const feed = allFeeds[index]
-        setSelectedFeed(feed)
-      }
+      const feed = allFeeds[index]
+      setSelectedFeed(feed)
+      lastPagerReportedIndexRef.current = index
     },
     [setDrawerSwipeDisabled, setSelectedFeed, setMinimalShellMode, allFeeds],
   )


### PR DESCRIPTION
Adds an event that fires when a feed is displayed, along with the index and the reason. It was a bit tricky to figure out the right place to thread these through. This is the minimally invasive way I've found.

## Test Plan

Add `console.log` to `logEvent` in `statsig.tsx`.

- Reload
- Use tabbar
- Use swipe
- On desktop, use right nav
- Switch between tabs

You should see events firing according to the schema.