### PR TITLE
hide top border for mentions and replies in notifications tab

### DIFF
--- a/src/view/com/notifications/FeedItem.tsx
+++ b/src/view/com/notifications/FeedItem.tsx
@@ -148,6 +148,7 @@ let FeedItem = ({
                   borderColor: pal.colors.unreadNotifBorder,
                 }
           }
+          hideTopBorder={hideTopBorder}
         />
       </Link>
     )

--- a/src/view/com/post/Post.tsx
+++ b/src/view/com/post/Post.tsx
@@ -41,10 +41,12 @@ import hairlineWidth = StyleSheet.hairlineWidth
 export function Post({
   post,
   showReplyLine,
+  hideTopBorder,
   style,
 }: {
   post: AppBskyFeedDefs.PostView
   showReplyLine?: boolean
+  hideTopBorder?: boolean
   style?: StyleProp<ViewStyle>
 }) {
   const moderationOpts = useModerationOpts()
@@ -82,6 +84,7 @@ export function Post({
         richText={richText}
         moderation={moderation}
         showReplyLine={showReplyLine}
+        hideTopBorder={hideTopBorder}
         style={style}
       />
     )
@@ -95,6 +98,7 @@ function PostInner({
   richText,
   moderation,
   showReplyLine,
+  hideTopBorder,
   style,
 }: {
   post: Shadow<AppBskyFeedDefs.PostView>
@@ -102,6 +106,7 @@ function PostInner({
   richText: RichTextAPI
   moderation: ModerationDecision
   showReplyLine?: boolean
+  hideTopBorder?: boolean
   style?: StyleProp<ViewStyle>
 }) {
   const queryClient = useQueryClient()
@@ -143,7 +148,12 @@ function PostInner({
   return (
     <Link
       href={itemHref}
-      style={[styles.outer, pal.border, style]}
+      style={[
+        styles.outer,
+        pal.border,
+        !hideTopBorder && {borderTopWidth: hairlineWidth},
+        style,
+      ]}
       onBeforePress={onBeforePress}>
       {showReplyLine && <View style={styles.replyLine} />}
       <View style={styles.layout}>
@@ -243,7 +253,6 @@ const styles = StyleSheet.create({
     paddingRight: 15,
     paddingBottom: 5,
     paddingLeft: 10,
-    borderTopWidth: hairlineWidth,
     // @ts-ignore web only -prf
     cursor: 'pointer',
   },


### PR DESCRIPTION
## Why

Missed one of these top borders when we moved to hairline widths. Likes, feegens, and reposts already hid the border, but we didn't add it to `Post`, which handles mentions, replies, and quotes.

## Test Plan

Check the notifications tab with a mention, reply, or quote as your top-most notification. There should no longer be a top border.

### Before and after

https://github.com/bluesky-social/social-app/assets/153161762/c5b112e9-3368-4fb6-ae93-584cdbed5960

