### PR TITLE
Fix notification->post jump for real

### DIFF
--- a/src/state/queries/notifications/util.ts
+++ b/src/state/queries/notifications/util.ts
@@ -175,19 +175,9 @@ async function fetchSubjects(
 }> {
   const postUris = new Set<string>()
   const packUris = new Set<string>()
-
-  const postUrisWithLikes = new Set<string>()
-  const postUrisWithReposts = new Set<string>()
-
   for (const notif of groupedNotifs) {
     if (notif.subjectUri?.includes('app.bsky.feed.post')) {
       postUris.add(notif.subjectUri)
-      if (notif.type === 'post-like') {
-        postUrisWithLikes.add(notif.subjectUri)
-      }
-      if (notif.type === 'repost') {
-        postUrisWithReposts.add(notif.subjectUri)
-      }
     } else if (
       notif.notification.reasonSubject?.includes('app.bsky.graph.starterpack')
     ) {
@@ -216,15 +206,6 @@ async function fetchSubjects(
       AppBskyFeedPost.validateRecord(post.record).success
     ) {
       postsMap.set(post.uri, post)
-
-      // HACK. In some cases, the appview appears to lag behind and returns empty counters.
-      // To prevent scroll jump due to missing metrics, fill in 1 like/repost instead of 0.
-      if (post.likeCount === 0 && postUrisWithLikes.has(post.uri)) {
-        post.likeCount = 1
-      }
-      if (post.repostCount === 0 && postUrisWithReposts.has(post.uri)) {
-        post.repostCount = 1
-      }
     }
   }
   for (const pack of packsChunks.flat()) {

--- a/src/state/queries/post-thread.ts
+++ b/src/state/queries/post-thread.ts
@@ -408,10 +408,14 @@ export function* findAllPostsInQueryData(
       }
     }
   }
-  for (let post of findAllPostsInFeedQueryData(queryClient, uri)) {
+  for (let post of findAllPostsInNotifsQueryData(queryClient, uri)) {
+    // Check notifications first. If you have a post in notifications,
+    // it's often due to a like or a repost, and we want to prioritize
+    // a post object with >0 likes/reposts over a stale version with no
+    // metrics in order to avoid a notification->post scroll jump.
     yield postViewToPlaceholderThread(post)
   }
-  for (let post of findAllPostsInNotifsQueryData(queryClient, uri)) {
+  for (let post of findAllPostsInFeedQueryData(queryClient, uri)) {
     yield postViewToPlaceholderThread(post)
   }
   for (let post of findAllPostsInQuoteQueryData(queryClient, uri)) {


### PR DESCRIPTION
Reverts https://github.com/bluesky-social/social-app/pull/5297 which is the wrong fix.

The actual problem was that when we construct a placeholder, we're looking into the author feed first. 

So here's what can happen:

1. Write a post
2. Go to your profile tab and refetch Posts
3. Go to notifications and wait for likes to pour in
4. Click on the liked post from the like notification, observe a jump (due to initially missing likes)

Previously, the post from author feed would be found first, which still has `likeCount: 0`.

With this change, the version from notifs would be prioritized over the version from feeds.

I think this generally makes sense because notifs seem more likely to be fresh. Ideally we'd either keep this normalized or prioritize the most recently fetched version. But that would require a much bigger refactoring.

This seems like a simple enough fix to me.

## Test Plan

Try the above. Verify we hit the breakpoint:

<img width="545" alt="Screenshot 2024-09-13 at 03 47 44" src="https://github.com/user-attachments/assets/7a4483af-0867-443b-8bf5-800e241dfd72">

Verify the version we find has the like count from the notif:

<img width="431" alt="Screenshot 2024-09-13 at 03 47 52" src="https://github.com/user-attachments/assets/2d64aa51-1979-4e6c-a7e8-ef0234ae13cb">

So there is no jump.