### PR TITLE
replace graphemer by unicode-segmenter

### DIFF
--- a/package.json
+++ b/package.json
@@ -195,6 +195,7 @@
     "statsig-react-native-expo": "^4.6.1",
     "tippy.js": "^6.3.7",
     "tlds": "^1.234.0",
+    "unicode-segmenter": "^0.7.0",
     "zeego": "^1.6.2",
     "zod": "^3.20.2"
   },

--- a/src/screens/Messages/Conversation/MessageInput.tsx
+++ b/src/screens/Messages/Conversation/MessageInput.tsx
@@ -14,7 +14,7 @@ import Animated, {
 import {useSafeAreaInsets} from 'react-native-safe-area-context'
 import {msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
-import Graphemer from 'graphemer'
+import {countGrapheme} from 'unicode-segmenter/grapheme'
 
 import {HITSLOP_10, MAX_DM_GRAPHEME_LENGTH} from '#/lib/constants'
 import {useHaptics} from '#/lib/haptics'
@@ -66,7 +66,7 @@ export function MessageInput({
     if (!hasEmbed && message.trim() === '') {
       return
     }
-    if (new Graphemer().countGraphemes(message) > MAX_DM_GRAPHEME_LENGTH) {
+    if (countGrapheme(message) > MAX_DM_GRAPHEME_LENGTH) {
       Toast.show(_(msg`Message is too long`))
       return
     }

--- a/src/screens/Messages/Conversation/MessageInput.web.tsx
+++ b/src/screens/Messages/Conversation/MessageInput.web.tsx
@@ -2,8 +2,8 @@ import React from 'react'
 import {Pressable, StyleSheet, View} from 'react-native'
 import {msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
-import Graphemer from 'graphemer'
 import TextareaAutosize from 'react-textarea-autosize'
+import {countGrapheme} from 'unicode-segmenter/grapheme'
 
 import {MAX_DM_GRAPHEME_LENGTH} from '#/lib/constants'
 import {
@@ -45,7 +45,7 @@ export function MessageInput({
     if (!hasEmbed && message.trim() === '') {
       return
     }
-    if (new Graphemer().countGraphemes(message) > MAX_DM_GRAPHEME_LENGTH) {
+    if (countGrapheme(message) > MAX_DM_GRAPHEME_LENGTH) {
       Toast.show(_(msg`Message is too long`))
       return
     }

--- a/src/view/com/composer/text-input/hooks/useGrapheme.tsx
+++ b/src/view/com/composer/text-input/hooks/useGrapheme.tsx
@@ -1,34 +1,33 @@
-import Graphemer from 'graphemer'
-import {useCallback, useMemo} from 'react'
+import {useCallback} from 'react'
+import {graphemeSegments} from 'unicode-segmenter/grapheme'
 
 export const useGrapheme = () => {
-  const splitter = useMemo(() => new Graphemer(), [])
+  const getGraphemeString = useCallback((name: string, length: number) => {
+    let remainingCharacters = 0
 
-  const getGraphemeString = useCallback(
-    (name: string, length: number) => {
-      let remainingCharacters = 0
+    if (name.length > length) {
+      const segments = [...graphemeSegments(name)]
+      const joinSegments = (
+        name: string,
+        {segment}: (typeof segments)[number],
+      ) => name + segment
 
-      if (name.length > length) {
-        const graphemes = splitter.splitGraphemes(name)
-
-        if (graphemes.length > length) {
-          remainingCharacters = 0
-          name = `${graphemes.slice(0, length).join('')}...`
-        } else {
-          remainingCharacters = length - graphemes.length
-          name = graphemes.join('')
-        }
+      if (segments.length > length) {
+        remainingCharacters = 0
+        name = `${segments.slice(0, length).reduce(joinSegments, '')}...`
       } else {
-        remainingCharacters = length - name.length
+        remainingCharacters = length - segments.length
+        name = segments.reduce(joinSegments, '')
       }
+    } else {
+      remainingCharacters = length - name.length
+    }
 
-      return {
-        name,
-        remainingCharacters,
-      }
-    },
-    [splitter],
-  )
+    return {
+      name,
+      remainingCharacters,
+    }
+  }, [])
 
   return {
     getGraphemeString,

--- a/yarn.lock
+++ b/yarn.lock
@@ -21332,6 +21332,11 @@ unicode-property-aliases-ecmascript@^2.0.0:
   resolved "https://registry.yarnpkg.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-2.1.0.tgz#43d41e3be698bd493ef911077c9b131f827e8ccd"
   integrity sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==
 
+unicode-segmenter@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/unicode-segmenter/-/unicode-segmenter-0.7.0.tgz#2f514794a0be4b99ab9f656cff08b3c9e020deb1"
+  integrity sha512-GgySw5Xcmz0rVL3WOsVFk9mdXPUWsgxulVrZQUcQq4HZNY5r2z8OPnTRAX+Y0GwRXPX+BuDa399PnIy6fqh8og==
+
 unimodules-app-loader@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/unimodules-app-loader/-/unimodules-app-loader-4.6.0.tgz#8836040b3acbf605fc4c2c6f6feb6dd9084ea0d4"


### PR DESCRIPTION
Same as https://github.com/bluesky-social/atproto/pull/2563

I also noticed that `graphemer` in social-app isn't specified in the `package.json`, but imported as a phantom dependency from the atproto package, which could be broken as the atproto package bumped. 