### PR TITLE
Only show replies in Following if following all involved actors

### DIFF
--- a/src/lib/api/feed-manip.ts
+++ b/src/lib/api/feed-manip.ts
@@ -82,10 +82,6 @@ export class FeedViewPostsSlice {
     return AppBskyFeedDefs.isReasonRepost(reason)
   }
 
-  get includesThreadRoot() {
-    return !this.items[0].reply
-  }
-
   get likeCount() {
     return this._feedPost.post.likeCount ?? 0
   }
@@ -307,9 +303,6 @@ export class FeedTuner {
       for (let i = slices.length - 1; i >= 0; i--) {
         const slice = slices[i]
         if (slice.isReply) {
-          if (slice.isThread && slice.includesThreadRoot) {
-            continue
-          }
           if (slice.isRepost) {
             continue
           }

--- a/src/lib/api/feed-manip.ts
+++ b/src/lib/api/feed-manip.ts
@@ -119,20 +119,19 @@ export class FeedViewPostsSlice {
 
   isFollowingAllAuthors(userDid: string) {
     const feedPost = this._feedPost
-    if (feedPost.post.author.did === userDid) {
-      return true
-    }
-    if (AppBskyFeedDefs.isPostView(feedPost.reply?.parent)) {
-      const parent = feedPost.reply?.parent
-      if (parent?.author.did === userDid) {
-        return true
+    const authors = [feedPost.post.author]
+    if (feedPost.reply) {
+      if (AppBskyFeedDefs.isPostView(feedPost.reply.parent)) {
+        authors.push(feedPost.reply.parent.author)
       }
-      return (
-        parent?.author.viewer?.following &&
-        feedPost.post.author.viewer?.following
-      )
+      if (feedPost.reply.grandparentAuthor) {
+        authors.push(feedPost.reply.grandparentAuthor)
+      }
+      if (AppBskyFeedDefs.isPostView(feedPost.reply.root)) {
+        authors.push(feedPost.reply.root.author)
+      }
     }
-    return false
+    return authors.every(a => a.did === userDid || a.viewer?.following)
   }
 }
 

--- a/src/lib/api/feed-manip.ts
+++ b/src/lib/api/feed-manip.ts
@@ -299,16 +299,14 @@ export class FeedTuner {
       tuner: FeedTuner,
       slices: FeedViewPostsSlice[],
     ): FeedViewPostsSlice[] => {
-      // remove any replies without at least minLikes likes
       for (let i = slices.length - 1; i >= 0; i--) {
         const slice = slices[i]
-        if (slice.isReply) {
-          if (slice.isRepost) {
-            continue
-          }
-          if (!slice.isFollowingAllAuthors(userDid)) {
-            slices.splice(i, 1)
-          }
+        if (
+          slice.isReply &&
+          !slice.isRepost &&
+          !slice.isFollowingAllAuthors(userDid)
+        ) {
+          slices.splice(i, 1)
         }
       }
       return slices


### PR DESCRIPTION
This fixes conditions where we erroneously show replies in Following where you don't follow somebody in the conversation. Unfortunately this is not a 100% solution because it only checks the following actors:

- The reply author
- The parent author
- The grandparent author
- (...But not the intermediate ones...)
- The root author

However, this catches most cases where it matters and fixes the issue where a reply chain from somebody you follow _in an unrelated account's thread_ ends up in your Following feed. Simply filtering by thread OP is already doing a lot.

The new logic is simpler than before. We simply check that all of the actors above are either you or someone you follow. That's it. If even one of them is someone you don't follow (and someone who isn't you), we omit that reply.

This means that it's stricter than before. Previously, we'd let through your own replies to non-follows. We'd also let through friend conversations where OP is a non-friend. Now we don't let those through.

In other words, everything you see in Following is composed out of people you actually follow.

In the future, if we track the entire conversation chain (we currently don't), we'd be able to extend this check all the way up so that it considers authors of *all* the intermediate posts as well. But for now, this will have to do.

## Test Plan

Inspect the code, it's trivial.

Check your Following feed, verify you're not seeing anyone who isn't supposed to be there.

I found it helpful to invert the boolean condition around the `splice` call for the sake of testing, and to verify that everything that's displayed is something I'd want to see filtered _out_.