### PR TITLE
Change touch device detection method

### DIFF
--- a/src/lib/browser.ts
+++ b/src/lib/browser.ts
@@ -3,7 +3,6 @@ export const isSafari = /^((?!chrome|android).)*safari/i.test(
   navigator.userAgent,
 )
 export const isFirefox = /firefox|fxios/i.test(navigator.userAgent)
-export const isTouchDevice =
-  'ontouchstart' in window || navigator.maxTouchPoints > 1
+export const isTouchDevice = window.matchMedia('(pointer: coarse)').matches
 export const isAndroidWeb =
   /android/i.test(navigator.userAgent) && isTouchDevice


### PR DESCRIPTION
Using `navigator.maxTouchPoints` to check whether a device is a "touch device" also matches laptops with touch screen support. Checking for [`pointer: coarse`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/pointer#coarse) instead should only detect whether the primary input mechanism is touch (e.g. smartphones and tablets but not laptops with touch screens).

It's not perfect though. No combination of `(any-)pointer` and `(any-)hover` seems to work for detecting when I plug a physical mouse into my Android phone for example. Might have to rely on the `touchstart` event for that.

Checking `pointer: coarse` is better than the current method at least as it does properly distinguish between mobile/tablet and pc, which the current method doesn't.

Resolves #5856 (hover cards and video volume slider not showing up), resolves #5859 (enter not sending chat messages)