### PR TITLE
[Temporary] Disable React Compiler lint rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -68,7 +68,8 @@ module.exports = {
       },
     ],
     'simple-import-sort/exports': 'warn',
-    'react-compiler/react-compiler': 'error',
+    // TODO: Reenable when we figure out why it gets stuck on CI.
+    // 'react-compiler/react-compiler': 'error',
   },
   ignorePatterns: [
     '**/__mocks__/*.ts',


### PR DESCRIPTION
This task gets stuck on CI and when I run `yarn lint` locally. Let's skip it for now and @poteto will have a look later.