### PR TITLE
Fix in pt-br locale

### DIFF
--- a/src/locale/locales/pt-BR/messages.po
+++ b/src/locale/locales/pt-BR/messages.po
@@ -2657,7 +2657,7 @@ msgstr "Expirado"
 
 #: src/components/dialogs/MutedWords.tsx:548
 msgid "Expires {0}"
-msgstr "Expirada {0}"
+msgstr "Expira {0}"
 
 #: src/lib/moderation/useGlobalLabelStrings.ts:47
 msgid "Explicit or potentially disturbing media."


### PR DESCRIPTION
![example image](https://github.com/user-attachments/assets/c9cab9df-71e2-46de-9221-050e67d6a00a)
the goal is to change sentences in the muted words window from something like "Expirada em 4 dias" to "Expira em 4 dias"