### PR TITLE
Expand the background color to cover the overscroll area on settings screen on iOS

### DIFF
--- a/src/view/screens/Settings/index.tsx
+++ b/src/view/screens/Settings/index.tsx
@@ -327,8 +327,7 @@ export function SettingsScreen({}: Props) {
         </View>
       </SimpleViewHeader>
       <ScrollView
-        style={s.hContentRegion}
-        contentContainerStyle={isMobile && pal.viewLight}
+        style={[s.hContentRegion, isMobile && pal.viewLight]}
         scrollIndicatorInsets={{right: 1}}
         // @ts-ignore web only -prf
         dataSet={{'stable-gutters': 1}}>


### PR DESCRIPTION
This is just a minor visual tweak to make the settings screen look better on iOS.

| Before | After |
| --- | --- |
| <img width="240" src="https://github.com/bluesky-social/social-app/assets/3784687/b867483b-3672-41e5-98a4-97b9ffada4b0" /> | <img width="240" src="https://github.com/bluesky-social/social-app/assets/3784687/27a78df7-2f49-47df-aa44-a1081df2b1e7" /> |
