### PR TITLE
Fix clipping issue with 2 image grid

### DIFF
--- a/src/view/com/util/images/ImageLayoutGrid.tsx
+++ b/src/view/com/util/images/ImageLayoutGrid.tsx
@@ -24,7 +24,7 @@ export function ImageLayoutGrid({style, ...props}: ImageLayoutGridProps) {
         : a.gap_2xs
       : a.gap_xs
   const count = props.images.length
-  let aspectRatio = count === 3 ? 2 : undefined
+  const aspectRatio = count === 3 ? 2 : undefined
   return (
     <View style={style}>
       <View style={[gap, a.rounded_md, a.overflow_hidden, {aspectRatio}]}>

--- a/src/view/com/util/images/ImageLayoutGrid.tsx
+++ b/src/view/com/util/images/ImageLayoutGrid.tsx
@@ -24,18 +24,7 @@ export function ImageLayoutGrid({style, ...props}: ImageLayoutGridProps) {
         : a.gap_2xs
       : a.gap_xs
   const count = props.images.length
-  let aspectRatio
-  switch (count) {
-    case 2:
-      aspectRatio = 2
-      break
-    case 3:
-      aspectRatio = 2
-      break
-    case 4:
-      aspectRatio = undefined
-      break
-  }
+  let aspectRatio = count === 3 ? 2 : undefined
   return (
     <View style={style}>
       <View style={[gap, a.rounded_md, a.overflow_hidden, {aspectRatio}]}>


### PR DESCRIPTION
Simply removes the aspect ratio of the container, since it didn't account for the gap

<table>
  <thead>
    <tr>
      <th>Before</th>
      <th>After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><img width="400" alt="Screenshot 2024-10-14 at 13 29 19" src="https://github.com/user-attachments/assets/e5452cf9-0e38-417f-b15d-185fb79eb477" /></td>
      <td><img width="400" alt="Screenshot 2024-10-14 at 13 29 32" src="https://github.com/user-attachments/assets/ad2469fb-60d7-484b-997f-cd031493171a" /></td>
    </tr>
  </tbody>
</table>