### PR TITLE
Adjust the translated strings to the correct max size.

### DIFF
--- a/src/locale/locales/pt-BR/messages.po
+++ b/src/locale/locales/pt-BR/messages.po
@@ -7040,7 +7040,7 @@ msgstr "A Política de Privacidade foi movida para <0/>"
 
 #: src/state/queries/video/video.ts:227
 msgid "The selected video is larger than 50MB."
-msgstr "Vídeo selecionado é maior que 100 MB."
+msgstr "Vídeo selecionado é maior que 50 MB."
 
 #: src/screens/StarterPack/StarterPackScreen.tsx:713
 msgid "The starter pack that you are trying to view is invalid. You may delete this starter pack instead."

--- a/src/locale/locales/ru/messages.po
+++ b/src/locale/locales/ru/messages.po
@@ -6238,7 +6238,7 @@ msgstr "Политика конфиденциальности была пере�
 
 #: src/state/queries/video/video.ts:188
 msgid "The selected video is larger than 50MB."
-msgstr "Размер выбранного видео превышает 100МБ."
+msgstr "Размер выбранного видео превышает 50МБ."
 
 #: src/screens/StarterPack/StarterPackScreen.tsx:713
 msgid "The starter pack that you are trying to view is invalid. You may delete this starter pack instead."


### PR DESCRIPTION
base #5245.
I noticed that the Brazilian Portuguese and Russian translations weren't updated to 50MB like other languages. The translation teams might not catch this for the already translated strings, so I opened this PR.