### PR TITLE
Constrain image heights in feeds and threads

### DIFF
--- a/assets/icons/crop_stroke2_corner0_rounded.svg
+++ b/assets/icons/crop_stroke2_corner0_rounded.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="#000" fill-rule="evenodd" d="M6 2a1 1 0 0 1 1 1v2h11a1 1 0 0 1 1 1v11h2a1 1 0 1 1 0 2h-2v2a1 1 0 1 1-2 0v-2H6a1 1 0 0 1-1-1V7H3a1 1 0 0 1 0-2h2V3a1 1 0 0 1 1-1Zm1 5v10h10V7H7Z" clip-rule="evenodd"/></svg>

--- a/src/components/dms/MessageItemEmbed.tsx
+++ b/src/components/dms/MessageItemEmbed.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import {View} from 'react-native'
 import {AppBskyEmbedRecord} from '@atproto/api'
 
-import {PostEmbeds} from '#/view/com/util/post-embeds'
+import {PostEmbeds, PostEmbedViewContext} from '#/view/com/util/post-embeds'
 import {atoms as a, native, useTheme} from '#/alf'
 
 let MessageItemEmbed = ({
@@ -14,7 +14,11 @@ let MessageItemEmbed = ({
 
   return (
     <View style={[a.my_xs, t.atoms.bg, native({flexBasis: 0})]}>
-      <PostEmbeds embed={embed} allowNestedQuotes />
+      <PostEmbeds
+        embed={embed}
+        allowNestedQuotes
+        viewContext={PostEmbedViewContext.Feed}
+      />
     </View>
   )
 }

--- a/src/components/icons/Crop.tsx
+++ b/src/components/icons/Crop.tsx
@@ -1,0 +1,5 @@
+import {createSinglePathSVG} from './TEMPLATE'
+
+export const Crop_Stroke2_Corner0_Rounded = createSinglePathSVG({
+  path: 'M6 2a1 1 0 0 1 1 1v2h11a1 1 0 0 1 1 1v11h2a1 1 0 1 1 0 2h-2v2a1 1 0 1 1-2 0v-2H6a1 1 0 0 1-1-1V7H3a1 1 0 0 1 0-2h2V3a1 1 0 0 1 1-1Zm1 5v10h10V7H7Z',
+})

--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -366,7 +366,7 @@ let PostThreadItemLoaded = ({
                   <PostEmbeds
                     embed={post.embed}
                     moderation={moderation}
-                    contextView="thread-highlighted"
+                    viewContext="thread-highlighted"
                   />
                 </View>
               )}

--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -43,7 +43,7 @@ import {ErrorMessage} from '../util/error/ErrorMessage'
 import {Link, TextLink} from '../util/Link'
 import {formatCount} from '../util/numeric/format'
 import {PostCtrls} from '../util/post-ctrls/PostCtrls'
-import {PostEmbeds} from '../util/post-embeds'
+import {PostEmbeds, PostEmbedViewContext} from '../util/post-embeds'
 import {PostMeta} from '../util/PostMeta'
 import {Text} from '../util/text/Text'
 import {PreviewableUserAvatar} from '../util/UserAvatar'
@@ -366,7 +366,7 @@ let PostThreadItemLoaded = ({
                   <PostEmbeds
                     embed={post.embed}
                     moderation={moderation}
-                    viewContext="thread-highlighted"
+                    viewContext={PostEmbedViewContext.ThreadHighlighted}
                   />
                 </View>
               )}
@@ -595,7 +595,11 @@ let PostThreadItemLoaded = ({
               ) : undefined}
               {post.embed && (
                 <View style={[a.pb_xs]}>
-                  <PostEmbeds embed={post.embed} moderation={moderation} />
+                  <PostEmbeds
+                    embed={post.embed}
+                    moderation={moderation}
+                    viewContext={PostEmbedViewContext.Feed}
+                  />
                 </View>
               )}
               <PostCtrls

--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -366,7 +366,7 @@ let PostThreadItemLoaded = ({
                   <PostEmbeds
                     embed={post.embed}
                     moderation={moderation}
-                    isHighlightedThreadItem
+                    contextView="thread-highlighted"
                   />
                 </View>
               )}

--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -363,7 +363,11 @@ let PostThreadItemLoaded = ({
               ) : undefined}
               {post.embed && (
                 <View style={[a.pb_sm]}>
-                  <PostEmbeds embed={post.embed} moderation={moderation} />
+                  <PostEmbeds
+                    embed={post.embed}
+                    moderation={moderation}
+                    isHighlightedThreadItem
+                  />
                 </View>
               )}
             </ContentHider>

--- a/src/view/com/post/Post.tsx
+++ b/src/view/com/post/Post.tsx
@@ -32,7 +32,7 @@ import {LabelsOnMyPost} from '../../../components/moderation/LabelsOnMe'
 import {PostAlerts} from '../../../components/moderation/PostAlerts'
 import {Link, TextLink} from '../util/Link'
 import {PostCtrls} from '../util/post-ctrls/PostCtrls'
-import {PostEmbeds} from '../util/post-embeds'
+import {PostEmbeds, PostEmbedViewContext} from '../util/post-embeds'
 import {PostMeta} from '../util/PostMeta'
 import {Text} from '../util/text/Text'
 import {PreviewableUserAvatar} from '../util/UserAvatar'
@@ -238,7 +238,11 @@ function PostInner({
               />
             ) : undefined}
             {post.embed ? (
-              <PostEmbeds embed={post.embed} moderation={moderation} />
+              <PostEmbeds
+                embed={post.embed}
+                moderation={moderation}
+                viewContext={PostEmbedViewContext.Feed}
+              />
             ) : null}
           </ContentHider>
           <PostCtrls

--- a/src/view/com/posts/FeedItem.tsx
+++ b/src/view/com/posts/FeedItem.tsx
@@ -34,7 +34,7 @@ import {useComposerControls} from '#/state/shell/composer'
 import {useMergedThreadgateHiddenReplies} from '#/state/threadgate-hidden-replies'
 import {FeedNameText} from '#/view/com/util/FeedInfoText'
 import {PostCtrls} from '#/view/com/util/post-ctrls/PostCtrls'
-import {PostEmbeds} from '#/view/com/util/post-embeds'
+import {PostEmbeds, PostEmbedViewContext} from '#/view/com/util/post-embeds'
 import {PostMeta} from '#/view/com/util/PostMeta'
 import {Text} from '#/view/com/util/text/Text'
 import {PreviewableUserAvatar} from '#/view/com/util/UserAvatar'
@@ -488,6 +488,7 @@ let PostContent = ({
             embed={postEmbed}
             moderation={moderation}
             onOpen={onOpenEmbed}
+            viewContext={PostEmbedViewContext.Feed}
           />
         </View>
       ) : null}

--- a/src/view/com/util/images/AutoSizedImage.tsx
+++ b/src/view/com/util/images/AutoSizedImage.tsx
@@ -7,7 +7,10 @@ import {useLingui} from '@lingui/react'
 
 import * as imageSizes from '#/lib/media/image-sizes'
 import {Dimensions} from '#/lib/media/types'
+import {useLargeAltBadgeEnabled} from '#/state/preferences/large-alt-badge'
 import {atoms as a, useTheme} from '#/alf'
+import {Crop_Stroke2_Corner0_Rounded as Crop} from '#/components/icons/Crop'
+import {Text} from '#/components/Typography'
 
 export function useImageAspectRatio({
   src,
@@ -16,9 +19,13 @@ export function useImageAspectRatio({
   src: string
   dimensions: Dimensions | undefined
 }) {
-  const [aspectRatio, setAspectRatio] = React.useState<number>(
+  const [rawAspectRatio, setAspectRatio] = React.useState<number>(
     dimensions ? calc(dimensions) : 1,
   )
+  const aspectRatio = React.useMemo(() => {
+    // max of 3:4 ratio
+    return Math.max(rawAspectRatio, 0.75)
+  }, [rawAspectRatio])
 
   React.useEffect(() => {
     let aborted = false
@@ -34,7 +41,9 @@ export function useImageAspectRatio({
 
   return {
     dimensions,
+    rawAspectRatio,
     aspectRatio,
+    isCropped: rawAspectRatio < aspectRatio,
   }
 }
 
@@ -54,13 +63,6 @@ export function SquareFramedImage({
     const ratio = Math.min(1 / aspectRatio, 1)
     return `${ratio * 100}%`
   }, [aspectRatio])
-  /**
-   * Computed as a CSS `aspectRatio` value
-   */
-  const innerAspectRatio = React.useMemo(() => {
-    // max of 3:4 ratio
-    return Math.max(aspectRatio, 0.75)
-  }, [aspectRatio])
 
   return (
     <View style={[a.w_full]}>
@@ -72,7 +74,7 @@ export function SquareFramedImage({
               a.rounded_sm,
               a.overflow_hidden,
               t.atoms.bg_contrast_25,
-              {aspectRatio: innerAspectRatio},
+              {aspectRatio},
             ]}>
             {children}
           </View>
@@ -88,31 +90,71 @@ export function AutoSizedImage({
   onPress,
   onLongPress,
   onPressIn,
-  children = null,
 }: {
   image: AppBskyEmbedImages.ViewImage
   disableCrop?: boolean
-  children?: React.ReactNode
   onPress?: () => void
   onLongPress?: () => void
   onPressIn?: () => void
 }) {
   const t = useTheme()
   const {_} = useLingui()
-  const {aspectRatio} = useImageAspectRatio({
+  const largeAlt = useLargeAltBadgeEnabled()
+  const {aspectRatio, isCropped: rawIsCropped} = useImageAspectRatio({
     src: image.thumb,
     dimensions: image.aspectRatio,
   })
+  const isCropped = rawIsCropped && !disableCrop
+  const hasAlt = !!image.alt
 
   const contents = (
-    <Image
-      style={[a.w_full, a.h_full]}
-      source={image.thumb}
-      accessible={true} // Must set for `accessibilityLabel` to work
-      accessibilityIgnoresInvertColors
-      accessibilityLabel={image.alt}
-      accessibilityHint=""
-    />
+    <>
+      <Image
+        style={[a.w_full, a.h_full]}
+        source={image.thumb}
+        accessible={true} // Must set for `accessibilityLabel` to work
+        accessibilityIgnoresInvertColors
+        accessibilityLabel={image.alt}
+        accessibilityHint=""
+      />
+
+      {hasAlt || isCropped ? (
+        <View
+          accessible={false}
+          style={[
+            a.absolute,
+            a.flex_row,
+            a.align_center,
+            a.rounded_xs,
+            t.atoms.bg_contrast_25,
+            {
+              gap: 3,
+              padding: 3,
+              bottom: a.p_sm.padding,
+              right: a.p_sm.padding,
+              opacity: 0.8,
+            },
+            largeAlt && [
+              {
+                gap: 4,
+                padding: 5,
+              },
+            ],
+          ]}>
+          {isCropped && (
+            <Crop
+              fill={t.atoms.text_contrast_high.color}
+              width={largeAlt ? 18 : 12}
+            />
+          )}
+          {hasAlt && (
+            <Text style={[a.font_heavy, largeAlt ? a.text_xs : {fontSize: 8}]}>
+              ALT
+            </Text>
+          )}
+        </View>
+      ) : null}
+    </>
   )
 
   if (disableCrop) {
@@ -132,7 +174,6 @@ export function AutoSizedImage({
           {aspectRatio},
         ]}>
         {contents}
-        {children}
       </Pressable>
     )
   } else {
@@ -147,7 +188,6 @@ export function AutoSizedImage({
           accessibilityHint={_(msg`Tap to view full image`)}
           style={[a.h_full]}>
           {contents}
-          {children}
         </Pressable>
       </SquareFramedImage>
     )

--- a/src/view/com/util/images/AutoSizedImage.tsx
+++ b/src/view/com/util/images/AutoSizedImage.tsx
@@ -55,11 +55,13 @@ export function useImageAspectRatio({
   }
 }
 
-export function SquareFramedImage({
+export function ConstrainedImage({
   aspectRatio,
+  fullBleed,
   children,
 }: {
   aspectRatio: number
+  fullBleed?: boolean
   children: React.ReactNode
 }) {
   const t = useTheme()
@@ -82,7 +84,7 @@ export function SquareFramedImage({
               a.rounded_sm,
               a.overflow_hidden,
               t.atoms.bg_contrast_25,
-              {aspectRatio},
+              {aspectRatio: fullBleed ? 1 : aspectRatio},
             ]}>
             {children}
           </View>
@@ -94,13 +96,13 @@ export function SquareFramedImage({
 
 export function AutoSizedImage({
   image,
-  disableCrop,
+  crop = 'constrained',
   onPress,
   onLongPress,
   onPressIn,
 }: {
   image: AppBskyEmbedImages.ViewImage
-  disableCrop?: boolean
+  crop?: 'none' | 'square' | 'constrained'
   onPress?: () => void
   onLongPress?: () => void
   onPressIn?: () => void
@@ -116,7 +118,8 @@ export function AutoSizedImage({
     src: image.thumb,
     dimensions: image.aspectRatio,
   })
-  const isCropped = rawIsCropped && !disableCrop
+  const cropDisabled = crop === 'none'
+  const isCropped = rawIsCropped && !cropDisabled
   const hasAlt = !!image.alt
 
   const contents = (
@@ -169,7 +172,7 @@ export function AutoSizedImage({
     </>
   )
 
-  if (disableCrop) {
+  if (cropDisabled) {
     return (
       <Pressable
         onPress={onPress}
@@ -190,7 +193,7 @@ export function AutoSizedImage({
     )
   } else {
     return (
-      <SquareFramedImage aspectRatio={constrained}>
+      <ConstrainedImage fullBleed={crop === 'square'} aspectRatio={constrained}>
         <Pressable
           onPress={onPress}
           onLongPress={onLongPress}
@@ -201,7 +204,7 @@ export function AutoSizedImage({
           style={[a.h_full]}>
           {contents}
         </Pressable>
-      </SquareFramedImage>
+      </ConstrainedImage>
     )
   }
 }

--- a/src/view/com/util/images/AutoSizedImage.tsx
+++ b/src/view/com/util/images/AutoSizedImage.tsx
@@ -97,12 +97,14 @@ export function ConstrainedImage({
 export function AutoSizedImage({
   image,
   crop = 'constrained',
+  hideBadge,
   onPress,
   onLongPress,
   onPressIn,
 }: {
   image: AppBskyEmbedImages.ViewImage
   crop?: 'none' | 'square' | 'constrained'
+  hideBadge?: boolean
   onPress?: () => void
   onLongPress?: () => void
   onPressIn?: () => void
@@ -133,7 +135,7 @@ export function AutoSizedImage({
         accessibilityHint=""
       />
 
-      {hasAlt || isCropped ? (
+      {(hasAlt || isCropped) && !hideBadge ? (
         <View
           accessible={false}
           style={[

--- a/src/view/com/util/images/AutoSizedImage.tsx
+++ b/src/view/com/util/images/AutoSizedImage.tsx
@@ -147,8 +147,8 @@ export function AutoSizedImage({
             {
               gap: 3,
               padding: 3,
-              bottom: a.p_sm.padding,
-              right: a.p_sm.padding,
+              bottom: a.p_xs.padding,
+              right: a.p_xs.padding,
               opacity: 0.8,
             },
             largeAlt && [

--- a/src/view/com/util/images/AutoSizedImage.tsx
+++ b/src/view/com/util/images/AutoSizedImage.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import {Pressable, View} from 'react-native'
+import {DimensionValue, Pressable, View} from 'react-native'
 import {Image} from 'expo-image'
 import {AppBskyEmbedImages} from '@atproto/api'
 import {msg} from '@lingui/macro'
@@ -46,17 +46,25 @@ export function SquareFramedImage({
   children: React.ReactNode
 }) {
   const t = useTheme()
-  const outerAspectRatio = React.useMemo(() => {
-    return Math.min(1 / aspectRatio, 1)
+  /**
+   * Computed as a % value to apply as `paddingTop`
+   */
+  const outerAspectRatio = React.useMemo<DimensionValue>(() => {
+    // capped to square or shorter
+    const ratio = Math.min(1 / aspectRatio, 1)
+    return `${ratio * 100}%`
   }, [aspectRatio])
+  /**
+   * Computed as a CSS `aspectRatio` value
+   */
   const innerAspectRatio = React.useMemo(() => {
+    // max of 3:4 ratio
     return Math.max(aspectRatio, 0.75)
   }, [aspectRatio])
 
   return (
     <View style={[a.w_full]}>
-      <View
-        style={[a.overflow_hidden, {paddingTop: `${outerAspectRatio * 100}%`}]}>
+      <View style={[a.overflow_hidden, {paddingTop: outerAspectRatio}]}>
         <View style={[a.absolute, a.inset_0, a.flex_row]}>
           <View
             style={[
@@ -113,8 +121,9 @@ export function AutoSizedImage({
         onPress={onPress}
         onLongPress={onLongPress}
         onPressIn={onPressIn}
+        // alt here is what screen readers actually use
         accessibilityLabel={image.alt}
-        accessibilityHint={_(msg`Tap to view fully`)}
+        accessibilityHint={_(msg`Tap to view full image`)}
         style={[
           a.w_full,
           a.rounded_sm,
@@ -133,8 +142,9 @@ export function AutoSizedImage({
           onPress={onPress}
           onLongPress={onLongPress}
           onPressIn={onPressIn}
+          // alt here is what screen readers actually use
           accessibilityLabel={image.alt}
-          accessibilityHint={_(msg`Tap to view fully`)}
+          accessibilityHint={_(msg`Tap to view full image`)}
           style={[a.h_full]}>
           {contents}
           {children}

--- a/src/view/com/util/images/AutoSizedImage.tsx
+++ b/src/view/com/util/images/AutoSizedImage.tsx
@@ -84,7 +84,7 @@ export function ConstrainedImage({
               a.rounded_sm,
               a.overflow_hidden,
               t.atoms.bg_contrast_25,
-              {aspectRatio: fullBleed ? 1 : aspectRatio},
+              fullBleed ? a.w_full : {aspectRatio},
             ]}>
             {children}
           </View>

--- a/src/view/com/util/images/Gallery.tsx
+++ b/src/view/com/util/images/Gallery.tsx
@@ -8,7 +8,6 @@ import {useLingui} from '@lingui/react'
 import {useLargeAltBadgeEnabled} from '#/state/preferences/large-alt-badge'
 import {PostEmbedViewContext} from '#/view/com/util/post-embeds/types'
 import {atoms as a, useTheme} from '#/alf'
-import {Crop_Stroke2_Corner0_Rounded as Crop} from '#/components/icons/Crop'
 import {Text} from '#/components/Typography'
 
 type EventFunction = (index: number) => void
@@ -37,11 +36,6 @@ export const GalleryItem: FC<GalleryItemProps> = ({
   const largeAltBadge = useLargeAltBadgeEnabled()
   const image = images[index]
   const hasAlt = !!image.alt
-  const isCropped = React.useMemo(() => {
-    if (!image.aspectRatio) return true
-    const aspect = image.aspectRatio.width / image.aspectRatio.height
-    return aspect !== 1
-  }, [image.aspectRatio])
   const hideBadges =
     viewContext === PostEmbedViewContext.FeedEmbedRecordWithMedia
   return (
@@ -69,7 +63,7 @@ export const GalleryItem: FC<GalleryItemProps> = ({
           accessibilityIgnoresInvertColors
         />
       </Pressable>
-      {(hasAlt || isCropped) && !hideBadges ? (
+      {hasAlt && !hideBadges ? (
         <View
           accessible={false}
           style={[
@@ -92,18 +86,10 @@ export const GalleryItem: FC<GalleryItemProps> = ({
               },
             ],
           ]}>
-          {isCropped && (
-            <Crop
-              fill={t.atoms.text_contrast_high.color}
-              width={largeAltBadge ? 18 : 12}
-            />
-          )}
-          {hasAlt && (
-            <Text
-              style={[a.font_heavy, largeAltBadge ? a.text_xs : {fontSize: 8}]}>
-              ALT
-            </Text>
-          )}
+          <Text
+            style={[a.font_heavy, largeAltBadge ? a.text_xs : {fontSize: 8}]}>
+            ALT
+          </Text>
         </View>
       ) : null}
     </View>

--- a/src/view/com/util/images/Gallery.tsx
+++ b/src/view/com/util/images/Gallery.tsx
@@ -6,6 +6,7 @@ import {msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
 import {useLargeAltBadgeEnabled} from '#/state/preferences/large-alt-badge'
+import {PostEmbedViewContext} from '#/view/com/util/post-embeds/types'
 import {atoms as a, useTheme} from '#/alf'
 import {Crop_Stroke2_Corner0_Rounded as Crop} from '#/components/icons/Crop'
 import {Text} from '#/components/Typography'
@@ -19,7 +20,7 @@ interface GalleryItemProps {
   onLongPress?: EventFunction
   onPressIn?: EventFunction
   imageStyle: ComponentProps<typeof Image>['style']
-  hideBadges?: boolean
+  viewContext?: PostEmbedViewContext
 }
 
 export const GalleryItem: FC<GalleryItemProps> = ({
@@ -29,7 +30,7 @@ export const GalleryItem: FC<GalleryItemProps> = ({
   onPress,
   onPressIn,
   onLongPress,
-  hideBadges,
+  viewContext,
 }) => {
   const t = useTheme()
   const {_} = useLingui()
@@ -41,6 +42,8 @@ export const GalleryItem: FC<GalleryItemProps> = ({
     const aspect = image.aspectRatio.width / image.aspectRatio.height
     return aspect !== 1
   }, [image.aspectRatio])
+  const hideBadges =
+    viewContext === PostEmbedViewContext.FeedEmbedRecordWithMedia
   return (
     <View style={a.flex_1}>
       <Pressable
@@ -78,8 +81,8 @@ export const GalleryItem: FC<GalleryItemProps> = ({
             {
               gap: 3,
               padding: 3,
-              bottom: a.p_sm.padding,
-              right: a.p_sm.padding,
+              bottom: a.p_xs.padding,
+              right: a.p_xs.padding,
               opacity: 0.8,
             },
             largeAltBadge && [

--- a/src/view/com/util/images/Gallery.tsx
+++ b/src/view/com/util/images/Gallery.tsx
@@ -7,7 +7,7 @@ import {useLingui} from '@lingui/react'
 
 import {isWeb} from '#/platform/detection'
 import {useLargeAltBadgeEnabled} from '#/state/preferences/large-alt-badge'
-import {atoms as a} from '#/alf'
+import {atoms as a, useTheme} from '#/alf'
 
 type EventFunction = (index: number) => void
 
@@ -28,6 +28,7 @@ export const GalleryItem: FC<GalleryItemProps> = ({
   onPressIn,
   onLongPress,
 }) => {
+  const t = useTheme()
   const {_} = useLingui()
   const largeAltBadge = useLargeAltBadgeEnabled()
   const image = images[index]
@@ -37,13 +38,19 @@ export const GalleryItem: FC<GalleryItemProps> = ({
         onPress={onPress ? () => onPress(index) : undefined}
         onPressIn={onPressIn ? () => onPressIn(index) : undefined}
         onLongPress={onLongPress ? () => onLongPress(index) : undefined}
-        style={a.flex_1}
+        style={[
+          a.flex_1,
+          a.rounded_xs,
+          a.overflow_hidden,
+          t.atoms.bg_contrast_25,
+          imageStyle,
+        ]}
         accessibilityRole="button"
         accessibilityLabel={image.alt || _(msg`Image`)}
         accessibilityHint="">
         <Image
           source={{uri: image.thumb}}
-          style={[a.flex_1, a.rounded_xs, imageStyle]}
+          style={[a.flex_1]}
           accessible={true}
           accessibilityLabel={image.alt}
           accessibilityHint=""

--- a/src/view/com/util/images/Gallery.tsx
+++ b/src/view/com/util/images/Gallery.tsx
@@ -19,7 +19,7 @@ interface GalleryItemProps {
   onPress?: EventFunction
   onLongPress?: EventFunction
   onPressIn?: EventFunction
-  imageStyle: ComponentProps<typeof Image>['style']
+  imageStyle?: ComponentProps<typeof Image>['style']
   viewContext?: PostEmbedViewContext
 }
 

--- a/src/view/com/util/images/ImageLayoutGrid.tsx
+++ b/src/view/com/util/images/ImageLayoutGrid.tsx
@@ -25,9 +25,11 @@ export function ImageLayoutGrid({style, ...props}: ImageLayoutGridProps) {
       : gtMobile
       ? a.gap_sm
       : a.gap_xs
+  const count = props.images.length
+  const aspectRatio = count === 2 ? 2 : count === 3 ? 1.5 : 1
   return (
     <View style={style}>
-      <View style={[gap]}>
+      <View style={[gap, {aspectRatio}]}>
         <ImageLayoutGridInner {...props} gap={gap} />
       </View>
     </View>
@@ -50,7 +52,7 @@ function ImageLayoutGridInner(props: ImageLayoutGridInnerProps) {
   switch (count) {
     case 2:
       return (
-        <View style={[a.flex_row, gap]}>
+        <View style={[a.flex_1, a.flex_row, gap]}>
           <View style={[a.flex_1, {aspectRatio: 1}]}>
             <GalleryItem {...props} index={0} />
           </View>
@@ -62,7 +64,7 @@ function ImageLayoutGridInner(props: ImageLayoutGridInnerProps) {
 
     case 3:
       return (
-        <View style={[a.flex_row, gap]}>
+        <View style={[a.flex_1, a.flex_row, gap]}>
           <View style={{flex: 2}}>
             <GalleryItem {...props} index={0} />
           </View>

--- a/src/view/com/util/images/ImageLayoutGrid.tsx
+++ b/src/view/com/util/images/ImageLayoutGrid.tsx
@@ -3,6 +3,8 @@ import {StyleProp, StyleSheet, View, ViewStyle} from 'react-native'
 import {AppBskyEmbedImages} from '@atproto/api'
 
 import {isWeb} from 'platform/detection'
+import {PostEmbedViewContext} from '#/view/com/util/post-embeds/types'
+import {atoms as a} from '#/alf'
 import {GalleryItem} from './Gallery'
 
 interface ImageLayoutGridProps {
@@ -11,13 +13,17 @@ interface ImageLayoutGridProps {
   onLongPress?: (index: number) => void
   onPressIn?: (index: number) => void
   style?: StyleProp<ViewStyle>
-  hideBadges?: boolean
+  viewContext?: PostEmbedViewContext
 }
 
 export function ImageLayoutGrid({style, ...props}: ImageLayoutGridProps) {
+  const gap =
+    props.viewContext === PostEmbedViewContext.FeedEmbedRecordWithMedia
+      ? a.gap_2xs
+      : a.gap_xs
   return (
     <View style={style}>
-      <View style={styles.container}>
+      <View style={[styles.container, gap]}>
         <ImageLayoutGridInner {...props} />
       </View>
     </View>
@@ -29,15 +35,20 @@ interface ImageLayoutGridInnerProps {
   onPress?: (index: number) => void
   onLongPress?: (index: number) => void
   onPressIn?: (index: number) => void
+  viewContext?: PostEmbedViewContext
 }
 
 function ImageLayoutGridInner(props: ImageLayoutGridInnerProps) {
   const count = props.images.length
+  const gap =
+    props.viewContext === PostEmbedViewContext.FeedEmbedRecordWithMedia
+      ? a.gap_2xs
+      : a.gap_xs
 
   switch (count) {
     case 2:
       return (
-        <View style={styles.flexRow}>
+        <View style={[a.flex_row, gap]}>
           <View style={styles.smallItem}>
             <GalleryItem {...props} index={0} imageStyle={styles.image} />
           </View>
@@ -49,11 +60,11 @@ function ImageLayoutGridInner(props: ImageLayoutGridInnerProps) {
 
     case 3:
       return (
-        <View style={styles.flexRow}>
+        <View style={[a.flex_row, gap]}>
           <View style={styles.threeSingle}>
             <GalleryItem {...props} index={0} imageStyle={styles.image} />
           </View>
-          <View style={styles.threeDouble}>
+          <View style={[styles.threeDouble, gap]}>
             <View style={styles.smallItem}>
               <GalleryItem {...props} index={1} imageStyle={styles.image} />
             </View>
@@ -67,7 +78,7 @@ function ImageLayoutGridInner(props: ImageLayoutGridInnerProps) {
     case 4:
       return (
         <>
-          <View style={styles.flexRow}>
+          <View style={[a.flex_row, gap]}>
             <View style={styles.smallItem}>
               <GalleryItem {...props} index={0} imageStyle={styles.image} />
             </View>
@@ -75,7 +86,7 @@ function ImageLayoutGridInner(props: ImageLayoutGridInnerProps) {
               <GalleryItem {...props} index={1} imageStyle={styles.image} />
             </View>
           </View>
-          <View style={styles.flexRow}>
+          <View style={[a.flex_row, gap]}>
             <View style={styles.smallItem}>
               <GalleryItem {...props} index={2} imageStyle={styles.image} />
             </View>
@@ -104,13 +115,7 @@ const styles = StyleSheet.create({
         marginHorizontal: -IMAGE_GAP / 2,
         marginVertical: -IMAGE_GAP / 2,
       }
-    : {
-        gap: IMAGE_GAP,
-      },
-  flexRow: {
-    flexDirection: 'row',
-    gap: isWeb ? undefined : IMAGE_GAP,
-  },
+    : {},
   smallItem: {flex: 1, aspectRatio: 1},
   image: isWeb
     ? {
@@ -123,6 +128,5 @@ const styles = StyleSheet.create({
   },
   threeDouble: {
     flex: 1,
-    gap: isWeb ? undefined : IMAGE_GAP,
   },
 })

--- a/src/view/com/util/images/ImageLayoutGrid.tsx
+++ b/src/view/com/util/images/ImageLayoutGrid.tsx
@@ -1,8 +1,9 @@
 import React from 'react'
 import {StyleProp, StyleSheet, View, ViewStyle} from 'react-native'
 import {AppBskyEmbedImages} from '@atproto/api'
-import {GalleryItem} from './Gallery'
+
 import {isWeb} from 'platform/detection'
+import {GalleryItem} from './Gallery'
 
 interface ImageLayoutGridProps {
   images: AppBskyEmbedImages.ViewImage[]
@@ -10,6 +11,7 @@ interface ImageLayoutGridProps {
   onLongPress?: (index: number) => void
   onPressIn?: (index: number) => void
   style?: StyleProp<ViewStyle>
+  hideBadges?: boolean
 }
 
 export function ImageLayoutGrid({style, ...props}: ImageLayoutGridProps) {

--- a/src/view/com/util/images/ImageLayoutGrid.tsx
+++ b/src/view/com/util/images/ImageLayoutGrid.tsx
@@ -1,10 +1,9 @@
 import React from 'react'
-import {StyleProp, StyleSheet, View, ViewStyle} from 'react-native'
+import {StyleProp, View, ViewStyle} from 'react-native'
 import {AppBskyEmbedImages} from '@atproto/api'
 
-import {isWeb} from 'platform/detection'
 import {PostEmbedViewContext} from '#/view/com/util/post-embeds/types'
-import {atoms as a} from '#/alf'
+import {atoms as a, useBreakpoints} from '#/alf'
 import {GalleryItem} from './Gallery'
 
 interface ImageLayoutGridProps {
@@ -17,14 +16,19 @@ interface ImageLayoutGridProps {
 }
 
 export function ImageLayoutGrid({style, ...props}: ImageLayoutGridProps) {
+  const {gtMobile} = useBreakpoints()
   const gap =
     props.viewContext === PostEmbedViewContext.FeedEmbedRecordWithMedia
-      ? a.gap_2xs
+      ? gtMobile
+        ? a.gap_xs
+        : a.gap_2xs
+      : gtMobile
+      ? a.gap_sm
       : a.gap_xs
   return (
     <View style={style}>
-      <View style={[styles.container, gap]}>
-        <ImageLayoutGridInner {...props} />
+      <View style={[gap]}>
+        <ImageLayoutGridInner {...props} gap={gap} />
       </View>
     </View>
   )
@@ -36,24 +40,22 @@ interface ImageLayoutGridInnerProps {
   onLongPress?: (index: number) => void
   onPressIn?: (index: number) => void
   viewContext?: PostEmbedViewContext
+  gap: {gap: number}
 }
 
 function ImageLayoutGridInner(props: ImageLayoutGridInnerProps) {
+  const gap = props.gap
   const count = props.images.length
-  const gap =
-    props.viewContext === PostEmbedViewContext.FeedEmbedRecordWithMedia
-      ? a.gap_2xs
-      : a.gap_xs
 
   switch (count) {
     case 2:
       return (
         <View style={[a.flex_row, gap]}>
-          <View style={styles.smallItem}>
-            <GalleryItem {...props} index={0} imageStyle={styles.image} />
+          <View style={[a.flex_1, {aspectRatio: 1}]}>
+            <GalleryItem {...props} index={0} />
           </View>
-          <View style={styles.smallItem}>
-            <GalleryItem {...props} index={1} imageStyle={styles.image} />
+          <View style={[a.flex_1, {aspectRatio: 1}]}>
+            <GalleryItem {...props} index={1} />
           </View>
         </View>
       )
@@ -61,15 +63,15 @@ function ImageLayoutGridInner(props: ImageLayoutGridInnerProps) {
     case 3:
       return (
         <View style={[a.flex_row, gap]}>
-          <View style={styles.threeSingle}>
-            <GalleryItem {...props} index={0} imageStyle={styles.image} />
+          <View style={{flex: 2}}>
+            <GalleryItem {...props} index={0} />
           </View>
-          <View style={[styles.threeDouble, gap]}>
-            <View style={styles.smallItem}>
-              <GalleryItem {...props} index={1} imageStyle={styles.image} />
+          <View style={[a.flex_1, gap]}>
+            <View style={[a.flex_1, {aspectRatio: 1}]}>
+              <GalleryItem {...props} index={1} />
             </View>
-            <View style={styles.smallItem}>
-              <GalleryItem {...props} index={2} imageStyle={styles.image} />
+            <View style={[a.flex_1, {aspectRatio: 1}]}>
+              <GalleryItem {...props} index={2} />
             </View>
           </View>
         </View>
@@ -79,19 +81,19 @@ function ImageLayoutGridInner(props: ImageLayoutGridInnerProps) {
       return (
         <>
           <View style={[a.flex_row, gap]}>
-            <View style={styles.smallItem}>
-              <GalleryItem {...props} index={0} imageStyle={styles.image} />
+            <View style={[a.flex_1, {aspectRatio: 1}]}>
+              <GalleryItem {...props} index={0} />
             </View>
-            <View style={styles.smallItem}>
-              <GalleryItem {...props} index={1} imageStyle={styles.image} />
+            <View style={[a.flex_1, {aspectRatio: 1}]}>
+              <GalleryItem {...props} index={1} />
             </View>
           </View>
           <View style={[a.flex_row, gap]}>
-            <View style={styles.smallItem}>
-              <GalleryItem {...props} index={2} imageStyle={styles.image} />
+            <View style={[a.flex_1, {aspectRatio: 1}]}>
+              <GalleryItem {...props} index={2} />
             </View>
-            <View style={styles.smallItem}>
-              <GalleryItem {...props} index={3} imageStyle={styles.image} />
+            <View style={[a.flex_1, {aspectRatio: 1}]}>
+              <GalleryItem {...props} index={3} />
             </View>
           </View>
         </>
@@ -101,32 +103,3 @@ function ImageLayoutGridInner(props: ImageLayoutGridInnerProps) {
       return null
   }
 }
-
-// On web we use margin to calculate gap, as aspectRatio does not properly size
-// all images on web. On native though we cannot rely on margin, since the
-// negative margin interferes with the swipe controls on pagers.
-// https://github.com/facebook/yoga/issues/1418
-// https://github.com/bluesky-social/social-app/issues/2601
-const IMAGE_GAP = 5
-
-const styles = StyleSheet.create({
-  container: isWeb
-    ? {
-        marginHorizontal: -IMAGE_GAP / 2,
-        marginVertical: -IMAGE_GAP / 2,
-      }
-    : {},
-  smallItem: {flex: 1, aspectRatio: 1},
-  image: isWeb
-    ? {
-        margin: IMAGE_GAP / 2,
-      }
-    : {},
-  threeSingle: {
-    flex: 2,
-    aspectRatio: isWeb ? 1 : undefined,
-  },
-  threeDouble: {
-    flex: 1,
-  },
-})

--- a/src/view/com/util/post-embeds/QuoteEmbed.tsx
+++ b/src/view/com/util/post-embeds/QuoteEmbed.tsx
@@ -248,12 +248,14 @@ export function QuoteEmbed({
               </View>
             )}
             {richText ? (
-              <RichText
-                value={richText}
-                style={a.text_md}
-                numberOfLines={20}
-                disableLinks
-              />
+              <View style={[a.flex_1, a.pt_xs]}>
+                <RichText
+                  value={richText}
+                  style={a.text_md}
+                  numberOfLines={20}
+                  disableLinks
+                />
+              </View>
             ) : null}
           </View>
         ) : (

--- a/src/view/com/util/post-embeds/QuoteEmbed.tsx
+++ b/src/view/com/util/post-embeds/QuoteEmbed.tsx
@@ -207,6 +207,7 @@ export function QuoteEmbed({
       }
     }
   }, [quote.embeds, allowNestedQuotes])
+  const isImagesEmbed = AppBskyEmbedImages.isView(embed)
 
   const onBeforePress = React.useCallback(() => {
     precacheProfile(queryClient, quote.author)
@@ -237,7 +238,8 @@ export function QuoteEmbed({
           <PostAlerts modui={moderation.ui('contentView')} style={[a.py_xs]} />
         ) : null}
 
-        {viewContext === QuoteEmbedViewContext.FeedEmbedRecordWithMedia ? (
+        {viewContext === QuoteEmbedViewContext.FeedEmbedRecordWithMedia &&
+        isImagesEmbed ? (
           <View style={[a.flex_row, a.gap_md]}>
             {embed && (
               <View style={[{width: gtMobile ? 100 : 80}]}>

--- a/src/view/com/util/post-embeds/QuoteEmbed.tsx
+++ b/src/view/com/util/post-embeds/QuoteEmbed.tsx
@@ -41,17 +41,20 @@ import {Link} from '../Link'
 import {PostMeta} from '../PostMeta'
 import {Text} from '../text/Text'
 import {PostEmbeds} from '.'
+import {PostEmbedViewContext, QuoteEmbedViewContext} from './types'
 
 export function MaybeQuoteEmbed({
   embed,
   onOpen,
   style,
   allowNestedQuotes,
+  viewContext,
 }: {
   embed: AppBskyEmbedRecord.View
   onOpen?: () => void
   style?: StyleProp<ViewStyle>
   allowNestedQuotes?: boolean
+  viewContext?: QuoteEmbedViewContext
 }) {
   const pal = usePalette('default')
   const {currentAccount} = useSession()
@@ -67,6 +70,7 @@ export function MaybeQuoteEmbed({
         onOpen={onOpen}
         style={style}
         allowNestedQuotes={allowNestedQuotes}
+        viewContext={viewContext}
       />
     )
   } else if (AppBskyEmbedRecord.isViewBlocked(embed.record)) {
@@ -113,12 +117,14 @@ function QuoteEmbedModerated({
   onOpen,
   style,
   allowNestedQuotes,
+  viewContext,
 }: {
   viewRecord: AppBskyEmbedRecord.ViewRecord
   postRecord: AppBskyFeedPost.Record
   onOpen?: () => void
   style?: StyleProp<ViewStyle>
   allowNestedQuotes?: boolean
+  viewContext?: QuoteEmbedViewContext
 }) {
   const moderationOpts = useModerationOpts()
   const moderation = React.useMemo(() => {
@@ -144,6 +150,7 @@ function QuoteEmbedModerated({
       onOpen={onOpen}
       style={style}
       allowNestedQuotes={allowNestedQuotes}
+      viewContext={viewContext}
     />
   )
 }
@@ -154,12 +161,14 @@ export function QuoteEmbed({
   onOpen,
   style,
   allowNestedQuotes,
+  viewContext,
 }: {
   quote: ComposerOptsQuote
   moderation?: ModerationDecision
   onOpen?: () => void
   style?: StyleProp<ViewStyle>
   allowNestedQuotes?: boolean
+  viewContext?: QuoteEmbedViewContext
 }) {
   const queryClient = useQueryClient()
   const pal = usePalette('default')
@@ -226,15 +235,40 @@ export function QuoteEmbed({
         {moderation ? (
           <PostAlerts modui={moderation.ui('contentView')} style={[a.py_xs]} />
         ) : null}
-        {richText ? (
-          <RichText
-            value={richText}
-            style={a.text_md}
-            numberOfLines={20}
-            disableLinks
-          />
-        ) : null}
-        {embed && <PostEmbeds embed={embed} moderation={moderation} />}
+
+        {viewContext === QuoteEmbedViewContext.FeedEmbedRecordWithMedia ? (
+          <View style={[a.flex_row, a.gap_md]}>
+            {embed && (
+              <View style={[{width: 100}]}>
+                <PostEmbeds
+                  embed={embed}
+                  moderation={moderation}
+                  viewContext={PostEmbedViewContext.FeedEmbedRecordWithMedia}
+                />
+              </View>
+            )}
+            {richText ? (
+              <RichText
+                value={richText}
+                style={a.text_md}
+                numberOfLines={20}
+                disableLinks
+              />
+            ) : null}
+          </View>
+        ) : (
+          <>
+            {richText ? (
+              <RichText
+                value={richText}
+                style={a.text_md}
+                numberOfLines={20}
+                disableLinks
+              />
+            ) : null}
+            {embed && <PostEmbeds embed={embed} moderation={moderation} />}
+          </>
+        )}
       </Link>
     </ContentHider>
   )

--- a/src/view/com/util/post-embeds/QuoteEmbed.tsx
+++ b/src/view/com/util/post-embeds/QuoteEmbed.tsx
@@ -33,7 +33,7 @@ import {InfoCircleIcon} from 'lib/icons'
 import {makeProfileLink} from 'lib/routes/links'
 import {precacheProfile} from 'state/queries/profile'
 import {ComposerOptsQuote} from 'state/shell/composer'
-import {atoms as a} from '#/alf'
+import {atoms as a, useBreakpoints} from '#/alf'
 import {RichText} from '#/components/RichText'
 import {ContentHider} from '../../../../components/moderation/ContentHider'
 import {PostAlerts} from '../../../../components/moderation/PostAlerts'
@@ -175,6 +175,7 @@ export function QuoteEmbed({
   const itemUrip = new AtUri(quote.uri)
   const itemHref = makeProfileLink(quote.author, 'post', itemUrip.rkey)
   const itemTitle = `Post by ${quote.author.handle}`
+  const {gtMobile} = useBreakpoints()
 
   const richText = React.useMemo(
     () =>
@@ -239,7 +240,7 @@ export function QuoteEmbed({
         {viewContext === QuoteEmbedViewContext.FeedEmbedRecordWithMedia ? (
           <View style={[a.flex_row, a.gap_md]}>
             {embed && (
-              <View style={[{width: 100}]}>
+              <View style={[{width: gtMobile ? 100 : 80}]}>
                 <PostEmbeds
                   embed={embed}
                   moderation={moderation}

--- a/src/view/com/util/post-embeds/index.tsx
+++ b/src/view/com/util/post-embeds/index.tsx
@@ -164,6 +164,9 @@ export function PostEmbeds({
               images={embed.images}
               onPress={_openLightbox}
               onPressIn={onPressIn}
+              hideBadges={
+                viewContext === PostEmbedViewContext.FeedEmbedRecordWithMedia
+              }
             />
           </View>
         </ContentHider>

--- a/src/view/com/util/post-embeds/index.tsx
+++ b/src/view/com/util/post-embeds/index.tsx
@@ -50,12 +50,14 @@ export function PostEmbeds({
   onOpen,
   style,
   allowNestedQuotes,
+  isHighlightedThreadItem,
 }: {
   embed?: Embed
   moderation?: ModerationDecision
   onOpen?: () => void
   style?: StyleProp<ViewStyle>
   allowNestedQuotes?: boolean
+  isHighlightedThreadItem?: boolean
 }) {
   const {openLightbox} = useLightboxControls()
   const largeAltBadge = useLargeAltBadgeEnabled()
@@ -124,18 +126,16 @@ export function PostEmbeds({
       }
 
       if (images.length === 1) {
-        const {alt, thumb, aspectRatio} = images[0]
+        const image = images[0]
         return (
           <ContentHider modui={moderation?.ui('contentMedia')}>
             <View style={[styles.container, style]}>
               <AutoSizedImage
-                alt={alt}
-                uri={thumb}
-                dimensionsHint={aspectRatio}
+                disableCrop={isHighlightedThreadItem}
+                image={image}
                 onPress={() => _openLightbox(0)}
-                onPressIn={() => onPressIn(0)}
-                style={a.rounded_sm}>
-                {alt === '' ? null : (
+                onPressIn={() => onPressIn(0)}>
+                {image.alt === '' ? null : (
                   <View style={styles.altContainer}>
                     <Text
                       style={[styles.alt, largeAltBadge && a.text_xs]}

--- a/src/view/com/util/post-embeds/index.tsx
+++ b/src/view/com/util/post-embeds/index.tsx
@@ -50,14 +50,14 @@ export function PostEmbeds({
   onOpen,
   style,
   allowNestedQuotes,
-  isHighlightedThreadItem,
+  contextView,
 }: {
   embed?: Embed
   moderation?: ModerationDecision
   onOpen?: () => void
   style?: StyleProp<ViewStyle>
   allowNestedQuotes?: boolean
-  isHighlightedThreadItem?: boolean
+  contextView?: 'thread-highlighted'
 }) {
   const {openLightbox} = useLightboxControls()
   const largeAltBadge = useLargeAltBadgeEnabled()
@@ -131,7 +131,7 @@ export function PostEmbeds({
           <ContentHider modui={moderation?.ui('contentMedia')}>
             <View style={[styles.container, style]}>
               <AutoSizedImage
-                disableCrop={isHighlightedThreadItem}
+                disableCrop={contextView === 'thread-highlighted'}
                 image={image}
                 onPress={() => _openLightbox(0)}
                 onPressIn={() => onPressIn(0)}>

--- a/src/view/com/util/post-embeds/index.tsx
+++ b/src/view/com/util/post-embeds/index.tsx
@@ -164,9 +164,7 @@ export function PostEmbeds({
               images={embed.images}
               onPress={_openLightbox}
               onPressIn={onPressIn}
-              hideBadges={
-                viewContext === PostEmbedViewContext.FeedEmbedRecordWithMedia
-              }
+              viewContext={viewContext}
             />
           </View>
         </ContentHider>

--- a/src/view/com/util/post-embeds/index.tsx
+++ b/src/view/com/util/post-embeds/index.tsx
@@ -48,14 +48,14 @@ export function PostEmbeds({
   onOpen,
   style,
   allowNestedQuotes,
-  contextView,
+  viewContext,
 }: {
   embed?: Embed
   moderation?: ModerationDecision
   onOpen?: () => void
   style?: StyleProp<ViewStyle>
   allowNestedQuotes?: boolean
-  contextView?: 'thread-highlighted'
+  viewContext?: 'thread-highlighted'
 }) {
   const {openLightbox} = useLightboxControls()
 
@@ -68,6 +68,7 @@ export function PostEmbeds({
           embed={embed.media}
           moderation={moderation}
           onOpen={onOpen}
+          viewContext={viewContext}
         />
         <MaybeQuoteEmbed embed={embed.record} onOpen={onOpen} />
       </View>
@@ -128,7 +129,7 @@ export function PostEmbeds({
           <ContentHider modui={moderation?.ui('contentMedia')}>
             <View style={[styles.container, style]}>
               <AutoSizedImage
-                disableCrop={contextView === 'thread-highlighted'}
+                disableCrop={viewContext === 'thread-highlighted'}
                 image={image}
                 onPress={() => _openLightbox(0)}
                 onPressIn={() => onPressIn(0)}

--- a/src/view/com/util/post-embeds/index.tsx
+++ b/src/view/com/util/post-embeds/index.tsx
@@ -151,6 +151,9 @@ export function PostEmbeds({
                 image={image}
                 onPress={() => _openLightbox(0)}
                 onPressIn={() => onPressIn(0)}
+                hideBadge={
+                  viewContext === PostEmbedViewContext.FeedEmbedRecordWithMedia
+                }
               />
             </View>
           </ContentHider>

--- a/src/view/com/util/post-embeds/index.tsx
+++ b/src/view/com/util/post-embeds/index.tsx
@@ -3,7 +3,6 @@ import {
   InteractionManager,
   StyleProp,
   StyleSheet,
-  Text,
   View,
   ViewStyle,
 } from 'react-native'
@@ -22,7 +21,6 @@ import {
 } from '@atproto/api'
 
 import {ImagesLightbox, useLightboxControls} from '#/state/lightbox'
-import {useLargeAltBadgeEnabled} from '#/state/preferences/large-alt-badge'
 import {useModerationOpts} from '#/state/preferences/moderation-opts'
 import {usePalette} from 'lib/hooks/usePalette'
 import {FeedSourceCard} from 'view/com/feeds/FeedSourceCard'
@@ -60,7 +58,6 @@ export function PostEmbeds({
   contextView?: 'thread-highlighted'
 }) {
   const {openLightbox} = useLightboxControls()
-  const largeAltBadge = useLargeAltBadgeEnabled()
 
   // quote post with media
   // =
@@ -134,17 +131,8 @@ export function PostEmbeds({
                 disableCrop={contextView === 'thread-highlighted'}
                 image={image}
                 onPress={() => _openLightbox(0)}
-                onPressIn={() => onPressIn(0)}>
-                {image.alt === '' ? null : (
-                  <View style={styles.altContainer}>
-                    <Text
-                      style={[styles.alt, largeAltBadge && a.text_xs]}
-                      accessible={false}>
-                      ALT
-                    </Text>
-                  </View>
-                )}
-              </AutoSizedImage>
+                onPressIn={() => onPressIn(0)}
+              />
             </View>
           </ContentHider>
         )

--- a/src/view/com/util/post-embeds/index.tsx
+++ b/src/view/com/util/post-embeds/index.tsx
@@ -32,7 +32,10 @@ import {AutoSizedImage} from '../images/AutoSizedImage'
 import {ImageLayoutGrid} from '../images/ImageLayoutGrid'
 import {ExternalLinkEmbed} from './ExternalLinkEmbed'
 import {MaybeQuoteEmbed} from './QuoteEmbed'
+import {PostEmbedViewContext, QuoteEmbedViewContext} from './types'
 import {VideoEmbed} from './VideoEmbed'
+
+export * from './types'
 
 type Embed =
   | AppBskyEmbedRecord.View
@@ -55,7 +58,7 @@ export function PostEmbeds({
   onOpen?: () => void
   style?: StyleProp<ViewStyle>
   allowNestedQuotes?: boolean
-  viewContext?: 'thread-highlighted'
+  viewContext?: PostEmbedViewContext
 }) {
   const {openLightbox} = useLightboxControls()
 
@@ -70,7 +73,15 @@ export function PostEmbeds({
           onOpen={onOpen}
           viewContext={viewContext}
         />
-        <MaybeQuoteEmbed embed={embed.record} onOpen={onOpen} />
+        <MaybeQuoteEmbed
+          embed={embed.record}
+          onOpen={onOpen}
+          viewContext={
+            viewContext === PostEmbedViewContext.Feed
+              ? QuoteEmbedViewContext.FeedEmbedRecordWithMedia
+              : undefined
+          }
+        />
       </View>
     )
   }
@@ -129,7 +140,14 @@ export function PostEmbeds({
           <ContentHider modui={moderation?.ui('contentMedia')}>
             <View style={[styles.container, style]}>
               <AutoSizedImage
-                disableCrop={viewContext === 'thread-highlighted'}
+                crop={
+                  viewContext === PostEmbedViewContext.ThreadHighlighted
+                    ? 'none'
+                    : viewContext ===
+                      PostEmbedViewContext.FeedEmbedRecordWithMedia
+                    ? 'square'
+                    : 'constrained'
+                }
                 image={image}
                 onPress={() => _openLightbox(0)}
                 onPressIn={() => onPressIn(0)}

--- a/src/view/com/util/post-embeds/types.ts
+++ b/src/view/com/util/post-embeds/types.ts
@@ -1,0 +1,9 @@
+export enum PostEmbedViewContext {
+  ThreadHighlighted = 'ThreadHighlighted',
+  Feed = 'Feed',
+  FeedEmbedRecordWithMedia = 'FeedEmbedRecordWithMedia',
+}
+
+export enum QuoteEmbedViewContext {
+  FeedEmbedRecordWithMedia = PostEmbedViewContext.FeedEmbedRecordWithMedia,
+}


### PR DESCRIPTION
Constrains the height of images in feeds and threads.
- anything shorter than 1:1 appears in-full
- anything taller than 1:1 appears "contained" by it's parent height (a square, so proportional to column width)
- anything taller than 3:4 crops within a min-sized container (matches common photo size)
- in highlighted thread view, images are not cropped
  - unless very tall, they're cropped to 1:4, but still appear full-width
- QP with media crops embed image to 1:1 to save space

**To do**
- [x] check on wiiiide image case
- [x] add image bg for multi-image posts

# Cases
Too tall, crops to min-sized container
![CleanShot 2024-09-03 at 20 48 21@2x](https://github.com/user-attachments/assets/a4797d1a-0d34-46a1-bb73-423486967759)

Same in quotes
![CleanShot 2024-09-03 at 20 48 34@2x](https://github.com/user-attachments/assets/f3b46507-6b76-40c2-b694-56e4839aa99b)

Quotes with media appear slightly differently
![CleanShot 2024-09-04 at 11 12 29@2x](https://github.com/user-attachments/assets/e6a83dbf-0607-48b7-a4bd-ef975f883371)

Image shorter than 1:1 appears as it's normal crop
![CleanShot 2024-09-03 at 20 49 03@2x](https://github.com/user-attachments/assets/d4e555b3-b758-4928-9488-ec0082fce955)

Very wide images display in full (TBD if we want this)
![CleanShot 2024-09-03 at 20 56 01@2x](https://github.com/user-attachments/assets/7cc0de67-0ce7-41bf-953a-0b9b2087a463)

All images now have a background, so that while loading there's something to take up space
![CleanShot 2024-09-03 at 20 49 31@2x](https://github.com/user-attachments/assets/2f9c5d99-b436-4046-b9c8-6d6dbc3b6584)
![CleanShot 2024-09-03 at 21 07 04@2x](https://github.com/user-attachments/assets/58cd1d7e-3d97-492d-871e-130401720774)

Works in DMs too
![CleanShot 2024-09-04 at 10 38 12@2x](https://github.com/user-attachments/assets/e6cbc91e-95fa-4a75-80ec-a12d36136ed8)
