### PR TITLE
Remove the `findView` lookup on the native side

### DIFF
--- a/modules/expo-scroll-forwarder/ios/ExpoScrollForwarderModule.swift
+++ b/modules/expo-scroll-forwarder/ios/ExpoScrollForwarderModule.swift
@@ -5,8 +5,9 @@ public class ExpoScrollForwarderModule: Module {
     Name("ExpoScrollForwarder")
     
     View(ExpoScrollForwarderView.self) {
-      Prop("scrollViewTag") { (view: ExpoScrollForwarderView, prop: Int) in
-        view.scrollViewTag = prop
+      // Still calling this scrollViewTag even though it is being converted to RCTScrollView
+      Prop("scrollViewTag") { (view: ExpoScrollForwarderView, prop: RCTScrollView) in
+        view.rctScrollView = prop
       }
     }
   }

--- a/modules/expo-scroll-forwarder/ios/ExpoScrollForwarderView.swift
+++ b/modules/expo-scroll-forwarder/ios/ExpoScrollForwarderView.swift
@@ -129,9 +129,9 @@ class ExpoScrollForwarderView: ExpoView, UIGestureRecognizerDelegate {
     }
     
     var animTranslation = -translation
-    self.animTimer = Timer.scheduledTimer(withTimeInterval: 1.0 / 120, repeats: true) { timer in
+    self.animTimer = Timer.scheduledTimer(withTimeInterval: 1.0 / 60, repeats: true) { timer in
       velocity *= 0.9875
-      animTranslation = (-velocity / 120) + animTranslation
+      animTranslation = (-velocity / 60) + animTranslation
       
       let nextOffset = self.dampenOffset(animTranslation + self.initialOffset)
       

--- a/modules/expo-scroll-forwarder/ios/ExpoScrollForwarderView.swift
+++ b/modules/expo-scroll-forwarder/ios/ExpoScrollForwarderView.swift
@@ -1,15 +1,15 @@
 import ExpoModulesCore
 
-// This view will be used as a native component. Make sure to inherit from `ExpoView`
-// to apply the proper styling (e.g. border radius and shadows).
 class ExpoScrollForwarderView: ExpoView, UIGestureRecognizerDelegate {
-  var scrollViewTag: Int? {
+  var rctScrollView: RCTScrollView? {
+    willSet {
+      self.removeCancelGestureRecognizers()
+    }
     didSet {
-      self.tryFindScrollView()
+      self.rctRefreshCtrl = self.rctScrollView?.scrollView.refreshControl as? RCTRefreshControl
+      self.addCancelGestureRecognizers()
     }
   }
-  
-  private var rctScrollView: RCTScrollView?
   private var rctRefreshCtrl: RCTRefreshControl?
   private var cancelGestureRecognizers: [UIGestureRecognizer]?
   private var animTimer: Timer?
@@ -160,22 +160,6 @@ class ExpoScrollForwarderView: ExpoView, UIGestureRecognizerDelegate {
     }
     
     return offset
-  }
-  
-  func tryFindScrollView() {
-    guard let scrollViewTag = scrollViewTag else {
-      return
-    }
-    
-    // Before we switch to a different scrollview, we always want to remove the cancel gesture recognizer.
-    // Otherwise we might end up with duplicates when we switch back to that scrollview.
-    self.removeCancelGestureRecognizers()
-    
-    self.rctScrollView = self.appContext?
-      .findView(withTag: scrollViewTag, ofType: RCTScrollView.self)
-    self.rctRefreshCtrl = self.rctScrollView?.scrollView.refreshControl as? RCTRefreshControl
-    
-    self.addCancelGestureRecognizers()
   }
   
   func addCancelGestureRecognizers() {


### PR DESCRIPTION
## Why

It turns out that we can remove the need for a `findView(withTag:)` lookup.

Instead, what we able to use `findNodeHandle()` as we were before on the JS side, but set the prop's type on the native side to `RCTScrollView`. The number will be converted to the view instance.

See this from Tomasz in the Expo discord:

> We actually support using classes extending UIView as an argument type in async functions. On the JS side you would have to pass a React node handle (also called a view tag) which is a number. To get this number, use findNodeHandle function from RN with the React ref as an argument. Then in your native async function you can try using EXCamera class as an argument (the number should get converted to the view instance).

## Test Plan

I have implemented this change and tested in a simulator. The result is the same behavior as before.