### PR TITLE
[React Native] Patch `RCTFileReaderModule` `readAsDataURL` to prevent crash when `type` is `nil`

### DIFF
--- a/patches/react-native+0.74.1.patch
+++ b/patches/react-native+0.74.1.patch
@@ -1,5 +1,18 @@
+diff --git a/node_modules/react-native/Libraries/Blob/RCTFileReaderModule.mm b/node_modules/react-native/Libraries/Blob/RCTFileReaderModule.mm
+index caa5540..6027825 100644
+--- a/node_modules/react-native/Libraries/Blob/RCTFileReaderModule.mm
++++ b/node_modules/react-native/Libraries/Blob/RCTFileReaderModule.mm
+@@ -71,7 +71,7 @@ @implementation RCTFileReaderModule
+           [NSString stringWithFormat:@"Unable to resolve data for blob: %@", [RCTConvert NSString:blob[@"blobId"]]],
+           nil);
+     } else {
+-      NSString *type = [RCTConvert NSString:blob[@"type"]];
++      NSString *type = RCTNilIfNull([RCTConvert NSString:blob[@"type"]]);
+       NSString *text = [NSString stringWithFormat:@"data:%@;base64,%@",
+                                                   type != nil && [type length] > 0 ? type : @"application/octet-stream",
+                                                   [data base64EncodedStringWithOptions:0]];
 diff --git a/node_modules/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.mm b/node_modules/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.mm
-index b0d71dc..9974932 100644
+index b0d71dc..41b9a0e 100644
 --- a/node_modules/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.mm
 +++ b/node_modules/react-native/Libraries/Text/TextInput/RCTBaseTextInputView.mm
 @@ -377,10 +377,6 @@ - (void)textInputDidBeginEditing
@@ -36,7 +49,7 @@ index e9b330f..1ecdf0a 100644
 +
  @end
 diff --git a/node_modules/react-native/React/Views/RefreshControl/RCTRefreshControl.m b/node_modules/react-native/React/Views/RefreshControl/RCTRefreshControl.m
-index b09e653..4c32b31 100644
+index b09e653..f93cb46 100644
 --- a/node_modules/react-native/React/Views/RefreshControl/RCTRefreshControl.m
 +++ b/node_modules/react-native/React/Views/RefreshControl/RCTRefreshControl.m
 @@ -198,9 +198,53 @@ - (void)refreshControlValueChanged


### PR DESCRIPTION
Fixes https://github.com/bluesky-social/social-app/issues/5100

## Why

The null check for `type` doesn't actually do anything here, because `type` will never be `nil`, but rather it will be either `NSString` or `NSNull`. We need to actually convert `NSNull` to `nil` first before the check.

### Breakdown

React Native handles the response for a request in this block of code: https://github.com/facebook/react-native/blob/303e0ed7641409acf2d852c077f6be426afd7a0c/packages/react-native/Libraries/Blob/RCTBlobManager.mm#L314-L326

Here, we see that values of `nil` - which `[response MIMEType]` will return when no `content-type` is provided in the response and the actual type cannot be determined (https://developer.apple.com/documentation/foundation/nsurlresponse/1411613-mimetype) - gets converted to `NSNull` by `RCTNullIfNil`. This is fine, since we cannot have `nil` in a dictionary so we have to do the conversion.

When we get back over to `readAsDataURL`, we see that we grab the type from the dictionary and check if its `nil` before calling `length` on the string. https://github.com/facebook/react-native/blob/303e0ed7641409acf2d852c077f6be426afd7a0c/packages/react-native/Libraries/Blob/RCTFileReaderModule.mm#L74-L77

However, this check is dubious, because the value will never actually be `nil`. It will always either be `NSString` or `NSNull` because of the `RCTNullIfNil` call made above. The `[RCTConvert NSString]` made when getting the type from the dictionary will simply return `NSNull` here, because `NSNull` is an objc class, which will merely be returned as such by the call (https://github.com/facebook/react-native/blob/303e0ed7641409acf2d852c077f6be426afd7a0c/packages/react-native/React/Base/RCTConvert.mm#L38-L60)

The trick here is to first use `RCTNilIfNull` to convert to `nil` if needed, then continue making the `!= nil` check.

## Test Plan

Nothing should break. The only way I can repro the crash right now is to add `nosniff` to the response headers in `x-content-type-options` for something like `registerPush` or `updateSeen`. Verified that this does fix the problem though.