### PR TITLE
[🐴] Clean up after deleting message

### DIFF
--- a/src/state/messages/__tests__/convo.test.ts
+++ b/src/state/messages/__tests__/convo.test.ts
@@ -35,11 +35,13 @@ describe(`#/state/messages/convo`, () => {
     it.todo(
       `successfully sent messages are re-ordered, if needed, by events received from server`,
     )
+    it.todo(`pending messages are cleaned up from state after firehose event`)
   })
 
   describe(`deleting messages`, () => {
     it.todo(`messages are optimistically deleted from the chat`)
     it.todo(`messages are confirmed deleted via events from the server`)
+    it.todo(`deleted messages are cleaned up from state after firehose event`)
   })
 
   describe(`log handling`, () => {

--- a/src/state/messages/convo/agent.ts
+++ b/src/state/messages/convo/agent.ts
@@ -695,8 +695,6 @@ export class Convo {
     if (needsCommit) {
       this.commit()
     }
-
-    console.log(this.deletedMessages)
   }
 
   async sendMessage(message: ChatBskyConvoSendMessage.InputSchema['message']) {

--- a/src/state/messages/convo/agent.ts
+++ b/src/state/messages/convo/agent.ts
@@ -678,14 +678,10 @@ export class Convo {
             /*
              * Update if we have this in state. If we don't, don't worry about it.
              */
-            // TODO check for other storage spots
-            if (this.pastMessages.has(ev.message.id)) {
-              /*
-               * For now, we remove deleted messages from the thread, if we receive one.
-               *
-               * To support them, it'd look something like this:
-               *   this.pastMessages.set(ev.message.id, ev.message)
-               */
+            if (
+              this.pastMessages.has(ev.message.id) ||
+              this.newMessages.has(ev.message.id)
+            ) {
               this.pastMessages.delete(ev.message.id)
               this.newMessages.delete(ev.message.id)
               this.deletedMessages.delete(ev.message.id)
@@ -699,6 +695,8 @@ export class Convo {
     if (needsCommit) {
       this.commit()
     }
+
+    console.log(this.deletedMessages)
   }
 
   async sendMessage(message: ChatBskyConvoSendMessage.InputSchema['message']) {


### PR DESCRIPTION
I noticed the other day that I was retaining deleted messages in the optimistic `deletedMessages` array. `pastMessages` are things loaded from history, and `newMessages` are things added from the firehose. So I need to check for existence in both those arrays and clean up once I get a committed event from the firehose.