### PR TITLE
Lower feedfeedback seen threshold to 0.5s

### DIFF
--- a/src/state/feed-feedback.tsx
+++ b/src/state/feed-feedback.tsx
@@ -72,7 +72,7 @@ export function useFeedFeedback(feed: FeedDescriptor, hasSession: boolean) {
 
   const sendToFeed = React.useMemo(
     () =>
-      throttle(sendToFeedNoDelay, 15e3, {
+      throttle(sendToFeedNoDelay, 10e3, {
         leading: false,
         trailing: true,
       }),

--- a/src/view/com/util/List.tsx
+++ b/src/view/com/util/List.tsx
@@ -110,7 +110,7 @@ function ListImpl<ItemT>(
       },
       {
         itemVisiblePercentThreshold: 40,
-        minimumViewTime: 1.5e3,
+        minimumViewTime: 0.5e3,
       },
     ]
   }, [onItemSeen])

--- a/src/view/com/util/List.web.tsx
+++ b/src/view/com/util/List.web.tsx
@@ -28,7 +28,7 @@ export type ListProps<ItemT> = Omit<
 }
 export type ListRef = React.MutableRefObject<any | null> // TODO: Better types.
 
-const ON_ITEM_SEEN_WAIT_DURATION = 1.5e3 // when we consider post to  be "seen"
+const ON_ITEM_SEEN_WAIT_DURATION = 0.5e3 // when we consider post to  be "seen"
 const ON_ITEM_SEEN_INTERSECTION_OPTS = {
   rootMargin: '-200px 0px -200px 0px',
 } // post must be 200px visible to be "seen"


### PR DESCRIPTION
We have quite enough content now, repetition is a bigger problem. Let's consider an item "seen" if it's onscreen for 0.5s (down from 1.5s). Let's also send stats a bit more often (10s, down from 15s).

## Test Plan

Log `interactions.length` in `sendToFeedNoDelay` on each platform. Verify that a relatively fast-paced casual scroll now registers ~2x items.