### PR TITLE
Improve localization

### DIFF
--- a/src/components/StarterPack/QrCode.tsx
+++ b/src/components/StarterPack/QrCode.tsx
@@ -59,20 +59,24 @@ export const QrCode = React.forwardRef<ViewShot, Props>(function QrCode(
             <QrCodeInner link={link} />
           </View>
 
-          <View style={[a.flex_row, a.align_center, {gap: 5}]}>
-            <Text
-              style={[
-                a.font_bold,
-                a.text_center,
-                {color: 'white', fontSize: 18},
-              ]}>
-              <Trans>on</Trans>
-            </Text>
-            <Logo width={26} fill="white" />
-            <View style={[{marginTop: 5, marginLeft: 2.5}]}>
-              <Logotype width={68} fill="white" />
-            </View>
-          </View>
+          <Text
+            style={[
+              a.flex,
+              a.flex_row,
+              a.align_center,
+              a.font_bold,
+              {color: 'white', fontSize: 18, gap: 6},
+            ]}>
+            <Trans>
+              on
+              <View style={[a.flex_row, a.align_center, {gap: 6}]}>
+                <Logo width={25} fill="white" />
+                <View style={[{marginTop: 3.5}]}>
+                  <Logotype width={72} fill="white" />
+                </View>
+              </View>
+            </Trans>
+          </Text>
         </View>
       </LinearGradientBackground>
     </ViewShot>

--- a/src/lib/generate-starterpack.ts
+++ b/src/lib/generate-starterpack.ts
@@ -65,7 +65,6 @@ export function useGenerateStarterPackMutation({
 }) {
   const {_} = useLingui()
   const agent = useAgent()
-  const starterPackString = _(msg`Starter Pack`)
 
   return useMutation<{uri: string; cid: string}, Error, void>({
     mutationFn: async () => {
@@ -106,7 +105,7 @@ export function useGenerateStarterPackMutation({
         25,
         true,
       )
-      const starterPackName = `${displayName}'s ${starterPackString}`
+      const starterPackName = _(msg`${displayName}'s Starter Pack`)
 
       const list = await createStarterPackList({
         name: starterPackName,


### PR DESCRIPTION
* Improves localization of starter pack names when automatically creating starter packs.
* Improves localization of `on Bluesky` at the bottom of the QR code sharing screen in the starter pack. Allows the string to be positioned after the logo.