### PR TITLE
Update horizontal padding for Saved feed header

### DIFF
--- a/src/view/screens/Feeds.tsx
+++ b/src/view/screens/Feeds.tsx
@@ -740,7 +740,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'space-between',
     gap: 16,
-    paddingHorizontal: 16,
+    paddingHorizontal: 18,
     paddingVertical: 12,
   },
 


### PR DESCRIPTION
Sets the `paddingHorizontal` of the Saved feeds header to 18, just like the headers on other pages, such as Settings, Notifications, etc.