### PR TITLE
add `document.referrer` to statsig custom

### DIFF
--- a/src/lib/statsig/statsig.tsx
+++ b/src/lib/statsig/statsig.tsx
@@ -27,6 +27,7 @@ type StatsigUser = {
     refSrc: string
     refUrl: string
     referrer: string
+    referrerHostname: string
     appLanguage: string
     contentLanguages: string[]
   }
@@ -35,6 +36,7 @@ type StatsigUser = {
 let refSrc = ''
 let refUrl = ''
 let referrer = ''
+let referrerHostname = ''
 if (isWeb && typeof window !== 'undefined') {
   const params = new URLSearchParams(window.location.search)
   refSrc = params.get('ref_src') ?? ''
@@ -45,6 +47,7 @@ if (isWeb && document != null) {
   const url = new URL(document.referrer)
   if (url.hostname !== 'bsky.app') {
     referrer = document.referrer
+    referrerHostname = url.hostname
   }
 }
 
@@ -208,6 +211,7 @@ function toStatsigUser(did: string | undefined): StatsigUser {
       refSrc,
       refUrl,
       referrer,
+      referrerHostname,
       platform: Platform.OS as 'ios' | 'android' | 'web',
       bundleIdentifier: BUNDLE_IDENTIFIER,
       bundleDate: BUNDLE_DATE,

--- a/src/lib/statsig/statsig.tsx
+++ b/src/lib/statsig/statsig.tsx
@@ -43,7 +43,7 @@ if (isWeb && typeof window !== 'undefined') {
   refUrl = decodeURIComponent(params.get('ref_url') ?? '')
 }
 
-if (isWeb && document !== 'undefined' && document != null) {
+if (isWeb && typeof document !== 'undefined' && document != null) {
   const url = new URL(document.referrer)
   if (url.hostname !== 'bsky.app') {
     referrer = document.referrer

--- a/src/lib/statsig/statsig.tsx
+++ b/src/lib/statsig/statsig.tsx
@@ -26,6 +26,7 @@ type StatsigUser = {
     bundleDate: number
     refSrc: string
     refUrl: string
+    referrer: string
     appLanguage: string
     contentLanguages: string[]
   }
@@ -33,10 +34,18 @@ type StatsigUser = {
 
 let refSrc = ''
 let refUrl = ''
+let referrer = ''
 if (isWeb && typeof window !== 'undefined') {
   const params = new URLSearchParams(window.location.search)
   refSrc = params.get('ref_src') ?? ''
   refUrl = decodeURIComponent(params.get('ref_url') ?? '')
+}
+
+if (isWeb && document != null) {
+  const url = new URL(document.referrer)
+  if (url.hostname !== 'bsky.app') {
+    referrer = document.referrer
+  }
 }
 
 export type {LogEvents}
@@ -198,6 +207,7 @@ function toStatsigUser(did: string | undefined): StatsigUser {
     custom: {
       refSrc,
       refUrl,
+      referrer,
       platform: Platform.OS as 'ios' | 'android' | 'web',
       bundleIdentifier: BUNDLE_IDENTIFIER,
       bundleDate: BUNDLE_DATE,

--- a/src/lib/statsig/statsig.tsx
+++ b/src/lib/statsig/statsig.tsx
@@ -43,7 +43,7 @@ if (isWeb && typeof window !== 'undefined') {
   refUrl = decodeURIComponent(params.get('ref_url') ?? '')
 }
 
-if (isWeb && document != null) {
+if (isWeb && document !== 'undefined' && document != null) {
   const url = new URL(document.referrer)
   if (url.hostname !== 'bsky.app') {
     referrer = document.referrer


### PR DESCRIPTION
## Why

Want to add referrer to statsig events. We currently have `refUrl`, but that requires a URL parameter that doesn't get set outside of our embeds.

## How

On web, let's add the value of `document.referrer` to the statsig session `custom` object.

## Test Plan

I modified a link on google to direct me to `http://localhost:19006` with a console log inside of `statsig.tsx`.

<img width="875" alt="Screenshot 2024-06-13 at 12 06 38 PM" src="https://github.com/bluesky-social/social-app/assets/153161762/bb499afa-df97-4edf-bfec-bc1523e0417c">
