### PR TITLE
Only sign out of a single account instead of all

### DIFF
--- a/src/state/session/index.tsx
+++ b/src/state/session/index.tsx
@@ -120,6 +120,7 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
       cancelPendingTask()
       dispatch({
         type: 'logged-out',
+        accountDid: account.did,
       })
       logEvent('account:loggedOut', {logContext})
       addSessionDebugLog({type: 'method:end', method: 'logout'})

--- a/src/state/session/reducer.ts
+++ b/src/state/session/reducer.ts
@@ -43,6 +43,7 @@ export type Action =
     }
   | {
       type: 'logged-out'
+      accountDid: string
     }
   | {
       type: 'synced-accounts'
@@ -143,21 +144,20 @@ let reducer = (state: State, action: Action): State => {
       }
     }
     case 'logged-out': {
-      //Fetch the account ID that the user signed out from
       const {accountDid} = action
 
-      //Find the account for which the tokens need to be cleared
-      const loggedOutAccount = state.accounts.filter(a => a.did === accountDid)
-
-      //Clear the tokens for the account that the user signed out from
-      loggedOutAccount.accessJwt = undefined
-      loggedOutAccount.refreshJwt = undefined
-
       return {
-        //Return all the accounts. The other accounts remain unchanged, so the user will
-        //stay signed in on them.
-        accounts: state.accounts
-        })),
+        accounts: state.accounts.map(a => {
+          if (a.did === accountDid) {
+            return {
+              ...a,
+              accessJwt: undefined,
+              refreshJwt: undefined,
+            }
+          } else {
+            return a
+          }
+        }),
         currentAgentState: createPublicAgentState(),
         needsPersist: true,
       }

--- a/src/state/session/reducer.ts
+++ b/src/state/session/reducer.ts
@@ -143,12 +143,20 @@ let reducer = (state: State, action: Action): State => {
       }
     }
     case 'logged-out': {
+      //Fetch the account ID that the user signed out from
+      const {accountDid} = action
+
+      //Find the account for which the tokens need to be cleared
+      const loggedOutAccount = state.accounts.filter(a => a.did === accountDid)
+
+      //Clear the tokens for the account that the user signed out from
+      loggedOutAccount.accessJwt = undefined
+      loggedOutAccount.refreshJwt = undefined
+
       return {
-        accounts: state.accounts.map(a => ({
-          ...a,
-          // Clear tokens for *every* account (this is a hard logout).
-          refreshJwt: undefined,
-          accessJwt: undefined,
+        //Return all the accounts. The other accounts remain unchanged, so the user will
+        //stay signed in on them.
+        accounts: state.accounts
         })),
         currentAgentState: createPublicAgentState(),
         needsPersist: true,


### PR DESCRIPTION
## Why

Updating https://github.com/bluesky-social/social-app/pull/4788

Right now, whenever a user logs out of an account, it signs them out of all their accounts rather than just the one they press "sign out" on. This means that even other accounts that still have a valid refresh token require a password to sign in again.

## Test Plan

Have not tested myself yet, just fixing some of the logic right now.