### PR TITLE
Remove double `an` from error message strings

### DIFF
--- a/src/screens/Profile/Header/ProfileHeaderLabeler.tsx
+++ b/src/screens/Profile/Header/ProfileHeaderLabeler.tsx
@@ -108,7 +108,7 @@ let ProfileHeaderLabeler = ({
     } catch (e: any) {
       Toast.show(
         _(
-          msg`There was an an issue contacting the server, please check your internet connection and try again.`,
+          msg`There was an issue contacting the server, please check your internet connection and try again.`,
         ),
         'xmark',
       )

--- a/src/view/com/posts/FeedErrorMessage.tsx
+++ b/src/view/com/posts/FeedErrorMessage.tsx
@@ -142,7 +142,7 @@ function FeedgenErrorMessage({
     } catch (err) {
       Toast.show(
         _l(
-          msgLingui`There was an an issue removing this feed. Please check your internet connection and try again.`,
+          msgLingui`There was an issue removing this feed. Please check your internet connection and try again.`,
         ),
         'exclamation-circle',
       )

--- a/src/view/com/posts/FeedShutdownMsg.tsx
+++ b/src/view/com/posts/FeedShutdownMsg.tsx
@@ -49,11 +49,11 @@ export function FeedShutdownMsg({feedUri}: {feedUri: string}) {
     } catch (err: any) {
       Toast.show(
         _(
-          msg`There was an an issue updating your feeds, please check your internet connection and try again.`,
+          msg`There was an issue updating your feeds, please check your internet connection and try again.`,
         ),
         'exclamation-circle',
       )
-      logger.error('Failed up update feeds', {message: err})
+      logger.error('Failed to update feeds', {message: err})
     }
   }, [removeFeed, feedConfig, _, hasDiscoverPinned, setSelectedFeed])
 
@@ -68,11 +68,11 @@ export function FeedShutdownMsg({feedUri}: {feedUri: string}) {
     } catch (err: any) {
       Toast.show(
         _(
-          msg`There was an an issue updating your feeds, please check your internet connection and try again.`,
+          msg`There was an issue updating your feeds, please check your internet connection and try again.`,
         ),
         'exclamation-circle',
       )
-      logger.error('Failed up update feeds', {message: err})
+      logger.error('Failed to update feeds', {message: err})
     }
   }, [
     replaceFeedWithDiscover,

--- a/src/view/screens/ProfileFeed.tsx
+++ b/src/view/screens/ProfileFeed.tsx
@@ -208,11 +208,11 @@ export function ProfileFeedScreenInner({
     } catch (err) {
       Toast.show(
         _(
-          msg`There was an an issue updating your feeds, please check your internet connection and try again.`,
+          msg`There was an issue updating your feeds, please check your internet connection and try again.`,
         ),
         'xmark',
       )
-      logger.error('Failed up update feeds', {message: err})
+      logger.error('Failed to update feeds', {message: err})
     }
   }, [_, playHaptic, feedInfo, removeFeed, addSavedFeeds, savedFeedConfig])
 
@@ -543,11 +543,11 @@ function AboutSection({
     } catch (err) {
       Toast.show(
         _(
-          msg`There was an an issue contacting the server, please check your internet connection and try again.`,
+          msg`There was an issue contacting the server, please check your internet connection and try again.`,
         ),
         'xmark',
       )
-      logger.error('Failed up toggle like', {message: err})
+      logger.error('Failed to toggle like', {message: err})
     }
   }, [playHaptic, isLiked, likeUri, unlikeFeed, likeFeed, feedInfo, _])
 


### PR DESCRIPTION
I noticed that there are [four files](https://github.com/search?q=repo%3Abluesky-social%2Fsocial-app+%22there+was+an+an%22+language%3ATSX&type=code&l=TSX) where `an` is repeated in some strings. This PR removes the repeated words.

Also, I noticed some logger error messages that say `Failed up` which – unless it's dev-speak or something? – I'm guessing should be `Failed to`, so I changed those too.