### PR TITLE
Fix count again

### DIFF
--- a/src/components/KnownFollowers.tsx
+++ b/src/components/KnownFollowers.tsx
@@ -100,7 +100,7 @@ function KnownFollowersInner({
       moderation,
     }
   })
-  const count = cachedKnownFollowers.count - Math.min(slice.length, 2)
+  const count = cachedKnownFollowers.count
 
   return (
     <Link


### PR DESCRIPTION
[Confused myself here](https://github.com/bluesky-social/social-app/pull/4499/files#diff-74e85eaa949c16e6b2da5eb5a60265bfd6ca8c5a2753e1829a8262382bcffa32R98) and was subtracting previewed users twice. This count value should be the server count, and the # of other users is already handled further down in this file.