### PR TITLE
Change Android's MainActivity launchMode to singleTop

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -204,6 +204,7 @@ module.exports = function (config) {
         ],
         './plugins/withAndroidManifestPlugin.js',
         './plugins/withAndroidManifestFCMIconPlugin.js',
+        './plugins/withAndroidManifestLaunchModePlugin.js',
         './plugins/withAndroidStylesWindowBackgroundPlugin.js',
         './plugins/withAndroidStylesAccentColorPlugin.js',
         './plugins/withAndroidSplashScreenStatusBarTranslucentPlugin.js',

--- a/plugins/withAndroidManifestLaunchModePlugin.js
+++ b/plugins/withAndroidManifestLaunchModePlugin.js
@@ -8,7 +8,7 @@ module.exports = function withAndroidManifestLaunchModePlugin(appConfig) {
       const mainActivity = mainApplication.activity.find(
         elem => elem.$['android:name'] === '.MainActivity',
       )
-      mainActivity.$['android:launchMode'] = 'standard'
+      mainActivity.$['android:launchMode'] = 'singleTop'
     } catch (e) {
       console.error(`withAndroidManifestLaunchModePlugin failed`, e)
     }

--- a/plugins/withAndroidManifestLaunchModePlugin.js
+++ b/plugins/withAndroidManifestLaunchModePlugin.js
@@ -1,0 +1,18 @@
+const {withAndroidManifest} = require('expo/config-plugins')
+
+module.exports = function withAndroidManifestLaunchModePlugin(appConfig) {
+  return withAndroidManifest(appConfig, function (decoratedAppConfig) {
+    try {
+      const mainApplication =
+        decoratedAppConfig.modResults.manifest.application[0]
+      const mainActivity = mainApplication.activity.find(
+        elem => elem.$['android:name'] === '.MainActivity',
+      )
+
+      mainActivity.$['android:launchMode'] = 'singleTop'
+    } catch (e) {
+      console.error(`withAndroidManifestLaunchModePlugin failed`, e)
+    }
+    return decoratedAppConfig
+  })
+}

--- a/plugins/withAndroidManifestLaunchModePlugin.js
+++ b/plugins/withAndroidManifestLaunchModePlugin.js
@@ -8,8 +8,7 @@ module.exports = function withAndroidManifestLaunchModePlugin(appConfig) {
       const mainActivity = mainApplication.activity.find(
         elem => elem.$['android:name'] === '.MainActivity',
       )
-
-      mainActivity.$['android:launchMode'] = 'singleTop'
+      mainActivity.$['android:launchMode'] = 'standard'
     } catch (e) {
       console.error(`withAndroidManifestLaunchModePlugin failed`, e)
     }

--- a/src/App.native.tsx
+++ b/src/App.native.tsx
@@ -143,7 +143,7 @@ function App() {
    * that is set up in the InnerApp component above.
    */
   return (
-    <KeyboardProvider enabled={true}>
+    <KeyboardProvider enabled={true} statusBarTranslucent={true}>
       <SessionProvider>
         <ShellStateProvider>
           <PrefsStateProvider>


### PR DESCRIPTION
Expo sets the `launchMode` property of  `.MainActivity` to `singleTask` in `AndroidManifest.xml` by default. This causes any activity above it in the app's stack to be destroyed any time the app is launched from the home screen. Since the app is a single activity, this normally isn't a problem since there aren't any activities above it in the stack. However, the in-app browser is a different activity, so reopening the app from the home screen when the browser had been open causes it to be closed and return the user to previous screen instead. The Android developer documentation cautions against using any mode other than `standard` or `singleTop`.

I've added a config plugin to alter the AndroidManifest to use `singleTop`. This seems to have resolved the issue.

Fixes #4212 

## Testing

I have built the release variant and installed it on my Pixel 6 Pro to verify the fix works. I have not tested for all possible side effects, though I haven't encountered any issues so far. If anyone can think of something specific that should be tested before merging, I'd be happy to try it.