### PR TITLE
Local post thread drafts

### DIFF
--- a/src/state/composer-drafts/database.ts
+++ b/src/state/composer-drafts/database.ts
@@ -1,0 +1,22 @@
+import {DraftEntry, UnknownDraftEntry} from './database.types'
+
+export const listDrafts = async ({
+  cursor: _cursor,
+  limit: _limit = 50,
+}: {
+  limit?: number
+  cursor?: string
+}): Promise<{
+  cursor: string | undefined
+  entries: UnknownDraftEntry[]
+}> => {
+  throw new Error(`unimplemented`)
+}
+
+export const putDraft = async (_entry: DraftEntry): Promise<void> => {
+  throw new Error(`unimplemented`)
+}
+
+export const removeDraft = async (_entryId: string): Promise<void> => {
+  throw new Error(`unimplemented`)
+}

--- a/src/state/composer-drafts/database.types.ts
+++ b/src/state/composer-drafts/database.types.ts
@@ -1,0 +1,15 @@
+import {SerializedThreadDraft} from './schema'
+
+export interface DraftEntry {
+  // We'll be iterating drafts through this string, so it should be incremental
+  // like TID rkeys.
+  id: string
+  createdAt: number
+  state: SerializedThreadDraft
+}
+
+export interface UnknownDraftEntry {
+  id: string
+  createdAt: number
+  state: unknown
+}

--- a/src/state/composer-drafts/database.web.ts
+++ b/src/state/composer-drafts/database.web.ts
@@ -1,0 +1,103 @@
+import {DBSchema, IDBPDatabase, openDB} from 'idb'
+
+import {DraftEntry, UnknownDraftEntry} from './database.types'
+
+interface DraftDBSchema extends DBSchema {
+  drafts: {
+    key: string
+    value: {
+      id: string
+      createdAt: number
+      state: unknown
+    }
+  }
+}
+
+let _db: Promise<IDBPDatabase<DraftDBSchema>> | undefined
+const openDraftDb = () => {
+  if (_db === undefined) {
+    _db = openDB<DraftDBSchema>('bsky-drafts', 1, {
+      upgrade(database, oldVersion) {
+        if (oldVersion < 1) {
+          database.createObjectStore('drafts', {keyPath: 'id'})
+        }
+      },
+    }).catch(err => {
+      _db = undefined
+      return Promise.reject(err)
+    })
+  }
+
+  return _db
+}
+
+export const listDrafts = async ({
+  cursor,
+  limit = 50,
+}: {
+  limit?: number
+  cursor?: string
+}): Promise<{cursor: string | undefined; entries: UnknownDraftEntry[]}> => {
+  const db = await openDraftDb()
+
+  const tx = db.transaction('drafts', 'readonly')
+
+  const range = cursor ? IDBKeyRange.upperBound(cursor, true) : undefined
+  const curs = tx.store.iterate(range, 'prev')
+
+  const items = await toArray(
+    take(
+      map(curs, c => c.value),
+      limit,
+    ),
+  )
+
+  return {
+    cursor: items.length >= limit ? items[items.length - 1].id : undefined,
+    entries: items,
+  }
+}
+
+export const putDraft = async (entry: DraftEntry): Promise<void> => {
+  const db = await openDraftDb()
+  await db.put('drafts', entry)
+}
+
+export const removeDraft = async (entryId: string): Promise<void> => {
+  const db = await openDraftDb()
+  await db.delete('drafts', entryId)
+}
+
+async function toArray<T>(iterable: AsyncIterable<T>): Promise<T[]> {
+  const array: T[] = []
+
+  for await (const value of iterable) {
+    array.push(value)
+  }
+
+  return array
+}
+
+async function* map<T, S>(
+  iterable: AsyncIterable<T>,
+  mapper: (value: T) => S,
+): AsyncGenerator<S> {
+  for await (const value of iterable) {
+    yield mapper(value)
+  }
+}
+
+async function* take<T>(
+  iterable: AsyncIterable<T>,
+  amount: number,
+): AsyncGenerator<T> {
+  let count = 0
+
+  for await (const value of iterable) {
+    yield value
+
+    if (++count >= amount) {
+      break
+    }
+  }
+}

--- a/src/state/composer-drafts/schema.ts
+++ b/src/state/composer-drafts/schema.ts
@@ -1,0 +1,256 @@
+import {readAsStringAsync} from 'expo-file-system'
+import {AtUri, RichText} from '@atproto/api'
+import {nanoid} from 'nanoid/non-secure'
+import * as z from 'zod'
+
+import {shortenLinks} from '#/lib/strings/rich-text-manip'
+import {isNative} from '#/platform/detection'
+import {EmbedDraft, ThreadDraft} from '#/view/com/composer/state/composer'
+import {ComposerImage} from '../gallery'
+import {createPostgateRecord} from '../queries/postgate/util'
+
+const serializedAtUri = z.string().refine(
+  uri => {
+    try {
+      // eslint-disable-next-line no-new
+      new AtUri(uri)
+      return true
+    } catch {
+      return false
+    }
+  },
+  {message: `Not a valid AT-URI`},
+)
+
+const serializedDataUri = z
+  .string()
+  .refine(uri => uri.startsWith('data:'), {message: `Not a valid data URI`})
+
+const serializedBskyPostUri = serializedAtUri.refine(
+  uri => uri.includes('/app.bsky.feed.post/'),
+  {message: `Not a valid app.bsky.feed.post URI`},
+)
+
+const imageMeta = z.object({
+  path: serializedDataUri,
+  width: z.number().nonnegative().int(),
+  height: z.number().nonnegative().int(),
+  mime: z.string(),
+})
+
+// ComposerImage can contain transformations, but we'll ignore those for now,
+// it does mean that users won't be able to re-edit their drafted images though.
+const serializedImage = z.object({
+  alt: z.string(),
+  source: imageMeta,
+})
+type SerializedImage = z.infer<typeof serializedImage>
+
+const serializedImageMedia = z.object({
+  type: z.literal('images'),
+  images: z.array(serializedImage),
+})
+
+const serializedLink = z.object({
+  type: z.literal('link'),
+  uri: z.string(),
+})
+
+const serializedEmbed = z.object({
+  quote: z.optional(serializedLink),
+  media: z.optional(serializedImageMedia),
+  link: z.optional(serializedLink),
+})
+type SerializedEmbed = z.infer<typeof serializedEmbed>
+
+const serializedPost = z.object({
+  text: z.string(),
+  labels: z.array(z.string()),
+  embed: serializedEmbed,
+})
+type SerializedPost = z.infer<typeof serializedPost>
+
+export const serializedThreadDraft = z.object({
+  version: z.literal(1),
+  posts: z.array(serializedPost).min(1),
+  postgate: z.object({
+    detachedEmbeddingUris: z.array(serializedBskyPostUri).optional(),
+    embeddingRules: z.array(z.object({type: z.literal('disable')})).optional(),
+  }),
+  threadgate: z.array(
+    z.union([
+      z.object({type: z.literal('everybody')}),
+      z.object({type: z.literal('nobody')}),
+      z.object({type: z.literal('mention')}),
+      z.object({type: z.literal('following')}),
+      z.object({type: z.literal('list'), list: z.unknown()}),
+    ]),
+  ),
+})
+
+export type SerializedThreadDraft = z.infer<typeof serializedThreadDraft>
+
+const convertToDataUri = async (uri: string): Promise<string> => {
+  if (uri.startsWith('data:')) {
+    return uri
+  }
+
+  if (!isNative) {
+    throw new Error(`unknown uri: ${uri}`)
+  }
+
+  const base64 = await readAsStringAsync(uri)
+  return `data:image/png;base64,${base64}`
+}
+
+const serializeMedia = async (
+  media: NonNullable<EmbedDraft['media']>,
+): Promise<NonNullable<SerializedEmbed['media']>> => {
+  if (media.type === 'images') {
+    return {
+      type: 'images',
+      images: await Promise.all(
+        media.images.map(async (img): Promise<SerializedImage> => {
+          const src = img.transformed ?? img.source
+
+          return {
+            alt: img.alt,
+            source: {
+              path: await convertToDataUri(src.path),
+              width: src.width,
+              height: src.height,
+              mime: src.mime,
+            },
+          }
+        }),
+      ),
+    }
+  }
+
+  // we specifically don't handle gifs and videos at the moment
+  throw new Error(`unhandled '${media.type}' media type`)
+}
+
+export const serializeThread = async ({
+  posts,
+  postgate,
+  threadgate,
+}: ThreadDraft): Promise<SerializedThreadDraft> => {
+  const serialized: SerializedThreadDraft = {
+    version: 1,
+    posts: await Promise.all(
+      posts.map(async ({richtext, embed, labels}): Promise<SerializedPost> => {
+        return {
+          text: richtext.text,
+          embed: {
+            link: embed.link && {type: 'link', uri: embed.link.uri},
+            quote: embed.quote && {type: 'link', uri: embed.quote.uri},
+            media: embed.media && (await serializeMedia(embed.media)),
+          },
+          labels: labels.slice(),
+        }
+      }),
+    ),
+    postgate: {
+      detachedEmbeddingUris: postgate.detachedEmbeddingUris?.slice(),
+      embeddingRules: postgate.embeddingRules?.map(rule => {
+        switch (rule.$type) {
+          case 'app.bsky.feed.postgate#disableRule':
+            return {type: 'disable'}
+
+          default:
+            throw new Error(`unhandled '${rule.$type}' postgate type`)
+        }
+      }),
+    },
+    threadgate: threadgate.map(allow => {
+      switch (allow.type) {
+        case 'everybody':
+          return {type: 'everybody'}
+        case 'following':
+          return {type: 'following'}
+        case 'list':
+          return {type: 'list', list: allow.list}
+        case 'mention':
+          return {type: 'mention'}
+        case 'nobody':
+          return {type: 'nobody'}
+      }
+    }),
+  }
+
+  // just in case, validate that they are correct.
+  return serializedThreadDraft.parse(serialized)
+}
+
+const deserializeMedia = (
+  media: NonNullable<SerializedEmbed['media']>,
+): NonNullable<EmbedDraft['media']> => {
+  if (media.type === 'images') {
+    return {
+      type: 'images',
+      images: media.images.map((img): ComposerImage => {
+        const src = img.source
+
+        return {
+          alt: img.alt,
+          source: {
+            id: nanoid(),
+            path: src.path,
+            width: src.width,
+            height: src.height,
+            mime: src.mime,
+          },
+        }
+      }),
+    }
+  }
+
+  throw new Error(`unhandled '${media.type}' media type`)
+}
+
+export const deserializeThread = ({
+  posts,
+  postgate,
+  threadgate,
+}: SerializedThreadDraft): ThreadDraft => {
+  const deserialized: ThreadDraft = {
+    posts: posts.map(({text, embed, labels}) => {
+      const richtext = new RichText({text})
+      richtext.detectFacetsWithoutResolution()
+
+      return {
+        id: nanoid(),
+        richtext: richtext,
+        shortenedGraphemeLength: shortenLinks(richtext).graphemeLength,
+        embed: {
+          link: embed.link && {type: 'link', uri: embed.link.uri},
+          quote: embed.quote && {type: 'link', uri: embed.quote.uri},
+          media: embed.media && deserializeMedia(embed.media),
+        },
+        labels: labels,
+      }
+    }),
+    postgate: createPostgateRecord({
+      post: '',
+      detachedEmbeddingUris: postgate.detachedEmbeddingUris,
+      embeddingRules: postgate.embeddingRules,
+    }),
+    threadgate: threadgate.map(allow => {
+      switch (allow.type) {
+        case 'everybody':
+          return {type: 'everybody'}
+        case 'following':
+          return {type: 'following'}
+        case 'list':
+          return {type: 'list', list: allow.list}
+        case 'mention':
+          return {type: 'mention'}
+        case 'nobody':
+          return {type: 'nobody'}
+      }
+    }),
+  }
+
+  return deserialized
+}

--- a/src/state/shell/composer/index.tsx
+++ b/src/state/shell/composer/index.tsx
@@ -11,6 +11,7 @@ import {useQueryClient} from '@tanstack/react-query'
 
 import {useNonReactiveCallback} from '#/lib/hooks/useNonReactiveCallback'
 import {postUriToRelativePath, toBskyAppUrl} from '#/lib/strings/url-helpers'
+import {DraftEntry} from '#/state/composer-drafts/database.types'
 import {purgeTemporaryImageFiles} from '#/state/gallery'
 import {precacheResolveLinkQuery} from '#/state/queries/resolve-link'
 import * as Toast from '#/view/com/util/Toast'
@@ -33,6 +34,7 @@ export interface ComposerOpts {
   text?: string
   imageUris?: {uri: string; width: number; height: number; altText?: string}[]
   videoUri?: {uri: string; width: number; height: number}
+  draft?: DraftEntry
 }
 
 type StateContext = ComposerOpts | undefined

--- a/src/view/com/composer/drafts/DiscardDraftPrompt.tsx
+++ b/src/view/com/composer/drafts/DiscardDraftPrompt.tsx
@@ -1,0 +1,36 @@
+import React from 'react'
+import {msg} from '@lingui/macro'
+import {useLingui} from '@lingui/react'
+
+import {DialogOuterProps} from '#/components/Dialog'
+import * as Prompt from '#/components/Prompt'
+
+export const DiscardDraftPrompt = ({
+  control,
+  onConfirm,
+  onDiscard,
+}: {
+  control: DialogOuterProps['control']
+  onConfirm: () => void
+  onDiscard: () => void
+}) => {
+  const {_} = useLingui()
+
+  return (
+    <Prompt.Outer control={control} testID="discardDraftModal">
+      <Prompt.TitleText>Save this draft?</Prompt.TitleText>
+      <Prompt.DescriptionText>
+        You can save this draft to send it at a later time.
+      </Prompt.DescriptionText>
+
+      <Prompt.Actions>
+        <Prompt.Action cta={_(msg`Save`)} onPress={onConfirm} />
+        <Prompt.Action
+          cta={_(msg`Discard`)}
+          onPress={onDiscard}
+          color="secondary"
+        />
+      </Prompt.Actions>
+    </Prompt.Outer>
+  )
+}

--- a/src/view/com/composer/state/composer.ts
+++ b/src/view/com/composer/state/composer.ts
@@ -10,6 +10,8 @@ import {
   postUriToRelativePath,
   toBskyAppUrl,
 } from '#/lib/strings/url-helpers'
+import {DraftEntry} from '#/state/composer-drafts/database.types'
+import {deserializeThread} from '#/state/composer-drafts/schema'
 import {ComposerImage, createInitialImages} from '#/state/gallery'
 import {createPostgateRecord} from '#/state/queries/postgate/util'
 import {Gif} from '#/state/queries/tenor'
@@ -86,6 +88,7 @@ export type ThreadDraft = {
 export type ComposerState = {
   thread: ThreadDraft
   activePostIndex: number
+  draftEntryId: string | undefined
   mutableNeedsFocusActive: boolean
 }
 
@@ -473,12 +476,23 @@ export function createComposerState({
   initMention,
   initImageUris,
   initQuoteUri,
+  initDraftEntry,
 }: {
   initText: string | undefined
   initMention: string | undefined
   initImageUris: ComposerOpts['imageUris']
   initQuoteUri: string | undefined
+  initDraftEntry: DraftEntry | undefined
 }): ComposerState {
+  if (initDraftEntry) {
+    return {
+      activePostIndex: 0,
+      mutableNeedsFocusActive: false,
+      draftEntryId: initDraftEntry.id,
+      thread: deserializeThread(initDraftEntry.state),
+    }
+  }
+
   let media: ImagesMedia | undefined
   if (initImageUris?.length) {
     media = {
@@ -511,6 +525,7 @@ export function createComposerState({
   return {
     activePostIndex: 0,
     mutableNeedsFocusActive: false,
+    draftEntryId: undefined,
     thread: {
       posts: [
         {


### PR DESCRIPTION
## To-dos

- [x] Validation schemas for saved drafts
- [x] Ability to save drafts
- [x] Modify composer reducer to accept the draft entry
- [ ] UI for user to view and restore drafts

### Native

- [ ] expo-sqlite persistence (the only place that seems to make sense)
- [x] Ensure that images are converted to data URIs

### Web

- [x] IndexedDB persistence