### PR TITLE
Don't show notifications for logged out accounts (part one for DMs)

### DIFF
--- a/modules/BlueskyNSE/NotificationService.swift
+++ b/modules/BlueskyNSE/NotificationService.swift
@@ -6,7 +6,7 @@ class NotificationService: UNNotificationServiceExtension {
   var prefs = UserDefaults(suiteName: APP_GROUP)
 
   override func didReceive(_ request: UNNotificationRequest, withContentHandler contentHandler: @escaping (UNNotificationContent) -> Void) {
-    guard var bestAttempt = createCopy(request.content),
+    guard let bestAttempt = createCopy(request.content),
           let reason = request.content.userInfo["reason"] as? String
     else {
       contentHandler(request.content)
@@ -56,8 +56,8 @@ class NotificationService: UNNotificationServiceExtension {
   func shouldBeFiltered(_ content: UNNotificationContent, reason: String) -> Bool {
     if reason == "chat-message",
        let recipientDid = content.userInfo["recipientDid"] as? String,
-       let disabledDids = prefs?.stringArray(forKey: "disabledDids"),
-       disabledDids.contains(recipientDid)
+       let disabledDids = prefs?.dictionary(forKey: "disabledDids") as? [String:Bool],
+       disabledDids[recipientDid] == true
     {
       return true
     }

--- a/modules/BlueskyNSE/NotificationService.swift
+++ b/modules/BlueskyNSE/NotificationService.swift
@@ -13,6 +13,10 @@ class NotificationService: UNNotificationServiceExtension {
       return
     }
     
+    if shouldBeFiltered(request.content, reason: reason) {
+      return
+    }
+    
     if reason == "chat-message" {
       mutateWithChatMessage(bestAttempt)
     }
@@ -47,5 +51,17 @@ class NotificationService: UNNotificationServiceExtension {
   
   func mutateWithDmSound(_ content: UNMutableNotificationContent) {
     content.sound = UNNotificationSound(named: UNNotificationSoundName(rawValue: "dm.aiff"))
+  }
+  
+  func shouldBeFiltered(_ content: UNNotificationContent, reason: String) -> Bool {
+    if reason == "chat-message",
+       let recipientDid = content.userInfo["recipientDid"] as? String,
+       let disabledDids = prefs?.stringArray(forKey: "disabledDids"),
+       disabledDids.contains(recipientDid)
+    {
+      return true
+    }
+    
+    return false
   }
 }

--- a/modules/expo-background-notification-handler/android/build.gradle
+++ b/modules/expo-background-notification-handler/android/build.gradle
@@ -88,6 +88,5 @@ repositories {
 
 dependencies {
   implementation project(':expo-modules-core')
-  implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
   implementation 'com.google.firebase:firebase-messaging-ktx:24.0.0'
 }

--- a/modules/expo-background-notification-handler/android/src/main/java/expo/modules/backgroundnotificationhandler/BackgroundNotificationHandler.kt
+++ b/modules/expo-background-notification-handler/android/src/main/java/expo/modules/backgroundnotificationhandler/BackgroundNotificationHandler.kt
@@ -13,6 +13,10 @@ class BackgroundNotificationHandler(
       return
     }
 
+    if(shouldBeFiltered(remoteMessage)) {
+      return
+    }
+
     if (remoteMessage.data["reason"] == "chat-message") {
       mutateWithChatMessage(remoteMessage)
     }
@@ -35,5 +39,19 @@ class BackgroundNotificationHandler(
         remoteMessage.data["sound"] = null
       }
     }
+  }
+
+  private fun shouldBeFiltered(remoteMessage: RemoteMessage): Boolean {
+    if (remoteMessage.data["reason"] == "chat-message") {
+      if (
+        NotificationPrefs(context)
+          .getStringStore("disabledDids")
+          ?.contains(remoteMessage.data["recipientDid"]) == true
+      ) {
+        return true
+      }
+    }
+
+    return false
   }
 }

--- a/modules/expo-background-notification-handler/android/src/main/java/expo/modules/backgroundnotificationhandler/BackgroundNotificationHandler.kt
+++ b/modules/expo-background-notification-handler/android/src/main/java/expo/modules/backgroundnotificationhandler/BackgroundNotificationHandler.kt
@@ -45,7 +45,7 @@ class BackgroundNotificationHandler(
     if (remoteMessage.data["reason"] == "chat-message") {
       if (
         NotificationPrefs(context)
-          .getStringStore("disabledDids")
+          .getStringStore("disabledChatDids")
           ?.contains(remoteMessage.data["recipientDid"]) == true
       ) {
         return true

--- a/modules/expo-background-notification-handler/android/src/main/java/expo/modules/backgroundnotificationhandler/ExpoBackgroundNotificationHandlerModule.kt
+++ b/modules/expo-background-notification-handler/android/src/main/java/expo/modules/backgroundnotificationhandler/ExpoBackgroundNotificationHandlerModule.kt
@@ -1,5 +1,6 @@
 package expo.modules.backgroundnotificationhandler
 
+import android.util.Log
 import expo.modules.kotlin.modules.Module
 import expo.modules.kotlin.modules.ModuleDefinition
 
@@ -52,6 +53,7 @@ class ExpoBackgroundNotificationHandlerModule : Module() {
     }
 
     AsyncFunction("addToStringStoreAsync") { forKey: String, string: String ->
+      Log.d("ExpoBackgroundNotificationHandler", "addToStringStoreAsync $forKey $string")
       NotificationPrefs(appContext.reactContext).addToStringStore(forKey, string)
     }
 

--- a/modules/expo-background-notification-handler/android/src/main/java/expo/modules/backgroundnotificationhandler/ExpoBackgroundNotificationHandlerModule.kt
+++ b/modules/expo-background-notification-handler/android/src/main/java/expo/modules/backgroundnotificationhandler/ExpoBackgroundNotificationHandlerModule.kt
@@ -35,8 +35,8 @@ class ExpoBackgroundNotificationHandlerModule : Module() {
       return@AsyncFunction NotificationPrefs(appContext.reactContext).getString(forKey)
     }
 
-    AsyncFunction("getStringArrayAsync") { forKey: String ->
-      return@AsyncFunction NotificationPrefs(appContext.reactContext).getStringArray(forKey)
+    AsyncFunction("getStringStoreAsync") { forKey: String ->
+      return@AsyncFunction NotificationPrefs(appContext.reactContext).getStringStore(forKey)
     }
 
     AsyncFunction("setBoolAsync") { forKey: String, value: Boolean ->
@@ -47,24 +47,24 @@ class ExpoBackgroundNotificationHandlerModule : Module() {
       NotificationPrefs(appContext.reactContext).setString(forKey, value)
     }
 
-    AsyncFunction("setStringArrayAsync") { forKey: String, value: Array<String> ->
-      NotificationPrefs(appContext.reactContext).setStringArray(forKey, value)
+    AsyncFunction("setStringStoreAsync") { forKey: String, value: Map<String, Boolean> ->
+      NotificationPrefs(appContext.reactContext).setStringStore(forKey, value)
     }
 
-    AsyncFunction("addToStringArrayAsync") { forKey: String, string: String ->
-      NotificationPrefs(appContext.reactContext).addToStringArray(forKey, string)
+    AsyncFunction("addToStringStoreAsync") { forKey: String, string: String ->
+      NotificationPrefs(appContext.reactContext).addToStringStore(forKey, string)
     }
 
-    AsyncFunction("removeFromStringArrayAsync") { forKey: String, string: String ->
-      NotificationPrefs(appContext.reactContext).removeFromStringArray(forKey, string)
+    AsyncFunction("removeFromStringStoreAsync") { forKey: String, string: String ->
+      NotificationPrefs(appContext.reactContext).removeFromStringStore(forKey, string)
     }
 
-    AsyncFunction("addManyToStringArrayAsync") { forKey: String, strings: Array<String> ->
-      NotificationPrefs(appContext.reactContext).addManyToStringArray(forKey, strings)
+    AsyncFunction("addManyToStringStoreAsync") { forKey: String, strings: Array<String> ->
+      NotificationPrefs(appContext.reactContext).addManyToStringStore(forKey, strings)
     }
 
-    AsyncFunction("removeManyFromStringArrayAsync") { forKey: String, strings: Array<String> ->
-      NotificationPrefs(appContext.reactContext).removeManyFromStringArray(forKey, strings)
+    AsyncFunction("removeManyFromStringStoreAsync") { forKey: String, strings: Array<String> ->
+      NotificationPrefs(appContext.reactContext).removeManyFromStringStore(forKey, strings)
     }
   }
 }

--- a/modules/expo-background-notification-handler/android/src/main/java/expo/modules/backgroundnotificationhandler/NotificationPrefs.kt
+++ b/modules/expo-background-notification-handler/android/src/main/java/expo/modules/backgroundnotificationhandler/NotificationPrefs.kt
@@ -140,7 +140,7 @@ class NotificationPrefs (private val context: Context?) {
   }
 
   private fun mapToString(map: Any): String {
-    return map.toString()
+    return JSONObject(map as Map<*, *>).toString()
   }
 
   private fun stringToMap(string: String): Map<String, Boolean> {

--- a/modules/expo-background-notification-handler/android/src/main/java/expo/modules/backgroundnotificationhandler/NotificationPrefs.kt
+++ b/modules/expo-background-notification-handler/android/src/main/java/expo/modules/backgroundnotificationhandler/NotificationPrefs.kt
@@ -15,6 +15,9 @@ val DEFAULTS = mapOf(
   "disabledDids" to mapOf<String, Boolean>(),
 )
 
+val BOOL_VALS = arrayOf("playSoundChat", "playSoundFollow", "playSoundLike", "playSoundMention", "playSoundQuote", "playSoundReply", "playSoundRepost")
+val MAP_VALS = arrayOf("threadMutes", "disabledDids")
+
 class NotificationPrefs (private val context: Context?) {
   private val prefs = context?.getSharedPreferences("xyz.blueskyweb.app", Context.MODE_PRIVATE)
     ?: throw Error("Context is null")
@@ -47,8 +50,17 @@ class NotificationPrefs (private val context: Context?) {
       .apply()
   }
 
-  fun getAllPrefs(): MutableMap<String, *> {
-    return prefs.all
+  fun getAllPrefs(): MutableMap<String, Any> {
+    val map = mutableMapOf<String, Any>()
+
+    BOOL_VALS.forEach { key ->
+      prefs.getBoolean(key, false).let { map[key] = it }
+    }
+    MAP_VALS.forEach { key ->
+      prefs.getString(key, null)?.let { map[key] = stringToMap(it) }
+    }
+
+    return map
   }
 
   fun getBoolean(key: String): Boolean {

--- a/modules/expo-background-notification-handler/ios/ExpoBackgroundNotificationHandlerModule.swift
+++ b/modules/expo-background-notification-handler/ios/ExpoBackgroundNotificationHandlerModule.swift
@@ -10,8 +10,8 @@ let DEFAULTS: [String:Any] = [
   "playSoundQuote": false,
   "playSoundReply": false,
   "playSoundRepost": false,
-  "threadMutes": [:] as! [String:Bool],
-  "disabledDids": [:] as! [String:Bool],
+  "threadMutes": [:] as [String:Bool],
+  "disabledChatDids": [:] as [String:Bool],
 ]
 
 /*
@@ -58,7 +58,7 @@ public class ExpoBackgroundNotificationHandlerModule: Module {
     }
     
     AsyncFunction("getStringStoreAsync") { (forKey: String) -> [String:Bool]? in
-      if let pref = userDefaults?.object(forKey: forKey) as? [String:Bool] {
+      if let pref = userDefaults?.dictionary(forKey: forKey) as? [String:Bool] {
         return pref
       }
       return nil
@@ -77,21 +77,21 @@ public class ExpoBackgroundNotificationHandlerModule: Module {
     }
     
     AsyncFunction("addToStringStoreAsync") { (forKey: String, string: String) in
-      if var curr = userDefaults?.object(forKey: forKey) as? [String:Bool] {
+      if var curr = userDefaults?.dictionary(forKey: forKey) as? [String:Bool] {
         curr[string] = true
         userDefaults?.setValue(curr, forKey: forKey)
       }
     }
     
     AsyncFunction("removeFromStringStoreAsync") { (forKey: String, string: String) in
-      if var curr = userDefaults?.object(forKey: forKey) as? [String:Bool] {
+      if var curr = userDefaults?.dictionary(forKey: forKey) as? [String:Bool] {
         curr.removeValue(forKey: string)
         userDefaults?.setValue(curr, forKey: forKey)
       }
     }
     
     AsyncFunction("addManyToStringStoreAsync") { (forKey: String, strings: [String]) in
-      if var curr = userDefaults?.object(forKey: forKey) as? [String:Bool] {
+      if var curr = userDefaults?.dictionary(forKey: forKey) as? [String:Bool] {
         strings.forEach { s in
           curr[s] = true
         }
@@ -100,7 +100,7 @@ public class ExpoBackgroundNotificationHandlerModule: Module {
     }
     
     AsyncFunction("removeManyFromStringStoreAsync") { (forKey: String, strings: [String]) in
-      if var curr = userDefaults?.object(forKey: forKey) as? [String:Bool] {
+      if var curr = userDefaults?.dictionary(forKey: forKey) as? [String:Bool] {
         strings.forEach { s in
           curr.removeValue(forKey: s)
         }

--- a/modules/expo-background-notification-handler/src/BackgroundNotificationHandlerProvider.tsx
+++ b/modules/expo-background-notification-handler/src/BackgroundNotificationHandlerProvider.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 
+import {useSession} from 'state/session'
 import {BackgroundNotificationHandlerPreferences} from './ExpoBackgroundNotificationHandler.types'
 import {BackgroundNotificationHandler} from './ExpoBackgroundNotificationHandlerModule'
 
@@ -8,7 +9,15 @@ interface BackgroundNotificationPreferencesContext {
   setPref: <Key extends keyof BackgroundNotificationHandlerPreferences>(
     key: Key,
     value: BackgroundNotificationHandlerPreferences[Key],
-  ) => void
+  ) => Promise<void>
+  addToStringStore: (
+    key: keyof BackgroundNotificationHandlerPreferences,
+    value: string,
+  ) => Promise<void>
+  removeFromStringStore: (
+    key: keyof BackgroundNotificationHandlerPreferences,
+    value: string,
+  ) => Promise<void>
 }
 
 const Context = React.createContext<BackgroundNotificationPreferencesContext>(
@@ -22,48 +31,101 @@ export function BackgroundNotificationPreferencesProvider({
 }: {
   children: React.ReactNode
 }) {
+  const {currentAccount, accounts} = useSession()
+  const prevAccounts = React.useRef(accounts)
+
   const [preferences, setPreferences] =
     React.useState<BackgroundNotificationHandlerPreferences>({
       playSoundChat: true,
+      disabledDids: {},
     })
+
+  const setPref = React.useCallback(
+    async <Key extends keyof BackgroundNotificationHandlerPreferences>(
+      k: Key,
+      v: BackgroundNotificationHandlerPreferences[Key],
+    ) => {
+      switch (typeof v) {
+        case 'boolean': {
+          await BackgroundNotificationHandler.setBoolAsync(k, v)
+          break
+        }
+        case 'string': {
+          await BackgroundNotificationHandler.setStringAsync(k, v)
+          break
+        }
+        default: {
+          throw new Error(`Invalid type for value: ${typeof v}`)
+        }
+      }
+
+      setPreferences(prev => ({
+        ...prev,
+        [k]: v,
+      }))
+    },
+    [],
+  )
+
+  const addToStringStore = React.useCallback(
+    async (k: keyof BackgroundNotificationHandlerPreferences, v: string) => {
+      setPreferences(prev => {
+        const prevObj = prev[k]
+        if (typeof prevObj !== 'object') return prev
+
+        return {
+          ...prev,
+          [k]: {...prevObj, [v]: true},
+        }
+      })
+      await BackgroundNotificationHandler.addToStringStoreAsync(k, v)
+    },
+    [],
+  )
+
+  const removeFromStringStore = React.useCallback(
+    async (k: keyof BackgroundNotificationHandlerPreferences, v: string) => {
+      setPreferences(prev => {
+        const prevObj = prev[k]
+        if (typeof prevObj !== 'object') return prev
+
+        return {
+          ...prev,
+          [k]: {...prevObj, [v]: false},
+        }
+      })
+      await BackgroundNotificationHandler.removeFromStringStoreAsync(k, v)
+    },
+    [],
+  )
 
   React.useEffect(() => {
     ;(async () => {
+      // Always handle updates from session changes first
+      if (
+        currentAccount &&
+        !prevAccounts.current.find(
+          a => a.did === currentAccount.did && !a.refreshJwt,
+        )
+      ) {
+        await removeFromStringStore('disabledDids', currentAccount.did)
+        prevAccounts.current = accounts
+      }
+
+      // Then get all of the preferences
       const prefs = await BackgroundNotificationHandler.getAllPrefsAsync()
       setPreferences(prefs)
     })()
-  }, [])
+  }, [currentAccount, accounts, removeFromStringStore])
 
   const value = React.useMemo(
     () => ({
       preferences,
-      setPref: async <
-        Key extends keyof BackgroundNotificationHandlerPreferences,
-      >(
-        k: Key,
-        v: BackgroundNotificationHandlerPreferences[Key],
-      ) => {
-        switch (typeof v) {
-          case 'boolean': {
-            await BackgroundNotificationHandler.setBoolAsync(k, v)
-            break
-          }
-          case 'string': {
-            await BackgroundNotificationHandler.setStringAsync(k, v)
-            break
-          }
-          default: {
-            throw new Error(`Invalid type for value: ${typeof v}`)
-          }
-        }
-
-        setPreferences(prev => ({
-          ...prev,
-          [k]: v,
-        }))
-      },
+      setPref,
+      addToStringStore,
+      removeFromStringStore,
     }),
-    [preferences],
+    [preferences, setPref, addToStringStore, removeFromStringStore],
   )
 
   return <Context.Provider value={value}>{children}</Context.Provider>

--- a/modules/expo-background-notification-handler/src/ExpoBackgroundNotificationHandler.types.ts
+++ b/modules/expo-background-notification-handler/src/ExpoBackgroundNotificationHandler.types.ts
@@ -2,7 +2,7 @@ export type ExpoBackgroundNotificationHandlerModule = {
   getAllPrefsAsync: () => Promise<BackgroundNotificationHandlerPreferences>
   getBoolAsync: (forKey: string) => Promise<boolean>
   getStringAsync: (forKey: string) => Promise<string>
-  getStringArrayAsync: (forKey: string) => Promise<string[]>
+  getStringStoreAsync: (forKey: string) => Promise<Record<string, boolean>>
   setBoolAsync: (
     forKey: keyof BackgroundNotificationHandlerPreferences,
     value: boolean,
@@ -11,23 +11,23 @@ export type ExpoBackgroundNotificationHandlerModule = {
     forKey: keyof BackgroundNotificationHandlerPreferences,
     value: string,
   ) => Promise<void>
-  setStringArrayAsync: (
+  setStringStoreAsync: (
     forKey: keyof BackgroundNotificationHandlerPreferences,
-    value: string[],
+    value: Record<string, boolean>,
   ) => Promise<void>
-  addToStringArrayAsync: (
-    forKey: keyof BackgroundNotificationHandlerPreferences,
-    value: string,
-  ) => Promise<void>
-  removeFromStringArrayAsync: (
+  addToStringStoreAsync: (
     forKey: keyof BackgroundNotificationHandlerPreferences,
     value: string,
   ) => Promise<void>
-  addManyToStringArrayAsync: (
+  removeFromStringStoreAsync: (
+    forKey: keyof BackgroundNotificationHandlerPreferences,
+    value: string,
+  ) => Promise<void>
+  addManyToStringStoreAsync: (
     forKey: keyof BackgroundNotificationHandlerPreferences,
     value: string[],
   ) => Promise<void>
-  removeManyFromStringArrayAsync: (
+  removeManyFromStringStoreAsync: (
     forKey: keyof BackgroundNotificationHandlerPreferences,
     value: string[],
   ) => Promise<void>
@@ -37,4 +37,5 @@ export type ExpoBackgroundNotificationHandlerModule = {
 // Don't add them until the native logic also handles the notifications for those preference types.
 export type BackgroundNotificationHandlerPreferences = {
   playSoundChat: boolean
+  disabledDids: Record<string, boolean>
 }

--- a/src/lib/notifications/notifications.ts
+++ b/src/lib/notifications/notifications.ts
@@ -71,6 +71,7 @@ export function useNotificationsRegistration() {
 
 export function useRequestNotificationsPermission() {
   const gate = useGate()
+  const {currentAccount} = useSession()
 
   return React.useCallback(
     async (context: 'StartOnboarding' | 'AfterOnboarding' | 'Login') => {
@@ -78,6 +79,7 @@ export function useRequestNotificationsPermission() {
 
       if (
         !isNative ||
+        !currentAccount ||
         permissions?.status === 'granted' ||
         (permissions?.status === 'denied' && !permissions?.canAskAgain)
       ) {
@@ -107,7 +109,7 @@ export function useRequestNotificationsPermission() {
         getPushToken(true)
       }
     },
-    [gate],
+    [currentAccount, gate],
   )
 }
 

--- a/src/view/screens/Settings/index.tsx
+++ b/src/view/screens/Settings/index.tsx
@@ -63,6 +63,7 @@ import {useTheme} from '#/alf'
 import {useDialogControl} from '#/components/Dialog'
 import {BirthDateSettingsDialog} from '#/components/dialogs/BirthDateSettings'
 import {navigate, resetToTab} from '#/Navigation'
+import {useBackgroundNotificationPreferences} from '../../../../modules/expo-background-notification-handler/src/BackgroundNotificationHandlerProvider'
 import {Email2FAToggle} from './Email2FAToggle'
 import {ExportCarDialog} from './ExportCarDialog'
 
@@ -85,6 +86,7 @@ function SettingsAccountCard({
   const {logout} = useSessionApi()
   const {data: profile} = useProfileQuery({did: account.did})
   const isCurrentAccount = account.did === currentAccount?.did
+  const {addToStringStore} = useBackgroundNotificationPreferences()
 
   const contents = (
     <View
@@ -113,6 +115,7 @@ function SettingsAccountCard({
         <TouchableOpacity
           testID="signOutBtn"
           onPress={() => {
+            addToStringStore('disabledDids', account.did)
             if (isNative) {
               logout('Settings')
               resetToTab('HomeTab')


### PR DESCRIPTION
## Why

Notifications may be received for logged out accounts, even if we log out first. One option would be to add an endpoint to the backend such as `unregisterPushToken`, but this wouldn't be a 100% reliable method. For example, something could happen during the logout where the request for unregistering fails but the client still removes the account from the logged in sessions.

Instead, we can take advantage of the new notification handling logic to store logged out/disabled DIDs and prevent notifications for those accounts from showing up.

Right now, this will only work for DMs since we need to implement the `recipientDid` or similar in notifications as well. (We might be able to parse the subject for some types, will have to look).

For general performance reasons, I am also converting the all of the string array preference types to a map instead. These could get a little chunky for future use cases like thread mutes, so better to get ahead of that now.


https://github.com/bluesky-social/social-app/assets/153161762/f1ecd600-78b1-429d-8f1a-81107ef8e71e

