### PR TITLE
[Session] Restore emailAuthFactor and emailConfirmed from last session

### DIFF
--- a/src/state/session/agent.ts
+++ b/src/state/session/agent.ts
@@ -1,5 +1,4 @@
-import {BskyAgent} from '@atproto/api'
-import {AtpSessionEvent} from '@atproto-labs/api'
+import {AtpSessionData, AtpSessionEvent, BskyAgent} from '@atproto/api'
 
 import {networkRetry} from '#/lib/async/retry'
 import {PUBLIC_BSKY_SERVICE} from '#/lib/constants'
@@ -32,11 +31,15 @@ export async function createAgentAndResume(
   }
   const gates = tryFetchGates(storedAccount.did, 'prefer-low-latency')
   const moderation = configureModerationForAccount(agent, storedAccount)
-  const prevSession = {
+  const prevSession: AtpSessionData = {
+    // Sorted in the same property order as when returned by BskyAgent (alphabetical).
     accessJwt: storedAccount.accessJwt ?? '',
-    refreshJwt: storedAccount.refreshJwt ?? '',
     did: storedAccount.did,
+    email: storedAccount.email,
+    emailAuthFactor: storedAccount.emailAuthFactor,
+    emailConfirmed: storedAccount.emailConfirmed,
     handle: storedAccount.handle,
+    refreshJwt: storedAccount.refreshJwt ?? '',
   }
   if (isSessionExpired(storedAccount)) {
     await networkRetry(1, () => agent.resumeSession(prevSession))


### PR DESCRIPTION
Carries over https://github.com/bluesky-social/social-app/pull/3728/files#diff-ba67025ff0027278031f772f88a9ed2f7fa4b12421d0a423ad74b4937aa2ca53R281 from #3728.

My bad that I missed it.

This fixes the false positive "you have not verified your email" popup. The `emailConfirmed` flag is not required so I forgot to specify it. So when you resume session from storage, the first render will not have the full object.

The full object still arrives a bit later (and gets written to the persistent storage) but then the same problem happens on next refresh. (The reason people don't see the same problem on next refreshes now is due to the auto-snoozing flag for this popup.)

## Test Plan

Comment out all the other checks in `shouldRequestEmailConfirmation`. Verify that the full object comes through when you refresh the page, and the popup does not appear.