### PR TITLE
Move to requestPollInterval handling

### DIFF
--- a/src/state/messages/events/types.ts
+++ b/src/state/messages/events/types.ts
@@ -60,12 +60,14 @@ export type TrailHandler = (
   events: ChatBskyConvoGetLog.OutputSchema['logs'],
 ) => void
 
+export type RequestPollIntervalHandler = (interval: number) => () => void
+
 export type MessagesEventBusState =
   | {
       status: MessagesEventBusStatus.Uninitialized
       rev: undefined
       error: undefined
-      setPollInterval: (interval: number) => void
+      requestPollInterval: RequestPollIntervalHandler
       trail: (handler: TrailHandler) => () => void
       trailConvo: (convoId: string, handler: TrailHandler) => () => void
     }
@@ -73,7 +75,7 @@ export type MessagesEventBusState =
       status: MessagesEventBusStatus.Initializing
       rev: undefined
       error: undefined
-      setPollInterval: (interval: number) => void
+      requestPollInterval: RequestPollIntervalHandler
       trail: (handler: TrailHandler) => () => void
       trailConvo: (convoId: string, handler: TrailHandler) => () => void
     }
@@ -81,7 +83,7 @@ export type MessagesEventBusState =
       status: MessagesEventBusStatus.Ready
       rev: string
       error: undefined
-      setPollInterval: (interval: number) => void
+      requestPollInterval: RequestPollIntervalHandler
       trail: (handler: TrailHandler) => () => void
       trailConvo: (convoId: string, handler: TrailHandler) => () => void
     }
@@ -89,7 +91,7 @@ export type MessagesEventBusState =
       status: MessagesEventBusStatus.Backgrounded
       rev: string | undefined
       error: undefined
-      setPollInterval: (interval: number) => void
+      requestPollInterval: RequestPollIntervalHandler
       trail: (handler: TrailHandler) => () => void
       trailConvo: (convoId: string, handler: TrailHandler) => () => void
     }
@@ -97,7 +99,7 @@ export type MessagesEventBusState =
       status: MessagesEventBusStatus.Suspended
       rev: string | undefined
       error: undefined
-      setPollInterval: (interval: number) => void
+      requestPollInterval: RequestPollIntervalHandler
       trail: (handler: TrailHandler) => () => void
       trailConvo: (convoId: string, handler: TrailHandler) => () => void
     }
@@ -105,7 +107,7 @@ export type MessagesEventBusState =
       status: MessagesEventBusStatus.Error
       rev: string | undefined
       error: MessagesEventBusError
-      setPollInterval: (interval: number) => void
+      requestPollInterval: RequestPollIntervalHandler
       trail: (handler: TrailHandler) => () => void
       trailConvo: (convoId: string, handler: TrailHandler) => () => void
     }


### PR DESCRIPTION
Different screens and views will require different poll intervals. Instead of implicitly setting and reverting poll interval directly for each case, this PR introduces `requestPollInterval`. This method maintains a reference to all requested intervals, and if the event bus is in the `Ready` state, we apply the lowest poll interval requested.

Components that request a poll interval will need to ensure they withdraw the request when unmounting, to `requestPollInterval` returns a function to do so.

```typescript
const events = useMessagesEventBus()

events.trailConvo(convoId, events => console.log(events))

useFocusEffect(
  useCallback(() => {
    const cleanup = events.requestPollInterval(1e3)
    return () => { cleanup() }
  }, [events])
)
```