### PR TITLE
Update Node.js to 20.x in Dockerfile.embedr

### DIFF
--- a/Dockerfile.embedr
+++ b/Dockerfile.embedr
@@ -5,7 +5,7 @@ WORKDIR /usr/src/social-app
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Node
-ENV NODE_VERSION=18
+ENV NODE_VERSION=20
 ENV NVM_DIR=/usr/share/nvm
 
 # Go


### PR DESCRIPTION
Missed in https://github.com/bluesky-social/social-app/pull/6099

GitHub Action failure
```console
Error: buildx failed with: ERROR: failed to solve: process "/bin/sh -c \\. \"$NVM_DIR/nvm.sh\" &&   nvm install $NODE_VERSION &&   nvm use $NODE_VERSION &&   npm install --global yarn &&   yarn &&   cd bskyembed && yarn install --frozen-lockfile && cd .. &&   yarn intl:build &&   yarn build-embed" did not complete successfully: exit code: 1
```
https://github.com/bluesky-social/social-app/actions/runs/11784553250/job/32823975623