### PR TITLE
Override X-Bsky-Topics with a debugging param

### DIFF
--- a/src/lib/api/feed/utils.ts
+++ b/src/lib/api/feed/utils.ts
@@ -1,11 +1,18 @@
 import {AtUri} from '@atproto/api'
 
 import {BSKY_FEED_OWNER_DIDS} from '#/lib/constants'
+import {isWeb} from '#/platform/detection'
 import {UsePreferencesQueryResponse} from '#/state/queries/preferences'
+
+let debugTopics = ''
+if (isWeb && typeof window !== 'undefined') {
+  const params = new URLSearchParams(window.location.search)
+  debugTopics = params.get('debug_topics') ?? ''
+}
 
 export function createBskyTopicsHeader(userInterests?: string) {
   return {
-    'X-Bsky-Topics': userInterests || '',
+    'X-Bsky-Topics': debugTopics || userInterests || '',
   }
 }
 


### PR DESCRIPTION
For convenience when trying new flags.

## Test Plan

Not sent to non-bsky feeds:

<img width="576" alt="Screenshot 2024-11-01 at 16 39 42" src="https://github.com/user-attachments/assets/6db136d9-4779-4608-9845-71e336215db9">

Bsky feeds still normally receive the topics header:

<img width="398" alt="Screenshot 2024-11-01 at 16 39 17" src="https://github.com/user-attachments/assets/6e2fe48c-70e8-4422-b4f1-b6c9580de37f">

But http://localhost:19006/?debug_topics=1234 overrides it:

<img width="298" alt="Screenshot 2024-11-01 at 16 39 31" src="https://github.com/user-attachments/assets/645be4b7-85c1-4240-bfd5-78fbe7c1dd69">
