### PR TITLE
Fix wrong empty state for liked by

### DIFF
--- a/src/components/LikedByList.tsx
+++ b/src/components/LikedByList.tsx
@@ -75,6 +75,7 @@ export function LikedByList({uri}: {uri: string}) {
         isLoading={isUriLoading || isLikedByLoading}
         isError={isError}
         emptyType="results"
+        emptyTitle={_(msg`No likes yet`)}
         emptyMessage={_(
           msg`Nobody has liked this yet. Maybe you should be the first!`,
         )}

--- a/src/view/com/post-thread/PostLikedBy.tsx
+++ b/src/view/com/post-thread/PostLikedBy.tsx
@@ -1,5 +1,7 @@
 import React, {useCallback, useMemo, useState} from 'react'
 import {AppBskyFeedGetLikes as GetLikes} from '@atproto/api'
+import {msg} from '@lingui/macro'
+import {useLingui} from '@lingui/react'
 
 import {cleanError} from '#/lib/strings/errors'
 import {logger} from '#/logger'
@@ -26,6 +28,7 @@ function keyExtractor(item: GetLikes.Like) {
 }
 
 export function PostLikedBy({uri}: {uri: string}) {
+  const {_} = useLingui()
   const initialNumToRender = useInitialNumToRender()
 
   const [isPTRing, setIsPTRing] = useState(false)
@@ -78,6 +81,12 @@ export function PostLikedBy({uri}: {uri: string}) {
       <ListMaybePlaceholder
         isLoading={isLoadingUri || isLoadingLikes}
         isError={isError}
+        emptyType="results"
+        emptyTitle={_(msg`No likes yet`)}
+        emptyMessage={_(
+          msg`Nobody has liked this yet. Maybe you should be the first!`,
+        )}
+        errorMessage={cleanError(resolveError || error)}
         sideBorders={false}
       />
     )

--- a/src/view/com/post-thread/PostQuotes.tsx
+++ b/src/view/com/post-thread/PostQuotes.tsx
@@ -97,11 +97,17 @@ export function PostQuotes({uri}: {uri: string}) {
     }
   }, [isFetchingNextPage, hasNextPage, isError, fetchNextPage])
 
-  if (isLoadingUri || isLoadingQuotes || isError) {
+  if (quotes.length < 1) {
     return (
       <ListMaybePlaceholder
         isLoading={isLoadingUri || isLoadingQuotes}
         isError={isError}
+        emptyType="results"
+        emptyTitle={_(msg`No quotes yet`)}
+        emptyMessage={_(
+          msg`Nobody has quoted this yet. Maybe you should be the first!`,
+        )}
+        errorMessage={cleanError(resolveError || error)}
         sideBorders={false}
       />
     )

--- a/src/view/com/post-thread/PostRepostedBy.tsx
+++ b/src/view/com/post-thread/PostRepostedBy.tsx
@@ -1,5 +1,7 @@
 import React, {useCallback, useMemo, useState} from 'react'
 import {AppBskyActorDefs as ActorDefs} from '@atproto/api'
+import {msg} from '@lingui/macro'
+import {useLingui} from '@lingui/react'
 
 import {cleanError} from '#/lib/strings/errors'
 import {logger} from '#/logger'
@@ -19,6 +21,7 @@ function keyExtractor(item: ActorDefs.ProfileViewBasic) {
 }
 
 export function PostRepostedBy({uri}: {uri: string}) {
+  const {_} = useLingui()
   const initialNumToRender = useInitialNumToRender()
 
   const [isPTRing, setIsPTRing] = useState(false)
@@ -71,6 +74,12 @@ export function PostRepostedBy({uri}: {uri: string}) {
       <ListMaybePlaceholder
         isLoading={isLoadingUri || isLoadingRepostedBy}
         isError={isError}
+        emptyType="results"
+        emptyTitle={_(msg`No reposts yet`)}
+        emptyMessage={_(
+          msg`Nobody has reposted this yet. Maybe you should be the first!`,
+        )}
+        errorMessage={cleanError(resolveError || error)}
         sideBorders={false}
       />
     )


### PR DESCRIPTION
Take a post with no likes and add `/liked-by` to the URL. 

Before:

<img width="615" alt="Screenshot 2024-09-14 at 14 41 52" src="https://github.com/user-attachments/assets/6efaa61b-09a0-49a1-bc3e-c517f1ac4966">

After:

<img width="590" alt="Screenshot 2024-09-14 at 14 42 37" src="https://github.com/user-attachments/assets/f41c4e76-5701-48d1-8431-c82ae6ed743b">

Did the same for reposts and quotes for consistency. (Quotes had a different empty state.)

Also added more specific titles.