### PR TITLE
[Persisted] Fix the race condition causing clobbered writes between tabs

### DIFF
--- a/src/state/persisted/index.ts
+++ b/src/state/persisted/index.ts
@@ -13,10 +13,9 @@ let _state: Schema = defaults
 
 export async function init() {
   const stored = await readFromStorage()
-  if (!stored) {
-    await writeToStorage(defaults)
+  if (stored) {
+    _state = stored
   }
-  _state = stored || defaults
 }
 init satisfies PersistedApi['init']
 
@@ -29,7 +28,10 @@ export async function write<K extends keyof Schema>(
   key: K,
   value: Schema[K],
 ): Promise<void> {
-  _state[key] = value
+  _state = {
+    ..._state,
+    [key]: value,
+  }
   await writeToStorage(_state)
 }
 write satisfies PersistedApi['write']

--- a/src/state/persisted/index.ts
+++ b/src/state/persisted/index.ts
@@ -1,7 +1,7 @@
 import AsyncStorage from '@react-native-async-storage/async-storage'
 
 import {logger} from '#/logger'
-import {defaults, Schema, schema} from '#/state/persisted/schema'
+import {defaults, Schema, schema, tryParse} from '#/state/persisted/schema'
 import {PersistedApi} from './types'
 
 export type {PersistedAccount, Schema} from '#/state/persisted/schema'
@@ -71,24 +71,7 @@ async function readFromStorage(): Promise<Schema | undefined> {
       message: e,
     })
   }
-
-  // new user
-  if (!objData) return undefined
-
-  // existing user, validate
-  const parsed = schema.safeParse(objData)
-
-  if (parsed.success) {
-    return objData
-  } else {
-    const errors =
-      parsed.error?.errors?.map(e => ({
-        code: e.code,
-        // @ts-ignore exists on some types
-        expected: e?.expected,
-        path: e.path?.join('.'),
-      })) || []
-    logger.error(`persisted store: data failed validation on read`, {errors})
-    return undefined
+  if (objData) {
+    return tryParse(objData)
   }
 }

--- a/src/state/persisted/index.ts
+++ b/src/state/persisted/index.ts
@@ -62,16 +62,13 @@ async function writeToStorage(value: Schema) {
 }
 
 async function readFromStorage(): Promise<Schema | undefined> {
-  let objData
+  let rawData: string | null = null
   try {
-    const rawData = await AsyncStorage.getItem(BSKY_STORAGE)
-    objData = rawData ? JSON.parse(rawData) : undefined
+    rawData = await AsyncStorage.getItem(BSKY_STORAGE)
   } catch (e) {
-    logger.error('persisted state: failed to load root state from storage', {
-      message: e,
-    })
+    // Ignore.
   }
-  if (objData) {
-    return tryParse(objData)
+  if (rawData) {
+    return tryParse(rawData)
   }
 }

--- a/src/state/persisted/index.web.ts
+++ b/src/state/persisted/index.web.ts
@@ -85,16 +85,13 @@ function writeToStorage(value: Schema) {
 }
 
 function readFromStorage(): Schema | undefined {
-  let objData
+  let rawData: string | null = null
   try {
-    const rawData = localStorage.getItem(BSKY_STORAGE)
-    objData = rawData ? JSON.parse(rawData) : undefined
+    rawData = localStorage.getItem(BSKY_STORAGE)
   } catch (e) {
-    logger.error('persisted state: failed to load root state from storage', {
-      message: e,
-    })
+    // Ignore.
   }
-  if (objData) {
-    return tryParse(objData)
+  if (rawData) {
+    return tryParse(rawData)
   }
 }

--- a/src/state/persisted/index.web.ts
+++ b/src/state/persisted/index.web.ts
@@ -89,6 +89,8 @@ function writeToStorage(value: Schema) {
   }
 }
 
+let lastRawData: string | undefined
+let lastResult: Schema | undefined
 function readFromStorage(): Schema | undefined {
   let rawData: string | null = null
   try {
@@ -97,6 +99,13 @@ function readFromStorage(): Schema | undefined {
     // Expected on the web in private mode.
   }
   if (rawData) {
-    return tryParse(rawData)
+    if (rawData === lastRawData) {
+      return lastResult
+    } else {
+      const result = tryParse(rawData)
+      lastRawData = rawData
+      lastResult = result
+      return result
+    }
   }
 }

--- a/src/state/persisted/index.web.ts
+++ b/src/state/persisted/index.web.ts
@@ -19,10 +19,9 @@ const _emitter = new EventEmitter()
 export async function init() {
   broadcast.onmessage = onBroadcastMessage
   const stored = readFromStorage()
-  if (!stored) {
-    writeToStorage(defaults)
+  if (stored) {
+    _state = stored
   }
-  _state = stored || defaults
 }
 init satisfies PersistedApi['init']
 
@@ -35,7 +34,10 @@ export async function write<K extends keyof Schema>(
   key: K,
   value: Schema[K],
 ): Promise<void> {
-  _state[key] = value
+  _state = {
+    ..._state,
+    [key]: value,
+  }
   writeToStorage(_state)
   broadcast.postMessage({event: UPDATE_EVENT})
 }

--- a/src/state/persisted/index.web.ts
+++ b/src/state/persisted/index.web.ts
@@ -45,8 +45,7 @@ export async function write<K extends keyof Schema>(
   try {
     _state[key] = value
     writeToStorage(_state)
-    // must happen on next tick, otherwise the tab will read stale storage data
-    setTimeout(() => broadcast.postMessage({event: UPDATE_EVENT}), 0)
+    broadcast.postMessage({event: UPDATE_EVENT})
   } catch (e) {
     logger.error(`persisted state: failed writing root state to storage`, {
       message: e,

--- a/src/state/persisted/index.web.ts
+++ b/src/state/persisted/index.web.ts
@@ -2,7 +2,7 @@ import EventEmitter from 'eventemitter3'
 
 import BroadcastChannel from '#/lib/broadcast'
 import {logger} from '#/logger'
-import {defaults, Schema, schema} from '#/state/persisted/schema'
+import {defaults, Schema, schema, tryParse} from '#/state/persisted/schema'
 import {PersistedApi} from './types'
 
 export type {PersistedAccount, Schema} from '#/state/persisted/schema'
@@ -94,24 +94,7 @@ function readFromStorage(): Schema | undefined {
       message: e,
     })
   }
-
-  // new user
-  if (!objData) return undefined
-
-  // existing user, validate
-  const parsed = schema.safeParse(objData)
-
-  if (parsed.success) {
-    return objData
-  } else {
-    const errors =
-      parsed.error?.errors?.map(e => ({
-        code: e.code,
-        // @ts-ignore exists on some types
-        expected: e?.expected,
-        path: e.path?.join('.'),
-      })) || []
-    logger.error(`persisted store: data failed validation on read`, {errors})
-    return undefined
+  if (objData) {
+    return tryParse(objData)
   }
 }

--- a/src/state/persisted/index.web.ts
+++ b/src/state/persisted/index.web.ts
@@ -39,6 +39,14 @@ export async function write<K extends keyof Schema>(
   key: K,
   value: Schema[K],
 ): Promise<void> {
+  const next = readFromStorage()
+  if (next) {
+    // The storage could have been updated by a different tab before this tab is notified.
+    // Make sure this write is applied on top of the latest data in the storage as long as it's valid.
+    _state = next
+    // Don't fire the update listeners yet to avoid a loop.
+    // If there was a change, we'll receive the broadcast event soon enough which will do that.
+  }
   _state = {
     ..._state,
     [key]: value,

--- a/src/state/persisted/schema.ts
+++ b/src/state/persisted/schema.ts
@@ -135,7 +135,18 @@ export const defaults: Schema = {
   hasCheckedForStarterPack: false,
 }
 
-export function tryParse(objData: any): Schema | undefined {
+export function tryParse(rawData: string): Schema | undefined {
+  let objData
+  try {
+    objData = JSON.parse(rawData)
+  } catch (e) {
+    logger.error('persisted state: failed to parse root state from storage', {
+      message: e,
+    })
+  }
+  if (!objData) {
+    return undefined
+  }
   const parsed = schema.safeParse(objData)
   if (parsed.success) {
     return objData

--- a/src/state/persisted/schema.ts
+++ b/src/state/persisted/schema.ts
@@ -44,7 +44,7 @@ const currentAccountSchema = accountSchema.extend({
 })
 export type PersistedCurrentAccount = z.infer<typeof currentAccountSchema>
 
-export const schema = z.object({
+const schema = z.object({
   colorMode: z.enum(['system', 'light', 'dark']),
   darkTheme: z.enum(['dim', 'dark']).optional(),
   session: z.object({
@@ -159,6 +159,18 @@ export function tryParse(rawData: string): Schema | undefined {
         path: e.path?.join('.'),
       })) || []
     logger.error(`persisted store: data failed validation on read`, {errors})
+    return undefined
+  }
+}
+
+export function tryStringify(value: Schema): string | undefined {
+  try {
+    schema.parse(value)
+    return JSON.stringify(value)
+  } catch (e) {
+    logger.error(`persisted state: failed stringifying root state`, {
+      message: e,
+    })
     return undefined
   }
 }

--- a/src/state/persisted/schema.ts
+++ b/src/state/persisted/schema.ts
@@ -1,5 +1,6 @@
 import {z} from 'zod'
 
+import {logger} from '#/logger'
 import {deviceLocales} from '#/platform/detection'
 import {PlatformInfo} from '../../../modules/expo-bluesky-swiss-army'
 
@@ -132,4 +133,21 @@ export const defaults: Schema = {
   disableAutoplay: PlatformInfo.getIsReducedMotionEnabled(),
   kawaii: false,
   hasCheckedForStarterPack: false,
+}
+
+export function tryParse(objData: any): Schema | undefined {
+  const parsed = schema.safeParse(objData)
+  if (parsed.success) {
+    return objData
+  } else {
+    const errors =
+      parsed.error?.errors?.map(e => ({
+        code: e.code,
+        // @ts-ignore exists on some types
+        expected: e?.expected,
+        path: e.path?.join('.'),
+      })) || []
+    logger.error(`persisted store: data failed validation on read`, {errors})
+    return undefined
+  }
 }


### PR DESCRIPTION
Stacked on #4872.

This removes defensive programming in the original code, extracts some shared logic between platforms, and fixes a race condition that caused potential clobbered concurrent writes between tabs. I recommend to review commit by commit:

- https://github.com/bluesky-social/social-app/commit/2e70c0c95ba8d47dcca6c95d6206517d349375c8: This removes the `setTimeout(..., 0)` around the `broadcast.postMessage` call. I believe its premise is incorrect. The premise of this wrapper is that the other tab might read stale data because the broadcast message can arrive before the local storage update is flushed. I find this difficult to believe given that the `localStorage` contract on the web is synchronous while `postMessage` is _definitely_ asynchronous and definitely can lag behind under pressure. In other words, the inverse of what the comment says is likely to be true unless I'm missing something extraordinary (which is always possible). I think this wrapper was likely added because it makes a different race condition less common (but not impossible), which I describe in the last commit (see below). For now let's remove this wrapper.
-  https://github.com/bluesky-social/social-app/commit/08f7c3f298f8921e147a4132e4dab5dfb467616d?w=1: This removes the overly broad `try`/`catch`es around the parts of the code that we do not expect to throw. There are three kinds of things that can throw: `schema.parse()`, `JSON.parse()`, `JSON.stringify()`, and `localStorage`/`AsyncStorage` methods. Those remain wrapped in `try`/`catch`es that deal with those specific errors.
- ab3a1596d250d1115a6ad7c9b97417faa673e9f3: We do not actually need to write defaults into the storage on first initialization. It is enough to write them on first attempt to write. While writing this, I noticed that `_state` can end up getting set to `defaults`. This is no bueno because we mutate `_state` directly in `write` but we wouldn't want to mutate the `defaults`. We could fix this in a few different ways but I opted to just shallowly copy `_state` on write since we already treat values inside as immutable.
- https://github.com/bluesky-social/social-app/commit/24f0e8c55d9c068376f9463fdd5b5d0550c1ce9b: Pure refactor. Extracts common code into a `tryParse(obj): Schema | undefined` utility.
- https://github.com/bluesky-social/social-app/commit/d55e9f84beab8d60bc305c589d068d1642277417: Pure refactor. Changes `tryParse` to take a string, moves `JSON.parse` inside it. 
- https://github.com/bluesky-social/social-app/commit/fe59dd025dab511e50a03c36a776e51da13675a9: Introduces `tryStringify(value): string | undefined` that mirrors `tryParse`. This lets us separate out the parts we want to report to Sentry (e.g. invalid JSON or failed schema validation) from parts we don't (`localStorage` on the web is expected to fail in private mode). `writeToStorage` and `readToStorage` become thin storage wrappers.
- https://github.com/bluesky-social/social-app/commit/acb4094e4a950c2f0ab7c56fa12ad478782e0c1b: Adds a bit of memoization to the web version of `readToStorage` because I'll call it more often.
- c82fe5bea45f330f714e3beabab0ea85ff2f7269: Finally, the actual bugfix! If a tab writes to the storage but another tab hasn't received the event, the write from the second tab will overwrite the data put into the storage by the first tab. While there's no way to avoid the conflict if the keys are overlapping, we can easily resolve the conflict when they're not — we just need to _read_ the data from the storage _before_ applying the write (and we need to apply the write _on top of_ the fresh data).

## Test Plan

Normal things you'd do when testing storage.

For testing the last part of the fix, you can apply this diff (which _disables_ the fix):

```difff
diff --git a/src/state/persisted/index.web.ts b/src/state/persisted/index.web.ts
index d71b59096..35aac04d9 100644
--- a/src/state/persisted/index.web.ts
+++ b/src/state/persisted/index.web.ts
@@ -43,7 +43,16 @@ export async function write<K extends keyof Schema>(
   if (next) {
     // The storage could have been updated by a different tab before this tab is notified.
     // Make sure this write is applied on top of the latest data in the storage as long as it's valid.
-    _state = next
+    // _state = next
+    if (JSON.stringify(next) !== JSON.stringify(_state)) {
+      console.error('oh no')
+      console.error(' [memory]    invites:', _state?.invites.copiedInvites)
+      console.error(' [storage]    invites:', next?.invites.copiedInvites)
+      console.log()
+      console.error(' [memory]    posts:', _state?.hiddenPosts)
+      console.error(' [storage]    posts:', next?.hiddenPosts)
+
+    }
     // Don't fire the update listeners yet to avoid a loop.
     // If there was a change, we'll receive the broadcast event soon enough which will do that.
   }
@@ -51,6 +60,7 @@ export async function write<K extends keyof Schema>(
     ..._state,
     [key]: value,
   }
+  console.log('writing', key, value)
   writeToStorage(_state)
   broadcast.postMessage({event: UPDATE_EVENT})
 }
@@ -75,6 +85,9 @@ async function onBroadcastMessage({data}: MessageEvent) {
   if (typeof data === 'object' && data.event === UPDATE_EVENT) {
     // read next state, possibly updated by another tab
     const next = readFromStorage()
+    console.log('-- read from broadcast')
+    console.log('    invites:', next?.invites.copiedInvites)
+    console.log('    posts:', next?.hiddenPosts)
     if (next) {
       _state = next
       _emitter.emit('update')
diff --git a/src/state/preferences/hidden-posts.tsx b/src/state/preferences/hidden-posts.tsx
index 2c6a373e1..0e9bc7859 100644
--- a/src/state/preferences/hidden-posts.tsx
+++ b/src/state/preferences/hidden-posts.tsx
@@ -44,6 +44,22 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
   )
 
   React.useEffect(() => {
+    if (location.search === '?foo=') {
+      setInterval(() => {
+        persisted.write('invites', {
+          copiedInvites: [
+            Math.random().toString()
+          ]
+        })
+      }, 100)
+    } else {
+      setInterval(() => {
+        persisted.write('hiddenPosts', [
+          Math.random().toString()
+        ])
+      }, 100)
+    }
+
     return persisted.onUpdate(() => {
       setState(persisted.get('hiddenPosts'))
     })
```

Then open two tabs:

- http://localhost:19006/
- http://localhost:19006/?foo=

One tab will attempt to write to `invites` every 100ms, another tab will attempt to write to `hiddenPosts` every 100ms.

Observe that they clobber each other's writes:

![Screenshot 2024-08-04 at 03 00 28](https://github.com/user-attachments/assets/33c8a057-76bc-48e3-9e58-b0b76ba12e24)

Of course, this just shows the symptom so you'd have to trust that the fix works. (It trivially works by making the `JSON.stringify(next) !== JSON.stringify(_state)` condition impossible to happen but I'm struggling to see how to demonstrate this more clearly.) So if this is not convincing, I can think a bit more, but I hope the idea should be clear.