### PR TITLE
[Video] Fix crash when switching tabs

### DIFF
--- a/src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerNative.tsx
+++ b/src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerNative.tsx
@@ -23,29 +23,14 @@ export function VideoEmbedInnerNative() {
   const ref = useRef<VideoView>(null)
   const isScreenFocused = useIsFocused()
   const isAppFocused = useAppState()
-  const prevFocusedRef = useRef(isAppFocused)
 
-  // resume video when coming back from background
   useEffect(() => {
-    if (isAppFocused !== prevFocusedRef.current) {
-      prevFocusedRef.current = isAppFocused
-      if (isAppFocused === 'active') {
-        player.play()
-      }
-    }
-  }, [isAppFocused, player])
-
-  // pause the video when the screen is not focused
-  useEffect(() => {
-    if (!isScreenFocused) {
-      let wasPlaying = player.playing
+    if (isAppFocused === 'active' && isScreenFocused && !player.playing) {
+      player.play()
+    } else if (player.playing) {
       player.pause()
-
-      return () => {
-        if (wasPlaying) player.play()
-      }
     }
-  }, [isScreenFocused, player])
+  }, [isAppFocused, player, isScreenFocused])
 
   const enterFullscreen = useCallback(() => {
     ref.current?.enterFullscreen()


### PR DESCRIPTION
More tweaks to come here, but we shouldn't try to access `player` inside of a cleanup function.