### PR TITLE
Remove useEffect from TimeElapsed

### DIFF
--- a/src/view/com/util/TimeElapsed.tsx
+++ b/src/view/com/util/TimeElapsed.tsx
@@ -3,8 +3,6 @@ import React from 'react'
 import {useTickEveryMinute} from '#/state/shell'
 import {ago} from 'lib/strings/time'
 
-// FIXME(dan): Figure out why the false positives
-
 export function TimeElapsed({
   timestamp,
   children,
@@ -15,9 +13,11 @@ export function TimeElapsed({
   const tick = useTickEveryMinute()
   const [timeElapsed, setTimeAgo] = React.useState(() => ago(timestamp))
 
-  React.useEffect(() => {
+  const [prevTick, setPrevTick] = React.useState(tick)
+  if (prevTick !== tick) {
+    setPrevTick(tick)
     setTimeAgo(ago(timestamp))
-  }, [timestamp, setTimeAgo, tick])
+  }
 
   return children({timeElapsed})
 }


### PR DESCRIPTION
It's not needed and forces an unnecessary second render pass.

See https://react.dev/learn/you-might-not-need-an-effect#adjusting-some-state-when-a-prop-changes.

## Test Plan

Waited a minute, verified timestamps get updated.