### PR TITLE
Apply labelers and handle language for PWI home

### DIFF
--- a/src/lib/api/feed/custom.ts
+++ b/src/lib/api/feed/custom.ts
@@ -5,7 +5,10 @@ import {
   jsonStringToLex,
 } from '@atproto/api'
 
-import {getContentLanguages} from '#/state/preferences/languages'
+import {
+  getAppLanguageAsContentLanguage,
+  getContentLanguages,
+} from '#/state/preferences/languages'
 import {FeedAPI, FeedAPIResponse} from './types'
 import {createBskyTopicsHeader, isBlueskyOwnedFeed} from './utils'
 
@@ -103,14 +106,27 @@ async function loggedOutFetch({
   limit: number
   cursor?: string
 }) {
-  let contentLangs = getContentLanguages().join(',')
+  let contentLangs = getAppLanguageAsContentLanguage()
+
+  /**
+   * Copied from our root `Agent` class
+   * @see https://github.com/bluesky-social/atproto/blob/60df3fc652b00cdff71dd9235d98a7a4bb828f05/packages/api/src/agent.ts#L120
+   */
+  const labelersHeader = {
+    'atproto-accept-labelers': BskyAgent.appLabelers
+      .map(l => `${l};redact`)
+      .join(', '),
+  }
 
   // manually construct fetch call so we can add the `lang` cache-busting param
   let res = await fetch(
     `https://api.bsky.app/xrpc/app.bsky.feed.getFeed?feed=${feed}${
       cursor ? `&cursor=${cursor}` : ''
     }&limit=${limit}&lang=${contentLangs}`,
-    {method: 'GET', headers: {'Accept-Language': contentLangs}},
+    {
+      method: 'GET',
+      headers: {'Accept-Language': contentLangs, ...labelersHeader},
+    },
   )
   let data = res.ok ? jsonStringToLex(await res.text()) : null
   if (data?.feed?.length) {
@@ -125,7 +141,7 @@ async function loggedOutFetch({
     `https://api.bsky.app/xrpc/app.bsky.feed.getFeed?feed=${feed}${
       cursor ? `&cursor=${cursor}` : ''
     }&limit=${limit}`,
-    {method: 'GET', headers: {'Accept-Language': ''}},
+    {method: 'GET', headers: {'Accept-Language': '', ...labelersHeader}},
   )
   data = res.ok ? jsonStringToLex(await res.text()) : null
   if (data?.feed?.length) {

--- a/src/state/preferences/languages.tsx
+++ b/src/state/preferences/languages.tsx
@@ -139,6 +139,16 @@ export function getContentLanguages() {
   return persisted.get('languagePrefs').contentLanguages
 }
 
+/**
+ * Be careful with this. It's used for the PWI home screen so that users can
+ * select a UI language and have it apply to the fetched Discover feed.
+ *
+ * We only support BCP-47 two-letter codes here, hence the split.
+ */
+export function getAppLanguageAsContentLanguage() {
+  return persisted.get('languagePrefs').appLanguage.split('-')[0]
+}
+
 export function toPostLanguages(postLanguage: string): string[] {
   // filter out empty strings if exist
   return postLanguage.split(',').filter(Boolean)


### PR DESCRIPTION
Noticed two things were happening:
1. PWI wasn't applying mod authorities to `getFeed` requests
2. PWI language selector wasn't applying to `getFeed` requests

I don't think we've ever noticed the first, and the second I broke when I untangled `appLanguage` from `contentLanguages` in #5384. We used to set `contentLanguages` to match the `appLanguage` when that field was changed. I understood this to be a UX decision without realizing that it was load bearing for the PWI experience. Since post record `lang` field doesn't support regional codes either, I don't think this has ever worked as intended for "app" languages with region codes.

This PR borrows the labeler logic from our base `Agent` class, and pulls the language value we pass to `getFeed` from the `appLanguage` setting, stripping out a region code if it exists.

### Testing
- check that `atproto-accept-labelers` is applied for PWI feed fetches
  - you can check `atproto-content-labelers` to see which are applied
- switch languages to our large market languages and make sure there's different content
