### PR TITLE
Sort pins last in thread view

### DIFF
--- a/src/state/queries/post-thread.ts
+++ b/src/state/queries/post-thread.ts
@@ -216,6 +216,17 @@ export function sortThread(
         }
       }
 
+      const aPin = Boolean(a.record.text.trim() === '📌')
+      const bPin = Boolean(b.record.text.trim() === '📌')
+      if (aPin !== bPin) {
+        if (aPin) {
+          return 1
+        }
+        if (bPin) {
+          return -1
+        }
+      }
+
       if (opts.prioritizeFollowedUsers) {
         const af = a.post.author.viewer?.following
         const bf = b.post.author.viewer?.following


### PR DESCRIPTION
Only affects non-self posts. Own posts are still bumped to the top.

## Before

https://github.com/user-attachments/assets/719cf1ad-ccd7-4cf1-877e-69476f77f9c2

## After

https://github.com/user-attachments/assets/b50c5c91-ef24-473f-aa5e-9c69bafe802f

