### PR TITLE
Use URI as key

### DIFF
--- a/src/view/screens/Search/Search.tsx
+++ b/src/view/screens/Search/Search.tsx
@@ -307,7 +307,7 @@ let SearchScreenFeedsResults = ({
               pinOnSave
             />
           )}
-          keyExtractor={item => item.did}
+          keyExtractor={item => item.uri}
           // @ts-ignore web only -prf
           desktopFixedHeight
           contentContainerStyle={{paddingBottom: 100}}


### PR DESCRIPTION
Was getting a duplicate key error — fat-fingered `did` instead of `uri`.