### PR TITLE
[Statsig] Sample router events

### DIFF
--- a/src/Navigation.tsx
+++ b/src/Navigation.tsx
@@ -611,7 +611,7 @@ function RoutesContainer({children}: React.PropsWithChildren<{}>) {
       linking={LINKING}
       theme={theme}
       onStateChange={() => {
-        logEvent('router:navigate', {
+        logEvent('router:navigate:sampled', {
           from: prevLoggedRouteName.current,
         })
         prevLoggedRouteName.current = getCurrentRouteName()
@@ -620,7 +620,7 @@ function RoutesContainer({children}: React.PropsWithChildren<{}>) {
         attachRouteToLogEvents(getCurrentRouteName)
         logModuleInitTime()
         onReady()
-        logEvent('router:navigate', {})
+        logEvent('router:navigate:sampled', {})
       }}>
       {children}
     </NavigationContainer>

--- a/src/lib/statsig/events.ts
+++ b/src/lib/statsig/events.ts
@@ -24,7 +24,7 @@ export type LogEvents = {
     secondsActive: number
   }
   'state:foreground': {}
-  'router:navigate': {}
+  'router:navigate:sampled': {}
 
   // Screen events
   'splash:signInPressed': {}

--- a/src/lib/statsig/statsig.tsx
+++ b/src/lib/statsig/statsig.tsx
@@ -85,11 +85,17 @@ export function toClout(n: number | null | undefined): number | undefined {
   }
 }
 
+const DOWNSAMPLED_EVENTS = new Set(['router:navigate:sampled'])
+const isDownsampledSession = Math.random() < 0.9 // 90% likely
+
 export function logEvent<E extends keyof LogEvents>(
   eventName: E & string,
   rawMetadata: LogEvents[E] & FlatJSONRecord,
 ) {
   try {
+    if (isDownsampledSession && DOWNSAMPLED_EVENTS.has(eventName)) {
+      return
+    }
     const fullMetadata = {
       ...rawMetadata,
     } as Record<string, string> // Statsig typings are unnecessarily strict here.


### PR DESCRIPTION
Adds simple sampling mechanism. For now enabling just for the noisiest event.

## Test Plan

Add some console logs. Verify that usually, the nav events get filtered out. Verify that forcing the probability to be lower results in sending nav events.