### PR TITLE
Filter out non-configrable mod authorities from report dialog

### DIFF
--- a/src/screens/Moderation/index.tsx
+++ b/src/screens/Moderation/index.tsx
@@ -169,7 +169,7 @@ export function ModerationScreenInner({
     isLoading: isLabelersLoading,
     data: labelers,
     error: labelersError,
-  } = useMyLabelersQuery()
+  } = useMyLabelersQuery({includeNonConfigurable: true})
 
   useFocusEffect(
     React.useCallback(() => {

--- a/src/state/queries/preferences/moderation.ts
+++ b/src/state/queries/preferences/moderation.ts
@@ -1,12 +1,13 @@
 import React from 'react'
 import {
-  DEFAULT_LABEL_SETTINGS,
   BskyAgent,
+  DEFAULT_LABEL_SETTINGS,
   interpretLabelValueDefinitions,
 } from '@atproto/api'
 
-import {usePreferencesQuery} from './index'
+import {isNonConfigurableModerationAuthority} from '#/state/session/additional-moderation-authorities'
 import {useLabelersDetailedInfoQuery} from '../labeler'
+import {usePreferencesQuery} from './index'
 
 /**
  * More strict than our default settings for logged in users.
@@ -16,15 +17,27 @@ export const DEFAULT_LOGGED_OUT_LABEL_PREFERENCES: typeof DEFAULT_LABEL_SETTINGS
     Object.entries(DEFAULT_LABEL_SETTINGS).map(([key, _pref]) => [key, 'hide']),
   )
 
-export function useMyLabelersQuery() {
+export function useMyLabelersQuery({
+  includeNonConfigurable = false,
+}: {
+  includeNonConfigurable?: boolean
+} = {}) {
   const prefs = usePreferencesQuery()
-  const dids = Array.from(
+  let dids = Array.from(
     new Set(
       BskyAgent.appLabelers.concat(
         prefs.data?.moderationPrefs.labelers.map(l => l.did) || [],
       ),
     ),
   )
+
+  /*
+   * By default, remove non-configurable moderation authorities
+   */
+  if (!includeNonConfigurable) {
+    dids = dids.filter(did => !isNonConfigurableModerationAuthority(did))
+  }
+
   const labelers = useLabelersDetailedInfoQuery({dids})
   const isLoading = prefs.isLoading || labelers.isLoading
   const error = prefs.error || labelers.error


### PR DESCRIPTION
Non-configurable regional labelers should not appear in the report dialog. However, they should appear on the Moderation screen.

This PR filters them out by default (since users can't really interact with them), but adds a flag to optionally include them where needed.