### PR TITLE
[Video] make hover state stick around if tapped

### DIFF
--- a/src/view/com/util/post-embeds/VideoEmbedInner/VideoWebControls.tsx
+++ b/src/view/com/util/post-embeds/VideoEmbedInner/VideoWebControls.tsx
@@ -235,6 +235,39 @@ export function Controls({
     }
   }, [])
 
+  // these are used to trigger the hover state. on mobile, the hover state
+  // should stick around for a bit after they tap, and if the controls aren't
+  // present this initial tab should *only* show the controls and not activate anything
+
+  const onPointerDown = useCallback(
+    (evt: React.PointerEvent<HTMLDivElement>) => {
+      if (evt.pointerType !== 'mouse' && !hovered) {
+        evt.preventDefault()
+      }
+    },
+    [hovered],
+  )
+
+  const timeoutRef = useRef<ReturnType<typeof setTimeout>>()
+
+  const onHoverWithTimeout = useCallback(() => {
+    onHover()
+    clearTimeout(timeoutRef.current)
+  }, [onHover])
+
+  const onEndHoverWithTimeout = useCallback(
+    (evt: React.PointerEvent<HTMLDivElement>) => {
+      // if touch, end after 3s
+      // if mouse, end immediately
+      if (evt.pointerType !== 'mouse') {
+        setTimeout(onEndHover, 3000)
+      } else {
+        onEndHover()
+      }
+    },
+    [onEndHover],
+  )
+
   const showControls =
     ((focused || autoplayDisabled) && !playing) ||
     (interactingViaKeypress ? hasFocus : hovered)
@@ -252,9 +285,10 @@ export function Controls({
         evt.stopPropagation()
         setInteractingViaKeypress(false)
       }}
-      onPointerEnter={onHover}
-      onPointerMove={onHover}
-      onPointerLeave={onEndHover}
+      onPointerEnter={onHoverWithTimeout}
+      onPointerMove={onHoverWithTimeout}
+      onPointerLeave={onEndHoverWithTimeout}
+      onPointerDown={onPointerDown}
       onFocus={onFocus}
       onBlur={onBlur}
       onKeyDown={onKeyDown}>


### PR DESCRIPTION
Currently, when you tap the video with a touch device on web, the controls disappear immediately because you've stopped hovering it.

This PR has two changes (for touchscreens only)

- The initial tap should *only* bring up the controls, and not unmute/pause/do anything else
- The controls should stay visible for 3 seconds after a tap, for you to press the buttons

Make sure there's no regressions for mouse users

Thanks @surfdude29 for the bug report!