### PR TITLE
Remove line breaks in intro text in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -5,10 +5,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to report an issue you've found in the app! Before you submit this issue, please make
-        sure you've searched for similar issues that are already open and being tracked. If you find an open issue that
-        seems relevant to yours, it is best to leave a response there with your information instead of opening a new
-        issue, since it helps to consolidate the info in one place.
+        Thanks for taking the time to report an issue you've found in the app! Before you submit this issue, please make sure you've searched for similar issues that are already open and being tracked. If you find an open issue that seems relevant to yours, it is best to leave a response there with your information instead of opening a new issue, since it helps to consolidate the info in one place.
   - type: textarea
     attributes:
       label: Steps to Reproduce

--- a/.github/ISSUE_TEMPLATE/bug_report_fabric.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_fabric.yml
@@ -12,10 +12,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to report an issue you've found in the app! Before you submit this issue, please make
-        sure you've searched for similar issues that are already open and being tracked. If you find an open issue that
-        seems relevant to yours, it is best to leave a response there with your information instead of opening a new
-        issue, since it helps to consolidate the info in one place.
+        Thanks for taking the time to report an issue you've found in the app! Before you submit this issue, please make sure you've searched for similar issues that are already open and being tracked. If you find an open issue that seems relevant to yours, it is best to leave a response there with your information instead of opening a new issue, since it helps to consolidate the info in one place.
   - type: textarea
     attributes:
       label: Steps to Reproduce

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -5,10 +5,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for submitting a feature request! Before you submit this request, please make sure you've searched for
-        similar requests that are already open and being tracked. If you find an open request that seems relevant to
-        yours, it is best to leave a response there with your information instead of opening a new request, since it
-        helps to consolidate the info in one place.
+        Thanks for submitting a feature request! Before you submit this request, please make sure you've searched for similar requests that are already open and being tracked. If you find an open request that seems relevant to yours, it is best to leave a response there with your information instead of opening a new request, since it helps to consolidate the info in one place.
   - type: textarea
     attributes:
       label: Describe the Feature


### PR DESCRIPTION
There are currently some awkward line breaks shown in the intro text when you open a new issue. This PR removes them.

The templates can be previewed here:
https://github.com/surfdude29/social-app/tree/rm-linebreaks/.github/ISSUE_TEMPLATE