### PR TITLE
Boolean filter improvement alternative: TS-reset

### DIFF
--- a/package.json
+++ b/package.json
@@ -222,6 +222,7 @@
     "@react-native/typescript-config": "^0.74.1",
     "@testing-library/jest-native": "^5.4.1",
     "@testing-library/react-native": "^11.5.2",
+    "@total-typescript/ts-reset": "^0.5.1",
     "@tsconfig/react-native": "^2.0.3",
     "@types/he": "^1.1.2",
     "@types/jest": "^29.4.0",

--- a/src/state/queries/post-feed.ts
+++ b/src/state/queries/post-feed.ts
@@ -378,11 +378,11 @@ export function usePostFeedQuery(
                         }
                         return undefined
                       })
-                      .filter(<T>(n?: T): n is T => Boolean(n)),
+                      .filter(Boolean),
                   }
                   return feedPostSlice
                 })
-                .filter(<T>(n?: T): n is T => Boolean(n)),
+                .filter(Boolean),
             })),
           ],
         }

--- a/src/state/queries/threadgate.ts
+++ b/src/state/queries/threadgate.ts
@@ -33,6 +33,6 @@ export function threadgateViewToSettings(
       }
       return setting
     })
-    .filter(<T>(n?: T): n is T => Boolean(n))
+    .filter(Boolean)
   return settings
 }

--- a/src/ts-reset.d.ts
+++ b/src/ts-reset.d.ts
@@ -1,0 +1,1 @@
+import '@total-typescript/ts-reset'

--- a/src/ts-reset.d.ts
+++ b/src/ts-reset.d.ts
@@ -1,1 +1,1 @@
-import '@total-typescript/ts-reset'
+import '@total-typescript/ts-reset/filter-boolean'

--- a/src/view/screens/Search/Explore.tsx
+++ b/src/view/screens/Search/Explore.tsx
@@ -119,7 +119,7 @@ function LoadMore({
         }
         return loadMoreItem
       })
-      .filter(<T,>(n?: T): n is T => Boolean(n))
+      .filter(Boolean)
   }, [item.items, moderationOpts])
 
   if (items.length === 0) return null

--- a/yarn.lock
+++ b/yarn.lock
@@ -7713,6 +7713,11 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-2.0.0.tgz#f544a148d3ab35801c1f633a7441fd87c2e484bf"
   integrity sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==
 
+"@total-typescript/ts-reset@^0.5.1":
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/@total-typescript/ts-reset/-/ts-reset-0.5.1.tgz#93b0535d00faa588518bcfb0db30182e63e4f7af"
+  integrity sha512-AqlrT8YA1o7Ff5wPfMOL0pvL+1X+sw60NN6CcOCqs658emD6RfiXhF7Gu9QcfKBH7ELY2nInLhKSCWVoNL70MQ==
+
 "@trysound/sax@0.2.0":
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/@trysound/sax/-/sax-0.2.0.tgz#cccaab758af56761eb7bf37af6f03f326dd798ad"


### PR DESCRIPTION
This is a follow up to #4830. This is a pull request with an alternative solution: see #4840. Feel free to merge both or either.

This version introduces [`ts-reset`](https://github.com/total-typescript/ts-reset) and uses it's type enchancements to simplify boolean filters.

Note that I had to enable only one enchancement from ts-reset, because enabling the whole of it fails the typecheck for the codebase due to `JSON.parse` returning `unknown` instead of `any`. You might want to look into enabling more, but it's out of scope for this PR