### PR TITLE
Show own replies before follows' replies in threads

### DIFF
--- a/src/state/queries/post-thread.ts
+++ b/src/state/queries/post-thread.ts
@@ -136,6 +136,7 @@ export function sortThread(
   node: ThreadNode,
   opts: UsePreferencesQueryResponse['threadViewPrefs'],
   modCache: ThreadModerationCache,
+  currentDid: string | undefined,
 ): ThreadNode {
   if (node.type !== 'post') {
     return node
@@ -157,6 +158,16 @@ export function sortThread(
         return -1 // op's own reply
       } else if (bIsByOp) {
         return 1 // op's own reply
+      }
+
+      const aIsBySelf = a.post.author.did === currentDid
+      const bIsBySelf = b.post.author.did === currentDid
+      if (aIsBySelf && bIsBySelf) {
+        return a.post.indexedAt.localeCompare(b.post.indexedAt) // oldest
+      } else if (aIsBySelf) {
+        return -1 // current account's reply
+      } else if (bIsBySelf) {
+        return 1 // current account's reply
       }
 
       const aBlur = Boolean(modCache.get(a)?.ui('contentList').blur)
@@ -195,7 +206,7 @@ export function sortThread(
       }
       return b.post.indexedAt.localeCompare(a.post.indexedAt)
     })
-    node.replies.forEach(reply => sortThread(reply, opts, modCache))
+    node.replies.forEach(reply => sortThread(reply, opts, modCache, currentDid))
   }
   return node
 }

--- a/src/view/com/post-thread/PostThread.tsx
+++ b/src/view/com/post-thread/PostThread.tsx
@@ -89,7 +89,7 @@ export function PostThread({
   onCanReply: (canReply: boolean) => void
   onPressReply: () => unknown
 }) {
-  const {hasSession} = useSession()
+  const {hasSession, currentAccount} = useSession()
   const {_} = useLingui()
   const t = useTheme()
   const {isMobile, isTabletOrMobile} = useWebMediaQueries()
@@ -154,6 +154,7 @@ export function PostThread({
   // On the web this is not necessary because we can synchronously adjust the scroll in onContentSizeChange instead.
   const [deferParents, setDeferParents] = React.useState(isNative)
 
+  const currentDid = currentAccount?.did
   const threadModerationCache = React.useMemo(() => {
     const cache: ThreadModerationCache = new WeakMap()
     if (thread && moderationOpts) {
@@ -167,8 +168,8 @@ export function PostThread({
     if (!threadViewPrefs || !thread) return null
 
     return createThreadSkeleton(
-      sortThread(thread, threadViewPrefs, threadModerationCache),
-      hasSession,
+      sortThread(thread, threadViewPrefs, threadModerationCache, currentDid),
+      !!currentDid,
       treeView,
       threadModerationCache,
       hiddenRepliesState !== HiddenRepliesState.Hide,
@@ -176,7 +177,7 @@ export function PostThread({
   }, [
     thread,
     preferences?.threadViewPrefs,
-    hasSession,
+    currentDid,
     treeView,
     threadModerationCache,
     hiddenRepliesState,


### PR DESCRIPTION
We currently put OP replies first, then people you follow (for an option that's true by default), then other replies. However, we're not doing anything with _your own_ replies which [makes them a bit hard to find](https://bsky.app/profile/citizenkate.bsky.social/post/3kz2qmt5eac2k) in bigger threads.

This tweaks the heuristic so that your own replies go right after the OP (but above your follows).

## Test Plan

Reply to a thread, see your reply below the OP.

https://github.com/user-attachments/assets/794c7262-4bc4-474b-9602-dabc0c4f507b

