### PR TITLE
add notification count badge mobile web

### DIFF
--- a/src/lib/statsig/gates.ts
+++ b/src/lib/statsig/gates.ts
@@ -3,3 +3,4 @@ export type Gate =
   | 'request_notifications_permission_after_onboarding_v2'
   | 'show_avi_follow_button'
   | 'show_follow_back_label_v2'
+  | 'show_notification_badge_mobile_web'

--- a/src/view/shell/bottom-bar/BottomBarWeb.tsx
+++ b/src/view/shell/bottom-bar/BottomBarWeb.tsx
@@ -115,8 +115,8 @@ export function BottomBarWeb() {
                         width={iconWidth - 1}
                         style={[styles.ctrlIcon, pal.text, styles.messagesIcon]}
                       />
-                      {gate('show_notification_badge_mobile_web') &&
-                        unreadMessageCount.numUnread && (
+                      {unreadMessageCount.count > 0 &&
+                        gate('show_notification_badge_mobile_web') && (
                           <View style={styles.notificationCount}>
                             <Text style={styles.notificationCountLabel}>
                               {unreadMessageCount.numUnread}
@@ -136,8 +136,8 @@ export function BottomBarWeb() {
                         width={iconWidth}
                         style={[styles.ctrlIcon, pal.text, styles.bellIcon]}
                       />
-                      {gate('show_notification_badge_mobile_web') &&
-                        notificationCountStr && (
+                      {notificationCountStr !== '' &&
+                        gate('show_notification_badge_mobile_web') && (
                           <View style={styles.notificationCount}>
                             <Text style={styles.notificationCountLabel}>
                               {notificationCountStr}

--- a/src/view/shell/bottom-bar/BottomBarWeb.tsx
+++ b/src/view/shell/bottom-bar/BottomBarWeb.tsx
@@ -16,6 +16,7 @@ import {s} from '#/lib/styles'
 import {useSession} from '#/state/session'
 import {useLoggedOutViewControls} from '#/state/shell/logged-out'
 import {useCloseAllActiveElements} from '#/state/util'
+import {useGate} from 'lib/statsig/statsig'
 import {useUnreadMessageCount} from 'state/queries/messages/list-converations'
 import {useUnreadNotifications} from 'state/queries/notifications/unread'
 import {Button} from '#/view/com/util/forms/Button'
@@ -48,10 +49,14 @@ export function BottomBarWeb() {
   const {hasSession, currentAccount} = useSession()
   const pal = usePalette('default')
   const safeAreaInsets = useSafeAreaInsets()
+  const gate = useGate()
   const {footerMinimalShellTransform} = useMinimalShellMode()
   const {requestSwitchToAccount} = useLoggedOutViewControls()
   const closeAllActiveElements = useCloseAllActiveElements()
   const iconWidth = 26
+
+  const unreadMessageCount = useUnreadMessageCount()
+  const notificationCountStr = useUnreadNotifications()
 
   const showSignIn = React.useCallback(() => {
     closeAllActiveElements()
@@ -63,9 +68,6 @@ export function BottomBarWeb() {
     requestSwitchToAccount({requestedAccount: 'new'})
     // setShowLoggedOut(true)
   }, [requestSwitchToAccount, closeAllActiveElements])
-
-  const unreadMessageCount = useUnreadMessageCount()
-  const notificationCountStr = useUnreadNotifications()
 
   return (
     <Animated.View
@@ -113,13 +115,14 @@ export function BottomBarWeb() {
                         width={iconWidth - 1}
                         style={[styles.ctrlIcon, pal.text, styles.messagesIcon]}
                       />
-                      {unreadMessageCount.numUnread && (
-                        <View style={[styles.notificationCount]}>
-                          <Text style={styles.notificationCountLabel}>
-                            {unreadMessageCount.numUnread}
-                          </Text>
-                        </View>
-                      )}
+                      {gate('show_notification_badge_mobile_web') &&
+                        unreadMessageCount.numUnread && (
+                          <View style={[styles.notificationCount]}>
+                            <Text style={styles.notificationCountLabel}>
+                              {unreadMessageCount.numUnread}
+                            </Text>
+                          </View>
+                        )}
                     </>
                   )
                 }}
@@ -133,13 +136,14 @@ export function BottomBarWeb() {
                         width={iconWidth}
                         style={[styles.ctrlIcon, pal.text, styles.bellIcon]}
                       />
-                      {notificationCountStr && (
-                        <View style={[styles.notificationCount]}>
-                          <Text style={styles.notificationCountLabel}>
-                            {notificationCountStr}
-                          </Text>
-                        </View>
-                      )}
+                      {gate('show_notification_badge_mobile_web') &&
+                        notificationCountStr && (
+                          <View style={[styles.notificationCount]}>
+                            <Text style={styles.notificationCountLabel}>
+                              {notificationCountStr}
+                            </Text>
+                          </View>
+                        )}
                     </>
                   )
                 }}

--- a/src/view/shell/bottom-bar/BottomBarWeb.tsx
+++ b/src/view/shell/bottom-bar/BottomBarWeb.tsx
@@ -117,7 +117,7 @@ export function BottomBarWeb() {
                       />
                       {gate('show_notification_badge_mobile_web') &&
                         unreadMessageCount.numUnread && (
-                          <View style={[styles.notificationCount]}>
+                          <View style={styles.notificationCount}>
                             <Text style={styles.notificationCountLabel}>
                               {unreadMessageCount.numUnread}
                             </Text>
@@ -138,7 +138,7 @@ export function BottomBarWeb() {
                       />
                       {gate('show_notification_badge_mobile_web') &&
                         notificationCountStr && (
-                          <View style={[styles.notificationCount]}>
+                          <View style={styles.notificationCount}>
                             <Text style={styles.notificationCountLabel}>
                               {notificationCountStr}
                             </Text>

--- a/src/view/shell/bottom-bar/BottomBarWeb.tsx
+++ b/src/view/shell/bottom-bar/BottomBarWeb.tsx
@@ -64,7 +64,7 @@ export function BottomBarWeb() {
     // setShowLoggedOut(true)
   }, [requestSwitchToAccount, closeAllActiveElements])
 
-  const unreadMessageCountStr = useUnreadMessageCount()
+  const unreadMessageCount = useUnreadMessageCount()
   const notificationCountStr = useUnreadNotifications()
 
   return (
@@ -113,10 +113,10 @@ export function BottomBarWeb() {
                         width={iconWidth - 1}
                         style={[styles.ctrlIcon, pal.text, styles.messagesIcon]}
                       />
-                      {unreadMessageCountStr.numUnread && (
+                      {unreadMessageCount.numUnread && (
                         <View style={[styles.notificationCount]}>
                           <Text style={styles.notificationCountLabel}>
-                            {unreadMessageCountStr.numUnread}
+                            {unreadMessageCount.numUnread}
                           </Text>
                         </View>
                       )}

--- a/src/view/shell/bottom-bar/BottomBarWeb.tsx
+++ b/src/view/shell/bottom-bar/BottomBarWeb.tsx
@@ -16,6 +16,8 @@ import {s} from '#/lib/styles'
 import {useSession} from '#/state/session'
 import {useLoggedOutViewControls} from '#/state/shell/logged-out'
 import {useCloseAllActiveElements} from '#/state/util'
+import {useUnreadMessageCount} from 'state/queries/messages/list-converations'
+import {useUnreadNotifications} from 'state/queries/notifications/unread'
 import {Button} from '#/view/com/util/forms/Button'
 import {Text} from '#/view/com/util/text/Text'
 import {Logo} from '#/view/icons/Logo'
@@ -62,6 +64,9 @@ export function BottomBarWeb() {
     // setShowLoggedOut(true)
   }, [requestSwitchToAccount, closeAllActiveElements])
 
+  const unreadMessageCountStr = useUnreadMessageCount()
+  const notificationCountStr = useUnreadNotifications()
+
   return (
     <Animated.View
       style={[
@@ -103,10 +108,19 @@ export function BottomBarWeb() {
                 {({isActive}) => {
                   const Icon = isActive ? MessageFilled : Message
                   return (
-                    <Icon
-                      width={iconWidth - 1}
-                      style={[styles.ctrlIcon, pal.text, styles.messagesIcon]}
-                    />
+                    <>
+                      <Icon
+                        width={iconWidth - 1}
+                        style={[styles.ctrlIcon, pal.text, styles.messagesIcon]}
+                      />
+                      {unreadMessageCountStr.numUnread && (
+                        <View style={[styles.notificationCount]}>
+                          <Text style={styles.notificationCountLabel}>
+                            {unreadMessageCountStr.numUnread}
+                          </Text>
+                        </View>
+                      )}
+                    </>
                   )
                 }}
               </NavItem>
@@ -114,10 +128,19 @@ export function BottomBarWeb() {
                 {({isActive}) => {
                   const Icon = isActive ? BellFilled : Bell
                   return (
-                    <Icon
-                      width={iconWidth}
-                      style={[styles.ctrlIcon, pal.text, styles.bellIcon]}
-                    />
+                    <>
+                      <Icon
+                        width={iconWidth}
+                        style={[styles.ctrlIcon, pal.text, styles.bellIcon]}
+                      />
+                      {notificationCountStr && (
+                        <View style={[styles.notificationCount]}>
+                          <Text style={styles.notificationCountLabel}>
+                            {notificationCountStr}
+                          </Text>
+                        </View>
+                      )}
+                    </>
                   )
                 }}
               </NavItem>


### PR DESCRIPTION
## Why

No count is shown right now on mobile web, so let's add it.

## Test Plan

- Set gate to 100%
- Send yourself a DM. The chats badge should increment and should clear once you open the message
- Like your own post or something from an alt, and the notifications tab badge should appear and clear once you open the tab.