### PR TITLE
Special-case bsky.app/download to open share sheet or copy to clipboard

### DIFF
--- a/__tests__/lib/strings/url-helpers.test.ts
+++ b/__tests__/lib/strings/url-helpers.test.ts
@@ -1,10 +1,10 @@
-import {it, describe, expect} from '@jest/globals'
+import {describe, expect, it} from '@jest/globals'
 
 import {
-  linkRequiresWarning,
   isPossiblyAUrl,
-  splitApexDomain,
   isTrustedUrl,
+  linkRequiresWarning,
+  splitApexDomain,
 } from '../../../src/lib/strings/url-helpers'
 
 describe('linkRequiresWarning', () => {
@@ -170,6 +170,7 @@ describe('isTrustedUrl', () => {
     ['https://google.com', false],
     ['https://docs.google.com', false],
     ['https://google.com/#', false],
+    ['https://blueskywebxzendesk.com', false],
   ]
 
   it.each(cases)('given input uri %p, returns %p', (str, expected) => {

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -3,10 +3,12 @@ import {GestureResponderEvent} from 'react-native'
 import {sanitizeUrl} from '@braintree/sanitize-url'
 import {StackActions, useLinkProps} from '@react-navigation/native'
 
+import {BSKY_DOWNLOAD_URL} from '#/lib/constants'
 import {AllNavigatorParams} from '#/lib/routes/types'
 import {shareUrl} from '#/lib/sharing'
 import {
   convertBskyAppUrlIfNeeded,
+  isBskyDownloadUrl,
   isExternalUrl,
   linkRequiresWarning,
 } from '#/lib/strings/url-helpers'
@@ -125,7 +127,9 @@ export function useLink({
             (event.metaKey || event.altKey || event.ctrlKey || event.shiftKey)
           const shouldOpenInNewTab = isMetaKey || isMiddleClick
 
-          if (
+          if (isBskyDownloadUrl(href)) {
+            shareUrl(BSKY_DOWNLOAD_URL)
+          } else if (
             shouldOpenInNewTab ||
             href.startsWith('http') ||
             href.startsWith('mailto')

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -10,6 +10,7 @@ const HELP_DESK_LANG = 'en-us'
 export const HELP_DESK_URL = `https://blueskyweb.zendesk.com/hc/${HELP_DESK_LANG}`
 export const EMBED_SERVICE = 'https://embed.bsky.app'
 export const EMBED_SCRIPT = `${EMBED_SERVICE}/static/embed.js`
+export const BSKY_DOWNLOAD_URL = 'https://bsky.app/download'
 
 const BASE_FEEDBACK_FORM_URL = `${HELP_DESK_URL}/requests/new`
 export function FEEDBACK_FORM_URL({

--- a/src/lib/strings/url-helpers.ts
+++ b/src/lib/strings/url-helpers.ts
@@ -150,7 +150,7 @@ export function isBskyDownloadUrl(url: string): boolean {
   if (isExternalUrl(url)) {
     return false
   }
-  return url.endsWith('/download')
+  return url === '/download' || url.startsWith('/download?')
 }
 
 export function convertBskyAppUrlIfNeeded(url: string): string {

--- a/src/lib/strings/url-helpers.ts
+++ b/src/lib/strings/url-helpers.ts
@@ -1,7 +1,8 @@
 import {AtUri} from '@atproto/api'
-import {BSKY_SERVICE} from 'lib/constants'
-import TLDs from 'tlds'
 import psl from 'psl'
+import TLDs from 'tlds'
+
+import {BSKY_SERVICE} from 'lib/constants'
 
 export const BSKY_APP_HOST = 'https://bsky.app'
 const BSKY_TRUSTED_HOSTS = [
@@ -143,6 +144,13 @@ export function isBskyListUrl(url: string): boolean {
     }
   }
   return false
+}
+
+export function isBskyDownloadUrl(url: string): boolean {
+  if (isExternalUrl(url)) {
+    return false
+  }
+  return url.endsWith('/download')
 }
 
 export function convertBskyAppUrlIfNeeded(url: string): string {

--- a/src/lib/strings/url-helpers.ts
+++ b/src/lib/strings/url-helpers.ts
@@ -6,10 +6,10 @@ import {BSKY_SERVICE} from 'lib/constants'
 
 export const BSKY_APP_HOST = 'https://bsky.app'
 const BSKY_TRUSTED_HOSTS = [
-  'bsky.app',
-  'bsky.social',
-  'blueskyweb.xyz',
-  'blueskyweb.zendesk.com',
+  'bsky\\.app',
+  'bsky\\.social',
+  'blueskyweb\\.xyz',
+  'blueskyweb\\.zendesk\\.com',
   ...(__DEV__ ? ['localhost:19006', 'localhost:8100'] : []),
 ]
 


### PR DESCRIPTION
We have a new bsky.app/download path that redirects users to the device-relevant app store. However, if you click the link in the app it tries to do a local navigation to a non-existent page and 404s. This PR opens the share sheet instead.

### Test plan

Click the link in this post: https://bsky.app/profile/bsky.app/post/3kqy4mjw5eo2t