### PR TITLE
Add eslint rule to fix imports without the `#/` path alias

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -33,6 +33,7 @@ module.exports = {
     ],
     'bsky-internal/use-exact-imports': 'error',
     'bsky-internal/use-typed-gates': 'error',
+    'bsky-internal/use-prefixed-imports': 'warn',
     'simple-import-sort/imports': [
       'warn',
       {

--- a/eslint/index.js
+++ b/eslint/index.js
@@ -5,5 +5,6 @@ module.exports = {
     'avoid-unwrapped-text': require('./avoid-unwrapped-text'),
     'use-exact-imports': require('./use-exact-imports'),
     'use-typed-gates': require('./use-typed-gates'),
+    'use-prefixed-imports': require('./use-prefixed-imports'),
   },
 }

--- a/eslint/use-exact-imports.js
+++ b/eslint/use-exact-imports.js
@@ -1,4 +1,3 @@
-/* eslint-disable bsky-internal/use-exact-imports */
 const BANNED_IMPORTS = [
   '@fortawesome/free-regular-svg-icons',
   '@fortawesome/free-solid-svg-icons',
@@ -6,11 +5,12 @@ const BANNED_IMPORTS = [
 
 exports.create = function create(context) {
   return {
-    Literal(node) {
-      if (typeof node.value !== 'string') {
+    ImportDeclaration(node) {
+      const source = node.source
+      if (typeof source.value !== 'string') {
         return
       }
-      if (BANNED_IMPORTS.includes(node.value)) {
+      if (BANNED_IMPORTS.includes(source.value)) {
         context.report({
           node,
           message:

--- a/eslint/use-prefixed-imports.js
+++ b/eslint/use-prefixed-imports.js
@@ -1,0 +1,39 @@
+const BANNED_IMPORT_PREFIXES = [
+  'alf/',
+  'components/',
+  'lib/',
+  'locale/',
+  'logger/',
+  'platform/',
+  'state/',
+  'storage/',
+  'view/',
+]
+
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    fixable: 'code',
+  },
+  create(context) {
+    return {
+      ImportDeclaration(node) {
+        const source = node.source
+        if (typeof source.value !== 'string') {
+          return
+        }
+        if (
+          BANNED_IMPORT_PREFIXES.some(banned => source.value.startsWith(banned))
+        ) {
+          context.report({
+            node: source,
+            message: `Use '#/${source.value}'`,
+            fix(fixer) {
+              return fixer.replaceText(source, `'#/${source.value}'`)
+            },
+          })
+        }
+      },
+    }
+  },
+}


### PR DESCRIPTION
Warns and auto-fixes imports without the `#/` path alias

Hopefully we can incrementally roll this out like we did with import sorting so the codebase gets cleaned up over time, and eventually we can remove the prefix-less path alias from the tsconfig.json

<img width="846" alt="Screenshot 2024-09-06 at 01 10 59" src="https://github.com/user-attachments/assets/2fad2355-eb2e-4b96-b35b-e13e55ae6424">

Also makes the `use-exact-import` rule more specific about which nodes it checks, which should be more efficient.