### PR TITLE
Always show the header on post threads on native

### DIFF
--- a/src/view/com/post-thread/PostThread.tsx
+++ b/src/view/com/post-thread/PostThread.tsx
@@ -315,7 +315,8 @@ export function PostThread({
     skeleton?.highlightedPost?.type === 'post' &&
     (skeleton.highlightedPost.ctx.isParentLoading ||
       Boolean(skeleton?.parents && skeleton.parents.length > 0))
-  const showHeader = isNative || !hasParents || !isFetching
+  const showHeader =
+    isNative || (isTabletOrMobile && (!hasParents || !isFetching))
 
   const renderItem = React.useCallback(
     ({item, index}: {item: RowItem; index: number}) => {
@@ -448,7 +449,7 @@ export function PostThread({
 
   return (
     <CenteredView style={[a.flex_1]} sideBorders={true}>
-      {isTabletOrMobile && showHeader && (
+      {showHeader && (
         <ViewHeader
           title={_(msg({message: `Post`, context: 'description'}))}
           showBorder

--- a/src/view/com/post-thread/PostThread.tsx
+++ b/src/view/com/post-thread/PostThread.tsx
@@ -325,22 +325,14 @@ export function PostThread({
           {!isMobile && <ComposePrompt onPressCompose={onPressReply} />}
         </View>
       )
-    } else if (item === SHOW_HIDDEN_REPLIES) {
+    } else if (item === SHOW_HIDDEN_REPLIES || item === SHOW_MUTED_REPLIES) {
       return (
         <PostThreadShowHiddenReplies
-          type="hidden"
+          type={item === SHOW_HIDDEN_REPLIES ? 'hidden' : 'muted'}
           onPress={() =>
             setHiddenRepliesState(HiddenRepliesState.ShowAndOverridePostHider)
           }
-        />
-      )
-    } else if (item === SHOW_MUTED_REPLIES) {
-      return (
-        <PostThreadShowHiddenReplies
-          type="muted"
-          onPress={() =>
-            setHiddenRepliesState(HiddenRepliesState.ShowAndOverridePostHider)
-          }
+          hideTopBorder={index === 0}
         />
       )
     } else if (isThreadNotFound(item)) {

--- a/src/view/com/post-thread/PostThread.tsx
+++ b/src/view/com/post-thread/PostThread.tsx
@@ -26,6 +26,7 @@ import {useSetTitle} from 'lib/hooks/useSetTitle'
 import {useWebMediaQueries} from 'lib/hooks/useWebMediaQueries'
 import {sanitizeDisplayName} from 'lib/strings/display-names'
 import {cleanError} from 'lib/strings/errors'
+import {CenteredView} from 'view/com/util/Views'
 import {atoms as a, useTheme} from '#/alf'
 import {ListFooter, ListMaybePlaceholder} from '#/components/Lists'
 import {Text} from '#/components/Typography'
@@ -440,7 +441,7 @@ export function PostThread({
   }
 
   return (
-    <>
+    <CenteredView style={[a.flex_1]}>
       {isTabletOrMobile && (
         <ViewHeader
           title={_(msg({message: `Post`, context: 'description'}))}
@@ -481,7 +482,7 @@ export function PostThread({
           windowSize={11}
         />
       </ScrollProvider>
-    </>
+    </CenteredView>
   )
 }
 

--- a/src/view/com/post-thread/PostThread.tsx
+++ b/src/view/com/post-thread/PostThread.tsx
@@ -441,7 +441,7 @@ export function PostThread({
   }
 
   return (
-    <CenteredView style={[a.flex_1]}>
+    <CenteredView style={[a.flex_1]} sideBorders={true}>
       {isTabletOrMobile && (
         <ViewHeader
           title={_(msg({message: `Post`, context: 'description'}))}
@@ -480,6 +480,7 @@ export function PostThread({
           }
           initialNumToRender={initialNumToRender}
           windowSize={11}
+          sideBorders={false}
         />
       </ScrollProvider>
     </CenteredView>

--- a/src/view/com/post-thread/PostThread.tsx
+++ b/src/view/com/post-thread/PostThread.tsx
@@ -318,121 +318,101 @@ export function PostThread({
   const showHeader =
     isNative || (isTabletOrMobile && (!hasParents || !isFetching))
 
-  const renderItem = React.useCallback(
-    ({item, index}: {item: RowItem; index: number}) => {
-      if (item === REPLY_PROMPT && hasSession) {
-        return (
-          <View>
-            {!isMobile && <ComposePrompt onPressCompose={onPressReply} />}
-          </View>
-        )
-      } else if (item === SHOW_HIDDEN_REPLIES) {
-        return (
-          <PostThreadShowHiddenReplies
-            type="hidden"
-            onPress={() =>
-              setHiddenRepliesState(HiddenRepliesState.ShowAndOverridePostHider)
+  const renderItem = ({item, index}: {item: RowItem; index: number}) => {
+    if (item === REPLY_PROMPT && hasSession) {
+      return (
+        <View>
+          {!isMobile && <ComposePrompt onPressCompose={onPressReply} />}
+        </View>
+      )
+    } else if (item === SHOW_HIDDEN_REPLIES) {
+      return (
+        <PostThreadShowHiddenReplies
+          type="hidden"
+          onPress={() =>
+            setHiddenRepliesState(HiddenRepliesState.ShowAndOverridePostHider)
+          }
+        />
+      )
+    } else if (item === SHOW_MUTED_REPLIES) {
+      return (
+        <PostThreadShowHiddenReplies
+          type="muted"
+          onPress={() =>
+            setHiddenRepliesState(HiddenRepliesState.ShowAndOverridePostHider)
+          }
+        />
+      )
+    } else if (isThreadNotFound(item)) {
+      return (
+        <View
+          style={[
+            a.p_lg,
+            a.border_t,
+            t.atoms.border_contrast_low,
+            t.atoms.bg_contrast_25,
+          ]}>
+          <Text style={[a.font_bold, a.text_md, t.atoms.text_contrast_medium]}>
+            <Trans>Deleted post.</Trans>
+          </Text>
+        </View>
+      )
+    } else if (isThreadBlocked(item)) {
+      return (
+        <View
+          style={[
+            a.p_lg,
+            a.border_t,
+            t.atoms.border_contrast_low,
+            t.atoms.bg_contrast_25,
+          ]}>
+          <Text style={[a.font_bold, a.text_md, t.atoms.text_contrast_medium]}>
+            <Trans>Blocked post.</Trans>
+          </Text>
+        </View>
+      )
+    } else if (isThreadPost(item)) {
+      const prev = isThreadPost(posts[index - 1])
+        ? (posts[index - 1] as ThreadPost)
+        : undefined
+      const next = isThreadPost(posts[index + 1])
+        ? (posts[index + 1] as ThreadPost)
+        : undefined
+      const showChildReplyLine = (next?.ctx.depth || 0) > item.ctx.depth
+      const showParentReplyLine =
+        (item.ctx.depth < 0 && !!item.parent) || item.ctx.depth > 1
+      const hasUnrevealedParents =
+        index === 0 && skeleton?.parents && maxParents < skeleton.parents.length
+      return (
+        <View
+          ref={item.ctx.isHighlightedPost ? highlightedPostRef : undefined}
+          onLayout={deferParents ? () => setDeferParents(false) : undefined}>
+          <PostThreadItem
+            post={item.post}
+            record={item.record}
+            moderation={threadModerationCache.get(item)}
+            treeView={treeView}
+            depth={item.ctx.depth}
+            prevPost={prev}
+            nextPost={next}
+            isHighlightedPost={item.ctx.isHighlightedPost}
+            hasMore={item.ctx.hasMore}
+            showChildReplyLine={showChildReplyLine}
+            showParentReplyLine={showParentReplyLine}
+            hasPrecedingItem={showParentReplyLine || !!hasUnrevealedParents}
+            overrideBlur={
+              hiddenRepliesState ===
+                HiddenRepliesState.ShowAndOverridePostHider &&
+              item.ctx.depth > 0
             }
+            onPostReply={refetch}
+            hideTopBorder={index === 0}
           />
-        )
-      } else if (item === SHOW_MUTED_REPLIES) {
-        return (
-          <PostThreadShowHiddenReplies
-            type="muted"
-            onPress={() =>
-              setHiddenRepliesState(HiddenRepliesState.ShowAndOverridePostHider)
-            }
-          />
-        )
-      } else if (isThreadNotFound(item)) {
-        return (
-          <View
-            style={[
-              a.p_lg,
-              a.border_t,
-              t.atoms.border_contrast_low,
-              t.atoms.bg_contrast_25,
-            ]}>
-            <Text
-              style={[a.font_bold, a.text_md, t.atoms.text_contrast_medium]}>
-              <Trans>Deleted post.</Trans>
-            </Text>
-          </View>
-        )
-      } else if (isThreadBlocked(item)) {
-        return (
-          <View
-            style={[
-              a.p_lg,
-              a.border_t,
-              t.atoms.border_contrast_low,
-              t.atoms.bg_contrast_25,
-            ]}>
-            <Text
-              style={[a.font_bold, a.text_md, t.atoms.text_contrast_medium]}>
-              <Trans>Blocked post.</Trans>
-            </Text>
-          </View>
-        )
-      } else if (isThreadPost(item)) {
-        const prev = isThreadPost(posts[index - 1])
-          ? (posts[index - 1] as ThreadPost)
-          : undefined
-        const next = isThreadPost(posts[index + 1])
-          ? (posts[index + 1] as ThreadPost)
-          : undefined
-        const showChildReplyLine = (next?.ctx.depth || 0) > item.ctx.depth
-        const showParentReplyLine =
-          (item.ctx.depth < 0 && !!item.parent) || item.ctx.depth > 1
-        const hasUnrevealedParents =
-          index === 0 &&
-          skeleton?.parents &&
-          maxParents < skeleton.parents.length
-        return (
-          <View
-            ref={item.ctx.isHighlightedPost ? highlightedPostRef : undefined}
-            onLayout={deferParents ? () => setDeferParents(false) : undefined}>
-            <PostThreadItem
-              post={item.post}
-              record={item.record}
-              moderation={threadModerationCache.get(item)}
-              treeView={treeView}
-              depth={item.ctx.depth}
-              prevPost={prev}
-              nextPost={next}
-              isHighlightedPost={item.ctx.isHighlightedPost}
-              hasMore={item.ctx.hasMore}
-              showChildReplyLine={showChildReplyLine}
-              showParentReplyLine={showParentReplyLine}
-              hasPrecedingItem={showParentReplyLine || !!hasUnrevealedParents}
-              overrideBlur={
-                hiddenRepliesState ===
-                  HiddenRepliesState.ShowAndOverridePostHider &&
-                item.ctx.depth > 0
-              }
-              onPostReply={refetch}
-            />
-          </View>
-        )
-      }
-      return null
-    },
-    [
-      t,
-      hasSession,
-      isMobile,
-      onPressReply,
-      posts,
-      skeleton?.parents,
-      maxParents,
-      deferParents,
-      treeView,
-      refetch,
-      threadModerationCache,
-      hiddenRepliesState,
-      setHiddenRepliesState,
-    ],
-  )
+        </View>
+      )
+    }
+    return null
+  }
 
   if (!thread || !preferences || error) {
     return (

--- a/src/view/com/post-thread/PostThread.tsx
+++ b/src/view/com/post-thread/PostThread.tsx
@@ -311,6 +311,12 @@ export function PostThread({
     setMaxReplies(prev => prev + 50)
   }, [isFetching, maxReplies, posts.length])
 
+  const hasParents =
+    skeleton?.highlightedPost?.type === 'post' &&
+    (skeleton.highlightedPost.ctx.isParentLoading ||
+      Boolean(skeleton?.parents && skeleton.parents.length > 0))
+  const showHeader = isNative || !hasParents || !isFetching
+
   const renderItem = React.useCallback(
     ({item, index}: {item: RowItem; index: number}) => {
       if (item === REPLY_PROMPT && hasSession) {
@@ -442,7 +448,7 @@ export function PostThread({
 
   return (
     <CenteredView style={[a.flex_1]} sideBorders={true}>
-      {isTabletOrMobile && (
+      {isTabletOrMobile && showHeader && (
         <ViewHeader
           title={_(msg({message: `Post`, context: 'description'}))}
           showBorder

--- a/src/view/com/post-thread/PostThread.tsx
+++ b/src/view/com/post-thread/PostThread.tsx
@@ -348,7 +348,7 @@ export function PostThread({
         <View
           style={[
             a.p_lg,
-            a.border_t,
+            index !== 0 && a.border_t,
             t.atoms.border_contrast_low,
             t.atoms.bg_contrast_25,
           ]}>
@@ -362,7 +362,7 @@ export function PostThread({
         <View
           style={[
             a.p_lg,
-            a.border_t,
+            index !== 0 && a.border_t,
             t.atoms.border_contrast_low,
             t.atoms.bg_contrast_25,
           ]}>

--- a/src/view/com/post-thread/PostThread.tsx
+++ b/src/view/com/post-thread/PostThread.tsx
@@ -454,7 +454,6 @@ export function PostThread({
           data={posts}
           renderItem={renderItem}
           keyExtractor={keyExtractor}
-          contentContainerStyle={{marginTop: -2}}
           onContentSizeChange={isNative ? undefined : onContentSizeChangeWeb}
           onStartReached={onStartReached}
           onEndReached={onEndReached}

--- a/src/view/com/post-thread/PostThread.tsx
+++ b/src/view/com/post-thread/PostThread.tsx
@@ -406,7 +406,7 @@ export function PostThread({
               item.ctx.depth > 0
             }
             onPostReply={refetch}
-            hideTopBorder={index === 0}
+            hideTopBorder={index === 0 && !item.ctx.isParentLoading}
           />
         </View>
       )

--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -65,6 +65,7 @@ export function PostThreadItem({
   hasPrecedingItem,
   overrideBlur,
   onPostReply,
+  hideTopBorder,
 }: {
   post: AppBskyFeedDefs.PostView
   record: AppBskyFeedPost.Record
@@ -80,6 +81,7 @@ export function PostThreadItem({
   hasPrecedingItem: boolean
   overrideBlur: boolean
   onPostReply: () => void
+  hideTopBorder?: boolean
 }) {
   const postShadowed = usePostShadow(post)
   const richText = useMemo(
@@ -91,7 +93,7 @@ export function PostThreadItem({
     [record],
   )
   if (postShadowed === POST_TOMBSTONE) {
-    return <PostThreadItemDeleted />
+    return <PostThreadItemDeleted hideTopBorder={hideTopBorder} />
   }
   if (richText && moderation) {
     return (
@@ -113,16 +115,25 @@ export function PostThreadItem({
         hasPrecedingItem={hasPrecedingItem}
         overrideBlur={overrideBlur}
         onPostReply={onPostReply}
+        hideTopBorder={hideTopBorder}
       />
     )
   }
   return null
 }
 
-function PostThreadItemDeleted() {
+function PostThreadItemDeleted({hideTopBorder}: {hideTopBorder?: boolean}) {
   const pal = usePalette('default')
   return (
-    <View style={[styles.outer, pal.border, pal.view, s.p20, s.flexRow]}>
+    <View
+      style={[
+        styles.outer,
+        pal.border,
+        pal.view,
+        s.p20,
+        s.flexRow,
+        hideTopBorder && styles.noTopBorder,
+      ]}>
       <FontAwesomeIcon icon={['far', 'trash-can']} color={pal.colors.icon} />
       <Text style={[pal.textLight, s.ml10]}>
         <Trans>This post has been deleted.</Trans>
@@ -147,6 +158,7 @@ let PostThreadItemLoaded = ({
   hasPrecedingItem,
   overrideBlur,
   onPostReply,
+  hideTopBorder,
 }: {
   post: Shadow<AppBskyFeedDefs.PostView>
   record: AppBskyFeedPost.Record
@@ -163,6 +175,7 @@ let PostThreadItemLoaded = ({
   hasPrecedingItem: boolean
   overrideBlur: boolean
   onPostReply: () => void
+  hideTopBorder?: boolean
 }): React.ReactNode => {
   const pal = usePalette('default')
   const {_} = useLingui()
@@ -247,7 +260,13 @@ let PostThreadItemLoaded = ({
 
         <View
           testID={`postThreadItem-by-${post.author.handle}`}
-          style={[styles.outer, styles.outerHighlighted, pal.border, pal.view]}
+          style={[
+            styles.outer,
+            styles.outerHighlighted,
+            pal.border,
+            pal.view,
+            hideTopBorder && styles.noTopBorder,
+          ]}
           accessible={false}>
           <View style={[styles.layout]}>
             <View style={[styles.layoutAvi, {paddingBottom: 8}]}>
@@ -395,7 +414,8 @@ let PostThreadItemLoaded = ({
           depth={depth}
           showParentReplyLine={!!showParentReplyLine}
           treeView={treeView}
-          hasPrecedingItem={hasPrecedingItem}>
+          hasPrecedingItem={hasPrecedingItem}
+          hideTopBorder={hideTopBorder}>
           <PostHider
             testID={`postThreadItem-by-${post.author.handle}`}
             href={postHref}
@@ -574,6 +594,7 @@ function PostOuterWrapper({
   depth,
   showParentReplyLine,
   hasPrecedingItem,
+  hideTopBorder,
   children,
 }: React.PropsWithChildren<{
   post: AppBskyFeedDefs.PostView
@@ -581,6 +602,7 @@ function PostOuterWrapper({
   depth: number
   showParentReplyLine: boolean
   hasPrecedingItem: boolean
+  hideTopBorder?: boolean
 }>) {
   const {isMobile} = useWebMediaQueries()
   const pal = usePalette('default')
@@ -617,6 +639,7 @@ function PostOuterWrapper({
         styles.outer,
         pal.border,
         showParentReplyLine && hasPrecedingItem && styles.noTopBorder,
+        hideTopBorder && styles.noTopBorder,
         styles.cursor,
       ]}>
       {children}

--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -250,7 +250,7 @@ let PostThreadItemLoaded = ({
                   styles.replyLine,
                   {
                     flexGrow: 1,
-                    backgroundColor: pal.colors.border,
+                    backgroundColor: pal.colors.replyLine,
                   },
                 ]}
               />
@@ -265,6 +265,7 @@ let PostThreadItemLoaded = ({
             styles.outerHighlighted,
             pal.border,
             pal.view,
+            rootUri === post.uri && styles.outerHighlightedRoot,
             hideTopBorder && styles.noTopBorder,
           ]}
           accessible={false}>
@@ -700,9 +701,14 @@ const styles = StyleSheet.create({
     paddingLeft: 8,
   },
   outerHighlighted: {
-    paddingTop: 16,
+    borderTopWidth: 0,
+    paddingTop: 4,
     paddingLeft: 8,
     paddingRight: 8,
+  },
+  outerHighlightedRoot: {
+    borderTopWidth: 1,
+    paddingTop: 16,
   },
   noTopBorder: {
     borderTopWidth: 0,

--- a/src/view/com/post-thread/PostThreadShowHiddenReplies.tsx
+++ b/src/view/com/post-thread/PostThreadShowHiddenReplies.tsx
@@ -11,9 +11,11 @@ import {Text} from '#/components/Typography'
 export function PostThreadShowHiddenReplies({
   type,
   onPress,
+  hideTopBorder,
 }: {
   type: 'hidden' | 'muted'
   onPress: () => void
+  hideTopBorder?: boolean
 }) {
   const {_} = useLingui()
   const t = useTheme()
@@ -31,7 +33,7 @@ export function PostThreadShowHiddenReplies({
             a.gap_sm,
             a.py_lg,
             a.px_xl,
-            a.border_t,
+            !hideTopBorder && a.border_t,
             t.atoms.border_contrast_low,
             hovered || pressed ? t.atoms.bg_contrast_25 : t.atoms.bg,
           ]}>


### PR DESCRIPTION
## Why

Whenever we introduced PRs for fixing layout jank in the post thread `List`, we inadvertently broke the header always being visible. Lots users - especially on iOS - miss not having the back button easily available.

This is just a rudimentary PR that adds back that header. It doesn't animate the header in/out like we do on some other screens. We may decide to do that, in which case we'll need a different approach.

I also did a bit of StyleSheet housekeeping while I was here by using ALFredo instead of the few uses of `palette`.

## Test Plan

Open a thread, and make sure the header stays at the top while also not breaking things in larger threads. This is a great thread to test in: https://bsky.app/profile/www.mozzius.dev/post/3kjqhblh6qk2o

https://github.com/bluesky-social/social-app/assets/153161762/93fa18f6-5a9b-4163-b39c-7cd9b2a92864

<img width="426" alt="Screenshot 2024-05-28 at 11 49 26 PM" src="https://github.com/bluesky-social/social-app/assets/153161762/5ac1e3fd-19df-41fd-8218-744406352ded">
