### PR TITLE
Move request for notifications permissions to `HomeReadyScreen`

### DIFF
--- a/src/lib/notifications/notifications.ts
+++ b/src/lib/notifications/notifications.ts
@@ -1,9 +1,8 @@
 import React from 'react'
 import * as Notifications from 'expo-notifications'
-import {BskyAgent} from '@atproto/api'
 
 import {logger} from '#/logger'
-import {SessionAccount, useAgent, useSession} from '#/state/session'
+import {useAgent, useSession} from '#/state/session'
 import {logEvent, useGate} from 'lib/statsig/statsig'
 import {devicePlatform, isNative} from 'platform/detection'
 
@@ -12,54 +11,48 @@ const SERVICE_DID = (serviceUrl?: string) =>
     ? 'did:web:api.staging.bsky.dev'
     : 'did:web:api.bsky.app'
 
-async function registerPushToken(
-  getAgent: () => BskyAgent,
-  account: SessionAccount,
-  token: Notifications.DevicePushToken,
-) {
-  try {
-    await getAgent().api.app.bsky.notification.registerPush({
-      serviceDid: SERVICE_DID(account.service),
-      platform: devicePlatform,
-      token: token.data,
-      appId: 'xyz.blueskyweb.app',
-    })
-    logger.debug(
-      'Notifications: Sent push token (init)',
-      {
-        tokenType: token.type,
-        token: token.data,
-      },
-      logger.DebugContext.notifications,
-    )
-  } catch (error) {
-    logger.error('Notifications: Failed to set push token', {message: error})
-  }
-}
-
 export function useNotificationsRegistration() {
   const [currentPermissions] = Notifications.usePermissions()
   const {getAgent} = useAgent()
   const {currentAccount} = useSession()
 
-  const prevAccountDid = React.useRef<string | undefined>(undefined)
-
   React.useEffect(() => {
-    if (
-      !currentPermissions?.granted ||
-      !currentAccount ||
-      prevAccountDid.current === currentAccount.did
-    ) {
-      return
+    const registerPushToken = async (token: Notifications.DevicePushToken) => {
+      if (!currentAccount) {
+        return
+      }
+
+      try {
+        await getAgent().api.app.bsky.notification.registerPush({
+          serviceDid: SERVICE_DID(currentAccount.service),
+          platform: devicePlatform,
+          token: token.data,
+          appId: 'xyz.blueskyweb.app',
+        })
+        logger.debug(
+          'Notifications: Sent push token (change)',
+          {
+            tokenType: token.type,
+            token: token.data,
+          },
+          logger.DebugContext.notifications,
+        )
+      } catch (error) {
+        logger.error('Notifications: Failed to set push token', {
+          message: error,
+        })
+      }
     }
 
     // Whenever we all `getDevicePushTokenAsync()`, a change event will be fired below
-    Notifications.getDevicePushTokenAsync()
+    if (currentPermissions?.granted) {
+      Notifications.getDevicePushTokenAsync()
+    }
 
     // According to the Expo docs, there is a chance that the token will change while the app is open in some rare
     // cases. This will fire `registerPushToken` whenever that happens.
     const subscription = Notifications.addPushTokenListener(async newToken => {
-      registerPushToken(getAgent, currentAccount, newToken)
+      registerPushToken(newToken)
     })
 
     return () => {

--- a/src/lib/notifications/notifications.ts
+++ b/src/lib/notifications/notifications.ts
@@ -1,8 +1,9 @@
+import React from 'react'
 import * as Notifications from 'expo-notifications'
 import {BskyAgent} from '@atproto/api'
 
 import {logger} from '#/logger'
-import {SessionAccount} from '#/state/session'
+import {SessionAccount, useAgent, useSession} from '#/state/session'
 import {devicePlatform} from 'platform/detection'
 
 const SERVICE_DID = (serviceUrl?: string) =>
@@ -10,17 +11,10 @@ const SERVICE_DID = (serviceUrl?: string) =>
     ? 'did:web:api.staging.bsky.dev'
     : 'did:web:api.bsky.app'
 
-export async function requestPermissionsAndRegisterToken(
+async function registerPushToken(
   getAgent: () => BskyAgent,
   account: SessionAccount,
 ) {
-  // request notifications permission once the user has logged in
-  const perms = await Notifications.getPermissionsAsync()
-  if (!perms.granted) {
-    await Notifications.requestPermissionsAsync()
-  }
-
-  // register the push token with the server
   const token = await Notifications.getDevicePushTokenAsync()
   try {
     await getAgent().api.app.bsky.notification.registerPush({
@@ -42,38 +36,30 @@ export async function requestPermissionsAndRegisterToken(
   }
 }
 
-export function registerTokenChangeHandler(
-  getAgent: () => BskyAgent,
-  account: SessionAccount,
-): () => void {
-  // listens for new changes to the push token
-  // In rare situations, a push token may be changed by the push notification service while the app is running. When a token is rolled, the old one becomes invalid and sending notifications to it will fail. A push token listener will let you handle this situation gracefully by registering the new token with your backend right away.
-  const sub = Notifications.addPushTokenListener(async newToken => {
-    logger.debug(
-      'Notifications: Push token changed',
-      {tokenType: newToken.data, token: newToken.type},
-      logger.DebugContext.notifications,
-    )
-    try {
-      await getAgent().api.app.bsky.notification.registerPush({
-        serviceDid: SERVICE_DID(account.service),
-        platform: devicePlatform,
-        token: newToken.data,
-        appId: 'xyz.blueskyweb.app',
-      })
-      logger.debug(
-        'Notifications: Sent push token (event)',
-        {
-          tokenType: newToken.type,
-          token: newToken.data,
-        },
-        logger.DebugContext.notifications,
-      )
-    } catch (error) {
-      logger.error('Notifications: Failed to set push token', {message: error})
+export function useNotificationsRegistration() {
+  const [currentPermissions] = Notifications.usePermissions()
+  const {getAgent} = useAgent()
+  const {currentAccount} = useSession()
+
+  const prevAccountDid = React.useRef<string | undefined>(undefined)
+
+  React.useEffect(() => {
+    if (
+      currentPermissions?.status !== 'granted' ||
+      !currentAccount ||
+      prevAccountDid.current === currentAccount.did
+    ) {
+      return
     }
-  })
-  return () => {
-    sub.remove()
-  }
+
+    registerPushToken(getAgent, currentAccount)
+
+    const subscription = Notifications.addPushTokenListener(() => {
+      registerPushToken(getAgent, currentAccount)
+    })
+
+    return () => {
+      subscription.remove()
+    }
+  }, [currentAccount, currentPermissions, getAgent])
 }

--- a/src/lib/notifications/notifications.ts
+++ b/src/lib/notifications/notifications.ts
@@ -86,13 +86,13 @@ export function useRequestNotificationsPermission() {
       ) {
         return
       }
-
       if (
         context === 'StartOnboarding' &&
         gate('request_notifications_permission_after_onboarding')
       ) {
         return
-      } else if (
+      }
+      if (
         context === 'AfterOnboarding' &&
         !gate('request_notifications_permission_after_onboarding')
       ) {

--- a/src/lib/notifications/notifications.ts
+++ b/src/lib/notifications/notifications.ts
@@ -78,7 +78,12 @@ export function useRequestNotificationsPermission() {
 
   return React.useCallback(
     async (context: 'StartOnboarding' | 'AfterOnboarding') => {
-      if (!isNative || currentPermissions?.granted) {
+      if (
+        !isNative ||
+        currentPermissions?.status === 'granted' ||
+        (currentPermissions?.status === 'denied' &&
+          !currentPermissions?.canAskAgain)
+      ) {
         return
       }
 
@@ -99,6 +104,6 @@ export function useRequestNotificationsPermission() {
         status: res.status,
       })
     },
-    [currentPermissions?.granted, gate],
+    [currentPermissions?.canAskAgain, currentPermissions?.status, gate],
   )
 }

--- a/src/lib/notifications/notifications.ts
+++ b/src/lib/notifications/notifications.ts
@@ -67,7 +67,7 @@ export function useNotificationsRegistration() {
   }, [currentAccount, currentPermissions, getAgent])
 }
 
-export function useNotificationsPermissionRequest() {
+export function useRequestNotificationsPermission() {
   const [currentPermissions] = Notifications.usePermissions()
 
   return React.useCallback(

--- a/src/lib/notifications/notifications.ts
+++ b/src/lib/notifications/notifications.ts
@@ -59,7 +59,7 @@ export function useNotificationsRegistration() {
     return () => {
       subscription.remove()
     }
-  }, [currentAccount, currentPermissions, getAgent])
+  }, [currentAccount, currentPermissions?.granted, getAgent])
 }
 
 export function useRequestNotificationsPermission() {

--- a/src/lib/notifications/notifications.ts
+++ b/src/lib/notifications/notifications.ts
@@ -1,8 +1,9 @@
 import React from 'react'
 import * as Notifications from 'expo-notifications'
+import {BskyAgent} from '@atproto/api'
 
 import {logger} from '#/logger'
-import {useAgent, useSession} from '#/state/session'
+import {SessionAccount, useAgent, useSession} from '#/state/session'
 import {logEvent, useGate} from 'lib/statsig/statsig'
 import {devicePlatform, isNative} from 'platform/detection'
 
@@ -11,48 +12,48 @@ const SERVICE_DID = (serviceUrl?: string) =>
     ? 'did:web:api.staging.bsky.dev'
     : 'did:web:api.bsky.app'
 
+async function registerPushToken(
+  getAgent: () => BskyAgent,
+  account: SessionAccount,
+  token: Notifications.DevicePushToken,
+) {
+  try {
+    await getAgent().api.app.bsky.notification.registerPush({
+      serviceDid: SERVICE_DID(account.service),
+      platform: devicePlatform,
+      token: token.data,
+      appId: 'xyz.blueskyweb.app',
+    })
+    logger.debug(
+      'Notifications: Sent push token (init)',
+      {
+        tokenType: token.type,
+        token: token.data,
+      },
+      logger.DebugContext.notifications,
+    )
+  } catch (error) {
+    logger.error('Notifications: Failed to set push token', {message: error})
+  }
+}
+
 export function useNotificationsRegistration() {
   const [currentPermissions] = Notifications.usePermissions()
   const {getAgent} = useAgent()
   const {currentAccount} = useSession()
 
   React.useEffect(() => {
-    const registerPushToken = async (token: Notifications.DevicePushToken) => {
-      if (!currentAccount) {
-        return
-      }
-
-      try {
-        await getAgent().api.app.bsky.notification.registerPush({
-          serviceDid: SERVICE_DID(currentAccount.service),
-          platform: devicePlatform,
-          token: token.data,
-          appId: 'xyz.blueskyweb.app',
-        })
-        logger.debug(
-          'Notifications: Sent push token (change)',
-          {
-            tokenType: token.type,
-            token: token.data,
-          },
-          logger.DebugContext.notifications,
-        )
-      } catch (error) {
-        logger.error('Notifications: Failed to set push token', {
-          message: error,
-        })
-      }
+    if (!currentAccount || !currentPermissions?.granted) {
+      return
     }
 
     // Whenever we all `getDevicePushTokenAsync()`, a change event will be fired below
-    if (currentPermissions?.granted) {
-      Notifications.getDevicePushTokenAsync()
-    }
+    Notifications.getDevicePushTokenAsync()
 
     // According to the Expo docs, there is a chance that the token will change while the app is open in some rare
     // cases. This will fire `registerPushToken` whenever that happens.
     const subscription = Notifications.addPushTokenListener(async newToken => {
-      registerPushToken(newToken)
+      registerPushToken(getAgent, currentAccount, newToken)
     })
 
     return () => {

--- a/src/lib/notifications/notifications.ts
+++ b/src/lib/notifications/notifications.ts
@@ -15,12 +15,8 @@ const SERVICE_DID = (serviceUrl?: string) =>
 async function registerPushToken(
   getAgent: () => BskyAgent,
   account: SessionAccount,
-  token?: Notifications.DevicePushToken,
+  token: Notifications.DevicePushToken,
 ) {
-  if (!token) {
-    token = await Notifications.getDevicePushTokenAsync()
-  }
-
   try {
     await getAgent().api.app.bsky.notification.registerPush({
       serviceDid: SERVICE_DID(account.service),

--- a/src/lib/statsig/events.ts
+++ b/src/lib/statsig/events.ts
@@ -16,6 +16,10 @@ export type LogEvents = {
     logContext: 'SwitchAccount' | 'Settings' | 'Deactivated'
   }
   'notifications:openApp': {}
+  'notifications:request': {
+    logContext: 'StartOnboarding' | 'AfterOnboarding'
+    status: 'granted' | 'denied' | 'undetermined'
+  }
   'state:background': {
     secondsActive: number
   }
@@ -68,10 +72,6 @@ export type LogEvents = {
   }
   'composer:gif:open': {}
   'composer:gif:select': {}
-  'notifications:request': {
-    logContext: 'StartOnboarding' | 'AfterOnboarding'
-    status: 'granted' | 'denied' | 'undetermined'
-  }
 
   // Data events
   'account:create:begin': {}

--- a/src/lib/statsig/events.ts
+++ b/src/lib/statsig/events.ts
@@ -17,7 +17,6 @@ export type LogEvents = {
   }
   'notifications:openApp': {}
   'notifications:request': {
-    logContext: 'StartOnboarding' | 'AfterOnboarding'
     status: 'granted' | 'denied' | 'undetermined'
   }
   'state:background': {

--- a/src/lib/statsig/events.ts
+++ b/src/lib/statsig/events.ts
@@ -68,6 +68,10 @@ export type LogEvents = {
   }
   'composer:gif:open': {}
   'composer:gif:select': {}
+  'notifications:request': {
+    logContext: 'StartOnboarding' | 'AfterOnboarding'
+    status: 'granted' | 'denied' | 'undetermined'
+  }
 
   // Data events
   'account:create:begin': {}

--- a/src/lib/statsig/gates.ts
+++ b/src/lib/statsig/gates.ts
@@ -5,6 +5,7 @@ export type Gate =
   | 'disable_poll_on_discover_v2'
   | 'dms'
   | 'reduced_onboarding_and_home_algo'
+  | 'request_notifications_permission_after_onboarding'
   | 'show_follow_back_label_v2'
   | 'start_session_with_following_v2'
   | 'test_gate_1'

--- a/src/screens/Onboarding/StepInterests/index.tsx
+++ b/src/screens/Onboarding/StepInterests/index.tsx
@@ -5,11 +5,12 @@ import {useLingui} from '@lingui/react'
 import {useQuery} from '@tanstack/react-query'
 
 import {useAnalytics} from '#/lib/analytics/analytics'
-import {logEvent} from '#/lib/statsig/statsig'
+import {logEvent, useGate} from '#/lib/statsig/statsig'
 import {capitalize} from '#/lib/strings/capitalize'
 import {logger} from '#/logger'
 import {useAgent} from '#/state/session'
 import {useOnboardingDispatch} from '#/state/shell'
+import {useRequestNotificationsPermission} from 'lib/notifications/notifications'
 import {
   DescriptionText,
   OnboardingControls,
@@ -33,6 +34,9 @@ export function StepInterests() {
   const t = useTheme()
   const {gtMobile} = useBreakpoints()
   const {track} = useAnalytics()
+  const gate = useGate()
+  const requestNotificationsPermission = useRequestNotificationsPermission()
+
   const {state, dispatch, interestsDisplayNames} = React.useContext(Context)
   const [saving, setSaving] = React.useState(false)
   const [interests, setInterests] = React.useState<string[]>(
@@ -128,6 +132,15 @@ export function StepInterests() {
     track('OnboardingV2:Begin')
     track('OnboardingV2:StepInterests:Start')
   }, [track])
+
+  React.useEffect(() => {
+    if (
+      !gate('reduced_onboarding_and_home_algo') &&
+      !gate('request_notifications_permission_after_onboarding')
+    ) {
+      requestNotificationsPermission('StartOnboarding')
+    }
+  }, [gate, requestNotificationsPermission])
 
   const title = isError ? (
     <Trans>Oh no! Something went wrong.</Trans>

--- a/src/screens/Onboarding/StepInterests/index.tsx
+++ b/src/screens/Onboarding/StepInterests/index.tsx
@@ -134,10 +134,7 @@ export function StepInterests() {
   }, [track])
 
   React.useEffect(() => {
-    if (
-      !gate('reduced_onboarding_and_home_algo') &&
-      !gate('request_notifications_permission_after_onboarding')
-    ) {
+    if (!gate('reduced_onboarding_and_home_algo')) {
       requestNotificationsPermission('StartOnboarding')
     }
   }, [gate, requestNotificationsPermission])

--- a/src/screens/Onboarding/StepProfile/index.tsx
+++ b/src/screens/Onboarding/StepProfile/index.tsx
@@ -10,11 +10,12 @@ import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
 import {useAnalytics} from '#/lib/analytics/analytics'
-import {logEvent} from '#/lib/statsig/statsig'
+import {logEvent, useGate} from '#/lib/statsig/statsig'
 import {usePhotoLibraryPermission} from 'lib/hooks/usePermissions'
 import {compressIfNeeded} from 'lib/media/manip'
 import {openCropper} from 'lib/media/picker'
 import {getDataUriSize} from 'lib/media/util'
+import {useRequestNotificationsPermission} from 'lib/notifications/notifications'
 import {isNative, isWeb} from 'platform/detection'
 import {
   DescriptionText,
@@ -69,6 +70,9 @@ export function StepProfile() {
   const {gtMobile} = useBreakpoints()
   const {track} = useAnalytics()
   const {requestPhotoAccessIfNeeded} = usePhotoLibraryPermission()
+  const gate = useGate()
+  const requestNotificationsPermission = useRequestNotificationsPermission()
+
   const creatorControl = Dialog.useDialogControl()
   const [error, setError] = React.useState('')
 
@@ -85,6 +89,17 @@ export function StepProfile() {
   React.useEffect(() => {
     track('OnboardingV2:StepProfile:Start')
   }, [track])
+
+  React.useEffect(() => {
+    // We have an experiment running for redueced onboarding, where this screen shows up as the first in onboarding.
+    // We only want to request permissions when that gate is actually active to prevent pollution
+    if (
+      gate('reduced_onboarding_and_home_algo') &&
+      !gate('request_notifications_permission_after_onboarding')
+    ) {
+      requestNotificationsPermission('StartOnboarding')
+    }
+  }, [gate, requestNotificationsPermission])
 
   const openPicker = React.useCallback(
     async (opts?: ImagePickerOptions) => {

--- a/src/screens/Onboarding/StepProfile/index.tsx
+++ b/src/screens/Onboarding/StepProfile/index.tsx
@@ -93,10 +93,7 @@ export function StepProfile() {
   React.useEffect(() => {
     // We have an experiment running for redueced onboarding, where this screen shows up as the first in onboarding.
     // We only want to request permissions when that gate is actually active to prevent pollution
-    if (
-      gate('reduced_onboarding_and_home_algo') &&
-      !gate('request_notifications_permission_after_onboarding')
-    ) {
+    if (gate('reduced_onboarding_and_home_algo')) {
       requestNotificationsPermission('StartOnboarding')
     }
   }, [gate, requestNotificationsPermission])

--- a/src/view/screens/Home.tsx
+++ b/src/view/screens/Home.tsx
@@ -120,7 +120,6 @@ function HomeScreenReady({
     }),
   )
 
-  const gate = useGate()
   const mode = useMinimalShellMode()
   const {isMobile} = useWebMediaQueries()
   useFocusEffect(

--- a/src/view/screens/Home.tsx
+++ b/src/view/screens/Home.tsx
@@ -76,10 +76,8 @@ function HomeScreenReady({
   useOTAUpdates()
 
   React.useEffect(() => {
-    if (gate('request_notifications_permission_after_onboarding')) {
-      requestNotificationsPermission('AfterOnboarding')
-    }
-  }, [gate, requestNotificationsPermission])
+    requestNotificationsPermission('AfterOnboarding')
+  }, [requestNotificationsPermission])
 
   const pagerRef = React.useRef<PagerRef>(null)
   const lastPagerReportedIndexRef = React.useRef(selectedIndex)

--- a/src/view/screens/Home.tsx
+++ b/src/view/screens/Home.tsx
@@ -72,6 +72,7 @@ function HomeScreenReady({
   const selectedIndex = Math.max(0, maybeFoundIndex)
   const selectedFeed = allFeeds[selectedIndex]
 
+  useSetTitle(pinnedFeedInfos[selectedIndex]?.displayName)
   useOTAUpdates()
 
   React.useEffect(() => {
@@ -79,8 +80,6 @@ function HomeScreenReady({
       requestNotificationsPermission('AfterOnboarding')
     }
   }, [gate, requestNotificationsPermission])
-
-  useSetTitle(pinnedFeedInfos[selectedIndex]?.displayName)
 
   const pagerRef = React.useRef<PagerRef>(null)
   const lastPagerReportedIndexRef = React.useRef(selectedIndex)

--- a/src/view/screens/Home.tsx
+++ b/src/view/screens/Home.tsx
@@ -20,6 +20,7 @@ import {
 } from '#/state/shell'
 import {useSelectedFeed, useSetSelectedFeed} from '#/state/shell/selected-feed'
 import {useOTAUpdates} from 'lib/hooks/useOTAUpdates'
+import {useRequestNotificationsPermission} from 'lib/notifications/notifications'
 import {HomeTabNavigatorParams, NativeStackScreenProps} from 'lib/routes/types'
 import {FeedPage} from 'view/com/feeds/FeedPage'
 import {Pager, PagerRef, RenderTabBarFnProps} from 'view/com/pager/Pager'
@@ -58,7 +59,9 @@ function HomeScreenReady({
   preferences: UsePreferencesQueryResponse
   pinnedFeedInfos: SavedFeedSourceInfo[]
 }) {
-  useOTAUpdates()
+  const gate = useGate()
+  const requestNotificationsPermission = useRequestNotificationsPermission()
+
   const allFeeds = React.useMemo(
     () => pinnedFeedInfos.map(f => f.feedDescriptor),
     [pinnedFeedInfos],
@@ -68,6 +71,14 @@ function HomeScreenReady({
   const maybeFoundIndex = allFeeds.indexOf(rawSelectedFeed)
   const selectedIndex = Math.max(0, maybeFoundIndex)
   const selectedFeed = allFeeds[selectedIndex]
+
+  useOTAUpdates()
+
+  React.useEffect(() => {
+    if (gate('request_notifications_permission_after_onboarding')) {
+      requestNotificationsPermission('AfterOnboarding')
+    }
+  }, [gate, requestNotificationsPermission])
 
   useSetTitle(pinnedFeedInfos[selectedIndex]?.displayName)
 

--- a/src/view/shell/index.tsx
+++ b/src/view/shell/index.tsx
@@ -61,6 +61,7 @@ function ShellInner() {
   const closeAnyActiveElement = useCloseAnyActiveElement()
   const {importantForAccessibility} = useDialogStateContext()
 
+  useNotificationsRegistration()
   useNotificationsHandler()
 
   React.useEffect(() => {
@@ -74,8 +75,6 @@ function ShellInner() {
       listener.remove()
     }
   }, [closeAnyActiveElement])
-
-  useNotificationsRegistration()
 
   return (
     <>

--- a/src/view/shell/index.tsx
+++ b/src/view/shell/index.tsx
@@ -13,7 +13,7 @@ import * as NavigationBar from 'expo-navigation-bar'
 import {StatusBar} from 'expo-status-bar'
 import {useNavigationState} from '@react-navigation/native'
 
-import {useAgent, useSession} from '#/state/session'
+import {useSession} from '#/state/session'
 import {
   useIsDrawerOpen,
   useIsDrawerSwipeDisabled,
@@ -22,7 +22,7 @@ import {
 import {useCloseAnyActiveElement} from '#/state/util'
 import {useNotificationsHandler} from 'lib/hooks/useNotificationHandler'
 import {usePalette} from 'lib/hooks/usePalette'
-import * as notifications from 'lib/notifications/notifications'
+import {useNotificationsRegistration} from 'lib/notifications/notifications'
 import {isStateAtTabRoot} from 'lib/routes/helpers'
 import {useTheme} from 'lib/ThemeContext'
 import {isAndroid} from 'platform/detection'
@@ -57,12 +57,9 @@ function ShellInner() {
     [setIsDrawerOpen],
   )
   const canGoBack = useNavigationState(state => !isStateAtTabRoot(state))
-  const {hasSession, currentAccount} = useSession()
-  const {getAgent} = useAgent()
+  const {hasSession} = useSession()
   const closeAnyActiveElement = useCloseAnyActiveElement()
   const {importantForAccessibility} = useDialogStateContext()
-  // start undefined
-  const currentAccountDid = React.useRef<string | undefined>(undefined)
 
   useNotificationsHandler()
 
@@ -78,18 +75,7 @@ function ShellInner() {
     }
   }, [closeAnyActiveElement])
 
-  React.useEffect(() => {
-    // only runs when did changes
-    if (currentAccount && currentAccountDid.current !== currentAccount.did) {
-      currentAccountDid.current = currentAccount.did
-      notifications.requestPermissionsAndRegisterToken(getAgent, currentAccount)
-      const unsub = notifications.registerTokenChangeHandler(
-        getAgent,
-        currentAccount,
-      )
-      return unsub
-    }
-  }, [currentAccount, getAgent])
+  useNotificationsRegistration()
 
   return (
     <>


### PR DESCRIPTION
## Why

Asking for permissions randomly at the start of onboarding can be pretty jarring and might result in more denials of permission. Instead, we can ask for permission after onboarding is complete.

We also want to be able to track this, so I have:

1. Added a feature gate on whether to show this at the start of onboarding or afterward
  - Display it on the interests screen of onboarding if the reduced onboarding gate is false
  - Display it on the profile screen of onboarding if the reduced onboarding gate is true
2. Added a new log type - `notifications:request`
  - Accepts a `status` with values `granted`, `denied`, or `undetermined` - the default values for Expo Notifications

On top of these changes, I am fixing/cleaning up some other logic. On main right now, we can see that we are registering the push token multiple times on app launch:

<img width="523" alt="Screenshot 2024-05-11 at 11 11 46 PM" src="https://github.com/bluesky-social/social-app/assets/153161762/1e224c62-5529-4fb8-8978-9614eed98ad3">

As noted below, that is because we are

1. Getting the device push token and registering it
2. Creating a listener that calls register token whenever the token changes. Whenever it changes, we register the new token (the one we just retrieved in step one!)

Instead, what I have done is call `getDevicePushToken()` on DID change _without_ registering it, then let the change listener handle the registration. This is the result:

<img width="480" alt="Screenshot 2024-05-11 at 11 14 54 PM" src="https://github.com/bluesky-social/social-app/assets/153161762/e192acfd-103f-4bce-a75a-065c97108673">

## Test Plan

Different gate configurations should be tested:

### Reduced Onboarding: False, Request After Onboarding: False

https://github.com/bluesky-social/social-app/assets/153161762/bc741932-dfa6-4220-a9a0-18fc46c78548

### Reduced Onboarding: True, Request After Onboarding: False

https://github.com/bluesky-social/social-app/assets/153161762/4485930b-54c5-4e7f-920a-1a2a18acf1d3

### Reduced Onboarding: True/False, Request After Onboarding: True

https://github.com/bluesky-social/social-app/assets/153161762/90e7d40f-dfbe-4ae0-a765-dd1103b2e177
