### PR TITLE
Tweak it moar

### DIFF
--- a/src/view/com/composer/labels/LabelsBtn.tsx
+++ b/src/view/com/composer/labels/LabelsBtn.tsx
@@ -76,7 +76,7 @@ export function LabelsBtn({
           {labels.length > 0 ? (
             <Trans>Labels added</Trans>
           ) : (
-            <Trans>Add label</Trans>
+            <Trans>Add labels</Trans>
           )}
         </ButtonText>
       </Button>

--- a/src/view/com/composer/labels/LabelsBtn.tsx
+++ b/src/view/com/composer/labels/LabelsBtn.tsx
@@ -15,8 +15,10 @@ import {atoms as a, native, useTheme, web} from '#/alf'
 import {Button, ButtonIcon, ButtonText} from '#/components/Button'
 import * as Dialog from '#/components/Dialog'
 import * as Toggle from '#/components/forms/Toggle'
+import {Check_Stroke2_Corner0_Rounded as Check} from '#/components/icons/Check'
 import {Shield_Stroke2_Corner0_Rounded} from '#/components/icons/Shield'
 import {Text} from '#/components/Typography'
+
 export function LabelsBtn({
   labels,
   hasMedia,
@@ -69,7 +71,7 @@ export function LabelsBtn({
             paddingVertical: 6,
           }),
         ]}>
-        <ButtonIcon icon={Shield_Stroke2_Corner0_Rounded} />
+        <ButtonIcon icon={hasLabel ? Check : Shield_Stroke2_Corner0_Rounded} />
         <ButtonText numberOfLines={1}>
           {labels.length > 0 ? (
             <Trans>Labels added</Trans>
@@ -125,7 +127,8 @@ function DialogInner({
               </Trans>
             ) : (
               <Trans>
-                There are no self-labels that can be applied to this post.
+                No self-labels can be applied to this post because it contains
+                no media.
               </Trans>
             )}
           </Text>


### PR DESCRIPTION
I felt that we may as well change the icon to make it more clear that something was added. And I like allowing pressing on it even though no media is present, but I think we should make it clear why there are no applicable labels. In the future if we allow labels for posts without media, we'll need to tweak this, but the purpose of it can remain the same.