### PR TITLE
Increase copied animation lingering time for reduced motion

### DIFF
--- a/src/screens/Settings/components/CopyButton.tsx
+++ b/src/screens/Settings/components/CopyButton.tsx
@@ -1,6 +1,10 @@
 import React, {useCallback, useEffect, useState} from 'react'
 import {GestureResponderEvent, View} from 'react-native'
-import Animated, {FadeOutUp, ZoomIn} from 'react-native-reanimated'
+import Animated, {
+  FadeOutUp,
+  useReducedMotion,
+  ZoomIn,
+} from 'react-native-reanimated'
 import * as Clipboard from 'expo-clipboard'
 import {Trans} from '@lingui/macro'
 
@@ -16,13 +20,17 @@ export function CopyButton({
 }: ButtonProps & {value: string}) {
   const [hasBeenCopied, setHasBeenCopied] = useState(false)
   const t = useTheme()
+  const isReducedMotionEnabled = useReducedMotion()
 
   useEffect(() => {
     if (hasBeenCopied) {
-      const timeout = setTimeout(() => setHasBeenCopied(false), 100)
+      const timeout = setTimeout(
+        () => setHasBeenCopied(false),
+        !isReducedMotionEnabled ? 100 : 2000,
+      )
       return () => clearTimeout(timeout)
     }
-  }, [hasBeenCopied])
+  }, [hasBeenCopied, isReducedMotionEnabled])
 
   const onPress = useCallback(
     (evt: GestureResponderEvent) => {


### PR DESCRIPTION
1. Summary
    When `reduced motion` is enabled via accessibility settings on desktop/mobile devices, copied animation stays for 0.1 sec, and it disappears too fast. It happens because `entering/exit` animations are disabled by the `react-native-reanimated` library by default for reduced motion.
2. Solution
    We can constantly enable `entering/exiting` animations regardless of `reduced motion` settings and adjust their parameters if we want. But I kept them enabled for now and increased the `Copied` label lingering time from 0.1 sec to 2 sec. Please advise if we want to follow a different path from a UX perspective.
    Here is what it looks like - 
https://github.com/user-attachments/assets/d7d9dc8c-4f3e-4e8a-8c55-b3c5e78a3a07
    


    