### PR TITLE
Fix Android startup perf regression

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -32,6 +32,7 @@ module.exports = {
       },
     ],
     'bsky-internal/use-typed-gates': 'error',
+    'bsky-internal/keep-i18n-patch-in-sync': 'error',
     'simple-import-sort/imports': [
       'warn',
       {

--- a/eslint/index.js
+++ b/eslint/index.js
@@ -2,6 +2,7 @@
 
 module.exports = {
   rules: {
+    'keep-i18n-patch-in-sync': require('./keep-i18n-patch-in-sync'),
     'avoid-unwrapped-text': require('./avoid-unwrapped-text'),
     'use-typed-gates': require('./use-typed-gates'),
   },

--- a/eslint/keep-i18n-patch-in-sync.js
+++ b/eslint/keep-i18n-patch-in-sync.js
@@ -1,0 +1,28 @@
+/* eslint-disable bsky-internal/keep-i18n-patch-in-sync */
+const LOCALE_DATA_FOLDER = '@formatjs/intl-pluralrules/locale-data/'
+const GEN_MODULE_PATH =
+  '@formatjs/intl-pluralrules/supported-locales.generated.js'
+
+exports.create = function create(context) {
+  delete require.cache[require.resolve(GEN_MODULE_PATH)]
+  const {supportedLocales} = require(GEN_MODULE_PATH)
+  return {
+    Literal(node) {
+      if (typeof node.value !== 'string') {
+        return
+      }
+      if (!node.value.startsWith(LOCALE_DATA_FOLDER)) {
+        return
+      }
+      const code = node.value.slice(LOCALE_DATA_FOLDER.length)
+      if (!supportedLocales.includes(code)) {
+        context.report({
+          node,
+          message:
+            'Edit .patches/@formatjs+intl-pluralrules+XXX.patch to include ' +
+            code,
+        })
+      }
+    },
+  }
+}

--- a/patches/@formatjs+intl-pluralrules+5.2.10.patch
+++ b/patches/@formatjs+intl-pluralrules+5.2.10.patch
@@ -1,0 +1,29 @@
+diff --git a/node_modules/@formatjs/intl-pluralrules/supported-locales.generated.js b/node_modules/@formatjs/intl-pluralrules/supported-locales.generated.js
+index 5e0692b..d11157a 100644
+--- a/node_modules/@formatjs/intl-pluralrules/supported-locales.generated.js
++++ b/node_modules/@formatjs/intl-pluralrules/supported-locales.generated.js
+@@ -2,3 +2,24 @@
+ Object.defineProperty(exports, "__esModule", { value: true });
+ exports.supportedLocales = void 0;
+ exports.supportedLocales = ["af", "ak", "am", "an", "ar", "ars", "as", "asa", "ast", "az", "bal", "be", "bem", "bez", "bg", "bho", "bm", "bn", "bo", "br", "brx", "bs", "ca", "ce", "ceb", "cgg", "chr", "ckb", "cs", "cy", "da", "de", "doi", "dsb", "dv", "dz", "ee", "el", "en", "eo", "es", "et", "eu", "fa", "ff", "fi", "fil", "fo", "fr", "fur", "fy", "ga", "gd", "gl", "gsw", "gu", "guw", "gv", "ha", "haw", "he", "hi", "hnj", "hr", "hsb", "hu", "hy", "ia", "id", "ig", "ii", "io", "is", "it", "iu", "ja", "jbo", "jgo", "jmc", "jv", "jw", "ka", "kab", "kaj", "kcg", "kde", "kea", "kk", "kkj", "kl", "km", "kn", "ko", "ks", "ksb", "ksh", "ku", "kw", "ky", "lag", "lb", "lg", "lij", "lkt", "ln", "lo", "lt", "lv", "mas", "mg", "mgo", "mk", "ml", "mn", "mo", "mr", "ms", "mt", "my", "nah", "naq", "nb", "nd", "ne", "nl", "nn", "nnh", "no", "nqo", "nr", "nso", "ny", "nyn", "om", "or", "os", "osa", "pa", "pap", "pcm", "pl", "prg", "ps", "pt", "pt-PT", "rm", "ro", "rof", "ru", "rwk", "sah", "saq", "sat", "sc", "scn", "sd", "sdh", "se", "seh", "ses", "sg", "sh", "shi", "si", "sk", "sl", "sma", "smi", "smj", "smn", "sms", "sn", "so", "sq", "sr", "ss", "ssy", "st", "su", "sv", "sw", "syr", "ta", "te", "teo", "th", "ti", "tig", "tk", "tl", "tn", "to", "tpi", "tr", "ts", "tzm", "ug", "uk", "und", "ur", "uz", "ve", "vi", "vo", "vun", "wa", "wae", "wo", "xh", "xog", "yi", "yo", "yue", "zh", "zu"];
++
++// PATCHED FOR ANDROID PERF. KEEP IN SYNC WITH i18n.ts -dan
++exports.supportedLocales = [
++  'ca',
++  'de',
++  'en',
++  'es',
++  'fi',
++  'fr',
++  'ga',
++  'hi',
++  'id',
++  'it',
++  'ja',
++  'ko',
++  'pt',
++  'tr',
++  'uk',
++  'zh'
++];
++


### PR DESCRIPTION
Patch `supportedLocales` from  `@formatjs/intl-pluralrules` to only include the ones we actually use. Since this is easy to mess up, I also added a lint rule that enforces we don't add new locales without also tweaking that patch.

I'm not sure why the `@formatjs/intl-pluralrules` polyfill is so slow but I didn't have time to get into it. I filed https://github.com/formatjs/formatjs/issues/4463.

## Test Plan

Disable the `console`-removing Babel plugin in the Babel config.

Before (5 runs):

```
Time to first paint: 2675 ms
Time to first paint: 2926 ms
Time to first paint: 2762 ms
Time to first paint: 2928 ms
Time to first paint: 2853 ms
```

After (5 runs):

```
Time to first paint: 1905 ms
Time to first paint: 1921 ms
Time to first paint: 1926 ms
Time to first paint: 1929 ms
Time to first paint: 1901 ms
```

I haven't verified what this part of the `Intl` polyfill _actually_ does but it seems safe to assume that it's OK to exclude the locales we don't use. 

Switching languages seems to still work.