### PR TITLE
Don't render `ComposerPills` when unnecessary

### DIFF
--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -872,6 +872,12 @@ function ComposerPills({
   const media = draft.embed.media
   const hasMedia = media?.type === 'images' || media?.type === 'video'
   const hasLink = !!draft.embed.link
+
+  // Don't render anything if no pills are going to be displayed
+  if (isReply && !hasMedia && !hasLink) {
+    return null
+  }
+
   return (
     <Animated.View
       style={[a.flex_row, a.p_sm, t.atoms.bg, bottomBarAnimatedStyle]}>


### PR DESCRIPTION
## Why

When replying to a post, we should only render `<ComposerPills>` whenever there is media in the image. Right now, even though the pill itself doesn't get rendered, the container does and displays a border.

## Test Plan

- Replying to a post shouldn't render the extra border at the bottom
  - If you add an image to the post, it should render and the "Label" button should appear
- Creating a new post should always render pill container