### PR TITLE
[🐴] Make status checks easier, fix load state

### DIFF
--- a/src/components/dms/MessageMenu.tsx
+++ b/src/components/dms/MessageMenu.tsx
@@ -7,8 +7,7 @@ import {useLingui} from '@lingui/react'
 
 import {richTextToString} from '#/lib/strings/rich-text-helpers'
 import {isWeb} from 'platform/detection'
-import {useConvo} from 'state/messages/convo'
-import {ConvoStatus} from 'state/messages/convo/types'
+import {useConvoActive} from 'state/messages/convo'
 import {useSession} from 'state/session'
 import * as Toast from '#/view/com/util/Toast'
 import {atoms as a, useTheme} from '#/alf'
@@ -34,7 +33,7 @@ export let MessageMenu = ({
   const {_} = useLingui()
   const t = useTheme()
   const {currentAccount} = useSession()
-  const convo = useConvo()
+  const convo = useConvoActive()
   const deleteControl = usePromptControl()
   const retryDeleteControl = usePromptControl()
   const reportControl = usePromptControl()
@@ -55,8 +54,6 @@ export let MessageMenu = ({
   }, [_, message.text, message.facets])
 
   const onDelete = React.useCallback(() => {
-    if (convo.status !== ConvoStatus.Ready) return
-
     LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut)
     convo
       .deleteMessage(message.id)

--- a/src/screens/Messages/Conversation/MessagesList.tsx
+++ b/src/screens/Messages/Conversation/MessagesList.tsx
@@ -7,8 +7,8 @@ import {AppBskyRichtextFacet, RichText} from '@atproto/api'
 
 import {shortenLinks} from '#/lib/strings/rich-text-manip'
 import {isNative} from '#/platform/detection'
-import {useConvo} from '#/state/messages/convo'
-import {ConvoItem, ConvoStatus} from '#/state/messages/convo/types'
+import {useConvoActive} from '#/state/messages/convo'
+import {ConvoItem} from '#/state/messages/convo/types'
 import {useAgent} from '#/state/session'
 import {ScrollProvider} from 'lib/ScrollContext'
 import {isWeb} from 'platform/detection'
@@ -60,7 +60,7 @@ function onScrollToIndexFailed() {
 }
 
 export function MessagesList() {
-  const convo = useConvo()
+  const convo = useConvoActive()
   const {getAgent} = useAgent()
   const flatListRef = useRef<FlatList>(null)
 
@@ -128,7 +128,7 @@ export function MessagesList() {
   // The check for `hasInitiallyScrolled` prevents an initial fetch on mount. FlatList triggers `onStartReached`
   // immediately on mount, since we are in fact at an offset of zero, so we have to ignore those initial calls.
   const onStartReached = useCallback(() => {
-    if (convo.status === ConvoStatus.Ready && hasInitiallyScrolled.value) {
+    if (hasInitiallyScrolled.value) {
       convo.fetchMessageHistory()
     }
   }, [convo, hasInitiallyScrolled])
@@ -150,12 +150,10 @@ export function MessagesList() {
         return true
       })
 
-      if (convo.status === ConvoStatus.Ready) {
-        convo.sendMessage({
-          text: rt.text,
-          facets: rt.facets,
-        })
-      }
+      convo.sendMessage({
+        text: rt.text,
+        facets: rt.facets,
+      })
     },
     [convo, getAgent],
   )

--- a/src/screens/Messages/Conversation/index.tsx
+++ b/src/screens/Messages/Conversation/index.tsx
@@ -15,7 +15,7 @@ import {useGate} from '#/lib/statsig/statsig'
 import {useCurrentConvoId} from '#/state/messages/current-convo-id'
 import {BACK_HITSLOP} from 'lib/constants'
 import {isIOS, isWeb} from 'platform/detection'
-import {ConvoProvider, isConvoReady, useConvo} from 'state/messages/convo'
+import {ConvoProvider, isConvoActive, useConvo} from 'state/messages/convo'
 import {ConvoStatus} from 'state/messages/convo/types'
 import {PreviewableUserAvatar} from 'view/com/util/UserAvatar'
 import {CenteredView} from 'view/com/util/Views'
@@ -72,7 +72,7 @@ function Inner() {
   React.useEffect(() => {
     if (
       !hasInitiallyRendered &&
-      isConvoReady(convoState) &&
+      isConvoActive(convoState) &&
       !convoState.isFetchingHistory
     ) {
       setTimeout(() => {
@@ -108,7 +108,7 @@ function Inner() {
         <CenteredView style={a.flex_1} sideBorders>
           <Header profile={convoState.recipients?.[0]} />
           <View style={[a.flex_1]}>
-            {isConvoReady(convoState) ? (
+            {isConvoActive(convoState) ? (
               <MessagesList />
             ) : (
               <ListMaybePlaceholder isLoading />
@@ -230,7 +230,7 @@ let Header = ({
           </>
         )}
       </View>
-      {isConvoReady(convoState) && profile ? (
+      {isConvoActive(convoState) && profile ? (
         <ConvoMenu
           convo={convoState.convo}
           profile={profile}

--- a/src/screens/Messages/Conversation/index.tsx
+++ b/src/screens/Messages/Conversation/index.tsx
@@ -15,7 +15,7 @@ import {useGate} from '#/lib/statsig/statsig'
 import {useCurrentConvoId} from '#/state/messages/current-convo-id'
 import {BACK_HITSLOP} from 'lib/constants'
 import {isIOS, isWeb} from 'platform/detection'
-import {ConvoProvider, useConvo} from 'state/messages/convo'
+import {ConvoProvider, isConvoReady, useConvo} from 'state/messages/convo'
 import {ConvoStatus} from 'state/messages/convo/types'
 import {PreviewableUserAvatar} from 'view/com/util/UserAvatar'
 import {CenteredView} from 'view/com/util/Views'
@@ -72,14 +72,14 @@ function Inner() {
   React.useEffect(() => {
     if (
       !hasInitiallyRendered &&
-      convoState.status === ConvoStatus.Ready &&
+      isConvoReady(convoState) &&
       !convoState.isFetchingHistory
     ) {
       setTimeout(() => {
         setHasInitiallyRendered(true)
       }, 15)
     }
-  }, [convoState.isFetchingHistory, convoState.status, hasInitiallyRendered])
+  }, [convoState, hasInitiallyRendered])
 
   if (convoState.status === ConvoStatus.Error) {
     return (
@@ -108,10 +108,10 @@ function Inner() {
         <CenteredView style={a.flex_1} sideBorders>
           <Header profile={convoState.recipients?.[0]} />
           <View style={[a.flex_1]}>
-            {convoState.status !== ConvoStatus.Ready ? (
-              <ListMaybePlaceholder isLoading />
-            ) : (
+            {isConvoReady(convoState) ? (
               <MessagesList />
+            ) : (
+              <ListMaybePlaceholder isLoading />
             )}
             {!hasInitiallyRendered && (
               <View
@@ -230,7 +230,7 @@ let Header = ({
           </>
         )}
       </View>
-      {convoState.status === ConvoStatus.Ready && profile ? (
+      {isConvoReady(convoState) && profile ? (
         <ConvoMenu
           convo={convoState.convo}
           profile={profile}

--- a/src/state/messages/convo/index.tsx
+++ b/src/state/messages/convo/index.tsx
@@ -39,7 +39,7 @@ export function useConvoActive() {
   }
   if (!isConvoActive(ctx)) {
     throw new Error(
-      `useConvoActive must only be rendered when the Convo is ready. Current status: ${ctx.status}`,
+      `useConvoActive must only be rendered when the Convo is ready.`,
     )
   }
   return ctx

--- a/src/state/messages/convo/index.tsx
+++ b/src/state/messages/convo/index.tsx
@@ -6,7 +6,9 @@ import {Convo} from '#/state/messages/convo/agent'
 import {
   ConvoParams,
   ConvoState,
-  ConvoStatus,
+  ConvoStateBackgrounded,
+  ConvoStateReady,
+  ConvoStateSuspended,
 } from '#/state/messages/convo/types'
 import {isConvoActive} from '#/state/messages/convo/util'
 import {useMessagesEventBus} from '#/state/messages/events'
@@ -31,9 +33,10 @@ export function useConvo() {
  * and ready for resumption.
  */
 export function useConvoActive() {
-  const ctx = useContext(ChatContext) as ConvoState & {
-    status: ConvoStatus.Ready | ConvoStatus.Backgrounded | ConvoStatus.Suspended
-  }
+  const ctx = useContext(ChatContext) as
+    | ConvoStateReady
+    | ConvoStateBackgrounded
+    | ConvoStateSuspended
   if (!ctx) {
     throw new Error('useConvo must be used within a ConvoProvider')
   }

--- a/src/state/messages/convo/index.tsx
+++ b/src/state/messages/convo/index.tsx
@@ -8,7 +8,7 @@ import {
   ConvoState,
   ConvoStatus,
 } from '#/state/messages/convo/types'
-import {isConvoReady} from '#/state/messages/convo/util'
+import {isConvoActive} from '#/state/messages/convo/util'
 import {useMessagesEventBus} from '#/state/messages/events'
 import {useMarkAsReadMutation} from '#/state/queries/messages/conversation'
 import {useAgent} from '#/state/session'
@@ -25,6 +25,11 @@ export function useConvo() {
   return ctx
 }
 
+/**
+ * This hook should only be used when the Convo is "active", meaning the chat
+ * is loaded and ready to be used, or its in a suspended or background state,
+ * and ready for resumption.
+ */
 export function useConvoActive() {
   const ctx = useContext(ChatContext) as ConvoState & {
     status: ConvoStatus.Ready | ConvoStatus.Backgrounded | ConvoStatus.Suspended
@@ -32,7 +37,7 @@ export function useConvoActive() {
   if (!ctx) {
     throw new Error('useConvo must be used within a ConvoProvider')
   }
-  if (!isConvoReady(ctx)) {
+  if (!isConvoActive(ctx)) {
     throw new Error(
       `useConvoActive must only be rendered when the Convo is ready. Current status: ${ctx.status}`,
     )

--- a/src/state/messages/convo/index.tsx
+++ b/src/state/messages/convo/index.tsx
@@ -3,10 +3,17 @@ import {AppState} from 'react-native'
 import {useFocusEffect, useIsFocused} from '@react-navigation/native'
 
 import {Convo} from '#/state/messages/convo/agent'
-import {ConvoParams, ConvoState} from '#/state/messages/convo/types'
+import {
+  ConvoParams,
+  ConvoState,
+  ConvoStatus,
+} from '#/state/messages/convo/types'
+import {isConvoReady} from '#/state/messages/convo/util'
 import {useMessagesEventBus} from '#/state/messages/events'
 import {useMarkAsReadMutation} from '#/state/queries/messages/conversation'
 import {useAgent} from '#/state/session'
+
+export * from '#/state/messages/convo/util'
 
 const ChatContext = React.createContext<ConvoState | null>(null)
 
@@ -14,6 +21,21 @@ export function useConvo() {
   const ctx = useContext(ChatContext)
   if (!ctx) {
     throw new Error('useConvo must be used within a ConvoProvider')
+  }
+  return ctx
+}
+
+export function useConvoActive() {
+  const ctx = useContext(ChatContext) as ConvoState & {
+    status: ConvoStatus.Ready | ConvoStatus.Backgrounded | ConvoStatus.Suspended
+  }
+  if (!ctx) {
+    throw new Error('useConvo must be used within a ConvoProvider')
+  }
+  if (!isConvoReady(ctx)) {
+    throw new Error(
+      `useConvoActive must only be rendered when the Convo is ready. Current status: ${ctx.status}`,
+    )
   }
   return ctx
 }

--- a/src/state/messages/convo/types.ts
+++ b/src/state/messages/convo/types.ts
@@ -107,82 +107,88 @@ export type ConvoItem =
       retry: () => void
     }
 
+type DeleteMessage = (messageId: string) => Promise<void>
+type SendMessage = (
+  message: ChatBskyConvoSendMessage.InputSchema['message'],
+) => Promise<void>
+type FetchMessageHistory = () => Promise<void>
+
+export type ConvoStateUninitialized = {
+  status: ConvoStatus.Uninitialized
+  items: []
+  convo: undefined
+  error: undefined
+  sender: undefined
+  recipients: undefined
+  isFetchingHistory: false
+  deleteMessage: undefined
+  sendMessage: undefined
+  fetchMessageHistory: undefined
+}
+export type ConvoStateInitializing = {
+  status: ConvoStatus.Initializing
+  items: []
+  convo: undefined
+  error: undefined
+  sender: undefined
+  recipients: undefined
+  isFetchingHistory: boolean
+  deleteMessage: undefined
+  sendMessage: undefined
+  fetchMessageHistory: undefined
+}
+export type ConvoStateReady = {
+  status: ConvoStatus.Ready
+  items: ConvoItem[]
+  convo: ChatBskyConvoDefs.ConvoView
+  error: undefined
+  sender: AppBskyActorDefs.ProfileViewBasic
+  recipients: AppBskyActorDefs.ProfileViewBasic[]
+  isFetchingHistory: boolean
+  deleteMessage: DeleteMessage
+  sendMessage: SendMessage
+  fetchMessageHistory: FetchMessageHistory
+}
+export type ConvoStateBackgrounded = {
+  status: ConvoStatus.Backgrounded
+  items: ConvoItem[]
+  convo: ChatBskyConvoDefs.ConvoView
+  error: undefined
+  sender: AppBskyActorDefs.ProfileViewBasic
+  recipients: AppBskyActorDefs.ProfileViewBasic[]
+  isFetchingHistory: boolean
+  deleteMessage: DeleteMessage
+  sendMessage: SendMessage
+  fetchMessageHistory: FetchMessageHistory
+}
+export type ConvoStateSuspended = {
+  status: ConvoStatus.Suspended
+  items: ConvoItem[]
+  convo: ChatBskyConvoDefs.ConvoView
+  error: undefined
+  sender: AppBskyActorDefs.ProfileViewBasic
+  recipients: AppBskyActorDefs.ProfileViewBasic[]
+  isFetchingHistory: boolean
+  deleteMessage: DeleteMessage
+  sendMessage: SendMessage
+  fetchMessageHistory: FetchMessageHistory
+}
+export type ConvoStateError = {
+  status: ConvoStatus.Error
+  items: []
+  convo: undefined
+  error: any
+  sender: undefined
+  recipients: undefined
+  isFetchingHistory: false
+  deleteMessage: undefined
+  sendMessage: undefined
+  fetchMessageHistory: undefined
+}
 export type ConvoState =
-  | {
-      status: ConvoStatus.Uninitialized
-      items: []
-      convo: undefined
-      error: undefined
-      sender: undefined
-      recipients: undefined
-      isFetchingHistory: false
-      deleteMessage: undefined
-      sendMessage: undefined
-      fetchMessageHistory: undefined
-    }
-  | {
-      status: ConvoStatus.Initializing
-      items: []
-      convo: undefined
-      error: undefined
-      sender: undefined
-      recipients: undefined
-      isFetchingHistory: boolean
-      deleteMessage: undefined
-      sendMessage: undefined
-      fetchMessageHistory: undefined
-    }
-  | {
-      status: ConvoStatus.Ready
-      items: ConvoItem[]
-      convo: ChatBskyConvoDefs.ConvoView
-      error: undefined
-      sender: AppBskyActorDefs.ProfileViewBasic
-      recipients: AppBskyActorDefs.ProfileViewBasic[]
-      isFetchingHistory: boolean
-      deleteMessage: (messageId: string) => Promise<void>
-      sendMessage: (
-        message: ChatBskyConvoSendMessage.InputSchema['message'],
-      ) => void
-      fetchMessageHistory: () => void
-    }
-  | {
-      status: ConvoStatus.Suspended
-      items: ConvoItem[]
-      convo: ChatBskyConvoDefs.ConvoView
-      error: undefined
-      sender: AppBskyActorDefs.ProfileViewBasic
-      recipients: AppBskyActorDefs.ProfileViewBasic[]
-      isFetchingHistory: boolean
-      deleteMessage: (messageId: string) => Promise<void>
-      sendMessage: (
-        message: ChatBskyConvoSendMessage.InputSchema['message'],
-      ) => Promise<void>
-      fetchMessageHistory: () => Promise<void>
-    }
-  | {
-      status: ConvoStatus.Backgrounded
-      items: ConvoItem[]
-      convo: ChatBskyConvoDefs.ConvoView
-      error: undefined
-      sender: AppBskyActorDefs.ProfileViewBasic
-      recipients: AppBskyActorDefs.ProfileViewBasic[]
-      isFetchingHistory: boolean
-      deleteMessage: (messageId: string) => Promise<void>
-      sendMessage: (
-        message: ChatBskyConvoSendMessage.InputSchema['message'],
-      ) => Promise<void>
-      fetchMessageHistory: () => Promise<void>
-    }
-  | {
-      status: ConvoStatus.Error
-      items: []
-      convo: undefined
-      error: any
-      sender: undefined
-      recipients: undefined
-      isFetchingHistory: false
-      deleteMessage: undefined
-      sendMessage: undefined
-      fetchMessageHistory: undefined
-    }
+  | ConvoStateUninitialized
+  | ConvoStateInitializing
+  | ConvoStateReady
+  | ConvoStateBackgrounded
+  | ConvoStateSuspended
+  | ConvoStateError

--- a/src/state/messages/convo/util.ts
+++ b/src/state/messages/convo/util.ts
@@ -1,6 +1,11 @@
 import {ConvoState, ConvoStatus} from './types'
 
-export function isConvoReady(convo: ConvoState) {
+/**
+ * Checks if a `Convo` has a `status` that is "active", meaning the chat is
+ * loaded and ready to be used, or its in a suspended or background state, and
+ * ready for resumption.
+ */
+export function isConvoActive(convo: ConvoState) {
   return (
     convo.status === ConvoStatus.Ready ||
     convo.status === ConvoStatus.Backgrounded ||

--- a/src/state/messages/convo/util.ts
+++ b/src/state/messages/convo/util.ts
@@ -1,11 +1,19 @@
-import {ConvoState, ConvoStatus} from './types'
+import {
+  ConvoState,
+  ConvoStateBackgrounded,
+  ConvoStateReady,
+  ConvoStateSuspended,
+  ConvoStatus,
+} from './types'
 
 /**
  * Checks if a `Convo` has a `status` that is "active", meaning the chat is
  * loaded and ready to be used, or its in a suspended or background state, and
  * ready for resumption.
  */
-export function isConvoActive(convo: ConvoState) {
+export function isConvoActive(
+  convo: ConvoState,
+): convo is ConvoStateReady | ConvoStateBackgrounded | ConvoStateSuspended {
   return (
     convo.status === ConvoStatus.Ready ||
     convo.status === ConvoStatus.Backgrounded ||

--- a/src/state/messages/convo/util.ts
+++ b/src/state/messages/convo/util.ts
@@ -1,0 +1,9 @@
+import {ConvoState, ConvoStatus} from './types'
+
+export function isConvoReady(convo: ConvoState) {
+  return (
+    convo.status === ConvoStatus.Ready ||
+    convo.status === ConvoStatus.Backgrounded ||
+    convo.status === ConvoStatus.Suspended
+  )
+}


### PR DESCRIPTION
One of the goals of the `Convo` agent is to help prevent invalid states and invalid prop access. This PR adds a couple utils to help with this:
- `isConvoActive` — checks if the `Convo` is in an active `status`
- `useConvoActive` — provides assurance that `isConvoActive(convo)` is true

This helps when creating UI, so that we don't always need to check `Convo.status`, and with load states for the same reason.

See below where the convo no longer re-initializes when backgrounded.

https://github.com/bluesky-social/social-app/assets/4732330/93fce095-c9ae-41f5-b9f2-1ba40531064c