### PR TITLE
Fix button hover color

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -225,7 +225,7 @@ export function Button({
         if (!disabled) {
           baseStyles.push(t.atoms.bg)
           hoverStyles.push({
-            backgroundColor: t.palette.contrast_100,
+            backgroundColor: t.palette.contrast_25,
           })
         }
       }

--- a/src/view/com/profile/ProfileMenu.tsx
+++ b/src/view/com/profile/ProfileMenu.tsx
@@ -9,7 +9,6 @@ import {useQueryClient} from '@tanstack/react-query'
 import {logger} from '#/logger'
 import {useAnalytics} from 'lib/analytics/analytics'
 import {HITSLOP_10} from 'lib/constants'
-import {usePalette} from 'lib/hooks/usePalette'
 import {makeProfileLink} from 'lib/routes/links'
 import {shareUrl} from 'lib/sharing'
 import {toShareUrl} from 'lib/strings/url-helpers'
@@ -24,7 +23,7 @@ import {
 import {useSession} from 'state/session'
 import {EventStopper} from 'view/com/util/EventStopper'
 import * as Toast from 'view/com/util/Toast'
-import {useTheme} from '#/alf'
+import {atoms as a, useTheme} from '#/alf'
 import {ArrowOutOfBox_Stroke2_Corner0_Rounded as Share} from '#/components/icons/ArrowOutOfBox'
 import {Flag_Stroke2_Corner0_Rounded as Flag} from '#/components/icons/Flag'
 import {ListSparkle_Stroke2_Corner0_Rounded as List} from '#/components/icons/ListSparkle'
@@ -49,7 +48,7 @@ let ProfileMenu = ({
   const {currentAccount, hasSession} = useSession()
   const t = useTheme()
   // TODO ALF this
-  const pal = usePalette('default')
+  const alf = useTheme()
   const {track} = useAnalytics()
   const {openModal} = useModalControls()
   const reportDialogControl = useReportDialogControl()
@@ -184,21 +183,21 @@ let ProfileMenu = ({
     <EventStopper onKeyDown={false}>
       <Menu.Root>
         <Menu.Trigger label={_(`More options`)}>
-          {({props}) => {
+          {({props, state}) => {
             return (
               <TouchableOpacity
                 {...props}
                 hitSlop={HITSLOP_10}
                 testID="profileHeaderDropdownBtn"
                 style={[
-                  {
-                    flexDirection: 'row',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                    padding: 8,
-                    borderRadius: 50,
-                  },
-                  pal.btn,
+                  a.rounded_full,
+                  a.justify_center,
+                  a.align_center,
+                  {width: 36, height: 36},
+                  alf.atoms.bg_contrast_25,
+                  (state.hovered || state.pressed) && [
+                    alf.atoms.bg_contrast_50,
+                  ],
                 ]}>
                 <FontAwesomeIcon
                   icon="ellipsis"

--- a/src/view/screens/ProfileFeed.tsx
+++ b/src/view/screens/ProfileFeed.tsx
@@ -1,5 +1,6 @@
 import React, {useCallback, useMemo} from 'react'
 import {Pressable, StyleSheet, View} from 'react-native'
+import {FontAwesomeIcon} from '@fortawesome/react-native-fontawesome'
 import {msg, Plural, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 import {useIsFocused, useNavigation} from '@react-navigation/native'
@@ -54,7 +55,6 @@ import {atoms as a, useTheme} from '#/alf'
 import {Button as NewButton, ButtonText} from '#/components/Button'
 import {ArrowOutOfBox_Stroke2_Corner0_Rounded as Share} from '#/components/icons/ArrowOutOfBox'
 import {CircleInfo_Stroke2_Corner0_Rounded as CircleInfo} from '#/components/icons/CircleInfo'
-import {DotGrid_Stroke2_Corner0_Rounded as Ellipsis} from '#/components/icons/DotGrid'
 import {
   Heart2_Filled_Stroke2_Corner0_Rounded as HeartFilled,
   Heart2_Stroke2_Corner0_Rounded as HeartOutline,
@@ -309,9 +309,10 @@ export function ProfileFeedScreenInner({
                         ],
                       ]}
                       testID="headerDropdownBtn">
-                      <Ellipsis
-                        size="lg"
-                        fill={t.atoms.text_contrast_medium.color}
+                      <FontAwesomeIcon
+                        icon="ellipsis"
+                        size={20}
+                        style={t.atoms.text}
                       />
                     </Pressable>
                   )

--- a/src/view/screens/ProfileFeed.tsx
+++ b/src/view/screens/ProfileFeed.tsx
@@ -303,9 +303,9 @@ export function ProfileFeedScreenInner({
                         a.align_center,
                         a.rounded_full,
                         {height: 36, width: 36},
-                        t.atoms.bg_contrast_50,
+                        t.atoms.bg_contrast_25,
                         (state.hovered || state.pressed) && [
-                          t.atoms.bg_contrast_100,
+                          t.atoms.bg_contrast_50,
                         ],
                       ]}
                       testID="headerDropdownBtn">


### PR DESCRIPTION
* Makes the ProfileMenu button in the ProfileHeader change color based on mouse over.
  - Before:
    <video src="https://github.com/bluesky-social/social-app/assets/11014257/991e3a35-88fa-4a3e-a8b0-149c7d2c94b3">
  - After:
    <video src="https://github.com/bluesky-social/social-app/assets/11014257/8a1c916d-e3e0-416d-9658-c5c8747319ca">

* Match the hover color of the other buttons to the other parts. And Match the icon to the ProfileMenu button.
  - Before:
    <video src="https://github.com/bluesky-social/social-app/assets/11014257/f4da6076-11c7-4a8a-8395-3aec62a4146b">
  - After:
    <video src="https://github.com/bluesky-social/social-app/assets/11014257/845f1177-316a-4e9e-9dbb-d3e9a208bdaa">

* Match the hover color of the ghost button accordingly.
  - Before:
    <video src="https://github.com/bluesky-social/social-app/assets/11014257/dc8088f0-bd32-47bb-9320-706c024f80b2">
  - After:
    <video src="https://github.com/bluesky-social/social-app/assets/11014257/00d9e1b7-80b3-41f0-8802-01898ad191c2">

