### PR TITLE
Rename session event, scope to errors

### DIFF
--- a/src/state/session/agent.ts
+++ b/src/state/session/agent.ts
@@ -12,7 +12,7 @@ import {tryFetchGates} from '#/lib/statsig/statsig'
 import {getAge} from '#/lib/strings/time'
 import {logger} from '#/logger'
 import {snoozeEmailConfirmationPrompt} from '#/state/shell/reminders'
-import {addSessionEventLog} from './logging'
+import {addSessionErrorLog} from './logging'
 import {
   configureModerationForAccount,
   configureModerationForGuest,
@@ -195,7 +195,9 @@ async function prepareAgent(
   const account = agentToSessionAccountOrThrow(agent)
   agent.setPersistSessionHandler(event => {
     onSessionChange(agent, account.did, event)
-    addSessionEventLog(account.did, event)
+    if (event !== 'create' && event !== 'update') {
+      addSessionErrorLog(account.did, event)
+    }
   })
   return {agent, account}
 }

--- a/src/state/session/logging.ts
+++ b/src/state/session/logging.ts
@@ -71,12 +71,12 @@ let nextMessageIndex = 0
 const MAX_SLICE_LENGTH = 1000
 
 // Not gated.
-export function addSessionEventLog(did: string, event: AtpSessionEvent) {
+export function addSessionErrorLog(did: string, event: AtpSessionEvent) {
   try {
     if (!Statsig.initializeCalled() || !Statsig.getStableID()) {
       return
     }
-    Statsig.logEvent('session:event', null, {did, event})
+    Statsig.logEvent('session:error', null, {did, event})
   } catch (e) {
     console.error(e)
   }


### PR DESCRIPTION
Follow-up to https://github.com/bluesky-social/social-app/pull/4758. Turns out there's just a _lot_ of `update` events so it makes hard to notice problems. Let's filter out expected successful events and focus on the failures.

## Test Plan

On `session-stress` branch, I still see this:

![Screenshot 2024-07-09 at 22 57 13](https://github.com/bluesky-social/social-app/assets/810438/6ed62f11-4ce9-4f31-a57d-b5b27b16240a)

Also manual inspection.