### PR TITLE
[🐴] State transitions

### DIFF
--- a/src/screens/Messages/Conversation/MessageListError.tsx
+++ b/src/screens/Messages/Conversation/MessageListError.tsx
@@ -18,10 +18,10 @@ export function MessageListError({
   const {_} = useLingui()
   const message = React.useMemo(() => {
     return {
-      [ConvoItemError.HistoryFailed]: _(msg`Failed to load past messages.`),
-      [ConvoItemError.ResumeFailed]: _(
+      [ConvoItemError.Network]: _(
         msg`There was an issue connecting to the chat.`,
       ),
+      [ConvoItemError.HistoryFailed]: _(msg`Failed to load past messages.`),
       [ConvoItemError.PollFailed]: _(
         msg`This chat was disconnected due to a network error.`,
       ),

--- a/src/screens/Messages/Conversation/index.tsx
+++ b/src/screens/Messages/Conversation/index.tsx
@@ -18,6 +18,7 @@ import {PreviewableUserAvatar} from 'view/com/util/UserAvatar'
 import {CenteredView} from 'view/com/util/Views'
 import {MessagesList} from '#/screens/Messages/Conversation/MessagesList'
 import {atoms as a, useBreakpoints, useTheme} from '#/alf'
+import {Button, ButtonText} from '#/components/Button'
 import {ConvoMenu} from '#/components/dms/ConvoMenu'
 import {ListMaybePlaceholder} from '#/components/Lists'
 import {Text} from '#/components/Typography'
@@ -51,8 +52,21 @@ function Inner() {
   }
 
   if (chat.status === ConvoStatus.Error) {
-    // TODO error
-    return null
+    // TODO
+    return (
+      <View>
+        <CenteredView style={{flex: 1}} sideBorders>
+          <Text>Something went wrong</Text>
+          <Button
+            label="Retry"
+            onPress={() => {
+              chat.error.retry()
+            }}>
+            <ButtonText>Retry</ButtonText>
+          </Button>
+        </CenteredView>
+      </View>
+    )
   }
 
   /*

--- a/src/state/messages/convo.ts
+++ b/src/state/messages/convo.ts
@@ -327,7 +327,6 @@ export class Convo {
 
       this.refreshConvo()
         .then(async () => {
-          await new Promise(y => setTimeout(y, 2000))
           if (this.status === ConvoStatus.Initializing) {
             this.status = ConvoStatus.Ready
             this.commit()
@@ -363,7 +362,6 @@ export class Convo {
   }
 
   // TODO resume failure
-  // TODO can I resume from error?
   resume() {
     if (
       this.status === ConvoStatus.Suspended ||
@@ -381,6 +379,8 @@ export class Convo {
       this.refreshConvo().then(() => {
         this.commit()
       })
+    } else if (this.status === ConvoStatus.Error) {
+      this.init()
     } else {
       logger.debug(
         `Convo: resume called from ${this.status}`,

--- a/src/state/messages/convo.ts
+++ b/src/state/messages/convo.ts
@@ -371,14 +371,15 @@ export class Convo {
           case ConvoDispatchEvent.Ready: {
             this.status = ConvoStatus.Ready
             this.pollInterval = ACTIVE_POLL_INTERVAL
-            this.fetchMessageHistory()
-            this.initiatePoll()
+            this.fetchMessageHistory().then(() => {
+              this.initiatePoll()
+            })
             break
           }
           case ConvoDispatchEvent.Background: {
             this.status = ConvoStatus.Backgrounded
             this.pollInterval = BACKGROUND_POLL_INTERVAL
-            this.fetchMessageHistory()
+            // TODO truncate history, then poll again
             this.initiatePoll()
             break
           }

--- a/src/state/messages/convo.ts
+++ b/src/state/messages/convo.ts
@@ -709,11 +709,14 @@ export class Convo {
       this.status === ConvoStatus.Ready ||
       this.status === ConvoStatus.Backgrounded
     ) {
-      logger.debug(
-        'Convo: poll events',
-        {id: this.id},
-        logger.DebugContext.convo,
-      )
+      /*
+       * Uncomment to view poll events
+       */
+      // logger.debug(
+      //   'Convo: poll events',
+      //   {id: this.id},
+      //   logger.DebugContext.convo,
+      // )
 
       try {
         this.pendingPoll = this.ingestLatestEvents()

--- a/src/state/messages/index.tsx
+++ b/src/state/messages/index.tsx
@@ -1,4 +1,5 @@
 import React, {useContext, useState, useSyncExternalStore} from 'react'
+import {AppState} from 'react-native'
 import {BskyAgent} from '@atproto-labs/api'
 import {useFocusEffect} from '@react-navigation/native'
 
@@ -43,6 +44,22 @@ export function ChatProvider({
       }
     }, [convo]),
   )
+
+  React.useEffect(() => {
+    const handleAppStateChange = (nextAppState: string) => {
+      if (nextAppState === 'active') {
+        convo.resume()
+      } else {
+        convo.background()
+      }
+    }
+
+    const sub = AppState.addEventListener('change', handleAppStateChange)
+
+    return () => {
+      sub.remove()
+    }
+  }, [convo])
 
   return <ChatContext.Provider value={service}>{children}</ChatContext.Provider>
 }

--- a/src/state/messages/index.tsx
+++ b/src/state/messages/index.tsx
@@ -1,7 +1,7 @@
 import React, {useContext, useState, useSyncExternalStore} from 'react'
 import {AppState} from 'react-native'
 import {BskyAgent} from '@atproto-labs/api'
-import {useFocusEffect} from '@react-navigation/native'
+import {useFocusEffect, useIsFocused} from '@react-navigation/native'
 
 import {Convo, ConvoParams, ConvoState} from '#/state/messages/convo'
 import {useAgent} from '#/state/session'
@@ -21,6 +21,7 @@ export function ChatProvider({
   children,
   convoId,
 }: Pick<ConvoParams, 'convoId'> & {children: React.ReactNode}) {
+  const isScreenFocused = useIsFocused()
   const {serviceUrl} = useDmServiceUrlStorage()
   const {getAgent} = useAgent()
   const [convo] = useState(
@@ -47,10 +48,12 @@ export function ChatProvider({
 
   React.useEffect(() => {
     const handleAppStateChange = (nextAppState: string) => {
-      if (nextAppState === 'active') {
-        convo.resume()
-      } else {
-        convo.background()
+      if (isScreenFocused) {
+        if (nextAppState === 'active') {
+          convo.resume()
+        } else {
+          convo.background()
+        }
       }
     }
 
@@ -59,7 +62,7 @@ export function ChatProvider({
     return () => {
       sub.remove()
     }
-  }, [convo])
+  }, [convo, isScreenFocused])
 
   return <ChatContext.Provider value={service}>{children}</ChatContext.Provider>
 }


### PR DESCRIPTION
[Reviewing without whitespace](https://github.com/bluesky-social/social-app/pull/3880/files?diff=split&w=1) helps a bit.

This PR handles state transitions from app foreground to background, including tab focus on web. It also begins to guard async data fetching from being called while another request is in-flight.

To do so, I refactored the state transition logic into a reducer. All updates to `this.status` go through this reducer. Various side effects are then called.
- state transition logic is synchronous
- consecutive state transitions don't clobber each other
  - example: open chat, then nav away while initializing, chat will resolve to correct `status`
- certain states only support a subset of actions

This should make it far more clear what's happening, and help us avoid invalid states.

### Testing
I recommend uncommenting the `debug` log within `pollEvents` for more visibility into what's happening.
- open chat, go back, should see logs setting the convo to `suspended`
- open chat, nav to a different screen (not Messages screen), convo should be `backgrounded`
- when navigating back to Messages screen, convo should be `suspended`
- on web, switch tabs and switch back, you should see logs going from `ready` -> `backgrounded` -> `ready`
- on native, background app, should see same logs
- on web, nav to different screen, then switch tabs, upon return the chat should still be in `backgrounded` state
- if you want, uncomment the various `throw` cases to test error states (some UI is needed)
- local hot reloads of `convo.ts` should also work fine