### PR TITLE
feat: always display next button in login page

### DIFF
--- a/src/screens/Login/LoginForm.tsx
+++ b/src/screens/Login/LoginForm.tsx
@@ -325,10 +325,11 @@ export const LoginForm = ({
               <Trans>Connecting...</Trans>
             </Text>
           </>
-        ) : isReady ? (
+        ) : (
           <Button
             testID="loginNextButton"
             label={_(msg`Next`)}
+            disabled={!isReady}
             accessibilityHint={_(msg`Navigates to the next screen`)}
             variant="solid"
             color="primary"
@@ -339,7 +340,7 @@ export const LoginForm = ({
             </ButtonText>
             {isProcessing && <ButtonIcon icon={Loader} />}
           </Button>
-        ) : undefined}
+        )}
       </View>
     </FormContainer>
   )


### PR DESCRIPTION
To make the login page more intuitive, this PR changes the login page to always display the "next" button. When the data is not filled in, the button remains in a disabled state.


Before:
![image](https://github.com/user-attachments/assets/cc0179e7-4db1-429b-b0f9-a8eb94244be2)


After:
`!isReady`
![image](https://github.com/user-attachments/assets/751a46a6-c297-4954-b2c6-38237b47691a)

`isReady`
![image](https://github.com/user-attachments/assets/578e5453-dd21-4827-bb62-c40f4439d062)
