### PR TITLE
Add android on-device translation

### DIFF
--- a/modules/expo-bluesky-translate/android/build.gradle
+++ b/modules/expo-bluesky-translate/android/build.gradle
@@ -1,0 +1,93 @@
+apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
+apply plugin: 'maven-publish'
+
+group = 'expo.modules.blueskytranslate'
+version = '0.5.0'
+
+buildscript {
+  def expoModulesCorePlugin = new File(project(":expo-modules-core").projectDir.absolutePath, "ExpoModulesCorePlugin.gradle")
+  if (expoModulesCorePlugin.exists()) {
+    apply from: expoModulesCorePlugin
+    applyKotlinExpoModulesCorePlugin()
+  }
+
+  // Simple helper that allows the root project to override versions declared by this library.
+  ext.safeExtGet = { prop, fallback ->
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+  }
+
+  // Ensures backward compatibility
+  ext.getKotlinVersion = {
+    if (ext.has("kotlinVersion")) {
+      ext.kotlinVersion()
+    } else {
+      ext.safeExtGet("kotlinVersion", "1.8.10")
+    }
+  }
+
+  repositories {
+    mavenCentral()
+  }
+
+  dependencies {
+    classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${getKotlinVersion()}")
+  }
+}
+
+afterEvaluate {
+  publishing {
+    publications {
+      release(MavenPublication) {
+        from components.release
+      }
+    }
+    repositories {
+      maven {
+        url = mavenLocal().url
+      }
+    }
+  }
+}
+
+android {
+  compileSdkVersion safeExtGet("compileSdkVersion", 33)
+
+  def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
+  if (agpVersion.tokenize('.')[0].toInteger() < 8) {
+    compileOptions {
+      sourceCompatibility JavaVersion.VERSION_11
+      targetCompatibility JavaVersion.VERSION_11
+    }
+
+    kotlinOptions {
+      jvmTarget = JavaVersion.VERSION_11.majorVersion
+    }
+  }
+
+  namespace "expo.modules.blueskytranslate"
+  defaultConfig {
+    minSdkVersion safeExtGet("minSdkVersion", 21)
+    targetSdkVersion safeExtGet("targetSdkVersion", 34)
+    versionCode 1
+    versionName "0.5.0"
+  }
+  lintOptions {
+    abortOnError false
+  }
+  publishing {
+    singleVariant("release") {
+      withSourcesJar()
+    }
+  }
+}
+
+repositories {
+  mavenCentral()
+}
+
+dependencies {
+  implementation project(':expo-modules-core')
+  implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
+  implementation 'com.google.mlkit:translate:17.0.2'
+}

--- a/modules/expo-bluesky-translate/android/src/main/AndroidManifest.xml
+++ b/modules/expo-bluesky-translate/android/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<manifest>
+</manifest>

--- a/modules/expo-bluesky-translate/android/src/main/java/expo/modules/blueskytranslate/ExpoBlueskyTranslateExceptions.kt
+++ b/modules/expo-bluesky-translate/android/src/main/java/expo/modules/blueskytranslate/ExpoBlueskyTranslateExceptions.kt
@@ -1,0 +1,9 @@
+package expo.modules.blueskytranslate
+import expo.modules.kotlin.exception.CodedException
+
+internal class UnableToTranslateTextException :
+    CodedException("Unable to translate text")
+
+
+internal class TranslationInProgressException :
+    CodedException("A translation is already in progress. Please await other translation first.")

--- a/modules/expo-bluesky-translate/android/src/main/java/expo/modules/blueskytranslate/ExpoBlueskyTranslateModule.kt
+++ b/modules/expo-bluesky-translate/android/src/main/java/expo/modules/blueskytranslate/ExpoBlueskyTranslateModule.kt
@@ -1,0 +1,65 @@
+package expo.modules.blueskytranslate
+
+import com.google.mlkit.common.model.DownloadConditions
+import com.google.mlkit.nl.translate.Translation
+import com.google.mlkit.nl.translate.TranslatorOptions
+import expo.modules.kotlin.modules.Module
+import expo.modules.kotlin.modules.ModuleDefinition
+import expo.modules.kotlin.Promise
+
+class ExpoBlueskyTranslateModule : Module() {
+    var translationPromise: Promise? = null
+
+    override fun definition() = ModuleDefinition {
+        Name("ExpoBlueskyTranslate")
+
+        AsyncFunction("translateAsync") { sourceLanguage: String, targetLanguage: String, text: String, promise: Promise ->
+            if (translationPromise != null) {
+                promise.reject(TranslationInProgressException())
+                return@AsyncFunction
+            }
+
+            translationPromise = promise
+
+            val options = TranslatorOptions.Builder()
+                .setSourceLanguage(sourceLanguage)
+                .setTargetLanguage(targetLanguage)
+                .build()
+
+            val translator = Translation.getClient(options)
+
+            val conditions = DownloadConditions.Builder()
+                .requireWifi()
+                .build()
+
+
+            translator.downloadModelIfNeeded(conditions)
+                .addOnSuccessListener {
+                    translator.translate(encodeSpecialCharacters(text))
+                        .addOnSuccessListener { translatedText ->
+                            promise.resolve(decodeSpecialCharacters(translatedText))
+                            translationPromise = null
+                        }
+                        .addOnFailureListener { exception ->
+                            promise.reject(UnableToTranslateTextException())
+                            translationPromise = null
+                        }
+                }
+                .addOnFailureListener { exception ->
+                    promise.reject(UnableToTranslateTextException())
+                    translationPromise = null
+                }
+
+        }
+    }
+
+  private fun encodeSpecialCharacters(text: String): String {
+    return text.replace("\n", "␤")  // Use Unicode character for newline
+      .replace("\t", "␉")  // Use Unicode character for tab
+  }
+
+  private fun decodeSpecialCharacters(text: String): String {
+    return text.replace("␤", "\n")
+      .replace("␉", "\t")
+  }
+}

--- a/modules/expo-bluesky-translate/expo-module.config.json
+++ b/modules/expo-bluesky-translate/expo-module.config.json
@@ -1,6 +1,9 @@
 {
-  "platforms": ["ios"],
+  "platforms": ["ios", "android"],
   "ios": {
     "modules": ["ExpoBlueskyTranslateModule"]
+  }, 
+  "android": {
+    "modules": ["expo.modules.blueskytranslate.ExpoBlueskyTranslateModule"]
   }
 }

--- a/modules/expo-bluesky-translate/index.ts
+++ b/modules/expo-bluesky-translate/index.ts
@@ -1,6 +1,66 @@
+import {Platform} from 'react-native'
+
+import ExpoBlueskyTranslate from './src/ExpoBlueskyTranslate'
+
+// can be something like "17.5.1", so just take the first two parts
+const version = String(Platform.Version).split('.').slice(0, 2).join('.')
+
+export const isAvailableIOS = Number(version) >= 17.4
+export const isAvailableAndroid = true
+
+// https://en.wikipedia.org/wiki/Translate_(Apple)#Languages
+const SUPPORTED_LANGUAGES = [
+  'ar',
+  'zh',
+  'nl',
+  'en',
+  'fr',
+  'de',
+  'id',
+  'it',
+  'ja',
+  'ko',
+  'pl',
+  'pt',
+  'ru',
+  'es',
+  'th',
+  'tr',
+  'uk',
+  'vi',
+]
+
+export function isLanguageSupported(lang?: string) {
+  // If the language is not provided, we assume it is supported
+  if (!lang) return true
+  return SUPPORTED_LANGUAGES.includes(lang)
+}
+
+export const isAvailable = Platform.select({
+  ios: isAvailableIOS,
+  android: isAvailableAndroid,
+})
+
+/**
+ * Translates the given text to the target language.
+ * @param sourceLanguage Source language code (IETF BCP-47 language tag)
+ * @param targetLanguage Target language code (IETF BCP-47 language tag)
+ * @param text Text to translate
+ * @returns Translated text
+ */
+export async function translateAsync(
+  sourceLanguage: string,
+  targetLanguage: string,
+  text: string,
+): Promise<string> {
+  return await ExpoBlueskyTranslate.translateAsync(
+    sourceLanguage,
+    targetLanguage,
+    text,
+  )
+}
+
 export {
-  isAvailable,
-  isLanguageSupported,
   NativeTranslationModule,
   NativeTranslationView,
 } from './src/ExpoBlueskyTranslateView'

--- a/modules/expo-bluesky-translate/index.ts
+++ b/modules/expo-bluesky-translate/index.ts
@@ -11,23 +11,23 @@ export const isAvailableAndroid = true
 // https://en.wikipedia.org/wiki/Translate_(Apple)#Languages
 const SUPPORTED_LANGUAGES = [
   'ar',
-  'zh',
-  'nl',
-  'en',
-  'fr',
   'de',
+  'en',
+  'es',
+  'fr',
   'id',
   'it',
   'ja',
   'ko',
+  'nl',
   'pl',
   'pt',
   'ru',
-  'es',
   'th',
   'tr',
   'uk',
   'vi',
+  'zh',
 ]
 
 export function isLanguageSupported(lang?: string) {

--- a/modules/expo-bluesky-translate/src/ExpoBlueskyTranslate.ts
+++ b/modules/expo-bluesky-translate/src/ExpoBlueskyTranslate.ts
@@ -1,0 +1,3 @@
+import {requireOptionalNativeModule} from 'expo-modules-core'
+
+export default requireOptionalNativeModule('ExpoBlueskyTranslate')

--- a/modules/expo-bluesky-translate/src/ExpoBlueskyTranslate.types.ts
+++ b/modules/expo-bluesky-translate/src/ExpoBlueskyTranslate.types.ts
@@ -1,3 +1,19 @@
 export type ExpoBlueskyTranslateModule = {
+  /**
+   * Translates the given text to the target language and presents it to the user.
+   * @param text Text to translate
+   */
   presentAsync: (text: string) => Promise<void>
+  /**
+   * Translates the given text to the target language.
+   * @param sourceLanguage Source language code (IETF BCP-47 language tag)
+   * @param targetLanguage Target language code (IETF BCP-47 language tag)
+   * @param text Text to translate
+   * @returns Translated text
+   */
+  translateAsync: (
+    sourceLanguage: string,
+    targetLanguage: string,
+    text: string,
+  ) => Promise<string>
 }

--- a/modules/expo-bluesky-translate/src/ExpoBlueskyTranslateView.ios.tsx
+++ b/modules/expo-bluesky-translate/src/ExpoBlueskyTranslateView.ios.tsx
@@ -1,11 +1,9 @@
 import React from 'react'
-import {Platform} from 'react-native'
-import {requireNativeModule, requireNativeViewManager} from 'expo-modules-core'
+import {requireNativeViewManager} from 'expo-modules-core'
 
-import {ExpoBlueskyTranslateModule} from './ExpoBlueskyTranslate.types'
+import ExpoBlueskyTranslate from './ExpoBlueskyTranslate'
 
-export const NativeTranslationModule =
-  requireNativeModule<ExpoBlueskyTranslateModule>('ExpoBlueskyTranslate')
+export const NativeTranslationModule = ExpoBlueskyTranslate
 
 const NativeView: React.ComponentType = requireNativeViewManager(
   'ExpoBlueskyTranslate',
@@ -13,39 +11,4 @@ const NativeView: React.ComponentType = requireNativeViewManager(
 
 export function NativeTranslationView() {
   return <NativeView />
-}
-
-// can be something like "17.5.1", so just take the first two parts
-const version = String(Platform.Version).split('.').slice(0, 2).join('.')
-
-export const isAvailable = Number(version) >= 17.4
-
-// https://en.wikipedia.org/wiki/Translate_(Apple)#Languages
-const SUPPORTED_LANGUAGES = [
-  'ar',
-  'zh',
-  'zh',
-  'nl',
-  'en',
-  'en',
-  'fr',
-  'de',
-  'id',
-  'it',
-  'ja',
-  'ko',
-  'pl',
-  'pt',
-  'ru',
-  'es',
-  'th',
-  'tr',
-  'uk',
-  'vi',
-]
-
-export function isLanguageSupported(lang?: string) {
-  // If the language is not provided, we assume it is supported
-  if (!lang) return true
-  return SUPPORTED_LANGUAGES.includes(lang)
 }

--- a/modules/expo-bluesky-translate/src/ExpoBlueskyTranslateView.tsx
+++ b/modules/expo-bluesky-translate/src/ExpoBlueskyTranslateView.tsx
@@ -1,13 +1,17 @@
-export const NativeTranslationModule = {
+import ExpoBlueskyTranslate from './ExpoBlueskyTranslate'
+import {ExpoBlueskyTranslateModule} from './ExpoBlueskyTranslate.types'
+
+export const NativeTranslationModule: ExpoBlueskyTranslateModule = {
   presentAsync: async (_: string) => {},
+  translateAsync: (sourceLanguage, targetLanguage, text) => {
+    return ExpoBlueskyTranslate.translateAsync(
+      sourceLanguage,
+      targetLanguage,
+      text,
+    )
+  },
 }
 
 export function NativeTranslationView() {
   return null
-}
-
-export const isAvailable = false
-
-export function isLanguageSupported(_lang?: string) {
-  return false
 }

--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -749,14 +749,14 @@ function ExpandedPostDetails({
               isTranslating
                 ? _(msg`Translating...`)
                 : didTranslate
-                ? _(msg`See original`)
+                ? _(msg`Translated by Google`)
                 : _(msg`Translate`)
             }
             onPress={onTranslatePress}>
             {isTranslating
               ? _(msg`Translating...`)
               : didTranslate
-              ? _(msg`See original`)
+              ? _(msg`Translated by Google`)
               : _(msg`Translate`)}
           </Text>
         </>


### PR DESCRIPTION
Builds on top of https://github.com/bluesky-social/social-app/pull/4098

This PR aims to add on-device translation to Android via MLKit's [Translation API](https://developers.google.com/ml-kit/language/translation) to achieve feature parity with iOS. From my testing, Google's 1st party service (translate.google.com) still is the best, but if the aim is to have feature parity on Android, then I think this is a satisfactory solution.

Do note that translation _could_ break rich text formatting (link detection etc) when displaying the translated text, but that may even be expected when translating - the user could revert to the original text at any time if needed.
 
I'm not super familiar with the codebase, so I might have not done everything in the best possible way so bear with me on that, open to any feedback.

Todo: Add better Google attribution (according to their guidelines)

Quick preview:


https://github.com/bluesky-social/social-app/assets/19533289/0767fead-64d0-4481-a330-027f5b9fd02b

