### PR TITLE
Use new button for PostThreadItem and list follow buttons

### DIFF
--- a/src/view/com/post-thread/PostThreadFollowBtn.tsx
+++ b/src/view/com/post-thread/PostThreadFollowBtn.tsx
@@ -1,24 +1,10 @@
 import React from 'react'
-import {View} from 'react-native'
 import {AppBskyActorDefs} from '@atproto/api'
-import {msg, Trans} from '@lingui/macro'
-import {useLingui} from '@lingui/react'
 import {useNavigation} from '@react-navigation/native'
 
-import {logger} from '#/logger'
-import {track} from 'lib/analytics/analytics'
-import {isNative, isWeb} from 'platform/detection'
 import {Shadow, useProfileShadow} from 'state/cache/profile-shadow'
-import {
-  useProfileFollowMutationQueue,
-  useProfileQuery,
-} from 'state/queries/profile'
-import {useRequireAuth} from 'state/session'
-import * as Toast from 'view/com/util/Toast'
-import {atoms as a} from '#/alf'
-import {Button, ButtonIcon, ButtonText} from '#/components/Button'
-import {Check_Stroke2_Corner0_Rounded as Check} from '#/components/icons/Check'
-import {PlusLarge_Stroke2_Corner0_Rounded as Plus} from '#/components/icons/Plus'
+import {useProfileQuery} from 'state/queries/profile'
+import {FollowButton} from 'view/com/profile/FollowButton'
 
 export function PostThreadFollowBtn({did}: {did: string}) {
   const {data: profile, isLoading} = useProfileQuery({did})
@@ -36,14 +22,8 @@ function PostThreadFollowBtnLoaded({
   profile: AppBskyActorDefs.ProfileViewDetailed
 }) {
   const navigation = useNavigation()
-  const {_} = useLingui()
   const profile: Shadow<AppBskyActorDefs.ProfileViewBasic> =
     useProfileShadow(profileUnshadowed)
-  const [queueFollow, queueUnfollow] = useProfileFollowMutationQueue(
-    profile,
-    'PostThreadItem',
-  )
-  const requireAuth = useRequireAuth()
 
   const isFollowing = !!profile.viewer?.following
   const [wasFollowing, setWasFollowing] = React.useState<boolean>(isFollowing)
@@ -81,64 +61,7 @@ function PostThreadFollowBtnLoaded({
     }
   }, [isFollowing, wasFollowing, navigation])
 
-  const onPress = React.useCallback(() => {
-    if (!isFollowing) {
-      requireAuth(async () => {
-        try {
-          track('ProfileHeader:FollowButtonClicked')
-          await queueFollow()
-        } catch (e: any) {
-          if (e?.name !== 'AbortError') {
-            logger.error('Failed to follow', {message: String(e)})
-            Toast.show(_(msg`There was an issue! ${e.toString()}`))
-          }
-        }
-      })
-    } else {
-      requireAuth(async () => {
-        try {
-          track('ProfileHeader:UnfollowButtonClicked')
-          await queueUnfollow()
-        } catch (e: any) {
-          if (e?.name !== 'AbortError') {
-            logger.error('Failed to unfollow', {message: String(e)})
-            Toast.show(_(msg`There was an issue! ${e.toString()}`))
-          }
-        }
-      })
-    }
-  }, [isFollowing, requireAuth, queueFollow, _, queueUnfollow])
-
   if (!showFollowBtn) return null
 
-  return (
-    <View>
-      <Button
-        testID={profile.viewer?.following ? 'unfollowBtn' : 'followBtn'}
-        size={isNative ? 'small' : 'medium'}
-        color={profile.viewer?.following ? 'secondary' : 'primary'}
-        variant="solid"
-        label={
-          profile.viewer?.following
-            ? _(msg`Unfollow ${profile.handle}`)
-            : _(msg`Follow ${profile.handle}`)
-        }
-        onPress={onPress}
-        style={[a.rounded_full, a.gap_xs]}>
-        {isWeb && (
-          <ButtonIcon
-            position="left"
-            icon={profile.viewer?.following ? Check : Plus}
-          />
-        )}
-        <ButtonText>
-          {profile.viewer?.following ? (
-            <Trans>Following</Trans>
-          ) : (
-            <Trans>Follow</Trans>
-          )}
-        </ButtonText>
-      </Button>
-    </View>
-  )
+  return <FollowButton profile={profile} logContext="PostThreadItem" />
 }

--- a/src/view/com/post-thread/PostThreadFollowBtn.tsx
+++ b/src/view/com/post-thread/PostThreadFollowBtn.tsx
@@ -1,25 +1,24 @@
 import React from 'react'
-import {StyleSheet, TouchableOpacity, View} from 'react-native'
+import {View} from 'react-native'
 import {AppBskyActorDefs} from '@atproto/api'
-import {FontAwesomeIcon} from '@fortawesome/react-native-fontawesome'
 import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 import {useNavigation} from '@react-navigation/native'
 
-import {useGate} from '#/lib/statsig/statsig'
 import {logger} from '#/logger'
 import {track} from 'lib/analytics/analytics'
-import {usePalette} from 'lib/hooks/usePalette'
-import {useWebMediaQueries} from 'lib/hooks/useWebMediaQueries'
-import {s} from 'lib/styles'
+import {isNative, isWeb} from 'platform/detection'
 import {Shadow, useProfileShadow} from 'state/cache/profile-shadow'
 import {
   useProfileFollowMutationQueue,
   useProfileQuery,
 } from 'state/queries/profile'
 import {useRequireAuth} from 'state/session'
-import {Text} from 'view/com/util/text/Text'
 import * as Toast from 'view/com/util/Toast'
+import {atoms as a} from '#/alf'
+import {Button, ButtonIcon, ButtonText} from '#/components/Button'
+import {Check_Stroke2_Corner0_Rounded as Check} from '#/components/icons/Check'
+import {PlusLarge_Stroke2_Corner0_Rounded as Plus} from '#/components/icons/Plus'
 
 export function PostThreadFollowBtn({did}: {did: string}) {
   const {data: profile, isLoading} = useProfileQuery({did})
@@ -38,9 +37,6 @@ function PostThreadFollowBtnLoaded({
 }) {
   const navigation = useNavigation()
   const {_} = useLingui()
-  const pal = usePalette('default')
-  const palInverted = usePalette('inverted')
-  const {isTabletOrDesktop} = useWebMediaQueries()
   const profile: Shadow<AppBskyActorDefs.ProfileViewBasic> =
     useProfileShadow(profileUnshadowed)
   const [queueFollow, queueUnfollow] = useProfileFollowMutationQueue(
@@ -48,10 +44,8 @@ function PostThreadFollowBtnLoaded({
     'PostThreadItem',
   )
   const requireAuth = useRequireAuth()
-  const showFollowBackLabel = useGate('show_follow_back_label')
 
   const isFollowing = !!profile.viewer?.following
-  const isFollowedBy = !!profile.viewer?.followedBy
   const [wasFollowing, setWasFollowing] = React.useState<boolean>(isFollowing)
 
   // This prevents the button from disappearing as soon as we follow.
@@ -118,51 +112,33 @@ function PostThreadFollowBtnLoaded({
   if (!showFollowBtn) return null
 
   return (
-    <View style={{width: isTabletOrDesktop ? 130 : 120}}>
-      <View style={styles.btnOuter}>
-        <TouchableOpacity
-          testID="followBtn"
-          onPress={onPress}
-          style={[styles.btn, !isFollowing ? palInverted.view : pal.viewLight]}
-          accessibilityRole="button"
-          accessibilityLabel={_(msg`Follow ${profile.handle}`)}
-          accessibilityHint={_(
-            msg`Shows posts from ${profile.handle} in your feed`,
-          )}>
-          {isTabletOrDesktop && (
-            <FontAwesomeIcon
-              icon={!isFollowing ? 'plus' : 'check'}
-              style={[!isFollowing ? palInverted.text : pal.text, s.mr5]}
-            />
+    <View>
+      <Button
+        testID={profile.viewer?.following ? 'unfollowBtn' : 'followBtn'}
+        size={isNative ? 'small' : 'medium'}
+        color={profile.viewer?.following ? 'secondary' : 'primary'}
+        variant="solid"
+        label={
+          profile.viewer?.following
+            ? _(msg`Unfollow ${profile.handle}`)
+            : _(msg`Follow ${profile.handle}`)
+        }
+        onPress={onPress}
+        style={[a.rounded_full, a.gap_xs]}>
+        {isWeb && (
+          <ButtonIcon
+            position="left"
+            icon={profile.viewer?.following ? Check : Plus}
+          />
+        )}
+        <ButtonText>
+          {profile.viewer?.following ? (
+            <Trans>Following</Trans>
+          ) : (
+            <Trans>Follow</Trans>
           )}
-          <Text
-            type="button"
-            style={[!isFollowing ? palInverted.text : pal.text, s.bold]}
-            numberOfLines={1}>
-            {!isFollowing ? (
-              showFollowBackLabel && isFollowedBy ? (
-                <Trans>Follow Back</Trans>
-              ) : (
-                <Trans>Follow</Trans>
-              )
-            ) : (
-              <Trans>Following</Trans>
-            )}
-          </Text>
-        </TouchableOpacity>
-      </View>
+        </ButtonText>
+      </Button>
     </View>
   )
 }
-
-const styles = StyleSheet.create({
-  btnOuter: {
-    marginLeft: 'auto',
-  },
-  btn: {
-    flexDirection: 'row',
-    borderRadius: 50,
-    paddingVertical: 8,
-    paddingHorizontal: 14,
-  },
-})

--- a/src/view/com/profile/FollowButton.tsx
+++ b/src/view/com/profile/FollowButton.tsx
@@ -53,7 +53,7 @@ export function FollowButton({
   }
 
   return (
-    <View style={a.pl_lg}>
+    <View style={a.pl_md}>
       <Button
         testID={profile.viewer?.following ? 'unfollowBtn' : 'followBtn'}
         size={isNative ? 'small' : 'medium'}

--- a/src/view/com/profile/FollowButton.tsx
+++ b/src/view/com/profile/FollowButton.tsx
@@ -53,7 +53,7 @@ export function FollowButton({
   }
 
   return (
-    <View>
+    <View style={a.pl_lg}>
       <Button
         testID={profile.viewer?.following ? 'unfollowBtn' : 'followBtn'}
         size={isNative ? 'small' : 'medium'}


### PR DESCRIPTION
## Why

We changed the follow button on the profile but left the others in the app the same black/white color. This looks better and solves the issue of people thinking the white follow button is too bright.

Analytics remain the same, and the logic is simplified - we just use the single `FollowButton` component for both of these now.

I maintained the "Follow Back" gate as well, but only applied it to the follow button for `PostThread`. If we want to use it in all of these places, we just have to remove the `&& logContext === 'PostThreadItem'`

## Screenshots

![Screenshot 2024-04-09 at 3 22 26 PM](https://github.com/bluesky-social/social-app/assets/153161762/686db3cf-ac42-42e9-8ef8-ee6e2a03f4cf)
![Screenshot 2024-04-09 at 3 22 29 PM](https://github.com/bluesky-social/social-app/assets/153161762/da2a0b23-bc60-42c0-b70c-c96a4361078a)
![Screenshot 2024-04-09 at 3 22 49 PM](https://github.com/bluesky-social/social-app/assets/153161762/fefdeb3d-2cc8-406b-9743-47bf0b97e477)
![Screenshot 2024-04-09 at 3 23 44 PM](https://github.com/bluesky-social/social-app/assets/153161762/2772ef5e-7c7e-4048-aa38-163d31bf416b)
![Screenshot 2024-04-09 at 3 23 51 PM](https://github.com/bluesky-social/social-app/assets/153161762/9e5b4bd3-4361-4e0c-8a3a-1f0ec2034501)


## Test Plan

I went through each button to verify that they the functionality still works (so on PostThread and in the various lists of users, i.e. Liked By or Reposted By)

I also verified that events still get sent to Statsig, although I don't know how to tell if the context is properly being attached (i.e. `ProfilePostThread` as the location the follow is from). I didn't see it in network logs even on the main profile follow button, so unsure how to verify.