### PR TITLE
Fix: put label defs provider above moderation opts provider

### DIFF
--- a/src/App.native.tsx
+++ b/src/App.native.tsx
@@ -80,8 +80,9 @@ function InnerApp() {
             <QueryProvider currentDid={currentAccount?.did}>
               <PushNotificationsListener>
                 <StatsigProvider>
-                  <ModerationOptsProvider>
-                    <LabelDefsProvider>
+                  {/* LabelDefsProvider MUST come before ModerationOptsProvider */}
+                  <LabelDefsProvider>
+                    <ModerationOptsProvider>
                       <LoggedOutViewProvider>
                         <SelectedFeedProvider>
                           <UnreadNotifsProvider>
@@ -97,8 +98,8 @@ function InnerApp() {
                           </UnreadNotifsProvider>
                         </SelectedFeedProvider>
                       </LoggedOutViewProvider>
-                    </LabelDefsProvider>
-                  </ModerationOptsProvider>
+                    </ModerationOptsProvider>
+                  </LabelDefsProvider>
                 </StatsigProvider>
               </PushNotificationsListener>
             </QueryProvider>

--- a/src/App.web.tsx
+++ b/src/App.web.tsx
@@ -57,8 +57,9 @@ function InnerApp() {
         key={currentAccount?.did}>
         <QueryProvider currentDid={currentAccount?.did}>
           <StatsigProvider>
-            <ModerationOptsProvider>
-              <LabelDefsProvider>
+            {/* LabelDefsProvider MUST come before ModerationOptsProvider */}
+            <LabelDefsProvider>
+              <ModerationOptsProvider>
                 <LoggedOutViewProvider>
                   <SelectedFeedProvider>
                     <UnreadNotifsProvider>
@@ -74,8 +75,8 @@ function InnerApp() {
                     </UnreadNotifsProvider>
                   </SelectedFeedProvider>
                 </LoggedOutViewProvider>
-              </LabelDefsProvider>
-            </ModerationOptsProvider>
+              </ModerationOptsProvider>
+            </LabelDefsProvider>
           </StatsigProvider>
         </QueryProvider>
       </React.Fragment>


### PR DESCRIPTION
Turns out that the moderation opts context depends on the label defs context. This fix restores 3p labeler behaviors.