### PR TITLE
Dont apply the content-language filter if it will remove all content

### DIFF
--- a/src/lib/api/feed-manip.ts
+++ b/src/lib/api/feed-manip.ts
@@ -1,11 +1,12 @@
 import {
+  AppBskyEmbedRecord,
+  AppBskyEmbedRecordWithMedia,
   AppBskyFeedDefs,
   AppBskyFeedPost,
-  AppBskyEmbedRecordWithMedia,
-  AppBskyEmbedRecord,
 } from '@atproto/api'
-import {ReasonFeedSource} from './feed/types'
+
 import {isPostInLanguage} from '../../locale/helpers'
+import {ReasonFeedSource} from './feed/types'
 type FeedViewPost = AppBskyFeedDefs.FeedViewPost
 
 export type FeedTunerFn = (
@@ -341,6 +342,8 @@ export class FeedTuner {
       tuner: FeedTuner,
       slices: FeedViewPostsSlice[],
     ): FeedViewPostsSlice[] => {
+      const candidate = slices.slice()
+
       // early return if no languages have been specified
       if (!preferredLangsCode2.length || preferredLangsCode2.length === 0) {
         return slices
@@ -357,10 +360,15 @@ export class FeedTuner {
 
         // if item does not fit preferred language, remove it
         if (!hasPreferredLang) {
-          slices.splice(i, 1)
+          candidate.splice(i, 1)
         }
       }
-      return slices
+
+      if (candidate.length === 0) {
+        return slices
+      }
+
+      return candidate
     }
   }
 }


### PR DESCRIPTION
Right now, if you land on a feed that gives you content entirely in a different language than you've selected, it ends up showing the feed as empty. This is pretty confusing, especially when you're going to a feed like "Brazilian Supercluster."

This modifies the language filter to just give the original results-page if the filter would have removed everything in the page.