### PR TITLE
Cleanup files after each iteration of compression and downloading

### DIFF
--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -1,4 +1,3 @@
-import {deleteAsync} from 'expo-file-system'
 import {
   AppBskyEmbedExternal,
   AppBskyEmbedImages,
@@ -20,6 +19,7 @@ import {shortenLinks} from 'lib/strings/rich-text-manip'
 import {isNative, isWeb} from 'platform/detection'
 import {ImageModel} from 'state/models/media/image'
 import {LinkMeta} from '../link-meta/link-meta'
+import {safeDeleteAsync} from '../media/manip'
 
 export interface ExternalEmbedDraft {
   uri: string
@@ -119,15 +119,9 @@ export async function post(agent: BskyAgent, opts: PostOpts) {
       const {width, height} = image.compressed || image
       logger.debug(`Uploading image`)
       const res = await uploadBlob(agent, path, 'image/jpeg')
-
       if (isNative) {
-        try {
-          deleteAsync(path)
-        } catch (e) {
-          console.error(e)
-        }
+        safeDeleteAsync(path)
       }
-
       images.push({
         image: res.data.blob,
         alt: image.altText ?? '',
@@ -182,13 +176,8 @@ export async function post(agent: BskyAgent, opts: PostOpts) {
             encoding,
           )
           thumb = thumbUploadRes.data.blob
-
-          try {
-            if (isNative) {
-              deleteAsync(opts.extLink.localThumb.path)
-            }
-          } catch (e) {
-            console.error(e)
+          if (isNative) {
+            safeDeleteAsync(opts.extLink.localThumb.path)
           }
         }
       }

--- a/src/lib/media/manip.ts
+++ b/src/lib/media/manip.ts
@@ -113,7 +113,12 @@ export async function shareImageModal({uri}: {uri: string}) {
       UTI: 'image/png',
     })
   }
-  RNFS.unlink(imagePath)
+
+  try {
+    deleteAsync(imagePath)
+  } catch (e) {
+    console.error(e)
+  }
 }
 
 export async function saveImageToMediaLibrary({uri}: {uri: string}) {
@@ -131,7 +136,11 @@ export async function saveImageToMediaLibrary({uri}: {uri: string}) {
   // save
   await MediaLibrary.createAssetAsync(imagePath)
 
-  // TODO we should add a `deleteAsync()` here as well -hailey
+  try {
+    deleteAsync(imagePath)
+  } catch (e) {
+    console.error(e)
+  }
 }
 
 export function getImageDim(path: string): Promise<Dimensions> {

--- a/src/lib/media/manip.ts
+++ b/src/lib/media/manip.ts
@@ -204,7 +204,7 @@ async function moveToPermanentPath(path: string, ext = 'jpg'): Promise<string> {
   return normalizePath(destinationPath)
 }
 
-async function safeDeleteAsync(path: string) {
+export async function safeDeleteAsync(path: string) {
   try {
     // Normalize is necessary for Android, otherwise it doesn't delete.
     await deleteAsync(normalizePath(path))

--- a/src/lib/media/manip.ts
+++ b/src/lib/media/manip.ts
@@ -24,7 +24,10 @@ export async function compressIfNeeded(
     mode: 'stretch',
     maxSize,
   })
-  const finalImageMovedPath = await moveToPermanentPath(resizedImage.path)
+  const finalImageMovedPath = await moveToPermanentPath(
+    resizedImage.path,
+    '.jpg',
+  )
   const finalImg = {
     ...resizedImage,
     path: finalImageMovedPath,

--- a/src/lib/media/manip.ts
+++ b/src/lib/media/manip.ts
@@ -212,10 +212,7 @@ async function moveToPermanentPath(path: string, ext = 'jpg'): Promise<string> {
 
   // cacheDirectory will not ever be null on native, but it could be on web. This function only ever gets called on
   // native so we assert as a string.
-  const destinationPath = joinPath(
-    cacheDirectory as string,
-    `${filename}.${ext}`,
-  )
+  const destinationPath = joinPath(cacheDirectory as string, filename + ext)
 
   await copyAsync({
     from: path,

--- a/src/lib/media/manip.ts
+++ b/src/lib/media/manip.ts
@@ -1,8 +1,7 @@
 import {Image as RNImage, Share as RNShare} from 'react-native'
-import * as RNFS from 'react-native-fs'
 import {Image} from 'react-native-image-crop-picker'
 import uuid from 'react-native-uuid'
-import {copyAsync, deleteAsync} from 'expo-file-system'
+import {cacheDirectory, copyAsync, deleteAsync} from 'expo-file-system'
 import * as MediaLibrary from 'expo-media-library'
 import * as Sharing from 'expo-sharing'
 import ImageResizer from '@bam.tech/react-native-image-resizer'
@@ -200,7 +199,7 @@ async function doResize(localUri: string, opts: DoResizeOpts): Promise<Image> {
   )
 }
 
-async function moveToPermanentPath(path: string, ext = ''): Promise<string> {
+async function moveToPermanentPath(path: string, ext = 'jpg'): Promise<string> {
   /*
   Since this package stores images in a temp directory, we need to move the file to a permanent location.
   Relevant: IOS bug when trying to open a second time:
@@ -208,10 +207,7 @@ async function moveToPermanentPath(path: string, ext = ''): Promise<string> {
   */
   const filename = uuid.v4()
 
-  const destinationPath = joinPath(
-    RNFS.TemporaryDirectoryPath,
-    `${filename}${ext}`,
-  )
+  const destinationPath = joinPath(cacheDirectory ?? '', `${filename}.${ext}`)
 
   await copyAsync({
     from: path,

--- a/src/lib/media/manip.ts
+++ b/src/lib/media/manip.ts
@@ -210,7 +210,12 @@ async function moveToPermanentPath(path: string, ext = 'jpg'): Promise<string> {
   */
   const filename = uuid.v4()
 
-  const destinationPath = joinPath(cacheDirectory ?? '', `${filename}.${ext}`)
+  // cacheDirectory will not ever be null on native, but it could be on web. This function only ever gets called on
+  // native so we assert as a string.
+  const destinationPath = joinPath(
+    cacheDirectory as string,
+    `${filename}.${ext}`,
+  )
 
   await copyAsync({
     from: path,

--- a/src/lib/media/manip.ts
+++ b/src/lib/media/manip.ts
@@ -2,7 +2,7 @@ import {Image as RNImage, Share as RNShare} from 'react-native'
 import * as RNFS from 'react-native-fs'
 import {Image} from 'react-native-image-crop-picker'
 import uuid from 'react-native-uuid'
-import {deleteAsync} from 'expo-file-system'
+import {copyAsync, deleteAsync} from 'expo-file-system'
 import * as MediaLibrary from 'expo-media-library'
 import * as Sharing from 'expo-sharing'
 import ImageResizer from '@bam.tech/react-native-image-resizer'
@@ -213,12 +213,17 @@ async function moveToPermanentPath(path: string, ext = ''): Promise<string> {
     `${filename}${ext}`,
   )
 
+  await copyAsync({
+    from: path,
+    to: destinationPath,
+  })
+
   try {
-    await RNFS.moveFile(path, destinationPath)
+    deleteAsync(path)
   } catch (e) {
-    console.error('Failed to move file', e)
-    await RNFS.copyFile(path, destinationPath)
+    console.error('Failed to delete file', e)
   }
+
   return normalizePath(destinationPath)
 }
 

--- a/src/lib/media/manip.ts
+++ b/src/lib/media/manip.ts
@@ -72,11 +72,7 @@ export async function downloadAndResize(opts: DownloadAndResizeOpts) {
       return
     }
 
-    let localUri = downloadRes.path()
-    if (!localUri.startsWith('file://')) {
-      localUri = `file://${localUri}`
-    }
-
+    const localUri = normalizePath(downloadRes.path(), true)
     return await doResize(localUri, opts)
   } finally {
     // TODO Whenever we remove `rn-fetch-blob`, we will need to replace this `flush()` with a `deleteAsync()` -hailey
@@ -201,8 +197,8 @@ async function moveToPermanentPath(path: string, ext = 'jpg'): Promise<string> {
   // native so we assert as a string.
   const destinationPath = joinPath(cacheDirectory as string, filename + ext)
   await copyAsync({
-    from: path,
-    to: destinationPath,
+    from: normalizePath(path),
+    to: normalizePath(destinationPath),
   })
   safeDeleteAsync(path)
   return normalizePath(destinationPath)


### PR DESCRIPTION
## Why

We currently do not remove files after each iteration of compression. This isn't ideal because we create a lot of extra copies of images that we don't need, bloating the document storage size

This also replaces a few current uses of `RNFS.unlink()` in favor of `deleteAsync()`, although there is no difference outside of the API change.

We also make a change to `moveToPermanentPath()` which ensures the move happens. It is possible for `moveAsync()` to fail (or in this case `RNFS.moveFile()`. If it does, then we may be in trouble later on. What we should instead do is _always_ copy the file, and then delete the original if possible. That way, we are guaranteed to have a copy that we can work with in the next step of the file upload process.

### Does this fix the error?

This PR might not solve the root issue at hand which is this:

![Screenshot 2024-04-17 at 2 30 30 PM](https://github.com/bluesky-social/social-app/assets/153161762/54f705f8-f59b-41fd-9d57-c5749f283051)

However, I found something very suspect whenever I was working on this. The `RNFS.TemporaryDirectory` path is _not_ writeable using `copyAsync()` or `moveAsync()` from the `expo-file-system` package. I'm not certain what the distinction is there. I suspect there might be an API change, and RNFS is using some outdated API, or is doing something else bizarre under the hood. There are a lot of issues open in their GitHub repo over the past year regarding issues causing errors and crashes.

Rose should still be able to repro with the image that she has, so we should see if this resolves the issue for her.

## Test Plan

Testing that changing the avatar or changing the banner results in multiple iterations, all of which are properly cleaned up. We can still upload the avatar, since the final output is not deleted in this for loop.

https://github.com/bluesky-social/social-app/assets/153161762/c8547dc8-077f-468c-8f05-667d439cc249

