### PR TITLE
[Video] Check upload limits before uploading

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -137,6 +137,9 @@ export const GIF_FEATURED = (params: string) =>
 
 export const MAX_LABELERS = 20
 
+export const VIDEO_SERVICE = 'https://video.bsky.app'
+export const VIDEO_SERVICE_DID = 'did:web:video.bsky.app'
+
 export const SUPPORTED_MIME_TYPES = [
   'video/mp4',
   'video/mpeg',

--- a/src/lib/media/video/errors.ts
+++ b/src/lib/media/video/errors.ts
@@ -11,3 +11,10 @@ export class ServerError extends Error {
     this.name = 'ServerError'
   }
 }
+
+export class UploadLimitError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'UploadLimitError'
+  }
+}

--- a/src/state/queries/video/util.ts
+++ b/src/state/queries/video/util.ts
@@ -1,15 +1,13 @@
 import {useMemo} from 'react'
 import {AtpAgent} from '@atproto/api'
 
-import {SupportedMimeTypes} from '#/lib/constants'
-
-const UPLOAD_ENDPOINT = 'https://video.bsky.app/'
+import {SupportedMimeTypes, VIDEO_SERVICE} from '#/lib/constants'
 
 export const createVideoEndpointUrl = (
   route: string,
   params?: Record<string, string>,
 ) => {
-  const url = new URL(`${UPLOAD_ENDPOINT}`)
+  const url = new URL(VIDEO_SERVICE)
   url.pathname = route
   if (params) {
     for (const key in params) {
@@ -22,7 +20,7 @@ export const createVideoEndpointUrl = (
 export function useVideoAgent() {
   return useMemo(() => {
     return new AtpAgent({
-      service: UPLOAD_ENDPOINT,
+      service: VIDEO_SERVICE,
     })
   }, [])
 }

--- a/src/state/queries/video/video-upload.shared.ts
+++ b/src/state/queries/video/video-upload.shared.ts
@@ -2,54 +2,64 @@ import {useCallback} from 'react'
 import {msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
+import {VIDEO_SERVICE_DID} from '#/lib/constants'
 import {UploadLimitError} from '#/lib/media/video/errors'
 import {getServiceAuthAudFromUrl} from '#/lib/strings/url-helpers'
 import {useAgent} from '#/state/session'
 import {useVideoAgent} from './util'
 
-export function useServiceAuthToken() {
+export function useServiceAuthToken({
+  aud,
+  lxm,
+  exp,
+}: {
+  aud?: string
+  lxm: string
+  exp?: number
+}) {
   const agent = useAgent()
 
   return useCallback(async () => {
-    const serviceAuthAud = getServiceAuthAudFromUrl(agent.dispatchUrl)
+    const pdsAud = getServiceAuthAudFromUrl(agent.dispatchUrl)
 
-    if (!serviceAuthAud) {
+    if (!pdsAud) {
       throw new Error('Agent does not have a PDS URL')
     }
 
     const {data: serviceAuth} = await agent.com.atproto.server.getServiceAuth({
-      aud: serviceAuthAud,
-      lxm: 'com.atproto.repo.uploadBlob',
-      exp: Date.now() / 1000 + 60 * 30, // 30 minutes
+      aud: aud ?? pdsAud,
+      lxm,
+      exp,
     })
 
     return serviceAuth.token
-  }, [agent])
+  }, [agent, aud, lxm, exp])
 }
 
 export function useVideoUploadLimits() {
   const agent = useVideoAgent()
+  const getToken = useServiceAuthToken({
+    lxm: 'app.bsky.video.getUploadLimits',
+    aud: VIDEO_SERVICE_DID,
+  })
   const {_} = useLingui()
 
-  return useCallback(
-    async (token: string) => {
-      const {data: limits} = await agent.app.bsky.video.getUploadLimits(
-        {},
-        {headers: {Authorization: `Bearer ${token}`}},
-      )
+  return useCallback(async () => {
+    const {data: limits} = await agent.app.bsky.video.getUploadLimits(
+      {},
+      {headers: {Authorization: `Bearer ${await getToken()}`}},
+    )
 
-      if (!limits.canUpload) {
-        if (limits.message) {
-          throw new UploadLimitError(limits.message)
-        } else {
-          throw new UploadLimitError(
-            _(
-              msg`You have temporarily reached the limit for video uploads. Please try again later.`,
-            ),
-          )
-        }
+    if (!limits.canUpload) {
+      if (limits.message) {
+        throw new UploadLimitError(limits.message)
+      } else {
+        throw new UploadLimitError(
+          _(
+            msg`You have temporarily reached the limit for video uploads. Please try again later.`,
+          ),
+        )
       }
-    },
-    [agent, _],
-  )
+    }
+  }, [agent, _, getToken])
 }

--- a/src/state/queries/video/video-upload.shared.ts
+++ b/src/state/queries/video/video-upload.shared.ts
@@ -1,0 +1,24 @@
+import {useCallback} from 'react'
+
+import {getServiceAuthAudFromUrl} from '#/lib/strings/url-helpers'
+import {useAgent} from '#/state/session'
+
+export function useServiceAuthToken() {
+  const agent = useAgent()
+
+  return useCallback(async () => {
+    const serviceAuthAud = getServiceAuthAudFromUrl(agent.dispatchUrl)
+
+    if (!serviceAuthAud) {
+      throw new Error('Agent does not have a PDS URL')
+    }
+
+    const {data: serviceAuth} = await agent.com.atproto.server.getServiceAuth({
+      aud: serviceAuthAud,
+      lxm: 'com.atproto.repo.uploadBlob',
+      exp: Date.now() / 1000 + 60 * 30, // 30 minutes
+    })
+
+    return serviceAuth.token
+  }, [agent])
+}

--- a/src/state/queries/video/video-upload.shared.ts
+++ b/src/state/queries/video/video-upload.shared.ts
@@ -45,10 +45,18 @@ export function useVideoUploadLimits() {
   const {_} = useLingui()
 
   return useCallback(async () => {
-    const {data: limits} = await agent.app.bsky.video.getUploadLimits(
-      {},
-      {headers: {Authorization: `Bearer ${await getToken()}`}},
-    )
+    const {data: limits} = await agent.app.bsky.video
+      .getUploadLimits(
+        {},
+        {headers: {Authorization: `Bearer ${await getToken()}`}},
+      )
+      .catch(err => {
+        if (err instanceof Error) {
+          throw new UploadLimitError(err.message)
+        } else {
+          throw err
+        }
+      })
 
     if (!limits.canUpload) {
       if (limits.message) {

--- a/src/state/queries/video/video-upload.web.ts
+++ b/src/state/queries/video/video-upload.web.ts
@@ -9,7 +9,7 @@ import {ServerError} from '#/lib/media/video/errors'
 import {CompressedVideo} from '#/lib/media/video/types'
 import {createVideoEndpointUrl, mimeToExt} from '#/state/queries/video/util'
 import {useSession} from '#/state/session'
-import {useServiceAuthToken} from './video-upload.shared'
+import {useServiceAuthToken, useVideoUploadLimits} from './video-upload.shared'
 
 export const useUploadVideoMutation = ({
   onSuccess,
@@ -24,17 +24,20 @@ export const useUploadVideoMutation = ({
 }) => {
   const {currentAccount} = useSession()
   const getToken = useServiceAuthToken()
+  const checkLimits = useVideoUploadLimits()
   const {_} = useLingui()
 
   return useMutation({
     mutationKey: ['video', 'upload'],
     mutationFn: cancelable(async (video: CompressedVideo) => {
+      const token = await getToken()
+
+      await checkLimits(token)
+
       const uri = createVideoEndpointUrl('/xrpc/app.bsky.video.uploadVideo', {
         did: currentAccount!.did,
         name: `${nanoid(12)}.${mimeToExt(video.mimeType)}`,
       })
-
-      const token = await getToken()
 
       let bytes = video.bytes
       if (!bytes) {

--- a/src/state/queries/video/video-upload.web.ts
+++ b/src/state/queries/video/video-upload.web.ts
@@ -23,16 +23,17 @@ export const useUploadVideoMutation = ({
   signal: AbortSignal
 }) => {
   const {currentAccount} = useSession()
-  const getToken = useServiceAuthToken()
+  const getToken = useServiceAuthToken({
+    lxm: 'com.atproto.repo.uploadBlob',
+    exp: Date.now() / 1000 + 60 * 30, // 30 minutes
+  })
   const checkLimits = useVideoUploadLimits()
   const {_} = useLingui()
 
   return useMutation({
     mutationKey: ['video', 'upload'],
     mutationFn: cancelable(async (video: CompressedVideo) => {
-      const token = await getToken()
-
-      await checkLimits(token)
+      await checkLimits()
 
       const uri = createVideoEndpointUrl('/xrpc/app.bsky.video.uploadVideo', {
         did: currentAccount!.did,
@@ -43,6 +44,8 @@ export const useUploadVideoMutation = ({
       if (!bytes) {
         bytes = await fetch(video.uri).then(res => res.arrayBuffer())
       }
+
+      const token = await getToken()
 
       const xhr = new XMLHttpRequest()
       const res = await new Promise<AppBskyVideoDefs.JobStatus>(

--- a/src/state/queries/video/video-upload.web.ts
+++ b/src/state/queries/video/video-upload.web.ts
@@ -8,8 +8,8 @@ import {cancelable} from '#/lib/async/cancelable'
 import {ServerError} from '#/lib/media/video/errors'
 import {CompressedVideo} from '#/lib/media/video/types'
 import {createVideoEndpointUrl, mimeToExt} from '#/state/queries/video/util'
-import {useAgent, useSession} from '#/state/session'
-import {getServiceAuthAudFromUrl} from 'lib/strings/url-helpers'
+import {useSession} from '#/state/session'
+import {useServiceAuthToken} from './video-upload.shared'
 
 export const useUploadVideoMutation = ({
   onSuccess,
@@ -23,7 +23,7 @@ export const useUploadVideoMutation = ({
   signal: AbortSignal
 }) => {
   const {currentAccount} = useSession()
-  const agent = useAgent()
+  const getToken = useServiceAuthToken()
   const {_} = useLingui()
 
   return useMutation({
@@ -34,22 +34,9 @@ export const useUploadVideoMutation = ({
         name: `${nanoid(12)}.${mimeToExt(video.mimeType)}`,
       })
 
-      const serviceAuthAud = getServiceAuthAudFromUrl(agent.dispatchUrl)
-
-      if (!serviceAuthAud) {
-        throw new Error('Agent does not have a PDS URL')
-      }
-
-      const {data: serviceAuth} = await agent.com.atproto.server.getServiceAuth(
-        {
-          aud: serviceAuthAud,
-          lxm: 'com.atproto.repo.uploadBlob',
-          exp: Date.now() / 1000 + 60 * 30, // 30 minutes
-        },
-      )
+      const token = await getToken()
 
       let bytes = video.bytes
-
       if (!bytes) {
         bytes = await fetch(video.uri).then(res => res.arrayBuffer())
       }
@@ -76,7 +63,7 @@ export const useUploadVideoMutation = ({
           }
           xhr.open('POST', uri)
           xhr.setRequestHeader('Content-Type', video.mimeType)
-          xhr.setRequestHeader('Authorization', `Bearer ${serviceAuth.token}`)
+          xhr.setRequestHeader('Authorization', `Bearer ${token}`)
           xhr.send(bytes)
         },
       )

--- a/src/state/queries/video/video.ts
+++ b/src/state/queries/video/video.ts
@@ -167,7 +167,7 @@ export function useUploadVideo({
             break
           case "Failed to get user's upload stats":
             message = _(
-              msg`Error: could not determine if you're allowed to upload videos. Please try again.`,
+              msg`We were unable to determine if you are allowed to upload videos. Please try again.`,
             )
             break
           case 'User has exceeded daily upload bytes limit':

--- a/src/state/queries/video/video.ts
+++ b/src/state/queries/video/video.ts
@@ -9,7 +9,11 @@ import {AbortError} from '#/lib/async/cancelable'
 import {SUPPORTED_MIME_TYPES, SupportedMimeTypes} from '#/lib/constants'
 import {logger} from '#/logger'
 import {isWeb} from '#/platform/detection'
-import {ServerError, VideoTooLargeError} from 'lib/media/video/errors'
+import {
+  ServerError,
+  UploadLimitError,
+  VideoTooLargeError,
+} from 'lib/media/video/errors'
 import {CompressedVideo} from 'lib/media/video/types'
 import {useCompressVideoMutation} from 'state/queries/video/compress-video'
 import {useVideoAgent} from 'state/queries/video/util'
@@ -149,7 +153,7 @@ export function useUploadVideo({
     onError: e => {
       if (e instanceof AbortError) {
         return
-      } else if (e instanceof ServerError) {
+      } else if (e instanceof ServerError || e instanceof UploadLimitError) {
         dispatch({
           type: 'SetError',
           error: e.message,

--- a/src/state/queries/video/video.ts
+++ b/src/state/queries/video/video.ts
@@ -154,9 +154,39 @@ export function useUploadVideo({
       if (e instanceof AbortError) {
         return
       } else if (e instanceof ServerError || e instanceof UploadLimitError) {
+        let message
+        // https://github.com/bluesky-social/tango/blob/lumi/lumi/worker/permissions.go#L77
+        switch (e.message) {
+          case 'User is not allowed to upload videos':
+            message = _(msg`You are not allowed to upload videos.`)
+            break
+          case 'Uploading is disabled at the moment':
+            message = _(
+              msg`Hold up! We’re gradually giving access to video, and you’re still waiting in line. Check back soon!`,
+            )
+            break
+          case "Failed to get user's upload stats":
+            message = _(
+              msg`Error: could not determine if you're allowed to upload videos. Please try again.`,
+            )
+            break
+          case 'User has exceeded daily upload bytes limit':
+            message = _(
+              msg`You've reached your daily limit for video uploads (too many bytes)`,
+            )
+            break
+          case 'User has exceeded daily upload videos limit':
+            message = _(
+              msg`You've reached your daily limit for video uploads (too many videos)`,
+            )
+            break
+          default:
+            message = e.message
+            break
+        }
         dispatch({
           type: 'SetError',
-          error: e.message,
+          error: message,
         })
       } else {
         dispatch({

--- a/src/view/com/composer/videos/VideoPreview.web.tsx
+++ b/src/view/com/composer/videos/VideoPreview.web.tsx
@@ -42,7 +42,7 @@ export function VideoPreview({
     ref.current.addEventListener(
       'error',
       () => {
-        Toast.show(_(msg`Could not process your video`))
+        Toast.show(_(msg`Could not process your video`), 'xmark')
         clear()
       },
       {signal},


### PR DESCRIPTION
Implementation of `getUploadLimits` API. This is the point where you'll recieve `uploads_disabled`/`uploads_forbidden` errors, so this includes nice messages for that case.

# Test plan

Check network request `getUploadLimits` for however many videos you have left, and upload more than that many

Comment out the upload gate then try with an account that does not pass the gate