### PR TITLE
KnownFollowers localization

### DIFF
--- a/src/components/KnownFollowers.tsx
+++ b/src/components/KnownFollowers.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import {View} from 'react-native'
 import {AppBskyActorDefs, moderateProfile, ModerationOpts} from '@atproto/api'
-import {msg, plural, Trans} from '@lingui/macro'
+import {msg, Plural, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
 import {makeProfileLink} from '#/lib/routes/links'
@@ -166,31 +166,34 @@ function KnownFollowersInner({
               },
             ]}
             numberOfLines={2}>
-            <Trans>Followed by</Trans>{' '}
             {count > 2 ? (
-              <>
+              <Trans>
+                Followed by{' '}
                 {slice.slice(0, 2).map(({profile: prof}, i) => (
                   <Text key={prof.did} style={textStyle}>
                     {prof.displayName}
                     {i === 0 && ', '}
                   </Text>
                 ))}
-                {', '}
-                {plural(count - 2, {
-                  one: 'and # other',
-                  other: 'and # others',
-                })}
-              </>
+                , and{' '}
+                <Plural value={count - 2} one="# other" other="# others" />
+              </Trans>
             ) : count === 2 ? (
-              slice.map(({profile: prof}, i) => (
-                <Text key={prof.did} style={textStyle}>
-                  {prof.displayName} {i === 0 ? _(msg`and`) + ' ' : ''}
-                </Text>
-              ))
+              <Trans>
+                Followed by{' '}
+                {slice.map(({profile: prof}, i) => (
+                  <Text key={prof.did} style={textStyle}>
+                    {prof.displayName} {i === 0 ? _(msg`and`) + ' ' : ''}
+                  </Text>
+                ))}
+              </Trans>
             ) : (
-              <Text key={slice[0].profile.did} style={textStyle}>
-                {slice[0].profile.displayName}
-              </Text>
+              <Trans>
+                Followed by{' '}
+                <Text key={slice[0].profile.did} style={textStyle}>
+                  {slice[0].profile.displayName}
+                </Text>
+              </Trans>
             )}
           </Text>
         </>

--- a/src/components/KnownFollowers.tsx
+++ b/src/components/KnownFollowers.tsx
@@ -169,12 +169,13 @@ function KnownFollowersInner({
             {count > 2 ? (
               <Trans>
                 Followed by{' '}
-                {slice.slice(0, 2).map(({profile: prof}, i) => (
-                  <Text key={prof.did} style={textStyle}>
-                    {prof.displayName}
-                    {i === 0 && ', '}
-                  </Text>
-                ))}
+                <Text key={slice[0].profile.did} style={textStyle}>
+                  {slice[0].profile.displayName}
+                </Text>
+                ,{' '}
+                <Text key={slice[1].profile.did} style={textStyle}>
+                  {slice[1].profile.displayName}
+                </Text>
                 , and{' '}
                 <Plural value={count - 2} one="# other" other="# others" />
               </Trans>

--- a/src/components/KnownFollowers.tsx
+++ b/src/components/KnownFollowers.tsx
@@ -182,11 +182,13 @@ function KnownFollowersInner({
             ) : count === 2 ? (
               <Trans>
                 Followed by{' '}
-                {slice.map(({profile: prof}, i) => (
-                  <Text key={prof.did} style={textStyle}>
-                    {prof.displayName} {i === 0 ? _(msg`and`) + ' ' : ''}
-                  </Text>
-                ))}
+                <Text key={slice[0].profile.did} style={textStyle}>
+                  {slice[0].profile.displayName}
+                </Text>{' '}
+                and{' '}
+                <Text key={slice[1].profile.did} style={textStyle}>
+                  {slice[1].profile.displayName}
+                </Text>
               </Trans>
             ) : (
               <Trans>


### PR DESCRIPTION
Provides full context to the KnownFollowers string to allow for easier localization.

```po
#: src/components/KnownFollowers.tsx:169
#~ msgid "Followed by"
#~ msgstr ""

#: src/components/KnownFollowers.tsx:179
#~ msgid "{0, plural, one {and # other} other {and # others}}"
#~ msgstr ""

#: src/components/KnownFollowers.tsx:194
msgid "Followed by <0>{0}</0>"
msgstr ""

#: src/components/KnownFollowers.tsx:183
msgid "Followed by <0>{0}</0> and <1>{1}</1>"
msgstr ""

#: src/components/KnownFollowers.tsx:170
msgid "Followed by <0>{0}</0>, <1>{1}</1>, and {2, plural, one {# other} other {# others}}"
msgstr ""
```