### PR TITLE
Link card errors

### DIFF
--- a/src/view/com/composer/useExternalLinkFetch.e2e.ts
+++ b/src/view/com/composer/useExternalLinkFetch.e2e.ts
@@ -1,4 +1,5 @@
 import {useEffect, useState} from 'react'
+import {useLingui} from '@lingui/react'
 
 import {useAgent} from '#/state/session'
 import * as apilib from 'lib/api/index'
@@ -8,6 +9,7 @@ import {ComposerOpts} from 'state/shell/composer'
 export function useExternalLinkFetch({}: {
   setQuote: (opts: ComposerOpts['quote']) => void
 }) {
+  const {i18n} = useLingui()
   const {getAgent} = useAgent()
   const [extLink, setExtLink] = useState<apilib.ExternalEmbedDraft | undefined>(
     undefined,
@@ -22,7 +24,7 @@ export function useExternalLinkFetch({}: {
       return cleanup
     }
     if (!extLink.meta) {
-      getLinkMeta(getAgent(), extLink.uri).then(meta => {
+      getLinkMeta(getAgent(), extLink.uri, 5e3, i18n).then(meta => {
         if (aborted) {
           return
         }
@@ -41,7 +43,7 @@ export function useExternalLinkFetch({}: {
       })
     }
     return cleanup
-  }, [extLink, getAgent])
+  }, [extLink, getAgent, i18n])
 
   return {extLink, setExtLink}
 }

--- a/src/view/com/composer/useExternalLinkFetch.ts
+++ b/src/view/com/composer/useExternalLinkFetch.ts
@@ -1,4 +1,5 @@
 import {useEffect, useState} from 'react'
+import {useLingui} from '@lingui/react'
 
 import {logger} from '#/logger'
 import {useFetchDid} from '#/state/queries/handle'
@@ -26,6 +27,7 @@ export function useExternalLinkFetch({
 }: {
   setQuote: (opts: ComposerOpts['quote']) => void
 }) {
+  const {i18n} = useLingui()
   const [extLink, setExtLink] = useState<apilib.ExternalEmbedDraft | undefined>(
     undefined,
   )
@@ -95,7 +97,7 @@ export function useExternalLinkFetch({
           },
         )
       } else {
-        getLinkMeta(getAgent(), extLink.uri).then(meta => {
+        getLinkMeta(getAgent(), extLink.uri, 15e3, i18n).then(meta => {
           if (aborted) {
             return
           }
@@ -137,7 +139,7 @@ export function useExternalLinkFetch({
       })
     }
     return cleanup
-  }, [extLink, setQuote, getPost, fetchDid, getAgent])
+  }, [extLink, setQuote, getPost, fetchDid, getAgent, i18n])
 
   return {extLink, setExtLink}
 }


### PR DESCRIPTION
Slight improvement, just trying to avoid more confusing errors like `AbortError: signal is aborted without reason`

![CleanShot 2024-05-02 at 10 54 06@2x](https://github.com/bluesky-social/social-app/assets/4732330/95aad507-bb7f-42e8-b4e9-123473aa02d8)
