### PR TITLE
Translate some missing strings via global i18n instance

### DIFF
--- a/src/lib/media/picker.shared.ts
+++ b/src/lib/media/picker.shared.ts
@@ -3,8 +3,10 @@ import {
   launchImageLibraryAsync,
   MediaTypeOptions,
 } from 'expo-image-picker'
+// TODO: replace global i18n instance with one returned from useLingui -sfn
+import {t} from '@lingui/macro'
 
-import * as Toast from 'view/com/util/Toast'
+import * as Toast from '#/view/com/util/Toast'
 import {getDataUriSize} from './util'
 
 export async function openPicker(opts?: ImagePickerOptions) {
@@ -17,14 +19,14 @@ export async function openPicker(opts?: ImagePickerOptions) {
   })
 
   if (response.assets && response.assets.length > 4) {
-    Toast.show('You may only select up to 4 images', 'exclamation-circle')
+    Toast.show(t`You may only select up to 4 images`, 'exclamation-circle')
   }
 
   return (response.assets ?? [])
     .slice(0, 4)
     .filter(asset => {
       if (asset.mimeType?.startsWith('image/')) return true
-      Toast.show('Only image files are supported', 'exclamation-circle')
+      Toast.show(t`Only image files are supported`, 'exclamation-circle')
       return false
     })
     .map(image => ({

--- a/src/lib/sharing.ts
+++ b/src/lib/sharing.ts
@@ -1,8 +1,10 @@
 import {Share} from 'react-native'
 // import * as Sharing from 'expo-sharing'
 import {setStringAsync} from 'expo-clipboard'
+// TODO: replace global i18n instance with one returned from useLingui -sfn
+import {t} from '@lingui/macro'
 
-import {isAndroid, isIOS} from 'platform/detection'
+import {isAndroid, isIOS} from '#/platform/detection'
 import * as Toast from '#/view/com/util/Toast'
 
 /**
@@ -20,6 +22,6 @@ export async function shareUrl(url: string) {
     // React Native Share is not supported by web. Web Share API
     // has increasing but not full support, so default to clipboard
     setStringAsync(url)
-    Toast.show('Copied to clipboard', 'clipboard-check')
+    Toast.show(t`Copied to clipboard`, 'clipboard-check')
   }
 }

--- a/src/view/com/util/forms/PostDropdownBtn.tsx
+++ b/src/view/com/util/forms/PostDropdownBtn.tsx
@@ -268,8 +268,8 @@ let PostDropdownBtn = ({
       item: postUri,
       feedContext: postFeedContext,
     })
-    Toast.show('Feedback sent!')
-  }, [feedFeedback, postUri, postFeedContext])
+    Toast.show(_(msg`Feedback sent!`))
+  }, [feedFeedback, postUri, postFeedContext, _])
 
   const onPressShowLess = React.useCallback(() => {
     feedFeedback.sendInteraction({
@@ -277,8 +277,8 @@ let PostDropdownBtn = ({
       item: postUri,
       feedContext: postFeedContext,
     })
-    Toast.show('Feedback sent!')
-  }, [feedFeedback, postUri, postFeedContext])
+    Toast.show(_(msg`Feedback sent!`))
+  }, [feedFeedback, postUri, postFeedContext, _])
 
   const onSelectChatToShareTo = React.useCallback(
     (conversation: string) => {


### PR DESCRIPTION
There are a few strings shown via toasts that are currently untranslated, since we have yet to restructure the places they are called to allow passing an i18n instance. however, in this circumstance, we can use the global `t` macro to translate them. This is not ideal, since it won't change when the language changes, however it's better than nothing. See the lingui docs:

https://lingui.dev/tutorials/react-patterns#translations-outside-react-components

My reasoning is that it's better for them to be translated but not change when changing language in the app, verses always being in english

# Test plan

Make up some translations for them by generating the i18n files, then check that they get translated after changing language and then restarting the app 