### PR TITLE
fix bad bool check in action

### DIFF
--- a/.easignore
+++ b/.easignore
@@ -95,7 +95,6 @@ web-build/
 /ios/
 
 # environment variables
-.env
 .env.*
 
 # Firebase (Android) Google services

--- a/.github/workflows/build-submit-android.yml
+++ b/.github/workflows/build-submit-android.yml
@@ -25,6 +25,8 @@ jobs:
 
       - name: ⬇️ Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 5
 
       - name: 🔧 Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/build-submit-ios.yml
+++ b/.github/workflows/build-submit-ios.yml
@@ -25,6 +25,8 @@ jobs:
 
       - name: ⬇️ Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 5
 
       - name: 🔧 Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/bundle-deploy-eas-update.yml
+++ b/.github/workflows/bundle-deploy-eas-update.yml
@@ -184,6 +184,8 @@ jobs:
 
       - name: ⬇️ Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 5
 
       - name: 🔧 Setup Node
         uses: actions/setup-node@v4
@@ -255,6 +257,8 @@ jobs:
 
       - name: ⬇️ Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 5
 
       - name: 🔧 Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/bundle-deploy-eas-update.yml
+++ b/.github/workflows/bundle-deploy-eas-update.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     concurrency:
       group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}-deploy
-      cancel-in-progress: true
+      cancel-in-progress: false
     outputs:
       fingerprint-is-different: ${{ steps.fingerprint-debug.outputs.fingerprint-is-different }}
 
@@ -68,7 +68,7 @@ jobs:
       - name: 🕵️ Get the base commit
         id: base-commit
         run: |
-          if [ -z "${{ inputs.channel == 'production' }}" ]; then
+          if [ ${{ inputs.channel == 'production' }} ]; then
             echo base-commit=$(git show-ref -s ${{ inputs.runtimeVersion }}) >> "$GITHUB_OUTPUT"
           else
             echo base-commit=${{ steps.last-successful-commit.base-commit }} >> "$GITHUB_OUTPUT"

--- a/src/lib/app-info.ts
+++ b/src/lib/app-info.ts
@@ -6,8 +6,7 @@ export const IS_TESTFLIGHT = process.env.EXPO_PUBLIC_ENV === 'testflight'
 
 // This is the commit hash that the current bundle was made from. The user can see the commit hash in the app's settings
 // along with the other version info. Useful for debugging/reporting.
-export const BUNDLE_IDENTIFIER =
-  process.env.EXPO_PUBLIC_BUNDLE_IDENTIFIER ?? 'dev'
+export const BUNDLE_IDENTIFIER = process.env.EXPO_PUBLIC_BUNDLE_IDENTIFIER ?? ''
 
 // This will always be in the format of YYMMDD, so that it always increases for each build. This should only be used
 // for Statsig reporting and shouldn't be used to identify a specific bundle.


### PR DESCRIPTION
- Don't cancel still-running bundle deploys if we merge another PR. Feels better to just let them run (this is for internal use only)
- Replace a null check with what is supposed to just be an equality check
- Always fetch some commits so that we can get the commit hash
- Add `.env` to `.easignore`

Regarding the last point, if we don't add this to the `.easignore`, it won't pick up our environment variables. See `eas build:inspect --stage archive -p ios --output sampleBuildFiles`