### PR TITLE
Refactor lightbox prop drilling

### DIFF
--- a/src/screens/Profile/Header/Shell.tsx
+++ b/src/screens/Profile/Header/Shell.tsx
@@ -55,8 +55,18 @@ let ProfileHeaderShell = ({
     const modui = moderation.ui('avatar')
     if (profile.avatar && !(modui.blur && modui.noOverride)) {
       openLightbox({
-        type: 'profile-image',
-        profile: profile,
+        images: [
+          {
+            uri: profile.avatar,
+            thumbUri: profile.avatar,
+            dimensions: {
+              // It's fine if it's actually smaller but we know it's 1:1.
+              height: 1000,
+              width: 1000,
+            },
+          },
+        ],
+        index: 0,
         thumbDims: null,
       })
     }

--- a/src/state/lightbox.tsx
+++ b/src/state/lightbox.tsx
@@ -1,15 +1,8 @@
 import React from 'react'
 import type {MeasuredDimensions} from 'react-native-reanimated'
-import {AppBskyActorDefs} from '@atproto/api'
 
 import {useNonReactiveCallback} from '#/lib/hooks/useNonReactiveCallback'
 import {Dimensions} from '#/lib/media/types'
-
-type ProfileImageLightbox = {
-  type: 'profile-image'
-  profile: AppBskyActorDefs.ProfileViewDetailed
-  thumbDims: null
-}
 
 type ImagesLightboxItem = {
   uri: string
@@ -18,14 +11,11 @@ type ImagesLightboxItem = {
   dimensions: Dimensions | null
 }
 
-type ImagesLightbox = {
-  type: 'images'
+type Lightbox = {
   images: ImagesLightboxItem[]
   thumbDims: MeasuredDimensions | null
   index: number
 }
-
-type Lightbox = ProfileImageLightbox | ImagesLightbox
 
 const LightboxContext = React.createContext<{
   activeLightbox: Lightbox | null

--- a/src/state/lightbox.tsx
+++ b/src/state/lightbox.tsx
@@ -2,17 +2,10 @@ import React from 'react'
 import type {MeasuredDimensions} from 'react-native-reanimated'
 
 import {useNonReactiveCallback} from '#/lib/hooks/useNonReactiveCallback'
-import {Dimensions} from '#/lib/media/types'
-
-type ImagesLightboxItem = {
-  uri: string
-  thumbUri: string
-  alt?: string
-  dimensions: Dimensions | null
-}
+import {ImageSource} from '#/view/com/lightbox/ImageViewing/@types'
 
 type Lightbox = {
-  images: ImagesLightboxItem[]
+  images: ImageSource[]
   thumbDims: MeasuredDimensions | null
   index: number
 }

--- a/src/view/com/lightbox/ImageViewing/index.tsx
+++ b/src/view/com/lightbox/ImageViewing/index.tsx
@@ -9,12 +9,26 @@
 // https://github.com/jobtoday/react-native-image-viewing
 
 import React, {useCallback, useMemo, useState} from 'react'
-import {Platform, StyleSheet, View} from 'react-native'
+import {
+  Dimensions,
+  LayoutAnimation,
+  Platform,
+  StyleSheet,
+  View,
+} from 'react-native'
 import PagerView from 'react-native-pager-view'
 import {MeasuredDimensions} from 'react-native-reanimated'
 import Animated, {useAnimatedStyle, withSpring} from 'react-native-reanimated'
+import {useSafeAreaInsets} from 'react-native-safe-area-context'
 import {Edge, SafeAreaView} from 'react-native-safe-area-context'
+import {FontAwesomeIcon} from '@fortawesome/react-native-fontawesome'
+import {Trans} from '@lingui/macro'
 
+import {colors, s} from '#/lib/styles'
+import {isIOS} from '#/platform/detection'
+import {Button} from '#/view/com/util/forms/Button'
+import {Text} from '#/view/com/util/text/Text'
+import {ScrollView} from '#/view/com/util/Views'
 import {ImageSource} from './@types'
 import ImageDefaultHeader from './components/ImageDefaultHeader'
 import ImageItem from './components/ImageItem/ImageItem'
@@ -26,9 +40,11 @@ type Props = {
   visible: boolean
   onRequestClose: () => void
   backgroundColor?: string
-  renderFooter: (index: number) => React.ReactNode
+  onPressSave: (uri: string) => void
+  onPressShare: (uri: string) => void
 }
 
+const SCREEN_HEIGHT = Dimensions.get('window').height
 const DEFAULT_BG_COLOR = '#000'
 
 function ImageViewing({
@@ -38,7 +54,8 @@ function ImageViewing({
   visible,
   onRequestClose,
   backgroundColor = DEFAULT_BG_COLOR,
-  renderFooter,
+  onPressSave,
+  onPressShare,
 }: Props) {
   const [isScaled, setIsScaled] = useState(false)
   const [isDragging, setIsDragging] = useState(false)
@@ -122,10 +139,96 @@ function ImageViewing({
           ))}
         </PagerView>
         <Animated.View style={[styles.footer, animatedFooterStyle]}>
-          {renderFooter(imageIndex)}
+          <LightboxFooter
+            images={images}
+            index={imageIndex}
+            onPressSave={onPressSave}
+            onPressShare={onPressShare}
+          />
         </Animated.View>
       </View>
     </SafeAreaView>
+  )
+}
+
+function LightboxFooter({
+  images,
+  index,
+  onPressSave,
+  onPressShare,
+}: {
+  images: ImageSource[]
+  index: number
+  onPressSave: (uri: string) => void
+  onPressShare: (uri: string) => void
+}) {
+  const {alt: altText, uri} = images[index]
+  const [isAltExpanded, setAltExpanded] = React.useState(false)
+  const insets = useSafeAreaInsets()
+  const svMaxHeight = SCREEN_HEIGHT - insets.top - 50
+  const isMomentumScrolling = React.useRef(false)
+  return (
+    <ScrollView
+      style={[
+        {
+          backgroundColor: '#000d',
+        },
+        {maxHeight: svMaxHeight},
+      ]}
+      scrollEnabled={isAltExpanded}
+      onMomentumScrollBegin={() => {
+        isMomentumScrolling.current = true
+      }}
+      onMomentumScrollEnd={() => {
+        isMomentumScrolling.current = false
+      }}
+      contentContainerStyle={{
+        paddingTop: 16,
+        paddingBottom: insets.bottom + 10,
+        paddingHorizontal: 24,
+      }}>
+      {altText ? (
+        <View accessibilityRole="button" style={styles.footerText}>
+          <Text
+            style={[s.gray3]}
+            numberOfLines={isAltExpanded ? undefined : 3}
+            selectable
+            onPress={() => {
+              if (isMomentumScrolling.current) {
+                return
+              }
+              LayoutAnimation.configureNext({
+                duration: 450,
+                update: {type: 'spring', springDamping: 1},
+              })
+              setAltExpanded(prev => !prev)
+            }}
+            onLongPress={() => {}}>
+            {altText}
+          </Text>
+        </View>
+      ) : null}
+      <View style={styles.footerBtns}>
+        <Button
+          type="primary-outline"
+          style={styles.footerBtn}
+          onPress={() => onPressSave(uri)}>
+          <FontAwesomeIcon icon={['far', 'floppy-disk']} style={s.white} />
+          <Text type="xl" style={s.white}>
+            <Trans context="action">Save</Trans>
+          </Text>
+        </Button>
+        <Button
+          type="primary-outline"
+          style={styles.footerBtn}
+          onPress={() => onPressShare(uri)}>
+          <FontAwesomeIcon icon="arrow-up-from-bracket" style={s.white} />
+          <Text type="xl" style={s.white}>
+            <Trans context="action">Share</Trans>
+          </Text>
+        </Button>
+      </View>
+    </ScrollView>
   )
 }
 
@@ -156,6 +259,21 @@ const styles = StyleSheet.create({
     width: '100%',
     zIndex: 1,
     bottom: 0,
+  },
+  footerText: {
+    paddingBottom: isIOS ? 20 : 16,
+  },
+  footerBtns: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    gap: 8,
+  },
+  footerBtn: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    backgroundColor: 'transparent',
+    borderColor: colors.white,
   },
 })
 

--- a/src/view/com/lightbox/ImageViewing/index.tsx
+++ b/src/view/com/lightbox/ImageViewing/index.tsx
@@ -8,7 +8,7 @@
 // Original code copied and simplified from the link below as the codebase is currently not maintained:
 // https://github.com/jobtoday/react-native-image-viewing
 
-import React, {ComponentType, useCallback, useMemo, useState} from 'react'
+import React, {useCallback, useMemo, useState} from 'react'
 import {Platform, StyleSheet, View} from 'react-native'
 import PagerView from 'react-native-pager-view'
 import {MeasuredDimensions} from 'react-native-reanimated'
@@ -26,8 +26,7 @@ type Props = {
   visible: boolean
   onRequestClose: () => void
   backgroundColor?: string
-  HeaderComponent?: ComponentType<{imageIndex: number}>
-  FooterComponent?: ComponentType<{imageIndex: number}>
+  renderFooter: (index: number) => React.ReactNode
 }
 
 const DEFAULT_BG_COLOR = '#000'
@@ -39,8 +38,7 @@ function ImageViewing({
   visible,
   onRequestClose,
   backgroundColor = DEFAULT_BG_COLOR,
-  HeaderComponent,
-  FooterComponent,
+  renderFooter,
 }: Props) {
   const [isScaled, setIsScaled] = useState(false)
   const [isDragging, setIsDragging] = useState(false)
@@ -96,13 +94,7 @@ function ImageViewing({
       accessibilityViewIsModal>
       <View style={[styles.container, {backgroundColor}]}>
         <Animated.View style={[styles.header, animatedHeaderStyle]}>
-          {typeof HeaderComponent !== 'undefined' ? (
-            React.createElement(HeaderComponent, {
-              imageIndex,
-            })
-          ) : (
-            <ImageDefaultHeader onRequestClose={onRequestClose} />
-          )}
+          <ImageDefaultHeader onRequestClose={onRequestClose} />
         </Animated.View>
         <PagerView
           scrollEnabled={!isScaled}
@@ -129,13 +121,9 @@ function ImageViewing({
             </View>
           ))}
         </PagerView>
-        {typeof FooterComponent !== 'undefined' && (
-          <Animated.View style={[styles.footer, animatedFooterStyle]}>
-            {React.createElement(FooterComponent, {
-              imageIndex,
-            })}
-          </Animated.View>
-        )}
+        <Animated.View style={[styles.footer, animatedFooterStyle]}>
+          {renderFooter(imageIndex)}
+        </Animated.View>
       </View>
     </SafeAreaView>
   )

--- a/src/view/com/lightbox/Lightbox.tsx
+++ b/src/view/com/lightbox/Lightbox.tsx
@@ -27,33 +27,11 @@ export function Lightbox() {
 
   if (!activeLightbox) {
     return null
-  } else if (activeLightbox.type === 'profile-image') {
+  } else {
     const opts = activeLightbox
     return (
       <ImageView
-        images={[
-          {
-            uri: opts.profile.avatar || '',
-            thumbUri: opts.profile.avatar || '',
-            dimensions: {
-              // It's fine if it's actually smaller but we know it's 1:1.
-              height: 1000,
-              width: 1000,
-            },
-          },
-        ]}
-        initialImageIndex={0}
-        thumbDims={opts.thumbDims}
-        visible
-        onRequestClose={onClose}
-        renderFooter={() => <LightboxFooter uri={opts.profile.avatar || ''} />}
-      />
-    )
-  } else if (activeLightbox.type === 'images') {
-    const opts = activeLightbox
-    return (
-      <ImageView
-        images={opts.images.map(img => ({...img}))}
+        images={opts.images}
         initialImageIndex={opts.index}
         thumbDims={opts.thumbDims}
         visible
@@ -66,8 +44,6 @@ export function Lightbox() {
         )}
       />
     )
-  } else {
-    return null
   }
 }
 

--- a/src/view/com/lightbox/Lightbox.tsx
+++ b/src/view/com/lightbox/Lightbox.tsx
@@ -46,7 +46,7 @@ export function Lightbox() {
         thumbDims={opts.thumbDims}
         visible
         onRequestClose={onClose}
-        FooterComponent={LightboxFooter}
+        renderFooter={() => <LightboxFooter uri={opts.profile.avatar || ''} />}
       />
     )
   } else if (activeLightbox.type === 'images') {
@@ -58,7 +58,12 @@ export function Lightbox() {
         thumbDims={opts.thumbDims}
         visible
         onRequestClose={onClose}
-        FooterComponent={LightboxFooter}
+        renderFooter={index => (
+          <LightboxFooter
+            uri={opts.images[index].uri}
+            altText={opts.images[index].alt || ''}
+          />
+        )}
       />
     )
   } else {
@@ -66,9 +71,8 @@ export function Lightbox() {
   }
 }
 
-function LightboxFooter({imageIndex}: {imageIndex: number}) {
+function LightboxFooter({altText, uri}: {altText?: string; uri: string}) {
   const {_} = useLingui()
-  const {activeLightbox} = useLightbox()
   const [isAltExpanded, setAltExpanded] = React.useState(false)
   const [permissionResponse, requestPermission] = MediaLibrary.usePermissions({
     granularPermissions: ['photo'],
@@ -106,22 +110,6 @@ function LightboxFooter({imageIndex}: {imageIndex: number}) {
     },
     [permissionResponse, requestPermission, _],
   )
-
-  const lightbox = activeLightbox
-  if (!lightbox) {
-    return null
-  }
-
-  let altText = ''
-  let uri = ''
-  if (lightbox.type === 'images') {
-    const opts = lightbox
-    uri = opts.images[imageIndex].uri
-    altText = opts.images[imageIndex].alt || ''
-  } else if (lightbox.type === 'profile-image') {
-    const opts = lightbox
-    uri = opts.profile.avatar || ''
-  }
 
   return (
     <ScrollView

--- a/src/view/com/lightbox/Lightbox.tsx
+++ b/src/view/com/lightbox/Lightbox.tsx
@@ -1,23 +1,12 @@
 import React from 'react'
-import {Dimensions, LayoutAnimation, StyleSheet, View} from 'react-native'
-import {useSafeAreaInsets} from 'react-native-safe-area-context'
 import * as MediaLibrary from 'expo-media-library'
-import {FontAwesomeIcon} from '@fortawesome/react-native-fontawesome'
-import {msg, Trans} from '@lingui/macro'
+import {msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
 import {saveImageToMediaLibrary, shareImageModal} from '#/lib/media/manip'
-import {colors, s} from '#/lib/styles'
-import {isIOS} from '#/platform/detection'
 import {useLightbox, useLightboxControls} from '#/state/lightbox'
-import {ImageSource} from '#/view/com/lightbox/ImageViewing/@types'
-import {ScrollView} from '#/view/com/util/Views'
-import {Button} from '../util/forms/Button'
-import {Text} from '../util/text/Text'
 import * as Toast from '../util/Toast'
 import ImageView from './ImageViewing'
-
-const SCREEN_HEIGHT = Dimensions.get('window').height
 
 export function Lightbox() {
   const {activeLightbox} = useLightbox()
@@ -71,110 +60,8 @@ export function Lightbox() {
       thumbDims={activeLightbox.thumbDims}
       visible
       onRequestClose={onClose}
-      renderFooter={index => (
-        <LightboxFooter
-          images={activeLightbox.images}
-          index={index}
-          onPressSave={saveImageToAlbumWithToasts}
-        />
-      )}
+      onPressSave={saveImageToAlbumWithToasts}
+      onPressShare={uri => shareImageModal({uri})}
     />
   )
 }
-
-function LightboxFooter({
-  images,
-  index,
-  onPressSave,
-}: {
-  images: ImageSource[]
-  index: number
-  onPressSave: (uri: string) => void
-}) {
-  const {alt: altText, uri} = images[index]
-  const [isAltExpanded, setAltExpanded] = React.useState(false)
-  const insets = useSafeAreaInsets()
-  const svMaxHeight = SCREEN_HEIGHT - insets.top - 50
-  const isMomentumScrolling = React.useRef(false)
-  return (
-    <ScrollView
-      style={[
-        {
-          backgroundColor: '#000d',
-        },
-        {maxHeight: svMaxHeight},
-      ]}
-      scrollEnabled={isAltExpanded}
-      onMomentumScrollBegin={() => {
-        isMomentumScrolling.current = true
-      }}
-      onMomentumScrollEnd={() => {
-        isMomentumScrolling.current = false
-      }}
-      contentContainerStyle={{
-        paddingTop: 16,
-        paddingBottom: insets.bottom + 10,
-        paddingHorizontal: 24,
-      }}>
-      {altText ? (
-        <View accessibilityRole="button" style={styles.footerText}>
-          <Text
-            style={[s.gray3]}
-            numberOfLines={isAltExpanded ? undefined : 3}
-            selectable
-            onPress={() => {
-              if (isMomentumScrolling.current) {
-                return
-              }
-              LayoutAnimation.configureNext({
-                duration: 450,
-                update: {type: 'spring', springDamping: 1},
-              })
-              setAltExpanded(prev => !prev)
-            }}
-            onLongPress={() => {}}>
-            {altText}
-          </Text>
-        </View>
-      ) : null}
-      <View style={styles.footerBtns}>
-        <Button
-          type="primary-outline"
-          style={styles.footerBtn}
-          onPress={() => onPressSave(uri)}>
-          <FontAwesomeIcon icon={['far', 'floppy-disk']} style={s.white} />
-          <Text type="xl" style={s.white}>
-            <Trans context="action">Save</Trans>
-          </Text>
-        </Button>
-        <Button
-          type="primary-outline"
-          style={styles.footerBtn}
-          onPress={() => shareImageModal({uri})}>
-          <FontAwesomeIcon icon="arrow-up-from-bracket" style={s.white} />
-          <Text type="xl" style={s.white}>
-            <Trans context="action">Share</Trans>
-          </Text>
-        </Button>
-      </View>
-    </ScrollView>
-  )
-}
-
-const styles = StyleSheet.create({
-  footerText: {
-    paddingBottom: isIOS ? 20 : 16,
-  },
-  footerBtns: {
-    flexDirection: 'row',
-    justifyContent: 'center',
-    gap: 8,
-  },
-  footerBtn: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 8,
-    backgroundColor: 'transparent',
-    borderColor: colors.white,
-  },
-})

--- a/src/view/com/lightbox/Lightbox.tsx
+++ b/src/view/com/lightbox/Lightbox.tsx
@@ -27,24 +27,23 @@ export function Lightbox() {
 
   if (!activeLightbox) {
     return null
-  } else {
-    const opts = activeLightbox
-    return (
-      <ImageView
-        images={opts.images}
-        initialImageIndex={opts.index}
-        thumbDims={opts.thumbDims}
-        visible
-        onRequestClose={onClose}
-        renderFooter={index => (
-          <LightboxFooter
-            uri={opts.images[index].uri}
-            altText={opts.images[index].alt || ''}
-          />
-        )}
-      />
-    )
   }
+
+  return (
+    <ImageView
+      images={activeLightbox.images}
+      initialImageIndex={activeLightbox.index}
+      thumbDims={activeLightbox.thumbDims}
+      visible
+      onRequestClose={onClose}
+      renderFooter={index => (
+        <LightboxFooter
+          uri={activeLightbox.images[index].uri}
+          altText={activeLightbox.images[index].alt || ''}
+        />
+      )}
+    />
+  )
 }
 
 function LightboxFooter({altText, uri}: {altText?: string; uri: string}) {

--- a/src/view/com/lightbox/Lightbox.web.tsx
+++ b/src/view/com/lightbox/Lightbox.web.tsx
@@ -38,24 +38,8 @@ export function Lightbox() {
     return null
   }
 
-  const initialIndex =
-    activeLightbox.type === 'images' ? activeLightbox.index : 0
-
-  let imgs: Img[] | undefined
-  if (activeLightbox.type === 'profile-image') {
-    const opts = activeLightbox
-    if (opts.profile.avatar) {
-      imgs = [{uri: opts.profile.avatar}]
-    }
-  } else if (activeLightbox.type === 'images') {
-    const opts = activeLightbox
-    imgs = opts.images
-  }
-
-  if (!imgs) {
-    return null
-  }
-
+  const initialIndex = activeLightbox.index
+  const imgs = activeLightbox.images
   return (
     <LightboxInner
       imgs={imgs}

--- a/src/view/com/profile/ProfileSubpageHeader.tsx
+++ b/src/view/com/profile/ProfileSubpageHeader.tsx
@@ -71,7 +71,6 @@ export function ProfileSubpageHeader({
       avatar // TODO && !(view.moderation.avatar.blur && view.moderation.avatar.noOverride)
     ) {
       openLightbox({
-        type: 'images',
         images: [
           {
             uri: avatar,

--- a/src/view/com/util/post-embeds/index.tsx
+++ b/src/view/com/util/post-embeds/index.tsx
@@ -152,7 +152,6 @@ export function PostEmbeds({
         thumbDims: MeasuredDimensions | null,
       ) => {
         openLightbox({
-          type: 'images',
           images: items,
           index,
           thumbDims,


### PR DESCRIPTION
Stacked on #6047

---

No changes to behavior.

This may be easier to read commit by commit.

- I get rid of the `cloneElement` and the weird data flow where the footer reads data via the hook. A more natural way to express this is to have the parent component pass a render prop to the child, closing over the lightbox data.
- Then I get rid of the two lightbox types. As far as the lightbox is concerned, everything here is images. It shouldn't be thinking about profile pictures etc. This makes it annoying to evolve the code. So I unified the types.
- Then I refactor `LightboxFooter` to take all `images`. This is a bit cleaner and allows it to make its own decisions about how to deal with them (right now it just reads the current one, but it doesn't have to).
- Finally, I decide to move `LightboxFooter` so it lives together with the actual lightbox shell. I keep some of the app-specific logic out of it but the visual parts are now moved. This will make adding animation later easier.

## Test Plan

Open lightbox with 1 image, or with multiple. Flick through them. Verify Save/Share buttons work and point at the right image. Verify the alt text shows up for the right image.

Open lightbox in profile too. Verify that works.