### PR TITLE
[🐴] delete chat service account on account delete

### DIFF
--- a/src/view/com/modals/DeleteAccount.tsx
+++ b/src/view/com/modals/DeleteAccount.tsx
@@ -11,6 +11,7 @@ import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
 import {useModalControls} from '#/state/modals'
+import {DM_SERVICE_HEADERS} from '#/state/queries/messages/const'
 import {useAgent, useSession, useSessionApi} from '#/state/session'
 import {usePalette} from 'lib/hooks/usePalette'
 import {useWebMediaQueries} from 'lib/hooks/useWebMediaQueries'
@@ -62,7 +63,12 @@ export function Component({}: {}) {
 
     try {
       // inform chat service of intent to delete account
-      const {success} = await getAgent().api.chat.bsky.actor.deleteAccount()
+      const {success} = await getAgent().api.chat.bsky.actor.deleteAccount(
+        undefined,
+        {
+          headers: DM_SERVICE_HEADERS,
+        },
+      )
       if (!success) {
         throw new Error('Failed to inform chat service of account deletion')
       }

--- a/src/view/com/modals/DeleteAccount.tsx
+++ b/src/view/com/modals/DeleteAccount.tsx
@@ -61,6 +61,11 @@ export function Component({}: {}) {
     const token = confirmCode.replace(/\s/g, '')
 
     try {
+      // inform chat service of intent to delete account
+      const {success} = await getAgent().api.chat.bsky.actor.deleteAccount()
+      if (!success) {
+        throw new Error('Failed to inform chat service of account deletion')
+      }
       await getAgent().com.atproto.server.deleteAccount({
         did: currentAccount.did,
         password,


### PR DESCRIPTION
## Dependant on https://github.com/bluesky-social/chat/pull/6

Deletes chat service account before deleting account. Throws if API call fails so that the main delete account call only happens if this one goes through

Backend not yet deployed so I have not tested it