### PR TITLE
Increase strength of check for post stats guard

### DIFF
--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -382,9 +382,9 @@ let PostThreadItemLoaded = ({
               translatorUrl={translatorUrl}
               needsTranslation={needsTranslation}
             />
-            {post.repostCount !== 0 ||
-            post.likeCount !== 0 ||
-            post.quoteCount !== 0 ? (
+            {(typeof post.repostCount === 'number' && post.repostCount !== 0) ||
+            (typeof post.likeCount === 'number' && post.likeCount !== 0) ||
+            (typeof post.quoteCount === 'number' && post.quoteCount !== 0) ? (
               // Show this section unless we're *sure* it has no engagement.
               <View
                 style={[


### PR DESCRIPTION
Some folks noticed during the outage earlier today that `quoteCount` wasn't returned on responses, which caused this section to display with no contents. This PR checks for the existence of these values, and the only shows the section if any of the values are > 0.

This should be a very rare case.