### PR TITLE
Add a11y context

### DIFF
--- a/src/App.native.tsx
+++ b/src/App.native.tsx
@@ -24,6 +24,7 @@ import {
 import {s} from '#/lib/styles'
 import {ThemeProvider} from '#/lib/ThemeContext'
 import {logger} from '#/logger'
+import {Provider as A11yProvider} from '#/state/a11y'
 import {Provider as MutedThreadsProvider} from '#/state/cache/thread-mutes'
 import {Provider as DialogStateProvider} from '#/state/dialogs'
 import {Provider as InvitesStateProvider} from '#/state/invites'
@@ -152,27 +153,29 @@ function App() {
    * that is set up in the InnerApp component above.
    */
   return (
-    <KeyboardProvider enabled={false} statusBarTranslucent={true}>
-      <SessionProvider>
-        <ShellStateProvider>
-          <PrefsStateProvider>
-            <InvitesStateProvider>
-              <ModalStateProvider>
-                <DialogStateProvider>
-                  <LightboxStateProvider>
-                    <I18nProvider>
-                      <PortalProvider>
-                        <InnerApp />
-                      </PortalProvider>
-                    </I18nProvider>
-                  </LightboxStateProvider>
-                </DialogStateProvider>
-              </ModalStateProvider>
-            </InvitesStateProvider>
-          </PrefsStateProvider>
-        </ShellStateProvider>
-      </SessionProvider>
-    </KeyboardProvider>
+    <A11yProvider>
+      <KeyboardProvider enabled={false} statusBarTranslucent={true}>
+        <SessionProvider>
+          <ShellStateProvider>
+            <PrefsStateProvider>
+              <InvitesStateProvider>
+                <ModalStateProvider>
+                  <DialogStateProvider>
+                    <LightboxStateProvider>
+                      <I18nProvider>
+                        <PortalProvider>
+                          <InnerApp />
+                        </PortalProvider>
+                      </I18nProvider>
+                    </LightboxStateProvider>
+                  </DialogStateProvider>
+                </ModalStateProvider>
+              </InvitesStateProvider>
+            </PrefsStateProvider>
+          </ShellStateProvider>
+        </SessionProvider>
+      </KeyboardProvider>
+    </A11yProvider>
   )
 }
 

--- a/src/App.web.tsx
+++ b/src/App.web.tsx
@@ -13,6 +13,7 @@ import {QueryProvider} from '#/lib/react-query'
 import {Provider as StatsigProvider} from '#/lib/statsig/statsig'
 import {ThemeProvider} from '#/lib/ThemeContext'
 import {logger} from '#/logger'
+import {Provider as A11yProvider} from '#/state/a11y'
 import {Provider as MutedThreadsProvider} from '#/state/cache/thread-mutes'
 import {Provider as DialogStateProvider} from '#/state/dialogs'
 import {Provider as InvitesStateProvider} from '#/state/invites'
@@ -135,25 +136,27 @@ function App() {
    * that is set up in the InnerApp component above.
    */
   return (
-    <SessionProvider>
-      <ShellStateProvider>
-        <PrefsStateProvider>
-          <InvitesStateProvider>
-            <ModalStateProvider>
-              <DialogStateProvider>
-                <LightboxStateProvider>
-                  <I18nProvider>
-                    <PortalProvider>
-                      <InnerApp />
-                    </PortalProvider>
-                  </I18nProvider>
-                </LightboxStateProvider>
-              </DialogStateProvider>
-            </ModalStateProvider>
-          </InvitesStateProvider>
-        </PrefsStateProvider>
-      </ShellStateProvider>
-    </SessionProvider>
+    <A11yProvider>
+      <SessionProvider>
+        <ShellStateProvider>
+          <PrefsStateProvider>
+            <InvitesStateProvider>
+              <ModalStateProvider>
+                <DialogStateProvider>
+                  <LightboxStateProvider>
+                    <I18nProvider>
+                      <PortalProvider>
+                        <InnerApp />
+                      </PortalProvider>
+                    </I18nProvider>
+                  </LightboxStateProvider>
+                </DialogStateProvider>
+              </ModalStateProvider>
+            </InvitesStateProvider>
+          </PrefsStateProvider>
+        </ShellStateProvider>
+      </SessionProvider>
+    </A11yProvider>
   )
 }
 

--- a/src/state/a11y.tsx
+++ b/src/state/a11y.tsx
@@ -1,0 +1,65 @@
+import React from 'react'
+import {AccessibilityInfo} from 'react-native'
+import {isReducedMotion} from 'react-native-reanimated'
+
+import {isWeb} from '#/platform/detection'
+
+const Context = React.createContext({
+  reduceMotionEnabled: false,
+  screenReaderEnabled: false,
+})
+
+export function useA11y() {
+  return React.useContext(Context)
+}
+
+export function Provider({children}: React.PropsWithChildren<{}>) {
+  const [reduceMotionEnabled, setReduceMotionEnabled] = React.useState(
+    isReducedMotion(),
+  )
+  const [screenReaderEnabled, setScreenReaderEnabled] = React.useState(false)
+
+  React.useEffect(() => {
+    const reduceMotionChangedSubscription = AccessibilityInfo.addEventListener(
+      'reduceMotionChanged',
+      enabled => {
+        setReduceMotionEnabled(enabled)
+      },
+    )
+    const screenReaderChangedSubscription = AccessibilityInfo.addEventListener(
+      'screenReaderChanged',
+      enabled => {
+        setScreenReaderEnabled(enabled)
+      },
+    )
+
+    ;(async () => {
+      const [_reduceMotionEnabled, _screenReaderEnabled] = await Promise.all([
+        AccessibilityInfo.isReduceMotionEnabled(),
+        AccessibilityInfo.isScreenReaderEnabled(),
+      ])
+      setReduceMotionEnabled(_reduceMotionEnabled)
+      setScreenReaderEnabled(_screenReaderEnabled)
+    })()
+
+    return () => {
+      reduceMotionChangedSubscription.remove()
+      screenReaderChangedSubscription.remove()
+    }
+  }, [])
+
+  const ctx = React.useMemo(() => {
+    return {
+      reduceMotionEnabled,
+      /**
+       * Always returns true on web. For now, we're using this for mobile a11y,
+       * so we reset to false on web.
+       *
+       * @see https://github.com/necolas/react-native-web/discussions/2072
+       */
+      screenReaderEnabled: isWeb ? false : screenReaderEnabled,
+    }
+  }, [reduceMotionEnabled, screenReaderEnabled])
+
+  return <Context.Provider value={ctx}>{children}</Context.Provider>
+}

--- a/src/state/a11y.tsx
+++ b/src/state/a11y.tsx
@@ -14,7 +14,7 @@ export function useA11y() {
 }
 
 export function Provider({children}: React.PropsWithChildren<{}>) {
-  const [reduceMotionEnabled, setReduceMotionEnabled] = React.useState(
+  const [reduceMotionEnabled, setReduceMotionEnabled] = React.useState(() =>
     isReducedMotion(),
   )
   const [screenReaderEnabled, setScreenReaderEnabled] = React.useState(false)


### PR DESCRIPTION
Adds a couple a11y props to context so that they're available synchronously in the app. Right now we only check for reduced motion, so I've used that same value from Reanimated as the initial value here (that check IS sync, actually).

This also adds screen reader state for use in Starter Packs and eventually other infinite scroll cases.

Note case on web: screen reader always returns `true`. Since we're primarily concerned about mobile for this immediate need, I've opted to override on web to always be `false`. Eventually we may want to fork these props into something like `isScreenReaderEnabledWeb` and handle some cases differently.