### PR TITLE
fix [5015]: Accidentally deleting draft post when you mention an account

### DIFF
--- a/src/view/com/composer/text-input/TextInput.web.tsx
+++ b/src/view/com/composer/text-input/TextInput.web.tsx
@@ -245,7 +245,10 @@ export const TextInput = React.forwardRef(function TextInputImpl(
   React.useEffect(() => {
     if (editor) {
       const handleKeyDown = (event: KeyboardEvent) => {
-        if ((event.metaKey || event.ctrlKey) && event.code === 'ArrowLeft') {
+        if (
+          (event.metaKey || event.ctrlKey || event.altKey) &&
+          event.code === 'ArrowLeft'
+        ) {
           const {state, dispatch} = editor.view
           const {selection} = state
           const {$anchor} = selection

--- a/src/view/com/composer/text-input/TextInput.web.tsx
+++ b/src/view/com/composer/text-input/TextInput.web.tsx
@@ -246,7 +246,7 @@ export const TextInput = React.forwardRef(function TextInputImpl(
     if (editor) {
       const handleKeyDown = (event: KeyboardEvent) => {
         if (
-          (event.metaKey || event.ctrlKey || event.altKey) &&
+          (event.metaKey || event.altKey) &&
           event.code === 'ArrowLeft'
         ) {
           const {state, dispatch} = editor.view


### PR DESCRIPTION
Fixed: Accidentally deleting draft post when you mention an account https://github.com/bluesky-social/social-app/issues/5105

This PR fixes the cursor movement functionality to the beginning of the line when the Cmd + ArrowLeft (or Ctrl + ArrowLeft) key combination is pressed. Previously, the behavior was not working as expected due to issues with setting the selection in the editor.

Screenshots:

https://github.com/user-attachments/assets/6e04d5bd-e998-4852-8a67-d8d625456c8a





