### PR TITLE
Fix: dont let notifications count go behind the icon

### DIFF
--- a/src/view/shell/bottom-bar/BottomBar.tsx
+++ b/src/view/shell/bottom-bar/BottomBar.tsx
@@ -348,12 +348,12 @@ function Btn({
       accessible={accessible}
       accessibilityLabel={accessibilityLabel}
       accessibilityHint={accessibilityHint}>
+      {icon}
       {notificationCount ? (
         <View style={[styles.notificationCount]}>
           <Text style={styles.notificationCountLabel}>{notificationCount}</Text>
         </View>
       ) : undefined}
-      {icon}
     </TouchableOpacity>
   )
 }


### PR DESCRIPTION
![CleanShot 2024-04-12 at 09 33 39@2x](https://github.com/bluesky-social/social-app/assets/1270099/3a6a6168-2e69-4700-a2f8-598645f58b49)

Without this change, it's possible for the count to go behind the icon on android. That's right yall: z-index can sometimes be overridden by component tree order in RN.