### PR TITLE
Fix repost button styling when logged out

### DIFF
--- a/src/view/com/util/post-ctrls/RepostButton.web.tsx
+++ b/src/view/com/util/post-ctrls/RepostButton.web.tsx
@@ -104,9 +104,7 @@ export const RepostButton = ({
       label={_(msg`Repost or quote post`)}
       style={{padding: 0}}
       hoverStyle={t.atoms.bg_contrast_25}
-      shape="round"
-      variant="ghost"
-      color="secondary">
+      shape="round">
       <RepostInner
         isReposted={isReposted}
         color={color}


### PR DESCRIPTION
On the web, the logged-out variant of the repost button sets a white background with `variant="ghost"`, which conflicts with the background applied when a post is hovered:
<img width="572" alt="Screenshot 2024-11-10 at 9 35 34 PM" src="https://github.com/user-attachments/assets/b09c5cad-dffc-49a0-af84-89d25137e52a">

Removing the button styling seems to make this button render like the others on the page:
<img width="572" alt="Screenshot 2024-11-10 at 9 36 22 PM" src="https://github.com/user-attachments/assets/9950e425-28ed-4fe7-8bbd-2cafcf88527c">
