### PR TITLE
Fix video quality for short videos

### DIFF
--- a/src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerWeb.tsx
+++ b/src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerWeb.tsx
@@ -33,7 +33,6 @@ export function VideoEmbedInnerWeb({
   }
 
   const hlsRef = useHLS({
-    focused,
     playlist: embed.playlist,
     setHasSubtitleTrack,
     setError,
@@ -113,14 +112,12 @@ promiseForHls.then(Hls => {
 })
 
 function useHLS({
-  focused,
   playlist,
   setHasSubtitleTrack,
   setError,
   videoRef,
   setHlsLoading,
 }: {
-  focused: boolean
   playlist: string
   setHasSubtitleTrack: (v: boolean) => void
   setError: (v: Error | null) => void
@@ -155,8 +152,8 @@ function useHLS({
       if (!hlsRef.current) return
       const hls = hlsRef.current
 
-      if (focused && hls.nextAutoLevel > 0) {
-        // if the current quality level goes above 0, flush the low quality segments
+      // if the current quality level goes above 0, flush the low quality segments
+      if (hls.nextAutoLevel > 0) {
         const flushed: HlsTypes.Fragment[] = []
 
         for (const lowQualFrag of lowQualityFragments) {
@@ -178,6 +175,29 @@ function useHLS({
       }
     },
   )
+
+  const flushOnLoop = useNonReactiveCallback(() => {
+    if (!Hls) return
+    if (!hlsRef.current) return
+    const hls = hlsRef.current
+    // the above callback will catch most stale frags, but there's a corner case -
+    // if there's only one segment in the video, it won't get flushed because it avoids
+    // flushing the currently active segment. Therefore, we have to catch it when we loop
+    if (
+      hls.nextAutoLevel > 0 &&
+      lowQualityFragments.length === 1 &&
+      lowQualityFragments[0].start === 0
+    ) {
+      const lowQualFrag = lowQualityFragments[0]
+
+      hls.trigger(Hls.Events.BUFFER_FLUSHING, {
+        startOffset: lowQualFrag.start,
+        endOffset: lowQualFrag.end,
+        type: 'video',
+      })
+      setLowQualityFragments([])
+    }
+  })
 
   useEffect(() => {
     if (!videoRef.current) return
@@ -203,7 +223,8 @@ function useHLS({
     const videoNode = videoRef.current
     videoNode.addEventListener(
       'ended',
-      function () {
+      () => {
+        flushOnLoop()
         videoNode.currentTime = 0
         videoNode.play()
       },
@@ -245,7 +266,15 @@ function useHLS({
       hls.destroy()
       abortController.abort()
     }
-  }, [playlist, setError, setHasSubtitleTrack, videoRef, handleFragChange, Hls])
+  }, [
+    playlist,
+    setError,
+    setHasSubtitleTrack,
+    videoRef,
+    handleFragChange,
+    flushOnLoop,
+    Hls,
+  ])
 
   return hlsRef
 }

--- a/src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerWeb.tsx
+++ b/src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerWeb.tsx
@@ -197,9 +197,6 @@ function useHLS({
     hls.attachMedia(videoRef.current)
     hls.loadSource(playlist)
 
-    // initial value, later on it's managed by Controls
-    hls.autoLevelCapping = 0
-
     // manually loop, so if we've flushed the first buffer it doesn't get confused
     const abortController = new AbortController()
     const {signal} = abortController

--- a/src/view/com/util/post-embeds/VideoEmbedInner/web-controls/VideoControls.tsx
+++ b/src/view/com/util/post-embeds/VideoEmbedInner/web-controls/VideoControls.tsx
@@ -138,13 +138,10 @@ export function Controls({
   useEffect(() => {
     if (!hlsRef.current) return
     if (focused) {
-      // auto decide quality based on network conditions
-      hlsRef.current.autoLevelCapping = -1
       // allow 30s of buffering
       hlsRef.current.config.maxMaxBufferLength = 30
     } else {
       // back to what we initially set
-      hlsRef.current.autoLevelCapping = 0
       hlsRef.current.config.maxMaxBufferLength = 10
     }
   }, [hlsRef, focused])


### PR DESCRIPTION
Two things which increase the quality

- Remove the requirement to click on the video to see the HD version
  - Not how it works on native, generally feels pretty horrible and leads to all the videos you watch being ugly
- Fix the edge case where low quality segments wouldn't get purged for short videos

# Test plan

Check that this one increases in quality after it loops (should be pretty obvious). You also should be able to see the increased quality without needing to click on it
https://bsky.app/profile/passivestar.bsky.social/post/3l7heqzikmi2j