### PR TITLE
Make default banner more palatable

### DIFF
--- a/src/view/com/util/UserBanner.tsx
+++ b/src/view/com/util/UserBanner.tsx
@@ -106,7 +106,7 @@ export function UserBanner({
               ) : (
                 <View
                   testID="userBannerFallback"
-                  style={[styles.bannerImage, styles.defaultBanner]}
+                  style={[styles.bannerImage, t.atoms.bg_contrast_25]}
                 />
               )}
               <View style={[styles.editButtonContainer, pal.btn]}>
@@ -181,7 +181,7 @@ export function UserBanner({
       testID="userBannerFallback"
       style={[
         styles.bannerImage,
-        type === 'labeler' ? styles.labelerBanner : styles.defaultBanner,
+        type === 'labeler' ? styles.labelerBanner : t.atoms.bg_contrast_25,
       ]}
     />
   )
@@ -202,9 +202,6 @@ const styles = StyleSheet.create({
   bannerImage: {
     width: '100%',
     height: 150,
-  },
-  defaultBanner: {
-    backgroundColor: '#0070ff',
   },
   labelerBanner: {
     backgroundColor: tokens.color.temp_purple,


### PR DESCRIPTION
With our avatar generation (even without) this blue default banner color is pretty garish. This tones it back to look a little nicer out of the gate.

![CleanShot 2024-10-10 at 12 10 28@2x](https://github.com/user-attachments/assets/cc86c39f-73fe-4516-8a09-5e67140f2ff0)
![CleanShot 2024-10-10 at 12 10 26@2x](https://github.com/user-attachments/assets/60781fe9-7566-49be-a400-938e45efa71c)

Before
![CleanShot 2024-10-10 at 12 10 38@2x](https://github.com/user-attachments/assets/700808a3-7d68-4358-96fd-341963c8204d)
![CleanShot 2024-10-10 at 12 10 40@2x](https://github.com/user-attachments/assets/573f9cd3-45f7-47e7-bb1f-57ec7a8c6e8b)
