### PR TITLE
[Video] Much simpler fix to fullscreen bug

### DIFF
--- a/src/view/com/util/post-embeds/VideoEmbed.web.tsx
+++ b/src/view/com/util/post-embeds/VideoEmbed.web.tsx
@@ -4,6 +4,7 @@ import {AppBskyEmbedVideo} from '@atproto/api'
 import {msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
+import {isFirefox} from '#/lib/browser'
 import {clamp} from '#/lib/numbers'
 import {useGate} from '#/lib/statsig/statsig'
 import {
@@ -27,7 +28,7 @@ export function VideoEmbed({embed}: {embed: AppBskyEmbedVideo.View}) {
 
   useEffect(() => {
     if (!ref.current) return
-    if (isFullscreen) return
+    if (isFullscreen && !isFirefox) return
     const observer = new IntersectionObserver(
       entries => {
         const entry = entries[0]
@@ -115,7 +116,7 @@ function ViewportObserver({
   // observing a div of 100vh height
   useEffect(() => {
     if (!ref.current) return
-    if (isFullscreen) return
+    if (isFullscreen && !isFirefox) return
     const observer = new IntersectionObserver(
       entries => {
         const entry = entries[0]

--- a/src/view/com/util/post-embeds/VideoEmbed.web.tsx
+++ b/src/view/com/util/post-embeds/VideoEmbed.web.tsx
@@ -23,9 +23,11 @@ export function VideoEmbed({embed}: {embed: AppBskyEmbedVideo.View}) {
   const {active, setActive, sendPosition, currentActiveView} =
     useActiveVideoWeb()
   const [onScreen, setOnScreen] = useState(false)
+  const [isFullscreen] = useFullscreen()
 
   useEffect(() => {
     if (!ref.current) return
+    if (isFullscreen) return
     const observer = new IntersectionObserver(
       entries => {
         const entry = entries[0]
@@ -39,7 +41,7 @@ export function VideoEmbed({embed}: {embed: AppBskyEmbedVideo.View}) {
     )
     observer.observe(ref.current)
     return () => observer.disconnect()
-  }, [sendPosition])
+  }, [sendPosition, isFullscreen])
 
   const [key, setKey] = useState(0)
   const renderError = useCallback(
@@ -108,12 +110,12 @@ function ViewportObserver({
   const ref = useRef<HTMLDivElement>(null)
   const [nearScreen, setNearScreen] = useState(false)
   const [isFullscreen] = useFullscreen()
-  const [nearScreenOrFullscreen, setNearScreenOrFullscreen] = useState(false)
 
   // Send position when scrolling. This is done with an IntersectionObserver
   // observing a div of 100vh height
   useEffect(() => {
     if (!ref.current) return
+    if (isFullscreen) return
     const observer = new IntersectionObserver(
       entries => {
         const entry = entries[0]
@@ -127,7 +129,7 @@ function ViewportObserver({
     )
     observer.observe(ref.current)
     return () => observer.disconnect()
-  }, [sendPosition])
+  }, [sendPosition, isFullscreen])
 
   // In case scrolling hasn't started yet, send up the position
   useEffect(() => {
@@ -138,17 +140,9 @@ function ViewportObserver({
     }
   }, [isAnyViewActive, sendPosition])
 
-  // disguesting effect - it should be `nearScreen` except when fullscreen
-  // when it should be whatever it was before fullscreen changed
-  useEffect(() => {
-    if (!isFullscreen) {
-      setNearScreenOrFullscreen(nearScreen)
-    }
-  }, [isFullscreen, nearScreen])
-
   return (
     <View style={[a.flex_1, a.flex_row]}>
-      {nearScreenOrFullscreen && children}
+      {nearScreen && children}
       <div
         ref={ref}
         style={{

--- a/src/view/com/util/post-embeds/VideoEmbedInner/VideoWebControls.tsx
+++ b/src/view/com/util/post-embeds/VideoEmbedInner/VideoWebControls.tsx
@@ -98,7 +98,6 @@ export function Controls({
   // pause + unfocus when another video is active
   useEffect(() => {
     if (!active) {
-      console.log('pause from inactive')
       pause()
       setFocused(false)
     }
@@ -111,7 +110,6 @@ export function Controls({
       if (onScreen) {
         if (!autoplayDisabled) play()
       } else {
-        console.log('pause from not onScreen')
         pause()
       }
     }
@@ -191,7 +189,6 @@ export function Controls({
   const onSeekStart = useCallback(() => {
     drawFocus()
     playStateBeforeSeekRef.current = playing
-    console.log('pause from onSeekStart')
     pause()
   }, [playing, pause, drawFocus])
 
@@ -810,7 +807,6 @@ function useVideoUtils(ref: React.RefObject<HTMLVideoElement>) {
     if (ref.current.paused) {
       play()
     } else {
-      console.log('pause from togglePlayPause')
       pause()
     }
   }, [ref, play, pause])

--- a/src/view/com/util/post-embeds/VideoEmbedInner/VideoWebControls.tsx
+++ b/src/view/com/util/post-embeds/VideoEmbedInner/VideoWebControls.tsx
@@ -98,6 +98,7 @@ export function Controls({
   // pause + unfocus when another video is active
   useEffect(() => {
     if (!active) {
+      console.log('pause from inactive')
       pause()
       setFocused(false)
     }
@@ -110,6 +111,7 @@ export function Controls({
       if (onScreen) {
         if (!autoplayDisabled) play()
       } else {
+        console.log('pause from not onScreen')
         pause()
       }
     }
@@ -189,6 +191,7 @@ export function Controls({
   const onSeekStart = useCallback(() => {
     drawFocus()
     playStateBeforeSeekRef.current = playing
+    console.log('pause from onSeekStart')
     pause()
   }, [playing, pause, drawFocus])
 
@@ -807,6 +810,7 @@ function useVideoUtils(ref: React.RefObject<HTMLVideoElement>) {
     if (ref.current.paused) {
       play()
     } else {
+      console.log('pause from togglePlayPause')
       pause()
     }
   }, [ref, play, pause])


### PR DESCRIPTION
Instead of hacking around the problem with some messed up `useEffect`s, this PR just turns off the intersection observer when fullscreen

Upsides:
- Significantly simpler logic
- You ~~Might~~ Do Not Need An Effect
- Fixes the video pausing when entering fullscreen

Downsides:
- New bug: on returning from fullscreen, the video player seems to reset itself and loses play state.

This seems like a significantly better tradeoff than before