### PR TITLE
Add support for autofill of one-time-code for email verification

### DIFF
--- a/src/view/com/modals/VerifyEmail.tsx
+++ b/src/view/com/modals/VerifyEmail.tsx
@@ -173,7 +173,7 @@ export function Component({
             accessibilityLabel={_(msg`Confirmation code`)}
             accessibilityHint=""
             autoCapitalize="none"
-            autoComplete="off"
+            autoComplete="one-time-code"
             autoCorrect={false}
           />
         ) : undefined}


### PR DESCRIPTION
Haven't been able to confirm this works, might be an issue with running in Expo, but I did test on a physical iOS device and no changes to functionality, so I think we might as well try it.