### PR TITLE
Fix double padding in `Dialog.InnerFlatList` on web

### DIFF
--- a/src/components/Dialog/index.web.tsx
+++ b/src/components/Dialog/index.web.tsx
@@ -217,14 +217,13 @@ export const InnerFlatList = React.forwardRef<
     <Inner
       label={label}
       style={[
+        a.overflow_hidden,
+        a.px_0,
         // @ts-ignore web only -sfn
-        {
-          paddingHorizontal: 0,
-          maxHeight: 'calc(-36px + 100vh)',
-          overflow: 'hidden',
-        },
+        {maxHeight: 'calc(-36px + 100vh)'},
         webInnerStyle,
-      ]}>
+      ]}
+      contentContainerStyle={[a.px_0]}>
       <FlatList
         ref={ref}
         style={[gtMobile ? a.px_2xl : a.px_xl, flatten(style)]}

--- a/src/components/dialogs/GifSelect.tsx
+++ b/src/components/dialogs/GifSelect.tsx
@@ -144,7 +144,7 @@ function GifList({
           a.mb_lg,
           a.flex_row,
           a.align_center,
-          !gtMobile && isWeb && a.gap_md,
+          !gtMobile && web(a.gap_md),
         ]}>
         {/* cover top corners */}
         <View
@@ -209,6 +209,7 @@ function GifList({
           native([a.px_xl, {minHeight: height}]),
           web(a.h_full_vh),
         ]}
+        style={[web(a.h_full_vh)]}
         ListHeaderComponent={
           <>
             {listHeader}
@@ -238,8 +239,6 @@ function GifList({
         onEndReached={onEndReached}
         onEndReachedThreshold={4}
         keyExtractor={(item: Gif) => item.id}
-        // @ts-expect-error web only
-        style={isWeb && {minHeight: '100vh'}}
         keyboardDismissMode="on-drag"
         ListFooterComponent={
           hasData ? (


### PR DESCRIPTION
I changed the structure of `Dialog.Inner` around so padding works differently now. Unfortunately, `Dialog.InnerFlatList` tries to remove the horizontal padding, which then stopped working. This uses the correct prop to return the style to how it was