### PR TITLE
Fixes for thread composer on Android

### DIFF
--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -1205,11 +1205,21 @@ export function useComposerCancelRef() {
 
 function useAnimatedBorders() {
   const t = useTheme()
-  const hasScrolledToTop = useSharedValue(1)
-  const hasScrolledToBottom = useSharedValue(1)
   const contentOffset = useSharedValue(0)
   const scrollViewHeight = useSharedValue(Infinity)
   const contentHeight = useSharedValue(0)
+
+  const hasScrolledToTop = useDerivedValue(() =>
+    withTiming(contentOffset.value === 0 ? 1 : 0),
+  )
+
+  const hasScrolledToBottom = useDerivedValue(() =>
+    withTiming(
+      contentHeight.value - contentOffset.value - 5 <= scrollViewHeight.value
+        ? 1
+        : 0,
+    ),
+  )
 
   const showHideBottomBorder = useCallback(
     ({
@@ -1222,27 +1232,19 @@ function useAnimatedBorders() {
       newScrollViewHeight?: number
     }) => {
       'worklet'
-
       if (typeof newContentHeight === 'number')
         contentHeight.value = Math.floor(newContentHeight)
       if (typeof newContentOffset === 'number')
         contentOffset.value = Math.floor(newContentOffset)
       if (typeof newScrollViewHeight === 'number')
         scrollViewHeight.value = Math.floor(newScrollViewHeight)
-
-      hasScrolledToBottom.value = withTiming(
-        contentHeight.value - contentOffset.value - 5 <= scrollViewHeight.value
-          ? 1
-          : 0,
-      )
     },
-    [contentHeight, contentOffset, scrollViewHeight, hasScrolledToBottom],
+    [contentHeight, contentOffset, scrollViewHeight],
   )
 
   const scrollHandler = useAnimatedScrollHandler({
     onScroll: event => {
       'worklet'
-      hasScrolledToTop.value = withTiming(event.contentOffset.y === 0 ? 1 : 0)
       showHideBottomBorder({
         newContentOffset: event.contentOffset.y,
         newContentHeight: event.contentSize.height,

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -513,7 +513,11 @@ export const ComposePost = ({
   useEffect(() => {
     if (composerState.mutableNeedsFocusActive) {
       composerState.mutableNeedsFocusActive = false
-      textInput.current?.focus()
+      // On Android, this risks getting the cursor stuck behind the keyboard.
+      // Not worth it.
+      if (!isAndroid) {
+        textInput.current?.focus()
+      }
     }
   }, [composerState])
 

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -19,6 +19,7 @@ import {
   View,
   ViewStyle,
 } from 'react-native'
+import {KeyboardAwareScrollView} from 'react-native-keyboard-controller'
 // @ts-expect-error no type definition
 import ProgressCircle from 'react-native-progress/Circle'
 import Animated, {
@@ -127,6 +128,10 @@ import {
   ThreadDraft,
 } from './state/composer'
 import {NO_VIDEO, NoVideoState, processVideo, VideoState} from './state/video'
+
+const AnimatedKeyboardAwareScrollView = Animated.createAnimatedComponent(
+  KeyboardAwareScrollView,
+)
 
 type CancelRef = {
   onPressCancel: () => void
@@ -588,7 +593,7 @@ export const ComposePost = ({
             />
           </ComposerTopBar>
 
-          <Animated.ScrollView
+          <AnimatedKeyboardAwareScrollView
             ref={scrollViewRef}
             layout={native(LinearTransition)}
             onScroll={scrollHandler}
@@ -616,7 +621,7 @@ export const ComposePost = ({
                 {isFooterSticky && post.id === activePost.id && footer}
               </React.Fragment>
             ))}
-          </Animated.ScrollView>
+          </AnimatedKeyboardAwareScrollView>
           {!isFooterSticky && footer}
         </View>
 

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -1256,7 +1256,6 @@ function useAnimatedBorders() {
 
   const onScrollViewContentSizeChange = useCallback(
     (_width: number, height: number) => {
-      'worklet'
       showHideBottomBorder({
         newContentHeight: height,
       })
@@ -1266,7 +1265,6 @@ function useAnimatedBorders() {
 
   const onScrollViewLayout = useCallback(
     (evt: LayoutChangeEvent) => {
-      'worklet'
       showHideBottomBorder({
         newScrollViewHeight: evt.nativeEvent.layout.height,
       })

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -520,12 +520,17 @@ export const ComposePost = ({
     bottomBarAnimatedStyle,
   } = useAnimatedBorders()
 
+  const scrollToBottom = React.useCallback(() => {
+    'worklet'
+    scrollTo(scrollViewRef, 0, contentHeight.value, true)
+  }, [scrollViewRef, contentHeight])
+
   useEffect(() => {
     if (composerState.mutableNeedsScrollToBottom) {
       composerState.mutableNeedsScrollToBottom = false
-      runOnUI(scrollTo)(scrollViewRef, 0, contentHeight.value, true)
+      runOnUI(scrollToBottom)()
     }
-  }, [composerState, scrollViewRef, contentHeight])
+  }, [composerState, scrollToBottom])
 
   const keyboardVerticalOffset = useKeyboardVerticalOffset()
 

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -1211,9 +1211,6 @@ function useAnimatedBorders() {
   const scrollViewHeight = useSharedValue(Infinity)
   const contentHeight = useSharedValue(0)
 
-  /**
-   * Make sure to run this on the UI thread!
-   */
   const showHideBottomBorder = useCallback(
     ({
       newContentHeight,

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -1274,7 +1274,7 @@ function useScrollTracker({
     (_width: number, height: number) => {
       if (stickyBottom && height > contentHeight.value) {
         const isFairlyCloseToBottom =
-          contentHeight.value - contentOffset.value - 50 <=
+          contentHeight.value - contentOffset.value - 100 <=
           scrollViewHeight.value
         if (isFairlyCloseToBottom) {
           runOnUI(() => {

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -28,8 +28,6 @@ import Animated, {
   interpolateColor,
   LayoutAnimationConfig,
   LinearTransition,
-  runOnUI,
-  scrollTo,
   useAnimatedRef,
   useAnimatedStyle,
   useDerivedValue,
@@ -512,25 +510,12 @@ export const ComposePost = ({
   }, [composerState])
 
   const {
-    contentHeight,
     scrollHandler,
     onScrollViewContentSizeChange,
     onScrollViewLayout,
     topBarAnimatedStyle,
     bottomBarAnimatedStyle,
   } = useAnimatedBorders()
-
-  const scrollToBottom = React.useCallback(() => {
-    'worklet'
-    scrollTo(scrollViewRef, 0, contentHeight.value, true)
-  }, [scrollViewRef, contentHeight])
-
-  useEffect(() => {
-    if (composerState.mutableNeedsScrollToBottom) {
-      composerState.mutableNeedsScrollToBottom = false
-      runOnUI(scrollToBottom)()
-    }
-  }, [composerState, scrollToBottom])
 
   const keyboardVerticalOffset = useKeyboardVerticalOffset()
 
@@ -1311,7 +1296,6 @@ function useAnimatedBorders() {
   })
 
   return {
-    contentHeight,
     scrollHandler,
     onScrollViewContentSizeChange,
     onScrollViewLayout,

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -19,7 +19,6 @@ import {
   View,
   ViewStyle,
 } from 'react-native'
-import {KeyboardAwareScrollView} from 'react-native-keyboard-controller'
 // @ts-expect-error no type definition
 import ProgressCircle from 'react-native-progress/Circle'
 import Animated, {
@@ -128,10 +127,6 @@ import {
   ThreadDraft,
 } from './state/composer'
 import {NO_VIDEO, NoVideoState, processVideo, VideoState} from './state/video'
-
-const AnimatedKeyboardAwareScrollView = Animated.createAnimatedComponent(
-  KeyboardAwareScrollView,
-)
 
 type CancelRef = {
   onPressCancel: () => void
@@ -597,7 +592,7 @@ export const ComposePost = ({
             />
           </ComposerTopBar>
 
-          <AnimatedKeyboardAwareScrollView
+          <Animated.ScrollView
             ref={scrollViewRef}
             layout={native(LinearTransition)}
             onScroll={scrollHandler}
@@ -625,7 +620,7 @@ export const ComposePost = ({
                 {isFooterSticky && post.id === activePost.id && footer}
               </React.Fragment>
             ))}
-          </AnimatedKeyboardAwareScrollView>
+          </Animated.ScrollView>
           {!isFooterSticky && footer}
         </View>
 

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -1205,8 +1205,8 @@ export function useComposerCancelRef() {
 
 function useAnimatedBorders() {
   const t = useTheme()
-  const hasScrolledTop = useSharedValue(0)
-  const hasScrolledBottom = useSharedValue(0)
+  const hasScrolledToTop = useSharedValue(1)
+  const hasScrolledToBottom = useSharedValue(1)
   const contentOffset = useSharedValue(0)
   const scrollViewHeight = useSharedValue(Infinity)
   const contentHeight = useSharedValue(0)
@@ -1233,19 +1233,19 @@ function useAnimatedBorders() {
       if (typeof newScrollViewHeight === 'number')
         scrollViewHeight.value = Math.floor(newScrollViewHeight)
 
-      hasScrolledBottom.value = withTiming(
-        contentHeight.value - contentOffset.value - 5 > scrollViewHeight.value
+      hasScrolledToBottom.value = withTiming(
+        contentHeight.value - contentOffset.value - 5 <= scrollViewHeight.value
           ? 1
           : 0,
       )
     },
-    [contentHeight, contentOffset, scrollViewHeight, hasScrolledBottom],
+    [contentHeight, contentOffset, scrollViewHeight, hasScrolledToBottom],
   )
 
   const scrollHandler = useAnimatedScrollHandler({
     onScroll: event => {
       'worklet'
-      hasScrolledTop.value = withTiming(event.contentOffset.y > 0 ? 1 : 0)
+      hasScrolledToTop.value = withTiming(event.contentOffset.y === 0 ? 1 : 0)
       showHideBottomBorder({
         newContentOffset: event.contentOffset.y,
         newContentHeight: event.contentSize.height,
@@ -1276,9 +1276,9 @@ function useAnimatedBorders() {
     return {
       borderBottomWidth: StyleSheet.hairlineWidth,
       borderColor: interpolateColor(
-        hasScrolledTop.value,
+        hasScrolledToTop.value,
         [0, 1],
-        ['transparent', t.atoms.border_contrast_medium.borderColor],
+        [t.atoms.border_contrast_medium.borderColor, 'transparent'],
       ),
     }
   })
@@ -1286,9 +1286,9 @@ function useAnimatedBorders() {
     return {
       borderTopWidth: StyleSheet.hairlineWidth,
       borderColor: interpolateColor(
-        hasScrolledBottom.value,
+        hasScrolledToBottom.value,
         [0, 1],
-        ['transparent', t.atoms.border_contrast_medium.borderColor],
+        [t.atoms.border_contrast_medium.borderColor, 'transparent'],
       ),
     }
   })

--- a/src/view/com/composer/state/composer.ts
+++ b/src/view/com/composer/state/composer.ts
@@ -87,7 +87,6 @@ export type ComposerState = {
   thread: ThreadDraft
   activePostIndex: number
   mutableNeedsFocusActive: boolean
-  mutableNeedsScrollToBottom: boolean
 }
 
 export type ComposerAction =
@@ -157,7 +156,6 @@ export function composerReducer(
     }
     case 'add_post': {
       const activePostIndex = state.activePostIndex
-      const isAtTheEnd = activePostIndex === state.thread.posts.length - 1
       const nextPosts = [...state.thread.posts]
       nextPosts.splice(activePostIndex + 1, 0, {
         id: nanoid(),
@@ -172,7 +170,6 @@ export function composerReducer(
       })
       return {
         ...state,
-        mutableNeedsScrollToBottom: isAtTheEnd,
         thread: {
           ...state.thread,
           posts: nextPosts,
@@ -514,7 +511,6 @@ export function createComposerState({
   return {
     activePostIndex: 0,
     mutableNeedsFocusActive: false,
-    mutableNeedsScrollToBottom: false,
     thread: {
       posts: [
         {


### PR DESCRIPTION
Stacked on #5962 

---

Easier to review the whole diff.

Does a couple of things:

- Turns off `input.focus` into previous post after deleting a post on Android. This unfortunately risks doing something weird with the keyboard where the input ends up behind it and the scroll view becomes unaware there is more to scroll. I.e. it breaks `KeyboardAvoidingView`. I found no other fix than to disable the behavior.
- <s>Replaces `ScrollView` with `KeyboardAwareScrollView` which on its own (even without the above fix) seemed to significantly reduce how often the above issue occurred. Although I did disable the `focus` calls, I suspect they're not the only cause, so I've left this fix in too.</s>
  - Actually removed this — caused issues on iOS and didn't seem necessary after the fix above.
- Changes how "autoscroll to end" works. The old approach only triggers scroll to end if you pressed "+" on the last post. But it's also confusing if you add media and it doesn't scroll down. I realized that it's easier to do this in `onContentSizeChaged` instead. We already had a handler for this so I expanded its scope a little bit. Also did a minor naming cleanup and refactor there.

## Test Plan

Use a real Android device.

Create a long enough thread to go offscreen. Observe best effort attempts to keep you scrolled down (it doesn't always look aligned though, I suspect because input autofocus is fighting with explicit `scrollTo` — ah well).

Observe that adding media in the last post will scroll you down to it (at least after a bit of a delay) assuming you were scrolled down roughly to the end.

Try to spam "+" and deleting posts in the thread. Try deleting the last post, a post in the middle, etc. You should hopefully never enter a situation where the scroll view refuses to scroll to the last items.

Just check that it's ... usable?