### PR TITLE
Better dist strings for Sentry

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -35,11 +35,6 @@ module.exports = function (config) {
    */
   const PLATFORM = process.env.EAS_BUILD_PLATFORM
 
-  const DIST_BUILD_NUMBER =
-    PLATFORM === 'android'
-      ? process.env.BSKY_ANDROID_VERSION_CODE
-      : process.env.BSKY_IOS_BUILD_NUMBER
-
   const IS_DEV = process.env.EXPO_PUBLIC_ENV === 'development'
   const IS_TESTFLIGHT = process.env.EXPO_PUBLIC_ENV === 'testflight'
   const IS_PRODUCTION = process.env.EXPO_PUBLIC_ENV === 'production'
@@ -51,9 +46,9 @@ module.exports = function (config) {
     : undefined
   const UPDATES_ENABLED = !!UPDATES_CHANNEL
 
-  const SENTRY_DIST = `${PLATFORM}.${VERSION}.${DIST_BUILD_NUMBER ?? ''}${
-    IS_TESTFLIGHT ? '.tf' : ''
-  }${IS_DEV ? '.dev' : ''}`
+  const SENTRY_DIST = `${PLATFORM}.${VERSION}.${IS_TESTFLIGHT ? 'tf' : ''}${
+    IS_DEV ? 'dev' : ''
+  }`
 
   return {
     expo: {

--- a/app.config.js
+++ b/app.config.js
@@ -51,6 +51,10 @@ module.exports = function (config) {
     : undefined
   const UPDATES_ENABLED = !!UPDATES_CHANNEL
 
+  const SENTRY_DIST = `${PLATFORM}.${VERSION}.${DIST_BUILD_NUMBER ?? ''}${
+    IS_TESTFLIGHT ? '-tf' : ''
+  }${IS_DEV ? '-dev' : ''}`
+
   return {
     expo: {
       version: VERSION,
@@ -217,7 +221,7 @@ module.exports = function (config) {
               organization: 'blueskyweb',
               project: 'react-native',
               release: VERSION,
-              dist: `${PLATFORM}.${VERSION}.${DIST_BUILD_NUMBER}`,
+              dist: SENTRY_DIST,
             },
           },
         ],

--- a/app.config.js
+++ b/app.config.js
@@ -52,8 +52,8 @@ module.exports = function (config) {
   const UPDATES_ENABLED = !!UPDATES_CHANNEL
 
   const SENTRY_DIST = `${PLATFORM}.${VERSION}.${DIST_BUILD_NUMBER ?? ''}${
-    IS_TESTFLIGHT ? '-tf' : ''
-  }${IS_DEV ? '-dev' : ''}`
+    IS_TESTFLIGHT ? '.tf' : ''
+  }${IS_DEV ? '.dev' : ''}`
 
   return {
     expo: {

--- a/src/lib/app-info.ts
+++ b/src/lib/app-info.ts
@@ -1,5 +1,6 @@
 import {nativeApplicationVersion, nativeBuildVersion} from 'expo-application'
 
+export const BUILD_ENV = process.env.EXPO_PUBLIC_ENV
 export const IS_DEV = process.env.EXPO_PUBLIC_ENV === 'development'
 export const IS_TESTFLIGHT = process.env.EXPO_PUBLIC_ENV === 'testflight'
 

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -26,8 +26,8 @@ const release = nativeApplicationVersion ?? 'dev'
  * - `android.1.57.0.46`
  */
 const dist = `${Platform.OS}.${release}.${nativeBuildVersion ?? ''}${
-  IS_TESTFLIGHT ? '-tf' : ''
-}${IS_DEV ? '-dev' : ''}`
+  IS_TESTFLIGHT ? '.tf' : ''
+}${IS_DEV ? '.dev' : ''}`
 
 init({
   autoSessionTracking: false,

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -25,9 +25,9 @@ const release = nativeApplicationVersion ?? 'dev'
  * - `ios.1.57.0.3`
  * - `android.1.57.0.46`
  */
-const dist = `${Platform.OS}.${release}.${nativeBuildVersion ?? ''}${
-  IS_TESTFLIGHT ? '.tf' : ''
-}${IS_DEV ? '.dev' : ''}`
+const dist = `${Platform.OS}.${nativeBuildVersion}.${
+  IS_TESTFLIGHT ? 'tf' : ''
+}${IS_DEV ? 'dev' : ''}`
 
 init({
   autoSessionTracking: false,

--- a/src/lib/sentry.ts
+++ b/src/lib/sentry.ts
@@ -5,16 +5,9 @@
 
 import {Platform} from 'react-native'
 import {nativeApplicationVersion, nativeBuildVersion} from 'expo-application'
-import * as info from 'expo-updates'
 import {init} from 'sentry-expo'
 
-/**
- * Matches the build profile `channel` props in `eas.json`
- */
-const buildChannel = (info.channel || 'development') as
-  | 'development'
-  | 'preview'
-  | 'production'
+import {BUILD_ENV, IS_DEV, IS_TESTFLIGHT} from 'lib/app-info'
 
 /**
  * Examples:
@@ -32,16 +25,16 @@ const release = nativeApplicationVersion ?? 'dev'
  * - `ios.1.57.0.3`
  * - `android.1.57.0.46`
  */
-const dist = `${Platform.OS}.${release}${
-  nativeBuildVersion ? `.${nativeBuildVersion}` : ''
-}`
+const dist = `${Platform.OS}.${release}.${nativeBuildVersion ?? ''}${
+  IS_TESTFLIGHT ? '-tf' : ''
+}${IS_DEV ? '-dev' : ''}`
 
 init({
   autoSessionTracking: false,
   dsn: 'https://05bc3789bf994b81bd7ce20c86ccd3ae@o4505071687041024.ingest.sentry.io/4505071690514432',
   debug: false, // If `true`, Sentry will try to print out useful debugging information if something goes wrong with sending the event. Set it to `false` in production
   enableInExpoDevelopment: false, // enable this to test in dev
-  environment: buildChannel,
+  environment: BUILD_ENV ?? 'development',
   dist,
   release,
 })


### PR DESCRIPTION
## Why

This resolves two problems:

- We use environment variables now to determine the channel to use for Expo updates, so the `info.channel` variable is undefined. This results in the default of `development` showing up for our builds on Sentry.
- It can be difficult to determine when adoption actually started for a particular version, since we release internally sometimes a week or so prior to cutting the production release. Instead, now we will use `-tf` or `-dev` to differentiate the various internal builds. Production builds will have nothing appended.

Also did a check to see if we rely on this `info.channel` anywhere else in the codebase, and we do not 👍 

## Test Plan

We can check the logs going to Sentry in a Testflight client to ensure that the `-tf` string is being properly appended. We can also check in Sentry to see if the symbols are being uploaded correctly following this change.