### PR TITLE
Fix notification time spacing

### DIFF
--- a/src/view/com/notifications/FeedItem.tsx
+++ b/src/view/com/notifications/FeedItem.tsx
@@ -451,8 +451,9 @@ let FeedItem = ({
             <TimeElapsed timestamp={item.notification.indexedAt}>
               {({timeElapsed}) => (
                 <>
-                  <Text style={[a.ml_xs, pal.textLight]}>&middot;</Text>
-                  <Text style={[a.ml_xs, pal.textLight]} title={niceTimestamp}>
+                  {/* make sure there's whitespace around the middot -sfn */}
+                  <Text style={[pal.textLight]}> &middot; </Text>
+                  <Text style={[pal.textLight]} title={niceTimestamp}>
                     {timeElapsed}
                   </Text>
                 </>


### PR DESCRIPTION
#5550 switched the spacing around the middot from whitespace characters to margins. Unfortunately this does not work, I'm unsure why - but it would definitely not work with text scaling, so probably best not to use it even if it did work.

This reverts it to just use whitespace again