### PR TITLE
Better error message (+ translations!)

### DIFF
--- a/src/lib/strings/errors.ts
+++ b/src/lib/strings/errors.ts
@@ -1,3 +1,5 @@
+import {t} from '@lingui/macro'
+
 export function cleanError(str: any): string {
   if (!str) {
     return ''
@@ -6,17 +8,17 @@ export function cleanError(str: any): string {
     str = str.toString()
   }
   if (isNetworkError(str)) {
-    return 'Unable to connect. Please check your internet connection and try again.'
+    return t`Unable to connect. Please check your internet connection and try again.`
   }
   if (
     str.includes('Upstream Failure') ||
     str.includes('NotEnoughResources') ||
     str.includes('pipethrough network error')
   ) {
-    return 'The server appears to be experiencing issues. Please try again in a few moments.'
+    return t`The server appears to be experiencing issues. Please try again in a few moments.`
   }
   if (str.includes('Bad token scope')) {
-    return 'This feature is not available while using an App Password. Please sign in with your main password.'
+    return t`This feature is not available while using an App Password. Please sign in with your main password.`
   }
   if (str.startsWith('Error: ')) {
     return str.slice('Error: '.length)

--- a/src/lib/strings/errors.ts
+++ b/src/lib/strings/errors.ts
@@ -8,7 +8,11 @@ export function cleanError(str: any): string {
   if (isNetworkError(str)) {
     return 'Unable to connect. Please check your internet connection and try again.'
   }
-  if (str.includes('Upstream Failure')) {
+  if (
+    str.includes('Upstream Failure') ||
+    str.includes('NotEnoughResources') ||
+    str.includes('pipethrough network error')
+  ) {
     return 'The server appears to be experiencing issues. Please try again in a few moments.'
   }
   if (str.includes('Bad token scope')) {


### PR DESCRIPTION
- Added `NotEnoughResources` and `pipethrough network error` to the generic server error message
- Translated errors

imo it's fine to use the `t` macro here, since error messages should not be sticking around in the tree, and imo it's an acceptable tradeoff if maybe you see one in the wrong language immediately after switching langs, vs current behaviour

## Potential problems

Potential problems might arise from checking against the output of `cleanError` and expecting one of the now-translated strings to still be in english. however I did a cursory check of the references and it seems fine