### PR TITLE
remove trailing period from query term in `useActorAutocompleteQuery`

### DIFF
--- a/src/state/queries/actor-autocomplete.ts
+++ b/src/state/queries/actor-autocomplete.ts
@@ -23,11 +23,17 @@ export function useActorAutocompleteQuery(
   const moderationOpts = useModerationOpts()
   const {getAgent} = useAgent()
 
-  prefix = prefix.toLowerCase()
+  const prefixTrimmed = React.useMemo(() => {
+    let trimmed = prefix.toLowerCase().trim()
+    if (trimmed.endsWith('.')) {
+      trimmed = trimmed.slice(0, -1)
+    }
+    return trimmed
+  }, [prefix])
 
   return useQuery<AppBskyActorDefs.ProfileViewBasic[]>({
     staleTime: STALE.MINUTES.ONE,
-    queryKey: RQKEY(prefix || ''),
+    queryKey: RQKEY(prefixTrimmed || ''),
     async queryFn() {
       const res = prefix
         ? await getAgent().searchActorsTypeahead({


### PR DESCRIPTION
## Why

Right now, if there's a trailing period in the search term, then no results are returned for the query.

https://github.com/bluesky-social/social-app/assets/153161762/593ef5c1-9b42-4b4b-9fa2-c345f65f1c0a

Instead, we can remove the trailing period (after converting it to lowercase and trimming) to get the expected result. We should get this fixed on the backend as well.

## Test Plan

Test various handles. Adding a period to the end of the autocomplete query should still return the query with the suggested actor(s).

https://github.com/bluesky-social/social-app/assets/153161762/68c980b7-eecd-40dc-913c-c7f29250930b

