### PR TITLE
Add alt text limit to image dialog

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -50,7 +50,7 @@ export const MAX_DM_GRAPHEME_LENGTH = 1000
 
 // Recommended is 100 per: https://www.w3.org/WAI/GL/WCAG20/tests/test3.html
 // but increasing limit per user feedback
-export const MAX_ALT_TEXT = 1000
+export const MAX_ALT_TEXT = 2000
 
 export function IS_TEST_USER(handle?: string) {
   return handle && handle?.endsWith('.test')

--- a/src/view/com/composer/AltTextCounterWrapper.tsx
+++ b/src/view/com/composer/AltTextCounterWrapper.tsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import {View} from 'react-native'
+
+import {MAX_ALT_TEXT} from '#/lib/constants'
+import {CharProgress} from '#/view/com/composer/char-progress/CharProgress'
+import {atoms as a, useTheme} from '#/alf'
+
+export function AltTextCounterWrapper({
+  altText,
+  children,
+}: {
+  altText?: string
+  children: React.ReactNode
+}) {
+  const t = useTheme()
+  return (
+    <View style={[a.flex_row]}>
+      <CharProgress
+        style={[
+          a.flex_col_reverse,
+          a.align_center,
+          a.mr_xs,
+          {minWidth: 50, gap: 1},
+        ]}
+        textStyle={[{marginRight: 0}, a.text_sm, t.atoms.text_contrast_medium]}
+        size={26}
+        count={altText?.length || 0}
+        max={MAX_ALT_TEXT}
+      />
+      {children}
+    </View>
+  )
+}

--- a/src/view/com/composer/GifAltText.tsx
+++ b/src/view/com/composer/GifAltText.tsx
@@ -14,11 +14,13 @@ import {
 import {enforceLen} from '#/lib/strings/helpers'
 import {isAndroid} from '#/platform/detection'
 import {Gif} from '#/state/queries/tenor'
+import {CharProgress} from '#/view/com/composer/char-progress/CharProgress'
 import {atoms as a, native, useTheme} from '#/alf'
 import {Button, ButtonText} from '#/components/Button'
 import * as Dialog from '#/components/Dialog'
 import * as TextField from '#/components/forms/TextField'
 import {Check_Stroke2_Corner0_Rounded as Check} from '#/components/icons/Check'
+import {CircleInfo_Stroke2_Corner0_Rounded as CircleInfo} from '#/components/icons/CircleInfo'
 import {PlusSmall_Stroke2_Corner0_Rounded as Plus} from '#/components/icons/Plus'
 import {PortalComponent} from '#/components/Portal'
 import {Text} from '#/components/Typography'
@@ -124,7 +126,8 @@ function AltTextInner({
   params: EmbedPlayerParams
   initialValue: string
 }) {
-  const {_} = useLingui()
+  const t = useTheme()
+  const {_, i18n} = useLingui()
   const [altText, setAltText] = useState(initalValue)
   const control = Dialog.useDialogContext()
 
@@ -136,29 +139,64 @@ function AltTextInner({
     <Dialog.ScrollableInner label={_(msg`Add alt text`)}>
       <View style={a.flex_col_reverse}>
         <View style={[a.mt_md, a.gap_md]}>
-          <View>
-            <TextField.LabelText>
-              <Trans>Descriptive alt text</Trans>
-            </TextField.LabelText>
-            <TextField.Root>
-              <Dialog.Input
-                label={_(msg`Alt text`)}
-                placeholder={link.title}
-                onChangeText={text =>
-                  setAltText(enforceLen(text, MAX_ALT_TEXT))
-                }
-                value={altText}
-                multiline
-                numberOfLines={3}
-                autoFocus
-                onKeyPress={({nativeEvent}) => {
-                  if (nativeEvent.key === 'Escape') {
-                    control.close()
+          <View style={[a.gap_sm]}>
+            <View style={[a.relative]}>
+              <TextField.LabelText>
+                <Trans>Descriptive alt text</Trans>
+              </TextField.LabelText>
+              <TextField.Root>
+                <Dialog.Input
+                  label={_(msg`Alt text`)}
+                  placeholder={link.title}
+                  onChangeText={text =>
+                    setAltText(enforceLen(text, MAX_ALT_TEXT))
                   }
-                }}
-              />
-            </TextField.Root>
+                  value={altText}
+                  multiline
+                  numberOfLines={3}
+                  autoFocus
+                  onKeyPress={({nativeEvent}) => {
+                    if (nativeEvent.key === 'Escape') {
+                      control.close()
+                    }
+                  }}
+                />
+              </TextField.Root>
+
+              <View
+                style={[
+                  a.absolute,
+                  a.flex_row,
+                  a.align_center,
+                  a.pr_md,
+                  a.pb_sm,
+                  {
+                    bottom: 0,
+                    right: 0,
+                  },
+                ]}>
+                <CharProgress count={altText?.length || 0} max={MAX_ALT_TEXT} />
+              </View>
+            </View>
+
+            {altText.length > MAX_ALT_TEXT && (
+              <View style={[a.pb_sm, a.flex_row, a.gap_xs]}>
+                <CircleInfo fill={t.palette.negative_500} />
+                <Text
+                  style={[
+                    a.italic,
+                    a.leading_snug,
+                    t.atoms.text_contrast_medium,
+                  ]}>
+                  <Trans>
+                    Alt text will be truncated. Limit:{' '}
+                    {i18n.number(MAX_ALT_TEXT)} characters.
+                  </Trans>
+                </Text>
+              </View>
+            )}
           </View>
+
           <Button
             label={_(msg`Save`)}
             size="large"

--- a/src/view/com/composer/GifAltText.tsx
+++ b/src/view/com/composer/GifAltText.tsx
@@ -132,7 +132,7 @@ function AltTextInner({
   const control = Dialog.useDialogContext()
 
   const onPressSubmit = useCallback(() => {
-    onSubmit(altText)
+    onSubmit(enforceLen(altText, MAX_ALT_TEXT, true))
   }, [onSubmit, altText])
 
   return (
@@ -148,9 +148,7 @@ function AltTextInner({
                 <Dialog.Input
                   label={_(msg`Alt text`)}
                   placeholder={link.title}
-                  onChangeText={text =>
-                    setAltText(enforceLen(text, MAX_ALT_TEXT))
-                  }
+                  onChangeText={text => setAltText(text)}
                   value={altText}
                   multiline
                   numberOfLines={3}

--- a/src/view/com/composer/GifAltText.tsx
+++ b/src/view/com/composer/GifAltText.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useState} from 'react'
+import React, {useState} from 'react'
 import {TouchableOpacity, View} from 'react-native'
 import {AppBskyEmbedExternal} from '@atproto/api'
 import {msg, Trans} from '@lingui/macro'
@@ -11,13 +11,13 @@ import {
   EmbedPlayerParams,
   parseEmbedPlayerFromUrl,
 } from '#/lib/strings/embed-player'
-import {enforceLen} from '#/lib/strings/helpers'
 import {isAndroid} from '#/platform/detection'
 import {Gif} from '#/state/queries/tenor'
 import {AltTextCounterWrapper} from '#/view/com/composer/AltTextCounterWrapper'
 import {atoms as a, native, useTheme} from '#/alf'
 import {Button, ButtonText} from '#/components/Button'
 import * as Dialog from '#/components/Dialog'
+import {DialogControlProps} from '#/components/Dialog'
 import * as TextField from '#/components/forms/TextField'
 import {Check_Stroke2_Corner0_Rounded as Check} from '#/components/icons/Check'
 import {CircleInfo_Stroke2_Corner0_Rounded as CircleInfo} from '#/components/icons/CircleInfo'
@@ -53,15 +53,6 @@ export function GifAltText({
       params: parseEmbedPlayerFromUrl(linkProp.uri),
     }
   }, [linkProp])
-
-  const onPressSubmit = useCallback(
-    (alt: string) => {
-      control.close(() => {
-        onSubmit(alt)
-      })
-    },
-    [onSubmit, control],
-  )
 
   const parsedAlt = parseAltFromGIFDescription(link.description)
   const altTextRef = React.useRef<string>('')
@@ -112,10 +103,9 @@ export function GifAltText({
         <Dialog.Handle />
         <AltTextInner
           altTextRef={altTextRef}
-          onSubmit={onPressSubmit}
+          control={control}
           link={link}
           params={params}
-          initialValue={parsedAlt.isPreferred ? parsedAlt.alt : ''}
           key={link.uri}
         />
       </Dialog.Outer>
@@ -125,25 +115,18 @@ export function GifAltText({
 
 function AltTextInner({
   altTextRef,
-  onSubmit,
+  control,
   link,
   params,
-  initialValue: initalValue,
 }: {
   altTextRef: React.MutableRefObject<string>
-  onSubmit: (text: string) => void
+  control: DialogControlProps
   link: AppBskyEmbedExternal.ViewExternal
   params: EmbedPlayerParams
-  initialValue: string
 }) {
   const t = useTheme()
   const {_, i18n} = useLingui()
-  const [altText, setAltText] = useState(initalValue)
-  const control = Dialog.useDialogContext()
-
-  const onPressSubmit = useCallback(() => {
-    onSubmit(enforceLen(altText, MAX_ALT_TEXT, true))
-  }, [onSubmit, altText])
+  const [altText, setAltText] = useState(altTextRef.current)
 
   return (
     <Dialog.ScrollableInner label={_(msg`Add alt text`)}>
@@ -199,7 +182,9 @@ function AltTextInner({
               size="large"
               color="primary"
               variant="solid"
-              onPress={onPressSubmit}
+              onPress={() => {
+                control.close()
+              }}
               style={[a.flex_grow]}>
               <ButtonText>
                 <Trans>Save</Trans>

--- a/src/view/com/composer/GifAltText.tsx
+++ b/src/view/com/composer/GifAltText.tsx
@@ -146,7 +146,7 @@ function AltTextInner({
                   onChangeText={text => {
                     setAltText(text)
                   }}
-                  value={altText}
+                  defaultValue={altText}
                   multiline
                   numberOfLines={3}
                   autoFocus

--- a/src/view/com/composer/GifAltText.tsx
+++ b/src/view/com/composer/GifAltText.tsx
@@ -55,7 +55,7 @@ export function GifAltText({
   }, [linkProp])
 
   const parsedAlt = parseAltFromGIFDescription(link.description)
-  const altTextRef = React.useRef<string>('')
+  const [altText, setAltText] = useState(parsedAlt.alt)
 
   if (!gif || !params) return null
 
@@ -97,12 +97,13 @@ export function GifAltText({
       <Dialog.Outer
         control={control}
         onClose={() => {
-          onSubmit(altTextRef.current)
+          onSubmit(altText)
         }}
         Portal={Portal}>
         <Dialog.Handle />
         <AltTextInner
-          altTextRef={altTextRef}
+          altText={altText}
+          setAltText={setAltText}
           control={control}
           link={link}
           params={params}
@@ -114,19 +115,20 @@ export function GifAltText({
 }
 
 function AltTextInner({
-  altTextRef,
+  altText,
+  setAltText,
   control,
   link,
   params,
 }: {
-  altTextRef: React.MutableRefObject<string>
+  altText: string
+  setAltText: (text: string) => void
   control: DialogControlProps
   link: AppBskyEmbedExternal.ViewExternal
   params: EmbedPlayerParams
 }) {
   const t = useTheme()
   const {_, i18n} = useLingui()
-  const [altText, setAltText] = useState(altTextRef.current)
 
   return (
     <Dialog.ScrollableInner label={_(msg`Add alt text`)}>
@@ -142,7 +144,6 @@ function AltTextInner({
                   label={_(msg`Alt text`)}
                   placeholder={link.title}
                   onChangeText={text => {
-                    altTextRef.current = text
                     setAltText(text)
                   }}
                   value={altText}

--- a/src/view/com/composer/char-progress/CharProgress.tsx
+++ b/src/view/com/composer/char-progress/CharProgress.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import {View} from 'react-native'
+import {StyleProp, TextStyle, View, ViewStyle} from 'react-native'
 // @ts-ignore no type definition -prf
 import ProgressCircle from 'react-native-progress/Circle'
 // @ts-ignore no type definition -prf
@@ -10,20 +10,32 @@ import {usePalette} from '#/lib/hooks/usePalette'
 import {s} from '#/lib/styles'
 import {Text} from '../../util/text/Text'
 
-export function CharProgress({count, max}: {count: number; max?: number}) {
+export function CharProgress({
+  count,
+  max,
+  style,
+  textStyle,
+  size,
+}: {
+  count: number
+  max?: number
+  style?: StyleProp<ViewStyle>
+  textStyle?: StyleProp<TextStyle>
+  size?: number
+}) {
   const maxLength = max || MAX_GRAPHEME_LENGTH
   const pal = usePalette('default')
   const textColor = count > maxLength ? '#e60000' : pal.colors.text
   const circleColor = count > maxLength ? '#e60000' : pal.colors.link
   return (
-    <>
-      <Text style={[s.mr10, s.tabularNum, {color: textColor}]}>
+    <View style={style}>
+      <Text style={[s.mr10, s.tabularNum, {color: textColor}, textStyle]}>
         {maxLength - count}
       </Text>
       <View>
         {count > maxLength ? (
           <ProgressPie
-            size={30}
+            size={size ?? 30}
             borderWidth={4}
             borderColor={circleColor}
             color={circleColor}
@@ -31,7 +43,7 @@ export function CharProgress({count, max}: {count: number; max?: number}) {
           />
         ) : (
           <ProgressCircle
-            size={30}
+            size={size ?? 30}
             borderWidth={1}
             borderColor={pal.colors.border}
             color={circleColor}
@@ -39,6 +51,6 @@ export function CharProgress({count, max}: {count: number; max?: number}) {
           />
         )}
       </View>
-    </>
+    </View>
   )
 }

--- a/src/view/com/composer/char-progress/CharProgress.tsx
+++ b/src/view/com/composer/char-progress/CharProgress.tsx
@@ -5,33 +5,29 @@ import ProgressCircle from 'react-native-progress/Circle'
 // @ts-ignore no type definition -prf
 import ProgressPie from 'react-native-progress/Pie'
 
-import {MAX_GRAPHEME_LENGTH} from 'lib/constants'
-import {usePalette} from 'lib/hooks/usePalette'
-import {s} from 'lib/styles'
+import {MAX_GRAPHEME_LENGTH} from '#/lib/constants'
+import {usePalette} from '#/lib/hooks/usePalette'
+import {s} from '#/lib/styles'
 import {Text} from '../../util/text/Text'
 
-const DANGER_LENGTH = MAX_GRAPHEME_LENGTH
-
-export function CharProgress({count}: {count: number}) {
+export function CharProgress({count, max}: {count: number; max?: number}) {
+  const maxLength = max || MAX_GRAPHEME_LENGTH
   const pal = usePalette('default')
-  const textColor = count > DANGER_LENGTH ? '#e60000' : pal.colors.text
-  const circleColor = count > DANGER_LENGTH ? '#e60000' : pal.colors.link
+  const textColor = count > maxLength ? '#e60000' : pal.colors.text
+  const circleColor = count > maxLength ? '#e60000' : pal.colors.link
   return (
     <>
       <Text style={[s.mr10, s.tabularNum, {color: textColor}]}>
-        {MAX_GRAPHEME_LENGTH - count}
+        {maxLength - count}
       </Text>
       <View>
-        {count > DANGER_LENGTH ? (
+        {count > maxLength ? (
           <ProgressPie
             size={30}
             borderWidth={4}
             borderColor={circleColor}
             color={circleColor}
-            progress={Math.min(
-              (count - MAX_GRAPHEME_LENGTH) / MAX_GRAPHEME_LENGTH,
-              1,
-            )}
+            progress={Math.min((count - maxLength) / maxLength, 1)}
           />
         ) : (
           <ProgressCircle
@@ -39,7 +35,7 @@ export function CharProgress({count}: {count: number}) {
             borderWidth={1}
             borderColor={pal.colors.border}
             color={circleColor}
-            progress={count / MAX_GRAPHEME_LENGTH}
+            progress={count / maxLength}
           />
         )}
       </View>

--- a/src/view/com/composer/photos/ImageAltTextDialog.tsx
+++ b/src/view/com/composer/photos/ImageAltTextDialog.tsx
@@ -5,12 +5,15 @@ import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
 import {MAX_ALT_TEXT} from '#/lib/constants'
+import {enforceLen} from '#/lib/strings/helpers'
 import {isAndroid, isWeb} from '#/platform/detection'
 import {ComposerImage} from '#/state/gallery'
+import {CharProgress} from '#/view/com/composer/char-progress/CharProgress'
 import {atoms as a, useTheme} from '#/alf'
 import {Button, ButtonText} from '#/components/Button'
 import * as Dialog from '#/components/Dialog'
 import * as TextField from '#/components/forms/TextField'
+import {CircleInfo_Stroke2_Corner0_Rounded as CircleInfo} from '#/components/icons/CircleInfo'
 import {PortalComponent} from '#/components/Portal'
 import {Text} from '#/components/Typography'
 
@@ -35,7 +38,7 @@ const ImageAltTextInner = ({
   image,
   onChange,
 }: Props): React.ReactNode => {
-  const {_} = useLingui()
+  const {_, i18n} = useLingui()
   const t = useTheme()
 
   const windim = useWindowDimensions()
@@ -44,7 +47,7 @@ const ImageAltTextInner = ({
 
   const onPressSubmit = React.useCallback(() => {
     control.close()
-    onChange({...image, alt: altText.trim()})
+    onChange({...image, alt: enforceLen(altText.trim(), MAX_ALT_TEXT, true)})
   }, [control, image, altText, onChange])
 
   const imageStyle = React.useMemo<ImageStyle>(() => {
@@ -90,24 +93,59 @@ const ImageAltTextInner = ({
       </View>
 
       <View style={[a.mt_md, a.gap_md]}>
-        <View>
-          <TextField.LabelText>
-            <Trans>Descriptive alt text</Trans>
-          </TextField.LabelText>
-          <TextField.Root>
-            <Dialog.Input
-              label={_(msg`Alt text`)}
-              onChangeText={text => setAltText(text)}
-              value={altText}
-              multiline
-              numberOfLines={3}
-              autoFocus
-            />
-          </TextField.Root>
+        <View style={[a.gap_sm]}>
+          <View style={[a.relative]}>
+            <TextField.LabelText>
+              <Trans>Descriptive alt text</Trans>
+            </TextField.LabelText>
+            <TextField.Root>
+              <Dialog.Input
+                label={_(msg`Alt text`)}
+                onChangeText={text => setAltText(text)}
+                value={altText}
+                multiline
+                numberOfLines={3}
+                autoFocus
+              />
+            </TextField.Root>
+
+            <View
+              style={[
+                a.absolute,
+                a.flex_row,
+                a.align_center,
+                a.pr_md,
+                a.pb_sm,
+                {
+                  bottom: 0,
+                  right: 0,
+                },
+              ]}>
+              <CharProgress count={altText?.length || 0} max={MAX_ALT_TEXT} />
+            </View>
+          </View>
+
+          {altText.length > MAX_ALT_TEXT && (
+            <View style={[a.pb_sm, a.flex_row, a.gap_xs]}>
+              <CircleInfo fill={t.palette.negative_500} />
+              <Text
+                style={[
+                  a.italic,
+                  a.leading_snug,
+                  t.atoms.text_contrast_medium,
+                ]}>
+                <Trans>
+                  Alt text will be truncated. Limit: {i18n.number(MAX_ALT_TEXT)}{' '}
+                  characters.
+                </Trans>
+              </Text>
+            </View>
+          )}
         </View>
+
         <Button
           label={_(msg`Save`)}
-          disabled={altText.length > MAX_ALT_TEXT || altText === image.alt}
+          disabled={altText === image.alt}
           size="large"
           color="primary"
           variant="solid"

--- a/src/view/com/composer/photos/ImageAltTextDialog.tsx
+++ b/src/view/com/composer/photos/ImageAltTextDialog.tsx
@@ -12,6 +12,7 @@ import {AltTextCounterWrapper} from '#/view/com/composer/AltTextCounterWrapper'
 import {atoms as a, useTheme} from '#/alf'
 import {Button, ButtonText} from '#/components/Button'
 import * as Dialog from '#/components/Dialog'
+import {DialogControlProps} from '#/components/Dialog'
 import * as TextField from '#/components/forms/TextField'
 import {CircleInfo_Stroke2_Corner0_Rounded as CircleInfo} from '#/components/icons/CircleInfo'
 import {PortalComponent} from '#/components/Portal'
@@ -32,48 +33,39 @@ export const ImageAltTextDialog = ({
 }: Props): React.ReactNode => {
   const altTextRef = React.useRef<string>(image.alt)
 
-  const onSubmit = (text: string) => {
-    control.close()
-    onChange({
-      ...image,
-      alt: enforceLen(text, MAX_ALT_TEXT, true),
-    })
-  }
-
   return (
     <Dialog.Outer
       control={control}
       onClose={() => {
-        onSubmit(altTextRef.current)
+        onChange({
+          ...image,
+          alt: enforceLen(altTextRef.current, MAX_ALT_TEXT, true),
+        })
       }}
       Portal={Portal}>
       <Dialog.Handle />
       <ImageAltTextInner
+        control={control}
         image={image}
         altTextRef={altTextRef}
-        onSubmit={onSubmit}
       />
     </Dialog.Outer>
   )
 }
 
 const ImageAltTextInner = ({
-  image,
   altTextRef,
-  onSubmit,
+  control,
+  image,
 }: {
-  image: Props['image']
   altTextRef: React.MutableRefObject<string>
-  onSubmit: (text: string) => void
+  control: DialogControlProps
+  image: Props['image']
 }): React.ReactNode => {
   const {_, i18n} = useLingui()
   const t = useTheme()
   const windim = useWindowDimensions()
   const [altText, setAltText] = React.useState(image.alt)
-
-  const onPressSubmit = () => {
-    onSubmit(altText)
-  }
 
   const imageStyle = React.useMemo<ImageStyle>(() => {
     const maxWidth = isWeb ? 450 : windim.width
@@ -163,7 +155,9 @@ const ImageAltTextInner = ({
             size="large"
             color="primary"
             variant="solid"
-            onPress={onPressSubmit}
+            onPress={() => {
+              control.close()
+            }}
             style={[a.flex_grow]}>
             <ButtonText>
               <Trans>Save</Trans>

--- a/src/view/com/composer/photos/ImageAltTextDialog.tsx
+++ b/src/view/com/composer/photos/ImageAltTextDialog.tsx
@@ -31,7 +31,7 @@ export const ImageAltTextDialog = ({
   onChange,
   Portal,
 }: Props): React.ReactNode => {
-  const altTextRef = React.useRef<string>(image.alt)
+  const [altText, setAltText] = React.useState(image.alt)
 
   return (
     <Dialog.Outer
@@ -39,7 +39,7 @@ export const ImageAltTextDialog = ({
       onClose={() => {
         onChange({
           ...image,
-          alt: enforceLen(altTextRef.current, MAX_ALT_TEXT, true),
+          alt: enforceLen(altText, MAX_ALT_TEXT, true),
         })
       }}
       Portal={Portal}>
@@ -47,25 +47,27 @@ export const ImageAltTextDialog = ({
       <ImageAltTextInner
         control={control}
         image={image}
-        altTextRef={altTextRef}
+        altText={altText}
+        setAltText={setAltText}
       />
     </Dialog.Outer>
   )
 }
 
 const ImageAltTextInner = ({
-  altTextRef,
+  altText,
+  setAltText,
   control,
   image,
 }: {
-  altTextRef: React.MutableRefObject<string>
+  altText: string
+  setAltText: (text: string) => void
   control: DialogControlProps
   image: Props['image']
 }): React.ReactNode => {
   const {_, i18n} = useLingui()
   const t = useTheme()
   const windim = useWindowDimensions()
-  const [altText, setAltText] = React.useState(image.alt)
 
   const imageStyle = React.useMemo<ImageStyle>(() => {
     const maxWidth = isWeb ? 450 : windim.width
@@ -119,10 +121,9 @@ const ImageAltTextInner = ({
               <Dialog.Input
                 label={_(msg`Alt text`)}
                 onChangeText={text => {
-                  altTextRef.current = text
                   setAltText(text)
                 }}
-                value={altText}
+                defaultValue={altText}
                 multiline
                 numberOfLines={3}
                 autoFocus


### PR DESCRIPTION
Updates alt text limit to 2k characters for both images and GIFs + updates the UI with our char counter.

![CleanShot 2024-10-04 at 15 51 39@2x](https://github.com/user-attachments/assets/90a4c1ae-b31d-4d6f-ba80-87b44f6b8e24)
![CleanShot 2024-10-04 at 15 51 34@2x](https://github.com/user-attachments/assets/8d2ec96b-66bd-45e6-996f-f3d8a64ebcbc)
![CleanShot 2024-10-04 at 15 55 41@2x](https://github.com/user-attachments/assets/8d589691-c130-4ff6-95df-86a5053a4cf7)
![CleanShot 2024-10-04 at 15 56 56@2x](https://github.com/user-attachments/assets/1da5f086-3744-4e89-95d9-688d22b2d055)
![CleanShot 2024-10-04 at 16 01 45@2x](https://github.com/user-attachments/assets/675619df-748b-47e8-82cb-874a508db4ca)
