### PR TITLE
Play haptics before closing repost dialog

### DIFF
--- a/src/view/com/util/post-ctrls/PostCtrls.tsx
+++ b/src/view/com/util/post-ctrls/PostCtrls.tsx
@@ -23,7 +23,6 @@ import {toShareUrl} from '#/lib/strings/url-helpers'
 import {s} from '#/lib/styles'
 import {Shadow} from '#/state/cache/types'
 import {useFeedFeedbackContext} from '#/state/feed-feedback'
-import {useModalControls} from '#/state/modals'
 import {
   usePostLikeMutationQueue,
   usePostRepostMutationQueue,
@@ -65,7 +64,6 @@ let PostCtrls = ({
   const t = useTheme()
   const {_} = useLingui()
   const {openComposer} = useComposerControls()
-  const {closeModal} = useModalControls()
   const [queueLike, queueUnlike] = usePostLikeMutationQueue(post, logContext)
   const [queueRepost, queueUnrepost] = usePostRepostMutationQueue(
     post,
@@ -118,10 +116,8 @@ let PostCtrls = ({
   ])
 
   const onRepost = useCallback(async () => {
-    closeModal()
     try {
       if (!post.viewer?.repost) {
-        playHaptic()
         sendInteraction({
           item: post.uri,
           event: 'app.bsky.feed.defs#interactionRepost',
@@ -137,10 +133,8 @@ let PostCtrls = ({
       }
     }
   }, [
-    closeModal,
     post.uri,
     post.viewer?.repost,
-    playHaptic,
     queueRepost,
     queueUnrepost,
     sendInteraction,
@@ -148,7 +142,6 @@ let PostCtrls = ({
   ])
 
   const onQuote = useCallback(() => {
-    closeModal()
     sendInteraction({
       item: post.uri,
       event: 'app.bsky.feed.defs#interactionQuote',
@@ -163,16 +156,13 @@ let PostCtrls = ({
         indexedAt: post.indexedAt,
       },
     })
-    playHaptic()
   }, [
-    closeModal,
     openComposer,
     post.uri,
     post.cid,
     post.author,
     post.indexedAt,
     record.text,
-    playHaptic,
     sendInteraction,
     feedContext,
   ])

--- a/src/view/com/util/post-ctrls/RepostButton.tsx
+++ b/src/view/com/util/post-ctrls/RepostButton.tsx
@@ -3,6 +3,7 @@ import {View} from 'react-native'
 import {msg, plural} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
+import {useHaptics} from '#/lib/haptics'
 import {useRequireAuth} from '#/state/session'
 import {atoms as a, useTheme} from '#/alf'
 import {Button, ButtonText} from '#/components/Button'
@@ -30,6 +31,7 @@ let RepostButton = ({
   const {_} = useLingui()
   const requireAuth = useRequireAuth()
   const dialogControl = Dialog.useDialogControl()
+  const playHaptic = useHaptics()
 
   const color = React.useMemo(
     () => ({
@@ -89,8 +91,11 @@ let RepostButton = ({
                     : _(msg({message: `Repost`, context: 'action'}))
                 }
                 onPress={() => {
-                  dialogControl.close()
-                  onRepost()
+                  if (!isReposted) playHaptic()
+
+                  dialogControl.close(() => {
+                    onRepost()
+                  })
                 }}
                 size="large"
                 variant="ghost"
@@ -106,6 +111,7 @@ let RepostButton = ({
                 style={[a.justify_start, a.px_md]}
                 label={_(msg`Quote post`)}
                 onPress={() => {
+                  playHaptic()
                   dialogControl.close(() => {
                     onQuote()
                   })


### PR DESCRIPTION
New repost dialog introduces a bit of a delay before the action takes place, due to needing to close the dialog first. This meant there was a bit of a pause before the haptic plays. This moves the haptic call to before the dialog starts closing.

Also removed some unnecessary legacy dialog stuff