### PR TITLE
fix: remove duplicate style `rounded_sm`

### DIFF
--- a/src/view/com/util/Toast.tsx
+++ b/src/view/com/util/Toast.tsx
@@ -59,7 +59,6 @@ function Toast({
             a.flex_1,
             t.atoms.bg,
             a.shadow_lg,
-            a.rounded_sm,
             t.atoms.border_contrast_medium,
             a.rounded_sm,
             a.px_md,


### PR DESCRIPTION
Only one deduplicated style is removed in the `util/Toast.tsx` component.
