### PR TITLE
Fix TagMenu initial render perf

### DIFF
--- a/src/components/Dialog/index.tsx
+++ b/src/components/Dialog/index.tsx
@@ -75,7 +75,7 @@ export function Outer({
       try {
         cb()
       } catch (e: any) {
-        logger.error('Error running close callback', e)
+        logger.error(e || 'Error running close callback')
       }
     }
 

--- a/src/components/TagMenu/index.tsx
+++ b/src/components/TagMenu/index.tsx
@@ -40,12 +40,18 @@ export function TagMenu({
   tag: string
   authorHandle?: string
 }>) {
+  const navigation = useNavigation<NavigationProp>()
   return (
     <>
       {children}
       <Dialog.Outer control={control}>
         <Dialog.Handle />
-        <TagMenuInner control={control} tag={tag} authorHandle={authorHandle} />
+        <TagMenuInner
+          control={control}
+          tag={tag}
+          authorHandle={authorHandle}
+          navigation={navigation}
+        />
       </Dialog.Outer>
     </>
   )
@@ -55,18 +61,16 @@ function TagMenuInner({
   control,
   tag,
   authorHandle,
+  navigation,
 }: {
   control: Dialog.DialogOuterProps['control']
-  /**
-   * This should be the sanitized tag value from the facet itself, not the
-   * "display" value with a leading `#`.
-   */
   tag: string
   authorHandle?: string
+  // Passed down because on native, we don't use real portals (and context would be wrong).
+  navigation: NavigationProp
 }) {
   const {_} = useLingui()
   const t = useTheme()
-  const navigation = useNavigation<NavigationProp>()
   const {isLoading: isPreferencesLoading, data: preferences} =
     usePreferencesQuery()
   const {


### PR DESCRIPTION
It is expensive to run all these `useMutation` hooks and construct all this JSX, only for it to be thrown away / needed on tap.

At least it's expensive on low-end Android. (In dev mode, but it would be bad in prod too.)

<img width="828" alt="Screenshot 2024-11-18 at 02 42 33" src="https://github.com/user-attachments/assets/cfc38206-3aa8-4223-832f-5f3d8f91b1ce">

Instead, we want this:

<img width="503" alt="Screenshot 2024-11-18 at 02 50 30" src="https://github.com/user-attachments/assets/644b3c5b-f071-4cc6-aac3-267a949d87b4">

How? Move all the logic down to the case where the menu is actually shown.

One quirk is that `useNavigation` stays above because we don't use real portals on native. So the context would be wrong otherwise.

I've also fixed a place where we swallow an error message which made debugging hard.

[Review sans whitespace](https://github.com/bluesky-social/social-app/pull/6483/files?w=1)

## Test Plan

Native only change.

https://github.com/user-attachments/assets/eed139c2-e1a3-40fe-af17-0a176fd960b0


https://github.com/user-attachments/assets/d9ebaa76-6c7a-4d90-a9aa-70619582d5da



