### PR TITLE
Tweak feed card to prevent spinnerz when pushing to screen

### DIFF
--- a/src/components/FeedCard.tsx
+++ b/src/components/FeedCard.tsx
@@ -295,7 +295,6 @@ export function createProfileFeedHref({
 }: {
   feed: AppBskyFeedDefs.GeneratorView | AppBskyGraphDefs.ListView
 }) {
-  console.log(feed.creator)
   const urip = new AtUri(feed.uri)
   const type = urip.collection === 'app.bsky.feed.generator' ? 'feed' : 'list'
   const handleOrDid = feed.creator.handle || feed.creator.did

--- a/src/components/FeedCard.tsx
+++ b/src/components/FeedCard.tsx
@@ -52,7 +52,9 @@ export function Default(props: Props) {
         <Header>
           <Avatar src={view.avatar} />
           <TitleAndByline title={displayName} creator={view.creator} />
-          <Action uri={view.uri} pin />
+          {type === 'list' && view.purpose !== 'app.bsky.graph.defs#modlist' ? (
+            <Action uri={view.uri} pin />
+          ) : null}
         </Header>
         <Description description={view.description} />
         {type === 'feed' && <Likes count={view.likeCount || 0} />}

--- a/src/components/FeedCard.tsx
+++ b/src/components/FeedCard.tsx
@@ -17,7 +17,7 @@ import {
   useRemoveFeedMutation,
 } from '#/state/queries/preferences'
 import {sanitizeHandle} from 'lib/strings/handles'
-import {precacheFeedFromGeneratorView} from 'state/queries/feed'
+import {precacheFeedFromGeneratorView, precacheList} from 'state/queries/feed'
 import {useSession} from 'state/session'
 import {UserAvatar} from '#/view/com/util/UserAvatar'
 import * as Toast from 'view/com/util/Toast'
@@ -81,6 +81,7 @@ export function Link({
         if (type === 'feed') {
           precacheFeedFromGeneratorView(queryClient, view)
         } else {
+          precacheList(queryClient, view)
         }
       }}>
       {children}

--- a/src/state/queries/feed.ts
+++ b/src/state/queries/feed.ts
@@ -578,7 +578,7 @@ function precacheFeed(queryClient: QueryClient, hydratedFeed: FeedSourceInfo) {
   )
 }
 
-function precacheList(
+export function precacheList(
   queryClient: QueryClient,
   list: AppBskyGraphDefs.ListView,
 ) {

--- a/src/state/queries/feed.ts
+++ b/src/state/queries/feed.ts
@@ -594,6 +594,5 @@ export function precacheFeedFromGeneratorView(
   view: AppBskyFeedDefs.GeneratorView,
 ) {
   const hydratedFeed = hydrateFeedGenerator(view)
-  console.log(hydratedFeed)
   precacheFeed(queryClient, hydratedFeed)
 }

--- a/src/state/queries/feed.ts
+++ b/src/state/queries/feed.ts
@@ -588,3 +588,12 @@ function precacheList(
     list,
   )
 }
+
+export function precacheFeedFromGeneratorView(
+  queryClient: QueryClient,
+  view: AppBskyFeedDefs.GeneratorView,
+) {
+  const hydratedFeed = hydrateFeedGenerator(view)
+  console.log(hydratedFeed)
+  precacheFeed(queryClient, hydratedFeed)
+}

--- a/src/view/com/lists/ProfileLists.tsx
+++ b/src/view/com/lists/ProfileLists.tsx
@@ -3,7 +3,6 @@ import {
   findNodeHandle,
   ListRenderItemInfo,
   StyleProp,
-  StyleSheet,
   View,
   ViewStyle,
 } from 'react-native'
@@ -12,17 +11,17 @@ import {useLingui} from '@lingui/react'
 import {useQueryClient} from '@tanstack/react-query'
 
 import {cleanError} from '#/lib/strings/errors'
-import {useTheme} from '#/lib/ThemeContext'
 import {logger} from '#/logger'
 import {isNative, isWeb} from '#/platform/detection'
 import {RQKEY, useProfileListsQuery} from '#/state/queries/profile-lists'
 import {useAnalytics} from 'lib/analytics/analytics'
 import {FeedLoadingPlaceholder} from '#/view/com/util/LoadingPlaceholder'
 import {EmptyState} from 'view/com/util/EmptyState'
+import {atoms as a, useTheme} from '#/alf'
+import * as FeedCard from '#/components/FeedCard'
 import {ErrorMessage} from '../util/error/ErrorMessage'
 import {List, ListRef} from '../util/List'
 import {LoadMoreRetryBtn} from '../util/LoadMoreRetryBtn'
-import {ListCard} from './ListCard'
 
 const LOADING = {_reactKey: '__loading__'}
 const EMPTY = {_reactKey: '__empty__'}
@@ -48,7 +47,7 @@ export const ProfileLists = React.forwardRef<SectionRef, ProfileListsProps>(
     {did, scrollElRef, headerOffset, enabled, style, testID, setScrollViewTag},
     ref,
   ) {
-    const theme = useTheme()
+    const t = useTheme()
     const {track} = useAnalytics()
     const {_} = useLingui()
     const [isPTRing, setIsPTRing] = React.useState(false)
@@ -166,15 +165,18 @@ export const ProfileLists = React.forwardRef<SectionRef, ProfileListsProps>(
           return <FeedLoadingPlaceholder />
         }
         return (
-          <ListCard
-            list={item}
-            testID={`list-${item.name}`}
-            style={styles.item}
-            noBorder={index === 0 && !isWeb}
-          />
+          <View
+            style={[
+              (index !== 0 || isWeb) && a.border_t,
+              t.atoms.border_contrast_low,
+              a.px_lg,
+              a.py_lg,
+            ]}>
+            <FeedCard.Default type="list" view={item} />
+          </View>
         )
       },
-      [error, refetch, onPressRetryLoadMore, _],
+      [error, refetch, onPressRetryLoadMore, _, t.atoms.border_contrast_low],
     )
 
     React.useEffect(() => {
@@ -198,7 +200,7 @@ export const ProfileLists = React.forwardRef<SectionRef, ProfileListsProps>(
           contentContainerStyle={
             isNative && {paddingBottom: headerOffset + 100}
           }
-          indicatorStyle={theme.colorScheme === 'dark' ? 'white' : 'black'}
+          indicatorStyle={t.name === 'light' ? 'black' : 'white'}
           removeClippedSubviews={true}
           // @ts-ignore our .web version only -prf
           desktopFixedHeight
@@ -208,9 +210,3 @@ export const ProfileLists = React.forwardRef<SectionRef, ProfileListsProps>(
     )
   },
 )
-
-const styles = StyleSheet.create({
-  item: {
-    paddingHorizontal: 18,
-  },
-})

--- a/src/view/screens/Feeds.tsx
+++ b/src/view/screens/Feeds.tsx
@@ -627,7 +627,7 @@ function FollowingFeed() {
             fill={t.palette.white}
           />
         </View>
-        <FeedCard.TitleAndByline title={_(msg`Following`)} />
+        <FeedCard.TitleAndByline title={_(msg`Following`)} type="feed" />
       </FeedCard.Header>
     </View>
   )
@@ -657,7 +657,10 @@ function SavedFeed({
           ]}>
           <FeedCard.Header>
             <FeedCard.Avatar src={feed.avatar} size={28} />
-            <FeedCard.TitleAndByline title={displayName} />
+            <FeedCard.TitleAndByline
+              title={displayName}
+              type={savedFeed.type}
+            />
 
             <ChevronRight size="sm" fill={t.atoms.text_contrast_low.color} />
           </FeedCard.Header>

--- a/src/view/screens/Feeds.tsx
+++ b/src/view/screens/Feeds.tsx
@@ -644,7 +644,7 @@ function SavedFeed({
     savedFeed.type === 'feed' ? savedFeed.view.displayName : savedFeed.view.name
 
   return (
-    <FeedCard.Link testID={`saved-feed-${feed.displayName}`} view={feed}>
+    <FeedCard.Link testID={`saved-feed-${feed.displayName}`} {...savedFeed}>
       {({hovered, pressed}) => (
         <View
           style={[

--- a/src/view/screens/Feeds.tsx
+++ b/src/view/screens/Feeds.tsx
@@ -644,7 +644,7 @@ function SavedFeed({
     savedFeed.type === 'feed' ? savedFeed.view.displayName : savedFeed.view.name
 
   return (
-    <FeedCard.Link testID={`saved-feed-${feed.displayName}`} feed={feed}>
+    <FeedCard.Link testID={`saved-feed-${feed.displayName}`} view={feed}>
       {({hovered, pressed}) => (
         <View
           style={[


### PR DESCRIPTION
## Why

There's some spinner states on feed cards - in prod, not related to the `FeedCard` change necessarily - that we'd like to remove. Easy little win.

We also didn't actually migrate to using the new `FeedCard` in the `ProfileFeedgens` list. I had done this work in the starterpacks branch, so I picked it out of there and made a couple tweaks after the recent `FeedCard` merge into main.

Finally, made a little types tweak inside of `FeedCard` so that `Link` knows whether something is a `ListView` or `GeneratorView`, supporting this new precaching.

## How

We already have a `precacheFeed` function that takes in `FeedSourceInfo` from inside one of our query functions. However, we also want to make it possible to run this with a `GeneratorView`.

Following a similar pattern that we use for posts and profiles, we're adding a `precacheFeedFromGeneratorView` that can be called with the `Link`'s `onPress`. This runs just before pushing to the screen - and lets the query already have the info it needs.

## Test Plan

Visit a profile that has some feeds, and notice the lack of a spinner state (easiest to see with throttling)

### Before

https://github.com/bluesky-social/social-app/assets/153161762/d1a9c122-e9d7-430e-9608-91babd558233 

### After

https://github.com/bluesky-social/social-app/assets/153161762/47194028-2246-423a-8e6a-4250e42dd9ea