### PR TITLE
[🐴] Make sure failed messages enter error state

### DIFF
--- a/src/state/messages/convo/agent.ts
+++ b/src/state/messages/convo/agent.ts
@@ -830,9 +830,10 @@ export class Convo {
       if (NETWORK_FAILURE_STATUSES.includes(e.status)) {
         this.pendingMessageFailure = 'recoverable'
       } else {
+        this.pendingMessageFailure = 'unrecoverable'
+
         switch (e.message) {
           case 'block between recipient and sender':
-            this.pendingMessageFailure = 'unrecoverable'
             this.emitter.emit('event', {
               type: 'invalidate-block-state',
               accountDids: [
@@ -842,8 +843,13 @@ export class Convo {
             })
             break
           case 'Account is disabled':
-            this.pendingMessageFailure = 'unrecoverable'
             this.dispatch({event: ConvoDispatchEvent.Disable})
+            break
+          case 'Convo not found':
+          case 'Account does not exist':
+          case 'recipient does not exist':
+          case 'recipient requires incoming messages to come from someone they follow':
+          case 'recipient has disabled incoming messages':
             break
           default:
             logger.warn(
@@ -857,6 +863,7 @@ export class Convo {
         }
       }
     } else {
+      this.pendingMessageFailure = 'unrecoverable'
       logger.error(e, {
         context: `Convo handleSendMessageFailure received unknown error`,
       })


### PR DESCRIPTION
Error handling for message send failures was incomplete. This PR adds handling for all our known errors, and ensures that `pendingMessageFailure` is set for all failures.