### PR TITLE
[Session] Convert account to session data explicitly

### DIFF
--- a/src/state/session/agent.ts
+++ b/src/state/session/agent.ts
@@ -37,21 +37,7 @@ export async function createAgentAndResume(
   }
   const gates = tryFetchGates(storedAccount.did, 'prefer-low-latency')
   const moderation = configureModerationForAccount(agent, storedAccount)
-  const prevSession: AtpSessionData = {
-    // Sorted in the same property order as when returned by BskyAgent (alphabetical).
-    accessJwt: storedAccount.accessJwt ?? '',
-    did: storedAccount.did,
-    email: storedAccount.email,
-    emailAuthFactor: storedAccount.emailAuthFactor,
-    emailConfirmed: storedAccount.emailConfirmed,
-    handle: storedAccount.handle,
-    refreshJwt: storedAccount.refreshJwt ?? '',
-    /**
-     * @see https://github.com/bluesky-social/atproto/blob/c5d36d5ba2a2c2a5c4f366a5621c06a5608e361e/packages/api/src/agent.ts#L188
-     */
-    active: storedAccount.active ?? true,
-    status: storedAccount.status,
-  }
+  const prevSession: AtpSessionData = sessionAccountToSession(storedAccount)
   if (isSessionExpired(storedAccount)) {
     await networkRetry(1, () => agent.resumeSession(prevSession))
   } else {
@@ -243,5 +229,25 @@ export function agentToSessionAccount(
     active: agent.session.active,
     status: agent.session.status as SessionAccount['status'],
     pdsUrl: agent.pdsUrl?.toString(),
+  }
+}
+
+export function sessionAccountToSession(
+  account: SessionAccount,
+): AtpSessionData {
+  return {
+    // Sorted in the same property order as when returned by BskyAgent (alphabetical).
+    accessJwt: account.accessJwt ?? '',
+    did: account.did,
+    email: account.email,
+    emailAuthFactor: account.emailAuthFactor,
+    emailConfirmed: account.emailConfirmed,
+    handle: account.handle,
+    refreshJwt: account.refreshJwt ?? '',
+    /**
+     * @see https://github.com/bluesky-social/atproto/blob/c5d36d5ba2a2c2a5c4f366a5621c06a5608e361e/packages/api/src/agent.ts#L188
+     */
+    active: account.active ?? true,
+    status: account.status,
   }
 }

--- a/src/state/session/index.tsx
+++ b/src/state/session/index.tsx
@@ -14,6 +14,7 @@ import {
   createAgentAndCreateAccount,
   createAgentAndLogin,
   createAgentAndResume,
+  sessionAccountToSession,
 } from './agent'
 import {getInitialState, reducer} from './reducer'
 
@@ -176,8 +177,7 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
           resumeSession(syncedAccount)
         } else {
           const agent = state.currentAgentState.agent as BskyAgent
-          // @ts-ignore TODO
-          agent.session = syncedAccount
+          agent.session = sessionAccountToSession(syncedAccount)
         }
       }
     })

--- a/src/state/session/index.tsx
+++ b/src/state/session/index.tsx
@@ -175,8 +175,9 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
         if (syncedAccount.did !== state.currentAgentState.did) {
           resumeSession(syncedAccount)
         } else {
-          // @ts-ignore we checked for `refreshJwt` above
-          state.currentAgentState.agent.session = syncedAccount
+          const agent = state.currentAgentState.agent as BskyAgent
+          // @ts-ignore TODO
+          agent.session = syncedAccount
         }
       }
     })


### PR DESCRIPTION
We were previously suppressing a type error which was a legit mismatch in types. We were assigning `SessionAccount` (an app concept) directly into `agent.session` as if it were `AtpSessionData`.

Strictly saying, this isn't valid — for example, `refreshJwt` can be `undefined` in `SessionAcount` but is expected to be a `string` (even if empty) in `AtpSessionData`. We *do* have a check (per suppression comment) that should rule out this actually happening but I think it's better to ensure this statically. This also avoids unrelated account fields like `pdsUrl` ending up attached to the `session` object.

This PR removes the suppression and adds an explicit conversion based on existing logic from the resume session codepath.

**I don't expect this to change anything in practice.**

## Test Plan

Idk how to test this since it needs to trigger expiry. I think we need support from backend to force early expiry — with a header or something. So for now the test plan is just careful reading.