### PR TITLE
Don't clear toasts when changing users

### DIFF
--- a/src/App.native.tsx
+++ b/src/App.native.tsx
@@ -91,34 +91,33 @@ function InnerApp() {
       <Alf theme={theme}>
         <ThemeProvider theme={theme}>
           <Splash isReady={isReady}>
-            <React.Fragment
-              // Resets the entire tree below when it changes:
-              key={currentAccount?.did}>
-              <QueryProvider currentDid={currentAccount?.did}>
-                <PushNotificationsListener>
-                  <StatsigProvider>
-                    {/* LabelDefsProvider MUST come before ModerationOptsProvider */}
-                    <LabelDefsProvider>
-                      <ModerationOptsProvider>
-                        <LoggedOutViewProvider>
-                          <SelectedFeedProvider>
-                            <UnreadNotifsProvider>
-                              {/* All components should be within this provider */}
-                              <RootSiblingParent>
+            <RootSiblingParent>
+              <React.Fragment
+                // Resets the entire tree below when it changes:
+                key={currentAccount?.did}>
+                <QueryProvider currentDid={currentAccount?.did}>
+                  <PushNotificationsListener>
+                    <StatsigProvider>
+                      {/* LabelDefsProvider MUST come before ModerationOptsProvider */}
+                      <LabelDefsProvider>
+                        <ModerationOptsProvider>
+                          <LoggedOutViewProvider>
+                            <SelectedFeedProvider>
+                              <UnreadNotifsProvider>
                                 <GestureHandlerRootView style={s.h100pct}>
                                   <TestCtrls />
                                   <Shell />
                                 </GestureHandlerRootView>
-                              </RootSiblingParent>
-                            </UnreadNotifsProvider>
-                          </SelectedFeedProvider>
-                        </LoggedOutViewProvider>
-                      </ModerationOptsProvider>
-                    </LabelDefsProvider>
-                  </StatsigProvider>
-                </PushNotificationsListener>
-              </QueryProvider>
-            </React.Fragment>
+                              </UnreadNotifsProvider>
+                            </SelectedFeedProvider>
+                          </LoggedOutViewProvider>
+                        </ModerationOptsProvider>
+                      </LabelDefsProvider>
+                    </StatsigProvider>
+                  </PushNotificationsListener>
+                </QueryProvider>
+              </React.Fragment>
+            </RootSiblingParent>
           </Splash>
         </ThemeProvider>
       </Alf>

--- a/src/App.native.tsx
+++ b/src/App.native.tsx
@@ -89,20 +89,20 @@ function InnerApp() {
   return (
     <SafeAreaProvider initialMetrics={initialWindowMetrics}>
       <Alf theme={theme}>
-        <Splash isReady={isReady}>
-          <React.Fragment
-            // Resets the entire tree below when it changes:
-            key={currentAccount?.did}>
-            <QueryProvider currentDid={currentAccount?.did}>
-              <PushNotificationsListener>
-                <StatsigProvider>
-                  {/* LabelDefsProvider MUST come before ModerationOptsProvider */}
-                  <LabelDefsProvider>
-                    <ModerationOptsProvider>
-                      <LoggedOutViewProvider>
-                        <SelectedFeedProvider>
-                          <UnreadNotifsProvider>
-                            <ThemeProvider theme={theme}>
+        <ThemeProvider theme={theme}>
+          <Splash isReady={isReady}>
+            <React.Fragment
+              // Resets the entire tree below when it changes:
+              key={currentAccount?.did}>
+              <QueryProvider currentDid={currentAccount?.did}>
+                <PushNotificationsListener>
+                  <StatsigProvider>
+                    {/* LabelDefsProvider MUST come before ModerationOptsProvider */}
+                    <LabelDefsProvider>
+                      <ModerationOptsProvider>
+                        <LoggedOutViewProvider>
+                          <SelectedFeedProvider>
+                            <UnreadNotifsProvider>
                               {/* All components should be within this provider */}
                               <RootSiblingParent>
                                 <GestureHandlerRootView style={s.h100pct}>
@@ -110,17 +110,17 @@ function InnerApp() {
                                   <Shell />
                                 </GestureHandlerRootView>
                               </RootSiblingParent>
-                            </ThemeProvider>
-                          </UnreadNotifsProvider>
-                        </SelectedFeedProvider>
-                      </LoggedOutViewProvider>
-                    </ModerationOptsProvider>
-                  </LabelDefsProvider>
-                </StatsigProvider>
-              </PushNotificationsListener>
-            </QueryProvider>
-          </React.Fragment>
-        </Splash>
+                            </UnreadNotifsProvider>
+                          </SelectedFeedProvider>
+                        </LoggedOutViewProvider>
+                      </ModerationOptsProvider>
+                    </LabelDefsProvider>
+                  </StatsigProvider>
+                </PushNotificationsListener>
+              </QueryProvider>
+            </React.Fragment>
+          </Splash>
+        </ThemeProvider>
       </Alf>
     </SafeAreaProvider>
   )

--- a/src/App.web.tsx
+++ b/src/App.web.tsx
@@ -67,32 +67,31 @@ function InnerApp() {
   return (
     <Alf theme={theme}>
       <ThemeProvider theme={theme}>
-        <React.Fragment
-          // Resets the entire tree below when it changes:
-          key={currentAccount?.did}>
-          <QueryProvider currentDid={currentAccount?.did}>
-            <StatsigProvider>
-              {/* LabelDefsProvider MUST come before ModerationOptsProvider */}
-              <LabelDefsProvider>
-                <ModerationOptsProvider>
-                  <LoggedOutViewProvider>
-                    <SelectedFeedProvider>
-                      <UnreadNotifsProvider>
-                        {/* All components should be within this provider */}
-                        <RootSiblingParent>
+        <RootSiblingParent>
+          <React.Fragment
+            // Resets the entire tree below when it changes:
+            key={currentAccount?.did}>
+            <QueryProvider currentDid={currentAccount?.did}>
+              <StatsigProvider>
+                {/* LabelDefsProvider MUST come before ModerationOptsProvider */}
+                <LabelDefsProvider>
+                  <ModerationOptsProvider>
+                    <LoggedOutViewProvider>
+                      <SelectedFeedProvider>
+                        <UnreadNotifsProvider>
                           <SafeAreaProvider>
                             <Shell />
                           </SafeAreaProvider>
-                        </RootSiblingParent>
-                        <ToastContainer />
-                      </UnreadNotifsProvider>
-                    </SelectedFeedProvider>
-                  </LoggedOutViewProvider>
-                </ModerationOptsProvider>
-              </LabelDefsProvider>
-            </StatsigProvider>
-          </QueryProvider>
-        </React.Fragment>
+                          <ToastContainer />
+                        </UnreadNotifsProvider>
+                      </SelectedFeedProvider>
+                    </LoggedOutViewProvider>
+                  </ModerationOptsProvider>
+                </LabelDefsProvider>
+              </StatsigProvider>
+            </QueryProvider>
+          </React.Fragment>
+        </RootSiblingParent>
       </ThemeProvider>
     </Alf>
   )

--- a/src/App.web.tsx
+++ b/src/App.web.tsx
@@ -4,6 +4,8 @@ import 'view/icons'
 import React, {useEffect, useState} from 'react'
 import {RootSiblingParent} from 'react-native-root-siblings'
 import {SafeAreaProvider} from 'react-native-safe-area-context'
+import {msg} from '@lingui/macro'
+import {useLingui} from '@lingui/react'
 
 import {Provider as StatsigProvider} from '#/lib/statsig/statsig'
 import {logger} from '#/logger'
@@ -30,18 +32,21 @@ import {
 import {Provider as ShellStateProvider} from 'state/shell'
 import {Provider as LoggedOutViewProvider} from 'state/shell/logged-out'
 import {Provider as SelectedFeedProvider} from 'state/shell/selected-feed'
+import * as Toast from 'view/com/util/Toast'
 import {ToastContainer} from 'view/com/util/Toast.web'
 import {Shell} from 'view/shell/index'
 import {ThemeProvider as Alf} from '#/alf'
 import {useColorModeTheme} from '#/alf/util/useColorModeTheme'
 import {Provider as PortalProvider} from '#/components/Portal'
 import I18nProvider from './locale/i18nProvider'
+import {listenSessionDropped} from './state/events'
 
 function InnerApp() {
   const [isReady, setIsReady] = React.useState(false)
   const {currentAccount} = useSession()
   const {initSession} = useSessionApi()
   const theme = useColorModeTheme()
+  const {_} = useLingui()
   useIntentHandler()
 
   // init
@@ -60,6 +65,12 @@ function InnerApp() {
     const account = readLastActiveAccount()
     resumeSession(account)
   }, [initSession])
+
+  useEffect(() => {
+    return listenSessionDropped(() => {
+      Toast.show(_(msg`Sorry! Your session expired. Please log in again.`))
+    })
+  }, [_])
 
   // wait for session to resume
   if (!isReady) return null

--- a/src/App.web.tsx
+++ b/src/App.web.tsx
@@ -66,18 +66,18 @@ function InnerApp() {
 
   return (
     <Alf theme={theme}>
-      <React.Fragment
-        // Resets the entire tree below when it changes:
-        key={currentAccount?.did}>
-        <QueryProvider currentDid={currentAccount?.did}>
-          <StatsigProvider>
-            {/* LabelDefsProvider MUST come before ModerationOptsProvider */}
-            <LabelDefsProvider>
-              <ModerationOptsProvider>
-                <LoggedOutViewProvider>
-                  <SelectedFeedProvider>
-                    <UnreadNotifsProvider>
-                      <ThemeProvider theme={theme}>
+      <ThemeProvider theme={theme}>
+        <React.Fragment
+          // Resets the entire tree below when it changes:
+          key={currentAccount?.did}>
+          <QueryProvider currentDid={currentAccount?.did}>
+            <StatsigProvider>
+              {/* LabelDefsProvider MUST come before ModerationOptsProvider */}
+              <LabelDefsProvider>
+                <ModerationOptsProvider>
+                  <LoggedOutViewProvider>
+                    <SelectedFeedProvider>
+                      <UnreadNotifsProvider>
                         {/* All components should be within this provider */}
                         <RootSiblingParent>
                           <SafeAreaProvider>
@@ -85,15 +85,15 @@ function InnerApp() {
                           </SafeAreaProvider>
                         </RootSiblingParent>
                         <ToastContainer />
-                      </ThemeProvider>
-                    </UnreadNotifsProvider>
-                  </SelectedFeedProvider>
-                </LoggedOutViewProvider>
-              </ModerationOptsProvider>
-            </LabelDefsProvider>
-          </StatsigProvider>
-        </QueryProvider>
-      </React.Fragment>
+                      </UnreadNotifsProvider>
+                    </SelectedFeedProvider>
+                  </LoggedOutViewProvider>
+                </ModerationOptsProvider>
+              </LabelDefsProvider>
+            </StatsigProvider>
+          </QueryProvider>
+        </React.Fragment>
+      </ThemeProvider>
     </Alf>
   )
 }

--- a/src/App.web.tsx
+++ b/src/App.web.tsx
@@ -82,7 +82,6 @@ function InnerApp() {
                           <SafeAreaProvider>
                             <Shell />
                           </SafeAreaProvider>
-                          <ToastContainer />
                         </UnreadNotifsProvider>
                       </SelectedFeedProvider>
                     </LoggedOutViewProvider>
@@ -91,6 +90,7 @@ function InnerApp() {
               </StatsigProvider>
             </QueryProvider>
           </React.Fragment>
+          <ToastContainer />
         </RootSiblingParent>
       </ThemeProvider>
     </Alf>

--- a/src/lib/hooks/useAccountSwitcher.ts
+++ b/src/lib/hooks/useAccountSwitcher.ts
@@ -54,7 +54,6 @@ export function useAccountSwitcher() {
           message: e.message,
         })
         clearCurrentAccount() // back user out to login
-        Toast.show(_(msg`Sorry! We need you to enter your password.`))
       } finally {
         setPendingDid(null)
       }

--- a/src/lib/hooks/useAccountSwitcher.ts
+++ b/src/lib/hooks/useAccountSwitcher.ts
@@ -41,9 +41,7 @@ export function useAccountSwitcher() {
           }
           await initSession(account)
           logEvent('account:loggedIn', {logContext, withPassword: false})
-          setTimeout(() => {
-            Toast.show(_(msg`Signed in as @${account.handle}`))
-          }, 100)
+          Toast.show(_(msg`Signed in as @${account.handle}`))
         } else {
           requestSwitchToAccount({requestedAccount: account.did})
           Toast.show(
@@ -56,9 +54,7 @@ export function useAccountSwitcher() {
           message: e.message,
         })
         clearCurrentAccount() // back user out to login
-        setTimeout(() => {
-          Toast.show(_(msg`Sorry! We need you to enter your password.`))
-        }, 100)
+        Toast.show(_(msg`Sorry! We need you to enter your password.`))
       } finally {
         setPendingDid(null)
       }

--- a/src/screens/Login/ChooseAccountForm.tsx
+++ b/src/screens/Login/ChooseAccountForm.tsx
@@ -52,9 +52,7 @@ export const ChooseAccountForm = ({
               withPassword: false,
             })
             track('Sign In', {resumedSession: true})
-            setTimeout(() => {
-              Toast.show(_(msg`Signed in as @${account.handle}`))
-            }, 100)
+            Toast.show(_(msg`Signed in as @${account.handle}`))
           } catch (e: any) {
             logger.error('choose account: initSession failed', {
               message: e.message,


### PR DESCRIPTION
While working on the session code I've noticed we have a bunch of weird `setTimeout`s around toasts, and that toasts work poorly when switching accounts in general. Turns out, it's because we unmount them.

In this PR, I've relaxed it so that toasts are placed outside the area that gets remounted on user change. As a result, I was able to remove the fragile `setTimeout` hacks. See individual commits.

## Reviewing

- https://github.com/bluesky-social/social-app/commit/dcb14756808c813ef79176a27f8ebf09bb70fb8e?w=1: Puts legacy theme provider next to Alf provider.
- https://github.com/bluesky-social/social-app/commit/38a02b85ec0b15cff18b712cd626c16ce81cff55?w=1: Moves `RootSiblingParent` upwards. This is where toasts get mounted on native. I'll assume we _only_ use it for toasts so it's fine to bleed previous users' UI on account change.
- https://github.com/bluesky-social/social-app/commit/b54e3580b63d49fc71c90f45ebb287248e3980a7?w=1: On web, we use this to render toasts. Make sure it also doesn't get remounted.
- https://github.com/bluesky-social/social-app/commit/1d8ad442f943f3b8202abe9d8bbcb3dc56a9587e?w=1: We can remove the hacks now.
- https://github.com/bluesky-social/social-app/commit/06e20b20fb5bf50ff4fa1d131814456cf808cafe: Our session code does `emitSessionDropped` in the `onAgentSessionChange` handler. It seems like it makes sense to show a toast whenever that happens, regardless of the reason (since it can happen out of the blue too). The native `App.native.tsx` component already does this by `listenSessionDropped` so this copy-pastes the same approach into `App.web.tsx`. I presume it wasn't previously enabled due to the remounting issues.
  - This also lets us remove the toast in `useAccountSwitcher`. It will be taken care of by the `emitSessionDropped` logic. In fact, this toast isn't even being used yet anyway. It was added in https://github.com/bluesky-social/social-app/pull/3762/commits/c020a4c5c5266c678d1055470a10232c1d9e99a1#r1584118170 but not hooked up (cause `initSession` never throws atm), and I think we don't need it now either due to the new strategy.

## Test Plan

Switch accounts on iOS and web. Observe the toast showing up. Try doing it via Settings, via quick switcher, and via the Choose Account screen.

Force session expiry on web using the trick I described in the test plan for https://github.com/bluesky-social/social-app/pull/3838. Observe the expiry toast showing up.