### PR TITLE
[🐴] disable min shell on convo screen

### DIFF
--- a/src/screens/Messages/Conversation/index.tsx
+++ b/src/screens/Messages/Conversation/index.tsx
@@ -43,6 +43,8 @@ export function MessagesConversationScreen({route}: Props) {
 
       if (isWeb && !gtMobile) {
         setMinimalShellMode(true)
+      } else {
+        setMinimalShellMode(false)
       }
 
       return () => {


### PR DESCRIPTION
was able to get to the screen via tapping a notification from the home screen which left the min shell mode active