### PR TITLE
[GIFs] Restore default alt text

### DIFF
--- a/src/lib/gif-alt-text.ts
+++ b/src/lib/gif-alt-text.ts
@@ -3,11 +3,8 @@ const DEFAULT_ALT_PREFIX = 'ALT: '
 
 export function createGIFDescription(
   tenorDescription: string,
-  preferredAlt?: string,
+  preferredAlt: string = '',
 ) {
-  if (!preferredAlt) {
-    return DEFAULT_ALT_PREFIX + tenorDescription
-  }
   preferredAlt = preferredAlt.trim()
   if (preferredAlt !== '') {
     return USER_ALT_PREFIX + preferredAlt

--- a/src/lib/gif-alt-text.ts
+++ b/src/lib/gif-alt-text.ts
@@ -20,7 +20,6 @@ export function parseAltFromGIFDescription(description: string): {
   isPreferred: boolean
   alt: string
 } {
-  console.log('description', description)
   if (description.startsWith(USER_ALT_PREFIX)) {
     return {
       isPreferred: true,

--- a/src/lib/gif-alt-text.ts
+++ b/src/lib/gif-alt-text.ts
@@ -1,3 +1,4 @@
+// Kind of a hack. We needed some way to distinguish these.
 const USER_ALT_PREFIX = 'Alt: '
 const DEFAULT_ALT_PREFIX = 'ALT: '
 

--- a/src/lib/gif-alt-text.ts
+++ b/src/lib/gif-alt-text.ts
@@ -1,4 +1,4 @@
-const USER_ALT_PREFIX = 'User-provided alt text: '
+const USER_ALT_PREFIX = 'Alt: '
 const DEFAULT_ALT_PREFIX = 'ALT: '
 
 export function createGIFDescription(

--- a/src/lib/gif-alt-text.ts
+++ b/src/lib/gif-alt-text.ts
@@ -1,0 +1,39 @@
+const USER_ALT_PREFIX = 'User-provided alt text: '
+const DEFAULT_ALT_PREFIX = 'ALT: '
+
+export function createGIFDescription(
+  tenorDescription: string,
+  preferredAlt?: string,
+) {
+  if (!preferredAlt) {
+    return DEFAULT_ALT_PREFIX + tenorDescription
+  }
+  preferredAlt = preferredAlt.trim()
+  if (preferredAlt !== '') {
+    return USER_ALT_PREFIX + preferredAlt
+  } else {
+    return DEFAULT_ALT_PREFIX + tenorDescription
+  }
+}
+
+export function parseAltFromGIFDescription(description: string): {
+  isPreferred: boolean
+  alt: string
+} {
+  console.log('description', description)
+  if (description.startsWith(USER_ALT_PREFIX)) {
+    return {
+      isPreferred: true,
+      alt: description.replace(USER_ALT_PREFIX, ''),
+    }
+  } else if (description.startsWith(DEFAULT_ALT_PREFIX)) {
+    return {
+      isPreferred: false,
+      alt: description.replace(DEFAULT_ALT_PREFIX, ''),
+    }
+  }
+  return {
+    isPreferred: false,
+    alt: description,
+  }
+}

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -328,7 +328,7 @@ export const ComposePost = observer(function ComposePost({
           image: gif.media_formats.preview.url,
           likelyType: LikelyType.HTML,
           title: gif.content_description,
-          description: '',
+          description: `ALT: ${gif.content_description}`,
         },
       })
       setExtGif(gif)
@@ -343,10 +343,10 @@ export const ComposePost = observer(function ComposePost({
           ? {
               ...ext,
               meta: {
-                ...ext?.meta,
+                ...ext.meta,
                 description:
                   altText.trim().length === 0
-                    ? ''
+                    ? `ALT: ${ext.meta.title}`
                     : `Alt text: ${altText.trim()}`,
               },
             }

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -18,6 +18,10 @@ import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 import {observer} from 'mobx-react-lite'
 
+import {
+  createGIFDescription,
+  parseAltFromGIFDescription,
+} from '#/lib/gif-alt-text'
 import {LikelyType} from '#/lib/link-meta/link-meta'
 import {logEvent} from '#/lib/statsig/statsig'
 import {logger} from '#/logger'
@@ -211,11 +215,25 @@ export const ComposePost = observer(function ComposePost({
     [gallery, track],
   )
 
+  const needsAltText = useMemo(() => {
+    if (!requireAltTextEnabled) return false
+
+    if (gallery.needsAltText) return true
+    if (extGif) {
+      if (!extLink?.meta?.description) return true
+
+      const parsedAlt = parseAltFromGIFDescription(extLink.meta.description)
+      if (!parsedAlt.isPreferred) return true
+    }
+    return false
+  }, [gallery.needsAltText, extLink, extGif, requireAltTextEnabled])
+
   const onPressPublish = async () => {
     if (isProcessing || graphemeLength > MAX_GRAPHEME_LENGTH) {
       return
     }
-    if (requireAltTextEnabled && gallery.needsAltText) {
+
+    if (needsAltText) {
       return
     }
 
@@ -298,10 +316,8 @@ export const ComposePost = observer(function ComposePost({
   }
 
   const canPost = useMemo(
-    () =>
-      graphemeLength <= MAX_GRAPHEME_LENGTH &&
-      (!requireAltTextEnabled || !gallery.needsAltText),
-    [graphemeLength, requireAltTextEnabled, gallery.needsAltText],
+    () => graphemeLength <= MAX_GRAPHEME_LENGTH && !needsAltText,
+    [graphemeLength, needsAltText],
   )
   const selectTextInputPlaceholder = replyTo
     ? _(msg`Write your reply`)
@@ -328,7 +344,7 @@ export const ComposePost = observer(function ComposePost({
           image: gif.media_formats.preview.url,
           likelyType: LikelyType.HTML,
           title: gif.content_description,
-          description: `ALT: ${gif.content_description}`,
+          description: createGIFDescription(gif.content_description),
         },
       })
       setExtGif(gif)
@@ -344,10 +360,10 @@ export const ComposePost = observer(function ComposePost({
               ...ext,
               meta: {
                 ...ext.meta,
-                description:
-                  altText.trim().length === 0
-                    ? `ALT: ${ext.meta.title}`
-                    : `Alt text: ${altText.trim()}`,
+                description: createGIFDescription(
+                  ext.meta.title ?? '',
+                  altText,
+                ),
               },
             }
           : ext,
@@ -433,7 +449,7 @@ export const ComposePost = observer(function ComposePost({
             </>
           )}
         </View>
-        {requireAltTextEnabled && gallery.needsAltText && (
+        {requireAltTextEnabled && needsAltText && (
           <View style={[styles.reminderLine, pal.viewLight]}>
             <View style={styles.errorIcon}>
               <FontAwesomeIcon

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -215,7 +215,7 @@ export const ComposePost = observer(function ComposePost({
     [gallery, track],
   )
 
-  const needsAltText = useMemo(() => {
+  const isAltTextRequiredAndMissing = useMemo(() => {
     if (!requireAltTextEnabled) return false
 
     if (gallery.needsAltText) return true
@@ -233,7 +233,7 @@ export const ComposePost = observer(function ComposePost({
       return
     }
 
-    if (needsAltText) {
+    if (isAltTextRequiredAndMissing) {
       return
     }
 
@@ -316,8 +316,8 @@ export const ComposePost = observer(function ComposePost({
   }
 
   const canPost = useMemo(
-    () => graphemeLength <= MAX_GRAPHEME_LENGTH && !needsAltText,
-    [graphemeLength, needsAltText],
+    () => graphemeLength <= MAX_GRAPHEME_LENGTH && !isAltTextRequiredAndMissing,
+    [graphemeLength, isAltTextRequiredAndMissing],
   )
   const selectTextInputPlaceholder = replyTo
     ? _(msg`Write your reply`)
@@ -449,7 +449,7 @@ export const ComposePost = observer(function ComposePost({
             </>
           )}
         </View>
-        {requireAltTextEnabled && needsAltText && (
+        {isAltTextRequiredAndMissing && (
           <View style={[styles.reminderLine, pal.viewLight]}>
             <View style={styles.errorIcon}>
               <FontAwesomeIcon

--- a/src/view/com/composer/GifAltText.tsx
+++ b/src/view/com/composer/GifAltText.tsx
@@ -58,6 +58,8 @@ export function GifAltText({
     [onSubmit, control],
   )
 
+  const parsedValue = parseAltFromGIFDescription(link.description)
+
   if (!gif || !params) return null
 
   return (
@@ -103,7 +105,7 @@ export function GifAltText({
           onSubmit={onPressSubmit}
           link={link}
           params={params}
-          initalValue={parseAltFromGIFDescription(link.description).alt}
+          initalValue={parsedValue.isPreferred ? parsedValue.alt : ''}
           key={link.uri}
         />
       </Dialog.Outer>
@@ -124,6 +126,7 @@ function AltTextInner({
 }) {
   const {_} = useLingui()
   const [altText, setAltText] = useState(initalValue)
+  const control = Dialog.useDialogContext()
 
   const onPressSubmit = useCallback(() => {
     onSubmit(altText)
@@ -148,6 +151,11 @@ function AltTextInner({
                 multiline
                 numberOfLines={3}
                 autoFocus
+                onKeyPress={({nativeEvent}) => {
+                  if (nativeEvent.key === 'Escape') {
+                    control.close()
+                  }
+                }}
               />
             </TextField.Root>
           </View>

--- a/src/view/com/composer/GifAltText.tsx
+++ b/src/view/com/composer/GifAltText.tsx
@@ -6,6 +6,7 @@ import {useLingui} from '@lingui/react'
 
 import {ExternalEmbedDraft} from '#/lib/api'
 import {HITSLOP_10, MAX_ALT_TEXT} from '#/lib/constants'
+import {parseAltFromGIFDescription} from '#/lib/gif-alt-text'
 import {
   EmbedPlayerParams,
   parseEmbedPlayerFromUrl,
@@ -80,7 +81,7 @@ export function GifAltText({
           a.align_center,
           {backgroundColor: 'rgba(0, 0, 0, 0.75)'},
         ]}>
-        {link.description.startsWith('Alt text: ') ? (
+        {parseAltFromGIFDescription(link.description).isPreferred ? (
           <Check size="xs" fill={t.palette.white} style={a.ml_xs} />
         ) : (
           <Plus size="sm" fill={t.palette.white} />
@@ -102,11 +103,7 @@ export function GifAltText({
           onSubmit={onPressSubmit}
           link={link}
           params={params}
-          initalValue={
-            link.description.startsWith('ALT: ')
-              ? ''
-              : link.description.replace('Alt text: ', '')
-          }
+          initalValue={parseAltFromGIFDescription(link.description).alt}
           key={link.uri}
         />
       </Dialog.Outer>

--- a/src/view/com/composer/GifAltText.tsx
+++ b/src/view/com/composer/GifAltText.tsx
@@ -105,7 +105,7 @@ export function GifAltText({
           onSubmit={onPressSubmit}
           link={link}
           params={params}
-          initalValue={parsedValue.isPreferred ? parsedValue.alt : ''}
+          initialValue={parsedValue.isPreferred ? parsedValue.alt : ''}
           key={link.uri}
         />
       </Dialog.Outer>
@@ -117,12 +117,12 @@ function AltTextInner({
   onSubmit,
   link,
   params,
-  initalValue,
+  initialValue: initalValue,
 }: {
   onSubmit: (text: string) => void
   link: AppBskyEmbedExternal.ViewExternal
   params: EmbedPlayerParams
-  initalValue: string
+  initialValue: string
 }) {
   const {_} = useLingui()
   const [altText, setAltText] = useState(initalValue)

--- a/src/view/com/composer/GifAltText.tsx
+++ b/src/view/com/composer/GifAltText.tsx
@@ -80,7 +80,7 @@ export function GifAltText({
           a.align_center,
           {backgroundColor: 'rgba(0, 0, 0, 0.75)'},
         ]}>
-        {link.description ? (
+        {link.description.startsWith('Alt text: ') ? (
           <Check size="xs" fill={t.palette.white} style={a.ml_xs} />
         ) : (
           <Plus size="sm" fill={t.palette.white} />
@@ -102,7 +102,11 @@ export function GifAltText({
           onSubmit={onPressSubmit}
           link={link}
           params={params}
-          initalValue={link.description.replace('Alt text: ', '')}
+          initalValue={
+            link.description.startsWith('ALT: ')
+              ? ''
+              : link.description.replace('Alt text: ', '')
+          }
           key={link.uri}
         />
       </Dialog.Outer>

--- a/src/view/com/composer/GifAltText.tsx
+++ b/src/view/com/composer/GifAltText.tsx
@@ -58,10 +58,9 @@ export function GifAltText({
     [onSubmit, control],
   )
 
-  const parsedValue = parseAltFromGIFDescription(link.description)
-
   if (!gif || !params) return null
 
+  const parsedAlt = parseAltFromGIFDescription(link.description)
   return (
     <>
       <TouchableOpacity
@@ -83,7 +82,7 @@ export function GifAltText({
           a.align_center,
           {backgroundColor: 'rgba(0, 0, 0, 0.75)'},
         ]}>
-        {parseAltFromGIFDescription(link.description).isPreferred ? (
+        {parsedAlt.isPreferred ? (
           <Check size="xs" fill={t.palette.white} style={a.ml_xs} />
         ) : (
           <Plus size="sm" fill={t.palette.white} />
@@ -105,7 +104,7 @@ export function GifAltText({
           onSubmit={onPressSubmit}
           link={link}
           params={params}
-          initialValue={parsedValue.isPreferred ? parsedValue.alt : ''}
+          initialValue={parsedAlt.isPreferred ? parsedAlt.alt : ''}
           key={link.uri}
         />
       </Dialog.Outer>

--- a/src/view/com/util/post-embeds/GifEmbed.tsx
+++ b/src/view/com/util/post-embeds/GifEmbed.tsx
@@ -6,6 +6,7 @@ import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
 import {HITSLOP_10} from '#/lib/constants'
+import {parseAltFromGIFDescription} from '#/lib/gif-alt-text'
 import {isWeb} from '#/platform/detection'
 import {EmbedPlayerParams} from 'lib/strings/embed-player'
 import {useAutoplayDisabled} from 'state/preferences'
@@ -116,6 +117,11 @@ export function GifEmbed({
     playerRef.current?.toggleAsync()
   }, [])
 
+  const altText = React.useMemo(
+    () => parseAltFromGIFDescription(link.description),
+    [link],
+  )
+
   return (
     <View
       style={[a.rounded_sm, a.overflow_hidden, a.mt_sm, {maxWidth: '100%'}]}>
@@ -140,23 +146,13 @@ export function GifEmbed({
           onPlayerStateChange={onPlayerStateChange}
           ref={playerRef}
           accessibilityHint={_(msg`Animated GIF`)}
-          accessibilityLabel={getAltText(link.description)}
+          accessibilityLabel={altText.alt}
         />
 
-        {!hideAlt && link.description.startsWith('Alt text: ') && (
-          <AltText text={link.description} />
-        )}
+        {!hideAlt && altText.isPreferred && <AltText text={altText.alt} />}
       </View>
     </View>
   )
-}
-
-function getAltText(text: string) {
-  if (text.startsWith('Alt text: ')) {
-    return text.replace('Alt text: ', '')
-  } else if (text.startsWith('ALT: ')) {
-    return text.replace('ALT: ', '')
-  }
 }
 
 function AltText({text}: {text: string}) {
@@ -182,9 +178,7 @@ function AltText({text}: {text: string}) {
         <Prompt.TitleText>
           <Trans>Alt Text</Trans>
         </Prompt.TitleText>
-        <Prompt.DescriptionText selectable>
-          {getAltText(text)}
-        </Prompt.DescriptionText>
+        <Prompt.DescriptionText selectable>{text}</Prompt.DescriptionText>
         <Prompt.Actions>
           <Prompt.Action
             onPress={control.close}

--- a/src/view/com/util/post-embeds/GifEmbed.tsx
+++ b/src/view/com/util/post-embeds/GifEmbed.tsx
@@ -117,7 +117,7 @@ export function GifEmbed({
     playerRef.current?.toggleAsync()
   }, [])
 
-  const altText = React.useMemo(
+  const parsedAlt = React.useMemo(
     () => parseAltFromGIFDescription(link.description),
     [link],
   )
@@ -146,10 +146,10 @@ export function GifEmbed({
           onPlayerStateChange={onPlayerStateChange}
           ref={playerRef}
           accessibilityHint={_(msg`Animated GIF`)}
-          accessibilityLabel={altText.alt}
+          accessibilityLabel={parsedAlt.alt}
         />
 
-        {!hideAlt && altText.isPreferred && <AltText text={altText.alt} />}
+        {!hideAlt && parsedAlt.isPreferred && <AltText text={parsedAlt.alt} />}
       </View>
     </View>
   )

--- a/src/view/com/util/post-embeds/GifEmbed.tsx
+++ b/src/view/com/util/post-embeds/GifEmbed.tsx
@@ -140,15 +140,23 @@ export function GifEmbed({
           onPlayerStateChange={onPlayerStateChange}
           ref={playerRef}
           accessibilityHint={_(msg`Animated GIF`)}
-          accessibilityLabel={link.description.replace('Alt text: ', '')}
+          accessibilityLabel={getAltText(link.description)}
         />
 
         {!hideAlt && link.description.startsWith('Alt text: ') && (
-          <AltText text={link.description.replace('Alt text: ', '')} />
+          <AltText text={link.description} />
         )}
       </View>
     </View>
   )
+}
+
+function getAltText(text: string) {
+  if (text.startsWith('Alt text: ')) {
+    return text.replace('Alt text: ', '')
+  } else if (text.startsWith('ALT: ')) {
+    return text.replace('ALT: ', '')
+  }
 }
 
 function AltText({text}: {text: string}) {
@@ -174,7 +182,9 @@ function AltText({text}: {text: string}) {
         <Prompt.TitleText>
           <Trans>Alt Text</Trans>
         </Prompt.TitleText>
-        <Prompt.DescriptionText selectable>{text}</Prompt.DescriptionText>
+        <Prompt.DescriptionText selectable>
+          {getAltText(text)}
+        </Prompt.DescriptionText>
         <Prompt.Actions>
           <Prompt.Action
             onPress={control.close}


### PR DESCRIPTION
If user-defined alt text is blank, this falls back to the bad one we get from tenor

- Starts with 'Alt text: ': user-defined, show badge
- Starts with 'ALT: ': default, don't show badge