### PR TITLE
Open convo menu when tapping on chat with deleted account

### DIFF
--- a/src/screens/Messages/List/ChatListItem.tsx
+++ b/src/screens/Messages/List/ChatListItem.tsx
@@ -208,7 +208,7 @@ function ChatListItemReady({
           !isDeletedAccount
             ? _(msg`Go to conversation with ${profile.handle}`)
             : _(
-                msg`The recipient of this chat has deleted their account. Press for options.`,
+                msg`This conversation is with a deleted or a deactivated account. Press for options.`,
               )
         }
         accessibilityActions={

--- a/src/screens/Messages/List/ChatListItem.tsx
+++ b/src/screens/Messages/List/ChatListItem.tsx
@@ -215,12 +215,7 @@ function ChatListItemReady({
         }
         onPress={onPress}
         onLongPress={isNative ? onLongPress : undefined}
-        onAccessibilityAction={onLongPress}
-        style={[
-          web({
-            cursor: 'pointer',
-          }),
-        ]}>
+        onAccessibilityAction={onLongPress}>
         {({hovered, pressed, focused}) => (
           <View
             style={[

--- a/src/screens/Messages/List/ChatListItem.tsx
+++ b/src/screens/Messages/List/ChatListItem.tsx
@@ -208,7 +208,7 @@ function ChatListItemReady({
           !isDeletedAccount
             ? _(msg`Go to conversation with ${profile.handle}`)
             : _(
-                msg`The recipient of this chat has deleted their account. Click for options.`,
+                msg`The recipient of this chat has deleted their account. Press for options.`,
               )
         }
         accessibilityActions={

--- a/src/screens/Messages/List/ChatListItem.tsx
+++ b/src/screens/Messages/List/ChatListItem.tsx
@@ -179,12 +179,13 @@ function ChatListItemReady({
     (e: GestureResponderEvent) => {
       if (isDeletedAccount) {
         e.preventDefault()
+        menuControl.open()
         return false
       } else {
         logEvent('chat:open', {logContext: 'ChatsList'})
       }
     },
-    [isDeletedAccount],
+    [isDeletedAccount, menuControl],
   )
 
   const onLongPress = useCallback(() => {
@@ -203,11 +204,7 @@ function ChatListItemReady({
       <Link
         to={`/messages/${convo.id}`}
         label={displayName}
-        accessibilityHint={
-          !isDeletedAccount
-            ? _(msg`Go to conversation with ${profile.handle}`)
-            : undefined
-        }
+        accessibilityHint={_(msg`Go to conversation with ${profile.handle}`)}
         accessibilityActions={
           isNative
             ? [
@@ -221,7 +218,7 @@ function ChatListItemReady({
         onAccessibilityAction={onLongPress}
         style={[
           web({
-            cursor: isDeletedAccount ? 'default' : 'pointer',
+            cursor: 'pointer',
           }),
         ]}>
         {({hovered, pressed, focused}) => (
@@ -233,9 +230,7 @@ function ChatListItemReady({
               a.px_lg,
               a.py_md,
               a.gap_md,
-              (hovered || pressed || focused) &&
-                !isDeletedAccount &&
-                t.atoms.bg_contrast_25,
+              (hovered || pressed || focused) && t.atoms.bg_contrast_25,
               t.atoms.border_contrast_low,
             ]}>
             <UserAvatar

--- a/src/screens/Messages/List/ChatListItem.tsx
+++ b/src/screens/Messages/List/ChatListItem.tsx
@@ -204,7 +204,13 @@ function ChatListItemReady({
       <Link
         to={`/messages/${convo.id}`}
         label={displayName}
-        accessibilityHint={_(msg`Go to conversation with ${profile.handle}`)}
+        accessibilityHint={
+          !isDeletedAccount
+            ? _(msg`Go to conversation with ${profile.handle}`)
+            : _(
+                msg`The recipient of this chat has deleted their account. Click for options.`,
+              )
+        }
         accessibilityActions={
           isNative
             ? [


### PR DESCRIPTION
As a better interim solution, this PR opens the `ConvoMenu` on click/press. 