### PR TITLE
[🐴] Suspend event bus when switching accounts

### DIFF
--- a/src/state/messages/events/index.tsx
+++ b/src/state/messages/events/index.tsx
@@ -36,6 +36,10 @@ export function MessagesEventBusProvider({
       // @ts-ignore
       window.bus = bus
     }
+
+    return () => {
+      bus.suspend()
+    }
   }, [bus])
 
   React.useEffect(() => {

--- a/src/state/messages/events/index.tsx
+++ b/src/state/messages/events/index.tsx
@@ -1,10 +1,8 @@
 import React from 'react'
 import {AppState} from 'react-native'
 
-import {isWeb} from '#/platform/detection'
 import {MessagesEventBus} from '#/state/messages/events/agent'
 import {useAgent} from '#/state/session'
-import {IS_DEV} from '#/env'
 
 const MessagesEventBusContext = React.createContext<MessagesEventBus | null>(
   null,
@@ -32,10 +30,7 @@ export function MessagesEventBusProvider({
   )
 
   React.useEffect(() => {
-    if (isWeb && IS_DEV) {
-      // @ts-ignore
-      window.bus = bus
-    }
+    bus.resume()
 
     return () => {
       bus.suspend()


### PR DESCRIPTION
This provider is mounted in `App.*.tsx` and unmounts when the account changes. When unmounting, we need to call `suspend()` to deactivate the active event bus.