### PR TITLE
Cache DID and profile basic on profile card presses

### DIFF
--- a/src/view/com/profile/ProfileCard.tsx
+++ b/src/view/com/profile/ProfileCard.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import {StyleProp, StyleSheet, View, ViewStyle} from 'react-native'
 import {
   AppBskyActorDefs,
@@ -7,6 +7,7 @@ import {
   ModerationDecision,
 } from '@atproto/api'
 import {Trans} from '@lingui/macro'
+import {useQueryClient} from '@tanstack/react-query'
 
 import {useModerationCauseDescription} from '#/lib/moderation/useModerationCauseDescription'
 import {useProfileShadow} from '#/state/cache/profile-shadow'
@@ -19,6 +20,8 @@ import {makeProfileLink} from 'lib/routes/links'
 import {sanitizeDisplayName} from 'lib/strings/display-names'
 import {sanitizeHandle} from 'lib/strings/handles'
 import {s} from 'lib/styles'
+import {profileBasicQueryKey as RQKEY_PROFILE_BASIC} from 'state/queries/profile'
+import {RQKEY as RQKEY_URI} from 'state/queries/resolve-uri'
 import {Link} from '../util/Link'
 import {Text} from '../util/text/Text'
 import {PreviewableUserAvatar} from '../util/UserAvatar'
@@ -47,10 +50,19 @@ export function ProfileCard({
   onPress?: () => void
   style?: StyleProp<ViewStyle>
 }) {
+  const queryClient = useQueryClient()
   const pal = usePalette('default')
   const profile = useProfileShadow(profileUnshadowed)
   const moderationOpts = useModerationOpts()
   const isLabeler = profile?.associated?.labeler
+
+  const onBeforePress = React.useCallback(() => {
+    onPress?.()
+
+    queryClient.setQueryData(RQKEY_URI(profile.handle), profile.did)
+    queryClient.setQueryData(RQKEY_PROFILE_BASIC(profile.did), profile)
+  }, [onPress, profile, queryClient])
+
   if (!moderationOpts) {
     return null
   }
@@ -72,9 +84,9 @@ export function ProfileCard({
       ]}
       href={makeProfileLink(profile)}
       title={profile.handle}
-      onBeforePress={onPress}
       asAnchor
-      anchorNoUnderline>
+      anchorNoUnderline
+      onBeforePress={onBeforePress}>
       <View style={styles.layout}>
         <View style={styles.layoutAvi}>
           <PreviewableUserAvatar

--- a/src/view/com/profile/ProfileCard.tsx
+++ b/src/view/com/profile/ProfileCard.tsx
@@ -85,8 +85,8 @@ export function ProfileCard({
       href={makeProfileLink(profile)}
       title={profile.handle}
       asAnchor
-      anchorNoUnderline
-      onBeforePress={onBeforePress}>
+      onBeforePress={onBeforePress}
+      anchorNoUnderline>
       <View style={styles.layout}>
         <View style={styles.layoutAvi}>
           <PreviewableUserAvatar


### PR DESCRIPTION
## Why

Similar to other changes like https://github.com/bluesky-social/social-app/pull/3509. Caches the DID and profile basic view before navigating to the profile screen. This allows us to have some of the shell already visible to the user.

## Test Plan

You can see this change in action both from the suggestions screen as well as well as from the various "Liked By", "Reposted By", etc. screens.

[screen-capture (6).webm](https://github.com/bluesky-social/social-app/assets/153161762/8f4c6be4-a6a9-42a8-889b-374f6943183f)
