### PR TITLE
Use native modal for signup queue screen

### DIFF
--- a/src/screens/SignupQueued.tsx
+++ b/src/screens/SignupQueued.tsx
@@ -95,7 +95,8 @@ export function SignupQueued() {
       {isIOS && <StatusBar style="light" />}
       <ScrollView
         style={[a.flex_1, t.atoms.bg]}
-        contentContainerStyle={{borderWidth: 0}}>
+        contentContainerStyle={{borderWidth: 0}}
+        bounces={false}>
         <View
           style={[
             a.flex_row,

--- a/src/screens/SignupQueued.tsx
+++ b/src/screens/SignupQueued.tsx
@@ -1,16 +1,17 @@
 import React from 'react'
-import {View} from 'react-native'
+import {Modal, View} from 'react-native'
 import {useSafeAreaInsets} from 'react-native-safe-area-context'
+import {StatusBar} from 'expo-status-bar'
 import {msg, plural, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
 import {logger} from '#/logger'
-import {isWeb} from '#/platform/detection'
+import {isIOS, isWeb} from '#/platform/detection'
 import {isSignupQueued, useAgent, useSessionApi} from '#/state/session'
 import {useOnboardingDispatch} from '#/state/shell'
 import {ScrollView} from '#/view/com/util/Views'
 import {Logo} from '#/view/icons/Logo'
-import {atoms as a, useBreakpoints, useTheme} from '#/alf'
+import {atoms as a, native, useBreakpoints, useTheme, web} from '#/alf'
 import {Button, ButtonIcon, ButtonText} from '#/components/Button'
 import {Loader} from '#/components/Loader'
 import {P, Text} from '#/components/Typography'
@@ -86,19 +87,21 @@ export function SignupQueued() {
   )
 
   return (
-    <View
-      aria-modal
-      role="dialog"
-      aria-role="dialog"
-      aria-label={_(msg`You're in line`)}
-      accessibilityLabel={_(msg`You're in line`)}
-      accessibilityHint=""
-      style={[a.absolute, a.inset_0, a.flex_1, t.atoms.bg]}>
+    <Modal
+      visible
+      animationType={native('slide')}
+      presentationStyle="formSheet"
+      style={[web(a.util_screen_outer)]}>
+      {isIOS && <StatusBar style="light" />}
       <ScrollView
-        style={[a.h_full, a.w_full, {paddingTop: insets.top}]}
+        style={[a.flex_1, t.atoms.bg]}
         contentContainerStyle={{borderWidth: 0}}>
         <View
-          style={[a.flex_row, a.justify_center, gtMobile ? a.pt_4xl : a.px_xl]}>
+          style={[
+            a.flex_row,
+            a.justify_center,
+            gtMobile ? a.pt_4xl : [a.px_xl, a.pt_xl],
+          ]}>
           <View style={[a.flex_1, {maxWidth: COL_WIDTH}]}>
             <View
               style={[a.w_full, a.justify_center, a.align_center, a.my_4xl]}>
@@ -121,11 +124,13 @@ export function SignupQueued() {
                 a.px_2xl,
                 a.py_4xl,
                 a.mt_2xl,
-                t.atoms.bg_contrast_50,
+                a.border,
+                t.atoms.bg_contrast_25,
+                t.atoms.border_contrast_medium,
               ]}>
               {typeof placeInQueue === 'number' && (
                 <Text
-                  style={[a.text_5xl, a.text_center, a.font_bold, a.mb_2xl]}>
+                  style={[a.text_5xl, a.text_center, a.font_heavy, a.mb_2xl]}>
                   {placeInQueue}
                 </Text>
               )}
@@ -148,7 +153,14 @@ export function SignupQueued() {
             </View>
 
             {isWeb && gtMobile && (
-              <View style={[a.w_full, a.flex_row, a.justify_between, a.pt_5xl]}>
+              <View
+                style={[
+                  a.w_full,
+                  a.flex_row,
+                  a.justify_between,
+                  a.pt_5xl,
+                  {paddingBottom: 200},
+                ]}>
                 <Button
                   variant="ghost"
                   size="large"
@@ -162,8 +174,6 @@ export function SignupQueued() {
               </View>
             )}
           </View>
-
-          <View style={{height: 200}} />
         </View>
       </ScrollView>
 
@@ -171,6 +181,7 @@ export function SignupQueued() {
         <View
           style={[
             a.align_center,
+            t.atoms.bg,
             gtMobile ? a.px_5xl : a.px_xl,
             {
               paddingBottom: Math.max(insets.bottom, a.pb_5xl.paddingBottom),
@@ -190,7 +201,7 @@ export function SignupQueued() {
           </View>
         </View>
       )}
-    </View>
+    </Modal>
   )
 }
 

--- a/src/screens/SignupQueued.tsx
+++ b/src/screens/SignupQueued.tsx
@@ -124,6 +124,7 @@ export function SignupQueued() {
                 a.px_2xl,
                 a.py_4xl,
                 a.mt_2xl,
+                a.mb_md,
                 a.border,
                 t.atoms.bg_contrast_25,
                 t.atoms.border_contrast_medium,

--- a/src/screens/SignupQueued.tsx
+++ b/src/screens/SignupQueued.tsx
@@ -95,7 +95,7 @@ export function SignupQueued() {
       accessibilityHint=""
       style={[a.absolute, a.inset_0, a.flex_1, t.atoms.bg]}>
       <ScrollView
-        style={[a.h_full, a.w_full]}
+        style={[a.h_full, a.w_full, {paddingTop: insets.top}]}
         contentContainerStyle={{borderWidth: 0}}>
         <View
           style={[a.flex_row, a.justify_center, gtMobile ? a.pt_4xl : a.px_xl]}>


### PR DESCRIPTION
The signup queue has slightly broken styles - no top inset, and the log out button is overlaid on top of the bottom bar, which shouldn't be visible at all

<img src=https://github.com/user-attachments/assets/f0d7036e-6b06-4fb1-ab02-4c4cf70af2c7 width=200>

We can fix this by using a nice native modal, which also makes it feel a lot nicer - it includes entry/exit animations and feels more like a "gate"

Also includes minor style tweaks like a border on the gray box

# iOS

https://github.com/user-attachments/assets/b028b8fc-dd6d-4e4a-a0b4-bf233d8382b6

# Android

https://github.com/user-attachments/assets/dc0379e1-13d7-4e63-8ac8-56fededf6cac

# Test plan

in `src/state/session/util.ts` replace `isSignupQueued` with

```
let temp = true

export function isSignupQueued(accessJwt: string | undefined) {
  if (accessJwt) {
    setTimeout(() => {
      temp = false
    }, 10000)

    return temp
  }
  return false
}
```

This will show the gate initially and after 10 seconds, will let you past when you press the button. If you want a "real" test, sign out beforehand and then go through the signup flow

Test all 3 platforms. Make sure there's no weirdness of the modal on android (there shouldn't be, since everything is very simple here, no gesture/keyboard bullshit)
