### PR TITLE
remove gate from updates

### DIFF
--- a/src/lib/hooks/useOTAUpdates.ts
+++ b/src/lib/hooks/useOTAUpdates.ts
@@ -12,7 +12,6 @@ import {
 
 import {logger} from '#/logger'
 import {IS_TESTFLIGHT} from 'lib/app-info'
-import {useGate} from 'lib/statsig/statsig'
 import {isIOS} from 'platform/detection'
 
 const MINIMUM_MINIMIZE_TIME = 15 * 60e3
@@ -31,8 +30,7 @@ async function setExtraParams() {
 }
 
 export function useOTAUpdates() {
-  const gate = useGate()
-  const shouldReceiveUpdates = isEnabled && !__DEV__ && gate('receive_updates')
+  const shouldReceiveUpdates = isEnabled && !__DEV__
 
   const appState = React.useRef<AppStateStatus>('active')
   const lastMinimize = React.useRef(0)

--- a/src/lib/statsig/gates.ts
+++ b/src/lib/statsig/gates.ts
@@ -6,7 +6,6 @@ export type Gate =
   | 'hide_vertical_scroll_indicators'
   | 'new_gif_player'
   | 'new_profile_scroll_component'
-  | 'receive_updates'
   | 'show_follow_back_label_v2'
   | 'start_session_with_following_v2'
   | 'use_new_suggestions_endpoint'


### PR DESCRIPTION
Small PR to remove updates gate. We've been receiving requests from half the user base for a bit over a week now, with no errors coming in from Sentry and a reliable backend that can handle the load.

Verified again that even if something does happen to the updates server, it does not affect the client (besides sending an error to Sentry). We actually saw this in practice during the initial 5% rollout where the backend was returning a 500 error rather than a 200. Just errors coming to sentry, no interference for the user.