### PR TITLE
Add clear all search history

### DIFF
--- a/src/components/ClearSearchHistory.tsx
+++ b/src/components/ClearSearchHistory.tsx
@@ -1,0 +1,140 @@
+import React, {useCallback,useEffect, useRef, useState} from 'react'
+import {Animated, Pressable} from 'react-native'
+import {msg} from '@lingui/macro'
+import {useLingui} from '@lingui/react'
+
+import {HITSLOP_10} from '#/lib/constants'
+import {isWeb} from '#/platform/detection'
+import {Text} from '#/view/com/util/text/Text'
+import {atoms as a, useTheme} from '#/alf'
+import {ButtonIcon} from '#/components/Button'
+import {TimesLarge_Stroke2_Corner0_Rounded as X} from '#/components/icons/Times'
+
+interface ClearButtonProps {
+  onClear: () => void
+}
+
+export const ClearButton = ({onClear}: ClearButtonProps): React.ReactNode => {
+  const t = useTheme()
+  const {_} = useLingui()
+  const [isExpanded, setIsExpanded] = useState(false)
+  const widthAnim = useRef(new Animated.Value(32)).current
+  const fadeIconAnim = useRef(new Animated.Value(1)).current
+  const fadeTextAnim = useRef(new Animated.Value(0)).current
+  const timeoutRef = React.useRef<NodeJS.Timeout | undefined>()
+
+  const animate = useCallback(
+    (expand: boolean) => {
+      Animated.parallel([
+        Animated.spring(widthAnim, {
+          toValue: expand ? 65 : 32,
+          useNativeDriver: false,
+          friction: 8,
+          tension: 40,
+        }),
+        Animated.timing(fadeIconAnim, {
+          toValue: expand ? 0 : 1,
+          duration: 200,
+          useNativeDriver: true,
+        }),
+        Animated.timing(fadeTextAnim, {
+          toValue: expand ? 1 : 0,
+          duration: 200,
+          useNativeDriver: true,
+        }),
+      ]).start()
+    },
+    [widthAnim, fadeIconAnim, fadeTextAnim],
+  )
+
+  const toggleExpand = (event: any) => {
+    event?.stopPropagation?.()
+    if (!isExpanded) {
+      setIsExpanded(true)
+      animate(true)
+      timeoutRef.current = setTimeout(() => {
+        collapse()
+      }, 5000)
+    } else {
+      handleClear()
+    }
+  }
+
+  const collapse = useCallback(() => {
+    animate(false)
+    setTimeout(() => setIsExpanded(false), 300)
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current)
+      timeoutRef.current = undefined
+    }
+  }, [animate])
+
+  const handleClear = () => {
+    onClear()
+    collapse()
+  }
+
+  useEffect(() => {
+    if (!isWeb || !isExpanded) return
+
+    const handleClickOutside = (event: MouseEvent) => {
+      const element = event.target as Element
+      if (element.closest('[data-testid="clearHistoryBtn"]')) return
+      collapse()
+    }
+
+    requestAnimationFrame(() => {
+      window.addEventListener('click', handleClickOutside)
+    })
+
+    return () => {
+      window.removeEventListener('click', handleClickOutside)
+    }
+  }, [collapse, isExpanded])
+
+  return (
+    <Pressable
+      testID="clearHistoryBtn"
+      onPress={toggleExpand}
+      hitSlop={HITSLOP_10}
+      accessibilityLabel={_(msg`Clear all recent searches`)}
+      accessibilityHint={_(
+        msg`Removes all search history and recently viewed profiles`,
+      )}
+      style={[a.flex_row, a.justify_end]}>
+      <Animated.View
+        style={{
+          width: widthAnim,
+        }}>
+        <Animated.View
+          style={[
+            a.rounded_full,
+            {
+              backgroundColor: t.atoms.bg_contrast_25.backgroundColor,
+              height: 28,
+              width: '100%',
+              flexDirection: 'row',
+              alignItems: 'center',
+              justifyContent: 'center',
+              paddingHorizontal: 8,
+            },
+          ]}>
+          <Animated.View
+            style={{
+              opacity: fadeIconAnim,
+              position: 'absolute',
+            }}>
+            <ButtonIcon icon={X} size="xs" />
+          </Animated.View>
+          <Animated.View
+            style={{
+              opacity: fadeTextAnim,
+              position: 'absolute',
+            }}>
+            <Text style={[{color: t.atoms.text.color}]}>Clear</Text>
+          </Animated.View>
+        </Animated.View>
+      </Animated.View>
+    </Pressable>
+  )
+}

--- a/src/components/ClearSearchHistory.tsx
+++ b/src/components/ClearSearchHistory.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback,useEffect, useRef, useState} from 'react'
+import React, {useCallback, useEffect, useRef, useState} from 'react'
 import {Animated, Pressable} from 'react-native'
 import {msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'

--- a/src/components/ClearSearchHistory.tsx
+++ b/src/components/ClearSearchHistory.tsx
@@ -10,128 +10,114 @@ import {atoms as a, useTheme} from '#/alf'
 import {ButtonIcon} from '#/components/Button'
 import {TimesLarge_Stroke2_Corner0_Rounded as X} from '#/components/icons/Times'
 
-interface ClearButtonProps {
+export const ClearButton = ({
+  onClear,
+}: {
   onClear: () => void
-}
-
-export const ClearButton = ({onClear}: ClearButtonProps): React.ReactNode => {
+}): React.ReactNode => {
   const t = useTheme()
   const {_} = useLingui()
   const [isExpanded, setIsExpanded] = useState(false)
-  const widthAnim = useRef(new Animated.Value(32)).current
-  const fadeIconAnim = useRef(new Animated.Value(1)).current
-  const fadeTextAnim = useRef(new Animated.Value(0)).current
-  const timeoutRef = React.useRef<NodeJS.Timeout | undefined>()
+  const animations = useRef({
+    width: new Animated.Value(32),
+    iconOpacity: new Animated.Value(1),
+    textOpacity: new Animated.Value(0),
+  }).current
+  const timeoutRef = useRef<NodeJS.Timeout>()
 
   const animate = useCallback(
     (expand: boolean) => {
       Animated.parallel([
-        Animated.spring(widthAnim, {
+        Animated.spring(animations.width, {
           toValue: expand ? 65 : 32,
           useNativeDriver: false,
           friction: 8,
           tension: 40,
         }),
-        Animated.timing(fadeIconAnim, {
+        Animated.timing(animations.iconOpacity, {
           toValue: expand ? 0 : 1,
           duration: 200,
           useNativeDriver: true,
         }),
-        Animated.timing(fadeTextAnim, {
+        Animated.timing(animations.textOpacity, {
           toValue: expand ? 1 : 0,
           duration: 200,
           useNativeDriver: true,
         }),
       ]).start()
     },
-    [widthAnim, fadeIconAnim, fadeTextAnim],
+    [animations],
   )
-
-  const toggleExpand = (event: any) => {
-    event?.stopPropagation?.()
-    if (!isExpanded) {
-      setIsExpanded(true)
-      animate(true)
-      timeoutRef.current = setTimeout(() => {
-        collapse()
-      }, 5000)
-    } else {
-      handleClear()
-    }
-  }
 
   const collapse = useCallback(() => {
     animate(false)
     setTimeout(() => setIsExpanded(false), 300)
-    if (timeoutRef.current) {
-      clearTimeout(timeoutRef.current)
-      timeoutRef.current = undefined
-    }
+    clearTimeout(timeoutRef.current)
   }, [animate])
 
-  const handleClear = () => {
-    onClear()
-    collapse()
-  }
+  const handlePress = useCallback(
+    (event?: any) => {
+      event?.stopPropagation?.()
+      if (!isExpanded) {
+        setIsExpanded(true)
+        animate(true)
+        timeoutRef.current = setTimeout(collapse, 5000)
+      } else {
+        onClear()
+        collapse()
+      }
+    },
+    [isExpanded, animate, collapse, onClear],
+  )
 
   useEffect(() => {
     if (!isWeb || !isExpanded) return
 
     const handleClickOutside = (event: MouseEvent) => {
-      const element = event.target as Element
-      if (element.closest('[data-testid="clearHistoryBtn"]')) return
-      collapse()
+      if (
+        !(event.target as Element).closest('[data-testid="clearHistoryBtn"]')
+      ) {
+        collapse()
+      }
     }
 
-    requestAnimationFrame(() => {
-      window.addEventListener('click', handleClickOutside)
-    })
-
-    return () => {
-      window.removeEventListener('click', handleClickOutside)
-    }
+    requestAnimationFrame(() =>
+      window.addEventListener('click', handleClickOutside),
+    )
+    return () => window.removeEventListener('click', handleClickOutside)
   }, [collapse, isExpanded])
 
   return (
     <Pressable
       testID="clearHistoryBtn"
-      onPress={toggleExpand}
+      onPress={handlePress}
       hitSlop={HITSLOP_10}
       accessibilityLabel={_(msg`Clear all recent searches`)}
       accessibilityHint={_(
         msg`Removes all search history and recently viewed profiles`,
       )}
       style={[a.flex_row, a.justify_end]}>
-      <Animated.View
-        style={{
-          width: widthAnim,
-        }}>
+      <Animated.View style={{width: animations.width}}>
         <Animated.View
           style={[
             a.rounded_full,
             {
               backgroundColor: t.atoms.bg_contrast_25.backgroundColor,
               height: 28,
-              width: '100%',
               flexDirection: 'row',
               alignItems: 'center',
               justifyContent: 'center',
               paddingHorizontal: 8,
+              width: '100%',
             },
           ]}>
           <Animated.View
-            style={{
-              opacity: fadeIconAnim,
-              position: 'absolute',
-            }}>
+            style={{opacity: animations.iconOpacity, position: 'absolute'}}>
             <ButtonIcon icon={X} size="xs" />
           </Animated.View>
           <Animated.View
-            style={{
-              opacity: fadeTextAnim,
-              position: 'absolute',
-            }}>
-            <Text style={[{color: t.atoms.text.color}]}>Clear</Text>
+            style={{opacity: animations.textOpacity, position: 'absolute'}}>
+            <Text style={{color: t.atoms.text.color}}>Clear</Text>
           </Animated.View>
         </Animated.View>
       </Animated.View>

--- a/src/view/screens/Search/Search.tsx
+++ b/src/view/screens/Search/Search.tsx
@@ -61,6 +61,7 @@ import {SearchLinkCard, SearchProfileCard} from '#/view/shell/desktop/Search'
 import {makeSearchQuery, parseSearchQuery} from '#/screens/Search/utils'
 import {atoms as a, useBreakpoints, useTheme as useThemeNew, web} from '#/alf'
 import {Button, ButtonIcon, ButtonText} from '#/components/Button'
+import {ClearButton} from '#/components/ClearSearchHistory'
 import * as FeedCard from '#/components/FeedCard'
 import {SearchInput} from '#/components/forms/SearchInput'
 import {ChevronBottom_Stroke2_Corner0_Rounded as ChevronDown} from '#/components/icons/Chevron'
@@ -1068,23 +1069,11 @@ function SearchHistory({
       <View style={styles.searchHistoryContainer}>
         {(searchHistory.length > 0 || selectedProfiles.length > 0) && (
           <View
-            style={[a.flex_row, a.justify_between, a.align_center, a.px_md]}>
+            style={[a.flex_row, a.justify_between, a.align_center, a.pr_md]}>
             <Text style={[pal.text, styles.searchHistoryTitle]}>
               <Trans>Recent Searches</Trans>
             </Text>
-            <Pressable
-              accessibilityRole="button"
-              accessibilityLabel={_(msg`Clear all recent searches`)}
-              accessibilityHint={_(
-                msg`Removes all search history and recently viewed profiles`,
-              )}
-              onPress={onRemoveAllClick}
-              hitSlop={HITSLOP_10}
-              style={[a.py_sm, a.px_md]}>
-              <Text style={[pal.text, {opacity: 0.75, fontSize: 14}]}>
-                Clear all
-              </Text>
-            </Pressable>
+            <ClearButton onClear={onRemoveAllClick} />
           </View>
         )}
         {selectedProfiles.length > 0 && (

--- a/src/view/screens/Search/Search.tsx
+++ b/src/view/screens/Search/Search.tsx
@@ -845,6 +845,17 @@ export function SearchScreen(
     [selectedProfiles],
   )
 
+  const handleRemoveAllSearches = React.useCallback(async () => {
+    setSearchHistory([])
+    setSelectedProfiles([])
+
+    await AsyncStorage.multiRemove(['searchHistory', 'selectedProfiles']).catch(
+      e => {
+        logger.error('Failed to clear search history', {message: e})
+      },
+    )
+  }, [])
+
   const onSearchInputFocus = React.useCallback(() => {
     if (isWeb) {
       // Prevent a jump on iPad by ensuring that
@@ -949,6 +960,7 @@ export function SearchScreen(
             onProfileClick={handleProfileClick}
             onRemoveItemClick={handleRemoveHistoryItem}
             onRemoveProfileClick={handleRemoveProfile}
+            onRemoveAllClick={handleRemoveAllSearches}
           />
         )}
       </View>
@@ -1032,6 +1044,7 @@ function SearchHistory({
   onProfileClick,
   onRemoveItemClick,
   onRemoveProfileClick,
+  onRemoveAllClick,
 }: {
   searchHistory: string[]
   selectedProfiles: AppBskyActorDefs.ProfileViewBasic[]
@@ -1039,6 +1052,7 @@ function SearchHistory({
   onProfileClick: (profile: AppBskyActorDefs.ProfileViewBasic) => void
   onRemoveItemClick: (item: string) => void
   onRemoveProfileClick: (profile: AppBskyActorDefs.ProfileViewBasic) => void
+  onRemoveAllClick: () => void
 }) {
   const {isTabletOrDesktop, isMobile} = useWebMediaQueries()
   const pal = usePalette('default')
@@ -1053,9 +1067,25 @@ function SearchHistory({
       }}>
       <View style={styles.searchHistoryContainer}>
         {(searchHistory.length > 0 || selectedProfiles.length > 0) && (
-          <Text style={[pal.text, styles.searchHistoryTitle]}>
-            <Trans>Recent Searches</Trans>
-          </Text>
+          <View
+            style={[a.flex_row, a.justify_between, a.align_center, a.px_md]}>
+            <Text style={[pal.text, styles.searchHistoryTitle]}>
+              <Trans>Recent Searches</Trans>
+            </Text>
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel={_(msg`Clear all recent searches`)}
+              accessibilityHint={_(
+                msg`Removes all search history and recently viewed profiles`,
+              )}
+              onPress={onRemoveAllClick}
+              hitSlop={HITSLOP_10}
+              style={[a.py_sm, a.px_md]}>
+              <Text style={[pal.text, {opacity: 0.75, fontSize: 14}]}>
+                Clear all
+              </Text>
+            </Pressable>
+          </View>
         )}
         {selectedProfiles.length > 0 && (
           <View


### PR DESCRIPTION
closes #4700

Added a button on search page to remove search history
Not sure if this is the best way to implement it, X button expands into 'Clear all'
Expanded button collapses after 5s. On web it closes on an outside click (could not get it to work on mobile, realised search input does not get blurred on outside click on mobile as well)

| collapsed | expanded |
|--------|-------|
|![Simulator Screenshot - iPhone 16 - 2024-11-14 at 02 06 43](https://github.com/user-attachments/assets/cf92d9a6-f69e-4210-ba11-eab93b736a93)|![Simulator Screenshot - iPhone 16 - 2024-11-14 at 02 06 59](https://github.com/user-attachments/assets/2e49700c-2165-40fc-ae76-d19aa141c58e)|