### PR TITLE
Unify label pills

### DIFF
--- a/src/components/Pills.tsx
+++ b/src/components/Pills.tsx
@@ -126,6 +126,7 @@ export function Label({
                 a.font_semibold,
                 a.leading_tight,
                 t.atoms.text_contrast_medium,
+                {paddingRight: 3},
               ]}>
               {desc.name}
             </Text>

--- a/src/components/Pills.tsx
+++ b/src/components/Pills.tsx
@@ -1,0 +1,165 @@
+import React from 'react'
+import {View} from 'react-native'
+import {BSKY_LABELER_DID, ModerationCause} from '@atproto/api'
+import {Trans} from '@lingui/macro'
+
+import {useModerationCauseDescription} from '#/lib/moderation/useModerationCauseDescription'
+import {UserAvatar} from '#/view/com/util/UserAvatar'
+import {atoms as a, useTheme, ViewStyleProp} from '#/alf'
+import {Button} from '#/components/Button'
+import {
+  ModerationDetailsDialog,
+  useModerationDetailsDialogControl,
+} from '#/components/moderation/ModerationDetailsDialog'
+import {Text} from '#/components/Typography'
+
+export type CommonProps = {
+  size?: 'sm' | 'lg'
+}
+
+export function Row({
+  children,
+  style,
+  size = 'sm',
+}: {children: React.ReactNode | React.ReactNode[]} & CommonProps &
+  ViewStyleProp) {
+  const styles = React.useMemo(() => {
+    switch (size) {
+      case 'sm':
+        return [{gap: 3, marginLeft: -3}]
+      case 'lg':
+        return [{gap: 5}]
+    }
+  }, [size])
+  return (
+    <View style={[a.flex_row, a.flex_wrap, a.gap_xs, styles, style]}>
+      {children}
+    </View>
+  )
+}
+
+export type LabelProps = {
+  cause: ModerationCause
+  disableDetailsDialog?: boolean
+  noBg?: boolean
+} & CommonProps
+
+export function Label({
+  cause,
+  size = 'sm',
+  disableDetailsDialog,
+  noBg,
+}: LabelProps) {
+  const t = useTheme()
+  const control = useModerationDetailsDialogControl()
+  const desc = useModerationCauseDescription(cause)
+  const isLabeler = Boolean(desc.sourceType && desc.sourceDid)
+  const isBlueskyLabel =
+    desc.sourceType === 'labeler' && desc.sourceDid === BSKY_LABELER_DID
+
+  const {outer, avi, text} = React.useMemo(() => {
+    switch (size) {
+      case 'sm': {
+        return {
+          outer: [
+            !noBg && t.atoms.bg_contrast_25,
+            {
+              gap: 3,
+              paddingHorizontal: 3,
+              paddingVertical: 3,
+            },
+          ],
+          avi: 12,
+          text: [a.text_xs],
+        }
+      }
+      case 'lg': {
+        return {
+          outer: [
+            t.atoms.bg_contrast_25,
+            {
+              gap: 5,
+              paddingHorizontal: 5,
+              paddingVertical: 5,
+            },
+          ],
+          avi: 16,
+          text: [a.text_sm],
+        }
+      }
+    }
+  }, [t, size, noBg])
+
+  return (
+    <>
+      <Button
+        disabled={disableDetailsDialog}
+        label={desc.name}
+        onPress={e => {
+          e.preventDefault()
+          e.stopPropagation()
+          control.open()
+        }}>
+        {({hovered, pressed}) => (
+          <View
+            style={[
+              a.flex_row,
+              a.align_center,
+              a.rounded_full,
+              outer,
+              (hovered || pressed) && t.atoms.bg_contrast_50,
+            ]}>
+            {isBlueskyLabel || !isLabeler ? (
+              <desc.icon
+                width={avi}
+                fill={t.atoms.text_contrast_medium.color}
+              />
+            ) : (
+              <UserAvatar avatar={desc.sourceAvi} size={avi} />
+            )}
+
+            <Text
+              style={[
+                text,
+                a.font_semibold,
+                a.leading_tight,
+                t.atoms.text_contrast_medium,
+              ]}>
+              {desc.name}
+            </Text>
+          </View>
+        )}
+      </Button>
+
+      {!disableDetailsDialog && (
+        <ModerationDetailsDialog control={control} modcause={cause} />
+      )}
+    </>
+  )
+}
+
+export function FollowsYou({size = 'sm'}: CommonProps) {
+  const t = useTheme()
+
+  const variantStyles = React.useMemo(() => {
+    switch (size) {
+      case 'sm':
+      case 'lg':
+        return [
+          {
+            paddingHorizontal: 6,
+            paddingVertical: 3,
+            borderRadius: 4,
+          },
+        ]
+    }
+  }, [size])
+
+  return (
+    <View style={[variantStyles, a.justify_center, t.atoms.bg_contrast_25]}>
+      <Text style={[a.text_xs, a.leading_tight]}>
+        <Trans>Follows You</Trans>
+      </Text>
+    </View>
+  )
+}

--- a/src/components/Pills.tsx
+++ b/src/components/Pills.tsx
@@ -25,10 +25,11 @@ export function Row({
   ViewStyleProp) {
   const styles = React.useMemo(() => {
     switch (size) {
-      case 'sm':
-        return [{gap: 3, marginLeft: -3}]
       case 'lg':
         return [{gap: 5}]
+      case 'sm':
+      default:
+        return [{gap: 3, marginLeft: -3}]
     }
   }, [size])
   return (
@@ -59,20 +60,6 @@ export function Label({
 
   const {outer, avi, text} = React.useMemo(() => {
     switch (size) {
-      case 'sm': {
-        return {
-          outer: [
-            !noBg && t.atoms.bg_contrast_25,
-            {
-              gap: 3,
-              paddingHorizontal: 3,
-              paddingVertical: 3,
-            },
-          ],
-          avi: 12,
-          text: [a.text_xs],
-        }
-      }
       case 'lg': {
         return {
           outer: [
@@ -85,6 +72,21 @@ export function Label({
           ],
           avi: 16,
           text: [a.text_sm],
+        }
+      }
+      case 'sm':
+      default: {
+        return {
+          outer: [
+            !noBg && t.atoms.bg_contrast_25,
+            {
+              gap: 3,
+              paddingHorizontal: 3,
+              paddingVertical: 3,
+            },
+          ],
+          avi: 12,
+          text: [a.text_xs],
         }
       }
     }
@@ -145,6 +147,7 @@ export function FollowsYou({size = 'sm'}: CommonProps) {
     switch (size) {
       case 'sm':
       case 'lg':
+      default:
         return [
           {
             paddingHorizontal: 6,

--- a/src/components/Pills.tsx
+++ b/src/components/Pills.tsx
@@ -29,7 +29,7 @@ export function Row({
         return [{gap: 5}]
       case 'sm':
       default:
-        return [{gap: 3, marginLeft: -3}]
+        return [{gap: 3}]
     }
   }, [size])
   return (

--- a/src/components/ProfileHoverCard/index.web.tsx
+++ b/src/components/ProfileHoverCard/index.web.tsx
@@ -29,10 +29,10 @@ import {
 } from '#/components/KnownFollowers'
 import {InlineLinkText, Link} from '#/components/Link'
 import {Loader} from '#/components/Loader'
+import * as Pills from '#/components/Pills'
 import {Portal} from '#/components/Portal'
 import {RichText} from '#/components/RichText'
 import {Text} from '#/components/Typography'
-import {ProfileLabel} from '../moderation/ProfileHeaderAlerts'
 import {ProfileHoverCardProps} from './types'
 
 const floatingMiddlewares = [
@@ -476,8 +476,9 @@ function Inner({
       {isBlockedUser && (
         <View style={[a.flex_row, a.flex_wrap, a.gap_xs]}>
           {moderation.ui('profileView').alerts.map(cause => (
-            <ProfileLabel
+            <Pills.Label
               key={getModerationCauseKey(cause)}
+              size="lg"
               cause={cause}
               disableDetailsDialog
             />

--- a/src/components/dms/MessagesListHeader.tsx
+++ b/src/components/dms/MessagesListHeader.tsx
@@ -214,7 +214,7 @@ function HeaderReady({
         ]}>
         <PostAlerts
           modui={moderation.ui('contentList')}
-          size="large"
+          size="lg"
           style={[a.pt_xs]}
         />
       </View>

--- a/src/components/moderation/ContentHider.tsx
+++ b/src/components/moderation/ContentHider.tsx
@@ -165,9 +165,7 @@ export function ContentHider({
 }
 
 const styles = StyleSheet.create({
-  outer: {
-    overflow: 'hidden',
-  },
+  outer: {},
   cover: {
     flexDirection: 'row',
     alignItems: 'center',

--- a/src/components/moderation/PostAlerts.tsx
+++ b/src/components/moderation/PostAlerts.tsx
@@ -1,25 +1,17 @@
 import React from 'react'
-import {StyleProp, View, ViewStyle} from 'react-native'
-import {BSKY_LABELER_DID, ModerationCause, ModerationUI} from '@atproto/api'
+import {StyleProp, ViewStyle} from 'react-native'
+import {ModerationUI} from '@atproto/api'
 
 import {getModerationCauseKey} from '#/lib/moderation'
-import {useModerationCauseDescription} from '#/lib/moderation/useModerationCauseDescription'
-import {UserAvatar} from '#/view/com/util/UserAvatar'
-import {atoms as a, useTheme} from '#/alf'
-import {Button} from '#/components/Button'
-import {
-  ModerationDetailsDialog,
-  useModerationDetailsDialogControl,
-} from '#/components/moderation/ModerationDetailsDialog'
-import {Text} from '#/components/Typography'
+import * as Pills from '#/components/Pills'
 
 export function PostAlerts({
   modui,
-  size,
+  size = 'sm',
   style,
 }: {
   modui: ModerationUI
-  size?: 'medium' | 'large'
+  size?: Pills.CommonProps['size']
   includeMute?: boolean
   style?: StyleProp<ViewStyle>
 }) {
@@ -28,90 +20,23 @@ export function PostAlerts({
   }
 
   return (
-    <View style={[a.flex_col, a.gap_xs, style]}>
-      <View style={[a.flex_row, a.flex_wrap, a.gap_xs]}>
-        {modui.alerts.map(cause => (
-          <PostLabel
-            key={getModerationCauseKey(cause)}
-            cause={cause}
-            size={size}
-          />
-        ))}
-        {modui.informs.map(cause => (
-          <PostLabel
-            key={getModerationCauseKey(cause)}
-            cause={cause}
-            size={size}
-          />
-        ))}
-      </View>
-    </View>
-  )
-}
-
-function PostLabel({
-  cause,
-  size,
-}: {
-  cause: ModerationCause
-  size?: 'medium' | 'large'
-}) {
-  const control = useModerationDetailsDialogControl()
-  const desc = useModerationCauseDescription(cause)
-  const t = useTheme()
-
-  return (
-    <>
-      <Button
-        label={desc.name}
-        onPress={e => {
-          e.preventDefault()
-          e.stopPropagation()
-          control.open()
-        }}>
-        {({hovered, pressed}) => (
-          <View
-            style={[
-              a.flex_row,
-              a.align_center,
-              a.gap_xs,
-              a.rounded_sm,
-              hovered || pressed
-                ? size === 'large'
-                  ? t.atoms.bg_contrast_50
-                  : t.atoms.bg_contrast_25
-                : size === 'large'
-                ? t.atoms.bg_contrast_25
-                : undefined,
-              size === 'large'
-                ? {paddingLeft: 4, paddingRight: 6, paddingVertical: 2}
-                : {paddingRight: 4, paddingVertical: 1},
-            ]}>
-            {desc.sourceType === 'labeler' &&
-            desc.sourceDid !== BSKY_LABELER_DID ? (
-              <UserAvatar
-                avatar={desc.sourceAvi}
-                size={size === 'large' ? 16 : 12}
-                type="labeler"
-                shape="circle"
-              />
-            ) : (
-              <desc.icon size="sm" fill={t.atoms.text_contrast_medium.color} />
-            )}
-            <Text
-              style={[
-                a.text_left,
-                a.leading_snug,
-                size === 'large' ? {fontSize: 13} : a.text_xs,
-                size === 'large' ? t.atoms.text : t.atoms.text_contrast_high,
-              ]}>
-              {desc.name}
-            </Text>
-          </View>
-        )}
-      </Button>
-
-      <ModerationDetailsDialog control={control} modcause={cause} />
-    </>
+    <Pills.Row size={size} style={style}>
+      {modui.alerts.map(cause => (
+        <Pills.Label
+          key={getModerationCauseKey(cause)}
+          cause={cause}
+          size={size}
+          noBg={size === 'sm'}
+        />
+      ))}
+      {modui.informs.map(cause => (
+        <Pills.Label
+          key={getModerationCauseKey(cause)}
+          cause={cause}
+          size={size}
+          noBg={size === 'sm'}
+        />
+      ))}
+    </Pills.Row>
   )
 }

--- a/src/components/moderation/PostAlerts.tsx
+++ b/src/components/moderation/PostAlerts.tsx
@@ -20,7 +20,7 @@ export function PostAlerts({
   }
 
   return (
-    <Pills.Row size={size} style={style}>
+    <Pills.Row size={size} style={[size === 'sm' && {marginLeft: -3}, style]}>
       {modui.alerts.map(cause => (
         <Pills.Label
           key={getModerationCauseKey(cause)}

--- a/src/components/moderation/ProfileHeaderAlerts.tsx
+++ b/src/components/moderation/ProfileHeaderAlerts.tsx
@@ -1,25 +1,12 @@
 import React from 'react'
-import {StyleProp, View, ViewStyle} from 'react-native'
-import {
-  BSKY_LABELER_DID,
-  ModerationCause,
-  ModerationDecision,
-} from '@atproto/api'
+import {StyleProp, ViewStyle} from 'react-native'
+import {ModerationDecision} from '@atproto/api'
 
-import {useModerationCauseDescription} from '#/lib/moderation/useModerationCauseDescription'
 import {getModerationCauseKey} from 'lib/moderation'
-import {UserAvatar} from '#/view/com/util/UserAvatar'
-import {atoms as a, useTheme} from '#/alf'
-import {Button} from '#/components/Button'
-import {
-  ModerationDetailsDialog,
-  useModerationDetailsDialogControl,
-} from '#/components/moderation/ModerationDetailsDialog'
-import {Text} from '#/components/Typography'
+import * as Pills from '#/components/Pills'
 
 export function ProfileHeaderAlerts({
   moderation,
-  style,
 }: {
   moderation: ModerationDecision
   style?: StyleProp<ViewStyle>
@@ -30,73 +17,21 @@ export function ProfileHeaderAlerts({
   }
 
   return (
-    <View style={[a.flex_col, a.gap_xs, style]}>
-      <View style={[a.flex_row, a.flex_wrap, a.gap_xs]}>
-        {modui.alerts.map(cause => (
-          <ProfileLabel key={getModerationCauseKey(cause)} cause={cause} />
-        ))}
-        {modui.informs.map(cause => (
-          <ProfileLabel key={getModerationCauseKey(cause)} cause={cause} />
-        ))}
-      </View>
-    </View>
-  )
-}
-
-export function ProfileLabel({
-  cause,
-  disableDetailsDialog,
-}: {
-  cause: ModerationCause
-  disableDetailsDialog?: boolean
-}) {
-  const t = useTheme()
-  const control = useModerationDetailsDialogControl()
-  const desc = useModerationCauseDescription(cause)
-
-  return (
-    <>
-      <Button
-        disabled={disableDetailsDialog}
-        label={desc.name}
-        onPress={() => {
-          control.open()
-        }}>
-        {({hovered, pressed}) => (
-          <View
-            style={[
-              a.flex_row,
-              a.align_center,
-              {paddingLeft: 6, paddingRight: 8, paddingVertical: 4},
-              a.gap_xs,
-              a.rounded_md,
-              hovered || pressed
-                ? t.atoms.bg_contrast_50
-                : t.atoms.bg_contrast_25,
-            ]}>
-            {desc.sourceType === 'labeler' &&
-            desc.sourceDid !== BSKY_LABELER_DID ? (
-              <UserAvatar avatar={desc.sourceAvi} size={16} />
-            ) : (
-              <desc.icon size="sm" fill={t.atoms.text_contrast_medium.color} />
-            )}
-            <Text
-              style={[
-                a.text_left,
-                a.leading_snug,
-                a.text_sm,
-                t.atoms.text_contrast_medium,
-                a.font_semibold,
-              ]}>
-              {desc.name}
-            </Text>
-          </View>
-        )}
-      </Button>
-
-      {!disableDetailsDialog && (
-        <ModerationDetailsDialog control={control} modcause={cause} />
-      )}
-    </>
+    <Pills.Row size="lg">
+      {modui.alerts.map(cause => (
+        <Pills.Label
+          size="lg"
+          key={getModerationCauseKey(cause)}
+          cause={cause}
+        />
+      ))}
+      {modui.informs.map(cause => (
+        <Pills.Label
+          size="lg"
+          key={getModerationCauseKey(cause)}
+          cause={cause}
+        />
+      ))}
+    </Pills.Row>
   )
 }

--- a/src/screens/Messages/List/ChatListItem.tsx
+++ b/src/screens/Messages/List/ChatListItem.tsx
@@ -315,7 +315,7 @@ function ChatListItemReady({
 
               <PostAlerts
                 modui={moderation.ui('contentList')}
-                size="large"
+                size="lg"
                 style={[a.pt_xs]}
               />
             </View>

--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -313,7 +313,7 @@ let PostThreadItemLoaded = ({
               childContainerStyle={styles.contentHiderChild}>
               <PostAlerts
                 modui={moderation.ui('contentView')}
-                size="large"
+                size="lg"
                 includeMute
                 style={[a.pt_2xs, a.pb_sm]}
               />

--- a/src/view/com/profile/ProfileCard.tsx
+++ b/src/view/com/profile/ProfileCard.tsx
@@ -3,13 +3,11 @@ import {StyleProp, StyleSheet, View, ViewStyle} from 'react-native'
 import {
   AppBskyActorDefs,
   moderateProfile,
-  ModerationCause,
   ModerationDecision,
 } from '@atproto/api'
 import {Trans} from '@lingui/macro'
 import {useQueryClient} from '@tanstack/react-query'
 
-import {useModerationCauseDescription} from '#/lib/moderation/useModerationCauseDescription'
 import {useProfileShadow} from '#/state/cache/profile-shadow'
 import {Shadow} from '#/state/cache/types'
 import {useModerationOpts} from '#/state/preferences/moderation-opts'
@@ -26,6 +24,8 @@ import {Text} from '../util/text/Text'
 import {PreviewableUserAvatar} from '../util/UserAvatar'
 import {FollowButton} from './FollowButton'
 import hairlineWidth = StyleSheet.hairlineWidth
+import {atoms as a} from '#/alf'
+import * as Pills from '#/components/Pills'
 
 export function ProfileCard({
   testID,
@@ -137,58 +137,21 @@ export function ProfileCardPills({
   followedBy: boolean
   moderation: ModerationDecision
 }) {
-  const pal = usePalette('default')
-
   const modui = moderation.ui('profileList')
   if (!followedBy && !modui.inform && !modui.alert) {
     return null
   }
 
   return (
-    <View style={styles.pills}>
-      {followedBy && (
-        <View style={[s.mt5, pal.btn, styles.pill]}>
-          <Text type="xs" style={pal.text}>
-            <Trans>Follows You</Trans>
-          </Text>
-        </View>
-      )}
+    <Pills.Row style={[a.pt_xs]}>
+      {followedBy && <Pills.FollowsYou />}
       {modui.alerts.map(alert => (
-        <ProfileCardPillModerationCause
-          key={getModerationCauseKey(alert)}
-          cause={alert}
-          severity="alert"
-        />
+        <Pills.Label key={getModerationCauseKey(alert)} cause={alert} />
       ))}
       {modui.informs.map(inform => (
-        <ProfileCardPillModerationCause
-          key={getModerationCauseKey(inform)}
-          cause={inform}
-          severity="inform"
-        />
+        <Pills.Label key={getModerationCauseKey(inform)} cause={inform} />
       ))}
-    </View>
-  )
-}
-
-function ProfileCardPillModerationCause({
-  cause,
-  severity,
-}: {
-  cause: ModerationCause
-  severity: 'alert' | 'inform'
-}) {
-  const pal = usePalette('default')
-  const {name} = useModerationCauseDescription(cause)
-  return (
-    <View
-      style={[s.mt5, pal.btn, styles.pill]}
-      key={getModerationCauseKey(cause)}>
-      <Text type="xs" style={pal.text}>
-        {severity === 'alert' ? '⚠ ' : ''}
-        {name}
-      </Text>
-    </View>
+    </Pills.Row>
   )
 }
 
@@ -322,6 +285,7 @@ const styles = StyleSheet.create({
     paddingBottom: 10,
   },
   pills: {
+    alignItems: 'flex-start',
     flexDirection: 'row',
     flexWrap: 'wrap',
     columnGap: 6,


### PR DESCRIPTION
We have 4 variations of labels in the app right now: profiles, post thread small/large, and one in the old ProfileCard. 

This PR copies the pill component from `PostAlerts` and consolidates styles to `sm` and `lg`, which almost exactly match what's in prod, and where they don't, try to strike a happy medium. This way, labels are presented and handled consistently throughout the app.

**Testing**
See screenshots for locations, and here's a good thread to use: http://localhost:19006/profile/darthbluesky.bsky.social/post/3kutuafqadc2k

All screenshots are after -> before

### Hover detail on small pills
![CleanShot 2024-07-02 at 13 48 50@2x](https://github.com/bluesky-social/social-app/assets/4732330/b5a7d1d3-7f5f-434d-8645-32ff65c3c091)
![CleanShot 2024-07-02 at 13 48 38@2x](https://github.com/bluesky-social/social-app/assets/4732330/053c22ae-bd4b-4fe4-9d39-ca269e90800e)

### PostAlerts
#### Quote embeds
![CleanShot 2024-07-02 at 13 32 53@2x](https://github.com/bluesky-social/social-app/assets/4732330/ffe52305-201f-4e7d-95d1-2f1a82ecb12b)
![CleanShot 2024-07-02 at 13 34 04@2x](https://github.com/bluesky-social/social-app/assets/4732330/5b8f5d8f-2942-45d8-9ea8-43d573e8eea7)

#### Notifications
![CleanShot 2024-07-02 at 13 34 48@2x](https://github.com/bluesky-social/social-app/assets/4732330/1b7cdbae-fa53-43c2-bfc4-58e57140c765)
![CleanShot 2024-07-02 at 13 34 57@2x](https://github.com/bluesky-social/social-app/assets/4732330/35f1c46e-a883-4eac-bae7-48a37d3e8bd6)

#### Feeds
![CleanShot 2024-07-02 at 13 36 04@2x](https://github.com/bluesky-social/social-app/assets/4732330/2e448208-669e-4d09-a2c3-e2ac14abc82c)
![CleanShot 2024-07-02 at 13 36 16@2x](https://github.com/bluesky-social/social-app/assets/4732330/df55d4ab-3e7a-4227-8edd-78996f3d86d9)

#### Threads
![CleanShot 2024-07-02 at 13 37 18@2x](https://github.com/bluesky-social/social-app/assets/4732330/0869d3cf-3c20-4043-b1a4-c101f502bf58)
![CleanShot 2024-07-02 at 13 37 12@2x](https://github.com/bluesky-social/social-app/assets/4732330/9949af24-6857-425c-9dee-1c72d295b5c9)

#### Chat list items
![CleanShot 2024-07-02 at 13 38 12@2x](https://github.com/bluesky-social/social-app/assets/4732330/060387df-5986-4438-aab3-65c66b63c296)
![CleanShot 2024-07-02 at 13 38 33@2x](https://github.com/bluesky-social/social-app/assets/4732330/308d7c90-4e32-4c43-ab9d-c2e4259c3b94)

#### Chat header
![CleanShot 2024-07-02 at 13 39 08@2x](https://github.com/bluesky-social/social-app/assets/4732330/225dab79-a4cf-4680-bf6b-429d9bb8c7c5)
![CleanShot 2024-07-02 at 13 39 16@2x](https://github.com/bluesky-social/social-app/assets/4732330/48757cb9-d870-4fbb-8ea2-b27e5e50dc7c)

#### Chat message embed
![CleanShot 2024-07-02 at 13 39 49@2x](https://github.com/bluesky-social/social-app/assets/4732330/faec3a35-6d3f-4356-906a-e422499dcecc)
![CleanShot 2024-07-02 at 13 40 00@2x](https://github.com/bluesky-social/social-app/assets/4732330/a15b04e9-e1e1-478b-a4a0-516af9dddc31)

### ProfileHeaderAlerts
![CleanShot 2024-07-02 at 13 40 42@2x](https://github.com/bluesky-social/social-app/assets/4732330/57280288-fcea-4b86-bfc1-eaa0f82c4f50)
![CleanShot 2024-07-02 at 13 40 51@2x](https://github.com/bluesky-social/social-app/assets/4732330/8ad8538e-b313-47f2-8639-cfad388dcb39)

### Hover card
![CleanShot 2024-07-02 at 13 41 51@2x](https://github.com/bluesky-social/social-app/assets/4732330/b09b56c7-5569-479b-8a23-f26409ab697d)
![CleanShot 2024-07-02 at 13 42 07@2x](https://github.com/bluesky-social/social-app/assets/4732330/8d35ec97-340e-4bfd-b71e-18bd64e42224)

### Old profile card
![CleanShot 2024-07-02 at 13 43 18@2x](https://github.com/bluesky-social/social-app/assets/4732330/98c84893-e225-4d62-8f34-b110c2ac7084)
![CleanShot 2024-07-02 at 13 43 28@2x](https://github.com/bluesky-social/social-app/assets/4732330/fd84944d-469a-41a3-963c-7d8c9ebde903)

### New profile card
![CleanShot 2024-07-02 at 13 46 57@2x](https://github.com/bluesky-social/social-app/assets/4732330/394eae14-97d4-4a91-b19d-04569e784bd5)
![CleanShot 2024-07-02 at 13 47 05@2x](https://github.com/bluesky-social/social-app/assets/4732330/f333f37b-299e-4093-b7a0-7fdc385f52ca)
