### PR TITLE
QT Jump Pt. 2 - Remove code duplication

### DIFF
--- a/src/state/queries/post-thread.ts
+++ b/src/state/queries/post-thread.ts
@@ -11,7 +11,7 @@ import {getAgent} from '#/state/session'
 import {findAllPostsInQueryData as findAllPostsInNotifsQueryData} from './notifications/feed'
 import {findAllPostsInQueryData as findAllPostsInFeedQueryData} from './post-feed'
 import {precacheThreadPostProfiles} from './profile'
-import {getEmbeddedPost} from './util'
+import {embedViewRecordToPostView, getEmbeddedPost} from './util'
 
 const RQKEY_ROOT = 'post-thread'
 export const RQKEY = (uri: string) => [RQKEY_ROOT, uri]
@@ -332,14 +332,7 @@ function embedViewRecordToPlaceholderThread(
     type: 'post',
     _reactKey: record.uri,
     uri: record.uri,
-    post: {
-      uri: record.uri,
-      cid: record.cid,
-      author: record.author,
-      record: record.value,
-      indexedAt: record.indexedAt,
-      labels: record.labels,
-    },
+    post: embedViewRecordToPostView(record),
     record: record.value as AppBskyFeedPost.Record, // validated in getEmbeddedPost
     parent: undefined,
     replies: undefined,

--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -1,50 +1,50 @@
 import React, {memo, useMemo} from 'react'
 import {StyleSheet, View} from 'react-native'
 import {
-  AtUri,
   AppBskyFeedDefs,
   AppBskyFeedPost,
-  RichText as RichTextAPI,
+  AtUri,
   ModerationDecision,
+  RichText as RichTextAPI,
 } from '@atproto/api'
-import {moderatePost_wrapped as moderatePost} from '#/lib/moderatePost_wrapped'
 import {FontAwesomeIcon} from '@fortawesome/react-native-fontawesome'
-import {PostThreadFollowBtn} from 'view/com/post-thread/PostThreadFollowBtn'
-import {Link, TextLink} from '../util/Link'
-import {RichText} from '#/components/RichText'
-import {Text} from '../util/text/Text'
-import {PreviewableUserAvatar} from '../util/UserAvatar'
-import {s} from 'lib/styles'
-import {niceDate} from 'lib/strings/time'
+import {msg, Trans} from '@lingui/macro'
+import {useLingui} from '@lingui/react'
+
+import {moderatePost_wrapped as moderatePost} from '#/lib/moderatePost_wrapped'
+import {POST_TOMBSTONE, Shadow, usePostShadow} from '#/state/cache/post-shadow'
+import {useLanguagePrefs} from '#/state/preferences'
+import {useOpenLink} from '#/state/preferences/in-app-browser'
+import {ThreadPost} from '#/state/queries/post-thread'
+import {useModerationOpts} from '#/state/queries/preferences'
+import {useComposerControls} from '#/state/shell/composer'
+import {MAX_POST_LINES} from 'lib/constants'
+import {usePalette} from 'lib/hooks/usePalette'
+import {useWebMediaQueries} from 'lib/hooks/useWebMediaQueries'
+import {makeProfileLink} from 'lib/routes/links'
 import {sanitizeDisplayName} from 'lib/strings/display-names'
 import {sanitizeHandle} from 'lib/strings/handles'
 import {countLines, pluralize} from 'lib/strings/helpers'
-import {getTranslatorLink, isPostInLanguage} from '../../../locale/helpers'
-import {PostMeta} from '../util/PostMeta'
-import {PostEmbeds} from '../util/post-embeds'
-import {PostCtrls} from '../util/post-ctrls/PostCtrls'
-import {PostHider} from '../../../components/moderation/PostHider'
-import {ContentHider} from '../../../components/moderation/ContentHider'
-import {PostAlerts} from '../../../components/moderation/PostAlerts'
-import {LabelsOnMyPost} from '../../../components/moderation/LabelsOnMe'
-import {ErrorMessage} from '../util/error/ErrorMessage'
-import {usePalette} from 'lib/hooks/usePalette'
-import {formatCount} from '../util/numeric/format'
-import {makeProfileLink} from 'lib/routes/links'
-import {useWebMediaQueries} from 'lib/hooks/useWebMediaQueries'
-import {MAX_POST_LINES} from 'lib/constants'
-import {Trans, msg} from '@lingui/macro'
-import {useLingui} from '@lingui/react'
-import {useLanguagePrefs} from '#/state/preferences'
-import {useComposerControls} from '#/state/shell/composer'
-import {useModerationOpts} from '#/state/queries/preferences'
-import {useOpenLink} from '#/state/preferences/in-app-browser'
-import {Shadow, usePostShadow, POST_TOMBSTONE} from '#/state/cache/post-shadow'
-import {ThreadPost} from '#/state/queries/post-thread'
+import {niceDate} from 'lib/strings/time'
+import {s} from 'lib/styles'
 import {useSession} from 'state/session'
-import {WhoCanReply} from '../threadgate/WhoCanReply'
-import {LoadingPlaceholder} from '../util/LoadingPlaceholder'
+import {PostThreadFollowBtn} from 'view/com/post-thread/PostThreadFollowBtn'
 import {atoms as a} from '#/alf'
+import {RichText} from '#/components/RichText'
+import {ContentHider} from '../../../components/moderation/ContentHider'
+import {LabelsOnMyPost} from '../../../components/moderation/LabelsOnMe'
+import {PostAlerts} from '../../../components/moderation/PostAlerts'
+import {PostHider} from '../../../components/moderation/PostHider'
+import {getTranslatorLink, isPostInLanguage} from '../../../locale/helpers'
+import {WhoCanReply} from '../threadgate/WhoCanReply'
+import {ErrorMessage} from '../util/error/ErrorMessage'
+import {Link, TextLink} from '../util/Link'
+import {formatCount} from '../util/numeric/format'
+import {PostCtrls} from '../util/post-ctrls/PostCtrls'
+import {PostEmbeds} from '../util/post-embeds'
+import {PostMeta} from '../util/PostMeta'
+import {Text} from '../util/text/Text'
+import {PreviewableUserAvatar} from '../util/UserAvatar'
 
 export function PostThreadItem({
   post,
@@ -325,12 +325,6 @@ let PostThreadItemLoaded = ({
             {post.repostCount !== 0 || post.likeCount !== 0 ? (
               // Show this section unless we're *sure* it has no engagement.
               <View style={[styles.expandedInfo, pal.border]}>
-                {post.repostCount == null && post.likeCount == null && (
-                  // If we're still loading and not sure, assume this post has engagement.
-                  // This lets us avoid a layout shift for the common case (embedded post with likes/reposts).
-                  // TODO: embeds should include metrics to avoid us having to guess.
-                  <LoadingPlaceholder width={50} height={20} />
-                )}
                 {post.repostCount != null && post.repostCount !== 0 ? (
                   <Link
                     style={styles.expandedInfoItem}


### PR DESCRIPTION
## Why

https://github.com/bluesky-social/social-app/pull/3500 should have removed the need for the shimmer/placeholder portion of a post's metrics. However, in some cases - specifically when opening a QT from inside of another `PostThread` - there was still missing metrics.

We had duplicated the logic for creating a `PostView` from an embed record, which made it rather unobvious that we needed to update two places for converting an embed record.

With this, the expected result of no longer needing the shimmer is correct, so we can rm. The big spinner will be fixed in a separate PR, where we need to address caching the QP author's DID (right now we have to wait to resolve the handle to a DID which is causing the spinner).

## Test Plan

You can use the same post as before, but test in two different ways:

- From a profile or feed, as was fixed before
- From a `PostThread` - Once you get past the spinner, notice that the metrics are already available.

[screen-capture (1).webm](https://github.com/bluesky-social/social-app/assets/153161762/d2cee59a-1fbf-42d2-884e-d76bd1de04e5)
