### PR TITLE
Add Hider component

### DIFF
--- a/src/components/moderation/Hider.tsx
+++ b/src/components/moderation/Hider.tsx
@@ -21,17 +21,7 @@ type Context = {
   }
 }
 
-const Context = React.createContext<Context>({
-  isContentVisible: false,
-  setIsContentVisible: () => {},
-  // @ts-ignore
-  info: {},
-  showInfoDialog: () => {},
-  meta: {
-    isNoPwi: false,
-    noOverride: false,
-  },
-})
+const Context = React.createContext<Context>({} as Context)
 
 export const useScreenHider = () => React.useContext(Context)
 

--- a/src/components/moderation/Hider.tsx
+++ b/src/components/moderation/Hider.tsx
@@ -33,6 +33,8 @@ const Context = React.createContext<Context>({
   },
 })
 
+export const useScreenHider = () => React.useContext(Context)
+
 export function Outer({
   modui,
   children,
@@ -44,40 +46,33 @@ export function Outer({
   const [isContentVisible, setIsContentVisible] = React.useState(!blur)
   const info = useModerationCauseDescription(blur)
 
-  const meta = React.useMemo(
-    () => ({
-      isNoPwi: !!modui.blurs.find(
+  const meta = {
+    isNoPwi: Boolean(
+      modui.blurs.find(
         cause =>
           cause.type === 'label' &&
           cause.labelDef.identifier === '!no-unauthenticated',
       ),
-      noOverride: modui.noOverride,
-    }),
-    [modui],
-  )
+    ),
+    noOverride: modui.noOverride,
+  }
 
-  const showInfoDialog = React.useCallback(() => {
+  const showInfoDialog = () => {
     control.open()
-  }, [control])
+  }
 
-  const onSetContentVisible = React.useCallback(
-    (show: boolean) => {
-      if (meta.noOverride) return
-      setIsContentVisible(show)
-    },
-    [setIsContentVisible, meta],
-  )
+  const onSetContentVisible = (show: boolean) => {
+    if (meta.noOverride) return
+    setIsContentVisible(show)
+  }
 
-  const ctx = React.useMemo(
-    () => ({
-      isContentVisible,
-      setIsContentVisible: onSetContentVisible,
-      showInfoDialog,
-      info,
-      meta,
-    }),
-    [isContentVisible, onSetContentVisible, info, meta, showInfoDialog],
-  )
+  const ctx = {
+    isContentVisible,
+    setIsContentVisible: onSetContentVisible,
+    showInfoDialog,
+    info,
+    meta,
+  }
 
   return (
     <Context.Provider value={ctx}>
@@ -87,22 +82,12 @@ export function Outer({
   )
 }
 
-export function Content({
-  children,
-}: {
-  children: (context: Context) => React.ReactNode
-}) {
-  const ctx = React.useContext(Context)
-  const child = React.useMemo(() => children(ctx), [ctx, children])
-  return ctx.isContentVisible ? child : null
+export function Content({children}: {children: React.ReactNode}) {
+  const ctx = useScreenHider()
+  return ctx.isContentVisible ? children : null
 }
 
-export function Mask({
-  children,
-}: {
-  children: (context: Context) => React.ReactNode
-}) {
-  const ctx = React.useContext(Context)
-  const child = React.useMemo(() => children(ctx), [ctx, children])
-  return !ctx.isContentVisible ? child : null
+export function Mask({children}: {children: React.ReactNode}) {
+  const ctx = useScreenHider()
+  return ctx.isContentVisible ? null : children
 }

--- a/src/components/moderation/Hider.tsx
+++ b/src/components/moderation/Hider.tsx
@@ -1,0 +1,108 @@
+import React from 'react'
+import {ModerationUI} from '@atproto/api'
+
+import {
+  ModerationCauseDescription,
+  useModerationCauseDescription,
+} from '#/lib/moderation/useModerationCauseDescription'
+import {
+  ModerationDetailsDialog,
+  useModerationDetailsDialogControl,
+} from '#/components/moderation/ModerationDetailsDialog'
+
+type Context = {
+  isContentVisible: boolean
+  setIsContentVisible: (show: boolean) => void
+  info: ModerationCauseDescription
+  showInfoDialog: () => void
+  meta: {
+    isNoPwi: boolean
+    noOverride: boolean
+  }
+}
+
+const Context = React.createContext<Context>({
+  isContentVisible: false,
+  setIsContentVisible: () => {},
+  // @ts-ignore
+  info: {},
+  showInfoDialog: () => {},
+  meta: {
+    isNoPwi: false,
+    noOverride: false,
+  },
+})
+
+export function Outer({
+  modui,
+  children,
+}: React.PropsWithChildren<{
+  modui: ModerationUI
+}>) {
+  const control = useModerationDetailsDialogControl()
+  const blur = modui.blurs[0]
+  const [isContentVisible, setIsContentVisible] = React.useState(!blur)
+  const info = useModerationCauseDescription(blur)
+
+  const meta = React.useMemo(
+    () => ({
+      isNoPwi: !!modui.blurs.find(
+        cause =>
+          cause.type === 'label' &&
+          cause.labelDef.identifier === '!no-unauthenticated',
+      ),
+      noOverride: modui.noOverride,
+    }),
+    [modui],
+  )
+
+  const showInfoDialog = React.useCallback(() => {
+    control.open()
+  }, [control])
+
+  const onSetContentVisible = React.useCallback(
+    (show: boolean) => {
+      if (meta.noOverride) return
+      setIsContentVisible(show)
+    },
+    [setIsContentVisible, meta],
+  )
+
+  const ctx = React.useMemo(
+    () => ({
+      isContentVisible,
+      setIsContentVisible: onSetContentVisible,
+      showInfoDialog,
+      info,
+      meta,
+    }),
+    [isContentVisible, onSetContentVisible, info, meta, showInfoDialog],
+  )
+
+  return (
+    <Context.Provider value={ctx}>
+      {children}
+      <ModerationDetailsDialog control={control} modcause={blur} />
+    </Context.Provider>
+  )
+}
+
+export function Content({
+  children,
+}: {
+  children: (context: Context) => React.ReactNode
+}) {
+  const ctx = React.useContext(Context)
+  const child = React.useMemo(() => children(ctx), [ctx, children])
+  return ctx.isContentVisible ? child : null
+}
+
+export function Mask({
+  children,
+}: {
+  children: (context: Context) => React.ReactNode
+}) {
+  const ctx = React.useContext(Context)
+  const child = React.useMemo(() => children(ctx), [ctx, children])
+  return !ctx.isContentVisible ? child : null
+}

--- a/src/view/screens/ProfileList.tsx
+++ b/src/view/screens/ProfileList.tsx
@@ -193,71 +193,29 @@ function ProfileListScreenLoaded({
     return (
       <Hider.Outer modui={moderation.ui('contentView')}>
         <Hider.Mask>
-          {() => <ListHiddenScreen list={list} preferences={preferences} />}
+          <ListHiddenScreen list={list} preferences={preferences} />
         </Hider.Mask>
         <Hider.Content>
-          {() => (
-            <View style={s.hContentRegion}>
-              <PagerWithHeader
-                items={SECTION_TITLES_CURATE}
-                isHeaderReady={true}
-                renderHeader={renderHeader}
-                onCurrentPageSelected={onCurrentPageSelected}>
-                {({headerHeight, scrollElRef, isFocused}) => (
-                  <FeedSection
-                    ref={feedSectionRef}
-                    feed={`list|${uri}`}
-                    scrollElRef={scrollElRef as ListRef}
-                    headerHeight={headerHeight}
-                    isFocused={isScreenFocused && isFocused}
-                  />
-                )}
-                {({headerHeight, scrollElRef}) => (
-                  <AboutSection
-                    ref={aboutSectionRef}
-                    scrollElRef={scrollElRef as ListRef}
-                    list={list}
-                    onPressAddUser={onPressAddUser}
-                    headerHeight={headerHeight}
-                  />
-                )}
-              </PagerWithHeader>
-              <FAB
-                testID="composeFAB"
-                onPress={() => openComposer({})}
-                icon={
-                  <ComposeIcon2
-                    strokeWidth={1.5}
-                    size={29}
-                    style={{color: 'white'}}
-                  />
-                }
-                accessibilityRole="button"
-                accessibilityLabel={_(msg`New post`)}
-                accessibilityHint=""
-              />
-            </View>
-          )}
-        </Hider.Content>
-      </Hider.Outer>
-    )
-  }
-  return (
-    <Hider.Outer modui={moderation.ui('contentView')}>
-      <Hider.Mask>
-        {() => <ListHiddenScreen list={list} preferences={preferences} />}
-      </Hider.Mask>
-      <Hider.Content>
-        {() => (
           <View style={s.hContentRegion}>
             <PagerWithHeader
-              items={SECTION_TITLES_MOD}
+              items={SECTION_TITLES_CURATE}
               isHeaderReady={true}
-              renderHeader={renderHeader}>
+              renderHeader={renderHeader}
+              onCurrentPageSelected={onCurrentPageSelected}>
+              {({headerHeight, scrollElRef, isFocused}) => (
+                <FeedSection
+                  ref={feedSectionRef}
+                  feed={`list|${uri}`}
+                  scrollElRef={scrollElRef as ListRef}
+                  headerHeight={headerHeight}
+                  isFocused={isScreenFocused && isFocused}
+                />
+              )}
               {({headerHeight, scrollElRef}) => (
                 <AboutSection
-                  list={list}
+                  ref={aboutSectionRef}
                   scrollElRef={scrollElRef as ListRef}
+                  list={list}
                   onPressAddUser={onPressAddUser}
                   headerHeight={headerHeight}
                 />
@@ -278,7 +236,45 @@ function ProfileListScreenLoaded({
               accessibilityHint=""
             />
           </View>
-        )}
+        </Hider.Content>
+      </Hider.Outer>
+    )
+  }
+  return (
+    <Hider.Outer modui={moderation.ui('contentView')}>
+      <Hider.Mask>
+        <ListHiddenScreen list={list} preferences={preferences} />
+      </Hider.Mask>
+      <Hider.Content>
+        <View style={s.hContentRegion}>
+          <PagerWithHeader
+            items={SECTION_TITLES_MOD}
+            isHeaderReady={true}
+            renderHeader={renderHeader}>
+            {({headerHeight, scrollElRef}) => (
+              <AboutSection
+                list={list}
+                scrollElRef={scrollElRef as ListRef}
+                onPressAddUser={onPressAddUser}
+                headerHeight={headerHeight}
+              />
+            )}
+          </PagerWithHeader>
+          <FAB
+            testID="composeFAB"
+            onPress={() => openComposer({})}
+            icon={
+              <ComposeIcon2
+                strokeWidth={1.5}
+                size={29}
+                style={{color: 'white'}}
+              />
+            }
+            accessibilityRole="button"
+            accessibilityLabel={_(msg`New post`)}
+            accessibilityHint=""
+          />
+        </View>
       </Hider.Content>
     </Hider.Outer>
   )

--- a/src/view/screens/ProfileList.tsx
+++ b/src/view/screens/ProfileList.tsx
@@ -71,7 +71,7 @@ import {CenteredView} from 'view/com/util/Views'
 import {ListHiddenScreen} from '#/screens/List/ListHiddenScreen'
 import {atoms as a, useTheme} from '#/alf'
 import {useDialogControl} from '#/components/Dialog'
-import {ScreenHider} from '#/components/moderation/ScreenHider'
+import * as Hider from '#/components/moderation/Hider'
 import * as Prompt from '#/components/Prompt'
 import {ReportDialog, useReportDialogControl} from '#/components/ReportDialog'
 import {RichText} from '#/components/RichText'
@@ -189,92 +189,98 @@ function ProfileListScreenLoaded({
     return <Header rkey={rkey} list={list} preferences={preferences} />
   }, [rkey, list, preferences])
 
-  if (isHidden) {
-    return <ListHiddenScreen list={list} preferences={preferences} />
-  }
-
   if (isCurateList) {
     return (
-      <ScreenHider
-        screenDescription={'list'}
-        modui={moderation.ui('contentView')}>
-        <View style={s.hContentRegion}>
-          <PagerWithHeader
-            items={SECTION_TITLES_CURATE}
-            isHeaderReady={true}
-            renderHeader={renderHeader}
-            onCurrentPageSelected={onCurrentPageSelected}>
-            {({headerHeight, scrollElRef, isFocused}) => (
-              <FeedSection
-                ref={feedSectionRef}
-                feed={`list|${uri}`}
-                scrollElRef={scrollElRef as ListRef}
-                headerHeight={headerHeight}
-                isFocused={isScreenFocused && isFocused}
+      <Hider.Outer modui={moderation.ui('contentView')}>
+        <Hider.Mask>
+          {() => <ListHiddenScreen list={list} preferences={preferences} />}
+        </Hider.Mask>
+        <Hider.Content>
+          {() => (
+            <View style={s.hContentRegion}>
+              <PagerWithHeader
+                items={SECTION_TITLES_CURATE}
+                isHeaderReady={true}
+                renderHeader={renderHeader}
+                onCurrentPageSelected={onCurrentPageSelected}>
+                {({headerHeight, scrollElRef, isFocused}) => (
+                  <FeedSection
+                    ref={feedSectionRef}
+                    feed={`list|${uri}`}
+                    scrollElRef={scrollElRef as ListRef}
+                    headerHeight={headerHeight}
+                    isFocused={isScreenFocused && isFocused}
+                  />
+                )}
+                {({headerHeight, scrollElRef}) => (
+                  <AboutSection
+                    ref={aboutSectionRef}
+                    scrollElRef={scrollElRef as ListRef}
+                    list={list}
+                    onPressAddUser={onPressAddUser}
+                    headerHeight={headerHeight}
+                  />
+                )}
+              </PagerWithHeader>
+              <FAB
+                testID="composeFAB"
+                onPress={() => openComposer({})}
+                icon={
+                  <ComposeIcon2
+                    strokeWidth={1.5}
+                    size={29}
+                    style={{color: 'white'}}
+                  />
+                }
+                accessibilityRole="button"
+                accessibilityLabel={_(msg`New post`)}
+                accessibilityHint=""
               />
-            )}
-            {({headerHeight, scrollElRef}) => (
-              <AboutSection
-                ref={aboutSectionRef}
-                scrollElRef={scrollElRef as ListRef}
-                list={list}
-                onPressAddUser={onPressAddUser}
-                headerHeight={headerHeight}
-              />
-            )}
-          </PagerWithHeader>
-          <FAB
-            testID="composeFAB"
-            onPress={() => openComposer({})}
-            icon={
-              <ComposeIcon2
-                strokeWidth={1.5}
-                size={29}
-                style={{color: 'white'}}
-              />
-            }
-            accessibilityRole="button"
-            accessibilityLabel={_(msg`New post`)}
-            accessibilityHint=""
-          />
-        </View>
-      </ScreenHider>
+            </View>
+          )}
+        </Hider.Content>
+      </Hider.Outer>
     )
   }
   return (
-    <ScreenHider
-      screenDescription={_(msg`list`)}
-      modui={moderation.ui('contentView')}>
-      <View style={s.hContentRegion}>
-        <PagerWithHeader
-          items={SECTION_TITLES_MOD}
-          isHeaderReady={true}
-          renderHeader={renderHeader}>
-          {({headerHeight, scrollElRef}) => (
-            <AboutSection
-              list={list}
-              scrollElRef={scrollElRef as ListRef}
-              onPressAddUser={onPressAddUser}
-              headerHeight={headerHeight}
+    <Hider.Outer modui={moderation.ui('contentView')}>
+      <Hider.Mask>
+        {() => <ListHiddenScreen list={list} preferences={preferences} />}
+      </Hider.Mask>
+      <Hider.Content>
+        {() => (
+          <View style={s.hContentRegion}>
+            <PagerWithHeader
+              items={SECTION_TITLES_MOD}
+              isHeaderReady={true}
+              renderHeader={renderHeader}>
+              {({headerHeight, scrollElRef}) => (
+                <AboutSection
+                  list={list}
+                  scrollElRef={scrollElRef as ListRef}
+                  onPressAddUser={onPressAddUser}
+                  headerHeight={headerHeight}
+                />
+              )}
+            </PagerWithHeader>
+            <FAB
+              testID="composeFAB"
+              onPress={() => openComposer({})}
+              icon={
+                <ComposeIcon2
+                  strokeWidth={1.5}
+                  size={29}
+                  style={{color: 'white'}}
+                />
+              }
+              accessibilityRole="button"
+              accessibilityLabel={_(msg`New post`)}
+              accessibilityHint=""
             />
-          )}
-        </PagerWithHeader>
-        <FAB
-          testID="composeFAB"
-          onPress={() => openComposer({})}
-          icon={
-            <ComposeIcon2
-              strokeWidth={1.5}
-              size={29}
-              style={{color: 'white'}}
-            />
-          }
-          accessibilityRole="button"
-          accessibilityLabel={_(msg`New post`)}
-          accessibilityHint=""
-        />
-      </View>
-    </ScreenHider>
+          </View>
+        )}
+      </Hider.Content>
+    </Hider.Outer>
   )
 }
 


### PR DESCRIPTION
Adds generic `Hider` component for use anywhere e.g.
- `ProfileList` entire screen
- list title on `Moderation > Lists` list of lists

Provides access to the result of `useModerationCauseDescription` and prepackages the `ModerationDetailsDialog`.

For lists right now we don't need to handle any other labels, so no need to have an override button for the moment.