### PR TITLE
add `quoteCount` to view creators

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "open-analyzer": "EXPO_PUBLIC_OPEN_ANALYZER=1 yarn build-web"
   },
   "dependencies": {
-    "@atproto/api": "0.13.2",
+    "@atproto/api": "0.13.3",
     "@bam.tech/react-native-image-resizer": "^3.0.4",
     "@braintree/sanitize-url": "^6.0.2",
     "@discord/bottom-sheet": "bluesky-social/react-native-bottom-sheet",

--- a/src/state/queries/postgate/util.ts
+++ b/src/state/queries/postgate/util.ts
@@ -106,6 +106,7 @@ export function createEmbedViewRecordFromPost(
     replyCount: post.replyCount,
     repostCount: post.repostCount,
     likeCount: post.likeCount,
+    quoteCount: post.quoteCount,
     indexedAt: post.indexedAt,
   }
 }

--- a/src/state/queries/util.ts
+++ b/src/state/queries/util.ts
@@ -74,6 +74,7 @@ export function embedViewRecordToPostView(
     labels: v.labels,
     embed: v.embeds?.[0],
     likeCount: v.likeCount,
+    quoteCount: v.quoteCount,
     replyCount: v.replyCount,
     repostCount: v.repostCount,
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -72,10 +72,10 @@
   resolved "https://registry.yarnpkg.com/@atproto-labs/simple-store/-/simple-store-0.1.1.tgz#e743a2722b5d8732166f0a72aca8bd10e9bff106"
   integrity sha512-WKILW2b3QbAYKh+w5U2x6p5FqqLl0nAeLwGeDY+KjX01K4Dq3vQTR9b/qNp0jZm48CabPQVrqCv0PPU9LgRRRg==
 
-"@atproto/api@0.13.2":
-  version "0.13.2"
-  resolved "https://registry.yarnpkg.com/@atproto/api/-/api-0.13.2.tgz#392c7e37d03f28a9d3bc53b003f2d90cea4f1863"
-  integrity sha512-AkCr+GbSJu+TSJzML/Ggh7CC61TKi4cQEOGmFHeI/0x9sa110UAAWHHRKom2vV09+cW5p/FMAtWvA05YR+v4jw==
+"@atproto/api@0.13.3":
+  version "0.13.3"
+  resolved "https://registry.yarnpkg.com/@atproto/api/-/api-0.13.3.tgz#d84f2a0e25f38cca59b69d178901634f2d20b4ff"
+  integrity sha512-/PEVTTEQXICOjZCujAPsjArhwR0tR3LiF0SxxpZlWOjaqjVbqnBI/j0MNmddBFgeljC4/DcBobcDJ9HkILn4yQ==
   dependencies:
     "@atproto/common-web" "^0.3.0"
     "@atproto/lexicon" "^0.4.1"


### PR DESCRIPTION
## Why

Was missing the `quoteCount` for `EmbedView` previously. Bumping the API and adding this to our little view creator helpers, which helps with caching and layout smoothness.

## Test Plan

Tap into a quote and the quote count should be immediately available, there shouldn't be any layout jank. (Pending appview deploy)