### PR TITLE
Make "Notification Sounds" in Messages/Settings translatable

### DIFF
--- a/src/screens/Messages/Settings.tsx
+++ b/src/screens/Messages/Settings.tsx
@@ -77,7 +77,9 @@ export function MessagesSettingsScreen({}: Props) {
             setPref('playSoundChat', !preferences.playSoundChat)
           }}>
           <Toggle.Checkbox />
-          <Toggle.LabelText>Notification Sounds</Toggle.LabelText>
+          <Toggle.LabelText>
+            <Trans>Notification Sounds</Trans>
+          </Toggle.LabelText>
         </Toggle.Item>
       </View>
     </CenteredView>


### PR DESCRIPTION
Make "Notification Sounds" in Messages/Settings screen translatable