### PR TITLE
Fix responsiveness of dismissing the progress guide

### DIFF
--- a/src/state/shell/progress-guide.tsx
+++ b/src/state/shell/progress-guide.tsx
@@ -59,11 +59,13 @@ export function useProgressGuideControls() {
 export function Provider({children}: React.PropsWithChildren<{}>) {
   const {_} = useLingui()
   const {data: preferences} = usePreferencesQuery()
-  const {mutateAsync, variables} = useSetActiveProgressGuideMutation()
+  const {mutateAsync, variables, isPending} =
+    useSetActiveProgressGuideMutation()
   const gate = useGate()
 
-  const activeProgressGuide = (variables ||
-    preferences?.bskyAppState?.activeProgressGuide) as ProgressGuide
+  const activeProgressGuide = (
+    isPending ? variables : preferences?.bskyAppState?.activeProgressGuide
+  ) as ProgressGuide
 
   // ensure the unspecced attributes have the correct types
   if (activeProgressGuide?.guide === 'like-10-and-follow-7') {
@@ -103,11 +105,8 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
       },
 
       endProgressGuide() {
-        // update the persisted first
-        mutateAsync(undefined).then(() => {
-          // now clear local state, to avoid rehydrating from the server
-          setLocalGuideState(undefined)
-        })
+        setLocalGuideState(undefined)
+        mutateAsync(undefined)
       },
 
       captureAction(action: ProgressGuideAction, count = 1) {


### PR DESCRIPTION
The details of this thing are goofy, but here's the sitch:

- We maintain the progress guide's canonical state in prefs where it's persisted.
- We also maintain a local copy of the active guide state. That local copy is what's used in the UI.
- The reason we do this is because when the guide is complete, the two states need to diverge.
  - Persisted state needs to be cleared out. It doesn't _need_ to be, but it's much better if we don't accumulate dead state for no reason.
  - Local state needs to keep the guide object with `isCompleted=true` so that the UI continues to render in the completed state.

Local state needs to correctly hydrate from persisted state upon init, so we have to read the persisted state into it. After that, the local state can operate pretty much independently. The trick is knowing when that "init" moment is happening, and for a while the `endProgressGuide` code was failing because I would clear the local state with `setLocalGuideState(undefined)` along with the `mutateAsync(undefined)` call, but then the `setLocalGuideState(activeProgressGuide)` would set it right back. My previous solution was to wait for `mutateAsync` to finish before trying to clear the local state, but that round trip made the UI feel unresponsive.

I was slightly confused that `variables` wasn't causing `activeProgressGuide` to correctly reflect current state, but I previously just assumed it was some delay in `mutateAsync` updating `variables`. When I sat down to look again, I realized that made no sense and looked closer -- realizing that, of course, `variables` was correctly becoming undefined, and therefore the reason `activeProgressGuide` was wrong was because it was falling back to the last persisted value.

By using `isPending` to decide whether to use `variables` or not, I was able to get `activeProgressGuide` to reflect the intended current state and drop the await on `mutateAsync`, making the progress guide dismissal much faster.