### PR TITLE
Make the counter more rounded

### DIFF
--- a/src/view/shell/desktop/LeftNav.tsx
+++ b/src/view/shell/desktop/LeftNav.tsx
@@ -470,7 +470,7 @@ const styles = StyleSheet.create({
     fontSize: 12,
     fontWeight: 'bold',
     paddingHorizontal: 4,
-    borderRadius: 6,
+    borderRadius: 8,
   },
   navItemCountTablet: {
     left: 18,


### PR DESCRIPTION
I hope it wasn't intended design 😨 

Before:
<img width="143" alt="Screenshot 2024-09-02 at 12 28 10" src="https://github.com/user-attachments/assets/6a81a731-aee7-4ab7-bd7c-79a5a8bfb103">

After:
<img width="213" alt="Screenshot 2024-09-02 at 12 32 44" src="https://github.com/user-attachments/assets/cac57c98-bbad-4263-9de0-67ca0dc48aa4">
<img width="173" alt="Screenshot 2024-09-02 at 12 32 48" src="https://github.com/user-attachments/assets/152f1962-6923-4415-83d9-5cd677113bb1">

PS. The circle still isn't perfectly round because the width is half a pixel more than the height. If no one minds, I can make a PR to make it look more like this:
<img width="163" alt="Screenshot 2024-09-02 at 12 22 57" src="https://github.com/user-attachments/assets/f022a032-042e-4a6b-9028-fad999d93c08">

