### PR TITLE
Remove .withProxy() calls

### DIFF
--- a/src/components/ReportDialog/SubmitView.tsx
+++ b/src/components/ReportDialog/SubmitView.tsx
@@ -6,7 +6,6 @@ import {useLingui} from '@lingui/react'
 
 import {getLabelingServiceTitle} from '#/lib/moderation'
 import {ReportOption} from '#/lib/moderation/useReportOptions'
-import {useGate} from '#/lib/statsig/statsig'
 import {useAgent} from '#/state/session'
 import {CharProgress} from '#/view/com/composer/char-progress/CharProgress'
 import * as Toast from '#/view/com/util/Toast'
@@ -37,7 +36,6 @@ export function SubmitView({
   const t = useTheme()
   const {_} = useLingui()
   const agent = useAgent()
-  const gate = useGate()
   const [details, setDetails] = React.useState<string>('')
   const [submitting, setSubmitting] = React.useState<boolean>(false)
   const [selectedServices, setSelectedServices] = React.useState<string[]>([
@@ -63,27 +61,17 @@ export function SubmitView({
     }
     const results = await Promise.all(
       selectedServices.map(did => {
-        if (gate('session_withproxy_fix')) {
-          return agent
-            .createModerationReport(report, {
-              encoding: 'application/json',
-              headers: {
-                'atproto-proxy': `${did}#atproto_labeler`,
-              },
-            })
-            .then(
-              _ => true,
-              _ => false,
-            )
-        } else {
-          return agent
-            .withProxy('atproto_labeler', did)
-            .createModerationReport(report)
-            .then(
-              _ => true,
-              _ => false,
-            )
-        }
+        return agent
+          .createModerationReport(report, {
+            encoding: 'application/json',
+            headers: {
+              'atproto-proxy': `${did}#atproto_labeler`,
+            },
+          })
+          .then(
+            _ => true,
+            _ => false,
+          )
       }),
     )
 
@@ -108,7 +96,6 @@ export function SubmitView({
     onSubmitComplete,
     setError,
     agent,
-    gate,
   ])
 
   return (

--- a/src/components/moderation/LabelsOnMeDialog.tsx
+++ b/src/components/moderation/LabelsOnMeDialog.tsx
@@ -7,7 +7,6 @@ import {useMutation} from '@tanstack/react-query'
 
 import {useLabelInfo} from '#/lib/moderation/useLabelInfo'
 import {makeProfileLink} from '#/lib/routes/links'
-import {useGate} from '#/lib/statsig/statsig'
 import {sanitizeHandle} from '#/lib/strings/handles'
 import {logger} from '#/logger'
 import {useAgent, useSession} from '#/state/session'
@@ -204,7 +203,6 @@ function AppealForm({
   const [details, setDetails] = React.useState('')
   const isAccountReport = 'did' in subject
   const agent = useAgent()
-  const gate = useGate()
   const sourceName = labeler
     ? sanitizeHandle(labeler.creator.handle, '@')
     : label.src
@@ -214,35 +212,22 @@ function AppealForm({
       const $type = !isAccountReport
         ? 'com.atproto.repo.strongRef'
         : 'com.atproto.admin.defs#repoRef'
-      if (gate('session_withproxy_fix')) {
-        await agent.createModerationReport(
-          {
-            reasonType: ComAtprotoModerationDefs.REASONAPPEAL,
-            subject: {
-              $type,
-              ...subject,
-            },
-            reason: details,
+      await agent.createModerationReport(
+        {
+          reasonType: ComAtprotoModerationDefs.REASONAPPEAL,
+          subject: {
+            $type,
+            ...subject,
           },
-          {
-            encoding: 'application/json',
-            headers: {
-              'atproto-proxy': `${label.src}#atproto_labeler`,
-            },
+          reason: details,
+        },
+        {
+          encoding: 'application/json',
+          headers: {
+            'atproto-proxy': `${label.src}#atproto_labeler`,
           },
-        )
-      } else {
-        await agent
-          .withProxy('atproto_labeler', label.src)
-          .createModerationReport({
-            reasonType: ComAtprotoModerationDefs.REASONAPPEAL,
-            subject: {
-              $type,
-              ...subject,
-            },
-            reason: details,
-          })
-      }
+        },
+      )
     },
     onError: err => {
       logger.error('Failed to submit label appeal', {message: err})

--- a/src/lib/statsig/gates.ts
+++ b/src/lib/statsig/gates.ts
@@ -3,7 +3,6 @@ export type Gate =
   | 'debug_show_feedcontext'
   | 'new_user_guided_tour'
   | 'onboarding_minimum_interests'
-  | 'session_withproxy_fix'
   | 'show_follow_back_label_v2'
   | 'suggested_feeds_interstitial'
   | 'video_debug'

--- a/src/state/feed-feedback.tsx
+++ b/src/state/feed-feedback.tsx
@@ -1,11 +1,10 @@
 import React from 'react'
 import {AppState, AppStateStatus} from 'react-native'
-import {AppBskyFeedDefs, BskyAgent} from '@atproto/api'
+import {AppBskyFeedDefs} from '@atproto/api'
 import throttle from 'lodash.throttle'
 
 import {PROD_DEFAULT_FEED} from '#/lib/constants'
 import {logEvent} from '#/lib/statsig/statsig'
-import {useGate} from '#/lib/statsig/statsig'
 import {logger} from '#/logger'
 import {FeedDescriptor, FeedPostSliceItem} from '#/state/queries/post-feed'
 import {getFeedPostSlice} from '#/view/com/posts/Feed'
@@ -25,7 +24,6 @@ const stateContext = React.createContext<StateContext>({
 
 export function useFeedFeedback(feed: FeedDescriptor, hasSession: boolean) {
   const agent = useAgent()
-  const gate = useGate()
   const enabled = isDiscoverFeed(feed) && hasSession
   const queue = React.useRef<Set<string>>(new Set())
   const history = React.useRef<
@@ -49,34 +47,20 @@ export function useFeedFeedback(feed: FeedDescriptor, hasSession: boolean) {
     queue.current.clear()
 
     // Send to the feed
-    if (gate('session_withproxy_fix')) {
-      agent.app.bsky.feed
-        .sendInteractions(
-          {interactions},
-          {
-            encoding: 'application/json',
-            headers: {
-              // TODO when we start sending to other feeds, we need to grab their DID -prf
-              'atproto-proxy': 'did:web:discover.bsky.app#bsky_fg',
-            },
+    agent.app.bsky.feed
+      .sendInteractions(
+        {interactions},
+        {
+          encoding: 'application/json',
+          headers: {
+            // TODO when we start sending to other feeds, we need to grab their DID -prf
+            'atproto-proxy': 'did:web:discover.bsky.app#bsky_fg',
           },
-        )
-        .catch((e: any) => {
-          logger.warn('Failed to send feed interactions', {error: e})
-        })
-    } else {
-      const proxyAgent = agent.withProxy(
-        // @ts-ignore TODO need to update withProxy() to support this key -prf
-        'bsky_fg',
-        // TODO when we start sending to other feeds, we need to grab their DID -prf
-        'did:web:discover.bsky.app',
-      ) as BskyAgent
-      proxyAgent.app.bsky.feed
-        .sendInteractions({interactions})
-        .catch((e: any) => {
-          logger.warn('Failed to send feed interactions', {error: e})
-        })
-    }
+        },
+      )
+      .catch((e: any) => {
+        logger.warn('Failed to send feed interactions', {error: e})
+      })
 
     // Send to Statsig
     if (aggregatedStats.current === null) {
@@ -84,7 +68,7 @@ export function useFeedFeedback(feed: FeedDescriptor, hasSession: boolean) {
     }
     sendOrAggregateInteractionsForStats(aggregatedStats.current, interactions)
     throttledFlushAggregatedStats()
-  }, [agent, gate, throttledFlushAggregatedStats])
+  }, [agent, throttledFlushAggregatedStats])
 
   const sendToFeed = React.useMemo(
     () =>


### PR DESCRIPTION
We accidentally broke them by subclassing the agent. Could remove the subclass but also we might as well remove this gate (it had no meaningful impact on session events so must've been equivalent).