### PR TITLE
Explicitly mark lightbox worklets

### DIFF
--- a/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.android.tsx
+++ b/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.android.tsx
@@ -142,12 +142,14 @@ const ImageItem = ({
 
   const pinch = Gesture.Pinch()
     .onStart(e => {
+      'worklet'
       pinchOrigin.value = {
         x: e.focalX - SCREEN.width / 2,
         y: e.focalY - SCREEN.height / 2,
       }
     })
     .onChange(e => {
+      'worklet'
       if (!imageDimensions) {
         return
       }
@@ -179,6 +181,7 @@ const ImageItem = ({
       }
     })
     .onEnd(() => {
+      'worklet'
       // Commit just the pinch.
       let t = createTransform()
       prependPinch(
@@ -202,6 +205,7 @@ const ImageItem = ({
     // Unlike .enabled(isScaled), this ensures that an initial pinch can turn into a pan midway:
     .minPointers(isScaled ? 1 : 2)
     .onChange(e => {
+      'worklet'
       if (!imageDimensions) {
         return
       }
@@ -223,6 +227,7 @@ const ImageItem = ({
       panTranslation.value = nextPanTranslation
     })
     .onEnd(() => {
+      'worklet'
       // Commit just the pan.
       let t = createTransform()
       prependPan(t, panTranslation.value)
@@ -235,12 +240,14 @@ const ImageItem = ({
     })
 
   const singleTap = Gesture.Tap().onEnd(() => {
+    'worklet'
     runOnJS(onTap)()
   })
 
   const doubleTap = Gesture.Tap()
     .numberOfTaps(2)
     .onEnd(e => {
+      'worklet'
       if (!imageDimensions) {
         return
       }
@@ -287,9 +294,11 @@ const ImageItem = ({
     .failOffsetX([-10, 10])
     .maxPointers(1)
     .onUpdate(e => {
+      'worklet'
       dismissSwipeTranslateY.value = e.translationY
     })
     .onEnd(e => {
+      'worklet'
       if (Math.abs(e.velocityY) > 1000) {
         dismissSwipeTranslateY.value = withDecay({velocity: e.velocityY})
         runOnJS(onRequestClose)()

--- a/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.ios.tsx
+++ b/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.ios.tsx
@@ -113,12 +113,14 @@ const ImageItem = ({
   }
 
   const singleTap = Gesture.Tap().onEnd(() => {
+    'worklet'
     runOnJS(onTap)()
   })
 
   const doubleTap = Gesture.Tap()
     .numberOfTaps(2)
     .onEnd(e => {
+      'worklet'
       const {absoluteX, absoluteY} = e
       runOnJS(handleDoubleTap)(absoluteX, absoluteY)
     })


### PR DESCRIPTION
Not sure what's up with that and whether it's a regression. But I started seeing these warnings:

<img width="384" alt="Screenshot 2024-10-31 at 17 24 34" src="https://github.com/user-attachments/assets/eb4dff2a-75e5-43f8-9cc1-4e5fbaf9e6e1">
<img width="352" alt="Screenshot 2024-10-31 at 17 25 04" src="https://github.com/user-attachments/assets/38724f04-e08c-49ee-9089-951dbaa143e0">

This marks all gesture handlers as worklets, which they should be.

## Test Plan

Warnings are gone.

I am able to perform all gestures (pinch, pan, tap, double tap) on all platforms.