### PR TITLE
Resolve source files for fonts, remove hack

### DIFF
--- a/package.json
+++ b/package.json
@@ -338,7 +338,9 @@
   },
   "lint-staged": {
     "*{.js,.jsx,.ts,.tsx}": [
-      "eslint --cache --fix",
+      "eslint --cache --fix"
+    ],
+    "*{.js,.jsx,.ts,.tsx,.css}": [
       "prettier --cache --write --ignore-unknown"
     ]
   }

--- a/src/alf/fonts.ts
+++ b/src/alf/fonts.ts
@@ -1,5 +1,3 @@
-import {useFonts as defaultUseFonts} from 'expo-font'
-
 import {isWeb} from '#/platform/detection'
 import {Device, device} from '#/storage'
 
@@ -32,39 +30,6 @@ export function getFontFamily() {
 
 export function setFontFamily(fontFamily: Device['fontFamily']) {
   device.set(['fontFamily'], fontFamily)
-}
-
-/*
- * IMPORTANT: This is unused. Expo statically extracts these fonts, but we load
- * them manually so that we can parallelize the loading along with the JS
- * bundle.
- *
- * See `#/alf/util/useFonts` for the actually used hooks.
- *
- * All used fonts MUST be configured here. Unused fonts are commented out, but
- * the files are there if we need them.
- */
-export function DO_NOT_USE() {
-  return defaultUseFonts({
-    // 'Inter-Thin': require('../../assets/fonts/inter/Inter-Thin.otf'),
-    // 'Inter-ThinItalic': require('../../assets/fonts/inter/Inter-ThinItalic.otf'),
-    // 'Inter-ExtraLight': require('../../assets/fonts/inter/Inter-ExtraLight.otf'),
-    // 'Inter-ExtraLightItalic': require('../../assets/fonts/inter/Inter-ExtraLightItalic.otf'),
-    // 'Inter-Light': require('../../assets/fonts/inter/Inter-Light.otf'),
-    // 'Inter-LightItalic': require('../../assets/fonts/inter/Inter-LightItalic.otf'),
-    'Inter-Regular': require('../../assets/fonts/inter/Inter-Regular.otf'),
-    'Inter-Italic': require('../../assets/fonts/inter/Inter-Italic.otf'),
-    // 'Inter-Medium': require('../../assets/fonts/inter/Inter-Medium.otf'),
-    // 'Inter-MediumItalic': require('../../assets/fonts/inter/Inter-MediumItalic.otf'),
-    'Inter-SemiBold': require('../../assets/fonts/inter/Inter-SemiBold.otf'),
-    'Inter-SemiBoldItalic': require('../../assets/fonts/inter/Inter-SemiBoldItalic.otf'),
-    // 'Inter-Bold': require('../../assets/fonts/inter/Inter-Bold.otf'),
-    // 'Inter-BoldItalic': require('../../assets/fonts/inter/Inter-BoldItalic.otf'),
-    'Inter-ExtraBold': require('../../assets/fonts/inter/Inter-ExtraBold.otf'),
-    'Inter-ExtraBoldItalic': require('../../assets/fonts/inter/Inter-ExtraBoldItalic.otf'),
-    // 'Inter-Black': require('../../assets/fonts/inter/Inter-Black.otf'),
-    // 'Inter-BlackItalic': require('../../assets/fonts/inter/Inter-BlackItalic.otf'),
-  })
 }
 
 /*

--- a/src/style.css
+++ b/src/style.css
@@ -1,7 +1,7 @@
 @font-face {
   font-family: 'Inter-Regular';
   src: local('Inter-Regular'),
-    url(/static/media/Inter-Regular.1f5ed03b6dd9fd1f9982.otf) format('font/otf');
+    url(/assets/fonts/inter/Inter-Regular.otf) format('font/otf');
   font-weight: 400;
   font-style: normal;
   font-display: swap;
@@ -9,7 +9,7 @@
 @font-face {
   font-family: 'Inter-Italic';
   src: local('Inter-Italic'),
-    url(/static/media/Inter-Italic.95778eb0c75dc956257e.otf) format('font/otf');
+    url(/assets/fonts/inter/Inter-Italic.otf) format('font/otf');
   font-weight: 400;
   font-style: italic;
   font-display: swap;
@@ -17,14 +17,14 @@
 /*
 @font-face {
   font-family: "Inter-Medium";
-  src: local("Inter-Medium"), url(/static/media/Inter-Medium.296aa2d65964269836b3.otf) format("font/otf");
+  src: local("Inter-Medium"), url(/assets/fonts/inter/Inter-Medium.otf) format("font/otf");
   font-weight: 500;
   font-style: normal;
   font-display: swap;
 }
 @font-face {
   font-family: "Inter-MediumItalic";
-  src: local("Inter-MediumItalic"), url(/static/media/Inter-MediumItalic.0e57e17a6311368e2114.otf) format("font/otf");
+  src: local("Inter-MediumItalic"), url(/assets/fonts/inter/Inter-MediumItalic.otf) format("font/otf");
   font-weight: 500;
   font-style: italic;
   font-display: swap;
@@ -33,7 +33,7 @@
 @font-face {
   font-family: 'Inter-SemiBold';
   src: local('Inter-SemiBold'),
-    url(/static/media/Inter-SemiBold.2277990330981b8409bb.otf)
+    url(/assets/fonts/inter/Inter-SemiBold.otf)
       format('font/otf');
   font-weight: 600;
   font-style: normal;
@@ -42,7 +42,7 @@
 @font-face {
   font-family: 'Inter-SemiBoldItalic';
   src: local('Inter-SemiBoldItalic'),
-    url(/static/media/Inter-SemiBoldItalic.f62fea3df3a521d6c8a7.otf)
+    url(/assets/fonts/inter/Inter-SemiBoldItalic.otf)
       format('font/otf');
   font-weight: 600;
   font-style: italic;
@@ -51,14 +51,14 @@
 /*
 @font-face {
   font-family: "Inter-Bold";
-  src: local("Inter-Bold"), url(/static/media/Inter-Bold.8d330503e1d034ad68de.otf) format("font/otf");
+  src: local("Inter-Bold"), url(/assets/fonts/inter/Inter-Bold.otf) format("font/otf");
   font-weight: 700;
   font-style: normal;
   font-display: swap;
 }
 @font-face {
   font-family: "Inter-BoldItalic";
-  src: local("Inter-BoldItalic"), url(/static/media/Inter-BoldItalic.bb17e63f9baa0d861a20.otf) format("font/otf");
+  src: local("Inter-BoldItalic"), url(/assets/fonts/inter/Inter-BoldItalic.otf) format("font/otf");
   font-weight: 700;
   font-style: italic;
   font-display: swap;
@@ -67,7 +67,7 @@
 @font-face {
   font-family: 'Inter-ExtraBold';
   src: local('Inter-ExtraBold'),
-    url(/static/media/Inter-ExtraBold.ff2581a193bf6b7e0b06.otf)
+    url(/assets/fonts/inter/Inter-ExtraBold.otf)
       format('font/otf');
   font-weight: 800;
   font-style: normal;
@@ -76,7 +76,7 @@
 @font-face {
   font-family: 'Inter-ExtraBoldItalic';
   src: local('Inter-ExtraBoldItalic'),
-    url(/static/media/Inter-ExtraBoldItalic.0e50b40728d24d40fdf4.otf)
+    url(/assets/fonts/inter/Inter-ExtraBoldItalic.otf)
       format('font/otf');
   font-weight: 800;
   font-style: italic;
@@ -85,14 +85,14 @@
 /*
 @font-face {
   font-family: "Inter-Black";
-  src: local("Inter-Black"), url(/static/media/Inter-Black.66e9a87f1c921e844ed4.otf) format("font/otf");
+  src: local("Inter-Black"), url(/assets/fonts/inter/Inter-Black.otf) format("font/otf");
   font-weight: 900;
   font-style: normal;
   font-display: swap;
 }
 @font-face {
   font-family: "Inter-BlackItalic";
-  src: local("Inter-BlackItalic"), url(/static/media/Inter-BlackItalic.27b9f0ad06fd13a7b9da.otf) format("font/otf");
+  src: local("Inter-BlackItalic"), url(/assets/fonts/inter/Inter-BlackItalic.otf) format("font/otf");
   font-weight: 900;
   font-style: italic;
   font-display: swap;

--- a/src/style.css
+++ b/src/style.css
@@ -33,8 +33,7 @@
 @font-face {
   font-family: 'Inter-SemiBold';
   src: local('Inter-SemiBold'),
-    url(/assets/fonts/inter/Inter-SemiBold.otf)
-      format('font/otf');
+    url(/assets/fonts/inter/Inter-SemiBold.otf) format('font/otf');
   font-weight: 600;
   font-style: normal;
   font-display: swap;
@@ -42,8 +41,7 @@
 @font-face {
   font-family: 'Inter-SemiBoldItalic';
   src: local('Inter-SemiBoldItalic'),
-    url(/assets/fonts/inter/Inter-SemiBoldItalic.otf)
-      format('font/otf');
+    url(/assets/fonts/inter/Inter-SemiBoldItalic.otf) format('font/otf');
   font-weight: 600;
   font-style: italic;
   font-display: swap;
@@ -67,8 +65,7 @@
 @font-face {
   font-family: 'Inter-ExtraBold';
   src: local('Inter-ExtraBold'),
-    url(/assets/fonts/inter/Inter-ExtraBold.otf)
-      format('font/otf');
+    url(/assets/fonts/inter/Inter-ExtraBold.otf) format('font/otf');
   font-weight: 800;
   font-style: normal;
   font-display: swap;
@@ -76,8 +73,7 @@
 @font-face {
   font-family: 'Inter-ExtraBoldItalic';
   src: local('Inter-ExtraBoldItalic'),
-    url(/assets/fonts/inter/Inter-ExtraBoldItalic.otf)
-      format('font/otf');
+    url(/assets/fonts/inter/Inter-ExtraBoldItalic.otf) format('font/otf');
   font-weight: 800;
   font-style: italic;
   font-display: swap;


### PR DESCRIPTION
Handy dandy. Plus, Webpack outputs the built files now, no need for the `expo-font` hack.