### PR TITLE
Fix: don't interpret blocked replies as truncated self-threads

### DIFF
--- a/src/state/queries/post-thread.ts
+++ b/src/state/queries/post-thread.ts
@@ -31,6 +31,7 @@ import {
   getEmbeddedPost,
 } from './util'
 
+const REPLY_TREE_DEPTH = 10
 const RQKEY_ROOT = 'post-thread'
 export const RQKEY = (uri: string) => [RQKEY_ROOT, uri]
 type ThreadViewNode = AppBskyFeedGetPostThread.OutputSchema['thread']
@@ -90,7 +91,10 @@ export function usePostThreadQuery(uri: string | undefined) {
     gcTime: 0,
     queryKey: RQKEY(uri || ''),
     async queryFn() {
-      const res = await agent.getPostThread({uri: uri!, depth: 10})
+      const res = await agent.getPostThread({
+        uri: uri!,
+        depth: REPLY_TREE_DEPTH,
+      })
       if (res.success) {
         const thread = responseToThreadNodes(res.data.thread)
         annotateSelfThread(thread)
@@ -287,7 +291,12 @@ function annotateSelfThread(thread: ThreadNode) {
       selfThreadNode.ctx.isSelfThread = true
     }
     const last = selfThreadNodes[selfThreadNodes.length - 1]
-    if (last && last.post.replyCount && !last.replies?.length) {
+    if (
+      last &&
+      last.ctx.depth === REPLY_TREE_DEPTH && // at the edge of the tree depth
+      last.post.replyCount && // has replies
+      !last.replies?.length // replies were not hydrated
+    ) {
       last.ctx.hasMoreSelfThread = true
     }
   }


### PR DESCRIPTION
Issue:

[This post demonstrates the issue](https://bsky.app/profile/o.simardcasanova.net/post/3kv4clsfcyk2x)

|Screenshot|Description|
|-|-|
|![CleanShot 2024-06-18 at 10 00 07@2x](https://github.com/bluesky-social/social-app/assets/1270099/0783d648-76a6-4751-8236-e1e2dc74204a)|The "Continue thread..." link is incorrectly showing on post 3 instead of post 10. In this case, there isn't actually a post 10. What did happen is, after 3 posts, another user replied and then was subsequently blocked.|

The reason this is happening is that a blocked reply and a truncation at the limit of the reply tree both look the same: a non-zero `replyCount` and an empty/undefined `replies`.

It turns out the solution to this is pretty straight-forward: only apply the "Continue thread" logic when you're at the known edge of the reply tree. Tested against the buggy thread linked above, and against actual self-threads to ensure that the behavior still works.