### PR TITLE
Report persisted schema validation failures

### DIFF
--- a/src/state/persisted/store.ts
+++ b/src/state/persisted/store.ts
@@ -17,11 +17,13 @@ export async function read(): Promise<Schema | undefined> {
   if (parsed.success) {
     return objData
   } else {
-    const errors = parsed.error.errors.map(e => ({
-      code: e.code,
-      expected: e.expected,
-      path: e.path,
-    }))
+    const errors =
+      parsed.error?.errors?.map(e => ({
+        code: e.code,
+        // @ts-ignore exists on some types
+        expected: e?.expected,
+        path: e.path,
+      })) || []
     logger.error(`persisted store: data failed validation on read`, {errors})
     return undefined
   }

--- a/src/state/persisted/store.ts
+++ b/src/state/persisted/store.ts
@@ -1,7 +1,7 @@
 import AsyncStorage from '@react-native-async-storage/async-storage'
 
-import {Schema, schema} from '#/state/persisted/schema'
 import {logger} from '#/logger'
+import {Schema, schema} from '#/state/persisted/schema'
 
 const BSKY_STORAGE = 'BSKY_STORAGE'
 
@@ -13,8 +13,17 @@ export async function write(value: Schema) {
 export async function read(): Promise<Schema | undefined> {
   const rawData = await AsyncStorage.getItem(BSKY_STORAGE)
   const objData = rawData ? JSON.parse(rawData) : undefined
-  if (schema.safeParse(objData).success) {
+  const parsed = schema.safeParse(objData)
+  if (parsed.success) {
     return objData
+  } else {
+    const errors = parsed.error.errors.map(e => ({
+      code: e.code,
+      expected: e.expected,
+      path: e.path,
+    }))
+    logger.error(`persisted store: data failed validation on read`, {errors})
+    return undefined
   }
 }
 


### PR DESCRIPTION
Just noticed this, and I think this has been overlooked since the beginning, but if this parse fails we silently return `undefined`. No reason we can't report some info around what failed validation.

Here I'm purposefully only including fields that will not include PII. This should give us a better idea of what's wrong, if something ever fails validation