### PR TITLE
create new cache key on each run when saving previous commit hash

### DIFF
--- a/.github/workflows/bundle-deploy-eas-update.yml
+++ b/.github/workflows/bundle-deploy-eas-update.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     concurrency:
       group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}-deploy
-      cancel-in-progress: false
+      cancel-in-progress: true
     outputs:
       fingerprint-is-different: ${{ steps.fingerprint-debug.outputs.fingerprint-is-different }}
 
@@ -54,7 +54,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: last-successful-commit-hash.txt
-          key: last-successful-deployment-commit-${{ github.ref_name }}
+          key: last-successful-deployment-commit-${{ github.ref_name }}-${{ github.sha }}
+          restore-keys: |
+            last-successful-deployment-commit-main-
 
       - name: Add the last successful deployment commit to the output
         id: last-successful-commit

--- a/.github/workflows/bundle-deploy-eas-update.yml
+++ b/.github/workflows/bundle-deploy-eas-update.yml
@@ -56,7 +56,7 @@ jobs:
           path: last-successful-commit-hash.txt
           key: last-successful-deployment-commit-${{ github.ref_name }}-${{ github.sha }}
           restore-keys: |
-            last-successful-deployment-commit-main-
+            last-successful-deployment-commit-${{ github.ref_name }}-
 
       - name: Add the last successful deployment commit to the output
         id: last-successful-commit


### PR DESCRIPTION
So, it turns out that `actions/checkout@v4` does not overwrite cache keys. This was revealed after fixing a boolean check last night. Now, TestFlight releases are using a bad previous commit hash which is always triggering a new build now.

Instead, let's save to a new key on every run. We'll pull from the cache using the `last-successful-deployment-commit-{branch}-` prefix to find the old one instead of just a static string.

Production builds were running appropriately because they do not pull from the cache but rather use version-specific tag for a base commit, so this only affects internal builds.

This also lets us actually use the `cancel-in-progress` correctly, since the cache will actually be properly updated.