### PR TITLE
add dimensions to data

### DIFF
--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -340,7 +340,7 @@ export const ComposePost = observer(function ComposePost({
           image: gif.images.original_still.url,
           likelyType: LikelyType.HTML,
           title: `${gif.title} - Find & Share on GIPHY`,
-          description: `ALT: ${gif}`,
+          description: `ALT: ${gif.alt_text}`,
         },
       }),
     [setExtLink],

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -333,7 +333,7 @@ export const ComposePost = observer(function ComposePost({
   const onSelectGif = useCallback(
     (gif: Gif) =>
       setExtLink({
-        uri: `${gif.url}?fw=${gif.images.fixed_width.width}-${gif.images.fixed_width.height}&fh=${gif.images.fixed_height.width}-${gif.images.fixed_height.height}`,
+        uri: `${gif.url}?hh=${gif.images.original.height}&ww=${gif.images.original.width}`,
         isLoading: true,
         meta: {
           url: gif.url,

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -336,11 +336,11 @@ export const ComposePost = observer(function ComposePost({
         uri: gif.url,
         isLoading: true,
         meta: {
-          url: gif.url,
+          url: `${gif.url}?fw=${gif.images.fixed_width.width}-${gif.images.fixed_width.height}&fh=${gif.images.fixed_height.width}-${gif.images.fixed_height.height}`,
           image: gif.images.original_still.url,
           likelyType: LikelyType.HTML,
           title: `${gif.title} - Find & Share on GIPHY`,
-          description: `ALT: ${gif.alt_text}`,
+          description: `ALT: ${gif}`,
         },
       }),
     [setExtLink],

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -333,10 +333,10 @@ export const ComposePost = observer(function ComposePost({
   const onSelectGif = useCallback(
     (gif: Gif) =>
       setExtLink({
-        uri: gif.url,
+        uri: `${gif.url}?fw=${gif.images.fixed_width.width}-${gif.images.fixed_width.height}&fh=${gif.images.fixed_height.width}-${gif.images.fixed_height.height}`,
         isLoading: true,
         meta: {
-          url: `${gif.url}?fw=${gif.images.fixed_width.width}-${gif.images.fixed_width.height}&fh=${gif.images.fixed_height.width}-${gif.images.fixed_height.height}`,
+          url: gif.url,
           image: gif.images.original_still.url,
           likelyType: LikelyType.HTML,
           title: `${gif.title} - Find & Share on GIPHY`,


### PR DESCRIPTION
We don't have anywhere in this schema right now to place height and width measurements for GIFs, so we have to load the thumbnail _before_ we know the size of container which is janky. Putting it at the end of the URL like this works, and does not break the URL if the user does click through.

![Screenshot 2024-04-18 at 9 00 08 PM](https://github.com/bluesky-social/social-app/assets/153161762/ccfffdb4-bd64-4113-8c9a-47c2496dafae)
