### PR TITLE
[Share Extension] Support images/movies from other apps like iMessage

### DIFF
--- a/modules/Share-with-Bluesky/ShareViewController.swift
+++ b/modules/Share-with-Bluesky/ShareViewController.swift
@@ -180,12 +180,12 @@ class ShareViewController: UIViewController {
 extension URL {
   var type: URLType {
     get {
-      let urlStr = self.absoluteString
-      let ext = self.pathComponents.last?.split(separator: ".").last?.lowercased() ?? ""
-
-      if !urlStr.starts(with: "file://") {
+      guard self.absoluteString.starts(with: "file://"),
+            let ext = self.pathComponents.last?.split(separator: ".").last?.lowercased() else {
         return .other
-      } else if IMAGE_EXTENSIONS.contains(ext) {
+      }
+
+      if IMAGE_EXTENSIONS.contains(ext) {
         return .image
       } else if MOVIE_EXTENSIONS.contains(ext) {
         return .movie

--- a/modules/Share-with-Bluesky/ShareViewController.swift
+++ b/modules/Share-with-Bluesky/ShareViewController.swift
@@ -1,5 +1,14 @@
 import UIKit
 
+let IMAGE_EXTENSIONS: [String] = ["png", "jpg", "jpeg", "gif", "heic"]
+let MOVIE_EXTENSIONS: [String] = ["mov", "mp4", "m4v"]
+
+enum URLType: String, CaseIterable {
+  case image
+  case movie
+  case other
+}
+
 class ShareViewController: UIViewController {
   // This allows other forks to use this extension while also changing their
   // scheme.
@@ -43,9 +52,18 @@ class ShareViewController: UIViewController {
 
   private func handleUrl(item: NSItemProvider) async {
     if let data = try? await item.loadItem(forTypeIdentifier: "public.url") as? URL {
-      if let encoded = data.absoluteString.addingPercentEncoding(withAllowedCharacters: .urlHostAllowed),
-         let url = URL(string: "\(self.appScheme)://intent/compose?text=\(encoded)") {
-        _ = self.openURL(url)
+      switch data.type {
+      case .image:
+        await handleImages(items: [item])
+        return
+      case .movie:
+        await handleVideos(items: [item])
+        return
+      case .other:
+        if let encoded = data.absoluteString.addingPercentEncoding(withAllowedCharacters: .urlHostAllowed),
+           let url = URL(string: "\(self.appScheme)://intent/compose?text=\(encoded)") {
+          _ = self.openURL(url)
+        }
       }
     }
     self.completeRequest()
@@ -156,5 +174,23 @@ class ShareViewController: UIViewController {
       responder = responder?.next
     }
     return false
+  }
+}
+
+extension URL {
+  var type: URLType {
+    get {
+      let urlStr = self.absoluteString
+      let ext = self.pathComponents.last?.split(separator: ".").last?.lowercased() ?? ""
+
+      if !urlStr.starts(with: "file://") {
+        return .other
+      } else if IMAGE_EXTENSIONS.contains(ext) {
+        return .image
+      } else if MOVIE_EXTENSIONS.contains(ext) {
+        return .movie
+      }
+      return .other
+    }
   }
 }


### PR DESCRIPTION
Fixes https://github.com/bluesky-social/social-app/issues/5492

## Why

Some apps - when sharing an image or movie - actually end up being `public.url` rather than `public.image` or `public.movie`. As a result, we need to do a little bit of parsing for these.

## Test Plan

Hard to test this in simulator, since the easiest way to test is by sharing a movie or image from iMessage into Bluesky. However, you should be able to test that on a device. Should test:

- Sharing an image works
- Sharing a video works
- Sharing URLs (from something like Safari) still works as it did before
