### PR TITLE
[Clipclops] Fix messages tab active state

### DIFF
--- a/src/Navigation.tsx
+++ b/src/Navigation.tsx
@@ -48,7 +48,7 @@ import {useWebScrollRestoration} from './lib/hooks/useWebScrollRestoration'
 import {attachRouteToLogEvents, logEvent} from './lib/statsig/statsig'
 import {router} from './routes'
 import {MessagesConversationScreen} from './screens/Messages/Conversation'
-import {MessagesListScreen} from './screens/Messages/List'
+import {MessagesScreen} from './screens/Messages/List'
 import {MessagesSettingsScreen} from './screens/Messages/Settings'
 import {useModalControls} from './state/modals'
 import {useUnreadNotifications} from './state/queries/notifications/unread'
@@ -462,8 +462,8 @@ function MessagesTabNavigator() {
         contentStyle: pal.view,
       }}>
       <MessagesTab.Screen
-        name="MessagesList"
-        getComponent={() => MessagesListScreen}
+        name="Messages"
+        getComponent={() => MessagesScreen}
         options={{requireAuth: true}}
       />
       {commonScreens(MessagesTab as typeof HomeTab)}
@@ -512,8 +512,8 @@ const FlatNavigator = () => {
         options={{title: title(msg`Notifications`), requireAuth: true}}
       />
       <Flat.Screen
-        name="MessagesList"
-        getComponent={() => MessagesListScreen}
+        name="Messages"
+        getComponent={() => MessagesScreen}
         options={{title: title(msg`Messages`), requireAuth: true}}
       />
       {commonScreens(Flat as typeof HomeTab, numUnread)}
@@ -570,7 +570,7 @@ const LINKING = {
         return buildStateObject('HomeTab', 'Home', params)
       }
       if (name === 'Messages') {
-        return buildStateObject('MessagesTab', 'MessagesList', params)
+        return buildStateObject('MessagesTab', 'Messages', params)
       }
       // if the path is something else, like a post, profile, or even settings, we need to initialize the home tab as pre-existing state otherwise the back button will not work
       return buildStateObject('HomeTab', name, params, [

--- a/src/components/dms/ConvoMenu.tsx
+++ b/src/components/dms/ConvoMenu.tsx
@@ -72,7 +72,7 @@ let ConvoMenu = ({
   const {mutate: leaveConvo} = useLeaveConvo(convo.id, {
     onSuccess: () => {
       if (currentScreen === 'conversation') {
-        navigation.replace('MessagesList')
+        navigation.replace('Messages')
       }
     },
     onError: () => {

--- a/src/lib/hooks/useNavigationTabState.ts
+++ b/src/lib/hooks/useNavigationTabState.ts
@@ -11,8 +11,9 @@ export function useNavigationTabState() {
       isAtNotifications:
         getTabState(state, 'Notifications') !== TabState.Outside,
       isAtMyProfile: getTabState(state, 'MyProfile') !== TabState.Outside,
-      isAtMessages: getTabState(state, 'MessagesList') !== TabState.Outside,
+      isAtMessages: getTabState(state, 'Messages') !== TabState.Outside,
     }
+
     if (
       !res.isAtHome &&
       !res.isAtSearch &&

--- a/src/lib/hooks/useNavigationTabState.web.ts
+++ b/src/lib/hooks/useNavigationTabState.web.ts
@@ -1,4 +1,5 @@
 import {useNavigationState} from '@react-navigation/native'
+
 import {getCurrentRoute} from 'lib/routes/helpers'
 
 export function useNavigationTabState() {
@@ -9,6 +10,7 @@ export function useNavigationTabState() {
       isAtSearch: currentRoute === 'Search',
       isAtNotifications: currentRoute === 'Notifications',
       isAtMyProfile: currentRoute === 'MyProfile',
+      isAtMessages: currentRoute === 'Messages',
     }
   })
 }

--- a/src/lib/routes/types.ts
+++ b/src/lib/routes/types.ts
@@ -72,7 +72,7 @@ export type MyProfileTabNavigatorParams = CommonNavigatorParams & {
 }
 
 export type MessagesTabNavigatorParams = CommonNavigatorParams & {
-  MessagesList: undefined
+  Messages: undefined
 }
 
 export type FlatNavigatorParams = CommonNavigatorParams & {
@@ -81,7 +81,7 @@ export type FlatNavigatorParams = CommonNavigatorParams & {
   Feeds: undefined
   Notifications: undefined
   Hashtag: {tag: string; author?: string}
-  MessagesList: undefined
+  Messages: undefined
 }
 
 export type AllNavigatorParams = CommonNavigatorParams & {
@@ -96,7 +96,7 @@ export type AllNavigatorParams = CommonNavigatorParams & {
   MyProfileTab: undefined
   Hashtag: {tag: string; author?: string}
   MessagesTab: undefined
-  MessagesList: undefined
+  Messages: undefined
 }
 
 // NOTE

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -37,7 +37,7 @@ export const router = new Router({
   CommunityGuidelines: '/support/community-guidelines',
   CopyrightPolicy: '/support/copyright',
   Hashtag: '/hashtag/:tag',
-  MessagesList: '/messages',
+  Messages: '/messages',
   MessagesSettings: '/messages/settings',
   MessagesConversation: '/messages/:conversation',
 })

--- a/src/screens/Messages/Conversation/index.tsx
+++ b/src/screens/Messages/Conversation/index.tsx
@@ -82,7 +82,7 @@ let Header = ({
 
   const onPressBack = useCallback(() => {
     if (isWeb) {
-      navigation.replace('MessagesList')
+      navigation.replace('Messages')
     } else {
       navigation.pop()
     }

--- a/src/screens/Messages/List/index.tsx
+++ b/src/screens/Messages/List/index.tsx
@@ -33,8 +33,8 @@ import {useMenuControl} from '#/components/Menu'
 import {Text} from '#/components/Typography'
 import {ClipClopGate} from '../gate'
 
-type Props = NativeStackScreenProps<MessagesTabNavigatorParams, 'MessagesList'>
-export function MessagesListScreen({navigation}: Props) {
+type Props = NativeStackScreenProps<MessagesTabNavigatorParams, 'Messages'>
+export function MessagesScreen({navigation}: Props) {
   const {_} = useLingui()
   const t = useTheme()
   const newChatControl = useDialogControl()


### PR DESCRIPTION
There's a convention I didn't notice that the root screen of each tab has to be named `Xyz` and the tab, `XyzTab`. I'd named them `MessageList` and `MessagesTab` so it wasn't able to figure out that `MessagesList` was the root screen