### PR TITLE
adding mute account and block account buttons

### DIFF
--- a/src/view/com/util/forms/PostDropdownBtn.tsx
+++ b/src/view/com/util/forms/PostDropdownBtn.tsx
@@ -40,6 +40,7 @@ import {CodeBrackets_Stroke2_Corner0_Rounded as CodeBrackets} from '#/components
 import {EyeSlash_Stroke2_Corner0_Rounded as EyeSlash} from '#/components/icons/EyeSlash'
 import {Filter_Stroke2_Corner0_Rounded as Filter} from '#/components/icons/Filter'
 import {Mute_Stroke2_Corner0_Rounded as Mute} from '#/components/icons/Mute'
+import {PersonX_Stroke2_Corner0_Rounded as PersonX} from '#/components/icons/PersonX'
 import {SpeakerVolumeFull_Stroke2_Corner0_Rounded as Unmute} from '#/components/icons/Speaker'
 import {Trash_Stroke2_Corner0_Rounded as Trash} from '#/components/icons/Trash'
 import {Warning_Stroke2_Corner0_Rounded as Warning} from '#/components/icons/Warning'
@@ -380,7 +381,7 @@ let PostDropdownBtn = ({
                       label={_(msg`Block account`)}
                       onPress={onBlockAccount}>
                       <Menu.ItemText>{_(msg`Block account`)}</Menu.ItemText>
-                      <Menu.ItemIcon icon={Warning} position="right" />
+                      <Menu.ItemIcon icon={PersonX} position="right" />
                     </Menu.Item>
                   </>
                 )}

--- a/src/view/com/util/forms/PostDropdownBtn.tsx
+++ b/src/view/com/util/forms/PostDropdownBtn.tsx
@@ -351,40 +351,38 @@ let PostDropdownBtn = ({
             </>
           )}
 
-          {hasSession && (
+          {!isAuthor && hasSession && (
             <>
               <Menu.Divider />
               <Menu.Group>
-                {!isAuthor && (
-                  <>
-                    <Menu.Item
-                      testID="postDropdownMuteAccountBtn"
-                      label={
-                        isAuthorMuted
-                          ? _(msg`Unmute account`)
-                          : _(msg`Mute account`)
-                      }
-                      onPress={onMuteAccount}>
-                      <Menu.ItemText>
-                        {isAuthorMuted
-                          ? _(msg`Unmute account`)
-                          : _(msg`Mute account`)}
-                      </Menu.ItemText>
-                      <Menu.ItemIcon
-                        icon={isAuthorMuted ? Unmute : Mute}
-                        position="right"
-                      />
-                    </Menu.Item>
+                <>
+                  <Menu.Item
+                    testID="postDropdownMuteAccountBtn"
+                    label={
+                      isAuthorMuted
+                        ? _(msg`Unmute account`)
+                        : _(msg`Mute account`)
+                    }
+                    onPress={onMuteAccount}>
+                    <Menu.ItemText>
+                      {isAuthorMuted
+                        ? _(msg`Unmute account`)
+                        : _(msg`Mute account`)}
+                    </Menu.ItemText>
+                    <Menu.ItemIcon
+                      icon={isAuthorMuted ? Unmute : Mute}
+                      position="right"
+                    />
+                  </Menu.Item>
 
-                    <Menu.Item
-                      testID="postDropdownBlockAccountBtn"
-                      label={_(msg`Block account`)}
-                      onPress={onBlockAccount}>
-                      <Menu.ItemText>{_(msg`Block account`)}</Menu.ItemText>
-                      <Menu.ItemIcon icon={PersonX} position="right" />
-                    </Menu.Item>
-                  </>
-                )}
+                  <Menu.Item
+                    testID="postDropdownBlockAccountBtn"
+                    label={_(msg`Block account`)}
+                    onPress={onBlockAccount}>
+                    <Menu.ItemText>{_(msg`Block account`)}</Menu.ItemText>
+                    <Menu.ItemIcon icon={PersonX} position="right" />
+                  </Menu.Item>
+                </>
               </Menu.Group>
             </>
           )}


### PR DESCRIPTION
Reopening with adjustments because I accidentally closed #2610.

<img width="612" alt="Screenshot 2024-04-25 at 3 40 29 PM" src="https://github.com/bluesky-social/social-app/assets/8646557/893f3c0b-4205-4234-a63c-76eb34607811">

### Original PR Description
This PR adds Mute Account and Block Account buttons to the Post dropdown menu to close issue https://github.com/bluesky-social/social-app/issues/1017.