### PR TITLE
Fix undefined block

### DIFF
--- a/src/components/ProfileHoverCard/index.web.tsx
+++ b/src/components/ProfileHoverCard/index.web.tsx
@@ -370,7 +370,10 @@ function Inner({
     profile: profileShadow,
     logContext: 'ProfileHoverCard',
   })
-  const blockHide = profile.viewer?.blocking || profile.viewer?.blockedBy
+  const isProfileBlocked =
+    profile.viewer?.blocking ||
+    profile.viewer?.blockedBy ||
+    profile.viewer?.blockingByList
   const following = formatCount(profile.followsCount || 0)
   const followers = formatCount(profile.followersCount || 0)
   const pluralizedFollowers = plural(profile.followersCount || 0, {
@@ -401,7 +404,7 @@ function Inner({
           />
         </Link>
 
-        {!isMe && (
+        {!isMe && !isProfileBlocked && (
           <Button
             size="small"
             color={profileShadow.viewer?.following ? 'secondary' : 'primary'}
@@ -439,7 +442,7 @@ function Inner({
         </View>
       </Link>
 
-      {!blockHide && (
+      {!isProfileBlocked && (
         <>
           <View style={[a.flex_row, a.flex_wrap, a.gap_md, a.pt_xs]}>
             <InlineLinkText

--- a/src/view/com/posts/FeedItem.tsx
+++ b/src/view/com/posts/FeedItem.tsx
@@ -196,22 +196,11 @@ let FeedItemInner = ({
     },
   ]
 
-  let blockedParentAuthorState: boolean = false
-  if (parentAuthor) {
-    if (
-      parentAuthor.viewer?.blockedBy == true ||
-      parentAuthor.viewer?.blocking ||
-      parentAuthor.viewer?.blockingByList
-    ) {
-      blockedParentAuthorState = true
-    }
-  }
-
-  let blockedParentAuthor: AppBskyActorDefs.ProfileViewBasic = {
-    did: '',
-    displayName: '[blocked user]',
-    handle: '',
-  }
+  const isParentBlocked = Boolean(
+    parentAuthor?.viewer?.blockedBy ||
+      parentAuthor?.viewer?.blocking ||
+      parentAuthor?.viewer?.blockingByList,
+  )
 
   return (
     <Link
@@ -339,7 +328,12 @@ let FeedItemInner = ({
           {!isThreadChild && showReplyTo && parentAuthor && (
             <ReplyToLabel
               profile={
-                blockedParentAuthorState ? blockedParentAuthor : parentAuthor
+                isParentBlocked
+                  ? {
+                      ...parentAuthor,
+                      displayName: _(msg`a blocked user`),
+                    }
+                  : parentAuthor
               }
             />
           )}

--- a/src/view/com/posts/FeedItem.tsx
+++ b/src/view/com/posts/FeedItem.tsx
@@ -196,6 +196,23 @@ let FeedItemInner = ({
     },
   ]
 
+  let blockedParentAuthorState: boolean = false
+  if (parentAuthor) {
+    if (
+      parentAuthor.viewer?.blockedBy == true ||
+      parentAuthor.viewer?.blocking ||
+      parentAuthor.viewer?.blockingByList
+    ) {
+      blockedParentAuthorState = true
+    }
+  }
+
+  let blockedParentAuthor: AppBskyActorDefs.ProfileViewBasic = {
+    did: '',
+    displayName: '[blocked user]',
+    handle: '',
+  }
+
   return (
     <Link
       testID={`feedItem-by-${post.author.handle}`}
@@ -320,7 +337,11 @@ let FeedItemInner = ({
             onOpenAuthor={onOpenAuthor}
           />
           {!isThreadChild && showReplyTo && parentAuthor && (
-            <ReplyToLabel profile={parentAuthor} />
+            <ReplyToLabel
+              profile={
+                blockedParentAuthorState ? blockedParentAuthor : parentAuthor
+              }
+            />
           )}
           <LabelsOnMyPost post={post} />
           <PostContent


### PR DESCRIPTION
Fixes what was previously showing as `Reply to undefined`. This PR tweaks to continue passing in the did, which enables linking to the profile as well as the hover card.

Also fixed the pesky issue where the hover card showed a follow button for a blocked user.

![CleanShot 2024-06-10 at 20 34 24@2x](https://github.com/bluesky-social/social-app/assets/4732330/104c8d6b-098e-4128-a3e0-393f67572d77)
