### PR TITLE
Fix List onMomentumScrollEnd

### DIFF
--- a/src/view/com/util/List.tsx
+++ b/src/view/com/util/List.tsx
@@ -13,7 +13,11 @@ import {FlatList_INTERNAL} from './Views'
 export type ListMethods = FlatList_INTERNAL
 export type ListProps<ItemT> = Omit<
   FlatListProps<ItemT>,
+  | 'onMomentumScrollBegin' // Use ScrollContext instead.
+  | 'onMomentumScrollEnd' // Use ScrollContext instead.
   | 'onScroll' // Use ScrollContext instead.
+  | 'onScrollBeginDrag' // Use ScrollContext instead.
+  | 'onScrollEndDrag' // Use ScrollContext instead.
   | 'refreshControl' // Pass refreshing and/or onRefresh instead.
   | 'contentOffset' // Pass headerOffset instead.
 > & {


### PR DESCRIPTION
I forgot that passing Reanimated handlers breaks built-in event handler properties on `FlatList`. So because I started passing in `onMomentumEnd` in the Reanimated handler, the built-in `onMomentumScrollEnd` was no longer being called.

The fix is to add it to the denylist we already have (which currently has `onScroll` in it). I've added the other related events there too so that we don't run into this again.

Then we use the existing `<ScrollContext>` to pass the contextual handler to the `List`. On this page it doesn't need to compose with anything because there's no top-level scroll context.

## Test Plan

No effect on the web — that event isn't wired up there. We don't need it on the web either.

iOS and Android are now able to load a long thread upwards.

https://github.com/bluesky-social/social-app/assets/810438/e40b35d1-a0db-4650-99e2-293e0ddf5550


https://github.com/bluesky-social/social-app/assets/810438/e0b64780-bf63-49ac-a3d6-2a6f85f07f80

