### PR TITLE
use granular permission of  for media perm request

### DIFF
--- a/src/lib/hooks/usePermissions.ts
+++ b/src/lib/hooks/usePermissions.ts
@@ -20,7 +20,9 @@ const openPermissionAlert = (perm: string) => {
 }
 
 export function usePhotoLibraryPermission() {
-  const [res, requestPermission] = MediaLibrary.usePermissions()
+  const [res, requestPermission] = MediaLibrary.usePermissions({
+    granularPermissions: ['photo'],
+  })
   const requestPhotoAccessIfNeeded = async () => {
     // On the, we use <input type="file"> to produce a filepicker
     // This does not need any permission granting.

--- a/src/view/com/composer/photos/OpenCameraBtn.tsx
+++ b/src/view/com/composer/photos/OpenCameraBtn.tsx
@@ -24,7 +24,7 @@ export function OpenCameraBtn({gallery, disabled}: Props) {
   const {_} = useLingui()
   const {requestCameraAccessIfNeeded} = useCameraPermission()
   const [mediaPermissionRes, requestMediaPermission] =
-    MediaLibrary.usePermissions()
+    MediaLibrary.usePermissions({granularPermissions: ['photo']})
   const t = useTheme()
 
   const onPressTakePicture = useCallback(async () => {

--- a/src/view/com/lightbox/Lightbox.tsx
+++ b/src/view/com/lightbox/Lightbox.tsx
@@ -59,7 +59,9 @@ function LightboxFooter({imageIndex}: {imageIndex: number}) {
   const {_} = useLingui()
   const {activeLightbox} = useLightbox()
   const [isAltExpanded, setAltExpanded] = React.useState(false)
-  const [permissionResponse, requestPermission] = MediaLibrary.usePermissions()
+  const [permissionResponse, requestPermission] = MediaLibrary.usePermissions({
+    granularPermissions: ['photo'],
+  })
 
   const saveImageToAlbumWithToasts = React.useCallback(
     async (uri: string) => {


### PR DESCRIPTION
## Why

See https://docs.expo.dev/versions/latest/sdk/media-library/#medialibrarygetpermissionsasyncwriteonly-granularpermissions

We should be setting a granular permission of `photo` as the only thing we request. Otherwise, the default is to request access to _all_ media types, which results in the weird "double prompt" we see now on Android.

We'll have to adjust this for video of course once we add that - though we should make sure to request only `video` when we do to prevent this double dialog again.

## Test Plan

Reinstall the Android app with a build of this one. You should still get a permission request for photos but you should not get a request for audio and video.