### PR TITLE
fix(web/header): make header transition more fluid

### DIFF
--- a/src/view/com/util/MainScrollProvider.tsx
+++ b/src/view/com/util/MainScrollProvider.tsx
@@ -14,6 +14,7 @@ import {useShellLayout} from '#/state/shell/shell-layout'
 import {isNative, isWeb} from 'platform/detection'
 
 const WEB_HIDE_SHELL_THRESHOLD = 200
+const WEB_SCROLL_MOMENTUM_THRESHOLD = 10
 
 function clamp(num: number, min: number, max: number) {
   'worklet'
@@ -30,7 +31,6 @@ export function MainScrollProvider({children}: {children: React.ReactNode}) {
   const setMode = React.useCallback(
     (v: boolean) => {
       'worklet'
-      cancelAnimation(headerMode)
       headerMode.value = withSpring(v ? 1 : 0, {
         overshootClamping: true,
       })
@@ -142,7 +142,7 @@ export function MainScrollProvider({children}: {children: React.ReactNode}) {
       } else {
         if (didJustRestoreScroll.value) {
           didJustRestoreScroll.value = false
-          // Don't hide/show navbar based on scroll restoratoin.
+          // Don't hide/show navbar based on scroll restoration.
           return
         }
         // On the web, we don't try to follow the drag because we don't know when it ends.
@@ -150,9 +150,24 @@ export function MainScrollProvider({children}: {children: React.ReactNode}) {
         const dy = e.contentOffset.y - (startDragOffset.value ?? 0)
         startDragOffset.value = e.contentOffset.y
 
-        if (dy < 0 || e.contentOffset.y < WEB_HIDE_SHELL_THRESHOLD) {
+        if (e.contentOffset.y < WEB_HIDE_SHELL_THRESHOLD) {
+          setMode(false)
+          // If scrolling up (dy < 0)
+        } else if (dy < 0) {
+          // If the scroll distance is less than the negative momentum threshold, ignore it
+          // This will discard minimal scroll up, and we consider these movements irrelevant for the header
+          if (dy > WEB_SCROLL_MOMENTUM_THRESHOLD * -2) {
+            return
+          }
+
           setMode(false)
         } else if (dy > 0) {
+          // Check if the scroll distance is less than the momentum threshold
+          // This ignores minimal scroll down, considering these movements irrelevant for the header
+          if (dy > WEB_SCROLL_MOMENTUM_THRESHOLD) {
+            return
+          }
+
           setMode(true)
         }
       }


### PR DESCRIPTION
The header transition when scrolling is a bit off today, at the point where the scroll event looks unresponsive. This odd behavior was mainly driven by the `cancelAnimation` function, which is called multiple times when scrolling, and as its name suggests, it cancels the previous animation that was in progress. 

Here's an example of a header transition that I would not expect: 

https://github.com/user-attachments/assets/2e2b43f0-c84c-42c9-9efc-e612c44cb373

**The solution + improvement suggestion**

Removing the `cancelAnimation` seems to solve the main issue. However, I don't have the context why it was added in the first place. Besides that, I'd like to suggest an addition to this logic to make this transition more fluid: introduce a momentum threshold, which discards minimal scroll up/down as such movements are not relevant to the header visibility change.  

For example, when a user is scrolling down and might want to see a previous post a bit above the fold, it's natural to scroll just a bit up, which previously would trigger the header visibility and overlap the previous post, making the user scroll unnecessarily more. In my opinion, such a feature makes the scroll more natural and fluid. 

https://github.com/user-attachments/assets/44ebfe95-1723-4498-b147-a2fa1d6d55b9

