### PR TITLE
Give a meaningful error in the composer when replying to a deleted post

### DIFF
--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -305,7 +305,13 @@ export const ComposePost = observer(function ComposePost({
           localThumb: undefined,
         } as apilib.ExternalEmbedDraft)
       }
-      setError(cleanError(e.message))
+      let err = cleanError(e.message)
+      if (err.includes('not locate record')) {
+        err = _(
+          msg`We're sorry! The post you are replying to has been deleted.`,
+        )
+      }
+      setError(err)
       setIsProcessing(false)
       return
     } finally {
@@ -785,11 +791,12 @@ const styles = StyleSheet.create({
   },
   errorLine: {
     flexDirection: 'row',
+    alignItems: 'center',
     backgroundColor: colors.red1,
     borderRadius: 6,
     marginHorizontal: 16,
-    paddingHorizontal: 8,
-    paddingVertical: 6,
+    paddingHorizontal: 12,
+    paddingVertical: 10,
     marginBottom: 8,
   },
   reminderLine: {


### PR DESCRIPTION
When you reply to a deleted post, you now get an error that's human-meaningful

![CleanShot 2024-06-10 at 12 35 07@2x](https://github.com/bluesky-social/social-app/assets/1270099/2b5ee06a-68e8-4ab8-bb8e-4e4dd3a2d264)
