### PR TITLE
Switch to withSpring to work around Reanimated regression

### DIFF
--- a/src/state/shell/minimal-mode.tsx
+++ b/src/state/shell/minimal-mode.tsx
@@ -1,10 +1,5 @@
 import React from 'react'
-import {
-  Easing,
-  SharedValue,
-  useSharedValue,
-  withTiming,
-} from 'react-native-reanimated'
+import {SharedValue, useSharedValue, withSpring} from 'react-native-reanimated'
 
 type StateContext = SharedValue<number>
 type SetContext = (v: boolean) => void
@@ -22,9 +17,8 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
   const setMode = React.useCallback(
     (v: boolean) => {
       'worklet'
-      mode.value = withTiming(v ? 1 : 0, {
-        duration: 400,
-        easing: Easing.bezier(0.25, 0.1, 0.25, 1),
+      mode.value = withSpring(v ? 1 : 0, {
+        overshootClamping: true,
       })
     },
     [mode],


### PR DESCRIPTION
When we switched from Reanimated 3.6 to 3.11, scrolling on Home has gotten incredibly choppy. @haileyok and I narrowed it down to this animated value — it's being set to both plain numbers and to `withTiming`, and for some reason it appears that doing both (or maybe even just `withTiming` by itself) makes it choppy even _after_ the animation has completed (i.e. while scrolling later). It seems like `withSpring` doesn't have this problem so this just switches us to do that.

I've looked at other places where we have `withTiming` and they don't seem negatively affected so I didn't touch it.

## Test Plan

Scroll Home feed on low-end Android. It was super choppy before, now it's okay (with some dropped frames).