### PR TITLE
[Statsig] Don't log extra background events

### DIFF
--- a/src/lib/statsig/statsig.tsx
+++ b/src/lib/statsig/statsig.tsx
@@ -226,11 +226,11 @@ AppState.addEventListener('change', (state: AppStateStatus) => {
     let secondsActive = 0
     if (lastActive != null) {
       secondsActive = Math.round((performance.now() - lastActive) / 1e3)
+      lastActive = null
+      logEvent('state:background:sampled', {
+        secondsActive,
+      })
     }
-    lastActive = null
-    logEvent('state:background:sampled', {
-      secondsActive,
-    })
   }
 })
 


### PR DESCRIPTION
Fixes excessive logging of `state:background:sampled` with `secondsActive = 0` on iOS.

The problem is that on iOS, app state goes `active` -> `inactive` -> `background`. As a result, the `else` branch of this code gets triggered both on `inactive` and `background`. It "correctly" counts the time only once (i.e. when going `active` -> `inactive`) and reports the other change as `secondsActive = 0` (because we weren't active in the first place). But it would be better not to send the event at all. With this change, only actual changes _to_ and _from_ `active` state emit the event.

## Test Plan

```diff
--- a/src/lib/statsig/statsig.tsx
+++ b/src/lib/statsig/statsig.tsx
@@ -222,11 +222,13 @@ AppState.addEventListener('change', (state: AppStateStatus) => {
   if (state === 'active') {
     lastActive = performance.now()
     logEvent('state:foreground:sampled', {})
+    console.log('log foreground')
   } else {
     let secondsActive = 0
     if (lastActive != null) {
       secondsActive = Math.round((performance.now() - lastActive) / 1e3)
       lastActive = null
+      console.log('log background', secondsActive)
       logEvent('state:background:sampled', {
         secondsActive,
       })
```

On iOS, verify logs show up when you switch away from the app and back to it. Verify there is no extra "log background 0" log which would've happened before this change. Verify pulling the notification center and back also gets counted as backgrounding and foregrounding.

On Android, verify logs show up when you switch away from the app and back to it.

On web, it doesn't feel like this setup works reliably at all — not sure if it broke at some point. Concretely, the listener only seems to fire as the tab is about to be closed, but it doesn't seem triggered on tab switch. That's unrelated to this PR though. 