### PR TITLE
Fix flashes when replacing For You

### DIFF
--- a/src/view/com/posts/FeedShutdownMsg.tsx
+++ b/src/view/com/posts/FeedShutdownMsg.tsx
@@ -43,6 +43,9 @@ export function FeedShutdownMsg({feedUri}: {feedUri: string}) {
         await removeFeed(feedConfig)
         Toast.show(_(msg`Removed from your feeds`))
       }
+      if (hasDiscoverPinned) {
+        setSelectedFeed(`feedgen|${PROD_DEFAULT_FEED('whats-hot')}`)
+      }
     } catch (err: any) {
       Toast.show(
         _(
@@ -51,7 +54,7 @@ export function FeedShutdownMsg({feedUri}: {feedUri: string}) {
       )
       logger.error('Failed up update feeds', {message: err})
     }
-  }, [removeFeed, feedConfig, _])
+  }, [removeFeed, feedConfig, _, hasDiscoverPinned, setSelectedFeed])
 
   const onReplaceFeed = React.useCallback(async () => {
     try {

--- a/src/view/com/posts/FeedShutdownMsg.tsx
+++ b/src/view/com/posts/FeedShutdownMsg.tsx
@@ -6,10 +6,9 @@ import {useLingui} from '@lingui/react'
 import {PROD_DEFAULT_FEED} from '#/lib/constants'
 import {logger} from '#/logger'
 import {
-  useAddSavedFeedsMutation,
   usePreferencesQuery,
   useRemoveFeedMutation,
-  useUpdateSavedFeedsMutation,
+  useReplaceForYouWithDiscoverFeedMutation,
 } from '#/state/queries/preferences'
 import {useSetSelectedFeed} from '#/state/shell/selected-feed'
 import * as Toast from '#/view/com/util/Toast'
@@ -24,12 +23,10 @@ export function FeedShutdownMsg({feedUri}: {feedUri: string}) {
   const {_} = useLingui()
   const setSelectedFeed = useSetSelectedFeed()
   const {data: preferences} = usePreferencesQuery()
-  const {mutateAsync: addSavedFeeds, isPending: isAddSavedFeedPending} =
-    useAddSavedFeedsMutation()
   const {mutateAsync: removeFeed, isPending: isRemovePending} =
     useRemoveFeedMutation()
-  const {mutateAsync: updateSavedFeeds, isPending: isUpdateFeedPending} =
-    useUpdateSavedFeedsMutation()
+  const {mutateAsync: replaceFeedWithDiscover, isPending: isReplacePending} =
+    useReplaceForYouWithDiscoverFeedMutation()
 
   const feedConfig = preferences?.savedFeeds?.find(
     f => f.value === feedUri && f.pinned,
@@ -58,26 +55,11 @@ export function FeedShutdownMsg({feedUri}: {feedUri: string}) {
 
   const onReplaceFeed = React.useCallback(async () => {
     try {
-      if (!discoverFeedConfig) {
-        await addSavedFeeds([
-          {
-            type: 'feed',
-            value: PROD_DEFAULT_FEED('whats-hot'),
-            pinned: true,
-          },
-        ])
-      } else {
-        await updateSavedFeeds([
-          {
-            ...discoverFeedConfig,
-            pinned: true,
-          },
-        ])
-      }
+      await replaceFeedWithDiscover({
+        forYouFeedConfig: feedConfig,
+        discoverFeedConfig,
+      })
       setSelectedFeed(`feedgen|${PROD_DEFAULT_FEED('whats-hot')}`)
-      if (feedConfig) {
-        await removeFeed(feedConfig)
-      }
       Toast.show(_(msg`The feed has been replaced with Discover.`))
     } catch (err: any) {
       Toast.show(
@@ -88,17 +70,14 @@ export function FeedShutdownMsg({feedUri}: {feedUri: string}) {
       logger.error('Failed up update feeds', {message: err})
     }
   }, [
-    addSavedFeeds,
-    updateSavedFeeds,
-    removeFeed,
+    replaceFeedWithDiscover,
     discoverFeedConfig,
     feedConfig,
     setSelectedFeed,
     _,
   ])
 
-  const isProcessing =
-    isAddSavedFeedPending || isUpdateFeedPending || isRemovePending
+  const isProcessing = isReplacePending || isRemovePending
   return (
     <View
       style={[
@@ -147,9 +126,7 @@ export function FeedShutdownMsg({feedUri}: {feedUri: string}) {
               <ButtonText>
                 <Trans>Replace with Discover</Trans>
               </ButtonText>
-              {(isAddSavedFeedPending || isUpdateFeedPending) && (
-                <ButtonIcon icon={Loader} />
-              )}
+              {isReplacePending && <ButtonIcon icon={Loader} />}
             </Button>
           )}
         </View>


### PR DESCRIPTION
We were triggering multiple mutations, each of which invalidates the prefs. So the transition felt very jumpy (two full screen refreshes one after another). This fixes it by introducing a special mutation just for this case, with one invalidation at the end.

This also changes "Remove" button to move you to Discover if you already have it pinned.

Note it's still a bit janky because there's an interrupting pager animation. But that already exists on main too.

## Test Plan

Press Remove when Discover is not saved:

https://github.com/bluesky-social/social-app/assets/810438/39c7a851-5188-487a-bee6-45ed58d9f0c7

Press Remove when Discover is saved (but not pinned):

https://github.com/bluesky-social/social-app/assets/810438/022a96da-dae2-444d-9382-793582a3b239

Press Remove when Discover is pinned:

https://github.com/bluesky-social/social-app/assets/810438/f15d035d-4602-40c8-90aa-e64bd261228d

Press Replace when Discover is not saved:

https://github.com/bluesky-social/social-app/assets/810438/5ffca8db-de66-47e4-af86-912bd2c98e91

Press Replace when Discover is saved (but not pinned):

https://github.com/bluesky-social/social-app/assets/810438/95f22709-45f8-4c03-b189-e6ecc0b61088

