### PR TITLE
Add context to `Unmute` and `Mute` strings

### DIFF
--- a/src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerNative.tsx
+++ b/src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerNative.tsx
@@ -160,7 +160,7 @@ function VideoControls({
 
       <ControlButton
         onPress={toggleMuted}
-        label={muted ? _(msg`Unmute`) : _(msg`Mute`)}
+        label={muted ? _(msg({message: `Unmute`, context: 'video'})) : _(msg({message: `Mute`, context: 'video'}))}
         accessibilityHint={_(msg`Tap to toggle sound`)}
         style={{right: 6}}>
         {muted ? (

--- a/src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerNative.tsx
+++ b/src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerNative.tsx
@@ -160,7 +160,11 @@ function VideoControls({
 
       <ControlButton
         onPress={toggleMuted}
-        label={muted ? _(msg({message: `Unmute`, context: 'video'})) : _(msg({message: `Mute`, context: 'video'}))}
+        label={
+          muted
+            ? _(msg({message: `Unmute`, context: 'video'}))
+            : _(msg({message: `Mute`, context: 'video'}))
+        }
         accessibilityHint={_(msg`Tap to toggle sound`)}
         style={{right: 6}}>
         {muted ? (


### PR DESCRIPTION
Similar to #5234, this PR adds `context` to the `Unmute` and `Mute` strings that refer to video, which enables better localization.

I think I got the syntax right 🤞

But I don't know how the code should be formatted to make Prettier happy?