### PR TITLE
[Video] Add volume slider to video embeds on web

### DIFF
--- a/src/view/com/util/post-embeds/VideoEmbedInner/VideoWebControls.tsx
+++ b/src/view/com/util/post-embeds/VideoEmbedInner/VideoWebControls.tsx
@@ -751,6 +751,13 @@ function formatTime(time: number) {
   return `${minutes}:${seconds}`
 }
 
+function sliderVolumeToVideoVolume(value: number) {
+  return Math.pow(value, 4)
+}
+function videoVolumeToSliderVolume(value: number) {
+  return Math.pow(value, 1 / 4)
+}
+
 const INITIAL_VOLUME = 0.5
 
 function useVideoUtils(ref: React.RefObject<HTMLVideoElement>) {
@@ -778,7 +785,7 @@ function useVideoUtils(ref: React.RefObject<HTMLVideoElement>) {
     setDuration(round(ref.current.duration) || 0)
     setMuted(ref.current.muted)
     setPlaying(!ref.current.paused)
-    ref.current.volume = INITIAL_VOLUME
+    ref.current.volume = sliderVolumeToVideoVolume(INITIAL_VOLUME)
 
     const handleTimeUpdate = () => {
       if (!ref.current) return
@@ -800,7 +807,7 @@ function useVideoUtils(ref: React.RefObject<HTMLVideoElement>) {
 
     const handleVolumeChange = () => {
       if (!ref.current) return
-      setVolume(ref.current.volume)
+      setVolume(videoVolumeToSliderVolume(ref.current.volume))
       setMuted(ref.current.muted)
     }
 
@@ -952,7 +959,7 @@ function useVideoUtils(ref: React.RefObject<HTMLVideoElement>) {
     (value: number) => {
       if (!ref.current) return
 
-      ref.current.volume = value
+      ref.current.volume = sliderVolumeToVideoVolume(value)
     },
     [ref],
   )

--- a/src/view/com/util/post-embeds/VideoEmbedInner/VideoWebControls.tsx
+++ b/src/view/com/util/post-embeds/VideoEmbedInner/VideoWebControls.tsx
@@ -703,6 +703,14 @@ function AudioControls({
     onIn: onStartHover,
     onOut: onEndHover,
   } = useInteractionState()
+  const [focused, setFocused] = useState(false)
+
+  const onFocus = useCallback(() => {
+    setFocused(true)
+  }, [setFocused])
+  const onBlur = useCallback(() => {
+    setFocused(false)
+  }, [setFocused])
 
   const onChangeVolume = useCallback(
     (evnt: React.ChangeEvent<HTMLInputElement>) => {
@@ -716,15 +724,18 @@ function AudioControls({
     <View
       style={[a.flex_row]}
       onPointerEnter={onStartHover}
-      onPointerLeave={onEndHover}>
+      onPointerLeave={onEndHover}
+      // @ts-expect-error web only
+      onFocus={onFocus}
+      onBlur={onBlur}>
       <View
         style={[
           a.mr_2xs,
           a.justify_center,
           a.overflow_hidden,
-          {width: hovered ? VOLUME_SLIDER_WIDTH : 0},
+          {width: focused || hovered ? VOLUME_SLIDER_WIDTH : 0},
           web({
-            transition: 'width 0.2s cubic-bezier(0.4, 0, 1, 1)',
+            transition: !focused && 'width 0.2s cubic-bezier(0.4, 0, 1, 1)',
           }),
         ]}>
         <input
@@ -737,6 +748,7 @@ function AudioControls({
           onChange={onChangeVolume}
           min={0}
           max={100}
+          tabIndex={0}
         />
       </View>
       <ControlButton

--- a/src/view/com/util/post-embeds/VideoEmbedInner/VideoWebControls.tsx
+++ b/src/view/com/util/post-embeds/VideoEmbedInner/VideoWebControls.tsx
@@ -695,6 +695,8 @@ function AudioControls({
   muted: boolean
   toggleMute: () => void
 }) {
+  const VOLUME_SLIDER_WIDTH = 60
+
   const {_} = useLingui()
   const {
     state: hovered,
@@ -715,18 +717,28 @@ function AudioControls({
       style={[a.flex_row]}
       onPointerEnter={onStartHover}
       onPointerLeave={onEndHover}>
-      {hovered && (
+      <View
+        style={[
+          a.mr_2xs,
+          a.justify_center,
+          a.overflow_hidden,
+          {width: hovered ? VOLUME_SLIDER_WIDTH : 0},
+          web({
+            transition: 'width 0.2s cubic-bezier(0.4, 0, 1, 1)',
+          }),
+        ]}>
         <input
           type="range"
           style={{
-            width: 60,
+            padding: 0,
+            width: VOLUME_SLIDER_WIDTH,
           }}
           value={volume * 100}
           onChange={onChangeVolume}
           min={0}
           max={100}
         />
-      )}
+      </View>
       <ControlButton
         active={muted}
         activeLabel={_(msg({message: `Unmute`, context: 'video'}))}

--- a/src/view/com/util/post-embeds/VideoEmbedInner/VideoWebControls.tsx
+++ b/src/view/com/util/post-embeds/VideoEmbedInner/VideoWebControls.tsx
@@ -32,6 +32,7 @@ import {Play_Filled_Corner0_Rounded as PlayIcon} from '#/components/icons/Play'
 import {SpeakerVolumeFull_Stroke2_Corner0_Rounded as UnmuteIcon} from '#/components/icons/Speaker'
 import {Loader} from '#/components/Loader'
 import {Text} from '#/components/Typography'
+import {useVideoVolumeState} from '../VideoVolumeContext'
 import {TimeIndicator} from './TimeIndicator'
 
 export function Controls({
@@ -758,12 +759,10 @@ function videoVolumeToSliderVolume(value: number) {
   return Math.pow(value, 1 / 4)
 }
 
-const INITIAL_VOLUME = 0.5
-
 function useVideoUtils(ref: React.RefObject<HTMLVideoElement>) {
   const [playing, setPlaying] = useState(false)
+  const {volume, setVolume} = useVideoVolumeState()
   const [muted, setMuted] = useState(true)
-  const [volume, setVolume] = useState(INITIAL_VOLUME)
   const [currentTime, setCurrentTime] = useState(0)
   const [duration, setDuration] = useState(0)
   const [buffering, setBuffering] = useState(false)
@@ -785,7 +784,6 @@ function useVideoUtils(ref: React.RefObject<HTMLVideoElement>) {
     setDuration(round(ref.current.duration) || 0)
     setMuted(ref.current.muted)
     setPlaying(!ref.current.paused)
-    ref.current.volume = sliderVolumeToVideoVolume(INITIAL_VOLUME)
 
     const handleTimeUpdate = () => {
       if (!ref.current) return
@@ -899,7 +897,13 @@ function useVideoUtils(ref: React.RefObject<HTMLVideoElement>) {
       abortController.abort()
       clearTimeout(bufferingTimeout)
     }
-  }, [ref])
+  }, [ref, setMuted, setVolume])
+
+  useEffect(() => {
+    if (!ref.current) return
+
+    ref.current.volume = sliderVolumeToVideoVolume(volume)
+  }, [ref, volume])
 
   const play = useCallback(() => {
     if (!ref.current) return
@@ -940,20 +944,23 @@ function useVideoUtils(ref: React.RefObject<HTMLVideoElement>) {
   const mute = useCallback(() => {
     if (!ref.current) return
 
+    setMuted(true)
     ref.current.muted = true
-  }, [ref])
+  }, [ref, setMuted])
 
   const unmute = useCallback(() => {
     if (!ref.current) return
 
+    setMuted(false)
     ref.current.muted = false
-  }, [ref])
+  }, [ref, setMuted])
 
   const toggleMute = useCallback(() => {
     if (!ref.current) return
 
+    setMuted(!ref.current.muted)
     ref.current.muted = !ref.current.muted
-  }, [ref])
+  }, [ref, setMuted])
 
   const changeVolume = useCallback(
     (value: number) => {

--- a/src/view/com/util/post-embeds/VideoVolumeContext.tsx
+++ b/src/view/com/util/post-embeds/VideoVolumeContext.tsx
@@ -2,20 +2,25 @@ import React from 'react'
 
 const Context = React.createContext(
   {} as {
+    volume: number
+    setVolume: (volume: number) => void
     muted: boolean
     setMuted: (muted: boolean) => void
   },
 )
 
 export function Provider({children}: {children: React.ReactNode}) {
+  const [volume, setVolume] = React.useState(0.5)
   const [muted, setMuted] = React.useState(true)
 
   const value = React.useMemo(
     () => ({
+      volume,
+      setVolume,
       muted,
       setMuted,
     }),
-    [muted, setMuted],
+    [volume, setVolume, muted, setMuted],
   )
 
   return <Context.Provider value={value}>{children}</Context.Provider>


### PR DESCRIPTION
Adds an `<input type="range">` (better designs are welcome) next to the Toggle Mute button to adjust the volume of the video.

- The slider defaults to 50% volume.
  This is more a personal preference, but I think not maxing out the volume and blasting people's ears when focus on a video is probably a good idea. 50% is a comfortable default for me.
- Moving the slider draws focus and unmutes the video. This is inline with other places, like Twitter.
- The slider is logarithmic, meaning it adjusts better to human perception of sound.
  Basically, with a logarithmic scale, moving the slider from one point to another should feel like the slider value change more accurately resembles the change in volume perceived, even to audiophiles.
  I chose to use the conversion function from this blog post: <https://www.dr-lex.be/info-stuff/volumecontrols.html>.
- Volume is applied to all video embeds. This repurposes the video volume state from 843f9925f5d0773db321e617c1bd0be6a308ef7f.
- Even has a nice sliding animation, borrowing from YouTube's design.

![GIF showcasing the volume slider animation](https://github.com/user-attachments/assets/0147aa86-8a02-4a22-b7d9-0b6f0974c474)

![GIF of user interacting with the new slider and toggle mute button](https://github.com/user-attachments/assets/64d82c5e-6b94-4bc9-9469-33e385fb8fa0)


Resolves #5285 