### PR TITLE
Make like animation on web same speed as mobile

### DIFF
--- a/src/lib/custom-animations/LikeIcon.web.tsx
+++ b/src/lib/custom-animations/LikeIcon.web.tsx
@@ -10,7 +10,7 @@ import {
 } from '#/components/icons/Heart2'
 
 const animationConfig = {
-  duration: 400,
+  duration: 600,
   easing: 'cubic-bezier(0.4, 0, 0.2, 1)',
   fill: 'forwards' as FillMode,
 }


### PR DESCRIPTION
Adjust speed of web like animation to be slower to match the iOS and Android like animations which look much smoother.
Closes #5390 

Mobile for comparison:

https://github.com/user-attachments/assets/278d9058-8897-46ce-a3a8-fb42f4aeaf72

Before:

https://github.com/user-attachments/assets/d35c61ad-429f-46dc-b3d0-bc046300ad8e

After:

https://github.com/user-attachments/assets/0802cdf5-85a5-40f3-9938-b292d3e6f2f6

