### PR TITLE
Fix long profile name is cut off for search history on mobile

### DIFF
--- a/src/view/screens/Search/Search.tsx
+++ b/src/view/screens/Search/Search.tsx
@@ -1217,6 +1217,7 @@ const styles = StyleSheet.create({
     width: 70,
   },
   profilePressable: {
+    width: '100%',
     alignItems: 'center',
   },
   profileAvatar: {
@@ -1225,7 +1226,6 @@ const styles = StyleSheet.create({
     borderRadius: 45,
   },
   profileName: {
-    width: 78,
     fontSize: 12,
     textAlign: 'center',
     marginTop: 5,


### PR DESCRIPTION
Fixes: #6351 

1. Summary
Long profile names are cut off on mobile devices (both Android & iOS) for search history. The root cause of the issue is that the profile name/avatar container has [`70px`](https://github.com/bluesky-social/social-app/blob/5f7caf30105569fe02cda2b029d3e6cb1e4e4780/src/view/screens/Search/Search.tsx#L1216) width on mobile ([`78px`](https://github.com/bluesky-social/social-app/blob/5f7caf30105569fe02cda2b029d3e6cb1e4e4780/src/view/screens/Search/Search.tsx#L1211-L1212) on web) when the profile name width is still [`78px`](https://github.com/bluesky-social/social-app/blob/5f7caf30105569fe02cda2b029d3e6cb1e4e4780/src/view/screens/Search/Search.tsx#L1228-L1229) on both web and mobile.

2. Solution
Removed width style from profile name and set `profilePressable` width to `100%` so that it has the same width as its container (70px on mobile, 78px on web). And the profile name takes up the available space based on `profilePressable` width dynamically.

3. Screenshots
![image](https://github.com/user-attachments/assets/cec2689c-a08c-477a-a35a-847fa869cb42)

![CleanShot 2024-11-15 at 09 58 56](https://github.com/user-attachments/assets/666e4f02-ad9b-4c2e-934d-4d0934311512)
