### PR TITLE
Use a 1:1 ratio for avatar cropper

### DIFF
--- a/src/screens/Onboarding/StepProfile/index.tsx
+++ b/src/screens/Onboarding/StepProfile/index.tsx
@@ -181,8 +181,8 @@ export function StepProfile() {
       image = await openCropper({
         mediaType: 'photo',
         cropperCircleOverlay: true,
-        height: image.height,
-        width: image.width,
+        height: 1000,
+        width: 1000,
         path: image.path,
       })
     }

--- a/src/view/com/util/UserAvatar.tsx
+++ b/src/view/com/util/UserAvatar.tsx
@@ -290,8 +290,8 @@ let EditableUserAvatar = ({
       const croppedImage = await openCropper({
         mediaType: 'photo',
         cropperCircleOverlay: true,
-        height: item.height,
-        width: item.width,
+        height: 1000,
+        width: 1000,
         path: item.path,
       })
 


### PR DESCRIPTION
## Why

Avatar cropping on Android is not great right now, since the current logic requires the new image be the same size as whatever the input is. For example, a 3000x1500 input will expect an image of that same aspect when cropping. This doesn't work very well for avatar crops.


https://github.com/bluesky-social/social-app/assets/153161762/8f592f37-36ee-463a-a322-c0587e055f3c

## How

Instead of using the input picture's height and width, we should just set this to a size with equal height and width. We'll use 1000x1000 for now. This ends up allowing us to crop to whatever region of the photo we want.

https://github.com/bluesky-social/social-app/assets/153161762/89f6af7d-f631-49d1-8847-5c3a60819018

## Test Plan

- Verify that crops still work correctly on Android on various devices
- Verify that iOS cropping still behaves the same as before

https://github.com/bluesky-social/social-app/assets/153161762/8c7ebeef-3c1a-47da-b66c-d76e1eb2e168

- Verify that cropping on web still behaves the same as before


https://github.com/bluesky-social/social-app/assets/153161762/89c0bb41-8fda-4503-bd4c-622013769989

