### PR TITLE
Fix notification scroll jump

### DIFF
--- a/src/state/queries/notifications/util.ts
+++ b/src/state/queries/notifications/util.ts
@@ -175,9 +175,19 @@ async function fetchSubjects(
 }> {
   const postUris = new Set<string>()
   const packUris = new Set<string>()
+
+  const postUrisWithLikes = new Set<string>()
+  const postUrisWithReposts = new Set<string>()
+
   for (const notif of groupedNotifs) {
     if (notif.subjectUri?.includes('app.bsky.feed.post')) {
       postUris.add(notif.subjectUri)
+      if (notif.type === 'post-like') {
+        postUrisWithLikes.add(notif.subjectUri)
+      }
+      if (notif.type === 'repost') {
+        postUrisWithReposts.add(notif.subjectUri)
+      }
     } else if (
       notif.notification.reasonSubject?.includes('app.bsky.graph.starterpack')
     ) {
@@ -206,6 +216,15 @@ async function fetchSubjects(
       AppBskyFeedPost.validateRecord(post.record).success
     ) {
       postsMap.set(post.uri, post)
+
+      // HACK. In some cases, the appview appears to lag behind and returns empty counters.
+      // To prevent scroll jump due to missing metrics, fill in 1 like/repost instead of 0.
+      if (post.likeCount === 0 && postUrisWithLikes.has(post.uri)) {
+        post.likeCount = 1
+      }
+      if (post.repostCount === 0 && postUrisWithReposts.has(post.uri)) {
+        post.repostCount = 1
+      }
     }
   }
   for (const pack of packsChunks.flat()) {


### PR DESCRIPTION
I don't know how to reliably reproduce it, but I often get a scroll jump when going into a notification:

https://github.com/user-attachments/assets/d0d2613c-cd97-4cf7-9d10-ce44cdc3bb55

You can see that for a split frame, it doesn't have counters:

<img width="373" alt="Screenshot 2024-09-12 at 15 16 33" src="https://github.com/user-attachments/assets/830cbaa4-60d2-453e-8970-97890e45a150">

But we're obviously coming from a "Like" notification so it has to have _some_ likes.

My theory is that sometimes the notification `getPosts` request comes in too early before the like counts have propagated. So we end up caching an earlier version of the `getPosts` response with the notification page.

To work around this, I'm adding a hack — if the notification is a Like or a Repost, but the received number of likes/reposts is zero, we're going to bump it to one. It'll still show the correct count when you navigate to it, but this way we solve the jump.

A proper fix would be to get rid of this client-side "let's guess what else we need" fetching and to have the server do its job.

## Test Plan

No great way to test this, but I manually set `post.likeCount = 0` earlier and verified it bumps it to one.