### PR TITLE
[For discussion] Wait for AppView after dismissing composer

### DIFF
--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -305,17 +305,6 @@ export const ComposePost = observer(function ComposePost({
           langs: toPostLanguages(langPrefs.postLanguage),
         })
       ).uri
-      try {
-        await whenAppViewReady(agent, postUri, res => {
-          const thread = res.data.thread
-          return AppBskyFeedDefs.isThreadViewPost(thread)
-        })
-      } catch (waitErr: any) {
-        logger.error(waitErr, {
-          message: `Waiting for app view failed`,
-        })
-        // Keep going because the post *was* published.
-      }
     } catch (e: any) {
       logger.error(e, {
         message: `Composer: create post failed`,
@@ -354,17 +343,30 @@ export const ComposePost = observer(function ComposePost({
       })
       if (replyTo && replyTo.uri) track('Post:Reply')
     }
-    if (postUri && !replyTo) {
-      emitPostCreated()
-    }
     setLangPrefs.savePostLanguageToHistory()
-    onPost?.()
     onClose()
     Toast.show(
       replyTo
         ? _(msg`Your reply has been published`)
         : _(msg`Your post has been published`),
     )
+    try {
+      if (postUri) {
+        await whenAppViewReady(agent, postUri, res => {
+          const thread = res.data.thread
+          return AppBskyFeedDefs.isThreadViewPost(thread)
+        })
+      }
+    } catch (waitErr: any) {
+      logger.error(waitErr, {
+        message: `Waiting for app view failed`,
+      })
+    } finally {
+      if (postUri && !replyTo) {
+        emitPostCreated()
+      }
+      onPost?.()
+    }
   }
 
   const canPost = useMemo(


### PR DESCRIPTION
See https://github.com/bluesky-social/social-app/pull/4584#pullrequestreview-2131442460

I'm actually not sure I like it as is. The spinner and a two-step loading sequence is kind of distracting. Maybe we can do something smarter there like an optimistic update? Not sure.