### PR TITLE
[🐴] DM button on profile

### DIFF
--- a/src/components/dms/MessageProfileButton.tsx
+++ b/src/components/dms/MessageProfileButton.tsx
@@ -1,44 +1,36 @@
-import React, {useCallback} from 'react'
+import React from 'react'
 import {AppBskyActorDefs} from '@atproto/api'
 import {msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
-import {useNavigation} from '@react-navigation/native'
 
-import {NavigationProp} from '#/lib/routes/types'
 import {useMaybeConvoForUser} from '#/state/queries/messages/get-convo-for-members'
-import {useTheme} from '#/alf'
-import {Envelope_Stroke2_Corner0_Rounded as Envelope} from '#/components/icons/Envelope'
-import {Button} from '../Button'
+import {atoms as a, useTheme} from '#/alf'
+import {Message_Stroke2_Corner0_Rounded as Message} from '../icons/Message'
+import {Link} from '../Link'
 
 export function MessageProfileButton({
   profile,
 }: {
   profile: AppBskyActorDefs.ProfileView
 }) {
-  const navigation = useNavigation<NavigationProp>()
   const {_} = useLingui()
   const t = useTheme()
 
   const {data: convoId} = useMaybeConvoForUser(profile.did)
 
-  const onPressDm = useCallback(() => {
-    if (!convoId) return
-    navigation.navigate('MessagesConversation', {conversation: convoId})
-  }, [navigation, convoId])
-
   if (!convoId) return null
 
   return (
-    <Button
+    <Link
       testID="dmBtn"
       size="small"
       color="secondary"
       variant="solid"
       shape="round"
-      onPress={onPressDm}
       label={_(msg`Message ${profile.handle}`)}
-      style={{width: 36, height: 36}}>
-      <Envelope style={t.atoms.text} size="md" />
-    </Button>
+      to={`/messages/${convoId}`}
+      style={[a.justify_center, {width: 36, height: 36}]}>
+      <Message style={t.atoms.text} size="md" />
+    </Link>
   )
 }

--- a/src/components/dms/MessageProfileButton.tsx
+++ b/src/components/dms/MessageProfileButton.tsx
@@ -1,0 +1,44 @@
+import React, {useCallback} from 'react'
+import {AppBskyActorDefs} from '@atproto/api'
+import {msg} from '@lingui/macro'
+import {useLingui} from '@lingui/react'
+import {useNavigation} from '@react-navigation/native'
+
+import {NavigationProp} from '#/lib/routes/types'
+import {useMaybeConvoForUser} from '#/state/queries/messages/get-convo-for-members'
+import {useTheme} from '#/alf'
+import {Envelope_Stroke2_Corner0_Rounded as Envelope} from '#/components/icons/Envelope'
+import {Button} from '../Button'
+
+export function MessageProfileButton({
+  profile,
+}: {
+  profile: AppBskyActorDefs.ProfileView
+}) {
+  const navigation = useNavigation<NavigationProp>()
+  const {_} = useLingui()
+  const t = useTheme()
+
+  const {data: convoId} = useMaybeConvoForUser(profile.did)
+
+  const onPressDm = useCallback(() => {
+    if (!convoId) return
+    navigation.navigate('MessagesConversation', {conversation: convoId})
+  }, [navigation, convoId])
+
+  if (!convoId) return null
+
+  return (
+    <Button
+      testID="dmBtn"
+      size="small"
+      color="secondary"
+      variant="solid"
+      shape="round"
+      onPress={onPressDm}
+      label={_(msg`Message ${profile.handle}`)}
+      style={{width: 36, height: 36}}>
+      <Envelope style={t.atoms.text} size="md" />
+    </Button>
+  )
+}

--- a/src/components/dms/MessageProfileButton.tsx
+++ b/src/components/dms/MessageProfileButton.tsx
@@ -30,7 +30,10 @@ export function MessageProfileButton({
       label={_(msg`Message ${profile.handle}`)}
       to={`/messages/${convoId}`}
       style={[a.justify_center, {width: 36, height: 36}]}>
-      <Message style={t.atoms.text} size="md" />
+      <Message
+        style={[t.atoms.text, {marginLeft: 1, marginBottom: 1}]}
+        size="md"
+      />
     </Link>
   )
 }

--- a/src/screens/Profile/Header/ProfileHeaderLabeler.tsx
+++ b/src/screens/Profile/Header/ProfileHeaderLabeler.tsx
@@ -128,7 +128,7 @@ let ProfileHeaderLabeler = ({
 
   const onPressSubscribe = React.useCallback(
     () =>
-      requireAuth(async () => {
+      requireAuth(async (): Promise<void> => {
         if (!canSubscribe) {
           cantSubscribePrompt.open()
           return
@@ -197,7 +197,6 @@ let ProfileHeaderLabeler = ({
                   <View
                     style={[
                       {
-                        paddingVertical: 12,
                         backgroundColor:
                           isSubscribed || !canSubscribe
                             ? state.hovered || state.pressed
@@ -207,7 +206,8 @@ let ProfileHeaderLabeler = ({
                             ? tokens.color.temp_purple_dark
                             : tokens.color.temp_purple,
                       },
-                      a.px_lg,
+                      a.py_sm,
+                      a.px_md,
                       a.rounded_sm,
                       a.gap_sm,
                     ]}>

--- a/src/screens/Profile/Header/ProfileHeaderStandard.tsx
+++ b/src/screens/Profile/Header/ProfileHeaderStandard.tsx
@@ -9,15 +9,12 @@ import {
 import {FontAwesomeIcon} from '@fortawesome/react-native-fontawesome'
 import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
-import {useNavigation} from '@react-navigation/native'
 
-import {NavigationProp} from '#/lib/routes/types'
 import {useGate} from '#/lib/statsig/statsig'
 import {logger} from '#/logger'
 import {isIOS, isWeb} from '#/platform/detection'
 import {Shadow} from '#/state/cache/types'
 import {useModalControls} from '#/state/modals'
-import {useMaybeConvoForUser} from '#/state/queries/messages/get-convo-for-members'
 import {
   useProfileBlockMutationQueue,
   useProfileFollowMutationQueue,
@@ -31,8 +28,8 @@ import {ProfileMenu} from '#/view/com/profile/ProfileMenu'
 import * as Toast from '#/view/com/util/Toast'
 import {atoms as a, useTheme} from '#/alf'
 import {Button, ButtonIcon, ButtonText} from '#/components/Button'
+import {MessageProfileButton} from '#/components/dms/MessageProfileButton'
 import {Check_Stroke2_Corner0_Rounded as Check} from '#/components/icons/Check'
-import {Envelope_Stroke2_Corner0_Rounded as Envelope} from '#/components/icons/Envelope'
 import {PlusLarge_Stroke2_Corner0_Rounded as Plus} from '#/components/icons/Plus'
 import * as Prompt from '#/components/Prompt'
 import {RichText} from '#/components/RichText'
@@ -75,9 +72,6 @@ let ProfileHeaderStandard = ({
   const [_queueBlock, queueUnblock] = useProfileBlockMutationQueue(profile)
   const unblockPromptControl = Prompt.usePromptControl()
   const requireAuth = useRequireAuth()
-  const navigation = useNavigation<NavigationProp>()
-
-  const {data: convoId} = useMaybeConvoForUser(profile.did)
 
   const onPressEditProfile = React.useCallback(() => {
     track('ProfileHeader:EditProfileButtonClicked')
@@ -148,11 +142,6 @@ let ProfileHeaderStandard = ({
     }
   }, [_, queueUnblock, track])
 
-  const onPressDm = React.useCallback(() => {
-    if (!convoId) return
-    navigation.navigate('MessagesConversation', {conversation: convoId})
-  }, [navigation, convoId])
-
   const isMe = React.useMemo(
     () => currentAccount?.did === profile.did,
     [currentAccount, profile],
@@ -210,19 +199,7 @@ let ProfileHeaderStandard = ({
             <>
               {hasSession && (
                 <>
-                  {convoId && (
-                    <Button
-                      testID="dmBtn"
-                      size="small"
-                      color="secondary"
-                      variant="solid"
-                      shape="round"
-                      onPress={onPressDm}
-                      label={_(msg`Message ${profile.handle}`)}
-                      style={{width: 36, height: 36}}>
-                      <Envelope style={t.atoms.text} size="md" />
-                    </Button>
-                  )}
+                  <MessageProfileButton profile={profile} />
                   <Button
                     testID="suggestedFollowsBtn"
                     size="small"

--- a/src/state/queries/messages/get-convo-for-members.ts
+++ b/src/state/queries/messages/get-convo-for-members.ts
@@ -4,6 +4,7 @@ import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query'
 import {logger} from '#/logger'
 import {DM_SERVICE_HEADERS} from '#/state/queries/messages/const'
 import {useAgent} from '#/state/session'
+import {STALE} from '..'
 import {RQKEY as CONVO_KEY} from './conversation'
 
 const RQKEY_ROOT = 'convo-for-user'
@@ -61,5 +62,6 @@ export function useMaybeConvoForUser(did: string) {
         return null
       }
     },
+    staleTime: STALE.INFINITY,
   })
 }

--- a/src/state/queries/messages/get-convo-for-members.ts
+++ b/src/state/queries/messages/get-convo-for-members.ts
@@ -1,10 +1,13 @@
 import {ChatBskyConvoGetConvoForMembers} from '@atproto/api'
-import {useMutation, useQueryClient} from '@tanstack/react-query'
+import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query'
 
 import {logger} from '#/logger'
 import {DM_SERVICE_HEADERS} from '#/state/queries/messages/const'
 import {useAgent} from '#/state/session'
 import {RQKEY as CONVO_KEY} from './conversation'
+
+const RQKEY_ROOT = 'convo-for-user'
+export const RQKEY = (did: string) => [RQKEY_ROOT, did]
 
 export function useGetConvoForMembers({
   onSuccess,
@@ -32,6 +35,31 @@ export function useGetConvoForMembers({
     onError: error => {
       logger.error(error)
       onError?.(error)
+    },
+  })
+}
+
+/**
+ * Gets the conversation ID for a given DID. Returns null if it's not possible to message them.
+ */
+export function useMaybeConvoForUser(did: string) {
+  const {getAgent} = useAgent()
+
+  return useQuery({
+    queryKey: RQKEY(did),
+    queryFn: async () => {
+      const convo = await getAgent()
+        .api.chat.bsky.convo.getConvoForMembers(
+          {members: [did]},
+          {headers: DM_SERVICE_HEADERS},
+        )
+        .catch(() => ({success: null}))
+
+      if (convo.success) {
+        return convo.data.convo.id
+      } else {
+        return null
+      }
     },
   })
 }

--- a/src/view/com/profile/ProfileMenu.tsx
+++ b/src/view/com/profile/ProfileMenu.tsx
@@ -1,41 +1,42 @@
 import React, {memo} from 'react'
 import {TouchableOpacity} from 'react-native'
 import {AppBskyActorDefs} from '@atproto/api'
+import {FontAwesomeIcon} from '@fortawesome/react-native-fontawesome'
 import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
-import {FontAwesomeIcon} from '@fortawesome/react-native-fontawesome'
 import {useQueryClient} from '@tanstack/react-query'
-import * as Toast from 'view/com/util/Toast'
-import {EventStopper} from 'view/com/util/EventStopper'
-import {useSession} from 'state/session'
-import * as Menu from '#/components/Menu'
-import {useTheme} from '#/alf'
-import {usePalette} from 'lib/hooks/usePalette'
+
+import {logger} from '#/logger'
+import {useAnalytics} from 'lib/analytics/analytics'
 import {HITSLOP_10} from 'lib/constants'
+import {usePalette} from 'lib/hooks/usePalette'
+import {makeProfileLink} from 'lib/routes/links'
 import {shareUrl} from 'lib/sharing'
 import {toShareUrl} from 'lib/strings/url-helpers'
-import {makeProfileLink} from 'lib/routes/links'
-import {useAnalytics} from 'lib/analytics/analytics'
+import {Shadow} from 'state/cache/types'
 import {useModalControls} from 'state/modals'
-import {ReportDialog, useReportDialogControl} from '#/components/ReportDialog'
 import {
   RQKEY as profileQueryKey,
   useProfileBlockMutationQueue,
   useProfileFollowMutationQueue,
   useProfileMuteMutationQueue,
 } from 'state/queries/profile'
+import {useSession} from 'state/session'
+import {EventStopper} from 'view/com/util/EventStopper'
+import * as Toast from 'view/com/util/Toast'
+import {useTheme} from '#/alf'
 import {ArrowOutOfBox_Stroke2_Corner0_Rounded as Share} from '#/components/icons/ArrowOutOfBox'
+import {Flag_Stroke2_Corner0_Rounded as Flag} from '#/components/icons/Flag'
 import {ListSparkle_Stroke2_Corner0_Rounded as List} from '#/components/icons/ListSparkle'
 import {Mute_Stroke2_Corner0_Rounded as Mute} from '#/components/icons/Mute'
-import {SpeakerVolumeFull_Stroke2_Corner0_Rounded as Unmute} from '#/components/icons/Speaker'
-import {Flag_Stroke2_Corner0_Rounded as Flag} from '#/components/icons/Flag'
+import {PeopleRemove2_Stroke2_Corner0_Rounded as UserMinus} from '#/components/icons/PeopleRemove2'
 import {PersonCheck_Stroke2_Corner0_Rounded as PersonCheck} from '#/components/icons/PersonCheck'
 import {PersonX_Stroke2_Corner0_Rounded as PersonX} from '#/components/icons/PersonX'
-import {PeopleRemove2_Stroke2_Corner0_Rounded as UserMinus} from '#/components/icons/PeopleRemove2'
 import {PlusLarge_Stroke2_Corner0_Rounded as Plus} from '#/components/icons/Plus'
-import {logger} from '#/logger'
-import {Shadow} from 'state/cache/types'
+import {SpeakerVolumeFull_Stroke2_Corner0_Rounded as Unmute} from '#/components/icons/Speaker'
+import * as Menu from '#/components/Menu'
 import * as Prompt from '#/components/Prompt'
+import {ReportDialog, useReportDialogControl} from '#/components/ReportDialog'
 
 let ProfileMenu = ({
   profile,
@@ -192,9 +193,8 @@ let ProfileMenu = ({
                     flexDirection: 'row',
                     alignItems: 'center',
                     justifyContent: 'center',
-                    paddingVertical: 10,
+                    padding: 8,
                     borderRadius: 50,
-                    paddingHorizontal: 16,
                   },
                   pal.btn,
                 ]}>


### PR DESCRIPTION
Calls `getProfileForMembers` to decide whether or not to show the button, since you can still chat someone if they have DMs closed if you already have an ongoing chat (I set mozzius.dev to `none` if you want to test). Means that it pops in after the rest of the profile but it doesn't cause layout shift. Buttons now wrap if needed, rather than flowing behind the avatar. Also includes a cleanup of the button sizes to make them all equal sizes (because before they were all different apparently????)

Opted not to show on labellers, you can still message them through the new chat dialog if you really need to but I think we want to avoid the perception of labellers as normal users.

![Screenshot 2024-05-18 at 21 14 03](https://github.com/bluesky-social/social-app/assets/10959775/2375d792-4c0f-4f26-b015-a4dbfbaad7c0)
