### PR TITLE
Remove reposts from the Replies tab

### DIFF
--- a/src/state/preferences/feed-tuners.tsx
+++ b/src/state/preferences/feed-tuners.tsx
@@ -12,6 +12,12 @@ export function useFeedTuners(feedDesc: FeedDescriptor) {
   const {currentAccount} = useSession()
 
   return useMemo(() => {
+    if (feedDesc.startsWith('author')) {
+      if (feedDesc.endsWith('|posts_with_replies')) {
+        // TODO: Do this on the server instead.
+        return [FeedTuner.removeReposts]
+      }
+    }
     if (feedDesc.startsWith('feedgen')) {
       return [
         FeedTuner.dedupReposts,


### PR DESCRIPTION
## Why

See [here](https://bsky.app/profile/retr0.id/post/3kvwayynkxj2v). Generally "Replies" is expected to show only original content. This is easy to do on the client so I'll just filter it out locally but IMO we should change it on the backend in the future.

## Before

![Screenshot 2024-06-27 at 17 41 46](https://github.com/bluesky-social/social-app/assets/810438/84b0f2ed-7a6e-4843-b383-150adab65b1c)

## After

![Screenshot 2024-06-27 at 17 41 34](https://github.com/bluesky-social/social-app/assets/810438/6f4534e8-f140-4537-a205-9294eb5fad3e)
