### PR TITLE
Fix RTL text rendering for display names

### DIFF
--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -166,7 +166,9 @@ export function NameAndHandle({
 
   return (
     <View style={[a.flex_1]}>
-      <Text style={[a.text_md, a.font_bold, a.leading_snug]} numberOfLines={1}>
+      <Text
+        style={[a.text_md, a.font_bold, a.leading_snug, a.self_start]}
+        numberOfLines={1}>
         {name}
       </Text>
       <Text

--- a/src/components/ProfileHoverCard/index.web.tsx
+++ b/src/components/ProfileHoverCard/index.web.tsx
@@ -462,7 +462,8 @@ function Inner({
 
       <Link to={profileURL} label={_(msg`View profile`)} onPress={hide}>
         <View style={[a.pb_sm, a.flex_1]}>
-          <Text style={[a.pt_md, a.pb_xs, a.text_lg, a.font_bold]}>
+          <Text
+            style={[a.pt_md, a.pb_xs, a.text_lg, a.font_bold, a.self_start]}>
             {sanitizeDisplayName(
               profile.displayName || sanitizeHandle(profile.handle),
               moderation.ui('displayName'),

--- a/src/components/StarterPack/Wizard/WizardListCard.tsx
+++ b/src/components/StarterPack/Wizard/WizardListCard.tsx
@@ -78,7 +78,13 @@ function WizardListCard({
       />
       <View style={[a.flex_1, a.gap_2xs]}>
         <Text
-          style={[a.flex_1, a.font_bold, a.text_md, a.leading_tight]}
+          style={[
+            a.flex_1,
+            a.font_bold,
+            a.text_md,
+            a.leading_tight,
+            a.self_start,
+          ]}
           numberOfLines={1}>
           {displayName}
         </Text>

--- a/src/components/dms/MessagesListHeader.tsx
+++ b/src/components/dms/MessagesListHeader.tsx
@@ -168,7 +168,12 @@ function HeaderReady({
           </View>
           <View style={a.flex_1}>
             <Text
-              style={[a.text_md, a.font_bold, web(a.leading_normal)]}
+              style={[
+                a.text_md,
+                a.font_bold,
+                a.self_start,
+                web(a.leading_normal),
+              ]}
               numberOfLines={1}>
               {displayName}
             </Text>

--- a/src/components/dms/dialogs/SearchablePeopleList.tsx
+++ b/src/components/dms/dialogs/SearchablePeopleList.tsx
@@ -395,7 +395,7 @@ function ProfileCard({
           />
           <View style={[a.flex_1, a.gap_2xs]}>
             <Text
-              style={[t.atoms.text, a.font_bold, a.leading_tight]}
+              style={[t.atoms.text, a.font_bold, a.leading_tight, a.self_start]}
               numberOfLines={1}>
               {displayName}
             </Text>

--- a/src/lib/strings/constants.ts
+++ b/src/lib/strings/constants.ts
@@ -1,0 +1,1 @@
+export const NON_BREAKING_SPACE = '\u00A0'

--- a/src/screens/Profile/Header/DisplayName.tsx
+++ b/src/screens/Profile/Header/DisplayName.tsx
@@ -20,7 +20,7 @@ export function ProfileHeaderDisplayName({
     <View pointerEvents="none">
       <Text
         testID="profileHeaderDisplayName"
-        style={[t.atoms.text, a.text_4xl, {fontWeight: '500'}]}>
+        style={[t.atoms.text, a.text_4xl, a.self_start, {fontWeight: '500'}]}>
         {sanitizeDisplayName(
           profile.displayName || sanitizeHandle(profile.handle),
           moderation.ui('displayName'),

--- a/src/view/com/notifications/FeedItem.tsx
+++ b/src/view/com/notifications/FeedItem.tsx
@@ -58,6 +58,7 @@ import {useNavigation} from '@react-navigation/native'
 import {parseTenorGif} from '#/lib/strings/embed-player'
 import {logger} from '#/logger'
 import {NavigationProp} from 'lib/routes/types'
+import {forceLTR} from 'lib/strings/bidi'
 import {DM_SERVICE_HEADERS} from 'state/queries/messages/const'
 import {useAgent} from 'state/session'
 import {Button, ButtonText} from '#/components/Button'
@@ -274,13 +275,15 @@ let FeedItem = ({
             showDmButton={item.type === 'starterpack-joined' || isFollowBack}
           />
           <ExpandedAuthorsList visible={isAuthorsExpanded} authors={authors} />
-          <Text style={styles.meta}>
+          <Text style={[styles.meta, a.self_start]}>
             <TextLink
               key={authors[0].href}
               style={[pal.text, s.bold]}
               href={authors[0].href}
-              text={sanitizeDisplayName(
-                authors[0].profile.displayName || authors[0].profile.handle,
+              text={forceLTR(
+                sanitizeDisplayName(
+                  authors[0].profile.displayName || authors[0].profile.handle,
+                ),
               )}
               disableMismatchWarning
             />

--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -281,7 +281,7 @@ let PostThreadItemLoaded = ({
                 <Link style={s.flex1} href={authorHref} title={authorTitle}>
                   <Text
                     type="xl-bold"
-                    style={[pal.text]}
+                    style={[pal.text, a.self_start]}
                     numberOfLines={1}
                     lineHeight={1.2}>
                     {sanitizeDisplayName(

--- a/src/view/com/profile/ProfileCard.tsx
+++ b/src/view/com/profile/ProfileCard.tsx
@@ -97,7 +97,7 @@ export function ProfileCard({
         <View style={styles.layoutContent}>
           <Text
             type="lg"
-            style={[s.bold, pal.text]}
+            style={[s.bold, pal.text, a.self_start]}
             numberOfLines={1}
             lineHeight={1.2}>
             {sanitizeDisplayName(

--- a/src/view/com/util/PostMeta.tsx
+++ b/src/view/com/util/PostMeta.tsx
@@ -6,6 +6,7 @@ import {useQueryClient} from '@tanstack/react-query'
 import {precacheProfile} from '#/state/queries/profile'
 import {usePalette} from 'lib/hooks/usePalette'
 import {makeProfileLink} from 'lib/routes/links'
+import {NON_BREAKING_SPACE} from 'lib/strings/constants'
 import {sanitizeDisplayName} from 'lib/strings/display-names'
 import {sanitizeHandle} from 'lib/strings/handles'
 import {niceDate} from 'lib/strings/time'
@@ -31,8 +32,6 @@ interface PostMetaOpts {
   onOpenAuthor?: () => void
   style?: StyleProp<ViewStyle>
 }
-
-const NON_BREAKING_SPACE = '\u00A0'
 
 let PostMeta = (opts: PostMetaOpts): React.ReactNode => {
   const pal = usePalette('default')

--- a/src/view/com/util/PostMeta.tsx
+++ b/src/view/com/util/PostMeta.tsx
@@ -6,6 +6,7 @@ import {useQueryClient} from '@tanstack/react-query'
 import {precacheProfile} from '#/state/queries/profile'
 import {usePalette} from 'lib/hooks/usePalette'
 import {makeProfileLink} from 'lib/routes/links'
+import {forceLTR} from 'lib/strings/bidi'
 import {NON_BREAKING_SPACE} from 'lib/strings/constants'
 import {sanitizeDisplayName} from 'lib/strings/display-names'
 import {sanitizeHandle} from 'lib/strings/handles'
@@ -69,14 +70,12 @@ let PostMeta = (opts: PostMetaOpts): React.ReactNode => {
             style={[pal.text]}
             lineHeight={1.2}
             disableMismatchWarning
-            text={
-              <>
-                {sanitizeDisplayName(
-                  displayName,
-                  opts.moderation?.ui('displayName'),
-                )}
-              </>
-            }
+            text={forceLTR(
+              sanitizeDisplayName(
+                displayName,
+                opts.moderation?.ui('displayName'),
+              ),
+            )}
             href={profileLink}
             onBeforePress={onBeforePressAuthor}
           />

--- a/src/view/screens/Settings/index.tsx
+++ b/src/view/screens/Settings/index.tsx
@@ -68,6 +68,7 @@ import {navigate, resetToTab} from '#/Navigation'
 import {Email2FAToggle} from './Email2FAToggle'
 import {ExportCarDialog} from './ExportCarDialog'
 import hairlineWidth = StyleSheet.hairlineWidth
+import {atoms as a} from '#/alf'
 
 function SettingsAccountCard({
   account,
@@ -104,7 +105,7 @@ function SettingsAccountCard({
         />
       </View>
       <View style={[s.flex1]}>
-        <Text type="md-bold" style={pal.text} numberOfLines={1}>
+        <Text type="md-bold" style={[pal.text, a.self_start]} numberOfLines={1}>
           {profile?.displayName || account.handle}
         </Text>
         <Text type="sm" style={pal.textLight} numberOfLines={1}>

--- a/src/view/shell/desktop/Search.tsx
+++ b/src/view/shell/desktop/Search.tsx
@@ -30,6 +30,7 @@ import {precacheProfile} from 'state/queries/profile'
 import {Link} from '#/view/com/util/Link'
 import {UserAvatar} from '#/view/com/util/UserAvatar'
 import {Text} from 'view/com/util/text/Text'
+import {atoms as a} from '#/alf'
 
 let SearchLinkCard = ({
   label,
@@ -127,7 +128,7 @@ let SearchProfileCard = ({
         <View style={{flex: 1}}>
           <Text
             type="lg"
-            style={[s.bold, pal.text]}
+            style={[s.bold, pal.text, a.self_start]}
             numberOfLines={1}
             lineHeight={1.2}>
             {sanitizeDisplayName(


### PR DESCRIPTION
## Why

Right now it's pretty rough on web and Android (iOS handles it pretty well for some reason). After getting https://github.com/bluesky-social/social-app/pull/4531 merged in, felt like a good time to hit these.

## How

Using `alignSelf: 'flex-start'` in the `Text` styles whenever rendering the display name keeps the text aligned properly.

## Test Plan

I'm probably forgetting somewhere that we render the display name, but I tried to find them all with a search for `sanitizeDisplayName(`

| Before | After |
|--------|--------|
| <img width="420" alt="Screenshot 2024-07-07 at 3 28 13 PM" src="https://github.com/bluesky-social/social-app/assets/153161762/d0b4b6d8-cc7c-41e1-b5a1-12cba14b9c43"> | <img width="407" alt="Screenshot 2024-07-07 at 3 28 33 PM" src="https://github.com/bluesky-social/social-app/assets/153161762/45614a1e-9105-477b-87b2-273f3740be5c"> |
| <img width="408" alt="Screenshot 2024-07-07 at 3 32 43 PM" src="https://github.com/bluesky-social/social-app/assets/153161762/68f77848-d243-48b0-9bc7-e5c490c6084c"> | <img width="404" alt="Screenshot 2024-07-07 at 3 32 32 PM" src="https://github.com/bluesky-social/social-app/assets/153161762/55f208e7-caa8-4067-8bb0-52f1ffaddd4d"> |
| <img width="329" alt="Screenshot 2024-07-07 at 4 15 11 PM" src="https://github.com/bluesky-social/social-app/assets/153161762/f84f1bcd-3ca6-43bd-9287-61d5266bd7c3"> | <img width="344" alt="Screenshot 2024-07-07 at 4 15 16 PM" src="https://github.com/bluesky-social/social-app/assets/153161762/7b1a8f6c-fb3e-42df-9f79-cf061838b3d9"> |
| <img width="619" alt="Screenshot 2024-07-07 at 4 24 54 PM" src="https://github.com/bluesky-social/social-app/assets/153161762/4aeef773-e028-43b8-84bb-d15aef763297"> | <img width="649" alt="Screenshot 2024-07-07 at 4 25 07 PM" src="https://github.com/bluesky-social/social-app/assets/153161762/b17b885b-2523-486d-bbdb-5270602dde08"> |
| <img width="372" alt="Screenshot 2024-07-07 at 4 29 17 PM" src="https://github.com/bluesky-social/social-app/assets/153161762/b2bd2354-0c1e-4282-8eab-48fde96e279d"> | <img width="484" alt="Screenshot 2024-07-07 at 4 29 41 PM" src="https://github.com/bluesky-social/social-app/assets/153161762/f6707c5f-5b64-430a-9b4f-97d71efc2997"> |
| <img width="628" alt="Screenshot 2024-07-07 at 4 32 29 PM" src="https://github.com/bluesky-social/social-app/assets/153161762/6ce23c54-047d-4d75-9441-e84d96d5abe2"> | <img width="648" alt="Screenshot 2024-07-07 at 4 32 51 PM" src="https://github.com/bluesky-social/social-app/assets/153161762/724b61e0-65c2-4f6e-a25d-38d46c8e9539"> | 
| <img width="528" alt="Screenshot 2024-07-07 at 4 34 13 PM" src="https://github.com/bluesky-social/social-app/assets/153161762/c156481c-d9ca-4e82-a739-f755065fe646"> | <img width="567" alt="Screenshot 2024-07-07 at 4 34 49 PM" src="https://github.com/bluesky-social/social-app/assets/153161762/dbc36c6c-6a7c-4b88-bd98-f46d8b1694b1"> |
| <img width="547" alt="Screenshot 2024-07-07 at 4 35 42 PM" src="https://github.com/bluesky-social/social-app/assets/153161762/a3b90111-2224-462c-bb99-34aa4b0ca347"> | <img width="221" alt="Screenshot 2024-07-07 at 4 36 23 PM" src="https://github.com/bluesky-social/social-app/assets/153161762/d0ab2fb6-02e1-43c6-8d67-336cea887ae3"> |
| <img width="616" alt="Screenshot 2024-07-07 at 4 37 08 PM" src="https://github.com/bluesky-social/social-app/assets/153161762/ab206288-83df-4313-a132-27831f16285a"> | <img width="599" alt="Screenshot 2024-07-07 at 4 37 36 PM" src="https://github.com/bluesky-social/social-app/assets/153161762/4cbb289b-8a4f-48ec-b2f6-b43e658895af"> |
| <img width="629" alt="Screenshot 2024-07-07 at 4 38 30 PM" src="https://github.com/bluesky-social/social-app/assets/153161762/51567885-bf89-4e77-898c-46260bf48b4a"> | <img width="633" alt="Screenshot 2024-07-07 at 4 41 07 PM" src="https://github.com/bluesky-social/social-app/assets/153161762/072c98c1-4458-4eb3-aef9-7946710e83dc"> |