### PR TITLE
[Settings] Add subdomain to _atproto host on change handle

### DIFF
--- a/src/screens/Settings/components/ChangeHandleDialog.tsx
+++ b/src/screens/Settings/components/ChangeHandleDialog.tsx
@@ -318,6 +318,18 @@ function OwnHandlePage({goToServiceHandle}: {goToServiceHandle: () => void}) {
     },
   })
 
+  const getHostFromDomain = (domainString: string): string => {
+    const parts = domainString.trim().split('.')
+
+    if (parts.length <= 2) {
+      return '_atproto'
+    }
+
+    return '_atproto.' + parts.slice(0, -2).join('.')
+  }
+
+  const host = getHostFromDomain(domain)
+
   return (
     <View style={[a.flex_1, a.gap_lg]}>
       {isSuccess && (
@@ -401,11 +413,11 @@ function OwnHandlePage({goToServiceHandle}: {goToServiceHandle: () => void}) {
                 <CopyButton
                   variant="solid"
                   color="secondary"
-                  value="_atproto"
+                  value={host}
                   label={_(msg`Copy host`)}
                   hoverStyle={[a.bg_transparent]}
                   hitSlop={HITSLOP_10}>
-                  <Text style={[a.text_md, a.flex_1]}>_atproto</Text>
+                  <Text style={[a.text_md, a.flex_1]}>{host}</Text>
                   <ButtonIcon icon={CopyIcon} />
                 </CopyButton>
               </View>


### PR DESCRIPTION
### Reproduce

1. Visit your account settings: https://bsky.app/settings
2. Select `Account` > `Handle`
3. Press `I have my own domain ->`
4. Enter custom domain with subdomain, for example `sub.bogdan.covrig.dev`

The DNS record text output will include the subdomain in the Host field.

### Before

<img width="615" alt="382391637-9d224c30-bc73-4fef-9038-021dc2b0eb0b" src="https://github.com/user-attachments/assets/5be4d8e9-7f97-4750-a29e-d22e0ccc74ba">

### After

<img width="615" alt="382391764-ab7ff756-08b4-4090-b25e-3bc9c8e08215" src="https://github.com/user-attachments/assets/edd35b5f-4797-4133-b45e-f6bdf8f168da">

Closes #5821. 