### PR TITLE
[Statsig] Add more events to downsample, increase downsample rate

### DIFF
--- a/src/Navigation.tsx
+++ b/src/Navigation.tsx
@@ -661,16 +661,15 @@ function RoutesContainer({children}: React.PropsWithChildren<{}>) {
       linking={LINKING}
       theme={theme}
       onStateChange={() => {
-        logEvent('router:navigate:sampled', {
-          from: prevLoggedRouteName.current,
-        })
-        prevLoggedRouteName.current = getCurrentRouteName()
+        const routeName = getCurrentRouteName()
+        if (routeName === 'Notifications') {
+          logEvent('router:navigate:notifications:sampled', {})
+        }
       }}
       onReady={() => {
         attachRouteToLogEvents(getCurrentRouteName)
         logModuleInitTime()
         onReady()
-        logEvent('router:navigate:sampled', {})
       }}>
       {children}
     </NavigationContainer>

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -276,8 +276,8 @@ export function DescriptionPlaceholder() {
 export type FollowButtonProps = {
   profile: AppBskyActorDefs.ProfileViewBasic
   moderationOpts: ModerationOpts
-  logContext: LogEvents['profile:follow']['logContext'] &
-    LogEvents['profile:unfollow']['logContext']
+  logContext: LogEvents['profile:follow:sampled']['logContext'] &
+    LogEvents['profile:unfollow:sampled']['logContext']
 } & Partial<ButtonProps>
 
 export function FollowButton(props: FollowButtonProps) {

--- a/src/components/hooks/useFollowMethods.ts
+++ b/src/components/hooks/useFollowMethods.ts
@@ -15,8 +15,8 @@ export function useFollowMethods({
   logContext,
 }: {
   profile: Shadow<AppBskyActorDefs.ProfileViewBasic>
-  logContext: LogEvents['profile:follow']['logContext'] &
-    LogEvents['profile:unfollow']['logContext']
+  logContext: LogEvents['profile:follow:sampled']['logContext'] &
+    LogEvents['profile:unfollow:sampled']['logContext']
 }) {
   const {_} = useLingui()
   const requireAuth = useRequireAuth()

--- a/src/lib/statsig/events.ts
+++ b/src/lib/statsig/events.ts
@@ -25,7 +25,7 @@ export type LogEvents = {
     secondsActive: number
   }
   'state:foreground:sampled': {}
-  'router:navigate:sampled': {}
+  'router:navigate:notifications:sampled': {}
   'deepLink:referrerReceived': {
     to: string
     referrer: string
@@ -127,25 +127,25 @@ export type LogEvents = {
     langs: string
     logContext: 'Composer'
   }
-  'post:like': {
+  'post:like:sampled': {
     doesLikerFollowPoster: boolean | undefined
     doesPosterFollowLiker: boolean | undefined
     likerClout: number | undefined
     postClout: number | undefined
     logContext: 'FeedItem' | 'PostThreadItem' | 'Post'
   }
-  'post:repost': {
+  'post:repost:sampled': {
     logContext: 'FeedItem' | 'PostThreadItem' | 'Post'
   }
-  'post:unlike': {
+  'post:unlike:sampled': {
     logContext: 'FeedItem' | 'PostThreadItem' | 'Post'
   }
-  'post:unrepost': {
+  'post:unrepost:sampled': {
     logContext: 'FeedItem' | 'PostThreadItem' | 'Post'
   }
   'post:mute': {}
   'post:unmute': {}
-  'profile:follow': {
+  'profile:follow:sampled': {
     didBecomeMutual: boolean | undefined
     followeeClout: number | undefined
     followerClout: number | undefined
@@ -162,7 +162,7 @@ export type LogEvents = {
       | 'FeedInterstitial'
       | 'ProfileHeaderSuggestedFollows'
   }
-  'profile:unfollow': {
+  'profile:unfollow:sampled': {
     logContext:
       | 'RecommendedFollowsItem'
       | 'PostThreadItem'

--- a/src/lib/statsig/statsig.tsx
+++ b/src/lib/statsig/statsig.tsx
@@ -107,7 +107,8 @@ const DOWNSAMPLED_EVENTS: Set<keyof LogEvents> = new Set([
   'profile:follow:sampled',
   'profile:unfollow:sampled',
 ])
-const isDownsampledSession = Math.random() < DOWNSAMPLE_RATE
+// const isDownsampledSession = Math.random() < DOWNSAMPLE_RATE
+const isDownsampledSession = false
 
 export function logEvent<E extends keyof LogEvents>(
   eventName: E & string,
@@ -124,13 +125,14 @@ export function logEvent<E extends keyof LogEvents>(
       )
     }
 
-    if (isDownsampledSession && DOWNSAMPLED_EVENTS.has(eventName)) {
+    const isDownsampledEvent = DOWNSAMPLED_EVENTS.has(eventName)
+    if (isDownsampledSession && isDownsampledEvent) {
       return
     }
     const fullMetadata = {
       ...rawMetadata,
     } as Record<string, string> // Statsig typings are unnecessarily strict here.
-    if (isDownsampledSession) {
+    if (isDownsampledEvent) {
       fullMetadata.downsampleRate = DOWNSAMPLE_RATE.toString()
     }
     fullMetadata.routeName = getCurrentRouteName() ?? '(Uninitialized)'

--- a/src/lib/statsig/statsig.tsx
+++ b/src/lib/statsig/statsig.tsx
@@ -107,8 +107,7 @@ const DOWNSAMPLED_EVENTS: Set<keyof LogEvents> = new Set([
   'profile:follow:sampled',
   'profile:unfollow:sampled',
 ])
-// const isDownsampledSession = Math.random() < DOWNSAMPLE_RATE
-const isDownsampledSession = false
+const isDownsampledSession = Math.random() < DOWNSAMPLE_RATE
 
 export function logEvent<E extends keyof LogEvents>(
   eventName: E & string,

--- a/src/lib/statsig/statsig.tsx
+++ b/src/lib/statsig/statsig.tsx
@@ -90,7 +90,7 @@ export function toClout(n: number | null | undefined): number | undefined {
 }
 
 const DOWNSAMPLED_EVENTS: Set<keyof LogEvents> = new Set([
-  'router:navigate:sampled',
+  'router:navigate:notifications:sampled',
   'state:background:sampled',
   'state:foreground:sampled',
   'home:feedDisplayed:sampled',
@@ -99,8 +99,14 @@ const DOWNSAMPLED_EVENTS: Set<keyof LogEvents> = new Set([
   'discover:clickthrough:sampled',
   'discover:engaged:sampled',
   'discover:seen:sampled',
+  'post:like:sampled',
+  'post:unlike:sampled',
+  'post:repost:sampled',
+  'post:unrepost:sampled',
+  'profile:follow:sampled',
+  'profile:unfollow:sampled',
 ])
-const isDownsampledSession = Math.random() < 0.9 // 90% likely
+const isDownsampledSession = Math.random() < 0.95 // 95% likely
 
 export function logEvent<E extends keyof LogEvents>(
   eventName: E & string,

--- a/src/state/queries/post.ts
+++ b/src/state/queries/post.ts
@@ -99,8 +99,8 @@ export function useGetPosts() {
 
 export function usePostLikeMutationQueue(
   post: Shadow<AppBskyFeedDefs.PostView>,
-  logContext: LogEvents['post:like']['logContext'] &
-    LogEvents['post:unlike']['logContext'],
+  logContext: LogEvents['post:like:sampled']['logContext'] &
+    LogEvents['post:unlike:sampled']['logContext'],
 ) {
   const queryClient = useQueryClient()
   const postUri = post.uri
@@ -158,7 +158,7 @@ export function usePostLikeMutationQueue(
 }
 
 function usePostLikeMutation(
-  logContext: LogEvents['post:like']['logContext'],
+  logContext: LogEvents['post:like:sampled']['logContext'],
   post: Shadow<AppBskyFeedDefs.PostView>,
 ) {
   const {currentAccount} = useSession()
@@ -175,7 +175,7 @@ function usePostLikeMutation(
       if (currentAccount) {
         ownProfile = findProfileQueryData(queryClient, currentAccount.did)
       }
-      logEvent('post:like', {
+      logEvent('post:like:sampled', {
         logContext,
         doesPosterFollowLiker: postAuthor.viewer
           ? Boolean(postAuthor.viewer.followedBy)
@@ -200,12 +200,12 @@ function usePostLikeMutation(
 }
 
 function usePostUnlikeMutation(
-  logContext: LogEvents['post:unlike']['logContext'],
+  logContext: LogEvents['post:unlike:sampled']['logContext'],
 ) {
   const agent = useAgent()
   return useMutation<void, Error, {postUri: string; likeUri: string}>({
     mutationFn: ({likeUri}) => {
-      logEvent('post:unlike', {logContext})
+      logEvent('post:unlike:sampled', {logContext})
       return agent.deleteLike(likeUri)
     },
     onSuccess() {
@@ -216,8 +216,8 @@ function usePostUnlikeMutation(
 
 export function usePostRepostMutationQueue(
   post: Shadow<AppBskyFeedDefs.PostView>,
-  logContext: LogEvents['post:repost']['logContext'] &
-    LogEvents['post:unrepost']['logContext'],
+  logContext: LogEvents['post:repost:sampled']['logContext'] &
+    LogEvents['post:unrepost:sampled']['logContext'],
 ) {
   const queryClient = useQueryClient()
   const postUri = post.uri
@@ -273,7 +273,7 @@ export function usePostRepostMutationQueue(
 }
 
 function usePostRepostMutation(
-  logContext: LogEvents['post:repost']['logContext'],
+  logContext: LogEvents['post:repost:sampled']['logContext'],
 ) {
   const agent = useAgent()
   return useMutation<
@@ -282,7 +282,7 @@ function usePostRepostMutation(
     {uri: string; cid: string} // the post's uri and cid
   >({
     mutationFn: post => {
-      logEvent('post:repost', {logContext})
+      logEvent('post:repost:sampled', {logContext})
       return agent.repost(post.uri, post.cid)
     },
     onSuccess() {
@@ -292,12 +292,12 @@ function usePostRepostMutation(
 }
 
 function usePostUnrepostMutation(
-  logContext: LogEvents['post:unrepost']['logContext'],
+  logContext: LogEvents['post:unrepost:sampled']['logContext'],
 ) {
   const agent = useAgent()
   return useMutation<void, Error, {postUri: string; repostUri: string}>({
     mutationFn: ({repostUri}) => {
-      logEvent('post:unrepost', {logContext})
+      logEvent('post:unrepost:sampled', {logContext})
       return agent.deleteRepost(repostUri)
     },
     onSuccess() {

--- a/src/state/queries/profile.ts
+++ b/src/state/queries/profile.ts
@@ -219,8 +219,8 @@ export function useProfileUpdateMutation() {
 
 export function useProfileFollowMutationQueue(
   profile: Shadow<AppBskyActorDefs.ProfileViewDetailed>,
-  logContext: LogEvents['profile:follow']['logContext'] &
-    LogEvents['profile:unfollow']['logContext'],
+  logContext: LogEvents['profile:follow:sampled']['logContext'] &
+    LogEvents['profile:follow:sampled']['logContext'],
 ) {
   const agent = useAgent()
   const queryClient = useQueryClient()
@@ -291,7 +291,7 @@ export function useProfileFollowMutationQueue(
 }
 
 function useProfileFollowMutation(
-  logContext: LogEvents['profile:follow']['logContext'],
+  logContext: LogEvents['profile:follow:sampled']['logContext'],
   profile: Shadow<AppBskyActorDefs.ProfileViewDetailed>,
 ) {
   const {currentAccount} = useSession()
@@ -306,7 +306,7 @@ function useProfileFollowMutation(
         ownProfile = findProfileQueryData(queryClient, currentAccount.did)
       }
       captureAction(ProgressGuideAction.Follow)
-      logEvent('profile:follow', {
+      logEvent('profile:follow:sampled', {
         logContext,
         didBecomeMutual: profile.viewer
           ? Boolean(profile.viewer.followedBy)
@@ -323,12 +323,12 @@ function useProfileFollowMutation(
 }
 
 function useProfileUnfollowMutation(
-  logContext: LogEvents['profile:unfollow']['logContext'],
+  logContext: LogEvents['profile:unfollow:sampled']['logContext'],
 ) {
   const agent = useAgent()
   return useMutation<void, Error, {did: string; followUri: string}>({
     mutationFn: async ({followUri}) => {
-      logEvent('profile:unfollow', {logContext})
+      logEvent('profile:unfollow:sampled', {logContext})
       track('Profile:Unfollow', {username: followUri})
       return await agent.deleteFollow(followUri)
     },


### PR DESCRIPTION
## Why

We want to do more downsampling of some events, because they are really noisy. Here we go! Doing two things here:

- Tweaking the downsample rate from 90% to 95%
- Remove navigation event, but continue recording navigation to the notifications tab
- Adding some more events for downsampling:
  -  'post:like:sampled'
  - 'post:unlike:sampled'
  - 'post:repost:sampled'
  - 'post:unrepost:sampled'
  - 'profile:follow:sampled'
  - 'profile:unfollow:sampled'
- Adding `downsampleRate` to downsampled event metadata

## Test Plan

This is a pretty simple change that is mostly verified by typecheck. Adding `sampled` to the end of the existing events handles downsampling for us with existing logic.

Testing that the metadata is being added can be done by just changing `isDownsampledSession` to `false`, then checking the network logs for something like post like (you'll need to spam some likes, doing it on a single post works).

![Screenshot 2024-09-06 at 3 39 12 PM](https://github.com/user-attachments/assets/6f61832b-c615-4c45-8b04-ce13efec1d1a)
