### PR TITLE
Fix video currentTime after scrolling away from video 

### DIFF
--- a/src/view/com/util/post-embeds/VideoEmbed.web.tsx
+++ b/src/view/com/util/post-embeds/VideoEmbed.web.tsx
@@ -104,7 +104,6 @@ function ViewportObserver({
   isAnyViewActive: boolean
 }) {
   const ref = useRef<HTMLDivElement>(null)
-  const [nearScreen, setNearScreen] = useState(false)
   const [isFullscreen] = useFullscreen()
   const isWithinMessage = useIsWithinMessage()
 
@@ -120,7 +119,6 @@ function ViewportObserver({
         const position =
           entry.boundingClientRect.y + entry.boundingClientRect.height / 2
         sendPosition(position)
-        setNearScreen(entry.isIntersecting)
       },
       {threshold: Array.from({length: 101}, (_, i) => i / 100)},
     )
@@ -139,7 +137,7 @@ function ViewportObserver({
 
   return (
     <View style={[a.flex_1, a.flex_row]}>
-      {nearScreen && children}
+      {children}
       <div
         ref={ref}
         style={{


### PR DESCRIPTION
On web, when you scroll away from a video an `IntersectionObserver` is used to `play()` and `pause()` the video. As described in  #6035 the `currentTime` of the video is lost after scrolling away. It appears conditional rendering in the following code is causing this:

https://github.com/bluesky-social/social-app/blob/6bc5a05f4bdfd3bf9dea400b3a6b5d9ac356457a/src/view/com/util/post-embeds/VideoEmbed.web.tsx#L145-L159

**I've traced these changes back to two prior PRs for context:**
* https://github.com/bluesky-social/social-app/pull/5246
* https://github.com/bluesky-social/social-app/pull/5251

I didn't experience any issues playing a fullscreen video and the `currentTime` of the video was retained as expected.

