### PR TITLE
Refactor `uri` getter to use `rootItem` for clarity

### DIFF
--- a/src/lib/api/feed-manip.ts
+++ b/src/lib/api/feed-manip.ts
@@ -25,10 +25,7 @@ export class FeedViewPostsSlice {
   }
 
   get uri() {
-    if (this.isFlattenedReply) {
-      return this.items[1].post.uri
-    }
-    return this.items[0].post.uri
+    return this.rootItem.post.uri
   }
 
   get ts() {


### PR DESCRIPTION
This PR refactors the `uri` getter in the `FeedViewPostsSlice` class to improve clarity and maintainability.