### PR TITLE
Always limit Following replies to the people you follow

### DIFF
--- a/src/lib/api/feed-manip.ts
+++ b/src/lib/api/feed-manip.ts
@@ -299,15 +299,7 @@ export class FeedTuner {
     return slices
   }
 
-  static thresholdRepliesOnly({
-    userDid,
-    minLikes,
-    followedOnly,
-  }: {
-    userDid: string
-    minLikes: number
-    followedOnly: boolean
-  }) {
+  static followedRepliesOnly({userDid}: {userDid: string}) {
     return (
       tuner: FeedTuner,
       slices: FeedViewPostsSlice[],
@@ -322,9 +314,7 @@ export class FeedTuner {
           if (slice.isRepost) {
             continue
           }
-          if (slice.likeCount < minLikes) {
-            slices.splice(i, 1)
-          } else if (followedOnly && !slice.isFollowingAllAuthors(userDid)) {
+          if (!slice.isFollowingAllAuthors(userDid)) {
             slices.splice(i, 1)
           }
         }

--- a/src/state/preferences/feed-tuners.tsx
+++ b/src/state/preferences/feed-tuners.tsx
@@ -38,10 +38,8 @@ export function useFeedTuners(feedDesc: FeedDescriptor) {
           feedTuners.push(FeedTuner.removeReplies)
         } else {
           feedTuners.push(
-            FeedTuner.thresholdRepliesOnly({
+            FeedTuner.followedRepliesOnly({
               userDid: currentAccount?.did || '',
-              minLikes: 0,
-              followedOnly: true,
             }),
           )
         }
@@ -65,10 +63,8 @@ export function useFeedTuners(feedDesc: FeedDescriptor) {
         feedTuners.push(FeedTuner.removeReplies)
       } else {
         feedTuners.push(
-          FeedTuner.thresholdRepliesOnly({
+          FeedTuner.followedRepliesOnly({
             userDid: currentAccount?.did || '',
-            minLikes: 0,
-            followedOnly: true,
           }),
         )
       }

--- a/src/state/preferences/feed-tuners.tsx
+++ b/src/state/preferences/feed-tuners.tsx
@@ -40,9 +40,8 @@ export function useFeedTuners(feedDesc: FeedDescriptor) {
           feedTuners.push(
             FeedTuner.thresholdRepliesOnly({
               userDid: currentAccount?.did || '',
-              minLikes: preferences?.feedViewPrefs.hideRepliesByLikeCount || 0,
-              followedOnly:
-                !!preferences?.feedViewPrefs.hideRepliesByUnfollowed,
+              minLikes: 0,
+              followedOnly: true,
             }),
           )
         }
@@ -68,8 +67,8 @@ export function useFeedTuners(feedDesc: FeedDescriptor) {
         feedTuners.push(
           FeedTuner.thresholdRepliesOnly({
             userDid: currentAccount?.did || '',
-            minLikes: preferences?.feedViewPrefs.hideRepliesByLikeCount || 0,
-            followedOnly: !!preferences?.feedViewPrefs.hideRepliesByUnfollowed,
+            minLikes: 0,
+            followedOnly: true,
           }),
         )
       }

--- a/src/state/queries/preferences/const.ts
+++ b/src/state/queries/preferences/const.ts
@@ -7,8 +7,8 @@ import {
 export const DEFAULT_HOME_FEED_PREFS: UsePreferencesQueryResponse['feedViewPrefs'] =
   {
     hideReplies: false,
-    hideRepliesByUnfollowed: true,
-    hideRepliesByLikeCount: 0,
+    hideRepliesByUnfollowed: true, // Legacy, ignored
+    hideRepliesByLikeCount: 0, // Legacy, ignored
     hideReposts: false,
     hideQuotePosts: false,
     lab_mergeFeedEnabled: false, // experimental

--- a/src/view/screens/PreferencesFollowingFeed.tsx
+++ b/src/view/screens/PreferencesFollowingFeed.tsx
@@ -1,16 +1,13 @@
-import React, {useState} from 'react'
+import React from 'react'
 import {StyleSheet, View} from 'react-native'
 import {FontAwesomeIcon} from '@fortawesome/react-native-fontawesome'
-import {msg, Plural, Trans} from '@lingui/macro'
+import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
-import {Slider} from '@miblanchard/react-native-slider'
-import debounce from 'lodash.debounce'
 
 import {usePalette} from '#/lib/hooks/usePalette'
 import {useWebMediaQueries} from '#/lib/hooks/useWebMediaQueries'
 import {CommonNavigatorParams, NativeStackScreenProps} from '#/lib/routes/types'
 import {colors, s} from '#/lib/styles'
-import {isWeb} from '#/platform/detection'
 import {
   usePreferencesQuery,
   useSetFeedViewPreferencesMutation,
@@ -20,61 +17,6 @@ import {SimpleViewHeader} from '#/view/com/util/SimpleViewHeader'
 import {Text} from '#/view/com/util/text/Text'
 import {ScrollView} from '#/view/com/util/Views'
 import {atoms as a} from '#/alf'
-
-function RepliesThresholdInput({
-  enabled,
-  initialValue,
-}: {
-  enabled: boolean
-  initialValue: number
-}) {
-  const pal = usePalette('default')
-  const [value, setValue] = useState(initialValue)
-  const {mutate: setFeedViewPref} = useSetFeedViewPreferencesMutation()
-  const preValue = React.useRef(initialValue)
-  const save = React.useMemo(
-    () =>
-      debounce(
-        threshold =>
-          setFeedViewPref({
-            hideRepliesByLikeCount: threshold,
-          }),
-        500,
-      ), // debouce for 500ms
-    [setFeedViewPref],
-  )
-
-  return (
-    <View style={[!enabled && styles.dimmed]}>
-      <Slider
-        value={value}
-        onValueChange={(v: number | number[]) => {
-          let threshold = Array.isArray(v) ? v[0] : v
-          if (threshold > preValue.current) threshold = Math.floor(threshold)
-          else threshold = Math.ceil(threshold)
-
-          preValue.current = threshold
-
-          setValue(threshold)
-          save(threshold)
-        }}
-        minimumValue={0}
-        maximumValue={25}
-        containerStyle={isWeb ? undefined : s.flex1}
-        disabled={!enabled}
-        thumbTintColor={colors.blue3}
-      />
-      <Text type="xs" style={pal.text}>
-        <Plural
-          value={value}
-          _0="Show all replies"
-          one="Show replies with at least # like"
-          other="Show replies with at least # likes"
-        />
-      </Text>
-    </View>
-  )
-}
 
 type Props = NativeStackScreenProps<
   CommonNavigatorParams,
@@ -137,51 +79,6 @@ export function PreferencesFollowingFeed({}: Props) {
               }
             />
           </View>
-          <View
-            style={[pal.viewLight, styles.card, !showReplies && styles.dimmed]}>
-            <Text type="title-sm" style={[pal.text, s.pb5]}>
-              <Trans>Reply Filters</Trans>
-            </Text>
-            <Text style={[pal.text, s.pb10]}>
-              <Trans>
-                Enable this setting to only see replies between people you
-                follow.
-              </Trans>
-            </Text>
-            <ToggleButton
-              type="default-light"
-              label={_(msg`Followed users only`)}
-              isSelected={Boolean(
-                variables?.hideRepliesByUnfollowed ??
-                  preferences?.feedViewPrefs?.hideRepliesByUnfollowed,
-              )}
-              onPress={
-                showReplies
-                  ? () =>
-                      setFeedViewPref({
-                        hideRepliesByUnfollowed: !(
-                          variables?.hideRepliesByUnfollowed ??
-                          preferences?.feedViewPrefs?.hideRepliesByUnfollowed
-                        ),
-                      })
-                  : undefined
-              }
-              style={[s.mb10]}
-            />
-            <Text style={[pal.text]}>
-              <Trans>
-                Adjust the number of likes a reply must have to be shown in your
-                feed.
-              </Trans>
-            </Text>
-            {preferences && (
-              <RepliesThresholdInput
-                enabled={showReplies}
-                initialValue={preferences.feedViewPrefs.hideRepliesByLikeCount}
-              />
-            )}
-          </View>
-
           <View style={[pal.viewLight, styles.card]}>
             <Text type="title-sm" style={[pal.text, s.pb5]}>
               <Trans>Show Reposts</Trans>


### PR DESCRIPTION
This removes the granular reply settings in favor of the current defaults. Only replies *between people you already follow* will be displayed in the Following timeline. (This is already the current default, and has been for many months — but this change applies it retroactively for people who might have changed this setting before the "followed only" filter existed.)

I'm also removing the like-based filter. The original purpose of the global like-based filter for replies in the Following feed was to avoid a flurry of replies overwhelming it. However, that was mostly necessary because there was no filtering by whether you follow both people in the exchange. Now that we have that filtering (and have had it as a default for many months), the like-based filter seems much less useful. It's unclear what value to pick as a user (3? 10? how do you choose?) and it creates an inconsistency in how people consume the following feed. It's easy to set it to some arbitrary value and then forget about it, causing replies between mutuals to seemingly randomly fail to appear.

This change does not affect other clients or how they choose to present the Following feed. They may still offer different filtering options, including filtering by likes or showing all replies. However, we've had a lot of feedback that bigger accounts replying to smaller accounts causes undesired attention to small accounts. Removing this option helps ensure that the default client does not show out-of-context convos in the Following feed unless you follow both people in the conversation.

Note there's still an outstanding bug that causes *some* replies to people you _don't_ follow to appear in your Following feed (this happens for multiple self-replies in a row). That bug will be fixed separately. I'm frontloading this change because it makes other things a bit easier and reduces the explosion of configurations.

Of course, you can also still turn off replies completely, if you want. That setting is still there.

## Before

![Screenshot 2024-08-01 at 20 10 42](https://github.com/user-attachments/assets/885c005e-2d4c-4e74-875b-a185c7423d3c)

## After

![Screenshot 2024-08-01 at 20 11 44](https://github.com/user-attachments/assets/4d80da6b-2491-4816-a9c3-abb459d8d663)

(The actual settings are identical to the screenshot above; they're just no longer configurable.)

## Test Plan

Set your account settings in prod to show _all replies_. Then check out this branch. Verify that you only see conversations between people you already follow. Then set the like threshold on prod really high. Verify that it isn't taken into account locally.