### PR TITLE
[🐴] Reduce polling when app is backgrounded

### DIFF
--- a/src/state/messages/events/agent.ts
+++ b/src/state/messages/events/agent.ts
@@ -4,7 +4,10 @@ import {nanoid} from 'nanoid/non-secure'
 
 import {networkRetry} from '#/lib/async/retry'
 import {logger} from '#/logger'
-import {DEFAULT_POLL_INTERVAL} from '#/state/messages/events/const'
+import {
+  BACKGROUND_POLL_INTERVAL,
+  DEFAULT_POLL_INTERVAL,
+} from '#/state/messages/events/const'
 import {
   MessagesEventBusDispatch,
   MessagesEventBusDispatchEvent,
@@ -286,6 +289,9 @@ export class MessagesEventBus {
         const requested = Array.from(this.requestedPollIntervals.values())
         const lowest = Math.min(DEFAULT_POLL_INTERVAL, ...requested)
         return lowest
+      }
+      case MessagesEventBusStatus.Backgrounded: {
+        return BACKGROUND_POLL_INTERVAL
       }
       default:
         return DEFAULT_POLL_INTERVAL

--- a/src/state/messages/events/const.ts
+++ b/src/state/messages/events/const.ts
@@ -1,1 +1,2 @@
 export const DEFAULT_POLL_INTERVAL = 20e3
+export const BACKGROUND_POLL_INTERVAL = 60e3


### PR DESCRIPTION
Built this with this use case in mind, but never returned to reduce polling when the app is backgrounded. This is mostly for web, which does actually continue to poll in the background. iOS and Android both pause and resume when foregrounded.