### PR TITLE
invert the fab animation, play a haptic

### DIFF
--- a/src/lib/haptics.ts
+++ b/src/lib/haptics.ts
@@ -4,17 +4,21 @@ import {impactAsync, ImpactFeedbackStyle} from 'expo-haptics'
 import {isIOS, isWeb} from 'platform/detection'
 import {useHapticsDisabled} from 'state/preferences/disable-haptics'
 
-const hapticImpact: ImpactFeedbackStyle = isIOS
-  ? ImpactFeedbackStyle.Medium
-  : ImpactFeedbackStyle.Light // Users said the medium impact was too strong on Android; see APP-537s
-
 export function useHaptics() {
   const isHapticsDisabled = useHapticsDisabled()
 
-  return React.useCallback(() => {
-    if (isHapticsDisabled || isWeb) {
-      return
-    }
-    impactAsync(hapticImpact)
-  }, [isHapticsDisabled])
+  return React.useCallback(
+    (strength: 'Light' | 'Medium' | 'Heavy' = 'Medium') => {
+      if (isHapticsDisabled || isWeb) {
+        return
+      }
+
+      // Users said the medium impact was too strong on Android; see APP-537s
+      const style = isIOS
+        ? ImpactFeedbackStyle[strength]
+        : ImpactFeedbackStyle.Light
+      impactAsync(style)
+    },
+    [isHapticsDisabled],
+  )
 }

--- a/src/view/com/util/fab/FABInner.tsx
+++ b/src/view/com/util/fab/FABInner.tsx
@@ -1,6 +1,10 @@
 import React, {ComponentProps} from 'react'
 import {StyleSheet, TouchableWithoutFeedback} from 'react-native'
-import Animated, {useAnimatedStyle, withTiming} from 'react-native-reanimated'
+import Animated, {
+  Easing,
+  useAnimatedStyle,
+  withTiming,
+} from 'react-native-reanimated'
 import {useSafeAreaInsets} from 'react-native-safe-area-context'
 import {LinearGradient} from 'expo-linear-gradient'
 
@@ -36,7 +40,14 @@ export function FABInner({testID, icon, onPress, ...props}: FABProps) {
     : {right: 24, bottom: clamp(insets.bottom, 15, 60) + 15}
 
   const animatedStyle = useAnimatedStyle(() => ({
-    transform: [{scale: withTiming(isPressed ? 1.1 : 1, {duration: 150})}],
+    transform: [
+      {
+        scale: withTiming(isPressed ? 1.1 : 1, {
+          duration: 250,
+          easing: Easing.out(Easing.quad),
+        }),
+      },
+    ],
   }))
 
   return (
@@ -44,7 +55,10 @@ export function FABInner({testID, icon, onPress, ...props}: FABProps) {
       testID={testID}
       onPress={e => {
         playHaptic()
-        onPress?.(e)
+
+        setTimeout(() => {
+          onPress?.(e)
+        }, 75)
       }}
       onPressIn={onPressIn}
       onPressOut={onPressOut}

--- a/src/view/com/util/fab/FABInner.tsx
+++ b/src/view/com/util/fab/FABInner.tsx
@@ -9,6 +9,7 @@ import {useWebMediaQueries} from '#/lib/hooks/useWebMediaQueries'
 import {clamp} from '#/lib/numbers'
 import {gradients} from '#/lib/styles'
 import {isWeb} from '#/platform/detection'
+import {useHaptics} from 'lib/haptics'
 import {useInteractionState} from '#/components/hooks/useInteractionState'
 
 export interface FABProps
@@ -17,15 +18,16 @@ export interface FABProps
   icon: JSX.Element
 }
 
-export function FABInner({testID, icon, ...props}: FABProps) {
+export function FABInner({testID, icon, onPress, ...props}: FABProps) {
   const insets = useSafeAreaInsets()
   const {isMobile, isTablet} = useWebMediaQueries()
   const fabMinimalShellTransform = useMinimalShellFabTransform()
   const {
-    state: pressed,
+    state: isPressed,
     onIn: onPressIn,
     onOut: onPressOut,
   } = useInteractionState()
+  const playHaptic = useHaptics()
 
   const size = isTablet ? styles.sizeLarge : styles.sizeRegular
 
@@ -33,13 +35,17 @@ export function FABInner({testID, icon, ...props}: FABProps) {
     ? {right: 50, bottom: 50}
     : {right: 24, bottom: clamp(insets.bottom, 15, 60) + 15}
 
-  const scale = useAnimatedStyle(() => ({
-    transform: [{scale: withTiming(pressed ? 0.95 : 1)}],
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{scale: withTiming(isPressed ? 1.1 : 1, {duration: 150})}],
   }))
 
   return (
     <TouchableWithoutFeedback
       testID={testID}
+      onPress={e => {
+        playHaptic()
+        onPress?.(e)
+      }}
       onPressIn={onPressIn}
       onPressOut={onPressOut}
       {...props}>
@@ -50,7 +56,7 @@ export function FABInner({testID, icon, ...props}: FABProps) {
           tabletSpacing,
           isMobile && fabMinimalShellTransform,
         ]}>
-        <Animated.View style={scale}>
+        <Animated.View style={animatedStyle}>
           <LinearGradient
             colors={[gradients.blueLight.start, gradients.blueLight.end]}
             start={{x: 0, y: 0}}

--- a/src/view/com/util/fab/FABInner.tsx
+++ b/src/view/com/util/fab/FABInner.tsx
@@ -57,7 +57,6 @@ export function FABInner({testID, icon, onPress, ...props}: FABProps) {
       testID={testID}
       onPress={e => {
         playHaptic()
-
         setTimeout(
           () => {
             onPress?.(e)

--- a/src/view/com/util/fab/FABInner.tsx
+++ b/src/view/com/util/fab/FABInner.tsx
@@ -14,6 +14,7 @@ import {clamp} from '#/lib/numbers'
 import {gradients} from '#/lib/styles'
 import {isWeb} from '#/platform/detection'
 import {useHaptics} from 'lib/haptics'
+import {useHapticsDisabled} from 'state/preferences'
 import {useInteractionState} from '#/components/hooks/useInteractionState'
 
 export interface FABProps
@@ -32,6 +33,7 @@ export function FABInner({testID, icon, onPress, ...props}: FABProps) {
     onOut: onPressOut,
   } = useInteractionState()
   const playHaptic = useHaptics()
+  const isHapticsDisabled = useHapticsDisabled()
 
   const size = isTablet ? styles.sizeLarge : styles.sizeRegular
 
@@ -56,9 +58,12 @@ export function FABInner({testID, icon, onPress, ...props}: FABProps) {
       onPress={e => {
         playHaptic()
 
-        setTimeout(() => {
-          onPress?.(e)
-        }, 75)
+        setTimeout(
+          () => {
+            onPress?.(e)
+          },
+          isHapticsDisabled ? 0 : 75,
+        )
       }}
       onPressIn={onPressIn}
       onPressOut={onPressOut}


### PR DESCRIPTION
## Why

While implementing a fab elsewhere, I realized that it's actually pretty hard to see the FAB animation right now. The fab is decreasing in size, so if your finger is over it you can't see the animation. Twitter's FAB does shrink as well, though to me it's still bizarre, since you can't actually see the animation at all. This PR inverts the animation, so it actually scales outward rather than inward.

I also added a small delay to the opening of the modal itself. There is still a haptic that immediately played so there's immediate feedback, but it gives us the chance to visually see the button shrink back to its original size. This delay does not occur if the user has haptic feedback disabled.

Additionally, I've added a haptic to the FAB (a light haptic though, not the default medium). The haptic gets you "excited to post" I think, though we can remove if we hate it. On device for me, it feels really nice.

The `Light` feedback here felt much better than the default `Medium`, so I updated `useHaptics()` to support passing in the wanted style - `Light`, `Medium`, or `Heavy`. On iOS, this defaults to `Medium`. On Android, it uses `Light` regardless of the passed style.

>  // Users said the medium impact was too strong on Android; see APP-537s

## Test Plan

On-device, you should be able to feel the light haptic once you press the button.



https://github.com/bluesky-social/social-app/assets/153161762/66644445-2caa-4686-b775-9cf5b8bcc009

