### PR TITLE
Fix feed feedback

### DIFF
--- a/src/state/feed-feedback.tsx
+++ b/src/state/feed-feedback.tsx
@@ -6,11 +6,8 @@ import throttle from 'lodash.throttle'
 import {PROD_DEFAULT_FEED} from '#/lib/constants'
 import {logEvent} from '#/lib/statsig/statsig'
 import {logger} from '#/logger'
-import {
-  FeedDescriptor,
-  FeedPostSliceItem,
-  isFeedPostSlice,
-} from '#/state/queries/post-feed'
+import {FeedDescriptor, FeedPostSliceItem} from '#/state/queries/post-feed'
+import {getFeedPostSlice} from '#/view/com/posts/Feed'
 import {useAgent} from './session'
 
 type StateContext = {
@@ -93,11 +90,12 @@ export function useFeedFeedback(feed: FeedDescriptor, hasSession: boolean) {
   }, [enabled, sendToFeed])
 
   const onItemSeen = React.useCallback(
-    (slice: any) => {
+    (feedItem: any) => {
       if (!enabled) {
         return
       }
-      if (!isFeedPostSlice(slice)) {
+      const slice = getFeedPostSlice(feedItem)
+      if (slice === null) {
         return
       }
       for (const postItem of slice.items) {

--- a/src/view/com/posts/Feed.tsx
+++ b/src/view/com/posts/Feed.tsx
@@ -156,6 +156,14 @@ const interstials: Record<
   ],
 }
 
+export function getFeedPostSlice(feedItem: FeedItem): FeedPostSlice | null {
+  if (feedItem.type === 'slice') {
+    return feedItem.slice
+  } else {
+    return null
+  }
+}
+
 // DISABLED need to check if this is causing random feed refreshes -prf
 // const REFRESH_AFTER = STALE.HOURS.ONE
 const CHECK_LATEST_AFTER = STALE.SECONDS.THIRTY


### PR DESCRIPTION
We broke feed feedback when adding interstitials because feed list item is no longer a slice but a wrapper over it. Solving by adding a utility function that maps between the two types so that we don't break this again.

## Test Plan

Feedback is being sent again:

![Screenshot 2024-07-04 at 19 49 19](https://github.com/bluesky-social/social-app/assets/810438/2034c2ff-9f71-417e-b6e0-bd696592b72c)

Interstitials get filtered out:

![Screenshot 2024-07-04 at 19 47 54](https://github.com/bluesky-social/social-app/assets/810438/348ba8de-468f-42cf-bf95-c1e92e3a347b)
