### PR TITLE
disable alt text auto focus on Android

### DIFF
--- a/src/view/com/modals/AltImage.tsx
+++ b/src/view/com/modals/AltImage.tsx
@@ -47,7 +47,7 @@ export function Component({image}: Props) {
     if (isAndroid) return
     setTimeout(() => {
       inputRef.current?.focus()
-    }, 1000)
+    }, 500)
   }, [])
 
   // We'd rather be at the bottom here so that we can easily dismiss the modal instead of having to scroll

--- a/src/view/com/modals/AltImage.tsx
+++ b/src/view/com/modals/AltImage.tsx
@@ -20,7 +20,7 @@ import {usePalette} from 'lib/hooks/usePalette'
 import {enforceLen} from 'lib/strings/helpers'
 import {gradients, s} from 'lib/styles'
 import {useTheme} from 'lib/ThemeContext'
-import {isWeb} from 'platform/detection'
+import {isAndroid, isWeb} from 'platform/detection'
 import {ImageModel} from 'state/models/media/image'
 import {Text} from '../util/text/Text'
 import {ScrollView, TextInput} from './util'
@@ -44,9 +44,10 @@ export function Component({image}: Props) {
 
   // Autofocus hack when we open the modal. We have to wait for the animation to complete first
   React.useEffect(() => {
+    if (isAndroid) return
     setTimeout(() => {
       inputRef.current?.focus()
-    }, 500)
+    }, 1000)
   }, [])
 
   // We'd rather be at the bottom here so that we can easily dismiss the modal instead of having to scroll


### PR DESCRIPTION
## Why

On Android, focusing this input automatically causes problems with resizing the container correctly. Even prior to the latest release - where something else broke - this still happens occasionally. It isn't consistent, it works 80% of the time but the other 20% it breaks.

For now, let's disable the autofocus on Android until we get a better chance to rework these dialogs.