### PR TITLE
Fix pasting images on web

### DIFF
--- a/src/view/com/composer/text-input/TextInput.web.tsx
+++ b/src/view/com/composer/text-input/TextInput.web.tsx
@@ -152,23 +152,22 @@ export const TextInput = React.forwardRef(function TextInputImpl(
         },
         handlePaste: (view, event) => {
           const clipboardData = event.clipboardData
+          let preventDefault = false
 
           if (clipboardData) {
             if (clipboardData.types.includes('text/html')) {
               // Rich-text formatting is pasted, try retrieving plain text
               const text = clipboardData.getData('text/plain')
-
               // `pasteText` will invoke this handler again, but `clipboardData` will be null.
               view.pasteText(text)
-
+              preventDefault = true
+            }
+            getImageFromUri(clipboardData.items, (uri: string) => {
+              textInputWebEmitter.emit('photo-pasted', uri)
+            })
+            if (preventDefault) {
               // Return `true` to prevent ProseMirror's default paste behavior.
               return true
-            } else {
-              // Otherwise, try retrieving images from the clipboard
-
-              getImageFromUri(clipboardData.items, (uri: string) => {
-                textInputWebEmitter.emit('photo-pasted', uri)
-              })
             }
           }
         },


### PR DESCRIPTION
Fixes https://github.com/bluesky-social/social-app/issues/4656.

This regressed in https://github.com/bluesky-social/social-app/pull/4327. Copying an image _does_ include `text/html` so the fix is to do both the `text/html` condition _and_ to run the code below searching for images.

## Test Plan

Copied an image, tried pasting it in Chrome, Safari, and FF. It works after the fix.

I haven't verified whether #4327 itself regressed (for Edge) but I don't see why it would. We're still taking plain text for the main paste, we just happen to _also_ look for images now. So it's probably fine.