### PR TITLE
Ensure app clip works even with `starter-pack`

### DIFF
--- a/modules/BlueskyClip/ViewController.swift
+++ b/modules/BlueskyClip/ViewController.swift
@@ -81,7 +81,7 @@ class ViewController: UIViewController, WKScriptMessageHandler, WKNavigationDele
   func isStarterPackUrl(_ url: URL) -> Bool {
     var host: String?
     if #available(iOS 16.0, *) {
-      host = url.host() ?? ""
+      host = url.host()
     } else {
       host = url.host
     }

--- a/modules/BlueskyClip/ViewController.swift
+++ b/modules/BlueskyClip/ViewController.swift
@@ -42,7 +42,7 @@ class ViewController: UIViewController, WKScriptMessageHandler, WKNavigationDele
           let payload = try? JSONDecoder().decode(WebViewActionPayload.self, from: data) else {
       return
     }
-
+    
     switch payload.action {
     case .present:
       guard let url = self.starterPackUrl else {
@@ -72,7 +72,7 @@ class ViewController: UIViewController, WKScriptMessageHandler, WKNavigationDele
     // pathComponents starts with "/" as the first component, then each path name. so...
     // ["/", "start", "name", "rkey"]
     if url.pathComponents.count == 4,
-       url.pathComponents[1] == "start" {
+       (url.pathComponents[1] == "start" || url.pathComponents[1] == "starter-pack") {
       self.starterPackUrl = url
     }
 

--- a/modules/BlueskyClip/ViewController.swift
+++ b/modules/BlueskyClip/ViewController.swift
@@ -66,23 +66,51 @@ class ViewController: UIViewController, WKScriptMessageHandler, WKNavigationDele
     guard let url = navigationAction.request.url else {
       return .allow
     }
-
+    
     // Store the previous one to compare later, but only set starterPackUrl when we find the right one
     prevUrl = url
     // pathComponents starts with "/" as the first component, then each path name. so...
     // ["/", "start", "name", "rkey"]
-    if url.pathComponents.count == 4,
-       (url.pathComponents[1] == "start" || url.pathComponents[1] == "starter-pack") {
+    if isStarterPackUrl(url){
       self.starterPackUrl = url
     }
-
+    
     return .allow
+  }
+  
+  func isStarterPackUrl(_ url: URL) -> Bool {
+    var host: String?
+    if #available(iOS 16.0, *) {
+      host = url.host() ?? ""
+    } else {
+      host = url.host
+    }
+    
+    switch host {
+    case "bsky.app":
+      if url.pathComponents.count == 4,
+         (url.pathComponents[1] == "start" || url.pathComponents[1] == "starter-pack") {
+        return true
+      }
+      return false
+    case "go.bsky.app":
+      if url.pathComponents.count == 2 {
+        return true
+      }
+      return false
+    default:
+      return false
+    }
   }
 
   func handleURL(url: URL) {
-    let urlString = "\(url.absoluteString)?clip=true"
-    if let url = URL(string: urlString) {
-      self.webView?.load(URLRequest(url: url))
+    if isStarterPackUrl(url) {
+      let urlString = "\(url.absoluteString)?clip=true"
+      if let url = URL(string: urlString) {
+        self.webView?.load(URLRequest(url: url))
+      }
+    } else {
+      self.webView?.load(URLRequest(url: URL(string: "https://bsky.app/?splash=true&clip=true")!))
     }
   }
 

--- a/src/screens/StarterPack/StarterPackLandingScreen.tsx
+++ b/src/screens/StarterPack/StarterPackLandingScreen.tsx
@@ -356,7 +356,7 @@ function LandingScreenLoaded({
   )
 }
 
-function AppClipOverlay({
+export function AppClipOverlay({
   visible,
   setIsVisible,
 }: {

--- a/src/view/com/auth/SplashScreen.web.tsx
+++ b/src/view/com/auth/SplashScreen.web.tsx
@@ -9,6 +9,7 @@ import {useKawaiiMode} from '#/state/preferences/kawaii'
 import {ErrorBoundary} from '#/view/com/util/ErrorBoundary'
 import {Logo} from '#/view/icons/Logo'
 import {Logotype} from '#/view/icons/Logotype'
+import {AppClipOverlay} from '#/screens/StarterPack/StarterPackLandingScreen'
 import {atoms as a, useTheme} from '#/alf'
 import {AppLanguageDropdown} from '#/components/AppLanguageDropdown'
 import {Button, ButtonText} from '#/components/Button'
@@ -28,6 +29,15 @@ export const SplashScreen = ({
   const {_} = useLingui()
   const t = useTheme()
   const {isTabletOrMobile: isMobileWeb} = useWebMediaQueries()
+  const [showClipOverlay, setShowClipOverlay] = React.useState(false)
+
+  React.useEffect(() => {
+    const getParams = new URLSearchParams(window.location.search)
+    const clip = getParams.get('clip')
+    if (clip === 'true') {
+      setShowClipOverlay(true)
+    }
+  }, [])
 
   const kawaii = useKawaiiMode()
 
@@ -119,6 +129,10 @@ export const SplashScreen = ({
         </View>
         <Footer />
       </CenteredView>
+      <AppClipOverlay
+        visible={showClipOverlay}
+        setIsVisible={setShowClipOverlay}
+      />
     </>
   )
 }

--- a/src/view/screens/Home.tsx
+++ b/src/view/screens/Home.tsx
@@ -4,8 +4,15 @@ import {useFocusEffect} from '@react-navigation/native'
 
 import {PROD_DEFAULT_FEED} from '#/lib/constants'
 import {useNonReactiveCallback} from '#/lib/hooks/useNonReactiveCallback'
+import {useOTAUpdates} from '#/lib/hooks/useOTAUpdates'
 import {useSetTitle} from '#/lib/hooks/useSetTitle'
+import {useRequestNotificationsPermission} from '#/lib/notifications/notifications'
+import {
+  HomeTabNavigatorParams,
+  NativeStackScreenProps,
+} from '#/lib/routes/types'
 import {logEvent, LogEvents} from '#/lib/statsig/statsig'
+import {isWeb} from '#/platform/detection'
 import {emitSoftReset} from '#/state/events'
 import {SavedFeedSourceInfo, usePinnedFeedsInfos} from '#/state/queries/feed'
 import {FeedParams} from '#/state/queries/post-feed'
@@ -13,26 +20,34 @@ import {usePreferencesQuery} from '#/state/queries/preferences'
 import {UsePreferencesQueryResponse} from '#/state/queries/preferences/types'
 import {useSession} from '#/state/session'
 import {useSetDrawerSwipeDisabled, useSetMinimalShellMode} from '#/state/shell'
+import {useLoggedOutViewControls} from '#/state/shell/logged-out'
 import {useSelectedFeed, useSetSelectedFeed} from '#/state/shell/selected-feed'
-import {useOTAUpdates} from 'lib/hooks/useOTAUpdates'
-import {useRequestNotificationsPermission} from 'lib/notifications/notifications'
-import {HomeTabNavigatorParams, NativeStackScreenProps} from 'lib/routes/types'
-import {FeedPage} from 'view/com/feeds/FeedPage'
-import {Pager, PagerRef, RenderTabBarFnProps} from 'view/com/pager/Pager'
-import {CustomFeedEmptyState} from 'view/com/posts/CustomFeedEmptyState'
-import {FollowingEmptyState} from 'view/com/posts/FollowingEmptyState'
-import {FollowingEndOfFeed} from 'view/com/posts/FollowingEndOfFeed'
+import {FeedPage} from '#/view/com/feeds/FeedPage'
+import {Pager, PagerRef, RenderTabBarFnProps} from '#/view/com/pager/Pager'
+import {CustomFeedEmptyState} from '#/view/com/posts/CustomFeedEmptyState'
+import {FollowingEmptyState} from '#/view/com/posts/FollowingEmptyState'
+import {FollowingEndOfFeed} from '#/view/com/posts/FollowingEndOfFeed'
 import {NoFeedsPinned} from '#/screens/Home/NoFeedsPinned'
 import {HomeHeader} from '../com/home/HomeHeader'
 
 type Props = NativeStackScreenProps<HomeTabNavigatorParams, 'Home' | 'Start'>
 export function HomeScreen(props: Props) {
+  const {setShowLoggedOut} = useLoggedOutViewControls()
   const {data: preferences} = usePreferencesQuery()
   const {currentAccount} = useSession()
   const {data: pinnedFeedInfos, isLoading: isPinnedFeedsLoading} =
     usePinnedFeedsInfos()
 
   React.useEffect(() => {
+    if (isWeb && !currentAccount) {
+      const getParams = new URLSearchParams(window.location.search)
+      const splash = getParams.get('splash')
+      if (splash === 'true') {
+        setShowLoggedOut(true)
+        return
+      }
+    }
+
     const params = props.route.params
     if (
       currentAccount &&
@@ -45,7 +60,13 @@ export function HomeScreen(props: Props) {
         name: params.name,
       })
     }
-  }, [currentAccount, props.navigation, props.route.name, props.route.params])
+  }, [
+    currentAccount,
+    props.navigation,
+    props.route.name,
+    props.route.params,
+    setShowLoggedOut,
+  ])
 
   if (preferences && pinnedFeedInfos && !isPinnedFeedsLoading) {
     return (


### PR DESCRIPTION
An unlikely edge case - which probably doesn't explain the thing Apple is seeing - that is possible to hit. The user would need to actually be signed in on web for this to be possible, since otherwise they'd get redirected to `/start` rather than `/starter-pack`, but might as well fix it here.