### PR TITLE
Interpret 'hide' setting as ALWAYS hiding from thread replies

### DIFF
--- a/src/components/moderation/PostHider.tsx
+++ b/src/components/moderation/PostHider.tsx
@@ -23,6 +23,7 @@ interface Props extends ComponentProps<typeof Link> {
   iconStyles: StyleProp<ViewStyle>
   modui: ModerationUI
   profile: AppBskyActorDefs.ProfileViewBasic
+  interpretFilterAsBlur?: boolean
 }
 
 export function PostHider({
@@ -35,6 +36,7 @@ export function PostHider({
   iconSize,
   iconStyles,
   profile,
+  interpretFilterAsBlur,
   ...props
 }: Props) {
   const queryClient = useQueryClient()
@@ -42,7 +44,8 @@ export function PostHider({
   const {_} = useLingui()
   const [override, setOverride] = React.useState(false)
   const control = useModerationDetailsDialogControl()
-  const blur = modui.blurs[0]
+  const blur =
+    modui.blurs[0] || (interpretFilterAsBlur ? modui.filters[0] : undefined)
   const desc = useModerationCauseDescription(blur)
 
   const onBeforePress = React.useCallback(() => {

--- a/src/view/com/post-thread/PostThread.tsx
+++ b/src/view/com/post-thread/PostThread.tsx
@@ -562,9 +562,9 @@ function* flattenThreadReplies(
     // handle blurred items
     if (node.ctx.depth > 0) {
       const modui = modCache.get(node)?.ui('contentList')
-      if (modui?.blur) {
+      if (modui?.blur || modui?.filter) {
         if (!showHiddenReplies || node.ctx.depth > 1) {
-          if (modui.blurs[0].type === 'muted') {
+          if ((modui.blurs[0] || modui.filters[0]).type === 'muted') {
             return HiddenReplyType.Muted
           }
           return HiddenReplyType.Hidden

--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -408,7 +408,8 @@ let PostThreadItemLoaded = ({
                 ? {marginRight: 4}
                 : {marginLeft: 2, marginRight: 2}
             }
-            profile={post.author}>
+            profile={post.author}
+            interpretFilterAsBlur>
             <View
               style={{
                 flexDirection: 'row',


### PR DESCRIPTION
While working on another PR, I noticed that we don't currently handle the "Hide" behavior correctly in thread replies.

## Current behavior

The current interpretation is that "Hide" only filters replies out of feeds. This means that replies only get blurred by `blur=content`. Put another way, on "badge"-style labels, the hide preference has no effect.

|Blur=content|Effect|
|-|-|
|![CleanShot 2024-05-29 at 12 54 10@2x](https://github.com/bluesky-social/social-app/assets/1270099/20b79d6e-3cf2-47c9-ac2c-5a4e56673d2c)|![CleanShot 2024-05-29 at 12 54 22@2x](https://github.com/bluesky-social/social-app/assets/1270099/726bdf4e-5534-4781-afd1-a7f8d49bb41a)|

|Blur=none|Effect|
|-|-|
|![CleanShot 2024-05-29 at 12 52 45@2x](https://github.com/bluesky-social/social-app/assets/1270099/cc43094e-aae0-40ac-92c4-1af3babdea88)|![CleanShot 2024-05-29 at 12 53 43@2x](https://github.com/bluesky-social/social-app/assets/1270099/eca2698e-0125-4cc5-9c93-f3d2498772a0)|

## New behavior

The new behavior ensures that a Hide preference will blur replies.

|Blur=none|Effect|
|-|-|
|![CleanShot 2024-05-29 at 12 55 48@2x](https://github.com/bluesky-social/social-app/assets/1270099/02161c14-81b4-4ee6-b251-81112634b2bb)|![CleanShot 2024-05-29 at 12 55 56@2x](https://github.com/bluesky-social/social-app/assets/1270099/b92affb5-4531-4bcf-b65e-b1693c236195)|



