### PR TITLE
Fix double border in PWI

### DIFF
--- a/src/view/com/home/HomeHeaderLayoutMobile.tsx
+++ b/src/view/com/home/HomeHeaderLayoutMobile.tsx
@@ -120,6 +120,7 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
     paddingVertical: 5,
     width: '100%',
+    minHeight: 46,
   },
   title: {
     fontSize: 21,


### PR DESCRIPTION
Header size was being influenced by the presence of the feeds button. This sets a min-height