### PR TITLE
[🐴] only try to initialize once in the NUX

### DIFF
--- a/src/components/dms/MessagesNUX.tsx
+++ b/src/components/dms/MessagesNUX.tsx
@@ -53,12 +53,13 @@ function DialogInner({
   const control = Dialog.useDialogContext()
   const {_} = useLingui()
   const t = useTheme()
+
+  const [initialized, setInitialzed] = React.useState(false)
   const {mutate: updateDeclaration} = useUpdateActorDeclaration({
     onError: () => {
       Toast.show(_(msg`Failed to update settings`))
     },
   })
-  const [initialized, setInitialzed] = React.useState(false)
 
   const onSelectItem = useCallback(
     (keys: string[]) => {

--- a/src/components/dms/MessagesNUX.tsx
+++ b/src/components/dms/MessagesNUX.tsx
@@ -58,6 +58,7 @@ function DialogInner({
       Toast.show(_(msg`Failed to update settings`))
     },
   })
+  const [initialized, setInitialzed] = React.useState(false)
 
   const onSelectItem = useCallback(
     (keys: string[]) => {
@@ -69,10 +70,11 @@ function DialogInner({
   )
 
   useEffect(() => {
-    if (!chatDeclation) {
+    if (!chatDeclation && !initialized) {
       updateDeclaration('following')
+      setInitialzed(true)
     }
-  }, [chatDeclation, updateDeclaration])
+  }, [chatDeclation, updateDeclaration, initialized])
 
   return (
     <Dialog.ScrollableInner


### PR DESCRIPTION
If the initial request fails for some reason, the state resets to `undefined`, causing an infinite loop. We should store some state that tells us we already tried to initialize.