### PR TITLE
Refactor feed slices

### DIFF
--- a/src/lib/api/feed-manip.ts
+++ b/src/lib/api/feed-manip.ts
@@ -64,10 +64,6 @@ export class FeedViewPostsSlice {
     )
   }
 
-  get isFullThread() {
-    return this.isThread && !this.items[0].reply
-  }
-
   get rootItem(): FeedViewPost {
     return this._originalFeedViewPost
   }
@@ -318,7 +314,7 @@ export class FeedTuner {
       // remove any replies without at least minLikes likes
       for (let i = slices.length - 1; i >= 0; i--) {
         const slice = slices[i]
-        if (slice.isFullThread || !slice.isReply) {
+        if ((slice.isThread && !slice.items[0].reply) || !slice.isReply) {
           continue
         }
 

--- a/src/lib/api/feed-manip.ts
+++ b/src/lib/api/feed-manip.ts
@@ -37,13 +37,13 @@ function toSliceItem(feedViewPost: FeedViewPost): FeedSliceItem {
 
 export class FeedViewPostsSlice {
   _reactKey: string
-  _originalFeedViewPost: FeedViewPost
+  _feedPost: FeedViewPost
   items: FeedSliceItem[]
   feedContext: string | undefined
 
   constructor(items: FeedViewPost[]) {
     const item = items[0]
-    this._originalFeedViewPost = item
+    this._feedPost = item
     this._reactKey = `slice-${item.post.uri}-${
       item.reason?.indexedAt || item.post.indexedAt
     }`
@@ -52,7 +52,7 @@ export class FeedViewPostsSlice {
   }
 
   get uri() {
-    return this.rootItem.post.uri
+    return this._feedPost.post.uri
   }
 
   get isThread() {
@@ -64,12 +64,8 @@ export class FeedViewPostsSlice {
     )
   }
 
-  get rootItem(): FeedViewPost {
-    return this._originalFeedViewPost
-  }
-
   get isQuotePost() {
-    const embed = this.rootItem.post.embed
+    const embed = this._feedPost.post.embed
     return (
       AppBskyEmbedRecord.isView(embed) ||
       AppBskyEmbedRecordWithMedia.isView(embed)
@@ -78,13 +74,13 @@ export class FeedViewPostsSlice {
 
   get isReply() {
     return (
-      AppBskyFeedPost.isRecord(this.rootItem.post.record) &&
-      !!this.rootItem.post.record.reply
+      AppBskyFeedPost.isRecord(this._feedPost.post.record) &&
+      !!this._feedPost.post.record.reply
     )
   }
 
   get isRepost() {
-    const reason = this.rootItem.reason
+    const reason = this._feedPost.reason
     return AppBskyFeedDefs.isReasonRepost(reason)
   }
 
@@ -93,7 +89,7 @@ export class FeedViewPostsSlice {
   }
 
   get likeCount() {
-    return this.rootItem.post.likeCount ?? 0
+    return this._feedPost.post.likeCount ?? 0
   }
 
   containsUri(uri: string) {
@@ -124,17 +120,18 @@ export class FeedViewPostsSlice {
   }
 
   isFollowingAllAuthors(userDid: string) {
-    const item = this.rootItem
-    if (item.post.author.did === userDid) {
+    const feedPost = this._feedPost
+    if (feedPost.post.author.did === userDid) {
       return true
     }
-    if (AppBskyFeedDefs.isPostView(item.reply?.parent)) {
-      const parent = item.reply?.parent
+    if (AppBskyFeedDefs.isPostView(feedPost.reply?.parent)) {
+      const parent = feedPost.reply?.parent
       if (parent?.author.did === userDid) {
         return true
       }
       return (
-        parent?.author.viewer?.following && item.post.author.viewer?.following
+        parent?.author.viewer?.following &&
+        feedPost.post.author.viewer?.following
       )
     }
     return false

--- a/src/lib/api/feed-manip.ts
+++ b/src/lib/api/feed-manip.ts
@@ -314,19 +314,20 @@ export class FeedTuner {
       // remove any replies without at least minLikes likes
       for (let i = slices.length - 1; i >= 0; i--) {
         const slice = slices[i]
-        if ((slice.isThread && !slice.items[0].reply) || !slice.isReply) {
-          continue
-        }
-
-        const item = slice.rootItem
-        const isRepost = Boolean(item.reason)
-        if (isRepost) {
-          continue
-        }
-        if ((item.post.likeCount || 0) < minLikes) {
-          slices.splice(i, 1)
-        } else if (followedOnly && !slice.isFollowingAllAuthors(userDid)) {
-          slices.splice(i, 1)
+        if (slice.isReply) {
+          if (slice.isThread && !slice.items[0].reply) {
+            continue
+          }
+          const item = slice.rootItem
+          const isRepost = Boolean(item.reason)
+          if (isRepost) {
+            continue
+          }
+          if ((item.post.likeCount || 0) < minLikes) {
+            slices.splice(i, 1)
+          } else if (followedOnly && !slice.isFollowingAllAuthors(userDid)) {
+            slices.splice(i, 1)
+          }
         }
       }
       return slices

--- a/src/lib/api/feed-manip.ts
+++ b/src/lib/api/feed-manip.ts
@@ -41,12 +41,6 @@ export class FeedViewPostsSlice {
     this.items = [toSliceItem(feedPost)]
   }
 
-  get reason() {
-    return '__source' in this._feedPost
-      ? (this._feedPost.__source as ReasonFeedSource)
-      : this._feedPost.reason
-  }
-
   get uri() {
     return this._feedPost.post.uri
   }
@@ -73,6 +67,12 @@ export class FeedViewPostsSlice {
       AppBskyFeedPost.isRecord(this._feedPost.post.record) &&
       !!this._feedPost.post.record.reply
     )
+  }
+
+  get reason() {
+    return '__source' in this._feedPost
+      ? (this._feedPost.__source as ReasonFeedSource)
+      : this._feedPost.reason
   }
 
   get isRepost() {

--- a/src/lib/api/feed-manip.ts
+++ b/src/lib/api/feed-manip.ts
@@ -37,12 +37,14 @@ function toSliceItem(feedViewPost: FeedViewPost): FeedSliceItem {
 
 export class FeedViewPostsSlice {
   _reactKey: string
+  _originalFeedViewPost: FeedViewPost
   items: FeedSliceItem[]
   isFlattenedReply = false
 
   constructor(items: FeedViewPost[]) {
     this.items = items.map(toSliceItem)
     const item = items[0]
+    this._originalFeedViewPost = item
     this._reactKey = `slice-${item.post.uri}-${
       item.reason?.indexedAt || item.post.indexedAt
     }`
@@ -75,11 +77,8 @@ export class FeedViewPostsSlice {
     return this.isThread && !this.items[0].reply
   }
 
-  get rootItem() {
-    if (this.isFlattenedReply) {
-      return this.items[1]
-    }
-    return this.items[0]
+  get rootItem(): FeedViewPost {
+    return this._originalFeedViewPost
   }
 
   get isReply() {

--- a/src/lib/api/feed-manip.ts
+++ b/src/lib/api/feed-manip.ts
@@ -30,14 +30,12 @@ export class FeedViewPostsSlice {
   _reactKey: string
   _feedPost: FeedViewPost
   items: FeedSliceItem[]
-  feedContext: string | undefined
 
   constructor(feedPost: FeedViewPost) {
     this._feedPost = feedPost
     this._reactKey = `slice-${feedPost.post.uri}-${
       feedPost.reason?.indexedAt || feedPost.post.indexedAt
     }`
-    this.feedContext = feedPost.feedContext
     this.items = [toSliceItem(feedPost)]
   }
 
@@ -73,6 +71,10 @@ export class FeedViewPostsSlice {
     return '__source' in this._feedPost
       ? (this._feedPost.__source as ReasonFeedSource)
       : this._feedPost.reason
+  }
+
+  get feedContext() {
+    return this._feedPost.feedContext
   }
 
   get isRepost() {

--- a/src/lib/api/feed-manip.ts
+++ b/src/lib/api/feed-manip.ts
@@ -32,14 +32,13 @@ export class FeedViewPostsSlice {
   items: FeedSliceItem[]
   feedContext: string | undefined
 
-  constructor(items: FeedViewPost[]) {
-    const item = items[0]
-    this._feedPost = item
-    this._reactKey = `slice-${item.post.uri}-${
-      item.reason?.indexedAt || item.post.indexedAt
+  constructor(feedPost: FeedViewPost) {
+    this._feedPost = feedPost
+    this._reactKey = `slice-${feedPost.post.uri}-${
+      feedPost.reason?.indexedAt || feedPost.post.indexedAt
     }`
-    this.feedContext = item.feedContext
-    this.items = items.map(toSliceItem)
+    this.feedContext = feedPost.feedContext
+    this.items = [toSliceItem(feedPost)]
   }
 
   get reason() {
@@ -141,7 +140,7 @@ export class NoopFeedTuner {
     feed: FeedViewPost[],
     _opts?: {dryRun: boolean; maintainOrder: boolean},
   ): FeedViewPostsSlice[] {
-    return feed.map(item => new FeedViewPostsSlice([item]))
+    return feed.map(item => new FeedViewPostsSlice(item))
   }
 }
 
@@ -179,7 +178,7 @@ export class FeedTuner {
     })
 
     if (maintainOrder) {
-      slices = feed.map(item => new FeedViewPostsSlice([item]))
+      slices = feed.map(item => new FeedViewPostsSlice(item))
     } else {
       // arrange the posts into thread slices
       for (let i = feed.length - 1; i >= 0; i--) {
@@ -206,7 +205,7 @@ export class FeedTuner {
           }
         }
 
-        slices.unshift(new FeedViewPostsSlice([item]))
+        slices.unshift(new FeedViewPostsSlice(item))
       }
     }
 

--- a/src/lib/api/feed-manip.ts
+++ b/src/lib/api/feed-manip.ts
@@ -14,11 +14,25 @@ export type FeedTunerFn = (
   slices: FeedViewPostsSlice[],
 ) => FeedViewPostsSlice[]
 
+type FeedSliceItem = {
+  post: AppBskyFeedDefs.PostView
+  reply?: AppBskyFeedDefs.ReplyRef
+  reason?: AppBskyFeedDefs.ReasonRepost | {$type: string; [k: string]: unknown}
+  feedContext?: string
+  [k: string]: unknown
+}
+
+function toSliceItem(feedViewPost: FeedViewPost): FeedSliceItem {
+  return feedViewPost
+}
+
 export class FeedViewPostsSlice {
   _reactKey: string
+  items: FeedSliceItem[]
   isFlattenedReply = false
 
-  constructor(public items: FeedViewPost[]) {
+  constructor(items: FeedViewPost[]) {
+    this.items = items.map(toSliceItem)
     const item = items[0]
     this._reactKey = `slice-${item.post.uri}-${
       item.reason?.indexedAt || item.post.indexedAt

--- a/src/lib/api/feed-manip.ts
+++ b/src/lib/api/feed-manip.ts
@@ -19,11 +19,20 @@ type FeedSliceItem = {
   reply?: AppBskyFeedDefs.ReplyRef
   reason?: AppBskyFeedDefs.ReasonRepost | {$type: string; [k: string]: unknown}
   feedContext?: string
-  [k: string]: unknown
+  __source?: ReasonFeedSource | undefined
 }
 
 function toSliceItem(feedViewPost: FeedViewPost): FeedSliceItem {
-  return feedViewPost
+  return {
+    post: feedViewPost.post,
+    reply: feedViewPost.reply,
+    reason: feedViewPost.reason,
+    feedContext: feedViewPost.feedContext,
+    __source:
+      '__source' in feedViewPost
+        ? (feedViewPost.__source as ReasonFeedSource)
+        : undefined,
+  }
 }
 
 export class FeedViewPostsSlice {
@@ -81,8 +90,7 @@ export class FeedViewPostsSlice {
   }
 
   get source(): ReasonFeedSource | undefined {
-    return this.items.find(item => '__source' in item && !!item.__source)
-      ?.__source as ReasonFeedSource
+    return this.items.find(item => !!item.__source)?.__source
   }
 
   get feedContext() {

--- a/src/lib/api/feed-manip.ts
+++ b/src/lib/api/feed-manip.ts
@@ -22,7 +22,6 @@ type FeedSliceItem = {
     | AppBskyFeedDefs.ReasonRepost
     | {$type: string; [k: string]: unknown}
     | undefined
-  feedContext?: string
 }
 
 function toSliceItem(feedViewPost: FeedViewPost): FeedSliceItem {
@@ -33,7 +32,6 @@ function toSliceItem(feedViewPost: FeedViewPost): FeedSliceItem {
       '__source' in feedViewPost
         ? (feedViewPost.__source as ReasonFeedSource)
         : feedViewPost.reason,
-    feedContext: feedViewPost.feedContext,
   }
 }
 
@@ -42,14 +40,16 @@ export class FeedViewPostsSlice {
   _originalFeedViewPost: FeedViewPost
   items: FeedSliceItem[]
   isFlattenedReply = false
+  feedContext: string | undefined
 
   constructor(items: FeedViewPost[]) {
-    this.items = items.map(toSliceItem)
     const item = items[0]
     this._originalFeedViewPost = item
     this._reactKey = `slice-${item.post.uri}-${
       item.reason?.indexedAt || item.post.indexedAt
     }`
+    this.feedContext = item.feedContext
+    this.items = items.map(toSliceItem)
   }
 
   get uri() {
@@ -89,10 +89,6 @@ export class FeedViewPostsSlice {
       AppBskyFeedPost.isRecord(this.rootItem.post.record) &&
       !!this.rootItem.post.record.reply
     )
-  }
-
-  get feedContext() {
-    return this.items.find(item => item.feedContext)?.feedContext
   }
 
   containsUri(uri: string) {

--- a/src/lib/api/feed-manip.ts
+++ b/src/lib/api/feed-manip.ts
@@ -75,6 +75,10 @@ export class FeedViewPostsSlice {
     )
   }
 
+  get includesThreadRoot() {
+    return !this.items[0].reply
+  }
+
   containsUri(uri: string) {
     return !!this.items.find(item => item.post.uri === uri)
   }
@@ -315,7 +319,7 @@ export class FeedTuner {
       for (let i = slices.length - 1; i >= 0; i--) {
         const slice = slices[i]
         if (slice.isReply) {
-          if (slice.isThread && !slice.items[0].reply) {
+          if (slice.isThread && slice.includesThreadRoot) {
             continue
           }
           const item = slice.rootItem

--- a/src/lib/api/feed-manip.ts
+++ b/src/lib/api/feed-manip.ts
@@ -39,7 +39,6 @@ export class FeedViewPostsSlice {
   _reactKey: string
   _originalFeedViewPost: FeedViewPost
   items: FeedSliceItem[]
-  isFlattenedReply = false
   feedContext: string | undefined
 
   constructor(items: FeedViewPost[]) {
@@ -53,10 +52,7 @@ export class FeedViewPostsSlice {
   }
 
   get uri() {
-    if (this.isFlattenedReply) {
-      return this.items[1].post.uri
-    }
-    return this.items[0].post.uri
+    return this.rootItem.post.uri
   }
 
   get ts() {
@@ -113,7 +109,6 @@ export class FeedViewPostsSlice {
     if (this.items[0].reply) {
       const reply = this.items[0].reply
       if (AppBskyFeedDefs.isPostView(reply.parent)) {
-        this.isFlattenedReply = true
         this.items.splice(0, 0, {post: reply.parent})
       }
     }

--- a/src/lib/api/feed-manip.ts
+++ b/src/lib/api/feed-manip.ts
@@ -17,21 +17,12 @@ export type FeedTunerFn = (
 type FeedSliceItem = {
   post: AppBskyFeedDefs.PostView
   reply?: AppBskyFeedDefs.ReplyRef
-  reason?:
-    | ReasonFeedSource
-    | AppBskyFeedDefs.ReasonRepost
-    | {$type: string; [k: string]: unknown}
-    | undefined
 }
 
 function toSliceItem(feedViewPost: FeedViewPost): FeedSliceItem {
   return {
     post: feedViewPost.post,
     reply: feedViewPost.reply,
-    reason:
-      '__source' in feedViewPost
-        ? (feedViewPost.__source as ReasonFeedSource)
-        : feedViewPost.reason,
   }
 }
 
@@ -49,6 +40,12 @@ export class FeedViewPostsSlice {
     }`
     this.feedContext = item.feedContext
     this.items = items.map(toSliceItem)
+  }
+
+  get reason() {
+    return '__source' in this._feedPost
+      ? (this._feedPost.__source as ReasonFeedSource)
+      : this._feedPost.reason
   }
 
   get uri() {
@@ -232,7 +229,7 @@ export class FeedTuner {
 
     // turn non-threads with reply parents into threads
     for (const slice of slices) {
-      if (!slice.isThread && !slice.items[0].reason && slice.items[0].reply) {
+      if (!slice.isThread && !slice.reason && slice.items[0].reply) {
         const reply = slice.items[0].reply
         if (
           AppBskyFeedDefs.isPostView(reply.parent) &&

--- a/src/lib/api/feed-manip.ts
+++ b/src/lib/api/feed-manip.ts
@@ -55,14 +55,6 @@ export class FeedViewPostsSlice {
     return this.rootItem.post.uri
   }
 
-  get ts() {
-    const reason = this.items[0].reason
-    if (AppBskyFeedDefs.isReasonRepost(reason) && reason?.indexedAt) {
-      return reason.indexedAt as string
-    }
-    return this.items[0].post.indexedAt
-  }
-
   get isThread() {
     return (
       this.items.length > 1 &&

--- a/src/lib/api/feed/merge.ts
+++ b/src/lib/api/feed/merge.ts
@@ -251,7 +251,7 @@ class MergeFeedSource_Following extends MergeFeedSource {
       dryRun: false,
       maintainOrder: true,
     })
-    res.data.feed = slices.map(slice => slice.rootItem)
+    res.data.feed = slices.map(slice => slice._feedPost)
     return res
   }
 }

--- a/src/state/queries/post-feed.ts
+++ b/src/state/queries/post-feed.ts
@@ -314,7 +314,7 @@ export function usePostFeedQuery(
                   if (isDiscover) {
                     userActionHistory.seen(
                       slice.items.map(item => ({
-                        feedContext: item.feedContext,
+                        feedContext: slice.feedContext,
                         likeCount: item.post.likeCount ?? 0,
                         repostCount: item.post.repostCount ?? 0,
                         replyCount: item.post.replyCount ?? 0,
@@ -366,7 +366,7 @@ export function usePostFeedQuery(
                             post: item.post,
                             record: item.post.record,
                             reason: item.reason,
-                            feedContext: item.feedContext || slice.feedContext,
+                            feedContext: slice.feedContext,
                             moderation: moderations[i],
                             parentAuthor,
                             isParentBlocked,

--- a/src/state/queries/post-feed.ts
+++ b/src/state/queries/post-feed.ts
@@ -329,7 +329,7 @@ export function usePostFeedQuery(
                   const feedPostSlice: FeedPostSlice = {
                     _reactKey: slice._reactKey,
                     _isFeedPostSlice: true,
-                    rootUri: slice.rootItem.post.uri,
+                    rootUri: slice.uri,
                     isThread:
                       slice.items.length > 1 &&
                       slice.items.every(

--- a/src/state/queries/post-feed.ts
+++ b/src/state/queries/post-feed.ts
@@ -365,10 +365,7 @@ export function usePostFeedQuery(
                             uri: item.post.uri,
                             post: item.post,
                             record: item.post.record,
-                            reason:
-                              i === 0 && slice.source
-                                ? slice.source
-                                : item.reason,
+                            reason: item.reason,
                             feedContext: item.feedContext || slice.feedContext,
                             moderation: moderations[i],
                             parentAuthor,

--- a/src/state/queries/post-feed.ts
+++ b/src/state/queries/post-feed.ts
@@ -365,7 +365,7 @@ export function usePostFeedQuery(
                             uri: item.post.uri,
                             post: item.post,
                             record: item.post.record,
-                            reason: item.reason,
+                            reason: slice.reason,
                             feedContext: slice.feedContext,
                             moderation: moderations[i],
                             parentAuthor,


### PR DESCRIPTION
I'm refactoring feed slicing. This refactor should fully preserve the existing behavior but it makes strategic code changes that will prepare us for the next PR https://github.com/bluesky-social/social-app/pull/4835, which solves longstanding problems with how replies show up in the feed.

The best way to follow along, unfortunately, is to read commit-by-commit. Each change is meant to be atomic and safe (mostly manipulation). The main theme of this refactor is to decouple the shape of a "slice item" from `FeedPostView` so that https://github.com/bluesky-social/social-app/pull/4835 can construct it on-the-fly from parent and root with correct information. I'm tucking away low-level access of `slices[i].items.reply` and similar fields into the `slice` API itself so that I can later change the type of individual items.

I guess you could also just [read the entire diff](https://github.com/bluesky-social/social-app/pull/4834/files?w=1).

By the end of this refactor, the only code that reaches out into "internals" of a slice is the slice item manipulation logic which the next PR will get rid of.

## Test Plan

This is going to require some non-trivial testing. Things you'll want to look at:

- Mergefeed on/off
- Reposts of replies
- Self-threads
- Other people's threads
- Replies on/off
- Like threshold on replies
- Follow setting on replies
- Deduplication
- Reposts on/off
- Quotes on/off
- Replies to blocked/deleted posts

The goal in this PR is to stay aligned with the behavior on main.