### PR TITLE
Modified to use "measure word" in "# others"

### DIFF
--- a/src/screens/StarterPack/Wizard/index.tsx
+++ b/src/screens/StarterPack/Wizard/index.tsx
@@ -493,17 +493,29 @@ function Footer({
               </Text>
               are included in your starter pack
             </Trans>
-          ) : (
-            <Trans>
+          ) : state.currentStep === 'Profiles' ? (
+            <Trans context="profiles">
               <Text style={[a.font_bold, textStyles]}>
                 {getName(items[initialNamesIndex])},{' '}
               </Text>
               <Text style={[a.font_bold, textStyles]}>
                 {getName(items[initialNamesIndex + 1])},{' '}
               </Text>
-              and {items.length - 2}{' '}
-              <Plural value={items.length - 2} one="other" other="others" /> are
-              included in your starter pack
+              and{' '}
+              <Plural value={items.length - 2} one="# other" other="# others" />{' '}
+              are included in your starter pack
+            </Trans>
+          ) : (
+            <Trans context="feeds">
+              <Text style={[a.font_bold, textStyles]}>
+                {getName(items[initialNamesIndex])},{' '}
+              </Text>
+              <Text style={[a.font_bold, textStyles]}>
+                {getName(items[initialNamesIndex + 1])},{' '}
+              </Text>
+              and{' '}
+              <Plural value={items.length - 2} one="# other" other="# others" />{' '}
+              are included in your starter pack
             </Trans>
           )}
         </Text>


### PR DESCRIPTION
In some languages, a measure word (counter word) may be required after a number, and different counter words are used to show the number of "profiles" and "feeds" in a sentence.

ref. https://en.wikipedia.org/wiki/Measure_word

In Japanese, you can use "人" for "(human) profiles", and "個" or "フィード" for "feeds" (if the number of feeds is less than 10. "つ" is also fine).

| | 1 profile | 2 profiles | 1 feed | 2 feeds |
| --- | --- | --- | --- | --- |
| English   | 1 other | 1 other | 2 others | 2 others |
| Japanese | 他1人 | 他1フィード | 他2人 | 他2フィード |


The current StarterPack does not distinguish between profiles and feeds, so I tried making it possible to distinguish by specifying the context property in <Trans>.
