### PR TITLE
check `maxTouchPoints` is greater than 1 - not 0 - for hover card

### DIFF
--- a/src/components/ProfileHoverCard/index.web.tsx
+++ b/src/components/ProfileHoverCard/index.web.tsx
@@ -43,7 +43,7 @@ const floatingMiddlewares = [
   }),
 ]
 
-const isTouchDevice = 'ontouchstart' in window || navigator.maxTouchPoints > 0
+const isTouchDevice = 'ontouchstart' in window || navigator.maxTouchPoints > 1
 
 export function ProfileHoverCard(props: ProfileHoverCardProps) {
   if (props.disable || isTouchDevice) {


### PR DESCRIPTION
## Why

Right now the hover cards do not work on Firefox Windows are not working, because - specifically on Windows and specifically with Firefox - `maxTouchPoints` is set to one, not zero.

The MDN docs also say that we should be using `> 1` instead of `> 0`

https://developer.mozilla.org/en-US/docs/Web/API/Navigator/maxTouchPoints

## Test Plan

Now that we are using `> 1`, this works correctly.

Before and after, on bsky.app vs localhost.


https://github.com/bluesky-social/social-app/assets/153161762/859bbced-bae4-4e31-890e-c8bdb5e965a3

