### PR TITLE
Fix handle collapse on Android

### DIFF
--- a/src/view/com/util/PostMeta.tsx
+++ b/src/view/com/util/PostMeta.tsx
@@ -11,6 +11,7 @@ import {NON_BREAKING_SPACE} from '#/lib/strings/constants'
 import {sanitizeDisplayName} from '#/lib/strings/display-names'
 import {sanitizeHandle} from '#/lib/strings/handles'
 import {niceDate} from '#/lib/strings/time'
+import {isAndroid} from '#/platform/detection'
 import {precacheProfile} from '#/state/queries/profile'
 import {atoms as a, useTheme, web} from '#/alf'
 import {WebOnlyInlineLinkText} from '#/components/Link'
@@ -70,7 +71,7 @@ let PostMeta = (opts: PostMetaOpts): React.ReactNode => {
         </View>
       )}
       <ProfileHoverCard inline did={opts.author.did}>
-        <Text numberOfLines={1} style={[a.flex_shrink]}>
+        <Text numberOfLines={1} style={[isAndroid ? a.flex_1 : a.flex_shrink]}>
           <WebOnlyInlineLinkText
             to={profileLink}
             label={_(msg`View profile`)}
@@ -102,11 +103,13 @@ let PostMeta = (opts: PostMetaOpts): React.ReactNode => {
         </Text>
       </ProfileHoverCard>
 
-      <Text
-        style={[a.text_md, t.atoms.text_contrast_medium]}
-        accessible={false}>
-        &middot;
-      </Text>
+      {!isAndroid && (
+        <Text
+          style={[a.text_md, t.atoms.text_contrast_medium]}
+          accessible={false}>
+          &middot;
+        </Text>
+      )}
 
       <TimeElapsed timestamp={opts.timestamp}>
         {({timeElapsed}) => (


### PR DESCRIPTION
I noticed that somewhat rarely, handles were collapsing and not being shown at all on Android. We had some code in the previous version of `PostMeta` that I had deleted, but evidently it was to handle this case.

I was not able to reproduce a collapsed handle on iOS or web. The fix was to allow the display name and handle to expand, which pushes the timestamp all the way to the right, which matches what we have in production today.

Collapsed handle:
![Screenshot_20240926-115424](https://github.com/user-attachments/assets/29d94258-9ca2-474d-996d-e94c556edaf1)

The fix was to allow the display name and handle to expand, which pushes the timestamp all the way to the right:
![Screenshot_20240926-121325](https://github.com/user-attachments/assets/522422d3-32db-436d-84ff-7df8e05cb01c)

Which matches what we have in production today:
![Screenshot_20240926-121054](https://github.com/user-attachments/assets/ca5286a4-890b-4d53-92d3-c6fa88e2c328)
