### PR TITLE
[GIFs] Remove consent flow

### DIFF
--- a/src/components/dialogs/GifSelect.tsx
+++ b/src/components/dialogs/GifSelect.tsx
@@ -9,10 +9,6 @@ import {logEvent} from '#/lib/statsig/statsig'
 import {cleanError} from '#/lib/strings/errors'
 import {isWeb} from '#/platform/detection'
 import {
-  useExternalEmbedsPrefs,
-  useSetExternalEmbedPref,
-} from '#/state/preferences'
-import {
   Gif,
   useFeaturedGifsQuery,
   useGifSearchQuery,
@@ -27,7 +23,6 @@ import {ArrowLeft_Stroke2_Corner0_Rounded as Arrow} from '#/components/icons/Arr
 import {MagnifyingGlass2_Stroke2_Corner0_Rounded as Search} from '#/components/icons/MagnifyingGlass2'
 import {Button, ButtonIcon, ButtonText} from '../Button'
 import {ListFooter, ListMaybePlaceholder} from '../Lists'
-import {Text} from '../Typography'
 
 export function GifSelectDialog({
   control,
@@ -38,26 +33,12 @@ export function GifSelectDialog({
   onClose: () => void
   onSelectGif: (gif: Gif) => void
 }) {
-  const externalEmbedsPrefs = useExternalEmbedsPrefs()
   const onSelectGif = useCallback(
     (gif: Gif) => {
       control.close(() => onSelectGifProp(gif))
     },
     [control, onSelectGifProp],
   )
-
-  let content = null
-  let snapPoints
-  switch (externalEmbedsPrefs?.tenor) {
-    case 'show':
-      content = <GifList control={control} onSelectGif={onSelectGif} />
-      snapPoints = ['100%']
-      break
-    case 'hide':
-    default:
-      content = <TenorConsentPrompt control={control} />
-      break
-  }
 
   const renderErrorBoundary = useCallback(
     (error: any) => <DialogError details={String(error)} />,
@@ -67,10 +48,12 @@ export function GifSelectDialog({
   return (
     <Dialog.Outer
       control={control}
-      nativeOptions={{sheet: {snapPoints}}}
+      nativeOptions={{sheet: {snapPoints: ['100%']}}}
       onClose={onClose}>
       <Dialog.Handle />
-      <ErrorBoundary renderError={renderErrorBoundary}>{content}</ErrorBoundary>
+      <ErrorBoundary renderError={renderErrorBoundary}>
+        <GifList control={control} onSelectGif={onSelectGif} />
+      </ErrorBoundary>
     </Dialog.Outer>
   )
 }
@@ -290,74 +273,6 @@ function GifPreview({
         />
       )}
     </Button>
-  )
-}
-
-function TenorConsentPrompt({control}: {control: Dialog.DialogControlProps}) {
-  const {_} = useLingui()
-  const t = useTheme()
-  const {gtMobile} = useBreakpoints()
-  const setExternalEmbedPref = useSetExternalEmbedPref()
-
-  const onShowPress = useCallback(() => {
-    setExternalEmbedPref('tenor', 'show')
-  }, [setExternalEmbedPref])
-
-  const onHidePress = useCallback(() => {
-    setExternalEmbedPref('tenor', 'hide')
-    control.close()
-  }, [control, setExternalEmbedPref])
-
-  const gtMobileWeb = gtMobile && isWeb
-
-  return (
-    <Dialog.ScrollableInner label={_(msg`Permission to use Tenor`)}>
-      <View style={a.gap_sm}>
-        <Text style={[a.text_2xl, a.font_bold]}>
-          <Trans>Permission to use Tenor</Trans>
-        </Text>
-
-        <View style={[a.mt_sm, a.mb_2xl, a.gap_lg]}>
-          <Text>
-            <Trans>
-              Bluesky uses Tenor to provide the GIF selector feature.
-            </Trans>
-          </Text>
-
-          <Text style={t.atoms.text_contrast_medium}>
-            <Trans>
-              Tenor is a third-party service that provides GIFs for use in
-              Bluesky. By enabling Tenor, requests will be made to Tenor's
-              servers to retrieve the GIFs.
-            </Trans>
-          </Text>
-        </View>
-      </View>
-      <View style={[a.gap_md, gtMobileWeb && a.flex_row_reverse]}>
-        <Button
-          label={_(msg`Enable Tenor`)}
-          onPress={onShowPress}
-          onAccessibilityEscape={control.close}
-          color="primary"
-          size={gtMobileWeb ? 'small' : 'medium'}
-          variant="solid">
-          <ButtonText>
-            <Trans>Enable Tenor</Trans>
-          </ButtonText>
-        </Button>
-        <Button
-          label={_(msg`No thanks`)}
-          onAccessibilityEscape={control.close}
-          onPress={onHidePress}
-          color="secondary"
-          size={gtMobileWeb ? 'small' : 'medium'}
-          variant="ghost">
-          <ButtonText>
-            <Trans>No thanks</Trans>
-          </ButtonText>
-        </Button>
-      </View>
-    </Dialog.ScrollableInner>
   )
 }
 

--- a/src/view/screens/PreferencesExternalEmbeds.tsx
+++ b/src/view/screens/PreferencesExternalEmbeds.tsx
@@ -1,25 +1,26 @@
 import React from 'react'
 import {StyleSheet, View} from 'react-native'
+import {Trans} from '@lingui/macro'
 import {useFocusEffect} from '@react-navigation/native'
-import {NativeStackScreenProps, CommonNavigatorParams} from 'lib/routes/types'
-import {s} from 'lib/styles'
-import {Text} from '../com/util/text/Text'
-import {usePalette} from 'lib/hooks/usePalette'
-import {useAnalytics} from 'lib/analytics/analytics'
-import {useWebMediaQueries} from 'lib/hooks/useWebMediaQueries'
+
 import {
   EmbedPlayerSource,
   externalEmbedLabels,
 } from '#/lib/strings/embed-player'
 import {useSetMinimalShellMode} from '#/state/shell'
-import {Trans} from '@lingui/macro'
-import {ScrollView} from '../com/util/Views'
+import {useAnalytics} from 'lib/analytics/analytics'
+import {usePalette} from 'lib/hooks/usePalette'
+import {useWebMediaQueries} from 'lib/hooks/useWebMediaQueries'
+import {CommonNavigatorParams, NativeStackScreenProps} from 'lib/routes/types'
+import {s} from 'lib/styles'
 import {
   useExternalEmbedsPrefs,
   useSetExternalEmbedPref,
 } from 'state/preferences'
 import {ToggleButton} from 'view/com/util/forms/ToggleButton'
 import {SimpleViewHeader} from '../com/util/SimpleViewHeader'
+import {Text} from '../com/util/text/Text'
+import {ScrollView} from '../com/util/Views'
 
 type Props = NativeStackScreenProps<
   CommonNavigatorParams,
@@ -74,13 +75,16 @@ export function PreferencesExternalEmbeds({}: Props) {
         <Text type="xl-bold" style={[pal.text, styles.heading]}>
           <Trans>Enable media players for</Trans>
         </Text>
-        {Object.entries(externalEmbedLabels).map(([key, label]) => (
-          <PrefSelector
-            source={key as EmbedPlayerSource}
-            label={label}
-            key={key}
-          />
-        ))}
+        {Object.entries(externalEmbedLabels)
+          // TODO: Remove special case when we disable the old integration.
+          .filter(([key]) => key !== 'tenor')
+          .map(([key, label]) => (
+            <PrefSelector
+              source={key as EmbedPlayerSource}
+              label={label}
+              key={key}
+            />
+          ))}
       </ScrollView>
     </View>
   )


### PR DESCRIPTION
We don't need this anymore because we're going to proxy all requests.

NOTE: We still need to actually add proxying to the player — this isn't happening in this PR.

## Test Plan

Load picker on clean storage. Doesn't ask anything. 

Load settings. See Tenor not listed there.

