### PR TITLE
fix [5039]: Pasting text into the Bluesky web client post box deletes blank …

### DIFF
--- a/src/view/com/composer/text-input/TextInput.web.tsx
+++ b/src/view/com/composer/text-input/TextInput.web.tsx
@@ -155,13 +155,18 @@ export const TextInput = React.forwardRef(function TextInputImpl(
           let preventDefault = false
 
           if (clipboardData) {
-            if (clipboardData.types.includes('text/html')) {
-              // Rich-text formatting is pasted, try retrieving plain text
-              const text = clipboardData.getData('text/plain')
-              // `pasteText` will invoke this handler again, but `clipboardData` will be null.
-              view.pasteText(text)
-              preventDefault = true
-            }
+            // !! IMPORTANT = NOT NEEDED, TIPTAP DOES IT BY DEFAULT !!
+            //
+            // if (clipboardData.types.includes('text/html')) {
+            //   // Rich-text formatting is pasted, try retrieving plain text
+            //   const text = clipboardData.getData('text/plain')
+
+            //   console.log({text})
+            //   // `pasteText` will invoke this handler again, but `clipboardData` will be null.
+            //   view.pasteText(text)
+            //   preventDefault = true
+            // }
+
             getImageFromUri(clipboardData.items, (uri: string) => {
               textInputWebEmitter.emit('photo-pasted', uri)
             })
@@ -194,6 +199,7 @@ export const TextInput = React.forwardRef(function TextInputImpl(
       },
       onUpdate({editor: editorProp}) {
         const json = editorProp.getJSON()
+
         const newText = editorJsonToText(json)
         const isPaste = window.event?.type === 'paste'
 


### PR DESCRIPTION
fixed the bug of pasting rich formatted text and it removing the white lines

fix this issue: https://github.com/bluesky-social/social-app/issues/5039

<img width="471" alt="Captura de Tela 2024-09-01 às 19 14 17" src="https://github.com/user-attachments/assets/fde04fa5-ea96-4915-a1c5-676672c8ec74">
