### PR TITLE
Fix search hashtags by author

### DIFF
--- a/src/screens/Hashtag.tsx
+++ b/src/screens/Hashtag.tsx
@@ -169,7 +169,7 @@ function HashtagScreenTab({
 
   const queryParam = React.useMemo(() => {
     if (!author) return fullTag
-    return `${fullTag} from:${sanitizeHandle(author)}`
+    return `${fullTag} from:${author}`
   }, [fullTag, author])
 
   const {


### PR DESCRIPTION
Unexpected and totally reasonable thing that broke in #4531 — `forceLTR` is adding characters to the string and borking the search query. We weren't doing anything special before so let's just go back to that here.