### PR TITLE
Actually move images to the intended cache directory and ignore data URIs

### DIFF
--- a/src/state/gallery.ts
+++ b/src/state/gallery.ts
@@ -248,7 +248,7 @@ export async function compressImage(img: ComposerImage): Promise<ImageMeta> {
 async function moveIfNecessary(from: string) {
   const cacheDir = isNative && getImageCacheDirectory()
 
-  if (cacheDir && from.startsWith(cacheDir)) {
+  if (cacheDir && !from.startsWith('data:') && !from.startsWith(cacheDir)) {
     const to = joinPath(cacheDir, nanoid(36))
 
     await makeDirectoryAsync(cacheDir, {intermediates: true})


### PR DESCRIPTION
Need additional verification, cc @gaearon 

Just realized that the `moveIfNecessary` function wasn't working as intended, the images never actually gets moved to our intended cache directory because `from.startsWith(cacheDir)` will always return false for those images.

Added an extra check to not do it for data URIs as well, to handle images coming from share intents, and images coming from local drafts (which I'm still working on).