### PR TITLE
[Experiment] Suggest profiles in profile

### DIFF
--- a/src/components/FeedInterstitials.tsx
+++ b/src/components/FeedInterstitials.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import {View} from 'react-native'
 import {ScrollView} from 'react-native-gesture-handler'
-import {AppBskyFeedDefs, AtUri} from '@atproto/api'
+import {AppBskyActorDefs, AppBskyFeedDefs, AtUri} from '@atproto/api'
 import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 import {useNavigation} from '@react-navigation/native'
@@ -12,7 +12,9 @@ import {logEvent} from '#/lib/statsig/statsig'
 import {logger} from '#/logger'
 import {useModerationOpts} from '#/state/preferences/moderation-opts'
 import {useGetPopularFeedsQuery} from '#/state/queries/feed'
+import {FeedDescriptor} from '#/state/queries/post-feed'
 import {useProfilesQuery} from '#/state/queries/profile'
+import {useSuggestedFollowsByActorQuery} from '#/state/queries/suggested-follows'
 import {useSession} from '#/state/session'
 import {useProgressGuide} from '#/state/shell/progress-guide'
 import * as userActionHistory from '#/state/userActionHistory'
@@ -173,14 +175,59 @@ function useExperimentalSuggestedUsersQuery() {
   }
 }
 
-export function SuggestedFollows() {
-  const t = useTheme()
-  const {_} = useLingui()
+export function SuggestedFollows({feed}: {feed: FeedDescriptor}) {
+  const [feedType, feedUri] = feed.split('|')
+  if (feedType === 'author') {
+    return <SuggestedFollowsProfile did={feedUri} />
+  } else {
+    return <SuggestedFollowsHome />
+  }
+}
+
+export function SuggestedFollowsProfile({did}: {did: string}) {
+  const {
+    isLoading: isSuggestionsLoading,
+    data,
+    error,
+  } = useSuggestedFollowsByActorQuery({
+    did,
+  })
+  return (
+    <ProfileGrid
+      isSuggestionsLoading={isSuggestionsLoading}
+      profiles={data?.suggestions ?? []}
+      error={error}
+    />
+  )
+}
+
+export function SuggestedFollowsHome() {
   const {
     isLoading: isSuggestionsLoading,
     profiles,
     error,
   } = useExperimentalSuggestedUsersQuery()
+  return (
+    <ProfileGrid
+      isSuggestionsLoading={isSuggestionsLoading}
+      profiles={profiles}
+      error={error}
+    />
+  )
+}
+
+export function ProfileGrid({
+  isSuggestionsLoading,
+  error,
+  profiles,
+}: {
+  isSuggestionsLoading: boolean
+  profiles: AppBskyActorDefs.ProfileViewDetailed[]
+  error: Error | null
+}) {
+  const t = useTheme()
+  const {_} = useLingui()
+
   const moderationOpts = useModerationOpts()
   const navigation = useNavigation<NavigationProp>()
   const {gtMobile} = useBreakpoints()

--- a/src/components/FeedInterstitials.tsx
+++ b/src/components/FeedInterstitials.tsx
@@ -233,7 +233,6 @@ export function ProfileGrid({
 }) {
   const t = useTheme()
   const {_} = useLingui()
-
   const moderationOpts = useModerationOpts()
   const navigation = useNavigation<NavigationProp>()
   const {gtMobile} = useBreakpoints()

--- a/src/components/FeedInterstitials.tsx
+++ b/src/components/FeedInterstitials.tsx
@@ -8,6 +8,7 @@ import {useNavigation} from '@react-navigation/native'
 
 import {useWebMediaQueries} from '#/lib/hooks/useWebMediaQueries'
 import {NavigationProp} from '#/lib/routes/types'
+import {useGate} from '#/lib/statsig/statsig'
 import {logEvent} from '#/lib/statsig/statsig'
 import {logger} from '#/logger'
 import {useModerationOpts} from '#/state/preferences/moderation-opts'
@@ -176,9 +177,14 @@ function useExperimentalSuggestedUsersQuery() {
 }
 
 export function SuggestedFollows({feed}: {feed: FeedDescriptor}) {
+  const gate = useGate()
   const [feedType, feedUri] = feed.split('|')
   if (feedType === 'author') {
-    return <SuggestedFollowsProfile did={feedUri} />
+    if (gate('show_follow_suggestions_in_profile')) {
+      return <SuggestedFollowsProfile did={feedUri} />
+    } else {
+      return null
+    }
   } else {
     return <SuggestedFollowsHome />
   }

--- a/src/lib/statsig/gates.ts
+++ b/src/lib/statsig/gates.ts
@@ -4,5 +4,6 @@ export type Gate =
   | 'fixed_bottom_bar'
   | 'onboarding_minimum_interests'
   | 'suggested_feeds_interstitial'
+  | 'show_follow_suggestions_in_profile'
   | 'video_debug'
   | 'videos'

--- a/src/screens/Profile/Header/ProfileHeaderStandard.tsx
+++ b/src/screens/Profile/Header/ProfileHeaderStandard.tsx
@@ -10,6 +10,7 @@ import {FontAwesomeIcon} from '@fortawesome/react-native-fontawesome'
 import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
+import {useGate} from '#/lib/statsig/statsig'
 import {logger} from '#/logger'
 import {isIOS} from '#/platform/detection'
 import {Shadow} from '#/state/cache/types'
@@ -59,6 +60,7 @@ let ProfileHeaderStandard = ({
   const profile: Shadow<AppBskyActorDefs.ProfileViewDetailed> =
     useProfileShadow(profileUnshadowed)
   const t = useTheme()
+  const gate = useGate()
   const {currentAccount, hasSession} = useSession()
   const {_} = useLingui()
   const {openModal} = useModalControls()
@@ -203,27 +205,29 @@ let ProfileHeaderStandard = ({
               {hasSession && (
                 <>
                   <MessageProfileButton profile={profile} />
-                  <Button
-                    testID="suggestedFollowsBtn"
-                    size="small"
-                    color={showSuggestedFollows ? 'primary' : 'secondary'}
-                    variant="solid"
-                    shape="round"
-                    onPress={() =>
-                      setShowSuggestedFollows(!showSuggestedFollows)
-                    }
-                    label={_(msg`Show follows similar to ${profile.handle}`)}
-                    style={{width: 36, height: 36}}>
-                    <FontAwesomeIcon
-                      icon="user-plus"
-                      style={
-                        showSuggestedFollows
-                          ? {color: t.palette.white}
-                          : t.atoms.text
+                  {!gate('show_follow_suggestions_in_profile') && (
+                    <Button
+                      testID="suggestedFollowsBtn"
+                      size="small"
+                      color={showSuggestedFollows ? 'primary' : 'secondary'}
+                      variant="solid"
+                      shape="round"
+                      onPress={() =>
+                        setShowSuggestedFollows(!showSuggestedFollows)
                       }
-                      size={14}
-                    />
-                  </Button>
+                      label={_(msg`Show follows similar to ${profile.handle}`)}
+                      style={{width: 36, height: 36}}>
+                      <FontAwesomeIcon
+                        icon="user-plus"
+                        style={
+                          showSuggestedFollows
+                            ? {color: t.palette.white}
+                            : t.atoms.text
+                        }
+                        size={14}
+                      />
+                    </Button>
+                  )}
                 </>
               )}
 

--- a/src/view/com/posts/Feed.tsx
+++ b/src/view/com/posts/Feed.tsx
@@ -194,8 +194,6 @@ let Feed = ({
   const checkForNewRef = React.useRef<(() => void) | null>(null)
   const lastFetchRef = React.useRef<number>(Date.now())
   const [feedType, feedUri] = feed.split('|')
-  const feedIsDiscover = feedUri === DISCOVER_FEED_URI
-  const feedIsFollowing = feedType === 'following'
   const gate = useGate()
 
   const opts = React.useMemo(
@@ -339,6 +337,8 @@ let Feed = ({
     }
 
     if (hasSession) {
+      const feedIsDiscover = feedUri === DISCOVER_FEED_URI
+      const feedIsFollowing = feedType === 'following'
       const feedKind = feedIsFollowing
         ? 'following'
         : feedIsDiscover
@@ -377,9 +377,8 @@ let Feed = ({
     isEmpty,
     lastFetchedAt,
     data,
+    feedType,
     feedUri,
-    feedIsDiscover,
-    feedIsFollowing,
     gate,
     hasSession,
   ])

--- a/src/view/com/posts/Feed.tsx
+++ b/src/view/com/posts/Feed.tsx
@@ -339,14 +339,14 @@ let Feed = ({
     }
 
     if (hasSession) {
-      const feedType = feedIsFollowing
+      const feedKind = feedIsFollowing
         ? 'following'
         : feedIsDiscover
         ? 'discover'
         : undefined
 
-      if (feedType) {
-        for (const interstitial of interstials[feedType]) {
+      if (feedKind) {
+        for (const interstitial of interstials[feedKind]) {
           const shouldShow =
             (interstitial.type === feedInterstitialType &&
               gate('suggested_feeds_interstitial')) ||

--- a/src/view/com/posts/Feed.tsx
+++ b/src/view/com/posts/Feed.tsx
@@ -337,13 +337,12 @@ let Feed = ({
     }
 
     if (hasSession) {
-      const feedIsDiscover = feedUri === DISCOVER_FEED_URI
-      const feedIsFollowing = feedType === 'following'
-      const feedKind = feedIsFollowing
-        ? 'following'
-        : feedIsDiscover
-        ? 'discover'
-        : undefined
+      const feedKind =
+        feedType === 'following'
+          ? 'following'
+          : feedUri === DISCOVER_FEED_URI
+          ? 'discover'
+          : undefined
 
       if (feedKind) {
         for (const interstitial of interstials[feedKind]) {


### PR DESCRIPTION
A more prominent placement for the profile suggestions since they've gotten better recently. This adds an interstitial to profile feeds (Posts and Replies tabs only).

## Test Plan

Enable the gate. Observe this block after 5 slices:

![Screenshot 2024-08-30 at 02 07 41](https://github.com/user-attachments/assets/050ba83b-2d54-4eb8-a8aa-e8e07038d406)

It should be profile-dependent. Check with different profiles. (Might work better with a fresh account if your cluster follows are already saturated.) Some profiles won't have it (if no suggestions were served). For some accounts you'll see generic suggestions (if we don't know their cluster).

Verify Discover interstitials work like before.