### PR TITLE
Fix share button not working for some users

### DIFF
--- a/src/components/Menu/context.tsx
+++ b/src/components/Menu/context.tsx
@@ -10,3 +10,23 @@ export const Context = React.createContext<ContextType>({
 export const ItemContext = React.createContext<ItemContextType>({
   disabled: false,
 })
+
+export function useMenuContext() {
+  const context = React.useContext(Context)
+
+  if (!context) {
+    throw new Error('useMenuContext must be used within a Context.Provider')
+  }
+
+  return context
+}
+
+export function useMenuItemContext() {
+  const context = React.useContext(ItemContext)
+
+  if (!context) {
+    throw new Error('useMenuItemContext must be used within a Context.Provider')
+  }
+
+  return context
+}

--- a/src/components/Menu/index.tsx
+++ b/src/components/Menu/index.tsx
@@ -121,10 +121,9 @@ export function Item({children, label, style, onPress, ...rest}: ItemProps) {
       onFocus={onFocus}
       onBlur={onBlur}
       onPress={async e => {
-        await onPress(e)
-        if (!e.defaultPrevented) {
-          control?.close()
-        }
+        control?.close(() => {
+          onPress?.(e)
+        })
       }}
       onPressIn={e => {
         onPressIn()

--- a/src/components/Menu/index.tsx
+++ b/src/components/Menu/index.tsx
@@ -121,9 +121,12 @@ export function Item({children, label, style, onPress, ...rest}: ItemProps) {
       onFocus={onFocus}
       onBlur={onBlur}
       onPress={async e => {
-        await onPress(e)
-        if (!e.defaultPrevented) {
-          control?.close()
+        if (e.defaultPrevented) {
+          await onPress(e)
+        } else {
+          control?.close(() => {
+            onPress(e)
+          })
         }
       }}
       onPressIn={e => {

--- a/src/components/Menu/index.tsx
+++ b/src/components/Menu/index.tsx
@@ -121,12 +121,9 @@ export function Item({children, label, style, onPress, ...rest}: ItemProps) {
       onFocus={onFocus}
       onBlur={onBlur}
       onPress={async e => {
-        if (e.defaultPrevented) {
-          await onPress(e)
-        } else {
-          control?.close(() => {
-            onPress(e)
-          })
+        await onPress(e)
+        if (!e.defaultPrevented) {
+          control?.close()
         }
       }}
       onPressIn={e => {

--- a/src/components/Menu/index.tsx
+++ b/src/components/Menu/index.tsx
@@ -9,7 +9,12 @@ import {atoms as a, useTheme} from '#/alf'
 import {Button, ButtonText} from '#/components/Button'
 import * as Dialog from '#/components/Dialog'
 import {useInteractionState} from '#/components/hooks/useInteractionState'
-import {Context, ItemContext} from '#/components/Menu/context'
+import {
+  Context,
+  ItemContext,
+  useMenuContext,
+  useMenuItemContext,
+} from '#/components/Menu/context'
 import {
   ContextType,
   GroupProps,
@@ -24,10 +29,6 @@ export {
   type DialogControlProps as MenuControlProps,
   useDialogControl as useMenuControl,
 } from '#/components/Dialog'
-
-export function useMemoControlContext() {
-  return React.useContext(Context)
-}
 
 export function Root({
   children,
@@ -47,7 +48,7 @@ export function Root({
 }
 
 export function Trigger({children, label, role = 'button'}: TriggerProps) {
-  const {control} = React.useContext(Context)
+  const context = useMenuContext()
   const {state: focused, onIn: onFocus, onOut: onBlur} = useInteractionState()
   const {
     state: pressed,
@@ -57,14 +58,14 @@ export function Trigger({children, label, role = 'button'}: TriggerProps) {
 
   return children({
     isNative: true,
-    control,
+    control: context.control,
     state: {
       hovered: false,
       focused,
       pressed,
     },
     props: {
-      onPress: control.open,
+      onPress: context.control.open,
       onFocus,
       onBlur,
       onPressIn,
@@ -82,7 +83,7 @@ export function Outer({
   showCancel?: boolean
   style?: StyleProp<ViewStyle>
 }>) {
-  const context = React.useContext(Context)
+  const context = useMenuContext()
   const {_} = useLingui()
 
   return (
@@ -105,7 +106,7 @@ export function Outer({
 
 export function Item({children, label, style, onPress, ...rest}: ItemProps) {
   const t = useTheme()
-  const {control} = React.useContext(Context)
+  const context = useMenuContext()
   const {state: focused, onIn: onFocus, onOut: onBlur} = useInteractionState()
   const {
     state: pressed,
@@ -121,7 +122,7 @@ export function Item({children, label, style, onPress, ...rest}: ItemProps) {
       onFocus={onFocus}
       onBlur={onBlur}
       onPress={async e => {
-        control?.close(() => {
+        context.control.close(() => {
           onPress?.(e)
         })
       }}
@@ -155,7 +156,7 @@ export function Item({children, label, style, onPress, ...rest}: ItemProps) {
 
 export function ItemText({children, style}: ItemTextProps) {
   const t = useTheme()
-  const {disabled} = React.useContext(ItemContext)
+  const {disabled} = useMenuItemContext()
   return (
     <Text
       numberOfLines={1}
@@ -176,7 +177,7 @@ export function ItemText({children, style}: ItemTextProps) {
 
 export function ItemIcon({icon: Comp}: ItemIconProps) {
   const t = useTheme()
-  const {disabled} = React.useContext(ItemContext)
+  const {disabled} = useMenuItemContext()
   return (
     <Comp
       size="lg"
@@ -222,7 +223,7 @@ export function Group({children, style}: GroupProps) {
 
 function Cancel() {
   const {_} = useLingui()
-  const {control} = React.useContext(Context)
+  const context = useMenuContext()
 
   return (
     <Button
@@ -230,7 +231,7 @@ function Cancel() {
       size="small"
       variant="ghost"
       color="secondary"
-      onPress={() => control.close()}>
+      onPress={() => context.control.close()}>
       <ButtonText>
         <Trans>Cancel</Trans>
       </ButtonText>

--- a/src/components/Menu/index.web.tsx
+++ b/src/components/Menu/index.web.tsx
@@ -7,7 +7,12 @@ import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
 import {atoms as a, flatten, useTheme, web} from '#/alf'
 import * as Dialog from '#/components/Dialog'
 import {useInteractionState} from '#/components/hooks/useInteractionState'
-import {Context, ItemContext} from '#/components/Menu/context'
+import {
+  Context,
+  ItemContext,
+  useMenuContext,
+  useMenuItemContext,
+} from '#/components/Menu/context'
 import {
   ContextType,
   GroupProps,
@@ -38,10 +43,6 @@ export function useMenuControl(): Dialog.DialogControlProps {
     }),
     [id, isOpen, setIsOpen],
   )
-}
-
-export function useMemoControlContext() {
-  return React.useContext(Context)
 }
 
 export function Root({
@@ -110,7 +111,7 @@ const RadixTriggerPassThrough = React.forwardRef(
 RadixTriggerPassThrough.displayName = 'RadixTriggerPassThrough'
 
 export function Trigger({children, label, role = 'button'}: TriggerProps) {
-  const {control} = React.useContext(Context)
+  const {control} = useMenuContext()
   const {
     state: hovered,
     onIn: onMouseEnter,
@@ -203,7 +204,7 @@ export function Outer({
 
 export function Item({children, label, onPress, ...rest}: ItemProps) {
   const t = useTheme()
-  const {control} = React.useContext(Context)
+  const {control} = useMenuContext()
   const {
     state: hovered,
     onIn: onMouseEnter,
@@ -262,7 +263,7 @@ export function Item({children, label, onPress, ...rest}: ItemProps) {
 
 export function ItemText({children, style}: ItemTextProps) {
   const t = useTheme()
-  const {disabled} = React.useContext(ItemContext)
+  const {disabled} = useMenuItemContext()
   return (
     <Text
       style={[
@@ -279,7 +280,7 @@ export function ItemText({children, style}: ItemTextProps) {
 
 export function ItemIcon({icon: Comp, position = 'left'}: ItemIconProps) {
   const t = useTheme()
-  const {disabled} = React.useContext(ItemContext)
+  const {disabled} = useMenuItemContext()
   return (
     <View
       style={[


### PR DESCRIPTION
Fixes https://github.com/bluesky-social/social-app/issues/5719

## Why

This is one that I was unable to reproduce for some time, but was finally able to "accidentally" discover. If you press too long on the "share" button, the dialog actually ends up staying open a tad bit longer. It seems like when that happens, the app isn't able to present the share dialog because the menu sheet is still presented and animating away.

Notably here, we were not calling our menu item `onPress` inside of the `close()` function's callback, but rather in parallel. We've seen in the past where its pretty essential to do that, and it seems like this is another one of those cases.

## Test Plan

Before this PR, open the share sheet and take a bit longer on pressing the "Share" button. It shouldn't open the share sheet. Then, test this pr and do the same. It should still open.

Also worth checking other buttons like "Translate" to ensure they still work.