### PR TITLE
Don't show profile labels until loaded

### DIFF
--- a/src/screens/Profile/Header/Shell.tsx
+++ b/src/screens/Profile/Header/Shell.tsx
@@ -81,15 +81,17 @@ let ProfileHeaderShell = ({
 
       {children}
 
-      <View
-        style={[a.px_lg, a.pb_sm]}
-        pointerEvents={isIOS ? 'auto' : 'box-none'}>
-        {isMe ? (
-          <LabelsOnMe details={{did: profile.did}} labels={profile.labels} />
-        ) : (
-          <ProfileHeaderAlerts moderation={moderation} />
-        )}
-      </View>
+      {!isPlaceholderProfile && (
+        <View
+          style={[a.px_lg, a.pb_sm]}
+          pointerEvents={isIOS ? 'auto' : 'box-none'}>
+          {isMe ? (
+            <LabelsOnMe details={{did: profile.did}} labels={profile.labels} />
+          ) : (
+            <ProfileHeaderAlerts moderation={moderation} />
+          )}
+        </View>
+      )}
 
       {!isDesktop && !hideBackButton && (
         <TouchableWithoutFeedback


### PR DESCRIPTION
Fixes the loading sequence to avoid shifting layout.

After this change, labels are only displayed when the stuff above them is also ready.

[Review sans whitespace](https://github.com/bluesky-social/social-app/pull/4357/files?w=1)

## Before

https://github.com/bluesky-social/social-app/assets/810438/807fde7c-89a4-4ee5-a8f7-d0a0a1d88c70

## After

https://github.com/bluesky-social/social-app/assets/810438/a4e116af-c18b-45d3-b647-4f4b89c89001

