### PR TITLE
Apply Following settings to Lists

### DIFF
--- a/src/components/StarterPack/Main/PostsList.tsx
+++ b/src/components/StarterPack/Main/PostsList.tsx
@@ -18,7 +18,7 @@ interface ProfilesListProps {
 
 export const PostsList = React.forwardRef<SectionRef, ProfilesListProps>(
   function PostsListImpl({listUri, headerHeight, scrollElRef}, ref) {
-    const feed: FeedDescriptor = `list|${listUri}|as_following`
+    const feed: FeedDescriptor = `list|${listUri}`
     const {_} = useLingui()
 
     const onScrollToTop = useCallback(() => {

--- a/src/state/preferences/feed-tuners.tsx
+++ b/src/state/preferences/feed-tuners.tsx
@@ -21,31 +21,7 @@ export function useFeedTuners(feedDesc: FeedDescriptor) {
     if (feedDesc.startsWith('feedgen')) {
       return [FeedTuner.preferredLangOnly(langPrefs.contentLanguages)]
     }
-    if (feedDesc.startsWith('list')) {
-      let feedTuners = []
-      if (feedDesc.endsWith('|as_following')) {
-        // Same as Following tuners below, copypaste for now.
-        feedTuners.push(FeedTuner.removeOrphans)
-        if (preferences?.feedViewPrefs.hideReposts) {
-          feedTuners.push(FeedTuner.removeReposts)
-        }
-        if (preferences?.feedViewPrefs.hideReplies) {
-          feedTuners.push(FeedTuner.removeReplies)
-        } else {
-          feedTuners.push(
-            FeedTuner.followedRepliesOnly({
-              userDid: currentAccount?.did || '',
-            }),
-          )
-        }
-        if (preferences?.feedViewPrefs.hideQuotePosts) {
-          feedTuners.push(FeedTuner.removeQuotePosts)
-        }
-        feedTuners.push(FeedTuner.dedupThreads)
-      }
-      return feedTuners
-    }
-    if (feedDesc === 'following') {
+    if (feedDesc === 'following' || feedDesc.startsWith('list')) {
       const feedTuners = [FeedTuner.removeOrphans]
 
       if (preferences?.feedViewPrefs.hideReposts) {

--- a/src/state/queries/post-feed.ts
+++ b/src/state/queries/post-feed.ts
@@ -51,7 +51,6 @@ type AuthorFilter =
   | 'posts_with_media'
 type FeedUri = string
 type ListUri = string
-type ListFilter = 'as_following' // Applies current Following settings. Currently client-side.
 
 export type FeedDescriptor =
   | 'following'
@@ -59,7 +58,6 @@ export type FeedDescriptor =
   | `feedgen|${FeedUri}`
   | `likes|${ActorDid}`
   | `list|${ListUri}`
-  | `list|${ListUri}|${ListFilter}`
 export interface FeedParams {
   mergeFeedEnabled?: boolean
   mergeFeedSources?: string[]


### PR DESCRIPTION
Currently Lists display every single reply from every user on the list. This makes them great for a narrow use case (watching every single reply from a small group of people) but difficult to use for a broad use case (keeping up with a scene).

This change applies the current Following feed settings and heuristics to Lists. This means you'll still see replies in Lists, but only when you have some context on that reply (i.e. you follow the parent, the grandparent, or the root). As a result, Lists where you follow a lot of people will appear chattier while Lists where you follow few people will mostly show top-level posts.

This also aligns Lists with the behavior of Posts tab in Starter Packs (which already worked this way).

## Before

Every single reply was displayed, so whenever someone went on a reply spree, it drowned out other people on the list. Many faces appearing _in_ the list weren't actually a part of the list.

https://github.com/user-attachments/assets/587c73ed-1b3c-40d3-b006-c089fa2fa846

https://github.com/user-attachments/assets/d97d15e2-ea7d-44f4-8a06-8f42bdf94bdd

## After

I don't follow almost anyone on this list so I mostly see top-level posts:

https://github.com/user-attachments/assets/fe3bc473-b14a-485e-901f-824fc0970863

On this list, I follow some people so I'm starting to see more conversations within it:

https://github.com/user-attachments/assets/2277f7f0-bdfe-4957-996e-6e00b8cd02cd
