### PR TITLE
[Statsig] Typecheck gates

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -31,6 +31,7 @@ module.exports = {
         },
       },
     ],
+    'bsky-internal/use-typed-gates': 'error',
     'simple-import-sort/imports': [
       'warn',
       {

--- a/eslint/index.js
+++ b/eslint/index.js
@@ -3,5 +3,6 @@
 module.exports = {
   rules: {
     'avoid-unwrapped-text': require('./avoid-unwrapped-text'),
+    'use-typed-gates': require('./use-typed-gates'),
   },
 }

--- a/eslint/use-typed-gates.js
+++ b/eslint/use-typed-gates.js
@@ -1,0 +1,31 @@
+'use strict'
+
+exports.create = function create(context) {
+  return {
+    ImportSpecifier(node) {
+      if (
+        !node.local ||
+        node.local.type !== 'Identifier' ||
+        node.local.name !== 'useGate'
+      ) {
+        return
+      }
+      if (
+        node.parent.type !== 'ImportDeclaration' ||
+        !node.parent.source ||
+        node.parent.source.type !== 'Literal'
+      ) {
+        return
+      }
+      const source = node.parent.source.value
+      if (source.startsWith('.') || source.startsWith('#')) {
+        return
+      }
+      context.report({
+        node,
+        message:
+          "Use useGate() from '#/lib/statsig/statsig' instead of the one on npm.",
+      })
+    },
+  }
+}

--- a/src/lib/statsig/gates.ts
+++ b/src/lib/statsig/gates.ts
@@ -1,3 +1,7 @@
-import {useGate} from './statsig'
-
-export const useNewSearchGate = () => useGate('new_search')
+export type Gate =
+  | 'autoexpand_suggestions_on_profile_follow'
+  | 'disable_min_shell_on_foregrounding'
+  | 'disable_poll_on_discover'
+  | 'new_search'
+  | 'show_follow_back_label'
+  | 'start_session_with_following'

--- a/src/lib/statsig/gates.ts
+++ b/src/lib/statsig/gates.ts
@@ -1,4 +1,5 @@
 export type Gate =
+  // Keep this alphabetic please.
   | 'autoexpand_suggestions_on_profile_follow'
   | 'disable_min_shell_on_foregrounding'
   | 'disable_poll_on_discover'

--- a/src/lib/statsig/statsig.tsx
+++ b/src/lib/statsig/statsig.tsx
@@ -11,6 +11,7 @@ import {
 import {logger} from '#/logger'
 import {useSession} from '../../state/session'
 import {LogEvents} from './events'
+import {Gate} from './gates'
 
 export type {LogEvents}
 
@@ -69,7 +70,7 @@ export function logEvent<E extends keyof LogEvents>(
   }
 }
 
-export function useGate(gateName: string) {
+export function useGate(gateName: Gate): boolean {
   const {isLoading, value} = useStatsigGate(gateName)
   if (isLoading) {
     // This should not happen because of waitForInitialization={true}.

--- a/src/view/screens/Search/Search.tsx
+++ b/src/view/screens/Search/Search.tsx
@@ -22,7 +22,7 @@ import {HITSLOP_10} from '#/lib/constants'
 import {usePalette} from '#/lib/hooks/usePalette'
 import {MagnifyingGlassIcon} from '#/lib/icons'
 import {NavigationProp} from '#/lib/routes/types'
-import {useNewSearchGate} from '#/lib/statsig/gates'
+import {useGate} from '#/lib/statsig/statsig'
 import {augmentSearchQuery} from '#/lib/strings/helpers'
 import {s} from '#/lib/styles'
 import {logger} from '#/logger'
@@ -337,7 +337,7 @@ export function SearchScreenInner({
   const {isDesktop} = useWebMediaQueries()
   const {_} = useLingui()
 
-  const isNewSearch = useNewSearchGate()
+  const isNewSearch = useGate('new_search')
 
   const onPageSelected = React.useCallback(
     (index: number) => {


### PR DESCRIPTION
@mozzius added `gates.ts` in #3408 to statically check the gate name. I'd prefer we do this using types so that we don't have to keep adding methods. This still gives us autocomplete etc.

I also added a lint rule that enforces we use the local (typed) version of `useGate`. This is important because ours also has a different signature — it returns the `value` directly rather than `{isLoading, value}` as the upstream one does.

## Test Plan

Gates are typechecked.

<img width="946" alt="Screenshot 2024-04-10 at 16 35 56" src="https://github.com/bluesky-social/social-app/assets/810438/a1d316b4-d6b7-4804-87ef-17ef07a8bc67">

Importing the wrong `useGate` errros.

<img width="763" alt="Screenshot 2024-04-10 at 16 36 36" src="https://github.com/bluesky-social/social-app/assets/810438/5e8192e3-c677-4cbf-b71f-0d2a0c3a72ef">
