### PR TITLE
Fix: show known feed error UI more reliably

### DIFF
--- a/src/view/com/posts/FeedErrorMessage.tsx
+++ b/src/view/com/posts/FeedErrorMessage.tsx
@@ -49,8 +49,7 @@ export function FeedErrorMessage({
   if (
     typeof knownError !== 'undefined' &&
     knownError !== KnownError.Unknown &&
-    (savedFeedConfig?.type === 'feed' ||
-      knownError === KnownError.FeedNSFPublic)
+    feedDesc.startsWith('feedgen')
   ) {
     return (
       <FeedgenErrorMessage
@@ -272,7 +271,7 @@ function detectKnownError(
   ) {
     return KnownError.FeedgenMisconfigured
   }
-  if (error.includes('feed provided an invalid response')) {
+  if (error.includes('invalid response')) {
     return KnownError.FeedgenBadResponse
   }
   return KnownError.FeedgenUnknown


### PR DESCRIPTION
Previously we were relying on the saved config to ensure the Known Feed Error UI was being given on feedgens. This updates it to work even if unsaved.

Can test with memgraph's authors feed