### PR TITLE
[Clipclops] External store, suspend/resume

### DIFF
--- a/src/logger/debugContext.ts
+++ b/src/logger/debugContext.ts
@@ -9,4 +9,5 @@ export const DebugContext = {
   // e.g. composer: 'composer'
   session: 'session',
   notifications: 'notifications',
+  convo: 'convo',
 } as const

--- a/src/screens/Messages/Conversation/MessagesList.tsx
+++ b/src/screens/Messages/Conversation/MessagesList.tsx
@@ -106,7 +106,7 @@ export function MessagesList() {
         text,
       })
     },
-    [chat.service],
+    [chat],
   )
 
   const onScroll = React.useCallback(

--- a/src/screens/Messages/Conversation/MessagesList.tsx
+++ b/src/screens/Messages/Conversation/MessagesList.tsx
@@ -89,7 +89,9 @@ export function MessagesList() {
   }, [])
 
   const onEndReached = useCallback(() => {
-    chat.service.fetchMessageHistory()
+    if (chat.status === ConvoStatus.Ready) {
+      chat.fetchMessageHistory()
+    }
   }, [chat])
 
   const onInputFocus = useCallback(() => {
@@ -102,9 +104,11 @@ export function MessagesList() {
 
   const onSendMessage = useCallback(
     (text: string) => {
-      chat.service.sendMessage({
-        text,
-      })
+      if (chat.status === ConvoStatus.Ready) {
+        chat.sendMessage({
+          text,
+        })
+      }
     },
     [chat],
   )
@@ -134,9 +138,7 @@ export function MessagesList() {
       contentContainerStyle={a.flex_1}>
       <FlatList
         ref={flatListRef}
-        data={
-          chat.state.status === ConvoStatus.Ready ? chat.state.items : undefined
-        }
+        data={chat.status === ConvoStatus.Ready ? chat.items : undefined}
         keyExtractor={keyExtractor}
         renderItem={renderItem}
         contentContainerStyle={{paddingHorizontal: 10}}
@@ -159,8 +161,7 @@ export function MessagesList() {
         ListFooterComponent={
           <MaybeLoader
             isLoading={
-              chat.state.status === ConvoStatus.Ready &&
-              chat.state.isFetchingHistory
+              chat.status === ConvoStatus.Ready && chat.isFetchingHistory
             }
           />
         }

--- a/src/screens/Messages/Conversation/index.tsx
+++ b/src/screens/Messages/Conversation/index.tsx
@@ -46,16 +46,16 @@ function Inner() {
   const myDid = currentAccount?.did
 
   const otherProfile = React.useMemo(() => {
-    if (chat.state.status !== ConvoStatus.Ready) return
-    return chat.state.convo.members.find(m => m.did !== myDid)
-  }, [chat.state, myDid])
+    if (chat.status !== ConvoStatus.Ready) return
+    return chat.convo.members.find(m => m.did !== myDid)
+  }, [chat, myDid])
 
   // TODO whenever we have error messages, we should use them in here -hailey
-  if (chat.state.status !== ConvoStatus.Ready || !otherProfile) {
+  if (chat.status !== ConvoStatus.Ready || !otherProfile) {
     return (
       <ListMaybePlaceholder
         isLoading={true}
-        isError={chat.state.status === ConvoStatus.Error}
+        isError={chat.status === ConvoStatus.Error}
       />
     )
   }
@@ -77,7 +77,7 @@ let Header = ({
   const {_} = useLingui()
   const {gtTablet} = useBreakpoints()
   const navigation = useNavigation<NavigationProp>()
-  const {state} = useChat()
+  const chat = useChat()
 
   const onPressBack = useCallback(() => {
     if (isWeb) {
@@ -129,9 +129,9 @@ let Header = ({
         <PreviewableUserAvatar size={32} profile={profile} />
         <Text style={[a.text_lg, a.font_bold]}>{profile.displayName}</Text>
       </View>
-      {state.status === ConvoStatus.Ready && state.convo ? (
+      {chat.status === ConvoStatus.Ready ? (
         <ConvoMenu
-          convo={state.convo}
+          convo={chat.convo}
           profile={profile}
           onUpdateConvo={onUpdateConvo}
           currentScreen="conversation"

--- a/src/screens/Messages/Conversation/index.tsx
+++ b/src/screens/Messages/Conversation/index.tsx
@@ -1,7 +1,6 @@
 import React, {useCallback} from 'react'
 import {TouchableOpacity, View} from 'react-native'
 import {AppBskyActorDefs} from '@atproto/api'
-import {ChatBskyConvoDefs} from '@atproto-labs/api'
 import {FontAwesomeIcon} from '@fortawesome/react-native-fontawesome'
 import {msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
@@ -78,7 +77,7 @@ let Header = ({
   const {_} = useLingui()
   const {gtTablet} = useBreakpoints()
   const navigation = useNavigation<NavigationProp>()
-  const {service} = useChat()
+  const {state} = useChat()
 
   const onPressBack = useCallback(() => {
     if (isWeb) {
@@ -88,12 +87,9 @@ let Header = ({
     }
   }, [navigation])
 
-  const onUpdateConvo = useCallback(
-    (convo: ChatBskyConvoDefs.ConvoView) => {
-      service.convo = convo
-    },
-    [service],
-  )
+  const onUpdateConvo = useCallback(() => {
+    // TODO eric update muted state
+  }, [])
 
   return (
     <View
@@ -133,9 +129,9 @@ let Header = ({
         <PreviewableUserAvatar size={32} profile={profile} />
         <Text style={[a.text_lg, a.font_bold]}>{profile.displayName}</Text>
       </View>
-      {service.convo ? (
+      {state.status === ConvoStatus.Ready && state.convo ? (
         <ConvoMenu
-          convo={service.convo}
+          convo={state.convo}
           profile={profile}
           onUpdateConvo={onUpdateConvo}
           currentScreen="conversation"

--- a/src/state/messages/__tests__/convo.test.ts
+++ b/src/state/messages/__tests__/convo.test.ts
@@ -12,6 +12,10 @@ describe(`#/state/messages/convo`, () => {
     })
   })
 
+  describe(`read states`, () => {
+    it.todo(`should mark messages as read as they come in`)
+  })
+
   describe(`history fetching`, () => {
     it.todo(`fetches initial chat history`)
     it.todo(`fetches additional chat history`)

--- a/src/state/messages/convo.ts
+++ b/src/state/messages/convo.ts
@@ -50,8 +50,6 @@ export type ConvoItem =
       retry: () => void
     }
 
-export type ConvoStateSharedFields<T> = T & {}
-
 export type ConvoState =
   | {
       status: ConvoStatus.Uninitialized

--- a/src/state/messages/convo.ts
+++ b/src/state/messages/convo.ts
@@ -132,7 +132,7 @@ export type ConvoState =
       fetchMessageHistory: undefined
     }
 
-const ACTIVE_POLL_INTERVAL = 1e3
+const ACTIVE_POLL_INTERVAL = 2e3
 const BACKGROUND_POLL_INTERVAL = 10e3
 
 export function isConvoItemMessage(

--- a/src/state/messages/index.tsx
+++ b/src/state/messages/index.tsx
@@ -39,7 +39,7 @@ export function ChatProvider({
       convo.resume()
 
       return () => {
-        convo.suspend()
+        convo.background()
       }
     }, [convo]),
   )

--- a/src/state/messages/index.tsx
+++ b/src/state/messages/index.tsx
@@ -1,11 +1,12 @@
 import React, {useContext, useState, useSyncExternalStore} from 'react'
 import {BskyAgent} from '@atproto-labs/api'
+import {useFocusEffect} from '@react-navigation/native'
 
-import {Convo, ConvoInterface, ConvoParams} from '#/state/messages/convo'
+import {Convo, ConvoParams, ConvoState} from '#/state/messages/convo'
 import {useAgent} from '#/state/session'
 import {useDmServiceUrlStorage} from '#/screens/Messages/Temp/useDmServiceUrlStorage'
 
-const ChatContext = React.createContext<ConvoInterface | null>(null)
+const ChatContext = React.createContext<ConvoState | null>(null)
 
 export function useChat() {
   const ctx = useContext(ChatContext)
@@ -32,6 +33,16 @@ export function ChatProvider({
       }),
   )
   const service = useSyncExternalStore(convo.subscribe, convo.getSnapshot)
+
+  useFocusEffect(
+    React.useCallback(() => {
+      convo.resume()
+
+      return () => {
+        convo.suspend()
+      }
+    }, [convo]),
+  )
 
   return <ChatContext.Provider value={service}>{children}</ChatContext.Provider>
 }


### PR DESCRIPTION
With this PR, `Convo` is hooked up to `useSyncExternalStore`.

- When React subscribes (goes from 0->1 listener) we init the `Convo`, and when React unsubscribes (1->0) the `Convo` enters a `suspended` status
  - `Convo` can resume from `suspended` status if it needs to
- When screen is backgrounded by React Navigation, `Convo` enters a `backgrounded` status, and polling drops to once every 10s (from every 2s by default)
  - When refocused, `Convo` resumes from `backgrounded`
- Snapshotting is lazy, only when React requests it
- Snapshots only change when a new message is received or sent
- Each `Convo` interface returned from `useSyncExternalStore` differs by `status`, but retains the same shape each time
  - This discriminated union might be a little much, but didn't want to totally change it in this PR, can fix-forward if need be
- Methods are bound to the instance once, never again
- Getters were replaced