### PR TITLE
Ignore bogus onScroll values

### DIFF
--- a/src/view/com/pager/PagerWithHeader.tsx
+++ b/src/view/com/pager/PagerWithHeader.tsx
@@ -166,7 +166,9 @@ export const PagerWithHeader = React.forwardRef<PagerRef, PagerWithHeaderProps>(
         // in fact, I actually can't do it, so let's just ignore those.
         // Let's only apply this hack if we've overscrolled by more than 300px
         // so that it's not a false positive from overscrolling -sfn
-        if (nextScrollY > -300 || nextScrollY !== -headerHeight) {
+        const isPossiblyInvalid =
+          headerHeight > 0 && nextScrollY === -headerHeight
+        if (!isPossiblyInvalid) {
           scrollY.value = nextScrollY
           runOnJS(queueThrottledOnScroll)()
         }

--- a/src/view/com/pager/PagerWithHeader.tsx
+++ b/src/view/com/pager/PagerWithHeader.tsx
@@ -161,10 +161,12 @@ export const PagerWithHeader = React.forwardRef<PagerRef, PagerWithHeaderProps>(
       (e: NativeScrollEvent) => {
         'worklet'
         const nextScrollY = e.contentOffset.y
-        // HACK: onScroll is reporting some strange values on load.
+        // HACK: onScroll is reporting some strange values on load (negative header height).
         // Highly improbable that you'd be overscrolled by over 400px -
-        // in fact, I actually can't do it, so let's just ignore those -sfn
-        if (nextScrollY !== -headerHeight) {
+        // in fact, I actually can't do it, so let's just ignore those.
+        // Let's only apply this hack if we've overscrolled by more than 300px
+        // so that it's not a false positive from overscrolling -sfn
+        if (nextScrollY > -300 || nextScrollY !== -headerHeight) {
           scrollY.value = nextScrollY
           runOnJS(queueThrottledOnScroll)()
         }

--- a/src/view/com/pager/PagerWithHeader.tsx
+++ b/src/view/com/pager/PagerWithHeader.tsx
@@ -161,10 +161,15 @@ export const PagerWithHeader = React.forwardRef<PagerRef, PagerWithHeaderProps>(
       (e: NativeScrollEvent) => {
         'worklet'
         const nextScrollY = e.contentOffset.y
-        scrollY.value = nextScrollY
-        runOnJS(queueThrottledOnScroll)()
+        // HACK: onScroll is reporting some strange values on load.
+        // Highly improbable that you'd be overscrolled by over 400px -
+        // in fact, I actually can't do it, so let's just ignore those -sfn
+        if (nextScrollY !== -headerHeight) {
+          scrollY.value = nextScrollY
+          runOnJS(queueThrottledOnScroll)()
+        }
       },
-      [scrollY, queueThrottledOnScroll],
+      [scrollY, queueThrottledOnScroll, headerHeight],
     )
 
     const onPageSelectedInner = React.useCallback(

--- a/src/view/com/pager/PagerWithHeader.tsx
+++ b/src/view/com/pager/PagerWithHeader.tsx
@@ -163,11 +163,9 @@ export const PagerWithHeader = React.forwardRef<PagerRef, PagerWithHeaderProps>(
         const nextScrollY = e.contentOffset.y
         // HACK: onScroll is reporting some strange values on load (negative header height).
         // Highly improbable that you'd be overscrolled by over 400px -
-        // in fact, I actually can't do it, so let's just ignore those.
-        // Let's only apply this hack if we've overscrolled by more than 300px
-        // so that it's not a false positive from overscrolling -sfn
+        // in fact, I actually can't do it, so let's just ignore those. -sfn
         const isPossiblyInvalid =
-          headerHeight > 0 && nextScrollY === -headerHeight
+          headerHeight > 0 && Math.round(nextScrollY * 2) / 2 === -headerHeight
         if (!isPossiblyInvalid) {
           scrollY.value = nextScrollY
           runOnJS(queueThrottledOnScroll)()


### PR DESCRIPTION
The scroll listener is reporting strange values when the profile first loads (equal to negative header height).

This is a little bit hacky, but it appears safe to ignore those values, since they're typically way out of the range you can possibly achieve by just overscrolling.

Video showing the bogus values:

https://github.com/user-attachments/assets/d252d937-ed64-4043-82ac-0f1af2be4b66

