### PR TITLE
Display second-to-last rather than second post in a slice

### DIFF
--- a/src/view/com/posts/FeedSlice.tsx
+++ b/src/view/com/posts/FeedSlice.tsx
@@ -19,6 +19,7 @@ let FeedSlice = ({
   hideTopBorder?: boolean
 }): React.ReactNode => {
   if (slice.isThread && slice.items.length > 3) {
+    const beforeLast = slice.items.length - 2
     const last = slice.items.length - 1
     return (
       <>
@@ -36,20 +37,20 @@ let FeedSlice = ({
           hideTopBorder={hideTopBorder}
           isParentBlocked={slice.items[0].isParentBlocked}
         />
-        <FeedItem
-          key={slice.items[1]._reactKey}
-          post={slice.items[1].post}
-          record={slice.items[1].record}
-          reason={slice.items[1].reason}
-          feedContext={slice.items[1].feedContext}
-          parentAuthor={slice.items[1].parentAuthor}
-          showReplyTo={false}
-          moderation={slice.items[1].moderation}
-          isThreadParent={isThreadParentAt(slice.items, 1)}
-          isThreadChild={isThreadChildAt(slice.items, 1)}
-          isParentBlocked={slice.items[1].isParentBlocked}
-        />
         <ViewFullThread slice={slice} />
+        <FeedItem
+          key={slice.items[beforeLast]._reactKey}
+          post={slice.items[beforeLast].post}
+          record={slice.items[beforeLast].record}
+          reason={slice.items[beforeLast].reason}
+          feedContext={slice.items[beforeLast].feedContext}
+          parentAuthor={slice.items[beforeLast].parentAuthor}
+          showReplyTo={false}
+          moderation={slice.items[beforeLast].moderation}
+          isThreadParent={isThreadParentAt(slice.items, beforeLast)}
+          isThreadChild={isThreadChildAt(slice.items, beforeLast)}
+          isParentBlocked={slice.items[beforeLast].isParentBlocked}
+        />
         <FeedItem
           key={slice.items[last]._reactKey}
           post={slice.items[last].post}


### PR DESCRIPTION
## Why

Extracted from https://github.com/bluesky-social/social-app/pull/4835. When we start showing replies in the context of the threads they're in, they'll follow the same structure. So this makes a similar change for the case where we already display the context.

Overall I think this makes the slice feel more coherent. OP post sets the context for the thread, and the last two posts are an unbroken chain. As opposed to how it behaves now where the last post can be pretty far disconnected from the initial point.

## Before

![Screenshot 2024-08-01 at 02 37 34](https://github.com/user-attachments/assets/c8dc1715-9881-4c4b-addf-89fe51b1bccb)

## After

![Screenshot 2024-08-01 at 02 38 08](https://github.com/user-attachments/assets/fdde85d5-62f5-48a0-9836-9add020194d6)

