### PR TITLE
scope enable/disable of keyboard controller in composer to only android

### DIFF
--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -134,8 +134,8 @@ export const ComposePost = observer(function ComposePost({
   // See https://github.com/bluesky-social/social-app/pull/4399
   const {setEnabled} = useKeyboardContext()
   React.useEffect(() => {
+    if (!isAndroid) return
     setEnabled(false)
-
     return () => {
       setEnabled(true)
     }


### PR DESCRIPTION
## Why

Follow up to https://github.com/bluesky-social/social-app/pull/4399. Let's scope this to only Android, doesn't work well on iOS.

## Test Plan

Just changing the iOS version back to what it was before disabling in https://github.com/bluesky-social/social-app/pull/4399, so no new behavior.