### PR TITLE
[🐴] Integrate event bus

### DIFF
--- a/src/state/messages/convo/agent.ts
+++ b/src/state/messages/convo/agent.ts
@@ -210,6 +210,7 @@ export class Convo {
           case ConvoDispatchEvent.Init: {
             this.status = ConvoStatus.Initializing
             this.setup()
+            this.requestPollInterval(ACTIVE_POLL_INTERVAL)
             break
           }
         }
@@ -225,15 +226,18 @@ export class Convo {
           case ConvoDispatchEvent.Background: {
             this.status = ConvoStatus.Backgrounded
             this.fetchMessageHistory()
+            this.requestPollInterval(BACKGROUND_POLL_INTERVAL)
             break
           }
           case ConvoDispatchEvent.Suspend: {
             this.status = ConvoStatus.Suspended
+            this.withdrawRequestedPollInterval()
             break
           }
           case ConvoDispatchEvent.Error: {
             this.status = ConvoStatus.Error
             this.error = action.payload
+            this.withdrawRequestedPollInterval()
             break
           }
         }
@@ -243,19 +247,23 @@ export class Convo {
         switch (action.event) {
           case ConvoDispatchEvent.Resume: {
             this.refreshConvo()
+            this.requestPollInterval(ACTIVE_POLL_INTERVAL)
             break
           }
           case ConvoDispatchEvent.Background: {
             this.status = ConvoStatus.Backgrounded
+            this.requestPollInterval(BACKGROUND_POLL_INTERVAL)
             break
           }
           case ConvoDispatchEvent.Suspend: {
             this.status = ConvoStatus.Suspended
+            this.withdrawRequestedPollInterval()
             break
           }
           case ConvoDispatchEvent.Error: {
             this.status = ConvoStatus.Error
             this.error = action.payload
+            this.withdrawRequestedPollInterval()
             break
           }
         }
@@ -272,15 +280,18 @@ export class Convo {
               this.status = ConvoStatus.Initializing
               this.setup()
             }
+            this.requestPollInterval(ACTIVE_POLL_INTERVAL)
             break
           }
           case ConvoDispatchEvent.Suspend: {
             this.status = ConvoStatus.Suspended
+            this.withdrawRequestedPollInterval()
             break
           }
           case ConvoDispatchEvent.Error: {
             this.status = ConvoStatus.Error
             this.error = action.payload
+            this.withdrawRequestedPollInterval()
             break
           }
         }
@@ -288,20 +299,12 @@ export class Convo {
       }
       case ConvoStatus.Suspended: {
         switch (action.event) {
-          // TODO truncate history if needed
           case ConvoDispatchEvent.Init: {
-            if (this.convo) {
-              this.status = ConvoStatus.Ready
-              this.refreshConvo()
-            } else {
-              this.status = ConvoStatus.Initializing
-              this.setup()
-            }
+            this.reset()
             break
           }
           case ConvoDispatchEvent.Resume: {
-            this.status = ConvoStatus.Ready
-            this.refreshConvo()
+            this.reset()
             break
           }
           case ConvoDispatchEvent.Error: {
@@ -414,22 +417,18 @@ export class Convo {
 
   init() {
     this.dispatch({event: ConvoDispatchEvent.Init})
-    this.requestPollInterval(ACTIVE_POLL_INTERVAL)
   }
 
   resume() {
     this.dispatch({event: ConvoDispatchEvent.Resume})
-    this.requestPollInterval(ACTIVE_POLL_INTERVAL)
   }
 
   background() {
     this.dispatch({event: ConvoDispatchEvent.Background})
-    this.requestPollInterval(BACKGROUND_POLL_INTERVAL)
   }
 
   suspend() {
     this.dispatch({event: ConvoDispatchEvent.Suspend})
-    this.withdrawRequestedPollInterval()
     DEBUG_ACTIVE_CHAT = undefined
   }
 

--- a/src/state/messages/convo/agent.ts
+++ b/src/state/messages/convo/agent.ts
@@ -582,6 +582,7 @@ export class Convo {
         error?.retry()
       },
     })
+    this.commit()
   }
 
   ingestFirehose(events: ChatBskyConvoGetLog.OutputSchema['logs']) {

--- a/src/state/messages/convo/const.ts
+++ b/src/state/messages/convo/const.ts
@@ -1,1 +1,2 @@
 export const ACTIVE_POLL_INTERVAL = 1e3
+export const BACKGROUND_POLL_INTERVAL = 5e3

--- a/src/state/messages/convo/const.ts
+++ b/src/state/messages/convo/const.ts
@@ -1,0 +1,1 @@
+export const ACTIVE_POLL_INTERVAL = 1e3

--- a/src/state/messages/convo/index.tsx
+++ b/src/state/messages/convo/index.tsx
@@ -24,7 +24,6 @@ export function ConvoProvider({
   children,
   convoId,
 }: Pick<ConvoParams, 'convoId'> & {children: React.ReactNode}) {
-  const requestedPollInterval = React.useRef<(() => void) | void>()
   const isScreenFocused = useIsFocused()
   const {serviceUrl} = useDmServiceUrlStorage()
   const {getAgent} = useAgent()
@@ -49,10 +48,6 @@ export function ConvoProvider({
       markAsRead({convoId})
 
       return () => {
-        if (requestedPollInterval.current) {
-          requestedPollInterval.current = requestedPollInterval.current()
-        }
-
         convo.background()
         markAsRead({convoId})
       }

--- a/src/state/messages/convo/index.tsx
+++ b/src/state/messages/convo/index.tsx
@@ -44,11 +44,15 @@ export function ConvoProvider({
   const events = useMessagesEventBus()
 
   React.useEffect(() => {
-    const remove = events.trailConvo(convoId, events => {
+    const trail = events.trailConvo(convoId, events => {
       convo.ingestFirehose(events)
     })
+    const onConnect = events.onConnect(convo.onFirehoseConnect)
+    const onError = events.onError(convo.onFirehoseError)
     return () => {
-      remove()
+      trail()
+      onConnect()
+      onError()
     }
   }, [convoId, convo, events])
 

--- a/src/state/messages/convo/types.ts
+++ b/src/state/messages/convo/types.ts
@@ -5,9 +5,12 @@ import {
   ChatBskyConvoSendMessage,
 } from '@atproto-labs/api'
 
+import {MessagesEventBus} from '#/state/messages/events/agent'
+
 export type ConvoParams = {
   convoId: string
   agent: BskyAgent
+  events: MessagesEventBus
   __tempFromUserDid: string
 }
 

--- a/src/state/messages/events/agent.ts
+++ b/src/state/messages/events/agent.ts
@@ -347,7 +347,15 @@ export class MessagesEventBus {
 
     this.isPolling = true
 
-    logger.debug(`${LOGGER_CONTEXT}: poll`, {}, logger.DebugContext.convo)
+    logger.debug(
+      `${LOGGER_CONTEXT}: poll`,
+      {
+        requestedPollIntervals: Array.from(
+          this.requestedPollIntervals.values(),
+        ),
+      },
+      logger.DebugContext.convo,
+    )
 
     try {
       const response = await this.agent.api.chat.bsky.convo.getLog(

--- a/src/state/messages/events/agent.ts
+++ b/src/state/messages/events/agent.ts
@@ -347,15 +347,15 @@ export class MessagesEventBus {
 
     this.isPolling = true
 
-    logger.debug(
-      `${LOGGER_CONTEXT}: poll`,
-      {
-        requestedPollIntervals: Array.from(
-          this.requestedPollIntervals.values(),
-        ),
-      },
-      logger.DebugContext.convo,
-    )
+    // logger.debug(
+    //   `${LOGGER_CONTEXT}: poll`,
+    //   {
+    //     requestedPollIntervals: Array.from(
+    //       this.requestedPollIntervals.values(),
+    //     ),
+    //   },
+    //   logger.DebugContext.convo,
+    // )
 
     try {
       const response = await this.agent.api.chat.bsky.convo.getLog(


### PR DESCRIPTION
This PR integrates the newly refactored event bus from #3919. This removes the need for the `Convo` agent to do its own polling.

Another key improvement is that `Convo` can now handle incoming firehose events _prior to being in a `Ready` state_. Meaning, you can open a chat, and see incoming messages immediately, and we fetch history in the background.