### PR TITLE
Use consistent index for reading last item

### DIFF
--- a/src/view/com/posts/FeedSlice.tsx
+++ b/src/view/com/posts/FeedSlice.tsx
@@ -56,12 +56,12 @@ let FeedSlice = ({
           record={slice.items[last].record}
           reason={slice.items[last].reason}
           feedContext={slice.items[last].feedContext}
-          parentAuthor={slice.items[2].parentAuthor}
+          parentAuthor={slice.items[last].parentAuthor}
           showReplyTo={false}
           moderation={slice.items[last].moderation}
           isThreadParent={isThreadParentAt(slice.items, last)}
           isThreadChild={isThreadChildAt(slice.items, last)}
-          isParentBlocked={slice.items[2].isParentBlocked}
+          isParentBlocked={slice.items[last].isParentBlocked}
           isThreadLastChild
         />
       </>


### PR DESCRIPTION
This doesn't actually change anything in practice (at least right now) but it fixes an inconsistency in which item we're reading the index from. This inconsistency by itself is definitely possible:

![Screenshot 2024-07-24 at 02 13 13](https://github.com/user-attachments/assets/05b0c0c9-5328-427b-8048-3d064e4df4c0)

The reason it didn't matter (despite wrong prop values) is that `showReplyTo` is `false` for this branch. It's still worth fixing though.

## Test Plan

Visual inspection. Self-threads still show like before:

![Screenshot 2024-07-24 at 02 18 53](https://github.com/user-attachments/assets/c2fb06fe-0c32-48fa-9f0a-ac8652ad61fb)
