### PR TITLE
[Video] set audio category to ambient every time a new player is made

### DIFF
--- a/modules/expo-bluesky-swiss-army/ios/PlatformInfo/ExpoPlatformInfoModule.swift
+++ b/modules/expo-bluesky-swiss-army/ios/PlatformInfo/ExpoPlatformInfoModule.swift
@@ -1,6 +1,9 @@
 import ExpoModulesCore
 
 public class ExpoPlatformInfoModule: Module {
+  private var prevAudioActive: Bool?
+  private var prevAudioCategory: AVAudioSession.Category?
+
   public func definition() -> ModuleDefinition {
     Name("ExpoPlatformInfo")
 
@@ -10,13 +13,20 @@ public class ExpoPlatformInfoModule: Module {
 
     Function("setAudioCategory") { (audioCategoryString: String) in
       let audioCategory = AVAudioSession.Category(rawValue: audioCategoryString)
-
+      if audioCategory == self.prevAudioCategory {
+        return
+      }
+      self.prevAudioCategory = audioCategory
       DispatchQueue.global(qos: .background).async {
         try? AVAudioSession.sharedInstance().setCategory(audioCategory)
       }
     }
 
     Function("setAudioActive") { (active: Bool) in
+      if active == self.prevAudioActive {
+        return
+      }
+      self.prevAudioActive = active
       if active {
         DispatchQueue.global(qos: .background).async {
           try? AVAudioSession.sharedInstance().setActive(true)

--- a/src/view/com/composer/videos/VideoPreview.tsx
+++ b/src/view/com/composer/videos/VideoPreview.tsx
@@ -16,8 +16,8 @@ export function VideoPreview({
 }) {
   const player = useVideoPlayer(video.uri, player => {
     player.loop = true
+    player.muted = true
     player.play()
-    player.volume = 0
   })
 
   return (

--- a/src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerNative.tsx
+++ b/src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerNative.tsx
@@ -28,6 +28,9 @@ export function VideoEmbedInnerNative() {
   useEffect(() => {
     try {
       if (isAppFocused === 'active' && isScreenFocused && !player.playing) {
+        PlatformInfo.setAudioCategory(AudioCategory.Ambient)
+        PlatformInfo.setAudioActive(false)
+        player.muted = true
         player.play()
       } else if (player.playing) {
         player.pause()

--- a/src/view/com/util/post-embeds/VideoPlayerContext.tsx
+++ b/src/view/com/util/post-embeds/VideoPlayerContext.tsx
@@ -3,6 +3,10 @@ import type {VideoPlayer} from 'expo-video'
 import {useVideoPlayer as useExpoVideoPlayer} from 'expo-video'
 
 import {logger} from '#/logger'
+import {
+  AudioCategory,
+  PlatformInfo,
+} from '../../../../../modules/expo-bluesky-swiss-army'
 
 const VideoPlayerContext = React.createContext<VideoPlayer | null>(null)
 
@@ -16,6 +20,9 @@ export function VideoPlayerProvider({
   // eslint-disable-next-line @typescript-eslint/no-shadow
   const player = useExpoVideoPlayer(source, player => {
     try {
+      PlatformInfo.setAudioCategory(AudioCategory.Ambient)
+      PlatformInfo.setAudioActive(false)
+
       player.loop = true
       player.muted = true
       player.play()


### PR DESCRIPTION
Audio category could get out of sync with the player if you switch video