### PR TITLE
Measure tapped image coordinates before opening lightbox

### DIFF
--- a/src/screens/Profile/Header/Shell.tsx
+++ b/src/screens/Profile/Header/Shell.tsx
@@ -57,6 +57,7 @@ let ProfileHeaderShell = ({
       openLightbox({
         type: 'profile-image',
         profile: profile,
+        thumbDims: null,
       })
     }
   }, [openLightbox, profile, moderation])

--- a/src/state/lightbox.tsx
+++ b/src/state/lightbox.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import type {MeasuredDimensions} from 'react-native-reanimated'
 import {AppBskyActorDefs} from '@atproto/api'
 
 import {useNonReactiveCallback} from '#/lib/hooks/useNonReactiveCallback'
@@ -6,6 +7,7 @@ import {useNonReactiveCallback} from '#/lib/hooks/useNonReactiveCallback'
 type ProfileImageLightbox = {
   type: 'profile-image'
   profile: AppBskyActorDefs.ProfileViewDetailed
+  thumbDims: null
 }
 
 type ImagesLightboxItem = {
@@ -17,6 +19,7 @@ type ImagesLightboxItem = {
 type ImagesLightbox = {
   type: 'images'
   images: ImagesLightboxItem[]
+  thumbDims: MeasuredDimensions | null
   index: number
 }
 

--- a/src/view/com/lightbox/ImageViewing/index.tsx
+++ b/src/view/com/lightbox/ImageViewing/index.tsx
@@ -11,6 +11,7 @@
 import React, {ComponentType, useCallback, useMemo, useState} from 'react'
 import {Platform, StyleSheet, View} from 'react-native'
 import PagerView from 'react-native-pager-view'
+import {MeasuredDimensions} from 'react-native-reanimated'
 import Animated, {useAnimatedStyle, withSpring} from 'react-native-reanimated'
 import {Edge, SafeAreaView} from 'react-native-safe-area-context'
 
@@ -20,6 +21,7 @@ import ImageItem from './components/ImageItem/ImageItem'
 
 type Props = {
   images: ImageSource[]
+  thumbDims: MeasuredDimensions | null
   initialImageIndex: number
   visible: boolean
   onRequestClose: () => void
@@ -32,6 +34,7 @@ const DEFAULT_BG_COLOR = '#000'
 
 function ImageViewing({
   images,
+  thumbDims: _thumbDims, // TODO: Pass down and use for animation.
   initialImageIndex,
   visible,
   onRequestClose,

--- a/src/view/com/lightbox/Lightbox.tsx
+++ b/src/view/com/lightbox/Lightbox.tsx
@@ -35,6 +35,7 @@ export function Lightbox() {
           {uri: opts.profile.avatar || '', thumbUri: opts.profile.avatar || ''},
         ]}
         initialImageIndex={0}
+        thumbDims={opts.thumbDims}
         visible
         onRequestClose={onClose}
         FooterComponent={LightboxFooter}
@@ -46,6 +47,7 @@ export function Lightbox() {
       <ImageView
         images={opts.images.map(img => ({...img}))}
         initialImageIndex={opts.index}
+        thumbDims={opts.thumbDims}
         visible
         onRequestClose={onClose}
         FooterComponent={LightboxFooter}

--- a/src/view/com/profile/ProfileSubpageHeader.tsx
+++ b/src/view/com/profile/ProfileSubpageHeader.tsx
@@ -74,6 +74,7 @@ export function ProfileSubpageHeader({
         type: 'images',
         images: [{uri: avatar, thumbUri: avatar}],
         index: 0,
+        thumbDims: null,
       })
     }
   }, [openLightbox, avatar])

--- a/src/view/com/util/images/Gallery.tsx
+++ b/src/view/com/util/images/Gallery.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import {Pressable, StyleProp, View, ViewStyle} from 'react-native'
+import Animated, {AnimatedRef, useAnimatedRef} from 'react-native-reanimated'
 import {Image, ImageStyle} from 'expo-image'
 import {AppBskyEmbedImages} from '@atproto/api'
 import {msg} from '@lingui/macro'
@@ -16,7 +17,10 @@ type EventFunction = (index: number) => void
 interface Props {
   images: AppBskyEmbedImages.ViewImage[]
   index: number
-  onPress?: EventFunction
+  onPress?: (
+    index: number,
+    containerRef: AnimatedRef<React.Component<{}, {}, any>>,
+  ) => void
   onLongPress?: EventFunction
   onPressIn?: EventFunction
   imageStyle?: StyleProp<ImageStyle>
@@ -41,10 +45,11 @@ export function GalleryItem({
   const hasAlt = !!image.alt
   const hideBadges =
     viewContext === PostEmbedViewContext.FeedEmbedRecordWithMedia
+  const containerRef = useAnimatedRef()
   return (
-    <View style={a.flex_1}>
+    <Animated.View style={a.flex_1} ref={containerRef}>
       <Pressable
-        onPress={onPress ? () => onPress(index) : undefined}
+        onPress={onPress ? () => onPress(index, containerRef) : undefined}
         onPressIn={onPressIn ? () => onPressIn(index) : undefined}
         onLongPress={onLongPress ? () => onLongPress(index) : undefined}
         style={[
@@ -95,6 +100,6 @@ export function GalleryItem({
           </Text>
         </View>
       ) : null}
-    </View>
+    </Animated.View>
   )
 }

--- a/src/view/com/util/images/ImageLayoutGrid.tsx
+++ b/src/view/com/util/images/ImageLayoutGrid.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import {StyleProp, StyleSheet, View, ViewStyle} from 'react-native'
+import {AnimatedRef} from 'react-native-reanimated'
 import {AppBskyEmbedImages} from '@atproto/api'
 
 import {PostEmbedViewContext} from '#/view/com/util/post-embeds/types'
@@ -8,7 +9,10 @@ import {GalleryItem} from './Gallery'
 
 interface ImageLayoutGridProps {
   images: AppBskyEmbedImages.ViewImage[]
-  onPress?: (index: number) => void
+  onPress?: (
+    index: number,
+    containerRef: AnimatedRef<React.Component<{}, {}, any>>,
+  ) => void
   onLongPress?: (index: number) => void
   onPressIn?: (index: number) => void
   style?: StyleProp<ViewStyle>
@@ -36,7 +40,10 @@ export function ImageLayoutGrid({style, ...props}: ImageLayoutGridProps) {
 
 interface ImageLayoutGridInnerProps {
   images: AppBskyEmbedImages.ViewImage[]
-  onPress?: (index: number) => void
+  onPress?: (
+    index: number,
+    containerRef: AnimatedRef<React.Component<{}, {}, any>>,
+  ) => void
   onLongPress?: (index: number) => void
   onPressIn?: (index: number) => void
   viewContext?: PostEmbedViewContext

--- a/src/view/com/util/post-embeds/index.tsx
+++ b/src/view/com/util/post-embeds/index.tsx
@@ -149,13 +149,13 @@ export function PostEmbeds({
       }))
       const _openLightbox = (
         index: number,
-        // TODO: Pass dimensions to the lightbox.
-        _dims: MeasuredDimensions | null,
+        thumbDims: MeasuredDimensions | null,
       ) => {
         openLightbox({
           type: 'images',
           images: items,
           index,
+          thumbDims,
         })
       }
       const onPress = (


### PR DESCRIPTION
Stacked on https://github.com/bluesky-social/social-app/pull/5999 and https://github.com/bluesky-social/social-app/pull/6000

---

When you click on an image preview in a feed, we need to know the screen coordinates of the image you clicked. This will later allow us to animate the image expanding into the lightbox.

In this PR, I'm measuring the screen coordinates for solo images and galleries in the feeds. The coordinates become a part of the lightbox state object and get plumbed into the lightbox component. The lightbox component doesn't use it yet.

## Test Plan

Add `console.log(_thumbDims)` in `ImageViewing/index.tsx` and verify that the coordinates make sense. Do it on iOS and Android.

It should be `null` for profile images cause I haven't bothered hooking it up there. In general the code is supposed to be resilient to the dimensions being `null` (in case something breaks with the measurement).

There's no user-visible behavior change in this PR.