### PR TITLE
Manage video reducer from composer reducer

### DIFF
--- a/src/state/queries/video/video.ts
+++ b/src/state/queries/video/video.ts
@@ -17,7 +17,6 @@ import {createVideoAgent} from '#/state/queries/video/util'
 import {uploadVideo} from '#/state/queries/video/video-upload'
 
 export type VideoAction =
-  | {type: 'to_idle'; nextController: AbortController}
   | {
       type: 'idle_to_compressing'
       asset: ImagePickerAsset
@@ -136,9 +135,6 @@ export function videoReducer(
   state: VideoState,
   action: VideoAction,
 ): VideoState {
-  if (action.type === 'to_idle') {
-    return createVideoState(action.nextController)
-  }
   if (action.signal.aborted || action.signal !== state.abortController.signal) {
     // This action is stale and the process that spawned it is no longer relevant.
     return state

--- a/src/state/queries/video/video.ts
+++ b/src/state/queries/video/video.ts
@@ -16,7 +16,7 @@ import {logger} from '#/logger'
 import {createVideoAgent} from '#/state/queries/video/util'
 import {uploadVideo} from '#/state/queries/video/video-upload'
 
-type Action =
+export type VideoAction =
   | {type: 'to_idle'; nextController: AbortController}
   | {
       type: 'idle_to_compressing'
@@ -114,7 +114,7 @@ type DoneState = {
   pendingPublish: {blobRef: BlobRef; mutableProcessed: boolean}
 }
 
-export type State =
+export type VideoState =
   | IdleState
   | ErrorState
   | CompressingState
@@ -132,7 +132,10 @@ export function createVideoState(
   }
 }
 
-export function videoReducer(state: State, action: Action): State {
+export function videoReducer(
+  state: VideoState,
+  action: VideoAction,
+): VideoState {
   if (action.type === 'to_idle') {
     return createVideoState(action.nextController)
   }
@@ -238,7 +241,7 @@ function trunc2dp(num: number) {
 
 export async function processVideo(
   asset: ImagePickerAsset,
-  dispatch: (action: Action) => void,
+  dispatch: (action: VideoAction) => void,
   agent: BskyAgent,
   did: string,
   signal: AbortSignal,

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -866,7 +866,7 @@ export const ComposePost = ({
               />
               <SelectVideoBtn
                 onSelectVideo={selectVideo}
-                disabled={!canSelectImages}
+                disabled={!canSelectImages || images?.length > 0}
                 setError={setError}
               />
               <OpenCameraBtn disabled={!canSelectImages} onAdd={onImageAdd} />

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -46,6 +46,7 @@ import {RichText} from '@atproto/api'
 import {FontAwesomeIcon} from '@fortawesome/react-native-fontawesome'
 import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
+import {createVideoState} from '#/state/queries/video/video'
 
 import * as apilib from '#/lib/api/index'
 import {until} from '#/lib/async/until'
@@ -85,6 +86,7 @@ import {threadgateViewToAllowUISetting} from '#/state/queries/threadgate/util'
 import {
   processVideo,
   VideoAction,
+  VideoState,
   VideoState as VideoUploadState,
 } from '#/state/queries/video/video'
 import {useAgent, useSession} from '#/state/session'
@@ -130,6 +132,7 @@ type CancelRef = {
 }
 
 const NO_IMAGES: ComposerImage[] = []
+const NO_VIDEO = createVideoState()
 
 type Props = ComposerOpts
 export const ComposePost = ({
@@ -198,10 +201,13 @@ export const ComposePost = ({
     createComposerState,
   )
 
-  const videoUploadState = composerState.video
+  let videoUploadState: VideoState = NO_VIDEO
+  if (composerState.embed.media?.type === 'video') {
+    videoUploadState = composerState.embed.media.video
+  }
   const videoDispatch = useCallback(
     (videoAction: VideoAction) => {
-      dispatch({type: 'video_action', videoAction})
+      dispatch({type: 'embed_update_video', videoAction})
     },
     [dispatch],
   )

--- a/src/view/com/composer/state.ts
+++ b/src/view/com/composer/state.ts
@@ -1,4 +1,10 @@
 import {ComposerImage, createInitialImages} from '#/state/gallery'
+import {
+  createVideoState,
+  VideoAction,
+  videoReducer,
+  VideoState,
+} from '#/state/queries/video/video'
 import {ComposerOpts} from '#/state/shell/composer'
 
 type PostRecord = {
@@ -21,12 +27,14 @@ type ComposerEmbed = {
 export type ComposerState = {
   // TODO: Other draft data.
   embed: ComposerEmbed
+  video: VideoState // TODO: Move into embed.
 }
 
 export type ComposerAction =
   | {type: 'embed_add_images'; images: ComposerImage[]}
   | {type: 'embed_update_image'; image: ComposerImage}
   | {type: 'embed_remove_image'; image: ComposerImage}
+  | {type: 'video_action'; videoAction: VideoAction}
 
 const MAX_IMAGES = 4
 
@@ -104,6 +112,13 @@ export function composerReducer(
       }
       return state
     }
+    case 'video_action': {
+      const videoAction = action.videoAction
+      return {
+        ...state,
+        video: videoReducer(state.video, videoAction),
+      }
+    }
     default:
       return state
   }
@@ -123,6 +138,7 @@ export function createComposerState({
     }
   }
   return {
+    video: createVideoState(), // TODO: Move into embed.
     embed: {
       record: undefined,
       media,

--- a/src/view/com/composer/state.ts
+++ b/src/view/com/composer/state.ts
@@ -56,6 +56,9 @@ export function composerReducer(
 ): ComposerState {
   switch (action.type) {
     case 'embed_add_images': {
+      if (action.images.length === 0) {
+        return state
+      }
       const prevMedia = state.embed.media
       let nextMedia = prevMedia
       if (!prevMedia) {


### PR DESCRIPTION
In https://github.com/bluesky-social/social-app/pull/5547, I introduced a reducer for composer state management. Over time, we want to move the rest of meaningful composer state there so that we can later lift it up and make it work for multiple threaded posts. In https://github.com/bluesky-social/social-app/pull/5547 I started with managing the image state there. In this PR, I'm extending this approach to also handle videos.

Integrating videos into the reducer was a bit tricky because they were managed by a custom hook with a combination of React Query and a separate reducer. So there was no easy way to let that state be controlled. To fix this, I've refactored video state management in https://github.com/bluesky-social/social-app/pull/5570 to just be a plain reducer. Why? Because plain reducers compose.

In this PR, the way the video reducer is integrated has changed. Previously, it was given to `useReducer`. Now, the videos reducer is called/composed from the composer reducer. Note how it's not always "there": its state gets created when you add the video embed, and gets destroyed when you remove the video embed. (To do this, I've made the `idle` state represent the lack of a video, and excluded it from the state union.) It always starts its life in the `compressing` state now.

Note how the video actions are now "packed" inside the composer actions. That's composition again.

## Test Plan

Add/remove images. Add/remove video. Should work like before.

One consequence of better modeling is that now we can't add a video while we have images. (Previously the composer would let you do that but would silently omit images on post.) Since the action being (correctly) ignored is confusing, I've added greying out of the "add video" button when images are selected.