### PR TITLE
Fix: iOS Keyboard Persists When Opening Sidebar

### DIFF
--- a/src/view/screens/Search/Search.tsx
+++ b/src/view/screens/Search/Search.tsx
@@ -679,6 +679,7 @@ export function SearchScreen(
   }, [])
 
   const onPressMenu = React.useCallback(() => {
+    textInput.current?.blur()
     setDrawerOpen(true)
   }, [setDrawerOpen])
 


### PR DESCRIPTION
On iOS, when hitting the sidebar/menu icon while the search input is focused, the keyboard remains visible and the search input stays focused

Changes: 
Added blur() call on the search input reference when the sidebar icon is pressed, ensuring the keyboard dismisses properly

![image](https://github.com/user-attachments/assets/29624acb-007b-46f7-8ac8-b58bfdf2e9fa)