### PR TITLE
Hide bio and social proof for blocked users

### DIFF
--- a/src/screens/Profile/Header/ProfileHeaderStandard.tsx
+++ b/src/screens/Profile/Header/ProfileHeaderStandard.tsx
@@ -75,6 +75,10 @@ let ProfileHeaderStandard = ({
   const [_queueBlock, queueUnblock] = useProfileBlockMutationQueue(profile)
   const unblockPromptControl = Prompt.usePromptControl()
   const requireAuth = useRequireAuth()
+  const isBlockedUser =
+    profile.viewer?.blocking ||
+    profile.viewer?.blockedBy ||
+    profile.viewer?.blockingByList
 
   const onPressEditProfile = React.useCallback(() => {
     track('ProfileHeader:EditProfileButtonClicked')
@@ -257,7 +261,7 @@ let ProfileHeaderStandard = ({
           <ProfileHeaderDisplayName profile={profile} moderation={moderation} />
           <ProfileHeaderHandle profile={profile} />
         </View>
-        {!isPlaceholderProfile && (
+        {!isPlaceholderProfile && !isBlockedUser && (
           <>
             <ProfileHeaderMetrics profile={profile} />
             {descriptionRT && !moderation.ui('profileView').blur ? (
@@ -274,6 +278,7 @@ let ProfileHeaderStandard = ({
             ) : undefined}
 
             {!isMe &&
+              !isBlockedUser &&
               shouldShowKnownFollowers(profile.viewer?.knownFollowers) && (
                 <View style={[a.flex_row, a.align_center, a.gap_sm, a.pt_md]}>
                   <KnownFollowers


### PR DESCRIPTION
Twitter doesn't display them. I'm not sure we should either. Showing social proof definitely feels off on a block. For bio, I could see it either way, but I lean towards not displaying it either if there's a block relationship.

https://github.com/bluesky-social/social-app/assets/810438/c590d632-a6d9-443a-ba31-5aef0a2b4deb

