### PR TITLE
StarterPack: fix "Follow All" processing layout

### DIFF
--- a/src/screens/StarterPack/StarterPackScreen.tsx
+++ b/src/screens/StarterPack/StarterPackScreen.tsx
@@ -429,11 +429,12 @@ function Header({
                 color="primary"
                 size="small"
                 disabled={isProcessing}
-                onPress={onFollowAll}>
+                onPress={onFollowAll}
+                style={[a.flex_row, a.gap_xs, a.align_center]}>
                 <ButtonText>
                   <Trans>Follow all</Trans>
-                  {isProcessing && <Loader size="xs" />}
                 </ButtonText>
+                {isProcessing && <Loader size="xs" />}
               </Button>
             )}
             <OverflowMenu


### PR DESCRIPTION
# Why

Spotted a minor layout misalignment, when processing "Follow All" action on the Starter Pack screen.

https://github.com/user-attachments/assets/d98bb3ae-3d30-4a73-a4f3-f533b58895e6

# How

Move activity indicator out of Text node, apply simple layout to the Button container.

# Preview

https://github.com/user-attachments/assets/32568f01-ca72-43da-91b3-7511783809f1

https://github.com/user-attachments/assets/f2abf704-41fb-4395-a98f-d2fe2f1fc119


