### PR TITLE
Add `/live/` to supported YouTube embed URLs

### DIFF
--- a/__tests__/lib/string.test.ts
+++ b/__tests__/lib/string.test.ts
@@ -340,12 +340,14 @@ describe('parseEmbedPlayerFromUrl', () => {
     'https://youtube.com/watch?v=videoId',
     'https://youtube.com/watch?v=videoId&feature=share',
     'https://youtube.com/shorts/videoId',
+    'https://youtube.com/live/videoId',
     'https://m.youtube.com/watch?v=videoId',
     'https://music.youtube.com/watch?v=videoId',
 
     'https://youtube.com/shorts/',
     'https://youtube.com/',
     'https://youtube.com/random',
+    'https://youtube.com/live/',
 
     'https://twitch.tv/channelName',
     'https://www.twitch.tv/channelName',
@@ -475,7 +477,13 @@ describe('parseEmbedPlayerFromUrl', () => {
       source: 'youtube',
       playerUri: 'https://bsky.app/iframe/youtube.html?videoId=videoId&start=0',
     },
+    {
+      type: 'youtube_video',
+      source: 'youtube',
+      playerUri: 'https://bsky.app/iframe/youtube.html?videoId=videoId&start=0',
+    },
 
+    undefined,
     undefined,
     undefined,
     undefined,

--- a/src/lib/strings/embed-player.ts
+++ b/src/lib/strings/embed-player.ts
@@ -103,16 +103,21 @@ export function parseEmbedPlayerFromUrl(
     urlp.hostname === 'm.youtube.com' ||
     urlp.hostname === 'music.youtube.com'
   ) {
-    const [_, page, shortVideoId] = urlp.pathname.split('/')
+    const [_, page, shortOrLiveVideoId] = urlp.pathname.split('/')
+
+    const isShorts = page === 'shorts'
+    const isLive = page === 'live'
     const videoId =
-      page === 'shorts' ? shortVideoId : (urlp.searchParams.get('v') as string)
+      isShorts || isLive
+        ? shortOrLiveVideoId
+        : (urlp.searchParams.get('v') as string)
     const seek = encodeURIComponent(urlp.searchParams.get('t') ?? 0)
 
     if (videoId) {
       return {
-        type: page === 'shorts' ? 'youtube_short' : 'youtube_video',
-        source: page === 'shorts' ? 'youtubeShorts' : 'youtube',
-        hideDetails: page === 'shorts' ? true : undefined,
+        type: isShorts ? 'youtube_short' : 'youtube_video',
+        source: isShorts ? 'youtubeShorts' : 'youtube',
+        hideDetails: isShorts ? true : undefined,
         playerUri: `${IFRAME_HOST}/iframe/youtube.html?videoId=${videoId}&start=${seek}`,
       }
     }


### PR DESCRIPTION
## Why

YouTube has a new `/live/` URL. Let's add it.

## How

Works the same as other YouTube embeds (particularly the same as `/short/`

## Test Plan

Embed this video: https://www.youtube.com/live/RpNW_UxRN3s

Note that you won't be able to load the player (because of CORS).