### PR TITLE
[Lightbox] Set 2 as minimal allowed zoom level

### DIFF
--- a/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.android.tsx
+++ b/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.android.tsx
@@ -26,7 +26,7 @@ import {
   TransformMatrix,
 } from '../../transforms'
 
-const MIN_DOUBLE_TAP_SCALE = 2
+const MIN_SCREEN_ZOOM = 2
 const MAX_ORIGINAL_IMAGE_ZOOM = 2
 
 const initialTransform = createTransform()
@@ -166,8 +166,10 @@ const ImageItem = ({
       // Don't let the picture zoom in so close that it gets blurry.
       // Also, like in stock Android apps, don't let the user zoom out further than 1:1.
       const [, , committedScale] = readTransform(committedTransform.value)
-      const maxCommittedScale =
-        (imageDimensions.width / screenSize.width) * MAX_ORIGINAL_IMAGE_ZOOM
+      const maxCommittedScale = Math.max(
+        MIN_SCREEN_ZOOM,
+        (imageDimensions.width / screenSize.width) * MAX_ORIGINAL_IMAGE_ZOOM,
+      )
       const minPinchScale = 1 / committedScale
       const maxPinchScale = maxCommittedScale / committedScale
       const nextPinchScale = Math.min(
@@ -277,11 +279,13 @@ const ImageItem = ({
       const candidateScale = Math.max(
         imageAspect / screenAspect,
         screenAspect / imageAspect,
-        MIN_DOUBLE_TAP_SCALE,
+        MIN_SCREEN_ZOOM,
       )
       // But don't zoom in so close that the picture gets blurry.
-      const maxScale =
-        (imageDimensions.width / screenSize.width) * MAX_ORIGINAL_IMAGE_ZOOM
+      const maxScale = Math.max(
+        MIN_SCREEN_ZOOM,
+        (imageDimensions.width / screenSize.width) * MAX_ORIGINAL_IMAGE_ZOOM,
+      )
       const scale = Math.min(candidateScale, maxScale)
 
       // Calculate where we would be if the user pinched into the double tapped point.

--- a/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.ios.tsx
+++ b/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.ios.tsx
@@ -28,7 +28,7 @@ import {ImageSource} from '../../@types'
 const SWIPE_CLOSE_OFFSET = 75
 const SWIPE_CLOSE_VELOCITY = 1
 const MAX_ORIGINAL_IMAGE_ZOOM = 2
-const MIN_DOUBLE_TAP_SCALE = 2
+const MIN_SCREEN_ZOOM = 2
 
 type Props = {
   imageSrc: ImageSource
@@ -57,11 +57,11 @@ const ImageItem = ({
     knownDimensions: imageSrc.dimensions,
   })
   const maxZoomScale = Math.max(
+    MIN_SCREEN_ZOOM,
     imageDimensions
       ? (imageDimensions.width / screenSizeDelayedForJSThreadOnly.width) *
           MAX_ORIGINAL_IMAGE_ZOOM
       : 1,
-    MIN_DOUBLE_TAP_SCALE,
   )
 
   const animatedStyle = useAnimatedStyle(() => {
@@ -221,7 +221,7 @@ const getZoomRectAfterDoubleTap = (
   const zoom = Math.max(
     imageAspect / screenAspect,
     screenAspect / imageAspect,
-    MIN_DOUBLE_TAP_SCALE,
+    MIN_SCREEN_ZOOM,
   )
   // Unlike in the Android version, we don't constrain the *max* zoom level here.
   // Instead, this is done in the ScrollView props so that it constraints pinch too.

--- a/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.ios.tsx
+++ b/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.ios.tsx
@@ -56,10 +56,13 @@ const ImageItem = ({
     src: imageSrc.uri,
     knownDimensions: imageSrc.dimensions,
   })
-  const maxZoomScale = imageDimensions
-    ? (imageDimensions.width / screenSizeDelayedForJSThreadOnly.width) *
-      MAX_ORIGINAL_IMAGE_ZOOM
-    : 1
+  const maxZoomScale = Math.max(
+    imageDimensions
+      ? (imageDimensions.width / screenSizeDelayedForJSThreadOnly.width) *
+          MAX_ORIGINAL_IMAGE_ZOOM
+      : 1,
+    MIN_DOUBLE_TAP_SCALE,
+  )
 
   const animatedStyle = useAnimatedStyle(() => {
     return {


### PR DESCRIPTION
If the image resolution is low, both iOS and Android lightboxes didn't let you pinch it at all, and double tap would zoom it _out_. This fixes the issue by ensuring the max zoom scale we pass to the scroll view is always positive. I set it to allow at least 2x magnification (for small images — for highres images it would magnify more, as before).

## Test Plan

Try this post: https://bsky.app/profile/neoxperson.bsky.social/post/3kaxlxr5tv622

Previously, the lightbox would zoom out on double tap. Now it slightly zooms in (and pinching also works).