### PR TITLE
Only run "disable min shell on foregrounding" behaviour if on the home screen

### DIFF
--- a/src/lib/statsig/gates.ts
+++ b/src/lib/statsig/gates.ts
@@ -1,7 +1,7 @@
 export type Gate =
   // Keep this alphabetic please.
   | 'autoexpand_suggestions_on_profile_follow_v2'
-  | 'disable_min_shell_on_foregrounding_v2'
+  | 'disable_min_shell_on_foregrounding_v3'
   | 'disable_poll_on_discover_v2'
   | 'dms'
   | 'hide_vertical_scroll_indicators'

--- a/src/view/screens/Home.tsx
+++ b/src/view/screens/Home.tsx
@@ -126,7 +126,7 @@ function HomeScreenReady({
           if (
             isMobile &&
             mode.value === 1 &&
-            gate('disable_min_shell_on_foregrounding_v2')
+            gate('disable_min_shell_on_foregrounding_v3')
           ) {
             setMinimalShellMode(false)
           }

--- a/src/view/screens/Home.tsx
+++ b/src/view/screens/Home.tsx
@@ -119,22 +119,24 @@ function HomeScreenReady({
   const gate = useGate()
   const mode = useMinimalShellMode()
   const {isMobile} = useWebMediaQueries()
-  React.useEffect(() => {
-    const listener = AppState.addEventListener('change', nextAppState => {
-      if (nextAppState === 'active') {
-        if (
-          isMobile &&
-          mode.value === 1 &&
-          gate('disable_min_shell_on_foregrounding_v2')
-        ) {
-          setMinimalShellMode(false)
+  useFocusEffect(
+    React.useCallback(() => {
+      const listener = AppState.addEventListener('change', nextAppState => {
+        if (nextAppState === 'active') {
+          if (
+            isMobile &&
+            mode.value === 1 &&
+            gate('disable_min_shell_on_foregrounding_v2')
+          ) {
+            setMinimalShellMode(false)
+          }
         }
+      })
+      return () => {
+        listener.remove()
       }
-    })
-    return () => {
-      listener.remove()
-    }
-  }, [setMinimalShellMode, mode, isMobile, gate])
+    }, [setMinimalShellMode, mode, isMobile, gate]),
+  )
 
   const onPageSelected = React.useCallback(
     (index: number) => {


### PR DESCRIPTION
Currently, the "disable min shell on foregrounding" behaviour is in a `useEffect` in the home screen component. However, React Navigation does not unmount components even if you're on a different tab, so this means that this actually happens on every screen in the app, so long as you've loaded the home tab at some point (which you almost certainly have).

This wouldn't matter except that the new messages screen uses min shell mode, so if you unbackground it on the messages screen the tab bar overlaps the text input.

I've changed it to use `useFocusEffect` from React Navigation, which only runs the effect when the screen is active

## Test plan

Check that the behaviour is unchanged on the home tab
Unbackground on the messages screen, and see that there's no tab bar