### PR TITLE
Tweak animation to not roll 0 -> 1, overflow hidden

### DIFF
--- a/src/lib/custom-animations/util.ts
+++ b/src/lib/custom-animations/util.ts
@@ -7,7 +7,7 @@ export function decideShouldRoll(isSet: boolean, count: number) {
   let shouldRoll = false
   if (!isSet && count === 0) {
     shouldRoll = true
-  } else if (count > 0 && count < 1000) {
+  } else if (count > 1 && count < 1000) {
     shouldRoll = true
   } else if (count > 0) {
     const mod = count % 100

--- a/src/lib/custom-animations/util.ts
+++ b/src/lib/custom-animations/util.ts
@@ -5,7 +5,7 @@
 // - The count is going down and is 1 less than a multiple of 100
 export function decideShouldRoll(isSet: boolean, count: number) {
   let shouldRoll = false
-  if (!isSet && count === 0) {
+  if (!isSet && count === 1) {
     shouldRoll = true
   } else if (count > 1 && count < 1000) {
     shouldRoll = true

--- a/src/view/com/util/post-ctrls/PostCtrls.tsx
+++ b/src/view/com/util/post-ctrls/PostCtrls.tsx
@@ -244,6 +244,7 @@ let PostCtrls = ({
       a.flex_row,
       a.justify_center,
       a.align_center,
+      a.overflow_hidden,
       {padding: 5},
       (pressed || hovered) && t.atoms.bg_contrast_25,
     ],


### PR DESCRIPTION
## Why

Just tweaking the like icon animation to:

- Not roll from 0 -> 1. Only the heart will animate in this case
- Add `overflow: hidden` to the wrapper so that the numbers don't go outside of the container

## Test Plan

Verify that liking a fresh post (zero likes) doesn't "roll in" the 1, and that the animation is "contained" to the button rather than animating outside of it.
