### PR TITLE
feat: double tapping search should focus the search bar

### DIFF
--- a/src/view/screens/Search/Search.tsx
+++ b/src/view/screens/Search/Search.tsx
@@ -805,6 +805,7 @@ export function SearchScreen(
     } else {
       setSearchText('')
       navigation.setParams({q: ''})
+      textInput.current?.focus()
     }
   }, [navigation])
 

--- a/src/view/shell/bottom-bar/BottomBar.tsx
+++ b/src/view/shell/bottom-bar/BottomBar.tsx
@@ -121,6 +121,24 @@ export function BottomBar({navigation}: BottomTabBarProps) {
     accountSwitchControl.open()
   }, [accountSwitchControl, playHaptic])
 
+  const onLongPressSearch = React.useCallback(() => {
+    const state = navigation.getState()
+    const tabState = getTabState(state, 'Search')
+    if (tabState === TabState.InsideAtRoot) {
+      emitSoftReset()
+    } else if (tabState === TabState.Inside) {
+      dedupe(() => {
+        navigation.dispatch(StackActions.popToTop())
+        setTimeout(() => emitSoftReset())
+      })
+    } else {
+      dedupe(() => {
+        navigation.navigate('SearchTab')
+        setTimeout(() => emitSoftReset())
+      })
+    }
+  }, [dedupe, navigation])
+
   return (
     <>
       <SwitchAccountDialog control={accountSwitchControl} />
@@ -174,6 +192,7 @@ export function BottomBar({navigation}: BottomTabBarProps) {
                 )
               }
               onPress={onPressSearch}
+              onLongPress={onLongPressSearch}
               accessibilityRole="search"
               accessibilityLabel={_(msg`Search`)}
               accessibilityHint=""


### PR DESCRIPTION
- Adds functionality to focus the search input when user double presses the search icon on the bottom bar
- Also focuses input on long press