### PR TITLE
Translate sort replies

### DIFF
--- a/src/screens/Settings/ThreadPreferences.tsx
+++ b/src/screens/Settings/ThreadPreferences.tsx
@@ -44,7 +44,9 @@ export function ThreadPreferencesScreen({}: Props) {
         <SettingsList.Container>
           <SettingsList.Group>
             <SettingsList.ItemIcon icon={BubblesIcon} />
-            <SettingsList.ItemText>Sort replies</SettingsList.ItemText>
+            <SettingsList.ItemText>
+              <Trans>Sort replies</Trans>
+            </SettingsList.ItemText>
             <View style={[a.w_full, a.gap_md]}>
               <Text style={[a.flex_1, t.atoms.text_contrast_medium]}>
                 <Trans>Sort replies to the same post by:</Trans>


### PR DESCRIPTION
#6051, except using `<Trans>` instead of `_(msg``)`