### PR TITLE
Fix notification spacing

### DIFF
--- a/src/view/com/notifications/FeedItem.tsx
+++ b/src/view/com/notifications/FeedItem.tsx
@@ -316,8 +316,7 @@ let FeedItem = ({
             {authors.length > 1 ? (
               <>
                 <Text style={[pal.text, s.mr5, s.ml5]}>
-                  {' '}
-                  <Trans>and</Trans>{' '}
+                  <Trans>and</Trans>
                 </Text>
                 <Text style={[pal.text, s.bold]}>
                   {plural(authors.length - 1, {


### PR DESCRIPTION
This PR removes unnecessary spaces around the word "and" in the FeedItem component's notification items. Previously, there was an extra space before and after "and" due to the inclusion of {' '}. These have been removed to ensure proper spacing is handled.


Before:
<img width="401" alt="Screenshot 2024-09-17 at 18 11 01" src="https://github.com/user-attachments/assets/7dce86ee-e839-4536-9f26-098a45859308">

After
<img width="401" alt="Screenshot 2024-09-17 at 18 11 07" src="https://github.com/user-attachments/assets/de8b9146-570f-4e3a-a423-6433ce2171f6">
