### PR TITLE
Move ALT indicator right and shrink it a bit

### DIFF
--- a/src/view/com/util/images/Gallery.tsx
+++ b/src/view/com/util/images/Gallery.tsx
@@ -74,12 +74,12 @@ const styles = StyleSheet.create({
     position: 'absolute',
     // Related to margin/gap hack. This keeps the alt label in the same position
     // on all platforms
-    left: isWeb ? 8 : 5,
+    right: isWeb ? 8 : 5,
     bottom: isWeb ? 8 : 5,
   },
   alt: {
     color: 'white',
-    fontSize: 10,
+    fontSize: 6,
     fontWeight: 'bold',
   },
 })

--- a/src/view/com/util/post-embeds/index.tsx
+++ b/src/view/com/util/post-embeds/index.tsx
@@ -178,12 +178,12 @@ const styles = StyleSheet.create({
     paddingHorizontal: 6,
     paddingVertical: 3,
     position: 'absolute',
-    left: 6,
+    right: 6,
     bottom: 6,
   },
   alt: {
     color: 'white',
-    fontSize: 10,
+    fontSize: 6,
     fontWeight: 'bold',
   },
   customFeedOuter: {


### PR DESCRIPTION
The ALT text indicator has a habit of covering text inside of images, which is pretty irritating and counter-productive for an a11y feature. This PR moves the ALT indicator from the left to the right and shrinks it, hopefully reducing the likelyhood that it'll cover content.

|Before|After|
|-|-|
|![CleanShot 2024-05-24 at 10 31 32@2x](https://github.com/bluesky-social/social-app/assets/1270099/14c4d9ab-2de6-4dae-b781-aaad1b144a79)|![CleanShot 2024-05-24 at 10 30 13@2x](https://github.com/bluesky-social/social-app/assets/1270099/cae673df-114a-4be2-9b79-154f9651665a)|
|||
|![CleanShot 2024-05-24 at 10 32 24@2x](https://github.com/bluesky-social/social-app/assets/1270099/00c1fef6-dbbb-42e1-b2af-a3708dbda4a5)|![CleanShot 2024-05-24 at 10 30 26@2x](https://github.com/bluesky-social/social-app/assets/1270099/7e4b8350-aae7-49c7-ae80-0498ddac0ad0)|
|||
|![CleanShot 2024-05-24 at 10 32 43@2x](https://github.com/bluesky-social/social-app/assets/1270099/427f2f8f-60e7-438b-b242-6bd3068fdb57)|![CleanShot 2024-05-24 at 10 30 35@2x](https://github.com/bluesky-social/social-app/assets/1270099/cef37ddd-e7a3-4586-a991-f5126bae24cc)|
|||
|![CleanShot 2024-05-24 at 10 32 58@2x](https://github.com/bluesky-social/social-app/assets/1270099/9f477671-49f6-4e7a-a452-c68e2847a7ac)|![CleanShot 2024-05-24 at 10 30 44@2x](https://github.com/bluesky-social/social-app/assets/1270099/24f70337-1761-4209-8b7c-bb0155dff2b3)|
|||
|![CleanShot 2024-05-24 at 10 33 13@2x](https://github.com/bluesky-social/social-app/assets/1270099/86ca13a9-7c8f-426d-ba92-c1b69881cfef)|![CleanShot 2024-05-24 at 10 30 58@2x](https://github.com/bluesky-social/social-app/assets/1270099/aee85462-270f-42a3-b488-8c2f408521ac)|
