### PR TITLE
Use megabytes rather than mebibytes for video limit

### DIFF
--- a/src/lib/media/video/compress.web.ts
+++ b/src/lib/media/video/compress.web.ts
@@ -3,7 +3,7 @@ import {ImagePickerAsset} from 'expo-image-picker'
 import {VideoTooLargeError} from '#/lib/media/video/errors'
 import {CompressedVideo} from './types'
 
-const MAX_VIDEO_SIZE = 1024 * 1024 * 50 // 50mb
+const MAX_VIDEO_SIZE = 1000 * 1000 * 50 // 50mb
 
 // doesn't actually compress, converts to ArrayBuffer
 export async function compressVideo(


### PR DESCRIPTION
Backend uses 50 megabytes (1000 * 1000 * 50) but frontend was using 50 mebibytes (1024 * 1024 * 50)