### PR TITLE
Fix `hitSlop` type

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3113,7 +3113,7 @@
 
 "@discord/bottom-sheet@bluesky-social/react-native-bottom-sheet":
   version "4.6.1"
-  resolved "https://codeload.github.com/bluesky-social/react-native-bottom-sheet/tar.gz/3232c7cd9b966dd977c849a360fa853f88dcf3ca"
+  resolved "https://codeload.github.com/bluesky-social/react-native-bottom-sheet/tar.gz/28a87d1bb55e10fc355fa1455545a30734995908"
   dependencies:
     "@gorhom/portal" "1.0.14"
     invariant "^2.2.4"


### PR DESCRIPTION
CI is failing typecheck because it says that `hitSlop` on a `TextInput` cannot be `null`. However, this isn't the case. See: https://github.com/facebook/react-native/blob/a93a15aca3e380f2f8158465b1b315ac3fab8307/packages/react-native/Libraries/Components/View/ViewPropTypes.d.ts#L135

This is a problem with `react-native-gesture-detector`'s type for `hitSlop` and it's version of `TextInput`. We don't use this in our codebase at all - and don't have any need to either. Nor do we use the `BottomSheetTextInput`. We use our own UI kit's text input component.

I've asserted the type for now in the `react-native-bottom-sheet` library to silence this error, so need to update the `yarn.lock`.