### PR TITLE
Player improvement pre-reqs

### DIFF
--- a/__tests__/lib/string.test.ts
+++ b/__tests__/lib/string.test.ts
@@ -1,17 +1,18 @@
 import {RichText} from '@atproto/api'
+
+import {parseEmbedPlayerFromUrl} from 'lib/strings/embed-player'
+import {cleanError} from '../../src/lib/strings/errors'
+import {createFullHandle, makeValidHandle} from '../../src/lib/strings/handles'
+import {enforceLen, pluralize} from '../../src/lib/strings/helpers'
+import {detectLinkables} from '../../src/lib/strings/rich-text-detection'
+import {shortenLinks} from '../../src/lib/strings/rich-text-manip'
+import {ago} from '../../src/lib/strings/time'
 import {
   makeRecordUri,
   toNiceDomain,
-  toShortUrl,
   toShareUrl,
+  toShortUrl,
 } from '../../src/lib/strings/url-helpers'
-import {pluralize, enforceLen} from '../../src/lib/strings/helpers'
-import {ago} from '../../src/lib/strings/time'
-import {detectLinkables} from '../../src/lib/strings/rich-text-detection'
-import {shortenLinks} from '../../src/lib/strings/rich-text-manip'
-import {makeValidHandle, createFullHandle} from '../../src/lib/strings/handles'
-import {cleanError} from '../../src/lib/strings/errors'
-import {parseEmbedPlayerFromUrl} from 'lib/strings/embed-player'
 
 describe('detectLinkables', () => {
   const inputs = [
@@ -621,7 +622,7 @@ describe('parseEmbedPlayerFromUrl', () => {
       isGif: true,
       hideDetails: true,
       metaUri: 'https://giphy.com/gifs/gifId',
-      playerUri: 'https://i.giphy.com/media/gifId/giphy.webp',
+      playerUri: 'https://i.giphy.com/media/gifId/200.webp',
     },
     undefined,
     undefined,
@@ -632,7 +633,7 @@ describe('parseEmbedPlayerFromUrl', () => {
       isGif: true,
       hideDetails: true,
       metaUri: 'https://giphy.com/gifs/gifId',
-      playerUri: 'https://i.giphy.com/media/gifId/giphy.webp',
+      playerUri: 'https://i.giphy.com/media/gifId/200.webp',
     },
     {
       type: 'giphy_gif',
@@ -640,7 +641,7 @@ describe('parseEmbedPlayerFromUrl', () => {
       isGif: true,
       hideDetails: true,
       metaUri: 'https://giphy.com/gifs/gifId',
-      playerUri: 'https://i.giphy.com/media/gifId/giphy.webp',
+      playerUri: 'https://i.giphy.com/media/gifId/200.webp',
     },
     {
       type: 'giphy_gif',
@@ -648,7 +649,7 @@ describe('parseEmbedPlayerFromUrl', () => {
       isGif: true,
       hideDetails: true,
       metaUri: 'https://giphy.com/gifs/gifId',
-      playerUri: 'https://i.giphy.com/media/gifId/giphy.webp',
+      playerUri: 'https://i.giphy.com/media/gifId/200.webp',
     },
     {
       type: 'giphy_gif',
@@ -656,7 +657,7 @@ describe('parseEmbedPlayerFromUrl', () => {
       isGif: true,
       hideDetails: true,
       metaUri: 'https://giphy.com/gifs/gifId',
-      playerUri: 'https://i.giphy.com/media/gifId/giphy.webp',
+      playerUri: 'https://i.giphy.com/media/gifId/200.webp',
     },
     {
       type: 'giphy_gif',
@@ -664,7 +665,7 @@ describe('parseEmbedPlayerFromUrl', () => {
       isGif: true,
       hideDetails: true,
       metaUri: 'https://giphy.com/gifs/gifId',
-      playerUri: 'https://i.giphy.com/media/gifId/giphy.webp',
+      playerUri: 'https://i.giphy.com/media/gifId/200.webp',
     },
     {
       type: 'giphy_gif',
@@ -672,7 +673,7 @@ describe('parseEmbedPlayerFromUrl', () => {
       isGif: true,
       hideDetails: true,
       metaUri: 'https://giphy.com/gifs/gifId',
-      playerUri: 'https://i.giphy.com/media/gifId/giphy.webp',
+      playerUri: 'https://i.giphy.com/media/gifId/200.webp',
     },
     undefined,
     undefined,
@@ -684,7 +685,7 @@ describe('parseEmbedPlayerFromUrl', () => {
       isGif: true,
       hideDetails: true,
       metaUri: 'https://giphy.com/gifs/gifId',
-      playerUri: 'https://i.giphy.com/media/gifId/giphy.webp',
+      playerUri: 'https://i.giphy.com/media/gifId/200.webp',
     },
 
     {
@@ -693,7 +694,7 @@ describe('parseEmbedPlayerFromUrl', () => {
       isGif: true,
       hideDetails: true,
       metaUri: 'https://giphy.com/gifs/gifId',
-      playerUri: 'https://i.giphy.com/media/gifId/giphy.webp',
+      playerUri: 'https://i.giphy.com/media/gifId/200.webp',
     },
     {
       type: 'giphy_gif',
@@ -701,7 +702,7 @@ describe('parseEmbedPlayerFromUrl', () => {
       isGif: true,
       hideDetails: true,
       metaUri: 'https://giphy.com/gifs/gifId',
-      playerUri: 'https://i.giphy.com/media/gifId/giphy.webp',
+      playerUri: 'https://i.giphy.com/media/gifId/200.webp',
     },
     {
       type: 'giphy_gif',
@@ -709,7 +710,7 @@ describe('parseEmbedPlayerFromUrl', () => {
       isGif: true,
       hideDetails: true,
       metaUri: 'https://giphy.com/gifs/gifId',
-      playerUri: 'https://i.giphy.com/media/gifId/giphy.webp',
+      playerUri: 'https://i.giphy.com/media/gifId/200.webp',
     },
     {
       type: 'giphy_gif',
@@ -717,7 +718,7 @@ describe('parseEmbedPlayerFromUrl', () => {
       isGif: true,
       hideDetails: true,
       metaUri: 'https://giphy.com/gifs/gifId',
-      playerUri: 'https://i.giphy.com/media/gifId/giphy.webp',
+      playerUri: 'https://i.giphy.com/media/gifId/200.webp',
     },
 
     {

--- a/__tests__/lib/string.test.ts
+++ b/__tests__/lib/string.test.ts
@@ -435,6 +435,8 @@ describe('parseEmbedPlayerFromUrl', () => {
     'https://giphy.com/gif/some-random-gif-name-gifId',
     'https://giphy.com/gifs/',
 
+    'https://giphy.com/gifs/39248209509382934029?hh=100&ww=100',
+
     'https://media.giphy.com/media/gifId/giphy.webp',
     'https://media0.giphy.com/media/gifId/giphy.webp',
     'https://media1.giphy.com/media/gifId/giphy.gif',
@@ -626,6 +628,19 @@ describe('parseEmbedPlayerFromUrl', () => {
     },
     undefined,
     undefined,
+
+    {
+      type: 'giphy_gif',
+      source: 'giphy',
+      isGif: true,
+      hideDetails: true,
+      metaUri: 'https://giphy.com/gifs/39248209509382934029',
+      playerUri: 'https://i.giphy.com/media/39248209509382934029/200.mp4',
+      dimensions: {
+        width: 100,
+        height: 100,
+      },
+    },
 
     {
       type: 'giphy_gif',

--- a/src/lib/statsig/gates.ts
+++ b/src/lib/statsig/gates.ts
@@ -4,6 +4,7 @@ export type Gate =
   | 'disable_min_shell_on_foregrounding'
   | 'disable_poll_on_discover'
   | 'hide_vertical_scroll_indicators'
+  | 'new_gif_player'
   | 'new_profile_scroll_component'
   | 'new_search'
   | 'receive_updates'

--- a/src/lib/strings/embed-player.ts
+++ b/src/lib/strings/embed-player.ts
@@ -1,4 +1,5 @@
 import {Dimensions} from 'react-native'
+
 import {isWeb} from 'platform/detection'
 const {height: SCREEN_HEIGHT} = Dimensions.get('window')
 
@@ -60,6 +61,10 @@ export interface EmbedPlayerParams {
   source: EmbedPlayerSource
   metaUri?: string
   hideDetails?: boolean
+  dimensions?: {
+    height: number
+    width: number
+  }
 }
 
 const giphyRegex = /media(?:[0-4]\.giphy\.com|\.giphy\.com)/i

--- a/src/lib/strings/embed-player.ts
+++ b/src/lib/strings/embed-player.ts
@@ -1,4 +1,4 @@
-import {Dimensions, Platform} from 'react-native'
+import {Dimensions} from 'react-native'
 
 import {isWeb} from 'platform/detection'
 const {height: SCREEN_HEIGHT} = Dimensions.get('window')
@@ -255,12 +255,13 @@ export function parseEmbedPlayerFromUrl(
   if (urlp.hostname === 'giphy.com' || urlp.hostname === 'www.giphy.com') {
     const [_, gifs, nameAndId] = urlp.pathname.split('/')
 
-    const fh = urlp.searchParams.get('fh')?.split('-')
-    const fw = urlp.searchParams.get('fw')?.split('-')
+    const h = urlp.searchParams.get('hh')
+    const w = urlp.searchParams.get('ww')
     let dimensions
-    if (fh && fw) {
+    if (h && w) {
       dimensions = {
-        width: Platform.OS === 'web' ? Number(fw[0]) : Number(fw[1]),
+        height: Number(h),
+        width: Number(w),
       }
     }
 
@@ -281,6 +282,7 @@ export function parseEmbedPlayerFromUrl(
           hideDetails: true,
           metaUri: `https://giphy.com/gifs/${gifId}`,
           playerUri: `https://i.giphy.com/media/${gifId}/giphy.webp`,
+          dimensions,
         }
       }
     }

--- a/src/lib/strings/embed-player.ts
+++ b/src/lib/strings/embed-player.ts
@@ -305,7 +305,7 @@ export function parseEmbedPlayerFromUrl(
           isGif: true,
           hideDetails: true,
           metaUri: `https://giphy.com/gifs/${trackingOrId}`,
-          playerUri: `https://i.giphy.com/media/${trackingOrId}/giphy.webp`,
+          playerUri: `https://i.giphy.com/media/${trackingOrId}/200.webp`,
         }
       } else if (filename && gifFilenameRegex.test(filename)) {
         return {
@@ -314,7 +314,7 @@ export function parseEmbedPlayerFromUrl(
           isGif: true,
           hideDetails: true,
           metaUri: `https://giphy.com/gifs/${idOrFilename}`,
-          playerUri: `https://i.giphy.com/media/${idOrFilename}/giphy.webp`,
+          playerUri: `https://i.giphy.com/media/${idOrFilename}/200.webp`,
         }
       }
     }
@@ -333,7 +333,7 @@ export function parseEmbedPlayerFromUrl(
         isGif: true,
         hideDetails: true,
         metaUri: `https://giphy.com/gifs/${gifId}`,
-        playerUri: `https://i.giphy.com/media/${gifId}/giphy.webp`,
+        playerUri: `https://i.giphy.com/media/${gifId}/200.webp`,
       }
     } else if (mediaOrFilename) {
       const gifId = mediaOrFilename.split('.')[0]
@@ -345,7 +345,7 @@ export function parseEmbedPlayerFromUrl(
         metaUri: `https://giphy.com/gifs/${gifId}`,
         playerUri: `https://i.giphy.com/media/${
           mediaOrFilename.split('.')[0]
-        }/giphy.webp`,
+        }/200.webp`,
       }
     }
   }

--- a/src/lib/strings/embed-player.ts
+++ b/src/lib/strings/embed-player.ts
@@ -282,7 +282,7 @@ export function parseEmbedPlayerFromUrl(
           hideDetails: true,
           metaUri: `https://giphy.com/gifs/${gifId}`,
           playerUri: `https://i.giphy.com/media/${gifId}/${
-            dimensions ? '200.webp' : '200.mp4'
+            dimensions ? '200.mp4' : '200.webp'
           }`,
           dimensions,
         }

--- a/src/lib/strings/embed-player.ts
+++ b/src/lib/strings/embed-player.ts
@@ -281,7 +281,9 @@ export function parseEmbedPlayerFromUrl(
           isGif: true,
           hideDetails: true,
           metaUri: `https://giphy.com/gifs/${gifId}`,
-          playerUri: `https://i.giphy.com/media/${gifId}/giphy.webp`,
+          playerUri: `https://i.giphy.com/media/${gifId}/${
+            dimensions ? '200.webp' : '200.mp4'
+          }`,
           dimensions,
         }
       }

--- a/src/lib/strings/embed-player.ts
+++ b/src/lib/strings/embed-player.ts
@@ -1,4 +1,4 @@
-import {Dimensions} from 'react-native'
+import {Dimensions, Platform} from 'react-native'
 
 import {isWeb} from 'platform/detection'
 const {height: SCREEN_HEIGHT} = Dimensions.get('window')
@@ -254,6 +254,15 @@ export function parseEmbedPlayerFromUrl(
 
   if (urlp.hostname === 'giphy.com' || urlp.hostname === 'www.giphy.com') {
     const [_, gifs, nameAndId] = urlp.pathname.split('/')
+
+    const fh = urlp.searchParams.get('fh')?.split('-')
+    const fw = urlp.searchParams.get('fw')?.split('-')
+    let dimensions
+    if (fh && fw) {
+      dimensions = {
+        width: Platform.OS === 'web' ? Number(fw[0]) : Number(fw[1]),
+      }
+    }
 
     /*
      * nameAndId is a string that consists of the name (dash separated) and the id of the gif (the last part of the name)

--- a/src/view/com/util/post-embeds/ExternalLinkEmbed.tsx
+++ b/src/view/com/util/post-embeds/ExternalLinkEmbed.tsx
@@ -1,15 +1,16 @@
 import React from 'react'
-import {Image} from 'expo-image'
-import {Text} from '../text/Text'
 import {StyleSheet, View} from 'react-native'
+import {Image} from 'expo-image'
+import {AppBskyEmbedExternal} from '@atproto/api'
+
 import {usePalette} from 'lib/hooks/usePalette'
 import {useWebMediaQueries} from 'lib/hooks/useWebMediaQueries'
-import {AppBskyEmbedExternal} from '@atproto/api'
-import {toNiceDomain} from 'lib/strings/url-helpers'
 import {parseEmbedPlayerFromUrl} from 'lib/strings/embed-player'
-import {ExternalPlayer} from 'view/com/util/post-embeds/ExternalPlayerEmbed'
-import {ExternalGifEmbed} from 'view/com/util/post-embeds/ExternalGifEmbed'
+import {toNiceDomain} from 'lib/strings/url-helpers'
 import {useExternalEmbedsPrefs} from 'state/preferences'
+import {ExternalGifEmbed} from 'view/com/util/post-embeds/ExternalGifEmbed'
+import {ExternalPlayer} from 'view/com/util/post-embeds/ExternalPlayerEmbed'
+import {Text} from '../text/Text'
 
 export const ExternalLinkEmbed = ({
   link,
@@ -37,12 +38,13 @@ export const ExternalLinkEmbed = ({
           accessibilityIgnoresInvertColors
         />
       ) : undefined}
-      {(embedPlayerParams?.isGif && (
+      {embedPlayerParams?.isGif && embedPlayerParams.dimensions ? (
+        <View />
+      ) : embedPlayerParams?.isGif ? (
         <ExternalGifEmbed link={link} params={embedPlayerParams} />
-      )) ||
-        (embedPlayerParams && (
-          <ExternalPlayer link={link} params={embedPlayerParams} />
-        ))}
+      ) : embedPlayerParams ? (
+        <ExternalPlayer link={link} params={embedPlayerParams} />
+      ) : undefined}
       <View style={[styles.info, {paddingHorizontal: isMobile ? 10 : 14}]}>
         <Text
           type="sm"

--- a/src/view/com/util/post-embeds/ExternalLinkEmbed.tsx
+++ b/src/view/com/util/post-embeds/ExternalLinkEmbed.tsx
@@ -38,7 +38,7 @@ export const ExternalLinkEmbed = ({
           accessibilityIgnoresInvertColors
         />
       ) : undefined}
-      {embedPlayerParams?.isGif && embedPlayerParams.dimensions ? (
+      {embedPlayerParams?.source === 'giphy' && embedPlayerParams.dimensions ? (
         <View />
       ) : embedPlayerParams?.isGif ? (
         <ExternalGifEmbed link={link} params={embedPlayerParams} />


### PR DESCRIPTION
## Why

This is a small pre-reqs PR that

- Updates the Giphy link rewriter to account for our new system.
- Accounts for https://github.com/bluesky-social/social-app/pull/3616 by updating the `EmbedPlayerParams` type with `dimensions`.
- Adds an additional test for that case
- Creates a new Statsig gate "new_gif_player`
- Adds some space for the new player to be rendered at inside of `ExternalLinkEmbed` although this is getting reworked a bit more in https://github.com/bluesky-social/social-app/pull/3605

## Test Plan

There should not be any noticeable differences except right now _except_ if you have the gate enabled _and _ you use the new composer GIF picker to post a GIF. Check that other embeds still render properly and are still clickable. Also can check that the gate works properly.