### PR TITLE
[Session] Logging

### DIFF
--- a/src/state/session/logging.ts
+++ b/src/state/session/logging.ts
@@ -80,7 +80,8 @@ export function addSessionDebugLog(log: Log) {
       return
     }
     const messageIndex = nextMessageIndex++
-    let payload = JSON.stringify(log, replacer)
+    const {type, ...content} = log
+    let payload = JSON.stringify(content, replacer)
 
     let nextSliceIndex = 0
     while (payload.length > 0) {
@@ -90,6 +91,7 @@ export function addSessionDebugLog(log: Log) {
       Statsig.logEvent('session:debug', null, {
         realmId,
         messageIndex: String(messageIndex),
+        messageType: type,
         sliceIndex: String(sliceIndex),
         slice,
       })

--- a/src/state/session/logging.ts
+++ b/src/state/session/logging.ts
@@ -1,0 +1,102 @@
+import {AtpSessionData} from '@atproto/api'
+import {sha256} from 'js-sha256'
+
+import {Schema} from '../persisted'
+import {Action, State} from './reducer'
+import {SessionAccount} from './types'
+
+type Reducer = (state: State, action: Action) => State
+
+type Log =
+  | {
+      type: 'reducer:init'
+      state: State
+    }
+  | {
+      type: 'reducer:call'
+      action: Action
+      prevState: State
+      nextState: State
+    }
+  | {
+      type: 'method:start'
+      method:
+        | 'createAccount'
+        | 'login'
+        | 'logout'
+        | 'resumeSession'
+        | 'removeAccount'
+      account?: SessionAccount
+    }
+  | {
+      type: 'method:end'
+      method:
+        | 'createAccount'
+        | 'login'
+        | 'logout'
+        | 'resumeSession'
+        | 'removeAccount'
+      account?: SessionAccount
+    }
+  | {
+      type: 'persisted:broadcast'
+      data: Schema['session']
+    }
+  | {
+      type: 'persisted:receive'
+      data: Schema['session']
+    }
+  | {
+      type: 'agent:switch'
+      prevAgent: object
+      nextAgent: object
+    }
+  | {
+      type: 'agent:patch'
+      agent: object
+      prevSession: AtpSessionData | undefined
+      nextSession: AtpSessionData
+    }
+
+export function wrapSessionReducerForLogging(reducer: Reducer): Reducer {
+  return function loggingWrapper(prevState: State, action: Action): State {
+    const nextState = reducer(prevState, action)
+    addSessionDebugLog({type: 'reducer:call', prevState, action, nextState})
+    return nextState
+  }
+}
+
+export function addSessionDebugLog(log: Log) {
+  try {
+    const str = JSON.stringify(log, replacer, 2)
+    console.log(str)
+  } catch (e) {
+    console.error(e)
+  }
+}
+
+let agentIds = new WeakMap<object, string>()
+let sessionId = Math.random().toString(36).slice(2)
+let nextAgentId = 1
+
+function getAgentId(agent: object) {
+  let id = agentIds.get(agent)
+  if (id === undefined) {
+    id = sessionId + '::' + nextAgentId++
+    agentIds.set(agent, id)
+  }
+  return id
+}
+
+function replacer(key: string, value: unknown) {
+  if (typeof value === 'object' && value != null && 'api' in value) {
+    return getAgentId(value)
+  }
+  if (
+    typeof value === 'string' &&
+    (key === 'email' || key === 'refreshJwt' || key === 'accessJwt')
+  ) {
+    return sha256(value)
+  }
+  return value
+}

--- a/src/state/session/reducer.ts
+++ b/src/state/session/reducer.ts
@@ -1,6 +1,7 @@
 import {AtpSessionEvent} from '@atproto/api'
 
 import {createPublicAgent} from './agent'
+import {wrapSessionReducerForLogging} from './logging'
 import {SessionAccount} from './types'
 
 // A hack so that the reducer can't read anything from the agent.
@@ -64,7 +65,7 @@ export function getInitialState(persistedAccounts: SessionAccount[]): State {
   }
 }
 
-export function reducer(state: State, action: Action): State {
+let reducer = (state: State, action: Action): State => {
   switch (action.type) {
     case 'received-agent-event': {
       const {agent, accountDid, refreshedAccount, sessionEvent} = action
@@ -166,3 +167,5 @@ export function reducer(state: State, action: Action): State {
     }
   }
 }
+reducer = wrapSessionReducerForLogging(reducer)
+export {reducer}


### PR DESCRIPTION
This adds enough logging to key parts of the session logic that we should be able to figure out what's going on if something goes wrong. Note that agents are numbered (using WeakMap), tokens are sent as hashes (so we can trace what happens to each of them over time).

- [x] Basic implementation
- [x] Add gate (by stable ID)
- [x] Send logs when the gate is on

## Test Plan

Allowlist your stable ID (`Statsig.getStableID()`) for the `debug_session` gate. We'll only enable it for the few users who reported problems. Observe events rolling in. (Don't forget to turn on "Show non-production logs"!)

![Screenshot 2024-06-20 at 05 33 32](https://github.com/bluesky-social/social-app/assets/810438/c30f9cf0-76bd-4ded-a202-19d8d1cbff8a)

![Screenshot 2024-06-20 at 05 33 40](https://github.com/bluesky-social/social-app/assets/810438/e95feaae-7cb8-45c2-a357-7e86ec6f9908)

Note that there's a notion of separate "realms" (`realmId`) which correspond to browser tabs or app instances, a notion of separate "messages" (which are JSON objects describing what happened), and "slices" (which is an artifact of the transport — Statsig forces us to break apart the logs into smaller chunks or it'll refuse to send them). Since this is all for manual debugging, I think that's fine. I might write a script to reconstruct it in a readable form if needed.

Also note that this is done by stable ID so it's able to debug across account switches and logouts.