### PR TITLE
Add events to signup for captcha results

### DIFF
--- a/src/lib/statsig/events.ts
+++ b/src/lib/statsig/events.ts
@@ -31,6 +31,7 @@ export type LogEvents = {
   'splash:createAccountPressed': {}
   'signup:nextPressed': {
     activeStep: number
+    phoneVerificationRequired?: boolean
   }
   'signup:backPressed': {
     activeStep: number

--- a/src/lib/statsig/events.ts
+++ b/src/lib/statsig/events.ts
@@ -32,6 +32,11 @@ export type LogEvents = {
   'signup:nextPressed': {
     activeStep: number
   }
+  'signup:backPressed': {
+    activeStep: number
+  }
+  'signup:captchaSuccess': {}
+  'signup:captchaFailure': {}
   'onboarding:interests:nextPressed': {
     selectedInterests: string[]
     selectedInterestsLength: number

--- a/src/screens/Signup/StepCaptcha/index.tsx
+++ b/src/screens/Signup/StepCaptcha/index.tsx
@@ -6,6 +6,7 @@ import {nanoid} from 'nanoid/non-secure'
 
 import {createFullHandle} from '#/lib/strings/handles'
 import {logger} from '#/logger'
+import {logEvent} from 'lib/statsig/statsig'
 import {ScreenTransition} from '#/screens/Login/ScreenTransition'
 import {useSignupContext, useSubmitSignup} from '#/screens/Signup/state'
 import {CaptchaWebView} from '#/screens/Signup/StepCaptcha/CaptchaWebView'
@@ -39,6 +40,7 @@ export function StepCaptcha() {
   const onSuccess = React.useCallback(
     (code: string) => {
       setCompleted(true)
+      logEvent('signup:captchaSuccess', {})
       submit(code)
     },
     [submit],
@@ -50,6 +52,7 @@ export function StepCaptcha() {
         type: 'setError',
         value: _(msg`Error receiving captcha response.`),
       })
+      logEvent('signup:captchaFailure', {})
       logger.error('Signup Flow Error', {
         registrationHandle: state.handle,
         error,

--- a/src/screens/Signup/index.tsx
+++ b/src/screens/Signup/index.tsx
@@ -112,6 +112,13 @@ export function Signup({onPressBack}: {onPressBack: () => void}) {
       }
     }
 
+    logEvent('signup:nextPressed', {
+      activeStep: state.activeStep,
+      phoneVerificationRequired: Boolean(
+        state.serviceDescription?.phoneVerificationRequired,
+      ),
+    })
+
     // phoneVerificationRequired is actually whether a captcha is required
     if (
       state.activeStep === SignupStep.HANDLE &&
@@ -120,11 +127,7 @@ export function Signup({onPressBack}: {onPressBack: () => void}) {
       submit()
       return
     }
-
     dispatch({type: 'next'})
-    logEvent('signup:nextPressed', {
-      activeStep: state.activeStep,
-    })
   }, [
     _,
     state.activeStep,

--- a/src/screens/Signup/index.tsx
+++ b/src/screens/Signup/index.tsx
@@ -144,11 +144,13 @@ export function Signup({onPressBack}: {onPressBack: () => void}) {
           registrationHandle: state.handle,
         })
       }
-
       dispatch({type: 'prev'})
     } else {
       onPressBack()
     }
+    logEvent('signup:backPressed', {
+      activeStep: state.activeStep,
+    })
   }, [onPressBack, state.activeStep, state.handle])
 
   return (

--- a/src/screens/Signup/index.tsx
+++ b/src/screens/Signup/index.tsx
@@ -114,9 +114,10 @@ export function Signup({onPressBack}: {onPressBack: () => void}) {
 
     logEvent('signup:nextPressed', {
       activeStep: state.activeStep,
-      phoneVerificationRequired: Boolean(
-        state.serviceDescription?.phoneVerificationRequired,
-      ),
+      phoneVerificationRequired:
+        state.activeStep === SignupStep.HANDLE
+          ? Boolean(state.serviceDescription?.phoneVerificationRequired)
+          : undefined,
     })
 
     // phoneVerificationRequired is actually whether a captcha is required

--- a/src/screens/Signup/index.tsx
+++ b/src/screens/Signup/index.tsx
@@ -115,9 +115,7 @@ export function Signup({onPressBack}: {onPressBack: () => void}) {
     logEvent('signup:nextPressed', {
       activeStep: state.activeStep,
       phoneVerificationRequired:
-        state.activeStep === SignupStep.HANDLE
-          ? Boolean(state.serviceDescription?.phoneVerificationRequired)
-          : undefined,
+        state.serviceDescription?.phoneVerificationRequired,
     })
 
     // phoneVerificationRequired is actually whether a captcha is required


### PR DESCRIPTION
## Why

It would be nice to know whenever people successfully complete the captcha. There's some weird stats that are hard to understand if users are not actually failing captchas - which is the most likely 
reason we're seeing this. It would be good to have confirmation on this though.

## How

Adds a success and failure event that get logged upon completion of the captcha - whether it fails or not.

## Test Plan

Check network tab while stepping through onboarding to ensure events get logged where they should.

![Screenshot 2024-07-01 at 2 25 26 PM](https://github.com/bluesky-social/social-app/assets/153161762/28d2ffae-c7b5-4476-b296-d6840b9752a8)

![Screenshot 2024-07-01 at 2 25 42 PM](https://github.com/bluesky-social/social-app/assets/153161762/7bfb2a86-5850-4523-bc14-503672b91cd6)

![Screenshot 2024-07-01 at 2 29 56 PM](https://github.com/bluesky-social/social-app/assets/153161762/a3c6fa2e-9c13-42c6-882a-d6b9cf65dc13)
