### PR TITLE
Moved self-label button tweak

### DIFF
--- a/src/view/com/composer/labels/LabelsBtn.tsx
+++ b/src/view/com/composer/labels/LabelsBtn.tsx
@@ -63,6 +63,7 @@ export function LabelsBtn({
           msg`Opens a dialog to add a content warning to your post`,
         )}
         style={[
+          !hasMedia && {opacity: 0.5},
           native({
             paddingHorizontal: 8,
             paddingVertical: 6,
@@ -73,7 +74,7 @@ export function LabelsBtn({
           {labels.length > 0 ? (
             <Trans>Labels added</Trans>
           ) : (
-            <Trans>Self-labels</Trans>
+            <Trans>Add label</Trans>
           )}
         </ButtonText>
       </Button>


### PR DESCRIPTION
For @haileyok's consideration

<table>
  <tbody>
    <tr>
      <td><img width="200" alt="Simulator Screenshot - iPhone 16 - 2024-10-17 at 12 18 56" src="https://github.com/user-attachments/assets/10d88103-dd2d-4d65-8fe1-9f53dd97476c" /></td>
      <td><img width="200" alt="Simulator Screenshot - iPhone 16 - 2024-10-17 at 12 20 18" src="https://github.com/user-attachments/assets/e67b49ea-9e79-4935-9b9d-eb54f27982dd" /></td>
    </tr>
  </tbody>
</table>