### PR TITLE
Prefer non-smart quotes in search field on iOS

### DIFF
--- a/src/view/screens/Search/Search.tsx
+++ b/src/view/screens/Search/Search.tsx
@@ -30,7 +30,7 @@ import {makeProfileLink} from '#/lib/routes/links'
 import {NavigationProp} from '#/lib/routes/types'
 import {augmentSearchQuery} from '#/lib/strings/helpers'
 import {logger} from '#/logger'
-import {isNative, isWeb} from '#/platform/detection'
+import {isIOS, isNative, isWeb} from '#/platform/detection'
 import {listenSoftReset} from '#/state/events'
 import {useModerationOpts} from '#/state/preferences/moderation-opts'
 import {useActorAutocompleteQuery} from '#/state/queries/actor-autocomplete'
@@ -794,6 +794,7 @@ let SearchInputBox = ({
         value={searchText}
         style={[pal.text, styles.headerSearchInput]}
         keyboardAppearance={theme.colorScheme}
+        keyboardType={isIOS ? 'ascii-capable' : undefined}
         selectTextOnFocus={isNative}
         onFocus={() => {
           if (isWeb) {


### PR DESCRIPTION
Bluesky's search backend supports exact-phrase matching using quotation marks, but only when the phrase is enclosed in `"straight quotes"`. On iOS, text input fields default to your system-wide preference for whether to use your locale's smart quotes, and that defaults to enabled - so you'll type `“your phrase”` and get search results for posts containing the terms `your` and `phrase` independently.

Normally you can override a text field's smart quote insertion behavior by setting its [`smartQuotesType`](https://developer.apple.com/documentation/uikit/uitextinputtraits/2865931-smartquotestype) to `UITextSmartQuotesType.no`, but unfortunately React Native doesn't expose this property on `TextInput`. It does, however, let you specify a [`keyboardType`](https://reactnative.dev/docs/textinput#keyboardtype), and when you set it to `ascii-capable` it seems to use [`UIKeyboardTypeASCIICapable`](https://developer.apple.com/documentation/uikit/uikeyboardtype/uikeyboardtypeasciicapable). This keyboard type defaults to inserting straight quotes when you hit the `"` key, but seems to let you insert smart quotes by long-pressing, which I believe is the desired behavior here. (Thanks to [this StackOverflow answer](https://stackoverflow.com/a/62961527) for the workaround.)

This seemed to work right in the iOS simulator. I'm not sure how to verify that it does the right thing when your default keyboard is non-English. In the simulator, I did still see the input switcher menu with this change, so I *think* it should be OK, but if you have a better test setup with a simulator that's configured with only a non-English OS language and keyboard, I'd suggest verifying that it doesn't force you to use an undesired keyboard layout in that situation. 