### PR TITLE
Put ExternalEmbedRemoveBtn on top

### DIFF
--- a/src/view/com/composer/ExternalEmbedRemoveBtn.tsx
+++ b/src/view/com/composer/ExternalEmbedRemoveBtn.tsx
@@ -11,7 +11,7 @@ export function ExternalEmbedRemoveBtn({onRemove}: {onRemove: () => void}) {
   const {_} = useLingui()
 
   return (
-    <View style={[a.absolute, a.pt_sm, a.pr_sm, {top: 0, right: 0}]}>
+    <View style={[a.absolute, a.pt_sm, a.pr_sm, a.z_50, {top: 0, right: 0}]}>
       <Button
         label={_(msg`Remove attachment`)}
         onPress={onRemove}


### PR DESCRIPTION
Evidently wasn't high enough in certain contexts ([video](https://github.com/bluesky-social/social-app/pull/5677#issuecomment-2423715433)). This seem to work not for all embed types.