### PR TITLE
Make 2 images with varying aspect ratio look more presentable

### DIFF
--- a/src/view/com/util/images/ImageLayoutGrid.tsx
+++ b/src/view/com/util/images/ImageLayoutGrid.tsx
@@ -59,17 +59,24 @@ function ImageLayoutGridInner(props: ImageLayoutGridInnerProps) {
   const count = props.images.length
 
   switch (count) {
-    case 2:
+    case 2: {
+      const imageA = props.images[0]
+      const imageB = props.images[1]
+
+      const ratioA = getClampedAspectRatio(imageA)
+      const ratioB = getClampedAspectRatio(imageB)
+      const totalRatio = ratioA + ratioB
+
       return (
-        <View style={[a.flex_1, a.flex_row, gap]}>
-          <View style={[a.flex_1, {aspectRatio: 1}]}>
+        <View style={[a.flex_1, a.flex_row, gap, {aspectRatio: totalRatio}]}>
+          <View style={[a.flex_1, {flexGrow: ratioA}]}>
             <GalleryItem
               {...props}
               index={0}
               insetBorderStyle={noCorners(['topRight', 'bottomRight'])}
             />
           </View>
-          <View style={[a.flex_1, {aspectRatio: 1}]}>
+          <View style={[a.flex_1, {flexGrow: ratioB}]}>
             <GalleryItem
               {...props}
               index={1}
@@ -78,6 +85,7 @@ function ImageLayoutGridInner(props: ImageLayoutGridInnerProps) {
           </View>
         </View>
       )
+    }
 
     case 3:
       return (
@@ -192,4 +200,18 @@ function noCorners(
     styles.push({borderBottomRightRadius: 0})
   }
   return StyleSheet.flatten(styles)
+}
+
+const getClampedAspectRatio = (image: AppBskyEmbedImages.ViewImage): number => {
+  const dims = image.aspectRatio
+
+  const width = dims ? dims.width : 1
+  const height = dims ? dims.height : 1
+  const ratio = width / height
+
+  return clamp(ratio, 3 / 4, 4 / 3)
+}
+
+const clamp = (value: number, min: number, max: number): number => {
+  return Math.max(min, Math.min(max, value))
 }


### PR DESCRIPTION
I used CSS grid for my web client but I wasn't sure how I'd translate it to something that works for React Native, so I don't think this is clamping the aspect ratio properly as it should have. (we're clamping the aspect ratio to between 3/4 and 4/3 so we don't end up with extreme crops)

| Before | After |
| --- | --- |
| ![image](https://github.com/user-attachments/assets/66b0d0b6-2501-4ac2-ab44-788b6a27c8ce) | ![image](https://github.com/user-attachments/assets/ec5be109-0307-47fd-a514-0cfb6b139051) |
| ![image](https://github.com/user-attachments/assets/84e493c9-2202-4b45-b91e-78606a87c3fd) | ![image](https://github.com/user-attachments/assets/72afcc9f-1646-4291-8f56-daf53ce48b47) |
| ![image](https://github.com/user-attachments/assets/99461cfb-571d-453e-a77f-9769ee18fd19) | ![image](https://github.com/user-attachments/assets/e49e0135-035d-46c7-9417-b1f31b365caf) |
