### PR TITLE
clear search on tab press

### DIFF
--- a/src/view/screens/Search/Search.tsx
+++ b/src/view/screens/Search/Search.tsx
@@ -601,7 +601,15 @@ export function SearchScreen(
   const onSoftReset = React.useCallback(() => {
     scrollToTopWeb()
     onPressCancelSearch()
-  }, [onPressCancelSearch])
+
+    if (isWeb) {
+      // Empty params resets the URL to be /search rather than /search?q=
+      navigation.replace('Search', {})
+    } else {
+      setSearchText('')
+      navigation.setParams({q: ''})
+    }
+  }, [navigation, onPressCancelSearch])
 
   useFocusEffect(
     React.useCallback(() => {

--- a/src/view/screens/Search/Search.tsx
+++ b/src/view/screens/Search/Search.tsx
@@ -599,9 +599,6 @@ export function SearchScreen(
   )
 
   const onSoftReset = React.useCallback(() => {
-    scrollToTopWeb()
-    onPressCancelSearch()
-
     if (isWeb) {
       // Empty params resets the URL to be /search rather than /search?q=
       navigation.replace('Search', {})
@@ -609,7 +606,7 @@ export function SearchScreen(
       setSearchText('')
       navigation.setParams({q: ''})
     }
-  }, [navigation, onPressCancelSearch])
+  }, [navigation])
 
   useFocusEffect(
     React.useCallback(() => {


### PR DESCRIPTION
## Why

We used to do this, but looks like we removed the logic on accident while reworking `onPressCancelSearch`. This adds back the logic that returns the user to the "Follow Suggestions" root screen after pressing the tab button again.

## Test Plan

Normal for this screen, and test the search tab button after searching to see if it properly takes you back.


https://github.com/bluesky-social/social-app/assets/153161762/f15c5558-90fb-4b57-8338-ca63b823c882

