### PR TITLE
[Neue] Ligatures & composer

### DIFF
--- a/bskyweb/templates/base.html
+++ b/bskyweb/templates/base.html
@@ -149,7 +149,6 @@
 
     /* ProseMirror */
     .ProseMirror {
-      font: 18px -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Liberation Sans", Helvetica, Arial, sans-serif;
       min-height: 140px;
     }
     .ProseMirror-dark {

--- a/src/alf/fonts.ts
+++ b/src/alf/fonts.ts
@@ -108,4 +108,10 @@ export function applyFonts(
       style.fontFamily = style.fontFamily || FAMILIES
     }
   }
+
+  /**
+   * Disable contextual ligatures
+   * {@link https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant}
+   */
+  style.fontVariant = ['no-contextual']
 }

--- a/src/view/com/composer/text-input/TextInput.tsx
+++ b/src/view/com/composer/text-input/TextInput.tsx
@@ -19,6 +19,7 @@ import PasteInput, {
   PasteInputRef,
 } from '@mattermost/react-native-paste-input'
 
+import {isAndroid} from '#/platform/detection'
 import {POST_IMG_MAX} from 'lib/constants'
 import {usePalette} from 'lib/hooks/usePalette'
 import {downloadAndResize} from 'lib/media/manip'
@@ -183,11 +184,30 @@ export const TextInput = forwardRef(function TextInputImpl(
   )
 
   const inputTextStyle = React.useMemo(() => {
-    return normalizeTextStyles([a.text_lg, a.leading_snug, t.atoms.text], {
-      fontScale: fonts.scaleMultiplier,
-      fontFamily: fonts.family,
-      flags: {},
-    })
+    const style = normalizeTextStyles(
+      [a.text_xl, a.leading_snug, t.atoms.text],
+      {
+        fontScale: fonts.scaleMultiplier,
+        fontFamily: fonts.family,
+        flags: {},
+      },
+    )
+
+    /*
+     * `PasteInput` appears to prefer no `lineHeight`
+     */
+    style.lineHeight = undefined
+
+    /*
+     * Android impl of `PasteInput` doesn't support the array syntax for `fontVariant`
+     */
+    if (isAndroid) {
+      // @ts-ignore
+      style.fontVariant = style.fontVariant
+        ? style.fontVariant.join(' ')
+        : undefined
+    }
+    return style
   }, [t, fonts])
 
   const textDecorated = useMemo(() => {

--- a/src/view/com/composer/text-input/TextInput.tsx
+++ b/src/view/com/composer/text-input/TextInput.tsx
@@ -26,12 +26,13 @@ import {isUriImage} from 'lib/media/util'
 import {cleanError} from 'lib/strings/errors'
 import {getMentionAt, insertMentionAt} from 'lib/strings/mention-manip'
 import {useTheme} from 'lib/ThemeContext'
-import {isIOS} from 'platform/detection'
 import {
   LinkFacetMatch,
   suggestLinkCardUri,
 } from 'view/com/composer/text-input/text-input-util'
 import {Text} from 'view/com/util/text/Text'
+import {atoms as a, useAlf} from '#/alf'
+import {normalizeTextStyles} from '#/components/Typography'
 import {Autocomplete} from './mobile/Autocomplete'
 
 export interface TextInputRef {
@@ -67,6 +68,7 @@ export const TextInput = forwardRef(function TextInputImpl(
   }: TextInputProps,
   ref,
 ) {
+  const {theme: t, fonts} = useAlf()
   const pal = usePalette('default')
   const textInput = useRef<PasteInputRef>(null)
   const textInputSelection = useRef<Selection>({start: 0, end: 0})
@@ -180,6 +182,14 @@ export const TextInput = forwardRef(function TextInputImpl(
     [onChangeText, richtext, setAutocompletePrefix],
   )
 
+  const inputTextStyle = React.useMemo(() => {
+    return normalizeTextStyles([a.text_lg, a.leading_snug, t.atoms.text], {
+      fontScale: fonts.scaleMultiplier,
+      fontFamily: fonts.family,
+      flags: {},
+    })
+  }, [t, fonts])
+
   const textDecorated = useMemo(() => {
     let i = 0
 
@@ -187,15 +197,12 @@ export const TextInput = forwardRef(function TextInputImpl(
       return (
         <Text
           key={i++}
-          style={[
-            segment.facet ? pal.link : pal.text,
-            styles.textInputFormatting,
-          ]}>
+          style={[inputTextStyle, segment.facet ? pal.link : pal.text]}>
           {segment.text}
         </Text>
       )
     })
-  }, [richtext, pal.link, pal.text])
+  }, [richtext, pal.link, pal.text, inputTextStyle])
 
   return (
     <View style={styles.container}>
@@ -213,12 +220,7 @@ export const TextInput = forwardRef(function TextInputImpl(
         multiline
         scrollEnabled={false}
         numberOfLines={4}
-        style={[
-          pal.text,
-          styles.textInput,
-          styles.textInputFormatting,
-          {textAlignVertical: 'top'},
-        ]}
+        style={[inputTextStyle, styles.textInput, {textAlignVertical: 'top'}]}
         {...props}>
         {textDecorated}
       </PasteInput>
@@ -241,12 +243,5 @@ const styles = StyleSheet.create({
     paddingBottom: 20,
     marginLeft: 8,
     alignSelf: 'flex-start',
-  },
-  textInputFormatting: {
-    fontSize: 18,
-    letterSpacing: 0.2,
-    fontWeight: '400',
-    // This is broken on ios right now, so don't set it there.
-    lineHeight: isIOS ? undefined : 23.4, // 1.3*16
   },
 })

--- a/src/view/com/composer/text-input/TextInput.web.tsx
+++ b/src/view/com/composer/text-input/TextInput.web.tsx
@@ -22,7 +22,9 @@ import {
   LinkFacetMatch,
   suggestLinkCardUri,
 } from 'view/com/composer/text-input/text-input-util'
+import {atoms as a, useAlf} from '#/alf'
 import {Portal} from '#/components/Portal'
+import {normalizeTextStyles} from '#/components/Typography'
 import {Text} from '../../util/text/Text'
 import {createSuggestion} from './web/Autocomplete'
 import {Emoji} from './web/EmojiPicker.web'
@@ -58,6 +60,7 @@ export const TextInput = React.forwardRef(function TextInputImpl(
   TextInputProps,
   ref,
 ) {
+  const {theme: t, fonts} = useAlf()
   const autocomplete = useActorAutocompleteFn()
   const pal = usePalette('default')
   const modeClass = useColorSchemeStyle('ProseMirror-light', 'ProseMirror-dark')
@@ -247,13 +250,26 @@ export const TextInput = React.forwardRef(function TextInputImpl(
     },
   }))
 
+  const inputStyle = React.useMemo(() => {
+    const style = normalizeTextStyles(
+      [a.text_lg, a.leading_snug, t.atoms.text],
+      {
+        fontScale: fonts.scaleMultiplier,
+        fontFamily: fonts.family,
+        flags: {},
+      },
+    )
+    // TipTap component isn't a RN View, need to convert some props - esb
+    // @ts-ignore
+    style.lineHeight = style.lineHeight += 'px'
+    return style
+  }, [t, fonts])
+
   return (
     <>
       <View style={styles.container}>
-        <EditorContent
-          editor={editor}
-          style={{color: pal.text.color as string}}
-        />
+        {/* @ts-ignore inputStyle is fine - esb */}
+        <EditorContent editor={editor} style={inputStyle} />
       </View>
 
       {isDropping && (

--- a/src/view/com/composer/text-input/TextInput.web.tsx
+++ b/src/view/com/composer/text-input/TextInput.web.tsx
@@ -265,8 +265,9 @@ export const TextInput = React.forwardRef(function TextInputImpl(
      *
      * `lineHeight` should always be defined here, this is defensive.
      */
-    // @ts-ignore
-    style.lineHeight = style.lineHeight ? (style.lineHeight += 'px') : undefined
+    style.lineHeight = style.lineHeight
+      ? ((style.lineHeight + 'px') as unknown as number)
+      : undefined
     return style
   }, [t, fonts])
 

--- a/src/view/com/composer/text-input/TextInput.web.tsx
+++ b/src/view/com/composer/text-input/TextInput.web.tsx
@@ -259,16 +259,21 @@ export const TextInput = React.forwardRef(function TextInputImpl(
         flags: {},
       },
     )
-    // TipTap component isn't a RN View, need to convert some props - esb
+    /*
+     * TipTap component isn't a RN View and while it seems to convert
+     * `fontSize` to `px`, it doesn't convert `lineHeight`.
+     *
+     * `lineHeight` should always be defined here, this is defensive.
+     */
     // @ts-ignore
-    style.lineHeight = style.lineHeight += 'px'
+    style.lineHeight = style.lineHeight ? (style.lineHeight += 'px') : undefined
     return style
   }, [t, fonts])
 
   return (
     <>
       <View style={styles.container}>
-        {/* @ts-ignore inputStyle is fine - esb */}
+        {/* @ts-ignore inputStyle is fine */}
         <EditorContent editor={editor} style={inputStyle} />
       </View>
 

--- a/web/index.html
+++ b/web/index.html
@@ -153,7 +153,6 @@
 
       /* ProseMirror */
       .ProseMirror {
-        font: 18px -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Liberation Sans", Helvetica, Arial, sans-serif;
         min-height: 140px;
       }
       .ProseMirror-dark {


### PR DESCRIPTION
### Web before/after
Very subtle differences
![CleanShot 2024-09-19 at 13 20 06@2x](https://github.com/user-attachments/assets/a9ae023a-90c7-452b-be03-16244aa606c9)
![CleanShot 2024-09-19 at 13 26 41@2x](https://github.com/user-attachments/assets/f538036f-60ec-4c01-9e88-2493098caa83)

### iOS before/after
Text is subtly smaller, tracking was previously `0.2` and with this update it's set to `0` to match our other text, that's the biggest difference.
![IMG_3899](https://github.com/user-attachments/assets/f82cc56a-88cd-4838-9de8-d9154735da2f)
![IMG_3898](https://github.com/user-attachments/assets/606860d3-cfea-4618-b1d8-147f97833123)


### Android before/after
Same as iOS
![Screenshot_20240919-141736](https://github.com/user-attachments/assets/01d542b4-735a-4b43-bf20-6f2da4c4d21c)
![Screenshot_20240919-141635](https://github.com/user-attachments/assets/db230e66-f93d-4f3f-8a5f-7433cf891f0c)
