### PR TITLE
Add option to remove quoted post in composer

### DIFF
--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -53,7 +53,7 @@ import {atoms as a} from '#/alf'
 import {Button} from '#/components/Button'
 import {EmojiArc_Stroke2_Corner0_Rounded as EmojiSmile} from '#/components/icons/Emoji'
 import * as Prompt from '#/components/Prompt'
-import {QuoteEmbed} from '../util/post-embeds/QuoteEmbed'
+import {QuoteEmbed, QuoteX} from '../util/post-embeds/QuoteEmbed'
 import {Text} from '../util/text/Text'
 import * as Toast from '../util/Toast'
 import {UserAvatar} from '../util/UserAvatar'
@@ -483,8 +483,13 @@ export const ComposePost = observer(function ComposePost({
             />
           )}
           {quote ? (
-            <View style={[s.mt5, isWeb && s.mb10, {pointerEvents: 'none'}]}>
-              <QuoteEmbed quote={quote} />
+            <View style={[s.mt5, isWeb && s.mb10]}>
+              <View style={{pointerEvents: 'none'}}>
+                <QuoteEmbed quote={quote} />
+              </View>
+              {quote.uri !== initQuote?.uri && (
+                <QuoteX onRemove={() => setQuote(undefined)} />
+              )}
             </View>
           ) : undefined}
         </ScrollView>

--- a/src/view/com/util/post-embeds/QuoteEmbed.tsx
+++ b/src/view/com/util/post-embeds/QuoteEmbed.tsx
@@ -23,6 +23,7 @@ import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 import {useQueryClient} from '@tanstack/react-query'
 
+import {HITSLOP_20} from '#/lib/constants'
 import {s} from '#/lib/styles'
 import {useModerationOpts} from '#/state/queries/preferences'
 import {RQKEY as RQKEY_URI} from '#/state/queries/resolve-uri'
@@ -206,7 +207,8 @@ export function QuoteX({onRemove}: {onRemove: () => void}) {
       accessibilityRole="button"
       accessibilityLabel={_(msg`Remove quote`)}
       accessibilityHint={_(msg`Removes quoted post`)}
-      onAccessibilityEscape={onRemove}>
+      onAccessibilityEscape={onRemove}
+      hitSlop={HITSLOP_20}>
       <FontAwesomeIcon size={12} icon="xmark" style={s.white} />
     </TouchableOpacity>
   )

--- a/src/view/com/util/post-embeds/QuoteEmbed.tsx
+++ b/src/view/com/util/post-embeds/QuoteEmbed.tsx
@@ -1,5 +1,11 @@
 import React from 'react'
-import {StyleProp, StyleSheet, View, ViewStyle} from 'react-native'
+import {
+  StyleProp,
+  StyleSheet,
+  TouchableOpacity,
+  View,
+  ViewStyle,
+} from 'react-native'
 import {
   AppBskyEmbedExternal,
   AppBskyEmbedImages,
@@ -12,9 +18,12 @@ import {
   RichText as RichTextAPI,
 } from '@atproto/api'
 import {AtUri} from '@atproto/api'
-import {Trans} from '@lingui/macro'
+import {FontAwesomeIcon} from '@fortawesome/react-native-fontawesome'
+import {msg, Trans} from '@lingui/macro'
+import {useLingui} from '@lingui/react'
 import {useQueryClient} from '@tanstack/react-query'
 
+import {s} from '#/lib/styles'
 import {useModerationOpts} from '#/state/queries/preferences'
 import {RQKEY as RQKEY_URI} from '#/state/queries/resolve-uri'
 import {usePalette} from 'lib/hooks/usePalette'
@@ -174,6 +183,32 @@ export function QuoteEmbed({
         {embed && <PostEmbeds embed={embed} moderation={moderation} />}
       </Link>
     </ContentHider>
+  )
+}
+
+export function QuoteX({onRemove}: {onRemove: () => void}) {
+  const {_} = useLingui()
+  return (
+    <TouchableOpacity
+      style={[
+        a.absolute,
+        a.p_xs,
+        a.rounded_full,
+        a.align_center,
+        a.justify_center,
+        {
+          top: 16,
+          right: 10,
+          backgroundColor: 'rgba(0, 0, 0, 0.75)',
+        },
+      ]}
+      onPress={onRemove}
+      accessibilityRole="button"
+      accessibilityLabel={_(msg`Remove quote`)}
+      accessibilityHint={_(msg`Removes quoted post`)}
+      onAccessibilityEscape={onRemove}>
+      <FontAwesomeIcon size={12} icon="xmark" style={s.white} />
+    </TouchableOpacity>
   )
 }
 


### PR DESCRIPTION
Adds an X in the top corner of the quote post. Does not apply to quotes added via the repost menu, should only be for pasted in quotes.

It's small, to keep it out of the way, but it has a generous hitslop

<img width="645" alt="Screenshot 2024-04-24 at 00 12 20" src="https://github.com/bluesky-social/social-app/assets/10959775/4dce9c50-55c1-4e68-b5d6-5d0861f14ccc">

### Test plan

1. Paste in link and try clearing it
2. Observe you can't clear a quote added via repost menu
3. Paste in a link on top of a repost menu quote and see it is clearable