### PR TITLE
Make all referrer info sync

### DIFF
--- a/modules/expo-bluesky-swiss-army/android/src/main/java/expo/modules/blueskyswissarmy/referrer/ExpoBlueskyReferrerModule.kt
+++ b/modules/expo-bluesky-swiss-army/android/src/main/java/expo/modules/blueskyswissarmy/referrer/ExpoBlueskyReferrerModule.kt
@@ -23,7 +23,7 @@ class ExpoBlueskyReferrerModule : Module() {
         activityReferrer = appContext.currentActivity?.referrer
       }
 
-      AsyncFunction("getReferrerInfoAsync") {
+      Function("getReferrerInfo") {
         val intentReferrer =
           if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             intent?.getParcelableExtra(Intent.EXTRA_REFERRER, Uri::class.java)
@@ -40,7 +40,7 @@ class ExpoBlueskyReferrerModule : Module() {
               "hostname" to intentReferrer.host,
             )
           intent = null
-          return@AsyncFunction res
+          return@Function res
         }
 
         // In all other cases, we'll just record the app that sent the intent.
@@ -52,10 +52,10 @@ class ExpoBlueskyReferrerModule : Module() {
               "hostname" to (activityReferrer?.host ?: ""),
             )
           activityReferrer = null
-          return@AsyncFunction res
+          return@Function res
         }
 
-        return@AsyncFunction null
+        return@Function null
       }
 
       AsyncFunction("getGooglePlayReferrerInfoAsync") { promise: Promise ->

--- a/modules/expo-bluesky-swiss-army/src/Referrer/index.android.ts
+++ b/modules/expo-bluesky-swiss-army/src/Referrer/index.android.ts
@@ -8,6 +8,6 @@ export function getGooglePlayReferrerInfoAsync(): Promise<GooglePlayReferrerInfo
   return NativeModule.getGooglePlayReferrerInfoAsync()
 }
 
-export function getReferrerInfoAsync(): Promise<ReferrerInfo | null> {
-  return NativeModule.getReferrerInfoAsync()
+export function getReferrerInfo(): Promise<ReferrerInfo | null> {
+  return NativeModule.getReferrerInfo()
 }

--- a/modules/expo-bluesky-swiss-army/src/Referrer/index.ios.ts
+++ b/modules/expo-bluesky-swiss-army/src/Referrer/index.ios.ts
@@ -6,7 +6,7 @@ export function getGooglePlayReferrerInfoAsync(): Promise<GooglePlayReferrerInfo
   throw new NotImplementedError()
 }
 
-export function getReferrerInfoAsync(): Promise<ReferrerInfo | null> {
+export function getReferrerInfo(): ReferrerInfo | null {
   const referrer = SharedPrefs.getString('referrer')
   if (referrer) {
     SharedPrefs.removeValue('referrer')
@@ -19,7 +19,7 @@ export function getReferrerInfoAsync(): Promise<ReferrerInfo | null> {
     } catch (e) {
       return {
         referrer,
-        hostname: undefined,
+        hostname: referrer,
       }
     }
   }

--- a/modules/expo-bluesky-swiss-army/src/Referrer/index.ts
+++ b/modules/expo-bluesky-swiss-army/src/Referrer/index.ts
@@ -5,6 +5,6 @@ export function getGooglePlayReferrerInfoAsync(): Promise<GooglePlayReferrerInfo
   throw new NotImplementedError()
 }
 
-export function getReferrerInfoAsync(): Promise<ReferrerInfo | null> {
+export function getReferrerInfo(): ReferrerInfo | null {
   throw new NotImplementedError()
 }

--- a/modules/expo-bluesky-swiss-army/src/Referrer/index.web.ts
+++ b/modules/expo-bluesky-swiss-army/src/Referrer/index.web.ts
@@ -7,7 +7,7 @@ export function getGooglePlayReferrerInfoAsync(): Promise<GooglePlayReferrerInfo
   throw new NotImplementedError()
 }
 
-export async function getReferrerInfoAsync(): Promise<ReferrerInfo | null> {
+export function getReferrerInfo(): ReferrerInfo | null {
   if (
     Platform.OS === 'web' &&
     // for ssr

--- a/modules/expo-bluesky-swiss-army/src/Referrer/index.web.ts
+++ b/modules/expo-bluesky-swiss-army/src/Referrer/index.web.ts
@@ -8,27 +8,29 @@ export function getGooglePlayReferrerInfoAsync(): Promise<GooglePlayReferrerInfo
 }
 
 export function getReferrerInfoAsync(): Promise<ReferrerInfo | null> {
-  if (
-    Platform.OS === 'web' &&
-    // for ssr
-    typeof document !== 'undefined' &&
-    document != null &&
-    document.referrer
-  ) {
-    try {
-      const url = new URL(document.referrer)
-      if (url.hostname !== 'bsky.app') {
-        return {
-          referrer: url.href,
-          hostname: url.hostname,
+  // Returning a promise to match the functionality on native
+  return new Promise(resolve => {
+    if (
+      Platform.OS === 'web' &&
+      // for ssr
+      typeof document !== 'undefined' &&
+      document != null &&
+      document.referrer
+    ) {
+      try {
+        const url = new URL(document.referrer)
+        if (url.hostname !== 'bsky.app') {
+          resolve({
+            referrer: url.href,
+            hostname: url.hostname,
+          })
         }
+      } catch {
+        // If something happens to the URL parsing, we don't want to actually cause any problems for the user. Just
+        // log the error so we might catch it
+        console.error('Failed to parse referrer URL')
       }
-    } catch {
-      // If something happens to the URL parsing, we don't want to actually cause any problems for the user. Just
-      // log the error so we might catch it
-      console.error('Failed to parse referrer URL')
     }
-  }
-
-  return null
+    resolve(null)
+  })
 }

--- a/modules/expo-bluesky-swiss-army/src/Referrer/index.web.ts
+++ b/modules/expo-bluesky-swiss-army/src/Referrer/index.web.ts
@@ -7,30 +7,27 @@ export function getGooglePlayReferrerInfoAsync(): Promise<GooglePlayReferrerInfo
   throw new NotImplementedError()
 }
 
-export function getReferrerInfoAsync(): Promise<ReferrerInfo | null> {
-  // Returning a promise to match the functionality on native
-  return new Promise(resolve => {
-    if (
-      Platform.OS === 'web' &&
-      // for ssr
-      typeof document !== 'undefined' &&
-      document != null &&
-      document.referrer
-    ) {
-      try {
-        const url = new URL(document.referrer)
-        if (url.hostname !== 'bsky.app') {
-          resolve({
-            referrer: url.href,
-            hostname: url.hostname,
-          })
+export async function getReferrerInfoAsync(): Promise<ReferrerInfo | null> {
+  if (
+    Platform.OS === 'web' &&
+    // for ssr
+    typeof document !== 'undefined' &&
+    document != null &&
+    document.referrer
+  ) {
+    try {
+      const url = new URL(document.referrer)
+      if (url.hostname !== 'bsky.app') {
+        return {
+          referrer: url.href,
+          hostname: url.hostname,
         }
-      } catch {
-        // If something happens to the URL parsing, we don't want to actually cause any problems for the user. Just
-        // log the error so we might catch it
-        console.error('Failed to parse referrer URL')
       }
+    } catch {
+      // If something happens to the URL parsing, we don't want to actually cause any problems for the user. Just
+      // log the error so we might catch it
+      console.error('Failed to parse referrer URL')
     }
-    resolve(null)
-  })
+  }
+  return null
 }

--- a/src/Navigation.tsx
+++ b/src/Navigation.tsx
@@ -771,15 +771,14 @@ function logModuleInitTime() {
   })
 
   if (isWeb) {
-    Referrer.getReferrerInfoAsync().then(info => {
-      if (info && info.hostname !== 'bsky.app') {
-        logEvent('deepLink:referrerReceived', {
-          to: window.location.href,
-          referrer: info?.referrer,
-          hostname: info?.hostname,
-        })
-      }
-    })
+    const referrerInfo = Referrer.getReferrerInfo()
+    if (referrerInfo && referrerInfo.hostname !== 'bsky.app') {
+      logEvent('deepLink:referrerReceived', {
+        to: window.location.href,
+        referrer: referrerInfo?.referrer,
+        hostname: referrerInfo?.hostname,
+      })
+    }
   }
 
   if (__DEV__) {

--- a/src/lib/hooks/useIntentHandler.ts
+++ b/src/lib/hooks/useIntentHandler.ts
@@ -18,15 +18,14 @@ export function useIntentHandler() {
 
   React.useEffect(() => {
     const handleIncomingURL = (url: string) => {
-      Referrer.getReferrerInfoAsync().then(info => {
-        if (info && info.hostname !== 'bsky.app') {
-          logEvent('deepLink:referrerReceived', {
-            to: url,
-            referrer: info?.referrer,
-            hostname: info?.hostname,
-          })
-        }
-      })
+      const referrerInfo = Referrer.getReferrerInfo()
+      if (referrerInfo && referrerInfo.hostname !== 'bsky.app') {
+        logEvent('deepLink:referrerReceived', {
+          to: url,
+          referrer: referrerInfo?.referrer,
+          hostname: referrerInfo?.hostname,
+        })
+      }
 
       // We want to be able to support bluesky:// deeplinks. It's unnatural for someone to use a deeplink with three
       // slashes, like bluesky:///intent/follow. However, supporting just two slashes causes us to have to take care


### PR DESCRIPTION
We wanted to make this sync, but in some merges there were some mixups. This corrects those.