### PR TITLE
Split Notifications into "All" & "Mentions" tabs

### DIFF
--- a/src/view/com/notifications/Feed.tsx
+++ b/src/view/com/notifications/Feed.tsx
@@ -77,7 +77,7 @@ export function Feed({
     overridePriorityNotifications,
   })
   const isEmpty = !isFetching && !data?.pages[0]?.items.length
-  const isTransitioning = tab.types !== deferredTab.types
+  const isTransitioning = tab !== deferredTab
 
   const items = React.useMemo(() => {
     if (isTransitioning) return [LOADING_ITEM]

--- a/src/view/com/notifications/Feed.tsx
+++ b/src/view/com/notifications/Feed.tsx
@@ -33,15 +33,10 @@ const EMPTY_FEED_ITEM = {_reactKey: '__empty__'}
 const LOAD_MORE_ERROR_ITEM = {_reactKey: '__load_more_error__'}
 const LOADING_ITEM = {_reactKey: '__loading__'}
 
-type Tab = {
+const tabs: {
   label: string
   types?: NotificationType[]
-}
-
-const tabs: Tab[] = [
-  {label: 'All'},
-  {label: 'Mentions', types: ['reply', 'quote']},
-]
+}[] = [{label: 'All'}, {label: 'Mentions', types: ['reply', 'quote']}]
 
 export function Feed({
   scrollElRef,

--- a/src/view/com/notifications/Feed.tsx
+++ b/src/view/com/notifications/Feed.tsx
@@ -96,14 +96,6 @@ export function Feed({
     return arr
   }, [isFetched, isError, isEmpty, data])
 
-  const filteredItems = React.useMemo(() => {
-    if (!tab.types) {
-      return items
-    }
-
-    return items.filter(item => tab.types?.includes(item.type))
-  }, [items, tab])
-
   const onRefresh = React.useCallback(async () => {
     try {
       setIsPTRing(true)
@@ -167,16 +159,26 @@ export function Feed({
             <NotificationFeedLoadingPlaceholder />
           </View>
         )
+      } else if (!tab.types || tab.types.includes(item.type)) {
+        return (
+          <FeedItem
+            item={item}
+            moderationOpts={moderationOpts!}
+            hideTopBorder={index === 0 && isTabletOrMobile}
+          />
+        )
       }
-      return (
-        <FeedItem
-          item={item}
-          moderationOpts={moderationOpts!}
-          hideTopBorder={index === 0 && isTabletOrMobile}
-        />
-      )
+
+      return null
     },
-    [moderationOpts, isTabletOrMobile, _, onPressRetryLoadMore, pal.border],
+    [
+      moderationOpts,
+      isTabletOrMobile,
+      _,
+      onPressRetryLoadMore,
+      pal.border,
+      tab,
+    ],
   )
 
   const FeedFooter = React.useCallback(
@@ -209,7 +211,7 @@ export function Feed({
       <List
         testID="notifsFeed"
         ref={scrollElRef}
-        data={filteredItems}
+        data={items}
         keyExtractor={item => item._reactKey}
         renderItem={renderItem}
         ListHeaderComponent={ListHeaderComponent}

--- a/src/view/com/notifications/Feed.tsx
+++ b/src/view/com/notifications/Feed.tsx
@@ -61,6 +61,7 @@ export function Feed({
   const moderationOpts = useModerationOpts()
   const {checkUnread} = useUnreadNotificationsApi()
   const [tab, setTab] = React.useState<(typeof tabs)[number]>(tabs[0])
+  const deferredTab = React.useDeferredValue(tab)
 
   const {
     data,
@@ -76,8 +77,11 @@ export function Feed({
     overridePriorityNotifications,
   })
   const isEmpty = !isFetching && !data?.pages[0]?.items.length
+  const isTransitioning = tab.types !== deferredTab.types
 
   const items = React.useMemo(() => {
+    if (isTransitioning) return [LOADING_ITEM]
+
     let arr: any[] = []
     if (isFetched) {
       if (isEmpty) {
@@ -94,7 +98,7 @@ export function Feed({
       arr.push(LOADING_ITEM)
     }
     return arr
-  }, [isFetched, isError, isEmpty, data])
+  }, [isFetched, isError, isEmpty, isTransitioning, data])
 
   const onRefresh = React.useCallback(async () => {
     try {
@@ -159,7 +163,7 @@ export function Feed({
             <NotificationFeedLoadingPlaceholder />
           </View>
         )
-      } else if (!tab.types || tab.types.includes(item.type)) {
+      } else if (!deferredTab.types || deferredTab.types.includes(item.type)) {
         return (
           <FeedItem
             item={item}
@@ -175,9 +179,9 @@ export function Feed({
       moderationOpts,
       isTabletOrMobile,
       _,
+      deferredTab.types,
       onPressRetryLoadMore,
       pal.border,
-      tab,
     ],
   )
 


### PR DESCRIPTION
This PR solves the firehose that is Notifications by adding a filtered _Mentions_ tab, based on my prototype here: 

> https://bksy.app/profile/ericclemmons.com/post/3l7wti3xu7d2f

(I hope this effort doesn't negatively affect https://github.com/bluesky-social/social-app/pull/3612!)

## TODOs

- [x] Client-side tabs for _All_ and _Mentions_ (filtered to `reply` and `quote` types)
- [x] ~Update backend~

  > "you know, if it works decently in your experience, maybe we can give client-side solution a try even though it kinda sucks."
  > – https://bsky.app/profile/danabra.mov/post/3l7y3ssjlfk23
  - [ ] ~Add `NotificationType` filter to backend API~
  - [ ] ~Update `useNotificationFeedQuery` to support `NotificationType` allowlist~
  - [ ] ~Pass `tab.types` to `useNotificationFeedQuery`~


## Demo

| Platform | All Tab			| Mentions Tab			|
|----------|----------------|---------------------------|
| Android  | <img height="420" alt="All" src="https://github.com/user-attachments/assets/3e52c346-3107-4b52-8c1e-d5d164c20d1c">		    | <img height="420" alt="Mentions" src="https://github.com/user-attachments/assets/cece53ec-b66c-48d2-91f5-b98a9a636390">        				|
| iOS      | <img height="420" alt="All" src="https://github.com/user-attachments/assets/acd687f6-c2af-4584-94c9-f76ff8db6b49"> | <img height="420" alt="Mentions" src="https://github.com/user-attachments/assets/6e35a336-81de-4a1c-8bfc-7a2edac7b4da">
| Web      | ![All](https://github.com/user-attachments/assets/ec086950-c9e6-4372-9706-391fab7eff78) | ![Mentions](https://github.com/user-attachments/assets/70e728af-ba45-403c-8847-813e42a9234b)  |
