### PR TITLE
Only show "followed you back" when appropriate

### DIFF
--- a/src/view/com/notifications/FeedItem.tsx
+++ b/src/view/com/notifications/FeedItem.tsx
@@ -194,13 +194,12 @@ let FeedItem = ({
       try {
         const rkey = new AtUri(item.notification.author.viewer.following).rkey
         const followingTimestamp = TID.fromStr(rkey).timestamp()
-        const followedTimestamp =
-          new Date(item.notification.record.createdAt).getTime() * 1000
-        isFollowBack = followedTimestamp > followingTimestamp
       } catch (e) {
         // For some reason the following URI was invalid. Default to it not being a follow back.
         console.error('Invalid following URI')
       }
+      const followedTimestamp = new Date(item.notification.record.createdAt).getTime() * 1000
+      isFollowBack = followedTimestamp > followingTimestamp
     }
 
     if (isFollowBack && gate('ungroup_follow_backs')) {

--- a/src/view/com/notifications/FeedItem.tsx
+++ b/src/view/com/notifications/FeedItem.tsx
@@ -191,13 +191,15 @@ let FeedItem = ({
       item.notification.author.viewer?.following &&
       AppBskyGraphFollow.isRecord(item.notification.record)
     ) {
-      const rkey = new AtUri(item.notification.author.viewer.following).rkey
-      const followingTimestamp = TID.fromStr(rkey).timestamp()
-      const followedTimestamp =
-        new Date(item.notification.record.createdAt).getTime() * 1000
-
-      console.log(followedTimestamp, followingTimestamp)
-      isFollowBack = followedTimestamp > followingTimestamp
+      try {
+        const rkey = new AtUri(item.notification.author.viewer.following).rkey
+        const followingTimestamp = TID.fromStr(rkey).timestamp()
+        const followedTimestamp =
+          new Date(item.notification.record.createdAt).getTime() * 1000
+        isFollowBack = followedTimestamp > followingTimestamp
+      } catch (e) {
+        // For some reason the following URI was invalid. Default to it not being a follow back.
+      }
     }
 
     if (isFollowBack && gate('ungroup_follow_backs')) {

--- a/src/view/com/notifications/FeedItem.tsx
+++ b/src/view/com/notifications/FeedItem.tsx
@@ -187,19 +187,24 @@ let FeedItem = ({
     icon = <RepostIcon size="xl" style={{color: t.palette.positive_600}} />
   } else if (item.type === 'follow') {
     let isFollowBack = false
+
     if (
       item.notification.author.viewer?.following &&
       AppBskyGraphFollow.isRecord(item.notification.record)
     ) {
+      let followingTimestamp
       try {
         const rkey = new AtUri(item.notification.author.viewer.following).rkey
-        const followingTimestamp = TID.fromStr(rkey).timestamp()
+        followingTimestamp = TID.fromStr(rkey).timestamp()
       } catch (e) {
         // For some reason the following URI was invalid. Default to it not being a follow back.
         console.error('Invalid following URI')
       }
-      const followedTimestamp = new Date(item.notification.record.createdAt).getTime() * 1000
-      isFollowBack = followedTimestamp > followingTimestamp
+      if (followingTimestamp) {
+        const followedTimestamp =
+          new Date(item.notification.record.createdAt).getTime() * 1000
+        isFollowBack = followedTimestamp > followingTimestamp
+      }
     }
 
     if (isFollowBack && gate('ungroup_follow_backs')) {

--- a/src/view/com/notifications/FeedItem.tsx
+++ b/src/view/com/notifications/FeedItem.tsx
@@ -199,6 +199,7 @@ let FeedItem = ({
         isFollowBack = followedTimestamp > followingTimestamp
       } catch (e) {
         // For some reason the following URI was invalid. Default to it not being a follow back.
+        console.error('Invalid following URI')
       }
     }
 


### PR DESCRIPTION
## Why

Right now, we will show the user "followed you back" in a follow notification if you follow the user. There's no other logic that checks if the follow occurred before or after you followed that person.
This means that if I follow you, then you follow me, your notification showing that I followed you will say "followed you back", even though I actually followed you first.

## How

Let's compare the rkey's timestamp with the new record's timestamp.

## Test Plan

See video


https://github.com/user-attachments/assets/f1961bfd-8169-44e3-9125-c154b8561bd8


