### PR TITLE
Request permission to badge the app

### DIFF
--- a/src/lib/notifications/notifications.ts
+++ b/src/lib/notifications/notifications.ts
@@ -120,6 +120,7 @@ export function useRequestNotificationsPermission() {
     const res = await Notifications.requestPermissionsAsync({
       ios: {
         allowBadge: true,
+        allowSound: true,
       },
     })
     logEvent('notifications:request', {

--- a/src/lib/notifications/notifications.ts
+++ b/src/lib/notifications/notifications.ts
@@ -117,7 +117,11 @@ export function useRequestNotificationsPermission() {
       return
     }
 
-    const res = await Notifications.requestPermissionsAsync()
+    const res = await Notifications.requestPermissionsAsync({
+      ios: {
+        allowBadge: true,
+      },
+    })
     logEvent('notifications:request', {
       context: context,
       status: res.status,


### PR DESCRIPTION
## Why

Unclear why this works for me without allowing this permission - maybe there's a system default? - but Expo docs say you need to request permission to badge the app: https://docs.expo.dev/versions/latest/sdk/notifications/#setbadgecountasyncbadgecount-options

## Test Plan

@gaearon sees if he receives iOS badges after this PR.