### PR TITLE
Fix session persistence handlers

### DIFF
--- a/src/state/session/agent.ts
+++ b/src/state/session/agent.ts
@@ -53,6 +53,7 @@ export async function createAgentAndResume(
   } else {
     agent.sessionManager.session = prevSession
     if (!storedAccount.signupQueued) {
+      // Intentionally not awaited to unblock the UI:
       networkRetry(3, () => agent.resumeSession(prevSession)).catch(
         (e: any) => {
           logger.error(`networkRetry failed to resume session`, {

--- a/src/state/session/agent.ts
+++ b/src/state/session/agent.ts
@@ -25,8 +25,6 @@ import {
 import {SessionAccount} from './types'
 import {isSessionExpired, isSignupQueued} from './util'
 
-type SetPersistSessionHandler = (cb: AtpPersistSessionHandler) => void
-
 export function createPublicAgent() {
   configureModerationForGuest() // Side effect but only relevant for tests
   return new BskyAgent({service: PUBLIC_BSKY_SERVICE})
@@ -39,9 +37,14 @@ export async function createAgentAndResume(
     did: string,
     event: AtpSessionEvent,
   ) => void,
-  setPersistSessionHandler: SetPersistSessionHandler,
 ) {
-  const agent = new BskyAgent({service: storedAccount.service})
+  let currentPersistHandler: AtpPersistSessionHandler | undefined
+  const agent = new BskyAgent({
+    service: storedAccount.service,
+    persistSession(event, session) {
+      currentPersistHandler?.(event, session)
+    },
+  })
   if (storedAccount.pdsUrl) {
     agent.sessionManager.pdsUrl = new URL(storedAccount.pdsUrl)
   }
@@ -68,13 +71,16 @@ export async function createAgentAndResume(
     }
   }
 
-  return prepareAgent(
-    agent,
-    gates,
-    moderation,
-    onSessionChange,
-    setPersistSessionHandler,
-  )
+  const account = agentToSessionAccountOrThrow(agent)
+  currentPersistHandler = event => {
+    onSessionChange(agent, account.did, event)
+    if (event !== 'create' && event !== 'update') {
+      addSessionErrorLog(account.did, event)
+    }
+  }
+
+  await Promise.all([gates, moderation])
+  return {account, agent}
 }
 
 export async function createAgentAndLogin(
@@ -94,21 +100,28 @@ export async function createAgentAndLogin(
     did: string,
     event: AtpSessionEvent,
   ) => void,
-  setPersistSessionHandler: SetPersistSessionHandler,
 ) {
-  const agent = new BskyAgent({service})
+  let currentPersistHandler: AtpPersistSessionHandler | undefined
+  const agent = new BskyAgent({
+    service,
+    persistSession(event, session) {
+      currentPersistHandler?.(event, session)
+    },
+  })
   await agent.login({identifier, password, authFactorToken})
 
   const account = agentToSessionAccountOrThrow(agent)
+  currentPersistHandler = event => {
+    onSessionChange(agent, account.did, event)
+    if (event !== 'create' && event !== 'update') {
+      addSessionErrorLog(account.did, event)
+    }
+  }
+
   const gates = tryFetchGates(account.did, 'prefer-fresh-gates')
   const moderation = configureModerationForAccount(agent, account)
-  return prepareAgent(
-    agent,
-    moderation,
-    gates,
-    onSessionChange,
-    setPersistSessionHandler,
-  )
+  await Promise.all([gates, moderation])
+  return {account, agent}
 }
 
 export async function createAgentAndCreateAccount(
@@ -136,9 +149,14 @@ export async function createAgentAndCreateAccount(
     did: string,
     event: AtpSessionEvent,
   ) => void,
-  setPersistSessionHandler: SetPersistSessionHandler,
 ) {
-  const agent = new BskyAgent({service})
+  let currentPersistHandler: AtpPersistSessionHandler | undefined
+  const agent = new BskyAgent({
+    service,
+    persistSession(event, session) {
+      currentPersistHandler?.(event, session)
+    },
+  })
   await agent.createAccount({
     email,
     password,
@@ -147,7 +165,15 @@ export async function createAgentAndCreateAccount(
     verificationPhone,
     verificationCode,
   })
+
   const account = agentToSessionAccountOrThrow(agent)
+  currentPersistHandler = event => {
+    onSessionChange(agent, account.did, event)
+    if (event !== 'create' && event !== 'update') {
+      addSessionErrorLog(account.did, event)
+    }
+  }
+
   const gates = tryFetchGates(account.did, 'prefer-fresh-gates')
   const moderation = configureModerationForAccount(agent, account)
 
@@ -196,39 +222,8 @@ export async function createAgentAndCreateAccount(
     logger.error(e, {context: `session: failed snoozeEmailConfirmationPrompt`})
   }
 
-  return prepareAgent(
-    agent,
-    gates,
-    moderation,
-    onSessionChange,
-    setPersistSessionHandler,
-  )
-}
-
-async function prepareAgent(
-  agent: BskyAgent,
-  // Not awaited in the calling code so we can delay blocking on them.
-  gates: Promise<void>,
-  moderation: Promise<void>,
-  onSessionChange: (
-    agent: BskyAgent,
-    did: string,
-    event: AtpSessionEvent,
-  ) => void,
-  setPersistSessionHandler: (cb: AtpPersistSessionHandler) => void,
-) {
-  // There's nothing else left to do, so block on them here.
   await Promise.all([gates, moderation])
-
-  // Now the agent is ready.
-  const account = agentToSessionAccountOrThrow(agent)
-  setPersistSessionHandler(event => {
-    onSessionChange(agent, account.did, event)
-    if (event !== 'create' && event !== 'update') {
-      addSessionErrorLog(account.did, event)
-    }
-  })
-  return {agent, account}
+  return {account, agent}
 }
 
 export function agentToSessionAccountOrThrow(agent: BskyAgent): SessionAccount {

--- a/src/state/session/index.tsx
+++ b/src/state/session/index.tsx
@@ -1,9 +1,5 @@
 import React from 'react'
-import {
-  AtpPersistSessionHandler,
-  AtpSessionEvent,
-  BskyAgent,
-} from '@atproto/api'
+import {AtpSessionEvent, BskyAgent} from '@atproto/api'
 
 import {track} from '#/lib/analytics/analytics'
 import {logEvent} from '#/lib/statsig/statsig'
@@ -51,15 +47,6 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
     return initialState
   })
 
-  const persistSessionHandler = React.useRef<
-    AtpPersistSessionHandler | undefined
-  >(undefined)
-  const setPersistSessionHandler = (
-    newHandler: AtpPersistSessionHandler | undefined,
-  ) => {
-    persistSessionHandler.current = newHandler
-  }
-
   const onAgentSessionChange = React.useCallback(
     (agent: BskyAgent, accountDid: string, sessionEvent: AtpSessionEvent) => {
       const refreshedAccount = agentToSessionAccount(agent) // Mutable, so snapshot it right away.
@@ -86,7 +73,6 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
       const {agent, account} = await createAgentAndCreateAccount(
         params,
         onAgentSessionChange,
-        setPersistSessionHandler,
       )
 
       if (signal.aborted) {
@@ -111,7 +97,6 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
       const {agent, account} = await createAgentAndLogin(
         params,
         onAgentSessionChange,
-        setPersistSessionHandler,
       )
 
       if (signal.aborted) {
@@ -153,7 +138,6 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
       const {agent, account} = await createAgentAndResume(
         storedAccount,
         onAgentSessionChange,
-        setPersistSessionHandler,
       )
 
       if (signal.aborted) {
@@ -266,7 +250,6 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
       // We never reuse agents so let's fully neutralize the previous one.
       // This ensures it won't try to consume any refresh tokens.
       prevAgent.sessionManager.session = undefined
-      setPersistSessionHandler(undefined)
     }
   }, [agent])
 


### PR DESCRIPTION
There is a regression in https://github.com/bluesky-social/social-app/pull/4857 — although it appears to be setting up the session persistence handler, that handler (stored in a ref) is not being read. Additionally, it is a little fragile that merely calling `createAgent*` modifies a ref since `create*` functions were intended to be stateless. Otherwise it gets very difficult to reason about race conditions.

In this PR, I remove the ref and move the persistence handler to be scoped per-agent like before. The underlying `BskyAgent` signature changed so that the persistence handler has to be supplied during creation. However, we don't always know the `did` during its creation (e.g. we wouldn't know the `did` of an agent whose `createAccount` call is yet to follow). So we want late binding for the session handler. To do that, I store it in a local variable and swap it out when ready.

I ended up removing `prepareAgent` handler because it was obscuring what's actually happening. This adds a bit of duplication but should be clearer.

## Test Plan

Have not explicitly tested but @haileyok knows a few bugs that this should fix.