### PR TITLE
Fix Retain Cycles in SheetViewController

### DIFF
--- a/modules/bottom-sheet/ios/SheetViewController.swift
+++ b/modules/bottom-sheet/ios/SheetViewController.swift
@@ -64,14 +64,14 @@ class SheetViewController: UIViewController {
 
   func updateDetents(contentHeight: CGFloat, preventExpansion: Bool) {
     if let sheet = self.sheetPresentationController {
-      // Added [weak self] to prevent a retain cycle. Without this, the closure strongly captures `self`,
-      // potentially causing the SheetViewController to never be deallocated.
-      sheet.animateChanges { [weak self] in
-        guard let self = self else { return }
-        self.setDetents(contentHeight: contentHeight, preventExpansion: preventExpansion)
-        if #available(iOS 16.0, *) {
-          sheet.invalidateDetents()
-        }
+      // Capture `self` weakly to prevent retain cycles.
+      // Also, capture `sheet` weakly to avoid potential strong references held by animateChanges.
+      sheet.animateChanges { [weak self, weak sheet] in
+          guard let weakSelf = self, let weakSheet = sheet else { return }
+          weakSelf.setDetents(contentHeight: contentHeight, preventExpansion: preventExpansion)
+          if #available(iOS 16.0, *) {
+              weakSheet.invalidateDetents()
+          }
       }
     }
   }

--- a/modules/bottom-sheet/ios/SheetViewController.swift
+++ b/modules/bottom-sheet/ios/SheetViewController.swift
@@ -64,7 +64,10 @@ class SheetViewController: UIViewController {
 
   func updateDetents(contentHeight: CGFloat, preventExpansion: Bool) {
     if let sheet = self.sheetPresentationController {
-      sheet.animateChanges {
+      // Added [weak self] to prevent a retain cycle. Without this, the closure strongly captures `self`,
+      // potentially causing the SheetViewController to never be deallocated.
+      sheet.animateChanges { [weak self] in
+        guard let self = self else { return }
         self.setDetents(contentHeight: contentHeight, preventExpansion: preventExpansion)
         if #available(iOS 16.0, *) {
           sheet.invalidateDetents()


### PR DESCRIPTION
Fix Retain Cycles in `SheetViewController.swift`

This pull request addresses potential retain cycles in `SheetViewController.swift` to improve memory management. Key changes include:

- Added `[weak self]` in the closure of `sheet.animateChanges` in the `updateDetents` method to prevent `self` from being strongly captured.
- Also captured `sheet` weakly in the closure to avoid any potential strong references retained by `animateChanges`.

These changes ensure the `SheetViewController` and its `UISheetPresentationController` are properly deallocated when no longer needed, preventing memory leaks while maintaining the functionality of the class.

**Reference**
- [**Apple Documentation on Memory Management**](https://developer.apple.com/library/archive/documentation/Swift/Conceptual/Swift_Programming_Language/AutomaticReferenceCounting.html)  

Let me know if you need further clarification!