### PR TITLE
[🐴] Prevent flash upon first message

### DIFF
--- a/src/screens/Messages/Conversation/MessagesList.tsx
+++ b/src/screens/Messages/Conversation/MessagesList.tsx
@@ -278,12 +278,16 @@ export function MessagesList({
         return true
       })
 
+      if (!hasScrolled) {
+        setHasScrolled(true)
+      }
+
       convoState.sendMessage({
         text: rt.text,
         facets: rt.facets,
       })
     },
-    [convoState, getAgent],
+    [convoState, getAgent, hasScrolled],
   )
 
   // -- List layout changes (opening emoji keyboard, etc.)

--- a/src/screens/Messages/Conversation/MessagesList.tsx
+++ b/src/screens/Messages/Conversation/MessagesList.tsx
@@ -287,7 +287,7 @@ export function MessagesList({
         facets: rt.facets,
       })
     },
-    [convoState, getAgent, hasScrolled],
+    [convoState, getAgent, hasScrolled, setHasScrolled],
   )
 
   // -- List layout changes (opening emoji keyboard, etc.)

--- a/src/screens/Messages/Conversation/index.tsx
+++ b/src/screens/Messages/Conversation/index.tsx
@@ -77,11 +77,7 @@ function Inner() {
   // we use `hasScrolled` to determine when to render. With that said however, there is a chance that the chat will be
   // empty. So, we also check for that possible state as well and render once we can.
   const [hasScrolled, setHasScrolled] = React.useState(false)
-  const readyToShow =
-    hasScrolled ||
-    (isConvoActive(convoState) &&
-      !convoState.isFetchingHistory &&
-      convoState.items.length === 0)
+  const readyToShow = hasScrolled || isConvoActive(convoState)
 
   // Any time that we re-render the `Initializing` state, we have to reset `hasScrolled` to false. After entering this
   // state, we know that we're resetting the list of messages and need to re-scroll to the bottom when they get added.

--- a/src/screens/Messages/Conversation/index.tsx
+++ b/src/screens/Messages/Conversation/index.tsx
@@ -77,7 +77,11 @@ function Inner() {
   // we use `hasScrolled` to determine when to render. With that said however, there is a chance that the chat will be
   // empty. So, we also check for that possible state as well and render once we can.
   const [hasScrolled, setHasScrolled] = React.useState(false)
-  const readyToShow = hasScrolled || isConvoActive(convoState)
+  const readyToShow =
+    hasScrolled ||
+    (isConvoActive(convoState) &&
+      !convoState.isFetchingHistory &&
+      convoState.items.length === 0)
 
   // Any time that we re-render the `Initializing` state, we have to reset `hasScrolled` to false. After entering this
   // state, we know that we're resetting the list of messages and need to re-scroll to the bottom when they get added.


### PR DESCRIPTION
Test with old version
- create fresh chat, leave one, or otherwise reset to no items in the MessageList
- send first message, see flash of load state

This PR fixes that, but probably breaks other stuff.