### PR TITLE
Fix 'Show badge' button label being cut off

### DIFF
--- a/src/components/forms/ToggleButton.tsx
+++ b/src/components/forms/ToggleButton.tsx
@@ -95,6 +95,9 @@ function ButtonInner({children}: React.PropsWithChildren<{}>) {
         native({
           paddingBottom: 10,
         }),
+        a.w_full,
+        a.h_full,
+        a.justify_center,
         a.px_md,
         t.atoms.bg,
         t.atoms.border_contrast_low,


### PR DESCRIPTION
Fixes #6185 
1. Summary
    `Show badge` label is cut off on the developer labels page.

2. Solution
    Before: 
![image](https://github.com/user-attachments/assets/5d7f69f3-cf03-4968-811c-d634aba550d5)
    After: 
![CleanShot 2024-11-10 at 15 26 03](https://github.com/user-attachments/assets/c51780d3-22a2-49ce-9240-66ecc758e33c)

The fix looks better than being cut off, but I am unsure if it is the best solution to the problem. I can think of different ways of solving it, and here are some of them
    - Updating the label to say `Show` instead of `Show badge`
    - Increasing the button width for all 3
    - Put the toggle group underneath `title/description` section like on mobile devices
    
I guess, I need some design inputs here on what is the desired behavior aesthetically.