### PR TITLE
Fix useGate lint rule

### DIFF
--- a/eslint/use-typed-gates.js
+++ b/eslint/use-typed-gates.js
@@ -18,14 +18,13 @@ exports.create = function create(context) {
         return
       }
       const source = node.parent.source.value
-      if (source.startsWith('.') || source.startsWith('#')) {
-        return
+      if (source.startsWith('statsig') || source.startsWith('@statsig')) {
+        context.report({
+          node,
+          message:
+            "Use useGate() from '#/lib/statsig/statsig' instead of the one on npm.",
+        })
       }
-      context.report({
-        node,
-        message:
-          "Use useGate() from '#/lib/statsig/statsig' instead of the one on npm.",
-      })
     },
   }
 }


### PR DESCRIPTION
Fixes false positive firing on main because https://github.com/bluesky-social/social-app/pull/2931 imports it from `lib/...`.

Let's just explicitly disallow imports starting with `statsig` or `@statsig` that refer to npm packages.