### PR TITLE
Hidden reply cache

### DIFF
--- a/src/App.native.tsx
+++ b/src/App.native.tsx
@@ -50,6 +50,7 @@ import {Provider as LoggedOutViewProvider} from '#/state/shell/logged-out'
 import {Provider as ProgressGuideProvider} from '#/state/shell/progress-guide'
 import {Provider as SelectedFeedProvider} from '#/state/shell/selected-feed'
 import {Provider as StarterPackProvider} from '#/state/shell/starter-pack'
+import {Provider as HiddenRepliesProvider} from '#/state/threadgate-hidden-replies'
 import {TestCtrls} from '#/view/com/testing/TestCtrls'
 import {ActiveVideoProvider} from '#/view/com/util/post-embeds/ActiveVideoContext'
 import * as Toast from '#/view/com/util/Toast'
@@ -181,7 +182,9 @@ function App() {
                       <I18nProvider>
                         <PortalProvider>
                           <StarterPackProvider>
-                            <InnerApp />
+                            <HiddenRepliesProvider>
+                              <InnerApp />
+                            </HiddenRepliesProvider>
                           </StarterPackProvider>
                         </PortalProvider>
                       </I18nProvider>

--- a/src/App.web.tsx
+++ b/src/App.web.tsx
@@ -39,6 +39,7 @@ import {Provider as LoggedOutViewProvider} from '#/state/shell/logged-out'
 import {Provider as ProgressGuideProvider} from '#/state/shell/progress-guide'
 import {Provider as SelectedFeedProvider} from '#/state/shell/selected-feed'
 import {Provider as StarterPackProvider} from '#/state/shell/starter-pack'
+import {Provider as HiddenRepliesProvider} from '#/state/threadgate-hidden-replies'
 import {ActiveVideoProvider} from '#/view/com/util/post-embeds/ActiveVideoContext'
 import * as Toast from '#/view/com/util/Toast'
 import {ToastContainer} from '#/view/com/util/Toast.web'
@@ -162,7 +163,9 @@ function App() {
                     <I18nProvider>
                       <PortalProvider>
                         <StarterPackProvider>
-                          <InnerApp />
+                          <HiddenRepliesProvider>
+                            <InnerApp />
+                          </HiddenRepliesProvider>
                         </StarterPackProvider>
                       </PortalProvider>
                     </I18nProvider>

--- a/src/components/moderation/ModerationDetailsDialog.tsx
+++ b/src/components/moderation/ModerationDetailsDialog.tsx
@@ -111,11 +111,11 @@ function ModerationDetailsDialogInner({
   } else if (modcause.type === 'reply-hidden') {
     const isYou = currentAccount?.did === modcause.source.did
     name = isYou
-      ? _(msg`Post Hidden by You`)
-      : _(msg`Post Hidden by Thread Author`)
+      ? _(msg`Reply Hidden by You`)
+      : _(msg`Reply Hidden by Thread Author`)
     description = isYou
-      ? _(msg`You hid this post.`)
-      : _(msg`The author of this thread has hidden this post.`)
+      ? _(msg`You hid this reply.`)
+      : _(msg`The author of this thread has hidden this reply.`)
   } else if (modcause.type === 'label') {
     name = desc.name
     description = desc.description

--- a/src/lib/moderation/useModerationCauseDescription.ts
+++ b/src/lib/moderation/useModerationCauseDescription.ts
@@ -119,11 +119,11 @@ export function useModerationCauseDescription(
       return {
         icon: EyeSlash,
         name: isYou
-          ? _(msg`Post Hidden by You`)
-          : _(msg`Post Hidden by Thread Author`),
+          ? _(msg`Reply Hidden by You`)
+          : _(msg`Reply Hidden by Thread Author`),
         description: isYou
-          ? _(msg`You hid this post.`)
-          : _(msg`The author of this thread has hidden this post.`),
+          ? _(msg`You hid this reply.`)
+          : _(msg`The author of this thread has hidden this reply.`),
       }
     }
     if (cause.type === 'label') {

--- a/src/state/queries/notifications/feed.ts
+++ b/src/state/queries/notifications/feed.ts
@@ -16,7 +16,7 @@
  * 3. Don't call this query's `refetch()` if you're trying to sync latest; call `checkUnread()` instead.
  */
 
-import {useEffect, useRef} from 'react'
+import {useCallback, useEffect, useMemo, useRef} from 'react'
 import {AppBskyActorDefs, AppBskyFeedDefs, AtUri} from '@atproto/api'
 import {
   InfiniteData,
@@ -27,6 +27,7 @@ import {
 } from '@tanstack/react-query'
 
 import {useAgent} from '#/state/session'
+import {useThreadgateHiddenReplyUris} from '#/state/threadgate-hidden-replies'
 import {useModerationOpts} from '../../preferences/moderation-opts'
 import {STALE} from '..'
 import {
@@ -58,10 +59,17 @@ export function useNotificationFeedQuery(opts?: {
   const moderationOpts = useModerationOpts()
   const unreads = useUnreadNotificationsApi()
   const enabled = opts?.enabled !== false
+  const {uris: hiddenReplyUris} = useThreadgateHiddenReplyUris()
 
   // false: force showing all notifications
   // undefined: let the server decide
   const priority = opts?.overridePriorityNotifications ? false : undefined
+
+  const selectArgs = useMemo(() => {
+    return {
+      hiddenReplyUris,
+    }
+  }, [hiddenReplyUris])
 
   const query = useInfiniteQuery<
     FeedPage,
@@ -101,20 +109,41 @@ export function useNotificationFeedQuery(opts?: {
     initialPageParam: undefined,
     getNextPageParam: lastPage => lastPage.cursor,
     enabled,
-    select(data: InfiniteData<FeedPage>) {
-      // override 'isRead' using the first page's returned seenAt
-      // we do this because the `markAllRead()` call above will
-      // mark subsequent pages as read prematurely
-      const seenAt = data.pages[0]?.seenAt || new Date()
-      for (const page of data.pages) {
-        for (const item of page.items) {
-          item.notification.isRead =
-            seenAt > new Date(item.notification.indexedAt)
-        }
-      }
+    select: useCallback(
+      (data: InfiniteData<FeedPage>) => {
+        const {hiddenReplyUris} = selectArgs
 
-      return data
-    },
+        // override 'isRead' using the first page's returned seenAt
+        // we do this because the `markAllRead()` call above will
+        // mark subsequent pages as read prematurely
+        const seenAt = data.pages[0]?.seenAt || new Date()
+        for (const page of data.pages) {
+          for (const item of page.items) {
+            item.notification.isRead =
+              seenAt > new Date(item.notification.indexedAt)
+          }
+        }
+
+        data = {
+          ...data,
+          pages: data.pages.map(page => {
+            return {
+              ...page,
+              items: page.items.filter(item => {
+                const isHiddenReply =
+                  item.type === 'reply' &&
+                  item.subjectUri &&
+                  hiddenReplyUris.includes(item.subjectUri)
+                return !isHiddenReply
+              }),
+            }
+          }),
+        }
+
+        return data
+      },
+      [selectArgs],
+    ),
   })
 
   // The server may end up returning an empty page, a page with too few items,

--- a/src/state/queries/post-feed.ts
+++ b/src/state/queries/post-feed.ts
@@ -145,7 +145,10 @@ export function usePostFeedQuery(
       moderationOpts,
       ignoreFilterFor: opts?.ignoreFilterFor,
       isDiscover,
-      hiddenReplyUris,
+      /*
+       * If we're viewing an author feed, hidden replies are visible
+       */
+      hiddenReplyUris: feedDesc.startsWith('author|') ? [] : hiddenReplyUris,
     }),
     [
       feedTuners,
@@ -153,6 +156,7 @@ export function usePostFeedQuery(
       opts?.ignoreFilterFor,
       isDiscover,
       hiddenReplyUris,
+      feedDesc,
     ],
   )
 

--- a/src/state/threadgate-hidden-replies.tsx
+++ b/src/state/threadgate-hidden-replies.tsx
@@ -1,0 +1,55 @@
+import React from 'react'
+
+type StateContext = {
+  uris: string[]
+}
+type ApiContext = {
+  addHiddenReplyUri: (uri: string) => void
+  removeHiddenReplyUri: (uri: string) => void
+}
+
+const StateContext = React.createContext<StateContext>({
+  uris: [],
+})
+
+const ApiContext = React.createContext<ApiContext>({
+  addHiddenReplyUri: () => {},
+  removeHiddenReplyUri: () => {},
+})
+
+export function Provider({children}: {children: React.ReactNode}) {
+  const [uris, setHiddenReplyUris] = React.useState<string[]>([])
+
+  const stateCtx = React.useMemo(
+    () => ({
+      uris,
+    }),
+    [uris],
+  )
+
+  const apiCtx = React.useMemo(
+    () => ({
+      addHiddenReplyUri(uri: string) {
+        setHiddenReplyUris(prev => Array.from(new Set([...prev, uri])))
+      },
+      removeHiddenReplyUri(uri: string) {
+        setHiddenReplyUris(prev => prev.filter(u => u !== uri))
+      },
+    }),
+    [setHiddenReplyUris],
+  )
+
+  return (
+    <ApiContext.Provider value={apiCtx}>
+      <StateContext.Provider value={stateCtx}>{children}</StateContext.Provider>
+    </ApiContext.Provider>
+  )
+}
+
+export function useThreadgateHiddenReplyUris() {
+  return React.useContext(StateContext)
+}
+
+export function useThreadgateHiddenReplyUrisAPI() {
+  return React.useContext(ApiContext)
+}

--- a/src/state/threadgate-hidden-replies.tsx
+++ b/src/state/threadgate-hidden-replies.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 
 type StateContext = {
   uris: string[]
+  recentlyUnhiddenUris: string[]
 }
 type ApiContext = {
   addHiddenReplyUri: (uri: string) => void
@@ -10,6 +11,7 @@ type ApiContext = {
 
 const StateContext = React.createContext<StateContext>({
   uris: [],
+  recentlyUnhiddenUris: [],
 })
 
 const ApiContext = React.createContext<ApiContext>({
@@ -19,21 +21,27 @@ const ApiContext = React.createContext<ApiContext>({
 
 export function Provider({children}: {children: React.ReactNode}) {
   const [uris, setHiddenReplyUris] = React.useState<string[]>([])
+  const [recentlyUnhiddenUris, setRecentlyUnhiddenUris] = React.useState<
+    string[]
+  >([])
 
   const stateCtx = React.useMemo(
     () => ({
       uris,
+      recentlyUnhiddenUris,
     }),
-    [uris],
+    [uris, recentlyUnhiddenUris],
   )
 
   const apiCtx = React.useMemo(
     () => ({
       addHiddenReplyUri(uri: string) {
         setHiddenReplyUris(prev => Array.from(new Set([...prev, uri])))
+        setRecentlyUnhiddenUris(prev => prev.filter(u => u !== uri))
       },
       removeHiddenReplyUri(uri: string) {
         setHiddenReplyUris(prev => prev.filter(u => u !== uri))
+        setRecentlyUnhiddenUris(prev => Array.from(new Set([...prev, uri])))
       },
     }),
     [setHiddenReplyUris],

--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -207,12 +207,11 @@ let PostThreadItemLoaded = ({
     return makeProfileLink(post.author, 'post', urip.rkey, 'reposted-by')
   }, [post.uri, post.author])
   const repostsTitle = _(msg`Reposts of this post`)
-  const isPostHiddenByThreadgate = threadgateRecord?.hiddenReplies?.includes(
-    post.uri,
-  )
-  // TODO memoize
-  const additionalPostAlerts: AppModerationCause[] =
-    threadgateRecord && isPostHiddenByThreadgate
+  const additionalPostAlerts: AppModerationCause[] = React.useMemo(() => {
+    const isPostHiddenByThreadgate = threadgateRecord?.hiddenReplies?.includes(
+      post.uri,
+    )
+    return threadgateRecord && isPostHiddenByThreadgate
       ? [
           {
             type: 'reply-hidden',
@@ -221,6 +220,7 @@ let PostThreadItemLoaded = ({
           },
         ]
       : []
+  }, [post, threadgateRecord])
 
   const translatorUrl = getTranslatorLink(
     record?.text || '',

--- a/src/view/com/posts/FeedItem.tsx
+++ b/src/view/com/posts/FeedItem.tsx
@@ -4,6 +4,7 @@ import {
   AppBskyActorDefs,
   AppBskyFeedDefs,
   AppBskyFeedPost,
+  AppBskyFeedThreadgate,
   AtUri,
   ModerationDecision,
   RichText as RichTextAPI,
@@ -78,7 +79,11 @@ export function FeedItem({
   isThreadParent,
   hideTopBorder,
   isParentBlocked,
-}: FeedItemProps & {post: AppBskyFeedDefs.PostView}): React.ReactNode {
+  rootPost,
+}: FeedItemProps & {
+  post: AppBskyFeedDefs.PostView
+  rootPost?: AppBskyFeedDefs.PostView
+}): React.ReactNode {
   const postShadowed = usePostShadow(post)
   const richText = useMemo(
     () =>
@@ -109,6 +114,7 @@ export function FeedItem({
         isThreadParent={isThreadParent}
         hideTopBorder={hideTopBorder}
         isParentBlocked={isParentBlocked}
+        rootPost={rootPost}
       />
     )
   }
@@ -129,9 +135,11 @@ let FeedItemInner = ({
   isThreadParent,
   hideTopBorder,
   isParentBlocked,
+  rootPost,
 }: FeedItemProps & {
   richText: RichTextAPI
   post: Shadow<AppBskyFeedDefs.PostView>
+  rootPost?: AppBskyFeedDefs.PostView
 }): React.ReactNode => {
   const queryClient = useQueryClient()
   const {openComposer} = useComposerControls()
@@ -366,6 +374,11 @@ let FeedItemInner = ({
             onPressReply={onPressReply}
             logContext="FeedItem"
             feedContext={feedContext}
+            threadgateRecord={
+              AppBskyFeedThreadgate.isRecord(rootPost?.threadgate?.record)
+                ? rootPost.threadgate.record
+                : undefined
+            }
           />
         </View>
       </View>

--- a/src/view/com/posts/FeedItem.tsx
+++ b/src/view/com/posts/FeedItem.tsx
@@ -84,7 +84,7 @@ export function FeedItem({
   rootPost,
 }: FeedItemProps & {
   post: AppBskyFeedDefs.PostView
-  rootPost?: AppBskyFeedDefs.PostView
+  rootPost: AppBskyFeedDefs.PostView
 }): React.ReactNode {
   const postShadowed = usePostShadow(post)
   const richText = useMemo(
@@ -141,7 +141,7 @@ let FeedItemInner = ({
 }: FeedItemProps & {
   richText: RichTextAPI
   post: Shadow<AppBskyFeedDefs.PostView>
-  rootPost?: AppBskyFeedDefs.PostView
+  rootPost: AppBskyFeedDefs.PostView
 }): React.ReactNode => {
   const queryClient = useQueryClient()
   const {openComposer} = useComposerControls()
@@ -225,7 +225,7 @@ let FeedItemInner = ({
     reason.by.did === currentAccount?.did
 
   const threadgateRecord = AppBskyFeedThreadgate.isRecord(
-    rootPost?.threadgate?.record,
+    rootPost.threadgate?.record,
   )
     ? rootPost.threadgate.record
     : undefined

--- a/src/view/com/posts/FeedItem.tsx
+++ b/src/view/com/posts/FeedItem.tsx
@@ -416,10 +416,12 @@ let PostContent = ({
   const [limitLines, setLimitLines] = useState(
     () => countLines(richText.text) >= MAX_POST_LINES,
   )
-  const {uris: hiddenReplyUris} = useThreadgateHiddenReplyUris()
+  const {uris: hiddenReplyUris, recentlyUnhiddenUris} =
+    useThreadgateHiddenReplyUris()
   const additionalPostAlerts: AppModerationCause[] = React.useMemo(() => {
     const isPostHiddenByHiddenReplyCache = hiddenReplyUris.includes(post.uri)
     const isPostHiddenByThreadgate =
+      !recentlyUnhiddenUris.includes(post.uri) &&
       !!threadgateRecord?.hiddenReplies?.includes(post.uri)
     const isHidden = isPostHiddenByHiddenReplyCache || isPostHiddenByThreadgate
     const alertSource =
@@ -437,7 +439,13 @@ let PostContent = ({
           },
         ]
       : []
-  }, [post, hiddenReplyUris, threadgateRecord, currentAccount?.did])
+  }, [
+    post,
+    hiddenReplyUris,
+    recentlyUnhiddenUris,
+    threadgateRecord,
+    currentAccount?.did,
+  ])
 
   const onPressShowMore = React.useCallback(() => {
     setLimitLines(false)

--- a/src/view/com/posts/FeedSlice.tsx
+++ b/src/view/com/posts/FeedSlice.tsx
@@ -36,6 +36,7 @@ let FeedSlice = ({
           isThreadChild={isThreadChildAt(slice.items, 0)}
           hideTopBorder={hideTopBorder}
           isParentBlocked={slice.items[0].isParentBlocked}
+          rootPost={slice.items[0].post}
         />
         <ViewFullThread uri={slice.items[0].uri} />
         <FeedItem
@@ -53,6 +54,7 @@ let FeedSlice = ({
           isThreadParent={isThreadParentAt(slice.items, beforeLast)}
           isThreadChild={isThreadChildAt(slice.items, beforeLast)}
           isParentBlocked={slice.items[beforeLast].isParentBlocked}
+          rootPost={slice.items[0].post}
         />
         <FeedItem
           key={slice.items[last]._reactKey}
@@ -67,6 +69,7 @@ let FeedSlice = ({
           isThreadChild={isThreadChildAt(slice.items, last)}
           isParentBlocked={slice.items[last].isParentBlocked}
           isThreadLastChild
+          rootPost={slice.items[0].post}
         />
       </>
     )
@@ -91,6 +94,7 @@ let FeedSlice = ({
           }
           isParentBlocked={slice.items[i].isParentBlocked}
           hideTopBorder={hideTopBorder && i === 0}
+          rootPost={slice.items[0].post}
         />
       ))}
     </>

--- a/src/view/com/util/forms/PostDropdownBtn.tsx
+++ b/src/view/com/util/forms/PostDropdownBtn.tsx
@@ -123,7 +123,8 @@ let PostDropdownBtn = ({
   const quotePostDetachConfirmControl = useDialogControl()
   const {mutateAsync: toggleReplyVisibility} =
     useToggleReplyVisibilityMutation()
-  const {uris: hiddenReplies} = useThreadgateHiddenReplyUris()
+  const {uris: hiddenReplies, recentlyUnhiddenUris} =
+    useThreadgateHiddenReplyUris()
 
   const postUri = post.uri
   const postCid = post.cid
@@ -147,7 +148,8 @@ let PostDropdownBtn = ({
   const isRootPostAuthor = new AtUri(rootUri).host === currentAccount?.did
   const isReplyHiddenByThreadgate =
     hiddenReplies.includes(postUri) ||
-    threadgateRecord?.hiddenReplies?.includes(postUri)
+    (!recentlyUnhiddenUris.includes(postUri) &&
+      threadgateRecord?.hiddenReplies?.includes(postUri))
 
   const {mutateAsync: toggleQuoteDetachment, isPending} =
     useToggleQuoteDetachmentMutation()

--- a/src/view/com/util/forms/PostDropdownBtn.tsx
+++ b/src/view/com/util/forms/PostDropdownBtn.tsx
@@ -146,8 +146,8 @@ let PostDropdownBtn = ({
   const isAuthor = postAuthor.did === currentAccount?.did
   const isRootPostAuthor = new AtUri(rootUri).host === currentAccount?.did
   const isReplyHiddenByThreadgate =
-    threadgateRecord?.hiddenReplies?.includes(postUri) ||
-    hiddenReplies.includes(postUri)
+    hiddenReplies.includes(postUri) ||
+    threadgateRecord?.hiddenReplies?.includes(postUri)
 
   const {mutateAsync: toggleQuoteDetachment, isPending} =
     useToggleQuoteDetachmentMutation()

--- a/src/view/com/util/forms/PostDropdownBtn.tsx
+++ b/src/view/com/util/forms/PostDropdownBtn.tsx
@@ -37,6 +37,7 @@ import {useToggleQuoteDetachmentMutation} from '#/state/queries/postgate'
 import {getMaybeDetachedQuoteEmbed} from '#/state/queries/postgate/util'
 import {useToggleReplyVisibilityMutation} from '#/state/queries/threadgate'
 import {useSession} from '#/state/session'
+import {useThreadgateHiddenReplyUris} from '#/state/threadgate-hidden-replies'
 import {getCurrentRoute} from 'lib/routes/helpers'
 import {shareUrl} from 'lib/sharing'
 import {toShareUrl} from 'lib/strings/url-helpers'
@@ -122,6 +123,7 @@ let PostDropdownBtn = ({
   const quotePostDetachConfirmControl = useDialogControl()
   const {mutateAsync: toggleReplyVisibility} =
     useToggleReplyVisibilityMutation()
+  const {uris: hiddenReplies} = useThreadgateHiddenReplyUris()
 
   const postUri = post.uri
   const postCid = post.cid
@@ -144,7 +146,8 @@ let PostDropdownBtn = ({
   const isAuthor = postAuthor.did === currentAccount?.did
   const isRootPostAuthor = new AtUri(rootUri).host === currentAccount?.did
   const isReplyHiddenByThreadgate =
-    threadgateRecord?.hiddenReplies?.includes(postUri)
+    threadgateRecord?.hiddenReplies?.includes(postUri) ||
+    hiddenReplies.includes(postUri)
 
   const {mutateAsync: toggleQuoteDetachment, isPending} =
     useToggleQuoteDetachmentMutation()

--- a/src/view/screens/DebugMod.tsx
+++ b/src/view/screens/DebugMod.tsx
@@ -807,6 +807,7 @@ function MockPostFeedItem({
       showReplyTo={false}
       reason={undefined}
       feedContext={''}
+      rootPost={post}
     />
   )
 }


### PR DESCRIPTION
[Review w/o whitespace](https://github.com/bluesky-social/social-app/pull/4933/files?diff=split&w=1). Can ignore the CI failures, I'll fix on the main branch.

This PR adds the ability to hide a reply directly from a feed generator as well as from the notifications feed. To do so, it adds an in-memory cache of replies that were hidden, and uses that array to filter out those replies from feed generators and notifications feed.

So what happens here is: when the user hides a reply, then the in-memory cache and threadgate record are updated with that URI. Then when navigating to other screens where this reply may be present, the reply is filtered on the client. Upon a full reload, the server strips out the reply, and the in-memory cache is reset.

For feed items, we're able to hydrate the threadgate from the root post, since it's present in feed slices. So we use that for the initial state, and then defer to the in-memory cache.

**Why not use post shadow?**

Not every place where we want to be able to hide replies has a root post whose `threadgate` prop we can update e.g. notifications. We also lack a root post if the root post or a post above the reply was blocked or hidden. Plus, if we were to generate a `ThreadgateView` for a post without one already, we'd need to hack in a fake record and leave an empty CID. Not that big of deal but still meh.