### PR TITLE
Syntax Highlighting for Handles

### DIFF
--- a/package.json
+++ b/package.json
@@ -204,6 +204,7 @@
     "statsig-react-native-expo": "^4.6.1",
     "tippy.js": "^6.3.7",
     "tlds": "^1.234.0",
+    "tldts": "^6.1.43",
     "zeego": "^1.6.2",
     "zod": "^3.20.2"
   },

--- a/src/components/FeedCard.tsx
+++ b/src/components/FeedCard.tsx
@@ -17,9 +17,9 @@ import {
   usePreferencesQuery,
   useRemoveFeedMutation,
 } from '#/state/queries/preferences'
-import {sanitizeHandle} from 'lib/strings/handles'
 import {precacheFeedFromGeneratorView} from 'state/queries/feed'
 import {useSession} from 'state/session'
+import {HighlightedHandle} from '#/view/com/util/HighlightedHandle'
 import {UserAvatar} from '#/view/com/util/UserAvatar'
 import * as Toast from 'view/com/util/Toast'
 import {useTheme} from '#/alf'
@@ -128,7 +128,7 @@ export function TitleAndByline({
         <Text
           style={[a.leading_snug, t.atoms.text_contrast_medium]}
           numberOfLines={1}>
-          <Trans>Feed by {sanitizeHandle(creator.handle, '@')}</Trans>
+          <Trans>Feed by {<HighlightedHandle handle={creator.handle} />}</Trans>
         </Text>
       )}
     </View>

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -15,6 +15,7 @@ import {useProfileFollowMutationQueue} from '#/state/queries/profile'
 import {sanitizeHandle} from 'lib/strings/handles'
 import {useProfileShadow} from 'state/cache/profile-shadow'
 import {useSession} from 'state/session'
+import {HighlightedHandle} from '#/view/com/util/HighlightedHandle'
 import * as Toast from '#/view/com/util/Toast'
 import {ProfileCardPills} from 'view/com/profile/ProfileCard'
 import {UserAvatar} from 'view/com/util/UserAvatar'
@@ -170,8 +171,6 @@ export function NameAndHandle({
     profile.displayName || sanitizeHandle(profile.handle),
     moderation.ui('displayName'),
   )
-  const handle = sanitizeHandle(profile.handle, '@')
-
   return (
     <View style={[a.flex_1]}>
       <Text
@@ -182,7 +181,7 @@ export function NameAndHandle({
       <Text
         style={[a.leading_snug, t.atoms.text_contrast_medium]}
         numberOfLines={1}>
-        {handle}
+        <HighlightedHandle handle={profile.handle} />
       </Text>
     </View>
   )

--- a/src/screens/Profile/Header/Handle.tsx
+++ b/src/screens/Profile/Header/Handle.tsx
@@ -6,6 +6,7 @@ import {Trans} from '@lingui/macro'
 import {Shadow} from '#/state/cache/types'
 import {isInvalidHandle} from 'lib/strings/handles'
 import {isIOS} from 'platform/detection'
+import {HighlightedHandle} from '#/view/com/util/HighlightedHandle'
 import {atoms as a, useTheme, web} from '#/alf'
 import {NewskieDialog} from '#/components/NewskieDialog'
 import {Text} from '#/components/Typography'
@@ -47,7 +48,7 @@ export function ProfileHeaderHandle({
             : [a.text_md, a.leading_tight, t.atoms.text_contrast_medium],
           web({wordBreak: 'break-all'}),
         ]}>
-        {invalidHandle ? <Trans>⚠Invalid Handle</Trans> : `@${profile.handle}`}
+        <HighlightedHandle handle={profile.handle} />
       </Text>
     </View>
   )

--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -40,6 +40,7 @@ import {PostHider} from '../../../components/moderation/PostHider'
 import {WhoCanReply} from '../../../components/WhoCanReply'
 import {getTranslatorLink, isPostInLanguage} from '../../../locale/helpers'
 import {ErrorMessage} from '../util/error/ErrorMessage'
+import {HighlightedHandle} from '../util/HighlightedHandle'
 import {Link, TextLink} from '../util/Link'
 import {formatCount} from '../util/numeric/format'
 import {PostCtrls} from '../util/post-ctrls/PostCtrls'
@@ -323,7 +324,7 @@ let PostThreadItemLoaded = ({
               <View style={styles.meta}>
                 <Link style={s.flex1} href={authorHref} title={authorTitle}>
                   <Text type="md" style={[pal.textLight]} numberOfLines={1}>
-                    {sanitizeHandle(post.author.handle, '@')}
+                    <HighlightedHandle handle={post.author.handle} />
                   </Text>
                 </Link>
               </View>

--- a/src/view/com/profile/ProfileCard.tsx
+++ b/src/view/com/profile/ProfileCard.tsx
@@ -24,6 +24,7 @@ import {
   shouldShowKnownFollowers,
 } from '#/components/KnownFollowers'
 import * as Pills from '#/components/Pills'
+import {HighlightedHandle} from '../util/HighlightedHandle'
 import {Link} from '../util/Link'
 import {Text} from '../util/text/Text'
 import {PreviewableUserAvatar} from '../util/UserAvatar'
@@ -113,7 +114,7 @@ export function ProfileCard({
             )}
           </Text>
           <Text type="md" style={[pal.textLight]} numberOfLines={1}>
-            {sanitizeHandle(profile.handle, '@')}
+            <HighlightedHandle handle={profile.handle} />
           </Text>
           <ProfileCardPills
             followedBy={!!profile.viewer?.followedBy}

--- a/src/view/com/util/HighlightedHandle.tsx
+++ b/src/view/com/util/HighlightedHandle.tsx
@@ -101,13 +101,10 @@ function getSpoof(suffix: string) {
     .slice(0, suffix.length - publicSuffix.length - 1)
     .split('.')
 
-  // ideally, we'd always start at 0, but the ammount of gTLDs is so large
+  // ideally, we'd start at 0, but the ammount of gTLDs is so large
   // that we end up with a lot of false positives for very common words
-  // in subdomains, like `blog`, `app`, `shop`, etc. We start at zero only
-  // if the suffix is long enough
-  let start = parts.length > 2 ? 0 : 1
-
-  for (let i = start; i < parts.length; i++) {
+  // in subdomains, like `blog`, `app`, `shop`, etc.
+  for (let i = 1; i < parts.length; i++) {
     // TODO: perhaps we should use a more restrictive list of gTLDs to avoid false positives
     if (tlds.includes(parts[i])) {
       return parts.slice(0, i + 1).join('.')

--- a/src/view/com/util/HighlightedHandle.tsx
+++ b/src/view/com/util/HighlightedHandle.tsx
@@ -1,0 +1,154 @@
+import React from 'react'
+import {Text} from 'react-native'
+import {TextStyle} from 'react-native'
+import {Trans} from '@lingui/macro'
+import tlds from 'tlds'
+import {getPublicSuffix} from 'tldts'
+
+import {isInvalidHandle} from '#/lib/strings/handles'
+import {atoms as a, useTheme} from '#/alf'
+
+// We can't really use `forceLTR()` here, because we'll be using
+// rich text, so we use the unicode characters directly.
+const LEFT_TO_RIGHT_EMBEDDING = '\u202A'
+const POP_DIRECTIONAL_FORMATTING = '\u202C'
+
+/**
+ * A syntax highlighted version of a handle, to provide cues to the user about
+ * the handle's structure, as well as to make spoofing attempts more visible.
+ */
+export function HighlightedHandle({
+  handle,
+  style,
+  suffixStyle,
+  spoofStyle,
+}: {
+  handle: string
+  style?: TextStyle[] | TextStyle
+  suffixStyle?: TextStyle[] | TextStyle
+  spoofStyle?: TextStyle[] | TextStyle
+}) {
+  const t = useTheme()
+
+  style ??= [t.atoms.text_contrast_medium]
+  suffixStyle ??= [t.atoms.text_contrast_low]
+  spoofStyle ??= [a.strike_through]
+
+  const {prefix, spoof, suffix} = React.useMemo(
+    () => getHandleParts(handle),
+    [handle],
+  )
+
+  if (isInvalidHandle(handle)) {
+    return (
+      <Text style={style}>
+        <Trans>⚠Invalid Handle</Trans>
+      </Text>
+    )
+  }
+
+  return (
+    <Text style={style}>
+      {LEFT_TO_RIGHT_EMBEDDING}@{prefix}
+      {suffix != null && (
+        <Text style={suffixStyle}>
+          {spoof != null && (
+            <>
+              .<Text style={spoofStyle}>{spoof}</Text>
+            </>
+          )}
+          .{suffix}
+        </Text>
+      )}
+      {POP_DIRECTIONAL_FORMATTING}
+    </Text>
+  )
+}
+
+/**
+ * Gets the suffix of a handle. We only consider private (non-ICANN) domains as suffixes.
+ *
+ * So `someone.example.com` will return `example.com` as a suffix, but `someone.co.uk` will return `undefined`.
+ */
+function getSuffix(handle: string) {
+  const publicSuffix = getPublicSuffix(handle)
+  if (publicSuffix) {
+    const prefix = handle.slice(0, handle.length - publicSuffix.length - 1)
+    if (!prefix.includes('.')) {
+      return undefined // If we're right under a public suffix, we're not under a private domain
+    }
+    return handle.slice(prefix.indexOf('.') + 1)
+  }
+  return undefined
+}
+
+/**
+ * Attemps to detect domain name spoofing in the suffix of a handle.
+ *
+ * E.g. someone might be attempting to trick the user into thinking they're
+ * seeing `someone.bsky.social` but they're seeing `someone.bsky.social.fake-domain.com`.
+ *
+ * Not all “spoofed” domains detected by this method are necessarily malicious, e.g. a legitimate
+ * use is mirroring content from somewhere else while having a somewhat matching handle.
+ */
+function getSpoof(suffix: string) {
+  const publicSuffix = getPublicSuffix(suffix)
+  if (publicSuffix == null) {
+    return undefined
+  }
+
+  let parts = suffix
+    .slice(0, suffix.length - publicSuffix.length - 1)
+    .split('.')
+
+  // ideally, we'd always start at 0, but the ammount of gTLDs is so large
+  // that we end up with a lot of false positives for very common words
+  // in subdomains, like `blog`, `app`, `shop`, etc. We start at zero only
+  // if the suffix is long enough
+  let start = parts.length > 2 ? 0 : 1
+
+  for (let i = start; i < parts.length; i++) {
+    // TODO: perhaps we should use a more restrictive list of gTLDs to avoid false positives
+    if (tlds.includes(parts[i])) {
+      return parts.slice(0, i + 1).join('.')
+    }
+  }
+
+  return undefined
+}
+
+/**
+ * Splits a handle into three possible parts: prefix, spoof, and suffix.
+ *
+ * Only the prefix is guaranteed to be present, the other two are optional.
+ * Additionally, the spoof can only be present if the suffix is present.
+ */
+function getHandleParts(handle: string): {
+  prefix: string
+  spoof?: string
+  suffix?: string
+} {
+  // Attempt to get a suffix
+  const suffix = getSuffix(handle)
+  if (suffix == null) {
+    // If there's no sufix, the entire handle is the prefix, and therefore there's no spoof
+    return {prefix: handle}
+  }
+
+  // Obtain the prefix by removing the suffix
+  const prefix = handle.slice(0, handle.length - suffix.length - 1)
+
+  // Check if there's a spoof
+  const spoof = getSpoof(suffix)
+  if (spoof == null) {
+    // If there's no spoof, the entire suffix remains as is, returning the prefix and suffix
+    return {prefix, suffix}
+  }
+
+  // If there's a spoof, we remove it from the suffix, and return everything
+  return {
+    prefix,
+    spoof,
+    suffix: suffix.slice(spoof.length + 1),
+  }
+}

--- a/src/view/com/util/PostMeta.tsx
+++ b/src/view/com/util/PostMeta.tsx
@@ -10,11 +10,11 @@ import {makeProfileLink} from 'lib/routes/links'
 import {forceLTR} from 'lib/strings/bidi'
 import {NON_BREAKING_SPACE} from 'lib/strings/constants'
 import {sanitizeDisplayName} from 'lib/strings/display-names'
-import {sanitizeHandle} from 'lib/strings/handles'
 import {niceDate} from 'lib/strings/time'
 import {TypographyVariant} from 'lib/ThemeContext'
 import {isAndroid} from 'platform/detection'
 import {ProfileHoverCard} from '#/components/ProfileHoverCard'
+import {HighlightedHandle} from './HighlightedHandle'
 import {TextLinkOnWebOnly} from './Link'
 import {Text} from './text/Text'
 import {TimeElapsed} from './TimeElapsed'
@@ -86,7 +86,12 @@ let PostMeta = (opts: PostMetaOpts): React.ReactNode => {
             type="md"
             disableMismatchWarning
             style={[pal.textLight, {flexShrink: 4}]}
-            text={NON_BREAKING_SPACE + sanitizeHandle(handle, '@')}
+            text={
+              <>
+                {NON_BREAKING_SPACE}
+                <HighlightedHandle handle={handle} />
+              </>
+            }
             href={profileLink}
             onBeforePress={onBeforePressAuthor}
             anchorNoUnderline

--- a/src/view/screens/Storybook/Handles.tsx
+++ b/src/view/screens/Storybook/Handles.tsx
@@ -1,0 +1,47 @@
+import React from 'react'
+import {View} from 'react-native'
+
+import {HighlightedHandle} from '#/view/com/util/HighlightedHandle'
+import {atoms as a, useTheme} from '#/alf'
+import {H1, H2, Text} from '#/components/Typography'
+
+export function Handles() {
+  const t = useTheme()
+  return (
+    <View style={[a.gap_sm]}>
+      <H1>Handles</H1>
+      <H2 style={[a.pt_md]}>Under a Private Domain</H2>
+      <HighlightedHandle handle="someone.bsky.social" />
+      <HighlightedHandle handle="someone.another.social" />
+      <HighlightedHandle handle="someone.github.io" />
+      <HighlightedHandle handle="someone.somewebsite.com" />
+      <HighlightedHandle handle="someone.sub.domain.social-provider.com" />
+      <H2 style={[a.pt_md]}>Under an ICANN Domain</H2>
+      <View style={[a.flex_row, a.justify_between]}>
+        <HighlightedHandle handle="someone" />
+        <Text style={{color: t.palette.primary_400}}>(Zero level)</Text>
+      </View>
+      <View style={[a.flex_row, a.justify_between]}>
+        <HighlightedHandle handle="someone.com" />
+        <Text style={{color: t.palette.primary_400}}>(One level)</Text>
+      </View>
+      <View style={[a.flex_row, a.justify_between]}>
+        <HighlightedHandle handle="someone.co.uk" />
+        <Text style={{color: t.palette.primary_400}}>(Two levels)</Text>
+      </View>
+      <View style={[a.flex_row, a.justify_between]}>
+        <HighlightedHandle handle="someone.mg.gov.br" />
+        <Text style={{color: t.palette.primary_400}}>(Three levels)</Text>
+      </View>
+      <H2 style={[a.pt_md]}>Spoof Detection</H2>
+      <HighlightedHandle handle="someone.bsky.social.some-fake-domain.com" />
+      <HighlightedHandle handle="someone.nytimes.com.some-fake-domain.com" />
+      <HighlightedHandle handle="someone.nasa.gov.some-fake-domain.com" />
+      <HighlightedHandle handle="someone.bsky.social.com" />
+      <HighlightedHandle handle="someone.nytimes.com.com" />
+      <HighlightedHandle handle="someone.nasa.gov.com" />
+      <H2 style={[a.pt_md]}>Invalid</H2>
+      <HighlightedHandle handle="handle.invalid" />
+    </View>
+  )
+}

--- a/src/view/screens/Storybook/index.tsx
+++ b/src/view/screens/Storybook/index.tsx
@@ -11,6 +11,7 @@ import {Breakpoints} from './Breakpoints'
 import {Buttons} from './Buttons'
 import {Dialogs} from './Dialogs'
 import {Forms} from './Forms'
+import {Handles} from './Handles'
 import {Icons} from './Icons'
 import {Links} from './Links'
 import {Menus} from './Menus'
@@ -101,6 +102,7 @@ function StorybookInner() {
             <Dialogs />
             <Menus />
             <Breakpoints />
+            <Handles />
 
             <Button
               variant="solid"

--- a/src/view/shell/Drawer.tsx
+++ b/src/view/shell/Drawer.tsx
@@ -57,6 +57,7 @@ import {
   UserCircle_Filled_Corner0_Rounded as UserCircleFilled,
   UserCircle_Stroke2_Corner0_Rounded as UserCircle,
 } from '#/components/icons/UserCircle'
+import {HighlightedHandle} from '../com/util/HighlightedHandle'
 import {TextLink} from '../com/util/Link'
 
 const iconWidth = 28
@@ -95,7 +96,7 @@ let DrawerProfileCard = ({
         type="2xl"
         style={[pal.textLight, styles.profileCardHandle]}
         numberOfLines={1}>
-        @{account.handle}
+        <HighlightedHandle handle={account.handle} />
       </Text>
       <View
         style={[

--- a/src/view/shell/desktop/Search.tsx
+++ b/src/view/shell/desktop/Search.tsx
@@ -25,6 +25,7 @@ import {useActorAutocompleteQuery} from '#/state/queries/actor-autocomplete'
 import {usePalette} from 'lib/hooks/usePalette'
 import {NavigationProp} from 'lib/routes/types'
 import {precacheProfile} from 'state/queries/profile'
+import {HighlightedHandle} from '#/view/com/util/HighlightedHandle'
 import {Link} from '#/view/com/util/Link'
 import {UserAvatar} from '#/view/com/util/UserAvatar'
 import {SearchInput} from 'view/com/util/forms/SearchInput'
@@ -136,7 +137,7 @@ let SearchProfileCard = ({
             )}
           </Text>
           <Text type="md" style={[pal.textLight]} numberOfLines={1}>
-            {sanitizeHandle(profile.handle, '@')}
+            <HighlightedHandle handle={profile.handle} />
           </Text>
         </View>
       </View>

--- a/yarn.lock
+++ b/yarn.lock
@@ -21227,6 +21227,18 @@ tlds@^1.234.0:
   resolved "https://registry.yarnpkg.com/tlds/-/tlds-1.242.0.tgz#da136a9c95b0efa1a4cd57dca8ef240c08ada4b7"
   integrity sha512-aP3dXawgmbfU94mA32CJGHmJUE1E58HCB1KmlKRhBNtqBL27mSQcAEmcaMaQ1Za9kIVvOdbxJD3U5ycDy7nJ3w==
 
+tldts-core@^6.1.43:
+  version "6.1.43"
+  resolved "https://registry.yarnpkg.com/tldts-core/-/tldts-core-6.1.43.tgz#ed90a48d746a59280108df1e3b612ffc170b21f6"
+  integrity sha512-iO1G3F2NqtmJUYlTfcH2liSdaqDnjpYn6iGftbLRNx8DF6IRIjbknVt+q0ijwZ2KGZX3J8zeYGFoiI+ZtHT5MQ==
+
+tldts@^6.1.43:
+  version "6.1.43"
+  resolved "https://registry.yarnpkg.com/tldts/-/tldts-6.1.43.tgz#fd98b012b6be323ede760a56484fbbe6b71208e7"
+  integrity sha512-5J2v/CbNH8CkwsQV+igsuu0+3eeTfRDn1CFf38a24ZD6FIrbm3DZFu4UrrpoOSejhuP4N1PNDNUvJcw+f4nXNw==
+  dependencies:
+    tldts-core "^6.1.43"
+
 tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"


### PR DESCRIPTION
Hey there 👋 I would like to propose this as an alternative to #5155 and #5117.

Instead of hiding the domain-like structure of the AT Protocol handles, or special-casing `bsky.social` or other “well-known” suffixes, this PR aims to make handles more _glanceable_, and to help users eventually build an _intuition_ about the structure/role of handles in a decentralized social network. It also aims to make at least a subset of domain spoofing attempts (malicious or not) obvious to the user.

## Storybook

<img width="382" alt="image" src="https://github.com/user-attachments/assets/d6cf159f-4ffe-4803-a361-fcf7b566fbde">

## How it works

We introduce a new `HighlightedHandle` component, that only renders `Text` elements, and can therefore be used as a drop-in solution almost anywhere `sanitizeHandle()` is currently used. This component uses straightforward rules to split a handle into up to three parts: a prefix, a suffix, and a spoof, and applies syntax highlighting. The `tldts` module is added as a new dependency and is used, along with the existing `tlds` module, to help with the splitting.

### Splitting Rules

- Handles directly under a public (ICANN) domain, regardless of nesting level (e.g. `.com`, `.co.uk`, `.mg.gov.br`) are entirely comprised of the prefix, with no suffix.
- Handles under a private (non-ICANN) domain, have the “deepest” (leftmost) portion as the prefix and everything else as the suffix.
- Suffixes that have a beginning portion that looks like it's under an ICANN domain (but isn't) are split, with the first part being marked as a spoof, and the rest remaining as a suffix.

## What this (hopefully) teaches users

- Handles are hierarchical/composed of multiple parts, not unlike email addresses or first/last names
- You should pay attention to those parts
- Handles under private domains represent a “shared” space or community
- Multiple of those shared communities exist
- Handles directly under a TLD or nested public (ICANN) domain stand out and represent _some_ type of (context-dependant) “authority”/"legitimacy"/"verification"/"independency"
- If you want that for your handle, you should/could get or configure a domain name
- Some handles may have parts that look like other domains, but are in fact _not_ associated with those domains
- Multiple handles might have the same prefix but different suffixes

## Screenshots

<img width="300" src="https://github.com/user-attachments/assets/ad700935-c772-4949-b799-eb134bb88936">
<img width="300" src="https://github.com/user-attachments/assets/54ef3487-54d8-4b2a-8bf7-0a0afa572424">
<img width="300" src="https://github.com/user-attachments/assets/cf2429e5-d66d-4e35-ab33-606d250403a0">
<img width="300" src="https://github.com/user-attachments/assets/7b6a17bf-10ed-4099-af66-47bd63d5fd2e">
<img width="300" src="https://github.com/user-attachments/assets/f57240ab-127e-4a44-828c-88efee4ca697">

## Prior Art

This very much like the URL syntax highlighting provided by web browsers, but with the reverse “focus” on the subdomain instead of the domain part, and a different treatment of public/private domains.

## Questions

Do we want to consider non-ICANN but otherwise “public” domains (e.g. `.github.io`, `vercel.app`) just like their ICANN counterparts? This is supported by `tldts`, we just need to set the `allowPrivateDomains` option to `true`. Might be more “technically consistent” with how DNS verification is set up, and potentially more inclusive to users on free webhosts who can't afford domains... But feels “weird” and might be confusing to users, who might not understand why these specific handles are not highlighted.

<img width="284" alt="image" src="https://github.com/user-attachments/assets/f47cfbba-c7b9-4955-924e-59930f71e99a">

