### PR TITLE
Highlight text in composer if over the character limit

### DIFF
--- a/src/view/com/composer/text-input/TextInput.tsx
+++ b/src/view/com/composer/text-input/TextInput.tsx
@@ -215,12 +215,14 @@ export const TextInput = forwardRef(function TextInputImpl(
   const splitter = useMemo(() => new Graphemer(), [])
   const textDecorated = useMemo(() => {
     let excess
+    let rt = richtext
     if (richtext.graphemeLength > MAX_GRAPHEME_LENGTH) {
+      rt = richtext.clone()
       const split = splitter.splitGraphemes(richtext.text)
       const validText = split.slice(0, MAX_GRAPHEME_LENGTH).join('')
       const validUnicode = new UnicodeString(validText)
       const excessText = split.slice(MAX_GRAPHEME_LENGTH).join('')
-      richtext.delete(validUnicode.utf8.byteLength, richtext.length)
+      rt.delete(validUnicode.utf8.byteLength, richtext.length)
       excess = (
         <RNText
           key="excess"
@@ -235,7 +237,7 @@ export const TextInput = forwardRef(function TextInputImpl(
     }
     let i = 0
 
-    const segments = Array.from(richtext.segments()).map(segment => {
+    const segments = Array.from(rt.segments()).map(segment => {
       return (
         <RNText
           key={i++}

--- a/src/view/com/composer/text-input/TextInput.tsx
+++ b/src/view/com/composer/text-input/TextInput.tsx
@@ -30,7 +30,7 @@ import {
   type LinkFacetMatch,
   suggestLinkCardUri,
 } from '#/view/com/composer/text-input/text-input-util'
-import {atoms as a, useAlf} from '#/alf'
+import {atoms as a, platform, useAlf} from '#/alf'
 import {normalizeTextStyles} from '#/alf/typography'
 import {Autocomplete} from './mobile/Autocomplete'
 
@@ -229,7 +229,18 @@ export const TextInput = forwardRef(function TextInputImpl(
           style={[
             t.atoms.text,
             inputTextStyle,
-            {backgroundColor: t.palette.negative_50, marginTop: -1},
+            {marginTop: -1},
+            a.underline,
+            platform({
+              ios: {
+                backgroundColor: t.palette.negative_50,
+                textDecorationColor: t.palette.negative_500,
+              },
+              // android both doesn't support textDecorationColor,
+              // and setting a background color renders the cursor invisible.
+              // next best thing is to just set the text color to red -sfn
+              android: {color: t.palette.negative_500},
+            }),
           ]}>
           {excessText}
         </RNText>

--- a/src/view/com/composer/text-input/TextInput.web.tsx
+++ b/src/view/com/composer/text-input/TextInput.web.tsx
@@ -28,6 +28,7 @@ import {normalizeTextStyles} from '#/alf/typography'
 import {Portal} from '#/components/Portal'
 import {Text} from '../../util/text/Text'
 import {createSuggestion} from './web/Autocomplete'
+import {CharacterLimitDecorator} from './web/CharacterLimitDecorator'
 import {type Emoji} from './web/EmojiPicker'
 import {LinkDecorator} from './web/LinkDecorator'
 import {TagDecorator} from './web/TagDecorator'
@@ -94,6 +95,7 @@ export const TextInput = React.forwardRef(function TextInputImpl(
       TiptapText,
       History,
       Hardbreak,
+      CharacterLimitDecorator,
     ],
     [autocomplete, placeholder],
   )

--- a/src/view/com/composer/text-input/web/CharacterLimitDecorator.ts
+++ b/src/view/com/composer/text-input/web/CharacterLimitDecorator.ts
@@ -1,0 +1,114 @@
+import {Extension} from '@tiptap/core'
+import {type Node as ProsemirrorNode} from '@tiptap/pm/model'
+import {Plugin, PluginKey} from '@tiptap/pm/state'
+import {Decoration, DecorationSet} from '@tiptap/pm/view'
+import Graphemer from 'graphemer'
+
+import {MAX_GRAPHEME_LENGTH} from '#/lib/constants'
+
+export const CharacterLimitDecorator = Extension.create({
+  name: 'characterLimit',
+
+  addProseMirrorPlugins() {
+    return [characterLimitPlugin()]
+  },
+})
+
+function getDecorations(doc: ProsemirrorNode, splitter: Graphemer) {
+  const decorations: Decoration[] = []
+
+  // Calculate the actual text content including mentions
+  let fullText = ''
+  doc.descendants(node => {
+    if (node.isText) {
+      fullText += node.text || ''
+    } else if (node.type.name === 'mention') {
+      fullText += `@${node.attrs?.id || ''}`
+    }
+  })
+
+  const graphemes = splitter.splitGraphemes(fullText)
+
+  if (graphemes.length > MAX_GRAPHEME_LENGTH) {
+    // Find the string position where the limit is exceeded
+    const validText = graphemes.slice(0, MAX_GRAPHEME_LENGTH).join('')
+    const limitPos = validText.length
+
+    let currentPos = 0
+
+    // Walk through the document to find text nodes and mentions
+    doc.descendants((node, pos) => {
+      if (node.isText) {
+        const nodeText = node.text || ''
+        const nodeStart = currentPos
+        const nodeEnd = currentPos + nodeText.length
+
+        // Check if this text node contains over-limit characters
+        if (nodeEnd > limitPos) {
+          const overLimitStart = Math.max(0, limitPos - nodeStart)
+          const overLimitEnd = nodeText.length
+
+          if (overLimitStart < overLimitEnd) {
+            // Create decoration for the over-limit portion
+            const from = pos + overLimitStart
+            const to = pos + overLimitEnd
+
+            decorations.push(
+              Decoration.inline(from, to, {
+                style: 'background-color: rgba(248, 113, 113, 0.3);',
+                class: 'character-limit-exceeded',
+              }),
+            )
+          }
+        }
+
+        currentPos = nodeEnd
+      } else if (node.type.name === 'mention') {
+        // Handle mention nodes - they contribute to the text length
+        const mentionText = `@${node.attrs?.id || ''}`
+        const nodeStart = currentPos
+        const nodeEnd = currentPos + mentionText.length
+
+        // Check if this mention is over the limit
+        if (nodeStart >= limitPos) {
+          // Entire mention is over the limit
+          decorations.push(
+            Decoration.node(pos, pos + node.nodeSize, {
+              style: 'background-color: rgba(248, 113, 113, 0.3);',
+              class: 'character-limit-exceeded',
+            }),
+          )
+        }
+
+        currentPos = nodeEnd
+      }
+    })
+  }
+
+  return DecorationSet.create(doc, decorations)
+}
+
+function characterLimitPlugin() {
+  const splitter = new Graphemer()
+
+  const characterLimitPlugin: Plugin = new Plugin({
+    key: new PluginKey('characterLimit'),
+
+    state: {
+      init: (_, {doc}) => getDecorations(doc, splitter),
+      apply: (transaction, decorationSet) => {
+        if (transaction.docChanged) {
+          return getDecorations(transaction.doc, splitter)
+        }
+        return decorationSet.map(transaction.mapping, transaction.doc)
+      },
+    },
+
+    props: {
+      decorations(state) {
+        return characterLimitPlugin.getState(state)
+      },
+    },
+  })
+  return characterLimitPlugin
+}


### PR DESCRIPTION
Native only for now. Splits the richtext in the composer on the character limit, and puts all characters over that into `<Text>` with a red background

# Test plan

- Type more than 300 characters into the composer and observe the red highlight
- Try and break it via putting multi-byte unicode characters in there. Flag emojis are a good candidate

![image](https://github.com/bluesky-social/social-app/assets/10959775/0216b82e-dd15-4cf9-bd62-ea3250290f77)
![image](https://github.com/bluesky-social/social-app/assets/10959775/94973c61-3207-4530-a062-0efd6a5ed67f)
