### PR TITLE
[🙅] Add deactivate account dialog

### DIFF
--- a/src/screens/Settings/components/DeactivateAccountDialog.tsx
+++ b/src/screens/Settings/components/DeactivateAccountDialog.tsx
@@ -1,27 +1,59 @@
 import React from 'react'
-import {msg} from '@lingui/macro'
+import {View} from 'react-native'
+import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
+import {atoms as a, useTheme} from '#/alf'
 import {DialogOuterProps} from '#/components/Dialog'
+import {Divider} from '#/components/Divider'
 import * as Prompt from '#/components/Prompt'
+import {Text} from '#/components/Typography'
 
 export function DeactivateAccountDialog({
   control,
 }: {
   control: DialogOuterProps['control']
 }) {
+  const t = useTheme()
   const {_} = useLingui()
 
   return (
-    <Prompt.Basic
-      control={control}
-      title={_(msg`Deactivate account`)}
-      description={_(
-        msg`Are you sure you want to deactivate your account? You won't be able to interact on the network using this account, and users won't be able to see your profile or posts.`,
-      )}
-      confirmButtonCta={_(msg`Yes, deactivate my account`)}
-      confirmButtonColor="negative"
-      onConfirm={() => {}}
-    />
+    <Prompt.Outer control={control} testID="confirmModal">
+      <Prompt.TitleText>{_(msg`Deactivate account`)}</Prompt.TitleText>
+      <Prompt.DescriptionText>
+        <Trans>
+          Your profile and posts will no longer be visible to other Bluesky
+          users. You can reactivate your account at any time by logging in.
+        </Trans>
+      </Prompt.DescriptionText>
+
+      <View style={[a.pb_xl]}>
+        <Divider />
+        <View style={[a.gap_sm, a.pt_lg, a.pb_xl]}>
+          <Text style={[t.atoms.text_contrast_medium, a.leading_snug]}>
+            <Trans>
+              There is no time limit for account deactivation, come back any
+              time.
+            </Trans>
+          </Text>
+          <Text style={[t.atoms.text_contrast_medium, a.leading_snug]}>
+            <Trans>
+              If you're trying to change your handle or email, do so before you
+              deactivate.
+            </Trans>
+          </Text>
+        </View>
+
+        <Divider />
+      </View>
+      <Prompt.Actions>
+        <Prompt.Action
+          cta={_(msg`Yes, deactivate`)}
+          onPress={() => {}}
+          color="negative"
+        />
+        <Prompt.Cancel />
+      </Prompt.Actions>
+    </Prompt.Outer>
   )
 }

--- a/src/screens/Settings/components/DeactivateAccountDialog.tsx
+++ b/src/screens/Settings/components/DeactivateAccountDialog.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import {msg} from '@lingui/macro'
+import {useLingui} from '@lingui/react'
+
+import {DialogOuterProps} from '#/components/Dialog'
+import * as Prompt from '#/components/Prompt'
+
+export function DeactivateAccountDialog({
+  control,
+}: {
+  control: DialogOuterProps['control']
+}) {
+  const {_} = useLingui()
+
+  return (
+    <Prompt.Basic
+      control={control}
+      title={_(msg`Deactivate account`)}
+      description={_(
+        msg`Are you sure you want to deactivate your account? You won't be able to interact on the network using this account, and users won't be able to see your profile or posts.`,
+      )}
+      confirmButtonCta={_(msg`Yes, deactivate my account`)}
+      confirmButtonColor="negative"
+      onConfirm={() => {}}
+    />
+  )
+}

--- a/src/screens/Settings/components/DeactivateAccountDialog.tsx
+++ b/src/screens/Settings/components/DeactivateAccountDialog.tsx
@@ -22,8 +22,9 @@ export function DeactivateAccountDialog({
       <Prompt.TitleText>{_(msg`Deactivate account`)}</Prompt.TitleText>
       <Prompt.DescriptionText>
         <Trans>
-          Your profile and posts will no longer be visible to other Bluesky
-          users. You can reactivate your account at any time by logging in.
+          Your profile, posts, feeds, and lists will no longer be visible to
+          other Bluesky users. You can reactivate your account at any time by
+          logging in.
         </Trans>
       </Prompt.DescriptionText>
 

--- a/src/view/com/modals/DeleteAccount.tsx
+++ b/src/view/com/modals/DeleteAccount.tsx
@@ -18,7 +18,7 @@ import {useWebMediaQueries} from 'lib/hooks/useWebMediaQueries'
 import {cleanError} from 'lib/strings/errors'
 import {colors, gradients, s} from 'lib/styles'
 import {useTheme} from 'lib/ThemeContext'
-import {isAndroid} from 'platform/detection'
+import {isAndroid, isWeb} from 'platform/detection'
 import {DeactivateAccountDialog} from '#/screens/Settings/components/DeactivateAccountDialog'
 import {atoms as a, useTheme as useNewTheme} from '#/alf'
 import {useDialogControl} from '#/components/Dialog'
@@ -177,40 +177,43 @@ export function Component({}: {}) {
               </>
             )}
 
-            <View
-              style={[
-                a.flex_row,
-                a.gap_sm,
-                a.mt_lg,
-                a.p_lg,
-                a.rounded_sm,
-                t.atoms.bg_contrast_25,
-              ]}>
-              <CircleInfo
-                size="xl"
+            <View style={[!isWeb && a.px_xl]}>
+              <View
                 style={[
-                  a.relative,
-                  {
-                    top: -5,
-                  },
-                ]}
-              />
+                  a.w_full,
+                  a.flex_row,
+                  a.gap_sm,
+                  a.mt_lg,
+                  a.p_lg,
+                  a.rounded_sm,
+                  t.atoms.bg_contrast_25,
+                ]}>
+                <CircleInfo
+                  size="md"
+                  style={[
+                    a.relative,
+                    {
+                      top: -1,
+                    },
+                  ]}
+                />
 
-              <NewText style={[a.leading_snug]}>
-                <Trans>
-                  You can also temporarily deactivate your account instead, and
-                  reactivate it at any time.
-                </Trans>{' '}
-                <InlineLinkText
-                  to="#"
-                  onPress={e => {
-                    e.preventDefault()
-                    deactivateAccountControl.open()
-                    return false
-                  }}>
-                  <Trans>Click here for more information.</Trans>
-                </InlineLinkText>
-              </NewText>
+                <NewText style={[a.leading_snug, a.flex_1]}>
+                  <Trans>
+                    You can also temporarily deactivate your account instead,
+                    and reactivate it at any time.
+                  </Trans>{' '}
+                  <InlineLinkText
+                    to="#"
+                    onPress={e => {
+                      e.preventDefault()
+                      deactivateAccountControl.open()
+                      return false
+                    }}>
+                    <Trans>Click here for more information.</Trans>
+                  </InlineLinkText>
+                </NewText>
+              </View>
             </View>
 
             <DeactivateAccountDialog control={deactivateAccountControl} />

--- a/src/view/com/modals/DeleteAccount.tsx
+++ b/src/view/com/modals/DeleteAccount.tsx
@@ -19,6 +19,12 @@ import {cleanError} from 'lib/strings/errors'
 import {colors, gradients, s} from 'lib/styles'
 import {useTheme} from 'lib/ThemeContext'
 import {isAndroid} from 'platform/detection'
+import {DeactivateAccountDialog} from '#/screens/Settings/components/DeactivateAccountDialog'
+import {atoms as a, useTheme as useNewTheme} from '#/alf'
+import {useDialogControl} from '#/components/Dialog'
+import {CircleInfo_Stroke2_Corner0_Rounded as CircleInfo} from '#/components/icons/CircleInfo'
+import {InlineLinkText} from '#/components/Link'
+import {Text as NewText} from '#/components/Typography'
 import {resetToTab} from '../../../Navigation'
 import {ErrorMessage} from '../util/error/ErrorMessage'
 import {Text} from '../util/text/Text'
@@ -30,6 +36,7 @@ export const snapPoints = isAndroid ? ['90%'] : ['55%']
 export function Component({}: {}) {
   const pal = usePalette('default')
   const theme = useTheme()
+  const t = useNewTheme()
   const {currentAccount} = useSession()
   const agent = useAgent()
   const {removeAccount} = useSessionApi()
@@ -41,6 +48,7 @@ export function Component({}: {}) {
   const [password, setPassword] = React.useState<string>('')
   const [isProcessing, setIsProcessing] = React.useState<boolean>(false)
   const [error, setError] = React.useState<string>('')
+  const deactivateAccountControl = useDialogControl()
   const onPressSendEmail = async () => {
     setError('')
     setIsProcessing(true)
@@ -168,6 +176,44 @@ export function Component({}: {}) {
                 </TouchableOpacity>
               </>
             )}
+
+            <View
+              style={[
+                a.flex_row,
+                a.gap_sm,
+                a.mt_lg,
+                a.p_lg,
+                a.rounded_sm,
+                t.atoms.bg_contrast_25,
+              ]}>
+              <CircleInfo
+                size="xl"
+                style={[
+                  a.relative,
+                  {
+                    top: -5,
+                  },
+                ]}
+              />
+
+              <NewText style={[a.leading_snug]}>
+                <Trans>
+                  You can also temporarily deactivate your account instead, and
+                  reactivate it at any time.
+                </Trans>{' '}
+                <InlineLinkText
+                  to="#"
+                  onPress={e => {
+                    e.preventDefault()
+                    deactivateAccountControl.open()
+                    return false
+                  }}>
+                  <Trans>Click here for more information.</Trans>
+                </InlineLinkText>
+              </NewText>
+            </View>
+
+            <DeactivateAccountDialog control={deactivateAccountControl} />
           </>
         ) : (
           <>

--- a/src/view/screens/Settings/index.tsx
+++ b/src/view/screens/Settings/index.tsx
@@ -808,7 +808,7 @@ export function SettingsScreen({}: Props) {
           )}>
           <View style={[styles.iconContainer, dangerBg]}>
             <FontAwesomeIcon
-              icon={'x'}
+              icon={'users-slash'}
               style={dangerText as FontAwesomeIconStyle}
               size={18}
             />

--- a/src/view/screens/Settings/index.tsx
+++ b/src/view/screens/Settings/index.tsx
@@ -63,6 +63,7 @@ import {ScrollView} from 'view/com/util/Views'
 import {useTheme} from '#/alf'
 import {useDialogControl} from '#/components/Dialog'
 import {BirthDateSettingsDialog} from '#/components/dialogs/BirthDateSettings'
+import * as Prompt from '#/components/Prompt'
 import {navigate, resetToTab} from '#/Navigation'
 import {Email2FAToggle} from './Email2FAToggle'
 import {ExportCarDialog} from './ExportCarDialog'
@@ -305,6 +306,11 @@ export function SettingsScreen({}: Props) {
     await clearLegacyStorage()
     Toast.show(_(msg`Legacy storage cleared, you need to restart the app now.`))
   }, [_])
+
+  const deactivateAccountControl = Prompt.usePromptControl()
+  const onPressDeactivateAccount = React.useCallback(() => {
+    deactivateAccountControl.open()
+  }, [deactivateAccountControl])
 
   const {mutate: onPressDeleteChatDeclaration} = useDeleteActorDeclaration()
 
@@ -790,6 +796,38 @@ export function SettingsScreen({}: Props) {
             <Trans>Export My Data</Trans>
           </Text>
         </TouchableOpacity>
+
+        <TouchableOpacity
+          style={[pal.view, styles.linkCard]}
+          onPress={onPressDeactivateAccount}
+          accessible={true}
+          accessibilityRole="button"
+          accessibilityLabel={_(msg`Deactivate account`)}
+          accessibilityHint={_(
+            msg`Opens modal for account deactivation confirmation`,
+          )}>
+          <View style={[styles.iconContainer, dangerBg]}>
+            <FontAwesomeIcon
+              icon={'x'}
+              style={dangerText as FontAwesomeIconStyle}
+              size={18}
+            />
+          </View>
+          <Text type="lg" style={dangerText}>
+            <Trans>Deactivate my account</Trans>
+          </Text>
+        </TouchableOpacity>
+        <Prompt.Basic
+          control={deactivateAccountControl}
+          title={_(msg`Deactivate account`)}
+          description={_(
+            msg`Are you sure you want to deactivate your account? You won't be able to interact on the network using this account, and users won't be able to see your profile or posts.`,
+          )}
+          confirmButtonCta={_(msg`Yes, deactivate my account`)}
+          confirmButtonColor="negative"
+          onConfirm={() => {}}
+        />
+
         <TouchableOpacity
           style={[pal.view, styles.linkCard]}
           onPress={onPressDeleteAccount}

--- a/src/view/screens/Settings/index.tsx
+++ b/src/view/screens/Settings/index.tsx
@@ -60,10 +60,10 @@ import {Text} from 'view/com/util/text/Text'
 import * as Toast from 'view/com/util/Toast'
 import {UserAvatar} from 'view/com/util/UserAvatar'
 import {ScrollView} from 'view/com/util/Views'
+import {DeactivateAccountDialog} from '#/screens/Settings/components/DeactivateAccountDialog'
 import {useTheme} from '#/alf'
 import {useDialogControl} from '#/components/Dialog'
 import {BirthDateSettingsDialog} from '#/components/dialogs/BirthDateSettings'
-import * as Prompt from '#/components/Prompt'
 import {navigate, resetToTab} from '#/Navigation'
 import {Email2FAToggle} from './Email2FAToggle'
 import {ExportCarDialog} from './ExportCarDialog'
@@ -307,7 +307,7 @@ export function SettingsScreen({}: Props) {
     Toast.show(_(msg`Legacy storage cleared, you need to restart the app now.`))
   }, [_])
 
-  const deactivateAccountControl = Prompt.usePromptControl()
+  const deactivateAccountControl = useDialogControl()
   const onPressDeactivateAccount = React.useCallback(() => {
     deactivateAccountControl.open()
   }, [deactivateAccountControl])
@@ -817,16 +817,7 @@ export function SettingsScreen({}: Props) {
             <Trans>Deactivate my account</Trans>
           </Text>
         </TouchableOpacity>
-        <Prompt.Basic
-          control={deactivateAccountControl}
-          title={_(msg`Deactivate account`)}
-          description={_(
-            msg`Are you sure you want to deactivate your account? You won't be able to interact on the network using this account, and users won't be able to see your profile or posts.`,
-          )}
-          confirmButtonCta={_(msg`Yes, deactivate my account`)}
-          confirmButtonColor="negative"
-          onConfirm={() => {}}
-        />
+        <DeactivateAccountDialog control={deactivateAccountControl} />
 
         <TouchableOpacity
           style={[pal.view, styles.linkCard]}


### PR DESCRIPTION
Adds the dialog as its own button on the Settings screen, and accessible from within the delete account dialog.

![CleanShot 2024-05-31 at 14 48 21@2x](https://github.com/bluesky-social/social-app/assets/4732330/47400715-b3fa-46cf-abeb-e59d5fbd7d7d)
![CleanShot 2024-05-31 at 15 05 15@2x](https://github.com/bluesky-social/social-app/assets/4732330/85eaa28e-e3c3-4f59-b65c-68d0b7067c50)
![CleanShot 2024-05-31 at 15 05 12@2x](https://github.com/bluesky-social/social-app/assets/4732330/f8ac93a9-04b2-432d-a54d-391a8034c964)
![CleanShot 2024-05-31 at 15 03 14@2x](https://github.com/bluesky-social/social-app/assets/4732330/ecfe30cd-01e5-463d-903e-a32afb04a39a)
![CleanShot 2024-05-31 at 14 54 01@2x](https://github.com/bluesky-social/social-app/assets/4732330/c30eaec2-40c7-49be-aaec-104f65ea19b5)
