### PR TITLE
Alt text followups -- SLIGHTLY larger, and update gifs

### DIFF
--- a/src/view/com/util/images/Gallery.tsx
+++ b/src/view/com/util/images/Gallery.tsx
@@ -79,7 +79,7 @@ const styles = StyleSheet.create({
   },
   alt: {
     color: 'white',
-    fontSize: 6,
+    fontSize: 7,
     fontWeight: 'bold',
   },
 })

--- a/src/view/com/util/post-embeds/GifEmbed.tsx
+++ b/src/view/com/util/post-embeds/GifEmbed.tsx
@@ -5,7 +5,7 @@ import {FontAwesomeIcon} from '@fortawesome/react-native-fontawesome'
 import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
-import {HITSLOP_10} from '#/lib/constants'
+import {HITSLOP_20} from '#/lib/constants'
 import {parseAltFromGIFDescription} from '#/lib/gif-alt-text'
 import {isWeb} from '#/platform/detection'
 import {EmbedPlayerParams} from 'lib/strings/embed-player'
@@ -166,7 +166,7 @@ function AltText({text}: {text: string}) {
         accessibilityRole="button"
         accessibilityLabel={_(msg`Show alt text`)}
         accessibilityHint=""
-        hitSlop={HITSLOP_10}
+        hitSlop={HITSLOP_20}
         onPress={control.open}
         style={styles.altContainer}>
         <Text style={styles.alt} accessible={false}>
@@ -195,18 +195,18 @@ const styles = StyleSheet.create({
   altContainer: {
     backgroundColor: 'rgba(0, 0, 0, 0.75)',
     borderRadius: 6,
-    paddingHorizontal: 6,
-    paddingVertical: 3,
+    paddingHorizontal: isWeb ? 8 : 6,
+    paddingVertical: isWeb ? 6 : 3,
     position: 'absolute',
     // Related to margin/gap hack. This keeps the alt label in the same position
     // on all platforms
-    left: isWeb ? 8 : 5,
+    right: isWeb ? 8 : 5,
     bottom: isWeb ? 8 : 5,
     zIndex: 2,
   },
   alt: {
     color: 'white',
-    fontSize: 10,
+    fontSize: isWeb ? 10 : 7,
     fontWeight: 'bold',
   },
 })

--- a/src/view/com/util/post-embeds/index.tsx
+++ b/src/view/com/util/post-embeds/index.tsx
@@ -183,7 +183,7 @@ const styles = StyleSheet.create({
   },
   alt: {
     color: 'white',
-    fontSize: 6,
+    fontSize: 7,
     fontWeight: 'bold',
   },
   customFeedOuter: {


### PR DESCRIPTION
- Slightly bumped up the text size of the alt text indicator
- Moved the GIF alt indicator to the right
  - On Web, kept the GIF alt indicator large because it needs to be specifically clicked
  - On Mobile, made it small but gave a larger hit slop

## Images

|Before|After|
|-|-|
|![CleanShot 2024-05-28 at 20 23 12@2x](https://github.com/bluesky-social/social-app/assets/1270099/528388c2-fed2-40be-8a24-451edc873ded)|![CleanShot 2024-05-28 at 20 22 23@2x](https://github.com/bluesky-social/social-app/assets/1270099/a01fe0c1-8319-4716-81bf-d83acf142326)|

## Gifs

|Before|After (Web)|After (Mobile)|
|-|-|-|
|![CleanShot 2024-05-28 at 19 57 50@2x](https://github.com/bluesky-social/social-app/assets/1270099/b902820c-d2aa-4ff0-8dd7-b0f1e03698d2)|![CleanShot 2024-05-28 at 19 59 55@2x](https://github.com/bluesky-social/social-app/assets/1270099/8b391eb0-5fb1-4acb-b63d-02c1ca0124b7)|![CleanShot 2024-05-28 at 20 05 08@2x](https://github.com/bluesky-social/social-app/assets/1270099/0e547b97-2b11-4d59-b566-b067d0564f5a)

