### PR TITLE
fix top border width for user list updates

### DIFF
--- a/src/view/com/modals/UserAddRemoveLists.tsx
+++ b/src/view/com/modals/UserAddRemoveLists.tsx
@@ -30,7 +30,6 @@ import {Text} from '../util/text/Text'
 import * as Toast from '../util/Toast'
 import {UserAvatar} from '../util/UserAvatar'
 import hairlineWidth = StyleSheet.hairlineWidth
-import {ViewHeader} from 'view/com/util/ViewHeader'
 
 export const snapPoints = ['fullscreen']
 
@@ -69,10 +68,20 @@ export function Component({
 
   return (
     <View testID="userAddRemoveListsModal" style={s.hContentRegion}>
-      <ViewHeader
-        title={_(msg`Update ${displayName} in Lists`)}
-        showBackButton={false}
-      />
+      <Text
+        style={[
+          {
+            textAlign: 'center',
+            fontWeight: 'bold',
+            fontSize: 20,
+            marginBottom: 12,
+            paddingHorizontal: 12,
+          },
+          pal.text,
+        ]}
+        numberOfLines={1}>
+        <Trans>Update {displayName} in Lists</Trans>
+      </Text>
       <MyLists
         filter="all"
         inline

--- a/src/view/com/modals/UserAddRemoveLists.tsx
+++ b/src/view/com/modals/UserAddRemoveLists.tsx
@@ -6,28 +6,31 @@ import {
   View,
 } from 'react-native'
 import {AppBskyGraphDefs as GraphDefs} from '@atproto/api'
-import {Text} from '../util/text/Text'
-import {UserAvatar} from '../util/UserAvatar'
-import {MyLists} from '../lists/MyLists'
-import {Button} from '../util/forms/Button'
-import * as Toast from '../util/Toast'
-import {sanitizeDisplayName} from 'lib/strings/display-names'
-import {sanitizeHandle} from 'lib/strings/handles'
-import {s} from 'lib/styles'
-import {usePalette} from 'lib/hooks/usePalette'
-import {isWeb, isAndroid, isMobileWeb} from 'platform/detection'
-import {Trans, msg} from '@lingui/macro'
+import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
+
+import {cleanError} from '#/lib/strings/errors'
 import {useModalControls} from '#/state/modals'
 import {
-  useDangerousListMembershipsQuery,
   getMembership,
   ListMembersip,
+  useDangerousListMembershipsQuery,
   useListMembershipAddMutation,
   useListMembershipRemoveMutation,
 } from '#/state/queries/list-memberships'
-import {cleanError} from '#/lib/strings/errors'
 import {useSession} from '#/state/session'
+import {usePalette} from 'lib/hooks/usePalette'
+import {sanitizeDisplayName} from 'lib/strings/display-names'
+import {sanitizeHandle} from 'lib/strings/handles'
+import {s} from 'lib/styles'
+import {isAndroid, isMobileWeb, isWeb} from 'platform/detection'
+import {MyLists} from '../lists/MyLists'
+import {Button} from '../util/forms/Button'
+import {Text} from '../util/text/Text'
+import * as Toast from '../util/Toast'
+import {UserAvatar} from '../util/UserAvatar'
+import hairlineWidth = StyleSheet.hairlineWidth
+import {ViewHeader} from 'view/com/util/ViewHeader'
 
 export const snapPoints = ['fullscreen']
 
@@ -61,14 +64,15 @@ export function Component({
       return [pal.border, {height: screenHeight / 1.5}]
     }
 
-    return [pal.border, {flex: 1, borderTopWidth: 1}]
+    return [pal.border, {flex: 1, borderTopWidth: hairlineWidth}]
   }, [pal.border, screenHeight])
 
   return (
     <View testID="userAddRemoveListsModal" style={s.hContentRegion}>
-      <Text style={[styles.title, pal.text]}>
-        <Trans>Update {displayName} in Lists</Trans>
-      </Text>
+      <ViewHeader
+        title={_(msg`Update ${displayName} in Lists`)}
+        showBackButton={false}
+      />
       <MyLists
         filter="all"
         inline
@@ -175,9 +179,7 @@ function ListItem({
       style={[
         styles.listItem,
         pal.border,
-        {
-          borderTopWidth: index === 0 ? 0 : 1,
-        },
+        index !== 0 && {borderTopWidth: hairlineWidth},
       ]}>
       <View style={styles.listItemAvi}>
         <UserAvatar size={40} avatar={list.avatar} type="list" />
@@ -228,12 +230,6 @@ function ListItem({
 const styles = StyleSheet.create({
   container: {
     paddingHorizontal: isWeb ? 0 : 16,
-  },
-  title: {
-    textAlign: 'center',
-    fontWeight: 'bold',
-    fontSize: 24,
-    marginBottom: 12,
   },
   btns: {
     position: 'relative',

--- a/src/view/com/modals/UserAddRemoveLists.tsx
+++ b/src/view/com/modals/UserAddRemoveLists.tsx
@@ -248,7 +248,7 @@ const styles = StyleSheet.create({
     gap: 10,
     paddingTop: 10,
     paddingBottom: isAndroid ? 10 : 0,
-    borderTopWidth: 1,
+    borderTopWidth: hairlineWidth,
   },
   footerBtn: {
     paddingHorizontal: 24,


### PR DESCRIPTION
## Why

While reviewing https://github.com/bluesky-social/social-app/pull/4315, I noticed a couple of existing nits to clean up:

- Still using some `borderTopWidth: 1` instead of `hairline` in the add/remove users to list screen
- Title was hitting the side of the screen and could take up multiple lines
- Border above the `Done` button was also using `1` instead of `hairline`.

### Before

<img width="559" alt="Screenshot 2024-06-03 at 4 08 32 PM" src="https://github.com/bluesky-social/social-app/assets/153161762/31047fca-0c76-48ec-88fe-368f079d170c">


### After

See Below

![Screenshot 2024-06-03 at 4 17 23 PM](https://github.com/bluesky-social/social-app/assets/153161762/0d71f292-a53a-4d11-840e-19438de53cbb)
