### PR TITLE
properly animate the profile hover card

### DIFF
--- a/src/components/ProfileHoverCard/index.web.tsx
+++ b/src/components/ProfileHoverCard/index.web.tsx
@@ -294,7 +294,7 @@ export function ProfileHoverCardInner(props: ProfileHoverCardProps) {
             style={floatingStyles}
             onPointerEnter={onPointerEnterCard}
             onPointerLeave={onPointerLeaveCard}>
-            <div style={animationStyle}>
+            <div style={{willChange: 'transform', ...animationStyle}}>
               <Card did={props.did} hide={onPress} />
             </div>
           </div>

--- a/src/components/ProfileHoverCard/index.web.tsx
+++ b/src/components/ProfileHoverCard/index.web.tsx
@@ -78,6 +78,10 @@ const HIDE_DELAY = 150
 const HIDE_DURATION = 150
 
 export function ProfileHoverCardInner(props: ProfileHoverCardProps) {
+  const {refs, floatingStyles} = useFloating({
+    middleware: floatingMiddlewares,
+  })
+
   const [currentState, dispatch] = React.useReducer(
     // Tip: console.log(state, action) when debugging.
     (state: State, action: Action): State => {
@@ -266,11 +270,6 @@ export function ProfileHoverCardInner(props: ProfileHoverCardProps) {
     currentState.stage === 'might-hide' ||
     currentState.stage === 'hiding'
 
-  const {refs, floatingStyles, isPositioned} = useFloating({
-    middleware: floatingMiddlewares,
-    open: isVisible,
-  })
-
   const animationStyle = {
     animation:
       currentState.stage === 'hiding'
@@ -290,15 +289,14 @@ export function ProfileHoverCardInner(props: ProfileHoverCardProps) {
       {props.children}
       {isVisible && (
         <Portal>
-          <div ref={refs.setFloating} style={floatingStyles}>
-            {isPositioned && (
-              <div
-                style={animationStyle}
-                onPointerEnter={onPointerEnterCard}
-                onPointerLeave={onPointerLeaveCard}>
-                <Card did={props.did} hide={onPress} />
-              </div>
-            )}
+          <div
+            ref={refs.setFloating}
+            style={floatingStyles}
+            onPointerEnter={onPointerEnterCard}
+            onPointerLeave={onPointerLeaveCard}>
+            <div style={animationStyle}>
+              <Card did={props.did} hide={onPress} />
+            </div>
           </div>
         </Portal>
       )}

--- a/src/components/ProfileHoverCard/index.web.tsx
+++ b/src/components/ProfileHoverCard/index.web.tsx
@@ -78,10 +78,6 @@ const HIDE_DELAY = 150
 const HIDE_DURATION = 150
 
 export function ProfileHoverCardInner(props: ProfileHoverCardProps) {
-  const {refs, floatingStyles} = useFloating({
-    middleware: floatingMiddlewares,
-  })
-
   const [currentState, dispatch] = React.useReducer(
     // Tip: console.log(state, action) when debugging.
     (state: State, action: Action): State => {
@@ -270,6 +266,11 @@ export function ProfileHoverCardInner(props: ProfileHoverCardProps) {
     currentState.stage === 'might-hide' ||
     currentState.stage === 'hiding'
 
+  const {refs, floatingStyles, isPositioned} = useFloating({
+    middleware: floatingMiddlewares,
+    open: isVisible,
+  })
+
   const animationStyle = {
     animation:
       currentState.stage === 'hiding'
@@ -289,14 +290,15 @@ export function ProfileHoverCardInner(props: ProfileHoverCardProps) {
       {props.children}
       {isVisible && (
         <Portal>
-          <div style={animationStyle}>
-            <div
-              ref={refs.setFloating}
-              style={floatingStyles}
-              onPointerEnter={onPointerEnterCard}
-              onPointerLeave={onPointerLeaveCard}>
-              <Card did={props.did} hide={onPress} />
-            </div>
+          <div ref={refs.setFloating} style={floatingStyles}>
+            {isPositioned && (
+              <div
+                style={animationStyle}
+                onPointerEnter={onPointerEnterCard}
+                onPointerLeave={onPointerLeaveCard}>
+                <Card did={props.did} hide={onPress} />
+              </div>
+            )}
           </div>
         </Portal>
       )}


### PR DESCRIPTION
## Why

It was pointed out that hover card animations on Firefox were not working very well. If you were scrolled down the page far enough, they would stutter. Turns out we had not properly implemented `useFloating()`.

See https://floating-ui.com/docs/useFloating#open and https://floating-ui.com/docs/useFloating#ispositioned

Edit: Well, we don't actually need to use `open` or `isPositioned`, but this seems to give us a hint as to what might be causing the jank. The card starts off at 0,0 when it gets rendered, then moves to wherever it's supposed to be positioned. Moving the animation _inside_ of the moving element fixes the jank.

## Test Plan

Using Firefox, scroll down the page about 20 posts or so, and hover over an avatar. The animations should now be smooth.