### PR TITLE
Move the profile header back-button in front of banner on Android

### DIFF
--- a/src/screens/Profile/Header/GrowableBanner.tsx
+++ b/src/screens/Profile/Header/GrowableBanner.tsx
@@ -36,8 +36,8 @@ export function GrowableBanner({
   if (!pagerContext || !isIOS) {
     return (
       <View style={[a.w_full, a.h_full]}>
-        {backButton}
         {children}
+        {backButton}
       </View>
     )
   }

--- a/src/screens/Profile/Header/Shell.tsx
+++ b/src/screens/Profile/Header/Shell.tsx
@@ -66,7 +66,7 @@ let ProfileHeaderShell = ({
   return (
     <View style={t.atoms.bg} pointerEvents={isIOS ? 'auto' : 'box-none'}>
       <View
-        pointerEvents={isIOS ? 'auto' : 'none'}
+        pointerEvents={isIOS ? 'auto' : 'box-none'}
         style={[a.relative, {height: 150}]}>
         <GrowableBanner
           backButton={


### PR DESCRIPTION
On Android, the new GrowableBanner places the back button in profile headers behind the banner, making it inaccessible (i think this was unintentional).
I brought it to the front and made it pressable again