### PR TITLE
Log session events unconditionally

### DIFF
--- a/src/state/session/agent.ts
+++ b/src/state/session/agent.ts
@@ -12,6 +12,7 @@ import {tryFetchGates} from '#/lib/statsig/statsig'
 import {getAge} from '#/lib/strings/time'
 import {logger} from '#/logger'
 import {snoozeEmailConfirmationPrompt} from '#/state/shell/reminders'
+import {addSessionEventLog} from './logging'
 import {
   configureModerationForAccount,
   configureModerationForGuest,
@@ -194,6 +195,7 @@ async function prepareAgent(
   const account = agentToSessionAccountOrThrow(agent)
   agent.setPersistSessionHandler(event => {
     onSessionChange(agent, account.did, event)
+    addSessionEventLog(account.did, event)
   })
   return {agent, account}
 }

--- a/src/state/session/logging.ts
+++ b/src/state/session/logging.ts
@@ -1,4 +1,4 @@
-import {AtpSessionData} from '@atproto/api'
+import {AtpSessionData, AtpSessionEvent} from '@atproto/api'
 import {sha256} from 'js-sha256'
 import {Statsig} from 'statsig-react-native-expo'
 
@@ -69,6 +69,18 @@ export function wrapSessionReducerForLogging(reducer: Reducer): Reducer {
 
 let nextMessageIndex = 0
 const MAX_SLICE_LENGTH = 1000
+
+// Not gated.
+export function addSessionEventLog(did: string, event: AtpSessionEvent) {
+  try {
+    if (!Statsig.initializeCalled() || !Statsig.getStableID()) {
+      return
+    }
+    Statsig.logEvent('session:event', null, {did, event})
+  } catch (e) {
+    console.error(e)
+  }
+}
 
 export function addSessionDebugLog(log: Log) {
   try {


### PR DESCRIPTION
Adds a log when an agent emits an event (`update`, `expired`, and a few others). We want to get a baseline on how much expiration is occurring in practice, and we want to be able to target that with experiment fixes.

## Test Plan

Force early expiration using the short session debug header, verify it results in sending this event.

![Screenshot 2024-07-09 at 20 11 02](https://github.com/bluesky-social/social-app/assets/810438/b8340eff-0c04-4eb9-80f4-0f2c443d5cb2)
