### PR TITLE
Fix crash in Feeds and Starter Packs

### DIFF
--- a/src/screens/StarterPack/Wizard/StepFeeds.tsx
+++ b/src/screens/StarterPack/Wizard/StepFeeds.tsx
@@ -41,13 +41,9 @@ export function StepFeeds({moderationOpts}: {moderationOpts: ModerationOpts}) {
     limit: 30,
   })
   const popularFeeds = popularFeedsPages?.pages.flatMap(p => p.feeds) ?? []
-
-  const suggestedFeeds =
-    savedFeeds.length === 0
-      ? popularFeeds
-      : savedFeeds.concat(
-          popularFeeds.filter(f => !savedFeeds.some(sf => sf.uri === f.uri)),
-        )
+  const suggestedFeeds = savedFeeds.concat(
+    popularFeeds.filter(f => !savedFeeds.some(sf => sf.uri === f.uri)),
+  )
 
   const {data: searchedFeeds, isLoading: isLoadingSearch} =
     useSearchPopularFeedsQuery({q: throttledQuery})

--- a/src/state/queries/feed.ts
+++ b/src/state/queries/feed.ts
@@ -556,28 +556,39 @@ export function useSavedFeeds() {
         precacheList(queryClient, list)
       })
 
-      const res: SavedFeedItem[] = savedItems.map(s => {
-        if (s.type === 'timeline') {
-          return {
+      const result: SavedFeedItem[] = []
+      for (let savedItem of savedItems) {
+        if (savedItem.type === 'timeline') {
+          result.push({
             type: 'timeline',
-            config: s,
+            config: savedItem,
             view: undefined,
+          })
+        } else if (savedItem.type === 'feed') {
+          const resolvedFeed = resolvedFeeds.get(savedItem.value)
+          if (resolvedFeed) {
+            result.push({
+              type: 'feed',
+              config: savedItem,
+              view: resolvedFeed,
+            })
+          }
+        } else if (savedItem.type === 'list') {
+          const resolvedList = resolvedLists.get(savedItem.value)
+          if (resolvedList) {
+            result.push({
+              type: 'list',
+              config: savedItem,
+              view: resolvedList,
+            })
           }
         }
-
-        return {
-          type: s.type,
-          config: s,
-          view:
-            s.type === 'feed'
-              ? resolvedFeeds.get(s.value)
-              : resolvedLists.get(s.value),
-        }
-      }) as SavedFeedItem[]
+      }
 
       return {
-        count: savedItems.length,
-        feeds: res,
+        // TODO: The count property seems superflouous.
+        count: result.length,
+        feeds: result,
       }
     },
   })

--- a/src/state/queries/feed.ts
+++ b/src/state/queries/feed.ts
@@ -509,6 +509,7 @@ export function useSavedFeeds() {
     placeholderData: previousData => {
       return (
         previousData || {
+          // The likely count before we try to resolve them.
           count: savedItems.length,
           feeds: [],
         }
@@ -586,7 +587,7 @@ export function useSavedFeeds() {
       }
 
       return {
-        // TODO: The count property seems superflouous.
+        // By this point we know the real count.
         count: result.length,
         feeds: result,
       }


### PR DESCRIPTION
See inline comments.

## Test Plan

Add `throw Error('no')` [here](https://github.com/bluesky-social/social-app/blob/873d91d4664403577fff0438bfc81304f1fafe5b/src/state/queries/feed.ts#L544), then add it [here](https://github.com/bluesky-social/social-app/blob/873d91d4664403577fff0438bfc81304f1fafe5b/src/state/queries/feed.ts#L531). In both cases the Feeds page should be able to recover, and show the rest instead. Similarly start pack creation should recover in both cases.