### PR TITLE
Fix scrolling for labeler profiles

### DIFF
--- a/src/view/com/util/Views.jsx
+++ b/src/view/com/util/Views.jsx
@@ -1,12 +1,7 @@
-import React from 'react'
 import {View} from 'react-native'
 import Animated from 'react-native-reanimated'
 
+// If you explode these into functions, don't forget to forwardRef!
 export const FlatList_INTERNAL = Animated.FlatList
-export function CenteredView(props) {
-  return <View {...props} />
-}
-
-export function ScrollView(props) {
-  return <Animated.ScrollView {...props} />
-}
+export const CenteredView = View
+export const ScrollView = Animated.ScrollView

--- a/src/view/com/util/Views.web.tsx
+++ b/src/view/com/util/Views.web.tsx
@@ -31,7 +31,7 @@ interface AddedProps {
   desktopFixedHeight?: boolean | number
 }
 
-export function CenteredView({
+export const CenteredView = React.forwardRef(function CenteredView({
   style,
   sideBorders,
   topBorder,
@@ -58,7 +58,7 @@ export function CenteredView({
     style = addStyle(style, pal.border)
   }
   return <View style={style} {...props} />
-}
+})
 
 export const FlatList_INTERNAL = React.forwardRef(function FlatListImpl<ItemT>(
   {


### PR DESCRIPTION
The ref wasn't being forwarded through these wrappers. (We had a React warning fire about this btw.) The wrappers are unnecessary so I collapsed them but I added a note.

## Test Plan


https://github.com/bluesky-social/social-app/assets/810438/b1a2772c-4a1b-4544-be84-9d1a556a96db

