### PR TITLE
Log error statuses from failed resume session calls

### DIFF
--- a/src/state/session/agent.ts
+++ b/src/state/session/agent.ts
@@ -52,8 +52,17 @@ export async function createAgentAndResume(
   } else {
     agent.session = prevSession
     if (!storedAccount.deactivated) {
-      // Intentionally not awaited to unblock the UI:
-      networkRetry(3, () => agent.resumeSession(prevSession))
+      try {
+        // Intentionally not awaited to unblock the UI:
+        networkRetry(3, () => agent.resumeSession(prevSession))
+      } catch (e: any) {
+        logger.error(`networkRetry failed`, {
+          status: e?.status || 'unknown',
+          message: e?.message || 'unknown',
+        })
+
+        throw e
+      }
     }
   }
 

--- a/src/state/session/agent.ts
+++ b/src/state/session/agent.ts
@@ -52,18 +52,18 @@ export async function createAgentAndResume(
   } else {
     agent.session = prevSession
     if (!storedAccount.deactivated) {
-      try {
-        // Intentionally not awaited to unblock the UI:
-        networkRetry(3, () => agent.resumeSession(prevSession))
-      } catch (e: any) {
-        logger.error(`networkRetry failed to resume session`, {
-          status: e?.status || 'unknown',
-          // this field name is ignored by Sentry scrubbers
-          safeMessage: e?.message || 'unknown',
-        })
+      // Intentionally not awaited to unblock the UI:
+      networkRetry(3, () => agent.resumeSession(prevSession)).catch(
+        (e: any) => {
+          logger.error(`networkRetry failed to resume session`, {
+            status: e?.status || 'unknown',
+            // this field name is ignored by Sentry scrubbers
+            safeMessage: e?.message || 'unknown',
+          })
 
-        throw e
-      }
+          throw e
+        },
+      )
     }
   }
 

--- a/src/state/session/agent.ts
+++ b/src/state/session/agent.ts
@@ -56,7 +56,7 @@ export async function createAgentAndResume(
         // Intentionally not awaited to unblock the UI:
         networkRetry(3, () => agent.resumeSession(prevSession))
       } catch (e: any) {
-        logger.error(`networkRetry failed`, {
+        logger.error(`networkRetry failed to resume session`, {
           status: e?.status || 'unknown',
           // this field name is ignored by Sentry scrubbers
           safeMessage: e?.message || 'unknown',

--- a/src/state/session/agent.ts
+++ b/src/state/session/agent.ts
@@ -58,7 +58,8 @@ export async function createAgentAndResume(
       } catch (e: any) {
         logger.error(`networkRetry failed`, {
           status: e?.status || 'unknown',
-          message: e?.message || 'unknown',
+          // this field name is ignored by Sentry scrubbers
+          safeMessage: e?.message || 'unknown',
         })
 
         throw e


### PR DESCRIPTION
I want to better understand what failures occur here. We can pull status codes from our backend logs too, but network connectivity issues and local timeouts need to be captured here.