### PR TITLE
Fix lightbox on Android for tall images

### DIFF
--- a/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.android.tsx
+++ b/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.android.tsx
@@ -1,30 +1,36 @@
 import React, {useState} from 'react'
-
 import {ActivityIndicator, Dimensions, StyleSheet} from 'react-native'
-import {Image} from 'expo-image'
+import {Gesture, GestureDetector} from 'react-native-gesture-handler'
 import Animated, {
   runOnJS,
+  useAnimatedReaction,
   useAnimatedRef,
   useAnimatedStyle,
-  useAnimatedReaction,
   useSharedValue,
   withDecay,
   withSpring,
 } from 'react-native-reanimated'
-import {GestureDetector, Gesture} from 'react-native-gesture-handler'
+import {Image} from 'expo-image'
+
+import type {Dimensions as ImageDimensions, ImageSource} from '../../@types'
 import useImageDimensions from '../../hooks/useImageDimensions'
 import {
-  createTransform,
-  readTransform,
   applyRounding,
+  createTransform,
   prependPan,
   prependPinch,
   prependTransform,
+  readTransform,
   TransformMatrix,
 } from '../../transforms'
-import type {ImageSource, Dimensions as ImageDimensions} from '../../@types'
 
-const SCREEN = Dimensions.get('window')
+const windowDim = Dimensions.get('window')
+const screenDim = Dimensions.get('screen')
+const statusBarHeight = windowDim.height - screenDim.height
+const SCREEN = {
+  width: windowDim.width,
+  height: windowDim.height + statusBarHeight,
+}
 const MIN_DOUBLE_TAP_SCALE = 2
 const MAX_ORIGINAL_IMAGE_ZOOM = 2
 


### PR DESCRIPTION
Tall images didn't fully fit due to a flawed calculation.

I'm not sure why the new calculation makes sense or when it regressed but it does appear to have correct results.

## Before

https://github.com/bluesky-social/social-app/assets/810438/b223536f-3c2a-4fb2-9dbe-b2da10ae7e06

## After

https://github.com/bluesky-social/social-app/assets/810438/6a7405a3-ccfc-4212-99d3-1e8eeb1c9c0d

