### PR TITLE
[Session] Move deactivated field off the session object

### DIFF
--- a/src/state/session/index.tsx
+++ b/src/state/session/index.tsx
@@ -422,13 +422,14 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
         logger.error(`session: could not decode jwt`)
       }
 
+      const accountOrSessionDeactivated =
+        isSessionDeactivated(account.accessJwt) || account.deactivated
+
       const prevSession = {
         accessJwt: account.accessJwt || '',
         refreshJwt: account.refreshJwt || '',
         did: account.did,
         handle: account.handle,
-        deactivated:
-          isSessionDeactivated(account.accessJwt) || account.deactivated,
       }
 
       if (canReusePrevSession) {
@@ -440,7 +441,7 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
         await fetchingGates
         upsertAccount(account)
 
-        if (prevSession.deactivated) {
+        if (accountOrSessionDeactivated) {
           // don't attempt to resume
           // use will be taken to the deactivated screen
           logger.debug(`session: reusing session for deactivated account`)


### PR DESCRIPTION
This didn't make sense because `prevSession` is only used as something we assign to `agent.session` (or pass to `agent.resumeSession` that does that assignment for us). But sessions have no `.deactivated` fields — only accounts do.

The only actual place where we depend on this field is right below, so I extracted it to a variable.

## Test Plan

Careful reading. Following types. Grepping `deactivated` to see usages.