### PR TITLE
Don't round up the count, have it truncate

### DIFF
--- a/src/view/com/util/numeric/format.ts
+++ b/src/view/com/util/numeric/format.ts
@@ -2,6 +2,10 @@ export const formatCount = (num: number) =>
   Intl.NumberFormat('en-US', {
     notation: 'compact',
     maximumFractionDigits: 1,
+    // `1,953` shouldn't be rounded up to 2k, it should be truncated.
+    // @ts-expect-error: `roundingMode` doesn't seem to be in the typings yet
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#roundingmode
+    roundingMode: 'trunc',
   }).format(num)
 
 export function formatCountShortOnly(num: number): string {


### PR DESCRIPTION
It seems misleading when the app is displaying that you've reached 2k likes on a post when it turns out you're only somewhat there (`1,953`)