### PR TITLE
Allow removal of feeds that fail to load

### DIFF
--- a/src/view/com/feeds/FeedSourceCard.tsx
+++ b/src/view/com/feeds/FeedSourceCard.tsx
@@ -94,7 +94,7 @@ export function FeedSourceCardLoaded({
     useRemoveFeedMutation()
 
   const savedFeedConfig = preferences?.savedFeeds?.find(
-    f => f.value === feed?.uri,
+    f => f.value === feedUri,
   )
   const isSaved = Boolean(savedFeedConfig)
 
@@ -173,7 +173,7 @@ export function FeedSourceCardLoaded({
             accessibilityRole="button"
             accessibilityLabel={_(msg`Remove from my feeds`)}
             accessibilityHint=""
-            onPress={onToggleSaved}
+            onPress={onUnsave}
             hitSlop={15}
             style={styles.btn}>
             <FontAwesomeIcon


### PR DESCRIPTION
Two issues here:
- if the feed fails to load, the `find` for `SavedFeedConfig` fails and we don't have anything to remove from prefs
- the warning dialog when removing a saved feed isn't part of the failed/loading state
  - fix here is to simply call `onUnsave`, don't need to warn the user if feed is failing to load and they want to remove