### PR TITLE
thread composer: avoid emitting action on paste for inactive posts

### DIFF
--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -715,6 +715,9 @@ let ComposerPost = React.memo(function ComposerPost({
 
   const onPhotoPasted = useCallback(
     async (uri: string) => {
+      if (!isActive) {
+        return
+      }
       if (uri.startsWith('data:video/')) {
         onSelectVideo(post.id, {uri, type: 'video', height: 0, width: 0})
       } else {
@@ -722,7 +725,7 @@ let ComposerPost = React.memo(function ComposerPost({
         onImageAdd([res])
       }
     },
-    [post.id, onSelectVideo, onImageAdd],
+    [post.id, onSelectVideo, onImageAdd, isActive],
   )
 
   return (


### PR DESCRIPTION
@gaearon 
I found this little thing while [exploring the new shiny stuff](https://bsky.app/profile/frncs.eu/post/3l7vsn6cmlc24)!
Basically EVERY post inside the thread composer was listening for the paste event and emitting the `embed_add_images` action, so every reducer was updating with the embed data to display.
This should stop that.
I tested on web only but AFAIK this (copy/pasting image content) should not be possible?
Let me know if it's ok!
