### PR TITLE
Remove SCREEN from lightbox layout

### DIFF
--- a/src/state/lightbox.tsx
+++ b/src/state/lightbox.tsx
@@ -5,7 +5,7 @@ import {nanoid} from 'nanoid/non-secure'
 import {useNonReactiveCallback} from '#/lib/hooks/useNonReactiveCallback'
 import {ImageSource} from '#/view/com/lightbox/ImageViewing/@types'
 
-type Lightbox = {
+export type Lightbox = {
   id: string
   images: ImageSource[]
   thumbDims: MeasuredDimensions | null

--- a/src/state/lightbox.tsx
+++ b/src/state/lightbox.tsx
@@ -1,10 +1,12 @@
 import React from 'react'
 import type {MeasuredDimensions} from 'react-native-reanimated'
+import {nanoid} from 'nanoid/non-secure'
 
 import {useNonReactiveCallback} from '#/lib/hooks/useNonReactiveCallback'
 import {ImageSource} from '#/view/com/lightbox/ImageViewing/@types'
 
 type Lightbox = {
+  id: string
   images: ImageSource[]
   thumbDims: MeasuredDimensions | null
   index: number
@@ -17,7 +19,7 @@ const LightboxContext = React.createContext<{
 })
 
 const LightboxControlContext = React.createContext<{
-  openLightbox: (lightbox: Lightbox) => void
+  openLightbox: (lightbox: Omit<Lightbox, 'id'>) => void
   closeLightbox: () => boolean
 }>({
   openLightbox: () => {},
@@ -29,9 +31,11 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
     null,
   )
 
-  const openLightbox = useNonReactiveCallback((lightbox: Lightbox) => {
-    setActiveLightbox(lightbox)
-  })
+  const openLightbox = useNonReactiveCallback(
+    (lightbox: Omit<Lightbox, 'id'>) => {
+      setActiveLightbox({...lightbox, id: nanoid()})
+    },
+  )
 
   const closeLightbox = useNonReactiveCallback(() => {
     let wasActive = !!activeLightbox

--- a/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.android.tsx
+++ b/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.android.tsx
@@ -1,5 +1,5 @@
 import React, {useState} from 'react'
-import {ActivityIndicator, Dimensions, StyleSheet, View} from 'react-native'
+import {ActivityIndicator, StyleSheet, View} from 'react-native'
 import {Gesture, GestureDetector} from 'react-native-gesture-handler'
 import Animated, {
   AnimatedRef,
@@ -26,13 +26,6 @@ import {
   TransformMatrix,
 } from '../../transforms'
 
-const windowDim = Dimensions.get('window')
-const screenDim = Dimensions.get('screen')
-const statusBarHeight = windowDim.height - screenDim.height
-const SCREEN = {
-  width: windowDim.width,
-  height: windowDim.height + statusBarHeight,
-}
 const MIN_DOUBLE_TAP_SCALE = 2
 const MAX_ORIGINAL_IMAGE_ZOOM = 2
 
@@ -368,8 +361,7 @@ const ImageItem = ({
 
 const styles = StyleSheet.create({
   container: {
-    width: SCREEN.width,
-    height: SCREEN.height,
+    height: '100%',
     overflow: 'hidden',
   },
   image: {

--- a/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.android.tsx
+++ b/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.android.tsx
@@ -1,7 +1,8 @@
 import React, {useState} from 'react'
-import {ActivityIndicator, Dimensions, StyleSheet} from 'react-native'
+import {ActivityIndicator, Dimensions, StyleSheet, View} from 'react-native'
 import {Gesture, GestureDetector} from 'react-native-gesture-handler'
 import Animated, {
+  AnimatedRef,
   runOnJS,
   useAnimatedReaction,
   useAnimatedRef,
@@ -43,6 +44,7 @@ type Props = {
   onZoom: (isZoomed: boolean) => void
   isScrollViewBeingDragged: boolean
   showControls: boolean
+  safeAreaRef: AnimatedRef<View>
 }
 const ImageItem = ({
   imageSrc,

--- a/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.ios.tsx
+++ b/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.ios.tsx
@@ -7,9 +7,10 @@
  */
 
 import React, {useState} from 'react'
-import {ActivityIndicator, Dimensions, StyleSheet} from 'react-native'
+import {ActivityIndicator, Dimensions, StyleSheet, View} from 'react-native'
 import {Gesture, GestureDetector} from 'react-native-gesture-handler'
 import Animated, {
+  AnimatedRef,
   interpolate,
   runOnJS,
   useAnimatedRef,
@@ -35,6 +36,7 @@ type Props = {
   onZoom: (scaled: boolean) => void
   isScrollViewBeingDragged: boolean
   showControls: boolean
+  safeAreaRef: AnimatedRef<View>
 }
 
 const ImageItem = ({

--- a/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.ios.tsx
+++ b/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.ios.tsx
@@ -7,7 +7,7 @@
  */
 
 import React, {useState} from 'react'
-import {ActivityIndicator, Dimensions, StyleSheet, View} from 'react-native'
+import {ActivityIndicator, StyleSheet, View} from 'react-native'
 import {Gesture, GestureDetector} from 'react-native-gesture-handler'
 import Animated, {
   AnimatedRef,
@@ -27,7 +27,6 @@ import {ImageSource} from '../../@types'
 
 const SWIPE_CLOSE_OFFSET = 75
 const SWIPE_CLOSE_VELOCITY = 1
-const SCREEN = Dimensions.get('screen')
 const MAX_ORIGINAL_IMAGE_ZOOM = 2
 const MIN_DOUBLE_TAP_SCALE = 2
 
@@ -150,13 +149,19 @@ const ImageItem = ({
       <Animated.ScrollView
         // @ts-ignore Something's up with the types here
         ref={scrollViewRef}
-        style={styles.listItem}
         pinchGestureEnabled
         showsHorizontalScrollIndicator={false}
         showsVerticalScrollIndicator={false}
         maximumZoomScale={maxZoomScale}
         onScroll={scrollHandler}>
-        <Animated.View style={[styles.imageScrollContainer, animatedStyle]}>
+        <Animated.View
+          style={[
+            {
+              // TODO: See if we can rely on native layout.
+              height: screenSizeDelayedForJSThreadOnly.height,
+            },
+            animatedStyle,
+          ]}>
           <ActivityIndicator size="small" color="#FFF" style={styles.loading} />
           <Image
             contentFit="contain"
@@ -176,23 +181,15 @@ const ImageItem = ({
 }
 
 const styles = StyleSheet.create({
-  imageScrollContainer: {
-    height: SCREEN.height,
-  },
-  listItem: {
-    width: SCREEN.width,
-    height: SCREEN.height,
-  },
-  image: {
-    width: SCREEN.width,
-    height: SCREEN.height,
-  },
   loading: {
     position: 'absolute',
     top: 0,
     left: 0,
     right: 0,
     bottom: 0,
+  },
+  image: {
+    flex: 1,
   },
 })
 

--- a/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.ios.tsx
+++ b/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.ios.tsx
@@ -63,6 +63,7 @@ const ImageItem = ({
 
   const animatedStyle = useAnimatedStyle(() => {
     return {
+      flex: 1,
       opacity: interpolate(
         translationY.value,
         [-SWIPE_CLOSE_OFFSET, 0, SWIPE_CLOSE_OFFSET],
@@ -153,15 +154,9 @@ const ImageItem = ({
         showsHorizontalScrollIndicator={false}
         showsVerticalScrollIndicator={false}
         maximumZoomScale={maxZoomScale}
-        onScroll={scrollHandler}>
-        <Animated.View
-          style={[
-            {
-              // TODO: See if we can rely on native layout.
-              height: screenSizeDelayedForJSThreadOnly.height,
-            },
-            animatedStyle,
-          ]}>
+        onScroll={scrollHandler}
+        contentContainerStyle={styles.scrollContainer}>
+        <Animated.View style={animatedStyle}>
           <ActivityIndicator size="small" color="#FFF" style={styles.loading} />
           <Image
             contentFit="contain"
@@ -187,6 +182,9 @@ const styles = StyleSheet.create({
     left: 0,
     right: 0,
     bottom: 0,
+  },
+  scrollContainer: {
+    flex: 1,
   },
   image: {
     flex: 1,

--- a/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.ios.tsx
+++ b/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.ios.tsx
@@ -12,11 +12,13 @@ import {Gesture, GestureDetector} from 'react-native-gesture-handler'
 import Animated, {
   AnimatedRef,
   interpolate,
+  measure,
   runOnJS,
   useAnimatedRef,
   useAnimatedStyle,
   useSharedValue,
 } from 'react-native-reanimated'
+import {useSafeAreaFrame} from 'react-native-safe-area-context'
 import {Image} from 'expo-image'
 
 import {useAnimatedScrollHandler} from '#/lib/hooks/useAnimatedScrollHandler_FIXED'
@@ -45,16 +47,19 @@ const ImageItem = ({
   onZoom,
   onRequestClose,
   showControls,
+  safeAreaRef,
 }: Props) => {
   const scrollViewRef = useAnimatedRef<Animated.ScrollView>()
   const translationY = useSharedValue(0)
   const [scaled, setScaled] = useState(false)
+  const screenSizeDelayedForJSThreadOnly = useSafeAreaFrame()
   const [imageAspect, imageDimensions] = useImageDimensions({
     src: imageSrc.uri,
     knownDimensions: imageSrc.dimensions,
   })
   const maxZoomScale = imageDimensions
-    ? (imageDimensions.width / SCREEN.width) * MAX_ORIGINAL_IMAGE_ZOOM
+    ? (imageDimensions.width / screenSizeDelayedForJSThreadOnly.width) *
+      MAX_ORIGINAL_IMAGE_ZOOM
     : 1
 
   const animatedStyle = useAnimatedStyle(() => {
@@ -92,24 +97,13 @@ const ImageItem = ({
     setScaled(nextIsScaled)
   }
 
-  function handleDoubleTap(absoluteX: number, absoluteY: number) {
+  function zoomTo(nextZoomRect: {
+    x: number
+    y: number
+    width: number
+    height: number
+  }) {
     const scrollResponderRef = scrollViewRef?.current?.getScrollResponder()
-    let nextZoomRect = {
-      x: 0,
-      y: 0,
-      width: SCREEN.width,
-      height: SCREEN.height,
-    }
-
-    const willZoom = !scaled
-    if (willZoom) {
-      nextZoomRect = getZoomRectAfterDoubleTap(
-        imageAspect,
-        absoluteX,
-        absoluteY,
-      )
-    }
-
     // @ts-ignore
     scrollResponderRef?.scrollResponderZoomTo({
       ...nextZoomRect, // This rect is in screen coordinates
@@ -126,8 +120,27 @@ const ImageItem = ({
     .numberOfTaps(2)
     .onEnd(e => {
       'worklet'
+      const screenSize = measure(safeAreaRef)
+      if (!screenSize) {
+        return
+      }
       const {absoluteX, absoluteY} = e
-      runOnJS(handleDoubleTap)(absoluteX, absoluteY)
+      let nextZoomRect = {
+        x: 0,
+        y: 0,
+        width: screenSize.width,
+        height: screenSize.height,
+      }
+      const willZoom = !scaled
+      if (willZoom) {
+        nextZoomRect = getZoomRectAfterDoubleTap(
+          imageAspect,
+          absoluteX,
+          absoluteY,
+          screenSize,
+        )
+      }
+      runOnJS(zoomTo)(nextZoomRect)
     })
 
   const composedGesture = Gesture.Exclusive(doubleTap, singleTap)
@@ -187,24 +200,26 @@ const getZoomRectAfterDoubleTap = (
   imageAspect: number | undefined,
   touchX: number,
   touchY: number,
+  screenSize: {width: number; height: number},
 ): {
   x: number
   y: number
   width: number
   height: number
 } => {
+  'worklet'
   if (!imageAspect) {
     return {
       x: 0,
       y: 0,
-      width: SCREEN.width,
-      height: SCREEN.height,
+      width: screenSize.width,
+      height: screenSize.height,
     }
   }
 
   // First, let's figure out how much we want to zoom in.
   // We want to try to zoom in at least close enough to get rid of black bars.
-  const screenAspect = SCREEN.width / SCREEN.height
+  const screenAspect = screenSize.width / screenSize.height
   const zoom = Math.max(
     imageAspect / screenAspect,
     screenAspect / imageAspect,
@@ -215,25 +230,25 @@ const getZoomRectAfterDoubleTap = (
 
   // Next, we'll be calculating the rectangle to "zoom into" in screen coordinates.
   // We already know the zoom level, so this gives us the rectangle size.
-  let rectWidth = SCREEN.width / zoom
-  let rectHeight = SCREEN.height / zoom
+  let rectWidth = screenSize.width / zoom
+  let rectHeight = screenSize.height / zoom
 
   // Before we settle on the zoomed rect, figure out the safe area it has to be inside.
   // We don't want to introduce new black bars or make existing black bars unbalanced.
   let minX = 0
   let minY = 0
-  let maxX = SCREEN.width - rectWidth
-  let maxY = SCREEN.height - rectHeight
+  let maxX = screenSize.width - rectWidth
+  let maxY = screenSize.height - rectHeight
   if (imageAspect >= screenAspect) {
     // The image has horizontal black bars. Exclude them from the safe area.
-    const renderedHeight = SCREEN.width / imageAspect
-    const horizontalBarHeight = (SCREEN.height - renderedHeight) / 2
+    const renderedHeight = screenSize.width / imageAspect
+    const horizontalBarHeight = (screenSize.height - renderedHeight) / 2
     minY += horizontalBarHeight
     maxY -= horizontalBarHeight
   } else {
     // The image has vertical black bars. Exclude them from the safe area.
-    const renderedWidth = SCREEN.height * imageAspect
-    const verticalBarWidth = (SCREEN.width - renderedWidth) / 2
+    const renderedWidth = screenSize.height * imageAspect
+    const verticalBarWidth = (screenSize.width - renderedWidth) / 2
     minX += verticalBarWidth
     maxX -= verticalBarWidth
   }
@@ -248,7 +263,7 @@ const getZoomRectAfterDoubleTap = (
     rectX = Math.max(rectX, minX)
   } else {
     // Keep the rect centered on the screen so that black bars are balanced.
-    rectX = SCREEN.width / 2 - rectWidth / 2
+    rectX = screenSize.width / 2 - rectWidth / 2
   }
   let rectY
   if (maxY >= minY) {
@@ -259,7 +274,7 @@ const getZoomRectAfterDoubleTap = (
     rectY = Math.max(rectY, minY)
   } else {
     // Keep the rect centered on the screen so that black bars are balanced.
-    rectY = SCREEN.height / 2 - rectHeight / 2
+    rectY = screenSize.height / 2 - rectHeight / 2
   }
 
   return {

--- a/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.tsx
+++ b/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react'
 import {View} from 'react-native'
+import {AnimatedRef} from 'react-native-reanimated'
 
 import {ImageSource} from '../../@types'
 
@@ -12,6 +13,7 @@ type Props = {
   onZoom: (scaled: boolean) => void
   isScrollViewBeingDragged: boolean
   showControls: boolean
+  safeAreaRef: AnimatedRef<View>
 }
 
 const ImageItem = (_props: Props) => {

--- a/src/view/com/lightbox/ImageViewing/index.tsx
+++ b/src/view/com/lightbox/ImageViewing/index.tsx
@@ -34,7 +34,6 @@ import ImageDefaultHeader from './components/ImageDefaultHeader'
 import ImageItem from './components/ImageItem/ImageItem'
 
 const SCREEN_HEIGHT = Dimensions.get('window').height
-const DEFAULT_BG_COLOR = '#000'
 
 export default function ImageViewRoot({
   lightbox,
@@ -64,13 +63,11 @@ export default function ImageViewRoot({
 function ImageView({
   lightbox,
   onRequestClose,
-  backgroundColor = DEFAULT_BG_COLOR,
   onPressSave,
   onPressShare,
 }: {
   lightbox: Lightbox
   onRequestClose: () => void
-  backgroundColor?: string
   onPressSave: (uri: string) => void
   onPressShare: (uri: string) => void
 }) {
@@ -123,7 +120,7 @@ function ImageView({
       edges={edges}
       aria-modal
       accessibilityViewIsModal>
-      <View style={[styles.container, {backgroundColor}]}>
+      <View style={[styles.container]}>
         <Animated.View style={[styles.header, animatedHeaderStyle]}>
           <ImageDefaultHeader onRequestClose={onRequestClose} />
         </Animated.View>

--- a/src/view/com/lightbox/ImageViewing/index.tsx
+++ b/src/view/com/lightbox/ImageViewing/index.tsx
@@ -17,7 +17,12 @@ import {
   View,
 } from 'react-native'
 import PagerView from 'react-native-pager-view'
-import Animated, {useAnimatedStyle, withSpring} from 'react-native-reanimated'
+import Animated, {
+  AnimatedRef,
+  useAnimatedRef,
+  useAnimatedStyle,
+  withSpring,
+} from 'react-native-reanimated'
 import {useSafeAreaInsets} from 'react-native-safe-area-context'
 import {Edge, SafeAreaView} from 'react-native-safe-area-context'
 import {FontAwesomeIcon} from '@fortawesome/react-native-fontawesome'
@@ -32,6 +37,8 @@ import {ScrollView} from '#/view/com/util/Views'
 import {ImageSource} from './@types'
 import ImageDefaultHeader from './components/ImageDefaultHeader'
 import ImageItem from './components/ImageItem/ImageItem'
+
+const AnimatedSafeAreaView = Animated.createAnimatedComponent(SafeAreaView)
 
 const SCREEN_HEIGHT = Dimensions.get('window').height
 const EDGES =
@@ -50,9 +57,11 @@ export default function ImageViewRoot({
   onPressSave: (uri: string) => void
   onPressShare: (uri: string) => void
 }) {
+  const ref = useAnimatedRef<View>()
   return (
     // Keep it always mounted to avoid flicker on the first frame.
-    <SafeAreaView
+    <AnimatedSafeAreaView
+      ref={ref}
       style={[styles.screen, !lightbox && styles.screenHidden]}
       edges={EDGES}
       aria-modal
@@ -65,9 +74,10 @@ export default function ImageViewRoot({
           onRequestClose={onRequestClose}
           onPressSave={onPressSave}
           onPressShare={onPressShare}
+          safeAreaRef={ref}
         />
       )}
-    </SafeAreaView>
+    </AnimatedSafeAreaView>
   )
 }
 
@@ -76,11 +86,13 @@ function ImageView({
   onRequestClose,
   onPressSave,
   onPressShare,
+  safeAreaRef,
 }: {
   lightbox: Lightbox
   onRequestClose: () => void
   onPressSave: (uri: string) => void
   onPressShare: (uri: string) => void
+  safeAreaRef: AnimatedRef<View>
 }) {
   const {images, index: initialImageIndex} = lightbox
   const [isScaled, setIsScaled] = useState(false)
@@ -144,6 +156,7 @@ function ImageView({
               onRequestClose={onRequestClose}
               isScrollViewBeingDragged={isDragging}
               showControls={showControls}
+              safeAreaRef={safeAreaRef}
             />
           </View>
         ))}

--- a/src/view/com/lightbox/ImageViewing/index.tsx
+++ b/src/view/com/lightbox/ImageViewing/index.tsx
@@ -50,22 +50,23 @@ export default function ImageViewRoot({
   onPressSave: (uri: string) => void
   onPressShare: (uri: string) => void
 }) {
-  if (!lightbox) {
-    return null
-  }
   return (
+    // Keep it always mounted to avoid flicker on the first frame.
     <SafeAreaView
-      style={styles.screen}
+      style={[styles.screen, !lightbox && styles.screenHidden]}
       edges={EDGES}
       aria-modal
-      accessibilityViewIsModal>
-      <ImageView
-        key={lightbox.id}
-        lightbox={lightbox}
-        onRequestClose={onRequestClose}
-        onPressSave={onPressSave}
-        onPressShare={onPressShare}
-      />
+      accessibilityViewIsModal
+      aria-hidden={!lightbox}>
+      {lightbox && (
+        <ImageView
+          key={lightbox.id}
+          lightbox={lightbox}
+          onRequestClose={onRequestClose}
+          onPressSave={onPressSave}
+          onPressShare={onPressShare}
+        />
+      )}
     </SafeAreaView>
   )
 }
@@ -247,6 +248,10 @@ const styles = StyleSheet.create({
     left: 0,
     bottom: 0,
     right: 0,
+  },
+  screenHidden: {
+    opacity: 0,
+    pointerEvents: 'none',
   },
   container: {
     flex: 1,

--- a/src/view/com/lightbox/ImageViewing/index.tsx
+++ b/src/view/com/lightbox/ImageViewing/index.tsx
@@ -17,7 +17,6 @@ import {
   View,
 } from 'react-native'
 import PagerView from 'react-native-pager-view'
-import {MeasuredDimensions} from 'react-native-reanimated'
 import Animated, {useAnimatedStyle, withSpring} from 'react-native-reanimated'
 import {useSafeAreaInsets} from 'react-native-safe-area-context'
 import {Edge, SafeAreaView} from 'react-native-safe-area-context'
@@ -26,6 +25,7 @@ import {Trans} from '@lingui/macro'
 
 import {colors, s} from '#/lib/styles'
 import {isIOS} from '#/platform/detection'
+import {Lightbox} from '#/state/lightbox'
 import {Button} from '#/view/com/util/forms/Button'
 import {Text} from '#/view/com/util/text/Text'
 import {ScrollView} from '#/view/com/util/Views'
@@ -33,31 +33,48 @@ import {ImageSource} from './@types'
 import ImageDefaultHeader from './components/ImageDefaultHeader'
 import ImageItem from './components/ImageItem/ImageItem'
 
-type Props = {
-  id: string
-  images: ImageSource[]
-  thumbDims: MeasuredDimensions | null
-  initialImageIndex: number
-  visible: boolean
-  onRequestClose: () => void
-  backgroundColor?: string
-  onPressSave: (uri: string) => void
-  onPressShare: (uri: string) => void
-}
-
 const SCREEN_HEIGHT = Dimensions.get('window').height
 const DEFAULT_BG_COLOR = '#000'
 
-function ImageViewing({
-  images,
-  thumbDims: _thumbDims, // TODO: Pass down and use for animation.
-  initialImageIndex,
-  visible,
+export default function ImageViewRoot({
+  lightbox,
+  onRequestClose,
+  onPressSave,
+  onPressShare,
+}: {
+  lightbox: Lightbox | null
+  onRequestClose: () => void
+  onPressSave: (uri: string) => void
+  onPressShare: (uri: string) => void
+}) {
+  if (!lightbox) {
+    return null
+  }
+  return (
+    <ImageView
+      key={lightbox.id}
+      lightbox={lightbox}
+      onRequestClose={onRequestClose}
+      onPressSave={onPressSave}
+      onPressShare={onPressShare}
+    />
+  )
+}
+
+function ImageView({
+  lightbox,
   onRequestClose,
   backgroundColor = DEFAULT_BG_COLOR,
   onPressSave,
   onPressShare,
-}: Props) {
+}: {
+  lightbox: Lightbox
+  onRequestClose: () => void
+  backgroundColor?: string
+  onPressSave: (uri: string) => void
+  onPressShare: (uri: string) => void
+}) {
+  const {images, index: initialImageIndex} = lightbox
   const [isScaled, setIsScaled] = useState(false)
   const [isDragging, setIsDragging] = useState(false)
   const [imageIndex, setImageIndex] = useState(initialImageIndex)
@@ -99,10 +116,6 @@ function ImageViewing({
     }
     return ['left', 'right'] satisfies Edge[] // iOS, so no top/bottom safe area
   }, [])
-
-  if (!visible) {
-    return null
-  }
 
   return (
     <SafeAreaView
@@ -277,10 +290,6 @@ const styles = StyleSheet.create({
     borderColor: colors.white,
   },
 })
-
-export default function ImageViewingRoot(props: Props) {
-  return <ImageViewing key={props.id} {...props} />
-}
 
 function withClampedSpring(value: any) {
   'worklet'

--- a/src/view/com/lightbox/ImageViewing/index.tsx
+++ b/src/view/com/lightbox/ImageViewing/index.tsx
@@ -38,8 +38,6 @@ import {ImageSource} from './@types'
 import ImageDefaultHeader from './components/ImageDefaultHeader'
 import ImageItem from './components/ImageItem/ImageItem'
 
-const AnimatedSafeAreaView = Animated.createAnimatedComponent(SafeAreaView)
-
 const SCREEN_HEIGHT = Dimensions.get('window').height
 const EDGES =
   Platform.OS === 'android'
@@ -60,24 +58,25 @@ export default function ImageViewRoot({
   const ref = useAnimatedRef<View>()
   return (
     // Keep it always mounted to avoid flicker on the first frame.
-    <AnimatedSafeAreaView
-      ref={ref}
+    <SafeAreaView
       style={[styles.screen, !lightbox && styles.screenHidden]}
       edges={EDGES}
       aria-modal
       accessibilityViewIsModal
       aria-hidden={!lightbox}>
-      {lightbox && (
-        <ImageView
-          key={lightbox.id}
-          lightbox={lightbox}
-          onRequestClose={onRequestClose}
-          onPressSave={onPressSave}
-          onPressShare={onPressShare}
-          safeAreaRef={ref}
-        />
-      )}
-    </AnimatedSafeAreaView>
+      <Animated.View ref={ref} style={{flex: 1}} collapsable={false}>
+        {lightbox && (
+          <ImageView
+            key={lightbox.id}
+            lightbox={lightbox}
+            onRequestClose={onRequestClose}
+            onPressSave={onPressSave}
+            onPressShare={onPressShare}
+            safeAreaRef={ref}
+          />
+        )}
+      </Animated.View>
+    </SafeAreaView>
   )
 }
 

--- a/src/view/com/lightbox/ImageViewing/index.tsx
+++ b/src/view/com/lightbox/ImageViewing/index.tsx
@@ -34,6 +34,7 @@ import ImageDefaultHeader from './components/ImageDefaultHeader'
 import ImageItem from './components/ImageItem/ImageItem'
 
 type Props = {
+  id: string
   images: ImageSource[]
   thumbDims: MeasuredDimensions | null
   initialImageIndex: number
@@ -277,13 +278,11 @@ const styles = StyleSheet.create({
   },
 })
 
-const EnhancedImageViewing = (props: Props) => (
-  <ImageViewing key={props.initialImageIndex} {...props} />
-)
+export default function ImageViewingRoot(props: Props) {
+  return <ImageViewing key={props.id} {...props} />
+}
 
 function withClampedSpring(value: any) {
   'worklet'
   return withSpring(value, {overshootClamping: true, stiffness: 300})
 }
-
-export default EnhancedImageViewing

--- a/src/view/com/lightbox/Lightbox.tsx
+++ b/src/view/com/lightbox/Lightbox.tsx
@@ -49,17 +49,9 @@ export function Lightbox() {
     [permissionResponse, requestPermission, _],
   )
 
-  if (!activeLightbox) {
-    return null
-  }
-
   return (
     <ImageView
-      id={activeLightbox.id}
-      images={activeLightbox.images}
-      initialImageIndex={activeLightbox.index}
-      thumbDims={activeLightbox.thumbDims}
-      visible
+      lightbox={activeLightbox}
       onRequestClose={onClose}
       onPressSave={saveImageToAlbumWithToasts}
       onPressShare={uri => shareImageModal({uri})}

--- a/src/view/com/lightbox/Lightbox.tsx
+++ b/src/view/com/lightbox/Lightbox.tsx
@@ -55,6 +55,7 @@ export function Lightbox() {
 
   return (
     <ImageView
+      id={activeLightbox.id}
       images={activeLightbox.images}
       initialImageIndex={activeLightbox.index}
       thumbDims={activeLightbox.thumbDims}


### PR DESCRIPTION
I want to get rid of these constants. They're subtly wrong in some cases, and it's very hard to think about the discrepancies due to safe insets. I want to change the code so that we rely on `SafeAreaView` and then everything is derived from its size.

I'm not entirely _sure_ this approach is the way to go, but this constant just sucks so I think it's a step forward.

The approach is to use alternatives to hardcoding `SCREEN`:

- On UI thread, use `measure(safeAreaRef)`. This always gives the height matching the area where we draw the image.
  - Curiously this _seems_ fine to do on every frame. So I'm just doing that unless proven wrong.
    - We might have to do something more fancy when adding orientation handling. But still better than before.
- On JS thread, prefer to use `<SafeAreaView>` where possible.
  - This works well when we don't need to know the value in the actual JS code. The `<SafeAreaView>` code is native.
  - When we absolutely *need* to know the value in JS itself, fall back to `useSafeAreaFrame()`.
    - Note it doesn't have the insets applied (which seems fine for the use case where we have it — measuring iOS width). We could always add `useSafeAreaInsets` if needed and subtract whichever ones we need manually.

## Test Plan

This fixes incorrect positioning on Android device when double-tapping into an image. Verify that double-tapping on main shows a black bar beneath, but double-tapping in this branch does not. (This doesn't repro on emulator for me.)

Verify controls (header, footer) work like before. Verify buttons are clickable. With no alt text, short alt text, and very long alt text. Verify very long alt text expands on tap but the scroll view doesn't overlap the header controls. Verify that controls still work and display correctly when invoking them while zoomed in.

Verify you can pan and pinch into the image. <s>Pinching into the image on device produces occasional flicker on Android, but this problem exists on main too. I'll need to look into that separately.</s> (Fixed in #6126)

It would be good to check what happens with super tall images.