### PR TITLE
Ability to search posts via profile dropdown

### DIFF
--- a/src/view/com/profile/ProfileMenu.tsx
+++ b/src/view/com/profile/ProfileMenu.tsx
@@ -234,6 +234,24 @@ let ProfileMenu = ({
           {hasSession && (
             <>
               <Menu.Divider />
+
+              {/* This group is seperated so users can use this button on their own account. */}
+              <Menu.Group>
+                <Menu.Item
+                  testID="profileHeaderDropdownSearchPostsBtn"
+                  label={_(msg`Search Posts`)}
+                  onPress={() => {
+                    navigate('Search', {
+                      q: `from:${profile.handle}`,
+                    })
+                  }}>
+                  <Menu.ItemText>
+                    <Trans>Search Posts</Trans>
+                  </Menu.ItemText>
+                  <Menu.ItemIcon icon={MagnifyingGlass} />
+                </Menu.Item>
+              </Menu.Group>
+
               <Menu.Group>
                 {!isSelf && (
                   <>
@@ -332,23 +350,6 @@ let ProfileMenu = ({
               </Menu.Group>
             </>
           )}
-
-          {/* This group is seperated so users can use this button on their own account. */}
-          <Menu.Group>
-            <Menu.Item
-              testID="profileHeaderDropdownSearchPostsBtn"
-              label={_(msg`Search Posts`)}
-              onPress={() => {
-                navigate('Search', {
-                  q: `from:${profile.handle}`,
-                })
-              }}>
-              <Menu.ItemText>
-                <Trans>Search Posts</Trans>
-              </Menu.ItemText>
-              <Menu.ItemIcon icon={MagnifyingGlass} />
-            </Menu.Item>
-          </Menu.Group>
         </Menu.Outer>
       </Menu.Root>
 

--- a/src/view/com/profile/ProfileMenu.tsx
+++ b/src/view/com/profile/ProfileMenu.tsx
@@ -28,6 +28,7 @@ import {useTheme} from '#/alf'
 import {ArrowOutOfBox_Stroke2_Corner0_Rounded as Share} from '#/components/icons/ArrowOutOfBox'
 import {Flag_Stroke2_Corner0_Rounded as Flag} from '#/components/icons/Flag'
 import {ListSparkle_Stroke2_Corner0_Rounded as List} from '#/components/icons/ListSparkle'
+import {MagnifyingGlass2_Stroke2_Corner0_Rounded as MagnifyingGlass} from '#/components/icons/MagnifyingGlass2'
 import {Mute_Stroke2_Corner0_Rounded as Mute} from '#/components/icons/Mute'
 import {PeopleRemove2_Stroke2_Corner0_Rounded as UserMinus} from '#/components/icons/PeopleRemove2'
 import {
@@ -39,6 +40,7 @@ import {SpeakerVolumeFull_Stroke2_Corner0_Rounded as Unmute} from '#/components/
 import * as Menu from '#/components/Menu'
 import * as Prompt from '#/components/Prompt'
 import {ReportDialog, useReportDialogControl} from '#/components/ReportDialog'
+import {navigate} from '#/Navigation'
 
 let ProfileMenu = ({
   profile,
@@ -330,6 +332,23 @@ let ProfileMenu = ({
               </Menu.Group>
             </>
           )}
+
+          {/* This group is seperated so users can use this button on their own account. */}
+          <Menu.Group>
+            <Menu.Item
+              testID="profileHeaderDropdownSearchPostsBtn"
+              label={_(msg`Search Posts`)}
+              onPress={() => {
+                navigate('Search', {
+                  q: `from:${profile.handle}`,
+                })
+              }}>
+              <Menu.ItemText>
+                <Trans>Search Posts</Trans>
+              </Menu.ItemText>
+              <Menu.ItemIcon icon={MagnifyingGlass} />
+            </Menu.Item>
+          </Menu.Group>
         </Menu.Outer>
       </Menu.Root>
 


### PR DESCRIPTION
Description: I've been using search tags to get posts from users, usually finding posts from 6 months ago that are going around in my head. I've found some usernames are long and annoying to type, or I can just never remember them (I cannot for the life of me remember Paul's "pfrazee.com" username [paul ur awesome, I'm just bad at some names]). Usernames have no autocomplete in the search-bar when using search tags. This makes it nice and easy.

You'll notice I've made another "<Menu.Group>", this is because otherwise users can't see the button when viewing their own account, or it's above the divider when logged in (if using the menu.group share is in). It's not visible when logged out because menu.group #2 and #3 are both under an "isSession" condition. I could have added it separately, but it would have made the code slightly harder to read, when there really isn't a use case for showing the button when logged out.

Limitations:
- "Search posts" is not translated.
- I have not tested this on mobile.

<img width="1440" alt="Screenshot 2024-06-05 at 3 46 07 PM" src="https://github.com/bluesky-social/social-app/assets/91714073/91f0652a-1faf-4aa4-933c-02f0cb6cd0de">

https://github.com/bluesky-social/social-app/assets/91714073/08ae003a-5780-4a15-aac3-8b1e5b080194

🦋

Thanks,
Josh