### PR TITLE
Return a promise for `getReferrerInfoAsync` on web

### DIFF
--- a/modules/expo-bluesky-swiss-army/src/Referrer/index.web.ts
+++ b/modules/expo-bluesky-swiss-army/src/Referrer/index.web.ts
@@ -8,27 +8,29 @@ export function getGooglePlayReferrerInfoAsync(): Promise<GooglePlayReferrerInfo
 }
 
 export function getReferrerInfoAsync(): Promise<ReferrerInfo | null> {
-  if (
-    Platform.OS === 'web' &&
-    // for ssr
-    typeof document !== 'undefined' &&
-    document != null &&
-    document.referrer
-  ) {
-    try {
-      const url = new URL(document.referrer)
-      if (url.hostname !== 'bsky.app') {
-        return {
-          referrer: url.href,
-          hostname: url.hostname,
+  // Returning a promise to match the functionality on native
+  return new Promise(resolve => {
+    if (
+      Platform.OS === 'web' &&
+      // for ssr
+      typeof document !== 'undefined' &&
+      document != null &&
+      document.referrer
+    ) {
+      try {
+        const url = new URL(document.referrer)
+        if (url.hostname !== 'bsky.app') {
+          resolve({
+            referrer: url.href,
+            hostname: url.hostname,
+          })
         }
+      } catch {
+        // If something happens to the URL parsing, we don't want to actually cause any problems for the user. Just
+        // log the error so we might catch it
+        console.error('Failed to parse referrer URL')
       }
-    } catch {
-      // If something happens to the URL parsing, we don't want to actually cause any problems for the user. Just
-      // log the error so we might catch it
-      console.error('Failed to parse referrer URL')
     }
-  }
-
-  return null
+    resolve(null)
+  })
 }

--- a/modules/expo-bluesky-swiss-army/src/Referrer/index.web.ts
+++ b/modules/expo-bluesky-swiss-army/src/Referrer/index.web.ts
@@ -7,30 +7,27 @@ export function getGooglePlayReferrerInfoAsync(): Promise<GooglePlayReferrerInfo
   throw new NotImplementedError()
 }
 
-export function getReferrerInfoAsync(): Promise<ReferrerInfo | null> {
-  // Returning a promise to match the functionality on native
-  return new Promise(resolve => {
-    if (
-      Platform.OS === 'web' &&
-      // for ssr
-      typeof document !== 'undefined' &&
-      document != null &&
-      document.referrer
-    ) {
-      try {
-        const url = new URL(document.referrer)
-        if (url.hostname !== 'bsky.app') {
-          resolve({
-            referrer: url.href,
-            hostname: url.hostname,
-          })
+export async function getReferrerInfoAsync(): Promise<ReferrerInfo | null> {
+  if (
+    Platform.OS === 'web' &&
+    // for ssr
+    typeof document !== 'undefined' &&
+    document != null &&
+    document.referrer
+  ) {
+    try {
+      const url = new URL(document.referrer)
+      if (url.hostname !== 'bsky.app') {
+        return {
+          referrer: url.href,
+          hostname: url.hostname,
         }
-      } catch {
-        // If something happens to the URL parsing, we don't want to actually cause any problems for the user. Just
-        // log the error so we might catch it
-        console.error('Failed to parse referrer URL')
       }
+    } catch {
+      // If something happens to the URL parsing, we don't want to actually cause any problems for the user. Just
+      // log the error so we might catch it
+      console.error('Failed to parse referrer URL')
     }
-    resolve(null)
-  })
+  }
+  return null
 }


### PR DESCRIPTION
## Why

Forgot to actually return a promise here. We use a promise because that matches the way it works on native.

## Test Plan

The app will actually load now (main.bsky.dev ftw, thanks @mary-ext for catching it really fast! ❤️)