### PR TITLE
patch `expo-notifications` to clear badge

### DIFF
--- a/patches/expo-notifications+0.28.7.patch
+++ b/patches/expo-notifications+0.28.7.patch
@@ -1,29 +1,54 @@
 diff --git a/node_modules/expo-notifications/android/build.gradle b/node_modules/expo-notifications/android/build.gradle
-index d233e1f..cc2f856 100644
+index b863077..8b5209e 100644
 --- a/node_modules/expo-notifications/android/build.gradle
 +++ b/node_modules/expo-notifications/android/build.gradle
 @@ -32,6 +32,7 @@ dependencies {
    api 'com.google.firebase:firebase-messaging:22.0.0'
-
+ 
    api 'me.leolin:ShortcutBadger:1.1.22@aar'
 +  implementation project(':expo-background-notification-handler')
-
+ 
    if (project.findProject(':expo-modules-test-core')) {
      testImplementation project(':expo-modules-test-core')
+diff --git a/node_modules/expo-notifications/android/src/main/java/expo/modules/notifications/badge/BadgeHelper.kt b/node_modules/expo-notifications/android/src/main/java/expo/modules/notifications/badge/BadgeHelper.kt
+index 63a46c5..f911834 100644
+--- a/node_modules/expo-notifications/android/src/main/java/expo/modules/notifications/badge/BadgeHelper.kt
++++ b/node_modules/expo-notifications/android/src/main/java/expo/modules/notifications/badge/BadgeHelper.kt
+@@ -1,5 +1,6 @@
+ package expo.modules.notifications.badge
+ 
++import android.app.NotificationManager
+ import android.content.Context
+ import android.util.Log
+ import me.leolin.shortcutbadger.ShortcutBadgeException
+@@ -12,7 +13,12 @@ object BadgeHelper {
+ 
+   fun setBadgeCount(context: Context, badgeCount: Int): Boolean {
+     return try {
+-      ShortcutBadger.applyCountOrThrow(context.applicationContext, badgeCount)
++      if (badgeCount == 0) {
++        val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
++        notificationManager.cancelAll()
++      } else {
++        ShortcutBadger.applyCountOrThrow(context.applicationContext, badgeCount)
++      }
+       BadgeHelper.badgeCount = badgeCount
+       true
+     } catch (e: ShortcutBadgeException) {
 diff --git a/node_modules/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/JSONNotificationContentBuilder.java b/node_modules/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/JSONNotificationContentBuilder.java
 index 0af7fe0..8f2c8d8 100644
 --- a/node_modules/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/JSONNotificationContentBuilder.java
 +++ b/node_modules/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/JSONNotificationContentBuilder.java
 @@ -14,6 +14,7 @@ import expo.modules.notifications.notifications.enums.NotificationPriority;
  import expo.modules.notifications.notifications.model.NotificationContent;
-
+ 
  public class JSONNotificationContentBuilder extends NotificationContent.Builder {
 +  private static final String CHANNEL_ID_KEY = "channelId";
    private static final String TITLE_KEY = "title";
    private static final String TEXT_KEY = "message";
    private static final String SUBTITLE_KEY = "subtitle";
 @@ -36,6 +37,7 @@ public class JSONNotificationContentBuilder extends NotificationContent.Builder
-
+ 
    public NotificationContent.Builder setPayload(JSONObject payload) {
      this.setTitle(getTitle(payload))
 +      .setChannelId(getChannelId(payload))
@@ -33,7 +58,7 @@ index 0af7fe0..8f2c8d8 100644
 @@ -60,6 +62,14 @@ public class JSONNotificationContentBuilder extends NotificationContent.Builder
      return this;
    }
-
+ 
 +  protected String getChannelId(JSONObject payload) {
 +    try {
 +      return payload.getString(CHANNEL_ID_KEY);
@@ -46,7 +71,7 @@ index 0af7fe0..8f2c8d8 100644
      try {
        return payload.getString(TITLE_KEY);
 diff --git a/node_modules/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/model/NotificationContent.java b/node_modules/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/model/NotificationContent.java
-index f1fed19..80afe9e 100644
+index f1fed19..012757b 100644
 --- a/node_modules/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/model/NotificationContent.java
 +++ b/node_modules/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/model/NotificationContent.java
 @@ -20,6 +20,7 @@ import expo.modules.notifications.notifications.enums.NotificationPriority;
@@ -60,7 +85,7 @@ index f1fed19..80afe9e 100644
 @@ -50,6 +51,11 @@ public class NotificationContent implements Parcelable, Serializable {
      }
    };
-
+ 
 +  @Nullable
 +  public String getChannelId() {
 +    return mChannelId;
@@ -71,14 +96,14 @@ index f1fed19..80afe9e 100644
      return mTitle;
 @@ -121,6 +127,7 @@ public class NotificationContent implements Parcelable, Serializable {
    }
-
+ 
    protected NotificationContent(Parcel in) {
 +    mChannelId = in.readString();
      mTitle = in.readString();
      mText = in.readString();
      mSubtitle = in.readString();
 @@ -146,6 +153,7 @@ public class NotificationContent implements Parcelable, Serializable {
-
+ 
    @Override
    public void writeToParcel(Parcel dest, int flags) {
 +    dest.writeString(mChannelId);
@@ -87,7 +112,7 @@ index f1fed19..80afe9e 100644
      dest.writeString(mSubtitle);
 @@ -166,6 +174,7 @@ public class NotificationContent implements Parcelable, Serializable {
    private static final long serialVersionUID = 397666843266836802L;
-
+ 
    private void writeObject(java.io.ObjectOutputStream out) throws IOException {
 +    out.writeObject(mChannelId);
      out.writeObject(mTitle);
@@ -95,7 +120,7 @@ index f1fed19..80afe9e 100644
      out.writeObject(mSubtitle);
 @@ -190,6 +199,7 @@ public class NotificationContent implements Parcelable, Serializable {
    }
-
+ 
    private void readObject(java.io.ObjectInputStream in) throws IOException, ClassNotFoundException {
 +    mChannelId = (String) in.readObject();
      mTitle = (String) in.readObject();
@@ -103,7 +128,7 @@ index f1fed19..80afe9e 100644
      mSubtitle = (String) in.readObject();
 @@ -240,6 +250,7 @@ public class NotificationContent implements Parcelable, Serializable {
    }
-
+ 
    public static class Builder {
 +    private String mChannelId;
      private String mTitle;
@@ -112,7 +137,7 @@ index f1fed19..80afe9e 100644
 @@ -260,6 +271,11 @@ public class NotificationContent implements Parcelable, Serializable {
        useDefaultVibrationPattern();
      }
-
+ 
 +    public Builder setChannelId(String channelId) {
 +      mChannelId = channelId;
 +      return this;
@@ -122,7 +147,7 @@ index f1fed19..80afe9e 100644
        mTitle = title;
        return this;
 @@ -336,6 +352,7 @@ public class NotificationContent implements Parcelable, Serializable {
-
+ 
      public NotificationContent build() {
        NotificationContent content = new NotificationContent();
 +      content.mChannelId = mChannelId;
@@ -134,16 +159,16 @@ index 6bd9928..ee93d70 100644
 --- a/node_modules/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/presentation/builders/ExpoNotificationBuilder.java
 +++ b/node_modules/expo-notifications/android/src/main/java/expo/modules/notifications/notifications/presentation/builders/ExpoNotificationBuilder.java
 @@ -48,6 +48,10 @@ public class ExpoNotificationBuilder extends ChannelAwareNotificationBuilder {
-
+ 
      NotificationContent content = getNotificationContent();
-
+ 
 +    if (content.getChannelId() != null) {
 +      builder.setChannelId(content.getChannelId());
 +    }
 +
      builder.setAutoCancel(content.isAutoDismiss());
      builder.setOngoing(content.isSticky());
-
+ 
 diff --git a/node_modules/expo-notifications/android/src/main/java/expo/modules/notifications/service/delegates/FirebaseMessagingDelegate.kt b/node_modules/expo-notifications/android/src/main/java/expo/modules/notifications/service/delegates/FirebaseMessagingDelegate.kt
 index 55b3a8d..1b99d5b 100644
 --- a/node_modules/expo-notifications/android/src/main/java/expo/modules/notifications/service/delegates/FirebaseMessagingDelegate.kt
@@ -158,7 +183,7 @@ index 55b3a8d..1b99d5b 100644
  import org.json.JSONObject
  import java.lang.ref.WeakReference
  import java.util.*
-
+ 
 -open class FirebaseMessagingDelegate(protected val context: Context) : FirebaseMessagingDelegate {
 +open class FirebaseMessagingDelegate(protected val context: Context) : FirebaseMessagingDelegate, BackgroundNotificationHandlerInterface {
    companion object {
@@ -166,7 +191,7 @@ index 55b3a8d..1b99d5b 100644
      // than by static properties. Fortunately, using weak references we can
 @@ -89,12 +92,21 @@ open class FirebaseMessagingDelegate(protected val context: Context) : FirebaseM
    fun getBackgroundTasks() = sBackgroundTaskConsumerReferences.values.mapNotNull { it.get() }
-
+ 
    override fun onMessageReceived(remoteMessage: RemoteMessage) {
 -    NotificationsService.receive(context, createNotification(remoteMessage))
 -    getBackgroundTasks().forEach {
@@ -181,7 +206,7 @@ index 55b3a8d..1b99d5b 100644
 +      }
      }
    }
-
+ 
 +  override fun showMessage(remoteMessage: RemoteMessage) {
 +    NotificationsService.receive(context, createNotification(remoteMessage))
 +  }

--- a/patches/expo-notifications-0.28.7.patch.md
+++ b/patches/expo-notifications-0.28.7.patch.md
@@ -7,3 +7,8 @@ in `onMessageReceived` are sent to the module for handling.
 
 It also allows us to set the Android notification channel ID from the notification `data`, rather
 than the `notification` object in the payload.
+
+### `setBadgeCountAsync` fix on Android
+
+`ShortcutBadger`'s `setCount` doesn't work for clearing the badge on Android for some reason. Instead, let's use the
+Android API for clearing the badge.


### PR DESCRIPTION
## Why

The library that `expo-notifications` is using to clear the badge - `ShortcutBadger` does not clear the badge count correctly for some reason. The documentation says that either `clearCount(context, 0)` or `resetCount(context)` should reset the badge, but it does not - even though the call returns `true`.

Instead, we can use the Android API to clear the badge count.

Solution from https://github.com/flutter/flutter/issues/25030#issuecomment-491232528, albeit in Java

## Test Plan

- Send yourself some notifications
- Verify the badge increments
- Open the app, visit the notifications tab
- Verify the badge has been removed