### PR TITLE
Set Inter to use ss02 disambiguation styleset

### DIFF
--- a/bskyweb/templates/base.html
+++ b/bskyweb/templates/base.html
@@ -49,6 +49,7 @@
       margin: 0px;
       padding: 0px;
       font-family: InterVariable, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Liberation Sans', Helvetica, Arial, sans-serif;
+      font-feature-settings: 'cv05' on, 'calt' off;
       text-rendering: optimizeLegibility;
       /* Platform-specific reset */
       -webkit-overflow-scrolling: touch;

--- a/src/alf/fonts.ts
+++ b/src/alf/fonts.ts
@@ -80,7 +80,9 @@ export function applyFonts(style: TextStyle, fontFamily: 'system' | 'theme') {
      * Disable contextual alternates in Inter
      * {@link https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant}
      */
-    style.fontVariant = (style.fontVariant || []).concat('no-contextual')
+    style.fontVariant = (style.fontVariant || [])
+      .concat('no-contextual')
+      .concat('character-variant-5')
   } else {
     // fallback families only supported on web
     if (isWeb) {

--- a/web/index.html
+++ b/web/index.html
@@ -54,6 +54,7 @@
         margin: 0px;
         padding: 0px;
         font-family: InterVariable, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Liberation Sans', Helvetica, Arial, sans-serif;
+        font-feature-settings: 'cv05' on, 'calt' off;
         text-rendering: optimizeLegibility;
         /* Platform-specific reset */
         -webkit-overflow-scrolling: touch;


### PR DESCRIPTION
This adds ss02 to Inter which is the disambiguation set https://rsms.me/inter/#features
It makes ILli1 a lot easier to tell apart.

Haven't been able to get this working on web. Seems that some react-native-web styles are overriding it and the font-feature-settings aren't getting applied correctly.

Looks great on android though

Thread with some more info
https://bsky.app/profile/benharri.org/post/3l7r4sv42sk2q