### PR TITLE
Stop feed pagination after we get dupes back

### DIFF
--- a/src/state/queries/feed.ts
+++ b/src/state/queries/feed.ts
@@ -251,11 +251,8 @@ export function useGetPopularFeedsQuery(options?: GetPopularFeedsOptions) {
         return {
           ...data,
           pages: data.pages.map(page => {
-            let __tempHasDuplicatesStopPagination__ = false
-
             const feeds = page.feeds.filter(feed => {
               if (seen.has(feed.uri)) {
-                __tempHasDuplicatesStopPagination__ = true
                 return false
               }
               seen.add(feed.uri)
@@ -275,9 +272,7 @@ export function useGetPopularFeedsQuery(options?: GetPopularFeedsOptions) {
 
             return {
               ...page,
-              cursor: __tempHasDuplicatesStopPagination__
-                ? undefined
-                : page.cursor,
+              cursor: page.cursor,
               feeds,
             }
           }),


### PR DESCRIPTION
Dataplane response is a static list atm, and is returning a few duplicates. Easiest protection is simply to filter those out until backend fix gets in. 