### PR TITLE
Paralellize image uploads

### DIFF
--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -201,7 +201,6 @@ async function resolveEmbed(agent: BskyAgent, opts: PostOpts) {
     embed = recordEmbed
   }
 
-  // add image embed if present
   if (opts.images?.length) {
     logger.debug(`Uploading images`, {
       count: opts.images.length,
@@ -239,10 +238,7 @@ async function resolveEmbed(agent: BskyAgent, opts: PostOpts) {
         images,
       }
     }
-  }
-
-  // add video embed if present
-  if (opts.video) {
+  } else if (opts.video) {
     const captions = await Promise.all(
       opts.video.captions
         .filter(caption => caption.lang !== '')
@@ -274,10 +270,7 @@ async function resolveEmbed(agent: BskyAgent, opts: PostOpts) {
         aspectRatio: opts.video.aspectRatio,
       }
     }
-  }
-
-  // add external embed if present
-  if (opts.extLink && !opts.images?.length) {
+  } else if (opts.extLink) {
     if (opts.extLink.embed) {
       embed = opts.extLink.embed
     } else {

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -191,9 +191,6 @@ async function resolveEmbed(
   | AppBskyEmbedRecordWithMedia.Main
   | undefined
 > {
-  if (opts.extLink?.embed) {
-    return opts.extLink.embed
-  }
   const media = await resolveMedia(agent, opts)
   if (opts.quote) {
     const quoteRecord = {
@@ -215,6 +212,9 @@ async function resolveEmbed(
   }
   if (media) {
     return media
+  }
+  if (opts.extLink?.embed) {
+    return opts.extLink.embed
   }
   return undefined
 }


### PR DESCRIPTION
I'm starting to bring in different pieces inspired by / taken from https://github.com/bluesky-social/social-app/pull/4163. The first of these pieces will be moving decoupling link meta / embed resolution from composer previews. I'm not ready to do that yet so I'm starting by doing little refactorings.

In this refactor, I'm doing a few things to the post creation method:

- Removed unsafe `as` coercions. They were only needed due to how the logic was structured with `embed` being redefined to wrap the previous `embed`.
- I found the recursive definition of `embed` a bit difficult to trace in general because it wasn't clear which cases are mutually exclusive. I've refactored it with stronger types to actually follow the codepaths that _can_ execute.
- While doing so, I've added parallelization for image uploads — similar to how we already do for video.

## Test Plan

Verify all of these still work.

- Posting a link (with preview)
- Posting one image
- Posting multiple images
- Posting a GIF
- Posting a video
- Posting a starter pack
- Posting a list
- Posting a feed
- Posting a quote
- Posting a quote with image(s)
- Posting a quote with video
- Posting a quote with GIF
- Posting a quote with link