### PR TITLE
Handle pressing all go.bsky.app links in-app w/ resolution

### DIFF
--- a/src/Navigation.tsx
+++ b/src/Navigation.tsx
@@ -325,12 +325,12 @@ function commonScreens(Stack: typeof HomeTab, unreadCountLabel?: string) {
       <Stack.Screen
         name="StarterPack"
         getComponent={() => StarterPackScreen}
-        options={{title: title(msg`Starter Pack`), requireAuth: true}}
+        options={{title: title(msg`Starter Pack`)}}
       />
       <Stack.Screen
         name="StarterPackShort"
         getComponent={() => StarterPackScreenShort}
-        options={{title: title(msg`Starter Pack`), requireAuth: true}}
+        options={{title: title(msg`Starter Pack`)}}
       />
       <Stack.Screen
         name="StarterPackWizard"

--- a/src/Navigation.tsx
+++ b/src/Navigation.tsx
@@ -43,7 +43,10 @@ import HashtagScreen from '#/screens/Hashtag'
 import {ModerationScreen} from '#/screens/Moderation'
 import {ProfileKnownFollowersScreen} from '#/screens/Profile/KnownFollowers'
 import {ProfileLabelerLikedByScreen} from '#/screens/Profile/ProfileLabelerLikedBy'
-import {StarterPackScreen} from '#/screens/StarterPack/StarterPackScreen'
+import {
+  StarterPackScreen,
+  StarterPackScreenShort,
+} from '#/screens/StarterPack/StarterPackScreen'
 import {Wizard} from '#/screens/StarterPack/Wizard'
 import {init as initAnalytics} from './lib/analytics/analytics'
 import {useWebScrollRestoration} from './lib/hooks/useWebScrollRestoration'
@@ -322,6 +325,11 @@ function commonScreens(Stack: typeof HomeTab, unreadCountLabel?: string) {
       <Stack.Screen
         name="StarterPack"
         getComponent={() => StarterPackScreen}
+        options={{title: title(msg`Starter Pack`), requireAuth: true}}
+      />
+      <Stack.Screen
+        name="StarterPackShort"
+        getComponent={() => StarterPackScreenShort}
         options={{title: title(msg`Starter Pack`), requireAuth: true}}
       />
       <Stack.Screen

--- a/src/lib/link-meta/resolve-short-link.ts
+++ b/src/lib/link-meta/resolve-short-link.ts
@@ -1,19 +1,23 @@
 import {logger} from '#/logger'
-import {startUriToStarterPackUri} from 'lib/strings/starter-pack'
 
 export async function resolveShortLink(shortLink: string) {
   const controller = new AbortController()
   const to = setTimeout(() => controller.abort(), 2e3)
 
   try {
-    const res = await fetch(shortLink, {
+    const res = await fetch(`${shortLink}`, {
       method: 'GET',
+      headers: {
+        contentType: 'application/json',
+      },
       signal: controller.signal,
     })
     if (res.status !== 200) {
+      logger.error('Failed to resolve short link', {status: res.status})
       return shortLink
     }
-    return startUriToStarterPackUri(res.url)
+    const json = (await res.json()) as {url: string}
+    return json.url
   } catch (e: unknown) {
     logger.error('Failed to resolve short link', {safeMessage: e})
     return null

--- a/src/lib/link-meta/resolve-short-link.ts
+++ b/src/lib/link-meta/resolve-short-link.ts
@@ -20,7 +20,7 @@ export async function resolveShortLink(shortLink: string) {
     return json.url
   } catch (e: unknown) {
     logger.error('Failed to resolve short link', {safeMessage: e})
-    return null
+    return shortLink
   } finally {
     clearTimeout(to)
   }

--- a/src/lib/link-meta/resolve-short-link.ts
+++ b/src/lib/link-meta/resolve-short-link.ts
@@ -8,7 +8,7 @@ export async function resolveShortLink(shortLink: string) {
     const res = await fetch(`${shortLink}`, {
       method: 'GET',
       headers: {
-        contentType: 'application/json',
+        Accept: 'application/json',
       },
       signal: controller.signal,
     })

--- a/src/lib/link-meta/resolve-short-link.ts
+++ b/src/lib/link-meta/resolve-short-link.ts
@@ -5,7 +5,7 @@ export async function resolveShortLink(shortLink: string) {
   const to = setTimeout(() => controller.abort(), 2e3)
 
   try {
-    const res = await fetch(`${shortLink}`, {
+    const res = await fetch(shortLink, {
       method: 'GET',
       headers: {
         Accept: 'application/json',

--- a/src/lib/routes/types.ts
+++ b/src/lib/routes/types.ts
@@ -44,6 +44,7 @@ export type CommonNavigatorParams = {
   Feeds: undefined
   Start: {name: string; rkey: string}
   StarterPack: {name: string; rkey: string; new?: boolean}
+  StarterPackShort: {code: string}
   StarterPackWizard: undefined
   StarterPackEdit: {
     rkey?: string
@@ -101,6 +102,7 @@ export type AllNavigatorParams = CommonNavigatorParams & {
   Messages: {animation?: 'push' | 'pop'}
   Start: {name: string; rkey: string}
   StarterPack: {name: string; rkey: string; new?: boolean}
+  StarterPackShort: {code: string}
   StarterPackWizard: undefined
   StarterPackEdit: {
     rkey?: string

--- a/src/lib/strings/url-helpers.ts
+++ b/src/lib/strings/url-helpers.ts
@@ -5,7 +5,6 @@ import TLDs from 'tlds'
 import {logger} from '#/logger'
 import {BSKY_SERVICE} from 'lib/constants'
 import {isInvalidHandle} from 'lib/strings/handles'
-import {isWeb} from 'platform/detection'
 
 export const BSKY_APP_HOST = 'https://bsky.app'
 const BSKY_TRUSTED_HOSTS = [
@@ -168,7 +167,7 @@ export function convertBskyAppUrlIfNeeded(url: string): string {
     } catch (e) {
       console.error('Unexpected error in convertBskyAppUrlIfNeeded()', e)
     }
-  } else if (!isWeb && isShortLink(url)) {
+  } else if (isShortLink(url)) {
     // We only want to do this on native, web handles the 301 for us
     return shortLinkToHref(url)
   }

--- a/src/lib/strings/url-helpers.ts
+++ b/src/lib/strings/url-helpers.ts
@@ -167,6 +167,8 @@ export function convertBskyAppUrlIfNeeded(url: string): string {
     } catch (e) {
       console.error('Unexpected error in convertBskyAppUrlIfNeeded()', e)
     }
+  } else if (isShortLink(url)) {
+    return shortLinkToHref(url)
   }
   return url
 }
@@ -288,11 +290,21 @@ export function createBskyAppAbsoluteUrl(path: string): string {
 }
 
 export function isShortLink(url: string): boolean {
+  return url.startsWith('https://go.bsky.app/')
+}
+
+export function shortLinkToHref(url: string): string {
   try {
     const urlp = new URL(url)
-    return urlp.host === 'go.bsky.app'
+
+    // For now we only support starter packs, but in the future we should add additional paths to this check
+    const parts = urlp.pathname.split('/').filter(Boolean)
+    if (parts.length === 1) {
+      return `/starter-pack/short-${parts[0]}`
+    }
+    return url
   } catch (e) {
     logger.error('Failed to parse possible short link', {safeMessage: e})
-    return false
+    return url
   }
 }

--- a/src/lib/strings/url-helpers.ts
+++ b/src/lib/strings/url-helpers.ts
@@ -5,6 +5,7 @@ import TLDs from 'tlds'
 import {logger} from '#/logger'
 import {BSKY_SERVICE} from 'lib/constants'
 import {isInvalidHandle} from 'lib/strings/handles'
+import {isWeb} from 'platform/detection'
 
 export const BSKY_APP_HOST = 'https://bsky.app'
 const BSKY_TRUSTED_HOSTS = [
@@ -167,7 +168,8 @@ export function convertBskyAppUrlIfNeeded(url: string): string {
     } catch (e) {
       console.error('Unexpected error in convertBskyAppUrlIfNeeded()', e)
     }
-  } else if (isShortLink(url)) {
+  } else if (!isWeb && isShortLink(url)) {
+    // We only want to do this on native, web handles the 301 for us
     return shortLinkToHref(url)
   }
   return url
@@ -300,7 +302,7 @@ export function shortLinkToHref(url: string): string {
     // For now we only support starter packs, but in the future we should add additional paths to this check
     const parts = urlp.pathname.split('/').filter(Boolean)
     if (parts.length === 1) {
-      return `/starter-pack/short-${parts[0]}`
+      return `/starter-pack-short/${parts[0]}`
     }
     return url
   } catch (e) {

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -43,6 +43,6 @@ export const router = new Router({
   MessagesConversation: '/messages/:conversation',
   Start: '/start/:name/:rkey',
   StarterPackEdit: '/starter-pack/edit/:rkey',
-  StarterPack: '/starter-pack/:name/:rkey',
+  StarterPack: ['/starter-pack/:name/:rkey', '/starter-pack/:name'],
   StarterPackWizard: '/starter-pack/create',
 })

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -43,6 +43,7 @@ export const router = new Router({
   MessagesConversation: '/messages/:conversation',
   Start: '/start/:name/:rkey',
   StarterPackEdit: '/starter-pack/edit/:rkey',
-  StarterPack: ['/starter-pack/:name/:rkey', '/starter-pack/:name'],
+  StarterPack: ['/starter-pack/:name/:rkey'],
+  StarterPackShort: ['/starter-pack-short/:code'],
   StarterPackWizard: '/starter-pack/create',
 })

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -43,7 +43,7 @@ export const router = new Router({
   MessagesConversation: '/messages/:conversation',
   Start: '/start/:name/:rkey',
   StarterPackEdit: '/starter-pack/edit/:rkey',
-  StarterPack: ['/starter-pack/:name/:rkey'],
-  StarterPackShort: ['/starter-pack-short/:code'],
+  StarterPack: '/starter-pack/:name/:rkey',
+  StarterPackShort: '/starter-pack-short/:code',
   StarterPackWizard: '/starter-pack/create',
 })

--- a/src/screens/StarterPack/StarterPackLandingScreen.tsx
+++ b/src/screens/StarterPack/StarterPackLandingScreen.tsx
@@ -115,9 +115,6 @@ function LandingScreenLoaded({
   const listItemsCount = starterPack.list?.listItemCount ?? 0
 
   const onContinue = () => {
-    setActiveStarterPack({
-      uri: starterPack.uri,
-    })
     setScreenState(LoggedOutScreenState.S_CreateAccount)
   }
 

--- a/src/screens/StarterPack/StarterPackLandingScreen.tsx
+++ b/src/screens/StarterPack/StarterPackLandingScreen.tsx
@@ -19,7 +19,6 @@ import {createStarterPackGooglePlayUri} from 'lib/strings/starter-pack'
 import {isWeb} from 'platform/detection'
 import {useModerationOpts} from 'state/preferences/moderation-opts'
 import {useStarterPackQuery} from 'state/queries/starter-packs'
-import {useLoggedOutViewControls} from 'state/shell/logged-out'
 import {
   useActiveStarterPack,
   useSetActiveStarterPack,
@@ -110,7 +109,6 @@ function LandingScreenLoaded({
   const activeStarterPack = useActiveStarterPack()
   const setActiveStarterPack = useSetActiveStarterPack()
   const {isTabletOrDesktop} = useWebMediaQueries()
-  const {setShowLoggedOut} = useLoggedOutViewControls()
   const androidDialogControl = useDialogControl()
 
   const [appClipOverlayVisible, setAppClipOverlayVisible] =
@@ -185,10 +183,7 @@ function LandingScreenLoaded({
               },
             ]}
             onPress={() => {
-              // Reset the entire state
               setActiveStarterPack(undefined)
-              setScreenState(LoggedOutScreenState.S_LoginOrCreateAccount)
-              setShowLoggedOut(false)
             }}
             accessibilityLabel={_(msg`Back`)}
             accessibilityHint={_(msg`Go back to previous screen`)}>

--- a/src/screens/StarterPack/StarterPackLandingScreen.tsx
+++ b/src/screens/StarterPack/StarterPackLandingScreen.tsx
@@ -19,6 +19,7 @@ import {createStarterPackGooglePlayUri} from 'lib/strings/starter-pack'
 import {isWeb} from 'platform/detection'
 import {useModerationOpts} from 'state/preferences/moderation-opts'
 import {useStarterPackQuery} from 'state/queries/starter-packs'
+import {useLoggedOutViewControls} from 'state/shell/logged-out'
 import {
   useActiveStarterPack,
   useSetActiveStarterPack,
@@ -31,6 +32,7 @@ import {atoms as a, useTheme} from '#/alf'
 import {Button, ButtonText} from '#/components/Button'
 import {useDialogControl} from '#/components/Dialog'
 import * as FeedCard from '#/components/FeedCard'
+import {ChevronLeft_Stroke2_Corner0_Rounded} from '#/components/icons/Chevron'
 import {LinearGradientBackground} from '#/components/LinearGradientBackground'
 import {ListMaybePlaceholder} from '#/components/Lists'
 import {Default as ProfileCard} from '#/components/ProfileCard'
@@ -104,6 +106,7 @@ function LandingScreenLoaded({
   const activeStarterPack = useActiveStarterPack()
   const setActiveStarterPack = useSetActiveStarterPack()
   const {isTabletOrDesktop} = useWebMediaQueries()
+  const {setShowLoggedOut} = useLoggedOutViewControls()
   const androidDialogControl = useDialogControl()
 
   const [appClipOverlayVisible, setAppClipOverlayVisible] =
@@ -166,6 +169,34 @@ function LandingScreenLoaded({
               paddingTop: 100,
             },
           ]}>
+          <Pressable
+            style={[
+              a.absolute,
+              a.rounded_full,
+              a.align_center,
+              a.justify_center,
+              {
+                top: 10,
+                left: 10,
+                height: 35,
+                width: 35,
+                backgroundColor: 'rgba(0, 0, 0, 0.5)',
+              },
+            ]}
+            onPress={() => {
+              // Reset the entire state
+              setActiveStarterPack(undefined)
+              setScreenState(LoggedOutScreenState.S_LoginOrCreateAccount)
+              setShowLoggedOut(false)
+            }}
+            accessibilityLabel={_(msg`Back`)}
+            accessibilityHint={_(msg`Go back to previous screen`)}>
+            <ChevronLeft_Stroke2_Corner0_Rounded
+              width={20}
+              height={20}
+              fill="white"
+            />
+          </Pressable>
           <View style={[a.flex_row, a.gap_md, a.pb_sm]}>
             <Logo width={76} fill="white" />
           </View>

--- a/src/screens/StarterPack/StarterPackLandingScreen.tsx
+++ b/src/screens/StarterPack/StarterPackLandingScreen.tsx
@@ -60,7 +60,11 @@ export function LandingScreen({
   const moderationOpts = useModerationOpts()
   const activeStarterPack = useActiveStarterPack()
 
-  const {data: starterPack, isError: isErrorStarterPack} = useStarterPackQuery({
+  const {
+    data: starterPack,
+    isError: isErrorStarterPack,
+    isFetching,
+  } = useStarterPackQuery({
     uri: activeStarterPack?.uri,
   })
 
@@ -76,7 +80,7 @@ export function LandingScreen({
     }
   }, [isErrorStarterPack, setScreenState, isValid, starterPack])
 
-  if (!starterPack || !isValid || !moderationOpts) {
+  if (isFetching || !starterPack || !isValid || !moderationOpts) {
     return <ListMaybePlaceholder isLoading={true} />
   }
 

--- a/src/screens/StarterPack/StarterPackScreen.tsx
+++ b/src/screens/StarterPack/StarterPackScreen.tsx
@@ -125,6 +125,7 @@ export function StarterPackAuthCheck({
     setActiveStarterPack({
       uri,
     })
+
     navigation.goBack()
   }, [routeParams, currentAccount, navigation, setActiveStarterPack])
 

--- a/src/screens/StarterPack/StarterPackScreen.tsx
+++ b/src/screens/StarterPack/StarterPackScreen.tsx
@@ -120,6 +120,7 @@ export function StarterPackAuthCheck({
       did: routeParams.name,
       rkey: routeParams.rkey,
     })
+
     if (!uri) return
     setActiveStarterPack({
       uri,

--- a/src/screens/StarterPack/StarterPackScreen.tsx
+++ b/src/screens/StarterPack/StarterPackScreen.tsx
@@ -68,30 +68,36 @@ type StarterPackScreeProps = NativeStackScreenProps<
   CommonNavigatorParams,
   'StarterPack'
 >
+type StarterPackScreenShortProps = NativeStackScreenProps<
+  CommonNavigatorParams,
+  'StarterPackShort'
+>
 
 export function StarterPackScreen({route}: StarterPackScreeProps) {
+  return <StarterPackScreenInner routeParams={route.params} />
+}
+
+export function StarterPackScreenShort({route}: StarterPackScreenShortProps) {
   const {_} = useLingui()
   const {
     data: resolvedStarterPack,
     isLoading,
     isError,
   } = useResolvedStarterPackShortLink({
-    nameOrCode: route.params.name,
+    code: route.params.code,
   })
-  const params = resolvedStarterPack ?? route.params
 
-  if (isLoading || isError) {
+  if (isLoading || isError || !resolvedStarterPack) {
     return (
       <ListMaybePlaceholder
-        isLoading={true}
+        isLoading={isLoading}
         isError={isError}
         errorMessage={_(msg`That starter pack could not be found.`)}
         emptyMessage={_(msg`That starter pack could not be found.`)}
       />
     )
   }
-
-  return <StarterPackScreenInner routeParams={params} />
+  return <StarterPackScreenInner routeParams={resolvedStarterPack} />
 }
 
 export function StarterPackScreenInner({

--- a/src/state/queries/resolve-short-link.ts
+++ b/src/state/queries/resolve-short-link.ts
@@ -9,21 +9,16 @@ const ROOT_URI = 'https://go.bsky.app/'
 const RQKEY_ROOT = 'resolved-short-link'
 export const RQKEY = (code: string) => [RQKEY_ROOT, code]
 
-export function useResolvedStarterPackShortLink({
-  nameOrCode,
-}: {
-  nameOrCode: string
-}) {
+export function useResolvedStarterPackShortLink({code}: {code: string}) {
   return useQuery({
-    queryKey: RQKEY(nameOrCode),
+    queryKey: RQKEY(code),
     queryFn: async () => {
-      const code = nameOrCode.split('short-')[1]
       const uri = `${ROOT_URI}${code}`
       const res = await resolveShortLink(uri)
       return parseStarterPackUri(res)
     },
     retry: 1,
-    enabled: Boolean(nameOrCode && nameOrCode.startsWith('short-')),
+    enabled: Boolean(code),
     staleTime: STALE.HOURS.ONE,
   })
 }

--- a/src/state/queries/resolve-short-link.ts
+++ b/src/state/queries/resolve-short-link.ts
@@ -1,0 +1,29 @@
+import {useQuery} from '@tanstack/react-query'
+
+import {resolveShortLink} from 'lib/link-meta/resolve-short-link'
+import {parseStarterPackUri} from 'lib/strings/starter-pack'
+import {STALE} from 'state/queries/index'
+
+const ROOT_URI = 'https://go.bsky.app/'
+
+const RQKEY_ROOT = 'resolved-short-link'
+export const RQKEY = (code: string) => [RQKEY_ROOT, code]
+
+export function useResolvedStarterPackShortLink({
+  nameOrCode,
+}: {
+  nameOrCode: string
+}) {
+  return useQuery({
+    queryKey: RQKEY(nameOrCode),
+    queryFn: async () => {
+      const code = nameOrCode.split('short-')[1]
+      const uri = `${ROOT_URI}${code}`
+      const res = await resolveShortLink(uri)
+      return parseStarterPackUri(res)
+    },
+    retry: 1,
+    enabled: Boolean(nameOrCode && nameOrCode.startsWith('short-')),
+    staleTime: STALE.HOURS.ONE,
+  })
+}

--- a/src/state/shell/logged-out.tsx
+++ b/src/state/shell/logged-out.tsx
@@ -60,15 +60,16 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
       : undefined,
   })
 
-  React.useEffect(() => {
-    if (activeStarterPack) {
-      setState(s => ({
-        ...s,
-        showLoggedOut: true,
-        requestedAccountSwitchTo: 'starterpack',
-      }))
-    }
-  }, [activeStarterPack])
+  const [prevActiveStarterPack, setPrevActiveStarterPack] =
+    React.useState(activeStarterPack)
+  if (activeStarterPack?.uri !== prevActiveStarterPack?.uri) {
+    setPrevActiveStarterPack(activeStarterPack)
+    setState(s => ({
+      ...s,
+      showLoggedOut: true,
+      requestedAccountSwitchTo: 'starterpack',
+    }))
+  }
 
   const controls = React.useMemo<Controls>(
     () => ({

--- a/src/state/shell/logged-out.tsx
+++ b/src/state/shell/logged-out.tsx
@@ -50,6 +50,7 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
   const activeStarterPack = useActiveStarterPack()
   const {hasSession} = useSession()
   const shouldShowStarterPack = Boolean(activeStarterPack?.uri) && !hasSession
+
   const [state, setState] = React.useState<State>({
     showLoggedOut: shouldShowStarterPack,
     requestedAccountSwitchTo: shouldShowStarterPack
@@ -58,6 +59,16 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
         : 'new'
       : undefined,
   })
+
+  React.useEffect(() => {
+    if (activeStarterPack) {
+      setState(s => ({
+        ...s,
+        showLoggedOut: true,
+        requestedAccountSwitchTo: 'starterpack',
+      }))
+    }
+  }, [activeStarterPack])
 
   const controls = React.useMemo<Controls>(
     () => ({

--- a/src/state/shell/logged-out.tsx
+++ b/src/state/shell/logged-out.tsx
@@ -64,11 +64,19 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
     React.useState(activeStarterPack)
   if (activeStarterPack?.uri !== prevActiveStarterPack?.uri) {
     setPrevActiveStarterPack(activeStarterPack)
-    setState(s => ({
-      ...s,
-      showLoggedOut: true,
-      requestedAccountSwitchTo: 'starterpack',
-    }))
+    if (activeStarterPack) {
+      setState(s => ({
+        ...s,
+        showLoggedOut: true,
+        requestedAccountSwitchTo: 'starterpack',
+      }))
+    } else {
+      setState(s => ({
+        ...s,
+        showLoggedOut: false,
+        requestedAccountSwitchTo: undefined,
+      }))
+    }
   }
 
   const controls = React.useMemo<Controls>(


### PR DESCRIPTION
## Why

We want to be able to resolve any short links in the app, even if they don't get resolved while posting. This is a little challenging because we have to reach out to `go.bsky.app` first. I added JSON response support in https://github.com/bluesky-social/social-app/pull/4671, which we can now use to perform resolution when landing on these.

## How

1. First, we click on a link in the app. We already check for if links start with `bsky.app` but we don't check `go.bsky.app` which we add here.
2. We then push to the `StarterPackScreenShort` route
3. The short route attempts to resolve the real URI and then render the starter pack screen with the resolved did and rkey

The nice thing here is this is extensible to other schemes whenever we want to. For example, post short links - which we are less worried about being _very_ short - could use `/p/123456` and we could create a resolve query for those types of links.

## Test Plan

![RocketSim_Recording___RNIDE_TEMP_SIM_com apple CoreSimulator SimDeviceType iPhone-15-Pro_6 1_2024-06-27_12 43 20](https://github.com/bluesky-social/social-app/assets/153161762/15edb076-7d74-4721-80b7-7af9b552d3a7)
