### PR TITLE
Keep interstitial fresh on refresh

### DIFF
--- a/src/view/com/posts/Feed.tsx
+++ b/src/view/com/posts/Feed.tsx
@@ -212,8 +212,9 @@ let Feed = ({
     isFetchingNextPage,
     fetchNextPage,
   } = usePostFeedQuery(feed, feedParams, opts)
-  if (data?.pages[0]) {
-    lastFetchRef.current = data?.pages[0].fetchedAt
+  const lastFetchedAt = data?.pages[0].fetchedAt
+  if (lastFetchedAt) {
+    lastFetchRef.current = lastFetchedAt
   }
   const isEmpty = React.useMemo(
     () => !isFetching && !data?.pages?.some(page => page.slices.length),
@@ -358,7 +359,7 @@ let Feed = ({
               ...interstitial,
               params: {variant},
               // overwrite key with unique value
-              key: [interstitial.type, variant].join(':'),
+              key: [interstitial.type, variant, lastFetchedAt].join(':'),
             }
 
             if (arr.length > interstitial.slot) {
@@ -374,6 +375,7 @@ let Feed = ({
     isFetched,
     isError,
     isEmpty,
+    lastFetchedAt,
     data,
     feedUri,
     feedIsDiscover,


### PR DESCRIPTION
Refreshing Discover doesn't currently refresh the interstitial. This updates the content by keying it by first page's fetch time.

## Test Plan

Scroll down.

![Screenshot 2024-08-08 at 05 53 09](https://github.com/user-attachments/assets/e09d1b91-7b21-44ad-a899-e8616bbab5e0)

Press Discover again to refresh. Scroll down again.

Observe different order/people:

![Screenshot 2024-08-08 at 05 53 00](https://github.com/user-attachments/assets/fd020573-8480-4e95-87e7-6a3870b99d86)
