### PR TITLE
[Session] Base

### DIFF
--- a/src/App.native.tsx
+++ b/src/App.native.tsx
@@ -16,8 +16,8 @@ import {useQueryClient} from '@tanstack/react-query'
 
 import {Provider as StatsigProvider} from '#/lib/statsig/statsig'
 import {init as initPersistedState} from '#/state/persisted'
-import * as persisted from '#/state/persisted'
 import {Provider as LabelDefsProvider} from '#/state/preferences/label-defs'
+import {readLastActiveAccount} from '#/state/session/util/readLastActiveAccount'
 import {useIntentHandler} from 'lib/hooks/useIntentHandler'
 import {useNotificationsListener} from 'lib/notifications/notifications'
 import {QueryProvider} from 'lib/react-query'
@@ -64,7 +64,7 @@ function InnerApp() {
       Toast.show(_(msg`Sorry! Your session expired. Please log in again.`))
     })
 
-    const account = persisted.get('session').currentAccount
+    const account = readLastActiveAccount()
     resumeSession(account)
   }, [resumeSession, _])
 

--- a/src/App.web.tsx
+++ b/src/App.web.tsx
@@ -7,8 +7,8 @@ import {SafeAreaProvider} from 'react-native-safe-area-context'
 
 import {Provider as StatsigProvider} from '#/lib/statsig/statsig'
 import {init as initPersistedState} from '#/state/persisted'
-import * as persisted from '#/state/persisted'
 import {Provider as LabelDefsProvider} from '#/state/preferences/label-defs'
+import {readLastActiveAccount} from '#/state/session/util/readLastActiveAccount'
 import {useIntentHandler} from 'lib/hooks/useIntentHandler'
 import {QueryProvider} from 'lib/react-query'
 import {ThemeProvider} from 'lib/ThemeContext'
@@ -42,7 +42,7 @@ function InnerApp() {
 
   // init
   useEffect(() => {
-    const account = persisted.get('session').currentAccount
+    const account = readLastActiveAccount()
     resumeSession(account)
   }, [resumeSession])
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -4,6 +4,7 @@ export const LOCAL_DEV_SERVICE =
   Platform.OS === 'android' ? 'http://10.0.2.2:2583' : 'http://localhost:2583'
 export const STAGING_SERVICE = 'https://staging.bsky.dev'
 export const BSKY_SERVICE = 'https://bsky.social'
+export const PUBLIC_BSKY_SERVICE = 'https://public.api.bsky.app'
 export const DEFAULT_SERVICE = BSKY_SERVICE
 const HELP_DESK_LANG = 'en-us'
 export const HELP_DESK_URL = `https://blueskyweb.zendesk.com/hc/${HELP_DESK_LANG}`

--- a/src/state/queries/index.ts
+++ b/src/state/queries/index.ts
@@ -1,7 +1,9 @@
 import {BskyAgent} from '@atproto/api'
 
+import {PUBLIC_BSKY_SERVICE} from '#/lib/constants'
+
 export const PUBLIC_BSKY_AGENT = new BskyAgent({
-  service: 'https://public.api.bsky.app',
+  service: PUBLIC_BSKY_SERVICE,
 })
 
 export const STALE = {

--- a/src/state/session/util/readLastActiveAccount.ts
+++ b/src/state/session/util/readLastActiveAccount.ts
@@ -1,0 +1,6 @@
+import * as persisted from '#/state/persisted'
+
+export function readLastActiveAccount() {
+  const {currentAccount, accounts} = persisted.get('session')
+  return accounts.find(a => a.did === currentAccount?.did)
+}


### PR DESCRIPTION
Moves the storage read for `currentAccount` into its own util, and adds/migrates to new const for the default public `BskyAgent`.

Other PRs on this stack:
- https://github.com/bluesky-social/social-app/pull/3543
- https://github.com/bluesky-social/social-app/pull/3544

Next steps:
- [ ] Update non-straightforward usages of `getAgent`, to be threaded through from a hook context
  - [ ] feeds created in `createApi` — afaict no usages of feed apis outside RQ contexts
  - [ ] `upsertProfile` callback in queries/profile
  - [ ] multiple usages of `whenAppViewReady`
  - [ ] `fetchPage` and `fetchSubjects` in `notifications/util`
  - [ ] couple things on `Onboarding/util`
  - [ ] `/lib/notifications/notifications` utils
- [ ] Implement `useGetAgent` hook in both v1 and v2 and replace usages of `getAgent` throughout codebase
- [ ] Integrate feature flag for rollout