### PR TITLE
Add hover feedback to back button on web

### DIFF
--- a/src/view/shell/desktop/LeftNav.tsx
+++ b/src/view/shell/desktop/LeftNav.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import {StyleSheet, TouchableOpacity, View} from 'react-native'
+import {StyleSheet, View} from 'react-native'
 import {
   FontAwesomeIcon,
   FontAwesomeIconStyle,
@@ -104,6 +104,7 @@ function ProfileCard() {
 const HIDDEN_BACK_BNT_ROUTES = ['StarterPackWizard', 'StarterPackEdit']
 
 function BackBtn() {
+  const t = useTheme()
   const {isTablet} = useWebMediaQueries()
   const pal = usePalette('default')
   const navigation = useNavigation<NavigationProp>()
@@ -125,11 +126,13 @@ function BackBtn() {
   if (!shouldShow || isTablet) {
     return <></>
   }
+
   return (
-    <TouchableOpacity
-      testID="viewHeaderBackOrMenuBtn"
+    <PressableWithHover
+      testID="viewHeaderBackBtn"
       onPress={onPressBack}
-      style={styles.backBtn}
+      style={[styles.backBtn, a.rounded_full, a.align_center, a.justify_center]}
+      hoverStyle={t.atoms.bg_contrast_25}
       accessibilityRole="button"
       accessibilityLabel={_(msg`Go back`)}
       accessibilityHint="">
@@ -138,7 +141,7 @@ function BackBtn() {
         icon="angle-left"
         style={pal.text as FontAwesomeIconStyle}
       />
-    </TouchableOpacity>
+    </PressableWithHover>
   )
 }
 
@@ -539,7 +542,6 @@ const styles = StyleSheet.create({
     width: 76,
     alignItems: 'center',
   },
-
   profileCard: {
     marginVertical: 10,
     width: 90,
@@ -548,7 +550,6 @@ const styles = StyleSheet.create({
   profileCardTablet: {
     width: 70,
   },
-
   backBtn: {
     position: 'absolute',
     top: 12,


### PR DESCRIPTION
# Why

<!--
Please describe the motivation for this PR, and link to relevant GitHub issues, forums posts, or feature requests.
-->

The back button in the left nav currently lacks hover feedback on web, which feels inconsistent with other interactive elements. This PR adds a hover state to the back button I've used `rounded_full`, but I've included screenshots of both below for a review.

# Test Plan

<!--
Please describe how you tested this change and how a reviewer could reproduce your test, especially if this PR does not include automated tests! If possible, please also provide terminal output and/or screenshots demonstrating your test/reproduction.
-->

<table>
  <thead>
    <tr>
      <th>Before</th>
      <th>After</th>
    </tr>
  </thead>
  <body>
<tr>
      <td><img src="https://github.com/user-attachments/assets/ac6841dc-6ab9-4d05-a150-f0c756c9abe3" alt="Before" /></td>
      <td><img src="https://github.com/user-attachments/assets/9e587268-c7d6-4e15-aa52-4076d573e78c" alt="After" /></td>
    </tr>
    <tr>
      <td><img src="" alt="Before" /></td>
      <td><img src="https://github.com/user-attachments/assets/25595b88-3c5a-47bb-b9fb-cb663affefc0" alt="After" /></td>
    </tr>
    <tr>
      <td><img src="" alt="Before" /></td>
      <td><img src="https://github.com/user-attachments/assets/1bd77b12-61aa-4fbe-90b6-aa48624c2aad" alt="After" /></td>
</tr>
  </tbody>
</table>
