### PR TITLE
Add padding to dialogs when keyboard is open on Android

### DIFF
--- a/src/components/Dialog/index.tsx
+++ b/src/components/Dialog/index.tsx
@@ -1,5 +1,12 @@
 import React, {useImperativeHandle} from 'react'
-import {Dimensions, Pressable, StyleProp, View, ViewStyle} from 'react-native'
+import {
+  Dimensions,
+  Keyboard,
+  Pressable,
+  StyleProp,
+  View,
+  ViewStyle,
+} from 'react-native'
 import Animated, {useAnimatedStyle} from 'react-native-reanimated'
 import {useSafeAreaInsets} from 'react-native-safe-area-context'
 import BottomSheet, {
@@ -169,7 +176,8 @@ export function Outer({
           // Android
           importantForAccessibility="yes"
           style={[a.absolute, a.inset_0]}
-          testID={testID}>
+          testID={testID}
+          onTouchMove={() => Keyboard.dismiss()}>
           <BottomSheet
             enableDynamicSizing={!hasSnapPoints}
             enablePanDownToClose
@@ -236,7 +244,6 @@ export const ScrollableInner = React.forwardRef<
   return (
     <BottomSheetScrollView
       keyboardShouldPersistTaps="handled"
-      keyboardDismissMode="on-drag"
       style={[
         a.flex_1, // main diff is this
         a.p_xl,

--- a/src/components/Dialog/index.tsx
+++ b/src/components/Dialog/index.tsx
@@ -25,6 +25,7 @@ import {
   DialogOuterProps,
 } from '#/components/Dialog/types'
 import {createInput} from '#/components/forms/TextField'
+import {KeyboardPadding} from '#/components/KeyboardPadding'
 import {Portal} from '#/components/Portal'
 
 export {useDialogContext, useDialogControl} from '#/components/Dialog/context'
@@ -250,6 +251,7 @@ export const ScrollableInner = React.forwardRef<
       contentContainerStyle={a.pb_4xl}
       ref={ref}>
       {children}
+      <KeyboardPadding />
       <View style={{height: insets.bottom + a.pt_5xl.paddingTop}} />
     </BottomSheetScrollView>
   )

--- a/src/components/Dialog/index.tsx
+++ b/src/components/Dialog/index.tsx
@@ -237,6 +237,7 @@ export const ScrollableInner = React.forwardRef<
   return (
     <BottomSheetScrollView
       keyboardShouldPersistTaps="handled"
+      keyboardDismissMode="on-drag"
       style={[
         a.flex_1, // main diff is this
         a.p_xl,

--- a/src/components/Dialog/index.tsx
+++ b/src/components/Dialog/index.tsx
@@ -25,7 +25,6 @@ import {
   DialogOuterProps,
 } from '#/components/Dialog/types'
 import {createInput} from '#/components/forms/TextField'
-import {KeyboardPadding} from '#/components/KeyboardPadding'
 import {Portal} from '#/components/Portal'
 
 export {useDialogContext, useDialogControl} from '#/components/Dialog/context'
@@ -252,7 +251,6 @@ export const ScrollableInner = React.forwardRef<
       contentContainerStyle={a.pb_4xl}
       ref={ref}>
       {children}
-      <KeyboardPadding />
       <View style={{height: insets.bottom + a.pt_5xl.paddingTop}} />
     </BottomSheetScrollView>
   )

--- a/src/components/KeyboardPadding.android.tsx
+++ b/src/components/KeyboardPadding.android.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import {useKeyboardHandler} from 'react-native-keyboard-controller'
+import Animated, {
+  useAnimatedStyle,
+  useSharedValue,
+} from 'react-native-reanimated'
+
+export function KeyboardPadding() {
+  const keyboardHeight = useSharedValue(0)
+
+  useKeyboardHandler({
+    onMove: e => {
+      'worklet'
+      keyboardHeight.value = e.height
+    },
+  })
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    height: keyboardHeight.value,
+  }))
+
+  return <Animated.View style={animatedStyle} />
+}

--- a/src/components/KeyboardPadding.android.tsx
+++ b/src/components/KeyboardPadding.android.tsx
@@ -5,15 +5,23 @@ import Animated, {
   useSharedValue,
 } from 'react-native-reanimated'
 
-export function KeyboardPadding() {
+export function KeyboardPadding({maxHeight}: {maxHeight?: number}) {
   const keyboardHeight = useSharedValue(0)
 
-  useKeyboardHandler({
-    onMove: e => {
-      'worklet'
-      keyboardHeight.value = e.height
+  useKeyboardHandler(
+    {
+      onMove: e => {
+        'worklet'
+
+        if (maxHeight && e.height > maxHeight) {
+          keyboardHeight.value = maxHeight
+        } else {
+          keyboardHeight.value = e.height
+        }
+      },
     },
-  })
+    [maxHeight],
+  )
 
   const animatedStyle = useAnimatedStyle(() => ({
     height: keyboardHeight.value,

--- a/src/components/KeyboardPadding.tsx
+++ b/src/components/KeyboardPadding.tsx
@@ -1,0 +1,3 @@
+export function KeyboardPadding() {
+  return null
+}

--- a/src/components/KeyboardPadding.tsx
+++ b/src/components/KeyboardPadding.tsx
@@ -1,3 +1,3 @@
-export function KeyboardPadding() {
+export function KeyboardPadding({maxHeight: _}: {maxHeight?: number}) {
   return null
 }

--- a/src/components/ReportDialog/SubmitView.tsx
+++ b/src/components/ReportDialog/SubmitView.tsx
@@ -15,6 +15,7 @@ import * as Dialog from '#/components/Dialog'
 import * as Toggle from '#/components/forms/Toggle'
 import {Check_Stroke2_Corner0_Rounded as Check} from '#/components/icons/Check'
 import {ChevronLeft_Stroke2_Corner0_Rounded as ChevronLeft} from '#/components/icons/Chevron'
+import {KeyboardPadding} from '#/components/KeyboardPadding'
 import {Loader} from '#/components/Loader'
 import {Text} from '#/components/Typography'
 import {ReportDialogProps} from './types'
@@ -221,6 +222,7 @@ export function SubmitView({
           {submitting && <ButtonIcon icon={Loader} />}
         </Button>
       </View>
+      <KeyboardPadding />
     </View>
   )
 }

--- a/src/components/dialogs/MutedWords.tsx
+++ b/src/components/dialogs/MutedWords.tsx
@@ -28,6 +28,7 @@ import {Hashtag_Stroke2_Corner0_Rounded as Hashtag} from '#/components/icons/Has
 import {PageText_Stroke2_Corner0_Rounded as PageText} from '#/components/icons/PageText'
 import {PlusLarge_Stroke2_Corner0_Rounded as Plus} from '#/components/icons/Plus'
 import {TimesLarge_Stroke2_Corner0_Rounded as X} from '#/components/icons/Times'
+import {KeyboardPadding} from '#/components/KeyboardPadding'
 import {Loader} from '#/components/Loader'
 import * as Prompt from '#/components/Prompt'
 import {Text} from '#/components/Typography'
@@ -256,6 +257,7 @@ function MutedWordsInner() {
       </View>
 
       <Dialog.Close />
+      <KeyboardPadding maxHeight={100} />
     </Dialog.ScrollableInner>
   )
 }

--- a/src/components/moderation/LabelsOnMeDialog.tsx
+++ b/src/components/moderation/LabelsOnMeDialog.tsx
@@ -14,6 +14,7 @@ import * as Toast from '#/view/com/util/Toast'
 import {atoms as a, useBreakpoints, useTheme} from '#/alf'
 import {Button, ButtonIcon, ButtonText} from '#/components/Button'
 import * as Dialog from '#/components/Dialog'
+import {KeyboardPadding} from '#/components/KeyboardPadding'
 import {InlineLinkText} from '#/components/Link'
 import {Text} from '#/components/Typography'
 import {Divider} from '../Divider'
@@ -108,8 +109,8 @@ function LabelsOnMeDialogInner(props: LabelsOnMeDialogProps) {
           </View>
         </>
       )}
-
       <Dialog.Close />
+      <KeyboardPadding />
     </Dialog.ScrollableInner>
   )
 }

--- a/src/view/com/composer/GifAltText.tsx
+++ b/src/view/com/composer/GifAltText.tsx
@@ -20,6 +20,7 @@ import * as Dialog from '#/components/Dialog'
 import * as TextField from '#/components/forms/TextField'
 import {Check_Stroke2_Corner0_Rounded as Check} from '#/components/icons/Check'
 import {PlusSmall_Stroke2_Corner0_Rounded as Plus} from '#/components/icons/Plus'
+import {KeyboardPadding} from '#/components/KeyboardPadding'
 import {Text} from '#/components/Typography'
 import {GifEmbed} from '../util/post-embeds/GifEmbed'
 import {AltTextReminder} from './photos/Gallery'
@@ -180,6 +181,7 @@ function AltTextInner({
         </View>
       </View>
       <Dialog.Close />
+      <KeyboardPadding />
     </Dialog.ScrollableInner>
   )
 }

--- a/src/view/com/modals/Modal.tsx
+++ b/src/view/com/modals/Modal.tsx
@@ -5,6 +5,7 @@ import BottomSheet from '@discord/bottom-sheet/src'
 
 import {useModalControls, useModals} from '#/state/modals'
 import {usePalette} from 'lib/hooks/usePalette'
+import {KeyboardPadding} from '#/components/KeyboardPadding'
 import {createCustomBackdrop} from '../util/BottomSheetCustomBackdrop'
 import * as AddAppPassword from './AddAppPasswords'
 import * as AltImageModal from './AltImage'
@@ -146,6 +147,7 @@ export function ModalsContainer() {
       handleStyle={[styles.handle, pal.view]}
       onChange={onBottomSheetChange}>
       {element}
+      <KeyboardPadding />
     </BottomSheet>
   )
 }


### PR DESCRIPTION
## Why

Because of the needed changes on Android for the keyboard to behave correctly for DMs (as well as, eventually, the composer), it seems to have affected some users ability to properly scroll down to the button for saving alt-text. This is also apparent on the report dialog. Although it doesn't _break_ functionality (the text can still be input) it isn't possible to see the input, since the container does not get resized correctly.

While it would be possible to use a `KeyboardAvoidingView` inside of the new dialogs fairly easily, this becomes complicated with dialogs that are presented inside of the composer itself. That is because our composer is actually a dialog in the _old_ system, and then we are presenting another _new_  dialog inside of that one. This results in a `KeyboardAvoidingView` that wrap other `KeyboardAvoidingView`s. Eventually we won't have this problem, if we move to a better dialog for the composer.

For now, we can use an animated view to apply the padding on Android as needed. This actually results in a better experience than what we had before - the input is automatically scrolled to now, something that previously only worked well on iOS.

## Test Plan

There are a variety of dialogs on Android where this is useful at. There is no change on iOS, since `null` is returned instead of a view on that platform.

### Report Dialog


https://github.com/bluesky-social/social-app/assets/153161762/8f7efede-d986-4d5a-9157-a18ace4901c9

### Alt Text


https://github.com/bluesky-social/social-app/assets/153161762/98ed02b8-5e11-42a8-98ef-937166211443


### Appeal Dialog


https://github.com/bluesky-social/social-app/assets/153161762/4ff18bd5-a6c2-450d-a5fc-8e19b6c7265b


