### PR TITLE
[Clipclops] All my clops gone

### DIFF
--- a/src/screens/Messages/Conversation/MessageListError.tsx
+++ b/src/screens/Messages/Conversation/MessageListError.tsx
@@ -22,6 +22,9 @@ export function MessageListError({
       [ConvoItemError.ResumeFailed]: _(
         msg`There was an issue connecting to the chat.`,
       ),
+      [ConvoItemError.PollFailed]: _(
+        msg`This chat was disconnected due to a network error.`,
+      ),
     }[item.code]
   }, [_, item.code])
 

--- a/src/screens/Messages/Conversation/MessageListError.tsx
+++ b/src/screens/Messages/Conversation/MessageListError.tsx
@@ -3,7 +3,7 @@ import {View} from 'react-native'
 import {msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
-import {ConvoError, ConvoItem} from '#/state/messages/convo'
+import {ConvoItem, ConvoItemError} from '#/state/messages/convo'
 import {atoms as a, useTheme} from '#/alf'
 import {CircleInfo_Stroke2_Corner0_Rounded as CircleInfo} from '#/components/icons/CircleInfo'
 import {InlineLinkText} from '#/components/Link'
@@ -18,7 +18,10 @@ export function MessageListError({
   const {_} = useLingui()
   const message = React.useMemo(() => {
     return {
-      [ConvoError.HistoryFailed]: _(msg`Failed to load past messages.`),
+      [ConvoItemError.HistoryFailed]: _(msg`Failed to load past messages.`),
+      [ConvoItemError.ResumeFailed]: _(
+        msg`There was an issue connecting to the chat.`,
+      ),
     }[item.code]
   }, [_, item.code])
 

--- a/src/screens/Messages/Conversation/MessagesList.tsx
+++ b/src/screens/Messages/Conversation/MessagesList.tsx
@@ -229,7 +229,7 @@ export function MessagesList() {
       <ScrollProvider onScroll={onScroll} onMomentumEnd={onMomentumEnd}>
         <List
           ref={flatListRef}
-          data={chat.status === ConvoStatus.Ready ? chat.items : undefined}
+          data={chat.items}
           renderItem={renderItem}
           keyExtractor={keyExtractor}
           disableVirtualization={true}
@@ -250,7 +250,7 @@ export function MessagesList() {
           ListHeaderComponent={
             <MaybeLoader
               isLoading={
-                chat.status === ConvoStatus.Ready && chat.isFetchingHistory
+                chat.isFetchingHistory
               }
             />
           }

--- a/src/screens/Messages/Conversation/MessagesList.tsx
+++ b/src/screens/Messages/Conversation/MessagesList.tsx
@@ -248,11 +248,7 @@ export function MessagesList() {
           onScrollToIndexFailed={onScrollToIndexFailed}
           scrollEventThrottle={100}
           ListHeaderComponent={
-            <MaybeLoader
-              isLoading={
-                chat.isFetchingHistory
-              }
-            />
+            <MaybeLoader isLoading={chat.isFetchingHistory} />
           }
         />
       </ScrollProvider>

--- a/src/screens/Messages/Conversation/index.tsx
+++ b/src/screens/Messages/Conversation/index.tsx
@@ -14,7 +14,6 @@ import {BACK_HITSLOP} from 'lib/constants'
 import {isWeb} from 'platform/detection'
 import {ChatProvider, useChat} from 'state/messages'
 import {ConvoStatus} from 'state/messages/convo'
-import {useSession} from 'state/session'
 import {PreviewableUserAvatar} from 'view/com/util/UserAvatar'
 import {CenteredView} from 'view/com/util/Views'
 import {MessagesList} from '#/screens/Messages/Conversation/MessagesList'
@@ -43,28 +42,27 @@ export function MessagesConversationScreen({route}: Props) {
 
 function Inner() {
   const chat = useChat()
-  const {currentAccount} = useSession()
-  const myDid = currentAccount?.did
 
-  const otherProfile = React.useMemo(() => {
-    if (chat.status !== ConvoStatus.Ready) return
-    return chat.convo.members.find(m => m.did !== myDid)
-  }, [chat, myDid])
-
-  // TODO whenever we have error messages, we should use them in here -hailey
-  if (chat.status !== ConvoStatus.Ready || !otherProfile) {
-    return (
-      <ListMaybePlaceholder
-        isLoading={true}
-        isError={chat.status === ConvoStatus.Error}
-      />
-    )
+  if (
+    chat.status === ConvoStatus.Uninitialized ||
+    chat.status === ConvoStatus.Initializing
+  ) {
+    return <ListMaybePlaceholder isLoading />
   }
+
+  if (chat.status === ConvoStatus.Error) {
+    // TODO error
+    return null
+  }
+
+  /*
+   * Any other chat states (atm) are "ready" states
+   */
 
   return (
     <KeyboardProvider>
       <CenteredView style={{flex: 1}} sideBorders>
-        <Header profile={otherProfile} />
+        <Header profile={chat.recipients[0]} />
         <MessagesList />
       </CenteredView>
     </KeyboardProvider>

--- a/src/state/messages/__tests__/convo.test.ts
+++ b/src/state/messages/__tests__/convo.test.ts
@@ -1,15 +1,19 @@
 import {describe, it} from '@jest/globals'
 
 describe(`#/state/messages/convo`, () => {
-  describe(`status states`, () => {
+  describe(`init`, () => {
+    it.todo(`fails if sender and recipients aren't found`)
     it.todo(`cannot re-initialize from a non-unintialized state`)
     it.todo(`can re-initialize from a failed state`)
+  })
 
-    describe(`destroy`, () => {
-      it.todo(`cannot be interacted with when destroyed`)
-      it.todo(`polling is stopped when destroyed`)
-      it.todo(`events are cleaned up when destroyed`)
-    })
+  describe(`resume`, () => {
+    it.todo(`restores previous state if resume fails`)
+  })
+
+  describe(`suspend`, () => {
+    it.todo(`cannot be interacted with when suspended`)
+    it.todo(`polling is stopped when suspended`)
   })
 
   describe(`read states`, () => {

--- a/src/state/messages/convo.ts
+++ b/src/state/messages/convo.ts
@@ -65,11 +65,6 @@ export type ConvoItem =
       code: ConvoItemError
       retry: () => void
     }
-  | {
-      type: 'error-fatal'
-      code: ConvoItemError
-      key: string
-    }
 
 export type ConvoState =
   | {


### PR DESCRIPTION
This PR handles the obvious error states. There are likely more to consider, but wanted to get the main guards in place.

- Clarified which states have what data
  - Moved some state into `Convo` to help with this, see `sender` and `recipients`
- Most errors are retry-able, except failures during initialization
- Handled initialization error, needs UI
- Handled failed resumption and polling

![CleanShot 2024-05-03 at 14 21 34@2x](https://github.com/bluesky-social/social-app/assets/4732330/8675a0ed-a4ee-4692-a8d3-62c919bf3f53)
![CleanShot 2024-05-03 at 14 49 20@2x](https://github.com/bluesky-social/social-app/assets/4732330/769c2770-5653-4481-a2d3-fe2821f47718)
