### PR TITLE
Add autoCapitalize to Signup password field

### DIFF
--- a/src/screens/Signup/StepInfo/index.tsx
+++ b/src/screens/Signup/StepInfo/index.tsx
@@ -172,6 +172,7 @@ export function StepInfo({
                   defaultValue={state.password}
                   secureTextEntry
                   autoComplete="new-password"
+                  autoCapitalize="none"
                 />
               </TextField.Root>
             </View>


### PR DESCRIPTION
Pretty small QOL change, found this while creating my first account some minutes ago. For some reason the main login form already have autoCapitalize to none, but the signup form hasn't.