### PR TITLE
Search - only enable queries once tab is active

### DIFF
--- a/src/state/queries/actor-search.ts
+++ b/src/state/queries/actor-search.ts
@@ -12,7 +12,7 @@ export function useActorSearch({
   enabled,
 }: {
   query: string
-  enabled: boolean
+  enabled?: boolean
 }) {
   return useQuery<AppBskyActorDefs.ProfileView[]>({
     staleTime: STALE.MINUTES.ONE,

--- a/src/state/queries/actor-search.ts
+++ b/src/state/queries/actor-search.ts
@@ -5,19 +5,25 @@ import {STALE} from '#/state/queries'
 import {getAgent} from '#/state/session'
 
 const RQKEY_ROOT = 'actor-search'
-export const RQKEY = (prefix: string) => [RQKEY_ROOT, prefix]
+export const RQKEY = (query: string) => [RQKEY_ROOT, query]
 
-export function useActorSearch(prefix: string) {
+export function useActorSearch({
+  query,
+  enabled,
+}: {
+  query: string
+  enabled: boolean
+}) {
   return useQuery<AppBskyActorDefs.ProfileView[]>({
     staleTime: STALE.MINUTES.ONE,
-    queryKey: RQKEY(prefix || ''),
+    queryKey: RQKEY(query || ''),
     async queryFn() {
       const res = await getAgent().searchActors({
-        q: prefix,
+        q: query,
       })
       return res.data.actors
     },
-    enabled: !!prefix,
+    enabled: enabled && !!query,
   })
 }
 

--- a/src/state/queries/search-posts.ts
+++ b/src/state/queries/search-posts.ts
@@ -23,7 +23,7 @@ export function useSearchPostsQuery({
 }: {
   query: string
   sort?: 'top' | 'latest'
-  enabled: boolean
+  enabled?: boolean
 }) {
   return useInfiniteQuery<
     AppBskyFeedSearchPosts.OutputSchema,

--- a/src/state/queries/search-posts.ts
+++ b/src/state/queries/search-posts.ts
@@ -19,9 +19,11 @@ const searchPostsQueryKey = ({query, sort}: {query: string; sort?: string}) => [
 export function useSearchPostsQuery({
   query,
   sort,
+  enabled,
 }: {
   query: string
   sort?: 'top' | 'latest'
+  enabled: boolean
 }) {
   return useInfiniteQuery<
     AppBskyFeedSearchPosts.OutputSchema,
@@ -47,6 +49,7 @@ export function useSearchPostsQuery({
     },
     initialPageParam: undefined,
     getNextPageParam: lastPage => lastPage.cursor,
+    enabled,
   })
 }
 

--- a/src/view/screens/Search/Search.tsx
+++ b/src/view/screens/Search/Search.tsx
@@ -204,7 +204,6 @@ function SearchScreenPostResults({
   const {_} = useLingui()
   const {currentAccount} = useSession()
   const [isPTR, setIsPTR] = React.useState(false)
-  const hasBeenViewed = useHasBeenTrue(active)
 
   const augmentedQuery = React.useMemo(() => {
     return augmentSearchQuery(query || '', {did: currentAccount?.did})
@@ -219,7 +218,7 @@ function SearchScreenPostResults({
     fetchNextPage,
     isFetchingNextPage,
     hasNextPage,
-  } = useSearchPostsQuery({query: augmentedQuery, sort, enabled: hasBeenViewed})
+  } = useSearchPostsQuery({query: augmentedQuery, sort, enabled: active})
 
   const onPullToRefresh = React.useCallback(async () => {
     setIsPTR(true)
@@ -308,11 +307,10 @@ function SearchScreenUserResults({
   active: boolean
 }) {
   const {_} = useLingui()
-  const hasBeenViewed = useHasBeenTrue(active)
 
   const {data: results, isFetched} = useActorSearch({
     query,
-    enabled: hasBeenViewed,
+    enabled: active,
   })
 
   return isFetched && results ? (
@@ -912,17 +910,6 @@ function scrollToTopWeb() {
   if (isWeb) {
     window.scrollTo(0, 0)
   }
-}
-
-// takes a bool. returns true once the bool is true, and stays true forever
-function useHasBeenTrue(bool: boolean) {
-  const [isTrue, setIsTrue] = React.useState(bool)
-
-  React.useEffect(() => {
-    if (bool) setIsTrue(true)
-  }, [bool])
-
-  return isTrue
 }
 
 const HEADER_HEIGHT = 50


### PR DESCRIPTION
Keeps track of the active tab, and only enables the queries once the tab is active

## Test plan

Look at the network tab - tabs should only load once you click on them