### PR TITLE
Increase hit slop for web's app language picker

### DIFF
--- a/src/components/AppLanguageDropdown.web.tsx
+++ b/src/components/AppLanguageDropdown.web.tsx
@@ -29,7 +29,14 @@ export function AppLanguageDropdown() {
   )
 
   return (
-    <View style={[a.flex_row, a.gap_sm, a.align_center, a.flex_shrink]}>
+    <View
+      style={[
+        {height: 32},
+        a.flex_row,
+        a.gap_sm,
+        a.align_center,
+        a.flex_shrink,
+      ]}>
       <Text aria-hidden={true} style={t.atoms.text_contrast_medium}>
         {APP_LANGUAGES.find(l => l.code2 === sanitizedLang)?.name}
       </Text>

--- a/src/components/AppLanguageDropdown.web.tsx
+++ b/src/components/AppLanguageDropdown.web.tsx
@@ -31,7 +31,9 @@ export function AppLanguageDropdown() {
   return (
     <View
       style={[
-        {height: 32},
+        // We don't have hitSlop here to increase the tap region,
+        // alternative is negative margins.
+        {height: 32, marginVertical: -((32 - 14) / 2)},
         a.flex_row,
         a.gap_sm,
         a.align_center,

--- a/src/view/com/auth/SplashScreen.web.tsx
+++ b/src/view/com/auth/SplashScreen.web.tsx
@@ -154,10 +154,7 @@ function Footer() {
 
       <View style={a.flex_1} />
 
-      {/* Offset the height imposed by <AppLanguageDropdown /> */}
-      <View style={{marginVertical: -9}}>
-        <AppLanguageDropdown />
-      </View>
+      <AppLanguageDropdown />
     </View>
   )
 }

--- a/src/view/com/auth/SplashScreen.web.tsx
+++ b/src/view/com/auth/SplashScreen.web.tsx
@@ -154,7 +154,10 @@ function Footer() {
 
       <View style={a.flex_1} />
 
-      <AppLanguageDropdown />
+      {/* Offset the height imposed by <AppLanguageDropdown /> */}
+      <View style={{marginVertical: -9}}>
+        <AppLanguageDropdown />
+      </View>
     </View>
   )
 }

--- a/src/view/shell/Drawer.tsx
+++ b/src/view/shell/Drawer.tsx
@@ -224,7 +224,9 @@ let DrawerContent = ({}: {}): React.ReactNode => {
               />
             </View>
           ) : (
-            <NavSignupCard />
+            <View style={{paddingRight: 20}}>
+              <NavSignupCard />
+            </View>
           )}
 
           {hasSession ? (


### PR DESCRIPTION
14px seems hard to tap, so let's make it 32px instead.