### PR TITLE
register the push token after request has been approved on android

### DIFF
--- a/modules/expo-background-notification-handler/android/src/main/java/expo/modules/backgroundnotificationhandler/BackgroundNotificationHandler.kt
+++ b/modules/expo-background-notification-handler/android/src/main/java/expo/modules/backgroundnotificationhandler/BackgroundNotificationHandler.kt
@@ -37,6 +37,6 @@ class BackgroundNotificationHandler(
     }
 
     // TODO - Remove this once we have more backend capability
-    remoteMessage.data["badge"] = "0"
+    remoteMessage.data["badge"] = null
   }
 }

--- a/modules/expo-background-notification-handler/android/src/main/java/expo/modules/backgroundnotificationhandler/BackgroundNotificationHandler.kt
+++ b/modules/expo-background-notification-handler/android/src/main/java/expo/modules/backgroundnotificationhandler/BackgroundNotificationHandler.kt
@@ -37,6 +37,6 @@ class BackgroundNotificationHandler(
     }
 
     // TODO - Remove this once we have more backend capability
-    remoteMessage.data["badge"] = null
+    remoteMessage.data["badge"] = "0"
   }
 }

--- a/src/lib/notifications/notifications.ts
+++ b/src/lib/notifications/notifications.ts
@@ -88,6 +88,7 @@ export function useNotificationsRegistration() {
 export function useRequestNotificationsPermission() {
   const gate = useGate()
   const {currentAccount} = useSession()
+  const agent = useAgent()
 
   return async (
     context: 'StartOnboarding' | 'AfterOnboarding' | 'Login' | 'Home',
@@ -125,7 +126,20 @@ export function useRequestNotificationsPermission() {
 
     if (res.granted) {
       // This will fire a pushTokenEvent, which will handle registration of the token
-      getPushToken(true)
+      const token = await getPushToken(true)
+
+      // Same hack as above. We cannot rely on the `addPushTokenListener` to fire on Android due to an Expo bug, so we
+      // will manually register it here. Note that this will occur only:
+      // 1. right after the user signs in, leading to no `currentAccount` account being available - this will be instead
+      // picked up from the useEffect above on `currentAccount` change
+      // 2. right after onboarding. In this case, we _need_ this registration, since `currentAccount` will not change
+      // and we need to ensure the token is registered right after permission is granted. `currentAccount` will already
+      // be available in this case, so the registration will succeed.
+      // We should remove this once expo-notifications (and possibly FCMv1) is fixed and the `addPushTokenListener` is
+      // working again. See https://github.com/expo/expo/issues/28656
+      if (isAndroid && currentAccount && token) {
+        registerPushToken(agent, currentAccount, token)
+      }
     }
   }
 }

--- a/src/screens/Messages/List/ChatListItem.tsx
+++ b/src/screens/Messages/List/ChatListItem.tsx
@@ -20,6 +20,7 @@ import {useProfileShadow} from '#/state/cache/profile-shadow'
 import {useModerationOpts} from '#/state/preferences/moderation-opts'
 import {useSession} from '#/state/session'
 import {useHaptics} from 'lib/haptics'
+import {decrementBadgeCount} from 'lib/notifications/notifications'
 import {logEvent} from 'lib/statsig/statsig'
 import {sanitizeDisplayName} from 'lib/strings/display-names'
 import {TimeElapsed} from '#/view/com/util/TimeElapsed'
@@ -177,6 +178,7 @@ function ChatListItemReady({
 
   const onPress = useCallback(
     (e: GestureResponderEvent) => {
+      decrementBadgeCount(convo.unreadCount)
       if (isDeletedAccount) {
         e.preventDefault()
         menuControl.open()
@@ -185,7 +187,7 @@ function ChatListItemReady({
         logEvent('chat:open', {logContext: 'ChatsList'})
       }
     },
-    [isDeletedAccount, menuControl],
+    [convo.unreadCount, isDeletedAccount, menuControl],
   )
 
   const onLongPress = useCallback(() => {


### PR DESCRIPTION
## Why

Temporary adjustment for now until we can mark messages read on the server and update the count. This will just decrement the badge count by the number of unread messages in the conversation when you open it.

Far from perfect, but given we're going to actually fix this in earnest in the nearish future, let's just make the badge clear for now and avoid digging too deeply at something that could cause more breaks.

I'm also adding one more fallback for push notification registration given the current expo bug. It shouldn't result in two push notification token registrations, but if it does that's fine too. Better to ensure their token registered right after onboarding.

## Test Plan

- Receive DM notification on Android
- Open the conversation
- See the badge has cleared