### PR TITLE
Move onboarding start to after successfull account creation

### DIFF
--- a/src/screens/Signup/state.ts
+++ b/src/screens/Signup/state.ts
@@ -252,7 +252,6 @@ export function useSubmitSignup({
       dispatch({type: 'setIsLoading', value: true})
 
       try {
-        onboardingDispatch({type: 'start'}) // start now to avoid flashing the wrong view
         await createAccount({
           service: state.serviceUrl,
           email: state.email,
@@ -262,6 +261,11 @@ export function useSubmitSignup({
           inviteCode: state.inviteCode.trim(),
           verificationCode: verificationCode,
         })
+        /*
+         * Must happen last so that if the user has multiple tabs open and
+         * createAccount fails, one tab is not stuck in onboarding — Eric
+         */
+        onboardingDispatch({type: 'start'})
       } catch (e: any) {
         onboardingDispatch({type: 'skip'}) // undo starting the onboard
         let errMsg = e.toString()

--- a/src/screens/Signup/state.ts
+++ b/src/screens/Signup/state.ts
@@ -267,7 +267,6 @@ export function useSubmitSignup({
          */
         onboardingDispatch({type: 'start'})
       } catch (e: any) {
-        onboardingDispatch({type: 'skip'}) // undo starting the onboard
         let errMsg = e.toString()
         if (e instanceof ComAtprotoServerCreateAccount.InvalidInviteCodeError) {
           dispatch({


### PR DESCRIPTION
We've heard rumors of pinned feeds and other profile data being lost when creating accounts. Aaron experienced this earlier, and was able to walk me through the exact steps he took.

The issue was that `createAccount` was failing AND he had multiple tabs open with a currently logged in account. So onboarding state was updated to `start`, which updates for all tabs, but the active tab then failed.

Upon failure, it does reset in the active tab, but in some cases it evidently doesn't reset in the other tabs, perhaps because of a write in one of those other tabs clobbering the active tab. When testing with Aaron we were able to enter onboarding in the inactive tabs, and when returning to the active tab where signup was taking place, we were also pulled into onboarding.

The other half of the issue is then that once in onboarding, you need to complete the flow, which sets some new defaults and overwrites some preferences you may have already set e.g. feeds and profile picture.

The fix here is to move the onboarding start call to after a successful `createAccount` call. Afaict the call to update the session post-success is sync, and I haven't been able to reproduce a flash that was previously noted in the code, on web or iOS. Since these are both sync state updates, I would hope they're squashed into a single update.

A future additive fix would probably be a boolean on the account's preferences object that we use to infer if they need onboarding or not.