### PR TITLE
Mark `Text field` for translation in SubmitView.tsx

### DIFF
--- a/src/components/ReportDialog/SubmitView.tsx
+++ b/src/components/ReportDialog/SubmitView.tsx
@@ -167,7 +167,7 @@ export function SubmitView({
             multiline
             value={details}
             onChangeText={setDetails}
-            label="Text field"
+            label={_(msg`Text field`)}
             style={{paddingRight: 60}}
             numberOfLines={6}
           />


### PR DESCRIPTION
This small PR marks the `Text field` placeholder text in the report dialog for translation.

![IMG_5840](https://github.com/bluesky-social/social-app/assets/149612116/d2620abd-05c1-44e1-b9cd-c1d5961a79ef)
