### PR TITLE
Hide search suggestion on clicking outside search field

### DIFF
--- a/src/view/shell/desktop/Search.tsx
+++ b/src/view/shell/desktop/Search.tsx
@@ -180,6 +180,10 @@ export function DesktopSearch() {
     setIsActive(false)
   }, [])
 
+  const onBlur = React.useCallback(() => {
+    setIsActive(false)
+  }, [])
+
   return (
     <View style={[styles.container, pal.view]}>
       <View
@@ -197,6 +201,7 @@ export function DesktopSearch() {
             returnKeyType="search"
             value={query}
             style={[pal.textLight, styles.input]}
+            onBlur={onBlur}
             onChangeText={onChangeText}
             onSubmitEditing={onSubmit}
             accessibilityRole="search"

--- a/src/view/shell/desktop/Search.tsx
+++ b/src/view/shell/desktop/Search.tsx
@@ -213,7 +213,7 @@ export function DesktopSearch() {
       document.removeEventListener('focusin', handleFocusIn)
       document.removeEventListener('focusout', handleFocusOut)
     }
-  }, [])
+  }, [searchViewRef, setIsActive])
 
   return (
     <View style={[styles.container, pal.view]} ref={searchViewRef}>

--- a/src/view/shell/desktop/Search.tsx
+++ b/src/view/shell/desktop/Search.tsx
@@ -31,6 +31,10 @@ import {Link} from '#/view/com/util/Link'
 import {UserAvatar} from '#/view/com/util/UserAvatar'
 import {Text} from 'view/com/util/text/Text'
 
+interface SearchRef extends View {
+  contains: (node: Node | null) => boolean
+}
+
 let SearchLinkCard = ({
   label,
   to,
@@ -152,6 +156,7 @@ export function DesktopSearch() {
   const navigation = useNavigation<NavigationProp>()
   const [isActive, setIsActive] = React.useState<boolean>(false)
   const [query, setQuery] = React.useState<string>('')
+  const searchViewRef = React.useRef<SearchRef>(null)
   const {data: autocompleteData, isFetching} = useActorAutocompleteQuery(
     query,
     true,
@@ -180,12 +185,38 @@ export function DesktopSearch() {
     setIsActive(false)
   }, [])
 
-  const onBlur = React.useCallback(() => {
-    setIsActive(false)
+  React.useEffect(() => {
+    const handleFocusIn = () => {
+      const shouldBeActive = Boolean(
+        searchViewRef.current?.contains(document.activeElement),
+      )
+      setIsActive(shouldBeActive)
+    }
+    const handleFocusOut = (event: FocusEvent) => {
+      const relatedTarget = event.relatedTarget
+
+      if (relatedTarget === null) {
+        setIsActive(false)
+        return
+      }
+
+      const shouldBeActive = Boolean(
+        searchViewRef.current?.contains(relatedTarget as Element),
+      )
+      setIsActive(shouldBeActive)
+    }
+
+    document.addEventListener('focusin', handleFocusIn)
+    document.addEventListener('focusout', handleFocusOut)
+
+    return () => {
+      document.removeEventListener('focusin', handleFocusIn)
+      document.removeEventListener('focusout', handleFocusOut)
+    }
   }, [])
 
   return (
-    <View style={[styles.container, pal.view]}>
+    <View style={[styles.container, pal.view]} ref={searchViewRef}>
       <View
         style={[{backgroundColor: pal.colors.backgroundLight}, styles.search]}>
         <View style={[styles.inputContainer]}>
@@ -201,7 +232,6 @@ export function DesktopSearch() {
             returnKeyType="search"
             value={query}
             style={[pal.textLight, styles.input]}
-            onBlur={onBlur}
             onChangeText={onChangeText}
             onSubmitEditing={onSubmit}
             accessibilityRole="search"


### PR DESCRIPTION
The current behavior, as @gaearon mentioned [here](https://github.com/bluesky-social/social-app/issues/3724#issuecomment-2080387930), allows the search suggestion open even when clicking outside the search field. Implementing an event handler for blurring would resolve this issue temporarily. Additionally, I concur with the suggestion to evolve the search suggestion into a popover.