### PR TITLE
Show Post header on desktop web

### DIFF
--- a/src/view/com/util/ViewHeader.tsx
+++ b/src/view/com/util/ViewHeader.tsx
@@ -151,6 +151,7 @@ function DesktopWebHeader({
       style={[
         styles.header,
         styles.desktopHeader,
+        pal.view,
         pal.border,
         {
           borderBottomWidth: showBorder ? StyleSheet.hairlineWidth : 0,


### PR DESCRIPTION
This thing:

https://github.com/user-attachments/assets/00879c47-7596-4936-927f-3bbda515d882

Previously we only showed it on mobile and tablet layouts, but not on desktop web. This wasn't intentional but was related to difficulties of scroll positioning. We've now resolved the underlying difficulties and can do this without much problem.

Arguably it feels a little large but we can fix that separately if we want — that's the same size as on other pages for desktop.

In addition to visual/behavior consistency, this also fixes a jump that appears when posting into a thread while desktop, which was caused by conditionally showing the view header based on `isFetching` when it should've been `isLoading`. If we revert this PR in the future, we need to apply the other fix then.

## Test Plan

https://github.com/user-attachments/assets/9e41c6d7-b3e1-4a47-bfbc-b92b3105cfc5

https://github.com/user-attachments/assets/81464ce9-af25-41dd-9401-9c78f028cdca

https://github.com/user-attachments/assets/06899518-6554-4fc8-8911-a789ac8c2787

No behavior difference on native (checked iOS and Android).