### PR TITLE
[Video] loosen checks on vtt file

### DIFF
--- a/src/view/com/composer/videos/SubtitleFilePicker.tsx
+++ b/src/view/com/composer/videos/SubtitleFilePicker.tsx
@@ -28,8 +28,9 @@ export function SubtitleFilePicker({
     if (selectedFile) {
       if (
         selectedFile.type === 'text/vtt' ||
-        (selectedFile.type === 'text/plain' &&
-          selectedFile.name.endsWith('.vtt'))
+        // HACK: sometimes the mime type is just straight-up missing
+        // best we can do is check the file extension and hope for the best
+        selectedFile.name.endsWith('.vtt')
       ) {
         onSelectFile(selectedFile)
       } else {


### PR DESCRIPTION
Seems sometimes the mime type is just... missing. Let's just allow files all that have a `.vtt` extension, broken files will just be broken when parsed on the backend, not much we can do there

https://blueskyweb.sentry.io/issues/5839940358/?project=4505071690514432&query=Invalid+subtitle+file+type&referrer=issue-stream&statsPeriod=14d&stream_index=0

