### PR TITLE
Fetch enough pages to fill a page's worth of items

### DIFF
--- a/src/state/queries/notifications/feed.ts
+++ b/src/state/queries/notifications/feed.ts
@@ -126,6 +126,7 @@ export function useNotificationFeedQuery(opts?: {
   // doesn't return enough items, we're going to continue asking for more items.
   const lastItemCount = useRef(0)
   const wantedItemCount = useRef(0)
+  const autoPaginationAttemptCount = useRef(0)
   useEffect(() => {
     const {data, isLoading, isRefetching, isFetchingNextPage, hasNextPage} =
       query
@@ -158,7 +159,12 @@ export function useNotificationFeedQuery(opts?: {
       // At this point we're not fetching anymore, so it's time to make a decision.
       // If we didn't receive enough items from the server, paginate again until we do.
       if (itemCount < wantedItemCount.current) {
-        query.fetchNextPage()
+        autoPaginationAttemptCount.current++
+        if (autoPaginationAttemptCount.current < 50 /* failsafe */) {
+          query.fetchNextPage()
+        }
+      } else {
+        autoPaginationAttemptCount.current = 0
       }
     }
   }, [query])

--- a/src/state/queries/notifications/feed.ts
+++ b/src/state/queries/notifications/feed.ts
@@ -59,7 +59,6 @@ export function useNotificationFeedQuery(opts?: {
   const moderationOpts = useModerationOpts()
   const unreads = useUnreadNotificationsApi()
   const enabled = opts?.enabled !== false
-  const lastPageCountRef = useRef(0)
   const gate = useGate()
 
   // false: force showing all notifications
@@ -121,28 +120,46 @@ export function useNotificationFeedQuery(opts?: {
     },
   })
 
+  // The server may end up returning an empty page, a page with too few items,
+  // or a page with items that end up getting filtered out. When we fetch pages,
+  // we'll keep track of how many items we actually hope to see. If the server
+  // doesn't return enough items, we're going to continue asking for more items.
+  const lastItemCount = useRef(0)
+  const wantedItemCount = useRef(0)
   useEffect(() => {
-    const {isFetching, hasNextPage, data} = query
-    if (isFetching || !hasNextPage) {
-      return
-    }
-
-    // avoid double-fires of fetchNextPage()
-    if (
-      lastPageCountRef.current !== 0 &&
-      lastPageCountRef.current === data?.pages?.length
-    ) {
-      return
-    }
-
-    // fetch next page if we haven't gotten a full page of content
-    let count = 0
+    const {data, isLoading, isRefetching, isFetchingNextPage, hasNextPage} =
+      query
+    // Count the items that we already have.
+    let itemCount = 0
     for (const page of data?.pages || []) {
-      count += page.items.length
+      itemCount += page.items.length
     }
-    if (count < PAGE_SIZE && (data?.pages.length || 0) < 6) {
-      query.fetchNextPage()
-      lastPageCountRef.current = data?.pages?.length || 0
+
+    // If items got truncated, reset the state we're tracking below.
+    if (itemCount !== lastItemCount.current) {
+      if (itemCount < lastItemCount.current) {
+        wantedItemCount.current = itemCount
+      }
+      lastItemCount.current = itemCount
+    }
+
+    // Now track how many items we really want, and fetch more if needed.
+    if (isLoading || isRefetching) {
+      // During the initial fetch, we want to get an entire page's worth of items.
+      wantedItemCount.current = PAGE_SIZE
+    } else if (isFetchingNextPage) {
+      if (itemCount > wantedItemCount.current) {
+        // We have more items than wantedItemCount, so wantedItemCount must be out of date.
+        // Some other code must have called fetchNextPage(), for example, from onEndReached.
+        // Adjust the wantedItemCount to reflect that we want one more full page of items.
+        wantedItemCount.current = itemCount + PAGE_SIZE
+      }
+    } else if (hasNextPage) {
+      // At this point we're not fetching anymore, so it's time to make a decision.
+      // If we didn't receive enough items from the server, paginate again until we do.
+      if (itemCount < wantedItemCount.current) {
+        query.fetchNextPage()
+      }
     }
   }, [query])
 

--- a/src/state/queries/post-feed.ts
+++ b/src/state/queries/post-feed.ts
@@ -134,7 +134,6 @@ export function usePostFeedQuery(
     args: typeof selectArgs
     result: InfiniteData<FeedPage>
   } | null>(null)
-  const lastPageCountRef = useRef(0)
   const isDiscover = feedDesc.includes(DISCOVER_FEED_URI)
 
   // Make sure this doesn't invalidate unless really needed.
@@ -376,30 +375,48 @@ export function usePostFeedQuery(
     ),
   })
 
+  // The server may end up returning an empty page, a page with too few items,
+  // or a page with items that end up getting filtered out. When we fetch pages,
+  // we'll keep track of how many items we actually hope to see. If the server
+  // doesn't return enough items, we're going to continue asking for more items.
+  const lastItemCount = useRef(0)
+  const wantedItemCount = useRef(0)
   useEffect(() => {
-    const {isFetching, hasNextPage, data} = query
-    if (isFetching || !hasNextPage) {
-      return
-    }
-
-    // avoid double-fires of fetchNextPage()
-    if (
-      lastPageCountRef.current !== 0 &&
-      lastPageCountRef.current === data?.pages?.length
-    ) {
-      return
-    }
-
-    // fetch next page if we haven't gotten a full page of content
-    let count = 0
+    const {data, isLoading, isRefetching, isFetchingNextPage, hasNextPage} =
+      query
+    // Count the items that we already have.
+    let itemCount = 0
     for (const page of data?.pages || []) {
       for (const slice of page.slices) {
-        count += slice.items.length
+        itemCount += slice.items.length
       }
     }
-    if (count < PAGE_SIZE && (data?.pages.length || 0) < 6) {
-      query.fetchNextPage()
-      lastPageCountRef.current = data?.pages?.length || 0
+
+    // If items got truncated, reset the state we're tracking below.
+    if (itemCount !== lastItemCount.current) {
+      if (itemCount < lastItemCount.current) {
+        wantedItemCount.current = itemCount
+      }
+      lastItemCount.current = itemCount
+    }
+
+    // Now track how many items we really want, and fetch more if needed.
+    if (isLoading || isRefetching) {
+      // During the initial fetch, we want to get an entire page's worth of items.
+      wantedItemCount.current = PAGE_SIZE
+    } else if (isFetchingNextPage) {
+      if (itemCount > wantedItemCount.current) {
+        // We have more items than wantedItemCount, so wantedItemCount must be out of date.
+        // Some other code must have called fetchNextPage(), for example, from onEndReached.
+        // Adjust the wantedItemCount to reflect that we want one more full page of items.
+        wantedItemCount.current = itemCount + PAGE_SIZE
+      }
+    } else if (hasNextPage) {
+      // At this point we're not fetching anymore, so it's time to make a decision.
+      // If we didn't receive enough items from the server, paginate again until we do.
+      if (itemCount < wantedItemCount.current) {
+        query.fetchNextPage()
+      }
     }
   }, [query])
 

--- a/src/state/queries/post-feed.ts
+++ b/src/state/queries/post-feed.ts
@@ -381,6 +381,7 @@ export function usePostFeedQuery(
   // doesn't return enough items, we're going to continue asking for more items.
   const lastItemCount = useRef(0)
   const wantedItemCount = useRef(0)
+  const autoPaginationAttemptCount = useRef(0)
   useEffect(() => {
     const {data, isLoading, isRefetching, isFetchingNextPage, hasNextPage} =
       query
@@ -415,7 +416,12 @@ export function usePostFeedQuery(
       // At this point we're not fetching anymore, so it's time to make a decision.
       // If we didn't receive enough items from the server, paginate again until we do.
       if (itemCount < wantedItemCount.current) {
-        query.fetchNextPage()
+        autoPaginationAttemptCount.current++
+        if (autoPaginationAttemptCount.current < 50 /* failsafe */) {
+          query.fetchNextPage()
+        }
+      } else {
+        autoPaginationAttemptCount.current = 0
       }
     }
   }, [query])


### PR DESCRIPTION
We have a hack that fetches enough items to fill the first page's worth of items (30) if we're not getting enough items within the first few pages (6). This hack isn't reliable and doesn't handle similar cases further down the scroll (e.g. when there's an empty `[]` response in for further pages, or when too many items get filtered out later).

I'm adding a more extensive fix that should handle these cases consistently. The idea of the fix is to keep track of the "wanted" item count. When we start paginating, we bump the "wanted" item count by the page size (30). If we then don't receive enough items, we keep trying to paginate until those 30 items are filled. There are a few conditions where we reset that counter.

This mostly acts as a failsafe. In practice `FlatList` content size change triggering `onEndReached` (which was ported to web in https://github.com/bluesky-social/social-app/pull/4859) is accidentally sufficient in most cases because rendering a pagination spinner causes a content size change. However, that's not guaranteed to be reliable. So this is an attempt to be more comprehensive.

It also means that, for next pages, fetching the missing pages happens a bit earlier, similar to how we try to preemptively load the first 30 items without waiting for `onEndReached` in the existing hack.

## Test Plan

This branch is based before https://github.com/bluesky-social/social-app/pull/4859 to show that it solves the problem independently from https://github.com/bluesky-social/social-app/pull/4859. However, it should also work when rebased to `main`.

You can try adding some console logs to verify the behavior:

https://github.com/user-attachments/assets/c2d2afdf-1ba9-4620-9ca4-06dcb2fe22a2

