### PR TITLE
Fix PageWithHeader header leaking into safe area

### DIFF
--- a/src/view/com/pager/Pager.tsx
+++ b/src/view/com/pager/Pager.tsx
@@ -7,7 +7,7 @@ import PagerView, {
 } from 'react-native-pager-view'
 
 import {LogEvents} from '#/lib/statsig/events'
-import {s} from 'lib/styles'
+import {atoms as a} from '#/alf'
 
 export type PageSelectedEvent = PagerViewOnPageSelectedEvent
 const AnimatedPagerView = Animated.createAnimatedComponent(PagerView)
@@ -133,14 +133,14 @@ export const Pager = forwardRef<PagerRef, React.PropsWithChildren<Props>>(
     )
 
     return (
-      <View testID={testID} style={s.flex1}>
+      <View testID={testID} style={[a.flex_1, a.overflow_hidden]}>
         {renderTabBar({
           selectedPage,
           onSelect: onTabBarSelect,
         })}
         <AnimatedPagerView
           ref={pagerView}
-          style={s.flex1}
+          style={[a.flex_1]}
           initialPage={initialPage}
           onPageScrollStateChanged={handlePageScrollStateChanged}
           onPageSelected={onPageSelectedInner}

--- a/src/view/com/pager/Pager.tsx
+++ b/src/view/com/pager/Pager.tsx
@@ -7,7 +7,7 @@ import PagerView, {
 } from 'react-native-pager-view'
 
 import {LogEvents} from '#/lib/statsig/events'
-import {atoms as a} from '#/alf'
+import {atoms as a, native} from '#/alf'
 
 export type PageSelectedEvent = PagerViewOnPageSelectedEvent
 const AnimatedPagerView = Animated.createAnimatedComponent(PagerView)
@@ -133,7 +133,7 @@ export const Pager = forwardRef<PagerRef, React.PropsWithChildren<Props>>(
     )
 
     return (
-      <View testID={testID} style={[a.flex_1, a.overflow_hidden]}>
+      <View testID={testID} style={[a.flex_1, native(a.overflow_hidden)]}>
         {renderTabBar({
           selectedPage,
           onSelect: onTabBarSelect,


### PR DESCRIPTION
Just needed a cheeky `overflow: hidden` :)

<table>
  <thead>
    <tr>
      <th>Before</th>
      <th>After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><img width="500" alt="Screenshot 2024-10-17 at 11 22 32" src="https://github.com/user-attachments/assets/4e0f958b-c639-49b4-8f8d-527fec218be5" /></td>
      <td><img width="500" alt="Screenshot 2024-10-17 at 11 22 05" src="https://github.com/user-attachments/assets/7920c396-13cd-4ad7-aa9b-9ee9e09c5943" /></td>
    </tr>
  </tbody>
</table>