### PR TITLE
Fix native translations on iOS 17.5.1

### DIFF
--- a/modules/expo-bluesky-translate/src/ExpoBlueskyTranslateView.ios.tsx
+++ b/modules/expo-bluesky-translate/src/ExpoBlueskyTranslateView.ios.tsx
@@ -15,12 +15,10 @@ export function NativeTranslationView() {
   return <NativeView />
 }
 
-const twoDigitVersion = String(Platform.Version)
-  .split('.')
-  .slice(0, 2)
-  .join('.')
+// can be something like "17.5.1", so just take the first two parts
+const version = String(Platform.Version).split('.').slice(0, 2).join('.')
 
-export const isAvailable = Number(twoDigitVersion) >= 17.4
+export const isAvailable = Number(version) >= 17.4
 
 // https://en.wikipedia.org/wiki/Translate_(Apple)#Languages
 const SUPPORTED_LANGUAGES = [

--- a/modules/expo-bluesky-translate/src/ExpoBlueskyTranslateView.ios.tsx
+++ b/modules/expo-bluesky-translate/src/ExpoBlueskyTranslateView.ios.tsx
@@ -15,7 +15,12 @@ export function NativeTranslationView() {
   return <NativeView />
 }
 
-export const isAvailable = Number(Platform.Version) >= 17.4
+const twoDigitVersion = String(Platform.Version)
+  .split('.')
+  .slice(0, 2)
+  .join('.')
+
+export const isAvailable = Number(twoDigitVersion) >= 17.4
 
 // https://en.wikipedia.org/wiki/Translate_(Apple)#Languages
 const SUPPORTED_LANGUAGES = [


### PR DESCRIPTION
Seems like simulators just report 17.5, so this dumb mistake totally slipped past me. Whoops!