### PR TITLE
Add `context` to `Mute` and `Unmute` labels on video control

### DIFF
--- a/src/view/com/util/post-embeds/VideoEmbedInner/VideoWebControls.tsx
+++ b/src/view/com/util/post-embeds/VideoEmbedInner/VideoWebControls.tsx
@@ -341,8 +341,8 @@ export function Controls({
           )}
           <ControlButton
             active={muted}
-            activeLabel={_(msg`Unmute video`)}
-            inactiveLabel={_(msg`Mute video`)}
+            activeLabel={_(msg({message: `Unmute`, context: 'video'}))}
+            inactiveLabel={_(msg({message: `Mute`, context: 'video'}))}
             activeIcon={MuteIcon}
             inactiveIcon={UnmuteIcon}
             onPress={onPressMute}

--- a/src/view/com/util/post-embeds/VideoEmbedInner/VideoWebControls.tsx
+++ b/src/view/com/util/post-embeds/VideoEmbedInner/VideoWebControls.tsx
@@ -341,8 +341,8 @@ export function Controls({
           )}
           <ControlButton
             active={muted}
-            activeLabel={_(msg`Unmute`)}
-            inactiveLabel={_(msg`Mute`)}
+            activeLabel={_(msg`Unmute video`)}
+            inactiveLabel={_(msg`Mute video`)}
             activeIcon={MuteIcon}
             inactiveIcon={UnmuteIcon}
             onPress={onPressMute}


### PR DESCRIPTION
Currently, the same `Mute` string is used in the context of the tag menu and as a label on a control for muting the sound of a video:

https://github.com/bluesky-social/social-app/blob/6c6a76b193edfd8bd46139b85fefd684ee557a8c/src/locale/locales/fr/messages.po#L3701-L3704

Given the different contexts, this isn't ideal for localization.

This PR suggests tweaking the labels to `Unmute video` and `Mute video`.