### PR TITLE
Empty following

### DIFF
--- a/src/components/FeedSuggestedFollows/index.tsx
+++ b/src/components/FeedSuggestedFollows/index.tsx
@@ -58,7 +58,7 @@ export function SuggestedFollowCardSkeleton() {
         </View>
       </View>
 
-      <View style={[a.flex_1, a.gap_xs]}>
+      <View style={[a.gap_xs]}>
         <View style={[a.rounded_xs, a.w_full, t.atoms.bg, {height: 12}]} />
         <View style={[a.rounded_xs, a.w_full, t.atoms.bg, {height: 12}]} />
         <View
@@ -151,7 +151,7 @@ export function SuggestedFollowCard({
         </View>
       </View>
 
-      <Text style={[a.flex_1]} numberOfLines={3}>
+      <Text numberOfLines={3}>
         <RichText value={descriptionRT} style={[t.atoms.text_contrast_high]} />
       </Text>
     </View>

--- a/src/components/FeedSuggestedFollows/index.tsx
+++ b/src/components/FeedSuggestedFollows/index.tsx
@@ -1,0 +1,156 @@
+import React from 'react'
+import {View} from 'react-native'
+import {ScrollView} from 'react-native-gesture-handler'
+import {AppBskyActorDefs, moderateProfile} from '@atproto/api'
+import {msg} from '@lingui/macro'
+import {useLingui} from '@lingui/react'
+
+import {useProfileShadow} from '#/state/cache/profile-shadow'
+import {useModerationOpts} from '#/state/queries/preferences'
+import {useSuggestedFollowsQuery} from '#/state/queries/suggested-follows'
+import {isJustAMute} from 'lib/moderation'
+import {sanitizeDisplayName} from 'lib/strings/display-names'
+import {sanitizeHandle} from 'lib/strings/handles'
+import {PreviewableUserAvatar} from '#/view/com/util/UserAvatar'
+import {atoms as a, useTheme} from '#/alf'
+import {Button, ButtonIcon} from '#/components/Button'
+import {useFollowMethods} from '#/components/hooks/useFollowMethods'
+import {useRichText} from '#/components/hooks/useRichText'
+import {Check_Stroke2_Corner0_Rounded as Check} from '#/components/icons/Check'
+import {PlusLarge_Stroke2_Corner0_Rounded as Plus} from '#/components/icons/Plus'
+import {RichText} from '#/components/RichText'
+import {Text} from '#/components/Typography'
+
+export function SuggestedFollowCard({
+  profile: profileUnshadowed,
+}: {
+  profile: AppBskyActorDefs.ProfileViewBasic
+}) {
+  const t = useTheme()
+  const {_} = useLingui()
+  const profile = useProfileShadow(profileUnshadowed)
+  const moderationOpts = useModerationOpts()
+  const {follow, unfollow} = useFollowMethods({
+    profile,
+    // @ts-ignore TODO
+    logContext: 'FeedSuggestedFollowsCard',
+  })
+  // @ts-ignore TODO
+  const [descriptionRT] = useRichText(profileUnshadowed?.description ?? '')
+
+  if (!moderationOpts) return null
+  const moderation = moderateProfile(profile, moderationOpts)
+  const modui = moderation.ui('profileList')
+  if (modui.filter && !isJustAMute(modui)) return null
+
+  return (
+    <View
+      style={[
+        a.p_lg,
+        a.rounded_md,
+        a.gap_sm,
+        t.atoms.bg,
+        {
+          width: 300,
+        },
+      ]}>
+      <View style={[a.flex_row, a.align_center, a.gap_sm]}>
+        <PreviewableUserAvatar
+          size={40}
+          did={profile.did}
+          handle={profile.handle}
+          avatar={profile.avatar}
+          moderation={moderation.ui('avatar')}
+        />
+
+        <View
+          style={[
+            a.flex_row,
+            a.align_center,
+            a.justify_between,
+            a.gap_lg,
+            a.flex_1,
+          ]}>
+          <View style={[a.gap_2xs, a.flex_1]}>
+            <Text
+              style={[a.text_md, a.font_bold, a.leading_tight, a.flex_1]}
+              numberOfLines={1}>
+              {sanitizeDisplayName(
+                profile.displayName || sanitizeHandle(profile.handle),
+                moderation.ui('displayName'),
+              )}
+            </Text>
+            <Text
+              style={[t.atoms.text_contrast_medium, a.flex_1]}
+              numberOfLines={1}>
+              {sanitizeHandle(profile.handle, '@')}
+            </Text>
+          </View>
+
+          <Button
+            label={
+              profile.viewer?.following ? _(msg`Following`) : _(msg`Follow`)
+            }
+            size="small"
+            shape="round"
+            variant="solid"
+            color="secondary"
+            onPress={profile.viewer?.following ? unfollow : follow}>
+            {profile.viewer?.following ? (
+              <ButtonIcon icon={Check} />
+            ) : (
+              <ButtonIcon icon={Plus} />
+            )}
+          </Button>
+        </View>
+      </View>
+
+      <Text style={[a.flex_1]} numberOfLines={2}>
+        <RichText value={descriptionRT} style={[t.atoms.text_contrast_high]} />
+      </Text>
+    </View>
+  )
+}
+
+export function FeedSuggestedFollows() {
+  const t = useTheme()
+  const {isLoading, data: suggestions, error} = useSuggestedFollowsQuery()
+
+  const profiles: AppBskyActorDefs.ProfileViewBasic[] = []
+  if (suggestions) {
+    // Currently the responses contain duplicate items.
+    // Needs to be fixed on backend, but let's dedupe to be safe.
+    let seen = new Set()
+    for (const page of suggestions.pages) {
+      for (const actor of page.actors) {
+        if (!seen.has(actor.did)) {
+          seen.add(actor.did)
+          profiles.push(actor)
+        }
+      }
+    }
+  }
+
+  return (
+    <View
+      style={[a.border_t, t.atoms.border_contrast_low, t.atoms.bg_contrast_25]}>
+      <View style={[a.pt_xl, a.px_lg, a.flex_row, a.gap_md]}>
+        <Text style={[a.font_bold, t.atoms.text_contrast_medium]}>
+          Suggested for you
+        </Text>
+      </View>
+
+      <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+        <View style={[a.px_lg, a.pt_md, a.pb_xl, a.flex_row, a.gap_md]}>
+          {isLoading
+            ? null
+            : error || !profiles.length
+            ? null
+            : profiles.map((profile, i) => (
+                <SuggestedFollowCard key={i} profile={profile} />
+              ))}
+        </View>
+      </ScrollView>
+    </View>
+  )
+}

--- a/src/components/FeedSuggestedFollows/index.tsx
+++ b/src/components/FeedSuggestedFollows/index.tsx
@@ -6,20 +6,68 @@ import {msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
 import {useProfileShadow} from '#/state/cache/profile-shadow'
-import {useModerationOpts} from '#/state/queries/preferences'
+import {useModerationOpts} from '#/state/preferences/moderation-opts'
 import {useSuggestedFollowsQuery} from '#/state/queries/suggested-follows'
 import {isJustAMute} from 'lib/moderation'
 import {sanitizeDisplayName} from 'lib/strings/display-names'
 import {sanitizeHandle} from 'lib/strings/handles'
 import {PreviewableUserAvatar} from '#/view/com/util/UserAvatar'
 import {atoms as a, useTheme} from '#/alf'
-import {Button, ButtonIcon} from '#/components/Button'
+import {Button, ButtonIcon, ButtonText} from '#/components/Button'
 import {useFollowMethods} from '#/components/hooks/useFollowMethods'
 import {useRichText} from '#/components/hooks/useRichText'
+import {ArrowRotateCounterClockwise_Stroke2_Corner0_Rounded as Refresh} from '#/components/icons/ArrowRotateCounterClockwise'
 import {Check_Stroke2_Corner0_Rounded as Check} from '#/components/icons/Check'
+import {CircleInfo_Stroke2_Corner0_Rounded as CircleInfo} from '#/components/icons/CircleInfo'
 import {PlusLarge_Stroke2_Corner0_Rounded as Plus} from '#/components/icons/Plus'
 import {RichText} from '#/components/RichText'
 import {Text} from '#/components/Typography'
+
+export function SuggestedFollowCardSkeleton() {
+  const t = useTheme()
+  return (
+    <View
+      style={[
+        a.p_lg,
+        a.rounded_md,
+        a.gap_sm,
+        t.atoms.bg_contrast_25,
+        {
+          width: 300,
+        },
+      ]}>
+      <View style={[a.flex_row, a.align_center, a.gap_sm]}>
+        <View style={[a.rounded_full, t.atoms.bg, {height: 40, width: 40}]} />
+
+        <View
+          style={[
+            a.flex_row,
+            a.align_center,
+            a.justify_between,
+            a.gap_lg,
+            a.flex_1,
+          ]}>
+          <View style={[a.gap_xs, a.flex_1]}>
+            <View
+              style={[a.rounded_xs, t.atoms.bg, {height: 16, width: 200}]}
+            />
+            <View
+              style={[a.rounded_xs, t.atoms.bg, {height: 12, width: 100}]}
+            />
+          </View>
+        </View>
+      </View>
+
+      <View style={[a.flex_1, a.gap_xs]}>
+        <View style={[a.rounded_xs, a.w_full, t.atoms.bg, {height: 12}]} />
+        <View style={[a.rounded_xs, a.w_full, t.atoms.bg, {height: 12}]} />
+        <View
+          style={[a.rounded_xs, a.w_full, t.atoms.bg, {height: 12, width: 100}]}
+        />
+      </View>
+    </View>
+  )
+}
 
 export function SuggestedFollowCard({
   profile: profileUnshadowed,
@@ -32,10 +80,9 @@ export function SuggestedFollowCard({
   const moderationOpts = useModerationOpts()
   const {follow, unfollow} = useFollowMethods({
     profile,
-    // @ts-ignore TODO
-    logContext: 'FeedSuggestedFollowsCard',
+    logContext: 'FeedSuggestedFollowCard',
   })
-  // @ts-ignore TODO
+  // @ts-ignore TODO why isn't this type correct
   const [descriptionRT] = useRichText(profileUnshadowed?.description ?? '')
 
   if (!moderationOpts) return null
@@ -49,7 +96,7 @@ export function SuggestedFollowCard({
         a.p_lg,
         a.rounded_md,
         a.gap_sm,
-        t.atoms.bg,
+        t.atoms.bg_contrast_25,
         {
           width: 300,
         },
@@ -57,8 +104,7 @@ export function SuggestedFollowCard({
       <View style={[a.flex_row, a.align_center, a.gap_sm]}>
         <PreviewableUserAvatar
           size={40}
-          did={profile.did}
-          handle={profile.handle}
+          profile={profile}
           avatar={profile.avatar}
           moderation={moderation.ui('avatar')}
         />
@@ -94,7 +140,7 @@ export function SuggestedFollowCard({
             size="small"
             shape="round"
             variant="solid"
-            color="secondary"
+            color="primary"
             onPress={profile.viewer?.following ? unfollow : follow}>
             {profile.viewer?.following ? (
               <ButtonIcon icon={Check} />
@@ -105,16 +151,54 @@ export function SuggestedFollowCard({
         </View>
       </View>
 
-      <Text style={[a.flex_1]} numberOfLines={2}>
+      <Text style={[a.flex_1]} numberOfLines={3}>
         <RichText value={descriptionRT} style={[t.atoms.text_contrast_high]} />
       </Text>
     </View>
   )
 }
 
-export function FeedSuggestedFollows() {
+export function ErrorState({retry}: {retry: () => void}) {
   const t = useTheme()
-  const {isLoading, data: suggestions, error} = useSuggestedFollowsQuery()
+  return (
+    <>
+      <View
+        style={[
+          a.align_start,
+          a.p_lg,
+          a.rounded_md,
+          a.gap_md,
+          t.atoms.bg_contrast_25,
+          {
+            width: 300,
+          },
+        ]}>
+        <CircleInfo size="lg" fill={t.palette.negative_400} />
+        <Text style={[a.font_bold]}>Whoops, something went wrong :(</Text>
+        <Button
+          label={'Retry'}
+          size="small"
+          variant="ghost"
+          color="secondary"
+          onPress={retry}>
+          <ButtonText>Retry</ButtonText>
+          <ButtonIcon icon={Refresh} position="right" />
+        </Button>
+      </View>
+
+      <SuggestedFollowCardSkeleton />
+      <SuggestedFollowCardSkeleton />
+    </>
+  )
+}
+
+export function FeedSuggestedFollowsCards() {
+  const {
+    isLoading,
+    data: suggestions,
+    error,
+    refetch,
+  } = useSuggestedFollowsQuery()
 
   const profiles: AppBskyActorDefs.ProfileViewBasic[] = []
   if (suggestions) {
@@ -132,6 +216,28 @@ export function FeedSuggestedFollows() {
   }
 
   return (
+    <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+      <View style={[a.px_lg, a.pt_md, a.pb_xl, a.flex_row, a.gap_md]}>
+        {isLoading ? (
+          Array(3)
+            .fill(0)
+            .map((_, i) => <SuggestedFollowCardSkeleton key={i} />)
+        ) : error || !profiles.length ? (
+          <ErrorState retry={refetch} />
+        ) : (
+          profiles.map((profile, i) => (
+            <SuggestedFollowCard key={i} profile={profile} />
+          ))
+        )}
+      </View>
+    </ScrollView>
+  )
+}
+
+export function FeedSuggestedFollowsInterstitial() {
+  const t = useTheme()
+
+  return (
     <View
       style={[a.border_t, t.atoms.border_contrast_low, t.atoms.bg_contrast_25]}>
       <View style={[a.pt_xl, a.px_lg, a.flex_row, a.gap_md]}>
@@ -140,17 +246,7 @@ export function FeedSuggestedFollows() {
         </Text>
       </View>
 
-      <ScrollView horizontal showsHorizontalScrollIndicator={false}>
-        <View style={[a.px_lg, a.pt_md, a.pb_xl, a.flex_row, a.gap_md]}>
-          {isLoading
-            ? null
-            : error || !profiles.length
-            ? null
-            : profiles.map((profile, i) => (
-                <SuggestedFollowCard key={i} profile={profile} />
-              ))}
-        </View>
-      </ScrollView>
+      <FeedSuggestedFollowsCards />
     </View>
   )
 }

--- a/src/lib/statsig/events.ts
+++ b/src/lib/statsig/events.ts
@@ -102,6 +102,7 @@ export type LogEvents = {
       | 'ProfileHeaderSuggestedFollows'
       | 'ProfileMenu'
       | 'ProfileHoverCard'
+      | 'FeedSuggestedFollowCard'
   }
   'profile:unfollow': {
     logContext:
@@ -112,6 +113,7 @@ export type LogEvents = {
       | 'ProfileHeaderSuggestedFollows'
       | 'ProfileMenu'
       | 'ProfileHoverCard'
+      | 'FeedSuggestedFollowCard'
   }
 
   'test:all:always': {}

--- a/src/screens/Home/EmptyTimeline.tsx
+++ b/src/screens/Home/EmptyTimeline.tsx
@@ -1,0 +1,70 @@
+import React from 'react'
+import {View} from 'react-native'
+import {msg, Trans} from '@lingui/macro'
+import {useLingui} from '@lingui/react'
+
+import {CenteredView} from '#/view/com/util/Views'
+import {atoms as a} from '#/alf'
+import {Button, ButtonIcon, ButtonText} from '#/components/Button'
+import {FeedSuggestedFollowsCards} from '#/components/FeedSuggestedFollows'
+import {IconCircle} from '#/components/IconCircle'
+import {ArrowRotateCounterClockwise_Stroke2_Corner0_Rounded as Refresh} from '#/components/icons/ArrowRotateCounterClockwise'
+import {FilterTimeline_Stroke2_Corner0_Rounded as FilterTimeline} from '#/components/icons/FilterTimeline'
+import {Divider} from '#/components/Menu'
+import {Text} from '#/components/Typography'
+
+export function EmptyTimeline() {
+  const {_} = useLingui()
+
+  return (
+    <CenteredView sideBorders style={[a.h_full_vh]}>
+      <View style={[a.px_lg, a.pt_3xl]}>
+        <IconCircle icon={FilterTimeline} style={[a.mb_2xl]} />
+
+        <Text style={[a.text_xl, a.font_bold, a.mb_sm]}>
+          <Trans>Welcome to your timeline</Trans>
+        </Text>
+        <Text style={[a.mb_sm, a.leading_snug]}>
+          <Trans>
+            Your timeline is where you can see posts from people you follow.
+            It's always chronologically sorted, so you'll never miss a post.
+          </Trans>
+        </Text>
+
+        <Text style={[a.pt_lg, a.font_bold, a.mb_sm, a.leading_snug]}>
+          <Trans>Follow some people to get started!</Trans>
+        </Text>
+      </View>
+      <View style={[a.flex_row, a.align_start]}>
+        <FeedSuggestedFollowsCards />
+      </View>
+      <View style={[a.px_lg]}>
+        <Divider />
+
+        <View
+          style={[
+            a.flex_row,
+            a.align_center,
+            a.justify_end,
+            a.pt_md,
+            a.gap_lg,
+          ]}>
+          <Text style={[a.leading_snug]}>
+            <Trans>When you're done:</Trans>
+          </Text>
+
+          <Button
+            label={_(msg`Click to view your timeline`)}
+            size="medium"
+            variant="solid"
+            color="primary">
+            <ButtonText>
+              <Trans>Click to view your timeline</Trans>
+            </ButtonText>
+            <ButtonIcon icon={Refresh} position="right" />
+          </Button>
+        </View>
+      </View>
+    </CenteredView>
+  )
+}

--- a/src/screens/Home/EmptyTimeline.tsx
+++ b/src/screens/Home/EmptyTimeline.tsx
@@ -1,24 +1,46 @@
 import React from 'react'
-import {View} from 'react-native'
+import {useWindowDimensions, View} from 'react-native'
 import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
+import {useWebMediaQueries} from 'lib/hooks/useWebMediaQueries'
 import {CenteredView} from '#/view/com/util/Views'
 import {atoms as a} from '#/alf'
 import {Button, ButtonIcon, ButtonText} from '#/components/Button'
+import {Divider} from '#/components/Divider'
 import {FeedSuggestedFollowsCards} from '#/components/FeedSuggestedFollows'
 import {IconCircle} from '#/components/IconCircle'
 import {ArrowRotateCounterClockwise_Stroke2_Corner0_Rounded as Refresh} from '#/components/icons/ArrowRotateCounterClockwise'
 import {FilterTimeline_Stroke2_Corner0_Rounded as FilterTimeline} from '#/components/icons/FilterTimeline'
-import {Divider} from '#/components/Menu'
 import {Text} from '#/components/Typography'
+
+// TODO replace this with new shared hook
+function useHeaderOffset() {
+  const {isDesktop, isTablet} = useWebMediaQueries()
+  const {fontScale} = useWindowDimensions()
+  if (isDesktop || isTablet) {
+    return 0
+  }
+  const navBarHeight = 42
+  const tabBarPad = 10 + 10 + 3 // padding + border
+  const normalLineHeight = 1.2
+  const tabBarText = 16 * normalLineHeight * fontScale
+  return navBarHeight + tabBarPad + tabBarText
+}
 
 export function EmptyTimeline() {
   const {_} = useLingui()
+  const offset = useHeaderOffset()
 
   return (
     <CenteredView sideBorders style={[a.h_full_vh]}>
-      <View style={[a.px_lg, a.pt_3xl]}>
+      <View
+        style={[
+          a.px_lg,
+          {
+            paddingTop: offset + a.pt_3xl.paddingTop,
+          },
+        ]}>
         <IconCircle icon={FilterTimeline} style={[a.mb_2xl]} />
 
         <Text style={[a.text_xl, a.font_bold, a.mb_sm]}>
@@ -47,7 +69,7 @@ export function EmptyTimeline() {
             a.align_center,
             a.justify_end,
             a.pt_md,
-            a.gap_lg,
+            a.gap_md,
           ]}>
           <Text style={[a.leading_snug]}>
             <Trans>When you're done:</Trans>
@@ -59,7 +81,7 @@ export function EmptyTimeline() {
             variant="solid"
             color="primary">
             <ButtonText>
-              <Trans>Click to view your timeline</Trans>
+              <Trans>View your timeline</Trans>
             </ButtonText>
             <ButtonIcon icon={Refresh} position="right" />
           </Button>

--- a/src/view/com/feeds/FeedPage.tsx
+++ b/src/view/com/feeds/FeedPage.tsx
@@ -20,6 +20,7 @@ import {useAnalytics} from 'lib/analytics/analytics'
 import {useWebMediaQueries} from 'lib/hooks/useWebMediaQueries'
 import {ComposeIcon2} from 'lib/icons'
 import {s} from 'lib/styles'
+import {EmptyTimeline} from '#/screens/Home/EmptyTimeline'
 import {Feed} from '../posts/Feed'
 import {FAB} from '../util/fab/FAB'
 import {ListMethods} from '../util/List'
@@ -112,25 +113,32 @@ export function FeedPage({
   const adjustedHasNew =
     hasNew && !(isDiscoverFeed && gate('disable_poll_on_discover_v2'))
 
+  const isTimeline = feed === 'home'
+
   return (
     <View testID={testID} style={s.h100pct}>
       <MainScrollProvider>
-        <FeedFeedbackProvider value={feedFeedback}>
-          <Feed
-            testID={testID ? `${testID}-feed` : undefined}
-            enabled={isPageFocused}
-            feed={feed}
-            feedParams={feedParams}
-            pollInterval={POLL_FREQ}
-            disablePoll={hasNew}
-            scrollElRef={scrollElRef}
-            onScrolledDownChange={setIsScrolledDown}
-            onHasNew={setHasNew}
-            renderEmptyState={renderEmptyState}
-            renderEndOfFeed={renderEndOfFeed}
-            headerOffset={headerOffset}
-          />
-        </FeedFeedbackProvider>
+        {isTimeline ? (
+          // TODO Gate this
+          <EmptyTimeline />
+        ) : (
+          <FeedFeedbackProvider value={feedFeedback}>
+            <Feed
+              testID={testID ? `${testID}-feed` : undefined}
+              enabled={isPageFocused}
+              feed={feed}
+              feedParams={feedParams}
+              pollInterval={POLL_FREQ}
+              disablePoll={hasNew}
+              scrollElRef={scrollElRef}
+              onScrolledDownChange={setIsScrolledDown}
+              onHasNew={setHasNew}
+              renderEmptyState={renderEmptyState}
+              renderEndOfFeed={renderEndOfFeed}
+              headerOffset={headerOffset}
+            />
+          </FeedFeedbackProvider>
+        )}
       </MainScrollProvider>
       {(isScrolledDown || adjustedHasNew) && (
         <LoadLatestBtn


### PR DESCRIPTION
Adds primitives to build suggested follows swipeable sections within feeds, and re-uses the same component for an "empty timeline" component.

None of this is used atm, I'll follow up with PRs to integrate it.

![CleanShot 2024-05-09 at 09 25 08@2x](https://github.com/bluesky-social/social-app/assets/4732330/31279f72-cb29-44d9-a445-1ed2219ccaec)
![CleanShot 2024-05-09 at 09 31 40@2x](https://github.com/bluesky-social/social-app/assets/4732330/4b3651c4-d439-489b-b24c-6d32a74f025f)
![CleanShot 2024-05-09 at 09 25 23@2x](https://github.com/bluesky-social/social-app/assets/4732330/0df4980c-235f-4892-8286-90a07a79ee77)
![CleanShot 2024-05-09 at 10 35 07@2x](https://github.com/bluesky-social/social-app/assets/4732330/a99fd5ec-b405-4c60-ad4d-62b50d52246c)
![CleanShot 2024-05-09 at 10 35 15@2x](https://github.com/bluesky-social/social-app/assets/4732330/fff84f34-1201-46ce-9de3-ccc240904186)
![CleanShot 2024-05-09 at 10 35 33@2x](https://github.com/bluesky-social/social-app/assets/4732330/96facef8-f36b-4fcb-b6d7-74ebe6ddaa2d)
