### PR TITLE
wrap web in disabled keyboard provider

### DIFF
--- a/src/App.web.tsx
+++ b/src/App.web.tsx
@@ -2,6 +2,7 @@ import 'lib/sentry' // must be near top
 import 'view/icons'
 
 import React, {useEffect, useState} from 'react'
+import {KeyboardProvider} from 'react-native-keyboard-controller'
 import {RootSiblingParent} from 'react-native-root-siblings'
 import {SafeAreaProvider} from 'react-native-safe-area-context'
 import {msg} from '@lingui/macro'
@@ -78,39 +79,41 @@ function InnerApp() {
   if (!isReady) return null
 
   return (
-    <Alf theme={theme}>
-      <ThemeProvider theme={theme}>
-        <RootSiblingParent>
-          <React.Fragment
-            // Resets the entire tree below when it changes:
-            key={currentAccount?.did}>
-            <QueryProvider currentDid={currentAccount?.did}>
-              <StatsigProvider>
-                <MessagesProvider>
-                  {/* LabelDefsProvider MUST come before ModerationOptsProvider */}
-                  <LabelDefsProvider>
-                    <ModerationOptsProvider>
-                      <LoggedOutViewProvider>
-                        <SelectedFeedProvider>
-                          <UnreadNotifsProvider>
-                            <BackgroundNotificationPreferencesProvider>
-                              <SafeAreaProvider>
-                                <Shell />
-                              </SafeAreaProvider>
-                            </BackgroundNotificationPreferencesProvider>
-                          </UnreadNotifsProvider>
-                        </SelectedFeedProvider>
-                      </LoggedOutViewProvider>
-                    </ModerationOptsProvider>
-                  </LabelDefsProvider>
-                </MessagesProvider>
-              </StatsigProvider>
-            </QueryProvider>
-          </React.Fragment>
-          <ToastContainer />
-        </RootSiblingParent>
-      </ThemeProvider>
-    </Alf>
+    <KeyboardProvider enabled={false}>
+      <Alf theme={theme}>
+        <ThemeProvider theme={theme}>
+          <RootSiblingParent>
+            <React.Fragment
+              // Resets the entire tree below when it changes:
+              key={currentAccount?.did}>
+              <QueryProvider currentDid={currentAccount?.did}>
+                <StatsigProvider>
+                  <MessagesProvider>
+                    {/* LabelDefsProvider MUST come before ModerationOptsProvider */}
+                    <LabelDefsProvider>
+                      <ModerationOptsProvider>
+                        <LoggedOutViewProvider>
+                          <SelectedFeedProvider>
+                            <UnreadNotifsProvider>
+                              <BackgroundNotificationPreferencesProvider>
+                                <SafeAreaProvider>
+                                  <Shell />
+                                </SafeAreaProvider>
+                              </BackgroundNotificationPreferencesProvider>
+                            </UnreadNotifsProvider>
+                          </SelectedFeedProvider>
+                        </LoggedOutViewProvider>
+                      </ModerationOptsProvider>
+                    </LabelDefsProvider>
+                  </MessagesProvider>
+                </StatsigProvider>
+              </QueryProvider>
+            </React.Fragment>
+            <ToastContainer />
+          </RootSiblingParent>
+        </ThemeProvider>
+      </Alf>
+    </KeyboardProvider>
   )
 }
 


### PR DESCRIPTION
## Why

`react-native-keyboard-controller` logs a warning - on every keystroke - if the app isn't wrapped in a `KeyboardProvider`. This makes sense of course on native, where it's a useful indication that something is wrong, but annoying when debugging on web.

This wraps the app in the keyboard provider on web as well to silence these warnings.

The context (https://github.com/kirillzyusko/react-native-keyboard-controller/blob/6da7f58bd692e0eeac26e44fd4960c1f4a31f3c0/src/context.ts#L20) contains just a few shared values and a couple functions. Hooks are no-op on web. https://github.com/kirillzyusko/react-native-keyboard-controller/blob/6da7f58bd692e0eeac26e44fd4960c1f4a31f3c0/src/reanimated.ts