### PR TITLE
Adjust image sizing

### DIFF
--- a/src/view/com/util/images/AutoSizedImage.tsx
+++ b/src/view/com/util/images/AutoSizedImage.tsx
@@ -23,9 +23,10 @@ export function useImageAspectRatio({
   const [raw, setAspectRatio] = React.useState<number>(
     dimensions ? calc(dimensions) : 1,
   )
+  // this basically controls the width of the image
   const {isCropped, constrained, max} = React.useMemo(() => {
-    const a34 = 0.75 // max of 3:4 ratio in feeds
-    const constrained = Math.max(raw, a34)
+    const ratio = 1 / 2 // max of 1:2 ratio in feeds
+    const constrained = Math.max(raw, ratio)
     const max = Math.max(raw, 0.25) // max of 1:4 in thread
     const isCropped = raw < constrained
     return {
@@ -68,14 +69,14 @@ export function ConstrainedImage({
   const t = useTheme()
   const {gtMobile} = useBreakpoints()
   /**
-   * Computed as a % value to apply as `paddingTop`
+   * Computed as a % value to apply as `paddingTop`, this basically controls
+   * the height of the image.
    */
   const outerAspectRatio = React.useMemo<DimensionValue>(() => {
-    // capped to square or shorter
     const ratio =
       isNative || !gtMobile
-        ? Math.min(1 / aspectRatio, 1.5)
-        : Math.min(1 / aspectRatio, 1)
+        ? Math.min(1 / aspectRatio, 16 / 9) // 9:16 bounding box
+        : Math.min(1 / aspectRatio, 1) // 1:1 bounding box
     return `${ratio * 100}%`
   }, [aspectRatio, gtMobile])
 


### PR DESCRIPTION
Adjusting image sizing based on user feedback.

**Constraints:**
- desktop web
  - height is limited by a 1:1 square container (see red dashed container in screenshot)
  - images taller than 1:2 will be cropped (but 9:16, 2:3, 3:4 will not)
- mobile
  - height is limited by a 9:16 container (see red dashed container in screenshot)
  - images taller than 1:2 will be cropped (but 9:16, 2:3, 3:4 will not)
 
![image sizing](https://github.com/user-attachments/assets/28fb9a82-761a-4658-b8c1-6e23b945dcb4)

### Screenshots
![CleanShot 2024-09-12 at 10 00 34@2x](https://github.com/user-attachments/assets/ca69243d-2f70-47a9-9200-2c00ef844afd)
![CleanShot 2024-09-12 at 09 59 54@2x](https://github.com/user-attachments/assets/47323b2e-01a9-4a03-b195-7a83563df21a)
![CleanShot 2024-09-12 at 10 00 38@2x](https://github.com/user-attachments/assets/6cbf7cf2-a027-4471-8d85-3d872a25a7a9)
![CleanShot 2024-09-12 at 10 00 52@2x](https://github.com/user-attachments/assets/7a3ac5aa-5b14-40cc-a8d9-b2ab7fb448f0)
![CleanShot 2024-09-12 at 10 01 11@2x](https://github.com/user-attachments/assets/585b2036-354d-4a8e-9b3d-aebb6c59fe65)
![CleanShot 2024-09-12 at 10 01 30@2x](https://github.com/user-attachments/assets/0f3e1ec4-228c-47f9-a6f8-d3673a094645)
![CleanShot 2024-09-12 at 10 01 50@2x](https://github.com/user-attachments/assets/bb242e68-0a93-4d54-b5b4-68cf84f22a2f)
![CleanShot 2024-09-12 at 10 02 01@2x](https://github.com/user-attachments/assets/0f6dbc03-04ca-439e-8f87-7d3adff32758)
![CleanShot 2024-09-12 at 10 02 18@2x](https://github.com/user-attachments/assets/5f32bbdc-e81e-42b4-a67f-0ab202717869)
![CleanShot 2024-09-12 at 10 02 28@2x](https://github.com/user-attachments/assets/17097954-d387-4e16-b794-9d30a3891d4b)
