### PR TITLE
[Session] V2

### DIFF
--- a/src/screens/Login/ChooseAccountForm.tsx
+++ b/src/screens/Login/ChooseAccountForm.tsx
@@ -5,6 +5,7 @@ import {useLingui} from '@lingui/react'
 
 import {useAnalytics} from '#/lib/analytics/analytics'
 import {logEvent} from '#/lib/statsig/statsig'
+import {logger} from '#/logger'
 import {SessionAccount, useSession, useSessionApi} from '#/state/session'
 import {useLoggedOutViewControls} from '#/state/shell/logged-out'
 import * as Toast from '#/view/com/util/Toast'
@@ -38,15 +39,22 @@ export const ChooseAccountForm = ({
           setShowLoggedOut(false)
           Toast.show(_(msg`Already signed in as @${account.handle}`))
         } else {
-          await initSession(account)
-          logEvent('account:loggedIn', {
-            logContext: 'ChooseAccountForm',
-            withPassword: false,
-          })
-          track('Sign In', {resumedSession: true})
-          setTimeout(() => {
-            Toast.show(_(msg`Signed in as @${account.handle}`))
-          }, 100)
+          try {
+            await initSession(account)
+            logEvent('account:loggedIn', {
+              logContext: 'ChooseAccountForm',
+              withPassword: false,
+            })
+            track('Sign In', {resumedSession: true})
+            setTimeout(() => {
+              Toast.show(_(msg`Signed in as @${account.handle}`))
+            }, 100)
+          } catch (e: any) {
+            logger.error('choose account: initSession failed', {
+              message: e.message,
+            })
+            onSelectAccount(account)
+          }
         }
       } else {
         onSelectAccount(account)

--- a/src/state/session/index.tsx
+++ b/src/state/session/index.tsx
@@ -1,7 +1,7 @@
 import * as V1 from '#/state/session/v1'
 import * as V2 from '#/state/session/v2'
 
-export type {SessionAccount} from '#/state/session/v1'
+export type {CurrentAccount, SessionAccount} from '#/state/session/types'
 
 const isV2 = false
 

--- a/src/state/session/types.ts
+++ b/src/state/session/types.ts
@@ -1,0 +1,88 @@
+import {BskyAgent} from '@atproto/api'
+
+import {LogEvents} from '#/lib/statsig/statsig'
+import {PersistedAccount} from '#/state/persisted'
+
+/**
+ * Alias for `PersistedAccount` from persisted storage.
+ */
+export type SessionAccount = PersistedAccount
+
+/**
+ * Subset of `SessionAccount` that excludes tokens.
+ */
+export type CurrentAccount = Omit<SessionAccount, 'accessJwt' | 'refreshJwt'>
+
+/**
+ * Context shape returned from `useSession()`
+ */
+export type SessionStateContext = {
+  currentAgent: BskyAgent
+  isInitialLoad: boolean
+  isSwitchingAccounts: boolean
+  hasSession: boolean
+  accounts: SessionAccount[]
+  /**
+   * Contains the full account object persisted to storage, minus access
+   * tokens.
+   */
+  currentAccount: CurrentAccount | undefined
+}
+
+/**
+ * Context shape returned from `useSessionApi()`
+ */
+export type SessionApiContext = {
+  createAccount: (props: {
+    service: string
+    email: string
+    password: string
+    handle: string
+    inviteCode?: string
+    verificationPhone?: string
+    verificationCode?: string
+  }) => Promise<void>
+  login: (
+    props: {
+      service: string
+      identifier: string
+      password: string
+    },
+    logContext: LogEvents['account:loggedIn']['logContext'],
+  ) => Promise<void>
+  /**
+   * A full logout. Clears the `currentAccount` from session, AND removes
+   * access tokens from all accounts, so that returning as any user will
+   * require a full login.
+   */
+  logout: (
+    logContext: LogEvents['account:loggedOut']['logContext'],
+  ) => Promise<void>
+  /**
+   * A partial logout. Clears the `currentAccount` from session, but DOES NOT
+   * clear access tokens from accounts, allowing the user to return to their
+   * other accounts without logging in.
+   *
+   * Used when adding a new account, deleting an account.
+   */
+  clearCurrentAccount: () => void
+  initSession: (account: SessionAccount) => Promise<void>
+  resumeSession: (account?: SessionAccount) => Promise<void>
+  removeAccount: (account: SessionAccount) => void
+  selectAccount: (
+    account: SessionAccount,
+    logContext: LogEvents['account:loggedIn']['logContext'],
+  ) => Promise<void>
+  /**
+   * Refreshes the BskyAgent's session and derive a fresh `currentAccount`
+   */
+  refreshSession: () => void
+  /**
+   * @deprecated Use `refreshSession` instead.
+   */
+  updateCurrentAccount: (
+    account: Partial<
+      Pick<SessionAccount, 'handle' | 'email' | 'emailConfirmed'>
+    >,
+  ) => void
+}

--- a/src/state/session/util/index.ts
+++ b/src/state/session/util/index.ts
@@ -1,0 +1,179 @@
+import {BSKY_LABELER_DID, BskyAgent} from '@atproto/api'
+import {jwtDecode} from 'jwt-decode'
+
+import {IS_TEST_USER} from '#/lib/constants'
+import {hasProp} from '#/lib/type-guards'
+import {logger} from '#/logger'
+import * as persisted from '#/state/persisted'
+import {readLabelers} from '#/state/session/agent-config'
+import {SessionAccount, SessionApiContext} from '#/state/session/types'
+
+export function isSessionDeactivated(accessJwt: string | undefined) {
+  if (accessJwt) {
+    const sessData = jwtDecode(accessJwt)
+    return (
+      hasProp(sessData, 'scope') && sessData.scope === 'com.atproto.deactivated'
+    )
+  }
+  return false
+}
+
+export function readLastActiveAccount() {
+  const {currentAccount, accounts} = persisted.get('session')
+  return accounts.find(a => a.did === currentAccount?.did)
+}
+
+export function agentToSessionAccount(
+  agent: BskyAgent,
+): SessionAccount | undefined {
+  if (!agent.session) return undefined
+
+  return {
+    service: agent.service.toString(),
+    did: agent.session.did,
+    handle: agent.session.handle,
+    email: agent.session.email,
+    emailConfirmed: agent.session.emailConfirmed,
+    deactivated: isSessionDeactivated(agent.session.accessJwt),
+    refreshJwt: agent.session.refreshJwt,
+    accessJwt: agent.session.accessJwt,
+  }
+}
+
+export function sessionAccountToAgentSession(
+  account: SessionAccount,
+): BskyAgent['session'] {
+  return {
+    did: account.did,
+    handle: account.handle,
+    email: account.email,
+    emailConfirmed: account.emailConfirmed,
+    accessJwt: account.accessJwt || '',
+    refreshJwt: account.refreshJwt || '',
+  }
+}
+
+export async function configureModeration(
+  agent: BskyAgent,
+  account?: SessionAccount,
+) {
+  if (account) {
+    if (IS_TEST_USER(account.handle)) {
+      const did = (
+        await agent
+          .resolveHandle({handle: 'mod-authority.test'})
+          .catch(_ => undefined)
+      )?.data.did
+      if (did) {
+        console.warn('USING TEST ENV MODERATION')
+        BskyAgent.configure({appLabelers: [did]})
+      }
+    } else {
+      BskyAgent.configure({appLabelers: [BSKY_LABELER_DID]})
+
+      if (account) {
+        const labelerDids = await readLabelers(account.did).catch(_ => {})
+        if (labelerDids) {
+          agent.configureLabelersHeader(
+            labelerDids.filter(did => did !== BSKY_LABELER_DID),
+          )
+        }
+      }
+    }
+  } else {
+    BskyAgent.configure({appLabelers: [BSKY_LABELER_DID]})
+  }
+}
+
+export function isSessionExpired(account: SessionAccount) {
+  let canReusePrevSession = false
+  try {
+    if (account.accessJwt) {
+      const decoded = jwtDecode(account.accessJwt)
+      if (decoded.exp) {
+        const didExpire = Date.now() >= decoded.exp * 1000
+        if (!didExpire) {
+          canReusePrevSession = true
+        }
+      }
+    }
+  } catch (e) {
+    logger.error(`session: could not decode jwt`)
+  }
+
+  return !canReusePrevSession
+}
+
+export async function createAgentAndLogin({
+  service,
+  identifier,
+  password,
+}: {
+  service: string
+  identifier: string
+  password: string
+}) {
+  const agent = new BskyAgent({service})
+  await agent.login({identifier, password})
+
+  if (!agent.session) {
+    throw new Error(`session: login failed to establish a session`)
+  }
+
+  const account = agentToSessionAccount(agent)!
+  await configureModeration(agent, account)
+
+  return {
+    agent,
+    account,
+  }
+}
+
+export async function createAgentAndCreateAccount({
+  service,
+  email,
+  password,
+  handle,
+  inviteCode,
+  verificationPhone,
+  verificationCode,
+}: Parameters<SessionApiContext['createAccount']>[0]) {
+  const agent = new BskyAgent({service})
+
+  await agent.createAccount({
+    handle,
+    password,
+    email,
+    inviteCode,
+    verificationPhone,
+    verificationCode,
+  })
+
+  if (!agent.session) {
+    throw new Error(`session: createAccount failed to establish a session`)
+  }
+
+  const deactivated = isSessionDeactivated(agent.session.accessJwt)
+  if (!deactivated) {
+    /*dont await*/ agent.upsertProfile(_existing => {
+      return {
+        displayName: '',
+
+        // HACKFIX
+        // creating a bunch of identical profile objects is breaking the relay
+        // tossing this unspecced field onto it to reduce the size of the problem
+        // -prf
+        createdAt: new Date().toISOString(),
+      }
+    })
+  }
+
+  const account = agentToSessionAccount(agent)!
+
+  await configureModeration(agent, account)
+
+  return {
+    agent,
+    account,
+  }
+}

--- a/src/state/session/v2.tsx
+++ b/src/state/session/v2.tsx
@@ -28,6 +28,7 @@ import {IS_DEV} from '#/env'
 import {emitSessionDropped} from '../events'
 
 export type {CurrentAccount, SessionAccount} from '#/state/session/types'
+export {isSessionDeactivated} from '#/state/session/util'
 
 /**
  * Only used for the initial agent values in state and context. Replaced

--- a/src/state/session/v2.tsx
+++ b/src/state/session/v2.tsx
@@ -1,103 +1,42 @@
 import React from 'react'
-import {
-  AtpPersistSessionHandler,
-  BSKY_LABELER_DID,
-  BskyAgent,
-} from '@atproto/api'
-import {jwtDecode} from 'jwt-decode'
+import {BskyAgent} from '@atproto/api'
 
 import {track} from '#/lib/analytics/analytics'
 import {networkRetry} from '#/lib/async/retry'
-import {IS_TEST_USER} from '#/lib/constants'
-import {logEvent, LogEvents, tryFetchGates} from '#/lib/statsig/statsig'
-import {hasProp} from '#/lib/type-guards'
+import {PUBLIC_BSKY_SERVICE} from '#/lib/constants'
+import {logEvent} from '#/lib/statsig/statsig'
 import {logger} from '#/logger'
 import {isWeb} from '#/platform/detection'
 import * as persisted from '#/state/persisted'
-import {PUBLIC_BSKY_AGENT} from '#/state/queries'
+import {
+  SessionAccount,
+  SessionApiContext,
+  SessionStateContext,
+} from '#/state/session/types'
+import {
+  agentToSessionAccount,
+  configureModeration,
+  createAgentAndCreateAccount,
+  createAgentAndLogin,
+  isSessionExpired,
+  sessionAccountToAgentSession,
+} from '#/state/session/util'
+import {useLoggedOutViewControls} from '#/state/shell/logged-out'
 import {useCloseAllActiveElements} from '#/state/util'
-import {useGlobalDialogsControlContext} from '#/components/dialogs/Context'
+import * as Toast from '#/view/com/util/Toast'
 import {IS_DEV} from '#/env'
 import {emitSessionDropped} from '../events'
-import {readLabelers} from './agent-config'
 
-let __globalAgent: BskyAgent = PUBLIC_BSKY_AGENT
+export type {CurrentAccount, SessionAccount} from '#/state/session/types'
 
-export function useAgent() {
-  return React.useMemo(
-    () => ({
-      getAgent() {
-        return __globalAgent
-      },
-    }),
-    [],
-  )
-}
+/**
+ * Only used for the initial agent values in state and context. Replaced
+ * immediately, and should not be reused.
+ */
+const INITIAL_AGENT = new BskyAgent({service: PUBLIC_BSKY_SERVICE})
 
-export type SessionAccount = persisted.PersistedAccount
-
-export type SessionState = {
-  isInitialLoad: boolean
-  isSwitchingAccounts: boolean
-  accounts: SessionAccount[]
-  currentAccount: SessionAccount | undefined
-}
-export type StateContext = SessionState & {
-  hasSession: boolean
-}
-export type ApiContext = {
-  createAccount: (props: {
-    service: string
-    email: string
-    password: string
-    handle: string
-    inviteCode?: string
-    verificationPhone?: string
-    verificationCode?: string
-  }) => Promise<void>
-  login: (
-    props: {
-      service: string
-      identifier: string
-      password: string
-      authFactorToken?: string | undefined
-    },
-    logContext: LogEvents['account:loggedIn']['logContext'],
-  ) => Promise<void>
-  /**
-   * A full logout. Clears the `currentAccount` from session, AND removes
-   * access tokens from all accounts, so that returning as any user will
-   * require a full login.
-   */
-  logout: (
-    logContext: LogEvents['account:loggedOut']['logContext'],
-  ) => Promise<void>
-  /**
-   * A partial logout. Clears the `currentAccount` from session, but DOES NOT
-   * clear access tokens from accounts, allowing the user to return to their
-   * other accounts without logging in.
-   *
-   * Used when adding a new account, deleting an account.
-   */
-  clearCurrentAccount: () => void
-  initSession: (account: SessionAccount) => Promise<void>
-  resumeSession: (account?: SessionAccount) => Promise<void>
-  removeAccount: (account: SessionAccount) => void
-  selectAccount: (
-    account: SessionAccount,
-    logContext: LogEvents['account:loggedIn']['logContext'],
-  ) => Promise<void>
-  updateCurrentAccount: (
-    account: Partial<
-      Pick<
-        SessionAccount,
-        'handle' | 'email' | 'emailConfirmed' | 'emailAuthFactor'
-      >
-    >,
-  ) => void
-}
-
-const StateContext = React.createContext<StateContext>({
+const StateContext = React.createContext<SessionStateContext>({
+  currentAgent: INITIAL_AGENT,
   isInitialLoad: true,
   isSwitchingAccounts: false,
   accounts: [],
@@ -105,7 +44,7 @@ const StateContext = React.createContext<StateContext>({
   hasSession: false,
 })
 
-const ApiContext = React.createContext<ApiContext>({
+const ApiContext = React.createContext<SessionApiContext>({
   createAccount: async () => {},
   login: async () => {},
   logout: async () => {},
@@ -113,116 +52,136 @@ const ApiContext = React.createContext<ApiContext>({
   resumeSession: async () => {},
   removeAccount: () => {},
   selectAccount: async () => {},
-  updateCurrentAccount: () => {},
+  refreshSession: () => {},
   clearCurrentAccount: () => {},
+  updateCurrentAccount: async () => {},
 })
-
-function createPersistSessionHandler(
-  agent: BskyAgent,
-  account: SessionAccount,
-  persistSessionCallback: (props: {
-    expired: boolean
-    refreshedAccount: SessionAccount
-  }) => void,
-  {
-    networkErrorCallback,
-  }: {
-    networkErrorCallback?: () => void
-  } = {},
-): AtpPersistSessionHandler {
-  return function persistSession(event, session) {
-    const expired = event === 'expired' || event === 'create-failed'
-
-    if (event === 'network-error') {
-      logger.warn(`session: persistSessionHandler received network-error event`)
-      networkErrorCallback?.()
-      return
-    }
-
-    const refreshedAccount: SessionAccount = {
-      service: account.service,
-      did: session?.did || account.did,
-      handle: session?.handle || account.handle,
-      email: session?.email || account.email,
-      emailConfirmed: session?.emailConfirmed || account.emailConfirmed,
-      deactivated: isSessionDeactivated(session?.accessJwt),
-      pdsUrl: agent.pdsUrl?.toString(),
-
-      /*
-       * Tokens are undefined if the session expires, or if creation fails for
-       * any reason e.g. tokens are invalid, network error, etc.
-       */
-      refreshJwt: session?.refreshJwt,
-      accessJwt: session?.accessJwt,
-    }
-
-    logger.debug(`session: persistSession`, {
-      event,
-      deactivated: refreshedAccount.deactivated,
-    })
-
-    if (expired) {
-      logger.warn(`session: expired`)
-      emitSessionDropped()
-    }
-
-    /*
-     * If the session expired, or it was successfully created/updated, we want
-     * to update/persist the data.
-     *
-     * If the session creation failed, it could be a network error, or it could
-     * be more serious like an invalid token(s). We can't differentiate, so in
-     * order to allow the user to get a fresh token (if they need it), we need
-     * to persist this data and wipe their tokens, effectively logging them
-     * out.
-     */
-    persistSessionCallback({
-      expired,
-      refreshedAccount,
-    })
-  }
-}
 
 export function Provider({children}: React.PropsWithChildren<{}>) {
   const isDirty = React.useRef(false)
-  const [state, setState] = React.useState<SessionState>({
-    isInitialLoad: true,
-    isSwitchingAccounts: false,
-    accounts: persisted.get('session').accounts,
-    currentAccount: undefined, // assume logged out to start
-  })
-
-  const setStateAndPersist = React.useCallback(
-    (fn: (prev: SessionState) => SessionState) => {
-      isDirty.current = true
-      setState(fn)
-    },
-    [setState],
+  const [currentAgent, setCurrentAgent] =
+    React.useState<BskyAgent>(INITIAL_AGENT)
+  const [accounts, setAccounts] = React.useState<SessionAccount[]>(
+    persisted.get('session').accounts,
+  )
+  const [isInitialLoad, setIsInitialLoad] = React.useState(true)
+  const [isSwitchingAccounts, setIsSwitchingAccounts] = React.useState(false)
+  const currentAccountDid = React.useMemo(
+    () => currentAgent.session?.did,
+    [currentAgent],
+  )
+  const currentAccount = React.useMemo(
+    () => accounts.find(a => a.did === currentAccountDid),
+    [accounts, currentAccountDid],
   )
 
-  const upsertAccount = React.useCallback(
-    (account: SessionAccount, expired = false) => {
-      setStateAndPersist(s => {
-        return {
-          ...s,
-          currentAccount: expired ? undefined : account,
-          accounts: [account, ...s.accounts.filter(a => a.did !== account.did)],
-        }
-      })
+  const persistNextUpdate = React.useCallback(
+    () => (isDirty.current = true),
+    [],
+  )
+
+  const upsertAndPersistAccount = React.useCallback(
+    (account: SessionAccount) => {
+      persistNextUpdate()
+      setAccounts(accounts => [
+        account,
+        ...accounts.filter(a => a.did !== account.did),
+      ])
     },
-    [setStateAndPersist],
+    [setAccounts, persistNextUpdate],
   )
 
   const clearCurrentAccount = React.useCallback(() => {
     logger.warn(`session: clear current account`)
-    __globalAgent = PUBLIC_BSKY_AGENT
-    setStateAndPersist(s => ({
-      ...s,
-      currentAccount: undefined,
-    }))
-  }, [setStateAndPersist])
 
-  const createAccount = React.useCallback<ApiContext['createAccount']>(
+    // immediate clear this so any pending requests don't use it
+    currentAgent.setPersistSessionHandler(() => {})
+
+    persistNextUpdate()
+
+    const newAgent = new BskyAgent({service: PUBLIC_BSKY_SERVICE})
+    setCurrentAgent(newAgent)
+    configureModeration(newAgent)
+  }, [currentAgent, persistNextUpdate, setCurrentAgent])
+
+  React.useEffect(() => {
+    /*
+     * This method is continually overwritten when `currentAgent` and dependent
+     * methods local to this file change, so that the freshest agent and
+     * handlers are always used.
+     */
+    currentAgent.setPersistSessionHandler(event => {
+      logger.debug(
+        `session: persistSession`,
+        {event},
+        logger.DebugContext.session,
+      )
+
+      const expired = event === 'expired' || event === 'create-failed'
+
+      /*
+       * Special case for a network error that occurs when calling
+       * `resumeSession`, which happens on page load, when switching
+       * accounts, or when refreshing user session data.
+       *
+       * When this occurs, we drop the user back out to the login screen, but
+       * we don't clear tokens, allowing them to quickly log back in when their
+       * connection improves.
+       */
+      if (event === 'network-error') {
+        logger.warn(
+          `session: persistSessionHandler received network-error event`,
+        )
+        emitSessionDropped()
+        clearCurrentAccount()
+        setTimeout(() => {
+          Toast.show(`Your internet connection is unstable. Please try again.`)
+        }, 100)
+        return
+      }
+
+      /*
+       * If the session was expired naturally, we want to drop the user back
+       * out to log in.
+       */
+      if (expired) {
+        logger.warn(`session: expired`)
+        emitSessionDropped()
+        clearCurrentAccount()
+        setTimeout(() => {
+          Toast.show(`Sorry! We need you to enter your password.`)
+        }, 100)
+      }
+
+      /**
+       * The updated account object, derived from the updated session we just
+       * received from this callback.
+       */
+      const refreshedAccount = agentToSessionAccount(currentAgent)
+
+      if (refreshedAccount) {
+        /*
+         * If the session expired naturally, or it was otherwise successfully
+         * created/updated, we want to update/persist the data.
+         */
+        upsertAndPersistAccount(refreshedAccount)
+      } else {
+        /*
+         * This should never happen based on current `AtpAgent` handling, but
+         * it's here for TypeScript, and should result in the same handling as
+         * a session expiration.
+         */
+        logger.error(`session: persistSession failed to get refreshed account`)
+        emitSessionDropped()
+        clearCurrentAccount()
+        setTimeout(() => {
+          Toast.show(`Sorry! We need you to enter your password.`)
+        }, 100)
+      }
+    })
+  }, [currentAgent, clearCurrentAccount, upsertAndPersistAccount])
+
+  const createAccount = React.useCallback<SessionApiContext['createAccount']>(
     async ({
       service,
       email,
@@ -236,9 +195,8 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
       track('Try Create Account')
       logEvent('account:create:begin', {})
 
-      const agent = new BskyAgent({service})
-
-      await agent.createAccount({
+      const {agent, account} = await createAgentAndCreateAccount({
+        service,
         handle,
         password,
         email,
@@ -247,281 +205,109 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
         verificationCode,
       })
 
-      if (!agent.session) {
-        throw new Error(`session: createAccount failed to establish a session`)
-      }
-      const fetchingGates = tryFetchGates(
-        agent.session.did,
-        'prefer-fresh-gates',
-      )
-
-      const deactivated = isSessionDeactivated(agent.session.accessJwt)
-      if (!deactivated) {
-        /*dont await*/ agent.upsertProfile(_existing => {
-          return {
-            displayName: '',
-
-            // HACKFIX
-            // creating a bunch of identical profile objects is breaking the relay
-            // tossing this unspecced field onto it to reduce the size of the problem
-            // -prf
-            createdAt: new Date().toISOString(),
-          }
-        })
-      }
-
-      const account: SessionAccount = {
-        service: agent.service.toString(),
-        did: agent.session.did,
-        handle: agent.session.handle,
-        email: agent.session.email!, // TODO this is always defined?
-        emailConfirmed: false,
-        refreshJwt: agent.session.refreshJwt,
-        accessJwt: agent.session.accessJwt,
-        deactivated,
-        pdsUrl: agent.pdsUrl?.toString(),
-      }
-
-      await configureModeration(agent, account)
-
-      agent.setPersistSessionHandler(
-        createPersistSessionHandler(
-          agent,
-          account,
-          ({expired, refreshedAccount}) => {
-            upsertAccount(refreshedAccount, expired)
-          },
-          {networkErrorCallback: clearCurrentAccount},
-        ),
-      )
-
-      __globalAgent = agent
-      await fetchingGates
-      upsertAccount(account)
+      setCurrentAgent(agent)
+      upsertAndPersistAccount(account)
 
       logger.debug(`session: created account`, {}, logger.DebugContext.session)
       track('Create Account')
       logEvent('account:create:success', {})
     },
-    [upsertAccount, clearCurrentAccount],
+    [upsertAndPersistAccount],
   )
 
-  const login = React.useCallback<ApiContext['login']>(
-    async ({service, identifier, password, authFactorToken}, logContext) => {
+  const login = React.useCallback<SessionApiContext['login']>(
+    async ({service, identifier, password}, logContext) => {
       logger.debug(`session: login`, {}, logger.DebugContext.session)
 
-      const agent = new BskyAgent({service})
+      const {agent, account} = await createAgentAndLogin({
+        service,
+        identifier,
+        password,
+      })
 
-      await agent.login({identifier, password, authFactorToken})
-
-      if (!agent.session) {
-        throw new Error(`session: login failed to establish a session`)
-      }
-      const fetchingGates = tryFetchGates(
-        agent.session.did,
-        'prefer-fresh-gates',
-      )
-
-      const account: SessionAccount = {
-        service: agent.service.toString(),
-        did: agent.session.did,
-        handle: agent.session.handle,
-        email: agent.session.email,
-        emailConfirmed: agent.session.emailConfirmed || false,
-        emailAuthFactor: agent.session.emailAuthFactor,
-        refreshJwt: agent.session.refreshJwt,
-        accessJwt: agent.session.accessJwt,
-        deactivated: isSessionDeactivated(agent.session.accessJwt),
-        pdsUrl: agent.pdsUrl?.toString(),
-      }
-
-      await configureModeration(agent, account)
-
-      agent.setPersistSessionHandler(
-        createPersistSessionHandler(
-          agent,
-          account,
-          ({expired, refreshedAccount}) => {
-            upsertAccount(refreshedAccount, expired)
-          },
-          {networkErrorCallback: clearCurrentAccount},
-        ),
-      )
-
-      __globalAgent = agent
-      // @ts-ignore
-      if (IS_DEV && isWeb) window.agent = agent
-      await fetchingGates
-      upsertAccount(account)
+      setCurrentAgent(agent)
+      upsertAndPersistAccount(account)
 
       logger.debug(`session: logged in`, {}, logger.DebugContext.session)
-
       track('Sign In', {resumedSession: false})
       logEvent('account:loggedIn', {logContext, withPassword: true})
     },
-    [upsertAccount, clearCurrentAccount],
+    [upsertAndPersistAccount],
   )
 
-  const logout = React.useCallback<ApiContext['logout']>(
+  const logout = React.useCallback<SessionApiContext['logout']>(
     async logContext => {
       logger.debug(`session: logout`)
+
       clearCurrentAccount()
-      setStateAndPersist(s => {
-        return {
-          ...s,
-          accounts: s.accounts.map(a => ({
-            ...a,
-            refreshJwt: undefined,
-            accessJwt: undefined,
-          })),
-        }
-      })
-      logEvent('account:loggedOut', {logContext})
-    },
-    [clearCurrentAccount, setStateAndPersist],
-  )
-
-  const initSession = React.useCallback<ApiContext['initSession']>(
-    async account => {
-      logger.debug(`session: initSession`, {}, logger.DebugContext.session)
-      const fetchingGates = tryFetchGates(account.did, 'prefer-low-latency')
-
-      const agent = new BskyAgent({service: account.service})
-
-      // restore the correct PDS URL if available
-      if (account.pdsUrl) {
-        agent.pdsUrl = agent.api.xrpc.uri = new URL(account.pdsUrl)
-      }
-
-      agent.setPersistSessionHandler(
-        createPersistSessionHandler(
-          agent,
-          account,
-          ({expired, refreshedAccount}) => {
-            upsertAccount(refreshedAccount, expired)
-          },
-          {networkErrorCallback: clearCurrentAccount},
-        ),
+      persistNextUpdate()
+      setAccounts(accounts =>
+        accounts.map(a => ({
+          ...a,
+          accessJwt: undefined,
+          refreshJwt: undefined,
+        })),
       )
 
-      // @ts-ignore
-      if (IS_DEV && isWeb) window.agent = agent
-      await configureModeration(agent, account)
-
-      let canReusePrevSession = false
-      try {
-        if (account.accessJwt) {
-          const decoded = jwtDecode(account.accessJwt)
-          if (decoded.exp) {
-            const didExpire = Date.now() >= decoded.exp * 1000
-            if (!didExpire) {
-              canReusePrevSession = true
-            }
-          }
-        }
-      } catch (e) {
-        logger.error(`session: could not decode jwt`)
-      }
-
-      const prevSession = {
-        accessJwt: account.accessJwt || '',
-        refreshJwt: account.refreshJwt || '',
-        did: account.did,
-        handle: account.handle,
-        deactivated:
-          isSessionDeactivated(account.accessJwt) || account.deactivated,
-      }
-
-      if (canReusePrevSession) {
-        logger.debug(`session: attempting to reuse previous session`)
-
-        agent.session = prevSession
-
-        __globalAgent = agent
-        await fetchingGates
-        upsertAccount(account)
-
-        if (prevSession.deactivated) {
-          // don't attempt to resume
-          // use will be taken to the deactivated screen
-          logger.debug(`session: reusing session for deactivated account`)
-          return
-        }
-
-        // Intentionally not awaited to unblock the UI:
-        resumeSessionWithFreshAccount()
-          .then(freshAccount => {
-            if (JSON.stringify(account) !== JSON.stringify(freshAccount)) {
-              logger.info(
-                `session: reuse of previous session returned a fresh account, upserting`,
-              )
-              upsertAccount(freshAccount)
-            }
-          })
-          .catch(e => {
-            /*
-             * Note: `agent.persistSession` is also called when this fails, and
-             * we handle that failure via `createPersistSessionHandler`
-             */
-            logger.info(`session: resumeSessionWithFreshAccount failed`, {
-              message: e,
-            })
-
-            __globalAgent = PUBLIC_BSKY_AGENT
-          })
-      } else {
-        logger.debug(`session: attempting to resume using previous session`)
-
-        try {
-          const freshAccount = await resumeSessionWithFreshAccount()
-          __globalAgent = agent
-          await fetchingGates
-          upsertAccount(freshAccount)
-        } catch (e) {
-          /*
-           * Note: `agent.persistSession` is also called when this fails, and
-           * we handle that failure via `createPersistSessionHandler`
-           */
-          logger.info(`session: resumeSessionWithFreshAccount failed`, {
-            message: e,
-          })
-
-          __globalAgent = PUBLIC_BSKY_AGENT
-        }
-      }
-
-      async function resumeSessionWithFreshAccount(): Promise<SessionAccount> {
-        logger.debug(`session: resumeSessionWithFreshAccount`)
-
-        await networkRetry(1, () => agent.resumeSession(prevSession))
-
-        /*
-         * If `agent.resumeSession` fails above, it'll throw. This is just to
-         * make TypeScript happy.
-         */
-        if (!agent.session) {
-          throw new Error(`session: initSession failed to establish a session`)
-        }
-
-        // ensure changes in handle/email etc are captured on reload
-        return {
-          service: agent.service.toString(),
-          did: agent.session.did,
-          handle: agent.session.handle,
-          email: agent.session.email,
-          emailConfirmed: agent.session.emailConfirmed || false,
-          emailAuthFactor: agent.session.emailAuthFactor || false,
-          refreshJwt: agent.session.refreshJwt,
-          accessJwt: agent.session.accessJwt,
-          deactivated: isSessionDeactivated(agent.session.accessJwt),
-          pdsUrl: agent.pdsUrl?.toString(),
-        }
-      }
+      logEvent('account:loggedOut', {logContext})
     },
-    [upsertAccount, clearCurrentAccount],
+    [clearCurrentAccount, persistNextUpdate, setAccounts],
   )
 
-  const resumeSession = React.useCallback<ApiContext['resumeSession']>(
+  const initSession = React.useCallback<SessionApiContext['initSession']>(
+    async account => {
+      logger.debug(`session: initSession`, {}, logger.DebugContext.session)
+
+      const newAgent = new BskyAgent({
+        service: account.service,
+      })
+
+      const prevSession = {
+        ...account,
+        accessJwt: account.accessJwt || '',
+        refreshJwt: account.refreshJwt || '',
+      }
+
+      /**
+       * Optimistically update moderation services so that when the new agent
+       * is applied, they're ready.
+       *
+       * If session resumption fails, this will be reset by
+       * `clearCurrentAccount`.
+       */
+      await configureModeration(newAgent, account)
+
+      if (isSessionExpired(account)) {
+        /*
+         * If session is expired, attempt to refresh the session using the
+         * refresh token via `resumeSession`
+         */
+        logger.debug(
+          `session: attempting to resumeSession using previous session`,
+          {},
+          logger.DebugContext.session,
+        )
+        await networkRetry(1, () => newAgent.resumeSession(prevSession))
+        setCurrentAgent(newAgent)
+        upsertAndPersistAccount(agentToSessionAccount(newAgent)!)
+      } else {
+        /*
+         * If the session is not expired, assume we can reuse it.
+         */
+        logger.debug(
+          `session: attempting to reuse previous session`,
+          {},
+          logger.DebugContext.session,
+        )
+        newAgent.session = prevSession
+        setCurrentAgent(newAgent)
+        upsertAndPersistAccount(account)
+      }
+    },
+    [upsertAndPersistAccount],
+  )
+
+  const resumeSession = React.useCallback<SessionApiContext['resumeSession']>(
     async account => {
       try {
         if (account) {
@@ -530,123 +316,129 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
       } catch (e) {
         logger.error(`session: resumeSession failed`, {message: e})
       } finally {
-        setState(s => ({
-          ...s,
-          isInitialLoad: false,
-        }))
+        setIsInitialLoad(false)
       }
     },
-    [initSession],
+    [initSession, setIsInitialLoad],
   )
 
-  const removeAccount = React.useCallback<ApiContext['removeAccount']>(
+  const removeAccount = React.useCallback<SessionApiContext['removeAccount']>(
     account => {
-      setStateAndPersist(s => {
-        return {
-          ...s,
-          accounts: s.accounts.filter(a => a.did !== account.did),
-        }
-      })
+      persistNextUpdate()
+      setAccounts(accounts => accounts.filter(a => a.did !== account.did))
     },
-    [setStateAndPersist],
+    [setAccounts, persistNextUpdate],
   )
 
-  const updateCurrentAccount = React.useCallback<
-    ApiContext['updateCurrentAccount']
-  >(
-    account => {
-      setStateAndPersist(s => {
-        const currentAccount = s.currentAccount
+  const refreshSession = React.useCallback<
+    SessionApiContext['refreshSession']
+  >(async () => {
+    const {accounts: persistedAccounts} = persisted.get('session')
+    const selectedAccount = persistedAccounts.find(
+      a => a.did === currentAccountDid,
+    )
+    if (!selectedAccount) return
 
-        // ignore, should never happen
-        if (!currentAccount) return s
+    // update and swap agent to trigger render refresh
+    const newAgent = currentAgent.clone()
+    await newAgent.resumeSession(sessionAccountToAgentSession(selectedAccount)!)
+    const refreshedAccount = agentToSessionAccount(newAgent)
+    persistNextUpdate()
+    upsertAndPersistAccount(refreshedAccount!)
+    setCurrentAgent(newAgent)
+    configureModeration(newAgent, refreshedAccount)
+  }, [
+    currentAccountDid,
+    currentAgent,
+    setCurrentAgent,
+    persistNextUpdate,
+    upsertAndPersistAccount,
+  ])
 
-        const updatedAccount = {
-          ...currentAccount,
-          handle: account.handle || currentAccount.handle,
-          email: account.email || currentAccount.email,
-          emailConfirmed:
-            account.emailConfirmed !== undefined
-              ? account.emailConfirmed
-              : currentAccount.emailConfirmed,
-          emailAuthFactor:
-            account.emailAuthFactor !== undefined
-              ? account.emailAuthFactor
-              : currentAccount.emailAuthFactor,
-        }
+  const updateCurrentAccount = React.useCallback(async () => {
+    await refreshSession()
+  }, [refreshSession])
 
-        return {
-          ...s,
-          currentAccount: updatedAccount,
-          accounts: [
-            updatedAccount,
-            ...s.accounts.filter(a => a.did !== currentAccount.did),
-          ],
-        }
-      })
-    },
-    [setStateAndPersist],
-  )
-
-  const selectAccount = React.useCallback<ApiContext['selectAccount']>(
+  const selectAccount = React.useCallback<SessionApiContext['selectAccount']>(
     async (account, logContext) => {
-      setState(s => ({...s, isSwitchingAccounts: true}))
+      setIsSwitchingAccounts(true)
       try {
         await initSession(account)
-        setState(s => ({...s, isSwitchingAccounts: false}))
+        setIsSwitchingAccounts(false)
         logEvent('account:loggedIn', {logContext, withPassword: false})
       } catch (e) {
         // reset this in case of error
-        setState(s => ({...s, isSwitchingAccounts: false}))
+        setIsSwitchingAccounts(false)
         // but other listeners need a throw
         throw e
       }
     },
-    [setState, initSession],
+    [setIsSwitchingAccounts, initSession],
   )
 
   React.useEffect(() => {
     if (isDirty.current) {
       isDirty.current = false
       persisted.write('session', {
-        accounts: state.accounts,
-        currentAccount: state.currentAccount,
+        accounts,
+        currentAccount,
       })
     }
-  }, [state])
+  }, [accounts, currentAccount])
 
   React.useEffect(() => {
-    return persisted.onUpdate(() => {
-      const session = persisted.get('session')
+    return persisted.onUpdate(async () => {
+      const persistedSession = persisted.get('session')
 
-      logger.debug(`session: persisted onUpdate`, {})
+      logger.debug(
+        `session: persisted onUpdate`,
+        {},
+        logger.DebugContext.session,
+      )
 
-      if (session.currentAccount && session.currentAccount.refreshJwt) {
-        if (session.currentAccount?.did !== state.currentAccount?.did) {
-          logger.debug(`session: persisted onUpdate, switching accounts`, {
-            from: {
-              did: state.currentAccount?.did,
-              handle: state.currentAccount?.handle,
+      /*
+       * Accounts are already persisted on other side of broadcast, but we need
+       * to update them in memory in this tab.
+       */
+      setAccounts(persistedSession.accounts)
+
+      const selectedAccount = persistedSession.accounts.find(
+        a => a.did === persistedSession.currentAccount?.did,
+      )
+
+      if (selectedAccount && selectedAccount.refreshJwt) {
+        if (selectedAccount?.did !== currentAccountDid) {
+          logger.debug(
+            `session: persisted onUpdate, switching accounts`,
+            {
+              from: {
+                did: currentAccountDid,
+              },
+              to: {
+                did: selectedAccount.did,
+              },
             },
-            to: {
-              did: session.currentAccount.did,
-              handle: session.currentAccount.handle,
-            },
-          })
+            logger.DebugContext.session,
+          )
 
-          initSession(session.currentAccount)
+          await initSession(selectedAccount)
         } else {
-          logger.debug(`session: persisted onUpdate, updating session`, {})
-
+          logger.debug(
+            `session: persisted onUpdate, updating session`,
+            {},
+            logger.DebugContext.session,
+          )
           /*
-           * Use updated session in this tab's agent. Do not call
-           * upsertAccount, since that will only persist the session that's
-           * already persisted, and we'll get a loop between tabs.
+           * Create a new agent for the same account, with updated data from
+           * other side of broadcast. Update on state to re-derive
+           * `currentAccount` and re-render the app.
            */
-          // @ts-ignore we checked for `refreshJwt` above
-          __globalAgent.session = session.currentAccount
+          const newAgent = currentAgent.clone()
+          newAgent.session = sessionAccountToAgentSession(selectedAccount)
+          configureModeration(newAgent, selectedAccount)
+          setCurrentAgent(newAgent)
         }
-      } else if (!session.currentAccount && state.currentAccount) {
+      } else if (!selectedAccount && currentAccountDid) {
         logger.debug(
           `session: persisted onUpdate, logging out`,
           {},
@@ -661,21 +453,32 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
          */
         clearCurrentAccount()
       }
-
-      setState(s => ({
-        ...s,
-        accounts: session.accounts,
-        currentAccount: session.currentAccount,
-      }))
     })
-  }, [state, setState, clearCurrentAccount, initSession])
+  }, [
+    currentAccountDid,
+    setAccounts,
+    clearCurrentAccount,
+    initSession,
+    currentAgent,
+    setCurrentAgent,
+  ])
 
   const stateContext = React.useMemo(
     () => ({
-      ...state,
-      hasSession: !!state.currentAccount,
+      currentAgent,
+      isInitialLoad,
+      isSwitchingAccounts,
+      currentAccount,
+      accounts,
+      hasSession: Boolean(currentAccount),
     }),
-    [state],
+    [
+      currentAgent,
+      isInitialLoad,
+      isSwitchingAccounts,
+      accounts,
+      currentAccount,
+    ],
   )
 
   const api = React.useMemo(
@@ -687,8 +490,9 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
       resumeSession,
       removeAccount,
       selectAccount,
-      updateCurrentAccount,
+      refreshSession,
       clearCurrentAccount,
+      updateCurrentAccount,
     }),
     [
       createAccount,
@@ -698,38 +502,22 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
       resumeSession,
       removeAccount,
       selectAccount,
-      updateCurrentAccount,
+      refreshSession,
       clearCurrentAccount,
+      updateCurrentAccount,
     ],
   )
+
+  if (IS_DEV && isWeb) {
+    // @ts-ignore
+    window.agent = currentAgent
+  }
 
   return (
     <StateContext.Provider value={stateContext}>
       <ApiContext.Provider value={api}>{children}</ApiContext.Provider>
     </StateContext.Provider>
   )
-}
-
-async function configureModeration(agent: BskyAgent, account: SessionAccount) {
-  if (IS_TEST_USER(account.handle)) {
-    const did = (
-      await agent
-        .resolveHandle({handle: 'mod-authority.test'})
-        .catch(_ => undefined)
-    )?.data.did
-    if (did) {
-      console.warn('USING TEST ENV MODERATION')
-      BskyAgent.configure({appLabelers: [did]})
-    }
-  } else {
-    BskyAgent.configure({appLabelers: [BSKY_LABELER_DID]})
-    const labelerDids = await readLabelers(account.did).catch(_ => {})
-    if (labelerDids) {
-      agent.configureLabelersHeader(
-        labelerDids.filter(did => did !== BSKY_LABELER_DID),
-      )
-    }
-  }
 }
 
 export function useSession() {
@@ -742,8 +530,8 @@ export function useSessionApi() {
 
 export function useRequireAuth() {
   const {hasSession} = useSession()
+  const {setShowLoggedOut} = useLoggedOutViewControls()
   const closeAll = useCloseAllActiveElements()
-  const {signinDialogControl} = useGlobalDialogsControlContext()
 
   return React.useCallback(
     (fn: () => void) => {
@@ -751,19 +539,21 @@ export function useRequireAuth() {
         fn()
       } else {
         closeAll()
-        signinDialogControl.open()
+        setShowLoggedOut(true)
       }
     },
-    [hasSession, signinDialogControl, closeAll],
+    [hasSession, setShowLoggedOut, closeAll],
   )
 }
 
-export function isSessionDeactivated(accessJwt: string | undefined) {
-  if (accessJwt) {
-    const sessData = jwtDecode(accessJwt)
-    return (
-      hasProp(sessData, 'scope') && sessData.scope === 'com.atproto.deactivated'
-    )
-  }
-  return false
+export function useAgent() {
+  const {currentAgent} = useSession()
+  return React.useMemo(
+    () => ({
+      getAgent() {
+        return currentAgent
+      },
+    }),
+    [currentAgent],
+  )
 }


### PR DESCRIPTION
This introduces the refactored session logic. Core to this is putting `currentAgent` on state/context.

Also here is some error handling when switching accounts and logging in. In v1, `initSession` was swallowing some errors where it shouldn't have been, and v2 fixes that. This handling has no effect if v1 is active, only v2.