### PR TITLE
Fix: Text keeps going upward and downward when entering a new line on Android

### DIFF
--- a/src/view/com/composer/text-input/TextInput.tsx
+++ b/src/view/com/composer/text-input/TextInput.tsx
@@ -252,7 +252,11 @@ export const TextInput = forwardRef(function TextInputImpl(
         style={[
           inputTextStyle,
           a.w_full,
-          {textAlignVertical: 'top', minHeight: 60},
+          {
+            textAlignVertical: 'top',
+            minHeight: 60,
+            includeFontPadding: false,
+          },
         ]}
         {...props}>
         {textDecorated}


### PR DESCRIPTION
Fixes #5917 

1. Recording (before & after)
before: [android-before.webm](https://github.com/user-attachments/assets/069569a9-96bd-4ac4-a754-d1043f4f1591)
after: [android-after.webm](https://github.com/user-attachments/assets/90689fe9-4924-43b3-b58b-6f4caa3f48a1)


2. Summary
This issue is cosmetic and happens only on Android. The problem is that when users enter a new line and start typing, the height of the TextInput slightly increases for some reason. It can be annoying to sensitive users because the position of the entire text keeps going up and down.
I did some research, and it seems setting `includeFontPadding` to false fixes the issue. This style is specific to Android and has no implications for iOS. I tested and confirmed this change doesn't affect iOS or other functionalities.
https://reactnative.dev/docs/text-style-props#includefontpadding-android