### PR TITLE
Fixing hover card for labeler accounts

### DIFF
--- a/src/components/ProfileHoverCard/index.web.tsx
+++ b/src/components/ProfileHoverCard/index.web.tsx
@@ -411,7 +411,7 @@ function Inner({
     () => currentAccount?.did === profile.did,
     [currentAccount, profile],
   )
-  const isLabeler = React.useMemo(() => profile.associated?.labeler, [profile])
+  const isLabeler = profile.associated?.labeler
 
   return (
     <View>

--- a/src/components/ProfileHoverCard/index.web.tsx
+++ b/src/components/ProfileHoverCard/index.web.tsx
@@ -411,6 +411,7 @@ function Inner({
     () => currentAccount?.did === profile.did,
     [currentAccount, profile],
   )
+  const isLabeler = React.useMemo(() => profile.associated?.labeler, [profile])
 
   return (
     <View>
@@ -419,11 +420,13 @@ function Inner({
           <UserAvatar
             size={64}
             avatar={profile.avatar}
+            type={isLabeler ? 'labeler' : 'user'}
             moderation={moderation.ui('avatar')}
           />
         </Link>
 
         {!isMe &&
+          !isLabeler &&
           (isBlockedUser ? (
             <Link
               to={profileURL}


### PR DESCRIPTION
Hey there! 👋 This PR fixes a bug in the ProfileHoverCard component where labeler status was not properly handled.
I have noticed this bug yesterday and it was also reported here #5337 

**Before:**
<img width="916" alt="Screenshot 2024-09-18 at 23 37 29" src="https://github.com/user-attachments/assets/bbad57f1-6e65-445a-92ec-10cc07b97884">

**After:**
<img width="916" alt="Screenshot 2024-09-18 at 23 36 58" src="https://github.com/user-attachments/assets/dced92c5-f7c5-4d73-aad5-dbb3fed67f1c">


**When hovering a user profile:**
<img width="916" alt="Screenshot 2024-09-18 at 23 37 10" src="https://github.com/user-attachments/assets/815fed42-0a7d-4d72-ac4e-069e7b6cf564">


