### PR TITLE
bump iOS target to `14.0`

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -183,7 +183,7 @@ module.exports = function (config) {
           'expo-build-properties',
           {
             ios: {
-              deploymentTarget: '13.4',
+              deploymentTarget: '14.0',
               newArchEnabled: false,
             },
             android: {


### PR DESCRIPTION
## Why

Some upcoming features are going to require a minimum target of iOS 14 or higher. While we can technically still keep targeting 13.4, this doesn't seem necessary. I've checked Statsig logs and we don't have any daily inits on any iOS 13 version.

## Test Plan

Just `yarn prebuild` and `yarn ios`