### PR TITLE
More retries when resuming non-stale account

### DIFF
--- a/src/state/session/agent.ts
+++ b/src/state/session/agent.ts
@@ -53,7 +53,7 @@ export async function createAgentAndResume(
     agent.session = prevSession
     if (!storedAccount.deactivated) {
       // Intentionally not awaited to unblock the UI:
-      networkRetry(1, () => agent.resumeSession(prevSession))
+      networkRetry(3, () => agent.resumeSession(prevSession))
     }
   }
 


### PR DESCRIPTION
A few of us have noticed getting signed out occasionally. For me anyway, this seems to happen when resuming from a background state e.g. foregrounding the app, or opening my laptop after being away.

The thinking in this PR is: if we have checked your JWT and it's not expired, we want to be _very_ sure the `resumeSession` call returns a real failure, and not some sort of network issue while the device reconnects to its wifi/cellular.

Other things that could be done here:
- check for network errors and retry those, but fail on actual auth errors
- add a back-off, so requests are spaced out a bit