### PR TITLE
Fix `IntersectionObserver` `rootMargin` in web `List` implementation, add `onStartReached`

### DIFF
--- a/src/view/com/util/List.web.tsx
+++ b/src/view/com/util/List.web.tsx
@@ -213,8 +213,8 @@ function ListImpl<ItemT>(
         ))}
         {onEndReached && (
           <Visibility
-            topMargin={(onEndReachedThreshold ?? 0) * 100 + '%'}
             onVisibleChange={onTailVisibilityChange}
+            bottomMargin={(onEndReachedThreshold ?? 0) * 100 + '%'}
           />
         )}
         {footer}
@@ -276,10 +276,12 @@ Row = React.memo(Row)
 
 let Visibility = ({
   topMargin = '0px',
+  bottomMargin = '0px',
   onVisibleChange,
   style,
 }: {
   topMargin?: string
+  bottomMargin?: string
   onVisibleChange: (isVisible: boolean) => void
   style?: ViewProps['style']
 }): React.ReactNode => {
@@ -301,14 +303,14 @@ let Visibility = ({
 
   React.useEffect(() => {
     const observer = new IntersectionObserver(handleIntersection, {
-      rootMargin: `${topMargin} 0px 0px 0px`,
+      rootMargin: `${topMargin} 0px ${bottomMargin} 0px`,
     })
     const tail: Element | null = tailRef.current!
     observer.observe(tail)
     return () => {
       observer.unobserve(tail)
     }
-  }, [handleIntersection, topMargin])
+  }, [bottomMargin, handleIntersection, topMargin])
 
   return (
     <View ref={tailRef} style={addStyle(styles.visibilityDetector, style)} />

--- a/src/view/com/util/List.web.tsx
+++ b/src/view/com/util/List.web.tsx
@@ -1,11 +1,12 @@
-import React, {isValidElement, memo, useRef, startTransition} from 'react'
+import React, {isValidElement, memo, startTransition, useRef} from 'react'
 import {FlatListProps, StyleSheet, View, ViewProps} from 'react-native'
-import {addStyle} from 'lib/styles'
+
+import {batchedUpdates} from '#/lib/batchedUpdates'
+import {useNonReactiveCallback} from '#/lib/hooks/useNonReactiveCallback'
+import {useScrollHandlers} from '#/lib/ScrollContext'
 import {usePalette} from 'lib/hooks/usePalette'
 import {useWebMediaQueries} from 'lib/hooks/useWebMediaQueries'
-import {useScrollHandlers} from '#/lib/ScrollContext'
-import {useNonReactiveCallback} from '#/lib/hooks/useNonReactiveCallback'
-import {batchedUpdates} from '#/lib/batchedUpdates'
+import {addStyle} from 'lib/styles'
 
 export type ListMethods = any // TODO: Better types.
 export type ListProps<ItemT> = Omit<
@@ -32,6 +33,8 @@ function ListImpl<ItemT>(
     headerOffset,
     keyExtractor,
     refreshing: _unsupportedRefreshing,
+    onStartReached,
+    onStartReachedThreshold = 0,
     onEndReached,
     onEndReachedThreshold = 0,
     onRefresh: _unsupportedOnRefresh,
@@ -148,6 +151,17 @@ function ListImpl<ItemT>(
     }
   }
 
+  // --- onStartReached ---
+  const onHeadVisibilityChange = useNonReactiveCallback(
+    (isHeadVisible: boolean) => {
+      if (isHeadVisible) {
+        onStartReached?.({
+          distanceFromStart: onStartReachedThreshold || 0,
+        })
+      }
+    },
+  )
+
   // --- onEndReached ---
   const onTailVisibilityChange = useNonReactiveCallback(
     (isTailVisible: boolean) => {
@@ -181,6 +195,12 @@ function ListImpl<ItemT>(
           onVisibleChange={handleAboveTheFoldVisibleChange}
           style={[styles.aboveTheFoldDetector, {height: headerOffset}]}
         />
+        {onStartReached && (
+          <Visibility
+            onVisibleChange={onHeadVisibilityChange}
+            topMargin={(onStartReachedThreshold ?? 0) * 100 + '%'}
+          />
+        )}
         {header}
         {(data as Array<ItemT>).map((item, index) => (
           <Row<ItemT>


### PR DESCRIPTION
## Why

Right now, we use `IntersectionObserver`  to tell when we have reached the bottom of the page in our web `List` implementation. The currently implementation however has not worked correctly with the `onEndReachedThreshold` parameter. The parameter should fire `onEndReached` whenever we reach X pages away from the bottom of the scrollable content. That has not worked here, and we would have to hit the end to actually load new data.

The problem turned out to be that we were not configuring the `rootMargin` properly. We can think of the value we supply to `rootMargin` as a box surrounding the parent of the `Visibility` element. So, with our current logic of using `100%, 0px, 0px, 0px` this is what it looks like.

![Screenshot 2024-05-04 at 9 10 19 PM](https://github.com/bluesky-social/social-app/assets/153161762/78573890-0751-45b9-a517-91f3d77b80b1)

We will never end up firing `onEndReached` here until we reach the end!

Instead, we want to be setting the _bottom margin_. If we use `0px, 0px, 100%, 0px` our region looks like this:

![Screenshot 2024-05-04 at 9 24 54 PM](https://github.com/bluesky-social/social-app/assets/153161762/f2d4646c-5bae-4f2a-8c65-da6c902ae5d1)

What I have done here is modify the `Visibility` component to accept two different props: `topMargin` and `bottomMargin`. Whenever we add a `Visiblity` component to fire `onEndReached`, we will use `bottomMargin`. Then, when we want to use `onStartReached`, we can use `topMargin`.

## Test Plan

On the home feed, we currently load more items whenever we come within 2 pages of the end of the list. So, you should be seeing new content load far before you reach the end now.

We don't actually use `onStartReached` anywhere on web right now, but I have recorded a video of what I'm working on in the chat list to show this behavior.

## onEndReached - Watch the scroll indicator in this video, uses a threshold of 2

https://github.com/bluesky-social/social-app/assets/153161762/266f9245-662c-4106-82db-ef3f2a0ed23c

## onStartReached - No threshold

https://github.com/bluesky-social/social-app/assets/153161762/6625172e-324b-41e7-a1c1-12e13f0614ea
