### PR TITLE
Fix alt text for GIFs

### DIFF
--- a/src/view/com/composer/GifAltText.tsx
+++ b/src/view/com/composer/GifAltText.tsx
@@ -14,7 +14,7 @@ import {
 import {enforceLen} from '#/lib/strings/helpers'
 import {isAndroid} from '#/platform/detection'
 import {Gif} from '#/state/queries/tenor'
-import {atoms as a, native, useTheme} from '#/alf'
+import {atoms as a, useTheme} from '#/alf'
 import {Button, ButtonText} from '#/components/Button'
 import * as Dialog from '#/components/Dialog'
 import * as TextField from '#/components/forms/TextField'
@@ -174,8 +174,13 @@ function AltTextInner({
           <Text style={[a.text_2xl, a.font_bold, a.leading_tight, a.pb_sm]}>
             <Trans>Add alt text</Trans>
           </Text>
-          <View style={[a.w_full, a.align_center, native({maxHeight: 200})]}>
-            <GifEmbed link={link} params={params} hideAlt />
+          <View style={[a.align_center]}>
+            <GifEmbed
+              link={link}
+              params={params}
+              hideAlt
+              style={{maxHeight: 225}}
+            />
           </View>
         </View>
       </View>

--- a/src/view/com/composer/GifAltText.tsx
+++ b/src/view/com/composer/GifAltText.tsx
@@ -14,7 +14,7 @@ import {
 import {enforceLen} from '#/lib/strings/helpers'
 import {isAndroid} from '#/platform/detection'
 import {Gif} from '#/state/queries/tenor'
-import {atoms as a, useTheme} from '#/alf'
+import {atoms as a, native, useTheme} from '#/alf'
 import {Button, ButtonText} from '#/components/Button'
 import * as Dialog from '#/components/Dialog'
 import * as TextField from '#/components/forms/TextField'
@@ -179,7 +179,7 @@ function AltTextInner({
               link={link}
               params={params}
               hideAlt
-              style={{maxHeight: 225}}
+              style={[native({maxHeight: 225})]}
             />
           </View>
         </View>

--- a/src/view/com/util/post-embeds/GifEmbed.tsx
+++ b/src/view/com/util/post-embeds/GifEmbed.tsx
@@ -1,5 +1,12 @@
 import React from 'react'
-import {Pressable, StyleSheet, TouchableOpacity, View} from 'react-native'
+import {
+  Pressable,
+  StyleProp,
+  StyleSheet,
+  TouchableOpacity,
+  View,
+  ViewStyle,
+} from 'react-native'
 import {AppBskyEmbedExternal} from '@atproto/api'
 import {FontAwesomeIcon} from '@fortawesome/react-native-fontawesome'
 import {msg, Trans} from '@lingui/macro'
@@ -89,10 +96,12 @@ export function GifEmbed({
   params,
   link,
   hideAlt,
+  style = {width: '100%'},
 }: {
   params: EmbedPlayerParams
   link: AppBskyEmbedExternal.ViewExternal
   hideAlt?: boolean
+  style?: StyleProp<ViewStyle>
 }) {
   const {_} = useLingui()
   const autoplayDisabled = useAutoplayDisabled()
@@ -124,7 +133,7 @@ export function GifEmbed({
   )
 
   return (
-    <View style={[a.rounded_sm, a.overflow_hidden, a.mt_sm, {width: '100%'}]}>
+    <View style={[a.rounded_sm, a.overflow_hidden, a.mt_sm, style]}>
       <View
         style={[
           a.rounded_sm,


### PR DESCRIPTION
## Why

We changed `maxWidth` to `width` in #4717. This works fine everywhere except in the ALT dialog, where we want to adjust the styles a bit.

## How

The easiest way to always allow us to make changes to how this looks is by making `style` a prop we can adjust from outside the `GifView` component. The default of `width: '100%'` works for pretty much every case except these edges.

## Test Plan

Check the GIF alt dialog on all platforms. Also check that DMing a post with a GIF in it works fine and doesn't regress after #4717.

![Screenshot 2024-07-10 at 11 58 58 AM](https://github.com/bluesky-social/social-app/assets/153161762/88b2a038-b37d-4ddf-89f3-25b0ed14e7a0)
![Screenshot 2024-07-10 at 12 03 48 PM](https://github.com/bluesky-social/social-app/assets/153161762/5d09b7fa-2437-48e0-9b3c-538800349870)
![Screenshot 2024-07-10 at 12 05 13 PM](https://github.com/bluesky-social/social-app/assets/153161762/c94f2283-8865-4947-a22c-7cfa01df4bfb)
![Screenshot 2024-07-10 at 12 06 09 PM](https://github.com/bluesky-social/social-app/assets/153161762/630d6b93-9046-4377-a12d-e8b3a2ff10b8)
![Screenshot 2024-07-10 at 12 06 22 PM](https://github.com/bluesky-social/social-app/assets/153161762/d504b949-35c2-4c61-9f20-6906a3c6dc62)
