### PR TITLE
Refactor `ProfileCard` to be composable

### DIFF
--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -79,7 +79,7 @@ export function Outer({
 }: {
   children: React.ReactElement | React.ReactElement[]
 }) {
-  return <View style={[a.flex_1, a.gap_sm]}>{children}</View>
+  return <View style={[a.flex_1, a.gap_xs]}>{children}</View>
 }
 
 export function Header({
@@ -172,12 +172,14 @@ export function Description({
   )
     return null
   return (
-    <RichText
-      value={rt}
-      style={[a.leading_snug]}
-      numberOfLines={3}
-      disableLinks
-    />
+    <View style={[a.pt_xs]}>
+      <RichText
+        value={rt}
+        style={[a.leading_snug]}
+        numberOfLines={3}
+        disableLinks
+      />
+    </View>
   )
 }
 

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -10,10 +10,30 @@ import {FollowButton} from 'view/com/profile/FollowButton'
 import {ProfileCardPills} from 'view/com/profile/ProfileCard'
 import {UserAvatar} from 'view/com/util/UserAvatar'
 import {atoms as a, useTheme} from '#/alf'
-import {Link} from '#/components/Link'
+import {Link as InternalLink, LinkProps} from '#/components/Link'
 import {Text} from '#/components/Typography'
 
 export function Default({
+  profile,
+  moderationOpts,
+  logContext = 'ProfileCard',
+}: {
+  profile: AppBskyActorDefs.ProfileViewDetailed
+  moderationOpts: ModerationOpts
+  logContext?: 'ProfileCard' | 'StarterPackProfilesList'
+}) {
+  return (
+    <Link did={profile.did}>
+      <Card
+        profile={profile}
+        moderationOpts={moderationOpts}
+        logContext={logContext}
+      />
+    </Link>
+  )
+}
+
+export function Card({
   profile: profileUnshadowed,
   moderationOpts,
   logContext = 'ProfileCard',
@@ -31,7 +51,7 @@ export function Default({
   const moderation = moderateProfile(profile, moderationOpts)
 
   return (
-    <Wrapper did={profile.did}>
+    <View style={[a.flex_1, a.gap_xs]}>
       <View style={[a.flex_row, a.gap_sm]}>
         <UserAvatar
           size={42}
@@ -74,18 +94,18 @@ export function Default({
           {profile.description}
         </Text>
       )}
-    </Wrapper>
+    </View>
   )
 }
 
-function Wrapper({did, children}: {did: string; children: React.ReactNode}) {
+export function Link({did, children}: {did: string} & Omit<LinkProps, 'to'>) {
   return (
-    <Link
+    <InternalLink
       to={{
         screen: 'Profile',
         params: {name: did},
       }}>
-      <View style={[a.flex_1, a.gap_xs]}>{children}</View>
-    </Link>
+      {children}
+    </InternalLink>
   )
 }

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -57,7 +57,7 @@ export function Card({
   const moderation = moderateProfile(profile, moderationOpts)
 
   return (
-    <View style={[a.flex_1, a.gap_sm]}>
+    <Outer>
       <Header>
         <Avatar profile={profile} moderationOpts={moderationOpts} />
         <NameAndHandle profile={profile} moderationOpts={moderationOpts} />
@@ -70,8 +70,16 @@ export function Card({
       />
 
       <Description profile={profile} />
-    </View>
+    </Outer>
   )
+}
+
+export function Outer({
+  children,
+}: {
+  children: React.ReactElement | React.ReactElement[]
+}) {
+  return <View style={[a.flex_1, a.gap_sm]}>{children}</View>
 }
 
 export function Header({

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -1,16 +1,28 @@
 import React from 'react'
-import {View} from 'react-native'
-import {AppBskyActorDefs, moderateProfile, ModerationOpts} from '@atproto/api'
+import {GestureResponderEvent, View} from 'react-native'
+import {
+  AppBskyActorDefs,
+  moderateProfile,
+  ModerationOpts,
+  RichText as RichTextApi,
+} from '@atproto/api'
+import {msg} from '@lingui/macro'
+import {useLingui} from '@lingui/react'
 
-import {createSanitizedDisplayName} from 'lib/moderation/create-sanitized-display-name'
+import {sanitizeDisplayName} from '#/lib/strings/display-names'
+import {useProfileFollowMutationQueue} from '#/state/queries/profile'
 import {sanitizeHandle} from 'lib/strings/handles'
 import {useProfileShadow} from 'state/cache/profile-shadow'
 import {useSession} from 'state/session'
-import {FollowButton} from 'view/com/profile/FollowButton'
+import * as Toast from '#/view/com/util/Toast'
 import {ProfileCardPills} from 'view/com/profile/ProfileCard'
 import {UserAvatar} from 'view/com/util/UserAvatar'
 import {atoms as a, useTheme} from '#/alf'
+import {Button, ButtonIcon, ButtonText} from '#/components/Button'
+import {Check_Stroke2_Corner0_Rounded as Check} from '#/components/icons/Check'
+import {PlusLarge_Stroke2_Corner0_Rounded as Plus} from '#/components/icons/Plus'
 import {Link as InternalLink, LinkProps} from '#/components/Link'
+import {RichText} from '#/components/RichText'
 import {Text} from '#/components/Typography'
 
 export function Default({
@@ -34,7 +46,7 @@ export function Default({
 }
 
 export function Card({
-  profile: profileUnshadowed,
+  profile,
   moderationOpts,
   logContext = 'ProfileCard',
 }: {
@@ -42,60 +54,34 @@ export function Card({
   moderationOpts: ModerationOpts
   logContext?: 'ProfileCard' | 'StarterPackProfilesList'
 }) {
-  const t = useTheme()
-  const {currentAccount, hasSession} = useSession()
-
-  const profile = useProfileShadow(profileUnshadowed)
-  const name = createSanitizedDisplayName(profile)
-  const handle = `@${sanitizeHandle(profile.handle)}`
   const moderation = moderateProfile(profile, moderationOpts)
 
   return (
     <View style={[a.flex_1, a.gap_xs]}>
-      <View style={[a.flex_row, a.gap_sm]}>
-        <UserAvatar
-          size={42}
-          avatar={profile.avatar}
-          type={
-            profile.associated?.labeler
-              ? 'labeler'
-              : profile.associated?.feedgens
-              ? 'algo'
-              : 'user'
-          }
-          moderation={moderation.ui('avatar')}
-        />
-        <View style={[a.flex_1]}>
-          <Text
-            style={[a.text_md, a.font_bold, a.leading_snug]}
-            numberOfLines={1}>
-            {name}
-          </Text>
-          <Text
-            style={[a.leading_snug, t.atoms.text_contrast_medium]}
-            numberOfLines={1}>
-            {handle}
-          </Text>
-        </View>
-        {hasSession && profile.did !== currentAccount?.did && (
-          <View style={[a.justify_center, {marginLeft: 'auto'}]}>
-            <FollowButton profile={profile} logContext={logContext} />
-          </View>
-        )}
-      </View>
+      <Header>
+        <Avatar profile={profile} moderationOpts={moderationOpts} />
+        <NameAndHandle profile={profile} moderationOpts={moderationOpts} />
+        <FollowButton profile={profile} logContext={logContext} />
+      </Header>
+
       <View style={[a.mb_xs]}>
         <ProfileCardPills
           followedBy={Boolean(profile.viewer?.followedBy)}
           moderation={moderation}
         />
       </View>
-      {profile.description && (
-        <Text numberOfLines={3} style={[a.leading_snug]}>
-          {profile.description}
-        </Text>
-      )}
+
+      {profile.description && <Description description={profile.description} />}
     </View>
   )
+}
+
+export function Header({
+  children,
+}: {
+  children: React.ReactElement | React.ReactElement[]
+}) {
+  return <View style={[a.flex_row, a.gap_sm]}>{children}</View>
 }
 
 export function Link({did, children}: {did: string} & Omit<LinkProps, 'to'>) {
@@ -107,5 +93,165 @@ export function Link({did, children}: {did: string} & Omit<LinkProps, 'to'>) {
       }}>
       {children}
     </InternalLink>
+  )
+}
+
+export function Avatar({
+  profile,
+  moderationOpts,
+}: {
+  profile: AppBskyActorDefs.ProfileViewDetailed
+  moderationOpts: ModerationOpts
+}) {
+  const moderation = moderateProfile(profile, moderationOpts)
+
+  return (
+    <UserAvatar
+      size={42}
+      avatar={profile.avatar}
+      type={profile.associated?.labeler ? 'labeler' : 'user'}
+      moderation={moderation.ui('avatar')}
+    />
+  )
+}
+
+export function NameAndHandle({
+  profile,
+  moderationOpts,
+}: {
+  profile: AppBskyActorDefs.ProfileViewDetailed
+  moderationOpts: ModerationOpts
+}) {
+  const t = useTheme()
+  const moderation = moderateProfile(profile, moderationOpts)
+  const name = sanitizeDisplayName(
+    profile.displayName || sanitizeHandle(profile.handle),
+    moderation.ui('displayName'),
+  )
+  const handle = sanitizeHandle(profile.handle, '@')
+
+  return (
+    <View style={[a.flex_1]}>
+      <Text style={[a.text_md, a.font_bold, a.leading_snug]} numberOfLines={1}>
+        {name}
+      </Text>
+      <Text
+        style={[a.leading_snug, t.atoms.text_contrast_medium]}
+        numberOfLines={1}>
+        {handle}
+      </Text>
+    </View>
+  )
+}
+
+export function Description({description}: {description?: string}) {
+  const rt = React.useMemo(() => {
+    if (!description) return
+    const rt = new RichTextApi({text: description || ''})
+    rt.detectFacetsWithoutResolution()
+    return rt
+  }, [description])
+  if (!rt) return null
+  return (
+    <RichText
+      value={rt}
+      style={[a.leading_snug]}
+      numberOfLines={3}
+      disableLinks
+    />
+  )
+}
+
+export function FollowButton({
+  profile,
+  logContext,
+}: {
+  profile: AppBskyActorDefs.ProfileViewBasic
+  logContext: 'ProfileCard' | 'StarterPackProfilesList'
+}) {
+  const {currentAccount, hasSession} = useSession()
+  const isMe = profile.did === currentAccount?.did
+  return hasSession && !isMe ? (
+    <FollowButtonInner profile={profile} logContext={logContext} />
+  ) : null
+}
+
+export function FollowButtonInner({
+  profile: profileUnshadowed,
+  logContext,
+}: {
+  profile: AppBskyActorDefs.ProfileViewBasic
+  logContext: 'ProfileCard' | 'StarterPackProfilesList'
+}) {
+  const {_} = useLingui()
+  const profile = useProfileShadow(profileUnshadowed)
+  const [queueFollow, queueUnfollow] = useProfileFollowMutationQueue(
+    profile,
+    logContext,
+  )
+
+  const onPressFollow = async (e: GestureResponderEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    try {
+      await queueFollow()
+    } catch (e: any) {
+      if (e?.name !== 'AbortError') {
+        Toast.show(_(msg`An issue occurred, please try again.`))
+      }
+    }
+  }
+
+  const onPressUnfollow = async (e: GestureResponderEvent) => {
+    e.preventDefault()
+    e.stopPropagation()
+    try {
+      await queueUnfollow()
+    } catch (e: any) {
+      if (e?.name !== 'AbortError') {
+        Toast.show(_(msg`An issue occurred, please try again.`))
+      }
+    }
+  }
+
+  const unfollowLabel = _(
+    msg({
+      message: 'Following',
+      comment: 'User is following this account, click to unfollow',
+    }),
+  )
+  const followLabel = _(
+    msg({
+      message: 'Follow',
+      comment: 'User is not following this account, click to follow',
+    }),
+  )
+
+  if (!profile.viewer) return null
+
+  return (
+    <View>
+      {profile.viewer.following ? (
+        <Button
+          label={unfollowLabel}
+          size="small"
+          variant="solid"
+          color="secondary"
+          onPress={onPressUnfollow}>
+          <ButtonIcon icon={Check} position="left" />
+          <ButtonText>{unfollowLabel}</ButtonText>
+        </Button>
+      ) : (
+        <Button
+          label={followLabel}
+          size="small"
+          variant="solid"
+          color="primary"
+          onPress={onPressFollow}>
+          <ButtonIcon icon={Plus} position="left" />
+          <ButtonText>{followLabel}</ButtonText>
+        </Button>
+      )}
+    </View>
   )
 }

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -57,21 +57,19 @@ export function Card({
   const moderation = moderateProfile(profile, moderationOpts)
 
   return (
-    <View style={[a.flex_1, a.gap_xs]}>
+    <View style={[a.flex_1, a.gap_sm]}>
       <Header>
         <Avatar profile={profile} moderationOpts={moderationOpts} />
         <NameAndHandle profile={profile} moderationOpts={moderationOpts} />
         <FollowButton profile={profile} logContext={logContext} />
       </Header>
 
-      <View style={[a.mb_xs]}>
-        <ProfileCardPills
-          followedBy={Boolean(profile.viewer?.followedBy)}
-          moderation={moderation}
-        />
-      </View>
+      <ProfileCardPills
+        followedBy={Boolean(profile.viewer?.followedBy)}
+        moderation={moderation}
+      />
 
-      {profile.description && <Description description={profile.description} />}
+      <Description profile={profile} />
     </View>
   )
 }
@@ -144,7 +142,13 @@ export function NameAndHandle({
   )
 }
 
-export function Description({description}: {description?: string}) {
+export function Description({
+  profile: profileUnshadowed,
+}: {
+  profile: AppBskyActorDefs.ProfileViewDetailed
+}) {
+  const profile = useProfileShadow(profileUnshadowed)
+  const {description} = profile
   const rt = React.useMemo(() => {
     if (!description) return
     const rt = new RichTextApi({text: description || ''})
@@ -152,6 +156,13 @@ export function Description({description}: {description?: string}) {
     return rt
   }, [description])
   if (!rt) return null
+  if (
+    profile.viewer &&
+    (profile.viewer.blockedBy ||
+      profile.viewer.blocking ||
+      profile.viewer.blockingByList)
+  )
+    return null
   return (
     <RichText
       value={rt}
@@ -224,6 +235,12 @@ export function FollowButtonInner({
   )
 
   if (!profile.viewer) return null
+  if (
+    profile.viewer.blockedBy ||
+    profile.viewer.blocking ||
+    profile.viewer.blockingByList
+  )
+    return null
 
   return (
     <View>

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -18,7 +18,7 @@ import * as Toast from '#/view/com/util/Toast'
 import {ProfileCardPills} from 'view/com/profile/ProfileCard'
 import {UserAvatar} from 'view/com/util/UserAvatar'
 import {atoms as a, useTheme} from '#/alf'
-import {Button, ButtonIcon, ButtonText} from '#/components/Button'
+import {Button, ButtonIcon, ButtonProps, ButtonText} from '#/components/Button'
 import {Check_Stroke2_Corner0_Rounded as Check} from '#/components/icons/Check'
 import {PlusLarge_Stroke2_Corner0_Rounded as Plus} from '#/components/icons/Plus'
 import {Link as InternalLink, LinkProps} from '#/components/Link'
@@ -162,33 +162,29 @@ export function Description({description}: {description?: string}) {
   )
 }
 
-export function FollowButton({
-  profile,
-  logContext,
-}: {
+export type FollowButtonProps = {
   profile: AppBskyActorDefs.ProfileViewBasic
   logContext: 'ProfileCard' | 'StarterPackProfilesList'
-}) {
+} & Partial<ButtonProps>
+
+export function FollowButton(props: FollowButtonProps) {
   const {currentAccount, hasSession} = useSession()
-  const isMe = profile.did === currentAccount?.did
-  return hasSession && !isMe ? (
-    <FollowButtonInner profile={profile} logContext={logContext} />
-  ) : null
+  const isMe = props.profile.did === currentAccount?.did
+  return hasSession && !isMe ? <FollowButtonInner {...props} /> : null
 }
 
 export function FollowButtonInner({
   profile: profileUnshadowed,
   logContext,
-}: {
-  profile: AppBskyActorDefs.ProfileViewBasic
-  logContext: 'ProfileCard' | 'StarterPackProfilesList'
-}) {
+  ...rest
+}: FollowButtonProps) {
   const {_} = useLingui()
   const profile = useProfileShadow(profileUnshadowed)
   const [queueFollow, queueUnfollow] = useProfileFollowMutationQueue(
     profile,
     logContext,
   )
+  const isRound = Boolean(rest.shape && rest.shape === 'round')
 
   const onPressFollow = async (e: GestureResponderEvent) => {
     e.preventDefault()
@@ -237,9 +233,10 @@ export function FollowButtonInner({
           size="small"
           variant="solid"
           color="secondary"
+          {...rest}
           onPress={onPressUnfollow}>
-          <ButtonIcon icon={Check} position="left" />
-          <ButtonText>{unfollowLabel}</ButtonText>
+          <ButtonIcon icon={Check} position={isRound ? undefined : 'left'} />
+          {isRound ? null : <ButtonText>{unfollowLabel}</ButtonText>}
         </Button>
       ) : (
         <Button
@@ -247,9 +244,10 @@ export function FollowButtonInner({
           size="small"
           variant="solid"
           color="primary"
+          {...rest}
           onPress={onPressFollow}>
-          <ButtonIcon icon={Plus} position="left" />
-          <ButtonText>{followLabel}</ButtonText>
+          <ButtonIcon icon={Plus} position={isRound ? undefined : 'left'} />
+          {isRound ? null : <ButtonText>{followLabel}</ButtonText>}
         </Button>
       )}
     </View>


### PR DESCRIPTION
Refactors the new `ProfileCard` component to be flexible and composable. Also handles blocked account state, see screenshot, but we should really filter those accounts out from this view.

Main exports here are `Default` (which matches the `StarterPackCard` and `FeedCard`) and `Card` which does not include a `Link` that wraps the card by default.

We could integrate `KnownFollowers` into the default exports here, or we could integrate that compositionally, tbd.

Only used in starter packs in two places right now:
![CleanShot 2024-06-27 at 12 17 05@2x](https://github.com/bluesky-social/social-app/assets/4732330/b7d862c4-6e02-4141-913b-c6e6ccd342f7)
![CleanShot 2024-06-27 at 12 17 14@2x](https://github.com/bluesky-social/social-app/assets/4732330/400430fa-b54c-41bf-a3d5-47df72110287)
![CleanShot 2024-06-27 at 12 17 22@2x](https://github.com/bluesky-social/social-app/assets/4732330/a4322f00-daa5-4725-8115-cc4d82b8d113)
![CleanShot 2024-06-27 at 12 18 12@2x](https://github.com/bluesky-social/social-app/assets/4732330/dfe6089b-c062-4077-ab23-5339a40fd5dd)

