### PR TITLE
[Session] Include stack with the debug event

### DIFF
--- a/src/state/session/logging.ts
+++ b/src/state/session/logging.ts
@@ -76,7 +76,12 @@ export function addSessionErrorLog(did: string, event: AtpSessionEvent) {
     if (!Statsig.initializeCalled() || !Statsig.getStableID()) {
       return
     }
-    Statsig.logEvent('session:error', null, {did, event})
+    const stack = (new Error().stack ?? '').slice(0, MAX_SLICE_LENGTH)
+    Statsig.logEvent('session:error', null, {
+      did,
+      event,
+      stack,
+    })
   } catch (e) {
     console.error(e)
   }


### PR DESCRIPTION
Seems useful to have it, maybe even if it's minified, it'll retain the Bsky agent method names?

## Test Plan

Tried on web, on iOS and Android on top of the `session-stress` branch. The stack is unfortunately not good on native due to the async/await transform that Hermes requires (which causes `await` continuations to get anonymous names).

But the web one seems good. It's fine if we at least get these for web.