### PR TITLE
[GIFs] Add error boundary to GIF picker

### DIFF
--- a/src/components/dialogs/GifSelect.tsx
+++ b/src/components/dialogs/GifSelect.tsx
@@ -57,7 +57,7 @@ export function GifSelectDialog({
   }
 
   const renderErrorBoundary = useCallback(
-    (error: any) => <DialogError details={error.toString()} />,
+    (error: any) => <DialogError details={String(error)} />,
     [],
   )
 

--- a/src/components/dialogs/GifSelect.tsx
+++ b/src/components/dialogs/GifSelect.tsx
@@ -13,6 +13,8 @@ import {
   useSetExternalEmbedPref,
 } from '#/state/preferences'
 import {Gif, useGifphySearch, useGiphyTrending} from '#/state/queries/giphy'
+import {ErrorScreen} from '#/view/com/util/error/ErrorScreen'
+import {ErrorBoundary} from '#/view/com/util/ErrorBoundary'
 import {atoms as a, useBreakpoints, useTheme} from '#/alf'
 import * as Dialog from '#/components/Dialog'
 import * as TextField from '#/components/forms/TextField'
@@ -54,13 +56,18 @@ export function GifSelectDialog({
       break
   }
 
+  const renderErrorBoundary = useCallback(
+    (error: any) => <DialogError details={error.toString()} />,
+    [],
+  )
+
   return (
     <Dialog.Outer
       control={control}
       nativeOptions={{sheet: {snapPoints}}}
       onClose={onClose}>
       <Dialog.Handle />
-      {content}
+      <ErrorBoundary renderError={renderErrorBoundary}>{content}</ErrorBoundary>
     </Dialog.Outer>
   )
 }
@@ -354,6 +361,35 @@ function GiphyConsentPrompt({control}: {control: Dialog.DialogControlProps}) {
           </ButtonText>
         </Button>
       </View>
+    </Dialog.ScrollableInner>
+  )
+}
+
+function DialogError({details}: {details?: string}) {
+  const {_} = useLingui()
+  const control = Dialog.useDialogContext()
+
+  return (
+    <Dialog.ScrollableInner
+      style={[a.flex_1, a.gap_md]}
+      label={_(msg`An error occured`)}>
+      <ErrorScreen
+        title={_(msg`Oh no!`)}
+        message={_(
+          msg`There was an unexpected issue in the application. Please let us know if this happened to you!`,
+        )}
+        details={details}
+      />
+      <Button
+        label={_(msg`Close dialog`)}
+        onPress={() => control.close()}
+        color="primary"
+        size="medium"
+        variant="solid">
+        <ButtonText>
+          <Trans>Close</Trans>
+        </ButtonText>
+      </Button>
     </Dialog.ScrollableInner>
   )
 }

--- a/src/components/dialogs/GifSelect.tsx
+++ b/src/components/dialogs/GifSelect.tsx
@@ -373,6 +373,7 @@ function DialogError({details}: {details?: string}) {
     <Dialog.ScrollableInner
       style={[a.flex_1, a.gap_md]}
       label={_(msg`An error occured`)}>
+      <Dialog.Close />
       <ErrorScreen
         title={_(msg`Oh no!`)}
         message={_(

--- a/src/components/dialogs/GifSelect.tsx
+++ b/src/components/dialogs/GifSelect.tsx
@@ -370,9 +370,7 @@ function DialogError({details}: {details?: string}) {
   const control = Dialog.useDialogContext()
 
   return (
-    <Dialog.ScrollableInner
-      style={[a.flex_1, a.gap_md]}
-      label={_(msg`An error occured`)}>
+    <Dialog.ScrollableInner style={a.gap_md} label={_(msg`An error occured`)}>
       <Dialog.Close />
       <ErrorScreen
         title={_(msg`Oh no!`)}

--- a/src/view/com/util/ErrorBoundary.tsx
+++ b/src/view/com/util/ErrorBoundary.tsx
@@ -1,12 +1,14 @@
 import React, {Component, ErrorInfo, ReactNode} from 'react'
+import {msg} from '@lingui/macro'
+import {useLingui} from '@lingui/react'
+
+import {logger} from '#/logger'
 import {ErrorScreen} from './error/ErrorScreen'
 import {CenteredView} from './Views'
-import {msg} from '@lingui/macro'
-import {logger} from '#/logger'
-import {useLingui} from '@lingui/react'
 
 interface Props {
   children?: ReactNode
+  renderError?: (error: any) => ReactNode
 }
 
 interface State {
@@ -30,6 +32,10 @@ export class ErrorBoundary extends Component<Props, State> {
 
   public render() {
     if (this.state.hasError) {
+      if (this.props.renderError) {
+        return this.props.renderError(this.state.error)
+      }
+
       return (
         <CenteredView style={{height: '100%', flex: 1}}>
           <TranslatedErrorScreen details={this.state.error.toString()} />


### PR DESCRIPTION
Adds an error boundary to the GIF picker. I couldn't reuse our existing `<ErrorBoundary>` since the error screen needs wrapping in a Dialog `<Inner>`, so I added a `renderError` prop to it so we can display a custom error screen.

![Simulator Screenshot - iPhone 15 - 2024-04-22 at 14 24 16](https://github.com/bluesky-social/social-app/assets/10959775/004f868c-05dd-440a-add6-7cad180e75de)

![Screenshot 2024-04-22 at 14 35 52](https://github.com/bluesky-social/social-app/assets/10959775/76e265bd-0768-46e0-b479-13e676781eff)

### Test plan

Throw some errors in the GIF picker, and see if it behaves as it should