### PR TITLE
fix accessibility label in notifications

### DIFF
--- a/src/view/com/notifications/FeedItem.tsx
+++ b/src/view/com/notifications/FeedItem.tsx
@@ -196,13 +196,13 @@ let FeedItem = ({
       noFeedback
       accessible={!isAuthorsExpanded}
       accessibilityActions={
-        item.type === 'post-like' && authors.length > 1
+        authors.length > 1
           ? [
               {
                 name: 'toggleAuthorsExpanded',
                 label: isAuthorsExpanded
-                  ? _(msg`Collapse list of users that liked this post`)
-                  : _(msg`Expand list of users that liked this post`),
+                  ? _(msg`Collapse list of users`)
+                  : _(msg`Expand list of users`),
               },
             ]
           : [

--- a/src/view/com/notifications/FeedItem.tsx
+++ b/src/view/com/notifications/FeedItem.tsx
@@ -201,13 +201,25 @@ let FeedItem = ({
               {
                 name: 'toggleAuthorsExpanded',
                 label: isAuthorsExpanded
-                  ? _(msg`Expand list of users that liked this post`)
-                  : _(msg`Collapse list of users that liked this post`),
+                  ? _(msg`Collapse list of users that liked this post`)
+                  : _(msg`Expand list of users that liked this post`),
               },
             ]
-          : undefined
+          : [
+              {
+                name: 'viewProfile',
+                label: _(
+                  msg`View ${
+                    authors[0].profile.displayName || authors[0].profile.handle
+                  }'s profile`,
+                ),
+              },
+            ]
       }
       onAccessibilityAction={e => {
+        if (e.nativeEvent.actionName === 'activate') {
+          onBeforePress()
+        }
         if (e.nativeEvent.actionName === 'toggleAuthorsExpanded') {
           onToggleAuthorsExpanded()
         }
@@ -346,6 +358,7 @@ function CondensedAuthorsList({
           profile={authors[0].profile}
           moderation={authors[0].moderation.ui('avatar')}
           type={authors[0].profile.associated?.labeler ? 'labeler' : 'user'}
+          accessible={false}
         />
       </View>
     )
@@ -362,6 +375,7 @@ function CondensedAuthorsList({
               profile={author.profile}
               moderation={author.moderation.ui('avatar')}
               type={author.profile.associated?.labeler ? 'labeler' : 'user'}
+              accessible={false}
             />
           </View>
         ))}
@@ -403,49 +417,45 @@ function ExpandedAuthorsList({
   }, [heightInterp, visible])
 
   return (
-    <Animated.View
-      style={[
-        heightStyle,
-        styles.overflowHidden,
-        visible ? s.mb10 : undefined,
-      ]}>
-      {authors.map(author => (
-        <NewLink
-          key={author.profile.did}
-          label={author.profile.displayName || author.profile.handle}
-          accessibilityHint={_(msg`Open's profile`)}
-          to={makeProfileLink({
-            did: author.profile.did,
-            handle: author.profile.handle,
-          })}
-          style={styles.expandedAuthor}>
-          <View style={styles.expandedAuthorAvi}>
-            <ProfileHoverCard did={author.profile.did}>
-              <UserAvatar
-                size={35}
-                avatar={author.profile.avatar}
-                moderation={author.moderation.ui('avatar')}
-                type={author.profile.associated?.labeler ? 'labeler' : 'user'}
-              />
-            </ProfileHoverCard>
-          </View>
-          <View style={s.flex1}>
-            <Text
-              type="lg-bold"
-              numberOfLines={1}
-              style={pal.text}
-              lineHeight={1.2}>
-              {sanitizeDisplayName(
-                author.profile.displayName || author.profile.handle,
-              )}
-              &nbsp;
-              <Text style={[pal.textLight]} lineHeight={1.2}>
-                {sanitizeHandle(author.profile.handle)}
+    <Animated.View style={[heightStyle, styles.overflowHidden]}>
+      {visible &&
+        authors.map(author => (
+          <NewLink
+            key={author.profile.did}
+            label={author.profile.displayName || author.profile.handle}
+            accessibilityHint={_(msg`Open's profile`)}
+            to={makeProfileLink({
+              did: author.profile.did,
+              handle: author.profile.handle,
+            })}
+            style={styles.expandedAuthor}>
+            <View style={styles.expandedAuthorAvi}>
+              <ProfileHoverCard did={author.profile.did}>
+                <UserAvatar
+                  size={35}
+                  avatar={author.profile.avatar}
+                  moderation={author.moderation.ui('avatar')}
+                  type={author.profile.associated?.labeler ? 'labeler' : 'user'}
+                />
+              </ProfileHoverCard>
+            </View>
+            <View style={s.flex1}>
+              <Text
+                type="lg-bold"
+                numberOfLines={1}
+                style={pal.text}
+                lineHeight={1.2}>
+                {sanitizeDisplayName(
+                  author.profile.displayName || author.profile.handle,
+                )}
+                &nbsp;
+                <Text style={[pal.textLight]} lineHeight={1.2}>
+                  {sanitizeHandle(author.profile.handle)}
+                </Text>
               </Text>
-            </Text>
-          </View>
-        </NewLink>
-      ))}
+            </View>
+          </NewLink>
+        ))}
     </Animated.View>
   )
 }

--- a/src/view/com/notifications/FeedItem.tsx
+++ b/src/view/com/notifications/FeedItem.tsx
@@ -194,10 +194,24 @@ let FeedItem = ({
       ]}
       href={itemHref}
       noFeedback
-      accessible={
-        (item.type === 'post-like' && authors.length === 1) ||
-        item.type === 'repost'
+      accessible={!isAuthorsExpanded}
+      accessibilityActions={
+        item.type === 'post-like' && authors.length > 1
+          ? [
+              {
+                name: 'toggleAuthorsExpanded',
+                label: isAuthorsExpanded
+                  ? _(msg`Expand list of users that liked this post`)
+                  : _(msg`Collapse list of users that liked this post`),
+              },
+            ]
+          : undefined
       }
+      onAccessibilityAction={e => {
+        if (e.nativeEvent.actionName === 'toggleAuthorsExpanded') {
+          onToggleAuthorsExpanded()
+        }
+      }}
       onBeforePress={onBeforePress}>
       <View style={[styles.layoutIcon, a.pr_sm]}>
         {/* TODO: Prevent conditional rendering and move toward composable
@@ -338,10 +352,7 @@ function CondensedAuthorsList({
   }
   return (
     <TouchableOpacity
-      accessibilityLabel={_(msg`Show users`)}
-      accessibilityHint={_(
-        msg`Opens an expanded list of users in this notification`,
-      )}
+      accessibilityRole="none"
       onPress={onToggleAuthorsExpanded}>
       <View style={styles.avis}>
         {authors.slice(0, MAX_AUTHORS).map(author => (

--- a/src/view/com/notifications/FeedItem.tsx
+++ b/src/view/com/notifications/FeedItem.tsx
@@ -423,7 +423,7 @@ function ExpandedAuthorsList({
           <NewLink
             key={author.profile.did}
             label={author.profile.displayName || author.profile.handle}
-            accessibilityHint={_(msg`Open's profile`)}
+            accessibilityHint={_(msg`Opens this profile`)}
             to={makeProfileLink({
               did: author.profile.did,
               handle: author.profile.handle,

--- a/src/view/com/notifications/FeedItem.tsx
+++ b/src/view/com/notifications/FeedItem.tsx
@@ -401,7 +401,8 @@ function ExpandedAuthorsList({
       {authors.map(author => (
         <NewLink
           key={author.profile.did}
-          label={_(msg`See profile`)}
+          label={author.profile.displayName || author.profile.handle}
+          accessibilityHint={_(msg`Open's profile`)}
           to={makeProfileLink({
             did: author.profile.did,
             handle: author.profile.handle,

--- a/src/view/com/util/Link.tsx
+++ b/src/view/com/util/Link.tsx
@@ -91,6 +91,11 @@ export const Link = memo(function Link({
     [closeModal, navigation, navigationAction, href, openLink, onBeforePress],
   )
 
+  const accessibilityActionsWithActivate = [
+    ...(accessibilityActions || []),
+    {name: 'activate', label: title},
+  ]
+
   if (noFeedback) {
     return (
       <WebAuxClickWrapper>
@@ -99,10 +104,7 @@ export const Link = memo(function Link({
           onPress={onPress}
           accessible={accessible}
           accessibilityRole="link"
-          accessibilityActions={[
-            ...(accessibilityActions || []),
-            {name: 'activate', label: title},
-          ]}
+          accessibilityActions={accessibilityActionsWithActivate}
           onAccessibilityAction={e => {
             if (e.nativeEvent.actionName === 'activate') {
               onPress()

--- a/src/view/com/util/Link.tsx
+++ b/src/view/com/util/Link.tsx
@@ -64,6 +64,8 @@ export const Link = memo(function Link({
   anchorNoUnderline,
   navigationAction,
   onBeforePress,
+  accessibilityActions,
+  onAccessibilityAction,
   ...props
 }: Props) {
   const t = useTheme()
@@ -97,6 +99,17 @@ export const Link = memo(function Link({
           onPress={onPress}
           accessible={accessible}
           accessibilityRole="link"
+          accessibilityActions={[
+            ...(accessibilityActions || []),
+            {name: 'activate', label: title},
+          ]}
+          onAccessibilityAction={e => {
+            if (e.nativeEvent.actionName === 'activate') {
+              onPress()
+            } else {
+              onAccessibilityAction?.(e)
+            }
+          }}
           {...props}
           android_ripple={{
             color: t.atoms.bg_contrast_25.backgroundColor,

--- a/src/view/com/util/UserAvatar.tsx
+++ b/src/view/com/util/UserAvatar.tsx
@@ -406,7 +406,7 @@ let PreviewableUserAvatar = ({
             ? _(msg`${profile.displayName || profile.handle}'s avatar`)
             : undefined
         }
-        accessibilityHint={accessible ? _(msg`Opens profile`) : undefined}
+        accessibilityHint={accessible ? _(msg`Opens this profile`) : undefined}
         to={makeProfileLink({
           did: profile.did,
           handle: profile.handle,

--- a/src/view/com/util/UserAvatar.tsx
+++ b/src/view/com/util/UserAvatar.tsx
@@ -399,7 +399,8 @@ let PreviewableUserAvatar = ({
   return (
     <ProfileHoverCard did={profile.did} disable={disableHoverCard}>
       <Link
-        label={_(msg`See profile`)}
+        label={_(msg`${profile.displayName || profile.handle}'s avatar`)}
+        accessibilityHint={_(msg`Opens profile`)}
         to={makeProfileLink({
           did: profile.did,
           handle: profile.handle,

--- a/src/view/com/util/UserAvatar.tsx
+++ b/src/view/com/util/UserAvatar.tsx
@@ -53,6 +53,7 @@ interface PreviewableUserAvatarProps extends BaseUserAvatarProps {
   profile: AppBskyActorDefs.ProfileViewBasic
   disableHoverCard?: boolean
   onBeforePress?: () => void
+  accessible?: boolean
 }
 
 const BLUR_AMOUNT = isWeb ? 5 : 100
@@ -386,6 +387,7 @@ let PreviewableUserAvatar = ({
   profile,
   disableHoverCard,
   onBeforePress,
+  accessible = true,
   ...rest
 }: PreviewableUserAvatarProps): React.ReactNode => {
   const {_} = useLingui()
@@ -399,8 +401,12 @@ let PreviewableUserAvatar = ({
   return (
     <ProfileHoverCard did={profile.did} disable={disableHoverCard}>
       <Link
-        label={_(msg`${profile.displayName || profile.handle}'s avatar`)}
-        accessibilityHint={_(msg`Opens profile`)}
+        label={
+          accessible
+            ? _(msg`${profile.displayName || profile.handle}'s avatar`)
+            : undefined
+        }
+        accessibilityHint={accessible ? _(msg`Opens profile`) : undefined}
         to={makeProfileLink({
           did: profile.did,
           handle: profile.handle,


### PR DESCRIPTION
## Why

The notifications accessibility was fairly convoluted (not that other places are much better yet either). This introduces a serious improvement that we can actually start implementing elsewhere, such as `FeedItem`.

- An optional prop on `PreviewableUserAvatar` that disables VoiceOver for this element
- The ability to pass `accessibilityActions` and `onAccessibilityAction` to `Link` without completely removing the default `activate` action.

In this PR, we're making the expansion of the list of users an accessibility action so that it doesn't interfere with other interactions on the notification. See the video below for an example.

## Test Plan

https://github.com/bluesky-social/social-app/assets/153161762/75af572b-4c9c-4ca6-a5dc-71c3497b4c01

