### PR TITLE
Fixed issue where X in search bar does nothing

### DIFF
--- a/src/components/forms/SearchInput.tsx
+++ b/src/components/forms/SearchInput.tsx
@@ -57,7 +57,7 @@ export const SearchInput = React.forwardRef<TextInput, SearchInputProps>(
           <View
             style={[
               a.absolute,
-              a.z_10,
+              a.z_20,
               a.my_auto,
               a.inset_0,
               a.justify_center,


### PR DESCRIPTION
This PR resolves issue #5845 by increasing the `zIndex` of the clear button in the search bar from 10 to 20