### PR TITLE
Option to disable native translations

### DIFF
--- a/src/lib/translate.ts
+++ b/src/lib/translate.ts
@@ -1,0 +1,33 @@
+import {useCallback} from 'react'
+
+import {getTranslatorLink} from '#/locale/helpers'
+import {useLanguagePrefs} from '#/state/preferences'
+import {useNativeTranslationDisabled} from '#/state/preferences/disable-native-translation'
+import {useOpenLink} from '#/state/preferences/in-app-browser'
+import {
+  isAvailable,
+  isLanguageSupported,
+  NativeTranslationModule,
+} from '../../modules/expo-bluesky-translate'
+
+export function useTranslate() {
+  const openLink = useOpenLink()
+  const disabled = useNativeTranslationDisabled()
+  const langPrefs = useLanguagePrefs()
+
+  return useCallback(
+    (text: string, lang?: string) => {
+      if (
+        isAvailable &&
+        !disabled &&
+        isLanguageSupported(lang) &&
+        isLanguageSupported(langPrefs.primaryLanguage)
+      ) {
+        NativeTranslationModule.presentAsync(text)
+      } else {
+        openLink(getTranslatorLink(text, langPrefs.primaryLanguage))
+      }
+    },
+    [openLink, disabled, langPrefs.primaryLanguage],
+  )
+}

--- a/src/state/persisted/schema.ts
+++ b/src/state/persisted/schema.ts
@@ -88,6 +88,7 @@ export const schema = z.object({
   disableHaptics: z.boolean().optional(),
   disableAutoplay: z.boolean().optional(),
   kawaii: z.boolean().optional(),
+  disableNativeTranslation: z.boolean().optional(),
 })
 export type Schema = z.infer<typeof schema>
 
@@ -126,4 +127,5 @@ export const defaults: Schema = {
   disableHaptics: false,
   disableAutoplay: prefersReducedMotion,
   kawaii: false,
+  disableNativeTranslation: false,
 }

--- a/src/state/preferences/disable-native-translation.tsx
+++ b/src/state/preferences/disable-native-translation.tsx
@@ -1,0 +1,45 @@
+import React from 'react'
+
+import * as persisted from '#/state/persisted'
+
+type StateContext = boolean
+type SetContext = (v: boolean) => void
+
+const stateContext = React.createContext<StateContext>(
+  Boolean(persisted.defaults.disableNativeTranslation),
+)
+const setContext = React.createContext<SetContext>((_: boolean) => {})
+
+export function Provider({children}: {children: React.ReactNode}) {
+  const [state, setState] = React.useState(
+    Boolean(persisted.get('disableNativeTranslation')),
+  )
+
+  const setStateWrapped = React.useCallback(
+    (
+      nativeTranslationEnabled: persisted.Schema['disableNativeTranslation'],
+    ) => {
+      setState(Boolean(nativeTranslationEnabled))
+      persisted.write('disableNativeTranslation', nativeTranslationEnabled)
+    },
+    [setState],
+  )
+
+  React.useEffect(() => {
+    return persisted.onUpdate(() => {
+      setState(Boolean(persisted.get('disableNativeTranslation')))
+    })
+  }, [setStateWrapped])
+
+  return (
+    <stateContext.Provider value={state}>
+      <setContext.Provider value={setStateWrapped}>
+        {children}
+      </setContext.Provider>
+    </stateContext.Provider>
+  )
+}
+
+export const useNativeTranslationDisabled = () => React.useContext(stateContext)
+export const useSetNativeTranslationDisabled = () =>
+  React.useContext(setContext)

--- a/src/state/preferences/index.tsx
+++ b/src/state/preferences/index.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import {Provider as AltTextRequiredProvider} from './alt-text-required'
 import {Provider as AutoplayProvider} from './autoplay'
 import {Provider as DisableHapticsProvider} from './disable-haptics'
+import {Provider as DisableNativeTranslationProvider} from './disable-native-translation'
 import {Provider as ExternalEmbedsProvider} from './external-embeds-prefs'
 import {Provider as HiddenPostsProvider} from './hidden-posts'
 import {Provider as InAppBrowserProvider} from './in-app-browser'
@@ -32,7 +33,11 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
             <InAppBrowserProvider>
               <DisableHapticsProvider>
                 <AutoplayProvider>
-                  <KawaiiProvider>{children}</KawaiiProvider>
+                  <KawaiiProvider>
+                    <DisableNativeTranslationProvider>
+                      {children}
+                    </DisableNativeTranslationProvider>
+                  </KawaiiProvider>
                 </AutoplayProvider>
               </DisableHapticsProvider>
             </InAppBrowserProvider>

--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -13,7 +13,6 @@ import {useLingui} from '@lingui/react'
 
 import {POST_TOMBSTONE, Shadow, usePostShadow} from '#/state/cache/post-shadow'
 import {useLanguagePrefs} from '#/state/preferences'
-import {useOpenLink} from '#/state/preferences/in-app-browser'
 import {ThreadPost} from '#/state/queries/post-thread'
 import {useComposerControls} from '#/state/shell/composer'
 import {MAX_POST_LINES} from 'lib/constants'
@@ -30,16 +29,11 @@ import {useSession} from 'state/session'
 import {PostThreadFollowBtn} from 'view/com/post-thread/PostThreadFollowBtn'
 import {atoms as a} from '#/alf'
 import {RichText} from '#/components/RichText'
-import {
-  isAvailable as isNativeTranslationAvailable,
-  isLanguageSupported,
-  NativeTranslationModule,
-} from '../../../../modules/expo-bluesky-translate'
 import {ContentHider} from '../../../components/moderation/ContentHider'
 import {LabelsOnMyPost} from '../../../components/moderation/LabelsOnMe'
 import {PostAlerts} from '../../../components/moderation/PostAlerts'
 import {PostHider} from '../../../components/moderation/PostHider'
-import {getTranslatorLink, isPostInLanguage} from '../../../locale/helpers'
+import {isPostInLanguage} from '../../../locale/helpers'
 import {WhoCanReply} from '../threadgate/WhoCanReply'
 import {ErrorMessage} from '../util/error/ErrorMessage'
 import {Link, TextLink} from '../util/Link'
@@ -50,6 +44,7 @@ import {PostMeta} from '../util/PostMeta'
 import {Text} from '../util/text/Text'
 import {PreviewableUserAvatar} from '../util/UserAvatar'
 import hairlineWidth = StyleSheet.hairlineWidth
+import {useTranslate} from '#/lib/translate'
 
 export function PostThreadItem({
   post,
@@ -205,10 +200,6 @@ let PostThreadItemLoaded = ({
   }, [post.uri, post.author])
   const repostsTitle = _(msg`Reposts of this post`)
 
-  const translatorUrl = getTranslatorLink(
-    record?.text || '',
-    langPrefs.primaryLanguage,
-  )
   const needsTranslation = useMemo(
     () =>
       Boolean(
@@ -345,7 +336,6 @@ let PostThreadItemLoaded = ({
             <ExpandedPostDetails
               post={post}
               record={record}
-              translatorUrl={translatorUrl}
               needsTranslation={needsTranslation}
             />
             {post.repostCount !== 0 || post.likeCount !== 0 ? (
@@ -655,29 +645,20 @@ function ExpandedPostDetails({
   post,
   record,
   needsTranslation,
-  translatorUrl,
 }: {
   post: AppBskyFeedDefs.PostView
   record?: AppBskyFeedPost.Record
   needsTranslation: boolean
-  translatorUrl: string
 }) {
   const pal = usePalette('default')
   const {_} = useLingui()
-  const openLink = useOpenLink()
 
   const text = record?.text || ''
 
+  const translate = useTranslate()
   const onTranslatePress = React.useCallback(() => {
-    if (
-      isNativeTranslationAvailable &&
-      isLanguageSupported(record?.langs?.at(0))
-    ) {
-      NativeTranslationModule.presentAsync(text)
-    } else {
-      openLink(translatorUrl)
-    }
-  }, [openLink, text, translatorUrl, record])
+    translate(text, record?.langs?.at(0))
+  }, [translate, text, record?.langs])
 
   return (
     <View style={[s.flexRow, s.mt2, s.mb10]}>

--- a/src/view/screens/LanguageSettings.tsx
+++ b/src/view/screens/LanguageSettings.tsx
@@ -12,6 +12,10 @@ import {useFocusEffect} from '@react-navigation/native'
 import {sanitizeAppLanguageSetting} from '#/locale/helpers'
 import {useModalControls} from '#/state/modals'
 import {useLanguagePrefs, useLanguagePrefsApi} from '#/state/preferences'
+import {
+  useNativeTranslationDisabled,
+  useSetNativeTranslationDisabled,
+} from '#/state/preferences/disable-native-translation'
 import {useSetMinimalShellMode} from '#/state/shell'
 import {APP_LANGUAGES, LANGUAGES} from 'lib/../locale/languages'
 import {useAnalytics} from 'lib/analytics/analytics'
@@ -22,7 +26,12 @@ import {s} from 'lib/styles'
 import {Button} from 'view/com/util/forms/Button'
 import {ViewHeader} from 'view/com/util/ViewHeader'
 import {CenteredView} from 'view/com/util/Views'
+import {atoms as a, useBreakpoints, web} from '#/alf'
+import {Divider} from '#/components/Divider'
+import * as Toggle from '#/components/forms/Toggle'
+import {isAvailable as isNativeTranslationAvailable} from '../../../modules/expo-bluesky-translate'
 import {Text} from '../com/util/text/Text'
+import {ScrollView} from '../com/util/Views'
 
 type Props = NativeStackScreenProps<CommonNavigatorParams, 'LanguageSettings'>
 
@@ -35,6 +44,9 @@ export function LanguageSettingsScreen(_props: Props) {
   const {screen, track} = useAnalytics()
   const setMinimalShellMode = useSetMinimalShellMode()
   const {openModal} = useModalControls()
+  const nativeTranslationDisabled = useNativeTranslationDisabled()
+  const setNativeTranslationDisabled = useSetNativeTranslationDisabled()
+  const {gtMobile} = useBreakpoints()
 
   useFocusEffect(
     React.useCallback(() => {
@@ -87,9 +99,16 @@ export function LanguageSettingsScreen(_props: Props) {
         styles.container,
         isTabletOrDesktop && styles.desktopContainer,
       ]}>
-      <ViewHeader title={_(msg`Language Settings`)} showOnDesktop />
+      <ViewHeader title={_(msg`Language Settings`)} showOnDesktop showBorder />
 
-      <View style={{paddingTop: 20, paddingHorizontal: 20}}>
+      <ScrollView
+        contentContainerStyle={[
+          a.border_0,
+          a.pt_2xl,
+          a.px_lg,
+          gtMobile && a.px_2xl,
+          web({minHeight: '100%'}),
+        ]}>
         {/* APP LANGUAGE */}
         <View style={{paddingBottom: 20}}>
           <Text type="title-sm" style={[pal.text, s.pb5]}>
@@ -175,13 +194,7 @@ export function LanguageSettingsScreen(_props: Props) {
           </View>
         </View>
 
-        <View
-          style={{
-            height: 1,
-            backgroundColor: pal.border.borderColor,
-            marginBottom: 20,
-          }}
-        />
+        <Divider style={{marginBottom: 20}} />
 
         {/* PRIMARY LANGUAGE */}
         <View style={{paddingBottom: 20}}>
@@ -266,13 +279,7 @@ export function LanguageSettingsScreen(_props: Props) {
           </View>
         </View>
 
-        <View
-          style={{
-            height: 1,
-            backgroundColor: pal.border.borderColor,
-            marginBottom: 20,
-          }}
-        />
+        <Divider style={{marginBottom: 20}} />
 
         {/* CONTENT LANGUAGES */}
         <View style={{paddingBottom: 20}}>
@@ -302,7 +309,51 @@ export function LanguageSettingsScreen(_props: Props) {
             </Text>
           </Button>
         </View>
-      </View>
+
+        {/* NATIVE TRANSLATION */}
+        {isNativeTranslationAvailable && (
+          <View style={{paddingBottom: 20}}>
+            <Divider style={{marginBottom: 20}} />
+
+            <Text type="title-sm" style={[pal.text, s.pb5]}>
+              <Trans>Native Translations</Trans>
+            </Text>
+            <Text style={[pal.text, s.pb10]}>
+              <Trans>
+                Translations are provided the operating system, where available.
+                Unfortuntely, the number of languages supported by this feature
+                is limited, so you may want to disable this and fall back to
+                opening a translation in your web browser.
+              </Trans>
+            </Text>
+
+            <Toggle.Group
+              label={_(msg`Enable native translation`)}
+              type="radio"
+              values={[nativeTranslationDisabled ? 'disabled' : 'enabled']}
+              onChange={value =>
+                setNativeTranslationDisabled(
+                  value[0] === 'enabled' ? false : true,
+                )
+              }>
+              <View style={[a.gap_sm, a.py_sm]}>
+                <Toggle.Item name="enabled" label={_(msg`Enabled`)}>
+                  <Toggle.Radio />
+                  <Toggle.LabelText>
+                    <Trans>Enabled</Trans>
+                  </Toggle.LabelText>
+                </Toggle.Item>
+                <Toggle.Item name="disabled" label={_(msg`Disabled`)}>
+                  <Toggle.Radio />
+                  <Toggle.LabelText>
+                    <Trans>Disabled</Trans>
+                  </Toggle.LabelText>
+                </Toggle.Item>
+              </View>
+            </Toggle.Group>
+          </View>
+        )}
+      </ScrollView>
     </CenteredView>
   )
 }
@@ -315,7 +366,7 @@ const styles = StyleSheet.create({
   desktopContainer: {
     borderLeftWidth: 1,
     borderRightWidth: 1,
-    paddingBottom: 40,
+    paddingBottom: 0,
   },
   button: {
     flexDirection: 'row',


### PR DESCRIPTION
This PR does three things

- Falls back to google translate if the user's preferred language is not supported
- Cleans up duplicated translation logic into a neat little hook called `useTranslate`
- Adds an option to disable native translations altogether

![simulator_screenshot_A9A6B60D-C9CA-4A8B-9129-AC75C1CDB6C7](https://github.com/bluesky-social/social-app/assets/10959775/572b1879-20a0-44b7-abfc-fed1db969498)
