### PR TITLE
[Session] Fix stale emailAuthFactor and emailConfirmed on the client

### DIFF
--- a/src/state/session/index.tsx
+++ b/src/state/session/index.tsx
@@ -121,9 +121,9 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
       // TODO: use agentToSessionAccount for this too.
       const refreshedAccount: SessionAccount = {
         service: account.service,
-        did: session?.did || account.did,
-        handle: session?.handle || account.handle,
-        email: session?.email || account.email,
+        did: session?.did ?? account.did,
+        handle: session?.handle ?? account.handle,
+        email: session?.email ?? account.email,
         emailConfirmed: session?.emailConfirmed ?? account.emailConfirmed,
         emailAuthFactor: session?.emailAuthFactor ?? account.emailAuthFactor,
         deactivated: isSessionDeactivated(session?.accessJwt),
@@ -311,8 +311,8 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
         isSessionDeactivated(account.accessJwt) || account.deactivated
 
       const prevSession = {
-        accessJwt: account.accessJwt || '',
-        refreshJwt: account.refreshJwt || '',
+        accessJwt: account.accessJwt ?? '',
+        refreshJwt: account.refreshJwt ?? '',
         did: account.did,
         handle: account.handle,
       }
@@ -457,16 +457,12 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
 
         const updatedAccount = {
           ...currentAccount,
-          handle: account.handle || currentAccount.handle,
-          email: account.email || currentAccount.email,
+          handle: account.handle ?? currentAccount.handle,
+          email: account.email ?? currentAccount.email,
           emailConfirmed:
-            account.emailConfirmed !== undefined
-              ? account.emailConfirmed
-              : currentAccount.emailConfirmed,
+            account.emailConfirmed ?? currentAccount.emailConfirmed,
           emailAuthFactor:
-            account.emailAuthFactor !== undefined
-              ? account.emailAuthFactor
-              : currentAccount.emailAuthFactor,
+            account.emailAuthFactor ?? currentAccount.emailAuthFactor,
         }
 
         return {

--- a/src/state/session/index.tsx
+++ b/src/state/session/index.tsx
@@ -124,8 +124,8 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
         did: session?.did || account.did,
         handle: session?.handle || account.handle,
         email: session?.email || account.email,
-        emailConfirmed: session?.emailConfirmed || account.emailConfirmed,
-        emailAuthFactor: session?.emailAuthFactor || account.emailAuthFactor,
+        emailConfirmed: session?.emailConfirmed ?? account.emailConfirmed,
+        emailAuthFactor: session?.emailAuthFactor ?? account.emailAuthFactor,
         deactivated: isSessionDeactivated(session?.accessJwt),
         pdsUrl: agent.pdsUrl?.toString(),
 


### PR DESCRIPTION
Extracted from #3728. The fix is https://github.com/bluesky-social/social-app/commit/b0aa70d26ade390704e735f3ababc6d493b9ac1c.

The intent of this code was to use the value from the session and fallback to the stored value if the session isn't present. However, if `session.emailAuthFactor` (newer) is `false` but `account.emailAuthFactor` (older) is `true`, the `session?.emailAuthFactor || account.emailAuthFactor` expression will keep giving us `true` even though `false` is the fresh value here. So we'll store and display the incorrect stored `true` value.

The fix is to use `??` instead. I've updated a few other places we use `||` for fallback values for consistency in the second commit, but that shouldn't affect the behavior.

## Test Plan

To trigger this, you'd need to get a "session changed" event from the agent with the new session info. One way you can get there is by having your token expired. I don't know how to make that happen though.

A simpler way to trigger it is to comment out [these lines](https://github.com/bluesky-social/social-app/blob/0f827c321370f26b0c1c8db7286ad9be7e6ac98a/src/state/session/index.tsx#L382-L413) so that `resumeSessionWithFreshAccount()` itself starts, but then we're rely on the logic in `onAgentSessionChange` to actually apply the update.

Then the test plan becomes:

1. Switch to `main` and comment out the lines mentioned above
1. In another browser window, open prod and turn on 2FA in Settings
1. Refresh browser locally, observe that 2FA flag is on in Settings
1. In another browser window, open prod and turn off 2FA in Settings
1. Refresh browser locally, observe that 2FA flag is **still on** in Settings
1. Refresh browser locally, observe that 2FA flag is **still on** in Settings
1. Switch to this branch and comment out the lines mentioned above
1. Refresh browser locally, observe that 2FA flag is off in Settings, as expected

From that point on, toggling it off and on in another browser window is correctly applied on session refresh.