### PR TITLE
Increase search `TextInput` hit area and improve the related UI

### DIFF
--- a/src/view/screens/Search/Search.tsx
+++ b/src/view/screens/Search/Search.tsx
@@ -11,6 +11,8 @@ import Animated, {
   FadeIn,
   FadeOut,
   LinearTransition,
+  useAnimatedStyle,
+  withSpring,
 } from 'react-native-reanimated'
 import {AppBskyActorDefs, AppBskyFeedDefs, moderateProfile} from '@atproto/api'
 import {
@@ -622,6 +624,14 @@ export function SearchScreen(
     )
   }
 
+  const showClearButton = showAutocomplete && searchText.length > 0
+  const clearButtonStyle = useAnimatedStyle(() => ({
+    opacity: withSpring(showClearButton ? 1 : 0, {
+      overshootClamping: true,
+      duration: 50,
+    }),
+  }))
+
   return (
     <View style={isWeb ? null : {flex: 1}}>
       <CenteredView
@@ -708,23 +718,22 @@ export function SearchScreen(
             autoComplete="off"
             autoCapitalize="none"
           />
-          {showAutocomplete && searchText.length > 0 ? (
-            <AnimatedPressable
-              entering={isNative ? FadeIn.delay(200).duration(200) : undefined}
-              exiting={isNative ? FadeOut.duration(50) : undefined}
-              testID="searchTextInputClearBtn"
-              onPress={onPressClearQuery}
-              accessibilityRole="button"
-              accessibilityLabel={_(msg`Clear search query`)}
-              accessibilityHint=""
-              hitSlop={HITSLOP_10}>
-              <FontAwesomeIcon
-                icon="xmark"
-                size={16}
-                style={pal.textLight as FontAwesomeIconStyle}
-              />
-            </AnimatedPressable>
-          ) : undefined}
+          <AnimatedPressable
+            layout={isNative ? LinearTransition.duration(200) : undefined}
+            disabled={!showClearButton}
+            style={clearButtonStyle}
+            testID="searchTextInputClearBtn"
+            onPress={onPressClearQuery}
+            accessibilityRole="button"
+            accessibilityLabel={_(msg`Clear search query`)}
+            accessibilityHint=""
+            hitSlop={HITSLOP_10}>
+            <FontAwesomeIcon
+              icon="xmark"
+              size={16}
+              style={pal.textLight as FontAwesomeIconStyle}
+            />
+          </AnimatedPressable>
         </AnimatedPressable>
         {showAutocomplete && (
           <View style={[styles.headerCancelBtn]}>

--- a/src/view/screens/Search/Search.tsx
+++ b/src/view/screens/Search/Search.tsx
@@ -527,23 +527,23 @@ export function SearchScreen(
 
   const onPressCancelSearch = React.useCallback(() => {
     scrollToTopWeb()
+    textInput.current?.blur()
+    setShowAutocomplete(false)
+    setSearchText(queryParam)
+  }, [queryParam])
 
-    if (showAutocomplete) {
-      textInput.current?.blur()
-      setShowAutocomplete(false)
-      setSearchText(queryParam)
+  const onPressClearSearch = React.useCallback(() => {
+    scrollToTopWeb()
+    // If we just `setParams` and set `q` to an empty string, the URL still displays `q=`, which isn't pretty.
+    // However, `.replace()` on native has a "push" animation that we don't want. So we need to handle these
+    // differently.
+    if (isWeb) {
+      navigation.replace('Search', {})
     } else {
-      // If we just `setParams` and set `q` to an empty string, the URL still displays `q=`, which isn't pretty.
-      // However, `.replace()` on native has a "push" animation that we don't want. So we need to handle these
-      // differently.
-      if (isWeb) {
-        navigation.replace('Search', {})
-      } else {
-        setSearchText('')
-        navigation.setParams({q: ''})
-      }
+      setSearchText('')
+      navigation.setParams({q: ''})
     }
-  }, [showAutocomplete, navigation, queryParam])
+  }, [navigation])
 
   const onChangeText = React.useCallback(async (text: string) => {
     scrollToTopWeb()
@@ -730,16 +730,29 @@ export function SearchScreen(
           ) : undefined}
         </Pressable>
 
-        {(queryParam || showAutocomplete) && (
+        {(showAutocomplete || queryParam) && (
           <View style={styles.headerCancelBtn}>
-            <Pressable
-              onPress={onPressCancelSearch}
-              accessibilityRole="button"
-              hitSlop={HITSLOP_10}>
-              <Text style={[pal.text]}>
-                <Trans>Cancel</Trans>
-              </Text>
-            </Pressable>
+            {showAutocomplete ? (
+              <Pressable
+                key="cancel"
+                onPress={onPressCancelSearch}
+                accessibilityRole="button"
+                hitSlop={HITSLOP_10}>
+                <Text style={[pal.text]}>
+                  <Trans>Cancel</Trans>
+                </Text>
+              </Pressable>
+            ) : (
+              <Pressable
+                key="clear"
+                onPress={onPressClearSearch}
+                accessibilityRole="button"
+                hitSlop={HITSLOP_10}>
+                <Text style={[pal.text]}>
+                  <Trans>Clear</Trans>
+                </Text>
+              </Pressable>
+            )}
           </View>
         )}
       </CenteredView>

--- a/src/view/screens/Search/Search.tsx
+++ b/src/view/screens/Search/Search.tsx
@@ -7,6 +7,11 @@ import {
   TextInput,
   View,
 } from 'react-native'
+import Animated, {
+  FadeIn,
+  FadeOut,
+  LinearTransition,
+} from 'react-native-reanimated'
 import {AppBskyActorDefs, AppBskyFeedDefs, moderateProfile} from '@atproto/api'
 import {
   FontAwesomeIcon,
@@ -56,6 +61,7 @@ import {
 } from '#/view/shell/desktop/Search'
 import {ProfileCardFeedLoadingPlaceholder} from 'view/com/util/LoadingPlaceholder'
 import {atoms as a} from '#/alf'
+const AnimatedPressable = Animated.createAnimatedComponent(Pressable)
 
 function Loader() {
   const pal = usePalette('default')
@@ -643,11 +649,13 @@ export function SearchScreen(
           </Pressable>
         )}
 
-        <Pressable
+        <AnimatedPressable
           // This only exists only for extra hitslop so don't expose it to the a11y tree.
           accessible={false}
           focusable={false}
+          // @ts-ignore web-only
           tabIndex={-1}
+          layout={isNative ? LinearTransition.duration(200) : undefined}
           style={[
             {backgroundColor: pal.colors.backgroundLight},
             styles.headerSearchContainer,
@@ -701,7 +709,9 @@ export function SearchScreen(
             autoCapitalize="none"
           />
           {showAutocomplete && searchText.length > 0 ? (
-            <Pressable
+            <AnimatedPressable
+              entering={isNative ? FadeIn.delay(200).duration(200) : undefined}
+              exiting={isNative ? FadeOut.duration(50) : undefined}
               testID="searchTextInputClearBtn"
               onPress={onPressClearQuery}
               accessibilityRole="button"
@@ -713,21 +723,22 @@ export function SearchScreen(
                 size={16}
                 style={pal.textLight as FontAwesomeIconStyle}
               />
-            </Pressable>
+            </AnimatedPressable>
           ) : undefined}
-        </Pressable>
-
+        </AnimatedPressable>
         {showAutocomplete && (
-          <View style={styles.headerCancelBtn}>
-            <Pressable
+          <View style={[styles.headerCancelBtn]}>
+            <AnimatedPressable
+              entering={isNative ? FadeIn.duration(300) : undefined}
+              exiting={isNative ? FadeOut.duration(50) : undefined}
               key="cancel"
               onPress={onPressCancelSearch}
               accessibilityRole="button"
               hitSlop={HITSLOP_10}>
-              <Text style={[pal.text]}>
+              <Text style={pal.text}>
                 <Trans>Cancel</Trans>
               </Text>
-            </Pressable>
+            </AnimatedPressable>
           </View>
         )}
       </CenteredView>
@@ -879,6 +890,9 @@ const styles = StyleSheet.create({
   },
   headerCancelBtn: {
     paddingLeft: 10,
+    alignSelf: 'center',
+    zIndex: -1,
+    elevation: -1, // For Android
   },
   tabBarContainer: {
     // @ts-ignore web only

--- a/src/view/screens/Search/Search.tsx
+++ b/src/view/screens/Search/Search.tsx
@@ -713,7 +713,7 @@ export function SearchScreen(
             autoComplete="off"
             autoCapitalize="none"
           />
-          {showAutocomplete ? (
+          {showAutocomplete && searchText.length > 0 ? (
             <Pressable
               testID="searchTextInputClearBtn"
               onPress={onPressClearQuery}

--- a/src/view/screens/Search/Search.tsx
+++ b/src/view/screens/Search/Search.tsx
@@ -657,13 +657,16 @@ export function SearchScreen(
         )}
 
         <Pressable
-          accessibilityRole="button"
+          // This only exists only for extra hitslop so don't expose it to the a11y tree.
+          accessible={false}
+          focusable={false}
+          tabIndex={-1}
           style={[
             {backgroundColor: pal.colors.backgroundLight},
             styles.headerSearchContainer,
             isWeb && {
               // @ts-ignore web only
-              cursor: 'text',
+              cursor: 'default',
             },
           ]}
           onPress={() => {

--- a/src/view/screens/Search/Search.tsx
+++ b/src/view/screens/Search/Search.tsx
@@ -656,11 +656,19 @@ export function SearchScreen(
           </Pressable>
         )}
 
-        <View
+        <Pressable
+          accessibilityRole="button"
           style={[
             {backgroundColor: pal.colors.backgroundLight},
             styles.headerSearchContainer,
-          ]}>
+            isWeb && {
+              // @ts-ignore web only
+              cursor: 'text',
+            },
+          ]}
+          onPress={() => {
+            textInput.current?.focus()
+          }}>
           <MagnifyingGlassIcon
             style={[pal.icon, styles.headerSearchIcon]}
             size={21}
@@ -717,7 +725,7 @@ export function SearchScreen(
               />
             </Pressable>
           ) : undefined}
-        </View>
+        </Pressable>
 
         {(queryParam || showAutocomplete) && (
           <View style={styles.headerCancelBtn}>

--- a/src/view/screens/Search/Search.tsx
+++ b/src/view/screens/Search/Search.tsx
@@ -532,19 +532,6 @@ export function SearchScreen(
     setSearchText(queryParam)
   }, [queryParam])
 
-  const onPressClearSearch = React.useCallback(() => {
-    scrollToTopWeb()
-    // If we just `setParams` and set `q` to an empty string, the URL still displays `q=`, which isn't pretty.
-    // However, `.replace()` on native has a "push" animation that we don't want. So we need to handle these
-    // differently.
-    if (isWeb) {
-      navigation.replace('Search', {})
-    } else {
-      setSearchText('')
-      navigation.setParams({q: ''})
-    }
-  }, [navigation])
-
   const onChangeText = React.useCallback(async (text: string) => {
     scrollToTopWeb()
     setSearchText(text)
@@ -730,29 +717,17 @@ export function SearchScreen(
           ) : undefined}
         </Pressable>
 
-        {(showAutocomplete || queryParam) && (
+        {showAutocomplete && (
           <View style={styles.headerCancelBtn}>
-            {showAutocomplete ? (
-              <Pressable
-                key="cancel"
-                onPress={onPressCancelSearch}
-                accessibilityRole="button"
-                hitSlop={HITSLOP_10}>
-                <Text style={[pal.text]}>
-                  <Trans>Cancel</Trans>
-                </Text>
-              </Pressable>
-            ) : (
-              <Pressable
-                key="clear"
-                onPress={onPressClearSearch}
-                accessibilityRole="button"
-                hitSlop={HITSLOP_10}>
-                <Text style={[pal.text]}>
-                  <Trans>Clear</Trans>
-                </Text>
-              </Pressable>
-            )}
+            <Pressable
+              key="cancel"
+              onPress={onPressCancelSearch}
+              accessibilityRole="button"
+              hitSlop={HITSLOP_10}>
+              <Text style={[pal.text]}>
+                <Trans>Cancel</Trans>
+              </Text>
+            </Pressable>
           </View>
         )}
       </CenteredView>


### PR DESCRIPTION
## Why

The hit area on the search text input is pretty small right now. What we can do instead is make the wrapper a `Pressable` and call `.focus()` whenever we press anywhere inside the gray pill.

## Test Plan

Open the app, tap around on the input. It should be a lot easier to focus now.

Also tested that the clear input button still works as well as our "select text on focus".

https://github.com/bluesky-social/social-app/assets/153161762/31c3dc26-79c4-41c2-8f3e-dc831e7908fe

