### PR TITLE
Remove Moderation from the sidebar

### DIFF
--- a/src/view/screens/Settings/index.tsx
+++ b/src/view/screens/Settings/index.tsx
@@ -494,6 +494,49 @@ export function SettingsScreen({}: Props) {
           </Text>
         </TouchableOpacity>
         <TouchableOpacity
+          testID="languageSettingsBtn"
+          style={[
+            styles.linkCard,
+            pal.view,
+            isSwitchingAccounts && styles.dimmed,
+          ]}
+          onPress={isSwitchingAccounts ? undefined : onPressLanguageSettings}
+          accessibilityRole="button"
+          accessibilityLabel={_(msg`Language settings`)}
+          accessibilityHint={_(msg`Opens configurable language settings`)}>
+          <View style={[styles.iconContainer, pal.btn]}>
+            <FontAwesomeIcon
+              icon="language"
+              style={pal.text as FontAwesomeIconStyle}
+            />
+          </View>
+          <Text type="lg" style={pal.text}>
+            <Trans>Languages</Trans>
+          </Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          testID="moderationBtn"
+          style={[
+            styles.linkCard,
+            pal.view,
+            isSwitchingAccounts && styles.dimmed,
+          ]}
+          onPress={
+            isSwitchingAccounts
+              ? undefined
+              : () => navigation.navigate('Moderation')
+          }
+          accessibilityRole="button"
+          accessibilityLabel={_(msg`Moderation settings`)}
+          accessibilityHint={_(msg`Opens moderation settings`)}>
+          <View style={[styles.iconContainer, pal.btn]}>
+            <HandIcon style={pal.text} size={18} strokeWidth={6} />
+          </View>
+          <Text type="lg" style={pal.text}>
+            <Trans>Moderation</Trans>
+          </Text>
+        </TouchableOpacity>
+        <TouchableOpacity
           testID="preferencesHomeFeedButton"
           style={[
             styles.linkCard,
@@ -552,49 +595,6 @@ export function SettingsScreen({}: Props) {
           </View>
           <Text type="lg" style={pal.text}>
             <Trans>My Saved Feeds</Trans>
-          </Text>
-        </TouchableOpacity>
-        <TouchableOpacity
-          testID="languageSettingsBtn"
-          style={[
-            styles.linkCard,
-            pal.view,
-            isSwitchingAccounts && styles.dimmed,
-          ]}
-          onPress={isSwitchingAccounts ? undefined : onPressLanguageSettings}
-          accessibilityRole="button"
-          accessibilityLabel={_(msg`Language settings`)}
-          accessibilityHint={_(msg`Opens configurable language settings`)}>
-          <View style={[styles.iconContainer, pal.btn]}>
-            <FontAwesomeIcon
-              icon="language"
-              style={pal.text as FontAwesomeIconStyle}
-            />
-          </View>
-          <Text type="lg" style={pal.text}>
-            <Trans>Languages</Trans>
-          </Text>
-        </TouchableOpacity>
-        <TouchableOpacity
-          testID="moderationBtn"
-          style={[
-            styles.linkCard,
-            pal.view,
-            isSwitchingAccounts && styles.dimmed,
-          ]}
-          onPress={
-            isSwitchingAccounts
-              ? undefined
-              : () => navigation.navigate('Moderation')
-          }
-          accessibilityRole="button"
-          accessibilityLabel={_(msg`Moderation settings`)}
-          accessibilityHint={_(msg`Opens moderation settings`)}>
-          <View style={[styles.iconContainer, pal.btn]}>
-            <HandIcon style={pal.text} size={18} strokeWidth={6} />
-          </View>
-          <Text type="lg" style={pal.text}>
-            <Trans>Moderation</Trans>
           </Text>
         </TouchableOpacity>
 

--- a/src/view/shell/Drawer.tsx
+++ b/src/view/shell/Drawer.tsx
@@ -30,7 +30,6 @@ import {
   BellIcon,
   BellIconSolid,
   CogIcon,
-  HandIcon,
   HashtagIcon,
   HomeIcon,
   HomeIconSolid,
@@ -177,12 +176,6 @@ let DrawerContent = ({}: {}): React.ReactNode => {
     setDrawerOpen(false)
   }, [navigation, track, setDrawerOpen])
 
-  const onPressModeration = React.useCallback(() => {
-    track('Menu:ItemClicked', {url: 'Moderation'})
-    navigation.navigate('Moderation')
-    setDrawerOpen(false)
-  }, [navigation, track, setDrawerOpen])
-
   const onPressSettings = React.useCallback(() => {
     track('Menu:ItemClicked', {url: 'Settings'})
     navigation.navigate('Settings')
@@ -240,7 +233,6 @@ let DrawerContent = ({}: {}): React.ReactNode => {
               />
               <FeedsMenuItem isActive={isAtFeeds} onPress={onPressMyFeeds} />
               <ListsMenuItem onPress={onPressLists} />
-              <ModerationMenuItem onPress={onPressModeration} />
               <ProfileMenuItem
                 isActive={isAtMyProfile}
                 onPress={onPressProfile}
@@ -506,25 +498,6 @@ let ListsMenuItem = ({onPress}: {onPress: () => void}): React.ReactNode => {
   )
 }
 ListsMenuItem = React.memo(ListsMenuItem)
-
-let ModerationMenuItem = ({
-  onPress,
-}: {
-  onPress: () => void
-}): React.ReactNode => {
-  const {_} = useLingui()
-  const pal = usePalette('default')
-  return (
-    <MenuItem
-      icon={<HandIcon strokeWidth={5} style={pal.text} size={24} />}
-      label={_(msg`Moderation`)}
-      accessibilityLabel={_(msg`Moderation`)}
-      accessibilityHint=""
-      onPress={onPress}
-    />
-  )
-}
-ModerationMenuItem = React.memo(ModerationMenuItem)
 
 let ProfileMenuItem = ({
   isActive,

--- a/src/view/shell/desktop/LeftNav.tsx
+++ b/src/view/shell/desktop/LeftNav.tsx
@@ -1,52 +1,52 @@
 import React from 'react'
 import {StyleSheet, TouchableOpacity, View} from 'react-native'
-import {PressableWithHover} from 'view/com/util/PressableWithHover'
+import {
+  FontAwesomeIcon,
+  FontAwesomeIconStyle,
+} from '@fortawesome/react-native-fontawesome'
+import {msg, Trans} from '@lingui/macro'
+import {useLingui} from '@lingui/react'
 import {
   useLinkProps,
   useNavigation,
   useNavigationState,
 } from '@react-navigation/native'
-import {
-  FontAwesomeIcon,
-  FontAwesomeIconStyle,
-} from '@fortawesome/react-native-fontawesome'
-import {Text} from 'view/com/util/text/Text'
-import {UserAvatar} from 'view/com/util/UserAvatar'
-import {Link} from 'view/com/util/Link'
-import {LoadingPlaceholder} from 'view/com/util/LoadingPlaceholder'
+
+import {isInvalidHandle} from '#/lib/strings/handles'
+import {emitSoftReset} from '#/state/events'
+import {useFetchHandle} from '#/state/queries/handle'
+import {useUnreadNotifications} from '#/state/queries/notifications/unread'
+import {useProfileQuery} from '#/state/queries/profile'
+import {useSession} from '#/state/session'
+import {useComposerControls} from '#/state/shell/composer'
 import {usePalette} from 'lib/hooks/usePalette'
 import {useWebMediaQueries} from 'lib/hooks/useWebMediaQueries'
-import {s, colors} from 'lib/styles'
 import {
-  HomeIcon,
-  HomeIconSolid,
-  MagnifyingGlassIcon2,
-  MagnifyingGlassIcon2Solid,
   BellIcon,
   BellIconSolid,
-  UserIcon,
-  UserIconSolid,
   CogIcon,
   CogIconSolid,
   ComposeIcon2,
-  ListIcon,
   HashtagIcon,
-  HandIcon,
+  HomeIcon,
+  HomeIconSolid,
+  ListIcon,
+  MagnifyingGlassIcon2,
+  MagnifyingGlassIcon2Solid,
+  UserIcon,
+  UserIconSolid,
 } from 'lib/icons'
-import {getCurrentRoute, isTab, isStateAtTabRoot} from 'lib/routes/helpers'
-import {NavigationProp, CommonNavigatorParams} from 'lib/routes/types'
-import {router} from '../../../routes'
+import {getCurrentRoute, isStateAtTabRoot, isTab} from 'lib/routes/helpers'
 import {makeProfileLink} from 'lib/routes/links'
-import {useLingui} from '@lingui/react'
-import {Trans, msg} from '@lingui/macro'
-import {useProfileQuery} from '#/state/queries/profile'
-import {useSession} from '#/state/session'
-import {useUnreadNotifications} from '#/state/queries/notifications/unread'
-import {useComposerControls} from '#/state/shell/composer'
-import {useFetchHandle} from '#/state/queries/handle'
-import {emitSoftReset} from '#/state/events'
+import {CommonNavigatorParams, NavigationProp} from 'lib/routes/types'
+import {colors, s} from 'lib/styles'
 import {NavSignupCard} from '#/view/shell/NavSignupCard'
-import {isInvalidHandle} from '#/lib/strings/handles'
+import {Link} from 'view/com/util/Link'
+import {LoadingPlaceholder} from 'view/com/util/LoadingPlaceholder'
+import {PressableWithHover} from 'view/com/util/PressableWithHover'
+import {Text} from 'view/com/util/text/Text'
+import {UserAvatar} from 'view/com/util/UserAvatar'
+import {router} from '../../../routes'
 
 function ProfileCard() {
   const {currentAccount} = useSession()
@@ -381,24 +381,6 @@ export function DesktopLeftNav() {
               />
             }
             label={_(msg`Lists`)}
-          />
-          <NavItem
-            href="/moderation"
-            icon={
-              <HandIcon
-                style={pal.text}
-                size={isDesktop ? 24 : 27}
-                strokeWidth={5.5}
-              />
-            }
-            iconFilled={
-              <FontAwesomeIcon
-                icon="hand"
-                style={pal.text as FontAwesomeIconStyle}
-                size={isDesktop ? 23 : 26}
-              />
-            }
-            label={_(msg`Moderation`)}
           />
           <NavItem
             href={currentAccount ? makeProfileLink(currentAccount) : '/'}


### PR DESCRIPTION
It's pretty busy in the left pane. Adjusting moderation settings isn't something you do every day, and it makes sense for them to just live in Settings. Let's remove the shortcut from the left pane. So you'd have to go Settings > Moderation. In Settings, I moved Moderation up so that it goes after Accessibility and Languages. So it's still easy to find.

## Left nav, desktop

<img width="1329" alt="Screenshot 2024-04-24 at 21 18 21" src="https://github.com/bluesky-social/social-app/assets/810438/3f0c429d-5d84-4247-b1ac-acb6c9848299">

## Drawer, mobile web

<img width="327" alt="Screenshot 2024-04-24 at 21 19 05" src="https://github.com/bluesky-social/social-app/assets/810438/f1301c5f-b66e-4cc7-b39f-80606d77d1c9">

## Drawer, iOS

<img width="351" alt="Screenshot 2024-04-24 at 21 20 02" src="https://github.com/bluesky-social/social-app/assets/810438/211e9957-dcef-40e0-ae9b-bd0dc7819f44">

## Drawer, Android

(Finally, I don't need to scroll to get to Settings.)

<img width="334" alt="Screenshot 2024-04-24 at 21 19 52" src="https://github.com/bluesky-social/social-app/assets/810438/7b18384f-b2d7-42cf-9c9a-47885144e208">

## Settings

I reordered some stuff so these go first:

<img width="731" alt="Screenshot 2024-04-24 at 21 20 41" src="https://github.com/bluesky-social/social-app/assets/810438/7b6b6f89-fa29-4dd5-9044-185d96a9852d">
