### PR TITLE
Follower sorting

### DIFF
--- a/src/components/StarterPack/Main/ProfilesList.tsx
+++ b/src/components/StarterPack/Main/ProfilesList.tsx
@@ -54,6 +54,18 @@ export const ProfilesList = React.forwardRef<SectionRef, ProfilesListProps>(
         p => !isBlockedOrBlocking(p.subject) && !p.subject.associated?.labeler,
       )
       .map(p => p.subject)
+      .sort((first, second) => {
+        const isFollowingFirst = Boolean(first.viewer?.following)
+        const isFollowingSecond = Boolean(second.viewer?.following)
+
+        if (isFollowingFirst && !isFollowingSecond) {
+          return -1
+        } else if (!isFollowingFirst && isFollowingSecond) {
+          return 1
+        }
+
+        return 0
+      })
       .reverse()
     const isOwn = new AtUri(listUri).host === currentAccount?.did
 

--- a/src/components/StarterPack/Main/ProfilesList.tsx
+++ b/src/components/StarterPack/Main/ProfilesList.tsx
@@ -19,6 +19,7 @@ import {SectionRef} from '#/screens/Profile/Sections/types'
 import {atoms as a, useTheme} from '#/alf'
 import {ListFooter, ListMaybePlaceholder} from '#/components/Lists'
 import {Default as ProfileCard} from '#/components/ProfileCard'
+import {sortProfiles} from '../../../lib/functions'
 
 function keyExtractor(item: AppBskyActorDefs.ProfileViewBasic, index: number) {
   return `${item.did}-${index}`
@@ -54,18 +55,7 @@ export const ProfilesList = React.forwardRef<SectionRef, ProfilesListProps>(
         p => !isBlockedOrBlocking(p.subject) && !p.subject.associated?.labeler,
       )
       .map(p => p.subject)
-      .sort((first, second) => {
-        const isFollowingFirst = Boolean(first.viewer?.following)
-        const isFollowingSecond = Boolean(second.viewer?.following)
-
-        if (isFollowingFirst && !isFollowingSecond) {
-          return -1
-        } else if (!isFollowingFirst && isFollowingSecond) {
-          return 1
-        }
-
-        return 0
-      })
+      .sort(sortProfiles)
       .reverse()
     const isOwn = new AtUri(listUri).host === currentAccount?.did
 

--- a/src/lib/functions.ts
+++ b/src/lib/functions.ts
@@ -1,3 +1,5 @@
+import {AppBskyActorDefs} from '@atproto/api'
+
 export function choose<U, T extends Record<string, U>>(
   value: keyof T,
   choices: T,
@@ -95,4 +97,20 @@ export function isPlainObject(o: any): o is Object {
 
 function hasObjectPrototype(o: any): boolean {
   return Object.prototype.toString.call(o) === '[object Object]'
+}
+
+export function sortProfiles(
+  first: AppBskyActorDefs.ProfileView,
+  second: AppBskyActorDefs.ProfileView,
+) {
+  const isFollowingFirst = Boolean(first.viewer?.following)
+  const isFollowingSecond = Boolean(second.viewer?.following)
+
+  if (isFollowingFirst && !isFollowingSecond) {
+    return -1
+  } else if (!isFollowingFirst && isFollowingSecond) {
+    return 1
+  }
+
+  return 0
 }

--- a/src/view/com/composer/text-input/web/Autocomplete.tsx
+++ b/src/view/com/composer/text-input/web/Autocomplete.tsx
@@ -5,6 +5,7 @@ import React, {
   useState,
 } from 'react'
 import {Pressable, StyleSheet, View} from 'react-native'
+import {AppBskyActorDefs} from '@atproto/api'
 import {Trans} from '@lingui/macro'
 import {ReactRenderer} from '@tiptap/react'
 import {
@@ -18,6 +19,7 @@ import {usePalette} from '#/lib/hooks/usePalette'
 import {ActorAutocompleteFn} from '#/state/queries/actor-autocomplete'
 import {Text} from '#/view/com/util/text/Text'
 import {UserAvatar} from '#/view/com/util/UserAvatar'
+import {sortProfiles} from '../../../../../lib/functions'
 import {useGrapheme} from '../hooks/useGrapheme'
 
 interface MentionListRef {
@@ -95,7 +97,10 @@ export function createSuggestion({
 }
 
 const MentionList = forwardRef<MentionListRef, SuggestionProps>(
-  function MentionListImpl(props: SuggestionProps, ref) {
+  function MentionListImpl(
+    props: SuggestionProps<AppBskyActorDefs.ProfileView>,
+    ref,
+  ) {
     const [selectedIndex, setSelectedIndex] = useState(0)
     const pal = usePalette('default')
     const {getGraphemeString} = useGrapheme()
@@ -151,7 +156,7 @@ const MentionList = forwardRef<MentionListRef, SuggestionProps>(
       <div className="items">
         <View style={[pal.borderDark, pal.view, styles.container]}>
           {items.length > 0 ? (
-            items.map((item, index) => {
+            items.sort(sortProfiles).map((item, index) => {
               const {name: displayName} = getGraphemeString(
                 item.displayName ?? item.handle,
                 30, // Heuristic value; can be modified

--- a/src/view/screens/Search/Search.tsx
+++ b/src/view/screens/Search/Search.tsx
@@ -66,6 +66,7 @@ import {SearchInput} from '#/components/forms/SearchInput'
 import {ChevronBottom_Stroke2_Corner0_Rounded as ChevronDown} from '#/components/icons/Chevron'
 import {Menu_Stroke2_Corner0_Rounded as Menu} from '#/components/icons/Menu'
 import * as Layout from '#/components/Layout'
+import {sortProfiles} from '../../../lib/functions'
 
 function Loader() {
   const pal = usePalette('default')
@@ -1006,7 +1007,7 @@ let AutocompleteResults = ({
             }
             style={{borderBottomWidth: 1}}
           />
-          {autocompleteData?.map(item => (
+          {autocompleteData?.sort(sortProfiles).map(item => (
             <SearchProfileCard
               key={item.did}
               profile={item}

--- a/src/view/shell/desktop/Search.tsx
+++ b/src/view/shell/desktop/Search.tsx
@@ -30,6 +30,7 @@ import {Text} from '#/view/com/util/text/Text'
 import {UserAvatar} from '#/view/com/util/UserAvatar'
 import {atoms as a} from '#/alf'
 import {SearchInput} from '#/components/forms/SearchInput'
+import {sortProfiles} from '../../../lib/functions'
 
 let SearchLinkCard = ({
   label,
@@ -206,7 +207,7 @@ export function DesktopSearch() {
                     : undefined
                 }
               />
-              {autocompleteData?.map(item => (
+              {autocompleteData?.sort(sortProfiles).map(item => (
                 <SearchProfileCard
                   key={item.did}
                   profile={item}


### PR DESCRIPTION
I think putting followers at the top and bottom in certain situations leads to easier to use UI. I was initially going to do separate PRs but realized that I needed the sorting function. I applied it to some places where I think it makes sense. There may be more

> Note: For examples I follow luna

1. Starter packs get followed people sorted to the bottom

![CleanShot 2024-11-09 at 01 45 16@2x](https://github.com/user-attachments/assets/6cf56006-805e-4a69-9c55-cdbedc94030d)

2. When mention a user, followed people are at the top

![CleanShot 2024-11-09 at 01 46 28@2x](https://github.com/user-attachments/assets/3fd81648-baa3-49d0-8a7a-c357b05d8abc)

3. Mobile searches sort followed people to the top

![CleanShot 2024-11-09 at 01 47 29@2x](https://github.com/user-attachments/assets/1f5bf2eb-af91-4b72-816c-9badf1f3663f)

4. Desktop searches sort followed people to the top

![CleanShot 2024-11-09 at 01 48 08@2x](https://github.com/user-attachments/assets/5260e801-a3fb-42a4-aee8-2a9081760cfb)

