### PR TITLE
Mark two starter pack strings for localization

### DIFF
--- a/src/components/StarterPack/ProfileStarterPacks.tsx
+++ b/src/components/StarterPack/ProfileStarterPacks.tsx
@@ -232,11 +232,13 @@ function Empty() {
             t.atoms.text_contrast_medium,
             {color: 'white'},
           ]}>
-          You haven't created a starter pack yet!
+          <Trans>You haven't created a starter pack yet!</Trans>
         </Text>
         <Text style={[a.text_md, {color: 'white'}]}>
-          Starter packs let you easily share your favorite feeds and people with
-          your friends.
+          <Trans>
+            Starter packs let you easily share your favorite feeds and people
+            with your friends.
+          </Trans>
         </Text>
       </View>
       <View style={[a.flex_row, a.gap_md, {marginLeft: 'auto'}]}>


### PR DESCRIPTION
After seeing [this video](https://github.com/bluesky-social/social-app/pull/4650#issuecomment-2191884933) I noticed that two of the starter pack strings haven't yet been marked for localization. This PR does that.