### PR TITLE
Always send ref_ params

### DIFF
--- a/src/lib/statsig/statsig.tsx
+++ b/src/lib/statsig/statsig.tsx
@@ -15,12 +15,12 @@ import {useSession} from '../../state/session'
 import {LogEvents} from './events'
 import {Gate} from './gates'
 
-let refSrc: string | undefined
-let refUrl: string | undefined
+let refSrc: string
+let refUrl: string
 if (isWeb && typeof window !== 'undefined') {
   const params = new URLSearchParams(window.location.search)
-  refSrc = params.get('ref_src') ?? undefined
-  refUrl = params.get('ref_url') ?? undefined
+  refSrc = params.get('ref_src') ?? ''
+  refUrl = decodeURIComponent(params.get('ref_url') ?? '')
 }
 
 export type {LogEvents}


### PR DESCRIPTION
Seems like conditionally including them isn't enough to get Statsig to show them in the UI. Also, let's decode the URL so it's more readable.

## Test Plan

Tried an existing link but changed to localhost.

<img width="705" alt="Screenshot 2024-04-16 at 21 20 52" src="https://github.com/bluesky-social/social-app/assets/810438/5295b49c-3892-4fd1-8704-c48a09808de6">

Also verified default values are empty strings.