### PR TITLE
[🐴] Remove keyboard controller lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -171,7 +171,6 @@
     "react-native-get-random-values": "~1.11.0",
     "react-native-image-crop-picker": "^0.38.1",
     "react-native-ios-context-menu": "^1.15.3",
-    "react-native-keyboard-controller": "^1.11.7",
     "react-native-pager-view": "6.2.3",
     "react-native-picker-select": "^8.1.0",
     "react-native-progress": "bluesky-social/react-native-progress",

--- a/src/screens/Messages/Conversation/MessageInput.tsx
+++ b/src/screens/Messages/Conversation/MessageInput.tsx
@@ -64,7 +64,7 @@ export function MessageInput({
       const keyboardHeight = Keyboard.metrics()?.height ?? 0
       const windowHeight = Dimensions.get('window').height
 
-      const max = windowHeight - keyboardHeight - topInset - 200
+      const max = windowHeight - keyboardHeight - topInset - 150
       const availableSpace = max - e.nativeEvent.contentSize.height
 
       setMaxHeight(max)
@@ -101,7 +101,6 @@ export function MessageInput({
           keyboardAppearance={t.name === 'light' ? 'light' : 'dark'}
           scrollEnabled={isInputScrollable}
           blurOnSubmit={false}
-          onFocus={scrollToEnd}
           onContentSizeChange={onInputLayout}
           ref={inputRef}
         />

--- a/src/screens/Messages/Conversation/MessageInput.tsx
+++ b/src/screens/Messages/Conversation/MessageInput.tsx
@@ -64,7 +64,7 @@ export function MessageInput({
       const keyboardHeight = Keyboard.metrics()?.height ?? 0
       const windowHeight = Dimensions.get('window').height
 
-      const max = windowHeight - keyboardHeight - topInset - 100
+      const max = windowHeight - keyboardHeight - topInset - 200
       const availableSpace = max - e.nativeEvent.contentSize.height
 
       setMaxHeight(max)

--- a/src/screens/Messages/Conversation/MessagesList.tsx
+++ b/src/screens/Messages/Conversation/MessagesList.tsx
@@ -250,8 +250,9 @@ export function MessagesList() {
           containWeb={true}
           contentContainerStyle={[a.px_md]}
           disableVirtualization={true}
-          initialNumToRender={isNative ? 30 : 60}
-          maxToRenderPerBatch={isWeb ? 30 : 60}
+          // The extra two items account for the header and the footer components
+          initialNumToRender={isNative ? 32 : 61}
+          maxToRenderPerBatch={isWeb ? 32 : 61}
           keyboardDismissMode="on-drag"
           keyboardShouldPersistTaps="handled"
           maintainVisibleContentPosition={{

--- a/src/screens/Messages/Conversation/MessagesList.tsx
+++ b/src/screens/Messages/Conversation/MessagesList.tsx
@@ -80,9 +80,7 @@ export function MessagesList() {
   // We don't want to call `scrollToEnd` again if we are already scolling to the end, because this creates a bit of jank
   // Instead, we use `onMomentumScrollEnd` and this value to determine if we need to start scrolling or not.
   const isMomentumScrolling = useSharedValue(false)
-
   const hasInitiallyScrolled = useSharedValue(false)
-
   const keyboardIsOpening = useSharedValue(false)
 
   // Every time the content size changes, that means one of two things is happening:
@@ -109,15 +107,9 @@ export function MessagesList() {
       contentHeight.value = height
 
       // This number _must_ be the height of the MaybeLoader component
-      if (height <= 50 || !isAtBottom.value) {
+      if (height <= 50 || (!isAtBottom.value && !keyboardIsOpening.value)) {
         return
       }
-
-      console.log(
-        hasInitiallyScrolled.value && !keyboardIsOpening.value,
-        hasInitiallyScrolled.value,
-        keyboardIsOpening.value,
-      )
 
       flatListRef.current?.scrollToOffset({
         animated: hasInitiallyScrolled.value && !keyboardIsOpening.value,

--- a/src/screens/Messages/Conversation/MessagesList.tsx
+++ b/src/screens/Messages/Conversation/MessagesList.tsx
@@ -113,6 +113,12 @@ export function MessagesList() {
         return
       }
 
+      console.log(
+        hasInitiallyScrolled.value && !keyboardIsOpening.value,
+        hasInitiallyScrolled.value,
+        keyboardIsOpening.value,
+      )
+
       flatListRef.current?.scrollToOffset({
         animated: hasInitiallyScrolled.value && !keyboardIsOpening.value,
         offset: height,
@@ -210,7 +216,12 @@ export function MessagesList() {
   useAnimatedReaction(
     () => animatedKeyboard.height.value,
     (now, prev) => {
-      keyboardIsOpening.value = now !== prev
+      // This never applies on web
+      if (isWeb) {
+        keyboardIsOpening.value = false
+      } else {
+        keyboardIsOpening.value = now !== prev
+      }
     },
   )
 

--- a/src/screens/Messages/Conversation/MessagesList.tsx
+++ b/src/screens/Messages/Conversation/MessagesList.tsx
@@ -219,21 +219,18 @@ export function MessagesList() {
 
   // This changes the size of the `ListFooterComponent`. Whenever this changes, the content size will change and our
   // `onContentSizeChange` function will handle scrolling to the appropriate offset.
-  const animatedFooterStyle = useAnimatedStyle(() => {
-    let height = bottomOffset
-    if (animatedKeyboard.height.value > height) {
-      height = animatedKeyboard.height.value
-    }
-    return {
-      marginBottom: height,
-    }
-  })
+  const animatedFooterStyle = useAnimatedStyle(() => ({
+    marginBottom:
+      animatedKeyboard.height.value > bottomOffset
+        ? animatedKeyboard.height.value
+        : bottomOffset,
+  }))
 
   // At a minimum we want the bottom to be whatever the height of our insets and bottom bar is. If the keyboard's height
   // is greater than that however, we use that value.
   const animatedInputStyle = useAnimatedStyle(() => ({
     bottom:
-      animatedKeyboard.height.value >= bottomOffset
+      animatedKeyboard.height.value > bottomOffset
         ? animatedKeyboard.height.value
         : bottomOffset,
   }))

--- a/src/screens/Messages/Conversation/MessagesList.tsx
+++ b/src/screens/Messages/Conversation/MessagesList.tsx
@@ -197,7 +197,7 @@ export function MessagesList() {
     requestAnimationFrame(() => {
       if (isMomentumScrolling.value) return
 
-      // flatListRef.current?.scrollToEnd({animated: true})
+      flatListRef.current?.scrollToEnd({animated: true})
       isMomentumScrolling.value = true
     })
   }, [isMomentumScrolling])

--- a/src/screens/Messages/Conversation/MessagesList.tsx
+++ b/src/screens/Messages/Conversation/MessagesList.tsx
@@ -1,7 +1,6 @@
 import React, {useCallback, useRef} from 'react'
 import {FlatList, View} from 'react-native'
-import {useKeyboardHandler} from 'react-native-keyboard-controller'
-import {runOnJS, useSharedValue} from 'react-native-reanimated'
+import {useSharedValue} from 'react-native-reanimated'
 import {ReanimatedScrollEvent} from 'react-native-reanimated/lib/typescript/reanimated2/hook/commonTypes'
 import {AppBskyRichtextFacet, RichText} from '@atproto/api'
 
@@ -186,18 +185,6 @@ export function MessagesList() {
       isMomentumScrolling.value = true
     })
   }, [isMomentumScrolling])
-
-  // This is only used inside the useKeyboardHandler because the worklet won't work with a ref directly.
-  const scrollToEndNow = React.useCallback(() => {
-    flatListRef.current?.scrollToEnd({animated: false})
-  }, [])
-
-  useKeyboardHandler({
-    onMove: () => {
-      'worklet'
-      runOnJS(scrollToEndNow)()
-    },
-  })
 
   return (
     <>

--- a/src/screens/Messages/Conversation/MessagesList.tsx
+++ b/src/screens/Messages/Conversation/MessagesList.tsx
@@ -251,8 +251,8 @@ export function MessagesList() {
           contentContainerStyle={[a.px_md]}
           disableVirtualization={true}
           // The extra two items account for the header and the footer components
-          initialNumToRender={isNative ? 32 : 61}
-          maxToRenderPerBatch={isWeb ? 32 : 61}
+          initialNumToRender={isNative ? 32 : 62}
+          maxToRenderPerBatch={isWeb ? 32 : 62}
           keyboardDismissMode="on-drag"
           keyboardShouldPersistTaps="handled"
           maintainVisibleContentPosition={{

--- a/src/screens/Messages/Conversation/index.tsx
+++ b/src/screens/Messages/Conversation/index.tsx
@@ -36,6 +36,7 @@ type Props = NativeStackScreenProps<
 >
 export function MessagesConversationScreen({route}: Props) {
   const gate = useGate()
+  const {gtMobile} = useBreakpoints()
   const setMinimalShellMode = useSetMinimalShellMode()
 
   const convoId = route.params.conversation
@@ -44,12 +45,16 @@ export function MessagesConversationScreen({route}: Props) {
   useFocusEffect(
     useCallback(() => {
       setCurrentConvoId(convoId)
-      // setMinimalShellMode(true)
+
+      if (isWeb && !gtMobile) {
+        setMinimalShellMode(true)
+      }
+
       return () => {
         setCurrentConvoId(undefined)
         setMinimalShellMode(false)
       }
-    }, [convoId, setCurrentConvoId, setMinimalShellMode]),
+    }, [gtMobile, convoId, setCurrentConvoId, setMinimalShellMode]),
   )
 
   if (!gate('dms')) return <ClipClopGate />

--- a/src/screens/Messages/Conversation/index.tsx
+++ b/src/screens/Messages/Conversation/index.tsx
@@ -1,6 +1,5 @@
 import React, {useCallback} from 'react'
 import {TouchableOpacity, View} from 'react-native'
-import {useSafeAreaInsets} from 'react-native-safe-area-context'
 import {AppBskyActorDefs, moderateProfile, ModerationOpts} from '@atproto/api'
 import {FontAwesomeIcon} from '@fortawesome/react-native-fontawesome'
 import {msg} from '@lingui/macro'
@@ -16,7 +15,7 @@ import {useModerationOpts} from '#/state/preferences/moderation-opts'
 import {useProfileQuery} from '#/state/queries/profile'
 import {BACK_HITSLOP} from 'lib/constants'
 import {sanitizeDisplayName} from 'lib/strings/display-names'
-import {isIOS, isNative, isWeb} from 'platform/detection'
+import {isWeb} from 'platform/detection'
 import {ConvoProvider, isConvoActive, useConvo} from 'state/messages/convo'
 import {ConvoStatus} from 'state/messages/convo/types'
 import {useSetMinimalShellMode} from 'state/shell'
@@ -38,7 +37,6 @@ type Props = NativeStackScreenProps<
 export function MessagesConversationScreen({route}: Props) {
   const gate = useGate()
   const setMinimalShellMode = useSetMinimalShellMode()
-  const {gtMobile} = useBreakpoints()
 
   const convoId = route.params.conversation
   const {setCurrentConvoId} = useCurrentConvoId()
@@ -46,16 +44,12 @@ export function MessagesConversationScreen({route}: Props) {
   useFocusEffect(
     useCallback(() => {
       setCurrentConvoId(convoId)
-
-      if (isWeb && !gtMobile) {
-        setMinimalShellMode(true)
-      }
-
+      // setMinimalShellMode(true)
       return () => {
         setCurrentConvoId(undefined)
         setMinimalShellMode(false)
       }
-    }, [convoId, gtMobile, setCurrentConvoId, setMinimalShellMode]),
+    }, [convoId, setCurrentConvoId, setMinimalShellMode]),
   )
 
   if (!gate('dms')) return <ClipClopGate />
@@ -73,9 +67,6 @@ function Inner() {
   const {_} = useLingui()
 
   const [hasInitiallyRendered, setHasInitiallyRendered] = React.useState(false)
-
-  const {bottom: bottomInset} = useSafeAreaInsets()
-  const nativeBottomBarHeight = isIOS ? 42 : 60
 
   // HACK: Because we need to scroll to the bottom of the list once initial items are added to the list, we also have
   // to take into account that scrolling to the end of the list on native will happen asynchronously. This will cause
@@ -109,40 +100,33 @@ function Inner() {
   /*
    * Any other convo states (atm) are "ready" states
    */
-
   return (
-    <View
-      style={[
-        a.flex_1,
-        isNative && {marginBottom: bottomInset + nativeBottomBarHeight},
-      ]}>
-      <CenteredView style={a.flex_1} sideBorders>
-        <Header profile={convoState.recipients?.[0]} />
-        <View style={[a.flex_1]}>
-          {isConvoActive(convoState) ? (
-            <MessagesList />
-          ) : (
-            <ListMaybePlaceholder isLoading />
-          )}
-          {!hasInitiallyRendered && (
-            <View
-              style={[
-                a.absolute,
-                a.z_10,
-                a.w_full,
-                a.h_full,
-                a.justify_center,
-                a.align_center,
-                t.atoms.bg,
-              ]}>
-              <View style={[{marginBottom: 75}]}>
-                <Loader size="xl" />
-              </View>
+    <CenteredView style={[a.flex_1]} sideBorders>
+      <Header profile={convoState.recipients?.[0]} />
+      <View style={[a.flex_1]}>
+        {isConvoActive(convoState) ? (
+          <MessagesList />
+        ) : (
+          <ListMaybePlaceholder isLoading />
+        )}
+        {!hasInitiallyRendered && (
+          <View
+            style={[
+              a.absolute,
+              a.z_10,
+              a.w_full,
+              a.h_full,
+              a.justify_center,
+              a.align_center,
+              t.atoms.bg,
+            ]}>
+            <View style={[{marginBottom: 75}]}>
+              <Loader size="xl" />
             </View>
-          )}
-        </View>
-      </CenteredView>
-    </View>
+          </View>
+        )}
+      </View>
+    </CenteredView>
   )
 }
 

--- a/src/screens/Messages/Conversation/index.tsx
+++ b/src/screens/Messages/Conversation/index.tsx
@@ -1,7 +1,5 @@
 import React, {useCallback} from 'react'
 import {TouchableOpacity, View} from 'react-native'
-import {KeyboardProvider} from 'react-native-keyboard-controller'
-import {KeyboardAvoidingView} from 'react-native-keyboard-controller'
 import {useSafeAreaInsets} from 'react-native-safe-area-context'
 import {AppBskyActorDefs, moderateProfile, ModerationOpts} from '@atproto/api'
 import {FontAwesomeIcon} from '@fortawesome/react-native-fontawesome'
@@ -76,7 +74,7 @@ function Inner() {
 
   const [hasInitiallyRendered, setHasInitiallyRendered] = React.useState(false)
 
-  const {bottom: bottomInset, top: topInset} = useSafeAreaInsets()
+  const {bottom: bottomInset} = useSafeAreaInsets()
   const nativeBottomBarHeight = isIOS ? 42 : 60
 
   // HACK: Because we need to scroll to the bottom of the list once initial items are added to the list, we also have
@@ -113,43 +111,38 @@ function Inner() {
    */
 
   return (
-    <KeyboardProvider>
-      <KeyboardAvoidingView
-        style={[
-          a.flex_1,
-          isNative && {marginBottom: bottomInset + nativeBottomBarHeight},
-        ]}
-        keyboardVerticalOffset={isIOS ? topInset : 0}
-        behavior="padding"
-        contentContainerStyle={a.flex_1}>
-        <CenteredView style={a.flex_1} sideBorders>
-          <Header profile={convoState.recipients?.[0]} />
-          <View style={[a.flex_1]}>
-            {isConvoActive(convoState) ? (
-              <MessagesList />
-            ) : (
-              <ListMaybePlaceholder isLoading />
-            )}
-            {!hasInitiallyRendered && (
-              <View
-                style={[
-                  a.absolute,
-                  a.z_10,
-                  a.w_full,
-                  a.h_full,
-                  a.justify_center,
-                  a.align_center,
-                  t.atoms.bg,
-                ]}>
-                <View style={[{marginBottom: 75}]}>
-                  <Loader size="xl" />
-                </View>
+    <View
+      style={[
+        a.flex_1,
+        isNative && {marginBottom: bottomInset + nativeBottomBarHeight},
+      ]}>
+      <CenteredView style={a.flex_1} sideBorders>
+        <Header profile={convoState.recipients?.[0]} />
+        <View style={[a.flex_1]}>
+          {isConvoActive(convoState) ? (
+            <MessagesList />
+          ) : (
+            <ListMaybePlaceholder isLoading />
+          )}
+          {!hasInitiallyRendered && (
+            <View
+              style={[
+                a.absolute,
+                a.z_10,
+                a.w_full,
+                a.h_full,
+                a.justify_center,
+                a.align_center,
+                t.atoms.bg,
+              ]}>
+              <View style={[{marginBottom: 75}]}>
+                <Loader size="xl" />
               </View>
-            )}
-          </View>
-        </CenteredView>
-      </KeyboardAvoidingView>
-    </KeyboardProvider>
+            </View>
+          )}
+        </View>
+      </CenteredView>
+    </View>
   )
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -18496,11 +18496,6 @@ react-native-ios-context-menu@^1.15.3:
   dependencies:
     "@dominicstop/ts-event-emitter" "^1.1.0"
 
-react-native-keyboard-controller@^1.11.7:
-  version "1.11.7"
-  resolved "https://registry.yarnpkg.com/react-native-keyboard-controller/-/react-native-keyboard-controller-1.11.7.tgz#85640374e4c3627c3b667256a1d308698ff80393"
-  integrity sha512-K2zlqVyWX4QO7r+dHMQgZT41G2dSEWtDYgBdht1WVyTaMQmwTMalZcHCWBVOnzyGaJq/hMKhF1kSPqJP1xqSFA==
-
 react-native-pager-view@6.2.3:
   version "6.2.3"
   resolved "https://registry.yarnpkg.com/react-native-pager-view/-/react-native-pager-view-6.2.3.tgz#698f6387fdf06cecc3d8d4792604419cb89cb775"


### PR DESCRIPTION
## Why

The keyboard controller library we were using for this was a little glitchy and was causing some side effects on Android that would have affected the composer 😮‍💨

What I've done here is taken a look at using Reanimated's `useAnimatedKeyboard` to achieve the same effect.

`useAnimatedKeyboard` has a shared value containing the current height of the keyboard at any given point during the animation. We can use this value to do two things:

1. Move a "sticky input" - an input with relative positioning and with a bottom that's always the height of the keyboard
2. Adjust the size of a `ListFooterComponent`, which will provide the needed "offset" and will fire a content size changed event.

The result is something that's actually a little closer to 60FPS than what we have right now, seemingly on both platforms (testing on Android simulator shows slightly lower FPS, but on a physical device I had good results)

## Test Plan

Really just use it. There might be more tweaks we have to make over time, but I think this is a much more solid solution than what we had before.


https://github.com/bluesky-social/social-app/assets/153161762/ce1e1161-9b51-4f29-898c-4c1c334733ac


https://github.com/bluesky-social/social-app/assets/153161762/c33d2af7-7719-488e-ada4-6e82913e6a0a

