### PR TITLE
Override legacy language codes for indonesian, hebrew, and yiddish

### DIFF
--- a/src/locale/helpers.ts
+++ b/src/locale/helpers.ts
@@ -134,6 +134,7 @@ export function sanitizeAppLanguageSetting(appLanguage: string): AppLanguage {
       case 'hi':
         return AppLanguage.hi
       case 'id':
+      case 'in': // some android devices wrongly report 'in' instead of 'id'
         return AppLanguage.id
       case 'it':
         return AppLanguage.it

--- a/src/locale/helpers.ts
+++ b/src/locale/helpers.ts
@@ -116,7 +116,7 @@ export function sanitizeAppLanguageSetting(appLanguage: string): AppLanguage {
   const langs = appLanguage.split(',').filter(Boolean)
 
   for (const lang of langs) {
-    switch (lang) {
+    switch (fixLegacyLanguageCode(lang)) {
       case 'en':
         return AppLanguage.en
       case 'ca':
@@ -134,7 +134,6 @@ export function sanitizeAppLanguageSetting(appLanguage: string): AppLanguage {
       case 'hi':
         return AppLanguage.hi
       case 'id':
-      case 'in': // some android devices wrongly report 'in' instead of 'id'
         return AppLanguage.id
       case 'it':
         return AppLanguage.it
@@ -157,4 +156,21 @@ export function sanitizeAppLanguageSetting(appLanguage: string): AppLanguage {
     }
   }
   return AppLanguage.en
+}
+
+export function fixLegacyLanguageCode(code: string | null): string | null {
+  // handle some legacy code conversions, see https://xml.coverpages.org/iso639a.html
+  if (code === 'in') {
+    // indonesian
+    return 'id'
+  }
+  if (code === 'iw') {
+    // hebrew
+    return 'he'
+  }
+  if (code === 'ji') {
+    // yiddish
+    return 'yi'
+  }
+  return code
 }

--- a/src/platform/detection.ts
+++ b/src/platform/detection.ts
@@ -17,8 +17,16 @@ export const isMobileWeb =
 
 export const deviceLocales = dedupArray(
   getLocales?.()
-    .map?.(locale => locale.languageCode)
+    .map?.(locale => fixLanguageCode(locale.languageCode))
     .filter(code => typeof code === 'string'),
 ) as string[]
 
 export const prefersReducedMotion = isReducedMotion()
+
+function fixLanguageCode(code: string | null): string | null {
+  // some android devices incorrectly report 'in' for indonesian
+  if (code === 'in') {
+    return 'id'
+  }
+  return code
+}

--- a/src/platform/detection.ts
+++ b/src/platform/detection.ts
@@ -2,6 +2,7 @@ import {Platform} from 'react-native'
 import {isReducedMotion} from 'react-native-reanimated'
 import {getLocales} from 'expo-localization'
 
+import {fixLegacyLanguageCode} from '#/locale/helpers'
 import {dedupArray} from 'lib/functions'
 
 export const isIOS = Platform.OS === 'ios'
@@ -17,16 +18,8 @@ export const isMobileWeb =
 
 export const deviceLocales = dedupArray(
   getLocales?.()
-    .map?.(locale => fixLanguageCode(locale.languageCode))
+    .map?.(locale => fixLegacyLanguageCode(locale.languageCode))
     .filter(code => typeof code === 'string'),
 ) as string[]
 
 export const prefersReducedMotion = isReducedMotion()
-
-function fixLanguageCode(code: string | null): string | null {
-  // some android devices incorrectly report 'in' for indonesian
-  if (code === 'in') {
-    return 'id'
-  }
-  return code
-}


### PR DESCRIPTION
Maps some old language codes that still get reported by Java (and thus Android)

https://stackoverflow.com/questions/55955641/correct-locale-for-indonesia-id-id-vs-in-id

> it is not a bug in Java, but "the problem" with backward compatibility. Java uses the first version of ISO 639. Later the standard has been updated, and some codes have been updated. Java was designed as fully backward compatible, so the authors decided to not update that codes. It is the cause why "id_ID" is changed to "in_ID". Indonesian is not the only code which is used in an old form. At least Hebrew and Yiddish are also used in the old form.

This is supported in https://xml.coverpages.org/iso639a.html