### PR TITLE
Remove `getProfile` calls when loading feed

### DIFF
--- a/src/state/queries/post-feed.ts
+++ b/src/state/queries/post-feed.ts
@@ -73,7 +73,7 @@ export interface FeedPostSliceItem {
   reason?: AppBskyFeedDefs.ReasonRepost | ReasonFeedSource
   feedContext: string | undefined
   moderation: ModerationDecision
-  grandparentAuthor?: AppBskyActorDefs.ProfileViewBasic
+  replyToAuthor?: AppBskyActorDefs.ProfileViewBasic
 }
 
 export interface FeedPostSlice {
@@ -304,14 +304,10 @@ export function usePostFeedQuery(
                           AppBskyFeedPost.validateRecord(item.post.record)
                             .success
                         ) {
-                          const grandparentAuthor =
-                            // We don't want to add a grandparent if this is not the first post in the slice
-                            i === 0
-                              ? // If we have removed a parent, we need to use the parent's author rather than the gp's
-                                slice.items.length === 1
-                                ? slice.items[i].reply?.parent.author
-                                : slice.items[i + 1]?.reply?.grandparentAuthor
-                              : undefined
+                          const replyToAuthor =
+                            slice.items.length === 1
+                              ? slice.items[0].reply?.parent.author
+                              : slice.items[1]?.reply?.grandparentAuthor
 
                           return {
                             _reactKey: `${slice._reactKey}-${i}-${item.post.uri}`,
@@ -324,7 +320,7 @@ export function usePostFeedQuery(
                                 : item.reason,
                             feedContext: item.feedContext || slice.feedContext,
                             moderation: moderations[i],
-                            grandparentAuthor,
+                            replyToAuthor,
                           }
                         }
                         return undefined

--- a/src/state/queries/post-feed.ts
+++ b/src/state/queries/post-feed.ts
@@ -73,7 +73,7 @@ export interface FeedPostSliceItem {
   reason?: AppBskyFeedDefs.ReasonRepost | ReasonFeedSource
   feedContext: string | undefined
   moderation: ModerationDecision
-  replyToAuthor?: AppBskyActorDefs.ProfileViewBasic
+  parentAuthor?: AppBskyActorDefs.ProfileViewBasic
 }
 
 export interface FeedPostSlice {
@@ -304,10 +304,9 @@ export function usePostFeedQuery(
                           AppBskyFeedPost.validateRecord(item.post.record)
                             .success
                         ) {
-                          const replyToAuthor =
-                            slice.items.length === 1
-                              ? slice.items[0].reply?.parent.author
-                              : slice.items[1]?.reply?.grandparentAuthor
+                          const parentAuthor =
+                            item.reply?.parent?.author ??
+                            slice.items[i + 1].reply?.grandparentAuthor
 
                           return {
                             _reactKey: `${slice._reactKey}-${i}-${item.post.uri}`,
@@ -320,7 +319,7 @@ export function usePostFeedQuery(
                                 : item.reason,
                             feedContext: item.feedContext || slice.feedContext,
                             moderation: moderations[i],
-                            replyToAuthor,
+                            parentAuthor,
                           }
                         }
                         return undefined

--- a/src/state/queries/post-feed.ts
+++ b/src/state/queries/post-feed.ts
@@ -306,7 +306,7 @@ export function usePostFeedQuery(
                         ) {
                           const parentAuthor =
                             item.reply?.parent?.author ??
-                            slice.items[i + 1].reply?.grandparentAuthor
+                            slice.items[i + 1]?.reply?.grandparentAuthor
 
                           return {
                             _reactKey: `${slice._reactKey}-${i}-${item.post.uri}`,

--- a/src/view/com/posts/FeedItem.tsx
+++ b/src/view/com/posts/FeedItem.tsx
@@ -42,27 +42,30 @@ import {PostMeta} from '../util/PostMeta'
 import {Text} from '../util/text/Text'
 import {PreviewableUserAvatar} from '../util/UserAvatar'
 
+interface FeedItemProps {
+  record: AppBskyFeedPost.Record
+  reason: AppBskyFeedDefs.ReasonRepost | ReasonFeedSource | undefined
+  moderation: ModerationDecision
+  parentAuthor: AppBskyActorDefs.ProfileViewBasic | undefined
+  showReplyTo: boolean
+  isThreadChild?: boolean
+  isThreadLastChild?: boolean
+  isThreadParent?: boolean
+  feedContext: string | undefined
+}
+
 export function FeedItem({
   post,
   record,
   reason,
   feedContext,
   moderation,
-  replyToAuthor,
+  parentAuthor,
+  showReplyTo,
   isThreadChild,
   isThreadLastChild,
   isThreadParent,
-}: {
-  post: AppBskyFeedDefs.PostView
-  record: AppBskyFeedPost.Record
-  reason: AppBskyFeedDefs.ReasonRepost | ReasonFeedSource | undefined
-  feedContext: string | undefined
-  moderation: ModerationDecision
-  replyToAuthor?: AppBskyActorDefs.ProfileViewBasic
-  isThreadChild?: boolean
-  isThreadLastChild?: boolean
-  isThreadParent?: boolean
-}) {
+}: FeedItemProps & {post: AppBskyFeedDefs.PostView}): React.ReactNode {
   const postShadowed = usePostShadow(post)
   const richText = useMemo(
     () =>
@@ -85,11 +88,12 @@ export function FeedItem({
         reason={reason}
         feedContext={feedContext}
         richText={richText}
+        parentAuthor={parentAuthor}
+        showReplyTo={showReplyTo}
         moderation={moderation}
         isThreadChild={isThreadChild}
         isThreadLastChild={isThreadLastChild}
         isThreadParent={isThreadParent}
-        replyToAuthor={replyToAuthor}
       />
     )
   }
@@ -103,21 +107,14 @@ let FeedItemInner = ({
   feedContext,
   richText,
   moderation,
-  replyToAuthor,
+  parentAuthor,
+  showReplyTo,
   isThreadChild,
   isThreadLastChild,
   isThreadParent,
-}: {
-  post: Shadow<AppBskyFeedDefs.PostView>
-  record: AppBskyFeedPost.Record
-  reason: AppBskyFeedDefs.ReasonRepost | ReasonFeedSource | undefined
-  feedContext: string | undefined
+}: FeedItemProps & {
   richText: RichTextAPI
-  moderation: ModerationDecision
-  replyToAuthor: AppBskyActorDefs.ProfileViewBasic | undefined
-  isThreadChild?: boolean
-  isThreadLastChild?: boolean
-  isThreadParent?: boolean
+  post: Shadow<AppBskyFeedDefs.PostView>
 }): React.ReactNode => {
   const queryClient = useQueryClient()
   const {openComposer} = useComposerControls()
@@ -315,8 +312,8 @@ let FeedItemInner = ({
             postHref={href}
             onOpenAuthor={onOpenAuthor}
           />
-          {!isThreadChild && replyToAuthor && (
-            <ReplyToLabel grandparentAuthor={replyToAuthor} />
+          {!isThreadChild && showReplyTo && parentAuthor && (
+            <ReplyToLabel profile={parentAuthor} />
           )}
           <LabelsOnMyPost post={post} />
           <PostContent
@@ -405,11 +402,7 @@ let PostContent = ({
 }
 PostContent = memo(PostContent)
 
-function ReplyToLabel({
-  grandparentAuthor,
-}: {
-  grandparentAuthor: AppBskyActorDefs.ProfileViewBasic
-}) {
+function ReplyToLabel({profile}: {profile: AppBskyActorDefs.ProfileViewBasic}) {
   const pal = usePalette('default')
 
   return (
@@ -426,17 +419,17 @@ function ReplyToLabel({
         numberOfLines={1}>
         <Trans context="description">
           Reply to{' '}
-          <ProfileHoverCard inline did={grandparentAuthor.did}>
+          <ProfileHoverCard inline did={profile.did}>
             <TextLinkOnWebOnly
               type="md"
               style={pal.textLight}
               lineHeight={1.2}
               numberOfLines={1}
-              href={makeProfileLink(grandparentAuthor)}
+              href={makeProfileLink(profile)}
               text={
-                grandparentAuthor.displayName
-                  ? sanitizeDisplayName(grandparentAuthor.displayName)
-                  : sanitizeHandle(grandparentAuthor.handle)
+                profile.displayName
+                  ? sanitizeDisplayName(profile.displayName)
+                  : sanitizeHandle(profile.handle)
               }
             />
           </ProfileHoverCard>

--- a/src/view/com/posts/FeedItem.tsx
+++ b/src/view/com/posts/FeedItem.tsx
@@ -48,7 +48,7 @@ export function FeedItem({
   reason,
   feedContext,
   moderation,
-  grandparentAuthor,
+  replyToAuthor,
   isThreadChild,
   isThreadLastChild,
   isThreadParent,
@@ -58,7 +58,7 @@ export function FeedItem({
   reason: AppBskyFeedDefs.ReasonRepost | ReasonFeedSource | undefined
   feedContext: string | undefined
   moderation: ModerationDecision
-  grandparentAuthor?: AppBskyActorDefs.ProfileViewBasic
+  replyToAuthor?: AppBskyActorDefs.ProfileViewBasic
   isThreadChild?: boolean
   isThreadLastChild?: boolean
   isThreadParent?: boolean
@@ -89,7 +89,7 @@ export function FeedItem({
         isThreadChild={isThreadChild}
         isThreadLastChild={isThreadLastChild}
         isThreadParent={isThreadParent}
-        grandparentAuthor={grandparentAuthor}
+        replyToAuthor={replyToAuthor}
       />
     )
   }
@@ -103,7 +103,7 @@ let FeedItemInner = ({
   feedContext,
   richText,
   moderation,
-  grandparentAuthor,
+  replyToAuthor,
   isThreadChild,
   isThreadLastChild,
   isThreadParent,
@@ -114,7 +114,7 @@ let FeedItemInner = ({
   feedContext: string | undefined
   richText: RichTextAPI
   moderation: ModerationDecision
-  grandparentAuthor: AppBskyActorDefs.ProfileViewBasic | undefined
+  replyToAuthor: AppBskyActorDefs.ProfileViewBasic | undefined
   isThreadChild?: boolean
   isThreadLastChild?: boolean
   isThreadParent?: boolean
@@ -315,8 +315,8 @@ let FeedItemInner = ({
             postHref={href}
             onOpenAuthor={onOpenAuthor}
           />
-          {!isThreadChild && grandparentAuthor && (
-            <ReplyToLabel grandparentAuthor={grandparentAuthor} />
+          {!isThreadChild && replyToAuthor && (
+            <ReplyToLabel grandparentAuthor={replyToAuthor} />
           )}
           <LabelsOnMyPost post={post} />
           <PostContent

--- a/src/view/com/posts/FeedSlice.tsx
+++ b/src/view/com/posts/FeedSlice.tsx
@@ -22,10 +22,10 @@ let FeedSlice = ({slice}: {slice: FeedPostSlice}): React.ReactNode => {
           record={slice.items[0].record}
           reason={slice.items[0].reason}
           feedContext={slice.items[0].feedContext}
+          grandparentAuthor={slice.items[0].grandparentAuthor}
           moderation={slice.items[0].moderation}
           isThreadParent={isThreadParentAt(slice.items, 0)}
           isThreadChild={isThreadChildAt(slice.items, 0)}
-          grandparentAuthor={slice.items[0].grandparentAuthor}
         />
         <FeedItem
           key={slice.items[1]._reactKey}
@@ -63,13 +63,11 @@ let FeedSlice = ({slice}: {slice: FeedPostSlice}): React.ReactNode => {
           reason={slice.items[i].reason}
           feedContext={slice.items[i].feedContext}
           moderation={slice.items[i].moderation}
+          grandparentAuthor={slice.items[i].grandparentAuthor}
           isThreadParent={isThreadParentAt(slice.items, i)}
           isThreadChild={isThreadChildAt(slice.items, i)}
           isThreadLastChild={
             isThreadChildAt(slice.items, i) && slice.items.length === i + 1
-          }
-          grandparentAuthor={
-            i === 0 ? slice.items[i].grandparentAuthor : undefined
           }
         />
       ))}

--- a/src/view/com/posts/FeedSlice.tsx
+++ b/src/view/com/posts/FeedSlice.tsx
@@ -22,7 +22,8 @@ let FeedSlice = ({slice}: {slice: FeedPostSlice}): React.ReactNode => {
           record={slice.items[0].record}
           reason={slice.items[0].reason}
           feedContext={slice.items[0].feedContext}
-          replyToAuthor={slice.items[0].replyToAuthor}
+          parentAuthor={slice.items[0].parentAuthor}
+          showReplyTo={true}
           moderation={slice.items[0].moderation}
           isThreadParent={isThreadParentAt(slice.items, 0)}
           isThreadChild={isThreadChildAt(slice.items, 0)}
@@ -33,6 +34,8 @@ let FeedSlice = ({slice}: {slice: FeedPostSlice}): React.ReactNode => {
           record={slice.items[1].record}
           reason={slice.items[1].reason}
           feedContext={slice.items[1].feedContext}
+          parentAuthor={slice.items[1].parentAuthor}
+          showReplyTo={false}
           moderation={slice.items[1].moderation}
           isThreadParent={isThreadParentAt(slice.items, 1)}
           isThreadChild={isThreadChildAt(slice.items, 1)}
@@ -44,6 +47,8 @@ let FeedSlice = ({slice}: {slice: FeedPostSlice}): React.ReactNode => {
           record={slice.items[last].record}
           reason={slice.items[last].reason}
           feedContext={slice.items[last].feedContext}
+          parentAuthor={slice.items[2].parentAuthor}
+          showReplyTo={false}
           moderation={slice.items[last].moderation}
           isThreadParent={isThreadParentAt(slice.items, last)}
           isThreadChild={isThreadChildAt(slice.items, last)}
@@ -63,7 +68,8 @@ let FeedSlice = ({slice}: {slice: FeedPostSlice}): React.ReactNode => {
           reason={slice.items[i].reason}
           feedContext={slice.items[i].feedContext}
           moderation={slice.items[i].moderation}
-          replyToAuthor={i === 0 ? slice.items[i].replyToAuthor : undefined}
+          parentAuthor={slice.items[i].parentAuthor}
+          showReplyTo={i === 0}
           isThreadParent={isThreadParentAt(slice.items, i)}
           isThreadChild={isThreadChildAt(slice.items, i)}
           isThreadLastChild={

--- a/src/view/com/posts/FeedSlice.tsx
+++ b/src/view/com/posts/FeedSlice.tsx
@@ -25,6 +25,7 @@ let FeedSlice = ({slice}: {slice: FeedPostSlice}): React.ReactNode => {
           moderation={slice.items[0].moderation}
           isThreadParent={isThreadParentAt(slice.items, 0)}
           isThreadChild={isThreadChildAt(slice.items, 0)}
+          grandparentAuthor={slice.items[0].grandparentAuthor}
         />
         <FeedItem
           key={slice.items[1]._reactKey}
@@ -66,6 +67,9 @@ let FeedSlice = ({slice}: {slice: FeedPostSlice}): React.ReactNode => {
           isThreadChild={isThreadChildAt(slice.items, i)}
           isThreadLastChild={
             isThreadChildAt(slice.items, i) && slice.items.length === i + 1
+          }
+          grandparentAuthor={
+            i === 0 ? slice.items[i].grandparentAuthor : undefined
           }
         />
       ))}

--- a/src/view/com/posts/FeedSlice.tsx
+++ b/src/view/com/posts/FeedSlice.tsx
@@ -22,7 +22,7 @@ let FeedSlice = ({slice}: {slice: FeedPostSlice}): React.ReactNode => {
           record={slice.items[0].record}
           reason={slice.items[0].reason}
           feedContext={slice.items[0].feedContext}
-          grandparentAuthor={slice.items[0].grandparentAuthor}
+          replyToAuthor={slice.items[0].replyToAuthor}
           moderation={slice.items[0].moderation}
           isThreadParent={isThreadParentAt(slice.items, 0)}
           isThreadChild={isThreadChildAt(slice.items, 0)}
@@ -63,7 +63,7 @@ let FeedSlice = ({slice}: {slice: FeedPostSlice}): React.ReactNode => {
           reason={slice.items[i].reason}
           feedContext={slice.items[i].feedContext}
           moderation={slice.items[i].moderation}
-          grandparentAuthor={slice.items[i].grandparentAuthor}
+          replyToAuthor={i === 0 ? slice.items[i].replyToAuthor : undefined}
           isThreadParent={isThreadParentAt(slice.items, i)}
           isThreadChild={isThreadChildAt(slice.items, i)}
           isThreadLastChild={

--- a/src/view/screens/DebugMod.tsx
+++ b/src/view/screens/DebugMod.tsx
@@ -803,6 +803,8 @@ function MockPostFeedItem({
       post={post}
       record={post.record as AppBskyFeedPost.Record}
       moderation={moderation}
+      parentAuthor={undefined}
+      showReplyTo={false}
       reason={undefined}
       feedContext={''}
     />


### PR DESCRIPTION
## Why

Currently, we make a ton of calls to `getProfile()` to display the "Reply to" label. However, since https://github.com/bluesky-social/atproto/pull/2461, we can now get this info from the `grandparentAuthor` field in the API response.

## Test Plan

### Before

![Screenshot 2024-05-06 at 4 20 52 PM](https://github.com/bluesky-social/social-app/assets/153161762/d11d1a67-bab1-4039-8eb5-7be4071a67b2)

### After

![Screenshot 2024-05-06 at 4 21 12 PM](https://github.com/bluesky-social/social-app/assets/153161762/353e023e-67c8-4b64-969c-ee3b4b3c90ef)

Verify that the requests are no longer present when loading your timeline. Also verify that posts properly display the `Reply to` label when they should.

Check situations where:

- It appears normally: i.e. a post with one parent above. It should show the parent's parent's author.
- We remove the parent from the timeline. It should show the parent's author.
- Where we put a thread together, i.e. below

### A normal situation

![Screenshot 2024-05-06 at 5 19 31 PM](https://github.com/bluesky-social/social-app/assets/153161762/ca9aa492-6923-42c5-a574-3c96002ee92a)

### Removing the parent

![Screenshot 2024-05-06 at 5 18 51 PM](https://github.com/bluesky-social/social-app/assets/153161762/1c3b9c87-bd36-4df5-9946-187bf68b1f42)

### Us making a thread 

![Screenshot 2024-05-06 at 5 16 31 PM](https://github.com/bluesky-social/social-app/assets/153161762/1d0180e8-b07f-4d80-bf81-8da9ade7c8ad)
