### PR TITLE
[🐴] Support Japanese (et al.) IME in message input on web

### DIFF
--- a/src/screens/Messages/Conversation/MessageInput.web.tsx
+++ b/src/screens/Messages/Conversation/MessageInput.web.tsx
@@ -45,7 +45,7 @@ export function MessageInput({
 
   const onKeyDown = React.useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-      // Don't submit the form
+      // Don't submit the form when the Japanese or any other IME is composing
       if (isComposing.current) return
 
       if (e.key === 'Enter') {

--- a/src/screens/Messages/Conversation/MessageInput.web.tsx
+++ b/src/screens/Messages/Conversation/MessageInput.web.tsx
@@ -26,6 +26,7 @@ export function MessageInput({
   const [message, setMessage] = React.useState(getDraft)
 
   const inputStyles = useSharedInputStyles()
+  const isComposing = React.useRef(false)
   const [isFocused, setIsFocused] = React.useState(false)
   const [isHovered, setIsHovered] = React.useState(false)
 
@@ -44,13 +45,16 @@ export function MessageInput({
 
   const onKeyDown = React.useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      // Don't submit the form
+      if (isComposing.current) return
+
       if (e.key === 'Enter') {
         if (e.shiftKey) return
         e.preventDefault()
         onSubmit()
       }
     },
-    [onSubmit],
+    [onSubmit, isComposing],
   )
 
   const onChange = React.useCallback(
@@ -102,6 +106,12 @@ export function MessageInput({
           autoFocus={true}
           onFocus={() => setIsFocused(true)}
           onBlur={() => setIsFocused(false)}
+          onCompositionStart={() => {
+            isComposing.current = true
+          }}
+          onCompositionEnd={() => {
+            isComposing.current = false
+          }}
           onChange={onChange}
           onKeyDown={onKeyDown}
         />

--- a/src/screens/Messages/Conversation/MessageInput.web.tsx
+++ b/src/screens/Messages/Conversation/MessageInput.web.tsx
@@ -47,7 +47,6 @@ export function MessageInput({
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
       // Don't submit the form when the Japanese or any other IME is composing
       if (isComposing.current) return
-
       if (e.key === 'Enter') {
         if (e.shiftKey) return
         e.preventDefault()


### PR DESCRIPTION
## Why

Fixes https://github.com/bluesky-social/social-app/issues/4157

Because we are listening for the `onKeyDown` event to know when to submit the message with the enter key, Japanese users cannot properly use the Japanese IME because it relies on using the enter key.

This PR uses the `onCompositionStart` and `onCompositionEnd` events on the `textarea` to prevent submission while the user is composing.

## Test Plan

I've recorded a video below of me using the Japanese keyboard IME with some console logs for clarification on what is going on.


https://github.com/bluesky-social/social-app/assets/153161762/5abfd67e-898b-4d25-8f23-6d0315b649bd



