### PR TITLE
Refactor post meta to return PostView

### DIFF
--- a/src/lib/api/resolve.ts
+++ b/src/lib/api/resolve.ts
@@ -1,6 +1,5 @@
 import {
-  AppBskyActorDefs,
-  AppBskyFeedPost,
+  AppBskyFeedDefs,
   AppBskyGraphStarterpack,
   ComAtprotoRepoStrongRef,
 } from '@atproto/api'
@@ -41,11 +40,7 @@ type ResolvedPostRecord = {
   type: 'record'
   record: ComAtprotoRepoStrongRef.Main
   kind: 'post'
-  meta: {
-    text: string
-    indexedAt: string
-    author: AppBskyActorDefs.ProfileViewBasic
-  }
+  meta: AppBskyFeedDefs.PostView
 }
 
 type ResolvedOtherRecord = {
@@ -92,11 +87,7 @@ export async function resolveLink(
         uri: post.uri,
       },
       kind: 'post',
-      meta: {
-        text: AppBskyFeedPost.isRecord(post.record) ? post.record.text : '',
-        indexedAt: post.indexedAt,
-        author: post.author,
-      },
+      meta: post,
     }
   }
   if (isBskyCustomFeedUrl(uri)) {

--- a/src/state/shell/composer/index.tsx
+++ b/src/state/shell/composer/index.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import {
   AppBskyActorDefs,
   AppBskyEmbedRecord,
-  AppBskyRichtextFacet,
+  AppBskyFeedDefs,
   ModerationDecision,
 } from '@atproto/api'
 import {msg} from '@lingui/macro'
@@ -23,20 +23,11 @@ export interface ComposerOptsPostRef {
   embed?: AppBskyEmbedRecord.ViewRecord['embed']
   moderation?: ModerationDecision
 }
-export interface ComposerOptsQuote {
-  uri: string
-  cid: string
-  text: string
-  facets?: AppBskyRichtextFacet.Main[]
-  indexedAt: string
-  author: AppBskyActorDefs.ProfileViewBasic
-  embeds?: AppBskyEmbedRecord.ViewRecord['embeds']
-}
+
 export interface ComposerOpts {
   replyTo?: ComposerOptsPostRef
   onPost?: (postUri: string | undefined) => void
-  quote?: ComposerOptsQuote
-  quoteCount?: number
+  quote?: AppBskyFeedDefs.PostView
   mention?: string // handle of user to mention
   openEmojiPicker?: (pos: DOMRect | undefined) => void
   text?: string
@@ -75,11 +66,7 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
             cid: opts.quote.cid,
             uri: opts.quote.uri,
           },
-          meta: {
-            author: opts.quote.author,
-            indexedAt: opts.quote.indexedAt,
-            text: opts.quote.text,
-          },
+          meta: opts.quote,
         })
       }
     }

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -129,7 +129,6 @@ export const ComposePost = ({
   replyTo,
   onPost,
   quote: initQuote,
-  quoteCount: initQuoteCount,
   mention: initMention,
   openEmojiPicker,
   text: initText,
@@ -425,13 +424,13 @@ export const ComposePost = ({
         emitPostCreated()
       }
       setLangPrefs.savePostLanguageToHistory()
-      if (initQuote && initQuoteCount !== undefined) {
+      if (initQuote) {
         // We want to wait for the quote count to update before we call `onPost`, which will refetch data
         whenAppViewReady(agent, initQuote.uri, res => {
           const thread = res.data.thread
           if (
             AppBskyFeedDefs.isThreadViewPost(thread) &&
-            thread.post.quoteCount !== initQuoteCount
+            thread.post.quoteCount !== initQuote.quoteCount
           ) {
             onPost?.(postUri)
             return true
@@ -463,7 +462,6 @@ export const ComposePost = ({
       onPost,
       quote,
       initQuote,
-      initQuoteCount,
       replyTo,
       richtext.text,
       setLangPrefs,

--- a/src/view/com/composer/ComposerReplyTo.tsx
+++ b/src/view/com/composer/ComposerReplyTo.tsx
@@ -13,7 +13,7 @@ import {useLingui} from '@lingui/react'
 import {sanitizeDisplayName} from '#/lib/strings/display-names'
 import {sanitizeHandle} from '#/lib/strings/handles'
 import {ComposerOptsPostRef} from '#/state/shell/composer'
-import {QuoteEmbed} from '#/view/com/util/post-embeds/QuoteEmbed'
+import {MaybeQuoteEmbed} from '#/view/com/util/post-embeds/QuoteEmbed'
 import {Text} from '#/view/com/util/text/Text'
 import {PreviewableUserAvatar} from '#/view/com/util/UserAvatar'
 import {atoms as a, useTheme} from '#/alf'
@@ -33,33 +33,21 @@ export function ComposerReplyTo({replyTo}: {replyTo: ComposerOptsPostRef}) {
     })
   }, [])
 
-  const quote = React.useMemo(() => {
+  const quoteEmbed = React.useMemo(() => {
     if (
       AppBskyEmbedRecord.isView(embed) &&
       AppBskyEmbedRecord.isViewRecord(embed.record) &&
       AppBskyFeedPost.isRecord(embed.record.value)
     ) {
-      // Not going to include the images right now
-      return {
-        author: embed.record.author,
-        cid: embed.record.cid,
-        uri: embed.record.uri,
-        indexedAt: embed.record.indexedAt,
-        text: embed.record.value.text,
-      }
+      return embed
     } else if (
       AppBskyEmbedRecordWithMedia.isView(embed) &&
       AppBskyEmbedRecord.isViewRecord(embed.record.record) &&
       AppBskyFeedPost.isRecord(embed.record.record.value)
     ) {
-      return {
-        author: embed.record.record.author,
-        cid: embed.record.record.cid,
-        uri: embed.record.record.uri,
-        indexedAt: embed.record.record.indexedAt,
-        text: embed.record.record.value.text,
-      }
+      return embed.record
     }
+    return null
   }, [embed])
 
   const images = React.useMemo(() => {
@@ -110,7 +98,7 @@ export function ComposerReplyTo({replyTo}: {replyTo: ComposerOptsPostRef}) {
             <ComposerReplyToImages images={images} showFull={showFull} />
           )}
         </View>
-        {showFull && quote && <QuoteEmbed quote={quote} />}
+        {showFull && quoteEmbed && <MaybeQuoteEmbed embed={quoteEmbed} />}
       </View>
     </Pressable>
   )

--- a/src/view/com/util/post-ctrls/PostCtrls.tsx
+++ b/src/view/com/util/post-ctrls/PostCtrls.tsx
@@ -199,27 +199,15 @@ let PostCtrls = ({
       feedContext,
     })
     openComposer({
-      quote: {
-        uri: post.uri,
-        cid: post.cid,
-        text: record.text,
-        author: post.author,
-        indexedAt: post.indexedAt,
-      },
-      quoteCount: post.quoteCount,
+      quote: post,
       onPost: onPostReply,
     })
   }, [
     _,
     sendInteraction,
-    post.uri,
-    post.cid,
-    post.author,
-    post.indexedAt,
-    post.quoteCount,
+    post,
     feedContext,
     openComposer,
-    record.text,
     onPostReply,
     isBlocked,
   ])

--- a/src/view/com/util/post-embeds/QuoteEmbed.tsx
+++ b/src/view/com/util/post-embeds/QuoteEmbed.tsx
@@ -33,7 +33,6 @@ import {useModerationOpts} from '#/state/preferences/moderation-opts'
 import {precacheProfile} from '#/state/queries/profile'
 import {useResolveLinkQuery} from '#/state/queries/resolve-link'
 import {useSession} from '#/state/session'
-import {ComposerOptsQuote} from '#/state/shell/composer'
 import {atoms as a, useTheme} from '#/alf'
 import {RichText} from '#/components/RichText'
 import {ContentHider} from '../../../../components/moderation/ContentHider'
@@ -68,7 +67,6 @@ export function MaybeQuoteEmbed({
     return (
       <QuoteEmbedModerated
         viewRecord={embed.record}
-        postRecord={embed.record.value}
         onOpen={onOpen}
         style={style}
         allowNestedQuotes={allowNestedQuotes}
@@ -118,39 +116,31 @@ export function MaybeQuoteEmbed({
 
 function QuoteEmbedModerated({
   viewRecord,
-  postRecord,
   onOpen,
   style,
   allowNestedQuotes,
   viewContext,
 }: {
   viewRecord: AppBskyEmbedRecord.ViewRecord
-  postRecord: AppBskyFeedPost.Record
   onOpen?: () => void
   style?: StyleProp<ViewStyle>
   allowNestedQuotes?: boolean
   viewContext?: QuoteEmbedViewContext
 }) {
   const moderationOpts = useModerationOpts()
+  const postView = React.useMemo(
+    () => viewRecordToPostView(viewRecord),
+    [viewRecord],
+  )
   const moderation = React.useMemo(() => {
     return moderationOpts
-      ? moderatePost_wrapped(viewRecordToPostView(viewRecord), moderationOpts)
+      ? moderatePost_wrapped(postView, moderationOpts)
       : undefined
-  }, [viewRecord, moderationOpts])
-
-  const quote = {
-    author: viewRecord.author,
-    cid: viewRecord.cid,
-    uri: viewRecord.uri,
-    indexedAt: viewRecord.indexedAt,
-    text: postRecord.text,
-    facets: postRecord.facets,
-    embeds: viewRecord.embeds,
-  }
+  }, [postView, moderationOpts])
 
   return (
     <QuoteEmbed
-      quote={quote}
+      quote={postView}
       moderation={moderation}
       onOpen={onOpen}
       style={style}
@@ -167,7 +157,7 @@ export function QuoteEmbed({
   style,
   allowNestedQuotes,
 }: {
-  quote: ComposerOptsQuote
+  quote: AppBskyFeedDefs.PostView
   moderation?: ModerationDecision
   onOpen?: () => void
   style?: StyleProp<ViewStyle>
@@ -181,16 +171,18 @@ export function QuoteEmbed({
   const itemHref = makeProfileLink(quote.author, 'post', itemUrip.rkey)
   const itemTitle = `Post by ${quote.author.handle}`
 
-  const richText = React.useMemo(
-    () =>
-      quote.text.trim()
-        ? new RichTextAPI({text: quote.text, facets: quote.facets})
-        : undefined,
-    [quote.text, quote.facets],
-  )
+  const richText = React.useMemo(() => {
+    const text = AppBskyFeedPost.isRecord(quote.record) ? quote.record.text : ''
+    const facets = AppBskyFeedPost.isRecord(quote.record)
+      ? quote.record.facets
+      : undefined
+    return text.trim()
+      ? new RichTextAPI({text: text, facets: facets})
+      : undefined
+  }, [quote.record])
 
   const embed = React.useMemo(() => {
-    const e = quote.embeds?.[0]
+    const e = quote.embed
 
     if (allowNestedQuotes) {
       return e
@@ -210,7 +202,7 @@ export function QuoteEmbed({
         return e.media
       }
     }
-  }, [quote.embeds, allowNestedQuotes])
+  }, [quote.embed, allowNestedQuotes])
 
   const onBeforePress = React.useCallback(() => {
     precacheProfile(queryClient, quote.author)
@@ -292,17 +284,7 @@ export function LazyQuoteEmbed({uri}: {uri: string}) {
   if (!data || data.type !== 'record' || data.kind !== 'post') {
     return null
   }
-  return (
-    <QuoteEmbed
-      quote={{
-        cid: data.record.cid,
-        uri: data.record.uri,
-        author: data.meta.author,
-        indexedAt: data.meta.indexedAt,
-        text: data.meta.text,
-      }}
-    />
-  )
+  return <QuoteEmbed quote={data.meta} />
 }
 
 function viewRecordToPostView(

--- a/src/view/shell/Composer.ios.tsx
+++ b/src/view/shell/Composer.ios.tsx
@@ -38,7 +38,6 @@ export function Composer({}: {winHeight: number}) {
           replyTo={state?.replyTo}
           onPost={state?.onPost}
           quote={state?.quote}
-          quoteCount={state?.quoteCount}
           mention={state?.mention}
           text={state?.text}
           imageUris={state?.imageUris}

--- a/src/view/shell/Composer.tsx
+++ b/src/view/shell/Composer.tsx
@@ -50,7 +50,6 @@ export function Composer({winHeight}: {winHeight: number}) {
         replyTo={state.replyTo}
         onPost={state.onPost}
         quote={state.quote}
-        quoteCount={state.quoteCount}
         mention={state.mention}
         text={state.text}
         imageUris={state.imageUris}

--- a/src/view/shell/Composer.web.tsx
+++ b/src/view/shell/Composer.web.tsx
@@ -94,7 +94,6 @@ function Inner({state}: {state: ComposerOpts}) {
             cancelRef={ref}
             replyTo={state.replyTo}
             quote={state.quote}
-            quoteCount={state?.quoteCount}
             onPost={state.onPost}
             mention={state.mention}
             openEmojiPicker={onOpenPicker}


### PR DESCRIPTION
Gonna stack a few little cleanups.

This first one removes the special `ComposerOptsQuote` type in favor of plain `AppBskyFeedDefs.PostView`. The `meta` returned when resolving post records now also becomes `AppBskyFeedDefs.PostView`.

In a follow-up, I'll change `meta` for other links to also use normal views.

## Test Plan

Note that this is touching actual quote display — not just composer previews. Verify quoting different types of posts (no media, media, quote, external link, non-post record, gif, some combinations) still works. Both in the composer (where you should see a preview of what you're quoting) and after posting (there should be no regression in displaying quotes — both in the feed and in the individual posts). It would be good to check moderation has not regressed (blocks get applied etc).

I've noticed even in prod there are some existing issues (like quotes of starter packs not displaying anything inside the quoted post bubble). I expect that this refactor should neither make those better nor worse.