### PR TITLE
Disable Post button when empty

### DIFF
--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -684,7 +684,7 @@ function ComposerTopBar({
               <ActivityIndicator />
             </View>
           </>
-        ) : canPost ? (
+        ) : (
           <Button
             testID="composerPublishBtn"
             label={isReply ? 'Publish reply' : 'Publish post'}
@@ -694,7 +694,7 @@ function ComposerTopBar({
             size="small"
             style={[a.rounded_full, a.py_sm]}
             onPress={onPublish}
-            disabled={isPublishQueued}>
+            disabled={!canPost || isPublishQueued}>
             <ButtonText style={[a.text_md]}>
               {isReply ? (
                 <Trans context="action">Reply</Trans>
@@ -703,12 +703,6 @@ function ComposerTopBar({
               )}
             </ButtonText>
           </Button>
-        ) : (
-          <View style={[styles.postBtn, pal.btn]}>
-            <Text style={[pal.textLight, s.f16, s.bold]}>
-              <Trans context="action">Post</Trans>
-            </Text>
-          </View>
         )}
       </View>
       {children}

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -293,13 +293,26 @@ export const ComposePost = ({
     return false
   }, [images, extGifAlt, extGif, requireAltTextEnabled])
 
+  const isEmptyPost =
+    richtext.text.trim().length === 0 &&
+    images.length === 0 &&
+    !extLink &&
+    !extGif &&
+    !quote &&
+    videoState.status === 'idle'
+
+  const canPost =
+    graphemeLength <= MAX_GRAPHEME_LENGTH &&
+    !isAltTextRequiredAndMissing &&
+    !isEmptyPost
+
   const onPressPublish = React.useCallback(
     async (finishedUploading: boolean) => {
-      if (isPublishing || graphemeLength > MAX_GRAPHEME_LENGTH) {
+      if (isPublishing) {
         return
       }
 
-      if (isAltTextRequiredAndMissing) {
+      if (!canPost) {
         return
       }
 
@@ -313,19 +326,6 @@ export const ComposePost = ({
       }
 
       setError('')
-
-      if (
-        richtext.text.trim().length === 0 &&
-        images.length === 0 &&
-        !extLink &&
-        !extGif &&
-        !quote &&
-        videoState.status === 'idle'
-      ) {
-        setError(_(msg`Did you want to say anything?`))
-        return
-      }
-
       setIsPublishing(true)
 
       let postUri
@@ -410,10 +410,8 @@ export const ComposePost = ({
       agent,
       draft,
       extLink,
-      extGif,
       images,
-      graphemeLength,
-      isAltTextRequiredAndMissing,
+      canPost,
       isPublishing,
       langPrefs.postLanguage,
       onClose,
@@ -421,7 +419,6 @@ export const ComposePost = ({
       quote,
       initQuote,
       replyTo,
-      richtext.text,
       setLangPrefs,
       videoState.asset,
       videoState.status,
@@ -437,11 +434,6 @@ export const ComposePost = ({
       }
     }
   }, [onPressPublish, publishOnUpload, videoState.pendingPublish])
-
-  const canPost = useMemo(
-    () => graphemeLength <= MAX_GRAPHEME_LENGTH && !isAltTextRequiredAndMissing,
-    [graphemeLength, isAltTextRequiredAndMissing],
-  )
 
   const onEmojiButtonPress = useCallback(() => {
     openEmojiPicker?.(textInput.current?.getCursorPosition())

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -304,7 +304,8 @@ export const ComposePost = ({
   const canPost =
     graphemeLength <= MAX_GRAPHEME_LENGTH &&
     !isAltTextRequiredAndMissing &&
-    !isEmptyPost
+    !isEmptyPost &&
+    videoState.status !== 'error'
 
   const onPressPublish = React.useCallback(
     async (finishedUploading: boolean) => {


### PR DESCRIPTION
This in preparation for the threaded composer. It doesn't quite make sense to treat this as an error — we should just prevent you from posting, same as we do in other invalid cases (like too long post or missing ALT).

In the second commit, I'm also replacing ad-hoc grey disabled styling with our normal disabled button. We've already been using the disabled button for the case when you _pressed_ post so let's use it here too.

## Test Plan

Observe the initial state.

<img width="617" alt="Screenshot 2024-10-26 at 20 45 16" src="https://github.com/user-attachments/assets/52ada4b7-4b0c-438b-b3b6-a27d4776e052">

Verify that typing makes the button enabled.

<img width="628" alt="Screenshot 2024-10-26 at 20 45 20" src="https://github.com/user-attachments/assets/448fa245-12a8-4840-8dd9-364f02464867">

Verify existing flows (adding image, filling alt, adding video, posting before it's uploaded) work like before.