### PR TITLE
Show just-posted replies above OP replies

### DIFF
--- a/src/state/queries/post-thread.ts
+++ b/src/state/queries/post-thread.ts
@@ -137,6 +137,7 @@ export function sortThread(
   opts: UsePreferencesQueryResponse['threadViewPrefs'],
   modCache: ThreadModerationCache,
   currentDid: string | undefined,
+  justPostedUris: Set<string>,
 ): ThreadNode {
   if (node.type !== 'post') {
     return node
@@ -148,6 +149,18 @@ export function sortThread(
       }
       if (b.type !== 'post') {
         return -1
+      }
+
+      const aIsJustPosted =
+        a.post.author.did === currentDid && justPostedUris.has(a.post.uri)
+      const bIsJustPosted =
+        b.post.author.did === currentDid && justPostedUris.has(b.post.uri)
+      if (aIsJustPosted && bIsJustPosted) {
+        return a.post.indexedAt.localeCompare(b.post.indexedAt) // oldest
+      } else if (aIsJustPosted) {
+        return -1 // reply while onscreen
+      } else if (bIsJustPosted) {
+        return 1 // reply while onscreen
       }
 
       const aIsByOp = a.post.author.did === node.post?.author.did
@@ -206,7 +219,9 @@ export function sortThread(
       }
       return b.post.indexedAt.localeCompare(a.post.indexedAt)
     })
-    node.replies.forEach(reply => sortThread(reply, opts, modCache, currentDid))
+    node.replies.forEach(reply =>
+      sortThread(reply, opts, modCache, currentDid, justPostedUris),
+    )
   }
   return node
 }

--- a/src/state/queries/post-thread.ts
+++ b/src/state/queries/post-thread.ts
@@ -151,16 +151,18 @@ export function sortThread(
         return -1
       }
 
-      const aIsJustPosted =
-        a.post.author.did === currentDid && justPostedUris.has(a.post.uri)
-      const bIsJustPosted =
-        b.post.author.did === currentDid && justPostedUris.has(b.post.uri)
-      if (aIsJustPosted && bIsJustPosted) {
-        return a.post.indexedAt.localeCompare(b.post.indexedAt) // oldest
-      } else if (aIsJustPosted) {
-        return -1 // reply while onscreen
-      } else if (bIsJustPosted) {
-        return 1 // reply while onscreen
+      if (node.ctx.isHighlightedPost || opts.lab_treeViewEnabled) {
+        const aIsJustPosted =
+          a.post.author.did === currentDid && justPostedUris.has(a.post.uri)
+        const bIsJustPosted =
+          b.post.author.did === currentDid && justPostedUris.has(b.post.uri)
+        if (aIsJustPosted && bIsJustPosted) {
+          return a.post.indexedAt.localeCompare(b.post.indexedAt) // oldest
+        } else if (aIsJustPosted) {
+          return -1 // reply while onscreen
+        } else if (bIsJustPosted) {
+          return 1 // reply while onscreen
+        }
       }
 
       const aIsByOp = a.post.author.did === node.post?.author.did

--- a/src/state/shell/composer.tsx
+++ b/src/state/shell/composer.tsx
@@ -1,10 +1,11 @@
 import React from 'react'
 import {
+  AppBskyActorDefs,
   AppBskyEmbedRecord,
   AppBskyRichtextFacet,
   ModerationDecision,
-  AppBskyActorDefs,
 } from '@atproto/api'
+
 import {useNonReactiveCallback} from '#/lib/hooks/useNonReactiveCallback'
 
 export interface ComposerOptsPostRef {
@@ -31,7 +32,7 @@ export interface ComposerOptsQuote {
 }
 export interface ComposerOpts {
   replyTo?: ComposerOptsPostRef
-  onPost?: () => void
+  onPost?: (postUri: string | undefined) => void
   quote?: ComposerOptsQuote
   mention?: string // handle of user to mention
   openPicker?: (pos: DOMRect | undefined) => void

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -392,7 +392,7 @@ export const ComposePost = observer(function ComposePost({
       emitPostCreated()
     }
     setLangPrefs.savePostLanguageToHistory()
-    onPost?.()
+    onPost?.(postUri)
     onClose()
     Toast.show(
       replyTo

--- a/src/view/com/post-thread/PostThread.tsx
+++ b/src/view/com/post-thread/PostThread.tsx
@@ -160,12 +160,22 @@ export function PostThread({uri}: {uri: string | undefined}) {
     return cache
   }, [thread, moderationOpts])
 
+  const [justPostedUris, setJustPostedUris] = React.useState(
+    () => new Set<string>(),
+  )
+
   const skeleton = React.useMemo(() => {
     const threadViewPrefs = preferences?.threadViewPrefs
     if (!threadViewPrefs || !thread) return null
 
     return createThreadSkeleton(
-      sortThread(thread, threadViewPrefs, threadModerationCache, currentDid),
+      sortThread(
+        thread,
+        threadViewPrefs,
+        threadModerationCache,
+        currentDid,
+        justPostedUris,
+      ),
       !!currentDid,
       treeView,
       threadModerationCache,
@@ -178,6 +188,7 @@ export function PostThread({uri}: {uri: string | undefined}) {
     treeView,
     threadModerationCache,
     hiddenRepliesState,
+    justPostedUris,
   ])
 
   const error = React.useMemo(() => {
@@ -302,9 +313,19 @@ export function PostThread({uri}: {uri: string | undefined}) {
     setMaxReplies(prev => prev + 50)
   }, [isFetching, maxReplies, posts.length])
 
-  const onPostReply = React.useCallback(() => {
-    refetch()
-  }, [refetch])
+  const onPostReply = React.useCallback(
+    (postUri: string | undefined) => {
+      refetch()
+      if (postUri) {
+        setJustPostedUris(set => {
+          const nextSet = new Set(set)
+          nextSet.add(postUri)
+          return nextSet
+        })
+      }
+    },
+    [refetch],
+  )
 
   const {openComposer} = useComposerControls()
   const onPressReply = React.useCallback(() => {

--- a/src/view/com/post-thread/PostThread.tsx
+++ b/src/view/com/post-thread/PostThread.tsx
@@ -302,6 +302,10 @@ export function PostThread({uri}: {uri: string | undefined}) {
     setMaxReplies(prev => prev + 50)
   }, [isFetching, maxReplies, posts.length])
 
+  const onPostReply = React.useCallback(() => {
+    refetch()
+  }, [refetch])
+
   const {openComposer} = useComposerControls()
   const onPressReply = React.useCallback(() => {
     if (thread?.type !== 'post') {
@@ -315,9 +319,9 @@ export function PostThread({uri}: {uri: string | undefined}) {
         author: thread.post.author,
         embed: thread.post.embed,
       },
-      onPost: () => refetch(),
+      onPost: onPostReply,
     })
-  }, [openComposer, thread, refetch])
+  }, [openComposer, thread, onPostReply])
 
   const canReply = !error && rootPost && !rootPost.viewer?.replyDisabled
   const hasParents =
@@ -415,7 +419,7 @@ export function PostThread({uri}: {uri: string | undefined}) {
                 HiddenRepliesState.ShowAndOverridePostHider &&
               item.ctx.depth > 0
             }
-            onPostReply={refetch}
+            onPostReply={onPostReply}
             hideTopBorder={index === 0 && !item.ctx.isParentLoading}
           />
         </View>

--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -75,7 +75,7 @@ export function PostThreadItem({
   showParentReplyLine?: boolean
   hasPrecedingItem: boolean
   overrideBlur: boolean
-  onPostReply: () => void
+  onPostReply: (postUri: string | undefined) => void
   hideTopBorder?: boolean
 }) {
   const postShadowed = usePostShadow(post)
@@ -169,7 +169,7 @@ let PostThreadItemLoaded = ({
   showParentReplyLine?: boolean
   hasPrecedingItem: boolean
   overrideBlur: boolean
-  onPostReply: () => void
+  onPostReply: (postUri: string | undefined) => void
   hideTopBorder?: boolean
 }): React.ReactNode => {
   const pal = usePalette('default')


### PR DESCRIPTION
Follow-up to https://github.com/bluesky-social/social-app/pull/4882.

Normally we show OP replies above all so that threads work. However, if you have _just_ posted a reply, it is confusing to have it appear offscreen. Twitter handles this by prioritizing just-posted own replies above the OP's (but showing them below the OP's if you navigate away and back to the post). This accomplishes the same thing.

We can do this now because #4898 consolidated the logic for "after post" callback in the post thread component.

## Test Plan

Normal mode:

https://github.com/user-attachments/assets/0dc0bbc9-dd47-4357-a6ab-2433ac0839e4

Thread mode:

https://github.com/user-attachments/assets/94c3392d-9f48-48e0-8e24-c40a14c980d8

Note that we only do this when we're sure we won't completely _displace_ the OP post out of view:

https://github.com/user-attachments/assets/d6e1a9f6-1b97-40be-8a31-d285fe8d067f

Concretely, this means that we only do this in threaded more _or_ directly under the highlighted post. Otherwise, it feels too confusing to have the OP post disappear.