### PR TITLE
[🐴] Recover from initial failed firehose state

### DIFF
--- a/src/state/messages/events/agent.ts
+++ b/src/state/messages/events/agent.ts
@@ -210,6 +210,7 @@ export class MessagesEventBus {
       }
       case MessagesEventBusStatus.Error: {
         switch (action.event) {
+          case MessagesEventBusDispatchEvent.UpdatePoll:
           case MessagesEventBusDispatchEvent.Resume: {
             // basically reset
             this.status = MessagesEventBusStatus.Initializing


### PR DESCRIPTION
We've had some reports of chats failing to update. One possible culprit I've thought of so far is what this PR addresses: if the event bus/firehose is in an error state, starting a new chat will not restart the polling.

So if the user:
- opens app
- event log fails for any reason
- they nav to a chat or start a new one
- send a message
- we never poll for messages, and so never get a response back from their recipient

It's not clear why the event log is failing yet, but we have had issues with session agents that could cause failures like this, and fixes have been merged already.

What this PR does is handle a dispatched `UpdatePoll` event when the firehose is in an error state, and uses that to basically restart from 0 and attempt a recovery. If it fails again after this, the Convo screen will show its normal error.