### PR TITLE
Don't kick to login screen on network error

### DIFF
--- a/src/lib/react-query.tsx
+++ b/src/lib/react-query.tsx
@@ -20,15 +20,12 @@ async function checkIsOnline(): Promise<boolean> {
     setTimeout(() => {
       controller.abort()
     }, 15e3)
-    const res = await fetch(
-      'https://plc.directory/did:plc:z72i7hdynmk6r22z27h6tvur',
-      {
-        cache: 'no-store',
-        signal: controller.signal,
-      },
-    )
+    const res = await fetch('https://public.api.bsky.app/xrpc/_health', {
+      cache: 'no-store',
+      signal: controller.signal,
+    })
     const json = await res.json()
-    if (json.id) {
+    if (json.version) {
       return true
     } else {
       return false

--- a/src/lib/react-query.tsx
+++ b/src/lib/react-query.tsx
@@ -9,6 +9,7 @@ import {
 } from '@tanstack/react-query-persist-client'
 
 import {isNative} from '#/platform/detection'
+import {listenNetworkConfirmed, listenNetworkLost} from '#/state/events'
 
 // any query keys in this array will be persisted to AsyncStorage
 export const labelersDetailedInfoQueryKeyRoot = 'labelers-detailed-info'
@@ -35,6 +36,14 @@ async function checkIsOnline(): Promise<boolean> {
   }
 }
 
+listenNetworkLost(() => {
+  onlineManager.setOnline(false)
+})
+
+listenNetworkConfirmed(() => {
+  onlineManager.setOnline(true)
+})
+
 let checkPromise: Promise<void> | undefined
 function checkIsOnlineIfNeeded() {
   if (checkPromise) {
@@ -47,7 +56,7 @@ function checkIsOnlineIfNeeded() {
 }
 
 setInterval(() => {
-  if (AppState.currentState === 'active') {
+  if (AppState.currentState === 'active' && !onlineManager.isOnline()) {
     checkIsOnlineIfNeeded()
   }
 }, 5000)

--- a/src/lib/react-query.tsx
+++ b/src/lib/react-query.tsx
@@ -77,7 +77,7 @@ setInterval(() => {
       checkIsOnlineIfNeeded()
     }
   }
-}, 5000)
+}, 2000)
 
 focusManager.setEventListener(onFocus => {
   if (isNative) {

--- a/src/state/events.ts
+++ b/src/state/events.ts
@@ -22,6 +22,22 @@ export function listenSessionDropped(fn: () => void): UnlistenFn {
   return () => emitter.off('session-dropped', fn)
 }
 
+export function emitNetworkConfirmed() {
+  emitter.emit('network-confirmed')
+}
+export function listenNetworkConfirmed(fn: () => void): UnlistenFn {
+  emitter.on('network-confirmed', fn)
+  return () => emitter.off('network-confirmed', fn)
+}
+
+export function emitNetworkLost() {
+  emitter.emit('network-lost')
+}
+export function listenNetworkLost(fn: () => void): UnlistenFn {
+  emitter.on('network-lost', fn)
+  return () => emitter.off('network-lost', fn)
+}
+
 export function emitPostCreated() {
   emitter.emit('post-created')
 }

--- a/src/state/queries/feed.ts
+++ b/src/state/queries/feed.ts
@@ -454,7 +454,8 @@ export function usePinnedFeedsInfos() {
           }),
       )
 
-      await Promise.allSettled([feedsPromise, ...listsPromises])
+      await feedsPromise // Fail the whole query if it fails.
+      await Promise.allSettled(listsPromises) // Ignore individual failing ones.
 
       // order the feeds/lists in the order they were pinned
       const result: SavedFeedSourceInfo[] = []

--- a/src/state/session/__tests__/session-test.ts
+++ b/src/state/session/__tests__/session-test.ts
@@ -1184,7 +1184,7 @@ describe('session', () => {
     expect(state.currentAgentState.did).toBe('bob-did')
   })
 
-  it('does soft logout on network error', () => {
+  it('ignores network errors', () => {
     let state = getInitialState([])
 
     const agent1 = new BskyAgent({service: 'https://alice.com'})
@@ -1217,11 +1217,9 @@ describe('session', () => {
       },
     ])
     expect(state.accounts.length).toBe(1)
-    // Network error should reset current user but not reset the tokens.
-    // TODO: We might want to remove or change this behavior?
     expect(state.accounts[0].accessJwt).toBe('alice-access-jwt-1')
     expect(state.accounts[0].refreshJwt).toBe('alice-refresh-jwt-1')
-    expect(state.currentAgentState.did).toBe(undefined)
+    expect(state.currentAgentState.did).toBe('alice-did')
     expect(printState(state)).toMatchInlineSnapshot(`
       {
         "accounts": [
@@ -1242,9 +1240,9 @@ describe('session', () => {
         ],
         "currentAgentState": {
           "agent": {
-            "service": "https://public.api.bsky.app/",
+            "service": "https://alice.com/",
           },
-          "did": undefined,
+          "did": "alice-did",
         },
         "needsPersist": true,
       }

--- a/src/state/session/agent.ts
+++ b/src/state/session/agent.ts
@@ -257,7 +257,14 @@ class BskyAppAgent extends BskyAgent {
 
     // Now the agent is ready.
     const account = agentToSessionAccountOrThrow(this)
+    let lastSession = this.sessionManager.session
     this.persistSessionHandler = event => {
+      if (this.sessionManager.session) {
+        lastSession = this.sessionManager.session
+      } else if (event === 'network-error') {
+        // Put it back, we'll try again later.
+        this.sessionManager.session = lastSession
+      }
       onSessionChange(this, account.did, event)
       if (event !== 'create' && event !== 'update') {
         addSessionErrorLog(account.did, event)

--- a/src/state/session/reducer.ts
+++ b/src/state/session/reducer.ts
@@ -79,12 +79,8 @@ let reducer = (state: State, action: Action): State => {
         return state
       }
       if (sessionEvent === 'network-error') {
-        // Don't change stored accounts but kick to the choose account screen.
-        return {
-          accounts: state.accounts,
-          currentAgentState: createPublicAgentState(),
-          needsPersist: true,
-        }
+        // Assume it's transient.
+        return state
       }
       const existingAccount = state.accounts.find(a => a.did === accountDid)
       if (


### PR DESCRIPTION
With this fix, we will no longer kick you to the login screen when the agent emits a `network-error` event. The original motivation for kicking you to the login screen was twofold:

- The agent was losing the `.session` field so it literally couldn't continue, and we wanted to mirror that in app state.
- The app did not have a reliable way to track when the network comes back online on native, so requests would get stuck.

We're fixing this by:

- Putting the `.session` field back on the agent after a `network-error` event. (We should maybe fix this upstream?)
- Adding a mechanism to track whether the app is online that works across platforms.

Regarding the mechanism. I tried initially to use different network libraries. But it seemed pretty unreliable — for example, on the Android simulator I'd often get network reported as working even when I was turning it off. But not always. In the end I decided to just poll a backend endpoint. This should also handle cases like captive portals.

I initially tried to guard it by a StableID gate. But it turns out this doesn't currently work with out Statsig setup due to `initialize` being called too late. I've tried fixing it and it's a can of worms. It might be easier with their new SDK but I say let's for now just test it ourselves and in the worst case disable this over OTA.

## Test Plan

For web, verify that quick double refresh in Safari no longer kicks you out. Verify that the app can recover from toggling the WiFi.

For native, verify starting the app with WiFi off no longer kicks you to login screen. Verify turning on WiFi fixes stuck screens within five seconds. Toggle WiFi on and off, verify it's generally able to recover after being offline.