### PR TITLE
[Issue 760] Use correct aspect ratio in banner cropper

### DIFF
--- a/src/lib/media/picker.tsx
+++ b/src/lib/media/picker.tsx
@@ -1,8 +1,9 @@
 import {
+  Image as RNImage,
   openCamera as openCameraFn,
   openCropper as openCropperFn,
-  Image as RNImage,
 } from 'react-native-image-crop-picker'
+
 import {CameraOpts, CropperOptions} from './types'
 export {openPicker} from './picker.shared'
 

--- a/src/lib/media/picker.web.tsx
+++ b/src/lib/media/picker.web.tsx
@@ -1,7 +1,8 @@
 /// <reference lib="dom" />
 
-import {CameraOpts, CropperOptions} from './types'
 import {Image as RNImage} from 'react-native-image-crop-picker'
+
+import {CameraOpts, CropperOptions} from './types'
 export {openPicker} from './picker.shared'
 import {unstable__openModal} from '#/state/modals'
 

--- a/src/lib/media/picker.web.tsx
+++ b/src/lib/media/picker.web.tsx
@@ -13,15 +13,13 @@ export async function openCamera(_opts: CameraOpts): Promise<RNImage> {
 
 export async function openCropper(opts: CropperOptions): Promise<RNImage> {
   // TODO handle more opts
-  return new Promise((resolve, reject) => {
+  return new Promise(resolve => {
     unstable__openModal({
       name: 'crop-image',
       uri: opts.path,
       onSelect: (img?: RNImage) => {
         if (img) {
           resolve(img)
-        } else {
-          reject(new Error('Canceled'))
         }
       },
     })

--- a/src/lib/media/picker.web.tsx
+++ b/src/lib/media/picker.web.tsx
@@ -17,6 +17,10 @@ export async function openCropper(opts: CropperOptions): Promise<RNImage> {
     unstable__openModal({
       name: 'crop-image',
       uri: opts.path,
+      dimensions:
+        opts.height && opts.width
+          ? {width: opts.width, height: opts.height}
+          : undefined,
       onSelect: (img?: RNImage) => {
         if (img) {
           resolve(img)

--- a/src/state/modals/index.tsx
+++ b/src/state/modals/index.tsx
@@ -47,6 +47,7 @@ export interface EditImageModal {
 export interface CropImageModal {
   name: 'crop-image'
   uri: string
+  dimensions?: {width: number; height: number}
   onSelect: (img?: RNImage) => void
 }
 

--- a/src/view/com/modals/crop-image/CropImage.web.tsx
+++ b/src/view/com/modals/crop-image/CropImage.web.tsx
@@ -117,36 +117,40 @@ export function Component({
           maximumValue={3}
           containerStyle={styles.slider}
         />
-        <TouchableOpacity
-          onPress={doSetAs(AspectRatio.Wide)}
-          accessibilityRole="button"
-          accessibilityLabel={_(msg`Wide`)}
-          accessibilityHint={_(msg`Sets image aspect ratio to wide`)}>
-          <RectWideIcon
-            size={24}
-            style={as === AspectRatio.Wide ? s.blue3 : pal.text}
-          />
-        </TouchableOpacity>
-        <TouchableOpacity
-          onPress={doSetAs(AspectRatio.Tall)}
-          accessibilityRole="button"
-          accessibilityLabel={_(msg`Tall`)}
-          accessibilityHint={_(msg`Sets image aspect ratio to tall`)}>
-          <RectTallIcon
-            size={24}
-            style={as === AspectRatio.Tall ? s.blue3 : pal.text}
-          />
-        </TouchableOpacity>
-        <TouchableOpacity
-          onPress={doSetAs(AspectRatio.Square)}
-          accessibilityRole="button"
-          accessibilityLabel={_(msg`Square`)}
-          accessibilityHint={_(msg`Sets image aspect ratio to square`)}>
-          <SquareIcon
-            size={24}
-            style={as === AspectRatio.Square ? s.blue3 : pal.text}
-          />
-        </TouchableOpacity>
+        {as === AspectRatio.Custom ? null : (
+          <>
+            <TouchableOpacity
+              onPress={doSetAs(AspectRatio.Wide)}
+              accessibilityRole="button"
+              accessibilityLabel={_(msg`Wide`)}
+              accessibilityHint={_(msg`Sets image aspect ratio to wide`)}>
+              <RectWideIcon
+                size={24}
+                style={as === AspectRatio.Wide ? s.blue3 : pal.text}
+              />
+            </TouchableOpacity>
+            <TouchableOpacity
+              onPress={doSetAs(AspectRatio.Tall)}
+              accessibilityRole="button"
+              accessibilityLabel={_(msg`Tall`)}
+              accessibilityHint={_(msg`Sets image aspect ratio to tall`)}>
+              <RectTallIcon
+                size={24}
+                style={as === AspectRatio.Tall ? s.blue3 : pal.text}
+              />
+            </TouchableOpacity>
+            <TouchableOpacity
+              onPress={doSetAs(AspectRatio.Square)}
+              accessibilityRole="button"
+              accessibilityLabel={_(msg`Square`)}
+              accessibilityHint={_(msg`Sets image aspect ratio to square`)}>
+              <SquareIcon
+                size={24}
+                style={as === AspectRatio.Square ? s.blue3 : pal.text}
+              />
+            </TouchableOpacity>
+          </>
+        )}
       </View>
       <View style={styles.btns}>
         <TouchableOpacity

--- a/src/view/com/modals/crop-image/CropImage.web.tsx
+++ b/src/view/com/modals/crop-image/CropImage.web.tsx
@@ -14,11 +14,13 @@ import {Dimensions} from 'lib/media/types'
 import {getDataUriSize} from 'lib/media/util'
 import {gradients, s} from 'lib/styles'
 import {Text} from 'view/com/util/text/Text'
+import {calculateDimensions} from './cropImageUtil'
 
 enum AspectRatio {
   Square = 'square',
   Wide = 'wide',
   Tall = 'tall',
+  Custom = 'custom',
 }
 
 const DIMS: Record<string, Dimensions> = {
@@ -31,17 +33,24 @@ export const snapPoints = ['0%']
 
 export function Component({
   uri,
+  dimensions,
   onSelect,
 }: {
   uri: string
+  dimensions?: Dimensions
   onSelect: (img?: RNImage) => void
 }) {
   const {closeModal} = useModalControls()
   const pal = usePalette('default')
   const {_} = useLingui()
-  const [as, setAs] = React.useState<AspectRatio>(AspectRatio.Square)
+  const defaultAspectStyle = dimensions
+    ? AspectRatio.Custom
+    : AspectRatio.Square
+  const [as, setAs] = React.useState<AspectRatio>(defaultAspectStyle)
   const [scale, setScale] = React.useState<number>(1)
   const editorRef = React.useRef<ImageEditor>(null)
+  const imageEditorWidth = dimensions ? dimensions.width : DIMS[as].width
+  const imageEditorHeight = dimensions ? dimensions.height : DIMS[as].height
 
   const doSetAs = (v: AspectRatio) => () => setAs(v)
 
@@ -57,8 +66,8 @@ export function Component({
         path: dataUri,
         mime: 'image/jpeg',
         size: getDataUriSize(dataUri),
-        width: DIMS[as].width,
-        height: DIMS[as].height,
+        width: imageEditorWidth,
+        height: imageEditorHeight,
       })
     } else {
       onSelect(undefined)
@@ -73,7 +82,18 @@ export function Component({
     cropperStyle = styles.cropperWide
   } else if (as === AspectRatio.Tall) {
     cropperStyle = styles.cropperTall
+  } else if (as === AspectRatio.Custom) {
+    const cropperDimensions = calculateDimensions(
+      550,
+      imageEditorHeight,
+      imageEditorWidth,
+    )
+    cropperStyle = {
+      width: cropperDimensions.width,
+      height: cropperDimensions.height,
+    }
   }
+
   return (
     <View>
       <View style={[styles.cropper, pal.borderDark, cropperStyle]}>
@@ -81,8 +101,8 @@ export function Component({
           ref={editorRef}
           style={styles.imageEditor}
           image={uri}
-          width={DIMS[as].width}
-          height={DIMS[as].height}
+          width={imageEditorWidth}
+          height={imageEditorHeight}
           scale={scale}
           border={0}
         />

--- a/src/view/com/modals/crop-image/cropImageUtil.ts
+++ b/src/view/com/modals/crop-image/cropImageUtil.ts
@@ -1,0 +1,13 @@
+export const calculateDimensions = (
+  maxWidth: number,
+  originalHeight: number,
+  originalWidth: number,
+) => {
+  const aspectRatio = originalWidth / originalHeight
+  const newHeight = maxWidth / aspectRatio
+  const newWidth = maxWidth
+  return {
+    width: newWidth,
+    height: newHeight,
+  }
+}

--- a/src/view/com/util/UserBanner.tsx
+++ b/src/view/com/util/UserBanner.tsx
@@ -1,29 +1,29 @@
 import React from 'react'
 import {StyleSheet, TouchableOpacity, View} from 'react-native'
-import {ModerationUI} from '@atproto/api'
+import {Image as RNImage} from 'react-native-image-crop-picker'
 import {Image} from 'expo-image'
-import {useLingui} from '@lingui/react'
+import {ModerationUI} from '@atproto/api'
 import {msg, Trans} from '@lingui/macro'
+import {useLingui} from '@lingui/react'
 
+import {usePalette} from 'lib/hooks/usePalette'
+import {
+  useCameraPermission,
+  usePhotoLibraryPermission,
+} from 'lib/hooks/usePermissions'
 import {colors} from 'lib/styles'
 import {useTheme} from 'lib/ThemeContext'
-import {useTheme as useAlfTheme, tokens} from '#/alf'
-import {openCamera, openCropper, openPicker} from '../../../lib/media/picker'
-import {
-  usePhotoLibraryPermission,
-  useCameraPermission,
-} from 'lib/hooks/usePermissions'
-import {usePalette} from 'lib/hooks/usePalette'
 import {isAndroid, isNative} from 'platform/detection'
-import {Image as RNImage} from 'react-native-image-crop-picker'
 import {EventStopper} from 'view/com/util/EventStopper'
-import * as Menu from '#/components/Menu'
+import {tokens, useTheme as useAlfTheme} from '#/alf'
 import {
   Camera_Filled_Stroke2_Corner0_Rounded as CameraFilled,
   Camera_Stroke2_Corner0_Rounded as Camera,
 } from '#/components/icons/Camera'
 import {StreamingLive_Stroke2_Corner0_Rounded as Library} from '#/components/icons/StreamingLive'
 import {Trash_Stroke2_Corner0_Rounded as Trash} from '#/components/icons/Trash'
+import * as Menu from '#/components/Menu'
+import {openCamera, openCropper, openPicker} from '../../../lib/media/picker'
 
 export function UserBanner({
   type,


### PR DESCRIPTION
This is a fix for the banner cropper issue closes https://github.com/bluesky-social/social-app/issues/760

Before:

<img width="622" alt="image" src="https://github.com/bluesky-social/social-app/assets/1474323/ed15c2ab-862a-4d48-b8df-48cda3be0252">

After:

<img width="621" alt="image" src="https://github.com/bluesky-social/social-app/assets/1474323/d11fd0ea-2617-4a0e-8862-523c86653860">

Note that in the "after" image the preview matches what you'd actually see ending up in the banner after clicking "Done"

Previously when uploading an image, you could choose aspect ratios, but none of them would fit the banner aspect ratio. I have modified the banner cropper on web to take into account the aspect ratio of the given width/height provided to the cropper [here](https://github.com/bluesky-social/social-app/blob/main/src/view/com/util/UserBanner.tsx#L67):

```
    onSelectNewBanner?.(
      await openCropper({
        mediaType: 'photo',
        path: items[0].path,
        width: 3000,
        height: 1000,
      }),
    )
```

I have also hidden the options to pick an aspect ratio in the cropper when the width / height is given, as I think it's confusing to pick a custom aspect ratio when we expect a specific width and height, right?

I've also removed the `reject(new Error('Canceled'))` call when pressing "Cancel" on the cropper preview, as it caused the app to crash with that error locally.