### PR TITLE
Only close mobile web drawer if press happens on backdrop

### DIFF
--- a/src/view/shell/index.web.tsx
+++ b/src/view/shell/index.web.tsx
@@ -1,5 +1,5 @@
 import React, {useEffect} from 'react'
-import {StyleSheet, TouchableOpacity, View} from 'react-native'
+import {StyleSheet, TouchableWithoutFeedback, View} from 'react-native'
 import {msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 import {useNavigation} from '@react-navigation/native'
@@ -51,15 +51,21 @@ function ShellInner() {
       <PortalOutlet />
 
       {!isDesktop && isDrawerOpen && (
-        <TouchableOpacity
-          onPress={() => setDrawerOpen(false)}
-          style={styles.drawerMask}
+        <TouchableWithoutFeedback
+          onPress={ev => {
+            // Only close if press happens outside of the drawer
+            if (ev.target === ev.currentTarget) {
+              setDrawerOpen(false)
+            }
+          }}
           accessibilityLabel={_(msg`Close navigation footer`)}
           accessibilityHint={_(msg`Closes bottom navigation bar`)}>
-          <View style={styles.drawerContainer}>
-            <DrawerContent />
+          <View style={styles.drawerMask}>
+            <View style={styles.drawerContainer}>
+              <DrawerContent />
+            </View>
           </View>
-        </TouchableOpacity>
+        </TouchableWithoutFeedback>
       )}
     </>
   )


### PR DESCRIPTION
Was trying to figure out why the language picker on th drawer was near-impossible to open with touch, noticed that we're closing the drawer *even if* the tap happens inside the drawer.

<img width=300 src=https://github.com/bluesky-social/social-app/assets/148872143/589b0f75-992c-4345-a08b-eb15f56db246>

Doesn't seem like the right behavior to do, this makes it so that it only happens on the backdrop instead.