### PR TITLE
Unified 'Chats' in drawers into 'Chat'

### DIFF
--- a/src/view/shell/Drawer.tsx
+++ b/src/view/shell/Drawer.tsx
@@ -443,8 +443,8 @@ let ChatMenuItem = ({
           <Message style={[t.atoms.text]} width={iconWidth} />
         )
       }
-      label={_(msg`Chats`)}
-      accessibilityLabel={_(msg`Chats`)}
+      label={_(msg`Chat`)}
+      accessibilityLabel={_(msg`Chat`)}
       accessibilityHint=""
       bold={isActive}
       onPress={onPress}


### PR DESCRIPTION
Based on #5761.

the desktop leftnav and the mobile bottom-bar accessibility hints used "Chat," so I have standardized it to "Chat" to allows for the use of previously translated strings in lingui.

![10-17 152756](https://github.com/user-attachments/assets/cb77dba4-815a-482a-aa1c-9419ab8f138d)
