### PR TITLE
Fix inconsistent middle-click behavior for quoted posts

### DIFF
--- a/src/view/com/util/Link.tsx
+++ b/src/view/com/util/Link.tsx
@@ -140,17 +140,19 @@ export const Link = memo(function Link({
 
   const Com = props.hoverStyle ? PressableWithHover : Pressable
   return (
-    <Com
-      testID={testID}
-      style={style}
-      onPress={onPress}
-      accessible={accessible}
-      accessibilityRole="link"
-      // @ts-ignore web only -prf
-      href={anchorHref}
-      {...props}>
-      {children ? children : <Text>{title || 'link'}</Text>}
-    </Com>
+    <WebAuxClickWrapper>
+      <Com
+        testID={testID}
+        style={style}
+        onPress={onPress}
+        accessible={accessible}
+        accessibilityRole="link"
+        // @ts-ignore web only -prf
+        href={anchorHref}
+        {...props}>
+        {children ? children : <Text>{title || 'link'}</Text>}
+      </Com>
+    </WebAuxClickWrapper>
   )
 })
 


### PR DESCRIPTION
Fixes #6280 

1. Summary
Inside the `Link` component, it seems we didn't enable `auxclick` when `noFeedback` is false, and that's why middle-click is doing nothing on the post thread page. I figured we probably wanna enable `auxclick` regardless of `noFeedback` flag for consistency for all links across the app. (https://developer.mozilla.org/en-US/docs/Web/API/Element/auxclick_event)

2. Solution
Always enable the `auxclick` for `Link` component

3. Recording

https://github.com/user-attachments/assets/a304d503-0ea5-4869-b5e2-8375958f3475

