### PR TITLE
Irish l10n update

### DIFF
--- a/src/locale/locales/ga/messages.po
+++ b/src/locale/locales/ga/messages.po
@@ -14,7 +14,7 @@ msgstr ""
 
 #: src/screens/Messages/List/ChatListItem.tsx:119
 msgid "(contains embedded content)"
-msgstr ""
+msgstr "(tá ábhar leabaithe ann)"
 
 #: src/view/com/modals/VerifyEmail.tsx:150
 msgid "(no email)"
@@ -22,29 +22,27 @@ msgstr "(gan ríomhphost)"
 
 #: src/view/com/notifications/FeedItem.tsx:261
 msgid "{0, plural, one {{formattedCount} other} other {{formattedCount} others}}"
-msgstr "{0, plural, one {{formattedCount} cheann amháin eile} two {{formattedCount} cheann eile} few {{formattedCount} cinn eile} many {{formattedCount} gcinn eile} other {{formattedCount} ceann eile}}"
+msgstr "{0, plural, one {duine amháin eile} two {beirt eile} few {{formattedCount} dhuine eile} many {{formattedCount} nduine eile} other {{formattedCount} duine eile}}"
 
 #: src/components/moderation/LabelsOnMe.tsx:55
 msgid "{0, plural, one {# label has been placed on this account} other {# labels have been placed on this account}}"
-msgstr "{0, plural, one {Cuireadh # lipéad amháin ar an gcuntas seo} two {Cuireadh # lipéad ar an gcuntas seo} few {Cuireadh # lipéad ar an gcuntas seo} many {Cuireadh # lipéad ar an gcuntas seo} other {Cuireadh # lipéad ar an gcuntas seo}}"
+msgstr "{0, plural, one {Cuireadh lipéad amháin ar an gcuntas seo} two {Cuireadh # lipéad ar an gcuntas seo} few {Cuireadh # lipéad ar an gcuntas seo} many {Cuireadh # lipéad ar an gcuntas seo} other {Cuireadh # lipéad ar an gcuntas seo}}"
 
 #: src/components/moderation/LabelsOnMe.tsx:61
 msgid "{0, plural, one {# label has been placed on this content} other {# labels have been placed on this content}}"
-msgstr "{0, plural, one {Cuireadh # lipéad amháin ar an ábhar seo} two {Cuireadh # lipéad ar an ábhar seo} few {Cuireadh # lipéad ar an ábhar seo} many {Cuireadh # lipéad ar an ábhar seo} other {Cuireadh # lipéad ar an ábhar seo}}"
+msgstr "{0, plural, one {Cuireadh lipéad amháin ar an ábhar seo} two {Cuireadh # lipéad ar an ábhar seo} few {Cuireadh # lipéad ar an ábhar seo} many {Cuireadh # lipéad ar an ábhar seo} other {Cuireadh # lipéad ar an ábhar seo}}"
 
 #: src/view/com/util/post-ctrls/RepostButton.tsx:64
 msgid "{0, plural, one {# repost} other {# reposts}}"
 msgstr "{0, plural, one {# athphostáil} two {# athphostáil} few {# athphostáil} many {# n-athphostáil} other {# athphostáil}}"
 
-#: src/components/ProfileHoverCard/index.web.tsx:376
-#: src/screens/Profile/Header/Metrics.tsx:23
+#: src/components/ProfileHoverCard/index.web.tsx:376 src/screens/Profile/Header/Metrics.tsx:23
 msgid "{0, plural, one {follower} other {followers}}"
-msgstr "{0, plural, one {# leantóir} two {# leantóir} few {# leantóir} many {# leantóir} other {# leantóir}}"
+msgstr "{0, plural, one {leantóir} two {leantóir} few {leantóir} many {leantóir} other {leantóir}}"
 
-#: src/components/ProfileHoverCard/index.web.tsx:380
-#: src/screens/Profile/Header/Metrics.tsx:27
+#: src/components/ProfileHoverCard/index.web.tsx:380 src/screens/Profile/Header/Metrics.tsx:27
 msgid "{0, plural, one {following} other {following}}"
-msgstr "{0, plural, one {# á leanúint} two {# á leanúint} few {# á leanúint} many {# á leanúint} other {# á leanúint}}"
+msgstr "{0, plural, one {á leanúint} two {á leanúint} few {á leanúint} many {á leanúint} other {á leanúint}}"
 
 #: src/view/com/util/post-ctrls/PostCtrls.tsx:252
 msgid "{0, plural, one {Like (# like)} other {Like (# likes)}}"
@@ -56,7 +54,7 @@ msgstr "{0, plural, one {moladh} two {mholadh} few {mholadh} many {moladh} other
 
 #: src/view/com/feeds/FeedSourceCard.tsx:280
 msgid "{0, plural, one {Liked by # user} other {Liked by # users}}"
-msgstr "{0, plural, one {Molta ag # úsáideoir amháin} two {Molta ag # úsáideoir} few {Molta ag # úsáideoir} many {Molta ag # n-úsáideoir} other {Molta ag # úsáideoir}}"
+msgstr "{0, plural, one {Molta ag úsáideoir amháin} two {Molta ag beirt úsáideoirí} few {Molta ag # úsáideoir} many {Molta ag # n-úsáideoir} other {Molta ag # úsáideoir}}"
 
 #: src/screens/Profile/Header/Metrics.tsx:59
 msgid "{0, plural, one {post} other {posts}}"
@@ -76,11 +74,11 @@ msgstr "{0, plural, one {Dímhol (# mholadh)} two {Dímhol (# mholadh)} few {Dí
 
 #: src/view/com/util/UserAvatar.tsx:406
 msgid "{0}'s avatar"
-msgstr ""
+msgstr "abhatár {0}"
 
 #: src/components/LabelingServiceCard/index.tsx:71
 msgid "{count, plural, one {Liked by # user} other {Liked by # users}}"
-msgstr "{count, plural, one {Molta ag # úsáideoir amháin} two {Molta ag # úsáideoir} few {Molta ag # úsáideoir} many {Molta ag # n-úsáideoir} other {Molta ag # úsáideoir}}"
+msgstr "{count, plural, one {Molta ag úsáideoir amháin} two {Molta ag beirt úsáideoirí} few {Molta ag # úsáideoir} many {Molta ag # n-úsáideoir} other {Molta ag # úsáideoir}}"
 
 #: src/screens/SignupQueued.tsx:207
 msgid "{estimatedTimeHrs, plural, one {hour} other {hours}}"
@@ -90,8 +88,7 @@ msgstr "{estimatedTimeHrs, plural, one {uair} two {uair} few {uair} many {uair} 
 msgid "{estimatedTimeMins, plural, one {minute} other {minutes}}"
 msgstr "{estimatedTimeMins, plural, one {nóiméad} two {nóiméad} few {nóiméad} many {nóiméad} other {nóiméad}}"
 
-#: src/components/ProfileHoverCard/index.web.tsx:457
-#: src/screens/Profile/Header/Metrics.tsx:50
+#: src/components/ProfileHoverCard/index.web.tsx:457 src/screens/Profile/Header/Metrics.tsx:50
 msgid "{following} following"
 msgstr "{following} á leanúint"
 
@@ -99,11 +96,9 @@ msgstr "{following} á leanúint"
 msgid "{handle} can't be messaged"
 msgstr "Ní féidir TD a chur chuig {handle}"
 
-#: src/screens/Profile/Header/ProfileHeaderLabeler.tsx:286
-#: src/screens/Profile/Header/ProfileHeaderLabeler.tsx:299
-#: src/view/screens/ProfileFeed.tsx:585
+#: src/screens/Profile/Header/ProfileHeaderLabeler.tsx:286 src/screens/Profile/Header/ProfileHeaderLabeler.tsx:299 src/view/screens/ProfileFeed.tsx:585
 msgid "{likeCount, plural, one {Liked by # user} other {Liked by # users}}"
-msgstr "{likeCount, plural, one {Molta ag # úsáideoir amháin} two {Molta ag # úsáideoir} few {Molta ag # úsáideoir} many {Molta ag # n-úsáideoir} other {Molta ag # úsáideoir}}"
+msgstr "{likeCount, plural, one {Molta ag úsáideoir amháin} two {Molta ag beirt úsáideoirí} few {Molta ag # úsáideoir} many {Molta ag # n-úsáideoir} other {Molta ag # úsáideoir}}"
 
 #: src/view/shell/Drawer.tsx:461
 msgid "{numUnreadNotifications} unread"
@@ -111,7 +106,7 @@ msgstr "{numUnreadNotifications} gan léamh"
 
 #: src/view/screens/PreferencesFollowingFeed.tsx:67
 msgid "{value, plural, =0 {Show all replies} one {Show replies with at least # like} other {Show replies with at least # likes}}"
-msgstr "{value, plural, =0 {Taispeáin gach freagra} one {Taispeáin freagraí a bhfuil ar a laghad # mholadh acu} two {Taispeáin freagraí a bhfuil ar a laghad # mholadh acu} few {Taispeáin freagraí a bhfuil ar a laghad # mholadh acu} many {Taispeáin freagraí a bhfuil ar a laghad # moladh acu} other {Taispeáin freagraí a bhfuil ar a laghad # moladh acu}}"
+msgstr "{value, plural, =0 {Taispeáin gach freagra} one {Taispeáin freagraí a bhfuil ar a laghad moladh amháin acu} two {Taispeáin freagraí a bhfuil ar a laghad # mholadh acu} few {Taispeáin freagraí a bhfuil ar a laghad # mholadh acu} many {Taispeáin freagraí a bhfuil ar a laghad # moladh acu} other {Taispeáin freagraí a bhfuil ar a laghad # moladh acu}}"
 
 #: src/view/com/threadgate/WhoCanReply.tsx:159
 msgid "<0/> members"
@@ -125,33 +120,9 @@ msgstr "<0>{0}</0> {1, plural, one {leantóir} two {leantóir} few {leantóir} m
 msgid "<0>{0}</0> {1, plural, one {following} other {following}}"
 msgstr "<0>{0}</0> {1, plural, one {á leanúint} two {á leanúint} few {á leanúint} many {á leanúint} other {á leanúint}}"
 
-#: src/view/shell/Drawer.tsx:96
-#~ msgid "<0>{0}</0> following"
-#~ msgstr "<0>{0}</0> á leanúint"
-
-#: src/components/ProfileHoverCard/index.web.tsx:437
-#~ msgid "<0>{followers} </0><1>{pluralizedFollowers}</1>"
-#~ msgstr "<0>{following} </0><1>{pluralizedFollowers}</1>"
-
-#: src/components/ProfileHoverCard/index.web.tsx:NaN
-#~ msgid "<0>{following} </0><1>following</1>"
-#~ msgstr "<0>{following} </0><1>á leanúint</1>"
-
-#: src/view/com/auth/onboarding/RecommendedFeeds.tsx:31
-#~ msgid "<0>Choose your</0><1>Recommended</1><2>Feeds</2>"
-#~ msgstr "<0>Roghnaigh do chuid</0><1>Fothaí</1><2>Molta</2>"
-
-#: src/view/com/auth/onboarding/RecommendedFollows.tsx:38
-#~ msgid "<0>Follow some</0><1>Recommended</1><2>Users</2>"
-#~ msgstr "<0>Lean cúpla</0><1>Úsáideoirí</1><2>Molta</2>"
-
 #: src/view/com/modals/SelfLabel.tsx:135
 msgid "<0>Not Applicable.</0> This warning is only available for posts with media attached."
 msgstr "<0>Neamhbhainteach.</0> Níl an rabhadh seo ar fáil ach le haghaidh postálacha a bhfuil meáin ceangailte leo."
-
-#: src/view/com/auth/onboarding/WelcomeDesktop.tsx:21
-#~ msgid "<0>Welcome to</0><1>Bluesky</1>"
-#~ msgstr "<0>Fáilte go</0><1>Bluesky</1>"
 
 #: src/screens/Profile/Header/Handle.tsx:43
 msgid "⚠Invalid Handle"
@@ -161,8 +132,7 @@ msgstr "⚠Leasainm Neamhbhailí"
 msgid "2FA Confirmation"
 msgstr "Dearbhú 2FA"
 
-#: src/view/com/util/ViewHeader.tsx:92
-#: src/view/screens/Search/Search.tsx:714
+#: src/view/com/util/ViewHeader.tsx:92 src/view/screens/Search/Search.tsx:714
 msgid "Access navigation links and settings"
 msgstr "Oscail nascanna agus socruithe"
 
@@ -170,8 +140,7 @@ msgstr "Oscail nascanna agus socruithe"
 msgid "Access profile and other navigation links"
 msgstr "Oscail próifíl agus nascanna eile"
 
-#: src/view/com/modals/EditImage.tsx:300
-#: src/view/screens/Settings/index.tsx:518
+#: src/view/com/modals/EditImage.tsx:300 src/view/screens/Settings/index.tsx:518
 msgid "Accessibility"
 msgstr "Inrochtaineacht"
 
@@ -179,18 +148,11 @@ msgstr "Inrochtaineacht"
 msgid "Accessibility settings"
 msgstr "Socruithe inrochtaineachta"
 
-#: src/Navigation.tsx:290
-#: src/view/screens/AccessibilitySettings.tsx:63
+#: src/Navigation.tsx:290 src/view/screens/AccessibilitySettings.tsx:63
 msgid "Accessibility Settings"
 msgstr "Socruithe Inrochtaineachta"
 
-#: src/components/moderation/LabelsOnMe.tsx:42
-#~ msgid "account"
-#~ msgstr "cuntas"
-
-#: src/screens/Login/LoginForm.tsx:167
-#: src/view/screens/Settings/index.tsx:345
-#: src/view/screens/Settings/index.tsx:752
+#: src/screens/Login/LoginForm.tsx:167 src/view/screens/Settings/index.tsx:345 src/view/screens/Settings/index.tsx:752
 msgid "Account"
 msgstr "Cuntas"
 
@@ -206,8 +168,7 @@ msgstr "Cuntas leanaithe"
 msgid "Account muted"
 msgstr "Cuireadh an cuntas i bhfolach"
 
-#: src/components/moderation/ModerationDetailsDialog.tsx:93
-#: src/lib/moderation/useModerationCauseDescription.ts:93
+#: src/components/moderation/ModerationDetailsDialog.tsx:93 src/lib/moderation/useModerationCauseDescription.ts:93
 msgid "Account Muted"
 msgstr "Cuireadh an cuntas i bhfolach"
 
@@ -223,8 +184,7 @@ msgstr "Roghanna cuntais"
 msgid "Account removed from quick access"
 msgstr "Baineadh an cuntas ón mearliosta"
 
-#: src/screens/Profile/Header/ProfileHeaderStandard.tsx:131
-#: src/view/com/profile/ProfileMenu.tsx:131
+#: src/screens/Profile/Header/ProfileHeaderStandard.tsx:131 src/view/com/profile/ProfileMenu.tsx:131
 msgid "Account unblocked"
 msgstr "Cuntas díbhlocáilte"
 
@@ -236,10 +196,7 @@ msgstr "Cuntas díleanaithe"
 msgid "Account unmuted"
 msgstr "Níl an cuntas i bhfolach a thuilleadh"
 
-#: src/components/dialogs/MutedWords.tsx:165
-#: src/view/com/modals/ListAddRemoveUsers.tsx:268
-#: src/view/com/modals/UserAddRemoveLists.tsx:230
-#: src/view/screens/ProfileList.tsx:881
+#: src/components/dialogs/MutedWords.tsx:165 src/view/com/modals/ListAddRemoveUsers.tsx:268 src/view/com/modals/UserAddRemoveLists.tsx:230 src/view/screens/ProfileList.tsx:881
 msgid "Add"
 msgstr "Cuir leis"
 
@@ -251,35 +208,17 @@ msgstr "Cuir rabhadh faoin ábhar leis"
 msgid "Add a user to this list"
 msgstr "Cuir cuntas leis an liosta seo"
 
-#: src/components/dialogs/SwitchAccount.tsx:56
-#: src/screens/Deactivated.tsx:199
-#: src/view/screens/Settings/index.tsx:422
-#: src/view/screens/Settings/index.tsx:431
+#: src/components/dialogs/SwitchAccount.tsx:56 src/screens/Deactivated.tsx:199 src/view/screens/Settings/index.tsx:422 src/view/screens/Settings/index.tsx:431
 msgid "Add account"
 msgstr "Cuir cuntas leis seo"
 
-#: src/view/com/composer/GifAltText.tsx:70
-#: src/view/com/composer/GifAltText.tsx:136
-#: src/view/com/composer/GifAltText.tsx:176
-#: src/view/com/composer/photos/Gallery.tsx:120
-#: src/view/com/composer/photos/Gallery.tsx:187
-#: src/view/com/modals/AltImage.tsx:118
+#: src/view/com/composer/GifAltText.tsx:70 src/view/com/composer/GifAltText.tsx:136 src/view/com/composer/GifAltText.tsx:176 src/view/com/composer/photos/Gallery.tsx:120 src/view/com/composer/photos/Gallery.tsx:187 src/view/com/modals/AltImage.tsx:118
 msgid "Add alt text"
 msgstr "Cuir téacs malartach leis seo"
 
-#: src/view/screens/AppPasswords.tsx:106
-#: src/view/screens/AppPasswords.tsx:148
-#: src/view/screens/AppPasswords.tsx:161
+#: src/view/screens/AppPasswords.tsx:106 src/view/screens/AppPasswords.tsx:148 src/view/screens/AppPasswords.tsx:161
 msgid "Add App Password"
 msgstr "Cuir pasfhocal aipe leis seo"
-
-#: src/view/com/composer/Composer.tsx:467
-#~ msgid "Add link card"
-#~ msgstr "Cuir cárta leanúna leis seo"
-
-#: src/view/com/composer/Composer.tsx:472
-#~ msgid "Add link card:"
-#~ msgstr "Cuir cárta leanúna leis seo:"
 
 #: src/components/dialogs/MutedWords.tsx:158
 msgid "Add mute word for configured settings"
@@ -301,8 +240,7 @@ msgstr "Ná cuir ach fotha réamhshocraithe de na daoine a leanann tú leis seo"
 msgid "Add the following DNS record to your domain:"
 msgstr "Cuir an taifead DNS seo a leanas le d'fhearann:"
 
-#: src/view/com/profile/ProfileMenu.tsx:265
-#: src/view/com/profile/ProfileMenu.tsx:268
+#: src/view/com/profile/ProfileMenu.tsx:265 src/view/com/profile/ProfileMenu.tsx:268
 msgid "Add to Lists"
 msgstr "Cuir le liostaí"
 
@@ -310,12 +248,7 @@ msgstr "Cuir le liostaí"
 msgid "Add to my feeds"
 msgstr "Cuir le mo chuid fothaí"
 
-#: src/view/com/auth/onboarding/RecommendedFeedsItem.tsx:139
-#~ msgid "Added"
-#~ msgstr "Curtha leis"
-
-#: src/view/com/modals/ListAddRemoveUsers.tsx:191
-#: src/view/com/modals/UserAddRemoveLists.tsx:157
+#: src/view/com/modals/ListAddRemoveUsers.tsx:191 src/view/com/modals/UserAddRemoveLists.tsx:157
 msgid "Added to list"
 msgstr "Curtha leis an liosta"
 
@@ -327,8 +260,7 @@ msgstr "Curtha le mo chuid fothaí"
 msgid "Adjust the number of likes a reply must have to be shown in your feed."
 msgstr "Sonraigh an méid moltaí ar fhreagra atá de dhíth le bheith le feiceáil i d'fhotha."
 
-#: src/lib/moderation/useGlobalLabelStrings.ts:34
-#: src/view/com/modals/SelfLabel.tsx:76
+#: src/lib/moderation/useGlobalLabelStrings.ts:34 src/view/com/modals/SelfLabel.tsx:76
 msgid "Adult Content"
 msgstr "Ábhar do dhaoine fásta"
 
@@ -336,8 +268,7 @@ msgstr "Ábhar do dhaoine fásta"
 msgid "Adult content is disabled."
 msgstr "Tá ábhar do dhaoine fásta curtha ar ceal."
 
-#: src/screens/Moderation/index.tsx:375
-#: src/view/screens/Settings/index.tsx:686
+#: src/screens/Moderation/index.tsx:375 src/view/screens/Settings/index.tsx:686
 msgid "Advanced"
 msgstr "Ardleibhéal"
 
@@ -345,18 +276,15 @@ msgstr "Ardleibhéal"
 msgid "All the feeds you've saved, right in one place."
 msgstr "Na fothaí go léir a shábháil tú, in áit amháin."
 
-#: src/view/com/modals/AddAppPasswords.tsx:188
-#: src/view/com/modals/AddAppPasswords.tsx:195
+#: src/view/com/modals/AddAppPasswords.tsx:188 src/view/com/modals/AddAppPasswords.tsx:195
 msgid "Allow access to your direct messages"
 msgstr "Ceadaigh fáil ar do chuid TDanna"
 
-#: src/screens/Messages/Settings.tsx:62
-#: src/screens/Messages/Settings.tsx:65
+#: src/screens/Messages/Settings.tsx:62 src/screens/Messages/Settings.tsx:65
 msgid "Allow new messages from"
 msgstr "Ceadaigh teachtaireachtaí nua ó"
 
-#: src/screens/Login/ForgotPasswordForm.tsx:178
-#: src/view/com/modals/ChangePassword.tsx:171
+#: src/screens/Login/ForgotPasswordForm.tsx:178 src/view/com/modals/ChangePassword.tsx:171
 msgid "Already have a code?"
 msgstr "An bhfuil cód agat cheana?"
 
@@ -364,15 +292,11 @@ msgstr "An bhfuil cód agat cheana?"
 msgid "Already signed in as @{0}"
 msgstr "Logáilte isteach cheana mar @{0}"
 
-#: src/view/com/composer/GifAltText.tsx:94
-#: src/view/com/composer/photos/Gallery.tsx:144
-#: src/view/com/util/post-embeds/GifEmbed.tsx:173
+#: src/view/com/composer/GifAltText.tsx:94 src/view/com/composer/photos/Gallery.tsx:144 src/view/com/util/post-embeds/GifEmbed.tsx:173
 msgid "ALT"
 msgstr "ALT"
 
-#: src/view/com/composer/GifAltText.tsx:145
-#: src/view/com/modals/EditImage.tsx:316
-#: src/view/screens/AccessibilitySettings.tsx:77
+#: src/view/com/composer/GifAltText.tsx:145 src/view/com/modals/EditImage.tsx:316 src/view/screens/AccessibilitySettings.tsx:77
 msgid "Alt text"
 msgstr "Téacs malartach"
 
@@ -384,8 +308,7 @@ msgstr "Téacs Malartach"
 msgid "Alt text describes images for blind and low-vision users, and helps give context to everyone."
 msgstr "Cuireann an téacs malartach síos ar na híomhánna do dhaoine atá dall nó a bhfuil lagú radhairc orthu agus cuireann sé an comhthéacs ar fáil do chuile dhuine."
 
-#: src/view/com/modals/VerifyEmail.tsx:132
-#: src/view/screens/Settings/DisableEmail2FADialog.tsx:96
+#: src/view/com/modals/VerifyEmail.tsx:132 src/view/screens/Settings/DisableEmail2FADialog.tsx:96
 msgid "An email has been sent to {0}. It includes a confirmation code which you can enter below."
 msgstr "Cuireadh teachtaireacht ríomhphoist chuig {0}. Tá cód dearbhaithe faoi iamh. Is féidir leat an cód a chur isteach thíos anseo."
 
@@ -397,16 +320,15 @@ msgstr "Cuireadh teachtaireacht ríomhphoist chuig do sheanseoladh. {0}. Tá có
 msgid "An error occured"
 msgstr "Tharla earráid"
 
+#: src/components/dms/MessageMenu.tsx:134
+msgid "An error occurred while trying to delete the message. Please try again."
+msgstr "Tharla earráid agus an teachtaireacht á scriosadh. Bain triail eile as."
+
 #: src/lib/moderation/useReportOptions.ts:27
 msgid "An issue not included in these options"
 msgstr "Rud nach bhfuil ar fáil sna roghanna seo"
 
-#: src/components/hooks/useFollowMethods.ts:35
-#: src/components/hooks/useFollowMethods.ts:50
-#: src/view/com/profile/FollowButton.tsx:35
-#: src/view/com/profile/FollowButton.tsx:45
-#: src/view/com/profile/ProfileHeaderSuggestedFollows.tsx:188
-#: src/view/com/profile/ProfileHeaderSuggestedFollows.tsx:198
+#: src/components/hooks/useFollowMethods.ts:35 src/components/hooks/useFollowMethods.ts:50 src/view/com/profile/FollowButton.tsx:35 src/view/com/profile/FollowButton.tsx:45 src/view/com/profile/ProfileHeaderSuggestedFollows.tsx:188 src/view/com/profile/ProfileHeaderSuggestedFollows.tsx:198
 msgid "An issue occurred, please try again."
 msgstr "Tharla fadhb. Déan iarracht eile, le do thoil."
 
@@ -414,8 +336,7 @@ msgstr "Tharla fadhb. Déan iarracht eile, le do thoil."
 msgid "an unknown error occurred"
 msgstr "tharla earráid nach eol dúinn"
 
-#: src/view/com/notifications/FeedItem.tsx:258
-#: src/view/com/threadgate/WhoCanReply.tsx:180
+#: src/view/com/notifications/FeedItem.tsx:258 src/view/com/threadgate/WhoCanReply.tsx:180
 msgid "and"
 msgstr "agus"
 
@@ -451,14 +372,11 @@ msgstr "Caithfear 4 charachtar ar a laghad a bheith in ainmneacha phasfhocal na 
 msgid "App password settings"
 msgstr "Socruithe phasfhocal na haipe"
 
-#: src/Navigation.tsx:258
-#: src/view/screens/AppPasswords.tsx:192
-#: src/view/screens/Settings/index.tsx:706
+#: src/Navigation.tsx:258 src/view/screens/AppPasswords.tsx:192 src/view/screens/Settings/index.tsx:706
 msgid "App Passwords"
 msgstr "Pasfhocal na haipe"
 
-#: src/components/moderation/LabelsOnMeDialog.tsx:153
-#: src/components/moderation/LabelsOnMeDialog.tsx:156
+#: src/components/moderation/LabelsOnMeDialog.tsx:153 src/components/moderation/LabelsOnMeDialog.tsx:156
 msgid "Appeal"
 msgstr "Achomharc"
 
@@ -466,19 +384,11 @@ msgstr "Achomharc"
 msgid "Appeal \"{0}\" label"
 msgstr "Achomharc in aghaidh lipéid \"{0}\""
 
-#: src/components/moderation/LabelsOnMeDialog.tsx:229
-#: src/screens/Messages/Conversation/ChatDisabled.tsx:91
+#: src/components/moderation/LabelsOnMeDialog.tsx:229 src/screens/Messages/Conversation/ChatDisabled.tsx:91
 msgid "Appeal submitted"
 msgstr "Achomharc déanta"
 
-#: src/components/moderation/LabelsOnMeDialog.tsx:193
-#~ msgid "Appeal submitted."
-#~ msgstr "Achomharc déanta"
-
-#: src/screens/Messages/Conversation/ChatDisabled.tsx:51
-#: src/screens/Messages/Conversation/ChatDisabled.tsx:53
-#: src/screens/Messages/Conversation/ChatDisabled.tsx:99
-#: src/screens/Messages/Conversation/ChatDisabled.tsx:101
+#: src/screens/Messages/Conversation/ChatDisabled.tsx:51 src/screens/Messages/Conversation/ChatDisabled.tsx:53 src/screens/Messages/Conversation/ChatDisabled.tsx:99 src/screens/Messages/Conversation/ChatDisabled.tsx:101
 msgid "Appeal this decision"
 msgstr "Déan achomharc i gcoinne an chinnidh seo"
 
@@ -486,8 +396,7 @@ msgstr "Déan achomharc i gcoinne an chinnidh seo"
 msgid "Appearance"
 msgstr "Cuma"
 
-#: src/screens/Feeds/NoSavedFeedsOfAnyType.tsx:47
-#: src/screens/Home/NoFeedsPinned.tsx:106
+#: src/screens/Feeds/NoSavedFeedsOfAnyType.tsx:47 src/screens/Home/NoFeedsPinned.tsx:106
 msgid "Apply default recommended feeds"
 msgstr "Bain úsáid as fothaí réamhshocraithe a moladh"
 
@@ -531,28 +440,9 @@ msgstr "Lomnochtacht ealaíonta nó gan a bheith gáirsiúil."
 msgid "At least 3 characters"
 msgstr "3 charachtar ar a laghad"
 
-#: src/components/dms/MessagesListHeader.tsx:75
-#: src/components/moderation/LabelsOnMeDialog.tsx:283
-#: src/components/moderation/LabelsOnMeDialog.tsx:284
-#: src/screens/Login/ChooseAccountForm.tsx:98
-#: src/screens/Login/ChooseAccountForm.tsx:103
-#: src/screens/Login/ForgotPasswordForm.tsx:129
-#: src/screens/Login/ForgotPasswordForm.tsx:135
-#: src/screens/Login/LoginForm.tsx:275
-#: src/screens/Login/LoginForm.tsx:281
-#: src/screens/Login/SetNewPasswordForm.tsx:160
-#: src/screens/Login/SetNewPasswordForm.tsx:166
-#: src/screens/Messages/Conversation/ChatDisabled.tsx:133
-#: src/screens/Messages/Conversation/ChatDisabled.tsx:134
-#: src/screens/Profile/Header/Shell.tsx:102
-#: src/screens/Signup/index.tsx:193
-#: src/view/com/util/ViewHeader.tsx:90
+#: src/components/dms/MessagesListHeader.tsx:75 src/components/moderation/LabelsOnMeDialog.tsx:283 src/components/moderation/LabelsOnMeDialog.tsx:284 src/screens/Login/ChooseAccountForm.tsx:98 src/screens/Login/ChooseAccountForm.tsx:103 src/screens/Login/ForgotPasswordForm.tsx:129 src/screens/Login/ForgotPasswordForm.tsx:135 src/screens/Login/LoginForm.tsx:275 src/screens/Login/LoginForm.tsx:281 src/screens/Login/SetNewPasswordForm.tsx:160 src/screens/Login/SetNewPasswordForm.tsx:166 src/screens/Messages/Conversation/ChatDisabled.tsx:133 src/screens/Messages/Conversation/ChatDisabled.tsx:134 src/screens/Profile/Header/Shell.tsx:102 src/screens/Signup/index.tsx:193 src/view/com/util/ViewHeader.tsx:90
 msgid "Back"
 msgstr "Ar ais"
-
-#: src/screens/Onboarding/StepSuggestedAccounts/index.tsx:144
-#~ msgid "Based on your interest in {interestsText}"
-#~ msgstr "Toisc go bhfuil suim agat in {interestsText}"
 
 #: src/view/screens/Settings/index.tsx:496
 msgid "Basics"
@@ -566,18 +456,15 @@ msgstr "Breithlá"
 msgid "Birthday:"
 msgstr "Breithlá:"
 
-#: src/screens/Profile/Header/ProfileHeaderStandard.tsx:295
-#: src/view/com/profile/ProfileMenu.tsx:363
+#: src/screens/Profile/Header/ProfileHeaderStandard.tsx:295 src/view/com/profile/ProfileMenu.tsx:363
 msgid "Block"
 msgstr "Blocáil"
 
-#: src/components/dms/ConvoMenu.tsx:188
-#: src/components/dms/ConvoMenu.tsx:192
+#: src/components/dms/ConvoMenu.tsx:188 src/components/dms/ConvoMenu.tsx:192
 msgid "Block account"
 msgstr "Blocáil an cuntas seo"
 
-#: src/view/com/profile/ProfileMenu.tsx:302
-#: src/view/com/profile/ProfileMenu.tsx:309
+#: src/view/com/profile/ProfileMenu.tsx:302 src/view/com/profile/ProfileMenu.tsx:309
 msgid "Block Account"
 msgstr "Blocáil an cuntas seo"
 
@@ -597,8 +484,7 @@ msgstr "Liosta blocála"
 msgid "Block these accounts?"
 msgstr "An bhfuil fonn ort na cuntais seo a bhlocáil?"
 
-#: src/view/com/lists/ListCard.tsx:112
-#: src/view/com/util/post-embeds/QuoteEmbed.tsx:75
+#: src/view/com/lists/ListCard.tsx:112 src/view/com/util/post-embeds/QuoteEmbed.tsx:75
 msgid "Blocked"
 msgstr "Blocáilte"
 
@@ -606,8 +492,7 @@ msgstr "Blocáilte"
 msgid "Blocked accounts"
 msgstr "Cuntais bhlocáilte"
 
-#: src/Navigation.tsx:141
-#: src/view/screens/ModerationBlockedAccounts.tsx:109
+#: src/Navigation.tsx:141 src/view/screens/ModerationBlockedAccounts.tsx:109
 msgid "Blocked Accounts"
 msgstr "Cuntais bhlocáilte"
 
@@ -639,26 +524,13 @@ msgstr "Ní chuirfidh blocáil cosc ar lipéid a bheith curtha ar do chuntas, ac
 msgid "Blog"
 msgstr "Blag"
 
-#: src/view/com/auth/server-input/index.tsx:89
-#: src/view/com/auth/server-input/index.tsx:91
+#: src/view/com/auth/server-input/index.tsx:89 src/view/com/auth/server-input/index.tsx:91
 msgid "Bluesky"
 msgstr "Bluesky"
 
 #: src/view/com/auth/server-input/index.tsx:154
 msgid "Bluesky is an open network where you can choose your hosting provider. Custom hosting is now available in beta for developers."
 msgstr "Is líonra oscailte é Bluesky, lenar féidir leat do sholáthraí óstála féin a roghnú. Tá leagan béite d'óstáil shaincheaptha ar fáil d'fhorbróirí anois."
-
-#: src/view/com/auth/onboarding/WelcomeDesktop.tsx:NaN
-#~ msgid "Bluesky is flexible."
-#~ msgstr "Tá Bluesky solúbtha."
-
-#: src/view/com/auth/onboarding/WelcomeDesktop.tsx:NaN
-#~ msgid "Bluesky is open."
-#~ msgstr "Tá Bluesky oscailte."
-
-#: src/view/com/auth/onboarding/WelcomeDesktop.tsx:NaN
-#~ msgid "Bluesky is public."
-#~ msgstr "Tá Bluesky poiblí."
 
 #: src/screens/Moderation/index.tsx:533
 msgid "Bluesky will not show your profile and posts to logged-out users. Other apps may not honor this request. This does not make your account private."
@@ -676,8 +548,7 @@ msgstr "Déan íomhánna doiléir agus scag ó fhothaí iad"
 msgid "Books"
 msgstr "Leabhair"
 
-#: src/screens/Home/NoFeedsPinned.tsx:116
-#: src/screens/Home/NoFeedsPinned.tsx:123
+#: src/screens/Home/NoFeedsPinned.tsx:116 src/screens/Home/NoFeedsPinned.tsx:123
 msgid "Browse other feeds"
 msgstr "Tabhair súil ar fhothaí eile"
 
@@ -689,17 +560,9 @@ msgstr "Gnó"
 msgid "by —"
 msgstr "le —"
 
-#: src/view/com/auth/onboarding/RecommendedFeedsItem.tsx:100
-#~ msgid "by {0}"
-#~ msgstr "le {0}"
-
 #: src/components/LabelingServiceCard/index.tsx:56
 msgid "By {0}"
 msgstr "Le {0}"
-
-#: src/screens/Onboarding/StepAlgoFeeds/FeedCard.tsx:112
-#~ msgid "by @{0}"
-#~ msgstr "ag @{0}"
 
 #: src/view/com/profile/ProfileSubpageHeader.tsx:163
 msgid "by <0/>"
@@ -721,43 +584,16 @@ msgstr "Ceamara"
 msgid "Can only contain letters, numbers, spaces, dashes, and underscores. Must be at least 4 characters long, but no more than 32 characters long."
 msgstr "Ní féidir ach litreacha, uimhreacha, spásanna, daiseanna agus fostríocanna a bheith ann. Caithfear 4 charachtar ar a laghad a bheith ann agus gan níos mó ná 32 charachtar."
 
-#: src/components/Menu/index.tsx:215
-#: src/components/Prompt.tsx:119
-#: src/components/Prompt.tsx:121
-#: src/components/TagMenu/index.tsx:268
-#: src/screens/Deactivated.tsx:161
-#: src/view/com/composer/Composer.tsx:417
-#: src/view/com/composer/Composer.tsx:423
-#: src/view/com/modals/ChangeEmail.tsx:213
-#: src/view/com/modals/ChangeEmail.tsx:215
-#: src/view/com/modals/ChangeHandle.tsx:148
-#: src/view/com/modals/ChangePassword.tsx:268
-#: src/view/com/modals/ChangePassword.tsx:271
-#: src/view/com/modals/CreateOrEditList.tsx:344
-#: src/view/com/modals/crop-image/CropImage.web.tsx:162
-#: src/view/com/modals/EditImage.tsx:324
-#: src/view/com/modals/EditProfile.tsx:250
-#: src/view/com/modals/InAppBrowserConsent.tsx:78
-#: src/view/com/modals/InAppBrowserConsent.tsx:80
-#: src/view/com/modals/LinkWarning.tsx:105
-#: src/view/com/modals/LinkWarning.tsx:107
-#: src/view/com/modals/VerifyEmail.tsx:255
-#: src/view/com/modals/VerifyEmail.tsx:261
-#: src/view/com/util/post-ctrls/RepostButton.tsx:136
-#: src/view/screens/Search/Search.tsx:738
-#: src/view/shell/desktop/Search.tsx:218
+#: src/components/Menu/index.tsx:215 src/components/Prompt.tsx:119 src/components/Prompt.tsx:121 src/components/TagMenu/index.tsx:268 src/screens/Deactivated.tsx:161 src/view/com/composer/Composer.tsx:417 src/view/com/composer/Composer.tsx:423 src/view/com/modals/ChangeEmail.tsx:213 src/view/com/modals/ChangeEmail.tsx:215 src/view/com/modals/ChangeHandle.tsx:148 src/view/com/modals/ChangePassword.tsx:268 src/view/com/modals/ChangePassword.tsx:271 src/view/com/modals/CreateOrEditList.tsx:344 src/view/com/modals/crop-image/CropImage.web.tsx:162 src/view/com/modals/EditImage.tsx:324 src/view/com/modals/EditProfile.tsx:250 src/view/com/modals/InAppBrowserConsent.tsx:78 src/view/com/modals/InAppBrowserConsent.tsx:80 src/view/com/modals/LinkWarning.tsx:105 src/view/com/modals/LinkWarning.tsx:107 src/view/com/modals/VerifyEmail.tsx:255 src/view/com/modals/VerifyEmail.tsx:261 src/view/com/util/post-ctrls/RepostButton.tsx:136 src/view/screens/Search/Search.tsx:738 src/view/shell/desktop/Search.tsx:218
 msgid "Cancel"
 msgstr "Cealaigh"
 
-#: src/view/com/modals/CreateOrEditList.tsx:349
-#: src/view/com/modals/DeleteAccount.tsx:174
-#: src/view/com/modals/DeleteAccount.tsx:296
+#: src/view/com/modals/CreateOrEditList.tsx:349 src/view/com/modals/DeleteAccount.tsx:174 src/view/com/modals/DeleteAccount.tsx:296
 msgctxt "action"
 msgid "Cancel"
 msgstr "Cealaigh"
 
-#: src/view/com/modals/DeleteAccount.tsx:170
-#: src/view/com/modals/DeleteAccount.tsx:292
+#: src/view/com/modals/DeleteAccount.tsx:170 src/view/com/modals/DeleteAccount.tsx:292
 msgid "Cancel account deletion"
 msgstr "Ná scrios an chuntas"
 
@@ -779,10 +615,9 @@ msgstr "Ná déan athlua na postála"
 
 #: src/screens/Deactivated.tsx:155
 msgid "Cancel reactivation and log out"
-msgstr ""
+msgstr "Cuir an t-athghníomhú ar ceal agus logáil amach"
 
-#: src/view/com/modals/ListAddRemoveUsers.tsx:87
-#: src/view/shell/desktop/Search.tsx:214
+#: src/view/com/modals/ListAddRemoveUsers.tsx:87 src/view/shell/desktop/Search.tsx:214
 msgid "Cancel search"
 msgstr "Cealaigh an cuardach"
 
@@ -803,8 +638,7 @@ msgstr "Athraigh"
 msgid "Change handle"
 msgstr "Athraigh mo leasainm"
 
-#: src/view/com/modals/ChangeHandle.tsx:156
-#: src/view/screens/Settings/index.tsx:729
+#: src/view/com/modals/ChangeHandle.tsx:156 src/view/screens/Settings/index.tsx:729
 msgid "Change Handle"
 msgstr "Athraigh mo leasainm"
 
@@ -816,8 +650,7 @@ msgstr "Athraigh mo ríomhphost"
 msgid "Change password"
 msgstr "Athraigh mo phasfhocal"
 
-#: src/view/com/modals/ChangePassword.tsx:142
-#: src/view/screens/Settings/index.tsx:774
+#: src/view/com/modals/ChangePassword.tsx:142 src/view/screens/Settings/index.tsx:774
 msgid "Change Password"
 msgstr "Athraigh mo phasfhocal"
 
@@ -829,9 +662,7 @@ msgstr "Athraigh an teanga phostála go {0}"
 msgid "Change Your Email"
 msgstr "Athraigh do ríomhphost"
 
-#: src/Navigation.tsx:302
-#: src/view/shell/bottom-bar/BottomBar.tsx:201
-#: src/view/shell/desktop/LeftNav.tsx:295
+#: src/Navigation.tsx:302 src/view/shell/bottom-bar/BottomBar.tsx:201 src/view/shell/desktop/LeftNav.tsx:295
 msgid "Chat"
 msgstr "Comhrá"
 
@@ -839,16 +670,11 @@ msgstr "Comhrá"
 msgid "Chat muted"
 msgstr "Balbhaíodh an comhrá"
 
-#: src/components/dms/ConvoMenu.tsx:112
-#: src/components/dms/MessageMenu.tsx:81
-#: src/Navigation.tsx:307
-#: src/screens/Messages/List/index.tsx:88
-#: src/view/screens/Settings/index.tsx:638
+#: src/components/dms/ConvoMenu.tsx:112 src/components/dms/MessageMenu.tsx:81 src/Navigation.tsx:307 src/screens/Messages/List/index.tsx:88 src/view/screens/Settings/index.tsx:638
 msgid "Chat settings"
 msgstr "Socruithe comhrá"
 
-#: src/screens/Messages/Settings.tsx:59
-#: src/view/screens/Settings/index.tsx:647
+#: src/screens/Messages/Settings.tsx:59 src/view/screens/Settings/index.tsx:647
 msgid "Chat Settings"
 msgstr "Socruithe Comhrá"
 
@@ -856,18 +682,13 @@ msgstr "Socruithe Comhrá"
 msgid "Chat unmuted"
 msgstr "Díbhalbhaíodh an comhrá"
 
-#: src/screens/SignupQueued.tsx:78
-#: src/screens/SignupQueued.tsx:82
+#: src/screens/Messages/Conversation/index.tsx:26
+msgid "Chat with {chatId}"
+msgstr "Comhrá le {chatId}"
+
+#: src/screens/SignupQueued.tsx:78 src/screens/SignupQueued.tsx:82
 msgid "Check my status"
 msgstr "Seiceáil mo stádas"
-
-#: src/view/com/auth/onboarding/RecommendedFeeds.tsx:122
-#~ msgid "Check out some recommended feeds. Tap + to add them to your list of pinned feeds."
-#~ msgstr "Cuir súil ar na fothaí seo. Brúigh + len iad a chur le liosta na bhfothaí atá greamaithe agat."
-
-#: src/view/com/auth/onboarding/RecommendedFollows.tsx:186
-#~ msgid "Check out some recommended users. Follow them to see similar users."
-#~ msgstr "Cuir súil ar na húsáideoirí seo. Lean iad le húsáideoirí atá cosúil leo a fheiceáil."
 
 #: src/screens/Login/LoginForm.tsx:268
 msgid "Check your email for a login code and enter it here."
@@ -889,17 +710,9 @@ msgstr "Roghnaigh Seirbhís"
 msgid "Choose the algorithms that power your custom feeds."
 msgstr "Roghnaigh na halgartaim le haghaidh do chuid sainfhothaí."
 
-#: src/view/com/auth/onboarding/WelcomeDesktop.tsx:NaN
-#~ msgid "Choose the algorithms that power your experience with custom feeds."
-#~ msgstr "Roghnaigh na halgartaim a shainíonn an dóigh a n-oibríonn do chuid sainfhothaí."
-
 #: src/screens/Onboarding/StepProfile/AvatarCreatorItems.tsx:107
 msgid "Choose this color as your avatar"
 msgstr "Roghnaigh an dath seo mar abhatár duit"
-
-#: src/screens/Onboarding/StepAlgoFeeds/index.tsx:104
-#~ msgid "Choose your main feeds"
-#~ msgstr "Roghnaigh do phríomhfhothaí"
 
 #: src/screens/Signup/StepInfo/index.tsx:114
 msgid "Choose your password"
@@ -921,8 +734,7 @@ msgstr "Glan na sonraí ar fad atá i dtaisce."
 msgid "Clear all storage data (restart after this)"
 msgstr "Glan na sonraí ar fad atá i dtaisce. Ansin atosaigh."
 
-#: src/view/com/util/forms/SearchInput.tsx:88
-#: src/view/screens/Search/Search.tsx:864
+#: src/view/com/util/forms/SearchInput.tsx:88 src/view/screens/Search/Search.tsx:864
 msgid "Clear search query"
 msgstr "Glan an cuardach"
 
@@ -940,19 +752,15 @@ msgstr "cliceáil anseo"
 
 #: src/view/com/modals/DeleteAccount.tsx:208
 msgid "Click here for more information on deactivating your account"
-msgstr ""
+msgstr "Cliceáil anseo le tuilleadh a fhoghlaim faoi dhíghníomhú do chuntais"
 
 #: src/view/com/modals/DeleteAccount.tsx:216
 msgid "Click here for more information."
-msgstr ""
+msgstr "Cliceáil anseo do bhreis eolais."
 
 #: src/components/TagMenu/index.web.tsx:138
 msgid "Click here to open tag menu for {tag}"
 msgstr "Cliceáil anseo le clár na clibe le haghaidh {tag} a oscailt"
-
-#: src/components/RichText.tsx:198
-#~ msgid "Click here to open tag menu for #{tag}"
-#~ msgstr "Cliceáil anseo le clár na clibe le haghaidh #{tag} a oscailt"
 
 #: src/components/dms/MessageItem.tsx:237
 msgid "Click to retry failed message"
@@ -966,17 +774,11 @@ msgstr "Aeráid"
 msgid "Clip 🐴 clop 🐴"
 msgstr "Trup, Trup a Chapaillín 🐴"
 
-#: src/components/dialogs/GifSelect.ios.tsx:250
-#: src/components/dialogs/GifSelect.tsx:268
-#: src/components/dms/dialogs/SearchablePeopleList.tsx:261
-#: src/view/com/modals/ChangePassword.tsx:268
-#: src/view/com/modals/ChangePassword.tsx:271
-#: src/view/com/util/post-embeds/GifEmbed.tsx:185
+#: src/components/dialogs/GifSelect.ios.tsx:250 src/components/dialogs/GifSelect.tsx:268 src/components/dms/dialogs/SearchablePeopleList.tsx:261 src/view/com/modals/ChangePassword.tsx:268 src/view/com/modals/ChangePassword.tsx:271 src/view/com/util/post-embeds/GifEmbed.tsx:185
 msgid "Close"
 msgstr "Dún"
 
-#: src/components/Dialog/index.web.tsx:113
-#: src/components/Dialog/index.web.tsx:251
+#: src/components/Dialog/index.web.tsx:113 src/components/Dialog/index.web.tsx:251
 msgid "Close active dialog"
 msgstr "Dún an dialóg oscailte"
 
@@ -988,8 +790,7 @@ msgstr "Dún an rabhadh"
 msgid "Close bottom drawer"
 msgstr "Dún an tarraiceán íochtair"
 
-#: src/components/dialogs/GifSelect.ios.tsx:244
-#: src/components/dialogs/GifSelect.tsx:262
+#: src/components/dialogs/GifSelect.ios.tsx:244 src/components/dialogs/GifSelect.tsx:262
 msgid "Close dialog"
 msgstr "Dún an dialóg"
 
@@ -1013,8 +814,7 @@ msgstr "Dún an fhuinneog"
 msgid "Close navigation footer"
 msgstr "Dún an buntásc"
 
-#: src/components/Menu/index.tsx:209
-#: src/components/TagMenu/index.tsx:262
+#: src/components/Menu/index.tsx:209 src/components/TagMenu/index.tsx:262
 msgid "Close this dialog"
 msgstr "Dún an dialóg seo"
 
@@ -1036,7 +836,7 @@ msgstr "Dúnann sé seo an t-amharcóir le haghaidh íomhá an cheanntáisc"
 
 #: src/view/com/notifications/FeedItem.tsx:205
 msgid "Collapse list of users"
-msgstr ""
+msgstr "Laghdaigh an liosta úsáideoirí"
 
 #: src/view/com/notifications/FeedItem.tsx:341
 msgid "Collapses list of users for a given notification"
@@ -1050,8 +850,7 @@ msgstr "Greann"
 msgid "Comics"
 msgstr "Greannáin"
 
-#: src/Navigation.tsx:248
-#: src/view/screens/CommunityGuidelines.tsx:32
+#: src/Navigation.tsx:248 src/view/screens/CommunityGuidelines.tsx:32
 msgid "Community Guidelines"
 msgstr "Treoirlínte an phobail"
 
@@ -1071,10 +870,6 @@ msgstr "Scríobh postálacha chomh fada le {MAX_GRAPHEME_LENGTH} litir agus cara
 msgid "Compose reply"
 msgstr "Scríobh freagra"
 
-#: src/screens/Onboarding/StepModeration/ModerationOption.tsx:81
-#~ msgid "Configure content filtering setting for category: {0}"
-#~ msgstr "Socraigh scagadh an ábhair le haghaidh catagóir: {0}"
-
 #: src/components/moderation/LabelPreference.tsx:81
 msgid "Configure content filtering setting for category: {name}"
 msgstr "Socraigh scagadh an ábhair le haghaidh catagóir: {name}"
@@ -1083,20 +878,11 @@ msgstr "Socraigh scagadh an ábhair le haghaidh catagóir: {name}"
 msgid "Configured in <0>moderation settings</0>."
 msgstr "Le socrú i <0>socruithe na modhnóireachta</0>."
 
-#: src/components/Prompt.tsx:159
-#: src/components/Prompt.tsx:162
-#: src/view/com/modals/SelfLabel.tsx:155
-#: src/view/com/modals/VerifyEmail.tsx:239
-#: src/view/com/modals/VerifyEmail.tsx:241
-#: src/view/screens/PreferencesFollowingFeed.tsx:307
-#: src/view/screens/PreferencesThreads.tsx:159
-#: src/view/screens/Settings/DisableEmail2FADialog.tsx:180
-#: src/view/screens/Settings/DisableEmail2FADialog.tsx:183
+#: src/components/Prompt.tsx:159 src/components/Prompt.tsx:162 src/view/com/modals/SelfLabel.tsx:155 src/view/com/modals/VerifyEmail.tsx:239 src/view/com/modals/VerifyEmail.tsx:241 src/view/screens/PreferencesFollowingFeed.tsx:307 src/view/screens/PreferencesThreads.tsx:159 src/view/screens/Settings/DisableEmail2FADialog.tsx:180 src/view/screens/Settings/DisableEmail2FADialog.tsx:183
 msgid "Confirm"
 msgstr "Dearbhaigh"
 
-#: src/view/com/modals/ChangeEmail.tsx:188
-#: src/view/com/modals/ChangeEmail.tsx:190
+#: src/view/com/modals/ChangeEmail.tsx:188 src/view/com/modals/ChangeEmail.tsx:190
 msgid "Confirm Change"
 msgstr "Dearbhaigh an t-athrú"
 
@@ -1116,13 +902,7 @@ msgstr "Dearbhaigh d'aois:"
 msgid "Confirm your birthdate"
 msgstr "Dearbhaigh do bhreithlá"
 
-#: src/screens/Login/LoginForm.tsx:250
-#: src/view/com/modals/ChangeEmail.tsx:152
-#: src/view/com/modals/DeleteAccount.tsx:238
-#: src/view/com/modals/DeleteAccount.tsx:244
-#: src/view/com/modals/VerifyEmail.tsx:173
-#: src/view/screens/Settings/DisableEmail2FADialog.tsx:143
-#: src/view/screens/Settings/DisableEmail2FADialog.tsx:149
+#: src/screens/Login/LoginForm.tsx:250 src/view/com/modals/ChangeEmail.tsx:152 src/view/com/modals/DeleteAccount.tsx:238 src/view/com/modals/DeleteAccount.tsx:244 src/view/com/modals/VerifyEmail.tsx:173 src/view/screens/Settings/DisableEmail2FADialog.tsx:143 src/view/screens/Settings/DisableEmail2FADialog.tsx:149
 msgid "Confirmation code"
 msgstr "Cód dearbhaithe"
 
@@ -1134,10 +914,6 @@ msgstr "Ag nascadh…"
 msgid "Contact support"
 msgstr "Teagmháil le Support"
 
-#: src/components/moderation/LabelsOnMe.tsx:42
-#~ msgid "content"
-#~ msgstr "ábhar"
-
 #: src/lib/moderation/useGlobalLabelStrings.ts:18
 msgid "Content Blocked"
 msgstr "Ábhar Blocáilte"
@@ -1146,20 +922,15 @@ msgstr "Ábhar Blocáilte"
 msgid "Content filters"
 msgstr "Scagthaí ábhair"
 
-#: src/view/com/modals/lang-settings/ContentLanguagesSettings.tsx:74
-#: src/view/screens/LanguageSettings.tsx:280
+#: src/view/com/modals/lang-settings/ContentLanguagesSettings.tsx:74 src/view/screens/LanguageSettings.tsx:280
 msgid "Content Languages"
 msgstr "Teangacha ábhair"
 
-#: src/components/moderation/ModerationDetailsDialog.tsx:75
-#: src/lib/moderation/useModerationCauseDescription.ts:77
+#: src/components/moderation/ModerationDetailsDialog.tsx:75 src/lib/moderation/useModerationCauseDescription.ts:77
 msgid "Content Not Available"
 msgstr "Ábhar nach bhfuil ar fáil"
 
-#: src/components/moderation/ModerationDetailsDialog.tsx:46
-#: src/components/moderation/ScreenHider.tsx:99
-#: src/lib/moderation/useGlobalLabelStrings.ts:22
-#: src/lib/moderation/useModerationCauseDescription.ts:40
+#: src/components/moderation/ModerationDetailsDialog.tsx:46 src/components/moderation/ScreenHider.tsx:99 src/lib/moderation/useGlobalLabelStrings.ts:22 src/lib/moderation/useModerationCauseDescription.ts:40
 msgid "Content Warning"
 msgstr "Rabhadh ábhair"
 
@@ -1171,8 +942,7 @@ msgstr "Rabhadh ábhair"
 msgid "Context menu backdrop, click to close the menu."
 msgstr "Cúlra an roghchláir comhthéacs, cliceáil chun an roghchlár a dhúnadh."
 
-#: src/screens/Onboarding/StepInterests/index.tsx:253
-#: src/screens/Onboarding/StepProfile/index.tsx:268
+#: src/screens/Onboarding/StepInterests/index.tsx:253 src/screens/Onboarding/StepProfile/index.tsx:268
 msgid "Continue"
 msgstr "Lean ar aghaidh"
 
@@ -1180,19 +950,9 @@ msgstr "Lean ar aghaidh"
 msgid "Continue as {0} (currently signed in)"
 msgstr "Lean ort mar {0} (atá logáilte isteach faoi láthair)"
 
-#: src/screens/Onboarding/StepInterests/index.tsx:250
-#: src/screens/Onboarding/StepProfile/index.tsx:265
-#: src/screens/Signup/index.tsx:213
+#: src/screens/Onboarding/StepInterests/index.tsx:250 src/screens/Onboarding/StepProfile/index.tsx:265 src/screens/Signup/index.tsx:213
 msgid "Continue to next step"
 msgstr "Lean ar aghaidh go dtí an chéad chéim eile"
-
-#: src/screens/Onboarding/StepAlgoFeeds/index.tsx:158
-#~ msgid "Continue to the next step"
-#~ msgstr "Lean ar aghaidh go dtí an chéad chéim eile"
-
-#: src/screens/Onboarding/StepSuggestedAccounts/index.tsx:199
-#~ msgid "Continue to the next step without following any accounts"
-#~ msgstr "Lean ar aghaidh go dtí an chéad chéim eile gan aon chuntas a leanúint"
 
 #: src/screens/Messages/List/ChatListItem.tsx:153
 msgid "Conversation deleted"
@@ -1202,8 +962,7 @@ msgstr "Scriosadh an comhrá"
 msgid "Cooking"
 msgstr "Cócaireacht"
 
-#: src/view/com/modals/AddAppPasswords.tsx:221
-#: src/view/com/modals/InviteCodes.tsx:183
+#: src/view/com/modals/AddAppPasswords.tsx:221 src/view/com/modals/InviteCodes.tsx:183
 msgid "Copied"
 msgstr "Cóipeáilte"
 
@@ -1211,11 +970,7 @@ msgstr "Cóipeáilte"
 msgid "Copied build version to clipboard"
 msgstr "Leagan cóipeáilte sa ghearrthaisce"
 
-#: src/components/dms/MessageMenu.tsx:57
-#: src/view/com/modals/AddAppPasswords.tsx:81
-#: src/view/com/modals/ChangeHandle.tsx:320
-#: src/view/com/modals/InviteCodes.tsx:153
-#: src/view/com/util/forms/PostDropdownBtn.tsx:187
+#: src/components/dms/MessageMenu.tsx:57 src/view/com/modals/AddAppPasswords.tsx:81 src/view/com/modals/ChangeHandle.tsx:320 src/view/com/modals/InviteCodes.tsx:153 src/view/com/util/forms/PostDropdownBtn.tsx:187
 msgid "Copied to clipboard"
 msgstr "Cóipeáilte sa ghearrthaisce"
 
@@ -1235,8 +990,7 @@ msgstr "Cóipeáil"
 msgid "Copy {0}"
 msgstr "Cóipeáil {0}"
 
-#: src/components/dialogs/Embed.tsx:120
-#: src/components/dialogs/Embed.tsx:139
+#: src/components/dialogs/Embed.tsx:120 src/components/dialogs/Embed.tsx:139
 msgid "Copy code"
 msgstr "Cóipeáil an cód"
 
@@ -1244,23 +998,19 @@ msgstr "Cóipeáil an cód"
 msgid "Copy link to list"
 msgstr "Cóipeáil an nasc leis an liosta"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:310
-#: src/view/com/util/forms/PostDropdownBtn.tsx:319
+#: src/view/com/util/forms/PostDropdownBtn.tsx:310 src/view/com/util/forms/PostDropdownBtn.tsx:319
 msgid "Copy link to post"
 msgstr "Cóipeáil an nasc leis an bpostáil"
 
-#: src/components/dms/MessageMenu.tsx:110
-#: src/components/dms/MessageMenu.tsx:112
+#: src/components/dms/MessageMenu.tsx:110 src/components/dms/MessageMenu.tsx:112
 msgid "Copy message text"
 msgstr "Cóipeáil téacs na teachtaireachta"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:288
-#: src/view/com/util/forms/PostDropdownBtn.tsx:290
+#: src/view/com/util/forms/PostDropdownBtn.tsx:288 src/view/com/util/forms/PostDropdownBtn.tsx:290
 msgid "Copy post text"
 msgstr "Cóipeáil téacs na postála"
 
-#: src/Navigation.tsx:253
-#: src/view/screens/CopyrightPolicy.tsx:29
+#: src/Navigation.tsx:253 src/view/screens/CopyrightPolicy.tsx:29
 msgid "Copyright Policy"
 msgstr "An polasaí maidir le cóipcheart"
 
@@ -1276,12 +1026,15 @@ msgstr "Ní féidir an fotha a lódáil"
 msgid "Could not load list"
 msgstr "Ní féidir an liosta a lódáil"
 
+#: src/components/dms/NewChat.tsx:241
+msgid "Could not load profiles. Please try again later."
+msgstr "Níorbh fhéidir próifílí a lódáil. Bain triail eile as ar ball."
+
 #: src/components/dms/ConvoMenu.tsx:88
 msgid "Could not mute chat"
 msgstr "Níor éiríodh ar an gcomhrá a bhalbhú"
 
-#: src/view/com/auth/SplashScreen.tsx:57
-#: src/view/com/auth/SplashScreen.web.tsx:106
+#: src/view/com/auth/SplashScreen.tsx:57 src/view/com/auth/SplashScreen.web.tsx:106
 msgid "Create a new account"
 msgstr "Cruthaigh cuntas nua"
 
@@ -1293,8 +1046,7 @@ msgstr "Cruthaigh cuntas nua Bluesky"
 msgid "Create Account"
 msgstr "Cruthaigh cuntas"
 
-#: src/components/dialogs/Signin.tsx:86
-#: src/components/dialogs/Signin.tsx:88
+#: src/components/dialogs/Signin.tsx:86 src/components/dialogs/Signin.tsx:88
 msgid "Create an account"
 msgstr "Cruthaigh cuntas"
 
@@ -1306,8 +1058,7 @@ msgstr "Cruthaigh abhatár nua ina ionad sin"
 msgid "Create App Password"
 msgstr "Cruthaigh pasfhocal aipe"
 
-#: src/view/com/auth/SplashScreen.tsx:48
-#: src/view/com/auth/SplashScreen.web.tsx:97
+#: src/view/com/auth/SplashScreen.tsx:48 src/view/com/auth/SplashScreen.web.tsx:97
 msgid "Create new account"
 msgstr "Cruthaigh cuntas nua"
 
@@ -1319,16 +1070,11 @@ msgstr "Cruthaigh tuairisc do {0}"
 msgid "Created {0}"
 msgstr "Cruthaíodh {0}"
 
-#: src/view/com/composer/Composer.tsx:469
-#~ msgid "Creates a card with a thumbnail. The card links to {url}"
-#~ msgstr "Cruthaíonn sé seo cárta le mionsamhail. Nascann an cárta le {url}."
-
 #: src/screens/Onboarding/index.tsx:26
 msgid "Culture"
 msgstr "Cultúr"
 
-#: src/view/com/auth/server-input/index.tsx:97
-#: src/view/com/auth/server-input/index.tsx:99
+#: src/view/com/auth/server-input/index.tsx:97 src/view/com/auth/server-input/index.tsx:99
 msgid "Custom"
 msgstr "Saincheaptha"
 
@@ -1344,8 +1090,7 @@ msgstr "Cruthaíonn an pobal fothaí chun eispéiris nua a chur ar fáil duit, a
 msgid "Customize media from external sites."
 msgstr "Oiriúnaigh na meáin ó shuíomhanna seachtracha"
 
-#: src/view/screens/Settings/index.tsx:458
-#: src/view/screens/Settings/index.tsx:484
+#: src/view/screens/Settings/index.tsx:458 src/view/screens/Settings/index.tsx:484
 msgid "Dark"
 msgstr "Dorcha"
 
@@ -1361,14 +1106,13 @@ msgstr "Téama Dorcha"
 msgid "Date of birth"
 msgstr "Dáta breithe"
 
-#: src/screens/Settings/components/DeactivateAccountDialog.tsx:73
-#: src/view/screens/Settings/index.tsx:806
+#: src/screens/Settings/components/DeactivateAccountDialog.tsx:73 src/view/screens/Settings/index.tsx:806
 msgid "Deactivate account"
-msgstr ""
+msgstr "Díghníomhaigh mo chuntas"
 
 #: src/view/screens/Settings/index.tsx:818
 msgid "Deactivate my account"
-msgstr ""
+msgstr "Díghníomhaigh mo chuntas"
 
 #: src/view/screens/Settings/index.tsx:873
 msgid "Debug Moderation"
@@ -1378,20 +1122,13 @@ msgstr "Dífhabhtaigh Modhnóireacht"
 msgid "Debug panel"
 msgstr "Painéal dífhabhtaithe"
 
-#: src/components/dms/MessageMenu.tsx:151
-#: src/view/com/util/forms/PostDropdownBtn.tsx:436
-#: src/view/screens/AppPasswords.tsx:285
-#: src/view/screens/ProfileList.tsx:667
+#: src/components/dms/MessageMenu.tsx:151 src/view/com/util/forms/PostDropdownBtn.tsx:436 src/view/screens/AppPasswords.tsx:285 src/view/screens/ProfileList.tsx:667
 msgid "Delete"
 msgstr "Scrios"
 
 #: src/view/screens/Settings/index.tsx:828
 msgid "Delete account"
 msgstr "Scrios an cuntas"
-
-#: src/view/com/modals/DeleteAccount.tsx:87
-#~ msgid "Delete Account"
-#~ msgstr "Scrios an Cuntas"
 
 #: src/view/com/modals/DeleteAccount.tsx:105
 msgid "Delete Account <0>\"</0><1>{0}</1><2>\"</2>"
@@ -1405,8 +1142,7 @@ msgstr "Scrios pasfhocal na haipe"
 msgid "Delete app password?"
 msgstr "Scrios pasfhocal na haipe?"
 
-#: src/view/screens/Settings/index.tsx:890
-#: src/view/screens/Settings/index.tsx:893
+#: src/view/screens/Settings/index.tsx:890 src/view/screens/Settings/index.tsx:893
 msgid "Delete chat declaration record"
 msgstr "Scrios taifead dearbhaithe comhrá"
 
@@ -1434,8 +1170,7 @@ msgstr "Scrios mo chuntas"
 msgid "Delete My Account…"
 msgstr "Scrios mo chuntas…"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:417
-#: src/view/com/util/forms/PostDropdownBtn.tsx:419
+#: src/view/com/util/forms/PostDropdownBtn.tsx:417 src/view/com/util/forms/PostDropdownBtn.tsx:419
 msgid "Delete post"
 msgstr "Scrios an phostáil"
 
@@ -1459,10 +1194,7 @@ msgstr "Scriosadh an phostáil."
 msgid "Deletes the chat declaration record"
 msgstr "Scriosann sé seo an taifead dearbhaithe comhrá"
 
-#: src/view/com/modals/CreateOrEditList.tsx:289
-#: src/view/com/modals/CreateOrEditList.tsx:310
-#: src/view/com/modals/EditProfile.tsx:199
-#: src/view/com/modals/EditProfile.tsx:211
+#: src/view/com/modals/CreateOrEditList.tsx:289 src/view/com/modals/CreateOrEditList.tsx:310 src/view/com/modals/EditProfile.tsx:199 src/view/com/modals/EditProfile.tsx:211
 msgid "Description"
 msgstr "Cur síos"
 
@@ -1494,20 +1226,7 @@ msgstr "Ná húsáid 2FA trí ríomhphost"
 msgid "Disable haptic feedback"
 msgstr "Ná húsáid aiseolas haptach"
 
-#: src/view/screens/Settings/index.tsx:697
-#~ msgid "Disable haptics"
-#~ msgstr "Ná húsáid aiseolas haptach"
-
-#: src/view/screens/Settings/index.tsx:697
-#~ msgid "Disable vibrations"
-#~ msgstr "Ná húsáid creathadh"
-
-#: src/lib/moderation/useLabelBehaviorDescription.ts:32
-#: src/lib/moderation/useLabelBehaviorDescription.ts:42
-#: src/lib/moderation/useLabelBehaviorDescription.ts:68
-#: src/screens/Messages/Settings.tsx:140
-#: src/screens/Messages/Settings.tsx:143
-#: src/screens/Moderation/index.tsx:341
+#: src/lib/moderation/useLabelBehaviorDescription.ts:32 src/lib/moderation/useLabelBehaviorDescription.ts:42 src/lib/moderation/useLabelBehaviorDescription.ts:68 src/screens/Messages/Settings.tsx:140 src/screens/Messages/Settings.tsx:143 src/screens/Moderation/index.tsx:341
 msgid "Disabled"
 msgstr "Díchumasaithe"
 
@@ -1519,13 +1238,11 @@ msgstr "Ná sábháil"
 msgid "Discard draft?"
 msgstr "Faigh réidh leis an dréacht?"
 
-#: src/screens/Moderation/index.tsx:518
-#: src/screens/Moderation/index.tsx:522
+#: src/screens/Moderation/index.tsx:518 src/screens/Moderation/index.tsx:522
 msgid "Discourage apps from showing my account to logged-out users"
 msgstr "Cuir ina luí ar aipeanna gan mo chuntas a thaispeáint d'úsáideoirí atá logáilte amach"
 
-#: src/view/com/posts/FollowingEmptyState.tsx:74
-#: src/view/com/posts/FollowingEndOfFeed.tsx:75
+#: src/view/com/posts/FollowingEmptyState.tsx:74 src/view/com/posts/FollowingEndOfFeed.tsx:75
 msgid "Discover new custom feeds"
 msgstr "Aimsigh sainfhothaí nua"
 
@@ -1561,32 +1278,11 @@ msgstr "Luach an Fhearainn"
 msgid "Domain verified!"
 msgstr "Fearann dearbhaithe!"
 
-#: src/components/dialogs/BirthDateSettings.tsx:119
-#: src/components/dialogs/BirthDateSettings.tsx:125
-#: src/components/forms/DateField/index.tsx:74
-#: src/components/forms/DateField/index.tsx:80
-#: src/screens/Onboarding/StepProfile/index.tsx:321
-#: src/screens/Onboarding/StepProfile/index.tsx:324
-#: src/view/com/auth/server-input/index.tsx:169
-#: src/view/com/auth/server-input/index.tsx:170
-#: src/view/com/modals/AddAppPasswords.tsx:243
-#: src/view/com/modals/AltImage.tsx:141
-#: src/view/com/modals/crop-image/CropImage.web.tsx:177
-#: src/view/com/modals/InviteCodes.tsx:81
-#: src/view/com/modals/InviteCodes.tsx:124
-#: src/view/com/modals/ListAddRemoveUsers.tsx:142
-#: src/view/screens/PreferencesFollowingFeed.tsx:310
+#: src/components/dialogs/BirthDateSettings.tsx:119 src/components/dialogs/BirthDateSettings.tsx:125 src/components/forms/DateField/index.tsx:74 src/components/forms/DateField/index.tsx:80 src/screens/Onboarding/StepProfile/index.tsx:321 src/screens/Onboarding/StepProfile/index.tsx:324 src/view/com/auth/server-input/index.tsx:169 src/view/com/auth/server-input/index.tsx:170 src/view/com/modals/AddAppPasswords.tsx:243 src/view/com/modals/AltImage.tsx:141 src/view/com/modals/crop-image/CropImage.web.tsx:177 src/view/com/modals/InviteCodes.tsx:81 src/view/com/modals/InviteCodes.tsx:124 src/view/com/modals/ListAddRemoveUsers.tsx:142 src/view/screens/PreferencesFollowingFeed.tsx:310
 msgid "Done"
 msgstr "Déanta"
 
-#: src/view/com/modals/EditImage.tsx:334
-#: src/view/com/modals/ListAddRemoveUsers.tsx:144
-#: src/view/com/modals/SelfLabel.tsx:158
-#: src/view/com/modals/Threadgate.tsx:130
-#: src/view/com/modals/Threadgate.tsx:133
-#: src/view/com/modals/UserAddRemoveLists.tsx:108
-#: src/view/com/modals/UserAddRemoveLists.tsx:111
-#: src/view/screens/PreferencesThreads.tsx:162
+#: src/view/com/modals/EditImage.tsx:334 src/view/com/modals/ListAddRemoveUsers.tsx:144 src/view/com/modals/SelfLabel.tsx:158 src/view/com/modals/Threadgate.tsx:130 src/view/com/modals/Threadgate.tsx:133 src/view/com/modals/UserAddRemoveLists.tsx:108 src/view/com/modals/UserAddRemoveLists.tsx:111 src/view/screens/PreferencesThreads.tsx:162
 msgctxt "action"
 msgid "Done"
 msgstr "Déanta"
@@ -1595,18 +1291,13 @@ msgstr "Déanta"
 msgid "Done{extraText}"
 msgstr "Déanta{extraText}"
 
-#: src/view/screens/Settings/ExportCarDialog.tsx:77
-#: src/view/screens/Settings/ExportCarDialog.tsx:81
+#: src/view/screens/Settings/ExportCarDialog.tsx:77 src/view/screens/Settings/ExportCarDialog.tsx:81
 msgid "Download CAR file"
 msgstr "Íoslódáil comhad CAR"
 
 #: src/view/com/composer/text-input/TextInput.web.tsx:261
 msgid "Drop to add images"
 msgstr "Scaoil anseo chun íomhánna a chur leis"
-
-#: src/screens/Onboarding/StepModeration/AdultContentEnabledPref.tsx:120
-#~ msgid "Due to Apple policies, adult content can only be enabled on the web after completing sign up."
-#~ msgstr "De bharr pholasaí Apple, ní féidir ábhar do dhaoine fásta ar an nGréasán a fháil roimh an logáil isteach a chríochnú."
 
 #: src/view/com/modals/ChangeHandle.tsx:252
 msgid "e.g. alice"
@@ -1653,13 +1344,11 @@ msgctxt "action"
 msgid "Edit"
 msgstr "Eagar"
 
-#: src/view/com/util/UserAvatar.tsx:312
-#: src/view/com/util/UserBanner.tsx:92
+#: src/view/com/util/UserAvatar.tsx:312 src/view/com/util/UserBanner.tsx:92
 msgid "Edit avatar"
 msgstr "Cuir an t-abhatár in eagar"
 
-#: src/view/com/composer/photos/Gallery.tsx:151
-#: src/view/com/modals/EditImage.tsx:208
+#: src/view/com/composer/photos/Gallery.tsx:151 src/view/com/modals/EditImage.tsx:208
 msgid "Edit image"
 msgstr "Cuir an íomhá seo in eagar"
 
@@ -1671,9 +1360,7 @@ msgstr "Athraigh mionsonraí an liosta"
 msgid "Edit Moderation List"
 msgstr "Athraigh liosta na modhnóireachta"
 
-#: src/Navigation.tsx:263
-#: src/view/screens/Feeds.tsx:495
-#: src/view/screens/SavedFeeds.tsx:93
+#: src/Navigation.tsx:263 src/view/screens/Feeds.tsx:495 src/view/screens/SavedFeeds.tsx:93
 msgid "Edit My Feeds"
 msgstr "Athraigh mo chuid fothaí"
 
@@ -1681,18 +1368,15 @@ msgstr "Athraigh mo chuid fothaí"
 msgid "Edit my profile"
 msgstr "Athraigh mo phróifíl"
 
-#: src/screens/Profile/Header/ProfileHeaderLabeler.tsx:181
-#: src/screens/Profile/Header/ProfileHeaderStandard.tsx:171
+#: src/screens/Profile/Header/ProfileHeaderLabeler.tsx:181 src/screens/Profile/Header/ProfileHeaderStandard.tsx:171
 msgid "Edit profile"
 msgstr "Athraigh an phróifíl"
 
-#: src/screens/Profile/Header/ProfileHeaderLabeler.tsx:184
-#: src/screens/Profile/Header/ProfileHeaderStandard.tsx:174
+#: src/screens/Profile/Header/ProfileHeaderLabeler.tsx:184 src/screens/Profile/Header/ProfileHeaderStandard.tsx:174
 msgid "Edit Profile"
 msgstr "Athraigh an Phróifíl"
 
-#: src/view/com/home/HomeHeaderLayout.web.tsx:76
-#: src/view/screens/Feeds.tsx:416
+#: src/view/com/home/HomeHeaderLayout.web.tsx:76 src/view/screens/Feeds.tsx:416
 msgid "Edit Saved Feeds"
 msgstr "Athraigh na fothaí sábháilte"
 
@@ -1712,8 +1396,7 @@ msgstr "Athraigh an cur síos ort sa phróifíl"
 msgid "Education"
 msgstr "Oideachas"
 
-#: src/screens/Signup/StepInfo/index.tsx:80
-#: src/view/com/modals/ChangeEmail.tsx:136
+#: src/screens/Signup/StepInfo/index.tsx:80 src/view/com/modals/ChangeEmail.tsx:136
 msgid "Email"
 msgstr "Ríomhphost"
 
@@ -1725,8 +1408,7 @@ msgstr "Níl 2FA trí ríomhphost ar fáil a thuilleadh"
 msgid "Email address"
 msgstr "Seoladh ríomhphoist"
 
-#: src/view/com/modals/ChangeEmail.tsx:54
-#: src/view/com/modals/ChangeEmail.tsx:83
+#: src/view/com/modals/ChangeEmail.tsx:54 src/view/com/modals/ChangeEmail.tsx:83
 msgid "Email updated"
 msgstr "Seoladh ríomhphoist uasdátaithe"
 
@@ -1746,9 +1428,7 @@ msgstr "Ríomhphost:"
 msgid "Embed HTML code"
 msgstr "Leabaigh an cód HTML"
 
-#: src/components/dialogs/Embed.tsx:97
-#: src/view/com/util/forms/PostDropdownBtn.tsx:327
-#: src/view/com/util/forms/PostDropdownBtn.tsx:329
+#: src/components/dialogs/Embed.tsx:97 src/view/com/util/forms/PostDropdownBtn.tsx:327 src/view/com/util/forms/PostDropdownBtn.tsx:329
 msgid "Embed post"
 msgstr "Leabaigh an phostáil"
 
@@ -1764,16 +1444,7 @@ msgstr "Cuir {0} amháin ar fáil"
 msgid "Enable adult content"
 msgstr "Cuir ábhar do dhaoine fásta ar fáil"
 
-#: src/screens/Onboarding/StepModeration/AdultContentEnabledPref.tsx:94
-#~ msgid "Enable Adult Content"
-#~ msgstr "Cuir ábhar do dhaoine fásta ar fáil"
-
-#: src/screens/Onboarding/StepModeration/AdultContentEnabledPref.tsx:NaN
-#~ msgid "Enable adult content in your feeds"
-#~ msgstr "Cuir ábhar do dhaoine fásta ar fáil i do chuid fothaí"
-
-#: src/components/dialogs/EmbedConsent.tsx:82
-#: src/components/dialogs/EmbedConsent.tsx:89
+#: src/components/dialogs/EmbedConsent.tsx:82 src/components/dialogs/EmbedConsent.tsx:89
 msgid "Enable external media"
 msgstr "Cuir meáin sheachtracha ar fáil"
 
@@ -1789,9 +1460,7 @@ msgstr "Cuir an socrú seo ar siúl le gan ach freagraí i measc na ndaoine a le
 msgid "Enable this source only"
 msgstr "Cuir an foinse seo amháin ar fáil"
 
-#: src/screens/Messages/Settings.tsx:131
-#: src/screens/Messages/Settings.tsx:134
-#: src/screens/Moderation/index.tsx:339
+#: src/screens/Messages/Settings.tsx:131 src/screens/Messages/Settings.tsx:134 src/screens/Moderation/index.tsx:339
 msgid "Enabled"
 msgstr "Cumasaithe"
 
@@ -1807,8 +1476,7 @@ msgstr "Cuir isteach ainm don phasfhocal aipe seo"
 msgid "Enter a password"
 msgstr "Cuir pasfhocal isteach"
 
-#: src/components/dialogs/MutedWords.tsx:100
-#: src/components/dialogs/MutedWords.tsx:101
+#: src/components/dialogs/MutedWords.tsx:100 src/components/dialogs/MutedWords.tsx:101
 msgid "Enter a word or tag"
 msgstr "Cuir focal na clib isteach"
 
@@ -1832,8 +1500,7 @@ msgstr "Cuir isteach an seoladh ríomhphoist a d’úsáid tú le do chuntas a c
 msgid "Enter your birth date"
 msgstr "Cuir isteach do bhreithlá"
 
-#: src/screens/Login/ForgotPasswordForm.tsx:105
-#: src/screens/Signup/StepInfo/index.tsx:92
+#: src/screens/Login/ForgotPasswordForm.tsx:105 src/screens/Signup/StepInfo/index.tsx:92
 msgid "Enter your email address"
 msgstr "Cuir isteach do sheoladh ríomhphoist"
 
@@ -1857,8 +1524,7 @@ msgstr "Tharla earráid le linn comhad a shábháil"
 msgid "Error receiving captcha response."
 msgstr "Earráid agus an freagra ar an captcha á phróiseáil."
 
-#: src/screens/Onboarding/StepInterests/index.tsx:192
-#: src/view/screens/Search/Search.tsx:115
+#: src/screens/Onboarding/StepInterests/index.tsx:192 src/view/screens/Search/Search.tsx:115
 msgid "Error:"
 msgstr "Earráid:"
 
@@ -1870,10 +1536,7 @@ msgstr "Chuile dhuine"
 msgid "Everybody can reply"
 msgstr "Tig le chuile dhuine freagra a thabhairt"
 
-#: src/components/dms/MessagesNUX.tsx:131
-#: src/components/dms/MessagesNUX.tsx:134
-#: src/screens/Messages/Settings.tsx:75
-#: src/screens/Messages/Settings.tsx:78
+#: src/components/dms/MessagesNUX.tsx:131 src/components/dms/MessagesNUX.tsx:134 src/screens/Messages/Settings.tsx:75 src/screens/Messages/Settings.tsx:78
 msgid "Everyone"
 msgstr "Chuile dhuine"
 
@@ -1901,8 +1564,7 @@ msgstr "Fágann sé seo próiseas laghdú an íomhá"
 msgid "Exits image view"
 msgstr "Fágann sé seo an radharc ar an íomhá"
 
-#: src/view/com/modals/ListAddRemoveUsers.tsx:88
-#: src/view/shell/desktop/Search.tsx:215
+#: src/view/com/modals/ListAddRemoveUsers.tsx:88 src/view/shell/desktop/Search.tsx:215
 msgid "Exits inputting search query"
 msgstr "Fágann sé seo an cuardach"
 
@@ -1912,10 +1574,9 @@ msgstr "Taispeáin an téacs malartach ina iomláine"
 
 #: src/view/com/notifications/FeedItem.tsx:206
 msgid "Expand list of users"
-msgstr ""
+msgstr "Leathnaigh an liosta úsáideoirí"
 
-#: src/view/com/composer/ComposerReplyTo.tsx:82
-#: src/view/com/composer/ComposerReplyTo.tsx:85
+#: src/view/com/composer/ComposerReplyTo.tsx:82 src/view/com/composer/ComposerReplyTo.tsx:85
 msgid "Expand or collapse the full post you are replying to"
 msgstr "Leathnaigh nó laghdaigh an téacs iomlán a bhfuil tú ag freagairt"
 
@@ -1931,24 +1592,19 @@ msgstr "Íomhánna gnéasacha."
 msgid "Export my data"
 msgstr "Easpórtáil mo chuid sonraí"
 
-#: src/view/screens/Settings/ExportCarDialog.tsx:62
-#: src/view/screens/Settings/index.tsx:797
+#: src/view/screens/Settings/ExportCarDialog.tsx:62 src/view/screens/Settings/index.tsx:797
 msgid "Export My Data"
 msgstr "Easpórtáil mo chuid sonraí"
 
-#: src/components/dialogs/EmbedConsent.tsx:55
-#: src/components/dialogs/EmbedConsent.tsx:59
+#: src/components/dialogs/EmbedConsent.tsx:55 src/components/dialogs/EmbedConsent.tsx:59
 msgid "External Media"
 msgstr "Meáin sheachtracha"
 
-#: src/components/dialogs/EmbedConsent.tsx:71
-#: src/view/screens/PreferencesExternalEmbeds.tsx:67
+#: src/components/dialogs/EmbedConsent.tsx:71 src/view/screens/PreferencesExternalEmbeds.tsx:67
 msgid "External media may allow websites to collect information about you and your device. No information is sent or requested until you press the \"play\" button."
 msgstr "Is féidir le meáin sheachtracha cumas a thabhairt do shuíomhanna ar an nGréasán eolas fútsa agus faoi do ghléas a chnuasach. Ní sheoltar ná iarrtar aon eolas go dtí go mbrúnn tú an cnaipe “play”."
 
-#: src/Navigation.tsx:282
-#: src/view/screens/PreferencesExternalEmbeds.tsx:53
-#: src/view/screens/Settings/index.tsx:679
+#: src/Navigation.tsx:282 src/view/screens/PreferencesExternalEmbeds.tsx:53 src/view/screens/Settings/index.tsx:679
 msgid "External Media Preferences"
 msgstr "Roghanna maidir le meáin sheachtracha"
 
@@ -1956,8 +1612,7 @@ msgstr "Roghanna maidir le meáin sheachtracha"
 msgid "External media settings"
 msgstr "Socruithe maidir le meáin sheachtracha"
 
-#: src/view/com/modals/AddAppPasswords.tsx:120
-#: src/view/com/modals/AddAppPasswords.tsx:124
+#: src/view/com/modals/AddAppPasswords.tsx:120 src/view/com/modals/AddAppPasswords.tsx:124
 msgid "Failed to create app password."
 msgstr "Teip ar phasfhocal aipe a chruthú."
 
@@ -1973,18 +1628,13 @@ msgstr "Teip ar theachtaireacht a scriosadh"
 msgid "Failed to delete post, please try again"
 msgstr "Teip ar scriosadh na postála. Déan iarracht eile."
 
-#: src/components/dialogs/GifSelect.ios.tsx:196
-#: src/components/dialogs/GifSelect.tsx:212
+#: src/components/dialogs/GifSelect.ios.tsx:196 src/components/dialogs/GifSelect.tsx:212
 msgid "Failed to load GIFs"
 msgstr "Theip ar lódáil na GIFanna"
 
 #: src/screens/Messages/Conversation/MessageListError.tsx:23
 msgid "Failed to load past messages"
 msgstr "Teip ar theachtaireachtaí roimhe seo a lódáil"
-
-#: src/view/com/auth/onboarding/RecommendedFeeds.tsx:NaN
-#~ msgid "Failed to load recommended feeds"
-#~ msgstr "Teip ar lódáil na bhfothaí molta"
 
 #: src/view/com/lightbox/Lightbox.tsx:84
 msgid "Failed to save image: {0}"
@@ -1994,13 +1644,11 @@ msgstr "Níor sábháladh an íomhá: {0}"
 msgid "Failed to send"
 msgstr "Teip ar sheoladh"
 
-#: src/components/moderation/LabelsOnMeDialog.tsx:225
-#: src/screens/Messages/Conversation/ChatDisabled.tsx:87
+#: src/components/moderation/LabelsOnMeDialog.tsx:225 src/screens/Messages/Conversation/ChatDisabled.tsx:87
 msgid "Failed to submit appeal, please try again."
 msgstr "Teip ar achomharc a dhéanamh, bain triail eile as, le do thoil."
 
-#: src/components/dms/MessagesNUX.tsx:60
-#: src/screens/Messages/Settings.tsx:35
+#: src/components/dms/MessagesNUX.tsx:60 src/screens/Messages/Settings.tsx:35
 msgid "Failed to update settings"
 msgstr "Teip ar shocruithe a uasdátú"
 
@@ -2016,32 +1664,17 @@ msgstr "Fotha le {0}"
 msgid "Feed offline"
 msgstr "Fotha as líne"
 
-#: src/view/shell/desktop/RightNav.tsx:66
-#: src/view/shell/Drawer.tsx:344
+#: src/view/shell/desktop/RightNav.tsx:66 src/view/shell/Drawer.tsx:344
 msgid "Feedback"
 msgstr "Aiseolas"
 
-#: src/Navigation.tsx:511
-#: src/view/screens/Feeds.tsx:480
-#: src/view/screens/Feeds.tsx:596
-#: src/view/screens/Profile.tsx:197
-#: src/view/shell/desktop/LeftNav.tsx:367
-#: src/view/shell/Drawer.tsx:492
-#: src/view/shell/Drawer.tsx:493
+#: src/Navigation.tsx:511 src/view/screens/Feeds.tsx:480 src/view/screens/Feeds.tsx:596 src/view/screens/Profile.tsx:197 src/view/shell/desktop/LeftNav.tsx:367 src/view/shell/Drawer.tsx:492 src/view/shell/Drawer.tsx:493
 msgid "Feeds"
 msgstr "Fothaí"
-
-#: src/view/com/auth/onboarding/RecommendedFeeds.tsx:58
-#~ msgid "Feeds are created by users to curate content. Choose some feeds that you find interesting."
-#~ msgstr "Is iad na húsáideoirí a chruthaíonn na fothaí le hábhar is spéis leo a chur ar fáil. Roghnaigh cúpla fotha a bhfuil suim agat iontu."
 
 #: src/view/screens/SavedFeeds.tsx:180
 msgid "Feeds are custom algorithms that users build with a little coding expertise. <0/> for more information."
 msgstr "Is sainalgartaim iad na fothaí. Cruthaíonn úsáideoirí a bhfuil beagán taithí acu ar chódáil iad. <0/> le tuilleadh eolais a fháil."
-
-#: src/screens/Onboarding/StepTopicalFeeds.tsx:80
-#~ msgid "Feeds can be topical as well!"
-#~ msgstr "Is féidir le fothaí a bheith bunaithe ar chúrsaí reatha freisin!"
 
 #: src/view/com/modals/ChangeHandle.tsx:475
 msgid "File Contents"
@@ -2059,27 +1692,13 @@ msgstr "Scag ó mo chuid fothaí"
 msgid "Finalizing"
 msgstr "Ag cur crích air"
 
-#: src/view/com/posts/CustomFeedEmptyState.tsx:47
-#: src/view/com/posts/FollowingEmptyState.tsx:57
-#: src/view/com/posts/FollowingEndOfFeed.tsx:58
+#: src/view/com/posts/CustomFeedEmptyState.tsx:47 src/view/com/posts/FollowingEmptyState.tsx:57 src/view/com/posts/FollowingEndOfFeed.tsx:58
 msgid "Find accounts to follow"
 msgstr "Aimsigh fothaí le leanúint"
 
 #: src/view/screens/Search/Search.tsx:469
 msgid "Find posts and users on Bluesky"
 msgstr "Aimsigh postálacha agus úsáideoirí ar Bluesky"
-
-#: src/view/screens/Search/Search.tsx:589
-#~ msgid "Find users on Bluesky"
-#~ msgstr "Aimsigh úsáideoirí ar Bluesky"
-
-#: src/view/screens/Search/Search.tsx:587
-#~ msgid "Find users with the search tool on the right"
-#~ msgstr "Aimsigh úsáideoirí leis an uirlis chuardaigh ar dheis"
-
-#: src/view/com/auth/onboarding/RecommendedFollowsItem.tsx:155
-#~ msgid "Finding similar accounts..."
-#~ msgstr "Cuntais eile atá cosúil leis seo á n-aimsiú..."
 
 #: src/view/screens/PreferencesFollowingFeed.tsx:110
 msgid "Fine-tune the content you see on your Following feed."
@@ -2101,16 +1720,11 @@ msgstr "Solúbtha"
 msgid "Flip horizontal"
 msgstr "Iompaigh go cothrománach é"
 
-#: src/view/com/modals/EditImage.tsx:121
-#: src/view/com/modals/EditImage.tsx:288
+#: src/view/com/modals/EditImage.tsx:121 src/view/com/modals/EditImage.tsx:288
 msgid "Flip vertically"
 msgstr "Iompaigh go hingearach é"
 
-#: src/components/ProfileHoverCard/index.web.tsx:412
-#: src/components/ProfileHoverCard/index.web.tsx:423
-#: src/screens/Profile/Header/ProfileHeaderStandard.tsx:244
-#: src/view/com/post-thread/PostThreadFollowBtn.tsx:146
-#: src/view/com/profile/ProfileHeaderSuggestedFollows.tsx:247
+#: src/components/ProfileHoverCard/index.web.tsx:412 src/components/ProfileHoverCard/index.web.tsx:423 src/screens/Profile/Header/ProfileHeaderStandard.tsx:244 src/view/com/post-thread/PostThreadFollowBtn.tsx:146 src/view/com/profile/ProfileHeaderSuggestedFollows.tsx:247
 msgid "Follow"
 msgstr "Lean"
 
@@ -2119,35 +1733,21 @@ msgctxt "action"
 msgid "Follow"
 msgstr "Lean"
 
-#: src/screens/Profile/Header/ProfileHeaderStandard.tsx:230
-#: src/view/com/post-thread/PostThreadFollowBtn.tsx:128
+#: src/screens/Profile/Header/ProfileHeaderStandard.tsx:230 src/view/com/post-thread/PostThreadFollowBtn.tsx:128
 msgid "Follow {0}"
 msgstr "Lean {0}"
 
 #: src/view/com/posts/AviFollowButton.tsx:71
 msgid "Follow {name}"
-msgstr ""
+msgstr "Lean {name}"
 
-#: src/view/com/profile/ProfileMenu.tsx:244
-#: src/view/com/profile/ProfileMenu.tsx:255
+#: src/view/com/profile/ProfileMenu.tsx:244 src/view/com/profile/ProfileMenu.tsx:255
 msgid "Follow Account"
 msgstr "Lean an cuntas seo"
-
-#: src/screens/Onboarding/StepSuggestedAccounts/index.tsx:187
-#~ msgid "Follow All"
-#~ msgstr "Lean iad uile"
 
 #: src/view/com/post-thread/PostThreadFollowBtn.tsx:144
 msgid "Follow Back"
 msgstr "Lean Ar Ais"
-
-#: src/screens/Onboarding/StepSuggestedAccounts/index.tsx:182
-#~ msgid "Follow selected accounts and continue to the next step"
-#~ msgstr "Lean na cuntais roghnaithe agus téigh ar aghaidh go dtí an chéad chéim eile"
-
-#: src/view/com/auth/onboarding/RecommendedFollows.tsx:65
-#~ msgid "Follow some users to get started. We can recommend you more users based on who you find interesting."
-#~ msgstr "Lean cúpla cuntas mar thosú. Tig linn níos mó úsáideoirí a mholadh duit a mbeadh suim agat iontu."
 
 #: src/view/com/profile/ProfileCard.tsx:227
 msgid "Followed by {0}"
@@ -2165,19 +1765,11 @@ msgstr "Cuntais a leanann tú amháin"
 msgid "followed you"
 msgstr "— lean sé/sí thú"
 
-#: src/view/com/profile/ProfileFollowers.tsx:104
-#: src/view/screens/ProfileFollowers.tsx:25
+#: src/view/com/profile/ProfileFollowers.tsx:104 src/view/screens/ProfileFollowers.tsx:25
 msgid "Followers"
 msgstr "Leantóirí"
 
-#: src/components/ProfileHoverCard/index.web.tsx:411
-#: src/components/ProfileHoverCard/index.web.tsx:422
-#: src/screens/Profile/Header/ProfileHeaderStandard.tsx:242
-#: src/view/com/post-thread/PostThreadFollowBtn.tsx:149
-#: src/view/com/profile/ProfileFollows.tsx:104
-#: src/view/screens/Feeds.tsx:683
-#: src/view/screens/ProfileFollows.tsx:25
-#: src/view/screens/SavedFeeds.tsx:415
+#: src/components/ProfileHoverCard/index.web.tsx:411 src/components/ProfileHoverCard/index.web.tsx:422 src/screens/Profile/Header/ProfileHeaderStandard.tsx:242 src/view/com/post-thread/PostThreadFollowBtn.tsx:149 src/view/com/profile/ProfileFollows.tsx:104 src/view/screens/Feeds.tsx:683 src/view/screens/ProfileFollows.tsx:25 src/view/screens/SavedFeeds.tsx:415
 msgid "Following"
 msgstr "Á leanúint"
 
@@ -2187,17 +1779,13 @@ msgstr "Ag leanúint {0}"
 
 #: src/view/com/posts/AviFollowButton.tsx:53
 msgid "Following {name}"
-msgstr ""
+msgstr "Ag leanacht {name}"
 
 #: src/view/screens/Settings/index.tsx:573
 msgid "Following feed preferences"
 msgstr "Roghanna le haghaidh an fhotha Following"
 
-#: src/Navigation.tsx:269
-#: src/view/com/home/HomeHeaderLayout.web.tsx:64
-#: src/view/com/home/HomeHeaderLayoutMobile.tsx:87
-#: src/view/screens/PreferencesFollowingFeed.tsx:103
-#: src/view/screens/Settings/index.tsx:582
+#: src/Navigation.tsx:269 src/view/com/home/HomeHeaderLayout.web.tsx:64 src/view/com/home/HomeHeaderLayoutMobile.tsx:87 src/view/screens/PreferencesFollowingFeed.tsx:103 src/view/screens/Settings/index.tsx:582
 msgid "Following Feed Preferences"
 msgstr "Roghanna don Fhotha Following"
 
@@ -2221,8 +1809,7 @@ msgstr "Ar chúiseanna slándála, beidh orainn cód dearbhaithe a chur chuig do
 msgid "For security reasons, you won't be able to view this again. If you lose this password, you'll need to generate a new one."
 msgstr "Ar chúiseanna slándála, ní bheidh tú in ann é seo a fheiceáil arís. Má chailleann tú an pasfhocal seo beidh ort ceann nua a chruthú."
 
-#: src/screens/Login/index.tsx:129
-#: src/screens/Login/index.tsx:144
+#: src/screens/Login/index.tsx:129 src/screens/Login/index.tsx:144
 msgid "Forgot Password"
 msgstr "Pasfhocal dearmadta"
 
@@ -2255,8 +1842,7 @@ msgstr "Gailearaí"
 msgid "Get started"
 msgstr "Tús maith"
 
-#: src/view/com/modals/VerifyEmail.tsx:197
-#: src/view/com/modals/VerifyEmail.tsx:199
+#: src/view/com/modals/VerifyEmail.tsx:197 src/view/com/modals/VerifyEmail.tsx:199
 msgid "Get Started"
 msgstr "Ar aghaidh leat anois!"
 
@@ -2268,32 +1854,15 @@ msgstr "Tabhair gnúis do do phróifíl"
 msgid "Glaring violations of law or terms of service"
 msgstr "Deargshárú an dlí nó na dtéarmaí seirbhíse"
 
-#: src/components/moderation/ScreenHider.tsx:151
-#: src/components/moderation/ScreenHider.tsx:160
-#: src/view/com/auth/LoggedOut.tsx:82
-#: src/view/com/auth/LoggedOut.tsx:83
-#: src/view/screens/NotFound.tsx:55
-#: src/view/screens/ProfileFeed.tsx:111
-#: src/view/screens/ProfileList.tsx:970
-#: src/view/shell/desktop/LeftNav.tsx:127
+#: src/components/moderation/ScreenHider.tsx:151 src/components/moderation/ScreenHider.tsx:160 src/view/com/auth/LoggedOut.tsx:82 src/view/com/auth/LoggedOut.tsx:83 src/view/screens/NotFound.tsx:55 src/view/screens/ProfileFeed.tsx:111 src/view/screens/ProfileList.tsx:970 src/view/shell/desktop/LeftNav.tsx:127
 msgid "Go back"
 msgstr "Ar ais"
 
-#: src/components/Error.tsx:103
-#: src/screens/Profile/ErrorState.tsx:62
-#: src/screens/Profile/ErrorState.tsx:66
-#: src/view/screens/NotFound.tsx:54
-#: src/view/screens/ProfileFeed.tsx:116
-#: src/view/screens/ProfileList.tsx:975
+#: src/components/Error.tsx:103 src/screens/Profile/ErrorState.tsx:62 src/screens/Profile/ErrorState.tsx:66 src/view/screens/NotFound.tsx:54 src/view/screens/ProfileFeed.tsx:116 src/view/screens/ProfileList.tsx:975
 msgid "Go Back"
 msgstr "Ar ais"
 
-#: src/components/dms/ReportDialog.tsx:152
-#: src/components/ReportDialog/SelectReportOptionView.tsx:77
-#: src/components/ReportDialog/SubmitView.tsx:105
-#: src/screens/Onboarding/Layout.tsx:102
-#: src/screens/Onboarding/Layout.tsx:191
-#: src/screens/Signup/index.tsx:187
+#: src/components/dms/ReportDialog.tsx:152 src/components/ReportDialog/SelectReportOptionView.tsx:77 src/components/ReportDialog/SubmitView.tsx:105 src/screens/Onboarding/Layout.tsx:102 src/screens/Onboarding/Layout.tsx:191 src/screens/Signup/index.tsx:187
 msgid "Go back to previous step"
 msgstr "Fill ar an gcéim roimhe seo"
 
@@ -2305,16 +1874,11 @@ msgstr "Abhaile"
 msgid "Go Home"
 msgstr "Abhaile"
 
-#: src/view/screens/Search/Search.tsx:NaN
-#~ msgid "Go to @{queryMaybeHandle}"
-#~ msgstr "Téigh go dtí @{queryMaybeHandle}"
-
 #: src/screens/Messages/List/ChatListItem.tsx:208
 msgid "Go to conversation with {0}"
 msgstr "Téigh go comhrá le {0}"
 
-#: src/screens/Login/ForgotPasswordForm.tsx:172
-#: src/view/com/modals/ChangePassword.tsx:168
+#: src/screens/Login/ForgotPasswordForm.tsx:172 src/view/com/modals/ChangePassword.tsx:168
 msgid "Go to next"
 msgstr "Téigh go dtí an chéad rud eile"
 
@@ -2354,8 +1918,7 @@ msgstr "Haischlib: #{tag}"
 msgid "Having trouble?"
 msgstr "Fadhb ort?"
 
-#: src/view/shell/desktop/RightNav.tsx:95
-#: src/view/shell/Drawer.tsx:354
+#: src/view/shell/desktop/RightNav.tsx:95 src/view/shell/Drawer.tsx:354
 msgid "Help"
 msgstr "Cúnamh"
 
@@ -2363,30 +1926,11 @@ msgstr "Cúnamh"
 msgid "Help people know you're not a bot by uploading a picture or creating an avatar."
 msgstr "Tabhair le fios dúinn nach bot thú trí pictiúr a uaslódáil nó abhatár a chruthú."
 
-#: src/screens/Onboarding/StepSuggestedAccounts/index.tsx:140
-#~ msgid "Here are some accounts for you to follow"
-#~ msgstr "Seo cúpla cuntas le leanúint duit"
-
-#: src/screens/Onboarding/StepTopicalFeeds.tsx:89
-#~ msgid "Here are some popular topical feeds. You can choose to follow as many as you like."
-#~ msgstr "Seo cúpla fotha a bhfuil ráchairt orthu. Is féidir leat an méid acu is mian leat a leanúint."
-
-#: src/screens/Onboarding/StepTopicalFeeds.tsx:84
-#~ msgid "Here are some topical feeds based on your interests: {interestsText}. You can choose to follow as many as you like."
-#~ msgstr "Seo cúpla fotha a phléann le rudaí a bhfuil suim agat iontu: {interestsText}. Is féidir leat an méid acu is mian leat a leanúint."
-
 #: src/view/com/modals/AddAppPasswords.tsx:204
 msgid "Here is your app password."
 msgstr "Seo é do phasfhocal aipe."
 
-#: src/components/moderation/ContentHider.tsx:116
-#: src/components/moderation/LabelPreference.tsx:134
-#: src/components/moderation/PostHider.tsx:121
-#: src/lib/moderation/useLabelBehaviorDescription.ts:15
-#: src/lib/moderation/useLabelBehaviorDescription.ts:20
-#: src/lib/moderation/useLabelBehaviorDescription.ts:25
-#: src/lib/moderation/useLabelBehaviorDescription.ts:30
-#: src/view/com/util/forms/PostDropdownBtn.tsx:445
+#: src/components/moderation/ContentHider.tsx:116 src/components/moderation/LabelPreference.tsx:134 src/components/moderation/PostHider.tsx:121 src/lib/moderation/useLabelBehaviorDescription.ts:15 src/lib/moderation/useLabelBehaviorDescription.ts:20 src/lib/moderation/useLabelBehaviorDescription.ts:25 src/lib/moderation/useLabelBehaviorDescription.ts:30 src/view/com/util/forms/PostDropdownBtn.tsx:445
 msgid "Hide"
 msgstr "Cuir i bhfolach"
 
@@ -2395,13 +1939,11 @@ msgctxt "action"
 msgid "Hide"
 msgstr "Cuir i bhfolach"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:390
-#: src/view/com/util/forms/PostDropdownBtn.tsx:392
+#: src/view/com/util/forms/PostDropdownBtn.tsx:390 src/view/com/util/forms/PostDropdownBtn.tsx:392
 msgid "Hide post"
 msgstr "Cuir an phostáil seo i bhfolach"
 
-#: src/components/moderation/ContentHider.tsx:68
-#: src/components/moderation/PostHider.tsx:78
+#: src/components/moderation/ContentHider.tsx:68 src/components/moderation/PostHider.tsx:78
 msgid "Hide the content"
 msgstr "Cuir an t-ábhar seo i bhfolach"
 
@@ -2441,11 +1983,7 @@ msgstr "Hmmm, is cosúil go bhfuil fadhb againn le lódáil na sonraí seo. Féa
 msgid "Hmmmm, we couldn't load that moderation service."
 msgstr "Hmmm, ní raibh muid in ann an tseirbhís modhnóireachta sin a lódáil."
 
-#: src/Navigation.tsx:501
-#: src/view/shell/bottom-bar/BottomBar.tsx:159
-#: src/view/shell/desktop/LeftNav.tsx:335
-#: src/view/shell/Drawer.tsx:424
-#: src/view/shell/Drawer.tsx:425
+#: src/Navigation.tsx:501 src/view/shell/bottom-bar/BottomBar.tsx:159 src/view/shell/desktop/LeftNav.tsx:335 src/view/shell/Drawer.tsx:424 src/view/shell/Drawer.tsx:425
 msgid "Home"
 msgstr "Baile"
 
@@ -2453,10 +1991,7 @@ msgstr "Baile"
 msgid "Host:"
 msgstr "Óstach:"
 
-#: src/screens/Login/ForgotPasswordForm.tsx:89
-#: src/screens/Login/LoginForm.tsx:157
-#: src/screens/Signup/StepInfo/index.tsx:40
-#: src/view/com/modals/ChangeHandle.tsx:275
+#: src/screens/Login/ForgotPasswordForm.tsx:89 src/screens/Login/LoginForm.tsx:157 src/screens/Signup/StepInfo/index.tsx:40 src/view/com/modals/ChangeHandle.tsx:275
 msgid "Hosting provider"
 msgstr "Soláthraí óstála"
 
@@ -2464,9 +1999,7 @@ msgstr "Soláthraí óstála"
 msgid "How should we open this link?"
 msgstr "Conas ar cheart dúinn an nasc seo a oscailt?"
 
-#: src/view/com/modals/VerifyEmail.tsx:222
-#: src/view/screens/Settings/DisableEmail2FADialog.tsx:132
-#: src/view/screens/Settings/DisableEmail2FADialog.tsx:135
+#: src/view/com/modals/VerifyEmail.tsx:222 src/view/screens/Settings/DisableEmail2FADialog.tsx:132 src/view/screens/Settings/DisableEmail2FADialog.tsx:135
 msgid "I have a code"
 msgstr "Tá cód agam"
 
@@ -2478,8 +2011,7 @@ msgstr "Tá cód dearbhaithe agam"
 msgid "I have my own domain"
 msgstr "Tá fearann de mo chuid féin agam"
 
-#: src/components/dms/BlockedByListDialog.tsx:56
-#: src/components/dms/ReportConversationPrompt.tsx:22
+#: src/components/dms/BlockedByListDialog.tsx:56 src/components/dms/ReportConversationPrompt.tsx:22
 msgid "I understand"
 msgstr "Tuigim"
 
@@ -2509,7 +2041,7 @@ msgstr "Más mian leat do phasfhocal a athrú, seolfaimid cód duit chun dearbh�
 
 #: src/screens/Settings/components/DeactivateAccountDialog.tsx:92
 msgid "If you're trying to change your handle or email, do so before you deactivate."
-msgstr ""
+msgstr "Má tá sé i gceist agat do hanla nó ríomhphost a athrú, déan sin sula ndéanann tú díghníomhú."
 
 #: src/lib/moderation/useReportOptions.ts:37
 msgid "Illegal and Urgent"
@@ -2579,8 +2111,7 @@ msgstr "Cuir isteach do leasainm"
 msgid "Introducing Direct Messages"
 msgstr "Ag cur Teachtaireachtaí Díreacha in aithne duit"
 
-#: src/screens/Login/LoginForm.tsx:132
-#: src/view/screens/Settings/DisableEmail2FADialog.tsx:70
+#: src/screens/Login/LoginForm.tsx:132 src/view/screens/Settings/DisableEmail2FADialog.tsx:70
 msgid "Invalid 2FA confirmation code."
 msgstr "Tá an cód 2FA seo neamhbhailí."
 
@@ -2612,10 +2143,6 @@ msgstr "Cóid chuiridh: {0} ar fáil"
 msgid "Invite codes: 1 available"
 msgstr "Cóid chuiridh: 1 ar fáil"
 
-#: src/screens/Onboarding/StepFollowingFeed.tsx:65
-#~ msgid "It shows posts from the people you follow as they happen."
-#~ msgstr "Taispeánann sé postálacha ó na daoine a leanann tú nuair a fhoilsítear iad."
-
 #: src/view/com/auth/SplashScreen.web.tsx:157
 msgid "Jobs"
 msgstr "Jabanna"
@@ -2623,10 +2150,6 @@ msgstr "Jabanna"
 #: src/screens/Onboarding/index.tsx:21
 msgid "Journalism"
 msgstr "Iriseoireacht"
-
-#: src/components/moderation/LabelsOnMe.tsx:59
-#~ msgid "label has been placed on this {labelTarget}"
-#~ msgstr "cuireadh lipéad ar an {labelTarget} seo"
 
 #: src/components/moderation/ContentHider.tsx:147
 msgid "Labeled by {0}."
@@ -2644,10 +2167,6 @@ msgstr "Lipéid"
 msgid "Labels are annotations on users and content. They can be used to hide, warn, and categorize the network."
 msgstr "Nótaí faoi úsáideoirí nó ábhar is ea lipéid. Is féidir úsáid a bhaint astu leis an líonra a cheilt, a chatagóiriú, agus fainic a chur air."
 
-#: src/components/moderation/LabelsOnMe.tsx:61
-#~ msgid "labels have been placed on this {labelTarget}"
-#~ msgstr "cuireadh lipéid ar an {labelTarget}"
-
 #: src/components/moderation/LabelsOnMeDialog.tsx:80
 msgid "Labels on your account"
 msgstr "Lipéid ar do chuntas"
@@ -2664,8 +2183,7 @@ msgstr "Rogha teanga"
 msgid "Language settings"
 msgstr "Socruithe teanga"
 
-#: src/Navigation.tsx:151
-#: src/view/screens/LanguageSettings.tsx:90
+#: src/Navigation.tsx:151 src/view/screens/LanguageSettings.tsx:90
 msgid "Language Settings"
 msgstr "Socruithe teanga"
 
@@ -2673,8 +2191,7 @@ msgstr "Socruithe teanga"
 msgid "Languages"
 msgstr "Teangacha"
 
-#: src/screens/Hashtag.tsx:99
-#: src/view/screens/Search/Search.tsx:376
+#: src/screens/Hashtag.tsx:99 src/view/screens/Search/Search.tsx:376
 msgid "Latest"
 msgstr "Is Déanaí"
 
@@ -2682,13 +2199,11 @@ msgstr "Is Déanaí"
 msgid "Learn More"
 msgstr "Le tuilleadh a fhoghlaim"
 
-#: src/components/moderation/ContentHider.tsx:66
-#: src/components/moderation/ContentHider.tsx:131
+#: src/components/moderation/ContentHider.tsx:66 src/components/moderation/ContentHider.tsx:131
 msgid "Learn more about the moderation applied to this content."
 msgstr "Foghlaim níos mó faoin modhnóireacht a dhéantar ar an ábhar seo."
 
-#: src/components/moderation/PostHider.tsx:99
-#: src/components/moderation/ScreenHider.tsx:125
+#: src/components/moderation/PostHider.tsx:99 src/components/moderation/ScreenHider.tsx:125
 msgid "Learn more about this warning"
 msgstr "Le tuilleadh a fhoghlaim faoin rabhadh seo"
 
@@ -2704,16 +2219,11 @@ msgstr "Tuilleadh eolais."
 msgid "Leave"
 msgstr "Éirigh as"
 
-#: src/components/dms/MessagesListBlockedFooter.tsx:66
-#: src/components/dms/MessagesListBlockedFooter.tsx:73
+#: src/components/dms/MessagesListBlockedFooter.tsx:66 src/components/dms/MessagesListBlockedFooter.tsx:73
 msgid "Leave chat"
 msgstr "Éirigh as an gcomhrá"
 
-#: src/components/dms/ConvoMenu.tsx:138
-#: src/components/dms/ConvoMenu.tsx:141
-#: src/components/dms/ConvoMenu.tsx:208
-#: src/components/dms/ConvoMenu.tsx:211
-#: src/components/dms/LeaveConvoPrompt.tsx:46
+#: src/components/dms/ConvoMenu.tsx:138 src/components/dms/ConvoMenu.tsx:141 src/components/dms/ConvoMenu.tsx:208 src/components/dms/ConvoMenu.tsx:211 src/components/dms/LeaveConvoPrompt.tsx:46
 msgid "Leave conversation"
 msgstr "Éirigh as an gcomhrá"
 
@@ -2733,8 +2243,7 @@ msgstr "le déanamh fós."
 msgid "Legacy storage cleared, you need to restart the app now."
 msgstr "Stóráil oidhreachta scriosta, tá ort an aip a atosú anois."
 
-#: src/screens/Login/index.tsx:130
-#: src/screens/Login/index.tsx:145
+#: src/screens/Login/index.tsx:130 src/screens/Login/index.tsx:145
 msgid "Let's get your password reset!"
 msgstr "Socraímis do phasfhocal arís!"
 
@@ -2746,38 +2255,17 @@ msgstr "Ar aghaidh linn!"
 msgid "Light"
 msgstr "Sorcha"
 
-#: src/view/com/util/post-ctrls/PostCtrls.tsx:197
-#~ msgid "Like"
-#~ msgstr "Mol"
-
-#: src/screens/Profile/Header/ProfileHeaderLabeler.tsx:267
-#: src/view/screens/ProfileFeed.tsx:570
+#: src/screens/Profile/Header/ProfileHeaderLabeler.tsx:267 src/view/screens/ProfileFeed.tsx:570
 msgid "Like this feed"
 msgstr "Mol an fotha seo"
 
-#: src/components/LikesDialog.tsx:87
-#: src/Navigation.tsx:208
-#: src/Navigation.tsx:213
+#: src/components/LikesDialog.tsx:87 src/Navigation.tsx:208 src/Navigation.tsx:213
 msgid "Liked by"
 msgstr "Molta ag"
 
-#: src/screens/Profile/ProfileLabelerLikedBy.tsx:29
-#: src/view/screens/PostLikedBy.tsx:27
-#: src/view/screens/ProfileFeedLikedBy.tsx:27
+#: src/screens/Profile/ProfileLabelerLikedBy.tsx:29 src/view/screens/PostLikedBy.tsx:27 src/view/screens/ProfileFeedLikedBy.tsx:27
 msgid "Liked By"
 msgstr "Molta ag"
-
-#: src/view/com/feeds/FeedSourceCard.tsx:268
-#~ msgid "Liked by {0} {1}"
-#~ msgstr "Molta ag {0} {1}"
-
-#: src/components/LabelingServiceCard/index.tsx:72
-#~ msgid "Liked by {count} {0}"
-#~ msgstr "Molta ag {count} {0}"
-
-#: src/screens/Profile/Header/ProfileHeaderLabeler.tsx:NaN
-#~ msgid "Liked by {likeCount} {0}"
-#~ msgstr "Molta ag {likeCount} {0}"
 
 #: src/view/com/notifications/FeedItem.tsx:176
 msgid "liked your custom feed"
@@ -2831,12 +2319,7 @@ msgstr "Liosta díbhlocáilte"
 msgid "List unmuted"
 msgstr "Liosta nach bhfuil balbhaithe níos mó"
 
-#: src/Navigation.tsx:121
-#: src/view/screens/Profile.tsx:192
-#: src/view/screens/Profile.tsx:198
-#: src/view/shell/desktop/LeftNav.tsx:373
-#: src/view/shell/Drawer.tsx:508
-#: src/view/shell/Drawer.tsx:509
+#: src/Navigation.tsx:121 src/view/screens/Profile.tsx:192 src/view/screens/Profile.tsx:198 src/view/shell/desktop/LeftNav.tsx:373 src/view/shell/Drawer.tsx:508 src/view/shell/Drawer.tsx:509
 msgid "Lists"
 msgstr "Liostaí"
 
@@ -2848,10 +2331,7 @@ msgstr "Liostaí a bhlocálann an t-úsáideoir seo:"
 msgid "Load new notifications"
 msgstr "Lódáil fógraí nua"
 
-#: src/screens/Profile/Sections/Feed.tsx:86
-#: src/view/com/feeds/FeedPage.tsx:136
-#: src/view/screens/ProfileFeed.tsx:492
-#: src/view/screens/ProfileList.tsx:749
+#: src/screens/Profile/Sections/Feed.tsx:86 src/view/com/feeds/FeedPage.tsx:136 src/view/screens/ProfileFeed.tsx:492 src/view/screens/ProfileList.tsx:749
 msgid "Load new posts"
 msgstr "Lódáil postálacha nua"
 
@@ -2863,15 +2343,11 @@ msgstr "Ag lódáil …"
 msgid "Log"
 msgstr "Logleabhar"
 
-#: src/screens/Deactivated.tsx:214
-#: src/screens/Deactivated.tsx:220
+#: src/screens/Deactivated.tsx:214 src/screens/Deactivated.tsx:220
 msgid "Log in or sign up"
-msgstr ""
+msgstr "Logáil isteach nó cláraigh le Bluesky"
 
-#: src/screens/SignupQueued.tsx:155
-#: src/screens/SignupQueued.tsx:158
-#: src/screens/SignupQueued.tsx:184
-#: src/screens/SignupQueued.tsx:187
+#: src/screens/SignupQueued.tsx:155 src/screens/SignupQueued.tsx:158 src/screens/SignupQueued.tsx:184 src/screens/SignupQueued.tsx:187
 msgid "Log out"
 msgstr "Logáil amach"
 
@@ -2911,13 +2387,11 @@ msgstr "Bí cinnte go bhfuil tú ag iarraidh cuairt a thabhairt ar an áit sin!"
 msgid "Manage your muted words and tags"
 msgstr "Bainistigh do chuid clibeanna agus na focail a chuir tú i bhfolach"
 
-#: src/components/dms/ConvoMenu.tsx:151
-#: src/components/dms/ConvoMenu.tsx:158
+#: src/components/dms/ConvoMenu.tsx:151 src/components/dms/ConvoMenu.tsx:158
 msgid "Mark as read"
 msgstr "Marcáil léite"
 
-#: src/view/screens/AccessibilitySettings.tsx:89
-#: src/view/screens/Profile.tsx:195
+#: src/view/screens/AccessibilitySettings.tsx:89 src/view/screens/Profile.tsx:195
 msgid "Media"
 msgstr "Meáin"
 
@@ -2929,8 +2403,7 @@ msgstr "úsáideoirí luaite"
 msgid "Mentioned users"
 msgstr "Úsáideoirí luaite"
 
-#: src/view/com/util/ViewHeader.tsx:90
-#: src/view/screens/Search/Search.tsx:713
+#: src/view/com/util/ViewHeader.tsx:90 src/view/screens/Search/Search.tsx:713
 msgid "Menu"
 msgstr "Clár"
 
@@ -2938,8 +2411,7 @@ msgstr "Clár"
 msgid "Message {0}"
 msgstr "Teachtaireacht {0}"
 
-#: src/components/dms/MessageMenu.tsx:72
-#: src/screens/Messages/List/ChatListItem.tsx:154
+#: src/components/dms/MessageMenu.tsx:72 src/screens/Messages/List/ChatListItem.tsx:154
 msgid "Message deleted"
 msgstr "Scriosadh an teachtaireacht"
 
@@ -2951,8 +2423,7 @@ msgstr "Teachtaireacht ón bhfreastalaí: {0}"
 msgid "Message input field"
 msgstr "Réimse ionchur teachtaireachtaí"
 
-#: src/screens/Messages/Conversation/MessageInput.tsx:70
-#: src/screens/Messages/Conversation/MessageInput.web.tsx:49
+#: src/screens/Messages/Conversation/MessageInput.tsx:70 src/screens/Messages/Conversation/MessageInput.web.tsx:49
 msgid "Message is too long"
 msgstr "Tá an teachtaireacht rófhada"
 
@@ -2960,10 +2431,7 @@ msgstr "Tá an teachtaireacht rófhada"
 msgid "Message settings"
 msgstr "Socruithe teachtaireachta"
 
-#: src/Navigation.tsx:521
-#: src/screens/Messages/List/index.tsx:164
-#: src/screens/Messages/List/index.tsx:246
-#: src/screens/Messages/List/index.tsx:317
+#: src/Navigation.tsx:521 src/screens/Messages/List/index.tsx:164 src/screens/Messages/List/index.tsx:246 src/screens/Messages/List/index.tsx:317
 msgid "Messages"
 msgstr "Teachtaireachtaí"
 
@@ -2971,9 +2439,7 @@ msgstr "Teachtaireachtaí"
 msgid "Misleading Account"
 msgstr "Cuntas atá Míthreorach"
 
-#: src/Navigation.tsx:126
-#: src/screens/Moderation/index.tsx:104
-#: src/view/screens/Settings/index.tsx:561
+#: src/Navigation.tsx:126 src/screens/Moderation/index.tsx:104 src/view/screens/Settings/index.tsx:561
 msgid "Moderation"
 msgstr "Modhnóireacht"
 
@@ -2981,8 +2447,7 @@ msgstr "Modhnóireacht"
 msgid "Moderation details"
 msgstr "Mionsonraí modhnóireachta"
 
-#: src/view/com/lists/ListCard.tsx:95
-#: src/view/com/modals/UserAddRemoveLists.tsx:217
+#: src/view/com/lists/ListCard.tsx:95 src/view/com/modals/UserAddRemoveLists.tsx:217
 msgid "Moderation list by {0}"
 msgstr "Liosta modhnóireachta le {0}"
 
@@ -2990,9 +2455,7 @@ msgstr "Liosta modhnóireachta le {0}"
 msgid "Moderation list by <0/>"
 msgstr "Liosta modhnóireachta le <0/>"
 
-#: src/view/com/lists/ListCard.tsx:93
-#: src/view/com/modals/UserAddRemoveLists.tsx:215
-#: src/view/screens/ProfileList.tsx:841
+#: src/view/com/lists/ListCard.tsx:93 src/view/com/modals/UserAddRemoveLists.tsx:215 src/view/screens/ProfileList.tsx:841
 msgid "Moderation list by you"
 msgstr "Liosta modhnóireachta leat"
 
@@ -3008,8 +2471,7 @@ msgstr "Liosta modhnóireachta uasdátaithe"
 msgid "Moderation lists"
 msgstr "Liostaí modhnóireachta"
 
-#: src/Navigation.tsx:131
-#: src/view/screens/ModerationModlists.tsx:58
+#: src/Navigation.tsx:131 src/view/screens/ModerationModlists.tsx:58
 msgid "Moderation Lists"
 msgstr "Liostaí modhnóireachta"
 
@@ -3025,8 +2487,7 @@ msgstr "Stádais modhnóireachta"
 msgid "Moderation tools"
 msgstr "Uirlisí modhnóireachta"
 
-#: src/components/moderation/ModerationDetailsDialog.tsx:48
-#: src/lib/moderation/useModerationCauseDescription.ts:42
+#: src/components/moderation/ModerationDetailsDialog.tsx:48 src/lib/moderation/useModerationCauseDescription.ts:42
 msgid "Moderator has chosen to set a general warning on the content."
 msgstr "Chuir an modhnóir rabhadh ginearálta ar an ábhar."
 
@@ -3054,8 +2515,7 @@ msgstr "Cuir i bhfolach"
 msgid "Mute {truncatedTag}"
 msgstr "Cuir {truncatedTag} i bhfolach"
 
-#: src/view/com/profile/ProfileMenu.tsx:281
-#: src/view/com/profile/ProfileMenu.tsx:288
+#: src/view/com/profile/ProfileMenu.tsx:281 src/view/com/profile/ProfileMenu.tsx:288
 msgid "Mute Account"
 msgstr "Cuir an cuntas i bhfolach"
 
@@ -3067,8 +2527,7 @@ msgstr "Cuir na cuntais i bhfolach"
 msgid "Mute all {displayTag} posts"
 msgstr "Cuir gach postáil {displayTag} i bhfolach"
 
-#: src/components/dms/ConvoMenu.tsx:172
-#: src/components/dms/ConvoMenu.tsx:178
+#: src/components/dms/ConvoMenu.tsx:172 src/components/dms/ConvoMenu.tsx:178
 msgid "Mute conversation"
 msgstr "Balbhaigh an comhrá"
 
@@ -3096,13 +2555,11 @@ msgstr "Cuir an focal seo i bhfolach i dtéacs postálacha agus i gclibeanna"
 msgid "Mute this word in tags only"
 msgstr "Ná cuir an focal seo i bhfolach ach i gclibeanna"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:365
-#: src/view/com/util/forms/PostDropdownBtn.tsx:371
+#: src/view/com/util/forms/PostDropdownBtn.tsx:365 src/view/com/util/forms/PostDropdownBtn.tsx:371
 msgid "Mute thread"
 msgstr "Cuir an snáithe seo i bhfolach"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:381
-#: src/view/com/util/forms/PostDropdownBtn.tsx:383
+#: src/view/com/util/forms/PostDropdownBtn.tsx:381 src/view/com/util/forms/PostDropdownBtn.tsx:383
 msgid "Mute words & tags"
 msgstr "Cuir focail ⁊ clibeanna i bhfolach"
 
@@ -3114,8 +2571,7 @@ msgstr "Curtha i bhfolach"
 msgid "Muted accounts"
 msgstr "Cuntais a cuireadh i bhfolach"
 
-#: src/Navigation.tsx:136
-#: src/view/screens/ModerationMutedAccounts.tsx:109
+#: src/Navigation.tsx:136 src/view/screens/ModerationMutedAccounts.tsx:109
 msgid "Muted Accounts"
 msgstr "Cuntais a Cuireadh i bhFolach"
 
@@ -3135,8 +2591,7 @@ msgstr "Focail ⁊ clibeanna a cuireadh i bhfolach"
 msgid "Muting is private. Muted accounts can interact with you, but you will not see their posts or receive notifications from them."
 msgstr "Tá an cur i bhfolach príobháideach. Is féidir leis na cuntais a chuir tú i bhfolach do chuid postálacha a fheiceáil agus is féidir leo scríobh chugat ach ní fheicfidh tú a gcuid postálacha eile ná aon fhógraí uathu."
 
-#: src/components/dialogs/BirthDateSettings.tsx:35
-#: src/components/dialogs/BirthDateSettings.tsx:38
+#: src/components/dialogs/BirthDateSettings.tsx:35 src/components/dialogs/BirthDateSettings.tsx:38
 msgid "My Birthday"
 msgstr "Mo Bhreithlá"
 
@@ -3156,8 +2611,7 @@ msgstr "Na fothaí a shábháil mé"
 msgid "My Saved Feeds"
 msgstr "Na Fothaí a Shábháil Mé"
 
-#: src/view/com/modals/AddAppPasswords.tsx:174
-#: src/view/com/modals/CreateOrEditList.tsx:279
+#: src/view/com/modals/AddAppPasswords.tsx:174 src/view/com/modals/CreateOrEditList.tsx:279
 msgid "Name"
 msgstr "Ainm"
 
@@ -3165,9 +2619,7 @@ msgstr "Ainm"
 msgid "Name is required"
 msgstr "Tá an t-ainm riachtanach"
 
-#: src/lib/moderation/useReportOptions.ts:58
-#: src/lib/moderation/useReportOptions.ts:92
-#: src/lib/moderation/useReportOptions.ts:100
+#: src/lib/moderation/useReportOptions.ts:58 src/lib/moderation/useReportOptions.ts:92 src/lib/moderation/useReportOptions.ts:100
 msgid "Name or Description Violates Community Standards"
 msgstr "Sáraíonn an tAinm nó an Cur Síos Caighdeáin an Phobail"
 
@@ -3175,9 +2627,7 @@ msgstr "Sáraíonn an tAinm nó an Cur Síos Caighdeáin an Phobail"
 msgid "Nature"
 msgstr "Nádúr"
 
-#: src/screens/Login/ForgotPasswordForm.tsx:173
-#: src/screens/Login/LoginForm.tsx:309
-#: src/view/com/modals/ChangePassword.tsx:169
+#: src/screens/Login/ForgotPasswordForm.tsx:173 src/screens/Login/LoginForm.tsx:309 src/view/com/modals/ChangePassword.tsx:169
 msgid "Navigates to the next screen"
 msgstr "Téann sé seo chuig an gcéad scáileán eile"
 
@@ -3188,10 +2638,6 @@ msgstr "Téann sé seo chuig do phróifíl"
 #: src/components/ReportDialog/SelectReportOptionView.tsx:127
 msgid "Need to report a copyright violation?"
 msgstr "An bhfuil tú ag iarraidh sárú cóipchirt a thuairisciú?"
-
-#: src/view/com/auth/onboarding/WelcomeDesktop.tsx:NaN
-#~ msgid "Never lose access to your followers and data."
-#~ msgstr "Ná bíodh gan fáil ar do chuid leantóirí ná ar do chuid dáta go deo."
 
 #: src/screens/Onboarding/StepFinished.tsx:152
 msgid "Never lose access to your followers or data."
@@ -3210,9 +2656,7 @@ msgstr "Nua"
 msgid "New"
 msgstr "Nua"
 
-#: src/components/dms/dialogs/NewChatDialog.tsx:52
-#: src/screens/Messages/List/index.tsx:331
-#: src/screens/Messages/List/index.tsx:338
+#: src/components/dms/dialogs/NewChatDialog.tsx:52 src/screens/Messages/List/index.tsx:331 src/screens/Messages/List/index.tsx:338
 msgid "New chat"
 msgstr "Comhrá nua"
 
@@ -3237,13 +2681,7 @@ msgctxt "action"
 msgid "New post"
 msgstr "Postáil nua"
 
-#: src/view/screens/Feeds.tsx:627
-#: src/view/screens/Notifications.tsx:177
-#: src/view/screens/Profile.tsx:464
-#: src/view/screens/ProfileFeed.tsx:426
-#: src/view/screens/ProfileList.tsx:201
-#: src/view/screens/ProfileList.tsx:229
-#: src/view/shell/desktop/LeftNav.tsx:271
+#: src/view/screens/Feeds.tsx:627 src/view/screens/Notifications.tsx:177 src/view/screens/Profile.tsx:464 src/view/screens/ProfileFeed.tsx:426 src/view/screens/ProfileList.tsx:201 src/view/screens/ProfileList.tsx:229 src/view/shell/desktop/LeftNav.tsx:271
 msgid "New post"
 msgstr "Postáil nua"
 
@@ -3264,38 +2702,19 @@ msgstr "Na freagraí is déanaí ar dtús"
 msgid "News"
 msgstr "Nuacht"
 
-#: src/screens/Login/ForgotPasswordForm.tsx:143
-#: src/screens/Login/ForgotPasswordForm.tsx:150
-#: src/screens/Login/LoginForm.tsx:308
-#: src/screens/Login/LoginForm.tsx:315
-#: src/screens/Login/SetNewPasswordForm.tsx:174
-#: src/screens/Login/SetNewPasswordForm.tsx:180
-#: src/screens/Signup/index.tsx:220
-#: src/view/com/modals/ChangePassword.tsx:254
-#: src/view/com/modals/ChangePassword.tsx:256
+#: src/screens/Login/ForgotPasswordForm.tsx:143 src/screens/Login/ForgotPasswordForm.tsx:150 src/screens/Login/LoginForm.tsx:308 src/screens/Login/LoginForm.tsx:315 src/screens/Login/SetNewPasswordForm.tsx:174 src/screens/Login/SetNewPasswordForm.tsx:180 src/screens/Signup/index.tsx:220 src/view/com/modals/ChangePassword.tsx:254 src/view/com/modals/ChangePassword.tsx:256
 msgid "Next"
 msgstr "Ar aghaidh"
-
-#: src/view/com/auth/onboarding/WelcomeDesktop.tsx:103
-#~ msgctxt "action"
-#~ msgid "Next"
-#~ msgstr "Ar aghaidh"
 
 #: src/view/com/lightbox/Lightbox.web.tsx:169
 msgid "Next image"
 msgstr "An chéad íomhá eile"
 
-#: src/view/screens/PreferencesFollowingFeed.tsx:128
-#: src/view/screens/PreferencesFollowingFeed.tsx:199
-#: src/view/screens/PreferencesFollowingFeed.tsx:234
-#: src/view/screens/PreferencesFollowingFeed.tsx:271
-#: src/view/screens/PreferencesThreads.tsx:106
-#: src/view/screens/PreferencesThreads.tsx:129
+#: src/view/screens/PreferencesFollowingFeed.tsx:128 src/view/screens/PreferencesFollowingFeed.tsx:199 src/view/screens/PreferencesFollowingFeed.tsx:234 src/view/screens/PreferencesFollowingFeed.tsx:271 src/view/screens/PreferencesThreads.tsx:106 src/view/screens/PreferencesThreads.tsx:129
 msgid "No"
 msgstr "Níl"
 
-#: src/view/screens/ProfileFeed.tsx:559
-#: src/view/screens/ProfileList.tsx:823
+#: src/view/screens/ProfileFeed.tsx:559 src/view/screens/ProfileList.tsx:823
 msgid "No description"
 msgstr "Gan chur síos"
 
@@ -3303,8 +2722,7 @@ msgstr "Gan chur síos"
 msgid "No DNS Panel"
 msgstr "Gan Phainéal DNS"
 
-#: src/components/dialogs/GifSelect.ios.tsx:202
-#: src/components/dialogs/GifSelect.tsx:218
+#: src/components/dialogs/GifSelect.ios.tsx:202 src/components/dialogs/GifSelect.tsx:218
 msgid "No featured GIFs found. There may be an issue with Tenor."
 msgstr "Níor aimsíodh GIFanna speisialta. D'fhéadfadh sé gur tharla fadhb le Tenor."
 
@@ -3328,15 +2746,11 @@ msgstr "Níl aon chomhráite eile le taispeáint"
 msgid "No notifications yet!"
 msgstr "Níl aon fhógra ann fós!"
 
-#: src/components/dms/MessagesNUX.tsx:149
-#: src/components/dms/MessagesNUX.tsx:152
-#: src/screens/Messages/Settings.tsx:93
-#: src/screens/Messages/Settings.tsx:96
+#: src/components/dms/MessagesNUX.tsx:149 src/components/dms/MessagesNUX.tsx:152 src/screens/Messages/Settings.tsx:93 src/screens/Messages/Settings.tsx:96
 msgid "No one"
 msgstr "Duine ar bith"
 
-#: src/view/com/composer/text-input/mobile/Autocomplete.tsx:101
-#: src/view/com/composer/text-input/web/Autocomplete.tsx:195
+#: src/view/com/composer/text-input/mobile/Autocomplete.tsx:101 src/view/com/composer/text-input/web/Autocomplete.tsx:195
 msgid "No result"
 msgstr "Gan torthaí"
 
@@ -3352,19 +2766,15 @@ msgstr "Gan torthaí"
 msgid "No results found for \"{query}\""
 msgstr "Gan torthaí ar “{query}”"
 
-#: src/view/com/modals/ListAddRemoveUsers.tsx:127
-#: src/view/screens/Search/Search.tsx:296
-#: src/view/screens/Search/Search.tsx:335
+#: src/view/com/modals/ListAddRemoveUsers.tsx:127 src/view/screens/Search/Search.tsx:296 src/view/screens/Search/Search.tsx:335
 msgid "No results found for {query}"
 msgstr "Gan torthaí ar {query}"
 
-#: src/components/dialogs/GifSelect.ios.tsx:200
-#: src/components/dialogs/GifSelect.tsx:216
+#: src/components/dialogs/GifSelect.ios.tsx:200 src/components/dialogs/GifSelect.tsx:216
 msgid "No search results found for \"{search}\"."
 msgstr "Gan torthaí ar \"{search}\"."
 
-#: src/components/dialogs/EmbedConsent.tsx:105
-#: src/components/dialogs/EmbedConsent.tsx:112
+#: src/components/dialogs/EmbedConsent.tsx:105 src/components/dialogs/EmbedConsent.tsx:112
 msgid "No thanks"
 msgstr "Níor mhaith liom é sin."
 
@@ -3376,8 +2786,7 @@ msgstr "Duine ar bith"
 msgid "Nobody can reply"
 msgstr "Níl cead ag éinne freagra a thabhairt"
 
-#: src/components/LikedByList.tsx:79
-#: src/components/LikesDialog.tsx:99
+#: src/components/LikedByList.tsx:79 src/components/LikesDialog.tsx:99
 msgid "Nobody has liked this yet. Maybe you should be the first!"
 msgstr "Níor mhol éinne fós é. Ar cheart duit tosú?"
 
@@ -3385,23 +2794,15 @@ msgstr "Níor mhol éinne fós é. Ar cheart duit tosú?"
 msgid "Non-sexual Nudity"
 msgstr "Lomnochtacht Neamhghnéasach"
 
-#: src/view/com/modals/SelfLabel.tsx:135
-#~ msgid "Not Applicable."
-#~ msgstr "Ní bhaineann sé sin le hábhar."
-
-#: src/Navigation.tsx:116
-#: src/view/screens/Profile.tsx:100
+#: src/Navigation.tsx:116 src/view/screens/Profile.tsx:100
 msgid "Not Found"
 msgstr "Ní bhfuarthas é sin"
 
-#: src/view/com/modals/VerifyEmail.tsx:254
-#: src/view/com/modals/VerifyEmail.tsx:260
+#: src/view/com/modals/VerifyEmail.tsx:254 src/view/com/modals/VerifyEmail.tsx:260
 msgid "Not right now"
 msgstr "Ní anois"
 
-#: src/view/com/profile/ProfileMenu.tsx:370
-#: src/view/com/util/forms/PostDropdownBtn.tsx:459
-#: src/view/com/util/post-ctrls/PostCtrls.tsx:308
+#: src/view/com/profile/ProfileMenu.tsx:370 src/view/com/util/forms/PostDropdownBtn.tsx:459 src/view/com/util/post-ctrls/PostCtrls.tsx:308
 msgid "Note about sharing"
 msgstr "Nóta faoi roinnt"
 
@@ -3421,13 +2822,7 @@ msgstr "Fuaimeanna fógra"
 msgid "Notification Sounds"
 msgstr "Fuaimeanna Fógra"
 
-#: src/Navigation.tsx:516
-#: src/view/screens/Notifications.tsx:126
-#: src/view/screens/Notifications.tsx:154
-#: src/view/shell/bottom-bar/BottomBar.tsx:227
-#: src/view/shell/desktop/LeftNav.tsx:350
-#: src/view/shell/Drawer.tsx:456
-#: src/view/shell/Drawer.tsx:457
+#: src/Navigation.tsx:516 src/view/screens/Notifications.tsx:126 src/view/screens/Notifications.tsx:154 src/view/shell/bottom-bar/BottomBar.tsx:227 src/view/shell/desktop/LeftNav.tsx:350 src/view/shell/Drawer.tsx:456 src/view/shell/Drawer.tsx:457
 msgid "Notifications"
 msgstr "Fógraí"
 
@@ -3443,17 +2838,11 @@ msgstr "Lomnochtacht"
 msgid "Nudity or adult content not labeled as such"
 msgstr "Lomnochtacht nó ábhar do dhaoine fásta nach bhfuil an lipéad sin air"
 
-#: src/screens/Signup/index.tsx:145
-#~ msgid "of"
-#~ msgstr "de"
-
 #: src/lib/moderation/useLabelBehaviorDescription.ts:11
 msgid "Off"
 msgstr "As"
 
-#: src/components/dialogs/GifSelect.ios.tsx:237
-#: src/components/dialogs/GifSelect.tsx:255
-#: src/view/com/util/ErrorBoundary.tsx:55
+#: src/components/dialogs/GifSelect.ios.tsx:237 src/components/dialogs/GifSelect.tsx:255 src/view/com/util/ErrorBoundary.tsx:55
 msgid "Oh no!"
 msgstr "Úps!"
 
@@ -3497,9 +2886,7 @@ msgstr "Níl ann ach litreacha, uimhreacha, agus fleiscíní"
 msgid "Oops, something went wrong!"
 msgstr "Úps! Theip ar rud éigin!"
 
-#: src/components/Lists.tsx:191
-#: src/view/screens/AppPasswords.tsx:69
-#: src/view/screens/Profile.tsx:100
+#: src/components/Lists.tsx:191 src/view/screens/AppPasswords.tsx:69 src/view/screens/Profile.tsx:100
 msgid "Oops!"
 msgstr "Úps!"
 
@@ -3509,19 +2896,17 @@ msgstr "Oscail"
 
 #: src/view/com/posts/AviFollowButton.tsx:89
 msgid "Open {name} profile shortcut menu"
-msgstr ""
+msgstr "Oscail roghchlár giorrúcháin phróifíl {name}"
 
 #: src/screens/Onboarding/StepProfile/index.tsx:276
 msgid "Open avatar creator"
 msgstr "Oscail an cruthaitheoir abhatáir"
 
-#: src/screens/Messages/List/ChatListItem.tsx:214
-#: src/screens/Messages/List/ChatListItem.tsx:215
+#: src/screens/Messages/List/ChatListItem.tsx:214 src/screens/Messages/List/ChatListItem.tsx:215
 msgid "Open conversation options"
 msgstr "Oscail na roghanna comhrá"
 
-#: src/view/com/composer/Composer.tsx:600
-#: src/view/com/composer/Composer.tsx:601
+#: src/view/com/composer/Composer.tsx:600 src/view/com/composer/Composer.tsx:601
 msgid "Open emoji picker"
 msgstr "Oscail roghnóir na n-emoji"
 
@@ -3549,8 +2934,7 @@ msgstr "Oscail an nascleanúint"
 msgid "Open post options menu"
 msgstr "Oscail roghchlár na bpostálacha"
 
-#: src/view/screens/Settings/index.tsx:860
-#: src/view/screens/Settings/index.tsx:870
+#: src/view/screens/Settings/index.tsx:860 src/view/screens/Settings/index.tsx:870
 msgid "Open storybook page"
 msgstr "Oscail leathanach an Storybook"
 
@@ -3569,10 +2953,6 @@ msgstr "Osclaíonn sé seo na socruithe inrochtaineachta"
 #: src/view/screens/Log.tsx:54
 msgid "Opens additional details for a debug entry"
 msgstr "Osclaíonn sé seo tuilleadh sonraí le haghaidh iontráil dífhabhtaithe"
-
-#: src/view/com/notifications/FeedItem.tsx:349
-#~ msgid "Opens an expanded list of users in this notification"
-#~ msgstr "Osclaíonn sé seo liosta méadaithe d’úsáideoirí san fhógra seo"
 
 #: src/view/com/composer/photos/OpenCameraBtn.tsx:74
 msgid "Opens camera on device"
@@ -3598,13 +2978,11 @@ msgstr "Osclaíonn sé seo gailearaí na ngrianghraf ar an ngléas"
 msgid "Opens external embeds settings"
 msgstr "Osclaíonn sé seo na socruithe le haghaidh leabuithe seachtracha"
 
-#: src/view/com/auth/SplashScreen.tsx:50
-#: src/view/com/auth/SplashScreen.web.tsx:99
+#: src/view/com/auth/SplashScreen.tsx:50 src/view/com/auth/SplashScreen.web.tsx:99
 msgid "Opens flow to create a new Bluesky account"
 msgstr "Osclaíonn sé seo an próiseas le cuntas nua Bluesky a chruthú"
 
-#: src/view/com/auth/SplashScreen.tsx:65
-#: src/view/com/auth/SplashScreen.web.tsx:114
+#: src/view/com/auth/SplashScreen.tsx:65 src/view/com/auth/SplashScreen.web.tsx:114
 msgid "Opens flow to sign into your existing Bluesky account"
 msgstr "Osclaíonn sé seo an síniú isteach ar an gcuntas Bluesky atá agat cheana féin"
 
@@ -3618,7 +2996,7 @@ msgstr "Osclaíonn sé seo liosta na gcód cuiridh"
 
 #: src/view/screens/Settings/index.tsx:808
 msgid "Opens modal for account deactivation confirmation"
-msgstr ""
+msgstr "Osclaíonn sé seo fuinneog chun díghníomhú an chuntais a dhearbhú"
 
 #: src/view/screens/Settings/index.tsx:830
 msgid "Opens modal for account deletion confirmation. Requires email code"
@@ -3652,8 +3030,7 @@ msgstr "Osclaíonn sé seo socruithe na modhnóireachta"
 msgid "Opens password reset form"
 msgstr "Osclaíonn sé seo an fhoirm leis an bpasfhocal a athrú"
 
-#: src/view/com/home/HomeHeaderLayout.web.tsx:77
-#: src/view/screens/Feeds.tsx:417
+#: src/view/com/home/HomeHeaderLayout.web.tsx:77 src/view/screens/Feeds.tsx:417
 msgid "Opens screen to edit Saved Feeds"
 msgstr "Osclaíonn sé seo an scáileán leis na fothaí sábháilte a athrú"
 
@@ -3673,8 +3050,7 @@ msgstr "Osclaíonn sé seo roghanna don fhotha Following"
 msgid "Opens the linked website"
 msgstr "Osclaíonn sé seo an suíomh gréasáin atá nasctha"
 
-#: src/view/screens/Settings/index.tsx:861
-#: src/view/screens/Settings/index.tsx:871
+#: src/view/screens/Settings/index.tsx:861 src/view/screens/Settings/index.tsx:871
 msgid "Opens the storybook page"
 msgstr "Osclaíonn sé seo leathanach an Storybook"
 
@@ -3686,17 +3062,15 @@ msgstr "Osclaíonn sé seo logleabhar an chórais"
 msgid "Opens the threads preferences"
 msgstr "Osclaíonn sé seo roghanna na snáitheanna"
 
-#: src/view/com/notifications/FeedItem.tsx:427
-#: src/view/com/util/UserAvatar.tsx:409
+#: src/view/com/notifications/FeedItem.tsx:427 src/view/com/util/UserAvatar.tsx:409
 msgid "Opens this profile"
-msgstr ""
+msgstr "Osclaíonn sé an phróifíl seo"
 
 #: src/view/com/util/forms/DropdownButton.tsx:293
 msgid "Option {0} of {numItems}"
 msgstr "Rogha {0} as {numItems}"
 
-#: src/components/dms/ReportDialog.tsx:181
-#: src/components/ReportDialog/SubmitView.tsx:163
+#: src/components/dms/ReportDialog.tsx:181 src/components/ReportDialog/SubmitView.tsx:163
 msgid "Optionally provide additional information below:"
 msgstr "Is féidir tuilleadh eolais a chur ar fáil thíos:"
 
@@ -3706,11 +3080,11 @@ msgstr "Nó cuir na roghanna seo le chéile:"
 
 #: src/screens/Deactivated.tsx:211
 msgid "Or, continue with another account."
-msgstr ""
+msgstr "Nó, lean ort le cuntas eile."
 
 #: src/screens/Deactivated.tsx:194
 msgid "Or, log into one of your other accounts."
-msgstr ""
+msgstr "Nó, logáil isteach i gceann eile de do chuntais."
 
 #: src/lib/moderation/useReportOptions.ts:26
 msgid "Other"
@@ -3728,8 +3102,7 @@ msgstr "Eile…"
 msgid "Our moderators have reviewed reports and decided to disable your access to chats on Bluesky."
 msgstr "Ta ár modhnóirí tar éis athbhreithniú a dhéanamh ar thuairiscí. Chinn siad gan ligean duit comhráite a úsáid ar Bluesky."
 
-#: src/components/Lists.tsx:208
-#: src/view/screens/NotFound.tsx:45
+#: src/components/Lists.tsx:208 src/view/screens/NotFound.tsx:45
 msgid "Page not found"
 msgstr "Leathanach gan aimsiú"
 
@@ -3737,10 +3110,7 @@ msgstr "Leathanach gan aimsiú"
 msgid "Page Not Found"
 msgstr "Leathanach gan aimsiú"
 
-#: src/screens/Login/LoginForm.tsx:201
-#: src/screens/Signup/StepInfo/index.tsx:102
-#: src/view/com/modals/DeleteAccount.tsx:257
-#: src/view/com/modals/DeleteAccount.tsx:264
+#: src/screens/Login/LoginForm.tsx:201 src/screens/Signup/StepInfo/index.tsx:102 src/view/com/modals/DeleteAccount.tsx:257 src/view/com/modals/DeleteAccount.tsx:264
 msgid "Password"
 msgstr "Pasfhocal"
 
@@ -3788,8 +3158,7 @@ msgstr "Peataí"
 msgid "Pictures meant for adults."
 msgstr "Pictiúir le haghaidh daoine fásta."
 
-#: src/view/screens/ProfileFeed.tsx:287
-#: src/view/screens/ProfileList.tsx:617
+#: src/view/screens/ProfileFeed.tsx:287 src/view/screens/ProfileList.tsx:617
 msgid "Pin to home"
 msgstr "Greamaigh le baile"
 
@@ -3817,8 +3186,7 @@ msgstr "Seinn {0}"
 msgid "Play or pause the GIF"
 msgstr "Seinn nó stop an GIF"
 
-#: src/view/com/util/post-embeds/ExternalPlayerEmbed.tsx:57
-#: src/view/com/util/post-embeds/ExternalPlayerEmbed.tsx:58
+#: src/view/com/util/post-embeds/ExternalPlayerEmbed.tsx:57 src/view/com/util/post-embeds/ExternalPlayerEmbed.tsx:58
 msgid "Play Video"
 msgstr "Seinn an físeán"
 
@@ -3870,8 +3238,7 @@ msgstr "Abair linn, le do thoil, cén fáth a gcreideann tú gur chuir {0} an li
 msgid "Please explain why you think your chats were incorrectly disabled"
 msgstr "Mínigh, le do thoil, an fáth a gcreideann tú go bhfuil sé mícheart nach ligtear duit comhráite a úsáid"
 
-#: src/lib/hooks/useAccountSwitcher.ts:48
-#: src/lib/hooks/useAccountSwitcher.ts:58
+#: src/lib/hooks/useAccountSwitcher.ts:48 src/lib/hooks/useAccountSwitcher.ts:58
 msgid "Please sign in as @{0}"
 msgstr "Logáil isteach mar @{0}"
 
@@ -3891,8 +3258,7 @@ msgstr "Polaitíocht"
 msgid "Porn"
 msgstr "Pornagrafaíocht"
 
-#: src/view/com/composer/Composer.tsx:462
-#: src/view/com/composer/Composer.tsx:470
+#: src/view/com/composer/Composer.tsx:462 src/view/com/composer/Composer.tsx:470
 msgctxt "action"
 msgid "Post"
 msgstr "Postáil"
@@ -3906,9 +3272,7 @@ msgstr "Postáil"
 msgid "Post by {0}"
 msgstr "Postáil ó {0}"
 
-#: src/Navigation.tsx:183
-#: src/Navigation.tsx:190
-#: src/Navigation.tsx:197
+#: src/Navigation.tsx:183 src/Navigation.tsx:190 src/Navigation.tsx:197
 msgid "Post by @{0}"
 msgstr "Postáil ó @{0}"
 
@@ -3920,13 +3284,11 @@ msgstr "Scriosadh an phostáil"
 msgid "Post hidden"
 msgstr "Cuireadh an phostáil i bhfolach"
 
-#: src/components/moderation/ModerationDetailsDialog.tsx:97
-#: src/lib/moderation/useModerationCauseDescription.ts:101
+#: src/components/moderation/ModerationDetailsDialog.tsx:97 src/lib/moderation/useModerationCauseDescription.ts:101
 msgid "Post Hidden by Muted Word"
 msgstr "Postáil nach bhfuil le feiceáil de bharr focail a cuireadh i bhfolach"
 
-#: src/components/moderation/ModerationDetailsDialog.tsx:100
-#: src/lib/moderation/useModerationCauseDescription.ts:110
+#: src/components/moderation/ModerationDetailsDialog.tsx:100 src/lib/moderation/useModerationCauseDescription.ts:110
 msgid "Post Hidden by You"
 msgstr "Postáil a chuir tú i bhfolach"
 
@@ -3938,8 +3300,7 @@ msgstr "Teanga postála"
 msgid "Post Languages"
 msgstr "Teangacha postála"
 
-#: src/view/com/post-thread/PostThread.tsx:188
-#: src/view/com/post-thread/PostThread.tsx:200
+#: src/view/com/post-thread/PostThread.tsx:188 src/view/com/post-thread/PostThread.tsx:200
 msgid "Post not found"
 msgstr "Ní bhfuarthas an phostáil"
 
@@ -3971,10 +3332,7 @@ msgstr "Brúigh le iarracht a thabhairt ar nascadh arís"
 msgid "Press to change hosting provider"
 msgstr "Brúigh leis an soláthraí óstála a athrú"
 
-#: src/components/Error.tsx:85
-#: src/components/Lists.tsx:93
-#: src/screens/Messages/Conversation/MessageListError.tsx:24
-#: src/screens/Signup/index.tsx:200
+#: src/components/Error.tsx:85 src/components/Lists.tsx:93 src/screens/Messages/Conversation/MessageListError.tsx:24 src/screens/Signup/index.tsx:200
 msgid "Press to retry"
 msgstr "Brúigh le iarracht eile a dhéanamh"
 
@@ -3990,16 +3348,11 @@ msgstr "Príomhtheanga"
 msgid "Prioritize Your Follows"
 msgstr "Tabhair Tosaíocht do Do Chuid Leantóirí"
 
-#: src/view/screens/Settings/index.tsx:654
-#: src/view/shell/desktop/RightNav.tsx:77
+#: src/view/screens/Settings/index.tsx:654 src/view/shell/desktop/RightNav.tsx:77
 msgid "Privacy"
 msgstr "Príobháideacht"
 
-#: src/Navigation.tsx:238
-#: src/screens/Signup/StepInfo/Policies.tsx:56
-#: src/view/screens/PrivacyPolicy.tsx:29
-#: src/view/screens/Settings/index.tsx:957
-#: src/view/shell/Drawer.tsx:284
+#: src/Navigation.tsx:238 src/screens/Signup/StepInfo/Policies.tsx:56 src/view/screens/PrivacyPolicy.tsx:29 src/view/screens/Settings/index.tsx:957 src/view/shell/Drawer.tsx:284
 msgid "Privacy Policy"
 msgstr "Polasaí príobháideachta"
 
@@ -4011,16 +3364,11 @@ msgstr "Roinn TDanna príobháideacha le úsáideoirí eile."
 msgid "Processing..."
 msgstr "Á phróiseáil..."
 
-#: src/view/screens/DebugMod.tsx:894
-#: src/view/screens/Profile.tsx:345
+#: src/view/screens/DebugMod.tsx:894 src/view/screens/Profile.tsx:345
 msgid "profile"
 msgstr "próifíl"
 
-#: src/view/shell/bottom-bar/BottomBar.tsx:272
-#: src/view/shell/desktop/LeftNav.tsx:381
-#: src/view/shell/Drawer.tsx:78
-#: src/view/shell/Drawer.tsx:541
-#: src/view/shell/Drawer.tsx:542
+#: src/view/shell/bottom-bar/BottomBar.tsx:272 src/view/shell/desktop/LeftNav.tsx:381 src/view/shell/Drawer.tsx:78 src/view/shell/Drawer.tsx:541 src/view/shell/Drawer.tsx:542
 msgid "Profile"
 msgstr "Próifíl"
 
@@ -4052,22 +3400,9 @@ msgstr "Foilsigh an phostáil"
 msgid "Publish reply"
 msgstr "Foilsigh an freagra"
 
-#: src/view/com/util/post-ctrls/RepostButton.tsx:113
-#: src/view/com/util/post-ctrls/RepostButton.tsx:125
-#: src/view/com/util/post-ctrls/RepostButton.web.tsx:78
-#: src/view/com/util/post-ctrls/RepostButton.web.tsx:81
+#: src/view/com/util/post-ctrls/RepostButton.tsx:113 src/view/com/util/post-ctrls/RepostButton.tsx:125 src/view/com/util/post-ctrls/RepostButton.web.tsx:78 src/view/com/util/post-ctrls/RepostButton.web.tsx:81
 msgid "Quote post"
 msgstr "Postáil athluaite"
-
-#: src/view/com/modals/Repost.tsx:66
-#~ msgctxt "action"
-#~ msgid "Quote post"
-#~ msgstr "Luaigh an phostáil seo"
-
-#: src/view/com/modals/Repost.tsx:71
-#~ msgctxt "action"
-#~ msgid "Quote Post"
-#~ msgstr "Luaigh an phostáil seo"
 
 #: src/view/screens/PreferencesThreads.tsx:86
 msgid "Random (aka \"Poster's Roulette\")"
@@ -4079,7 +3414,7 @@ msgstr "Cóimheasa"
 
 #: src/screens/Deactivated.tsx:144
 msgid "Reactivate your account"
-msgstr ""
+msgstr "Athghníomhaigh do chuntas"
 
 #: src/components/dms/ReportDialog.tsx:172
 msgid "Reason:"
@@ -4089,14 +3424,6 @@ msgstr "Fáth:"
 msgid "Recent Searches"
 msgstr "Cuardaigh a Rinneadh le Déanaí"
 
-#: src/view/com/auth/onboarding/RecommendedFeeds.tsx:117
-#~ msgid "Recommended Feeds"
-#~ msgstr "Fothaí molta"
-
-#: src/view/com/auth/onboarding/RecommendedFollows.tsx:181
-#~ msgid "Recommended Users"
-#~ msgstr "Cuntais mholta"
-
 #: src/screens/Messages/Conversation/MessageListError.tsx:20
 msgid "Reconnect"
 msgstr "Athnasc"
@@ -4105,12 +3432,7 @@ msgstr "Athnasc"
 msgid "Reload conversations"
 msgstr "Athlódáil comhráite"
 
-#: src/components/dialogs/MutedWords.tsx:288
-#: src/view/com/feeds/FeedSourceCard.tsx:296
-#: src/view/com/modals/ListAddRemoveUsers.tsx:268
-#: src/view/com/modals/SelfLabel.tsx:84
-#: src/view/com/modals/UserAddRemoveLists.tsx:230
-#: src/view/com/posts/FeedErrorMessage.tsx:213
+#: src/components/dialogs/MutedWords.tsx:288 src/view/com/feeds/FeedSourceCard.tsx:296 src/view/com/modals/ListAddRemoveUsers.tsx:268 src/view/com/modals/SelfLabel.tsx:84 src/view/com/modals/UserAddRemoveLists.tsx:230 src/view/com/posts/FeedErrorMessage.tsx:213
 msgid "Remove"
 msgstr "Scrios"
 
@@ -4128,11 +3450,9 @@ msgstr "Bain an Fógra Meirge Amach"
 
 #: src/screens/Messages/Conversation/MessageInputEmbed.tsx:218
 msgid "Remove embed"
-msgstr ""
+msgstr "Bain an leabú"
 
-#: src/view/com/posts/FeedErrorMessage.tsx:169
-#: src/view/com/posts/FeedShutdownMsg.tsx:113
-#: src/view/com/posts/FeedShutdownMsg.tsx:117
+#: src/view/com/posts/FeedErrorMessage.tsx:169 src/view/com/posts/FeedShutdownMsg.tsx:113 src/view/com/posts/FeedShutdownMsg.tsx:117
 msgid "Remove feed"
 msgstr "Bain an fotha de"
 
@@ -4140,11 +3460,7 @@ msgstr "Bain an fotha de"
 msgid "Remove feed?"
 msgstr "An bhfuil fonn ort an fotha a bhaint?"
 
-#: src/view/com/feeds/FeedSourceCard.tsx:180
-#: src/view/com/feeds/FeedSourceCard.tsx:245
-#: src/view/screens/ProfileFeed.tsx:330
-#: src/view/screens/ProfileFeed.tsx:336
-#: src/view/screens/ProfileList.tsx:443
+#: src/view/com/feeds/FeedSourceCard.tsx:180 src/view/com/feeds/FeedSourceCard.tsx:245 src/view/screens/ProfileFeed.tsx:330 src/view/screens/ProfileFeed.tsx:336 src/view/screens/ProfileList.tsx:443
 msgid "Remove from my feeds"
 msgstr "Bain de mo chuid fothaí"
 
@@ -4166,18 +3482,17 @@ msgstr "Bain focal folaigh de do liosta"
 
 #: src/view/screens/Search/Search.tsx:1014
 msgid "Remove profile"
-msgstr ""
+msgstr "Bain an phróifíl"
 
 #: src/view/screens/Search/Search.tsx:1016
 msgid "Remove profile from search history"
-msgstr ""
+msgstr "Bain an phróifíl seo as an stair cuardaigh"
 
 #: src/view/com/util/post-embeds/QuoteEmbed.tsx:238
 msgid "Remove quote"
 msgstr "Bain an t-athfhriotal de"
 
-#: src/view/com/util/post-ctrls/RepostButton.tsx:90
-#: src/view/com/util/post-ctrls/RepostButton.tsx:106
+#: src/view/com/util/post-ctrls/RepostButton.tsx:90 src/view/com/util/post-ctrls/RepostButton.tsx:106
 msgid "Remove repost"
 msgstr "Scrios an athphostáil"
 
@@ -4185,8 +3500,7 @@ msgstr "Scrios an athphostáil"
 msgid "Remove this feed from your saved feeds"
 msgstr "Bain an fotha seo de do chuid fothaí sábháilte"
 
-#: src/view/com/modals/ListAddRemoveUsers.tsx:199
-#: src/view/com/modals/UserAddRemoveLists.tsx:165
+#: src/view/com/modals/ListAddRemoveUsers.tsx:199 src/view/com/modals/UserAddRemoveLists.tsx:165
 msgid "Removed from list"
 msgstr "Baineadh den liosta é"
 
@@ -4194,9 +3508,7 @@ msgstr "Baineadh den liosta é"
 msgid "Removed from my feeds"
 msgstr "Baineadh de do chuid fothaí é"
 
-#: src/view/com/posts/FeedShutdownMsg.tsx:44
-#: src/view/screens/ProfileFeed.tsx:191
-#: src/view/screens/ProfileList.tsx:320
+#: src/view/com/posts/FeedShutdownMsg.tsx:44 src/view/screens/ProfileFeed.tsx:191 src/view/screens/ProfileList.tsx:320
 msgid "Removed from your feeds"
 msgstr "Baineadh de do chuid fothaí é"
 
@@ -4208,8 +3520,7 @@ msgstr "Baineann sé seo an mhionsamhail réamhshocraithe de {0}"
 msgid "Removes quoted post"
 msgstr "Baineann sé seo an t-athfhriotal"
 
-#: src/view/com/posts/FeedShutdownMsg.tsx:126
-#: src/view/com/posts/FeedShutdownMsg.tsx:130
+#: src/view/com/posts/FeedShutdownMsg.tsx:126 src/view/com/posts/FeedShutdownMsg.tsx:130
 msgid "Replace with Discover"
 msgstr "Cuir an fotha Discover ina áit"
 
@@ -4230,31 +3541,20 @@ msgstr "Freagair"
 msgid "Reply Filters"
 msgstr "Scagairí freagra"
 
-#: src/view/com/post/Post.tsx:NaN
-#~ msgctxt "description"
-#~ msgid "Reply to <0/>"
-#~ msgstr "Freagra ar <0/>"
-
-#: src/view/com/post/Post.tsx:190
-#: src/view/com/posts/FeedItem.tsx:427
+#: src/view/com/post/Post.tsx:190 src/view/com/posts/FeedItem.tsx:427
 msgctxt "description"
 msgid "Reply to <0><1/></0>"
 msgstr "Freagra ar <0><1/></0>"
 
-#: src/components/dms/MessageMenu.tsx:132
-#: src/components/dms/MessagesListBlockedFooter.tsx:77
-#: src/components/dms/MessagesListBlockedFooter.tsx:84
+#: src/components/dms/MessageMenu.tsx:132 src/components/dms/MessagesListBlockedFooter.tsx:77 src/components/dms/MessagesListBlockedFooter.tsx:84
 msgid "Report"
 msgstr "Tuairiscigh"
 
-#: src/view/com/profile/ProfileMenu.tsx:321
-#: src/view/com/profile/ProfileMenu.tsx:324
+#: src/view/com/profile/ProfileMenu.tsx:321 src/view/com/profile/ProfileMenu.tsx:324
 msgid "Report Account"
 msgstr "Déan gearán faoi chuntas"
 
-#: src/components/dms/ConvoMenu.tsx:197
-#: src/components/dms/ConvoMenu.tsx:200
-#: src/components/dms/ReportConversationPrompt.tsx:18
+#: src/components/dms/ConvoMenu.tsx:197 src/components/dms/ConvoMenu.tsx:200 src/components/dms/ReportConversationPrompt.tsx:18
 msgid "Report conversation"
 msgstr "Tuairiscigh an comhrá seo"
 
@@ -4262,8 +3562,7 @@ msgstr "Tuairiscigh an comhrá seo"
 msgid "Report dialog"
 msgstr "Tuairiscigh comhrá"
 
-#: src/view/screens/ProfileFeed.tsx:347
-#: src/view/screens/ProfileFeed.tsx:349
+#: src/view/screens/ProfileFeed.tsx:347 src/view/screens/ProfileFeed.tsx:349
 msgid "Report feed"
 msgstr "Déan gearán faoi fhotha"
 
@@ -4275,8 +3574,7 @@ msgstr "Déan gearán faoi liosta"
 msgid "Report message"
 msgstr "Tuairiscigh an teachtaireacht seo"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:407
-#: src/view/com/util/forms/PostDropdownBtn.tsx:409
+#: src/view/com/util/forms/PostDropdownBtn.tsx:407 src/view/com/util/forms/PostDropdownBtn.tsx:409
 msgid "Report post"
 msgstr "Déan gearán faoi phostáil"
 
@@ -4292,9 +3590,7 @@ msgstr "Déan gearán faoin fhotha seo"
 msgid "Report this list"
 msgstr "Déan gearán faoin liosta seo"
 
-#: src/components/dms/ReportDialog.tsx:47
-#: src/components/dms/ReportDialog.tsx:140
-#: src/components/ReportDialog/SelectReportOptionView.tsx:59
+#: src/components/dms/ReportDialog.tsx:47 src/components/dms/ReportDialog.tsx:140 src/components/ReportDialog/SelectReportOptionView.tsx:59
 msgid "Report this message"
 msgstr "Tuairiscigh an teachtaireacht seo"
 
@@ -4306,21 +3602,16 @@ msgstr "Déan gearán faoin phostáil seo"
 msgid "Report this user"
 msgstr "Déan gearán faoin úsáideoir seo"
 
-#: src/view/com/util/post-ctrls/RepostButton.tsx:63
-#: src/view/com/util/post-ctrls/RepostButton.tsx:91
-#: src/view/com/util/post-ctrls/RepostButton.tsx:107
+#: src/view/com/util/post-ctrls/RepostButton.tsx:63 src/view/com/util/post-ctrls/RepostButton.tsx:91 src/view/com/util/post-ctrls/RepostButton.tsx:107
 msgctxt "action"
 msgid "Repost"
 msgstr "Athphostáil"
 
-#: src/view/com/util/post-ctrls/RepostButton.web.tsx:69
-#: src/view/com/util/post-ctrls/RepostButton.web.tsx:73
+#: src/view/com/util/post-ctrls/RepostButton.web.tsx:69 src/view/com/util/post-ctrls/RepostButton.web.tsx:73
 msgid "Repost"
 msgstr "Athphostáil"
 
-#: src/view/com/util/post-ctrls/RepostButton.tsx:83
-#: src/view/com/util/post-ctrls/RepostButton.web.tsx:46
-#: src/view/com/util/post-ctrls/RepostButton.web.tsx:92
+#: src/view/com/util/post-ctrls/RepostButton.tsx:83 src/view/com/util/post-ctrls/RepostButton.web.tsx:46 src/view/com/util/post-ctrls/RepostButton.web.tsx:92
 msgid "Repost or quote post"
 msgstr "Athphostáil nó luaigh postáil"
 
@@ -4331,10 +3622,6 @@ msgstr "Athphostáilte ag"
 #: src/view/com/posts/FeedItem.tsx:250
 msgid "Reposted by {0}"
 msgstr "Athphostáilte ag {0}"
-
-#: src/view/com/posts/FeedItem.tsx:214
-#~ msgid "Reposted by <0/>"
-#~ msgstr "Athphostáilte ag <0/>"
 
 #: src/view/com/posts/FeedItem.tsx:265
 msgid "Reposted by <0><1/></0>"
@@ -4348,13 +3635,11 @@ msgstr "— d'athphostáil sé/sí do phostáil"
 msgid "Reposts of this post"
 msgstr "Athphostálacha den phostáil seo"
 
-#: src/view/com/modals/ChangeEmail.tsx:176
-#: src/view/com/modals/ChangeEmail.tsx:178
+#: src/view/com/modals/ChangeEmail.tsx:176 src/view/com/modals/ChangeEmail.tsx:178
 msgid "Request Change"
 msgstr "Iarr Athrú"
 
-#: src/view/com/modals/ChangePassword.tsx:242
-#: src/view/com/modals/ChangePassword.tsx:244
+#: src/view/com/modals/ChangePassword.tsx:242 src/view/com/modals/ChangePassword.tsx:244
 msgid "Request Code"
 msgstr "Iarr Cód"
 
@@ -4370,8 +3655,7 @@ msgstr "Bíodh cód ríomhphoist ag teastáil chun logáil isteach"
 msgid "Required for this provider"
 msgstr "Riachtanach don soláthraí seo"
 
-#: src/view/screens/Settings/DisableEmail2FADialog.tsx:168
-#: src/view/screens/Settings/DisableEmail2FADialog.tsx:171
+#: src/view/screens/Settings/DisableEmail2FADialog.tsx:168 src/view/screens/Settings/DisableEmail2FADialog.tsx:171
 msgid "Resend email"
 msgstr "Athsheol an ríomhphost"
 
@@ -4383,8 +3667,7 @@ msgstr "Cód athshocraithe"
 msgid "Reset Code"
 msgstr "Cód Athshocraithe"
 
-#: src/view/screens/Settings/index.tsx:900
-#: src/view/screens/Settings/index.tsx:903
+#: src/view/screens/Settings/index.tsx:900 src/view/screens/Settings/index.tsx:903
 msgid "Reset onboarding state"
 msgstr "Athshocraigh an próiseas cláraithe"
 
@@ -4392,8 +3675,7 @@ msgstr "Athshocraigh an próiseas cláraithe"
 msgid "Reset password"
 msgstr "Athshocraigh an pasfhocal"
 
-#: src/view/screens/Settings/index.tsx:880
-#: src/view/screens/Settings/index.tsx:883
+#: src/view/screens/Settings/index.tsx:880 src/view/screens/Settings/index.tsx:883
 msgid "Reset preferences state"
 msgstr "Athshocraigh na roghanna"
 
@@ -4409,27 +3691,15 @@ msgstr "Athshocraíonn sé seo na roghanna"
 msgid "Retries login"
 msgstr "Baineann sé seo triail eile as an logáil isteach"
 
-#: src/view/com/util/error/ErrorMessage.tsx:57
-#: src/view/com/util/error/ErrorScreen.tsx:74
+#: src/view/com/util/error/ErrorMessage.tsx:57 src/view/com/util/error/ErrorScreen.tsx:74
 msgid "Retries the last action, which errored out"
 msgstr "Baineann sé seo triail eile as an ngníomh is déanaí, ar theip air"
 
-#: src/components/dms/MessageItem.tsx:241
-#: src/components/Error.tsx:90
-#: src/components/Lists.tsx:104
-#: src/screens/Login/LoginForm.tsx:288
-#: src/screens/Login/LoginForm.tsx:295
-#: src/screens/Messages/Conversation/MessageListError.tsx:25
-#: src/screens/Onboarding/StepInterests/index.tsx:226
-#: src/screens/Onboarding/StepInterests/index.tsx:229
-#: src/screens/Signup/index.tsx:207
-#: src/view/com/util/error/ErrorMessage.tsx:55
-#: src/view/com/util/error/ErrorScreen.tsx:72
+#: src/components/dms/MessageItem.tsx:241 src/components/Error.tsx:90 src/components/Lists.tsx:104 src/screens/Login/LoginForm.tsx:288 src/screens/Login/LoginForm.tsx:295 src/screens/Messages/Conversation/MessageListError.tsx:25 src/screens/Onboarding/StepInterests/index.tsx:226 src/screens/Onboarding/StepInterests/index.tsx:229 src/screens/Signup/index.tsx:207 src/view/com/util/error/ErrorMessage.tsx:55 src/view/com/util/error/ErrorScreen.tsx:72
 msgid "Retry"
 msgstr "Bain triail eile as"
 
-#: src/components/Error.tsx:98
-#: src/view/screens/ProfileList.tsx:971
+#: src/components/Error.tsx:98 src/view/screens/ProfileList.tsx:971
 msgid "Return to previous page"
 msgstr "Fill ar an leathanach roimhe seo"
 
@@ -4437,22 +3707,15 @@ msgstr "Fill ar an leathanach roimhe seo"
 msgid "Returns to home page"
 msgstr "Filleann sé seo abhaile"
 
-#: src/view/screens/NotFound.tsx:58
-#: src/view/screens/ProfileFeed.tsx:112
+#: src/view/screens/NotFound.tsx:58 src/view/screens/ProfileFeed.tsx:112
 msgid "Returns to previous page"
 msgstr "Filleann sé seo ar an leathanach roimhe seo"
 
-#: src/components/dialogs/BirthDateSettings.tsx:125
-#: src/view/com/composer/GifAltText.tsx:163
-#: src/view/com/composer/GifAltText.tsx:169
-#: src/view/com/modals/ChangeHandle.tsx:168
-#: src/view/com/modals/CreateOrEditList.tsx:326
-#: src/view/com/modals/EditProfile.tsx:225
+#: src/components/dialogs/BirthDateSettings.tsx:125 src/view/com/composer/GifAltText.tsx:163 src/view/com/composer/GifAltText.tsx:169 src/view/com/modals/ChangeHandle.tsx:168 src/view/com/modals/CreateOrEditList.tsx:326 src/view/com/modals/EditProfile.tsx:225
 msgid "Save"
 msgstr "Sábháil"
 
-#: src/view/com/lightbox/Lightbox.tsx:133
-#: src/view/com/modals/CreateOrEditList.tsx:334
+#: src/view/com/lightbox/Lightbox.tsx:133 src/view/com/modals/CreateOrEditList.tsx:334
 msgctxt "action"
 msgid "Save"
 msgstr "Sábháil"
@@ -4477,8 +3740,7 @@ msgstr "Sábháil an leasainm nua"
 msgid "Save image crop"
 msgstr "Sábháil an pictiúr bearrtha"
 
-#: src/view/screens/ProfileFeed.tsx:331
-#: src/view/screens/ProfileFeed.tsx:337
+#: src/view/screens/ProfileFeed.tsx:331 src/view/screens/ProfileFeed.tsx:337
 msgid "Save to my feeds"
 msgstr "Sábháil i mo chuid fothaí"
 
@@ -4490,12 +3752,7 @@ msgstr "Fothaí Sábháilte"
 msgid "Saved to your camera roll"
 msgstr "Sábháladh i do rolla ceamara é"
 
-#: src/view/com/lightbox/Lightbox.tsx:81
-#~ msgid "Saved to your camera roll."
-#~ msgstr "Sábháilte i do rolla ceamara."
-
-#: src/view/screens/ProfileFeed.tsx:200
-#: src/view/screens/ProfileList.tsx:300
+#: src/view/screens/ProfileFeed.tsx:200 src/view/screens/ProfileList.tsx:300
 msgid "Saved to your feeds"
 msgstr "Sábháilte le mo chuid fothaí"
 
@@ -4523,21 +3780,7 @@ msgstr "Eolaíocht"
 msgid "Scroll to top"
 msgstr "Fill ar an mbarr"
 
-#: src/components/dms/dialogs/SearchablePeopleList.tsx:504
-#: src/Navigation.tsx:506
-#: src/view/com/auth/LoggedOut.tsx:123
-#: src/view/com/modals/ListAddRemoveUsers.tsx:75
-#: src/view/com/util/forms/SearchInput.tsx:67
-#: src/view/com/util/forms/SearchInput.tsx:79
-#: src/view/screens/Search/Search.tsx:451
-#: src/view/screens/Search/Search.tsx:825
-#: src/view/screens/Search/Search.tsx:853
-#: src/view/shell/bottom-bar/BottomBar.tsx:179
-#: src/view/shell/desktop/LeftNav.tsx:343
-#: src/view/shell/desktop/Search.tsx:194
-#: src/view/shell/desktop/Search.tsx:203
-#: src/view/shell/Drawer.tsx:393
-#: src/view/shell/Drawer.tsx:394
+#: src/components/dms/dialogs/SearchablePeopleList.tsx:504 src/Navigation.tsx:506 src/view/com/auth/LoggedOut.tsx:123 src/view/com/modals/ListAddRemoveUsers.tsx:75 src/view/com/util/forms/SearchInput.tsx:67 src/view/com/util/forms/SearchInput.tsx:79 src/view/screens/Search/Search.tsx:451 src/view/screens/Search/Search.tsx:825 src/view/screens/Search/Search.tsx:853 src/view/shell/bottom-bar/BottomBar.tsx:179 src/view/shell/desktop/LeftNav.tsx:343 src/view/shell/desktop/Search.tsx:194 src/view/shell/desktop/Search.tsx:203 src/view/shell/Drawer.tsx:393 src/view/shell/Drawer.tsx:394
 msgid "Search"
 msgstr "Cuardaigh"
 
@@ -4557,24 +3800,23 @@ msgstr "Lorg na postálacha uile le @{authorHandle} leis an gclib {displayTag}"
 msgid "Search for all posts with tag {displayTag}"
 msgstr "Lorg na postálacha uile leis an gclib {displayTag}"
 
-#: src/view/com/auth/LoggedOut.tsx:105
-#: src/view/com/auth/LoggedOut.tsx:106
-#: src/view/com/modals/ListAddRemoveUsers.tsx:70
+#: src/components/dms/NewChat.tsx:226
+msgid "Search for someone to start a conversation with."
+msgstr "Lorg duine éigin le comhrá a dhéanamh leo."
+
+#: src/view/com/auth/LoggedOut.tsx:105 src/view/com/auth/LoggedOut.tsx:106 src/view/com/modals/ListAddRemoveUsers.tsx:70
 msgid "Search for users"
 msgstr "Cuardaigh úsáideoirí"
 
-#: src/components/dialogs/GifSelect.ios.tsx:159
-#: src/components/dialogs/GifSelect.tsx:169
+#: src/components/dialogs/GifSelect.ios.tsx:159 src/components/dialogs/GifSelect.tsx:169
 msgid "Search GIFs"
 msgstr "Cuardaigh GIFanna"
 
-#: src/components/dms/dialogs/SearchablePeopleList.tsx:524
-#: src/components/dms/dialogs/SearchablePeopleList.tsx:525
+#: src/components/dms/dialogs/SearchablePeopleList.tsx:524 src/components/dms/dialogs/SearchablePeopleList.tsx:525
 msgid "Search profiles"
 msgstr "Cuardaigh próifílí"
 
-#: src/components/dialogs/GifSelect.ios.tsx:160
-#: src/components/dialogs/GifSelect.tsx:170
+#: src/components/dialogs/GifSelect.ios.tsx:160 src/components/dialogs/GifSelect.tsx:170
 msgid "Search Tenor"
 msgstr "Cuardaigh Tenor"
 
@@ -4598,17 +3840,9 @@ msgstr "Féach na postálacha <0>{displayTag}</0>"
 msgid "See <0>{displayTag}</0> posts by this user"
 msgstr "Féach na postálacha <0>{displayTag}</0> leis an úsáideoir seo"
 
-#: src/view/com/notifications/FeedItem.tsx:NaN
-#~ msgid "See profile"
-#~ msgstr "Féach ar an bpróifíl"
-
 #: src/view/screens/SavedFeeds.tsx:187
 msgid "See this guide"
 msgstr "Féach ar an treoirleabhar seo"
-
-#: src/view/com/auth/HomeLoggedOutCTA.tsx:40
-#~ msgid "See what's next"
-#~ msgstr "Féach an chéad rud eile"
 
 #: src/view/com/util/Selector.tsx:106
 msgid "Select {item}"
@@ -4654,10 +3888,6 @@ msgstr "Roghnaigh modhnóir"
 msgid "Select option {i} of {numItems}"
 msgstr "Roghnaigh rogha {i} as {numItems}"
 
-#: src/screens/Onboarding/StepSuggestedAccounts/index.tsx:52
-#~ msgid "Select some accounts below to follow"
-#~ msgstr "Roghnaigh cúpla cuntas le leanúint"
-
 #: src/screens/Onboarding/StepProfile/AvatarCreatorItems.tsx:83
 msgid "Select the {emojiName} emoji as your avatar"
 msgstr "Roghnaigh an emoji {emojiName} mar abhatár"
@@ -4669,14 +3899,6 @@ msgstr "Roghnaigh na seirbhísí modhnóireachta le tuairisciú chuige"
 #: src/view/com/auth/server-input/index.tsx:82
 msgid "Select the service that hosts your data."
 msgstr "Roghnaigh an tseirbhís a óstálann do chuid sonraí."
-
-#: src/screens/Onboarding/StepTopicalFeeds.tsx:100
-#~ msgid "Select topical feeds to follow from the list below"
-#~ msgstr "Roghnaigh fothaí le leanúint ón liosta thíos"
-
-#: src/screens/Onboarding/StepModeration/index.tsx:63
-#~ msgid "Select what you want to see (or not see), and we’ll handle the rest."
-#~ msgstr "Roghnaigh na rudaí ba mhaith leat a fheiceáil (nó gan a fheiceáil), agus leanfaimid ar aghaidh as sin"
 
 #: src/view/screens/LanguageSettings.tsx:283
 msgid "Select which languages you want your subscribed feeds to include. If none are selected, all languages will be shown."
@@ -4698,20 +3920,11 @@ msgstr "Roghnaigh na rudaí a bhfuil suim agat iontu as na roghanna thíos"
 msgid "Select your preferred language for translations in your feed."
 msgstr "Do rogha teanga nuair a dhéanfar aistriúchán ar ábhar i d'fhotha."
 
-#: src/screens/Onboarding/StepAlgoFeeds/index.tsx:117
-#~ msgid "Select your primary algorithmic feeds"
-#~ msgstr "Roghnaigh do phríomhfhothaí algartamacha"
-
-#: src/screens/Onboarding/StepAlgoFeeds/index.tsx:133
-#~ msgid "Select your secondary algorithmic feeds"
-#~ msgstr "Roghnaigh do chuid fothaí algartamacha tánaisteacha"
-
 #: src/components/dms/ChatEmptyPill.tsx:38
 msgid "Send a neat website!"
 msgstr "Seol suíomh gréasáin spéisiúil!"
 
-#: src/view/com/modals/VerifyEmail.tsx:210
-#: src/view/com/modals/VerifyEmail.tsx:212
+#: src/view/com/modals/VerifyEmail.tsx:210 src/view/com/modals/VerifyEmail.tsx:212
 msgid "Send Confirmation Email"
 msgstr "Seol ríomhphost dearbhaithe"
 
@@ -4724,24 +3937,19 @@ msgctxt "action"
 msgid "Send Email"
 msgstr "Seol ríomhphost"
 
-#: src/view/shell/Drawer.tsx:328
-#: src/view/shell/Drawer.tsx:349
+#: src/view/shell/Drawer.tsx:328 src/view/shell/Drawer.tsx:349
 msgid "Send feedback"
 msgstr "Seol aiseolas"
 
-#: src/screens/Messages/Conversation/MessageInput.tsx:163
-#: src/screens/Messages/Conversation/MessageInput.web.tsx:155
+#: src/screens/Messages/Conversation/MessageInput.tsx:163 src/screens/Messages/Conversation/MessageInput.web.tsx:155
 msgid "Send message"
 msgstr "Seol teachtaireacht"
 
 #: src/components/dms/dialogs/ShareViaChatDialog.tsx:47
 msgid "Send post to..."
-msgstr ""
+msgstr "Seol an phostáil seo chuig..."
 
-#: src/components/dms/ReportDialog.tsx:232
-#: src/components/dms/ReportDialog.tsx:235
-#: src/components/ReportDialog/SubmitView.tsx:216
-#: src/components/ReportDialog/SubmitView.tsx:220
+#: src/components/dms/ReportDialog.tsx:232 src/components/dms/ReportDialog.tsx:235 src/components/ReportDialog/SubmitView.tsx:216 src/components/ReportDialog/SubmitView.tsx:220
 msgid "Send report"
 msgstr "Seol an tuairisc"
 
@@ -4749,15 +3957,13 @@ msgstr "Seol an tuairisc"
 msgid "Send report to {0}"
 msgstr "Seol an tuairisc chuig {0}"
 
-#: src/view/screens/Settings/DisableEmail2FADialog.tsx:119
-#: src/view/screens/Settings/DisableEmail2FADialog.tsx:122
+#: src/view/screens/Settings/DisableEmail2FADialog.tsx:119 src/view/screens/Settings/DisableEmail2FADialog.tsx:122
 msgid "Send verification email"
 msgstr "Seol ríomhphost dearbhaithe"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:299
-#: src/view/com/util/forms/PostDropdownBtn.tsx:302
+#: src/view/com/util/forms/PostDropdownBtn.tsx:299 src/view/com/util/forms/PostDropdownBtn.tsx:302
 msgid "Send via direct message"
-msgstr ""
+msgstr "Seol mar theachtaireacht dhíreach"
 
 #: src/view/com/modals/DeleteAccount.tsx:151
 msgid "Sends email with confirmation code for account deletion"
@@ -4839,11 +4045,7 @@ msgstr "Socraíonn sé seo cóimheas treoíochta na híomhá go hard"
 msgid "Sets image aspect ratio to wide"
 msgstr "Socraíonn sé seo cóimheas treoíochta na híomhá go leathan"
 
-#: src/Navigation.tsx:146
-#: src/view/screens/Settings/index.tsx:332
-#: src/view/shell/desktop/LeftNav.tsx:389
-#: src/view/shell/Drawer.tsx:558
-#: src/view/shell/Drawer.tsx:559
+#: src/Navigation.tsx:146 src/view/screens/Settings/index.tsx:332 src/view/shell/desktop/LeftNav.tsx:389 src/view/shell/Drawer.tsx:558 src/view/shell/Drawer.tsx:559
 msgid "Settings"
 msgstr "Socruithe"
 
@@ -4860,12 +4062,7 @@ msgctxt "action"
 msgid "Share"
 msgstr "Comhroinn"
 
-#: src/view/com/profile/ProfileMenu.tsx:217
-#: src/view/com/profile/ProfileMenu.tsx:226
-#: src/view/com/util/forms/PostDropdownBtn.tsx:310
-#: src/view/com/util/forms/PostDropdownBtn.tsx:319
-#: src/view/com/util/post-ctrls/PostCtrls.tsx:297
-#: src/view/screens/ProfileList.tsx:428
+#: src/view/com/profile/ProfileMenu.tsx:217 src/view/com/profile/ProfileMenu.tsx:226 src/view/com/util/forms/PostDropdownBtn.tsx:310 src/view/com/util/forms/PostDropdownBtn.tsx:319 src/view/com/util/post-ctrls/PostCtrls.tsx:297 src/view/screens/ProfileList.tsx:428
 msgid "Share"
 msgstr "Comhroinn"
 
@@ -4877,19 +4074,15 @@ msgstr "Inis scéal suimiúil!"
 msgid "Share a fun fact!"
 msgstr "Roinn rud éigin fútsa féin!"
 
-#: src/view/com/profile/ProfileMenu.tsx:375
-#: src/view/com/util/forms/PostDropdownBtn.tsx:464
-#: src/view/com/util/post-ctrls/PostCtrls.tsx:313
+#: src/view/com/profile/ProfileMenu.tsx:375 src/view/com/util/forms/PostDropdownBtn.tsx:464 src/view/com/util/post-ctrls/PostCtrls.tsx:313
 msgid "Share anyway"
 msgstr "Comhroinn mar sin féin"
 
-#: src/view/screens/ProfileFeed.tsx:357
-#: src/view/screens/ProfileFeed.tsx:359
+#: src/view/screens/ProfileFeed.tsx:357 src/view/screens/ProfileFeed.tsx:359
 msgid "Share feed"
 msgstr "Comhroinn an fotha"
 
-#: src/view/com/modals/LinkWarning.tsx:89
-#: src/view/com/modals/LinkWarning.tsx:95
+#: src/view/com/modals/LinkWarning.tsx:89 src/view/com/modals/LinkWarning.tsx:95
 msgid "Share Link"
 msgstr "Comhroinn Nasc"
 
@@ -4901,28 +4094,19 @@ msgstr "Roinn an fotha is fearr leat!"
 msgid "Shares the linked website"
 msgstr "Roinneann sé seo na suíomh gréasáin atá nasctha"
 
-#: src/components/moderation/ContentHider.tsx:116
-#: src/components/moderation/LabelPreference.tsx:136
-#: src/components/moderation/PostHider.tsx:121
-#: src/view/screens/Settings/index.tsx:381
+#: src/components/moderation/ContentHider.tsx:116 src/components/moderation/LabelPreference.tsx:136 src/components/moderation/PostHider.tsx:121 src/view/screens/Settings/index.tsx:381
 msgid "Show"
 msgstr "Taispeáin"
-
-#: src/view/screens/PreferencesFollowingFeed.tsx:68
-#~ msgid "Show all replies"
-#~ msgstr "Taispeáin gach freagra"
 
 #: src/view/com/util/post-embeds/GifEmbed.tsx:167
 msgid "Show alt text"
 msgstr "Taispeáin an téacs malartach"
 
-#: src/components/moderation/ScreenHider.tsx:169
-#: src/components/moderation/ScreenHider.tsx:172
+#: src/components/moderation/ScreenHider.tsx:169 src/components/moderation/ScreenHider.tsx:172
 msgid "Show anyway"
 msgstr "Taispeáin mar sin féin"
 
-#: src/lib/moderation/useLabelBehaviorDescription.ts:27
-#: src/lib/moderation/useLabelBehaviorDescription.ts:63
+#: src/lib/moderation/useLabelBehaviorDescription.ts:27 src/lib/moderation/useLabelBehaviorDescription.ts:63
 msgid "Show badge"
 msgstr "Taispeáin suaitheantas"
 
@@ -4938,19 +4122,15 @@ msgstr "Taispeáin cuntais cosúil le {0}"
 msgid "Show hidden replies"
 msgstr "Taispeáin freagraí i bhfolach"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:349
-#: src/view/com/util/forms/PostDropdownBtn.tsx:351
+#: src/view/com/util/forms/PostDropdownBtn.tsx:349 src/view/com/util/forms/PostDropdownBtn.tsx:351
 msgid "Show less like this"
 msgstr "Níos lú den sórt seo"
 
-#: src/view/com/post-thread/PostThreadItem.tsx:538
-#: src/view/com/post/Post.tsx:227
-#: src/view/com/posts/FeedItem.tsx:392
+#: src/view/com/post-thread/PostThreadItem.tsx:538 src/view/com/post/Post.tsx:227 src/view/com/posts/FeedItem.tsx:392
 msgid "Show More"
 msgstr "Tuilleadh"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:341
-#: src/view/com/util/forms/PostDropdownBtn.tsx:343
+#: src/view/com/util/forms/PostDropdownBtn.tsx:341 src/view/com/util/forms/PostDropdownBtn.tsx:343
 msgid "Show more like this"
 msgstr "Níos mó den sórt seo"
 
@@ -4966,18 +4146,6 @@ msgstr "Taispeáin postálacha ó mo chuid fothaí"
 msgid "Show Quote Posts"
 msgstr "Taispeáin postálacha athluaite"
 
-#: src/screens/Onboarding/StepFollowingFeed.tsx:119
-#~ msgid "Show quote-posts in Following feed"
-#~ msgstr "Taispeáin postálacha athluaite san fhotha “Á Leanúint”"
-
-#: src/screens/Onboarding/StepFollowingFeed.tsx:135
-#~ msgid "Show quotes in Following"
-#~ msgstr "Taispeáin postálacha athluaite san fhotha “Á Leanúint”"
-
-#: src/screens/Onboarding/StepFollowingFeed.tsx:95
-#~ msgid "Show re-posts in Following feed"
-#~ msgstr "Taispeáin athphostálacha san fhotha “Á Leanúint”"
-
 #: src/view/screens/PreferencesFollowingFeed.tsx:118
 msgid "Show Replies"
 msgstr "Taispeáin freagraí"
@@ -4986,34 +4154,13 @@ msgstr "Taispeáin freagraí"
 msgid "Show replies by people you follow before all other replies."
 msgstr "Taispeáin freagraí ó na daoine a leanann tú roimh aon fhreagra eile."
 
-#: src/screens/Onboarding/StepFollowingFeed.tsx:87
-#~ msgid "Show replies in Following"
-#~ msgstr "Taispeáin freagraí san fhotha “Á Leanúint”"
-
-#: src/screens/Onboarding/StepFollowingFeed.tsx:71
-#~ msgid "Show replies in Following feed"
-#~ msgstr "Taispeáin freagraí san fhotha “Á Leanúint”"
-
-#: src/view/screens/PreferencesFollowingFeed.tsx:70
-#~ msgid "Show replies with at least {value} {0}"
-#~ msgstr "Taispeáin freagraí a bhfuil ar a laghad {value} {0} acu"
-
 #: src/view/screens/PreferencesFollowingFeed.tsx:187
 msgid "Show Reposts"
 msgstr "Taispeáin athphostálacha"
 
-#: src/screens/Onboarding/StepFollowingFeed.tsx:111
-#~ msgid "Show reposts in Following"
-#~ msgstr "Taispeáin athphostálacha san fhotha “Á Leanúint”"
-
-#: src/components/moderation/ContentHider.tsx:69
-#: src/components/moderation/PostHider.tsx:78
+#: src/components/moderation/ContentHider.tsx:69 src/components/moderation/PostHider.tsx:78
 msgid "Show the content"
 msgstr "Taispeáin an t-ábhar"
-
-#: src/view/com/notifications/FeedItem.tsx:347
-#~ msgid "Show users"
-#~ msgstr "Taispeáin úsáideoirí"
 
 #: src/lib/moderation/useLabelBehaviorDescription.ts:58
 msgid "Show warning"
@@ -5027,24 +4174,7 @@ msgstr "Taispeáin rabhadh agus scag ó na fothaí é"
 msgid "Shows posts from {0} in your feed"
 msgstr "Taispeánann sé seo postálacha ó {0} i d'fhotha"
 
-#: src/components/dialogs/Signin.tsx:97
-#: src/components/dialogs/Signin.tsx:99
-#: src/screens/Login/index.tsx:100
-#: src/screens/Login/index.tsx:119
-#: src/screens/Login/LoginForm.tsx:154
-#: src/view/com/auth/SplashScreen.tsx:63
-#: src/view/com/auth/SplashScreen.tsx:72
-#: src/view/com/auth/SplashScreen.web.tsx:112
-#: src/view/com/auth/SplashScreen.web.tsx:121
-#: src/view/shell/bottom-bar/BottomBar.tsx:312
-#: src/view/shell/bottom-bar/BottomBar.tsx:313
-#: src/view/shell/bottom-bar/BottomBar.tsx:315
-#: src/view/shell/bottom-bar/BottomBarWeb.tsx:181
-#: src/view/shell/bottom-bar/BottomBarWeb.tsx:182
-#: src/view/shell/bottom-bar/BottomBarWeb.tsx:184
-#: src/view/shell/NavSignupCard.tsx:69
-#: src/view/shell/NavSignupCard.tsx:70
-#: src/view/shell/NavSignupCard.tsx:72
+#: src/components/dialogs/Signin.tsx:97 src/components/dialogs/Signin.tsx:99 src/screens/Login/index.tsx:100 src/screens/Login/index.tsx:119 src/screens/Login/LoginForm.tsx:154 src/view/com/auth/SplashScreen.tsx:63 src/view/com/auth/SplashScreen.tsx:72 src/view/com/auth/SplashScreen.web.tsx:112 src/view/com/auth/SplashScreen.web.tsx:121 src/view/shell/bottom-bar/BottomBar.tsx:312 src/view/shell/bottom-bar/BottomBar.tsx:313 src/view/shell/bottom-bar/BottomBar.tsx:315 src/view/shell/bottom-bar/BottomBarWeb.tsx:181 src/view/shell/bottom-bar/BottomBarWeb.tsx:182 src/view/shell/bottom-bar/BottomBarWeb.tsx:184 src/view/shell/NavSignupCard.tsx:69 src/view/shell/NavSignupCard.tsx:70 src/view/shell/NavSignupCard.tsx:72
 msgid "Sign in"
 msgstr "Logáil isteach"
 
@@ -5064,20 +4194,11 @@ msgstr "Logáil isteach nó cláraigh chun páirt a ghlacadh sa chomhrá!"
 msgid "Sign into Bluesky or create a new account"
 msgstr "Logáil isteach i Bluesky nó cruthaigh cuntas nua"
 
-#: src/view/screens/Settings/index.tsx:129
-#: src/view/screens/Settings/index.tsx:133
+#: src/view/screens/Settings/index.tsx:129 src/view/screens/Settings/index.tsx:133
 msgid "Sign out"
 msgstr "Logáil amach"
 
-#: src/view/shell/bottom-bar/BottomBar.tsx:302
-#: src/view/shell/bottom-bar/BottomBar.tsx:303
-#: src/view/shell/bottom-bar/BottomBar.tsx:305
-#: src/view/shell/bottom-bar/BottomBarWeb.tsx:171
-#: src/view/shell/bottom-bar/BottomBarWeb.tsx:172
-#: src/view/shell/bottom-bar/BottomBarWeb.tsx:174
-#: src/view/shell/NavSignupCard.tsx:60
-#: src/view/shell/NavSignupCard.tsx:61
-#: src/view/shell/NavSignupCard.tsx:63
+#: src/view/shell/bottom-bar/BottomBar.tsx:302 src/view/shell/bottom-bar/BottomBar.tsx:303 src/view/shell/bottom-bar/BottomBar.tsx:305 src/view/shell/bottom-bar/BottomBarWeb.tsx:171 src/view/shell/bottom-bar/BottomBarWeb.tsx:172 src/view/shell/bottom-bar/BottomBarWeb.tsx:174 src/view/shell/NavSignupCard.tsx:60 src/view/shell/NavSignupCard.tsx:61 src/view/shell/NavSignupCard.tsx:63
 msgid "Sign up"
 msgstr "Cláraigh"
 
@@ -5085,8 +4206,7 @@ msgstr "Cláraigh"
 msgid "Sign up or sign in to join the conversation"
 msgstr "Cláraigh nó logáil isteach chun páirt a ghlacadh sa chomhrá"
 
-#: src/components/moderation/ScreenHider.tsx:97
-#: src/lib/moderation/useGlobalLabelStrings.ts:28
+#: src/components/moderation/ScreenHider.tsx:97 src/lib/moderation/useGlobalLabelStrings.ts:28
 msgid "Sign-in Required"
 msgstr "Caithfidh tú logáil isteach"
 
@@ -5094,8 +4214,7 @@ msgstr "Caithfidh tú logáil isteach"
 msgid "Signed in as"
 msgstr "Logáilte isteach mar"
 
-#: src/lib/hooks/useAccountSwitcher.ts:44
-#: src/screens/Login/ChooseAccountForm.tsx:60
+#: src/lib/hooks/useAccountSwitcher.ts:44 src/screens/Login/ChooseAccountForm.tsx:60
 msgid "Signed in as @{0}"
 msgstr "Logáilte isteach mar @{0}"
 
@@ -5119,19 +4238,15 @@ msgstr "Tá daoine áirithe in ann freagra a thabhairt"
 msgid "Something went wrong"
 msgstr "Theip ar rud éigin"
 
-#: src/screens/Deactivated.tsx:94
-#: src/screens/Settings/components/DeactivateAccountDialog.tsx:59
+#: src/screens/Deactivated.tsx:94 src/screens/Settings/components/DeactivateAccountDialog.tsx:59
 msgid "Something went wrong, please try again"
-msgstr ""
+msgstr "Chuaigh rud éigin amú, bain triail eile as"
 
-#: src/components/ReportDialog/index.tsx:59
-#: src/screens/Moderation/index.tsx:114
-#: src/screens/Profile/Sections/Labels.tsx:87
+#: src/components/ReportDialog/index.tsx:59 src/screens/Moderation/index.tsx:114 src/screens/Profile/Sections/Labels.tsx:87
 msgid "Something went wrong, please try again."
 msgstr "Chuaigh rud éigin ó rath. Bain triail eile as."
 
-#: src/App.native.tsx:85
-#: src/App.web.tsx:74
+#: src/App.native.tsx:85 src/App.web.tsx:74
 msgid "Sorry! Your session expired. Please log in again."
 msgstr "Ár leithscéal. Chuaigh do sheisiún i léig. Ní mór duit logáil isteach arís."
 
@@ -5143,16 +4258,11 @@ msgstr "Sórtáil freagraí"
 msgid "Sort replies to the same post by:"
 msgstr "Sórtáil freagraí ar an bpostáil chéanna de réir:"
 
-#: src/components/moderation/LabelsOnMeDialog.tsx:168
-#~ msgid "Source:"
-#~ msgstr "Foinse:"
-
 #: src/components/moderation/LabelsOnMeDialog.tsx:170
 msgid "Source: <0>{0}</0>"
 msgstr "Foinse: <0>{0}</0>"
 
-#: src/lib/moderation/useReportOptions.ts:66
-#: src/lib/moderation/useReportOptions.ts:79
+#: src/lib/moderation/useReportOptions.ts:66 src/lib/moderation/useReportOptions.ts:79
 msgid "Spam"
 msgstr "Turscar"
 
@@ -5180,17 +4290,9 @@ msgstr "Tosaigh comhrá le {displayName}"
 msgid "Start chatting"
 msgstr "Tosaigh ag comhrá"
 
-#: src/view/screens/Settings/index.tsx:862
-#~ msgid "Status page"
-#~ msgstr "Leathanach stádais"
-
 #: src/view/screens/Settings/index.tsx:963
 msgid "Status Page"
 msgstr "Leathanach Stádais"
-
-#: src/screens/Signup/index.tsx:145
-#~ msgid "Step"
-#~ msgstr "Céim"
 
 #: src/screens/Signup/index.tsx:154
 msgid "Step {0} of {1}"
@@ -5200,15 +4302,11 @@ msgstr "Céim {0} as {1}"
 msgid "Storage cleared, you need to restart the app now."
 msgstr "Stóráil scriosta, tá ort an aip a atosú anois."
 
-#: src/Navigation.tsx:218
-#: src/view/screens/Settings/index.tsx:863
+#: src/Navigation.tsx:218 src/view/screens/Settings/index.tsx:863
 msgid "Storybook"
 msgstr "Storybook"
 
-#: src/components/moderation/LabelsOnMeDialog.tsx:292
-#: src/components/moderation/LabelsOnMeDialog.tsx:293
-#: src/screens/Messages/Conversation/ChatDisabled.tsx:142
-#: src/screens/Messages/Conversation/ChatDisabled.tsx:143
+#: src/components/moderation/LabelsOnMeDialog.tsx:292 src/components/moderation/LabelsOnMeDialog.tsx:293 src/screens/Messages/Conversation/ChatDisabled.tsx:142 src/screens/Messages/Conversation/ChatDisabled.tsx:143
 msgid "Submit"
 msgstr "Seol"
 
@@ -5223,10 +4321,6 @@ msgstr "Glac síntiús le @{0} leis na lipéid seo a úsáid:"
 #: src/screens/Profile/Header/ProfileHeaderLabeler.tsx:230
 msgid "Subscribe to Labeler"
 msgstr "Glac síntiús le lipéadóir"
-
-#: src/screens/Onboarding/StepAlgoFeeds/FeedCard.tsx:NaN
-#~ msgid "Subscribe to the {0} feed"
-#~ msgstr "Liostáil leis an bhfotha {0}"
 
 #: src/screens/Profile/Header/ProfileHeaderLabeler.tsx:194
 msgid "Subscribe to this labeler"
@@ -5248,14 +4342,11 @@ msgstr "Molta duit"
 msgid "Suggestive"
 msgstr "Gáirsiúil"
 
-#: src/Navigation.tsx:233
-#: src/view/screens/Support.tsx:30
-#: src/view/screens/Support.tsx:33
+#: src/Navigation.tsx:233 src/view/screens/Support.tsx:30 src/view/screens/Support.tsx:33
 msgid "Support"
 msgstr "Tacaíocht"
 
-#: src/components/dialogs/SwitchAccount.tsx:47
-#: src/components/dialogs/SwitchAccount.tsx:50
+#: src/components/dialogs/SwitchAccount.tsx:47 src/components/dialogs/SwitchAccount.tsx:50
 msgid "Switch Account"
 msgstr "Athraigh an cuntas"
 
@@ -5303,17 +4394,11 @@ msgstr "Inis scéal grinn!"
 msgid "Terms"
 msgstr "Téarmaí"
 
-#: src/Navigation.tsx:243
-#: src/screens/Signup/StepInfo/Policies.tsx:49
-#: src/view/screens/Settings/index.tsx:951
-#: src/view/screens/TermsOfService.tsx:29
-#: src/view/shell/Drawer.tsx:278
+#: src/Navigation.tsx:243 src/screens/Signup/StepInfo/Policies.tsx:49 src/view/screens/Settings/index.tsx:951 src/view/screens/TermsOfService.tsx:29 src/view/shell/Drawer.tsx:278
 msgid "Terms of Service"
 msgstr "Téarmaí Seirbhíse"
 
-#: src/lib/moderation/useReportOptions.ts:59
-#: src/lib/moderation/useReportOptions.ts:93
-#: src/lib/moderation/useReportOptions.ts:101
+#: src/lib/moderation/useReportOptions.ts:59 src/lib/moderation/useReportOptions.ts:93 src/lib/moderation/useReportOptions.ts:101
 msgid "Terms used violate community standards"
 msgstr "Sárú ar chaighdeáin an phobail atá sna téarmaí a úsáideadh"
 
@@ -5321,13 +4406,11 @@ msgstr "Sárú ar chaighdeáin an phobail atá sna téarmaí a úsáideadh"
 msgid "text"
 msgstr "téacs"
 
-#: src/components/moderation/LabelsOnMeDialog.tsx:256
-#: src/screens/Messages/Conversation/ChatDisabled.tsx:108
+#: src/components/moderation/LabelsOnMeDialog.tsx:256 src/screens/Messages/Conversation/ChatDisabled.tsx:108
 msgid "Text input field"
 msgstr "Réimse téacs"
 
-#: src/components/dms/ReportDialog.tsx:132
-#: src/components/ReportDialog/SubmitView.tsx:78
+#: src/components/dms/ReportDialog.tsx:132 src/components/ReportDialog/SubmitView.tsx:78
 msgid "Thank you. Your report has been sent."
 msgstr "Go raibh maith agat. Seoladh do thuairisc."
 
@@ -5339,14 +4422,9 @@ msgstr "Ina bhfuil an méid seo a leanas:"
 msgid "That handle is already taken."
 msgstr "Tá an leasainm sin in úsáid cheana féin."
 
-#: src/screens/Profile/Header/ProfileHeaderStandard.tsx:291
-#: src/view/com/profile/ProfileMenu.tsx:351
+#: src/screens/Profile/Header/ProfileHeaderStandard.tsx:291 src/view/com/profile/ProfileMenu.tsx:351
 msgid "The account will be able to interact with you after unblocking."
 msgstr "Beidh an cuntas seo in ann caidreamh a dhéanamh leat tar éis duit é a dhíbhlocáil"
-
-#: src/components/moderation/ModerationDetailsDialog.tsx:127
-#~ msgid "the author"
-#~ msgstr "an t-údar"
 
 #: src/view/screens/CommunityGuidelines.tsx:36
 msgid "The Community Guidelines have been moved to <0/>"
@@ -5372,8 +4450,7 @@ msgstr "Cuireadh na lipéid seo a leanas le do chuid ábhair."
 msgid "The following steps will help customize your Bluesky experience."
 msgstr "Cuideoidh na céimeanna seo a leanas leat Bluesky a chur in oiriúint duit féin."
 
-#: src/view/com/post-thread/PostThread.tsx:189
-#: src/view/com/post-thread/PostThread.tsx:201
+#: src/view/com/post-thread/PostThread.tsx:189 src/view/com/post-thread/PostThread.tsx:201
 msgid "The post may have been deleted."
 msgstr "Is féidir gur scriosadh an phostáil seo."
 
@@ -5389,16 +4466,11 @@ msgstr "Bogadh an fhoirm tacaíochta go dtí <0/>. Má tá cuidiú ag teastáil 
 msgid "The Terms of Service have been moved to"
 msgstr "Bogadh ár dTéarmaí Seirbhíse go dtí"
 
-#: src/screens/Onboarding/StepAlgoFeeds/index.tsx:141
-#~ msgid "There are many feeds to try:"
-#~ msgstr "Tá a lán fothaí ann le blaiseadh:"
-
 #: src/screens/Settings/components/DeactivateAccountDialog.tsx:86
 msgid "There is no time limit for account deactivation, come back any time."
-msgstr ""
+msgstr "Níl srian ama le díghníomhú cuntais, fill uair ar bith."
 
-#: src/screens/Profile/Header/ProfileHeaderLabeler.tsx:115
-#: src/view/screens/ProfileFeed.tsx:541
+#: src/screens/Profile/Header/ProfileHeaderLabeler.tsx:115 src/view/screens/ProfileFeed.tsx:541
 msgid "There was an an issue contacting the server, please check your internet connection and try again."
 msgstr "Bhí fadhb ann maidir le dul i dteagmháil leis an bhfreastalaí. Seiceáil do cheangal leis an idirlíon agus bain triail eile as, le do thoil."
 
@@ -5406,28 +4478,19 @@ msgstr "Bhí fadhb ann maidir le dul i dteagmháil leis an bhfreastalaí. Seice�
 msgid "There was an an issue removing this feed. Please check your internet connection and try again."
 msgstr "Bhí fadhb ann maidir leis an bhfotha seo a bhaint. Seiceáil do cheangal leis an idirlíon agus bain triail eile as, le do thoil."
 
-#: src/view/com/posts/FeedShutdownMsg.tsx:52
-#: src/view/com/posts/FeedShutdownMsg.tsx:70
-#: src/view/screens/ProfileFeed.tsx:205
+#: src/view/com/posts/FeedShutdownMsg.tsx:52 src/view/com/posts/FeedShutdownMsg.tsx:70 src/view/screens/ProfileFeed.tsx:205
 msgid "There was an an issue updating your feeds, please check your internet connection and try again."
 msgstr "Bhí fadhb ann maidir le huasdátú do chuid fothaí. Seiceáil do cheangal leis an idirlíon agus bain triail eile as, le do thoil."
 
-#: src/components/dialogs/GifSelect.ios.tsx:197
-#: src/components/dialogs/GifSelect.tsx:213
+#: src/components/dialogs/GifSelect.ios.tsx:197 src/components/dialogs/GifSelect.tsx:213
 msgid "There was an issue connecting to Tenor."
 msgstr "Bhí fadhb ann maidir le teagmháil a dhéanamh le Tenor."
 
-#: src/view/screens/ProfileFeed.tsx:233
-#: src/view/screens/ProfileList.tsx:303
-#: src/view/screens/ProfileList.tsx:322
-#: src/view/screens/SavedFeeds.tsx:237
-#: src/view/screens/SavedFeeds.tsx:263
-#: src/view/screens/SavedFeeds.tsx:289
+#: src/view/screens/ProfileFeed.tsx:233 src/view/screens/ProfileList.tsx:303 src/view/screens/ProfileList.tsx:322 src/view/screens/SavedFeeds.tsx:237 src/view/screens/SavedFeeds.tsx:263 src/view/screens/SavedFeeds.tsx:289
 msgid "There was an issue contacting the server"
 msgstr "Bhí fadhb ann maidir le teagmháil a dhéanamh leis an bhfreastalaí"
 
-#: src/view/com/feeds/FeedSourceCard.tsx:120
-#: src/view/com/feeds/FeedSourceCard.tsx:133
+#: src/view/com/feeds/FeedSourceCard.tsx:120 src/view/com/feeds/FeedSourceCard.tsx:133
 msgid "There was an issue contacting your server"
 msgstr "Bhí fadhb ann maidir le teagmháil a dhéanamh le do fhreastálaí"
 
@@ -5443,58 +4506,33 @@ msgstr "Bhí fadhb ann maidir le postálacha a fháil. Tapáil anseo le triail e
 msgid "There was an issue fetching the list. Tap here to try again."
 msgstr "Bhí fadhb ann maidir leis an liosta a fháil. Tapáil anseo le triail eile a bhaint as."
 
-#: src/view/com/feeds/ProfileFeedgens.tsx:153
-#: src/view/com/lists/ProfileLists.tsx:160
+#: src/view/com/feeds/ProfileFeedgens.tsx:153 src/view/com/lists/ProfileLists.tsx:160
 msgid "There was an issue fetching your lists. Tap here to try again."
 msgstr "Bhí fadhb ann maidir le do chuid liostaí a fháil. Tapáil anseo le triail eile a bhaint as."
 
-#: src/components/dms/ReportDialog.tsx:220
-#: src/components/ReportDialog/SubmitView.tsx:83
+#: src/components/dms/ReportDialog.tsx:220 src/components/ReportDialog/SubmitView.tsx:83
 msgid "There was an issue sending your report. Please check your internet connection."
 msgstr "Níor seoladh do thuairisc. Seiceáil do nasc leis an idirlíon, le do thoil."
-
-#: src/screens/Onboarding/StepModeration/AdultContentEnabledPref.tsx:65
-#~ msgid "There was an issue syncing your preferences with the server"
-#~ msgstr "Bhí fadhb ann maidir le do chuid roghanna a shioncronú leis an bhfreastalaí"
 
 #: src/view/screens/AppPasswords.tsx:70
 msgid "There was an issue with fetching your app passwords"
 msgstr "Bhí fadhb ann maidir le do chuid pasfhocal don aip a fháil"
 
-#: src/screens/Profile/Header/ProfileHeaderStandard.tsx:99
-#: src/screens/Profile/Header/ProfileHeaderStandard.tsx:121
-#: src/screens/Profile/Header/ProfileHeaderStandard.tsx:135
-#: src/view/com/post-thread/PostThreadFollowBtn.tsx:99
-#: src/view/com/post-thread/PostThreadFollowBtn.tsx:111
-#: src/view/com/profile/ProfileMenu.tsx:109
-#: src/view/com/profile/ProfileMenu.tsx:120
-#: src/view/com/profile/ProfileMenu.tsx:135
-#: src/view/com/profile/ProfileMenu.tsx:146
-#: src/view/com/profile/ProfileMenu.tsx:160
-#: src/view/com/profile/ProfileMenu.tsx:173
+#: src/screens/Profile/Header/ProfileHeaderStandard.tsx:99 src/screens/Profile/Header/ProfileHeaderStandard.tsx:121 src/screens/Profile/Header/ProfileHeaderStandard.tsx:135 src/view/com/post-thread/PostThreadFollowBtn.tsx:99 src/view/com/post-thread/PostThreadFollowBtn.tsx:111 src/view/com/profile/ProfileMenu.tsx:109 src/view/com/profile/ProfileMenu.tsx:120 src/view/com/profile/ProfileMenu.tsx:135 src/view/com/profile/ProfileMenu.tsx:146 src/view/com/profile/ProfileMenu.tsx:160 src/view/com/profile/ProfileMenu.tsx:173
 msgid "There was an issue! {0}"
 msgstr "Bhí fadhb ann! {0}"
 
-#: src/view/screens/ProfileList.tsx:335
-#: src/view/screens/ProfileList.tsx:349
-#: src/view/screens/ProfileList.tsx:363
-#: src/view/screens/ProfileList.tsx:377
+#: src/view/screens/ProfileList.tsx:335 src/view/screens/ProfileList.tsx:349 src/view/screens/ProfileList.tsx:363 src/view/screens/ProfileList.tsx:377
 msgid "There was an issue. Please check your internet connection and try again."
 msgstr "Bhí fadhb ann. Seiceáil do cheangal leis an idirlíon, le do thoil, agus bain triail eile as."
 
-#: src/components/dialogs/GifSelect.ios.tsx:239
-#: src/components/dialogs/GifSelect.tsx:257
-#: src/view/com/util/ErrorBoundary.tsx:57
+#: src/components/dialogs/GifSelect.ios.tsx:239 src/components/dialogs/GifSelect.tsx:257 src/view/com/util/ErrorBoundary.tsx:57
 msgid "There was an unexpected issue in the application. Please let us know if this happened to you!"
 msgstr "D’éirigh fadhb gan choinne leis an aip. Abair linn, le do thoil, má tharla sé sin duit!"
 
 #: src/screens/SignupQueued.tsx:112
 msgid "There's been a rush of new users to Bluesky! We'll activate your account as soon as we can."
 msgstr "Tá ráchairt ar Bluesky le déanaí! Cuirfidh muid do chuntas ag obair chomh luath agus is féidir."
-
-#: src/screens/Onboarding/StepSuggestedAccounts/index.tsx:146
-#~ msgid "These are popular accounts you might like:"
-#~ msgstr "Is cuntais iad seo a bhfuil a lán leantóirí acu. Is féidir go dtaitneoidh siad leat."
 
 #: src/components/moderation/ScreenHider.tsx:116
 msgid "This {screenDescription} has been flagged:"
@@ -5532,8 +4570,7 @@ msgstr "Chuir na modhnóirí foláireamh ginearálta leis an ábhar seo."
 msgid "This content is hosted by {0}. Do you want to enable external media?"
 msgstr "Tá an t-ábhar seo ar fáil ó {0}. An bhfuil fonn ort na meáin sheachtracha a thaispeáint?"
 
-#: src/components/moderation/ModerationDetailsDialog.tsx:77
-#: src/lib/moderation/useModerationCauseDescription.ts:79
+#: src/components/moderation/ModerationDetailsDialog.tsx:77 src/lib/moderation/useModerationCauseDescription.ts:79
 msgid "This content is not available because one of the users involved has blocked the other."
 msgstr "Níl an t-ábhar seo le feiceáil toisc gur bhlocáil duine de na húsáideoirí an duine eile."
 
@@ -5549,9 +4586,7 @@ msgstr "Tá an ghné seo á tástáil fós. Tig leat níos mó faoi chartlanna e
 msgid "This feed is currently receiving high traffic and is temporarily unavailable. Please try again later."
 msgstr "Tá ráchairt an-mhór ar an bhfotha seo faoi láthair. Níl sé ar fáil anois díreach dá bhrí sin. Bain triail eile as níos déanaí, le do thoil."
 
-#: src/screens/Profile/Sections/Feed.tsx:59
-#: src/view/screens/ProfileFeed.tsx:471
-#: src/view/screens/ProfileList.tsx:729
+#: src/screens/Profile/Sections/Feed.tsx:59 src/view/screens/ProfileFeed.tsx:471 src/view/screens/ProfileList.tsx:729
 msgid "This feed is empty!"
 msgstr "Tá an fotha seo folamh!"
 
@@ -5570,10 +4605,6 @@ msgstr "Ní roinntear an t-eolas seo le húsáideoirí eile."
 #: src/view/com/modals/VerifyEmail.tsx:127
 msgid "This is important in case you ever need to change your email or reset your password."
 msgstr "Tá sé seo tábhachtach má bhíonn ort do ríomhphost nó do phasfhocal a athrú."
-
-#: src/components/moderation/ModerationDetailsDialog.tsx:124
-#~ msgid "This label was applied by {0}."
-#~ msgstr "Cuireadh an lipéad seo ag {0}."
 
 #: src/components/moderation/ModerationDetailsDialog.tsx:127
 msgid "This label was applied by <0>{0}</0>."
@@ -5611,8 +4642,7 @@ msgstr "Tá an t-ainm seo in úsáid cheana féin"
 msgid "This post has been deleted."
 msgstr "Scriosadh an phostáil seo."
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:461
-#: src/view/com/util/post-ctrls/PostCtrls.tsx:310
+#: src/view/com/util/forms/PostDropdownBtn.tsx:461 src/view/com/util/post-ctrls/PostCtrls.tsx:310
 msgid "This post is only visible to logged-in users. It won't be visible to people who aren't logged in."
 msgstr "Níl an phostáil seo le feiceáil ach ag úsáideoirí atá logáilte isteach. Ní bheidh daoine nach bhfuil logáilte isteach in ann í a fheiceáil."
 
@@ -5640,8 +4670,7 @@ msgstr "Níl aon leantóirí ag an úsáideoir seo."
 msgid "This user has blocked you"
 msgstr "Tá tú blocáilte ag an úsáideoir seo."
 
-#: src/components/moderation/ModerationDetailsDialog.tsx:72
-#: src/lib/moderation/useModerationCauseDescription.ts:70
+#: src/components/moderation/ModerationDetailsDialog.tsx:72 src/lib/moderation/useModerationCauseDescription.ts:70
 msgid "This user has blocked you. You cannot view their content."
 msgstr "Tá an t-úsáideoir seo tar éis thú a bhlocáil. Ní féidir leat a gcuid ábhair a fheiceáil."
 
@@ -5661,10 +4690,6 @@ msgstr "Tá an t-úsáideoir seo ar an liosta <0>{0}</0> a chuir tú i bhfolach.
 msgid "This user isn't following anyone."
 msgstr "Níl éinne á leanúint ag an úsáideoir seo."
 
-#: src/view/com/modals/SelfLabel.tsx:137
-#~ msgid "This warning is only available for posts with media attached."
-#~ msgstr "Níl an rabhadh seo ar fáil ach le haghaidh postálacha a bhfuil meáin ceangailte leo."
-
 #: src/components/dialogs/MutedWords.tsx:285
 msgid "This will delete {0} from your muted words. You can always add it back later."
 msgstr "Bainfidh sé seo {0} de do chuid focal i bhfolach. Tig leat é a chur ar ais níos déanaí."
@@ -5673,8 +4698,7 @@ msgstr "Bainfidh sé seo {0} de do chuid focal i bhfolach. Tig leat é a chur ar
 msgid "Thread preferences"
 msgstr "Roghanna snáitheanna"
 
-#: src/view/screens/PreferencesThreads.tsx:53
-#: src/view/screens/Settings/index.tsx:604
+#: src/view/screens/PreferencesThreads.tsx:53 src/view/screens/Settings/index.tsx:604
 msgid "Thread Preferences"
 msgstr "Roghanna Snáitheanna"
 
@@ -5710,8 +4734,7 @@ msgstr "Scoránaigh an bosca anuas"
 msgid "Toggle to enable or disable adult content"
 msgstr "Scoránaigh le ábhar do dhaoine fásta a cheadú nó gan a cheadú"
 
-#: src/screens/Hashtag.tsx:88
-#: src/view/screens/Search/Search.tsx:366
+#: src/screens/Hashtag.tsx:88 src/view/screens/Search/Search.tsx:366
 msgid "Top"
 msgstr "Barr"
 
@@ -5719,12 +4742,7 @@ msgstr "Barr"
 msgid "Transformations"
 msgstr "Trasfhoirmithe"
 
-#: src/components/dms/MessageMenu.tsx:103
-#: src/components/dms/MessageMenu.tsx:105
-#: src/view/com/post-thread/PostThreadItem.tsx:691
-#: src/view/com/post-thread/PostThreadItem.tsx:693
-#: src/view/com/util/forms/PostDropdownBtn.tsx:280
-#: src/view/com/util/forms/PostDropdownBtn.tsx:282
+#: src/components/dms/MessageMenu.tsx:103 src/components/dms/MessageMenu.tsx:105 src/view/com/post-thread/PostThreadItem.tsx:691 src/view/com/post-thread/PostThreadItem.tsx:693 src/view/com/util/forms/PostDropdownBtn.tsx:280 src/view/com/util/forms/PostDropdownBtn.tsx:282
 msgid "Translate"
 msgstr "Aistrigh"
 
@@ -5753,23 +4771,11 @@ msgstr "Díbhlocáil an liosta"
 msgid "Un-mute list"
 msgstr "Ná coinnigh an liosta sin i bhfolach níos mó"
 
-#: src/screens/Login/ForgotPasswordForm.tsx:74
-#: src/screens/Login/index.tsx:78
-#: src/screens/Login/LoginForm.tsx:142
-#: src/screens/Login/SetNewPasswordForm.tsx:77
-#: src/screens/Signup/index.tsx:66
-#: src/view/com/modals/ChangePassword.tsx:71
+#: src/screens/Login/ForgotPasswordForm.tsx:74 src/screens/Login/index.tsx:78 src/screens/Login/LoginForm.tsx:142 src/screens/Login/SetNewPasswordForm.tsx:77 src/screens/Signup/index.tsx:66 src/view/com/modals/ChangePassword.tsx:71
 msgid "Unable to contact your service. Please check your Internet connection."
 msgstr "Ní féidir teagmháil a dhéanamh le do sheirbhís. Seiceáil do cheangal leis an idirlíon, le do thoil."
 
-#: src/components/dms/MessagesListBlockedFooter.tsx:89
-#: src/components/dms/MessagesListBlockedFooter.tsx:96
-#: src/components/dms/MessagesListBlockedFooter.tsx:104
-#: src/components/dms/MessagesListBlockedFooter.tsx:111
-#: src/screens/Profile/Header/ProfileHeaderStandard.tsx:184
-#: src/screens/Profile/Header/ProfileHeaderStandard.tsx:295
-#: src/view/com/profile/ProfileMenu.tsx:363
-#: src/view/screens/ProfileList.tsx:626
+#: src/components/dms/MessagesListBlockedFooter.tsx:89 src/components/dms/MessagesListBlockedFooter.tsx:96 src/components/dms/MessagesListBlockedFooter.tsx:104 src/components/dms/MessagesListBlockedFooter.tsx:111 src/screens/Profile/Header/ProfileHeaderStandard.tsx:184 src/screens/Profile/Header/ProfileHeaderStandard.tsx:295 src/view/com/profile/ProfileMenu.tsx:363 src/view/screens/ProfileList.tsx:626
 msgid "Unblock"
 msgstr "Díbhlocáil"
 
@@ -5778,24 +4784,19 @@ msgctxt "action"
 msgid "Unblock"
 msgstr "Díbhlocáil"
 
-#: src/components/dms/ConvoMenu.tsx:188
-#: src/components/dms/ConvoMenu.tsx:192
+#: src/components/dms/ConvoMenu.tsx:188 src/components/dms/ConvoMenu.tsx:192
 msgid "Unblock account"
 msgstr "Díbhlocáil an cuntas"
 
-#: src/view/com/profile/ProfileMenu.tsx:301
-#: src/view/com/profile/ProfileMenu.tsx:307
+#: src/view/com/profile/ProfileMenu.tsx:301 src/view/com/profile/ProfileMenu.tsx:307
 msgid "Unblock Account"
 msgstr "Díbhlocáil an cuntas"
 
-#: src/screens/Profile/Header/ProfileHeaderStandard.tsx:289
-#: src/view/com/profile/ProfileMenu.tsx:345
+#: src/screens/Profile/Header/ProfileHeaderStandard.tsx:289 src/view/com/profile/ProfileMenu.tsx:345
 msgid "Unblock Account?"
 msgstr "An bhfuil fonn ort an cuntas seo a dhíbhlocáil?"
 
-#: src/view/com/util/post-ctrls/RepostButton.tsx:62
-#: src/view/com/util/post-ctrls/RepostButton.web.tsx:69
-#: src/view/com/util/post-ctrls/RepostButton.web.tsx:73
+#: src/view/com/util/post-ctrls/RepostButton.tsx:62 src/view/com/util/post-ctrls/RepostButton.web.tsx:69 src/view/com/util/post-ctrls/RepostButton.web.tsx:73
 msgid "Undo repost"
 msgstr "Cuir stop leis an athphostáil"
 
@@ -5812,21 +4813,15 @@ msgstr "Dílean"
 msgid "Unfollow {0}"
 msgstr "Dílean {0}"
 
-#: src/view/com/profile/ProfileMenu.tsx:243
-#: src/view/com/profile/ProfileMenu.tsx:253
+#: src/view/com/profile/ProfileMenu.tsx:243 src/view/com/profile/ProfileMenu.tsx:253
 msgid "Unfollow Account"
 msgstr "Dílean an cuntas seo"
-
-#: src/view/com/util/post-ctrls/PostCtrls.tsx:197
-#~ msgid "Unlike"
-#~ msgstr "Dímhol"
 
 #: src/view/screens/ProfileFeed.tsx:570
 msgid "Unlike this feed"
 msgstr "Dímhol an fotha seo"
 
-#: src/components/TagMenu/index.tsx:249
-#: src/view/screens/ProfileList.tsx:633
+#: src/components/TagMenu/index.tsx:249 src/view/screens/ProfileList.tsx:633
 msgid "Unmute"
 msgstr "Ná coinnigh i bhfolach"
 
@@ -5834,8 +4829,7 @@ msgstr "Ná coinnigh i bhfolach"
 msgid "Unmute {truncatedTag}"
 msgstr "Ná coinnigh {truncatedTag} i bhfolach"
 
-#: src/view/com/profile/ProfileMenu.tsx:280
-#: src/view/com/profile/ProfileMenu.tsx:286
+#: src/view/com/profile/ProfileMenu.tsx:280 src/view/com/profile/ProfileMenu.tsx:286
 msgid "Unmute Account"
 msgstr "Ná coinnigh an cuntas seo i bhfolach níos mó"
 
@@ -5847,13 +4841,11 @@ msgstr "Ná coinnigh aon phostáil {displayTag} i bhfolach"
 msgid "Unmute conversation"
 msgstr "Díbhalbhaigh an comhrá seo"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:365
-#: src/view/com/util/forms/PostDropdownBtn.tsx:370
+#: src/view/com/util/forms/PostDropdownBtn.tsx:365 src/view/com/util/forms/PostDropdownBtn.tsx:370
 msgid "Unmute thread"
 msgstr "Ná coinnigh an snáithe seo i bhfolach níos mó"
 
-#: src/view/screens/ProfileFeed.tsx:290
-#: src/view/screens/ProfileList.tsx:617
+#: src/view/screens/ProfileFeed.tsx:290 src/view/screens/ProfileList.tsx:617
 msgid "Unpin"
 msgstr "Díghreamaigh"
 
@@ -5877,8 +4869,7 @@ msgstr "Díliostáil"
 msgid "Unsubscribe from this labeler"
 msgstr "Díliostáil ón lipéadóir seo"
 
-#: src/lib/moderation/useReportOptions.ts:71
-#: src/lib/moderation/useReportOptions.ts:84
+#: src/lib/moderation/useReportOptions.ts:71 src/lib/moderation/useReportOptions.ts:84
 msgid "Unwanted Sexual Content"
 msgstr "Ábhar graosta nach mian liom"
 
@@ -5902,22 +4893,15 @@ msgstr "Uaslódáil grianghraf in ionad"
 msgid "Upload a text file to:"
 msgstr "Uaslódáil comhad téacs chuig:"
 
-#: src/view/com/util/UserAvatar.tsx:339
-#: src/view/com/util/UserAvatar.tsx:342
-#: src/view/com/util/UserBanner.tsx:123
-#: src/view/com/util/UserBanner.tsx:126
+#: src/view/com/util/UserAvatar.tsx:339 src/view/com/util/UserAvatar.tsx:342 src/view/com/util/UserBanner.tsx:123 src/view/com/util/UserBanner.tsx:126
 msgid "Upload from Camera"
 msgstr "Uaslódáil ó Cheamara"
 
-#: src/view/com/util/UserAvatar.tsx:356
-#: src/view/com/util/UserBanner.tsx:140
+#: src/view/com/util/UserAvatar.tsx:356 src/view/com/util/UserBanner.tsx:140
 msgid "Upload from Files"
 msgstr "Uaslódáil ó Chomhaid"
 
-#: src/view/com/util/UserAvatar.tsx:350
-#: src/view/com/util/UserAvatar.tsx:354
-#: src/view/com/util/UserBanner.tsx:134
-#: src/view/com/util/UserBanner.tsx:138
+#: src/view/com/util/UserAvatar.tsx:350 src/view/com/util/UserAvatar.tsx:354 src/view/com/util/UserBanner.tsx:134 src/view/com/util/UserBanner.tsx:138
 msgid "Upload from Library"
 msgstr "Uaslódáil ó Leabharlann"
 
@@ -5937,13 +4921,11 @@ msgstr "Bain feidhm as bsky.social mar sholáthraí óstála"
 msgid "Use default provider"
 msgstr "Úsáid an soláthraí réamhshocraithe"
 
-#: src/view/com/modals/InAppBrowserConsent.tsx:56
-#: src/view/com/modals/InAppBrowserConsent.tsx:58
+#: src/view/com/modals/InAppBrowserConsent.tsx:56 src/view/com/modals/InAppBrowserConsent.tsx:58
 msgid "Use in-app browser"
 msgstr "Úsáid an brabhsálaí san aip seo"
 
-#: src/view/com/modals/InAppBrowserConsent.tsx:66
-#: src/view/com/modals/InAppBrowserConsent.tsx:68
+#: src/view/com/modals/InAppBrowserConsent.tsx:66 src/view/com/modals/InAppBrowserConsent.tsx:68
 msgid "Use my default browser"
 msgstr "Úsáid an brabhsálaí réamhshocraithe atá agam"
 
@@ -5963,8 +4945,7 @@ msgstr "Úsáid é seo le logáil isteach ar an aip eile in éindí le do leasai
 msgid "Used by:"
 msgstr "In úsáid ag:"
 
-#: src/components/moderation/ModerationDetailsDialog.tsx:64
-#: src/lib/moderation/useModerationCauseDescription.ts:58
+#: src/components/moderation/ModerationDetailsDialog.tsx:64 src/lib/moderation/useModerationCauseDescription.ts:58
 msgid "User Blocked"
 msgstr "Úsáideoir blocáilte"
 
@@ -5988,8 +4969,7 @@ msgstr "Úsáideoir a bhlocálann thú"
 msgid "User Blocks You"
 msgstr "Blocálann an t-úsáideoir seo thú"
 
-#: src/view/com/lists/ListCard.tsx:87
-#: src/view/com/modals/UserAddRemoveLists.tsx:209
+#: src/view/com/lists/ListCard.tsx:87 src/view/com/modals/UserAddRemoveLists.tsx:209
 msgid "User list by {0}"
 msgstr "Liosta úsáideoirí le {0}"
 
@@ -5997,9 +4977,7 @@ msgstr "Liosta úsáideoirí le {0}"
 msgid "User list by <0/>"
 msgstr "Liosta úsáideoirí le <0/>"
 
-#: src/view/com/lists/ListCard.tsx:85
-#: src/view/com/modals/UserAddRemoveLists.tsx:207
-#: src/view/screens/ProfileList.tsx:829
+#: src/view/com/lists/ListCard.tsx:85 src/view/com/modals/UserAddRemoveLists.tsx:207 src/view/screens/ProfileList.tsx:829
 msgid "User list by you"
 msgstr "Liosta úsáideoirí leat"
 
@@ -6027,10 +5005,7 @@ msgstr "Úsáideoirí"
 msgid "users followed by <0/>"
 msgstr "Úsáideoirí a bhfuil <0/> á leanúint"
 
-#: src/components/dms/MessagesNUX.tsx:140
-#: src/components/dms/MessagesNUX.tsx:143
-#: src/screens/Messages/Settings.tsx:84
-#: src/screens/Messages/Settings.tsx:87
+#: src/components/dms/MessagesNUX.tsx:140 src/components/dms/MessagesNUX.tsx:143 src/screens/Messages/Settings.tsx:84 src/screens/Messages/Settings.tsx:87
 msgid "Users I follow"
 msgstr "Úsáideoirí a leanaim"
 
@@ -6045,10 +5020,6 @@ msgstr "Úsáideoirí ar thaitin an t-ábhar nó an próifíl seo leo"
 #: src/view/com/modals/ChangeHandle.tsx:430
 msgid "Value:"
 msgstr "Luach:"
-
-#: src/view/com/modals/ChangeHandle.tsx:510
-#~ msgid "Verify {0}"
-#~ msgstr "Dearbhaigh {0}"
 
 #: src/view/com/modals/ChangeHandle.tsx:504
 msgid "Verify DNS Record"
@@ -6066,8 +5037,7 @@ msgstr "Dearbhaigh mo ríomhphost"
 msgid "Verify My Email"
 msgstr "Dearbhaigh Mo Ríomhphost"
 
-#: src/view/com/modals/ChangeEmail.tsx:200
-#: src/view/com/modals/ChangeEmail.tsx:202
+#: src/view/com/modals/ChangeEmail.tsx:200 src/view/com/modals/ChangeEmail.tsx:202
 msgid "Verify New Email"
 msgstr "Dearbhaigh an Ríomhphost Nua"
 
@@ -6078,10 +5048,6 @@ msgstr "Dearbhaigh comhad téacs"
 #: src/view/com/modals/VerifyEmail.tsx:111
 msgid "Verify Your Email"
 msgstr "Dearbhaigh Do Ríomhphost"
-
-#: src/view/screens/Settings/index.tsx:852
-#~ msgid "Version {0}"
-#~ msgstr "Leagan {0}"
 
 #: src/view/screens/Settings/index.tsx:935
 msgid "Version {appVersion} {bundleInfo}"
@@ -6097,7 +5063,7 @@ msgstr "Féach ar an abhatár atá ag {0}"
 
 #: src/view/com/notifications/FeedItem.tsx:213
 msgid "View {0}'s profile"
-msgstr ""
+msgstr "Amharc ar phróifíl {0}"
 
 #: src/view/screens/Log.tsx:52
 msgid "View debug entry"
@@ -6119,10 +5085,7 @@ msgstr "Féach ar an snáithe iomlán"
 msgid "View information about these labels"
 msgstr "Féach ar eolas faoi na lipéid seo"
 
-#: src/components/ProfileHoverCard/index.web.tsx:396
-#: src/components/ProfileHoverCard/index.web.tsx:429
-#: src/view/com/posts/AviFollowButton.tsx:58
-#: src/view/com/posts/FeedErrorMessage.tsx:175
+#: src/components/ProfileHoverCard/index.web.tsx:396 src/components/ProfileHoverCard/index.web.tsx:429 src/view/com/posts/AviFollowButton.tsx:58 src/view/com/posts/FeedErrorMessage.tsx:175
 msgid "View profile"
 msgstr "Féach ar an bpróifíl"
 
@@ -6138,14 +5101,11 @@ msgstr "Féach ar an tseirbhís lipéadaithe atá curtha ar fáil ag @{0}"
 msgid "View users who like this feed"
 msgstr "Féach ar úsáideoirí ar thaitin an fotha seo leo"
 
-#: src/view/com/modals/LinkWarning.tsx:89
-#: src/view/com/modals/LinkWarning.tsx:95
+#: src/view/com/modals/LinkWarning.tsx:89 src/view/com/modals/LinkWarning.tsx:95
 msgid "Visit Site"
 msgstr "Tabhair cuairt ar an suíomh"
 
-#: src/components/moderation/LabelPreference.tsx:135
-#: src/lib/moderation/useLabelBehaviorDescription.ts:17
-#: src/lib/moderation/useLabelBehaviorDescription.ts:22
+#: src/components/moderation/LabelPreference.tsx:135 src/lib/moderation/useLabelBehaviorDescription.ts:17 src/lib/moderation/useLabelBehaviorDescription.ts:22
 msgid "Warn"
 msgstr "Rabhadh"
 
@@ -6180,10 +5140,6 @@ msgstr "Níl aon ábhar nua le taispeáint ó na cuntais a leanann tú. Seo duit
 #: src/components/dialogs/MutedWords.tsx:204
 msgid "We recommend avoiding common words that appear in many posts, since it can result in no posts being shown."
 msgstr "Molaimid focail choitianta a bhíonn i go leor póstálacha a sheachaint, toisc gur féidir nach dtaispeánfaí aon phostáil dá bharr."
-
-#: src/screens/Onboarding/StepAlgoFeeds/index.tsx:125
-#~ msgid "We recommend our \"Discover\" feed:"
-#~ msgstr "Molaimid an fotha “Discover”."
 
 #: src/components/dialogs/BirthDateSettings.tsx:52
 msgid "We were unable to load your birth date preferences. Please try again."
@@ -6225,8 +5181,7 @@ msgstr "Tá brón orainn, ach theip orainn na focail a chuir tú i bhfolach a l�
 msgid "We're sorry, but your search could not be completed. Please try again in a few minutes."
 msgstr "Ár leithscéal, ach níorbh fhéidir linn do chuardach a chur i gcrích. Bain triail eile as i gceann cúpla nóiméad."
 
-#: src/components/Lists.tsx:212
-#: src/view/screens/NotFound.tsx:48
+#: src/components/Lists.tsx:212 src/view/screens/NotFound.tsx:48
 msgid "We're sorry! We can't find the page you were looking for."
 msgstr "Ár leithscéal, ach ní féidir linn an leathanach atá tú ag lorg a aimsiú."
 
@@ -6236,19 +5191,13 @@ msgstr "Tá brón orainn! Ní féidir síntiúis a ghlacadh ach le deich lipéad
 
 #: src/screens/Deactivated.tsx:128
 msgid "Welcome back!"
-msgstr ""
-
-#: src/view/com/auth/onboarding/WelcomeMobile.tsx:48
-#~ msgid "Welcome to <0>Bluesky</0>"
-#~ msgstr "Fáilte go <0>Bluesky</0>"
+msgstr "Fáilte ar ais!"
 
 #: src/screens/Onboarding/StepInterests/index.tsx:135
 msgid "What are your interests?"
 msgstr "Cad iad na rudaí a bhfuil suim agat iontu?"
 
-#: src/view/com/auth/SplashScreen.tsx:40
-#: src/view/com/auth/SplashScreen.web.tsx:86
-#: src/view/com/composer/Composer.tsx:340
+#: src/view/com/auth/SplashScreen.tsx:40 src/view/com/auth/SplashScreen.web.tsx:86 src/view/com/composer/Composer.tsx:340
 msgid "What's up?"
 msgstr "Aon scéal?"
 
@@ -6260,8 +5209,7 @@ msgstr "Cad iad na teangacha sa phostáil seo?"
 msgid "Which languages would you like to see in your algorithmic feeds?"
 msgstr "Cad iad na teangacha ba mhaith leat a fheiceáil i do chuid fothaí algartamacha?"
 
-#: src/components/dms/MessagesNUX.tsx:110
-#: src/components/dms/MessagesNUX.tsx:124
+#: src/components/dms/MessagesNUX.tsx:110 src/components/dms/MessagesNUX.tsx:124
 msgid "Who can message you?"
 msgstr "Cé ar féidir leo teachtaireacht a sheoladh chugat?"
 
@@ -6269,8 +5217,7 @@ msgstr "Cé ar féidir leo teachtaireacht a sheoladh chugat?"
 msgid "Who can reply"
 msgstr "Cé atá in ann freagra a thabhairt"
 
-#: src/screens/Home/NoFeedsPinned.tsx:92
-#: src/screens/Messages/List/index.tsx:185
+#: src/screens/Home/NoFeedsPinned.tsx:92 src/screens/Messages/List/index.tsx:185
 msgid "Whoops!"
 msgstr "Úps!"
 
@@ -6302,8 +5249,7 @@ msgstr "Cén fáth gur cheart athbhreithniú a dhéanamh ar an úsáideoir seo?"
 msgid "Wide"
 msgstr "Leathan"
 
-#: src/screens/Messages/Conversation/MessageInput.tsx:140
-#: src/screens/Messages/Conversation/MessageInput.web.tsx:134
+#: src/screens/Messages/Conversation/MessageInput.tsx:140 src/screens/Messages/Conversation/MessageInput.web.tsx:134
 msgid "Write a message"
 msgstr "Scríobh teachtaireacht"
 
@@ -6311,8 +5257,7 @@ msgstr "Scríobh teachtaireacht"
 msgid "Write post"
 msgstr "Scríobh postáil"
 
-#: src/view/com/composer/Composer.tsx:339
-#: src/view/com/composer/Prompt.tsx:39
+#: src/view/com/composer/Composer.tsx:339 src/view/com/composer/Prompt.tsx:39
 msgid "Write your reply"
 msgstr "Scríobh freagra"
 
@@ -6320,24 +5265,17 @@ msgstr "Scríobh freagra"
 msgid "Writers"
 msgstr "Scríbhneoirí"
 
-#: src/view/com/composer/select-language/SuggestedLanguage.tsx:77
-#: src/view/screens/PreferencesFollowingFeed.tsx:128
-#: src/view/screens/PreferencesFollowingFeed.tsx:200
-#: src/view/screens/PreferencesFollowingFeed.tsx:235
-#: src/view/screens/PreferencesFollowingFeed.tsx:270
-#: src/view/screens/PreferencesThreads.tsx:106
-#: src/view/screens/PreferencesThreads.tsx:129
+#: src/view/com/composer/select-language/SuggestedLanguage.tsx:77 src/view/screens/PreferencesFollowingFeed.tsx:128 src/view/screens/PreferencesFollowingFeed.tsx:200 src/view/screens/PreferencesFollowingFeed.tsx:235 src/view/screens/PreferencesFollowingFeed.tsx:270 src/view/screens/PreferencesThreads.tsx:106 src/view/screens/PreferencesThreads.tsx:129
 msgid "Yes"
 msgstr "Tá"
 
-#: src/screens/Settings/components/DeactivateAccountDialog.tsx:106
-#: src/screens/Settings/components/DeactivateAccountDialog.tsx:108
+#: src/screens/Settings/components/DeactivateAccountDialog.tsx:106 src/screens/Settings/components/DeactivateAccountDialog.tsx:108
 msgid "Yes, deactivate"
-msgstr ""
+msgstr "Tá, díghníomhaigh"
 
 #: src/screens/Deactivated.tsx:150
 msgid "Yes, reactivate my account"
-msgstr ""
+msgstr "Tá, athghníomhaigh mo chuntas"
 
 #: src/components/dms/MessageItem.tsx:188
 msgid "Yesterday, {time}"
@@ -6351,18 +5289,13 @@ msgstr "Tá tú sa scuaine."
 msgid "You are not following anyone."
 msgstr "Níl éinne á leanúint agat."
 
-#: src/view/com/posts/FollowingEmptyState.tsx:67
-#: src/view/com/posts/FollowingEndOfFeed.tsx:68
+#: src/view/com/posts/FollowingEmptyState.tsx:67 src/view/com/posts/FollowingEndOfFeed.tsx:68
 msgid "You can also discover new Custom Feeds to follow."
 msgstr "Is féidir leat sainfhothaí nua a aimsiú le leanúint."
 
 #: src/view/com/modals/DeleteAccount.tsx:202
 msgid "You can also temporarily deactivate your account instead, and reactivate it at any time."
-msgstr ""
-
-#: src/screens/Onboarding/StepFollowingFeed.tsx:143
-#~ msgid "You can change these settings later."
-#~ msgstr "Is féidir leat na socruithe seo a athrú níos déanaí."
+msgstr "Is féidir leat do chuntas a dhíghníomhú go sealadach, agus é a athghníomhú uair ar bith."
 
 #: src/components/dms/MessagesNUX.tsx:119
 msgid "You can change this at any time."
@@ -6372,14 +5305,13 @@ msgstr "Is féidir leat é seo a athrú uair ar bith."
 msgid "You can continue ongoing conversations regardless of which setting you choose."
 msgstr "Is féidir leat leanacht le comhráite beag beann ar cén socrú a roghnaíonn tú."
 
-#: src/screens/Login/index.tsx:158
-#: src/screens/Login/PasswordUpdatedForm.tsx:33
+#: src/screens/Login/index.tsx:158 src/screens/Login/PasswordUpdatedForm.tsx:33
 msgid "You can now sign in with your new password."
 msgstr "Is féidir leat logáil isteach le do phasfhocal nua anois."
 
 #: src/screens/Deactivated.tsx:136
 msgid "You can reactivate your account to continue logging in. Your profile and posts will be visible to other users."
-msgstr ""
+msgstr "Is féidir leat do chuntas a athghníomhú chun leanacht ort ag logáil isteach. Beidh úsáideoirí eile in ann do phróifíl agus do chuid postálacha a fheiceáil."
 
 #: src/view/com/profile/ProfileFollowers.tsx:86
 msgid "You do not have any followers."
@@ -6393,10 +5325,6 @@ msgstr "Níl aon chóid chuiridh agat fós! Cuirfidh muid cúpla cód chugat tar
 msgid "You don't have any pinned feeds."
 msgstr "Níl aon fhothaí greamaithe agat."
 
-#: src/view/screens/Feeds.tsx:477
-#~ msgid "You don't have any saved feeds!"
-#~ msgstr "Níl aon fhothaí sábháilte agat!"
-
 #: src/view/screens/SavedFeeds.tsx:158
 msgid "You don't have any saved feeds."
 msgstr "Níl aon fhothaí sábháilte agat."
@@ -6409,16 +5337,11 @@ msgstr "Bhlocáil tú an t-údar nó tá tú blocáilte ag an údar."
 msgid "You have blocked this user"
 msgstr "Bhlocáil tú an t-úsáideoir seo"
 
-#: src/components/moderation/ModerationDetailsDialog.tsx:66
-#: src/lib/moderation/useModerationCauseDescription.ts:52
-#: src/lib/moderation/useModerationCauseDescription.ts:60
+#: src/components/moderation/ModerationDetailsDialog.tsx:66 src/lib/moderation/useModerationCauseDescription.ts:52 src/lib/moderation/useModerationCauseDescription.ts:60
 msgid "You have blocked this user. You cannot view their content."
 msgstr "Bhlocáil tú an cuntas seo. Ní féidir leat a gcuid ábhar a fheiceáil."
 
-#: src/screens/Login/SetNewPasswordForm.tsx:54
-#: src/screens/Login/SetNewPasswordForm.tsx:91
-#: src/view/com/modals/ChangePassword.tsx:88
-#: src/view/com/modals/ChangePassword.tsx:122
+#: src/screens/Login/SetNewPasswordForm.tsx:54 src/screens/Login/SetNewPasswordForm.tsx:91 src/view/com/modals/ChangePassword.tsx:88 src/view/com/modals/ChangePassword.tsx:122
 msgid "You have entered an invalid code. It should look like XXXXX-XXXXX."
 msgstr "Tá tú tar éis cód míchruinn a chur isteach. Ba cheart an cruth seo a bheith air: XXXXX-XXXXX."
 
@@ -6430,8 +5353,7 @@ msgstr "Chuir tú an phostáil seo i bhfolach"
 msgid "You have hidden this post."
 msgstr "Chuir tú an phostáil seo i bhfolach."
 
-#: src/components/moderation/ModerationDetailsDialog.tsx:94
-#: src/lib/moderation/useModerationCauseDescription.ts:94
+#: src/components/moderation/ModerationDetailsDialog.tsx:94 src/lib/moderation/useModerationCauseDescription.ts:94
 msgid "You have muted this account."
 msgstr "Chuir tú an cuntas seo i bhfolach."
 
@@ -6447,8 +5369,7 @@ msgstr "Níl comhrá ar bith agat fós. Tosaigh ceann!"
 msgid "You have no feeds."
 msgstr "Níl aon fhothaí agat."
 
-#: src/view/com/lists/MyLists.tsx:90
-#: src/view/com/lists/ProfileLists.tsx:145
+#: src/view/com/lists/MyLists.tsx:90 src/view/com/lists/ProfileLists.tsx:145
 msgid "You have no lists."
 msgstr "Níl aon liostaí agat."
 
@@ -6484,17 +5405,13 @@ msgstr "Is féidir leat achomharc a dhéanamh maidir leis na lipéad seo má sh�
 msgid "You must be 13 years of age or older to sign up."
 msgstr "Caithfidh tú a bheith 13 bliana d’aois nó níos sine le clárú."
 
-#: src/screens/Onboarding/StepModeration/AdultContentEnabledPref.tsx:110
-#~ msgid "You must be 18 years or older to enable adult content"
-#~ msgstr "Caithfidh tú a bheith 18 mbliana d’aois nó níos sine le hábhar do dhaoine fásta a fháil."
-
 #: src/components/ReportDialog/SubmitView.tsx:206
 msgid "You must select at least one labeler for a report"
 msgstr "Caithfidh tú ar a laghad lipéadóir amháin a roghnú do thuairisc"
 
 #: src/screens/Deactivated.tsx:131
 msgid "You previously deactivated @{0}."
-msgstr ""
+msgstr "Rinne tú díghníomhú ar @{0} cheana."
 
 #: src/view/com/util/forms/PostDropdownBtn.tsx:173
 msgid "You will no longer receive notifications for this thread"
@@ -6514,33 +5431,25 @@ msgstr "Tusa {0}"
 
 #: src/screens/Messages/List/ChatListItem.tsx:142
 msgid "You: {defaultEmbeddedContentMessage}"
-msgstr ""
+msgstr "Tusa: {defaultEmbeddedContentMessage}"
 
 #: src/screens/Messages/List/ChatListItem.tsx:135
 msgid "You: {short}"
-msgstr ""
+msgstr "Tusa: {short}"
 
-#: src/screens/Onboarding/StepModeration/index.tsx:60
-#~ msgid "You're in control"
-#~ msgstr "Tá sé faoi do stiúir"
-
-#: src/screens/SignupQueued.tsx:93
-#: src/screens/SignupQueued.tsx:94
-#: src/screens/SignupQueued.tsx:109
+#: src/screens/SignupQueued.tsx:93 src/screens/SignupQueued.tsx:94 src/screens/SignupQueued.tsx:109
 msgid "You're in line"
 msgstr "Tá tú sa scuaine"
 
-#: src/screens/Deactivated.tsx:89
-#: src/screens/Settings/components/DeactivateAccountDialog.tsx:54
+#: src/screens/Deactivated.tsx:89 src/screens/Settings/components/DeactivateAccountDialog.tsx:54
 msgid "You're logged in with an App Password. Please log in with your main password to continue deactivating your account."
-msgstr ""
+msgstr "Tá tú logáilte isteach le pasfhocal aipe. Logáil isteach le do phríomh-phasfhocal chun dul ar aghaidh le díghníomhú do chuntais."
 
 #: src/screens/Onboarding/StepFinished.tsx:123
 msgid "You're ready to go!"
 msgstr "Tá tú réidh!"
 
-#: src/components/moderation/ModerationDetailsDialog.tsx:98
-#: src/lib/moderation/useModerationCauseDescription.ts:103
+#: src/components/moderation/ModerationDetailsDialog.tsx:98 src/lib/moderation/useModerationCauseDescription.ts:103
 msgid "You've chosen to hide a word or tag within this post."
 msgstr "Roghnaigh tú focal nó clib atá sa phostáil seo a chur i bhfolach."
 
@@ -6572,13 +5481,7 @@ msgstr "Cuireadh do chuid comhráite ar ceal"
 msgid "Your choice will be saved, but can be changed later in settings."
 msgstr "Sábhálfar do rogha, ach is féidir é athrú níos déanaí sna socruithe."
 
-#: src/screens/Onboarding/StepFollowingFeed.tsx:62
-#~ msgid "Your default feed is \"Following\""
-#~ msgstr "Is é “Following” d’fhotha réamhshocraithe"
-
-#: src/screens/Login/ForgotPasswordForm.tsx:57
-#: src/screens/Signup/state.ts:220
-#: src/view/com/modals/ChangePassword.tsx:55
+#: src/screens/Login/ForgotPasswordForm.tsx:57 src/screens/Signup/state.ts:220 src/view/com/modals/ChangePassword.tsx:55
 msgid "Your email appears to be invalid."
 msgstr "Is cosúil go bhfuil do ríomhphost neamhbhailí."
 
@@ -6624,7 +5527,7 @@ msgstr "Do phróifíl"
 
 #: src/screens/Settings/components/DeactivateAccountDialog.tsx:75
 msgid "Your profile, posts, feeds, and lists will no longer be visible to other Bluesky users. You can reactivate your account at any time by logging in."
-msgstr ""
+msgstr "Ní bheidh do phróifíl, postálacha, fothaí ná liostaí infheicthe ag úsáideoirí eile Bluesky. Is féidir leat do chuntas a athghníomhú uair ar bith trí logáil isteach."
 
 #: src/view/com/composer/Composer.tsx:329
 msgid "Your reply has been published"
@@ -6637,3 +5540,551 @@ msgstr "Seolfar do thuairisc go dtí Seirbhís Modhnóireachta Bluesky"
 #: src/screens/Signup/index.tsx:166
 msgid "Your user handle"
 msgstr "Do leasainm"
+
+#: src/components/moderation/LabelsOnMe.tsx:55
+#, fuzzy
+#~ msgid "{0, plural, one {# label has been placed on this account} other {# labels has been placed on this account}}"
+#~ msgstr "{0, plural, one {Cuireadh # lipéad amháin ar an gcuntas seo} two {Cuireadh # lipéad ar an gcuntas seo} few {Cuireadh # lipéad ar an gcuntas seo} many {Cuireadh # lipéad ar an gcuntas seo} other {Cuireadh # lipéad ar an gcuntas seo}}"
+
+#: src/components/moderation/LabelsOnMe.tsx:61
+#, fuzzy
+#~ msgid "{0, plural, one {# label has been placed on this content} other {# labels has been placed on this content}}"
+#~ msgstr "{0, plural, one {Cuireadh # lipéad amháin ar an ábhar seo} two {Cuireadh # lipéad ar an ábhar seo} few {Cuireadh # lipéad ar an ábhar seo} many {Cuireadh # lipéad ar an ábhar seo} other {Cuireadh # lipéad ar an ábhar seo}}"
+
+#: src/view/screens/ProfileList.tsx:286
+#, fuzzy
+#~ msgid "{0} your feeds"
+#~ msgstr "Sábháilte le mo chuid fothaí"
+
+#: src/view/shell/Drawer.tsx:96
+#~ msgid "<0>{0}</0> following"
+#~ msgstr "<0>{0}</0> á leanúint"
+
+#: src/components/ProfileHoverCard/index.web.tsx:437
+#~ msgid "<0>{followers} </0><1>{pluralizedFollowers}</1>"
+#~ msgstr "<0>{following} </0><1>{pluralizedFollowers}</1>"
+
+#: src/components/ProfileHoverCard/index.web.tsx:449 src/screens/Profile/Header/Metrics.tsx:45
+#~ msgid "<0>{following} </0><1>following</1>"
+#~ msgstr "<0>{following} </0><1>á leanúint</1>"
+
+#: src/view/com/auth/onboarding/RecommendedFeeds.tsx:31
+#~ msgid "<0>Choose your</0><1>Recommended</1><2>Feeds</2>"
+#~ msgstr "<0>Roghnaigh do chuid</0><1>Fothaí</1><2>Molta</2>"
+
+#: src/view/com/auth/onboarding/RecommendedFollows.tsx:38
+#~ msgid "<0>Follow some</0><1>Recommended</1><2>Users</2>"
+#~ msgstr "<0>Lean cúpla</0><1>Úsáideoirí</1><2>Molta</2>"
+
+#: src/view/com/auth/onboarding/WelcomeDesktop.tsx:21
+#~ msgid "<0>Welcome to</0><1>Bluesky</1>"
+#~ msgstr "<0>Fáilte go</0><1>Bluesky</1>"
+
+#: src/components/moderation/LabelsOnMe.tsx:42
+#~ msgid "account"
+#~ msgstr "cuntas"
+
+#: src/view/com/composer/GifAltText.tsx:175
+#, fuzzy
+#~ msgid "Add ALT text"
+#~ msgstr "Cuir téacs malartach leis seo"
+
+#: src/view/com/composer/Composer.tsx:467
+#~ msgid "Add link card"
+#~ msgstr "Cuir cárta leanúna leis seo"
+
+#: src/view/com/composer/Composer.tsx:472
+#~ msgid "Add link card:"
+#~ msgstr "Cuir cárta leanúna leis seo:"
+
+#: src/view/com/auth/onboarding/RecommendedFeedsItem.tsx:139
+#~ msgid "Added"
+#~ msgstr "Curtha leis"
+
+#: src/screens/Messages/Settings.tsx:61 src/screens/Messages/Settings.tsx:64
+#, fuzzy
+#~ msgid "Allow messages from"
+#~ msgstr "Ceadaigh teachtaireachtaí nua ó"
+
+#: src/components/moderation/LabelsOnMeDialog.tsx:193
+#~ msgid "Appeal submitted."
+#~ msgstr "Achomharc déanta"
+
+#: src/components/dms/MessageMenu.tsx:123
+#, fuzzy
+#~ msgid "Are you sure you want to delete this message? The message will be deleted for you, but not for other participants."
+#~ msgstr "An bhfuil tú cinnte gur mhaith leat an teachtaireacht seo a scrios? Scriosfar duitse í ach ní don duine eile atá páirteach."
+
+#: src/components/dms/ConvoMenu.tsx:189
+#, fuzzy
+#~ msgid "Are you sure you want to leave this conversation? Your messages will be deleted for you, but not for other participants."
+#~ msgstr "An bhfuil tú cinnte gur mhaith leat imeacht ón gcomhrá seo? Scriosfar duitse é ach ní don duine eile atá páirteach."
+
+#: src/screens/Onboarding/StepSuggestedAccounts/index.tsx:144
+#~ msgid "Based on your interest in {interestsText}"
+#~ msgstr "Toisc go bhfuil suim agat in {interestsText}"
+
+#: src/view/com/auth/onboarding/WelcomeDesktop.tsx:80 src/view/com/auth/onboarding/WelcomeMobile.tsx:82
+#~ msgid "Bluesky is flexible."
+#~ msgstr "Tá Bluesky solúbtha."
+
+#: src/view/com/auth/onboarding/WelcomeDesktop.tsx:69 src/view/com/auth/onboarding/WelcomeMobile.tsx:71
+#~ msgid "Bluesky is open."
+#~ msgstr "Tá Bluesky oscailte."
+
+#: src/view/com/auth/onboarding/WelcomeDesktop.tsx:56 src/view/com/auth/onboarding/WelcomeMobile.tsx:58
+#~ msgid "Bluesky is public."
+#~ msgstr "Tá Bluesky poiblí."
+
+#: src/view/com/auth/onboarding/RecommendedFeedsItem.tsx:100
+#~ msgid "by {0}"
+#~ msgstr "le {0}"
+
+#: src/screens/Onboarding/StepAlgoFeeds/FeedCard.tsx:112
+#~ msgid "by @{0}"
+#~ msgstr "ag @{0}"
+
+#: src/view/com/auth/onboarding/RecommendedFeeds.tsx:122
+#~ msgid "Check out some recommended feeds. Tap + to add them to your list of pinned feeds."
+#~ msgstr "Cuir súil ar na fothaí seo. Brúigh + len iad a chur le liosta na bhfothaí atá greamaithe agat."
+
+#: src/view/com/auth/onboarding/RecommendedFollows.tsx:186
+#~ msgid "Check out some recommended users. Follow them to see similar users."
+#~ msgstr "Cuir súil ar na húsáideoirí seo. Lean iad le húsáideoirí atá cosúil leo a fheiceáil."
+
+#: src/view/com/auth/onboarding/WelcomeDesktop.tsx:83 src/view/com/auth/onboarding/WelcomeMobile.tsx:85
+#~ msgid "Choose the algorithms that power your experience with custom feeds."
+#~ msgstr "Roghnaigh na halgartaim a shainíonn an dóigh a n-oibríonn do chuid sainfhothaí."
+
+#: src/screens/Onboarding/StepAlgoFeeds/index.tsx:104
+#~ msgid "Choose your main feeds"
+#~ msgstr "Roghnaigh do phríomhfhothaí"
+
+#: src/screens/Feeds/NoFollowingFeed.tsx:46
+#, fuzzy
+#~ msgid "Click here to add one."
+#~ msgstr "Cliceáil anseo do bhreis eolais."
+
+#: src/components/RichText.tsx:198
+#~ msgid "Click here to open tag menu for #{tag}"
+#~ msgstr "Cliceáil anseo le clár na clibe le haghaidh #{tag} a oscailt"
+
+#: src/screens/Onboarding/StepModeration/ModerationOption.tsx:81
+#~ msgid "Configure content filtering setting for category: {0}"
+#~ msgstr "Socraigh scagadh an ábhair le haghaidh catagóir: {0}"
+
+#: src/components/moderation/LabelsOnMe.tsx:42
+#~ msgid "content"
+#~ msgstr "ábhar"
+
+#: src/screens/Onboarding/StepAlgoFeeds/index.tsx:158
+#~ msgid "Continue to the next step"
+#~ msgstr "Lean ar aghaidh go dtí an chéad chéim eile"
+
+#: src/screens/Onboarding/StepSuggestedAccounts/index.tsx:199
+#~ msgid "Continue to the next step without following any accounts"
+#~ msgstr "Lean ar aghaidh go dtí an chéad chéim eile gan aon chuntas a leanúint"
+
+#: src/components/dms/ConvoMenu.tsx:68
+#, fuzzy
+#~ msgid "Could not unmute chat"
+#~ msgstr "Níor éiríodh ar an gcomhrá a bhalbhú"
+
+#: src/view/com/composer/Composer.tsx:469
+#~ msgid "Creates a card with a thumbnail. The card links to {url}"
+#~ msgstr "Cruthaíonn sé seo cárta le mionsamhail. Nascann an cárta le {url}."
+
+#: src/view/com/modals/DeleteAccount.tsx:87
+#~ msgid "Delete Account"
+#~ msgstr "Scrios an Cuntas"
+
+#: src/view/screens/Settings/index.tsx:697
+#~ msgid "Disable haptics"
+#~ msgstr "Ná húsáid aiseolas haptach"
+
+#: src/view/screens/Settings/index.tsx:697
+#~ msgid "Disable vibrations"
+#~ msgstr "Ná húsáid creathadh"
+
+#: src/screens/Onboarding/StepModeration/AdultContentEnabledPref.tsx:120
+#~ msgid "Due to Apple policies, adult content can only be enabled on the web after completing sign up."
+#~ msgstr "De bharr pholasaí Apple, ní féidir ábhar do dhaoine fásta ar an nGréasán a fháil roimh an logáil isteach a chríochnú."
+
+#: src/screens/Onboarding/StepModeration/AdultContentEnabledPref.tsx:94
+#~ msgid "Enable Adult Content"
+#~ msgstr "Cuir ábhar do dhaoine fásta ar fáil"
+
+#: src/screens/Onboarding/StepModeration/AdultContentEnabledPref.tsx:78 src/screens/Onboarding/StepModeration/AdultContentEnabledPref.tsx:79
+#~ msgid "Enable adult content in your feeds"
+#~ msgstr "Cuir ábhar do dhaoine fásta ar fáil i do chuid fothaí"
+
+#: src/components/Lists.tsx:52
+#, fuzzy
+#~ msgid "End of list"
+#~ msgstr "Curtha leis an liosta"
+
+#: src/screens/Messages/Conversation/MessageListError.tsx:28
+#, fuzzy
+#~ msgid "Failed to load past messages."
+#~ msgstr "Teip ar theachtaireachtaí roimhe seo a lódáil"
+
+#: src/view/com/auth/onboarding/RecommendedFeeds.tsx:110 src/view/com/auth/onboarding/RecommendedFeeds.tsx:143
+#~ msgid "Failed to load recommended feeds"
+#~ msgstr "Teip ar lódáil na bhfothaí molta"
+
+#: src/screens/Messages/Conversation/MessageListError.tsx:29
+#, fuzzy
+#~ msgid "Failed to send message(s)."
+#~ msgstr "Teip ar theachtaireacht a scriosadh"
+
+#: src/view/com/auth/onboarding/RecommendedFeeds.tsx:58
+#~ msgid "Feeds are created by users to curate content. Choose some feeds that you find interesting."
+#~ msgstr "Is iad na húsáideoirí a chruthaíonn na fothaí le hábhar is spéis leo a chur ar fáil. Roghnaigh cúpla fotha a bhfuil suim agat iontu."
+
+#: src/screens/Onboarding/StepTopicalFeeds.tsx:80
+#~ msgid "Feeds can be topical as well!"
+#~ msgstr "Is féidir le fothaí a bheith bunaithe ar chúrsaí reatha freisin!"
+
+#: src/view/screens/Search/Search.tsx:589
+#~ msgid "Find users on Bluesky"
+#~ msgstr "Aimsigh úsáideoirí ar Bluesky"
+
+#: src/view/screens/Search/Search.tsx:587
+#~ msgid "Find users with the search tool on the right"
+#~ msgstr "Aimsigh úsáideoirí leis an uirlis chuardaigh ar dheis"
+
+#: src/view/com/auth/onboarding/RecommendedFollowsItem.tsx:155
+#~ msgid "Finding similar accounts..."
+#~ msgstr "Cuntais eile atá cosúil leis seo á n-aimsiú..."
+
+#: src/screens/Onboarding/StepSuggestedAccounts/index.tsx:187
+#~ msgid "Follow All"
+#~ msgstr "Lean iad uile"
+
+#: src/screens/Onboarding/StepSuggestedAccounts/index.tsx:182
+#~ msgid "Follow selected accounts and continue to the next step"
+#~ msgstr "Lean na cuntais roghnaithe agus téigh ar aghaidh go dtí an chéad chéim eile"
+
+#: src/view/com/auth/onboarding/RecommendedFollows.tsx:65
+#~ msgid "Follow some users to get started. We can recommend you more users based on who you find interesting."
+#~ msgstr "Lean cúpla cuntas mar thosú. Tig linn níos mó úsáideoirí a mholadh duit a mbeadh suim agat iontu."
+
+#: src/view/screens/Search/Search.tsx:827 src/view/shell/desktop/Search.tsx:263
+#~ msgid "Go to @{queryMaybeHandle}"
+#~ msgstr "Téigh go dtí @{queryMaybeHandle}"
+
+#: src/screens/Onboarding/StepSuggestedAccounts/index.tsx:140
+#~ msgid "Here are some accounts for you to follow"
+#~ msgstr "Seo cúpla cuntas le leanúint duit"
+
+#: src/screens/Onboarding/StepTopicalFeeds.tsx:89
+#~ msgid "Here are some popular topical feeds. You can choose to follow as many as you like."
+#~ msgstr "Seo cúpla fotha a bhfuil ráchairt orthu. Is féidir leat an méid acu is mian leat a leanúint."
+
+#: src/screens/Onboarding/StepTopicalFeeds.tsx:84
+#~ msgid "Here are some topical feeds based on your interests: {interestsText}. You can choose to follow as many as you like."
+#~ msgstr "Seo cúpla fotha a phléann le rudaí a bhfuil suim agat iontu: {interestsText}. Is féidir leat an méid acu is mian leat a leanúint."
+
+#: src/screens/Onboarding/StepFollowingFeed.tsx:65
+#~ msgid "It shows posts from the people you follow as they happen."
+#~ msgstr "Taispeánann sé postálacha ó na daoine a leanann tú nuair a fhoilsítear iad."
+
+#: src/components/moderation/LabelsOnMe.tsx:59
+#~ msgid "label has been placed on this {labelTarget}"
+#~ msgstr "cuireadh lipéad ar an {labelTarget} seo"
+
+#: src/components/moderation/LabelsOnMe.tsx:61
+#~ msgid "labels have been placed on this {labelTarget}"
+#~ msgstr "cuireadh lipéid ar an {labelTarget}"
+
+#: src/view/com/util/post-ctrls/PostCtrls.tsx:197
+#~ msgid "Like"
+#~ msgstr "Mol"
+
+#: src/view/com/feeds/FeedSourceCard.tsx:268
+#~ msgid "Liked by {0} {1}"
+#~ msgstr "Molta ag {0} {1}"
+
+#: src/components/LabelingServiceCard/index.tsx:72
+#~ msgid "Liked by {count} {0}"
+#~ msgstr "Molta ag {count} {0}"
+
+#: src/screens/Profile/Header/ProfileHeaderLabeler.tsx:287 src/screens/Profile/Header/ProfileHeaderLabeler.tsx:301 src/view/screens/ProfileFeed.tsx:600
+#~ msgid "Liked by {likeCount} {0}"
+#~ msgstr "Molta ag {likeCount} {0}"
+
+#: src/screens/Feeds/NoFollowingFeed.tsx:38
+#, fuzzy
+#~ msgid "Looks like you're missing a following feed."
+#~ msgstr "Is cosúil go bhfuil fotha leanúna ar iarraidh ort. <0>Cliceáil anseo le ceann a fháil.</0>"
+
+#: src/Navigation.tsx:307
+#, fuzzy
+#~ msgid "Messaging settings"
+#~ msgstr "Socruithe teachtaireachta"
+
+#: src/components/dms/ConvoMenu.tsx:136 src/components/dms/ConvoMenu.tsx:142
+#, fuzzy
+#~ msgid "Mute notifications"
+#~ msgstr "Fógraí"
+
+#: src/view/com/auth/onboarding/WelcomeDesktop.tsx:72 src/view/com/auth/onboarding/WelcomeMobile.tsx:74
+#~ msgid "Never lose access to your followers and data."
+#~ msgstr "Ná bíodh gan fáil ar do chuid leantóirí ná ar do chuid dáta go deo."
+
+#: src/view/com/auth/onboarding/WelcomeDesktop.tsx:103
+#~ msgctxt "action"
+#~ msgid "Next"
+#~ msgstr "Ar aghaidh"
+
+#: src/components/dms/NewChat.tsx:240
+#, fuzzy
+#~ msgid "No search results found for \"{searchText}\"."
+#~ msgstr "Gan torthaí ar \"{search}\"."
+
+#: src/view/com/modals/SelfLabel.tsx:135
+#~ msgid "Not Applicable."
+#~ msgstr "Ní bhaineann sé sin le hábhar."
+
+#: src/screens/Signup/index.tsx:145
+#~ msgid "of"
+#~ msgstr "de"
+
+#: src/view/com/notifications/FeedItem.tsx:349
+#~ msgid "Opens an expanded list of users in this notification"
+#~ msgstr "Osclaíonn sé seo liosta méadaithe d’úsáideoirí san fhógra seo"
+
+#: src/screens/Messages/List/index.tsx:86
+#, fuzzy
+#~ msgid "Opens the message settings page"
+#~ msgstr "Osclaíonn sé seo logleabhar an chórais"
+
+#: src/screens/Messages/Settings.tsx:97 src/screens/Messages/Settings.tsx:104
+#, fuzzy
+#~ msgid "Play notification sounds"
+#~ msgstr "Fuaimeanna fógra"
+
+#: src/screens/Messages/Conversation/MessagesList.tsx:47 src/screens/Messages/Conversation/MessagesList.tsx:53
+#, fuzzy
+#~ msgid "Press to Retry"
+#~ msgstr "Brúigh le iarracht eile a dhéanamh"
+
+#: src/view/com/modals/Repost.tsx:66
+#~ msgctxt "action"
+#~ msgid "Quote post"
+#~ msgstr "Luaigh an phostáil seo"
+
+#: src/view/com/modals/Repost.tsx:71
+#~ msgctxt "action"
+#~ msgid "Quote Post"
+#~ msgstr "Luaigh an phostáil seo"
+
+#: src/components/dms/MessageReportDialog.tsx:149
+#, fuzzy
+#~ msgid "Reason: {0}"
+#~ msgstr "Fáth:"
+
+#: src/view/com/auth/onboarding/RecommendedFeeds.tsx:117
+#~ msgid "Recommended Feeds"
+#~ msgstr "Fothaí molta"
+
+#: src/view/com/auth/onboarding/RecommendedFollows.tsx:181
+#~ msgid "Recommended Users"
+#~ msgstr "Cuntais mholta"
+
+#: src/view/com/post/Post.tsx:177 src/view/com/posts/FeedItem.tsx:285
+#~ msgctxt "description"
+#~ msgid "Reply to <0/>"
+#~ msgstr "Freagra ar <0/>"
+
+#: src/components/dms/ConvoMenu.tsx:146 src/components/dms/ConvoMenu.tsx:150
+#, fuzzy
+#~ msgid "Report account"
+#~ msgstr "Déan gearán faoi chuntas"
+
+#: src/view/com/posts/FeedItem.tsx:214
+#~ msgid "Reposted by <0/>"
+#~ msgstr "Athphostáilte ag <0/>"
+
+#: src/screens/Messages/Conversation/MessageListError.tsx:54
+#, fuzzy
+#~ msgid "Retry."
+#~ msgstr "Bain triail eile as"
+
+#: src/view/com/lightbox/Lightbox.tsx:81
+#~ msgid "Saved to your camera roll."
+#~ msgstr "Sábháilte i do rolla ceamara."
+
+#: src/view/com/notifications/FeedItem.tsx:411 src/view/com/util/UserAvatar.tsx:402
+#~ msgid "See profile"
+#~ msgstr "Féach ar an bpróifíl"
+
+#: src/view/com/auth/HomeLoggedOutCTA.tsx:40
+#~ msgid "See what's next"
+#~ msgstr "Féach an chéad rud eile"
+
+#: src/screens/Onboarding/StepSuggestedAccounts/index.tsx:52
+#~ msgid "Select some accounts below to follow"
+#~ msgstr "Roghnaigh cúpla cuntas le leanúint"
+
+#: src/screens/Onboarding/StepTopicalFeeds.tsx:100
+#~ msgid "Select topical feeds to follow from the list below"
+#~ msgstr "Roghnaigh fothaí le leanúint ón liosta thíos"
+
+#: src/screens/Onboarding/StepModeration/index.tsx:63
+#~ msgid "Select what you want to see (or not see), and we’ll handle the rest."
+#~ msgstr "Roghnaigh na rudaí ba mhaith leat a fheiceáil (nó gan a fheiceáil), agus leanfaimid ar aghaidh as sin"
+
+#: src/screens/Onboarding/StepAlgoFeeds/index.tsx:117
+#~ msgid "Select your primary algorithmic feeds"
+#~ msgstr "Roghnaigh do phríomhfhothaí algartamacha"
+
+#: src/screens/Onboarding/StepAlgoFeeds/index.tsx:133
+#~ msgid "Select your secondary algorithmic feeds"
+#~ msgstr "Roghnaigh do chuid fothaí algartamacha tánaisteacha"
+
+#: src/view/screens/PreferencesFollowingFeed.tsx:68
+#~ msgid "Show all replies"
+#~ msgstr "Taispeáin gach freagra"
+
+#: src/screens/Onboarding/StepFollowingFeed.tsx:119
+#~ msgid "Show quote-posts in Following feed"
+#~ msgstr "Taispeáin postálacha athluaite san fhotha “Á Leanúint”"
+
+#: src/screens/Onboarding/StepFollowingFeed.tsx:135
+#~ msgid "Show quotes in Following"
+#~ msgstr "Taispeáin postálacha athluaite san fhotha “Á Leanúint”"
+
+#: src/screens/Onboarding/StepFollowingFeed.tsx:95
+#~ msgid "Show re-posts in Following feed"
+#~ msgstr "Taispeáin athphostálacha san fhotha “Á Leanúint”"
+
+#: src/screens/Onboarding/StepFollowingFeed.tsx:87
+#~ msgid "Show replies in Following"
+#~ msgstr "Taispeáin freagraí san fhotha “Á Leanúint”"
+
+#: src/screens/Onboarding/StepFollowingFeed.tsx:71
+#~ msgid "Show replies in Following feed"
+#~ msgstr "Taispeáin freagraí san fhotha “Á Leanúint”"
+
+#: src/view/screens/PreferencesFollowingFeed.tsx:70
+#~ msgid "Show replies with at least {value} {0}"
+#~ msgstr "Taispeáin freagraí a bhfuil ar a laghad {value} {0} acu"
+
+#: src/screens/Onboarding/StepFollowingFeed.tsx:111
+#~ msgid "Show reposts in Following"
+#~ msgstr "Taispeáin athphostálacha san fhotha “Á Leanúint”"
+
+#: src/view/com/notifications/FeedItem.tsx:347
+#~ msgid "Show users"
+#~ msgstr "Taispeáin úsáideoirí"
+
+#: src/components/moderation/LabelsOnMeDialog.tsx:168
+#~ msgid "Source:"
+#~ msgstr "Foinse:"
+
+#: src/view/screens/Settings/index.tsx:862
+#~ msgid "Status page"
+#~ msgstr "Leathanach stádais"
+
+#: src/screens/Signup/index.tsx:145
+#~ msgid "Step"
+#~ msgstr "Céim"
+
+#: src/screens/Onboarding/StepAlgoFeeds/FeedCard.tsx:172 src/screens/Onboarding/StepAlgoFeeds/FeedCard.tsx:307
+#~ msgid "Subscribe to the {0} feed"
+#~ msgstr "Liostáil leis an bhfotha {0}"
+
+#: src/components/moderation/ModerationDetailsDialog.tsx:127
+#~ msgid "the author"
+#~ msgstr "an t-údar"
+
+#: src/screens/Onboarding/StepAlgoFeeds/index.tsx:141
+#~ msgid "There are many feeds to try:"
+#~ msgstr "Tá a lán fothaí ann le blaiseadh:"
+
+#: src/screens/Messages/Conversation/MessageListError.tsx:23
+#, fuzzy
+#~ msgid "There was an issue connecting to the chat."
+#~ msgstr "Bhí fadhb ann maidir le teagmháil a dhéanamh le Tenor."
+
+#: src/screens/Onboarding/StepModeration/AdultContentEnabledPref.tsx:65
+#~ msgid "There was an issue syncing your preferences with the server"
+#~ msgstr "Bhí fadhb ann maidir le do chuid roghanna a shioncronú leis an bhfreastalaí"
+
+#: src/screens/Onboarding/StepSuggestedAccounts/index.tsx:146
+#~ msgid "These are popular accounts you might like:"
+#~ msgstr "Is cuntais iad seo a bhfuil a lán leantóirí acu. Is féidir go dtaitneoidh siad leat."
+
+#: src/screens/Messages/Conversation/MessageListError.tsx:26
+#, fuzzy
+#~ msgid "This chat was disconnected due to a network error."
+#~ msgstr "Dínascadh an comhrá seo"
+
+#: src/components/moderation/ModerationDetailsDialog.tsx:124
+#~ msgid "This label was applied by {0}."
+#~ msgstr "Cuireadh an lipéad seo ag {0}."
+
+#: src/components/moderation/LabelsOnMeDialog.tsx:165
+#, fuzzy
+#~ msgid "This label was applied by you"
+#~ msgstr "Chuir tusa an lipéad seo leis."
+
+#: src/view/com/modals/SelfLabel.tsx:137
+#~ msgid "This warning is only available for posts with media attached."
+#~ msgstr "Níl an rabhadh seo ar fáil ach le haghaidh postálacha a bhfuil meáin ceangailte leo."
+
+#: src/view/com/util/post-ctrls/PostCtrls.tsx:197
+#~ msgid "Unlike"
+#~ msgstr "Dímhol"
+
+#: src/components/dms/ConvoMenu.tsx:140
+#, fuzzy
+#~ msgid "Unmute notifications"
+#~ msgstr "Lódáil fógraí nua"
+
+#: src/lib/moderation/useReportOptions.ts:85
+#, fuzzy
+#~ msgid "Unwanted sexual content"
+#~ msgstr "Ábhar graosta nach mian liom"
+
+#: src/view/com/modals/ChangeHandle.tsx:510
+#~ msgid "Verify {0}"
+#~ msgstr "Dearbhaigh {0}"
+
+#: src/view/screens/Settings/index.tsx:852
+#~ msgid "Version {0}"
+#~ msgstr "Leagan {0}"
+
+#: src/screens/Onboarding/StepAlgoFeeds/index.tsx:125
+#~ msgid "We recommend our \"Discover\" feed:"
+#~ msgstr "Molaimid an fotha “Discover”."
+
+#: src/view/com/auth/onboarding/WelcomeMobile.tsx:48
+#~ msgid "Welcome to <0>Bluesky</0>"
+#~ msgstr "Fáilte go <0>Bluesky</0>"
+
+#: src/screens/Onboarding/StepFollowingFeed.tsx:143
+#~ msgid "You can change these settings later."
+#~ msgstr "Is féidir leat na socruithe seo a athrú níos déanaí."
+
+#: src/view/screens/Feeds.tsx:477
+#~ msgid "You don't have any saved feeds!"
+#~ msgstr "Níl aon fhothaí sábháilte agat!"
+
+#: src/screens/Messages/List/index.tsx:200
+#, fuzzy
+#~ msgid "You have no messages yet. Start a conversation with someone!"
+#~ msgstr "Níl comhrá ar bith agat fós. Tosaigh ceann!"
+
+#: src/screens/Onboarding/StepModeration/AdultContentEnabledPref.tsx:110
+#~ msgid "You must be 18 years or older to enable adult content"
+#~ msgstr "Caithfidh tú a bheith 18 mbliana d’aois nó níos sine le hábhar do dhaoine fásta a fháil."
+
+#: src/screens/Onboarding/StepModeration/index.tsx:60
+#~ msgid "You're in control"
+#~ msgstr "Tá sé faoi do stiúir"
+
+#: src/screens/Onboarding/StepFollowingFeed.tsx:62
+#~ msgid "Your default feed is \"Following\""
+#~ msgstr "Is é “Following” d’fhotha réamhshocraithe"


### PR DESCRIPTION
This PR brings us back to 100%, and fixes a couple of small linguistic bugs in our plural forms.  Thanks to @Aonghuso and Donncha King as usual!

Small review request from someone who knows the setup for plural forms: I've assumed here that we can leave out the "#" from the translation if we don't need it. For example in the "one" case, we can say "1 duine amháin" for "1 person", but it's nicer to say just "Duine amháin" so that's what I've done here.