### PR TITLE
show precise count in label/hover text

### DIFF
--- a/src/screens/Profile/Header/Metrics.tsx
+++ b/src/screens/Profile/Header/Metrics.tsx
@@ -37,7 +37,7 @@ export function ProfileHeaderMetrics({
         testID="profileHeaderFollowersButton"
         style={[a.flex_row, t.atoms.text]}
         to={makeProfileLink(profile, 'followers')}
-        label={`${followers} ${pluralizedFollowers}`}>
+        label={`${profile.followersCount || 0} ${pluralizedFollowers}`}>
         <Text style={[a.font_bold, a.text_md]}>{followers} </Text>
         <Text style={[t.atoms.text_contrast_medium, a.text_md]}>
           {pluralizedFollowers}
@@ -47,7 +47,7 @@ export function ProfileHeaderMetrics({
         testID="profileHeaderFollowsButton"
         style={[a.flex_row, t.atoms.text]}
         to={makeProfileLink(profile, 'follows')}
-        label={_(msg`${following} following`)}>
+        label={_(msg`${profile.followsCount || 0} following`)}>
         <Text style={[a.font_bold, a.text_md]}>{following} </Text>
         <Text style={[t.atoms.text_contrast_medium, a.text_md]}>
           {pluralizedFollowings}


### PR DESCRIPTION
The intention is to expose the precise number of followers somewhere. Currently I have "1.1K", but until that drops to "1K" or rises to "1.2K", i'll have no idea where in that hundred-range the number falls.

I'm sure I'll need to do something with tests, and maybe still format the count in a less-approximate way - please give me some pointers since I'm very unfamiliar with the codebase.

I'd also like to expand this PR to show the full count on the `/follows` and `/followers` pages so it's easily visible on mobile, but i thought i'd start here :-)