### PR TITLE
Improve focus-visible outlines in navigation

### DIFF
--- a/src/alf/atoms.ts
+++ b/src/alf/atoms.ts
@@ -1,4 +1,4 @@
-import {Platform, StyleSheet, ViewStyle} from 'react-native'
+import {Platform, StyleProp, StyleSheet, ViewStyle} from 'react-native'
 
 import * as tokens from '#/alf/tokens'
 import {native, web} from '#/alf/util/platform'
@@ -887,9 +887,9 @@ export const atoms = {
   user_select_all: {
     userSelect: 'all',
   },
-  focus_visible: {
-    'outline-offset': '-1px',
-  },
+  outline_inset_1: {
+    outlineOffset: '-1px',
+  } as StyleProp<ViewStyle>,
 
   /*
    * Text decoration

--- a/src/alf/atoms.ts
+++ b/src/alf/atoms.ts
@@ -887,6 +887,9 @@ export const atoms = {
   user_select_all: {
     userSelect: 'all',
   },
+  focus_visible: {
+    'outline-offset': '-1px',
+  },
 
   /*
    * Text decoration

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -468,8 +468,6 @@ export const Button = React.forwardRef<View, ButtonProps>(
           a.flex_row,
           a.align_center,
           a.justify_center,
-          // @ts-ignore - web only
-          a.focus_visible,
           flattenedBaseStyles,
           ...(state.hovered || state.pressed
             ? [hoverStyles, flatten(hoverStyleProp)]

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -468,6 +468,8 @@ export const Button = React.forwardRef<View, ButtonProps>(
           a.flex_row,
           a.align_center,
           a.justify_center,
+          // @ts-ignore - web only
+          a.focus_visible,
           flattenedBaseStyles,
           ...(state.hovered || state.pressed
             ? [hoverStyles, flatten(hoverStyleProp)]

--- a/src/view/shell/desktop/LeftNav.tsx
+++ b/src/view/shell/desktop/LeftNav.tsx
@@ -185,7 +185,14 @@ function NavItem({count, href, icon, iconFilled, label}: NavItemProps) {
 
   return (
     <PressableWithHover
-      style={[a.flex_row, a.align_center, a.p_md, a.rounded_sm, a.gap_sm]}
+      style={[
+        a.flex_row,
+        a.align_center,
+        a.p_md,
+        a.rounded_sm,
+        a.gap_sm,
+        a.outline_inset_1,
+      ]}
       hoverStyle={t.atoms.bg_contrast_25}
       // @ts-ignore the function signature differs on web -prf
       onPress={onPressWrapped}


### PR DESCRIPTION
I noticed focus outlines on buttons are overflow most of the time.

The behavior replicates in currently deployed app on all browsers I tried (Safari, Firefox, Chrome)

Tried to improve it by adding `outline-offset`.

`outline-offset` do not seem supported by the Atoms convention, yet it seem [widely available](https://developer.mozilla.org/en-US/docs/Web/CSS/outline-offset).

Here is tab navigation before the PR:

![CleanShot 2024-11-01 at 19 27 25](https://github.com/user-attachments/assets/6d7685e1-9202-4ce1-bb3c-0bdd8c11297f)

You can notice almost all outlines overflows their parent container.

And here it is after the changes:

![CleanShot 2024-11-01 at 19 28 03](https://github.com/user-attachments/assets/107b7c73-dc47-4eca-9a08-6e50d447b5df)

I think we could also improve the outlines for avatar/collapse button by using `tabIndex` prop, the TypeScript errors made me question it.