### PR TITLE
patch RN to remove JS hack for `selectTextOnFocus`

### DIFF
--- a/patches/react-native+0.73.2.patch
+++ b/patches/react-native+0.73.2.patch
@@ -1,8 +1,8 @@
-diff --git a/node_modules/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.mm b/node_modules/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.mm
+diff --git a/node_modules/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.mm b/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.mm
 index b0d71dc..34cb289 100644
---- a/node_modules/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.mm
-+++ b/node_modules/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.mm
-@@ -377,10 +377,6 @@ - (void)textInputDidBeginEditing
+--- a/node_modules/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.mm	(revision bb2c13af5372856cf3f4222ad6543d4698919dbc)
++++ b/node_modules/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.mm	(revision d71fb46b9477b646c203f161aa3787740e1bbcbd)
+@@ -377,10 +377,6 @@
      self.backedTextInputView.attributedText = [NSAttributedString new];
    }
 
@@ -13,7 +13,7 @@ index b0d71dc..34cb289 100644
    [_eventDispatcher sendTextEventWithType:RCTTextEventTypeFocus
                                   reactTag:self.reactTag
                                       text:[self.backedTextInputView.attributedText.string copy]
-@@ -611,6 +607,10 @@ - (UIView *)reactAccessibilityElement
+@@ -611,6 +607,10 @@
  - (void)reactFocus
  {
    [self.backedTextInputView reactFocus];
@@ -24,6 +24,36 @@ index b0d71dc..34cb289 100644
  }
 
  - (void)reactBlur
+diff --git a/node_modules/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
+index b0d71dc..34cb289 100644
+--- a/node_modules/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
++++ b/node_modules/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
+@@ -281,11 +281,6 @@
+     [self textInputDidChange];
+   }
+
+-  if (props.traits.selectTextOnFocus) {
+-    [_backedTextInputView selectAll:nil];
+-    [self textInputDidChangeSelection];
+-  }
+-
+   if (_eventEmitter) {
+     static_cast<const TextInputEventEmitter &>(*_eventEmitter).onFocus([self _textInputMetrics]);
+   }
+@@ -425,6 +420,13 @@
+ - (void)focus
+ {
+   [_backedTextInputView becomeFirstResponder];
++
++  const auto &props = static_cast<const TextInputProps &>(*_props);
++
++  if (props.traits.selectTextOnFocus) {
++    [_backedTextInputView selectAll:nil];
++    [self textInputDidChangeSelection];
++  }
+ }
+
+ - (void)blur
 diff --git a/node_modules/react-native/React/Views/RefreshControl/RCTRefreshControl.h b/node_modules/react-native/React/Views/RefreshControl/RCTRefreshControl.h
 index e9b330f..1ecdf0a 100644
 --- a/node_modules/react-native/React/Views/RefreshControl/RCTRefreshControl.h

--- a/patches/react-native+0.73.2.patch
+++ b/patches/react-native+0.73.2.patch
@@ -1,7 +1,7 @@
 diff --git a/node_modules/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.mm b/packages/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.mm
 index b0d71dc..34cb289 100644
---- a/node_modules/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.mm	(revision bb2c13af5372856cf3f4222ad6543d4698919dbc)
-+++ b/node_modules/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.mm	(revision d71fb46b9477b646c203f161aa3787740e1bbcbd)
+--- a/node_modules/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.mm
++++ b/node_modules/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.mm
 @@ -377,10 +377,6 @@
      self.backedTextInputView.attributedText = [NSAttributedString new];
    }

--- a/patches/react-native+0.73.2.patch
+++ b/patches/react-native+0.73.2.patch
@@ -1,3 +1,29 @@
+diff --git a/node_modules/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.mm b/node_modules/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.mm
+index b0d71dc..34cb289 100644
+--- a/node_modules/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.mm
++++ b/node_modules/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.mm
+@@ -377,10 +377,6 @@ - (void)textInputDidBeginEditing
+     self.backedTextInputView.attributedText = [NSAttributedString new];
+   }
+
+-  if (_selectTextOnFocus) {
+-    [self.backedTextInputView selectAll:nil];
+-  }
+-
+   [_eventDispatcher sendTextEventWithType:RCTTextEventTypeFocus
+                                  reactTag:self.reactTag
+                                      text:[self.backedTextInputView.attributedText.string copy]
+@@ -611,6 +607,10 @@ - (UIView *)reactAccessibilityElement
+ - (void)reactFocus
+ {
+   [self.backedTextInputView reactFocus];
++
++  if (_selectTextOnFocus) {
++    [self.backedTextInputView selectAll:nil];
++  }
+ }
+
+ - (void)reactBlur
 diff --git a/node_modules/react-native/React/Views/RefreshControl/RCTRefreshControl.h b/node_modules/react-native/React/Views/RefreshControl/RCTRefreshControl.h
 index e9b330f..1ecdf0a 100644
 --- a/node_modules/react-native/React/Views/RefreshControl/RCTRefreshControl.h
@@ -5,7 +31,7 @@ index e9b330f..1ecdf0a 100644
 @@ -16,4 +16,6 @@
  @property (nonatomic, copy) RCTDirectEventBlock onRefresh;
  @property (nonatomic, weak) UIScrollView *scrollView;
- 
+
 +- (void)forwarderBeginRefreshing;
 +
  @end
@@ -16,7 +42,7 @@ index b09e653..4c32b31 100644
 @@ -198,9 +198,53 @@ - (void)refreshControlValueChanged
    [self setCurrentRefreshingState:super.refreshing];
    _refreshingProgrammatically = NO;
- 
+
 +  if (@available(iOS 17.4, *)) {
 +    if (_currentRefreshingState) {
 +      UIImpactFeedbackGenerator *feedbackGenerator = [[UIImpactFeedbackGenerator alloc] initWithStyle:UIImpactFeedbackStyleLight];
@@ -29,7 +55,7 @@ index b09e653..4c32b31 100644
      _onRefresh(nil);
    }
  }
- 
+
 +/*
 + This method is used by Bluesky's ExpoScrollForwarder. This allows other React Native
 + libraries to perform a refresh of a scrollview and access the refresh control's onRefresh
@@ -38,15 +64,15 @@ index b09e653..4c32b31 100644
 +- (void)forwarderBeginRefreshing
 +{
 +  _refreshingProgrammatically = NO;
-+  
++
 +  [self sizeToFit];
-+  
++
 +  if (!self.scrollView) {
 +    return;
 +  }
-+  
++
 +  UIScrollView *scrollView = (UIScrollView *)self.scrollView;
-+  
++
 +  [UIView animateWithDuration:0.3
 +    delay:0
 +    options:UIViewAnimationOptionBeginFromCurrentState
@@ -58,7 +84,7 @@ index b09e653..4c32b31 100644
 +    completion:^(__unused BOOL finished) {
 +      [super beginRefreshing];
 +      [self setCurrentRefreshingState:super.refreshing];
-+    
++
 +      if (self->_onRefresh) {
 +        self->_onRefresh(nil);
 +      }

--- a/patches/react-native+0.73.2.patch.md
+++ b/patches/react-native+0.73.2.patch.md
@@ -11,3 +11,23 @@ in the RN repo: https://github.com/facebook/react-native/issues/43388
 Patching `RCTRefreshControl.m` and `RCTRefreshControl.h` to add a new `forwarderBeginRefreshing` method to the class.
 This method is used by `ExpoScrollForwarder` to initiate a refresh of the underlying `UIScrollView` from inside that
 module.
+
+
+## RCTBaseTextInputView Patch - Move `selectAll` call to `reactFocus` method
+
+Patching `RCTBaseTextInputView.m` to move the `selectAll` call to the `reactFocus` method. Currently, `selectAll` is
+called in `textInputDidBeginEditing`. This would be fine, however, once `reactFocus` is later called (this happens every
+time the text field is focused), the selection is reset/removed. The previous solution was to do this:
+
+```tsx
+<TextInput
+    onFocus={() => {
+      if (Platform.OS === 'ios') {
+        textInput.current?.setSelection(0, searchText.length)
+      }
+    }}
+/>
+```
+
+This likely works, because by the time the `onFocus` event is called, `reactFocus` has also already been called. However
+this is probably unreliable.

--- a/src/view/screens/Search/Search.tsx
+++ b/src/view/screens/Search/Search.tsx
@@ -671,7 +671,7 @@ export function SearchScreen(
             placeholder={_(msg`Search`)}
             placeholderTextColor={pal.colors.textLight}
             returnKeyType="search"
-            // value={searchText}
+            value={searchText}
             style={[pal.text, styles.headerSearchInput]}
             keyboardAppearance={theme.colorScheme}
             selectTextOnFocus={isNative}

--- a/src/view/screens/Search/Search.tsx
+++ b/src/view/screens/Search/Search.tsx
@@ -25,7 +25,7 @@ import {NavigationProp} from '#/lib/routes/types'
 import {augmentSearchQuery} from '#/lib/strings/helpers'
 import {s} from '#/lib/styles'
 import {logger} from '#/logger'
-import {isIOS, isNative, isWeb} from '#/platform/detection'
+import {isNative, isWeb} from '#/platform/detection'
 import {listenSoftReset} from '#/state/events'
 import {useActorAutocompleteQuery} from '#/state/queries/actor-autocomplete'
 import {useActorSearch} from '#/state/queries/actor-search'
@@ -671,7 +671,7 @@ export function SearchScreen(
             placeholder={_(msg`Search`)}
             placeholderTextColor={pal.colors.textLight}
             returnKeyType="search"
-            value={searchText}
+            // value={searchText}
             style={[pal.text, styles.headerSearchInput]}
             keyboardAppearance={theme.colorScheme}
             selectTextOnFocus={isNative}
@@ -684,12 +684,6 @@ export function SearchScreen(
                 })
               } else {
                 setShowAutocomplete(true)
-                if (isIOS) {
-                  // We rely on selectTextOnFocus, but it's broken on iOS:
-                  // https://github.com/facebook/react-native/issues/41988
-                  textInput.current?.setSelection(0, searchText.length)
-                  // We still rely on selectTextOnFocus for it to be instant on Android.
-                }
               }
             }}
             onChangeText={onChangeText}


### PR DESCRIPTION
## Why

Note: Let's see what feedback comes from https://github.com/facebook/react-native/pull/44307 before merging this (or at least before releasing to prod)

There seems to be a bug in React Native's `TextInput` code when using `selectTextOnFocus` on iOS. After a brief investigation, I discovered that `selectAll` is called on the underlying `UITextField` whenever `textInputDidBeginEditing` is fired. However, it turns out that shortly after `textInputDidBeginEditing` is called, another method - `reactFocus` - is called on the view. Once `reactFocus` is called, the text selection is removed, and it appears that it never even happened at all.

This patch moves the `selectAll` call to be ran _after_ the `reactFocus` call has finished. This results in the consistent behavior we expect when selecting the text.

To note, `reactFocus` is the method used on the native side whenever you call `textInputRef.current?.focus()`. `reactFocus` is also special to the `RCTBaseTextInputView`, so we know that this method is related to the focusing of the input.

As I stated in the readme for the patch, it is quite possible that the current hack fix would continue to work.

```tsx
<TextInput
    onFocus={() => {
      if (Platform.OS === 'ios') {
        textInput.current?.setSelection(0, searchText.length)
      }
    }}
/>
```

It likely works, because by the time the `onFocus` event is received and we subsequently update the selection, `reactFocus` has also already been called. There very well could be situations where this is not true - note that the native code fires the `onFocus` event _prior_ to `reactFocus`, so it is theoretically possible I believe for the event to be received and the JS selection to be called _before_ `reactFocus` fires - although it's probably unlikely.

## Test Plan

Build for iOS with this patch, and observe that the search input filed is properly highlighted whenever the input is focused.

Here is a video of the before and after:


https://github.com/bluesky-social/social-app/assets/153161762/b6a2c7fb-958f-4376-b634-35a935f0764e

