### PR TITLE
Visually improve the empty state of feeds

### DIFF
--- a/src/screens/Profile/Sections/Feed.tsx
+++ b/src/screens/Profile/Sections/Feed.tsx
@@ -56,7 +56,7 @@ export const ProfileFeedSection = React.forwardRef<
   }))
 
   const renderPostsEmpty = React.useCallback(() => {
-    return <EmptyState icon="feed" message={_(msg`This feed is empty!`)} />
+    return <EmptyState icon="growth" message={_(msg`No posts yet.`)} />
   }, [_])
 
   React.useEffect(() => {

--- a/src/view/com/util/EmptyState.tsx
+++ b/src/view/com/util/EmptyState.tsx
@@ -5,10 +5,13 @@ import {
   FontAwesomeIcon,
   FontAwesomeIconStyle,
 } from '@fortawesome/react-native-fontawesome'
-import {Text} from './text/Text'
-import {UserGroupIcon} from 'lib/icons'
+
+import {useWebMediaQueries} from '#/lib/hooks/useWebMediaQueries'
 import {usePalette} from 'lib/hooks/usePalette'
+import {UserGroupIcon} from 'lib/icons'
 import {isWeb} from 'platform/detection'
+import {Growth_Stroke2_Corner0_Rounded as Growth} from '#/components/icons/Growth'
+import {Text} from './text/Text'
 
 export function EmptyState({
   testID,
@@ -17,32 +20,41 @@ export function EmptyState({
   style,
 }: {
   testID?: string
-  icon: IconProp | 'user-group'
+  icon: IconProp | 'user-group' | 'growth'
   message: string
   style?: StyleProp<ViewStyle>
 }) {
   const pal = usePalette('default')
+  const {isTabletOrDesktop} = useWebMediaQueries()
+  const iconSize = isTabletOrDesktop ? 80 : 64
   return (
     <View
       testID={testID}
-      style={[styles.container, isWeb && pal.border, style]}>
-      <View style={styles.iconContainer}>
+      style={[
+        styles.container,
+        isWeb && pal.border,
+        isTabletOrDesktop && {paddingRight: 20},
+        style,
+      ]}>
+      <View
+        style={[
+          styles.iconContainer,
+          isTabletOrDesktop && styles.iconContainerBig,
+          pal.viewLight,
+        ]}>
         {icon === 'user-group' ? (
-          <UserGroupIcon size="64" style={styles.icon} />
+          <UserGroupIcon size={iconSize} />
+        ) : icon === 'growth' ? (
+          <Growth width={iconSize} fill={pal.colors.emptyStateIcon} />
         ) : (
           <FontAwesomeIcon
             icon={icon}
-            size={64}
-            style={[
-              styles.icon,
-              {color: pal.colors.emptyStateIcon} as FontAwesomeIconStyle,
-            ]}
+            size={iconSize}
+            style={[{color: pal.colors.emptyStateIcon} as FontAwesomeIconStyle]}
           />
         )}
       </View>
-      <Text
-        type="xl-medium"
-        style={[{color: pal.colors.textVeryLight}, styles.text]}>
+      <Text type="xl" style={[{color: pal.colors.textLight}, styles.text]}>
         {message}
       </Text>
     </View>
@@ -51,16 +63,23 @@ export function EmptyState({
 
 const styles = StyleSheet.create({
   container: {
-    paddingVertical: 24,
-    paddingHorizontal: 36,
     borderTopWidth: isWeb ? 1 : undefined,
   },
   iconContainer: {
     flexDirection: 'row',
-  },
-  icon: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    height: 100,
+    width: 100,
     marginLeft: 'auto',
     marginRight: 'auto',
+    borderRadius: 80,
+    marginTop: 30,
+  },
+  iconContainerBig: {
+    width: 140,
+    height: 140,
+    marginTop: 50,
   },
   text: {
     textAlign: 'center',

--- a/src/view/screens/ProfileFeed.tsx
+++ b/src/view/screens/ProfileFeed.tsx
@@ -468,7 +468,7 @@ const FeedSection = React.forwardRef<SectionRef, FeedSectionProps>(
     }, [onScrollToTop, isScreenFocused])
 
     const renderPostsEmpty = useCallback(() => {
-      return <EmptyState icon="feed" message={_(msg`This feed is empty!`)} />
+      return <EmptyState icon="hashtag" message={_(msg`This feed is empty.`)} />
     }, [_])
 
     return (

--- a/src/view/screens/ProfileList.tsx
+++ b/src/view/screens/ProfileList.tsx
@@ -726,7 +726,7 @@ const FeedSection = React.forwardRef<SectionRef, FeedSectionProps>(
     }, [onScrollToTop, isScreenFocused])
 
     const renderPostsEmpty = useCallback(() => {
-      return <EmptyState icon="feed" message={_(msg`This feed is empty!`)} />
+      return <EmptyState icon="hashtag" message={_(msg`This feed is empty.`)} />
     }, [_])
 
     return (


### PR DESCRIPTION
This isn't a huge improvement but I just can't take the ugliness of the old screen anymore

## Before
|Light|Dark|
|-|-|
|![Simulator Screenshot - iPhone 15 Pro - 2024-06-10 at 13 30 20](https://github.com/bluesky-social/social-app/assets/1270099/f3f2d406-1751-4b3a-b758-92a11eff665f)|![Simulator Screenshot - iPhone 15 Pro - 2024-06-10 at 13 30 27](https://github.com/bluesky-social/social-app/assets/1270099/ea70bece-f398-4fa0-9e86-c36edeb79378)|

## After
|Light|Dark|
|-|-|
|![Simulator Screenshot - iPhone 15 Pro - 2024-06-10 at 13 29 59](https://github.com/bluesky-social/social-app/assets/1270099/8bc0212a-6cbc-4ff3-a0b3-ab04abc912e4)|![Simulator Screenshot - iPhone 15 Pro - 2024-06-10 at 13 29 50](https://github.com/bluesky-social/social-app/assets/1270099/0d7a79bc-dcbb-46a9-9bf2-55f0fe855927)|
