### PR TITLE
[Clipclops] Dynamic input height

### DIFF
--- a/package.json
+++ b/package.json
@@ -185,6 +185,7 @@
     "react-native-web-webview": "^1.0.2",
     "react-native-webview": "13.6.4",
     "react-responsive": "^9.0.2",
+    "react-textarea-autosize": "^8.5.3",
     "rn-fetch-blob": "^0.12.0",
     "sentry-expo": "~7.0.1",
     "statsig-react-native-expo": "^4.6.1",

--- a/src/screens/Messages/Conversation/MessageInput.tsx
+++ b/src/screens/Messages/Conversation/MessageInput.tsx
@@ -35,7 +35,10 @@ export function MessageInput({
   const inputRef = React.useRef<TextInput>(null)
 
   const onSubmit = React.useCallback(() => {
-    onSendMessage(message)
+    if (message.trim() === '') {
+      return
+    }
+    onSendMessage(message.trimEnd())
     setMessage('')
     setTimeout(() => {
       inputRef.current?.focus()

--- a/src/screens/Messages/Conversation/MessageInput.tsx
+++ b/src/screens/Messages/Conversation/MessageInput.tsx
@@ -9,6 +9,8 @@ import {
   View,
 } from 'react-native'
 import {useSafeAreaInsets} from 'react-native-safe-area-context'
+import {msg} from '@lingui/macro'
+import {useLingui} from '@lingui/react'
 
 import {atoms as a, useTheme} from '#/alf'
 import {Text} from '#/components/Typography'
@@ -22,6 +24,7 @@ export function MessageInput({
   onFocus: () => void
   onBlur: () => void
 }) {
+  const {_} = useLingui()
   const t = useTheme()
   const [message, setMessage] = React.useState('')
   const [maxHeight, setMaxHeight] = React.useState<number | undefined>()
@@ -65,11 +68,11 @@ export function MessageInput({
         {borderRadius: 23},
       ]}>
       <TextInput
-        accessibilityLabel="Text input field"
-        accessibilityHint="Write a message"
-        value={message}
-        placeholder="Write a message"
+        accessibilityLabel={_(msg`Message input field`)}
+        accessibilityHint={_(msg`Type your message here`)}
+        placeholder={_(msg`Write a message`)}
         placeholderTextColor={t.palette.contrast_500}
+        value={message}
         multiline={true}
         onChangeText={setMessage}
         style={[a.flex_1, a.text_md, a.px_sm, t.atoms.text, {maxHeight}]}

--- a/src/screens/Messages/Conversation/MessageInput.tsx
+++ b/src/screens/Messages/Conversation/MessageInput.tsx
@@ -81,10 +81,10 @@ export function MessageInput({
         style={[a.flex_1, a.text_md, a.px_sm, t.atoms.text, {maxHeight}]}
         keyboardAppearance={t.name === 'light' ? 'light' : 'dark'}
         scrollEnabled={isInputScrollable}
+        blurOnSubmit={false}
         onFocus={onFocus}
         onBlur={onBlur}
         onContentSizeChange={onInputLayout}
-        blurOnSubmit={false}
         ref={inputRef}
       />
       <Pressable

--- a/src/screens/Messages/Conversation/MessageInput.tsx
+++ b/src/screens/Messages/Conversation/MessageInput.tsx
@@ -91,7 +91,8 @@ export function MessageInput({
           a.align_center,
           a.justify_center,
           {height: 30, width: 30, backgroundColor: t.palette.primary_500},
-        ]}>
+        ]}
+        onPress={onSubmit}>
         <Text style={a.text_md}>🐴</Text>
       </Pressable>
     </View>

--- a/src/screens/Messages/Conversation/MessageInput.tsx
+++ b/src/screens/Messages/Conversation/MessageInput.tsx
@@ -2,16 +2,13 @@ import React from 'react'
 import {
   Dimensions,
   Keyboard,
-  LayoutChangeEvent,
   NativeSyntheticEvent,
   Pressable,
   TextInput,
   TextInputContentSizeChangeEventData,
-  useWindowDimensions,
   View,
 } from 'react-native'
-import {useKeyboardContext} from 'react-native-keyboard-controller'
-import {useSafeArea, useSafeAreaInsets} from 'react-native-safe-area-context'
+import {useSafeAreaInsets} from 'react-native-safe-area-context'
 
 import {atoms as a, useTheme} from '#/alf'
 import {Text} from '#/components/Typography'

--- a/src/screens/Messages/Conversation/MessageInput.tsx
+++ b/src/screens/Messages/Conversation/MessageInput.tsx
@@ -81,10 +81,10 @@ export function MessageInput({
         style={[a.flex_1, a.text_md, a.px_sm, t.atoms.text, {maxHeight}]}
         keyboardAppearance={t.name === 'light' ? 'light' : 'dark'}
         scrollEnabled={isInputScrollable}
-        onSubmitEditing={onSubmit}
         onFocus={onFocus}
         onBlur={onBlur}
         onContentSizeChange={onInputLayout}
+        blurOnSubmit={false}
         ref={inputRef}
       />
       <Pressable

--- a/src/screens/Messages/Conversation/MessageInput.web.tsx
+++ b/src/screens/Messages/Conversation/MessageInput.web.tsx
@@ -1,0 +1,66 @@
+import React, {ReactHTMLElement} from 'react'
+import {Pressable, View} from 'react-native'
+import {msg} from '@lingui/macro'
+import {useLingui} from '@lingui/react'
+import TextareaAutosize from 'react-textarea-autosize'
+
+import {atoms as a, useTheme} from '#/alf'
+import {Text} from '#/components/Typography'
+
+export function MessageInput({
+  onSendMessage,
+}: {
+  onSendMessage: (message: string) => void
+  onFocus: () => void
+  onBlur: () => void
+}) {
+  const {_} = useLingui()
+  const t = useTheme()
+  const [message, setMessage] = React.useState('')
+
+  const inputRef = React.useRef<ReactHTMLElement<HTMLTextAreaElement>>(null)
+
+  const onSubmit = React.useCallback(() => {
+    onSendMessage(message)
+    setMessage('')
+    inputRef.current?.focus?.()
+  }, [message, onSendMessage])
+
+  return (
+    <View
+      style={[
+        a.flex_row,
+        a.py_sm,
+        a.px_sm,
+        a.pl_md,
+        a.mt_sm,
+        t.atoms.bg_contrast_25,
+        {borderRadius: 23},
+      ]}>
+      <TextareaAutosize
+        style={{
+          backgroundColor: 'transparent',
+          border: 'none',
+          resize: 'none',
+          flex: 1,
+        }}
+        maxRows={12}
+        accessibilityLabel={_(msg`Message input field`)}
+        accessibilityHint={_(msg`Type your message here`)}
+        placeholder={_(msg`Write a message`)}
+        autoFocus={true}
+        ref={inputRef}
+      />
+      <Pressable
+        accessibilityRole="button"
+        style={[
+          a.rounded_full,
+          a.align_center,
+          a.justify_center,
+          {height: 30, width: 30, backgroundColor: t.palette.primary_500},
+        ]}>
+        <Text style={a.text_md}>🐴</Text>
+      </Pressable>
+    </View>
+  )
+}

--- a/src/screens/Messages/Conversation/MessageInput.web.tsx
+++ b/src/screens/Messages/Conversation/MessageInput.web.tsx
@@ -1,4 +1,4 @@
-import React, {ReactHTMLElement} from 'react'
+import React from 'react'
 import {Pressable, View} from 'react-native'
 import {msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
@@ -18,12 +18,9 @@ export function MessageInput({
   const t = useTheme()
   const [message, setMessage] = React.useState('')
 
-  const inputRef = React.useRef<ReactHTMLElement<HTMLTextAreaElement>>(null)
-
   const onSubmit = React.useCallback(() => {
     onSendMessage(message)
     setMessage('')
-    inputRef.current?.focus?.()
   }, [message, onSendMessage])
 
   const onKeyDown = React.useCallback(
@@ -63,14 +60,13 @@ export function MessageInput({
           flex: 1,
         }}
         maxRows={12}
-        accessibilityLabel={_(msg`Message input field`)}
-        accessibilityHint={_(msg`Type your message here`)}
         placeholder={_(msg`Write a message`)}
+        defaultValue=""
         value={message}
+        dirName="ltr"
         autoFocus={true}
         onChange={onChange}
         onKeyDown={onKeyDown}
-        ref={inputRef}
       />
       <Pressable
         accessibilityRole="button"

--- a/src/screens/Messages/Conversation/MessageInput.web.tsx
+++ b/src/screens/Messages/Conversation/MessageInput.web.tsx
@@ -26,6 +26,24 @@ export function MessageInput({
     inputRef.current?.focus?.()
   }, [message, onSendMessage])
 
+  const onKeyDown = React.useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (e.key === 'Enter') {
+        if (e.shiftKey) return
+        e.preventDefault()
+        onSubmit()
+      }
+    },
+    [onSubmit],
+  )
+
+  const onChange = React.useCallback(
+    (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+      setMessage(e.target.value)
+    },
+    [],
+  )
+
   return (
     <View
       style={[
@@ -48,7 +66,10 @@ export function MessageInput({
         accessibilityLabel={_(msg`Message input field`)}
         accessibilityHint={_(msg`Type your message here`)}
         placeholder={_(msg`Write a message`)}
+        value={message}
         autoFocus={true}
+        onChange={onChange}
+        onKeyDown={onKeyDown}
         ref={inputRef}
       />
       <Pressable

--- a/src/screens/Messages/Conversation/MessageInput.web.tsx
+++ b/src/screens/Messages/Conversation/MessageInput.web.tsx
@@ -23,7 +23,6 @@ export function MessageInput({
       return
     }
     onSendMessage(message.trimEnd())
-    onSendMessage(message)
     setMessage('')
   }, [message, onSendMessage])
 

--- a/src/screens/Messages/Conversation/MessageInput.web.tsx
+++ b/src/screens/Messages/Conversation/MessageInput.web.tsx
@@ -19,6 +19,10 @@ export function MessageInput({
   const [message, setMessage] = React.useState('')
 
   const onSubmit = React.useCallback(() => {
+    if (message.trim() === '') {
+      return
+    }
+    onSendMessage(message.trimEnd())
     onSendMessage(message)
     setMessage('')
   }, [message, onSendMessage])

--- a/src/screens/Messages/Conversation/MessageInput.web.tsx
+++ b/src/screens/Messages/Conversation/MessageInput.web.tsx
@@ -56,11 +56,12 @@ export function MessageInput({
         style={StyleSheet.flatten([
           a.flex_1,
           a.px_sm,
-          a.py_xs,
+          a.border_0,
+          t.atoms.text,
           {
             backgroundColor: 'transparent',
-            border: 'none',
             resize: 'none',
+            paddingTop: 6,
           },
         ])}
         maxRows={12}

--- a/src/screens/Messages/Conversation/MessageInput.web.tsx
+++ b/src/screens/Messages/Conversation/MessageInput.web.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import {Pressable, View} from 'react-native'
+import {Pressable, StyleSheet, View} from 'react-native'
 import {msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 import TextareaAutosize from 'react-textarea-autosize'
@@ -53,12 +53,16 @@ export function MessageInput({
         {borderRadius: 23},
       ]}>
       <TextareaAutosize
-        style={{
-          backgroundColor: 'transparent',
-          border: 'none',
-          resize: 'none',
-          flex: 1,
-        }}
+        style={StyleSheet.flatten([
+          a.flex_1,
+          a.px_sm,
+          a.py_xs,
+          {
+            backgroundColor: 'transparent',
+            border: 'none',
+            resize: 'none',
+          },
+        ])}
         maxRows={12}
         placeholder={_(msg`Write a message`)}
         defaultValue=""

--- a/yarn.lock
+++ b/yarn.lock
@@ -18981,6 +18981,15 @@ react-test-renderer@18.2.0:
     react-shallow-renderer "^16.15.0"
     scheduler "^0.23.0"
 
+react-textarea-autosize@^8.5.3:
+  version "8.5.3"
+  resolved "https://registry.yarnpkg.com/react-textarea-autosize/-/react-textarea-autosize-8.5.3.tgz#d1e9fe760178413891484847d3378706052dd409"
+  integrity sha512-XT1024o2pqCuZSuBt9FwHlaDeNtVrtCXu0Rnz88t1jUGheCLa3PhjE1GH8Ctm2axEtvdCl5SUHYschyQ0L5QHQ==
+  dependencies:
+    "@babel/runtime" "^7.20.13"
+    use-composed-ref "^1.3.0"
+    use-latest "^1.2.1"
+
 react@18.2.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"
@@ -21353,6 +21362,16 @@ use-callback-ref@^1.3.0:
   dependencies:
     tslib "^2.0.0"
 
+use-composed-ref@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/use-composed-ref/-/use-composed-ref-1.3.0.tgz#3d8104db34b7b264030a9d916c5e94fbe280dbda"
+  integrity sha512-GLMG0Jc/jiKov/3Ulid1wbv3r54K9HlMW29IWcDFPEqFkSO2nS0MuefWgMJpeHQ9YJeXDL3ZUF+P3jdXlZX/cQ==
+
+use-isomorphic-layout-effect@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz#497cefb13d863d687b08477d9e5a164ad8c1a6fb"
+  integrity sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==
+
 use-latest-callback@^0.1.5:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/use-latest-callback/-/use-latest-callback-0.1.6.tgz#3fa6e7babbb5f9bfa24b5094b22939e1e92ebcf6"
@@ -21362,6 +21381,13 @@ use-latest-callback@^0.1.9:
   version "0.1.9"
   resolved "https://registry.yarnpkg.com/use-latest-callback/-/use-latest-callback-0.1.9.tgz#10191dc54257e65a8e52322127643a8940271e2a"
   integrity sha512-CL/29uS74AwreI/f2oz2hLTW7ZqVeV5+gxFeGudzQrgkCytrHw33G4KbnQOrRlAEzzAFXi7dDLMC9zhWcVpzmw==
+
+use-latest@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/use-latest/-/use-latest-1.2.1.tgz#d13dfb4b08c28e3e33991546a2cee53e14038cf2"
+  integrity sha512-xA+AVm/Wlg3e2P/JiItTziwS7FK92LWrDB0p+hgXloIMuVCeJJ8v6f0eeHyPZaJrM+usM1FkFfbNCrJGs8A/zw==
+  dependencies:
+    use-isomorphic-layout-effect "^1.1.1"
 
 use-sidecar@^1.1.2:
   version "1.1.2"


### PR DESCRIPTION
I'm adding one new package here for web `react-textarea-autoresize`. If anyone has a good idea on how to do this on web w/o the library that would be fine too. Seems to be quite a pain to get right though and to maintain accessibility.

## iOS

![RocketSim_Recording_iPhone_15_Pro_6 1_2024-04-30_17 37 27](https://github.com/bluesky-social/social-app/assets/153161762/440ca91c-eecb-4d9f-ace6-3b4d59ca442a)

## Android

https://github.com/bluesky-social/social-app/assets/153161762/eb603925-09d1-4225-ac19-6c6e87c6c55b

## Web

The first messages are me just hitting Enter. The subsequent new lines are me pressing Shift + Enter

https://github.com/bluesky-social/social-app/assets/153161762/7de6b4ad-f2ee-4ff1-a700-8cf93fe0f265

