### PR TITLE
truncate if display name extends one line in the settings account switcher

### DIFF
--- a/src/view/screens/Settings/index.tsx
+++ b/src/view/screens/Settings/index.tsx
@@ -103,10 +103,10 @@ function SettingsAccountCard({
         />
       </View>
       <View style={[s.flex1]}>
-        <Text type="md-bold" style={pal.text}>
+        <Text type="md-bold" style={pal.text} numberOfLines={1}>
           {profile?.displayName || account.handle}
         </Text>
-        <Text type="sm" style={pal.textLight}>
+        <Text type="sm" style={pal.textLight} numberOfLines={1}>
           {account.handle}
         </Text>
       </View>
@@ -381,7 +381,7 @@ export function SettingsScreen({}: Props) {
             {!currentAccount.emailConfirmed && <EmailConfirmationNotice />}
 
             <View style={[s.flexRow, styles.heading]}>
-              <Text type="xl-bold" style={pal.text}>
+              <Text type="xl-bold" style={pal.text} numberOfLines={1}>
                 <Trans>Signed in as</Trans>
               </Text>
               <View style={s.flex1} />


### PR DESCRIPTION
## Why

This has been bothering me for a bit, since I have a testing alt account that has a long name. Every time I open the settings page I get layout shift once the display name is shown:


https://github.com/bluesky-social/social-app/assets/153161762/cddf5798-1506-4426-8d7b-55140ab70779


Just adding a `numberOfLines={1}` to the `Text` here. No need to add `flex: 1` since the container already has it applied.

## Test Plan

Verify layout doesn't break on web or native.

![Screenshot 2024-05-31 at 3 39 57 PM](https://github.com/bluesky-social/social-app/assets/153161762/b609fbee-51ad-474f-82c9-110950b12f34)
<img width="306" alt="Screenshot 2024-05-31 at 3 40 00 PM" src="https://github.com/bluesky-social/social-app/assets/153161762/1d080f11-29db-48dc-9b0a-206b21f6604b">
