### PR TITLE
Fix notifications pagination on web

### DIFF
--- a/src/view/com/notifications/Feed.tsx
+++ b/src/view/com/notifications/Feed.tsx
@@ -182,7 +182,7 @@ export function Feed({
         refreshing={isPTRing}
         onRefresh={onRefresh}
         onEndReached={onEndReached}
-        onEndReachedThreshold={2}
+        onEndReachedThreshold={0.6}
         onScrolledDownChange={onScrolledDownChange}
         contentContainerStyle={s.contentContainer}
         // @ts-ignore our .web version only -prf

--- a/src/view/com/notifications/Feed.tsx
+++ b/src/view/com/notifications/Feed.tsx
@@ -25,6 +25,7 @@ import {LoadMoreRetryBtn} from '#/view/com/util/LoadMoreRetryBtn'
 import {CenteredView} from '#/view/com/util/Views'
 import {FeedItem} from './FeedItem'
 import hairlineWidth = StyleSheet.hairlineWidth
+import {isWeb} from '#/platform/detection'
 
 const EMPTY_FEED_ITEM = {_reactKey: '__empty__'}
 const LOAD_MORE_ERROR_ITEM = {_reactKey: '__load_more_error__'}
@@ -182,7 +183,15 @@ export function Feed({
         refreshing={isPTRing}
         onRefresh={onRefresh}
         onEndReached={onEndReached}
-        onEndReachedThreshold={0.6}
+        onEndReachedThreshold={
+          /*
+          NOTE:
+          web's intersection observer struggles with the 2x threshold
+          and leads to missed pagination, so we keep it <1
+          -prf
+          */
+          isWeb ? 0.6 : 2
+        }
         onScrolledDownChange={onScrolledDownChange}
         contentContainerStyle={s.contentContainer}
         // @ts-ignore our .web version only -prf


### PR DESCRIPTION
Reverts https://github.com/bluesky-social/social-app/pull/4235

It looks like the issue is that fetching the next page doesn't reliably add 2x list height to the scrollview. The intersection observer only tells us when the boundary is crossed -- it doesn't trigger if we're still in the boundary -- and so the next page successfully fires but then doesn't retrigger.

It's entirely possible, with client-side filtering, that even dropping the threshold down to 60% doesn't totally fix the issue.

- We could possibly solve this by calculating the number of new list items getting added post-grouping and, if it's too low, queue another fetch. That feels brittle though.
- We could look for some way to fire an event post-layout, perhaps by running [checkVisiblity](https://developer.mozilla.org/en-US/docs/Web/API/Element/checkVisibility) on the bottom of the screen.