### PR TITLE
Hack patch for testing OTA update crash behavior

### DIFF
--- a/patches/expo-modules-core+1.12.11.patch
+++ b/patches/expo-modules-core+1.12.11.patch
@@ -25,7 +25,7 @@ index 109d3fe..c421931 100644
  const nativeUuidv5 = globalThis?.expo?.uuidv5;
  function uuidv4() {
 diff --git a/node_modules/expo-modules-core/ios/Core/SharedObjects/SharedObjectRegistry.swift b/node_modules/expo-modules-core/ios/Core/SharedObjects/SharedObjectRegistry.swift
-index ee2268a..87b9cd0 100644
+index ee2268a..4851b67 100644
 --- a/node_modules/expo-modules-core/ios/Core/SharedObjects/SharedObjectRegistry.swift
 +++ b/node_modules/expo-modules-core/ios/Core/SharedObjects/SharedObjectRegistry.swift
 @@ -173,7 +173,7 @@ public final class SharedObjectRegistry {
@@ -33,7 +33,7 @@ index ee2268a..87b9cd0 100644
  
    internal func clear() {
 -    Self.lockQueue.async {
-+    Self.lockQueue.sync {
++    DispatchQueue.main.sync {
        self.pairs.removeAll()
      }
    }

--- a/patches/expo-modules-core+1.12.11.patch
+++ b/patches/expo-modules-core+1.12.11.patch
@@ -4,16 +4,16 @@ index bb74e80..0aa0202 100644
 +++ b/node_modules/expo-modules-core/android/src/main/java/expo/modules/adapters/react/NativeModulesProxy.java
 @@ -90,8 +90,8 @@ public class NativeModulesProxy extends ReactContextBaseJavaModule {
      mModuleRegistry.ensureIsInitialized();
-
+ 
      KotlinInteropModuleRegistry kotlinModuleRegistry = getKotlinInteropModuleRegistry();
 -    kotlinModuleRegistry.emitOnCreate();
      kotlinModuleRegistry.installJSIInterop();
 +    kotlinModuleRegistry.emitOnCreate();
-
+ 
      Map<String, Object> constants = new HashMap<>(3);
      constants.put(MODULES_CONSTANTS_KEY, new HashMap<>());
 diff --git a/node_modules/expo-modules-core/build/uuid/uuid.js b/node_modules/expo-modules-core/build/uuid/uuid.js
-index 109d3fe..c7fce9e 100644
+index 109d3fe..c421931 100644
 --- a/node_modules/expo-modules-core/build/uuid/uuid.js
 +++ b/node_modules/expo-modules-core/build/uuid/uuid.js
 @@ -1,5 +1,7 @@
@@ -24,3 +24,16 @@ index 109d3fe..c7fce9e 100644
  const nativeUuidv4 = globalThis?.expo?.uuidv4;
  const nativeUuidv5 = globalThis?.expo?.uuidv5;
  function uuidv4() {
+diff --git a/node_modules/expo-modules-core/ios/Core/SharedObjects/SharedObjectRegistry.swift b/node_modules/expo-modules-core/ios/Core/SharedObjects/SharedObjectRegistry.swift
+index ee2268a..87b9cd0 100644
+--- a/node_modules/expo-modules-core/ios/Core/SharedObjects/SharedObjectRegistry.swift
++++ b/node_modules/expo-modules-core/ios/Core/SharedObjects/SharedObjectRegistry.swift
+@@ -173,7 +173,7 @@ public final class SharedObjectRegistry {
+   }
+ 
+   internal func clear() {
+-    Self.lockQueue.async {
++    Self.lockQueue.sync {
+       self.pairs.removeAll()
+     }
+   }


### PR DESCRIPTION
## Why

There's a crash that's happening when `reloadAsync()` gets called by `expo-updates`. This is coming from attempting to destructure a null pointer, whenever removing all of the `SharedObject`s in `SharedObjectRegistry.clear()`.

A little digging shows that the `deinit` block of `VideoPlayer` runs _after_ `clear()` get's called. However, right now `clear()` calls `dict.removeAll()` _asynchronously_ inside of a separate queue from the main one. This is a small test to see if this helps to alievate the crashes. I don't consider this a production fix.

## Test Plan

Merge, let it build, and monitor for OTA crashes as we have been internally.