### PR TITLE
Remove autofocus from alt text input

### DIFF
--- a/src/view/com/composer/GifAltText.tsx
+++ b/src/view/com/composer/GifAltText.tsx
@@ -9,7 +9,7 @@ import {
   EmbedPlayerParams,
   parseEmbedPlayerFromUrl,
 } from '#/lib/strings/embed-player'
-import {isAndroid} from '#/platform/detection'
+import {isAndroid, isWeb} from '#/platform/detection'
 import {useResolveGifQuery} from '#/state/queries/resolve-link'
 import {Gif} from '#/state/queries/tenor'
 import {AltTextCounterWrapper} from '#/view/com/composer/AltTextCounterWrapper'
@@ -157,7 +157,7 @@ function AltTextInner({
                   defaultValue={altText}
                   multiline
                   numberOfLines={3}
-                  autoFocus
+                  autoFocus={isWeb}
                   onKeyPress={({nativeEvent}) => {
                     if (nativeEvent.key === 'Escape') {
                       control.close()

--- a/src/view/com/composer/GifAltText.tsx
+++ b/src/view/com/composer/GifAltText.tsx
@@ -1,5 +1,5 @@
 import React, {useState} from 'react'
-import {TouchableOpacity, View} from 'react-native'
+import {Dimensions, TouchableOpacity, View} from 'react-native'
 import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
@@ -107,7 +107,8 @@ export function GifAltTextDialogLoaded({
         control={control}
         onClose={() => {
           onSubmit(altTextDraft)
-        }}>
+        }}
+        nativeOptions={{minHeight: Dimensions.get('window').height}}>
         <Dialog.Handle />
         <AltTextInner
           vendorAltText={vendorAltText}

--- a/src/view/com/composer/photos/ImageAltTextDialog.tsx
+++ b/src/view/com/composer/photos/ImageAltTextDialog.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import {ImageStyle, useWindowDimensions, View} from 'react-native'
+import {Dimensions, ImageStyle, useWindowDimensions, View} from 'react-native'
 import {Image} from 'expo-image'
 import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
@@ -38,7 +38,8 @@ export const ImageAltTextDialog = ({
           ...image,
           alt: enforceLen(altText, MAX_ALT_TEXT, true),
         })
-      }}>
+      }}
+      nativeOptions={{minHeight: Dimensions.get('window').height}}>
       <Dialog.Handle />
       <ImageAltTextInner
         control={control}

--- a/src/view/com/composer/photos/ImageAltTextDialog.tsx
+++ b/src/view/com/composer/photos/ImageAltTextDialog.tsx
@@ -122,7 +122,7 @@ const ImageAltTextInner = ({
                 defaultValue={altText}
                 multiline
                 numberOfLines={3}
-                autoFocus
+                autoFocus={isWeb}
               />
             </TextField.Root>
           </View>


### PR DESCRIPTION
## Why

I have been unable to reproduce this issue, but in the past the autofocus prop has caused problems with these types of dialogs. Let's remove it from the alt composer for now and see if that provides us any success. If it does, we can re-evaluate with a better fix later perhaps.

## Test Plan

Things should work as they do now, though the input should not be focused immediately.