### PR TITLE
Reduce Reanimated serialization traffic

### DIFF
--- a/src/view/com/util/MainScrollProvider.tsx
+++ b/src/view/com/util/MainScrollProvider.tsx
@@ -3,6 +3,7 @@ import {NativeScrollEvent} from 'react-native'
 import {
   cancelAnimation,
   interpolate,
+  makeMutable,
   useSharedValue,
   withSpring,
 } from 'react-native-reanimated'
@@ -20,6 +21,18 @@ function clamp(num: number, min: number, max: number) {
   return Math.min(Math.max(num, min), max)
 }
 
+const V0 = makeMutable(
+  withSpring(0, {
+    overshootClamping: true,
+  }),
+)
+
+const V1 = makeMutable(
+  withSpring(1, {
+    overshootClamping: true,
+  }),
+)
+
 export function MainScrollProvider({children}: {children: React.ReactNode}) {
   const {headerHeight} = useShellLayout()
   const {headerMode} = useMinimalShellMode()
@@ -31,9 +44,7 @@ export function MainScrollProvider({children}: {children: React.ReactNode}) {
     (v: boolean) => {
       'worklet'
       cancelAnimation(headerMode)
-      headerMode.value = withSpring(v ? 1 : 0, {
-        overshootClamping: true,
-      })
+      headerMode.value = v ? V1.value : V0.value
     },
     [headerMode],
   )


### PR DESCRIPTION
This was a major WTF moment for me and I'm still not sure to what extent this is actually useful. However, the [Android GPU profiler](https://developer.android.com/topic/performance/rendering/profile-gpu) seems to be happy about this change.

There is some information about how Reanimated closures work here: https://github.com/software-mansion/react-native-reanimated/issues/3670#issuecomment-1303388096

We're closing over `withSpring` which I assume means that [this clone function](https://github.com/software-mansion/react-native-reanimated/blob/66137a6b084d787e5d98aa496d66b83cbd204d71/packages/react-native-reanimated/src/shareables.ts#L103-L291) will have to go into `withSpring` itself, deal with _its_ closures over top scope, and so on. I haven't tried logging what's going on there but I suspect there may be some serialization overhead.

However, we can just create initial and final values of the animation and expose _those_ to the worklet. I didn't expect this to be faster but it does seem to be. Or maybe the GPU debugger is being misleading.

## Test Plan

Enable GPU profiler, build for release on device, remove all embeds (they add too much other unpredictability), continuously scroll a little bit up and down with your finger without releasing on Home.

## Before

Overall we're way above the red line.

The green+blue stuff reaches the green line.

<img width="637" alt="Screenshot 2024-11-11 at 01 27 26" src="https://github.com/user-attachments/assets/01933597-6def-4505-ba0f-68f20589ddfe">

## After

Overall we're a bit below the red line.

The green+blue stuff is halfway within the green line.

<img width="605" alt="Screenshot 2024-11-11 at 01 27 16" src="https://github.com/user-attachments/assets/c1a857d6-9684-4d71-a72f-48a7e0cbbb1b">
