### PR TITLE
adjust notifications experiment by removing `canAskAgain`

### DIFF
--- a/src/lib/notifications/notifications.ts
+++ b/src/lib/notifications/notifications.ts
@@ -71,46 +71,41 @@ export function useNotificationsRegistration() {
 
 export function useRequestNotificationsPermission() {
   const gate = useGate()
-  const {currentAccount} = useSession()
 
-  return React.useCallback(
-    async (context: 'StartOnboarding' | 'AfterOnboarding' | 'Login') => {
-      const permissions = await Notifications.getPermissionsAsync()
+  return async (context: 'StartOnboarding' | 'AfterOnboarding' | 'Login') => {
+    const permissions = await Notifications.getPermissionsAsync()
 
-      if (
-        !currentAccount ||
-        !isNative ||
-        permissions?.status === 'granted' ||
-        (permissions?.status === 'denied' && !permissions?.canAskAgain)
-      ) {
-        return
-      }
-      if (
-        context === 'StartOnboarding' &&
-        gate('request_notifications_permission_after_onboarding')
-      ) {
-        return
-      }
-      if (
-        context === 'AfterOnboarding' &&
-        !gate('request_notifications_permission_after_onboarding')
-      ) {
-        return
-      }
+    if (
+      !isNative ||
+      permissions?.status === 'granted' ||
+      permissions?.status === 'denied'
+    ) {
+      return
+    }
+    if (
+      context === 'StartOnboarding' &&
+      gate('request_notifications_permission_after_onboarding_v2')
+    ) {
+      return
+    }
+    if (
+      context === 'AfterOnboarding' &&
+      !gate('request_notifications_permission_after_onboarding_v2')
+    ) {
+      return
+    }
 
-      const res = await Notifications.requestPermissionsAsync()
-      logEvent('notifications:request', {
-        context: context,
-        status: res.status,
-      })
+    const res = await Notifications.requestPermissionsAsync()
+    logEvent('notifications:request', {
+      context: context,
+      status: res.status,
+    })
 
-      if (res.granted) {
-        // This will fire a pushTokenEvent, which will handle registration of the token
-        getPushToken(true)
-      }
-    },
-    [gate, currentAccount],
-  )
+    if (res.granted) {
+      // This will fire a pushTokenEvent, which will handle registration of the token
+      getPushToken(true)
+    }
+  }
 }
 
 export async function decrementBadgeCount(by: number | 'reset' = 1) {

--- a/src/lib/statsig/gates.ts
+++ b/src/lib/statsig/gates.ts
@@ -1,4 +1,4 @@
 export type Gate =
   // Keep this alphabetic please.
-  | 'request_notifications_permission_after_onboarding'
+  | 'request_notifications_permission_after_onboarding_v2'
   | 'show_follow_back_label_v2'

--- a/src/screens/Onboarding/StepFinished.tsx
+++ b/src/screens/Onboarding/StepFinished.tsx
@@ -13,6 +13,7 @@ import {RQKEY as profileRQKey} from '#/state/queries/profile'
 import {useAgent} from '#/state/session'
 import {useOnboardingDispatch} from '#/state/shell'
 import {uploadBlob} from 'lib/api'
+import {useRequestNotificationsPermission} from 'lib/notifications/notifications'
 import {
   DescriptionText,
   OnboardingControls,
@@ -39,6 +40,7 @@ export function StepFinished() {
   const [saving, setSaving] = React.useState(false)
   const queryClient = useQueryClient()
   const agent = useAgent()
+  const requestNotificationsPermission = useRequestNotificationsPermission()
 
   const finishOnboarding = React.useCallback(async () => {
     setSaving(true)
@@ -72,6 +74,7 @@ export function StepFinished() {
               : 'default',
           })
         })(),
+        requestNotificationsPermission('AfterOnboarding'),
       ])
     } catch (e: any) {
       logger.info(`onboarding: bulk save failed`)
@@ -98,7 +101,15 @@ export function StepFinished() {
     track('OnboardingV2:StepFinished:End')
     track('OnboardingV2:Complete')
     logEvent('onboarding:finished:nextPressed', {})
-  }, [state, dispatch, onboardDispatch, setSaving, track, agent, queryClient])
+  }, [
+    state,
+    queryClient,
+    agent,
+    dispatch,
+    onboardDispatch,
+    track,
+    requestNotificationsPermission,
+  ])
 
   React.useEffect(() => {
     track('OnboardingV2:StepFinished:Start')

--- a/src/view/screens/Home.tsx
+++ b/src/view/screens/Home.tsx
@@ -59,6 +59,7 @@ function HomeScreenReady({
   preferences: UsePreferencesQueryResponse
   pinnedFeedInfos: SavedFeedSourceInfo[]
 }) {
+  const {currentAccount} = useSession()
   const requestNotificationsPermission = useRequestNotificationsPermission()
 
   const allFeeds = React.useMemo(
@@ -75,8 +76,10 @@ function HomeScreenReady({
   useOTAUpdates()
 
   React.useEffect(() => {
+    if (!currentAccount) return
+
     requestNotificationsPermission('AfterOnboarding')
-  }, [requestNotificationsPermission])
+  }, [currentAccount, requestNotificationsPermission])
 
   const pagerRef = React.useRef<PagerRef>(null)
   const lastPagerReportedIndexRef = React.useRef(selectedIndex)

--- a/src/view/screens/Home.tsx
+++ b/src/view/screens/Home.tsx
@@ -20,7 +20,6 @@ import {
 } from '#/state/shell'
 import {useSelectedFeed, useSetSelectedFeed} from '#/state/shell/selected-feed'
 import {useOTAUpdates} from 'lib/hooks/useOTAUpdates'
-import {useRequestNotificationsPermission} from 'lib/notifications/notifications'
 import {HomeTabNavigatorParams, NativeStackScreenProps} from 'lib/routes/types'
 import {FeedPage} from 'view/com/feeds/FeedPage'
 import {Pager, PagerRef, RenderTabBarFnProps} from 'view/com/pager/Pager'
@@ -59,9 +58,6 @@ function HomeScreenReady({
   preferences: UsePreferencesQueryResponse
   pinnedFeedInfos: SavedFeedSourceInfo[]
 }) {
-  const {currentAccount} = useSession()
-  const requestNotificationsPermission = useRequestNotificationsPermission()
-
   const allFeeds = React.useMemo(
     () => pinnedFeedInfos.map(f => f.feedDescriptor),
     [pinnedFeedInfos],
@@ -74,12 +70,6 @@ function HomeScreenReady({
 
   useSetTitle(pinnedFeedInfos[selectedIndex]?.displayName)
   useOTAUpdates()
-
-  React.useEffect(() => {
-    if (!currentAccount) return
-
-    requestNotificationsPermission('AfterOnboarding')
-  }, [currentAccount, requestNotificationsPermission])
 
   const pagerRef = React.useRef<PagerRef>(null)
   const lastPagerReportedIndexRef = React.useRef(selectedIndex)


### PR DESCRIPTION
## Why

There was a significantly higher number of people hitting the `request_notifications_permission_after_onboarding` gate that were not actually new signups. It looks like this may have been tied to `canAskAgain` being `true` on some devices. Let's remove that check completely, and just skip the check if `permissions.status` is `granted` or `denied`.

## Test Plan

We can probably do some minimal testing by flipping the gate back and forth and creating new accounts to check the Statsig logs, but I'm not certain how we can verify whether the `canAskAgain` was indeed the problem here. Might be something we just need to wait and see results for.

![image](https://github.com/bluesky-social/social-app/assets/153161762/98c77d1d-b5ab-4007-8b9e-b8540c55ac92)
