### PR TITLE
Fix fixed footer experiment

### DIFF
--- a/src/lib/hooks/useMinimalShellTransform.ts
+++ b/src/lib/hooks/useMinimalShellTransform.ts
@@ -2,7 +2,6 @@ import {interpolate, useAnimatedStyle} from 'react-native-reanimated'
 
 import {useMinimalShellMode} from '#/state/shell/minimal-mode'
 import {useShellLayout} from '#/state/shell/shell-layout'
-import {useGate} from '../statsig/statsig'
 
 // Keep these separated so that we only pay for useAnimatedStyle that gets used.
 
@@ -32,13 +31,8 @@ export function useMinimalShellHeaderTransform() {
 export function useMinimalShellFooterTransform() {
   const {footerMode} = useMinimalShellMode()
   const {footerHeight} = useShellLayout()
-  const gate = useGate()
-  const isFixedBottomBar = gate('fixed_bottom_bar')
 
   const footerTransform = useAnimatedStyle(() => {
-    if (isFixedBottomBar) {
-      return {}
-    }
     return {
       pointerEvents: footerMode.value === 0 ? 'auto' : 'none',
       opacity: Math.pow(1 - footerMode.value, 2),
@@ -59,19 +53,8 @@ export function useMinimalShellFooterTransform() {
 
 export function useMinimalShellFabTransform() {
   const {footerMode} = useMinimalShellMode()
-  const gate = useGate()
-  const isFixedBottomBar = gate('fixed_bottom_bar')
 
   const fabTransform = useAnimatedStyle(() => {
-    if (isFixedBottomBar) {
-      return {
-        transform: [
-          {
-            translateY: -44,
-          },
-        ],
-      }
-    }
     return {
       transform: [
         {

--- a/src/lib/hooks/useMinimalShellTransform.ts
+++ b/src/lib/hooks/useMinimalShellTransform.ts
@@ -7,16 +7,20 @@ import {useGate} from '../statsig/statsig'
 // Keep these separated so that we only pay for useAnimatedStyle that gets used.
 
 export function useMinimalShellHeaderTransform() {
-  const mode = useMinimalShellMode()
+  const {headerMode} = useMinimalShellMode()
   const {headerHeight} = useShellLayout()
 
   const headerTransform = useAnimatedStyle(() => {
     return {
-      pointerEvents: mode.value === 0 ? 'auto' : 'none',
-      opacity: Math.pow(1 - mode.value, 2),
+      pointerEvents: headerMode.value === 0 ? 'auto' : 'none',
+      opacity: Math.pow(1 - headerMode.value, 2),
       transform: [
         {
-          translateY: interpolate(mode.value, [0, 1], [0, -headerHeight.value]),
+          translateY: interpolate(
+            headerMode.value,
+            [0, 1],
+            [0, -headerHeight.value],
+          ),
         },
       ],
     }
@@ -26,7 +30,7 @@ export function useMinimalShellHeaderTransform() {
 }
 
 export function useMinimalShellFooterTransform() {
-  const mode = useMinimalShellMode()
+  const {footerMode} = useMinimalShellMode()
   const {footerHeight} = useShellLayout()
   const gate = useGate()
   const isFixedBottomBar = gate('fixed_bottom_bar')
@@ -36,11 +40,15 @@ export function useMinimalShellFooterTransform() {
       return {}
     }
     return {
-      pointerEvents: mode.value === 0 ? 'auto' : 'none',
-      opacity: Math.pow(1 - mode.value, 2),
+      pointerEvents: footerMode.value === 0 ? 'auto' : 'none',
+      opacity: Math.pow(1 - footerMode.value, 2),
       transform: [
         {
-          translateY: interpolate(mode.value, [0, 1], [0, footerHeight.value]),
+          translateY: interpolate(
+            footerMode.value,
+            [0, 1],
+            [0, footerHeight.value],
+          ),
         },
       ],
     }
@@ -50,7 +58,7 @@ export function useMinimalShellFooterTransform() {
 }
 
 export function useMinimalShellFabTransform() {
-  const mode = useMinimalShellMode()
+  const {footerMode} = useMinimalShellMode()
   const gate = useGate()
   const isFixedBottomBar = gate('fixed_bottom_bar')
 
@@ -67,7 +75,7 @@ export function useMinimalShellFabTransform() {
     return {
       transform: [
         {
-          translateY: interpolate(mode.value, [0, 1], [-44, 0]),
+          translateY: interpolate(footerMode.value, [0, 1], [-44, 0]),
         },
       ],
     }

--- a/src/state/shell/minimal-mode.tsx
+++ b/src/state/shell/minimal-mode.tsx
@@ -6,32 +6,55 @@ import {
   withSpring,
 } from 'react-native-reanimated'
 
-type StateContext = SharedValue<number>
+type StateContext = {
+  headerMode: SharedValue<number>
+  footerMode: SharedValue<number>
+}
 type SetContext = (v: boolean) => void
 
 const stateContext = React.createContext<StateContext>({
-  value: 0,
-  addListener() {},
-  removeListener() {},
-  modify() {},
+  headerMode: {
+    value: 0,
+    addListener() {},
+    removeListener() {},
+    modify() {},
+  },
+  footerMode: {
+    value: 0,
+    addListener() {},
+    removeListener() {},
+    modify() {},
+  },
 })
 const setContext = React.createContext<SetContext>((_: boolean) => {})
 
 export function Provider({children}: React.PropsWithChildren<{}>) {
-  const mode = useSharedValue(0)
+  const headerMode = useSharedValue(0)
+  const footerMode = useSharedValue(0)
   const setMode = React.useCallback(
     (v: boolean) => {
       'worklet'
       // Cancel any existing animation
-      cancelAnimation(mode)
-      mode.value = withSpring(v ? 1 : 0, {
+      cancelAnimation(headerMode)
+      headerMode.value = withSpring(v ? 1 : 0, {
+        overshootClamping: true,
+      })
+      cancelAnimation(footerMode)
+      footerMode.value = withSpring(v ? 1 : 0, {
         overshootClamping: true,
       })
     },
-    [mode],
+    [headerMode, footerMode],
+  )
+  const value = React.useMemo(
+    () => ({
+      headerMode,
+      footerMode,
+    }),
+    [headerMode, footerMode],
   )
   return (
-    <stateContext.Provider value={mode}>
+    <stateContext.Provider value={value}>
       <setContext.Provider value={setMode}>{children}</setContext.Provider>
     </stateContext.Provider>
   )

--- a/src/view/com/util/MainScrollProvider.tsx
+++ b/src/view/com/util/MainScrollProvider.tsx
@@ -4,11 +4,12 @@ import {
   cancelAnimation,
   interpolate,
   useSharedValue,
+  withSpring,
 } from 'react-native-reanimated'
 import EventEmitter from 'eventemitter3'
 
 import {ScrollProvider} from '#/lib/ScrollContext'
-import {useMinimalShellMode, useSetMinimalShellMode} from '#/state/shell'
+import {useMinimalShellMode} from '#/state/shell'
 import {useShellLayout} from '#/state/shell/shell-layout'
 import {isNative, isWeb} from 'platform/detection'
 
@@ -22,10 +23,24 @@ function clamp(num: number, min: number, max: number) {
 export function MainScrollProvider({children}: {children: React.ReactNode}) {
   const {headerHeight} = useShellLayout()
   const {headerMode, footerMode} = useMinimalShellMode()
-  const setMode = useSetMinimalShellMode()
   const startDragOffset = useSharedValue<number | null>(null)
   const startMode = useSharedValue<number | null>(null)
   const didJustRestoreScroll = useSharedValue<boolean>(false)
+
+  const setMode = React.useCallback(
+    (v: boolean) => {
+      'worklet'
+      cancelAnimation(headerMode)
+      headerMode.value = withSpring(v ? 1 : 0, {
+        overshootClamping: true,
+      })
+      cancelAnimation(footerMode)
+      footerMode.value = withSpring(v ? 1 : 0, {
+        overshootClamping: true,
+      })
+    },
+    [headerMode, footerMode],
+  )
 
   useEffect(() => {
     if (isWeb) {

--- a/src/view/screens/Home.tsx
+++ b/src/view/screens/Home.tsx
@@ -167,7 +167,7 @@ function HomeScreenReady({
     }),
   )
 
-  const mode = useMinimalShellMode()
+  const {footerMode} = useMinimalShellMode()
   const {isMobile} = useWebMediaQueries()
   useFocusEffect(
     React.useCallback(() => {
@@ -177,7 +177,7 @@ function HomeScreenReady({
       }
       const listener = AppState.addEventListener('change', nextAppState => {
         if (nextAppState === 'active') {
-          if (isMobile && mode.value === 1) {
+          if (isMobile && footerMode.value === 1) {
             // Reveal the bottom bar so you don't miss notifications or messages.
             // TODO: Experiment with only doing it when unread > 0.
             setMinimalShellMode(false)
@@ -187,7 +187,7 @@ function HomeScreenReady({
       return () => {
         listener.remove()
       }
-    }, [setMinimalShellMode, mode, isMobile, gate]),
+    }, [setMinimalShellMode, footerMode, isMobile, gate]),
   )
 
   const onPageSelected = React.useCallback(


### PR DESCRIPTION
Haven't tested this very deeply but I think this should fix the `fixed_bottom_bar` experiment.

It takes an alternate approach to what I had before. The idea is to split the `mode` variable into `headerMode` and `footerMode`. Initially we always update them in unison (but read from `headerMode` unless we're specifically interested in the footer). Then we rip out the current conditional logic during read. Then we add some conditional logic during write, and only for the `MainScrollProvider` case which governs on-scroll showing/hiding. Other cases still set both.

Individual commits tell the story.

I think this should be enough.

## Test Plan

Verify the old mode (without gate) works like in prod.

Verify the experiment doesn't break starter pack wizard and other screens where we intentionally hide the bottom bar.