### PR TITLE
Optimistic hidden replies

### DIFF
--- a/src/state/cache/post-shadow.ts
+++ b/src/state/cache/post-shadow.ts
@@ -21,7 +21,6 @@ export interface PostShadow {
   repostUri: string | undefined
   isDeleted: boolean
   embed: AppBskyEmbedRecord.View | AppBskyEmbedRecordWithMedia.View | undefined
-  threadgateView: AppBskyFeedDefs.ThreadgateView | undefined
 }
 
 export const POST_TOMBSTONE = Symbol('PostTombstone')
@@ -105,16 +104,6 @@ function mergeShadow(
     }
   }
 
-  let threadgateView: typeof post.threadgate
-  if ('threadgateView' in shadow && !post.threadgate) {
-    if (
-      AppBskyFeedDefs.isThreadgateView(shadow.threadgateView) ||
-      shadow.threadgateView === undefined
-    ) {
-      threadgateView = shadow.threadgateView
-    }
-  }
-
   return castAsShadow({
     ...post,
     embed: embed || post.embed,
@@ -125,8 +114,6 @@ function mergeShadow(
       like: 'likeUri' in shadow ? shadow.likeUri : post.viewer?.like,
       repost: 'repostUri' in shadow ? shadow.repostUri : post.viewer?.repost,
     },
-    // always prefer real post data
-    threadgate: post.threadgate || threadgateView,
   })
 }
 

--- a/src/state/queries/post-thread.ts
+++ b/src/state/queries/post-thread.ts
@@ -102,7 +102,12 @@ export function usePostThreadQuery(uri: string | undefined) {
       if (res.success) {
         const thread = responseToThreadNodes(res.data.thread)
         annotateSelfThread(thread)
-        return {thread, threadgate: res.data.threadgate}
+        return {
+          thread,
+          threadgate: res.data.threadgate as
+            | AppBskyFeedDefs.ThreadgateView
+            | undefined,
+        }
       }
       return {thread: {type: 'unknown', uri: uri!}}
     },

--- a/src/state/queries/post-thread.ts
+++ b/src/state/queries/post-thread.ts
@@ -88,7 +88,10 @@ export type ThreadModerationCache = WeakMap<ThreadNode, ModerationDecision>
 export function usePostThreadQuery(uri: string | undefined) {
   const queryClient = useQueryClient()
   const agent = useAgent()
-  return useQuery<ThreadNode, Error>({
+  return useQuery<
+    {thread: ThreadNode; threadgate?: AppBskyFeedDefs.ThreadgateView},
+    Error
+  >({
     gcTime: 0,
     queryKey: RQKEY(uri || ''),
     async queryFn() {
@@ -99,16 +102,16 @@ export function usePostThreadQuery(uri: string | undefined) {
       if (res.success) {
         const thread = responseToThreadNodes(res.data.thread)
         annotateSelfThread(thread)
-        return thread
+        return {thread, threadgate: res.data.threadgate}
       }
-      return {type: 'unknown', uri: uri!}
+      return {thread: {type: 'unknown', uri: uri!}}
     },
     enabled: !!uri,
     placeholderData: () => {
       if (!uri) return
       const post = findPostInQueryData(queryClient, uri)
       if (post) {
-        return post
+        return {thread: post}
       }
       return undefined
     },

--- a/src/state/queries/threadgate/index.ts
+++ b/src/state/queries/threadgate/index.ts
@@ -33,18 +33,16 @@ export const createThreadgateRecordQueryKey = (uri: string) => [
 ]
 
 export function useThreadgateRecordQuery({
-  enabled,
   postUri,
   initialData,
 }: {
-  enabled?: boolean
   postUri?: string
   initialData?: AppBskyFeedThreadgate.Record
 } = {}) {
   const agent = useAgent()
 
   return useQuery({
-    enabled: enabled ?? !!postUri,
+    enabled: !!postUri,
     queryKey: createThreadgateRecordQueryKey(postUri || ''),
     placeholderData: initialData,
     staleTime: STALE.MINUTES.ONE,

--- a/src/state/queries/threadgate/index.ts
+++ b/src/state/queries/threadgate/index.ts
@@ -9,12 +9,10 @@ import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query'
 
 import {networkRetry, retry} from '#/lib/async/retry'
 import {until} from '#/lib/async/until'
-import {updatePostShadow} from '#/state/cache/post-shadow'
 import {STALE} from '#/state/queries'
 import {RQKEY_ROOT as postThreadQueryKeyRoot} from '#/state/queries/post-thread'
 import {ThreadgateAllowUISetting} from '#/state/queries/threadgate/types'
 import {
-  createTempThreadgateView,
   createThreadgateRecord,
   mergeThreadgateRecords,
   threadgateAllowUISettingToAllowRecordValue,
@@ -342,26 +340,17 @@ export function useToggleReplyVisibilityMutation() {
         }
       })
     },
-    onSuccess(_, {postUri, replyUri}) {
-      updatePostShadow(queryClient, postUri, {
-        threadgateView: createTempThreadgateView({
-          postUri,
-          hiddenReplies: [replyUri],
-        }),
-      })
+    onSuccess() {
       queryClient.invalidateQueries({
         queryKey: [threadgateRecordQueryKeyRoot],
       })
     },
-    onError(_, {postUri, replyUri, action}) {
+    onError(_, {replyUri, action}) {
       if (action === 'hide') {
         hiddenReplies.removeHiddenReplyUri(replyUri)
       } else if (action === 'show') {
         hiddenReplies.addHiddenReplyUri(replyUri)
       }
-      updatePostShadow(queryClient, postUri, {
-        threadgateView: undefined,
-      })
     },
   })
 }

--- a/src/state/queries/threadgate/util.ts
+++ b/src/state/queries/threadgate/util.ts
@@ -139,23 +139,3 @@ export function createThreadgateRecord(
     hiddenReplies: threadgate.hiddenReplies || [],
   }
 }
-
-export function createTempThreadgateView({
-  postUri,
-  hiddenReplies,
-}: Pick<AppBskyFeedThreadgate.Record, 'hiddenReplies'> & {
-  postUri: string
-}): AppBskyFeedDefs.ThreadgateView {
-  const record: AppBskyFeedThreadgate.Record = {
-    $type: 'app.bsky.feed.threadgate',
-    post: postUri,
-    allow: undefined,
-    hiddenReplies,
-    createdAt: new Date().toISOString(),
-  }
-  return {
-    $type: 'app.bsky.feed.defs#threadgateView',
-    uri: postUri,
-    record,
-  }
-}

--- a/src/state/threadgate-hidden-replies.tsx
+++ b/src/state/threadgate-hidden-replies.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import {AppBskyFeedThreadgate} from '@atproto/api'
 
 type StateContext = {
   uris: Set<string>
@@ -66,4 +67,19 @@ export function useThreadgateHiddenReplyUris() {
 
 export function useThreadgateHiddenReplyUrisAPI() {
   return React.useContext(ApiContext)
+}
+
+export function useMergedThreadgateHiddenReplies({
+  threadgateRecord,
+}: {
+  threadgateRecord?: AppBskyFeedThreadgate.Record
+}) {
+  const {uris, recentlyUnhiddenUris} = useThreadgateHiddenReplyUris()
+  return React.useMemo(() => {
+    const set = new Set([...(threadgateRecord?.hiddenReplies || []), ...uris])
+    for (const uri of recentlyUnhiddenUris) {
+      set.delete(uri)
+    }
+    return set
+  }, [uris, recentlyUnhiddenUris, threadgateRecord])
 }

--- a/src/view/com/post-thread/PostThread.tsx
+++ b/src/view/com/post-thread/PostThread.tsx
@@ -448,7 +448,7 @@ export function PostThread({uri}: {uri: string | undefined}) {
           <PostThreadItem
             post={item.post}
             record={item.record}
-            threadgateRecord={threadgateRecord}
+            threadgateRecord={threadgateRecord ?? undefined}
             moderation={threadModerationCache.get(item)}
             treeView={treeView}
             depth={item.ctx.depth}

--- a/src/view/com/post-thread/PostThread.tsx
+++ b/src/view/com/post-thread/PostThread.tsx
@@ -3,12 +3,7 @@ import {StyleSheet, useWindowDimensions, View} from 'react-native'
 import {runOnJS} from 'react-native-reanimated'
 import Animated from 'react-native-reanimated'
 import {useSafeAreaInsets} from 'react-native-safe-area-context'
-import {
-  AppBskyFeedDefs,
-  AppBskyFeedPost,
-  AppBskyFeedThreadgate,
-  AtUri,
-} from '@atproto/api'
+import {AppBskyFeedDefs, AppBskyFeedThreadgate} from '@atproto/api'
 import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
@@ -28,9 +23,9 @@ import {
   usePostThreadQuery,
 } from '#/state/queries/post-thread'
 import {usePreferencesQuery} from '#/state/queries/preferences'
-import {useThreadgateRecordQuery} from '#/state/queries/threadgate'
 import {useSession} from '#/state/session'
 import {useComposerControls} from '#/state/shell'
+import {useMergedThreadgateHiddenReplies} from '#/state/threadgate-hidden-replies'
 import {useInitialNumToRender} from 'lib/hooks/useInitialNumToRender'
 import {useMinimalShellFabTransform} from 'lib/hooks/useMinimalShellTransform'
 import {useSetTitle} from 'lib/hooks/useSetTitle'
@@ -119,28 +114,13 @@ export function PostThread({uri}: {uri: string | undefined}) {
   )
   const rootPost = thread?.type === 'post' ? thread.post : undefined
   const rootPostRecord = thread?.type === 'post' ? thread.record : undefined
-  const replyRef =
-    rootPostRecord && AppBskyFeedPost.isRecord(rootPostRecord)
-      ? rootPostRecord.reply
-      : undefined
-  const rootPostUri = replyRef ? replyRef.root.uri : rootPost?.uri
-
-  const isOP =
-    currentAccount &&
-    rootPostUri &&
-    currentAccount?.did === new AtUri(rootPostUri).host
   const initialThreadgateRecord = rootPost?.threadgate?.record as
     | AppBskyFeedThreadgate.Record
     | undefined
-  const {data: threadgateRecord} = useThreadgateRecordQuery({
-    /**
-     * If the user is the OP and the root post has a threadgate, we should load
-     * the threadgate record. Otherwise, fallback to initialData, which is taken
-     * from the response from `getPostThread`.
-     */
-    enabled: Boolean(isOP && rootPostUri && initialThreadgateRecord),
-    postUri: rootPostUri,
-    initialData: initialThreadgateRecord,
+  const threadgateHiddenReplies = useMergedThreadgateHiddenReplies({
+    threadgateRecord: rootPost?.threadgate?.record as
+      | AppBskyFeedThreadgate.Record
+      | undefined,
   })
 
   const moderationOpts = useModerationOpts()
@@ -196,9 +176,6 @@ export function PostThread({uri}: {uri: string | undefined}) {
   const skeleton = React.useMemo(() => {
     const threadViewPrefs = preferences?.threadViewPrefs
     if (!threadViewPrefs || !thread) return null
-    const threadgateRecordHiddenReplies = new Set<string>(
-      threadgateRecord?.hiddenReplies || [],
-    )
 
     return createThreadSkeleton(
       sortThread(
@@ -207,13 +184,13 @@ export function PostThread({uri}: {uri: string | undefined}) {
         threadModerationCache,
         currentDid,
         justPostedUris,
-        threadgateRecordHiddenReplies,
+        threadgateHiddenReplies,
       ),
       currentDid,
       treeView,
       threadModerationCache,
       hiddenRepliesState !== HiddenRepliesState.Hide,
-      threadgateRecordHiddenReplies,
+      threadgateHiddenReplies,
     )
   }, [
     thread,
@@ -223,7 +200,7 @@ export function PostThread({uri}: {uri: string | undefined}) {
     threadModerationCache,
     hiddenRepliesState,
     justPostedUris,
-    threadgateRecord,
+    threadgateHiddenReplies,
   ])
 
   const error = React.useMemo(() => {
@@ -460,7 +437,7 @@ export function PostThread({uri}: {uri: string | undefined}) {
           <PostThreadItem
             post={item.post}
             record={item.record}
-            threadgateRecord={threadgateRecord ?? undefined}
+            threadgateRecord={initialThreadgateRecord}
             moderation={threadModerationCache.get(item)}
             treeView={treeView}
             depth={item.ctx.depth}

--- a/src/view/com/post-thread/PostThread.tsx
+++ b/src/view/com/post-thread/PostThread.tsx
@@ -3,11 +3,7 @@ import {StyleSheet, useWindowDimensions, View} from 'react-native'
 import {runOnJS} from 'react-native-reanimated'
 import Animated from 'react-native-reanimated'
 import {useSafeAreaInsets} from 'react-native-safe-area-context'
-import {
-  AppBskyFeedDefs,
-  AppBskyFeedPost,
-  AppBskyFeedThreadgate,
-} from '@atproto/api'
+import {AppBskyFeedDefs, AppBskyFeedThreadgate} from '@atproto/api'
 import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
@@ -27,7 +23,6 @@ import {
   usePostThreadQuery,
 } from '#/state/queries/post-thread'
 import {usePreferencesQuery} from '#/state/queries/preferences'
-import {useThreadgateRecordQuery} from '#/state/queries/threadgate'
 import {useSession} from '#/state/session'
 import {useComposerControls} from '#/state/shell'
 import {useMergedThreadgateHiddenReplies} from '#/state/threadgate-hidden-replies'
@@ -108,7 +103,7 @@ export function PostThread({uri}: {uri: string | undefined}) {
     isError: isThreadError,
     error: threadError,
     refetch,
-    data: thread,
+    data: {thread, threadgate} = {},
   } = usePostThreadQuery(uri)
 
   const treeView = React.useMemo(
@@ -119,19 +114,11 @@ export function PostThread({uri}: {uri: string | undefined}) {
   )
   const rootPost = thread?.type === 'post' ? thread.post : undefined
   const rootPostRecord = thread?.type === 'post' ? thread.record : undefined
-  const replyRef =
-    rootPostRecord && AppBskyFeedPost.isRecord(rootPostRecord)
-      ? rootPostRecord.reply
-      : undefined
-  const rootPostUri = replyRef ? replyRef.root.uri : rootPost?.uri
-  const {data: threadgateRecord} = useThreadgateRecordQuery({
-    postUri: rootPostUri,
-    initialData: rootPost?.threadgate?.record as
-      | AppBskyFeedThreadgate.Record
-      | undefined,
-  })
+  const threadgateRecord = threadgate?.record as
+    | AppBskyFeedThreadgate.Record
+    | undefined
   const threadgateHiddenReplies = useMergedThreadgateHiddenReplies({
-    threadgateRecord: threadgateRecord ?? undefined,
+    threadgateRecord,
   })
 
   const moderationOpts = useModerationOpts()

--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -213,12 +213,11 @@ let PostThreadItemLoaded = ({
   const additionalPostAlerts: AppModerationCause[] = React.useMemo(() => {
     const isPostHiddenByThreadgate = threadgateHiddenReplies.has(post.uri)
     const isControlledByViewer = new AtUri(rootUri).host === currentAccount?.did
-    if (!isControlledByViewer) return []
-    return isPostHiddenByThreadgate
+    return isControlledByViewer && isPostHiddenByThreadgate
       ? [
           {
             type: 'reply-hidden',
-            source: {type: 'user', did: new AtUri(rootUri).host},
+            source: {type: 'user', did: currentAccount?.did},
             priority: 6,
           },
         ]

--- a/src/view/com/posts/FeedItem.tsx
+++ b/src/view/com/posts/FeedItem.tsx
@@ -381,6 +381,7 @@ let FeedItemInner = ({
             onOpenEmbed={onOpenEmbed}
             post={post}
             rootPost={rootPost}
+            threadgateRecord={threadgateRecord}
           />
           <VideoDebug />
           <PostCtrls

--- a/src/view/com/posts/FeedItem.tsx
+++ b/src/view/com/posts/FeedItem.tsx
@@ -431,9 +431,11 @@ let PostContent = ({
   })
   const additionalPostAlerts: AppModerationCause[] = React.useMemo(() => {
     const isPostHiddenByThreadgate = threadgateHiddenReplies.has(post.uri)
+    const rootPostUri = AppBskyFeedPost.isRecord(post.record)
+      ? post.record?.reply?.root?.uri || post.uri
+      : undefined
     const isControlledByViewer =
-      threadgateRecord &&
-      new AtUri(threadgateRecord.post).host === currentAccount?.did
+      rootPostUri && new AtUri(rootPostUri).host === currentAccount?.did
     if (!isControlledByViewer) return []
     return isPostHiddenByThreadgate
       ? [
@@ -444,7 +446,7 @@ let PostContent = ({
           },
         ]
       : []
-  }, [post, currentAccount?.did, threadgateRecord, threadgateHiddenReplies])
+  }, [post, currentAccount?.did, threadgateHiddenReplies])
 
   const onPressShowMore = React.useCallback(() => {
     setLimitLines(false)

--- a/src/view/com/posts/FeedItem.tsx
+++ b/src/view/com/posts/FeedItem.tsx
@@ -436,8 +436,7 @@ let PostContent = ({
       : undefined
     const isControlledByViewer =
       rootPostUri && new AtUri(rootPostUri).host === currentAccount?.did
-    if (!isControlledByViewer) return []
-    return isPostHiddenByThreadgate
+    return isControlledByViewer && isPostHiddenByThreadgate
       ? [
           {
             type: 'reply-hidden',

--- a/src/view/com/posts/FeedItem.tsx
+++ b/src/view/com/posts/FeedItem.tsx
@@ -227,6 +227,10 @@ let FeedItemInner = ({
     AppBskyFeedDefs.isReasonRepost(reason) &&
     reason.by.did === currentAccount?.did
 
+  /**
+   * If `post[0]` in this slice is the actual root post (not an orphan thread),
+   * then we may have a threadgate record to reference
+   */
   const threadgateRecord = AppBskyFeedThreadgate.isRecord(
     rootPost.threadgate?.record,
   )
@@ -380,7 +384,6 @@ let FeedItemInner = ({
             postAuthor={post.author}
             onOpenEmbed={onOpenEmbed}
             post={post}
-            rootPost={rootPost}
             threadgateRecord={threadgateRecord}
           />
           <VideoDebug />
@@ -407,7 +410,6 @@ let PostContent = ({
   postEmbed,
   postAuthor,
   onOpenEmbed,
-  rootPost,
   threadgateRecord,
 }: {
   moderation: ModerationDecision
@@ -416,7 +418,6 @@ let PostContent = ({
   postAuthor: AppBskyFeedDefs.PostView['author']
   onOpenEmbed: () => void
   post: AppBskyFeedDefs.PostView
-  rootPost: AppBskyFeedDefs.PostView
   threadgateRecord?: AppBskyFeedThreadgate.Record
 }): React.ReactNode => {
   const pal = usePalette('default')
@@ -431,7 +432,8 @@ let PostContent = ({
   const additionalPostAlerts: AppModerationCause[] = React.useMemo(() => {
     const isPostHiddenByThreadgate = threadgateHiddenReplies.has(post.uri)
     const isControlledByViewer =
-      new AtUri(rootPost.uri).host === currentAccount?.did
+      threadgateRecord &&
+      new AtUri(threadgateRecord.post).host === currentAccount?.did
     if (!isControlledByViewer) return []
     return isPostHiddenByThreadgate
       ? [
@@ -442,7 +444,7 @@ let PostContent = ({
           },
         ]
       : []
-  }, [post, currentAccount?.did, rootPost.uri, threadgateHiddenReplies])
+  }, [post, currentAccount?.did, threadgateRecord, threadgateHiddenReplies])
 
   const onPressShowMore = React.useCallback(() => {
     setLimitLines(false)

--- a/src/view/com/posts/FeedSlice.tsx
+++ b/src/view/com/posts/FeedSlice.tsx
@@ -18,7 +18,6 @@ let FeedSlice = ({
   slice: FeedPostSlice
   hideTopBorder?: boolean
 }): React.ReactNode => {
-  console.log(slice)
   if (slice.isIncompleteThread && slice.items.length >= 3) {
     const beforeLast = slice.items.length - 2
     const last = slice.items.length - 1

--- a/src/view/com/posts/FeedSlice.tsx
+++ b/src/view/com/posts/FeedSlice.tsx
@@ -18,6 +18,7 @@ let FeedSlice = ({
   slice: FeedPostSlice
   hideTopBorder?: boolean
 }): React.ReactNode => {
+  console.log(slice)
   if (slice.isIncompleteThread && slice.items.length >= 3) {
     const beforeLast = slice.items.length - 2
     const last = slice.items.length - 1

--- a/src/view/com/util/forms/PostDropdownBtn.tsx
+++ b/src/view/com/util/forms/PostDropdownBtn.tsx
@@ -37,7 +37,7 @@ import {useToggleQuoteDetachmentMutation} from '#/state/queries/postgate'
 import {getMaybeDetachedQuoteEmbed} from '#/state/queries/postgate/util'
 import {useToggleReplyVisibilityMutation} from '#/state/queries/threadgate'
 import {useSession} from '#/state/session'
-import {useThreadgateHiddenReplyUris} from '#/state/threadgate-hidden-replies'
+import {useMergedThreadgateHiddenReplies} from '#/state/threadgate-hidden-replies'
 import {getCurrentRoute} from 'lib/routes/helpers'
 import {shareUrl} from 'lib/sharing'
 import {toShareUrl} from 'lib/strings/url-helpers'
@@ -124,8 +124,6 @@ let PostDropdownBtn = ({
   const hideReplyConfirmControl = useDialogControl()
   const {mutateAsync: toggleReplyVisibility} =
     useToggleReplyVisibilityMutation()
-  const {uris: hiddenReplies, recentlyUnhiddenUris} =
-    useThreadgateHiddenReplyUris()
 
   const postUri = post.uri
   const postCid = post.cid
@@ -147,10 +145,10 @@ let PostDropdownBtn = ({
   const isPostHidden = hiddenPosts && hiddenPosts.includes(postUri)
   const isAuthor = postAuthor.did === currentAccount?.did
   const isRootPostAuthor = new AtUri(rootUri).host === currentAccount?.did
-  const isReplyHiddenByThreadgate =
-    hiddenReplies.has(postUri) ||
-    (!recentlyUnhiddenUris.has(postUri) &&
-      threadgateRecord?.hiddenReplies?.includes(postUri))
+  const threadgateHiddenReplies = useMergedThreadgateHiddenReplies({
+    threadgateRecord,
+  })
+  const isReplyHiddenByThreadgate = threadgateHiddenReplies.has(postUri)
 
   const {mutateAsync: toggleQuoteDetachment, isPending} =
     useToggleQuoteDetachmentMutation()


### PR DESCRIPTION
### Relies on https://github.com/bluesky-social/atproto/pull/2737

Merges local hidden reply cache (specific to user) with initially hydrated threadgate record, if we have it. Uses that as the source of truth for rendering logic.

Integrates new app view PR that returns `threadgate` on the `getPostThread` response, so that we always have an initial record to hydrate from, if it exists.

Clarifies relationship, so that only OP sees labels.