### PR TITLE
[Video] Split 'videos' gate in two

### DIFF
--- a/src/lib/statsig/gates.ts
+++ b/src/lib/statsig/gates.ts
@@ -5,5 +5,6 @@ export type Gate =
   | 'onboarding_minimum_interests'
   | 'suggested_feeds_interstitial'
   | 'show_follow_suggestions_in_profile'
-  | 'video_debug'
-  | 'videos'
+  | 'video_debug' // not recommended
+  | 'video_upload' // upload videos
+  | 'video_view_on_posts' // see posted videos

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -760,7 +760,7 @@ export const ComposePost = observer(function ComposePost({
           ) : (
             <ToolbarWrapper style={[a.flex_row, a.align_center, a.gap_xs]}>
               <SelectPhotoBtn gallery={gallery} disabled={!canSelectImages} />
-              {gate('videos') && (
+              {gate('video_upload') && (
                 <SelectVideoBtn
                   onSelectVideo={selectVideo}
                   disabled={!canSelectImages}

--- a/src/view/com/util/post-embeds/VideoEmbed.tsx
+++ b/src/view/com/util/post-embeds/VideoEmbed.tsx
@@ -31,7 +31,7 @@ export function VideoEmbed({embed}: {embed: AppBskyEmbedVideo.View}) {
   )
   const gate = useGate()
 
-  if (!gate('videos')) {
+  if (!gate('video_view_on_posts')) {
     return null
   }
 

--- a/src/view/com/util/post-embeds/VideoEmbed.web.tsx
+++ b/src/view/com/util/post-embeds/VideoEmbed.web.tsx
@@ -47,7 +47,7 @@ export function VideoEmbed({embed}: {embed: AppBskyEmbedVideo.View}) {
     [key],
   )
 
-  if (!gate('videos')) {
+  if (!gate('video_view_on_posts')) {
     return null
   }
 


### PR DESCRIPTION
Splits the `videos` gate in two - `video_upload` (which is also used in the backend) and `video_view_on_posts`

# Test plan

Cross-reference with statsig and check there's no type errors