### PR TITLE
Remove `react-native-fs`

### DIFF
--- a/package.json
+++ b/package.json
@@ -177,7 +177,6 @@
     "react-native-compressor": "^1.8.24",
     "react-native-date-picker": "^4.4.2",
     "react-native-drawer-layout": "^4.0.0-alpha.3",
-    "react-native-fs": "^2.20.0",
     "react-native-gesture-handler": "~2.16.2",
     "react-native-get-random-values": "~1.11.0",
     "react-native-image-crop-picker": "0.41.2",

--- a/src/lib/api/upload-blob.ts
+++ b/src/lib/api/upload-blob.ts
@@ -1,4 +1,4 @@
-import RNFS from 'react-native-fs'
+import {copyAsync, deleteAsync} from 'expo-file-system'
 import {BskyAgent, ComAtprotoRepoUploadBlob} from '@atproto/api'
 
 /**
@@ -65,7 +65,7 @@ async function withSafeFile<T>(
     // temporary file).
     const newPath = uri.replace(/\.jpe?g$/, '.bin')
     try {
-      await RNFS.copyFile(uri, newPath)
+      await copyAsync({from: uri, to: newPath})
     } catch {
       // Failed to copy the file, just use the original
       return await fn(uri)
@@ -74,7 +74,7 @@ async function withSafeFile<T>(
       return await fn(newPath)
     } finally {
       // Remove the temporary file
-      await RNFS.unlink(newPath)
+      await deleteAsync(newPath)
     }
   } else {
     return fn(uri)

--- a/src/lib/api/upload-blob.ts
+++ b/src/lib/api/upload-blob.ts
@@ -1,5 +1,7 @@
-import {copyAsync, deleteAsync} from 'expo-file-system'
+import {copyAsync} from 'expo-file-system'
 import {BskyAgent, ComAtprotoRepoUploadBlob} from '@atproto/api'
+
+import {safeDeleteAsync} from '#/lib/media/manip'
 
 /**
  * @param encoding Allows overriding the blob's type
@@ -74,7 +76,7 @@ async function withSafeFile<T>(
       return await fn(newPath)
     } finally {
       // Remove the temporary file
-      await deleteAsync(newPath)
+      await safeDeleteAsync(newPath)
     }
   } else {
     return fn(uri)

--- a/src/lib/media/picker.e2e.tsx
+++ b/src/lib/media/picker.e2e.tsx
@@ -12,15 +12,18 @@ import {compressIfNeeded} from './manip'
 import {CropperOptions} from './types'
 
 async function getFile() {
-  let files = await readDirectoryAsync(
-    documentDirectory!
-      .split('/')
-      .slice(0, -5)
-      .concat(['Media', 'DCIM', '100APPLE'])
-      .join('/'),
-  )
+  const imagesDir = documentDirectory!
+    .split('/')
+    .slice(0, -6)
+    .concat(['Media', 'DCIM', '100APPLE'])
+    .join('/')
+
+  let files = await readDirectoryAsync(imagesDir)
   files = files.filter(file => file.endsWith('.JPG'))
-  const file = files[0]
+  const file = `${imagesDir}/${files[0]}`
+
+  console.log(file)
+
   const fileInfo = await getInfoAsync(file)
 
   if (!fileInfo.exists) {

--- a/src/lib/media/picker.e2e.tsx
+++ b/src/lib/media/picker.e2e.tsx
@@ -22,8 +22,6 @@ async function getFile() {
   files = files.filter(file => file.endsWith('.JPG'))
   const file = `${imagesDir}/${files[0]}`
 
-  console.log(file)
-
   const fileInfo = await getInfoAsync(file)
 
   if (!fileInfo.exists) {

--- a/src/lib/media/picker.e2e.tsx
+++ b/src/lib/media/picker.e2e.tsx
@@ -1,25 +1,36 @@
-import RNFS from 'react-native-fs'
 import {
   Image as RNImage,
   openCropper as openCropperFn,
 } from 'react-native-image-crop-picker'
+import {
+  documentDirectory,
+  getInfoAsync,
+  readDirectoryAsync,
+} from 'expo-file-system'
 
 import {compressIfNeeded} from './manip'
 import {CropperOptions} from './types'
 
 async function getFile() {
-  let files = await RNFS.readDir(
-    RNFS.LibraryDirectoryPath.split('/')
+  let files = await readDirectoryAsync(
+    documentDirectory!
+      .split('/')
       .slice(0, -5)
       .concat(['Media', 'DCIM', '100APPLE'])
       .join('/'),
   )
-  files = files.filter(file => file.path.endsWith('.JPG'))
+  files = files.filter(file => file.endsWith('.JPG'))
   const file = files[0]
+  const fileInfo = await getInfoAsync(file)
+
+  if (!fileInfo.exists) {
+    throw new Error('Failed to get file info')
+  }
+
   return await compressIfNeeded({
-    path: file.path,
+    path: file,
     mime: 'image/jpeg',
-    size: file.size,
+    size: fileInfo.size,
     width: 4288,
     height: 2848,
   })

--- a/yarn.lock
+++ b/yarn.lock
@@ -9547,7 +9547,7 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
-base-64@0.1.0, base-64@^0.1.0:
+base-64@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/base-64/-/base-64-0.1.0.tgz#780a99c84e7d600260361511c4877613bf24f6bb"
   integrity sha512-Y5gU45svrR5tI2Vt/X9GPd3L0HNIKzGu202EjxrXMpuc2V2CiKgemAbUUsqYmZJvPtCXoUKjNZwBJzsNScUbXA==
@@ -19031,14 +19031,6 @@ react-native-drawer-layout@^4.0.0-alpha.3:
   dependencies:
     use-latest-callback "^0.1.9"
 
-react-native-fs@^2.20.0:
-  version "2.20.0"
-  resolved "https://registry.yarnpkg.com/react-native-fs/-/react-native-fs-2.20.0.tgz#05a9362b473bfc0910772c0acbb73a78dbc810f6"
-  integrity sha512-VkTBzs7fIDUiy/XajOSNk0XazFE9l+QlMAce7lGuebZcag5CnjszB+u4BdqzwaQOdcYb5wsJIsqq4kxInIRpJQ==
-  dependencies:
-    base-64 "^0.1.0"
-    utf8 "^3.0.0"
-
 react-native-gesture-handler@~2.16.2:
   version "2.16.2"
   resolved "https://registry.yarnpkg.com/react-native-gesture-handler/-/react-native-gesture-handler-2.16.2.tgz#032bd2a07334292d7f6cff1dc9d1ec928f72e26d"
@@ -21793,11 +21785,6 @@ use-sidecar@^1.1.2:
   dependencies:
     detect-node-es "^1.1.0"
     tslib "^2.0.0"
-
-utf8@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/utf8/-/utf8-3.0.0.tgz#f052eed1364d696e769ef058b183df88c87f69d1"
-  integrity sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ==
 
 util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"


### PR DESCRIPTION
## Why

This has been lingering for a bit for almost no reason. We've pretty much completely moved to using `expo-file-system`, but there was a couple small usages left over.

## Test Plan

- Upload an image from both iOS and Android
- Verify the e2e `getFile()` still works (see video). It only needs to work on iOS


https://github.com/user-attachments/assets/ab7a4d93-ed59-4743-a0be-274c9616cde1

