### PR TITLE
Fix spacing on native post meta

### DIFF
--- a/src/components/ProfileHoverCard/index.web.tsx
+++ b/src/components/ProfileHoverCard/index.web.tsx
@@ -51,10 +51,23 @@ const floatingMiddlewares = [
 ]
 
 export function ProfileHoverCard(props: ProfileHoverCardProps) {
+  const prefetchProfileQuery = usePrefetchProfileQuery()
+  const prefetchedProfile = React.useRef(false)
+  const onPointerMove = () => {
+    if (!prefetchedProfile.current) {
+      prefetchedProfile.current = true
+      prefetchProfileQuery(props.did)
+    }
+  }
+
   if (props.disable || isTouchDevice) {
     return props.children
   } else {
-    return <ProfileHoverCardInner {...props} />
+    return (
+      <View onPointerMove={onPointerMove}>
+        <ProfileHoverCardInner {...props} />
+      </View>
+    )
   }
 }
 

--- a/src/view/com/util/PostMeta.tsx
+++ b/src/view/com/util/PostMeta.tsx
@@ -3,15 +3,14 @@ import {StyleProp, StyleSheet, TextStyle, View, ViewStyle} from 'react-native'
 import {AppBskyActorDefs, ModerationDecision, ModerationUI} from '@atproto/api'
 import {useQueryClient} from '@tanstack/react-query'
 
-import {precacheProfile, usePrefetchProfileQuery} from '#/state/queries/profile'
+import {precacheProfile} from '#/state/queries/profile'
 import {usePalette} from 'lib/hooks/usePalette'
 import {makeProfileLink} from 'lib/routes/links'
 import {sanitizeDisplayName} from 'lib/strings/display-names'
 import {sanitizeHandle} from 'lib/strings/handles'
 import {niceDate} from 'lib/strings/time'
 import {TypographyVariant} from 'lib/ThemeContext'
-import {isAndroid, isWeb} from 'platform/detection'
-import {atoms as a} from '#/alf'
+import {isAndroid} from 'platform/detection'
 import {ProfileHoverCard} from '#/components/ProfileHoverCard'
 import {TextLinkOnWebOnly} from './Link'
 import {Text} from './text/Text'
@@ -37,17 +36,7 @@ let PostMeta = (opts: PostMetaOpts): React.ReactNode => {
   const pal = usePalette('default')
   const displayName = opts.author.displayName || opts.author.handle
   const handle = opts.author.handle
-  const prefetchProfileQuery = usePrefetchProfileQuery()
-
   const profileLink = makeProfileLink(opts.author)
-  const prefetchedProfile = React.useRef(false)
-  const onPointerMove = React.useCallback(() => {
-    if (!prefetchedProfile.current) {
-      prefetchedProfile.current = true
-      prefetchProfileQuery(opts.author.did)
-    }
-  }, [opts.author.did, prefetchProfileQuery])
-
   const queryClient = useQueryClient()
   const onOpenAuthor = opts.onOpenAuthor
   const onBeforePressAuthor = useCallback(() => {
@@ -71,39 +60,35 @@ let PostMeta = (opts: PostMetaOpts): React.ReactNode => {
         </View>
       )}
       <ProfileHoverCard inline did={opts.author.did}>
-        <View
-          onPointerMove={isWeb ? onPointerMove : undefined}
-          style={[a.flex_1]}>
-          <Text
-            numberOfLines={1}
-            style={[styles.maxWidth, pal.textLight, opts.displayNameStyle]}>
-            <TextLinkOnWebOnly
-              type={opts.displayNameType || 'lg-bold'}
-              style={[pal.text]}
-              lineHeight={1.2}
-              disableMismatchWarning
-              text={
-                <>
-                  {sanitizeDisplayName(
-                    displayName,
-                    opts.moderation?.ui('displayName'),
-                  )}
-                </>
-              }
-              href={profileLink}
-              onBeforePress={onBeforePressAuthor}
-            />
-            <TextLinkOnWebOnly
-              type="md"
-              disableMismatchWarning
-              style={[pal.textLight, {flexShrink: 4}]}
-              text={'\xa0' + sanitizeHandle(handle, '@')}
-              href={profileLink}
-              onBeforePress={onBeforePressAuthor}
-              anchorNoUnderline
-            />
-          </Text>
-        </View>
+        <Text
+          numberOfLines={1}
+          style={[styles.maxWidth, pal.textLight, opts.displayNameStyle]}>
+          <TextLinkOnWebOnly
+            type={opts.displayNameType || 'lg-bold'}
+            style={[pal.text]}
+            lineHeight={1.2}
+            disableMismatchWarning
+            text={
+              <>
+                {sanitizeDisplayName(
+                  displayName,
+                  opts.moderation?.ui('displayName'),
+                )}
+              </>
+            }
+            href={profileLink}
+            onBeforePress={onBeforePressAuthor}
+          />
+          <TextLinkOnWebOnly
+            type="md"
+            disableMismatchWarning
+            style={[pal.textLight, {flexShrink: 4}]}
+            text={'\xa0' + sanitizeHandle(handle, '@')}
+            href={profileLink}
+            onBeforePress={onBeforePressAuthor}
+            anchorNoUnderline
+          />
+        </Text>
       </ProfileHoverCard>
       {!isAndroid && (
         <Text


### PR DESCRIPTION
**[without whitespace](https://github.com/bluesky-social/social-app/pull/4530/files?w=1)**

## Why

Looks like we added a `View` around the text in `PostMeta`. This breaks the layout on iOS, particularly since we added `flex: 1` to the `View`.

Removing that flex though then breaks Android. Since we want to avoid breaking things in any scenario - which is fairly hard to test - let's just move this new wrapper (and all of the prefetch logic) into the web implementation.

## How

Moved the wrapper view into the `ProfileHoverCard` in `index.web.tsx`. On native, it will continue to just return children.

## Test Plan

### iOS

<img width="319" alt="Screenshot 2024-06-16 at 2 14 03 AM" src="https://github.com/bluesky-social/social-app/assets/153161762/7c5816cf-29e5-450f-b38a-e65884d75008">

### Android

<img width="406" alt="Screenshot 2024-06-16 at 2 13 27 AM" src="https://github.com/bluesky-social/social-app/assets/153161762/4376092a-7818-47b9-ba0e-fa94224cf9e6">

### Web


https://github.com/bluesky-social/social-app/assets/153161762/41143e4a-bbb5-4c62-bd5a-c50f6540b078

