### PR TITLE
Just use server count

### DIFF
--- a/src/components/KnownFollowers.tsx
+++ b/src/components/KnownFollowers.tsx
@@ -82,7 +82,6 @@ function KnownFollowersInner({
     t.atoms.text_contrast_medium,
   ]
 
-  const count = cachedKnownFollowers.count
   const slice = cachedKnownFollowers.followers.slice(0, 3).map(f => {
     const moderation = moderateProfile(f, moderationOpts)
     return {
@@ -96,6 +95,7 @@ function KnownFollowersInner({
       moderation,
     }
   })
+  const count = cachedKnownFollowers.count - Math.min(slice.length, 2)
 
   return (
     <Link

--- a/src/components/KnownFollowers.tsx
+++ b/src/components/KnownFollowers.tsx
@@ -82,15 +82,7 @@ function KnownFollowersInner({
     t.atoms.text_contrast_medium,
   ]
 
-  // list of users, minus blocks
-  const returnedCount = cachedKnownFollowers.followers.length
-  // db count, includes blocks
-  const fullCount = cachedKnownFollowers.count
-  // knownFollowers can return up to 5 users, but will exclude blocks
-  // therefore, if we have less 5 users, use whichever count is lower
-  const count =
-    returnedCount < 5 ? Math.min(fullCount, returnedCount) : fullCount
-
+  const count = cachedKnownFollowers.count
   const slice = cachedKnownFollowers.followers.slice(0, 3).map(f => {
     const moderation = moderateProfile(f, moderationOpts)
     return {


### PR DESCRIPTION
Was trying to be clever, but this logic was clearly flawed: the server only hydrates 5 profiles, and if any blocks exists, it filters those out. Adjusting the count here on the client isn't possible to do correctly, since there could still be 300 other follows in common that weren't hydrated.

Also, the count wasn't reflecting the few that show up as previews, so `and n others` was always wrong.

So we'll still rarely have the issue where we count 300 known followers, but all 300 are blocked. For this, `KnownFollowers` simply won't be rendered. But if say, 2 are not blocked, you'll get `followed by X, Y, and 298 others`, and when clicking into to view all, you'll see only those 2.