### PR TITLE
[Statsig] Send Discover aggregate interactions

### DIFF
--- a/src/lib/statsig/events.ts
+++ b/src/lib/statsig/events.ts
@@ -73,6 +73,22 @@ export type LogEvents = {
     feedType: string
     reason: 'pull-to-refresh' | 'soft-reset' | 'load-latest'
   }
+  'discover:showMore': {
+    feedContext: string
+  }
+  'discover:showLess': {
+    feedContext: string
+  }
+  'discover:clickthrough:sampled': {
+    count: number
+  }
+  'discover:engaged:sampled': {
+    count: number
+  }
+  'discover:seen:sampled': {
+    count: number
+  }
+
   'composer:gif:open': {}
   'composer:gif:select': {}
 

--- a/src/lib/statsig/statsig.tsx
+++ b/src/lib/statsig/statsig.tsx
@@ -115,6 +115,9 @@ const DOWNSAMPLED_EVENTS: Set<keyof LogEvents> = new Set([
   'home:feedDisplayed:sampled',
   'feed:endReached:sampled',
   'feed:refresh:sampled',
+  'discover:clickthrough:sampled',
+  'discover:engaged:sampled',
+  'discover:seen:sampled',
 ])
 const isDownsampledSession = Math.random() < 0.9 // 90% likely
 


### PR DESCRIPTION
To get more statistical power in experiments, let's reuse the feed feedback system. There's some aggregation, throttling, and sampling to ensure that we don't blow too many event credits.

## Test Plan

Try scrolling, liking, engaging with posts in Discover. Turn off sampling in `statsig.ts`, put `console.log` in `logEvent`, and verify the events coming through.