### PR TITLE
Remove extra wrapper on notification user links

### DIFF
--- a/src/view/com/notifications/FeedItem.tsx
+++ b/src/view/com/notifications/FeedItem.tsx
@@ -420,31 +420,30 @@ function ExpandedAuthorsList({
           to={makeProfileLink({
             did: author.did,
             handle: author.handle,
-          })}>
-          <View style={styles.expandedAuthor}>
-            <View style={styles.expandedAuthorAvi}>
-              <ProfileHoverCard did={author.did}>
-                <UserAvatar
-                  size={35}
-                  avatar={author.avatar}
-                  moderation={author.moderation.ui('avatar')}
-                  type={author.associated?.labeler ? 'labeler' : 'user'}
-                />
-              </ProfileHoverCard>
-            </View>
-            <View style={s.flex1}>
-              <Text
-                type="lg-bold"
-                numberOfLines={1}
-                style={pal.text}
-                lineHeight={1.2}>
-                {sanitizeDisplayName(author.displayName || author.handle)}
-                &nbsp;
-                <Text style={[pal.textLight]} lineHeight={1.2}>
-                  {sanitizeHandle(author.handle)}
-                </Text>
+          })}
+          style={styles.expandedAuthor}>
+          <View style={styles.expandedAuthorAvi}>
+            <ProfileHoverCard did={author.did}>
+              <UserAvatar
+                size={35}
+                avatar={author.avatar}
+                moderation={author.moderation.ui('avatar')}
+                type={author.associated?.labeler ? 'labeler' : 'user'}
+              />
+            </ProfileHoverCard>
+          </View>
+          <View style={s.flex1}>
+            <Text
+              type="lg-bold"
+              numberOfLines={1}
+              style={pal.text}
+              lineHeight={1.2}>
+              {sanitizeDisplayName(author.displayName || author.handle)}
+              &nbsp;
+              <Text style={[pal.textLight]} lineHeight={1.2}>
+                {sanitizeHandle(author.handle)}
               </Text>
-            </View>
+            </Text>
           </View>
         </NewLink>
       ))}


### PR DESCRIPTION
## Why

We added profile hovers to the users in a notification dropdown in #3508. When we did this, we introduced the usage of another wrapper, `NewLink` (the new `Link` component). Because of how flexbox and text works in React Native, sometimes these additional wrappers really mess with text layout. Here, we just need to remove the extra `View` and place the styles that were used in that view on `NewLink` instead.

## Test Plan

Open the notifications page on native and expand a notification.

Before:

![Screenshot 2024-04-13 at 4 45 53 PM](https://github.com/bluesky-social/social-app/assets/153161762/d95a170f-29d5-437e-8efb-26beefbb0673)

After:

![Screenshot 2024-04-13 at 4 45 42 PM](https://github.com/bluesky-social/social-app/assets/153161762/fee50d49-f2a6-4569-a025-eacf3513e177)
