### PR TITLE
[Statsig] Prefetch configs for other accounts

### DIFF
--- a/src/lib/statsig/statsig.tsx
+++ b/src/lib/statsig/statsig.tsx
@@ -34,7 +34,7 @@ if (isWeb && typeof window !== 'undefined') {
 
 export type {LogEvents}
 
-function createStatsigOptions() {
+function createStatsigOptions(prefetchUsers: StatsigUser[]) {
   return {
     environment: {
       tier:
@@ -48,6 +48,8 @@ function createStatsigOptions() {
     // This ensures the UI is always consistent and doesn't update mid-session.
     // Note this makes cold load (no local storage) and private mode return `false` for all gates.
     initTimeoutMs: 1,
+    // Get fresh flags for other accounts as well, if any.
+    prefetchUsers,
   }
 }
 
@@ -173,7 +175,10 @@ export function Provider({children}: {children: React.ReactNode}) {
         .map(toStatsigUser),
     [accounts, did],
   )
-  const statsigOptions = React.useMemo(() => createStatsigOptions(), [])
+  const statsigOptions = React.useMemo(
+    () => createStatsigOptions(otherStatsigUsers),
+    [otherStatsigUsers],
+  )
 
   // Have our own cache in front of Statsig.
   // This ensures the results remain stable until the active DID changes.

--- a/src/lib/statsig/statsig.tsx
+++ b/src/lib/statsig/statsig.tsx
@@ -193,11 +193,12 @@ export function Provider({children}: {children: React.ReactNode}) {
   // These changes are prefetched and stored, but don't get applied until the active DID changes.
   // This ensures that when you switch an account, it already has fresh results by then.
   React.useEffect(() => {
-    const id = setInterval(
-      // Note: Only first five will be taken into account by Statsig.
-      () => Statsig.prefetchUsers([currentStatsigUser, ...otherStatsigUsers]),
-      3 * 60e3 /* 3 min */,
-    )
+    const id = setInterval(() => {
+      if (Statsig.initializeCalled()) {
+        // Note: Only first five will be taken into account by Statsig.
+        Statsig.prefetchUsers([currentStatsigUser, ...otherStatsigUsers])
+      }
+    }, 3 * 60e3 /* 3 min */)
     return () => clearInterval(id)
   }, [currentStatsigUser, otherStatsigUsers])
 

--- a/src/lib/statsig/statsig.tsx
+++ b/src/lib/statsig/statsig.tsx
@@ -201,7 +201,7 @@ export function Provider({children}: {children: React.ReactNode}) {
     }
   })
   React.useEffect(() => {
-    const id = setInterval(handleIntervalTick, 3 * 60e3 /* 3 min */)
+    const id = setInterval(handleIntervalTick, 60e3 /* 1 min */)
     return () => clearInterval(id)
   }, [handleIntervalTick])
 

--- a/src/lib/statsig/statsig.tsx
+++ b/src/lib/statsig/statsig.tsx
@@ -34,19 +34,21 @@ if (isWeb && typeof window !== 'undefined') {
 
 export type {LogEvents}
 
-const statsigOptions = {
-  environment: {
-    tier:
-      process.env.NODE_ENV === 'development'
-        ? 'development'
-        : IS_TESTFLIGHT
-        ? 'staging'
-        : 'production',
-  },
-  // Don't block on waiting for network. The fetched config will kick in on next load.
-  // This ensures the UI is always consistent and doesn't update mid-session.
-  // Note this makes cold load (no local storage) and private mode return `false` for all gates.
-  initTimeoutMs: 1,
+function createStatsigOptions() {
+  return {
+    environment: {
+      tier:
+        process.env.NODE_ENV === 'development'
+          ? 'development'
+          : IS_TESTFLIGHT
+          ? 'staging'
+          : 'production',
+    },
+    // Don't block on waiting for network. The fetched config will kick in on next load.
+    // This ensures the UI is always consistent and doesn't update mid-session.
+    // Note this makes cold load (no local storage) and private mode return `false` for all gates.
+    initTimeoutMs: 1,
+  }
 }
 
 type FlatJSONRecord = Record<
@@ -171,6 +173,7 @@ export function Provider({children}: {children: React.ReactNode}) {
         .map(toStatsigUser),
     [accounts, did],
   )
+  const statsigOptions = React.useMemo(() => createStatsigOptions(), [])
 
   // Have our own cache in front of Statsig.
   // This ensures the results remain stable until the active DID changes.


### PR DESCRIPTION
Currently, we only fetch (and poll) the feature gate configuration for the _current_ user. So if the configuration has updated for another user, and then you switch accounts, we won't know that, and we'll use stale configs from the cache. It's only another refresh that you'll get the new config for the other user.

With this change, we're always fetching configs for all accounts:

- During init, we prefetch the "other" accounts.
- During polling, we prefetch all accounts (both current and "other").

While this doesn't by itself guarantee that an account switch would give you a fresh config (we'll improve on this in a follow-up PR), it would make it more likely because last poll could've grabbed it.

Note I've also changed the polling method from `updateUser(currentUser)` to `prefetchUsers(users)`. This seems to work just as fine but is more targeted (and unlike `updateUser` can be used for non-current users).

I also decreased the polling interval to one minute.

## Test Plan

**Tip: Decrease the polling time to 5 seconds for easier testing!**

Test that polling own account works:

1. Override some flag to be false for Alice.
1. Log into Alice's account. Observe the flag being false. Refresh if needed.
1. Override a flag to be true for Alice. Wait ~20 seconds for the change to deploy.
1. Wait for the poll. Verify the flag is still reported as false in the app.
1. Refresh the app. The flag should be reported as true.

Test that polling other accounts works:

1. Override some flag to be false for Alice.
1. Log into Alice's account. Observe the flag being false. Refresh if needed.
1. Switch to Bob's account. While being logged into Bob's account, override the flag to be true for Alice. Wait ~20 seconds for the change to deploy.
1. Wait for the poll (5 seconds).
1. Switch accounts to Alice. Verify the flag is already true for Alice (no refresh!)

For the initialization change:

1. Override some flag to be false for Alice.
1. Comment out polling completely in the source
1. Log into Alice's account. Observe the flag being false. Refresh if needed.
1. Switch to Bob's account. While being logged into Bob's account, override the flag to be true for Alice. Wait ~20 seconds for the change to deploy.
1. Refresh while being on Bob's account.
1. Refresh again while being on Bob's account.
1. Switch to Alice's account. Verify the flag is already true for Alice (no refresh!)