### PR TITLE
[🐴] Simplify message passing, cleanup

### DIFF
--- a/src/state/messages/convo/agent.ts
+++ b/src/state/messages/convo/agent.ts
@@ -107,26 +107,6 @@ export class Convo {
     } else {
       DEBUG_ACTIVE_CHAT = this.convoId
     }
-
-    this.events.on(
-      event => {
-        switch (event.type) {
-          case 'connect': {
-            this.onFirehoseConnect()
-            break
-          }
-          case 'error': {
-            this.onFirehoseError(event.error)
-            break
-          }
-          case 'logs': {
-            this.ingestFirehose(event.logs)
-            break
-          }
-        }
-      },
-      {convoId: this.convoId},
-    )
   }
 
   private commit() {
@@ -225,6 +205,7 @@ export class Convo {
           case ConvoDispatchEvent.Init: {
             this.status = ConvoStatus.Initializing
             this.setup()
+            this.setupFirehose()
             this.requestPollInterval(ACTIVE_POLL_INTERVAL)
             break
           }
@@ -246,12 +227,14 @@ export class Convo {
           }
           case ConvoDispatchEvent.Suspend: {
             this.status = ConvoStatus.Suspended
+            this.cleanupFirehoseConnection?.()
             this.withdrawRequestedPollInterval()
             break
           }
           case ConvoDispatchEvent.Error: {
             this.status = ConvoStatus.Error
             this.error = action.payload
+            this.cleanupFirehoseConnection?.()
             this.withdrawRequestedPollInterval()
             break
           }
@@ -272,12 +255,14 @@ export class Convo {
           }
           case ConvoDispatchEvent.Suspend: {
             this.status = ConvoStatus.Suspended
+            this.cleanupFirehoseConnection?.()
             this.withdrawRequestedPollInterval()
             break
           }
           case ConvoDispatchEvent.Error: {
             this.status = ConvoStatus.Error
             this.error = action.payload
+            this.cleanupFirehoseConnection?.()
             this.withdrawRequestedPollInterval()
             break
           }
@@ -300,12 +285,14 @@ export class Convo {
           }
           case ConvoDispatchEvent.Suspend: {
             this.status = ConvoStatus.Suspended
+            this.cleanupFirehoseConnection?.()
             this.withdrawRequestedPollInterval()
             break
           }
           case ConvoDispatchEvent.Error: {
             this.status = ConvoStatus.Error
             this.error = action.payload
+            this.cleanupFirehoseConnection?.()
             this.withdrawRequestedPollInterval()
             break
           }
@@ -615,6 +602,33 @@ export class Convo {
     }
   }
 
+  private cleanupFirehoseConnection: (() => void) | undefined
+  private setupFirehose() {
+    // remove old listeners, if exist
+    this.cleanupFirehoseConnection?.()
+
+    // reconnect
+    this.cleanupFirehoseConnection = this.events.on(
+      event => {
+        switch (event.type) {
+          case 'connect': {
+            this.onFirehoseConnect()
+            break
+          }
+          case 'error': {
+            this.onFirehoseError(event.error)
+            break
+          }
+          case 'logs': {
+            this.ingestFirehose(event.logs)
+            break
+          }
+        }
+      },
+      {convoId: this.convoId},
+    )
+  }
+
   onFirehoseConnect() {
     this.footerItems.delete(ConvoItemError.FirehoseFailed)
     this.commit()
@@ -727,6 +741,8 @@ export class Convo {
       id: tempId,
       message,
     })
+    // remove on each send, it might go through now without user having to click
+    this.footerItems.delete(ConvoItemError.PendingFailed)
     this.commit()
 
     if (!this.isProcessingPendingMessages) {

--- a/src/state/messages/convo/agent.ts
+++ b/src/state/messages/convo/agent.ts
@@ -108,11 +108,25 @@ export class Convo {
       DEBUG_ACTIVE_CHAT = this.convoId
     }
 
-    this.events.trailConvo(this.convoId, events => {
-      this.ingestFirehose(events)
-    })
-    this.events.onConnect(this.onFirehoseConnect)
-    this.events.onError(this.onFirehoseError)
+    this.events.on(
+      event => {
+        switch (event.type) {
+          case 'connect': {
+            this.onFirehoseConnect()
+            break
+          }
+          case 'error': {
+            this.onFirehoseError(event.error)
+            break
+          }
+          case 'logs': {
+            this.ingestFirehose(event.logs)
+            break
+          }
+        }
+      },
+      {convoId: this.convoId},
+    )
   }
 
   private commit() {

--- a/src/state/messages/events/types.ts
+++ b/src/state/messages/events/types.ts
@@ -55,18 +55,15 @@ export type MessagesEventBusDispatch =
       event: MessagesEventBusDispatchEvent.UpdatePoll
     }
 
-export type TrailHandler = (
-  events: ChatBskyConvoGetLog.OutputSchema['logs'],
-) => void
-
-export type RequestPollIntervalHandler = (interval: number) => () => void
-export type OnConnectHandler = (handler: () => void) => () => void
-export type OnDisconnectHandler = (
-  handler: (error?: MessagesEventBusError) => void,
-) => () => void
-
-export type MessagesEventBusEvents = {
-  events: [ChatBskyConvoGetLog.OutputSchema['logs']]
-  connect: undefined
-  error: [MessagesEventBusError] | undefined
-}
+export type MessagesEventBusEvent =
+  | {
+      type: 'connect'
+    }
+  | {
+      type: 'error'
+      error: MessagesEventBusError
+    }
+  | {
+      type: 'logs'
+      logs: ChatBskyConvoGetLog.OutputSchema['logs']
+    }


### PR DESCRIPTION
Simplifies the contract between the two agents and removes some unused types. It also ensures the events are torn down when the class is suspended.