### PR TITLE
Force at least one item to always be initially rendered

### DIFF
--- a/src/lib/hooks/useInitialNumToRender.ts
+++ b/src/lib/hooks/useInitialNumToRender.ts
@@ -15,5 +15,10 @@ export function useInitialNumToRender({
 
   const finalHeight =
     screenHeight - screenHeightOffset - topInset - bottomBarHeight
-  return Math.floor(finalHeight / minItemHeight) + 1
+
+  const minItems = Math.floor(finalHeight / minItemHeight)
+  if (minItems < 1) {
+    return 1
+  }
+  return minItems
 }


### PR DESCRIPTION
If the user's font size is too large, the current logic might return a value of 0 (Math.floor will give us -1 then add 1 for 0). Let's force it to always be at least 1.