### PR TITLE
Include ghost hook to statically export fonts

### DIFF
--- a/src/alf/fonts.ts
+++ b/src/alf/fonts.ts
@@ -1,3 +1,5 @@
+import {useFonts} from 'expo-font'
+
 import {isWeb} from '#/platform/detection'
 import {Device, device} from '#/storage'
 
@@ -62,4 +64,16 @@ export function applyFonts(
    * {@link https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant}
    */
   style.fontVariant = ['no-contextual']
+}
+
+/*
+ * IMPORTANT: This is unused. Expo statically extracts these fonts.
+ *
+ * All used fonts MUST be configured here. Unused fonts can be commented out.
+ */
+export function DO_NOT_USE() {
+  return useFonts({
+    InterVariable: require('../../assets/fonts/inter/InterVariable.ttf'),
+    'InterVariable-Italic': require('../../assets/fonts/inter/InterVariable-Italic.ttf'),
+  })
 }


### PR DESCRIPTION
We use `expo export` when building for OTA updates. The although the `expo-font` plugin works for production builds, the `export` CLI command does not use the plugin config, and therefore does not output our font files for use in the OTA bundle.

The `useFonts` hook here ensures that the fonts are exported for native OTA, even though it is not otherwise used.