### PR TITLE
Prevent rich-formatting paste

### DIFF
--- a/src/view/com/composer/text-input/TextInput.web.tsx
+++ b/src/view/com/composer/text-input/TextInput.web.tsx
@@ -156,12 +156,13 @@ export const TextInput = React.forwardRef(function TextInputImpl(
           if (clipboardData) {
             if (clipboardData.types.includes('text/html')) {
               // Rich-text formatting is pasted, try retrieving plain text
-              event.preventDefault()
-
               const text = clipboardData.getData('text/plain')
 
-              // `pasteText` will invoke this handler again, but `clipboardData` will be empty.
+              // `pasteText` will invoke this handler again, but `clipboardData` will be null.
               view.pasteText(text)
+
+              // Return `true` to prevent ProseMirror's default paste behavior.
+              return true
             } else {
               // Otherwise, try retrieving images from the clipboard
 


### PR DESCRIPTION
Fixes https://github.com/bluesky-social/social-app/issues/1321
Fixes https://github.com/bluesky-social/social-app/issues/3032
Fixes https://github.com/bluesky-social/social-app/issues/4301

We don't actually support rich WYSIWYG formatting in the composer, check if what's being pasted is one, and retrieve a plain-text version of it. This won't interfere with pasting HTML files (even though that's not supported either) as pasted files only have `Files` in the types array.