### PR TITLE
FeedFeedback fixes

### DIFF
--- a/src/lib/api/feed-manip.ts
+++ b/src/lib/api/feed-manip.ts
@@ -71,6 +71,10 @@ export class FeedViewPostsSlice {
       ?.__source as ReasonFeedSource
   }
 
+  get feedContext() {
+    return this.items.find(item => item.feedContext)?.feedContext
+  }
+
   containsUri(uri: string) {
     return !!this.items.find(item => item.post.uri === uri)
   }

--- a/src/state/queries/post-feed.ts
+++ b/src/state/queries/post-feed.ts
@@ -303,7 +303,10 @@ export function usePostFeedQuery(
                               i === 0 && slice.source
                                 ? slice.source
                                 : item.reason,
-                            feedContext: item.feedContext,
+                            feedContext:
+                              i === 0 && slice.feedContext
+                                ? slice.feedContext
+                                : item.feedContext,
                             moderation: moderations[i],
                           }
                         }

--- a/src/state/queries/post-feed.ts
+++ b/src/state/queries/post-feed.ts
@@ -303,10 +303,7 @@ export function usePostFeedQuery(
                               i === 0 && slice.source
                                 ? slice.source
                                 : item.reason,
-                            feedContext:
-                              i === 0 && slice.feedContext
-                                ? slice.feedContext
-                                : item.feedContext,
+                            feedContext: item.feedContext || slice.feedContext,
                             moderation: moderations[i],
                           }
                         }

--- a/src/view/com/util/List.tsx
+++ b/src/view/com/util/List.tsx
@@ -90,7 +90,7 @@ function ListImpl<ItemT>(
       },
       {
         itemVisiblePercentThreshold: 40,
-        minimumViewTime: 2e3,
+        minimumViewTime: 1.5e3,
       },
     ]
   }, [onItemSeen])

--- a/src/view/com/util/List.web.tsx
+++ b/src/view/com/util/List.web.tsx
@@ -27,7 +27,7 @@ export type ListProps<ItemT> = Omit<
 }
 export type ListRef = React.MutableRefObject<any | null> // TODO: Better types.
 
-const ON_ITEM_SEEN_WAIT_DURATION = 2e3 // post must be "seen" 2 seconds before capturing
+const ON_ITEM_SEEN_WAIT_DURATION = 1.5e3 // when we consider post to  be "seen"
 const ON_ITEM_SEEN_INTERSECTION_OPTS = {
   rootMargin: '-200px 0px -200px 0px',
 } // post must be 200px visible to be "seen"


### PR DESCRIPTION
- https://github.com/bluesky-social/social-app/commit/3cc47165a9bd6f064ef269e4995838e4b6d97502: Lower the time threshold to 1500ms as discussed with @whyrusleeping.
- https://github.com/bluesky-social/social-app/commit/14f00d55cae9a8ed0168b30b3ac53c0388982e52: Replies were missing `feedContext` because the parent item (which was unshifted) didn't have it. For our purposes, the entire convo has the same context. The fix is mostly copypaste from how we handle `source`. There's probably a simpler way to write this but I don't understand the data structure for sure — and this will definitely work.

## Test Plan

Read the code for the first change. For the second change, added

```diff
--- a/src/state/queries/post-feed.ts
+++ b/src/state/queries/post-feed.ts
@@ -294,6 +294,14 @@ export function usePostFeedQuery(
                           AppBskyFeedPost.validateRecord(item.post.record)
                             .success
                         ) {
+                          let before = item.feedContext
+                          let after =
+                            i === 0 && slice.feedContext
+                              ? slice.feedContext
+                              : item.feedContext
+                          if (before !== after) {
+                            console.log('before != after', before, after)
+                          }

```

and verified that the log shows up for replies

<img width="249" alt="Screenshot 2024-05-11 at 20 32 32" src="https://github.com/bluesky-social/social-app/assets/810438/c40cdba6-6af0-4e7e-820a-f050b713c367">
