### PR TITLE
Fixes to animated lightbox

### DIFF
--- a/src/screens/Profile/Header/Shell.tsx
+++ b/src/screens/Profile/Header/Shell.tsx
@@ -162,21 +162,22 @@ let ProfileHeaderShell = ({
           accessibilityRole="image"
           accessibilityLabel={_(msg`View ${profile.handle}'s avatar`)}
           accessibilityHint="">
-          <Animated.View
-            ref={aviRef}
+          <View
             style={[
               t.atoms.bg,
               {borderColor: t.atoms.bg.backgroundColor},
               styles.avi,
               profile.associated?.labeler && styles.aviLabeler,
             ]}>
-            <UserAvatar
-              type={profile.associated?.labeler ? 'labeler' : 'user'}
-              size={90}
-              avatar={profile.avatar}
-              moderation={moderation.ui('avatar')}
-            />
-          </Animated.View>
+            <Animated.View ref={aviRef}>
+              <UserAvatar
+                type={profile.associated?.labeler ? 'labeler' : 'user'}
+                size={90}
+                avatar={profile.avatar}
+                moderation={moderation.ui('avatar')}
+              />
+            </Animated.View>
+          </View>
         </TouchableWithoutFeedback>
       </GrowableAvatar>
     </View>

--- a/src/screens/Profile/Header/Shell.tsx
+++ b/src/screens/Profile/Header/Shell.tsx
@@ -169,7 +169,7 @@ let ProfileHeaderShell = ({
               styles.avi,
               profile.associated?.labeler && styles.aviLabeler,
             ]}>
-            <Animated.View ref={aviRef}>
+            <Animated.View ref={aviRef} collapsable={false}>
               <UserAvatar
                 type={profile.associated?.labeler ? 'labeler' : 'user'}
                 size={90}

--- a/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.android.tsx
+++ b/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.android.tsx
@@ -293,13 +293,13 @@ const ImageItem = ({
       )
 
   return (
-    <Animated.View
-      ref={containerRef}
-      // Necessary to make opacity work for both children together.
-      renderToHardwareTextureAndroid
-      style={[styles.container, animatedStyle, {}]}>
-      <ActivityIndicator size="small" color="#FFF" style={styles.loading} />
-      <GestureDetector gesture={composedGesture}>
+    <GestureDetector gesture={composedGesture}>
+      <Animated.View
+        ref={containerRef}
+        // Necessary to make opacity work for both children together.
+        renderToHardwareTextureAndroid
+        style={[styles.container, animatedStyle, {}]}>
+        <ActivityIndicator size="small" color="#FFF" style={styles.loading} />
         <Image
           contentFit="contain"
           source={{uri: imageSrc.uri}}
@@ -320,8 +320,8 @@ const ImageItem = ({
           accessibilityIgnoresInvertColors
           cachePolicy="memory"
         />
-      </GestureDetector>
-    </Animated.View>
+      </Animated.View>
+    </GestureDetector>
   )
 }
 

--- a/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.android.tsx
+++ b/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.android.tsx
@@ -236,6 +236,13 @@ const ImageItem = ({
 
   const singleTap = Gesture.Tap().onEnd(() => {
     'worklet'
+    const [, , committedScale] = readTransform(committedTransform.value)
+    if (committedScale !== 1) {
+      // Go back to 1:1 using the identity vector.
+      let t = createTransform()
+      committedTransform.value = withClampedSpring(t)
+      return
+    }
     runOnJS(onTap)()
   })
 

--- a/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.android.tsx
+++ b/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.android.tsx
@@ -251,7 +251,6 @@ const ImageItem = ({
       // Go back to 1:1 using the identity vector.
       let t = createTransform()
       committedTransform.value = withClampedSpring(t)
-      return
     }
     runOnJS(onTap)()
   })

--- a/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.android.tsx
+++ b/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.android.tsx
@@ -1,5 +1,10 @@
 import React, {useState} from 'react'
-import {ActivityIndicator, Dimensions, StyleSheet} from 'react-native'
+import {
+  ActivityIndicator,
+  Dimensions,
+  StyleProp,
+  StyleSheet,
+} from 'react-native'
 import {
   Gesture,
   GestureDetector,
@@ -13,7 +18,7 @@ import Animated, {
   useSharedValue,
   withSpring,
 } from 'react-native-reanimated'
-import {Image} from 'expo-image'
+import {Image, ImageStyle} from 'expo-image'
 
 import {useImageDimensions} from '#/lib/media/image-sizes'
 import type {Dimensions as ImageDimensions, ImageSource} from '../../@types'
@@ -26,6 +31,8 @@ import {
   readTransform,
   TransformMatrix,
 } from '../../transforms'
+
+const AnimatedImage = Animated.createAnimatedComponent(Image)
 
 const windowDim = Dimensions.get('window')
 const screenDim = Dimensions.get('screen')
@@ -47,13 +54,16 @@ type Props = {
   isPagingAndroid: boolean
   showControls: boolean
   dismissSwipePan: PanGesture
+  imageStyle: StyleProp<ImageStyle>
 }
+
 const ImageItem = ({
   imageSrc,
   onTap,
   onZoom,
   isPagingAndroid,
   dismissSwipePan,
+  imageStyle,
 }: Props) => {
   const [isScaled, setIsScaled] = useState(false)
   const [imageAspect, imageDimensions] = useImageDimensions({
@@ -307,21 +317,24 @@ const ImageItem = ({
         renderToHardwareTextureAndroid
         style={[styles.container, animatedStyle, {}]}>
         <ActivityIndicator size="small" color="#FFF" style={styles.loading} />
-        <Image
-          contentFit="contain"
+        <AnimatedImage
+          contentFit="cover"
           source={{uri: imageSrc.uri}}
-          placeholderContentFit="contain"
+          placeholderContentFit="cover"
           placeholder={{uri: imageSrc.thumbUri}}
-          style={{
-            width: SCREEN.width,
-            height: imageAspect ? SCREEN.width / imageAspect : undefined,
-            borderRadius:
-              imageSrc.type === 'circle-avi'
-                ? SCREEN.width / 2
-                : imageSrc.type === 'rect-avi'
-                ? 20
-                : 0,
-          }}
+          style={[
+            {
+              width: SCREEN.width,
+              height: imageAspect ? SCREEN.width / imageAspect : undefined,
+              borderRadius:
+                imageSrc.type === 'circle-avi'
+                  ? SCREEN.width / 2
+                  : imageSrc.type === 'rect-avi'
+                  ? 20
+                  : 0,
+            },
+            imageStyle,
+          ]}
           accessibilityLabel={imageSrc.alt}
           accessibilityHint=""
           accessibilityIgnoresInvertColors

--- a/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.android.tsx
+++ b/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.android.tsx
@@ -44,7 +44,7 @@ type Props = {
   onRequestClose: () => void
   onTap: () => void
   onZoom: (isZoomed: boolean) => void
-  isScrollViewBeingDragged: boolean
+  isPagingAndroid: boolean
   showControls: boolean
   dismissSwipePan: PanGesture
 }
@@ -52,7 +52,7 @@ const ImageItem = ({
   imageSrc,
   onTap,
   onZoom,
-  isScrollViewBeingDragged,
+  isPagingAndroid,
   dismissSwipePan,
 }: Props) => {
   const [isScaled, setIsScaled] = useState(false)
@@ -282,7 +282,7 @@ const ImageItem = ({
       committedTransform.value = withClampedSpring(finalTransform)
     })
 
-  const composedGesture = isScrollViewBeingDragged
+  const composedGesture = isPagingAndroid
     ? // If the parent is not at rest, provide a no-op gesture.
       Gesture.Manual()
     : Gesture.Exclusive(

--- a/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.ios.tsx
+++ b/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.ios.tsx
@@ -117,9 +117,8 @@ const ImageItem = ({
         height: SCREEN.height,
         animated: true,
       })
-    } else {
-      onTap()
     }
+    onTap()
   }
 
   const singleTap = Gesture.Tap().onEnd(() => {

--- a/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.ios.tsx
+++ b/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.ios.tsx
@@ -97,9 +97,25 @@ const ImageItem = ({
     })
   }
 
+  function handleTap() {
+    if (scaled) {
+      const scrollResponderRef = scrollViewRef?.current?.getScrollResponder()
+      // @ts-ignore
+      scrollResponderRef?.scrollResponderZoomTo({
+        x: 0,
+        y: 0,
+        width: SCREEN.width,
+        height: SCREEN.height,
+        animated: true,
+      })
+    } else {
+      onTap()
+    }
+  }
+
   const singleTap = Gesture.Tap().onEnd(() => {
     'worklet'
-    runOnJS(onTap)()
+    runOnJS(handleTap)()
   })
 
   const doubleTap = Gesture.Tap()

--- a/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.ios.tsx
+++ b/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.ios.tsx
@@ -7,18 +7,25 @@
  */
 
 import React, {useState} from 'react'
-import {ActivityIndicator, Dimensions, StyleSheet} from 'react-native'
+import {
+  ActivityIndicator,
+  Dimensions,
+  StyleProp,
+  StyleSheet,
+} from 'react-native'
 import {
   Gesture,
   GestureDetector,
   PanGesture,
 } from 'react-native-gesture-handler'
 import Animated, {runOnJS, useAnimatedRef} from 'react-native-reanimated'
-import {Image} from 'expo-image'
+import {Image, ImageStyle} from 'expo-image'
 
 import {useAnimatedScrollHandler} from '#/lib/hooks/useAnimatedScrollHandler_FIXED'
 import {useImageDimensions} from '#/lib/media/image-sizes'
 import {ImageSource} from '../../@types'
+
+const AnimatedImage = Animated.createAnimatedComponent(Image)
 
 const SCREEN = Dimensions.get('screen')
 const MAX_ORIGINAL_IMAGE_ZOOM = 2
@@ -32,6 +39,7 @@ type Props = {
   isPagingAndroid: boolean // Not available on iOS
   showControls: boolean
   dismissSwipePan: PanGesture | null
+  imageStyle: StyleProp<ImageStyle>
 }
 
 const ImageItem = ({
@@ -40,6 +48,7 @@ const ImageItem = ({
   onZoom,
   showControls,
   dismissSwipePan,
+  imageStyle,
 }: Props) => {
   const scrollViewRef = useAnimatedRef<Animated.ScrollView>()
 
@@ -145,21 +154,24 @@ const ImageItem = ({
         bounces={scaled}
         centerContent>
         <ActivityIndicator size="small" color="#FFF" style={styles.loading} />
-        <Image
-          contentFit="contain"
+        <AnimatedImage
+          contentFit="cover"
           source={{uri: imageSrc.uri}}
-          placeholderContentFit="contain"
+          placeholderContentFit="cover"
           placeholder={{uri: imageSrc.thumbUri}}
-          style={{
-            width: SCREEN.width,
-            height: imageAspect ? SCREEN.width / imageAspect : undefined,
-            borderRadius:
-              imageSrc.type === 'circle-avi'
-                ? SCREEN.width / 2
-                : imageSrc.type === 'rect-avi'
-                ? 20
-                : 0,
-          }}
+          style={[
+            {
+              width: SCREEN.width,
+              height: imageAspect ? SCREEN.width / imageAspect : undefined,
+              borderRadius:
+                imageSrc.type === 'circle-avi'
+                  ? SCREEN.width / 2
+                  : imageSrc.type === 'rect-avi'
+                  ? 20
+                  : 0,
+            },
+            imageStyle,
+          ]}
           accessibilityLabel={imageSrc.alt}
           accessibilityHint=""
           enableLiveTextInteraction={showControls && !scaled}

--- a/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.ios.tsx
+++ b/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.ios.tsx
@@ -22,8 +22,7 @@ import Animated, {runOnJS, useAnimatedRef} from 'react-native-reanimated'
 import {Image, ImageStyle} from 'expo-image'
 
 import {useAnimatedScrollHandler} from '#/lib/hooks/useAnimatedScrollHandler_FIXED'
-import {useImageDimensions} from '#/lib/media/image-sizes'
-import {ImageSource} from '../../@types'
+import {Dimensions as ImageDimensions, ImageSource} from '../../@types'
 
 const AnimatedImage = Animated.createAnimatedComponent(Image)
 
@@ -40,25 +39,24 @@ type Props = {
   showControls: boolean
   dismissSwipePan: PanGesture | null
   imageStyle: StyleProp<ImageStyle>
+  imageAspect: number | undefined
+  dimensions: ImageDimensions | undefined
 }
 
 const ImageItem = ({
   imageSrc,
+  dimensions,
   onTap,
   onZoom,
   showControls,
   dismissSwipePan,
   imageStyle,
+  imageAspect,
 }: Props) => {
   const scrollViewRef = useAnimatedRef<Animated.ScrollView>()
-
   const [scaled, setScaled] = useState(false)
-  const [imageAspect, imageDimensions] = useImageDimensions({
-    src: imageSrc.uri,
-    knownDimensions: imageSrc.dimensions,
-  })
-  const maxZoomScale = imageDimensions
-    ? (imageDimensions.width / SCREEN.width) * MAX_ORIGINAL_IMAGE_ZOOM
+  const maxZoomScale = dimensions
+    ? (dimensions.width / SCREEN.width) * MAX_ORIGINAL_IMAGE_ZOOM
     : 1
 
   const scrollHandler = useAnimatedScrollHandler({
@@ -158,19 +156,7 @@ const ImageItem = ({
           source={{uri: imageSrc.uri}}
           placeholderContentFit="cover"
           placeholder={{uri: imageSrc.thumbUri}}
-          style={[
-            {
-              width: SCREEN.width,
-              height: imageAspect ? SCREEN.width / imageAspect : undefined,
-              borderRadius:
-                imageSrc.type === 'circle-avi'
-                  ? SCREEN.width / 2
-                  : imageSrc.type === 'rect-avi'
-                  ? 20
-                  : 0,
-            },
-            imageStyle,
-          ]}
+          style={imageStyle}
           accessibilityLabel={imageSrc.alt}
           accessibilityHint=""
           enableLiveTextInteraction={showControls && !scaled}

--- a/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.ios.tsx
+++ b/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.ios.tsx
@@ -29,7 +29,7 @@ type Props = {
   onRequestClose: () => void
   onTap: () => void
   onZoom: (scaled: boolean) => void
-  isScrollViewBeingDragged: boolean
+  isPagingAndroid: boolean // Not available on iOS
   showControls: boolean
   dismissSwipePan: PanGesture | null
 }

--- a/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.tsx
+++ b/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.tsx
@@ -5,7 +5,7 @@ import {StyleProp, View} from 'react-native'
 import {PanGesture} from 'react-native-gesture-handler'
 import {ImageStyle} from 'expo-image'
 
-import {ImageSource} from '../../@types'
+import {Dimensions as ImageDimensions, ImageSource} from '../../@types'
 
 type Props = {
   imageSrc: ImageSource
@@ -16,6 +16,8 @@ type Props = {
   showControls: boolean
   dismissSwipePan: PanGesture | null
   imageStyle: StyleProp<ImageStyle>
+  imageAspect: number | undefined
+  dimensions: ImageDimensions | undefined
 }
 
 const ImageItem = (_props: Props) => {

--- a/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.tsx
+++ b/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.tsx
@@ -1,7 +1,7 @@
 // default implementation fallback for web
 
 import React from 'react'
-import {StyleProp,View} from 'react-native'
+import {StyleProp, View} from 'react-native'
 import {PanGesture} from 'react-native-gesture-handler'
 import {ImageStyle} from 'expo-image'
 

--- a/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.tsx
+++ b/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.tsx
@@ -11,7 +11,7 @@ type Props = {
   onRequestClose: () => void
   onTap: () => void
   onZoom: (scaled: boolean) => void
-  isScrollViewBeingDragged: boolean
+  isPagingAndroid: boolean
   showControls: boolean
   dismissSwipePan: PanGesture | null
 }

--- a/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.tsx
+++ b/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.tsx
@@ -1,8 +1,9 @@
 // default implementation fallback for web
 
 import React from 'react'
-import {View} from 'react-native'
+import {StyleProp,View} from 'react-native'
 import {PanGesture} from 'react-native-gesture-handler'
+import {ImageStyle} from 'expo-image'
 
 import {ImageSource} from '../../@types'
 
@@ -14,6 +15,7 @@ type Props = {
   isPagingAndroid: boolean
   showControls: boolean
   dismissSwipePan: PanGesture | null
+  imageStyle: StyleProp<ImageStyle>
 }
 
 const ImageItem = (_props: Props) => {

--- a/src/view/com/lightbox/ImageViewing/index.tsx
+++ b/src/view/com/lightbox/ImageViewing/index.tsx
@@ -72,6 +72,7 @@ function ImageViewing({
   const [imageIndex, setImageIndex] = useState(initialImageIndex)
   const [showControls, setShowControls] = useState(true)
   const dismissSwipeTranslateY = useSharedValue(0)
+  const isFlyingAway = useSharedValue(false)
 
   const animatedHeaderStyle = useAnimatedStyle(() => {
     const show = showControls && dismissSwipeTranslateY.value === 0
@@ -98,10 +99,16 @@ function ImageViewing({
     }
   })
 
+  const containerStyle = useAnimatedStyle(() => {
+    if (openProgress.value < 1 || isFlyingAway.value) {
+      return {pointerEvents: 'none'}
+    }
+    return {pointerEvents: 'auto'}
+  })
+
   const activeImageStyle = useAnimatedStyle(() => {
     if (openProgress.value === 1 || dismissSwipeTranslateY.value !== 0) {
       return {
-        pointerEvents: 'auto',
         transform: [{translateY: dismissSwipeTranslateY.value}],
       }
     }
@@ -114,12 +121,10 @@ function ImageViewing({
         image.dimensions,
       )
       return {
-        pointerEvents: 'none',
         transform: interpolatedTransform,
       }
     }
     return {
-      pointerEvents: 'auto',
       transform: [],
     }
   })
@@ -136,6 +141,7 @@ function ImageViewing({
     .onEnd(e => {
       'worklet'
       if (Math.abs(e.velocityY) > 1000) {
+        isFlyingAway.value = true
         dismissSwipeTranslateY.value = withDecay({
           velocity: e.velocityY,
           velocityFactor: Math.max(3000 / Math.abs(e.velocityY), 1), // Speed up if it's too slow.
@@ -198,7 +204,7 @@ function ImageViewing({
       edges={edges}
       aria-modal
       accessibilityViewIsModal>
-      <View style={[styles.container]}>
+      <Animated.View style={[styles.container, containerStyle]}>
         <Animated.View style={[styles.backdrop, backdropStyle]} />
         <Animated.View style={[styles.header, animatedHeaderStyle]}>
           <ImageDefaultHeader onRequestClose={onRequestClose} />
@@ -245,7 +251,7 @@ function ImageViewing({
             onPressShare={onPressShare}
           />
         </Animated.View>
-      </View>
+      </Animated.View>
     </SafeAreaView>
   )
 }

--- a/src/view/com/lightbox/ImageViewing/index.tsx
+++ b/src/view/com/lightbox/ImageViewing/index.tsx
@@ -38,6 +38,7 @@ import {Edge, SafeAreaView} from 'react-native-safe-area-context'
 import {FontAwesomeIcon} from '@fortawesome/react-native-fontawesome'
 import {Trans} from '@lingui/macro'
 
+import {useImageDimensions} from '#/lib/media/image-sizes'
 import {colors, s} from '#/lib/styles'
 import {isAndroid, isIOS} from '#/platform/detection'
 import {Lightbox} from '#/state/lightbox'
@@ -262,20 +263,22 @@ function LightboxPage({
   dismissSwipeTranslateY: SharedValue<number>
   dismissSwipePan: PanGesture
 }) {
-  const {thumbRect, dimensions} = imageSrc
-  const imageAspect = dimensions
-    ? dimensions.width / dimensions.height
-    : undefined
+  const {thumbRect, dimensions: knownDimensions, type} = imageSrc
+  const [imageAspect, dimensions] = useImageDimensions({
+    src: imageSrc.uri,
+    knownDimensions,
+  })
+
   const finalWidth = SCREEN.width
   const finalHeight = imageAspect ? SCREEN.width / imageAspect : undefined
 
   const interpolation = useDerivedValue(() => {
-    if (isActive && thumbRect && dimensions && openProgress.value < 1) {
+    if (isActive && thumbRect && knownDimensions && openProgress.value < 1) {
       return interpolateTransform(
         openProgress.value,
         thumbRect,
         SCREEN,
-        dimensions,
+        knownDimensions,
       )
     }
     const translateY = isActive ? dismissSwipeTranslateY.value : 0
@@ -299,6 +302,8 @@ function LightboxPage({
     return {
       width,
       height,
+      borderRadius:
+        type === 'circle-avi' ? SCREEN.width / 2 : type === 'rect-avi' ? 20 : 0,
     }
   })
 
@@ -313,6 +318,8 @@ function LightboxPage({
         showControls={showControls}
         dismissSwipePan={isActive ? dismissSwipePan : null}
         imageStyle={imageStyle}
+        imageAspect={imageAspect}
+        dimensions={dimensions}
       />
     </Animated.View>
   )

--- a/src/view/com/lightbox/ImageViewing/index.tsx
+++ b/src/view/com/lightbox/ImageViewing/index.tsx
@@ -37,7 +37,7 @@ import {FontAwesomeIcon} from '@fortawesome/react-native-fontawesome'
 import {Trans} from '@lingui/macro'
 
 import {colors, s} from '#/lib/styles'
-import {isIOS} from '#/platform/detection'
+import {isAndroid, isIOS} from '#/platform/detection'
 import {Lightbox} from '#/state/lightbox'
 import {Button} from '#/view/com/util/forms/Button'
 import {Text} from '#/view/com/util/text/Text'
@@ -68,7 +68,7 @@ function ImageViewing({
 }) {
   const {images, index: initialImageIndex} = lightbox
   const [isScaled, setIsScaled] = useState(false)
-  const [isDragging, setIsDragging] = useState(false)
+  const [isPagingAndroid, setIsPagingAndroid] = useState(false)
   const [imageIndex, setImageIndex] = useState(initialImageIndex)
   const [showControls, setShowControls] = useState(true)
   const dismissSwipeTranslateY = useSharedValue(0)
@@ -211,7 +211,13 @@ function ImageViewing({
             setIsScaled(false)
           }}
           onPageScrollStateChanged={e => {
-            setIsDragging(e.nativeEvent.pageScrollState !== 'idle')
+            if (isAndroid) {
+              // This condition isn't reliable on iOS (the pager may send
+              // events out of order if you spam it with vertical pans in
+              // the middle of deceleration). However, we only need this
+              // variable for Android anyway, so let's make that explicit.
+              setIsPagingAndroid(e.nativeEvent.pageScrollState !== 'idle')
+            }
           }}
           overdrag={true}
           style={styles.pager}>
@@ -224,11 +230,9 @@ function ImageViewing({
                 onZoom={onZoom}
                 imageSrc={imageSrc}
                 onRequestClose={onRequestClose}
-                isScrollViewBeingDragged={isDragging}
+                isPagingAndroid={isPagingAndroid}
                 showControls={showControls}
-                dismissSwipePan={
-                  imageIndex === i && !isDragging ? dismissSwipePan : null
-                }
+                dismissSwipePan={imageIndex === i ? dismissSwipePan : null}
               />
             </Animated.View>
           ))}

--- a/src/view/com/profile/ProfileSubpageHeader.tsx
+++ b/src/view/com/profile/ProfileSubpageHeader.tsx
@@ -154,7 +154,7 @@ export function ProfileSubpageHeader({
           paddingBottom: 6,
           paddingHorizontal: isMobile ? 12 : 14,
         }}>
-        <Animated.View ref={aviRef}>
+        <Animated.View ref={aviRef} collapsable={false}>
           <Pressable
             testID="headerAviButton"
             onPress={onPressAvi}

--- a/src/view/com/util/images/Gallery.tsx
+++ b/src/view/com/util/images/Gallery.tsx
@@ -48,7 +48,10 @@ export function GalleryItem({
   const hideBadges =
     viewContext === PostEmbedViewContext.FeedEmbedRecordWithMedia
   return (
-    <Animated.View style={a.flex_1} ref={containerRefs[index]}>
+    <Animated.View
+      style={a.flex_1}
+      ref={containerRefs[index]}
+      collapsable={false}>
       <Pressable
         onPress={onPress ? () => onPress(index, containerRefs) : undefined}
         onPressIn={onPressIn ? () => onPressIn(index) : undefined}

--- a/src/view/com/util/post-embeds/index.tsx
+++ b/src/view/com/util/post-embeds/index.tsx
@@ -180,7 +180,10 @@ export function PostEmbeds({
         const image = images[0]
         return (
           <ContentHider modui={moderation?.ui('contentMedia')}>
-            <Animated.View ref={containerRef} style={[a.mt_sm, style]}>
+            <Animated.View
+              ref={containerRef}
+              style={[a.mt_sm, style]}
+              collapsable={false}>
               <AutoSizedImage
                 crop={
                   viewContext === PostEmbedViewContext.ThreadHighlighted


### PR DESCRIPTION
Stacked on https://github.com/bluesky-social/social-app/pull/6047, https://github.com/bluesky-social/social-app/pull/6073, https://github.com/bluesky-social/social-app/pull/6048, and https://github.com/bluesky-social/social-app/pull/6081

---

## Known issues

- Slow in prod on low-end Android
  - I have a few ideas to try, otherwise might have to disable it on Android
- Incorrect positioning on Android device 
  - Doesn’t happen on emulator. 
- Flash of borders on the thumbnail after dismiss via swipe 
- Extra high aspect is behaving weirdly  https://bsky.app/profile/schlagteslinks.bsky.social/post/3l7y4l6yur72e
- I’ve had it lock up on iOS

---

Fixes for known issues in the preceding stack. It would've been a pain to rebase and I had to be very careful not to break other things. This seems to be an equilibrium of features working but it's quite fragile. See commit by commit.

- Fixes swipe-up gesture stopping working if you spam it too fast during a pager slide on iOS.
- Fixes being unable to drag or perform gestures with finger(s) on the black bars on Android.
- Fixes unintended ability to paginate while in the middle of an opening or closing animation.
- A single tap in zoomed state now always zooms out and shows controls. It was too hard to make the close animation (if you pressed close after bringing up controls in a zoomed state) work well. Now it just pops you back before showing controls. Twitter does the same.
- Cropped images no longer flash their cropped edges on the first animation frame. Now they continuously expand. This needs device testing because it definitely affects perf a bit. Mostly relevant for multi-image layouts.
- The avatar first frame is now precisely positioned.

## Test Plan

All of the above. Plus the usual. Try portraits/landscapes in different layouts (1, 2, 3, 4). Slow down if needed to verify animation.


https://github.com/user-attachments/assets/126f79c2-1967-4e54-9544-573cf6a5cc37


https://github.com/user-attachments/assets/cd6c1af6-8420-4035-b8d9-53032170b175

