### PR TITLE
Tweak feed card styles

### DIFF
--- a/src/view/com/feeds/FeedSourceCard.tsx
+++ b/src/view/com/feeds/FeedSourceCard.tsx
@@ -211,10 +211,10 @@ export function FeedSourceCardLoaded({
             <UserAvatar type="algo" size={36} avatar={feed.avatar} />
           </View>
           <View style={[styles.headerTextContainer]}>
-            <Text style={[pal.text, s.bold]} numberOfLines={3}>
+            <Text style={[pal.text, s.bold]} numberOfLines={1}>
               {feed.displayName}
             </Text>
-            <Text style={[pal.textLight]} numberOfLines={3}>
+            <Text style={[pal.textLight]} numberOfLines={1}>
               {feed.type === 'feed' ? (
                 <Trans>Feed by {sanitizeHandle(feed.creatorHandle, '@')}</Trans>
               ) : (


### PR DESCRIPTION
Small tweaks to #3998 

No real changes to desktop, so just mobile screenshots.

This PR adjusts `FeedSourceCard` to truncate the display name and `Feed by` text to 1 line. This would affect rendering in other locations in the app.

However, `displayName` for a feed gen is limited to 24 graphemes, so this is really only an issue on small screens.

For the `Feed by` text, this could be much longer, but as you can see with a long handle, the wrapping is pretty bad. When clicking into a feed detail screen, this text is shown in full.

### After:
![CleanShot 2024-05-13 at 17 17 15@2x](https://github.com/bluesky-social/social-app/assets/4732330/154271c1-80c0-4023-87cb-bf4145bc856e)
![CleanShot 2024-05-13 at 17 22 55@2x](https://github.com/bluesky-social/social-app/assets/4732330/cc6cc5c6-1c2e-467a-80f5-37aeb004dcd3)
![CleanShot 2024-05-13 at 17 23 22@2x](https://github.com/bluesky-social/social-app/assets/4732330/0b0ecd65-e499-4a8a-9116-8fa1f78d875d)

### Before:
![CleanShot 2024-05-13 at 17 25 15@2x](https://github.com/bluesky-social/social-app/assets/4732330/fa29310f-7e49-4823-89a4-83c01d80d3fd)
![CleanShot 2024-05-13 at 17 25 00@2x](https://github.com/bluesky-social/social-app/assets/4732330/bb77e00c-cfa5-42a6-b32d-cca24fa6d743)
