### PR TITLE
tweak app clip AASA

### DIFF
--- a/bskylink/src/routes/siteAssociation.ts
+++ b/bskylink/src/routes/siteAssociation.ts
@@ -5,6 +5,15 @@ import {AppContext} from '../context.js'
 export default function (ctx: AppContext, app: Express) {
   return app.get('/.well-known/apple-app-site-association', (req, res) => {
     res.json({
+      applinks: {
+        apps: [],
+        details: [
+          {
+            appID: 'B3LX46C5HS.xyz.blueskyweb.app',
+            paths: [],
+          },
+        ],
+      },
       appclips: {
         apps: ['B3LX46C5HS.xyz.blueskyweb.app.AppClip'],
       },

--- a/bskylink/src/routes/siteAssociation.ts
+++ b/bskylink/src/routes/siteAssociation.ts
@@ -10,7 +10,7 @@ export default function (ctx: AppContext, app: Express) {
         details: [
           {
             appID: 'B3LX46C5HS.xyz.blueskyweb.app',
-            paths: [],
+            paths: ['*'],
           },
         ],
       },

--- a/bskyweb/static/.well-known/apple-app-site-association
+++ b/bskyweb/static/.well-known/apple-app-site-association
@@ -1,8 +1,5 @@
 {
   "applinks": {
-    "appclips": {
-      "apps": ["B3LX46C5HS.xyz.blueskyweb.app.AppClip"]
-    },
     "details": [
       {
         "appID": "B3LX46C5HS.xyz.blueskyweb.app",
@@ -11,5 +8,8 @@
         ]
       }
     ]
-  }
+  },
+  "appclips": {
+    "apps": ["B3LX46C5HS.xyz.blueskyweb.app.AppClip"]
+  },
 }

--- a/bskyweb/static/.well-known/apple-app-site-association
+++ b/bskyweb/static/.well-known/apple-app-site-association
@@ -11,5 +11,5 @@
   },
   "appclips": {
     "apps": ["B3LX46C5HS.xyz.blueskyweb.app.AppClip"]
-  },
+  }
 }


### PR DESCRIPTION
AASA requires `applinks` to be present, even if the domain is only used for an app clip.