### PR TITLE
Move Notifications up on desktop web

### DIFF
--- a/src/view/shell/desktop/LeftNav.tsx
+++ b/src/view/shell/desktop/LeftNav.tsx
@@ -328,24 +328,6 @@ export function DesktopLeftNav() {
             label={_(msg`Search`)}
           />
           <NavItem
-            href="/feeds"
-            icon={
-              <HashtagIcon
-                strokeWidth={2.25}
-                style={pal.text as FontAwesomeIconStyle}
-                size={isDesktop ? 24 : 28}
-              />
-            }
-            iconFilled={
-              <HashtagIcon
-                strokeWidth={4}
-                style={pal.text as FontAwesomeIconStyle}
-                size={isDesktop ? 24 : 28}
-              />
-            }
-            label={_(msg`Feeds`)}
-          />
-          <NavItem
             href="/notifications"
             count={numUnread}
             icon={
@@ -363,6 +345,24 @@ export function DesktopLeftNav() {
               />
             }
             label={_(msg`Notifications`)}
+          />
+          <NavItem
+            href="/feeds"
+            icon={
+              <HashtagIcon
+                strokeWidth={2.25}
+                style={pal.text as FontAwesomeIconStyle}
+                size={isDesktop ? 24 : 28}
+              />
+            }
+            iconFilled={
+              <HashtagIcon
+                strokeWidth={4}
+                style={pal.text as FontAwesomeIconStyle}
+                size={isDesktop ? 24 : 28}
+              />
+            }
+            label={_(msg`Feeds`)}
           />
           <NavItem
             href="/lists"


### PR DESCRIPTION
## Before

<img width="637" alt="Screenshot 2024-04-25 at 04 19 13" src="https://github.com/bluesky-social/social-app/assets/810438/dd07c31a-f053-4403-89af-b1865e68791f">

## After

<img width="738" alt="Screenshot 2024-04-25 at 04 19 48" src="https://github.com/bluesky-social/social-app/assets/810438/3b2f160d-3dc3-4d6f-a902-94e08ffca7a8">

I think this feels a bit better. Places Feeds and Lists closer together. Groups most commonly used ones at the top. Matches mobile which already uses this order.