### PR TITLE
[🐴] Blocks/mutes and revalidation

### DIFF
--- a/src/components/dms/ConvoMenu.tsx
+++ b/src/components/dms/ConvoMenu.tsx
@@ -54,6 +54,7 @@ let ConvoMenu = ({
   const t = useTheme()
   const leaveConvoControl = Prompt.usePromptControl()
   const reportControl = Prompt.usePromptControl()
+  const blockedByListControl = Prompt.usePromptControl()
   const {mutate: markAsRead} = useMarkAsReadMutation()
 
   const {data: convo} = useConvoQuery(initialConvo)
@@ -82,9 +83,15 @@ let ConvoMenu = ({
     useAwaitedProfileUnblockMutation()
   const isBlockMutationPending = isBlockPending || isUnblockPending
   const isBlocking = Boolean(profile.viewer?.blocking)
+  const isBlockedByList = Boolean(profile.viewer?.blockingByList)
 
   const toggleBlock = useCallback(async () => {
     if (isBlockMutationPending) return
+
+    if (isBlockedByList) {
+      blockedByListControl.open()
+      return
+    }
 
     if (profile.viewer?.blocking) {
       await unblockProfile({
@@ -102,6 +109,8 @@ let ConvoMenu = ({
     blockProfile,
     unblockProfile,
     onUpdateConvo,
+    isBlockedByList,
+    blockedByListControl,
   ])
 
   const {mutate: leaveConvo} = useLeaveConvo(convo?.id, {
@@ -231,6 +240,16 @@ let ConvoMenu = ({
         title={_(msg`Report conversation`)}
         description={_(
           msg`To report a conversation, please report one of its messages via the conversation screen. This lets our moderators understand the context of your issue.`,
+        )}
+        confirmButtonCta={_(msg`I understand`)}
+        onConfirm={noop}
+      />
+
+      <Prompt.Basic
+        control={blockedByListControl}
+        title={_(msg`Blocked by list`)}
+        description={_(
+          msg`This user is blocked by one of your moderation lists. You can unblock them from the moderation list settings.`,
         )}
         confirmButtonCta={_(msg`I understand`)}
         onConfirm={noop}

--- a/src/screens/Messages/Conversation/index.tsx
+++ b/src/screens/Messages/Conversation/index.tsx
@@ -98,6 +98,7 @@ function Inner() {
    * Any other convo states (atm) are "ready" states
    */
 
+  console.log(convoState.blocks)
   return (
     <KeyboardProvider>
       <KeyboardAvoidingView
@@ -242,6 +243,7 @@ let Header = ({
           convo={convoState.convo}
           profile={profile}
           currentScreen="conversation"
+          onUpdateConvo={convoState.revalidateConvo}
         />
       ) : (
         <View style={{width: 30}} />

--- a/src/screens/Messages/Conversation/index.tsx
+++ b/src/screens/Messages/Conversation/index.tsx
@@ -98,7 +98,6 @@ function Inner() {
    * Any other convo states (atm) are "ready" states
    */
 
-  console.log(convoState.blocks)
   return (
     <KeyboardProvider>
       <KeyboardAvoidingView

--- a/src/screens/Messages/List/ChatListItem.tsx
+++ b/src/screens/Messages/List/ChatListItem.tsx
@@ -4,9 +4,11 @@ import {ChatBskyConvoDefs} from '@atproto/api'
 import {msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 import {useNavigation} from '@react-navigation/native'
+import {useQueryClient} from '@tanstack/react-query'
 
 import {NavigationProp} from '#/lib/routes/types'
 import {isNative} from '#/platform/detection'
+import {RQKEY as ListConvosQueryKey} from '#/state/queries/messages/list-converations'
 import {useSession} from '#/state/session'
 import {TimeElapsed} from '#/view/com/util/TimeElapsed'
 import {UserAvatar} from '#/view/com/util/UserAvatar'
@@ -36,6 +38,7 @@ export function ChatListItem({
   const displayName = isDeletedAccount
     ? 'Deleted Account'
     : otherUser?.displayName || otherUser?.handle
+  const queryClient = useQueryClient()
 
   let lastMessage = _(msg`No messages yet`)
   let lastMessageSentAt: string | null = null
@@ -72,6 +75,10 @@ export function ChatListItem({
       conversation: convo.id,
     })
   }, [convo.id, navigation])
+
+  const onUpdateConvo = React.useCallback(() => {
+    queryClient.invalidateQueries({queryKey: ListConvosQueryKey})
+  }, [queryClient])
 
   if (!otherUser) {
     return null
@@ -204,6 +211,7 @@ export function ChatListItem({
                 triggerOpacity={
                   !gtMobile || showActions || menuControl.isOpen ? 1 : 0
                 }
+                onUpdateConvo={onUpdateConvo}
               />
             </View>
           </View>

--- a/src/state/messages/convo/agent.ts
+++ b/src/state/messages/convo/agent.ts
@@ -97,6 +97,7 @@ export class Convo {
     this.sendMessage = this.sendMessage.bind(this)
     this.deleteMessage = this.deleteMessage.bind(this)
     this.fetchMessageHistory = this.fetchMessageHistory.bind(this)
+    this.revalidateConvo = this.revalidateConvo.bind(this)
     this.ingestFirehose = this.ingestFirehose.bind(this)
     this.onFirehoseConnect = this.onFirehoseConnect.bind(this)
     this.onFirehoseError = this.onFirehoseError.bind(this)
@@ -148,6 +149,7 @@ export class Convo {
           deleteMessage: undefined,
           sendMessage: undefined,
           fetchMessageHistory: undefined,
+          revalidateConvo: undefined,
         }
       }
       case ConvoStatus.Suspended:
@@ -164,6 +166,7 @@ export class Convo {
           deleteMessage: this.deleteMessage,
           sendMessage: this.sendMessage,
           fetchMessageHistory: this.fetchMessageHistory,
+          revalidateConvo: this.revalidateConvo,
         }
       }
       case ConvoStatus.Error: {
@@ -178,6 +181,7 @@ export class Convo {
           deleteMessage: undefined,
           sendMessage: undefined,
           fetchMessageHistory: undefined,
+          revalidateConvo: undefined,
         }
       }
       default: {
@@ -192,6 +196,7 @@ export class Convo {
           deleteMessage: undefined,
           sendMessage: undefined,
           fetchMessageHistory: undefined,
+          revalidateConvo: undefined,
         }
       }
     }
@@ -489,7 +494,7 @@ export class Convo {
     return this.pendingFetchConvo
   }
 
-  async refreshConvo() {
+  private async refreshConvo() {
     try {
       const {convo, sender, recipients} = await this.fetchConvo()
       // throw new Error('UNCOMMENT TO TEST REFRESH FAILURE')
@@ -508,6 +513,20 @@ export class Convo {
           this.resume()
         },
       })
+      this.commit()
+    }
+  }
+
+  async revalidateConvo() {
+    try {
+      const {convo, sender, recipients} = await this.fetchConvo()
+      // throw new Error('UNCOMMENT TO TEST REFRESH FAILURE')
+      this.convo = convo || this.convo
+      this.sender = sender || this.sender
+      this.recipients = recipients || this.recipients
+    } catch (e: any) {
+      logger.error(e, {context: `Convo: failed to revalidate convo`})
+    } finally {
       this.commit()
     }
   }

--- a/src/state/messages/convo/types.ts
+++ b/src/state/messages/convo/types.ts
@@ -124,6 +124,7 @@ export type ConvoStateUninitialized = {
   deleteMessage: undefined
   sendMessage: undefined
   fetchMessageHistory: undefined
+  revalidateConvo: undefined
 }
 export type ConvoStateInitializing = {
   status: ConvoStatus.Initializing
@@ -136,6 +137,7 @@ export type ConvoStateInitializing = {
   deleteMessage: undefined
   sendMessage: undefined
   fetchMessageHistory: undefined
+  revalidateConvo: undefined
 }
 export type ConvoStateReady = {
   status: ConvoStatus.Ready
@@ -148,6 +150,7 @@ export type ConvoStateReady = {
   deleteMessage: DeleteMessage
   sendMessage: SendMessage
   fetchMessageHistory: FetchMessageHistory
+  revalidateConvo: () => void
 }
 export type ConvoStateBackgrounded = {
   status: ConvoStatus.Backgrounded
@@ -160,6 +163,7 @@ export type ConvoStateBackgrounded = {
   deleteMessage: DeleteMessage
   sendMessage: SendMessage
   fetchMessageHistory: FetchMessageHistory
+  revalidateConvo: () => void
 }
 export type ConvoStateSuspended = {
   status: ConvoStatus.Suspended
@@ -172,6 +176,7 @@ export type ConvoStateSuspended = {
   deleteMessage: DeleteMessage
   sendMessage: SendMessage
   fetchMessageHistory: FetchMessageHistory
+  revalidateConvo: () => void
 }
 export type ConvoStateError = {
   status: ConvoStatus.Error
@@ -184,6 +189,7 @@ export type ConvoStateError = {
   deleteMessage: undefined
   sendMessage: undefined
   fetchMessageHistory: undefined
+  revalidateConvo: undefined
 }
 export type ConvoState =
   | ConvoStateUninitialized

--- a/src/state/messages/convo/types.ts
+++ b/src/state/messages/convo/types.ts
@@ -120,6 +120,7 @@ export type ConvoStateUninitialized = {
   error: undefined
   sender: undefined
   recipients: undefined
+  blocks: undefined
   isFetchingHistory: false
   deleteMessage: undefined
   sendMessage: undefined
@@ -133,6 +134,7 @@ export type ConvoStateInitializing = {
   error: undefined
   sender: undefined
   recipients: undefined
+  blocks: undefined
   isFetchingHistory: boolean
   deleteMessage: undefined
   sendMessage: undefined
@@ -146,6 +148,7 @@ export type ConvoStateReady = {
   error: undefined
   sender: AppBskyActorDefs.ProfileViewBasic
   recipients: AppBskyActorDefs.ProfileViewBasic[]
+  blocks: AppBskyActorDefs.ProfileViewBasic[]
   isFetchingHistory: boolean
   deleteMessage: DeleteMessage
   sendMessage: SendMessage
@@ -159,6 +162,7 @@ export type ConvoStateBackgrounded = {
   error: undefined
   sender: AppBskyActorDefs.ProfileViewBasic
   recipients: AppBskyActorDefs.ProfileViewBasic[]
+  blocks: AppBskyActorDefs.ProfileViewBasic[]
   isFetchingHistory: boolean
   deleteMessage: DeleteMessage
   sendMessage: SendMessage
@@ -172,6 +176,7 @@ export type ConvoStateSuspended = {
   error: undefined
   sender: AppBskyActorDefs.ProfileViewBasic
   recipients: AppBskyActorDefs.ProfileViewBasic[]
+  blocks: AppBskyActorDefs.ProfileViewBasic[]
   isFetchingHistory: boolean
   deleteMessage: DeleteMessage
   sendMessage: SendMessage
@@ -185,6 +190,7 @@ export type ConvoStateError = {
   error: any
   sender: undefined
   recipients: undefined
+  blocks: undefined
   isFetchingHistory: false
   deleteMessage: undefined
   sendMessage: undefined


### PR DESCRIPTION
This PR introduces a method on the `Convo` agent called `revalidateConvo` that re-fetches the `ConvoView` and updates state for use in the React tree. It also adds an array of `blocks` which are basic profile views, inclusive of `viewer` state, if any members of the chat are blocking each other.
