### PR TITLE
Tiny tweak to Thread Preferences string

### DIFF
--- a/src/screens/Settings/ThreadPreferences.tsx
+++ b/src/screens/Settings/ThreadPreferences.tsx
@@ -111,7 +111,7 @@ export function ThreadPreferencesScreen({}: Props) {
               style={[a.w_full, a.gap_md]}>
               <Toggle.LabelText style={[a.flex_1]}>
                 <Trans>
-                  Show replies by people you follow before all other replies.
+                  Show replies by people you follow before all other replies
                 </Trans>
               </Toggle.LabelText>
               <Toggle.Platform />


### PR DESCRIPTION
The new Settings screens look great, but when trying them out I just noticed one tiny thing. In my opinion it looks a bit strange to have a `.` at the end of the Prioritize your Follows label string:

![IMG_0031](https://github.com/user-attachments/assets/84f02a3e-cead-4241-91d0-44280c287948)

This tiny PR removes it so that it becomes simply:
`Show replies by people you follow before all other replies`