### PR TITLE
Use latest node:20-alpine for Bsky Link Service

### DIFF
--- a/Dockerfile.bskylink
+++ b/Dockerfile.bskylink
@@ -1,4 +1,4 @@
-FROM node:20.11-alpine3.18 as build
+FROM node:20-alpine as build
 
 # Move files into the image and install
 WORKDIR /app
@@ -14,7 +14,7 @@ RUN yarn build
 RUN yarn install --production --ignore-scripts --prefer-offline
 
 # Uses assets from build stage to reduce build size
-FROM node:20.11-alpine3.18
+FROM node:20-alpine
 
 RUN apk add --update dumb-init
 


### PR DESCRIPTION
The current Node.js Dockerfile [node:20.11-alpine3.18](https://hub.docker.com/layers/library/node/20.11-alpine3.18/images/sha256-d70c7175214f849ab24c115fea5419064407a8c64209d4c5ddf8626e2be06a80) used in Bsky Link Service is vulnerable.

This PR attempts to use the latest Node.js 20.x alpine
List of official images https://hub.docker.com/_/node