### PR TITLE
tap search icon twice to focus search input

### DIFF
--- a/src/view/screens/Search/Search.tsx
+++ b/src/view/screens/Search/Search.tsx
@@ -20,7 +20,11 @@ import {
 import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 import AsyncStorage from '@react-native-async-storage/async-storage'
-import {useFocusEffect, useNavigation} from '@react-navigation/native'
+import {
+  useFocusEffect,
+  useIsFocused,
+  useNavigation,
+} from '@react-navigation/native'
 
 import {APP_LANGUAGES, LANGUAGES} from '#/lib/../locale/languages'
 import {createHitslop} from '#/lib/constants'
@@ -624,6 +628,7 @@ export function SearchScreen(
   const t = useThemeNew()
   const {gtMobile} = useBreakpoints()
   const navigation = useNavigation<NavigationProp>()
+  const isFocused = useIsFocused()
   const textInput = React.useRef<TextInput>(null)
   const {_} = useLingui()
   const setDrawerOpen = useSetDrawerOpen()
@@ -658,6 +663,13 @@ export function SearchScreen(
       }
     }),
   )
+
+  React.useEffect(() => {
+    if (!isFocused) {
+      return
+    }
+    return listenSoftReset(() => textInput.current?.focus())
+  }, [isFocused])
 
   React.useEffect(() => {
     const loadSearchHistory = async () => {


### PR DESCRIPTION
with this PR, tapping on the search icon in the bottom tab bar (while on the search screen) will focus the search input. this is a nice shortcut for searching quickly!

this mirrors the behavior of many other apps such as the iOS app store.

fixes #5061.


https://github.com/user-attachments/assets/5af5963b-dd2f-486d-9b9d-c67047372f38

