### PR TITLE
NewChatDialog: remove extra padding on web

### DIFF
--- a/src/components/dms/dialogs/SearchablePeopleList.tsx
+++ b/src/components/dms/dialogs/SearchablePeopleList.tsx
@@ -278,7 +278,7 @@ export function SearchablePeopleList({
           ) : null}
         </View>
 
-        <View style={[, web([a.pt_xs])]}>
+        <View style={web([a.pt_xs])}>
           <SearchInput
             inputRef={inputRef}
             value={searchText}
@@ -313,6 +313,7 @@ export function SearchablePeopleList({
         web([a.py_0, {height: '100vh', maxHeight: 600}, a.px_0]),
         native({height: '100%'}),
       ]}
+      webInnerContentContainerStyle={a.py_0}
       webInnerStyle={[a.py_0, {maxWidth: 500, minWidth: 200}]}
       keyboardDismissMode="on-drag"
     />


### PR DESCRIPTION
# Why

Spotted that "New Chat" dialog container includes an extra padding on the web, which seems unintended. It also causes a visual clipping at the end of the users list.

<img src="https://github.com/user-attachments/assets/121cfca9-f74b-4240-a69d-a6b5d8436eb4" width="380" align="left" />
<img src="https://github.com/user-attachments/assets/d63a729a-000e-4cdf-accd-ed89d32cc945"  width="380" />

# How

Modify the default inner container style for web by `webInnerContentContainerStyle` prop.

This fix also applies to `SendViaChat` dialog.

# Test Plan

Tested the changes by running app locally, made sure that the new styles does not affect native platforms.

# Preview

![Screenshot 2024-11-14 at 14 31 39](https://github.com/user-attachments/assets/64b542f3-b6ed-4589-8c42-aa0273d9c2bd)

