### PR TITLE
Improve thread loading

### DIFF
--- a/src/view/com/post-thread/PostThread.tsx
+++ b/src/view/com/post-thread/PostThread.tsx
@@ -34,6 +34,7 @@ import {ComposePrompt} from '../composer/Prompt'
 import {List, ListMethods} from '../util/List'
 import {ViewHeader} from '../util/ViewHeader'
 import {PostThreadItem} from './PostThreadItem'
+import {PostThreadLoadMore} from './PostThreadLoadMore'
 import {PostThreadShowHiddenReplies} from './PostThreadShowHiddenReplies'
 
 // FlatList maintainVisibleContentPosition breaks if too many items
@@ -364,6 +365,9 @@ export function PostThread({
         </View>
       )
     } else if (isThreadPost(item)) {
+      if (!treeView && item.ctx.hasMoreSelfThread) {
+        return <PostThreadLoadMore post={item.post} />
+      }
       const prev = isThreadPost(posts[index - 1])
         ? (posts[index - 1] as ThreadPost)
         : undefined

--- a/src/view/com/post-thread/PostThreadLoadMore.tsx
+++ b/src/view/com/post-thread/PostThreadLoadMore.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react'
+import {View} from 'react-native'
+import {AppBskyFeedDefs, AtUri} from '@atproto/api'
+import {Trans} from '@lingui/macro'
+
+import {makeProfileLink} from '#/lib/routes/links'
+import {atoms as a, useTheme} from '#/alf'
+import {Text} from '#/components/Typography'
+import {Link} from '../util/Link'
+import {UserAvatar} from '../util/UserAvatar'
+
+export function PostThreadLoadMore({post}: {post: AppBskyFeedDefs.PostView}) {
+  const t = useTheme()
+
+  const postHref = React.useMemo(() => {
+    const urip = new AtUri(post.uri)
+    return makeProfileLink(post.author, 'post', urip.rkey)
+  }, [post.uri, post.author])
+
+  return (
+    <Link
+      href={postHref}
+      style={[a.flex_row, a.align_center, a.px_xl, a.py_md]}
+      hoverStyle={[t.atoms.bg_contrast_25]}>
+      <UserAvatar avatar={post.author.avatar} size={30} />
+      <View style={[a.px_lg]}>
+        <Text style={[{color: t.palette.primary_500}, a.text_md]}>
+          <Trans>Continue thread...</Trans>
+        </Text>
+      </View>
+    </Link>
+  )
+}

--- a/src/view/com/post-thread/PostThreadLoadMore.tsx
+++ b/src/view/com/post-thread/PostThreadLoadMore.tsx
@@ -20,10 +20,34 @@ export function PostThreadLoadMore({post}: {post: AppBskyFeedDefs.PostView}) {
   return (
     <Link
       href={postHref}
-      style={[a.flex_row, a.align_center, a.px_xl, a.py_md]}
+      style={[a.flex_row, a.align_center, a.py_md, {paddingHorizontal: 14}]}
       hoverStyle={[t.atoms.bg_contrast_25]}>
-      <UserAvatar avatar={post.author.avatar} size={30} />
-      <View style={[a.px_lg]}>
+      <View style={[a.flex_row]}>
+        <View
+          style={{
+            alignItems: 'center',
+            justifyContent: 'center',
+            width: 34,
+            height: 34,
+            borderRadius: 18,
+            backgroundColor: t.atoms.bg.backgroundColor,
+            marginRight: -20,
+          }}>
+          <UserAvatar avatar={post.author.avatar} size={30} />
+        </View>
+        <View
+          style={{
+            alignItems: 'center',
+            justifyContent: 'center',
+            width: 34,
+            height: 34,
+            borderRadius: 18,
+            backgroundColor: t.atoms.bg.backgroundColor,
+          }}>
+          <UserAvatar avatar={post.author.avatar} size={30} />
+        </View>
+      </View>
+      <View style={[a.px_sm]}>
         <Text style={[{color: t.palette.primary_500}, a.text_md]}>
           <Trans>Continue thread...</Trans>
         </Text>


### PR DESCRIPTION
Ignore the first commit. The second commit took a different approach:

- Increase depth to 10
- Replace the last post in a self-thread with a "Continue thread..." link

Here's a screenshot with the depth decreased to show the behavior:

![image](https://github.com/bluesky-social/social-app/assets/1270099/d72c83ae-64a6-4f0e-8b6c-ac54d8299525)
