### PR TITLE
Add starter pack embeds to posts

### DIFF
--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -1,5 +1,10 @@
 import React from 'react'
-import {GestureResponderEvent} from 'react-native'
+import {
+  GestureResponderEvent,
+  Pressable,
+  StyleProp,
+  ViewStyle,
+} from 'react-native'
 import {sanitizeUrl} from '@braintree/sanitize-url'
 import {StackActions, useLinkProps} from '@react-navigation/native'
 
@@ -321,5 +326,40 @@ export function InlineLinkText({
       })}>
       {children}
     </Text>
+  )
+}
+
+/**
+ * A Pressable that uses useLink to handle navigation. It is unstyled, so can be used in cases where the Button styles
+ * in Link are not desired.
+ * @param displayText
+ * @param style
+ * @param children
+ * @param rest
+ * @constructor
+ */
+export function BaseLink({
+  displayText,
+  style,
+  children,
+  ...rest
+}: {
+  style?: StyleProp<ViewStyle>
+  children: React.ReactNode
+  to: string
+  action: 'push' | 'replace' | 'navigate'
+  onPress?: () => false | void
+  shareOnLongPress?: boolean
+  label: string
+  displayText?: string
+}) {
+  const btnProps = useLink({
+    displayText: displayText ?? rest.to,
+    ...rest,
+  })
+  return (
+    <Pressable style={style} {...btnProps}>
+      {children}
+    </Pressable>
   )
 }

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -340,6 +340,7 @@ export function InlineLinkText({
  */
 export function BaseLink({
   displayText,
+  onPress: onPressOuter,
   style,
   children,
   ...rest
@@ -353,12 +354,18 @@ export function BaseLink({
   label: string
   displayText?: string
 }) {
-  const btnProps = useLink({
+  const {onPress, ...btnProps} = useLink({
     displayText: displayText ?? rest.to,
     ...rest,
   })
   return (
-    <Pressable style={style} {...btnProps}>
+    <Pressable
+      style={style}
+      onPress={e => {
+        onPressOuter?.()
+        onPress(e)
+      }}
+      {...btnProps}>
       {children}
     </Pressable>
   )

--- a/src/components/StarterPack/Main/ProfilesList.tsx
+++ b/src/components/StarterPack/Main/ProfilesList.tsx
@@ -10,10 +10,12 @@ import {InfiniteData, UseInfiniteQueryResult} from '@tanstack/react-query'
 
 import {useBottomBarOffset} from 'lib/hooks/useBottomBarOffset'
 import {isNative, isWeb} from 'platform/detection'
+import {useListMembersQuery} from 'state/queries/list-members'
 import {useSession} from 'state/session'
 import {List, ListRef} from 'view/com/util/List'
 import {SectionRef} from '#/screens/Profile/Sections/types'
 import {atoms as a, useTheme} from '#/alf'
+import {ListMaybePlaceholder} from '#/components/Lists'
 import {Default as ProfileCard} from '#/components/ProfileCard'
 
 function keyExtractor(item: AppBskyActorDefs.ProfileViewBasic, index: number) {
@@ -32,17 +34,16 @@ interface ProfilesListProps {
 
 export const ProfilesList = React.forwardRef<SectionRef, ProfilesListProps>(
   function ProfilesListImpl(
-    {listUri, listMembersQuery, moderationOpts, headerHeight, scrollElRef},
+    {listUri, moderationOpts, headerHeight, scrollElRef},
     ref,
   ) {
     const t = useTheme()
     const [initialHeaderHeight] = React.useState(headerHeight)
     const bottomBarOffset = useBottomBarOffset(20)
     const {currentAccount} = useSession()
+    const {data, refetch, isError} = useListMembersQuery(listUri, 50)
 
     const [isPTRing, setIsPTRing] = React.useState(false)
-
-    const {data, refetch} = listMembersQuery
 
     // The server returns these sorted by descending creation date, so we want to invert
     const profiles = data?.pages
@@ -95,7 +96,19 @@ export const ProfilesList = React.forwardRef<SectionRef, ProfilesListProps>(
       )
     }
 
-    if (listMembersQuery)
+    if (!data) {
+      return (
+        <View style={{marginTop: headerHeight, marginBottom: bottomBarOffset}}>
+          <ListMaybePlaceholder
+            isLoading={true}
+            isError={isError}
+            onRetry={refetch}
+          />
+        </View>
+      )
+    }
+
+    if (data)
       return (
         <List
           data={getSortedProfiles()}

--- a/src/components/StarterPack/StarterPackCard.tsx
+++ b/src/components/StarterPack/StarterPackCard.tsx
@@ -136,6 +136,7 @@ export function Embed({starterPack}: {starterPack: StarterPackViewBasic}) {
   return (
     <View
       style={[
+        a.mt_xs,
         a.border,
         a.rounded_sm,
         a.overflow_hidden,

--- a/src/components/StarterPack/StarterPackCard.tsx
+++ b/src/components/StarterPack/StarterPackCard.tsx
@@ -1,18 +1,17 @@
 import React from 'react'
-import {Pressable, View} from 'react-native'
+import {View} from 'react-native'
 import {Image} from 'expo-image'
 import {AppBskyGraphStarterpack, AtUri} from '@atproto/api'
 import {StarterPackViewBasic} from '@atproto/api/dist/client/types/app/bsky/graph/defs'
 import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
-import {useNavigation} from '@react-navigation/native'
 
-import {NavigationProp} from 'lib/routes/types'
 import {sanitizeHandle} from 'lib/strings/handles'
 import {getStarterPackOgCard} from 'lib/strings/starter-pack'
 import {useSession} from 'state/session'
 import {atoms as a, useTheme} from '#/alf'
 import {StarterPack} from '#/components/icons/StarterPack'
+import {BaseLink} from '#/components/Link'
 import {Text} from '#/components/Typography'
 
 export function Default({starterPack}: {starterPack?: StarterPackViewBasic}) {
@@ -90,14 +89,13 @@ export function Card({
 
 export function Link({
   starterPack,
-  onPress,
   children,
 }: {
   starterPack: StarterPackViewBasic
   onPress?: () => void
   children: React.ReactNode
 }) {
-  const navigation = useNavigation<NavigationProp>()
+  const {_} = useLingui()
   const {record} = starterPack
   const {rkey, handleOrDid} = React.useMemo(() => {
     const rkey = new AtUri(starterPack.uri).rkey
@@ -110,17 +108,12 @@ export function Link({
   }
 
   return (
-    <Pressable
-      accessibilityRole="button"
-      onPress={() => {
-        onPress?.()
-        navigation.navigate('StarterPack', {
-          name: handleOrDid,
-          rkey,
-        })
-      }}>
+    <BaseLink
+      action="push"
+      to={`/starter-pack/${handleOrDid}/${rkey}`}
+      label={_(msg`Navigate to ${record.name}`)}>
       {children}
-    </Pressable>
+    </BaseLink>
   )
 }
 

--- a/src/components/StarterPack/StarterPackCard.tsx
+++ b/src/components/StarterPack/StarterPackCard.tsx
@@ -5,9 +5,12 @@ import {AppBskyGraphStarterpack, AtUri} from '@atproto/api'
 import {StarterPackViewBasic} from '@atproto/api/dist/client/types/app/bsky/graph/defs'
 import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
+import {useQueryClient} from '@tanstack/react-query'
 
 import {sanitizeHandle} from 'lib/strings/handles'
 import {getStarterPackOgCard} from 'lib/strings/starter-pack'
+import {precacheResolvedUri} from 'state/queries/resolve-uri'
+import {precacheStarterPack} from 'state/queries/starter-packs'
 import {useSession} from 'state/session'
 import {atoms as a, useTheme} from '#/alf'
 import {StarterPack} from '#/components/icons/StarterPack'
@@ -96,6 +99,7 @@ export function Link({
   children: React.ReactNode
 }) {
   const {_} = useLingui()
+  const queryClient = useQueryClient()
   const {record} = starterPack
   const {rkey, handleOrDid} = React.useMemo(() => {
     const rkey = new AtUri(starterPack.uri).rkey
@@ -111,7 +115,15 @@ export function Link({
     <BaseLink
       action="push"
       to={`/starter-pack/${handleOrDid}/${rkey}`}
-      label={_(msg`Navigate to ${record.name}`)}>
+      label={_(msg`Navigate to ${record.name}`)}
+      onPress={() => {
+        precacheResolvedUri(
+          queryClient,
+          starterPack.creator.handle,
+          starterPack.creator.did,
+        )
+        precacheStarterPack(queryClient, starterPack)
+      }}>
       {children}
     </BaseLink>
   )

--- a/src/lib/link-meta/bsky.ts
+++ b/src/lib/link-meta/bsky.ts
@@ -192,7 +192,7 @@ export async function getStarterPackAsEmbed(
     )
   }
   const did = await fetchDid(parsed.name)
-  const starterPack = createStarterPackUri({did, rkey: parsed.rkey})!
+  const starterPack = createStarterPackUri({did, rkey: parsed.rkey})
   const res = await agent.app.bsky.graph.getStarterPack({starterPack})
   const record = res.data.starterPack.record
   return {

--- a/src/lib/link-meta/bsky.ts
+++ b/src/lib/link-meta/bsky.ts
@@ -1,11 +1,16 @@
-import {AppBskyFeedPost, BskyAgent} from '@atproto/api'
+import {AppBskyFeedPost, AppBskyGraphStarterpack, BskyAgent} from '@atproto/api'
+
+import {useFetchDid} from '#/state/queries/handle'
+import {useGetPost} from '#/state/queries/post'
 import * as apilib from 'lib/api/index'
-import {LikelyType, LinkMeta} from './link-meta'
+import {
+  createStarterPackUri,
+  parseStarterPackUri,
+} from 'lib/strings/starter-pack'
+import {ComposerOptsQuote} from 'state/shell/composer'
 // import {match as matchRoute} from 'view/routes'
 import {convertBskyAppUrlIfNeeded, makeRecordUri} from '../strings/url-helpers'
-import {ComposerOptsQuote} from 'state/shell/composer'
-import {useGetPost} from '#/state/queries/post'
-import {useFetchDid} from '#/state/queries/handle'
+import {LikelyType, LinkMeta} from './link-meta'
 
 // TODO
 // import {Home} from 'view/screens/Home'
@@ -170,6 +175,42 @@ export async function getListAsEmbed(
       record: {
         uri: res.data.list.uri,
         cid: res.data.list.cid,
+      },
+    },
+  }
+}
+
+export async function getStarterPackAsEmbed(
+  agent: BskyAgent,
+  fetchDid: ReturnType<typeof useFetchDid>,
+  url: string,
+): Promise<apilib.ExternalEmbedDraft> {
+  const parsed = parseStarterPackUri(url)
+  if (!parsed) {
+    throw new Error(
+      'Unexepectedly called getStarterPackAsEmbed with a non-starterpack url',
+    )
+  }
+  const did = await fetchDid(parsed.name)
+  const starterPack = createStarterPackUri({did, rkey: parsed.rkey})!
+  const res = await agent.app.bsky.graph.getStarterPack({starterPack})
+  const record = res.data.starterPack.record
+  return {
+    isLoading: false,
+    uri: starterPack,
+    meta: {
+      url: starterPack,
+      likelyType: LikelyType.AtpData,
+      // Validation here should never fail
+      title: AppBskyGraphStarterpack.isRecord(record)
+        ? record.name
+        : 'Starter Pack',
+    },
+    embed: {
+      $type: 'app.bsky.embed.record',
+      record: {
+        uri: res.data.starterPack.uri,
+        cid: res.data.starterPack.cid,
       },
     },
   }

--- a/src/lib/strings/starter-pack.ts
+++ b/src/lib/strings/starter-pack.ts
@@ -96,7 +96,7 @@ export function createStarterPackUri({
 }: {
   did: string
   rkey: string
-}): string | null {
+}): string {
   return new AtUri(`at://${did}/app.bsky.graph.starterpack/${rkey}`).toString()
 }
 

--- a/src/lib/strings/url-helpers.ts
+++ b/src/lib/strings/url-helpers.ts
@@ -152,6 +152,30 @@ export function isBskyListUrl(url: string): boolean {
   return false
 }
 
+export function isBskyStartUrl(url: string): boolean {
+  if (isBskyAppUrl(url)) {
+    try {
+      const urlp = new URL(url)
+      return /start\/(?<name>[^/]+)\/(?<rkey>[^/]+)/i.test(urlp.pathname)
+    } catch {
+      console.error('Unexpected error in isBskyStartUrl()', url)
+    }
+  }
+  return false
+}
+
+export function isBskyStarterPackUrl(url: string): boolean {
+  if (isBskyAppUrl(url)) {
+    try {
+      const urlp = new URL(url)
+      return /starter-pack\/(?<name>[^/]+)\/(?<rkey>[^/]+)/i.test(urlp.pathname)
+    } catch {
+      console.error('Unexpected error in isBskyStartUrl()', url)
+    }
+  }
+  return false
+}
+
 export function isBskyDownloadUrl(url: string): boolean {
   if (isExternalUrl(url)) {
     return false

--- a/src/screens/StarterPack/StarterPackScreen.tsx
+++ b/src/screens/StarterPack/StarterPackScreen.tsx
@@ -3,7 +3,6 @@ import {View} from 'react-native'
 import {Image} from 'expo-image'
 import {
   AppBskyGraphDefs,
-  AppBskyGraphGetList,
   AppBskyGraphStarterpack,
   AtUri,
   ModerationOpts,
@@ -14,11 +13,7 @@ import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 import {useNavigation} from '@react-navigation/native'
 import {NativeStackScreenProps} from '@react-navigation/native-stack'
-import {
-  InfiniteData,
-  UseInfiniteQueryResult,
-  useQueryClient,
-} from '@tanstack/react-query'
+import {useQueryClient} from '@tanstack/react-query'
 
 import {cleanError} from '#/lib/strings/errors'
 import {logger} from '#/logger'
@@ -32,7 +27,6 @@ import {getStarterPackOgCard} from 'lib/strings/starter-pack'
 import {isWeb} from 'platform/detection'
 import {updateProfileShadow} from 'state/cache/profile-shadow'
 import {useModerationOpts} from 'state/preferences/moderation-opts'
-import {useListMembersQuery} from 'state/queries/list-members'
 import {useResolvedStarterPackShortLink} from 'state/queries/resolve-short-link'
 import {useResolveDidQuery} from 'state/queries/resolve-uri'
 import {useShortenLink} from 'state/queries/shorten-link'
@@ -122,7 +116,6 @@ export function StarterPackScreenInner({
     isLoading: isLoadingStarterPack,
     isError: isErrorStarterPack,
   } = useStarterPackQuery({did, rkey})
-  const listMembersQuery = useListMembersQuery(starterPack?.list?.uri, 50)
 
   const isValid =
     starterPack &&
@@ -133,12 +126,7 @@ export function StarterPackScreenInner({
   if (!did || !starterPack || !isValid || !moderationOpts) {
     return (
       <ListMaybePlaceholder
-        isLoading={
-          isLoadingDid ||
-          isLoadingStarterPack ||
-          listMembersQuery.isLoading ||
-          !moderationOpts
-        }
+        isLoading={isLoadingDid || isLoadingStarterPack || !moderationOpts}
         isError={isErrorDid || isErrorStarterPack || !isValid}
         errorMessage={_(msg`That starter pack could not be found.`)}
         emptyMessage={_(msg`That starter pack could not be found.`)}
@@ -154,7 +142,6 @@ export function StarterPackScreenInner({
     <StarterPackScreenLoaded
       starterPack={starterPack}
       routeParams={routeParams}
-      listMembersQuery={listMembersQuery}
       moderationOpts={moderationOpts}
     />
   )
@@ -163,14 +150,10 @@ export function StarterPackScreenInner({
 function StarterPackScreenLoaded({
   starterPack,
   routeParams,
-  listMembersQuery,
   moderationOpts,
 }: {
   starterPack: AppBskyGraphDefs.StarterPackView
   routeParams: StarterPackScreeProps['route']['params']
-  listMembersQuery: UseInfiniteQueryResult<
-    InfiniteData<AppBskyGraphGetList.OutputSchema>
-  >
   moderationOpts: ModerationOpts
 }) {
   const showPeopleTab = Boolean(starterPack.list)
@@ -240,7 +223,6 @@ function StarterPackScreenLoaded({
                   headerHeight={headerHeight}
                   // @ts-expect-error
                   scrollElRef={scrollElRef}
-                  listMembersQuery={listMembersQuery}
                   moderationOpts={moderationOpts}
                 />
               )

--- a/src/screens/StarterPack/Wizard/index.tsx
+++ b/src/screens/StarterPack/Wizard/index.tsx
@@ -561,7 +561,7 @@ function Footer({
         ) : (
           <View style={{width: 70, height: 35}} />
         )}
-        {state.currentStep === 'Profiles' && items.length < 8 ? (
+        {state.currentStep === 'Profiles' && items.length < 2 ? (
           <>
             <Text
               style={[a.font_bold, textStyles, t.atoms.text_contrast_medium]}>

--- a/src/screens/StarterPack/Wizard/index.tsx
+++ b/src/screens/StarterPack/Wizard/index.tsx
@@ -561,7 +561,7 @@ function Footer({
         ) : (
           <View style={{width: 70, height: 35}} />
         )}
-        {state.currentStep === 'Profiles' && items.length < 2 ? (
+        {state.currentStep === 'Profiles' && items.length < 8 ? (
           <>
             <Text
               style={[a.font_bold, textStyles, t.atoms.text_contrast_medium]}>

--- a/src/state/queries/starter-packs.ts
+++ b/src/state/queries/starter-packs.ts
@@ -39,11 +39,6 @@ const RQKEY = ({
   did?: string
   rkey?: string
 }) => {
-  console.log({
-    uri,
-    did,
-    rkey,
-  })
   if (uri?.startsWith('https://') || uri?.startsWith('at://')) {
     const parsed = parseStarterPackUri(uri)
     return [RQKEY_ROOT, parsed?.name, parsed?.rkey]

--- a/src/state/queries/starter-packs.ts
+++ b/src/state/queries/starter-packs.ts
@@ -364,6 +364,7 @@ export async function precacheStarterPack(
   } else if (AppBskyGraphDefs.isStarterPackViewBasic(starterPack)) {
     const listView: AppBskyGraphDefs.ListViewBasic = {
       uri: starterPack.record.list,
+      // This will be populated once the data from server is fetched
       cid: '',
       name: starterPack.record.name,
       purpose: 'app.bsky.graph.defs#referencelist',

--- a/src/view/com/composer/useExternalLinkFetch.ts
+++ b/src/view/com/composer/useExternalLinkFetch.ts
@@ -10,6 +10,7 @@ import {
   getFeedAsEmbed,
   getListAsEmbed,
   getPostAsQuote,
+  getStarterPackAsEmbed,
 } from 'lib/link-meta/bsky'
 import {getLinkMeta} from 'lib/link-meta/link-meta'
 import {resolveShortLink} from 'lib/link-meta/resolve-short-link'
@@ -18,6 +19,8 @@ import {
   isBskyCustomFeedUrl,
   isBskyListUrl,
   isBskyPostUrl,
+  isBskyStarterPackUrl,
+  isBskyStartUrl,
   isShortLink,
 } from 'lib/strings/url-helpers'
 import {ImageModel} from 'state/models/media/image'
@@ -94,6 +97,23 @@ export function useExternalLinkFetch({
           err => {
             logger.error('Failed to fetch list for embedding', {message: err})
             setExtLink(undefined)
+          },
+        )
+      } else if (
+        isBskyStartUrl(extLink.uri) ||
+        isBskyStarterPackUrl(extLink.uri)
+      ) {
+        getStarterPackAsEmbed(agent, fetchDid, extLink.uri).then(
+          ({embed, meta}) => {
+            if (aborted) {
+              return
+            }
+            setExtLink({
+              uri: extLink.uri,
+              isLoading: false,
+              meta,
+              embed,
+            })
           },
         )
       } else if (isShortLink(extLink.uri)) {

--- a/src/view/com/util/post-embeds/index.tsx
+++ b/src/view/com/util/post-embeds/index.tsx
@@ -30,6 +30,7 @@ import {ListEmbed} from './ListEmbed'
 import {MaybeQuoteEmbed} from './QuoteEmbed'
 import hairlineWidth = StyleSheet.hairlineWidth
 import {useLargeAltBadgeEnabled} from '#/state/preferences/large-alt-badge'
+import {Embed as StarterPackCard} from '#/components/StarterPack/StarterPackCard'
 
 type Embed =
   | AppBskyEmbedRecord.View
@@ -88,6 +89,10 @@ export function PostEmbeds({
     if (AppBskyGraphDefs.isListView(embed.record)) {
       // TODO moderation
       return <ListEmbed item={embed.record} />
+    }
+
+    if (AppBskyGraphDefs.isStarterPackViewBasic(embed.record)) {
+      return <StarterPackCard starterPack={embed.record} />
     }
 
     // quote post


### PR DESCRIPTION
Relies on https://github.com/bluesky-social/atproto/pull/2613 being deployed or using dev env from that branch.

Note that these will work with `go.bsky.app` links as well, though those records wouldn't work in the local dev env. Once ^ gets deployed we should just test again to make sure.

## Web

<img width="1190" alt="Screenshot 2024-06-28 at 12 46 41 PM" src="https://github.com/bluesky-social/social-app/assets/153161762/cc8d5d56-fdf7-4450-9b2e-ddfcd150db03">

<img width="1215" alt="Screenshot 2024-06-28 at 12 46 47 PM" src="https://github.com/bluesky-social/social-app/assets/153161762/393f8aca-05fe-4b5d-a33d-ced9a3e2eae8">

## Native

![Screenshot 2024-06-28 at 12 56 24 PM](https://github.com/bluesky-social/social-app/assets/153161762/b6c53de1-d1dc-4b89-8bed-65dd4feb9071)

![Screenshot 2024-06-28 at 12 56 28 PM](https://github.com/bluesky-social/social-app/assets/153161762/7c5b721b-0c91-4cbd-804b-35eef8a05a14)

