### PR TITLE
Fix hit slop for profile avi follow button

### DIFF
--- a/src/view/com/posts/AviFollowButton.tsx
+++ b/src/view/com/posts/AviFollowButton.tsx
@@ -90,30 +90,43 @@ export function AviFollowButton({
           hitSlop={createHitslop(3)}
           style={[
             a.rounded_full,
-            select(t.name, {
-              light: t.atoms.bg_contrast_100,
-              dim: t.atoms.bg_contrast_100,
-              dark: t.atoms.bg_contrast_200,
-            }),
             a.absolute,
             {
-              bottom: -1,
-              right: -1,
-              borderWidth: 1,
-              borderColor: t.atoms.bg.backgroundColor,
+              height: 30,
+              width: 30,
+              bottom: -7,
+              right: -7,
             },
           ]}>
           <NativeDropdown items={items}>
-            <Plus
-              size="sm"
-              fill={
-                select(t.name, {
-                  light: t.atoms.bg_contrast_600,
-                  dim: t.atoms.bg_contrast_500,
-                  dark: t.atoms.bg_contrast_600,
-                }).backgroundColor
-              }
-            />
+            <View
+              style={[a.h_full, a.w_full, a.justify_center, a.align_center]}>
+              <View
+                style={[
+                  a.rounded_full,
+                  a.align_center,
+                  select(t.name, {
+                    light: t.atoms.bg_contrast_100,
+                    dim: t.atoms.bg_contrast_100,
+                    dark: t.atoms.bg_contrast_200,
+                  }),
+                  {
+                    borderWidth: 1,
+                    borderColor: t.atoms.bg.backgroundColor,
+                  },
+                ]}>
+                <Plus
+                  size="sm"
+                  fill={
+                    select(t.name, {
+                      light: t.atoms.bg_contrast_600,
+                      dim: t.atoms.bg_contrast_500,
+                      dark: t.atoms.bg_contrast_600,
+                    }).backgroundColor
+                  }
+                />
+              </View>
+            </View>
           </NativeDropdown>
         </Button>
       )}


### PR DESCRIPTION
## Why

It's really hard to press the follow button on avatars. That is because Zeego/RN iOS context menu is not actually applying any hit slop at all. The slop around our button has no affect on the hit slop, as it needs to be explicitly the content area of the `Dropdown.Trigger` that opens the menu - not the button wrapping it.

Placing a button _inside_ the trigger and adding a hit slop to that _also_ does not work for the same reason. The pressable area will _only_ be the area of the content, not the extended hit slop area.

## How

Instead, we can use some additional `View`s with transparent background to increase the size of the `Dropdown.Trigger`, making it a lot easier to press.

## Test Plan

See how this feels on a device mainly. On a simulator it's much easier to tap now - you can tap a little outside the circle and still trigger the menu. It's still pretty small and we may want to increase it even more - but right now it's _only_ the size of the `Plus` icon, which is why it's so hard to hit. I think this will be a good improvement.


https://github.com/bluesky-social/social-app/assets/153161762/8c02a347-0369-4029-88a7-3c3df8fe093d

