### PR TITLE
Add debug feedContext label

### DIFF
--- a/src/lib/statsig/gates.ts
+++ b/src/lib/statsig/gates.ts
@@ -1,5 +1,6 @@
 export type Gate =
   // Keep this alphabetic please.
+  | 'debug_show_feedcontext'
   | 'native_pwi_disabled'
   | 'request_notifications_permission_after_onboarding_v2'
   | 'show_avi_follow_button'

--- a/src/view/com/util/post-ctrls/PostCtrls.tsx
+++ b/src/view/com/util/post-ctrls/PostCtrls.tsx
@@ -6,6 +6,7 @@ import {
   View,
   type ViewStyle,
 } from 'react-native'
+import * as Clipboard from 'expo-clipboard'
 import {
   AppBskyFeedDefs,
   AppBskyFeedPost,
@@ -19,6 +20,7 @@ import {POST_CTRL_HITSLOP} from '#/lib/constants'
 import {useHaptics} from '#/lib/haptics'
 import {makeProfileLink} from '#/lib/routes/links'
 import {shareUrl} from '#/lib/sharing'
+import {useGate} from '#/lib/statsig/statsig'
 import {toShareUrl} from '#/lib/strings/url-helpers'
 import {s} from '#/lib/styles'
 import {Shadow} from '#/state/cache/types'
@@ -41,6 +43,7 @@ import * as Prompt from '#/components/Prompt'
 import {PostDropdownBtn} from '../forms/PostDropdownBtn'
 import {formatCount} from '../numeric/format'
 import {Text} from '../text/Text'
+import * as Toast from '../Toast'
 import {RepostButton} from './RepostButton'
 
 let PostCtrls = ({
@@ -75,6 +78,7 @@ let PostCtrls = ({
   const loggedOutWarningPromptControl = useDialogControl()
   const {sendInteraction} = useFeedFeedbackContext()
   const playHaptic = useHaptics()
+  const gate = useGate()
 
   const shouldShowLoggedOutWarning = React.useMemo(() => {
     return (
@@ -329,6 +333,31 @@ let PostCtrls = ({
           timestamp={post.indexedAt}
         />
       </View>
+      {gate('debug_show_feedcontext') && feedContext && (
+        <Pressable
+          accessible={false}
+          style={{
+            position: 'absolute',
+            top: 0,
+            bottom: 0,
+            right: 0,
+            display: 'flex',
+            justifyContent: 'center',
+          }}
+          onPress={e => {
+            e.stopPropagation()
+            Clipboard.setStringAsync(feedContext)
+            Toast.show(_(msg`Copied to clipboard`))
+          }}>
+          <Text
+            style={{
+              color: t.palette.contrast_400,
+              fontSize: 7,
+            }}>
+            {feedContext}
+          </Text>
+        </Pressable>
+      )}
     </View>
   )
 }


### PR DESCRIPTION
If you pass the gate (meant only for debugging), this shows a tiny label with `feedContext`. I could make it bigger but I don't want to interfere with the "real" layout or to have it be obscured by anything. It copies to clipboard on tap.

![Screenshot 2024-06-22 at 02 00 19](https://github.com/bluesky-social/social-app/assets/810438/0d48301a-6b9e-4d81-b9ea-382fa3a51799)
