### PR TITLE
Use tabular numbers in `CharProgress`

### DIFF
--- a/src/view/com/composer/char-progress/CharProgress.tsx
+++ b/src/view/com/composer/char-progress/CharProgress.tsx
@@ -30,7 +30,13 @@ export function CharProgress({
   return (
     <View
       style={[a.flex_row, a.align_center, a.justify_between, a.gap_sm, style]}>
-      <Text style={[{color: textColor}, a.flex_grow, a.text_right, textStyle]}>
+      <Text
+        style={[
+          {color: textColor, fontVariant: ['tabular-nums']},
+          a.flex_grow,
+          a.text_right,
+          textStyle,
+        ]}>
         {maxLength - count}
       </Text>
       {count > maxLength ? (


### PR DESCRIPTION
As a follow-up to #5620, I noticed that the character count doesn't use tabular numbers anymore. This adds back the style.

Inspired by #5293 🙏