### PR TITLE
Set profile hover prefetch stale time to 30s

### DIFF
--- a/src/state/queries/profile.ts
+++ b/src/state/queries/profile.ts
@@ -94,6 +94,7 @@ export function usePrefetchProfileQuery() {
   const prefetchProfileQuery = useCallback(
     async (did: string) => {
       await queryClient.prefetchQuery({
+        staleTime: STALE.SECONDS.THIRTY,
         queryKey: RQKEY(did),
         queryFn: async () => {
           const res = await agent.getProfile({actor: did || ''})

--- a/src/view/com/util/PostMeta.tsx
+++ b/src/view/com/util/PostMeta.tsx
@@ -11,6 +11,7 @@ import {sanitizeHandle} from 'lib/strings/handles'
 import {niceDate} from 'lib/strings/time'
 import {TypographyVariant} from 'lib/ThemeContext'
 import {isAndroid, isWeb} from 'platform/detection'
+import {atoms as a} from '#/alf'
 import {ProfileHoverCard} from '#/components/ProfileHoverCard'
 import {TextLinkOnWebOnly} from './Link'
 import {Text} from './text/Text'
@@ -66,37 +67,37 @@ let PostMeta = (opts: PostMetaOpts): React.ReactNode => {
         </View>
       )}
       <ProfileHoverCard inline did={opts.author.did}>
-        <Text
-          numberOfLines={1}
-          style={[styles.maxWidth, pal.textLight, opts.displayNameStyle]}>
-          <TextLinkOnWebOnly
-            type={opts.displayNameType || 'lg-bold'}
-            style={[pal.text]}
-            lineHeight={1.2}
-            disableMismatchWarning
-            text={
-              <>
-                {sanitizeDisplayName(
-                  displayName,
-                  opts.moderation?.ui('displayName'),
-                )}
-              </>
-            }
-            href={profileLink}
-            onBeforePress={onBeforePressAuthor}
-            onPointerEnter={onPointerEnter}
-          />
-          <TextLinkOnWebOnly
-            type="md"
-            disableMismatchWarning
-            style={[pal.textLight, {flexShrink: 4}]}
-            text={'\xa0' + sanitizeHandle(handle, '@')}
-            href={profileLink}
-            onBeforePress={onBeforePressAuthor}
-            onPointerEnter={onPointerEnter}
-            anchorNoUnderline
-          />
-        </Text>
+        <View onPointerMove={onPointerEnter} style={[a.flex_1]}>
+          <Text
+            numberOfLines={1}
+            style={[styles.maxWidth, pal.textLight, opts.displayNameStyle]}>
+            <TextLinkOnWebOnly
+              type={opts.displayNameType || 'lg-bold'}
+              style={[pal.text]}
+              lineHeight={1.2}
+              disableMismatchWarning
+              text={
+                <>
+                  {sanitizeDisplayName(
+                    displayName,
+                    opts.moderation?.ui('displayName'),
+                  )}
+                </>
+              }
+              href={profileLink}
+              onBeforePress={onBeforePressAuthor}
+            />
+            <TextLinkOnWebOnly
+              type="md"
+              disableMismatchWarning
+              style={[pal.textLight, {flexShrink: 4}]}
+              text={'\xa0' + sanitizeHandle(handle, '@')}
+              href={profileLink}
+              onBeforePress={onBeforePressAuthor}
+              anchorNoUnderline
+            />
+          </Text>
+        </View>
       </ProfileHoverCard>
       {!isAndroid && (
         <Text

--- a/src/view/com/util/PostMeta.tsx
+++ b/src/view/com/util/PostMeta.tsx
@@ -40,9 +40,13 @@ let PostMeta = (opts: PostMetaOpts): React.ReactNode => {
   const prefetchProfileQuery = usePrefetchProfileQuery()
 
   const profileLink = makeProfileLink(opts.author)
-  const onPointerEnter = isWeb
-    ? () => prefetchProfileQuery(opts.author.did)
-    : undefined
+  const prefetchedProfile = React.useRef(false)
+  const onPointerMove = React.useCallback(() => {
+    if (!prefetchedProfile.current) {
+      prefetchedProfile.current = true
+      prefetchProfileQuery(opts.author.did)
+    }
+  }, [opts.author.did, prefetchProfileQuery])
 
   const queryClient = useQueryClient()
   const onOpenAuthor = opts.onOpenAuthor
@@ -67,7 +71,9 @@ let PostMeta = (opts: PostMetaOpts): React.ReactNode => {
         </View>
       )}
       <ProfileHoverCard inline did={opts.author.did}>
-        <View onPointerMove={onPointerEnter} style={[a.flex_1]}>
+        <View
+          onPointerMove={isWeb ? onPointerMove : undefined}
+          style={[a.flex_1]}>
           <Text
             numberOfLines={1}
             style={[styles.maxWidth, pal.textLight, opts.displayNameStyle]}>


### PR DESCRIPTION
Two related things were happening in this PR:
- though `ProfileHoverCard` was using `onPointerMove` to prevent triggering prefetches while scrolling, `PostMeta` was still using `onPointerEnter`, which triggers while scrolling
- whether scroll or roll-over, profile prefetch was being called every time, so adding stale time of 30s effectively debounces those calls

So the result is: `getProfile` is no longer called on scroll, and it's called at most once every 30s if the user intentionally hovers over the triggers.

In `PostMeta`, `Text` doesn't support `onPointerMove`, so I wrapped it in a `View` and double checked overflow, should be OK (see screenshots)
![CleanShot 2024-06-07 at 10 27 43@2x](https://github.com/bluesky-social/social-app/assets/4732330/7c195ddd-5899-4b4a-8d95-a9351bbce95d)
![CleanShot 2024-06-07 at 10 30 40@2x](https://github.com/bluesky-social/social-app/assets/4732330/41c8a128-7ecd-4b0f-b087-1b1c5fde379e)
