### PR TITLE
Remove search from disabled PWI state

### DIFF
--- a/src/view/com/auth/LoggedOut.tsx
+++ b/src/view/com/auth/LoggedOut.tsx
@@ -17,6 +17,7 @@ import {
 } from '#/state/shell/logged-out'
 import {useSetMinimalShellMode} from '#/state/shell/minimal-mode'
 import {NavigationProp} from 'lib/routes/types'
+import {useGate} from 'lib/statsig/statsig'
 import {ErrorBoundary} from '#/view/com/util/ErrorBoundary'
 import {Text} from '#/view/com/util/text/Text'
 import {Login} from '#/screens/Login'
@@ -52,6 +53,7 @@ export function LoggedOut({onDismiss}: {onDismiss?: () => void}) {
   })
   const {clearRequestedAccount} = useLoggedOutViewControls()
   const navigation = useNavigation<NavigationProp>()
+  const gate = useGate()
 
   const isFirstScreen = screenState === ScreenState.S_LoginOrCreateAccount
   React.useEffect(() => {
@@ -96,7 +98,10 @@ export function LoggedOut({onDismiss}: {onDismiss?: () => void}) {
               }}
             />
           </Pressable>
-        ) : isNative && !hasSession && isFirstScreen ? (
+        ) : isNative &&
+          !hasSession &&
+          isFirstScreen &&
+          !gate('native_pwi_disabled') ? (
           <Pressable
             accessibilityHint={_(msg`Search for users`)}
             accessibilityLabel={_(msg`Search for users`)}


### PR DESCRIPTION
If PWI is disabled for this experiment, we need to hide the link to search as well, since those routes are now inaccessible. Tested and confirmed this experiment only applies to native.

![CleanShot 2024-07-02 at 18 57 38@2x](https://github.com/bluesky-social/social-app/assets/4732330/c84bfd3d-6694-4cde-84d7-1c434426c12f)
