### PR TITLE
Ignore image responses on non-200 status

### DIFF
--- a/__tests__/lib/images.test.ts
+++ b/__tests__/lib/images.test.ts
@@ -1,9 +1,10 @@
+import ImageResizer from '@bam.tech/react-native-image-resizer'
+import RNFetchBlob from 'rn-fetch-blob'
+
 import {
   downloadAndResize,
   DownloadAndResizeOpts,
 } from '../../src/lib/media/manip'
-import ImageResizer from '@bam.tech/react-native-image-resizer'
-import RNFetchBlob from 'rn-fetch-blob'
 
 describe('downloadAndResize', () => {
   const errorSpy = jest.spyOn(global.console, 'error')
@@ -30,6 +31,7 @@ describe('downloadAndResize', () => {
     const mockedFetch = RNFetchBlob.fetch as jest.Mock
     mockedFetch.mockResolvedValueOnce({
       path: jest.fn().mockReturnValue('file://downloaded-image.jpg'),
+      info: jest.fn().mockReturnValue({status: 200}),
       flush: jest.fn(),
     })
 
@@ -84,6 +86,7 @@ describe('downloadAndResize', () => {
     const mockedFetch = RNFetchBlob.fetch as jest.Mock
     mockedFetch.mockResolvedValueOnce({
       path: jest.fn().mockReturnValue('file://downloaded-image'),
+      info: jest.fn().mockReturnValue({status: 200}),
       flush: jest.fn(),
     })
 
@@ -117,5 +120,27 @@ describe('downloadAndResize', () => {
       undefined,
       {mode: 'cover'},
     )
+  })
+
+  it('should return undefined for non-200 response', async () => {
+    const mockedFetch = RNFetchBlob.fetch as jest.Mock
+    mockedFetch.mockResolvedValueOnce({
+      path: jest.fn().mockReturnValue('file://downloaded-image'),
+      info: jest.fn().mockReturnValue({status: 400}),
+      flush: jest.fn(),
+    })
+
+    const opts: DownloadAndResizeOpts = {
+      uri: 'https://example.com/image',
+      width: 100,
+      height: 100,
+      maxSize: 500000,
+      mode: 'cover',
+      timeout: 10000,
+    }
+
+    const result = await downloadAndResize(opts)
+    expect(errorSpy).not.toHaveBeenCalled()
+    expect(result).toBeUndefined()
   })
 })

--- a/src/lib/media/manip.ts
+++ b/src/lib/media/manip.ts
@@ -1,13 +1,14 @@
-import RNFetchBlob from 'rn-fetch-blob'
-import ImageResizer from '@bam.tech/react-native-image-resizer'
 import {Image as RNImage, Share as RNShare} from 'react-native'
-import {Image} from 'react-native-image-crop-picker'
 import * as RNFS from 'react-native-fs'
+import {Image} from 'react-native-image-crop-picker'
 import uuid from 'react-native-uuid'
-import * as Sharing from 'expo-sharing'
 import * as MediaLibrary from 'expo-media-library'
-import {Dimensions} from './types'
+import * as Sharing from 'expo-sharing'
+import ImageResizer from '@bam.tech/react-native-image-resizer'
+import RNFetchBlob from 'rn-fetch-blob'
+
 import {isAndroid, isIOS} from 'platform/detection'
+import {Dimensions} from './types'
 
 export async function compressIfNeeded(
   img: Image,
@@ -62,6 +63,11 @@ export async function downloadAndResize(opts: DownloadAndResizeOpts) {
     const to1 = setTimeout(() => downloadResPromise.cancel(), opts.timeout)
     downloadRes = await downloadResPromise
     clearTimeout(to1)
+
+    const status = downloadRes.info().status
+    if (status !== 200) {
+      return
+    }
 
     let localUri = downloadRes.path()
     if (!localUri.startsWith('file://')) {


### PR DESCRIPTION
We currently crash in simulator if Cardy returns a non-200 response (as it does when an image is missing, e.g. for google.com). Let's instead check the response status.

## Test Plan

Verified callsites are resilient to returning undefined.

https://github.com/bluesky-social/social-app/assets/810438/43dda678-9e51-4325-afe7-f8eb062b525a


https://github.com/bluesky-social/social-app/assets/810438/419da788-213e-4dbd-9312-5b00f7e640fa


https://github.com/bluesky-social/social-app/assets/810438/d7f4a669-8383-40a6-b085-ee91658ccbe4


