### PR TITLE
Adjust size of reply prompt on native

### DIFF
--- a/src/view/com/composer/Prompt.tsx
+++ b/src/view/com/composer/Prompt.tsx
@@ -34,15 +34,14 @@ export function ComposePrompt({onPressCompose}: {onPressCompose: () => void}) {
         style={[
           a.flex_row,
           a.align_center,
-          a.gap_sm,
-          !isTabletOrDesktop && a.mb_xs,
+          isTabletOrDesktop ? [a.gap_md] : [a.gap_sm, a.mb_xs],
         ]}>
         <UserAvatar
           avatar={profile?.avatar}
           size={isTabletOrDesktop ? 36 : 28}
           type={profile?.associated?.labeler ? 'labeler' : 'user'}
         />
-        <Text style={[a.text_md, t.atoms.text_contrast_high]}>
+        <Text style={[{fontSize: isTabletOrDesktop ? 18 : 16}]}>
           <Trans>Write your reply</Trans>
         </Text>
       </View>

--- a/src/view/com/composer/Prompt.tsx
+++ b/src/view/com/composer/Prompt.tsx
@@ -20,7 +20,9 @@ export function ComposePrompt({onPressCompose}: {onPressCompose: () => void}) {
     <TouchableOpacity
       testID="replyPromptBtn"
       style={[
-        isTabletOrDesktop ? a.p_md : a.p_sm,
+        isTabletOrDesktop
+          ? [a.p_md]
+          : {paddingHorizontal: 14, paddingVertical: 10},
         a.border_t,
         t.atoms.border_contrast_medium,
         t.atoms.bg,
@@ -34,7 +36,7 @@ export function ComposePrompt({onPressCompose}: {onPressCompose: () => void}) {
         style={[
           a.flex_row,
           a.align_center,
-          isTabletOrDesktop ? [a.gap_md] : [a.gap_sm, a.mb_xs],
+          isTabletOrDesktop ? [a.gap_md] : [{gap: 10}, a.mb_xs],
         ]}>
         <UserAvatar
           avatar={profile?.avatar}

--- a/src/view/com/composer/Prompt.tsx
+++ b/src/view/com/composer/Prompt.tsx
@@ -1,58 +1,51 @@
 import React from 'react'
-import {StyleSheet, TouchableOpacity} from 'react-native'
-import {UserAvatar} from '../util/UserAvatar'
-import {Text} from '../util/text/Text'
-import {usePalette} from 'lib/hooks/usePalette'
-import {useWebMediaQueries} from 'lib/hooks/useWebMediaQueries'
-import {Trans, msg} from '@lingui/macro'
+import {TouchableOpacity, View} from 'react-native'
+import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
-import {useSession} from '#/state/session'
+
 import {useProfileQuery} from '#/state/queries/profile'
+import {useSession} from '#/state/session'
+import {useWebMediaQueries} from 'lib/hooks/useWebMediaQueries'
+import {atoms as a, useTheme} from '#/alf'
+import {Text} from '#/components/Typography'
+import {UserAvatar} from '../util/UserAvatar'
 
 export function ComposePrompt({onPressCompose}: {onPressCompose: () => void}) {
+  const t = useTheme()
   const {currentAccount} = useSession()
   const {data: profile} = useProfileQuery({did: currentAccount?.did})
-  const pal = usePalette('default')
   const {_} = useLingui()
-  const {isDesktop} = useWebMediaQueries()
+  const {isTabletOrDesktop} = useWebMediaQueries()
   return (
     <TouchableOpacity
       testID="replyPromptBtn"
-      style={[pal.view, pal.border, styles.prompt]}
+      style={[
+        isTabletOrDesktop ? a.p_md : a.p_sm,
+        a.border_t,
+        t.atoms.border_contrast_medium,
+        t.atoms.bg,
+      ]}
       onPress={() => onPressCompose()}
       accessibilityRole="button"
       accessibilityLabel={_(msg`Compose reply`)}
-      accessibilityHint={_(msg`Opens composer`)}>
-      <UserAvatar
-        avatar={profile?.avatar}
-        size={38}
-        type={profile?.associated?.labeler ? 'labeler' : 'user'}
-      />
-      <Text
-        type="xl"
+      accessibilityHint={_(msg`Opens composer`)}
+      activeOpacity={0.925}>
+      <View
         style={[
-          pal.text,
-          isDesktop ? styles.labelDesktopWeb : styles.labelMobile,
+          a.flex_row,
+          a.align_center,
+          a.gap_sm,
+          !isTabletOrDesktop && a.mb_xs,
         ]}>
-        <Trans>Write your reply</Trans>
-      </Text>
+        <UserAvatar
+          avatar={profile?.avatar}
+          size={isTabletOrDesktop ? 36 : 28}
+          type={profile?.associated?.labeler ? 'labeler' : 'user'}
+        />
+        <Text style={[a.text_md, t.atoms.text_contrast_high]}>
+          <Trans>Write your reply</Trans>
+        </Text>
+      </View>
     </TouchableOpacity>
   )
 }
-
-const styles = StyleSheet.create({
-  prompt: {
-    paddingHorizontal: 16,
-    paddingTop: 10,
-    paddingBottom: 10,
-    flexDirection: 'row',
-    alignItems: 'center',
-    borderTopWidth: 1,
-  },
-  labelMobile: {
-    paddingLeft: 12,
-  },
-  labelDesktopWeb: {
-    paddingLeft: 12,
-  },
-})


### PR DESCRIPTION
## Why

This is a follow up to https://github.com/bluesky-social/social-app/pull/4254. It became even more apparent to me how big the reply prompt is on native once the header was always there. This PR adjusts the height of this prompt.

### Web

<table>
<tr>
 <td>Before
 <td>After
<tr>
 <td>
<img width="624" alt="Screenshot 2024-05-29 at 12 42 33 AM" src="https://github.com/bluesky-social/social-app/assets/153161762/e2096099-fd7e-4cc9-b248-1d2529d50663">

 <td>
<img width="596" alt="Screenshot 2024-05-29 at 12 54 26 AM" src="https://github.com/bluesky-social/social-app/assets/153161762/f215126f-a387-429a-9534-d832cbf97f83">


</table>

### Native

<table>
<tr>
 <td>Before
 <td>After
<tr>
 <td>
<img width="573" alt="Screenshot 2024-05-29 at 12 47 49 AM" src="https://github.com/bluesky-social/social-app/assets/153161762/126cb7d9-c220-46cd-8603-25c6050e6f9d">
 <td>
<img width="573" alt="Screenshot 2024-05-29 at 12 54 32 AM" src="https://github.com/bluesky-social/social-app/assets/153161762/29616f79-9924-410b-81b7-0b43a827e8ca">

</table>