### PR TITLE
[Statsig] Fix exposure logging by doing gate checks lazily

### DIFF
--- a/eslint/use-typed-gates.js
+++ b/eslint/use-typed-gates.js
@@ -25,6 +25,7 @@ exports.create = function create(context) {
             "Use useGate() from '#/lib/statsig/statsig' instead of the one on npm.",
         })
       }
+      // TODO: Verify gate() call results aren't stored in variables.
     },
   }
 }

--- a/src/lib/hooks/useOTAUpdates.ts
+++ b/src/lib/hooks/useOTAUpdates.ts
@@ -31,8 +31,8 @@ async function setExtraParams() {
 }
 
 export function useOTAUpdates() {
-  const shouldReceiveUpdates =
-    useGate('receive_updates') && isEnabled && !__DEV__
+  const gate = useGate()
+  const shouldReceiveUpdates = isEnabled && !__DEV__ && gate('receive_updates')
 
   const appState = React.useRef<AppStateStatus>('active')
   const lastMinimize = React.useRef(0)

--- a/src/screens/Profile/Header/ProfileHeaderStandard.tsx
+++ b/src/screens/Profile/Header/ProfileHeaderStandard.tsx
@@ -80,9 +80,7 @@ let ProfileHeaderStandard = ({
     })
   }, [track, openModal, profile])
 
-  const autoExpandSuggestionsOnProfileFollow = useGate(
-    'autoexpand_suggestions_on_profile_follow',
-  )
+  const gate = useGate()
   const onPressFollow = () => {
     requireAuth(async () => {
       try {
@@ -96,7 +94,7 @@ let ProfileHeaderStandard = ({
             )}`,
           ),
         )
-        if (isWeb && autoExpandSuggestionsOnProfileFollow) {
+        if (isWeb && gate('autoexpand_suggestions_on_profile_follow')) {
           setShowSuggestedFollows(true)
         }
       } catch (e: any) {

--- a/src/state/shell/selected-feed.tsx
+++ b/src/state/shell/selected-feed.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import {Gate} from '#/lib/statsig/gates'
 import {useGate} from '#/lib/statsig/statsig'
 import {isWeb} from '#/platform/detection'
 import * as persisted from '#/state/persisted'
@@ -10,7 +11,7 @@ type SetContext = (v: string) => void
 const stateContext = React.createContext<StateContext>('home')
 const setContext = React.createContext<SetContext>((_: string) => {})
 
-function getInitialFeed(startSessionWithFollowing: boolean) {
+function getInitialFeed(gate: (gateName: Gate) => boolean) {
   if (isWeb) {
     if (window.location.pathname === '/') {
       const params = new URLSearchParams(window.location.search)
@@ -26,7 +27,7 @@ function getInitialFeed(startSessionWithFollowing: boolean) {
       return feedFromSession
     }
   }
-  if (!startSessionWithFollowing) {
+  if (!gate('start_session_with_following')) {
     const feedFromPersisted = persisted.get('lastSelectedHomeFeed')
     if (feedFromPersisted) {
       // Fall back to the last chosen one across all tabs.
@@ -37,10 +38,8 @@ function getInitialFeed(startSessionWithFollowing: boolean) {
 }
 
 export function Provider({children}: React.PropsWithChildren<{}>) {
-  const startSessionWithFollowing = useGate('start_session_with_following')
-  const [state, setState] = React.useState(() =>
-    getInitialFeed(startSessionWithFollowing),
-  )
+  const gate = useGate()
+  const [state, setState] = React.useState(() => getInitialFeed(gate))
 
   const saveState = React.useCallback((feed: string) => {
     setState(feed)

--- a/src/view/com/feeds/FeedPage.tsx
+++ b/src/view/com/feeds/FeedPage.tsx
@@ -53,6 +53,7 @@ export function FeedPage({
   const headerOffset = useHeaderOffset()
   const scrollElRef = React.useRef<ListMethods>(null)
   const [hasNew, setHasNew] = React.useState(false)
+  const gate = useGate()
 
   const scrollToTop = React.useCallback(() => {
     scrollElRef.current?.scrollToOffset({
@@ -105,9 +106,10 @@ export function FeedPage({
 
   let feedPollInterval
   if (
-    useGate('disable_poll_on_discover') &&
     feed === // Discover
-      'feedgen|at://did:plc:z72i7hdynmk6r22z27h6tvur/app.bsky.feed.generator/whats-hot'
+      'feedgen|at://did:plc:z72i7hdynmk6r22z27h6tvur/app.bsky.feed.generator/whats-hot' &&
+    // TODO: This gate check is still too early. Move it to where the polling happens.
+    gate('disable_poll_on_discover')
   ) {
     feedPollInterval = undefined
   } else {

--- a/src/view/com/post-thread/PostThreadFollowBtn.tsx
+++ b/src/view/com/post-thread/PostThreadFollowBtn.tsx
@@ -48,7 +48,7 @@ function PostThreadFollowBtnLoaded({
     'PostThreadItem',
   )
   const requireAuth = useRequireAuth()
-  const showFollowBackLabel = useGate('show_follow_back_label')
+  const gate = useGate()
 
   const isFollowing = !!profile.viewer?.following
   const isFollowedBy = !!profile.viewer?.followedBy
@@ -140,7 +140,7 @@ function PostThreadFollowBtnLoaded({
             style={[!isFollowing ? palInverted.text : pal.text, s.bold]}
             numberOfLines={1}>
             {!isFollowing ? (
-              showFollowBackLabel && isFollowedBy ? (
+              isFollowedBy && gate('show_follow_back_label') ? (
                 <Trans>Follow Back</Trans>
               ) : (
                 <Trans>Follow</Trans>

--- a/src/view/com/util/List.tsx
+++ b/src/view/com/util/List.tsx
@@ -40,8 +40,8 @@ function ListImpl<ItemT>(
   const isScrolledDown = useSharedValue(false)
   const contextScrollHandlers = useScrollHandlers()
   const pal = usePalette('default')
-  const showsVerticalScrollIndicator =
-    !useGate('hide_vertical_scroll_indicators') || isWeb
+  const gate = useGate()
+
   function handleScrolledDownChange(didScrollDown: boolean) {
     onScrolledDownChange?.(didScrollDown)
   }
@@ -97,7 +97,9 @@ function ListImpl<ItemT>(
       scrollEventThrottle={1}
       style={style}
       ref={ref}
-      showsVerticalScrollIndicator={showsVerticalScrollIndicator}
+      showsVerticalScrollIndicator={
+        isWeb || !gate('hide_vertical_scroll_indicators')
+      }
     />
   )
 }

--- a/src/view/com/util/Views.jsx
+++ b/src/view/com/util/Views.jsx
@@ -10,14 +10,11 @@ export function CenteredView(props) {
 }
 
 export function ScrollView(props) {
-  const showsVerticalScrollIndicator = !useGate(
-    'hide_vertical_scroll_indicators',
-  )
-
+  const gate = useGate()
   return (
     <Animated.ScrollView
       {...props}
-      showsVerticalScrollIndicator={showsVerticalScrollIndicator}
+      showsVerticalScrollIndicator={!gate('hide_vertical_scroll_indicators')}
     />
   )
 }

--- a/src/view/screens/Home.tsx
+++ b/src/view/screens/Home.tsx
@@ -111,21 +111,20 @@ function HomeScreenReady({
     }),
   )
 
-  const disableMinShellOnForegrounding = useGate(
-    'disable_min_shell_on_foregrounding',
-  )
+  const gate = useGate()
   React.useEffect(() => {
-    if (disableMinShellOnForegrounding) {
-      const listener = AppState.addEventListener('change', nextAppState => {
-        if (nextAppState === 'active') {
+    const listener = AppState.addEventListener('change', nextAppState => {
+      if (nextAppState === 'active') {
+        // TODO: Check if minimal shell is on before logging an exposure.
+        if (gate('disable_min_shell_on_foregrounding')) {
           setMinimalShellMode(false)
         }
-      })
-      return () => {
-        listener.remove()
       }
+    })
+    return () => {
+      listener.remove()
     }
-  }, [setMinimalShellMode, disableMinShellOnForegrounding])
+  }, [setMinimalShellMode, gate])
 
   const onPageSelected = React.useCallback(
     (index: number) => {

--- a/src/view/screens/ModerationBlockedAccounts.tsx
+++ b/src/view/screens/ModerationBlockedAccounts.tsx
@@ -38,8 +38,7 @@ export function ModerationBlockedAccounts({}: Props) {
   const setMinimalShellMode = useSetMinimalShellMode()
   const {isTabletOrDesktop} = useWebMediaQueries()
   const {screen} = useAnalytics()
-  const showsVerticalScrollIndicator =
-    !useGate('hide_vertical_scroll_indicators') || isWeb
+  const gate = useGate()
 
   const [isPTRing, setIsPTRing] = React.useState(false)
   const {
@@ -169,7 +168,9 @@ export function ModerationBlockedAccounts({}: Props) {
           )}
           // @ts-ignore our .web version only -prf
           desktopFixedHeight
-          showsVerticalScrollIndicator={showsVerticalScrollIndicator}
+          showsVerticalScrollIndicator={
+            isWeb || !gate('hide_vertical_scroll_indicators')
+          }
         />
       )}
     </CenteredView>

--- a/src/view/screens/ModerationMutedAccounts.tsx
+++ b/src/view/screens/ModerationMutedAccounts.tsx
@@ -38,8 +38,8 @@ export function ModerationMutedAccounts({}: Props) {
   const setMinimalShellMode = useSetMinimalShellMode()
   const {isTabletOrDesktop} = useWebMediaQueries()
   const {screen} = useAnalytics()
-  const showsVerticalScrollIndicator =
-    !useGate('hide_vertical_scroll_indicators') || isWeb
+  const gate = useGate()
+
   const [isPTRing, setIsPTRing] = React.useState(false)
   const {
     data,
@@ -167,7 +167,9 @@ export function ModerationMutedAccounts({}: Props) {
           )}
           // @ts-ignore our .web version only -prf
           desktopFixedHeight
-          showsVerticalScrollIndicator={showsVerticalScrollIndicator}
+          showsVerticalScrollIndicator={
+            isWeb || !gate('hide_vertical_scroll_indicators')
+          }
         />
       )}
     </CenteredView>

--- a/src/view/screens/Profile.tsx
+++ b/src/view/screens/Profile.tsx
@@ -143,7 +143,7 @@ function ProfileScreenLoaded({
   const setMinimalShellMode = useSetMinimalShellMode()
   const {openComposer} = useComposerControls()
   const {screen, track} = useAnalytics()
-  const shouldUseScrollableHeader = useGate('new_profile_scroll_component')
+  const gate = useGate()
   const {
     data: labelerInfo,
     error: labelerError,
@@ -317,7 +317,7 @@ function ProfileScreenLoaded({
   // =
 
   const renderHeader = React.useCallback(() => {
-    if (shouldUseScrollableHeader) {
+    if (gate('new_profile_scroll_component')) {
       return (
         <ExpoScrollForwarderView scrollViewTag={scrollViewTag}>
           <ProfileHeader
@@ -343,7 +343,7 @@ function ProfileScreenLoaded({
       )
     }
   }, [
-    shouldUseScrollableHeader,
+    gate,
     scrollViewTag,
     profile,
     labelerInfo,

--- a/src/view/screens/Search/Search.tsx
+++ b/src/view/screens/Search/Search.tsx
@@ -210,7 +210,8 @@ function useSuggestedFollowsV2(): [
 
 function SearchScreenSuggestedFollows() {
   const pal = usePalette('default')
-  const useSuggestedFollows = useGate('use_new_suggestions_endpoint')
+  const gate = useGate()
+  const useSuggestedFollows = gate('use_new_suggestions_endpoint')
     ? // Conditional hook call here is *only* OK because useGate()
       // result won't change until a remount.
       useSuggestedFollowsV2
@@ -406,8 +407,7 @@ export function SearchScreenInner({
   const {isDesktop} = useWebMediaQueries()
   const [activeTab, setActiveTab] = React.useState(0)
   const {_} = useLingui()
-
-  const isNewSearch = useGate('new_search')
+  const gate = useGate()
 
   const onPageSelected = React.useCallback(
     (index: number) => {
@@ -420,7 +420,7 @@ export function SearchScreenInner({
 
   const sections = React.useMemo(() => {
     if (!query) return []
-    if (isNewSearch) {
+    if (gate('new_search')) {
       if (hasSession) {
         return [
           {
@@ -487,7 +487,7 @@ export function SearchScreenInner({
         ]
       }
     }
-  }, [hasSession, isNewSearch, _, query, activeTab])
+  }, [hasSession, gate, _, query, activeTab])
 
   if (hasSession) {
     return query ? (


### PR DESCRIPTION
Our experiments are noisy. The hypothesis is that they're noisy in part because we're overcounting exposures. We only want an exposure if the GK result materially affects the outcome. However, the previous `useGate(...)` API forced us to do exposures early even if the GK results isn't even used (such as if it's only taken into account during some future event, or maybe it's used inside another condition).

To counter-act that, I'm changing the API to be:

```js
const gate = useGate()

if (gate('foo')) {
  // ...
}
```

The `gate('foo')` call will log an exposure so it must be put as late as possible — i.e. at the point where it actually affects the outcome in some user-perceptible way.

```js
// Bad ❌
if (gk('foo') && bar) {
  // ...
}

// Good ✅
if (bar && gk('foo')) {
  // ...
}
```

Although look inside!

```js
// Still bad ❌
if (bar && gk('foo')) {
  if (baz) {
    // ...
  }
}
```

(Can you guess how to fix this one?)

This also means that this is now an anti-pattern:

```js
const gate = useGate('foo')
const enableFoo = gate('foo') // Bad ❌

if (bar && enableFoo) {
  // ...
}
```

Instead, do:

```js
const gate = useGate('foo')

if (bar && gate('foo')) { // Good ✅
  // ...
}
```

A nice rule of thumb is imagine each `gate('foo')` call costs you money (it's also kind of true). How would you write the code? Write it that way.

## Test Plan

Manual scanning.

Check some test exposures in the dev console. Verify they hit more lazily than before (e.g. only when clicking Follow for the suggested follows gate).

<img width="889" alt="Screenshot 2024-04-17 at 05 59 53" src="https://github.com/bluesky-social/social-app/assets/810438/36a49b78-4ae4-4b48-a87e-61d6911a0137">

I need to also check that changing accounts works as expected — haven't done that yet.