### PR TITLE
Fix performance of feed reordering and add layout animations

### DIFF
--- a/src/view/screens/SavedFeeds.tsx
+++ b/src/view/screens/SavedFeeds.tsx
@@ -274,7 +274,8 @@ function ListItem({
     const index = ids.indexOf(feed.id)
     const nextIndex = index + 1
 
-    if (index === -1 || index >= nextFeeds.length - 1) return
+    if (index === -1 || index >= nextFeeds.filter(f => f.pinned).length - 1)
+      return
     ;[nextFeeds[index], nextFeeds[nextIndex]] = [
       nextFeeds[nextIndex],
       nextFeeds[index],

--- a/src/view/screens/SavedFeeds.tsx
+++ b/src/view/screens/SavedFeeds.tsx
@@ -292,7 +292,7 @@ function ListItem({
   return (
     <Animated.View
       style={[styles.itemContainer, pal.border]}
-      layout={LinearTransition}>
+      layout={LinearTransition.duration(100)}>
       {feed.type === 'timeline' ? (
         <FollowingFeedCard />
       ) : (

--- a/src/view/screens/SavedFeeds.tsx
+++ b/src/view/screens/SavedFeeds.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import {ActivityIndicator, Pressable, StyleSheet, View} from 'react-native'
+import Animated, {LinearTransition} from 'react-native-reanimated'
 import {AppBskyActorDefs} from '@atproto/api'
 import {FontAwesomeIcon} from '@fortawesome/react-native-fontawesome'
 import {msg, Trans} from '@lingui/macro'
@@ -288,7 +289,9 @@ function ListItem({
   }, [playHaptic, feed, currentFeeds, setCurrentFeeds])
 
   return (
-    <View style={[styles.itemContainer, pal.border]}>
+    <Animated.View
+      style={[styles.itemContainer, pal.border]}
+      layout={LinearTransition}>
       {feed.type === 'timeline' ? (
         <FollowingFeedCard />
       ) : (
@@ -380,7 +383,7 @@ function ListItem({
           />
         </Pressable>
       </View>
-    </View>
+    </Animated.View>
   )
 }
 

--- a/src/view/screens/SavedFeeds.tsx
+++ b/src/view/screens/SavedFeeds.tsx
@@ -33,19 +33,6 @@ import {Button, ButtonIcon, ButtonText} from '#/components/Button'
 import {FilterTimeline_Stroke2_Corner0_Rounded as FilterTimeline} from '#/components/icons/FilterTimeline'
 import {Loader} from '#/components/Loader'
 
-const HITSLOP_TOP = {
-  top: 20,
-  left: 20,
-  bottom: 5,
-  right: 20,
-}
-const HITSLOP_BOTTOM = {
-  top: 5,
-  left: 20,
-  bottom: 20,
-  right: 20,
-}
-
 type Props = NativeStackScreenProps<CommonNavigatorParams, 'SavedFeeds'>
 export function SavedFeeds({}: Props) {
   const {data: preferences} = usePreferencesQuery()
@@ -318,7 +305,7 @@ function ListItem({
           <Pressable
             accessibilityRole="button"
             onPress={onPressUp}
-            hitSlop={HITSLOP_TOP}
+            hitSlop={5}
             style={state => ({
               backgroundColor: pal.viewLight.backgroundColor,
               paddingHorizontal: 12,
@@ -336,7 +323,7 @@ function ListItem({
           <Pressable
             accessibilityRole="button"
             onPress={onPressDown}
-            hitSlop={HITSLOP_BOTTOM}
+            hitSlop={5}
             style={state => ({
               backgroundColor: pal.viewLight.backgroundColor,
               paddingHorizontal: 12,
@@ -359,7 +346,7 @@ function ListItem({
           accessibilityLabel={_(msg`Remove from my feeds`)}
           accessibilityHint=""
           onPress={onPressRemove}
-          hitSlop={15}
+          hitSlop={5}
           style={state => ({
             marginRight: 8,
             paddingHorizontal: 12,
@@ -377,7 +364,7 @@ function ListItem({
       <View style={{paddingRight: 16}}>
         <Pressable
           accessibilityRole="button"
-          hitSlop={10}
+          hitSlop={5}
           onPress={onTogglePinned}
           style={state => ({
             backgroundColor: pal.viewLight.backgroundColor,


### PR DESCRIPTION
Changes the "Edit Feeds" screen to bundle all of the changes into one save action. Also adds animations. Tested on web, ios sim, and android sim.

|Mobile|Desktop|
|-|-|
|https://github.com/user-attachments/assets/9c8f6fe6-da36-47f0-871c-70f4d42a8be7|https://github.com/user-attachments/assets/19258a16-e5e6-438a-abfc-c8984a3b5370|



