### PR TITLE
Add a loading indicator to notifications when loading latest

### DIFF
--- a/src/view/screens/Notifications.tsx
+++ b/src/view/screens/Notifications.tsx
@@ -154,8 +154,8 @@ export function NotificationsScreen({}: Props) {
 
   const renderHeaderSpinner = React.useCallback(() => {
     return (
-      <View style={{width: 20}}>
-        {isLoadingLatest ? <Loader size="sm" /> : <></>}
+      <View style={{width: 30, height: 20, alignItems: 'flex-end'}}>
+        {isLoadingLatest ? <Loader width={20} /> : <></>}
       </View>
     )
   }, [isLoadingLatest])

--- a/src/view/screens/Notifications.tsx
+++ b/src/view/screens/Notifications.tsx
@@ -30,6 +30,7 @@ import {TextLink} from 'view/com/util/Link'
 import {ListMethods} from 'view/com/util/List'
 import {LoadLatestBtn} from 'view/com/util/load-latest/LoadLatestBtn'
 import {CenteredView} from 'view/com/util/Views'
+import {Loader} from '#/components/Loader'
 import {Feed} from '../com/notifications/Feed'
 import {FAB} from '../com/util/fab/FAB'
 import {MainScrollProvider} from '../com/util/MainScrollProvider'
@@ -43,6 +44,7 @@ export function NotificationsScreen({}: Props) {
   const {_} = useLingui()
   const setMinimalShellMode = useSetMinimalShellMode()
   const [isScrolledDown, setIsScrolledDown] = React.useState(false)
+  const [isLoadingLatest, setIsLoadingLatest] = React.useState(false)
   const scrollElRef = React.useRef<ListMethods>(null)
   const {screen} = useAnalytics()
   const pal = usePalette('default')
@@ -68,9 +70,13 @@ export function NotificationsScreen({}: Props) {
       truncateAndInvalidate(queryClient, NOTIFS_RQKEY())
     } else {
       // check with the server
-      unreadApi.checkUnread({invalidate: true})
+      setIsLoadingLatest(true)
+      unreadApi
+        .checkUnread({invalidate: true})
+        .catch(() => undefined)
+        .then(() => setIsLoadingLatest(false))
     }
-  }, [scrollToTop, queryClient, unreadApi, hasNew])
+  }, [scrollToTop, queryClient, unreadApi, hasNew, setIsLoadingLatest])
 
   const onFocusCheckLatest = useNonReactiveCallback(() => {
     // on focus, check for latest, but only invalidate if the user
@@ -139,11 +145,20 @@ export function NotificationsScreen({}: Props) {
             }
             onPress={emitSoftReset}
           />
+          {isLoadingLatest ? <Loader size="md" /> : <></>}
         </View>
       )
     }
     return <></>
-  }, [isDesktop, pal, hasNew])
+  }, [isDesktop, pal, hasNew, isLoadingLatest])
+
+  const renderHeaderSpinner = React.useCallback(() => {
+    return (
+      <View style={{width: 20}}>
+        {isLoadingLatest ? <Loader size="sm" /> : <></>}
+      </View>
+    )
+  }, [isLoadingLatest])
 
   return (
     <CenteredView
@@ -154,6 +169,7 @@ export function NotificationsScreen({}: Props) {
         title={_(msg`Notifications`)}
         canGoBack={false}
         showBorder={true}
+        renderButton={renderHeaderSpinner}
       />
       <MainScrollProvider>
         <Feed


### PR DESCRIPTION
Right now we give no visual indication of when loading latest on notifications due to the "soft reset" or the scroll-to-top button. This PR adds a spinner to the top right.

EDIT: Tested on all platforms via sims.

## Web

https://github.com/bluesky-social/social-app/assets/1270099/3624ae48-e4e7-4d9f-8f93-162a5cd1bb2d

## Mobile

https://github.com/bluesky-social/social-app/assets/1270099/fb428229-93d8-4080-a337-754e76262ec5

