### PR TITLE
Add more Android ripples

### DIFF
--- a/src/components/moderation/PostHider.tsx
+++ b/src/components/moderation/PostHider.tsx
@@ -60,6 +60,7 @@ export function PostHider({
         style={style}
         href={href}
         accessible={false}
+        noFeedback
         onBeforePress={onBeforePress}
         {...props}>
         {children}
@@ -128,6 +129,7 @@ export function PostHider({
       testID={testID}
       style={addStyle(style, styles.child)}
       href={href}
+      noFeedback
       accessible={false}
       {...props}>
       {children}

--- a/src/screens/Profile/Header/Shell.tsx
+++ b/src/screens/Profile/Header/Shell.tsx
@@ -1,5 +1,10 @@
 import React, {memo} from 'react'
-import {StyleSheet, TouchableWithoutFeedback, View} from 'react-native'
+import {
+  Pressable,
+  StyleSheet,
+  TouchableWithoutFeedback,
+  View,
+} from 'react-native'
 import {MeasuredDimensions, runOnJS, runOnUI} from 'react-native-reanimated'
 import {AppBskyActorDefs, ModerationDecision} from '@atproto/api'
 import {FontAwesomeIcon} from '@fortawesome/react-native-fontawesome'
@@ -153,19 +158,28 @@ let ProfileHeaderShell = ({
       )}
 
       <GrowableAvatar style={styles.aviPosition}>
-        <TouchableWithoutFeedback
-          testID="profileHeaderAviButton"
-          onPress={onPressAvi}
-          accessibilityRole="image"
-          accessibilityLabel={_(msg`View ${profile.handle}'s avatar`)}
-          accessibilityHint="">
-          <View
+        <View
+          style={[
+            t.atoms.bg,
+            {borderColor: t.atoms.bg.backgroundColor},
+            styles.avi,
+            profile.associated?.labeler && styles.aviLabeler,
+          ]}>
+          <Pressable
+            testID="profileHeaderAviButton"
+            android_ripple={{foreground: true, borderless: true}}
             style={[
-              t.atoms.bg,
-              {borderColor: t.atoms.bg.backgroundColor},
-              styles.avi,
-              profile.associated?.labeler && styles.aviLabeler,
-            ]}>
+              {
+                borderRadius: profile.associated?.labeler
+                  ? styles.aviLabeler.borderRadius
+                  : styles.avi.borderRadius,
+                overflow: 'hidden',
+              },
+            ]}
+            onPress={onPressAvi}
+            accessibilityRole="image"
+            accessibilityLabel={_(msg`View ${profile.handle}'s avatar`)}
+            accessibilityHint="">
             <View ref={aviRef} collapsable={false}>
               <UserAvatar
                 type={profile.associated?.labeler ? 'labeler' : 'user'}
@@ -174,8 +188,8 @@ let ProfileHeaderShell = ({
                 moderation={moderation.ui('avatar')}
               />
             </View>
-          </View>
-        </TouchableWithoutFeedback>
+          </Pressable>
+        </View>
       </GrowableAvatar>
     </View>
   )

--- a/src/view/com/composer/photos/Gallery.tsx
+++ b/src/view/com/composer/photos/Gallery.tsx
@@ -3,6 +3,7 @@ import {
   ImageStyle,
   Keyboard,
   LayoutChangeEvent,
+  Pressable,
   StyleSheet,
   TouchableOpacity,
   View,
@@ -211,24 +212,23 @@ const GalleryItem = ({
           />
         </TouchableOpacity>
       </View>
-      <TouchableOpacity
+      <Pressable
         accessibilityRole="button"
         accessibilityLabel={_(msg`Add alt text`)}
         accessibilityHint=""
         onPress={onAltTextEdit}
-        style={styles.altTextHiddenRegion}
-      />
-
-      <Image
-        testID="selectedPhotoImage"
-        style={[styles.image, imageStyle] as ImageStyle}
-        source={{
-          uri: (image.transformed ?? image.source).path,
-        }}
-        accessible={true}
-        accessibilityIgnoresInvertColors
-      />
-
+        style={[styles.image, {overflow: 'hidden'}]}
+        android_ripple={{foreground: true, borderless: true}}>
+        <Image
+          testID="selectedPhotoImage"
+          style={[styles.image, imageStyle] as ImageStyle}
+          source={{
+            uri: (image.transformed ?? image.source).path,
+          }}
+          accessible={true}
+          accessibilityIgnoresInvertColors
+        />
+      </Pressable>
       <ImageAltTextDialog
         control={altTextControl}
         image={image}

--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -490,6 +490,11 @@ let PostThreadItemLoaded = ({
         <PostHider
           testID={`postThreadItem-by-${post.author.handle}`}
           href={postHref}
+          style={{
+            paddingRight: a.px_sm.paddingRight,
+            paddingLeft:
+              a.px_sm.paddingLeft - (!treeView || depth <= 1 ? 0 : 2),
+          }}
           disabled={overrideBlur}
           modui={moderation.ui('contentList')}
           iconSize={isThreadedChild ? 24 : 42}
@@ -672,8 +677,7 @@ function PostOuterWrapper({
       <View
         style={[
           a.flex_row,
-          a.px_sm,
-          a.flex_row,
+          depth !== 1 && a.pl_sm,
           t.atoms.border_contrast_low,
           styles.cursor,
           depth === 1 && a.border_t,
@@ -688,19 +692,13 @@ function PostOuterWrapper({
               t.atoms.border_contrast_low,
               {
                 borderLeftWidth: 2,
-                paddingLeft: a.pl_sm.paddingLeft - 2, // minus border
+                paddingLeft: n === depth - 2 ? 0 : a.pl_sm.paddingLeft - 2, // minus border
               },
             ]}
           />
         ))}
         <View style={a.flex_1}>
-          <SubtleWebHover
-            hover={hover}
-            style={{
-              left: (depth === 1 ? 0 : 2) - a.pl_sm.paddingLeft,
-              right: -a.pr_sm.paddingRight,
-            }}
-          />
+          <SubtleWebHover hover={hover} />
           {children}
         </View>
       </View>
@@ -712,7 +710,6 @@ function PostOuterWrapper({
       onPointerLeave={onHoverOut}
       style={[
         a.border_t,
-        a.px_sm,
         t.atoms.border_contrast_low,
         showParentReplyLine && hasPrecedingItem && styles.noTopBorder,
         hideTopBorder && styles.noTopBorder,

--- a/src/view/com/post/Post.tsx
+++ b/src/view/com/post/Post.tsx
@@ -159,6 +159,7 @@ function PostInner({
         !hideTopBorder && {borderTopWidth: StyleSheet.hairlineWidth},
         style,
       ]}
+      noFeedback
       onBeforePress={onBeforePress}
       onPointerEnter={() => {
         setHover(true)

--- a/src/view/com/util/images/AutoSizedImage.tsx
+++ b/src/view/com/util/images/AutoSizedImage.tsx
@@ -194,6 +194,7 @@ export function AutoSizedImage({
         onPress={() => onPress?.(containerRef, fetchedDimsRef.current)}
         onLongPress={onLongPress}
         onPressIn={onPressIn}
+        android_ripple={{foreground: true, borderless: true}}
         // alt here is what screen readers actually use
         accessibilityLabel={image.alt}
         accessibilityHint={_(msg`Tap to view full image`)}
@@ -216,6 +217,7 @@ export function AutoSizedImage({
           onPress={() => onPress?.(containerRef, fetchedDimsRef.current)}
           onLongPress={onLongPress}
           onPressIn={onPressIn}
+          android_ripple={{foreground: true, borderless: true}}
           // alt here is what screen readers actually use
           accessibilityLabel={image.alt}
           accessibilityHint={_(msg`Tap to view full image`)}

--- a/src/view/com/util/images/Gallery.tsx
+++ b/src/view/com/util/images/Gallery.tsx
@@ -67,6 +67,7 @@ export function GalleryItem({
           t.atoms.bg_contrast_25,
           imageStyle,
         ]}
+        android_ripple={{foreground: true, borderless: true}}
         accessibilityRole="button"
         accessibilityLabel={image.alt || _(msg`Image`)}
         accessibilityHint="">

--- a/src/view/com/util/post-embeds/ExternalGifEmbed.tsx
+++ b/src/view/com/util/post-embeds/ExternalGifEmbed.tsx
@@ -102,6 +102,7 @@ export function ExternalGifEmbed({
           },
         ]}
         onPress={onPlayPress}
+        android_ripple={{foreground: true, borderless: true}}
         accessibilityRole="button"
         accessibilityHint={_(msg`Plays the GIF`)}
         accessibilityLabel={_(msg`Play ${link.title}`)}>

--- a/src/view/com/util/post-embeds/GifEmbed.tsx
+++ b/src/view/com/util/post-embeds/GifEmbed.tsx
@@ -38,6 +38,7 @@ function PlaybackControls({
 
   return (
     <Pressable
+      android_ripple={{foreground: true, borderless: true}}
       accessibilityRole="button"
       accessibilityHint={_(msg`Play or pause the GIF`)}
       accessibilityLabel={isPlaying ? _(msg`Pause`) : _(msg`Play`)}

--- a/src/view/com/util/post-embeds/QuoteEmbed.tsx
+++ b/src/view/com/util/post-embeds/QuoteEmbed.tsx
@@ -223,16 +223,18 @@ export function QuoteEmbed({
         modui={moderation?.ui('contentList')}
         style={[
           a.rounded_md,
-          a.p_md,
           a.mt_sm,
           a.border,
           t.atoms.border_contrast_low,
           style,
+          {overflow: 'hidden'},
         ]}
         childContainerStyle={[a.pt_sm]}>
         <SubtleWebHover hover={hover} />
         <Link
           hoverStyle={{borderColor: pal.colors.borderLinkHover}}
+          style={a.p_md}
+          noFeedback
           href={itemHref}
           title={itemTitle}
           onBeforePress={onBeforePress}>

--- a/src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerNative.tsx
+++ b/src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerNative.tsx
@@ -134,6 +134,7 @@ function VideoControls({
         accessibilityLabel={_(msg`Video`)}
         accessibilityHint={_(msg`Tap to enter full screen`)}
         accessibilityRole="button"
+        android_ripple={{foreground: true, borderless: true}}
       />
       <ControlButton
         onPress={togglePlayback}


### PR DESCRIPTION
I don't know if this was a deliberate design choice but the lack of ripple effects on Android makes the app feel very unresponsive to me, so I tried adding them in some places where I feel they make sense.

#### What I added
* Ripples were already implemented for posts that appear in the home tab, but they don't work on posts that appear in replies, or in the search and notification tabs. Quote embeds also don't have ripples even when the parent post does. I added all of those by setting the noFeedback property on the `view/com/util/Link` component but that looks like a hack and is probably not good
* I added ripples on user avatars that appear in profile headers
* I also added ripples on image/video/gif embeds. On images that are added in the composer, I replaced an invisible `TouchableOpacity` that only covered part of the image so now the entire image is pressable

#### What is missing
* I didn't add ripples on components that use the `components/Link` element because I couldn't figure out how to do it properly. Those include Cards (as in `ProfileCard`, `FeedCard` etc.), user avatars on posts, and embedded external links