### PR TITLE
[Video] Temporary OTAable fix for looping videos, negative counter

### DIFF
--- a/src/view/com/util/post-embeds/VideoEmbed.tsx
+++ b/src/view/com/util/post-embeds/VideoEmbed.tsx
@@ -102,9 +102,12 @@ function InnerWrapper({embed}: Props) {
           setPlayerStatus(status)
           if (status === 'error') {
             setError(playerError ?? new Error('Unknown player error'))
-          }
-          if (status === 'readyToPlay' && oldStatus !== 'readyToPlay') {
+          } else if (status === 'readyToPlay' && oldStatus !== 'readyToPlay') {
             player.play()
+            // @ts-expect-error This exists! It is a temporary hack fix that we can OTA while pending the native real fix
+            // for looping with captions
+          } else if (status === 'playbackBufferEmpty') {
+            player.replay()
           }
         },
       )

--- a/src/view/com/util/post-embeds/VideoEmbed.tsx
+++ b/src/view/com/util/post-embeds/VideoEmbed.tsx
@@ -104,9 +104,13 @@ function InnerWrapper({embed}: Props) {
             setError(playerError ?? new Error('Unknown player error'))
           } else if (status === 'readyToPlay' && oldStatus !== 'readyToPlay') {
             player.play()
-            // @ts-expect-error This exists! It is a temporary hack fix that we can OTA while pending the native real fix
+          } else if (
+            // @ts-expect-error - Read below
+            status === 'playbackBufferEmpty' &&
+            oldStatus === 'readyToPlay'
+          ) {
+            // This status exists! It is a temporary hack fix that we can OTA while pending the native real fix
             // for looping with captions
-          } else if (status === 'playbackBufferEmpty') {
             player.replay()
           }
         },


### PR DESCRIPTION
## Why

There's a bug where subtitles cause the video to enter the `playbackBufferEmpty` state rather than
actually replaying whenever `loop` is set to true. This actually causes the video to stop looping,
since it seems to be pausing when this happens.

We can fix this nicely over on the native side, but this is a temporary fix pending that change that
we can OTA.

## Test Plan

- View https://bsky.app/profile/samuel.bsky.team/post/3l2uftgmitr2p on iOS in production
- Let the video play through with subtitles on. It should pause when it restarts.
- Test this branch, and do the same thing. It should loop regardless of whether subs are on or off
