### PR TITLE
Add missing `to` in StarterPackScreen.tsx string

### DIFF
--- a/src/screens/StarterPack/StarterPackScreen.tsx
+++ b/src/screens/StarterPack/StarterPackScreen.tsx
@@ -607,7 +607,7 @@ function OverflowMenu({
           <Trans>Delete starter pack?</Trans>
         </Prompt.TitleText>
         <Prompt.DescriptionText>
-          <Trans>Are you sure you want delete this starter pack?</Trans>
+          <Trans>Are you sure you want to delete this starter pack?</Trans>
         </Prompt.DescriptionText>
         {deleteError && (
           <View


### PR DESCRIPTION
@cdfzo pointed out in a [review comment](https://github.com/bluesky-social/social-app/pull/4742/files#r1667428796) that there's a missing `to` in the string that the user is shown when they're deleting a starter pack. This PR adds it.