### PR TITLE
Fix a missing curly brace in pt-BR

### DIFF
--- a/src/locale/locales/pt-BR/messages.po
+++ b/src/locale/locales/pt-BR/messages.po
@@ -48,7 +48,7 @@ msgstr "{0, plural, one {# repostagem} other {# repostagens}}"
 
 #: src/components/KnownFollowers.tsx:179
 #~ msgid "{0, plural, one {and # other} other {and # others}}"
-#~ msgstr "{0, plural, one {e # outro} other {e # outros}"
+#~ msgstr "{0, plural, one {e # outro} other {e # outros}}"
 
 #: src/components/ProfileHoverCard/index.web.tsx:398
 #: src/screens/Profile/Header/Metrics.tsx:23


### PR DESCRIPTION

![2024-09-04 105309](https://github.com/user-attachments/assets/349ab85a-6e74-4101-9d7d-12325c7ce0e7)

When I was updating translations for other languages, I encountered this error indicating that a curly brace is missing in the pt-BR translation.

Although it’s a commented-out translation, it still seems to affect the generating process for target messages.js files, so I added the missing curly brace back.