### PR TITLE
[Session] Use flag on state for persistence

### DIFF
--- a/src/state/session/index.tsx
+++ b/src/state/session/index.tsx
@@ -86,9 +86,8 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
     (account: SessionAccount, expired = false) => {
       setStateAndPersist(s => {
         return {
-          ...s,
-          currentAccount: expired ? undefined : account,
           accounts: [account, ...s.accounts.filter(a => a.did !== account.did)],
+          currentAccount: expired ? undefined : account,
         }
       })
     },
@@ -100,7 +99,7 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
     __globalAgent = PUBLIC_BSKY_AGENT
     configureModerationForGuest()
     setStateAndPersist(s => ({
-      ...s,
+      accounts: s.accounts,
       currentAccount: undefined,
     }))
   }, [setStateAndPersist])
@@ -266,12 +265,12 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
       clearCurrentAccount()
       setStateAndPersist(s => {
         return {
-          ...s,
           accounts: s.accounts.map(a => ({
             ...a,
             refreshJwt: undefined,
             accessJwt: undefined,
           })),
+          currentAccount: s.currentAccount,
         }
       })
       logEvent('account:loggedOut', {logContext})
@@ -411,8 +410,8 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
     account => {
       setStateAndPersist(s => {
         return {
-          ...s,
           accounts: s.accounts.filter(a => a.did !== account.did),
+          currentAccount: s.currentAccount,
         }
       })
     },
@@ -444,12 +443,11 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
         }
 
         return {
-          ...s,
-          currentAccount: updatedAccount,
           accounts: [
             updatedAccount,
             ...s.accounts.filter(a => a.did !== currentAccount.did),
           ],
+          currentAccount: updatedAccount,
         }
       })
     },
@@ -534,8 +532,7 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
         clearCurrentAccount()
       }
 
-      setState(s => ({
-        ...s,
+      setState(() => ({
         accounts: session.accounts,
         currentAccount: selectedAccount,
       }))

--- a/src/state/session/index.tsx
+++ b/src/state/session/index.tsx
@@ -67,13 +67,13 @@ type State = {
 }
 
 export function Provider({children}: React.PropsWithChildren<{}>) {
+  const [isInitialLoad, setIsInitialLoad] = React.useState(true)
+  const [isSwitchingAccounts, setIsSwitchingAccounts] = React.useState(false)
   const [state, setState] = React.useState<State>({
     accounts: persisted.get('session').accounts,
     currentAccount: undefined, // assume logged out to start
     needsPersist: false,
   })
-  const [isInitialLoad, setIsInitialLoad] = React.useState(true)
-  const [isSwitchingAccounts, setIsSwitchingAccounts] = React.useState(false)
 
   const upsertAccount = React.useCallback(
     (account: SessionAccount, expired = false) => {

--- a/src/state/session/types.ts
+++ b/src/state/session/types.ts
@@ -3,13 +3,11 @@ import {PersistedAccount} from '#/state/persisted'
 
 export type SessionAccount = PersistedAccount
 
-export type SessionState = {
-  isInitialLoad: boolean
-  isSwitchingAccounts: boolean
+export type SessionStateContext = {
   accounts: SessionAccount[]
   currentAccount: SessionAccount | undefined
-}
-export type SessionStateContext = SessionState & {
+  isInitialLoad: boolean
+  isSwitchingAccounts: boolean
   hasSession: boolean
 }
 export type SessionApiContext = {


### PR DESCRIPTION
See individual commits.

- cf360ed927a573d43ec67647c09e8843c0c21a36 and 5d0d740a75b77146eb990b90643c6601f4f22ea6 move `isInitialLoad` and `isSwitchingAccounts` out of the main `state` object, similar to how they're taken out in #3728.
- 5d0d740a75b77146eb990b90643c6601f4f22ea6 is just a visual cleanup so we always see the `state` object shape.
- Now, 9e0dd84fc3b5c627caadff7e3abb6aea35a1c610 is the interesting bit. This is a change in strategy both from what's in main and what's in #3728. If this change looks good, I'll update the other PR to match it. See below.
- 2cdab86f97546b5b44286aff40f5eae506eb3860 is just a line reorder.

## Persistence change

Whenever we update `accounts` or `currentAccount`, we need to persist that change to the local storage. There is only one exception to that — we don't want to do that if the update is coming from another tab (which means it was _already_ persisted — and we want to avoid two tabs entering a cycle of persisting and notifying each other).

Well, and we also don't want to persist the initial state.

So how do we do this?

On `main`, persistence is achieved with an explicit call like this:

```js
setStateAndPersist(prev => ({
  accounts: [account, ...prev.accounts.filter(...)],
  currentAccount: prev.currentAccount
})
```

which by itself sets `isDirty.current = true`, and then an Effect checks it.

On #3728, the strategy is different because there's no single `state` object so there's no `setStateAndPersist` function. Instead there's a function called `persistNextUpdate` which sets the same `isDirty.current = true` ref. I'm not a big fan of this approach because it's a bit hard to tell _which exactly_ state update will be persisted. It also seems easy to add a `setState` call somewhere in a different function, assume it's taken care of by an earlier `persistNextUpdate` call, and then to lose that earlier call due to some refactoring. So I'd like to enforce that the decision to persist is close to the state update.

The strategy I'm taking in this PR is different from both of these approaches. Instead of tracking a separate ref, I track the need to persist _in the state object itself_ as a mutable field.

```diff
- setStateAndPersist(prev => ({
+ setState(prev => ({
  accounts: [account, ...prev.accounts.filter(...)],
  currentAccount: prev.currentAccount,
+  needsPersist: true
})
```

There is no `isDirty` ref. Instead, the effect checks the latest committed state:

```js
  React.useEffect(() => {
    if (state.needsPersist) {
      state.needsPersist = false
      persisted.write('session', {
        accounts: state.accounts,
        currentAccount: state.currentAccount,
      })
    }
  }, [state])
```

This ensures that any state updates to `state.accounts` and `state.currentAccount` get persisted as long as they have the `needsPersist: true` tag. I'm keeping it `false` on updates originating from the tab sync.

Note that if you have a `needsPersist: true` update that hasn't been processed yet, immediately followed by a `needsPersist: false` update, neither of them will get persisted because the latest version wins. This is different from the current behavior where `isDirty.current` being `true` will cause the next committed update to be persisted. *However* I think that's fine (and maybe even good?) because the only reason you could get a `needsPersist: false` update is if you did something in another tab — and in that case the other-tab-originating update is fresher anyway. So it kind of makes sense that we only ever want to persist the latest state — and only if that specific state is marked to be persisted.

I plan to port this change to #3728 as well if we get it into main.

## Test Plan

Put logs next to persistence. Verify changes get persisted as before. Verify switching account, logging out, logging in works. Verify logging out or switching accounts in another tab switches the current tab.