### PR TITLE
Fix scrollbar in nav signup card 

### DIFF
--- a/src/components/AppLanguageDropdown.web.tsx
+++ b/src/components/AppLanguageDropdown.web.tsx
@@ -71,6 +71,7 @@ export function AppLanguageDropdown() {
           color: t.atoms.text.color,
           background: t.atoms.bg.backgroundColor,
           padding: 4,
+          maxWidth: '100%',
         }}>
         {APP_LANGUAGES.filter(l => Boolean(l.code2)).map(l => (
           <option key={l.code2} value={l.code2}>


### PR DESCRIPTION
`<select>` has a default width, so you can't just set it's size with `inset: 0`. This was causing overflow in the nav signup card. We can just add a `max-width: 100%` to fix this.

![image](https://github.com/bluesky-social/social-app/assets/10959775/6f191a82-1002-483f-9ffb-66735f788ccb)
