### PR TITLE
Fix profile hover card blocked state

### DIFF
--- a/src/components/ProfileHoverCard/index.web.tsx
+++ b/src/components/ProfileHoverCard/index.web.tsx
@@ -5,6 +5,7 @@ import {flip, offset, shift, size, useFloating} from '@floating-ui/react-dom'
 import {msg, plural} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
+import {getModerationCauseKey} from '#/lib/moderation'
 import {makeProfileLink} from '#/lib/routes/links'
 import {sanitizeDisplayName} from '#/lib/strings/display-names'
 import {sanitizeHandle} from '#/lib/strings/handles'
@@ -27,6 +28,7 @@ import {Loader} from '#/components/Loader'
 import {Portal} from '#/components/Portal'
 import {RichText} from '#/components/RichText'
 import {Text} from '#/components/Typography'
+import {ProfileLabel} from '../moderation/ProfileHeaderAlerts'
 import {ProfileHoverCardProps} from './types'
 
 const floatingMiddlewares = [
@@ -401,29 +403,41 @@ function Inner({
           />
         </Link>
 
-        {!isMe && (
-          <Button
-            size="small"
-            color={profileShadow.viewer?.following ? 'secondary' : 'primary'}
-            variant="solid"
-            label={
-              profileShadow.viewer?.following
-                ? _(msg`Following`)
-                : _(msg`Follow`)
-            }
-            style={[a.rounded_full]}
-            onPress={profileShadow.viewer?.following ? unfollow : follow}>
-            <ButtonIcon
-              position="left"
-              icon={profileShadow.viewer?.following ? Check : Plus}
-            />
-            <ButtonText>
-              {profileShadow.viewer?.following
-                ? _(msg`Following`)
-                : _(msg`Follow`)}
-            </ButtonText>
-          </Button>
-        )}
+        {!isMe &&
+          (blockHide ? (
+            <Link to={profileURL} label={_(msg`View profile`)} onPress={hide}>
+              <Button
+                size="small"
+                color={'secondary'}
+                variant="solid"
+                label={_(msg`Unblock`)}
+                style={[a.rounded_full]}>
+                <ButtonText>{_(msg`View profile`)}</ButtonText>
+              </Button>
+            </Link>
+          ) : (
+            <Button
+              size="small"
+              color={profileShadow.viewer?.following ? 'secondary' : 'primary'}
+              variant="solid"
+              label={
+                profileShadow.viewer?.following
+                  ? _(msg`Following`)
+                  : _(msg`Follow`)
+              }
+              style={[a.rounded_full]}
+              onPress={profileShadow.viewer?.following ? unfollow : follow}>
+              <ButtonIcon
+                position="left"
+                icon={profileShadow.viewer?.following ? Check : Plus}
+              />
+              <ButtonText>
+                {profileShadow.viewer?.following
+                  ? _(msg`Following`)
+                  : _(msg`Follow`)}
+              </ButtonText>
+            </Button>
+          ))}
       </View>
 
       <Link to={profileURL} label={_(msg`View profile`)} onPress={hide}>
@@ -438,6 +452,18 @@ function Inner({
           <ProfileHeaderHandle profile={profileShadow} />
         </View>
       </Link>
+
+      {blockHide && (
+        <View style={[a.flex_row, a.flex_wrap, a.gap_xs]}>
+          {moderation.ui('profileView').alerts.map(cause => (
+            <ProfileLabel
+              key={getModerationCauseKey(cause)}
+              cause={cause}
+              withModerationDetailsDialog={false}
+            />
+          ))}
+        </View>
+      )}
 
       {!blockHide && (
         <>

--- a/src/components/ProfileHoverCard/index.web.tsx
+++ b/src/components/ProfileHoverCard/index.web.tsx
@@ -372,7 +372,10 @@ function Inner({
     profile: profileShadow,
     logContext: 'ProfileHoverCard',
   })
-  const blockHide = profile.viewer?.blocking || profile.viewer?.blockedBy
+  const isBlockedUser =
+    profile.viewer?.blocking ||
+    profile.viewer?.blockedBy ||
+    profile.viewer?.blockingByList
   const following = formatCount(profile.followsCount || 0)
   const followers = formatCount(profile.followersCount || 0)
   const pluralizedFollowers = plural(profile.followersCount || 0, {
@@ -404,16 +407,16 @@ function Inner({
         </Link>
 
         {!isMe &&
-          (blockHide ? (
-            <Link to={profileURL} label={_(msg`View profile`)} onPress={hide}>
-              <Button
-                size="small"
-                color={'secondary'}
-                variant="solid"
-                label={_(msg`Unblock`)}
-                style={[a.rounded_full]}>
-                <ButtonText>{_(msg`View profile`)}</ButtonText>
-              </Button>
+          (isBlockedUser ? (
+            <Link
+              to={profileURL}
+              label={_(msg`View blocked user's profile`)}
+              onPress={hide}
+              size="small"
+              color="secondary"
+              variant="solid"
+              style={[a.rounded_full]}>
+              <ButtonText>{_(msg`View profile`)}</ButtonText>
             </Link>
           ) : (
             <Button
@@ -453,19 +456,19 @@ function Inner({
         </View>
       </Link>
 
-      {blockHide && (
+      {isBlockedUser && (
         <View style={[a.flex_row, a.flex_wrap, a.gap_xs]}>
           {moderation.ui('profileView').alerts.map(cause => (
             <ProfileLabel
               key={getModerationCauseKey(cause)}
               cause={cause}
-              withModerationDetailsDialog={false}
+              disableDetailsDialog
             />
           ))}
         </View>
       )}
 
-      {!blockHide && (
+      {!isBlockedUser && (
         <>
           <View style={[a.flex_row, a.flex_wrap, a.gap_md, a.pt_xs]}>
             <InlineLinkText

--- a/src/components/moderation/ProfileHeaderAlerts.tsx
+++ b/src/components/moderation/ProfileHeaderAlerts.tsx
@@ -43,7 +43,13 @@ export function ProfileHeaderAlerts({
   )
 }
 
-function ProfileLabel({cause}: {cause: ModerationCause}) {
+export function ProfileLabel({
+  cause,
+  withModerationDetailsDialog = true,
+}: {
+  cause: ModerationCause
+  withModerationDetailsDialog?: boolean
+}) {
   const t = useTheme()
   const control = useModerationDetailsDialogControl()
   const desc = useModerationCauseDescription(cause)
@@ -87,7 +93,9 @@ function ProfileLabel({cause}: {cause: ModerationCause}) {
         )}
       </Button>
 
-      <ModerationDetailsDialog control={control} modcause={cause} />
+      {withModerationDetailsDialog && (
+        <ModerationDetailsDialog control={control} modcause={cause} />
+      )}
     </>
   )
 }

--- a/src/components/moderation/ProfileHeaderAlerts.tsx
+++ b/src/components/moderation/ProfileHeaderAlerts.tsx
@@ -45,10 +45,10 @@ export function ProfileHeaderAlerts({
 
 export function ProfileLabel({
   cause,
-  withModerationDetailsDialog = true,
+  disableDetailsDialog,
 }: {
   cause: ModerationCause
-  withModerationDetailsDialog?: boolean
+  disableDetailsDialog?: boolean
 }) {
   const t = useTheme()
   const control = useModerationDetailsDialogControl()
@@ -57,6 +57,7 @@ export function ProfileLabel({
   return (
     <>
       <Button
+        disabled={disableDetailsDialog}
         label={desc.name}
         onPress={() => {
           control.open()
@@ -93,7 +94,7 @@ export function ProfileLabel({
         )}
       </Button>
 
-      {withModerationDetailsDialog && (
+      {!disableDetailsDialog && (
         <ModerationDetailsDialog control={control} modcause={cause} />
       )}
     </>


### PR DESCRIPTION
Fixes the blocked state of the profile hover cards, fixes #4423

The profile label here is non-interactive, the overlaying multiple modals was causing issues.

![CleanShot 2024-06-11 at 10 08 20@2x](https://github.com/bluesky-social/social-app/assets/4732330/88230668-55d4-4905-b08c-2078b7efa959)
