### PR TITLE
Fix `onEndReached` not firing sometimes on web

### DIFF
--- a/src/view/com/notifications/Feed.tsx
+++ b/src/view/com/notifications/Feed.tsx
@@ -25,6 +25,7 @@ import {LoadMoreRetryBtn} from '#/view/com/util/LoadMoreRetryBtn'
 import {CenteredView} from '#/view/com/util/Views'
 import {FeedItem} from './FeedItem'
 import hairlineWidth = StyleSheet.hairlineWidth
+import {isWeb} from '#/platform/detection'
 
 const EMPTY_FEED_ITEM = {_reactKey: '__empty__'}
 const LOAD_MORE_ERROR_ITEM = {_reactKey: '__load_more_error__'}
@@ -182,7 +183,15 @@ export function Feed({
         refreshing={isPTRing}
         onRefresh={onRefresh}
         onEndReached={onEndReached}
-        onEndReachedThreshold={2}
+        onEndReachedThreshold={
+          /*
+          NOTE:
+          web's intersection observer struggles with the 2x threshold
+          and leads to missed pagination, so we keep it <1
+          -prf
+          */
+          isWeb ? 0.6 : 2
+        }
         onScrolledDownChange={onScrolledDownChange}
         contentContainerStyle={s.contentContainer}
         // @ts-ignore our .web version only -prf

--- a/src/view/com/notifications/Feed.tsx
+++ b/src/view/com/notifications/Feed.tsx
@@ -25,7 +25,6 @@ import {LoadMoreRetryBtn} from '#/view/com/util/LoadMoreRetryBtn'
 import {CenteredView} from '#/view/com/util/Views'
 import {FeedItem} from './FeedItem'
 import hairlineWidth = StyleSheet.hairlineWidth
-import {isWeb} from '#/platform/detection'
 
 const EMPTY_FEED_ITEM = {_reactKey: '__empty__'}
 const LOAD_MORE_ERROR_ITEM = {_reactKey: '__load_more_error__'}
@@ -183,15 +182,7 @@ export function Feed({
         refreshing={isPTRing}
         onRefresh={onRefresh}
         onEndReached={onEndReached}
-        onEndReachedThreshold={
-          /*
-          NOTE:
-          web's intersection observer struggles with the 2x threshold
-          and leads to missed pagination, so we keep it <1
-          -prf
-          */
-          isWeb ? 0.6 : 2
-        }
+        onEndReachedThreshold={2}
         onScrolledDownChange={onScrolledDownChange}
         contentContainerStyle={s.contentContainer}
         // @ts-ignore our .web version only -prf

--- a/src/view/com/util/List.web.tsx
+++ b/src/view/com/util/List.web.tsx
@@ -365,6 +365,7 @@ function ListImpl<ItemT>(
             root={containWeb ? nativeRef : null}
             onVisibleChange={onTailVisibilityChange}
             bottomMargin={(onEndReachedThreshold ?? 0) * 100 + '%'}
+            key={data?.length}
           />
         )}
         {footerComponent}

--- a/src/view/com/util/List.web.tsx
+++ b/src/view/com/util/List.web.tsx
@@ -63,7 +63,53 @@ function ListImpl<ItemT>(
   }: ListProps<ItemT>,
   ref: React.Ref<ListMethods>,
 ) {
-  const [prevDataLength, setPrevDataLength] = React.useState(data?.length)
+  const contextScrollHandlers = useScrollHandlers()
+  const pal = usePalette('default')
+  const {isMobile} = useWebMediaQueries()
+  if (!isMobile) {
+    contentContainerStyle = addStyle(
+      contentContainerStyle,
+      styles.containerScroll,
+    )
+  }
+
+  const isEmpty = !data || data.length === 0
+
+  let headerComponent: JSX.Element | null = null
+  if (ListHeaderComponent != null) {
+    if (isValidElement(ListHeaderComponent)) {
+      headerComponent = ListHeaderComponent
+    } else {
+      // @ts-ignore Nah it's fine.
+      headerComponent = <ListHeaderComponent />
+    }
+  }
+
+  let footerComponent: JSX.Element | null = null
+  if (ListFooterComponent != null) {
+    if (isValidElement(ListFooterComponent)) {
+      footerComponent = ListFooterComponent
+    } else {
+      // @ts-ignore Nah it's fine.
+      footerComponent = <ListFooterComponent />
+    }
+  }
+
+  let emptyComponent: JSX.Element | null = null
+  if (ListEmptyComponent != null) {
+    if (isValidElement(ListEmptyComponent)) {
+      emptyComponent = ListEmptyComponent
+    } else {
+      // @ts-ignore Nah it's fine.
+      emptyComponent = <ListEmptyComponent />
+    }
+  }
+
+  if (headerOffset != null) {
+    style = addStyle(style, {
+      paddingTop: headerOffset,
+    })
+  }
 
   const getScrollableNode = React.useCallback(() => {
     if (containWeb) {
@@ -137,77 +183,6 @@ function ListImpl<ItemT>(
       }
     }
   }, [containWeb])
-
-  // Whenever we get new data, we want to make sure that the onEndReached threshold will be *below* the current scroll
-  // bottom position. If it is not the IntersectionObserver will never fire the onEndReached threshold for us - since
-  // we've already scrolled past the component.
-  const callOnEndReachedIfNeeded = () => {
-    const node = getScrollableNode()
-    if (!node || !onEndReached || !onEndReachedThreshold || !data?.length) {
-      return
-    }
-
-    const scrollViewHeight = node.clientHeight
-    const scrollContainerHeight = node.scrollHeight
-    const scrollPos = node.scrollY
-    const thresholdPx = onEndReachedThreshold * scrollViewHeight
-
-    if (scrollContainerHeight - thresholdPx <= scrollPos) {
-      onEndReached({distanceFromEnd: 0})
-    }
-    setPrevDataLength(data?.length)
-  }
-  if (data?.length !== prevDataLength) {
-    callOnEndReachedIfNeeded()
-  }
-
-  const contextScrollHandlers = useScrollHandlers()
-  const pal = usePalette('default')
-  const {isMobile} = useWebMediaQueries()
-  if (!isMobile) {
-    contentContainerStyle = addStyle(
-      contentContainerStyle,
-      styles.containerScroll,
-    )
-  }
-
-  const isEmpty = !data || data.length === 0
-
-  let headerComponent: JSX.Element | null = null
-  if (ListHeaderComponent != null) {
-    if (isValidElement(ListHeaderComponent)) {
-      headerComponent = ListHeaderComponent
-    } else {
-      // @ts-ignore Nah it's fine.
-      headerComponent = <ListHeaderComponent />
-    }
-  }
-
-  let footerComponent: JSX.Element | null = null
-  if (ListFooterComponent != null) {
-    if (isValidElement(ListFooterComponent)) {
-      footerComponent = ListFooterComponent
-    } else {
-      // @ts-ignore Nah it's fine.
-      footerComponent = <ListFooterComponent />
-    }
-  }
-
-  let emptyComponent: JSX.Element | null = null
-  if (ListEmptyComponent != null) {
-    if (isValidElement(ListEmptyComponent)) {
-      emptyComponent = ListEmptyComponent
-    } else {
-      // @ts-ignore Nah it's fine.
-      emptyComponent = <ListEmptyComponent />
-    }
-  }
-
-  if (headerOffset != null) {
-    style = addStyle(style, {
-      paddingTop: headerOffset,
-    })
-  }
 
   const nativeRef = React.useRef<HTMLDivElement>(null)
   React.useImperativeHandle(

--- a/src/view/com/util/List.web.tsx
+++ b/src/view/com/util/List.web.tsx
@@ -63,53 +63,7 @@ function ListImpl<ItemT>(
   }: ListProps<ItemT>,
   ref: React.Ref<ListMethods>,
 ) {
-  const contextScrollHandlers = useScrollHandlers()
-  const pal = usePalette('default')
-  const {isMobile} = useWebMediaQueries()
-  if (!isMobile) {
-    contentContainerStyle = addStyle(
-      contentContainerStyle,
-      styles.containerScroll,
-    )
-  }
-
-  const isEmpty = !data || data.length === 0
-
-  let headerComponent: JSX.Element | null = null
-  if (ListHeaderComponent != null) {
-    if (isValidElement(ListHeaderComponent)) {
-      headerComponent = ListHeaderComponent
-    } else {
-      // @ts-ignore Nah it's fine.
-      headerComponent = <ListHeaderComponent />
-    }
-  }
-
-  let footerComponent: JSX.Element | null = null
-  if (ListFooterComponent != null) {
-    if (isValidElement(ListFooterComponent)) {
-      footerComponent = ListFooterComponent
-    } else {
-      // @ts-ignore Nah it's fine.
-      footerComponent = <ListFooterComponent />
-    }
-  }
-
-  let emptyComponent: JSX.Element | null = null
-  if (ListEmptyComponent != null) {
-    if (isValidElement(ListEmptyComponent)) {
-      emptyComponent = ListEmptyComponent
-    } else {
-      // @ts-ignore Nah it's fine.
-      emptyComponent = <ListEmptyComponent />
-    }
-  }
-
-  if (headerOffset != null) {
-    style = addStyle(style, {
-      paddingTop: headerOffset,
-    })
-  }
+  const [prevDataLength, setPrevDataLength] = React.useState(data?.length)
 
   const getScrollableNode = React.useCallback(() => {
     if (containWeb) {
@@ -183,6 +137,77 @@ function ListImpl<ItemT>(
       }
     }
   }, [containWeb])
+
+  // Whenever we get new data, we want to make sure that the onEndReached threshold will be *below* the current scroll
+  // bottom position. If it is not the IntersectionObserver will never fire the onEndReached threshold for us - since
+  // we've already scrolled past the component.
+  const callOnEndReachedIfNeeded = () => {
+    const node = getScrollableNode()
+    if (!node || !onEndReached || !onEndReachedThreshold || !data?.length) {
+      return
+    }
+
+    const scrollViewHeight = node.clientHeight
+    const scrollContainerHeight = node.scrollHeight
+    const scrollPos = node.scrollY
+    const thresholdPx = onEndReachedThreshold * scrollViewHeight
+
+    if (scrollContainerHeight - thresholdPx <= scrollPos) {
+      onEndReached({distanceFromEnd: 0})
+    }
+    setPrevDataLength(data?.length)
+  }
+  if (data?.length !== prevDataLength) {
+    callOnEndReachedIfNeeded()
+  }
+
+  const contextScrollHandlers = useScrollHandlers()
+  const pal = usePalette('default')
+  const {isMobile} = useWebMediaQueries()
+  if (!isMobile) {
+    contentContainerStyle = addStyle(
+      contentContainerStyle,
+      styles.containerScroll,
+    )
+  }
+
+  const isEmpty = !data || data.length === 0
+
+  let headerComponent: JSX.Element | null = null
+  if (ListHeaderComponent != null) {
+    if (isValidElement(ListHeaderComponent)) {
+      headerComponent = ListHeaderComponent
+    } else {
+      // @ts-ignore Nah it's fine.
+      headerComponent = <ListHeaderComponent />
+    }
+  }
+
+  let footerComponent: JSX.Element | null = null
+  if (ListFooterComponent != null) {
+    if (isValidElement(ListFooterComponent)) {
+      footerComponent = ListFooterComponent
+    } else {
+      // @ts-ignore Nah it's fine.
+      footerComponent = <ListFooterComponent />
+    }
+  }
+
+  let emptyComponent: JSX.Element | null = null
+  if (ListEmptyComponent != null) {
+    if (isValidElement(ListEmptyComponent)) {
+      emptyComponent = ListEmptyComponent
+    } else {
+      // @ts-ignore Nah it's fine.
+      emptyComponent = <ListEmptyComponent />
+    }
+  }
+
+  if (headerOffset != null) {
+    style = addStyle(style, {
+      paddingTop: headerOffset,
+    })
+  }
 
   const nativeRef = React.useRef<HTMLDivElement>(null)
   React.useImperativeHandle(


### PR DESCRIPTION
## Why

Currently, if the tail intersection observer is intersecting, and then we fetch more items but not enough to push it offscreen, we won't get another `onEndReached` event (because we only fire `onEndReached` when the intersection status _changes_ but in this case it's `true` -> `true`). We need to retrigger `onEndReached` if it's _still_ intersecting after fetch.

## How

Add `key={data.length}` to the intersection observer at the tail. This remounts it if the number of items changes, so it re-executes the intersection callback if it's still close to the viewport.

## Test Plan

You can set the `onEndReachedThreshold` inside of `src/view/com/notifications/Feed.tsx` to some big number like 10, and see that we end up making a few calls for notifications as soon as we load the page. The behavior when the height is "normal" should remain the same.

Tested on janky wifi so pretty sure this works from some console logs but not 100% certain.