### PR TITLE
add an apk to production build outputs for Obtanium release support

### DIFF
--- a/.github/workflows/build-submit-android.yml
+++ b/.github/workflows/build-submit-android.yml
@@ -120,6 +120,32 @@ jobs:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_CLIENT_ALERT_WEBHOOK }}
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
+      - name: 🏗️ Build Production APK
+        if: ${{ inputs.profile == 'production' }}
+        run: yarn use-build-number-with-bump eas build -p android --profile production-apk --local --output build.apk --non-interactive
+
+      - name: 🚀 Upload Production APK Artifact
+        id: upload-artifact-production-apk
+        if: ${{ inputs.profile == 'production' }}
+        uses: actions/upload-artifact@v4
+        with:
+          retention-days: 30
+          compression-level: 6
+          name: build-${{ steps.timestamp.outputs.time }}.apk
+          path: build.apk
+
+      - name: 🔔 Notify Slack of Production APK Build
+        if: ${{ inputs.profile == 'production' }}
+        uses: slackapi/slack-github-action@v1.25.0
+        with:
+          payload: |
+            {
+              "text": "Android production APK build is ready for download. This is a production build, and you should add it to the GitHub release! Download the artifact here: ${{ steps.upload-artifact-production-apk.outputs.artifact-url }}"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_CLIENT_ALERT_WEBHOOK }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+
       - name: ⬇️ Restore Cache
         id: get-base-commit
         uses: actions/cache@v4

--- a/.github/workflows/build-submit-android.yml
+++ b/.github/workflows/build-submit-android.yml
@@ -2,6 +2,9 @@
 name: Build and Submit Android
 
 on:
+  push:
+    branches:
+      - hailey/android-apk-production
   workflow_dispatch:
     inputs:
       profile:
@@ -63,12 +66,12 @@ jobs:
           echo "EXPO_PUBLIC_BUNDLE_DATE=$(date -u +"%y%m%d%H")" >> .env
           echo "$json" > google-services.json
 
-      - name: 🏗️ EAS Build
-        run: yarn use-build-number-with-bump eas build -p android --profile ${{ inputs.profile || 'testflight-android' }} --local --output build.aab --non-interactive
-
-      - name: ✍️ Rename Testflight bundle
-        if: ${{ inputs.profile != 'production' }}
-        run: mv build.aab build.apk
+#      - name: 🏗️ EAS Build
+#        run: yarn use-build-number-with-bump eas build -p android --profile ${{ inputs.profile || 'testflight-android' }} --local --output build.aab --non-interactive
+#
+#      - name: ✍️ Rename Testflight bundle
+#        if: ${{ inputs.profile != 'production' }}
+#        run: mv build.aab build.apk
 
       - name: ⏰ Get a timestamp
         id: timestamp
@@ -76,57 +79,57 @@ jobs:
         with:
           format: 'MM-DD-HH-mm-ss'
 
-      - name: 🚀 Upload Production Artifact
-        id: upload-artifact-production
-        if: ${{ inputs.profile == 'production' }}
-        uses: actions/upload-artifact@v4
-        with:
-          retention-days: 30
-          compression-level: 6
-          name: build-${{ steps.timestamp.outputs.time }}.aab
-          path: build.aab
+#      - name: 🚀 Upload Production Artifact
+#        id: upload-artifact-production
+#        if: ${{ inputs.profile == 'production' }}
+#        uses: actions/upload-artifact@v4
+#        with:
+#          retention-days: 30
+#          compression-level: 6
+#          name: build-${{ steps.timestamp.outputs.time }}.aab
+#          path: build.aab
+#
+#      - name: 🚀 Upload Testflight Artifact
+#        id: upload-artifact-testflight
+#        if: ${{ inputs.profile != 'production' }}
+#        uses: actions/upload-artifact@v4
+#        with:
+#          retention-days: 30
+#          compression-level: 6
+#          name: build-${{ steps.timestamp.outputs.time }}.apk
+#          path: build.apk
 
-      - name: 🚀 Upload Testflight Artifact
-        id: upload-artifact-testflight
-        if: ${{ inputs.profile != 'production' }}
-        uses: actions/upload-artifact@v4
-        with:
-          retention-days: 30
-          compression-level: 6
-          name: build-${{ steps.timestamp.outputs.time }}.apk
-          path: build.apk
-
-      - name: 🔔 Notify Slack of Production Build
-        if: ${{ inputs.profile == 'production' }}
-        uses: slackapi/slack-github-action@v1.25.0
-        with:
-          payload: |
-            {
-              "text": "Android build is ready for submission. This is a production build! Download the artifact here: ${{ steps.upload-artifact-production.outputs.artifact-url }}"
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_CLIENT_ALERT_WEBHOOK }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
-
-      - name: 🔔 Notify Slack of Testflight Build
-        if: ${{ inputs.profile != 'production' }}
-        uses: slackapi/slack-github-action@v1.25.0
-        with:
-          payload: |
-            {
-              "text": "Android build is ready for testing. Download the artifact here: ${{ steps.upload-artifact-testflight.outputs.artifact-url }}"
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_CLIENT_ALERT_WEBHOOK }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+#      - name: 🔔 Notify Slack of Production Build
+#        if: ${{ inputs.profile == 'production' }}
+#        uses: slackapi/slack-github-action@v1.25.0
+#        with:
+#          payload: |
+#            {
+#              "text": "Android build is ready for submission. This is a production build! Download the artifact here: ${{ steps.upload-artifact-production.outputs.artifact-url }}"
+#            }
+#        env:
+#          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_CLIENT_ALERT_WEBHOOK }}
+#          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+#
+#      - name: 🔔 Notify Slack of Testflight Build
+#        if: ${{ inputs.profile != 'production' }}
+#        uses: slackapi/slack-github-action@v1.25.0
+#        with:
+#          payload: |
+#            {
+#              "text": "Android build is ready for testing. Download the artifact here: ${{ steps.upload-artifact-testflight.outputs.artifact-url }}"
+#            }
+#        env:
+#          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_CLIENT_ALERT_WEBHOOK }}
+#          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
       - name: 🏗️ Build Production APK
-        if: ${{ inputs.profile == 'production' }}
+#        if: ${{ inputs.profile == 'production' }}
         run: yarn use-build-number-with-bump eas build -p android --profile production-apk --local --output build.apk --non-interactive
 
       - name: 🚀 Upload Production APK Artifact
         id: upload-artifact-production-apk
-        if: ${{ inputs.profile == 'production' }}
+#        if: ${{ inputs.profile == 'production' }}
         uses: actions/upload-artifact@v4
         with:
           retention-days: 30
@@ -135,7 +138,7 @@ jobs:
           path: build.apk
 
       - name: 🔔 Notify Slack of Production APK Build
-        if: ${{ inputs.profile == 'production' }}
+#        if: ${{ inputs.profile == 'production' }}
         uses: slackapi/slack-github-action@v1.25.0
         with:
           payload: |

--- a/.github/workflows/build-submit-android.yml
+++ b/.github/workflows/build-submit-android.yml
@@ -2,9 +2,6 @@
 name: Build and Submit Android
 
 on:
-  push:
-    branches:
-      - hailey/android-apk-production
   workflow_dispatch:
     inputs:
       profile:
@@ -66,12 +63,12 @@ jobs:
           echo "EXPO_PUBLIC_BUNDLE_DATE=$(date -u +"%y%m%d%H")" >> .env
           echo "$json" > google-services.json
 
-#      - name: 🏗️ EAS Build
-#        run: yarn use-build-number-with-bump eas build -p android --profile ${{ inputs.profile || 'testflight-android' }} --local --output build.aab --non-interactive
-#
-#      - name: ✍️ Rename Testflight bundle
-#        if: ${{ inputs.profile != 'production' }}
-#        run: mv build.aab build.apk
+      - name: 🏗️ EAS Build
+        run: yarn use-build-number-with-bump eas build -p android --profile ${{ inputs.profile || 'testflight-android' }} --local --output build.aab --non-interactive
+
+      - name: ✍️ Rename Testflight bundle
+        if: ${{ inputs.profile != 'production' }}
+        run: mv build.aab build.apk
 
       - name: ⏰ Get a timestamp
         id: timestamp
@@ -79,57 +76,57 @@ jobs:
         with:
           format: 'MM-DD-HH-mm-ss'
 
-#      - name: 🚀 Upload Production Artifact
-#        id: upload-artifact-production
-#        if: ${{ inputs.profile == 'production' }}
-#        uses: actions/upload-artifact@v4
-#        with:
-#          retention-days: 30
-#          compression-level: 6
-#          name: build-${{ steps.timestamp.outputs.time }}.aab
-#          path: build.aab
-#
-#      - name: 🚀 Upload Testflight Artifact
-#        id: upload-artifact-testflight
-#        if: ${{ inputs.profile != 'production' }}
-#        uses: actions/upload-artifact@v4
-#        with:
-#          retention-days: 30
-#          compression-level: 6
-#          name: build-${{ steps.timestamp.outputs.time }}.apk
-#          path: build.apk
+      - name: 🚀 Upload Production Artifact
+        id: upload-artifact-production
+        if: ${{ inputs.profile == 'production' }}
+        uses: actions/upload-artifact@v4
+        with:
+          retention-days: 30
+          compression-level: 6
+          name: build-${{ steps.timestamp.outputs.time }}.aab
+          path: build.aab
 
-#      - name: 🔔 Notify Slack of Production Build
-#        if: ${{ inputs.profile == 'production' }}
-#        uses: slackapi/slack-github-action@v1.25.0
-#        with:
-#          payload: |
-#            {
-#              "text": "Android build is ready for submission. This is a production build! Download the artifact here: ${{ steps.upload-artifact-production.outputs.artifact-url }}"
-#            }
-#        env:
-#          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_CLIENT_ALERT_WEBHOOK }}
-#          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
-#
-#      - name: 🔔 Notify Slack of Testflight Build
-#        if: ${{ inputs.profile != 'production' }}
-#        uses: slackapi/slack-github-action@v1.25.0
-#        with:
-#          payload: |
-#            {
-#              "text": "Android build is ready for testing. Download the artifact here: ${{ steps.upload-artifact-testflight.outputs.artifact-url }}"
-#            }
-#        env:
-#          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_CLIENT_ALERT_WEBHOOK }}
-#          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+      - name: 🚀 Upload Testflight Artifact
+        id: upload-artifact-testflight
+        if: ${{ inputs.profile != 'production' }}
+        uses: actions/upload-artifact@v4
+        with:
+          retention-days: 30
+          compression-level: 6
+          name: build-${{ steps.timestamp.outputs.time }}.apk
+          path: build.apk
+
+      - name: 🔔 Notify Slack of Production Build
+        if: ${{ inputs.profile == 'production' }}
+        uses: slackapi/slack-github-action@v1.25.0
+        with:
+          payload: |
+            {
+              "text": "Android build is ready for submission. This is a production build! Download the artifact here: ${{ steps.upload-artifact-production.outputs.artifact-url }}"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_CLIENT_ALERT_WEBHOOK }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+
+      - name: 🔔 Notify Slack of Testflight Build
+        if: ${{ inputs.profile != 'production' }}
+        uses: slackapi/slack-github-action@v1.25.0
+        with:
+          payload: |
+            {
+              "text": "Android build is ready for testing. Download the artifact here: ${{ steps.upload-artifact-testflight.outputs.artifact-url }}"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_CLIENT_ALERT_WEBHOOK }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
 
       - name: 🏗️ Build Production APK
-#        if: ${{ inputs.profile == 'production' }}
+        if: ${{ inputs.profile == 'production' }}
         run: yarn use-build-number-with-bump eas build -p android --profile production-apk --local --output build.apk --non-interactive
 
       - name: 🚀 Upload Production APK Artifact
         id: upload-artifact-production-apk
-#        if: ${{ inputs.profile == 'production' }}
+        if: ${{ inputs.profile == 'production' }}
         uses: actions/upload-artifact@v4
         with:
           retention-days: 30
@@ -138,7 +135,7 @@ jobs:
           path: build.apk
 
       - name: 🔔 Notify Slack of Production APK Build
-#        if: ${{ inputs.profile == 'production' }}
+        if: ${{ inputs.profile == 'production' }}
         uses: slackapi/slack-github-action@v1.25.0
         with:
           payload: |

--- a/eas.json
+++ b/eas.json
@@ -46,6 +46,20 @@
         "EXPO_PUBLIC_ENV": "production"
       }
     },
+    "production-apk": {
+      "extends": "base",
+      "distribution": "internal",
+      "ios": {
+        "autoIncrement": false
+      },
+      "android": {
+        "autoIncrement": false
+      },
+      "channel": "production",
+      "env": {
+        "EXPO_PUBLIC_ENV": "production"
+      }
+    },
     "testflight": {
       "extends": "base",
       "ios": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bsky.app",
-  "version": "1.84.0",
+  "version": "1.85.0",
   "private": true,
   "engines": {
     "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bsky.app",
-  "version": "1.85.0",
+  "version": "1.84.0",
   "private": true,
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
## Why

https://github.com/bluesky-social/social-app/issues/898
Fixes https://github.com/bluesky-social/social-app/issues/2222

There are a lot of users who either cannot or prefer not to use the Google Play store for downloading apps. It appears that Obtanium allows users to keep their apps up-to-date based on GitHub releases, as long as we provide an APK for them to use inside of that release.

We can create another step in the workflow that produces an APK rather than an AAB but with all the production environment variables:

- Still includes Firebase credentials for notifications
- Uses the `production` channel for OTA updates
- Uses the AAB's bundle version

This can be ran _after_ the production AAB build completes and notifies Slack, since we don't want to slow down the process of getting the builds ready to submit to the Play Store. This just means the APK release will land on Slack about 20 minutes after the AAB build does.

## Test Plan

~~Running a test build now in this PR. Can add it to the existing GitHub 1.84.0 release to see if Obtanium does indeed pick it up and let users download it.~~

Tested this and it works!

![Screenshot_20240601_140629](https://github.com/bluesky-social/social-app/assets/153161762/919edd7b-532c-4da3-b1af-bca799701bb7)
