### PR TITLE
[GIFs] Fix infinite pagination issue by forcing flatlist to scroll

### DIFF
--- a/src/components/Dialog/index.web.tsx
+++ b/src/components/Dialog/index.web.tsx
@@ -199,11 +199,23 @@ export const ScrollableInner = Inner
 
 export function InnerFlatList({
   label,
+  style,
   ...props
 }: FlatListProps<any> & {label: string}) {
+  const {gtMobile} = useBreakpoints()
   return (
-    <Inner label={label}>
-      <FlatList {...props} />
+    <Inner
+      label={label}
+      // @ts-ignore web only -sfn
+      style={{
+        paddingHorizontal: 0,
+        maxHeight: 'calc(-36px + 100vh)',
+        overflow: 'hidden',
+      }}>
+      <FlatList
+        style={[gtMobile ? a.px_2xl : a.px_xl, flatten(style)]}
+        {...props}
+      />
     </Inner>
   )
 }

--- a/src/components/dialogs/GifSelect.tsx
+++ b/src/components/dialogs/GifSelect.tsx
@@ -152,7 +152,11 @@ function GifList({
         <View
           style={[
             a.absolute,
-            {top: 0, left: 0, right: 0, height: '50%'},
+            a.inset_0,
+            {
+              borderBottomLeftRadius: 8,
+              borderBottomRightRadius: 8,
+            },
             t.atoms.bg,
           ]}
         />


### PR DESCRIPTION
FlatList was endlessly triggering `onEndReached` on web, and it turns out that was because it was the dialog that was scrolling rather than the flatlist. By capping the height of `Dialog.Inner`, it means that the FlatList does the scrolling.

Also includes some style tweaks.

## Test plan

If you want to see the original bug in action, go to https://main.bsky.dev, scroll down the timeline a bit and open the gif viewer. In the network tab you can see it loading new pages of trending gifs.

To test the fix, follow the same steps and check that this doesn't happen