### PR TITLE
Fix filtering uris of fetchSubjects for notifications list

### DIFF
--- a/src/state/queries/notifications/util.ts
+++ b/src/state/queries/notifications/util.ts
@@ -145,7 +145,7 @@ async function fetchSubjects(
 ): Promise<Map<string, AppBskyFeedDefs.PostView>> {
   const uris = new Set<string>()
   for (const notif of groupedNotifs) {
-    if (notif.subjectUri && !notif.subjectUri.includes('feed.generator')) {
+    if (notif.subjectUri?.includes('app.bsky.feed.post')) {
       uris.add(notif.subjectUri)
     }
   }


### PR DESCRIPTION
On the “Notifications” page,  there was a problem in handling uris filtering to get the details of posts, so I fixed it.

Repost and Like operations can also be performed on Records other than `app.bsky.feed.post` (e.g. `app.bsky.actor.profile/self`).  When someone performs a like or repost operation on those my Records, it seems to be included in my `listNotifications` response. (I don't know if this behavior of the current appview is correct.)
Anyway, the results of the `listNotifications` are grouped and the `subjectUri` is collected in `fetchSubjects` and passed to `app.bsky.feed.getPosts`, but only those containing `feed.generator` were excluded from `uris`. 

However, if `app.bsky.actor.profile`, such as the one described above, is included, `getPosts` returns an error, and the notification page is not displayed correctly.
Fixed to collect only those that contain `app.bsky.feed.post`, which are correctly handled.

see also: https://bsky.app/profile/ioriayane.relog.tech/post/3ktuwhycioc2y