### PR TITLE
add `legacy` to picker for Android

### DIFF
--- a/src/lib/media/picker.shared.ts
+++ b/src/lib/media/picker.shared.ts
@@ -3,8 +3,9 @@ import {
   launchImageLibraryAsync,
   MediaTypeOptions,
 } from 'expo-image-picker'
-import {getDataUriSize} from './util'
+
 import * as Toast from 'view/com/util/Toast'
+import {getDataUriSize} from './util'
 
 export async function openPicker(opts?: ImagePickerOptions) {
   const response = await launchImageLibraryAsync({
@@ -12,6 +13,7 @@ export async function openPicker(opts?: ImagePickerOptions) {
     mediaTypes: MediaTypeOptions.Images,
     quality: 1,
     ...opts,
+    legacy: true,
   })
 
   if (response.assets && response.assets.length > 4) {

--- a/src/screens/Onboarding/StepProfile/index.tsx
+++ b/src/screens/Onboarding/StepProfile/index.tsx
@@ -102,6 +102,7 @@ export function StepProfile() {
         mediaTypes: MediaTypeOptions.Images,
         quality: 1,
         ...opts,
+        legacy: true,
       })
 
       return (response.assets ?? [])


### PR DESCRIPTION
## Why

Missed adding this flag in (big whoops on my part!). Android now _does_ show the `...` by default, but it _only_ allows browsing "Cloud media". The `legacy` flag is required for _local_ content.

## Test Plan

Build the app, see that the `...` also has the `Browse` option in the dropdown.