### PR TITLE
Ensure `/start` navigates to `/starter-pack` when clicking a link internally

### DIFF
--- a/src/lib/strings/url-helpers.ts
+++ b/src/lib/strings/url-helpers.ts
@@ -5,6 +5,7 @@ import TLDs from 'tlds'
 import {logger} from '#/logger'
 import {BSKY_SERVICE} from 'lib/constants'
 import {isInvalidHandle} from 'lib/strings/handles'
+import {startUriToStarterPackUri} from 'lib/strings/starter-pack'
 
 export const BSKY_APP_HOST = 'https://bsky.app'
 const BSKY_TRUSTED_HOSTS = [
@@ -187,6 +188,11 @@ export function convertBskyAppUrlIfNeeded(url: string): string {
   if (isBskyAppUrl(url)) {
     try {
       const urlp = new URL(url)
+
+      if (isBskyStartUrl(url)) {
+        return startUriToStarterPackUri(urlp.pathname)
+      }
+
       return urlp.pathname
     } catch (e) {
       console.error('Unexpected error in convertBskyAppUrlIfNeeded()', e)

--- a/src/view/com/util/post-embeds/ExternalLinkEmbed.tsx
+++ b/src/view/com/util/post-embeds/ExternalLinkEmbed.tsx
@@ -79,37 +79,35 @@ export const ExternalLinkEmbed = ({
         ) : embedPlayerParams ? (
           <ExternalPlayer link={link} params={embedPlayerParams} />
         ) : undefined}
-        {!starterPackParsed ? (
-          <View
-            style={[
-              a.flex_1,
-              a.py_sm,
-              {
-                paddingHorizontal: isMobile ? 10 : 14,
-              },
-            ]}>
-            <Text
-              type="sm"
-              numberOfLines={1}
-              style={[pal.textLight, {marginVertical: 2}]}>
-              {toNiceDomain(link.uri)}
-            </Text>
+        <View
+          style={[
+            a.flex_1,
+            a.py_sm,
+            {
+              paddingHorizontal: isMobile ? 10 : 14,
+            },
+          ]}>
+          <Text
+            type="sm"
+            numberOfLines={1}
+            style={[pal.textLight, {marginVertical: 2}]}>
+            {toNiceDomain(link.uri)}
+          </Text>
 
-            {!embedPlayerParams?.isGif && !embedPlayerParams?.dimensions && (
-              <Text type="lg-bold" numberOfLines={3} style={[pal.text]}>
-                {link.title || link.uri}
-              </Text>
-            )}
-            {link.description ? (
-              <Text
-                type="md"
-                numberOfLines={link.thumb ? 2 : 4}
-                style={[pal.text, a.mt_xs]}>
-                {link.description}
-              </Text>
-            ) : undefined}
-          </View>
-        ) : null}
+          {!embedPlayerParams?.isGif && !embedPlayerParams?.dimensions && (
+            <Text type="lg-bold" numberOfLines={3} style={[pal.text]}>
+              {link.title || link.uri}
+            </Text>
+          )}
+          {link.description ? (
+            <Text
+              type="md"
+              numberOfLines={link.thumb ? 2 : 4}
+              style={[pal.text, a.mt_xs]}>
+              {link.description}
+            </Text>
+          ) : undefined}
+        </View>
       </LinkWrapper>
     </View>
   )


### PR DESCRIPTION
**[without whitespace](https://github.com/bluesky-social/social-app/pull/4745/files?w=1)**

## Why

Links that lead to `/start` should just navigate to `/starter-pack` when clicking them within the app. Although the current behavior is generally fine, it is possible to trigger this crash with the current behavior:

`<RNSNavigationController: 0x111824200> is pushing the same view controller instance (<RNSScreen: 0x159982600>) more than once which is not supported and is most likely an error in the application : xyz.blueskyweb.app`. It seems to only affect iOS users as well.

## How

Whenever we call `convertBskyAppUrlIfNeeded()`, we can add a check to replace `/start/` with `/starter-pack/` if the link is indeed pointing toward `/start/`. While this is generally not needed after https://github.com/bluesky-social/social-app/pull/4699 (which handles SP embeds natively instead of leaving them as external links), it would be good to ensure that even if someone pastes in a raw `/start/` link that it gets handled nicely.

## Test Plan

Weirdly, it took me a long time to actually repro the crash. It turns out you need to do the following to reproduce it (at least, this is how I was able to)

1. Post a starter pack link (do it from 1.87.0, _not_ from `main`)
2. Restart the app to make sure the navigation state is clear
3. Find the new post you just made in Following tab. Press the image. It should take you to the starter pack
4. Press back
5. Press the starter pack _again_

After this change, test the same. The crash no longer reproduces.