### PR TITLE
Localized date time strings

### DIFF
--- a/__tests__/lib/string.test.ts
+++ b/__tests__/lib/string.test.ts
@@ -1,4 +1,5 @@
 import {RichText} from '@atproto/api'
+import {I18n} from '@lingui/core'
 
 import {parseEmbedPlayerFromUrl} from 'lib/strings/embed-player'
 import {cleanError} from '../../src/lib/strings/errors'
@@ -207,8 +208,10 @@ describe('ago', () => {
   ]
 
   it('correctly calculates how much time passed, in a string', () => {
+    const i18n = new I18n({locale: 'en'})
+
     for (let i = 0; i < inputs.length; i++) {
-      const result = ago(inputs[i])
+      const result = ago(i18n, inputs[i])
       expect(result).toEqual(outputs[i])
     }
   })

--- a/src/components/ProfileHoverCard/index.web.tsx
+++ b/src/components/ProfileHoverCard/index.web.tsx
@@ -358,7 +358,7 @@ function Inner({
   hide: () => void
 }) {
   const t = useTheme()
-  const {_} = useLingui()
+  const {_, i18n} = useLingui()
   const {currentAccount} = useSession()
   const moderation = React.useMemo(
     () => moderateProfile(profile, moderationOpts),
@@ -371,8 +371,8 @@ function Inner({
     logContext: 'ProfileHoverCard',
   })
   const blockHide = profile.viewer?.blocking || profile.viewer?.blockedBy
-  const following = formatCount(profile.followsCount || 0)
-  const followers = formatCount(profile.followersCount || 0)
+  const following = formatCount(i18n, profile.followsCount || 0)
+  const followers = formatCount(i18n, profile.followersCount || 0)
   const pluralizedFollowers = plural(profile.followersCount || 0, {
     one: 'follower',
     other: 'followers',

--- a/src/components/dialogs/Embed.tsx
+++ b/src/components/dialogs/Embed.tsx
@@ -43,7 +43,7 @@ function EmbedDialogInner({
   timestamp,
 }: Omit<EmbedDialogProps, 'control'>) {
   const t = useTheme()
-  const {_} = useLingui()
+  const {_, i18n} = useLingui()
   const ref = useRef<TextInput>(null)
   const [copied, setCopied] = useState(false)
 
@@ -86,9 +86,9 @@ function EmbedDialogInner({
     )} (<a href="${escapeHtml(profileHref)}">@${escapeHtml(
       postAuthor.handle,
     )}</a>) <a href="${escapeHtml(href)}">${escapeHtml(
-      niceDate(timestamp),
+      niceDate(i18n, timestamp),
     )}</a></blockquote><script async src="${EMBED_SCRIPT}" charset="utf-8"></script>`
-  }, [postUri, postCid, record, timestamp, postAuthor])
+  }, [i18n, postUri, postCid, record, timestamp, postAuthor])
 
   return (
     <Dialog.Inner label="Embed post" style={[a.gap_md, {maxWidth: 500}]}>

--- a/src/components/dms/MessageItem.tsx
+++ b/src/components/dms/MessageItem.tsx
@@ -7,6 +7,7 @@ import {
   View,
 } from 'react-native'
 import {ChatBskyConvoDefs, RichText as RichTextAPI} from '@atproto/api'
+import {I18n} from '@lingui/core'
 import {msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
@@ -130,7 +131,7 @@ let MessageItemMetadata = ({
   style: StyleProp<TextStyle>
 }): React.ReactNode => {
   const t = useTheme()
-  const {_, i18n} = useLingui()
+  const {_} = useLingui()
   const {message} = item
 
   const handleRetry = useCallback(
@@ -145,7 +146,7 @@ let MessageItemMetadata = ({
   )
 
   const relativeTimestamp = useCallback(
-    (timestamp: string) => {
+    (i18n: I18n, timestamp: string) => {
       const date = new Date(timestamp)
       const now = new Date()
 
@@ -182,7 +183,7 @@ let MessageItemMetadata = ({
         year: 'numeric',
       })
     },
-    [_, i18n],
+    [_],
   )
 
   return (

--- a/src/components/dms/MessageItem.tsx
+++ b/src/components/dms/MessageItem.tsx
@@ -130,7 +130,7 @@ let MessageItemMetadata = ({
   style: StyleProp<TextStyle>
 }): React.ReactNode => {
   const t = useTheme()
-  const {_} = useLingui()
+  const {_, i18n} = useLingui()
   const {message} = item
 
   const handleRetry = useCallback(
@@ -149,10 +149,10 @@ let MessageItemMetadata = ({
       const date = new Date(timestamp)
       const now = new Date()
 
-      const time = new Intl.DateTimeFormat(undefined, {
+      const time = i18n.date(date, {
         hour: 'numeric',
         minute: 'numeric',
-      }).format(date)
+      })
 
       const diff = now.getTime() - date.getTime()
 
@@ -174,15 +174,15 @@ let MessageItemMetadata = ({
         return _(msg`Yesterday, ${time}`)
       }
 
-      return new Intl.DateTimeFormat(undefined, {
+      return i18n.date(date, {
         hour: 'numeric',
         minute: 'numeric',
         day: 'numeric',
         month: 'numeric',
         year: 'numeric',
-      }).format(date)
+      })
     },
-    [_],
+    [_, i18n],
   )
 
   return (

--- a/src/components/forms/DateField/index.shared.tsx
+++ b/src/components/forms/DateField/index.shared.tsx
@@ -1,12 +1,12 @@
 import React from 'react'
 import {Pressable, View} from 'react-native'
+import {useLingui} from '@lingui/react'
 
 import {android, atoms as a, useTheme, web} from '#/alf'
 import * as TextField from '#/components/forms/TextField'
 import {useInteractionState} from '#/components/hooks/useInteractionState'
 import {CalendarDays_Stroke2_Corner0_Rounded as CalendarDays} from '#/components/icons/CalendarDays'
 import {Text} from '#/components/Typography'
-import {localizeDate} from './utils'
 
 // looks like a TextField.Input, but is just a button. It'll do something different on each platform on press
 // iOS: open a dialog with an inline date picker
@@ -25,6 +25,7 @@ export function DateFieldButton({
   isInvalid?: boolean
   accessibilityHint?: string
 }) {
+  const {i18n} = useLingui()
   const t = useTheme()
 
   const {
@@ -91,7 +92,7 @@ export function DateFieldButton({
             t.atoms.text,
             {lineHeight: a.text_md.fontSize * 1.1875},
           ]}>
-          {localizeDate(value)}
+          {i18n.date(value, {timeZone: 'UTC'})}
         </Text>
       </Pressable>
     </View>

--- a/src/components/forms/DateField/utils.ts
+++ b/src/components/forms/DateField/utils.ts
@@ -1,16 +1,5 @@
-import {getLocales} from 'expo-localization'
-
-const LOCALE = getLocales()[0]
-
 // we need the date in the form yyyy-MM-dd to pass to the input
 export function toSimpleDateString(date: Date | string): string {
   const _date = typeof date === 'string' ? new Date(date) : date
   return _date.toISOString().split('T')[0]
-}
-
-export function localizeDate(date: Date | string): string {
-  const _date = typeof date === 'string' ? new Date(date) : date
-  return new Intl.DateTimeFormat(LOCALE.languageTag, {
-    timeZone: 'UTC',
-  }).format(_date)
 }

--- a/src/lib/strings/time.ts
+++ b/src/lib/strings/time.ts
@@ -1,10 +1,15 @@
+import {I18n} from '@lingui/core'
+import {msg} from '@lingui/macro'
+
+import {MONTH_FALLBACK_LOCALES} from '#/locale/constants'
+
 const NOW = 5
 const MINUTE = 60
 const HOUR = MINUTE * 60
 const DAY = HOUR * 24
 const MONTH_30 = DAY * 30
 const MONTH = DAY * 30.41675 // This results in 365.001 days in a year, which is close enough for nearly all cases
-export function ago(date: number | string | Date): string {
+export function ago(i18n: I18n, date: number | string | Date): string {
   let ts: number
   if (typeof date === 'string') {
     ts = Number(new Date(date))
@@ -15,15 +20,31 @@ export function ago(date: number | string | Date): string {
   }
   const diffSeconds = Math.floor((Date.now() - ts) / 1e3)
   if (diffSeconds < NOW) {
-    return `now`
+    return i18n._(msg`now`)
   } else if (diffSeconds < MINUTE) {
-    return `${diffSeconds}s`
+    return i18n.number(diffSeconds, {
+      style: 'unit',
+      unitDisplay: 'narrow',
+      unit: 'second',
+    })
   } else if (diffSeconds < HOUR) {
-    return `${Math.floor(diffSeconds / MINUTE)}m`
+    return i18n.number(Math.floor(diffSeconds / MINUTE), {
+      style: 'unit',
+      unitDisplay: 'narrow',
+      unit: 'minute',
+    })
   } else if (diffSeconds < DAY) {
-    return `${Math.floor(diffSeconds / HOUR)}h`
+    return i18n.number(Math.floor(diffSeconds / HOUR), {
+      style: 'unit',
+      unitDisplay: 'narrow',
+      unit: 'hour',
+    })
   } else if (diffSeconds < MONTH_30) {
-    return `${Math.round(diffSeconds / DAY)}d`
+    return i18n.number(Math.round(diffSeconds / DAY), {
+      style: 'unit',
+      unitDisplay: 'narrow',
+      unit: 'day',
+    })
   } else {
     let months = diffSeconds / MONTH
     if (months % 1 >= 0.9) {
@@ -33,23 +54,26 @@ export function ago(date: number | string | Date): string {
     }
 
     if (months < 12) {
-      return `${months}mo`
+      if (MONTH_FALLBACK_LOCALES.includes(i18n.locale)) return `${months}mo`
+
+      return i18n.number(months, {
+        style: 'unit',
+        unitDisplay: 'narrow',
+        unit: 'month',
+      })
     } else {
-      return new Date(ts).toLocaleDateString()
+      return i18n.date(new Date(ts))
     }
   }
 }
 
-export function niceDate(date: number | string | Date) {
+export function niceDate(i18n: I18n, date: number | string | Date) {
   const d = new Date(date)
-  return `${d.toLocaleDateString('en-us', {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-  })} at ${d.toLocaleTimeString(undefined, {
-    hour: 'numeric',
-    minute: '2-digit',
-  })}`
+
+  return i18n.date(d, {
+    dateStyle: 'long',
+    timeStyle: 'short',
+  })
 }
 
 export function getAge(birthDate: Date): number {

--- a/src/lib/strings/time.ts
+++ b/src/lib/strings/time.ts
@@ -1,7 +1,5 @@
 import {I18n} from '@lingui/core'
-import {msg} from '@lingui/macro'
-
-import {MONTH_FALLBACK_LOCALES} from '#/locale/constants'
+import {defineMessage, msg} from '@lingui/macro'
 
 const NOW = 5
 const MINUTE = 60
@@ -18,33 +16,57 @@ export function ago(i18n: I18n, date: number | string | Date): string {
   } else {
     ts = date
   }
+
   const diffSeconds = Math.floor((Date.now() - ts) / 1e3)
+
+  // We can't use `i18n.number` with a `unit` format here because ICU (which
+  // provides localization data) doesn't seem to have narrow unit display
+  // formatting for locales like Japanese, Spanish, French and Turkish.
+
+  // We'll use `defineMessage` here instead of our usual `msg` as we can pass
+  // an object with a `comment` property that better describes what these
+  // strings are supposed to be. These comments get stripped out in production.
+
+  // Intermediate variables are created to improve the interpolation keys.
+
   if (diffSeconds < NOW) {
     return i18n._(msg`now`)
   } else if (diffSeconds < MINUTE) {
-    return i18n.number(diffSeconds, {
-      style: 'unit',
-      unitDisplay: 'narrow',
-      unit: 'second',
-    })
+    const seconds = diffSeconds
+
+    return i18n._(
+      defineMessage({
+        message: `${seconds}s`,
+        comment: `How many seconds has passed, displayed in a narrow form`,
+      }),
+    )
   } else if (diffSeconds < HOUR) {
-    return i18n.number(Math.floor(diffSeconds / MINUTE), {
-      style: 'unit',
-      unitDisplay: 'narrow',
-      unit: 'minute',
-    })
+    const minutes = Math.floor(diffSeconds / MINUTE)
+
+    return i18n._(
+      defineMessage({
+        message: `${minutes}m`,
+        comment: `How many minutes has passed, displayed in a narrow form`,
+      }),
+    )
   } else if (diffSeconds < DAY) {
-    return i18n.number(Math.floor(diffSeconds / HOUR), {
-      style: 'unit',
-      unitDisplay: 'narrow',
-      unit: 'hour',
-    })
+    const hours = Math.floor(diffSeconds / HOUR)
+
+    return i18n._(
+      defineMessage({
+        message: `${hours}h`,
+        comment: `How many minutes has passed, displayed in a narrow form`,
+      }),
+    )
   } else if (diffSeconds < MONTH_30) {
-    return i18n.number(Math.round(diffSeconds / DAY), {
-      style: 'unit',
-      unitDisplay: 'narrow',
-      unit: 'day',
-    })
+    const days = Math.round(diffSeconds / DAY)
+
+    return i18n._(
+      defineMessage({
+        message: `${days}d`,
+        comment: `How many minutes has passed, displayed in a narrow form`,
+      }),
+    )
   } else {
     let months = diffSeconds / MONTH
     if (months % 1 >= 0.9) {
@@ -54,13 +76,12 @@ export function ago(i18n: I18n, date: number | string | Date): string {
     }
 
     if (months < 12) {
-      if (MONTH_FALLBACK_LOCALES.includes(i18n.locale)) return `${months}mo`
-
-      return i18n.number(months, {
-        style: 'unit',
-        unitDisplay: 'narrow',
-        unit: 'month',
-      })
+      return i18n._(
+        defineMessage({
+          message: `${months}mo`,
+          comment: `How many months has passed, displayed in a narrow form`,
+        }),
+      )
     } else {
       return i18n.date(new Date(ts))
     }

--- a/src/lib/strings/time.ts
+++ b/src/lib/strings/time.ts
@@ -55,7 +55,7 @@ export function ago(i18n: I18n, date: number | string | Date): string {
     return i18n._(
       defineMessage({
         message: `${hours}h`,
-        comment: `How many minutes has passed, displayed in a narrow form`,
+        comment: `How many hours has passed, displayed in a narrow form`,
       }),
     )
   } else if (diffSeconds < MONTH_30) {
@@ -64,7 +64,7 @@ export function ago(i18n: I18n, date: number | string | Date): string {
     return i18n._(
       defineMessage({
         message: `${days}d`,
-        comment: `How many minutes has passed, displayed in a narrow form`,
+        comment: `How many days has passed, displayed in a narrow form`,
       }),
     )
   } else {

--- a/src/locale/constants.ts
+++ b/src/locale/constants.ts
@@ -1,4 +1,0 @@
-// The narrow unit display for `month` in English is `m`, which conflicts with
-// the one for `minute` (also `m`), this also goes for any locale that currently
-// falls back to English for narrow-unit display (missing localization?)
-export const MONTH_FALLBACK_LOCALES = ['en', 'ja', 'es', 'fr', 'tr']

--- a/src/locale/constants.ts
+++ b/src/locale/constants.ts
@@ -1,0 +1,4 @@
+// The narrow unit display for `month` in English is `m`, which conflicts with
+// the one for `minute` (also `m`), this also goes for any locale that currently
+// falls back to English for narrow-unit display (missing localization?)
+export const MONTH_FALLBACK_LOCALES = ['en', 'ja', 'es', 'fr', 'tr']

--- a/src/screens/Profile/Header/Metrics.tsx
+++ b/src/screens/Profile/Header/Metrics.tsx
@@ -17,9 +17,9 @@ export function ProfileHeaderMetrics({
   profile: Shadow<AppBskyActorDefs.ProfileViewDetailed>
 }) {
   const t = useTheme()
-  const {_} = useLingui()
-  const following = formatCount(profile.followsCount || 0)
-  const followers = formatCount(profile.followersCount || 0)
+  const {_, i18n} = useLingui()
+  const following = formatCount(i18n, profile.followsCount || 0)
+  const followers = formatCount(i18n, profile.followersCount || 0)
   const pluralizedFollowers = plural(profile.followersCount || 0, {
     one: 'follower',
     other: 'followers',
@@ -54,7 +54,7 @@ export function ProfileHeaderMetrics({
         </Text>
       </InlineLinkText>
       <Text style={[a.font_bold, t.atoms.text, a.text_md]}>
-        {formatCount(profile.postsCount || 0)}{' '}
+        {formatCount(i18n, profile.postsCount || 0)}{' '}
         <Text style={[t.atoms.text_contrast_medium, a.font_normal, a.text_md]}>
           {plural(profile.postsCount || 0, {one: 'post', other: 'posts'})}
         </Text>

--- a/src/view/com/notifications/FeedItem.tsx
+++ b/src/view/com/notifications/FeedItem.tsx
@@ -67,7 +67,7 @@ let FeedItem = ({
 }): React.ReactNode => {
   const queryClient = useQueryClient()
   const pal = usePalette('default')
-  const {_} = useLingui()
+  const {_, i18n} = useLingui()
   const [isAuthorsExpanded, setAuthorsExpanded] = useState<boolean>(false)
   const itemHref = useMemo(() => {
     if (item.type === 'post-like' || item.type === 'repost') {
@@ -175,7 +175,8 @@ let FeedItem = ({
     return null
   }
 
-  let formattedCount = authors.length > 1 ? formatCount(authors.length - 1) : ''
+  let formattedCount =
+    authors.length > 1 ? formatCount(i18n, authors.length - 1) : ''
   return (
     <Link
       testID={`feedItem-by-${item.notification.author.handle}`}

--- a/src/view/com/notifications/FeedItem.tsx
+++ b/src/view/com/notifications/FeedItem.tsx
@@ -249,7 +249,7 @@ let FeedItem = ({
               {({timeElapsed}) => (
                 <Text
                   style={[pal.textLight, styles.pointer]}
-                  title={niceDate(item.notification.indexedAt)}>
+                  title={niceDate(i18n, item.notification.indexedAt)}>
                   {' ' + timeElapsed}
                 </Text>
               )}

--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -165,7 +165,7 @@ let PostThreadItemLoaded = ({
   onPostReply: () => void
 }): React.ReactNode => {
   const pal = usePalette('default')
-  const {_} = useLingui()
+  const {_, i18n} = useLingui()
   const langPrefs = useLanguagePrefs()
   const {openComposer} = useComposerControls()
   const [limitLines, setLimitLines] = React.useState(
@@ -339,7 +339,7 @@ let PostThreadItemLoaded = ({
                       type="lg"
                       style={pal.textLight}>
                       <Text type="xl-bold" style={pal.text}>
-                        {formatCount(post.repostCount)}
+                        {formatCount(i18n, post.repostCount)}
                       </Text>{' '}
                       <Plural
                         value={post.repostCount}
@@ -359,7 +359,7 @@ let PostThreadItemLoaded = ({
                       type="lg"
                       style={pal.textLight}>
                       <Text type="xl-bold" style={pal.text}>
-                        {formatCount(post.likeCount)}
+                        {formatCount(i18n, post.likeCount)}
                       </Text>{' '}
                       <Plural value={post.likeCount} one="like" other="likes" />
                     </Text>

--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -636,7 +636,7 @@ function ExpandedPostDetails({
   translatorUrl: string
 }) {
   const pal = usePalette('default')
-  const {_} = useLingui()
+  const {_, i18n} = useLingui()
   const openLink = useOpenLink()
 
   const text = record?.text || ''
@@ -654,7 +654,7 @@ function ExpandedPostDetails({
 
   return (
     <View style={[s.flexRow, s.mt2, s.mb10]}>
-      <Text style={pal.textLight}>{niceDate(post.indexedAt)}</Text>
+      <Text style={pal.textLight}>{niceDate(i18n, post.indexedAt)}</Text>
       {needsTranslation && (
         <>
           <Text style={pal.textLight}> &middot; </Text>

--- a/src/view/com/util/PostMeta.tsx
+++ b/src/view/com/util/PostMeta.tsx
@@ -1,6 +1,7 @@
 import React, {memo, useCallback} from 'react'
 import {StyleProp, StyleSheet, TextStyle, View, ViewStyle} from 'react-native'
 import {AppBskyActorDefs, ModerationDecision, ModerationUI} from '@atproto/api'
+import {useLingui} from '@lingui/react'
 import {useQueryClient} from '@tanstack/react-query'
 
 import {precacheProfile, usePrefetchProfileQuery} from '#/state/queries/profile'
@@ -33,6 +34,8 @@ interface PostMetaOpts {
 }
 
 let PostMeta = (opts: PostMetaOpts): React.ReactNode => {
+  const {i18n} = useLingui()
+
   const pal = usePalette('default')
   const displayName = opts.author.displayName || opts.author.handle
   const handle = opts.author.handle
@@ -114,8 +117,8 @@ let PostMeta = (opts: PostMetaOpts): React.ReactNode => {
             style={pal.textLight}
             lineHeight={1.2}
             text={timeElapsed}
-            accessibilityLabel={niceDate(opts.timestamp)}
-            title={niceDate(opts.timestamp)}
+            accessibilityLabel={niceDate(i18n, opts.timestamp)}
+            title={niceDate(i18n, opts.timestamp)}
             accessibilityHint=""
             href={opts.postHref}
             onBeforePress={onBeforePressPost}

--- a/src/view/com/util/TimeElapsed.tsx
+++ b/src/view/com/util/TimeElapsed.tsx
@@ -1,4 +1,6 @@
 import React from 'react'
+import {I18n} from '@lingui/core'
+import {useLingui} from '@lingui/react'
 
 import {useTickEveryMinute} from '#/state/shell'
 import {ago} from 'lib/strings/time'
@@ -10,17 +12,19 @@ export function TimeElapsed({
 }: {
   timestamp: string
   children: ({timeElapsed}: {timeElapsed: string}) => JSX.Element
-  timeToString?: (timeElapsed: string) => string
+  timeToString?: (i18n: I18n, timeElapsed: string) => string
 }) {
+  const {i18n} = useLingui()
+
   const tick = useTickEveryMinute()
   const [timeElapsed, setTimeAgo] = React.useState(() =>
-    timeToString(timestamp),
+    timeToString(i18n, timestamp),
   )
 
   const [prevTick, setPrevTick] = React.useState(tick)
   if (prevTick !== tick) {
     setPrevTick(tick)
-    setTimeAgo(timeToString(timestamp))
+    setTimeAgo(timeToString(i18n, timestamp))
   }
 
   return children({timeElapsed})

--- a/src/view/com/util/forms/DateInput.tsx
+++ b/src/view/com/util/forms/DateInput.tsx
@@ -1,19 +1,18 @@
-import React, {useState, useCallback} from 'react'
+import React, {useCallback, useState} from 'react'
 import {StyleProp, StyleSheet, TextStyle, View, ViewStyle} from 'react-native'
+import DatePicker from 'react-native-date-picker'
 import {
   FontAwesomeIcon,
   FontAwesomeIconStyle,
 } from '@fortawesome/react-native-fontawesome'
-import {isIOS, isAndroid} from 'platform/detection'
-import {Button, ButtonType} from './Button'
-import {Text} from '../text/Text'
+import {useLingui} from '@lingui/react'
+
+import {usePalette} from 'lib/hooks/usePalette'
 import {TypographyVariant} from 'lib/ThemeContext'
 import {useTheme} from 'lib/ThemeContext'
-import {usePalette} from 'lib/hooks/usePalette'
-import {getLocales} from 'expo-localization'
-import DatePicker from 'react-native-date-picker'
-
-const LOCALE = getLocales()[0]
+import {isAndroid, isIOS} from 'platform/detection'
+import {Text} from '../text/Text'
+import {Button, ButtonType} from './Button'
 
 interface Props {
   testID?: string
@@ -30,15 +29,10 @@ interface Props {
 }
 
 export function DateInput(props: Props) {
+  const {i18n} = useLingui()
   const [show, setShow] = useState(false)
   const theme = useTheme()
   const pal = usePalette('default')
-
-  const formatter = React.useMemo(() => {
-    return new Intl.DateTimeFormat(LOCALE.languageTag, {
-      timeZone: props.handleAsUTC ? 'UTC' : undefined,
-    })
-  }, [props.handleAsUTC])
 
   const onChangeInternal = useCallback(
     (date: Date) => {
@@ -74,7 +68,9 @@ export function DateInput(props: Props) {
             <Text
               type={props.buttonLabelType}
               style={[pal.text, props.buttonLabelStyle]}>
-              {formatter.format(props.value)}
+              {i18n.date(props.value, {
+                timeZone: props.handleAsUTC ? 'UTC' : undefined,
+              })}
             </Text>
           </View>
         </Button>

--- a/src/view/com/util/numeric/format.ts
+++ b/src/view/com/util/numeric/format.ts
@@ -1,19 +1,12 @@
-export const formatCount = (num: number) =>
-  Intl.NumberFormat('en-US', {
+import type {I18n} from '@lingui/core'
+
+export const formatCount = (i18n: I18n, num: number) => {
+  return i18n.number(num, {
     notation: 'compact',
     maximumFractionDigits: 1,
     // `1,953` shouldn't be rounded up to 2k, it should be truncated.
     // @ts-expect-error: `roundingMode` doesn't seem to be in the typings yet
     // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#roundingmode
     roundingMode: 'trunc',
-  }).format(num)
-
-export function formatCountShortOnly(num: number): string {
-  if (num >= 1000000) {
-    return (num / 1000000).toFixed(1) + 'M'
-  }
-  if (num >= 1000) {
-    return (num / 1000).toFixed(1) + 'K'
-  }
-  return String(num)
+  })
 }

--- a/src/view/screens/AppPasswords.tsx
+++ b/src/view/screens/AppPasswords.tsx
@@ -18,7 +18,6 @@ import {useWebMediaQueries} from '#/lib/hooks/useWebMediaQueries'
 import {CommonNavigatorParams} from '#/lib/routes/types'
 import {cleanError} from '#/lib/strings/errors'
 import {useModalControls} from '#/state/modals'
-import {useLanguagePrefs} from '#/state/preferences'
 import {
   useAppPasswordDeleteMutation,
   useAppPasswordsQuery,
@@ -218,9 +217,8 @@ function AppPassword({
   privileged?: boolean
 }) {
   const pal = usePalette('default')
-  const {_} = useLingui()
+  const {_, i18n} = useLingui()
   const control = useDialogControl()
-  const {contentLanguages} = useLanguagePrefs()
   const deleteMutation = useAppPasswordDeleteMutation()
 
   const onDelete = React.useCallback(async () => {
@@ -231,9 +229,6 @@ function AppPassword({
   const onPress = React.useCallback(() => {
     control.open()
   }, [control])
-
-  const primaryLocale =
-    contentLanguages.length > 0 ? contentLanguages[0] : 'en-US'
 
   return (
     <TouchableOpacity
@@ -250,14 +245,14 @@ function AppPassword({
         <Text type="md" style={[pal.text, styles.pr10]} numberOfLines={1}>
           <Trans>
             Created{' '}
-            {Intl.DateTimeFormat(primaryLocale, {
+            {i18n.date(createdAt, {
               year: 'numeric',
               month: 'numeric',
               day: 'numeric',
               hour: '2-digit',
               minute: '2-digit',
               second: '2-digit',
-            }).format(new Date(createdAt))}
+            })}
           </Trans>
         </Text>
         {privileged && (

--- a/src/view/screens/Log.tsx
+++ b/src/view/screens/Log.tsx
@@ -1,25 +1,26 @@
 import React from 'react'
 import {StyleSheet, TouchableOpacity, View} from 'react-native'
-import {useFocusEffect} from '@react-navigation/native'
 import {FontAwesomeIcon} from '@fortawesome/react-native-fontawesome'
-import {NativeStackScreenProps, CommonNavigatorParams} from 'lib/routes/types'
-import {ScrollView} from '../com/util/Views'
-import {s} from 'lib/styles'
-import {ViewHeader} from '../com/util/ViewHeader'
-import {Text} from '../com/util/text/Text'
-import {usePalette} from 'lib/hooks/usePalette'
-import {getEntries} from '#/logger/logDump'
-import {ago} from 'lib/strings/time'
-import {useLingui} from '@lingui/react'
 import {msg} from '@lingui/macro'
+import {useLingui} from '@lingui/react'
+import {useFocusEffect} from '@react-navigation/native'
+
+import {getEntries} from '#/logger/logDump'
 import {useSetMinimalShellMode} from '#/state/shell'
+import {usePalette} from 'lib/hooks/usePalette'
+import {CommonNavigatorParams, NativeStackScreenProps} from 'lib/routes/types'
+import {ago} from 'lib/strings/time'
+import {s} from 'lib/styles'
+import {Text} from '../com/util/text/Text'
+import {ViewHeader} from '../com/util/ViewHeader'
+import {ScrollView} from '../com/util/Views'
 
 export function LogScreen({}: NativeStackScreenProps<
   CommonNavigatorParams,
   'Log'
 >) {
   const pal = usePalette('default')
-  const {_} = useLingui()
+  const {_, i18n} = useLingui()
   const setMinimalShellMode = useSetMinimalShellMode()
   const [expanded, setExpanded] = React.useState<string[]>([])
 
@@ -70,7 +71,7 @@ export function LogScreen({}: NativeStackScreenProps<
                     />
                   ) : undefined}
                   <Text type="sm" style={[styles.ts, pal.textLight]}>
-                    {ago(entry.timestamp)}
+                    {ago(i18n, entry.timestamp)}
                   </Text>
                 </TouchableOpacity>
                 {expanded.includes(entry.id) ? (

--- a/src/view/shell/Drawer.tsx
+++ b/src/view/shell/Drawer.tsx
@@ -33,7 +33,7 @@ import {colors, s} from 'lib/styles'
 import {useTheme} from 'lib/ThemeContext'
 import {isWeb} from 'platform/detection'
 import {NavSignupCard} from '#/view/shell/NavSignupCard'
-import {formatCountShortOnly} from 'view/com/util/numeric/format'
+import {formatCount} from 'view/com/util/numeric/format'
 import {Text} from 'view/com/util/text/Text'
 import {UserAvatar} from 'view/com/util/UserAvatar'
 import {useTheme as useAlfTheme} from '#/alf'
@@ -68,7 +68,7 @@ let DrawerProfileCard = ({
   account: SessionAccount
   onPressProfile: () => void
 }): React.ReactNode => {
-  const {_} = useLingui()
+  const {_, i18n} = useLingui()
   const pal = usePalette('default')
   const {data: profile} = useProfileQuery({did: account.did})
 
@@ -100,7 +100,7 @@ let DrawerProfileCard = ({
       <Text type="xl" style={[pal.textLight, styles.profileCardFollowers]}>
         <Trans>
           <Text type="xl-medium" style={pal.text}>
-            {formatCountShortOnly(profile?.followersCount ?? 0)}
+            {formatCount(i18n, profile?.followersCount ?? 0)}
           </Text>{' '}
           <Plural
             value={profile?.followersCount || 0}
@@ -111,7 +111,7 @@ let DrawerProfileCard = ({
         &middot;{' '}
         <Trans>
           <Text type="xl-medium" style={pal.text}>
-            {formatCountShortOnly(profile?.followsCount ?? 0)}
+            {formatCount(i18n, profile?.followsCount ?? 0)}
           </Text>{' '}
           <Plural
             value={profile?.followsCount || 0}


### PR DESCRIPTION
Stacked on #4268, adds proper datetime localization.

There's an issue where memoized components might not necessarily reflect, as the I18n class instance is reused across locale changes. If that's a concern, we can do another change where we'll remake the instance when changing languages.
