### PR TITLE
Fix typo in threadgate modal

### DIFF
--- a/src/components/dialogs/ThreadgateEditor.tsx
+++ b/src/components/dialogs/ThreadgateEditor.tsx
@@ -92,7 +92,7 @@ function DialogContent({
       style={[{maxWidth: 500}, a.w_full]}>
       <View style={[a.flex_1, a.gap_md]}>
         <Text style={[a.text_2xl, a.font_bold]}>
-          <Trans>Chose who can reply</Trans>
+          <Trans>Choose who can reply</Trans>
         </Text>
         <Text style={a.mt_xs}>
           <Trans>Either choose "Everybody" or "Nobody"</Trans>


### PR DESCRIPTION
As a follow-up to #4329, this tiny PR fixes a typo in the threadgate modal, changing `Chose` to `Choose`.

![IMG_2967](https://github.com/bluesky-social/social-app/assets/149612116/9fd1adc3-5f48-4297-92a1-d9324dd9463e)