### PR TITLE
Limit number of lines in starter pack card

### DIFF
--- a/src/components/StarterPack/StarterPackCard.tsx
+++ b/src/components/StarterPack/StarterPackCard.tsx
@@ -66,10 +66,16 @@ export function Card({
       <View style={[a.flex_row, a.gap_sm]}>
         {!noIcon ? <StarterPack width={40} gradient="sky" /> : null}
         <View style={[a.flex_1]}>
-          <Text emoji style={[a.text_md, a.font_bold, a.leading_snug]}>
+          <Text
+            emoji
+            style={[a.text_md, a.font_bold, a.leading_snug]}
+            numberOfLines={2}>
             {record.name}
           </Text>
-          <Text emoji style={[a.leading_snug, t.atoms.text_contrast_medium]}>
+          <Text
+            emoji
+            style={[a.leading_snug, t.atoms.text_contrast_medium]}
+            numberOfLines={1}>
             {creator?.did === currentAccount?.did
               ? _(msg`Starter pack by you`)
               : _(msg`Starter pack by ${sanitizeHandle(creator.handle, '@')}`)}


### PR DESCRIPTION
## Why

Quick follow up to https://github.com/bluesky-social/social-app/pull/5891. Just avoiding any UI breaks because of excessive line counts.

## Test Plan

Should be no change from https://github.com/bluesky-social/social-app/pull/5891.