### PR TITLE
android: fix various places still using default Material Teal

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -64,6 +64,8 @@ module.exports = function (config) {
       icon: './assets/icon.png',
       userInterfaceStyle: 'automatic',
       splash: SPLASH_CONFIG,
+      // hsl(211, 99%, 53%), same as palette.default.brandText
+      primaryColor: '#1083fe',
       ios: {
         supportsTablet: false,
         bundleIdentifier: 'xyz.blueskyweb.app',
@@ -180,6 +182,7 @@ module.exports = function (config) {
         './plugins/withAndroidManifestPlugin.js',
         './plugins/withAndroidManifestFCMIconPlugin.js',
         './plugins/withAndroidStylesWindowBackgroundPlugin.js',
+        './plugins/withAndroidStylesAccentColorPlugin.js',
         './plugins/withAndroidSplashScreenStatusBarTranslucentPlugin.js',
         './plugins/shareExtension/withShareExtensions.js',
       ].filter(Boolean),

--- a/plugins/withAndroidStylesAccentColorPlugin.js
+++ b/plugins/withAndroidStylesAccentColorPlugin.js
@@ -1,0 +1,25 @@
+/**
+ * @file Set accent color to primaryColor from app.config.js.
+ * This way we get a sane default color for spinners, text inputs, etc.
+ */
+
+const {withAndroidStyles, AndroidConfig} = require('@expo/config-plugins')
+
+module.exports = function withAndroidStylesAccentColorPlugin(appConfig) {
+  return withAndroidStyles(appConfig, function (decoratedAppConfig) {
+    try {
+      decoratedAppConfig.modResults = AndroidConfig.Styles.assignStylesValue(
+        decoratedAppConfig.modResults,
+        {
+          add: true,
+          parent: AndroidConfig.Styles.getAppThemeLightNoActionBarGroup(),
+          name: 'colorAccent',
+          value: '@color/colorPrimary',
+        },
+      )
+    } catch (e) {
+      console.error(`withAndroidStylesAccentColorPlugin failed`, e)
+    }
+    return decoratedAppConfig
+  })
+}


### PR DESCRIPTION
Some places on Android are currently using the default [Material Teal](https://m1.material.io/style/color.html#:~:text=Teal) color, including the TextInput cursor, TextInput selection, and the spinner (ActivityIndicator) --- it's quite out of place whenever it shows up.

This PR sets Expo's primaryColor to #1083fe (which is the color that defaultTheme.palette.default.brandText resolves to), then applies it as the native accent color via a plugin (because Expo doesn't apply the accent color).

Comparison:

| Before (composer & signup) | After (composer & signup) |
|--------|--------|
| ![before-composer](https://github.com/bluesky-social/social-app/assets/11722318/6d8eaee4-5fd9-4938-afca-867058e68db7) | ![after-composer](https://github.com/bluesky-social/social-app/assets/11722318/4b94e4a0-d366-4043-956e-8e7a9b5e8d8f) |
| ![before-signup](https://github.com/bluesky-social/social-app/assets/11722318/c9bc2b1b-b40b-47e4-ac57-e268bb0e8da1) | ![after-signup](https://github.com/bluesky-social/social-app/assets/11722318/c4690376-ff0d-4b66-abeb-03b5de988a1b) |

The `plugins/withAndroidStylesAccentColorPlugin.js` plugin is copied and modified from `plugins/withAndroidStylesWindowBackgroundPlugin.js` since that appears to be the idiomatic way of modifying Android's `res/values/styles.xml`.