### PR TITLE
[D1X] Use user action and viewing history to inform suggested follows

### DIFF
--- a/src/components/FeedInterstitials.tsx
+++ b/src/components/FeedInterstitials.tsx
@@ -90,7 +90,7 @@ function useExperimentalSuggestedUsersQuery() {
       .map(l => new AtUri(l))
       .map(uri => uri.host)
       .filter(did => !follows.includes(did))
-    const seenDids = seen.map(l => new AtUri(l)).map(uri => uri.host)
+    const seenDids = seen.map(l => new AtUri(l.uri)).map(uri => uri.host)
     return [...new Set([...likeDids, ...seenDids])]
   }, [userActionSnapshot])
   const {data, isLoading, error} = useProfilesQuery({

--- a/src/state/queries/post-feed.ts
+++ b/src/state/queries/post-feed.ts
@@ -310,7 +310,7 @@ export function usePostFeedQuery(
 
                   if (isDiscover) {
                     userActionHistory.seen(
-                      ...slice.items.map(item => item.post.uri),
+                      slice.items.map(item => item.post.uri),
                     )
                   }
 

--- a/src/state/queries/post-feed.ts
+++ b/src/state/queries/post-feed.ts
@@ -17,11 +17,13 @@ import {
 
 import {HomeFeedAPI} from '#/lib/api/feed/home'
 import {aggregateUserInterests} from '#/lib/api/feed/utils'
+import {DISCOVER_FEED_URI} from '#/lib/constants'
 import {moderatePost_wrapped as moderatePost} from '#/lib/moderatePost_wrapped'
 import {logger} from '#/logger'
 import {STALE} from '#/state/queries'
 import {DEFAULT_LOGGED_OUT_PREFERENCES} from '#/state/queries/preferences/const'
 import {useAgent} from '#/state/session'
+import * as userActionHistory from '#/state/userActionHistory'
 import {AuthorFeedAPI} from 'lib/api/feed/author'
 import {CustomFeedAPI} from 'lib/api/feed/custom'
 import {FollowingFeedAPI} from 'lib/api/feed/following'
@@ -131,6 +133,7 @@ export function usePostFeedQuery(
     result: InfiniteData<FeedPage>
   } | null>(null)
   const lastPageCountRef = useRef(0)
+  const isDiscover = feedDesc.includes(DISCOVER_FEED_URI)
 
   // Make sure this doesn't invalidate unless really needed.
   const selectArgs = React.useMemo(
@@ -139,8 +142,15 @@ export function usePostFeedQuery(
       disableTuner: params?.disableTuner,
       moderationOpts,
       ignoreFilterFor: opts?.ignoreFilterFor,
+      isDiscover,
     }),
-    [feedTuners, params?.disableTuner, moderationOpts, opts?.ignoreFilterFor],
+    [
+      feedTuners,
+      params?.disableTuner,
+      moderationOpts,
+      opts?.ignoreFilterFor,
+      isDiscover,
+    ],
   )
 
   const query = useInfiniteQuery<
@@ -219,8 +229,13 @@ export function usePostFeedQuery(
       (data: InfiniteData<FeedPageUnselected, RQPageParam>) => {
         // If the selection depends on some data, that data should
         // be included in the selectArgs object and read here.
-        const {feedTuners, disableTuner, moderationOpts, ignoreFilterFor} =
-          selectArgs
+        const {
+          feedTuners,
+          disableTuner,
+          moderationOpts,
+          ignoreFilterFor,
+          isDiscover,
+        } = selectArgs
 
         const tuner = disableTuner
           ? new NoopFeedTuner()
@@ -291,6 +306,12 @@ export function usePostFeedQuery(
                     ) {
                       return undefined
                     }
+                  }
+
+                  if (isDiscover) {
+                    userActionHistory.seen(
+                      ...slice.items.map(item => item.post.uri),
+                    )
                   }
 
                   return {

--- a/src/state/queries/post-feed.ts
+++ b/src/state/queries/post-feed.ts
@@ -310,7 +310,16 @@ export function usePostFeedQuery(
 
                   if (isDiscover) {
                     userActionHistory.seen(
-                      slice.items.map(item => item.post.uri),
+                      slice.items.map(item => ({
+                        feedContext: item.feedContext,
+                        likeCount: item.post.likeCount ?? 0,
+                        repostCount: item.post.repostCount ?? 0,
+                        replyCount: item.post.replyCount ?? 0,
+                        isFollowedBy: Boolean(
+                          item.post.author.viewer?.followedBy,
+                        ),
+                        uri: item.post.uri,
+                      })),
                     )
                   }
 

--- a/src/state/queries/post.ts
+++ b/src/state/queries/post.ts
@@ -93,7 +93,7 @@ export function usePostLikeMutationQueue(
           uri: postUri,
           cid: postCid,
         })
-        userActionHistory.like(postUri)
+        userActionHistory.like([postUri])
         return likeUri
       } else {
         if (prevLikeUri) {
@@ -101,7 +101,7 @@ export function usePostLikeMutationQueue(
             postUri: postUri,
             likeUri: prevLikeUri,
           })
-          userActionHistory.unlike(postUri)
+          userActionHistory.unlike([postUri])
         }
         return undefined
       }

--- a/src/state/queries/post.ts
+++ b/src/state/queries/post.ts
@@ -8,6 +8,7 @@ import {logEvent, LogEvents, toClout} from '#/lib/statsig/statsig'
 import {updatePostShadow} from '#/state/cache/post-shadow'
 import {Shadow} from '#/state/cache/types'
 import {useAgent, useSession} from '#/state/session'
+import * as userActionHistory from '#/state/userActionHistory'
 import {useIsThreadMuted, useSetThreadMute} from '../cache/thread-mutes'
 import {findProfileQueryData} from './profile'
 
@@ -92,6 +93,7 @@ export function usePostLikeMutationQueue(
           uri: postUri,
           cid: postCid,
         })
+        userActionHistory.like(postUri)
         return likeUri
       } else {
         if (prevLikeUri) {
@@ -99,6 +101,7 @@ export function usePostLikeMutationQueue(
             postUri: postUri,
             likeUri: prevLikeUri,
           })
+          userActionHistory.unlike(postUri)
         }
         return undefined
       }

--- a/src/state/queries/profile.ts
+++ b/src/state/queries/profile.ts
@@ -234,7 +234,7 @@ export function useProfileFollowMutationQueue(
         const {uri} = await followMutation.mutateAsync({
           did,
         })
-        userActionHistory.follow(did)
+        userActionHistory.follow([did])
         return uri
       } else {
         if (prevFollowingUri) {
@@ -242,7 +242,7 @@ export function useProfileFollowMutationQueue(
             did,
             followUri: prevFollowingUri,
           })
-          userActionHistory.unfollow(did)
+          userActionHistory.unfollow([did])
         }
         return undefined
       }

--- a/src/state/queries/profile.ts
+++ b/src/state/queries/profile.ts
@@ -23,6 +23,7 @@ import {logEvent, LogEvents, toClout} from '#/lib/statsig/statsig'
 import {Shadow} from '#/state/cache/types'
 import {STALE} from '#/state/queries'
 import {resetProfilePostsQueries} from '#/state/queries/post-feed'
+import * as userActionHistory from '#/state/userActionHistory'
 import {updateProfileShadow} from '../cache/profile-shadow'
 import {useAgent, useSession} from '../session'
 import {RQKEY as RQKEY_LIST_CONVOS} from './messages/list-converations'
@@ -229,6 +230,7 @@ export function useProfileFollowMutationQueue(
         const {uri} = await followMutation.mutateAsync({
           did,
         })
+        userActionHistory.follow(did)
         return uri
       } else {
         if (prevFollowingUri) {
@@ -236,6 +238,7 @@ export function useProfileFollowMutationQueue(
             did,
             followUri: prevFollowingUri,
           })
+          userActionHistory.unfollow(did)
         }
         return undefined
       }

--- a/src/state/userActionHistory.ts
+++ b/src/state/userActionHistory.ts
@@ -33,29 +33,29 @@ export function useActionHistorySnapshot() {
   return React.useState(() => getActionHistory())[0]
 }
 
-export function like(...postUris: string[]) {
+export function like(postUris: string[]) {
   userActionHistory.likes = userActionHistory.likes
     .concat(postUris)
     .slice(-LIKE_WINDOW)
 }
-export function unlike(...postUris: string[]) {
+export function unlike(postUris: string[]) {
   userActionHistory.likes = userActionHistory.likes.filter(
     uri => !postUris.includes(uri),
   )
 }
 
-export function follow(...dids: string[]) {
+export function follow(dids: string[]) {
   userActionHistory.follows = userActionHistory.follows
     .concat(dids)
     .slice(-FOLLOW_WINDOW)
 }
-export function unfollow(...dids: string[]) {
+export function unfollow(dids: string[]) {
   userActionHistory.follows = userActionHistory.follows.filter(
     uri => !dids.includes(uri),
   )
 }
 
-export function seen(...postUris: string[]) {
+export function seen(postUris: string[]) {
   userActionHistory.seen = userActionHistory.seen
     .concat(postUris)
     .slice(-SEEN_WINDOW)

--- a/src/state/userActionHistory.ts
+++ b/src/state/userActionHistory.ts
@@ -1,0 +1,62 @@
+import React from 'react'
+
+const LIKE_WINDOW = 100
+const FOLLOW_WINDOW = 100
+const SEEN_WINDOW = 100
+
+export type UserActionHistory = {
+  /**
+   * The last 100 post URIs the user has liked
+   */
+  likes: string[]
+  /**
+   * The last 100 DIDs the user has followed
+   */
+  follows: string[]
+  /**
+   * The last 100 post URIs the user has seen from the Discover feed only
+   */
+  seen: string[]
+}
+
+const userActionHistory: UserActionHistory = {
+  likes: [],
+  follows: [],
+  seen: [],
+}
+
+export function getActionHistory() {
+  return userActionHistory
+}
+
+export function useActionHistorySnapshot() {
+  return React.useState(() => getActionHistory())[0]
+}
+
+export function like(...postUris: string[]) {
+  userActionHistory.likes = userActionHistory.likes
+    .concat(postUris)
+    .slice(-LIKE_WINDOW)
+}
+export function unlike(...postUris: string[]) {
+  userActionHistory.likes = userActionHistory.likes.filter(
+    uri => !postUris.includes(uri),
+  )
+}
+
+export function follow(...dids: string[]) {
+  userActionHistory.follows = userActionHistory.follows
+    .concat(dids)
+    .slice(-FOLLOW_WINDOW)
+}
+export function unfollow(...dids: string[]) {
+  userActionHistory.follows = userActionHistory.follows.filter(
+    uri => !dids.includes(uri),
+  )
+}
+
+export function seen(...postUris: string[]) {
+  userActionHistory.seen = userActionHistory.seen
+    .concat(postUris)
+    .slice(-SEEN_WINDOW)
+}

--- a/src/state/userActionHistory.ts
+++ b/src/state/userActionHistory.ts
@@ -4,6 +4,15 @@ const LIKE_WINDOW = 100
 const FOLLOW_WINDOW = 100
 const SEEN_WINDOW = 100
 
+type SeenPost = {
+  uri: string
+  likeCount: number
+  repostCount: number
+  replyCount: number
+  isFollowedBy: boolean
+  feedContext: string | undefined
+}
+
 export type UserActionHistory = {
   /**
    * The last 100 post URIs the user has liked
@@ -16,7 +25,7 @@ export type UserActionHistory = {
   /**
    * The last 100 post URIs the user has seen from the Discover feed only
    */
-  seen: string[]
+  seen: SeenPost[]
 }
 
 const userActionHistory: UserActionHistory = {
@@ -55,8 +64,8 @@ export function unfollow(dids: string[]) {
   )
 }
 
-export function seen(postUris: string[]) {
+export function seen(posts: SeenPost[]) {
   userActionHistory.seen = userActionHistory.seen
-    .concat(postUris)
+    .concat(posts)
     .slice(-SEEN_WINDOW)
 }

--- a/src/state/userActionHistory.ts
+++ b/src/state/userActionHistory.ts
@@ -4,7 +4,7 @@ const LIKE_WINDOW = 100
 const FOLLOW_WINDOW = 100
 const SEEN_WINDOW = 100
 
-type SeenPost = {
+export type SeenPost = {
   uri: string
   likeCount: number
   repostCount: number

--- a/src/view/com/posts/Feed.tsx
+++ b/src/view/com/posts/Feed.tsx
@@ -92,33 +92,8 @@ const interstials: Record<
   'following' | 'discover',
   (FeedItem & {type: 'interstitialFeeds' | 'interstitialFollows'})[]
 > = {
-  following: [
-    {
-      type: followInterstitialType,
-      params: {
-        variant: 'default',
-      },
-      key: followInterstitialType,
-      slot: 20,
-    },
-    {
-      type: feedInterstitialType,
-      params: {
-        variant: 'default',
-      },
-      key: feedInterstitialType,
-      slot: 40,
-    },
-  ],
+  following: [],
   discover: [
-    {
-      type: feedInterstitialType,
-      params: {
-        variant: 'default',
-      },
-      key: feedInterstitialType,
-      slot: 20,
-    },
     {
       type: followInterstitialType,
       params: {


### PR DESCRIPTION
Keeps an in-memory store of liked posts, followed users, and post URIs seen on the Discover feed. This is only used in memory and is not stored or transmit anywhere.

This data is then used to grab up to 16 profiles, which are then filtered for any users already followed by the acting user. Up to 6 are then shown to the user as suggestions for others to follow.