### PR TITLE
(RFC) Add explicit non-handling of detached quotes in embed

### DIFF
--- a/bskyembed/src/components/embed.tsx
+++ b/bskyembed/src/components/embed.tsx
@@ -158,6 +158,12 @@ export function Embed({
         return <Info>The quoted post is blocked.</Info>
       }
 
+      // Case 3.8: Detached quote post
+      if (AppBskyEmbedRecord.isViewDetached(record)) {
+        // Just don't show anything
+        return null
+      }
+
       // Unknown embed type
       return null
     }


### PR DESCRIPTION
My thinking here is that we don't need to publicize beef between users. If a embed exists on a site, and a quote is later detached, it should just render nothing and not entice users to click on it for negative reasons.

The embed already behaves like this, but I added a specific check to make it more clear.