### PR TITLE
Platform-native back buttons

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "@react-native-picker/picker": "2.6.1",
     "@react-navigation/bottom-tabs": "^6.5.20",
     "@react-navigation/drawer": "^6.6.15",
+    "@react-navigation/elements": "^1.3.31",
     "@react-navigation/native": "^6.1.17",
     "@react-navigation/native-stack": "^6.9.26",
     "@segment/analytics-next": "^1.51.3",

--- a/src/view/com/util/ViewHeader.tsx
+++ b/src/view/com/util/ViewHeader.tsx
@@ -4,15 +4,17 @@ import Animated from 'react-native-reanimated'
 import {FontAwesomeIcon} from '@fortawesome/react-native-fontawesome'
 import {msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
+import {HeaderBackButton} from '@react-navigation/elements'
 import {useNavigation} from '@react-navigation/native'
 
+import {isWeb} from '#/platform/detection'
 import {useSetDrawerOpen} from '#/state/shell'
 import {useAnalytics} from 'lib/analytics/analytics'
 import {useMinimalShellHeaderTransform} from 'lib/hooks/useMinimalShellTransform'
 import {usePalette} from 'lib/hooks/usePalette'
 import {useWebMediaQueries} from 'lib/hooks/useWebMediaQueries'
 import {NavigationProp} from 'lib/routes/types'
-import {useTheme} from '#/alf'
+import {ios, useTheme} from '#/alf'
 import {Menu_Stroke2_Corner0_Rounded as Menu} from '#/components/icons/Menu'
 import {Text} from './text/Text'
 import {CenteredView} from './Views'
@@ -81,26 +83,39 @@ export function ViewHeader({
         <View style={{flex: 1}}>
           <View style={{flexDirection: 'row', alignItems: 'center'}}>
             {showBackButton ? (
-              <TouchableOpacity
-                testID="viewHeaderDrawerBtn"
-                onPress={canGoBack ? onPressBack : onPressMenu}
-                hitSlop={BACK_HITSLOP}
-                style={canGoBack ? styles.backBtn : styles.backBtnWide}
-                accessibilityRole="button"
-                accessibilityLabel={canGoBack ? _(msg`Back`) : _(msg`Menu`)}
-                accessibilityHint={
-                  canGoBack ? '' : _(msg`Access navigation links and settings`)
-                }>
-                {canGoBack ? (
-                  <FontAwesomeIcon
-                    size={18}
-                    icon="angle-left"
-                    style={[styles.backIcon, pal.text]}
+              isWeb || !canGoBack ? (
+                <TouchableOpacity
+                  testID="viewHeaderDrawerBtn"
+                  onPress={canGoBack ? onPressBack : onPressMenu}
+                  hitSlop={BACK_HITSLOP}
+                  style={canGoBack ? styles.backBtn : styles.backBtnWide}
+                  accessibilityRole="button"
+                  accessibilityLabel={canGoBack ? _(msg`Back`) : _(msg`Menu`)}
+                  accessibilityHint={
+                    canGoBack
+                      ? ''
+                      : _(msg`Access navigation links and settings`)
+                  }>
+                  {canGoBack ? (
+                    <FontAwesomeIcon
+                      size={18}
+                      icon="angle-left"
+                      style={[styles.backIcon, pal.text]}
+                    />
+                  ) : !isTablet ? (
+                    <Menu size="lg" style={[{marginTop: 3}, pal.textLight]} />
+                  ) : null}
+                </TouchableOpacity>
+              ) : (
+                <View style={styles.nativeBackBtn}>
+                  <HeaderBackButton
+                    onPress={onPressBack}
+                    labelVisible={false}
+                    tintColor={t.atoms.text.color}
+                    style={ios({transform: [{scale: 0.8}]})}
                   />
-                ) : !isTablet ? (
-                  <Menu size="lg" style={[{marginTop: 3}, pal.textLight]} />
-                ) : null}
-              </TouchableOpacity>
+                </View>
+              )
             ) : null}
             <View style={styles.titleContainer} pointerEvents="none">
               <Text type="title" style={[pal.text, styles.title]}>
@@ -270,5 +285,11 @@ const styles = StyleSheet.create({
   },
   backIcon: {
     marginTop: 6,
+  },
+  nativeBackBtn: {
+    width: 30,
+    height: 30,
+    alignItems: 'center',
+    justifyContent: 'center',
   },
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -5653,6 +5653,11 @@
   resolved "https://registry.yarnpkg.com/@react-navigation/elements/-/elements-1.3.30.tgz#a81371f599af1070b12014f05d6c09b1a611fd9a"
   integrity sha512-plhc8UvCZs0UkV+sI+3bisIyn78wz9O/BiWZXpounu72k/R/Sj5PuZYFJ1fi6psvriUveMCGh4LeZckAZu2qiQ==
 
+"@react-navigation/elements@^1.3.31":
+  version "1.3.31"
+  resolved "https://registry.yarnpkg.com/@react-navigation/elements/-/elements-1.3.31.tgz#28dd802a0787bb03fc0e5be296daf1804dbebbcf"
+  integrity sha512-bUzP4Awlljx5RKEExw8WYtif8EuQni2glDaieYROKTnaxsu9kEIA515sXQgUDZU4Ob12VoL7+z70uO3qrlfXcQ==
+
 "@react-navigation/native-stack@^6.9.26":
   version "6.9.26"
   resolved "https://registry.yarnpkg.com/@react-navigation/native-stack/-/native-stack-6.9.26.tgz#90facf7783c9927f094bc9f01c613af75b6c241e"


### PR DESCRIPTION
Kinda random but I hate our back chevron. This replaces it with the native back buttons, tweaked to match the size of our existing button.

Current:
<img width="362" alt="Screenshot 2024-08-09 at 00 40 22" src="https://github.com/user-attachments/assets/774ae595-6554-491f-a8d2-77f4f29f8fc1">

New (iOS)
<img width="371" alt="Screenshot 2024-08-09 at 00 07 26" src="https://github.com/user-attachments/assets/a5382b4b-7b7f-4647-a160-a80e178436af">
New (Android)
<img width="319" alt="Screenshot 2024-08-09 at 00 07 45" src="https://github.com/user-attachments/assets/d6c57f86-54b6-4c04-b8a7-196ef19aab5e">

# Test plan

Double check I got the logic right - we still want the existing pressable if it's for the hamburger menu