### PR TITLE
Fix language filtering for feeds

### DIFF
--- a/src/lib/api/feed-manip.ts
+++ b/src/lib/api/feed-manip.ts
@@ -392,27 +392,22 @@ export class FeedTuner {
       slices: FeedViewPostsSlice[],
       _dryRun: boolean,
     ): FeedViewPostsSlice[] => {
-      const candidateSlices = slices.slice()
-
       // early return if no languages have been specified
       if (!preferredLangsCode2.length || preferredLangsCode2.length === 0) {
         return slices
       }
 
-      for (let i = 0; i < slices.length; i++) {
+      const candidateSlices = slices.filter(slice => {
         let hasPreferredLang = false
-        for (const item of slices[i].items) {
+        for (const item of slice.items) {
           if (isPostInLanguage(item.post, preferredLangsCode2)) {
             hasPreferredLang = true
             break
           }
         }
-
         // if item does not fit preferred language, remove it
-        if (!hasPreferredLang) {
-          candidateSlices.splice(i, 1)
-        }
-      }
+        return hasPreferredLang
+      })
 
       // if the language filter cleared out the entire page, return the original set
       // so that something always shows

--- a/src/lib/api/feed-manip.ts
+++ b/src/lib/api/feed-manip.ts
@@ -398,15 +398,13 @@ export class FeedTuner {
       }
 
       const candidateSlices = slices.filter(slice => {
-        let hasPreferredLang = false
         for (const item of slice.items) {
           if (isPostInLanguage(item.post, preferredLangsCode2)) {
-            hasPreferredLang = true
-            break
+            return true
           }
         }
         // if item does not fit preferred language, remove it
-        return hasPreferredLang
+        return false
       })
 
       // if the language filter cleared out the entire page, return the original set


### PR DESCRIPTION
I broke this during a refactor — it was not ok to change iteration direction here. This is confusing enough that IMO we should just do a `filter`, especially given that we already clone the array anyway.

## Before

![Screenshot 2024-08-29 at 20 05 02](https://github.com/user-attachments/assets/36f83cec-1341-42c4-b741-3ca209b46906)

## After

![Screenshot 2024-08-29 at 20 05 11](https://github.com/user-attachments/assets/d0ab490c-97ac-400c-b0c7-0de58958d711)
