### PR TITLE
Use getSuggestions endpoint behind the gate

### DIFF
--- a/src/lib/statsig/gates.ts
+++ b/src/lib/statsig/gates.ts
@@ -7,3 +7,4 @@ export type Gate =
   | 'new_search'
   | 'show_follow_back_label'
   | 'start_session_with_following'
+  | 'use_new_suggestions_endpoint'

--- a/src/lib/statsig/statsig.tsx
+++ b/src/lib/statsig/statsig.tsx
@@ -82,7 +82,10 @@ export function useGate(gateName: Gate): boolean {
     // This should not happen because of waitForInitialization={true}.
     console.error('Did not expected isLoading to ever be true.')
   }
-  return value
+  // This shouldn't technically be necessary but let's get a strong
+  // guarantee that a gate value can never change while mounted.
+  const [initialValue] = React.useState(value)
+  return initialValue
 }
 
 function toStatsigUser(did: string | undefined) {

--- a/src/view/screens/Search/Search.tsx
+++ b/src/view/screens/Search/Search.tsx
@@ -224,10 +224,11 @@ function SearchScreenSuggestedFollows() {
       keyExtractor={item => item.did}
       // @ts-ignore web only -prf
       desktopFixedHeight
-      contentContainerStyle={{paddingBottom: 1200}}
+      contentContainerStyle={{paddingBottom: 200}}
       keyboardShouldPersistTaps="handled"
       keyboardDismissMode="on-drag"
       onEndReached={onEndReached}
+      onEndReachedThreshold={2}
     />
   ) : (
     <CenteredView sideBorders style={[pal.border, s.hContentRegion]}>

--- a/src/view/screens/Search/Search.tsx
+++ b/src/view/screens/Search/Search.tsx
@@ -118,8 +118,7 @@ function EmptyState({message, error}: {message: string; error?: string}) {
   )
 }
 
-function SearchScreenSuggestedFollows() {
-  const pal = usePalette('default')
+function useSuggestedFollows() {
   const {currentAccount} = useSession()
   const [suggestions, setSuggestions] = React.useState<
     AppBskyActorDefs.ProfileViewBasic[]
@@ -161,6 +160,12 @@ function SearchScreenSuggestedFollows() {
       })
     }
   }, [currentAccount, setSuggestions, getSuggestedFollowsByActor])
+  return suggestions
+}
+
+function SearchScreenSuggestedFollows() {
+  const pal = usePalette('default')
+  const suggestions = useSuggestedFollows()
 
   return suggestions.length ? (
     <List

--- a/src/view/screens/Search/Search.tsx
+++ b/src/view/screens/Search/Search.tsx
@@ -210,7 +210,12 @@ function useSuggestedFollowsV2(): [
 
 function SearchScreenSuggestedFollows() {
   const pal = usePalette('default')
-  const [suggestions, onEndReached] = useSuggestedFollowsV1()
+  const useSuggestedFollows = useGate('use_new_suggestions_endpoint')
+    ? // Conditional hook call here is *only* OK because useGate()
+      // result won't change until a remount.
+      useSuggestedFollowsV2
+    : useSuggestedFollowsV1
+  const [suggestions, onEndReached] = useSuggestedFollows()
 
   return suggestions.length ? (
     <List


### PR DESCRIPTION
When `use_new_suggestions_endpoint` is `true`, the Search tab uses the `getSuggestions` endpoint instead of what we're doing now (which hits `getSuggestedFollowsByActor` and then does the same for a few of them). The old behavior is preserved when the flag is off (which it currently is for everyone).

## Test Plan

Go to search tab. Observe roughly the same set (or at least after a few refreshes) as in prod.

Then pass yourself in overrides for the `use_new_suggestions_endpoint` gate.

Observe a difference set of results. (They're not currently very relevant but we'll be improving that on the backend.)