### PR TITLE
use the new icon in reposted by

### DIFF
--- a/src/view/com/posts/FeedItem.tsx
+++ b/src/view/com/posts/FeedItem.tsx
@@ -253,9 +253,9 @@ let FeedItemInner = ({
               )}
               onBeforePress={onOpenReposter}>
               <Repost
-                style={{color: pal.colors.textLight, marginRight: 2}}
-                width={16}
-                height={16}
+                style={{color: pal.colors.textLight, marginRight: 3}}
+                width={14}
+                height={14}
               />
               <Text
                 type="sm-bold"
@@ -464,7 +464,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     marginTop: 2,
     marginBottom: 2,
-    marginLeft: -20,
+    marginLeft: -18,
   },
   layout: {
     flexDirection: 'row',

--- a/src/view/com/posts/FeedItem.tsx
+++ b/src/view/com/posts/FeedItem.tsx
@@ -43,6 +43,7 @@ import {Text} from '../util/text/Text'
 import {PreviewableUserAvatar} from '../util/UserAvatar'
 import {AviFollowButton} from './AviFollowButton'
 import hairlineWidth = StyleSheet.hairlineWidth
+import {Repost_Stroke2_Corner2_Rounded as Repost} from '#/components/icons/Repost'
 
 interface FeedItemProps {
   record: AppBskyFeedPost.Record
@@ -251,13 +252,10 @@ let FeedItemInner = ({
                 )}`,
               )}
               onBeforePress={onOpenReposter}>
-              <FontAwesomeIcon
-                icon="retweet"
-                style={{
-                  marginRight: 4,
-                  color: pal.colors.textLight,
-                  minWidth: 16,
-                }}
+              <Repost
+                style={{color: pal.colors.textLight, marginRight: 2}}
+                width={16}
+                height={16}
               />
               <Text
                 type="sm-bold"
@@ -463,6 +461,7 @@ const styles = StyleSheet.create({
   },
   includeReason: {
     flexDirection: 'row',
+    alignItems: 'center',
     marginTop: 2,
     marginBottom: 2,
     marginLeft: -20,


### PR DESCRIPTION
## Why

We changed the icon elsewhere, but missed the reposted by label.

### Comparison in size

![Screenshot 2024-05-31 at 1 39 22 PM](https://github.com/bluesky-social/social-app/assets/153161762/287ba9c8-e431-4781-8beb-2563cb32467e)

### With new icon

![Screenshot 2024-05-31 at 1 40 43 PM](https://github.com/bluesky-social/social-app/assets/153161762/d807b66a-9ebe-45c7-89f0-24b3fd3dd468)
