### PR TITLE
get a little more accurate with month length

### DIFF
--- a/__tests__/lib/string.test.ts
+++ b/__tests__/lib/string.test.ts
@@ -143,6 +143,10 @@ describe('makeRecordUri', () => {
 })
 
 describe('ago', () => {
+  const oneYearDate = new Date(
+    new Date().setMonth(new Date().getMonth() - 11),
+  ).setDate(new Date().getDate() - 28)
+
   const inputs = [
     1671461038,
     '04 Dec 1995 00:12:00 GMT',
@@ -151,7 +155,27 @@ describe('ago', () => {
     new Date().setMinutes(new Date().getMinutes() - 10),
     new Date().setHours(new Date().getHours() - 1),
     new Date().setDate(new Date().getDate() - 1),
+    new Date().setDate(new Date().getDate() - 20),
+    new Date().setDate(new Date().getDate() - 25),
+    new Date().setDate(new Date().getDate() - 28),
     new Date().setMonth(new Date().getMonth() - 1),
+    new Date(new Date().setMonth(new Date().getMonth() - 1)).setDate(
+      new Date().getDate() - 20,
+    ),
+    new Date(new Date().setMonth(new Date().getMonth() - 1)).setDate(
+      new Date().getDate() - 25,
+    ),
+    new Date(new Date().setMonth(new Date().getMonth() - 1)).setDate(
+      new Date().getDate() - 28,
+    ),
+    new Date().setMonth(new Date().getMonth() - 11),
+    new Date(new Date().setMonth(new Date().getMonth() - 11)).setDate(
+      new Date().getDate() - 20,
+    ),
+    new Date(new Date().setMonth(new Date().getMonth() - 11)).setDate(
+      new Date().getDate() - 25,
+    ),
+    oneYearDate,
   ]
   const outputs = [
     new Date(1671461038).toLocaleDateString(),
@@ -161,7 +185,17 @@ describe('ago', () => {
     '10m',
     '1h',
     '1d',
+    '20d',
+    '25d',
+    '28d',
     '1mo',
+    '1mo',
+    '1mo',
+    '2mo',
+    '11mo',
+    '11mo',
+    '11mo',
+    new Date(oneYearDate).toLocaleDateString(),
   ]
 
   it('correctly calculates how much time passed, in a string', () => {

--- a/__tests__/lib/string.test.ts
+++ b/__tests__/lib/string.test.ts
@@ -158,6 +158,8 @@ describe('ago', () => {
     new Date().setDate(new Date().getDate() - 20),
     new Date().setDate(new Date().getDate() - 25),
     new Date().setDate(new Date().getDate() - 28),
+    new Date().setDate(new Date().getDate() - 29),
+    new Date().setDate(new Date().getDate() - 30),
     new Date().setMonth(new Date().getMonth() - 1),
     new Date(new Date().setMonth(new Date().getMonth() - 1)).setDate(
       new Date().getDate() - 20,
@@ -167,6 +169,9 @@ describe('ago', () => {
     ),
     new Date(new Date().setMonth(new Date().getMonth() - 1)).setDate(
       new Date().getDate() - 28,
+    ),
+    new Date(new Date().setMonth(new Date().getMonth() - 1)).setDate(
+      new Date().getDate() - 29,
     ),
     new Date().setMonth(new Date().getMonth() - 11),
     new Date(new Date().setMonth(new Date().getMonth() - 11)).setDate(
@@ -188,9 +193,12 @@ describe('ago', () => {
     '20d',
     '25d',
     '28d',
+    '29d',
     '1mo',
     '1mo',
     '1mo',
+    '1mo',
+    '2mo',
     '2mo',
     '11mo',
     '11mo',

--- a/src/lib/strings/time.ts
+++ b/src/lib/strings/time.ts
@@ -2,8 +2,8 @@ const NOW = 5
 const MINUTE = 60
 const HOUR = MINUTE * 60
 const DAY = HOUR * 24
+const MONTH_30 = DAY * 30
 const MONTH = DAY * 30.41675 // This results in 365.001 days in a year, which is close enough for nearly all cases
-const YEAR = DAY * 365
 export function ago(date: number | string | Date): string {
   let ts: number
   if (typeof date === 'string') {
@@ -22,12 +22,21 @@ export function ago(date: number | string | Date): string {
     return `${Math.floor(diffSeconds / MINUTE)}m`
   } else if (diffSeconds < DAY) {
     return `${Math.floor(diffSeconds / HOUR)}h`
-  } else if (diffSeconds < MONTH) {
+  } else if (diffSeconds < MONTH_30) {
     return `${Math.round(diffSeconds / DAY)}d`
-  } else if (diffSeconds < YEAR) {
-    return `${Math.floor(diffSeconds / MONTH)}mo`
   } else {
-    return new Date(ts).toLocaleDateString()
+    let months = diffSeconds / MONTH
+    if (months % 1 >= 0.9) {
+      months = Math.ceil(months)
+    } else {
+      months = Math.floor(months)
+    }
+
+    if (months < 12) {
+      return `${months}mo`
+    } else {
+      return new Date(ts).toLocaleDateString()
+    }
   }
 }
 

--- a/src/lib/strings/time.ts
+++ b/src/lib/strings/time.ts
@@ -2,7 +2,7 @@ const NOW = 5
 const MINUTE = 60
 const HOUR = MINUTE * 60
 const DAY = HOUR * 24
-const MONTH = DAY * 28
+const MONTH = DAY * 30.41675 // This results in 365.001 days in a year, which is close enough for nearly all cases
 const YEAR = DAY * 365
 export function ago(date: number | string | Date): string {
   let ts: number


### PR DESCRIPTION
## Why

Because we are assuming months have 28 days, we're starting to see some cases like this:

![image](https://github.com/bluesky-social/social-app/assets/153161762/13fa1a0a-1452-4fd7-86ab-63395ae10e3d)

Obviously, we know that a year cannot have 13 months in it, but we're starting to encounter cases like this because...well it was just Bluesky's "mainstream" birthday!

So, what do we want to do instead?

- Keep the same logic as before for anything under 30 days
	- 29 days should be `29d`
	- 30 days should be `1mo`
- Anything like 1 month and 15 days, 1 month and 20 days, etc. should display `1mo` in most cases.
- As we approach 28, 29, or 30 days, we can show the next month, i.e. 1 month and 19 days should show `2mo`
- As we reach the end of the year, we should not show `12mo` but instead begin showing the full date. I.e. 11 months and 29 days should show `4/20/24`
- As before, anything over a year old should also show the localized date string.

## Test Plan

<img width="213" alt="Screenshot 2024-05-12 at 6 14 14 PM" src="https://github.com/bluesky-social/social-app/assets/153161762/12fc078a-e5f8-4578-834f-e6411eba12d1">


I have added a variety of test cases to `string.test.ts`. Remember, this still is not _precise_, but it more closely resembles reality - especially as we get into the later months or as in this case the "13 months" case. If we truly want to be precise, 
we would either need to write some additional (annoying) logic or use a library like dayjs which is a little overkill for this purpose.

Of course feel free to tweak this however you feel like.