### PR TITLE
remove unnecessary padding from the right hand side of the post in threaded mode

### DIFF
--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -675,7 +675,6 @@ const styles = StyleSheet.create({
   },
   layoutContentThreaded: {
     flex: 1,
-    paddingRight: 10,
   },
   meta: {
     flexDirection: 'row',


### PR DESCRIPTION
## Why

Noticed over the weekend while testing that there's some strange padding on the right hand side of the post in threaded mode which makes photos or other embeds look skewed in the thread.

This should be safe, because we still have other padding that prevents the content from reaching the side of the screen:

![Screenshot 2024-04-22 at 9 16 12 AM](https://github.com/bluesky-social/social-app/assets/153161762/e6130c22-2e25-45ae-93a1-28cc73f79953)
![Screenshot 2024-04-22 at 9 16 18 AM](https://github.com/bluesky-social/social-app/assets/153161762/7e7cd927-886f-49d9-b181-945e379c41fc)


## Test Plan

Open a post in threaded mode that has some embeds before and after to see the difference in alignment.

### Before

![Screenshot 2024-04-22 at 9 11 59 AM](https://github.com/bluesky-social/social-app/assets/153161762/280b357d-e115-4773-bc25-a3d151a0b558)

### After

![Screenshot 2024-04-22 at 9 12 16 AM](https://github.com/bluesky-social/social-app/assets/153161762/a50b1dca-3e4a-4402-b68c-88526c42453e)
