### PR TITLE
Allow search params when converting bsky.app urls

### DIFF
--- a/src/lib/strings/url-helpers.ts
+++ b/src/lib/strings/url-helpers.ts
@@ -158,11 +158,18 @@ export function isBskyDownloadUrl(url: string): boolean {
   return url === '/download' || url.startsWith('/download?')
 }
 
-export function convertBskyAppUrlIfNeeded(url: string): string {
+export function convertBskyAppUrlIfNeeded(
+  url: string,
+  includeSearch = false,
+): string {
   if (isBskyAppUrl(url)) {
     try {
       const urlp = new URL(url)
-      return urlp.pathname + urlp.search
+      if (includeSearch) {
+        return urlp.pathname + urlp.search
+      } else {
+        return urlp.pathname
+      }
     } catch (e) {
       console.error('Unexpected error in convertBskyAppUrlIfNeeded()', e)
     }

--- a/src/lib/strings/url-helpers.ts
+++ b/src/lib/strings/url-helpers.ts
@@ -162,7 +162,7 @@ export function convertBskyAppUrlIfNeeded(url: string): string {
   if (isBskyAppUrl(url)) {
     try {
       const urlp = new URL(url)
-      return urlp.pathname
+      return urlp.pathname + urlp.search
     } catch (e) {
       console.error('Unexpected error in convertBskyAppUrlIfNeeded()', e)
     }

--- a/src/view/com/util/Link.tsx
+++ b/src/view/com/util/Link.tsx
@@ -388,7 +388,7 @@ function onPressInner(
   }
 
   if (shouldHandle) {
-    href = convertBskyAppUrlIfNeeded(href)
+    href = convertBskyAppUrlIfNeeded(href, true)
     if (
       newTab ||
       href.startsWith('http') ||


### PR DESCRIPTION
Allows linking to specific searches, i.e. https://bsky.app/profile/jgarplind.bsky.social/post/3kuyshu7heu2a