### PR TITLE
[iOS] Fix selecting search input on focus

### DIFF
--- a/src/view/screens/Search/Search.tsx
+++ b/src/view/screens/Search/Search.tsx
@@ -25,7 +25,7 @@ import {NavigationProp} from '#/lib/routes/types'
 import {augmentSearchQuery} from '#/lib/strings/helpers'
 import {s} from '#/lib/styles'
 import {logger} from '#/logger'
-import {isNative, isWeb} from '#/platform/detection'
+import {isIOS, isNative, isWeb} from '#/platform/detection'
 import {listenSoftReset} from '#/state/events'
 import {useActorAutocompleteQuery} from '#/state/queries/actor-autocomplete'
 import {useActorSearch} from '#/state/queries/actor-search'
@@ -674,6 +674,7 @@ export function SearchScreen(
             value={searchText}
             style={[pal.text, styles.headerSearchInput]}
             keyboardAppearance={theme.colorScheme}
+            selectTextOnFocus={isNative}
             onFocus={() => {
               if (isWeb) {
                 // Prevent a jump on iPad by ensuring that
@@ -683,9 +684,12 @@ export function SearchScreen(
                 })
               } else {
                 setShowAutocomplete(true)
-                // We'd use selectTextOnFocus, but it's broken:
-                // https://github.com/facebook/react-native/issues/41988
-                textInput.current?.setSelection(0, searchText.length)
+                if (isIOS) {
+                  // We rely on selectTextOnFocus, but it's broken on iOS:
+                  // https://github.com/facebook/react-native/issues/41988
+                  textInput.current?.setSelection(0, searchText.length)
+                  // We still rely on selectTextOnFocus for it to be instant on Android.
+                }
               }
             }}
             onChangeText={onChangeText}

--- a/src/view/screens/Search/Search.tsx
+++ b/src/view/screens/Search/Search.tsx
@@ -670,7 +670,6 @@ export function SearchScreen(
             ref={textInput}
             placeholder={_(msg`Search`)}
             placeholderTextColor={pal.colors.textLight}
-            selectTextOnFocus={isNative}
             returnKeyType="search"
             value={searchText}
             style={[pal.text, styles.headerSearchInput]}
@@ -684,6 +683,9 @@ export function SearchScreen(
                 })
               } else {
                 setShowAutocomplete(true)
+                // We'd use selectTextOnFocus, but it's broken:
+                // https://github.com/facebook/react-native/issues/41988
+                textInput.current?.setSelection(0, searchText.length)
               }
             }}
             onChangeText={onChangeText}


### PR DESCRIPTION
Makes this work on iOS.

https://github.com/bluesky-social/social-app/assets/810438/399c753d-f351-46e9-bd12-efd065c5ab1e

Doesn't touch Android or web.