### PR TITLE
Fix hover card flickering open and close on Notifications page with small viewport

### DIFF
--- a/src/components/ProfileHoverCard/index.web.tsx
+++ b/src/components/ProfileHoverCard/index.web.tsx
@@ -277,18 +277,45 @@ export function ProfileHoverCardInner(props: ProfileHoverCardProps) {
     }
   }, [prefetchIfNeeded])
 
-  const onPointerLeaveTarget = React.useCallback(() => {
-    didFireHover.current = false
-    dispatch('unhovered-target')
-  }, [])
+  const onPointerLeaveTarget = React.useCallback(
+    (event: any) => {
+      const relatedTarget = event.nativeEvent.relatedTarget as Node | null
+      if (!relatedTarget) {
+        didFireHover.current = false
+        dispatch('unhovered-target')
+        return
+      }
+      const floating = refs.floating.current as any
+      // @ts-ignore
+      if (floating?.contains && floating.contains(relatedTarget)) {
+        return
+      }
+      didFireHover.current = false
+      dispatch('unhovered-target')
+    },
+    [refs.floating],
+  )
 
   const onPointerEnterCard = React.useCallback(() => {
     dispatch('hovered-card')
   }, [])
 
-  const onPointerLeaveCard = React.useCallback(() => {
-    dispatch('unhovered-card')
-  }, [])
+  const onPointerLeaveCard = React.useCallback(
+    (event: any) => {
+      const relatedTarget = event.nativeEvent.relatedTarget as Node | null
+      if (!relatedTarget) {
+        dispatch('unhovered-card')
+        return
+      }
+      const reference = refs.reference.current as any
+      // @ts-ignore
+      if (reference?.contains && reference.contains(relatedTarget)) {
+        return
+      }
+      dispatch('unhovered-card')
+    },
+    [refs.reference],
+  )
 
   const onPress = React.useCallback(() => {
     dispatch('pressed')


### PR DESCRIPTION
**Issue:** #6067 

**Summary:** On Notifications page when viewport is small/mobile and hovering over the avatar, the ProfileHoverCard pops up then closes instantly for some avatars.

**Solution:** Prevent the hover card from disappearing when moving the pointer between the avatar and the hover card by checking if the pointer’s destination is within either element. Avoid unnecessary transitions when the pointer hovers over the related elements.

**Before:**

https://github.com/user-attachments/assets/f79bfbb9-a2c7-4f33-9bfa-fc410696f38b

**After:**

https://github.com/user-attachments/assets/865ba72f-1a26-4f69-b52f-1a717c7c932e
