### PR TITLE
Re-add live validation to signup form

### DIFF
--- a/src/screens/Signup/BackNextButtons.tsx
+++ b/src/screens/Signup/BackNextButtons.tsx
@@ -11,6 +11,7 @@ export interface BackNextButtonsProps {
   hideNext?: boolean
   showRetry?: boolean
   isLoading: boolean
+  isNextDisabled?: boolean
   onBackPress: () => void
   onNextPress?: () => void
   onRetryPress?: () => void
@@ -20,6 +21,7 @@ export function BackNextButtons({
   hideNext,
   showRetry,
   isLoading,
+  isNextDisabled,
   onBackPress,
   onNextPress,
   onRetryPress,
@@ -58,7 +60,7 @@ export function BackNextButtons({
             variant="solid"
             color="primary"
             size="medium"
-            disabled={isLoading}
+            disabled={isLoading || isNextDisabled}
             onPress={onNextPress}>
             <ButtonText>
               <Trans>Next</Trans>

--- a/src/screens/Signup/StepHandle.tsx
+++ b/src/screens/Signup/StepHandle.tsx
@@ -4,11 +4,7 @@ import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
 import {logEvent} from '#/lib/statsig/statsig'
-import {
-  createFullHandle,
-  IsValidHandle,
-  validateHandle,
-} from '#/lib/strings/handles'
+import {createFullHandle, validateHandle} from '#/lib/strings/handles'
 import {useAgent} from '#/state/session'
 import {ScreenTransition} from '#/screens/Login/ScreenTransition'
 import {useSignupContext, useSubmitSignup} from '#/screens/Signup/state'
@@ -27,14 +23,7 @@ export function StepHandle() {
   const submit = useSubmitSignup({state, dispatch})
   const agent = useAgent()
   const handleValueRef = useRef<string>(state.handle)
-
-  const [validCheck, setValidCheck] = React.useState<IsValidHandle>({
-    handleChars: false,
-    hyphenStartOrEnd: false,
-    frontLength: false,
-    totalLength: true,
-    overall: false,
-  })
+  const [draftValue, setDraftValue] = React.useState(state.handle)
 
   const onNextPress = React.useCallback(async () => {
     const handle = handleValueRef.current.trim()
@@ -47,7 +36,6 @@ export function StepHandle() {
     })
 
     const newValidCheck = validateHandle(handle, state.userDomain)
-    setValidCheck(newValidCheck)
     if (!newValidCheck.overall) {
       return
     }
@@ -106,6 +94,7 @@ export function StepHandle() {
     })
   }, [dispatch, state.activeStep])
 
+  const validCheck = validateHandle(draftValue, state.userDomain)
   return (
     <ScreenTransition>
       <View style={[a.gap_lg]}>
@@ -114,11 +103,13 @@ export function StepHandle() {
             <TextField.Icon icon={At} />
             <TextField.Input
               testID="handleInput"
-              onChangeText={value => {
-                handleValueRef.current = value
+              onChangeText={val => {
+                // These need to always be in sync.
+                handleValueRef.current = val
+                setDraftValue(val)
               }}
               label={_(msg`Input your user handle`)}
-              defaultValue={state.handle}
+              defaultValue={draftValue}
               autoCapitalize="none"
               autoCorrect={false}
               autoFocus
@@ -129,7 +120,7 @@ export function StepHandle() {
         <Text style={[a.text_md]}>
           <Trans>Your full handle will be</Trans>{' '}
           <Text style={[a.text_md, a.font_bold]}>
-            @{createFullHandle(state.handle, state.userDomain)}
+            @{createFullHandle(draftValue, state.userDomain)}
           </Text>
         </Text>
 

--- a/src/screens/Signup/StepHandle.tsx
+++ b/src/screens/Signup/StepHandle.tsx
@@ -104,6 +104,10 @@ export function StepHandle() {
             <TextField.Input
               testID="handleInput"
               onChangeText={val => {
+                if (state.error) {
+                  dispatch({type: 'setError', value: ''})
+                }
+
                 // These need to always be in sync.
                 handleValueRef.current = val
                 setDraftValue(val)

--- a/src/screens/Signup/StepHandle.tsx
+++ b/src/screens/Signup/StepHandle.tsx
@@ -27,9 +27,6 @@ export function StepHandle() {
 
   const onNextPress = React.useCallback(async () => {
     const handle = handleValueRef.current.trim()
-    if (state.error) {
-      dispatch({type: 'setError', value: ''})
-    }
     dispatch({
       type: 'setHandle',
       value: handle,
@@ -74,7 +71,6 @@ export function StepHandle() {
   }, [
     _,
     dispatch,
-    state.error,
     state.activeStep,
     state.serviceDescription?.phoneVerificationRequired,
     state.userDomain,

--- a/src/screens/Signup/StepHandle.tsx
+++ b/src/screens/Signup/StepHandle.tsx
@@ -117,61 +117,66 @@ export function StepHandle() {
             />
           </TextField.Root>
         </View>
-        <Text style={[a.text_md]}>
-          <Trans>Your full handle will be</Trans>{' '}
-          <Text style={[a.text_md, a.font_bold]}>
-            @{createFullHandle(draftValue, state.userDomain)}
+        {draftValue !== '' && (
+          <Text style={[a.text_md]}>
+            <Trans>Your full handle will be</Trans>{' '}
+            <Text style={[a.text_md, a.font_bold]}>
+              @{createFullHandle(draftValue, state.userDomain)}
+            </Text>
           </Text>
-        </Text>
+        )}
 
-        <View
-          style={[
-            a.w_full,
-            a.rounded_sm,
-            a.border,
-            a.p_md,
-            a.gap_sm,
-            t.atoms.border_contrast_low,
-          ]}>
-          {state.error ? (
-            <View style={[a.w_full, a.flex_row, a.align_center, a.gap_sm]}>
-              <IsValidIcon valid={false} />
-              <Text style={[a.text_md, a.flex_1]}>{state.error}</Text>
-            </View>
-          ) : undefined}
-          {validCheck.hyphenStartOrEnd ? (
-            <View style={[a.w_full, a.flex_row, a.align_center, a.gap_sm]}>
-              <IsValidIcon valid={validCheck.handleChars} />
-              <Text style={[a.text_md, a.flex_1]}>
-                <Trans>Only contains letters, numbers, and hyphens</Trans>
-              </Text>
-            </View>
-          ) : (
-            <View style={[a.w_full, a.flex_row, a.align_center, a.gap_sm]}>
-              <IsValidIcon valid={validCheck.hyphenStartOrEnd} />
-              <Text style={[a.text_md, a.flex_1]}>
-                <Trans>Doesn't begin or end with a hyphen</Trans>
-              </Text>
-            </View>
-          )}
-          <View style={[a.w_full, a.flex_row, a.align_center, a.gap_sm]}>
-            <IsValidIcon
-              valid={validCheck.frontLength && validCheck.totalLength}
-            />
-            {!validCheck.totalLength ? (
-              <Text style={[a.text_md, a.flex_1]}>
-                <Trans>No longer than 253 characters</Trans>
-              </Text>
+        {draftValue !== '' && (
+          <View
+            style={[
+              a.w_full,
+              a.rounded_sm,
+              a.border,
+              a.p_md,
+              a.gap_sm,
+              t.atoms.border_contrast_low,
+            ]}>
+            {state.error ? (
+              <View style={[a.w_full, a.flex_row, a.align_center, a.gap_sm]}>
+                <IsValidIcon valid={false} />
+                <Text style={[a.text_md, a.flex_1]}>{state.error}</Text>
+              </View>
+            ) : undefined}
+            {validCheck.hyphenStartOrEnd ? (
+              <View style={[a.w_full, a.flex_row, a.align_center, a.gap_sm]}>
+                <IsValidIcon valid={validCheck.handleChars} />
+                <Text style={[a.text_md, a.flex_1]}>
+                  <Trans>Only contains letters, numbers, and hyphens</Trans>
+                </Text>
+              </View>
             ) : (
-              <Text style={[a.text_md, a.flex_1]}>
-                <Trans>At least 3 characters</Trans>
-              </Text>
+              <View style={[a.w_full, a.flex_row, a.align_center, a.gap_sm]}>
+                <IsValidIcon valid={validCheck.hyphenStartOrEnd} />
+                <Text style={[a.text_md, a.flex_1]}>
+                  <Trans>Doesn't begin or end with a hyphen</Trans>
+                </Text>
+              </View>
             )}
+            <View style={[a.w_full, a.flex_row, a.align_center, a.gap_sm]}>
+              <IsValidIcon
+                valid={validCheck.frontLength && validCheck.totalLength}
+              />
+              {!validCheck.totalLength ? (
+                <Text style={[a.text_md, a.flex_1]}>
+                  <Trans>No longer than 253 characters</Trans>
+                </Text>
+              ) : (
+                <Text style={[a.text_md, a.flex_1]}>
+                  <Trans>At least 3 characters</Trans>
+                </Text>
+              )}
+            </View>
           </View>
-        </View>
+        )}
       </View>
       <BackNextButtons
         isLoading={state.isLoading}
+        isNextDisabled={!validCheck.overall}
         onBackPress={onBackPress}
         onNextPress={onNextPress}
       />


### PR DESCRIPTION
A few changes to match the old behavior:

- Adds back live validation based on a controlled "draft" local state (the input remains uncontrolled though)
- Adds back clearing of server event on first keystroke (and removes clearing on pressing Next)

Small tweak on top:

- Don't show the validation "errors" and a broken `@.bsky.social` until the user types something

[Review without whitespace](https://github.com/bluesky-social/social-app/pull/4720/files?w=1)

## Test Plan

https://github.com/bluesky-social/social-app/assets/810438/67dcde35-a534-4a49-ba0d-55c108b1cc4d

