### PR TITLE
[Session] Track agent in state

### DIFF
--- a/src/state/session/index.tsx
+++ b/src/state/session/index.tsx
@@ -347,7 +347,7 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
           })
 
           __globalAgent = PUBLIC_BSKY_AGENT
-          // TODO: Should this update currentAgentState?
+          // TODO: This needs a setState.
         }
       } else {
         logger.debug(`session: attempting to reuse previous session`)
@@ -409,7 +409,7 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
             })
 
             __globalAgent = PUBLIC_BSKY_AGENT
-            // TODO: Should this update currentAccountDid?
+            // TODO: This needs a setState.
           })
       }
 
@@ -526,6 +526,7 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
            */
           // @ts-ignore we checked for `refreshJwt` above
           __globalAgent.session = selectedAccount
+          // TODO: This needs a setState.
         }
       } else if (!selectedAccount && state.currentAgentState.did) {
         logger.debug(
@@ -549,7 +550,7 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
             did: undefined,
             agent: PUBLIC_BSKY_AGENT,
           },
-          needsPersist: true,
+          needsPersist: true, // TODO: This seems bad in this codepath. Existing behavior.
         }))
       }
 

--- a/src/state/session/index.tsx
+++ b/src/state/session/index.tsx
@@ -268,14 +268,6 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
       logger.warn(`session: clear current account`)
       __globalAgent = PUBLIC_BSKY_AGENT
       configureModerationForGuest()
-      setState(s => ({
-        accounts: s.accounts,
-        currentAgentState: {
-          did: undefined,
-          agent: PUBLIC_BSKY_AGENT,
-        },
-        needsPersist: true,
-      }))
       setState(s => {
         return {
           accounts: s.accounts.map(a => ({
@@ -283,7 +275,10 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
             refreshJwt: undefined,
             accessJwt: undefined,
           })),
-          currentAgentState: s.currentAgentState,
+          currentAgentState: {
+            did: undefined,
+            agent: PUBLIC_BSKY_AGENT,
+          },
           needsPersist: true,
         }
       })
@@ -560,10 +555,7 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
 
       setState(s => ({
         accounts: persistedSession.accounts,
-        currentAgentState: {
-          agent: s.currentAgentState.agent, // TODO: This is shady. Restructure.
-          did: selectedAccount?.did,
-        },
+        currentAgentState: s.currentAgentState,
         needsPersist: false, // Synced from another tab. Don't persist to avoid cycles.
       }))
     })

--- a/src/state/session/index.tsx
+++ b/src/state/session/index.tsx
@@ -99,7 +99,16 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
         logger.warn(
           `session: persistSessionHandler received network-error event`,
         )
-        clearCurrentAccount()
+        logger.warn(`session: clear current account`)
+        __globalAgent = PUBLIC_BSKY_AGENT
+        configureModerationForGuest()
+        setState(s => ({
+          accounts: s.accounts,
+          currentAgentState: {
+            did: undefined,
+          },
+          needsPersist: true,
+        }))
         return
       }
 
@@ -155,7 +164,7 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
         }
       })
     },
-    [clearCurrentAccount],
+    [],
   )
 
   const createAccount = React.useCallback<SessionApiContext['createAccount']>(
@@ -245,7 +254,16 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
   const logout = React.useCallback<SessionApiContext['logout']>(
     async logContext => {
       logger.debug(`session: logout`)
-      clearCurrentAccount()
+      logger.warn(`session: clear current account`)
+      __globalAgent = PUBLIC_BSKY_AGENT
+      configureModerationForGuest()
+      setState(s => ({
+        accounts: s.accounts,
+        currentAgentState: {
+          did: undefined,
+        },
+        needsPersist: true,
+      }))
       setState(s => {
         return {
           accounts: s.accounts.map(a => ({
@@ -259,7 +277,7 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
       })
       logEvent('account:loggedOut', {logContext})
     },
-    [clearCurrentAccount, setState],
+    [setState],
   )
 
   const initSession = React.useCallback<SessionApiContext['initSession']>(
@@ -512,7 +530,16 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
          * handled by `persistSession` (which nukes this accounts tokens only),
          * or by a `logout` call  which nukes all accounts tokens)
          */
-        clearCurrentAccount()
+        logger.warn(`session: clear current account`)
+        __globalAgent = PUBLIC_BSKY_AGENT
+        configureModerationForGuest()
+        setState(s => ({
+          accounts: s.accounts,
+          currentAgentState: {
+            did: undefined,
+          },
+          needsPersist: true,
+        }))
       }
 
       setState(() => ({
@@ -523,7 +550,7 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
         needsPersist: false, // Synced from another tab. Don't persist to avoid cycles.
       }))
     })
-  }, [state, setState, clearCurrentAccount, initSession])
+  }, [state, setState, initSession])
 
   const stateContext = React.useMemo(
     () => ({


### PR DESCRIPTION
Extracted from #3728 but slightly adjusted.

The point of #3728 was to move the agent into React state so that it has a predictable lifetime and we don't depend on reading the global. This PR takes an incremental step by storing a `{did, agent}` pair in state instead of just the `did`.

Note I'm storing `{did, agent}` rather than just `agent` as done in #3728. This is because we can't safely derive a did from an agent instance. The only way to do that is to do `agent.session.did`, but `agent.session` is `undefined` if the session has expired. So keeping track of the agent alone is not enough.

To avoid them getting out of sync, I store them in a group (rather than two top-level keys) and encourage thinking about `{did, agent}` as a unit ("agent state"). I'll later change agent factories to produce "agent state" directly to reflect that.

## Reviewing

I recommend reviewing individual commits. They're supposed to be safe atomic changes.

- https://github.com/bluesky-social/social-app/commit/c3c39f9ecb501b0a49197daddb8e92a96f17c796: Moves `did` inside an object.
- https://github.com/bluesky-social/social-app/commit/5a8a2cadecf1ab41bc0d13fca0dca8a81d727388: Gets rid of the `upsertAccount` method and inlines it everywhere. This will make it easier to see what state transformations occur at each callsite. I plan to do a dedupe pass at the end of this refactor (might write a reducer).
- https://github.com/bluesky-social/social-app/commit/e65aa2283a4597b10b21375aef982f0549061488: Does the same for `clearCurrentAccount`. It's adding some duplication but that's fine, will dedupe later.
- https://github.com/bluesky-social/social-app/commit/f20a63987cbc09ce45a1dcbf17948b30650a7bd3: Actually adds `agent`, turning `{did}` into `{did, agent}`. We fill it in based on what the user did (similar to global `__agent` mutations).
- https://github.com/bluesky-social/social-app/commit/6059c10da29c3240221af61033fb16cc5e74a4b5: Simplifies the code a bit, merging unnecessary setStates.

## Test Plan

Read the commits thoroughly. My strategy is to try to keep the changes themselves digestible so we don't have to test every single change in isolation, and then do a heavier QA pass at the end.

That said, I've tested login and logout, account switching (via settings, login modal, and profile switcher), syncing between tabs, and account creation.