### PR TITLE
Sanitize multiple spaces in display names to protect against some security concerns

### DIFF
--- a/src/lib/strings/display-names.ts
+++ b/src/lib/strings/display-names.ts
@@ -7,6 +7,7 @@ import {ModerationUI} from '@atproto/api'
 const CHECK_MARKS_RE = /[\u2705\u2713\u2714\u2611]/gu
 const CONTROL_CHARS_RE =
   /[\u0000-\u001F\u007F-\u009F\u061C\u200E\u200F\u202A-\u202E\u2066-\u2069]/g
+const MULTIPLE_SPACES_RE = /[\s][\s]+/g
 
 export function sanitizeDisplayName(
   str: string,
@@ -16,7 +17,11 @@ export function sanitizeDisplayName(
     return ''
   }
   if (typeof str === 'string') {
-    return str.replace(CHECK_MARKS_RE, '').replace(CONTROL_CHARS_RE, '').trim()
+    return str
+      .replace(CHECK_MARKS_RE, '')
+      .replace(CONTROL_CHARS_RE, '')
+      .replace(MULTIPLE_SPACES_RE, ' ')
+      .trim()
   }
   return ''
 }


### PR DESCRIPTION
Adds a display name sanitation rule which reduces runs of spaces into a single space.

|Before|After|
|-|-|
|![CleanShot 2024-10-10 at 20 05 44@2x](https://github.com/user-attachments/assets/5f1d7d92-37e4-47a3-b55e-36ffe701a29d)|![CleanShot 2024-10-10 at 20 05 29@2x](https://github.com/user-attachments/assets/b40ad942-765a-4eb1-96b4-6ae8342bf012)|

With apologies to rem.
