### PR TITLE
Add a Make Valid Handle Function for Custom Domain Handles

### DIFF
--- a/src/lib/strings/handles.ts
+++ b/src/lib/strings/handles.ts
@@ -13,6 +13,11 @@ export function makeValidHandle(str: string): string {
   return str.replace(/^[^a-z0-9]+/g, '').replace(/[^a-z0-9-]/g, '')
 }
 
+export function makeValidCustomDomainHandle(str: string): string {
+  str = str.toLowerCase()
+  return str.replace(/^[-]+/g, '').replace(/[!@#$%^&*()_;:,?/\\=+<> ]/g, '');
+}
+
 export function createFullHandle(name: string, domain: string): string {
   name = (name || '').replace(/[.]+$/, '')
   domain = (domain || '').replace(/^[.]+/, '')

--- a/src/view/com/modals/ChangeHandle.tsx
+++ b/src/view/com/modals/ChangeHandle.tsx
@@ -19,7 +19,7 @@ import {SessionAccount, useAgent, useSession} from '#/state/session'
 import {useAnalytics} from 'lib/analytics/analytics'
 import {usePalette} from 'lib/hooks/usePalette'
 import {cleanError} from 'lib/strings/errors'
-import {createFullHandle, makeValidHandle} from 'lib/strings/handles'
+import {createFullHandle, makeValidHandle, makeValidCustomDomainHandle} from 'lib/strings/handles'
 import {s} from 'lib/styles'
 import {useTheme} from 'lib/ThemeContext'
 import {ErrorMessage} from '../util/error/ErrorMessage'
@@ -321,7 +321,8 @@ function CustomHandleForm({
   }, [currentAccount, isDNSForm, _])
   const onChangeHandle = React.useCallback(
     (v: string) => {
-      setHandle(v)
+      const newHandle = makeValidCustomDomainHandle(v)
+      setHandle(newHandle)
       setCanSave(false)
     },
     [setHandle, setCanSave],


### PR DESCRIPTION
Prevents the user from putting invalid domain characters in the Change Handle field for Custom Domains, mentioned in #1528 

Hopefully this is okay? 🩵🩷🩵🩷