### PR TITLE
Don't follow self when following all

### DIFF
--- a/src/screens/StarterPack/StarterPackScreen.tsx
+++ b/src/screens/StarterPack/StarterPackScreen.tsx
@@ -343,7 +343,11 @@ function Header({
         list: starterPack.list.uri,
       })
       const dids = list.data.items
-        .filter(li => !li.subject.viewer?.following)
+        .filter(
+          li =>
+            li.subject.did !== currentAccount?.did &&
+            !li.subject.viewer?.following,
+        )
         .map(li => li.subject.did)
 
       const followUris = await bulkWriteFollows(agent, dids)


### PR DESCRIPTION
## Why

Simple, just don't follow yourself (still love that you can do this lol) whenever pressing Follow All in a starter pack

## Test Plan

Follow all on a starter pack, see that you no longer follow yourself.
