### PR TITLE
Fix starter pack profiles list being cut off

### DIFF
--- a/src/components/StarterPack/Main/ProfilesList.tsx
+++ b/src/components/StarterPack/Main/ProfilesList.tsx
@@ -40,7 +40,7 @@ export const ProfilesList = React.forwardRef<SectionRef, ProfilesListProps>(
     ref,
   ) {
     const t = useTheme()
-    const bottomBarOffset = useBottomBarOffset(300)
+    const bottomBarOffset = useBottomBarOffset(headerHeight)
     const initialNumToRender = useInitialNumToRender()
     const {currentAccount} = useSession()
     const {data, refetch, isError} = useAllListMembersQuery(listUri)


### PR DESCRIPTION
Fixes: #5961 

- Summary
   The issue was the profiles list being cut off on some devices with specific starter packs. Actually, It is not specific to the devices, but it occurs whenever the starter pack header section is tall enough. So, in the current code, the bottom padding of the list is derived from an arbitrary number (300), which means it can be either bigger or smaller than necessary.
   
- Solution
    I updated the code so that the bottom padding is derived from the header height rather than an arbitrary number like 300. This ensures that the profiles list always has a consistent bottom space across all devices(30px). 
    
- Before
    Android - 
    [android-before.webm](https://github.com/user-attachments/assets/f8bb5535-4eae-462e-91d8-a1fb7b28f64c)

    iOS - 
    https://github.com/user-attachments/assets/3560756d-a6a4-4aea-a754-b8e4e99c0e5b

- After
    Android - 
    [android-after.webm](https://github.com/user-attachments/assets/d9a7a37d-00dd-4475-a5cf-76823056bc07)

    iOS - 
    https://github.com/user-attachments/assets/b92fa574-5d93-4e2b-bc3c-b882a1ce9f91
    
    
    

