### PR TITLE
Submit fix

### DIFF
--- a/src/components/hooks/useThrottledValue.ts
+++ b/src/components/hooks/useThrottledValue.ts
@@ -2,7 +2,7 @@ import {useEffect, useRef, useState} from 'react'
 
 import {useNonReactiveCallback} from '#/lib/hooks/useNonReactiveCallback'
 
-export function useThrottledValue<T>(value: T, time?: number) {
+export function useThrottledValue<T>(value: T, time: number) {
   const pendingValueRef = useRef(value)
   const [throttledValue, setThrottledValue] = useState(value)
 

--- a/src/screens/Signup/StepCaptcha/index.tsx
+++ b/src/screens/Signup/StepCaptcha/index.tsx
@@ -41,7 +41,11 @@ export function StepCaptcha() {
     (code: string) => {
       setCompleted(true)
       logEvent('signup:captchaSuccess', {})
-      dispatch({type: 'submit', code})
+      const submitTask = {code, mutableProcessed: false}
+      dispatch({
+        type: 'submit',
+        task: submitTask,
+      })
     },
     [dispatch],
   )

--- a/src/screens/Signup/StepCaptcha/index.tsx
+++ b/src/screens/Signup/StepCaptcha/index.tsx
@@ -8,7 +8,7 @@ import {createFullHandle} from '#/lib/strings/handles'
 import {logger} from '#/logger'
 import {logEvent} from 'lib/statsig/statsig'
 import {ScreenTransition} from '#/screens/Login/ScreenTransition'
-import {useSignupContext, useSubmitSignup} from '#/screens/Signup/state'
+import {useSignupContext} from '#/screens/Signup/state'
 import {CaptchaWebView} from '#/screens/Signup/StepCaptcha/CaptchaWebView'
 import {atoms as a, useTheme} from '#/alf'
 import {FormError} from '#/components/forms/FormError'
@@ -20,7 +20,6 @@ export function StepCaptcha() {
   const {_} = useLingui()
   const theme = useTheme()
   const {state, dispatch} = useSignupContext()
-  const submit = useSubmitSignup({state, dispatch})
 
   const [completed, setCompleted] = React.useState(false)
 
@@ -42,9 +41,9 @@ export function StepCaptcha() {
     (code: string) => {
       setCompleted(true)
       logEvent('signup:captchaSuccess', {})
-      submit(code)
+      dispatch({type: 'submit', code})
     },
-    [submit],
+    [dispatch],
   )
 
   const onError = React.useCallback(

--- a/src/screens/Signup/StepHandle.tsx
+++ b/src/screens/Signup/StepHandle.tsx
@@ -10,6 +10,7 @@ import {ScreenTransition} from '#/screens/Login/ScreenTransition'
 import {useSignupContext} from '#/screens/Signup/state'
 import {atoms as a, useTheme} from '#/alf'
 import * as TextField from '#/components/forms/TextField'
+import {useThrottledValue} from '#/components/hooks/useThrottledValue'
 import {At_Stroke2_Corner0_Rounded as At} from '#/components/icons/At'
 import {Check_Stroke2_Corner0_Rounded as Check} from '#/components/icons/Check'
 import {TimesLarge_Stroke2_Corner0_Rounded as Times} from '#/components/icons/Times'
@@ -23,6 +24,7 @@ export function StepHandle() {
   const agent = useAgent()
   const handleValueRef = useRef<string>(state.handle)
   const [draftValue, setDraftValue] = React.useState(state.handle)
+  const isLoading = useThrottledValue(state.isLoading)
 
   const onNextPress = React.useCallback(async () => {
     const handle = handleValueRef.current.trim()
@@ -174,7 +176,7 @@ export function StepHandle() {
         )}
       </View>
       <BackNextButtons
-        isLoading={state.isLoading}
+        isLoading={isLoading}
         isNextDisabled={!validCheck.overall}
         onBackPress={onBackPress}
         onNextPress={onNextPress}

--- a/src/screens/Signup/StepHandle.tsx
+++ b/src/screens/Signup/StepHandle.tsx
@@ -24,7 +24,7 @@ export function StepHandle() {
   const agent = useAgent()
   const handleValueRef = useRef<string>(state.handle)
   const [draftValue, setDraftValue] = React.useState(state.handle)
-  const isLoading = useThrottledValue(state.isLoading)
+  const isLoading = useThrottledValue(state.isLoading, 500)
 
   const onNextPress = React.useCallback(async () => {
     const handle = handleValueRef.current.trim()

--- a/src/screens/Signup/StepHandle.tsx
+++ b/src/screens/Signup/StepHandle.tsx
@@ -63,7 +63,8 @@ export function StepHandle() {
     })
     // phoneVerificationRequired is actually whether a captcha is required
     if (!state.serviceDescription?.phoneVerificationRequired) {
-      dispatch({type: 'submit', code: undefined})
+      const submitTask = {code: undefined, mutableProcessed: false}
+      dispatch({type: 'submit', task: submitTask})
       return
     }
     dispatch({type: 'next'})

--- a/src/screens/Signup/StepHandle.tsx
+++ b/src/screens/Signup/StepHandle.tsx
@@ -7,7 +7,7 @@ import {logEvent} from '#/lib/statsig/statsig'
 import {createFullHandle, validateHandle} from '#/lib/strings/handles'
 import {useAgent} from '#/state/session'
 import {ScreenTransition} from '#/screens/Login/ScreenTransition'
-import {useSignupContext, useSubmitSignup} from '#/screens/Signup/state'
+import {useSignupContext} from '#/screens/Signup/state'
 import {atoms as a, useTheme} from '#/alf'
 import * as TextField from '#/components/forms/TextField'
 import {At_Stroke2_Corner0_Rounded as At} from '#/components/icons/At'
@@ -20,7 +20,6 @@ export function StepHandle() {
   const {_} = useLingui()
   const t = useTheme()
   const {state, dispatch} = useSignupContext()
-  const submit = useSubmitSignup({state, dispatch})
   const agent = useAgent()
   const handleValueRef = useRef<string>(state.handle)
   const [draftValue, setDraftValue] = React.useState(state.handle)
@@ -64,7 +63,7 @@ export function StepHandle() {
     })
     // phoneVerificationRequired is actually whether a captcha is required
     if (!state.serviceDescription?.phoneVerificationRequired) {
-      submit()
+      dispatch({type: 'submit', code: null})
       return
     }
     dispatch({type: 'next'})
@@ -74,7 +73,6 @@ export function StepHandle() {
     state.activeStep,
     state.serviceDescription?.phoneVerificationRequired,
     state.userDomain,
-    submit,
     agent,
   ])
 

--- a/src/screens/Signup/StepHandle.tsx
+++ b/src/screens/Signup/StepHandle.tsx
@@ -63,7 +63,7 @@ export function StepHandle() {
     })
     // phoneVerificationRequired is actually whether a captcha is required
     if (!state.serviceDescription?.phoneVerificationRequired) {
-      dispatch({type: 'submit', code: null})
+      dispatch({type: 'submit', code: undefined})
       return
     }
     dispatch({type: 'next'})

--- a/src/screens/Signup/index.tsx
+++ b/src/screens/Signup/index.tsx
@@ -16,6 +16,7 @@ import {
   reducer,
   SignupContext,
   SignupStep,
+  useSubmitSignup,
 } from '#/screens/Signup/state'
 import {StepCaptcha} from '#/screens/Signup/StepCaptcha'
 import {StepHandle} from '#/screens/Signup/StepHandle'
@@ -33,6 +34,7 @@ export function Signup({onPressBack}: {onPressBack: () => void}) {
   const {screen} = useAnalytics()
   const [state, dispatch] = React.useReducer(reducer, initialState)
   const {gtMobile} = useBreakpoints()
+  const submit = useSubmitSignup()
 
   const activeStarterPack = useActiveStarterPack()
   const {
@@ -80,6 +82,15 @@ export function Signup({onPressBack}: {onPressBack: () => void}) {
       dispatch({type: 'setError', value: ''})
     }
   }, [_, serviceInfo, isError])
+
+  React.useEffect(() => {
+    if (state.pendingSubmit) {
+      if (!state.pendingSubmit.mutableProcessed) {
+        state.pendingSubmit.mutableProcessed = true
+        submit(state, dispatch)
+      }
+    }
+  }, [state, dispatch, submit])
 
   return (
     <SignupContext.Provider value={{state, dispatch}}>

--- a/src/screens/Signup/state.ts
+++ b/src/screens/Signup/state.ts
@@ -41,6 +41,8 @@ export type SignupState = {
 
   error: string
   isLoading: boolean
+
+  pendingSubmit: null | {code: string | undefined; mutableProcessed: boolean}
 }
 
 export type SignupAction =
@@ -58,6 +60,7 @@ export type SignupAction =
   | {type: 'setVerificationCode'; value: string}
   | {type: 'setError'; value: string}
   | {type: 'setIsLoading'; value: boolean}
+  | {type: 'submit'; code: string | undefined}
 
 export const initialState: SignupState = {
   hasPrev: false,
@@ -74,6 +77,8 @@ export const initialState: SignupState = {
 
   error: '',
   isLoading: false,
+
+  pendingSubmit: null,
 }
 
 export function is13(date: Date) {
@@ -149,6 +154,10 @@ export function reducer(s: SignupState, a: SignupAction): SignupState {
       next.error = a.value
       break
     }
+    case 'submit': {
+      next.pendingSubmit = {code: a.code, mutableProcessed: false}
+      break
+    }
   }
 
   next.hasPrev = next.activeStep !== SignupStep.INFO
@@ -169,19 +178,17 @@ interface IContext {
 export const SignupContext = React.createContext<IContext>({} as IContext)
 export const useSignupContext = () => React.useContext(SignupContext)
 
-export function useSubmitSignup({
-  state,
-  dispatch,
-}: {
-  state: SignupState
-  dispatch: (action: SignupAction) => void
-}) {
+export function useSubmitSignup() {
   const {_} = useLingui()
   const {createAccount} = useSessionApi()
   const onboardingDispatch = useOnboardingDispatch()
 
   return useCallback(
-    async (verificationCode?: string) => {
+    async (
+      state: SignupState,
+      dispatch: (action: SignupAction) => void,
+      verificationCode?: string,
+    ) => {
       if (!state.email) {
         dispatch({type: 'setStep', value: SignupStep.INFO})
         return dispatch({
@@ -270,19 +277,6 @@ export function useSubmitSignup({
         dispatch({type: 'setIsLoading', value: false})
       }
     },
-    [
-      state.email,
-      state.password,
-      state.handle,
-      state.serviceDescription?.phoneVerificationRequired,
-      state.serviceUrl,
-      state.userDomain,
-      state.inviteCode,
-      state.dateOfBirth,
-      dispatch,
-      _,
-      onboardingDispatch,
-      createAccount,
-    ],
+    [_, onboardingDispatch, createAccount],
   )
 }

--- a/src/screens/Signup/state.ts
+++ b/src/screens/Signup/state.ts
@@ -26,6 +26,11 @@ export enum SignupStep {
   CAPTCHA,
 }
 
+type SubmitTask = {
+  code: string | undefined
+  mutableProcessed: boolean // OK to mutate assuming it's never read in render.
+}
+
 export type SignupState = {
   hasPrev: boolean
   activeStep: SignupStep
@@ -42,7 +47,7 @@ export type SignupState = {
   error: string
   isLoading: boolean
 
-  pendingSubmit: null | {code: string | undefined; mutableProcessed: boolean}
+  pendingSubmit: null | SubmitTask
 }
 
 export type SignupAction =
@@ -60,7 +65,7 @@ export type SignupAction =
   | {type: 'setVerificationCode'; value: string}
   | {type: 'setError'; value: string}
   | {type: 'setIsLoading'; value: boolean}
-  | {type: 'submit'; code: string | undefined}
+  | {type: 'submit'; task: SubmitTask}
 
 export const initialState: SignupState = {
   hasPrev: false,
@@ -155,7 +160,7 @@ export function reducer(s: SignupState, a: SignupAction): SignupState {
       break
     }
     case 'submit': {
-      next.pendingSubmit = {code: a.code, mutableProcessed: false}
+      next.pendingSubmit = a.task
       break
     }
   }


### PR DESCRIPTION
The closure was reading a stale value of `state` because it has not been updated by this point yet. To fix this, we need to let the reducer run first. Then in an effect we can run the `signup` function with fresh state.

## Test Plan

Go through the registration flow, confirm can still go through the captcha step.

Confirm that in local dev environment, the handle no longer is reported as invalid on first attempt.