### PR TITLE
Maintain portrait in app clip

### DIFF
--- a/plugins/starterPackAppClipExtension/withClipInfoPlist.js
+++ b/plugins/starterPackAppClipExtension/withClipInfoPlist.js
@@ -26,6 +26,14 @@ const withClipInfoPlist = (config, {targetName}) => {
       CFBundleShortVersionString: config.version,
       CFBundleIconName: 'AppIcon',
       UIViewControllerBasedStatusBarAppearance: 'NO',
+      UISupportedInterfaceOrientations: [
+        'UIInterfaceOrientationPortrait',
+        'UIInterfaceOrientationPortraitUpsideDown',
+      ],
+      'UISupportedInterfaceOrientations~ipad': [
+        'UIInterfaceOrientationPortrait',
+        'UIInterfaceOrientationPortraitUpsideDown',
+      ],
     })
 
     fs.mkdirSync(path.dirname(targetPath), {recursive: true})


### PR DESCRIPTION
## Why

Make sure the app clip can't rotate to horizontal mode. Using the same values here as our app.