### PR TITLE
Fix sloppy filter(Boolean) types

### DIFF
--- a/src/state/queries/post-feed.ts
+++ b/src/state/queries/post-feed.ts
@@ -78,7 +78,10 @@ export interface FeedPostSliceItem {
   uri: string
   post: AppBskyFeedDefs.PostView
   record: AppBskyFeedPost.Record
-  reason?: AppBskyFeedDefs.ReasonRepost | ReasonFeedSource
+  reason?:
+    | AppBskyFeedDefs.ReasonRepost
+    | ReasonFeedSource
+    | {[k: string]: unknown; $type: string}
   feedContext: string | undefined
   moderation: ModerationDecision
   parentAuthor?: AppBskyActorDefs.ProfileViewBasic

--- a/src/state/queries/post-feed.ts
+++ b/src/state/queries/post-feed.ts
@@ -344,9 +344,17 @@ export function usePostFeedQuery(
                           AppBskyFeedPost.validateRecord(item.post.record)
                             .success
                         ) {
-                          const parentAuthor =
-                            item.reply?.parent?.author ??
-                            slice.items[i + 1]?.reply?.grandparentAuthor
+                          const parent = item.reply?.parent
+                          let parentAuthor:
+                            | AppBskyActorDefs.ProfileViewBasic
+                            | undefined
+                          if (AppBskyFeedDefs.isPostView(parent)) {
+                            parentAuthor = parent.author
+                          }
+                          if (!parentAuthor) {
+                            parentAuthor =
+                              slice.items[i + 1]?.reply?.grandparentAuthor
+                          }
                           const replyRef = item.reply
                           const isParentBlocked = AppBskyFeedDefs.isBlockedPost(
                             replyRef?.parent,

--- a/src/state/queries/post-feed.ts
+++ b/src/state/queries/post-feed.ts
@@ -323,7 +323,7 @@ export function usePostFeedQuery(
                     )
                   }
 
-                  return {
+                  const feedPostSlice: FeedPostSlice = {
                     _reactKey: slice._reactKey,
                     _isFeedPostSlice: true,
                     rootUri: slice.rootItem.post.uri,
@@ -349,7 +349,7 @@ export function usePostFeedQuery(
                             replyRef?.parent,
                           )
 
-                          return {
+                          const feedPostSliceItem: FeedPostSliceItem = {
                             _reactKey: `${slice._reactKey}-${i}-${item.post.uri}`,
                             uri: item.post.uri,
                             post: item.post,
@@ -363,13 +363,15 @@ export function usePostFeedQuery(
                             parentAuthor,
                             isParentBlocked,
                           }
+                          return feedPostSliceItem
                         }
                         return undefined
                       })
-                      .filter(Boolean) as FeedPostSliceItem[],
+                      .filter(<T>(n?: T): n is T => Boolean(n)),
                   }
+                  return feedPostSlice
                 })
-                .filter(Boolean) as FeedPostSlice[],
+                .filter(<T>(n?: T): n is T => Boolean(n)),
             })),
           ],
         }

--- a/src/state/queries/threadgate.ts
+++ b/src/state/queries/threadgate.ts
@@ -4,7 +4,7 @@ export type ThreadgateSetting =
   | {type: 'nobody'}
   | {type: 'mention'}
   | {type: 'following'}
-  | {type: 'list'; list: string}
+  | {type: 'list'; list: unknown}
 
 export function threadgateViewToSettings(
   threadgate: AppBskyFeedDefs.ThreadgateView | undefined,
@@ -21,18 +21,18 @@ export function threadgateViewToSettings(
   if (!record.allow?.length) {
     return [{type: 'nobody'}]
   }
-  return record.allow
+  const settings: ThreadgateSetting[] = record.allow
     .map(allow => {
+      let setting: ThreadgateSetting | undefined
       if (allow.$type === 'app.bsky.feed.threadgate#mentionRule') {
-        return {type: 'mention'}
+        setting = {type: 'mention'}
+      } else if (allow.$type === 'app.bsky.feed.threadgate#followingRule') {
+        setting = {type: 'following'}
+      } else if (allow.$type === 'app.bsky.feed.threadgate#listRule') {
+        setting = {type: 'list', list: allow.list}
       }
-      if (allow.$type === 'app.bsky.feed.threadgate#followingRule') {
-        return {type: 'following'}
-      }
-      if (allow.$type === 'app.bsky.feed.threadgate#listRule') {
-        return {type: 'list', list: allow.list}
-      }
-      return undefined
+      return setting
     })
-    .filter(Boolean) as ThreadgateSetting[]
+    .filter(<T>(n?: T): n is T => Boolean(n))
+  return settings
 }

--- a/src/view/com/posts/FeedItem.tsx
+++ b/src/view/com/posts/FeedItem.tsx
@@ -48,7 +48,11 @@ import {Repost_Stroke2_Corner2_Rounded as Repost} from '#/components/icons/Repos
 
 interface FeedItemProps {
   record: AppBskyFeedPost.Record
-  reason: AppBskyFeedDefs.ReasonRepost | ReasonFeedSource | undefined
+  reason:
+    | AppBskyFeedDefs.ReasonRepost
+    | ReasonFeedSource
+    | {[k: string]: unknown; $type: string}
+    | undefined
   moderation: ModerationDecision
   parentAuthor: AppBskyActorDefs.ProfileViewBasic | undefined
   showReplyTo: boolean

--- a/src/view/screens/Search/Explore.tsx
+++ b/src/view/screens/Search/Explore.tsx
@@ -75,17 +75,17 @@ function SuggestedItemsHeader({
   )
 }
 
-type LoadMoreItems =
+type LoadMoreItem =
   | {
       type: 'profile'
       key: string
-      avatar: string
+      avatar: string | undefined
       moderation: ModerationDecision
     }
   | {
       type: 'feed'
       key: string
-      avatar: string
+      avatar: string | undefined
       moderation: undefined
     }
 
@@ -98,27 +98,28 @@ function LoadMore({
 }) {
   const t = useTheme()
   const {_} = useLingui()
-  const items = React.useMemo(() => {
+  const items: LoadMoreItem[] = React.useMemo(() => {
     return item.items
       .map(_item => {
+        let loadMoreItem: LoadMoreItem | undefined
         if (_item.type === 'profile') {
-          return {
+          loadMoreItem = {
             type: 'profile',
             key: _item.profile.did,
             avatar: _item.profile.avatar,
             moderation: moderateProfile(_item.profile, moderationOpts!),
           }
         } else if (_item.type === 'feed') {
-          return {
+          loadMoreItem = {
             type: 'feed',
             key: _item.feed.uri,
             avatar: _item.feed.avatar,
             moderation: undefined,
           }
         }
-        return undefined
+        return loadMoreItem
       })
-      .filter(Boolean) as LoadMoreItems[]
+      .filter(<T,>(n?: T): n is T => Boolean(n))
   }, [item.items, moderationOpts])
 
   if (items.length === 0) return null


### PR DESCRIPTION
We were using this `as Foo[]` pattern which is not good. I got bit by this in my ongoing feed slice refactor because the types were lyring. I'm using [this approach](https://stackoverflow.com/questions/47632622/typescript-and-filter-boolean#comment93284037_47636222) to get them typed more strongly. It requires extracting variables instead of early returns and some manual annotations, but these actually _do_ get checked.

This surfaced some violations. They're not actually breaking the logic. These two are trivial:

- https://github.com/bluesky-social/social-app/commit/16c714a4ba64da90cff696b742691fa9f0e7d1d6
- https://github.com/bluesky-social/social-app/commit/d3189d3fe27819a82046c6079e4f0b2875150584

This one is more involved:

- https://github.com/bluesky-social/social-app/commit/f3caf3e921fb7c0e8dfaf449c1229346511bb6c5
- https://github.com/bluesky-social/social-app/commit/41f2dd7ebdaafd6522af28cb04c65e70b69e9720
- https://github.com/bluesky-social/social-app/commit/6dadf673d46f8cb2351f61effc41fa03d82fb9bf

It uncovered type errors stemming from `parentAuthor` being defined as `ProfileViewBasic` even though technically it could be anything (because we're reading `author` from a union). We also aren't able to use `isProfileViewBasic()` here because the object from the server does not have a `$type`. So instead I'm checking the `post` itself. If it's a `PostView`, we can read the `author` from it. I've had to add some extra logic to deal with blocked posts because the component types were lying.

## Test Plan

- Verified editing thread gates still work for each option.
- Verified "Load more" shows up and works as expected in Explore for both profiles and feeds.
- Verified "in reply to..." still shows up in feed
  - Placed breakpoints in both cases where we assign `parentAuthor` and verified we're able to hit both
  - Verified "Reply to you", "Reply to blocked post", "Reply to <...>" all work