### PR TITLE
Tweak shared element animation to make it much smoother

### DIFF
--- a/src/view/com/lightbox/ImageViewing/index.tsx
+++ b/src/view/com/lightbox/ImageViewing/index.tsx
@@ -32,6 +32,7 @@ import Animated, {
   useSharedValue,
   withDecay,
   withSpring,
+  WithSpringConfig,
 } from 'react-native-reanimated'
 import {
   Edge,
@@ -62,8 +63,18 @@ const EDGES =
     ? (['top', 'bottom', 'left', 'right'] satisfies Edge[])
     : (['left', 'right'] satisfies Edge[]) // iOS, so no top/bottom safe area
 
-const SLOW_SPRING = {stiffness: isIOS ? 180 : 250}
-const FAST_SPRING = {stiffness: 700}
+const SLOW_SPRING: WithSpringConfig = {
+  mass: isIOS ? 1.5 : 1,
+  damping: 300,
+  stiffness: 800,
+  restDisplacementThreshold: 0.01,
+}
+const FAST_SPRING: WithSpringConfig = {
+  mass: isIOS ? 1.5 : 1,
+  damping: 150,
+  stiffness: 900,
+  restDisplacementThreshold: 0.01,
+}
 
 export default function ImageViewRoot({
   lightbox: nextLightbox,
@@ -706,7 +717,7 @@ function interpolateTransform(
   }
 }
 
-function withClampedSpring(value: any, {stiffness}: {stiffness: number}) {
+function withClampedSpring(value: any, config: WithSpringConfig) {
   'worklet'
-  return withSpring(value, {overshootClamping: true, stiffness})
+  return withSpring(value, {...config, overshootClamping: true})
 }


### PR DESCRIPTION
It always felt off to me, so I wanted to change it. lmk ur thoughts on this PR.

<table>
<tr>
<th>Before</th>
<th>After</th>

<tr>
<td>

https://github.com/user-attachments/assets/991013cd-68ad-4bd6-8d24-25f42fb11f56

</td>

<td>

https://github.com/user-attachments/assets/8d13a4ca-917c-4e2d-af11-df414f21801f


</td>
</tr>
<tr>
<td>


https://github.com/user-attachments/assets/5671fb47-1576-40d1-9db0-56790380c062



</td>

<td>



https://github.com/user-attachments/assets/0a19d2bb-33ba-4bf1-b7b9-ee4c8770418e



</td>
</tr>
</table>

sorry I'm a bit perfectionistic when it comes to animations. 