### PR TITLE
Store QP authors in the DID cache

### DIFF
--- a/src/state/queries/resolve-uri.ts
+++ b/src/state/queries/resolve-uri.ts
@@ -49,13 +49,3 @@ export function useResolveDidQuery(didOrHandle: string | undefined) {
     enabled: !!didOrHandle,
   })
 }
-
-export function useAddDidToCache(handle: string, did: string) {
-  return useQuery<string, Error>({
-    staleTime: STALE.HOURS.ONE,
-    queryKey: RQKEY(handle),
-    queryFn: async () => {
-      return did
-    },
-  })
-}

--- a/src/state/queries/resolve-uri.ts
+++ b/src/state/queries/resolve-uri.ts
@@ -49,3 +49,13 @@ export function useResolveDidQuery(didOrHandle: string | undefined) {
     enabled: !!didOrHandle,
   })
 }
+
+export function useAddDidToCache(handle: string, did: string) {
+  return useQuery<string, Error>({
+    staleTime: STALE.HOURS.ONE,
+    queryKey: RQKEY(handle),
+    queryFn: async () => {
+      return did
+    },
+  })
+}

--- a/src/view/com/util/post-embeds/QuoteEmbed.tsx
+++ b/src/view/com/util/post-embeds/QuoteEmbed.tsx
@@ -109,11 +109,12 @@ export function QuoteEmbed({
   moderation?: ModerationDecision
   style?: StyleProp<ViewStyle>
 }) {
-  useAddDidToCache(quote.author.handle, quote.author.did)
   const pal = usePalette('default')
   const itemUrip = new AtUri(quote.uri)
   const itemHref = makeProfileLink(quote.author, 'post', itemUrip.rkey)
   const itemTitle = `Post by ${quote.author.handle}`
+
+  useAddDidToCache(quote.author.handle, quote.author.did)
 
   const richText = React.useMemo(
     () =>

--- a/src/view/com/util/post-embeds/QuoteEmbed.tsx
+++ b/src/view/com/util/post-embeds/QuoteEmbed.tsx
@@ -1,31 +1,33 @@
 import React from 'react'
 import {StyleProp, StyleSheet, View, ViewStyle} from 'react-native'
 import {
-  AppBskyFeedDefs,
-  AppBskyEmbedRecord,
-  AppBskyFeedPost,
-  AppBskyEmbedImages,
-  AppBskyEmbedRecordWithMedia,
   AppBskyEmbedExternal,
-  RichText as RichTextAPI,
+  AppBskyEmbedImages,
+  AppBskyEmbedRecord,
+  AppBskyEmbedRecordWithMedia,
+  AppBskyFeedDefs,
+  AppBskyFeedPost,
   moderatePost,
   ModerationDecision,
+  RichText as RichTextAPI,
 } from '@atproto/api'
 import {AtUri} from '@atproto/api'
-import {PostMeta} from '../PostMeta'
-import {Link} from '../Link'
-import {Text} from '../text/Text'
-import {usePalette} from 'lib/hooks/usePalette'
-import {ComposerOptsQuote} from 'state/shell/composer'
-import {PostEmbeds} from '.'
-import {PostAlerts} from '../../../../components/moderation/PostAlerts'
-import {makeProfileLink} from 'lib/routes/links'
-import {InfoCircleIcon} from 'lib/icons'
 import {Trans} from '@lingui/macro'
+
 import {useModerationOpts} from '#/state/queries/preferences'
-import {ContentHider} from '../../../../components/moderation/ContentHider'
-import {RichText} from '#/components/RichText'
+import {usePalette} from 'lib/hooks/usePalette'
+import {InfoCircleIcon} from 'lib/icons'
+import {makeProfileLink} from 'lib/routes/links'
+import {useAddDidToCache} from 'state/queries/resolve-uri'
+import {ComposerOptsQuote} from 'state/shell/composer'
 import {atoms as a} from '#/alf'
+import {RichText} from '#/components/RichText'
+import {ContentHider} from '../../../../components/moderation/ContentHider'
+import {PostAlerts} from '../../../../components/moderation/PostAlerts'
+import {Link} from '../Link'
+import {PostMeta} from '../PostMeta'
+import {Text} from '../text/Text'
+import {PostEmbeds} from '.'
 
 export function MaybeQuoteEmbed({
   embed,
@@ -107,6 +109,7 @@ export function QuoteEmbed({
   moderation?: ModerationDecision
   style?: StyleProp<ViewStyle>
 }) {
+  useAddDidToCache(quote.author.handle, quote.author.did)
   const pal = usePalette('default')
   const itemUrip = new AtUri(quote.uri)
   const itemHref = makeProfileLink(quote.author, 'post', itemUrip.rkey)

--- a/src/view/com/util/post-embeds/QuoteEmbed.tsx
+++ b/src/view/com/util/post-embeds/QuoteEmbed.tsx
@@ -13,12 +13,13 @@ import {
 } from '@atproto/api'
 import {AtUri} from '@atproto/api'
 import {Trans} from '@lingui/macro'
+import {useQueryClient} from '@tanstack/react-query'
 
 import {useModerationOpts} from '#/state/queries/preferences'
+import {RQKEY as RQKEY_URI} from '#/state/queries/resolve-uri'
 import {usePalette} from 'lib/hooks/usePalette'
 import {InfoCircleIcon} from 'lib/icons'
 import {makeProfileLink} from 'lib/routes/links'
-import {useAddDidToCache} from 'state/queries/resolve-uri'
 import {ComposerOptsQuote} from 'state/shell/composer'
 import {atoms as a} from '#/alf'
 import {RichText} from '#/components/RichText'
@@ -109,12 +110,11 @@ export function QuoteEmbed({
   moderation?: ModerationDecision
   style?: StyleProp<ViewStyle>
 }) {
+  const queryClient = useQueryClient()
   const pal = usePalette('default')
   const itemUrip = new AtUri(quote.uri)
   const itemHref = makeProfileLink(quote.author, 'post', itemUrip.rkey)
   const itemTitle = `Post by ${quote.author.handle}`
-
-  useAddDidToCache(quote.author.handle, quote.author.did)
 
   const richText = React.useMemo(
     () =>
@@ -144,7 +144,13 @@ export function QuoteEmbed({
         style={[styles.container, pal.borderDark, style]}
         hoverStyle={{borderColor: pal.colors.borderLinkHover}}
         href={itemHref}
-        title={itemTitle}>
+        title={itemTitle}
+        onBeforePress={() => {
+          queryClient.setQueryData(
+            RQKEY_URI(quote.author.handle),
+            quote.author.did,
+          )
+        }}>
         <View pointerEvents="none">
           <PostMeta
             author={quote.author}

--- a/src/view/com/util/post-embeds/QuoteEmbed.tsx
+++ b/src/view/com/util/post-embeds/QuoteEmbed.tsx
@@ -138,6 +138,10 @@ export function QuoteEmbed({
     }
   }, [quote.embeds])
 
+  const onBeforePress = React.useCallback(() => {
+    queryClient.setQueryData(RQKEY_URI(quote.author.handle), quote.author.did)
+  }, [queryClient, quote.author.did, quote.author.handle])
+
   return (
     <ContentHider modui={moderation?.ui('contentList')}>
       <Link
@@ -145,12 +149,7 @@ export function QuoteEmbed({
         hoverStyle={{borderColor: pal.colors.borderLinkHover}}
         href={itemHref}
         title={itemTitle}
-        onBeforePress={() => {
-          queryClient.setQueryData(
-            RQKEY_URI(quote.author.handle),
-            quote.author.did,
-          )
-        }}>
+        onBeforePress={onBeforePress}>
         <View pointerEvents="none">
           <PostMeta
             author={quote.author}


### PR DESCRIPTION
## Why

This is another follow up to https://github.com/bluesky-social/social-app/pull/3500. We uncovered that quote post authors are not having their DIDs cached, which results in a full spinner when we navigate to the quoted post.

An existing solution to this would be to use `useResolveDid()`, however this results in an extra request for information that we already have. Instead, it makes more sense to update the cache with the author's handle and DID without performing a resolution, since we already have that information in the embed record.

## Testing

Using this post: http://localhost:19006/profile/kevinmkruse.bsky.social/post/3kpxbhmzcym2p

[screen-capture (2).webm](https://github.com/bluesky-social/social-app/assets/153161762/c186c063-0e58-439e-81bc-338f1415f7c2)

