### PR TITLE
Split ShareViaChatDialog

### DIFF
--- a/src/components/dms/dialogs/ShareViaChatDialog.tsx
+++ b/src/components/dms/dialogs/ShareViaChatDialog.tsx
@@ -15,8 +15,24 @@ export function SendViaChatDialog({
   control: Dialog.DialogControlProps
   onSelectChat: (chatId: string) => void
 }) {
-  const {_} = useLingui()
+  return (
+    <Dialog.Outer
+      control={control}
+      testID="sendViaChatChatDialog"
+      nativeOptions={{sheet: {snapPoints: ['100%']}}}>
+      <SendViaChatDialogInner control={control} onSelectChat={onSelectChat} />
+    </Dialog.Outer>
+  )
+}
 
+function SendViaChatDialogInner({
+  control,
+  onSelectChat,
+}: {
+  control: Dialog.DialogControlProps
+  onSelectChat: (chatId: string) => void
+}) {
+  const {_} = useLingui()
   const {mutate: createChat} = useGetConvoForMembers({
     onSuccess: data => {
       onSelectChat(data.convo.id)
@@ -39,15 +55,10 @@ export function SendViaChatDialog({
   )
 
   return (
-    <Dialog.Outer
-      control={control}
-      testID="sendViaChatChatDialog"
-      nativeOptions={{sheet: {snapPoints: ['100%']}}}>
-      <SearchablePeopleList
-        title={_(msg`Send post to...`)}
-        onSelectChat={onCreateChat}
-        showRecentConvos
-      />
-    </Dialog.Outer>
+    <SearchablePeopleList
+      title={_(msg`Send post to...`)}
+      onSelectChat={onCreateChat}
+      showRecentConvos
+    />
   )
 }


### PR DESCRIPTION
Prevents calling `useGetConvoForMembers` for every feed item until needed.

By moving it inside the inner dialog component.

## Test Plan

Send via DM button still works.