### PR TITLE
Wait for preferences before showing suggested feeds

### DIFF
--- a/src/screens/StarterPack/Wizard/StepFeeds.tsx
+++ b/src/screens/StarterPack/Wizard/StepFeeds.tsx
@@ -46,11 +46,16 @@ export function StepFeeds({moderationOpts}: {moderationOpts: ModerationOpts}) {
     limit: 30,
   })
   const popularFeeds = popularFeedsPages?.pages.flatMap(p => p.feeds) ?? []
+
+  // If we have saved feeds already loaded, display them immediately
+  // Then, if we also have popular feeds we can concat them to the saved feeds
   const suggestedFeeds =
-    isFetchedSavedFeeds && !isLoadingPopularFeeds
-      ? savedFeeds.concat(
-          popularFeeds.filter(f => !savedFeeds.some(sf => sf.uri === f.uri)),
-        )
+    savedFeeds || isFetchedSavedFeeds
+      ? popularFeeds
+        ? savedFeeds.concat(
+            popularFeeds.filter(f => !savedFeeds.some(sf => sf.uri === f.uri)),
+          )
+        : savedFeeds
       : undefined
 
   const {data: searchedFeeds, isFetching: isFetchingSearchedFeeds} =

--- a/src/screens/StarterPack/Wizard/StepFeeds.tsx
+++ b/src/screens/StarterPack/Wizard/StepFeeds.tsx
@@ -48,7 +48,7 @@ export function StepFeeds({moderationOpts}: {moderationOpts: ModerationOpts}) {
   const popularFeeds = popularFeedsPages?.pages.flatMap(p => p.feeds) ?? []
 
   // If we have saved feeds already loaded, display them immediately
-  // Then, if we also have popular feeds we can concat them to the saved feeds
+  // Then, when popular feeds have loaded we can concat them to the saved feeds
   const suggestedFeeds =
     savedFeeds || isFetchedSavedFeeds
       ? popularFeeds

--- a/src/screens/StarterPack/Wizard/StepFeeds.tsx
+++ b/src/screens/StarterPack/Wizard/StepFeeds.tsx
@@ -32,11 +32,8 @@ export function StepFeeds({moderationOpts}: {moderationOpts: ModerationOpts}) {
   const throttledQuery = useThrottledValue(query, 500)
   const {screenReaderEnabled} = useA11y()
 
-  const {
-    data: savedFeedsAndLists,
-    isLoading: isLoadingSavedFeeds,
-    isFetchedAfterMount: isFetchedSavedFeeds,
-  } = useSavedFeeds()
+  const {data: savedFeedsAndLists, isFetchedAfterMount: isFetchedSavedFeeds} =
+    useSavedFeeds()
   const savedFeeds = savedFeedsAndLists?.feeds
     .filter(f => f.type === 'feed' && f.view.uri !== DISCOVER_FEED_URI)
     .map(f => f.view) as AppBskyFeedDefs.GeneratorView[]
@@ -50,7 +47,7 @@ export function StepFeeds({moderationOpts}: {moderationOpts: ModerationOpts}) {
   })
   const popularFeeds = popularFeedsPages?.pages.flatMap(p => p.feeds) ?? []
   const suggestedFeeds =
-    isFetchedSavedFeeds && !isLoadingSavedFeeds && !isLoadingPopularFeeds
+    isFetchedSavedFeeds && !isLoadingPopularFeeds
       ? savedFeeds.concat(
           popularFeeds.filter(f => !savedFeeds.some(sf => sf.uri === f.uri)),
         )
@@ -60,10 +57,7 @@ export function StepFeeds({moderationOpts}: {moderationOpts: ModerationOpts}) {
     useSearchPopularFeedsQuery({q: throttledQuery})
 
   const isLoading =
-    !isFetchedSavedFeeds ||
-    isLoadingSavedFeeds ||
-    isLoadingPopularFeeds ||
-    isFetchingSearchedFeeds
+    !isFetchedSavedFeeds || isLoadingPopularFeeds || isFetchingSearchedFeeds
 
   const renderItem = ({
     item,


### PR DESCRIPTION
## Why

The `useSavedFeeds` query needs the user's preferences to be loaded first. Generally a user's preferences should be loaded already and cached before we enter the wizard, but its possible for them to be invalidated when we enter. If they are invalidated, they will get refetched inside of `useSavedFeeds`.

While fetching preferences, the `useQuery` in `useSavedFeeds` is disabled. This means that `isLoading` will be _false_ for a moment - so just checking `isLoadingSavedFeeds` will not always work. Instead, we want to look at `isFetchedAfterMount`.

## Test Plan

You can add a test promise as shown in the video below and remove `staleTime: Infinity`.

### Before

https://github.com/bluesky-social/social-app/assets/153161762/b0ae5fd7-7dae-4aff-ac85-250fa8a9a246

### After

https://github.com/bluesky-social/social-app/assets/153161762/1b59e8a3-af7a-4395-8bcc-4777a9bfe5d2

