### PR TITLE
[Lightbox] Small tweaks

### DIFF
--- a/src/view/com/lightbox/ImageViewing/index.tsx
+++ b/src/view/com/lightbox/ImageViewing/index.tsx
@@ -62,7 +62,7 @@ const EDGES =
     ? (['top', 'bottom', 'left', 'right'] satisfies Edge[])
     : (['left', 'right'] satisfies Edge[]) // iOS, so no top/bottom safe area
 
-const SLOW_SPRING = {stiffness: 180}
+const SLOW_SPRING = {stiffness: isIOS ? 180 : 250}
 const FAST_SPRING = {stiffness: 700}
 
 export default function ImageViewRoot({

--- a/src/view/com/lightbox/ImageViewing/index.tsx
+++ b/src/view/com/lightbox/ImageViewing/index.tsx
@@ -62,7 +62,7 @@ const EDGES =
     ? (['top', 'bottom', 'left', 'right'] satisfies Edge[])
     : (['left', 'right'] satisfies Edge[]) // iOS, so no top/bottom safe area
 
-const SLOW_SPRING = {stiffness: 120}
+const SLOW_SPRING = {stiffness: 180}
 const FAST_SPRING = {stiffness: 700}
 
 export default function ImageViewRoot({
@@ -433,7 +433,7 @@ function LightboxImage({
       if (openProgress.value !== 1 || isFlyingAway.value) {
         return
       }
-      if (Math.abs(e.velocityY) > 1000) {
+      if (Math.abs(e.velocityY) > 200) {
         isFlyingAway.value = true
         if (dismissSwipeTranslateY.value === 0) {
           // HACK: If the initial value is 0, withDecay() animation doesn't start.

--- a/src/view/com/lightbox/ImageViewing/index.tsx
+++ b/src/view/com/lightbox/ImageViewing/index.tsx
@@ -442,7 +442,7 @@ function LightboxImage({
         }
         dismissSwipeTranslateY.value = withDecay({
           velocity: e.velocityY,
-          velocityFactor: Math.max(3000 / Math.abs(e.velocityY), 1), // Speed up if it's too slow.
+          velocityFactor: Math.max(3500 / Math.abs(e.velocityY), 1), // Speed up if it's too slow.
           deceleration: 1, // Danger! This relies on the reaction below stopping it.
         })
       } else {

--- a/src/view/com/util/List.tsx
+++ b/src/view/com/util/List.tsx
@@ -8,6 +8,7 @@ import {useDedupe} from '#/lib/hooks/useDedupe'
 import {useScrollHandlers} from '#/lib/ScrollContext'
 import {addStyle} from '#/lib/styles'
 import {isIOS} from '#/platform/detection'
+import {useLightbox} from '#/state/lightbox'
 import {useTheme} from '#/alf'
 import {FlatList_INTERNAL} from './Views'
 
@@ -52,6 +53,7 @@ function ListImpl<ItemT>(
   const isScrolledDown = useSharedValue(false)
   const t = useTheme()
   const dedupe = useDedupe(400)
+  const {activeLightbox} = useLightbox()
 
   function handleScrolledDownChange(didScrollDown: boolean) {
     onScrolledDownChange?.(didScrollDown)
@@ -143,6 +145,7 @@ function ListImpl<ItemT>(
       contentOffset={contentOffset}
       refreshControl={refreshControl}
       onScroll={scrollHandler}
+      scrollsToTop={!activeLightbox}
       scrollEventThrottle={1}
       onViewableItemsChanged={onViewableItemsChanged}
       viewabilityConfig={viewabilityConfig}


### PR DESCRIPTION
- Tweak lightbox animations to have smaller durations
- Smaller velocity threshold for the dismiss gesture
- Disable iOS "scroll to top" while lightbox is active to prevent unintentional feed scrolls