### PR TITLE
[Web] Clicking root link twice refreshes the screen

### DIFF
--- a/src/view/com/util/Link.tsx
+++ b/src/view/com/util/Link.tsx
@@ -403,19 +403,21 @@ function onPressInner(
       closeModal() // close any active modals
 
       const [routeName, params] = router.matchPath(href)
-      const state = navigation.getState()
-      const tabState = getTabState(state, routeName)
-      if (tabState === TabState.InsideAtRoot) {
-        emitSoftReset()
-      } else if (navigationAction === 'push') {
+      if (navigationAction === 'push') {
         // @ts-ignore we're not able to type check on this one -prf
         navigation.dispatch(StackActions.push(routeName, params))
       } else if (navigationAction === 'replace') {
         // @ts-ignore we're not able to type check on this one -prf
         navigation.dispatch(StackActions.replace(routeName, params))
       } else if (navigationAction === 'navigate') {
-        // @ts-ignore we're not able to type check on this one -prf
-        navigation.navigate(routeName, params)
+        const state = navigation.getState()
+        const tabState = getTabState(state, routeName)
+        if (tabState === TabState.InsideAtRoot) {
+          emitSoftReset()
+        } else {
+          // @ts-ignore we're not able to type check on this one -prf
+          navigation.navigate(routeName, params)
+        }
       } else {
         throw Error('Unsupported navigator action.')
       }

--- a/src/view/com/util/Link.tsx
+++ b/src/view/com/util/Link.tsx
@@ -18,6 +18,7 @@ import {
   useNavigationDeduped,
 } from '#/lib/hooks/useNavigationDeduped'
 import {useOpenLink} from '#/lib/hooks/useOpenLink'
+import {getTabState, TabState} from '#/lib/routes/helpers'
 import {
   convertBskyAppUrlIfNeeded,
   isExternalUrl,
@@ -25,6 +26,7 @@ import {
 } from '#/lib/strings/url-helpers'
 import {TypographyVariant} from '#/lib/ThemeContext'
 import {isAndroid, isWeb} from '#/platform/detection'
+import {emitSoftReset} from '#/state/events'
 import {useModalControls} from '#/state/modals'
 import {WebAuxClickWrapper} from '#/view/com/util/WebAuxClickWrapper'
 import {useTheme} from '#/alf'
@@ -400,15 +402,20 @@ function onPressInner(
     } else {
       closeModal() // close any active modals
 
-      if (navigationAction === 'push') {
+      const [routeName, params] = router.matchPath(href)
+      const state = navigation.getState()
+      const tabState = getTabState(state, routeName)
+      if (tabState === TabState.InsideAtRoot) {
+        emitSoftReset()
+      } else if (navigationAction === 'push') {
         // @ts-ignore we're not able to type check on this one -prf
-        navigation.dispatch(StackActions.push(...router.matchPath(href)))
+        navigation.dispatch(StackActions.push(routeName, params))
       } else if (navigationAction === 'replace') {
         // @ts-ignore we're not able to type check on this one -prf
-        navigation.dispatch(StackActions.replace(...router.matchPath(href)))
+        navigation.dispatch(StackActions.replace(routeName, params))
       } else if (navigationAction === 'navigate') {
         // @ts-ignore we're not able to type check on this one -prf
-        navigation.navigate(...router.matchPath(href))
+        navigation.navigate(routeName, params)
       } else {
         throw Error('Unsupported navigator action.')
       }


### PR DESCRIPTION
This adds the "soft reset" behavior to the web version of the `Link` component used by the bottom tab bar, bringing it in correspondence with [similar native logic](https://github.com/bluesky-social/social-app/blob/3c30bb1d358c6544170b8d334c5ee0530020a566/src/view/shell/bottom-bar/BottomBar.tsx#L91-L94). As a result, tapping on bottom bar icons on mobile web _while already in that tab_ finally refreshes the content. Previously, the content would not refresh, which was both inconsistent with the mobile apps and misleading. (Previously you had to tap the "show new" button to make any new notifications show up, for example.)

I initially thought I would add it to `BottomBarWeb.tsx` but this wasn't feasible because of how the decision to handle new tab vs same tab links is structured. This seemed like the most natural place to add it with the current link component wiring. In practice this will still only apply to the bottom bar because it's the only place that has `navigationAction="navigate"`. Scoping this to the tabbar buttons is important because soft reset wouldn't be enough for cases like `/search?q=foo`.

## Test Plan

Confirm that bottom bar on mobile web now works like native bottom bar.

Confirm other usages of this `Link` component (e.g. "Search for foo" in autocomplete on Search page) works like before.

### Before

Notifications don't reload on subsequent clicks:

https://github.com/user-attachments/assets/a445eef5-8766-47c9-b527-2d0bacf4b670

Home doesn't scroll up / refresh on subsequent clicks:

https://github.com/user-attachments/assets/2810e541-24c8-46ce-be2d-67dd34e3e7ad

### After

It works like in the mobile apps. Repeated taps on the tab bar buttons emit soft refresh.

https://github.com/user-attachments/assets/e82ae1cf-8c5b-4bd0-8092-5471d7034209
