### PR TITLE
Show some known OP replies in Following

### DIFF
--- a/src/lib/api/feed-manip.ts
+++ b/src/lib/api/feed-manip.ts
@@ -450,6 +450,11 @@ function shouldDisplayReplyInFollowing(
     // Always show self-threads.
     return true
   }
+  // If the thread is hosted by someone you know,
+  // show it even when the OP replies to someone else.
+  if (rootAuthor && isSelfOrFollowing(rootAuthor, userDid)) {
+    return true
+  }
   // From this point on we need at least one more reason to show it.
   if (
     parentAuthor &&
@@ -462,13 +467,6 @@ function shouldDisplayReplyInFollowing(
     grandparentAuthor &&
     grandparentAuthor.did !== author.did &&
     isSelfOrFollowing(grandparentAuthor, userDid)
-  ) {
-    return true
-  }
-  if (
-    rootAuthor &&
-    rootAuthor.did !== author.did &&
-    isSelfOrFollowing(rootAuthor, userDid)
   ) {
     return true
   }


### PR DESCRIPTION
This adjusts the heuristic to show more replies in Following.

Concretely, replies like `A -> B -> A` or `A -> ... -> B -> A` will now show even if you _only_ follow A (but not B). Previously, they were getting filtered out. Effectively, this means that an OP reply bumps the OP thread if you follow OP — but the condition is that B has to have >0 likes. This would filter out replies that didn't get anyone interested so far.

This doesn't contribute to the snowballing effect because you're _already_ following A anyway.

## Examples

I follow Mark but I don't follow Tim. With the change, this reply shows in Following.

![Screenshot 2024-08-31 at 03 02 27](https://github.com/user-attachments/assets/670e7f7a-a18d-4a12-9ec0-6a845fce7e82)

I follow Joyce but I don't follow David. With the change, this reply shows in Following.

![Screenshot 2024-08-31 at 03 03 48](https://github.com/user-attachments/assets/d6e1349a-ad70-4cc7-a19f-f00669a92ef1)

I follow Jerry but I don't follow Molly. With the change, this reply shows in Following.

![Screenshot 2024-08-31 at 02 59 23](https://github.com/user-attachments/assets/7ffb96d0-9992-4083-a59d-0cefe59db5d1)

## Counter-examples

I follow Megan but this reply would still not show because the parent (whom I don't follow) has no likes.

![Screenshot 2024-08-31 at 03 38 37](https://github.com/user-attachments/assets/7770d63c-99c4-4552-9e61-da7a0d851b64)
