### PR TITLE
HomeMenuItem goes above SearchMenuItem in a sessioned Drawer

### DIFF
--- a/src/view/shell/Drawer.tsx
+++ b/src/view/shell/Drawer.tsx
@@ -246,8 +246,8 @@ let DrawerContent = ({}: {}): React.ReactNode => {
           {hasSession ? (
             <>
               <View style={{height: 16}} />
-              <SearchMenuItem isActive={isAtSearch} onPress={onPressSearch} />
               <HomeMenuItem isActive={isAtHome} onPress={onPressHome} />
+              <SearchMenuItem isActive={isAtSearch} onPress={onPressSearch} />
               <NotificationsMenuItem
                 isActive={isAtNotifications}
                 onPress={onPressNotifications}


### PR DESCRIPTION
Unsure if this is wanted but in a Drawer with a session, move Home to the top to be consistent with other navigation menus.

### Before

![before](https://github.com/bluesky-social/social-app/assets/30475/d4ab3cc9-0b8f-404d-9655-7f0d4c735554)

### After

![after](https://github.com/bluesky-social/social-app/assets/30475/a29c78de-96d7-4b19-96b3-fcfe9c66e1df)

