### PR TITLE
Fix login footer not being vertically centered on mobile web view

### DIFF
--- a/src/view/shell/bottom-bar/BottomBarWeb.tsx
+++ b/src/view/shell/bottom-bar/BottomBarWeb.tsx
@@ -177,7 +177,7 @@ export function BottomBarWeb() {
               alignItems: 'center',
               justifyContent: 'space-between',
               paddingTop: 14,
-              paddingBottom: 2,
+              paddingBottom: 14,
               paddingLeft: 14,
               paddingRight: 6,
               gap: 8,


### PR DESCRIPTION
Fixes #6253 

1. Summary
Bottom padding is 2px whereas the top padding is 14px for the login/signup footer on mobile web view

2. Solution
I am not sure which value will make it look best aesthetically, but I went with 14px for both top and bottom paddings for now.

3. Screenshot
![localhost_19006_profile_alicewastaken bsky social_post_3lai4cj6t2c22(iPhone 12 Pro) (1)](https://github.com/user-attachments/assets/ee9bade2-7570-46a0-8361-835041efc9c0)
