### PR TITLE
Add option to share link including user's domain (#6250)

### DIFF
--- a/src/lib/strings/url-helpers.ts
+++ b/src/lib/strings/url-helpers.ts
@@ -86,6 +86,16 @@ export function toShareUrl(url: string): string {
   return url
 }
 
+export function toShareUrlWithUserDomain(url: string): string {
+  if (!url.startsWith('https')) {
+    // Assume that user has set up ALIAS/CNAME called bsky to redirect.bsky.app
+    // This ensures that post links are controlled by the user
+    // See https://github.com/bluesky-social/social-app/issues/6250
+    url = url.replace('/profile/', 'https://bsky.')
+  }
+  return url
+}
+
 export function toBskyAppUrl(url: string): string {
   return new URL(url, BSKY_APP_HOST).toString()
 }

--- a/src/view/com/util/forms/PostDropdownBtn.tsx
+++ b/src/view/com/util/forms/PostDropdownBtn.tsx
@@ -25,7 +25,7 @@ import {CommonNavigatorParams, NavigationProp} from '#/lib/routes/types'
 import {shareUrl} from '#/lib/sharing'
 import {logEvent} from '#/lib/statsig/statsig'
 import {richTextToString} from '#/lib/strings/rich-text-helpers'
-import {toShareUrl} from '#/lib/strings/url-helpers'
+import {toShareUrl, toShareUrlWithUserDomain} from '#/lib/strings/url-helpers'
 import {useTheme} from '#/lib/ThemeContext'
 import {getTranslatorLink} from '#/locale/helpers'
 import {logger} from '#/logger'
@@ -262,6 +262,11 @@ let PostDropdownBtn = ({
     shareUrl(url)
   }, [href])
 
+  const onSharePostWithUserDomain = React.useCallback(() => {
+    const url = toShareUrlWithUserDomain(href)
+    shareUrl(url)
+  }, [href])
+
   const onPressShowMore = React.useCallback(() => {
     feedFeedback.sendInteraction({
       event: 'app.bsky.feed.defs#requestMore',
@@ -459,6 +464,29 @@ let PostDropdownBtn = ({
               }}>
               <Menu.ItemText>
                 {isWeb ? _(msg`Copy link to post`) : _(msg`Share`)}
+              </Menu.ItemText>
+              <Menu.ItemIcon icon={Share} position="right" />
+            </Menu.Item>
+
+            <Menu.Item
+              testID="postDropdownShareBtn"
+              label={
+                isWeb
+                  ? _(msg`Copy link with user's domain`)
+                  : _(msg`Share with user's domain`)
+              }
+              onPress={() => {
+                if (showLoggedOutWarning) {
+                  loggedOutWarningPromptControl.open()
+                } else {
+                  onSharePostWithUserDomain()
+                }
+              }}>
+              <Menu.ItemText>
+                {href}{' '}
+                {isWeb
+                  ? _(msg`Copy link with user's domain`)
+                  : _(msg`Share with user's domain`)}
               </Menu.ItemText>
               <Menu.ItemIcon icon={Share} position="right" />
             </Menu.Item>


### PR DESCRIPTION
This is experimental and adds an option to start enable and encourage users to share post URLs which are owned by them but are [redirected to bsky host of their choice](https://bsky.app/profile/jacob.gold/post/3kh6re46yd42k).

This would be a partial fix for #6250. I am keeping this PR as draft until I receive more feedback on this direction.