### PR TITLE
fix text clipping around external embed's domain

### DIFF
--- a/src/screens/Profile/Header/Handle.tsx
+++ b/src/screens/Profile/Header/Handle.tsx
@@ -47,7 +47,7 @@ export function ProfileHeaderHandle({
                 a.rounded_xs,
                 {borderColor: t.palette.contrast_200},
               ]
-            : [a.text_md, a.leading_tight, t.atoms.text_contrast_medium],
+            : [a.text_md, a.leading_snug, t.atoms.text_contrast_medium],
           web({wordBreak: 'break-all'}),
         ]}>
         {invalidHandle ? _(msg`⚠Invalid Handle`) : `@${profile.handle}`}

--- a/src/view/com/util/post-embeds/ExternalLinkEmbed.tsx
+++ b/src/view/com/util/post-embeds/ExternalLinkEmbed.tsx
@@ -156,7 +156,7 @@ export const ExternalLinkEmbed = ({
                   style={[
                     a.transition_color,
                     a.text_xs,
-                    a.leading_tight,
+                    a.leading_snug,
                     hovered
                       ? t.atoms.text_contrast_high
                       : t.atoms.text_contrast_medium,


### PR DESCRIPTION
before:
![image](https://github.com/user-attachments/assets/22d9ac7d-537e-4773-be8e-fd8b7f342b27)

after:
![image](https://github.com/user-attachments/assets/2b687235-eaef-46b9-b007-5e1f781ce76c)
