### PR TITLE
Show a toast when a haptic is meant to fire while using simulator

### DIFF
--- a/src/lib/haptics.ts
+++ b/src/lib/haptics.ts
@@ -1,8 +1,10 @@
 import React from 'react'
+import * as Device from 'expo-device'
 import {impactAsync, ImpactFeedbackStyle} from 'expo-haptics'
 
 import {isIOS, isWeb} from '#/platform/detection'
 import {useHapticsDisabled} from '#/state/preferences/disable-haptics'
+import * as Toast from '#/view/com/util/Toast'
 
 export function useHaptics() {
   const isHapticsDisabled = useHapticsDisabled()
@@ -18,6 +20,11 @@ export function useHaptics() {
         ? ImpactFeedbackStyle[strength]
         : ImpactFeedbackStyle.Light
       impactAsync(style)
+
+      // DEV ONLY - show a toast when a haptic is meant to fire on simulator
+      if (__DEV__ && !Device.isDevice) {
+        Toast.show(`Buzzz!`)
+      }
     },
     [isHapticsDisabled],
   )


### PR DESCRIPTION
Dev only. Should help test haptics while developing