### PR TITLE
Fix to thread load-more bug

### DIFF
--- a/src/state/queries/post-thread.ts
+++ b/src/state/queries/post-thread.ts
@@ -94,7 +94,6 @@ export function usePostThreadQuery(uri: string | undefined) {
       if (res.success) {
         const thread = responseToThreadNodes(res.data.thread)
         annotateSelfThread(thread)
-        console.log(thread)
         return thread
       }
       return {type: 'unknown', uri: uri!}
@@ -267,7 +266,7 @@ function annotateSelfThread(thread: ThreadNode) {
       // not a self-thread
       return
     }
-    selfThreadNodes.push(parent)
+    selfThreadNodes.unshift(parent)
     parent = parent.parent
   }
 
@@ -287,7 +286,7 @@ function annotateSelfThread(thread: ThreadNode) {
     for (const selfThreadNode of selfThreadNodes) {
       selfThreadNode.ctx.isSelfThread = true
     }
-    const last = selfThreadNodes.at(-1)
+    const last = selfThreadNodes[selfThreadNodes.length - 1]
     if (last && last.post.replyCount && !last.replies?.length) {
       last.ctx.hasMoreSelfThread = true
     }


### PR DESCRIPTION
The logic for identifying the self-thread cutoff (where a "load more" is needed) assumed that the self-thread was being gathered in order. I accidentally appended when I needed to prepend. This fixes it.

|Before|After|
|-|-|
|![CleanShot 2024-06-11 at 14 49 19@2x](https://github.com/bluesky-social/social-app/assets/1270099/4b23bbe1-4f3d-471e-b3d1-43d27e3e84b0)|![CleanShot 2024-06-11 at 14 49 35@2x](https://github.com/bluesky-social/social-app/assets/1270099/aac40e54-8d8d-449b-961e-5b635447595c)|

