### PR TITLE
Restore the dot in the message displayed in the moderation details dialog

### DIFF
--- a/src/components/moderation/ModerationDetailsDialog.tsx
+++ b/src/components/moderation/ModerationDetailsDialog.tsx
@@ -157,6 +157,7 @@ function ModerationDetailsDialogInner({
                     style={a.text_md}>
                     {desc.source || _(msg`an unknown labeler`)}
                   </InlineLinkText>
+                  .
                 </Trans>
               </Text>
             </>


### PR DESCRIPTION
Ah, I forgot to add trailing ``.`` in #5616 . This fix will eliminate the need to modify existing message translations.