### PR TITLE
Handle zero bottom inset on iOS

### DIFF
--- a/src/screens/Messages/Conversation/MessagesList.tsx
+++ b/src/screens/Messages/Conversation/MessagesList.tsx
@@ -222,7 +222,7 @@ export function MessagesList({
 
   // -- Keyboard animation handling
   const {bottom: bottomInset} = useSafeAreaInsets()
-  const bottomOffset = isWeb ? 0 : clamp(60 + bottomInset, 60, 76)
+  const bottomOffset = isWeb ? 0 : clamp(60 + bottomInset, 60, 75)
 
   const keyboardHeight = useSharedValue(0)
   const keyboardIsOpening = useSharedValue(false)

--- a/src/screens/Messages/Conversation/MessagesList.tsx
+++ b/src/screens/Messages/Conversation/MessagesList.tsx
@@ -16,10 +16,11 @@ import {useSafeAreaInsets} from 'react-native-safe-area-context'
 import {AppBskyRichtextFacet, RichText} from '@atproto/api'
 
 import {shortenLinks} from '#/lib/strings/rich-text-manip'
-import {isIOS, isNative} from '#/platform/detection'
+import {isNative} from '#/platform/detection'
 import {isConvoActive, useConvoActive} from '#/state/messages/convo'
 import {ConvoItem, ConvoStatus} from '#/state/messages/convo/types'
 import {useAgent} from '#/state/session'
+import {clamp} from 'lib/numbers'
 import {ScrollProvider} from 'lib/ScrollContext'
 import {isWeb} from 'platform/detection'
 import {List} from 'view/com/util/List'
@@ -221,8 +222,7 @@ export function MessagesList({
 
   // -- Keyboard animation handling
   const {bottom: bottomInset} = useSafeAreaInsets()
-  const nativeBottomBarHeight = isIOS ? 42 : 60
-  const bottomOffset = isWeb ? 0 : bottomInset + nativeBottomBarHeight
+  const bottomOffset = isWeb ? 0 : clamp(60 + bottomInset, 60, 76)
 
   const keyboardHeight = useSharedValue(0)
   const keyboardIsOpening = useSharedValue(false)


### PR DESCRIPTION
## Why

It is fairly difficult on iOS for us to calculate our real safe area because our bottom is clamping the padding based on the device's inset. For example, on an iPhone 8 or lower, the padding gets set to `15` - because the real bottom inset is `0`. However, on other devices it becomes `30` because the inset _is_ set (an iPhone X or higher has a bottom inset of `34`).

this results in some bad behavior with the message input in the chat screen. We need to account for this _missing_ padding in these circumstances.

On most devices this offset is very small, even on Android devices. Newer iPhone devices have the tallest offsets, so for thos devices we want to set the max to 76. The minimum - when the offset is zero - should be 60.

## Test Plan

With the adjusted offset for these circumstances, all devices should appear to have the same style for the text input

![Screenshot 2024-05-22 at 7 10 24 PM](https://github.com/bluesky-social/social-app/assets/153161762/e6abbd98-f261-406c-90ca-e8a4d6f8852d)
