### PR TITLE
Don't show warning when sharing your own post in PWI opt-out mode

### DIFF
--- a/src/view/com/profile/ProfileMenu.tsx
+++ b/src/view/com/profile/ProfileMenu.tsx
@@ -71,8 +71,11 @@ let ProfileMenu = ({
   const loggedOutWarningPromptControl = Prompt.usePromptControl()
 
   const showLoggedOutWarning = React.useMemo(() => {
-    return !!profile.labels?.find(label => label.val === '!no-unauthenticated')
-  }, [profile.labels])
+    return (
+      profile.did !== currentAccount?.did &&
+      !!profile.labels?.find(label => label.val === '!no-unauthenticated')
+    )
+  }, [currentAccount, profile])
 
   const invalidateProfileQuery = React.useCallback(() => {
     queryClient.invalidateQueries({

--- a/src/view/com/util/forms/PostDropdownBtn.tsx
+++ b/src/view/com/util/forms/PostDropdownBtn.tsx
@@ -196,6 +196,9 @@ let PostDropdownBtn = ({
     )
   }, [postAuthor])
 
+  const showLoggedOutWarning =
+    postAuthor.did !== currentAccount?.did && hideInPWI
+
   const onSharePost = React.useCallback(() => {
     const url = toShareUrl(href)
     shareUrl(url)
@@ -296,7 +299,7 @@ let PostDropdownBtn = ({
               testID="postDropdownShareBtn"
               label={isWeb ? _(msg`Copy link to post`) : _(msg`Share`)}
               onPress={() => {
-                if (hideInPWI) {
+                if (showLoggedOutWarning) {
                   loggedOutWarningPromptControl.open()
                 } else {
                   onSharePost()

--- a/src/view/com/util/post-ctrls/PostCtrls.tsx
+++ b/src/view/com/util/post-ctrls/PostCtrls.tsx
@@ -27,7 +27,7 @@ import {
   usePostLikeMutationQueue,
   usePostRepostMutationQueue,
 } from '#/state/queries/post'
-import {useRequireAuth} from '#/state/session'
+import {useRequireAuth, useSession} from '#/state/session'
 import {useComposerControls} from '#/state/shell/composer'
 import {atoms as a, useTheme} from '#/alf'
 import {useDialogControl} from '#/components/Dialog'
@@ -64,6 +64,7 @@ let PostCtrls = ({
   const t = useTheme()
   const {_} = useLingui()
   const {openComposer} = useComposerControls()
+  const {currentAccount} = useSession()
   const [queueLike, queueUnlike] = usePostLikeMutationQueue(post, logContext)
   const [queueRepost, queueUnrepost] = usePostRepostMutationQueue(
     post,
@@ -75,10 +76,11 @@ let PostCtrls = ({
   const playHaptic = useHaptics()
 
   const shouldShowLoggedOutWarning = React.useMemo(() => {
-    return !!post.author.labels?.find(
-      label => label.val === '!no-unauthenticated',
+    return (
+      post.author.did !== currentAccount?.did &&
+      !!post.author.labels?.find(label => label.val === '!no-unauthenticated')
     )
-  }, [post])
+  }, [currentAccount, post])
 
   const defaultCtrlColor = React.useMemo(
     () => ({


### PR DESCRIPTION
## Why

As the title says. Annoying to have to press "Share Anyway" every time you share your own post if you're in PWI opt-out

## Test Plan

- Test sharing on an account that is opted-out
	- Share a post from post controls
	- Share a post from the post dropdown/dialog
	- Share a profile from the profile dropdown
- Test sharing on an account that isn't your own and is opted-out
    - Same as above


https://github.com/bluesky-social/social-app/assets/153161762/70767c42-4e19-4717-a8e2-4596109c50f1


