### PR TITLE
[🐴] Don't retry sends

### DIFF
--- a/src/state/messages/convo/agent.ts
+++ b/src/state/messages/convo/agent.ts
@@ -793,15 +793,13 @@ export class Convo {
 
       const {id, message} = pendingMessage
 
-      const response = await networkRetry(2, () => {
-        return this.agent.api.chat.bsky.convo.sendMessage(
-          {
-            convoId: this.convoId,
-            message,
-          },
-          {encoding: 'application/json', headers: DM_SERVICE_HEADERS},
-        )
-      })
+      const response = await this.agent.api.chat.bsky.convo.sendMessage(
+        {
+          convoId: this.convoId,
+          message,
+        },
+        {encoding: 'application/json', headers: DM_SERVICE_HEADERS},
+      )
       const res = response.data
 
       // remove from queue


### PR DESCRIPTION
Last week when we DOSd the test server and the responses were very slow, we noticed a couple instances of duplicate messages. These messages didn't go away when reloading the app, which means the messages were actually sent twice.

One possible culprit of this is our retry logic, which may have received a false positive failure due to slow server responses, and subsequently retried and re-sent the same payload twice.

Failing this fast and allowing the user to retry is probably a better solution for this write action, whereas reads can continue to retry.