### PR TITLE
Check for retry-able status codes also

### DIFF
--- a/src/lib/async/retry.ts
+++ b/src/lib/async/retry.ts
@@ -1,9 +1,30 @@
+import {XRPCError} from '@atproto/xrpc'
+
 import {isNetworkError} from 'lib/strings/errors'
 
+export const NETWORK_FAILURE_STATUSES = [
+  1, 408, 425, 429, 500, 502, 503, 504, 522, 524,
+]
+
+function isRetryable(e: unknown) {
+  if (e instanceof XRPCError) {
+    if (NETWORK_FAILURE_STATUSES.includes(e.status)) {
+      return true
+    }
+  }
+
+  return isNetworkError(e)
+}
+
 export async function retry<P>(
-  retries: number,
-  cond: (err: any) => boolean,
   fn: () => Promise<P>,
+  {
+    retries,
+    checkIsRetryable = isRetryable,
+  }: {
+    retries: number
+    checkIsRetryable?: (err: any) => boolean
+  },
 ): Promise<P> {
   let lastErr
   while (retries > 0) {
@@ -11,7 +32,7 @@ export async function retry<P>(
       return await fn()
     } catch (e: any) {
       lastErr = e
-      if (cond(e)) {
+      if (checkIsRetryable(e)) {
         retries--
         continue
       }
@@ -25,5 +46,7 @@ export async function networkRetry<P>(
   retries: number,
   fn: () => Promise<P>,
 ): Promise<P> {
-  return retry(retries, isNetworkError, fn)
+  return retry(fn, {
+    retries,
+  })
 }


### PR DESCRIPTION
This is stacked (in spirit) on top of #4174 which should give us a better idea of what we're handling.

This PR changes the API of the `retry` function and includes a check for retry-able status codes. I lifted these codes from [our API SDK handling](https://github.com/bluesky-social/atproto/blob/main/packages/api/src/agent.ts#L236) of network errors. Functionality otherwise should be unchanged.