### PR TITLE
Rework native autocomplete

### DIFF
--- a/src/lib/custom-animations/PressableScale.tsx
+++ b/src/lib/custom-animations/PressableScale.tsx
@@ -13,17 +13,19 @@ import {isNative} from '#/platform/detection'
 
 const DEFAULT_TARGET_SCALE = isNative || isTouchDevice ? 0.98 : 1
 
+const AnimatedPressable = Animated.createAnimatedComponent(Pressable)
+
 export function PressableScale({
   targetScale = DEFAULT_TARGET_SCALE,
   children,
-  contentContainerStyle,
+  style,
   onPressIn,
   onPressOut,
   ...rest
 }: {
   targetScale?: number
-  contentContainerStyle?: StyleProp<ViewStyle>
-} & Exclude<PressableProps, 'onPressIn' | 'onPressOut'>) {
+  style?: StyleProp<ViewStyle>
+} & Exclude<PressableProps, 'onPressIn' | 'onPressOut' | 'style'>) {
   const scale = useSharedValue(1)
 
   const animatedStyle = useAnimatedStyle(() => ({
@@ -31,7 +33,7 @@ export function PressableScale({
   }))
 
   return (
-    <Pressable
+    <AnimatedPressable
       accessibilityRole="button"
       onPressIn={e => {
         'worklet'
@@ -49,10 +51,9 @@ export function PressableScale({
         cancelAnimation(scale)
         scale.value = withTiming(1, {duration: 100})
       }}
+      style={[animatedStyle, style]}
       {...rest}>
-      <Animated.View style={[animatedStyle, contentContainerStyle]}>
-        {children as React.ReactNode}
-      </Animated.View>
-    </Pressable>
+      {children as React.ReactNode}
+    </AnimatedPressable>
   )
 }

--- a/src/lib/custom-animations/PressableScale.tsx
+++ b/src/lib/custom-animations/PressableScale.tsx
@@ -53,7 +53,7 @@ export function PressableScale({
       }}
       style={[animatedStyle, style]}
       {...rest}>
-      {children as React.ReactNode}
+      {children}
     </AnimatedPressable>
   )
 }

--- a/src/view/com/composer/text-input/TextInput.tsx
+++ b/src/view/com/composer/text-input/TextInput.tsx
@@ -245,7 +245,11 @@ export const TextInput = forwardRef(function TextInputImpl(
         multiline
         scrollEnabled={false}
         numberOfLines={4}
-        style={[inputTextStyle, a.w_full, {textAlignVertical: 'top'}]}
+        style={[
+          inputTextStyle,
+          a.w_full,
+          {textAlignVertical: 'top', minHeight: 60},
+        ]}
         {...props}>
         {textDecorated}
       </PasteInput>

--- a/src/view/com/composer/text-input/mobile/Autocomplete.tsx
+++ b/src/view/com/composer/text-input/mobile/Autocomplete.tsx
@@ -60,12 +60,13 @@ export function Autocomplete({
           style={[
             pal.view,
             a.mt_sm,
-            a.border_t,
+            a.border,
+            a.rounded_sm,
             t.atoms.border_contrast_high,
-            {marginLeft: -50},
+            {marginLeft: -62},
           ]}>
           {suggestionsRef.current?.length ? (
-            suggestionsRef.current.slice(0, 5).map(item => {
+            suggestionsRef.current.slice(0, 5).map((item, index, arr) => {
               // Eventually use an average length
               const MAX_CHARS = 40
               const MAX_HANDLE_CHARS = 20
@@ -76,51 +77,56 @@ export function Autocomplete({
                 getGraphemeString(item.handle, MAX_HANDLE_CHARS)
 
               const {name: displayName} = getGraphemeString(
-                item.displayName ?? item.handle,
+                item.displayName || item.handle,
                 MAX_CHARS -
                   MAX_HANDLE_CHARS +
                   (remainingCharacters > 0 ? remainingCharacters : 0),
               )
 
               return (
-                <PressableScale
-                  testID="autocompleteButton"
-                  key={item.handle}
+                <View
                   style={[
-                    a.flex_row,
-                    a.gap_sm,
-                    a.justify_between,
-                    a.align_center,
-                    a.py_md,
-                    a.border_b,
+                    index !== arr.length - 1 && a.border_b,
                     t.atoms.border_contrast_high,
+                    a.px_sm,
+                    a.py_md,
                   ]}
-                  onPress={() => onSelect(item.handle)}
-                  accessibilityLabel={`Select ${item.handle}`}
-                  accessibilityHint="">
-                  <View style={[a.flex_row, a.gap_sm, a.align_center]}>
-                    <UserAvatar
-                      avatar={item.avatar ?? null}
-                      size={24}
-                      type={item.associated?.labeler ? 'labeler' : 'user'}
-                    />
+                  key={item.handle}>
+                  <PressableScale
+                    testID="autocompleteButton"
+                    style={[
+                      a.flex_row,
+                      a.gap_sm,
+                      a.justify_between,
+                      a.align_center,
+                    ]}
+                    onPress={() => onSelect(item.handle)}
+                    accessibilityLabel={`Select ${item.handle}`}
+                    accessibilityHint="">
+                    <View style={[a.flex_row, a.gap_sm, a.align_center]}>
+                      <UserAvatar
+                        avatar={item.avatar ?? null}
+                        size={24}
+                        type={item.associated?.labeler ? 'labeler' : 'user'}
+                      />
+                      <Text
+                        style={[a.text_md, a.font_bold]}
+                        emoji={true}
+                        numberOfLines={1}>
+                        {sanitizeDisplayName(displayName)}
+                      </Text>
+                    </View>
                     <Text
-                      style={[a.text_md, a.font_bold]}
-                      emoji={true}
+                      style={[t.atoms.text_contrast_medium]}
                       numberOfLines={1}>
-                      {sanitizeDisplayName(displayName)}
+                      {sanitizeHandle(displayHandle, '@')}
                     </Text>
-                  </View>
-                  <Text
-                    style={[t.atoms.text_contrast_medium]}
-                    numberOfLines={1}>
-                    {sanitizeHandle(displayHandle, '@')}
-                  </Text>
-                </PressableScale>
+                  </PressableScale>
+                </View>
               )
             })
           ) : (
-            <Text style={[a.text_md, a.pt_sm]}>
+            <Text style={[a.text_md, a.px_sm, a.py_md]}>
               {isFetching ? (
                 <Trans>Loading...</Trans>
               ) : (

--- a/src/view/com/composer/text-input/mobile/Autocomplete.tsx
+++ b/src/view/com/composer/text-input/mobile/Autocomplete.tsx
@@ -1,11 +1,10 @@
-import React, {useEffect, useRef} from 'react'
-import {Animated, View} from 'react-native'
+import React, {useRef} from 'react'
+import {View} from 'react-native'
+import Animated, {FadeInDown, FadeOut} from 'react-native-reanimated'
 import {AppBskyActorDefs} from '@atproto/api'
 import {Trans} from '@lingui/macro'
 
 import {PressableScale} from '#/lib/custom-animations/PressableScale'
-import {useAnimatedValue} from '#/lib/hooks/useAnimatedValue'
-import {usePalette} from '#/lib/hooks/usePalette'
 import {sanitizeDisplayName} from '#/lib/strings/display-names'
 import {sanitizeHandle} from '#/lib/strings/handles'
 import {useActorAutocompleteQuery} from '#/state/queries/actor-autocomplete'
@@ -22,8 +21,7 @@ export function Autocomplete({
   onSelect: (item: string) => void
 }) {
   const t = useTheme()
-  const pal = usePalette('default')
-  const positionInterp = useAnimatedValue(0)
+
   const {getGraphemeString} = useGrapheme()
   const isActive = !!prefix
   const {data: suggestions, isFetching} = useActorAutocompleteQuery(prefix)
@@ -34,108 +32,85 @@ export function Autocomplete({
     suggestionsRef.current = suggestions
   }
 
-  useEffect(() => {
-    Animated.timing(positionInterp, {
-      toValue: isActive ? 1 : 0,
-      duration: 200,
-      useNativeDriver: true,
-    }).start()
-  }, [positionInterp, isActive])
-
-  const topAnimStyle = {
-    transform: [
-      {
-        translateY: positionInterp.interpolate({
-          inputRange: [0, 1],
-          outputRange: [200, 0],
-        }),
-      },
-    ],
-  }
+  if (!isActive) return null
 
   return (
-    <Animated.View style={topAnimStyle}>
-      {isActive ? (
-        <View
-          style={[
-            pal.view,
-            a.mt_sm,
-            a.border,
-            a.rounded_sm,
-            t.atoms.border_contrast_high,
-            {marginLeft: -62},
-          ]}>
-          {suggestionsRef.current?.length ? (
-            suggestionsRef.current.slice(0, 5).map((item, index, arr) => {
-              // Eventually use an average length
-              const MAX_CHARS = 40
-              const MAX_HANDLE_CHARS = 20
+    <Animated.View
+      entering={FadeInDown.duration(200)}
+      exiting={FadeOut.duration(100)}
+      style={[
+        t.atoms.bg,
+        a.mt_sm,
+        a.border,
+        a.rounded_sm,
+        t.atoms.border_contrast_high,
+        {marginLeft: -62},
+      ]}>
+      {suggestionsRef.current?.length ? (
+        suggestionsRef.current.slice(0, 5).map((item, index, arr) => {
+          // Eventually use an average length
+          const MAX_CHARS = 40
+          const MAX_HANDLE_CHARS = 20
 
-              // Using this approach because styling is not respecting
-              // bounding box wrapping (before converting to ellipsis)
-              const {name: displayHandle, remainingCharacters} =
-                getGraphemeString(item.handle, MAX_HANDLE_CHARS)
+          // Using this approach because styling is not respecting
+          // bounding box wrapping (before converting to ellipsis)
+          const {name: displayHandle, remainingCharacters} = getGraphemeString(
+            item.handle,
+            MAX_HANDLE_CHARS,
+          )
 
-              const {name: displayName} = getGraphemeString(
-                item.displayName || item.handle,
-                MAX_CHARS -
-                  MAX_HANDLE_CHARS +
-                  (remainingCharacters > 0 ? remainingCharacters : 0),
-              )
+          const {name: displayName} = getGraphemeString(
+            item.displayName || item.handle,
+            MAX_CHARS -
+              MAX_HANDLE_CHARS +
+              (remainingCharacters > 0 ? remainingCharacters : 0),
+          )
 
-              return (
-                <View
-                  style={[
-                    index !== arr.length - 1 && a.border_b,
-                    t.atoms.border_contrast_high,
-                    a.px_sm,
-                    a.py_md,
-                  ]}
-                  key={item.handle}>
-                  <PressableScale
-                    testID="autocompleteButton"
-                    style={[
-                      a.flex_row,
-                      a.gap_sm,
-                      a.justify_between,
-                      a.align_center,
-                    ]}
-                    onPress={() => onSelect(item.handle)}
-                    accessibilityLabel={`Select ${item.handle}`}
-                    accessibilityHint="">
-                    <View style={[a.flex_row, a.gap_sm, a.align_center]}>
-                      <UserAvatar
-                        avatar={item.avatar ?? null}
-                        size={24}
-                        type={item.associated?.labeler ? 'labeler' : 'user'}
-                      />
-                      <Text
-                        style={[a.text_md, a.font_bold]}
-                        emoji={true}
-                        numberOfLines={1}>
-                        {sanitizeDisplayName(displayName)}
-                      </Text>
-                    </View>
-                    <Text
-                      style={[t.atoms.text_contrast_medium]}
-                      numberOfLines={1}>
-                      {sanitizeHandle(displayHandle, '@')}
-                    </Text>
-                  </PressableScale>
+          return (
+            <View
+              style={[
+                index !== arr.length - 1 && a.border_b,
+                t.atoms.border_contrast_high,
+                a.px_sm,
+                a.py_md,
+              ]}
+              key={item.handle}>
+              <PressableScale
+                testID="autocompleteButton"
+                style={[
+                  a.flex_row,
+                  a.gap_sm,
+                  a.justify_between,
+                  a.align_center,
+                ]}
+                onPress={() => onSelect(item.handle)}
+                accessibilityLabel={`Select ${item.handle}`}
+                accessibilityHint="">
+                <View style={[a.flex_row, a.gap_sm, a.align_center]}>
+                  <UserAvatar
+                    avatar={item.avatar ?? null}
+                    size={24}
+                    type={item.associated?.labeler ? 'labeler' : 'user'}
+                  />
+                  <Text
+                    style={[a.text_md, a.font_bold]}
+                    emoji={true}
+                    numberOfLines={1}>
+                    {sanitizeDisplayName(displayName)}
+                  </Text>
                 </View>
-              )
-            })
-          ) : (
-            <Text style={[a.text_md, a.px_sm, a.py_md]}>
-              {isFetching ? (
-                <Trans>Loading...</Trans>
-              ) : (
-                <Trans>No result</Trans>
-              )}
-            </Text>
-          )}
-        </View>
-      ) : null}
+                <Text style={[t.atoms.text_contrast_medium]} numberOfLines={1}>
+                  {sanitizeHandle(displayHandle, '@')}
+                </Text>
+              </PressableScale>
+            </View>
+          )
+        })
+      ) : (
+        <Text style={[a.text_md, a.px_sm, a.py_md]}>
+          {isFetching ? <Trans>Loading...</Trans> : <Trans>No result</Trans>}
+        </Text>
+      )}
     </Animated.View>
   )
 }

--- a/src/view/shell/bottom-bar/BottomBar.tsx
+++ b/src/view/shell/bottom-bar/BottomBar.tsx
@@ -354,17 +354,16 @@ function Btn({
   return (
     <PressableScale
       testID={testID}
-      style={styles.ctrl}
+      style={[styles.ctrl, a.flex_1]}
       onPress={onPress}
       onLongPress={onLongPress}
       accessible={accessible}
       accessibilityLabel={accessibilityLabel}
       accessibilityHint={accessibilityHint}
-      targetScale={0.8}
-      contentContainerStyle={[a.flex_1]}>
+      targetScale={0.8}>
       {icon}
       {notificationCount ? (
-        <View style={[styles.notificationCount, {top: -5}]}>
+        <View style={[styles.notificationCount]}>
           <Text style={styles.notificationCountLabel}>{notificationCount}</Text>
         </View>
       ) : undefined}


### PR DESCRIPTION
## Why

There was some clipping here that needed to get fixed. It also just kind of looked janky, so redid some design here.

- Add a border to the entire thing like there is on web
- Fix missing handles (`||` instead of `??`)
- Stop using `TouchableOpacity` and instead use `PressableScale`
- Change `PressableScale` to be a bit more in-line with stuff like `style` (remove `contentContainerStyle` prop)

## Test Plan

Everything should be the same as before functionality wise, with a couple of fixes.

https://github.com/user-attachments/assets/d51e7dcb-ce14-4e6a-a911-e86865a56bfa