### PR TITLE
StarterPackPreferences View & Screen implementation

### DIFF
--- a/src/Navigation.tsx
+++ b/src/Navigation.tsx
@@ -98,6 +98,7 @@ import {FollowingFeedPreferencesScreen} from './screens/Settings/FollowingFeedPr
 import {LanguageSettingsScreen} from './screens/Settings/LanguageSettings'
 import {PrivacyAndSecuritySettingsScreen} from './screens/Settings/PrivacyAndSecuritySettings'
 import {SettingsScreen} from './screens/Settings/Settings'
+import {StarterPacksPreferencesScreen} from './screens/Settings/StarterPacksPreferences'
 import {ThreadPreferencesScreen} from './screens/Settings/ThreadPreferences'
 
 const navigationRef = createNavigationContainerRef<AllNavigatorParams>()
@@ -313,6 +314,11 @@ function commonScreens(Stack: typeof HomeTab, unreadCountLabel?: string) {
           title: title(msg`External Media Preferences`),
           requireAuth: true,
         }}
+      />
+      <Stack.Screen
+        name="PreferencesStarterPacks"
+        getComponent={() => StarterPacksPreferencesScreen}
+        options={{title: title(msg`Starter Packs`), requireAuth: true}}
       />
       <Stack.Screen
         name="AccessibilitySettings"

--- a/src/components/StarterPack/StarterPackCard.tsx
+++ b/src/components/StarterPack/StarterPackCard.tsx
@@ -18,13 +18,24 @@ import {Text} from '#/components/Typography'
 
 export function Default({
   starterPack,
+  noIcon,
+  noAuthorInfo,
+  noDescription,
 }: {
   starterPack?: AppBskyGraphDefs.StarterPackViewBasic
+  noIcon?: boolean
+  noAuthorInfo?: boolean
+  noDescription?: boolean
 }) {
   if (!starterPack) return null
   return (
     <Link starterPack={starterPack}>
-      <Card starterPack={starterPack} />
+      <Card
+        starterPack={starterPack}
+        noIcon={noIcon}
+        noAuthorInfo={noAuthorInfo}
+        noDescription={noDescription}
+      />
     </Link>
   )
 }
@@ -45,10 +56,12 @@ export function Notification({
 export function Card({
   starterPack,
   noIcon,
+  noAuthorInfo,
   noDescription,
 }: {
   starterPack: AppBskyGraphDefs.StarterPackViewBasic
   noIcon?: boolean
+  noAuthorInfo?: boolean
   noDescription?: boolean
 }) {
   const {record, creator, joinedAllTimeCount} = starterPack
@@ -63,7 +76,7 @@ export function Card({
 
   return (
     <View style={[a.w_full, a.gap_md]}>
-      <View style={[a.flex_row, a.gap_sm, a.w_full]}>
+      <View style={[a.flex_row, a.align_center, a.gap_sm, a.w_full]}>
         {!noIcon ? <StarterPack width={40} gradient="sky" /> : null}
         <View style={[a.flex_1]}>
           <Text
@@ -72,14 +85,18 @@ export function Card({
             numberOfLines={2}>
             {record.name}
           </Text>
-          <Text
-            emoji
-            style={[a.leading_snug, t.atoms.text_contrast_medium]}
-            numberOfLines={1}>
-            {creator?.did === currentAccount?.did
-              ? _(msg`Starter pack by you`)
-              : _(msg`Starter pack by ${sanitizeHandle(creator.handle, '@')}`)}
-          </Text>
+          {!noAuthorInfo && (
+            <Text
+              emoji
+              style={[a.leading_snug, t.atoms.text_contrast_medium]}
+              numberOfLines={1}>
+              {creator?.did === currentAccount?.did
+                ? _(msg`Starter pack by you`)
+                : _(
+                    msg`Starter pack by ${sanitizeHandle(creator.handle, '@')}`,
+                  )}
+            </Text>
+          )}
         </View>
       </View>
       {!noDescription && record.description ? (
@@ -108,9 +125,9 @@ export function Link({
   const queryClient = useQueryClient()
   const {record} = starterPack
   const {rkey, handleOrDid} = React.useMemo(() => {
-    const rkey = new AtUri(starterPack.uri).rkey
+    const newRkey = new AtUri(starterPack.uri).rkey
     const {creator} = starterPack
-    return {rkey, handleOrDid: creator.handle || creator.did}
+    return {rkey: newRkey, handleOrDid: creator.handle || creator.did}
   }, [starterPack])
 
   if (!AppBskyGraphStarterpack.isRecord(record)) {

--- a/src/lib/routes/types.ts
+++ b/src/lib/routes/types.ts
@@ -38,6 +38,7 @@ export type CommonNavigatorParams = {
   PreferencesFollowingFeed: undefined
   PreferencesThreads: undefined
   PreferencesExternalEmbeds: undefined
+  PreferencesStarterPacks: undefined
   AccessibilitySettings: undefined
   AppearanceSettings: undefined
   AccountSettings: undefined

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -36,6 +36,7 @@ export const router = new Router({
   PreferencesFollowingFeed: '/settings/following-feed',
   PreferencesThreads: '/settings/threads',
   PreferencesExternalEmbeds: '/settings/external-embeds',
+  PreferencesStarterPacks: '/settings/starter-packs',
   AccessibilitySettings: '/settings/accessibility',
   AppearanceSettings: '/settings/appearance',
   SavedFeeds: '/settings/saved-feeds',

--- a/src/screens/Settings/ContentAndMediaSettings.tsx
+++ b/src/screens/Settings/ContentAndMediaSettings.tsx
@@ -17,6 +17,7 @@ import {Hashtag_Stroke2_Corner0_Rounded as HashtagIcon} from '#/components/icons
 import {Home_Stroke2_Corner2_Rounded as HomeIcon} from '#/components/icons/Home'
 import {Macintosh_Stroke2_Corner2_Rounded as MacintoshIcon} from '#/components/icons/Macintosh'
 import {Play_Stroke2_Corner2_Rounded as PlayIcon} from '#/components/icons/Play'
+import {StarterPack as StarterPackIcon} from '#/components/icons/StarterPack'
 import {Window_Stroke2_Corner2_Rounded as WindowIcon} from '#/components/icons/Window'
 import * as Layout from '#/components/Layout'
 
@@ -66,6 +67,14 @@ export function ContentAndMediaSettingsScreen({}: Props) {
             <SettingsList.ItemIcon icon={MacintoshIcon} />
             <SettingsList.ItemText>
               <Trans>External media</Trans>
+            </SettingsList.ItemText>
+          </SettingsList.LinkItem>
+          <SettingsList.LinkItem
+            to="/settings/starter-packs"
+            label={_(msg`Starter Packs`)}>
+            <SettingsList.ItemIcon icon={StarterPackIcon} />
+            <SettingsList.ItemText>
+              <Trans>Starter Packs</Trans>
             </SettingsList.ItemText>
           </SettingsList.LinkItem>
           <SettingsList.Divider />

--- a/src/screens/Settings/StarterPacksPreferences.tsx
+++ b/src/screens/Settings/StarterPacksPreferences.tsx
@@ -1,0 +1,222 @@
+import React from 'react'
+import {ListRenderItemInfo, Text, View} from 'react-native'
+import {AppBskyGraphDefs} from '@atproto/api'
+import {msg, Trans} from '@lingui/macro'
+import {useLingui} from '@lingui/react'
+
+import {useWebMediaQueries} from '#/lib/hooks/useWebMediaQueries'
+import {CommonNavigatorParams, NativeStackScreenProps} from '#/lib/routes/types'
+import {logger} from '#/logger'
+import {useActorStarterPacksQuery} from '#/state/queries/actor-starter-packs'
+import {useSession} from '#/state/session'
+import {List} from '#/view/com/util/List'
+import {atoms as a, ios, useTheme} from '#/alf'
+import {Button, ButtonIcon, ButtonText} from '#/components/Button'
+import {SearchInput} from '#/components/forms/SearchInput'
+import {EditBig_Stroke2_Corner0_Rounded as Edit} from '#/components/icons/EditBig'
+import {PlusSmall_Stroke2_Corner0_Rounded as Plus} from '#/components/icons/Plus'
+import * as Layout from '#/components/Layout'
+import {Default as StarterPackCard} from '#/components/StarterPack/StarterPackCard'
+import {navigate} from '#/Navigation'
+
+type Props = NativeStackScreenProps<
+  CommonNavigatorParams,
+  'PreferencesStarterPacks'
+>
+export function StarterPacksPreferencesScreen({}: Props) {
+  const {_} = useLingui()
+
+  return (
+    <Layout.Screen testID="starterPacksPreferencesScreen">
+      <Layout.Header title={_(msg`Starter Packs`)} />
+      <Layout.Content>
+        <StarterPackList />
+      </Layout.Content>
+    </Layout.Screen>
+  )
+}
+
+function Empty() {
+  const t = useTheme()
+
+  return (
+    <View style={[a.p_xl, a.align_center]}>
+      <Text style={[a.text_lg, t.atoms.text_contrast_medium]}>
+        <Trans>You haven't created a starter pack yet!</Trans>
+      </Text>
+    </View>
+  )
+}
+
+function keyExtractor(item: AppBskyGraphDefs.StarterPackView) {
+  return item.uri
+}
+
+function StarterPackList() {
+  const {_} = useLingui()
+  const t = useTheme()
+  const [isPTRing, setIsPTRing] = React.useState(false)
+  const {isTabletOrDesktop} = useWebMediaQueries()
+  const {currentAccount} = useSession()
+  const {data, refetch, isFetching, hasNextPage, fetchNextPage} =
+    useActorStarterPacksQuery({
+      did: currentAccount?.did,
+    })
+  const [query, setQuery] = React.useState('')
+
+  const onChangeQuery = (text: string) => {
+    setQuery(text)
+  }
+
+  const onPressCancelSearch = () => {
+    setQuery('')
+  }
+
+  const openCreateScreen = () => {
+    navigate('StarterPackWizard')
+  }
+
+  const onRefresh = React.useCallback(async () => {
+    setIsPTRing(true)
+    try {
+      await refetch()
+    } catch (err) {
+      logger.error('Failed to refresh starter packs', {message: err})
+    }
+    setIsPTRing(false)
+  }, [refetch, setIsPTRing])
+
+  const onEndReached = React.useCallback(async () => {
+    if (isFetching || !hasNextPage) return
+
+    try {
+      await fetchNextPage()
+    } catch (err) {
+      logger.error('Failed to load more starter packs', {message: err})
+    }
+  }, [isFetching, hasNextPage, fetchNextPage])
+
+  const items = data?.pages
+    .flatMap(page => page.starterPacks)
+    .filter(item => {
+      return (item.record as any).name
+        .toLowerCase()
+        .includes(query.toLowerCase())
+    })
+    .sort((itemA, itemB) => {
+      return (itemA as any).record.name < (itemB as any).record.name ? -1 : 1
+    })
+
+  const hasItems = items?.length !== undefined && items.length > 0
+
+  const renderItem = ({
+    item,
+    index,
+  }: ListRenderItemInfo<AppBskyGraphDefs.StarterPackView>) => {
+    const openStartPackEditScreen = () => {
+      const id = item.uri.split('/').pop()
+      navigate('StarterPackEdit', {rkey: id})
+    }
+
+    return (
+      <View
+        style={[
+          a.flex_row,
+          a.gap_md,
+          a.align_center,
+          a.p_lg,
+          a.overflow_hidden,
+          (isTabletOrDesktop || index !== 0) && a.border_t,
+          t.atoms.border_contrast_low,
+        ]}>
+        <View style={[a.flex_grow, a.flex_shrink]}>
+          <StarterPackCard starterPack={item} noAuthorInfo noDescription />
+        </View>
+        <Button
+          testID="editStarterPackButton"
+          label={_(msg`Edit`)}
+          variant="ghost"
+          color="primary"
+          size="small"
+          style={[a.flex_shrink_0]}
+          onPress={openStartPackEditScreen}>
+          <ButtonText>
+            <Trans>Edit</Trans>
+          </ButtonText>
+          <ButtonIcon icon={Edit} />
+        </Button>
+      </View>
+    )
+  }
+
+  const listFooter = () => {
+    return (
+      <View
+        style={[
+          a.justify_center,
+          a.align_center,
+          a.pt_lg,
+          a.border_t,
+          hasItems && t.atoms.border_contrast_low,
+        ]}>
+        <Button
+          label={
+            hasItems ? _(msg`Create another`) : _(msg`Create a Starter Pack`)
+          }
+          variant="solid"
+          color="secondary"
+          size="small"
+          onPress={openCreateScreen}>
+          <ButtonText>
+            <Trans>
+              {hasItems ? 'Create another' : 'Create a Starter Pack'}
+            </Trans>
+          </ButtonText>
+          <ButtonIcon icon={Plus} position="right" />
+        </Button>
+      </View>
+    )
+  }
+
+  return (
+    <View>
+      <View style={[a.flex_row, a.gap_md, a.p_lg]}>
+        <View style={[a.flex_grow, a.flex_shrink]}>
+          <SearchInput
+            value={query}
+            onChangeText={onChangeQuery}
+            onClearText={onPressCancelSearch}
+            placeholder={_(msg`Search your starter packs`)}
+          />
+        </View>
+        <Button
+          label={_(msg`Create`)}
+          variant="solid"
+          color="secondary"
+          size="small"
+          style={[a.flex_shrink_0]}
+          onPress={openCreateScreen}>
+          <ButtonText>
+            <Trans>Create</Trans>
+          </ButtonText>
+          <ButtonIcon icon={Plus} position="right" />
+        </Button>
+      </View>
+      <List
+        testID="starterPacksList"
+        data={items}
+        renderItem={renderItem}
+        keyExtractor={keyExtractor}
+        refreshing={isPTRing}
+        progressViewOffset={ios(0)}
+        indicatorStyle={t.name === 'light' ? 'black' : 'white'}
+        removeClippedSubviews={true}
+        desktopFixedHeight
+        onEndReached={onEndReached}
+        onRefresh={onRefresh}
+        ListEmptyComponent={Empty}
+        ListFooterComponent={listFooter}
+      />
+    </View>
+  )
+}


### PR DESCRIPTION
This pull request introduces a new feature for managing "Starter Packs" as preferences in the settings. 

The changes include a new screen for the preferences, updated navigation routes, and enhancing the `StarterPackCard` component to support additional customization options.

New screen and navigation updates:

* [`src/Navigation.tsx`](diffhunk://#diff-36de9238965be77e2516411ab3985b1b8834b813bbb1f56c81ddd22ddff6d437R101): Added `StarterPacksPreferencesScreen` to the import list and included a new screen in the `commonScreens` function for navigating to "Starter Packs" preferences. [[1]](diffhunk://#diff-36de9238965be77e2516411ab3985b1b8834b813bbb1f56c81ddd22ddff6d437R101) [[2]](diffhunk://#diff-36de9238965be77e2516411ab3985b1b8834b813bbb1f56c81ddd22ddff6d437R318-R322)
* [`src/lib/routes/types.ts`](diffhunk://#diff-bdca1f16be6e5b4b8691b6075929e8cae18aeade2942f5960f098c0dd8cc55d2R41): Added `PreferencesStarterPacks` to the `CommonNavigatorParams` type.
* [`src/routes.ts`](diffhunk://#diff-3b62bfb52c340d82485e1a1712ac89b98c5c8f55499990329997e0c692ac620dR39): Added a new route for "Starter Packs" preferences.

Enhancements to `StarterPackCard` component:

* [`src/components/StarterPack/StarterPackCard.tsx`](diffhunk://#diff-70cb2488444290dd86170a39a74d62d8c81504b48167b97a3f4b97fe7aae92feR21-R38): Updated the `Default` and `Card` components to include optional props (`noIcon`, `noAuthorInfo`, `noDescription`) for customizing the display of starter packs. [[1]](diffhunk://#diff-70cb2488444290dd86170a39a74d62d8c81504b48167b97a3f4b97fe7aae92feR21-R38) [[2]](diffhunk://#diff-70cb2488444290dd86170a39a74d62d8c81504b48167b97a3f4b97fe7aae92feR59-R64) [[3]](diffhunk://#diff-70cb2488444290dd86170a39a74d62d8c81504b48167b97a3f4b97fe7aae92feL66-R79) [[4]](diffhunk://#diff-70cb2488444290dd86170a39a74d62d8c81504b48167b97a3f4b97fe7aae92feR88-R99) [[5]](diffhunk://#diff-70cb2488444290dd86170a39a74d62d8c81504b48167b97a3f4b97fe7aae92feL111-R130)

Addition of new "Starter Packs" preferences screen:

* [`src/screens/Settings/StarterPacksPreferences.tsx`](diffhunk://#diff-36528dccc7a90716fa53af1e1857c31882478a324324cb8909766643445abda4R1-R222): Created a new screen for managing "Starter Packs" preferences, including a list of starter packs, search functionality, and options to create or edit starter packs.

Update to settings screen:

* [`src/screens/Settings/ContentAndMediaSettings.tsx`](diffhunk://#diff-631182eb36fb7f54fa66cb1e019324f3b22d6ec5378a770988beaef72fe535f9R20): Added a link to navigate to the new "Starter Packs" preferences screen. [[1]](diffhunk://#diff-631182eb36fb7f54fa66cb1e019324f3b22d6ec5378a770988beaef72fe535f9R20) [[2]](diffhunk://#diff-631182eb36fb7f54fa66cb1e019324f3b22d6ec5378a770988beaef72fe535f9R72-R79)

## Screenshots

![image](https://github.com/user-attachments/assets/8f3b6c25-4904-4c2c-bc41-36cd4fcca02b)

![image](https://github.com/user-attachments/assets/4e6b4ec4-0969-41f3-af3d-d0341496fd84)

## Video

https://github.com/user-attachments/assets/2968295d-2d99-49d8-a3f7-fd4f4e549152

