### PR TITLE
don't maintain position whenever there are no parents

### DIFF
--- a/src/view/com/post-thread/PostThread.tsx
+++ b/src/view/com/post-thread/PostThread.tsx
@@ -440,7 +440,9 @@ export function PostThread({
           onEndReachedThreshold={2}
           onScrollToTop={onScrollToTop}
           maintainVisibleContentPosition={
-            isNative ? MAINTAIN_VISIBLE_CONTENT_POSITION : undefined
+            isNative && hasParents
+              ? MAINTAIN_VISIBLE_CONTENT_POSITION
+              : undefined
           }
           // @ts-ignore our .web version only -prf
           desktopFixedHeight


### PR DESCRIPTION
## Why

In https://github.com/bluesky-social/social-app/pull/4254, we removed the `ViewHeader` from the items given to `FlatList` and instead placed it outside the `FlatList`. In doing so, we removed the first element of our array.

Now, whenever we open a post that has no parents but has a link card inside of it, we see that the list is maintaining the position of the root post - since that is the first item in the list that can be "latched onto".

https://github.com/bluesky-social/social-app/assets/153161762/8eb22c0d-3240-4cac-a644-24d15605395c

The solution is to set the `maintainVisibleContentPosition` prop to `undefined` whenever we know there are no parents that could cause a layout jump.

## Test Plan

Visit this post and test opening the quoted post. There should be no layout jump. https://bsky.app/profile/ellyzoe.bsky.social/post/3ktlkoamoko2h

https://github.com/bluesky-social/social-app/assets/153161762/71e17dd1-d409-43da-8546-bec4a8fbfb19
