### PR TITLE
Fix switch style and animate

### DIFF
--- a/src/components/forms/Toggle.tsx
+++ b/src/components/forms/Toggle.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import {Pressable, StyleSheet, View, ViewStyle} from 'react-native'
+import {Pressable, View, ViewStyle} from 'react-native'
 import Animated, {LinearTransition} from 'react-native-reanimated'
 
 import {HITSLOP_10} from 'lib/constants'
@@ -14,8 +14,6 @@ import {
 import {useInteractionState} from '#/components/hooks/useInteractionState'
 import {CheckThick_Stroke2_Corner0_Rounded as Checkmark} from '#/components/icons/Check'
 import {Text} from '#/components/Typography'
-
-const hairlineWidth = StyleSheet.hairlineWidth
 
 export type ItemState = {
   name: string
@@ -348,10 +346,10 @@ export function Checkbox() {
       style={[
         a.justify_center,
         a.align_center,
-        a.border,
         a.rounded_xs,
         t.atoms.border_contrast_high,
         {
+          borderWidth: 1,
           height: 20,
           width: 20,
         },
@@ -379,14 +377,14 @@ export function Switch() {
     <View
       style={[
         a.relative,
-        a.border,
         a.rounded_full,
         t.atoms.bg,
         t.atoms.border_contrast_high,
         {
-          height: 20 + hairlineWidth * 2,
-          width: 35,
-          padding: 3,
+          borderWidth: 1,
+          height: 20,
+          width: 32,
+          padding: 2,
         },
         baseStyles,
         hovered ? baseHoverStyles : {},
@@ -433,10 +431,10 @@ export function Radio() {
       style={[
         a.justify_center,
         a.align_center,
-        a.border,
         a.rounded_full,
         t.atoms.border_contrast_high,
         {
+          borderWidth: 1,
           height: 20,
           width: 20,
         },

--- a/src/components/forms/Toggle.tsx
+++ b/src/components/forms/Toggle.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import {Pressable, View, ViewStyle} from 'react-native'
+import {Pressable, StyleSheet, View, ViewStyle} from 'react-native'
 
 import {HITSLOP_10} from 'lib/constants'
 import {
@@ -13,6 +13,8 @@ import {
 import {useInteractionState} from '#/components/hooks/useInteractionState'
 import {CheckThick_Stroke2_Corner0_Rounded as Checkmark} from '#/components/icons/Check'
 import {Text} from '#/components/Typography'
+
+const hairlineWidth = StyleSheet.hairlineWidth
 
 export type ItemState = {
   name: string
@@ -380,29 +382,29 @@ export function Switch() {
         t.atoms.bg,
         t.atoms.border_contrast_high,
         {
-          height: 20,
-          width: 30,
+          height: 20 + hairlineWidth * 2,
+          width: 35,
+          padding: 3,
         },
         baseStyles,
         hovered ? baseHoverStyles : {},
       ]}>
       <View
         style={[
-          a.absolute,
           a.rounded_full,
           {
-            height: 12,
-            width: 12,
-            top: 3,
-            left: 3,
-            backgroundColor: t.palette.contrast_400,
+            height: 14,
+            width: 14,
           },
           selected
             ? {
                 backgroundColor: t.palette.primary_500,
-                left: 13,
+                alignSelf: 'flex-start',
               }
-            : {},
+            : {
+                backgroundColor: t.palette.contrast_400,
+                alignSelf: 'flex-end',
+              },
           indicatorStyles,
         ]}
       />

--- a/src/components/forms/Toggle.tsx
+++ b/src/components/forms/Toggle.tsx
@@ -247,6 +247,7 @@ export function LabelText({
     <Text
       style={[
         a.font_bold,
+        a.leading_tight,
         {
           userSelect: 'none',
           color: disabled
@@ -254,7 +255,7 @@ export function LabelText({
             : t.atoms.text_contrast_high.color,
         },
         native({
-          paddingTop: 3,
+          paddingTop: 2,
         }),
         flatten(style),
       ]}>

--- a/src/components/forms/Toggle.tsx
+++ b/src/components/forms/Toggle.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import {Pressable, StyleSheet, View, ViewStyle} from 'react-native'
+import Animated, {LinearTransition} from 'react-native-reanimated'
 
 import {HITSLOP_10} from 'lib/constants'
 import {
@@ -389,7 +390,8 @@ export function Switch() {
         baseStyles,
         hovered ? baseHoverStyles : {},
       ]}>
-      <View
+      <Animated.View
+        layout={LinearTransition.duration(100)}
         style={[
           a.rounded_full,
           {


### PR DESCRIPTION
After we changed all the border widths to hairline, the switch component broke, since the size of the container was expecting the border to be 1px. Setting the height to `20 + hairlineWidth * 2` fixes it

While I'm here, I added a layout animation, made it slightly wider, and made it use flexbox instead of absolute positioning

Before
![Screenshot 2024-07-23 at 21 58 05](https://github.com/user-attachments/assets/b3db96cf-64ef-4467-a06d-d942d35e962a)
After
![Screenshot 2024-07-23 at 21 53 04](https://github.com/user-attachments/assets/7de68f88-f351-49c4-9ca0-b9c9994e6233)