### PR TITLE
add support for `ListEmptyComponent`, allow `undefined` data

### DIFF
--- a/src/view/com/util/List.web.tsx
+++ b/src/view/com/util/List.web.tsx
@@ -73,6 +73,8 @@ function ListImpl<ItemT>(
     )
   }
 
+  const isEmpty = !data || data.length === 0
+
   let headerComponent: JSX.Element | null = null
   if (ListHeaderComponent != null) {
     if (isValidElement(ListHeaderComponent)) {
@@ -334,7 +336,7 @@ function ListImpl<ItemT>(
           onVisibleChange={handleAboveTheFoldVisibleChange}
           style={[styles.aboveTheFoldDetector, {height: headerOffset}]}
         />
-        {onStartReached && (
+        {onStartReached && !isEmpty && (
           <Visibility
             root={containWeb ? nativeRef : null}
             onVisibleChange={onHeadVisibilityChange}
@@ -342,7 +344,7 @@ function ListImpl<ItemT>(
           />
         )}
         {headerComponent}
-        {!data || data.length === 0
+        {isEmpty
           ? emptyComponent
           : (data as Array<ItemT>)?.map((item, index) => {
               const key = keyExtractor!(item, index)
@@ -358,7 +360,7 @@ function ListImpl<ItemT>(
                 />
               )
             })}
-        {onEndReached && (
+        {onEndReached && !isEmpty && (
           <Visibility
             root={containWeb ? nativeRef : null}
             onVisibleChange={onTailVisibilityChange}

--- a/src/view/com/util/List.web.tsx
+++ b/src/view/com/util/List.web.tsx
@@ -38,6 +38,7 @@ function ListImpl<ItemT>(
   {
     ListHeaderComponent,
     ListFooterComponent,
+    ListEmptyComponent,
     containWeb,
     contentContainerStyle,
     data,
@@ -89,6 +90,16 @@ function ListImpl<ItemT>(
     } else {
       // @ts-ignore Nah it's fine.
       footer = <ListFooterComponent />
+    }
+  }
+
+  let emptyComponent: JSX.Element | null = null
+  if (ListEmptyComponent != null) {
+    if (isValidElement(ListEmptyComponent)) {
+      emptyComponent = ListEmptyComponent
+    } else {
+      // @ts-ignore Nah it's fine.
+      emptyComponent = <ListEmptyComponent />
     }
   }
 
@@ -331,20 +342,22 @@ function ListImpl<ItemT>(
           />
         )}
         {header}
-        {(data as Array<ItemT>).map((item, index) => {
-          const key = keyExtractor!(item, index)
-          return (
-            <Row<ItemT>
-              key={key}
-              item={item}
-              index={index}
-              renderItem={renderItem}
-              extraData={extraData}
-              onItemSeen={onItemSeen}
-              disableContentVisibility={disableContentVisibility}
-            />
-          )
-        })}
+        {!data || data.length === 0
+          ? emptyComponent
+          : (data as Array<ItemT>)?.map((item, index) => {
+              const key = keyExtractor!(item, index)
+              return (
+                <Row<ItemT>
+                  key={key}
+                  item={item}
+                  index={index}
+                  renderItem={renderItem}
+                  extraData={extraData}
+                  onItemSeen={onItemSeen}
+                  disableContentVisibility={disableContentVisibility}
+                />
+              )
+            })}
         {onEndReached && (
           <Visibility
             root={containWeb ? nativeRef : null}

--- a/src/view/com/util/List.web.tsx
+++ b/src/view/com/util/List.web.tsx
@@ -73,23 +73,23 @@ function ListImpl<ItemT>(
     )
   }
 
-  let header: JSX.Element | null = null
+  let headerComponent: JSX.Element | null = null
   if (ListHeaderComponent != null) {
     if (isValidElement(ListHeaderComponent)) {
-      header = ListHeaderComponent
+      headerComponent = ListHeaderComponent
     } else {
       // @ts-ignore Nah it's fine.
-      header = <ListHeaderComponent />
+      headerComponent = <ListHeaderComponent />
     }
   }
 
-  let footer: JSX.Element | null = null
+  let footerComponent: JSX.Element | null = null
   if (ListFooterComponent != null) {
     if (isValidElement(ListFooterComponent)) {
-      footer = ListFooterComponent
+      footerComponent = ListFooterComponent
     } else {
       // @ts-ignore Nah it's fine.
-      footer = <ListFooterComponent />
+      footerComponent = <ListFooterComponent />
     }
   }
 
@@ -341,7 +341,7 @@ function ListImpl<ItemT>(
             topMargin={(onStartReachedThreshold ?? 0) * 100 + '%'}
           />
         )}
-        {header}
+        {headerComponent}
         {!data || data.length === 0
           ? emptyComponent
           : (data as Array<ItemT>)?.map((item, index) => {
@@ -365,7 +365,7 @@ function ListImpl<ItemT>(
             bottomMargin={(onEndReachedThreshold ?? 0) * 100 + '%'}
           />
         )}
-        {footer}
+        {footerComponent}
       </View>
     </View>
   )


### PR DESCRIPTION
## Why

### 1. `data` can be `undefined`

The native `FlatList` implementation allows `data` to be `undefined`. It does not _have_ to be an array. In our web implementation though, we assume that it is since all we do is assert `data as Array<ItemT>`.

To test this, use `Feed.tsx` and change the `data` prop to `undefined`. This appears fine - since the `FlatList` types allow it - but our causes an error.

<img width="1037" alt="Screenshot 2024-06-06 at 4 09 03 PM" src="https://github.com/bluesky-social/social-app/assets/153161762/b4a65a2e-2e7d-422d-8fd9-94c09fdca014">

### 2. `ListEmptyComponent` should be rendered when `data` is `undefined` or an empty array

There is a `ListEmptyComponent` prop on `FlatList` that will render the given element when the `data` is empty or `undefined`. I've added support for that view as well in this PR.

## Test Plan

- Use `Feeds.tsx` as an example
- Change `data` in the `List` to `undefined`
- There should no longer be an error 

<img width="1188" alt="Screenshot 2024-06-06 at 4 10 34 PM" src="https://github.com/bluesky-social/social-app/assets/153161762/03c1ac0e-1c61-4564-afb7-419feb33806f">


### Empty Component 

- Add `ListEmptyComponent` prop to the `List`, with a value like:

```tsx
<View style={{alignItems: 'center', marginTop: 20}}>
	<Loader size="lg" />
</View>
```

- You should see a spinner

<img width="1247" alt="Screenshot 2024-06-06 at 4 12 47 PM" src="https://github.com/bluesky-social/social-app/assets/153161762/4320bfa6-1ee2-48d4-a195-f93a407a1af0">
