### PR TITLE
[Video] Flush low quality segments once focused

### DIFF
--- a/src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerWeb.tsx
+++ b/src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerWeb.tsx
@@ -51,6 +51,18 @@ export function VideoEmbedInnerWeb({
     // initial value, later on it's managed by Controls
     hls.autoLevelCapping = 0
 
+    // manually loop, so if we've flushed the first buffer it doesn't get confused
+    const abortController = new AbortController()
+    const {signal} = abortController
+    videoRef.current.addEventListener(
+      'ended',
+      function () {
+        this.currentTime = 0
+        this.play()
+      },
+      {signal},
+    )
+
     hls.on(Hls.Events.SUBTITLE_TRACKS_UPDATED, (_event, data) => {
       if (data.subtitleTracks.length > 0) {
         setHasSubtitleTrack(true)
@@ -82,6 +94,7 @@ export function VideoEmbedInnerWeb({
       hlsRef.current = undefined
       hls.detachMedia()
       hls.destroy()
+      abortController.abort()
     }
   }, [embed.playlist])
 
@@ -136,7 +149,6 @@ export function VideoEmbedInnerWeb({
             style={{width: '100%', height: '100%', objectFit: 'contain'}}
             playsInline
             preload="none"
-            loop
             muted={!focused}
             aria-labelledby={embed.alt ? figId : undefined}
           />

--- a/src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerWeb.tsx
+++ b/src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerWeb.tsx
@@ -96,10 +96,8 @@ export function VideoEmbedInnerWeb({
         _event: Events.FRAG_CHANGED,
         {frag}: FragChangedData,
       ) {
-        if (!hlsRef.current) return
-
         // if the current quality level goes above 0, flush the low quality segments
-        if (hlsRef.current.nextAutoLevel > 0) {
+        if (current.nextAutoLevel > 0) {
           const flushed: Fragment[] = []
 
           for (const lowQualFrag of lowQualityFragments) {
@@ -108,7 +106,7 @@ export function VideoEmbedInnerWeb({
               return
             }
 
-            hlsRef.current.trigger(Hls.Events.BUFFER_FLUSHING, {
+            current.trigger(Hls.Events.BUFFER_FLUSHING, {
               startOffset: lowQualFrag.start,
               endOffset: lowQualFrag.end,
               type: 'video',

--- a/src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerWeb.tsx
+++ b/src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerWeb.tsx
@@ -89,6 +89,8 @@ export function VideoEmbedInnerWeb({
   useEffect(() => {
     if (!hlsRef.current) return
 
+    const current = hlsRef.current
+
     if (focused) {
       function fragChanged(
         _event: Events.FRAG_CHANGED,
@@ -118,9 +120,8 @@ export function VideoEmbedInnerWeb({
           setLowQualityFragments(prev => prev.filter(f => !flushed.includes(f)))
         }
       }
-      hlsRef.current.on(Hls.Events.FRAG_CHANGED, fragChanged)
+      current.on(Hls.Events.FRAG_CHANGED, fragChanged)
 
-      const current = hlsRef.current
       return () => {
         current.off(Hls.Events.FRAG_CHANGED, fragChanged)
       }


### PR DESCRIPTION
Fixes #5315 

By default, once a fragment (~5 seconds of video) is loaded by HLS.js, it sticks around indefinitely. This means that the initial low-res fragments (which at minimum is the first 9 seconds of the video) stay low-res even after the video loops.

Solution:

1. Keep track of low-res fragments. We do this via the `FRAG_BUFFERED` event.
2. Once focused, we wait for the next fragment change, then:
3. If the auto-detected quality level at this time is greater than low-res, flush the low-res fragments
4. HLS.js will automatically reload the fragments on next loop, likely now in hi-res

This *shouldn't* result in unbounded loading of data - it only triggers the eviction if it has sufficient network conditions to load hi-res fragments, and once something is hi-res it should never be subsequently evicted.

This also fixes a bug which would result in the hi-res version loading regardless of whether the video was focused, so it might even reduce bandwidth use!

# Test plan

This is tricky to test. I would suggest adding logs to the flushing event trigger (VideoEmbedInnerWeb.tsx:109) and logging the `lowQualityFragments` state. Also keep an eye on the network tag, and just review the video to ensure that the first ~9 seconds are hi-res after looping

A good video to test with: https://bsky.app/profile/haileyok.com/post/3l4ioa5mudh25