### PR TITLE
hailey/filter dupe labels

### DIFF
--- a/src/view/com/composer/labels/LabelsBtn.tsx
+++ b/src/view/com/composer/labels/LabelsBtn.tsx
@@ -34,13 +34,18 @@ export function LabelsBtn({
   const updateAdultLabels = (newLabels: AdultSelfLabel[]) => {
     const newLabel = newLabels[newLabels.length - 1]
     const filtered = labels.filter(l => !ADULT_CONTENT_LABELS.includes(l))
-    onChange([...filtered, newLabel].filter(Boolean) as SelfLabel[])
+    onChange([
+      ...new Set([...filtered, newLabel].filter(Boolean) as SelfLabel[]),
+    ])
   }
 
   const updateOtherLabels = (newLabels: OtherSelfLabel[]) => {
+    console.log(newLabels)
     const newLabel = newLabels[newLabels.length - 1]
     const filtered = labels.filter(l => !OTHER_SELF_LABELS.includes(l))
-    onChange([...filtered, newLabel].filter(Boolean) as SelfLabel[])
+    onChange([
+      ...new Set([...filtered, newLabel].filter(Boolean) as SelfLabel[]),
+    ])
   }
 
   return (

--- a/src/view/com/composer/labels/LabelsBtn.tsx
+++ b/src/view/com/composer/labels/LabelsBtn.tsx
@@ -40,7 +40,6 @@ export function LabelsBtn({
   }
 
   const updateOtherLabels = (newLabels: OtherSelfLabel[]) => {
-    console.log(newLabels)
     const newLabel = newLabels[newLabels.length - 1]
     const filtered = labels.filter(l => !OTHER_SELF_LABELS.includes(l))
     onChange([


### PR DESCRIPTION
## Why

The new values that get passed along can contain duplicates of the already passed along labels.

## Test Plan

Make a post with labels. Spam press the "Graphic Media" label item, then post. There shouldn't be any duplicates.