### PR TITLE
[Session] Extract selectAccount out

### DIFF
--- a/src/components/AccountList.tsx
+++ b/src/components/AccountList.tsx
@@ -16,12 +16,14 @@ export function AccountList({
   onSelectAccount,
   onSelectOther,
   otherLabel,
+  isSwitchingAccounts,
 }: {
   onSelectAccount: (account: SessionAccount) => void
   onSelectOther: () => void
   otherLabel?: string
+  isSwitchingAccounts: boolean
 }) {
-  const {isSwitchingAccounts, currentAccount, accounts} = useSession()
+  const {currentAccount, accounts} = useSession()
   const t = useTheme()
   const {_} = useLingui()
 

--- a/src/components/dialogs/SwitchAccount.tsx
+++ b/src/components/dialogs/SwitchAccount.tsx
@@ -18,7 +18,7 @@ export function SwitchAccountDialog({
 }) {
   const {_} = useLingui()
   const {currentAccount} = useSession()
-  const {onPressSwitchAccount} = useAccountSwitcher()
+  const {onPressSwitchAccount, isSwitchingAccounts} = useAccountSwitcher()
   const {setShowLoggedOut} = useLoggedOutViewControls()
 
   const onSelectAccount = useCallback(
@@ -54,6 +54,7 @@ export function SwitchAccountDialog({
             onSelectAccount={onSelectAccount}
             onSelectOther={onPressAddAccount}
             otherLabel={_(msg`Add account`)}
+            isSwitchingAccounts={isSwitchingAccounts}
           />
         </View>
       </Dialog.ScrollableInner>

--- a/src/screens/Login/ChooseAccountForm.tsx
+++ b/src/screens/Login/ChooseAccountForm.tsx
@@ -22,6 +22,7 @@ export const ChooseAccountForm = ({
   onSelectAccount: (account?: SessionAccount) => void
   onPressBack: () => void
 }) => {
+  const [isSwitchingAccounts, setIsSwitchingAccounts] = React.useState(false)
   const {track, screen} = useAnalytics()
   const {_} = useLingui()
   const {currentAccount} = useSession()
@@ -40,6 +41,7 @@ export const ChooseAccountForm = ({
           Toast.show(_(msg`Already signed in as @${account.handle}`))
         } else {
           try {
+            setIsSwitchingAccounts(true)
             await initSession(account)
             logEvent('account:loggedIn', {
               logContext: 'ChooseAccountForm',
@@ -54,6 +56,8 @@ export const ChooseAccountForm = ({
               message: e.message,
             })
             onSelectAccount(account)
+          } finally {
+            setIsSwitchingAccounts(false)
           }
         }
       } else {
@@ -74,6 +78,7 @@ export const ChooseAccountForm = ({
         <AccountList
           onSelectAccount={onSelect}
           onSelectOther={() => onSelectAccount()}
+          isSwitchingAccounts={isSwitchingAccounts}
         />
       </View>
       <View style={[a.flex_row]}>

--- a/src/state/session/types.ts
+++ b/src/state/session/types.ts
@@ -6,7 +6,6 @@ export type SessionAccount = PersistedAccount
 export type SessionStateContext = {
   accounts: SessionAccount[]
   currentAccount: SessionAccount | undefined
-  isSwitchingAccounts: boolean
   hasSession: boolean
 }
 export type SessionApiContext = {
@@ -46,10 +45,6 @@ export type SessionApiContext = {
   clearCurrentAccount: () => void
   initSession: (account: SessionAccount) => Promise<void>
   removeAccount: (account: SessionAccount) => void
-  selectAccount: (
-    account: SessionAccount,
-    logContext: LogEvents['account:loggedIn']['logContext'],
-  ) => Promise<void>
   updateCurrentAccount: (
     account: Partial<
       Pick<

--- a/src/view/screens/Settings/index.tsx
+++ b/src/view/screens/Settings/index.tsx
@@ -70,14 +70,24 @@ import {navigate, resetToTab} from '#/Navigation'
 import {Email2FAToggle} from './Email2FAToggle'
 import {ExportCarDialog} from './ExportCarDialog'
 
-function SettingsAccountCard({account}: {account: SessionAccount}) {
+function SettingsAccountCard({
+  account,
+  isSwitchingAccounts,
+  onPressSwitchAccount,
+}: {
+  account: SessionAccount
+  isSwitchingAccounts: boolean
+  onPressSwitchAccount: (
+    account: SessionAccount,
+    logContext: 'Settings',
+  ) => void
+}) {
   const pal = usePalette('default')
   const {_} = useLingui()
-  const {isSwitchingAccounts, currentAccount} = useSession()
+  const {currentAccount} = useSession()
   const {logout} = useSessionApi()
   const {data: profile} = useProfileQuery({did: account.did})
   const isCurrentAccount = account.did === currentAccount?.did
-  const {onPressSwitchAccount} = useAccountSwitcher()
 
   const contents = (
     <View style={[pal.view, styles.linkCard]}>
@@ -165,12 +175,13 @@ export function SettingsScreen({}: Props) {
   const {isMobile} = useWebMediaQueries()
   const {screen, track} = useAnalytics()
   const {openModal} = useModalControls()
-  const {isSwitchingAccounts, accounts, currentAccount} = useSession()
+  const {accounts, currentAccount} = useSession()
   const {mutate: clearPreferences} = useClearPreferencesMutation()
   const {setShowLoggedOut} = useLoggedOutViewControls()
   const closeAllActiveElements = useCloseAllActiveElements()
   const exportCarControl = useDialogControl()
   const birthdayControl = useDialogControl()
+  const {isSwitchingAccounts, onPressSwitchAccount} = useAccountSwitcher()
 
   // TODO: TEMP REMOVE WHEN CLOPS ARE RELEASED
   const gate = useGate()
@@ -385,13 +396,22 @@ export function SettingsScreen({}: Props) {
             <ActivityIndicator />
           </View>
         ) : (
-          <SettingsAccountCard account={currentAccount!} />
+          <SettingsAccountCard
+            account={currentAccount!}
+            onPressSwitchAccount={onPressSwitchAccount}
+            isSwitchingAccounts={isSwitchingAccounts}
+          />
         )}
 
         {accounts
           .filter(a => a.did !== currentAccount?.did)
           .map(account => (
-            <SettingsAccountCard key={account.did} account={account} />
+            <SettingsAccountCard
+              key={account.did}
+              account={account}
+              onPressSwitchAccount={onPressSwitchAccount}
+              isSwitchingAccounts={isSwitchingAccounts}
+            />
           ))}
 
         <TouchableOpacity


### PR DESCRIPTION
This is similar to https://github.com/bluesky-social/social-app/pull/3811 in spirit and is based on the same insight. `selectAccount` has nothing to do with session management per se, it's just a wrapper around `initSession` that tracks the progress of that call. It makes sense to make such state tracking local to where the action was triggered in the UI code. So I'm moving that state back into components.

I moved the `isSwitchingAccounts` state variable out of the Session API and into the calling components which now call `initSession` directly. For `AccountList`, I've plumbed it down from the component that owns the switch press handler.

## Test Plan

Use the account switcher, both the popover and the settings one. It feels a bit janky but I replicated the existing logic. This should make it a bit easier to change the UI logic if we'd like to later because it's all local state now.