### PR TITLE
[🐴] allow nested quotes in DMs

### DIFF
--- a/src/components/dms/MessageItemEmbed.tsx
+++ b/src/components/dms/MessageItemEmbed.tsx
@@ -14,7 +14,7 @@ let MessageItemEmbed = ({
 
   return (
     <View style={[a.my_xs, t.atoms.bg, native({flexBasis: 0})]}>
-      <PostEmbeds embed={embed} />
+      <PostEmbeds embed={embed} allowNestedQuotes />
     </View>
   )
 }

--- a/src/view/com/util/post-embeds/QuoteEmbed.tsx
+++ b/src/view/com/util/post-embeds/QuoteEmbed.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import {
   StyleProp,
   StyleSheet,
-  TextStyle,
   TouchableOpacity,
   View,
   ViewStyle,
@@ -32,7 +31,7 @@ import {InfoCircleIcon} from 'lib/icons'
 import {makeProfileLink} from 'lib/routes/links'
 import {precacheProfile} from 'state/queries/profile'
 import {ComposerOptsQuote} from 'state/shell/composer'
-import {atoms as a, flatten} from '#/alf'
+import {atoms as a} from '#/alf'
 import {RichText} from '#/components/RichText'
 import {ContentHider} from '../../../../components/moderation/ContentHider'
 import {PostAlerts} from '../../../../components/moderation/PostAlerts'
@@ -46,12 +45,12 @@ export function MaybeQuoteEmbed({
   embed,
   onOpen,
   style,
-  textStyle,
+  allowNestedQuotes,
 }: {
   embed: AppBskyEmbedRecord.View
   onOpen?: () => void
   style?: StyleProp<ViewStyle>
-  textStyle?: StyleProp<TextStyle>
+  allowNestedQuotes?: boolean
 }) {
   const pal = usePalette('default')
   if (
@@ -65,7 +64,7 @@ export function MaybeQuoteEmbed({
         postRecord={embed.record.value}
         onOpen={onOpen}
         style={style}
-        textStyle={textStyle}
+        allowNestedQuotes={allowNestedQuotes}
       />
     )
   } else if (AppBskyEmbedRecord.isViewBlocked(embed.record)) {
@@ -95,13 +94,13 @@ function QuoteEmbedModerated({
   postRecord,
   onOpen,
   style,
-  textStyle,
+  allowNestedQuotes,
 }: {
   viewRecord: AppBskyEmbedRecord.ViewRecord
   postRecord: AppBskyFeedPost.Record
   onOpen?: () => void
   style?: StyleProp<ViewStyle>
-  textStyle?: StyleProp<TextStyle>
+  allowNestedQuotes?: boolean
 }) {
   const moderationOpts = useModerationOpts()
   const moderation = React.useMemo(() => {
@@ -126,7 +125,7 @@ function QuoteEmbedModerated({
       moderation={moderation}
       onOpen={onOpen}
       style={style}
-      textStyle={textStyle}
+      allowNestedQuotes={allowNestedQuotes}
     />
   )
 }
@@ -136,13 +135,13 @@ export function QuoteEmbed({
   moderation,
   onOpen,
   style,
-  textStyle,
+  allowNestedQuotes,
 }: {
   quote: ComposerOptsQuote
   moderation?: ModerationDecision
   onOpen?: () => void
   style?: StyleProp<ViewStyle>
-  textStyle?: StyleProp<TextStyle>
+  allowNestedQuotes?: boolean
 }) {
   const queryClient = useQueryClient()
   const pal = usePalette('default')
@@ -161,16 +160,20 @@ export function QuoteEmbed({
   const embed = React.useMemo(() => {
     const e = quote.embeds?.[0]
 
-    if (AppBskyEmbedImages.isView(e) || AppBskyEmbedExternal.isView(e)) {
+    if (allowNestedQuotes) {
       return e
-    } else if (
-      AppBskyEmbedRecordWithMedia.isView(e) &&
-      (AppBskyEmbedImages.isView(e.media) ||
-        AppBskyEmbedExternal.isView(e.media))
-    ) {
-      return e.media
+    } else {
+      if (AppBskyEmbedImages.isView(e) || AppBskyEmbedExternal.isView(e)) {
+        return e
+      } else if (
+        AppBskyEmbedRecordWithMedia.isView(e) &&
+        (AppBskyEmbedImages.isView(e.media) ||
+          AppBskyEmbedExternal.isView(e.media))
+      ) {
+        return e.media
+      }
     }
-  }, [quote.embeds])
+  }, [quote.embeds, allowNestedQuotes])
 
   const onBeforePress = React.useCallback(() => {
     precacheProfile(queryClient, quote.author)
@@ -201,7 +204,7 @@ export function QuoteEmbed({
         {richText ? (
           <RichText
             value={richText}
-            style={[a.text_md, flatten(textStyle)]}
+            style={a.text_md}
             numberOfLines={20}
             disableLinks
           />

--- a/src/view/com/util/post-embeds/index.tsx
+++ b/src/view/com/util/post-embeds/index.tsx
@@ -4,7 +4,6 @@ import {
   StyleProp,
   StyleSheet,
   Text,
-  TextStyle,
   View,
   ViewStyle,
 } from 'react-native'
@@ -42,13 +41,13 @@ export function PostEmbeds({
   moderation,
   onOpen,
   style,
-  quoteTextStyle,
+  allowNestedQuotes,
 }: {
   embed?: Embed
   moderation?: ModerationDecision
   onOpen?: () => void
   style?: StyleProp<ViewStyle>
-  quoteTextStyle?: StyleProp<TextStyle>
+  allowNestedQuotes?: boolean
 }) {
   const pal = usePalette('default')
   const {openLightbox} = useLightboxControls()
@@ -63,11 +62,7 @@ export function PostEmbeds({
           moderation={moderation}
           onOpen={onOpen}
         />
-        <MaybeQuoteEmbed
-          embed={embed.record}
-          onOpen={onOpen}
-          textStyle={quoteTextStyle}
-        />
+        <MaybeQuoteEmbed embed={embed.record} onOpen={onOpen} />
       </View>
     )
   }
@@ -98,8 +93,8 @@ export function PostEmbeds({
       <MaybeQuoteEmbed
         embed={embed}
         style={style}
-        textStyle={quoteTextStyle}
         onOpen={onOpen}
+        allowNestedQuotes={allowNestedQuotes}
       />
     )
   }


### PR DESCRIPTION
Since we were using the `PostEmbeds` component, we lost the ability to see quoted content of quote posts. This adds a prop which stops the component from showing nested quotes

Also removes unused text style prop