### PR TITLE
Account for momentum when hiding minimal shell

### DIFF
--- a/src/lib/ScrollContext.tsx
+++ b/src/lib/ScrollContext.tsx
@@ -5,6 +5,8 @@ const ScrollContext = createContext<ScrollHandlers<any>>({
   onBeginDrag: undefined,
   onEndDrag: undefined,
   onScroll: undefined,
+  onMomentumBegin: undefined,
+  onMomentumEnd: undefined,
 })
 
 export function useScrollHandlers(): ScrollHandlers<any> {
@@ -20,14 +22,18 @@ export function ScrollProvider({
   onBeginDrag,
   onEndDrag,
   onScroll,
+  onMomentumBegin,
+  onMomentumEnd,
 }: ProviderProps) {
   const handlers = useMemo(
     () => ({
       onBeginDrag,
       onEndDrag,
       onScroll,
+      onMomentumBegin,
+      onMomentumEnd,
     }),
-    [onBeginDrag, onEndDrag, onScroll],
+    [onBeginDrag, onEndDrag, onScroll, onMomentumBegin, onMomentumEnd],
   )
   return (
     <ScrollContext.Provider value={handlers}>{children}</ScrollContext.Provider>

--- a/src/lib/ScrollContext.tsx
+++ b/src/lib/ScrollContext.tsx
@@ -5,7 +5,6 @@ const ScrollContext = createContext<ScrollHandlers<any>>({
   onBeginDrag: undefined,
   onEndDrag: undefined,
   onScroll: undefined,
-  onMomentumBegin: undefined,
   onMomentumEnd: undefined,
 })
 
@@ -22,7 +21,6 @@ export function ScrollProvider({
   onBeginDrag,
   onEndDrag,
   onScroll,
-  onMomentumBegin,
   onMomentumEnd,
 }: ProviderProps) {
   const handlers = useMemo(
@@ -30,10 +28,9 @@ export function ScrollProvider({
       onBeginDrag,
       onEndDrag,
       onScroll,
-      onMomentumBegin,
       onMomentumEnd,
     }),
-    [onBeginDrag, onEndDrag, onScroll, onMomentumBegin, onMomentumEnd],
+    [onBeginDrag, onEndDrag, onScroll, onMomentumEnd],
   )
   return (
     <ScrollContext.Provider value={handlers}>{children}</ScrollContext.Provider>

--- a/src/screens/Profile/Sections/Labels.tsx
+++ b/src/screens/Profile/Sections/Labels.tsx
@@ -123,9 +123,6 @@ export function ProfileLabelsSectionInner({
     onScroll(e, ctx) {
       contextScrollHandlers.onScroll?.(e, ctx)
     },
-    onMomentumBegin(e, ctx) {
-      contextScrollHandlers.onMomentumBegin?.(e, ctx)
-    },
     onMomentumEnd(e, ctx) {
       contextScrollHandlers.onMomentumEnd?.(e, ctx)
     },

--- a/src/screens/Profile/Sections/Labels.tsx
+++ b/src/screens/Profile/Sections/Labels.tsx
@@ -123,6 +123,12 @@ export function ProfileLabelsSectionInner({
     onScroll(e, ctx) {
       contextScrollHandlers.onScroll?.(e, ctx)
     },
+    onMomentumBegin(e, ctx) {
+      contextScrollHandlers.onMomentumBegin?.(e, ctx)
+    },
+    onMomentumEnd(e, ctx) {
+      contextScrollHandlers.onMomentumEnd?.(e, ctx)
+    },
   })
 
   const {labelValues} = labelerInfo.policies

--- a/src/view/com/util/List.tsx
+++ b/src/view/com/util/List.tsx
@@ -64,9 +64,8 @@ function ListImpl<ItemT>(
         }
       }
     },
-    onMomentumBegin(e, ctx) {
-      contextScrollHandlers.onMomentumBegin?.(e, ctx)
-    },
+    // Note: adding onMomentumBegin here makes simulator scroll
+    // lag on Android. So either don't add it, or figure out why.
     onMomentumEnd(e, ctx) {
       contextScrollHandlers.onMomentumEnd?.(e, ctx)
     },

--- a/src/view/com/util/List.tsx
+++ b/src/view/com/util/List.tsx
@@ -64,6 +64,12 @@ function ListImpl<ItemT>(
         }
       }
     },
+    onMomentumBegin(e, ctx) {
+      contextScrollHandlers.onMomentumBegin?.(e, ctx)
+    },
+    onMomentumEnd(e, ctx) {
+      contextScrollHandlers.onMomentumEnd?.(e, ctx)
+    },
   })
 
   let refreshControl

--- a/src/view/com/util/MainScrollProvider.tsx
+++ b/src/view/com/util/MainScrollProvider.tsx
@@ -37,11 +37,18 @@ export function MainScrollProvider({children}: {children: React.ReactNode}) {
     (e: NativeScrollEvent) => {
       'worklet'
       if (isNative) {
+        if (startDragOffset.value === null) {
+          return
+        }
+        const didScrollDown = e.contentOffset.y > startDragOffset.value
         startDragOffset.value = null
         startMode.value = null
-        if (e.contentOffset.y < headerHeight.value / 2) {
+        if (e.contentOffset.y < headerHeight.value) {
           // If we're close to the top, show the shell.
           setMode(false)
+        } else if (didScrollDown) {
+          // Showing the bar again on scroll down feels annoying, so don't.
+          setMode(true)
         } else {
           // Snap to whichever state is the closest.
           setMode(Math.round(mode.value) === 1)


### PR DESCRIPTION
Several tweaks to how we toggle the minimal shell based on scroll for native apps:

- If there is a velocity, don't snap scroll on drag end. Instead, wait for the momentum end.
- When snapping, always hide the bar if we scrolled down. (Previously, it was snap to closest position.)
- Bump the threshold for when we always show the shell at the top. (Avoids weird empty space at the top.)

No changes on web.

## Why

This is easier to understand on video (before/after below).

This aims to resolve several interaction problems:

- If you quickly flick the feed down, the bar would previously often snap back up — because it wouldn't take the velocity into account (so the calculation would think you haven't scrolled down "far enough"). With these changes, it will no longer snap "just" at the drag end, and instead will wait for the momentum events to settle. Note we're making an assumption that a non-zero velocity will be followed by momentum events.
- If you move the feed just a _little bit_ down and then release, it would previously snap back up — because we'd snap to the "closest" state, and if you only moved it a bit, the closest state is still "show the top bar". I'm changing this to always hide the bar on scroll down. (The only case in which you'd now ever see it "pop back up" during a drag down is at the very top of the feed where we don't want to show a blank space.)

Overall I think this makes it feels less obtrusive.

## iOS

### Before

https://github.com/bluesky-social/social-app/assets/810438/632dc9f8-c557-4d14-932a-b0ad1d1d79fb

### After

https://github.com/bluesky-social/social-app/assets/810438/4d7a7fa5-cffd-4aff-a2f3-88d3a6c09bc7

## Android

### Before

https://github.com/bluesky-social/social-app/assets/810438/9b06e7bf-9aaa-4738-9148-ca865ce17aaa

### After

https://github.com/bluesky-social/social-app/assets/810438/e6a56c8a-845e-4437-8a98-77f780a915c4

