### PR TITLE
Fix number formatting for non-English locales

### DIFF
--- a/src/locale/i18n.ts
+++ b/src/locale/i18n.ts
@@ -37,82 +37,130 @@ export async function dynamicActivate(locale: AppLanguage) {
   switch (locale) {
     case AppLanguage.ca: {
       i18n.loadAndActivate({locale, messages: messagesCa})
-      await import('@formatjs/intl-pluralrules/locale-data/ca')
+      await Promise.all([
+        import('@formatjs/intl-pluralrules/locale-data/ca'),
+        import('@formatjs/intl-numberformat/locale-data/ca'),
+      ])
       break
     }
     case AppLanguage.de: {
       i18n.loadAndActivate({locale, messages: messagesDe})
-      await import('@formatjs/intl-pluralrules/locale-data/de')
+      await Promise.all([
+        import('@formatjs/intl-pluralrules/locale-data/de'),
+        import('@formatjs/intl-numberformat/locale-data/de'),
+      ])
       break
     }
     case AppLanguage.es: {
       i18n.loadAndActivate({locale, messages: messagesEs})
-      await import('@formatjs/intl-pluralrules/locale-data/es')
+      await Promise.all([
+        import('@formatjs/intl-pluralrules/locale-data/es'),
+        import('@formatjs/intl-numberformat/locale-data/es'),
+      ])
       break
     }
     case AppLanguage.fi: {
       i18n.loadAndActivate({locale, messages: messagesFi})
-      await import('@formatjs/intl-pluralrules/locale-data/fi')
+      await Promise.all([
+        import('@formatjs/intl-pluralrules/locale-data/fi'),
+        import('@formatjs/intl-numberformat/locale-data/fi'),
+      ])
       break
     }
     case AppLanguage.fr: {
       i18n.loadAndActivate({locale, messages: messagesFr})
-      await import('@formatjs/intl-pluralrules/locale-data/fr')
+      await Promise.all([
+        import('@formatjs/intl-pluralrules/locale-data/fr'),
+        import('@formatjs/intl-numberformat/locale-data/fr'),
+      ])
       break
     }
     case AppLanguage.ga: {
       i18n.loadAndActivate({locale, messages: messagesGa})
-      await import('@formatjs/intl-pluralrules/locale-data/ga')
+      await Promise.all([
+        import('@formatjs/intl-pluralrules/locale-data/ga'),
+        import('@formatjs/intl-numberformat/locale-data/ga'),
+      ])
       break
     }
     case AppLanguage.hi: {
       i18n.loadAndActivate({locale, messages: messagesHi})
-      await import('@formatjs/intl-pluralrules/locale-data/hi')
+      await Promise.all([
+        import('@formatjs/intl-pluralrules/locale-data/hi'),
+        import('@formatjs/intl-numberformat/locale-data/hi'),
+      ])
       break
     }
     case AppLanguage.id: {
       i18n.loadAndActivate({locale, messages: messagesId})
-      await import('@formatjs/intl-pluralrules/locale-data/id')
+      await Promise.all([
+        import('@formatjs/intl-pluralrules/locale-data/id'),
+        import('@formatjs/intl-numberformat/locale-data/id'),
+      ])
       break
     }
     case AppLanguage.it: {
       i18n.loadAndActivate({locale, messages: messagesIt})
-      await import('@formatjs/intl-pluralrules/locale-data/it')
+      await Promise.all([
+        import('@formatjs/intl-pluralrules/locale-data/it'),
+        import('@formatjs/intl-numberformat/locale-data/it'),
+      ])
       break
     }
     case AppLanguage.ja: {
       i18n.loadAndActivate({locale, messages: messagesJa})
-      await import('@formatjs/intl-pluralrules/locale-data/ja')
+      await Promise.all([
+        import('@formatjs/intl-pluralrules/locale-data/ja'),
+        import('@formatjs/intl-numberformat/locale-data/ja'),
+      ])
       break
     }
     case AppLanguage.ko: {
       i18n.loadAndActivate({locale, messages: messagesKo})
-      await import('@formatjs/intl-pluralrules/locale-data/ko')
+      await Promise.all([
+        import('@formatjs/intl-pluralrules/locale-data/ko'),
+        import('@formatjs/intl-numberformat/locale-data/ko'),
+      ])
       break
     }
     case AppLanguage.pt_BR: {
       i18n.loadAndActivate({locale, messages: messagesPt_BR})
-      await import('@formatjs/intl-pluralrules/locale-data/pt')
+      await Promise.all([
+        import('@formatjs/intl-pluralrules/locale-data/pt'),
+        import('@formatjs/intl-numberformat/locale-data/pt'),
+      ])
       break
     }
     case AppLanguage.tr: {
       i18n.loadAndActivate({locale, messages: messagesTr})
-      await import('@formatjs/intl-pluralrules/locale-data/tr')
+      await Promise.all([
+        import('@formatjs/intl-pluralrules/locale-data/tr'),
+        import('@formatjs/intl-numberformat/locale-data/tr'),
+      ])
       break
     }
     case AppLanguage.uk: {
       i18n.loadAndActivate({locale, messages: messagesUk})
-      await import('@formatjs/intl-pluralrules/locale-data/uk')
+      await Promise.all([
+        import('@formatjs/intl-pluralrules/locale-data/uk'),
+        import('@formatjs/intl-numberformat/locale-data/uk'),
+      ])
       break
     }
     case AppLanguage.zh_CN: {
       i18n.loadAndActivate({locale, messages: messagesZh_CN})
-      await import('@formatjs/intl-pluralrules/locale-data/zh')
+      await Promise.all([
+        import('@formatjs/intl-pluralrules/locale-data/zh'),
+        import('@formatjs/intl-numberformat/locale-data/zh'),
+      ])
       break
     }
     case AppLanguage.zh_TW: {
       i18n.loadAndActivate({locale, messages: messagesZh_TW})
-      await import('@formatjs/intl-pluralrules/locale-data/zh')
+      await Promise.all([
+        import('@formatjs/intl-pluralrules/locale-data/zh'),
+        import('@formatjs/intl-numberformat/locale-data/zh'),
+      ])
       break
     }
     default: {


### PR DESCRIPTION
Number formatting data was not being loaded along with the pluralization rule data when activating locales. This PR makes it so that numbers are now properly formatted across the different locales.

Before / After

<img src="https://github.com/user-attachments/assets/a0d14d72-6153-4e54-becf-22b9376c5ff6" width="300">
<img src="https://github.com/user-attachments/assets/b5b484a2-9c2f-4664-bf35-68facab72727" width="300">
