### PR TITLE
Fix: web modals being closed unintentionally

### DIFF
--- a/src/view/com/modals/Modal.web.tsx
+++ b/src/view/com/modals/Modal.web.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, {useState} from 'react'
 import {StyleSheet, TouchableWithoutFeedback, View} from 'react-native'
 import Animated, {FadeIn, FadeOut} from 'react-native-reanimated'
 
@@ -45,17 +45,29 @@ function Modal({modal}: {modal: ModalIface}) {
   const {closeModal} = useModalControls()
   const pal = usePalette('default')
   const {isMobile} = useWebMediaQueries()
+  const [isMaskPressedIn, setIsMaskPressedIn] = useState(false)
 
   if (!isModalActive) {
     return null
   }
 
   const onPressMask = () => {
+    // make sure onPressIn occurred prior to onPress for the mask
+    if (!isMaskPressedIn) {
+      return
+    }
+    setIsMaskPressedIn(false)
     if (modal.name === 'crop-image') {
       return // dont close on mask presses during crop
     }
     closeModal()
   }
+
+  const onPressInMask = () => {
+    // prevent onPress event from responding to onPressIn that occurred outside the mask
+    setIsMaskPressedIn(true)
+  }
+
   const onInnerPress = () => {
     // TODO: can we use prevent default?
     // do nothing, we just want to stop it from bubbling
@@ -98,7 +110,7 @@ function Modal({modal}: {modal: ModalIface}) {
 
   return (
     // eslint-disable-next-line react-native-a11y/has-valid-accessibility-descriptors
-    <TouchableWithoutFeedback onPressOut={onPressMask}>
+    <TouchableWithoutFeedback onPress={onPressMask} onPressIn={onPressInMask}>
       <Animated.View
         style={styles.mask}
         entering={FadeIn.duration(150)}

--- a/src/view/com/modals/Modal.web.tsx
+++ b/src/view/com/modals/Modal.web.tsx
@@ -98,7 +98,7 @@ function Modal({modal}: {modal: ModalIface}) {
 
   return (
     // eslint-disable-next-line react-native-a11y/has-valid-accessibility-descriptors
-    <TouchableWithoutFeedback onPressIn={onPressMask}>
+    <TouchableWithoutFeedback onPressOut={onPressMask}>
       <Animated.View
         style={styles.mask}
         entering={FadeIn.duration(150)}

--- a/src/view/com/modals/Modal.web.tsx
+++ b/src/view/com/modals/Modal.web.tsx
@@ -98,7 +98,7 @@ function Modal({modal}: {modal: ModalIface}) {
 
   return (
     // eslint-disable-next-line react-native-a11y/has-valid-accessibility-descriptors
-    <TouchableWithoutFeedback onPress={onPressMask}>
+    <TouchableWithoutFeedback onPressIn={onPressMask}>
       <Animated.View
         style={styles.mask}
         entering={FadeIn.duration(150)}


### PR DESCRIPTION
… close #6096 and close #6040 

- Description of the issue
The reproduction steps and details are well described in the linked issue. In addition to that, this issue is not specific to the custom domain modal but all modals on the web.

- Root cause explained
The [backdrop](https://github.com/khuddite/social-app/blob/ac9d910e1e77c559eff8b32cd8412335f41074f1/src/view/com/modals/Modal.web.tsx#L101) component is listening to `onPress` event and closes out the modal when it happens. 
But as described [here](https://reactnative.dev/docs/pressable), `onPress` event occurs after `onPressOut` event, which means it will occur whenever the mouse is pressed out on the `Pressable` component. 
And that's exactly what's happening in the current implementation. When you press the mouse inside the modal and drag it out to the backdrop component (`TouchableWithoutFeedback`), the `onPress` event still occurs thus the modal disappears.

- Changes made in the PR
Replaced `onPress` with `onPressIn` so the modal closes only when the mouse press event happens inside the backdrop (not the modal).

- Screen recording of the updated behavior
https://github.com/user-attachments/assets/df9bade5-fb0d-4027-a7ed-f3312f38d1ee


