### PR TITLE
Don't log downsample warning when unnecessary

### DIFF
--- a/src/lib/statsig/statsig.tsx
+++ b/src/lib/statsig/statsig.tsx
@@ -102,15 +102,18 @@ export function logEvent<E extends keyof LogEvents>(
   rawMetadata: LogEvents[E] & FlatJSONRecord,
 ) {
   try {
+    if (
+      process.env.NODE_ENV === 'development' &&
+      eventName.endsWith(':sampled') &&
+      DOWNSAMPLED_EVENTS.has(eventName)
+    ) {
+      logger.error(
+        'Did you forget to add ' + eventName + ' to DOWNSAMPLED_EVENTS?',
+      )
+    }
+
     if (isDownsampledSession && DOWNSAMPLED_EVENTS.has(eventName)) {
       return
-    }
-    if (process.env.NODE_ENV === 'development') {
-      if (eventName.endsWith(':sampled')) {
-        logger.error(
-          'Did you forget to add ' + eventName + ' to DOWNSAMPLED_EVENTS?',
-        )
-      }
     }
     const fullMetadata = {
       ...rawMetadata,

--- a/src/lib/statsig/statsig.tsx
+++ b/src/lib/statsig/statsig.tsx
@@ -105,7 +105,7 @@ export function logEvent<E extends keyof LogEvents>(
     if (
       process.env.NODE_ENV === 'development' &&
       eventName.endsWith(':sampled') &&
-      DOWNSAMPLED_EVENTS.has(eventName)
+      !DOWNSAMPLED_EVENTS.has(eventName)
     ) {
       logger.error(
         'Did you forget to add ' + eventName + ' to DOWNSAMPLED_EVENTS?',


### PR DESCRIPTION
## Why

The logic that is logging errors in dev mode for a missing entry in `DOWNSAMPLED_EVENTS` gets logged any time that `isDownsampledSession` is true - which is most often since there's a 90% chance of downsampling, since there is no `.has` check before the log, just a check for `endsWith`.

I've fixed that, as well as moved this log above the `isDownsampledSession` check, so we are sure to get an error rather than possibly missing it if we get the 10% chance of a downsampled session.

## Test Plan

Open the app, see that there is no longer an error displayed when viewing the home tab. You can invert the check on line 108 to see that the logs do still show up in dev mode.