### PR TITLE
Fix the translation of the adjective "open"

### DIFF
--- a/src/locale/locales/it/messages.po
+++ b/src/locale/locales/it/messages.po
@@ -5033,7 +5033,7 @@ msgstr "Ops!"
 
 #: src/screens/Onboarding/StepFinished.tsx:251
 msgid "Open"
-msgstr "Apri"
+msgstr "Aperto"
 
 #: src/view/com/posts/AviFollowButton.tsx:86
 msgid "Open {name} profile shortcut menu"


### PR DESCRIPTION
The word "open" can be a verb like in "Open avatar creator" or an adjective (e.g. "Bluesky is open"). This commit replace the verb "Apri" with the adjective "Aperto".