### PR TITLE
don't use flexBasis on web for message post embeds

### DIFF
--- a/src/components/dms/MessageItemEmbed.tsx
+++ b/src/components/dms/MessageItemEmbed.tsx
@@ -3,7 +3,7 @@ import {View} from 'react-native'
 import {AppBskyEmbedRecord} from '@atproto/api'
 
 import {PostEmbeds} from '#/view/com/util/post-embeds'
-import {atoms as a, useTheme} from '#/alf'
+import {atoms as a, native, useTheme} from '#/alf'
 
 let MessageItemEmbed = ({
   embed,
@@ -13,7 +13,7 @@ let MessageItemEmbed = ({
   const t = useTheme()
 
   return (
-    <View style={[a.my_xs, t.atoms.bg, a.rounded_md, {flexBasis: 0}]}>
+    <View style={[a.my_xs, t.atoms.bg, a.rounded_md, native({flexBasis: 0})]}>
       <PostEmbeds embed={embed} />
     </View>
   )

--- a/src/components/dms/MessageItemEmbed.tsx
+++ b/src/components/dms/MessageItemEmbed.tsx
@@ -13,7 +13,7 @@ let MessageItemEmbed = ({
   const t = useTheme()
 
   return (
-    <View style={[a.my_xs, t.atoms.bg, a.rounded_md, native({flexBasis: 0})]}>
+    <View style={[a.my_xs, t.atoms.bg, native({flexBasis: 0})]}>
       <PostEmbeds embed={embed} />
     </View>
   )


### PR DESCRIPTION
## Why

Using `flexBasis: 0` on web is causing messages to lose their positioning:

![Screenshot 2024-05-31 at 9 33 34 AM](https://github.com/bluesky-social/social-app/assets/153161762/fc09d1a9-2b93-469f-b45e-674da784f739)

## Test Plan

### Web Tablet/Desktop

![Screenshot 2024-05-31 at 10 41 21 AM](https://github.com/bluesky-social/social-app/assets/153161762/c480d829-3d54-4b6e-804b-61c54fcf2307)

### Web Mobile

![Screenshot 2024-05-31 at 10 41 14 AM](https://github.com/bluesky-social/social-app/assets/153161762/70eb7a60-b81d-4a5a-a856-f1f740afb337)
