### PR TITLE
add a `Login` notifications request

### DIFF
--- a/src/lib/notifications/notifications.ts
+++ b/src/lib/notifications/notifications.ts
@@ -72,7 +72,7 @@ export function useRequestNotificationsPermission() {
   const gate = useGate()
 
   return React.useCallback(
-    async (context: 'StartOnboarding' | 'AfterOnboarding') => {
+    async (context: 'StartOnboarding' | 'AfterOnboarding' | 'Login') => {
       const permissions = await Notifications.getPermissionsAsync()
 
       if (
@@ -97,6 +97,7 @@ export function useRequestNotificationsPermission() {
 
       const res = await Notifications.requestPermissionsAsync()
       logEvent('notifications:request', {
+        context: context,
         status: res.status,
       })
 

--- a/src/lib/statsig/events.ts
+++ b/src/lib/statsig/events.ts
@@ -17,6 +17,7 @@ export type LogEvents = {
   }
   'notifications:openApp': {}
   'notifications:request': {
+    context: 'StartOnboarding' | 'AfterOnboarding' | 'Login'
     status: 'granted' | 'denied' | 'undetermined'
   }
   'state:background': {

--- a/src/screens/Login/LoginForm.tsx
+++ b/src/screens/Login/LoginForm.tsx
@@ -19,6 +19,7 @@ import {cleanError} from '#/lib/strings/errors'
 import {createFullHandle} from '#/lib/strings/handles'
 import {logger} from '#/logger'
 import {useSessionApi} from '#/state/session'
+import {useRequestNotificationsPermission} from 'lib/notifications/notifications'
 import {atoms as a, useTheme} from '#/alf'
 import {Button, ButtonIcon, ButtonText} from '#/components/Button'
 import {FormError} from '#/components/forms/FormError'
@@ -65,6 +66,7 @@ export const LoginForm = ({
   const passwordInputRef = useRef<TextInput>(null)
   const {_} = useLingui()
   const {login} = useSessionApi()
+  const requestNotificationsPermission = useRequestNotificationsPermission()
 
   const onPressSelectService = React.useCallback(() => {
     Keyboard.dismiss()
@@ -111,6 +113,7 @@ export const LoginForm = ({
         },
         'LoginForm',
       )
+      requestNotificationsPermission('Login')
     } catch (e: any) {
       const errMsg = e.toString()
       LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut)


### PR DESCRIPTION
Add another log context for notifications request, for 'Login'. Don't want this to conflict with events for `StartOnboarding` or `AfterOnboarding`