### PR TITLE
Fix mismatched exports for platform-specific files

### DIFF
--- a/src/lib/app-info.web.ts
+++ b/src/lib/app-info.web.ts
@@ -1,6 +1,8 @@
 import {version} from '../../package.json'
 
+export const BUILD_ENV = process.env.EXPO_PUBLIC_ENV
 export const IS_DEV = process.env.EXPO_PUBLIC_ENV === 'development'
+export const IS_TESTFLIGHT = false
 
 // This is the commit hash that the current bundle was made from. The user can see the commit hash in the app's settings
 // along with the other version info. Useful for debugging/reporting.

--- a/src/lib/media/manip.web.ts
+++ b/src/lib/media/manip.web.ts
@@ -159,3 +159,7 @@ async function downloadUrl(href: string, filename: string) {
   a.download = filename
   a.click()
 }
+
+export async function safeDeleteAsync() {
+  // no-op
+}

--- a/src/view/com/util/images/Image.web.tsx
+++ b/src/view/com/util/images/Image.web.tsx
@@ -1,11 +1,3 @@
-import {
-  Image,
-  NativeSyntheticEvent,
-  ImageLoadEventData,
-  ImageSourcePropType,
-} from 'react-native'
-export default Image
+import {Image} from 'react-native'
+
 export const HighPriorityImage = Image
-export type OnLoadEvent = NativeSyntheticEvent<ImageLoadEventData>
-export type Source = ImageSourcePropType
-export type {ImageStyle} from 'react-native'


### PR DESCRIPTION
There were a couple of places where some exports were added to some files but not to their `.web.ts` version. Doesn't have any behaviour changes, but reduces some of the log spam in the console when running web