### PR TITLE
Show handle in recent searches and fix truncation

### DIFF
--- a/src/view/screens/Search/Search.tsx
+++ b/src/view/screens/Search/Search.tsx
@@ -960,8 +960,7 @@ function SearchHistory({
                     />
                     <Text
                       style={[pal.text, styles.profileName]}
-                      numberOfLines={1}
-                      ellipsizeMode="tail">
+                      numberOfLines={1}>
                       {profile.displayName || profile.handle}
                     </Text>
                   </Link>

--- a/src/view/screens/Search/Search.tsx
+++ b/src/view/screens/Search/Search.tsx
@@ -961,7 +961,7 @@ function SearchHistory({
                     <Text
                       style={[pal.text, styles.profileName]}
                       numberOfLines={1}
-                      ellipsizeMode="head">
+                      ellipsizeMode="tail">
                       {profile.displayName || profile.handle}
                     </Text>
                   </Link>

--- a/src/view/screens/Search/Search.tsx
+++ b/src/view/screens/Search/Search.tsx
@@ -894,13 +894,6 @@ let AutocompleteResults = ({
 }
 AutocompleteResults = React.memo(AutocompleteResults)
 
-function truncateText(text: string, maxLength: number) {
-  if (text.length > maxLength) {
-    return text.substring(0, maxLength) + '...'
-  }
-  return text
-}
-
 function SearchHistory({
   searchHistory,
   selectedProfiles,
@@ -965,8 +958,11 @@ function SearchHistory({
                       style={styles.profileAvatar as StyleProp<ImageStyle>}
                       accessibilityIgnoresInvertColors
                     />
-                    <Text style={[pal.text, styles.profileName]}>
-                      {truncateText(profile.displayName || '', 12)}
+                    <Text
+                      style={[pal.text, styles.profileName]}
+                      numberOfLines={1}
+                      ellipsizeMode="head">
+                      {profile.displayName || profile.handle}
                     </Text>
                   </Link>
                   <Pressable
@@ -1117,6 +1113,7 @@ const styles = StyleSheet.create({
     borderRadius: 45,
   },
   profileName: {
+    width: 78,
     fontSize: 12,
     textAlign: 'center',
     marginTop: 5,


### PR DESCRIPTION
The profile view in "recent searches" used to not show a label if the user didn't have a display name set:

<img width="603" alt="Screenshot 2024-08-10 at 12 06 54 AM" src="https://github.com/user-attachments/assets/ff599381-14e5-47db-b934-90355c614487">

Also, when the name was truncated, the existing implementation was supposed to add "...", but the way it was implemented, the ellipsis often spilled onto a second line that overflowed and didn't render. This change switches the label to use the built-in ellipsis truncation behavior.

<img width="603" alt="Screenshot 2024-08-10 at 12 06 42 AM" src="https://github.com/user-attachments/assets/26607db1-7495-422e-a819-da764487958c">
