### PR TITLE
Animate search bar width when cancel appears

### DIFF
--- a/src/components/hooks/useLayoutAnimation.ts
+++ b/src/components/hooks/useLayoutAnimation.ts
@@ -1,0 +1,27 @@
+import {useLayoutEffect, useRef} from 'react'
+import {LayoutAnimation} from 'react-native'
+
+import {isAndroid, isIOS} from '#/platform/detection'
+
+// triggers a layout animation when the deps change
+// disabled on the first render
+export function useLayoutAnimation(
+  {
+    animation = LayoutAnimation.Presets.easeInEaseOut,
+    iOS = true,
+    android = true,
+  },
+  deps: any[],
+) {
+  const firstRef = useRef(true)
+  useLayoutEffect(() => {
+    if (firstRef.current) {
+      firstRef.current = false
+      return
+    }
+    if ((isAndroid && android) || (isIOS && iOS)) {
+      LayoutAnimation.configureNext(animation)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [android, iOS, animation, ...deps])
+}

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -1,17 +1,9 @@
-import React, {
-  useCallback,
-  useEffect,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react'
+import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react'
 import {
   ActivityIndicator,
   BackHandler,
   Keyboard,
   KeyboardAvoidingView,
-  LayoutAnimation,
   Platform,
   ScrollView,
   StyleSheet,
@@ -59,6 +51,7 @@ import {ComposerOpts} from 'state/shell/composer'
 import {ComposerReplyTo} from 'view/com/composer/ComposerReplyTo'
 import {atoms as a} from '#/alf'
 import {Button} from '#/components/Button'
+import {useLayoutAnimation} from '#/components/hooks/useLayoutAnimation'
 import {EmojiArc_Stroke2_Corner0_Rounded as EmojiSmile} from '#/components/icons/Emoji'
 import * as Prompt from '#/components/Prompt'
 import {QuoteEmbed} from '../util/post-embeds/QuoteEmbed'
@@ -136,11 +129,8 @@ export const ComposePost = observer(function ComposePost({
     [initImageUris],
   )
 
-  useLayoutEffect(() => {
-    if (isIOS) {
-      LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut)
-    }
-  }, [gallery.size])
+  // trigger layout animation when the number of images changes
+  useLayoutAnimation({android: false}, [gallery.size])
 
   const onClose = useCallback(() => {
     closeComposer()

--- a/src/view/screens/Search/Search.tsx
+++ b/src/view/screens/Search/Search.tsx
@@ -59,6 +59,7 @@ import {
 } from '#/view/shell/desktop/Search'
 import {ProfileCardFeedLoadingPlaceholder} from 'view/com/util/LoadingPlaceholder'
 import {atoms as a} from '#/alf'
+import {useLayoutAnimation} from '#/components/hooks/useLayoutAnimation'
 
 function Loader() {
   const pal = usePalette('default')
@@ -775,6 +776,10 @@ export function SearchScreen(
     )
   }
 
+  const showCancel = query.length > 0 || inputIsFocused
+
+  useLayoutAnimation({}, [showCancel])
+
   return (
     <View style={isWeb ? null : {flex: 1}}>
       <CenteredView
@@ -855,7 +860,7 @@ export function SearchScreen(
           ) : undefined}
         </View>
 
-        {query || inputIsFocused ? (
+        {showCancel ? (
           <View style={styles.headerCancelBtn}>
             <Pressable
               onPress={onPressCancelSearch}


### PR DESCRIPTION
Uses the `useLayoutEffect`/`LayoutAnimation` trick on the search bar cancel button. I also put it in a custom hook, `useLayoutAnimation`, which ensures `configureNext` is not run on the first render.

https://github.com/bluesky-social/social-app/assets/10959775/b41e6127-e11a-4bd9-b2b9-d3f71a413d65

https://github.com/bluesky-social/social-app/assets/10959775/1e6282b2-78ac-4b2b-8cc9-fc7d3ea524f6

