### PR TITLE
[Clipclops] Refactor message list

### DIFF
--- a/src/components/dms/MessageItem.tsx
+++ b/src/components/dms/MessageItem.tsx
@@ -10,7 +10,7 @@ import {atoms as a, useTheme} from '#/alf'
 import {ActionsWrapper} from '#/components/dms/ActionsWrapper'
 import {Text} from '#/components/Typography'
 
-export function MessageItem({
+export let MessageItem = ({
   item,
   next,
 }: {
@@ -19,7 +19,7 @@ export function MessageItem({
     | ChatBskyConvoDefs.MessageView
     | ChatBskyConvoDefs.DeletedMessageView
     | null
-}) {
+}): React.ReactNode => {
   const t = useTheme()
   const {currentAccount} = useSession()
 
@@ -87,7 +87,9 @@ export function MessageItem({
   )
 }
 
-export function MessageItemMetadata({
+MessageItem = React.memo(MessageItem)
+
+let MessageItemMetadata = ({
   message,
   isLastInGroup,
   style,
@@ -95,7 +97,7 @@ export function MessageItemMetadata({
   message: ChatBskyConvoDefs.MessageView
   isLastInGroup: boolean
   style: StyleProp<TextStyle>
-}) {
+}): React.ReactNode => {
   const t = useTheme()
   const {_} = useLingui()
 
@@ -163,6 +165,8 @@ export function MessageItemMetadata({
     </TimeElapsed>
   )
 }
+
+MessageItemMetadata = React.memo(MessageItemMetadata)
 
 function localDateString(date: Date) {
   // can't use toISOString because it should be in local time

--- a/src/screens/Messages/Conversation/MessageInput.tsx
+++ b/src/screens/Messages/Conversation/MessageInput.tsx
@@ -19,11 +19,9 @@ import {PaperPlane_Stroke2_Corner0_Rounded as PaperPlane} from '#/components/ico
 export function MessageInput({
   onSendMessage,
   onFocus,
-  onBlur,
 }: {
   onSendMessage: (message: string) => void
-  onFocus: () => void
-  onBlur: () => void
+  onFocus?: () => void
 }) {
   const {_} = useLingui()
   const t = useTheme()
@@ -85,7 +83,6 @@ export function MessageInput({
           scrollEnabled={isInputScrollable}
           blurOnSubmit={false}
           onFocus={onFocus}
-          onBlur={onBlur}
           onContentSizeChange={onInputLayout}
           ref={inputRef}
         />

--- a/src/screens/Messages/Conversation/MessageInput.web.tsx
+++ b/src/screens/Messages/Conversation/MessageInput.web.tsx
@@ -12,7 +12,6 @@ export function MessageInput({
 }: {
   onSendMessage: (message: string) => void
   onFocus: () => void
-  onBlur: () => void
 }) {
   const {_} = useLingui()
   const t = useTheme()

--- a/src/screens/Messages/Conversation/MessagesList.tsx
+++ b/src/screens/Messages/Conversation/MessagesList.tsx
@@ -85,32 +85,26 @@ export function MessagesList() {
 
   useScrollToEndOnFocus(flatListRef)
 
-  const messages = React.useMemo(() => {
-    if (chat.state.status !== ConvoStatus.Ready) {
-      return []
-    }
-    const items = chat.state.items
-    return chat.state.status === ConvoStatus.Ready
-      ? items.map((item, index) => items[items.length - 1 - index])
-      : []
-  }, [chat.state])
-
   const onContentSizeChange = useCallback((_: number, height: number) => {
     if (!isAtBottom.current) return
     flatListRef.current?.scrollToOffset({animated: isNative, offset: height})
   }, [])
 
   const onStartReached = useCallback(() => {
-    chat.service.fetchMessageHistory()
-  }, [chat.service])
+    if (chat.status === ConvoStatus.Ready) {
+      chat.fetchMessageHistory()
+    }
+  }, [chat])
 
   const onSendMessage = useCallback(
     (text: string) => {
-      chat.service.sendMessage({
-        text,
-      })
+      if (chat.status === ConvoStatus.Ready) {
+        chat.sendMessage({
+          text,
+        })
+      }
     },
-    [chat.service],
+    [chat],
   )
 
   const onScroll = React.useCallback(
@@ -138,6 +132,8 @@ export function MessagesList() {
   const {bottom: bottomInset} = useSafeAreaInsets()
   const keyboardVerticalOffset = useKeyboardVerticalOffset()
 
+  console.log(chat.items)
+
   return (
     <KeyboardAvoidingView
       style={[a.flex_1, {marginBottom: bottomInset}]}
@@ -146,7 +142,7 @@ export function MessagesList() {
       contentContainerStyle={a.flex_1}>
       <FlatList
         ref={flatListRef}
-        data={chat.state.status === ConvoStatus.Ready ? messages : undefined}
+        data={chat.status === ConvoStatus.Ready ? chat.items : undefined}
         keyExtractor={keyExtractor}
         renderItem={renderItem}
         contentContainerStyle={{paddingHorizontal: 10}}
@@ -171,8 +167,7 @@ export function MessagesList() {
         ListHeaderComponent={
           <MaybeLoader
             isLoading={
-              chat.state.status === ConvoStatus.Ready &&
-              chat.state.isFetchingHistory
+              chat.status === ConvoStatus.Ready && chat.isFetchingHistory
             }
           />
         }

--- a/src/screens/Messages/Conversation/MessagesList.tsx
+++ b/src/screens/Messages/Conversation/MessagesList.tsx
@@ -16,6 +16,7 @@ import {useChat} from '#/state/messages'
 import {ConvoItem, ConvoStatus} from '#/state/messages/convo'
 import {useSetMinimalShellMode} from '#/state/shell'
 import {isWeb} from 'platform/detection'
+import {List} from 'view/com/util/List'
 import {MessageInput} from '#/screens/Messages/Conversation/MessageInput'
 import {MessageListError} from '#/screens/Messages/Conversation/MessageListError'
 import {useScrollToEndOnFocus} from '#/screens/Messages/Conversation/useScrollToEndOnFocus'
@@ -199,33 +200,36 @@ export function MessagesList() {
       keyboardVerticalOffset={keyboardVerticalOffset}
       behavior="padding"
       contentContainerStyle={a.flex_1}>
-      <FlatList
-        ref={flatListRef}
-        data={chat.status === ConvoStatus.Ready ? chat.items : undefined}
-        renderItem={renderItem}
-        keyExtractor={keyExtractor}
-        disableVirtualization={true}
-        initialNumToRender={isWeb ? 100 : 25}
-        maxToRenderPerBatch={isWeb ? 100 : 25}
-        keyboardDismissMode="on-drag"
-        maintainVisibleContentPosition={{
-          minIndexForVisible: 1,
-        }}
-        removeClippedSubviews={false}
-        showsVerticalScrollIndicator={hasInitiallyScrolled}
-        onContentSizeChange={onContentSizeChange}
-        onStartReached={onStartReached}
-        onScrollToIndexFailed={onScrollToIndexFailed}
-        onScroll={onScroll}
-        scrollEventThrottle={100}
-        ListHeaderComponent={
-          <MaybeLoader
-            isLoading={
-              chat.status === ConvoStatus.Ready && chat.isFetchingHistory
-            }
-          />
-        }
-      />
+      {/* @ts-expect-error web only */}
+      <View style={[{flex: 1}, isWeb && {'overflow-y': 'scroll'}]}>
+        <List
+          ref={flatListRef}
+          data={chat.status === ConvoStatus.Ready ? chat.items : undefined}
+          renderItem={renderItem}
+          keyExtractor={keyExtractor}
+          disableVirtualization={true}
+          initialNumToRender={isWeb ? 100 : 25}
+          maxToRenderPerBatch={isWeb ? 100 : 25}
+          keyboardDismissMode="on-drag"
+          maintainVisibleContentPosition={{
+            minIndexForVisible: 1,
+          }}
+          removeClippedSubviews={false}
+          showsVerticalScrollIndicator={hasInitiallyScrolled}
+          onContentSizeChange={onContentSizeChange}
+          onStartReached={onStartReached}
+          onScrollToIndexFailed={onScrollToIndexFailed}
+          onScroll={onScroll}
+          scrollEventThrottle={100}
+          ListHeaderComponent={
+            <MaybeLoader
+              isLoading={
+                chat.status === ConvoStatus.Ready && chat.isFetchingHistory
+              }
+            />
+          }
+        />
+      </View>
       <MessageInput
         onSendMessage={onSendMessage}
         onFocus={isWeb ? onInputFocus : undefined}

--- a/src/screens/Messages/Conversation/MessagesList.tsx
+++ b/src/screens/Messages/Conversation/MessagesList.tsx
@@ -1,7 +1,7 @@
 import React, {useCallback, useRef} from 'react'
 import {FlatList, Platform, View} from 'react-native'
 import {KeyboardAvoidingView} from 'react-native-keyboard-controller'
-import {useSharedValue} from 'react-native-reanimated'
+import {runOnJS, useSharedValue} from 'react-native-reanimated'
 import {ReanimatedScrollEvent} from 'react-native-reanimated/lib/typescript/reanimated2/hook/commonTypes'
 import {useSafeAreaInsets} from 'react-native-safe-area-context'
 import {msg, Trans} from '@lingui/macro'
@@ -91,7 +91,7 @@ export function MessagesList() {
   // onStartReached to fire.
   const contentHeight = useSharedValue(0)
 
-  const hasInitiallyScrolled = useSharedValue(false)
+  const [hasInitiallyScrolled, setHasInitiallyScrolled] = React.useState(false)
 
   // This is only used on native because `Keyboard` can't be imported on web. On web, an input focus will immediately
   // trigger scrolling to the bottom. On native however, we need to wait for the keyboard to present before scrolling,
@@ -116,11 +116,11 @@ export function MessagesList() {
       }
 
       flatListRef.current?.scrollToOffset({
-        animated: hasInitiallyScrolled.value,
+        animated: hasInitiallyScrolled,
         offset: height,
       })
     },
-    [contentHeight, hasInitiallyScrolled.value, isAtBottom.value],
+    [contentHeight, hasInitiallyScrolled, isAtBottom.value],
   )
 
   const onStartReached = useCallback(() => {
@@ -152,8 +152,8 @@ export function MessagesList() {
       // This number _must_ be the height of the MaybeLoader component.
       // We don't check for zero, because the `MaybeLoader` component is always present, even when not visible, which
       // adds a 50 pixel offset.
-      if (contentHeight.value > 50 && !hasInitiallyScrolled.value) {
-        hasInitiallyScrolled.value = true
+      if (contentHeight.value > 50 && !hasInitiallyScrolled) {
+        runOnJS(setHasInitiallyScrolled)(true)
       }
     },
     [contentHeight.value, hasInitiallyScrolled, isAtBottom],
@@ -181,8 +181,8 @@ export function MessagesList() {
             renderItem={renderItem}
             keyExtractor={keyExtractor}
             disableVirtualization={true}
-            initialNumToRender={isWeb ? 100 : 25}
-            maxToRenderPerBatch={isWeb ? 100 : 25}
+            initialNumToRender={isWeb ? 50 : 25}
+            maxToRenderPerBatch={isWeb ? 50 : 25}
             keyboardDismissMode="on-drag"
             maintainVisibleContentPosition={{
               minIndexForVisible: 1,

--- a/src/screens/Messages/Conversation/useScrollToEndOnFocus.ts
+++ b/src/screens/Messages/Conversation/useScrollToEndOnFocus.ts
@@ -1,0 +1,16 @@
+import React from 'react'
+import {FlatList, Keyboard} from 'react-native'
+
+export function useScrollToEndOnFocus(flatListRef: React.RefObject<FlatList>) {
+  React.useEffect(() => {
+    const listener = Keyboard.addListener('keyboardDidShow', () => {
+      requestAnimationFrame(() => {
+        flatListRef.current?.scrollToEnd({animated: true})
+      })
+    })
+
+    return () => {
+      listener.remove()
+    }
+  }, [flatListRef])
+}

--- a/src/screens/Messages/Conversation/useScrollToEndOnFocus.web.ts
+++ b/src/screens/Messages/Conversation/useScrollToEndOnFocus.web.ts
@@ -1,0 +1,6 @@
+import React from 'react'
+import {FlatList} from 'react-native'
+
+// Stub for web
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export function useScrollToEndOnFocus(flatListRef: React.RefObject<FlatList>) {}

--- a/src/state/messages/convo.ts
+++ b/src/state/messages/convo.ts
@@ -673,45 +673,6 @@ export class Convo {
   getItems(): ConvoItem[] {
     const items: ConvoItem[] = []
 
-    // `newMessages` is in insertion order, unshift to reverse
-    this.newMessages.forEach(m => {
-      if (ChatBskyConvoDefs.isMessageView(m)) {
-        items.unshift({
-          type: 'message',
-          key: m.id,
-          message: m,
-          nextMessage: null,
-        })
-      } else if (ChatBskyConvoDefs.isDeletedMessageView(m)) {
-        items.unshift({
-          type: 'deleted-message',
-          key: m.id,
-          message: m,
-          nextMessage: null,
-        })
-      }
-    })
-
-    // `newMessages` is in insertion order, unshift to reverse
-    this.pendingMessages.forEach(m => {
-      items.unshift({
-        type: 'pending-message',
-        key: m.id,
-        message: {
-          ...m.message,
-          id: nanoid(),
-          rev: '__fake__',
-          sentAt: new Date().toISOString(),
-          sender: this.sender,
-        },
-        nextMessage: null,
-      })
-    })
-
-    this.footerItems.forEach(item => {
-      items.unshift(item)
-    })
-
     this.pastMessages.forEach(m => {
       if (ChatBskyConvoDefs.isMessageView(m)) {
         items.push({
@@ -728,6 +689,43 @@ export class Convo {
           nextMessage: null,
         })
       }
+    })
+
+    this.newMessages.forEach(m => {
+      if (ChatBskyConvoDefs.isMessageView(m)) {
+        items.push({
+          type: 'message',
+          key: m.id,
+          message: m,
+          nextMessage: null,
+        })
+      } else if (ChatBskyConvoDefs.isDeletedMessageView(m)) {
+        items.push({
+          type: 'deleted-message',
+          key: m.id,
+          message: m,
+          nextMessage: null,
+        })
+      }
+    })
+
+    this.pendingMessages.forEach(m => {
+      items.push({
+        type: 'pending-message',
+        key: m.id,
+        message: {
+          ...m.message,
+          id: nanoid(),
+          rev: '__fake__',
+          sentAt: new Date().toISOString(),
+          sender: this.sender,
+        },
+        nextMessage: null,
+      })
+    })
+
+    this.footerItems.forEach(item => {
+      items.push(item)
     })
 
     return items


### PR DESCRIPTION
Turns out that `inverted` messeds up the accessibility - the accessibility is _also_ inverted on android and web. So this refactors to a normal `FlatList`

Did some explaining of the quirky things below. There are sure to be some things to tweak over the next week, but this feels like a _decent_ implementation of what we need. At some point, a better implementation - maybe one that fixes some of the issues present in `FlatList` as of right now - would be useful and probably feel better.