### PR TITLE
Type tweaks

### DIFF
--- a/src/alf/fonts.ts
+++ b/src/alf/fonts.ts
@@ -52,21 +52,23 @@ export function applyFonts(
     if (isWeb) {
       style.fontFamily += `, ${FAMILIES}`
     }
+
+    /**
+     * Disable contextual alternates in Inter
+     * {@link https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant}
+     */
+    style.fontVariant = (style.fontVariant || []).concat('no-contextual')
   } else {
     // fallback families only supported on web
     if (isWeb) {
       style.fontFamily = style.fontFamily || FAMILIES
     }
-  }
 
-  style.fontVariant = style.fontVariant || []
-
-  /**
-   * Disable contextual alternates in Inter
-   * {@link https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant}
-   */
-  if (fontFamily === 'theme') {
-    style.fontVariant = (style.fontVariant || []).concat('no-contextual')
+    /**
+     * Overridden to previous spacing for the `system` font option.
+     * https://github.com/bluesky-social/social-app/commit/2419096e2409008b7d71fd6b8f8d0dd5b016e267
+     */
+    style.letterSpacing = 0.25
   }
 }
 

--- a/src/alf/fonts.ts
+++ b/src/alf/fonts.ts
@@ -1,3 +1,4 @@
+import {TextStyle} from 'react-native'
 import {useFonts} from 'expo-font'
 
 import {isWeb} from '#/platform/detection'
@@ -37,10 +38,7 @@ export function setFontFamily(fontFamily: Device['fontFamily']) {
 /*
  * Unused fonts are commented out, but the files are there if we need them.
  */
-export function applyFonts(
-  style: Record<string, any>,
-  fontFamily: 'system' | 'theme',
-) {
+export function applyFonts(style: TextStyle, fontFamily: 'system' | 'theme') {
   if (fontFamily === 'theme') {
     style.fontFamily = 'InterVariable'
 


### PR DESCRIPTION
Overrides the global tracking for the `system` font variant back to what it was prior to 2419096e2409008b7d71fd6b8f8d0dd5b016e267

System @ 0.25px tracking
![CleanShot 2024-10-10 at 20 50 04@2x](https://github.com/user-attachments/assets/a344d32d-b4d8-4d4e-b0ca-ad870173860b)
![CleanShot 2024-10-10 at 20 56 10@2x](https://github.com/user-attachments/assets/25e795ae-ed3d-48d4-ab5e-3108f02ce1b5)

Inter @ `normal` tracking (the default, since it's a variable font with contextual-sizing enabled)
![CleanShot 2024-10-10 at 20 49 53@2x](https://github.com/user-attachments/assets/860ba8fe-d384-4c9f-bc99-24d7bb19e341)
![CleanShot 2024-10-10 at 20 56 00@2x](https://github.com/user-attachments/assets/7c91424d-966a-4ee6-9543-87b810fe472b)
