### PR TITLE
Tweak `expo-modules-core` hack patch

### DIFF
--- a/patches/expo-modules-core+1.12.11.patch
+++ b/patches/expo-modules-core+1.12.11.patch
@@ -4,12 +4,12 @@ index bb74e80..0aa0202 100644
 +++ b/node_modules/expo-modules-core/android/src/main/java/expo/modules/adapters/react/NativeModulesProxy.java
 @@ -90,8 +90,8 @@ public class NativeModulesProxy extends ReactContextBaseJavaModule {
      mModuleRegistry.ensureIsInitialized();
- 
+
      KotlinInteropModuleRegistry kotlinModuleRegistry = getKotlinInteropModuleRegistry();
 -    kotlinModuleRegistry.emitOnCreate();
      kotlinModuleRegistry.installJSIInterop();
 +    kotlinModuleRegistry.emitOnCreate();
- 
+
      Map<String, Object> constants = new HashMap<>(3);
      constants.put(MODULES_CONSTANTS_KEY, new HashMap<>());
 diff --git a/node_modules/expo-modules-core/build/uuid/uuid.js b/node_modules/expo-modules-core/build/uuid/uuid.js
@@ -30,10 +30,10 @@ index ee2268a..4851b67 100644
 +++ b/node_modules/expo-modules-core/ios/Core/SharedObjects/SharedObjectRegistry.swift
 @@ -173,7 +173,7 @@ public final class SharedObjectRegistry {
    }
- 
+
    internal func clear() {
 -    Self.lockQueue.async {
-+    DispatchQueue.main.sync {
++    Self.lockQueue.sync {
        self.pairs.removeAll()
      }
    }


### PR DESCRIPTION
Per expo recommendation in https://bluesky-builders.slack.com/archives/C05R8KJK1PC/p1723836730258259, tweaking the patch added in https://github.com/bluesky-social/social-app/pull/4942.