### PR TITLE
Optimize doResize method with binary search 

### DIFF
--- a/src/lib/media/manip.web.ts
+++ b/src/lib/media/manip.web.ts
@@ -72,17 +72,28 @@ interface DoResizeOpts {
 async function doResize(dataUri: string, opts: DoResizeOpts): Promise<RNImage> {
   let newDataUri
 
-  for (let i = 0; i <= 10; i++) {
-    newDataUri = await createResizedImage(dataUri, {
+  let minQualityPercentage = 0
+  let maxQualityPercentage = 101 //exclusive
+
+  while (maxQualityPercentage - minQualityPercentage > 1) {
+    const qualityPercentage = Math.round(
+      (maxQualityPercentage + minQualityPercentage) / 2,
+    )
+    const tempDataUri = await createResizedImage(dataUri, {
       width: opts.width,
       height: opts.height,
-      quality: 1 - i * 0.1,
+      quality: qualityPercentage / 100,
       mode: opts.mode,
     })
-    if (getDataUriSize(newDataUri) < opts.maxSize) {
-      break
+
+    if (getDataUriSize(tempDataUri) < opts.maxSize) {
+      minQualityPercentage = qualityPercentage
+      newDataUri = tempDataUri
+    } else {
+      maxQualityPercentage = qualityPercentage
     }
   }
+
   if (!newDataUri) {
     throw new Error('Failed to compress image')
   }


### PR DESCRIPTION
This pull request addresses issues discussed in #6112 . Currently, if an uploaded image exceeds a certain size threshold, BlueSky reduces the image quality by 10% and checks if the new size falls within the threshold. If not, BlueSky repeats this step until the image quality reaches 0. There are two issues with this approach:

1. As mentioned in #6112, even a 1-2% decrease in quality can significantly reduce the image size, so the 10% decrement is somewhat overkill.
2. The current solution could be optimized, especially for larger images. For these, the current approach requires multiple iterations to reach the target size, which is not ideal.

My proposed solution is to use binary search to find the maximum quality level that keeps the image size within the limit. This approach will prevent too much loss in image quality. Not only that, I also ran some benchmarks, and it appears that the current solution may perform slightly better for smaller images. However, for larger images, the binary search method does much better. That said, I only conducted a few tests here, so additional testing may be needed to confirm the difference.

| Image Size (KB) | Current Method (ms) | Binary Search Method (ms) |
|-----------------|---------------------|----------------------------|
| 1148            | 844                 | 1040                       |
| 1911            | 5454                | 6477                       |
| 3011            | 5530                | 3396                       |
| 3230            | 6079                | 5402                       |
| 10609           | 12210               | 4141                       |
| 14765           | 26390               | 10213                      |


