### PR TITLE
Fix stale Notifications after push

### DIFF
--- a/src/lib/notifications/notifications.ts
+++ b/src/lib/notifications/notifications.ts
@@ -4,6 +4,7 @@ import {QueryClient} from '@tanstack/react-query'
 
 import {logger} from '#/logger'
 import {RQKEY as RQKEY_NOTIFS} from '#/state/queries/notifications/feed'
+import {invalidateCachedUnreadPage} from '#/state/queries/notifications/unread'
 import {truncateAndInvalidate} from '#/state/queries/util'
 import {getAgent, SessionAccount} from '#/state/session'
 import {track} from 'lib/analytics/analytics'
@@ -87,6 +88,7 @@ export function useNotificationsListener(queryClient: QueryClient) {
     // handle notifications that are received, both in the foreground or background
     // NOTE: currently just here for debug logging
     const sub1 = Notifications.addNotificationReceivedListener(event => {
+      invalidateCachedUnreadPage()
       logger.debug(
         'Notifications: received',
         {event},
@@ -131,11 +133,13 @@ export function useNotificationsListener(queryClient: QueryClient) {
           )
           track('Notificatons:OpenApp')
           logEvent('notifications:openApp', {})
+          invalidateCachedUnreadPage()
           truncateAndInvalidate(queryClient, RQKEY_NOTIFS())
           resetToTab('NotificationsTab') // open notifications tab
         }
       },
     )
+
     return () => {
       sub1.remove()
       sub2.remove()


### PR DESCRIPTION
Should fix notifications being stale after foregrounding the app.

The issue was that the Notifications query checks the unread count cache first, but that cache gets out of date.

## Test Plan

Added a fake handler to `notifications.ts` to simulate a push notif 20 seconds after app startup.

```js
    setTimeout(() => {
      invalidateCachedUnreadPage()
      truncateAndInvalidate(queryClient, RQKEY_NOTIFS())
      resetToTab('NotificationsTab') // open notifications tab
    }, 20000)
```

Open the app, open Notifs, switch to Home, background the app.

Like your own post from another acc.

Wait so 20 seconds pass and foreground the app.

Before the fix, you wouldn't see the new notif. Now you do.

## Before

The new notification doesn't show until PTR:


https://github.com/bluesky-social/social-app/assets/810438/fe8ac40a-ddf3-401b-9568-c2d9b4d89243


## After

The new notification shows:

https://github.com/bluesky-social/social-app/assets/810438/a3a6a0cc-dd56-4a2f-90a0-055953272935


