### PR TITLE
add prop to ListImpl for disabling `content-visibility` style

### DIFF
--- a/src/screens/Messages/Conversation/MessagesList.tsx
+++ b/src/screens/Messages/Conversation/MessagesList.tsx
@@ -328,6 +328,7 @@ export function MessagesList({
           renderItem={renderItem}
           keyExtractor={keyExtractor}
           containWeb={true}
+          disableContentVisibility={true}
           disableVirtualization={true}
           style={animatedListStyle}
           // The extra two items account for the header and the footer components
@@ -340,7 +341,6 @@ export function MessagesList({
           }}
           removeClippedSubviews={false}
           sideBorders={false}
-          useContentVisibility={false}
           onContentSizeChange={onContentSizeChange}
           onLayout={onListLayout}
           onStartReached={onStartReached}

--- a/src/screens/Messages/Conversation/MessagesList.tsx
+++ b/src/screens/Messages/Conversation/MessagesList.tsx
@@ -340,6 +340,7 @@ export function MessagesList({
           }}
           removeClippedSubviews={false}
           sideBorders={false}
+          useContentVisibility={false}
           onContentSizeChange={onContentSizeChange}
           onLayout={onListLayout}
           onStartReached={onStartReached}

--- a/src/screens/Messages/Conversation/MessagesList.tsx
+++ b/src/screens/Messages/Conversation/MessagesList.tsx
@@ -15,7 +15,6 @@ import {ReanimatedScrollEvent} from 'react-native-reanimated/lib/typescript/rean
 import {useSafeAreaInsets} from 'react-native-safe-area-context'
 import {AppBskyRichtextFacet, RichText} from '@atproto/api'
 
-import {isFirefox} from '#/lib/browser'
 import {shortenLinks} from '#/lib/strings/rich-text-manip'
 import {isNative} from '#/platform/detection'
 import {isConvoActive, useConvoActive} from '#/state/messages/convo'
@@ -329,10 +328,9 @@ export function MessagesList({
           renderItem={renderItem}
           keyExtractor={keyExtractor}
           containWeb={true}
-          disableContentVisibility={
-            /* Prevents jank when sending message */
-            isFirefox
-          }
+          // Prevents wrong position in Firefox when sending a message
+          // as well as scroll getting stuck on Chome when scrolling upwards.
+          disableContentVisibility={true}
           disableVirtualization={true}
           style={animatedListStyle}
           // The extra two items account for the header and the footer components

--- a/src/screens/Messages/Conversation/MessagesList.tsx
+++ b/src/screens/Messages/Conversation/MessagesList.tsx
@@ -15,6 +15,7 @@ import {ReanimatedScrollEvent} from 'react-native-reanimated/lib/typescript/rean
 import {useSafeAreaInsets} from 'react-native-safe-area-context'
 import {AppBskyRichtextFacet, RichText} from '@atproto/api'
 
+import {isFirefox} from '#/lib/browser'
 import {shortenLinks} from '#/lib/strings/rich-text-manip'
 import {isNative} from '#/platform/detection'
 import {isConvoActive, useConvoActive} from '#/state/messages/convo'
@@ -328,7 +329,10 @@ export function MessagesList({
           renderItem={renderItem}
           keyExtractor={keyExtractor}
           containWeb={true}
-          disableContentVisibility={true}
+          disableContentVisibility={
+            /* Prevents jank when sending message */
+            isFirefox
+          }
           disableVirtualization={true}
           style={animatedListStyle}
           // The extra two items account for the header and the footer components

--- a/src/view/com/util/List.tsx
+++ b/src/view/com/util/List.tsx
@@ -26,6 +26,8 @@ export type ListProps<ItemT> = Omit<
   onItemSeen?: (item: ItemT) => void
   containWeb?: boolean
   sideBorders?: boolean
+  // Web only prop for performance optimizing style. Default is true.
+  useContentVisibility?: boolean
 }
 export type ListRef = React.MutableRefObject<FlatList_INTERNAL | null>
 

--- a/src/view/com/util/List.tsx
+++ b/src/view/com/util/List.tsx
@@ -27,7 +27,7 @@ export type ListProps<ItemT> = Omit<
   containWeb?: boolean
   sideBorders?: boolean
   // Web only prop for performance optimizing style. Default is true.
-  useContentVisibility?: boolean
+  disableContentVisibility?: boolean
 }
 export type ListRef = React.MutableRefObject<FlatList_INTERNAL | null>
 

--- a/src/view/com/util/List.tsx
+++ b/src/view/com/util/List.tsx
@@ -26,7 +26,7 @@ export type ListProps<ItemT> = Omit<
   onItemSeen?: (item: ItemT) => void
   containWeb?: boolean
   sideBorders?: boolean
-  // Web only prop for performance optimizing style. Default is true.
+  // Web only prop to disable a perf optimization (which would otherwise be on).
   disableContentVisibility?: boolean
 }
 export type ListRef = React.MutableRefObject<FlatList_INTERNAL | null>

--- a/src/view/com/util/List.web.tsx
+++ b/src/view/com/util/List.web.tsx
@@ -25,7 +25,7 @@ export type ListProps<ItemT> = Omit<
   desktopFixedHeight: any // TODO: Better types.
   containWeb?: boolean
   sideBorders?: boolean
-  useContentVisibility?: boolean
+  disableContentVisibility?: boolean
 }
 export type ListRef = React.MutableRefObject<any | null> // TODO: Better types.
 
@@ -57,7 +57,7 @@ function ListImpl<ItemT>(
     extraData,
     style,
     sideBorders = true,
-    useContentVisibility = true,
+    disableContentVisibility,
     ...props
   }: ListProps<ItemT>,
   ref: React.Ref<ListMethods>,
@@ -341,7 +341,7 @@ function ListImpl<ItemT>(
               renderItem={renderItem}
               extraData={extraData}
               onItemSeen={onItemSeen}
-              useContentVisibility={useContentVisibility}
+              disableContentVisibility={disableContentVisibility}
             />
           )
         })}
@@ -390,7 +390,7 @@ let Row = function RowImpl<ItemT>({
   renderItem,
   extraData: _unused,
   onItemSeen,
-  useContentVisibility,
+  disableContentVisibility,
 }: {
   item: ItemT
   index: number
@@ -400,7 +400,7 @@ let Row = function RowImpl<ItemT>({
     | ((data: {index: number; item: any; separators: any}) => React.ReactNode)
   extraData: any
   onItemSeen: ((item: any) => void) | undefined
-  useContentVisibility: boolean
+  disableContentVisibility: boolean
 }): React.ReactNode {
   const rowRef = React.useRef(null)
   const intersectionTimeout = React.useRef<NodeJS.Timer | undefined>(undefined)
@@ -450,7 +450,9 @@ let Row = function RowImpl<ItemT>({
   }
 
   return (
-    <View style={useContentVisibility ? styles.row : undefined} ref={rowRef}>
+    <View
+      style={disableContentVisibility ? undefined : styles.row}
+      ref={rowRef}>
       {renderItem({item, index, separators: null as any})}
     </View>
   )

--- a/src/view/com/util/List.web.tsx
+++ b/src/view/com/util/List.web.tsx
@@ -400,7 +400,7 @@ let Row = function RowImpl<ItemT>({
     | ((data: {index: number; item: any; separators: any}) => React.ReactNode)
   extraData: any
   onItemSeen: ((item: any) => void) | undefined
-  disableContentVisibility: boolean
+  disableContentVisibility?: boolean
 }): React.ReactNode {
   const rowRef = React.useRef(null)
   const intersectionTimeout = React.useRef<NodeJS.Timer | undefined>(undefined)

--- a/src/view/com/util/List.web.tsx
+++ b/src/view/com/util/List.web.tsx
@@ -5,7 +5,7 @@ import {ReanimatedScrollEvent} from 'react-native-reanimated/lib/typescript/rean
 import {batchedUpdates} from '#/lib/batchedUpdates'
 import {useNonReactiveCallback} from '#/lib/hooks/useNonReactiveCallback'
 import {useScrollHandlers} from '#/lib/ScrollContext'
-import {isFirefox, isSafari} from 'lib/browser'
+import {isSafari} from 'lib/browser'
 import {usePalette} from 'lib/hooks/usePalette'
 import {useWebMediaQueries} from 'lib/hooks/useWebMediaQueries'
 import {addStyle} from 'lib/styles'
@@ -25,6 +25,7 @@ export type ListProps<ItemT> = Omit<
   desktopFixedHeight: any // TODO: Better types.
   containWeb?: boolean
   sideBorders?: boolean
+  useContentVisibility?: boolean
 }
 export type ListRef = React.MutableRefObject<any | null> // TODO: Better types.
 
@@ -56,6 +57,7 @@ function ListImpl<ItemT>(
     extraData,
     style,
     sideBorders = true,
+    useContentVisibility = true,
     ...props
   }: ListProps<ItemT>,
   ref: React.Ref<ListMethods>,
@@ -339,6 +341,7 @@ function ListImpl<ItemT>(
               renderItem={renderItem}
               extraData={extraData}
               onItemSeen={onItemSeen}
+              useContentVisibility={useContentVisibility}
             />
           )
         })}
@@ -387,6 +390,7 @@ let Row = function RowImpl<ItemT>({
   renderItem,
   extraData: _unused,
   onItemSeen,
+  useContentVisibility,
 }: {
   item: ItemT
   index: number
@@ -396,6 +400,7 @@ let Row = function RowImpl<ItemT>({
     | ((data: {index: number; item: any; separators: any}) => React.ReactNode)
   extraData: any
   onItemSeen: ((item: any) => void) | undefined
+  useContentVisibility: boolean
 }): React.ReactNode {
   const rowRef = React.useRef(null)
   const intersectionTimeout = React.useRef<NodeJS.Timer | undefined>(undefined)
@@ -445,7 +450,7 @@ let Row = function RowImpl<ItemT>({
   }
 
   return (
-    <View style={styles.row} ref={rowRef}>
+    <View style={useContentVisibility ? styles.row : undefined} ref={rowRef}>
       {renderItem({item, index, separators: null as any})}
     </View>
   )
@@ -518,7 +523,7 @@ const styles = StyleSheet.create({
   },
   row: {
     // @ts-ignore web only
-    contentVisibility: isSafari || isFirefox ? '' : 'auto', // Safari support for this is buggy.
+    contentVisibility: isSafari ? '' : 'auto', // Safari support for this is buggy.
   },
   minHeightViewport: {
     // @ts-ignore web only

--- a/src/view/com/util/List.web.tsx
+++ b/src/view/com/util/List.web.tsx
@@ -449,9 +449,14 @@ let Row = function RowImpl<ItemT>({
     return null
   }
 
+  const shouldDisableContentVisibility = disableContentVisibility || isSafari
   return (
     <View
-      style={disableContentVisibility ? undefined : styles.row}
+      style={
+        shouldDisableContentVisibility
+          ? undefined
+          : styles.contentVisibilityAuto
+      }
       ref={rowRef}>
       {renderItem({item, index, separators: null as any})}
     </View>
@@ -523,9 +528,9 @@ const styles = StyleSheet.create({
     marginLeft: 'auto',
     marginRight: 'auto',
   },
-  row: {
+  contentVisibilityAuto: {
     // @ts-ignore web only
-    contentVisibility: isSafari ? '' : 'auto', // Safari support for this is buggy.
+    contentVisibility: 'auto',
   },
   minHeightViewport: {
     // @ts-ignore web only


### PR DESCRIPTION
## Why

We recently discovered that there was some problems with the `content-visibility` style in the `ListImpl` for chat on Firefox. We originally just removed this style all together on Firefox, however that came with what seems like some performance hits. It seems like a better idea to scope this down to specific cases where it causes problems instead.

I've added a prop to `ListProps` called `disableContentVisibility`, which will simply not add the style when set to `true`.

We could scope this down further to just set this prop to `true` if the browser is Firefox, though this might not always work in cases such as:

- Spoofed user agent
- Some older Chrome version that might not have good support for this style (?)

## Test Plan

Using the `MessagesList`, you can comment out the `disableContentVisibility` prop and see that on Firefox we return to having jank on message sending. If we uncomment the prop, we see that the jank disappears.