### PR TITLE
don't use `contentVisibility` on Firefox

### DIFF
--- a/src/view/com/util/List.web.tsx
+++ b/src/view/com/util/List.web.tsx
@@ -504,6 +504,7 @@ export const List = memo(React.forwardRef(ListImpl)) as <ItemT>(
 
 // https://stackoverflow.com/questions/7944460/detect-safari-browser
 const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent)
+const isFirefox = /firefox|fxios/i.test(navigator.userAgent)
 
 const styles = StyleSheet.create({
   sideBorders: {
@@ -518,7 +519,7 @@ const styles = StyleSheet.create({
   },
   row: {
     // @ts-ignore web only
-    contentVisibility: isSafari ? '' : 'auto', // Safari support for this is buggy.
+    contentVisibility: isSafari || isFirefox ? '' : 'auto', // Safari support for this is buggy.
   },
   minHeightViewport: {
     // @ts-ignore web only


### PR DESCRIPTION
## Why

The `content-visibility` style on Firefox is causing problems with the `List` implementation - at least for the list we use for chat conversations.

This PR just checks the useragent for `Firefox` and does not use this style - the same way we do not use it for Safari - if it matches.

## Test Plan

With this PR, the chat list should be fine on Firefox.


https://github.com/bluesky-social/social-app/assets/153161762/9e7732f9-7296-406d-a665-59aff3826b76

