### PR TITLE
Add statusBarTranslucent prop (= true) to KeyboardProvider in App.native.tsx

### DIFF
--- a/src/App.native.tsx
+++ b/src/App.native.tsx
@@ -143,7 +143,7 @@ function App() {
    * that is set up in the InnerApp component above.
    */
   return (
-    <KeyboardProvider enabled={true}>
+    <KeyboardProvider enabled={true} statusBarTranslucent={true}>
       <SessionProvider>
         <ShellStateProvider>
           <PrefsStateProvider>


### PR DESCRIPTION
In current version (1.83.0.190), splash screen on Android has unwanted white (not translucent) status bar. In previous version, status bar had the same color as background (blue on light mode or dark blue on dark mode).

![Splash screen](https://github.com/bluesky-social/social-app/assets/7834440/58d6a8d8-10db-4942-b8a5-575e31bfdcce)

This is due to `KeyboardProvider` of the Keyboard Controller library. By default Keyboard Controller adds the padding of status bar. To override this behavior, we can add `statusBarTranslucent` prop and set to true. See [the document of Keyboard Controller](https://kirillzyusko.github.io/react-native-keyboard-controller/docs/api/keyboard-provider#statusbartranslucent-) for more information.

Note: I do not check all side effects of this modification about the Keyboard Controller library. Before merging, check the behavior of existing implimentation using Keyboard Controller library.