### PR TITLE
Disable autoplay by default if prefers-reduced-motion

### DIFF
--- a/src/platform/detection.ts
+++ b/src/platform/detection.ts
@@ -1,5 +1,6 @@
 import {Platform} from 'react-native'
 import {getLocales} from 'expo-localization'
+
 import {dedupArray} from 'lib/functions'
 
 export const isIOS = Platform.OS === 'ios'
@@ -18,3 +19,8 @@ export const deviceLocales = dedupArray(
     .map?.(locale => locale.languageCode)
     .filter(code => typeof code === 'string'),
 ) as string[]
+
+export const prefersReducedMotion =
+  isWeb &&
+  // @ts-ignore we know window exists -prf
+  !global.window.matchMedia('(prefers-reduced-motion: no-preference)')?.matches

--- a/src/state/persisted/schema.ts
+++ b/src/state/persisted/schema.ts
@@ -1,6 +1,6 @@
 import {z} from 'zod'
 
-import {deviceLocales} from '#/platform/detection'
+import {deviceLocales, prefersReducedMotion} from '#/platform/detection'
 
 const externalEmbedOptions = ['show', 'hide'] as const
 
@@ -98,5 +98,5 @@ export const defaults: Schema = {
   lastSelectedHomeFeed: undefined,
   pdsAddressHistory: [],
   disableHaptics: false,
-  disableAutoplay: false,
+  disableAutoplay: prefersReducedMotion,
 }


### PR DESCRIPTION
Web-only change. Only affects the default the first time we init this setting. From that point on, it will be read from storage, as usual.

## Test Plan

Clear local storage. Set "reduce motion" to true in system settings. Log in.

<img width="657" alt="Screenshot 2024-04-24 at 00 53 43" src="https://github.com/bluesky-social/social-app/assets/810438/d0abb6cb-39d3-41be-8918-fbe9d76f460a">
<img width="647" alt="Screenshot 2024-04-24 at 00 53 50" src="https://github.com/bluesky-social/social-app/assets/810438/9c673c51-e0c4-45b6-a11d-e81c9219f810">


Clear local storage. Set "reduce motion" to false in system settings. Log in.

<img width="675" alt="Screenshot 2024-04-24 at 00 54 21" src="https://github.com/bluesky-social/social-app/assets/810438/ff6e2d56-f3b6-4a21-bf35-b118991597d8">

(It's playing)