### PR TITLE
[🐴] Reset after 5 min

### DIFF
--- a/src/state/messages/convo/const.ts
+++ b/src/state/messages/convo/const.ts
@@ -1,2 +1,3 @@
 export const ACTIVE_POLL_INTERVAL = 1e3
 export const BACKGROUND_POLL_INTERVAL = 5e3
+export const INACTIVE_TIMEOUT = 60e3 * 5


### PR DESCRIPTION
Reset and re-initialize the chat after 5 minutes of inactivity. Only (potentially) runs from a `Backgrounded` to a `Ready` transition. Other `-> Ready` transitions already reset where needed.