### PR TITLE
Introduce a composer reducer and move image state there

### DIFF
--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -24,6 +24,7 @@ import {
   threadgateAllowUISettingToAllowRecordValue,
   writeThreadgateRecord,
 } from '#/state/queries/threadgate'
+import {ComposerState} from '#/view/com/composer/state'
 import {LinkMeta} from '../link-meta/link-meta'
 import {uploadBlob} from './upload-blob'
 
@@ -38,6 +39,7 @@ export interface ExternalEmbedDraft {
 }
 
 interface PostOpts {
+  composerState: ComposerState // TODO: Not used yet.
   rawText: string
   replyTo?: string
   quote?: {

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -3,6 +3,7 @@ import React, {
   useEffect,
   useImperativeHandle,
   useMemo,
+  useReducer,
   useRef,
   useState,
 } from 'react'
@@ -119,6 +120,7 @@ import {EmojiArc_Stroke2_Corner0_Rounded as EmojiSmile} from '#/components/icons
 import {TimesLarge_Stroke2_Corner0_Rounded as X} from '#/components/icons/Times'
 import * as Prompt from '#/components/Prompt'
 import {Text as NewText} from '#/components/Typography'
+import {composerReducer,createComposerState} from './state'
 
 const MAX_IMAGES = 4
 
@@ -216,6 +218,14 @@ export const ComposePost = ({
   const [images, setImages] = useState<ComposerImage[]>(() =>
     createInitialImages(initImageUris),
   )
+
+  // Not used yet.
+  const [composerState, _dispatch] = useReducer(
+    composerReducer,
+    null,
+    createComposerState,
+  )
+
   const onClose = useCallback(() => {
     closeComposer()
   }, [closeComposer])
@@ -374,6 +384,7 @@ export const ComposePost = ({
       try {
         postUri = (
           await apilib.post(agent, {
+            composerState, // TODO: not used yet.
             rawText: richtext.text,
             replyTo: replyTo?.uri,
             images,
@@ -475,6 +486,7 @@ export const ComposePost = ({
       _,
       agent,
       captions,
+      composerState,
       extLink,
       images,
       graphemeLength,

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -120,7 +120,7 @@ import {EmojiArc_Stroke2_Corner0_Rounded as EmojiSmile} from '#/components/icons
 import {TimesLarge_Stroke2_Corner0_Rounded as X} from '#/components/icons/Times'
 import * as Prompt from '#/components/Prompt'
 import {Text as NewText} from '#/components/Typography'
-import {composerReducer,createComposerState} from './state'
+import {composerReducer, createComposerState} from './state'
 
 const MAX_IMAGES = 4
 
@@ -220,9 +220,9 @@ export const ComposePost = ({
   )
 
   // Not used yet.
-  const [composerState, _dispatch] = useReducer(
+  const [composerState, dispatch] = useReducer(
     composerReducer,
-    null,
+    {initImageUris},
     createComposerState,
   )
 
@@ -312,8 +312,12 @@ export const ComposePost = ({
   const onImageAdd = useCallback(
     (next: ComposerImage[]) => {
       setImages(prev => prev.concat(next.slice(0, MAX_IMAGES - prev.length)))
+      dispatch({
+        type: 'embed_add_images',
+        images: next,
+      })
     },
-    [setImages],
+    [setImages, dispatch],
   )
 
   const onPhotoPasted = useCallback(

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -733,7 +733,7 @@ export const ComposePost = ({
             />
           </View>
 
-          <Gallery images={images} onChange={setImages} />
+          <Gallery images={images} onChange={setImages} dispatch={dispatch} />
           {images.length === 0 && extLink && (
             <View style={a.relative}>
               <ExternalEmbed

--- a/src/view/com/composer/photos/Gallery.tsx
+++ b/src/view/com/composer/photos/Gallery.tsx
@@ -21,6 +21,7 @@ import {ComposerImage, cropImage} from '#/state/gallery'
 import {Text} from '#/view/com/util/text/Text'
 import {useTheme} from '#/alf'
 import * as Dialog from '#/components/Dialog'
+import {ComposerAction} from '../state'
 import {EditImageDialog} from './EditImageDialog'
 import {ImageAltTextDialog} from './ImageAltTextDialog'
 
@@ -29,6 +30,7 @@ const IMAGE_GAP = 8
 interface GalleryProps {
   images: ComposerImage[]
   onChange: (next: ComposerImage[]) => void
+  dispatch: (action: ComposerAction) => void
 }
 
 export let Gallery = (props: GalleryProps): React.ReactNode => {
@@ -56,7 +58,12 @@ interface GalleryInnerProps extends GalleryProps {
   containerInfo: Dimensions
 }
 
-const GalleryInner = ({images, containerInfo, onChange}: GalleryInnerProps) => {
+const GalleryInner = ({
+  images,
+  containerInfo,
+  onChange,
+  dispatch,
+}: GalleryInnerProps) => {
   const {isMobile} = useWebMediaQueries()
 
   const {altTextControlStyle, imageControlsStyle, imageStyle} =
@@ -105,6 +112,7 @@ const GalleryInner = ({images, containerInfo, onChange}: GalleryInnerProps) => {
               imageControlsStyle={imageControlsStyle}
               imageStyle={imageStyle}
               onChange={next => {
+                dispatch({type: 'embed_update_image', image: next})
                 onChange(
                   images.map(i => (i.source === image.source ? next : i)),
                 )
@@ -113,6 +121,7 @@ const GalleryInner = ({images, containerInfo, onChange}: GalleryInnerProps) => {
                 const next = images.slice()
                 next.splice(index, 1)
 
+                dispatch({type: 'embed_remove_image', image})
                 onChange(next)
               }}
             />

--- a/src/view/com/composer/photos/Gallery.tsx
+++ b/src/view/com/composer/photos/Gallery.tsx
@@ -29,7 +29,6 @@ const IMAGE_GAP = 8
 
 interface GalleryProps {
   images: ComposerImage[]
-  onChange: (next: ComposerImage[]) => void
   dispatch: (action: ComposerAction) => void
 }
 
@@ -58,12 +57,7 @@ interface GalleryInnerProps extends GalleryProps {
   containerInfo: Dimensions
 }
 
-const GalleryInner = ({
-  images,
-  containerInfo,
-  onChange,
-  dispatch,
-}: GalleryInnerProps) => {
+const GalleryInner = ({images, containerInfo, dispatch}: GalleryInnerProps) => {
   const {isMobile} = useWebMediaQueries()
 
   const {altTextControlStyle, imageControlsStyle, imageStyle} =
@@ -103,7 +97,7 @@ const GalleryInner = ({
   return images.length !== 0 ? (
     <>
       <View testID="selectedPhotosView" style={styles.gallery}>
-        {images.map((image, index) => {
+        {images.map(image => {
           return (
             <GalleryItem
               key={image.source.id}
@@ -113,16 +107,9 @@ const GalleryInner = ({
               imageStyle={imageStyle}
               onChange={next => {
                 dispatch({type: 'embed_update_image', image: next})
-                onChange(
-                  images.map(i => (i.source === image.source ? next : i)),
-                )
               }}
               onRemove={() => {
-                const next = images.slice()
-                next.splice(index, 1)
-
                 dispatch({type: 'embed_remove_image', image})
-                onChange(next)
               }}
             />
           )

--- a/src/view/com/composer/state.ts
+++ b/src/view/com/composer/state.ts
@@ -1,0 +1,42 @@
+import {ComposerImage} from '#/state/gallery'
+
+type PostRecord = {
+  uri: string
+}
+
+type ImagesMedia = {
+  images: ComposerImage[]
+  labels: string[]
+}
+
+type ComposerEmbed = {
+  // TODO: Other record types.
+  record: PostRecord | undefined
+  // TODO: Other media types.
+  media: ImagesMedia | undefined
+}
+
+export type ComposerState = {
+  // TODO: Other draft data.
+  embed: ComposerEmbed
+}
+
+// TODO: Actual actions.
+export type ComposerAction = {type: 'todo'}
+
+export function composerReducer(
+  state: ComposerState,
+  _action: ComposerAction,
+): ComposerState {
+  return state
+}
+
+export function createComposerState(): ComposerState {
+  // TODO: Initial data like images from intent.
+  return {
+    embed: {
+      record: undefined,
+      media: undefined,
+    },
+  }
+}

--- a/src/view/com/composer/state.ts
+++ b/src/view/com/composer/state.ts
@@ -23,7 +23,10 @@ export type ComposerState = {
   embed: ComposerEmbed
 }
 
-export type ComposerAction = {type: 'embed_add_images'; images: ComposerImage[]}
+export type ComposerAction =
+  | {type: 'embed_add_images'; images: ComposerImage[]}
+  | {type: 'embed_update_image'; image: ComposerImage}
+  | {type: 'embed_remove_image'; image: ComposerImage}
 
 const MAX_IMAGES = 4
 
@@ -54,6 +57,52 @@ export function composerReducer(
           media: nextMedia,
         },
       }
+    }
+    case 'embed_update_image': {
+      const prevMedia = state.embed.media
+      if (prevMedia?.type === 'images') {
+        const updatedImage = action.image
+        const nextMedia = {
+          ...prevMedia,
+          images: prevMedia.images.map(img => {
+            if (img.source.id === updatedImage.source.id) {
+              return updatedImage
+            }
+            return img
+          }),
+        }
+        return {
+          ...state,
+          embed: {
+            ...state.embed,
+            media: nextMedia,
+          },
+        }
+      }
+      return state
+    }
+    case 'embed_remove_image': {
+      const prevMedia = state.embed.media
+      if (prevMedia?.type === 'images') {
+        const removedImage = action.image
+        let nextMedia: ImagesMedia | undefined = {
+          ...prevMedia,
+          images: prevMedia.images.filter(img => {
+            return img.source.id !== removedImage.source.id
+          }),
+        }
+        if (nextMedia.images.length === 0) {
+          nextMedia = undefined
+        }
+        return {
+          ...state,
+          embed: {
+            ...state.embed,
+            media: nextMedia,
+          },
+        }
+      }
+      return state
     }
     default:
       return state


### PR DESCRIPTION
Stacked on https://github.com/bluesky-social/social-app/pull/5535.

---

This continues taking apart / adapting https://github.com/bluesky-social/social-app/pull/4163.

Currently, all composer-related state lives in assorted state variables inside the `Composer` component. We're going to need to change this since we need to support composing multiple posts in a thread. So we're going to need to lift state up.

As a first step towards that future, I am adding a reducer for composer state. Reducers are much easier to lift up because we'll be able to index individual posts state by the ID/index of that post. For now, this reducer only manages the `images` state. But similarly to https://github.com/bluesky-social/social-app/pull/4163, I intend to move most composer state there, stacking individual behaviors on top of this PR.

This PR implements enough logic in the reducer that we can delete the `images` state variable completely. However, I haven't changed any surrounding logic to keep the diff small. So the `images` is still being re-derived directly in the component. I will be changing that later.

Note that I've also chosen to diverge from the data model in https://github.com/bluesky-social/social-app/pull/4163. In https://github.com/bluesky-social/social-app/pull/4163, the shape of the composer state tries to mimic the record shape. There are some benefits to that but I find it too clunky (and it's not truly the record shape anyway). Instead, I'm choosing a simpler data structure (an optional record + an optional media embed) which represents the same constraints ("can't have two record embeds") but is easier to update. (This PR does not use the `record` field yet.)

## Test Plan

- Verify adding, editing (alt text, crop), removing images works.
- Verify removing actually does remove the image (on post).
- Verify removing all images creates a post with no images.
- Verify the image limit is respected.
- Verify attaching videos and quotes works like before.
- Verify sharing image from intent works.