### PR TITLE
[Web] Retrigger onEndReached if needed when content height changes

### DIFF
--- a/src/view/com/util/List.web.tsx
+++ b/src/view/com/util/List.web.tsx
@@ -344,7 +344,7 @@ function ListImpl<ItemT>(
           style={[styles.aboveTheFoldDetector, {height: headerOffset}]}
         />
         {onStartReached && !isEmpty && (
-          <Visibility
+          <EdgeVisibility
             root={disableFullWindowScroll ? nativeRef : null}
             onVisibleChange={onHeadVisibilityChange}
             topMargin={(onStartReachedThreshold ?? 0) * 100 + '%'}
@@ -368,7 +368,7 @@ function ListImpl<ItemT>(
               )
             })}
         {onEndReached && !isEmpty && (
-          <Visibility
+          <EdgeVisibility
             root={disableFullWindowScroll ? nativeRef : null}
             onVisibleChange={onTailVisibilityChange}
             bottomMargin={(onEndReachedThreshold ?? 0) * 100 + '%'}
@@ -378,6 +378,27 @@ function ListImpl<ItemT>(
         {footerComponent}
       </View>
     </View>
+  )
+}
+
+function EdgeVisibility({
+  root,
+  topMargin,
+  bottomMargin,
+  onVisibleChange,
+}: {
+  root?: React.RefObject<HTMLDivElement> | null
+  topMargin?: string
+  bottomMargin?: string
+  onVisibleChange: (isVisible: boolean) => void
+}) {
+  return (
+    <Visibility
+      root={root}
+      topMargin={topMargin}
+      bottomMargin={bottomMargin}
+      onVisibleChange={onVisibleChange}
+    />
   )
 }
 

--- a/src/view/com/util/List.web.tsx
+++ b/src/view/com/util/List.web.tsx
@@ -348,6 +348,7 @@ function ListImpl<ItemT>(
             root={disableFullWindowScroll ? nativeRef : null}
             onVisibleChange={onHeadVisibilityChange}
             topMargin={(onStartReachedThreshold ?? 0) * 100 + '%'}
+            containerRef={containerRef}
           />
         )}
         {headerComponent}
@@ -372,7 +373,7 @@ function ListImpl<ItemT>(
             root={disableFullWindowScroll ? nativeRef : null}
             onVisibleChange={onTailVisibilityChange}
             bottomMargin={(onEndReachedThreshold ?? 0) * 100 + '%'}
-            key={data?.length}
+            containerRef={containerRef}
           />
         )}
         {footerComponent}
@@ -385,15 +386,22 @@ function EdgeVisibility({
   root,
   topMargin,
   bottomMargin,
+  containerRef,
   onVisibleChange,
 }: {
   root?: React.RefObject<HTMLDivElement> | null
   topMargin?: string
   bottomMargin?: string
+  containerRef: React.RefObject<Element>
   onVisibleChange: (isVisible: boolean) => void
 }) {
+  const [containerHeight, setContainerHeight] = React.useState(0)
+  useResizeObserver(containerRef, (w, h) => {
+    setContainerHeight(h)
+  })
   return (
     <Visibility
+      key={containerHeight}
       root={root}
       topMargin={topMargin}
       bottomMargin={bottomMargin}


### PR DESCRIPTION
We want to ensure that when you scroll to bottom and the next fetch yielded too few new items, we're triggering a refetch on the web. With https://github.com/bluesky-social/social-app/pull/4728, we've made it work by putting a `key` on the tail intersection observer so that it gets recomputed (and thus retriggers if the tail is _still_ in the viewport) when the number of items in the list changes.

However, the current behavior is still inconsistent with the native side. In particular, on native, it appears that having _the same number of rows but with different content for the footer_ (such as [here](https://github.com/bluesky-social/social-app/blob/c75bb65bef1671e493f10e06b51ee4d0cda98d83/src/view/com/posts/Feed.tsx#L511-L520)) also triggers `onEndReached`. Looking closer at the native implementation, it [fires `onEndReached` if the *content size* changed](https://github.com/facebook/react-native/blob/71b5f049862db733237b27f8f1a4d081393a4592/packages/virtualized-lists/Lists/VirtualizedList.js#L1542) since the last check rather than item count.

This PR aligns the logic to use content size as the key on the web as well. We use a resize observer on the content area, similar to how `onContentSizeChanged` is implemented. I've moved the resize observer and the associated state to an isolated component so that the associated state update does not re-render the list itself.

## Test Plan

We currently have a bug where if the feed responds with `[]` and an updated cursor after first 30 items, we don't attempt to fetch the next page and gets stuck. This bug is currently being covered up on native by the RN FlatList behavior (the "footer" spinner size change causes `onEndThreshold` to invalidate). This is how I noticed the discrepancy. This PR fixes the discrepancy so that the bug is covered up on web as well. This PR does not fix the root cause of that bug though.

I'll send the fix for the root cause of the bug separately later, but this bug is nice as a test plan in the meantime.

1. Load http://localhost:19006/profile/rahaeli.bsky.social
2. Without this PR, pagination gets stuck on the web
3. With this PR, pagination does not get stuck on the web

### Before

https://github.com/user-attachments/assets/a2f819bc-0349-4d69-9c5d-3cd378e70ae9

### After

https://github.com/user-attachments/assets/802086e4-ee7d-4b4d-ae98-23031a191158

