### PR TITLE
Marked "Sort Replies" as translatable

### DIFF
--- a/src/screens/Settings/ThreadPreferences.tsx
+++ b/src/screens/Settings/ThreadPreferences.tsx
@@ -44,7 +44,7 @@ export function ThreadPreferencesScreen({}: Props) {
         <SettingsList.Container>
           <SettingsList.Group>
             <SettingsList.ItemIcon icon={BubblesIcon} />
-            <SettingsList.ItemText>Sort replies</SettingsList.ItemText>
+            <SettingsList.ItemText>{_(msg`Sort Replies`)}</SettingsList.ItemText>
             <View style={[a.w_full, a.gap_md]}>
               <Text style={[a.flex_1, t.atoms.text_contrast_medium]}>
                 <Trans>Sort replies to the same post by:</Trans>

--- a/src/screens/Settings/ThreadPreferences.tsx
+++ b/src/screens/Settings/ThreadPreferences.tsx
@@ -44,7 +44,9 @@ export function ThreadPreferencesScreen({}: Props) {
         <SettingsList.Container>
           <SettingsList.Group>
             <SettingsList.ItemIcon icon={BubblesIcon} />
-            <SettingsList.ItemText>{_(msg`Sort Replies`)}</SettingsList.ItemText>
+            <SettingsList.ItemText>
+              {_(msg`Sort Replies`)}
+            </SettingsList.ItemText>
             <View style={[a.w_full, a.gap_md]}>
               <Text style={[a.flex_1, t.atoms.text_contrast_medium]}>
                 <Trans>Sort replies to the same post by:</Trans>


### PR DESCRIPTION
Based on #5772

"Sort replies" was not translatable, so I marked it.

Also made a slight adjustment to "Sort Replies," as this term had already been translated previously and could be reused directly.