### PR TITLE
Fix unscrollable body when returning to desktop mode from mobile mode with navigation drawer open.

### DIFF
--- a/src/view/shell/index.web.tsx
+++ b/src/view/shell/index.web.tsx
@@ -32,8 +32,8 @@ function ShellInner() {
   const navigator = useNavigation<NavigationProp>()
   const closeAllActiveElements = useCloseAllActiveElements()
   const {_} = useLingui()
-
   const showDrawer = !isDesktop && isDrawerOpen
+
   useWebBodyScrollLock(showDrawer)
   useComposerKeyboardShortcut()
   useIntentHandler()
@@ -57,7 +57,7 @@ function ShellInner() {
       <Lightbox />
       <PortalOutlet />
 
-      {!isDesktop && isDrawerOpen && (
+      {showDrawer && (
         <TouchableWithoutFeedback
           onPress={ev => {
             // Only close if press happens outside of the drawer

--- a/src/view/shell/index.web.tsx
+++ b/src/view/shell/index.web.tsx
@@ -33,7 +33,8 @@ function ShellInner() {
   const closeAllActiveElements = useCloseAllActiveElements()
   const {_} = useLingui()
 
-  useWebBodyScrollLock(isDrawerOpen)
+  const showDrawer = !isDesktop && isDrawerOpen
+  useWebBodyScrollLock(showDrawer)
   useComposerKeyboardShortcut()
   useIntentHandler()
 


### PR DESCRIPTION
So, this PR is related to this issue: #6200. Currently, BlueSky blocks the body scroll when the navigation drawer is opened: https://github.com/bluesky-social/social-app/blob/89c93313a3fc3123a2e53856f53cc8cea8e693fa/src/view/shell/index.web.tsx#L36

The problem is that when users switch to mobile mode, open the drawer, and then switch back to desktop mode, the navigation drawer is still considered open, which is incorrect. I’ve implemented a quick fix here to automatically close the drawer whenever the user exits mobile mode.