### PR TITLE
[Draft] Show replies in context of their threads

### DIFF
--- a/src/lib/api/feed-manip.ts
+++ b/src/lib/api/feed-manip.ts
@@ -59,7 +59,11 @@ export class FeedViewPostsSlice {
       ) {
         if (parent.uri !== root.uri) {
           this.items.unshift({
-            isParentBlocked: false, // TODO(dan)
+            isParentBlocked: Boolean(
+              grandparentAuthor?.viewer?.blockedBy ||
+                grandparentAuthor?.viewer?.blocking ||
+                grandparentAuthor?.viewer?.blockingByList,
+            ),
             parentAuthor: grandparentAuthor,
             post: parent,
           })

--- a/src/lib/api/feed-manip.ts
+++ b/src/lib/api/feed-manip.ts
@@ -1,4 +1,5 @@
 import {
+  AppBskyActorDefs,
   AppBskyEmbedRecord,
   AppBskyEmbedRecordWithMedia,
   AppBskyFeedDefs,
@@ -16,13 +17,21 @@ export type FeedTunerFn = (
 
 type FeedSliceItem = {
   post: AppBskyFeedDefs.PostView
-  reply?: AppBskyFeedDefs.ReplyRef
+  parentAuthor: AppBskyActorDefs.ProfileViewBasic | undefined
+  isParentBlocked: boolean
 }
 
 function toSliceItem(feedViewPost: FeedViewPost): FeedSliceItem {
+  const parent = feedViewPost.reply?.parent
+  const isParentBlocked = AppBskyFeedDefs.isBlockedPost(parent)
+  let parentAuthor: AppBskyActorDefs.ProfileViewBasic | undefined
+  if (AppBskyFeedDefs.isPostView(parent)) {
+    parentAuthor = parent.author
+  }
   return {
     post: feedViewPost.post,
-    reply: feedViewPost.reply,
+    parentAuthor,
+    isParentBlocked,
   }
 }
 
@@ -83,7 +92,7 @@ export class FeedViewPostsSlice {
   }
 
   get includesThreadRoot() {
-    return !this.items[0].reply
+    return true // TODO(dan): Ensure this is actually the case.
   }
 
   get likeCount() {

--- a/src/lib/api/feed-manip.ts
+++ b/src/lib/api/feed-manip.ts
@@ -99,8 +99,8 @@ export class FeedViewPostsSlice {
   }
 
   insert(item: FeedViewPost) {
-    const selfReplyUri = getSelfReplyUri(item)
-    const i = this.items.findIndex(item2 => item2.post.uri === selfReplyUri)
+    const replyUri = getReplyUri(item)
+    const i = this.items.findIndex(item2 => item2.post.uri === replyUri)
     if (i !== -1) {
       this.items.splice(i + 1, 0, item)
     } else {
@@ -186,10 +186,10 @@ export class FeedTuner {
       for (let i = feed.length - 1; i >= 0; i--) {
         const item = feed[i]
 
-        const selfReplyUri = getSelfReplyUri(item)
-        if (selfReplyUri) {
+        const replyUri = getReplyUri(item)
+        if (replyUri) {
           const index = slices.findIndex(slice =>
-            slice.isNextInThread(selfReplyUri),
+            slice.isNextInThread(replyUri),
           )
 
           if (index !== -1) {
@@ -388,15 +388,13 @@ export class FeedTuner {
   }
 }
 
-function getSelfReplyUri(item: FeedViewPost): string | undefined {
+function getReplyUri(item: FeedViewPost): string | undefined {
   if (item.reply) {
     if (
       AppBskyFeedDefs.isPostView(item.reply.parent) &&
       !AppBskyFeedDefs.isReasonRepost(item.reason) // don't thread reposted self-replies
     ) {
-      return item.reply.parent.author.did === item.post.author.did
-        ? item.reply.parent.uri
-        : undefined
+      return item.reply.parent.uri
     }
   }
   return undefined

--- a/src/lib/api/feed/merge.ts
+++ b/src/lib/api/feed/merge.ts
@@ -249,7 +249,6 @@ class MergeFeedSource_Following extends MergeFeedSource {
     // run the tuner pre-emptively to ensure better mixing
     const slices = this.tuner.tune(res.data.feed, {
       dryRun: false,
-      maintainOrder: true,
     })
     res.data.feed = slices.map(slice => slice._feedPost)
     return res

--- a/src/state/queries/post-feed.ts
+++ b/src/state/queries/post-feed.ts
@@ -93,7 +93,6 @@ export interface FeedPostSlice {
   _reactKey: string
   rootUri: string
   hasGap: boolean
-  isThread: boolean
   items: FeedPostSliceItem[]
 }
 
@@ -332,13 +331,6 @@ export function usePostFeedQuery(
                     _isFeedPostSlice: true,
                     hasGap: slice.hasGap,
                     rootUri: slice.uri,
-                    isThread:
-                      slice.items.length > 1 &&
-                      slice.items.every(
-                        item =>
-                          item.post.author.did ===
-                          slice.items[0].post.author.did,
-                      ),
                     items: slice.items
                       .map((item, i) => {
                         if (

--- a/src/state/queries/post-feed.ts
+++ b/src/state/queries/post-feed.ts
@@ -434,7 +434,6 @@ export async function pollLatest(page: FeedPage | undefined) {
   if (post) {
     const slices = page.tuner.tune([post], {
       dryRun: true,
-      maintainOrder: true,
     })
     if (slices[0]) {
       return true

--- a/src/state/queries/post-feed.ts
+++ b/src/state/queries/post-feed.ts
@@ -92,6 +92,7 @@ export interface FeedPostSlice {
   _isFeedPostSlice: boolean
   _reactKey: string
   rootUri: string
+  hasGap: boolean
   isThread: boolean
   items: FeedPostSliceItem[]
 }
@@ -329,6 +330,7 @@ export function usePostFeedQuery(
                   const feedPostSlice: FeedPostSlice = {
                     _reactKey: slice._reactKey,
                     _isFeedPostSlice: true,
+                    hasGap: slice.hasGap,
                     rootUri: slice.uri,
                     isThread:
                       slice.items.length > 1 &&

--- a/src/state/queries/post-feed.ts
+++ b/src/state/queries/post-feed.ts
@@ -344,22 +344,6 @@ export function usePostFeedQuery(
                           AppBskyFeedPost.validateRecord(item.post.record)
                             .success
                         ) {
-                          const parent = item.reply?.parent
-                          let parentAuthor:
-                            | AppBskyActorDefs.ProfileViewBasic
-                            | undefined
-                          if (AppBskyFeedDefs.isPostView(parent)) {
-                            parentAuthor = parent.author
-                          }
-                          if (!parentAuthor) {
-                            parentAuthor =
-                              slice.items[i + 1]?.reply?.grandparentAuthor
-                          }
-                          const replyRef = item.reply
-                          const isParentBlocked = AppBskyFeedDefs.isBlockedPost(
-                            replyRef?.parent,
-                          )
-
                           const feedPostSliceItem: FeedPostSliceItem = {
                             _reactKey: `${slice._reactKey}-${i}-${item.post.uri}`,
                             uri: item.post.uri,
@@ -368,8 +352,8 @@ export function usePostFeedQuery(
                             reason: slice.reason,
                             feedContext: slice.feedContext,
                             moderation: moderations[i],
-                            parentAuthor,
-                            isParentBlocked,
+                            parentAuthor: item.parentAuthor,
+                            isParentBlocked: item.isParentBlocked,
                           }
                           return feedPostSliceItem
                         }

--- a/src/view/com/posts/FeedSlice.tsx
+++ b/src/view/com/posts/FeedSlice.tsx
@@ -19,6 +19,7 @@ let FeedSlice = ({
   hideTopBorder?: boolean
 }): React.ReactNode => {
   if (slice.items.length > 3) {
+    const beforeLast = slice.items.length - 2
     const last = slice.items.length - 1
     return (
       <>
@@ -36,20 +37,20 @@ let FeedSlice = ({
           hideTopBorder={hideTopBorder}
           isParentBlocked={slice.items[0].isParentBlocked}
         />
-        <FeedItem
-          key={slice.items[1]._reactKey}
-          post={slice.items[1].post}
-          record={slice.items[1].record}
-          reason={slice.items[1].reason}
-          feedContext={slice.items[1].feedContext}
-          parentAuthor={slice.items[1].parentAuthor}
-          showReplyTo={false}
-          moderation={slice.items[1].moderation}
-          isThreadParent={isThreadParentAt(slice.items, 1)}
-          isThreadChild={isThreadChildAt(slice.items, 1)}
-          isParentBlocked={slice.items[1].isParentBlocked}
-        />
         <ViewFullThread slice={slice} />
+        <FeedItem
+          key={slice.items[beforeLast]._reactKey}
+          post={slice.items[beforeLast].post}
+          record={slice.items[beforeLast].record}
+          reason={slice.items[beforeLast].reason}
+          feedContext={slice.items[beforeLast].feedContext}
+          parentAuthor={slice.items[beforeLast].parentAuthor}
+          showReplyTo={false}
+          moderation={slice.items[beforeLast].moderation}
+          isThreadParent={isThreadParentAt(slice.items, beforeLast)}
+          isThreadChild={isThreadChildAt(slice.items, beforeLast)}
+          isParentBlocked={slice.items[beforeLast].isParentBlocked}
+        />
         <FeedItem
           key={slice.items[last]._reactKey}
           post={slice.items[last].post}

--- a/src/view/com/posts/FeedSlice.tsx
+++ b/src/view/com/posts/FeedSlice.tsx
@@ -18,7 +18,7 @@ let FeedSlice = ({
   slice: FeedPostSlice
   hideTopBorder?: boolean
 }): React.ReactNode => {
-  if (slice.isThread && slice.items.length > 3) {
+  if (slice.items.length > 3) {
     const last = slice.items.length - 1
     return (
       <>

--- a/src/view/com/posts/FeedSlice.tsx
+++ b/src/view/com/posts/FeedSlice.tsx
@@ -18,7 +18,7 @@ let FeedSlice = ({
   slice: FeedPostSlice
   hideTopBorder?: boolean
 }): React.ReactNode => {
-  if (slice.items.length > 3) {
+  if (slice.hasGap) {
     const beforeLast = slice.items.length - 2
     const last = slice.items.length - 1
     return (


### PR DESCRIPTION
This moves replies in feeds to work much more similarly to Twitter.

**Not ready for review yet.**

## What it looks like

- Replies never show up in isolation — a reply is always seen in context of its root thread
- Slices are deduped by thread — with default settings, a friend reply essentially "bumps" a thread
- Threads never get torn apart, whether due to pagination or different author
- For long convos, you see root + last two items, which gives you better context than 1,2...N

## TODO

- [x] Proof of concept
- [ ] Address TODOs in code
- [ ] Handle blocks (for all levels), not found
- [ ] Handle Posts, Replies tabs
- [ ] Check feeds, lists
- [ ] Check self-threads
- [ ] Check how deduping interacts with self-reposts
- [ ] Double-check filtering still makes sense
- [ ] Simplify data structures 
- [ ] Fix the "self-reply to a non-follow" problem
- [ ] Consider dropping reply settings

https://github.com/user-attachments/assets/4373a130-7aad-40f7-bf97-cff6a5be8be4

## What it fixes

Torn replies like this will no longer happen:

![Screenshot 2024-07-25 at 21 17 45](https://github.com/user-attachments/assets/c1ec9967-d16a-416f-b6fc-82d14d4cf003)
![Screenshot 2024-07-25 at 21 18 00](https://github.com/user-attachments/assets/5d00e381-c9f4-4c9f-b052-887c0fbac05f)

Replies without context like this will no longer happen:

![Screenshot 2024-07-25 at 21 14 49](https://github.com/user-attachments/assets/d1f5c0a9-b894-4e75-acfb-a6664ad1eb68)
![Screenshot 2024-07-25 at 21 15 00](https://github.com/user-attachments/assets/49c7b338-d8f9-4344-b554-a2ef0fbd4442)

