### PR TITLE
Fix error screen

### DIFF
--- a/src/components/Error.tsx
+++ b/src/components/Error.tsx
@@ -32,7 +32,7 @@ export function Error({
   return (
     <CenteredView
       style={[
-        a.flex_1,
+        a.w_full,
         a.align_center,
         a.gap_5xl,
         !gtMobile && a.justify_between,


### PR DESCRIPTION
Error screen height collapsed due to some sort of flexbox issue. I would love to know the root cause, but changing `flex_1` to `w_full` fixes it for now


<table>
  <thead>
    <tr>
      <th>Before</th>
      <th>After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><img width="200" alt="Simulator Screenshot 1" src="https://github.com/user-attachments/assets/996db362-40d7-4ab4-aa29-d4be90ed412b" /></td>
      <td><img width="200" alt="Simulator Screenshot 2" src="https://github.com/user-attachments/assets/df22d067-4246-4d7d-a0a1-fae5664ebe13" /></td>
    </tr>
  </tbody>
</table>

# Test plan

- Get to the screen by finding a post with one repost, blocking that person, and then going back to the screen (or edit code to make the query return [])
- Check it now works on all platforms
- Confirm that the component still works in other places (i.e. gif select error). It might've changed some screens on native since it's now `w_full` instead of `flex_1`, but I can't find any examples