### PR TITLE
Track links and embeds in the composer reducer

### DIFF
--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -190,7 +190,7 @@ export const ComposePost = ({
   // TODO: Move more state here.
   const [composerState, dispatch] = useReducer(
     composerReducer,
-    {initImageUris},
+    {initImageUris, initQuoteUri: initQuote?.uri},
     createComposerState,
   )
 

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -337,9 +337,9 @@ export const ComposePost = ({
 
   const onNewLink = useCallback(
     (uri: string) => {
+      dispatch({type: 'embed_add_uri', uri})
       if (extLink != null) return
       setExtLink({uri, isLoading: true})
-      dispatch({type: 'embed_add_uri', uri})
     },
     [extLink, setExtLink],
   )

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -339,6 +339,7 @@ export const ComposePost = ({
     (uri: string) => {
       if (extLink != null) return
       setExtLink({uri, isLoading: true})
+      dispatch({type: 'embed_add_uri', uri})
     },
     [extLink, setExtLink],
   )
@@ -582,6 +583,7 @@ export const ComposePost = ({
 
   const onSelectGif = useCallback(
     (gif: Gif) => {
+      dispatch({type: 'embed_add_gif', gif})
       setExtLink({
         uri: `${gif.media_formats.gif.url}?hh=${gif.media_formats.gif.dims[1]}&ww=${gif.media_formats.gif.dims[0]}`,
         isLoading: true,
@@ -600,6 +602,7 @@ export const ComposePost = ({
 
   const handleChangeGifAltText = useCallback(
     (altText: string) => {
+      dispatch({type: 'embed_update_gif', alt: altText})
       setExtLink(ext =>
         ext && ext.meta
           ? {
@@ -770,6 +773,11 @@ export const ComposePost = ({
                 link={extLink}
                 gif={extGif}
                 onRemove={() => {
+                  if (extGif) {
+                    dispatch({type: 'embed_remove_gif'})
+                  } else {
+                    dispatch({type: 'embed_remove_link'})
+                  }
                   setExtLink(undefined)
                   setExtGif(undefined)
                 }}
@@ -818,7 +826,12 @@ export const ComposePost = ({
                   <QuoteEmbed quote={quote} />
                 </View>
                 {quote.uri !== initQuote?.uri && (
-                  <QuoteX onRemove={() => setQuote(undefined)} />
+                  <QuoteX
+                    onRemove={() => {
+                      dispatch({type: 'embed_remove_quote'})
+                      setQuote(undefined)
+                    }}
+                  />
                 )}
               </View>
             ) : null}

--- a/src/view/com/composer/state/composer.ts
+++ b/src/view/com/composer/state/composer.ts
@@ -217,8 +217,10 @@ export function composerReducer(
 
 export function createComposerState({
   initImageUris,
+  initQuoteUri,
 }: {
   initImageUris: ComposerOpts['imageUris']
+  initQuoteUri: string | undefined
 }): ComposerState {
   let media: ImagesMedia | undefined
   if (initImageUris?.length) {
@@ -227,12 +229,19 @@ export function createComposerState({
       images: createInitialImages(initImageUris),
     }
   }
+  let quote: Link | undefined
+  if (initQuoteUri) {
+    quote = {
+      type: 'link',
+      uri: initQuoteUri,
+    }
+  }
   // TODO: Other initial content.
   return {
     embed: {
-      quote: undefined,
-      link: undefined,
+      quote,
       media,
+      link: undefined,
     },
   }
 }

--- a/src/view/com/composer/state/composer.ts
+++ b/src/view/com/composer/state/composer.ts
@@ -1,5 +1,6 @@
 import {ImagePickerAsset} from 'expo-image-picker'
 
+import {isBskyPostUrl} from '#/lib/strings/url-helpers'
 import {ComposerImage, createInitialImages} from '#/state/gallery'
 import {Gif} from '#/state/queries/tenor'
 import {ComposerOpts} from '#/state/shell/composer'
@@ -187,28 +188,100 @@ export function composerReducer(
       }
     }
     case 'embed_add_uri': {
-      // TODO
-      return state
+      const prevQuote = state.embed.quote
+      const prevLink = state.embed.link
+      let nextQuote = prevQuote
+      let nextLink = prevLink
+      if (isBskyPostUrl(action.uri)) {
+        if (!prevQuote) {
+          nextQuote = {
+            type: 'link',
+            uri: action.uri,
+          }
+        }
+      } else {
+        if (!prevLink) {
+          nextLink = {
+            type: 'link',
+            uri: action.uri,
+          }
+        }
+      }
+      return {
+        ...state,
+        embed: {
+          ...state.embed,
+          quote: nextQuote,
+          link: nextLink,
+        },
+      }
     }
     case 'embed_remove_link': {
-      // TODO
-      return state
+      return {
+        ...state,
+        embed: {
+          ...state.embed,
+          link: undefined,
+        },
+      }
     }
     case 'embed_remove_quote': {
-      // TODO
-      return state
+      return {
+        ...state,
+        embed: {
+          ...state.embed,
+          quote: undefined,
+        },
+      }
     }
     case 'embed_add_gif': {
-      // TODO
-      return state
+      const prevMedia = state.embed.media
+      let nextMedia = prevMedia
+      if (!prevMedia) {
+        nextMedia = {
+          type: 'gif',
+          gif: action.gif,
+          alt: '',
+        }
+      }
+      return {
+        ...state,
+        embed: {
+          ...state.embed,
+          media: nextMedia,
+        },
+      }
     }
     case 'embed_update_gif': {
-      // TODO
-      return state
+      const prevMedia = state.embed.media
+      let nextMedia = prevMedia
+      if (prevMedia?.type === 'gif') {
+        nextMedia = {
+          ...prevMedia,
+          alt: action.alt,
+        }
+      }
+      return {
+        ...state,
+        embed: {
+          ...state.embed,
+          media: nextMedia,
+        },
+      }
     }
     case 'embed_remove_gif': {
-      // TODO
-      return state
+      const prevMedia = state.embed.media
+      let nextMedia = prevMedia
+      if (prevMedia?.type === 'gif') {
+        nextMedia = undefined
+      }
+      return {
+        ...state,
+        embed: {
+          ...state.embed,
+          media: nextMedia,
+        },
+      }
     }
     default:
       return state

--- a/src/view/com/composer/state/composer.ts
+++ b/src/view/com/composer/state/composer.ts
@@ -1,17 +1,13 @@
 import {ImagePickerAsset} from 'expo-image-picker'
 
 import {ComposerImage, createInitialImages} from '#/state/gallery'
+import {Gif} from '#/state/queries/tenor'
 import {ComposerOpts} from '#/state/shell/composer'
 import {createVideoState, VideoAction, videoReducer, VideoState} from './video'
-
-type PostRecord = {
-  uri: string
-}
 
 type ImagesMedia = {
   type: 'images'
   images: ComposerImage[]
-  labels: string[]
 }
 
 type VideoMedia = {
@@ -19,16 +15,30 @@ type VideoMedia = {
   video: VideoState
 }
 
-type ComposerEmbed = {
-  // TODO: Other record types.
-  record: PostRecord | undefined
-  // TODO: Other media types.
-  media: ImagesMedia | VideoMedia | undefined
+type GifMedia = {
+  type: 'gif'
+  gif: Gif
+  alt: string
+}
+
+type Link = {
+  type: 'link'
+  uri: string
+}
+
+// This structure doesn't exactly correspond to the data model.
+// Instead, it maps to how the UI is organized, and how we present a post.
+type EmbedDraft = {
+  // We'll always submit quote and actual media (images, video, gifs) chosen by the user.
+  quote: Link | undefined
+  media: ImagesMedia | VideoMedia | GifMedia | undefined
+  // This field may end up ignored if we have more important things to display than a link card:
+  link: Link | undefined
 }
 
 export type ComposerState = {
   // TODO: Other draft data.
-  embed: ComposerEmbed
+  embed: EmbedDraft
 }
 
 export type ComposerAction =
@@ -42,6 +52,12 @@ export type ComposerAction =
     }
   | {type: 'embed_remove_video'}
   | {type: 'embed_update_video'; videoAction: VideoAction}
+  | {type: 'embed_add_uri'; uri: string}
+  | {type: 'embed_remove_quote'}
+  | {type: 'embed_remove_link'}
+  | {type: 'embed_add_gif'; gif: Gif}
+  | {type: 'embed_update_gif'; alt: string}
+  | {type: 'embed_remove_gif'}
 
 const MAX_IMAGES = 4
 
@@ -60,7 +76,6 @@ export function composerReducer(
         nextMedia = {
           type: 'images',
           images: action.images.slice(0, MAX_IMAGES),
-          labels: [],
         }
       } else if (prevMedia.type === 'images') {
         nextMedia = {
@@ -171,6 +186,30 @@ export function composerReducer(
         },
       }
     }
+    case 'embed_add_uri': {
+      // TODO
+      return state
+    }
+    case 'embed_remove_link': {
+      // TODO
+      return state
+    }
+    case 'embed_remove_quote': {
+      // TODO
+      return state
+    }
+    case 'embed_add_gif': {
+      // TODO
+      return state
+    }
+    case 'embed_update_gif': {
+      // TODO
+      return state
+    }
+    case 'embed_remove_gif': {
+      // TODO
+      return state
+    }
     default:
       return state
   }
@@ -186,13 +225,13 @@ export function createComposerState({
     media = {
       type: 'images',
       images: createInitialImages(initImageUris),
-      labels: [],
     }
   }
-  // TODO: initial video.
+  // TODO: Other initial content.
   return {
     embed: {
-      record: undefined,
+      quote: undefined,
+      link: undefined,
       media,
     },
   }


### PR DESCRIPTION
This adds tracking of remaining embed/media types to the composer reducer.

They're not being used for anything yet, but you should roughly expect their state to mirror how the composer works today. (There are also some improvements. For example, pasting a quote link after a regular link will correctly mark a quote in the reducer state, whereas the old composer logic was not able to handle that.)

In future PRs, I will be making this the source of truth for two things:

- Composer preview
- Publishing a post

However we're missing some pieces to be able to do that, so for now it's not connected yet.

Note that in the draft, we don't distinguish between different types of links (other than quote/other distinction). This is because they're only relevant for preview and for posting. They're not important in the draft data model because the reducer behavior ("which field gets replaced by which field in which cases") doesn't care about the contents of the link beyond that.

## Test Plan

Add `console.log(composerState)` to `Composer.tsx`. Verify the `composerState.embed` fields evolve as you'd expect when you add GIF, add/remove media, paste links, remove GIF, remove links, etc.