### PR TITLE
Fix 3 image grid in DMs

### DIFF
--- a/src/view/com/util/images/ImageLayoutGrid.tsx
+++ b/src/view/com/util/images/ImageLayoutGrid.tsx
@@ -27,11 +27,10 @@ export function ImageLayoutGrid({style, ...props}: ImageLayoutGridProps) {
         ? a.gap_xs
         : a.gap_2xs
       : a.gap_xs
-  const count = props.images.length
-  const aspectRatio = count === 3 ? 2 : undefined
+
   return (
     <View style={style}>
-      <View style={[gap, a.rounded_md, a.overflow_hidden, {aspectRatio}]}>
+      <View style={[gap, a.rounded_md, a.overflow_hidden]}>
         <ImageLayoutGridInner {...props} gap={gap} />
       </View>
     </View>
@@ -78,14 +77,14 @@ function ImageLayoutGridInner(props: ImageLayoutGridInnerProps) {
     case 3:
       return (
         <View style={[a.flex_1, a.flex_row, gap]}>
-          <View style={[a.flex_1]}>
+          <View style={[a.flex_1, {aspectRatio: 1}]}>
             <GalleryItem
               {...props}
               index={0}
               insetBorderStyle={noCorners(['topRight', 'bottomRight'])}
             />
           </View>
-          <View style={[a.flex_1, gap]}>
+          <View style={[a.flex_1, {aspectRatio: 1}, gap]}>
             <View style={[a.flex_1]}>
               <GalleryItem
                 {...props}


### PR DESCRIPTION
<table>
  <thead>
    <tr>
      <th>Before</th>
      <th>After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><img width="300" alt="Screenshot 2024-11-08 at 12 10 54" src="https://github.com/user-attachments/assets/a0efe04c-fdb7-44b3-bedc-bbf260d20c72" /></td>
      <td><img width="300" alt="Screenshot 2024-11-08 at 12 10 32" src="https://github.com/user-attachments/assets/473cf6d5-94a5-4c08-b601-f47c870acfda" /></td>
    </tr>
  </tbody>
</table>