### PR TITLE
Hide 'Follows You' pill on own Followers page

### DIFF
--- a/src/view/com/profile/ProfileCard.tsx
+++ b/src/view/com/profile/ProfileCard.tsx
@@ -39,6 +39,7 @@ export function ProfileCard({
   onPress,
   style,
   showKnownFollowers,
+  hideFollowedBy,
 }: {
   testID?: string
   profile: AppBskyActorDefs.ProfileViewBasic
@@ -51,6 +52,7 @@ export function ProfileCard({
   onPress?: () => void
   style?: StyleProp<ViewStyle>
   showKnownFollowers?: boolean
+  hideFollowedBy?: boolean
 }) {
   const queryClient = useQueryClient()
   const pal = usePalette('default')
@@ -117,7 +119,7 @@ export function ProfileCard({
             {sanitizeHandle(profile.handle, '@')}
           </Text>
           <ProfileCardPills
-            followedBy={!!profile.viewer?.followedBy}
+            followedBy={!hideFollowedBy && !!profile.viewer?.followedBy}
             moderation={moderation}
           />
           {!!profile.viewer?.followedBy && <View style={s.flexRow} />}
@@ -186,6 +188,7 @@ export function ProfileCardWithFollowBtn({
   onPress,
   logContext = 'ProfileCard',
   showKnownFollowers,
+  hideFollowedBy,
 }: {
   profile: AppBskyActorDefs.ProfileView
   noBg?: boolean
@@ -193,6 +196,7 @@ export function ProfileCardWithFollowBtn({
   onPress?: () => void
   logContext?: 'ProfileCard' | 'StarterPackProfilesList'
   showKnownFollowers?: boolean
+  hideFollowedBy?: boolean
 }) {
   const {currentAccount} = useSession()
   const isMe = profile.did === currentAccount?.did
@@ -211,6 +215,7 @@ export function ProfileCardWithFollowBtn({
       }
       onPress={onPress}
       showKnownFollowers={!isMe && showKnownFollowers}
+      hideFollowedBy={hideFollowedBy}
     />
   )
 }

--- a/src/view/com/profile/ProfileFollowers.tsx
+++ b/src/view/com/profile/ProfileFollowers.tsx
@@ -14,18 +14,22 @@ import {ListFooter, ListMaybePlaceholder} from '#/components/Lists'
 import {List} from '../util/List'
 import {ProfileCardWithFollowBtn} from './ProfileCard'
 
-function renderItem({
-  item,
-  index,
-}: {
-  item: ActorDefs.ProfileViewBasic
-  index: number
-}) {
+function renderItem(
+  {
+    item,
+    index,
+  }: {
+    item: ActorDefs.ProfileViewBasic
+    index: number
+  },
+  hideFollowedBy: boolean,
+) {
   return (
     <ProfileCardWithFollowBtn
       key={item.did}
       profile={item}
       noBorder={index === 0 && !isWeb}
+      hideFollowedBy={hideFollowedBy}
     />
   )
 }
@@ -105,7 +109,7 @@ export function ProfileFollowers({name}: {name: string}) {
   return (
     <List
       data={followers}
-      renderItem={renderItem}
+      renderItem={info => renderItem(info, isMe)}
       keyExtractor={keyExtractor}
       refreshing={isPTRing}
       onRefresh={onRefresh}


### PR DESCRIPTION
When looking at your own followers page, every account listed has the "Follows You" pill:

![image](https://github.com/user-attachments/assets/535f5107-0b28-4c9b-bb08-e9ec0acd8179)

That seems a little redundant; after all, I am looking at my own followers page. Of course they all follow me...

This PR hides that pill when viewing your own page, like:

![image](https://github.com/user-attachments/assets/a9739f8e-60ec-4cd3-9c22-fc31d404fbb8)

I will note that I really thought Twitter did this, and then I looked and it didn't. So, maybe this is a silly idea. Happy to close; it was fun to hack on the app locally! :smile: 

Also, have never worked with react-native, so wasn't sure how I was supposed to pass additional data down to `renderItem`, so just added a param instead of making each item be an object or something.