### PR TITLE
[Videos] Add iOS function to set `AVAudioSession.CategoryOptions` to `.mixWithOthers`

### DIFF
--- a/modules/expo-bluesky-swiss-army/ios/PlatformInfo/ExpoPlatformInfoModule.swift
+++ b/modules/expo-bluesky-swiss-army/ios/PlatformInfo/ExpoPlatformInfoModule.swift
@@ -7,7 +7,7 @@ public class ExpoPlatformInfoModule: Module {
     Function("getIsReducedMotionEnabled") {
       return UIAccessibility.isReduceMotionEnabled
     }
-    
+
     Function("setAudioMixWithOthers") { (mixWithOthers: Bool) in
       var options: AVAudioSession.CategoryOptions
       if mixWithOthers {
@@ -15,7 +15,7 @@ public class ExpoPlatformInfoModule: Module {
       } else {
         options = []
       }
-      try? AVAudioSession.sharedInstance().setCategory(AVAudioSession.Category.playback, mode: .default, options:  options)
+      try? AVAudioSession.sharedInstance().setCategory(AVAudioSession.Category.playback, mode: .default, options: options)
     }
   }
 }

--- a/modules/expo-bluesky-swiss-army/ios/PlatformInfo/ExpoPlatformInfoModule.swift
+++ b/modules/expo-bluesky-swiss-army/ios/PlatformInfo/ExpoPlatformInfoModule.swift
@@ -7,5 +7,15 @@ public class ExpoPlatformInfoModule: Module {
     Function("getIsReducedMotionEnabled") {
       return UIAccessibility.isReduceMotionEnabled
     }
+    
+    Function("setAudioMixWithOthers") { (mixWithOthers: Bool) in
+      var options: AVAudioSession.CategoryOptions
+      if mixWithOthers {
+        options = [.mixWithOthers]
+      } else {
+        options = []
+      }
+      try? AVAudioSession.sharedInstance().setCategory(AVAudioSession.Category.playback, mode: .default, options:  options)
+    }
   }
 }

--- a/modules/expo-bluesky-swiss-army/src/PlatformInfo/index.native.ts
+++ b/modules/expo-bluesky-swiss-army/src/PlatformInfo/index.native.ts
@@ -1,7 +1,13 @@
+import {Platform} from 'react-native'
 import {requireNativeModule} from 'expo-modules-core'
 
 const NativeModule = requireNativeModule('ExpoPlatformInfo')
 
 export function getIsReducedMotionEnabled(): boolean {
   return NativeModule.getIsReducedMotionEnabled()
+}
+
+export function setAudioMixWithOthers(mixWithOthers: boolean): void {
+  if (Platform.OS !== 'ios') return
+  NativeModule.setAudioMixWithOthers(mixWithOthers)
 }

--- a/modules/expo-bluesky-swiss-army/src/PlatformInfo/index.ts
+++ b/modules/expo-bluesky-swiss-army/src/PlatformInfo/index.ts
@@ -3,3 +3,7 @@ import {NotImplementedError} from '../NotImplemented'
 export function getIsReducedMotionEnabled(): boolean {
   throw new NotImplementedError()
 }
+
+export function setAudioMixWithOthers(mixWithOthers: boolean): void {
+  throw new NotImplementedError({mixWithOthers})
+}

--- a/modules/expo-bluesky-swiss-army/src/PlatformInfo/index.web.ts
+++ b/modules/expo-bluesky-swiss-army/src/PlatformInfo/index.web.ts
@@ -1,6 +1,12 @@
+import {NotImplementedError} from '../NotImplemented'
+
 export function getIsReducedMotionEnabled(): boolean {
   if (typeof window === 'undefined') {
     return false
   }
   return window.matchMedia('(prefers-reduced-motion: reduce)').matches
+}
+
+export function setAudioMixWithOthers(mixWithOthers: boolean): void {
+  throw new NotImplementedError({mixWithOthers})
 }


### PR DESCRIPTION
## Why

When there is an active `AVPlayer`, it seems like background audio gets paused on app open. The solution here is to set the `AVAudioSession`'s `CategoryOptions` to `.mixWithOthers`.

## Usage

```
// When about to play a video, i.e. when going into fullscreen or watching a YouTube video
PlatformInfo.mixWithOthers(true)

// After exiting full screen or on app start
PlatformInfo.mixwithOthers(false)
```

## Test Plan

Merge this, then add code where needed.