### PR TITLE
Link to app.bsky.actor.profile record in link rel=alternate

### DIFF
--- a/bskyweb/templates/profile.html
+++ b/bskyweb/templates/profile.html
@@ -37,7 +37,7 @@
   {%- if requestHost %}
   <link rel="alternate" type="application/rss+xml" href="https://{{ requestHost }}/profile/{{ profileView.Did }}/rss">
   {% endif %}
-  <link rel="alternate" href="at://{{ profileView.Did }}" />
+  <link rel="alternate" href="at://{{ profileView.Did }}/app.bsky.actor.profile/self" />
 {% endif -%}
 {%- endblock %}
 


### PR DESCRIPTION
re: #6033

what do we think chat? this disambiguates Bluesky profiles from ATProto identities. 

after writing this, I've just seen [mary's comment](https://github.com/bluesky-social/social-app/pull/6033#issuecomment-2451109988) raising the same issue