### PR TITLE
Remove logging of following prefs

### DIFF
--- a/src/lib/statsig/events.ts
+++ b/src/lib/statsig/events.ts
@@ -216,12 +216,6 @@ export type LogEvents = {
 
   'profile:header:suggestedFollowsCard:press': {}
 
-  'debug:followingPrefs': {
-    followingShowRepliesFromPref: 'all' | 'following' | 'off'
-    followingRepliesMinLikePref: number
-  }
-  'debug:followingDisplayed': {}
-
   'test:all:always': {}
   'test:all:sometimes': {}
   'test:all:boosted_by_gate1': {reason: 'base' | 'gate1'}

--- a/src/view/screens/Home.tsx
+++ b/src/view/screens/Home.tsx
@@ -10,7 +10,7 @@ import {logEvent, LogEvents} from '#/lib/statsig/statsig'
 import {useGate} from '#/lib/statsig/statsig'
 import {emitSoftReset} from '#/state/events'
 import {SavedFeedSourceInfo, usePinnedFeedsInfos} from '#/state/queries/feed'
-import {FeedDescriptor, FeedParams} from '#/state/queries/post-feed'
+import {FeedParams} from '#/state/queries/post-feed'
 import {usePreferencesQuery} from '#/state/queries/preferences'
 import {UsePreferencesQueryResponse} from '#/state/queries/preferences/types'
 import {useSession} from '#/state/session'
@@ -110,30 +110,6 @@ function HomeScreenReady({
     }
   }, [selectedIndex])
 
-  // Temporary, remove when finished debugging
-  const debugHasLoggedFollowingPrefs = React.useRef(false)
-  const debugLogFollowingPrefs = React.useCallback(
-    (feed: FeedDescriptor) => {
-      if (debugHasLoggedFollowingPrefs.current) return
-      if (feed !== 'following') return
-      logEvent('debug:followingPrefs', {
-        followingShowRepliesFromPref: preferences.feedViewPrefs.hideReplies
-          ? 'off'
-          : preferences.feedViewPrefs.hideRepliesByUnfollowed
-          ? 'following'
-          : 'all',
-        followingRepliesMinLikePref:
-          preferences.feedViewPrefs.hideRepliesByLikeCount,
-      })
-      debugHasLoggedFollowingPrefs.current = true
-    },
-    [
-      preferences.feedViewPrefs.hideReplies,
-      preferences.feedViewPrefs.hideRepliesByLikeCount,
-      preferences.feedViewPrefs.hideRepliesByUnfollowed,
-    ],
-  )
-
   const {hasSession} = useSession()
   const setMinimalShellMode = useSetMinimalShellMode()
   const setDrawerSwipeDisabled = useSetDrawerSwipeDisabled()
@@ -162,7 +138,6 @@ function HomeScreenReady({
           feedUrl: selectedFeed,
           reason: 'focus',
         })
-        debugLogFollowingPrefs(selectedFeed)
       }
     }),
   )
@@ -213,9 +188,8 @@ function HomeScreenReady({
         feedUrl: feed,
         reason,
       })
-      debugLogFollowingPrefs(feed)
     },
-    [allFeeds, debugLogFollowingPrefs],
+    [allFeeds],
   )
 
   const onPressSelected = React.useCallback(() => {


### PR DESCRIPTION
We don't need to log these anymore so let's stop sending events.

(We can still do cohort analysis using events from the past.)

## Test Plan

Verify Following feed loads, verify can switch between feeds.