### PR TITLE
Fix optimistic like/repost

### DIFF
--- a/src/state/cache/post-shadow.ts
+++ b/src/state/cache/post-shadow.ts
@@ -62,25 +62,29 @@ function mergeShadow(
     return POST_TOMBSTONE
   }
 
-  const wasLiked = !!post.viewer?.like
-  const isLiked = !!shadow.likeUri
   let likeCount = post.likeCount ?? 0
-  if (wasLiked && !isLiked) {
-    likeCount--
-  } else if (!wasLiked && isLiked) {
-    likeCount++
+  if ('likeUri' in shadow) {
+    const wasLiked = !!post.viewer?.like
+    const isLiked = !!shadow.likeUri
+    if (wasLiked && !isLiked) {
+      likeCount--
+    } else if (!wasLiked && isLiked) {
+      likeCount++
+    }
+    likeCount = Math.max(0, likeCount)
   }
-  likeCount = Math.max(0, likeCount)
 
-  const wasReposted = !!post.viewer?.repost
-  const isReposted = !!shadow.repostUri
   let repostCount = post.repostCount ?? 0
-  if (wasReposted && !isReposted) {
-    repostCount--
-  } else if (!wasReposted && isReposted) {
-    repostCount++
+  if ('repostUri' in shadow) {
+    const wasReposted = !!post.viewer?.repost
+    const isReposted = !!shadow.repostUri
+    if (wasReposted && !isReposted) {
+      repostCount--
+    } else if (!wasReposted && isReposted) {
+      repostCount++
+    }
+    repostCount = Math.max(0, repostCount)
   }
-  repostCount = Math.max(0, repostCount)
 
   return castAsShadow({
     ...post,


### PR DESCRIPTION
Fixes a bug where disliking an already liked post would optimistically decrease its repost count.

[Review without whitespace](https://github.com/bluesky-social/social-app/pull/3503/files?w=1)

## Before

https://github.com/bluesky-social/social-app/assets/810438/0db57eea-3ee9-4d17-a944-528f7b9a4eec

## After

https://github.com/bluesky-social/social-app/assets/810438/9de3c419-ab3f-4b5d-8f99-309034545b74

## Why

The logic assumed `!!shadow.likeUri` is a good way to test if something is optimistically liked, and `!!shadow.repostUri` is a good way to test if something is optimistically reposted. But this doesn't take into account that the shadow object may be partial — and indeed it usually is — so it might not have those fields in the first place. In that case, they should be ignored rather than assumed to be an "unlike" or an "unrepost".

[Review without whitespace](https://github.com/bluesky-social/social-app/pull/3503/files?w=1)
