### PR TITLE
don't underline handle in post meta

### DIFF
--- a/src/view/com/util/Link.tsx
+++ b/src/view/com/util/Link.tsx
@@ -2,34 +2,35 @@ import React, {ComponentProps, memo, useMemo} from 'react'
 import {
   GestureResponderEvent,
   Platform,
+  Pressable,
   StyleProp,
-  TextStyle,
   TextProps,
+  TextStyle,
+  TouchableOpacity,
   View,
   ViewStyle,
-  Pressable,
-  TouchableOpacity,
 } from 'react-native'
-import {useLinkProps, StackActions} from '@react-navigation/native'
-import {Text} from './text/Text'
-import {TypographyVariant} from 'lib/ThemeContext'
-import {router} from '../../../routes'
+import {sanitizeUrl} from '@braintree/sanitize-url'
+import {StackActions, useLinkProps} from '@react-navigation/native'
+
+import {useModalControls} from '#/state/modals'
+import {useOpenLink} from '#/state/preferences/in-app-browser'
+import {
+  DebouncedNavigationProp,
+  useNavigationDeduped,
+} from 'lib/hooks/useNavigationDeduped'
 import {
   convertBskyAppUrlIfNeeded,
   isExternalUrl,
   linkRequiresWarning,
 } from 'lib/strings/url-helpers'
+import {TypographyVariant} from 'lib/ThemeContext'
 import {isAndroid, isWeb} from 'platform/detection'
-import {sanitizeUrl} from '@braintree/sanitize-url'
-import {PressableWithHover} from './PressableWithHover'
-import {useModalControls} from '#/state/modals'
-import {useOpenLink} from '#/state/preferences/in-app-browser'
 import {WebAuxClickWrapper} from 'view/com/util/WebAuxClickWrapper'
-import {
-  DebouncedNavigationProp,
-  useNavigationDeduped,
-} from 'lib/hooks/useNavigationDeduped'
 import {useTheme} from '#/alf'
+import {router} from '../../../routes'
+import {PressableWithHover} from './PressableWithHover'
+import {Text} from './text/Text'
 
 type Event =
   | React.MouseEvent<HTMLAnchorElement, MouseEvent>
@@ -149,6 +150,7 @@ export const TextLink = memo(function TextLink({
   onPress,
   disableMismatchWarning,
   navigationAction,
+  anchorNoUnderline,
   ...orgProps
 }: {
   testID?: string
@@ -162,6 +164,7 @@ export const TextLink = memo(function TextLink({
   title?: string
   disableMismatchWarning?: boolean
   navigationAction?: 'push' | 'replace' | 'navigate'
+  anchorNoUnderline?: boolean
 } & TextProps) {
   const {...props} = useLinkProps({to: sanitizeUrl(href)})
   const navigation = useNavigationDeduped()
@@ -170,6 +173,11 @@ export const TextLink = memo(function TextLink({
 
   if (!disableMismatchWarning && typeof text !== 'string') {
     console.error('Unable to detect mismatching label')
+  }
+
+  if (anchorNoUnderline) {
+    dataSet = dataSet ?? {}
+    dataSet.noUnderline = 1
   }
 
   props.onPress = React.useCallback(
@@ -267,6 +275,7 @@ interface TextLinkOnWebOnlyProps extends TextProps {
   navigationAction?: 'push' | 'replace' | 'navigate'
   disableMismatchWarning?: boolean
   onPointerEnter?: () => void
+  anchorNoUnderline?: boolean
 }
 export const TextLinkOnWebOnly = memo(function DesktopWebTextLink({
   testID,

--- a/src/view/com/util/PostMeta.tsx
+++ b/src/view/com/util/PostMeta.tsx
@@ -54,7 +54,7 @@ let PostMeta = (opts: PostMetaOpts): React.ReactNode => {
           />
         </View>
       )}
-      <Text numberOfLines={1} style={[styles.maxWidth]}>
+      <Text numberOfLines={1} style={[styles.maxWidth, pal.textLight]}>
         <TextLinkOnWebOnly
           type={opts.displayNameType || 'lg-bold'}
           style={[pal.text, opts.displayNameStyle]}

--- a/src/view/com/util/PostMeta.tsx
+++ b/src/view/com/util/PostMeta.tsx
@@ -74,7 +74,7 @@ let PostMeta = (opts: PostMetaOpts): React.ReactNode => {
         <TextLinkOnWebOnly
           type="md"
           disableMismatchWarning
-          style={[pal.textLight, {flexShrink: 4, paddingLeft: 5}]}
+          style={[pal.textLight, {flexShrink: 4, paddingLeft: 4}]}
           text={sanitizeHandle(handle, '@')}
           href={profileLink}
           onPointerEnter={onPointerEnter}

--- a/src/view/com/util/PostMeta.tsx
+++ b/src/view/com/util/PostMeta.tsx
@@ -35,6 +35,11 @@ let PostMeta = (opts: PostMetaOpts): React.ReactNode => {
   const handle = opts.author.handle
   const prefetchProfileQuery = usePrefetchProfileQuery()
 
+  const profileLink = makeProfileLink(opts.author)
+  const onPointerEnter = isWeb
+    ? () => prefetchProfileQuery(opts.author.did)
+    : undefined
+
   return (
     <View style={[styles.container, opts.style]}>
       {opts.showAvatar && (
@@ -49,11 +54,10 @@ let PostMeta = (opts: PostMetaOpts): React.ReactNode => {
           />
         </View>
       )}
-      <View style={styles.maxWidth}>
+      <Text numberOfLines={1} style={[styles.maxWidth]}>
         <TextLinkOnWebOnly
           type={opts.displayNameType || 'lg-bold'}
           style={[pal.text, opts.displayNameStyle]}
-          numberOfLines={1}
           lineHeight={1.2}
           disableMismatchWarning
           text={
@@ -63,21 +67,21 @@ let PostMeta = (opts: PostMetaOpts): React.ReactNode => {
                 opts.moderation?.ui('displayName'),
               )}
               &nbsp;
-              <Text
-                type="md"
-                numberOfLines={1}
-                lineHeight={1.2}
-                style={pal.textLight}>
-                {sanitizeHandle(handle, '@')}
-              </Text>
             </>
           }
-          href={makeProfileLink(opts.author)}
-          onPointerEnter={
-            isWeb ? () => prefetchProfileQuery(opts.author.did) : undefined
-          }
+          href={profileLink}
+          onPointerEnter={onPointerEnter}
         />
-      </View>
+        <TextLinkOnWebOnly
+          type="md"
+          disableMismatchWarning
+          style={[pal.textLight, {flexShrink: 1}]}
+          text={sanitizeHandle(handle, '@')}
+          href={profileLink}
+          onPointerEnter={onPointerEnter}
+          anchorNoUnderline
+        />
+      </Text>
       {!isAndroid && (
         <Text
           type="md"
@@ -110,7 +114,7 @@ export {PostMeta}
 const styles = StyleSheet.create({
   container: {
     flexDirection: 'row',
-    alignItems: 'center',
+    alignItems: 'flex-end',
     paddingBottom: 2,
     gap: 4,
     zIndex: 1,

--- a/src/view/com/util/PostMeta.tsx
+++ b/src/view/com/util/PostMeta.tsx
@@ -74,8 +74,8 @@ let PostMeta = (opts: PostMetaOpts): React.ReactNode => {
         <TextLinkOnWebOnly
           type="md"
           disableMismatchWarning
-          style={[pal.textLight, {flexShrink: 4, paddingLeft: 4}]}
-          text={sanitizeHandle(handle, '@')}
+          style={[pal.textLight, {flexShrink: 4}]}
+          text={'\xa0' + sanitizeHandle(handle, '@')}
           href={profileLink}
           onPointerEnter={onPointerEnter}
           anchorNoUnderline

--- a/src/view/com/util/PostMeta.tsx
+++ b/src/view/com/util/PostMeta.tsx
@@ -66,7 +66,6 @@ let PostMeta = (opts: PostMetaOpts): React.ReactNode => {
                 displayName,
                 opts.moderation?.ui('displayName'),
               )}
-              &nbsp;
             </>
           }
           href={profileLink}
@@ -75,7 +74,7 @@ let PostMeta = (opts: PostMetaOpts): React.ReactNode => {
         <TextLinkOnWebOnly
           type="md"
           disableMismatchWarning
-          style={[pal.textLight, {flexShrink: 1}]}
+          style={[pal.textLight, {flexShrink: 4, paddingLeft: 5}]}
           text={sanitizeHandle(handle, '@')}
           href={profileLink}
           onPointerEnter={onPointerEnter}


### PR DESCRIPTION
## Why

It looks ugly.

But seriously. Right now, having the single underline for the entire text doesn't look great at all. We can separate them into two components, so they are individually underlined, but the @ doesn't look great.

![image](https://github.com/bluesky-social/social-app/assets/153161762/f9f19546-61df-4346-a19a-3ff0b979522e)


Instead, let's just not underline the handle at all. It is still a link though.

## Test Plan

Hover the display name which should still be underlined, then the handle which should not.

<img width="382" alt="Screenshot 2024-04-16 at 7 10 20 PM" src="https://github.com/bluesky-social/social-app/assets/153161762/b946052a-018b-4aac-a756-4b66080d2de0">
