### PR TITLE
Remove `expo-constants`

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,6 @@
     "expo-build-properties": "^0.12.1",
     "expo-camera": "~15.0.9",
     "expo-clipboard": "^6.0.3",
-    "expo-constants": "~16.0.1",
     "expo-dev-client": "^4.0.14",
     "expo-device": "~6.0.2",
     "expo-file-system": "^17.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12083,7 +12083,7 @@ expo-constants@^13.0.2:
     "@expo/config" "~7.0.0"
     uuid "^3.3.2"
 
-expo-constants@~16.0.0, expo-constants@~16.0.1:
+expo-constants@~16.0.0:
   version "16.0.1"
   resolved "https://registry.yarnpkg.com/expo-constants/-/expo-constants-16.0.1.tgz#1285e29c85513c6e88e118289e2baab72596d3f7"
   integrity sha512-s6aTHtglp926EsugWtxN7KnpSsE9FCEjb7CgEjQQ78Gpu4btj4wB+IXot2tlqNwqv+x7xFe5veoPGfJDGF/kVg==


### PR DESCRIPTION
## Why

We're not using this package at all anymore - we moved to using `expo-application` and `expo-device` as recommended in the Expo docs (https://docs.expo.dev/versions/latest/sdk/constants/), so lets rm.

## Test Plan

Shouldn't see a warning anymore in dev client, and should still see version info on the Settings screen.