### PR TITLE
Add `native_pwi_disabled` feature gate experiment

### DIFF
--- a/src/App.native.tsx
+++ b/src/App.native.tsx
@@ -14,7 +14,11 @@ import * as SplashScreen from 'expo-splash-screen'
 import {msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
-import {Provider as StatsigProvider} from '#/lib/statsig/statsig'
+import {
+  initialize,
+  Provider as StatsigProvider,
+  tryFetchGates,
+} from '#/lib/statsig/statsig'
 import {logger} from '#/logger'
 import {MessagesProvider} from '#/state/messages'
 import {init as initPersistedState} from '#/state/persisted'
@@ -69,6 +73,9 @@ function InnerApp() {
       try {
         if (account) {
           await resumeSession(account)
+        } else {
+          await initialize()
+          await tryFetchGates(undefined, 'prefer-fresh-gates')
         }
       } catch (e) {
         logger.error(`session: resume failed`, {message: e})

--- a/src/lib/statsig/gates.ts
+++ b/src/lib/statsig/gates.ts
@@ -1,5 +1,6 @@
 export type Gate =
   // Keep this alphabetic please.
+  | 'native_pwi_disabled'
   | 'request_notifications_permission_after_onboarding_v2'
   | 'show_avi_follow_button'
   | 'show_follow_back_label_v2'

--- a/src/lib/statsig/statsig.tsx
+++ b/src/lib/statsig/statsig.tsx
@@ -305,7 +305,7 @@ export function Provider({children}: {children: React.ReactNode}) {
     <GateCache.Provider value={gateCache}>
       <StatsigProvider
         key={did}
-        sdkKey="client-SXJakO39w9vIhl3D44u8UupyzFl4oZ2qPIkjwcvuPsV"
+        sdkKey={SDK_KEY}
         mountKey={currentStatsigUser.userID}
         user={currentStatsigUser}
         // This isn't really blocking due to short initTimeoutMs above.

--- a/src/lib/statsig/statsig.tsx
+++ b/src/lib/statsig/statsig.tsx
@@ -14,6 +14,8 @@ import {useNonReactiveCallback} from '../hooks/useNonReactiveCallback'
 import {LogEvents} from './events'
 import {Gate} from './gates'
 
+const SDK_KEY = 'client-SXJakO39w9vIhl3D44u8UupyzFl4oZ2qPIkjwcvuPsV'
+
 type StatsigUser = {
   userID: string | undefined
   // TODO: Remove when enough users have custom.platform:
@@ -230,7 +232,7 @@ AppState.addEventListener('change', (state: AppStateStatus) => {
 })
 
 export async function tryFetchGates(
-  did: string,
+  did: string | undefined,
   strategy: 'prefer-low-latency' | 'prefer-fresh-gates',
 ) {
   try {
@@ -252,6 +254,10 @@ export async function tryFetchGates(
     // Don't leak errors to the calling code, this is meant to be always safe.
     console.error(e)
   }
+}
+
+export function initialize() {
+  return Statsig.initialize(SDK_KEY, null, createStatsigOptions([]))
 }
 
 export function Provider({children}: {children: React.ReactNode}) {

--- a/src/view/shell/createNativeStackNavigatorWithAuth.tsx
+++ b/src/view/shell/createNativeStackNavigatorWithAuth.tsx
@@ -29,7 +29,8 @@ import {
   useLoggedOutView,
   useLoggedOutViewControls,
 } from '#/state/shell/logged-out'
-import {isWeb} from 'platform/detection'
+import {useGate} from 'lib/statsig/statsig'
+import {isNative, isWeb} from 'platform/detection'
 import {Deactivated} from '#/screens/Deactivated'
 import {Onboarding} from '#/screens/Onboarding'
 import {SignupQueued} from '#/screens/SignupQueued'
@@ -50,6 +51,7 @@ function NativeStackNavigator({
   screenOptions,
   ...rest
 }: NativeStackNavigatorProps) {
+  const gate = useGate()
   // --- this is copy and pasted from the original native stack navigator ---
   const {state, descriptors, navigation, NavigationContent} =
     useNavigationBuilder<
@@ -100,7 +102,11 @@ function NativeStackNavigator({
   const {showLoggedOut} = useLoggedOutView()
   const {setShowLoggedOut} = useLoggedOutViewControls()
   const {isMobile, isTabletOrMobile} = useWebMediaQueries()
-  if ((!PWI_ENABLED || activeRouteRequiresAuth) && !hasSession) {
+  const isNativePWIDisabled = isNative && gate('native_pwi_disabled')
+  if (
+    (!PWI_ENABLED || isNativePWIDisabled || activeRouteRequiresAuth) &&
+    !hasSession
+  ) {
     return <LoggedOut />
   }
   if (hasSession && currentAccount?.signupQueued) {


### PR DESCRIPTION
This adds an experiment to the logged-out view on native only. To do so, we need to fetch Statsig config immediately. So, if we have no user to resume from, we do a full load of Statsig data to ensure we have accurate config based on the stable device ID.

To do this, I tested calling `initialize` with `prefetchUsers` on the options object, but this failed all three tests I did, in that it didn't load the config in time. So I opted to adjust the API of `tryFetchGates` to allow `undefined` as the DID value, [which will then fall back](https://docs.statsig.com/client/jsClientSDK#statsig-user) to using the stable device ID.

This works in my testing every time:
- delete app to clear storage
- re-run `yarn ios`
- see that the config in Statsig dashboard is correct
  - I've been using 100% on or 100% off
- repeat