### PR TITLE
Fix non-home screen soft resetting when feed is selected from right nav

### DIFF
--- a/src/view/shell/desktop/Feeds.tsx
+++ b/src/view/shell/desktop/Feeds.tsx
@@ -41,7 +41,7 @@ export function DesktopFeeds() {
             onPress={() => {
               setSelectedFeed(feed)
               navigation.navigate('Home')
-              if (feed === selectedFeed) {
+              if (route.name === 'Home' && feed === selectedFeed) {
                 emitSoftReset()
               }
             }}


### PR DESCRIPTION
On desktop, when the current feed is selected from the right nav, that performs a soft reset of the current screen. This behavior is expected when the current screen is Home, but it's unnecessary on every other screen since the app will immediately navigate to Home anyway.
In fact, this soft resetting manifested as a bug where selecting the "current" feed (the feed that was last accessed) while on the Search screen will fail to navigate to Home, since soft resetting the Search screen involves a navigation, which cancels the navigation to Home.

I just made it so that it only soft resets on Home, since that's the only place where we want that, I think