### PR TITLE
Add layout transitions to the composer photo gallery on iOS

### DIFF
--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -126,7 +126,7 @@ export const ComposePost = observer(function ComposePost({
 
   const prevNumberOfImages = useRef<number>(gallery.size)
 
-  if (prevNumberOfImages.current !== gallery.size) {
+  if (isIOS && prevNumberOfImages.current !== gallery.size) {
     prevNumberOfImages.current = gallery.size
     LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut)
   }

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -1,4 +1,11 @@
-import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react'
+import React, {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 import {
   ActivityIndicator,
   BackHandler,
@@ -124,12 +131,9 @@ export const ComposePost = observer(function ComposePost({
     [initImageUris],
   )
 
-  const prevNumberOfImages = useRef<number>(gallery.size)
-
-  if (isIOS && prevNumberOfImages.current !== gallery.size) {
-    prevNumberOfImages.current = gallery.size
+  useLayoutEffect(() => {
     LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut)
-  }
+  }, [gallery.size])
 
   const onClose = useCallback(() => {
     closeComposer()

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -132,7 +132,9 @@ export const ComposePost = observer(function ComposePost({
   )
 
   useLayoutEffect(() => {
-    LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut)
+    if (isIOS) {
+      LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut)
+    }
   }, [gallery.size])
 
   const onClose = useCallback(() => {

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -4,6 +4,7 @@ import {
   BackHandler,
   Keyboard,
   KeyboardAvoidingView,
+  LayoutAnimation,
   Platform,
   Pressable,
   ScrollView,
@@ -122,6 +123,14 @@ export const ComposePost = observer(function ComposePost({
     () => new GalleryModel(initImageUris),
     [initImageUris],
   )
+
+  const prevNumberOfImages = useRef<number>(gallery.size)
+
+  if (prevNumberOfImages.current !== gallery.size) {
+    prevNumberOfImages.current = gallery.size
+    LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut)
+  }
+
   const onClose = useCallback(() => {
     closeComposer()
   }, [closeComposer])

--- a/src/view/com/composer/photos/Gallery.tsx
+++ b/src/view/com/composer/photos/Gallery.tsx
@@ -1,19 +1,20 @@
 import React, {useState} from 'react'
 import {ImageStyle, Keyboard, LayoutChangeEvent} from 'react-native'
-import {GalleryModel} from 'state/models/media/gallery'
-import {observer} from 'mobx-react-lite'
-import {FontAwesomeIcon} from '@fortawesome/react-native-fontawesome'
-import {s, colors} from 'lib/styles'
 import {StyleSheet, TouchableOpacity, View} from 'react-native'
 import {Image} from 'expo-image'
-import {Text} from 'view/com/util/text/Text'
-import {Dimensions} from 'lib/media/types'
+import {FontAwesomeIcon} from '@fortawesome/react-native-fontawesome'
+import {msg, Trans} from '@lingui/macro'
+import {useLingui} from '@lingui/react'
+import {observer} from 'mobx-react-lite'
+
+import {useModalControls} from '#/state/modals'
 import {usePalette} from 'lib/hooks/usePalette'
 import {useWebMediaQueries} from 'lib/hooks/useWebMediaQueries'
-import {Trans, msg} from '@lingui/macro'
-import {useLingui} from '@lingui/react'
-import {useModalControls} from '#/state/modals'
+import {Dimensions} from 'lib/media/types'
+import {colors, s} from 'lib/styles'
 import {isNative} from 'platform/detection'
+import {GalleryModel} from 'state/models/media/gallery'
+import {Text} from 'view/com/util/text/Text'
 
 const IMAGE_GAP = 8
 
@@ -197,6 +198,7 @@ const GalleryInner = observer(function GalleryImpl({
               }}
               accessible={true}
               accessibilityIgnoresInvertColors
+              transition={200}
             />
           </View>
         ))}


### PR DESCRIPTION
Adds layout animations + a little fade-in transition on the image. iOS-only (looks horrible on Android and `LayoutAnimation` is not available on web)

https://github.com/bluesky-social/social-app/assets/10959775/24bc180d-f49e-4eba-8ad1-73f799b99671

