### PR TITLE
Fix German localisation of social proof

### DIFF
--- a/src/locale/locales/de/messages.po
+++ b/src/locale/locales/de/messages.po
@@ -2679,7 +2679,7 @@ msgstr "Gefolgt von <0>{0}</0>"
 
 #: src/components/KnownFollowers.tsx:217
 msgid "Followed by <0>{0}</0> and {1, plural, one {# other} other {# others}}"
-msgstr "Gefolgt von <0>{0}</0> und {1, plural, one {# anderer} other {# andere}}"
+msgstr "Gefolgt von <0>{0}</0> und {1} anderen"
 
 #: src/components/KnownFollowers.tsx:204
 msgid "Followed by <0>{0}</0> and <1>{1}</1>"
@@ -2687,7 +2687,7 @@ msgstr "Gefolgt von <0>{0}</0> und <1>{1}</1>"
 
 #: src/components/KnownFollowers.tsx:186
 msgid "Followed by <0>{0}</0>, <1>{1}</1>, and {2, plural, one {# other} other {# others}}"
-msgstr "Gefolgt von <0>{0}</0>, <1>{1}</1> und {1, plural, one {# anderer} other {# andere}}"
+msgstr "Gefolgt von <0>{0}</0>, <1>{1}</1> und {2} anderen"
 
 #: src/components/dialogs/PostInteractionSettingsDialog.tsx:403
 msgid "Followed users"


### PR DESCRIPTION
The NaN and grammar were bothering me too much. Much like in English, the passive construction here implies dative case (which has indistinguishable genders and plurals of "andere(r)", conveniently enough).

That said, it's very unusual and pretty rough to use the number "1" in this position. In German, you would always use the indeterminate singular article here instead, which unfortunately is gendered between "einem" and "einer" even in dative.

The best way to fix this properly is most likely to avoid the "one other" case entirely here, i.e. you'd either list three users or (more likely in terms of screen space) write "Gefolgt von … und 2 anderen" in the three-known-followers case. I'm not sure how to implement this here.