### PR TITLE
Revert unneeded changes to `expo-modules-core` patch

### DIFF
--- a/patches/expo-modules-core+1.12.11.patch
+++ b/patches/expo-modules-core+1.12.11.patch
@@ -4,16 +4,16 @@ index bb74e80..0aa0202 100644
 +++ b/node_modules/expo-modules-core/android/src/main/java/expo/modules/adapters/react/NativeModulesProxy.java
 @@ -90,8 +90,8 @@ public class NativeModulesProxy extends ReactContextBaseJavaModule {
      mModuleRegistry.ensureIsInitialized();
- 
+
      KotlinInteropModuleRegistry kotlinModuleRegistry = getKotlinInteropModuleRegistry();
 -    kotlinModuleRegistry.emitOnCreate();
      kotlinModuleRegistry.installJSIInterop();
 +    kotlinModuleRegistry.emitOnCreate();
- 
+
      Map<String, Object> constants = new HashMap<>(3);
      constants.put(MODULES_CONSTANTS_KEY, new HashMap<>());
 diff --git a/node_modules/expo-modules-core/build/uuid/uuid.js b/node_modules/expo-modules-core/build/uuid/uuid.js
-index 109d3fe..c421931 100644
+index 109d3fe..c7fce9e 100644
 --- a/node_modules/expo-modules-core/build/uuid/uuid.js
 +++ b/node_modules/expo-modules-core/build/uuid/uuid.js
 @@ -1,5 +1,7 @@
@@ -24,16 +24,3 @@ index 109d3fe..c421931 100644
  const nativeUuidv4 = globalThis?.expo?.uuidv4;
  const nativeUuidv5 = globalThis?.expo?.uuidv5;
  function uuidv4() {
-diff --git a/node_modules/expo-modules-core/ios/Core/SharedObjects/SharedObjectRegistry.swift b/node_modules/expo-modules-core/ios/Core/SharedObjects/SharedObjectRegistry.swift
-index ee2268a..4851b67 100644
---- a/node_modules/expo-modules-core/ios/Core/SharedObjects/SharedObjectRegistry.swift
-+++ b/node_modules/expo-modules-core/ios/Core/SharedObjects/SharedObjectRegistry.swift
-@@ -173,7 +173,7 @@ public final class SharedObjectRegistry {
-   }
- 
-   internal func clear() {
--    Self.lockQueue.async {
-+    DispatchQueue.main.sync {
-       self.pairs.removeAll()
-     }
-   }

--- a/patches/expo-modules-core+1.12.11.patch
+++ b/patches/expo-modules-core+1.12.11.patch
@@ -4,12 +4,12 @@ index bb74e80..0aa0202 100644
 +++ b/node_modules/expo-modules-core/android/src/main/java/expo/modules/adapters/react/NativeModulesProxy.java
 @@ -90,8 +90,8 @@ public class NativeModulesProxy extends ReactContextBaseJavaModule {
      mModuleRegistry.ensureIsInitialized();
-
+ 
      KotlinInteropModuleRegistry kotlinModuleRegistry = getKotlinInteropModuleRegistry();
 -    kotlinModuleRegistry.emitOnCreate();
      kotlinModuleRegistry.installJSIInterop();
 +    kotlinModuleRegistry.emitOnCreate();
-
+ 
      Map<String, Object> constants = new HashMap<>(3);
      constants.put(MODULES_CONSTANTS_KEY, new HashMap<>());
 diff --git a/node_modules/expo-modules-core/build/uuid/uuid.js b/node_modules/expo-modules-core/build/uuid/uuid.js
@@ -30,10 +30,10 @@ index ee2268a..4851b67 100644
 +++ b/node_modules/expo-modules-core/ios/Core/SharedObjects/SharedObjectRegistry.swift
 @@ -173,7 +173,7 @@ public final class SharedObjectRegistry {
    }
-
+ 
    internal func clear() {
 -    Self.lockQueue.async {
-+    Self.lockQueue.sync {
++    DispatchQueue.main.sync {
        self.pairs.removeAll()
      }
    }

--- a/patches/expo-modules-core+1.12.11.patch
+++ b/patches/expo-modules-core+1.12.11.patch
@@ -12,15 +12,3 @@ index bb74e80..0aa0202 100644
 
      Map<String, Object> constants = new HashMap<>(3);
      constants.put(MODULES_CONSTANTS_KEY, new HashMap<>());
-diff --git a/node_modules/expo-modules-core/build/uuid/uuid.js b/node_modules/expo-modules-core/build/uuid/uuid.js
-index 109d3fe..c7fce9e 100644
---- a/node_modules/expo-modules-core/build/uuid/uuid.js
-+++ b/node_modules/expo-modules-core/build/uuid/uuid.js
-@@ -1,5 +1,7 @@
- import bytesToUuid from './lib/bytesToUuid';
- import { Uuidv5Namespace } from './uuid.types';
-+import { ensureNativeModulesAreInstalled } from '../ensureNativeModulesAreInstalled';
-+ensureNativeModulesAreInstalled();
- const nativeUuidv4 = globalThis?.expo?.uuidv4;
- const nativeUuidv5 = globalThis?.expo?.uuidv5;
- function uuidv4() {


### PR DESCRIPTION
No longer needed since we are not using `expo-video`.