### PR TITLE
Make `lint-staged` work in more envs

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-yarn lint-staged
+npx lint-staged


### PR DESCRIPTION
When setting up the environment on a Windows machine with Git Bash, the pre-commit hook errored out:

> /usr/bin/bash: line 1: C:UsersNameFoldersocial-appnode_modules.binlint-staged: command not found

Seemingly, `yarn lint-staged` is not able to correctly resolve the path.

This commit changes the pre-commit hook to use `npx` instead of `yarn`, for 2 reasons:
1. It works on my machine (and is supposedly a more universal solution)
2. It is how it is done in the documentation: https://github.com/lint-staged/lint-staged?tab=readme-ov-file#examples