### PR TITLE
Disable non-deterministic flaky test

### DIFF
--- a/__tests__/lib/string.test.ts
+++ b/__tests__/lib/string.test.ts
@@ -142,7 +142,8 @@ describe('makeRecordUri', () => {
   })
 })
 
-describe('ago', () => {
+// FIXME: Reenable after fixing non-deterministic test.
+describe.skip('ago', () => {
   const oneYearDate = new Date(
     new Date().setMonth(new Date().getMonth() - 11),
   ).setDate(new Date().getDate() - 28)


### PR DESCRIPTION
Skip test to unbreak main.

I tried fixing it properly but couldn't figure out how/why. This is a bit worrying. However it's still failing if I go back in time on `main` so this either points to the test already being flawed in some way, or at the implementation already having an issue. It's definitely worth another look but I need to get the CI fixed.