### PR TITLE
Refactor composer state for threads

### DIFF
--- a/src/view/com/composer/photos/Gallery.tsx
+++ b/src/view/com/composer/photos/Gallery.tsx
@@ -21,7 +21,7 @@ import {ComposerImage, cropImage} from '#/state/gallery'
 import {Text} from '#/view/com/util/text/Text'
 import {useTheme} from '#/alf'
 import * as Dialog from '#/components/Dialog'
-import {ComposerAction} from '../state/composer'
+import {PostAction} from '../state/composer'
 import {EditImageDialog} from './EditImageDialog'
 import {ImageAltTextDialog} from './ImageAltTextDialog'
 
@@ -29,7 +29,7 @@ const IMAGE_GAP = 8
 
 interface GalleryProps {
   images: ComposerImage[]
-  dispatch: (action: ComposerAction) => void
+  dispatch: (action: PostAction) => void
 }
 
 export let Gallery = (props: GalleryProps): React.ReactNode => {

--- a/src/view/com/composer/state/composer.ts
+++ b/src/view/com/composer/state/composer.ts
@@ -376,8 +376,6 @@ function postReducer(state: PostDraft, action: PostAction): PostDraft {
         },
       }
     }
-    default:
-      return state
   }
 }
 


### PR DESCRIPTION
Stacked on https://github.com/bluesky-social/social-app/pull/5953

---

This prepares the composer state structure to handle multiple posts in a thread. Previously we just had the `draft`. Now we have a `thread` made of `posts`.

Most of the reducer logic is now in `postReducer` which updates `PostState` in response to `PostAction`. The `postReducer` is being called for the current post from the outer `composerReducer`.

We're not actually taking advantage of this in the UI yet. The UI is the same and it only reads the current post's state (which is always the first post because we don't have any logic to add/remove posts yet).

Also, the publishing code only looks at the first post at the moment. That will be changed later.

## Test Plan

Same as usual, verify different composer features work.