### PR TITLE
Make more localizable

### DIFF
--- a/src/components/moderation/LabelsOnMeDialog.tsx
+++ b/src/components/moderation/LabelsOnMeDialog.tsx
@@ -162,19 +162,21 @@ function Label({
       <View style={[a.px_md, a.py_sm, t.atoms.bg_contrast_25]}>
         <Text style={[t.atoms.text_contrast_medium]}>
           {isSelfLabel ? (
-            <Trans>This label was applied by you</Trans>
+            <Trans>This label was applied by you.</Trans>
           ) : (
             <>
-              <Trans>Source:</Trans>{' '}
-              <InlineLinkText
-                to={makeProfileLink(
-                  labeler ? labeler.creator : {did: label.src, handle: ''},
-                )}
-                onPress={() => control.close()}>
-                {labeler
-                  ? sanitizeHandle(labeler.creator.handle, '@')
-                  : label.src}
-              </InlineLinkText>
+              <Trans>
+                Source:{' '}
+                <InlineLinkText
+                  to={makeProfileLink(
+                    labeler ? labeler.creator : {did: label.src, handle: ''},
+                  )}
+                  onPress={() => control.close()}>
+                  {labeler
+                    ? sanitizeHandle(labeler.creator.handle, '@')
+                    : label.src}
+                </InlineLinkText>
+              </Trans>
             </>
           )}
         </Text>

--- a/src/components/moderation/LabelsOnMeDialog.tsx
+++ b/src/components/moderation/LabelsOnMeDialog.tsx
@@ -164,20 +164,18 @@ function Label({
           {isSelfLabel ? (
             <Trans>This label was applied by you.</Trans>
           ) : (
-            <>
-              <Trans>
-                Source:{' '}
-                <InlineLinkText
-                  to={makeProfileLink(
-                    labeler ? labeler.creator : {did: label.src, handle: ''},
-                  )}
-                  onPress={() => control.close()}>
-                  {labeler
-                    ? sanitizeHandle(labeler.creator.handle, '@')
-                    : label.src}
-                </InlineLinkText>
-              </Trans>
-            </>
+            <Trans>
+              Source:{' '}
+              <InlineLinkText
+                to={makeProfileLink(
+                  labeler ? labeler.creator : {did: label.src, handle: ''},
+                )}
+                onPress={() => control.close()}>
+                {labeler
+                  ? sanitizeHandle(labeler.creator.handle, '@')
+                  : label.src}
+              </InlineLinkText>
+            </Trans>
           )}
         </Text>
       </View>

--- a/src/screens/Feeds/NoFollowingFeed.tsx
+++ b/src/screens/Feeds/NoFollowingFeed.tsx
@@ -33,18 +33,26 @@ export function NoFollowingFeed() {
 
   return (
     <View style={[a.flex_row, a.flex_wrap, a.align_center, a.py_md, a.px_lg]}>
-      <Text
-        style={[a.leading_snug, t.atoms.text_contrast_medium, {maxWidth: 310}]}>
-        <Trans>Looks like you're missing a following feed.</Trans>{' '}
-      </Text>
+      <Text>
+        <Trans>
+          <Text
+            style={[
+              a.leading_snug,
+              t.atoms.text_contrast_medium,
+              {maxWidth: 310},
+            ]}>
+            Looks like you're missing a following feed.{' '}
+          </Text>
 
-      <InlineLinkText
-        to="/"
-        label={_(msg`Add the default feed of only people you follow`)}
-        onPress={addRecommendedFeeds}
-        style={[a.leading_snug]}>
-        <Trans>Click here to add one.</Trans>
-      </InlineLinkText>
+          <InlineLinkText
+            to="/"
+            label={_(msg`Add the default feed of only people you follow`)}
+            onPress={addRecommendedFeeds}
+            style={[a.leading_snug]}>
+            Click here to add one.
+          </InlineLinkText>
+        </Trans>
+      </Text>
     </View>
   )
 }

--- a/src/screens/Feeds/NoFollowingFeed.tsx
+++ b/src/screens/Feeds/NoFollowingFeed.tsx
@@ -33,17 +33,9 @@ export function NoFollowingFeed() {
 
   return (
     <View style={[a.flex_row, a.flex_wrap, a.align_center, a.py_md, a.px_lg]}>
-      <Text>
+      <Text style={[a.leading_snug, t.atoms.text_contrast_medium]}>
         <Trans>
-          <Text
-            style={[
-              a.leading_snug,
-              t.atoms.text_contrast_medium,
-              {maxWidth: 310},
-            ]}>
-            Looks like you're missing a following feed.{' '}
-          </Text>
-
+          Looks like you're missing a following feed.{' '}
           <InlineLinkText
             to="/"
             label={_(msg`Add the default feed of only people you follow`)}

--- a/src/view/screens/ProfileList.tsx
+++ b/src/view/screens/ProfileList.tsx
@@ -283,7 +283,11 @@ function Header({rkey, list}: {rkey: string; list: AppBskyGraphDefs.ListView}) {
             pinned,
           },
         ])
-        Toast.show(_(msg`${pinned ? 'Pinned to' : 'Unpinned from'} your feeds`))
+        Toast.show(
+          pinned
+            ? _(msg`Pinned to your feeds`)
+            : _(msg`Unpinned from your feeds`),
+        )
       } else {
         await addSavedFeeds([
           {

--- a/src/view/screens/SavedFeeds.tsx
+++ b/src/view/screens/SavedFeeds.tsx
@@ -175,7 +175,7 @@ export function SavedFeeds({}: Props) {
         )}
 
         <View style={styles.footerText}>
-          <Text type="sm" style={pal.textLight}>
+          <Text type="sm" style={[a.leading_snug, pal.textLight]}>
             <Trans>
               Feeds are custom algorithms that users build with a little coding
               expertise.{' '}

--- a/src/view/screens/SavedFeeds.tsx
+++ b/src/view/screens/SavedFeeds.tsx
@@ -175,7 +175,7 @@ export function SavedFeeds({}: Props) {
         )}
 
         <View style={styles.footerText}>
-          <Text type="sm" style={[a.leading_snug, pal.textLight]}>
+          <Text type="sm" style={pal.textLight}>
             <Trans>
               Feeds are custom algorithms that users build with a little coding
               expertise.{' '}


### PR DESCRIPTION
````diff
- Toast.show(_(msg`${pinned ? 'Pinned to' : 'Unpinned from'} your feeds`))
+ Toast.show(
+   pinned
+     ? _(msg`Pinned to your feeds`)
+     : _(msg`Unpinned from your feeds`),
+ )
````
Enables localization of these strings.

---

<img width="491" alt="스크린샷 2024-05-11 15 10 26" src="https://github.com/bluesky-social/social-app/assets/11014257/e999ab67-310c-4f3f-9408-b1a09a6acdca">

This part

Before:
````po
#: src/screens/Feeds/NoFollowingFeed.tsx:38
msgid "Looks like you're missing a following feed."
msgstr ""

#: src/screens/Feeds/NoFollowingFeed.tsx:46
msgid "Click here to add one."
msgstr ""
````

After:
````po
#: src/screens/Feeds/NoFollowingFeed.tsx:37
msgid "Looks like you're missing a following feed. <0>Click here to add one.</0>"
msgstr ""
````

Makes it easier to understand the context of a string. It's also better suited for localization in languages that don't use whitespace.