### PR TITLE
Fix ext embeds in DMs

### DIFF
--- a/src/lib/embeds.ts
+++ b/src/lib/embeds.ts
@@ -1,7 +1,7 @@
 import {
-  AppBskyFeedDefs,
   AppBskyEmbedRecord,
   AppBskyEmbedRecordWithMedia,
+  AppBskyFeedDefs,
 } from '@atproto/api'
 
 export function isEmbedByEmbedder(

--- a/src/view/com/util/post-embeds/ExternalLinkEmbed.tsx
+++ b/src/view/com/util/post-embeds/ExternalLinkEmbed.tsx
@@ -59,7 +59,7 @@ export const ExternalLinkEmbed = ({
   }
 
   return (
-    <View style={[a.flex_col, a.rounded_sm]}>
+    <View style={[a.flex_col, a.w_full]}>
       <LinkWrapper link={link} onOpen={onOpen} style={style}>
         {imageUri && !embedPlayerParams ? (
           <View>
@@ -105,7 +105,7 @@ export const ExternalLinkEmbed = ({
               borderBottomLeftRadius: 8,
               paddingHorizontal: isMobile ? 10 : 14,
             },
-            !imageUri && !embedPlayerParams && [a.border, a.rounded_sm],
+            !imageUri && !embedPlayerParams && [a.border, a.rounded_md],
           ]}>
           <Text
             type="sm"

--- a/src/view/com/util/post-embeds/ExternalLinkEmbed.tsx
+++ b/src/view/com/util/post-embeds/ExternalLinkEmbed.tsx
@@ -105,7 +105,7 @@ export const ExternalLinkEmbed = ({
               borderBottomLeftRadius: 8,
               paddingHorizontal: isMobile ? 10 : 14,
             },
-            !imageUri && !embedPlayerParams && [a.border, a.rounded_md],
+            !imageUri && !embedPlayerParams && [a.border, a.rounded_sm],
           ]}>
           <Text
             type="sm"


### PR DESCRIPTION
<table>
  <thead>
    <tr>
      <th>Before</th>
      <th>After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><img src="https://github.com/user-attachments/assets/dc0ffb0d-2405-468d-948e-668966d48974" alt="Before Screenshot - iPhone 16 - 2024-09-19 at 14 49 30" /></td>
      <td><img src="https://github.com/user-attachments/assets/0cb00f90-8e2f-4c18-a073-1d4108f81343" /></td>
    </tr>
  </tbody>
</table>