### PR TITLE
Embedr: fix build / node version

### DIFF
--- a/.github/workflows/build-and-push-embedr-aws.yaml
+++ b/.github/workflows/build-and-push-embedr-aws.yaml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - divy/embed-rate-limit
 
 env:
   REGISTRY: ${{ secrets.AWS_ECR_REGISTRY_USEAST2_PACKAGES_REGISTRY }}

--- a/.github/workflows/build-and-push-embedr-aws.yaml
+++ b/.github/workflows/build-and-push-embedr-aws.yaml
@@ -3,8 +3,7 @@ on:
   push:
     branches:
       - main
-      - bnewbold/embedr
-      - bnewbold/embedr-rebase
+      - divy/embed-rate-limit
 
 env:
   REGISTRY: ${{ secrets.AWS_ECR_REGISTRY_USEAST2_PACKAGES_REGISTRY }}

--- a/Dockerfile.embedr
+++ b/Dockerfile.embedr
@@ -5,7 +5,7 @@ WORKDIR /usr/src/social-app
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Node
-ENV NODE_VERSION=18
+ENV NODE_VERSION=20
 ENV NVM_DIR=/usr/share/nvm
 
 # Go

--- a/bskyweb/cmd/embedr/server.go
+++ b/bskyweb/cmd/embedr/server.go
@@ -112,8 +112,8 @@ func serve(cctx *cli.Context) error {
 		Skipper: middleware.DefaultSkipper,
 		Store: middleware.NewRateLimiterMemoryStoreWithConfig(
 			middleware.RateLimiterMemoryStoreConfig{
-				Rate:      10,              // requests per second
-				Burst:     30,              // allow bursts
+				Rate:      20,              // requests per second
+				Burst:     150,             // allow bursts
 				ExpiresIn: 3 * time.Minute, // garbage collect entries older than 3 minutes
 			},
 		),


### PR DESCRIPTION
A recent change to the supported node version needed to be synced-up in embedr's dockerfile.