### PR TITLE
Clean up left nav on web

### DIFF
--- a/src/alf/tokens.ts
+++ b/src/alf/tokens.ts
@@ -60,6 +60,14 @@ export const fontWeight = {
 } as const
 
 export const gradients = {
+  primary: {
+    values: [
+      [0, '#0A6CFF'],
+      [0.6, '#1085FE'],
+      [1, '#59B9FF'],
+    ],
+    hover_value: '#1085FE',
+  },
   sky: {
     values: [
       [0, '#0A7AFF'],

--- a/src/alf/tokens.ts
+++ b/src/alf/tokens.ts
@@ -62,7 +62,7 @@ export const fontWeight = {
 export const gradients = {
   primary: {
     values: [
-      [0, '#0A6CFF'],
+      [0, '#0561FF'],
       [0.6, '#1085FE'],
       [1, '#59B9FF'],
     ],

--- a/src/alf/tokens.ts
+++ b/src/alf/tokens.ts
@@ -62,7 +62,8 @@ export const fontWeight = {
 export const gradients = {
   primary: {
     values: [
-      [0, '#0561FF'],
+      [0, '#054CFF'],
+      [0.4, '#1085FE'],
       [0.6, '#1085FE'],
       [1, '#59B9FF'],
     ],

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -444,7 +444,7 @@ export const Button = React.forwardRef<View, ButtonProps>(
       [state, variant, color, size, disabled],
     )
 
-    const flattenedBaseStyles = flatten(baseStyles)
+    const flattenedBaseStyles = flatten([baseStyles, style])
 
     return (
       <Pressable
@@ -464,7 +464,6 @@ export const Button = React.forwardRef<View, ButtonProps>(
           a.align_center,
           a.justify_center,
           flattenedBaseStyles,
-          flatten(style),
           ...(state.hovered || state.pressed
             ? [hoverStyles, flatten(hoverStyleProp)]
             : []),

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -24,6 +24,7 @@ export type ButtonColor =
   | 'secondary'
   | 'secondary_inverted'
   | 'negative'
+  | 'gradient_primary'
   | 'gradient_sky'
   | 'gradient_midnight'
   | 'gradient_sunrise'
@@ -412,6 +413,7 @@ export const Button = React.forwardRef<View, ButtonProps>(
           secondary: tokens.gradients.sky,
           secondary_inverted: tokens.gradients.sky,
           negative: tokens.gradients.sky,
+          gradient_primary: tokens.gradients.primary,
           gradient_sky: tokens.gradients.sky,
           gradient_midnight: tokens.gradients.midnight,
           gradient_sunrise: tokens.gradients.sunrise,

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -626,9 +626,9 @@ export function useSharedButtonTextStyles() {
     }
 
     if (size === 'large') {
-      baseStyles.push(a.text_md, a.leading_tight, web({paddingTop: 1}))
+      baseStyles.push(a.text_md, a.leading_tight, web({top: -0.4}))
     } else if (size === 'small') {
-      baseStyles.push(a.text_sm, a.leading_tight, web({paddingTop: 1}))
+      baseStyles.push(a.text_sm, a.leading_tight, web({top: -0.4}))
     } else if (size === 'tiny') {
       baseStyles.push(a.text_xs, a.leading_tight)
     }

--- a/src/view/shell/desktop/LeftNav.tsx
+++ b/src/view/shell/desktop/LeftNav.tsx
@@ -199,6 +199,7 @@ function NavItem({count, href, icon, iconFilled, label}: NavItemProps) {
         style={[
           a.align_center,
           a.justify_center,
+          a.z_10,
           {
             width: 24,
             height: 24,

--- a/src/view/shell/desktop/LeftNav.tsx
+++ b/src/view/shell/desktop/LeftNav.tsx
@@ -18,7 +18,6 @@ import {getCurrentRoute, isStateAtTabRoot, isTab} from '#/lib/routes/helpers'
 import {makeProfileLink} from '#/lib/routes/links'
 import {CommonNavigatorParams, NavigationProp} from '#/lib/routes/types'
 import {isInvalidHandle} from '#/lib/strings/handles'
-import {colors} from '#/lib/styles'
 import {emitSoftReset} from '#/state/events'
 import {useFetchHandle} from '#/state/queries/handle'
 import {useUnreadMessageCount} from '#/state/queries/messages/list-converations'
@@ -32,6 +31,7 @@ import {PressableWithHover} from '#/view/com/util/PressableWithHover'
 import {UserAvatar} from '#/view/com/util/UserAvatar'
 import {NavSignupCard} from '#/view/shell/NavSignupCard'
 import {atoms as a, useBreakpoints, useTheme} from '#/alf'
+import {Button, ButtonIcon, ButtonText} from '#/components/Button'
 import {
   Bell_Filled_Corner0_Rounded as BellFilled,
   Bell_Stroke2_Corner0_Rounded as Bell,
@@ -294,21 +294,19 @@ function ComposeBtn() {
     return null
   }
   return (
-    <View style={styles.newPostBtnContainer}>
-      <TouchableOpacity
+    <View style={[a.flex_row, a.pl_md, a.pt_xl]}>
+      <Button
         disabled={isFetchingHandle}
-        style={styles.newPostBtn}
+        label={_(msg`New post`)}
         onPress={onPressCompose}
-        accessibilityRole="button"
-        accessibilityLabel={_(msg`New post`)}
-        accessibilityHint="">
-        <View style={styles.newPostBtnIconWrapper}>
-          <EditBig width={19} style={styles.newPostBtnLabel} />
-        </View>
-        <Text type="button" style={styles.newPostBtnLabel}>
+        size="large"
+        variant="gradient"
+        color="gradient_sky">
+        <ButtonIcon icon={EditBig} position="left" />
+        <ButtonText>
           <Trans context="action">New Post</Trans>
-        </Text>
-      </TouchableOpacity>
+        </ButtonText>
+      </Button>
     </View>
   )
 }
@@ -465,32 +463,5 @@ const styles = StyleSheet.create({
     right: 12,
     width: 30,
     height: 30,
-  },
-
-  newPostBtnContainer: {
-    flexDirection: 'row',
-  },
-  newPostBtn: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'center',
-    borderRadius: 24,
-    paddingTop: 10,
-    paddingBottom: 12, // visually aligns the text vertically inside the button
-    paddingLeft: 16,
-    paddingRight: 18, // looks nicer like this
-    backgroundColor: colors.blue3,
-    marginLeft: 12,
-    marginTop: 20,
-    marginBottom: 10,
-    gap: 8,
-  },
-  newPostBtnIconWrapper: {
-    marginTop: 2, // aligns the icon visually with the text
-  },
-  newPostBtnLabel: {
-    color: colors.white,
-    fontSize: 16,
-    fontWeight: '600',
   },
 })

--- a/src/view/shell/desktop/LeftNav.tsx
+++ b/src/view/shell/desktop/LeftNav.tsx
@@ -18,7 +18,7 @@ import {getCurrentRoute, isStateAtTabRoot, isTab} from '#/lib/routes/helpers'
 import {makeProfileLink} from '#/lib/routes/links'
 import {CommonNavigatorParams, NavigationProp} from '#/lib/routes/types'
 import {isInvalidHandle} from '#/lib/strings/handles'
-import {colors, s} from '#/lib/styles'
+import {colors} from '#/lib/styles'
 import {emitSoftReset} from '#/state/events'
 import {useFetchHandle} from '#/state/queries/handle'
 import {useUnreadMessageCount} from '#/state/queries/messages/list-converations'
@@ -29,9 +29,9 @@ import {useComposerControls} from '#/state/shell/composer'
 import {Link} from '#/view/com/util/Link'
 import {LoadingPlaceholder} from '#/view/com/util/LoadingPlaceholder'
 import {PressableWithHover} from '#/view/com/util/PressableWithHover'
-import {Text} from '#/view/com/util/text/Text'
 import {UserAvatar} from '#/view/com/util/UserAvatar'
 import {NavSignupCard} from '#/view/shell/NavSignupCard'
+import {atoms as a, useBreakpoints, useTheme} from '#/alf'
 import {
   Bell_Filled_Corner0_Rounded as BellFilled,
   Bell_Stroke2_Corner0_Rounded as Bell,
@@ -63,9 +63,10 @@ import {
   UserCircle_Filled_Corner0_Rounded as UserCircleFilled,
   UserCircle_Stroke2_Corner0_Rounded as UserCircle,
 } from '#/components/icons/UserCircle'
+import {Text} from '#/components/Typography'
 import {router} from '../../../routes'
 
-const NAV_ICON_WIDTH = 24
+const NAV_ICON_WIDTH = 28
 
 function ProfileCard() {
   const {currentAccount} = useSession()
@@ -149,9 +150,10 @@ interface NavItemProps {
   label: string
 }
 function NavItem({count, href, icon, iconFilled, label}: NavItemProps) {
-  const pal = usePalette('default')
+  const t = useTheme()
   const {currentAccount} = useSession()
-  const {isDesktop, isTablet} = useWebMediaQueries()
+  const {gtMobile, gtTablet} = useBreakpoints()
+  const isTablet = gtMobile && !gtTablet
   const [pathName] = React.useMemo(() => router.matchPath(href), [href])
   const currentRouteInfo = useNavigationState(state => {
     if (!state) {
@@ -183,8 +185,8 @@ function NavItem({count, href, icon, iconFilled, label}: NavItemProps) {
 
   return (
     <PressableWithHover
-      style={styles.navItemWrapper}
-      hoverStyle={pal.viewLight}
+      style={[a.flex_row, a.align_center, a.p_md, a.rounded_sm, a.gap_sm]}
+      hoverStyle={t.atoms.bg_contrast_25}
       // @ts-ignore the function signature differs on web -prf
       onPress={onPressWrapped}
       // @ts-ignore web only -prf
@@ -195,23 +197,47 @@ function NavItem({count, href, icon, iconFilled, label}: NavItemProps) {
       accessibilityHint="">
       <View
         style={[
-          styles.navItemIconWrapper,
-          isTablet && styles.navItemIconWrapperTablet,
+          a.align_center,
+          a.justify_center,
+          {
+            width: 24,
+            height: 24,
+          },
+          isTablet && {
+            width: 40,
+            height: 40,
+          },
         ]}>
         {isCurrent ? iconFilled : icon}
         {typeof count === 'string' && count ? (
           <Text
-            type="button"
             style={[
-              styles.navItemCount,
-              isTablet && styles.navItemCountTablet,
+              a.absolute,
+              a.text_sm,
+              a.font_bold,
+              a.rounded_full,
+              {
+                top: '-10%',
+                left: '60%',
+                backgroundColor: t.palette.primary_500,
+                color: t.palette.white,
+                lineHeight: a.text_sm.fontSize,
+                paddingHorizontal: 4,
+                paddingVertical: 1,
+              },
+              isTablet && [
+                {
+                  top: '10%',
+                  left: '50%',
+                },
+              ],
             ]}>
             {count}
           </Text>
         ) : null}
       </View>
-      {isDesktop && (
-        <Text type="title" style={[isCurrent ? s.bold : s.normal, pal.text]}>
+      {gtTablet && (
+        <Text style={[a.text_xl, isCurrent ? a.font_heavy : a.font_normal]}>
           {label}
         </Text>
       )}
@@ -439,41 +465,6 @@ const styles = StyleSheet.create({
     right: 12,
     width: 30,
     height: 30,
-  },
-
-  navItemWrapper: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    paddingHorizontal: 12,
-    padding: 12,
-    borderRadius: 8,
-    gap: 10,
-  },
-  navItemIconWrapper: {
-    width: 24,
-    height: 24,
-    zIndex: 1,
-  },
-  navItemIconWrapperTablet: {
-    width: 40,
-    height: 40,
-  },
-  navItemCount: {
-    position: 'absolute',
-    top: 0,
-    left: 15,
-    backgroundColor: colors.blue3,
-    color: colors.white,
-    fontSize: 12,
-    lineHeight: 12,
-    fontWeight: '600',
-    paddingHorizontal: 4,
-    paddingVertical: 1,
-    borderRadius: 100,
-  },
-  navItemCountTablet: {
-    left: 18,
-    fontSize: 14,
   },
 
   newPostBtnContainer: {

--- a/src/view/shell/desktop/LeftNav.tsx
+++ b/src/view/shell/desktop/LeftNav.tsx
@@ -468,9 +468,11 @@ const styles = StyleSheet.create({
     backgroundColor: colors.blue3,
     color: colors.white,
     fontSize: 12,
+    lineHeight: 12,
     fontWeight: '600',
     paddingHorizontal: 4,
-    borderRadius: 6,
+    paddingVertical: 1,
+    borderRadius: 100,
   },
   navItemCountTablet: {
     left: 18,

--- a/src/view/shell/desktop/LeftNav.tsx
+++ b/src/view/shell/desktop/LeftNav.tsx
@@ -217,6 +217,7 @@ function NavItem({count, href, icon, iconFilled, label}: NavItemProps) {
               a.text_xs,
               a.font_bold,
               a.rounded_full,
+              a.text_center,
               {
                 top: '-10%',
                 left: count.length === 1 ? '50%' : '40%',
@@ -225,6 +226,7 @@ function NavItem({count, href, icon, iconFilled, label}: NavItemProps) {
                 lineHeight: a.text_sm.fontSize,
                 paddingHorizontal: 4,
                 paddingVertical: 1,
+                minWidth: 16,
               },
               isTablet && [
                 {

--- a/src/view/shell/desktop/LeftNav.tsx
+++ b/src/view/shell/desktop/LeftNav.tsx
@@ -214,12 +214,12 @@ function NavItem({count, href, icon, iconFilled, label}: NavItemProps) {
           <Text
             style={[
               a.absolute,
-              a.text_sm,
+              a.text_xs,
               a.font_bold,
               a.rounded_full,
               {
                 top: '-10%',
-                left: '60%',
+                left: count.length === 1 ? '50%' : '40%',
                 backgroundColor: t.palette.primary_500,
                 color: t.palette.white,
                 lineHeight: a.text_sm.fontSize,
@@ -229,7 +229,7 @@ function NavItem({count, href, icon, iconFilled, label}: NavItemProps) {
               isTablet && [
                 {
                   top: '10%',
-                  left: '50%',
+                  left: count.length === 1 ? '50%' : '40%',
                 },
               ],
             ]}>

--- a/src/view/shell/desktop/LeftNav.tsx
+++ b/src/view/shell/desktop/LeftNav.tsx
@@ -65,7 +65,7 @@ import {
 } from '#/components/icons/UserCircle'
 import {router} from '../../../routes'
 
-const NAV_ICON_WIDTH = 28
+const NAV_ICON_WIDTH = 24
 
 function ProfileCard() {
   const {currentAccount} = useSession()
@@ -450,11 +450,8 @@ const styles = StyleSheet.create({
     gap: 10,
   },
   navItemIconWrapper: {
-    alignItems: 'center',
-    justifyContent: 'center',
-    width: 28,
+    width: 24,
     height: 24,
-    marginTop: 2,
     zIndex: 1,
   },
   navItemIconWrapperTablet: {

--- a/src/view/shell/desktop/LeftNav.tsx
+++ b/src/view/shell/desktop/LeftNav.tsx
@@ -302,7 +302,7 @@ function ComposeBtn() {
         onPress={onPressCompose}
         size="large"
         variant="gradient"
-        color="gradient_sky"
+        color="gradient_primary"
         style={[a.rounded_full]}>
         <ButtonIcon icon={EditBig} position="left" />
         <ButtonText>

--- a/src/view/shell/desktop/LeftNav.tsx
+++ b/src/view/shell/desktop/LeftNav.tsx
@@ -302,7 +302,8 @@ function ComposeBtn() {
         onPress={onPressCompose}
         size="large"
         variant="gradient"
-        color="gradient_sky">
+        color="gradient_sky"
+        style={[a.rounded_full]}>
         <ButtonIcon icon={EditBig} position="left" />
         <ButtonText>
           <Trans context="action">New Post</Trans>

--- a/src/view/shell/desktop/LeftNav.tsx
+++ b/src/view/shell/desktop/LeftNav.tsx
@@ -301,8 +301,8 @@ function ComposeBtn() {
         label={_(msg`New post`)}
         onPress={onPressCompose}
         size="large"
-        variant="gradient"
-        color="gradient_primary"
+        variant="solid"
+        color="primary"
         style={[a.rounded_full]}>
         <ButtonIcon icon={EditBig} position="left" />
         <ButtonText>


### PR DESCRIPTION
Does a few things:
- new compose button
- fixes sizing/alignment of nav icons, these were a little wonky
- increases font weight of active item
- fixes sizing/alignment of notification dot, was a little wonky with the new type

### New
![CleanShot 2024-09-25 at 16 59 35@2x](https://github.com/user-attachments/assets/2e350eb0-c372-4e5a-a3b5-91777640c539)
![CleanShot 2024-09-25 at 16 59 43@2x](https://github.com/user-attachments/assets/7a5d78cb-a2e8-41c0-a214-ad6c3c35fdc6)
![CleanShot 2024-09-25 at 16 46 46@2x](https://github.com/user-attachments/assets/a843a298-8da9-41d9-8fde-49d82247e89e)
![CleanShot 2024-09-25 at 16 47 47@2x](https://github.com/user-attachments/assets/498a3952-4b3e-48b4-9e3e-758f0b433bb7)


### Old
![CleanShot 2024-09-25 at 16 49 14@2x](https://github.com/user-attachments/assets/826c0fa3-8cb1-4f7c-a113-898744303047)
![CleanShot 2024-09-25 at 16 50 55@2x](https://github.com/user-attachments/assets/18939c07-cdde-4867-aa8e-a5977ef44c92)
![CleanShot 2024-09-25 at 16 49 18@2x](https://github.com/user-attachments/assets/74dd7347-1db5-47b1-bded-d7be069d196c)
![CleanShot 2024-09-25 at 16 49 47@2x](https://github.com/user-attachments/assets/384d12a6-da62-40c3-ba99-582300eba1f3)

