### PR TITLE
Suggested follows by actor (on profiles) updates

### DIFF
--- a/src/components/FeedInterstitials.tsx
+++ b/src/components/FeedInterstitials.tsx
@@ -60,16 +60,13 @@ function CardOuter({
 export function SuggestedFollowPlaceholder() {
   const t = useTheme()
   return (
-    <CardOuter style={[a.gap_sm, t.atoms.border_contrast_low]}>
+    <CardOuter style={[a.gap_md, t.atoms.border_contrast_low]}>
       <ProfileCard.Header>
         <ProfileCard.AvatarPlaceholder />
+        <ProfileCard.NameAndHandlePlaceholder />
       </ProfileCard.Header>
 
-      <View style={[a.py_xs]}>
-        <ProfileCard.NameAndHandlePlaceholder />
-      </View>
-
-      <ProfileCard.DescriptionPlaceholder />
+      <ProfileCard.DescriptionPlaceholder numberOfLines={2} />
     </CardOuter>
   )
 }

--- a/src/components/FeedInterstitials.tsx
+++ b/src/components/FeedInterstitials.tsx
@@ -197,6 +197,7 @@ export function SuggestedFollowsProfile({did}: {did: string}) {
       isSuggestionsLoading={isSuggestionsLoading}
       profiles={data?.suggestions ?? []}
       error={error}
+      viewContext="profile"
     />
   )
 }
@@ -220,10 +221,12 @@ export function ProfileGrid({
   isSuggestionsLoading,
   error,
   profiles,
+  viewContext = 'feed',
 }: {
   isSuggestionsLoading: boolean
   profiles: AppBskyActorDefs.ProfileViewDetailed[]
   error: Error | null
+  viewContext?: 'profile' | 'feed'
 }) {
   const t = useTheme()
   const {_} = useLingui()
@@ -280,7 +283,7 @@ export function ProfileGrid({
                     shape="round"
                   />
                 </ProfileCard.Header>
-                <ProfileCard.Description profile={profile} />
+                <ProfileCard.Description profile={profile} numberOfLines={2} />
               </ProfileCard.Outer>
             </CardOuter>
           )}
@@ -297,33 +300,31 @@ export function ProfileGrid({
   return (
     <View
       style={[a.border_t, t.atoms.border_contrast_low, t.atoms.bg_contrast_25]}>
-      <View style={[a.pt_2xl, a.px_lg, a.flex_row, a.pb_xs]}>
-        <Text
-          style={[
-            a.flex_1,
-            a.text_lg,
-            a.font_bold,
-            t.atoms.text_contrast_medium,
-          ]}>
-          <Trans>Suggested for you</Trans>
+      <View
+        style={[
+          a.p_lg,
+          a.pb_xs,
+          a.flex_row,
+          a.align_center,
+          a.justify_between,
+        ]}>
+        <Text style={[a.text_sm, a.font_bold, t.atoms.text_contrast_medium]}>
+          {viewContext === 'profile' ? (
+            <Trans>Similar accounts</Trans>
+          ) : (
+            <Trans>Suggested for you</Trans>
+          )}
         </Text>
-        <Person fill={t.atoms.text_contrast_low.color} />
+        <Person fill={t.atoms.text_contrast_low.color} size="sm" />
       </View>
 
       {gtMobile ? (
-        <View style={[a.flex_1, a.px_lg, a.pt_md, a.pb_xl, a.gap_md]}>
-          <View style={[a.flex_1, a.flex_row, a.flex_wrap, a.gap_md]}>
+        <View style={[a.flex_1, a.px_lg, a.pt_sm, a.pb_lg, a.gap_md]}>
+          <View style={[a.flex_1, a.flex_row, a.flex_wrap, a.gap_sm]}>
             {content}
           </View>
 
-          <View
-            style={[
-              a.flex_row,
-              a.justify_end,
-              a.align_center,
-              a.pt_xs,
-              a.gap_md,
-            ]}>
+          <View style={[a.flex_row, a.justify_end, a.align_center, a.gap_md]}>
             <InlineLinkText
               label={_(msg`Browse more suggestions`)}
               to="/search"
@@ -339,7 +340,7 @@ export function ProfileGrid({
           showsHorizontalScrollIndicator={false}
           snapToInterval={MOBILE_CARD_WIDTH + a.gap_md.gap}
           decelerationRate="fast">
-          <View style={[a.px_lg, a.pt_md, a.pb_xl, a.flex_row, a.gap_md]}>
+          <View style={[a.px_lg, a.pt_sm, a.pb_lg, a.flex_row, a.gap_md]}>
             {content}
 
             <Button

--- a/src/components/FeedInterstitials.tsx
+++ b/src/components/FeedInterstitials.tsx
@@ -174,11 +174,13 @@ function useExperimentalSuggestedUsersQuery() {
 
 export function SuggestedFollows({feed}: {feed: FeedDescriptor}) {
   const {currentAccount} = useSession()
-  const [feedType, feedUri] = feed.split('|')
+  const [feedType, feedUriOrDid] = feed.split('|')
   if (feedType === 'author') {
-    return currentAccount?.did !== feedUri ? (
-      <SuggestedFollowsProfile did={feedUri} />
-    ) : null
+    if (currentAccount?.did === feedUriOrDid) {
+      return null
+    } else {
+      return <SuggestedFollowsProfile did={feedUriOrDid} />
+    }
   } else {
     return <SuggestedFollowsHome />
   }
@@ -213,6 +215,7 @@ export function SuggestedFollowsHome() {
       isSuggestionsLoading={isSuggestionsLoading}
       profiles={profiles}
       error={error}
+      viewContext="feed"
     />
   )
 }
@@ -226,7 +229,7 @@ export function ProfileGrid({
   isSuggestionsLoading: boolean
   profiles: AppBskyActorDefs.ProfileViewDetailed[]
   error: Error | null
-  viewContext?: 'profile' | 'feed'
+  viewContext: 'profile' | 'feed'
 }) {
   const t = useTheme()
   const {_} = useLingui()

--- a/src/components/FeedInterstitials.tsx
+++ b/src/components/FeedInterstitials.tsx
@@ -176,9 +176,12 @@ function useExperimentalSuggestedUsersQuery() {
 }
 
 export function SuggestedFollows({feed}: {feed: FeedDescriptor}) {
+  const {currentAccount} = useSession()
   const [feedType, feedUri] = feed.split('|')
   if (feedType === 'author') {
-    return <SuggestedFollowsProfile did={feedUri} />
+    return currentAccount?.did !== feedUri ? (
+      <SuggestedFollowsProfile did={feedUri} />
+    ) : null
   } else {
     return <SuggestedFollowsHome />
   }

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -253,24 +253,27 @@ export function Description({
   )
 }
 
-export function DescriptionPlaceholder() {
+export function DescriptionPlaceholder({
+  numberOfLines = 3,
+}: {
+  numberOfLines?: number
+}) {
   const t = useTheme()
   return (
-    <View style={[a.gap_xs]}>
-      <View
-        style={[a.rounded_xs, a.w_full, t.atoms.bg_contrast_50, {height: 12}]}
-      />
-      <View
-        style={[a.rounded_xs, a.w_full, t.atoms.bg_contrast_50, {height: 12}]}
-      />
-      <View
-        style={[
-          a.rounded_xs,
-          a.w_full,
-          t.atoms.bg_contrast_50,
-          {height: 12, width: 100},
-        ]}
-      />
+    <View style={[{gap: 8}]}>
+      {Array(numberOfLines)
+        .fill(0)
+        .map((_, i) => (
+          <View
+            key={i}
+            style={[
+              a.rounded_xs,
+              a.w_full,
+              t.atoms.bg_contrast_50,
+              {height: 12, width: i + 1 === numberOfLines ? '60%' : '100%'},
+            ]}
+          />
+        ))}
     </View>
   )
 }

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -220,8 +220,10 @@ export function NameAndHandlePlaceholder() {
 
 export function Description({
   profile: profileUnshadowed,
+  numberOfLines = 3,
 }: {
   profile: AppBskyActorDefs.ProfileViewDetailed
+  numberOfLines?: number
 }) {
   const profile = useProfileShadow(profileUnshadowed)
   const {description} = profile
@@ -244,7 +246,7 @@ export function Description({
       <RichText
         value={rt}
         style={[a.leading_snug]}
-        numberOfLines={3}
+        numberOfLines={numberOfLines}
         disableLinks
       />
     </View>

--- a/src/state/queries/suggested-follows.ts
+++ b/src/state/queries/suggested-follows.ts
@@ -106,13 +106,13 @@ export function useSuggestedFollowsQuery(options?: SuggestedFollowsOptions) {
 export function useSuggestedFollowsByActorQuery({did}: {did: string}) {
   const agent = useAgent()
   return useQuery<AppBskyGraphGetSuggestedFollowsByActor.OutputSchema, Error>({
-    gcTime: 0,
+    gcTime: 0, // TODO
     queryKey: suggestedFollowsByActorQueryKey(did),
     queryFn: async () => {
       const res = await agent.app.bsky.graph.getSuggestedFollowsByActor({
         actor: did,
       })
-      return res.data
+      return res.data.isFallback ? {suggestions: []} : res.data
     },
   })
 }

--- a/src/state/queries/suggested-follows.ts
+++ b/src/state/queries/suggested-follows.ts
@@ -111,7 +111,11 @@ export function useSuggestedFollowsByActorQuery({did}: {did: string}) {
       const res = await agent.app.bsky.graph.getSuggestedFollowsByActor({
         actor: did,
       })
-      return res.data.isFallback ? {suggestions: []} : res.data
+      const data = res.data.isFallback ? {suggestions: []} : res.data
+      data.suggestions = data.suggestions.filter(profile => {
+        return !profile.viewer?.following
+      })
+      return data
     },
   })
 }

--- a/src/state/queries/suggested-follows.ts
+++ b/src/state/queries/suggested-follows.ts
@@ -106,7 +106,6 @@ export function useSuggestedFollowsQuery(options?: SuggestedFollowsOptions) {
 export function useSuggestedFollowsByActorQuery({did}: {did: string}) {
   const agent = useAgent()
   return useQuery<AppBskyGraphGetSuggestedFollowsByActor.OutputSchema, Error>({
-    gcTime: 0, // TODO
     queryKey: suggestedFollowsByActorQueryKey(did),
     queryFn: async () => {
       const res = await agent.app.bsky.graph.getSuggestedFollowsByActor({


### PR DESCRIPTION
The `isFallback` handling relies on backend https://github.com/bluesky-social/atproto/pull/2805 but this can be deployed independently without negative effects.

Also filtered out followed users from this response. I thought we had done that on the backend, but let's just do it here since backend is swamped right now.

To do:
- [x] Investigate if we need `gcTime` here (seems fine to me)

Compressed the size of this a bit, before/after on desktop web:

![CleanShot 2024-09-12 at 10 56 29@2x](https://github.com/user-attachments/assets/3cf70516-9c40-4831-9937-20ce49247e16)
![CleanShot 2024-09-12 at 10 56 37@2x](https://github.com/user-attachments/assets/a411184d-6b31-4a18-b25c-b1002865df64)
![CleanShot 2024-09-12 at 11 07 27@2x](https://github.com/user-attachments/assets/e397d54a-af9c-4bc2-9635-4d3cc9701c3b)

Basically no change on mobile, looks like this now:

![CleanShot 2024-09-12 at 10 58 13@2x](https://github.com/user-attachments/assets/6a411a78-97d3-4ee4-84ae-155e18b12384)
![CleanShot 2024-09-12 at 10 58 19@2x](https://github.com/user-attachments/assets/3bb0fe06-3a09-47c7-a1d4-278330fa4f92)
