### PR TITLE
Update font size in WhoCanReply

### DIFF
--- a/src/view/com/threadgate/WhoCanReply.tsx
+++ b/src/view/com/threadgate/WhoCanReply.tsx
@@ -6,16 +6,16 @@ import {
   AppBskyGraphDefs,
   AtUri,
 } from '@atproto/api'
-import {Trans} from '@lingui/macro'
-import {usePalette} from '#/lib/hooks/usePalette'
-import {Text} from '../util/text/Text'
-import {TextLink} from '../util/Link'
-import {makeProfileLink, makeListLink} from '#/lib/routes/links'
 import {FontAwesomeIcon} from '@fortawesome/react-native-fontawesome'
-import {useColorSchemeStyle} from '#/lib/hooks/useColorSchemeStyle'
-import {useWebMediaQueries} from '#/lib/hooks/useWebMediaQueries'
+import {Trans} from '@lingui/macro'
 
+import {useColorSchemeStyle} from '#/lib/hooks/useColorSchemeStyle'
+import {usePalette} from '#/lib/hooks/usePalette'
+import {useWebMediaQueries} from '#/lib/hooks/useWebMediaQueries'
+import {makeListLink, makeProfileLink} from '#/lib/routes/links'
 import {colors} from '#/lib/styles'
+import {TextLink} from '../util/Link'
+import {Text} from '../util/text/Text'
 
 export function WhoCanReply({
   post,
@@ -143,6 +143,7 @@ function Rule({
       <Trans>
         users followed by{' '}
         <TextLink
+          type="sm"
           href={makeProfileLink(post.author)}
           text={`@${post.author.handle}`}
           style={pal.link}
@@ -157,6 +158,7 @@ function Rule({
       return (
         <Trans>
           <TextLink
+            type="sm"
             href={makeListLink(listUrip.hostname, listUrip.rkey)}
             text={list.name}
             style={pal.link}


### PR DESCRIPTION
Before:

![303183412-93034c09-5673-462f-b879-3dcee7ae1739](https://github.com/bluesky-social/social-app/assets/11014257/c4d10322-f7a7-44d0-bbeb-48692a3c76a5)

After:

![303183382-f0166361-3a69-4c29-b922-ed899e3b60ab](https://github.com/bluesky-social/social-app/assets/11014257/9eff606a-db3e-4464-bbba-436da52a6e9a)

Fixes an issue in `WhoCanReply.tsx` where a bigger font size was set for `TextLink` only.