### PR TITLE
Move font-face defs into HTML for CDN

### DIFF
--- a/bskyweb/templates/base.html
+++ b/bskyweb/templates/base.html
@@ -24,6 +24,20 @@
      *
      * THIS NEEDS TO BE DUPLICATED IN `bskyweb/templates/base.html`
      */
+    @font-face {
+      font-family: 'InterVariable';
+      src: url(/static/media/InterVariable.c9f788f6e7ebaec75d7c.ttf) format('truetype');
+      font-weight: 300 1000;
+      font-style: normal;
+      font-display: swap;
+    }
+    @font-face {
+      font-family: 'InterVariableItalic';
+      src: url(/static/media/InterVariable-Italic.55d6a3f35e9b605ba6f4.ttf) format('truetype');
+      font-weight: 300 1000;
+      font-style: italic;
+      font-display: swap;
+    }
     html {
       background-color: white;
       scrollbar-gutter: stable both-edges;

--- a/src/alf/fonts.ts
+++ b/src/alf/fonts.ts
@@ -70,6 +70,8 @@ export function applyFonts(
  * IMPORTANT: This is unused. Expo statically extracts these fonts.
  *
  * All used fonts MUST be configured here. Unused fonts can be commented out.
+ *
+ * This is used for both web fonts and native fonts.
  */
 export function DO_NOT_USE() {
   return useFonts({

--- a/src/style.css
+++ b/src/style.css
@@ -6,21 +6,6 @@
  * may need to touch all three. Ask Eric if you aren't sure.
  */
 
-@font-face {
-  font-family: 'InterVariable';
-  src: url(/assets/fonts/inter/InterVariable.ttf) format('truetype');
-  font-weight: 300 1000;
-  font-style: normal;
-  font-display: swap;
-}
-@font-face {
-  font-family: 'InterVariableItalic';
-  src: url(/assets/fonts/inter/InterVariable-Italic.ttf) format('truetype');
-  font-weight: 300 1000;
-  font-style: italic;
-  font-display: swap;
-}
-
 /**
  * BEGIN STYLES
  *

--- a/web/index.html
+++ b/web/index.html
@@ -29,6 +29,20 @@
        *
        * THIS NEEDS TO BE DUPLICATED IN `bskyweb/templates/base.html`
        */
+      @font-face {
+        font-family: 'InterVariable';
+        src: url(/static/media/InterVariable.c9f788f6e7ebaec75d7c.ttf) format('truetype');
+        font-weight: 300 1000;
+        font-style: normal;
+        font-display: swap;
+      }
+      @font-face {
+        font-family: 'InterVariableItalic';
+        src: url(/static/media/InterVariable-Italic.55d6a3f35e9b605ba6f4.ttf) format('truetype');
+        font-weight: 300 1000;
+        font-style: italic;
+        font-display: swap;
+      }
       html {
         background-color: white;
         scrollbar-gutter: stable both-edges;


### PR DESCRIPTION
This moves the `@font-face` defs into the HTML files so we can prefix them with our CDN in #5610.

Previously, Webpack exported these font files and hashed them by reference from the CSS file, and they were then spit out into `/web-build`. But, we added the (unused) `useFonts` hook back for native the other day, and Expo statically exports the same files bc that hook is present. This works for prod build as well as local dev.

So the files output are the same. And these `@font-face` defs just need to point to the proper location.