### PR TITLE
[🐴] Overfetch follow for default new dialog state

### DIFF
--- a/src/components/dms/NewChatDialog/index.tsx
+++ b/src/components/dms/NewChatDialog/index.tsx
@@ -314,9 +314,7 @@ function SearchablePeopleList({
     isError,
     isFetching,
   } = useActorAutocompleteQuery(searchText, true, 12)
-  const {data: follows} = useProfileFollowsQuery(currentAccount?.did, {
-    limit: 12,
-  })
+  const {data: follows} = useProfileFollowsQuery(currentAccount?.did)
 
   const items = useMemo(() => {
     let _items: Item[] = []


### PR DESCRIPTION
Ok last thing I had on my list to get in was related to the new chat dialog. Users are confused that they can’t message the users in the list.

The easiest way to help that right now is to overfetch follows and apply the same sorting, so that presumably a greater # of users can be messaged.

Right now we’re fetching 12, which for me rn returns only 6 I can follow. If I increase that to the default of 50, I get ~15, which is more than enough to fill the window.