### PR TITLE
Fix starter pack text overflow

### DIFF
--- a/src/components/StarterPack/StarterPackCard.tsx
+++ b/src/components/StarterPack/StarterPackCard.tsx
@@ -65,7 +65,7 @@ export function Card({
     <View style={[a.w_full, a.gap_md]}>
       <View style={[a.flex_row, a.gap_sm]}>
         {!noIcon ? <StarterPack width={40} gradient="sky" /> : null}
-        <View>
+        <View style={[a.flex_1]}>
           <Text emoji style={[a.text_md, a.font_bold, a.leading_snug]}>
             {record.name}
           </Text>


### PR DESCRIPTION
just a silly flexbox issue

<table>
  <thead>
    <tr>
      <th>Before</th>
      <th>After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><img width="200" alt="Simulator Screenshot - iPhone 16 - 2024-10-21 at 19 46 58" src="https://github.com/user-attachments/assets/a12ee3c0-6b71-464f-aa16-ef9ff8ea7b7a" /></td>
      <td><img width="200" alt="Simulator Screenshot - iPhone 16 - 2024-10-21 at 19 46 47" src="https://github.com/user-attachments/assets/d41cf98a-48e9-4b59-a086-4c19daf3be2d" /></td>
    </tr>
  </tbody>
</table>