### PR TITLE
Add follower/following count to profile lists

### DIFF
--- a/src/components/Lists.tsx
+++ b/src/components/Lists.tsx
@@ -112,9 +112,11 @@ function ListFooterMaybeError({
 export function ListHeaderDesktop({
   title,
   subtitle,
+  detail,
 }: {
   title: string
   subtitle?: string
+  detail?: React.ReactNode
 }) {
   const {gtTablet} = useBreakpoints()
   const t = useTheme()
@@ -131,7 +133,10 @@ export function ListHeaderDesktop({
         a.justify_center,
         {minHeight: 50},
       ]}>
-      <Text style={[a.text_2xl, a.font_bold]}>{title}</Text>
+      <View style={[a.flex_row, a.align_center, a.gap_md]}>
+        <Text style={[a.text_2xl, a.font_bold]}>{title}</Text>
+        {detail}
+      </View>
       {subtitle ? (
         <Text style={[a.text_md, t.atoms.text_contrast_medium]}>
           {subtitle}

--- a/src/view/com/profile/ProfileCount.tsx
+++ b/src/view/com/profile/ProfileCount.tsx
@@ -1,0 +1,56 @@
+import React from 'react'
+import {useLingui} from '@lingui/react'
+
+import {useResolveDidQuery} from '#/state/queries/resolve-uri'
+import {atoms as a, useTheme} from '#/alf'
+import {Text} from '#/components/Typography'
+import {useProfileQuery} from '../../../state/queries/profile'
+import {formatCount} from '../util/numeric/format'
+
+export function ProfileCount({
+  name,
+  metric,
+}: {
+  name: string
+  metric: 'followersCount' | 'followsCount'
+}) {
+  const t = useTheme()
+  const {
+    data: resolvedDid,
+    isLoading: isDidLoading,
+    error: resolveError,
+  } = useResolveDidQuery(name)
+  const {
+    data: profile,
+    error: profileError,
+    isLoading: isLoadingProfile,
+  } = useProfileQuery({
+    did: resolvedDid,
+  })
+
+  const {i18n} = useLingui()
+
+  if (
+    isDidLoading ||
+    isLoadingProfile ||
+    profileError ||
+    resolveError ||
+    !profile
+  ) {
+    return null
+  }
+
+  return (
+    <Text
+      style={[
+        a.text_sm,
+        a.font_bold,
+        a.rounded_md,
+        t.atoms.bg_contrast_100,
+        a.px_sm,
+        a.py_xs,
+      ]}>
+      {formatCount(i18n, profile[metric] || 0, 'standard')}
+    </Text>
+  )
+}

--- a/src/view/com/util/ViewHeader.tsx
+++ b/src/view/com/util/ViewHeader.tsx
@@ -11,7 +11,7 @@ import {usePalette} from '#/lib/hooks/usePalette'
 import {useWebMediaQueries} from '#/lib/hooks/useWebMediaQueries'
 import {NavigationProp} from '#/lib/routes/types'
 import {useSetDrawerOpen} from '#/state/shell'
-import {useTheme} from '#/alf'
+import {atoms as a, useTheme} from '#/alf'
 import {Menu_Stroke2_Corner0_Rounded as Menu} from '#/components/icons/Menu'
 import {Text} from './text/Text'
 import {CenteredView} from './Views'
@@ -21,6 +21,7 @@ const BACK_HITSLOP = {left: 20, top: 20, right: 50, bottom: 20}
 export function ViewHeader({
   title,
   subtitle,
+  detail,
   canGoBack,
   showBackButton = true,
   hideOnScroll,
@@ -30,6 +31,7 @@ export function ViewHeader({
 }: {
   title: string
   subtitle?: string
+  detail?: React.ReactNode
   canGoBack?: boolean
   showBackButton?: boolean
   hideOnScroll?: boolean
@@ -99,10 +101,18 @@ export function ViewHeader({
                 ) : null}
               </TouchableOpacity>
             ) : null}
-            <View style={styles.titleContainer} pointerEvents="none">
+            <View
+              style={[
+                styles.titleContainer,
+                a.flex_row,
+                a.align_center,
+                a.gap_sm,
+              ]}
+              pointerEvents="none">
               <Text emoji type="title" style={[pal.text, styles.title]}>
                 {title}
               </Text>
+              {detail}
             </View>
             {renderButton ? (
               renderButton()

--- a/src/view/com/util/numeric/format.ts
+++ b/src/view/com/util/numeric/format.ts
@@ -1,8 +1,12 @@
 import type {I18n} from '@lingui/core'
 
-export const formatCount = (i18n: I18n, num: number) => {
+export const formatCount = (
+  i18n: I18n,
+  num: number,
+  notation: Intl.NumberFormatOptions['notation'] = 'compact',
+): string => {
   return i18n.number(num, {
-    notation: 'compact',
+    notation,
     maximumFractionDigits: 1,
     // `1,953` shouldn't be rounded up to 2k, it should be truncated.
     // @ts-expect-error: `roundingMode` doesn't seem to be in the typings yet

--- a/src/view/screens/ProfileFollowers.tsx
+++ b/src/view/screens/ProfileFollowers.tsx
@@ -11,6 +11,7 @@ import {ViewHeader} from '#/view/com/util/ViewHeader'
 import {CenteredView} from '#/view/com/util/Views'
 import * as Layout from '#/components/Layout'
 import {ListHeaderDesktop} from '#/components/Lists'
+import {ProfileCount} from '../com/profile/ProfileCount'
 
 type Props = NativeStackScreenProps<CommonNavigatorParams, 'ProfileFollowers'>
 export const ProfileFollowersScreen = ({route}: Props) => {
@@ -27,8 +28,15 @@ export const ProfileFollowersScreen = ({route}: Props) => {
   return (
     <Layout.Screen testID="profileFollowersScreen">
       <CenteredView sideBorders={true}>
-        <ListHeaderDesktop title={_(msg`Followers`)} />
-        <ViewHeader title={_(msg`Followers`)} showBorder={!isWeb} />
+        <ListHeaderDesktop
+          title={_(msg`Followers`)}
+          detail={<ProfileCount name={name} metric="followersCount" />}
+        />
+        <ViewHeader
+          title={_(msg`Followers`)}
+          detail={<ProfileCount name={name} metric="followersCount" />}
+          showBorder={!isWeb}
+        />
         <ProfileFollowersComponent name={name} />
       </CenteredView>
     </Layout.Screen>

--- a/src/view/screens/ProfileFollows.tsx
+++ b/src/view/screens/ProfileFollows.tsx
@@ -11,6 +11,7 @@ import {ViewHeader} from '#/view/com/util/ViewHeader'
 import {CenteredView} from '#/view/com/util/Views'
 import * as Layout from '#/components/Layout'
 import {ListHeaderDesktop} from '#/components/Lists'
+import {ProfileCount} from '../com/profile/ProfileCount'
 
 type Props = NativeStackScreenProps<CommonNavigatorParams, 'ProfileFollows'>
 export const ProfileFollowsScreen = ({route}: Props) => {
@@ -27,8 +28,15 @@ export const ProfileFollowsScreen = ({route}: Props) => {
   return (
     <Layout.Screen testID="profileFollowsScreen">
       <CenteredView sideBorders={true}>
-        <ListHeaderDesktop title={_(msg`Following`)} />
-        <ViewHeader title={_(msg`Following`)} showBorder={!isWeb} />
+        <ListHeaderDesktop
+          title={_(msg`Following`)}
+          detail={<ProfileCount name={name} metric="followsCount" />}
+        />
+        <ViewHeader
+          title={_(msg`Following`)}
+          detail={<ProfileCount name={name} metric="followsCount" />}
+          showBorder={!isWeb}
+        />
         <ProfileFollowsComponent name={name} />
       </CenteredView>
     </Layout.Screen>


### PR DESCRIPTION
There wasn't an easy way to see this info in app. I also noticed some people were making services just to see this info. It probably makes sense to just show the full count on this page

Mobile

![CleanShot 2024-11-03 at 20 49 58@2x](https://github.com/user-attachments/assets/a1c155ad-5451-4c25-a569-df4b91b709ba)

Desktop

![CleanShot 2024-11-03 at 20 50 03@2x](https://github.com/user-attachments/assets/09fa7877-3edc-4095-b793-4bc6bc31be6f)
