### PR TITLE
Scrolling while target is hovered and card is visible should hide the card

### DIFF
--- a/src/components/ProfileHoverCard/index.web.tsx
+++ b/src/components/ProfileHoverCard/index.web.tsx
@@ -57,8 +57,10 @@ type State = {
 
 type Action =
   | 'pressed'
-  | 'hovered'
-  | 'unhovered'
+  | 'hovered-target'
+  | 'unhovered-target'
+  | 'hovered-card'
+  | 'unhovered-card'
   | 'hovered-long-enough'
   | 'unhovered-long-enough'
   | 'finished-animating-hide'
@@ -90,7 +92,7 @@ export function ProfileHoverCardInner(props: ProfileHoverCardProps) {
 
       // The user can kick things off by hovering a target.
       if (state.stage === 'hidden') {
-        if (action === 'hovered') {
+        if (action === 'hovered-target' || action === 'hovered-card') {
           return mightShow(SHOW_DELAY)
         }
       }
@@ -111,7 +113,7 @@ export function ProfileHoverCardInner(props: ProfileHoverCardProps) {
 
       // We'll make a decision at the end of a grace period timeout.
       if (state.stage === 'might-show') {
-        if (action === 'unhovered') {
+        if (action === 'unhovered-target' || action === 'unhovered-card') {
           return hidden()
         }
         if (action === 'hovered-long-enough') {
@@ -127,7 +129,7 @@ export function ProfileHoverCardInner(props: ProfileHoverCardProps) {
 
       // If the user moves the pointer away, we'll begin to consider hiding it.
       if (state.stage === 'showing') {
-        if (action === 'unhovered') {
+        if (action === 'unhovered-target' || action === 'unhovered-card') {
           return mightHide(HIDE_DELAY)
         }
       }
@@ -149,7 +151,7 @@ export function ProfileHoverCardInner(props: ProfileHoverCardProps) {
 
       // We'll make a decision based on whether it received hover again in time.
       if (state.stage === 'might-hide') {
-        if (action === 'hovered') {
+        if (action === 'hovered-target' || action === 'hovered-card') {
           return showing()
         }
         if (action === 'unhovered-long-enough') {
@@ -203,19 +205,19 @@ export function ProfileHoverCardInner(props: ProfileHoverCardProps) {
 
   const onPointerEnterTarget = React.useCallback(() => {
     prefetchIfNeeded()
-    dispatch('hovered')
+    dispatch('hovered-target')
   }, [prefetchIfNeeded])
 
   const onPointerLeaveTarget = React.useCallback(() => {
-    dispatch('unhovered')
+    dispatch('unhovered-target')
   }, [])
 
   const onPointerEnterCard = React.useCallback(() => {
-    dispatch('hovered')
+    dispatch('hovered-card')
   }, [])
 
   const onPointerLeaveCard = React.useCallback(() => {
-    dispatch('unhovered')
+    dispatch('unhovered-card')
   }, [])
 
   const onPress = React.useCallback(() => {

--- a/src/components/ProfileHoverCard/index.web.tsx
+++ b/src/components/ProfileHoverCard/index.web.tsx
@@ -161,8 +161,12 @@ export function ProfileHoverCardInner(props: ProfileHoverCardProps) {
         if (action === 'unhovered-target' || action === 'unhovered-card') {
           return mightHide()
         }
-        // Scrolling away instantly hides without a delay.
-        if (action === 'scrolled-while-showing') {
+        // Scrolling away if the hover is on the target instantly hides without a delay.
+        // If the hover is already on the card, we won't this.
+        if (
+          state.reason === 'hovered-target' &&
+          action === 'scrolled-while-showing'
+        ) {
           return hiding()
         }
       }

--- a/src/components/ProfileHoverCard/index.web.tsx
+++ b/src/components/ProfileHoverCard/index.web.tsx
@@ -89,9 +89,8 @@ export function ProfileHoverCardInner(props: ProfileHoverCardProps) {
       function hidden(): State {
         return {stage: 'hidden'}
       }
-
-      // The user can kick things off by hovering a target.
       if (state.stage === 'hidden') {
+        // The user can kick things off by hovering a target.
         if (action === 'hovered-target' || action === 'hovered-card') {
           return mightShow(SHOW_DELAY)
         }
@@ -110,9 +109,8 @@ export function ProfileHoverCardInner(props: ProfileHoverCardProps) {
           },
         }
       }
-
-      // We'll make a decision at the end of a grace period timeout.
       if (state.stage === 'might-show') {
+        // We'll make a decision at the end of a grace period timeout.
         if (action === 'unhovered-target' || action === 'unhovered-card') {
           return hidden()
         }
@@ -126,9 +124,8 @@ export function ProfileHoverCardInner(props: ProfileHoverCardProps) {
       function showing(): State {
         return {stage: 'showing'}
       }
-
-      // If the user moves the pointer away, we'll begin to consider hiding it.
       if (state.stage === 'showing') {
+        // If the user moves the pointer away, we'll begin to consider hiding it.
         if (action === 'unhovered-target' || action === 'unhovered-card') {
           return mightHide(HIDE_DELAY)
         }
@@ -148,9 +145,8 @@ export function ProfileHoverCardInner(props: ProfileHoverCardProps) {
           },
         }
       }
-
-      // We'll make a decision based on whether it received hover again in time.
       if (state.stage === 'might-hide') {
+        // We'll make a decision based on whether it received hover again in time.
         if (action === 'hovered-target' || action === 'hovered-card') {
           return showing()
         }
@@ -173,10 +169,9 @@ export function ProfileHoverCardInner(props: ProfileHoverCardProps) {
           },
         }
       }
-
-      // While hiding, we don't want to be interrupted by anything else.
-      // When the animation finishes, we loop back to the initial hidden state.
       if (state.stage === 'hiding') {
+        // While hiding, we don't want to be interrupted by anything else.
+        // When the animation finishes, we loop back to the initial hidden state.
         if (action === 'finished-animating-hide') {
           return hidden()
         }

--- a/src/components/ProfileHoverCard/index.web.tsx
+++ b/src/components/ProfileHoverCard/index.web.tsx
@@ -93,15 +93,13 @@ export function ProfileHoverCardInner(props: ProfileHoverCardProps) {
       if (state.stage === 'hidden') {
         // The user can kick things off by hovering a target.
         if (action === 'hovered-target' || action === 'hovered-card') {
-          return mightShow({
-            waitMs: SHOW_DELAY,
-          })
+          return mightShow()
         }
       }
 
       // --- Might Show ---
       // The card is not visible yet but we're considering showing it.
-      function mightShow({waitMs = SHOW_DELAY}: {waitMs: number}): State {
+      function mightShow({waitMs = SHOW_DELAY}: {waitMs?: number} = {}): State {
         return {
           stage: 'might-show',
           effect() {
@@ -139,17 +137,17 @@ export function ProfileHoverCardInner(props: ProfileHoverCardProps) {
       if (state.stage === 'showing') {
         // If the user moves the pointer away, we'll begin to consider hiding it.
         if (action === 'unhovered-target' || action === 'unhovered-card') {
-          return mightHide({waitMs: HIDE_DELAY})
+          return mightHide()
         }
         // Scrolling away instantly hides without a delay.
         if (action === 'scrolled-while-showing') {
-          return hiding({animationDurationMs: HIDE_DURATION})
+          return hiding()
         }
       }
 
       // --- Might Hide ---
       // The user has moved hover away from a visible card.
-      function mightHide({waitMs}: {waitMs: number}): State {
+      function mightHide({waitMs = HIDE_DELAY}: {waitMs?: number} = {}): State {
         return {
           stage: 'might-hide',
           effect() {
@@ -167,17 +165,17 @@ export function ProfileHoverCardInner(props: ProfileHoverCardProps) {
           return showing()
         }
         if (action === 'unhovered-long-enough') {
-          return hiding({animationDurationMs: HIDE_DURATION})
+          return hiding()
         }
       }
 
       // --- Hiding ---
       // The user waited enough outside that we're hiding the card.
       function hiding({
-        animationDurationMs,
+        animationDurationMs = HIDE_DURATION,
       }: {
-        animationDurationMs: number
-      }): State {
+        animationDurationMs?: number
+      } = {}): State {
         return {
           stage: 'hiding',
           effect() {

--- a/src/components/ProfileHoverCard/index.web.tsx
+++ b/src/components/ProfileHoverCard/index.web.tsx
@@ -93,13 +93,15 @@ export function ProfileHoverCardInner(props: ProfileHoverCardProps) {
       if (state.stage === 'hidden') {
         // The user can kick things off by hovering a target.
         if (action === 'hovered-target' || action === 'hovered-card') {
-          return mightShow(SHOW_DELAY)
+          return mightShow({
+            waitMs: SHOW_DELAY,
+          })
         }
       }
 
       // --- Might Show ---
       // The card is not visible yet but we're considering showing it.
-      function mightShow(waitMs: number): State {
+      function mightShow({waitMs = SHOW_DELAY}: {waitMs: number}): State {
         return {
           stage: 'might-show',
           effect() {
@@ -137,17 +139,17 @@ export function ProfileHoverCardInner(props: ProfileHoverCardProps) {
       if (state.stage === 'showing') {
         // If the user moves the pointer away, we'll begin to consider hiding it.
         if (action === 'unhovered-target' || action === 'unhovered-card') {
-          return mightHide(HIDE_DELAY)
+          return mightHide({waitMs: HIDE_DELAY})
         }
         // Scrolling away instantly hides without a delay.
         if (action === 'scrolled-while-showing') {
-          return hiding(HIDE_DURATION)
+          return hiding({animationDurationMs: HIDE_DURATION})
         }
       }
 
       // --- Might Hide ---
       // The user has moved hover away from a visible card.
-      function mightHide(waitMs: number): State {
+      function mightHide({waitMs}: {waitMs: number}): State {
         return {
           stage: 'might-hide',
           effect() {
@@ -165,13 +167,17 @@ export function ProfileHoverCardInner(props: ProfileHoverCardProps) {
           return showing()
         }
         if (action === 'unhovered-long-enough') {
-          return hiding(HIDE_DURATION)
+          return hiding({animationDurationMs: HIDE_DURATION})
         }
       }
 
       // --- Hiding ---
       // The user waited enough outside that we're hiding the card.
-      function hiding(animationDurationMs: number): State {
+      function hiding({
+        animationDurationMs,
+      }: {
+        animationDurationMs: number
+      }): State {
         return {
           stage: 'hiding',
           effect() {

--- a/src/components/ProfileHoverCard/index.web.tsx
+++ b/src/components/ProfileHoverCard/index.web.tsx
@@ -57,6 +57,7 @@ type State = {
 
 type Action =
   | 'pressed'
+  | 'scrolled-while-showing'
   | 'hovered-target'
   | 'unhovered-target'
   | 'hovered-card'
@@ -122,12 +123,25 @@ export function ProfileHoverCardInner(props: ProfileHoverCardProps) {
       // --- Showing ---
       // The card is beginning to show up and then will remain visible.
       function showing(): State {
-        return {stage: 'showing'}
+        return {
+          stage: 'showing',
+          effect() {
+            function onScroll() {
+              dispatch('scrolled-while-showing')
+            }
+            window.addEventListener('scroll', onScroll)
+            return () => window.removeEventListener('scroll', onScroll)
+          },
+        }
       }
       if (state.stage === 'showing') {
         // If the user moves the pointer away, we'll begin to consider hiding it.
         if (action === 'unhovered-target' || action === 'unhovered-card') {
           return mightHide(HIDE_DELAY)
+        }
+        // Scrolling away instantly hides without a delay.
+        if (action === 'scrolled-while-showing') {
+          return hiding(HIDE_DURATION)
         }
       }
 

--- a/src/components/ProfileHoverCard/index.web.tsx
+++ b/src/components/ProfileHoverCard/index.web.tsx
@@ -188,7 +188,6 @@ export function ProfileHoverCardInner(props: ProfileHoverCardProps) {
   React.useEffect(() => {
     if (currentState.effect) {
       const effect = currentState.effect
-      delete currentState.effect // Mark as completed
       return effect()
     }
   }, [currentState])


### PR DESCRIPTION
This is kind of subtle but pretty important.

If you're just scrolling, you don't want the hover popup to appear all the time due to your cursor position. In this PR, I'm adding a new behavior: scrolling away dismisses the popover (similar to unhovering).

There are some nuances.

Scrolling away _while the hover is on the card itself_ will not dismiss it. This is because, to end up in this situation, you must have moved the cursor on the card. So you might legitimately be trying to do something with it. 

Also, scrolling before the card is even visible (i.e. during the "might show" state) will reset it back to the hidden state. So this will restart the timer, reducing false positives.

## Implementation

I've needed to massage the abstraction a little bit to get it to be able to do this. In particular:

- The `delete state.effect` thing was unnecessary — [see here](https://twitter.com/dan_abramov2/status/1780230637397451185).
- I've made state function arguments named so that they're clearer when parameterized.
- I've given the existing arguments some default values cause they're actually always the same.
- I've added the ability for different states to store different information, i.e. taking more advantage of this being a discriminated union.
  - In particular, `'might-show'` and `'showing'` keep track of _why_ we're showing stuff in `state.reason` (either due to `'hovered-target'` or `'hovered-card'`). I didn't _have to_ literally store an action there, but seemed convenient.
  - This lets us conditionally decide whether scrolling should dismiss anything. (E.g. we want to do that in the `showing` state only when `state.reason` is `'hovered-target'`. If we're hovering a card, we don't want scrolling to dismiss it.)

Note that we're only listening to scroll when needed and not all the time. So this avoids firing lots of tiny state updates for every card on scroll. We only really need this for the one where something's currently happening.

You _might_ want to review individual commits for clarity but the whole diff isn't too bad.

## Test Plan


https://github.com/bluesky-social/social-app/assets/810438/a9c33b6f-f207-4aed-a1a6-07401b678780

