### PR TITLE
Show muted word in `ContentHider`

### DIFF
--- a/src/lib/moderation/useModerationCauseDescription.ts
+++ b/src/lib/moderation/useModerationCauseDescription.ts
@@ -101,7 +101,7 @@ export function useModerationCauseDescription(
     if (cause.type === 'mute-word') {
       return {
         icon: EyeSlash,
-        name: _(msg`Post Hidden by Muted Word`),
+        name: _(msg`Post hidden by muted word: ${cause.match.word.value}`),
         description: _(
           msg`You've chosen to hide a word or tag within this post.`,
         ),

--- a/src/lib/moderation/useModerationCauseDescription.ts
+++ b/src/lib/moderation/useModerationCauseDescription.ts
@@ -101,7 +101,11 @@ export function useModerationCauseDescription(
     if (cause.type === 'mute-word') {
       return {
         icon: EyeSlash,
-        name: _(msg`Post hidden by muted word: ${cause.match.word.value}`),
+        name: _(
+          msg`Post hidden by muted word(s): ${cause.match
+            .map(m => m.word.value)
+            .join(', ')}`,
+        ),
         description: _(
           msg`You've chosen to hide a word or tag within this post.`,
         ),


### PR DESCRIPTION
Depends on backend PR: https://github.com/bluesky-social/atproto/pull/2934

I think we can improve how this looks, but solved for the base need to start.

![CleanShot 2024-10-31 at 15 52 06@2x](https://github.com/user-attachments/assets/b081fca7-8a25-40c9-939e-b3154b0e2ae8)
![CleanShot 2024-10-31 at 16 16 26@2x](https://github.com/user-attachments/assets/a75284bf-1c3c-425c-ab9d-a84d309fa33c)

