### PR TITLE
[Session] Extract resumeSession out

### DIFF
--- a/src/state/session/index.tsx
+++ b/src/state/session/index.tsx
@@ -35,7 +35,6 @@ const PUBLIC_BSKY_AGENT = new BskyAgent({service: PUBLIC_BSKY_SERVICE})
 configureModerationForGuest()
 
 const StateContext = React.createContext<SessionStateContext>({
-  isInitialLoad: true,
   isSwitchingAccounts: false,
   accounts: [],
   currentAccount: undefined,
@@ -47,7 +46,6 @@ const ApiContext = React.createContext<SessionApiContext>({
   login: async () => {},
   logout: async () => {},
   initSession: async () => {},
-  resumeSession: async () => {},
   removeAccount: () => {},
   selectAccount: async () => {},
   updateCurrentAccount: () => {},
@@ -67,7 +65,6 @@ type State = {
 }
 
 export function Provider({children}: React.PropsWithChildren<{}>) {
-  const [isInitialLoad, setIsInitialLoad] = React.useState(true)
   const [isSwitchingAccounts, setIsSwitchingAccounts] = React.useState(false)
   const [state, setState] = React.useState<State>({
     accounts: persisted.get('session').accounts,
@@ -389,21 +386,6 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
     [upsertAccount, clearCurrentAccount, createPersistSessionHandler],
   )
 
-  const resumeSession = React.useCallback<SessionApiContext['resumeSession']>(
-    async account => {
-      try {
-        if (account) {
-          await initSession(account)
-        }
-      } catch (e) {
-        logger.error(`session: resumeSession failed`, {message: e})
-      } finally {
-        setIsInitialLoad(false)
-      }
-    },
-    [initSession],
-  )
-
   const removeAccount = React.useCallback<SessionApiContext['removeAccount']>(
     account => {
       setState(s => {
@@ -547,11 +529,10 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
       currentAccount: state.accounts.find(
         a => a.did === state.currentAccountDid,
       ),
-      isInitialLoad,
       isSwitchingAccounts,
       hasSession: !!state.currentAccountDid,
     }),
-    [state, isInitialLoad, isSwitchingAccounts],
+    [state, isSwitchingAccounts],
   )
 
   const api = React.useMemo(
@@ -560,7 +541,6 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
       login,
       logout,
       initSession,
-      resumeSession,
       removeAccount,
       selectAccount,
       updateCurrentAccount,
@@ -571,7 +551,6 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
       login,
       logout,
       initSession,
-      resumeSession,
       removeAccount,
       selectAccount,
       updateCurrentAccount,

--- a/src/state/session/types.ts
+++ b/src/state/session/types.ts
@@ -6,7 +6,6 @@ export type SessionAccount = PersistedAccount
 export type SessionStateContext = {
   accounts: SessionAccount[]
   currentAccount: SessionAccount | undefined
-  isInitialLoad: boolean
   isSwitchingAccounts: boolean
   hasSession: boolean
 }
@@ -46,7 +45,6 @@ export type SessionApiContext = {
    */
   clearCurrentAccount: () => void
   initSession: (account: SessionAccount) => Promise<void>
-  resumeSession: (account?: SessionAccount) => Promise<void>
   removeAccount: (account: SessionAccount) => void
   selectAccount: (
     account: SessionAccount,


### PR DESCRIPTION
`resumeSession` is a thin wrapper over `initSession` which sets `setIsInitialLoad(false)` to hide the splash and then becomes effectively the same as `initSession`. I was wondering if I could get rid of it, and the only usage of `resumeSession` was from top-level `InnerApp` components which, conveniently, were the ones who needed `isInitialLoad` in the first place (to hide the splash). So I removed `resumeSession` from the Session API and removed `isInitialLoad` from its context.

## Why?

I want to pare it down, and `resumeSession` doesn't depend on any knowledge that isn't already available through the Session API. So it made sense to me to move it out to keep that code more focused. Conceptually we have one instance of the `InnerApp` component (it's just forked between two platforms). The local usage also makes sense because it lets us get rid of context for something that's really a very local thing that only one component cares about.

## Test Plan

Verify splash screen still gets hidden on session init. Verify switching users still works. 