### PR TITLE
Cleanup files after upload on native

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "expo-constants": "~15.4.5",
     "expo-dev-client": "~3.3.8",
     "expo-device": "~5.9.3",
+    "expo-file-system": "^16.0.9",
     "expo-haptics": "^12.8.1",
     "expo-image": "~1.10.6",
     "expo-image-manipulator": "^11.8.0",

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -1,6 +1,7 @@
+import {deleteAsync} from 'expo-file-system'
 import {
-  AppBskyEmbedImages,
   AppBskyEmbedExternal,
+  AppBskyEmbedImages,
   AppBskyEmbedRecord,
   AppBskyEmbedRecordWithMedia,
   AppBskyFeedThreadgate,
@@ -11,13 +12,14 @@ import {
   RichText,
 } from '@atproto/api'
 import {AtUri} from '@atproto/api'
-import {isNetworkError} from 'lib/strings/errors'
-import {LinkMeta} from '../link-meta/link-meta'
-import {isWeb} from 'platform/detection'
-import {ImageModel} from 'state/models/media/image'
-import {shortenLinks} from 'lib/strings/rich-text-manip'
+
 import {logger} from '#/logger'
 import {ThreadgateSetting} from '#/state/queries/threadgate'
+import {isNetworkError} from 'lib/strings/errors'
+import {shortenLinks} from 'lib/strings/rich-text-manip'
+import {isNative, isWeb} from 'platform/detection'
+import {ImageModel} from 'state/models/media/image'
+import {LinkMeta} from '../link-meta/link-meta'
 
 export interface ExternalEmbedDraft {
   uri: string
@@ -117,6 +119,15 @@ export async function post(agent: BskyAgent, opts: PostOpts) {
       const {width, height} = image.compressed || image
       logger.debug(`Uploading image`)
       const res = await uploadBlob(agent, path, 'image/jpeg')
+
+      if (isNative) {
+        try {
+          console.log('attempting to delete', path)
+          deleteAsync(path)
+          console.log('deleted', path)
+        } catch (e) {}
+      }
+
       images.push({
         image: res.data.blob,
         alt: image.altText ?? '',
@@ -171,6 +182,14 @@ export async function post(agent: BskyAgent, opts: PostOpts) {
             encoding,
           )
           thumb = thumbUploadRes.data.blob
+
+          try {
+            if (isNative) {
+              console.log('attempting to delete', opts.extLink.localThumb.path)
+              deleteAsync(opts.extLink.localThumb.path)
+              console.log('deleted', opts.extLink.localThumb.path)
+            }
+          } catch (e) {}
         }
       }
 

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -122,7 +122,7 @@ export async function post(agent: BskyAgent, opts: PostOpts) {
 
       if (isNative) {
         try {
-          deleteAsync(path)
+          await deleteAsync(path)
         } catch (e) {}
       }
 
@@ -183,7 +183,7 @@ export async function post(agent: BskyAgent, opts: PostOpts) {
 
           try {
             if (isNative) {
-              deleteAsync(opts.extLink.localThumb.path)
+              await deleteAsync(opts.extLink.localThumb.path)
             }
           } catch (e) {}
         }

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -123,7 +123,9 @@ export async function post(agent: BskyAgent, opts: PostOpts) {
       if (isNative) {
         try {
           deleteAsync(path)
-        } catch (e) {}
+        } catch (e) {
+          console.error(e)
+        }
       }
 
       images.push({
@@ -185,7 +187,9 @@ export async function post(agent: BskyAgent, opts: PostOpts) {
             if (isNative) {
               deleteAsync(opts.extLink.localThumb.path)
             }
-          } catch (e) {}
+          } catch (e) {
+            console.error(e)
+          }
         }
       }
 

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -122,7 +122,7 @@ export async function post(agent: BskyAgent, opts: PostOpts) {
 
       if (isNative) {
         try {
-          await deleteAsync(path)
+          deleteAsync(path)
         } catch (e) {}
       }
 
@@ -183,7 +183,7 @@ export async function post(agent: BskyAgent, opts: PostOpts) {
 
           try {
             if (isNative) {
-              await deleteAsync(opts.extLink.localThumb.path)
+              deleteAsync(opts.extLink.localThumb.path)
             }
           } catch (e) {}
         }

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -122,9 +122,7 @@ export async function post(agent: BskyAgent, opts: PostOpts) {
 
       if (isNative) {
         try {
-          console.log('attempting to delete', path)
           deleteAsync(path)
-          console.log('deleted', path)
         } catch (e) {}
       }
 
@@ -185,9 +183,7 @@ export async function post(agent: BskyAgent, opts: PostOpts) {
 
           try {
             if (isNative) {
-              console.log('attempting to delete', opts.extLink.localThumb.path)
               deleteAsync(opts.extLink.localThumb.path)
-              console.log('deleted', opts.extLink.localThumb.path)
             }
           } catch (e) {}
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11852,6 +11852,11 @@ expo-eas-client@~0.11.0:
   resolved "https://registry.yarnpkg.com/expo-eas-client/-/expo-eas-client-0.11.0.tgz#0f25aa497849cade7ebef55c0631093a87e58b07"
   integrity sha512-99W0MUGe3U4/MY1E9UeJ4uKNI39mN8/sOGA0Le8XC47MTbwbLoVegHR3C5y2fXLwLn7EpfNxAn5nlxYjY3gD2A==
 
+expo-file-system@^16.0.9:
+  version "16.0.9"
+  resolved "https://registry.yarnpkg.com/expo-file-system/-/expo-file-system-16.0.9.tgz#cbd6c4b228b60a6b6c71fd1b91fe57299fb24da7"
+  integrity sha512-3gRPvKVv7/Y7AdD9eHMIdfg5YbUn2zbwKofjsloTI5sEC57SLUFJtbLvUCz9Pk63DaSQ7WIE1JM0EASyvuPbuw==
+
 expo-file-system@~16.0.0:
   version "16.0.1"
   resolved "https://registry.yarnpkg.com/expo-file-system/-/expo-file-system-16.0.1.tgz#326b7c2f6e53e1a0eaafc9769578aafb3f9c9f43"


### PR DESCRIPTION
## Why

This kicks off a migration to `expo-file-system`. All we do here is remove files from the local storage after they are uploaded to prevent a growing cache.

## Test Plan

Attempting to upload an image or images in the composer still works, and a log lets us know that the image has been deleted. Similarly, after uploading an external link card, the downloaded image gets deleted.