### PR TITLE
stop using `addPushTokenListener`

### DIFF
--- a/patches/expo-notifications+0.28.7.patch
+++ b/patches/expo-notifications+0.28.7.patch
@@ -63,7 +63,7 @@ index f1fed19..80afe9e 100644
 
 +  @Nullable
 +  public String getChannelId() {
-+    return mTitle;
++    return mChannelId;
 +  }
 +
    @Nullable

--- a/src/lib/notifications/notifications.ts
+++ b/src/lib/notifications/notifications.ts
@@ -56,6 +56,10 @@ export function useNotificationsRegistration() {
       return
     }
 
+    // HACK - see https://github.com/bluesky-social/social-app/pull/4467
+    // An apparent regression in expo-notifications causes `addPushTokenListener` to not fire on Android whenever the
+    // token changes by calling `getPushToken()`. This is a workaround to ensure we register the token once it is
+    // generated on Android.
     if (isAndroid) {
       ;(async () => {
         const token = await getPushToken()

--- a/src/lib/notifications/notifications.ts
+++ b/src/lib/notifications/notifications.ts
@@ -76,10 +76,7 @@ export function useNotificationsRegistration() {
     // According to the Expo docs, there is a chance that the token will change while the app is open in some rare
     // cases. This will fire `registerPushToken` whenever that happens.
     const subscription = Notifications.addPushTokenListener(async newToken => {
-      registerPushToken(agent, currentAccount, {
-        data: newToken.data,
-        type: 'android',
-      })
+      registerPushToken(agent, currentAccount, newToken)
     })
 
     return () => {


### PR DESCRIPTION
## Why

The callback in `addPushTokenListener` is not fired once the token changes on Android. This appears to be a possible regression in `expo-notifications` - we are inquiring on that now.

What we know:
- Notifications.getDevicePushTokenAsync() still works on both iOS and Android
- The callback in addPushTokenListener() does get called on iOS
- The callback does not get called on Android

What is unclear:
- If this is actually expected behavior. I do not believe it is because:
  - It certainly worked in the past (this isn't a guarantee that it's expected of course though)
  - It continues to work on iOS
  - The documentation suggests to use this callback for registering your push token.
- What can happen if the listener is not added/it is broken. see https://docs.expo.dev/versions/latest/sdk/notifications/#addpushtokenlistenerlistener re the warning about it possibly changing.

## Test Plan

Merge this in and see if notifications start coming through on some production devices.