### PR TITLE
[Session] Rely on agent session change event for persisting resumed session

### DIFF
--- a/src/state/session/index.tsx
+++ b/src/state/session/index.tsx
@@ -379,38 +379,6 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
 
         // Intentionally not awaited to unblock the UI:
         resumeSessionWithFreshAccount()
-          .then(freshAccount => {
-            if (JSON.stringify(account) !== JSON.stringify(freshAccount)) {
-              logger.info(
-                `session: reuse of previous session returned a fresh account, upserting`,
-              )
-              setState(s => {
-                return {
-                  accounts: [
-                    freshAccount,
-                    ...s.accounts.filter(a => a.did !== freshAccount.did),
-                  ],
-                  currentAgentState: {
-                    did: freshAccount.did,
-                    agent: agent,
-                  },
-                  needsPersist: true,
-                }
-              })
-            }
-          })
-          .catch(e => {
-            /*
-             * Note: `agent.persistSession` is also called when this fails, and
-             * we handle that failure via `createPersistSessionHandler`
-             */
-            logger.info(`session: resumeSessionWithFreshAccount failed`, {
-              message: e,
-            })
-
-            __globalAgent = PUBLIC_BSKY_AGENT
-            // TODO: This needs a setState.
-          })
       }
 
       async function resumeSessionWithFreshAccount(): Promise<SessionAccount> {

--- a/src/state/session/index.tsx
+++ b/src/state/session/index.tsx
@@ -158,6 +158,18 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
        * out.
        */
       setState(s => {
+        const existingAccount = s.accounts.find(
+          a => a.did === refreshedAccount.did,
+        )
+        if (
+          !expired &&
+          existingAccount &&
+          refreshedAccount &&
+          JSON.stringify(existingAccount) === JSON.stringify(refreshedAccount)
+        ) {
+          // Fast path without a state update.
+          return s
+        }
         return {
           accounts: [
             refreshedAccount,


### PR DESCRIPTION
Extracted from #3728.

See two individual commits.

- 7095822a5b97ffad86ee1a7bccf431594f216790: When we resume session, we don't want to block the UI so we assume it'll come through. Still, we kick off a `resumeSession` request in background. When that request comes back, we want to persist the new session if it's different from what we've stored. Turns out, we don't actually need to write this logic explicitly because the `onAgentSessionChange` handler already has the logic to handle session updates — and the agent will call it. So just kicking off a resume is sufficient on its own. Errors would be reported to `onAgentSessionChange` as well.
- https://github.com/bluesky-social/social-app/commit/529d1fec07e0f6be67895a49882bf0919ad26ccd: Previously, we had an optimization that avoids a state update right after startup if the resumed session is the same as what we've stored. We've lost this optimization in the last commit so let's re-add it here.

## Test Plan

1. Toggle 2FA setting in a different browser window.
2. Reload and observe that the change is being picked up on resume via `onAgentSessionChange`.
3. Reload and observe that next resumes are able to bail out of the `setState` due to identical payload.