### PR TITLE
shift hitslop of avi follow button

### DIFF
--- a/src/view/com/posts/AviFollowButton.tsx
+++ b/src/view/com/posts/AviFollowButton.tsx
@@ -87,8 +87,8 @@ export function AviFollowButton({
           hitSlop={{
             top: 0,
             left: 0,
-            right: 3,
-            bottom: 3,
+            right: 5,
+            bottom: 5,
           }}
           style={[
             a.rounded_full,

--- a/src/view/com/posts/AviFollowButton.tsx
+++ b/src/view/com/posts/AviFollowButton.tsx
@@ -5,7 +5,6 @@ import {msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 import {useNavigation} from '@react-navigation/native'
 
-import {createHitslop} from '#/lib/constants'
 import {NavigationProp} from '#/lib/routes/types'
 import {sanitizeDisplayName} from '#/lib/strings/display-names'
 import {useProfileShadow} from '#/state/cache/profile-shadow'
@@ -85,7 +84,12 @@ export function AviFollowButton({
       {!isFollowing && (
         <Button
           label={_(msg`Open ${name} profile shortcut menu`)}
-          hitSlop={createHitslop(3)}
+          hitSlop={{
+            top: 0,
+            left: 0,
+            right: 3,
+            bottom: 3,
+          }}
           style={[
             a.rounded_full,
             a.absolute,


### PR DESCRIPTION
A smaller avatar makes it a little bit harder to "tap". The avi follow button's hitslop is currently extending into the avatar a bit, and because the overall avatar hit area is smaller, its harder to "correctly" hit it unless you tap the top of the avatar.

At least on a simulator, this lets us tap in the area the user probably expects and tries to tap in. Need to test on a physical device to be sure though, since simulator is easy to not realize problems with irt hit area. 