### PR TITLE
Hack-modify avi path to use smaller thumbs behind gate

### DIFF
--- a/src/lib/statsig/gates.ts
+++ b/src/lib/statsig/gates.ts
@@ -14,3 +14,4 @@ export type Gate =
   | 'suggested_follows_interstitial'
   | 'ungroup_follow_backs'
   | 'videos'
+  | 'small_avi_thumb'

--- a/src/view/com/util/UserAvatar.tsx
+++ b/src/view/com/util/UserAvatar.tsx
@@ -224,7 +224,10 @@ let UserAvatar = ({
           style={aviStyle}
           resizeMode="cover"
           source={{
-            uri: hackModifyThumbnailPath(avatar, gate('small_avi_thumb')),
+            uri: hackModifyThumbnailPath(
+              avatar,
+              size < 90 && gate('small_avi_thumb'),
+            ),
           }}
           blurRadius={moderation?.blur ? BLUR_AMOUNT : 0}
         />
@@ -234,7 +237,10 @@ let UserAvatar = ({
           style={aviStyle}
           contentFit="cover"
           source={{
-            uri: hackModifyThumbnailPath(avatar, gate('small_avi_thumb')),
+            uri: hackModifyThumbnailPath(
+              avatar,
+              size < 90 && gate('small_avi_thumb'),
+            ),
           }}
           blurRadius={moderation?.blur ? BLUR_AMOUNT : 0}
         />
@@ -443,8 +449,8 @@ export {PreviewableUserAvatar}
 // We have started serving smaller avis but haven't updated lexicons to give the data properly
 // manually string-replace to use the smaller ones
 // -prf
-function hackModifyThumbnailPath(uri: string, isGateEnabled: boolean): string {
-  return isGateEnabled
+function hackModifyThumbnailPath(uri: string, isEnabled: boolean): string {
+  return isEnabled
     ? uri.replace('/img/avatar/plain/', '/img/avatar_thumbnail/plain/')
     : uri
 }

--- a/src/view/com/util/UserAvatar.tsx
+++ b/src/view/com/util/UserAvatar.tsx
@@ -8,6 +8,7 @@ import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 import {useQueryClient} from '@tanstack/react-query'
 
+import {useGate} from '#/lib/statsig/statsig'
 import {logger} from '#/logger'
 import {usePalette} from 'lib/hooks/usePalette'
 import {
@@ -179,6 +180,7 @@ let UserAvatar = ({
   const pal = usePalette('default')
   const backgroundColor = pal.colors.backgroundLight
   const finalShape = overrideShape ?? (type === 'user' ? 'circle' : 'square')
+  const gate = useGate()
 
   const aviStyle = useMemo(() => {
     if (finalShape === 'square') {
@@ -221,7 +223,9 @@ let UserAvatar = ({
           testID="userAvatarImage"
           style={aviStyle}
           resizeMode="cover"
-          source={{uri: avatar}}
+          source={{
+            uri: hackModifyThumbnailPath(avatar, gate('small_avi_thumb')),
+          }}
           blurRadius={moderation?.blur ? BLUR_AMOUNT : 0}
         />
       ) : (
@@ -229,7 +233,9 @@ let UserAvatar = ({
           testID="userAvatarImage"
           style={aviStyle}
           contentFit="cover"
-          source={{uri: avatar}}
+          source={{
+            uri: hackModifyThumbnailPath(avatar, gate('small_avi_thumb')),
+          }}
           blurRadius={moderation?.blur ? BLUR_AMOUNT : 0}
         />
       )}
@@ -432,6 +438,16 @@ let PreviewableUserAvatar = ({
 }
 PreviewableUserAvatar = memo(PreviewableUserAvatar)
 export {PreviewableUserAvatar}
+
+// HACK
+// We have started serving smaller avis but haven't updated lexicons to give the data properly
+// manually string-replace to use the smaller ones
+// -prf
+function hackModifyThumbnailPath(uri: string, isGateEnabled: boolean): string {
+  return isGateEnabled
+    ? uri.replace('/img/avatar/plain/', '/img/avatar_thumbnail/plain/')
+    : uri
+}
 
 const styles = StyleSheet.create({
   editButtonContainer: {


### PR DESCRIPTION
We now have smaller AVI thumbnails being served. We will eventually update our lexicons, or just the server responses, to give the new smaller AVI-thumb paths. For now, we're manually modifying the path.

Note: behind the `small_avi_thumb` gate so that we can roll this out progressively, since this change will result in a bunch of CDN cache misses and we need to control its rollout.