### PR TITLE
Add newskies badge to skeets and DMs

### DIFF
--- a/src/components/dms/MessagesListHeader.tsx
+++ b/src/components/dms/MessagesListHeader.tsx
@@ -24,6 +24,7 @@ import {Bell2Off_Filled_Corner0_Rounded as BellStroke} from '#/components/icons/
 import {Link} from '#/components/Link'
 import {PostAlerts} from '#/components/moderation/PostAlerts'
 import {Text} from '#/components/Typography'
+import {NewskieDialog} from '../NewskieDialog'
 
 const PFP_SIZE = isWeb ? 40 : 34
 
@@ -181,25 +182,28 @@ function HeaderReady({
               {displayName}
             </Text>
             {!isDeletedAccount && (
-              <Text
-                style={[
-                  t.atoms.text_contrast_medium,
-                  a.text_sm,
-                  web([a.leading_normal, {marginTop: -2}]),
-                ]}
-                numberOfLines={1}>
-                @{profile.handle}
-                {convoState.convo?.muted && (
-                  <>
-                    {' '}
-                    &middot;{' '}
-                    <BellStroke
-                      size="xs"
-                      style={t.atoms.text_contrast_medium}
-                    />
-                  </>
-                )}
-              </Text>
+              <View style={[a.flex_row, a.gap_xs, a.align_center]}>
+                <Text
+                  style={[
+                    t.atoms.text_contrast_medium,
+                    a.text_sm,
+                    web([a.leading_normal, {marginTop: -2}]),
+                  ]}
+                  numberOfLines={1}>
+                  @{profile.handle}
+                  {convoState.convo?.muted && (
+                    <>
+                      {' '}
+                      &middot;{' '}
+                      <BellStroke
+                        size="xs"
+                        style={t.atoms.text_contrast_medium}
+                      />
+                    </>
+                  )}
+                </Text>
+                <NewskieDialog profile={profile} disabled={false} />
+              </View>
             )}
           </View>
         </Link>

--- a/src/screens/Messages/components/ChatListItem.tsx
+++ b/src/screens/Messages/components/ChatListItem.tsx
@@ -38,6 +38,7 @@ import {Trash_Stroke2_Corner0_Rounded} from '#/components/icons/Trash'
 import {Link} from '#/components/Link'
 import {useMenuControl} from '#/components/Menu'
 import {PostAlerts} from '#/components/moderation/PostAlerts'
+import {NewskieDialog} from '#/components/NewskieDialog'
 import {Text} from '#/components/Typography'
 
 export let ChatListItem = ({
@@ -326,6 +327,7 @@ function ChatListItemReady({
                       )}
                     </TimeElapsed>
                   )}
+
                   {(convo.muted || moderation.blocked) && (
                     <Text
                       style={[
@@ -345,11 +347,22 @@ function ChatListItemReady({
                 </View>
 
                 {!isDeletedAccount && (
-                  <Text
-                    numberOfLines={1}
-                    style={[a.text_sm, t.atoms.text_contrast_medium, a.pb_xs]}>
-                    @{profile.handle}
-                  </Text>
+                  <View style={[a.flex_row, a.gap_xs, a.align_center]}>
+                    <Text
+                      numberOfLines={1}
+                      style={[
+                        a.text_sm,
+                        t.atoms.text_contrast_medium,
+                        a.pb_xs,
+                      ]}>
+                      @{profile.handle}
+                    </Text>
+
+                    {/* Newskies dialog is disabled as if the user clicks the badge, it'll open the conversation and message. */}
+                    {profile.createdAt && (
+                      <NewskieDialog profile={profile} disabled={true} />
+                    )}
+                  </View>
                 )}
 
                 <Text

--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -29,6 +29,7 @@ import {useComposerControls} from '#/state/shell/composer'
 import {useMergedThreadgateHiddenReplies} from '#/state/threadgate-hidden-replies'
 import {PostThreadFollowBtn} from '#/view/com/post-thread/PostThreadFollowBtn'
 import {atoms as a, useTheme} from '#/alf'
+import {NewskieDialog} from '#/components/NewskieDialog'
 import {AppModerationCause} from '#/components/Pills'
 import {RichText} from '#/components/RichText'
 import {Text as NewText} from '#/components/Typography'
@@ -317,7 +318,10 @@ let PostThreadItemLoaded = ({
                   )}
                 </NewText>
               </Link>
-              <Link style={s.flex1} href={authorHref} title={authorTitle}>
+              <Link
+                style={[a.flex_row, a.gap_xs, a.align_center]}
+                href={authorHref}
+                title={authorTitle}>
                 <NewText
                   emoji
                   style={[
@@ -328,6 +332,8 @@ let PostThreadItemLoaded = ({
                   numberOfLines={1}>
                   {sanitizeHandle(post.author.handle, '@')}
                 </NewText>
+
+                <NewskieDialog profile={post.author} disabled={false} />
               </Link>
             </View>
             {currentAccount?.did !== post.author.did && (

--- a/src/view/com/util/PostMeta.tsx
+++ b/src/view/com/util/PostMeta.tsx
@@ -15,6 +15,7 @@ import {isAndroid} from '#/platform/detection'
 import {precacheProfile} from '#/state/queries/profile'
 import {atoms as a, useTheme, web} from '#/alf'
 import {WebOnlyInlineLinkText} from '#/components/Link'
+import {NewskieDialog} from '#/components/NewskieDialog'
 import {ProfileHoverCard} from '#/components/ProfileHoverCard'
 import {Text} from '#/components/Typography'
 import {TimeElapsed} from './TimeElapsed'
@@ -102,6 +103,8 @@ let PostMeta = (opts: PostMetaOpts): React.ReactNode => {
           </WebOnlyInlineLinkText>
         </Text>
       </ProfileHoverCard>
+
+      <NewskieDialog profile={opts.author} disabled={false} />
 
       {!isAndroid && (
         <Text


### PR DESCRIPTION
<img width="601" alt="Screenshot 2024-10-22 at 7 17 36 PM" src="https://github.com/user-attachments/assets/d5db3dea-a567-4805-91db-ed382281b3ff">

<img width="1435" alt="Screenshot 2024-10-22 at 7 13 39 PM" src="https://github.com/user-attachments/assets/2db30185-aae5-40da-b9f8-4c14d30cf3db">
<img width="1438" alt="Screenshot 2024-10-22 at 7 13 30 PM" src="https://github.com/user-attachments/assets/71accdac-12d7-48b0-a6d9-95c4d968d70a">
<img width="1437" alt="Screenshot 2024-10-22 at 7 09 58 PM" src="https://github.com/user-attachments/assets/19049789-1f71-40e7-8a1d-3695189a0df8">

Issues with this:
- The badge won't appear on the DMs conversations list because createdAt isn't returned. There is a conditional render so that it will automatically start working when it is returned.
- The newskies badge is only 7 days, Bossett's is 30. I'd suggest the 7 day limit gets upped to 30, though we should be mindful of that fact new users will join and get called newskies for ages. I've left it up for everyone to decide how that should work.
- The badge should maybe have a slightly different colour?
- The sizing is off in some areas, this is because it didn't have a styling prop or css class.

Bossett's kangaroos can go back to fighting them rather than getting ratelimited labeling newskies.