### PR TITLE
[Session] Align state and global agent switchpoints

### DIFF
--- a/src/lib/hooks/useAccountSwitcher.ts
+++ b/src/lib/hooks/useAccountSwitcher.ts
@@ -15,7 +15,7 @@ export function useAccountSwitcher() {
   const [pendingDid, setPendingDid] = useState<string | null>(null)
   const {_} = useLingui()
   const {track} = useAnalytics()
-  const {initSession, clearCurrentAccount} = useSessionApi()
+  const {initSession} = useSessionApi()
   const {requestSwitchToAccount} = useLoggedOutViewControls()
 
   const onPressSwitchAccount = useCallback(
@@ -53,19 +53,11 @@ export function useAccountSwitcher() {
         logger.error(`switch account: selectAccount failed`, {
           message: e.message,
         })
-        clearCurrentAccount() // back user out to login
       } finally {
         setPendingDid(null)
       }
     },
-    [
-      _,
-      track,
-      clearCurrentAccount,
-      initSession,
-      requestSwitchToAccount,
-      pendingDid,
-    ],
+    [_, track, initSession, requestSwitchToAccount, pendingDid],
   )
 
   return {onPressSwitchAccount, pendingDid}

--- a/src/screens/Login/ChooseAccountForm.tsx
+++ b/src/screens/Login/ChooseAccountForm.tsx
@@ -57,12 +57,13 @@ export const ChooseAccountForm = ({
             logger.error('choose account: initSession failed', {
               message: e.message,
             })
+            onSelectAccount(account) // Move to login form.
           } finally {
             setPendingDid(null)
           }
         }
       } else {
-        onSelectAccount(account)
+        onSelectAccount(account) // Move to login form.
       }
     },
     [

--- a/src/screens/Login/ChooseAccountForm.tsx
+++ b/src/screens/Login/ChooseAccountForm.tsx
@@ -39,31 +39,33 @@ export const ChooseAccountForm = ({
         // The session API isn't resilient to race conditions so let's just ignore this.
         return
       }
-      if (account.accessJwt) {
-        if (account.did === currentAccount?.did) {
-          setShowLoggedOut(false)
-          Toast.show(_(msg`Already signed in as @${account.handle}`))
-        } else {
-          try {
-            setPendingDid(account.did)
-            await initSession(account)
-            logEvent('account:loggedIn', {
-              logContext: 'ChooseAccountForm',
-              withPassword: false,
-            })
-            track('Sign In', {resumedSession: true})
-            Toast.show(_(msg`Signed in as @${account.handle}`))
-          } catch (e: any) {
-            logger.error('choose account: initSession failed', {
-              message: e.message,
-            })
-            onSelectAccount(account) // Move to login form.
-          } finally {
-            setPendingDid(null)
-          }
-        }
-      } else {
-        onSelectAccount(account) // Move to login form.
+      if (!account.accessJwt) {
+        // Move to login form.
+        onSelectAccount(account)
+        return
+      }
+      if (account.did === currentAccount?.did) {
+        setShowLoggedOut(false)
+        Toast.show(_(msg`Already signed in as @${account.handle}`))
+        return
+      }
+      try {
+        setPendingDid(account.did)
+        await initSession(account)
+        logEvent('account:loggedIn', {
+          logContext: 'ChooseAccountForm',
+          withPassword: false,
+        })
+        track('Sign In', {resumedSession: true})
+        Toast.show(_(msg`Signed in as @${account.handle}`))
+      } catch (e: any) {
+        logger.error('choose account: initSession failed', {
+          message: e.message,
+        })
+        // Move to login form.
+        onSelectAccount(account)
+      } finally {
+        setPendingDid(null)
       }
     },
     [

--- a/src/screens/Login/ChooseAccountForm.tsx
+++ b/src/screens/Login/ChooseAccountForm.tsx
@@ -57,7 +57,6 @@ export const ChooseAccountForm = ({
             logger.error('choose account: initSession failed', {
               message: e.message,
             })
-            onSelectAccount(account)
           } finally {
             setPendingDid(null)
           }

--- a/src/state/session/index.tsx
+++ b/src/state/session/index.tsx
@@ -480,6 +480,11 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
       const persistedSession = persisted.get('session')
 
       logger.debug(`session: persisted onUpdate`, {})
+      setState(s => ({
+        accounts: persistedSession.accounts,
+        currentAgentState: s.currentAgentState,
+        needsPersist: false, // Synced from another tab. Don't persist to avoid cycles.
+      }))
 
       const selectedAccount = persistedSession.accounts.find(
         a => a.did === persistedSession.currentAccount?.did,
@@ -534,12 +539,6 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
           needsPersist: true, // TODO: This seems bad in this codepath. Existing behavior.
         }))
       }
-
-      setState(s => ({
-        accounts: persistedSession.accounts,
-        currentAgentState: s.currentAgentState,
-        needsPersist: false, // Synced from another tab. Don't persist to avoid cycles.
-      }))
     })
   }, [state, setState, initSession])
 

--- a/src/state/session/index.tsx
+++ b/src/state/session/index.tsx
@@ -337,35 +337,22 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
       if (isSessionExpired(account)) {
         logger.debug(`session: attempting to resume using previous session`)
 
-        try {
-          const freshAccount = await resumeSessionWithFreshAccount()
-          __globalAgent = agent
-          await fetchingGates
-          setState(s => {
-            return {
-              accounts: [
-                freshAccount,
-                ...s.accounts.filter(a => a.did !== freshAccount.did),
-              ],
-              currentAgentState: {
-                did: freshAccount.did,
-                agent: agent,
-              },
-              needsPersist: true,
-            }
-          })
-        } catch (e) {
-          /*
-           * Note: `agent.persistSession` is also called when this fails, and
-           * we handle that failure via `createPersistSessionHandler`
-           */
-          logger.info(`session: resumeSessionWithFreshAccount failed`, {
-            message: e,
-          })
-
-          __globalAgent = PUBLIC_BSKY_AGENT
-          // TODO: This needs a setState.
-        }
+        const freshAccount = await resumeSessionWithFreshAccount()
+        __globalAgent = agent
+        await fetchingGates
+        setState(s => {
+          return {
+            accounts: [
+              freshAccount,
+              ...s.accounts.filter(a => a.did !== freshAccount.did),
+            ],
+            currentAgentState: {
+              did: freshAccount.did,
+              agent: agent,
+            },
+            needsPersist: true,
+          }
+        })
       } else {
         logger.debug(`session: attempting to reuse previous session`)
 
@@ -536,7 +523,7 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
             did: undefined,
             agent: PUBLIC_BSKY_AGENT,
           },
-          needsPersist: true, // TODO: This seems bad in this codepath. Existing behavior.
+          needsPersist: false, // Synced from another tab. Don't persist to avoid cycles.
         }))
       }
     })


### PR DESCRIPTION
Extracted from #3728.

There's a few different changes here but they all work together towards the goal of aligning `__globalAgent` assignments with `setState` calls that modify `currentAgentState`. Once they fully align, we can kill the global.

This PR doesn't fully get us all the way there because it leaves some existing timing differences.
I will address them in a follow-up.

## Reviewing

These are meant to be safe but slightly riskier than the ones before.

I suggest reading each change in isolation.

### 97a5304410879a8764fdf2e7cd2a9a52cb0a680b

This moves [this `setState` on `persisted.onUpdate` callback](https://github.com/bluesky-social/social-app/blob/1e484c6318c0f1a2fa46c028d53b92d817293d11/src/state/session/index.tsx#L538-L542) to the beginning of the function.

The purpose of this `setState` is to update the current `accounts` to the `persisted.accounts` from another tab. We _always_ need to do it, and it doesn't depend on any other data, so it makes sense to do it early.

Note for this change to be safe, we need to make sure that it wasn't clashing with any other `setState` during this callback. Here's how we verify this (links are to the existing code):

- This [other `setState`](https://github.com/bluesky-social/social-app/blob/1e484c6318c0f1a2fa46c028d53b92d817293d11/src/state/session/index.tsx#L528-L535) does not touch `accounts` so it doesn't matter whether it runs before or after — they accumulate regardless of order.
- This [`initSession` call](https://github.com/bluesky-social/social-app/blob/1e484c6318c0f1a2fa46c028d53b92d817293d11/src/state/session/index.tsx#L499) happens in the middle of the function but it's not being awaited. Therefore, only [the code before the first `await`](https://github.com/bluesky-social/social-app/blob/1e484c6318c0f1a2fa46c028d53b92d817293d11/src/state/session/index.tsx#L309-L324) would run, which transitively has no `setState` calls.

Therefore, it is safe to move this `setState` to the beginning of the function.

### af704f7412efd9591be3712a28eaa1f7ea4881f7

If another tab logged us out, that has already been persisted to the storage by that tab. So it doesn't make sense to persist anything in the storage here. 

I believe this was only set to `true` due to the previous structure of the code which had helper methods like `clearCurrentAccount` (which always had persistence on). Now that we've gotten rid of helper methods, we can see more clearly what is actually going on, and can adjust it more precisely.

### 5923f3f83

This removes a `try/catch` around `resumeSessionWithFreshAccount` in the "saved session expired during `initSession`" codepath. The thinking here is similar to #3836 — we can rely on `onAgentSessionChange` callback to log us out. In fact, we're _already_ relying on it because clearly updating `__globalAgent` is not enough — it does not update the UI. This code was _only_ updating `__globalAgent` so it can be removed (updating `__globalAgent` on expiry is done by #3838).

Another consequence of this change is that `initSession` would now throw if resuming the session failed. Counter-intuitively, I'm _removing_ the logic inside the existing `catch`es in this commit. Since it did _not_ throw in the past, those were superflouous. However, I'm keeping the `catch`es itself so that the calling code's expectations don't change.

Let's audit its callsites to verify this:

- The `InnerApp` calls [here](https://github.com/bluesky-social/social-app/blob/1e484c6318c0f1a2fa46c028d53b92d817293d11/src/App.web.tsx#L50-L58) and [here](https://github.com/bluesky-social/social-app/blob/main/src/App.native.tsx#L69-L77) already handle exceptions, no change in behavior.
- `useAccountSwitcher` has an [`initSession` call](https://github.com/bluesky-social/social-app/blob/1e484c6318c0f1a2fa46c028d53b92d817293d11/src/lib/hooks/useAccountSwitcher.ts#L42-L61) which _does_ change the behavior.
  - Previously, we'd show "Signed in as ..." even on failure.
  - After the change, we don't show it on failure. (Technically we still do if the session is resumed optimistically but that's an existing problem.)
  - Again, note I've removed the logic inside the `catch` because we weren't hitting it in the past either. It's superfluous because both clearing the account and showing the failure toast is already handled by `onAgentSessionChange`.
- Same story with [this call in `ChooseAccountForm`](https://github.com/bluesky-social/social-app/blob/85b34418ef31247f8d88bdb08248a149192c5b46/src/screens/Login/ChooseAccountForm.tsx#L56-L61).
  - Previously, we'd show "Signed in as ..." even on failure.
  - After the change, we don't show it on failure. (Technically we still do if the session is resumed optimistically but that's an existing problem.)
  - Here, too, I've removed the logic inside the `catch` because it wasn't getting called in the past either. So it's superflouous.

Note how by the end of this change, all `__globalAgent` assignments have a matching `setState` next to them. There's sometimes an async gap between them, which I'll fix in a follow-up PR.

## Test Plan

Verify syncing between tabs (login / logout / switch) still works.

Verify expiration during resumption is handled (see above and test plan from https://github.com/bluesky-social/social-app/pull/3838 for testing scenarios).