### PR TITLE
[Video] speculative .vtt file selection fix

### DIFF
--- a/src/view/com/composer/videos/SubtitleFilePicker.tsx
+++ b/src/view/com/composer/videos/SubtitleFilePicker.tsx
@@ -25,7 +25,11 @@ export function SubtitleFilePicker({
   const handlePick = (evt: React.ChangeEvent<HTMLInputElement>) => {
     const selectedFile = evt.target.files?.[0]
     if (selectedFile) {
-      if (selectedFile.type === 'text/vtt') {
+      if (
+        selectedFile.type === 'text/vtt' ||
+        (selectedFile.type === 'text/plain' &&
+          selectedFile.name.endsWith('.vtt'))
+      ) {
         onSelectFile(selectedFile)
       } else {
         Toast.show(_(msg`Only WebVTT (.vtt) files are supported`))

--- a/src/view/com/composer/videos/SubtitleFilePicker.tsx
+++ b/src/view/com/composer/videos/SubtitleFilePicker.tsx
@@ -3,6 +3,7 @@ import {View} from 'react-native'
 import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
+import {logger} from '#/logger'
 import * as Toast from '#/view/com/util/Toast'
 import {atoms as a} from '#/alf'
 import {Button, ButtonIcon, ButtonText} from '#/components/Button'
@@ -32,6 +33,9 @@ export function SubtitleFilePicker({
       ) {
         onSelectFile(selectedFile)
       } else {
+        logger.error('Invalid subtitle file type', {
+          safeMessage: `File: ${selectedFile.name} (${selectedFile.type})`,
+        })
         Toast.show(_(msg`Only WebVTT (.vtt) files are supported`))
       }
     }


### PR DESCRIPTION
I can't replicate the bug, but this maybe might fix it? My guess is some OS/browser combo doesn't know what vtt files are and are giving a generic mime type

This also adds error logging so we can see what the actual mime type we're getting is