### PR TITLE
embedr: handle out-of-range maxwidth; change default

### DIFF
--- a/bskyweb/cmd/embedr/handlers.go
+++ b/bskyweb/cmd/embedr/handlers.go
@@ -122,14 +122,20 @@ func (srv *Server) WebOEmbed(c echo.Context) error {
 	}
 
 	// TODO: do we actually do something with width?
-	width := 550
+	width := 600
 	maxWidthParam := c.QueryParam("maxwidth")
 	if maxWidthParam != "" {
 		maxWidthInt, err := strconv.Atoi(maxWidthParam)
-		if err != nil || maxWidthInt < 220 || maxWidthInt > 550 {
-			return c.String(http.StatusBadRequest, "Invalid maxwidth (expected integer between 220 and 550)")
+		if err != nil {
+			return c.String(http.StatusBadRequest, "Invalid maxwidth (expected integer)")
 		}
-		width = maxWidthInt
+		if maxWidthInt < 220 {
+			width = 220
+		} else if maxWidthInt > 600 {
+			width = 600
+		} else {
+			width = maxWidthInt
+		}
 	}
 	// NOTE: maxheight ignored
 


### PR DESCRIPTION
Looks like the default width is actually 600px, so I increased to that. Not sure if we should allow larger widths? Or whether that param is de facto even being used?

And don't return an error on out-of-range params, just return range-limited value.