### PR TITLE
use xcode 15.3

### DIFF
--- a/.github/workflows/build-submit-android.yml
+++ b/.github/workflows/build-submit-android.yml
@@ -123,11 +123,11 @@ jobs:
       - name: ⬇️ Restore Cache
         id: get-base-commit
         uses: actions/cache@v4
-        if: ${{ inputs.profile == 'testflight' && github.ref == 'refs/heads/main' }}
+        if: ${{ inputs.profile == 'testflight' }}
         with:
           path: most-recent-testflight-commit.txt
           key: most-recent-testflight-commit
 
       - name: ✏️ Write commit hash to cache
-        if: ${{ inputs.profile == 'testflight' && github.ref == 'refs/heads/main' }}
+        if: ${{ inputs.profile == 'testflight' }}
         run: echo ${{ github.sha }} > most-recent-testflight-commit.txt

--- a/.github/workflows/build-submit-ios.yml
+++ b/.github/workflows/build-submit-ios.yml
@@ -47,6 +47,10 @@ jobs:
       - name: ⚙️ Install dependencies
         run: yarn install
 
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '15.3'
+
       - name: ☕️ Setup Cocoapods
         uses: maxim-lobanov/setup-cocoapods@v1
         with:

--- a/.github/workflows/build-submit-ios.yml
+++ b/.github/workflows/build-submit-ios.yml
@@ -84,11 +84,11 @@ jobs:
       - name: ⬇️ Restore Cache
         id: get-base-commit
         uses: actions/cache@v4
-        if: ${{ inputs.profile == 'testflight' && github.ref == 'refs/heads/main' }}
+        if: ${{ inputs.profile == 'testflight' }}
         with:
           path: most-recent-testflight-commit.txt
           key: most-recent-testflight-commit
 
       - name: ✏️ Write commit hash to cache
-        if: ${{ inputs.profile == 'testflight' && github.ref == 'refs/heads/main' }}
+        if: ${{ inputs.profile == 'testflight' }}
         run: echo ${{ github.sha }} > most-recent-testflight-commit.txt

--- a/.github/workflows/bundle-deploy-eas-update.yml
+++ b/.github/workflows/bundle-deploy-eas-update.yml
@@ -170,6 +170,10 @@ jobs:
       - name: ⚙️ Install dependencies
         run: yarn install
 
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '15.3'
+
       - name: ☕️ Setup Cocoapods
         uses: maxim-lobanov/setup-cocoapods@v1
         with:


### PR DESCRIPTION
## Why

We added some code recently to a native module that requires iOS 17.4.1. To build for that iOS version, we need XCode 15.3 or greater.

See https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md#installed-sdks. We are already using `macos-14`, so `15.3` should be available and will give us access to the 17.4 SDK.

<img width="967" alt="Screenshot 2024-05-28 at 10 08 55 PM" src="https://github.com/bluesky-social/social-app/assets/153161762/207bac89-18d8-4632-aa61-4e8a6443611c">

## Test Plan

Merge, see if the action runs. 