### PR TITLE
[Embeds] Align nested quote behaviour with the app

### DIFF
--- a/bskyembed/src/components/embed.tsx
+++ b/bskyembed/src/components/embed.tsx
@@ -19,9 +19,11 @@ import {Link} from './link'
 export function Embed({
   content,
   labels,
+  hideRecord,
 }: {
   content: AppBskyFeedDefs.PostView['embed']
   labels: AppBskyFeedDefs.PostView['labels']
+  hideRecord?: boolean
 }) {
   const labelInfo = useMemo(() => labelsToInfo(labels), [labels])
 
@@ -40,6 +42,10 @@ export function Embed({
 
     // Case 3: Record (quote or linked post)
     if (AppBskyEmbedRecord.isView(content)) {
+      if (hideRecord) {
+        return null
+      }
+
       const record = content.record
 
       // Case 3.1: Post
@@ -84,19 +90,14 @@ export function Embed({
               </p>
             </div>
             {text && <p className="text-sm">{text}</p>}
-            {record.embeds
-              ?.filter(embed => {
-                if (AppBskyEmbedImages.isView(embed)) return true
-                if (AppBskyEmbedExternal.isView(embed)) return true
-                return false
-              })
-              .map(embed => (
-                <Embed
-                  key={embed.$type}
-                  content={embed}
-                  labels={record.labels}
-                />
-              ))}
+            {record.embeds?.map(embed => (
+              <Embed
+                key={embed.$type}
+                content={embed}
+                labels={record.labels}
+                hideRecord
+              />
+            ))}
           </Link>
         )
       }
@@ -164,13 +165,18 @@ export function Embed({
     ) {
       return (
         <div className="flex flex-col gap-2">
-          <Embed content={content.media} labels={labels} />
+          <Embed
+            content={content.media}
+            labels={labels}
+            hideRecord={hideRecord}
+          />
           <Embed
             content={{
               $type: 'app.bsky.embed.record#view',
               record: content.record.record,
             }}
             labels={content.record.record.labels}
+            hideRecord={hideRecord}
           />
         </div>
       )


### PR DESCRIPTION
I had quotepost embeds only allow images and externals, however the app allows the image from a recordWithMedia. This PR changes the way we cap nesting by passing a "hideRecord" prop, so we can explicitly only hide quotes in a quote, allowing their image to appear

Current behaviour:

![Screenshot 2024-04-13 at 11 12 14](https://github.com/bluesky-social/social-app/assets/10959775/9fb49bbb-e660-43fe-b756-b64887bdca70)

New behaviour:

![Screenshot 2024-04-13 at 11 08 12](https://github.com/bluesky-social/social-app/assets/10959775/a3b91739-185d-42cd-8924-6ee2b13ed804)

App:

![Screenshot 2024-04-13 at 11 08 21](https://github.com/bluesky-social/social-app/assets/10959775/9a97670a-1e20-45c0-84f5-654ff9b13efe)
