### PR TITLE
Don't use flex on `TextField.Root`

### DIFF
--- a/src/components/dialogs/Embed.tsx
+++ b/src/components/dialogs/Embed.tsx
@@ -106,16 +106,18 @@ function EmbedDialogInner({
       </View>
 
       <View style={[a.flex_row, a.gap_sm]}>
-        <TextField.Root>
-          <TextField.Icon icon={CodeBrackets} />
-          <TextField.Input
-            label={_(msg`Embed HTML code`)}
-            editable={false}
-            selection={{start: 0, end: snippet.length}}
-            value={snippet}
-            style={{}}
-          />
-        </TextField.Root>
+        <View style={[a.flex_1]}>
+          <TextField.Root>
+            <TextField.Icon icon={CodeBrackets} />
+            <TextField.Input
+              label={_(msg`Embed HTML code`)}
+              editable={false}
+              selection={{start: 0, end: snippet.length}}
+              value={snippet}
+              style={{}}
+            />
+          </TextField.Root>
+        </View>
         <Button
           label={_(msg`Copy code`)}
           color="primary"

--- a/src/components/forms/TextField.tsx
+++ b/src/components/forms/TextField.tsx
@@ -9,8 +9,8 @@ import {
   ViewStyle,
 } from 'react-native'
 
+import {HITSLOP_20} from '#/lib/constants'
 import {mergeRefs} from '#/lib/merge-refs'
-import {HITSLOP_20} from 'lib/constants'
 import {android, atoms as a, useTheme, web} from '#/alf'
 import {useInteractionState} from '#/components/hooks/useInteractionState'
 import {Props as SVGIconProps} from '#/components/icons/common'
@@ -73,7 +73,7 @@ export function Root({children, isInvalid = false}: RootProps) {
   return (
     <Context.Provider value={context}>
       <View
-        style={[a.flex_row, a.align_center, a.relative, a.flex_1, a.px_md]}
+        style={[a.flex_row, a.align_center, a.relative, a.w_full, a.px_md]}
         {...web({
           onClick: () => inputRef.current?.focus(),
           onMouseOver: onHoverIn,

--- a/src/view/screens/Storybook/Forms.tsx
+++ b/src/view/screens/Storybook/Forms.tsx
@@ -32,6 +32,27 @@ export function Forms() {
           label="Text field"
         />
 
+        <View style={[a.flex_row, a.gap_sm]}>
+          <View
+            style={[
+              {
+                width: '50%',
+              },
+            ]}>
+            <TextField.Root>
+              <TextField.Icon icon={Globe} />
+              <TextField.Input
+                value={value}
+                onChangeText={setValue}
+                label="Text field"
+              />
+            </TextField.Root>
+          </View>
+          <Button label="Submit" size="large" variant="solid" color="primary">
+            <ButtonText>Submit</ButtonText>
+          </Button>
+        </View>
+
         <TextField.Root>
           <TextField.Icon icon={Globe} />
           <TextField.Input

--- a/src/view/screens/Storybook/index.tsx
+++ b/src/view/screens/Storybook/index.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import {ScrollView, View} from 'react-native'
 
+import {isWeb} from '#/platform/detection'
 import {useSetThemePrefs} from '#/state/shell'
-import {isWeb} from 'platform/detection'
 import {CenteredView} from '#/view/com/util/Views'
-import {ListContained} from 'view/screens/Storybook/ListContained'
+import {ListContained} from '#/view/screens/Storybook/ListContained'
 import {atoms as a, ThemeProvider, useTheme} from '#/alf'
 import {Button, ButtonText} from '#/components/Button'
 import {Breakpoints} from './Breakpoints'
@@ -80,9 +80,8 @@ function StorybookInner() {
               </Button>
             </View>
 
-            <Buttons />
+            <Forms />
 
-            <Dialogs />
             <ThemeProvider theme="light">
               <Theming />
             </ThemeProvider>
@@ -93,16 +92,17 @@ function StorybookInner() {
               <Theming />
             </ThemeProvider>
 
+            <Buttons />
             <Typography />
             <Spacing />
             <Shadows />
             <Buttons />
             <Icons />
             <Links />
-            <Forms />
             <Dialogs />
             <Menus />
             <Breakpoints />
+            <Dialogs />
 
             <Button
               variant="solid"


### PR DESCRIPTION
Was having some trouble with `TextField` collapsing in flex contexts. Really, we should use flexbox for the layout, not the sizing of the low-level component itself.

Should be no visible change, fixed one sizing issue in the web Embed dialog. Here are all the current usages:

![CleanShot 2024-09-23 at 16 26 17@2x](https://github.com/user-attachments/assets/8118dd2b-454f-44f3-a1bb-c5832d3be44b)
![CleanShot 2024-09-23 at 16 26 27@2x](https://github.com/user-attachments/assets/db142c52-74ab-4324-b445-e98530533ded)
![CleanShot 2024-09-23 at 16 27 08@2x](https://github.com/user-attachments/assets/e0541ab4-1be1-4846-a1f2-c75827b6f23f)
![CleanShot 2024-09-23 at 16 28 13@2x](https://github.com/user-attachments/assets/2cc3198c-5794-431d-abb5-a07b8fcd2f23)
![CleanShot 2024-09-23 at 16 28 41@2x](https://github.com/user-attachments/assets/3bfe2921-487d-44a0-9adf-a6ead29de5ea)
![CleanShot 2024-09-23 at 16 29 00@2x](https://github.com/user-attachments/assets/06b377d0-f672-4ec5-b089-45bee34d4590)
![CleanShot 2024-09-23 at 16 29 18@2x](https://github.com/user-attachments/assets/e01271ca-29d4-479f-9eca-fc44e33397e1)
![CleanShot 2024-09-23 at 16 29 26@2x](https://github.com/user-attachments/assets/2b36578a-e2f7-4941-a5dc-275e377b39b8)
![CleanShot 2024-09-23 at 16 29 33@2x](https://github.com/user-attachments/assets/81585081-4956-43d8-bbd6-18fdde03b166)
![CleanShot 2024-09-23 at 16 30 08@2x](https://github.com/user-attachments/assets/82c6d2d7-e1c6-4224-9518-dcc0d0b6351e)
