### PR TITLE
sentry errors for captcha web views and registration attempts

### DIFF
--- a/src/screens/Signup/StepCaptcha/CaptchaWebView.tsx
+++ b/src/screens/Signup/StepCaptcha/CaptchaWebView.tsx
@@ -3,7 +3,6 @@ import {StyleSheet} from 'react-native'
 import {WebView, WebViewNavigation} from 'react-native-webview'
 import {ShouldStartLoadRequest} from 'react-native-webview/lib/WebViewTypes'
 
-import {logger} from '#/logger'
 import {SignupState} from '#/screens/Signup/state'
 
 const ALLOWED_HOSTS = [
@@ -27,7 +26,7 @@ export function CaptchaWebView({
   stateParam: string
   state?: SignupState
   onSuccess: (code: string) => void
-  onError: () => void
+  onError: (error: object) => void
 }) {
   const redirectHost = React.useMemo(() => {
     if (!state?.serviceUrl) return 'bsky.app'
@@ -57,7 +56,7 @@ export function CaptchaWebView({
 
       const code = urlp.searchParams.get('code')
       if (urlp.searchParams.get('state') !== stateParam || !code) {
-        onError()
+        onError({error: 'Invalid state or code'})
         return
       }
 
@@ -77,14 +76,10 @@ export function CaptchaWebView({
       scrollEnabled={false}
       on
       onError={e => {
-        logger.warn('Signup Flow Error: CaptchaWebView', {
-          webViewError: JSON.stringify(e.nativeEvent),
-        })
+        onError(e.nativeEvent)
       }}
       onHttpError={e => {
-        logger.warn('Signup Flow Error: CaptchaWebView', {
-          webViewError: JSON.stringify(e.nativeEvent),
-        })
+        onError(e.nativeEvent)
       }}
     />
   )

--- a/src/screens/Signup/StepCaptcha/CaptchaWebView.tsx
+++ b/src/screens/Signup/StepCaptcha/CaptchaWebView.tsx
@@ -74,7 +74,6 @@ export function CaptchaWebView({
       onShouldStartLoadWithRequest={onShouldStartLoadWithRequest}
       onNavigationStateChange={onNavigationStateChange}
       scrollEnabled={false}
-      on
       onError={e => {
         onError(e.nativeEvent)
       }}

--- a/src/screens/Signup/StepCaptcha/CaptchaWebView.tsx
+++ b/src/screens/Signup/StepCaptcha/CaptchaWebView.tsx
@@ -3,6 +3,7 @@ import {StyleSheet} from 'react-native'
 import {WebView, WebViewNavigation} from 'react-native-webview'
 import {ShouldStartLoadRequest} from 'react-native-webview/lib/WebViewTypes'
 
+import {logger} from '#/logger'
 import {SignupState} from '#/screens/Signup/state'
 
 const ALLOWED_HOSTS = [
@@ -74,6 +75,17 @@ export function CaptchaWebView({
       onShouldStartLoadWithRequest={onShouldStartLoadWithRequest}
       onNavigationStateChange={onNavigationStateChange}
       scrollEnabled={false}
+      on
+      onError={e => {
+        logger.warn('Signup Flow Error: CaptchaWebView', {
+          webViewError: JSON.stringify(e.nativeEvent),
+        })
+      }}
+      onHttpError={e => {
+        logger.warn('Signup Flow Error: CaptchaWebView', {
+          webViewError: JSON.stringify(e.nativeEvent),
+        })
+      }}
     />
   )
 }

--- a/src/screens/Signup/StepCaptcha/CaptchaWebView.tsx
+++ b/src/screens/Signup/StepCaptcha/CaptchaWebView.tsx
@@ -26,7 +26,7 @@ export function CaptchaWebView({
   stateParam: string
   state?: SignupState
   onSuccess: (code: string) => void
-  onError: (error: object) => void
+  onError: (error: unknown) => void
 }) {
   const redirectHost = React.useMemo(() => {
     if (!state?.serviceUrl) return 'bsky.app'

--- a/src/screens/Signup/StepCaptcha/CaptchaWebView.web.tsx
+++ b/src/screens/Signup/StepCaptcha/CaptchaWebView.web.tsx
@@ -1,8 +1,6 @@
 import React from 'react'
 import {StyleSheet} from 'react-native'
 
-import {logger} from '#/logger'
-
 // @ts-ignore web only, we will always redirect to the app on web (CORS)
 const REDIRECT_HOST = new URL(window.location.href).host
 
@@ -15,7 +13,7 @@ export function CaptchaWebView({
   url: string
   stateParam: string
   onSuccess: (code: string) => void
-  onError: () => void
+  onError: (error: object) => void
 }) {
   const onLoad = React.useCallback(() => {
     // @ts-ignore web
@@ -34,7 +32,7 @@ export function CaptchaWebView({
 
       const code = urlp.searchParams.get('code')
       if (urlp.searchParams.get('state') !== stateParam || !code) {
-        onError()
+        onError({error: 'Invalid state or code'})
         return
       }
       onSuccess(code)
@@ -50,9 +48,7 @@ export function CaptchaWebView({
       id="captcha-iframe"
       onLoad={onLoad}
       onError={e => {
-        logger.warn('Signup Flow Error: CaptchaWebView', {
-          webViewError: JSON.stringify(e.nativeEvent),
-        })
+        onError(e.nativeEvent)
       }}
     />
   )

--- a/src/screens/Signup/StepCaptcha/CaptchaWebView.web.tsx
+++ b/src/screens/Signup/StepCaptcha/CaptchaWebView.web.tsx
@@ -18,9 +18,9 @@ export function CaptchaWebView({
   React.useEffect(() => {
     const interval = setTimeout(() => {
       onError({
-        errorMessage: 'User did not complete the captcha within 20 seconds',
+        errorMessage: 'User did not complete the captcha within 30 seconds',
       })
-    }, 20e3)
+    }, 30e3)
 
     return () => {
       clearTimeout(interval)

--- a/src/screens/Signup/StepCaptcha/CaptchaWebView.web.tsx
+++ b/src/screens/Signup/StepCaptcha/CaptchaWebView.web.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import {StyleSheet} from 'react-native'
 
+import {logger} from '#/logger'
+
 // @ts-ignore web only, we will always redirect to the app on web (CORS)
 const REDIRECT_HOST = new URL(window.location.href).host
 
@@ -47,6 +49,11 @@ export function CaptchaWebView({
       style={styles.iframe}
       id="captcha-iframe"
       onLoad={onLoad}
+      onError={e => {
+        logger.warn('Signup Flow Error: CaptchaWebView', {
+          webViewError: JSON.stringify(e.nativeEvent),
+        })
+      }}
     />
   )
 }

--- a/src/screens/Signup/StepCaptcha/CaptchaWebView.web.tsx
+++ b/src/screens/Signup/StepCaptcha/CaptchaWebView.web.tsx
@@ -49,7 +49,9 @@ export function CaptchaWebView({
       }
       onSuccess(code)
     } catch (e: unknown) {
-      onError(e)
+      // We don't actually want to record an error here, because this will happen quite a bit. We will only be able to
+      // get hte href of the iframe if it's on our domain, so all the hcaptcha requests will throw here, although it's
+      // harmless. Our other indicators of time-to-complete and back press should be more reliable in catching issues.
     }
   }, [stateParam, onSuccess, onError])
 

--- a/src/screens/Signup/StepCaptcha/CaptchaWebView.web.tsx
+++ b/src/screens/Signup/StepCaptcha/CaptchaWebView.web.tsx
@@ -15,6 +15,18 @@ export function CaptchaWebView({
   onSuccess: (code: string) => void
   onError: (error: object) => void
 }) {
+  React.useEffect(() => {
+    const interval = setTimeout(() => {
+      onError({
+        errorMessage: 'User did not complete the captcha within 20 seconds',
+      })
+    }, 20e3)
+
+    return () => {
+      clearTimeout(interval)
+    }
+  }, [onError])
+
   const onLoad = React.useCallback(() => {
     // @ts-ignore web
     const frame: HTMLIFrameElement = document.getElementById(
@@ -37,7 +49,7 @@ export function CaptchaWebView({
       }
       onSuccess(code)
     } catch (e) {
-      // We don't need to handle this
+      onError({errorMessage: 'Error creating captcha URL'})
     }
   }, [stateParam, onSuccess, onError])
 
@@ -47,9 +59,6 @@ export function CaptchaWebView({
       style={styles.iframe}
       id="captcha-iframe"
       onLoad={onLoad}
-      onError={e => {
-        onError(e.nativeEvent)
-      }}
     />
   )
 }

--- a/src/screens/Signup/StepCaptcha/CaptchaWebView.web.tsx
+++ b/src/screens/Signup/StepCaptcha/CaptchaWebView.web.tsx
@@ -13,7 +13,7 @@ export function CaptchaWebView({
   url: string
   stateParam: string
   onSuccess: (code: string) => void
-  onError: (error: object) => void
+  onError: (error: unknown) => void
 }) {
   React.useEffect(() => {
     const interval = setTimeout(() => {
@@ -48,8 +48,8 @@ export function CaptchaWebView({
         return
       }
       onSuccess(code)
-    } catch (e) {
-      onError({errorMessage: 'Error creating captcha URL'})
+    } catch (e: unknown) {
+      onError(e)
     }
   }, [stateParam, onSuccess, onError])
 

--- a/src/screens/Signup/StepCaptcha/CaptchaWebView.web.tsx
+++ b/src/screens/Signup/StepCaptcha/CaptchaWebView.web.tsx
@@ -16,14 +16,14 @@ export function CaptchaWebView({
   onError: (error: unknown) => void
 }) {
   React.useEffect(() => {
-    const interval = setTimeout(() => {
+    const timeout = setTimeout(() => {
       onError({
         errorMessage: 'User did not complete the captcha within 30 seconds',
       })
     }, 30e3)
 
     return () => {
-      clearTimeout(interval)
+      clearTimeout(timeout)
     }
   }, [onError])
 

--- a/src/screens/Signup/StepCaptcha/index.tsx
+++ b/src/screens/Signup/StepCaptcha/index.tsx
@@ -50,10 +50,10 @@ export function StepCaptcha() {
         type: 'setError',
         value: _(msg`Error receiving captcha response.`),
       })
-      logger.error(
-        'Signup Flow Error: An error occurred during the captcha process.',
-        {registrationHandle: state.handle, error},
-      )
+      logger.error('Signup Flow Error', {
+        registrationHandle: state.handle,
+        error,
+      })
     },
     [_, dispatch, state.handle],
   )

--- a/src/screens/Signup/StepCaptcha/index.tsx
+++ b/src/screens/Signup/StepCaptcha/index.tsx
@@ -45,7 +45,7 @@ export function StepCaptcha() {
   )
 
   const onError = React.useCallback(
-    (error?: object) => {
+    (error?: unknown) => {
       dispatch({
         type: 'setError',
         value: _(msg`Error receiving captcha response.`),

--- a/src/screens/Signup/StepCaptcha/index.tsx
+++ b/src/screens/Signup/StepCaptcha/index.tsx
@@ -5,6 +5,7 @@ import {useLingui} from '@lingui/react'
 import {nanoid} from 'nanoid/non-secure'
 
 import {createFullHandle} from '#/lib/strings/handles'
+import {logger} from '#/logger'
 import {ScreenTransition} from '#/screens/Login/ScreenTransition'
 import {useSignupContext, useSubmitSignup} from '#/screens/Signup/state'
 import {CaptchaWebView} from '#/screens/Signup/StepCaptcha/CaptchaWebView'
@@ -43,12 +44,19 @@ export function StepCaptcha() {
     [submit],
   )
 
-  const onError = React.useCallback(() => {
-    dispatch({
-      type: 'setError',
-      value: _(msg`Error receiving captcha response.`),
-    })
-  }, [_, dispatch])
+  const onError = React.useCallback(
+    (error?: object) => {
+      dispatch({
+        type: 'setError',
+        value: _(msg`Error receiving captcha response.`),
+      })
+      logger.error(
+        'Signup Flow Error: An error occurred during the captcha process.',
+        {registrationHandle: state.handle, error},
+      )
+    },
+    [_, dispatch, state.handle],
+  )
 
   return (
     <ScreenTransition>

--- a/src/screens/Signup/index.tsx
+++ b/src/screens/Signup/index.tsx
@@ -8,6 +8,7 @@ import {useAnalytics} from '#/lib/analytics/analytics'
 import {FEEDBACK_FORM_URL} from '#/lib/constants'
 import {logEvent} from '#/lib/statsig/statsig'
 import {createFullHandle} from '#/lib/strings/handles'
+import {logger} from '#/logger'
 import {useServiceQuery} from '#/state/queries/service'
 import {useAgent} from '#/state/session'
 import {LoggedOutLayout} from '#/view/com/util/layouts/LoggedOutLayout'
@@ -119,11 +120,20 @@ export function Signup({onPressBack}: {onPressBack: () => void}) {
 
   const onBackPress = React.useCallback(() => {
     if (state.activeStep !== SignupStep.INFO) {
+      if (state.activeStep === SignupStep.CAPTCHA) {
+        console.log('hit this')
+        logger.error('Signup Flow Error:', {
+          errorMessage:
+            'User went back from captcha step. Possibly encountered an error.',
+          registrationHandle: state.handle,
+        })
+      }
+
       dispatch({type: 'prev'})
     } else {
       onPressBack()
     }
-  }, [onPressBack, state.activeStep])
+  }, [onPressBack, state.activeStep, state.handle])
 
   return (
     <SignupContext.Provider value={{state, dispatch}}>

--- a/src/screens/Signup/index.tsx
+++ b/src/screens/Signup/index.tsx
@@ -121,7 +121,7 @@ export function Signup({onPressBack}: {onPressBack: () => void}) {
   const onBackPress = React.useCallback(() => {
     if (state.activeStep !== SignupStep.INFO) {
       if (state.activeStep === SignupStep.CAPTCHA) {
-        logger.error('Signup Flow Error:', {
+        logger.error('Signup Flow Error', {
           errorMessage:
             'User went back from captcha step. Possibly encountered an error.',
           registrationHandle: state.handle,

--- a/src/screens/Signup/index.tsx
+++ b/src/screens/Signup/index.tsx
@@ -121,7 +121,6 @@ export function Signup({onPressBack}: {onPressBack: () => void}) {
   const onBackPress = React.useCallback(() => {
     if (state.activeStep !== SignupStep.INFO) {
       if (state.activeStep === SignupStep.CAPTCHA) {
-        console.log('hit this')
         logger.error('Signup Flow Error:', {
           errorMessage:
             'User went back from captcha step. Possibly encountered an error.',

--- a/src/screens/Signup/state.ts
+++ b/src/screens/Signup/state.ts
@@ -246,6 +246,10 @@ export function useSubmitSignup({
         !verificationCode
       ) {
         dispatch({type: 'setStep', value: SignupStep.CAPTCHA})
+        logger.error('Signup Flow Error:', {
+          errorMessage: 'Verification captcha code was not set.',
+          registrationHandle: state.handle,
+        })
         return dispatch({
           type: 'setError',
           value: _(msg`Please complete the verification captcha.`),
@@ -282,20 +286,17 @@ export function useSubmitSignup({
           return
         }
 
-        if ([400, 429].includes(e.status)) {
-          logger.warn('Failed to create account', {message: e})
-        } else {
-          logger.error(`Failed to create account (${e.status} status)`, {
-            message: e,
-          })
-        }
-
         const error = cleanError(errMsg)
         const isHandleError = error.toLowerCase().includes('handle')
 
         dispatch({type: 'setIsLoading', value: false})
-        dispatch({type: 'setError', value: cleanError(errMsg)})
+        dispatch({type: 'setError', value: error})
         dispatch({type: 'setStep', value: isHandleError ? 2 : 1})
+
+        logger.error('Signup Flow Error:', {
+          errorMessage: error,
+          registrationHandle: state.handle,
+        })
       } finally {
         dispatch({type: 'setIsLoading', value: false})
       }

--- a/src/screens/Signup/state.ts
+++ b/src/screens/Signup/state.ts
@@ -246,7 +246,7 @@ export function useSubmitSignup({
         !verificationCode
       ) {
         dispatch({type: 'setStep', value: SignupStep.CAPTCHA})
-        logger.error('Signup Flow Error:', {
+        logger.error('Signup Flow Error', {
           errorMessage: 'Verification captcha code was not set.',
           registrationHandle: state.handle,
         })
@@ -293,7 +293,7 @@ export function useSubmitSignup({
         dispatch({type: 'setError', value: error})
         dispatch({type: 'setStep', value: isHandleError ? 2 : 1})
 
-        logger.error('Signup Flow Error:', {
+        logger.error('Signup Flow Error', {
           errorMessage: error,
           registrationHandle: state.handle,
         })


### PR DESCRIPTION
## Why

We should have some more robust error reporting around signups. This adds Sentry logs to the most sensitive areas of that flow:

- Captcha webview errors
- Other cases where a captcha isn't set (we shouldn't hit this one but just in case?)
- Any failure after submitting the registration request

## Test Plan

Not really sure how to test this one, aside from waiting for these to come through on Sentry. For what it's worth, we already had some of these coming through but this makes the errors a little easier to set up alerts for using the "Signup Flow Error:" prefix.