### PR TITLE
[External Embeds] Add podcasts to Spotify embeds

### DIFF
--- a/src/lib/strings/embed-player.ts
+++ b/src/lib/strings/embed-player.ts
@@ -1,7 +1,7 @@
 import {Dimensions} from 'react-native'
 
-import {isSafari} from 'lib/browser'
-import {isWeb} from 'platform/detection'
+import {isSafari} from '#/lib/browser'
+import {isWeb} from '#/platform/detection'
 
 const {height: SCREEN_HEIGHT} = Dimensions.get('window')
 
@@ -183,6 +183,20 @@ export function parseEmbedPlayerFromUrl(
           type: 'spotify_song',
           source: 'spotify',
           playerUri: `https://open.spotify.com/embed/track/${id ?? idOrType}`,
+        }
+      }
+      if (typeOrLocale === 'episode' || idOrType === 'episode') {
+        return {
+          type: 'spotify_song',
+          source: 'spotify',
+          playerUri: `https://open.spotify.com/embed/episode/${id ?? idOrType}`,
+        }
+      }
+      if (typeOrLocale === 'show' || idOrType === 'show') {
+        return {
+          type: 'spotify_song',
+          source: 'spotify',
+          playerUri: `https://open.spotify.com/embed/show/${id ?? idOrType}`,
         }
       }
     }


### PR DESCRIPTION
Fixes https://github.com/bluesky-social/social-app/issues/5162

## Why

Adding podcasts to embed support for Spotify

## Test Plan

Add a Spotify podcast (either a `/show/` or `/episode/` type url) to a post.

![Screenshot 2024-09-26 at 5 51 14 PM](https://github.com/user-attachments/assets/0280999a-4406-4af4-83db-81a1251aa214)