### PR TITLE
lint: enable eslint compiler plugin

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,7 +13,7 @@ module.exports = {
     'lingui',
     'simple-import-sort',
     'bsky-internal',
-    'eslint-plugin-react-compiler',
+    'react-compiler',
   ],
   rules: {
     // Temporary until https://github.com/facebook/react-native/pull/43756 gets into a release.
@@ -68,8 +68,7 @@ module.exports = {
       },
     ],
     'simple-import-sort/exports': 'warn',
-    // TODO: Reenable when we figure out why it gets stuck on CI.
-    // 'react-compiler/react-compiler': 'error',
+    'react-compiler/react-compiler': 'error',
   },
   ignorePatterns: [
     '**/__mocks__/*.ts',


### PR DESCRIPTION
### Why
Using `eslint-plugin-react-compiler` instead of `react-compiler` was the issue in my setup. Maybe it is in yours, too?

### How

Simple eslint change: I just re-enabled the rule and renamed the plugin.

### Test Plan

Ensure that the CI passes. I'll need the maintainers' approvals to run the pipeline.