### PR TITLE
[Search] New API `sort` param

### DIFF
--- a/src/state/queries/search-posts.ts
+++ b/src/state/queries/search-posts.ts
@@ -34,18 +34,13 @@ export function useSearchPostsQuery({
   >({
     queryKey: searchPostsQueryKey({query, sort}),
     queryFn: async ({pageParam}) => {
-      // waiting on new APIs
-      switch (sort) {
-        // case 'top':
-        // case 'latest':
-        default:
-          const res = await getAgent().app.bsky.feed.searchPosts({
-            q: query,
-            limit: 25,
-            cursor: pageParam,
-          })
-          return res.data
-      }
+      const res = await getAgent().app.bsky.feed.searchPosts({
+        q: query,
+        limit: 25,
+        cursor: pageParam,
+        sort,
+      })
+      return res.data
     },
     initialPageParam: undefined,
     getNextPageParam: lastPage => lastPage.cursor,


### PR DESCRIPTION
Makes the top/latest tab actually do something now

Results don't seem different yet, but I can see it in the network request