### PR TITLE
 User is signed out of a selected account rather than all accounts

### DIFF
--- a/src/state/session/index.tsx
+++ b/src/state/session/index.tsx
@@ -120,6 +120,7 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
       cancelPendingTask()
       dispatch({
         type: 'logged-out',
+        accountDid: account.did,
       })
       logEvent('account:loggedOut', {logContext})
       addSessionDebugLog({type: 'method:end', method: 'logout'})

--- a/src/state/session/index.tsx
+++ b/src/state/session/index.tsx
@@ -115,7 +115,7 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
   )
 
   const logout = React.useCallback<SessionApiContext['logout']>(
-    logContext => {
+    (account, logContext) => {
       addSessionDebugLog({type: 'method:start', method: 'logout'})
       cancelPendingTask()
       dispatch({

--- a/src/state/session/reducer.ts
+++ b/src/state/session/reducer.ts
@@ -156,8 +156,7 @@ let reducer = (state: State, action: Action): State => {
       return {
         //Return all the accounts. The other accounts remain unchanged, so the user will
         //stay signed in on them.
-        accounts: state.accounts
-        })),
+        accounts: state.accounts,
         currentAgentState: createPublicAgentState(),
         needsPersist: true,
       }

--- a/src/state/session/reducer.ts
+++ b/src/state/session/reducer.ts
@@ -143,12 +143,20 @@ let reducer = (state: State, action: Action): State => {
       }
     }
     case 'logged-out': {
+      //Fetch the account ID that the user signed out from
+      const {accountDid} = action
+
+      //Find the account for which the tokens need to be cleared
+      const loggedOutAccount = state.accounts.filter(a => a.did === accountDid)
+
+      //Clear the tokens for the account that the user signed out from
+      loggedOutAccount.accessJwt = undefined
+      loggedOutAccount.refreshJwt = undefined
+
       return {
-        accounts: state.accounts.map(a => ({
-          ...a,
-          // Clear tokens for *every* account (this is a hard logout).
-          refreshJwt: undefined,
-          accessJwt: undefined,
+        //Return all the accounts. The other accounts remain unchanged, so the user will
+        //stay signed in on them.
+        accounts: state.accounts
         })),
         currentAgentState: createPublicAgentState(),
         needsPersist: true,

--- a/src/state/session/types.ts
+++ b/src/state/session/types.ts
@@ -30,11 +30,12 @@ export type SessionApiContext = {
     logContext: LogEvents['account:loggedIn']['logContext'],
   ) => Promise<void>
   /**
-   * A full logout. Clears the `currentAccount` from session, AND removes
-   * access tokens from all accounts, so that returning as any user will
-   * require a full login.
+   * Log out of the selected session only.
    */
-  logout: (logContext: LogEvents['account:loggedOut']['logContext']) => void
+  logout: (
+    account: SessionAccount,
+    logContext: LogEvents['account:loggedOut']['logContext'],
+  ) => void
   resumeSession: (account: SessionAccount) => Promise<void>
   removeAccount: (account: SessionAccount) => void
 }


### PR DESCRIPTION
- Added the relevant account ID when dispatching the logout event (session/index.tsx)
- Consumed the account ID in the reducer and cleared the tokens for the specific account.

- Feature Request: https://github.com/bluesky-social/social-app/issues/4775
- Bug: https://github.com/bluesky-social/social-app/issues/4683