### PR TITLE
Add slight spacing between Post and CW button

### DIFF
--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -560,6 +560,7 @@ export const ComposePost = observer(function ComposePost({
                   onChange={setLabels}
                   hasMedia={hasMedia}
                 />
+                <View style={[styles.spacer]} />
                 {canPost ? (
                   <Button
                     testID="composerPublishBtn"
@@ -1015,6 +1016,9 @@ const styles = StyleSheet.create({
     paddingRight: 16,
     alignItems: 'center',
     borderTopWidth: StyleSheet.hairlineWidth,
+  },
+  spacer: {
+    width: 6,
   },
 })
 

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -554,13 +554,12 @@ export const ComposePost = observer(function ComposePost({
                 </View>
               </>
             ) : (
-              <>
+              <View style={[styles.postBtnWrapper]}>
                 <LabelsBtn
                   labels={labels}
                   onChange={setLabels}
                   hasMedia={hasMedia}
                 />
-                <View style={[styles.spacer]} />
                 {canPost ? (
                   <Button
                     testID="composerPublishBtn"
@@ -591,7 +590,7 @@ export const ComposePost = observer(function ComposePost({
                     </Text>
                   </View>
                 )}
-              </>
+              </View>
             )}
           </View>
 
@@ -959,6 +958,10 @@ const styles = StyleSheet.create({
     paddingVertical: 6,
     marginLeft: 12,
   },
+  postBtnWrapper: {
+    flexDirection: 'row',
+    gap: 14,
+  },
   errorLine: {
     flexDirection: 'row',
     alignItems: 'center',
@@ -1016,9 +1019,6 @@ const styles = StyleSheet.create({
     paddingRight: 16,
     alignItems: 'center',
     borderTopWidth: StyleSheet.hairlineWidth,
-  },
-  spacer: {
-    width: 6,
   },
 })
 


### PR DESCRIPTION
Found it easy to hit the wrong button by accident since they are so close... This PR adds a slight gap between them to help prevent someone accidentally hitting “Post” when they want to add a CW first.

Before / After

<img src="https://github.com/user-attachments/assets/4d5ebe57-2425-49a5-ada2-d5451575a06e" width="300">
<img src="https://github.com/user-attachments/assets/e5ba933f-5165-4ffd-9cff-2aa4ec23b3f2" width="300">
