### PR TITLE
don't show individual labels on own profile, only "have been placed..."

### DIFF
--- a/src/screens/Profile/Header/Shell.tsx
+++ b/src/screens/Profile/Header/Shell.tsx
@@ -84,9 +84,10 @@ let ProfileHeaderShell = ({
       <View
         style={[a.px_lg, a.pb_sm]}
         pointerEvents={isIOS ? 'auto' : 'box-none'}>
-        <ProfileHeaderAlerts moderation={moderation} />
-        {isMe && (
+        {isMe ? (
           <LabelsOnMe details={{did: profile.did}} labels={profile.labels} />
+        ) : (
+          <ProfileHeaderAlerts moderation={moderation} />
         )}
       </View>
 


### PR DESCRIPTION
## Why

Fixes https://github.com/bluesky-social/social-app/issues/4054

I think this showed up as a result of this: https://github.com/bluesky-social/atproto/commit/0b6f6f8636e6b9212568bdb508f8e6f61102b3e7#diff-1003892846e81d97c6492ad916b5379e6dac4e3b25c923d0a5007ec3eac08260

I think we only want to display individual labels on accounts which are _not_ our own, since on our own profile we show the appeal dialog.

## Test Plan

There's a labeler that has a applied labels to a lot of our accounts here: https://bsky.app/profile/yardcrow.com

Subscribe to that labeler and see if you have a label on your account. If you do, great. Test:

- On production, you should see both a list of labels _and_ the "placed on this account..." label
- On this branch, you should _only_ see the "placed on this account..." label
- On my profile https://bsky.app/profile/haileyok.com you should see _only_ the individual labels