### PR TITLE
fix timeline appearance in browser on smartphone

### DIFF
--- a/src/view/com/util/PostMeta.tsx
+++ b/src/view/com/util/PostMeta.tsx
@@ -14,6 +14,7 @@ import {sanitizeHandle} from 'lib/strings/handles'
 import {niceDate} from 'lib/strings/time'
 import {TypographyVariant} from 'lib/ThemeContext'
 import {isAndroid} from 'platform/detection'
+import {web} from '#/alf'
 import {ProfileHoverCard} from '#/components/ProfileHoverCard'
 import {TextLinkOnWebOnly} from './Link'
 import {Text} from './text/Text'
@@ -102,7 +103,7 @@ let PostMeta = (opts: PostMetaOpts): React.ReactNode => {
         {({timeElapsed}) => (
           <TextLinkOnWebOnly
             type="md"
-            style={pal.textLight}
+            style={[pal.textLight, web({whiteSpace: 'nowrap'})]}
             text={timeElapsed}
             accessibilityLabel={niceDate(i18n, opts.timestamp)}
             title={niceDate(i18n, opts.timestamp)}


### PR DESCRIPTION
If you view the timeline with the language setting set to Japanese in your smartphone browser, user posts with long handles and names look like this (probably all languages where the browser automatically does the wrapping without recognizing the space between words will be like this)
![image](https://github.com/user-attachments/assets/d3407065-dbb0-4b1e-9955-5f81c288d8b0)
If the name and handle are short, it will look normal like this
![image](https://github.com/user-attachments/assets/34746a30-f5a2-4b88-9b1a-b20e7995ca20)
If the language display is set to English, even if the name is in Japanese, it will be displayed correctly like this
![image](https://github.com/user-attachments/assets/30c35f5a-ed0b-423a-90bb-88bfa43b93f8)

