### PR TITLE
[Session] Persist updates from inactive agent

### DIFF
--- a/src/state/session/__tests__/session-test.ts
+++ b/src/state/session/__tests__/session-test.ts
@@ -872,7 +872,7 @@ describe('session', () => {
     expect(state.accounts[0].accessJwt).toBe('alice-access-jwt-3')
   })
 
-  it('ignores updates from a stale agent', () => {
+  it('accepts updates from a stale agent', () => {
     let state = getInitialState([])
 
     const agent1 = new BskyAgent({service: 'https://alice.com'})
@@ -928,10 +928,10 @@ describe('session', () => {
     ])
     expect(state.accounts.length).toBe(2)
     expect(state.accounts[1].did).toBe('alice-did')
-    // Should retain the old values because Alice is not active.
-    expect(state.accounts[1].handle).toBe('alice.test')
-    expect(state.accounts[1].accessJwt).toBe('alice-access-jwt-1')
-    expect(state.accounts[1].refreshJwt).toBe('alice-refresh-jwt-1')
+    // Should update Alice's tokens because otherwise they'll be stale.
+    expect(state.accounts[1].handle).toBe('alice-updated.test')
+    expect(state.accounts[1].accessJwt).toBe('alice-access-jwt-2')
+    expect(state.accounts[1].refreshJwt).toBe('alice-refresh-jwt-2')
     expect(printState(state)).toMatchInlineSnapshot(`
       {
         "accounts": [
@@ -948,15 +948,15 @@ describe('session', () => {
             "service": "https://bob.com/",
           },
           {
-            "accessJwt": "alice-access-jwt-1",
+            "accessJwt": "alice-access-jwt-2",
             "deactivated": false,
             "did": "alice-did",
-            "email": undefined,
+            "email": "alice@foo.bar",
             "emailAuthFactor": false,
             "emailConfirmed": false,
-            "handle": "alice.test",
+            "handle": "alice-updated.test",
             "pdsUrl": undefined,
-            "refreshJwt": "alice-refresh-jwt-1",
+            "refreshJwt": "alice-refresh-jwt-2",
             "service": "https://alice.com/",
           },
         ],
@@ -988,7 +988,7 @@ describe('session', () => {
     ])
     expect(state.accounts.length).toBe(2)
     expect(state.accounts[0].did).toBe('bob-did')
-    // Should update the values because Bob is active.
+    // Should update Bob's tokens because otherwise they'll be stale.
     expect(state.accounts[0].handle).toBe('bob-updated.test')
     expect(state.accounts[0].accessJwt).toBe('bob-access-jwt-2')
     expect(state.accounts[0].refreshJwt).toBe('bob-refresh-jwt-2')
@@ -1008,15 +1008,15 @@ describe('session', () => {
             "service": "https://bob.com/",
           },
           {
-            "accessJwt": "alice-access-jwt-1",
+            "accessJwt": "alice-access-jwt-2",
             "deactivated": false,
             "did": "alice-did",
-            "email": undefined,
+            "email": "alice@foo.bar",
             "emailAuthFactor": false,
             "emailConfirmed": false,
-            "handle": "alice.test",
+            "handle": "alice-updated.test",
             "pdsUrl": undefined,
-            "refreshJwt": "alice-refresh-jwt-1",
+            "refreshJwt": "alice-refresh-jwt-2",
             "service": "https://alice.com/",
           },
         ],
@@ -1030,7 +1030,7 @@ describe('session', () => {
       }
     `)
 
-    // Ignore other events for inactive agent too.
+    // Ignore other events for inactive agent.
     const lastState = state
     agent1.session = undefined
     state = run(state, [

--- a/src/state/session/index.tsx
+++ b/src/state/session/index.tsx
@@ -208,6 +208,19 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
   if (IS_DEV && isWeb) window.agent = state.currentAgentState.agent
 
   const agent = state.currentAgentState.agent as BskyAgent
+  const currentAgentRef = React.useRef(agent)
+  React.useEffect(() => {
+    if (currentAgentRef.current !== agent) {
+      // Read the previous value and immediately advance the pointer.
+      const prevAgent = currentAgentRef.current
+      currentAgentRef.current = agent
+      // We never reuse agents so let's fully neutralize the previous one.
+      // This ensures it won't try to consume any refresh tokens.
+      prevAgent.session = undefined
+      prevAgent.setPersistSessionHandler(undefined)
+    }
+  }, [agent])
+
   return (
     <AgentContext.Provider value={agent}>
       <StateContext.Provider value={stateContext}>

--- a/src/state/session/reducer.ts
+++ b/src/state/session/reducer.ts
@@ -68,8 +68,13 @@ export function reducer(state: State, action: Action): State {
   switch (action.type) {
     case 'received-agent-event': {
       const {agent, accountDid, refreshedAccount, sessionEvent} = action
-      if (agent !== state.currentAgentState.agent) {
-        // Only consider events from the active agent.
+      if (
+        refreshedAccount === undefined &&
+        agent !== state.currentAgentState.agent
+      ) {
+        // If the session got cleared out (e.g. due to expiry or network error) but
+        // this account isn't the active one, don't clear it out at this time.
+        // This way, if the problem is transient, it'll work on next resume.
         return state
       }
       if (sessionEvent === 'network-error') {


### PR DESCRIPTION
If we have an agent in memory (but it isn't the active one), it's still possible that its session would get refreshed (e.g. if we have a dangling interval call somewhere that we didn't clean up). In that case, it's important that we actually persist the session since refreshing it has already consumed the stored refresh token.

It's possible this may be one of the causes of the reported unexpected logouts.

This PR changes the logic so that any agent's `update` event leads to updating persisted tokens — even if it's not the active agent. This should mean that, whenever we get a new session from the server (for any agent), it will get written into the persisted storage.

Note that in theory, we could have multiple agents for the same account "active" at the same time, which I think would mean that they might start "fighting" with each other. I'll think more about this case and <s>maybe send some follow-up</s> send https://github.com/bluesky-social/social-app/pull/4183.

## Test Plan

Mostly tests cause I'm not sure how to actually trigger refresh or expiry.