### PR TITLE
Make `ToggleButton` full width everywhere

### DIFF
--- a/src/components/forms/ToggleButton.tsx
+++ b/src/components/forms/ToggleButton.tsx
@@ -95,9 +95,6 @@ function ButtonInner({children}: React.PropsWithChildren<{}>) {
         native({
           paddingBottom: 10,
         }),
-        a.w_full,
-        a.h_full,
-        a.justify_center,
         a.px_md,
         t.atoms.bg,
         t.atoms.border_contrast_low,

--- a/src/components/forms/ToggleButton.tsx
+++ b/src/components/forms/ToggleButton.tsx
@@ -95,6 +95,9 @@ function ButtonInner({children}: React.PropsWithChildren<{}>) {
         native({
           paddingBottom: 10,
         }),
+        a.w_full,
+        a.h_full,
+        a.justify_center,
         a.px_md,
         t.atoms.bg,
         t.atoms.border_contrast_low,

--- a/src/components/moderation/LabelPreference.tsx
+++ b/src/components/moderation/LabelPreference.tsx
@@ -22,7 +22,7 @@ export function Outer({children}: React.PropsWithChildren<{}>) {
     <View
       style={[
         a.flex_row,
-        a.gap_md,
+        a.gap_sm,
         a.px_lg,
         a.py_lg,
         a.justify_between,
@@ -74,10 +74,9 @@ export function Buttons({
   hideLabel?: string
 }) {
   const {_} = useLingui()
-  const {gtPhone} = useBreakpoints()
 
   return (
-    <View style={[{minHeight: 35}, gtPhone ? undefined : a.w_full]}>
+    <View style={[{minHeight: 35}, a.w_full]}>
       <ToggleButton.Group
         label={_(
           msg`Configure content filtering setting for category: ${name}`,
@@ -259,7 +258,7 @@ export function LabelerLabelPreference({
       </Content>
 
       {showConfig && (
-        <View style={[gtPhone ? undefined : a.w_full]}>
+        <>
           {cantConfigure ? (
             <View
               style={[
@@ -290,7 +289,7 @@ export function LabelerLabelPreference({
               hideLabel={hideLabel}
             />
           )}
-        </View>
+        </>
       )}
     </Outer>
   )


### PR DESCRIPTION
Can't find a perfect way to handle these in all cases, so to retain flexibility and not break layouts, let's just make these full-width. We may also investigate a different pattern for mod settings in the near future.

![CleanShot 2024-11-13 at 12 37 39@2x](https://github.com/user-attachments/assets/e93e5a19-f7d6-4c76-9e66-880f97db1895)
