### PR TITLE
[Video] throw HLS errors to be caught by error boundary

### DIFF
--- a/src/view/com/util/post-embeds/VideoEmbed.tsx
+++ b/src/view/com/util/post-embeds/VideoEmbed.tsx
@@ -1,7 +1,7 @@
 import React, {useCallback, useEffect, useId, useState} from 'react'
 import {View} from 'react-native'
 import {Image} from 'expo-image'
-import {VideoPlayerStatus} from 'expo-video'
+import {PlayerError, VideoPlayerStatus} from 'expo-video'
 import {AppBskyEmbedVideo} from '@atproto/api'
 import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
@@ -79,7 +79,7 @@ function InnerWrapper({embed}: Props) {
       playerStatus === 'loading')
 
   // send error up to error boundary
-  const [error, setError] = useState<Error | null>(null)
+  const [error, setError] = useState<Error | PlayerError | null>(null)
   if (error) {
     throw error
   }
@@ -98,10 +98,10 @@ function InnerWrapper({embed}: Props) {
       )
       const statusSub = player.addListener(
         'statusChange',
-        (status, _oldStatus, error) => {
+        (status, _oldStatus, playerError) => {
           setPlayerStatus(status)
           if (status === 'error') {
-            setError(error)
+            setError(playerError ?? new Error('Unknown player error'))
           }
         },
       )

--- a/src/view/com/util/post-embeds/VideoEmbed.tsx
+++ b/src/view/com/util/post-embeds/VideoEmbed.tsx
@@ -78,6 +78,12 @@ function InnerWrapper({embed}: Props) {
     (playerStatus === 'waitingToPlayAtSpecifiedRate' ||
       playerStatus === 'loading')
 
+  // send error up to error boundary
+  const [error, setError] = useState<Error | null>(null)
+  if (error) {
+    throw error
+  }
+
   useEffect(() => {
     if (isActive) {
       // eslint-disable-next-line @typescript-eslint/no-shadow
@@ -95,7 +101,7 @@ function InnerWrapper({embed}: Props) {
         (status, _oldStatus, error) => {
           setPlayerStatus(status)
           if (status === 'error') {
-            throw error
+            setError(error)
           }
         },
       )

--- a/src/view/com/util/post-embeds/VideoEmbed.web.tsx
+++ b/src/view/com/util/post-embeds/VideoEmbed.web.tsx
@@ -1,13 +1,15 @@
 import React, {useCallback, useEffect, useRef, useState} from 'react'
 import {View} from 'react-native'
 import {AppBskyEmbedVideo} from '@atproto/api'
-import {Trans} from '@lingui/macro'
+import {msg} from '@lingui/macro'
+import {useLingui} from '@lingui/react'
 
 import {clamp} from '#/lib/numbers'
 import {useGate} from '#/lib/statsig/statsig'
 import {
   HLSUnsupportedError,
   VideoEmbedInnerWeb,
+  VideoNotFoundError,
 } from '#/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerWeb'
 import {atoms as a} from '#/alf'
 import {ErrorBoundary} from '../ErrorBoundary'
@@ -152,23 +154,28 @@ function ViewportObserver({
 }
 
 function VideoError({error, retry}: {error: unknown; retry: () => void}) {
-  const isHLS = error instanceof HLSUnsupportedError
+  const {_} = useLingui()
+
+  let showRetryButton = true
+  let text = null
+
+  if (error instanceof VideoNotFoundError) {
+    text = _(msg`Video not found.`)
+  } else if (error instanceof HLSUnsupportedError) {
+    showRetryButton = false
+    text = _(
+      msg`Your browser does not support the video format. Please try a different browser.`,
+    )
+  } else {
+    text = _(
+      msg`An error occurred while loading the video. Please try again later.`,
+    )
+  }
 
   return (
     <VideoFallback.Container>
-      <VideoFallback.Text>
-        {isHLS ? (
-          <Trans>
-            Your browser does not support the video format. Please try a
-            different browser.
-          </Trans>
-        ) : (
-          <Trans>
-            An error occurred while loading the video. Please try again later.
-          </Trans>
-        )}
-      </VideoFallback.Text>
-      {!isHLS && <VideoFallback.RetryButton onPress={retry} />}
+      <VideoFallback.Text>{text}</VideoFallback.Text>
+      {showRetryButton && <VideoFallback.RetryButton onPress={retry} />}
     </VideoFallback.Container>
   )
 }

--- a/src/view/com/util/post-embeds/VideoEmbed.web.tsx
+++ b/src/view/com/util/post-embeds/VideoEmbed.web.tsx
@@ -167,9 +167,7 @@ function VideoError({error, retry}: {error: unknown; retry: () => void}) {
       msg`Your browser does not support the video format. Please try a different browser.`,
     )
   } else {
-    text = _(
-      msg`An error occurred while loading the video. Please try again later.`,
-    )
+    text = _(msg`An error occurred while loading the video. Please try again.`)
   }
 
   return (


### PR DESCRIPTION
If `expo-video` or `hls.js` encounters a fatal error, throw it up to the error boundary. On web 404 errors are special-cased with a friendlier error message.

<img width="593" alt="Screenshot 2024-09-05 at 15 23 54" src="https://github.com/user-attachments/assets/921fbe3b-2c87-472f-acd5-833606d1fb94">
<img width="592" alt="Screenshot 2024-09-05 at 15 24 47" src="https://github.com/user-attachments/assets/3cfc5b35-d0f4-4767-81dd-58d0e429e8ab">

![image](https://github.com/user-attachments/assets/976cf01a-66c1-4a8c-ab68-13c6c30aacd1)


# Test plan

Check out https://bsky.app/profile/samuel.bsky.team/post/3l3drakerfs2o