### PR TITLE
Use appropriate icons for toasts

### DIFF
--- a/src/App.native.tsx
+++ b/src/App.native.tsx
@@ -95,7 +95,10 @@ function InnerApp() {
 
   useEffect(() => {
     return listenSessionDropped(() => {
-      Toast.show(_(msg`Sorry! Your session expired. Please log in again.`))
+      Toast.show(
+        _(msg`Sorry! Your session expired. Please log in again.`),
+        'xmark',
+      )
     })
   }, [_])
 

--- a/src/App.native.tsx
+++ b/src/App.native.tsx
@@ -97,7 +97,7 @@ function InnerApp() {
     return listenSessionDropped(() => {
       Toast.show(
         _(msg`Sorry! Your session expired. Please log in again.`),
-        'xmark',
+        'info',
       )
     })
   }, [_])

--- a/src/App.web.tsx
+++ b/src/App.web.tsx
@@ -79,7 +79,7 @@ function InnerApp() {
     return listenSessionDropped(() => {
       Toast.show(
         _(msg`Sorry! Your session expired. Please log in again.`),
-        'xmark',
+        'info',
       )
     })
   }, [_])

--- a/src/App.web.tsx
+++ b/src/App.web.tsx
@@ -77,7 +77,10 @@ function InnerApp() {
 
   useEffect(() => {
     return listenSessionDropped(() => {
-      Toast.show(_(msg`Sorry! Your session expired. Please log in again.`))
+      Toast.show(
+        _(msg`Sorry! Your session expired. Please log in again.`),
+        'xmark',
+      )
     })
   }, [_])
 

--- a/src/components/FeedCard.tsx
+++ b/src/components/FeedCard.tsx
@@ -264,9 +264,9 @@ function SaveButtonInner({
           ])
         }
         Toast.show(_(msg`Feeds updated!`))
-      } catch (e: any) {
-        logger.error(e, {context: `FeedCard: failed to update feeds`, pin})
-        Toast.show(_(msg`Failed to update feeds`))
+      } catch (err: any) {
+        logger.error(err, {context: `FeedCard: failed to update feeds`, pin})
+        Toast.show(_(msg`Failed to update feeds`), 'xmark')
       }
     },
     [_, pin, saveFeeds, removeFeed, uri, savedFeedConfig, type],

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -306,9 +306,9 @@ export function FollowButtonInner({
           )}`,
         ),
       )
-    } catch (e: any) {
-      if (e?.name !== 'AbortError') {
-        Toast.show(_(msg`An issue occurred, please try again.`))
+    } catch (err: any) {
+      if (err?.name !== 'AbortError') {
+        Toast.show(_(msg`An issue occurred, please try again.`), 'xmark')
       }
     }
   }
@@ -326,9 +326,9 @@ export function FollowButtonInner({
           )}`,
         ),
       )
-    } catch (e: any) {
-      if (e?.name !== 'AbortError') {
-        Toast.show(_(msg`An issue occurred, please try again.`))
+    } catch (err: any) {
+      if (err?.name !== 'AbortError') {
+        Toast.show(_(msg`An issue occurred, please try again.`), 'xmark')
       }
     }
   }

--- a/src/components/StarterPack/QrCodeDialog.tsx
+++ b/src/components/StarterPack/QrCodeDialog.tsx
@@ -67,7 +67,10 @@ export function QrCodeDialog({
         try {
           await createAssetAsync(`file://${uri}`)
         } catch (e: unknown) {
-          Toast.show(_(msg`An error occurred while saving the QR code!`))
+          Toast.show(
+            _(msg`An error occurred while saving the QR code!`),
+            'xmark',
+          )
           logger.error('Failed to save QR code', {error: e})
           return
         }

--- a/src/components/StarterPack/ShareDialog.tsx
+++ b/src/components/StarterPack/ShareDialog.tsx
@@ -66,6 +66,7 @@ function ShareDialogInner({
     if (!res) {
       Toast.show(
         _(msg`You must grant access to your photo library to save the image.`),
+        'xmark',
       )
       return
     }
@@ -75,7 +76,7 @@ function ShareDialogInner({
       Toast.show(_(msg`Image saved to your camera roll!`))
       control.close()
     } catch (e: unknown) {
-      Toast.show(_(msg`An error occurred while saving the QR code!`))
+      Toast.show(_(msg`An error occurred while saving the QR code!`), 'xmark')
       logger.error('Failed to save QR code', {error: e})
       return
     }

--- a/src/components/WhoCanReply.tsx
+++ b/src/components/WhoCanReply.tsx
@@ -115,6 +115,7 @@ export function WhoCanReply({post, isThreadAuthor, style}: WhoCanReplyProps) {
         _(
           msg`There was an issue. Please check your internet connection and try again.`,
         ),
+        'xmark',
       )
       logger.error('Failed to edit threadgate', {message: err})
     }

--- a/src/components/dms/ConvoMenu.tsx
+++ b/src/components/dms/ConvoMenu.tsx
@@ -85,7 +85,7 @@ let ConvoMenu = ({
       }
     },
     onError: () => {
-      Toast.show(_(msg`Could not mute chat`))
+      Toast.show(_(msg`Could not mute chat`), 'xmark')
     },
   })
 

--- a/src/components/dms/LeaveConvoPrompt.tsx
+++ b/src/components/dms/LeaveConvoPrompt.tsx
@@ -36,7 +36,7 @@ export function LeaveConvoPrompt({
       }
     },
     onError: () => {
-      Toast.show(_(msg`Could not leave chat`))
+      Toast.show(_(msg`Could not leave chat`), 'xmark')
     },
   })
 

--- a/src/components/dms/MessageMenu.tsx
+++ b/src/components/dms/MessageMenu.tsx
@@ -54,7 +54,7 @@ export let MessageMenu = ({
     )
 
     Clipboard.setStringAsync(str)
-    Toast.show(_(msg`Copied to clipboard`))
+    Toast.show(_(msg`Copied to clipboard`), 'clipboard-check')
   }, [_, message.text, message.facets])
 
   const onPressTranslateMessage = React.useCallback(() => {

--- a/src/components/dms/MessagesNUX.tsx
+++ b/src/components/dms/MessagesNUX.tsx
@@ -57,7 +57,7 @@ function DialogInner({
   const [initialized, setInitialzed] = React.useState(false)
   const {mutate: updateDeclaration} = useUpdateActorDeclaration({
     onError: () => {
-      Toast.show(_(msg`Failed to update settings`))
+      Toast.show(_(msg`Failed to update settings`), 'xmark')
     },
   })
 

--- a/src/components/dms/dialogs/NewChatDialog.tsx
+++ b/src/components/dms/dialogs/NewChatDialog.tsx
@@ -32,7 +32,7 @@ export function NewChat({
       logEvent('chat:open', {logContext: 'NewChatDialog'})
     },
     onError: error => {
-      logger.error('Failed to create chat', {message: error})
+      logger.error('Failed to create chat', {safeMessage: error})
       Toast.show(_(msg`An issue occurred starting the chat`), 'xmark')
     },
   })

--- a/src/components/dms/dialogs/NewChatDialog.tsx
+++ b/src/components/dms/dialogs/NewChatDialog.tsx
@@ -2,6 +2,7 @@ import React, {useCallback} from 'react'
 import {msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
+import {logger} from '#/logger'
 import {useGetConvoForMembers} from '#/state/queries/messages/get-convo-for-members'
 import {logEvent} from 'lib/statsig/statsig'
 import {FAB} from '#/view/com/util/fab/FAB'
@@ -31,7 +32,8 @@ export function NewChat({
       logEvent('chat:open', {logContext: 'NewChatDialog'})
     },
     onError: error => {
-      Toast.show(error.message)
+      logger.error('Failed to create chat', {message: error})
+      Toast.show(_(msg`An issue occurred starting the chat`), 'xmark')
     },
   })
 

--- a/src/components/dms/dialogs/ShareViaChatDialog.tsx
+++ b/src/components/dms/dialogs/ShareViaChatDialog.tsx
@@ -2,6 +2,7 @@ import React, {useCallback} from 'react'
 import {msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
+import {logger} from '#/logger'
 import {useGetConvoForMembers} from '#/state/queries/messages/get-convo-for-members'
 import {logEvent} from 'lib/statsig/statsig'
 import * as Toast from '#/view/com/util/Toast'
@@ -43,7 +44,11 @@ function SendViaChatDialogInner({
       logEvent('chat:open', {logContext: 'SendViaChatDialog'})
     },
     onError: error => {
-      Toast.show(error.message)
+      logger.error('Failed to share post to chat', {message: error})
+      Toast.show(
+        _(msg`An issue occurred while trying to open the chat`),
+        'xmark',
+      )
     },
   })
 

--- a/src/components/hooks/useFollowMethods.ts
+++ b/src/components/hooks/useFollowMethods.ts
@@ -32,7 +32,7 @@ export function useFollowMethods({
       } catch (e: any) {
         logger.error(`useFollowMethods: failed to follow`, {message: String(e)})
         if (e?.name !== 'AbortError') {
-          Toast.show(_(msg`An issue occurred, please try again.`))
+          Toast.show(_(msg`An issue occurred, please try again.`), 'xmark')
         }
       }
     })
@@ -47,7 +47,7 @@ export function useFollowMethods({
           message: String(e),
         })
         if (e?.name !== 'AbortError') {
-          Toast.show(_(msg`An issue occurred, please try again.`))
+          Toast.show(_(msg`An issue occurred, please try again.`), 'xmark')
         }
       }
     })

--- a/src/components/moderation/LabelsOnMeDialog.tsx
+++ b/src/components/moderation/LabelsOnMeDialog.tsx
@@ -241,7 +241,7 @@ function AppealForm({
     },
     onError: err => {
       logger.error('Failed to submit label appeal', {message: err})
-      Toast.show(_(msg`Failed to submit appeal, please try again.`))
+      Toast.show(_(msg`Failed to submit appeal, please try again.`), 'xmark')
     },
     onSuccess: () => {
       control.close()

--- a/src/lib/media/picker.shared.ts
+++ b/src/lib/media/picker.shared.ts
@@ -17,14 +17,14 @@ export async function openPicker(opts?: ImagePickerOptions) {
   })
 
   if (response.assets && response.assets.length > 4) {
-    Toast.show('You may only select up to 4 images')
+    Toast.show('You may only select up to 4 images', 'exclamation-circle')
   }
 
   return (response.assets ?? [])
     .slice(0, 4)
     .filter(asset => {
       if (asset.mimeType?.startsWith('image/')) return true
-      Toast.show('Only image files are supported')
+      Toast.show('Only image files are supported', 'exclamation-circle')
       return false
     })
     .map(image => ({

--- a/src/lib/sharing.ts
+++ b/src/lib/sharing.ts
@@ -20,6 +20,6 @@ export async function shareUrl(url: string) {
     // React Native Share is not supported by web. Web Share API
     // has increasing but not full support, so default to clipboard
     setStringAsync(url)
-    Toast.show('Copied to clipboard')
+    Toast.show('Copied to clipboard', 'clipboard-check')
   }
 }

--- a/src/screens/Messages/Conversation/ChatDisabled.tsx
+++ b/src/screens/Messages/Conversation/ChatDisabled.tsx
@@ -84,7 +84,7 @@ function DialogInner() {
     },
     onError: err => {
       logger.error('Failed to submit chat appeal', {message: err})
-      Toast.show(_(msg`Failed to submit appeal, please try again.`))
+      Toast.show(_(msg`Failed to submit appeal, please try again.`), 'xmark')
     },
     onSuccess: () => {
       control.close()

--- a/src/screens/Messages/Conversation/MessageInput.tsx
+++ b/src/screens/Messages/Conversation/MessageInput.tsx
@@ -67,7 +67,7 @@ export function MessageInput({
       return
     }
     if (new Graphemer().countGraphemes(message) > MAX_DM_GRAPHEME_LENGTH) {
-      Toast.show(_(msg`Message is too long`))
+      Toast.show(_(msg`Message is too long`), 'xmark')
       return
     }
     clearDraft()

--- a/src/screens/Messages/Conversation/MessageInput.web.tsx
+++ b/src/screens/Messages/Conversation/MessageInput.web.tsx
@@ -46,7 +46,7 @@ export function MessageInput({
       return
     }
     if (new Graphemer().countGraphemes(message) > MAX_DM_GRAPHEME_LENGTH) {
-      Toast.show(_(msg`Message is too long`))
+      Toast.show(_(msg`Message is too long`), 'xmark')
       return
     }
     clearDraft()

--- a/src/screens/Messages/Settings.tsx
+++ b/src/screens/Messages/Settings.tsx
@@ -32,7 +32,7 @@ export function MessagesSettingsScreen({}: Props) {
 
   const {mutate: updateDeclaration} = useUpdateActorDeclaration({
     onError: () => {
-      Toast.show(_(msg`Failed to update settings`))
+      Toast.show(_(msg`Failed to update settings`), 'xmark')
     },
   })
 

--- a/src/screens/Profile/Header/ProfileHeaderLabeler.tsx
+++ b/src/screens/Profile/Header/ProfileHeaderLabeler.tsx
@@ -116,6 +116,7 @@ let ProfileHeaderLabeler = ({
         _(
           msg`There was an an issue contacting the server, please check your internet connection and try again.`,
         ),
+        'xmark',
       )
       logger.error(`Failed to toggle labeler like`, {message: e.message})
     }

--- a/src/screens/Profile/Header/ProfileHeaderStandard.tsx
+++ b/src/screens/Profile/Header/ProfileHeaderStandard.tsx
@@ -104,7 +104,7 @@ let ProfileHeaderStandard = ({
       } catch (e: any) {
         if (e?.name !== 'AbortError') {
           logger.error('Failed to follow', {message: String(e)})
-          Toast.show(_(msg`There was an issue! ${e.toString()}`))
+          Toast.show(_(msg`There was an issue! ${e.toString()}`), 'xmark')
         }
       }
     })
@@ -126,7 +126,7 @@ let ProfileHeaderStandard = ({
       } catch (e: any) {
         if (e?.name !== 'AbortError') {
           logger.error('Failed to unfollow', {message: String(e)})
-          Toast.show(_(msg`There was an issue! ${e.toString()}`))
+          Toast.show(_(msg`There was an issue! ${e.toString()}`), 'xmark')
         }
       }
     })
@@ -140,7 +140,7 @@ let ProfileHeaderStandard = ({
     } catch (e: any) {
       if (e?.name !== 'AbortError') {
         logger.error('Failed to unblock account', {message: e})
-        Toast.show(_(msg`There was an issue! ${e.toString()}`))
+        Toast.show(_(msg`There was an issue! ${e.toString()}`), 'xmark')
       }
     }
   }, [_, queueUnblock, track])

--- a/src/screens/StarterPack/StarterPackScreen.tsx
+++ b/src/screens/StarterPack/StarterPackScreen.tsx
@@ -359,7 +359,7 @@ function Header({
       captureAction(ProgressGuideAction.Follow, dids.length)
       Toast.show(_(msg`All accounts have been followed!`))
     } catch (e) {
-      Toast.show(_(msg`An error occurred while trying to follow all`))
+      Toast.show(_(msg`An error occurred while trying to follow all`), 'xmark')
     } finally {
       setIsProcessing(false)
     }
@@ -672,7 +672,7 @@ function InvalidStarterPack({rkey}: {rkey: string}) {
     onError: e => {
       setIsProcessing(false)
       logger.error('Failed to delete invalid starter pack', {safeMessage: e})
-      Toast.show(_(msg`Failed to delete starter pack`))
+      Toast.show(_(msg`Failed to delete starter pack`), 'xmark')
     },
   })
 

--- a/src/screens/StarterPack/Wizard/State.tsx
+++ b/src/screens/StarterPack/Wizard/State.tsx
@@ -74,7 +74,10 @@ function reducer(state: State, action: Action): State {
       break
     case 'AddProfile':
       if (state.profiles.length >= 51) {
-        Toast.show(msg`You may only add up to 50 profiles`.message ?? '')
+        Toast.show(
+          msg`You may only add up to 50 profiles`.message ?? '',
+          'info',
+        )
       } else {
         updatedState = {...state, profiles: [...state.profiles, action.profile]}
       }
@@ -89,7 +92,7 @@ function reducer(state: State, action: Action): State {
       break
     case 'AddFeed':
       if (state.feeds.length >= 50) {
-        Toast.show(msg`You may only add up to 50 feeds`.message ?? '')
+        Toast.show(msg`You may only add up to 50 feeds`.message ?? '', 'info')
       } else {
         updatedState = {...state, feeds: [...state.feeds, action.feed]}
       }

--- a/src/screens/StarterPack/Wizard/index.tsx
+++ b/src/screens/StarterPack/Wizard/index.tsx
@@ -227,7 +227,7 @@ function WizardInner({
     onError: e => {
       logger.error('Failed to create starter pack', {safeMessage: e})
       dispatch({type: 'SetProcessing', processing: false})
-      Toast.show(_(msg`Failed to create starter pack`))
+      Toast.show(_(msg`Failed to create starter pack`), 'xmark')
     },
   })
   const {mutate: editStarterPack} = useEditStarterPackMutation({
@@ -235,7 +235,7 @@ function WizardInner({
     onError: e => {
       logger.error('Failed to edit starter pack', {safeMessage: e})
       dispatch({type: 'SetProcessing', processing: false})
-      Toast.show(_(msg`Failed to create starter pack`))
+      Toast.show(_(msg`Failed to create starter pack`), 'xmark')
     },
   })
 

--- a/src/view/com/composer/videos/state.ts
+++ b/src/view/com/composer/videos/state.ts
@@ -24,7 +24,7 @@ export function useVideoState({setError}: {setError: (error: string) => void}) {
     onError: (e: any) => {
       // Don't log these errors in sentry, just let the user know
       if (e instanceof VideoTooLargeError) {
-        Toast.show(_(msg`Videos cannot be larger than 100MB`))
+        Toast.show(_(msg`Videos cannot be larger than 100MB`), 'xmark')
         return
       }
       logger.error('Failed to compress video', {safeError: e})

--- a/src/view/com/feeds/FeedSourceCard.tsx
+++ b/src/view/com/feeds/FeedSourceCard.tsx
@@ -125,7 +125,7 @@ export function FeedSourceCardLoaded({
       ])
       Toast.show(_(msg`Added to my feeds`))
     } catch (e) {
-      Toast.show(_(msg`There was an issue contacting your server`))
+      Toast.show(_(msg`There was an issue contacting your server`), 'xmark')
       logger.error('Failed to save feed', {message: e})
     }
   }, [_, feed, pinOnSave, addSavedFeeds, isSaved])
@@ -138,7 +138,7 @@ export function FeedSourceCardLoaded({
       // await item.unsave()
       Toast.show(_(msg`Removed from my feeds`))
     } catch (e) {
-      Toast.show(_(msg`There was an issue contacting your server`))
+      Toast.show(_(msg`There was an issue contacting your server`), 'xmark')
       logger.error('Failed to unsave feed', {message: e})
     }
   }, [_, removeFeed, savedFeedConfig])

--- a/src/view/com/lightbox/Lightbox.tsx
+++ b/src/view/com/lightbox/Lightbox.tsx
@@ -66,7 +66,10 @@ function LightboxFooter({imageIndex}: {imageIndex: number}) {
   const saveImageToAlbumWithToasts = React.useCallback(
     async (uri: string) => {
       if (!permissionResponse || permissionResponse.granted === false) {
-        Toast.show(_(msg`Permission to access camera roll is required.`))
+        Toast.show(
+          _(msg`Permission to access camera roll is required.`),
+          'info',
+        )
         if (permissionResponse?.canAskAgain) {
           requestPermission()
         } else {
@@ -74,6 +77,7 @@ function LightboxFooter({imageIndex}: {imageIndex: number}) {
             _(
               msg`Permission to access camera roll was denied. Please enable it in your system settings.`,
             ),
+            'xmark',
           )
         }
         return
@@ -83,7 +87,7 @@ function LightboxFooter({imageIndex}: {imageIndex: number}) {
         await saveImageToMediaLibrary({uri})
         Toast.show(_(msg`Saved to your camera roll`))
       } catch (e: any) {
-        Toast.show(_(msg`Failed to save image: ${String(e)}`))
+        Toast.show(_(msg`Failed to save image: ${String(e)}`), 'xmark')
       }
     },
     [permissionResponse, requestPermission, _],

--- a/src/view/com/modals/AddAppPasswords.tsx
+++ b/src/view/com/modals/AddAppPasswords.tsx
@@ -77,7 +77,7 @@ export function Component({}: {}) {
   const onCopy = React.useCallback(() => {
     if (appPassword) {
       setStringAsync(appPassword)
-      Toast.show(_(msg`Copied to clipboard`))
+      Toast.show(_(msg`Copied to clipboard`), 'clipboard-check')
       setWasCopied(true)
     }
   }, [appPassword, _])
@@ -93,7 +93,7 @@ export function Component({}: {}) {
         _(
           msg`Please enter a name for your app password. All spaces is not allowed.`,
         ),
-        'times',
+        'xmark',
       )
       return
     }
@@ -101,13 +101,13 @@ export function Component({}: {}) {
     if (name.length < 4) {
       Toast.show(
         _(msg`App Password names must be at least 4 characters long.`),
-        'times',
+        'xmark',
       )
       return
     }
 
     if (passwords?.find(p => p.name === name)) {
-      Toast.show(_(msg`This name is already in use`), 'times')
+      Toast.show(_(msg`This name is already in use`), 'xmark')
       return
     }
 
@@ -116,11 +116,11 @@ export function Component({}: {}) {
       if (newPassword) {
         setAppPassword(newPassword.password)
       } else {
-        Toast.show(_(msg`Failed to create app password.`), 'times')
+        Toast.show(_(msg`Failed to create app password.`), 'xmark')
         // TODO: better error handling (?)
       }
     } catch (e) {
-      Toast.show(_(msg`Failed to create app password.`), 'times')
+      Toast.show(_(msg`Failed to create app password.`), 'xmark')
       logger.error('Failed to create app password', {message: e})
     }
   }
@@ -137,6 +137,7 @@ export function Component({}: {}) {
         _(
           msg`App Password names can only contain letters, numbers, spaces, dashes, and underscores.`,
         ),
+        'xmark',
       )
     }
   }

--- a/src/view/com/modals/ChangeHandle.tsx
+++ b/src/view/com/modals/ChangeHandle.tsx
@@ -317,7 +317,7 @@ function CustomHandleForm({
   // =
   const onPressCopy = React.useCallback(() => {
     setStringAsync(isDNSForm ? `did=${currentAccount.did}` : currentAccount.did)
-    Toast.show(_(msg`Copied to clipboard`))
+    Toast.show(_(msg`Copied to clipboard`), 'clipboard-check')
   }, [currentAccount, isDNSForm, _])
   const onChangeHandle = React.useCallback(
     (v: string) => {

--- a/src/view/com/modals/InviteCodes.tsx
+++ b/src/view/com/modals/InviteCodes.tsx
@@ -150,7 +150,7 @@ function InviteCode({
 
   const onPress = React.useCallback(() => {
     setStringAsync(invite.code)
-    Toast.show(_(msg`Copied to clipboard`))
+    Toast.show(_(msg`Copied to clipboard`), 'clipboard-check')
     setInviteCopied(invite.code)
   }, [setInviteCopied, invite, _])
 

--- a/src/view/com/modals/ListAddRemoveUsers.tsx
+++ b/src/view/com/modals/ListAddRemoveUsers.tsx
@@ -7,32 +7,33 @@ import {
   View,
 } from 'react-native'
 import {AppBskyActorDefs, AppBskyGraphDefs} from '@atproto/api'
-import {ScrollView, TextInput} from './util'
 import {FontAwesomeIcon} from '@fortawesome/react-native-fontawesome'
-import {Text} from '../util/text/Text'
-import {Button} from '../util/forms/Button'
-import {UserAvatar} from '../util/UserAvatar'
-import * as Toast from '../util/Toast'
-import {s, colors} from 'lib/styles'
-import {usePalette} from 'lib/hooks/usePalette'
-import {isWeb} from 'platform/detection'
-import {useWebMediaQueries} from 'lib/hooks/useWebMediaQueries'
-import {useIsKeyboardVisible} from 'lib/hooks/useIsKeyboardVisible'
-import {cleanError} from 'lib/strings/errors'
-import {sanitizeDisplayName} from 'lib/strings/display-names'
-import {sanitizeHandle} from 'lib/strings/handles'
-import {HITSLOP_20} from '#/lib/constants'
-import {Trans, msg} from '@lingui/macro'
+import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
+
+import {HITSLOP_20} from '#/lib/constants'
 import {useModalControls} from '#/state/modals'
+import {useActorAutocompleteQuery} from '#/state/queries/actor-autocomplete'
 import {
-  useDangerousListMembershipsQuery,
   getMembership,
   ListMembersip,
+  useDangerousListMembershipsQuery,
   useListMembershipAddMutation,
   useListMembershipRemoveMutation,
 } from '#/state/queries/list-memberships'
-import {useActorAutocompleteQuery} from '#/state/queries/actor-autocomplete'
+import {useIsKeyboardVisible} from 'lib/hooks/useIsKeyboardVisible'
+import {usePalette} from 'lib/hooks/usePalette'
+import {useWebMediaQueries} from 'lib/hooks/useWebMediaQueries'
+import {sanitizeDisplayName} from 'lib/strings/display-names'
+import {cleanError} from 'lib/strings/errors'
+import {sanitizeHandle} from 'lib/strings/handles'
+import {colors, s} from 'lib/styles'
+import {isWeb} from 'platform/detection'
+import {Button} from '../util/forms/Button'
+import {Text} from '../util/text/Text'
+import * as Toast from '../util/Toast'
+import {UserAvatar} from '../util/UserAvatar'
+import {ScrollView, TextInput} from './util'
 
 export const snapPoints = ['90%']
 
@@ -200,7 +201,7 @@ function UserResult({
         onChange?.('remove', profile)
       }
     } catch (e) {
-      Toast.show(cleanError(e))
+      Toast.show(cleanError(e), 'xmark')
     } finally {
       setIsProcessing(false)
     }

--- a/src/view/com/modals/UserAddRemoveLists.tsx
+++ b/src/view/com/modals/UserAddRemoveLists.tsx
@@ -166,7 +166,7 @@ function ListItem({
         onRemove?.(list.uri)
       }
     } catch (e) {
-      Toast.show(cleanError(e))
+      Toast.show(cleanError(e), 'xmark')
     } finally {
       setIsProcessing(false)
     }

--- a/src/view/com/post-thread/PostThreadFollowBtn.tsx
+++ b/src/view/com/post-thread/PostThreadFollowBtn.tsx
@@ -96,7 +96,7 @@ function PostThreadFollowBtnLoaded({
         } catch (e: any) {
           if (e?.name !== 'AbortError') {
             logger.error('Failed to follow', {message: String(e)})
-            Toast.show(_(msg`There was an issue! ${e.toString()}`))
+            Toast.show(_(msg`There was an issue! ${e.toString()}`), 'xmark')
           }
         }
       })
@@ -108,7 +108,7 @@ function PostThreadFollowBtnLoaded({
         } catch (e: any) {
           if (e?.name !== 'AbortError') {
             logger.error('Failed to unfollow', {message: String(e)})
-            Toast.show(_(msg`There was an issue! ${e.toString()}`))
+            Toast.show(_(msg`There was an issue! ${e.toString()}`), 'xmark')
           }
         }
       })

--- a/src/view/com/posts/FeedErrorMessage.tsx
+++ b/src/view/com/posts/FeedErrorMessage.tsx
@@ -144,6 +144,7 @@ function FeedgenErrorMessage({
         _l(
           msgLingui`There was an an issue removing this feed. Please check your internet connection and try again.`,
         ),
+        'exclamation-circle',
       )
       logger.error('Failed to remove feed', {message: err})
     }

--- a/src/view/com/posts/FeedShutdownMsg.tsx
+++ b/src/view/com/posts/FeedShutdownMsg.tsx
@@ -51,6 +51,7 @@ export function FeedShutdownMsg({feedUri}: {feedUri: string}) {
         _(
           msg`There was an an issue updating your feeds, please check your internet connection and try again.`,
         ),
+        'exclamation-circle',
       )
       logger.error('Failed up update feeds', {message: err})
     }
@@ -69,6 +70,7 @@ export function FeedShutdownMsg({feedUri}: {feedUri: string}) {
         _(
           msg`There was an an issue updating your feeds, please check your internet connection and try again.`,
         ),
+        'exclamation-circle',
       )
       logger.error('Failed up update feeds', {message: err})
     }

--- a/src/view/com/profile/FollowButton.tsx
+++ b/src/view/com/profile/FollowButton.tsx
@@ -33,7 +33,7 @@ export function FollowButton({
       await queueFollow()
     } catch (e: any) {
       if (e?.name !== 'AbortError') {
-        Toast.show(_(msg`An issue occurred, please try again.`))
+        Toast.show(_(msg`An issue occurred, please try again.`), 'xmark')
       }
     }
   }
@@ -43,7 +43,7 @@ export function FollowButton({
       await queueUnfollow()
     } catch (e: any) {
       if (e?.name !== 'AbortError') {
-        Toast.show(_(msg`An issue occurred, please try again.`))
+        Toast.show(_(msg`An issue occurred, please try again.`), 'xmark')
       }
     }
   }

--- a/src/view/com/profile/ProfileHeaderSuggestedFollows.tsx
+++ b/src/view/com/profile/ProfileHeaderSuggestedFollows.tsx
@@ -185,7 +185,7 @@ function SuggestedFollow({
       await queueFollow()
     } catch (e: any) {
       if (e?.name !== 'AbortError') {
-        Toast.show(_(msg`An issue occurred, please try again.`))
+        Toast.show(_(msg`An issue occurred, please try again.`), 'xmark')
       }
     }
   }, [queueFollow, track, _])
@@ -195,7 +195,7 @@ function SuggestedFollow({
       await queueUnfollow()
     } catch (e: any) {
       if (e?.name !== 'AbortError') {
-        Toast.show(_(msg`An issue occurred, please try again.`))
+        Toast.show(_(msg`An issue occurred, please try again.`), 'xmark')
       }
     }
   }, [queueUnfollow, _])

--- a/src/view/com/profile/ProfileMenu.tsx
+++ b/src/view/com/profile/ProfileMenu.tsx
@@ -108,7 +108,7 @@ let ProfileMenu = ({
       } catch (e: any) {
         if (e?.name !== 'AbortError') {
           logger.error('Failed to unmute account', {message: e})
-          Toast.show(_(msg`There was an issue! ${e.toString()}`))
+          Toast.show(_(msg`There was an issue! ${e.toString()}`), 'xmark')
         }
       }
     } else {
@@ -119,7 +119,7 @@ let ProfileMenu = ({
       } catch (e: any) {
         if (e?.name !== 'AbortError') {
           logger.error('Failed to mute account', {message: e})
-          Toast.show(_(msg`There was an issue! ${e.toString()}`))
+          Toast.show(_(msg`There was an issue! ${e.toString()}`), 'xmark')
         }
       }
     }
@@ -134,7 +134,7 @@ let ProfileMenu = ({
       } catch (e: any) {
         if (e?.name !== 'AbortError') {
           logger.error('Failed to unblock account', {message: e})
-          Toast.show(_(msg`There was an issue! ${e.toString()}`))
+          Toast.show(_(msg`There was an issue! ${e.toString()}`), 'xmark')
         }
       }
     } else {
@@ -145,7 +145,7 @@ let ProfileMenu = ({
       } catch (e: any) {
         if (e?.name !== 'AbortError') {
           logger.error('Failed to block account', {message: e})
-          Toast.show(_(msg`There was an issue! ${e.toString()}`))
+          Toast.show(_(msg`There was an issue! ${e.toString()}`), 'xmark')
         }
       }
     }
@@ -159,7 +159,7 @@ let ProfileMenu = ({
     } catch (e: any) {
       if (e?.name !== 'AbortError') {
         logger.error('Failed to follow account', {message: e})
-        Toast.show(_(msg`There was an issue! ${e.toString()}`))
+        Toast.show(_(msg`There was an issue! ${e.toString()}`), 'xmark')
       }
     }
   }, [_, queueFollow, track])
@@ -172,7 +172,7 @@ let ProfileMenu = ({
     } catch (e: any) {
       if (e?.name !== 'AbortError') {
         logger.error('Failed to unfollow account', {message: e})
-        Toast.show(_(msg`There was an issue! ${e.toString()}`))
+        Toast.show(_(msg`There was an issue! ${e.toString()}`), 'xmark')
       }
     }
   }, [_, queueUnfollow, track])

--- a/src/view/com/util/Toast.web.tsx
+++ b/src/view/com/util/Toast.web.tsx
@@ -2,7 +2,7 @@
  * Note: the dataSet properties are used to leverage custom CSS in public/index.html
  */
 
-import React, {useState, useEffect} from 'react'
+import React, {useEffect, useState} from 'react'
 import {StyleSheet, Text, View} from 'react-native'
 import {
   FontAwesomeIcon,
@@ -39,7 +39,7 @@ export const ToastContainer: React.FC<ToastContainerProps> = ({}) => {
         <View style={styles.container}>
           <FontAwesomeIcon
             icon={activeToast.icon}
-            size={24}
+            size={16}
             style={styles.icon as FontAwesomeIconStyle}
           />
           <Text style={styles.text}>{activeToast.text}</Text>
@@ -79,6 +79,7 @@ const styles = StyleSheet.create({
   },
   icon: {
     color: '#fff',
+    flexShrink: 0,
   },
   text: {
     color: '#fff',

--- a/src/view/com/util/Toast.web.tsx
+++ b/src/view/com/util/Toast.web.tsx
@@ -39,7 +39,7 @@ export const ToastContainer: React.FC<ToastContainerProps> = ({}) => {
         <View style={styles.container}>
           <FontAwesomeIcon
             icon={activeToast.icon}
-            size={16}
+            size={20}
             style={styles.icon as FontAwesomeIconStyle}
           />
           <Text style={styles.text}>{activeToast.text}</Text>

--- a/src/view/com/util/forms/PostDropdownBtn.tsx
+++ b/src/view/com/util/forms/PostDropdownBtn.tsx
@@ -149,7 +149,7 @@ let PostDropdownBtn = ({
       },
       e => {
         logger.error('Failed to delete post', {message: e})
-        Toast.show(_(msg`Failed to delete post, please try again`))
+        Toast.show(_(msg`Failed to delete post, please try again`), 'xmark')
       },
     )
   }, [
@@ -177,7 +177,10 @@ let PostDropdownBtn = ({
     } catch (e: any) {
       if (e?.name !== 'AbortError') {
         logger.error('Failed to toggle thread mute', {message: e})
-        Toast.show(_(msg`Failed to toggle thread mute, please try again`))
+        Toast.show(
+          _(msg`Failed to toggle thread mute, please try again`),
+          'xmark',
+        )
       }
     }
   }, [isThreadMuted, unmuteThread, _, muteThread])
@@ -186,7 +189,7 @@ let PostDropdownBtn = ({
     const str = richTextToString(richText, true)
 
     Clipboard.setStringAsync(str)
-    Toast.show(_(msg`Copied to clipboard`))
+    Toast.show(_(msg`Copied to clipboard`), 'clipboard-check')
   }, [_, richText])
 
   const onPressTranslate = React.useCallback(() => {

--- a/src/view/com/util/post-ctrls/PostCtrls.tsx
+++ b/src/view/com/util/post-ctrls/PostCtrls.tsx
@@ -354,7 +354,7 @@ let PostCtrls = ({
           onPress={e => {
             e.stopPropagation()
             Clipboard.setStringAsync(feedContext)
-            Toast.show(_(msg`Copied to clipboard`))
+            Toast.show(_(msg`Copied to clipboard`), 'clipboard-check')
           }}>
           <Text
             style={{

--- a/src/view/icons/index.tsx
+++ b/src/view/icons/index.tsx
@@ -51,6 +51,7 @@ import {faChevronRight} from '@fortawesome/free-solid-svg-icons/faChevronRight'
 import {faCircleCheck} from '@fortawesome/free-solid-svg-icons/faCircleCheck'
 import {faCircleDot} from '@fortawesome/free-solid-svg-icons/faCircleDot'
 import {faCircleExclamation} from '@fortawesome/free-solid-svg-icons/faCircleExclamation'
+import {faClipboardCheck} from '@fortawesome/free-solid-svg-icons/faClipboardCheck'
 import {faClone} from '@fortawesome/free-solid-svg-icons/faClone'
 import {faCommentSlash} from '@fortawesome/free-solid-svg-icons/faCommentSlash'
 import {faDownload} from '@fortawesome/free-solid-svg-icons/faDownload'
@@ -140,6 +141,7 @@ library.add(
   faCircleExclamation,
   faCirclePlay,
   faCircleUser,
+  faClipboardCheck,
   faClone,
   farClone,
   faComment,

--- a/src/view/screens/ProfileFeed.tsx
+++ b/src/view/screens/ProfileFeed.tsx
@@ -205,6 +205,7 @@ export function ProfileFeedScreenInner({
         _(
           msg`There was an an issue updating your feeds, please check your internet connection and try again.`,
         ),
+        'xmark',
       )
       logger.error('Failed up update feeds', {message: err})
     }
@@ -231,7 +232,7 @@ export function ProfileFeedScreenInner({
         ])
       }
     } catch (e) {
-      Toast.show(_(msg`There was an issue contacting the server`))
+      Toast.show(_(msg`There was an issue contacting the server`), 'xmark')
       logger.error('Failed to toggle pinned feed', {message: e})
     }
   }, [
@@ -543,6 +544,7 @@ function AboutSection({
         _(
           msg`There was an an issue contacting the server, please check your internet connection and try again.`,
         ),
+        'xmark',
       )
       logger.error('Failed up toggle like', {message: err})
     }

--- a/src/view/screens/ProfileList.tsx
+++ b/src/view/screens/ProfileList.tsx
@@ -300,7 +300,7 @@ function Header({rkey, list}: {rkey: string; list: AppBskyGraphDefs.ListView}) {
         Toast.show(_(msg`Saved to your feeds`))
       }
     } catch (e) {
-      Toast.show(_(msg`There was an issue contacting the server`))
+      Toast.show(_(msg`There was an issue contacting the server`), 'xmark')
       logger.error('Failed to toggle pinned feed', {message: e})
     }
   }, [
@@ -319,7 +319,7 @@ function Header({rkey, list}: {rkey: string; list: AppBskyGraphDefs.ListView}) {
       await removeSavedFeed(savedFeedConfig)
       Toast.show(_(msg`Removed from your feeds`))
     } catch (e) {
-      Toast.show(_(msg`There was an issue contacting the server`))
+      Toast.show(_(msg`There was an issue contacting the server`), 'xmark')
       logger.error('Failed to remove pinned list', {message: e})
     }
   }, [playHaptic, removeSavedFeed, _, savedFeedConfig])

--- a/src/view/screens/SavedFeeds.tsx
+++ b/src/view/screens/SavedFeeds.tsx
@@ -234,7 +234,7 @@ function ListItem({
         },
       ])
     } catch (e) {
-      Toast.show(_(msg`There was an issue contacting the server`))
+      Toast.show(_(msg`There was an issue contacting the server`), 'xmark')
       logger.error('Failed to toggle pinned feed', {message: e})
     }
   }, [_, playHaptic, feed, updateSavedFeeds, resetSaveFeedsMutationState])
@@ -260,7 +260,7 @@ function ListItem({
         index: nextIndex,
       })
     } catch (e) {
-      Toast.show(_(msg`There was an issue contacting the server`))
+      Toast.show(_(msg`There was an issue contacting the server`), 'xmark')
       logger.error('Failed to set pinned feed order', {message: e})
     }
   }, [feed, isPinned, overwriteSavedFeeds, currentFeeds, _])
@@ -286,7 +286,7 @@ function ListItem({
         index: nextIndex,
       })
     } catch (e) {
-      Toast.show(_(msg`There was an issue contacting the server`))
+      Toast.show(_(msg`There was an issue contacting the server`), 'xmark')
       logger.error('Failed to set pinned feed order', {message: e})
     }
   }, [feed, isPinned, overwriteSavedFeeds, currentFeeds, _])

--- a/src/view/screens/Settings/ExportCarDialog.tsx
+++ b/src/view/screens/Settings/ExportCarDialog.tsx
@@ -43,7 +43,7 @@ export function ExportCarDialog({
       }
     } catch (e) {
       logger.error('Error occurred while downloading CAR file', {message: e})
-      Toast.show(_(msg`Error occurred while saving file`))
+      Toast.show(_(msg`Error occurred while saving file`), 'xmark')
     } finally {
       setLoading(false)
       control.close()


### PR DESCRIPTION
Despite toasts being used heavily for reporting errors, we just show a default tick icon which is a bit dissonant for a popup displaying bad news. This PR goes through and uses `xmark` for negative ones, with a few as `info` or `exclamation-circle` where appropriate. I also made the clipboard related ones use a clipboard icon.

Also, I shrunk the icon a little and applied `flex-shrink: 0` so it stays a consistent size

<img width="415" alt="Screenshot 2024-07-19 at 14 56 57" src="https://github.com/user-attachments/assets/4f6b64ee-bba1-457c-815d-2b271abdf151">
<img width="397" alt="Screenshot 2024-07-19 at 14 56 33" src="https://github.com/user-attachments/assets/7e50d189-7f76-4233-97dd-ede4ead1582d">
