### PR TITLE
Remove aria-pressed attr from button. Closes #6325

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -458,7 +458,6 @@ export const Button = React.forwardRef<View, ButtonProps>(
         // @ts-ignore - this will always be a pressable
         ref={ref}
         aria-label={label}
-        aria-pressed={state.pressed}
         accessibilityLabel={label}
         disabled={disabled || false}
         accessibilityState={{


### PR DESCRIPTION
Removes aria-pressed attr from button element as this attribute is [designed for usage with checkbox inputs](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-pressed). Closes #6325 