### PR TITLE
cache fix for search post results

### DIFF
--- a/src/state/queries/post-thread.ts
+++ b/src/state/queries/post-thread.ts
@@ -8,6 +8,7 @@ import {QueryClient, useQuery, useQueryClient} from '@tanstack/react-query'
 
 import {UsePreferencesQueryResponse} from '#/state/queries/preferences/types'
 import {getAgent} from '#/state/session'
+import {findAllPostsInQueryData as findAllPostsInSearchQueryData} from 'state/queries/search-posts'
 import {findAllPostsInQueryData as findAllPostsInNotifsQueryData} from './notifications/feed'
 import {findAllPostsInQueryData as findAllPostsInFeedQueryData} from './post-feed'
 import {precacheThreadPostProfiles} from './profile'
@@ -258,6 +259,9 @@ export function* findAllPostsInQueryData(
     yield postViewToPlaceholderThread(post)
   }
   for (let post of findAllPostsInNotifsQueryData(queryClient, uri)) {
+    yield postViewToPlaceholderThread(post)
+  }
+  for (let post of findAllPostsInSearchQueryData(queryClient, uri)) {
     yield postViewToPlaceholderThread(post)
   }
 }


### PR DESCRIPTION
## Why

Similar to https://github.com/bluesky-social/social-app/pull/3509. We set the author's DID in the cache whenever we press on a post so that we remove all spinners.

We also add `findAllPostsInSearchQueryData()` to the `findAllPostsInQueryData()` so that we populate from search results (we already had this function ready to go, but it was just not being used).

## Test Plan

Search up something, see results

[screen-capture (4).webm](https://github.com/bluesky-social/social-app/assets/153161762/79493710-fb42-46f4-8e19-dde29e272703)
