### PR TITLE
[Session] Experiment: Don't use withProxy

### DIFF
--- a/src/components/moderation/LabelsOnMeDialog.tsx
+++ b/src/components/moderation/LabelsOnMeDialog.tsx
@@ -7,6 +7,7 @@ import {useMutation} from '@tanstack/react-query'
 
 import {useLabelInfo} from '#/lib/moderation/useLabelInfo'
 import {makeProfileLink} from '#/lib/routes/links'
+import {useGate} from '#/lib/statsig/statsig'
 import {sanitizeHandle} from '#/lib/strings/handles'
 import {logger} from '#/logger'
 import {useAgent, useSession} from '#/state/session'
@@ -201,22 +202,42 @@ function AppealForm({
   const [details, setDetails] = React.useState('')
   const isAccountReport = 'did' in subject
   const agent = useAgent()
+  const gate = useGate()
 
   const {mutate, isPending} = useMutation({
     mutationFn: async () => {
       const $type = !isAccountReport
         ? 'com.atproto.repo.strongRef'
         : 'com.atproto.admin.defs#repoRef'
-      await agent
-        .withProxy('atproto_labeler', label.src)
-        .createModerationReport({
-          reasonType: ComAtprotoModerationDefs.REASONAPPEAL,
-          subject: {
-            $type,
-            ...subject,
+      if (gate('session_withproxy_fix')) {
+        await agent.createModerationReport(
+          {
+            reasonType: ComAtprotoModerationDefs.REASONAPPEAL,
+            subject: {
+              $type,
+              ...subject,
+            },
+            reason: details,
           },
-          reason: details,
-        })
+          {
+            encoding: 'application/json',
+            headers: {
+              'atproto-proxy': `${label.src}#atproto_labeler`,
+            },
+          },
+        )
+      } else {
+        await agent
+          .withProxy('atproto_labeler', label.src)
+          .createModerationReport({
+            reasonType: ComAtprotoModerationDefs.REASONAPPEAL,
+            subject: {
+              $type,
+              ...subject,
+            },
+            reason: details,
+          })
+      }
     },
     onError: err => {
       logger.error('Failed to submit label appeal', {message: err})

--- a/src/lib/statsig/gates.ts
+++ b/src/lib/statsig/gates.ts
@@ -7,6 +7,7 @@ export type Gate =
   | 'new_user_progress_guide'
   | 'onboarding_minimum_interests'
   | 'request_notifications_permission_after_onboarding_v2'
+  | 'session_withproxy_fix'
   | 'show_avi_follow_button'
   | 'show_follow_back_label_v2'
   | 'suggested_feeds_interstitial'

--- a/src/state/feed-feedback.tsx
+++ b/src/state/feed-feedback.tsx
@@ -5,6 +5,7 @@ import throttle from 'lodash.throttle'
 
 import {PROD_DEFAULT_FEED} from '#/lib/constants'
 import {logEvent} from '#/lib/statsig/statsig'
+import {useGate} from '#/lib/statsig/statsig'
 import {logger} from '#/logger'
 import {FeedDescriptor, FeedPostSliceItem} from '#/state/queries/post-feed'
 import {getFeedPostSlice} from '#/view/com/posts/Feed'
@@ -24,6 +25,7 @@ const stateContext = React.createContext<StateContext>({
 
 export function useFeedFeedback(feed: FeedDescriptor, hasSession: boolean) {
   const agent = useAgent()
+  const gate = useGate()
   const enabled = isDiscoverFeed(feed) && hasSession
   const queue = React.useRef<Set<string>>(new Set())
   const history = React.useRef<
@@ -47,17 +49,34 @@ export function useFeedFeedback(feed: FeedDescriptor, hasSession: boolean) {
     queue.current.clear()
 
     // Send to the feed
-    const proxyAgent = agent.withProxy(
-      // @ts-ignore TODO need to update withProxy() to support this key -prf
-      'bsky_fg',
-      // TODO when we start sending to other feeds, we need to grab their DID -prf
-      'did:web:discover.bsky.app',
-    ) as BskyAgent
-    proxyAgent.app.bsky.feed
-      .sendInteractions({interactions})
-      .catch((e: any) => {
-        logger.warn('Failed to send feed interactions', {error: e})
-      })
+    if (gate('session_withproxy_fix')) {
+      agent.app.bsky.feed
+        .sendInteractions(
+          {interactions},
+          {
+            encoding: 'application/json',
+            headers: {
+              // TODO when we start sending to other feeds, we need to grab their DID -prf
+              'atproto-proxy': 'did:web:discover.bsky.app#bsky_fg',
+            },
+          },
+        )
+        .catch((e: any) => {
+          logger.warn('Failed to send feed interactions', {error: e})
+        })
+    } else {
+      const proxyAgent = agent.withProxy(
+        // @ts-ignore TODO need to update withProxy() to support this key -prf
+        'bsky_fg',
+        // TODO when we start sending to other feeds, we need to grab their DID -prf
+        'did:web:discover.bsky.app',
+      ) as BskyAgent
+      proxyAgent.app.bsky.feed
+        .sendInteractions({interactions})
+        .catch((e: any) => {
+          logger.warn('Failed to send feed interactions', {error: e})
+        })
+    }
 
     // Send to Statsig
     if (aggregatedStats.current === null) {
@@ -65,7 +84,7 @@ export function useFeedFeedback(feed: FeedDescriptor, hasSession: boolean) {
     }
     sendOrAggregateInteractionsForStats(aggregatedStats.current, interactions)
     throttledFlushAggregatedStats()
-  }, [agent, throttledFlushAggregatedStats])
+  }, [agent, gate, throttledFlushAggregatedStats])
 
   const sendToFeed = React.useMemo(
     () =>

--- a/src/state/feed-feedback.tsx
+++ b/src/state/feed-feedback.tsx
@@ -43,17 +43,16 @@ export function useFeedFeedback(feed: FeedDescriptor, hasSession: boolean) {
   )
 
   const sendToFeedNoDelay = React.useCallback(() => {
+    const interactions = Array.from(queue.current).map(toInteraction)
+    queue.current.clear()
+
+    // Send to the feed
     const proxyAgent = agent.withProxy(
       // @ts-ignore TODO need to update withProxy() to support this key -prf
       'bsky_fg',
       // TODO when we start sending to other feeds, we need to grab their DID -prf
       'did:web:discover.bsky.app',
     ) as BskyAgent
-
-    const interactions = Array.from(queue.current).map(toInteraction)
-    queue.current.clear()
-
-    // Send to the feed
     proxyAgent.app.bsky.feed
       .sendInteractions({interactions})
       .catch((e: any) => {


### PR DESCRIPTION
There's a theory that some of the logouts may be due to a bug in how `withProxy` interacts with the expiry logic (a cloned agent may expire and fork the token). I'm adding a gate that forks the logic to not use `withProxy`. We _could_ do this without the gate (the behavior should be equivalent) but I want to see if this actually reduces the number of `expired` events or not.

[Review without whitespace](https://github.com/bluesky-social/social-app/pull/4762/files?w=1)

## How

This is basically what `withProxy` does at the lower level:

https://github.com/bluesky-social/atproto/blob/7761a463b221717e5923dff77b1cc4c3755f3fd7/packages/api/src/agent.ts#L95-L99

which means this:

https://github.com/bluesky-social/atproto/blob/7761a463b221717e5923dff77b1cc4c3755f3fd7/packages/api/src/agent.ts#L128-L133

which means this:

https://github.com/bluesky-social/atproto/blob/7761a463b221717e5923dff77b1cc4c3755f3fd7/packages/api/src/agent.ts#L263-L268

So I'm doing the same but manually.

## Test Plan

Here's the feed feedback request with the gate off:

![Screenshot 2024-07-09 at 23 17 50](https://github.com/bluesky-social/social-app/assets/810438/8ceb9a01-c8d0-4c6c-9eb7-9c74a7c37ea1)

Same request with the gate on:

![Screenshot 2024-07-09 at 23 49 05](https://github.com/bluesky-social/social-app/assets/810438/83d8156d-1fa4-4dec-8222-17e25e5222ff)

Also verified I can still appeal labels (200 OK):

![Screenshot 2024-07-09 at 23 55 16](https://github.com/bluesky-social/social-app/assets/810438/c3e57d32-aa15-4665-b149-85d8cf255bc9)

Also still able to submit reports (200 OK):

![Screenshot 2024-07-10 at 00 00 10](https://github.com/bluesky-social/social-app/assets/810438/23bc7a6e-dfad-4c2f-8f1d-8a26083cce78)

Also checked these with the gate off.