### PR TITLE
Tweak threadgate button sizing in the composer on Web

### DIFF
--- a/src/view/com/composer/threadgate/ThreadgateBtn.tsx
+++ b/src/view/com/composer/threadgate/ThreadgateBtn.tsx
@@ -64,7 +64,9 @@ export function ThreadgateBtn({
           accessibilityHint={_(
             msg`Opens a dialog to choose who can reply to this thread`,
           )}
-          style={{paddingVertical: 6, paddingHorizontal: 8}}>
+          style={
+            !isNative ? {paddingVertical: 6, paddingHorizontal: 8} : undefined
+          }>
           <ButtonIcon icon={anyoneCanInteract ? Earth : Group} />
           <ButtonText>{label}</ButtonText>
         </Button>

--- a/src/view/com/composer/threadgate/ThreadgateBtn.tsx
+++ b/src/view/com/composer/threadgate/ThreadgateBtn.tsx
@@ -63,7 +63,8 @@ export function ThreadgateBtn({
           label={label}
           accessibilityHint={_(
             msg`Opens a dialog to choose who can reply to this thread`,
-          )}>
+          )}
+          style={{paddingVertical: 6, paddingHorizontal: 8}}>
           <ButtonIcon icon={anyoneCanInteract ? Earth : Group} />
           <ButtonText>{label}</ButtonText>
         </Button>


### PR DESCRIPTION
Reduces the pad on Web so the button isnt so dominant

|Before|After|
|-|-|
|![CleanShot 2024-10-10 at 16 59 00@2x](https://github.com/user-attachments/assets/b22d0fa0-835c-4f9d-985e-f1d4c3bbb47e)|![CleanShot 2024-10-10 at 16 58 39@2x](https://github.com/user-attachments/assets/cd8754e8-61ab-420c-b7d1-2411c0f5c55c)|

Mobile remains unchanged

|Mobile|
|-|
|![CleanShot 2024-10-10 at 17 11 57@2x](https://github.com/user-attachments/assets/bd964508-7191-4439-8cbc-3f83000d1f61)|
