### PR TITLE
Make `Post not found` error message more accurate

### DIFF
--- a/src/view/com/post-thread/PostThread.tsx
+++ b/src/view/com/post-thread/PostThread.tsx
@@ -198,7 +198,9 @@ export function PostThread({
     } else if (threadError?.message.startsWith('Post not found')) {
       return {
         title: _(msg`Post not found`),
-        message: _(msg`The post may have been deleted.`),
+        message: _(
+          msg`The post may have been deleted or the account may be deactivated.`,
+        ),
       }
     } else if (isThreadError) {
       return {


### PR DESCRIPTION
If a user visits a link for a post that is from an account that has been deactivated, the error message says `The post may have been deleted.` This is not technically inaccurate but it is misleading, because the post has not been deleted but rather the user has deactivated their account.

This PR amends the error message to say `The post may have been deleted or the account may be deactivated.`