### PR TITLE
bskyweb: add robots disallow and 'canonical' config flags

### DIFF
--- a/bskyweb/cmd/bskyweb/main.go
+++ b/bskyweb/cmd/bskyweb/main.go
@@ -94,6 +94,20 @@ func run(args []string) {
 					Value:    "",
 					EnvVars:  []string{"STATIC_CDN_HOST"},
 				},
+				&cli.BoolFlag{
+					Name:     "bsky-canonical-instance",
+					Usage:    "Enable if this is the canonical deployment (bsky.app)",
+					Value:    false,
+					Required: false,
+					EnvVars:  []string{"BSKY_CANONICAL_INSTANCE"},
+				},
+				&cli.BoolFlag{
+					Name:     "robots-disallow-all",
+					Usage:    "Crawling is allowed by default. Enable this flag to Disallow all",
+					Value:    false,
+					Required: false,
+					EnvVars:  []string{"ROBOTS_DISALLOW_ALL"},
+				},
 			},
 		},
 	}

--- a/bskyweb/static/robots-disallow-all.txt
+++ b/bskyweb/static/robots-disallow-all.txt
@@ -1,0 +1,3 @@
+# This is an development or self-hosted instance of the bsky web app, and crawling has been disallowed by the operator team.
+User-Agent: *
+Disallow: /


### PR DESCRIPTION
NOTE: it is critical to enable the "canonical" flag for our prod deployment before merging/deploying this branch.

Adds two config/envvar flags:

- one to allow swapping in a blank "Disallow: *" robots.txt to prevent crawling (eg, in dev/staging/informal deployments)
- another to only serve some endpoints in the "canonical" deployment (eg, bsky.app)

Normally we might try to detect what "environment" we are in and change these behaviors based on that, but we have kind of a sprawling menagerie of environments, and folks also might be forking this repo for their own use, so made these more granular flags. Open to changing path and doing this the traditional `ENVIRONMENT` variable way though.