### PR TITLE
[Session] Reset global agent on expire

### DIFF
--- a/src/state/session/index.tsx
+++ b/src/state/session/index.tsx
@@ -145,6 +145,16 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
       if (expired) {
         logger.warn(`session: expired`)
         emitSessionDropped()
+        __globalAgent = PUBLIC_BSKY_AGENT
+        configureModerationForGuest()
+        setState(s => ({
+          accounts: s.accounts,
+          currentAgentState: {
+            agent: PUBLIC_BSKY_AGENT,
+            did: undefined,
+          },
+          needsPersist: true,
+        }))
       }
 
       /*
@@ -175,12 +185,7 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
             refreshedAccount,
             ...s.accounts.filter(a => a.did !== refreshedAccount.did),
           ],
-          currentAgentState: expired
-            ? {
-                agent: PUBLIC_BSKY_AGENT,
-                did: undefined,
-              }
-            : s.currentAgentState,
+          currentAgentState: s.currentAgentState,
           needsPersist: true,
         }
       })


### PR DESCRIPTION
Fixes a mistake I introduced in https://github.com/bluesky-social/social-app/pull/3836.
Extracted from https://github.com/bluesky-social/social-app/pull/3728.

The change in https://github.com/bluesky-social/social-app/pull/3836 assumes the persistence handler will handle any errors. However, our `onAgentSessionChange` persistence handler does not currently update `__globalAgent` on expiry (despite updating the related state). This is inconsistent with how the same persistence handler treats `network-error` (for which it does update `__globalAgent`).

Updating the global agent seems like the correct behavior if we're updating the UI to show PWI. So this seems like an omission in the existing code (which #3836 made worse). I suppose this was less important before https://github.com/bluesky-social/social-app/pull/3836 because the `catch` branch would restore `__globalAgent` regardless of the persistence handler. Anyway, _this_ fix is in the handler itself.

In this PR, I adjust the `expired` branch to do the same things (copy paste) as the `network-error` early condition. (Unlike with `network-error`, we don't want an early return because we still want the `accounts`-related state update below to run.)

## Test Plan

To trigger the `expiry` codepath, you can set a breakpoint in `resumeSession` and evaluate `res.data.did = 'foo'` so that it raises an error which the agent will broadcast as an expiry.

Verify that previously `__globalAgent` was being set in this case by the `catch` block I removed in https://github.com/bluesky-social/social-app/pull/3836. So now it's not being set at all, and you can verify it's stale.

After applying this PR and doing the same thing, verify that `__globalAgent` is being set by the persisted handler.

Verify you get kicked to the login and can log in after entering credentials.