### PR TITLE
[🐴] Fix empty message pill overlapping input

### DIFF
--- a/src/components/dms/ChatEmptyPill.tsx
+++ b/src/components/dms/ChatEmptyPill.tsx
@@ -72,7 +72,7 @@ export function ChatEmptyPill() {
         a.z_10,
         a.align_center,
         {
-          bottom: 70,
+          top: -50,
         },
       ]}>
       <AnimatedPressable


### PR DESCRIPTION
Fixes https://github.com/bluesky-social/social-app/issues/4150

Fixed to top of container rather than bottom, so it grows with input size

![Screenshot 2024-05-21 at 15 35 35](https://github.com/bluesky-social/social-app/assets/10959775/2b675b25-1df7-4870-9001-d119dbdc33e7)
![Screenshot 2024-05-21 at 15 37 12](https://github.com/bluesky-social/social-app/assets/10959775/8ac01245-16a6-45fa-a2ee-09a90b363cc2)
