### PR TITLE
[Statsig] Fix exposure logging for reduced onboarding

### DIFF
--- a/src/lib/statsig/gates.ts
+++ b/src/lib/statsig/gates.ts
@@ -4,7 +4,7 @@ export type Gate =
   | 'disable_min_shell_on_foregrounding_v3'
   | 'disable_poll_on_discover_v2'
   | 'dms'
-  | 'reduced_onboarding_and_home_algo'
+  | 'reduced_onboarding_and_home_algo_v2'
   | 'request_notifications_permission_after_onboarding'
   | 'show_follow_back_label_v2'
   | 'start_session_with_following_v2'

--- a/src/screens/Onboarding/StepFinished.tsx
+++ b/src/screens/Onboarding/StepFinished.tsx
@@ -83,7 +83,7 @@ export function StepFinished() {
            * selected in onboarding and therefore we don't need to run this
            * code (which would overwrite the other feeds already set).
            */
-          if (!gate('reduced_onboarding_and_home_algo')) {
+          if (!gate('reduced_onboarding_and_home_algo_v2')) {
             const otherFeeds = selectedFeeds.length
               ? selectedFeeds.map(f => ({
                   type: 'feed',
@@ -120,7 +120,7 @@ export function StepFinished() {
         })(),
 
         (async () => {
-          if (!gate('reduced_onboarding_and_home_algo')) return
+          if (!gate('reduced_onboarding_and_home_algo_v2')) return
 
           const {imageUri, imageMime} = profileStepResults
           if (imageUri && imageMime) {

--- a/src/screens/Onboarding/StepInterests/index.tsx
+++ b/src/screens/Onboarding/StepInterests/index.tsx
@@ -134,7 +134,7 @@ export function StepInterests() {
   }, [track])
 
   React.useEffect(() => {
-    if (!gate('reduced_onboarding_and_home_algo')) {
+    if (!gate('reduced_onboarding_and_home_algo_v2')) {
       requestNotificationsPermission('StartOnboarding')
     }
   }, [gate, requestNotificationsPermission])

--- a/src/screens/Onboarding/StepProfile/index.tsx
+++ b/src/screens/Onboarding/StepProfile/index.tsx
@@ -94,7 +94,7 @@ export function StepProfile() {
   React.useEffect(() => {
     // We have an experiment running for redueced onboarding, where this screen shows up as the first in onboarding.
     // We only want to request permissions when that gate is actually active to prevent pollution
-    if (gate('reduced_onboarding_and_home_algo')) {
+    if (gate('reduced_onboarding_and_home_algo_v2')) {
       requestNotificationsPermission('StartOnboarding')
     }
   }, [gate, requestNotificationsPermission])

--- a/src/screens/Onboarding/index.tsx
+++ b/src/screens/Onboarding/index.tsx
@@ -24,7 +24,7 @@ import {Portal} from '#/components/Portal'
 export function Onboarding() {
   const {_} = useLingui()
   const gate = useGate()
-  const isReducedOnboardingEnabled = gate('reduced_onboarding_and_home_algo')
+  const isReducedOnboardingEnabled = gate('reduced_onboarding_and_home_algo_v2')
   const [state, dispatch] = React.useReducer(
     isReducedOnboardingEnabled ? reducerReduced : reducer,
     isReducedOnboardingEnabled ? {...initialStateReduced} : {...initialState},

--- a/src/state/queries/post-feed.ts
+++ b/src/state/queries/post-feed.ts
@@ -152,7 +152,7 @@ export function usePostFeedQuery(
               feedTuners,
               userInterests, // Not in the query key because they don't change.
               getAgent,
-              useBaseFollowingFeed: gate('reduced_onboarding_and_home_algo'),
+              useBaseFollowingFeed: gate('reduced_onboarding_and_home_algo_v2'),
             }),
             cursor: undefined,
           }

--- a/src/state/queries/post-feed.ts
+++ b/src/state/queries/post-feed.ts
@@ -152,7 +152,13 @@ export function usePostFeedQuery(
               feedTuners,
               userInterests, // Not in the query key because they don't change.
               getAgent,
-              useBaseFollowingFeed: gate('reduced_onboarding_and_home_algo_v2'),
+              useBaseFollowingFeed: gate(
+                'reduced_onboarding_and_home_algo_v2',
+                {
+                  // If you're not already in this experiment, we don't want to expose you to it now.
+                  dangerouslyDisableExposureLogging: true,
+                },
+              ),
             }),
             cursor: undefined,
           }

--- a/src/view/com/testing/TestCtrls.e2e.tsx
+++ b/src/view/com/testing/TestCtrls.e2e.tsx
@@ -112,7 +112,7 @@ export function TestCtrls() {
         testID="e2eStartOnboarding"
         onPress={() => {
           // TODO remove when experiment is over
-          setGate('reduced_onboarding_and_home_algo', true)
+          setGate('reduced_onboarding_and_home_algo_v2', true)
           onboardingDispatch({type: 'start'})
         }}
         accessibilityRole="button"
@@ -123,7 +123,7 @@ export function TestCtrls() {
         testID="e2eStartLongboarding"
         onPress={() => {
           // TODO remove when experiment is over
-          setGate('reduced_onboarding_and_home_algo', false)
+          setGate('reduced_onboarding_and_home_algo_v2', false)
           onboardingDispatch({type: 'start'})
         }}
         accessibilityRole="button"


### PR DESCRIPTION
First commit adds an option that disables exposure logging for a specific gate check. Then we rename the onboarding experiment name (to get fresh data) and enable the option for the place where we don't want exposures.

## Test Plan

Add a logpoint to Statsig exposure logger.

![Screenshot 2024-05-20 at 23 30 06](https://github.com/bluesky-social/social-app/assets/810438/9944d507-27da-449b-b3a4-5ce0d0080c1c)

Confirm that on `main`, we expose the user to the onboarding experiment while on Following tab.

![Screenshot 2024-05-20 at 23 28 33](https://github.com/bluesky-social/social-app/assets/810438/da36153e-1944-4b2b-a002-03a3968f79a5)

Confirm that on this branch, we don't.

![Screenshot 2024-05-20 at 23 28 20](https://github.com/bluesky-social/social-app/assets/810438/7d00e0e9-6d72-4923-8a63-9b61d19a5328)
