### PR TITLE
[Video] Mute behaviour & autoplay disabled improvements

### DIFF
--- a/src/view/com/util/post-embeds/VideoEmbedInner/TimeIndicator.tsx
+++ b/src/view/com/util/post-embeds/VideoEmbedInner/TimeIndicator.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import {StyleProp, ViewStyle} from 'react-native'
 import Animated, {FadeInDown, FadeOutDown} from 'react-native-reanimated'
 
 import {atoms as a, native, useTheme} from '#/alf'
@@ -8,7 +9,13 @@ import {Text} from '#/components/Typography'
  * Absolutely positioned time indicator showing how many seconds are remaining
  * Time is in seconds
  */
-export function TimeIndicator({time}: {time: number}) {
+export function TimeIndicator({
+  time,
+  style,
+}: {
+  time: number
+  style?: StyleProp<ViewStyle>
+}) {
   const t = useTheme()
 
   if (isNaN(time)) {
@@ -22,18 +29,20 @@ export function TimeIndicator({time}: {time: number}) {
     <Animated.View
       entering={native(FadeInDown.duration(300))}
       exiting={native(FadeOutDown.duration(500))}
+      pointerEvents="none"
       style={[
         {
           backgroundColor: 'rgba(0, 0, 0, 0.5)',
           borderRadius: 6,
           paddingHorizontal: 6,
           paddingVertical: 3,
-          position: 'absolute',
           left: 6,
           bottom: 6,
           minHeight: 21,
-          justifyContent: 'center',
         },
+        a.absolute,
+        a.justify_center,
+        style,
       ]}>
       <Text
         style={[

--- a/src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerNative.tsx
+++ b/src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerNative.tsx
@@ -1,7 +1,7 @@
 import React, {useCallback, useRef} from 'react'
 import {Pressable, View} from 'react-native'
 import Animated, {FadeInDown} from 'react-native-reanimated'
-import {VideoPlayer, VideoView} from 'expo-video'
+import {VideoView} from 'expo-video'
 import {AppBskyEmbedVideo} from '@atproto/api'
 import {msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
@@ -33,7 +33,7 @@ export function VideoEmbedInnerNative({
   isMuted: boolean
 }) {
   const {_} = useLingui()
-  const {player} = useActiveVideoNative()
+  const {player, mutedInFeed} = useActiveVideoNative()
   const ref = useRef<VideoView>(null)
 
   const enterFullscreen = useCallback(() => {
@@ -69,7 +69,7 @@ export function VideoEmbedInnerNative({
         onFullscreenExit={() => {
           PlatformInfo.setAudioCategory(AudioCategory.Ambient)
           PlatformInfo.setAudioActive(false)
-          player.muted = true
+          player.muted = mutedInFeed
           player.playbackRate = 1
           setIsFullscreen(false)
         }}
@@ -79,7 +79,6 @@ export function VideoEmbedInnerNative({
         accessibilityHint=""
       />
       <VideoControls
-        player={player}
         enterFullscreen={enterFullscreen}
         isMuted={isMuted}
         timeRemaining={timeRemaining}
@@ -89,18 +88,17 @@ export function VideoEmbedInnerNative({
 }
 
 function VideoControls({
-  player,
   enterFullscreen,
   timeRemaining,
   isMuted,
 }: {
-  player: VideoPlayer
   enterFullscreen: () => void
   timeRemaining: number
   isMuted: boolean
 }) {
   const {_} = useLingui()
   const t = useTheme()
+  const {player, setMutedInFeed} = useActiveVideoNative()
 
   const onPressFullscreen = useCallback(() => {
     switch (player.status) {
@@ -128,7 +126,8 @@ function VideoControls({
     PlatformInfo.setAudioCategory(category)
     PlatformInfo.setAudioActive(mix)
     player.muted = muted
-  }, [player])
+    setMutedInFeed(muted)
+  }, [player, setMutedInFeed])
 
   // show countdown when:
   // 1. timeRemaining is a number - was seeing NaNs


### PR DESCRIPTION
This PR does three things (all native)

1. Persists mute state (in feed) between videos
2. Makes sure videos are unmuted initially when autoplay is disabled
3. Adds a play/pause button when autoplay is disabled

The rationale behind change # 3 is that when autoplay is disabled, it acts a bit more like a traditional video player and thus would be nice to be able to make it _stop_ playing

<img width="256" alt="Screenshot 2024-09-12 at 12 15 15" src="https://github.com/user-attachments/assets/a704dfec-ac5d-4194-9d9e-daed04349709">

# Test plan

Test all 3 changes individually. Make sure with autoplay enabled, there are no regressions other than the the persisted mute state change