### PR TITLE
Fix web image layout

### DIFF
--- a/src/view/com/util/images/AutoSizedImage.tsx
+++ b/src/view/com/util/images/AutoSizedImage.tsx
@@ -105,7 +105,7 @@ export function AutoSizedImage({
   const hasAlt = !!image.alt
 
   const contents = (
-    <Animated.View ref={containerRef} collapsable={false}>
+    <Animated.View ref={containerRef} collapsable={false} style={{flex: 1}}>
       <Image
         style={[a.w_full, a.h_full]}
         source={image.thumb}


### PR DESCRIPTION
Broke this in https://github.com/bluesky-social/social-app/pull/6159.

## Before

<img width="611" alt="Screenshot 2024-11-09 at 23 07 42" src="https://github.com/user-attachments/assets/e9323b7d-12b5-4b88-b531-edb3b0c0d33f">

## After

<img width="595" alt="Screenshot 2024-11-09 at 23 07 34" src="https://github.com/user-attachments/assets/27eb722f-931e-465d-b21b-bf54e8bca646">
