### PR TITLE
use four-digit years for RSS pubDate

### DIFF
--- a/bskyweb/cmd/bskyweb/rss.go
+++ b/bskyweb/cmd/bskyweb/rss.go
@@ -5,13 +5,15 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
-	"time"
 
 	appbsky "github.com/bluesky-social/indigo/api/bsky"
 	"github.com/bluesky-social/indigo/atproto/syntax"
 
 	"github.com/labstack/echo/v4"
 )
+
+// time.RFC822Z, but with four digit year. used for RSS pubData.
+var FullYearRFC822Z = "02 Jan 2006 15:04 -0700"
 
 type ItemGUID struct {
 	XMLName xml.Name `xml:"guid"`
@@ -107,7 +109,7 @@ func (srv *Server) WebProfileRSS(c echo.Context) error {
 		pubDate := ""
 		createdAt, err := syntax.ParseDatetimeLenient(rec.CreatedAt)
 		if nil == err {
-			pubDate = createdAt.Time().Format(time.RFC822Z)
+			pubDate = createdAt.Time().Format(FullYearRFC822Z)
 		}
 		posts = append(posts, Item{
 			Link:        fmt.Sprintf("https://%s/profile/%s/post/%s", req.Host, pv.Handle, aturi.RecordKey().String()),


### PR DESCRIPTION
for any typescript reviewer: the way the golang `time` library works is that you give it an example string with special values for each part (year, minute, etc), and the library infers the pattern. I copied the RFC822Z example from the library and made it a four digit year, then tested locally that this is working as expected.

closes: #3362 