### PR TITLE
[Session] Derive currentAccount from accounts + currentAccountDid

### DIFF
--- a/src/state/session/index.tsx
+++ b/src/state/session/index.tsx
@@ -329,6 +329,7 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
           })
 
           __globalAgent = PUBLIC_BSKY_AGENT
+          // TODO: Should this update currentAccountDid?
         }
       } else {
         logger.debug(`session: attempting to reuse previous session`)
@@ -366,6 +367,7 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
             })
 
             __globalAgent = PUBLIC_BSKY_AGENT
+            // TODO: Should this update currentAccountDid?
           })
       }
 


### PR DESCRIPTION
We should be able to reconstruct `currentAccount` on demand from `accounts` and only track the current DID instead. Although we've wanted to make a bigger change to this in #3728 (and reconstruct it from agent), I'm doing a more incremental step here.

## Test Plan

Careful reading. Verify login/logout/switch still works. Do it in another tab too.