### PR TITLE
Add patch for `RCTBaseTextInput` fixing `selectTextOnFocus` prop

### DIFF
--- a/patches/react-native+0.74.1.patch
+++ b/patches/react-native+0.74.1.patch
@@ -1,3 +1,29 @@
+diff --git a/node_modules/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.mm b/node_modules/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.mm
+index b0d71dc..9974932 100644
+--- a/node_modules/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.mm
++++ b/node_modules/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.mm
+@@ -377,10 +377,6 @@ - (void)textInputDidBeginEditing
+     self.backedTextInputView.attributedText = [NSAttributedString new];
+   }
+
+-  if (_selectTextOnFocus) {
+-    [self.backedTextInputView selectAll:nil];
+-  }
+-
+   [_eventDispatcher sendTextEventWithType:RCTTextEventTypeFocus
+                                  reactTag:self.reactTag
+                                      text:[self.backedTextInputView.attributedText.string copy]
+@@ -611,6 +607,10 @@ - (UIView *)reactAccessibilityElement
+ - (void)reactFocus
+ {
+   [self.backedTextInputView reactFocus];
++
++  if (_selectTextOnFocus) {
++    [self.backedTextInputView selectAll:nil];
++  }
+ }
+
+ - (void)reactBlur
 diff --git a/node_modules/react-native/React/Views/RefreshControl/RCTRefreshControl.h b/node_modules/react-native/React/Views/RefreshControl/RCTRefreshControl.h
 index e9b330f..1ecdf0a 100644
 --- a/node_modules/react-native/React/Views/RefreshControl/RCTRefreshControl.h
@@ -5,7 +31,7 @@ index e9b330f..1ecdf0a 100644
 @@ -16,4 +16,6 @@
  @property (nonatomic, copy) RCTDirectEventBlock onRefresh;
  @property (nonatomic, weak) UIScrollView *scrollView;
- 
+
 +- (void)forwarderBeginRefreshing;
 +
  @end
@@ -16,7 +42,7 @@ index b09e653..4c32b31 100644
 @@ -198,9 +198,53 @@ - (void)refreshControlValueChanged
    [self setCurrentRefreshingState:super.refreshing];
    _refreshingProgrammatically = NO;
- 
+
 +  if (@available(iOS 17.4, *)) {
 +    if (_currentRefreshingState) {
 +      UIImpactFeedbackGenerator *feedbackGenerator = [[UIImpactFeedbackGenerator alloc] initWithStyle:UIImpactFeedbackStyleLight];
@@ -29,7 +55,7 @@ index b09e653..4c32b31 100644
      _onRefresh(nil);
    }
  }
- 
+
 +/*
 + This method is used by Bluesky's ExpoScrollForwarder. This allows other React Native
 + libraries to perform a refresh of a scrollview and access the refresh control's onRefresh
@@ -38,15 +64,15 @@ index b09e653..4c32b31 100644
 +- (void)forwarderBeginRefreshing
 +{
 +  _refreshingProgrammatically = NO;
-+  
++
 +  [self sizeToFit];
-+  
++
 +  if (!self.scrollView) {
 +    return;
 +  }
-+  
++
 +  UIScrollView *scrollView = (UIScrollView *)self.scrollView;
-+  
++
 +  [UIView animateWithDuration:0.3
 +    delay:0
 +    options:UIViewAnimationOptionBeginFromCurrentState
@@ -58,7 +84,7 @@ index b09e653..4c32b31 100644
 +    completion:^(__unused BOOL finished) {
 +      [super beginRefreshing];
 +      [self setCurrentRefreshingState:super.refreshing];
-+    
++
 +      if (self->_onRefresh) {
 +        self->_onRefresh(nil);
 +      }
@@ -73,7 +99,7 @@ index 5f5e1ab..aac00b6 100644
 +++ b/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/core/JavaTimerManager.java
 @@ -99,8 +99,9 @@ public class JavaTimerManager {
        }
- 
+
        // If the JS thread is busy for multiple frames we cancel any other pending runnable.
 -      if (mCurrentIdleCallbackRunnable != null) {
 -        mCurrentIdleCallbackRunnable.cancel();
@@ -81,5 +107,5 @@ index 5f5e1ab..aac00b6 100644
 +      if (currentRunnable != null) {
 +        currentRunnable.cancel();
        }
- 
+
        mCurrentIdleCallbackRunnable = new IdleCallbackRunnable(frameTimeNanos);

--- a/patches/react-native+0.74.1.patch.md
+++ b/patches/react-native+0.74.1.patch.md
@@ -11,3 +11,10 @@ in the RN repo: https://github.com/facebook/react-native/issues/43388
 Patching `RCTRefreshControl.m` and `RCTRefreshControl.h` to add a new `forwarderBeginRefreshing` method to the class.
 This method is used by `ExpoScrollForwarder` to initiate a refresh of the underlying `UIScrollView` from inside that
 module.
+
+
+## TextInput Patch - `selectTextOnFocus` fix
+
+Patching `RCTBaseTextInputView.m` to fix an issue where `selectTextOnFocus` does not work as expected on iOS 17. This
+patch _only_ fixes the Paper version of `TextInput`. If we migrate to Fabric and the fix has not been made upstream,
+we can apply the same fix. See https://github.com/facebook/react-native/pull/44307.

--- a/src/view/screens/Search/Search.tsx
+++ b/src/view/screens/Search/Search.tsx
@@ -30,7 +30,7 @@ import {makeProfileLink} from '#/lib/routes/links'
 import {NavigationProp} from '#/lib/routes/types'
 import {augmentSearchQuery} from '#/lib/strings/helpers'
 import {logger} from '#/logger'
-import {isIOS, isNative, isWeb} from '#/platform/detection'
+import {isNative, isWeb} from '#/platform/detection'
 import {listenSoftReset} from '#/state/events'
 import {useModerationOpts} from '#/state/preferences/moderation-opts'
 import {useActorAutocompleteQuery} from '#/state/queries/actor-autocomplete'
@@ -802,12 +802,6 @@ let SearchInputBox = ({
             })
           } else {
             setShowAutocomplete(true)
-            if (isIOS) {
-              // We rely on selectTextOnFocus, but it's broken on iOS:
-              // https://github.com/facebook/react-native/issues/41988
-              textInput.current?.setSelection(0, searchText.length)
-              // We still rely on selectTextOnFocus for it to be instant on Android.
-            }
           }
         }}
         onChangeText={onChangeText}


### PR DESCRIPTION
## Why

We added a little JS workaround in https://github.com/bluesky-social/social-app/pull/3746 to fix the `selectTextOnFocus` prop on the search screen. That fix does seem to work well there, though I've now been implementing a few additional `TextInput`s that I also want this prop to work with.

![RocketSim_Recording_iPhone_15_Pro_6 1_2024-06-16_15 55 30](https://github.com/bluesky-social/social-app/assets/153161762/58f4d4e1-6fa5-4d4b-946e-6f96af7fbcdc)

## How

Currently the `selectTextOnFocus` prop does not work as expected on a single line text input. It seems that if the `UITextField` has not yet become the first responder, the text will be briefly selected but then deselected immediately afterward.

Instead, we can move the `selectAll` call to `reactFocus` in `RCTBaseTextInputView`, which gives us the expected result. There's a video of this in the RN tester app in this PR: https://github.com/facebook/react-native/pull/44307

## Test Plan

The best place to look at this in the app right now is on the Search screen.

![RocketSim_Recording_iPhone_15_Pro_6 1_2024-06-16_16 01 34](https://github.com/bluesky-social/social-app/assets/153161762/d7aefbd0-4eaa-4e92-b40a-45825d550613)

It is also working in the `starter-packs` branch

![RocketSim_Recording_iPhone_15_Pro_6 1_2024-06-16_15 56 11](https://github.com/bluesky-social/social-app/assets/153161762/e19aadf7-32cc-4749-a1e6-a067e1ee02f3)
