### PR TITLE
Make composer min height conditional and align attachments

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -92,9 +92,6 @@ a[role='link'][data-no-underline='1']:hover {
 }
 
 /* ProseMirror */
-.ProseMirror {
-  min-height: 140px;
-}
 .ProseMirror-dark {
   color: white;
 }

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -761,7 +761,7 @@ function ComposerEmbeds({
       )}
 
       {embed.media?.type === 'gif' && (
-        <View style={a.relative} key={embed.media.gif.url}>
+        <View style={[a.relative, a.mt_lg]} key={embed.media.gif.url}>
           <ExternalEmbedGif
             gif={embed.media.gif}
             onRemove={() => dispatch({type: 'embed_remove_gif'})}
@@ -777,7 +777,7 @@ function ComposerEmbeds({
       )}
 
       {!embed.media && embed.link && (
-        <View style={a.relative} key={embed.link.uri}>
+        <View style={[a.relative, a.mt_lg]} key={embed.link.uri}>
           <ExternalEmbedLink
             uri={embed.link.uri}
             hasQuote={!!embed.quote}

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -565,6 +565,9 @@ function ComposerPost({
   const {_} = useLingui()
   const {data: currentProfile} = useProfileQuery({did: currentDid})
   const richtext = draft.richtext
+  const isTextOnly =
+    !draft.embed.link && !draft.embed.quote && !draft.embed.media
+  const forceMinHeight = isWeb && isTextOnly
   const selectTextInputPlaceholder = isReply
     ? _(msg`Write your reply`)
     : _(msg`What's up?`)
@@ -615,6 +618,7 @@ function ComposerPost({
           richtext={richtext}
           placeholder={selectTextInputPlaceholder}
           autoFocus
+          webForceMinHeight={forceMinHeight}
           setRichText={rt => {
             dispatch({type: 'update_richtext', richtext: rt})
           }}

--- a/src/view/com/composer/text-input/TextInput.tsx
+++ b/src/view/com/composer/text-input/TextInput.tsx
@@ -43,6 +43,7 @@ export interface TextInputRef {
 interface TextInputProps extends ComponentProps<typeof RNTextInput> {
   richtext: RichText
   placeholder: string
+  webForceMinHeight: boolean
   setRichText: (v: RichText) => void
   onPhotoPasted: (uri: string) => void
   onPressPublish: (richtext: RichText) => void

--- a/src/view/com/composer/text-input/TextInput.tsx
+++ b/src/view/com/composer/text-input/TextInput.tsx
@@ -231,7 +231,7 @@ export const TextInput = forwardRef(function TextInputImpl(
   }, [t, richtext, inputTextStyle])
 
   return (
-    <View style={[a.flex_1, a.pl_md, a.pb_2xl]}>
+    <View style={[a.flex_1, a.pl_md]}>
       <PasteInput
         testID="composerTextInput"
         ref={textInput}
@@ -245,7 +245,7 @@ export const TextInput = forwardRef(function TextInputImpl(
         allowFontScaling
         multiline
         scrollEnabled={false}
-        numberOfLines={4}
+        numberOfLines={2}
         style={[
           inputTextStyle,
           a.w_full,

--- a/src/view/com/composer/text-input/TextInput.web.tsx
+++ b/src/view/com/composer/text-input/TextInput.web.tsx
@@ -41,6 +41,7 @@ interface TextInputProps {
   richtext: RichText
   placeholder: string
   suggestedLinks: Set<string>
+  webForceMinHeight: boolean
   setRichText: (v: RichText | ((v: RichText) => RichText)) => void
   onPhotoPasted: (uri: string) => void
   onPressPublish: (richtext: RichText) => void
@@ -52,6 +53,7 @@ export const TextInput = React.forwardRef(function TextInputImpl(
   {
     richtext,
     placeholder,
+    webForceMinHeight,
     setRichText,
     onPhotoPasted,
     onPressPublish,
@@ -270,6 +272,13 @@ export const TextInput = React.forwardRef(function TextInputImpl(
       : undefined
     return style
   }, [t, fonts])
+
+  React.useLayoutEffect(() => {
+    let node = editor?.view.dom
+    if (node) {
+      node.style.minHeight = webForceMinHeight ? '140px' : ''
+    }
+  }, [editor, webForceMinHeight])
 
   return (
     <>


### PR DESCRIPTION
There's a web-only min height on the composer, but having it always be on (even when there's attachments) is annoying. Twitter doesn't do that. This is the easiest way I found to adjust the behavior.

I've also adjusted the padding on mobile to be consistent between different attachment types.

## Before

https://github.com/user-attachments/assets/820ce96d-0c5e-4ecd-9af1-d8aa7b288518

## After

https://github.com/user-attachments/assets/5d624a8a-736b-4aca-8f15-c20c84bf362b


https://github.com/user-attachments/assets/425f3c60-25ef-4518-bdea-d99c203035d5


https://github.com/user-attachments/assets/dc18cb6e-81fa-4667-81c1-8267e4b62142

## Test Plan

Try all types of attachments on all platforms. (Including links, post embeds, list embeds, starter pack embeds.)

On the web, the expectation is that min-height is only enforced when there's no attachment.

Also verify the same for replies.