### PR TITLE
[Video] Add dimension info to share intent

### DIFF
--- a/modules/expo-receive-android-intents/android/src/main/java/xyz/blueskyweb/app/exporeceiveandroidintents/ExpoReceiveAndroidIntentsModule.kt
+++ b/modules/expo-receive-android-intents/android/src/main/java/xyz/blueskyweb/app/exporeceiveandroidintents/ExpoReceiveAndroidIntentsModule.kt
@@ -2,6 +2,7 @@ package xyz.blueskyweb.app.exporeceiveandroidintents
 
 import android.content.Intent
 import android.graphics.Bitmap
+import android.media.MediaMetadataRetriever
 import android.net.Uri
 import android.os.Build
 import android.provider.MediaStore
@@ -143,7 +144,10 @@ class ExpoReceiveAndroidIntentsModule : Module() {
     appContext.currentActivity?.contentResolver?.openInputStream(uri)?.use {
       it.copyTo(out)
     }
-    "bluesky://intent/compose?videoUri=${URLEncoder.encode(file.path, "UTF-8")}".toUri().let {
+
+    val info = getVideoInfo(uri) ?: return
+
+    "bluesky://intent/compose?videoUri=${URLEncoder.encode(file.path, "UTF-8")}|${info["width"]}|${info["height"]}".toUri().let {
       val newIntent = Intent(Intent.ACTION_VIEW, it)
       appContext.currentActivity?.startActivity(newIntent)
     }
@@ -163,6 +167,24 @@ class ExpoReceiveAndroidIntentsModule : Module() {
       "width" to bitmap.width,
       "height" to bitmap.height,
       "path" to file.path.toString(),
+    )
+  }
+
+  private fun getVideoInfo(uri: Uri): Map<String, Any>? {
+    val retriever = MediaMetadataRetriever()
+    retriever.setDataSource(appContext.currentActivity, uri)
+
+    val width = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_WIDTH)?.toIntOrNull()
+    val height = retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_VIDEO_HEIGHT)?.toIntOrNull()
+
+    if (width == null || height == null) {
+      return null
+    }
+
+    return mapOf(
+      "width" to width,
+      "height" to height,
+      "path" to uri.path.toString(),
     )
   }
 

--- a/src/lib/hooks/useIntentHandler.ts
+++ b/src/lib/hooks/useIntentHandler.ts
@@ -93,9 +93,10 @@ export function useComposeIntent() {
 
       // Whenever a video URI is present, we don't support adding images right now.
       if (videoUri) {
+        const [uri, width, height] = videoUri.split('|')
         openComposer({
           text: text ?? undefined,
-          videoUri,
+          videoUri: {uri, width: Number(width), height: Number(height)},
         })
         return
       }

--- a/src/state/shell/composer/index.tsx
+++ b/src/state/shell/composer/index.tsx
@@ -38,7 +38,7 @@ export interface ComposerOpts {
   openEmojiPicker?: (pos: DOMRect | undefined) => void
   text?: string
   imageUris?: {uri: string; width: number; height: number; altText?: string}[]
-  videoUri?: string
+  videoUri?: {uri: string; width: number; height: number}
 }
 
 type StateContext = ComposerOpts | undefined

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -218,7 +218,7 @@ export const ComposePost = ({
   // Whenever we receive an initial video uri, we should immediately run compression if necessary
   useEffect(() => {
     if (initVideoUri) {
-      selectVideo({uri: initVideoUri} as ImagePickerAsset)
+      selectVideo(initVideoUri)
     }
   }, [initVideoUri, selectVideo])
 


### PR DESCRIPTION
## Why

We added share intent for videos, though were not passing along any dimension info which is required for the upload. Adding that here.

## Test Plan

Sharing a video into the app works and you can actually upload it.