### PR TITLE
Fix alt position

### DIFF
--- a/src/view/com/composer/ExternalEmbedRemoveBtn.tsx
+++ b/src/view/com/composer/ExternalEmbedRemoveBtn.tsx
@@ -11,7 +11,7 @@ export function ExternalEmbedRemoveBtn({onRemove}: {onRemove: () => void}) {
   const {_} = useLingui()
 
   return (
-    <View style={[a.absolute, a.pt_sm, a.pr_sm, a.z_50, {top: 0, right: 0}]}>
+    <View style={[a.absolute, {top: 8, right: 8}, a.z_50]}>
       <Button
         label={_(msg`Remove attachment`)}
         onPress={onRemove}

--- a/src/view/com/composer/GifAltText.tsx
+++ b/src/view/com/composer/GifAltText.tsx
@@ -79,7 +79,7 @@ export function GifAltTextDialogLoaded({
         onPress={control.open}
         style={[
           a.absolute,
-          {top: 20, left: 12},
+          {top: 8, left: 8},
           {borderRadius: 6},
           a.pl_xs,
           a.pr_sm,


### PR DESCRIPTION
<table>
  <thead>
    <tr>
      <th>Before</th>
      <th>After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><img width="400" alt="Screenshot 2024-10-28 at 23 19 22" src="https://github.com/user-attachments/assets/a5998276-e6f7-4ecb-90ec-3dbec50aaa90" /></td>
      <td><img width="400" alt="Screenshot 2024-10-28 at 23 15 15" src="https://github.com/user-attachments/assets/88cd2bbc-74ad-4138-8cd8-8304f4cad163" /></td>
    </tr>
  </tbody>
</table>