### PR TITLE
Hide back button in my profile

### DIFF
--- a/src/Navigation.tsx
+++ b/src/Navigation.tsx
@@ -490,6 +490,7 @@ function MyProfileTabNavigator() {
         getComponent={() => ProfileScreen}
         initialParams={{
           name: 'me',
+          hideBackButton: true,
         }}
       />
       {commonScreens(MyProfileTab as typeof HomeTab)}


### PR DESCRIPTION
Hello,

For some reason, I find the back button in my profile tab very annoying. I don't think it's necessary because you can go back by clicking any other tab button. I've never seen this pattern before.

Is this expected behavior? If so, please feel free to ignore this PR.

Before:


https://github.com/user-attachments/assets/3fc63f0a-d545-4f29-bf3d-f444e334aa6b

After:


https://github.com/user-attachments/assets/d602e620-2d2c-4f82-b794-6dd2647c3961

