### PR TITLE
Tighten up video upload state management

### DIFF
--- a/src/state/queries/video/video.ts
+++ b/src/state/queries/video/video.ts
@@ -38,7 +38,6 @@ export interface State {
   asset?: ImagePickerAsset
   video: CompressedVideo | null
   jobStatus?: AppBskyVideoDefs.JobStatus
-  blobRef?: BlobRef
   error?: string
   abortController: AbortController
   pendingPublish?: {blobRef: BlobRef; mutableProcessed: boolean}
@@ -64,7 +63,6 @@ function reducer(queryClient: QueryClient) {
         status: 'idle',
         progress: 0,
         video: null,
-        blobRef: undefined,
         abortController: new AbortController(),
       }
     } else if (action.type === 'SetAsset') {

--- a/src/state/queries/video/video.ts
+++ b/src/state/queries/video/video.ts
@@ -22,7 +22,7 @@ import {useUploadVideoMutation} from '#/state/queries/video/video-upload'
 type Status = 'idle' | 'compressing' | 'processing' | 'uploading' | 'done'
 
 type Action =
-  | {type: 'SetStatus'; status: Status}
+  | {type: 'SetProcessing'}
   | {type: 'SetProgress'; progress: number}
   | {type: 'SetError'; error: string | undefined}
   | {type: 'Reset'}
@@ -45,8 +45,8 @@ export interface State {
 
 function reducer(state: State, action: Action): State {
   let updatedState = state
-  if (action.type === 'SetStatus') {
-    updatedState = {...state, status: action.status}
+  if (action.type === 'SetProcessing') {
+    updatedState = {...state, status: 'processing'}
   } else if (action.type === 'SetProgress') {
     updatedState = {...state, progress: action.progress}
   } else if (action.type === 'SetError') {
@@ -139,8 +139,7 @@ export function useUploadVideo({
   const {mutate: onVideoCompressed} = useUploadVideoMutation({
     onSuccess: response => {
       dispatch({
-        type: 'SetStatus',
-        status: 'processing',
+        type: 'SetProcessing',
       })
       setJobId(response.jobId)
     },

--- a/src/state/queries/video/video.ts
+++ b/src/state/queries/video/video.ts
@@ -43,8 +43,6 @@ export interface State {
   pendingPublish?: {blobRef: BlobRef; mutableProcessed: boolean}
 }
 
-export type VideoUploadDispatch = (action: Action) => void
-
 function reducer(queryClient: QueryClient) {
   return (state: State, action: Action): State => {
     let updatedState = state
@@ -277,7 +275,6 @@ export function useUploadVideo({
 
   return {
     state,
-    dispatch,
     selectVideo,
     clearVideo,
     updateVideoDimensions,

--- a/src/state/queries/video/video.ts
+++ b/src/state/queries/video/video.ts
@@ -90,6 +90,10 @@ function reducer(state: State, action: Action): State {
   return updatedState
 }
 
+function RQKEY(jobId: string | undefined) {
+  return ['video-status', jobId || '']
+}
+
 export function useUploadVideo({
   setStatus,
   initialVideoUri,
@@ -251,9 +255,11 @@ export function useUploadVideo({
 
   const clearVideo = () => {
     state.abortController.abort()
-    queryClient.cancelQueries({
-      queryKey: ['video'],
-    })
+    if (state.jobId) {
+      queryClient.cancelQueries({
+        queryKey: RQKEY(state.jobId),
+      })
+    }
     dispatch({type: 'Reset'})
   }
 
@@ -301,7 +307,7 @@ const useUploadStatusQuery = ({
   }
 
   const {error} = useQuery({
-    queryKey: ['video', 'upload status', jobId],
+    queryKey: RQKEY(jobId),
     queryFn: async () => {
       if (!jobId) return
 

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -1134,7 +1134,7 @@ function ErrorBanner({
             <ButtonIcon icon={X} />
           </Button>
         </View>
-        {videoError && videoUploadState.jobStatus?.jobId && (
+        {videoError && videoUploadState.jobId && (
           <NewText
             style={[
               {paddingLeft: 28},
@@ -1143,7 +1143,7 @@ function ErrorBanner({
               a.leading_snug,
               t.atoms.text_contrast_low,
             ]}>
-            <Trans>Job ID: {videoUploadState.jobStatus.jobId}</Trans>
+            <Trans>Job ID: {videoUploadState.jobId}</Trans>
           </NewText>
         )}
       </View>

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -84,7 +84,6 @@ import {threadgateViewToAllowUISetting} from '#/state/queries/threadgate/util'
 import {
   State as VideoUploadState,
   useUploadVideo,
-  VideoUploadDispatch,
 } from '#/state/queries/video/video'
 import {useAgent, useSession} from '#/state/session'
 import {useComposerControls} from '#/state/shell/composer'
@@ -194,7 +193,6 @@ export const ComposePost = ({
     clearVideo,
     state: videoUploadState,
     updateVideoDimensions,
-    dispatch: videoUploadDispatch,
   } = useUploadVideo({
     setStatus: setProcessingState,
     onSuccess: () => {
@@ -694,7 +692,7 @@ export const ComposePost = ({
             error={error}
             videoUploadState={videoUploadState}
             clearError={() => setError('')}
-            videoUploadDispatch={videoUploadDispatch}
+            clearVideo={clearVideo}
           />
         </Animated.View>
         <Animated.ScrollView
@@ -1083,12 +1081,12 @@ function ErrorBanner({
   error: standardError,
   videoUploadState,
   clearError,
-  videoUploadDispatch,
+  clearVideo,
 }: {
   error: string
   videoUploadState: VideoUploadState
   clearError: () => void
-  videoUploadDispatch: VideoUploadDispatch
+  clearVideo: () => void
 }) {
   const t = useTheme()
   const {_} = useLingui()
@@ -1101,7 +1099,7 @@ function ErrorBanner({
     if (standardError) {
       clearError()
     } else {
-      videoUploadDispatch({type: 'Reset'})
+      clearVideo()
     }
   }
 


### PR DESCRIPTION
This is related to the stream of work in https://github.com/bluesky-social/social-app/pull/5547. We want to aim towards making video state a part of the composer reducer. At least in some way. Syncing two different reducers is tricky so I'm hoping I can actually unify them in the future.

For now, I want to reduce the complexity of the video reducer a little bit. This is an assorted set of tweaks.

- c3789de6eb469aa7464d759b2c3d140fa5e83ba8: Removing dead code.
- a3aa41238b7807b85fa2ee24c5a6aed872039b55: Exposing the inner `dispatch` of the video reducer is unnecessary because we already expose an equivalent method called `clearVideo` which does `dispatch({ type: 'Reset' })` internally. Let's use that instead in the remaining callsite. This isn't strictly necessary now but I'm doing it so that in the future we can switch to composer's `dispatch`.
- [`bfd4874`?w=1](https://github.com/bluesky-social/social-app/pull/5551/commits/bfd4874a8197699d93b4c69b5fc767f0006bc466?w=1): We shouldn't write side effects in reducers. Now that there's only one place from which `dispatch({ type: 'Reset' })` can happen, we move this code into that method. The reducer no longer needs `queryClient`.
- ea254e132f78b43ada01d64a7b53ccf02ac34cd7: I want to move `jobId` into the reducer state later, so let's pull it out of the hook. I've added some logic to reset `setEnabled` when new `jobId` comes in which should be equivalent to the earlier method which did this by hand.
- 68e35bdfc5dbe53c7fbdd0ff51a134e208e2ab98: Notice this is the only `SetStatus` callsite. Let's make it more concrete.
- 50287fd40a9c89c78601cd131bd49d6aa91dfb10: Thanks to the above preparations, we can now move `jobId` itself into the video reducer state.
- d31c736eafb3ccae2a00f9fdf613ce8d849046d9: This makes query cancellation scoped. We'll need this for the thread composer in the future because it could have multiple videos (in multiple posts) uploading at the same time.

## Test Plan

Upload some videos, cancel upload at different points, there should be no changes in behavior. Verify you're able to remove an uploaded video and upload a different video instead. Turn off the internet during upload to trigger error cases.

This should basically work like before, but the code is tightened up a bit.