### PR TITLE
Mark unhydrated replies as orphaned

### DIFF
--- a/src/lib/api/feed-manip.ts
+++ b/src/lib/api/feed-manip.ts
@@ -81,7 +81,14 @@ export class FeedViewPostsSlice {
       isParentBlocked,
       isParentNotFound,
     })
-    if (!reply || reason) {
+    if (!reply) {
+      if (post.record.reply) {
+        // This reply wasn't properly hydrated by the AppView.
+        this.isOrphan = true
+      }
+      return
+    }
+    if (reason) {
       return
     }
     if (

--- a/src/lib/api/feed-manip.ts
+++ b/src/lib/api/feed-manip.ts
@@ -85,6 +85,7 @@ export class FeedViewPostsSlice {
       if (post.record.reply) {
         // This reply wasn't properly hydrated by the AppView.
         this.isOrphan = true
+        this.items[0].isParentNotFound = true
       }
       return
     }


### PR DESCRIPTION
Noticed this during appview/relay syncing issues.

(This logic existed in the old code but I dropped but because I didn't know why. Now I know.)

If we have `post.record.reply` but we didn't receive a `reply`, something went wrong (i.e. we don't know its parent or root). Let's mark it as orphaned in this case.

This will make it filtered out of Following. On other feeds, it will display as "reply to a post" (so it won't seem top-level).

## Test Plan

Don't know how to force it to happen, but I hardcoded the condition as `true` and verified the above.