### PR TITLE
Remove local file check

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -8,16 +8,14 @@
 
 @font-face {
   font-family: 'InterVariable';
-  src: local('InterVariable'),
-    url(/assets/fonts/inter/InterVariable.ttf) format('truetype');
+  src: url(/assets/fonts/inter/InterVariable.ttf) format('truetype');
   font-weight: 300 1000;
   font-style: normal;
   font-display: swap;
 }
 @font-face {
   font-family: 'InterVariableItalic';
-  src: local('InterVariableItalic'),
-    url(/assets/fonts/inter/InterVariable-Italic.ttf) format('truetype');
+  src: url(/assets/fonts/inter/InterVariable-Italic.ttf) format('truetype');
   font-weight: 300 1000;
   font-style: italic;
   font-display: swap;


### PR DESCRIPTION
The `local` check seemed to be taking precedence in Chrome (I have `InterVariable` installed), but weights weren't working. It was working fine in Safari and FF.

I time-boxed this to 10 min, and considering how low the % hit rate on `InterVariable` and the italics would be, I think we can just remove this. Tested with the prod server too.