### PR TITLE
Remove top border of the post

### DIFF
--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -243,7 +243,13 @@ let PostThreadItemLoaded = ({
 
         <View
           testID={`postThreadItem-by-${post.author.handle}`}
-          style={[styles.outer, styles.outerHighlighted, pal.border, pal.view]}
+          style={[
+            styles.outer,
+            rootUri === post.uri && styles.noTopBorder,
+            styles.outerHighlighted,
+            pal.border,
+            pal.view,
+          ]}
           accessible={false}>
           <View style={[styles.layout]}>
             <View style={[styles.layoutAvi, {paddingBottom: 8}]}>
@@ -608,6 +614,7 @@ function PostOuterWrapper({
     <View
       style={[
         styles.outer,
+        depth < 1 && styles.noTopBorder,
         pal.border,
         showParentReplyLine && hasPrecedingItem && styles.noTopBorder,
         styles.cursor,


### PR DESCRIPTION
<img width="1320" alt="303974395-549201d2-6b4f-4005-8a0d-78744c98e3b7" src="https://github.com/bluesky-social/social-app/assets/11014257/b3addec0-61b9-44c9-8cd3-877a070d6e1a">

This removes unnecessary top border of the post.