### PR TITLE
Mark `Copied to clipboard` toast for translation

### DIFF
--- a/src/lib/sharing.ts
+++ b/src/lib/sharing.ts
@@ -1,6 +1,7 @@
 import {Share} from 'react-native'
 // import * as Sharing from 'expo-sharing'
 import {setStringAsync} from 'expo-clipboard'
+import {msg} from '@lingui/macro'
 
 import {isAndroid, isIOS} from 'platform/detection'
 import * as Toast from '#/view/com/util/Toast'
@@ -20,6 +21,6 @@ export async function shareUrl(url: string) {
     // React Native Share is not supported by web. Web Share API
     // has increasing but not full support, so default to clipboard
     setStringAsync(url)
-    Toast.show('Copied to clipboard')
+    Toast.show(_(msg`Copied to clipboard`))
   }
 }

--- a/src/lib/sharing.ts
+++ b/src/lib/sharing.ts
@@ -2,6 +2,7 @@ import {Share} from 'react-native'
 // import * as Sharing from 'expo-sharing'
 import {setStringAsync} from 'expo-clipboard'
 import {msg} from '@lingui/macro'
+import {useLingui} from '@lingui/react'
 
 import {isAndroid, isIOS} from 'platform/detection'
 import * as Toast from '#/view/com/util/Toast'

--- a/src/lib/sharing.ts
+++ b/src/lib/sharing.ts
@@ -13,6 +13,7 @@ import * as Toast from '#/view/com/util/Toast'
  * clipboard.
  */
 export async function shareUrl(url: string) {
+  const {_} = useLingui()
   if (isAndroid) {
     await Share.share({message: url})
   } else if (isIOS) {


### PR DESCRIPTION
This small PR marks for translation the `Copied to clipboard` toast that is displayed on web when sharing the link to a post.