### PR TITLE
Disable contextual alternates only in Inter

### DIFF
--- a/src/alf/fonts.ts
+++ b/src/alf/fonts.ts
@@ -59,11 +59,15 @@ export function applyFonts(
     }
   }
 
+  style.fontVariant = style.fontVariant || []
+
   /**
-   * Disable contextual ligatures
+   * Disable contextual alternates in Inter
    * {@link https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant}
    */
-  style.fontVariant = (style.fontVariant || []).concat('no-contextual')
+  if (fontFamily === 'theme') {
+    style.fontVariant = (style.fontVariant || []).concat('no-contextual')
+  }
 }
 
 /*


### PR DESCRIPTION
Disables contextual alternates only in Inter because non-common contextual alternates such as `0x10` and `=> ->` are characteristic of Inter.