### PR TITLE
Ensure all configured appLabelers are applied for logged out users

### DIFF
--- a/src/state/preferences/moderation-opts.tsx
+++ b/src/state/preferences/moderation-opts.tsx
@@ -1,5 +1,5 @@
 import React, {createContext, useContext, useMemo} from 'react'
-import {BSKY_LABELER_DID, ModerationOpts} from '@atproto/api'
+import {BskyAgent,ModerationOpts} from '@atproto/api'
 
 import {useHiddenPosts, useLabelDefinitions} from '#/state/preferences'
 import {DEFAULT_LOGGED_OUT_LABEL_PREFERENCES} from '#/state/queries/preferences/moderation'
@@ -41,12 +41,10 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
         ...moderationPrefs,
         labelers: moderationPrefs.labelers.length
           ? moderationPrefs.labelers
-          : [
-              {
-                did: BSKY_LABELER_DID,
-                labels: DEFAULT_LOGGED_OUT_LABEL_PREFERENCES,
-              },
-            ],
+          : BskyAgent.appLabelers.map(did => ({
+              did,
+              labels: DEFAULT_LOGGED_OUT_LABEL_PREFERENCES,
+            })),
         hiddenPosts: hiddenPosts || [],
       },
       labelDefs,

--- a/src/state/preferences/moderation-opts.tsx
+++ b/src/state/preferences/moderation-opts.tsx
@@ -1,5 +1,5 @@
 import React, {createContext, useContext, useMemo} from 'react'
-import {BskyAgent,ModerationOpts} from '@atproto/api'
+import {BskyAgent, ModerationOpts} from '@atproto/api'
 
 import {useHiddenPosts, useLabelDefinitions} from '#/state/preferences'
 import {DEFAULT_LOGGED_OUT_LABEL_PREFERENCES} from '#/state/queries/preferences/moderation'


### PR DESCRIPTION
`BskyAgent.appLablers` is a static property that's configured via `configureAdditionalModerationAuthorities` called in our session code. This was working for logged in users because `BskyAgent` internally runs this same bit of code when we call `getPreferences`. But for logged out users, we were only configuring the Bluesky labeler by default.

This PR uses the same source of truth for logged out users as for logged in users: `BskyAgent.appLabelers`. It applies the same `DEFAULT_LOGGED_OUT_LABEL_PREFERENCES` config as well.