### PR TITLE
Fix spanish translation for "Likes" tab

### DIFF
--- a/src/locale/locales/es/messages.po
+++ b/src/locale/locales/es/messages.po
@@ -3763,7 +3763,7 @@ msgstr ""
 
 #: src/view/screens/Profile.tsx:222
 msgid "Likes"
-msgstr "Cantidad de «Me gusta»"
+msgstr "Me gusta"
 
 #: src/view/com/post-thread/PostThreadItem.tsx:204
 msgid "Likes on this post"


### PR DESCRIPTION
"Likes" tab label currently translates as `Number of Likes` in the Spanish locale, which is too long and not accurate to the original label.
![image](https://github.com/user-attachments/assets/36831894-5898-4baa-9f2c-56012b40b217)

This is a PR for changing the translation to just `Likes`.
