### PR TITLE
Add extra space to clear search btn

### DIFF
--- a/src/alf/atoms.ts
+++ b/src/alf/atoms.ts
@@ -48,6 +48,16 @@ export const atoms = {
   },
 
   /*
+   * Extra space
+   */
+  inset_outer_md: {
+    top: tokens.outerInset.md,
+    left: tokens.outerInset.md,
+    right: tokens.outerInset.md,
+    bottom: tokens.outerInset.md,
+  },
+
+  /*
    * Width
    */
   w_full: {

--- a/src/alf/tokens.ts
+++ b/src/alf/tokens.ts
@@ -20,6 +20,16 @@ export const space = {
   _5xl: 40,
 } as const
 
+export const outerInset = {
+  _2xs: -1,
+  xs: -2,
+  sm: -4,
+  md: -6,
+  lg: -8,
+  xl: -10,
+  _2xl: -12,
+} as const
+
 export const fontSize = {
   _2xs: 10,
   xs: 12,

--- a/src/components/forms/SearchInput.tsx
+++ b/src/components/forms/SearchInput.tsx
@@ -73,6 +73,7 @@ export const SearchInput = React.forwardRef<TextInput, SearchInputProps>(
               shape="round"
               variant="ghost"
               color="secondary">
+              <View style={[a.absolute, a.inset_outer_md, a.rounded_full]} />
               <ButtonIcon icon={X} size="xs" />
             </Button>
           </View>


### PR DESCRIPTION
The clear search button is only 22x22 pixels. For better accessibility, it should be at least 32x32.

Made a classic trick for extra outer space. Added 6px so now it 34x34.

Before:

https://github.com/user-attachments/assets/b4180cae-7950-475b-9e46-0e56a811cb8d

After:

https://github.com/user-attachments/assets/7e6f7d8c-5620-4369-8190-436d92c2040f

Fixes: #6148, also improvement for #5845