### PR TITLE
Persist PDS URL for session resumption

### DIFF
--- a/src/state/persisted/schema.ts
+++ b/src/state/persisted/schema.ts
@@ -14,6 +14,7 @@ const accountSchema = z.object({
   refreshJwt: z.string().optional(), // optional because it can expire
   accessJwt: z.string().optional(), // optional because it can expire
   deactivated: z.boolean().optional(),
+  pdsUrl: z.string().optional(),
 })
 export type PersistedAccount = z.infer<typeof accountSchema>
 

--- a/src/state/session/index.tsx
+++ b/src/state/session/index.tsx
@@ -313,6 +313,7 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
         refreshJwt: agent.session.refreshJwt,
         accessJwt: agent.session.accessJwt,
         deactivated: isSessionDeactivated(agent.session.accessJwt),
+        pdsUrl: agent.pdsUrl?.toString(),
       }
 
       await configureModeration(agent, account)
@@ -405,6 +406,10 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
         logger.debug(`session: attempting to reuse previous session`)
 
         agent.session = prevSession
+        if (account.pdsUrl) {
+          agent.api.xrpc.uri = agent.pdsUrl = new URL(account.pdsUrl)
+        }
+
         __globalAgent = agent
         upsertAccount(account)
 
@@ -479,6 +484,7 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
           refreshJwt: agent.session.refreshJwt,
           accessJwt: agent.session.accessJwt,
           deactivated: isSessionDeactivated(agent.session.accessJwt),
+          pdsUrl: agent.pdsUrl?.toString(),
         }
       }
     },

--- a/src/state/session/index.tsx
+++ b/src/state/session/index.tsx
@@ -369,7 +369,12 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
     async account => {
       logger.debug(`session: initSession`, {}, logger.DebugContext.session)
 
-      const agent = new BskyAgent({service: account.pdsUrl || account.service})
+      const agent = new BskyAgent({service: account.service})
+
+      // restore the correct PDS URL if available
+      if (account.pdsUrl) {
+        agent.pdsUrl = agent.api.xrpc.uri = new URL(account.pdsUrl)
+      }
 
       agent.setPersistSessionHandler(
         createPersistSessionHandler(

--- a/src/state/session/index.tsx
+++ b/src/state/session/index.tsx
@@ -369,7 +369,7 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
     async account => {
       logger.debug(`session: initSession`, {}, logger.DebugContext.session)
 
-      const agent = new BskyAgent({service: account.service})
+      const agent = new BskyAgent({service: account.pdsUrl || account.service})
 
       agent.setPersistSessionHandler(
         createPersistSessionHandler(
@@ -408,10 +408,6 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
         handle: account.handle,
         deactivated:
           isSessionDeactivated(account.accessJwt) || account.deactivated,
-      }
-
-      if (account.pdsUrl) {
-        agent.api.xrpc.uri = agent.pdsUrl = new URL(account.pdsUrl)
       }
 
       if (canReusePrevSession) {

--- a/src/state/session/index.tsx
+++ b/src/state/session/index.tsx
@@ -410,13 +410,14 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
           isSessionDeactivated(account.accessJwt) || account.deactivated,
       }
 
+      if (account.pdsUrl) {
+        agent.api.xrpc.uri = agent.pdsUrl = new URL(account.pdsUrl)
+      }
+
       if (canReusePrevSession) {
         logger.debug(`session: attempting to reuse previous session`)
 
         agent.session = prevSession
-        if (account.pdsUrl) {
-          agent.api.xrpc.uri = agent.pdsUrl = new URL(account.pdsUrl)
-        }
 
         __globalAgent = agent
         upsertAccount(account)


### PR DESCRIPTION
Fixes the pesky issue where non-blocking session resumption would cause API requests to go through `bsky.social` rather than the intended PDS URL.

This is a little more annoying than it needed to be because there isn't a single function for mapping the agent's state to the intended persisted schema. I *believe* I have caught all the cases (looked at where `upsertAccount` is being called)

**This fixes handle resolution issues during initial page load for _any and all_ accounts that are currently residing outside of bsky.social instances**. (only happens when authenticated, PWI works fine because it goes through AppView)

Should have a slight network improvement as well as it doesn't have to make connection requests to `bsky.social` first before going through the user's actual PDS.