### PR TITLE
Renaming the Follow button to "Follow back" when followed by user

### DIFF
--- a/src/screens/Profile/Header/ProfileHeaderStandard.tsx
+++ b/src/screens/Profile/Header/ProfileHeaderStandard.tsx
@@ -220,7 +220,9 @@ let ProfileHeaderStandard = ({
                   {profile.viewer?.following ? (
                     <Trans>Following</Trans>
                   ) : (
-                    <Trans>Follow</Trans>
+                    <Trans>
+                      {profile.viewer?.followedBy ? 'Follow back' : 'Follow'}
+                    </Trans>
                   )}
                 </ButtonText>
               </Button>

--- a/src/screens/Profile/Header/ProfileHeaderStandard.tsx
+++ b/src/screens/Profile/Header/ProfileHeaderStandard.tsx
@@ -219,10 +219,10 @@ let ProfileHeaderStandard = ({
                 <ButtonText>
                   {profile.viewer?.following ? (
                     <Trans>Following</Trans>
+                  ) : profile.viewer?.followedBy ? (
+                    <Trans>Follow Back</Trans>
                   ) : (
-                    <Trans>
-                      {profile.viewer?.followedBy ? 'Follow back' : 'Follow'}
-                    </Trans>
+                    <Trans>Follow</Trans>
                   )}
                 </ButtonText>
               </Button>

--- a/src/view/com/profile/FollowButton.tsx
+++ b/src/view/com/profile/FollowButton.tsx
@@ -61,18 +61,22 @@ export function FollowButton({
         label={_(msg({message: 'Unfollow', context: 'action'}))}
       />
     )
+  } else if (!profile.viewer.followedBy) {
+    return (
+      <Button
+        type={unfollowedType}
+        labelStyle={labelStyle}
+        onPress={onPressFollow}
+        label={_(msg({message: 'Follow', context: 'action'}))}
+      />
+    )
   } else {
     return (
       <Button
         type={unfollowedType}
         labelStyle={labelStyle}
         onPress={onPressFollow}
-        label={_(
-          msg({
-            message: profile.viewer.followedBy ? 'Follow back' : 'Follow',
-            context: 'action',
-          }),
-        )}
+        label={_(msg({message: 'Follow Back', context: 'action'}))}
       />
     )
   }

--- a/src/view/com/profile/FollowButton.tsx
+++ b/src/view/com/profile/FollowButton.tsx
@@ -67,7 +67,12 @@ export function FollowButton({
         type={unfollowedType}
         labelStyle={labelStyle}
         onPress={onPressFollow}
-        label={_(msg({message: 'Follow', context: 'action'}))}
+        label={_(
+          msg({
+            message: profile.viewer.followedBy ? 'Follow back' : 'Follow',
+            context: 'action',
+          }),
+        )}
       />
     )
   }


### PR DESCRIPTION
Hi there! 👋 I’d like to suggest a small improvement:
Rename the “Follow” button to “Follow back” when the user is already followed by someone, similar to how Instagram handles it? I think this would make it more intuitive for users to follow each other back.


Before:
<img width="601" alt="Screenshot 2024-09-11 at 19 44 04" src="https://github.com/user-attachments/assets/509117a4-1836-46fd-9de0-44335b653ab3">
After:
<img width="601" alt="Screenshot 2024-09-11 at 19 43 41" src="https://github.com/user-attachments/assets/51104e2b-4bf6-4fdb-ba99-d5f62c100b27">
Before:
<img width="601" alt="Screenshot 2024-09-11 at 19 43 09" src="https://github.com/user-attachments/assets/8008ded8-ef47-44c0-a643-e2ea65d189c8">
After:
<img width="601" alt="Screenshot 2024-09-11 at 19 42 17" src="https://github.com/user-attachments/assets/de192953-0f50-42e3-b72f-3844d81d2b97">

