### PR TITLE
Remove broken and void back button

### DIFF
--- a/src/screens/StarterPack/StarterPackLandingScreen.tsx
+++ b/src/screens/StarterPack/StarterPackLandingScreen.tsx
@@ -31,7 +31,6 @@ import {atoms as a, useTheme} from '#/alf'
 import {Button, ButtonText} from '#/components/Button'
 import {useDialogControl} from '#/components/Dialog'
 import * as FeedCard from '#/components/FeedCard'
-import {ChevronLeft_Stroke2_Corner0_Rounded} from '#/components/icons/Chevron'
 import {LinearGradientBackground} from '#/components/LinearGradientBackground'
 import {ListMaybePlaceholder} from '#/components/Lists'
 import {Default as ProfileCard} from '#/components/ProfileCard'
@@ -168,31 +167,6 @@ function LandingScreenLoaded({
               paddingTop: 100,
             },
           ]}>
-          <Pressable
-            style={[
-              a.absolute,
-              a.rounded_full,
-              a.align_center,
-              a.justify_center,
-              {
-                top: 10,
-                left: 10,
-                height: 35,
-                width: 35,
-                backgroundColor: 'rgba(0, 0, 0, 0.5)',
-              },
-            ]}
-            onPress={() => {
-              setActiveStarterPack(undefined)
-            }}
-            accessibilityLabel={_(msg`Back`)}
-            accessibilityHint={_(msg`Go back to previous screen`)}>
-            <ChevronLeft_Stroke2_Corner0_Rounded
-              width={20}
-              height={20}
-              fill="white"
-            />
-          </Pressable>
           <View style={[a.flex_row, a.gap_md, a.pb_sm]}>
             <Logo width={76} fill="white" />
           </View>


### PR DESCRIPTION
https://github.com/bluesky-social/social-app/assets/91714073/5b0f60a0-1654-4e8f-8596-fbe400093e67

This back button shouldn't be here. This button isn't programmed to go back, but instead updates "setActiveStarterPack(undefined)". Which causes a permanent 'processing' state.

However, this button causes an infinite loading spin and sucks for new users, especially for mobile users. Also, Because it's the same URL, browsers do not go back, my immediate instinct upon getting this infinite spin was to go back a page, but instead it will send the user to a new tab or what they were looking at, so they'd need to go back to their chat app (or whatever) and re-click the link. Horrifically bad for new user sign-ups. Because of browser caching, going back and forward (at least in FireFox) will display the infinite loading state again.

The starter-pack has different UIs for logged-in and logged-out view, thus we can just remove the entire button, as we don't need to support logged-in context.

(unrelated, but this is how this all started lol) https://bsky.app/profile/oracularhades.com/post/3kwnui4dg6f2z

🦋