### PR TITLE
Make tab names in starterpacks translatable

### DIFF
--- a/src/screens/StarterPack/StarterPackScreen.tsx
+++ b/src/screens/StarterPack/StarterPackScreen.tsx
@@ -176,11 +176,12 @@ function StarterPackScreenLoaded({
   const showPeopleTab = Boolean(starterPack.list)
   const showFeedsTab = Boolean(starterPack.feeds?.length)
   const showPostsTab = Boolean(starterPack.list)
+  const {_} = useLingui()
 
   const tabs = [
-    ...(showPeopleTab ? ['People'] : []),
-    ...(showFeedsTab ? ['Feeds'] : []),
-    ...(showPostsTab ? ['Posts'] : []),
+    ...(showPeopleTab ? [_(msg`People`)] : []),
+    ...(showFeedsTab ? [_(msg`Feeds`)] : []),
+    ...(showPostsTab ? [_(msg`Posts`)] : []),
   ]
 
   const qrCodeDialogControl = useDialogControl()


### PR DESCRIPTION
Make the names of the tabs in the starter pack translatable.

like this.

Before:
![image](https://github.com/bluesky-social/social-app/assets/65759/c9de952d-10f9-464b-9d43-6f3efe32c7f5)

After:
![image](https://github.com/bluesky-social/social-app/assets/65759/25602e9c-aac9-4214-baa2-26640d576a59)

(this PR does not contain updates of messages.po)