### PR TITLE
Fix thin red circle around Like button on iOS

### DIFF
--- a/src/lib/custom-animations/CountWheel.tsx
+++ b/src/lib/custom-animations/CountWheel.tsx
@@ -91,15 +91,15 @@ export function CountWheel({
   likeCount,
   big,
   isLiked,
-  isToggle,
+  hasBeenToggled,
 }: {
   likeCount: number
   big?: boolean
   isLiked: boolean
-  isToggle: boolean
+  hasBeenToggled: boolean
 }) {
   const t = useTheme()
-  const shouldAnimate = !useReducedMotion() && isToggle
+  const shouldAnimate = !useReducedMotion() && hasBeenToggled
   const shouldRoll = decideShouldRoll(isLiked, likeCount)
 
   // Incrementing the key will cause the `Animated.View` to re-render, with the newly selected entering/exiting

--- a/src/lib/custom-animations/LikeIcon.tsx
+++ b/src/lib/custom-animations/LikeIcon.tsx
@@ -71,15 +71,15 @@ const circle2Keyframe = new Keyframe({
 export function AnimatedLikeIcon({
   isLiked,
   big,
-  isToggle,
+  hasBeenToggled,
 }: {
   isLiked: boolean
   big?: boolean
-  isToggle: boolean
+  hasBeenToggled: boolean
 }) {
   const t = useTheme()
   const size = big ? 22 : 18
-  const shouldAnimate = !useReducedMotion() && isToggle
+  const shouldAnimate = !useReducedMotion() && hasBeenToggled
 
   return (
     <View>

--- a/src/lib/custom-animations/LikeIcon.tsx
+++ b/src/lib/custom-animations/LikeIcon.tsx
@@ -95,12 +95,10 @@ export function AnimatedLikeIcon({
             width={size}
           />
         )}
-        {isLiked ? (
+        {isLiked && shouldAnimate ? (
           <>
             <Animated.View
-              entering={
-                shouldAnimate ? circle1Keyframe.duration(300) : undefined
-              }
+              entering={circle1Keyframe.duration(300)}
               style={{
                 position: 'absolute',
                 backgroundColor: s.likeColor.color,
@@ -114,9 +112,7 @@ export function AnimatedLikeIcon({
               }}
             />
             <Animated.View
-              entering={
-                shouldAnimate ? circle2Keyframe.duration(300) : undefined
-              }
+              entering={circle2Keyframe.duration(300)}
               style={{
                 position: 'absolute',
                 backgroundColor: t.atoms.bg.backgroundColor,

--- a/src/view/com/util/post-ctrls/PostCtrls.tsx
+++ b/src/view/com/util/post-ctrls/PostCtrls.tsx
@@ -107,7 +107,8 @@ let PostCtrls = ({
     [t],
   ) as StyleProp<ViewStyle>
 
-  const [isToggleLikeIcon, setIsToggleLikeIcon] = React.useState(false)
+  const [hasLikeIconBeenToggled, setHasLikeIconBeenToggled] =
+    React.useState(false)
 
   const onPressToggleLike = React.useCallback(async () => {
     if (isBlocked) {
@@ -119,7 +120,7 @@ let PostCtrls = ({
     }
 
     try {
-      setIsToggleLikeIcon(true)
+      setHasLikeIconBeenToggled(true)
       if (!post.viewer?.like) {
         playHaptic('Light')
         sendInteraction({
@@ -311,13 +312,13 @@ let PostCtrls = ({
           <AnimatedLikeIcon
             isLiked={Boolean(post.viewer?.like)}
             big={big}
-            isToggle={isToggleLikeIcon}
+            hasBeenToggled={hasLikeIconBeenToggled}
           />
           <CountWheel
             likeCount={post.likeCount ?? 0}
             big={big}
             isLiked={Boolean(post.viewer?.like)}
-            isToggle={isToggleLikeIcon}
+            isToggle={hasLikeIconBeenToggled}
           />
         </Pressable>
       </View>

--- a/src/view/com/util/post-ctrls/PostCtrls.tsx
+++ b/src/view/com/util/post-ctrls/PostCtrls.tsx
@@ -318,7 +318,7 @@ let PostCtrls = ({
             likeCount={post.likeCount ?? 0}
             big={big}
             isLiked={Boolean(post.viewer?.like)}
-            isToggle={hasLikeIconBeenToggled}
+            hasBeenToggled={hasLikeIconBeenToggled}
           />
         </Pressable>
       </View>


### PR DESCRIPTION
Fixes #6118 

Summary: We display an animation when the post is liked on the Post screen around `Like` button. However, when the post is already liked, we still display the animation UI with 0 opacity without an animation. That seems problematic on iOS because there is a noticeable thin red circle displayed even though its opacity is set to zero. I think it has something to do with how iOS handles UI rendering or how `react-native-reanimated` library handles keyframes.

Solution: The animation is completely removed from DOM tree when unnecessary. When necessary, it gets mounted and displays the animation as usual. It results in the reported issue being fixed while not impacting the current animation implementation.

Updated behavior:

https://github.com/user-attachments/assets/e32b4aa1-ea36-4b2f-999b-c0bf9e0759d3

