### PR TITLE
Enclose the entire message in Trans tags for translation

### DIFF
--- a/src/components/moderation/LabelsOnMeDialog.tsx
+++ b/src/components/moderation/LabelsOnMeDialog.tsx
@@ -242,18 +242,20 @@ function AppealForm({
           <Trans>Appeal "{strings.name}" label</Trans>
         </Text>
         <Text style={[a.text_md, a.leading_snug]}>
-          <Trans>This appeal will be sent to</Trans>{' '}
+          <Trans>
+            This appeal will be sent to{' '}
+            <InlineLinkText
+              label={sourceName}
+              to={makeProfileLink(
+                labeler ? labeler.creator : {did: label.src, handle: ''},
+              )}
+              onPress={() => control.close()}
+              style={[a.text_md, a.leading_snug]}>
+              {sourceName}
+            </InlineLinkText>
+            .
+          </Trans>
         </Text>
-        <InlineLinkText
-          label={sourceName}
-          to={makeProfileLink(
-            labeler ? labeler.creator : {did: label.src, handle: ''},
-          )}
-          onPress={() => control.close()}
-          style={[a.text_md, a.leading_snug]}>
-          {sourceName}
-        </InlineLinkText>
-        <Text style={[a.text_md, a.leading_snug]}>.</Text>
       </View>
       <View style={[a.my_md]}>
         <Dialog.Input

--- a/src/components/moderation/ModerationDetailsDialog.tsx
+++ b/src/components/moderation/ModerationDetailsDialog.tsx
@@ -148,15 +148,17 @@ function ModerationDetailsDialogInner({
           ) : (
             <>
               <Text style={[t.atoms.text, a.text_md, a.leading_snug, a.mt_lg]}>
-                <Trans>This label was applied by </Trans>
+                <Trans>
+                  This label was applied by{' '}
+                  <InlineLinkText
+                    label={desc.source || _(msg`an unknown labeler`)}
+                    to={makeProfileLink({did: modcause.label.src, handle: ''})}
+                    onPress={() => control.close()}
+                    style={a.text_md}>
+                    {desc.source || _(msg`an unknown labeler`)}
+                  </InlineLinkText>
+                </Trans>
               </Text>
-              <InlineLinkText
-                label={desc.source || _(msg`an unknown labeler`)}
-                to={makeProfileLink({did: modcause.label.src, handle: ''})}
-                onPress={() => control.close()}
-                style={a.text_md}>
-                {desc.source || _(msg`an unknown labeler`)}
-              </InlineLinkText>
             </>
           )}
         </View>


### PR DESCRIPTION
Recent modifications to the label-related code complicated the translation work for languages with word orders different from English. To address this, I made a patch to enclose the entire sentence within a Trans tag.
