### PR TITLE
Fix padding in repost dialog

### DIFF
--- a/src/view/com/util/post-ctrls/RepostButton.tsx
+++ b/src/view/com/util/post-ctrls/RepostButton.tsx
@@ -90,7 +90,7 @@ let RepostButton = ({
         control={dialogControl}
         nativeOptions={{preventExpansion: true}}>
         <Dialog.Handle />
-        <Dialog.Inner label={_(msg`Repost or quote post`)}>
+        <Dialog.ScrollableInner label={_(msg`Repost or quote post`)}>
           <View style={a.gap_xl}>
             <View style={a.gap_xs}>
               <Button
@@ -164,7 +164,7 @@ let RepostButton = ({
               <ButtonText>{_(msg`Cancel`)}</ButtonText>
             </Button>
           </View>
-        </Dialog.Inner>
+        </Dialog.ScrollableInner>
       </Dialog.Outer>
     </>
   )


### PR DESCRIPTION
Swaps out `Inner` for `ScrollableInner` which fixes the padding problem. Going to go through and check the other few places we use `Inner` and - probably - replace them.