### PR TITLE
disable keyboard controller in the composer screen

### DIFF
--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -17,6 +17,7 @@ import {
 import {
   KeyboardAvoidingView,
   KeyboardStickyView,
+  useKeyboardContext,
 } from 'react-native-keyboard-controller'
 import Animated, {
   interpolateColor,
@@ -128,6 +129,15 @@ export const ComposePost = observer(function ComposePost({
   const discardPromptControl = Prompt.usePromptControl()
   const {closeAllDialogs} = useDialogStateControlContext()
   const t = useTheme()
+
+  const context = useKeyboardContext()
+
+  React.useEffect(() => {
+    context.setEnabled(false)
+    return () => {
+      context.setEnabled(true)
+    }
+  })
 
   const [isKeyboardVisible] = useIsKeyboardVisible({iosUseWillEvents: true})
   const [isProcessing, setIsProcessing] = useState(false)

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -134,9 +134,11 @@ export const ComposePost = observer(function ComposePost({
   // See https://github.com/bluesky-social/social-app/pull/4399
   const context = useKeyboardContext()
   React.useEffect(() => {
-    context.setEnabled(false)
+    const {setEnabled} = context
+    setEnabled(false)
+
     return () => {
-      context.setEnabled(true)
+      setEnabled(true)
     }
   }, [context])
 

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -130,8 +130,9 @@ export const ComposePost = observer(function ComposePost({
   const {closeAllDialogs} = useDialogStateControlContext()
   const t = useTheme()
 
+  // Disable this in the composer to prevent any extra keyboard height being applied.
+  // See https://github.com/bluesky-social/social-app/pull/4399
   const context = useKeyboardContext()
-
   React.useEffect(() => {
     context.setEnabled(false)
     return () => {

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -138,7 +138,7 @@ export const ComposePost = observer(function ComposePost({
     return () => {
       context.setEnabled(true)
     }
-  })
+  }, [context])
 
   const [isKeyboardVisible] = useIsKeyboardVisible({iosUseWillEvents: true})
   const [isProcessing, setIsProcessing] = useState(false)

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -132,8 +132,7 @@ export const ComposePost = observer(function ComposePost({
 
   // Disable this in the composer to prevent any extra keyboard height being applied.
   // See https://github.com/bluesky-social/social-app/pull/4399
-  const keyboardContext = useKeyboardContext()
-  const {setEnabled} = keyboardContext
+  const {setEnabled} = useKeyboardContext()
   React.useEffect(() => {
     setEnabled(false)
 

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -132,15 +132,15 @@ export const ComposePost = observer(function ComposePost({
 
   // Disable this in the composer to prevent any extra keyboard height being applied.
   // See https://github.com/bluesky-social/social-app/pull/4399
-  const context = useKeyboardContext()
+  const keyboardContext = useKeyboardContext()
   React.useEffect(() => {
-    const {setEnabled} = context
+    const {setEnabled} = keyboardContext
     setEnabled(false)
 
     return () => {
       setEnabled(true)
     }
-  }, [context])
+  }, [keyboardContext])
 
   const [isKeyboardVisible] = useIsKeyboardVisible({iosUseWillEvents: true})
   const [isProcessing, setIsProcessing] = useState(false)

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -133,14 +133,14 @@ export const ComposePost = observer(function ComposePost({
   // Disable this in the composer to prevent any extra keyboard height being applied.
   // See https://github.com/bluesky-social/social-app/pull/4399
   const keyboardContext = useKeyboardContext()
+  const {setEnabled} = keyboardContext
   React.useEffect(() => {
-    const {setEnabled} = keyboardContext
     setEnabled(false)
 
     return () => {
       setEnabled(true)
     }
-  }, [keyboardContext])
+  }, [setEnabled])
 
   const [isKeyboardVisible] = useIsKeyboardVisible({iosUseWillEvents: true})
   const [isProcessing, setIsProcessing] = useState(false)


### PR DESCRIPTION
## Why

See https://kirillzyusko.github.io/react-native-keyboard-controller/blog/set-enabled

It appears that on some devices, the `react-native-keyboard-controller` library is setting some padding on the bottom of the composer. This breaks the composer, for example as seen here:

![image](https://github.com/bluesky-social/social-app/assets/153161762/3842cb54-590f-4655-a4d1-6c501a11da9d)

Instead, what we can do is enable it in the app, but specifically disable it in this screen. If we do that, this is the result:

![image](https://github.com/bluesky-social/social-app/assets/153161762/2ec664d5-9a04-40b0-8e6e-851edf1d2c9f)

## Test Plan

- Test on simulator, medium device, API level 28 ✅ 
- Test on device one (personal) ✅ 
- Test on device two (personal) ✅ 