### PR TITLE
Cleanup gates

### DIFF
--- a/src/lib/statsig/gates.ts
+++ b/src/lib/statsig/gates.ts
@@ -2,7 +2,6 @@ export type Gate =
   // Keep this alphabetic please.
   | 'autoexpand_suggestions_on_profile_follow_v2'
   | 'disable_min_shell_on_foregrounding_v3'
-  | 'disable_poll_on_discover_v2'
   | 'reduced_onboarding_and_home_algo_v2'
   | 'request_notifications_permission_after_onboarding'
   | 'show_follow_back_label_v2'

--- a/src/lib/statsig/gates.ts
+++ b/src/lib/statsig/gates.ts
@@ -5,6 +5,3 @@ export type Gate =
   | 'reduced_onboarding_and_home_algo_v2'
   | 'request_notifications_permission_after_onboarding'
   | 'show_follow_back_label_v2'
-  | 'start_session_with_following_v2'
-  | 'test_gate_1'
-  | 'test_gate_2'

--- a/src/lib/statsig/gates.ts
+++ b/src/lib/statsig/gates.ts
@@ -1,6 +1,5 @@
 export type Gate =
   // Keep this alphabetic please.
-  | 'autoexpand_suggestions_on_profile_follow_v2'
   | 'disable_min_shell_on_foregrounding_v3'
   | 'reduced_onboarding_and_home_algo_v2'
   | 'request_notifications_permission_after_onboarding'

--- a/src/lib/statsig/gates.ts
+++ b/src/lib/statsig/gates.ts
@@ -1,6 +1,5 @@
 export type Gate =
   // Keep this alphabetic please.
-  | 'disable_min_shell_on_foregrounding_v3'
   | 'reduced_onboarding_and_home_algo_v2'
   | 'request_notifications_permission_after_onboarding'
   | 'show_follow_back_label_v2'

--- a/src/screens/Profile/Header/ProfileHeaderStandard.tsx
+++ b/src/screens/Profile/Header/ProfileHeaderStandard.tsx
@@ -10,9 +10,8 @@ import {FontAwesomeIcon} from '@fortawesome/react-native-fontawesome'
 import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
-import {useGate} from '#/lib/statsig/statsig'
 import {logger} from '#/logger'
-import {isIOS, isWeb} from '#/platform/detection'
+import {isIOS} from '#/platform/detection'
 import {Shadow} from '#/state/cache/types'
 import {useModalControls} from '#/state/modals'
 import {
@@ -81,7 +80,6 @@ let ProfileHeaderStandard = ({
     })
   }, [track, openModal, profile])
 
-  const gate = useGate()
   const onPressFollow = () => {
     requireAuth(async () => {
       try {
@@ -95,9 +93,6 @@ let ProfileHeaderStandard = ({
             )}`,
           ),
         )
-        if (isWeb && gate('autoexpand_suggestions_on_profile_follow_v2')) {
-          setShowSuggestedFollows(true)
-        }
       } catch (e: any) {
         if (e?.name !== 'AbortError') {
           logger.error('Failed to follow', {message: String(e)})

--- a/src/view/com/feeds/FeedPage.tsx
+++ b/src/view/com/feeds/FeedPage.tsx
@@ -7,7 +7,7 @@ import {useNavigation} from '@react-navigation/native'
 import {useQueryClient} from '@tanstack/react-query'
 
 import {getRootNavigation, getTabState, TabState} from '#/lib/routes/helpers'
-import {logEvent, useGate} from '#/lib/statsig/statsig'
+import {logEvent} from '#/lib/statsig/statsig'
 import {isNative} from '#/platform/detection'
 import {listenSoftReset} from '#/state/events'
 import {FeedFeedbackProvider, useFeedFeedback} from '#/state/feed-feedback'
@@ -58,7 +58,6 @@ export function FeedPage({
   const feedFeedback = useFeedFeedback(feed, hasSession)
   const scrollElRef = React.useRef<ListMethods>(null)
   const [hasNew, setHasNew] = React.useState(false)
-  const gate = useGate()
 
   const scrollToTop = React.useCallback(() => {
     scrollElRef.current?.scrollToOffset({
@@ -109,12 +108,6 @@ export function FeedPage({
     })
   }, [scrollToTop, feed, queryClient, setHasNew])
 
-  const isDiscoverFeed =
-    feed ===
-    'feedgen|at://did:plc:z72i7hdynmk6r22z27h6tvur/app.bsky.feed.generator/whats-hot'
-  const adjustedHasNew =
-    hasNew && !(isDiscoverFeed && gate('disable_poll_on_discover_v2'))
-
   return (
     <View testID={testID} style={s.h100pct}>
       <MainScrollProvider>
@@ -136,11 +129,11 @@ export function FeedPage({
           />
         </FeedFeedbackProvider>
       </MainScrollProvider>
-      {(isScrolledDown || adjustedHasNew) && (
+      {(isScrolledDown || hasNew) && (
         <LoadLatestBtn
           onPress={onPressLoadLatest}
           label={_(msg`Load new posts`)}
-          showIndicator={adjustedHasNew}
+          showIndicator={hasNew}
         />
       )}
 

--- a/src/view/screens/Home.tsx
+++ b/src/view/screens/Home.tsx
@@ -6,7 +6,7 @@ import {PROD_DEFAULT_FEED} from '#/lib/constants'
 import {useNonReactiveCallback} from '#/lib/hooks/useNonReactiveCallback'
 import {useSetTitle} from '#/lib/hooks/useSetTitle'
 import {useWebMediaQueries} from '#/lib/hooks/useWebMediaQueries'
-import {logEvent, LogEvents, useGate} from '#/lib/statsig/statsig'
+import {logEvent, LogEvents} from '#/lib/statsig/statsig'
 import {emitSoftReset} from '#/state/events'
 import {SavedFeedSourceInfo, usePinnedFeedsInfos} from '#/state/queries/feed'
 import {FeedParams} from '#/state/queries/post-feed'
@@ -59,7 +59,6 @@ function HomeScreenReady({
   preferences: UsePreferencesQueryResponse
   pinnedFeedInfos: SavedFeedSourceInfo[]
 }) {
-  const gate = useGate()
   const requestNotificationsPermission = useRequestNotificationsPermission()
 
   const allFeeds = React.useMemo(
@@ -123,11 +122,9 @@ function HomeScreenReady({
     React.useCallback(() => {
       const listener = AppState.addEventListener('change', nextAppState => {
         if (nextAppState === 'active') {
-          if (
-            isMobile &&
-            mode.value === 1 &&
-            gate('disable_min_shell_on_foregrounding_v3')
-          ) {
+          if (isMobile && mode.value === 1) {
+            // Reveal the bottom bar so you don't miss notifications or messages.
+            // TODO: Experiment with only doing it when unread > 0.
             setMinimalShellMode(false)
           }
         }
@@ -135,7 +132,7 @@ function HomeScreenReady({
       return () => {
         listener.remove()
       }
-    }, [setMinimalShellMode, mode, isMobile, gate]),
+    }, [setMinimalShellMode, mode, isMobile]),
   )
 
   const onPageSelected = React.useCallback(


### PR DESCRIPTION
Launching:

- `disable_min_shell_on_foregrounding_v3` (positive results)

Unlaunching:

- `autoexpand_suggestions_on_profile_follow_v2` (negative results)
- `disable_poll_on_discover_v2` (neutral)

Removing unused:

- `start_session_with_following_v2`
- `test_gate_1`
- `test_gate_2`

## Test Plan

Read the code.