### PR TITLE
Add hovercards to "Reply To"

### DIFF
--- a/src/components/ProfileHoverCard/index.web.tsx
+++ b/src/components/ProfileHoverCard/index.web.tsx
@@ -72,10 +72,10 @@ type Action =
   | 'unhovered-long-enough'
   | 'finished-animating-hide'
 
-const SHOW_DELAY = 350
+const SHOW_DELAY = 400
 const SHOW_DURATION = 300
-const HIDE_DELAY = 200
-const HIDE_DURATION = 200
+const HIDE_DELAY = 150
+const HIDE_DURATION = 150
 
 export function ProfileHoverCardInner(props: ProfileHoverCardProps) {
   const {refs, floatingStyles} = useFloating({

--- a/src/view/com/post/Post.tsx
+++ b/src/view/com/post/Post.tsx
@@ -23,6 +23,7 @@ import {countLines} from 'lib/strings/helpers'
 import {colors, s} from 'lib/styles'
 import {RQKEY as RQKEY_URI} from 'state/queries/resolve-uri'
 import {atoms as a} from '#/alf'
+import {ProfileHoverCard} from '#/components/ProfileHoverCard'
 import {RichText} from '#/components/RichText'
 import {ContentHider} from '../../../components/moderation/ContentHider'
 import {LabelsOnMyPost} from '../../../components/moderation/LabelsOnMe'
@@ -176,12 +177,14 @@ function PostInner({
                 numberOfLines={1}>
                 <Trans context="description">
                   Reply to{' '}
-                  <UserInfoText
-                    type="sm"
-                    did={replyAuthorDid}
-                    attr="displayName"
-                    style={[pal.textLight]}
-                  />
+                  <ProfileHoverCard inline did={replyAuthorDid}>
+                    <UserInfoText
+                      type="sm"
+                      did={replyAuthorDid}
+                      attr="displayName"
+                      style={[pal.textLight]}
+                    />
+                  </ProfileHoverCard>
                 </Trans>
               </Text>
             </View>

--- a/src/view/com/posts/FeedItem.tsx
+++ b/src/view/com/posts/FeedItem.tsx
@@ -284,12 +284,14 @@ let FeedItemInner = ({
                 numberOfLines={1}>
                 <Trans context="description">
                   Reply to{' '}
-                  <UserInfoText
-                    type="md"
-                    did={replyAuthorDid}
-                    attr="displayName"
-                    style={[pal.textLight]}
-                  />
+                  <ProfileHoverCard inline did={replyAuthorDid}>
+                    <UserInfoText
+                      type="md"
+                      did={replyAuthorDid}
+                      attr="displayName"
+                      style={[pal.textLight]}
+                    />
+                  </ProfileHoverCard>
                 </Trans>
               </Text>
             </View>


### PR DESCRIPTION
Self-explanatory.

<img width="452" alt="Screenshot 2024-04-16 at 23 37 22" src="https://github.com/bluesky-social/social-app/assets/810438/dbfd0fe0-94b2-4ccf-a1fb-6b878dd67e39">
<img width="452" alt="Screenshot 2024-04-16 at 23 38 10" src="https://github.com/bluesky-social/social-app/assets/810438/818ca165-3117-404d-be9e-2d11a250177c">

Also ever-so-slightly adjusted the durations to be more conservative (wait longer before showing, hide them faster).

Verified it doesn't break native.