### PR TITLE
Add tiktok embed

### DIFF
--- a/__tests__/lib/string.test.ts
+++ b/__tests__/lib/string.test.ts
@@ -1,11 +1,11 @@
 import {RichText} from '@atproto/api'
 
-import {parseEmbedPlayerFromUrl} from 'lib/strings/embed-player'
+import {parseEmbedPlayerFromUrl} from '#/lib/strings/embed-player'
 import {
   createStarterPackGooglePlayUri,
   createStarterPackLinkFromAndroidReferrer,
   parseStarterPackUri,
-} from 'lib/strings/starter-pack'
+} from '#/lib/strings/starter-pack'
 import {cleanError} from '../../src/lib/strings/errors'
 import {createFullHandle, makeValidHandle} from '../../src/lib/strings/handles'
 import {enforceLen} from '../../src/lib/strings/helpers'
@@ -433,6 +433,9 @@ describe('parseEmbedPlayerFromUrl', () => {
 
     'https://www.flickr.com/groups/898944@N23/',
     'https://www.flickr.com/groups',
+
+    'https://www.tiktok.com/@maxinne.me/video/7413048848903326982',
+    'https://vm.tiktok.com/ZMhXDgKxA/',
   ]
 
   const outputs = [
@@ -795,6 +798,14 @@ describe('parseEmbedPlayerFromUrl', () => {
     },
 
     undefined,
+    undefined,
+
+    {
+      type: 'tiktok_video',
+      source: 'tiktok',
+      playerUri:
+        'https://www.tiktok.com/player/v1/7413048848903326982?autoplay=1&loop=1&rel=0',
+    },
     undefined,
   ]
 

--- a/src/lib/link-meta/link-meta.ts
+++ b/src/lib/link-meta/link-meta.ts
@@ -53,6 +53,26 @@ export async function getLinkMeta(
       url,
     }
   }
+
+  if (url.includes('vm.tiktok.com')) {
+    try {
+      const tiktokUri = await fetch(`https://www.tiktok.com/oembed?url=${url}`)
+        .then(res => res.json())
+        .then(json => [json.author_url, json.embed_product_id])
+
+      if (tiktokUri) {
+        url = `${tiktokUri[0]}/video/${tiktokUri[1]}`
+        urlp = new URL(url)
+      }
+    } catch (e) {
+      return {
+        error: 'Invalid URL',
+        likelyType: LikelyType.Other,
+        url,
+      }
+    }
+  }
+
   const likelyType = getLikelyType(urlp)
   const meta: LinkMeta = {
     likelyType,

--- a/src/lib/strings/embed-player.ts
+++ b/src/lib/strings/embed-player.ts
@@ -25,6 +25,7 @@ export const embedPlayerSources = [
   'giphy',
   'tenor',
   'flickr',
+  'tiktok',
 ] as const
 
 export type EmbedPlayerSource = (typeof embedPlayerSources)[number]
@@ -45,6 +46,7 @@ export type EmbedPlayerType =
   | 'giphy_gif'
   | 'tenor_gif'
   | 'flickr_album'
+  | 'tiktok_video'
 
 export const externalEmbedLabels: Record<EmbedPlayerSource, string> = {
   youtube: 'YouTube',
@@ -57,6 +59,7 @@ export const externalEmbedLabels: Record<EmbedPlayerSource, string> = {
   appleMusic: 'Apple Music',
   soundcloud: 'SoundCloud',
   flickr: 'Flickr',
+  tiktok: 'Tiktok',
 }
 
 export interface EmbedPlayerParams {
@@ -119,6 +122,18 @@ export function parseEmbedPlayerFromUrl(
         source: isShorts ? 'youtubeShorts' : 'youtube',
         hideDetails: isShorts ? true : undefined,
         playerUri: `${IFRAME_HOST}/iframe/youtube.html?videoId=${videoId}&start=${seek}`,
+      }
+    }
+  }
+
+  //tiktok
+  if (urlp.hostname === 'www.tiktok.com') {
+    const videoId = urlp.pathname.split('/')[3]
+    if (videoId) {
+      return {
+        type: 'tiktok_video',
+        source: 'tiktok',
+        playerUri: `https://www.tiktok.com/player/v1/${videoId}?autoplay=1&loop=1&rel=0`,
       }
     }
   }
@@ -466,6 +481,7 @@ export function getPlayerAspect({
     case 'twitch_video':
     case 'vimeo_video':
       return {aspectRatio: 16 / 9}
+    case 'tiktok_video':
     case 'youtube_short':
       if (SCREEN_HEIGHT < 600) {
         return {aspectRatio: (9 / 16) * 1.75}


### PR DESCRIPTION
## Details

I noticed that Tiktok links had no embed option, and even the link preview card looked very raw, then on a [comment](https://github.com/bluesky-social/social-app/issues/2314#issuecomment-1871070227) on #2314, @haileyok make some points about the Tiktok embeds. While searching a possible solution, I found out that now tiktok offers an embed player, and it was quite simple to add. While at it, I solved an issue with shortened Tiktok links that wouldn't return the page metadata due to an 301 redirect. This commits solves both the short `vm.tiktok.com` link and the embed to allow viewing Tiktok videos on the feed.

## Demo


https://github.com/user-attachments/assets/ee2bec2a-53ff-40e2-abf4-dfd3d8e6d5f5

