### PR TITLE
Move intent handler to a child of `InnerApp`

### DIFF
--- a/src/App.native.tsx
+++ b/src/App.native.tsx
@@ -14,7 +14,6 @@ import * as SplashScreen from 'expo-splash-screen'
 import {msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
-import {useIntentHandler} from '#/lib/hooks/useIntentHandler'
 import {QueryProvider} from '#/lib/react-query'
 import {
   initialize,
@@ -85,7 +84,6 @@ function InnerApp() {
   const theme = useColorModeTheme()
   const {_} = useLingui()
 
-  useIntentHandler()
   const hasCheckedReferrer = useStarterPackEntry()
 
   // init

--- a/src/lib/hooks/useIntentHandler.ts
+++ b/src/lib/hooks/useIntentHandler.ts
@@ -13,6 +13,8 @@ type IntentType = 'compose' | 'verify-email'
 
 const VALID_IMAGE_REGEX = /^[\w.:\-_/]+\|\d+(\.\d+)?\|\d+(\.\d+)?$/
 
+let previousIntentUrl = ''
+
 export function useIntentHandler() {
   const incomingUrl = Linking.useURL()
   const composeIntent = useComposeIntent()
@@ -68,7 +70,13 @@ export function useIntentHandler() {
       }
     }
 
-    if (incomingUrl) handleIncomingURL(incomingUrl)
+    if (incomingUrl) {
+      if (previousIntentUrl === incomingUrl) {
+        return
+      }
+      handleIncomingURL(incomingUrl)
+      previousIntentUrl = incomingUrl
+    }
   }, [incomingUrl, composeIntent, verifyEmailIntent])
 }
 

--- a/src/lib/hooks/useIntentHandler.ts
+++ b/src/lib/hooks/useIntentHandler.ts
@@ -13,6 +13,7 @@ type IntentType = 'compose' | 'verify-email'
 
 const VALID_IMAGE_REGEX = /^[\w.:\-_/]+\|\d+(\.\d+)?\|\d+(\.\d+)?$/
 
+// This needs to stay outside of react to persist between account switches
 let previousIntentUrl = ''
 
 export function useIntentHandler() {

--- a/src/view/shell/index.tsx
+++ b/src/view/shell/index.tsx
@@ -14,6 +14,7 @@ import {StatusBar} from 'expo-status-bar'
 import {useNavigation, useNavigationState} from '@react-navigation/native'
 
 import {useDedupe} from '#/lib/hooks/useDedupe'
+import {useIntentHandler} from '#/lib/hooks/useIntentHandler'
 import {useNotificationsHandler} from '#/lib/hooks/useNotificationHandler'
 import {usePalette} from '#/lib/hooks/usePalette'
 import {useNotificationsRegistration} from '#/lib/notifications/notifications'
@@ -129,6 +130,8 @@ export const Shell: React.FC = function ShellImpl() {
   const {fullyExpandedCount} = useDialogStateControlContext()
   const pal = usePalette('default')
   const theme = useTheme()
+  useIntentHandler()
+
   React.useEffect(() => {
     if (isAndroid) {
       NavigationBar.setBackgroundColorAsync(theme.palette.default.background)


### PR DESCRIPTION
## Why

We did some tweaking for the composer state, and that provider is now being used beneath the `useIntentHandler()` hook. We can move this to `Shell`, which actually gives us some additional benefits:

- Composer doesn't open until the app is seemingly "ready" (no longer opens with the splash screen as could happen right now)
- We ensure that the session is ready to go before attempting to use an intent

We should check that everything still works correctly though.

## Test Plan

- Compose intents work
  - Video
  - Images
- Verify email intent works