### PR TITLE
[🐴] Ensure keyboard gets dismissed when leaving screen

### DIFF
--- a/src/components/dms/MessagesListHeader.tsx
+++ b/src/components/dms/MessagesListHeader.tsx
@@ -1,5 +1,5 @@
 import React, {useCallback} from 'react'
-import {TouchableOpacity, View} from 'react-native'
+import {Keyboard, TouchableOpacity, View} from 'react-native'
 import {
   AppBskyActorDefs,
   ModerationCause,
@@ -46,6 +46,7 @@ export let MessagesListHeader = ({
     if (isWeb) {
       navigation.replace('Messages', {})
     } else {
+      Keyboard.dismiss()
       navigation.goBack()
     }
   }, [navigation])


### PR DESCRIPTION
I have a hunch this will help Reanimated's `useAnimatedKeyboard` to properly reset, but need to test on device. Cannot reproduce the original issue on simulator.