### PR TITLE
Manually implement `drawerType` logic

### DIFF
--- a/src/view/shell/index.tsx
+++ b/src/view/shell/index.tsx
@@ -105,6 +105,7 @@ function ShellInner() {
             onOpen={onOpenDrawer}
             onClose={onCloseDrawer}
             swipeEdgeWidth={winDim.width / 2}
+            drawerType={isIOS ? 'slide' : 'front'}
             swipeEnabled={!canGoBack && hasSession && !isDrawerSwipeDisabled}
             overlayStyle={{
               backgroundColor: select(t.name, {


### PR DESCRIPTION
Seems like when upgrading react-native-drawer-layout there was a regression where `drawerType` is always `front` despite what the docs say. It should be `slide` on iOS

# Test plan

Confirm that it is indeed broken on iOS without this change
Confirm this change fixes it