### PR TITLE
Disable in-thread deduping for reposted replies

### DIFF
--- a/src/lib/api/feed-manip.ts
+++ b/src/lib/api/feed-manip.ts
@@ -271,7 +271,12 @@ export class FeedTuner {
           }
         } else {
           if (!dryRun) {
-            this.seenUris.add(item.post.uri)
+            // Reposting a reply elevates it to top-level, so its parent/root won't be displayed.
+            // Disable in-thread dedupe for this case since we don't want to miss them later.
+            const disableDedupe = slice.isReply && slice.isRepost
+            if (!disableDedupe) {
+              this.seenUris.add(item.post.uri)
+            }
           }
         }
       }


### PR DESCRIPTION
Fixes a bug where the author's Posts feed would miss some thread because a reply from it is reposted.

## Test Plan

Make a thread of two posts and repost the later one.

Before the fix:

![Screenshot 2024-09-04 at 09 16 08](https://github.com/user-attachments/assets/4bc4f08b-0d76-4c0d-b83b-3f52ddea824b)

After the fix:

![Screenshot 2024-09-04 at 09 15 57](https://github.com/user-attachments/assets/fb7ef89c-90ab-4d3e-ad4e-5ee7a4d79748)

