### PR TITLE
Fix for autofill covering border

### DIFF
--- a/src/components/forms/TextField.tsx
+++ b/src/components/forms/TextField.tsx
@@ -196,6 +196,13 @@ export function createInput(Component: typeof TextInput) {
               textAlignVertical: rest.multiline ? 'top' : undefined,
               minHeight: rest.multiline ? 80 : undefined,
             },
+            // fix for autofill styles covering border
+            web({
+              paddingTop: 12,
+              paddingBottom: 12,
+              marginTop: 2,
+              marginBottom: 2,
+            }),
             android({
               paddingBottom: 16,
             }),


### PR DESCRIPTION
Scoped to web only. Adds 2px of margin to the top and bottom of the text input so that it doesn't cover the border, and reduces padding by that amount

<table>
  <tr>
    <td>Before (ff)</td>
    <td>After (ff)</td>
    <td>Before (chrome)</td>
    <td>After (chrome)</td>
  </tr>
  <tr>
    <td><img width="700" alt="Screenshot 2024-06-19 at 19 20 34" src="https://github.com/bluesky-social/social-app/assets/10959775/2106733f-0975-46f9-9695-333ae6b82760"></td>
    <td><img width="701" alt="Screenshot 2024-06-19 at 19 20 24" src="https://github.com/bluesky-social/social-app/assets/10959775/cf29a42d-5065-41a4-b640-51752c9abf9e"></td>
    <td><img width="695" alt="Screenshot 2024-06-19 at 19 21 50" src="https://github.com/bluesky-social/social-app/assets/10959775/594cba4f-248e-4579-b733-4dcce043b2ae"></td>
    <td><img width="698" alt="Screenshot 2024-06-19 at 19 21 21" src="https://github.com/bluesky-social/social-app/assets/10959775/ff122b14-93fa-46f7-a17d-ff77cc7a5e66"></td>
  </tr>
</table>