### PR TITLE
set `onEndReachedThreshold` to `2` for notifications

### DIFF
--- a/src/view/com/notifications/Feed.tsx
+++ b/src/view/com/notifications/Feed.tsx
@@ -165,7 +165,7 @@ export function Feed({
         refreshing={isPTRing}
         onRefresh={onRefresh}
         onEndReached={onEndReached}
-        onEndReachedThreshold={0.6}
+        onEndReachedThreshold={2}
         onScrolledDownChange={onScrolledDownChange}
         contentContainerStyle={s.contentContainer}
         // @ts-ignore our .web version only -prf


### PR DESCRIPTION
## Why

The notifications tab is one of the last places I consistently hit the end of now, especially on web. Ideally we want to prevent seeing the spinner at the bottom of the page as much as possible.

## Test Plan

This page should be much more difficult to hit the end of now, as we should load in the new notifications well before hitting the end.


https://github.com/bluesky-social/social-app/assets/153161762/eb7a6483-bc75-483d-9765-a1b2558bc630

