### PR TITLE
Fix GIFs in DMs

### DIFF
--- a/src/view/com/util/post-embeds/GifEmbed.tsx
+++ b/src/view/com/util/post-embeds/GifEmbed.tsx
@@ -124,15 +124,12 @@ export function GifEmbed({
   )
 
   return (
-    <View
-      style={[a.rounded_sm, a.overflow_hidden, a.mt_sm, {maxWidth: '100%'}]}>
+    <View style={[a.rounded_sm, a.overflow_hidden, a.mt_sm, {width: '100%'}]}>
       <View
         style={[
           a.rounded_sm,
           a.overflow_hidden,
-          {
-            aspectRatio: params.dimensions!.width / params.dimensions!.height,
-          },
+          {aspectRatio: params.dimensions!.width / params.dimensions!.height},
         ]}>
         <PlaybackControls
           onPress={onPress}


### PR DESCRIPTION
Changes `maxWidth: 100%` to `width: 100%`. GIFs are full-width anyway so I don't believe this should cause any issues.

<table>
  <tr>
    <td>Before</td>
    <td>After</td>
  </tr>
  <tr>
    <td><img width="289" alt="Screenshot 2024-07-02 at 16 21 43" src="https://github.com/bluesky-social/social-app/assets/10959775/c567ca80-8871-4538-a9c9-9897b95113bb"></td>
    <td><img width="289" alt="Screenshot 2024-07-02 at 16 21 27" src="https://github.com/bluesky-social/social-app/assets/10959775/b0f375a3-799a-4768-9a22-20a426c980bc"></td>
  </tr>
</table>

## Test plan

Check GIFs still work in other places across the app
