### PR TITLE
Fix render loop on Android

### DIFF
--- a/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.android.tsx
+++ b/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.android.tsx
@@ -396,10 +396,14 @@ const ImageItem = ({
                 placeholderContentFit="cover"
                 placeholder={{uri: imageSrc.thumbUri}}
                 accessibilityLabel={imageSrc.alt}
-                onLoad={e => {
-                  setHasLoaded(true)
-                  onLoad({width: e.source.width, height: e.source.height})
-                }}
+                onLoad={
+                  hasLoaded
+                    ? undefined
+                    : e => {
+                        setHasLoaded(true)
+                        onLoad({width: e.source.width, height: e.source.height})
+                      }
+                }
                 style={{flex: 1, borderRadius}}
                 accessibilityHint=""
                 accessibilityIgnoresInvertColors

--- a/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.ios.tsx
+++ b/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.ios.tsx
@@ -228,10 +228,14 @@ const ImageItem = ({
               accessibilityHint=""
               enableLiveTextInteraction={showControls && !scaled}
               accessibilityIgnoresInvertColors
-              onLoad={e => {
-                setHasLoaded(true)
-                onLoad({width: e.source.width, height: e.source.height})
-              }}
+              onLoad={
+                hasLoaded
+                  ? undefined
+                  : e => {
+                      setHasLoaded(true)
+                      onLoad({width: e.source.width, height: e.source.height})
+                    }
+              }
             />
           </Animated.View>
         </Animated.View>

--- a/src/view/com/util/images/AutoSizedImage.tsx
+++ b/src/view/com/util/images/AutoSizedImage.tsx
@@ -113,9 +113,13 @@ export function AutoSizedImage({
         accessibilityIgnoresInvertColors
         accessibilityLabel={image.alt}
         accessibilityHint=""
-        onLoad={e => {
-          setFetchedDims({width: e.source.width, height: e.source.height})
-        }}
+        onLoad={
+          fetchedDims
+            ? undefined
+            : e => {
+                setFetchedDims({width: e.source.width, height: e.source.height})
+              }
+        }
       />
       <MediaInsetBorder />
 


### PR DESCRIPTION
I'm not sure what the root cause is, but I'm seeing `onLoad -> setState -> onLoad` loops on Android in the feed even when the image has not changed. I'm also not sure whether this is a comprehensive fix, but it does seem to help.

## Test Plan

I haven't found a better way than to add `console.log('render')` to `AutoSizedImage.tsx`. As I scroll Discover, it would occasionally start repeatedly fire for the same image. After applying the fix (with Fast Refresh), it stops.

### Before

https://github.com/user-attachments/assets/d0f6d73e-0007-4128-9121-81d53e45b9af

### After

https://github.com/user-attachments/assets/0d19a482-6d69-434e-88d5-1da540d6b65b


The fix should generally be safe anyway so this shouldn't hurt anything.