### PR TITLE
Fix undefined block

### DIFF
--- a/src/state/queries/post-feed.ts
+++ b/src/state/queries/post-feed.ts
@@ -78,6 +78,7 @@ export interface FeedPostSliceItem {
   feedContext: string | undefined
   moderation: ModerationDecision
   parentAuthor?: AppBskyActorDefs.ProfileViewBasic
+  isParentBlocked?: boolean
 }
 
 export interface FeedPostSlice {
@@ -311,6 +312,10 @@ export function usePostFeedQuery(
                           const parentAuthor =
                             item.reply?.parent?.author ??
                             slice.items[i + 1]?.reply?.grandparentAuthor
+                          const replyRef = item.reply
+                          const isParentBlocked = AppBskyFeedDefs.isBlockedPost(
+                            replyRef?.parent,
+                          )
 
                           return {
                             _reactKey: `${slice._reactKey}-${i}-${item.post.uri}`,
@@ -324,6 +329,7 @@ export function usePostFeedQuery(
                             feedContext: item.feedContext || slice.feedContext,
                             moderation: moderations[i],
                             parentAuthor,
+                            isParentBlocked,
                           }
                         }
                         return undefined

--- a/src/view/com/posts/FeedItem.tsx
+++ b/src/view/com/posts/FeedItem.tsx
@@ -204,8 +204,6 @@ let FeedItemInner = ({
     ) ||
     (!parentAuthor?.displayName && !parentAuthor?.handle)
 
-  console.log({isParentBlocked, parentAuthor})
-
   return (
     <Link
       testID={`feedItem-by-${post.author.handle}`}

--- a/src/view/com/posts/FeedItem.tsx
+++ b/src/view/com/posts/FeedItem.tsx
@@ -56,6 +56,7 @@ interface FeedItemProps {
   isThreadParent?: boolean
   feedContext: string | undefined
   hideTopBorder?: boolean
+  isParentBlocked?: boolean
 }
 
 export function FeedItem({
@@ -70,6 +71,7 @@ export function FeedItem({
   isThreadLastChild,
   isThreadParent,
   hideTopBorder,
+  isParentBlocked,
 }: FeedItemProps & {post: AppBskyFeedDefs.PostView}): React.ReactNode {
   const postShadowed = usePostShadow(post)
   const richText = useMemo(
@@ -100,6 +102,7 @@ export function FeedItem({
         isThreadLastChild={isThreadLastChild}
         isThreadParent={isThreadParent}
         hideTopBorder={hideTopBorder}
+        isParentBlocked={isParentBlocked}
       />
     )
   }
@@ -119,6 +122,7 @@ let FeedItemInner = ({
   isThreadLastChild,
   isThreadParent,
   hideTopBorder,
+  isParentBlocked,
 }: FeedItemProps & {
   richText: RichTextAPI
   post: Shadow<AppBskyFeedDefs.PostView>
@@ -195,13 +199,6 @@ let FeedItemInner = ({
       borderTopWidth: hideTopBorder || isThreadChild ? 0 : hairlineWidth,
     },
   ]
-
-  const isParentBlocked = Boolean(
-    parentAuthor &&
-      (parentAuthor.viewer?.blockedBy ||
-        parentAuthor.viewer?.blocking ||
-        parentAuthor.viewer?.blockingByList),
-  )
 
   return (
     <Link

--- a/src/view/com/posts/FeedItem.tsx
+++ b/src/view/com/posts/FeedItem.tsx
@@ -421,8 +421,6 @@ function ReplyToLabel({
   blocked?: boolean
 }) {
   const pal = usePalette('default')
-  const {_} = useLingui()
-
   return (
     <View style={[s.flexRow, s.mb2, s.alignCenter]}>
       <FontAwesomeIcon
@@ -435,11 +433,11 @@ function ReplyToLabel({
         style={[pal.textLight, s.mr2]}
         lineHeight={1.2}
         numberOfLines={1}>
-        <Trans context="description">
-          Reply to{' '}
-          {blocked ? (
-            _(msg`a blocked post`)
-          ) : (
+        {blocked ? (
+          <Trans context="description">Reply to a blocked post</Trans>
+        ) : (
+          <Trans context="description">
+            Reply to{' '}
             <ProfileHoverCard inline did={profile.did}>
               <TextLinkOnWebOnly
                 type="md"
@@ -454,8 +452,8 @@ function ReplyToLabel({
                 }
               />
             </ProfileHoverCard>
-          )}
-        </Trans>
+          </Trans>
+        )}
       </Text>
     </View>
   )

--- a/src/view/com/posts/FeedItem.tsx
+++ b/src/view/com/posts/FeedItem.tsx
@@ -196,11 +196,15 @@ let FeedItemInner = ({
     },
   ]
 
-  const isParentBlocked = Boolean(
-    parentAuthor?.viewer?.blockedBy ||
-      parentAuthor?.viewer?.blocking ||
-      parentAuthor?.viewer?.blockingByList,
-  )
+  const isParentBlocked =
+    Boolean(
+      parentAuthor?.viewer?.blockedBy ||
+        parentAuthor?.viewer?.blocking ||
+        parentAuthor?.viewer?.blockingByList,
+    ) ||
+    (!parentAuthor?.displayName && !parentAuthor?.handle)
+
+  console.log({isParentBlocked, parentAuthor})
 
   return (
     <Link
@@ -326,16 +330,7 @@ let FeedItemInner = ({
             onOpenAuthor={onOpenAuthor}
           />
           {!isThreadChild && showReplyTo && parentAuthor && (
-            <ReplyToLabel
-              profile={
-                isParentBlocked
-                  ? {
-                      ...parentAuthor,
-                      displayName: _(msg`a blocked user`),
-                    }
-                  : parentAuthor
-              }
-            />
+            <ReplyToLabel blocked={isParentBlocked} profile={parentAuthor} />
           )}
           <LabelsOnMyPost post={post} />
           <PostContent
@@ -424,8 +419,15 @@ let PostContent = ({
 }
 PostContent = memo(PostContent)
 
-function ReplyToLabel({profile}: {profile: AppBskyActorDefs.ProfileViewBasic}) {
+function ReplyToLabel({
+  profile,
+  blocked,
+}: {
+  profile: AppBskyActorDefs.ProfileViewBasic
+  blocked?: boolean
+}) {
   const pal = usePalette('default')
+  const {_} = useLingui()
 
   return (
     <View style={[s.flexRow, s.mb2, s.alignCenter]}>
@@ -441,20 +443,24 @@ function ReplyToLabel({profile}: {profile: AppBskyActorDefs.ProfileViewBasic}) {
         numberOfLines={1}>
         <Trans context="description">
           Reply to{' '}
-          <ProfileHoverCard inline did={profile.did}>
-            <TextLinkOnWebOnly
-              type="md"
-              style={pal.textLight}
-              lineHeight={1.2}
-              numberOfLines={1}
-              href={makeProfileLink(profile)}
-              text={
-                profile.displayName
-                  ? sanitizeDisplayName(profile.displayName)
-                  : sanitizeHandle(profile.handle)
-              }
-            />
-          </ProfileHoverCard>
+          {blocked ? (
+            _(msg`a blocked post`)
+          ) : (
+            <ProfileHoverCard inline did={profile.did}>
+              <TextLinkOnWebOnly
+                type="md"
+                style={pal.textLight}
+                lineHeight={1.2}
+                numberOfLines={1}
+                href={makeProfileLink(profile)}
+                text={
+                  profile.displayName
+                    ? sanitizeDisplayName(profile.displayName)
+                    : sanitizeHandle(profile.handle)
+                }
+              />
+            </ProfileHoverCard>
+          )}
         </Trans>
       </Text>
     </View>

--- a/src/view/com/posts/FeedItem.tsx
+++ b/src/view/com/posts/FeedItem.tsx
@@ -196,13 +196,12 @@ let FeedItemInner = ({
     },
   ]
 
-  const isParentBlocked =
-    Boolean(
-      parentAuthor?.viewer?.blockedBy ||
-        parentAuthor?.viewer?.blocking ||
-        parentAuthor?.viewer?.blockingByList,
-    ) ||
-    (!parentAuthor?.displayName && !parentAuthor?.handle)
+  const isParentBlocked = Boolean(
+    parentAuthor &&
+      (parentAuthor.viewer?.blockedBy ||
+        parentAuthor.viewer?.blocking ||
+        parentAuthor.viewer?.blockingByList),
+  )
 
   return (
     <Link

--- a/src/view/com/posts/FeedItem.tsx
+++ b/src/view/com/posts/FeedItem.tsx
@@ -196,22 +196,11 @@ let FeedItemInner = ({
     },
   ]
 
-  let blockedParentAuthorState: boolean = false
-  if (parentAuthor) {
-    if (
-      parentAuthor.viewer?.blockedBy == true ||
-      parentAuthor.viewer?.blocking ||
-      parentAuthor.viewer?.blockingByList
-    ) {
-      blockedParentAuthorState = true
-    }
-  }
-
-  let blockedParentAuthor: AppBskyActorDefs.ProfileViewBasic = {
-    did: '',
-    displayName: '[blocked user]',
-    handle: '',
-  }
+  const isParentBlocked = Boolean(
+    parentAuthor?.viewer?.blockedBy ||
+      parentAuthor?.viewer?.blocking ||
+      parentAuthor?.viewer?.blockingByList,
+  )
 
   return (
     <Link
@@ -339,7 +328,12 @@ let FeedItemInner = ({
           {!isThreadChild && showReplyTo && parentAuthor && (
             <ReplyToLabel
               profile={
-                blockedParentAuthorState ? blockedParentAuthor : parentAuthor
+                isParentBlocked
+                  ? {
+                      ...parentAuthor,
+                      displayName: _(msg`a blocked user`),
+                    }
+                  : parentAuthor
               }
             />
           )}

--- a/src/view/com/posts/FeedItem.tsx
+++ b/src/view/com/posts/FeedItem.tsx
@@ -196,6 +196,23 @@ let FeedItemInner = ({
     },
   ]
 
+  let blockedParentAuthorState: boolean = false
+  if (parentAuthor) {
+    if (
+      parentAuthor.viewer?.blockedBy == true ||
+      parentAuthor.viewer?.blocking ||
+      parentAuthor.viewer?.blockingByList
+    ) {
+      blockedParentAuthorState = true
+    }
+  }
+
+  let blockedParentAuthor: AppBskyActorDefs.ProfileViewBasic = {
+    did: '',
+    displayName: '[blocked user]',
+    handle: '',
+  }
+
   return (
     <Link
       testID={`feedItem-by-${post.author.handle}`}
@@ -320,7 +337,11 @@ let FeedItemInner = ({
             onOpenAuthor={onOpenAuthor}
           />
           {!isThreadChild && showReplyTo && parentAuthor && (
-            <ReplyToLabel profile={parentAuthor} />
+            <ReplyToLabel
+              profile={
+                blockedParentAuthorState ? blockedParentAuthor : parentAuthor
+              }
+            />
           )}
           <LabelsOnMyPost post={post} />
           <PostContent

--- a/src/view/com/posts/FeedSlice.tsx
+++ b/src/view/com/posts/FeedSlice.tsx
@@ -34,6 +34,7 @@ let FeedSlice = ({
           isThreadParent={isThreadParentAt(slice.items, 0)}
           isThreadChild={isThreadChildAt(slice.items, 0)}
           hideTopBorder={hideTopBorder}
+          isParentBlocked={slice.items[0].isParentBlocked}
         />
         <FeedItem
           key={slice.items[1]._reactKey}
@@ -46,6 +47,7 @@ let FeedSlice = ({
           moderation={slice.items[1].moderation}
           isThreadParent={isThreadParentAt(slice.items, 1)}
           isThreadChild={isThreadChildAt(slice.items, 1)}
+          isParentBlocked={slice.items[1].isParentBlocked}
         />
         <ViewFullThread slice={slice} />
         <FeedItem
@@ -59,6 +61,7 @@ let FeedSlice = ({
           moderation={slice.items[last].moderation}
           isThreadParent={isThreadParentAt(slice.items, last)}
           isThreadChild={isThreadChildAt(slice.items, last)}
+          isParentBlocked={slice.items[2].isParentBlocked}
           isThreadLastChild
         />
       </>
@@ -82,6 +85,7 @@ let FeedSlice = ({
           isThreadLastChild={
             isThreadChildAt(slice.items, i) && slice.items.length === i + 1
           }
+          isParentBlocked={slice.items[i].isParentBlocked}
           hideTopBorder={hideTopBorder && i === 0}
         />
       ))}


### PR DESCRIPTION
[Review without whitespace](https://github.com/bluesky-social/social-app/pull/4479/files?diff=split&w=1)

Simplifies this handling a bit after some discussion.

In production right now, blocks between users appear here as `Reply to undefined`, which is broken behavior. In post threads, posts display as `Blocked post` and they are non-interactive. You can't click into this user or otherwise follow the post through the block.

This PR improves upon this by replacing `undefined` with `a blocked post`, to mirror the post thread. It also removes the profile hover on web, and the link around the reply text. This way a user seeing this `Reply to a blocked post` cannot hover or navigate to this user: it's non-interactive. When clicking into the reply, they'll see our existing `Blocked post` handling in the thread view.

![CleanShot 2024-06-11 at 09 51 45@2x](https://github.com/bluesky-social/social-app/assets/4732330/8a6d52cc-dc28-4837-aa75-ec8af0bde31d)
