### PR TITLE
switch branch for installing `react-native-bottom-sheet`

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@atproto/api": "^0.12.5",
     "@bam.tech/react-native-image-resizer": "^3.0.4",
     "@braintree/sanitize-url": "^6.0.2",
-    "@discord/bottom-sheet": "https://github.com/bluesky-social/react-native-bottom-sheet.git#discord-fork-4.6.1",
+    "@discord/bottom-sheet": "bluesky-social/react-native-bottom-sheet",
     "@emoji-mart/react": "^1.1.1",
     "@expo/html-elements": "^0.4.2",
     "@expo/webpack-config": "^19.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2765,9 +2765,9 @@
     pino "^8.11.0"
     pino-http "^8.3.3"
 
-"@discord/bottom-sheet@https://github.com/bluesky-social/react-native-bottom-sheet.git#discord-fork-4.6.1":
+"@discord/bottom-sheet@bluesky-social/react-native-bottom-sheet":
   version "4.6.1"
-  resolved "https://github.com/bluesky-social/react-native-bottom-sheet.git#54dc2e0e318b0524a2d2d8fb817f6c48101bb0b1"
+  resolved "https://codeload.github.com/bluesky-social/react-native-bottom-sheet/tar.gz/2b3f77e04a25c454e70d893a2692e8c03aced06b"
   dependencies:
     "@gorhom/portal" "1.0.14"
     invariant "^2.2.4"


### PR DESCRIPTION
Just switches to using the main branch vs the `4.6.1` branch. I did:

- Merged Discord's 4.6.1 branch - what we were using - into main
- Reverted https://github.com/gorhom/react-native-bottom-sheet/pull/1288. See https://github.com/bluesky-social/react-native-bottom-sheet/commit/4af77ba9158fd2356650c952f6e8ff6ae9e8ec0b
- Tested that accessibility now works.
- Tested that closing the dialog w/ the keyboard open still works (this verifies that the 4.6.1 branch is now on main).

We shouldn't need to mess with this anymore.