### PR TITLE
Only close modal if directly clicking on backdrop

### DIFF
--- a/src/lib/hooks/useOutsideClick.ts
+++ b/src/lib/hooks/useOutsideClick.ts
@@ -1,0 +1,46 @@
+import React from 'react'
+
+export function useOutsideClick(
+  containerRef: React.RefObject<HTMLElement>,
+  callback: () => void,
+  enabled = true,
+) {
+  React.useEffect(() => {
+    if (!enabled) {
+      return
+    }
+
+    const container = containerRef.current!
+
+    // We'd like to know where the click initially started from, not where the
+    // click ended up, this prevents closing the modal prematurely from the user
+    // accidentally overshooting their mouse cursor.
+    let initialTarget: HTMLElement | null
+
+    const handlePointerDown = (ev: MouseEvent) => {
+      initialTarget = ev.target as HTMLElement | null
+    }
+
+    const handleClick = () => {
+      if (!initialTarget) {
+        return
+      }
+
+      const target = initialTarget
+      initialTarget = null
+
+      if (container.contains(target)) {
+        return
+      }
+
+      callback()
+    }
+
+    document.addEventListener('pointerdown', handlePointerDown)
+    document.addEventListener('click', handleClick)
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDown)
+      document.removeEventListener('click', handleClick)
+    }
+  }, [containerRef, callback, enabled])
+}

--- a/src/view/com/modals/Modal.web.tsx
+++ b/src/view/com/modals/Modal.web.tsx
@@ -55,7 +55,7 @@ function Modal({modal, active}: {modal: ModalIface; active: boolean}) {
   const pal = usePalette('default')
   const {isMobile} = useWebMediaQueries()
 
-  const containerRef = React.useRef<HTMLDivElement>(null)
+  const containerRef = React.useRef(null)
 
   useOutsideClick(containerRef, closeModal, active)
 
@@ -109,17 +109,16 @@ function Modal({modal, active}: {modal: ModalIface; active: boolean}) {
       style={styles.mask}
       entering={FadeIn.duration(150)}
       exiting={FadeOut}>
-      <div ref={containerRef}>
-        <View
-          style={[
-            styles.container,
-            isMobile && styles.containerMobile,
-            pal.view,
-            pal.border,
-          ]}>
-          {element}
-        </View>
-      </div>
+      <View
+        ref={containerRef}
+        style={[
+          styles.container,
+          isMobile && styles.containerMobile,
+          pal.view,
+          pal.border,
+        ]}>
+        {element}
+      </View>
     </Animated.View>
   )
 }


### PR DESCRIPTION
Fixes #1894
Fixes #3834

This seemed to work for checking where the click/press initially started from, we don't want any clicks that initially started from the modal to be handled by the backdrop (which closes the modal)
