### PR TITLE
Revert change in FAB animation

### DIFF
--- a/src/lib/haptics.ts
+++ b/src/lib/haptics.ts
@@ -4,21 +4,17 @@ import {impactAsync, ImpactFeedbackStyle} from 'expo-haptics'
 import {isIOS, isWeb} from 'platform/detection'
 import {useHapticsDisabled} from 'state/preferences/disable-haptics'
 
+const hapticImpact: ImpactFeedbackStyle = isIOS
+  ? ImpactFeedbackStyle.Medium
+  : ImpactFeedbackStyle.Light // Users said the medium impact was too strong on Android; see APP-537s
+
 export function useHaptics() {
   const isHapticsDisabled = useHapticsDisabled()
 
-  return React.useCallback(
-    (strength: 'Light' | 'Medium' | 'Heavy' = 'Medium') => {
-      if (isHapticsDisabled || isWeb) {
-        return
-      }
-
-      // Users said the medium impact was too strong on Android; see APP-537s
-      const style = isIOS
-        ? ImpactFeedbackStyle[strength]
-        : ImpactFeedbackStyle.Light
-      impactAsync(style)
-    },
-    [isHapticsDisabled],
-  )
+  return React.useCallback(() => {
+    if (isHapticsDisabled || isWeb) {
+      return
+    }
+    impactAsync(hapticImpact)
+  }, [isHapticsDisabled])
 }

--- a/src/lib/haptics.ts
+++ b/src/lib/haptics.ts
@@ -1,20 +1,24 @@
 import React from 'react'
 import {impactAsync, ImpactFeedbackStyle} from 'expo-haptics'
 
-import {isIOS, isWeb} from 'platform/detection'
-import {useHapticsDisabled} from 'state/preferences/disable-haptics'
-
-const hapticImpact: ImpactFeedbackStyle = isIOS
-  ? ImpactFeedbackStyle.Medium
-  : ImpactFeedbackStyle.Light // Users said the medium impact was too strong on Android; see APP-537s
+import {isIOS, isWeb} from '#/platform/detection'
+import {useHapticsDisabled} from '#/state/preferences/disable-haptics'
 
 export function useHaptics() {
   const isHapticsDisabled = useHapticsDisabled()
 
-  return React.useCallback(() => {
-    if (isHapticsDisabled || isWeb) {
-      return
-    }
-    impactAsync(hapticImpact)
-  }, [isHapticsDisabled])
+  return React.useCallback(
+    (strength: 'Light' | 'Medium' | 'Heavy' = 'Medium') => {
+      if (isHapticsDisabled || isWeb) {
+        return
+      }
+
+      // Users said the medium impact was too strong on Android; see APP-537s
+      const style = isIOS
+        ? ImpactFeedbackStyle[strength]
+        : ImpactFeedbackStyle.Light
+      impactAsync(style)
+    },
+    [isHapticsDisabled],
+  )
 }

--- a/src/view/com/util/fab/FABInner.tsx
+++ b/src/view/com/util/fab/FABInner.tsx
@@ -1,10 +1,6 @@
 import React, {ComponentProps} from 'react'
 import {StyleSheet, TouchableWithoutFeedback} from 'react-native'
-import Animated, {
-  Easing,
-  useAnimatedStyle,
-  withTiming,
-} from 'react-native-reanimated'
+import Animated, {useAnimatedStyle, withTiming} from 'react-native-reanimated'
 import {useSafeAreaInsets} from 'react-native-safe-area-context'
 import {LinearGradient} from 'expo-linear-gradient'
 
@@ -13,8 +9,6 @@ import {useWebMediaQueries} from '#/lib/hooks/useWebMediaQueries'
 import {clamp} from '#/lib/numbers'
 import {gradients} from '#/lib/styles'
 import {isWeb} from '#/platform/detection'
-import {useHaptics} from 'lib/haptics'
-import {useHapticsDisabled} from 'state/preferences'
 import {useInteractionState} from '#/components/hooks/useInteractionState'
 
 export interface FABProps
@@ -23,17 +17,15 @@ export interface FABProps
   icon: JSX.Element
 }
 
-export function FABInner({testID, icon, onPress, ...props}: FABProps) {
+export function FABInner({testID, icon, ...props}: FABProps) {
   const insets = useSafeAreaInsets()
   const {isMobile, isTablet} = useWebMediaQueries()
   const fabMinimalShellTransform = useMinimalShellFabTransform()
   const {
-    state: isPressed,
+    state: pressed,
     onIn: onPressIn,
     onOut: onPressOut,
   } = useInteractionState()
-  const playHaptic = useHaptics()
-  const isHapticsDisabled = useHapticsDisabled()
 
   const size = isTablet ? styles.sizeLarge : styles.sizeRegular
 
@@ -41,29 +33,13 @@ export function FABInner({testID, icon, onPress, ...props}: FABProps) {
     ? {right: 50, bottom: 50}
     : {right: 24, bottom: clamp(insets.bottom, 15, 60) + 15}
 
-  const animatedStyle = useAnimatedStyle(() => ({
-    transform: [
-      {
-        scale: withTiming(isPressed ? 1.1 : 1, {
-          duration: 250,
-          easing: Easing.out(Easing.quad),
-        }),
-      },
-    ],
+  const scale = useAnimatedStyle(() => ({
+    transform: [{scale: withTiming(pressed ? 0.95 : 1)}],
   }))
 
   return (
     <TouchableWithoutFeedback
       testID={testID}
-      onPress={e => {
-        playHaptic()
-        setTimeout(
-          () => {
-            onPress?.(e)
-          },
-          isHapticsDisabled ? 0 : 75,
-        )
-      }}
       onPressIn={onPressIn}
       onPressOut={onPressOut}
       {...props}>
@@ -74,7 +50,7 @@ export function FABInner({testID, icon, onPress, ...props}: FABProps) {
           tabletSpacing,
           isMobile && fabMinimalShellTransform,
         ]}>
-        <Animated.View style={animatedStyle}>
+        <Animated.View style={scale}>
           <LinearGradient
             colors={[gradients.blueLight.start, gradients.blueLight.end]}
             start={{x: 0, y: 0}}

--- a/src/view/com/util/fab/FABInner.tsx
+++ b/src/view/com/util/fab/FABInner.tsx
@@ -4,11 +4,13 @@ import Animated, {useAnimatedStyle, withTiming} from 'react-native-reanimated'
 import {useSafeAreaInsets} from 'react-native-safe-area-context'
 import {LinearGradient} from 'expo-linear-gradient'
 
+import {useHaptics} from '#/lib/haptics'
 import {useMinimalShellFabTransform} from '#/lib/hooks/useMinimalShellTransform'
 import {useWebMediaQueries} from '#/lib/hooks/useWebMediaQueries'
 import {clamp} from '#/lib/numbers'
 import {gradients} from '#/lib/styles'
 import {isWeb} from '#/platform/detection'
+import {useHapticsDisabled} from '#/state/preferences'
 import {useInteractionState} from '#/components/hooks/useInteractionState'
 
 export interface FABProps
@@ -17,9 +19,11 @@ export interface FABProps
   icon: JSX.Element
 }
 
-export function FABInner({testID, icon, ...props}: FABProps) {
+export function FABInner({testID, icon, onPress, ...props}: FABProps) {
   const insets = useSafeAreaInsets()
   const {isMobile, isTablet} = useWebMediaQueries()
+  const playHaptic = useHaptics()
+  const isHapticsDisabled = useHapticsDisabled()
   const fabMinimalShellTransform = useMinimalShellFabTransform()
   const {
     state: pressed,
@@ -42,6 +46,15 @@ export function FABInner({testID, icon, ...props}: FABProps) {
       testID={testID}
       onPressIn={onPressIn}
       onPressOut={onPressOut}
+      onPress={e => {
+        playHaptic('Light')
+        setTimeout(
+          () => {
+            onPress?.(e)
+          },
+          isHapticsDisabled ? 0 : 75,
+        )
+      }}
       {...props}>
       <Animated.View
         style={[


### PR DESCRIPTION
## Why

The "growing outward" animation didn't feel as good as hoped for on device. Let's revert to what we had before.

Also, I'm tweaking the haptic to be a `Light` variant rather than the default `Medium`, since it does feel good but maybe a bit too strong.

## Test Plan

Animation should now be returned to what it was before, and he haptic should be a bit weaker.
