### PR TITLE
Migrate local thread mutes

### DIFF
--- a/src/state/cache/thread-mutes.tsx
+++ b/src/state/cache/thread-mutes.tsx
@@ -17,7 +17,9 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
   const agent = useAgent()
 
   useEffect(() => {
-    migrateThreadMutes(agent)
+    if (agent.hasSession) {
+      migrateThreadMutes(agent)
+    }
   }, [agent])
 
   const setThreadMute = React.useCallback(

--- a/src/state/cache/thread-mutes.tsx
+++ b/src/state/cache/thread-mutes.tsx
@@ -66,14 +66,14 @@ function useMigrateMutes(setThreadMute: SetStateContext) {
 
           if (!root) break
 
+          persisted.write('mutedThreads', threads)
+
           setThreadMute(root, true)
 
           await agent.api.app.bsky.graph
             .muteThread({root})
             // not a big deal if this fails, since the post might have been deleted
             .catch(console.error)
-
-          persisted.write('mutedThreads', threads)
         }
       }
 

--- a/src/state/persisted/schema.ts
+++ b/src/state/persisted/schema.ts
@@ -74,7 +74,6 @@ export const schema = z.object({
       flickr: z.enum(externalEmbedOptions).optional(),
     })
     .optional(),
-  mutedThreads: z.array(z.string()), // should move to server
   invites: z.object({
     copiedInvites: z.array(z.string()),
   }),
@@ -88,6 +87,8 @@ export const schema = z.object({
   disableHaptics: z.boolean().optional(),
   disableAutoplay: z.boolean().optional(),
   kawaii: z.boolean().optional(),
+  // deprecated
+  mutedThreads: z.array(z.string()),
 })
 export type Schema = z.infer<typeof schema>
 

--- a/src/state/persisted/schema.ts
+++ b/src/state/persisted/schema.ts
@@ -87,7 +87,7 @@ export const schema = z.object({
   disableHaptics: z.boolean().optional(),
   disableAutoplay: z.boolean().optional(),
   kawaii: z.boolean().optional(),
-  // deprecated
+  /** @deprecated */
   mutedThreads: z.array(z.string()),
 })
 export type Schema = z.infer<typeof schema>

--- a/src/state/queries/post.ts
+++ b/src/state/queries/post.ts
@@ -304,8 +304,8 @@ export function useThreadMuteMutationQueue(
 
   const queueToggle = useToggleMutationQueue<boolean>({
     initialState: isThreadMuted,
-    runMutation: async (_prev, shouldLike) => {
-      if (shouldLike) {
+    runMutation: async (_prev, shouldMute) => {
+      if (shouldMute) {
         await threadMuteMutation.mutateAsync({
           uri: rootUri,
         })


### PR DESCRIPTION
# Stacked on https://github.com/bluesky-social/social-app/pull/4518

Simple. Uploads existing thread mutes then deletes them.

Does not account for multi-accounts, but I'm not sure if there is a neat solution here without making this far more complex than necessary