### PR TITLE
Onboarding fixes

### DIFF
--- a/src/screens/Onboarding/StepFinished.tsx
+++ b/src/screens/Onboarding/StepFinished.tsx
@@ -120,19 +120,17 @@ export function StepFinished() {
         })(),
 
         (async () => {
-          if (gate('reduced_onboarding_and_home_algo')) {
-            const {imageUri, imageMime} = profileStepResults
-            if (imageUri && imageMime) {
-              const blobPromise = uploadBlob(getAgent(), imageUri, imageMime)
-              await getAgent().upsertProfile(async existing => {
-                existing = existing ?? {}
-                const res = await blobPromise
-                if (res.data.blob) {
-                  existing.avatar = res.data.blob
-                }
-                return existing
-              })
-            }
+          const {imageUri, imageMime} = profileStepResults
+          if (imageUri && imageMime) {
+            const blobPromise = uploadBlob(getAgent(), imageUri, imageMime)
+            await getAgent().upsertProfile(async existing => {
+              existing = existing ?? {}
+              const res = await blobPromise
+              if (res.data.blob) {
+                existing.avatar = res.data.blob
+              }
+              return existing
+            })
           }
         })(),
       ])

--- a/src/screens/Onboarding/StepFinished.tsx
+++ b/src/screens/Onboarding/StepFinished.tsx
@@ -117,27 +117,29 @@ export function StepFinished() {
             ])
           }
         })(),
-      ])
 
-      if (gate('reduced_onboarding_and_home_algo')) {
-        await getAgent().upsertProfile(async existing => {
-          existing = existing ?? {}
+        (async () => {
+          if (gate('reduced_onboarding_and_home_algo')) {
+            await getAgent().upsertProfile(async existing => {
+              existing = existing ?? {}
 
-          if (profileStepResults.imageUri && profileStepResults.imageMime) {
-            const res = await uploadBlob(
-              getAgent(),
-              profileStepResults.imageUri,
-              profileStepResults.imageMime,
-            )
+              if (profileStepResults.imageUri && profileStepResults.imageMime) {
+                const res = await uploadBlob(
+                  getAgent(),
+                  profileStepResults.imageUri,
+                  profileStepResults.imageMime,
+                )
 
-            if (res.data.blob) {
-              existing.avatar = res.data.blob
-            }
+                if (res.data.blob) {
+                  existing.avatar = res.data.blob
+                }
+              }
+
+              return existing
+            })
           }
-
-          return existing
-        })
-      }
+        })(),
+      ])
     } catch (e: any) {
       logger.info(`onboarding: bulk save failed`)
       logger.error(e)

--- a/src/screens/Onboarding/StepFinished.tsx
+++ b/src/screens/Onboarding/StepFinished.tsx
@@ -120,23 +120,17 @@ export function StepFinished() {
 
         (async () => {
           if (gate('reduced_onboarding_and_home_algo')) {
-            await getAgent().upsertProfile(async existing => {
-              existing = existing ?? {}
-
-              if (profileStepResults.imageUri && profileStepResults.imageMime) {
-                const res = await uploadBlob(
-                  getAgent(),
-                  profileStepResults.imageUri,
-                  profileStepResults.imageMime,
-                )
-
+            const {imageUri, imageMime} = profileStepResults
+            if (imageUri && imageMime) {
+              await getAgent().upsertProfile(async existing => {
+                existing = existing ?? {}
+                const res = await uploadBlob(getAgent(), imageUri, imageMime)
                 if (res.data.blob) {
                   existing.avatar = res.data.blob
                 }
-              }
-
-              return existing
-            })
+                return existing
+              })
+            }
           }
         })(),
       ])

--- a/src/screens/Onboarding/StepFinished.tsx
+++ b/src/screens/Onboarding/StepFinished.tsx
@@ -122,9 +122,10 @@ export function StepFinished() {
           if (gate('reduced_onboarding_and_home_algo')) {
             const {imageUri, imageMime} = profileStepResults
             if (imageUri && imageMime) {
+              const blobPromise = uploadBlob(getAgent(), imageUri, imageMime)
               await getAgent().upsertProfile(async existing => {
                 existing = existing ?? {}
-                const res = await uploadBlob(getAgent(), imageUri, imageMime)
+                const res = await blobPromise
                 if (res.data.blob) {
                   existing.avatar = res.data.blob
                 }

--- a/src/screens/Onboarding/StepFinished.tsx
+++ b/src/screens/Onboarding/StepFinished.tsx
@@ -14,6 +14,7 @@ import {
   preferencesQueryKey,
   useOverwriteSavedFeedsMutation,
 } from '#/state/queries/preferences'
+import {RQKEY as profileRQKey} from '#/state/queries/profile'
 import {useAgent} from '#/state/session'
 import {useOnboardingDispatch} from '#/state/shell'
 import {uploadBlob} from 'lib/api'
@@ -141,15 +142,18 @@ export function StepFinished() {
       // don't alert the user, just let them into their account
     }
 
-    // Try to ensure that prefs are up-to-date by the time we render Home.
-    await queryClient
-      .invalidateQueries({
+    // Try to ensure that prefs and profile are up-to-date by the time we render Home.
+    await Promise.all([
+      queryClient.invalidateQueries({
         queryKey: preferencesQueryKey,
-      })
-      .catch(e => {
-        logger.error(e)
-        // Keep going.
-      })
+      }),
+      queryClient.invalidateQueries({
+        queryKey: profileRQKey(getAgent().session?.did ?? ''),
+      }),
+    ]).catch(e => {
+      logger.error(e)
+      // Keep going.
+    })
 
     setSaving(false)
     dispatch({type: 'finish'})

--- a/src/state/queries/profile.ts
+++ b/src/state/queries/profile.ts
@@ -6,6 +6,7 @@ import {
   AppBskyActorProfile,
   AtUri,
   BskyAgent,
+  ComAtprotoRepoUploadBlob,
 } from '@atproto/api'
 import {
   QueryClient,
@@ -124,6 +125,26 @@ export function useProfileUpdateMutation() {
       newUserBanner,
       checkCommitted,
     }) => {
+      let newUserAvatarPromise:
+        | Promise<ComAtprotoRepoUploadBlob.Response>
+        | undefined
+      if (newUserAvatar) {
+        newUserAvatarPromise = uploadBlob(
+          getAgent(),
+          newUserAvatar.path,
+          newUserAvatar.mime,
+        )
+      }
+      let newUserBannerPromise:
+        | Promise<ComAtprotoRepoUploadBlob.Response>
+        | undefined
+      if (newUserBanner) {
+        newUserBannerPromise = uploadBlob(
+          getAgent(),
+          newUserBanner.path,
+          newUserBanner.mime,
+        )
+      }
       await getAgent().upsertProfile(async existing => {
         existing = existing || {}
         if (typeof updates === 'function') {
@@ -132,22 +153,14 @@ export function useProfileUpdateMutation() {
           existing.displayName = updates.displayName
           existing.description = updates.description
         }
-        if (newUserAvatar) {
-          const res = await uploadBlob(
-            getAgent(),
-            newUserAvatar.path,
-            newUserAvatar.mime,
-          )
+        if (newUserAvatarPromise) {
+          const res = await newUserAvatarPromise
           existing.avatar = res.data.blob
         } else if (newUserAvatar === null) {
           existing.avatar = undefined
         }
-        if (newUserBanner) {
-          const res = await uploadBlob(
-            getAgent(),
-            newUserBanner.path,
-            newUserBanner.mime,
-          )
+        if (newUserBannerPromise) {
+          const res = await newUserBannerPromise
           existing.banner = res.data.blob
         } else if (newUserBanner === null) {
           existing.banner = undefined


### PR DESCRIPTION
See individual commits.

- https://github.com/bluesky-social/social-app/commit/d8ee3b630d2ae907df0a0e613cd3640ed683296a: Fixes a flash after new onboarding that caused Following to get selected instead of Discover. The problem is we were writing Discover into `savedFeeds` via `overwriteSavedFeeds`, but RQ has already cached initial `savedFeeds` (just the `following`), and we had a flash of that during the initial Home render. The fix is to invalidate RQ cache before going to Home.
- d8265e52650941a565e8593316a2326e9931b39a: There is no reason for this call to be serial from what I can see. It can be parallelized against bulk follows and setting prefs. Only setting prefs has to be serial (because lol, we designed it to be this way).
- https://github.com/bluesky-social/social-app/commit/03ecf4cce77b965b995965f8ec4283729cb1a1f7: Unnecessary await if we're not uploading anything. Let's remove that.
- https://github.com/bluesky-social/social-app/commit/cf29021070dcaa6bb42f2811000dbcd6d0900a4f: Unnecessary waterfall. Let the image upload begin in parallel with getting the profile.
- fd692948d842c4d82b7e371f394fda0f49ddda98: Drive-by fix for the same issue in regular profile editor. We can upload in parallel without waiting for account info.
- 528877bd012587b9dac8a72bc0a184a6946af0a0: It's weird to see an empty profile pic after finishing onboarding. Let's invalidate that query.
- https://github.com/bluesky-social/social-app/commit/a72bb815de7fd53df14704e44a65c6b7862533b9: The code in main adds the profile image step both to old and new onboarding, but only new onboarding used to persist this image. Oops. This makes it persist in both cases. If we don't want that step, we can gate this code again.


## Test Plan

Hardcode either `true` or `false` like this:

```diff
--- a/src/lib/statsig/statsig.tsx
+++ b/src/lib/statsig/statsig.tsx
@@ -115,6 +115,9 @@ export function useGate(): (gateName: Gate) => boolean {
   }
   const gate = React.useCallback(
     (gateName: Gate): boolean => {
+      if (gateName === 'reduced_onboarding_and_home_algo') {
+        return false
+      }
```

Then go through both onboardings. Observe that:

- There is no flash of Following tab after onboard
- You reliably land on Discover
- Your profile pic is set

Also verify the normal "edit profile" workflow isn't borked (incl. avatar and cover upload).

New onboarding:

https://github.com/bluesky-social/social-app/assets/810438/bffbd1d0-7539-4a71-855a-e6260bccfc95

Old onboarding:


https://github.com/bluesky-social/social-app/assets/810438/341dcb0d-2dc1-4743-bda4-8ea4f8c62f70

