### PR TITLE
Better handling of blocks in `KnownFollowers`

### DIFF
--- a/src/components/KnownFollowers.tsx
+++ b/src/components/KnownFollowers.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import {View} from 'react-native'
 import {AppBskyActorDefs, moderateProfile, ModerationOpts} from '@atproto/api'
-import {msg, plural, Trans} from '@lingui/macro'
+import {msg, Plural, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
 import {makeProfileLink} from '#/lib/routes/links'
@@ -166,23 +166,44 @@ function KnownFollowersInner({
             ]}
             numberOfLines={2}>
             {renderableCount >= 2 ? (
+              // 2-n followers, including blocks
+              count > 2 ? (
+                <Trans>
+                  {_(msg`Followed by`)}{' '}
+                  <Text key={slice[0].profile.did} style={textStyle}>
+                    {slice[0].profile.displayName}
+                  </Text>
+                  ,{' '}
+                  <Text key={slice[1].profile.did} style={textStyle}>
+                    {slice[1].profile.displayName}
+                  </Text>
+                  , and{' '}
+                  <Plural value={count - 2} one="# other" other="# others" />
+                </Trans>
+              ) : (
+                // only 2
+                <Trans>
+                  Followed by{' '}
+                  <Text key={slice[0].profile.did} style={textStyle}>
+                    {slice[0].profile.displayName}
+                  </Text>{' '}
+                  and{' '}
+                  <Text key={slice[1].profile.did} style={textStyle}>
+                    {slice[1].profile.displayName}
+                  </Text>
+                </Trans>
+              )
+            ) : count > 1 ? (
+              // 1-n followers, including blocks
               <Trans>
                 {_(msg`Followed by`)}{' '}
                 <Text key={slice[0].profile.did} style={textStyle}>
                   {slice[0].profile.displayName}
-                </Text>
-                {count > 2 ? ', ' : ' ' + _(msg`and`) + ' '}
-                <Text key={slice[1].profile.did} style={textStyle}>
-                  {slice[1].profile.displayName}
-                </Text>
-                {count > 2 ? (
-                  <>
-                    {_(msg`, and`)}{' '}
-                    {plural(count - 2, {one: '# other', other: '# others'})}
-                  </>
-                ) : null}
+                </Text>{' '}
+                and <Plural value={count - 1} one="# other" other="# others" />
               </Trans>
             ) : (
+              // only 1
               <Trans>
                 Followed by{' '}
                 <Text key={slice[0].profile.did} style={textStyle}>

--- a/src/components/KnownFollowers.tsx
+++ b/src/components/KnownFollowers.tsx
@@ -176,7 +176,7 @@ function KnownFollowersInner({
               // 2-n followers, including blocks
               serverCount > 2 ? (
                 <Trans>
-                  {_(msg`Followed by`)}{' '}
+                  Followed by{' '}
                   <Text key={slice[0].profile.did} style={textStyle}>
                     {slice[0].profile.displayName}
                   </Text>
@@ -207,7 +207,7 @@ function KnownFollowersInner({
             ) : serverCount > 1 ? (
               // 1-n followers, including blocks
               <Trans>
-                {_(msg`Followed by`)}{' '}
+                Followed by{' '}
                 <Text key={slice[0].profile.did} style={textStyle}>
                   {slice[0].profile.displayName}
                 </Text>{' '}

--- a/src/components/KnownFollowers.tsx
+++ b/src/components/KnownFollowers.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import {View} from 'react-native'
 import {AppBskyActorDefs, moderateProfile, ModerationOpts} from '@atproto/api'
-import {msg, Plural, Trans} from '@lingui/macro'
+import {msg, plural, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
 import {makeProfileLink} from '#/lib/routes/links'
@@ -101,6 +101,7 @@ function KnownFollowersInner({
     }
   })
   const count = cachedKnownFollowers.count
+  const renderableCount = slice.length
 
   return (
     <Link
@@ -164,29 +165,22 @@ function KnownFollowersInner({
               },
             ]}
             numberOfLines={2}>
-            {count > 2 ? (
+            {renderableCount >= 2 ? (
               <Trans>
                 Followed by{' '}
                 <Text key={slice[0].profile.did} style={textStyle}>
                   {slice[0].profile.displayName}
                 </Text>
-                ,{' '}
+                {count > 2 ? ', ' : ' and '}
                 <Text key={slice[1].profile.did} style={textStyle}>
                   {slice[1].profile.displayName}
                 </Text>
-                , and{' '}
-                <Plural value={count - 2} one="# other" other="# others" />
-              </Trans>
-            ) : count === 2 ? (
-              <Trans>
-                Followed by{' '}
-                <Text key={slice[0].profile.did} style={textStyle}>
-                  {slice[0].profile.displayName}
-                </Text>{' '}
-                and{' '}
-                <Text key={slice[1].profile.did} style={textStyle}>
-                  {slice[1].profile.displayName}
-                </Text>
+                {count > 2 ? (
+                  <>
+                    , and{' '}
+                    {plural(count - 2, {one: '# other', other: '# others'})}
+                  </>
+                ) : null}
               </Trans>
             ) : (
               <Trans>

--- a/src/components/KnownFollowers.tsx
+++ b/src/components/KnownFollowers.tsx
@@ -104,6 +104,12 @@ function KnownFollowersInner({
   // Does not have blocks applied. Always >= slices.length
   const serverCount = cachedKnownFollowers.count
 
+  /*
+   * We check above too, but here for clarity and a reminder to _check for
+   * valid indices_
+   */
+  if (slice.length === 0) return null
+
   return (
     <Link
       label={_(

--- a/src/components/KnownFollowers.tsx
+++ b/src/components/KnownFollowers.tsx
@@ -100,8 +100,9 @@ function KnownFollowersInner({
       moderation,
     }
   })
-  const count = cachedKnownFollowers.count
-  const renderableCount = slice.length
+
+  // Does not have blocks applied. Always >= slices.length
+  const serverCount = cachedKnownFollowers.count
 
   return (
     <Link
@@ -165,9 +166,9 @@ function KnownFollowersInner({
               },
             ]}
             numberOfLines={2}>
-            {renderableCount >= 2 ? (
+            {slice.length >= 2 ? (
               // 2-n followers, including blocks
-              count > 2 ? (
+              serverCount > 2 ? (
                 <Trans>
                   {_(msg`Followed by`)}{' '}
                   <Text key={slice[0].profile.did} style={textStyle}>
@@ -178,7 +179,11 @@ function KnownFollowersInner({
                     {slice[1].profile.displayName}
                   </Text>
                   , and{' '}
-                  <Plural value={count - 2} one="# other" other="# others" />
+                  <Plural
+                    value={serverCount - 2}
+                    one="# other"
+                    other="# others"
+                  />
                 </Trans>
               ) : (
                 // only 2
@@ -193,14 +198,19 @@ function KnownFollowersInner({
                   </Text>
                 </Trans>
               )
-            ) : count > 1 ? (
+            ) : serverCount > 1 ? (
               // 1-n followers, including blocks
               <Trans>
                 {_(msg`Followed by`)}{' '}
                 <Text key={slice[0].profile.did} style={textStyle}>
                   {slice[0].profile.displayName}
                 </Text>{' '}
-                and <Plural value={count - 1} one="# other" other="# others" />
+                and{' '}
+                <Plural
+                  value={serverCount - 1}
+                  one="# other"
+                  other="# others"
+                />
               </Trans>
             ) : (
               // only 1

--- a/src/components/KnownFollowers.tsx
+++ b/src/components/KnownFollowers.tsx
@@ -167,17 +167,17 @@ function KnownFollowersInner({
             numberOfLines={2}>
             {renderableCount >= 2 ? (
               <Trans>
-                Followed by{' '}
+                {_(msg`Followed by`)}{' '}
                 <Text key={slice[0].profile.did} style={textStyle}>
                   {slice[0].profile.displayName}
                 </Text>
-                {count > 2 ? ', ' : ' and '}
+                {count > 2 ? ', ' : ' ' + _(msg`and`) + ' '}
                 <Text key={slice[1].profile.did} style={textStyle}>
                   {slice[1].profile.displayName}
                 </Text>
                 {count > 2 ? (
                   <>
-                    , and{' '}
+                    {_(msg`, and`)}{' '}
                     {plural(count - 2, {one: '# other', other: '# others'})}
                   </>
                 ) : null}


### PR DESCRIPTION
So the issue here is that there are two count values that matter, `length` or `count`:
- `knownFollowers.followers.length`
- `knownFollowers.count`

`followers[]` filters out blocks, and only hydrates 5 profiles server-side, so that array _could_ be `0`, though it's unlikely. If that ever happened, we'd just not render anything at all.

More likely is `followers.length < count` because 1 or more profiles are blocked and filtered out.

So rendering should be driven by `followers.length`, but `and N others` can only be driven by `count` since that can be much higher than the 5 max returned on `followers`.

So the fix here is:
- determine if we have 1, or more than 1 `followers[]` to render
- use the `count` to determine if we need a `, ` or ` and `
- use `count` to determine if we need `and N others`

Here's a test case illustrating that: we have 3 follows in common, but I block one of them. Note only 2 avis (one is blocked), but it still says `and 1 other`. Clicking through will only show 2 profiles.
![CleanShot 2024-06-18 at 15 06 20@2x](https://github.com/bluesky-social/social-app/assets/4732330/fa7b4c47-2687-4bdc-bcd9-5628f1fee417)
