### PR TITLE
actually register token on permissions change

### DIFF
--- a/src/lib/notifications/notifications.ts
+++ b/src/lib/notifications/notifications.ts
@@ -37,9 +37,10 @@ async function registerPushToken(
   }
 }
 
-async function getPushToken() {
-  const permissions = await Notifications.getPermissionsAsync()
-  if (permissions.granted) {
+async function getPushToken(skipPermissionCheck = false) {
+  const granted =
+    skipPermissionCheck || (await Notifications.getPermissionsAsync()).granted
+  if (granted) {
     Notifications.getDevicePushTokenAsync()
   }
 }
@@ -99,8 +100,10 @@ export function useRequestNotificationsPermission() {
         status: res.status,
       })
 
-      // This will fire a pushTokenEvent, which will handle registration of the token
-      getPushToken()
+      if (res.granted) {
+        // This will fire a pushTokenEvent, which will handle registration of the token
+        getPushToken(true)
+      }
     },
     [gate],
   )

--- a/src/lib/notifications/notifications.ts
+++ b/src/lib/notifications/notifications.ts
@@ -45,10 +45,7 @@ async function getPushToken() {
 }
 
 export function useNotificationsRegistration() {
-  const [currentPermissions] = Notifications.usePermissions()
   const {getAgent} = useAgent()
-
-  // WARNING This is not reactive. Current permissions change will not cause a re-render
   const {currentAccount} = useSession()
 
   React.useEffect(() => {
@@ -67,22 +64,20 @@ export function useNotificationsRegistration() {
     return () => {
       subscription.remove()
     }
-  }, [currentAccount, currentPermissions, getAgent])
+  }, [currentAccount, getAgent])
 }
 
 export function useRequestNotificationsPermission() {
   const gate = useGate()
 
-  // WARNING This is not reactive. Current permissions change will not cause a re-render
-  const [currentPermissions] = Notifications.usePermissions()
-
   return React.useCallback(
     async (context: 'StartOnboarding' | 'AfterOnboarding') => {
+      const permissions = await Notifications.getPermissionsAsync()
+
       if (
         !isNative ||
-        currentPermissions?.status === 'granted' ||
-        (currentPermissions?.status === 'denied' &&
-          !currentPermissions?.canAskAgain)
+        permissions?.status === 'granted' ||
+        (permissions?.status === 'denied' && !permissions?.canAskAgain)
       ) {
         return
       }
@@ -107,6 +102,6 @@ export function useRequestNotificationsPermission() {
       // This will fire a pushTokenEvent, which will handle registration of the token
       getPushToken()
     },
-    [currentPermissions, gate],
+    [gate],
   )
 }

--- a/src/lib/notifications/notifications.ts
+++ b/src/lib/notifications/notifications.ts
@@ -101,6 +101,7 @@ export function useRequestNotificationsPermission() {
       })
 
       if (res.granted) {
+        // This will fire a pushTokenEvent, which will handle registration of the token
         Notifications.getDevicePushTokenAsync()
       }
     },

--- a/src/lib/notifications/notifications.ts
+++ b/src/lib/notifications/notifications.ts
@@ -37,6 +37,13 @@ async function registerPushToken(
   }
 }
 
+async function getPushToken() {
+  const permissions = await Notifications.getPermissionsAsync()
+  if (permissions.granted) {
+    Notifications.getDevicePushTokenAsync()
+  }
+}
+
 export function useNotificationsRegistration() {
   const [currentPermissions] = Notifications.usePermissions()
   const {getAgent} = useAgent()
@@ -49,10 +56,7 @@ export function useNotificationsRegistration() {
       return
     }
 
-    // Whenever we all `getDevicePushTokenAsync()`, a change event will be fired below
-    if (currentPermissions?.status === 'granted') {
-      Notifications.getDevicePushTokenAsync()
-    }
+    getPushToken()
 
     // According to the Expo docs, there is a chance that the token will change while the app is open in some rare
     // cases. This will fire `registerPushToken` whenever that happens.
@@ -100,10 +104,8 @@ export function useRequestNotificationsPermission() {
         status: res.status,
       })
 
-      if (res.granted) {
-        // This will fire a pushTokenEvent, which will handle registration of the token
-        Notifications.getDevicePushTokenAsync()
-      }
+      // This will fire a pushTokenEvent, which will handle registration of the token
+      getPushToken()
     },
     [currentPermissions, gate],
   )


### PR DESCRIPTION
## Why

Follow up to https://github.com/bluesky-social/social-app/pull/3977

While testing on a physical device, it became apparent that `currentPermissions` does _not_ cause a re-render when used in this way

```tsx
const [currentPermissions] = Notifications.usePermissions()

React.useEffect(() => {
	console.log('change')
}, [currentPermissions])
```

As a result, we don't end up registering a push token immediately when relying on `currentPermissions` to result in `getDevicePushTokenAsync()` being called.

We already know that calling `getDevicePushTokenAsync()` fires a `PushTokenEvent`. Therefore, what we want to do is call the `getDevicePushTokenAsync()` as soon as we receive the request response, instead of relying on the `useEffect` to re-run.

## Test Plan

We should see `Sent push token (init)` logged as soon as the permissions are granted for push notifications. The best way to test this flow is on a real device with the following flow:

1. Create a new account
2. Go through onboarding and approve push notifications
3. Close/background the application
4. From another device, follow the new account that you just made
5. Make sure that you got a notification