### PR TITLE
Reduce calls to getLogs

### DIFF
--- a/src/state/messages/convo/const.ts
+++ b/src/state/messages/convo/const.ts
@@ -1,5 +1,5 @@
-export const ACTIVE_POLL_INTERVAL = 3e3
-export const MESSAGE_SCREEN_POLL_INTERVAL = 10e3
+export const ACTIVE_POLL_INTERVAL = 4e3
+export const MESSAGE_SCREEN_POLL_INTERVAL = 30e3
 export const BACKGROUND_POLL_INTERVAL = 60e3
 export const INACTIVE_TIMEOUT = 60e3 * 5
 


### PR DESCRIPTION
Stacked on #6378

Reduces poll interval for active chats from 3s to 4s, and polling on the messages list screen from 10s to 30s. Background polling doesn't matter here, all platforms pause polling when backgrounded atm.