### PR TITLE
Fix weird ALT label press behavior in embedded images

### DIFF
--- a/src/view/com/util/images/AutoSizedImage.tsx
+++ b/src/view/com/util/images/AutoSizedImage.tsx
@@ -125,6 +125,7 @@ export function AutoSizedImage({
 
       {(hasAlt || isCropped) && !hideBadge ? (
         <View
+          pointerEvents="none"
           accessible={false}
           style={[
             a.absolute,

--- a/src/view/com/util/images/Gallery.tsx
+++ b/src/view/com/util/images/Gallery.tsx
@@ -89,6 +89,7 @@ export function GalleryItem({
       {hasAlt && !hideBadges ? (
         <View
           accessible={false}
+          pointerEvents="none"
           style={[
             a.absolute,
             a.flex_row,


### PR DESCRIPTION
On posts with more than one embedded image, pressing on the ALT label on any of the images registers a press on the rest of the post instead of on the image, which is weird, see video. This doesn't happen with a single embedded image


https://github.com/user-attachments/assets/1dc52bc5-9e4d-4dd8-a166-360e915b8b4e



EDIT: This is what happens in posts with a single embedded image (added ripple for visibility). It looks like it does register a press on the actual image but it's kinda funky (it starts at the top right corner instead of at the point of contact), so that should probably be fixed too

https://github.com/user-attachments/assets/3c24ef22-f03e-44ab-8d77-e274b9dd3510



I disabled pointer events on the badges and now it works fine i think