### PR TITLE
Tweak desktop list header

### DIFF
--- a/src/components/Lists.tsx
+++ b/src/components/Lists.tsx
@@ -122,8 +122,16 @@ export function ListHeaderDesktop({
   if (!gtTablet) return null
 
   return (
-    <View style={[a.w_full, a.py_lg, a.px_xl, a.gap_xs]}>
-      <Text style={[a.text_3xl, a.font_bold]}>{title}</Text>
+    <View
+      style={[
+        a.w_full,
+        a.py_sm,
+        a.px_xl,
+        a.gap_xs,
+        a.justify_center,
+        {minHeight: 50},
+      ]}>
+      <Text style={[a.text_2xl, a.font_bold]}>{title}</Text>
       {subtitle ? (
         <Text style={[a.text_md, t.atoms.text_contrast_medium]}>
           {subtitle}


### PR DESCRIPTION
Tweak desktop list header - it now matches the size of the notifications header

## Before

<img width="625" alt="Screenshot 2024-08-03 at 00 23 45" src="https://github.com/user-attachments/assets/7f6658b7-20d0-4c7d-8f7c-f9470d4489cb">

## After

<img width="620" alt="Screenshot 2024-08-03 at 00 23 28" src="https://github.com/user-attachments/assets/4eff624a-2ff6-4745-8dd8-f4810c965add">
