### PR TITLE
Fix: visually indicate when quoted content is labeled

### DIFF
--- a/src/view/com/util/post-embeds/QuoteEmbed.tsx
+++ b/src/view/com/util/post-embeds/QuoteEmbed.tsx
@@ -181,9 +181,11 @@ export function QuoteEmbed({
   }, [queryClient, quote.author, onOpen])
 
   return (
-    <ContentHider modui={moderation?.ui('contentList')}>
+    <ContentHider
+      modui={moderation?.ui('contentList')}
+      style={[styles.container, pal.borderDark, style]}
+      childContainerStyle={[a.pt_sm]}>
       <Link
-        style={[styles.container, pal.borderDark, style]}
         hoverStyle={{borderColor: pal.colors.borderLinkHover}}
         href={itemHref}
         title={itemTitle}


### PR DESCRIPTION
There's been some confusion with the current "blurring" control for quote posts, where it looks like the quoting post is the one labeled. This update fixes that issue by showing the border around the blur control.

(The example below is not actually labeled)

|Before|After|
|-|-|
|![CleanShot 2024-06-04 at 16 59 06@2x](https://github.com/bluesky-social/social-app/assets/1270099/008157ce-38c9-4991-8678-49da2cb5ee43)![CleanShot 2024-06-04 at 16 59 19@2x](https://github.com/bluesky-social/social-app/assets/1270099/b16caa2c-42f4-44e3-8c3a-4d3a40299fec)|![CleanShot 2024-06-04 at 16 56 53@2x](https://github.com/bluesky-social/social-app/assets/1270099/52540c79-5333-43ed-bbac-e75dfe7c7644)![CleanShot 2024-06-04 at 16 58 30@2x](https://github.com/bluesky-social/social-app/assets/1270099/38ee9663-2246-400e-8946-757c5bb154d6)|
