### PR TITLE
[Reduced Onboarding] Fix forward/backward nav with profile step

### DIFF
--- a/src/lib/statsig/events.ts
+++ b/src/lib/statsig/events.ts
@@ -53,6 +53,9 @@ export type LogEvents = {
   'onboarding:moderation:nextPressed': {}
   'onboarding:profile:nextPressed': {}
   'onboarding:finished:nextPressed': {}
+  'onboarding:finished:avatarResult': {
+    avatarResult: 'default' | 'created' | 'uploaded'
+  }
   'home:feedDisplayed': {
     feedUrl: string
     feedType: string

--- a/src/screens/Onboarding/StepFinished.tsx
+++ b/src/screens/Onboarding/StepFinished.tsx
@@ -134,6 +134,14 @@ export function StepFinished() {
               return existing
             })
           }
+
+          logEvent('onboarding:finished:avatarResult', {
+            avatarResult: profileStepResults.isCreatedAvatar
+              ? 'created'
+              : profileStepResults.image
+              ? 'uploaded'
+              : 'default',
+          })
         })(),
       ])
     } catch (e: any) {

--- a/src/screens/Onboarding/StepProfile/index.tsx
+++ b/src/screens/Onboarding/StepProfile/index.tsx
@@ -144,6 +144,7 @@ export function StepProfile() {
         image: avatar.image,
         imageUri,
         imageMime: avatar.image?.mime ?? 'image/jpeg',
+        isCreatedAvatar: avatar.useCreatedAvatar,
       })
     }
 

--- a/src/screens/Onboarding/StepProfile/index.tsx
+++ b/src/screens/Onboarding/StepProfile/index.tsx
@@ -79,9 +79,10 @@ export function StepProfile() {
   const {state, dispatch} = React.useContext(Context)
   const [avatar, setAvatar] = React.useState<Avatar>({
     image: state.profileStepResults?.image,
-    placeholder: emojiItems.at,
-    backgroundColor: randomColor,
-    useCreatedAvatar: false,
+    placeholder: state.profileStepResults.creatorState?.emoji || emojiItems.at,
+    backgroundColor:
+      state.profileStepResults.creatorState?.backgroundColor || randomColor,
+    useCreatedAvatar: state.profileStepResults.isCreatedAvatar,
   })
 
   const canvasRef = React.useRef<PlaceholderCanvasRef>(null)
@@ -145,17 +146,22 @@ export function StepProfile() {
         imageUri,
         imageMime: avatar.image?.mime ?? 'image/jpeg',
         isCreatedAvatar: avatar.useCreatedAvatar,
+        creatorState: {
+          emoji: avatar.placeholder,
+          backgroundColor: avatar.backgroundColor,
+        },
       })
     }
 
     dispatch({type: 'next'})
     track('OnboardingV2:StepProfile:End')
     logEvent('onboarding:profile:nextPressed', {})
-  }, [avatar.image, avatar.useCreatedAvatar, dispatch, track])
+  }, [avatar, dispatch, track])
 
   const onDoneCreating = React.useCallback(() => {
     setAvatar(prev => ({
       ...prev,
+      image: undefined,
       useCreatedAvatar: true,
     }))
     creatorControl.close()

--- a/src/screens/Onboarding/state.ts
+++ b/src/screens/Onboarding/state.ts
@@ -31,6 +31,7 @@ export type OnboardingState = {
     feedUris: string[]
   }
   profileStepResults: {
+    isCreatedAvatar: boolean
     image?: {
       path: string
       mime: string
@@ -72,6 +73,7 @@ export type OnboardingAction =
     }
   | {
       type: 'setProfileStepResults'
+      isCreatedAvatar: boolean
       image?: OnboardingState['profileStepResults']['image']
       imageUri: string
       imageMime: string
@@ -111,6 +113,7 @@ export const initialState: OnboardingState = {
     feedUris: [],
   },
   profileStepResults: {
+    isCreatedAvatar: false,
     image: undefined,
     imageUri: '',
     imageMime: '',
@@ -286,6 +289,7 @@ export const initialStateReduced: OnboardingState = {
     feedUris: [],
   },
   profileStepResults: {
+    isCreatedAvatar: false,
     image: undefined,
     imageUri: '',
     imageMime: '',
@@ -341,6 +345,7 @@ export function reducerReduced(
     }
     case 'setProfileStepResults': {
       next.profileStepResults = {
+        isCreatedAvatar: a.isCreatedAvatar,
         image: a.image,
         imageUri: a.imageUri,
         imageMime: a.imageMime,

--- a/src/screens/Onboarding/state.ts
+++ b/src/screens/Onboarding/state.ts
@@ -1,6 +1,7 @@
 import React from 'react'
 
 import {logger} from '#/logger'
+import {AvatarColor, Emoji} from '#/screens/Onboarding/StepProfile/types'
 
 export type OnboardingState = {
   hasPrev: boolean
@@ -41,6 +42,10 @@ export type OnboardingState = {
     }
     imageUri?: string
     imageMime?: string
+    creatorState?: {
+      emoji: Emoji
+      backgroundColor: AvatarColor
+    }
   }
 }
 
@@ -77,6 +82,10 @@ export type OnboardingAction =
       image?: OnboardingState['profileStepResults']['image']
       imageUri: string
       imageMime: string
+      creatorState?: {
+        emoji: Emoji
+        backgroundColor: string
+      }
     }
 
 export type ApiResponseMap = {
@@ -349,6 +358,7 @@ export function reducerReduced(
         image: a.image,
         imageUri: a.imageUri,
         imageMime: a.imageMime,
+        creatorState: a.creatorState,
       }
       break
     }

--- a/src/screens/Onboarding/state.ts
+++ b/src/screens/Onboarding/state.ts
@@ -84,7 +84,7 @@ export type OnboardingAction =
       imageMime: string
       creatorState?: {
         emoji: Emoji
-        backgroundColor: string
+        backgroundColor: AvatarColor
       }
     }
 


### PR DESCRIPTION
Initially made this work with the image, but realized when adding metrics that it didn't work for created avatars. This PR ensures that whatever your last choice was, it retains that state when navigating forward and backward through onboarding.

Lint error fixed in #3999, will merge that into this before merging into main.