### PR TITLE
FeedCard & ListCard cleanups

### DIFF
--- a/src/components/FeedCard.tsx
+++ b/src/components/FeedCard.tsx
@@ -3,6 +3,7 @@ import {GestureResponderEvent, View} from 'react-native'
 import {
   AppBskyActorDefs,
   AppBskyFeedDefs,
+  AppBskyGraphDefs,
   AtUri,
   RichText as RichTextApi,
 } from '@atproto/api'
@@ -44,7 +45,7 @@ export function Default(props: Props) {
         <Header>
           <Avatar src={view.avatar} />
           <TitleAndByline title={view.displayName} creator={view.creator} />
-          <Action uri={view.uri} pin type="feed" />
+          <Action view={view} pin />
         </Header>
         <Description description={view.description} />
         <Likes count={view.likeCount || 0} />
@@ -190,27 +191,23 @@ export function Likes({count}: {count: number}) {
 }
 
 export function Action({
-  uri,
+  view,
   pin,
-  type,
 }: {
-  uri: string
+  view: AppBskyFeedDefs.GeneratorView | AppBskyGraphDefs.ListView
   pin?: boolean
-  type: 'feed' | 'list'
 }) {
   const {hasSession} = useSession()
   if (!hasSession) return null
-  return <ActionInner uri={uri} pin={pin} type={type} />
+  return <ActionInner view={view} pin={pin} />
 }
 
 function ActionInner({
-  uri,
+  view,
   pin,
-  type,
 }: {
-  uri: string
+  view: AppBskyFeedDefs.GeneratorView | AppBskyGraphDefs.ListView
   pin?: boolean
-  type: 'feed' | 'list'
 }) {
   const {_} = useLingui()
   const {data: preferences} = usePreferencesQuery()
@@ -218,6 +215,10 @@ function ActionInner({
     useAddSavedFeedsMutation()
   const {isPending: isRemovePending, mutateAsync: removeFeed} =
     useRemoveFeedMutation()
+
+  const uri = view.uri
+  const type = view.uri.includes('app.bsky.feed.generator') ? 'feed' : 'list'
+
   const savedFeedConfig = React.useMemo(() => {
     return preferences?.savedFeeds?.find(feed => feed.value === uri)
   }, [preferences?.savedFeeds, uri])

--- a/src/components/FeedCard.tsx
+++ b/src/components/FeedCard.tsx
@@ -45,7 +45,7 @@ export function Default(props: Props) {
         <Header>
           <Avatar src={view.avatar} />
           <TitleAndByline title={view.displayName} creator={view.creator} />
-          <Action view={view} pin />
+          <SaveButton view={view} pin />
         </Header>
         <Description description={view.description} />
         <Likes count={view.likeCount || 0} />
@@ -190,7 +190,7 @@ export function Likes({count}: {count: number}) {
   )
 }
 
-export function Action({
+export function SaveButton({
   view,
   pin,
 }: {
@@ -199,10 +199,10 @@ export function Action({
 }) {
   const {hasSession} = useSession()
   if (!hasSession) return null
-  return <ActionInner view={view} pin={pin} />
+  return <SaveButtonInner view={view} pin={pin} />
 }
 
-function ActionInner({
+function SaveButtonInner({
   view,
   pin,
 }: {

--- a/src/components/ListCard.tsx
+++ b/src/components/ListCard.tsx
@@ -1,0 +1,101 @@
+import React from 'react'
+import {View} from 'react-native'
+import {AppBskyActorDefs, AppBskyGraphDefs, AtUri} from '@atproto/api'
+import {Trans} from '@lingui/macro'
+import {useQueryClient} from '@tanstack/react-query'
+
+import {sanitizeHandle} from 'lib/strings/handles'
+import {precacheList} from 'state/queries/feed'
+import {useTheme} from '#/alf'
+import {atoms as a} from '#/alf'
+import {Avatar, Description, Header, Outer} from '#/components/FeedCard'
+import {Link as InternalLink, LinkProps} from '#/components/Link'
+import {Text} from '#/components/Typography'
+
+/*
+ * This component is based on `FeedCard` and is tightly coupled with that
+ * component. Please refer to `FeedCard` for more context.
+ */
+
+export {
+  AvatarPlaceholder,
+  TitleAndBylinePlaceholder,
+} from '#/components/FeedCard'
+
+export {Avatar, Description, Header, Outer}
+
+type Props = {
+  view: AppBskyGraphDefs.ListView
+}
+
+export function Default(props: Props) {
+  const {view} = props
+  return (
+    <Link label={view.name} {...props}>
+      <Outer>
+        <Header>
+          <Avatar src={view.avatar} />
+          <TitleAndByline title={view.name} creator={view.creator} />
+        </Header>
+        <Description description={view.description} />
+      </Outer>
+    </Link>
+  )
+}
+
+export function Link({
+  view,
+  children,
+  ...props
+}: Props & Omit<LinkProps, 'to'>) {
+  const queryClient = useQueryClient()
+
+  const href = React.useMemo(() => {
+    return createProfileListHref({list: view})
+  }, [view])
+
+  React.useEffect(() => {
+    precacheList(queryClient, view)
+  }, [view, queryClient])
+
+  return (
+    <InternalLink to={href} {...props}>
+      {children}
+    </InternalLink>
+  )
+}
+
+export function TitleAndByline({
+  title,
+  creator,
+}: {
+  title: string
+  creator?: AppBskyActorDefs.ProfileViewBasic
+}) {
+  const t = useTheme()
+
+  return (
+    <View style={[a.flex_1]}>
+      <Text style={[a.text_md, a.font_bold, a.leading_snug]} numberOfLines={1}>
+        {title}
+      </Text>
+      {creator && (
+        <Text
+          style={[a.leading_snug, t.atoms.text_contrast_medium]}
+          numberOfLines={1}>
+          <Trans>List by {sanitizeHandle(creator.handle, '@')}</Trans>
+        </Text>
+      )}
+    </View>
+  )
+}
+
+export function createProfileListHref({
+  list,
+}: {
+  list: AppBskyGraphDefs.ListView
+}) {
+  const urip = new AtUri(list.uri)
+  const handleOrDid = list.creator.handle || list.creator.did
+  return `/profile/${handleOrDid}/lists/${urip.rkey}`
+}

--- a/src/components/ListCard.tsx
+++ b/src/components/ListCard.tsx
@@ -8,7 +8,13 @@ import {sanitizeHandle} from 'lib/strings/handles'
 import {precacheList} from 'state/queries/feed'
 import {useTheme} from '#/alf'
 import {atoms as a} from '#/alf'
-import {Action, Avatar, Description, Header, Outer} from '#/components/FeedCard'
+import {
+  Avatar,
+  Description,
+  Header,
+  Outer,
+  SaveButton,
+} from '#/components/FeedCard'
 import {Link as InternalLink, LinkProps} from '#/components/Link'
 import {Text} from '#/components/Typography'
 
@@ -18,12 +24,12 @@ import {Text} from '#/components/Typography'
  */
 
 export {
-  Action,
   Avatar,
   AvatarPlaceholder,
   Description,
   Header,
   Outer,
+  SaveButton,
   TitleAndBylinePlaceholder,
 } from '#/components/FeedCard'
 
@@ -48,7 +54,7 @@ export function Default(props: Props) {
             purpose={view.purpose}
           />
           {showPinButton && view.purpose === CURATELIST && (
-            <Action view={view} pin />
+            <SaveButton view={view} pin />
           )}
         </Header>
         <Description description={view.description} />

--- a/src/components/ListCard.tsx
+++ b/src/components/ListCard.tsx
@@ -27,6 +27,9 @@ export {
   TitleAndBylinePlaceholder,
 } from '#/components/FeedCard'
 
+const CURATELIST = 'app.bsky.graph.defs#curatelist'
+const MODLIST = 'app.bsky.graph.defs#modlist'
+
 type Props = {
   view: AppBskyGraphDefs.ListView
   showPinButton?: boolean
@@ -44,7 +47,9 @@ export function Default(props: Props) {
             creator={view.creator}
             purpose={view.purpose}
           />
-          {showPinButton && <Action uri={view.uri} pin type="list" />}
+          {showPinButton && view.purpose === CURATELIST && (
+            <Action view={view} pin />
+          )}
         </Header>
         <Description description={view.description} />
       </Outer>
@@ -77,11 +82,11 @@ export function Link({
 export function TitleAndByline({
   title,
   creator,
-  purpose,
+  purpose = CURATELIST,
 }: {
   title: string
   creator?: AppBskyActorDefs.ProfileViewBasic
-  purpose: AppBskyGraphDefs.ListView['purpose']
+  purpose?: AppBskyGraphDefs.ListView['purpose']
 }) {
   const t = useTheme()
 
@@ -94,12 +99,12 @@ export function TitleAndByline({
         <Text
           style={[a.leading_snug, t.atoms.text_contrast_medium]}
           numberOfLines={1}>
-          {purpose === 'app.bsky.graph.defs#curatelist' ? (
-            <Trans>List by {sanitizeHandle(creator.handle, '@')}</Trans>
-          ) : (
+          {purpose === MODLIST ? (
             <Trans>
               Moderation list by {sanitizeHandle(creator.handle, '@')}
             </Trans>
+          ) : (
+            <Trans>List by {sanitizeHandle(creator.handle, '@')}</Trans>
           )}
         </Text>
       )}

--- a/src/components/ListCard.tsx
+++ b/src/components/ListCard.tsx
@@ -8,7 +8,7 @@ import {sanitizeHandle} from 'lib/strings/handles'
 import {precacheList} from 'state/queries/feed'
 import {useTheme} from '#/alf'
 import {atoms as a} from '#/alf'
-import {Avatar, Description, Header, Outer} from '#/components/FeedCard'
+import {Action, Avatar, Description, Header, Outer} from '#/components/FeedCard'
 import {Link as InternalLink, LinkProps} from '#/components/Link'
 import {Text} from '#/components/Typography'
 
@@ -18,24 +18,29 @@ import {Text} from '#/components/Typography'
  */
 
 export {
+  Action,
+  Avatar,
   AvatarPlaceholder,
+  Description,
+  Header,
+  Outer,
   TitleAndBylinePlaceholder,
 } from '#/components/FeedCard'
 
-export {Avatar, Description, Header, Outer}
-
 type Props = {
   view: AppBskyGraphDefs.ListView
+  showPinButton?: boolean
 }
 
 export function Default(props: Props) {
-  const {view} = props
+  const {view, showPinButton} = props
   return (
     <Link label={view.name} {...props}>
       <Outer>
         <Header>
           <Avatar src={view.avatar} />
           <TitleAndByline title={view.name} creator={view.creator} />
+          {showPinButton && <Action uri={view.uri} pin type="list" />}
         </Header>
         <Description description={view.description} />
       </Outer>

--- a/src/components/ListCard.tsx
+++ b/src/components/ListCard.tsx
@@ -39,7 +39,11 @@ export function Default(props: Props) {
       <Outer>
         <Header>
           <Avatar src={view.avatar} />
-          <TitleAndByline title={view.name} creator={view.creator} />
+          <TitleAndByline
+            title={view.name}
+            creator={view.creator}
+            purpose={view.purpose}
+          />
           {showPinButton && <Action uri={view.uri} pin type="list" />}
         </Header>
         <Description description={view.description} />
@@ -73,9 +77,11 @@ export function Link({
 export function TitleAndByline({
   title,
   creator,
+  purpose,
 }: {
   title: string
   creator?: AppBskyActorDefs.ProfileViewBasic
+  purpose: AppBskyGraphDefs.ListView['purpose']
 }) {
   const t = useTheme()
 
@@ -88,7 +94,13 @@ export function TitleAndByline({
         <Text
           style={[a.leading_snug, t.atoms.text_contrast_medium]}
           numberOfLines={1}>
-          <Trans>List by {sanitizeHandle(creator.handle, '@')}</Trans>
+          {purpose === 'app.bsky.graph.defs#curatelist' ? (
+            <Trans>List by {sanitizeHandle(creator.handle, '@')}</Trans>
+          ) : (
+            <Trans>
+              Moderation list by {sanitizeHandle(creator.handle, '@')}
+            </Trans>
+          )}
         </Text>
       )}
     </View>

--- a/src/components/StarterPack/Main/FeedsList.tsx
+++ b/src/components/StarterPack/Main/FeedsList.tsx
@@ -45,7 +45,7 @@ export const FeedsList = React.forwardRef<SectionRef, ProfilesListProps>(
             (isWeb || index !== 0) && a.border_t,
             t.atoms.border_contrast_low,
           ]}>
-          <FeedCard.Default type="feed" view={item} />
+          <FeedCard.Default view={item} />
         </View>
       )
     }

--- a/src/screens/StarterPack/StarterPackLandingScreen.tsx
+++ b/src/screens/StarterPack/StarterPackLandingScreen.tsx
@@ -285,7 +285,7 @@ function LandingScreenLoaded({
                         t.atoms.border_contrast_low,
                       ]}
                       key={feed.uri}>
-                      <FeedCard.Default type="feed" view={feed} />
+                      <FeedCard.Default view={feed} />
                     </View>
                   ))}
                 </View>

--- a/src/view/com/feeds/ProfileFeedgens.tsx
+++ b/src/view/com/feeds/ProfileFeedgens.tsx
@@ -163,7 +163,7 @@ export const ProfileFeedgens = React.forwardRef<
             a.px_lg,
             a.py_lg,
           ]}>
-          <FeedCard.Default type="feed" view={item} />
+          <FeedCard.Default view={item} />
         </View>
       )
     }

--- a/src/view/com/lists/ProfileLists.tsx
+++ b/src/view/com/lists/ProfileLists.tsx
@@ -18,7 +18,7 @@ import {useAnalytics} from 'lib/analytics/analytics'
 import {FeedLoadingPlaceholder} from '#/view/com/util/LoadingPlaceholder'
 import {EmptyState} from 'view/com/util/EmptyState'
 import {atoms as a, useTheme} from '#/alf'
-import * as FeedCard from '#/components/FeedCard'
+import * as ListCard from '#/components/ListCard'
 import {ErrorMessage} from '../util/error/ErrorMessage'
 import {List, ListRef} from '../util/List'
 import {LoadMoreRetryBtn} from '../util/LoadMoreRetryBtn'
@@ -172,7 +172,7 @@ export const ProfileLists = React.forwardRef<SectionRef, ProfileListsProps>(
               a.px_lg,
               a.py_lg,
             ]}>
-            <FeedCard.Default type="list" view={item} />
+            <ListCard.Default view={item} />
           </View>
         )
       },

--- a/src/view/screens/Feeds.tsx
+++ b/src/view/screens/Feeds.tsx
@@ -41,6 +41,7 @@ import hairlineWidth = StyleSheet.hairlineWidth
 import {Divider} from '#/components/Divider'
 import * as FeedCard from '#/components/FeedCard'
 import {ChevronRight_Stroke2_Corner0_Rounded as ChevronRight} from '#/components/icons/Chevron'
+import * as ListCard from '#/components/ListCard'
 
 type Props = NativeStackScreenProps<CommonNavigatorParams, 'Feeds'>
 
@@ -495,7 +496,7 @@ export function FeedsScreen(_props: Props) {
       } else if (item.type === 'popularFeed') {
         return (
           <View style={[a.px_lg, a.pt_lg, a.gap_lg]}>
-            <FeedCard.Default type="feed" view={item.feed} />
+            <FeedCard.Default view={item.feed} />
             <Divider />
           </View>
         )
@@ -627,7 +628,7 @@ function FollowingFeed() {
             fill={t.palette.white}
           />
         </View>
-        <FeedCard.TitleAndByline title={_(msg`Following`)} type="feed" />
+        <FeedCard.TitleAndByline title={_(msg`Following`)} />
       </FeedCard.Header>
     </View>
   )
@@ -639,34 +640,45 @@ function SavedFeed({
   savedFeed: SavedFeedItem & {type: 'feed' | 'list'}
 }) {
   const t = useTheme()
-  const {view: feed} = savedFeed
-  const displayName =
-    savedFeed.type === 'feed' ? savedFeed.view.displayName : savedFeed.view.name
 
-  return (
-    <FeedCard.Link testID={`saved-feed-${feed.displayName}`} {...savedFeed}>
+  const commonStyle = [
+    a.flex_1,
+    a.px_lg,
+    a.py_md,
+    a.border_b,
+    t.atoms.border_contrast_low,
+  ]
+
+  return savedFeed.type === 'feed' ? (
+    <FeedCard.Link
+      testID={`saved-feed-${savedFeed.view.displayName}`}
+      {...savedFeed}>
       {({hovered, pressed}) => (
         <View
-          style={[
-            a.flex_1,
-            a.px_lg,
-            a.py_md,
-            a.border_b,
-            t.atoms.border_contrast_low,
-            (hovered || pressed) && t.atoms.bg_contrast_25,
-          ]}>
+          style={[commonStyle, (hovered || pressed) && t.atoms.bg_contrast_25]}>
           <FeedCard.Header>
-            <FeedCard.Avatar src={feed.avatar} size={28} />
-            <FeedCard.TitleAndByline
-              title={displayName}
-              type={savedFeed.type}
-            />
+            <FeedCard.Avatar src={savedFeed.view.avatar} size={28} />
+            <FeedCard.TitleAndByline title={savedFeed.view.displayName} />
 
             <ChevronRight size="sm" fill={t.atoms.text_contrast_low.color} />
           </FeedCard.Header>
         </View>
       )}
     </FeedCard.Link>
+  ) : (
+    <ListCard.Link testID={`saved-feed-${savedFeed.view.name}`} {...savedFeed}>
+      {({hovered, pressed}) => (
+        <View
+          style={[commonStyle, (hovered || pressed) && t.atoms.bg_contrast_25]}>
+          <ListCard.Header>
+            <ListCard.Avatar src={savedFeed.view.avatar} size={28} />
+            <ListCard.TitleAndByline title={savedFeed.view.name} />
+
+            <ChevronRight size="sm" fill={t.atoms.text_contrast_low.color} />
+          </ListCard.Header>
+        </View>
+      )}
+    </ListCard.Link>
   )
 }
 

--- a/src/view/screens/Search/Explore.tsx
+++ b/src/view/screens/Search/Explore.tsx
@@ -505,7 +505,7 @@ export function Explore() {
                 a.px_lg,
                 a.py_lg,
               ]}>
-              <FeedCard.Default type="feed" view={item.feed} />
+              <FeedCard.Default view={item.feed} />
             </View>
           )
         }

--- a/src/view/screens/Search/Search.tsx
+++ b/src/view/screens/Search/Search.tsx
@@ -306,7 +306,7 @@ let SearchScreenFeedsResults = ({
                 a.px_lg,
                 a.py_lg,
               ]}>
-              <FeedCard.Default type="feed" view={item} />
+              <FeedCard.Default view={item} />
             </View>
           )}
           keyExtractor={item => item.uri}


### PR DESCRIPTION
This PR refactors `FeedCard` a bit and extracts a `ListCard` component for easier usage in either case. If you're rendering a feed, use `FeedCard`. List, use `ListCard`.

`ListCard` inherits from `FeedCard`, since they're very similar, but I think the clarity of usage like this makes this pattern worth it. If we need to further differentiate in the future we can pretty easily like this. Examples:
- lists don't have likes, no need for `Likes` component
- maybe one day we need a different action export for modlists like `SubscribeButton`
- `TitleAndByline` needs a `purpose` for lists, but not for feeds
  - maybe soon we need a `type` or `purpose` field for feeds  👀 

