### PR TITLE
Implement prefersReducedMotion on native

### DIFF
--- a/patches/react-native-reanimated+3.6.0.patch
+++ b/patches/react-native-reanimated+3.6.0.patch
@@ -1,0 +1,30 @@
+diff --git a/node_modules/react-native-reanimated/lib/module/reanimated2/index.js b/node_modules/react-native-reanimated/lib/module/reanimated2/index.js
+index 91e49f4..c10d3fc 100644
+--- a/node_modules/react-native-reanimated/lib/module/reanimated2/index.js
++++ b/node_modules/react-native-reanimated/lib/module/reanimated2/index.js
+@@ -45,4 +45,5 @@ export { getUseOfValueInStyleWarning } from './pluginUtils';
+ export { withReanimatedTimer, advanceAnimationByTime, advanceAnimationByFrame, setUpTests, getAnimatedStyle } from './jestUtils';
+ export { LayoutAnimationConfig } from './component/LayoutAnimationConfig';
+ export { startMapper, stopMapper } from './mappers';
++export { isReducedMotion } from './PlatformChecker';
+ //# sourceMappingURL=index.js.map
+\ No newline at end of file
+diff --git a/node_modules/react-native-reanimated/lib/typescript/reanimated2/index.d.ts b/node_modules/react-native-reanimated/lib/typescript/reanimated2/index.d.ts
+index 96bd913..ad63a09 100644
+--- a/node_modules/react-native-reanimated/lib/typescript/reanimated2/index.d.ts
++++ b/node_modules/react-native-reanimated/lib/typescript/reanimated2/index.d.ts
+@@ -33,3 +33,4 @@ export type { Adaptable, AdaptTransforms, AnimateProps, AnimatedProps, AnimatedT
+ export type { AnimatedScrollViewProps } from './component/ScrollView';
+ export type { FlatListPropsWithLayout } from './component/FlatList';
+ export { startMapper, stopMapper } from './mappers';
++export { isReducedMotion } from './PlatformChecker';
+diff --git a/node_modules/react-native-reanimated/src/reanimated2/index.ts b/node_modules/react-native-reanimated/src/reanimated2/index.ts
+index 096dc05..38fc01d 100644
+--- a/node_modules/react-native-reanimated/src/reanimated2/index.ts
++++ b/node_modules/react-native-reanimated/src/reanimated2/index.ts
+@@ -271,3 +271,4 @@ export type {
+ export type { AnimatedScrollViewProps } from './component/ScrollView';
+ export type { FlatListPropsWithLayout } from './component/FlatList';
+ export { startMapper, stopMapper } from './mappers';
++export { isReducedMotion } from './PlatformChecker';
+\ No newline at end of file

--- a/src/platform/detection.ts
+++ b/src/platform/detection.ts
@@ -20,7 +20,12 @@ export const deviceLocales = dedupArray(
     .filter(code => typeof code === 'string'),
 ) as string[]
 
-export const prefersReducedMotion =
-  isWeb &&
-  // @ts-ignore we know window exists -prf
-  !global.window.matchMedia('(prefers-reduced-motion: no-preference)')?.matches
+export const prefersReducedMotion = isWeb
+  ? // @ts-ignore we know window exists -prf
+    !global.window.matchMedia('(prefers-reduced-motion: no-preference)')
+      ?.matches
+  : // @ts-expect-error this comes from reanimated but is obviously not typed
+    // this is how `useReducedMotion` is implemented, see:
+    // https://github.com/software-mansion/react-native-reanimated/blob/44d55dd3b6b92759fa820538d4f7c420bc8c2fa0/src/reanimated2/PlatformChecker.ts#L49
+    // -sfn
+    !!global._REANIMATED_IS_REDUCED_MOTION

--- a/src/platform/detection.ts
+++ b/src/platform/detection.ts
@@ -1,5 +1,5 @@
 import {Platform} from 'react-native'
-import {isReducedMotion} from 'react-native-reanimated/src/reanimated2/PlatformChecker'
+import {isReducedMotion} from 'react-native-reanimated'
 import {getLocales} from 'expo-localization'
 
 import {dedupArray} from 'lib/functions'

--- a/src/platform/detection.ts
+++ b/src/platform/detection.ts
@@ -1,4 +1,5 @@
 import {Platform} from 'react-native'
+import {isReducedMotion} from 'react-native-reanimated/src/reanimated2/PlatformChecker'
 import {getLocales} from 'expo-localization'
 
 import {dedupArray} from 'lib/functions'
@@ -20,12 +21,4 @@ export const deviceLocales = dedupArray(
     .filter(code => typeof code === 'string'),
 ) as string[]
 
-export const prefersReducedMotion = isWeb
-  ? // @ts-ignore we know window exists -prf
-    !global.window.matchMedia('(prefers-reduced-motion: no-preference)')
-      ?.matches
-  : // @ts-expect-error this comes from reanimated but is obviously not typed
-    // this is how `useReducedMotion` is implemented, see:
-    // https://github.com/software-mansion/react-native-reanimated/blob/44d55dd3b6b92759fa820538d4f7c420bc8c2fa0/src/reanimated2/PlatformChecker.ts#L49
-    // -sfn
-    !!global._REANIMATED_IS_REDUCED_MOTION
+export const prefersReducedMotion = isReducedMotion()


### PR DESCRIPTION
Currently, we only get the `prefersReducedMotion` value on web. Luckily, Reanimated has a `useReducedMotion` hook, but we need the value not in a hook. This PR uses the (internal) `isReducedMotion` function from Reanimated since it does exactly the same thing on web, and gets the value as it is at app startup on native. Check the simple implementation here

https://github.com/software-mansion/react-native-reanimated/blob/44d55dd3b6b92759fa820538d4f7c420bc8c2fa0/src/reanimated2/PlatformChecker.ts#L49

Note that the implementation of `useReducedMotion` is ultra simple and we could just call it here as not to rely on internal functions, but I think it's probably unsafe to break the rule of hooks here in case they change the implementation.

https://github.com/software-mansion/react-native-reanimated/blob/44d55dd3b6b92759fa820538d4f7c420bc8c2fa0/src/reanimated2/hook/useReducedMotion.ts#L4