### PR TITLE
Tweak `de` string

### DIFF
--- a/src/locale/locales/de/messages.po
+++ b/src/locale/locales/de/messages.po
@@ -2747,7 +2747,7 @@ msgstr "Gefolgt von <0>{0}</0> und <1>{1}</1>"
 
 #: src/components/KnownFollowers.tsx:186
 msgid "Followed by <0>{0}</0>, <1>{1}</1>, and {2, plural, one {# other} other {# others}}"
-msgstr "Gefolgt von <0>{0}</0>, <1>{1}</1> und {1, plural, one {# anderer} other {# andere}}"
+msgstr "Gefolgt von <0>{0}</0>, <1>{1}</1> und {2, plural, one {# anderer} other {# andere}}"
 
 #: src/components/dialogs/PostInteractionSettingsDialog.tsx:404
 msgid "Followed users"


### PR DESCRIPTION
This is a tiny PR that cherry-picks a change from #5451 (which is in draft) that fixes a translation error in one of the German strings that I inadvertently introduced and partially fixes #5559.