### PR TITLE
Update web font families def

### DIFF
--- a/src/alf/fonts.ts
+++ b/src/alf/fonts.ts
@@ -4,7 +4,7 @@ import {useFonts} from 'expo-font'
 import {isWeb} from '#/platform/detection'
 import {Device, device} from '#/storage'
 
-const FAMILIES = `-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Liberation Sans", Helvetica, Arial, sans-serif`
+const WEB_FONT_FAMILIES = `system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji"`
 
 const factor = 0.0625 // 1 - (15/16)
 const fontScaleMultipliers: Record<Device['fontScale'], number> = {
@@ -48,7 +48,7 @@ export function applyFonts(style: TextStyle, fontFamily: 'system' | 'theme') {
 
     // fallback families only supported on web
     if (isWeb) {
-      style.fontFamily += `, ${FAMILIES}`
+      style.fontFamily += `, ${WEB_FONT_FAMILIES}`
     }
 
     /**
@@ -59,7 +59,7 @@ export function applyFonts(style: TextStyle, fontFamily: 'system' | 'theme') {
   } else {
     // fallback families only supported on web
     if (isWeb) {
-      style.fontFamily = style.fontFamily || FAMILIES
+      style.fontFamily = style.fontFamily || WEB_FONT_FAMILIES
     }
 
     /**


### PR DESCRIPTION
Fixes #5722

This font stack is something we've all been copying around for years, but looks like we should update it to include `system-ui`. Thanks to @byemc for pointing that out!

I pulled this `font-family` definition from GitHub itself and prepended `system-ui`.