### PR TITLE
[🐴] Handle deleted accounts, restructure ChatListItem

### DIFF
--- a/src/components/dms/ConvoMenu.tsx
+++ b/src/components/dms/ConvoMenu.tsx
@@ -41,7 +41,6 @@ let ConvoMenu = ({
   currentScreen,
   showMarkAsRead,
   hideTrigger,
-  triggerOpacity,
   blockInfo,
   style,
 }: {
@@ -51,7 +50,6 @@ let ConvoMenu = ({
   currentScreen: 'list' | 'conversation'
   showMarkAsRead?: boolean
   hideTrigger?: boolean
-  triggerOpacity?: number
   blockInfo: {
     listBlocks: ModerationCause[]
     userBlock?: ModerationCause
@@ -108,7 +106,7 @@ let ConvoMenu = ({
     <>
       <Menu.Root control={control}>
         {!hideTrigger && (
-          <View style={[style, {opacity: triggerOpacity}]}>
+          <View style={[style]}>
             <Menu.Trigger label={_(msg`Chat settings`)}>
               {({props, state}) => (
                 <Pressable

--- a/src/components/dms/ConvoMenu.tsx
+++ b/src/components/dms/ConvoMenu.tsx
@@ -18,7 +18,7 @@ import {
 import {useMuteConvo} from '#/state/queries/messages/mute-conversation'
 import {useProfileBlockMutationQueue} from '#/state/queries/profile'
 import * as Toast from '#/view/com/util/Toast'
-import {atoms as a, useTheme} from '#/alf'
+import {atoms as a, useTheme, ViewStyleProp} from '#/alf'
 import {BlockedByListDialog} from '#/components/dms/BlockedByListDialog'
 import {LeaveConvoPrompt} from '#/components/dms/LeaveConvoPrompt'
 import {ReportDialog} from '#/components/dms/ReportDialog'
@@ -43,6 +43,7 @@ let ConvoMenu = ({
   hideTrigger,
   triggerOpacity,
   blockInfo,
+  style,
 }: {
   convo: ChatBskyConvoDefs.ConvoView
   profile: Shadow<AppBskyActorDefs.ProfileViewBasic>
@@ -55,6 +56,7 @@ let ConvoMenu = ({
     listBlocks: ModerationCause[]
     userBlock?: ModerationCause
   }
+  style?: ViewStyleProp['style']
 }): React.ReactNode => {
   const navigation = useNavigation<NavigationProp>()
   const {_} = useLingui()
@@ -66,6 +68,7 @@ let ConvoMenu = ({
 
   const {listBlocks, userBlock} = blockInfo
   const isBlocking = userBlock || !!listBlocks.length
+  const isDeletedAccount = profile.handle === 'missing.invalid'
 
   const {data: convo} = useConvoQuery(initialConvo)
 
@@ -105,7 +108,7 @@ let ConvoMenu = ({
     <>
       <Menu.Root control={control}>
         {!hideTrigger && (
-          <View style={{opacity: triggerOpacity}}>
+          <View style={[style, {opacity: triggerOpacity}]}>
             <Menu.Trigger label={_(msg`Chat settings`)}>
               {({props, state}) => (
                 <Pressable
@@ -128,66 +131,9 @@ let ConvoMenu = ({
             </Menu.Trigger>
           </View>
         )}
-        <Menu.Outer>
-          <Menu.Group>
-            {showMarkAsRead && (
-              <Menu.Item
-                label={_(msg`Mark as read`)}
-                onPress={() =>
-                  markAsRead({
-                    convoId: convo?.id,
-                  })
-                }>
-                <Menu.ItemText>
-                  <Trans>Mark as read</Trans>
-                </Menu.ItemText>
-                <Menu.ItemIcon icon={Bubble} />
-              </Menu.Item>
-            )}
-            <Menu.Item
-              label={_(msg`Go to user's profile`)}
-              onPress={onNavigateToProfile}>
-              <Menu.ItemText>
-                <Trans>Go to profile</Trans>
-              </Menu.ItemText>
-              <Menu.ItemIcon icon={Person} />
-            </Menu.Item>
-            <Menu.Item
-              label={_(msg`Mute conversation`)}
-              onPress={() => muteConvo({mute: !convo?.muted})}>
-              <Menu.ItemText>
-                {convo?.muted ? (
-                  <Trans>Unmute conversation</Trans>
-                ) : (
-                  <Trans>Mute conversation</Trans>
-                )}
-              </Menu.ItemText>
-              <Menu.ItemIcon icon={convo?.muted ? Unmute : Mute} />
-            </Menu.Item>
-          </Menu.Group>
-          <Menu.Divider />
-          <Menu.Group>
-            <Menu.Item
-              label={
-                isBlocking ? _(msg`Unblock account`) : _(msg`Block account`)
-              }
-              onPress={toggleBlock}>
-              <Menu.ItemText>
-                {isBlocking ? _(msg`Unblock account`) : _(msg`Block account`)}
-              </Menu.ItemText>
-              <Menu.ItemIcon icon={isBlocking ? PersonX : PersonCheck} />
-            </Menu.Item>
-            <Menu.Item
-              label={_(msg`Report conversation`)}
-              onPress={reportControl.open}>
-              <Menu.ItemText>
-                <Trans>Report conversation</Trans>
-              </Menu.ItemText>
-              <Menu.ItemIcon icon={Flag} />
-            </Menu.Item>
-          </Menu.Group>
-          <Menu.Divider />
-          <Menu.Group>
+
+        {isDeletedAccount ? (
+          <Menu.Outer>
             <Menu.Item
               label={_(msg`Leave conversation`)}
               onPress={leaveConvoControl.open}>
@@ -196,8 +142,79 @@ let ConvoMenu = ({
               </Menu.ItemText>
               <Menu.ItemIcon icon={ArrowBoxLeft} />
             </Menu.Item>
-          </Menu.Group>
-        </Menu.Outer>
+          </Menu.Outer>
+        ) : (
+          <Menu.Outer>
+            <Menu.Group>
+              {showMarkAsRead && (
+                <Menu.Item
+                  label={_(msg`Mark as read`)}
+                  onPress={() =>
+                    markAsRead({
+                      convoId: convo?.id,
+                    })
+                  }>
+                  <Menu.ItemText>
+                    <Trans>Mark as read</Trans>
+                  </Menu.ItemText>
+                  <Menu.ItemIcon icon={Bubble} />
+                </Menu.Item>
+              )}
+              <Menu.Item
+                label={_(msg`Go to user's profile`)}
+                onPress={onNavigateToProfile}>
+                <Menu.ItemText>
+                  <Trans>Go to profile</Trans>
+                </Menu.ItemText>
+                <Menu.ItemIcon icon={Person} />
+              </Menu.Item>
+              <Menu.Item
+                label={_(msg`Mute conversation`)}
+                onPress={() => muteConvo({mute: !convo?.muted})}>
+                <Menu.ItemText>
+                  {convo?.muted ? (
+                    <Trans>Unmute conversation</Trans>
+                  ) : (
+                    <Trans>Mute conversation</Trans>
+                  )}
+                </Menu.ItemText>
+                <Menu.ItemIcon icon={convo?.muted ? Unmute : Mute} />
+              </Menu.Item>
+            </Menu.Group>
+            <Menu.Divider />
+            <Menu.Group>
+              <Menu.Item
+                label={
+                  isBlocking ? _(msg`Unblock account`) : _(msg`Block account`)
+                }
+                onPress={toggleBlock}>
+                <Menu.ItemText>
+                  {isBlocking ? _(msg`Unblock account`) : _(msg`Block account`)}
+                </Menu.ItemText>
+                <Menu.ItemIcon icon={isBlocking ? PersonX : PersonCheck} />
+              </Menu.Item>
+              <Menu.Item
+                label={_(msg`Report conversation`)}
+                onPress={reportControl.open}>
+                <Menu.ItemText>
+                  <Trans>Report conversation</Trans>
+                </Menu.ItemText>
+                <Menu.ItemIcon icon={Flag} />
+              </Menu.Item>
+            </Menu.Group>
+            <Menu.Divider />
+            <Menu.Group>
+              <Menu.Item
+                label={_(msg`Leave conversation`)}
+                onPress={leaveConvoControl.open}>
+                <Menu.ItemText>
+                  <Trans>Leave conversation</Trans>
+                </Menu.ItemText>
+                <Menu.ItemIcon icon={ArrowBoxLeft} />
+              </Menu.Item>
+            </Menu.Group>
+          </Menu.Outer>
+        )}
       </Menu.Root>
 
       <LeaveConvoPrompt

--- a/src/screens/Messages/List/ChatListItem.tsx
+++ b/src/screens/Messages/List/ChatListItem.tsx
@@ -284,7 +284,6 @@ function ChatListItemReady({
         currentScreen="list"
         showMarkAsRead={convo.unreadCount > 0}
         hideTrigger={isNative}
-        triggerOpacity={!gtMobile || showActions || menuControl.isOpen ? 1 : 0}
         blockInfo={blockInfo}
         style={[
           a.absolute,
@@ -293,6 +292,7 @@ function ChatListItemReady({
           a.justify_center,
           {
             right: a.px_lg.paddingRight,
+            opacity: !gtMobile || showActions || menuControl.isOpen ? 1 : 0,
           },
         ]}
       />

--- a/src/screens/Messages/List/ChatListItem.tsx
+++ b/src/screens/Messages/List/ChatListItem.tsx
@@ -136,7 +136,7 @@ function ChatListItemReady({
         to={`/messages/${convo.id}`}
         label={displayName}
         accessibilityHint={
-          profile.handle !== 'missing.invalid'
+          !isDeletedAccount
             ? _(msg`Go to conversation with ${profile.handle}`)
             : undefined
         }

--- a/src/screens/Messages/List/ChatListItem.tsx
+++ b/src/screens/Messages/List/ChatListItem.tsx
@@ -134,8 +134,12 @@ function ChatListItemReady({
       style={[a.relative]}>
       <Link
         to={`/messages/${convo.id}`}
-        label={profile.displayName || profile.handle}
-        accessibilityHint={_(msg`Go to conversation with ${profile.handle}`)}
+        label={displayName}
+        accessibilityHint={
+          profile.handle !== 'missing.invalid'
+            ? _(msg`Go to conversation with ${profile.handle}`)
+            : undefined
+        }
         accessibilityActions={
           isNative
             ? [

--- a/src/screens/Messages/List/ChatListItem.tsx
+++ b/src/screens/Messages/List/ChatListItem.tsx
@@ -8,9 +8,7 @@ import {
 } from '@atproto/api'
 import {msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
-import {useNavigation} from '@react-navigation/native'
 
-import {NavigationProp} from '#/lib/routes/types'
 import {isNative} from '#/platform/detection'
 import {useProfileShadow} from '#/state/cache/profile-shadow'
 import {useModerationOpts} from '#/state/preferences/moderation-opts'
@@ -19,9 +17,9 @@ import {sanitizeDisplayName} from 'lib/strings/display-names'
 import {TimeElapsed} from '#/view/com/util/TimeElapsed'
 import {UserAvatar} from '#/view/com/util/UserAvatar'
 import {atoms as a, useBreakpoints, useTheme, web} from '#/alf'
-import {Button} from '#/components/Button'
 import {ConvoMenu} from '#/components/dms/ConvoMenu'
 import {Bell2Off_Filled_Corner0_Rounded as BellStroke} from '#/components/icons/Bell2'
+import {Link} from '#/components/Link'
 import {useMenuControl} from '#/components/Menu'
 import {Text} from '#/components/Typography'
 
@@ -91,6 +89,8 @@ function ChatListItemReady({
         moderation.ui('displayName'),
       )
 
+  const isDimStyle = convo.muted || moderation.blocked || isDeletedAccount
+
   let lastMessage = _(msg`No messages yet`)
   let lastMessageSentAt: string | null = null
   if (ChatBskyConvoDefs.isMessageView(convo.lastMessage)) {
@@ -102,10 +102,9 @@ function ChatListItemReady({
     lastMessageSentAt = convo.lastMessage.sentAt
   }
   if (ChatBskyConvoDefs.isDeletedMessageView(convo.lastMessage)) {
-    lastMessage = _(msg`Message deleted`)
+    lastMessage = _(msg`Conversation deleted`)
   }
 
-  const navigation = useNavigation<NavigationProp>()
   const [showActions, setShowActions] = useState(false)
 
   const onMouseEnter = useCallback(() => {
@@ -121,33 +120,43 @@ function ChatListItemReady({
     setShowActions(true)
   }, [])
 
-  const onPress = useCallback(() => {
-    navigation.push('MessagesConversation', {
-      conversation: convo.id,
-    })
-  }, [convo.id, navigation])
-
   return (
     <View
       // @ts-expect-error web only
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
       onFocus={onFocus}
-      onBlur={onMouseLeave}>
-      <Button
+      onBlur={onMouseLeave}
+      style={[a.relative]}>
+      <Link
+        to={`/messages/${convo.id}`}
         label={profile.displayName || profile.handle}
-        onPress={onPress}
-        style={[a.flex_1]}
+        onPress={
+          isDeletedAccount
+            ? e => {
+                e.preventDefault()
+                return false
+              }
+            : undefined
+        }
+        style={[
+          web({
+            cursor: isDeletedAccount ? 'default' : 'pointer',
+          }),
+        ]}
         onLongPress={isNative ? menuControl.open : undefined}>
         {({hovered, pressed, focused}) => (
           <View
             style={[
               a.flex_row,
+              isDeletedAccount ? a.align_center : a.align_start,
               a.flex_1,
               a.px_lg,
               a.py_md,
               a.gap_md,
-              (hovered || pressed || focused) && t.atoms.bg_contrast_25,
+              (hovered || pressed || focused) &&
+                !isDeletedAccount &&
+                t.atoms.bg_contrast_25,
               t.atoms.border_contrast_low,
             ]}>
             <UserAvatar
@@ -155,85 +164,85 @@ function ChatListItemReady({
               size={52}
               moderation={moderation.ui('avatar')}
             />
-            <View style={[a.flex_1, a.flex_row, a.align_center]}>
-              <View style={[a.flex_1]}>
-                <View
-                  style={[
-                    a.flex_1,
-                    a.flex_row,
-                    a.align_end,
-                    a.pb_2xs,
-                    web([{marginTop: -2}]),
-                  ]}>
+
+            <View style={[a.flex_1, a.justify_center]}>
+              <View style={[a.w_full, a.flex_row, a.align_end, a.pb_2xs]}>
+                <Text
+                  numberOfLines={1}
+                  style={[{maxWidth: '85%'}, web([a.leading_normal])]}>
                   <Text
-                    numberOfLines={1}
-                    style={[{maxWidth: '85%'}, web([a.leading_normal])]}>
-                    <Text style={[a.text_md, t.atoms.text, a.font_bold]}>
-                      {displayName}
-                    </Text>
+                    style={[
+                      a.text_md,
+                      t.atoms.text,
+                      a.font_bold,
+                      {lineHeight: 21},
+                      isDimStyle && t.atoms.text_contrast_medium,
+                    ]}>
+                    {displayName}
                   </Text>
-                  {lastMessageSentAt && (
-                    <TimeElapsed timestamp={lastMessageSentAt}>
-                      {({timeElapsed}) => (
-                        <Text
-                          style={[
-                            a.text_sm,
-                            web([a.leading_normal, {whiteSpace: 'pre'}]),
-                            t.atoms.text_contrast_medium,
-                          ]}>
-                          {' '}
-                          &middot; {timeElapsed}
-                        </Text>
-                      )}
-                    </TimeElapsed>
-                  )}
-                  {(convo.muted || moderation.blocked) && (
-                    <Text
-                      style={[
-                        a.text_sm,
-                        web([a.leading_normal, {whiteSpace: 'pre'}]),
-                        t.atoms.text_contrast_medium,
-                      ]}>
-                      {' '}
-                      &middot;{' '}
-                      <BellStroke
-                        size="xs"
-                        style={t.atoms.text_contrast_medium}
-                      />
-                    </Text>
-                  )}
-                </View>
-                {!isDeletedAccount && (
+                </Text>
+                {lastMessageSentAt && (
+                  <TimeElapsed timestamp={lastMessageSentAt}>
+                    {({timeElapsed}) => (
+                      <Text
+                        style={[
+                          a.text_sm,
+                          {lineHeight: 21},
+                          t.atoms.text_contrast_medium,
+                        ]}>
+                        {' '}
+                        &middot; {timeElapsed}
+                      </Text>
+                    )}
+                  </TimeElapsed>
+                )}
+                {(convo.muted || moderation.blocked) && (
                   <Text
-                    numberOfLines={1}
-                    style={[a.text_sm, t.atoms.text_contrast_medium, a.pb_xs]}>
-                    @{profile.handle}
+                    style={[
+                      a.text_sm,
+                      {lineHeight: 21},
+                      t.atoms.text_contrast_medium,
+                    ]}>
+                    {' '}
+                    &middot;{' '}
+                    <BellStroke
+                      size="xs"
+                      style={[t.atoms.text_contrast_medium]}
+                    />
                   </Text>
                 )}
-                <Text
-                  numberOfLines={2}
-                  style={[
-                    a.text_sm,
-                    a.leading_snug,
-                    convo.unreadCount > 0
-                      ? a.font_bold
-                      : t.atoms.text_contrast_high,
-                    (convo.muted || moderation.blocked) &&
-                      t.atoms.text_contrast_medium,
-                  ]}>
-                  {lastMessage}
-                </Text>
               </View>
+
+              {!isDeletedAccount && (
+                <Text
+                  numberOfLines={1}
+                  style={[a.text_sm, t.atoms.text_contrast_medium, a.pb_xs]}>
+                  @{profile.handle}
+                </Text>
+              )}
+
+              <Text
+                numberOfLines={2}
+                style={[
+                  a.text_sm,
+                  a.leading_snug,
+                  convo.unreadCount > 0
+                    ? a.font_bold
+                    : t.atoms.text_contrast_high,
+                  isDimStyle && t.atoms.text_contrast_medium,
+                ]}>
+                {lastMessage}
+              </Text>
+
               {convo.unreadCount > 0 && (
                 <View
                   style={[
                     a.absolute,
                     a.rounded_full,
                     {
-                      backgroundColor:
-                        convo.muted || moderation.blocked
-                          ? t.palette.contrast_200
-                          : t.palette.primary_500,
+                      backgroundColor: isDimStyle
+                        ? t.palette.contrast_200
+                        : t.palette.primary_500,
                       height: 7,
                       width: 7,
                     },
@@ -249,22 +258,30 @@ function ChatListItemReady({
                   ]}
                 />
               )}
-              <ConvoMenu
-                convo={convo}
-                profile={profile}
-                control={menuControl}
-                currentScreen="list"
-                showMarkAsRead={convo.unreadCount > 0}
-                hideTrigger={isNative}
-                triggerOpacity={
-                  !gtMobile || showActions || menuControl.isOpen ? 1 : 0
-                }
-                blockInfo={blockInfo}
-              />
             </View>
           </View>
         )}
-      </Button>
+      </Link>
+
+      <ConvoMenu
+        convo={convo}
+        profile={profile}
+        control={menuControl}
+        currentScreen="list"
+        showMarkAsRead={convo.unreadCount > 0}
+        hideTrigger={isNative}
+        triggerOpacity={!gtMobile || showActions || menuControl.isOpen ? 1 : 0}
+        blockInfo={blockInfo}
+        style={[
+          a.absolute,
+          a.h_full,
+          a.self_end,
+          a.justify_center,
+          {
+            right: a.px_lg.paddingRight,
+          },
+        ]}
+      />
     </View>
   )
 }


### PR DESCRIPTION
Review without whitespace: https://github.com/bluesky-social/social-app/pull/4114/files?diff=split&w=1

Deleted accounts delete all messages for both parties, so there's no need to load the Convo screen. This PR disables that link.

This PR also converts to a `Link` for better a11y, and restructures the `ChatListItem` so that the context menu is outside the `Link` for better a11y. It should also fix some alignment issues we had with deleted accounts.

![CleanShot 2024-05-20 at 10 25 47@2x](https://github.com/bluesky-social/social-app/assets/4732330/d1cf0d43-5b7d-4a94-b16f-fc14fdc96f16)
![CleanShot 2024-05-20 at 10 26 40@2x](https://github.com/bluesky-social/social-app/assets/4732330/2bc82324-834b-4374-b5be-e4e6f2c1adc4)
![CleanShot 2024-05-20 at 10 26 47@2x](https://github.com/bluesky-social/social-app/assets/4732330/386e4503-e89b-4d1a-85f6-f73ed17c89d8)
