### PR TITLE
[Session] Dispose of stale agents immediately

### DIFF
--- a/src/state/session/__tests__/session-test.ts
+++ b/src/state/session/__tests__/session-test.ts
@@ -872,7 +872,7 @@ describe('session', () => {
     expect(state.accounts[0].accessJwt).toBe('alice-access-jwt-3')
   })
 
-  it('ignores updates from a stale agent', () => {
+  it('accepts updates from a stale agent', () => {
     let state = getInitialState([])
 
     const agent1 = new BskyAgent({service: 'https://alice.com'})
@@ -928,10 +928,10 @@ describe('session', () => {
     ])
     expect(state.accounts.length).toBe(2)
     expect(state.accounts[1].did).toBe('alice-did')
-    // Should retain the old values because Alice is not active.
-    expect(state.accounts[1].handle).toBe('alice.test')
-    expect(state.accounts[1].accessJwt).toBe('alice-access-jwt-1')
-    expect(state.accounts[1].refreshJwt).toBe('alice-refresh-jwt-1')
+    // Should update Alice's tokens because otherwise they'll be stale.
+    expect(state.accounts[1].handle).toBe('alice-updated.test')
+    expect(state.accounts[1].accessJwt).toBe('alice-access-jwt-2')
+    expect(state.accounts[1].refreshJwt).toBe('alice-refresh-jwt-2')
     expect(printState(state)).toMatchInlineSnapshot(`
       {
         "accounts": [
@@ -948,15 +948,15 @@ describe('session', () => {
             "service": "https://bob.com/",
           },
           {
-            "accessJwt": "alice-access-jwt-1",
+            "accessJwt": "alice-access-jwt-2",
             "deactivated": false,
             "did": "alice-did",
-            "email": undefined,
+            "email": "alice@foo.bar",
             "emailAuthFactor": false,
             "emailConfirmed": false,
-            "handle": "alice.test",
+            "handle": "alice-updated.test",
             "pdsUrl": undefined,
-            "refreshJwt": "alice-refresh-jwt-1",
+            "refreshJwt": "alice-refresh-jwt-2",
             "service": "https://alice.com/",
           },
         ],
@@ -988,7 +988,7 @@ describe('session', () => {
     ])
     expect(state.accounts.length).toBe(2)
     expect(state.accounts[0].did).toBe('bob-did')
-    // Should update the values because Bob is active.
+    // Should update Bob's tokens because otherwise they'll be stale.
     expect(state.accounts[0].handle).toBe('bob-updated.test')
     expect(state.accounts[0].accessJwt).toBe('bob-access-jwt-2')
     expect(state.accounts[0].refreshJwt).toBe('bob-refresh-jwt-2')
@@ -1008,15 +1008,15 @@ describe('session', () => {
             "service": "https://bob.com/",
           },
           {
-            "accessJwt": "alice-access-jwt-1",
+            "accessJwt": "alice-access-jwt-2",
             "deactivated": false,
             "did": "alice-did",
-            "email": undefined,
+            "email": "alice@foo.bar",
             "emailAuthFactor": false,
             "emailConfirmed": false,
-            "handle": "alice.test",
+            "handle": "alice-updated.test",
             "pdsUrl": undefined,
-            "refreshJwt": "alice-refresh-jwt-1",
+            "refreshJwt": "alice-refresh-jwt-2",
             "service": "https://alice.com/",
           },
         ],
@@ -1030,7 +1030,7 @@ describe('session', () => {
       }
     `)
 
-    // Ignore other events for inactive agent too.
+    // Ignore other events for inactive agent.
     const lastState = state
     agent1.session = undefined
     state = run(state, [

--- a/src/state/session/index.tsx
+++ b/src/state/session/index.tsx
@@ -208,6 +208,19 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
   if (IS_DEV && isWeb) window.agent = state.currentAgentState.agent
 
   const agent = state.currentAgentState.agent as BskyAgent
+  const currentAgentRef = React.useRef(agent)
+  React.useEffect(() => {
+    if (currentAgentRef.current !== agent) {
+      // Read the previous value and immediately advance the pointer.
+      const prevAgent = currentAgentRef.current
+      currentAgentRef.current = agent
+      // We never reuse agents so let's fully neutralize the previous one.
+      // This ensures it won't try to consume any refresh tokens.
+      prevAgent.session = undefined
+      prevAgent.setPersistSessionHandler(undefined)
+    }
+  }, [agent])
+
   return (
     <AgentContext.Provider value={agent}>
       <StateContext.Provider value={stateContext}>

--- a/src/state/session/reducer.ts
+++ b/src/state/session/reducer.ts
@@ -68,8 +68,13 @@ export function reducer(state: State, action: Action): State {
   switch (action.type) {
     case 'received-agent-event': {
       const {agent, accountDid, refreshedAccount, sessionEvent} = action
-      if (agent !== state.currentAgentState.agent) {
-        // Only consider events from the active agent.
+      if (
+        refreshedAccount === undefined &&
+        agent !== state.currentAgentState.agent
+      ) {
+        // If the session got cleared out (e.g. due to expiry or network error) but
+        // this account isn't the active one, don't clear it out at this time.
+        // This way, if the problem is transient, it'll work on next resume.
         return state
       }
       if (sessionEvent === 'network-error') {


### PR DESCRIPTION
## Stacked on #4181

In #4181, I added some logic for the case when a stale agent refreshes the token. We'd like to persist the new refresh token if that happens. However, that by itself is more like a failsafe — ideally stale agents wouldn't even _be able_ to consume existing refresh tokens. Since otherwise two agents may keep fighting for tokens and invalidating each other.

So this stacks a second commit which disposes of stale agents by clearing out their session (and the persistence handler for good measure). This means that the failsafe I added in #4181 actually become a no-op (i.e. this should never happen). Still, both fixes make sense to me in isolation so I think I'd like to get both of them in.

## Test Plan

Careful inspection of the logic. One thing we can do for testing is to force the old agent to keep doing something in an interval, getting to the refresh timeout, and then checking whether they're fighting for resuming or not.