### PR TITLE
[Video] Audio duck off main thread

### DIFF
--- a/modules/expo-bluesky-swiss-army/ios/PlatformInfo/ExpoPlatformInfoModule.swift
+++ b/modules/expo-bluesky-swiss-army/ios/PlatformInfo/ExpoPlatformInfoModule.swift
@@ -10,19 +10,26 @@ public class ExpoPlatformInfoModule: Module {
 
     Function("setAudioCategory") { (audioCategoryString: String) in
       let audioCategory = AVAudioSession.Category(rawValue: audioCategoryString)
-      try? AVAudioSession.sharedInstance().setCategory(audioCategory)
+
+      DispatchQueue.global(qos: .background).async {
+        try? AVAudioSession.sharedInstance().setCategory(audioCategory)
+      }
     }
 
     Function("setAudioActive") { (active: Bool) in
       if active {
-        try? AVAudioSession.sharedInstance().setActive(true)
+        DispatchQueue.global(qos: .background).async {
+          try? AVAudioSession.sharedInstance().setActive(true)
+        }
       } else {
-        try? AVAudioSession
-          .sharedInstance()
-          .setActive(
-            false,
-            options: [.notifyOthersOnDeactivation]
-          )
+        DispatchQueue.global(qos: .background).async {
+          try? AVAudioSession
+            .sharedInstance()
+            .setActive(
+              false,
+              options: [.notifyOthersOnDeactivation]
+            )
+        }
       }
     }
   }


### PR DESCRIPTION
Seems that iOS doesn't like modifying the `AVAudioSession` on the main thread - this causes some lag. Let's run it on a background thread instead.