### PR TITLE
Add quick access to “Quote” action via long press

### DIFF
--- a/src/view/com/util/post-ctrls/RepostButton.tsx
+++ b/src/view/com/util/post-ctrls/RepostButton.tsx
@@ -53,6 +53,9 @@ let RepostButton = ({
         onPress={() => {
           requireAuth(() => dialogControl.open())
         }}
+        onLongPress={() => {
+          requireAuth(() => onQuote())
+        }}
         style={[
           a.flex_row,
           a.align_center,


### PR DESCRIPTION
This is an established UX pattern/power user shortcut from other social networks. When long pressing the repost button, you bypass the intermediate dialog and are sent straight to the compose screen.