### PR TITLE
Fix empty quotes in title on image-only post

### DIFF
--- a/src/view/com/post-thread/PostThread.tsx
+++ b/src/view/com/post-thread/PostThread.tsx
@@ -121,13 +121,18 @@ export function PostThread({
   )
   const [maxReplies, setMaxReplies] = React.useState(50)
 
-  useSetTitle(
-    rootPost && !isNoPwi
-      ? `${sanitizeDisplayName(
-          rootPost.author.displayName || `@${rootPost.author.handle}`,
-        )}: "${rootPostRecord!.text}"`
-      : '',
-  )
+  let title = ''
+  if (rootPost && !isNoPwi) {
+    const name = sanitizeDisplayName(
+      rootPost.author.displayName || `@${rootPost.author.handle}`,
+    )
+    if (rootPostRecord!.text?.length > 0) {
+      title = `${name}: "${rootPostRecord!.text}"`
+    } else {
+      title = _(msg`Post by ${name}`)
+    }
+  }
+  useSetTitle(title)
 
   // On native, this is going to start out `true`. We'll toggle it to `false` after the initial render if flushed.
   // This ensures that the first render contains no parents--even if they are already available in the cache.


### PR DESCRIPTION
This fixes that image-only posts show empty quotes in the page `<title>` by setting it to `Post by {name}` in that case.

Other considered solution: We could also _always_ fall back to `Post by @{handle}` like is the default for `PostThread`, but in this case we know their display name.

Example post: https://bsky.app/profile/skyeeee.bsky.social/post/3koyzqu4chh2p

## Screenshots

| Before | After |
| ------ | ----- |
| ![image](https://github.com/bluesky-social/social-app/assets/28510368/7ceb7205-cac0-4b9f-93ab-379342b83240) | ![image](https://github.com/bluesky-social/social-app/assets/28510368/118db04e-3be8-4935-aa3d-24dd2d357edc)