### PR TITLE
Add logging of selected feed preference when displaying the following feed

### DIFF
--- a/src/lib/statsig/events.ts
+++ b/src/lib/statsig/events.ts
@@ -75,19 +75,6 @@ export type LogEvents = {
   'onboarding:finished:avatarResult': {
     avatarResult: 'default' | 'created' | 'uploaded'
   }
-  'home:feedDisplayed': {
-    feedUrl: string
-    feedType: string
-    index: number
-    followingShowRepliesFromPref: 'all' | 'following' | 'off'
-    followingRepliesMinLikePref: number
-    reason:
-      | 'focus'
-      | 'tabbar-click'
-      | 'pager-swipe'
-      | 'desktop-sidebar-click'
-      | 'starter-pack-initial-feed'
-  }
   'home:feedDisplayed:sampled': {
     feedUrl: string
     feedType: string
@@ -223,6 +210,12 @@ export type LogEvents = {
 
   'feed:interstitial:profileCard:press': {}
   'feed:interstitial:feedCard:press': {}
+
+  'debug:followingPrefs': {
+    followingShowRepliesFromPref: 'all' | 'following' | 'off'
+    followingRepliesMinLikePref: number
+  }
+  'debug:followingDisplayed': {}
 
   'test:all:always': {}
   'test:all:sometimes': {}

--- a/src/lib/statsig/events.ts
+++ b/src/lib/statsig/events.ts
@@ -75,6 +75,19 @@ export type LogEvents = {
   'onboarding:finished:avatarResult': {
     avatarResult: 'default' | 'created' | 'uploaded'
   }
+  'home:feedDisplayed': {
+    feedUrl: string
+    feedType: string
+    index: number
+    followingShowRepliesFromPref: 'all' | 'following' | 'off'
+    followingRepliesMinLikePref: number
+    reason:
+      | 'focus'
+      | 'tabbar-click'
+      | 'pager-swipe'
+      | 'desktop-sidebar-click'
+      | 'starter-pack-initial-feed'
+  }
   'home:feedDisplayed:sampled': {
     feedUrl: string
     feedType: string

--- a/src/view/screens/Home.tsx
+++ b/src/view/screens/Home.tsx
@@ -110,26 +110,27 @@ function HomeScreenReady({
 
   // Temporary, remove when finished debugging
   const debugHasLoggedFollowingPrefs = React.useRef(false)
-  const debugHasLoggedFollowingDisplayed = React.useRef(false)
-  const debugLogFollowingPrefs = () => {
-    if (debugHasLoggedFollowingPrefs.current) return
-    logEvent('debug:followingPrefs', {
-      followingShowRepliesFromPref: preferences.feedViewPrefs.hideReplies
-        ? 'off'
-        : preferences.feedViewPrefs.hideRepliesByUnfollowed
-        ? 'following'
-        : 'all',
-      followingRepliesMinLikePref:
-        preferences.feedViewPrefs.hideRepliesByLikeCount,
-    })
-    debugHasLoggedFollowingPrefs.current = true
-  }
-  const debugLogFollowingDisplayed = (feed: FeedDescriptor) => {
-    if (debugHasLoggedFollowingDisplayed.current) return
-    if (feed !== 'following') return
-    logEvent('debug:followingDisplayed', {})
-    debugHasLoggedFollowingDisplayed.current = true
-  }
+  const debugLogFollowingPrefs = React.useCallback(
+    (feed: FeedDescriptor) => {
+      if (debugHasLoggedFollowingPrefs.current) return
+      if (feed !== 'following') return
+      logEvent('debug:followingPrefs', {
+        followingShowRepliesFromPref: preferences.feedViewPrefs.hideReplies
+          ? 'off'
+          : preferences.feedViewPrefs.hideRepliesByUnfollowed
+          ? 'following'
+          : 'all',
+        followingRepliesMinLikePref:
+          preferences.feedViewPrefs.hideRepliesByLikeCount,
+      })
+      debugHasLoggedFollowingPrefs.current = true
+    },
+    [
+      preferences.feedViewPrefs.hideReplies,
+      preferences.feedViewPrefs.hideRepliesByLikeCount,
+      preferences.feedViewPrefs.hideRepliesByUnfollowed,
+    ],
+  )
 
   const {hasSession} = useSession()
   const setMinimalShellMode = useSetMinimalShellMode()
@@ -159,8 +160,7 @@ function HomeScreenReady({
           feedUrl: selectedFeed,
           reason: 'focus',
         })
-        debugLogFollowingPrefs()
-        debugLogFollowingDisplayed(selectedFeed)
+        debugLogFollowingPrefs(selectedFeed)
       }
     }),
   )
@@ -207,9 +207,9 @@ function HomeScreenReady({
         feedUrl: feed,
         reason,
       })
-      debugLogFollowingDisplayed(feed)
+      debugLogFollowingPrefs(feed)
     },
-    [allFeeds],
+    [allFeeds, debugLogFollowingPrefs],
   )
 
   const onPressSelected = React.useCallback(() => {

--- a/src/view/screens/Home.tsx
+++ b/src/view/screens/Home.tsx
@@ -127,15 +127,47 @@ function HomeScreenReady({
     ]),
   )
 
+  const onPageSelecting = React.useCallback(
+    (
+      index: number,
+      reason: LogEvents['home:feedDisplayed:sampled']['reason'],
+    ) => {
+      const feed = allFeeds[index]
+      if (feed === 'following') {
+        logEvent('home:feedDisplayed', {
+          index,
+          feedType: feed.split('|')[0],
+          feedUrl: feed,
+          reason,
+          followingShowRepliesFromPref: preferences.feedViewPrefs.hideReplies
+            ? 'off'
+            : preferences.feedViewPrefs.hideRepliesByUnfollowed
+            ? 'following'
+            : 'all',
+          followingRepliesMinLikePref:
+            preferences.feedViewPrefs.hideRepliesByLikeCount,
+        })
+      } else {
+        logEvent('home:feedDisplayed:sampled', {
+          index,
+          feedType: feed.split('|')[0],
+          feedUrl: feed,
+          reason,
+        })
+      }
+    },
+    [
+      allFeeds,
+      preferences.feedViewPrefs.hideReplies,
+      preferences.feedViewPrefs.hideRepliesByLikeCount,
+      preferences.feedViewPrefs.hideRepliesByUnfollowed,
+    ],
+  )
+
   useFocusEffect(
     useNonReactiveCallback(() => {
       if (selectedFeed) {
-        logEvent('home:feedDisplayed:sampled', {
-          index: selectedIndex,
-          feedType: selectedFeed.split('|')[0],
-          feedUrl: selectedFeed,
-          reason: 'focus',
-        })
+        onPageSelecting(selectedIndex, 'focus')
       }
     }),
   )
@@ -168,22 +200,6 @@ function HomeScreenReady({
       lastPagerReportedIndexRef.current = index
     },
     [setDrawerSwipeDisabled, setSelectedFeed, setMinimalShellMode, allFeeds],
-  )
-
-  const onPageSelecting = React.useCallback(
-    (
-      index: number,
-      reason: LogEvents['home:feedDisplayed:sampled']['reason'],
-    ) => {
-      const feed = allFeeds[index]
-      logEvent('home:feedDisplayed:sampled', {
-        index,
-        feedType: feed.split('|')[0],
-        feedUrl: feed,
-        reason,
-      })
-    },
-    [allFeeds],
   )
 
   const onPressSelected = React.useCallback(() => {

--- a/src/view/screens/Home.tsx
+++ b/src/view/screens/Home.tsx
@@ -9,7 +9,7 @@ import {useWebMediaQueries} from '#/lib/hooks/useWebMediaQueries'
 import {logEvent, LogEvents} from '#/lib/statsig/statsig'
 import {emitSoftReset} from '#/state/events'
 import {SavedFeedSourceInfo, usePinnedFeedsInfos} from '#/state/queries/feed'
-import {FeedParams} from '#/state/queries/post-feed'
+import {FeedDescriptor, FeedParams} from '#/state/queries/post-feed'
 import {usePreferencesQuery} from '#/state/queries/preferences'
 import {UsePreferencesQueryResponse} from '#/state/queries/preferences/types'
 import {useSession} from '#/state/session'
@@ -108,6 +108,29 @@ function HomeScreenReady({
     }
   }, [selectedIndex])
 
+  // Temporary, remove when finished debugging
+  const debugHasLoggedFollowingPrefs = React.useRef(false)
+  const debugHasLoggedFollowingDisplayed = React.useRef(false)
+  const debugLogFollowingPrefs = () => {
+    if (debugHasLoggedFollowingPrefs.current) return
+    logEvent('debug:followingPrefs', {
+      followingShowRepliesFromPref: preferences.feedViewPrefs.hideReplies
+        ? 'off'
+        : preferences.feedViewPrefs.hideRepliesByUnfollowed
+        ? 'following'
+        : 'all',
+      followingRepliesMinLikePref:
+        preferences.feedViewPrefs.hideRepliesByLikeCount,
+    })
+    debugHasLoggedFollowingPrefs.current = true
+  }
+  const debugLogFollowingDisplayed = (feed: FeedDescriptor) => {
+    if (debugHasLoggedFollowingDisplayed.current) return
+    if (feed !== 'following') return
+    logEvent('debug:followingDisplayed', {})
+    debugHasLoggedFollowingDisplayed.current = true
+  }
+
   const {hasSession} = useSession()
   const setMinimalShellMode = useSetMinimalShellMode()
   const setDrawerSwipeDisabled = useSetDrawerSwipeDisabled()
@@ -127,47 +150,17 @@ function HomeScreenReady({
     ]),
   )
 
-  const onPageSelecting = React.useCallback(
-    (
-      index: number,
-      reason: LogEvents['home:feedDisplayed:sampled']['reason'],
-    ) => {
-      const feed = allFeeds[index]
-      if (feed === 'following') {
-        logEvent('home:feedDisplayed', {
-          index,
-          feedType: feed.split('|')[0],
-          feedUrl: feed,
-          reason,
-          followingShowRepliesFromPref: preferences.feedViewPrefs.hideReplies
-            ? 'off'
-            : preferences.feedViewPrefs.hideRepliesByUnfollowed
-            ? 'following'
-            : 'all',
-          followingRepliesMinLikePref:
-            preferences.feedViewPrefs.hideRepliesByLikeCount,
-        })
-      } else {
-        logEvent('home:feedDisplayed:sampled', {
-          index,
-          feedType: feed.split('|')[0],
-          feedUrl: feed,
-          reason,
-        })
-      }
-    },
-    [
-      allFeeds,
-      preferences.feedViewPrefs.hideReplies,
-      preferences.feedViewPrefs.hideRepliesByLikeCount,
-      preferences.feedViewPrefs.hideRepliesByUnfollowed,
-    ],
-  )
-
   useFocusEffect(
     useNonReactiveCallback(() => {
       if (selectedFeed) {
-        onPageSelecting(selectedIndex, 'focus')
+        logEvent('home:feedDisplayed:sampled', {
+          index: selectedIndex,
+          feedType: selectedFeed.split('|')[0],
+          feedUrl: selectedFeed,
+          reason: 'focus',
+        })
+        debugLogFollowingPrefs()
+        debugLogFollowingDisplayed(selectedFeed)
       }
     }),
   )
@@ -200,6 +193,23 @@ function HomeScreenReady({
       lastPagerReportedIndexRef.current = index
     },
     [setDrawerSwipeDisabled, setSelectedFeed, setMinimalShellMode, allFeeds],
+  )
+
+  const onPageSelecting = React.useCallback(
+    (
+      index: number,
+      reason: LogEvents['home:feedDisplayed:sampled']['reason'],
+    ) => {
+      const feed = allFeeds[index]
+      logEvent('home:feedDisplayed:sampled', {
+        index,
+        feedType: feed.split('|')[0],
+        feedUrl: feed,
+        reason,
+      })
+      debugLogFollowingDisplayed(feed)
+    },
+    [allFeeds],
   )
 
   const onPressSelected = React.useCallback(() => {


### PR DESCRIPTION
## Why

We want to do a little logging to ensure we don't have a bug in following feed preferences. There have been some reports that maybe it isn't working correctly, so let's test it out and see.

## How

We sample the feed displayed event now, so for the time being while we start debugging this, let's change that to always log these displays instead of sampling them.

## Test Plan

Whenever opening the app and displaying the following feed, we should be sending `feedDisplayed` events now instead of `feedDisplayed:sampled`. However, for all other feeds, we should still be using `feedDisplayed:sampled`.

There should also be two additional fields in the metadata now, showing what the preference is and how many likes are needed to actually display a reply in the following feed.

<img width="792" alt="Screenshot 2024-07-13 at 10 55 56 AM" src="https://github.com/user-attachments/assets/0ba5d9a4-d70a-4116-a9fd-4d88611f527d">

<img width="768" alt="Screenshot 2024-07-13 at 10 57 47 AM" src="https://github.com/user-attachments/assets/3e0a1d7a-cae1-42f8-bee4-e19629d2bcdb">

<img width="783" alt="Screenshot 2024-07-13 at 10 58 15 AM" src="https://github.com/user-attachments/assets/8b47e354-f8db-41f0-a38d-af21e39b46a7">

