### PR TITLE
Fix follower count truncation

### DIFF
--- a/src/view/com/util/numeric/format.ts
+++ b/src/view/com/util/numeric/format.ts
@@ -2,9 +2,7 @@ import type {I18n} from '@lingui/core'
 
 import {isWeb} from '#/platform/detection'
 
-// `@formatjs/intl-numberformat/polyfill` doesn't support `roundingMode`, and
-// we'd ideally want `roundingMode: trunc` to properly display shortened counts
-// without it being rounded up, which can be misleading for follower count.
+// `@formatjs/intl-numberformat/polyfill` doesn't support `roundingMode`
 const truncateRounding = (num: number): number => {
   if (num < 1_000) {
     return num
@@ -21,6 +19,8 @@ export const formatCount = (i18n: I18n, num: number) => {
     notation: 'compact',
     maximumFractionDigits: 1,
     // `1,953` shouldn't be rounded up to 2k, it should be truncated.
+    // @ts-expect-error: `roundingMode` doesn't seem to be in the typings yet
+    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#roundingmode
     roundingMode: 'trunc',
   })
 }

--- a/src/view/com/util/numeric/format.ts
+++ b/src/view/com/util/numeric/format.ts
@@ -1,12 +1,26 @@
 import type {I18n} from '@lingui/core'
 
+import {isWeb} from '#/platform/detection'
+
+// `@formatjs/intl-numberformat/polyfill` doesn't support `roundingMode`, and
+// we'd ideally want `roundingMode: trunc` to properly display shortened counts
+// without it being rounded up, which can be misleading for follower count.
+const truncateRounding = (num: number): number => {
+  if (num < 1_000) {
+    return num
+  }
+
+  const factor = Math.floor((Math.log10(num) - 3) / 3) * 3 + 2
+  const pow = 10 ** factor
+
+  return Math.trunc(num / pow) * pow
+}
+
 export const formatCount = (i18n: I18n, num: number) => {
-  return i18n.number(num, {
+  return i18n.number(isWeb ? num : truncateRounding(num), {
     notation: 'compact',
     maximumFractionDigits: 1,
     // `1,953` shouldn't be rounded up to 2k, it should be truncated.
-    // @ts-expect-error: `roundingMode` doesn't seem to be in the typings yet
-    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#roundingmode
     roundingMode: 'trunc',
   })
 }


### PR DESCRIPTION
Fixes https://github.com/bluesky-social/social-app/issues/5538

On mobile, apply our own truncation since NumberFormat polyfill doesn't support roundingMode option.

This may look wrong on some locales like JP locale where numbers get displayed weirdly (e.g. 5083801 -> 5M / 508.3万), perhaps we should just apply it to web as well?

From brief testing, this truncation should work up to 999\_999\_999\_999\_997, I don't think anyone will reach this value.