### PR TITLE
Reduce the size of the inner logo in the QR code

### DIFF
--- a/src/components/StarterPack/QrCode.tsx
+++ b/src/components/StarterPack/QrCode.tsx
@@ -110,7 +110,7 @@ export function QrCodeInner({link}: {link: string}) {
       innerEyesOptions={{borderRadius: 3}}
       logo={{
         href: require('../../../assets/logo.png'),
-        scale: 1.2,
+        scale: 1,
         padding: 2,
         hidePieces: true,
       }}

--- a/src/components/StarterPack/QrCode.tsx
+++ b/src/components/StarterPack/QrCode.tsx
@@ -108,6 +108,12 @@ export function QrCodeInner({link}: {link: string}) {
         },
       }}
       innerEyesOptions={{borderRadius: 3}}
+      logo={{
+        href: require('../../../assets/logo.png'),
+        scale: 1,
+        padding: 2,
+        hidePieces: true,
+      }}
     />
   )
 }

--- a/src/components/StarterPack/QrCode.tsx
+++ b/src/components/StarterPack/QrCode.tsx
@@ -110,7 +110,7 @@ export function QrCodeInner({link}: {link: string}) {
       innerEyesOptions={{borderRadius: 3}}
       logo={{
         href: require('../../../assets/logo.png'),
-        scale: 1,
+        scale: 0.95,
         padding: 2,
         hidePieces: true,
       }}

--- a/src/components/StarterPack/QrCode.tsx
+++ b/src/components/StarterPack/QrCode.tsx
@@ -108,12 +108,6 @@ export function QrCodeInner({link}: {link: string}) {
         },
       }}
       innerEyesOptions={{borderRadius: 3}}
-      logo={{
-        href: require('../../../assets/logo.png'),
-        scale: 1,
-        padding: 2,
-        hidePieces: true,
-      }}
     />
   )
 }


### PR DESCRIPTION
## Why

Fixes https://github.com/bluesky-social/social-app/issues/4740

Some of the generated QR codes cannot be scanned if the logo is too big - presumably certain combinations of data have pieces that end up underneath the logo.

For example, see:

- https://bsky.app/starter-pack/esb.lol/3kvuiptvhkx2y
- https://bsky.app/starter-pack/pfrazee.com/3kvaphb2hpf2u
- https://bsky.app/starter-pack/joshuajfriedman.com/3kvuh7u324m2c
- https://bsky.app/starter-pack/rudyfraser.com/3kvubqmzzi32t

These QR codes can indeed be scanned just fine. However, see these starter packs:

- https://bsky.app/starter-pack/pfrazee.com/3kvaqmutnga2z
- https://bsky.app/starter-pack/did:plc:fb3iwxg23jziddgbtsixx3zu/3kwjfvvlve32g

These ones cannot be scanned.

## How

If we change the `scale` of the logo to `1` instead of `1.2`, then all of the above packs do indeed work. However, it seems possible that certain data combinations may still cause problems - indeed, if we add _additional_ data (probably unlikely, but maybe in the future?) it seems even riskier. Since we already have the logo and name at the bottom of the image, it feels okay to remove the logo entirely to ensure these work fine.

## Test Plan

Test the above starter packs with this PR. They should _all_ be scannable now instead of just the first set.