### PR TITLE
Sort profile feedgens by likes

### DIFF
--- a/src/state/queries/profile-feedgens.ts
+++ b/src/state/queries/profile-feedgens.ts
@@ -30,13 +30,24 @@ export function useProfileFeedgensQuery(
         limit: PAGE_SIZE,
         cursor: pageParam,
       })
-      res.data.feeds = res.data.feeds.sort((a, b) => {
-        return (b.likeCount || 0) - (a.likeCount || 0)
-      })
       return res.data
     },
     initialPageParam: undefined,
     getNextPageParam: lastPage => lastPage.cursor,
     enabled,
+    select: data => {
+      const sorted = data.pages
+        .flatMap(p => p.feeds)
+        .sort((a, b) => {
+          return (b.likeCount || 0) - (a.likeCount || 0)
+        })
+      data.pages = data.pages.map((p, i) => {
+        return {
+          ...p,
+          feeds: sorted.slice(i * PAGE_SIZE, (i + 1) * PAGE_SIZE),
+        }
+      })
+      return data
+    },
   })
 }

--- a/src/state/queries/profile-feedgens.ts
+++ b/src/state/queries/profile-feedgens.ts
@@ -30,7 +30,7 @@ export function useProfileFeedgensQuery(
         limit: PAGE_SIZE,
         cursor: pageParam,
       })
-      res.data.feeds = res.data.feeds.sort((a, b) => {
+      res.data.feeds.sort((a, b) => {
         return (b.likeCount || 0) - (a.likeCount || 0)
       })
       return res.data

--- a/src/state/queries/profile-feedgens.ts
+++ b/src/state/queries/profile-feedgens.ts
@@ -3,7 +3,7 @@ import {InfiniteData, QueryKey, useInfiniteQuery} from '@tanstack/react-query'
 
 import {useAgent} from '#/state/session'
 
-const PAGE_SIZE = 30
+const PAGE_SIZE = 50
 type RQPageParam = string | undefined
 
 // TODO refactor invalidate on mutate?
@@ -29,6 +29,9 @@ export function useProfileFeedgensQuery(
         actor: did,
         limit: PAGE_SIZE,
         cursor: pageParam,
+      })
+      res.data.feeds = res.data.feeds.sort((a, b) => {
+        return (b.likeCount || 0) - (a.likeCount || 0)
       })
       return res.data
     },

--- a/src/state/queries/profile-feedgens.ts
+++ b/src/state/queries/profile-feedgens.ts
@@ -30,24 +30,13 @@ export function useProfileFeedgensQuery(
         limit: PAGE_SIZE,
         cursor: pageParam,
       })
+      res.data.feeds = res.data.feeds.sort((a, b) => {
+        return (b.likeCount || 0) - (a.likeCount || 0)
+      })
       return res.data
     },
     initialPageParam: undefined,
     getNextPageParam: lastPage => lastPage.cursor,
     enabled,
-    select: data => {
-      const sorted = data.pages
-        .flatMap(p => p.feeds)
-        .sort((a, b) => {
-          return (b.likeCount || 0) - (a.likeCount || 0)
-        })
-      data.pages = data.pages.map((p, i) => {
-        return {
-          ...p,
-          feeds: sorted.slice(i * PAGE_SIZE, (i + 1) * PAGE_SIZE),
-        }
-      })
-      return data
-    },
   })
 }


### PR DESCRIPTION
Sorts _each page_ of profile feedgens by likes. Because this is per-page, I upped the page size to `50` to lower the chances of not getting a good sort for users with many feeds.

I also considered appending results and re-sorting as it paginates, but this would mean that if a popular feed loads from page 2, it would get sorted to the top out of the user's view, and they _still_ may not see it. So best to retain per-page sorts for the moment.