### PR TITLE
Bump icon size for small size buttons

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -670,7 +670,7 @@ export function ButtonIcon({
       size ??
       (({
         large: 'sm',
-        small: 'xs',
+        small: 'sm',
         tiny: 'xs',
       }[buttonSize || 'small'] || 'sm') as Exclude<
         SVGIconProps['size'],


### PR DESCRIPTION
This was an oversight, should definitely be a size up.
![CleanShot 2024-10-10 at 18 28 23@2x](https://github.com/user-attachments/assets/1d96df86-d07c-453a-814a-e561cba1e717)
