### PR TITLE
Fix lexicon validation in PWI Discover

### DIFF
--- a/src/lib/api/feed/custom.ts
+++ b/src/lib/api/feed/custom.ts
@@ -2,6 +2,7 @@ import {
   AppBskyFeedDefs,
   AppBskyFeedGetFeed as GetCustomFeed,
   BskyAgent,
+  jsonStringToLex,
 } from '@atproto/api'
 
 import {getContentLanguages} from '#/state/preferences/languages'
@@ -111,7 +112,7 @@ async function loggedOutFetch({
     }&limit=${limit}&lang=${contentLangs}`,
     {method: 'GET', headers: {'Accept-Language': contentLangs}},
   )
-  let data = res.ok ? await res.json() : null
+  let data = res.ok ? jsonStringToLex(await res.text()) : null
   if (data?.feed?.length) {
     return {
       success: true,
@@ -126,7 +127,7 @@ async function loggedOutFetch({
     }&limit=${limit}`,
     {method: 'GET', headers: {'Accept-Language': ''}},
   )
-  data = res.ok ? await res.json() : null
+  data = res.ok ? jsonStringToLex(await res.text()) : null
   if (data?.feed?.length) {
     return {
       success: true,


### PR DESCRIPTION
## Before

https://github.com/user-attachments/assets/917b8388-3eec-4e48-a8af-52959c308984

## After

https://github.com/user-attachments/assets/97cf6d7c-16f4-4a85-ba53-7ba2f52b03d7

## What?!

None of the media embeds were passing Lexicon validation in the logged out Discover because it did not go through the json-to-lex rehydration codepath, and so blobs were plain objects instead of `BlobRef` instances.

<img width="846" alt="Screenshot 2024-09-13 at 19 50 58" src="https://github.com/user-attachments/assets/c16b2603-f894-4c7c-a226-7763218571ad">

The fix is to make it go through the same codepath as done in normal circumstances.

I verified we're not using this hack anywhere else so this should be enough.