### PR TITLE
[🐴] Remove error for refresh, not necessary

### DIFF
--- a/src/state/messages/convo/agent.ts
+++ b/src/state/messages/convo/agent.ts
@@ -517,17 +517,6 @@ export class Convo {
       this.recipients = recipients || this.recipients
     } catch (e: any) {
       logger.error(e, {context: `Convo: failed to refresh convo`})
-
-      this.footerItems.set(ConvoItemError.Network, {
-        type: 'error-recoverable',
-        key: ConvoItemError.Network,
-        code: ConvoItemError.Network,
-        retry: () => {
-          this.footerItems.delete(ConvoItemError.Network)
-          this.resume()
-        },
-      })
-      this.commit()
     }
   }
 


### PR DESCRIPTION
`refreshConvo` is used when transitioning some states just to get a fresh `ConvoView` and any updates therein. In these cases, it's not currently useful to alert the user if this fails, since failures here don't require us to update the `status` of the `Convo`.

Network failures e.g. failure to send or firehose errors are more important, and actually recoverable e.g. we need to manually re-enter a `Ready` status.

This reduces noise for the user.