### PR TITLE
Add border radius to GIF loading state

### DIFF
--- a/src/view/com/util/post-embeds/GifEmbed.tsx
+++ b/src/view/com/util/post-embeds/GifEmbed.tsx
@@ -38,6 +38,7 @@ function PlaybackControls({
         a.inset_0,
         a.w_full,
         a.h_full,
+        a.rounded_sm,
         {
           zIndex: 2,
           backgroundColor: !isLoaded


### PR DESCRIPTION
Current (notice the corners are cut off):
<img width="594" alt="Screenshot 2024-04-23 at 23 53 39" src="https://github.com/bluesky-social/social-app/assets/10959775/86881300-3a1a-4f6e-8fdc-36098538a97b">


This PR:
<img width="568" alt="Screenshot 2024-04-23 at 23 51 09" src="https://github.com/bluesky-social/social-app/assets/10959775/4893f16f-0023-4372-b34b-2228a0dbce2b">
