### PR TITLE
[Video] More tweaks to `AVAudioSession` options

### DIFF
--- a/modules/expo-bluesky-swiss-army/index.ts
+++ b/modules/expo-bluesky-swiss-army/index.ts
@@ -1,6 +1,7 @@
 import * as PlatformInfo from './src/PlatformInfo'
+import {AudioCategory} from './src/PlatformInfo/types'
 import * as Referrer from './src/Referrer'
 import * as SharedPrefs from './src/SharedPrefs'
 import VisibilityView from './src/VisibilityView'
 
-export {PlatformInfo, Referrer, SharedPrefs, VisibilityView}
+export {AudioCategory, PlatformInfo, Referrer, SharedPrefs, VisibilityView}

--- a/modules/expo-bluesky-swiss-army/ios/PlatformInfo/ExpoPlatformInfoModule.swift
+++ b/modules/expo-bluesky-swiss-army/ios/PlatformInfo/ExpoPlatformInfoModule.swift
@@ -3,16 +3,16 @@ import ExpoModulesCore
 public class ExpoPlatformInfoModule: Module {
   public func definition() -> ModuleDefinition {
     Name("ExpoPlatformInfo")
-    
+
     Function("getIsReducedMotionEnabled") {
       return UIAccessibility.isReduceMotionEnabled
     }
-    
+
     Function("setAudioCategory") { (audioCategoryString: String) in
       let audioCategory = AVAudioSession.Category(rawValue: audioCategoryString)
       try? AVAudioSession.sharedInstance().setCategory(audioCategory)
     }
-    
+
     Function("setAudioMixWithOthers") { (mixWithOthers: Bool) in
       var options: AVAudioSession.CategoryOptions
       let currentCategory = AVAudioSession.sharedInstance().category

--- a/modules/expo-bluesky-swiss-army/ios/PlatformInfo/ExpoPlatformInfoModule.swift
+++ b/modules/expo-bluesky-swiss-army/ios/PlatformInfo/ExpoPlatformInfoModule.swift
@@ -3,19 +3,31 @@ import ExpoModulesCore
 public class ExpoPlatformInfoModule: Module {
   public func definition() -> ModuleDefinition {
     Name("ExpoPlatformInfo")
-
+    
     Function("getIsReducedMotionEnabled") {
       return UIAccessibility.isReduceMotionEnabled
     }
-
+    
+    Function("setAudioCategory") { (audioCategoryString: String) in
+      let audioCategory = AVAudioSession.Category(rawValue: audioCategoryString)
+      try? AVAudioSession.sharedInstance().setCategory(audioCategory)
+    }
+    
     Function("setAudioMixWithOthers") { (mixWithOthers: Bool) in
       var options: AVAudioSession.CategoryOptions
+      let currentCategory = AVAudioSession.sharedInstance().category
       if mixWithOthers {
         options = [.mixWithOthers]
       } else {
-        options = []
+        options = [.duckOthers]
       }
-      try? AVAudioSession.sharedInstance().setCategory(AVAudioSession.Category.playback, mode: .default, options: options)
+      try? AVAudioSession
+        .sharedInstance()
+        .setCategory(
+          currentCategory,
+          mode: .default,
+          options: options
+        )
     }
   }
 }

--- a/modules/expo-bluesky-swiss-army/src/PlatformInfo/index.native.ts
+++ b/modules/expo-bluesky-swiss-army/src/PlatformInfo/index.native.ts
@@ -1,6 +1,8 @@
 import {Platform} from 'react-native'
 import {requireNativeModule} from 'expo-modules-core'
 
+import {AudioCategory} from './types'
+
 const NativeModule = requireNativeModule('ExpoPlatformInfo')
 
 export function getIsReducedMotionEnabled(): boolean {
@@ -10,4 +12,9 @@ export function getIsReducedMotionEnabled(): boolean {
 export function setAudioMixWithOthers(mixWithOthers: boolean): void {
   if (Platform.OS !== 'ios') return
   NativeModule.setAudioMixWithOthers(mixWithOthers)
+}
+
+export function setAudioCategory(audioCategory: AudioCategory): void {
+  if (Platform.OS !== 'ios') return
+  NativeModule.setAudioCategory(audioCategory)
 }

--- a/modules/expo-bluesky-swiss-army/src/PlatformInfo/index.ts
+++ b/modules/expo-bluesky-swiss-army/src/PlatformInfo/index.ts
@@ -1,9 +1,23 @@
 import {NotImplementedError} from '../NotImplemented'
+import {AudioCategory} from './types'
 
 export function getIsReducedMotionEnabled(): boolean {
   throw new NotImplementedError()
 }
 
+/**
+ * Set whether the app's audio should mix with other apps' audio.
+ * @param mixWithOthers
+ */
 export function setAudioMixWithOthers(mixWithOthers: boolean): void {
   throw new NotImplementedError({mixWithOthers})
+}
+
+/**
+ * Set the audio category for the app.
+ * @param audioCategory
+ * @platform ios
+ */
+export function setAudioCategory(audioCategory: AudioCategory): void {
+  throw new NotImplementedError({audioCategory})
 }

--- a/modules/expo-bluesky-swiss-army/src/PlatformInfo/index.web.ts
+++ b/modules/expo-bluesky-swiss-army/src/PlatformInfo/index.web.ts
@@ -1,4 +1,5 @@
 import {NotImplementedError} from '../NotImplemented'
+import {AudioCategory} from './types'
 
 export function getIsReducedMotionEnabled(): boolean {
   if (typeof window === 'undefined') {
@@ -9,4 +10,8 @@ export function getIsReducedMotionEnabled(): boolean {
 
 export function setAudioMixWithOthers(mixWithOthers: boolean): void {
   throw new NotImplementedError({mixWithOthers})
+}
+
+export function setAudioCategory(audioCategory: AudioCategory): void {
+  throw new NotImplementedError({audioCategory})
 }

--- a/modules/expo-bluesky-swiss-army/src/PlatformInfo/types.ts
+++ b/modules/expo-bluesky-swiss-army/src/PlatformInfo/types.ts
@@ -6,9 +6,10 @@
  * @platform ios
  */
 export enum AudioCategory {
-  Ambient = 'ambient',
-  Playback = 'playback',
-  _PlaybackAndRecord = 'playbackAndRecord',
-  _MultiRoute = 'multiRoute',
-  _SoloAmbient = 'soloAmbient',
+  Ambient = 'AVAudioSessionCategoryAmbient',
+  Playback = 'AVAudioSessionCategoryPlayback',
+  _SoloAmbient = 'AVAudioSessionCategorySoloAmbient',
+  _Record = 'AVAudioSessionCategoryRecord',
+  _PlayAndRecord = 'AVAudioSessionCategoryPlayAndRecord',
+  _MultiRoute = 'AVAudioSessionCategoryMultiRoute',
 }

--- a/modules/expo-bluesky-swiss-army/src/PlatformInfo/types.ts
+++ b/modules/expo-bluesky-swiss-army/src/PlatformInfo/types.ts
@@ -1,0 +1,14 @@
+/**
+ * Sets the audio session category on iOS. In general, we should only need to use this for the `playback` and `ambient`
+ * categories. This enum however includes other categories that are available in the native API for clarity and
+ * potential future use.
+ * @see https://developer.apple.com/documentation/avfoundation/avaudiosession/category
+ * @platform ios
+ */
+export enum AudioCategory {
+  Ambient = 'ambient',
+  Playback = 'playback',
+  _PlaybackAndRecord = 'playbackAndRecord',
+  _MultiRoute = 'multiRoute',
+  _SoloAmbient = 'soloAmbient',
+}

--- a/src/App.native.tsx
+++ b/src/App.native.tsx
@@ -61,7 +61,7 @@ import {Provider as PortalProvider} from '#/components/Portal'
 import {Splash} from '#/Splash'
 import {Provider as TourProvider} from '#/tours'
 import {BackgroundNotificationPreferencesProvider} from '../modules/expo-background-notification-handler/src/BackgroundNotificationHandlerProvider'
-import {PlatformInfo} from '../modules/expo-bluesky-swiss-army'
+import {AudioCategory, PlatformInfo} from '../modules/expo-bluesky-swiss-army'
 
 SplashScreen.preventAutoHideAsync()
 
@@ -158,6 +158,7 @@ function App() {
   const [isReady, setReady] = useState(false)
 
   React.useEffect(() => {
+    PlatformInfo.setAudioCategory(AudioCategory.Ambient)
     PlatformInfo.setAudioMixWithOthers(true)
     initPersistedState().then(() => setReady(true))
   }, [])

--- a/src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerNative.tsx
+++ b/src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerNative.tsx
@@ -12,7 +12,10 @@ import {android, atoms as a, useTheme} from '#/alf'
 import {Mute_Stroke2_Corner0_Rounded as MuteIcon} from '#/components/icons/Mute'
 import {SpeakerVolumeFull_Stroke2_Corner0_Rounded as UnmuteIcon} from '#/components/icons/Speaker'
 import {Text} from '#/components/Typography'
-import {PlatformInfo} from '../../../../../../modules/expo-bluesky-swiss-army'
+import {
+  AudioCategory,
+  PlatformInfo,
+} from '../../../../../../modules/expo-bluesky-swiss-army'
 
 export function VideoEmbedInnerNative() {
   const player = useVideoPlayer()
@@ -96,12 +99,16 @@ function Controls({
     }
   }, [player])
 
-  const toggleSound = useCallback(() => {
-    const newValue = !player.muted
+  const toggleMuted = useCallback(() => {
+    const muted = !player.muted
     // We want to set this to the _inverse_ of the new value, because we actually want for the audio to be mixed when
     // the video is muted, and vice versa.
-    PlatformInfo.setAudioMixWithOthers(!newValue)
-    player.muted = newValue
+    const mix = !muted
+    const category = muted ? AudioCategory.Ambient : AudioCategory.Playback
+
+    PlatformInfo.setAudioCategory(category)
+    PlatformInfo.setAudioMixWithOthers(mix)
+    player.muted = muted
   }, [player])
 
   return (
@@ -140,7 +147,7 @@ function Controls({
         accessibilityRole="button"
       />
       <Pressable
-        onPress={toggleSound}
+        onPress={toggleMuted}
         style={{
           backgroundColor: 'rgba(0, 0, 0, 0.75)',
           borderRadius: 6,

--- a/src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerNative.tsx
+++ b/src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerNative.tsx
@@ -42,10 +42,12 @@ export function VideoEmbedInnerNative() {
         style={a.flex_1}
         nativeControls={true}
         onEnterFullscreen={() => {
+          PlatformInfo.setAudioCategory(AudioCategory.Playback)
           PlatformInfo.setAudioMixWithOthers(false)
           player.muted = false
         }}
         onExitFullscreen={() => {
+          PlatformInfo.setAudioCategory(AudioCategory.Ambient)
           PlatformInfo.setAudioMixWithOthers(true)
           player.muted = true
         }}


### PR DESCRIPTION
## Why

Upon doing some documentation digging, it looks like we might actually want to be tweaking the category itself from `ambient` to `playback` depending on what state we are in.

## How

First, it looks like we want to take our app out of the _default_ state, which is `soloAmbient`. This is described as

> Your audio is silenced by screen locking and by the Silent switch (called the Ring/Silent switch on iPhone).
>
> By default, using this category implies that your app’s audio is nonmixable—activating your session will interrupt any other audio sessions which are also nonmixable. To allow mixing, use the `ambient` category instead.
(https://developer.apple.com/documentation/avfaudio/avaudiosession/category/1616488-soloambient)

And the `ambient` category is described as

> This category is also appropriate for “play-along” apps, such as a virtual piano that a user plays while the Music app is playing. When you use this category, audio from other apps mixes with your audio. Screen locking and the Silent switch (on iPhone, the Ring/Silent switch) silence your audio.
(https://developer.apple.com/documentation/avfaudio/avaudiosession/category/1616560-ambient)

Finally, whenever we want for audio to take over - without background audio - we should switch to `playback`. We want this because video audio _should play_ whenever the user enables it - regardless of their silent mode.

> When using this category, your app audio continues with the Silent switch set to silent or when the screen locks. (The switch is called the Ring/Silent switch on iPhone.) To continue playing audio when your app transitions to the background (for example, when the screen locks), add the audio value to the [UIBackgroundModes](https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/iPhoneOSKeys.html#//apple_ref/doc/plist/info/UIBackgroundModes) key in your information property list file.

Note that this might have implications as described here on what happens when the app transitions to the background, however, I believe that `AVPlayer` should handle those cases. We will need to see what happens on device.

I don't believe that this will account for restarting of background audio whenever the user exits full screen for a video. I'll investigate that with a separate PR.

## Test Plan

More changes that are hard to test in simulator here. We should see what happens whenever the TestFlight app updates. I expect we will want to tweak more.