### PR TITLE
Exclude bskyweb, bskyembed, and web-build in tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,5 +12,6 @@
       "view/*": ["./src/view/*"],
       "crypto": ["./src/platform/crypto.ts"]
     }
-  }
+  },
+  "exclude": ["bskyweb", "bskyembed", "web-build"]
 }


### PR DESCRIPTION
My editor's typescript language server kept crashing and overall being extremely slow. I realised this started when we did the embeds, and on closer inspection our base tsconfig is not scoped to the `src` directory, so was looking at every directory. This PR excludes `bskyembed`, which has its own tsconfig, and also `bskyweb` and `web-build` because there might be some lingering JS files in there that we don't need typechecking.