### PR TITLE
Adjust dark mode text color to softer white

### DIFF
--- a/src/alf/themes.ts
+++ b/src/alf/themes.ts
@@ -183,7 +183,7 @@ export function createThemes({
   } as const
 
   const darkPalette: Palette = {
-    white: color.gray_0,
+    white: color.gray_25,
     black: color.trueBlack,
 
     contrast_25: color.gray_975,

--- a/src/lib/themes.ts
+++ b/src/lib/themes.ts
@@ -325,11 +325,11 @@ export const darkTheme: Theme = {
       textInverted: colors.green2,
     },
     inverted: {
-      background: lightPalette.white,
+      background: darkPalette.white,
       backgroundLight: lightPalette.contrast_50,
       text: lightPalette.black,
       textLight: lightPalette.contrast_700,
-      textInverted: lightPalette.white,
+      textInverted: darkPalette.white,
       link: lightPalette.primary_500,
       border: lightPalette.contrast_100,
       borderDark: lightPalette.contrast_200,


### PR DESCRIPTION
related to #647 and #1751
helps users with sensitive eyes
changes foreground color in dark mode to a softer white (no pure white)
no changes to foreground color in light mode (light mode already uses soft black for foreground)
background colors are not changed

| Before | After |
|--------|--------|
| ![before-dim](https://github.com/user-attachments/assets/d59a08aa-8cc3-4f9e-973e-35f6a7044cf9) | ![after-dim](https://github.com/user-attachments/assets/514ea69a-2445-41ec-87f3-9ac17390c659) |
| ![before](https://github.com/user-attachments/assets/cedb4b08-b562-48cf-8f68-206a73bec641) |![after](https://github.com/user-attachments/assets/0207f9e4-47f9-4ab1-a3ea-9a6d73c9f819) | 