### PR TITLE
Fix orphaned feed slices, handle blocks

### DIFF
--- a/src/lib/api/feed-manip.ts
+++ b/src/lib/api/feed-manip.ts
@@ -23,6 +23,7 @@ type FeedSliceItem = {
   record: AppBskyFeedPost.Record
   parentAuthor: AppBskyActorDefs.ProfileViewBasic | undefined
   isParentBlocked: boolean
+  isParentNotFound: boolean
 }
 
 type AuthorContext = {
@@ -68,6 +69,7 @@ export class FeedViewPostsSlice {
     }
     const parent = reply?.parent
     const isParentBlocked = AppBskyFeedDefs.isBlockedPost(parent)
+    const isParentNotFound = AppBskyFeedDefs.isNotFoundPost(parent)
     let parentAuthor: AppBskyActorDefs.ProfileViewBasic | undefined
     if (AppBskyFeedDefs.isPostView(parent)) {
       parentAuthor = parent.author
@@ -77,6 +79,7 @@ export class FeedViewPostsSlice {
       record: post.record,
       parentAuthor,
       isParentBlocked,
+      isParentNotFound,
     })
     if (!reply || reason) {
       return
@@ -94,11 +97,15 @@ export class FeedViewPostsSlice {
     const isGrandparentBlocked = Boolean(
       grandparent && AppBskyFeedDefs.isBlockedPost(grandparent),
     )
+    const isGrandparentNotFound = Boolean(
+      grandparent && AppBskyFeedDefs.isNotFoundPost(grandparent),
+    )
     this.items.unshift({
       post: parent,
       record: parent.record,
       parentAuthor: grandparentAuthor,
       isParentBlocked: isGrandparentBlocked,
+      isParentNotFound: isGrandparentNotFound,
     })
     if (isGrandparentBlocked) {
       this.isOrphan = true
@@ -121,6 +128,7 @@ export class FeedViewPostsSlice {
       post: root,
       record: root.record,
       isParentBlocked: false,
+      isParentNotFound: false,
       parentAuthor: undefined,
     })
     if (parent.record.reply?.parent.uri !== root.uri) {

--- a/src/lib/api/feed-manip.ts
+++ b/src/lib/api/feed-manip.ts
@@ -92,7 +92,14 @@ export class FeedViewPostsSlice {
       this.isOrphan = true
       return
     }
-    const grandparent = reply?.grandparent
+    const root = reply.root
+    const rootIsView =
+      AppBskyFeedDefs.isPostView(root) || AppBskyFeedDefs.isBlockedPost(root)
+    // if parent is also the root, we have data!
+    const grandparent =
+      rootIsView && parent?.record?.reply?.parent?.uri === root?.uri
+        ? reply?.root
+        : undefined
     const grandparentAuthor = reply.grandparentAuthor
     const isGrandparentBlocked = Boolean(
       grandparent && AppBskyFeedDefs.isBlockedPost(grandparent),
@@ -112,7 +119,6 @@ export class FeedViewPostsSlice {
       // Keep going, it might still have a root, and we need this for thread
       // de-deduping
     }
-    const root = reply.root
     if (
       !AppBskyFeedDefs.isPostView(root) ||
       !AppBskyFeedPost.isRecord(root.record) ||

--- a/src/lib/api/feed-manip.ts
+++ b/src/lib/api/feed-manip.ts
@@ -12,13 +12,6 @@ import {ReasonFeedSource} from './feed/types'
 
 type FeedViewPost = AppBskyFeedDefs.FeedViewPost
 
-type ReplyRefMap = Map<
-  string,
-  | AppBskyFeedDefs.PostView
-  | AppBskyFeedDefs.BlockedPost
-  | AppBskyFeedDefs.NotFoundPost
->
-
 export type FeedTunerFn = (
   tuner: FeedTuner,
   slices: FeedViewPostsSlice[],
@@ -48,7 +41,7 @@ export class FeedViewPostsSlice {
   isOrphan: boolean
   rootUri: string
 
-  constructor(feedPost: FeedViewPost, replyRefMap: ReplyRefMap) {
+  constructor(feedPost: FeedViewPost) {
     const {post, reply, reason} = feedPost
     this.items = []
     this.isIncompleteThread = false
@@ -96,9 +89,7 @@ export class FeedViewPostsSlice {
       this.isOrphan = true
       return
     }
-    const grandparent = parent?.record?.reply?.parent?.uri
-      ? replyRefMap.get(parent.record.reply.parent.uri)
-      : undefined
+    const grandparent = reply?.grandparent
     const grandparentAuthor = reply.grandparentAuthor
     const isGrandparentBlocked = Boolean(
       grandparent && AppBskyFeedDefs.isBlockedPost(grandparent),
@@ -111,7 +102,8 @@ export class FeedViewPostsSlice {
     })
     if (isGrandparentBlocked) {
       this.isOrphan = true
-      return
+      // Keep going, it might still have a root, and we need this for thread
+      // de-deduping
     }
     const root = reply.root
     if (
@@ -213,22 +205,8 @@ export class FeedTuner {
       dryRun: false,
     },
   ): FeedViewPostsSlice[] {
-    const replyRefMap: ReplyRefMap = new Map()
-    for (const item of feed) {
-      for (const ancestor of [item.reply?.parent, item.reply?.root]) {
-        // trust server for blocked and not found reply parent/root refs
-        if (
-          AppBskyFeedDefs.isPostView(ancestor) ||
-          AppBskyFeedDefs.isBlockedPost(ancestor) ||
-          AppBskyFeedDefs.isNotFoundPost(ancestor)
-        ) {
-          replyRefMap.set(ancestor.uri, ancestor)
-        }
-      }
-    }
-
     let slices: FeedViewPostsSlice[] = feed
-      .map(item => new FeedViewPostsSlice(item, replyRefMap))
+      .map(item => new FeedViewPostsSlice(item))
       .filter(s => s.items.length > 0 || s.isFallbackMarker)
 
     // run the custom tuners

--- a/src/lib/api/feed-manip.ts
+++ b/src/lib/api/feed-manip.ts
@@ -94,11 +94,18 @@ export class FeedViewPostsSlice {
     }
     const root = reply.root
     const rootIsView =
-      AppBskyFeedDefs.isPostView(root) || AppBskyFeedDefs.isBlockedPost(root)
-    // if parent is also the root, we have data!
+      AppBskyFeedDefs.isPostView(root) ||
+      AppBskyFeedDefs.isBlockedPost(root) ||
+      AppBskyFeedDefs.isNotFoundPost(root)
+    /*
+     * If the parent is also the root, we just so happen to have the data we
+     * need to compute if the parent's parent (grandparent) is blocked. This
+     * doesn't always happen, of course, but we can take advantage of it when
+     * it does.
+     */
     const grandparent =
-      rootIsView && parent?.record?.reply?.parent?.uri === root?.uri
-        ? reply?.root
+      rootIsView && parent.record.reply?.parent.uri === root.uri
+        ? root
         : undefined
     const grandparentAuthor = reply.grandparentAuthor
     const isGrandparentBlocked = Boolean(

--- a/src/state/preferences/feed-tuners.tsx
+++ b/src/state/preferences/feed-tuners.tsx
@@ -46,7 +46,7 @@ export function useFeedTuners(feedDesc: FeedDescriptor) {
       return feedTuners
     }
     if (feedDesc === 'following') {
-      const feedTuners = [FeedTuner.removeOrphans]
+      const feedTuners = []
 
       if (preferences?.feedViewPrefs.hideReposts) {
         feedTuners.push(FeedTuner.removeReposts)

--- a/src/state/preferences/feed-tuners.tsx
+++ b/src/state/preferences/feed-tuners.tsx
@@ -46,7 +46,7 @@ export function useFeedTuners(feedDesc: FeedDescriptor) {
       return feedTuners
     }
     if (feedDesc === 'following') {
-      const feedTuners = []
+      const feedTuners = [FeedTuner.removeOrphans]
 
       if (preferences?.feedViewPrefs.hideReposts) {
         feedTuners.push(FeedTuner.removeReposts)

--- a/src/state/queries/post-feed.ts
+++ b/src/state/queries/post-feed.ts
@@ -80,6 +80,7 @@ export interface FeedPostSliceItem {
   moderation: ModerationDecision
   parentAuthor?: AppBskyActorDefs.ProfileViewBasic
   isParentBlocked?: boolean
+  isParentNotFound?: boolean
 }
 
 export interface FeedPostSlice {
@@ -326,6 +327,7 @@ export function usePostFeedQuery(
                         moderation: moderations[i],
                         parentAuthor: item.parentAuthor,
                         isParentBlocked: item.isParentBlocked,
+                        isParentNotFound: item.isParentNotFound,
                       }
                       return feedPostSliceItem
                     }),

--- a/src/view/com/posts/FeedItem.tsx
+++ b/src/view/com/posts/FeedItem.tsx
@@ -63,6 +63,7 @@ interface FeedItemProps {
   feedContext: string | undefined
   hideTopBorder?: boolean
   isParentBlocked?: boolean
+  isParentNotFound?: boolean
 }
 
 export function FeedItem({
@@ -78,6 +79,7 @@ export function FeedItem({
   isThreadParent,
   hideTopBorder,
   isParentBlocked,
+  isParentNotFound,
 }: FeedItemProps & {post: AppBskyFeedDefs.PostView}): React.ReactNode {
   const postShadowed = usePostShadow(post)
   const richText = useMemo(
@@ -109,6 +111,7 @@ export function FeedItem({
         isThreadParent={isThreadParent}
         hideTopBorder={hideTopBorder}
         isParentBlocked={isParentBlocked}
+        isParentNotFound={isParentNotFound}
       />
     )
   }
@@ -129,6 +132,7 @@ let FeedItemInner = ({
   isThreadParent,
   hideTopBorder,
   isParentBlocked,
+  isParentNotFound,
 }: FeedItemProps & {
   richText: RichTextAPI
   post: Shadow<AppBskyFeedDefs.PostView>
@@ -344,9 +348,14 @@ let FeedItemInner = ({
             postHref={href}
             onOpenAuthor={onOpenAuthor}
           />
-          {showReplyTo && (parentAuthor || isParentBlocked) && (
-            <ReplyToLabel blocked={isParentBlocked} profile={parentAuthor} />
-          )}
+          {showReplyTo &&
+            (parentAuthor || isParentBlocked || isParentNotFound) && (
+              <ReplyToLabel
+                blocked={isParentBlocked}
+                notFound={isParentNotFound}
+                profile={parentAuthor}
+              />
+            )}
           <LabelsOnMyPost post={post} />
           <PostContent
             moderation={moderation}
@@ -438,9 +447,11 @@ PostContent = memo(PostContent)
 function ReplyToLabel({
   profile,
   blocked,
+  notFound,
 }: {
   profile: AppBskyActorDefs.ProfileViewBasic | undefined
   blocked?: boolean
+  notFound?: boolean
 }) {
   const pal = usePalette('default')
   const {currentAccount} = useSession()
@@ -448,6 +459,8 @@ function ReplyToLabel({
   let label
   if (blocked) {
     label = <Trans context="description">Reply to a blocked post</Trans>
+  } else if (notFound) {
+    label = <Trans context="description">Reply to an unknown post</Trans>
   } else if (profile != null) {
     const isMe = profile.did === currentAccount?.did
     if (isMe) {

--- a/src/view/com/posts/FeedSlice.tsx
+++ b/src/view/com/posts/FeedSlice.tsx
@@ -36,6 +36,7 @@ let FeedSlice = ({
           isThreadChild={isThreadChildAt(slice.items, 0)}
           hideTopBorder={hideTopBorder}
           isParentBlocked={slice.items[0].isParentBlocked}
+          isParentNotFound={slice.items[0].isParentNotFound}
         />
         <ViewFullThread uri={slice.items[0].uri} />
         <FeedItem
@@ -53,6 +54,7 @@ let FeedSlice = ({
           isThreadParent={isThreadParentAt(slice.items, beforeLast)}
           isThreadChild={isThreadChildAt(slice.items, beforeLast)}
           isParentBlocked={slice.items[beforeLast].isParentBlocked}
+          isParentNotFound={slice.items[beforeLast].isParentNotFound}
         />
         <FeedItem
           key={slice.items[last]._reactKey}
@@ -66,6 +68,7 @@ let FeedSlice = ({
           isThreadParent={isThreadParentAt(slice.items, last)}
           isThreadChild={isThreadChildAt(slice.items, last)}
           isParentBlocked={slice.items[last].isParentBlocked}
+          isParentNotFound={slice.items[last].isParentNotFound}
           isThreadLastChild
         />
       </>
@@ -90,6 +93,7 @@ let FeedSlice = ({
             isThreadChildAt(slice.items, i) && slice.items.length === i + 1
           }
           isParentBlocked={slice.items[i].isParentBlocked}
+          isParentNotFound={slice.items[i].isParentNotFound}
           hideTopBorder={hideTopBorder && i === 0}
         />
       ))}


### PR DESCRIPTION
### Relies on https://github.com/bluesky-social/atproto/pull/2721

Fixes a regression in #4871 where `A -> B -> C` and `A` blocks `B`, we'd see the entire `A -> B -> C` thread, whereas the intention was to filter out those "orphaned" threads. If we want to show orphaned threads, it's a one-line change in `feed-tuners`.

## Testing

Test the scenarios below using the backend PR. Otherwise test prod, nothing should look different using prod data. Only the backend PR sends down data needed to compute the correct view.

## Blocks

### `A` blocks `B`, or `B` blocks `A`. Viewing as `C`.

See in prod, thread is orphaned (and technically "Reply to test.esb.lol" should say "Reply to blocked post")
![CleanShot 2024-08-15 at 17 19 01@2x](https://github.com/user-attachments/assets/1e7ad1e7-dbc9-466f-8623-ed742c9b35fd)

In main, you can see through the 3p blocks:
![CleanShot 2024-08-15 at 17 20 28@2x](https://github.com/user-attachments/assets/9792a26e-43d4-47eb-9a8b-68d5b5275001)

In this PR, `C` only sees `A` because the thread view would otherwise be "orphaned"
![CleanShot 2024-08-16 at 16 09 08@2x](https://github.com/user-attachments/assets/30b32e63-8f64-4d3e-9b77-ca43be349472)

### `C` blocks `A`. Viewing as `C`
In all cases the entire feed slice is filtered out 👍 

### `C` blocks `B`. Viewing as `C`.
In all cases, only `A` is visible 👍 

## Not found posts

In case of `B` deleting their post, again only `A` is visible in feeds, and when viewing `C` author feed, this PR now notes that the post was removed with the following:

![CleanShot 2024-08-16 at 16 28 45@2x](https://github.com/user-attachments/assets/f0570966-7982-4af7-ae96-c8406e0876c2)

I chose "unknown post" instead of "deleted post" because there are multiple reasons a post might be "not found".
