### PR TITLE
Update Italian translations

### DIFF
--- a/src/locale/locales/it/messages.po
+++ b/src/locale/locales/it/messages.po
@@ -2193,7 +2193,7 @@ msgstr "Modifica il profilo"
 #: src/screens/Profile/Header/ProfileHeaderLabeler.tsx:189
 #: src/screens/Profile/Header/ProfileHeaderStandard.tsx:182
 msgid "Edit Profile"
-msgstr "Modifica il Profilo"
+msgstr "Modifica il profilo"
 
 #: src/screens/StarterPack/StarterPackScreen.tsx:566
 msgid "Edit starter pack"
@@ -3876,7 +3876,7 @@ msgstr "Il mio Compleanno"
 
 #: src/view/screens/Feeds.tsx:732
 msgid "My Feeds"
-msgstr "I miei Feed"
+msgstr "I miei feed"
 
 #: src/view/shell/desktop/LeftNav.tsx:85
 msgid "My Profile"

--- a/src/locale/locales/it/messages.po
+++ b/src/locale/locales/it/messages.po
@@ -3,9 +3,9 @@ msgstr ""
 "Project-Id-Version: Italian localization\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-01-05 11:44+0530\n"
-"PO-Revision-Date: 2024-11-20 08:34+0100\n"
+"PO-Revision-Date: 2024-11-20 14:05+0100\n"
 "Last-Translator: Michele Locati <michele@locati.it>\n"
-"Language-Team: Gabriella Nonino\n"
+"Language-Team: \n"
 "Language: it\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -18,7 +18,7 @@ msgstr ""
 msgid "(contains embedded content)"
 msgstr "(contiene allegati)"
 
-#: src/screens/Settings/AccountSettings.tsx:58
+#: src/screens/Settings/AccountSettings.tsx:57
 #: src/view/com/modals/VerifyEmail.tsx:150
 msgid "(no email)"
 msgstr "(nessuna email)"
@@ -31,11 +31,11 @@ msgstr "{0, plural, one {# giorno} other {# giorni}}"
 msgid "{0, plural, one {# hour} other {# hours}}"
 msgstr "{0, plural, one {# hour} other {# hours}}"
 
-#: src/components/moderation/LabelsOnMe.tsx:54
+#: src/components/moderation/LabelsOnMe.tsx:53
 msgid "{0, plural, one {# label has been placed on this account} other {# labels have been placed on this account}}"
 msgstr "{0, plural, one {# etichetta è stata applicata a questo account} other {# etichette sono stata applicate a questo account}}"
 
-#: src/components/moderation/LabelsOnMe.tsx:60
+#: src/components/moderation/LabelsOnMe.tsx:59
 msgid "{0, plural, one {# label has been placed on this content} other {# labels have been placed on this content}}"
 msgstr "{0, plural, one {# etichetta è stata applicata a questo contenuto} other {# etichette sono state applicate a questo contenuto}}"
 
@@ -56,12 +56,12 @@ msgid "{0, plural, one {# second} other {# seconds}}"
 msgstr "{0, plural, one {# secondo} other {# secondi}}"
 
 #: src/components/ProfileHoverCard/index.web.tsx:398
-#: src/screens/Profile/Header/Metrics.tsx:23
+#: src/screens/Profile/Header/Metrics.tsx:22
 msgid "{0, plural, one {follower} other {followers}}"
 msgstr "{0, plural, one {follower} other {followers}}"
 
 #: src/components/ProfileHoverCard/index.web.tsx:402
-#: src/screens/Profile/Header/Metrics.tsx:27
+#: src/screens/Profile/Header/Metrics.tsx:26
 msgid "{0, plural, one {following} other {following}}"
 msgstr "{0, plural, one {following} other {following}}"
 
@@ -77,7 +77,7 @@ msgstr "{0, plural, one {like} other {likes}}"
 msgid "{0, plural, one {Liked by # user} other {Liked by # users}}"
 msgstr "{0, plural, one {# utente ha messo like} other {# utenti hanno messo like}}"
 
-#: src/screens/Profile/Header/Metrics.tsx:59
+#: src/screens/Profile/Header/Metrics.tsx:58
 msgid "{0, plural, one {post} other {posts}}"
 msgstr "{0, plural, one {post} other {posts}}"
 
@@ -131,11 +131,11 @@ msgstr "{0} elementi non letti"
 msgid "{0}'s avatar"
 msgstr "Foto profilo di {0}"
 
-#: src/screens/StarterPack/Wizard/StepDetails.tsx:68
+#: src/screens/StarterPack/Wizard/StepDetails.tsx:67
 msgid "{0}'s favorite feeds and people - join me!"
 msgstr "Feed e utenti preferiti di {0} - unisciti!"
 
-#: src/screens/StarterPack/Wizard/StepDetails.tsx:47
+#: src/screens/StarterPack/Wizard/StepDetails.tsx:46
 msgid "{0}'s starter pack"
 msgstr "Starter pack di {0}"
 
@@ -181,11 +181,11 @@ msgstr "{count} elementi non letti"
 msgid "{displayName}'s Starter Pack"
 msgstr "Starter Pack di {displayName}"
 
-#: src/screens/SignupQueued.tsx:207
+#: src/screens/SignupQueued.tsx:220
 msgid "{estimatedTimeHrs, plural, one {hour} other {hours}}"
 msgstr "{estimatedTimeHrs, plural, one {hour} other {hours}}"
 
-#: src/screens/SignupQueued.tsx:213
+#: src/screens/SignupQueued.tsx:226
 msgid "{estimatedTimeMins, plural, one {minute} other {minutes}}"
 msgstr "{estimatedTimeMins, plural, one {minute} other {minutes}}"
 
@@ -219,19 +219,19 @@ msgstr ""
 
 #: src/view/com/notifications/FeedItem.tsx:338
 msgid "{firstAuthorLink} liked your custom feed"
-msgstr ""
+msgstr "A {firstAuthorLink} è piaciuto il tuo feed personalizzato"
 
 #: src/view/com/notifications/FeedItem.tsx:234
 msgid "{firstAuthorLink} liked your post"
-msgstr ""
+msgstr "A {firstAuthorLink} è piaciuto il tuo post"
 
 #: src/view/com/notifications/FeedItem.tsx:258
 msgid "{firstAuthorLink} reposted your post"
-msgstr ""
+msgstr "{firstAuthorLink} ha ripubblicato il tuo post"
 
 #: src/view/com/notifications/FeedItem.tsx:362
 msgid "{firstAuthorLink} signed up with your starter pack"
-msgstr ""
+msgstr "{firstAuthorLink} si è iscritto con il tuo starter pack"
 
 #: src/view/com/notifications/FeedItem.tsx:293
 msgid "{firstAuthorName} and {additionalAuthorsCount, plural, one {{formattedAuthorsCount} other} other {{formattedAuthorsCount} others}} followed you"
@@ -255,30 +255,30 @@ msgstr ""
 
 #: src/view/com/notifications/FeedItem.tsx:298
 msgid "{firstAuthorName} followed you"
-msgstr ""
+msgstr "{firstAuthorName} ha iniziato a seguirti"
 
 #: src/view/com/notifications/FeedItem.tsx:288
 msgid "{firstAuthorName} followed you back"
-msgstr ""
+msgstr "{firstAuthorName} ha iniziato a seguirti a sua volta"
 
 #: src/view/com/notifications/FeedItem.tsx:324
 msgid "{firstAuthorName} liked your custom feed"
-msgstr ""
+msgstr "A {firstAuthorName} è piaciuto il tuo feed personalizzato"
 
 #: src/view/com/notifications/FeedItem.tsx:220
 msgid "{firstAuthorName} liked your post"
-msgstr ""
+msgstr "A {firstAuthorName} è piaciuto il tuo post"
 
 #: src/view/com/notifications/FeedItem.tsx:244
 msgid "{firstAuthorName} reposted your post"
-msgstr ""
+msgstr "{firstAuthorName} ha ripubblicato il tuo post"
 
 #: src/view/com/notifications/FeedItem.tsx:348
 msgid "{firstAuthorName} signed up with your starter pack"
-msgstr ""
+msgstr "{firstAuthorName} si è iscritto con il tuo starter pack"
 
 #: src/components/ProfileHoverCard/index.web.tsx:508
-#: src/screens/Profile/Header/Metrics.tsx:50
+#: src/screens/Profile/Header/Metrics.tsx:49
 msgid "{following} following"
 msgstr "{following} following"
 
@@ -298,7 +298,7 @@ msgstr "{numUnreadNotifications} non letto/i"
 
 #: src/view/shell/bottom-bar/BottomBar.tsx:230
 msgid "{numUnreadNotifications} unread items"
-msgstr ""
+msgstr "{numUnreadNotifications} elementi non letti"
 
 #: src/components/NewskieDialog.tsx:116
 msgid "{profileName} joined Bluesky {0} ago"
@@ -342,7 +342,7 @@ msgstr "<0>{0}</0> membri"
 msgid "<0>{date}</0> at {time}"
 msgstr "<0>{date}</0> alle {time}"
 
-#: src/screens/Settings/NotificationSettings.tsx:72
+#: src/screens/Settings/NotificationSettings.tsx:71
 msgid "<0>Experimental:</0> When this preference is enabled, you'll only receive reply and quote notifications from users you follow. We'll continue to add more controls here over time."
 msgstr ""
 
@@ -350,7 +350,7 @@ msgstr ""
 msgid "<0>You</0> and<1> </1><2>{0} </2>are included in your starter pack"
 msgstr "<0>Tu</0> e<1> </1><2>{0} </2>sono inclusi nel tuo starter pack"
 
-#: src/screens/Profile/Header/Handle.tsx:53
+#: src/screens/Profile/Header/Handle.tsx:52
 msgid "⚠Invalid Handle"
 msgstr "⚠Nome utente non valido"
 
@@ -370,7 +370,7 @@ msgstr "30 giorni"
 msgid "7 days"
 msgstr "7 giorni"
 
-#: src/Navigation.tsx:361 src/screens/Settings/AboutSettings.tsx:25
+#: src/Navigation.tsx:361 src/screens/Settings/AboutSettings.tsx:24
 #: src/screens/Settings/Settings.tsx:207 src/screens/Settings/Settings.tsx:210
 msgid "About"
 msgstr "Informazioni su"
@@ -383,7 +383,7 @@ msgstr "Accedi alle impostazioni di navigazione"
 msgid "Access profile and other navigation links"
 msgstr "Accedi al profilo e ad altre impostazioni di navigazione"
 
-#: src/screens/Settings/AccessibilitySettings.tsx:43
+#: src/screens/Settings/AccessibilitySettings.tsx:42
 #: src/screens/Settings/Settings.tsx:183 src/screens/Settings/Settings.tsx:186
 msgid "Accessibility"
 msgstr "Accessibilità"
@@ -393,7 +393,7 @@ msgid "Accessibility Settings"
 msgstr "Impostazioni di Accessibilità"
 
 #: src/Navigation.tsx:337 src/screens/Login/LoginForm.tsx:176
-#: src/screens/Settings/AccountSettings.tsx:42
+#: src/screens/Settings/AccountSettings.tsx:41
 #: src/screens/Settings/Settings.tsx:145 src/screens/Settings/Settings.tsx:148
 msgid "Account"
 msgstr "Account"
@@ -410,12 +410,12 @@ msgstr "Account seguito"
 msgid "Account muted"
 msgstr "Account silenziato"
 
-#: src/components/moderation/ModerationDetailsDialog.tsx:102
+#: src/components/moderation/ModerationDetailsDialog.tsx:101
 #: src/lib/moderation/useModerationCauseDescription.ts:96
 msgid "Account Muted"
 msgstr "Account Silenziato"
 
-#: src/components/moderation/ModerationDetailsDialog.tsx:88
+#: src/components/moderation/ModerationDetailsDialog.tsx:87
 msgid "Account Muted by List"
 msgstr "Account silenziato dalla Lista"
 
@@ -451,12 +451,12 @@ msgstr "Aggiungi"
 msgid "Add {0} more to continue"
 msgstr "Aggiungi {0} utenti per continuare"
 
-#: src/components/StarterPack/Wizard/WizardListCard.tsx:59
+#: src/components/StarterPack/Wizard/WizardListCard.tsx:58
 msgid "Add {displayName} to starter pack"
 msgstr "Aggiungi {displayName} allo starter pack"
 
-#: src/view/com/composer/labels/LabelsBtn.tsx:108
-#: src/view/com/composer/labels/LabelsBtn.tsx:113
+#: src/view/com/composer/labels/LabelsBtn.tsx:107
+#: src/view/com/composer/labels/LabelsBtn.tsx:112
 msgid "Add a content warning"
 msgstr "Aggiungi un avviso sul contenuto"
 
@@ -550,14 +550,14 @@ msgstr "Aggiunto alla lista"
 msgid "Added to my feeds"
 msgstr "Aggiunto ai miei feed"
 
-#: src/view/com/composer/labels/LabelsBtn.tsx:161
+#: src/view/com/composer/labels/LabelsBtn.tsx:160
 msgid "Adult"
 msgstr "Adulto"
 
 #: src/components/moderation/ContentHider.tsx:113
 #: src/lib/moderation/useGlobalLabelStrings.ts:34
 #: src/lib/moderation/useModerationCauseDescription.ts:144
-#: src/view/com/composer/labels/LabelsBtn.tsx:129
+#: src/view/com/composer/labels/LabelsBtn.tsx:128
 msgid "Adult Content"
 msgstr "Contenuto per adulti"
 
@@ -569,8 +569,8 @@ msgstr "I contenuti per adulti possono essere abilitati solo dal sito Web a <0>b
 msgid "Adult content is disabled."
 msgstr "Il contenuto per adulti è disattivato."
 
-#: src/view/com/composer/labels/LabelsBtn.tsx:140
-#: src/view/com/composer/labels/LabelsBtn.tsx:198
+#: src/view/com/composer/labels/LabelsBtn.tsx:139
+#: src/view/com/composer/labels/LabelsBtn.tsx:197
 msgid "Adult Content labels"
 msgstr "Etichette per contenuti per adulti"
 
@@ -622,7 +622,7 @@ msgstr "Hai già effettuato l'accesso come @{0}"
 msgid "ALT"
 msgstr "ALT"
 
-#: src/screens/Settings/AccessibilitySettings.tsx:49
+#: src/screens/Settings/AccessibilitySettings.tsx:48
 #: src/view/com/composer/GifAltText.tsx:154
 #: src/view/com/composer/photos/ImageAltTextDialog.tsx:118
 #: src/view/com/composer/videos/SubtitleDialog.tsx:56
@@ -655,7 +655,7 @@ msgstr "Una email è stata inviata al tuo indirizzo precedente, {0}. Include un 
 
 #: src/components/dialogs/VerifyEmailDialog.tsx:91
 msgid "An email has been sent! Please enter the confirmation code included in the email below."
-msgstr "Un email è stata inviata! Per favore inserisci qui sotto il codice di conferma presente nell'email."
+msgstr "Un email è stata inviata! Inserisci qui sotto il codice di conferma presente nell'email."
 
 #: src/components/dialogs/GifSelect.tsx:265
 msgid "An error has occurred"
@@ -673,16 +673,16 @@ msgstr "Si è verificato un errore durante la compressione del video."
 msgid "An error occurred while generating your starter pack. Want to try again?"
 msgstr "Si è verificato un errore nel creare il tuo starter pack. Vuoi riprovare?"
 
-#: src/view/com/util/post-embeds/VideoEmbed.tsx:135
+#: src/view/com/util/post-embeds/VideoEmbed.tsx:133
 msgid "An error occurred while loading the video. Please try again later."
-msgstr "Si è verificato un errore nel caricare il video. Per favore riprova più tardi."
+msgstr "Si è verificato un errore durante il caricamento del video. Riprova più tardi."
 
-#: src/view/com/util/post-embeds/VideoEmbed.web.tsx:174
+#: src/view/com/util/post-embeds/VideoEmbed.web.tsx:176
 msgid "An error occurred while loading the video. Please try again."
-msgstr "Si è verificato un errore durante il caricamento del video. Per favore ritenta."
+msgstr "Si è verificato un errore durante il caricamento del video. Riprova."
 
 #: src/components/StarterPack/QrCodeDialog.tsx:71
-#: src/components/StarterPack/ShareDialog.tsx:80
+#: src/components/StarterPack/ShareDialog.tsx:79
 msgid "An error occurred while saving the QR code!"
 msgstr "Si è verificato un errore nel salvare il codice QR!"
 
@@ -714,17 +714,17 @@ msgstr "Si è verificato un problema nell'aprire la chat"
 #: src/components/hooks/useFollowMethods.ts:35
 #: src/components/hooks/useFollowMethods.ts:50
 #: src/components/ProfileCard.tsx:326 src/components/ProfileCard.tsx:346
-#: src/view/com/profile/FollowButton.tsx:36
-#: src/view/com/profile/FollowButton.tsx:46
+#: src/view/com/profile/FollowButton.tsx:35
+#: src/view/com/profile/FollowButton.tsx:45
 msgid "An issue occurred, please try again."
-msgstr "Si è verificato un problema, per favore riprova più tardi."
+msgstr "Si è verificato un problema, riprova."
 
 #: src/screens/Onboarding/StepInterests/index.tsx:185
 msgid "an unknown error occurred"
 msgstr "si è verificato un errore sconosciuto"
 
-#: src/components/moderation/ModerationDetailsDialog.tsx:158
-#: src/components/moderation/ModerationDetailsDialog.tsx:154
+#: src/components/moderation/ModerationDetailsDialog.tsx:157
+#: src/components/moderation/ModerationDetailsDialog.tsx:153
 msgid "an unknown labeler"
 msgstr "un etichettatore sconosciuto"
 
@@ -749,7 +749,7 @@ msgstr "Comportamento antisociale"
 msgid "Any language"
 msgstr "Qualsiasi lingua"
 
-#: src/view/com/composer/threadgate/ThreadgateBtn.tsx:49
+#: src/view/com/composer/threadgate/ThreadgateBtn.tsx:48
 msgid "Anybody can interact"
 msgstr "Tutti possono interagire"
 
@@ -777,8 +777,8 @@ msgstr "I nomi delle password delle app possono contenere solo lettere, numeri, 
 msgid "App password names must be at least 4 characters long"
 msgstr "I nomi delle password devono essere lunghi almeno 4 caratteri"
 
-#: src/screens/Settings/PrivacyAndSecuritySettings.tsx:56
-#: src/screens/Settings/PrivacyAndSecuritySettings.tsx:59
+#: src/screens/Settings/PrivacyAndSecuritySettings.tsx:55
+#: src/screens/Settings/PrivacyAndSecuritySettings.tsx:58
 msgid "App passwords"
 msgstr "Password delle app"
 
@@ -842,9 +842,9 @@ msgstr "Sicuro di voler eliminare questo starter pack?"
 msgid "Are you sure you want to discard your changes?"
 msgstr "Annullare le modifiche?"
 
-#: src/components/dms/LeaveConvoPrompt.tsx:48
+#: src/components/dms/LeaveConvoPrompt.tsx:47
 msgid "Are you sure you want to leave this conversation? Your messages will be deleted for you, but not for the other participant."
-msgstr "Sei sicuro di voler abbandonare questa conversazione? I messaggi verranno cancellati per te, ma non per gli altri partecipanti."
+msgstr "Abbandonare questa conversazione? I messaggi verranno eliminati per te, ma non per gli altri partecipanti."
 
 #: src/view/com/feeds/FeedSourceCard.tsx:316
 msgid "Are you sure you want to remove {0} from your feeds?"
@@ -860,7 +860,7 @@ msgstr "Confermi di voler eliminare questa bozza?"
 
 #: src/view/com/composer/Composer.tsx:830
 msgid "Are you sure you'd like to discard this post?"
-msgstr ""
+msgstr "Scartare questo post?"
 
 #: src/components/dialogs/MutedWords.tsx:433
 msgid "Are you sure?"
@@ -874,7 +874,7 @@ msgstr "Stai scrivendo in <0>{0}</0>?"
 msgid "Art"
 msgstr "Arte"
 
-#: src/view/com/composer/labels/LabelsBtn.tsx:173
+#: src/view/com/composer/labels/LabelsBtn.tsx:172
 msgid "Artistic or non-erotic nudity."
 msgstr "Nudità artistica o non erotica."
 
@@ -882,14 +882,14 @@ msgstr "Nudità artistica o non erotica."
 msgid "At least 3 characters"
 msgstr "Almeno 3 caratteri"
 
-#: src/screens/Settings/AccessibilitySettings.tsx:98
+#: src/screens/Settings/AccessibilitySettings.tsx:97
 msgid "Autoplay options have moved to the <0>Content and Media settings</0>."
 msgstr ""
 
-#: src/screens/Settings/ContentAndMediaSettings.tsx:89
-#: src/screens/Settings/ContentAndMediaSettings.tsx:95
+#: src/screens/Settings/ContentAndMediaSettings.tsx:88
+#: src/screens/Settings/ContentAndMediaSettings.tsx:94
 msgid "Autoplay videos and GIFs"
-msgstr ""
+msgstr "Riproduci automaticamente video e GIF"
 
 #: src/components/dms/MessagesListHeader.tsx:75
 #: src/components/moderation/LabelsOnMeDialog.tsx:290
@@ -904,7 +904,7 @@ msgstr ""
 #: src/screens/Messages/components/ChatDisabled.tsx:133
 #: src/screens/Messages/components/ChatDisabled.tsx:134
 #: src/screens/Profile/Header/Shell.tsx:112
-#: src/screens/Signup/BackNextButtons.tsx:42
+#: src/screens/Signup/BackNextButtons.tsx:41
 #: src/screens/StarterPack/Wizard/index.tsx:307
 #: src/view/com/util/ViewHeader.tsx:87
 msgid "Back"
@@ -912,7 +912,7 @@ msgstr "Indietro"
 
 #: src/view/screens/Lists.tsx:104 src/view/screens/ModerationModlists.tsx:100
 msgid "Before creating a list, you must first verify your email."
-msgstr ""
+msgstr "Prima di creare una lista devi verificare il tuo indirizzo email."
 
 #: src/view/com/composer/Composer.tsx:593
 msgid "Before creating a post, you must first verify your email."
@@ -929,7 +929,7 @@ msgid "Before you may message another user, you must first verify your email."
 msgstr "Prima di poter inviare un messaggio a un altro utente, devi verificare la tua email."
 
 #: src/components/dialogs/BirthDateSettings.tsx:106
-#: src/screens/Settings/AccountSettings.tsx:102
+#: src/screens/Settings/AccountSettings.tsx:101
 msgid "Birthday"
 msgstr "Compleanno"
 
@@ -1010,13 +1010,13 @@ msgstr "Bluesky"
 
 #: src/view/com/post-thread/PostThreadItem.tsx:850
 msgid "Bluesky cannot confirm the authenticity of the claimed date."
-msgstr ""
+msgstr "Bluesky non può confermare l'autenticità della data dichiarata."
 
 #: src/view/com/auth/server-input/index.tsx:151
 msgid "Bluesky is an open network where you can choose your hosting provider. If you're a developer, you can host your own server."
 msgstr "Bluesky è una rete aperta dove puoi scegliere il fornitore di hosting. Se sei uno sviluppatore, puoi ospitare il tuo server."
 
-#: src/components/ProgressGuide/List.tsx:55
+#: src/components/ProgressGuide/List.tsx:54
 msgid "Bluesky is better with friends!"
 msgstr "Bluesky è meglio con gli amici!"
 
@@ -1108,7 +1108,8 @@ msgstr "Fotocamera"
 #: src/screens/Profile/Header/EditProfileDialog.tsx:228
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:72
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:79
-#: src/screens/Settings/Settings.tsx:252 src/view/com/composer/Composer.tsx:893
+#: src/screens/Settings/Settings.tsx:252
+#: src/view/com/composer/Composer.tsx:893
 #: src/view/com/modals/ChangeEmail.tsx:213
 #: src/view/com/modals/ChangeEmail.tsx:215
 #: src/view/com/modals/ChangePassword.tsx:268
@@ -1137,7 +1138,7 @@ msgstr "Annulla"
 #: src/view/com/modals/DeleteAccount.tsx:170
 #: src/view/com/modals/DeleteAccount.tsx:293
 msgid "Cancel account deletion"
-msgstr "Annulla la cancellazione dell'account"
+msgstr "Annulla l'eliminazione dell'account"
 
 #: src/view/com/modals/CropImage.web.tsx:94
 msgid "Cancel image crop"
@@ -1184,8 +1185,8 @@ msgstr "Sottotitoli & testo alternativo"
 msgid "Change"
 msgstr "Cambia"
 
-#: src/screens/Settings/AccountSettings.tsx:90
-#: src/screens/Settings/AccountSettings.tsx:94
+#: src/screens/Settings/AccountSettings.tsx:89
+#: src/screens/Settings/AccountSettings.tsx:93
 msgid "Change email"
 msgstr "Modifica email"
 
@@ -1241,7 +1242,7 @@ msgstr "Impostazioni messaggi"
 msgid "Chat unmuted"
 msgstr "Conversizione non silenziata"
 
-#: src/screens/SignupQueued.tsx:78 src/screens/SignupQueued.tsx:82
+#: src/screens/SignupQueued.tsx:79 src/screens/SignupQueued.tsx:83
 msgid "Check my status"
 msgstr "Verifica il mio stato"
 
@@ -1269,7 +1270,7 @@ msgstr "Scegli per me"
 msgid "Choose People"
 msgstr "Scegli utenti"
 
-#: src/view/com/composer/labels/LabelsBtn.tsx:116
+#: src/view/com/composer/labels/LabelsBtn.tsx:115
 msgid "Choose self-labels that are applicable for the media you are posting. If none are selected, this post is suitable for all audiences."
 msgstr ""
 
@@ -1354,7 +1355,7 @@ msgstr "Chiudi"
 msgid "Close active dialog"
 msgstr "Chiudi la finestra attiva"
 
-#: src/screens/Login/PasswordUpdatedForm.tsx:32
+#: src/screens/Login/PasswordUpdatedForm.tsx:31
 msgid "Close alert"
 msgstr "Chiudi l'avviso"
 
@@ -1370,7 +1371,7 @@ msgstr "Chiudi la finestra di dialogo"
 msgid "Close GIF dialog"
 msgstr "Chiudi la finestra di dialogo GIF"
 
-#: src/view/com/lightbox/ImageViewing/components/ImageDefaultHeader.tsx:36
+#: src/view/com/lightbox/ImageViewing/components/ImageDefaultHeader.tsx:35
 msgid "Close image"
 msgstr "Chiudi l'immagine"
 
@@ -1390,11 +1391,11 @@ msgstr "Chiudi la finestra"
 msgid "Closes bottom navigation bar"
 msgstr "Chiude la barra di navigazione in basso"
 
-#: src/screens/Login/PasswordUpdatedForm.tsx:33
+#: src/screens/Login/PasswordUpdatedForm.tsx:32
 msgid "Closes password update alert"
 msgstr "Chiude l'avviso di aggiornamento della password"
 
-#: src/view/com/lightbox/ImageViewing/components/ImageDefaultHeader.tsx:37
+#: src/view/com/lightbox/ImageViewing/components/ImageDefaultHeader.tsx:36
 msgid "Closes viewer for header image"
 msgstr "Chiude il visualizzatore dell'immagine di intestazione"
 
@@ -1438,7 +1439,7 @@ msgstr "Scrivi un nuovo post"
 msgid "Compose posts up to {MAX_GRAPHEME_LENGTH} characters in length"
 msgstr "Componi un post fino a {MAX_GRAPHEME_LENGTH} caratteri"
 
-#: src/view/com/post-thread/PostThreadComposePrompt.tsx:35
+#: src/view/com/post-thread/PostThreadComposePrompt.tsx:34
 msgid "Compose reply"
 msgstr "Scrivi la risposta"
 
@@ -1470,7 +1471,7 @@ msgstr "Conferma"
 msgid "Confirm Change"
 msgstr "Conferma il cambio"
 
-#: src/view/com/modals/lang-settings/ConfirmLanguagesButton.tsx:35
+#: src/view/com/modals/lang-settings/ConfirmLanguagesButton.tsx:34
 msgid "Confirm content language settings"
 msgstr "Conferma le impostazioni della lingua del contenuto"
 
@@ -1509,12 +1510,12 @@ msgstr "Connessione in corso..."
 msgid "Contact support"
 msgstr "Contatta il supporto"
 
-#: src/screens/Settings/AccessibilitySettings.tsx:102
+#: src/screens/Settings/AccessibilitySettings.tsx:101
 #: src/screens/Settings/Settings.tsx:167 src/screens/Settings/Settings.tsx:170
 msgid "Content and media"
 msgstr "Contenuti e media"
 
-#: src/Navigation.tsx:353 src/screens/Settings/ContentAndMediaSettings.tsx:36
+#: src/Navigation.tsx:353 src/screens/Settings/ContentAndMediaSettings.tsx:35
 msgid "Content and Media"
 msgstr "Contenuti e media"
 
@@ -1531,23 +1532,23 @@ msgstr "Filtri dei contenuti"
 msgid "Content Languages"
 msgstr "Lingue dei contenuti"
 
-#: src/components/moderation/ModerationDetailsDialog.tsx:81
+#: src/components/moderation/ModerationDetailsDialog.tsx:80
 #: src/lib/moderation/useModerationCauseDescription.ts:80
 msgid "Content Not Available"
 msgstr "Contenuto non disponibile"
 
-#: src/components/moderation/ModerationDetailsDialog.tsx:49
+#: src/components/moderation/ModerationDetailsDialog.tsx:48
 #: src/components/moderation/ScreenHider.tsx:93
 #: src/lib/moderation/useGlobalLabelStrings.ts:22
 #: src/lib/moderation/useModerationCauseDescription.ts:43
 msgid "Content Warning"
 msgstr "Avviso sul Contenuto"
 
-#: src/view/com/composer/labels/LabelsBtn.tsx:61
+#: src/view/com/composer/labels/LabelsBtn.tsx:60
 msgid "Content warnings"
 msgstr "Avviso sui contenuti"
 
-#: src/components/Menu/index.web.tsx:83
+#: src/components/Menu/index.web.tsx:81
 msgid "Context menu backdrop, click to close the menu."
 msgstr "Sfondo del menu contestuale, clicca per chiudere il menu."
 
@@ -1566,7 +1567,7 @@ msgstr "Continua thread..."
 
 #: src/screens/Onboarding/StepInterests/index.tsx:241
 #: src/screens/Onboarding/StepProfile/index.tsx:275
-#: src/screens/Signup/BackNextButtons.tsx:61
+#: src/screens/Signup/BackNextButtons.tsx:60
 msgid "Continue to next step"
 msgstr "Vai al passaggio successivo"
 
@@ -1582,13 +1583,13 @@ msgstr "Cucina"
 msgid "Copied"
 msgstr "Copiato"
 
-#: src/screens/Settings/AboutSettings.tsx:66
+#: src/screens/Settings/AboutSettings.tsx:65
 msgid "Copied build version to clipboard"
 msgstr "Versione di build copiata nella clipboard"
 
 #: src/components/dms/MessageMenu.tsx:57 src/lib/sharing.ts:25
 #: src/view/com/modals/InviteCodes.tsx:153
-#: src/view/com/util/forms/PostDropdownBtn.tsx:240
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:229
 #: src/view/com/util/post-ctrls/PostCtrls.tsx:386
 msgid "Copied to clipboard"
 msgstr "Copiato nel clipboard"
@@ -1606,7 +1607,7 @@ msgstr "Copia"
 msgid "Copy App Password"
 msgstr "Copia password dell'app"
 
-#: src/screens/Settings/AboutSettings.tsx:61
+#: src/screens/Settings/AboutSettings.tsx:60
 msgid "Copy build version to clipboard"
 msgstr "Copia versione build negli appunti"
 
@@ -1622,11 +1623,11 @@ msgstr "Copia DID"
 msgid "Copy host"
 msgstr "Copia host"
 
-#: src/components/StarterPack/ShareDialog.tsx:124
+#: src/components/StarterPack/ShareDialog.tsx:123
 msgid "Copy link"
 msgstr "Copia link"
 
-#: src/components/StarterPack/ShareDialog.tsx:131
+#: src/components/StarterPack/ShareDialog.tsx:130
 msgid "Copy Link"
 msgstr "Copia link"
 
@@ -1634,8 +1635,8 @@ msgstr "Copia link"
 msgid "Copy link to list"
 msgstr "Copia il link alla lista"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:452
-#: src/view/com/util/forms/PostDropdownBtn.tsx:461
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:416
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:425
 msgid "Copy link to post"
 msgstr "Copia il link al post"
 
@@ -1644,8 +1645,8 @@ msgstr "Copia il link al post"
 msgid "Copy message text"
 msgstr "Copia il testo del messaggio"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:430
-#: src/view/com/util/forms/PostDropdownBtn.tsx:432
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:394
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:396
 msgid "Copy post text"
 msgstr "Copia il testo del post"
 
@@ -1661,7 +1662,7 @@ msgstr "Copia valore del record TXT"
 msgid "Copyright Policy"
 msgstr "Politica sul diritto d'autore"
 
-#: src/components/dms/LeaveConvoPrompt.tsx:39
+#: src/components/dms/LeaveConvoPrompt.tsx:38
 msgid "Could not leave chat"
 msgstr "Errore nell'abbandonare la conversazione"
 
@@ -1699,7 +1700,7 @@ msgstr "Crea uno starter pack"
 msgid "Create a starter pack for me"
 msgstr "Crea uno starter pack per me"
 
-#: src/view/com/auth/SplashScreen.tsx:56
+#: src/view/com/auth/SplashScreen.tsx:55
 #: src/view/com/auth/SplashScreen.web.tsx:117
 msgid "Create account"
 msgstr "Crea un account"
@@ -1720,7 +1721,7 @@ msgstr "In alternativa crea un avatar"
 msgid "Create another"
 msgstr "Creane un altro"
 
-#: src/view/com/auth/SplashScreen.tsx:48
+#: src/view/com/auth/SplashScreen.tsx:47
 #: src/view/com/auth/SplashScreen.web.tsx:109
 msgid "Create new account"
 msgstr "Crea un nuovo account"
@@ -1767,8 +1768,8 @@ msgstr "Tema scuro"
 msgid "Date of birth"
 msgstr "Data di nascita"
 
-#: src/screens/Settings/AccountSettings.tsx:139
-#: src/screens/Settings/AccountSettings.tsx:144
+#: src/screens/Settings/AccountSettings.tsx:138
+#: src/screens/Settings/AccountSettings.tsx:143
 #: src/screens/Settings/components/DeactivateAccountDialog.tsx:73
 msgid "Deactivate account"
 msgstr "Disattiva account"
@@ -1790,13 +1791,13 @@ msgstr "Predefinito"
 #: src/screens/StarterPack/StarterPackScreen.tsx:585
 #: src/screens/StarterPack/StarterPackScreen.tsx:664
 #: src/screens/StarterPack/StarterPackScreen.tsx:744
-#: src/view/com/util/forms/PostDropdownBtn.tsx:673
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:632
 #: src/view/screens/ProfileList.tsx:726
 msgid "Delete"
 msgstr "Elimina"
 
-#: src/screens/Settings/AccountSettings.tsx:149
-#: src/screens/Settings/AccountSettings.tsx:154
+#: src/screens/Settings/AccountSettings.tsx:148
+#: src/screens/Settings/AccountSettings.tsx:153
 msgid "Delete account"
 msgstr "Elimina l'account"
 
@@ -1837,8 +1838,8 @@ msgid "Delete my account"
 msgstr "Elimina il mio account"
 
 #: src/view/com/composer/Composer.tsx:804
-#: src/view/com/util/forms/PostDropdownBtn.tsx:653
-#: src/view/com/util/forms/PostDropdownBtn.tsx:655
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:613
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:615
 msgid "Delete post"
 msgstr "Elimina il post"
 
@@ -1855,7 +1856,7 @@ msgstr "Eliminare lo starter pack?"
 msgid "Delete this list?"
 msgstr "Eliminare questa lista?"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:668
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:627
 msgid "Delete this post?"
 msgstr "Eliminare questo post?"
 
@@ -1893,12 +1894,12 @@ msgstr "La descrizione è troppo lunga. Il numero massimo di caratteri è {DESCR
 msgid "Descriptive alt text"
 msgstr "Testo descrittivo alternativo"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:586
-#: src/view/com/util/forms/PostDropdownBtn.tsx:596
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:548
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:558
 msgid "Detach quote"
 msgstr "Stacca citazione"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:731
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:690
 msgid "Detach quote post?"
 msgstr "Staccare la citazione del post?"
 
@@ -1918,8 +1919,8 @@ msgstr "Soffuso"
 msgid "Disable Email 2FA"
 msgstr "Disattiva l'email 2FA"
 
-#: src/screens/Settings/AccessibilitySettings.tsx:84
-#: src/screens/Settings/AccessibilitySettings.tsx:89
+#: src/screens/Settings/AccessibilitySettings.tsx:83
+#: src/screens/Settings/AccessibilitySettings.tsx:88
 msgid "Disable haptic feedback"
 msgstr "Disattiva il feedback tattile"
 
@@ -1979,12 +1980,12 @@ msgstr "Ignora"
 msgid "Dismiss error"
 msgstr "Ignora errore"
 
-#: src/components/ProgressGuide/List.tsx:40
+#: src/components/ProgressGuide/List.tsx:39
 msgid "Dismiss getting started guide"
 msgstr "Ignora la guida iniziale"
 
-#: src/screens/Settings/AccessibilitySettings.tsx:64
-#: src/screens/Settings/AccessibilitySettings.tsx:69
+#: src/screens/Settings/AccessibilitySettings.tsx:63
+#: src/screens/Settings/AccessibilitySettings.tsx:68
 msgid "Display larger alt text badges"
 msgstr "Ignora l'icona ALT più grande"
 
@@ -2038,8 +2039,8 @@ msgstr "Dominio verificato!"
 #: src/screens/Settings/components/AddAppPasswordDialog.tsx:222
 #: src/view/com/auth/server-input/index.tsx:170
 #: src/view/com/auth/server-input/index.tsx:171
-#: src/view/com/composer/labels/LabelsBtn.tsx:225
-#: src/view/com/composer/labels/LabelsBtn.tsx:232
+#: src/view/com/composer/labels/LabelsBtn.tsx:224
+#: src/view/com/composer/labels/LabelsBtn.tsx:231
 #: src/view/com/composer/videos/SubtitleDialog.tsx:169
 #: src/view/com/composer/videos/SubtitleDialog.tsx:179
 #: src/view/com/modals/CropImage.web.tsx:112
@@ -2056,7 +2057,7 @@ msgctxt "action"
 msgid "Done"
 msgstr "Fatto"
 
-#: src/view/com/modals/lang-settings/ConfirmLanguagesButton.tsx:43
+#: src/view/com/modals/lang-settings/ConfirmLanguagesButton.tsx:42
 msgid "Done{extraText}"
 msgstr "Fatto{extraText}"
 
@@ -2087,7 +2088,7 @@ msgstr "e.g. alice"
 
 #: src/screens/Profile/Header/EditProfileDialog.tsx:321
 msgid "e.g. Alice Lastname"
-msgstr ""
+msgstr "es. Mario Rossi"
 
 #: src/view/com/modals/EditProfile.tsx:180
 msgid "e.g. Alice Roberts"
@@ -2125,7 +2126,7 @@ msgstr "e.g. Utenti che rispondono ripetutamente con annunci."
 msgid "Each code works once. You'll receive more invite codes periodically."
 msgstr "Ogni codice funziona per un solo uso. Riceverai periodicamente più codici di invito."
 
-#: src/screens/Settings/AccountSettings.tsx:105
+#: src/screens/Settings/AccountSettings.tsx:104
 #: src/screens/StarterPack/StarterPackScreen.tsx:574
 #: src/screens/StarterPack/Wizard/index.tsx:560
 #: src/screens/StarterPack/Wizard/index.tsx:567 src/view/screens/Feeds.tsx:386
@@ -2152,8 +2153,8 @@ msgstr "Modifica i feed"
 msgid "Edit image"
 msgstr "Modifica l'immagine"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:632
-#: src/view/com/util/forms/PostDropdownBtn.tsx:647
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:594
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:607
 msgid "Edit interaction settings"
 msgstr "Modifica le impostazioni di interazione"
 
@@ -2223,7 +2224,7 @@ msgstr "Modifica il tuo starter pack"
 msgid "Education"
 msgstr "Formazione scolastica"
 
-#: src/screens/Settings/AccountSettings.tsx:53
+#: src/screens/Settings/AccountSettings.tsx:52
 #: src/screens/Signup/StepInfo/index.tsx:170
 #: src/view/com/modals/ChangeEmail.tsx:136
 msgid "Email"
@@ -2233,9 +2234,9 @@ msgstr "Email"
 msgid "Email 2FA disabled"
 msgstr "E-mail 2FA disattivata"
 
-#: src/screens/Settings/PrivacyAndSecuritySettings.tsx:47
+#: src/screens/Settings/PrivacyAndSecuritySettings.tsx:46
 msgid "Email 2FA enabled"
-msgstr ""
+msgstr "2FA via email abilitata"
 
 #: src/screens/Login/ForgotPasswordForm.tsx:93
 msgid "Email address"
@@ -2267,8 +2268,8 @@ msgid "Embed HTML code"
 msgstr "Incorpora il codice HTML"
 
 #: src/components/dialogs/Embed.tsx:97
-#: src/view/com/util/forms/PostDropdownBtn.tsx:469
-#: src/view/com/util/forms/PostDropdownBtn.tsx:471
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:433
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:435
 msgid "Embed post"
 msgstr "Incorpora il post"
 
@@ -2302,8 +2303,8 @@ msgstr "Abilita i media esterni"
 msgid "Enable media players for"
 msgstr "Attiva i lettori multimediali per"
 
-#: src/screens/Settings/NotificationSettings.tsx:61
-#: src/screens/Settings/NotificationSettings.tsx:64
+#: src/screens/Settings/NotificationSettings.tsx:60
+#: src/screens/Settings/NotificationSettings.tsx:63
 msgid "Enable priority notifications"
 msgstr "Attiva notifiche prioritarie"
 
@@ -2462,10 +2463,10 @@ msgstr "Espandi o comprimi l'intero post a cui stai rispondendo"
 
 #: src/lib/api/index.ts:400
 msgid "Expected uri to resolve to a record"
-msgstr ""
+msgstr "L'URI dovrebbe risolvere in un record"
 
-#: src/screens/Settings/FollowingFeedPreferences.tsx:116
-#: src/screens/Settings/ThreadPreferences.tsx:124
+#: src/screens/Settings/FollowingFeedPreferences.tsx:115
+#: src/screens/Settings/ThreadPreferences.tsx:123
 msgid "Experimental"
 msgstr "Sperimentale"
 
@@ -2485,8 +2486,8 @@ msgstr "Media espliciti o potenzialmente inquietanti."
 msgid "Explicit sexual images."
 msgstr "Immagini sessuali esplicite."
 
-#: src/screens/Settings/AccountSettings.tsx:130
-#: src/screens/Settings/AccountSettings.tsx:134
+#: src/screens/Settings/AccountSettings.tsx:129
+#: src/screens/Settings/AccountSettings.tsx:133
 msgid "Export my data"
 msgstr "Esporta i miei dati"
 
@@ -2494,8 +2495,8 @@ msgstr "Esporta i miei dati"
 msgid "Export My Data"
 msgstr "Esporta i miei dati"
 
-#: src/screens/Settings/ContentAndMediaSettings.tsx:65
-#: src/screens/Settings/ContentAndMediaSettings.tsx:68
+#: src/screens/Settings/ContentAndMediaSettings.tsx:64
+#: src/screens/Settings/ContentAndMediaSettings.tsx:67
 msgid "External media"
 msgstr "Media esterni"
 
@@ -2534,7 +2535,7 @@ msgstr "Impossibile creare l'elenco. Controlla la connessione Internet e riprova
 msgid "Failed to delete message"
 msgstr "Errore nell'eliminazione del messaggio"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:200
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:189
 msgid "Failed to delete post, please try again"
 msgstr "Non possiamo eliminare il post, riprova di nuovo"
 
@@ -2574,7 +2575,7 @@ msgstr "Non è possibile salvare l'immagine: {0}"
 
 #: src/state/queries/notifications/settings.ts:39
 msgid "Failed to save notification preferences, please try again"
-msgstr "Impossibile salvare preferenze notifiche, per favore riprova"
+msgstr "Si è verificato un errore durante il salvataggio delle modifiche: riprova"
 
 #: src/components/dms/MessageItem.tsx:233
 msgid "Failed to send"
@@ -2585,7 +2586,7 @@ msgstr "Impossibile inviare messaggio"
 msgid "Failed to submit appeal, please try again."
 msgstr "Impossibile inviare appello, per favore riprova."
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:229
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:218
 msgid "Failed to toggle thread mute, please try again"
 msgstr "Impossbile abilitare silenziamento thread, per favore riprova"
 
@@ -2614,16 +2615,16 @@ msgstr "Feed"
 msgid "Feed by {0}"
 msgstr "Feed creato da {0}"
 
-#: src/components/StarterPack/Wizard/WizardListCard.tsx:55
+#: src/components/StarterPack/Wizard/WizardListCard.tsx:54
 msgid "Feed toggle"
 msgstr ""
 
-#: src/view/shell/desktop/RightNav.tsx:70 src/view/shell/Drawer.tsx:319
+#: src/view/shell/desktop/RightNav.tsx:69 src/view/shell/Drawer.tsx:319
 msgid "Feedback"
 msgstr "Commenti"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:271
-#: src/view/com/util/forms/PostDropdownBtn.tsx:280
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:260
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:269
 msgid "Feedback sent!"
 msgstr "Feedback inviato!"
 
@@ -2685,7 +2686,7 @@ msgstr "Flessibile"
 msgid "Follow"
 msgstr "Segui"
 
-#: src/view/com/profile/FollowButton.tsx:70
+#: src/view/com/profile/FollowButton.tsx:69
 msgctxt "action"
 msgid "Follow"
 msgstr "Segui"
@@ -2699,7 +2700,7 @@ msgstr "Segui {0}"
 msgid "Follow {name}"
 msgstr "Segui {name}"
 
-#: src/components/ProgressGuide/List.tsx:54
+#: src/components/ProgressGuide/List.tsx:53
 msgid "Follow 7 accounts"
 msgstr "Segui 7 account"
 
@@ -2718,10 +2719,10 @@ msgstr "Segui tutti"
 msgid "Follow Back"
 msgstr "Ricambia follow"
 
-#: src/view/com/profile/FollowButton.tsx:79
+#: src/view/com/profile/FollowButton.tsx:78
 msgctxt "action"
 msgid "Follow Back"
-msgstr ""
+msgstr "Segui anche tu"
 
 #: src/view/screens/Search/Explore.tsx:334
 msgid "Follow more accounts to get connected to your interests and build your network."
@@ -2781,16 +2782,16 @@ msgstr "Seguiti {0}"
 msgid "Following {name}"
 msgstr "Stai segendo {name}"
 
-#: src/screens/Settings/ContentAndMediaSettings.tsx:57
-#: src/screens/Settings/ContentAndMediaSettings.tsx:60
+#: src/screens/Settings/ContentAndMediaSettings.tsx:56
+#: src/screens/Settings/ContentAndMediaSettings.tsx:59
 msgid "Following feed preferences"
 msgstr "Preferenze del feed Following"
 
-#: src/Navigation.tsx:300 src/screens/Settings/FollowingFeedPreferences.tsx:50
+#: src/Navigation.tsx:300 src/screens/Settings/FollowingFeedPreferences.tsx:49
 msgid "Following Feed Preferences"
 msgstr "Preferenze del Following Feed"
 
-#: src/screens/Profile/Header/Handle.tsx:33
+#: src/screens/Profile/Header/Handle.tsx:32
 msgid "Follows you"
 msgstr "Ti segue"
 
@@ -2872,7 +2873,7 @@ msgstr "Ottieni aiuto"
 msgid "Get Started"
 msgstr "Inizia"
 
-#: src/components/ProgressGuide/List.tsx:33
+#: src/components/ProgressGuide/List.tsx:32
 msgid "Getting started"
 msgstr "Iniziamo"
 
@@ -2896,7 +2897,7 @@ msgstr "Evidenti violazioni della legge o dei termini di servizio"
 msgid "Go back"
 msgstr "Torna indietro"
 
-#: src/components/Error.tsx:79 src/screens/List/ListHiddenScreen.tsx:210
+#: src/components/Error.tsx:78 src/screens/List/ListHiddenScreen.tsx:210
 #: src/screens/Profile/ErrorState.tsx:62 src/screens/Profile/ErrorState.tsx:66
 #: src/screens/StarterPack/StarterPackScreen.tsx:757
 #: src/view/screens/NotFound.tsx:56 src/view/screens/ProfileFeed.tsx:118
@@ -2912,7 +2913,7 @@ msgstr "Torna alla pagina precedente"
 #: src/components/ReportDialog/SelectReportOptionView.tsx:80
 #: src/components/ReportDialog/SubmitView.tsx:109
 #: src/screens/Onboarding/Layout.tsx:102 src/screens/Onboarding/Layout.tsx:191
-#: src/screens/Signup/BackNextButtons.tsx:36
+#: src/screens/Signup/BackNextButtons.tsx:35
 msgid "Go back to previous step"
 msgstr "Torna al passaggio precedente"
 
@@ -2946,8 +2947,8 @@ msgid "Go to user's profile"
 msgstr "Vai al profilo dell'utente"
 
 #: src/lib/moderation/useGlobalLabelStrings.ts:46
-#: src/view/com/composer/labels/LabelsBtn.tsx:203
-#: src/view/com/composer/labels/LabelsBtn.tsx:206
+#: src/view/com/composer/labels/LabelsBtn.tsx:202
+#: src/view/com/composer/labels/LabelsBtn.tsx:205
 msgid "Graphic Media"
 msgstr "Media grafici"
 
@@ -2955,8 +2956,8 @@ msgstr "Media grafici"
 msgid "Half way there!"
 msgstr "Siamo a metà!"
 
-#: src/screens/Settings/AccountSettings.tsx:119
-#: src/screens/Settings/AccountSettings.tsx:124
+#: src/screens/Settings/AccountSettings.tsx:118
+#: src/screens/Settings/AccountSettings.tsx:123
 msgid "Handle"
 msgstr "Nome utente"
 
@@ -2973,7 +2974,7 @@ msgstr "Nome utente modificato!"
 msgid "Handle too long. Please try a shorter one."
 msgstr "Nome utente troppo lungo. Provarne uno più breve."
 
-#: src/screens/Settings/AccessibilitySettings.tsx:80
+#: src/screens/Settings/AccessibilitySettings.tsx:79
 msgid "Haptics"
 msgstr "Aptica"
 
@@ -2994,7 +2995,7 @@ msgid "Having trouble?"
 msgstr "Ci sono problemi?"
 
 #: src/screens/Settings/Settings.tsx:199 src/screens/Settings/Settings.tsx:203
-#: src/view/shell/desktop/RightNav.tsx:99 src/view/shell/Drawer.tsx:332
+#: src/view/shell/desktop/RightNav.tsx:98 src/view/shell/Drawer.tsx:332
 msgid "Help"
 msgstr "Aiuto"
 
@@ -3017,7 +3018,7 @@ msgstr "Lista nascosta"
 #: src/lib/moderation/useLabelBehaviorDescription.ts:20
 #: src/lib/moderation/useLabelBehaviorDescription.ts:25
 #: src/lib/moderation/useLabelBehaviorDescription.ts:30
-#: src/view/com/util/forms/PostDropdownBtn.tsx:684
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:643
 msgid "Hide"
 msgstr "Nascondi"
 
@@ -3026,18 +3027,18 @@ msgctxt "action"
 msgid "Hide"
 msgstr "Nascondi"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:543
-#: src/view/com/util/forms/PostDropdownBtn.tsx:549
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:505
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:511
 msgid "Hide post for me"
 msgstr "Nascondi post per me"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:560
-#: src/view/com/util/forms/PostDropdownBtn.tsx:570
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:522
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:532
 msgid "Hide reply for everyone"
 msgstr "Nascondi risposta per tutti"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:542
-#: src/view/com/util/forms/PostDropdownBtn.tsx:548
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:504
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:510
 msgid "Hide reply for me"
 msgstr "Nascondi risposta per me"
 
@@ -3046,12 +3047,12 @@ msgstr "Nascondi risposta per me"
 msgid "Hide the content"
 msgstr "Nascondere il contenuto"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:679
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:638
 msgid "Hide this post?"
 msgstr "Vuoi nascondere questo post?"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:679
-#: src/view/com/util/forms/PostDropdownBtn.tsx:741
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:638
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:700
 msgid "Hide this reply?"
 msgstr "Nascondere questa risposta?"
 
@@ -3089,7 +3090,7 @@ msgstr "Non siamo riusciti a caricare il servizio di moderazione."
 
 #: src/view/com/composer/state/video.ts:426
 msgid "Hold up! We’re gradually giving access to video, and you’re still waiting in line. Check back soon!"
-msgstr ""
+msgstr "Un po' di pazienza: stiamo gradualmente dando accesso al video e tu sei ancora in coda. Ricontrolla presto!"
 
 #: src/Navigation.tsx:585 src/Navigation.tsx:605
 #: src/view/shell/bottom-bar/BottomBar.tsx:158
@@ -3132,7 +3133,7 @@ msgid "I have my own domain"
 msgstr "Ho il mio dominio"
 
 #: src/components/dms/BlockedByListDialog.tsx:57
-#: src/components/dms/ReportConversationPrompt.tsx:22
+#: src/components/dms/ReportConversationPrompt.tsx:21
 msgid "I understand"
 msgstr "Ho capito"
 
@@ -3152,7 +3153,7 @@ msgstr "Se elimini questa lista, non potrai recuperarla."
 msgid "If you have your own domain, you can use that as your handle. This lets you self-verify your identity – <0>learn more</0>."
 msgstr "Se hai un tuo dominio, puoi usarlo come nome utente. Questo consente di auto-verificare la tua identità – <0>ulteriori informazioni</0>."
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:670
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:629
 msgid "If you remove this post, you won't be able to recover it."
 msgstr "Se rimuovi questo post, non potrai recuperarlo."
 
@@ -3172,7 +3173,7 @@ msgstr "Illegale e Urgente"
 msgid "Image"
 msgstr "Immagine"
 
-#: src/components/StarterPack/ShareDialog.tsx:77
+#: src/components/StarterPack/ShareDialog.tsx:76
 msgid "Image saved to your camera roll!"
 msgstr "Immagine salvata nella galleria!"
 
@@ -3220,7 +3221,7 @@ msgstr "Inserisci la tua password"
 msgid "Input your user handle"
 msgstr "Inserisci il tuo nome utente"
 
-#: src/view/com/composer/threadgate/ThreadgateBtn.tsx:50
+#: src/view/com/composer/threadgate/ThreadgateBtn.tsx:49
 msgid "Interaction limited"
 msgstr "Interazione limitata"
 
@@ -3265,15 +3266,15 @@ msgstr "Codici di invito: {0} disponibili"
 msgid "Invite codes: 1 available"
 msgstr "Codici di invito: 1 disponibile"
 
-#: src/components/StarterPack/ShareDialog.tsx:97
+#: src/components/StarterPack/ShareDialog.tsx:96
 msgid "Invite people to this starter pack!"
 msgstr "Invita persone nel tuo starter pack!"
 
-#: src/screens/StarterPack/Wizard/StepDetails.tsx:35
+#: src/screens/StarterPack/Wizard/StepDetails.tsx:34
 msgid "Invite your friends to follow your favorite feeds and people"
 msgstr "Invita i tuoi amici per seguire persone e feed preferiti"
 
-#: src/screens/StarterPack/Wizard/StepDetails.tsx:32
+#: src/screens/StarterPack/Wizard/StepDetails.tsx:31
 msgid "Invites, but personal"
 msgstr "Inviti, ma personali"
 
@@ -3291,7 +3292,7 @@ msgstr "Sei solo tu al momento! Aggiungi altre persone al tuo starter pack cerca
 
 #: src/view/com/composer/Composer.tsx:1566
 msgid "Job ID: {0}"
-msgstr ""
+msgstr "ID processo: {0}"
 
 #: src/view/com/auth/SplashScreen.web.tsx:178
 msgid "Jobs"
@@ -3304,7 +3305,8 @@ msgstr "Lavori"
 msgid "Join Bluesky"
 msgstr "Entra in Bluesky"
 
-#: src/components/StarterPack/QrCode.tsx:61 src/view/shell/NavSignupCard.tsx:40
+#: src/components/StarterPack/QrCode.tsx:61
+#: src/view/shell/NavSignupCard.tsx:40
 msgid "Join the conversation"
 msgstr "Entra nella conversazione"
 
@@ -3320,12 +3322,12 @@ msgstr "Etichettato da {0}."
 msgid "Labeled by the author."
 msgstr "Etichettato dall'autore."
 
-#: src/view/com/composer/labels/LabelsBtn.tsx:76
+#: src/view/com/composer/labels/LabelsBtn.tsx:75
 #: src/view/screens/Profile.tsx:226
 msgid "Labels"
 msgstr "Etichette"
 
-#: src/view/com/composer/labels/LabelsBtn.tsx:74
+#: src/view/com/composer/labels/LabelsBtn.tsx:73
 msgid "Labels added"
 msgstr "Etichette aggiunte"
 
@@ -3388,8 +3390,8 @@ msgstr "Scopri di più sulla moderazione applicata a questo contenuto."
 msgid "Learn more about this warning"
 msgstr "Ulteriori informazioni su questo avviso"
 
-#: src/screens/Settings/PrivacyAndSecuritySettings.tsx:92
-#: src/screens/Settings/PrivacyAndSecuritySettings.tsx:95
+#: src/screens/Settings/PrivacyAndSecuritySettings.tsx:91
+#: src/screens/Settings/PrivacyAndSecuritySettings.tsx:94
 msgid "Learn more about what is public on Bluesky."
 msgstr "Scopri cosa è pubblico su Bluesky."
 
@@ -3398,7 +3400,7 @@ msgstr "Scopri cosa è pubblico su Bluesky."
 msgid "Learn more."
 msgstr "Saperne di più."
 
-#: src/components/dms/LeaveConvoPrompt.tsx:50
+#: src/components/dms/LeaveConvoPrompt.tsx:49
 msgid "Leave"
 msgstr "Abbandona"
 
@@ -3409,7 +3411,7 @@ msgstr "Abbandona la chat"
 
 #: src/components/dms/ConvoMenu.tsx:138 src/components/dms/ConvoMenu.tsx:141
 #: src/components/dms/ConvoMenu.tsx:208 src/components/dms/ConvoMenu.tsx:211
-#: src/components/dms/LeaveConvoPrompt.tsx:46
+#: src/components/dms/LeaveConvoPrompt.tsx:45
 msgid "Leave conversation"
 msgstr "Abbandona la conversazione"
 
@@ -3421,7 +3423,7 @@ msgstr "Deseleziona tutte per vedere qualsiasi lingua."
 msgid "Leaving Bluesky"
 msgstr "Stai lasciando Bluesky"
 
-#: src/screens/SignupQueued.tsx:134
+#: src/screens/SignupQueued.tsx:141
 msgid "left to go."
 msgstr "mancanti."
 
@@ -3441,7 +3443,7 @@ msgstr "Andiamo!"
 msgid "Light"
 msgstr "Chiaro"
 
-#: src/components/ProgressGuide/List.tsx:48
+#: src/components/ProgressGuide/List.tsx:47
 msgid "Like 10 posts"
 msgstr "Metti like a 10 post"
 
@@ -3544,8 +3546,9 @@ msgstr "Carica più follow consigliati"
 msgid "Load new notifications"
 msgstr "Carica più notifiche"
 
-#: src/screens/Profile/Sections/Feed.tsx:96 src/view/com/feeds/FeedPage.tsx:132
-#: src/view/screens/ProfileFeed.tsx:499 src/view/screens/ProfileList.tsx:808
+#: src/screens/Profile/Sections/Feed.tsx:96
+#: src/view/com/feeds/FeedPage.tsx:132 src/view/screens/ProfileFeed.tsx:499
+#: src/view/screens/ProfileList.tsx:808
 msgid "Load new posts"
 msgstr "Carica nuovi posts"
 
@@ -3561,12 +3564,12 @@ msgstr "Log"
 msgid "Log in or sign up"
 msgstr "Accedi o Iscriviti"
 
-#: src/screens/SignupQueued.tsx:155 src/screens/SignupQueued.tsx:158
-#: src/screens/SignupQueued.tsx:184 src/screens/SignupQueued.tsx:187
+#: src/screens/SignupQueued.tsx:169 src/screens/SignupQueued.tsx:172
+#: src/screens/SignupQueued.tsx:197 src/screens/SignupQueued.tsx:200
 msgid "Log out"
 msgstr "Esci"
 
-#: src/screens/Settings/PrivacyAndSecuritySettings.tsx:71
+#: src/screens/Settings/PrivacyAndSecuritySettings.tsx:70
 msgid "Logged-out visibility"
 msgstr "Visibilità degli utenti disconnessi"
 
@@ -3574,7 +3577,7 @@ msgstr "Visibilità degli utenti disconnessi"
 msgid "Login to account that is not listed"
 msgstr "Accedi all'account che non è nella lista"
 
-#: src/view/shell/desktop/RightNav.tsx:104
+#: src/view/shell/desktop/RightNav.tsx:103
 msgid "Logo by <0/>"
 msgstr "Logo di <0/>"
 
@@ -3610,8 +3613,8 @@ msgstr "Creane uno per me"
 msgid "Make sure this is where you intend to go!"
 msgstr "Assicurati che questo sia dove intendi andare!"
 
-#: src/screens/Settings/ContentAndMediaSettings.tsx:41
-#: src/screens/Settings/ContentAndMediaSettings.tsx:44
+#: src/screens/Settings/ContentAndMediaSettings.tsx:40
+#: src/screens/Settings/ContentAndMediaSettings.tsx:43
 msgid "Manage saved feeds"
 msgstr "Gestisci i feed salvati"
 
@@ -3627,7 +3630,7 @@ msgstr "Segna come letto"
 msgid "Media"
 msgstr "Media"
 
-#: src/view/com/composer/labels/LabelsBtn.tsx:212
+#: src/view/com/composer/labels/LabelsBtn.tsx:211
 msgid "Media that may be disturbing or inappropriate for some audiences."
 msgstr "Media che potrebbero disturbare o risultare inappropriati per alcuni tipi di pubblico."
 
@@ -3688,7 +3691,7 @@ msgstr "Post ingannevole"
 msgid "Moderation"
 msgstr "Moderazione"
 
-#: src/components/moderation/ModerationDetailsDialog.tsx:133
+#: src/components/moderation/ModerationDetailsDialog.tsx:132
 msgid "Moderation details"
 msgstr "Dettagli sulla moderazione"
 
@@ -3734,7 +3737,7 @@ msgstr "Stato di moderazione"
 msgid "Moderation tools"
 msgstr "Strumenti di moderazione"
 
-#: src/components/moderation/ModerationDetailsDialog.tsx:51
+#: src/components/moderation/ModerationDetailsDialog.tsx:50
 #: src/lib/moderation/useModerationCauseDescription.ts:45
 msgid "Moderator has chosen to set a general warning on the content."
 msgstr "Il moderatore ha scelto di mettere un avviso generale sul contenuto."
@@ -3743,7 +3746,7 @@ msgstr "Il moderatore ha scelto di mettere un avviso generale sul contenuto."
 msgid "More"
 msgstr "Di più"
 
-#: src/view/shell/desktop/Feeds.tsx:55
+#: src/view/shell/desktop/Feeds.tsx:54
 msgid "More feeds"
 msgstr "Altri feed"
 
@@ -3752,11 +3755,11 @@ msgstr "Altri feed"
 msgid "More options"
 msgstr "Altre opzioni"
 
-#: src/screens/Settings/ThreadPreferences.tsx:81
+#: src/screens/Settings/ThreadPreferences.tsx:80
 msgid "Most-liked first"
-msgstr ""
+msgstr "Prima quelli con più like"
 
-#: src/screens/Settings/ThreadPreferences.tsx:78
+#: src/screens/Settings/ThreadPreferences.tsx:77
 msgid "Most-liked replies first"
 msgstr "Dai priorità alle risposte con più likes"
 
@@ -3772,7 +3775,7 @@ msgstr "Musica"
 msgid "Mute"
 msgstr "Silenzia"
 
-#: src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerNative.tsx:157
+#: src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerNative.tsx:156
 #: src/view/com/util/post-embeds/VideoEmbedInner/web-controls/VolumeControl.tsx:94
 msgctxt "video"
 msgid "Mute"
@@ -3835,13 +3838,13 @@ msgstr "Siilenzia questa parola solo nei tags"
 msgid "Mute this word until you unmute it"
 msgstr "Silenzia questa parola finchè non la riattivi"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:507
-#: src/view/com/util/forms/PostDropdownBtn.tsx:513
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:471
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:475
 msgid "Mute thread"
 msgstr "Silenzia questa discussione"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:523
-#: src/view/com/util/forms/PostDropdownBtn.tsx:525
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:485
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:487
 msgid "Mute words & tags"
 msgstr "Silenzia parole & tags"
 
@@ -3991,8 +3994,8 @@ msgstr "Finestra informativa per nuovi utenti"
 msgid "New User List"
 msgstr "Nuova lista"
 
-#: src/screens/Settings/ThreadPreferences.tsx:70
-#: src/screens/Settings/ThreadPreferences.tsx:73
+#: src/screens/Settings/ThreadPreferences.tsx:69
+#: src/screens/Settings/ThreadPreferences.tsx:72
 msgid "Newest replies first"
 msgstr "Mostrare prima le risposte più recenti"
 
@@ -4007,7 +4010,7 @@ msgstr "Notizie"
 #: src/screens/Login/SetNewPasswordForm.tsx:174
 #: src/screens/Settings/components/AddAppPasswordDialog.tsx:157
 #: src/screens/Settings/components/AddAppPasswordDialog.tsx:165
-#: src/screens/Signup/BackNextButtons.tsx:68
+#: src/screens/Signup/BackNextButtons.tsx:67
 #: src/screens/StarterPack/Wizard/index.tsx:192
 #: src/screens/StarterPack/Wizard/index.tsx:196
 #: src/screens/StarterPack/Wizard/index.tsx:367
@@ -4023,7 +4026,7 @@ msgstr "Immagine successiva"
 
 #: src/screens/Settings/AppPasswords.tsx:100
 msgid "No app passwords yet"
-msgstr ""
+msgstr "Non è stata ancora definita alcuna password per le app"
 
 #: src/view/screens/ProfileFeed.tsx:565 src/view/screens/ProfileList.tsx:882
 msgid "No description"
@@ -4089,7 +4092,7 @@ msgid "No reposts yet"
 msgstr "Ancora nessun repost"
 
 #: src/view/com/composer/text-input/mobile/Autocomplete.tsx:111
-#: src/view/com/composer/text-input/web/Autocomplete.tsx:196
+#: src/view/com/composer/text-input/web/Autocomplete.tsx:191
 msgid "No result"
 msgstr "Nessun risultato"
 
@@ -4156,12 +4159,12 @@ msgid "Not right now"
 msgstr "Non adesso"
 
 #: src/view/com/profile/ProfileMenu.tsx:348
-#: src/view/com/util/forms/PostDropdownBtn.tsx:698
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:657
 #: src/view/com/util/post-ctrls/PostCtrls.tsx:350
 msgid "Note about sharing"
 msgstr "Nota sulla condivisione"
 
-#: src/screens/Settings/PrivacyAndSecuritySettings.tsx:81
+#: src/screens/Settings/PrivacyAndSecuritySettings.tsx:80
 msgid "Note: Bluesky is an open and public network. This setting only limits the visibility of your content on the Bluesky app and website, and other apps may not respect this setting. Your content may still be shown to logged-out users by other apps and websites."
 msgstr "Nota: Bluesky è una rete aperta e pubblica. Questa impostazione limita solo la visibilità dei tuoi contenuti sull'app e sul sito Web di Bluesky e altre app potrebbero non rispettare questa impostazione. I tuoi contenuti potrebbero comunque essere mostrati agli utenti disconnessi da altre app e siti web."
 
@@ -4169,7 +4172,7 @@ msgstr "Nota: Bluesky è una rete aperta e pubblica. Questa impostazione limita 
 msgid "Nothing here"
 msgstr "Nulla qui"
 
-#: src/screens/Settings/NotificationSettings.tsx:51
+#: src/screens/Settings/NotificationSettings.tsx:50
 msgid "Notification filters"
 msgstr "Filtri notifiche"
 
@@ -4177,7 +4180,7 @@ msgstr "Filtri notifiche"
 msgid "Notification settings"
 msgstr "Notifiche"
 
-#: src/screens/Settings/NotificationSettings.tsx:37
+#: src/screens/Settings/NotificationSettings.tsx:36
 msgid "Notification Settings"
 msgstr "Notifiche"
 
@@ -4205,8 +4208,8 @@ msgstr "ora"
 msgid "Now"
 msgstr "Ora"
 
-#: src/view/com/composer/labels/LabelsBtn.tsx:152
-#: src/view/com/composer/labels/LabelsBtn.tsx:155
+#: src/view/com/composer/labels/LabelsBtn.tsx:151
+#: src/view/com/composer/labels/LabelsBtn.tsx:154
 msgid "Nudity"
 msgstr "Nudità"
 
@@ -4231,13 +4234,13 @@ msgstr "Oh no! Qualcosa è andato male."
 msgid "OK"
 msgstr "OK"
 
-#: src/screens/Login/PasswordUpdatedForm.tsx:38
+#: src/screens/Login/PasswordUpdatedForm.tsx:37
 #: src/view/com/post-thread/PostThreadItem.tsx:855
 msgid "Okay"
 msgstr "Va bene"
 
-#: src/screens/Settings/ThreadPreferences.tsx:62
-#: src/screens/Settings/ThreadPreferences.tsx:65
+#: src/screens/Settings/ThreadPreferences.tsx:61
+#: src/screens/Settings/ThreadPreferences.tsx:64
 msgid "Oldest replies first"
 msgstr "Mostrare prima le risposte più vecchie"
 
@@ -4290,7 +4293,7 @@ msgstr "Ops! Qualcosa è andato male!"
 #: src/components/StarterPack/ProfileStarterPacks.tsx:331
 #: src/screens/Settings/AppPasswords.tsx:51
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:101
-#: src/screens/Settings/NotificationSettings.tsx:41
+#: src/screens/Settings/NotificationSettings.tsx:40
 #: src/view/screens/Profile.tsx:128
 msgid "Oops!"
 msgstr "Ops!"
@@ -4307,7 +4310,7 @@ msgstr ""
 msgid "Open avatar creator"
 msgstr "Apri il creatore di avatar"
 
-#: src/screens/Settings/AccountSettings.tsx:120
+#: src/screens/Settings/AccountSettings.tsx:119
 msgid "Open change handle dialog"
 msgstr "Apri la finestra di dialogo per la modifica del nome utente"
 
@@ -4350,7 +4353,7 @@ msgstr "Apri le impostazioni delle parole e dei tag silenziati"
 msgid "Open navigation"
 msgstr "Apri la navigazione"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:365
+#: src/view/com/util/forms/PostDropdownBtn.tsx:70
 msgid "Open post options menu"
 msgstr "Apri il menu delle opzioni del post"
 
@@ -4370,11 +4373,11 @@ msgstr "Apri il registro di sistema"
 msgid "Opens {numItems} options"
 msgstr "Apre le {numItems} opzioni"
 
-#: src/view/com/composer/labels/LabelsBtn.tsx:63
+#: src/view/com/composer/labels/LabelsBtn.tsx:62
 msgid "Opens a dialog to add a content warning to your post"
 msgstr ""
 
-#: src/view/com/composer/threadgate/ThreadgateBtn.tsx:62
+#: src/view/com/composer/threadgate/ThreadgateBtn.tsx:61
 msgid "Opens a dialog to choose who can reply to this thread"
 msgstr "Apre un menu per scegliere chi può rispondere a questo thread"
 
@@ -4386,7 +4389,7 @@ msgstr "Apre dettagli aggiuntivi per una debug entry"
 msgid "Opens camera on device"
 msgstr "Apre la fotocamera sul dispositivo"
 
-#: src/view/com/post-thread/PostThreadComposePrompt.tsx:36
+#: src/view/com/post-thread/PostThreadComposePrompt.tsx:35
 msgid "Opens composer"
 msgstr "Apre il compositore"
 
@@ -4394,12 +4397,12 @@ msgstr "Apre il compositore"
 msgid "Opens device photo gallery"
 msgstr "Apre la galleria fotografica del dispositivo"
 
-#: src/view/com/auth/SplashScreen.tsx:50
+#: src/view/com/auth/SplashScreen.tsx:49
 #: src/view/com/auth/SplashScreen.web.tsx:111
 msgid "Opens flow to create a new Bluesky account"
 msgstr "Apre il procedimento per creare un nuovo account Bluesky"
 
-#: src/view/com/auth/SplashScreen.tsx:64
+#: src/view/com/auth/SplashScreen.tsx:63
 #: src/view/com/auth/SplashScreen.web.tsx:125
 msgid "Opens flow to sign into your existing Bluesky account"
 msgstr "Apre il procedimento per accedere al tuo account esistente di Bluesky"
@@ -4455,7 +4458,7 @@ msgid "Or, log into one of your other accounts."
 msgstr "Oppure, accedi in uno dei tuoi altri account."
 
 #: src/lib/moderation/useReportOptions.ts:27
-#: src/view/com/composer/labels/LabelsBtn.tsx:187
+#: src/view/com/composer/labels/LabelsBtn.tsx:186
 msgid "Other"
 msgstr "Altri"
 
@@ -4480,8 +4483,8 @@ msgid "Page Not Found"
 msgstr "Pagina non trovata"
 
 #: src/screens/Login/LoginForm.tsx:210
-#: src/screens/Settings/AccountSettings.tsx:110
-#: src/screens/Settings/AccountSettings.tsx:114
+#: src/screens/Settings/AccountSettings.tsx:109
+#: src/screens/Settings/AccountSettings.tsx:113
 #: src/screens/Signup/StepInfo/index.tsx:192
 #: src/view/com/modals/DeleteAccount.tsx:258
 #: src/view/com/modals/DeleteAccount.tsx:265
@@ -4496,12 +4499,12 @@ msgstr "Password Cambiato"
 msgid "Password updated"
 msgstr "Password aggiornata"
 
-#: src/screens/Login/PasswordUpdatedForm.tsx:24
+#: src/screens/Login/PasswordUpdatedForm.tsx:23
 msgid "Password updated!"
 msgstr "Password aggiornata!"
 
 #: src/view/com/util/post-embeds/GifEmbed.tsx:43
-#: src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerNative.tsx:141
+#: src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerNative.tsx:140
 #: src/view/com/util/post-embeds/VideoEmbedInner/web-controls/VideoControls.tsx:368
 msgid "Pause"
 msgstr "Pausa"
@@ -4531,7 +4534,7 @@ msgstr "È richiesta l'autorizzazione per accedere al la cartella delle immagini
 msgid "Permission to access camera roll was denied. Please enable it in your system settings."
 msgstr "L'autorizzazione per accedere la cartella delle immagini è stata negata. Si prega di abilitarla nelle impostazioni del sistema."
 
-#: src/components/StarterPack/Wizard/WizardListCard.tsx:55
+#: src/components/StarterPack/Wizard/WizardListCard.tsx:54
 msgid "Person toggle"
 msgstr ""
 
@@ -4543,7 +4546,7 @@ msgstr "Animali di compagnia"
 msgid "Photography"
 msgstr "Foto"
 
-#: src/view/com/composer/labels/LabelsBtn.tsx:171
+#: src/view/com/composer/labels/LabelsBtn.tsx:170
 msgid "Pictures meant for adults."
 msgstr "Immagini per adulti."
 
@@ -4555,8 +4558,8 @@ msgstr "Fissa su Home"
 msgid "Pin to Home"
 msgstr "Fissa su Home"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:398
-#: src/view/com/util/forms/PostDropdownBtn.tsx:405
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:362
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:369
 msgid "Pin to your profile"
 msgstr "Fissa sul tuo profilo"
 
@@ -4573,7 +4576,7 @@ msgid "Pinned to your feeds"
 msgstr "Fissa ai tuoi feed"
 
 #: src/view/com/util/post-embeds/GifEmbed.tsx:43
-#: src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerNative.tsx:141
+#: src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerNative.tsx:140
 #: src/view/com/util/post-embeds/VideoEmbedInner/web-controls/VideoControls.tsx:369
 msgid "Play"
 msgstr "Play"
@@ -4586,7 +4589,7 @@ msgstr "Riproduci {0}"
 msgid "Play or pause the GIF"
 msgstr "Riproduci o pausa la GIF"
 
-#: src/view/com/util/post-embeds/VideoEmbed.tsx:110
+#: src/view/com/util/post-embeds/VideoEmbed.tsx:107
 #: src/view/com/util/post-embeds/VideoEmbedInner/web-controls/VideoControls.tsx:321
 msgid "Play video"
 msgstr "Riproduci video"
@@ -4642,7 +4645,7 @@ msgstr "Spiega perché ritieni che questa etichetta sia stata applicata in modo 
 
 #: src/screens/Messages/components/ChatDisabled.tsx:110
 msgid "Please explain why you think your chats were incorrectly disabled"
-msgstr "Per favore spiega perché pensi che i tuoi messaggi siano stati erroneamente disabiltiati"
+msgstr "Spiega perché pensi che i tuoi messaggi siano stati disabiltiati per errore"
 
 #: src/lib/hooks/useAccountSwitcher.ts:45
 #: src/lib/hooks/useAccountSwitcher.ts:55
@@ -4657,7 +4660,7 @@ msgstr "Verifica la tua email"
 msgid "Politics"
 msgstr "Politica"
 
-#: src/view/com/composer/labels/LabelsBtn.tsx:158
+#: src/view/com/composer/labels/LabelsBtn.tsx:157
 msgid "Porn"
 msgstr "Porno"
 
@@ -4685,7 +4688,7 @@ msgstr "Pubblicato da {0}"
 msgid "Post by @{0}"
 msgstr "Pubblicato da @{0}"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:180
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:169
 msgid "Post deleted"
 msgstr "Post eliminato"
 
@@ -4697,12 +4700,12 @@ msgstr ""
 msgid "Post hidden"
 msgstr "Post nascosto"
 
-#: src/components/moderation/ModerationDetailsDialog.tsx:106
+#: src/components/moderation/ModerationDetailsDialog.tsx:105
 #: src/lib/moderation/useModerationCauseDescription.ts:104
 msgid "Post Hidden by Muted Word"
 msgstr "Post nascosto dalla Parola Silenziata"
 
-#: src/components/moderation/ModerationDetailsDialog.tsx:109
+#: src/components/moderation/ModerationDetailsDialog.tsx:108
 #: src/lib/moderation/useModerationCauseDescription.ts:113
 msgid "Post Hidden by You"
 msgstr "Post nascosto da te"
@@ -4765,9 +4768,9 @@ msgstr "Premere per tentare di riconnetterti"
 msgid "Press to change hosting provider"
 msgstr "Premi per cambiare provider di hosting"
 
-#: src/components/Error.tsx:61 src/components/Lists.tsx:93
+#: src/components/Error.tsx:60 src/components/Lists.tsx:93
 #: src/screens/Messages/components/MessageListError.tsx:24
-#: src/screens/Signup/BackNextButtons.tsx:48
+#: src/screens/Signup/BackNextButtons.tsx:47
 msgid "Press to retry"
 msgstr "Premere per riprovare"
 
@@ -4783,16 +4786,16 @@ msgstr "Immagine precedente"
 msgid "Primary Language"
 msgstr "Lingua principale"
 
-#: src/screens/Settings/ThreadPreferences.tsx:99
-#: src/screens/Settings/ThreadPreferences.tsx:104
+#: src/screens/Settings/ThreadPreferences.tsx:98
+#: src/screens/Settings/ThreadPreferences.tsx:103
 msgid "Prioritize your Follows"
 msgstr "Dai priorità a chi segui"
 
-#: src/screens/Settings/NotificationSettings.tsx:54
+#: src/screens/Settings/NotificationSettings.tsx:53
 msgid "Priority notifications"
 msgstr "Impostazioni di priorità"
 
-#: src/view/shell/desktop/RightNav.tsx:81
+#: src/view/shell/desktop/RightNav.tsx:80
 msgid "Privacy"
 msgstr "Privacy"
 
@@ -4801,12 +4804,12 @@ msgid "Privacy and security"
 msgstr "Privacy e sicurezza"
 
 #: src/Navigation.tsx:345
-#: src/screens/Settings/PrivacyAndSecuritySettings.tsx:33
+#: src/screens/Settings/PrivacyAndSecuritySettings.tsx:32
 msgid "Privacy and Security"
 msgstr "Privacy e sicurezza"
 
-#: src/Navigation.tsx:269 src/screens/Settings/AboutSettings.tsx:38
-#: src/screens/Settings/AboutSettings.tsx:41
+#: src/Navigation.tsx:269 src/screens/Settings/AboutSettings.tsx:37
+#: src/screens/Settings/AboutSettings.tsx:40
 #: src/view/screens/PrivacyPolicy.tsx:31 src/view/shell/Drawer.tsx:624
 #: src/view/shell/Drawer.tsx:625
 msgid "Privacy Policy"
@@ -4866,11 +4869,11 @@ msgstr "Codice QR salvato nella galleria!"
 msgid "Quote post"
 msgstr "Cita il post"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:308
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:297
 msgid "Quote post was re-attached"
 msgstr "Citazione post riattaccata"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:307
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:296
 msgid "Quote post was successfully detached"
 msgstr "Citazione post staccata con successo"
 
@@ -4898,8 +4901,8 @@ msgstr "Citazioni"
 msgid "Quotes of this post"
 msgstr "Citazioni post"
 
-#: src/screens/Settings/ThreadPreferences.tsx:86
-#: src/screens/Settings/ThreadPreferences.tsx:89
+#: src/screens/Settings/ThreadPreferences.tsx:85
+#: src/screens/Settings/ThreadPreferences.tsx:88
 msgid "Random (aka \"Poster's Roulette\")"
 msgstr "Selezione a caso (nota anche come \"Poster's Roulette\")"
 
@@ -4907,8 +4910,8 @@ msgstr "Selezione a caso (nota anche come \"Poster's Roulette\")"
 msgid "Rate limit exceeded – you've tried to change your handle too many times in a short period. Please wait a minute before trying again."
 msgstr "Limite di richieste superato: hai provato a cambiare il nome utente troppe volte in un breve lasso di tempo. Attendi un minuto prima di riprovare."
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:585
-#: src/view/com/util/forms/PostDropdownBtn.tsx:595
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:547
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:557
 msgid "Re-attach quote"
 msgstr "Riattacca citazioni"
 
@@ -4951,8 +4954,8 @@ msgid "Reload conversations"
 msgstr "Ricarica conversazioni"
 
 #: src/components/dialogs/MutedWords.tsx:438 src/components/FeedCard.tsx:316
-#: src/components/StarterPack/Wizard/WizardListCard.tsx:102
-#: src/components/StarterPack/Wizard/WizardListCard.tsx:109
+#: src/components/StarterPack/Wizard/WizardListCard.tsx:101
+#: src/components/StarterPack/Wizard/WizardListCard.tsx:108
 #: src/screens/Settings/Settings.tsx:458
 #: src/view/com/feeds/FeedSourceCard.tsx:319
 #: src/view/com/modals/ListAddRemoveUsers.tsx:269
@@ -4961,7 +4964,7 @@ msgstr "Ricarica conversazioni"
 msgid "Remove"
 msgstr "Rimuovi"
 
-#: src/components/StarterPack/Wizard/WizardListCard.tsx:58
+#: src/components/StarterPack/Wizard/WizardListCard.tsx:57
 msgid "Remove {displayName} from starter pack"
 msgstr "Rimuovi {displayName} dallo starter pack"
 
@@ -4969,7 +4972,7 @@ msgstr "Rimuovi {displayName} dallo starter pack"
 msgid "Remove account"
 msgstr "Rimuovi account"
 
-#: src/view/com/composer/ExternalEmbedRemoveBtn.tsx:16
+#: src/view/com/composer/ExternalEmbedRemoveBtn.tsx:15
 msgid "Remove attachment"
 msgstr "Allegato rimosso"
 
@@ -5100,12 +5103,12 @@ msgctxt "action"
 msgid "Reply"
 msgstr "Risposta"
 
-#: src/components/moderation/ModerationDetailsDialog.tsx:115
+#: src/components/moderation/ModerationDetailsDialog.tsx:114
 #: src/lib/moderation/useModerationCauseDescription.ts:123
 msgid "Reply Hidden by Thread Author"
 msgstr "Risposta nascosta dall'autore del thread"
 
-#: src/components/moderation/ModerationDetailsDialog.tsx:114
+#: src/components/moderation/ModerationDetailsDialog.tsx:113
 #: src/lib/moderation/useModerationCauseDescription.ts:122
 msgid "Reply Hidden by You"
 msgstr "Risposta nascosta da me"
@@ -5138,11 +5141,11 @@ msgctxt "description"
 msgid "Reply to you"
 msgstr "Risposta a te"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:338
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:327
 msgid "Reply visibility updated"
 msgstr "Visibilità risposte aggiornata"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:337
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:326
 msgid "Reply was successfully hidden"
 msgstr "Risposta nascosta con successo"
 
@@ -5158,7 +5161,7 @@ msgid "Report Account"
 msgstr "Segnala l'account"
 
 #: src/components/dms/ConvoMenu.tsx:197 src/components/dms/ConvoMenu.tsx:200
-#: src/components/dms/ReportConversationPrompt.tsx:18
+#: src/components/dms/ReportConversationPrompt.tsx:17
 msgid "Report conversation"
 msgstr "Segnala la conversazione"
 
@@ -5178,8 +5181,8 @@ msgstr "Segnala la lista"
 msgid "Report message"
 msgstr "Segnala il messaggio"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:621
-#: src/view/com/util/forms/PostDropdownBtn.tsx:623
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:583
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:585
 msgid "Report post"
 msgstr "Segnala il post"
 
@@ -5268,8 +5271,8 @@ msgstr "Richiedi un cambio"
 msgid "Request Code"
 msgstr "Richiedi il codice"
 
-#: src/screens/Settings/AccessibilitySettings.tsx:53
-#: src/screens/Settings/AccessibilitySettings.tsx:58
+#: src/screens/Settings/AccessibilitySettings.tsx:52
+#: src/screens/Settings/AccessibilitySettings.tsx:57
 msgid "Require alt text before posting"
 msgstr "Richiedi il testo alternativo prima di pubblicare"
 
@@ -5320,27 +5323,27 @@ msgstr "Reimposta la password"
 msgid "Retries login"
 msgstr "Ritenta l'accesso"
 
-#: src/view/com/util/error/ErrorMessage.tsx:58
-#: src/view/com/util/error/ErrorScreen.tsx:75
+#: src/view/com/util/error/ErrorMessage.tsx:57
+#: src/view/com/util/error/ErrorScreen.tsx:74
 msgid "Retries the last action, which errored out"
 msgstr "Ritenta l'ultima azione che ha generato un errore"
 
-#: src/components/dms/MessageItem.tsx:244 src/components/Error.tsx:66
+#: src/components/dms/MessageItem.tsx:244 src/components/Error.tsx:65
 #: src/components/Lists.tsx:104
 #: src/components/StarterPack/ProfileStarterPacks.tsx:336
 #: src/screens/Login/LoginForm.tsx:295 src/screens/Login/LoginForm.tsx:302
 #: src/screens/Messages/components/MessageListError.tsx:25
 #: src/screens/Onboarding/StepInterests/index.tsx:217
 #: src/screens/Onboarding/StepInterests/index.tsx:220
-#: src/screens/Signup/BackNextButtons.tsx:54
-#: src/view/com/util/error/ErrorMessage.tsx:56
-#: src/view/com/util/error/ErrorScreen.tsx:73
+#: src/screens/Signup/BackNextButtons.tsx:53
+#: src/view/com/util/error/ErrorMessage.tsx:55
+#: src/view/com/util/error/ErrorScreen.tsx:72
 #: src/view/com/util/post-embeds/VideoEmbedInner/VideoFallback.tsx:55
 #: src/view/com/util/post-embeds/VideoEmbedInner/VideoFallback.tsx:57
 msgid "Retry"
 msgstr "Riprova"
 
-#: src/components/Error.tsx:74 src/screens/List/ListHiddenScreen.tsx:205
+#: src/components/Error.tsx:73 src/screens/List/ListHiddenScreen.tsx:205
 #: src/screens/StarterPack/StarterPackScreen.tsx:751
 #: src/view/screens/ProfileList.tsx:1030
 msgid "Return to previous page"
@@ -5390,8 +5393,8 @@ msgstr "Salva modifiche"
 msgid "Save Changes"
 msgstr "Salva modifiche"
 
-#: src/components/StarterPack/ShareDialog.tsx:151
-#: src/components/StarterPack/ShareDialog.tsx:158
+#: src/components/StarterPack/ShareDialog.tsx:150
+#: src/components/StarterPack/ShareDialog.tsx:157
 msgid "Save image"
 msgstr "Salva immagine"
 
@@ -5431,7 +5434,8 @@ msgstr "Salva eventuali modifiche al tuo profilo"
 msgid "Saves image crop settings"
 msgstr "Salva le impostazioni di ritaglio dell'immagine"
 
-#: src/components/dms/ChatEmptyPill.tsx:33 src/components/NewskieDialog.tsx:105
+#: src/components/dms/ChatEmptyPill.tsx:33
+#: src/components/NewskieDialog.tsx:105
 #: src/view/com/notifications/FeedItem.tsx:539
 #: src/view/com/notifications/FeedItem.tsx:564
 msgid "Say hello!"
@@ -5564,7 +5568,7 @@ msgstr "Seleziona lingua..."
 msgid "Select languages"
 msgstr "Seleziona lingue"
 
-#: src/components/ReportDialog/SelectLabelerView.tsx:29
+#: src/components/ReportDialog/SelectLabelerView.tsx:28
 msgid "Select moderator"
 msgstr "Seleziona moderatore"
 
@@ -5662,7 +5666,7 @@ msgstr "Invia post a..."
 msgid "Send report"
 msgstr "Invia la segnalazione"
 
-#: src/components/ReportDialog/SelectLabelerView.tsx:43
+#: src/components/ReportDialog/SelectLabelerView.tsx:42
 msgid "Send report to {0}"
 msgstr "Invia la segnalazione a {0}"
 
@@ -5671,14 +5675,14 @@ msgstr "Invia la segnalazione a {0}"
 msgid "Send verification email"
 msgstr "Invia la email di verifica"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:441
-#: src/view/com/util/forms/PostDropdownBtn.tsx:444
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:405
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:408
 msgid "Send via direct message"
 msgstr "Invia tramite messaggi"
 
 #: src/view/com/modals/DeleteAccount.tsx:151
 msgid "Sends email with confirmation code for account deletion"
-msgstr "Invia un'email con il codice di conferma per la cancellazione dell'account"
+msgstr "Invia un'email con il codice di conferma per l'eliminazione dell'account"
 
 #: src/view/com/auth/server-input/index.tsx:111
 msgid "Server address"
@@ -5705,7 +5709,7 @@ msgstr "Imposta l'email per la reimpostazione della password"
 msgid "Settings"
 msgstr "Impostazioni"
 
-#: src/view/com/composer/labels/LabelsBtn.tsx:175
+#: src/view/com/composer/labels/LabelsBtn.tsx:174
 msgid "Sexual activity or erotic nudity."
 msgstr "Attività sessuale o nudità erotica."
 
@@ -5718,8 +5722,8 @@ msgstr "Sessualmente allusivo"
 #: src/screens/StarterPack/StarterPackScreen.tsx:594
 #: src/view/com/profile/ProfileMenu.tsx:195
 #: src/view/com/profile/ProfileMenu.tsx:204
-#: src/view/com/util/forms/PostDropdownBtn.tsx:452
-#: src/view/com/util/forms/PostDropdownBtn.tsx:461
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:416
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:425
 #: src/view/com/util/post-ctrls/PostCtrls.tsx:339
 #: src/view/screens/ProfileList.tsx:487
 msgid "Share"
@@ -5739,7 +5743,7 @@ msgid "Share a fun fact!"
 msgstr "Condividi un fatto divertente!"
 
 #: src/view/com/profile/ProfileMenu.tsx:353
-#: src/view/com/util/forms/PostDropdownBtn.tsx:703
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:662
 #: src/view/com/util/post-ctrls/PostCtrls.tsx:355
 msgid "Share anyway"
 msgstr "Condividi comunque"
@@ -5748,8 +5752,8 @@ msgstr "Condividi comunque"
 msgid "Share feed"
 msgstr "Condividi il feed"
 
-#: src/components/StarterPack/ShareDialog.tsx:124
-#: src/components/StarterPack/ShareDialog.tsx:131
+#: src/components/StarterPack/ShareDialog.tsx:123
+#: src/components/StarterPack/ShareDialog.tsx:130
 #: src/screens/StarterPack/StarterPackScreen.tsx:598
 msgid "Share link"
 msgstr "Condividi link"
@@ -5759,12 +5763,12 @@ msgstr "Condividi link"
 msgid "Share Link"
 msgstr "Condividi il link"
 
-#: src/components/StarterPack/ShareDialog.tsx:88
+#: src/components/StarterPack/ShareDialog.tsx:87
 msgid "Share link dialog"
 msgstr "Finestra link di condivisione"
 
-#: src/components/StarterPack/ShareDialog.tsx:135
-#: src/components/StarterPack/ShareDialog.tsx:146
+#: src/components/StarterPack/ShareDialog.tsx:134
+#: src/components/StarterPack/ShareDialog.tsx:145
 msgid "Share QR code"
 msgstr "Condividi codice QR"
 
@@ -5772,7 +5776,7 @@ msgstr "Condividi codice QR"
 msgid "Share this starter pack"
 msgstr "Condividi starter pack"
 
-#: src/components/StarterPack/ShareDialog.tsx:100
+#: src/components/StarterPack/ShareDialog.tsx:99
 msgid "Share this starter pack and help people join your community on Bluesky."
 msgstr "Condividi starter pack e invita persone a far parte della tua community su Bluesky."
 
@@ -5813,7 +5817,7 @@ msgstr "Mostra badge"
 msgid "Show badge and filter from feeds"
 msgstr "Mostra badge e filtra dai feed"
 
-#: src/view/com/post-thread/PostThreadShowHiddenReplies.tsx:23
+#: src/view/com/post-thread/PostThreadShowHiddenReplies.tsx:22
 msgid "Show hidden replies"
 msgstr "Mostra risposte nascoste"
 
@@ -5821,8 +5825,8 @@ msgstr "Mostra risposte nascoste"
 msgid "Show information about when this post was created"
 msgstr ""
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:491
-#: src/view/com/util/forms/PostDropdownBtn.tsx:493
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:455
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:457
 msgid "Show less like this"
 msgstr "Mostra meno come questo"
 
@@ -5835,12 +5839,12 @@ msgstr "Mosta comunque questa lista"
 msgid "Show More"
 msgstr "Mostra di più"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:483
-#: src/view/com/util/forms/PostDropdownBtn.tsx:485
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:447
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:449
 msgid "Show more like this"
 msgstr "Mosta altro come questo"
 
-#: src/view/com/post-thread/PostThreadShowHiddenReplies.tsx:23
+#: src/view/com/post-thread/PostThreadShowHiddenReplies.tsx:22
 msgid "Show muted replies"
 msgstr "Mosta risposte silenziate"
 
@@ -5848,36 +5852,36 @@ msgstr "Mosta risposte silenziate"
 msgid "Show other accounts you can switch to"
 msgstr ""
 
-#: src/screens/Settings/FollowingFeedPreferences.tsx:97
-#: src/screens/Settings/FollowingFeedPreferences.tsx:107
+#: src/screens/Settings/FollowingFeedPreferences.tsx:96
+#: src/screens/Settings/FollowingFeedPreferences.tsx:106
 msgid "Show quote posts"
 msgstr "Mostra i post con citazione"
 
-#: src/screens/Settings/FollowingFeedPreferences.tsx:61
-#: src/screens/Settings/FollowingFeedPreferences.tsx:71
+#: src/screens/Settings/FollowingFeedPreferences.tsx:60
+#: src/screens/Settings/FollowingFeedPreferences.tsx:70
 msgid "Show replies"
 msgstr "Mostra risposte"
 
-#: src/screens/Settings/ThreadPreferences.tsx:113
+#: src/screens/Settings/ThreadPreferences.tsx:112
 msgid "Show replies by people you follow before all other replies"
 msgstr "Mostra risposte delle persone che segui prima delle altre risposte"
 
-#: src/screens/Settings/ThreadPreferences.tsx:138
+#: src/screens/Settings/ThreadPreferences.tsx:137
 msgid "Show replies in a threaded view"
 msgstr "Mostra risposte in modalità a thread"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:559
-#: src/view/com/util/forms/PostDropdownBtn.tsx:569
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:521
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:531
 msgid "Show reply for everyone"
 msgstr "Mostra risposta per tutti"
 
-#: src/screens/Settings/FollowingFeedPreferences.tsx:79
-#: src/screens/Settings/FollowingFeedPreferences.tsx:89
+#: src/screens/Settings/FollowingFeedPreferences.tsx:78
+#: src/screens/Settings/FollowingFeedPreferences.tsx:88
 msgid "Show reposts"
 msgstr ""
 
-#: src/screens/Settings/FollowingFeedPreferences.tsx:122
-#: src/screens/Settings/FollowingFeedPreferences.tsx:132
+#: src/screens/Settings/FollowingFeedPreferences.tsx:121
+#: src/screens/Settings/FollowingFeedPreferences.tsx:131
 msgid "Show samples of your saved feeds in your Following feed"
 msgstr ""
 
@@ -5896,8 +5900,8 @@ msgstr "Mostra avviso e filtra dai feed"
 
 #: src/components/dialogs/Signin.tsx:97 src/components/dialogs/Signin.tsx:99
 #: src/screens/Login/index.tsx:97 src/screens/Login/index.tsx:116
-#: src/screens/Login/LoginForm.tsx:163 src/view/com/auth/SplashScreen.tsx:62
-#: src/view/com/auth/SplashScreen.tsx:70
+#: src/screens/Login/LoginForm.tsx:163 src/view/com/auth/SplashScreen.tsx:61
+#: src/view/com/auth/SplashScreen.tsx:69
 #: src/view/com/auth/SplashScreen.web.tsx:123
 #: src/view/com/auth/SplashScreen.web.tsx:131
 #: src/view/shell/bottom-bar/BottomBar.tsx:311
@@ -5996,7 +6000,7 @@ msgstr "Qualcosa è andato storto"
 #: src/screens/Deactivated.tsx:94
 #: src/screens/Settings/components/DeactivateAccountDialog.tsx:59
 msgid "Something went wrong, please try again"
-msgstr "Qualcosa è andato storto, per favore riprova"
+msgstr "Qualcosa è andato storto: riprova"
 
 #: src/components/ReportDialog/index.tsx:54
 #: src/screens/Moderation/index.tsx:111
@@ -6005,23 +6009,23 @@ msgid "Something went wrong, please try again."
 msgstr "Qualcosa è andato male, prova di nuovo."
 
 #: src/components/Lists.tsx:200
-#: src/screens/Settings/NotificationSettings.tsx:42
+#: src/screens/Settings/NotificationSettings.tsx:41
 msgid "Something went wrong!"
 msgstr "Qualcosa è andato storto!"
 
 #: src/App.native.tsx:113 src/App.web.tsx:95
 msgid "Sorry! Your session expired. Please log in again."
-msgstr "Scusa! La tua sessione è scaduta. Per favore accedi di nuovo."
+msgstr "La tua sessione è scaduta: accedi di nuovo."
 
-#: src/screens/Settings/ThreadPreferences.tsx:48
+#: src/screens/Settings/ThreadPreferences.tsx:47
 msgid "Sort replies"
 msgstr "Ordina risposte"
 
-#: src/screens/Settings/ThreadPreferences.tsx:55
+#: src/screens/Settings/ThreadPreferences.tsx:54
 msgid "Sort replies by"
 msgstr "Ordina risposte per"
 
-#: src/screens/Settings/ThreadPreferences.tsx:52
+#: src/screens/Settings/ThreadPreferences.tsx:51
 msgid "Sort replies to the same post by:"
 msgstr "Ordina le risposte allo stesso post per:"
 
@@ -6075,8 +6079,8 @@ msgstr "Starter pack"
 msgid "Starter packs let you easily share your favorite feeds and people with your friends."
 msgstr "Gli starter pack ti permettono di condividere utenti e feed preferiti coi tuoi amici."
 
-#: src/screens/Settings/AboutSettings.tsx:46
-#: src/screens/Settings/AboutSettings.tsx:49
+#: src/screens/Settings/AboutSettings.tsx:45
+#: src/screens/Settings/AboutSettings.tsx:48
 msgid "Status Page"
 msgstr "Pagina di stato"
 
@@ -6131,8 +6135,8 @@ msgstr "Account suggeriti"
 msgid "Suggested for you"
 msgstr "Suggerito per te"
 
-#: src/view/com/composer/labels/LabelsBtn.tsx:146
-#: src/view/com/composer/labels/LabelsBtn.tsx:149
+#: src/view/com/composer/labels/LabelsBtn.tsx:145
+#: src/view/com/composer/labels/LabelsBtn.tsx:148
 msgid "Suggestive"
 msgstr "Suggestivo"
 
@@ -6156,8 +6160,8 @@ msgstr "Cambia account"
 msgid "System"
 msgstr "Sistema"
 
-#: src/screens/Settings/AboutSettings.tsx:53
-#: src/screens/Settings/AboutSettings.tsx:56
+#: src/screens/Settings/AboutSettings.tsx:52
+#: src/screens/Settings/AboutSettings.tsx:55
 #: src/screens/Settings/Settings.tsx:309
 msgid "System log"
 msgstr "Registro di sistema"
@@ -6174,15 +6178,15 @@ msgstr "Solo tag"
 msgid "Tap to dismiss"
 msgstr "Tocca per ignorare"
 
-#: src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerNative.tsx:136
+#: src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerNative.tsx:135
 msgid "Tap to enter full screen"
 msgstr "Tocca per entrare in modalità a schermo intero"
 
-#: src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerNative.tsx:142
+#: src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerNative.tsx:141
 msgid "Tap to play or pause"
 msgstr "Tocca per riprodurre o mettere in pausa"
 
-#: src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerNative.tsx:159
+#: src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerNative.tsx:158
 msgid "Tap to toggle sound"
 msgstr "Tocca per attivare o disattivare l'audio"
 
@@ -6195,7 +6199,7 @@ msgstr "Tocca per vedere a schermo intero"
 msgid "Task complete - 10 likes!"
 msgstr "Completato - 10 like!"
 
-#: src/components/ProgressGuide/List.tsx:49
+#: src/components/ProgressGuide/List.tsx:48
 msgid "Teach our algorithm what you like"
 msgstr "Insegna all'algoritmo cosa ti piace"
 
@@ -6211,16 +6215,16 @@ msgstr "Racconta una barzalletta!"
 msgid "Tell us a bit about yourself"
 msgstr "Raccontaci un po' di te"
 
-#: src/screens/StarterPack/Wizard/StepDetails.tsx:63
+#: src/screens/StarterPack/Wizard/StepDetails.tsx:62
 msgid "Tell us a little more"
 msgstr "Dicci un po' di più"
 
-#: src/view/shell/desktop/RightNav.tsx:90
+#: src/view/shell/desktop/RightNav.tsx:89
 msgid "Terms"
 msgstr "Termini"
 
-#: src/Navigation.tsx:274 src/screens/Settings/AboutSettings.tsx:30
-#: src/screens/Settings/AboutSettings.tsx:33
+#: src/Navigation.tsx:274 src/screens/Settings/AboutSettings.tsx:29
+#: src/screens/Settings/AboutSettings.tsx:32
 #: src/view/screens/TermsOfService.tsx:31 src/view/shell/Drawer.tsx:617
 #: src/view/shell/Drawer.tsx:619
 msgid "Terms of Service"
@@ -6281,7 +6285,7 @@ msgstr "Questo è tutto gente!"
 msgid "The account will be able to interact with you after unblocking."
 msgstr "L'account sarà in grado di interagire con te dopo lo sblocco."
 
-#: src/components/moderation/ModerationDetailsDialog.tsx:118
+#: src/components/moderation/ModerationDetailsDialog.tsx:117
 #: src/lib/moderation/useModerationCauseDescription.ts:126
 msgid "The author of this thread has hidden this reply."
 msgstr "L'autore del thread ha nascosto questa risposta."
@@ -6358,7 +6362,7 @@ msgstr "I Termini di servizio sono stati spostati a"
 
 #: src/components/intents/VerifyEmailIntentDialog.tsx:94
 msgid "The verification code you have provided is invalid. Please make sure that you have used the correct verification link or request a new one."
-msgstr "Il codice di verifica che hai fornito non è valido. Per favore assicurati di aver usato il link di verifica corretto o richiedine uno nuovo."
+msgstr "Il codice di verifica che hai fornito non è valido. Assicurati di aver usato il link di verifica corretto o richiedine uno nuovo."
 
 #: src/screens/Settings/AppearanceSettings.tsx:136
 msgid "Theme"
@@ -6391,7 +6395,7 @@ msgstr "Si è verificato un problema durante il contatto con il tuo server"
 msgid "There was an issue fetching notifications. Tap here to try again."
 msgstr "Si è verificato un problema durante il recupero delle notifiche. Tocca qui per riprovare."
 
-#: src/view/com/posts/Feed.tsx:473
+#: src/view/com/posts/Feed.tsx:523
 msgid "There was an issue fetching posts. Tap here to try again."
 msgstr "Si è verificato un problema nel recupero dei post. Tocca qui per riprovare."
 
@@ -6419,7 +6423,7 @@ msgstr ""
 #: src/components/dms/ReportDialog.tsx:217
 #: src/components/ReportDialog/SubmitView.tsx:87
 msgid "There was an issue sending your report. Please check your internet connection."
-msgstr "Si è verificato un problema durante l'invio della segnalazione. Per favore controlla la tua connessione Internet."
+msgstr "Si è verificato un problema durante l'invio della segnalazione. Verifica la tua connessione a internet."
 
 #: src/view/com/posts/FeedShutdownMsg.tsx:52
 #: src/view/com/posts/FeedShutdownMsg.tsx:71
@@ -6448,18 +6452,18 @@ msgstr "Si è verificato un problema! {0}"
 #: src/view/screens/ProfileList.tsx:400 src/view/screens/ProfileList.tsx:413
 #: src/view/screens/ProfileList.tsx:426 src/view/screens/ProfileList.tsx:439
 msgid "There was an issue. Please check your internet connection and try again."
-msgstr "Si è verificato un problema. Per favore controlla la tua connessione Internet e prova di nuovo."
+msgstr "Si è verificato un problema. Verifica la tua connessione a internet e prova di nuovo."
 
 #: src/components/dialogs/GifSelect.tsx:270
 #: src/view/com/util/ErrorBoundary.tsx:59
 msgid "There was an unexpected issue in the application. Please let us know if this happened to you!"
-msgstr "Si è verificato un problema imprevisto nell'applicazione. Per favore facci sapere se ti è successo!"
+msgstr "Si è verificato un problema imprevisto nell'applicazione. Facci sapere se ti è successo!"
 
-#: src/screens/SignupQueued.tsx:112
+#: src/screens/SignupQueued.tsx:116
 msgid "There's been a rush of new users to Bluesky! We'll activate your account as soon as we can."
 msgstr "C'è stata un'ondata di nuovi utenti su Bluesky! Attiveremo il tuo account il prima possibile."
 
-#: src/screens/Settings/FollowingFeedPreferences.tsx:55
+#: src/screens/Settings/FollowingFeedPreferences.tsx:54
 msgid "These settings only apply to the Following feed."
 msgstr ""
 
@@ -6499,7 +6503,7 @@ msgstr "Questo contenuto ha ricevuto un avviso generale dai moderatori."
 msgid "This content is hosted by {0}. Do you want to enable external media?"
 msgstr "Questo contenuto è ospitato da {0}. Abilitare i media esterni?"
 
-#: src/components/moderation/ModerationDetailsDialog.tsx:83
+#: src/components/moderation/ModerationDetailsDialog.tsx:82
 #: src/lib/moderation/useModerationCauseDescription.ts:82
 msgid "This content is not available because one of the users involved has blocked the other."
 msgstr "Questo contenuto non è disponibile perché uno degli utenti coinvolti ha bloccato l'altro."
@@ -6549,11 +6553,11 @@ msgstr "Queste informazioni non vengono condivise con altri utenti."
 msgid "This is important in case you ever need to change your email or reset your password."
 msgstr "Questo è importante nel caso in cui avessi bisogno di modificare la tua email o reimpostare la password."
 
-#: src/components/moderation/ModerationDetailsDialog.tsx:151
+#: src/components/moderation/ModerationDetailsDialog.tsx:150
 msgid "This label was applied by <0>{0}</0>."
 msgstr "Questa etichetta è stata applicata da <0>{0}</0>."
 
-#: src/components/moderation/ModerationDetailsDialog.tsx:146
+#: src/components/moderation/ModerationDetailsDialog.tsx:145
 msgid "This label was applied by the author."
 msgstr "Questa etichetta è stata applicata dall'autore."
 
@@ -6589,12 +6593,12 @@ msgstr ""
 msgid "This post has been deleted."
 msgstr "Questo post è stato eliminato."
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:700
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:659
 #: src/view/com/util/post-ctrls/PostCtrls.tsx:352
 msgid "This post is only visible to logged-in users. It won't be visible to people who aren't logged in."
 msgstr "Questo post è visibile solo agli utenti registrati. Non sarà visibile alle persone che non hanno effettuato l'accesso."
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:681
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:640
 msgid "This post will be hidden from feeds and threads. This cannot be undone."
 msgstr "Questo post verrà nascosto dai feed e dai thread. L'azione è irreversibile."
 
@@ -6606,7 +6610,7 @@ msgstr "L'autore di questo post ha disattivato le citazioni."
 msgid "This profile is only visible to logged-in users. It won't be visible to people who aren't logged in."
 msgstr "Questo profilo è visibile solo agli utenti registrati. Non sarà visibile alle persone che non hanno effettuato l'accesso."
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:743
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:702
 msgid "This reply will be sorted into a hidden section at the bottom of your thread and will mute notifications for subsequent replies - both for yourself and others."
 msgstr "Questa risposta verrà spostata in una sezione nascosta in basso al thread e disattiverà le notifiche delle risposte - sia per te che per gli altri."
 
@@ -6626,7 +6630,7 @@ msgstr "Questo utente non ha follower."
 msgid "This user has blocked you"
 msgstr "Questo utente ti ha bloccato"
 
-#: src/components/moderation/ModerationDetailsDialog.tsx:78
+#: src/components/moderation/ModerationDetailsDialog.tsx:77
 #: src/lib/moderation/useModerationCauseDescription.ts:73
 msgid "This user has blocked you. You cannot view their content."
 msgstr "Questo utente ti ha bloccato. Non è possibile visualizzare il suo contenuto."
@@ -6635,11 +6639,11 @@ msgstr "Questo utente ti ha bloccato. Non è possibile visualizzare il suo conte
 msgid "This user has requested that their content only be shown to signed-in users."
 msgstr "Questo utente ha richiesto che i suoi contenuti vengano mostrati solo agli utenti che hanno effettuato l'accesso."
 
-#: src/components/moderation/ModerationDetailsDialog.tsx:58
+#: src/components/moderation/ModerationDetailsDialog.tsx:57
 msgid "This user is included in the <0>{0}</0> list which you have blocked."
 msgstr "Questo utente è incluso nell'elenco <0>{0}</0> che hai bloccato."
 
-#: src/components/moderation/ModerationDetailsDialog.tsx:90
+#: src/components/moderation/ModerationDetailsDialog.tsx:89
 msgid "This user is included in the <0>{0}</0> list which you have muted."
 msgstr "Questo utente è incluso nell'elenco <0>{0}</0> che hai silenziato."
 
@@ -6659,20 +6663,20 @@ msgstr "Questo eliminerà \"{0}\" dalle tue parole silenziate. Puoi riaggiungerl
 msgid "This will remove @{0} from the quick access list."
 msgstr "Questo rimuoverà @{0} dalla lista d'accesso rapido."
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:733
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:692
 msgid "This will remove your post from this quote post for all users, and replace it with a placeholder."
 msgstr "Questo rimuoverà il tuo post da questa citazione per tutti gli utenti, e la rimpiazzerà con un placeholder."
 
-#: src/screens/Settings/ContentAndMediaSettings.tsx:49
-#: src/screens/Settings/ContentAndMediaSettings.tsx:52
+#: src/screens/Settings/ContentAndMediaSettings.tsx:48
+#: src/screens/Settings/ContentAndMediaSettings.tsx:51
 msgid "Thread preferences"
 msgstr "Preferenze delle discussioni"
 
-#: src/screens/Settings/ThreadPreferences.tsx:42
+#: src/screens/Settings/ThreadPreferences.tsx:41
 msgid "Thread Preferences"
 msgstr "Preferenze delle Discussioni"
 
-#: src/screens/Settings/ThreadPreferences.tsx:129
+#: src/screens/Settings/ThreadPreferences.tsx:128
 msgid "Threaded mode"
 msgstr "Modalità a thread"
 
@@ -6684,7 +6688,7 @@ msgstr "Preferenze per le discussioni"
 msgid "To disable the email 2FA method, please verify your access to the email address."
 msgstr "Per disabilitare il metodo 2FA via e-mail, verifica il tuo accesso all'indirizzo e-mail."
 
-#: src/components/dms/ReportConversationPrompt.tsx:20
+#: src/components/dms/ReportConversationPrompt.tsx:19
 msgid "To report a conversation, please report one of its messages via the conversation screen. This lets our moderators understand the context of your issue."
 msgstr "Per segnalare una conversazione, segnala uno dei messaggi nella schermata della conversazione. Questo permetterà ai nostri moderatori di capire il contesto del problema."
 
@@ -6692,7 +6696,7 @@ msgstr "Per segnalare una conversazione, segnala uno dei messaggi nella schermat
 msgid "To upload videos to Bluesky, you must first verify your email."
 msgstr "Per caricare video su Bluesky, devi prima verificare la tua email."
 
-#: src/components/ReportDialog/SelectLabelerView.tsx:32
+#: src/components/ReportDialog/SelectLabelerView.tsx:31
 msgid "To whom would you like to send this report?"
 msgstr "A chi desideri inviare questo report?"
 
@@ -6716,12 +6720,12 @@ msgstr "Top"
 #: src/components/dms/MessageMenu.tsx:105
 #: src/view/com/post-thread/PostThreadItem.tsx:761
 #: src/view/com/post-thread/PostThreadItem.tsx:764
-#: src/view/com/util/forms/PostDropdownBtn.tsx:422
-#: src/view/com/util/forms/PostDropdownBtn.tsx:424
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:386
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:388
 msgid "Translate"
 msgstr "Traduci"
 
-#: src/view/com/util/error/ErrorScreen.tsx:83
+#: src/view/com/util/error/ErrorScreen.tsx:82
 msgctxt "action"
 msgid "Try again"
 msgstr "Riprova"
@@ -6730,7 +6734,7 @@ msgstr "Riprova"
 msgid "TV"
 msgstr "TV"
 
-#: src/screens/Settings/PrivacyAndSecuritySettings.tsx:49
+#: src/screens/Settings/PrivacyAndSecuritySettings.tsx:48
 msgid "Two-factor authentication (2FA)"
 msgstr "Autenticazione a due fattori (2FA)"
 
@@ -6759,7 +6763,7 @@ msgstr ""
 #: src/screens/Login/SetNewPasswordForm.tsx:71 src/screens/Signup/index.tsx:71
 #: src/view/com/modals/ChangePassword.tsx:71
 msgid "Unable to contact your service. Please check your Internet connection."
-msgstr "Impossibile contattare il servizio. Per favore controlla la tua connessione Internet."
+msgstr "Impossibile contattare il servizio. Verifica la tua connessione a internet."
 
 #: src/screens/StarterPack/StarterPackScreen.tsx:649
 msgid "Unable to delete"
@@ -6801,7 +6805,7 @@ msgstr "Sblocca Account?"
 msgid "Undo repost"
 msgstr "Annulla la ripubblicazione"
 
-#: src/view/com/profile/FollowButton.tsx:61
+#: src/view/com/profile/FollowButton.tsx:60
 msgctxt "action"
 msgid "Unfollow"
 msgstr "Smetti di seguire"
@@ -6823,7 +6827,7 @@ msgstr "Togli il like a questo feed"
 msgid "Unmute"
 msgstr "Riattiva"
 
-#: src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerNative.tsx:156
+#: src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerNative.tsx:155
 #: src/view/com/util/post-embeds/VideoEmbedInner/web-controls/VolumeControl.tsx:93
 msgctxt "video"
 msgid "Unmute"
@@ -6846,8 +6850,8 @@ msgstr "Riattiva tutti i post di {displayTag}"
 msgid "Unmute conversation"
 msgstr "Riattiva conversazione"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:507
-#: src/view/com/util/forms/PostDropdownBtn.tsx:512
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:471
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:475
 msgid "Unmute thread"
 msgstr "Riattiva questa discussione"
 
@@ -6863,8 +6867,8 @@ msgstr "Stacca dal profilo"
 msgid "Unpin from home"
 msgstr "Stacca dalla Home"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:397
-#: src/view/com/util/forms/PostDropdownBtn.tsx:404
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:361
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:368
 msgid "Unpin from profile"
 msgstr "Rimuovi dal profilo"
 
@@ -6911,11 +6915,11 @@ msgstr "Aggiorna <0>{displayName}</0> nelle Liste"
 msgid "Update to {domain}"
 msgstr "Aggiorna a {domain}"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:311
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:300
 msgid "Updating quote attachment failed"
 msgstr "Impossibile aggiornare allegato"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:341
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:330
 msgid "Updating reply visibility failed"
 msgstr "Impossibile aggiornare visibilità risposte"
 
@@ -6970,8 +6974,8 @@ msgstr "Utilizza il tuo provider predefinito"
 msgid "Use in-app browser"
 msgstr "Utilizza il browser dell'app"
 
-#: src/screens/Settings/ContentAndMediaSettings.tsx:75
-#: src/screens/Settings/ContentAndMediaSettings.tsx:81
+#: src/screens/Settings/ContentAndMediaSettings.tsx:74
+#: src/screens/Settings/ContentAndMediaSettings.tsx:80
 msgid "Use in-app browser to open links"
 msgstr "Utilizza il browser dell'app per aprire i link"
 
@@ -6992,7 +6996,7 @@ msgstr "Usalo per accedere all'altra app insieme al tuo nome utente."
 msgid "Used by:"
 msgstr "Usato da:"
 
-#: src/components/moderation/ModerationDetailsDialog.tsx:70
+#: src/components/moderation/ModerationDetailsDialog.tsx:69
 #: src/lib/moderation/useModerationCauseDescription.ts:61
 msgid "User Blocked"
 msgstr "Utente bloccato"
@@ -7005,7 +7009,7 @@ msgstr "Utente bloccato da \"{0}\""
 msgid "User blocked by list"
 msgstr "Utente bloccato dalla lista"
 
-#: src/components/moderation/ModerationDetailsDialog.tsx:56
+#: src/components/moderation/ModerationDetailsDialog.tsx:55
 msgid "User Blocked by List"
 msgstr "Utente bloccato dalla lista"
 
@@ -7013,7 +7017,7 @@ msgstr "Utente bloccato dalla lista"
 msgid "User Blocking You"
 msgstr "Questo Utente ti Blocca"
 
-#: src/components/moderation/ModerationDetailsDialog.tsx:76
+#: src/components/moderation/ModerationDetailsDialog.tsx:75
 msgid "User Blocks You"
 msgstr "Questo utente ti blocca"
 
@@ -7098,8 +7102,8 @@ msgstr "Verifica ora"
 msgid "Verify Text File"
 msgstr "Verifica file di testo"
 
-#: src/screens/Settings/AccountSettings.tsx:68
-#: src/screens/Settings/AccountSettings.tsx:84
+#: src/screens/Settings/AccountSettings.tsx:67
+#: src/screens/Settings/AccountSettings.tsx:83
 msgid "Verify your email"
 msgstr "Verifica il tuo indirizzo email"
 
@@ -7108,13 +7112,13 @@ msgstr "Verifica il tuo indirizzo email"
 msgid "Verify Your Email"
 msgstr "Verifica la tua email"
 
-#: src/screens/Settings/AboutSettings.tsx:60
-#: src/screens/Settings/AboutSettings.tsx:70
+#: src/screens/Settings/AboutSettings.tsx:59
+#: src/screens/Settings/AboutSettings.tsx:69
 msgid "Version {appVersion}"
 msgstr "Versione {appVersion}"
 
-#: src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerNative.tsx:84
-#: src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerNative.tsx:135
+#: src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerNative.tsx:83
+#: src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerNative.tsx:134
 msgid "Video"
 msgstr "Video"
 
@@ -7126,7 +7130,7 @@ msgstr "Elaborazione video fallita"
 msgid "Video Games"
 msgstr "Video Games"
 
-#: src/view/com/util/post-embeds/VideoEmbed.web.tsx:167
+#: src/view/com/util/post-embeds/VideoEmbed.web.tsx:169
 msgid "Video not found."
 msgstr "Video non trovato."
 
@@ -7138,7 +7142,7 @@ msgstr "Settaggi video"
 msgid "Video uploaded"
 msgstr "Video caricato"
 
-#: src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerNative.tsx:84
+#: src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerNative.tsx:83
 msgid "Video: {0}"
 msgstr "Video: {0}"
 
@@ -7188,11 +7192,11 @@ msgstr "Vedere dettagli"
 msgid "View details for reporting a copyright violation"
 msgstr "Visualizza i dettagli per segnalare una violazione del copyright"
 
-#: src/view/com/posts/FeedSlice.tsx:154
+#: src/view/com/posts/ViewFullThread.tsx:56
 msgid "View full thread"
 msgstr "Vedi la discussione completa"
 
-#: src/components/moderation/LabelsOnMe.tsx:47
+#: src/components/moderation/LabelsOnMe.tsx:46
 msgid "View information about these labels"
 msgstr "Visualizza le informazioni su queste etichette"
 
@@ -7261,7 +7265,7 @@ msgstr "Non siamo riusciti a trovare alcun risultato per quell'hashtag."
 msgid "We couldn't load this conversation"
 msgstr "Non riusciamo a caricare questa conversazione"
 
-#: src/screens/SignupQueued.tsx:139
+#: src/screens/SignupQueued.tsx:146
 msgid "We estimate {estimatedTime} until your account is ready."
 msgstr "Stimiamo {estimatedTime} prima che il tuo account sia pronto."
 
@@ -7273,17 +7277,17 @@ msgstr "Ti abbiamo inviato un'altra email di verifica a <0>{0}</0>."
 msgid "We hope you have a wonderful time. Remember, Bluesky is:"
 msgstr "Speriamo di darti dei momenti dei bei momenti. Ricorda, Bluesky è:"
 
-#: src/view/com/posts/DiscoverFallbackHeader.tsx:30
+#: src/view/com/posts/DiscoverFallbackHeader.tsx:29
 msgid "We ran out of posts from your follows. Here's the latest from <0/>."
 msgstr "Abbiamo esaurito i posts dei tuoi follower. Ecco le ultime novità da <0/>."
 
 #: src/view/com/composer/state/video.ts:430
 msgid "We were unable to determine if you are allowed to upload videos. Please try again."
-msgstr "Non siamo riusciti a verificare se puoi caricare video. Per favore ritenta."
+msgstr "Non è stato possibile verificare se puoi caricare video. Riprova."
 
 #: src/components/dialogs/BirthDateSettings.tsx:51
 msgid "We were unable to load your birth date preferences. Please try again."
-msgstr "Non siamo riusciti a caricare le tue preferenze relative alla data di nascita. Per favore riprova."
+msgstr "Non è stato possibile caricare le tue preferenze relative alla data di nascita: riprova."
 
 #: src/screens/Moderation/index.tsx:414
 msgid "We were unable to load your configured labelers at this time."
@@ -7293,7 +7297,7 @@ msgstr "Al momento non è stato possibile caricare le etichettatori configurati.
 msgid "We weren't able to connect. Please try again to continue setting up your account. If it continues to fail, you can skip this flow."
 msgstr "Non siamo riusciti a connetterci. Riprova per continuare a configurare il tuo account. Se il problema persiste, puoi ignorare questo flusso."
 
-#: src/screens/SignupQueued.tsx:143
+#: src/screens/SignupQueued.tsx:150
 msgid "We will let you know when your account is ready."
 msgstr "Ti faremo sapere quando il tuo account sarà pronto."
 
@@ -7315,7 +7319,7 @@ msgstr "Siamo spiacenti, ma non siamo riusciti a risolvere questa lista. Se il p
 
 #: src/components/dialogs/MutedWords.tsx:378
 msgid "We're sorry, but we weren't able to load your muted words at this time. Please try again."
-msgstr "Siamo spiacenti, ma al momento non siamo riusciti a caricare le parole silenziate. Per favore riprova si nuovo."
+msgstr "Non è stato possibile caricare le parole silenziate: riprova."
 
 #: src/view/screens/Search/Search.tsx:212
 msgid "We're sorry, but your search could not be completed. Please try again in a few minutes."
@@ -7345,11 +7349,11 @@ msgstr "Benvenut*, amic*!"
 msgid "What are your interests?"
 msgstr "Quali sono i tuoi interessi?"
 
-#: src/screens/StarterPack/Wizard/StepDetails.tsx:42
+#: src/screens/StarterPack/Wizard/StepDetails.tsx:41
 msgid "What do you want to call your starter pack?"
 msgstr "Come vuoi chiamare il tuo starter pack?"
 
-#: src/view/com/auth/SplashScreen.tsx:39
+#: src/view/com/auth/SplashScreen.tsx:38
 #: src/view/com/auth/SplashScreen.web.tsx:99
 #: src/view/com/composer/Composer.tsx:716
 msgid "What's up?"
@@ -7413,7 +7417,7 @@ msgid "Write post"
 msgstr "Scrivi un post"
 
 #: src/view/com/composer/Composer.tsx:714
-#: src/view/com/post-thread/PostThreadComposePrompt.tsx:71
+#: src/view/com/post-thread/PostThreadComposePrompt.tsx:70
 msgid "Write your reply"
 msgstr "Scrivi la tua risposta"
 
@@ -7438,11 +7442,11 @@ msgstr "Sì, disattiva il mio account"
 msgid "Yes, delete this starter pack"
 msgstr "Sì, elimina questo starter pack"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:736
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:695
 msgid "Yes, detach"
 msgstr "Sì"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:746
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:705
 msgid "Yes, hide"
 msgstr "Sì"
 
@@ -7462,7 +7466,7 @@ msgstr "io"
 msgid "You"
 msgstr "Io"
 
-#: src/screens/SignupQueued.tsx:136
+#: src/screens/SignupQueued.tsx:143
 msgid "You are in line."
 msgstr "Sei nella lista."
 
@@ -7487,7 +7491,8 @@ msgstr "Puoi anche disattivare temporaneamente il tuo account, e riattivarlo in 
 msgid "You can continue ongoing conversations regardless of which setting you choose."
 msgstr "Puoi proseguire le conversazioni in corso indipendentemente dall'impostazione scelta."
 
-#: src/screens/Login/index.tsx:155 src/screens/Login/PasswordUpdatedForm.tsx:27
+#: src/screens/Login/index.tsx:155
+#: src/screens/Login/PasswordUpdatedForm.tsx:26
 msgid "You can now sign in with your new password."
 msgstr "Adesso puoi accedere con la tua nuova password."
 
@@ -7523,7 +7528,7 @@ msgstr "Hai bloccato l'autore o sei stato bloccato dall'autore."
 msgid "You have blocked this user"
 msgstr "Hai bloccato questo utente"
 
-#: src/components/moderation/ModerationDetailsDialog.tsx:72
+#: src/components/moderation/ModerationDetailsDialog.tsx:71
 #: src/lib/moderation/useModerationCauseDescription.ts:55
 #: src/lib/moderation/useModerationCauseDescription.ts:63
 msgid "You have blocked this user. You cannot view their content."
@@ -7540,11 +7545,11 @@ msgstr "Hai inserito un codice non valido. Dovrebbe apparire come XXXX-XXXXXX."
 msgid "You have hidden this post"
 msgstr "Hai nascosto questo post"
 
-#: src/components/moderation/ModerationDetailsDialog.tsx:110
+#: src/components/moderation/ModerationDetailsDialog.tsx:109
 msgid "You have hidden this post."
 msgstr "Hai silenziato questo post."
 
-#: src/components/moderation/ModerationDetailsDialog.tsx:103
+#: src/components/moderation/ModerationDetailsDialog.tsx:102
 #: src/lib/moderation/useModerationCauseDescription.ts:97
 msgid "You have muted this account."
 msgstr "Hai silenziato questo account."
@@ -7579,7 +7584,7 @@ msgstr "Hai raggiunto la fine"
 
 #: src/lib/media/video/upload.shared.ts:56
 msgid "You have temporarily reached the limit for video uploads. Please try again later."
-msgstr "Hai temporaneamente raggiunto il limite dei video caricati. Per favore riprova più tardi."
+msgstr "Hai temporaneamente raggiunto il limite dei video caricati. Riprova più tardi."
 
 #: src/components/StarterPack/ProfileStarterPacks.tsx:241
 msgid "You haven't created a starter pack yet!"
@@ -7589,7 +7594,7 @@ msgstr "Non hai ancora creato uno starter pack!"
 msgid "You haven't muted any words or tags yet"
 msgstr "Non hai ancora silenziato nessuna parola o tag"
 
-#: src/components/moderation/ModerationDetailsDialog.tsx:117
+#: src/components/moderation/ModerationDetailsDialog.tsx:116
 #: src/lib/moderation/useModerationCauseDescription.ts:125
 msgid "You hid this reply."
 msgstr "Hai nascosto questa risposta."
@@ -7626,7 +7631,7 @@ msgstr "Devi seguire almeno altre 7 utenti per creare uno starter pack."
 msgid "You must grant access to your photo library to save a QR code"
 msgstr "Devi attivare il permesso alla Galleria per salvare il codice QR"
 
-#: src/components/StarterPack/ShareDialog.tsx:69
+#: src/components/StarterPack/ShareDialog.tsx:68
 msgid "You must grant access to your photo library to save the image."
 msgstr "Devi attivare il permesso alla Galleria per salvare l'immagine."
 
@@ -7642,11 +7647,11 @@ msgstr "Hai precedentemente disattivato @{0}."
 msgid "You will be signed out of all your accounts."
 msgstr ""
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:222
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:211
 msgid "You will no longer receive notifications for this thread"
 msgstr "Non riceverai più notifiche per questo filo di discussione"
 
-#: src/view/com/util/forms/PostDropdownBtn.tsx:218
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:207
 msgid "You will now receive notifications for this thread"
 msgstr "Adesso riceverai le notifiche per questa discussione"
 
@@ -7690,8 +7695,7 @@ msgstr "Riceverai un'email all'indirizzo <0>{0}</0> per verificare la tua identi
 msgid "You'll stay updated with these feeds"
 msgstr "Resterai aggiornato su questi feed"
 
-#: src/screens/SignupQueued.tsx:93 src/screens/SignupQueued.tsx:94
-#: src/screens/SignupQueued.tsx:109
+#: src/screens/SignupQueued.tsx:113
 msgid "You're in line"
 msgstr "Sei in fila"
 
@@ -7704,7 +7708,7 @@ msgstr "Hai effettuato l'accesso con una password dell'app. Accedi con la tua pa
 msgid "You're ready to go!"
 msgstr "Sei pronto per iniziare!"
 
-#: src/components/moderation/ModerationDetailsDialog.tsx:107
+#: src/components/moderation/ModerationDetailsDialog.tsx:106
 #: src/lib/moderation/useModerationCauseDescription.ts:106
 msgid "You've chosen to hide a word or tag within this post."
 msgstr "Hai scelto di nascondere una parola o un tag in questo post."
@@ -7731,7 +7735,7 @@ msgstr "Il tuo account è stato eliminato"
 
 #: src/view/com/composer/state/video.ts:442
 msgid "Your account is not yet old enough to upload videos. Please try again later."
-msgstr "Il tuo account è troppo recente per caricare video. Per favore riprova successivamente."
+msgstr "Il tuo account è troppo recente per caricare video. Riprova più tardi."
 
 #: src/screens/Settings/components/ExportCarDialog.tsx:65
 msgid "Your account repository, containing all public data records, can be downloaded as a \"CAR\" file. This file does not include media embeds, such as images, or your private data, which must be fetched separately."
@@ -7741,9 +7745,9 @@ msgstr "L'archivio del tuo account, che contiene tutti i record di dati pubblici
 msgid "Your birth date"
 msgstr "La tua data di nascita"
 
-#: src/view/com/util/post-embeds/VideoEmbed.web.tsx:171
+#: src/view/com/util/post-embeds/VideoEmbed.web.tsx:173
 msgid "Your browser does not support the video format. Please try a different browser."
-msgstr "Il tuo browser non supporta questo formato video. Per favore prova un altro browser."
+msgstr "Il tuo browser non supporta questo formato video. Prova con un altro browser."
 
 #: src/screens/Messages/components/ChatDisabled.tsx:25
 msgid "Your chats have been disabled"
@@ -7818,1568 +7822,3 @@ msgstr "La tua segnalazione verrà inviata al Servizio Moderazione di Bluesky"
 #: src/screens/Signup/index.tsx:142
 msgid "Your user handle"
 msgstr "Il tuo nome utente"
-
-#~ msgid "{0, plural, one {{formattedCount} other} other {{formattedCount} others}}"
-#~ msgstr "{0, plural, one {{formattedCount} altro} other {{formattedCount} altri}}"
-
-#~ msgid "{0, plural, one {and # other} other {and # others}}"
-#~ msgstr "{0, plural, one {e # altro} other {e # altri}}"
-
-#~ msgid "{0} {purposeLabel} List"
-#~ msgstr "Lista {purposeLabel} {0}"
-
-#~ msgid "{0} your feeds"
-#~ msgstr "{0} tuoi feed"
-
-#~ msgid "{diff, plural, one {day} other {days}}"
-#~ msgstr "{diff, plural, one {giorno} other {giorni}}"
-
-#~ msgid "{diff, plural, one {hour} other {hours}}"
-#~ msgstr "{diff, plural, one {ora} other {ore}}"
-
-#~ msgid "{diff, plural, one {minute} other {minutes}}"
-#~ msgstr "{diff, plural, one {minuto} other {minuti}}"
-
-#~ msgid "{diff, plural, one {month} other {months}}"
-#~ msgstr "{diff, plural, one {mese} other {mesi}}"
-
-#~ msgid "{diffSeconds, plural, one {second} other {seconds}}"
-#~ msgstr "{diffSeconds, plural, one {secondo} other {secondi}}"
-
-#~ msgid "{invitesAvailable, plural, one {Invite codes: # available} other {Invite codes: # available}}"
-#~ msgstr "{invitesAvailable, plural, one {Codici d'invito: # disponibile} other {Codici d'invito: # disponibili}}"
-
-#~ msgid "{invitesAvailable} invite code available"
-#~ msgstr "{invitesAvailable} codice d'invito disponibile"
-
-#~ msgid "{invitesAvailable} invite codes available"
-#~ msgstr "{invitesAvailable} codici d'invito disponibili"
-
-#~ msgid "{message}"
-#~ msgstr "{message}"
-
-#~ msgid "{value, plural, =0 {Show all replies} one {Show replies with at least # like} other {Show replies with at least # likes}}"
-#~ msgstr "{value, plural, =0 {Mostra tutte le risposte} one {Mostra risposte con almeno # like} other {Mostra risposte con almeno # like}}"
-
-#~ msgid "<0/> members"
-#~ msgstr "<0/> membri"
-
-#~ msgid "<0>{0} </0>and<1> </1><2>{1} </2>are included in your starter pack"
-#~ msgstr "<0>{0} </0>e<1> </1><2>{1} </2>sono inclusi nel tuo starter pack"
-
-#~ msgid "<0>{0}, </0><1>{1}, </1>and {2} {3, plural, one {other} other {others}} are included in your starter pack"
-#~ msgstr "<0>{0}, </0><1>{1}, </1>e {2} {3, plural, one {# altro} other {# altri}} sono inclusi nel tuo starter pack"
-
-#~ msgid "<0>{0}</0> following"
-#~ msgstr "<0>{0}</0> seguito"
-
-#~ msgid "<0>{followers} </0><1>{pluralizedFollowers}</1>"
-#~ msgstr "<0>{followers} </0><1>{pluralizedFollowers}</1>"
-
-#~ msgid "<0>{following} </0><1>following</1>"
-#~ msgstr "<0>{following} </0><1>following</1>"
-
-#~ msgid "<0>Choose your</0><1>Recommended</1><2>Feeds</2>"
-#~ msgstr "<0>Scegli i tuoi</0><1>feed/1><2>consigliati</2>"
-
-#~ msgid "<0>Follow some</0><1>Recommended</1><2>Users</2>"
-#~ msgstr "<0>Segui alcuni</0><1>utenti</1><2>consigliati</2>"
-
-#~ msgid "<0>Not Applicable.</0> This warning is only available for posts with media attached."
-#~ msgstr "<0>Non applicabile.</0> Questo avviso è disponibile solo per i post che contengono media."
-
-#~ msgid "<0>Welcome to</0><1>Bluesky</1>"
-#~ msgstr "<0>Ti diamo il benvenuto su</0><1>Bluesky</1>"
-
-#~ msgid "A content warning has been applied to this {0}."
-#~ msgstr "A questo post è stato applicato un avviso di contenuto {0}."
-
-#~ msgid "A new version of the app is available. Please update to continue using the app."
-#~ msgstr "È disponibile una nuova versione dell'app. Aggiorna per continuare a utilizzarla."
-
-#~ msgid "Accessibility settings"
-#~ msgstr "Impostazioni di accessibilità"
-
-#~ msgid "account"
-#~ msgstr "account"
-
-#~ msgid "Add ALT text"
-#~ msgstr "Agguingo del testo descrittivo"
-
-#~ msgid "Add details"
-#~ msgstr "Aggiungi i dettagli"
-
-#~ msgid "Add details to report"
-#~ msgstr "Aggiungi dettagli da segnalare"
-
-#~ msgid "Add link card"
-#~ msgstr "Aggiungi anteprima del link"
-
-#~ msgid "Add link card:"
-#~ msgstr "Aggiungi anteprima del link:"
-
-#~ msgid "Add people to your starter pack that you think others will enjoy following"
-#~ msgstr "Aggiungi persone al tuo starter pack che potrebbero interessare agli altri utenti"
-
-#~ msgid "Added"
-#~ msgstr "Aggiunto"
-
-#~ msgid "Adjust the number of likes a reply must have to be shown in your feed."
-#~ msgstr "Modifica il numero di \"Mi piace\" che una risposta deve avere per essere mostrata nel tuo feed."
-
-#~ msgid "Adult content can only be enabled via the Web at <0/>."
-#~ msgstr "I contenuti per adulti possono essere abilitati solo dal sito Web a <0/>."
-
-#~ msgid "Allow messages from"
-#~ msgstr "Permetti tutti i messaggi di"
-
-#~ msgid "An error occured"
-#~ msgstr "Si è verificato un errore"
-
-#~ msgid "An error occurred while saving the image."
-#~ msgstr "Si è verificato un errore nel caricare l'immagine."
-
-#~ msgid "An error occurred while trying to delete the message. Please try again."
-#~ msgstr "Si è verificato un errore durante la cancellazione del messaggio. Per favore riprova più tardi."
-
-#~ msgid "App Password names can only contain letters, numbers, spaces, dashes, and underscores."
-#~ msgstr "Le password dell'app possono contenere solo lettere, numeri, spazi, trattini e trattini bassi."
-
-#~ msgid "App Password names must be at least 4 characters long."
-#~ msgstr "Le password delle app devono contenere almeno 4 caratteri."
-
-#~ msgid "App password settings"
-#~ msgstr "Impostazioni della password dell'app"
-
-#~ msgid "Appeal content warning"
-#~ msgstr "Ricorso contro l'avviso sui contenuti"
-
-#~ msgid "Appeal Content Warning"
-#~ msgstr "Ricorso contro l'Avviso sui Contenuti"
-
-#~ msgid "Appeal Decision"
-#~ msgstr "Decisión de apelación"
-
-#~ msgid "Appeal submitted."
-#~ msgstr "Ricorso presentato."
-
-#~ msgid "Appeal this decision."
-#~ msgstr "Appella contro questa decisione."
-
-#~ msgid "Appearance settings"
-#~ msgstr "Impostazioni dell'aspetto"
-
-#~ msgid "Appearance Settings"
-#~ msgstr "Impostazioni dell'aspetto"
-
-#~ msgid "Are you sure you want delete this starter pack?"
-#~ msgstr "Sicuro di voler eliminare questo starter pack?"
-
-#~ msgid "Are you sure you want to delete the app password \"{name}\"?"
-#~ msgstr "Confermi di voler eliminare la password dell'app \"{name}\"?"
-
-#~ msgid "Are you sure? This cannot be undone."
-#~ msgstr "Vuoi proseguire? Questa operazione non può essere annullata."
-
-#~ msgctxt "action"
-#~ msgid "Back"
-#~ msgstr "Indietro"
-
-#~ msgid "Based on your interest in {interestsText}"
-#~ msgstr "Basato sui tuoi interessi {interestsText}"
-
-#~ msgid "Basics"
-#~ msgstr "Preferenze"
-
-#~ msgid "Birthday:"
-#~ msgstr "Compleanno:"
-
-#~ msgid "Block this List"
-#~ msgstr "Blocca questa Lista"
-
-#~ msgid "Bluesky is an open network where you can choose your hosting provider. Custom hosting is now available in beta for developers."
-#~ msgstr "Bluesky è un network aperto in cui puoi scegliere il tuo provider di hosting. L'hosting personalizzato è adesso disponibile in versione beta per gli sviluppatori."
-
-#~ msgid "Bluesky is flexible."
-#~ msgstr "Bluesky è flessibile."
-
-#~ msgid "Bluesky is open."
-#~ msgstr "Bluesky è aperto."
-
-#~ msgid "Bluesky is public."
-#~ msgstr "Bluesky è pubblico."
-
-#~ msgid "Bluesky uses invites to build a healthier community. If you don't know anybody with an invite, you can sign up for the waitlist and we'll send one soon."
-#~ msgstr "Bluesky utilizza gli inviti per costruire una comunità più sana. Se non conosci nessuno con un invito, puoi iscriverti alla lista d'attesa e te ne invieremo uno al più presto."
-
-#~ msgid "Bluesky.Social"
-#~ msgstr "Bluesky.Social"
-
-#~ msgid "Build version {0} {1}"
-#~ msgstr "Versione {0} {1}"
-
-#~ msgid "Button disabled. Input custom domain to proceed."
-#~ msgstr "Pulsante disabilitato. Inserisci il dominio personalizzato per procedere."
-
-#~ msgid "by {0}"
-#~ msgstr "di {0}"
-
-#~ msgid "by @{0}"
-#~ msgstr "Di @{0}"
-
-#~ msgid "By creating an account you agree to the {els}."
-#~ msgstr "Creando un account accetti i {els}."
-
-#~ msgid "Can only contain letters, numbers, spaces, dashes, and underscores. Must be at least 4 characters long, but no more than 32 characters long."
-#~ msgstr "Può contenere solo lettere, numeri, spazi, trattini e trattini bassi. Deve contenere almeno 4 caratteri, ma non più di 32 caratteri."
-
-#~ msgid "Cancel add image alt text"
-#~ msgstr "Annulla inserimento testo alternativo immagine "
-
-#~ msgid "Cancel change handle"
-#~ msgstr "Annulla il cambio del tuo nome utente"
-
-#~ msgid "Cancel waitlist signup"
-#~ msgstr "Annulla l'iscrizione alla lista d'attesa"
-
-#~ msgctxt "action"
-#~ msgid "Change"
-#~ msgstr "Cambia"
-
-#~ msgid "Change handle"
-#~ msgstr "Cambia il nome utente"
-
-#~ msgid "Change password"
-#~ msgstr "Cambia la password"
-
-#~ msgid "Change your Bluesky password"
-#~ msgstr "Cambia la tua password di Bluesky"
-
-#~ msgid "Check out some recommended feeds. Tap + to add them to your list of pinned feeds."
-#~ msgstr "Dai un'occhiata ad alcuni feed consigliati. Clicca + per aggiungerli al tuo elenco dei feed."
-
-#~ msgid "Check out some recommended users. Follow them to see similar users."
-#~ msgstr "Scopri alcuni utenti consigliati. Seguili per vedere utenti simili."
-
-#~ msgid "Choose \"Everybody\" or \"Nobody\""
-#~ msgstr "Scegli \"Tutti\" o \"Nessuno\""
-
-#~ msgid "Choose 3 or more:"
-#~ msgstr "Scegli 3 o più:"
-
-#~ msgid "Choose a new Bluesky username or create"
-#~ msgstr "Scegli un nuovo nome utente Bluesky o creane uno"
-
-#~ msgid "Choose at least {0} more"
-#~ msgstr "Scegli almeno {0} in più"
-
-#~ msgid "Choose the algorithms that power your experience with custom feeds."
-#~ msgstr "Scegli gli algoritmi che migliorano la tua esperienza con i feed personalizzati."
-
-#~ msgid "Choose who can reply"
-#~ msgstr "Scegli chi può rispondere"
-
-#~ msgid "Choose your main feeds"
-#~ msgstr "Scegli i tuoi feed principali"
-
-#~ msgid "Clear all legacy storage data"
-#~ msgstr "Cancella tutti i dati legacy in archivio"
-
-#~ msgid "Clear all legacy storage data (restart after this)"
-#~ msgstr "Cancella tutti i dati legacy in archivio (poi ricomincia)"
-
-#~ msgid "Clears all legacy storage data"
-#~ msgstr "Cancella tutti i dati di archiviazione legacy"
-
-#~ msgid "Clears all storage data"
-#~ msgstr "Cancella tutti i dati di archiviazione"
-
-#~ msgid "Click here to add one."
-#~ msgstr "Clicca qui per aggiungerne uno."
-
-#~ msgid "Click here to open tag menu for #{tag}"
-#~ msgstr "Clicca qui per aprire il menu per #{tag}"
-
-#~ msgid "Close modal"
-#~ msgstr "Chiudi finestra"
-
-#~ msgid "Closes post composer and discards post draft"
-#~ msgstr "Chiude l'editore del post ed elimina la bozza del post"
-
-#~ msgid "Compressing..."
-#~ msgstr "Compressione in corso..."
-
-#~ msgid "Configure content filtering setting for category: {0}"
-#~ msgstr "Configura l'impostazione del filtro dei contenuti per la categoria:{0}"
-
-#~ msgctxt "action"
-#~ msgid "Confirm"
-#~ msgstr "Conferma"
-
-#~ msgid "Confirm your age to enable adult content."
-#~ msgstr "Conferma la tua età per abilitare i contenuti per adulti."
-
-#~ msgid "Confirms signing up {email} to the waitlist"
-#~ msgstr "Conferma l'iscrizione di {email} alla lista d'attesa"
-
-#~ msgid "content"
-#~ msgstr "contenuto"
-
-#~ msgid "Content filtering"
-#~ msgstr "Filtro dei contenuti"
-
-#~ msgid "Content Filtering"
-#~ msgstr "Filtro dei Contenuti"
-
-#~ msgid "Continue to the next step"
-#~ msgstr "Vai al passaggio successivo"
-
-#~ msgid "Continue to the next step without following any accounts"
-#~ msgstr "Vai al passaggio successivo senza seguire nessun account"
-
-#~ msgid "Copies app password"
-#~ msgstr "Copia la password dell'app"
-
-#~ msgid "Copy {0}"
-#~ msgstr "Copia {0}"
-
-#~ msgid "Copy link to profile"
-#~ msgstr "Copia il link al profilo"
-
-#~ msgid "Could not compress video"
-#~ msgstr "Impossibile comprimere il video"
-
-#~ msgid "Could not load profiles. Please try again later."
-#~ msgstr "Impossibile caricare i profili. Per favore riprova più tardi."
-
-#~ msgid "Country"
-#~ msgstr "Paese"
-
-#~ msgid "Create a new account"
-#~ msgstr "Crea un nuovo account"
-
-#~ msgid "Create a new Bluesky account"
-#~ msgstr "Crea un nuovo account Bluesky"
-
-#~ msgid "Create App Password"
-#~ msgstr "Crea un password per l'app"
-
-#~ msgid "Create QR code"
-#~ msgstr "Crea codice QR"
-
-#~ msgid "Created by <0/>"
-#~ msgstr "Creato da <0/>"
-
-#~ msgid "Created by you"
-#~ msgstr "Creato da te"
-
-#~ msgid "Creates a card with a thumbnail. The card links to {url}"
-#~ msgstr "Crea una scheda con una miniatura. La scheda si collega a {url}"
-
-#~ msgid "Custom domain"
-#~ msgstr "Dominio personalizzato"
-
-#~ msgid "Customize media from external sites."
-#~ msgstr "Personalizza i media da i siti esterni."
-
-#~ msgid "Danger Zone"
-#~ msgstr "Zona di Pericolo"
-
-#~ msgid "Dark Theme"
-#~ msgstr "Tema scuro"
-
-#~ msgid "Deactivate my account"
-#~ msgstr "Disattiva il mio account"
-
-#~ msgid "Delete Account"
-#~ msgstr "Elimina l'Account"
-
-#~ msgid "Delete my account…"
-#~ msgstr "Cancella il mio account…"
-
-#~ msgid "Delete My Account…"
-#~ msgstr "Cancellare Account…"
-
-#~ msgid "Dev Server"
-#~ msgstr "Server di sviluppo"
-
-#~ msgid "Developer Tools"
-#~ msgstr "Strumenti per sviluppatori"
-
-#~ msgid "Did you want to say anything?"
-#~ msgstr "Volevi dire qualcosa?"
-
-#~ msgid "Direct messages are here!"
-#~ msgstr "I messaggi diretti sono arrivati!"
-
-#~ msgid "Disable autoplay for GIFs"
-#~ msgstr "Disattiva la riproduzione automatica per le GIF"
-
-#~ msgid "Disable autoplay for videos and GIFs"
-#~ msgstr "Disabilita riproduzione automatica per video e GIFs."
-
-#~ msgid "Discard draft"
-#~ msgstr "Scarta la bozza"
-
-#~ msgid "Discover learns which posts you like as you browse."
-#~ msgstr "Ricerca imparerà quali post ti piacciono nel mentre cerchi."
-
-#~ msgid "Does not contain adult content."
-#~ msgstr "Non contiene materiale per adulti."
-
-#~ msgid "Domain Value"
-#~ msgstr "Valore del dominio"
-
-#~ msgid "Don't have an invite code?"
-#~ msgstr "Non hai un codice di invito?"
-
-#~ msgid "Double tap to sign in"
-#~ msgstr "Usa il doppio tocco per accedere"
-
-#~ msgid "Download Bluesky account data (repository)"
-#~ msgstr "Scarica i dati dell'account Bluesky (archivio)"
-
-#~ msgid "Due to Apple policies, adult content can only be enabled on the web after completing sign up."
-#~ msgstr "A causa delle politiche di Apple, i contenuti per adulti possono essere abilitati sul Web solo dopo aver completato la registrazione."
-
-#~ msgid "Edit Saved Feeds"
-#~ msgstr "Modifica i feed memorizzati"
-
-#~ msgid "Either choose \"Everybody\" or \"Nobody\""
-#~ msgstr "Scegli \"Everybody\" o \"Nobody\\"
-
-#~ msgid "Email:"
-#~ msgstr "Email:"
-
-#~ msgid "Enable Adult Content"
-#~ msgstr "Attiva Contenuto per Adulti"
-
-#~ msgid "Enable adult content in your feeds"
-#~ msgstr "Abilita i contenuti per adulti nei tuoi feed"
-
-#~ msgid "Enable External Media"
-#~ msgstr "Attiva Media Esterna"
-
-#~ msgid "Enable this setting to only see replies between people you follow."
-#~ msgstr "Abilita questa impostazione per vedere solo le risposte delle persone che segui."
-
-#~ msgid "Enter a name for this App Password"
-#~ msgstr "Inserisci un nome per questa password dell'app"
-
-#~ msgid "Enter the address of your provider:"
-#~ msgstr "Inserisci l'indirizzo del tuo provider:"
-
-#~ msgid "Enter your email"
-#~ msgstr "Inserisci la tua email"
-
-#~ msgid "Enter your phone number"
-#~ msgstr "Inserisci il tuo numero di telefono"
-
-#~ msgid "Exits handle change process"
-#~ msgstr "Uscita dal processo di modifica"
-
-#~ msgid "Exits signing up for waitlist with {email}"
-#~ msgstr "Uscita dall'iscrizione alla lista d'attesa con {email}"
-
-#~ msgid "Experimental: When this preference is enabled, you'll only receive reply and quote notifications from users you follow. We'll continue to add more controls here over time."
-#~ msgstr "SPERIMENTALE: Abilitando questa opzione, riceverai notifiche esclusivamente dagli utenti che segui. Continueremo ad aggiungere nuovi controlli in futuro."
-
-#~ msgid "External media settings"
-#~ msgstr "Impostazioni multimediali esterni"
-
-#~ msgid "Failed to create app password."
-#~ msgstr "Impossibile creare la password dell'app."
-
-#~ msgid "Failed to load recommended feeds"
-#~ msgstr "Impossibile caricare feed consigliati"
-
-#~ msgid "Feed offline"
-#~ msgstr "Feed offline"
-
-#~ msgid "Feed Preferences"
-#~ msgstr "Preferenze del feed"
-
-#~ msgid "Feeds are created by users to curate content. Choose some feeds that you find interesting."
-#~ msgstr "I feed vengono creati dagli utenti per curare i contenuti. Scegli alcuni feed che ritieni interessanti."
-
-#~ msgid "Feeds can be topical as well!"
-#~ msgstr "I feed possono anche avere tematiche!"
-
-#~ msgid "File Contents"
-#~ msgstr "Archivia i contenuti"
-
-#~ msgid "Find more feeds and accounts to follow in the Explore page."
-#~ msgstr "Scopri nuovi account e feed da seguire in Esplora."
-
-#~ msgid "Find users on Bluesky"
-#~ msgstr "Scopri utenti su Bluesky"
-
-#~ msgid "Find users with the search tool on the right"
-#~ msgstr "Scopri gli utenti con lo strumento di ricerca sulla destra"
-
-#~ msgid "Finding similar accounts..."
-#~ msgstr "Scoprendo account simili…"
-
-#~ msgid "Fine-tune the content you see on your Following feed."
-#~ msgstr "Ottimizza il contenuto che vedi nel tuo Following feed."
-
-#~ msgid "Fine-tune the content you see on your home screen."
-#~ msgstr "Ottimizza il contenuto che vedi nella Home."
-
-#~ msgid "Fine-tune the discussion threads."
-#~ msgstr "Ottimizza la visualizzazione delle discussioni."
-
-#~ msgid "Finish tour and begin using the application"
-#~ msgstr "Termina il tour ed inizia ad usare l'app"
-
-#~ msgid "Flip horizontal"
-#~ msgstr "Gira in orizzontale"
-
-#~ msgid "Flip vertically"
-#~ msgstr "Gira in verticale"
-
-#~ msgid "Follow All"
-#~ msgstr "Segui tutti"
-
-#~ msgid "Follow selected accounts and continue to the next step"
-#~ msgstr "Segui gli account selezionati e vai al passaggio successivo"
-
-#~ msgid "Follow some users to get started. We can recommend you more users based on who you find interesting."
-#~ msgstr "Segui alcuni utenti per iniziare. Possiamo consigliarti più utenti in base a chi trovi interessante."
-
-#~ msgid "Followed by"
-#~ msgstr "Seguito da"
-
-#~ msgid "Followed by {0}"
-#~ msgstr "Seguito da {0}"
-
-#~ msgid "Followed users only"
-#~ msgstr "Solo utenti seguiti"
-
-#~ msgid "followed you"
-#~ msgstr "ti segue"
-
-#~ msgid "followed you back"
-#~ msgstr "ti ha seguito"
-
-#~ msgid "following"
-#~ msgstr "following"
-
-#~ msgid "Following shows the latest posts from people you follow."
-#~ msgstr "Il feed Following mostra i post più recenti delle persone che segui."
-
-#~ msgid "For security reasons, you won't be able to view this again. If you lose this password, you'll need to generate a new one."
-#~ msgstr "Per motivi di sicurezza non potrai visualizzarlo nuovamente. Se perdi questa password, dovrai generarne una nuova."
-
-#~ msgid "Forgot"
-#~ msgstr "Dimenticato"
-
-#~ msgid "Forgot password"
-#~ msgstr "Ho dimenticato la password"
-
-#~ msgid "Get started"
-#~ msgstr "Iniziamo"
-
-#~ msgid "Go to @{queryMaybeHandle}"
-#~ msgstr "Vai a @{queryMaybeHandle}"
-
-#~ msgid "Go to the next step of the tour"
-#~ msgstr "Vai avanti"
-
-#~ msgid "Here are some accounts for you to follow"
-#~ msgstr "Ecco alcuni account da seguire"
-
-#~ msgid "Here are some popular topical feeds. You can choose to follow as many as you like."
-#~ msgstr "Ecco alcuni feed più visitati. Puoi seguire quanti ne vuoi."
-
-#~ msgid "Here are some topical feeds based on your interests: {interestsText}. You can choose to follow as many as you like."
-#~ msgstr "Ecco alcuni feed di attualità scelti in base ai tuoi interessi: {interestsText}. Puoi seguire quanti ne vuoi."
-
-#~ msgid "Here is your app password."
-#~ msgstr "Ecco la password dell'app."
-
-#~ msgid "Hide post"
-#~ msgstr "Nascondi post"
-
-#~ msgid "Hides posts from {0} in your feed"
-#~ msgstr "Nasconde i post di {0} nel tuo feed"
-
-#~ msgid "Home Feed Preferences"
-#~ msgstr "Preferenze per i feed per la pagina d'inizio"
-
-#~ msgid "Hosting provider address"
-#~ msgstr "Indirizzo del fornitore di hosting"
-
-#~ msgid "If none are selected, suitable for all ages."
-#~ msgstr "Se niente è selezionato, adatto a tutte le età."
-
-#~ msgid "Image alt text"
-#~ msgstr "Testo alternativo dell'immagine"
-
-#~ msgid "Image options"
-#~ msgstr "Opzioni per l'immagine"
-
-#~ msgid "Input email for Bluesky account"
-#~ msgstr "Inserisci l'e-mail per l'account di Bluesky"
-
-#~ msgid "Input invite code to proceed"
-#~ msgstr "Inserisci il codice di invito per procedere"
-
-#~ msgid "Input name for app password"
-#~ msgstr "Inserisci il nome per la password dell'app"
-
-#~ msgid "Input phone number for SMS verification"
-#~ msgstr "Inserisci il numero di telefono per la verifica via SMS"
-
-#~ msgid "Input the password tied to {identifier}"
-#~ msgstr "Inserisci la password relazionata a {identifier}"
-
-#~ msgid "Input the verification code we have texted to you"
-#~ msgstr "Inserisci il codice di verifica che ti abbiamo inviato tramite SMS"
-
-#~ msgid "Input your email to get on the Bluesky waitlist"
-#~ msgstr "Inserisci la tua email per entrare nella lista d'attesa di Bluesky"
-
-#~ msgid "Input your preferred hosting provider"
-#~ msgstr "Inserisci il tuo provider di hosting preferito"
-
-#~ msgid "Introducing Direct Messages"
-#~ msgstr "Introduzione ai Messaggi Diretti"
-
-#~ msgid "Introducing new font settings"
-#~ msgstr "Introduzione di nuovi settaggi per i font"
-
-#~ msgid "Invite"
-#~ msgstr "Invita"
-
-#~ msgid "Invite codes: {invitesAvailable} available"
-#~ msgstr "Codici di invito: {invitesAvailable} disponibili"
-
-#~ msgid "It shows posts from the people you follow as they happen."
-#~ msgstr "Mostra i post delle persone che segui."
-
-#~ msgid "Join the waitlist"
-#~ msgstr "Iscriviti alla lista d'attesa"
-
-#~ msgid "Join the waitlist."
-#~ msgstr "Iscriviti alla lista d'attesa."
-
-#~ msgid "Join Waitlist"
-#~ msgstr "Iscriviti alla Lista d'Attesa"
-
-#~ msgid "label has been placed on this {labelTarget}"
-#~ msgstr "l'etichetta è stata inserita su questo {labelTarget}"
-
-#~ msgid "labels have been placed on this {labelTarget}"
-#~ msgstr "le etichette sono state inserite su questo {labelTarget}"
-
-#~ msgid "Language settings"
-#~ msgstr "Impostazione delle lingue"
-
-#~ msgid "Last step!"
-#~ msgstr "Ultimo passo!"
-
-#~ msgid "Learn more"
-#~ msgstr "Ulteriori informazioni"
-
-#~ msgid "Legacy storage cleared, you need to restart the app now."
-#~ msgstr "L'archivio legacy è stato cancellato, riattiva la app."
-
-#~ msgid "Library"
-#~ msgstr "Biblioteca"
-
-#~ msgid "Like"
-#~ msgstr "Mi piace"
-
-#~ msgid "Liked by {0} {1}"
-#~ msgstr "Piace a {0} {1}"
-
-#~ msgid "Liked by {count} {0}"
-#~ msgstr "È piaciuto a {count} {0}"
-
-#~ msgid "Liked by {likeCount} {0}"
-#~ msgstr "Piace a {likeCount} {0}"
-
-#~ msgid "liked your custom feed"
-#~ msgstr "piace il tuo feed personalizzato"
-
-#~ msgid "liked your custom feed{0}"
-#~ msgstr "piace il feed personalizzato{0}"
-
-#~ msgid "liked your post"
-#~ msgstr "piace il tuo post"
-
-#~ msgid "Load more posts"
-#~ msgstr "Carica più post"
-
-#~ msgid "Local dev server"
-#~ msgstr "Server di sviluppo locale"
-
-#~ msgid "Looks like this feed is only available to users with a Bluesky account. Please sign up or sign in to view this feed!"
-#~ msgstr "Sembra che questo feed sia disponibile solo per gli utenti con un account Bluesky. Per favore registrati o accedi per visualizzare questo feed!"
-
-#~ msgid "May not be longer than 253 characters"
-#~ msgstr "Non può contenere più di 253 caratteri"
-
-#~ msgid "May only contain letters and numbers"
-#~ msgstr "Può contenere solo lettere e numeri"
-
-#~ msgid "Message from server"
-#~ msgstr "Messaggio dal server"
-
-#~ msgid "Mode"
-#~ msgstr "Tema"
-
-#~ msgid "Moderation settings"
-#~ msgstr "Impostazioni di moderazione"
-
-#~ msgid "More post options"
-#~ msgstr "Altre impostazioni per il post"
-
-#~ msgid "Must be at least 3 characters"
-#~ msgstr "Deve contenere almeno 3 caratteri"
-
-#~ msgid "Mute in tags only"
-#~ msgstr "Silenzia solo i tags"
-
-#~ msgid "Mute in text & tags"
-#~ msgstr "Silenzia nel testo & tags"
-
-#~ msgid "Mute notifications"
-#~ msgstr "Silenza notifiche"
-
-#~ msgid "Mute this List"
-#~ msgstr "Silenzia questa Lista"
-
-#~ msgid "Muted"
-#~ msgstr "Silenziato"
-
-#~ msgid "My saved feeds"
-#~ msgstr "I miei feed salvati"
-
-#~ msgid "My Saved Feeds"
-#~ msgstr "I miei Feed Salvati"
-
-#~ msgid "my-server.com"
-#~ msgstr "my-server.com"
-
-#~ msgid "Navigate to starter pack"
-#~ msgstr "Vai allo starter pack"
-
-#~ msgid "Never load embeds from {0}"
-#~ msgstr "Non caricare mai gli inserimenti di {0}"
-
-#~ msgid "Never lose access to your followers and data."
-#~ msgstr "Non perdere mai l'accesso ai tuoi follower e ai tuoi dati."
-
-#~ msgid "New font settings ✨"
-#~ msgstr "Nuovi settaggi per i font ✨"
-
-#~ msgid "New Post"
-#~ msgstr "Nuovo Post"
-
-#~ msgctxt "action"
-#~ msgid "Next"
-#~ msgstr "Seguente"
-
-#~ msgid "No"
-#~ msgstr "No"
-
-#~ msgid "Nobody can reply"
-#~ msgstr "Nessuno puo rispondere"
-
-#~ msgid "Not Applicable."
-#~ msgstr "Non applicabile."
-
-#~ msgid "Nudity or pornography not labeled as such"
-#~ msgstr "Nudità o pornografia non etichettata come tale"
-
-#~ msgid "of"
-#~ msgstr "di"
-
-#~ msgid "on"
-#~ msgstr "su"
-
-#~ msgid "on {str}"
-#~ msgstr "su {str}"
-
-#~ msgid "Only {0} can reply"
-#~ msgstr "Solo {0} può rispondere"
-
-#~ msgid "Open links with in-app browser"
-#~ msgstr "Apri i links con il navigatore della app"
-
-#~ msgid "Opens accessibility settings"
-#~ msgstr "Apre le impostazioni di accessibilità"
-
-#~ msgid "Opens an expanded list of users in this notification"
-#~ msgstr "Apre un elenco ampliato di utenti in questa notifica"
-
-#~ msgid "Opens appearance settings"
-#~ msgstr "Apre le impostazioni del tema"
-
-#~ msgid "Opens chat settings"
-#~ msgstr "Apre impostazioni messaggi"
-
-#~ msgid "Opens configurable language settings"
-#~ msgstr "Apre le impostazioni configurabili delle lingue"
-
-#~ msgid "Opens editor for profile display name, avatar, background image, and description"
-#~ msgstr "Apre l'editor per il nome configurato del profilo, l'avatar, l'immagine di sfondo e la descrizione"
-
-#~ msgid "Opens external embeds settings"
-#~ msgstr "Apre le impostazioni esterne per gli incorporamenti"
-
-#~ msgid "Opens followers list"
-#~ msgstr "Apre la lista dei follower"
-
-#~ msgid "Opens following list"
-#~ msgstr "Apre la lista di chi segui"
-
-#~ msgid "Opens invite code list"
-#~ msgstr "Apre la lista dei codici di invito"
-
-#~ msgid "Opens modal for account deactivation confirmation"
-#~ msgstr "Apre menu per confermare la disattivazione dell'account"
-
-#~ msgid "Opens modal for account deletion confirmation. Requires email code"
-#~ msgstr "Apre la modale per la conferma dell'eliminazione dell'account. Richiede un codice e-mail"
-
-#~ msgid "Opens modal for account deletion confirmation. Requires email code."
-#~ msgstr "Apre il modal per la conferma dell'eliminazione dell'account. Richiede un codice email."
-
-#~ msgid "Opens modal for changing your Bluesky password"
-#~ msgstr "Apre la modale per modificare il tuo password di Bluesky"
-
-#~ msgid "Opens modal for choosing a new Bluesky handle"
-#~ msgstr "Apre la modale per la scelta di un nuovo handle di Bluesky"
-
-#~ msgid "Opens modal for downloading your Bluesky account data (repository)"
-#~ msgstr "Apre la modale per scaricare i dati del tuo account Bluesky (repository)"
-
-#~ msgid "Opens modal for email verification"
-#~ msgstr "Apre la modale per la verifica dell'e-mail"
-
-#~ msgid "Opens modal for using custom domain"
-#~ msgstr "Apre il modal per l'utilizzo del dominio personalizzato"
-
-#~ msgid "Opens moderation settings"
-#~ msgstr "Apre le impostazioni di moderazione"
-
-#~ msgid "Opens screen to edit Saved Feeds"
-#~ msgstr "Apre la schermata per modificare i feed salvati"
-
-#~ msgid "Opens screen with all saved feeds"
-#~ msgstr "Apre la schermata con tutti i feed salvati"
-
-#~ msgid "Opens the app password settings"
-#~ msgstr "Apre le impostazioni della password dell'app"
-
-#~ msgid "Opens the app password settings page"
-#~ msgstr "Apre la pagina delle impostazioni della password dell'app"
-
-#~ msgid "Opens the Following feed preferences"
-#~ msgstr "Apre le preferenze del feed Following"
-
-#~ msgid "Opens the home feed preferences"
-#~ msgstr "Apre le preferenze del home feed"
-
-#~ msgid "Opens the message settings page"
-#~ msgstr "Apre le impostazioni dei messaggi"
-
-#~ msgid "Opens the storybook page"
-#~ msgstr "Apri la pagina della cronologia"
-
-#~ msgid "Opens the system log page"
-#~ msgstr "Apre la pagina del registro di sistema"
-
-#~ msgid "Opens the threads preferences"
-#~ msgstr "Apre le preferenze dei threads"
-
-#~ msgid "Other accounts"
-#~ msgstr "Altri account"
-
-#~ msgid "Other service"
-#~ msgstr "Altro servizio"
-
-#~ msgid "Phone number"
-#~ msgstr "Numero di telefono"
-
-#~ msgid "Please enter a name for your app password. All spaces is not allowed."
-#~ msgstr "Inserisci un nome per la password dell'app. Tutti gli spazi non sono consentiti."
-
-#~ msgid "Please enter a phone number that can receive SMS text messages."
-#~ msgstr "Inserisci un numero di telefono in grado di ricevere messaggi di testo SMS."
-
-#~ msgid "Please enter a unique name for this App Password or use our randomly generated one."
-#~ msgstr "Inserisci un nome unico per la password dell'app o utilizzane uno generato automaticamente."
-
-#~ msgid "Please enter the code you received by SMS."
-#~ msgstr "Inserisci il codice che hai ricevuto via SMS."
-
-#~ msgid "Please enter the verification code sent to {phoneNumberFormatted}."
-#~ msgstr "Inserisci il codice di verifica inviato a {phoneNumberFormatted}."
-
-#~ msgid "Please tell us why you think this content warning was incorrectly applied!"
-#~ msgstr "Spiegaci perché ritieni che questo avviso sui contenuti sia stato applicato in modo errato!"
-
-#~ msgid "Please tell us why you think this decision was incorrect."
-#~ msgstr "Per favore spiegaci perché ritieni che questa decisione sia stata sbagliata."
-
-#~ msgid "Please wait for your link card to finish loading"
-#~ msgstr "Attendi il caricamento della scheda di collegamento"
-
-#~ msgid "Pornography"
-#~ msgstr "Pornografia"
-
-#~ msgid "Post"
-#~ msgstr "Post"
-
-#~ msgid "Posts can be muted based on their text, their tags, or both."
-#~ msgstr "I post possono essere silenziati ​​in base al testo, ai tag o entrambi."
-
-#~ msgid "Prioritize Your Follows"
-#~ msgstr "Dai priorità a quelli che segui"
-
-#~ msgid "Privately chat with other users."
-#~ msgstr "Messaggia privatamente con altri utenti."
-
-#~ msgid "Protect your account by verifying your email."
-#~ msgstr "Proteggi il tuo account verificando la tua email."
-
-#~ msgid "Publish post"
-#~ msgstr "Pubblica il post"
-
-#~ msgid "Publish reply"
-#~ msgstr "Pubblica la risposta"
-
-#~ msgctxt "action"
-#~ msgid "Quote post"
-#~ msgstr "Cita il post"
-
-#~ msgctxt "action"
-#~ msgid "Quote Post"
-#~ msgstr "Cita il post"
-
-#~ msgid "Quote Post"
-#~ msgstr "Cita il post"
-
-#~ msgid "Ratios"
-#~ msgstr "Rapporti"
-
-#~ msgid "Recommended Feeds"
-#~ msgstr "Feed consigliati"
-
-#~ msgid "Recommended Users"
-#~ msgstr "Utenti consigliati"
-
-#~ msgid "Remove {0} from my feeds?"
-#~ msgstr "Rimuovere {0} dai miei feed?"
-
-#~ msgid "Remove image preview"
-#~ msgstr "Rimuovi l'anteprima dell'immagine"
-
-#~ msgid "Remove this feed from my feeds?"
-#~ msgstr "Rimuovere questo feed dai miei feed?"
-
-#~ msgid "Remove this feed from your saved feeds?"
-#~ msgstr "Elimina questo feed dai feed salvati?"
-
-#~ msgid "Removes default thumbnail from {0}"
-#~ msgstr "Elimina la miniatura predefinita da {0}"
-
-#~ msgid "Removes the image preview"
-#~ msgstr "Rimuove la preview dell'immagine"
-
-#~ msgid "Replies on this thread are disabled"
-#~ msgstr "Le risposte a questo thread sono disattivate"
-
-#~ msgid "Replies to this thread are disabled"
-#~ msgstr "Le risposte a questo thread sono disabilitate"
-
-#~ msgid "Reply Filters"
-#~ msgstr "Filtri di risposta"
-
-#~ msgctxt "description"
-#~ msgid "Reply to <0/>"
-#~ msgstr "In risposta a <0/>"
-
-#~ msgid "Report {collectionName}"
-#~ msgstr "Segnala {collectionName}"
-
-#~ msgid "Reposted by"
-#~ msgstr "Repost di"
-
-#~ msgid "Reposted by {0})"
-#~ msgstr "Repost di {0})"
-
-#~ msgid "Reposted by <0/>"
-#~ msgstr "Repost di <0/>"
-
-#~ msgid "reposted your post"
-#~ msgstr "ripubblicato il tuo post"
-
-#~ msgid "Request code"
-#~ msgstr "Richiedi un codice"
-
-#~ msgid "Require email code to log into your account"
-#~ msgstr "Richiedi il codice via email per accedere al tuo account"
-
-#~ msgid "Reset onboarding"
-#~ msgstr "Reimposta l'incorporazione"
-
-#~ msgid "Reset preferences"
-#~ msgstr "Reimposta le preferenze"
-
-#~ msgid "Reset preferences state"
-#~ msgstr "Reimposta lo stato delle preferenze"
-
-#~ msgid "Resets the onboarding state"
-#~ msgstr "Reimposta lo stato dell'incorporazione"
-
-#~ msgid "Resets the preferences state"
-#~ msgstr "Reimposta lo stato delle preferenze"
-
-#~ msgid "Retry."
-#~ msgstr "Riprova."
-
-#~ msgid "SANDBOX. Posts and accounts are not permanent."
-#~ msgstr "SANDBOX. I post e gli account non sono permanenti."
-
-#~ msgid "Save alt text"
-#~ msgstr "Salva il testo alternativo"
-
-#~ msgid "Save handle change"
-#~ msgstr "Salva la modifica del tuo identificatore"
-
-#~ msgid "Saved to your camera roll."
-#~ msgstr "Salvato nel rullino fotografico."
-
-#~ msgid "Saves handle change to {handle}"
-#~ msgstr "Salva la modifica del cambio dell'utente in {handle}"
-
-#~ msgid "Search for all posts by @{authorHandle} with tag {displayTag}"
-#~ msgstr "Cerca tutti i post di @{authorHandle} con tag {displayTag}"
-
-#~ msgid "Search for all posts with tag {displayTag}"
-#~ msgstr "Cerca tutti i post con il tag {displayTag}"
-
-#~ msgid "See profile"
-#~ msgstr "Vedi il profilo"
-
-#~ msgid "See what's next"
-#~ msgstr "Scopri cosa c'è dopo"
-
-#~ msgid "Select Bluesky Social"
-#~ msgstr "Seleziona Bluesky Social"
-
-#~ msgid "Select service"
-#~ msgstr "Selecciona el servei"
-
-#~ msgid "Select some accounts below to follow"
-#~ msgstr "Seleziona alcuni account da seguire qui giù"
-
-#~ msgid "Select topical feeds to follow from the list below"
-#~ msgstr "Seleziona i feed con temi da seguire dal seguente elenco"
-
-#~ msgid "Select what you want to see (or not see), and we’ll handle the rest."
-#~ msgstr "Seleziona ciò che vuoi vedere (o non vedere) e noi gestiremo il resto."
-
-#~ msgid "Select your app language for the default text to display in the app"
-#~ msgstr "Seleziona la lingua dell'app per il testo predefinito da visualizzare nell'app"
-
-#~ msgid "Select your phone's country"
-#~ msgstr "Seleziona il Paese del tuo cellulare"
-
-#~ msgid "Select your primary algorithmic feeds"
-#~ msgstr "Seleziona i tuoi feed algoritmici principali"
-
-#~ msgid "Select your secondary algorithmic feeds"
-#~ msgstr "Seleziona i tuoi feed algoritmici secondari"
-
-#~ msgid "Send Email"
-#~ msgstr "Envia Email"
-
-#~ msgid "Send Report"
-#~ msgstr "Invia segnalazione"
-
-#~ msgid "Set {value} for {labelGroup} content moderation policy"
-#~ msgstr "Imposta {value} per la politica di moderazione dei contenuti di {labelGroup}"
-
-#~ msgctxt "action"
-#~ msgid "Set Age"
-#~ msgstr "Imposta l'età"
-
-#~ msgid "Set color theme to dark"
-#~ msgstr "Imposta il colore del tema scuro"
-
-#~ msgid "Set color theme to light"
-#~ msgstr "Imposta il colore del tema su chiaro"
-
-#~ msgid "Set color theme to system setting"
-#~ msgstr "Imposta il colore del tema basato sulle impostazioni del tuo sistema"
-
-#~ msgid "Set dark theme to the dark theme"
-#~ msgstr "Imposta il tema scuro sul tema scuro"
-
-#~ msgid "Set dark theme to the dim theme"
-#~ msgstr "Imposta il tema scuro sul tema scuro"
-
-#~ msgid "Set password"
-#~ msgstr "Imposta la password"
-
-#~ msgid "Set this setting to \"No\" to hide all quote posts from your feed. Reposts will still be visible."
-#~ msgstr "Seleziona \"No\" per nascondere tutti i post con le citazioni dal tuo feed. I repost saranno ancora visibili."
-
-#~ msgid "Set this setting to \"No\" to hide all replies from your feed."
-#~ msgstr "Seleziona \"No\" per nascondere tutte le risposte dal tuo feed."
-
-#~ msgid "Set this setting to \"No\" to hide all reposts from your feed."
-#~ msgstr "Seleziona \"No\" per nascondere tutte le ripubblicazioni dal tuo feed."
-
-#~ msgid "Set this setting to \"Yes\" to show replies in a threaded view. This is an experimental feature."
-#~ msgstr "Seleziona \"Sì\" per mostrare le risposte in una visualizzazione concatenata. Questa è una funzionalità sperimentale."
-
-#~ msgid "Set this setting to \"Yes\" to show samples of your saved feeds in your following feed. This is an experimental feature."
-#~ msgstr "Seleziona \"Sì\" per mostrare esempi dei feed salvati nel feed successivo. Questa è una funzionalità sperimentale."
-
-#~ msgid "Set this setting to \"Yes\" to show samples of your saved feeds in your Following feed. This is an experimental feature."
-#~ msgstr "Imposta questa impostazione su \"Sì\" per mostrare esempi dei tuoi feed salvati nel feed Seguiti. Questa è una funzionalità sperimentale."
-
-#~ msgid "Sets Bluesky username"
-#~ msgstr "Imposta il tuo nome utente di Bluesky"
-
-#~ msgid "Sets color theme to dark"
-#~ msgstr "Imposta il tema scuro"
-
-#~ msgid "Sets color theme to light"
-#~ msgstr "Imposta il tema chiaro"
-
-#~ msgid "Sets color theme to system setting"
-#~ msgstr "Imposta il tema basato impostazioni di sistema"
-
-#~ msgid "Sets dark theme to the dark theme"
-#~ msgstr "Imposta il tema scuro"
-
-#~ msgid "Sets dark theme to the dim theme"
-#~ msgstr "Imposta il tema soffuso"
-
-#~ msgid "Sets hosting provider for password reset"
-#~ msgstr "Imposta il provider del hosting per la reimpostazione della password"
-
-#~ msgid "Sets image aspect ratio to square"
-#~ msgstr "Imposta le proporzioni quadrate sull'immagine"
-
-#~ msgid "Sets image aspect ratio to tall"
-#~ msgstr "Imposta l'altura sulle proporzioni dell'immagine"
-
-#~ msgid "Sets image aspect ratio to wide"
-#~ msgstr "Imposta l'amplio sulle proporzioni dell'immagine"
-
-#~ msgid "Sets server for the Bluesky client"
-#~ msgstr "Imposta il server per il client Bluesky"
-
-#~ msgid "Show all replies"
-#~ msgstr "Mostra tutte le repliche"
-
-#~ msgid "Show embeds from {0}"
-#~ msgstr "Mostra incorporamenti di {0}"
-
-#~ msgid "Show follows similar to {0}"
-#~ msgstr "Mostra follows simile a {0}"
-
-#~ msgid "Show Posts from My Feeds"
-#~ msgstr "Mostra post dai miei feed"
-
-#~ msgid "Show Quote Posts"
-#~ msgstr "Mostra post con citazioni"
-
-#~ msgid "Show quote-posts in Following feed"
-#~ msgstr "Mostra i post con citazioni nel feed Seguiti"
-
-#~ msgid "Show quotes in Following"
-#~ msgstr "Mostra le citazioni in Seguiti"
-
-#~ msgid "Show re-posts in Following feed"
-#~ msgstr "Mostra re-post nel feed Seguiti"
-
-#~ msgid "Show Replies"
-#~ msgstr "Mostra risposte"
-
-#~ msgid "Show replies by people you follow before all other replies."
-#~ msgstr "Mostra le risposte delle persone che segui prima delle altre risposte."
-
-#~ msgid "Show replies in Following"
-#~ msgstr "Mostra le risposte in Seguiti"
-
-#~ msgid "Show replies in Following feed"
-#~ msgstr "Mostra le risposte nel feed Seguiti"
-
-#~ msgid "Show replies with at least {value} {0}"
-#~ msgstr "Mostra risposte con almeno {value} {0}"
-
-#~ msgid "Show Reposts"
-#~ msgstr "Mostra ripubblicazioni"
-
-#~ msgid "Show reposts in Following"
-#~ msgstr "Mostra i re-repost in Seguiti"
-
-#~ msgid "Show users"
-#~ msgstr "Mostra utenti"
-
-#~ msgid "Shows a list of users similar to this user."
-#~ msgstr "Mostra un elenco di utenti simili a questo utente."
-
-#~ msgid "Shows posts from {0} in your feed"
-#~ msgstr "Mostra i post di {0} nel tuo feed"
-
-#~ msgid "Sign In"
-#~ msgstr "Accedi"
-
-#~ msgid "Sign into"
-#~ msgstr "Accedi a"
-
-#~ msgid "Sign out of all accounts"
-#~ msgstr "Scollega tutti gli account"
-
-#~ msgid "Sign up or sign in to join the conversation"
-#~ msgstr "Iscriviti o accedi per partecipare alla conversazione"
-
-#~ msgid "Signed in as"
-#~ msgstr "Iscritto/a come"
-
-#~ msgid "signed up with your starter pack"
-#~ msgstr "iscritto/a col tuo starter pack"
-
-#~ msgid "Signs {0} out of Bluesky"
-#~ msgstr "Esci da Bluesky con {0}"
-
-#~ msgid "SMS verification"
-#~ msgstr "Verifica tramite SMS"
-
-#~ msgid "Some subtitle"
-#~ msgstr "Altri sottotitoli"
-
-#~ msgid "Something went wrong and we're not sure what."
-#~ msgstr "Qualcosa è andato storto ma non siamo sicuri di cosa."
-
-#~ msgid "Something went wrong. Check your email and try again."
-#~ msgstr "Qualcosa è andato storto. Controlla la tua email e riprova."
-
-#~ msgid "Sort Replies"
-#~ msgstr "Ordina le risposte"
-
-#~ msgid "Source: <0>{0}</0>"
-#~ msgstr "Fonte: <0>{0}</0>"
-
-#~ msgid "Source: <0>{sourceName}</0>"
-#~ msgstr "Fonte: <0>{sourceName}</0>"
-
-#~ msgid "Square"
-#~ msgstr "Quadrato"
-
-#~ msgid "Staging"
-#~ msgstr "Allestimento"
-
-#~ msgid "Start chatting"
-#~ msgstr "Iniza a conversare"
-
-#~ msgid "Status page"
-#~ msgstr "Pagina di stato"
-
-#~ msgid "Step"
-#~ msgstr "Passo"
-
-#~ msgid "Step {0} of {numSteps}"
-#~ msgstr "Passo {0} di {numSteps}"
-
-#~ msgid "Subscribe to the {0} feed"
-#~ msgstr "Iscriviti a {0} feed"
-
-#~ msgid "Suggested Follows"
-#~ msgstr "Accounts da seguire"
-
-#~ msgid "Swipe up to see more"
-#~ msgstr "Scorri verso l'alto per vedere di più"
-
-#~ msgid "Switch between feeds to control your experience."
-#~ msgstr "Cambia tra i feed per avere il totale controllo della tua esperienza."
-
-#~ msgid "Switch to {0}"
-#~ msgstr "Cambia a {0}"
-
-#~ msgid "Switches the account you are logged in to"
-#~ msgstr "Cambia l'account dal quale hai effettuato l'accesso"
-
-#~ msgid "tag"
-#~ msgstr "tag"
-
-#~ msgid "Tall"
-#~ msgstr "Alto"
-
-#~ msgid "Tap to view fully"
-#~ msgstr "Tocca per visualizzare completamente"
-
-#~ msgid "text"
-#~ msgstr "testo"
-
-#~ msgid "the author"
-#~ msgstr "l'autore"
-
-#~ msgid "The support form has been moved. If you need help, please<0/> or visit {HELP_DESK_URL} to get in touch with us."
-#~ msgstr "Il modulo di supporto è stato spostato. Se hai bisogno di aiuto, <0/> o visita {HELP_DESK_URL} per metterti in contatto con noi."
-
-#~ msgid "There are many feeds to try:"
-#~ msgstr "Ci sono molti feed da provare:"
-
-#~ msgid "There was an an issue contacting the server, please check your internet connection and try again."
-#~ msgstr "Si è verificato un problema nel contattare il server, controlla la tua connessione Internet e riprova."
-
-#~ msgid "There was an an issue removing this feed. Please check your internet connection and try again."
-#~ msgstr "Si è verificato un problema durante la rimozione di questo feed. Per favore controlla la tua connessione Internet e prova di nuovo."
-
-#~ msgid "There was an an issue updating your feeds, please check your internet connection and try again."
-#~ msgstr "Si è verificato un problema durante la rimozione di questo feed. Per favore controlla la tua connessione Internet e prova di nuovo."
-
-#~ msgid "There was an issue connecting to the chat."
-#~ msgstr "Si è verificato un errore nel connettersi alla chat."
-
-#~ msgid "There was an issue syncing your preferences with the server"
-#~ msgstr "Si è verificato un problema durante la sincronizzazione delle tue preferenze con il server"
-
-#~ msgid "There was an issue with fetching your app passwords"
-#~ msgstr "Si è verificato un problema durante il recupero delle password dell'app"
-
-#~ msgid "There's something wrong with this number. Please choose your country and enter your full phone number!"
-#~ msgstr "C'è qualcosa di sbagliato in questo numero. Scegli il tuo Paese e inserisci il tuo numero di telefono completo!"
-
-#~ msgid "These are popular accounts you might like:"
-#~ msgstr "Questi sono gli account popolari che potrebbero piacerti:"
-
-#~ msgid "This {0} has been labeled."
-#~ msgstr "Questo {0} è stato etichettato."
-
-#~ msgid "This appeal will be sent to <0>{0}</0>."
-#~ msgstr "Questo ricorso verrà inviato a <0>{0}</0>."
-
-#~ msgid "This feature is in beta. You can read more about repository exports in <0>this blogpost.</0>"
-#~ msgstr "Questa funzionalità è in versione beta. Puoi leggere ulteriori informazioni sulle esportazioni dell' archivio in <0>questo post del blog.</0>"
-
-#~ msgid "This feed is empty!"
-#~ msgstr "Questo feed è vuoto!"
-
-#~ msgid "This is the service that keeps you online."
-#~ msgstr "Questo è il servizio che ti mantiene online."
-
-#~ msgid "This label was applied by {0}."
-#~ msgstr "Questa etichetta è stata applicata da {0}."
-
-#~ msgid "This name is already in use"
-#~ msgstr "Questo nome è già in uso"
-
-#~ msgid "This post will be hidden from feeds."
-#~ msgstr "Questo post verrà nascosto dai feed."
-
-#~ msgid "This user is included in the <0/> list which you have blocked."
-#~ msgstr "Questo utente è incluso nell'elenco <0/> che hai bloccato."
-
-#~ msgid "This user is included in the <0/> list which you have muted."
-#~ msgstr "Questo utente è incluso nell'elenco <0/> che hai disattivato."
-
-#~ msgid "This user is included the <0/> list which you have muted."
-#~ msgstr "Questo utente è incluso nella lista <0/> che hai silenziato."
-
-#~ msgid "This warning is only available for posts with media attached."
-#~ msgstr "Questo avviso è disponibile solo per i post con contenuti multimediali allegati."
-
-#~ msgid "This will delete {0} from your muted words. You can always add it back later."
-#~ msgstr "Questo eliminerà {0} dalle parole disattivate. Puoi sempre aggiungerla nuovamente in seguito."
-
-#~ msgid "This will hide this post from your feeds."
-#~ msgstr "Questo nasconderà il post dai tuoi feed."
-
-#~ msgid "Thread settings updated"
-#~ msgstr "Impostazioni thread aggiornate"
-
-#~ msgid "Threaded Mode"
-#~ msgstr "Modalità discussione"
-
-#~ msgid "Toggle between muted word options."
-#~ msgstr "Alterna tra le opzioni delle parole silenziate."
-
-#~ msgid "Transformations"
-#~ msgstr "Trasformazioni"
-
-#~ msgid "Try again"
-#~ msgstr "Provalo di nuovo"
-
-#~ msgid "Two-factor authentication"
-#~ msgstr "Autenticazione a due fattori"
-
-#~ msgid "Unfollow"
-#~ msgstr "Smetti di seguire"
-
-#~ msgid "Unfortunately, you do not meet the requirements to create an account."
-#~ msgstr "Sfortunatamente, non soddisfi i requisiti per creare un account."
-
-#~ msgid "Unlike"
-#~ msgstr "Togli Mi piace"
-
-#~ msgid "Unmuted"
-#~ msgstr "Audio riattivato"
-
-#~ msgid "Unsave"
-#~ msgstr "Rimuovi"
-
-#~ msgid "Update {displayName} in Lists"
-#~ msgstr "Aggiorna {displayName} negli elenchi"
-
-#~ msgid "Update Available"
-#~ msgstr "Aggiornamento disponibile"
-
-#~ msgid "Update to {handle}"
-#~ msgstr "Aggiorna a {handle}"
-
-#~ msgid "Use a file on your server"
-#~ msgstr "Utilizza un file sul tuo server"
-
-#~ msgid "Use app passwords to login to other Bluesky clients without giving full access to your account or password."
-#~ msgstr "Utilizza le password dell'app per accedere ad altri client Bluesky senza fornire l'accesso completo al tuo account o alla tua password."
-
-#~ msgid "Use bsky.social as hosting provider"
-#~ msgstr "Utilizza bsky.social come provider di hosting"
-
-#~ msgid "Use the DNS panel"
-#~ msgstr "Utilizza il pannello DNS"
-
-#~ msgid "Use your domain as your Bluesky client service provider"
-#~ msgstr "Utilizza il tuo dominio come provider di servizi clienti Bluesky"
-
-#~ msgid "User handle"
-#~ msgstr "Handle dell'utente"
-
-#~ msgid "users followed by <0/>"
-#~ msgstr "utenti seguiti da <0/>"
-
-#~ msgid "Verification code"
-#~ msgstr "Codice di verifica"
-
-#~ msgid "Verify {0}"
-#~ msgstr "Verifica {0}"
-
-#~ msgid "Verify email"
-#~ msgstr "Verifica Email"
-
-#~ msgid "Verify my email"
-#~ msgstr "Verifica la mia email"
-
-#~ msgid "Verify My Email"
-#~ msgstr "Verifica la Mia Email"
-
-#~ msgid "Version {0}"
-#~ msgstr "Versione {0}"
-
-#~ msgid "Version {appVersion} {bundleInfo}"
-#~ msgstr "Versione {appVersion} {bundleInfo}"
-
-#~ msgid "Videos cannot be larger than 50MB"
-#~ msgstr "I video non possono essere più grandi di 50MB"
-
-#~ msgid "We also think you'll like \"For You\" by Skygaze:"
-#~ msgstr "Pensiamo che ti piacerà anche \"Per Te\" di Skygaze:"
-
-#~ msgid "We recommend avoiding common words that appear in many posts, since it can result in no posts being shown."
-#~ msgstr "Ti consigliamo di evitare usare parole comuni che compaiono in molti post, perchè ciò potrebbe comportare la mancata visualizzazione dei post."
-
-#~ msgid "We recommend our \"Discover\" feed:"
-#~ msgstr "Consigliamo il nostro feed \"Scopri\":"
-
-#~ msgid "We'll look into your appeal promptly."
-#~ msgstr "Esamineremo il tuo ricorso al più presto."
-
-#~ msgid "We're introducing a new theme font, along with adjustable font sizing."
-#~ msgstr "Abbiamo introdotto un nuovo tema font, assieme alla possibilità di aggiustare le dimensioni del font."
-
-#~ msgid "We're sorry! You can only subscribe to ten labelers, and you've reached your limit of ten."
-#~ msgstr "Ci dispiace! Puoi iscriverti solo a dieci etichettatori e hai raggiunto il limite di dieci."
-
-#~ msgid "Welcome to <0>Bluesky</0>"
-#~ msgstr "Ti diamo il benvenuto a <0>Bluesky</0>"
-
-#~ msgid "What is the issue with this {collectionName}?"
-#~ msgstr "Qual è il problema con questo {collectionName}?"
-
-#~ msgid "What's next?"
-#~ msgstr "Qual è il prossimo?"
-
-#~ msgid "Who can message you?"
-#~ msgstr "Chi puoi inviarti messaggi?"
-
-#~ msgid "Who can reply?"
-#~ msgstr "Chi può rispondere?"
-
-#~ msgid "Wide"
-#~ msgstr "Largo"
-
-#~ msgid "XXXXXX"
-#~ msgstr "XXXXXX"
-
-#~ msgid "Yesterday, {time}"
-#~ msgstr "Ieri, {time}"
-
-#~ msgid "You can adjust these in your Appearance Settings later."
-#~ msgstr "Puoi modificarli successivamente nelle Impostazioni Aspetto."
-
-#~ msgid "You can change hosting providers at any time."
-#~ msgstr "Puoi cambiare provider di hosting in qualsiasi momento."
-
-#~ msgid "You can change these settings later."
-#~ msgstr "Potrai modificare queste impostazioni in seguito."
-
-#~ msgid "You can change this at any time."
-#~ msgstr "Puoi modificarlo in qualsiasi momento."
-
-#~ msgid "You don't have any saved feeds!"
-#~ msgstr "Non hai salvato nessun feed!"
-
-#~ msgid "You have muted this user."
-#~ msgstr "Hai disattivato questo utente."
-
-#~ msgid "You have not blocked any accounts yet. To block an account, go to their profile and selected \"Block account\" from the menu on their account."
-#~ msgstr "Non hai ancora bloccato nessun conto. Per bloccare un conto, vai al profilo e seleziona \"Blocca conto\" dal menu del suo conto."
-
-#~ msgid "You have not created any app passwords yet. You can create one by pressing the button below."
-#~ msgstr "Non hai ancora creato alcuna password per l'app. Puoi crearne uno premendo il pulsante qui sotto."
-
-#~ msgid "You have not muted any accounts yet. To mute an account, go to their profile and selected \"Mute account\" from the menu on their account."
-#~ msgstr "Non hai ancora disattivato alcun account. Per disattivare un account, vai al suo profilo e seleziona \"Disattiva account\" dal menu del account."
-
-#~ msgid "You may only add up to 50 feeds"
-#~ msgstr "Puoi aggiungere un massimo di 50 feed"
-
-#~ msgid "You may only add up to 50 profiles"
-#~ msgstr "Puoi aggiungere un massimo di 50 utenti"
-
-#~ msgid "You must be 18 or older to enable adult content."
-#~ msgstr "Devi avere almeno 18 anni per abilitare i contenuti per adulti."
-
-#~ msgid "You must be 18 years or older to enable adult content"
-#~ msgstr "Devi avere almeno 18 anni per abilitare i contenuti per adulti"
-
-#~ msgid "You're in control"
-#~ msgstr "Sei in controllo"
-
-#~ msgid "Your default feed is \"Following\""
-#~ msgstr "Il tuo feed predefinito è \"Following\""
-
-#~ msgid "Your email has been saved! We'll be in touch soon."
-#~ msgstr "La tua email è stata salvata! Ci metteremo in contatto al più presto."
-
-#~ msgid "Your hosting provider"
-#~ msgstr "Il tuo fornitore di hosting"
-
-#~ msgid "Your invite codes are hidden when logged in using an App Password"
-#~ msgstr "I tuoi codici di invito vengono celati quando accedi utilizzando una password per l'app"
-
-#~ msgid "Your profile"
-#~ msgstr "Il tuo profilo"

--- a/src/locale/locales/it/messages.po
+++ b/src/locale/locales/it/messages.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: Italian localization\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-01-05 11:44+0530\n"
-"PO-Revision-Date: 2024-11-20 14:05+0100\n"
+"PO-Revision-Date: 2024-11-21 10:10+0100\n"
 "Last-Translator: Michele Locati <michele@locati.it>\n"
 "Language-Team: \n"
 "Language: it\n"
@@ -147,7 +147,7 @@ msgstr "{0}g"
 #. How many hours have passed, displayed in a narrow form
 #: src/lib/hooks/useTimeAgo.ts:148
 msgid "{0}h"
-msgstr "{0}o"
+msgstr "{0}h"
 
 #. How many minutes have passed, displayed in a narrow form
 #: src/lib/hooks/useTimeAgo.ts:138

--- a/src/locale/locales/it/messages.po
+++ b/src/locale/locales/it/messages.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Italian localization\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-23 01:06+0000\n"
-"PO-Revision-Date: 2024-11-23 08:06+0000\n"
+"POT-Creation-Date: 2024-11-23 12:26+0000\n"
+"PO-Revision-Date: 2024-11-23 18:03+0000\n"
 "Last-Translator: Michele Locati <michele@locati.it>, 2024\n"
 "Language-Team: Italian (https://app.transifex.com/mlocati/teams/201833/it/)\n"
 "Language: it\n"
@@ -2536,7 +2536,7 @@ msgid "Expected uri to resolve to a record"
 msgstr "L'URI dovrebbe risolvere in un record"
 
 #: src/screens/Settings/FollowingFeedPreferences.tsx:115
-#: src/screens/Settings/ThreadPreferences.tsx:123
+#: src/screens/Settings/ThreadPreferences.tsx:129
 msgid "Experimental"
 msgstr "Sperimentale"
 
@@ -3202,6 +3202,11 @@ msgstr "Hosting:"
 #: src/screens/Signup/StepInfo/index.tsx:133
 msgid "Hosting provider"
 msgstr "Servizio di hosting"
+
+#: src/screens/Settings/ThreadPreferences.tsx:59
+#: src/screens/Settings/ThreadPreferences.tsx:62
+msgid "Hot replies first"
+msgstr "Prima le risposte più popolari"
 
 #: src/view/com/modals/InAppBrowserConsent.tsx:41
 msgid "How should we open this link?"
@@ -3873,11 +3878,11 @@ msgstr "Altri feed"
 msgid "More options"
 msgstr "Altre opzioni"
 
-#: src/screens/Settings/ThreadPreferences.tsx:80
+#: src/screens/Settings/ThreadPreferences.tsx:86
 msgid "Most-liked first"
 msgstr "Prima quelli con più like"
 
-#: src/screens/Settings/ThreadPreferences.tsx:77
+#: src/screens/Settings/ThreadPreferences.tsx:83
 msgid "Most-liked replies first"
 msgstr "Dai priorità alle risposte con più likes"
 
@@ -4119,8 +4124,8 @@ msgstr "Finestra informativa per nuovi utenti"
 msgid "New User List"
 msgstr "Nuova lista"
 
-#: src/screens/Settings/ThreadPreferences.tsx:69
-#: src/screens/Settings/ThreadPreferences.tsx:72
+#: src/screens/Settings/ThreadPreferences.tsx:75
+#: src/screens/Settings/ThreadPreferences.tsx:78
 msgid "Newest replies first"
 msgstr "Mostrare prima le risposte più recenti"
 
@@ -4373,8 +4378,8 @@ msgstr "OK"
 msgid "Okay"
 msgstr "Va bene"
 
-#: src/screens/Settings/ThreadPreferences.tsx:61
-#: src/screens/Settings/ThreadPreferences.tsx:64
+#: src/screens/Settings/ThreadPreferences.tsx:67
+#: src/screens/Settings/ThreadPreferences.tsx:70
 msgid "Oldest replies first"
 msgstr "Mostrare prima le risposte più vecchie"
 
@@ -4930,8 +4935,8 @@ msgstr "Immagine precedente"
 msgid "Primary Language"
 msgstr "Lingua principale"
 
-#: src/screens/Settings/ThreadPreferences.tsx:98
-#: src/screens/Settings/ThreadPreferences.tsx:103
+#: src/screens/Settings/ThreadPreferences.tsx:104
+#: src/screens/Settings/ThreadPreferences.tsx:109
 msgid "Prioritize your Follows"
 msgstr "Dai priorità a chi segui"
 
@@ -5052,8 +5057,8 @@ msgstr "Citazioni"
 msgid "Quotes of this post"
 msgstr "Citazioni post"
 
-#: src/screens/Settings/ThreadPreferences.tsx:85
-#: src/screens/Settings/ThreadPreferences.tsx:88
+#: src/screens/Settings/ThreadPreferences.tsx:91
+#: src/screens/Settings/ThreadPreferences.tsx:94
 msgid "Random (aka \"Poster's Roulette\")"
 msgstr "Selezione a caso (nota anche come \"Poster's Roulette\")"
 
@@ -6036,11 +6041,11 @@ msgstr "Mostra i post con citazione"
 msgid "Show replies"
 msgstr "Mostra risposte"
 
-#: src/screens/Settings/ThreadPreferences.tsx:112
+#: src/screens/Settings/ThreadPreferences.tsx:118
 msgid "Show replies by people you follow before all other replies"
 msgstr "Mostra risposte delle persone che segui prima delle altre risposte"
 
-#: src/screens/Settings/ThreadPreferences.tsx:137
+#: src/screens/Settings/ThreadPreferences.tsx:143
 msgid "Show replies in a threaded view"
 msgstr "Mostra risposte in modalità a thread"
 
@@ -6876,7 +6881,7 @@ msgstr "Preferenze delle discussioni"
 msgid "Thread Preferences"
 msgstr "Preferenze delle Discussioni"
 
-#: src/screens/Settings/ThreadPreferences.tsx:128
+#: src/screens/Settings/ThreadPreferences.tsx:134
 msgid "Threaded mode"
 msgstr "Modalità a thread"
 

--- a/src/locale/locales/it/messages.po
+++ b/src/locale/locales/it/messages.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: Italian localization\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-11-20 10:25+0000\n"
-"PO-Revision-Date: 2024-11-21 11:08+0100\n"
+"PO-Revision-Date: 2024-11-21 20:48+0100\n"
 "Last-Translator: Michele Locati <michele@locati.it>\n"
 "Language-Team: \n"
 "Language: it\n"
@@ -524,7 +524,7 @@ msgstr "Aggiungi dei feed al tuo starter pack!"
 msgid "Add the default feed of only people you follow"
 msgstr "Aggiungi il feed predefinito delle sole persone che segui"
 
-#: src/screens/Settings/components/ChangeHandleDialog.tsx:387
+#: src/screens/Settings/components/ChangeHandleDialog.tsx:386
 msgid "Add the following DNS record to your domain:"
 msgstr "Aggiungi il seguente record DNS al tuo dominio:"
 
@@ -1196,7 +1196,7 @@ msgid "Change email address"
 msgstr "Cambia indirizzo email"
 
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:88
-#: src/screens/Settings/components/ChangeHandleDialog.tsx:93
+#: src/screens/Settings/components/ChangeHandleDialog.tsx:92
 msgid "Change Handle"
 msgstr "Modifica il nome utente"
 
@@ -1254,7 +1254,7 @@ msgstr "Controlla la tua email per il codice di accesso e inseriscilo qui."
 msgid "Check your inbox for an email with the confirmation code to enter below:"
 msgstr "Controlla la tua posta in arrivo, dovrebbe contenere un'e-mail con il codice di conferma da inserire di seguito:"
 
-#: src/screens/Settings/components/ChangeHandleDialog.tsx:370
+#: src/screens/Settings/components/ChangeHandleDialog.tsx:369
 msgid "Choose domain verification method"
 msgstr "Scegli il metodo di verifica del dominio"
 
@@ -1615,11 +1615,11 @@ msgstr "Copia versione build negli appunti"
 msgid "Copy code"
 msgstr "Copia il codice"
 
-#: src/screens/Settings/components/ChangeHandleDialog.tsx:472
+#: src/screens/Settings/components/ChangeHandleDialog.tsx:471
 msgid "Copy DID"
 msgstr "Copia DID"
 
-#: src/screens/Settings/components/ChangeHandleDialog.tsx:405
+#: src/screens/Settings/components/ChangeHandleDialog.tsx:404
 msgid "Copy host"
 msgstr "Copia host"
 
@@ -1654,7 +1654,7 @@ msgstr "Copia il testo del post"
 msgid "Copy QR code"
 msgstr "Copia codice QR"
 
-#: src/screens/Settings/components/ChangeHandleDialog.tsx:426
+#: src/screens/Settings/components/ChangeHandleDialog.tsx:425
 msgid "Copy TXT record value"
 msgstr "Copia valore del record TXT"
 
@@ -2008,8 +2008,8 @@ msgstr "Il nome visualizzato è troppo lungo"
 msgid "Display name is too long. The maximum number of characters is {DISPLAY_NAME_MAX_GRAPHEMES}."
 msgstr "Il nome visualizzato è troppo lungo. Il numero massimo di caratteri è {DISPLAY_NAME_MAX_GRAPHEMES}."
 
-#: src/screens/Settings/components/ChangeHandleDialog.tsx:373
-#: src/screens/Settings/components/ChangeHandleDialog.tsx:375
+#: src/screens/Settings/components/ChangeHandleDialog.tsx:372
+#: src/screens/Settings/components/ChangeHandleDialog.tsx:374
 msgid "DNS Panel"
 msgstr "Pannello DNS"
 
@@ -2025,7 +2025,7 @@ msgstr "Non include nudità."
 msgid "Doesn't begin or end with a hyphen"
 msgstr "Non inizia o termina con un trattino"
 
-#: src/screens/Settings/components/ChangeHandleDialog.tsx:488
+#: src/screens/Settings/components/ChangeHandleDialog.tsx:487
 msgid "Domain verified!"
 msgstr "Dominio verificato!"
 
@@ -2082,7 +2082,7 @@ msgstr "Trascina e rilascia per aggiungere immagini"
 msgid "Duration:"
 msgstr "Durata:"
 
-#: src/screens/Settings/components/ChangeHandleDialog.tsx:210
+#: src/screens/Settings/components/ChangeHandleDialog.tsx:209
 msgid "e.g. alice"
 msgstr "e.g. alice"
 
@@ -2094,7 +2094,7 @@ msgstr "es. Mario Rossi"
 msgid "e.g. Alice Roberts"
 msgstr "e.g. Alice Roberts"
 
-#: src/screens/Settings/components/ChangeHandleDialog.tsx:357
+#: src/screens/Settings/components/ChangeHandleDialog.tsx:356
 msgid "e.g. alice.com"
 msgstr "e.g. alice.com"
 
@@ -2350,7 +2350,7 @@ msgstr "Inserire il codice di conferma"
 msgid "Enter the code you received to change your password."
 msgstr "Inserisci il codice che hai ricevuto per modificare la tua password."
 
-#: src/screens/Settings/components/ChangeHandleDialog.tsx:351
+#: src/screens/Settings/components/ChangeHandleDialog.tsx:350
 msgid "Enter the domain you want to use"
 msgstr "Inserisci il dominio che vuoi utilizzare"
 
@@ -2514,7 +2514,7 @@ msgstr "I media esterni possono consentire ai siti web di raccogliere informazio
 msgid "External Media Preferences"
 msgstr "Preferenze media esterni"
 
-#: src/screens/Settings/components/ChangeHandleDialog.tsx:553
+#: src/screens/Settings/components/ChangeHandleDialog.tsx:552
 msgid "Failed to change handle. Please try again."
 msgstr "Non è stato possibile cambiare il nome utente. Riprovare."
 
@@ -2603,7 +2603,7 @@ msgstr "Errore nell'aggiornamento delle impostazioni"
 msgid "Failed to upload video"
 msgstr "Errore nel caricamento video"
 
-#: src/screens/Settings/components/ChangeHandleDialog.tsx:341
+#: src/screens/Settings/components/ChangeHandleDialog.tsx:340
 msgid "Failed to verify handle. Please try again."
 msgstr "Impossibile verificare il nome utente. Riprovare."
 
@@ -2905,7 +2905,7 @@ msgstr "Torna indietro"
 msgid "Go Back"
 msgstr "Torna indietro"
 
-#: src/screens/Settings/components/ChangeHandleDialog.tsx:529
+#: src/screens/Settings/components/ChangeHandleDialog.tsx:528
 msgid "Go back to previous page"
 msgstr "Torna alla pagina precedente"
 
@@ -2961,16 +2961,16 @@ msgstr "Siamo a metà!"
 msgid "Handle"
 msgstr "Nome utente"
 
-#: src/screens/Settings/components/ChangeHandleDialog.tsx:557
+#: src/screens/Settings/components/ChangeHandleDialog.tsx:556
 msgid "Handle already taken. Please try a different one."
 msgstr "Nome utente già in uso. Prova con uno diverso."
 
-#: src/screens/Settings/components/ChangeHandleDialog.tsx:188
-#: src/screens/Settings/components/ChangeHandleDialog.tsx:325
+#: src/screens/Settings/components/ChangeHandleDialog.tsx:187
+#: src/screens/Settings/components/ChangeHandleDialog.tsx:324
 msgid "Handle changed!"
 msgstr "Nome utente modificato!"
 
-#: src/screens/Settings/components/ChangeHandleDialog.tsx:561
+#: src/screens/Settings/components/ChangeHandleDialog.tsx:560
 msgid "Handle too long. Please try a shorter one."
 msgstr "Nome utente troppo lungo. Provarne uno più breve."
 
@@ -3098,7 +3098,7 @@ msgstr "Un po' di pazienza: stiamo gradualmente dando accesso al video e tu sei 
 msgid "Home"
 msgstr "Home"
 
-#: src/screens/Settings/components/ChangeHandleDialog.tsx:398
+#: src/screens/Settings/components/ChangeHandleDialog.tsx:397
 msgid "Host:"
 msgstr "Hosting:"
 
@@ -3127,8 +3127,8 @@ msgstr "Ho il Codice"
 msgid "I have a confirmation code"
 msgstr "Ho un codice di conferma"
 
-#: src/screens/Settings/components/ChangeHandleDialog.tsx:261
-#: src/screens/Settings/components/ChangeHandleDialog.tsx:267
+#: src/screens/Settings/components/ChangeHandleDialog.tsx:260
+#: src/screens/Settings/components/ChangeHandleDialog.tsx:266
 msgid "I have my own domain"
 msgstr "Ho il mio dominio"
 
@@ -3149,7 +3149,7 @@ msgstr "Se non sei ancora maggiorenne secondo le leggi del tuo Paese, il tuo gen
 msgid "If you delete this list, you won't be able to recover it."
 msgstr "Se elimini questa lista, non potrai recuperarla."
 
-#: src/screens/Settings/components/ChangeHandleDialog.tsx:247
+#: src/screens/Settings/components/ChangeHandleDialog.tsx:246
 msgid "If you have your own domain, you can use that as your handle. This lets you self-verify your identity – <0>learn more</0>."
 msgstr "Se hai un tuo dominio, puoi usarlo come nome utente. Questo consente di auto-verificare la tua identità – <0>ulteriori informazioni</0>."
 
@@ -3230,7 +3230,7 @@ msgstr "Interazione limitata"
 msgid "Invalid 2FA confirmation code."
 msgstr "Codice di conferma 2FA non valido."
 
-#: src/screens/Settings/components/ChangeHandleDialog.tsx:563
+#: src/screens/Settings/components/ChangeHandleDialog.tsx:562
 msgid "Invalid handle. Please try a different one."
 msgstr "Nome utente non valido. Provarne un altro."
 
@@ -3364,7 +3364,7 @@ msgstr "Più grande"
 msgid "Latest"
 msgstr "Ultime"
 
-#: src/screens/Settings/components/ChangeHandleDialog.tsx:251
+#: src/screens/Settings/components/ChangeHandleDialog.tsx:250
 msgid "learn more"
 msgstr "ulteriori informazioni"
 
@@ -3550,7 +3550,7 @@ msgstr "Carica più notifiche"
 #: src/view/com/feeds/FeedPage.tsx:132 src/view/screens/ProfileFeed.tsx:499
 #: src/view/screens/ProfileList.tsx:808
 msgid "Load new posts"
-msgstr "Carica nuovi posts"
+msgstr "Carica nuovi post"
 
 #: src/view/com/composer/text-input/mobile/Autocomplete.tsx:111
 msgid "Loading..."
@@ -3930,7 +3930,7 @@ msgstr "Hai bisogno di segnalare una violazione del copyright?"
 msgid "Never lose access to your followers or data."
 msgstr "Non perdere mai l'accesso ai tuoi follower o ai tuoi dati."
 
-#: src/screens/Settings/components/ChangeHandleDialog.tsx:533
+#: src/screens/Settings/components/ChangeHandleDialog.tsx:532
 msgid "Nevermind, create a handle for me"
 msgstr "Non importa, crea un nome utente per me"
 
@@ -3948,9 +3948,9 @@ msgstr "Nuova"
 msgid "New chat"
 msgstr "Nuova chat"
 
-#: src/screens/Settings/components/ChangeHandleDialog.tsx:201
-#: src/screens/Settings/components/ChangeHandleDialog.tsx:209
-#: src/screens/Settings/components/ChangeHandleDialog.tsx:356
+#: src/screens/Settings/components/ChangeHandleDialog.tsx:200
+#: src/screens/Settings/components/ChangeHandleDialog.tsx:208
+#: src/screens/Settings/components/ChangeHandleDialog.tsx:355
 msgid "New handle"
 msgstr "Nuovo nome utente"
 
@@ -4032,8 +4032,8 @@ msgstr "Non è stata ancora definita alcuna password per le app"
 msgid "No description"
 msgstr "Senza descrizione"
 
-#: src/screens/Settings/components/ChangeHandleDialog.tsx:378
-#: src/screens/Settings/components/ChangeHandleDialog.tsx:380
+#: src/screens/Settings/components/ChangeHandleDialog.tsx:377
+#: src/screens/Settings/components/ChangeHandleDialog.tsx:379
 msgid "No DNS Panel"
 msgstr "Nessun pannello DNS"
 
@@ -4292,7 +4292,7 @@ msgstr "Ops! Qualcosa è andato male!"
 #: src/components/StarterPack/ProfileStarterPacks.tsx:322
 #: src/components/StarterPack/ProfileStarterPacks.tsx:331
 #: src/screens/Settings/AppPasswords.tsx:51
-#: src/screens/Settings/components/ChangeHandleDialog.tsx:101
+#: src/screens/Settings/components/ChangeHandleDialog.tsx:100
 #: src/screens/Settings/NotificationSettings.tsx:40
 #: src/view/screens/Profile.tsx:128
 msgid "Oops!"
@@ -4906,7 +4906,7 @@ msgstr "Citazioni post"
 msgid "Random (aka \"Poster's Roulette\")"
 msgstr "Selezione a caso (nota anche come \"Poster's Roulette\")"
 
-#: src/screens/Settings/components/ChangeHandleDialog.tsx:566
+#: src/screens/Settings/components/ChangeHandleDialog.tsx:565
 msgid "Rate limit exceeded – you've tried to change your handle too many times in a short period. Please wait a minute before trying again."
 msgstr "Limite di richieste superato: hai provato a cambiare il nome utente troppe volte in un breve lasso di tempo. Attendi un minuto prima di riprovare."
 
@@ -5363,7 +5363,7 @@ msgstr "Ritorna alla pagina precedente"
 #: src/components/StarterPack/QrCodeDialog.tsx:185
 #: src/screens/Profile/Header/EditProfileDialog.tsx:238
 #: src/screens/Profile/Header/EditProfileDialog.tsx:252
-#: src/screens/Settings/components/ChangeHandleDialog.tsx:242
+#: src/screens/Settings/components/ChangeHandleDialog.tsx:241
 #: src/view/com/composer/GifAltText.tsx:190
 #: src/view/com/composer/GifAltText.tsx:199
 #: src/view/com/composer/photos/EditImageDialog.web.tsx:77
@@ -5402,7 +5402,7 @@ msgstr "Salva immagine"
 msgid "Save image crop"
 msgstr "Salva il ritaglio dell'immagine"
 
-#: src/screens/Settings/components/ChangeHandleDialog.tsx:228
+#: src/screens/Settings/components/ChangeHandleDialog.tsx:227
 msgid "Save new handle"
 msgstr "Salva nuovo nome utente"
 
@@ -5502,11 +5502,11 @@ msgstr "Visualizza i post {truncatedTag} per utente"
 
 #: src/components/TagMenu/index.tsx:155
 msgid "See <0>{displayTag}</0> posts"
-msgstr "Vedi <0>{displayTag}</0> posts"
+msgstr "Vedi post su <0>{displayTag}</0>"
 
 #: src/components/TagMenu/index.tsx:203
 msgid "See <0>{displayTag}</0> posts by this user"
-msgstr "Vedi <0>{displayTag}</0> posts di questo utente"
+msgstr "Vedi post su <0>{displayTag}</0> di questo utente"
 
 #: src/view/com/auth/SplashScreen.web.tsx:176
 msgid "See jobs at Bluesky"
@@ -5519,10 +5519,6 @@ msgstr "Consulta questa guida"
 #: src/view/com/util/post-embeds/VideoEmbedInner/web-controls/Scrubber.tsx:189
 msgid "Seek slider"
 msgstr "Cursore di ricerca"
-
-#: src/view/com/util/Selector.tsx:107
-msgid "Select {item}"
-msgstr "Seleziona {item}"
 
 #: src/screens/Onboarding/StepProfile/AvatarCreatorItems.tsx:67
 msgid "Select a color"
@@ -5571,10 +5567,6 @@ msgstr "Seleziona lingue"
 #: src/components/ReportDialog/SelectLabelerView.tsx:28
 msgid "Select moderator"
 msgstr "Seleziona moderatore"
-
-#: src/view/com/util/Selector.tsx:108
-msgid "Select option {i} of {numItems}"
-msgstr "Seleziona l'opzione {i} di {numItems}"
 
 #: src/view/com/composer/videos/SubtitleFilePicker.tsx:66
 msgid "Select subtitle file (.vtt)"
@@ -6259,7 +6251,7 @@ msgstr "Grazie. La tua segnalazione è stata inviata."
 msgid "Thanks, you have successfully verified your email address. You can close this dialog."
 msgstr "Grazie, hai verificato con successo il tuo indirizzo email. Puoi chiudere questa finestra."
 
-#: src/screens/Settings/components/ChangeHandleDialog.tsx:468
+#: src/screens/Settings/components/ChangeHandleDialog.tsx:467
 msgid "That contains the following:"
 msgstr "Che contiene il seguente:"
 
@@ -6412,7 +6404,7 @@ msgstr "Si è verificato un problema durante il recupero delle password dell'app
 msgid "There was an issue fetching your lists. Tap here to try again."
 msgstr "Si è verificato un problema durante il recupero delle tue liste. Tocca qui per riprovare."
 
-#: src/screens/Settings/components/ChangeHandleDialog.tsx:102
+#: src/screens/Settings/components/ChangeHandleDialog.tsx:101
 msgid "There was an issue fetching your service info"
 msgstr "Si è verificato un problema durante il recupero delle tue informazioni di servizio"
 
@@ -6541,7 +6533,7 @@ msgstr "Questo feed è vuoto."
 msgid "This feed is no longer online. We are showing <0>Discover</0> instead."
 msgstr "Questo feed non è più online. Stiamo mostrando <0>Discover</0> al suo posto."
 
-#: src/screens/Settings/components/ChangeHandleDialog.tsx:559
+#: src/screens/Settings/components/ChangeHandleDialog.tsx:558
 msgid "This handle is reserved. Please try a different one."
 msgstr "Questo nome utente è riservato. Prova con un altro nome utente."
 
@@ -6618,7 +6610,7 @@ msgstr "Questa risposta verrà spostata in una sezione nascosta in basso al thre
 msgid "This service has not provided terms of service or a privacy policy."
 msgstr "Questo servizio non ha fornito termini di servizio o un'informativa sulla privacy."
 
-#: src/screens/Settings/components/ChangeHandleDialog.tsx:437
+#: src/screens/Settings/components/ChangeHandleDialog.tsx:436
 msgid "This should create a domain record at:"
 msgstr "Questo dovrebbe creare un record di dominio in:"
 
@@ -6742,7 +6734,7 @@ msgstr "Autenticazione a due fattori (2FA)"
 msgid "Type your message here"
 msgstr "Scrivi il tuo messaggio qui"
 
-#: src/screens/Settings/components/ChangeHandleDialog.tsx:413
+#: src/screens/Settings/components/ChangeHandleDialog.tsx:412
 msgid "Type:"
 msgstr "Tipo:"
 
@@ -6910,8 +6902,8 @@ msgstr "Contenuti Sessuali Indesiderati"
 msgid "Update <0>{displayName}</0> in Lists"
 msgstr "Aggiorna <0>{displayName}</0> nelle Liste"
 
-#: src/screens/Settings/components/ChangeHandleDialog.tsx:495
-#: src/screens/Settings/components/ChangeHandleDialog.tsx:516
+#: src/screens/Settings/components/ChangeHandleDialog.tsx:494
+#: src/screens/Settings/components/ChangeHandleDialog.tsx:515
 msgid "Update to {domain}"
 msgstr "Aggiorna a {domain}"
 
@@ -6931,7 +6923,7 @@ msgstr "Aggiornamento..."
 msgid "Upload a photo instead"
 msgstr "Alternativamente carica una foto"
 
-#: src/screens/Settings/components/ChangeHandleDialog.tsx:453
+#: src/screens/Settings/components/ChangeHandleDialog.tsx:452
 msgid "Upload a text file to:"
 msgstr "Carica una file di testo a:"
 
@@ -6965,7 +6957,7 @@ msgstr "Caricamento del video..."
 msgid "Use app passwords to sign in to other Bluesky clients without giving full access to your account or password."
 msgstr "Usa le password delle app per accedere ad altri client Bluesky senza fornire l'accesso completo al tuo account o alla tua password."
 
-#: src/screens/Settings/components/ChangeHandleDialog.tsx:528
+#: src/screens/Settings/components/ChangeHandleDialog.tsx:527
 msgid "Use default provider"
 msgstr "Utilizza il tuo provider predefinito"
 
@@ -7070,7 +7062,7 @@ msgstr "Utenti in «{0}»"
 msgid "Users that have liked this content or profile"
 msgstr "Utenti a cui è piaciuto questo contenuto o profilo"
 
-#: src/screens/Settings/components/ChangeHandleDialog.tsx:419
+#: src/screens/Settings/components/ChangeHandleDialog.tsx:418
 msgid "Value:"
 msgstr "Valore:"
 
@@ -7078,8 +7070,8 @@ msgstr "Valore:"
 msgid "Verified email required"
 msgstr "Email verificata richiesta"
 
-#: src/screens/Settings/components/ChangeHandleDialog.tsx:497
-#: src/screens/Settings/components/ChangeHandleDialog.tsx:518
+#: src/screens/Settings/components/ChangeHandleDialog.tsx:496
+#: src/screens/Settings/components/ChangeHandleDialog.tsx:517
 msgid "Verify DNS Record"
 msgstr "Verifica record DNS"
 
@@ -7097,8 +7089,8 @@ msgstr "Verifica la nuova email"
 msgid "Verify now"
 msgstr "Verifica ora"
 
-#: src/screens/Settings/components/ChangeHandleDialog.tsx:498
-#: src/screens/Settings/components/ChangeHandleDialog.tsx:520
+#: src/screens/Settings/components/ChangeHandleDialog.tsx:497
+#: src/screens/Settings/components/ChangeHandleDialog.tsx:519
 msgid "Verify Text File"
 msgstr "Verifica file di testo"
 
@@ -7279,7 +7271,7 @@ msgstr "Speriamo di darti dei momenti dei bei momenti. Ricorda, Bluesky è:"
 
 #: src/view/com/posts/DiscoverFallbackHeader.tsx:29
 msgid "We ran out of posts from your follows. Here's the latest from <0/>."
-msgstr "Abbiamo esaurito i posts dei tuoi follower. Ecco le ultime novità da <0/>."
+msgstr "Abbiamo esaurito i post di chi segui. Ecco le ultime novità da <0/>."
 
 #: src/view/com/composer/state/video.ts:430
 msgid "We were unable to determine if you are allowed to upload videos. Please try again."
@@ -7369,7 +7361,7 @@ msgstr "Quali lingue vorresti vedere negli algoritmi dei tuoi feed?"
 
 #: src/components/WhoCanReply.tsx:179
 msgid "Who can interact with this post?"
-msgstr "Chi puo interagire a questo post?"
+msgstr "Chi puo interagire con questo post?"
 
 #: src/components/WhoCanReply.tsx:87
 msgid "Who can reply"
@@ -7425,7 +7417,7 @@ msgstr "Scrivi la tua risposta"
 msgid "Writers"
 msgstr "Scrittori"
 
-#: src/screens/Settings/components/ChangeHandleDialog.tsx:337
+#: src/screens/Settings/components/ChangeHandleDialog.tsx:336
 msgid "Wrong DID returned from server. Received: {0}"
 msgstr "Il server ha restituito un DID errato. Ricevuto: {0}"
 
@@ -7783,7 +7775,7 @@ msgstr "Il tuo feed seguente è vuoto! Segui più utenti per vedere cosa sta suc
 msgid "Your full handle will be"
 msgstr "Il tuo nome utente completo sarà"
 
-#: src/screens/Settings/components/ChangeHandleDialog.tsx:220
+#: src/screens/Settings/components/ChangeHandleDialog.tsx:219
 msgid "Your full handle will be <0>@{0}</0>"
 msgstr "Il tuo nome utente completo sarà <0>@{0}</0>"
 

--- a/src/locale/locales/it/messages.po
+++ b/src/locale/locales/it/messages.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Italian localization\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-01-05 11:44+0530\n"
-"PO-Revision-Date: 2024-11-21 10:10+0100\n"
+"POT-Creation-Date: 2024-11-20 10:25+0000\n"
+"PO-Revision-Date: 2024-11-21 11:08+0100\n"
 "Last-Translator: Michele Locati <michele@locati.it>\n"
 "Language-Team: \n"
 "Language: it\n"
@@ -29,7 +29,7 @@ msgstr "{0, plural, one {# giorno} other {# giorni}}"
 
 #: src/lib/hooks/useTimeAgo.ts:146
 msgid "{0, plural, one {# hour} other {# hours}}"
-msgstr "{0, plural, one {# hour} other {# hours}}"
+msgstr "{0, plural, one {# ora} other {# ore}}"
 
 #: src/components/moderation/LabelsOnMe.tsx:53
 msgid "{0, plural, one {# label has been placed on this account} other {# labels have been placed on this account}}"
@@ -41,7 +41,7 @@ msgstr "{0, plural, one {# etichetta è stata applicata a questo contenuto} othe
 
 #: src/lib/hooks/useTimeAgo.ts:136
 msgid "{0, plural, one {# minute} other {# minutes}}"
-msgstr "{0, plural, one {# minute} other {# minutes}}"
+msgstr "{0, plural, one {# minuto} other {# minuti}}"
 
 #: src/lib/hooks/useTimeAgo.ts:167
 msgid "{0, plural, one {# month} other {# months}}"
@@ -58,12 +58,12 @@ msgstr "{0, plural, one {# secondo} other {# secondi}}"
 #: src/components/ProfileHoverCard/index.web.tsx:398
 #: src/screens/Profile/Header/Metrics.tsx:22
 msgid "{0, plural, one {follower} other {followers}}"
-msgstr "{0, plural, one {follower} other {followers}}"
+msgstr "{0, plural, one {follower} other {follower}}"
 
 #: src/components/ProfileHoverCard/index.web.tsx:402
 #: src/screens/Profile/Header/Metrics.tsx:26
 msgid "{0, plural, one {following} other {following}}"
-msgstr "{0, plural, one {following} other {following}}"
+msgstr "{0, plural, one {seguito} other {seguiti}}"
 
 #: src/view/com/util/post-ctrls/PostCtrls.tsx:305
 msgid "{0, plural, one {Like (# like)} other {Like (# likes)}}"
@@ -71,23 +71,23 @@ msgstr "{0, plural, one {Like (# like)} other {Like (# like)}}"
 
 #: src/view/com/post-thread/PostThreadItem.tsx:442
 msgid "{0, plural, one {like} other {likes}}"
-msgstr "{0, plural, one {like} other {likes}}"
+msgstr "{0, plural, one {like} other {like}}"
 
 #: src/components/FeedCard.tsx:213 src/view/com/feeds/FeedSourceCard.tsx:303
 msgid "{0, plural, one {Liked by # user} other {Liked by # users}}"
-msgstr "{0, plural, one {# utente ha messo like} other {# utenti hanno messo like}}"
+msgstr "{0, plural, one {Piace a # utente} other {Piace a # utenti}}"
 
 #: src/screens/Profile/Header/Metrics.tsx:58
 msgid "{0, plural, one {post} other {posts}}"
-msgstr "{0, plural, one {post} other {posts}}"
+msgstr "{0, plural, one {post} other {post}}"
 
 #: src/view/com/post-thread/PostThreadItem.tsx:426
 msgid "{0, plural, one {quote} other {quotes}}"
-msgstr "{0, plural, one {quote} other {quotes}}"
+msgstr "{0, plural, one {citazione} other {citazioni}}"
 
 #: src/view/com/util/post-ctrls/PostCtrls.tsx:261
 msgid "{0, plural, one {Reply (# reply)} other {Reply (# replies)}}"
-msgstr "{0, plural, one {Reply (# risposta)} other {Reply (# risposte)}}"
+msgstr "{0, plural, one {Rispondi (# risposta)} other {Rispondi (# risposte)}}"
 
 #: src/view/com/post-thread/PostThreadItem.tsx:408
 msgid "{0, plural, one {repost} other {reposts}}"
@@ -95,7 +95,7 @@ msgstr "{0, plural, one {repost} other {reposts}}"
 
 #: src/view/com/util/post-ctrls/PostCtrls.tsx:301
 msgid "{0, plural, one {Unlike (# like)} other {Unlike (# likes)}}"
-msgstr "{0, plural, one {Unlike (# like)} other {Unlike (# like)}}"
+msgstr "{0, plural, one {Togli like (# like)} other {Togli like (# like)}}"
 
 #: src/screens/Settings/Settings.tsx:414
 msgid "{0}"
@@ -170,7 +170,7 @@ msgstr "{badge} elementi non letti"
 
 #: src/components/LabelingServiceCard/index.tsx:96
 msgid "{count, plural, one {Liked by # user} other {Liked by # users}}"
-msgstr "{count, plural, one {# utente ha messo like} other {# utenti hanno messo like}}"
+msgstr "{count, plural, one {Piace a # utente} other {Piace a # utenti}}"
 
 #: src/view/shell/desktop/LeftNav.tsx:223
 msgid "{count} unread items"
@@ -183,39 +183,39 @@ msgstr "Starter Pack di {displayName}"
 
 #: src/screens/SignupQueued.tsx:220
 msgid "{estimatedTimeHrs, plural, one {hour} other {hours}}"
-msgstr "{estimatedTimeHrs, plural, one {hour} other {hours}}"
+msgstr "{estimatedTimeHrs, plural, one {ora} other {ore}}"
 
 #: src/screens/SignupQueued.tsx:226
 msgid "{estimatedTimeMins, plural, one {minute} other {minutes}}"
-msgstr "{estimatedTimeMins, plural, one {minute} other {minutes}}"
+msgstr "{estimatedTimeMins, plural, one {minuto} other {minuti}}"
 
 #: src/view/com/notifications/FeedItem.tsx:300
 msgid "{firstAuthorLink} and <0>{additionalAuthorsCount, plural, one {{formattedAuthorsCount} other} other {{formattedAuthorsCount} others}}</0> followed you"
-msgstr ""
+msgstr "{firstAuthorLink} e <0>{additionalAuthorsCount, plural, one {{formattedAuthorsCount} other} altro {{formattedAuthorsCount} altri}}</0> ti hanno seguito"
 
 #: src/view/com/notifications/FeedItem.tsx:326
 msgid "{firstAuthorLink} and <0>{additionalAuthorsCount, plural, one {{formattedAuthorsCount} other} other {{formattedAuthorsCount} others}}</0> liked your custom feed"
-msgstr ""
+msgstr "A {firstAuthorLink} e <0>{additionalAuthorsCount, plural, one {{formattedAuthorsCount} altro} other {{formattedAuthorsCount} altri}}</0> è piaciuto il tuo feed personalizzato"
 
 #: src/view/com/notifications/FeedItem.tsx:222
 msgid "{firstAuthorLink} and <0>{additionalAuthorsCount, plural, one {{formattedAuthorsCount} other} other {{formattedAuthorsCount} others}}</0> liked your post"
-msgstr ""
+msgstr "A {firstAuthorLink} e <0>{additionalAuthorsCount, plural, one {{formattedAuthorsCount} altro} other {{formattedAuthorsCount} altri}}</0> è piaciuto il tuo post"
 
 #: src/view/com/notifications/FeedItem.tsx:246
 msgid "{firstAuthorLink} and <0>{additionalAuthorsCount, plural, one {{formattedAuthorsCount} other} other {{formattedAuthorsCount} others}}</0> reposted your post"
-msgstr ""
+msgstr "{firstAuthorLink} e <0>{additionalAuthorsCount, plural, one {{formattedAuthorsCount} altro} other {{formattedAuthorsCount} altri}}</0> hanno ripubblicato il tuo post"
 
 #: src/view/com/notifications/FeedItem.tsx:350
 msgid "{firstAuthorLink} and <0>{additionalAuthorsCount, plural, one {{formattedAuthorsCount} other} other {{formattedAuthorsCount} others}}</0> signed up with your starter pack"
-msgstr ""
+msgstr "{firstAuthorLink} e <0>{additionalAuthorsCount, plural, one {{formattedAuthorsCount} altro} other {{formattedAuthorsCount} altri}}</0> si sono iscritti al tuo starter pack"
 
 #: src/view/com/notifications/FeedItem.tsx:312
 msgid "{firstAuthorLink} followed you"
-msgstr ""
+msgstr "{firstAuthorLink} ha iniziato a seguirti"
 
 #: src/view/com/notifications/FeedItem.tsx:289
 msgid "{firstAuthorLink} followed you back"
-msgstr ""
+msgstr "{firstAuthorLink} ha iniziato a seguirti a sua volta"
 
 #: src/view/com/notifications/FeedItem.tsx:338
 msgid "{firstAuthorLink} liked your custom feed"
@@ -231,27 +231,27 @@ msgstr "{firstAuthorLink} ha ripubblicato il tuo post"
 
 #: src/view/com/notifications/FeedItem.tsx:362
 msgid "{firstAuthorLink} signed up with your starter pack"
-msgstr "{firstAuthorLink} si è iscritto con il tuo starter pack"
+msgstr "{firstAuthorLink} si è iscritto al tuo starter pack"
 
 #: src/view/com/notifications/FeedItem.tsx:293
 msgid "{firstAuthorName} and {additionalAuthorsCount, plural, one {{formattedAuthorsCount} other} other {{formattedAuthorsCount} others}} followed you"
-msgstr ""
+msgstr "{firstAuthorName} e {additionalAuthorsCount, plural, one {{formattedAuthorsCount} altro} other {{formattedAuthorsCount} altri}} hanno iniziato a seguirti"
 
 #: src/view/com/notifications/FeedItem.tsx:319
 msgid "{firstAuthorName} and {additionalAuthorsCount, plural, one {{formattedAuthorsCount} other} other {{formattedAuthorsCount} others}} liked your custom feed"
-msgstr ""
+msgstr "A {firstAuthorName} e {additionalAuthorsCount, plural, one {{formattedAuthorsCount} altro} other {{formattedAuthorsCount} altri}} è piaciuto il tuo feed personalizzato"
 
 #: src/view/com/notifications/FeedItem.tsx:215
 msgid "{firstAuthorName} and {additionalAuthorsCount, plural, one {{formattedAuthorsCount} other} other {{formattedAuthorsCount} others}} liked your post"
-msgstr ""
+msgstr "A {firstAuthorName} e {additionalAuthorsCount, plural, one {{formattedAuthorsCount} altro} other {{formattedAuthorsCount} altri}} è piaciuto il tuo post"
 
 #: src/view/com/notifications/FeedItem.tsx:239
 msgid "{firstAuthorName} and {additionalAuthorsCount, plural, one {{formattedAuthorsCount} other} other {{formattedAuthorsCount} others}} reposted your post"
-msgstr ""
+msgstr "{firstAuthorName} e {additionalAuthorsCount, plural, one {{formattedAuthorsCount} altro} other {{formattedAuthorsCount} altri}} hanno ripubblicato il tuo post"
 
 #: src/view/com/notifications/FeedItem.tsx:343
 msgid "{firstAuthorName} and {additionalAuthorsCount, plural, one {{formattedAuthorsCount} other} other {{formattedAuthorsCount} others}} signed up with your starter pack"
-msgstr ""
+msgstr "{firstAuthorName} e {additionalAuthorsCount, plural, one {{formattedAuthorsCount} altro} other {{formattedAuthorsCount} altri}} si sono iscritti al tuo starter pack"
 
 #: src/view/com/notifications/FeedItem.tsx:298
 msgid "{firstAuthorName} followed you"
@@ -275,12 +275,12 @@ msgstr "{firstAuthorName} ha ripubblicato il tuo post"
 
 #: src/view/com/notifications/FeedItem.tsx:348
 msgid "{firstAuthorName} signed up with your starter pack"
-msgstr "{firstAuthorName} si è iscritto con il tuo starter pack"
+msgstr "{firstAuthorName} si è iscritto al tuo starter pack"
 
 #: src/components/ProfileHoverCard/index.web.tsx:508
 #: src/screens/Profile/Header/Metrics.tsx:49
 msgid "{following} following"
-msgstr "{following} following"
+msgstr "{following} seguiti"
 
 #: src/components/dms/dialogs/SearchablePeopleList.tsx:385
 msgid "{handle} can't be messaged"
@@ -290,7 +290,7 @@ msgstr "{handle} non può ricevere messaggi"
 #: src/screens/Profile/Header/ProfileHeaderLabeler.tsx:307
 #: src/view/screens/ProfileFeed.tsx:591
 msgid "{likeCount, plural, one {Liked by # user} other {Liked by # users}}"
-msgstr "{likeCount, plural, one {# utente ha messo like} other {# utenti hanno messo like}}"
+msgstr "{likeCount, plural, one {Piaciuto a # utente} other {Piaciuto a # utenti}}"
 
 #: src/view/shell/Drawer.tsx:448
 msgid "{numUnreadNotifications} unread"
@@ -320,11 +320,11 @@ msgstr "<0>{0}, </0><1>{1}, </1>e {2, plural, one {# altro} other {# altri}} son
 
 #: src/view/shell/Drawer.tsx:97
 msgid "<0>{0}</0> {1, plural, one {follower} other {followers}}"
-msgstr "<0>{0}</0> {1, plural, one {follower} other {followers}}"
+msgstr "<0>{0}</0> {1, plural, one {follower} other {follower}}"
 
 #: src/view/shell/Drawer.tsx:108
 msgid "<0>{0}</0> {1, plural, one {following} other {following}}"
-msgstr "<0>{0}</0> {1, plural, one {following} other {following}}"
+msgstr "<0>{0}</0> {1, plural, one {seguito} other {seguiti}}"
 
 #: src/screens/StarterPack/Wizard/index.tsx:516
 msgid "<0>{0}</0> and<1> </1><2>{1} </2>are included in your starter pack"
@@ -344,7 +344,7 @@ msgstr "<0>{date}</0> alle {time}"
 
 #: src/screens/Settings/NotificationSettings.tsx:71
 msgid "<0>Experimental:</0> When this preference is enabled, you'll only receive reply and quote notifications from users you follow. We'll continue to add more controls here over time."
-msgstr ""
+msgstr "<0>Sperimentale:</0> Attivando questa opzione riceverai solo le notifiche di risposte e citazioni dagli utenti che segui. Col tempo continueremo ad aggiungere ulteriori controlli."
 
 #: src/screens/StarterPack/Wizard/index.tsx:466
 msgid "<0>You</0> and<1> </1><2>{0} </2>are included in your starter pack"
@@ -884,7 +884,7 @@ msgstr "Almeno 3 caratteri"
 
 #: src/screens/Settings/AccessibilitySettings.tsx:97
 msgid "Autoplay options have moved to the <0>Content and Media settings</0>."
-msgstr ""
+msgstr "Le opzioni di riproduzione automatica sono state spostate nelle <0>impostazioni di contenuti e media</0>."
 
 #: src/screens/Settings/ContentAndMediaSettings.tsx:88
 #: src/screens/Settings/ContentAndMediaSettings.tsx:94
@@ -1272,7 +1272,7 @@ msgstr "Scegli utenti"
 
 #: src/view/com/composer/labels/LabelsBtn.tsx:115
 msgid "Choose self-labels that are applicable for the media you are posting. If none are selected, this post is suitable for all audiences."
-msgstr ""
+msgstr "Scegli le etichette che si adattano meglio ai media che stai pubblicando. Se non ne viene selezionata nessuna, questo post è adatto a tutti i tipi di pubblico."
 
 #: src/view/com/auth/server-input/index.tsx:76
 msgid "Choose Service"
@@ -2617,7 +2617,7 @@ msgstr "Feed creato da {0}"
 
 #: src/components/StarterPack/Wizard/WizardListCard.tsx:54
 msgid "Feed toggle"
-msgstr ""
+msgstr "Attiva/disattiva feed"
 
 #: src/view/shell/desktop/RightNav.tsx:69 src/view/shell/Drawer.tsx:319
 msgid "Feedback"
@@ -2771,12 +2771,12 @@ msgstr "Follower che conosci"
 #: src/view/screens/Feeds.tsx:632 src/view/screens/ProfileFollows.tsx:30
 #: src/view/screens/ProfileFollows.tsx:31 src/view/screens/SavedFeeds.tsx:431
 msgid "Following"
-msgstr "Following"
+msgstr "Seguito"
 
 #: src/components/ProfileCard.tsx:318
 #: src/screens/Profile/Header/ProfileHeaderStandard.tsx:98
 msgid "Following {0}"
-msgstr "Seguiti {0}"
+msgstr "Stai seguendo {0}"
 
 #: src/view/com/posts/AviFollowButton.tsx:50
 msgid "Following {name}"
@@ -2785,11 +2785,11 @@ msgstr "Stai segendo {name}"
 #: src/screens/Settings/ContentAndMediaSettings.tsx:56
 #: src/screens/Settings/ContentAndMediaSettings.tsx:59
 msgid "Following feed preferences"
-msgstr "Preferenze del feed Following"
+msgstr "Preferenze del feed di chi segui"
 
 #: src/Navigation.tsx:300 src/screens/Settings/FollowingFeedPreferences.tsx:49
 msgid "Following Feed Preferences"
-msgstr "Preferenze del Following Feed"
+msgstr "Preferenze del feed di chi segui"
 
 #: src/screens/Profile/Header/Handle.tsx:32
 msgid "Follows you"
@@ -2903,7 +2903,7 @@ msgstr "Torna indietro"
 #: src/view/screens/NotFound.tsx:56 src/view/screens/ProfileFeed.tsx:118
 #: src/view/screens/ProfileList.tsx:1034
 msgid "Go Back"
-msgstr "Torna Indietro"
+msgstr "Torna indietro"
 
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:529
 msgid "Go back to previous page"
@@ -2919,7 +2919,7 @@ msgstr "Torna al passaggio precedente"
 
 #: src/screens/StarterPack/Wizard/index.tsx:308
 msgid "Go back to the previous step"
-msgstr "Torna indietro"
+msgstr "Torna al passaggio precedente"
 
 #: src/view/screens/NotFound.tsx:57
 msgid "Go home"
@@ -3603,7 +3603,7 @@ msgstr "Sembra che tu non abbia più feed fissati. Ma non ti preoccupare, puoi a
 
 #: src/screens/Feeds/NoFollowingFeed.tsx:37
 msgid "Looks like you're missing a following feed. <0>Click here to add one.</0>"
-msgstr "Sembra che ti manchi un following feed. <0>Clicca qui per aggiungere uno.</0>"
+msgstr "Sembra che ti manchi un feed di chi segui. <0>Clicca qui per aggiungere uno.</0>"
 
 #: src/components/StarterPack/ProfileStarterPacks.tsx:266
 msgid "Make one for me"
@@ -4246,7 +4246,7 @@ msgstr "Mostrare prima le risposte più vecchie"
 
 #: src/components/StarterPack/QrCode.tsx:75
 msgid "on<0><1/><2><3/></2></0>"
-msgstr ""
+msgstr "su<0><1/><2><3/></2></0>"
 
 #: src/screens/Settings/Settings.tsx:295
 msgid "Onboarding reset"
@@ -4254,7 +4254,7 @@ msgstr "Reimpostazione dell'onboarding"
 
 #: src/view/com/composer/Composer.tsx:325
 msgid "One or more GIFs is missing alt text."
-msgstr ""
+msgstr "Una o più GIF non hanno un testo alternativo."
 
 #: src/view/com/composer/Composer.tsx:322
 msgid "One or more images is missing alt text."
@@ -4262,7 +4262,7 @@ msgstr "A una o più immagini manca il testo alternativo."
 
 #: src/view/com/composer/Composer.tsx:332
 msgid "One or more videos is missing alt text."
-msgstr ""
+msgstr "In uno o più video manca il testo alternativo."
 
 #: src/screens/Onboarding/StepProfile/index.tsx:115
 msgid "Only .jpg and .png files are supported"
@@ -4278,7 +4278,7 @@ msgstr "Contiene solo lettere, numeri e trattini"
 
 #: src/lib/media/picker.shared.ts:29
 msgid "Only image files are supported"
-msgstr ""
+msgstr "Sono supportati solo i file immagine"
 
 #: src/view/com/composer/videos/SubtitleFilePicker.tsx:40
 msgid "Only WebVTT (.vtt) files are supported"
@@ -4304,7 +4304,7 @@ msgstr "Aperto"
 
 #: src/view/com/posts/AviFollowButton.tsx:86
 msgid "Open {name} profile shortcut menu"
-msgstr ""
+msgstr "Apri il menu di scelta rapida del profilo {name}"
 
 #: src/screens/Onboarding/StepProfile/index.tsx:286
 msgid "Open avatar creator"
@@ -4331,11 +4331,11 @@ msgstr "Apri il menu delle opzioni del feed"
 
 #: src/screens/Settings/Settings.tsx:200
 msgid "Open helpdesk in browser"
-msgstr ""
+msgstr "Apri l'helpdesk nel browser"
 
 #: src/view/com/util/post-embeds/ExternalLinkEmbed.tsx:71
 msgid "Open link to {niceUrl}"
-msgstr ""
+msgstr "Apri link verso {niceUrl}"
 
 #: src/components/dms/ActionsWrapper.tsx:90
 msgid "Open message options"
@@ -4343,7 +4343,7 @@ msgstr "Apri opzioni messaggio"
 
 #: src/screens/Settings/Settings.tsx:321
 msgid "Open moderation debug page"
-msgstr ""
+msgstr "Apri pagina di debug della moderazione"
 
 #: src/screens/Moderation/index.tsx:225
 msgid "Open muted words and tags settings"
@@ -4375,7 +4375,7 @@ msgstr "Apre le {numItems} opzioni"
 
 #: src/view/com/composer/labels/LabelsBtn.tsx:62
 msgid "Opens a dialog to add a content warning to your post"
-msgstr ""
+msgstr "Apre una finestra di dialogo per aggiungere un avviso sui contenuto al tuo post."
 
 #: src/view/com/composer/threadgate/ThreadgateBtn.tsx:61
 msgid "Opens a dialog to choose who can reply to this thread"
@@ -4536,7 +4536,7 @@ msgstr "L'autorizzazione per accedere la cartella delle immagini è stata negata
 
 #: src/components/StarterPack/Wizard/WizardListCard.tsx:54
 msgid "Person toggle"
-msgstr ""
+msgstr "Attiva/disattiva persona"
 
 #: src/screens/Onboarding/index.tsx:28 src/screens/Onboarding/state.ts:96
 msgid "Pets"
@@ -4621,7 +4621,7 @@ msgstr "Conferma la tua email prima di cambiarla. Si tratta di un requisito temp
 
 #: src/screens/Settings/components/AddAppPasswordDialog.tsx:114
 msgid "Please enter a unique name for this app password or use our randomly generated one."
-msgstr ""
+msgstr "Inserisci un nome univoco per questa password dell'app o utilizza quello generato casualmente."
 
 #: src/components/dialogs/MutedWords.tsx:86
 msgid "Please enter a valid word, tag, or phrase to mute"
@@ -4677,7 +4677,7 @@ msgstr "Post"
 #: src/view/com/composer/Composer.tsx:919
 msgctxt "action"
 msgid "Post All"
-msgstr ""
+msgstr "Posta tutti"
 
 #: src/view/com/post-thread/PostThreadItem.tsx:204
 msgid "Post by {0}"
@@ -4694,7 +4694,7 @@ msgstr "Post eliminato"
 
 #: src/lib/api/index.ts:185
 msgid "Post failed to upload. Please check your Internet connection and try again."
-msgstr ""
+msgstr "Non è stato possibile inviare il post. Verifica la tua connessione a internet e riprova."
 
 #: src/view/com/post-thread/PostThread.tsx:212
 msgid "Post hidden"
@@ -5278,7 +5278,7 @@ msgstr "Richiedi il testo alternativo prima di pubblicare"
 
 #: src/screens/Settings/components/Email2FAToggle.tsx:54
 msgid "Require an email code to log in to your account."
-msgstr ""
+msgstr "Richiedi un codice inviato via email per accedere al tuo account."
 
 #: src/screens/Signup/StepInfo/index.tsx:159
 msgid "Required for this provider"
@@ -5518,7 +5518,7 @@ msgstr "Consulta questa guida"
 
 #: src/view/com/util/post-embeds/VideoEmbedInner/web-controls/Scrubber.tsx:189
 msgid "Seek slider"
-msgstr ""
+msgstr "Cursore di ricerca"
 
 #: src/view/com/util/Selector.tsx:107
 msgid "Select {item}"
@@ -5823,7 +5823,7 @@ msgstr "Mostra risposte nascoste"
 
 #: src/view/com/post-thread/PostThreadItem.tsx:796
 msgid "Show information about when this post was created"
-msgstr ""
+msgstr "Mostra informazioni sulla data di creazione di questo post."
 
 #: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:455
 #: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:457
@@ -5850,7 +5850,7 @@ msgstr "Mosta risposte silenziate"
 
 #: src/screens/Settings/Settings.tsx:96
 msgid "Show other accounts you can switch to"
-msgstr ""
+msgstr "Mostra gli altri account a cui puoi passare"
 
 #: src/screens/Settings/FollowingFeedPreferences.tsx:96
 #: src/screens/Settings/FollowingFeedPreferences.tsx:106
@@ -5878,12 +5878,12 @@ msgstr "Mostra risposta per tutti"
 #: src/screens/Settings/FollowingFeedPreferences.tsx:78
 #: src/screens/Settings/FollowingFeedPreferences.tsx:88
 msgid "Show reposts"
-msgstr ""
+msgstr "Mostra le ripubblicazioni"
 
 #: src/screens/Settings/FollowingFeedPreferences.tsx:121
 #: src/screens/Settings/FollowingFeedPreferences.tsx:131
 msgid "Show samples of your saved feeds in your Following feed"
-msgstr ""
+msgstr "Mostra un estratto dei tuoi feed salvati nel feed di chi segui"
 
 #: src/components/moderation/ContentHider.tsx:152
 #: src/components/moderation/PostHider.tsx:79
@@ -6346,7 +6346,7 @@ msgstr "Questo video è più grande di 50MB."
 
 #: src/lib/strings/errors.ts:18
 msgid "The server appears to be experiencing issues. Please try again in a few moments."
-msgstr ""
+msgstr "Sembra che ci siano problemi sul server. Riprova tra qualche istante."
 
 #: src/screens/StarterPack/StarterPackScreen.tsx:725
 msgid "The starter pack that you are trying to view is invalid. You may delete this starter pack instead."
@@ -6384,7 +6384,7 @@ msgstr "Si è verificato un problema durante il contatto con il server"
 #: src/screens/Profile/Header/ProfileHeaderLabeler.tsx:112
 #: src/view/screens/ProfileFeed.tsx:546
 msgid "There was an issue contacting the server, please check your internet connection and try again."
-msgstr ""
+msgstr "Si è verificato un problema contattando il server, verifica la tua connessione a internet e riprova."
 
 #: src/view/com/feeds/FeedSourceCard.tsx:127
 #: src/view/com/feeds/FeedSourceCard.tsx:140
@@ -6418,7 +6418,7 @@ msgstr "Si è verificato un problema durante il recupero delle tue informazioni 
 
 #: src/view/com/posts/FeedErrorMessage.tsx:145
 msgid "There was an issue removing this feed. Please check your internet connection and try again."
-msgstr ""
+msgstr "Si è verificato un problema durante la rimozione di questo feed. Verifica la tua connessione a internet e riprova."
 
 #: src/components/dms/ReportDialog.tsx:217
 #: src/components/ReportDialog/SubmitView.tsx:87
@@ -6429,7 +6429,7 @@ msgstr "Si è verificato un problema durante l'invio della segnalazione. Verific
 #: src/view/com/posts/FeedShutdownMsg.tsx:71
 #: src/view/screens/ProfileFeed.tsx:211
 msgid "There was an issue updating your feeds, please check your internet connection and try again."
-msgstr ""
+msgstr "Si è verificato un problema durante l'aggiornamento dei tuoi feed. Verifica la tua connessione a internet e riprova."
 
 #: src/screens/Profile/Header/ProfileHeaderStandard.tsx:107
 #: src/screens/Profile/Header/ProfileHeaderStandard.tsx:128
@@ -6465,7 +6465,7 @@ msgstr "C'è stata un'ondata di nuovi utenti su Bluesky! Attiveremo il tuo accou
 
 #: src/screens/Settings/FollowingFeedPreferences.tsx:54
 msgid "These settings only apply to the Following feed."
-msgstr ""
+msgstr "Queste impostazioni si applicano solo al feed di chi segui."
 
 #: src/components/moderation/ScreenHider.tsx:111
 msgid "This {screenDescription} has been flagged:"
@@ -6522,7 +6522,7 @@ msgstr "Questa funzionalità è in versione beta. Puoi leggere ulteriori informa
 
 #: src/lib/strings/errors.ts:21
 msgid "This feature is not available while using an App Password. Please sign in with your main password."
-msgstr ""
+msgstr "Questa funzionalità non è disponibile quando si una una password delle app. Accedi con la tua password principale."
 
 #: src/view/com/posts/FeedErrorMessage.tsx:120
 msgid "This feed is currently receiving high traffic and is temporarily unavailable. Please try again later."
@@ -6587,7 +6587,7 @@ msgstr "Questo servizio di moderazione non è disponibile. Vedi giù per ulterio
 
 #: src/view/com/post-thread/PostThreadItem.tsx:836
 msgid "This post claims to have been created on <0>{0}</0>, but was first seen by Bluesky on <1>{1}</1>."
-msgstr ""
+msgstr "Questo post dichiara di essere stato creato il <0>{0}</0>, ma è stato visto per la prima volta da Bluesky il <1>{1}</1>."
 
 #: src/view/com/post-thread/PostThreadItem.tsx:147
 msgid "This post has been deleted."
@@ -6756,7 +6756,7 @@ msgstr "Riattiva questa lista"
 
 #: src/lib/strings/errors.ts:11
 msgid "Unable to connect. Please check your internet connection and try again."
-msgstr ""
+msgstr "Impossibile connettersi. Verifica la tua connessione a internet e riprova."
 
 #: src/screens/Login/ForgotPasswordForm.tsx:68 src/screens/Login/index.tsx:76
 #: src/screens/Login/LoginForm.tsx:152
@@ -6831,7 +6831,7 @@ msgstr "Riattiva"
 #: src/view/com/util/post-embeds/VideoEmbedInner/web-controls/VolumeControl.tsx:93
 msgctxt "video"
 msgid "Unmute"
-msgstr ""
+msgstr "Attiva il suono"
 
 #: src/components/TagMenu/index.web.tsx:115
 msgid "Unmute {truncatedTag}"
@@ -6963,7 +6963,7 @@ msgstr "Caricamento del video..."
 
 #: src/screens/Settings/AppPasswords.tsx:59
 msgid "Use app passwords to sign in to other Bluesky clients without giving full access to your account or password."
-msgstr ""
+msgstr "Usa le password delle app per accedere ad altri client Bluesky senza fornire l'accesso completo al tuo account o alla tua password."
 
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:528
 msgid "Use default provider"
@@ -7427,7 +7427,7 @@ msgstr "Scrittori"
 
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:337
 msgid "Wrong DID returned from server. Received: {0}"
-msgstr ""
+msgstr "Il server ha restituito un DID errato. Ricevuto: {0}"
 
 #: src/view/com/composer/select-language/SuggestedLanguage.tsx:78
 msgid "Yes"
@@ -7645,7 +7645,7 @@ msgstr "Hai precedentemente disattivato @{0}."
 
 #: src/screens/Settings/Settings.tsx:249
 msgid "You will be signed out of all your accounts."
-msgstr ""
+msgstr "Verrai disconnesso da tutti i tuoi account."
 
 #: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:211
 msgid "You will no longer receive notifications for this thread"

--- a/src/locale/locales/it/messages.po
+++ b/src/locale/locales/it/messages.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: Italian localization\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-01-05 11:44+0530\n"
-"PO-Revision-Date: 2024-11-19 14:38+0100\n"
+"PO-Revision-Date: 2024-11-20 08:34+0100\n"
 "Last-Translator: Michele Locati <michele@locati.it>\n"
 "Language-Team: Gabriella Nonino\n"
 "Language: it\n"
@@ -302,7 +302,7 @@ msgstr ""
 
 #: src/components/NewskieDialog.tsx:116
 msgid "{profileName} joined Bluesky {0} ago"
-msgstr "{profileName} si è iscritto a Bluesky {0} giorno/i fa"
+msgstr "{profileName} si è iscritto a Bluesky {0} fa"
 
 #: src/components/NewskieDialog.tsx:111
 msgid "{profileName} joined Bluesky using a starter pack {0} ago"
@@ -5121,12 +5121,12 @@ msgstr "Le impostazioni delle risposte sono scelte dall'autore del thread"
 #: src/view/com/post/Post.tsx:204 src/view/com/posts/FeedItem.tsx:553
 msgctxt "description"
 msgid "Reply to <0><1/></0>"
-msgstr "Rispondi a <0><1/></0>"
+msgstr "Risposta a <0><1/></0>"
 
 #: src/view/com/posts/FeedItem.tsx:544
 msgctxt "description"
 msgid "Reply to a blocked post"
-msgstr "Rispondi ad un post bloccato"
+msgstr "Risposta ad un post bloccato"
 
 #: src/view/com/posts/FeedItem.tsx:546
 msgctxt "description"
@@ -5136,7 +5136,7 @@ msgstr "Rispondi ad un post"
 #: src/view/com/post/Post.tsx:202 src/view/com/posts/FeedItem.tsx:550
 msgctxt "description"
 msgid "Reply to you"
-msgstr "Risposta"
+msgstr "Risposta a te"
 
 #: src/view/com/util/forms/PostDropdownBtn.tsx:338
 msgid "Reply visibility updated"

--- a/src/locale/locales/it/messages.po
+++ b/src/locale/locales/it/messages.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: Italian localization\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-01-05 11:44+0530\n"
-"PO-Revision-Date: 2024-11-19 12:34+0100\n"
+"PO-Revision-Date: 2024-11-19 14:23+0100\n"
 "Last-Translator: Michele Locati <michele@locati.it>\n"
 "Language-Team: Gabriella Nonino\n"
 "Language: it\n"
@@ -121,7 +121,7 @@ msgstr "{0} di {1}"
 
 #: src/screens/StarterPack/StarterPackScreen.tsx:479
 msgid "{0} people have used this starter pack!"
-msgstr "{0} persone hanno usat questo starter pack!"
+msgstr "{0} persone hanno usato questo starter pack!"
 
 #: src/view/shell/bottom-bar/BottomBar.tsx:203
 msgid "{0} unread items"
@@ -294,7 +294,7 @@ msgstr "{likeCount, plural, one {# utente ha messo like} other {# utenti hanno m
 
 #: src/view/shell/Drawer.tsx:448
 msgid "{numUnreadNotifications} unread"
-msgstr "{numUnreadNotifications} non letto"
+msgstr "{numUnreadNotifications} non letto/i"
 
 #: src/view/shell/bottom-bar/BottomBar.tsx:230
 msgid "{numUnreadNotifications} unread items"
@@ -832,7 +832,7 @@ msgstr "Eliminare la password dell'app \"{0}\"?"
 
 #: src/components/dms/MessageMenu.tsx:149
 msgid "Are you sure you want to delete this message? The message will be deleted for you, but not for the other participant."
-msgstr "Sicuro di voler cancellare questo messaggio? Il messaggio verrà cancellato per te, ma non per gli altri partecipanti."
+msgstr "Eliminare questo messaggio? Il messaggio verrà eliminato per te, ma non per gli altri partecipanti."
 
 #: src/screens/StarterPack/StarterPackScreen.tsx:633
 msgid "Are you sure you want to delete this starter pack?"
@@ -916,17 +916,17 @@ msgstr ""
 
 #: src/view/com/composer/Composer.tsx:593
 msgid "Before creating a post, you must first verify your email."
-msgstr ""
+msgstr "Prima di creare un post, devi verificare la tua email."
 
 #: src/components/StarterPack/ProfileStarterPacks.tsx:340
 msgid "Before creating a starter pack, you must first verify your email."
-msgstr ""
+msgstr "Prima di creare uno starter pack, devi verificare la tua email."
 
 #: src/components/dms/dialogs/NewChatDialog.tsx:79
 #: src/components/dms/MessageProfileButton.tsx:89
 #: src/screens/Messages/Conversation.tsx:219
 msgid "Before you may message another user, you must first verify your email."
-msgstr ""
+msgstr "Prima di poter inviare un messaggio a un altro utente, devi verificare la tua email."
 
 #: src/components/dialogs/BirthDateSettings.tsx:106
 #: src/screens/Settings/AccountSettings.tsx:102
@@ -1572,7 +1572,7 @@ msgstr "Vai al passaggio successivo"
 
 #: src/screens/Messages/components/ChatListItem.tsx:164
 msgid "Conversation deleted"
-msgstr "Conversazione cancellata"
+msgstr "Conversazione eliminata"
 
 #: src/screens/Onboarding/index.tsx:41
 msgid "Cooking"
@@ -1834,7 +1834,7 @@ msgstr "Elimina messaggio per me"
 
 #: src/view/com/modals/DeleteAccount.tsx:286
 msgid "Delete my account"
-msgstr "Cancellare account"
+msgstr "Elimina il mio account"
 
 #: src/view/com/composer/Composer.tsx:804
 #: src/view/com/util/forms/PostDropdownBtn.tsx:653
@@ -2497,7 +2497,7 @@ msgstr "Esporta i miei dati"
 #: src/screens/Settings/ContentAndMediaSettings.tsx:65
 #: src/screens/Settings/ContentAndMediaSettings.tsx:68
 msgid "External media"
-msgstr "Media esterno"
+msgstr "Media esterni"
 
 #: src/components/dialogs/EmbedConsent.tsx:54
 #: src/components/dialogs/EmbedConsent.tsx:58
@@ -2507,11 +2507,11 @@ msgstr "Media esterni"
 #: src/components/dialogs/EmbedConsent.tsx:70
 #: src/screens/Settings/ExternalMediaPreferences.tsx:34
 msgid "External media may allow websites to collect information about you and your device. No information is sent or requested until you press the \"play\" button."
-msgstr "I multimediali esterni possono consentire ai siti web di raccogliere informazioni su di te e sul tuo dispositivo. Nessuna informazione viene inviata o richiesta finché non si preme il pulsante \"Riproduci\"."
+msgstr "I media esterni possono consentire ai siti web di raccogliere informazioni su di te e sul tuo dispositivo. Nessuna informazione viene inviata o richiesta finché non si preme il pulsante \"Riproduci\"."
 
 #: src/Navigation.tsx:313 src/screens/Settings/ExternalMediaPreferences.tsx:29
 msgid "External Media Preferences"
-msgstr "Preferenze multimediali esterni"
+msgstr "Preferenze media esterni"
 
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:553
 msgid "Failed to change handle. Please try again."
@@ -2532,7 +2532,7 @@ msgstr "Impossibile creare l'elenco. Controlla la connessione Internet e riprova
 
 #: src/components/dms/MessageMenu.tsx:73
 msgid "Failed to delete message"
-msgstr "Errore nel cancellare il messaggio"
+msgstr "Errore nell'eliminazione del messaggio"
 
 #: src/view/com/util/forms/PostDropdownBtn.tsx:200
 msgid "Failed to delete post, please try again"
@@ -2540,7 +2540,7 @@ msgstr "Non possiamo eliminare il post, riprova di nuovo"
 
 #: src/screens/StarterPack/StarterPackScreen.tsx:698
 msgid "Failed to delete starter pack"
-msgstr "Impossibile cancellare lo starter pack"
+msgstr "Impossibile eliminare lo starter pack"
 
 #: src/view/screens/Search/Explore.tsx:427
 #: src/view/screens/Search/Explore.tsx:455
@@ -2636,7 +2636,7 @@ msgstr "Feed"
 
 #: src/view/screens/SavedFeeds.tsx:205
 msgid "Feeds are custom algorithms that users build with a little coding expertise. <0/> for more information."
-msgstr "I feed sono algoritmi personalizzati che gli utenti creano con un minimo di esperienza nella codifica. Vedi <0/> per ulteriori informazioni."
+msgstr "I feed sono algoritmi personalizzati che gli utenti creano con un minimo di competenza di programmazione. Vedi <0/> per ulteriori informazioni."
 
 #: src/components/FeedCard.tsx:273 src/view/screens/SavedFeeds.tsx:83
 msgid "Feeds updated!"
@@ -2820,7 +2820,7 @@ msgstr "Per motivi di sicurezza non potrai più visualizzarla. Se perdi questa p
 
 #: src/screens/Settings/AppearanceSettings.tsx:127
 msgid "For the best experience, we recommend using the theme font."
-msgstr "Per una migliore esperienza, consigliamo di usare un font del tema."
+msgstr "Per una migliore esperienza, consigliamo di usare il font del tema."
 
 #: src/components/dialogs/MutedWords.tsx:178
 msgid "Forever"
@@ -2935,11 +2935,11 @@ msgstr "Vai alla conversazione con {0}"
 #: src/screens/Login/ForgotPasswordForm.tsx:165
 #: src/view/com/modals/ChangePassword.tsx:168
 msgid "Go to next"
-msgstr "Seguente"
+msgstr "Prosegui"
 
 #: src/components/dms/ConvoMenu.tsx:167
 msgid "Go to profile"
-msgstr "Va al profilo"
+msgstr "Vai al profilo"
 
 #: src/components/dms/ConvoMenu.tsx:164
 msgid "Go to user's profile"
@@ -3077,11 +3077,11 @@ msgstr "Il server del feed ha dato una risposta negativa. Informa il proprietari
 
 #: src/view/com/posts/FeedErrorMessage.tsx:102
 msgid "Hmm, we're having trouble finding this feed. It may have been deleted."
-msgstr "Stiamo riscontrando problemi nel trovare questo feed. Potrebbe essere stato cancellato."
+msgstr "Stiamo riscontrando problemi nel trovare questo feed. Potrebbe essere stato eliminato."
 
 #: src/screens/Moderation/index.tsx:55
 msgid "Hmmmm, it seems we're having trouble loading this data. See below for more details. If this issue persists, please contact us."
-msgstr "Stiamo riscontrando problemi nel trovare questi dati. Guarda PI[U giù per trovare più dettagli. Se il problema continua mettiti in contatto."
+msgstr "Stiamo riscontrando problemi a caricare questi dati. Vedi sotto per maggiori dettagli. Se il problema persiste, contattaci."
 
 #: src/screens/Profile/ErrorState.tsx:31
 msgid "Hmmmm, we couldn't load that moderation service."
@@ -3194,7 +3194,7 @@ msgstr "Inserisci il codice inviato alla tua email per reimpostare la password"
 
 #: src/view/com/modals/DeleteAccount.tsx:247
 msgid "Input confirmation code for account deletion"
-msgstr "Inserisci il codice di conferma per la cancellazione dell'account"
+msgstr "Inserisci il codice di conferma per l'eliminazione dell'account"
 
 #: src/screens/Login/SetNewPasswordForm.tsx:145
 msgid "Input new password"
@@ -3202,7 +3202,7 @@ msgstr "Inserisci la nuova password"
 
 #: src/view/com/modals/DeleteAccount.tsx:266
 msgid "Input password for account deletion"
-msgstr "Inserisci la password per la cancellazione dell'account"
+msgstr "Inserisci la password per l'eliminazione dell'account"
 
 #: src/screens/Login/LoginForm.tsx:270
 msgid "Input the code which has been emailed to you"
@@ -3279,7 +3279,7 @@ msgstr "Inviti, ma personali"
 
 #: src/screens/Signup/StepInfo/index.tsx:80
 msgid "It looks like you may have entered your email address incorrectly. Are you sure it's right?"
-msgstr "Sembra che tu abbia inserito il tuo indirizzo email in maniera non corretta. Se sicuro che sia giusto?"
+msgstr "Sembra che tu abbia inserito il tuo indirizzo email in modo errato. Se sicuro che sia corretto?"
 
 #: src/screens/Signup/StepInfo/index.tsx:241
 msgid "It's correct"
@@ -3356,7 +3356,7 @@ msgstr "Lingue"
 
 #: src/screens/Settings/AppearanceSettings.tsx:157
 msgid "Larger"
-msgstr "Molto largo"
+msgstr "Più grande"
 
 #: src/screens/Hashtag.tsx:98 src/view/screens/Search/Search.tsx:521
 msgid "Latest"
@@ -3492,7 +3492,7 @@ msgstr "Lista di {0}"
 
 #: src/view/screens/ProfileList.tsx:459
 msgid "List deleted"
-msgstr "Lista cancellata"
+msgstr "Lista eliminata"
 
 #: src/screens/List/ListHiddenScreen.tsx:126
 msgid "List has been hidden"
@@ -3629,7 +3629,7 @@ msgstr "Media"
 
 #: src/view/com/composer/labels/LabelsBtn.tsx:212
 msgid "Media that may be disturbing or inappropriate for some audiences."
-msgstr "Contenuti multimediali che potrebbero disturbare o risultare inappropriati per alcuni tipi di pubblico."
+msgstr "Media che potrebbero disturbare o risultare inappropriati per alcuni tipi di pubblico."
 
 #: src/components/WhoCanReply.tsx:254
 msgid "mentioned users"
@@ -3642,7 +3642,7 @@ msgstr "Utenti menzionati"
 #: src/components/Menu/index.tsx:95 src/view/com/util/ViewHeader.tsx:87
 #: src/view/screens/Search/Search.tsx:882
 msgid "Menu"
-msgstr "Menù"
+msgstr "Menu"
 
 #: src/components/dms/MessageProfileButton.tsx:82
 msgid "Message {0}"
@@ -3651,7 +3651,7 @@ msgstr "Messaggio {0}"
 #: src/components/dms/MessageMenu.tsx:72
 #: src/screens/Messages/components/ChatListItem.tsx:165
 msgid "Message deleted"
-msgstr "Messaggio cancellato"
+msgstr "Messaggio eliminato"
 
 #: src/view/com/posts/FeedErrorMessage.tsx:201
 msgid "Message from server: {0}"
@@ -3681,7 +3681,7 @@ msgstr "Account Ingannevole"
 
 #: src/lib/moderation/useReportOptions.ts:67
 msgid "Misleading Post"
-msgstr "Post frainteso"
+msgstr "Post ingannevole"
 
 #: src/Navigation.tsx:138 src/screens/Moderation/index.tsx:101
 #: src/screens/Settings/Settings.tsx:159 src/screens/Settings/Settings.tsx:162
@@ -3917,7 +3917,7 @@ msgstr "Vai al tuo profilo"
 
 #: src/components/dialogs/VerifyEmailDialog.tsx:196
 msgid "Need to change it?"
-msgstr "Serve modificarlo?"
+msgstr "Hai bisogno di modificarla?"
 
 #: src/components/ReportDialog/SelectReportOptionView.tsx:130
 msgid "Need to report a copyright violation?"
@@ -4015,11 +4015,11 @@ msgstr "Notizie"
 #: src/view/com/modals/ChangePassword.tsx:254
 #: src/view/com/modals/ChangePassword.tsx:256
 msgid "Next"
-msgstr "Seguente"
+msgstr "Avanti"
 
 #: src/view/com/lightbox/Lightbox.web.tsx:167
 msgid "Next image"
-msgstr "Immagine seguente"
+msgstr "Immagine successiva"
 
 #: src/screens/Settings/AppPasswords.tsx:100
 msgid "No app passwords yet"
@@ -4062,7 +4062,7 @@ msgstr "Ancora nessun messaggio"
 
 #: src/screens/Messages/ChatList.tsx:271
 msgid "No more conversations to show"
-msgstr "Nessuna conversazione da visualizzare"
+msgstr "Nessun'altra conversazione da visualizzare"
 
 #: src/view/com/notifications/Feed.tsx:121
 msgid "No notifications yet!"
@@ -4845,7 +4845,7 @@ msgstr "Elenchi pubblici e condivisibili di utenti da disattivare o bloccare in 
 
 #: src/view/screens/Lists.tsx:81
 msgid "Public, shareable lists which can drive feeds."
-msgstr "Liste pubbliche e condivisibili che possono impulsare i feed."
+msgstr "Liste pubbliche e condivisibili che possono guidare i feed."
 
 #: src/components/StarterPack/QrCodeDialog.tsx:128
 msgid "QR code copied to your clipboard!"
@@ -4967,7 +4967,7 @@ msgstr "Rimuovi {displayName} dallo starter pack"
 
 #: src/screens/Settings/Settings.tsx:437 src/screens/Settings/Settings.tsx:440
 msgid "Remove account"
-msgstr "Rimuovi l'account"
+msgstr "Rimuovi account"
 
 #: src/view/com/composer/ExternalEmbedRemoveBtn.tsx:16
 msgid "Remove attachment"
@@ -5288,7 +5288,7 @@ msgstr "Richiesto nella tuo paese"
 #: src/screens/Settings/components/DisableEmail2FADialog.tsx:173
 #: src/screens/Settings/components/DisableEmail2FADialog.tsx:176
 msgid "Resend email"
-msgstr "Rinvia l'email"
+msgstr "Rinvia email"
 
 #: src/components/dialogs/VerifyEmailDialog.tsx:267
 #: src/components/dialogs/VerifyEmailDialog.tsx:277
@@ -5348,7 +5348,7 @@ msgstr "Ritorna alla pagina precedente"
 
 #: src/view/screens/NotFound.tsx:61
 msgid "Returns to home page"
-msgstr "Ritorna su Home"
+msgstr "Ritorna alla home"
 
 #: src/view/screens/NotFound.tsx:60 src/view/screens/ProfileFeed.tsx:114
 msgid "Returns to previous page"
@@ -5435,7 +5435,7 @@ msgstr "Salva le impostazioni di ritaglio dell'immagine"
 #: src/view/com/notifications/FeedItem.tsx:539
 #: src/view/com/notifications/FeedItem.tsx:564
 msgid "Say hello!"
-msgstr "Di ciao!"
+msgstr "Di' ciao!"
 
 #: src/screens/Onboarding/index.tsx:33 src/screens/Onboarding/state.ts:99
 msgid "Science"
@@ -5473,7 +5473,7 @@ msgstr "Cerca utenti"
 
 #: src/components/dialogs/GifSelect.tsx:177
 msgid "Search GIFs"
-msgstr "Cerca i Gif"
+msgstr "Cerca GIF"
 
 #: src/components/dms/dialogs/SearchablePeopleList.tsx:504
 #: src/components/dms/dialogs/SearchablePeopleList.tsx:505
@@ -6172,24 +6172,24 @@ msgstr "Solo tag"
 
 #: src/components/ProgressGuide/Toast.tsx:156
 msgid "Tap to dismiss"
-msgstr "Clicca per ignorare"
+msgstr "Togga per ignorare"
 
 #: src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerNative.tsx:136
 msgid "Tap to enter full screen"
-msgstr "Clicca per entrare in modalità a schermo intero"
+msgstr "Tocca per entrare in modalità a schermo intero"
 
 #: src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerNative.tsx:142
 msgid "Tap to play or pause"
-msgstr "Premi per riprodurre o mettere in pausa"
+msgstr "Tocca per riprodurre o mettere in pausa"
 
 #: src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerNative.tsx:159
 msgid "Tap to toggle sound"
-msgstr "Clicca per attivare o disattivare l'audio"
+msgstr "Tocca per attivare o disattivare l'audio"
 
 #: src/view/com/util/images/AutoSizedImage.tsx:199
 #: src/view/com/util/images/AutoSizedImage.tsx:221
 msgid "Tap to view full image"
-msgstr "Premi per vedere a schermo intero"
+msgstr "Tocca per vedere a schermo intero"
 
 #: src/state/shell/progress-guide.tsx:166
 msgid "Task complete - 10 likes!"
@@ -6330,7 +6330,7 @@ msgstr "I passaggi seguenti ti aiuteranno a personalizzare la tua esperienza con
 #: src/view/com/post-thread/PostThread.tsx:208
 #: src/view/com/post-thread/PostThread.tsx:220
 msgid "The post may have been deleted."
-msgstr "Il post potrebbe essere stato cancellato."
+msgstr "Il post potrebbe essere stato eliminato."
 
 #: src/view/screens/PrivacyPolicy.tsx:35
 msgid "The Privacy Policy has been moved to <0/>"
@@ -6346,7 +6346,7 @@ msgstr ""
 
 #: src/screens/StarterPack/StarterPackScreen.tsx:725
 msgid "The starter pack that you are trying to view is invalid. You may delete this starter pack instead."
-msgstr "Questo starter pack non è valido. Prova a cancellare questo starter pack invece."
+msgstr "Questo starter pack non è valido. Prova a eliminare questo starter pack invece."
 
 #: src/view/screens/Support.tsx:37
 msgid "The support form has been moved. If you need help, please <0/> or visit {HELP_DESK_URL} to get in touch with us."
@@ -6497,7 +6497,7 @@ msgstr "Questo contenuto ha ricevuto un avviso generale dai moderatori."
 
 #: src/components/dialogs/EmbedConsent.tsx:63
 msgid "This content is hosted by {0}. Do you want to enable external media?"
-msgstr "Questo contenuto è hosted da {0}. Vuoi abilitare i media esterni?"
+msgstr "Questo contenuto è ospitato da {0}. Abilitare i media esterni?"
 
 #: src/components/moderation/ModerationDetailsDialog.tsx:83
 #: src/lib/moderation/useModerationCauseDescription.ts:82
@@ -6510,7 +6510,7 @@ msgstr "Questo contenuto non è visualizzabile senza un account Bluesky."
 
 #: src/screens/Messages/components/ChatListItem.tsx:266
 msgid "This conversation is with a deleted or a deactivated account. Press for options."
-msgstr "L'utente di questa conversazione ha disattivato o cancellato l'account. Premi per le opzioni."
+msgstr "L'utente di questa conversazione ha disattivato o eliminato l'account. Premi per le opzioni."
 
 #: src/screens/Settings/components/ExportCarDialog.tsx:94
 msgid "This feature is in beta. You can read more about repository exports in <0>this blogpost</0>."
@@ -6587,7 +6587,7 @@ msgstr ""
 
 #: src/view/com/post-thread/PostThreadItem.tsx:147
 msgid "This post has been deleted."
-msgstr "Questo post è stato cancellato."
+msgstr "Questo post è stato eliminato."
 
 #: src/view/com/util/forms/PostDropdownBtn.tsx:700
 #: src/view/com/util/post-ctrls/PostCtrls.tsx:352
@@ -6973,7 +6973,7 @@ msgstr "Utilizza il browser dell'app"
 #: src/screens/Settings/ContentAndMediaSettings.tsx:75
 #: src/screens/Settings/ContentAndMediaSettings.tsx:81
 msgid "Use in-app browser to open links"
-msgstr ""
+msgstr "Utilizza il browser dell'app per aprire i link"
 
 #: src/view/com/modals/InAppBrowserConsent.tsx:63
 #: src/view/com/modals/InAppBrowserConsent.tsx:65
@@ -7323,7 +7323,7 @@ msgstr "Siamo spiacenti, ma non è stato possibile completare la ricerca. Riprov
 
 #: src/view/com/composer/Composer.tsx:404
 msgid "We're sorry! The post you are replying to has been deleted."
-msgstr "Ci dispiace! Il post a cui cerchi di rispondere è stato cancellato."
+msgstr "Ci dispiace! Il post a cui cerchi di rispondere è stato eliminato."
 
 #: src/components/Lists.tsx:220 src/view/screens/NotFound.tsx:50
 msgid "We're sorry! We can't find the page you were looking for."
@@ -7485,7 +7485,7 @@ msgstr "Puoi anche disattivare temporaneamente il tuo account, e riattivarlo in 
 
 #: src/screens/Messages/Settings.tsx:105
 msgid "You can continue ongoing conversations regardless of which setting you choose."
-msgstr "Puoi proseguire le conversazioni in corso indipendentemente da quale settaggio scegli."
+msgstr "Puoi proseguire le conversazioni in corso indipendentemente dall'impostazione scelta."
 
 #: src/screens/Login/index.tsx:155 src/screens/Login/PasswordUpdatedForm.tsx:27
 msgid "You can now sign in with your new password."
@@ -7684,7 +7684,7 @@ msgstr "Seguirai immediatamente queste persone"
 
 #: src/components/dialogs/VerifyEmailDialog.tsx:178
 msgid "You'll receive an email at <0>{0}</0> to verify it's you."
-msgstr "Riceverai un email a <0>{0}</0> per verificare che sia tu."
+msgstr "Riceverai un'email all'indirizzo <0>{0}</0> per verificare la tua identità."
 
 #: src/screens/StarterPack/StarterPackLandingScreen.tsx:270
 msgid "You'll stay updated with these feeds"

--- a/src/locale/locales/it/messages.po
+++ b/src/locale/locales/it/messages.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: Italian localization\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-01-05 11:44+0530\n"
-"PO-Revision-Date: 2024-11-18 11:19+0100\n"
+"PO-Revision-Date: 2024-11-19 12:34+0100\n"
 "Last-Translator: Michele Locati <michele@locati.it>\n"
 "Language-Team: Gabriella Nonino\n"
 "Language: it\n"
@@ -47,7 +47,7 @@ msgstr "{0, plural, one {# minute} other {# minutes}}"
 msgid "{0, plural, one {# month} other {# months}}"
 msgstr "{0, plural, one {# mese} other {# mesi}}"
 
-#: src/view/com/util/post-ctrls/RepostButton.tsx:73
+#: src/view/com/util/post-ctrls/RepostButton.tsx:69
 msgid "{0, plural, one {# repost} other {# reposts}}"
 msgstr "{0, plural, one {# ripubblicazione} other {# ripubblicazioni}}"
 
@@ -486,7 +486,7 @@ msgstr "Aggiungi testo alternativo (opzionale)"
 msgid "Add another account"
 msgstr "Aggiungi un altro account"
 
-#: src/view/com/composer/Composer.tsx:713
+#: src/view/com/composer/Composer.tsx:715
 msgid "Add another post"
 msgstr "Aggiungi un altro post"
 
@@ -508,7 +508,7 @@ msgstr "Aggiungi parola silenziata alle impostazioni configurate"
 msgid "Add muted words and tags"
 msgstr "Aggiungi parole e tag silenziati"
 
-#: src/view/com/composer/Composer.tsx:1228
+#: src/view/com/composer/Composer.tsx:1230
 msgid "Add new post"
 msgstr "Aggiungi nuovo post"
 
@@ -554,7 +554,7 @@ msgstr "Aggiunto ai miei feed"
 msgid "Adult"
 msgstr "Adulto"
 
-#: src/components/moderation/ContentHider.tsx:83
+#: src/components/moderation/ContentHider.tsx:113
 #: src/lib/moderation/useGlobalLabelStrings.ts:34
 #: src/lib/moderation/useModerationCauseDescription.ts:144
 #: src/view/com/composer/labels/LabelsBtn.tsx:129
@@ -854,11 +854,11 @@ msgstr "Confermi di voler rimuovere {0} dai tuoi feed?"
 msgid "Are you sure you want to remove this from your feeds?"
 msgstr "Sicuro di rimuoverlo dai tuoi feed?"
 
-#: src/view/com/composer/Composer.tsx:664
+#: src/view/com/composer/Composer.tsx:666
 msgid "Are you sure you'd like to discard this draft?"
 msgstr "Confermi di voler eliminare questa bozza?"
 
-#: src/view/com/composer/Composer.tsx:828
+#: src/view/com/composer/Composer.tsx:830
 msgid "Are you sure you'd like to discard this post?"
 msgstr ""
 
@@ -903,7 +903,7 @@ msgstr ""
 #: src/screens/Login/SetNewPasswordForm.tsx:160
 #: src/screens/Messages/components/ChatDisabled.tsx:133
 #: src/screens/Messages/components/ChatDisabled.tsx:134
-#: src/screens/Profile/Header/Shell.tsx:116
+#: src/screens/Profile/Header/Shell.tsx:112
 #: src/screens/Signup/BackNextButtons.tsx:42
 #: src/screens/StarterPack/Wizard/index.tsx:307
 #: src/view/com/util/ViewHeader.tsx:87
@@ -914,7 +914,7 @@ msgstr "Indietro"
 msgid "Before creating a list, you must first verify your email."
 msgstr ""
 
-#: src/view/com/composer/Composer.tsx:591
+#: src/view/com/composer/Composer.tsx:593
 msgid "Before creating a post, you must first verify your email."
 msgstr ""
 
@@ -1069,7 +1069,7 @@ msgstr "Cerca altri feed"
 msgid "Business"
 msgstr "Attività commerciale"
 
-#: src/view/com/profile/ProfileSubpageHeader.tsx:197
+#: src/view/com/profile/ProfileSubpageHeader.tsx:193
 msgid "by —"
 msgstr "da —"
 
@@ -1077,7 +1077,7 @@ msgstr "da —"
 msgid "By {0}"
 msgstr "Di {0}"
 
-#: src/view/com/profile/ProfileSubpageHeader.tsx:201
+#: src/view/com/profile/ProfileSubpageHeader.tsx:197
 msgid "by <0/>"
 msgstr "di <0/>"
 
@@ -1093,7 +1093,7 @@ msgstr "Creando un account accetti i <0>termini di servizio</0> e l'<1>informati
 msgid "By creating an account you agree to the <0>Terms of Service</0>."
 msgstr "Creando un account accetti i <0>Termini di servizio</0>."
 
-#: src/view/com/profile/ProfileSubpageHeader.tsx:199
+#: src/view/com/profile/ProfileSubpageHeader.tsx:195
 msgid "by you"
 msgstr "da te"
 
@@ -1102,13 +1102,13 @@ msgid "Camera"
 msgstr "Fotocamera"
 
 #: src/components/Menu/index.tsx:236 src/components/Prompt.tsx:129
-#: src/components/Prompt.tsx:131 src/components/TagMenu/index.tsx:267
+#: src/components/Prompt.tsx:131 src/components/TagMenu/index.tsx:283
 #: src/screens/Deactivated.tsx:164
 #: src/screens/Profile/Header/EditProfileDialog.tsx:220
 #: src/screens/Profile/Header/EditProfileDialog.tsx:228
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:72
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:79
-#: src/screens/Settings/Settings.tsx:252 src/view/com/composer/Composer.tsx:891
+#: src/screens/Settings/Settings.tsx:252 src/view/com/composer/Composer.tsx:893
 #: src/view/com/modals/ChangeEmail.tsx:213
 #: src/view/com/modals/ChangeEmail.tsx:215
 #: src/view/com/modals/ChangePassword.tsx:268
@@ -1122,7 +1122,7 @@ msgstr "Fotocamera"
 #: src/view/com/modals/LinkWarning.tsx:107
 #: src/view/com/modals/VerifyEmail.tsx:255
 #: src/view/com/modals/VerifyEmail.tsx:261
-#: src/view/com/util/post-ctrls/RepostButton.tsx:166
+#: src/view/com/util/post-ctrls/RepostButton.tsx:198
 #: src/view/screens/Search/Search.tsx:911
 msgid "Cancel"
 msgstr "Annulla"
@@ -1147,7 +1147,7 @@ msgstr "Annulla il ritaglio dell'immagine"
 msgid "Cancel profile editing"
 msgstr "Annulla la modifica del profilo"
 
-#: src/view/com/util/post-ctrls/RepostButton.tsx:161
+#: src/view/com/util/post-ctrls/RepostButton.tsx:193
 msgid "Cancel quote post"
 msgstr "Annnulla la citazione del post"
 
@@ -1382,7 +1382,7 @@ msgstr "Chiudi il visualizzatore di immagini"
 msgid "Close navigation footer"
 msgstr "Chiudi la navigazione del footer"
 
-#: src/components/Menu/index.tsx:230 src/components/TagMenu/index.tsx:261
+#: src/components/Menu/index.tsx:230 src/components/TagMenu/index.tsx:277
 msgid "Close this dialog"
 msgstr "Chiudi la finestra"
 
@@ -1434,7 +1434,7 @@ msgstr "Completa la challenge"
 msgid "Compose new post"
 msgstr "Scrivi un nuovo post"
 
-#: src/view/com/composer/Composer.tsx:794
+#: src/view/com/composer/Composer.tsx:796
 msgid "Compose posts up to {MAX_GRAPHEME_LENGTH} characters in length"
 msgstr "Componi un post fino a {MAX_GRAPHEME_LENGTH} caratteri"
 
@@ -1442,7 +1442,7 @@ msgstr "Componi un post fino a {MAX_GRAPHEME_LENGTH} caratteri"
 msgid "Compose reply"
 msgstr "Scrivi la risposta"
 
-#: src/view/com/composer/Composer.tsx:1613
+#: src/view/com/composer/Composer.tsx:1623
 msgid "Compressing video..."
 msgstr "Compressione del video..."
 
@@ -1836,7 +1836,7 @@ msgstr "Elimina messaggio per me"
 msgid "Delete my account"
 msgstr "Cancellare account"
 
-#: src/view/com/composer/Composer.tsx:802
+#: src/view/com/composer/Composer.tsx:804
 #: src/view/com/util/forms/PostDropdownBtn.tsx:653
 #: src/view/com/util/forms/PostDropdownBtn.tsx:655
 msgid "Delete post"
@@ -1936,8 +1936,8 @@ msgid "Disabled"
 msgstr "Disabilitato"
 
 #: src/screens/Profile/Header/EditProfileDialog.tsx:84
-#: src/view/com/composer/Composer.tsx:666
-#: src/view/com/composer/Composer.tsx:835
+#: src/view/com/composer/Composer.tsx:668
+#: src/view/com/composer/Composer.tsx:837
 msgid "Discard"
 msgstr "Scartare"
 
@@ -1945,11 +1945,11 @@ msgstr "Scartare"
 msgid "Discard changes?"
 msgstr "Scartare le modifiche?"
 
-#: src/view/com/composer/Composer.tsx:663
+#: src/view/com/composer/Composer.tsx:665
 msgid "Discard draft?"
 msgstr "Scartare la bozza?"
 
-#: src/view/com/composer/Composer.tsx:827
+#: src/view/com/composer/Composer.tsx:829
 msgid "Discard post?"
 msgstr "Scartare il post?"
 
@@ -1975,7 +1975,7 @@ msgstr "Scopri nuovi feed"
 msgid "Dismiss"
 msgstr "Ignora"
 
-#: src/view/com/composer/Composer.tsx:1537
+#: src/view/com/composer/Composer.tsx:1547
 msgid "Dismiss error"
 msgstr "Ignora errore"
 
@@ -2015,14 +2015,6 @@ msgstr "Pannello DNS"
 #: src/components/dialogs/MutedWords.tsx:302
 msgid "Do not apply this mute word to users you follow"
 msgstr "Non applicare questa parola silenziata agli utenti seguiti"
-
-#: src/view/com/composer/labels/LabelsBtn.tsx:174
-msgid "Does not contain adult content."
-msgstr "Non contiene materiale per adulti."
-
-#: src/view/com/composer/labels/LabelsBtn.tsx:213
-msgid "Does not contain graphic or disturbing content."
-msgstr ""
 
 #: src/lib/moderation/useGlobalLabelStrings.ts:39
 msgid "Does not include nudity."
@@ -2386,7 +2378,7 @@ msgstr "Inserisci il tuo nuovo indirizzo email qui sotto."
 msgid "Enter your username and password"
 msgstr "Inserisci il tuo nome utente e la tua password"
 
-#: src/view/com/composer/Composer.tsx:1622
+#: src/view/com/composer/Composer.tsx:1632
 msgid "Error"
 msgstr "Errore"
 
@@ -3018,7 +3010,7 @@ msgstr "Ecco la tua password dell'app!"
 msgid "Hidden list"
 msgstr "Lista nascosta"
 
-#: src/components/moderation/ContentHider.tsx:178
+#: src/components/moderation/ContentHider.tsx:200
 #: src/components/moderation/LabelPreference.tsx:135
 #: src/components/moderation/PostHider.tsx:122
 #: src/lib/moderation/useLabelBehaviorDescription.ts:15
@@ -3049,7 +3041,7 @@ msgstr "Nascondi risposta per tutti"
 msgid "Hide reply for me"
 msgstr "Nascondi risposta per me"
 
-#: src/components/moderation/ContentHider.tsx:129
+#: src/components/moderation/ContentHider.tsx:151
 #: src/components/moderation/PostHider.tsx:79
 msgid "Hide the content"
 msgstr "Nascondere il contenuto"
@@ -3176,7 +3168,7 @@ msgstr "Se stai cercando di cambiare nome utente o email, fallo prima di disatti
 msgid "Illegal and Urgent"
 msgstr "Illegale e Urgente"
 
-#: src/view/com/util/images/Gallery.tsx:74
+#: src/view/com/util/images/Gallery.tsx:71
 msgid "Image"
 msgstr "Immagine"
 
@@ -3297,7 +3289,7 @@ msgstr "È corretto"
 msgid "It's just you right now! Add more people to your starter pack by searching above."
 msgstr "Sei solo tu al momento! Aggiungi altre persone al tuo starter pack cercandole qui in alto."
 
-#: src/view/com/composer/Composer.tsx:1556
+#: src/view/com/composer/Composer.tsx:1566
 msgid "Job ID: {0}"
 msgstr ""
 
@@ -3320,11 +3312,11 @@ msgstr "Entra nella conversazione"
 msgid "Journalism"
 msgstr "Giornalismo"
 
-#: src/components/moderation/ContentHider.tsx:209
+#: src/components/moderation/ContentHider.tsx:231
 msgid "Labeled by {0}."
 msgstr "Etichettato da {0}."
 
-#: src/components/moderation/ContentHider.tsx:207
+#: src/components/moderation/ContentHider.tsx:229
 msgid "Labeled by the author."
 msgstr "Etichettato dall'autore."
 
@@ -3386,8 +3378,8 @@ msgstr "Scopri di più su Bluesky"
 msgid "Learn more about self hosting your PDS."
 msgstr "Maggiori informazioni sull'ospitare il tuo PDS."
 
-#: src/components/moderation/ContentHider.tsx:127
-#: src/components/moderation/ContentHider.tsx:193
+#: src/components/moderation/ContentHider.tsx:149
+#: src/components/moderation/ContentHider.tsx:215
 msgid "Learn more about the moderation applied to this content."
 msgstr "Scopri di più sulla moderazione applicata a questo contenuto."
 
@@ -3401,7 +3393,7 @@ msgstr "Ulteriori informazioni su questo avviso"
 msgid "Learn more about what is public on Bluesky."
 msgstr "Scopri cosa è pubblico su Bluesky."
 
-#: src/components/moderation/ContentHider.tsx:217
+#: src/components/moderation/ContentHider.tsx:239
 #: src/view/com/auth/server-input/index.tsx:158
 msgid "Learn more."
 msgstr "Saperne di più."
@@ -3776,7 +3768,7 @@ msgstr "Film"
 msgid "Music"
 msgstr "Musica"
 
-#: src/components/TagMenu/index.tsx:248
+#: src/components/TagMenu/index.tsx:264
 msgid "Mute"
 msgstr "Silenzia"
 
@@ -3799,7 +3791,7 @@ msgstr "Silenzia l'account"
 msgid "Mute accounts"
 msgstr "Silenzia gli accounts"
 
-#: src/components/TagMenu/index.tsx:205
+#: src/components/TagMenu/index.tsx:224
 msgid "Mute all {displayTag} posts"
 msgstr "Silenzia tutti i post {displayTag}"
 
@@ -4257,15 +4249,15 @@ msgstr ""
 msgid "Onboarding reset"
 msgstr "Reimpostazione dell'onboarding"
 
-#: src/view/com/composer/Composer.tsx:323
+#: src/view/com/composer/Composer.tsx:325
 msgid "One or more GIFs is missing alt text."
 msgstr ""
 
-#: src/view/com/composer/Composer.tsx:320
+#: src/view/com/composer/Composer.tsx:322
 msgid "One or more images is missing alt text."
 msgstr "A una o più immagini manca il testo alternativo."
 
-#: src/view/com/composer/Composer.tsx:330
+#: src/view/com/composer/Composer.tsx:332
 msgid "One or more videos is missing alt text."
 msgstr ""
 
@@ -4325,8 +4317,8 @@ msgid "Open conversation options"
 msgstr "Apri opzioni conversazione"
 
 #: src/screens/Messages/components/MessageInput.web.tsx:165
-#: src/view/com/composer/Composer.tsx:1214
-#: src/view/com/composer/Composer.tsx:1215
+#: src/view/com/composer/Composer.tsx:1216
+#: src/view/com/composer/Composer.tsx:1217
 msgid "Open emoji picker"
 msgstr "Apri il selettore emoji"
 
@@ -4342,7 +4334,7 @@ msgstr ""
 msgid "Open link to {niceUrl}"
 msgstr ""
 
-#: src/components/dms/ActionsWrapper.tsx:88
+#: src/components/dms/ActionsWrapper.tsx:90
 msgid "Open message options"
 msgstr "Apri opzioni messaggio"
 
@@ -4586,7 +4578,7 @@ msgstr "Fissa ai tuoi feed"
 msgid "Play"
 msgstr "Play"
 
-#: src/view/com/util/post-embeds/ExternalGifEmbed.tsx:128
+#: src/view/com/util/post-embeds/ExternalGifEmbed.tsx:107
 msgid "Play {0}"
 msgstr "Riproduci {0}"
 
@@ -4604,7 +4596,7 @@ msgstr "Riproduci video"
 msgid "Play Video"
 msgstr "Riproduci video"
 
-#: src/view/com/util/post-embeds/ExternalGifEmbed.tsx:127
+#: src/view/com/util/post-embeds/ExternalGifEmbed.tsx:106
 msgid "Plays the GIF"
 msgstr "Riproduci questa GIF"
 
@@ -4669,7 +4661,7 @@ msgstr "Politica"
 msgid "Porn"
 msgstr "Porno"
 
-#: src/view/com/composer/Composer.tsx:919
+#: src/view/com/composer/Composer.tsx:921
 msgctxt "action"
 msgid "Post"
 msgstr "Post"
@@ -4679,7 +4671,7 @@ msgctxt "description"
 msgid "Post"
 msgstr "Post"
 
-#: src/view/com/composer/Composer.tsx:917
+#: src/view/com/composer/Composer.tsx:919
 msgctxt "action"
 msgid "Post All"
 msgstr ""
@@ -4740,7 +4732,7 @@ msgstr "Post fissato"
 msgid "Post unpinned"
 msgstr "Post rimosso"
 
-#: src/components/TagMenu/index.tsx:252
+#: src/components/TagMenu/index.tsx:268
 msgid "posts"
 msgstr "post"
 
@@ -4820,7 +4812,7 @@ msgstr "Privacy e sicurezza"
 msgid "Privacy Policy"
 msgstr "Informativa sulla privacy"
 
-#: src/view/com/composer/Composer.tsx:1619
+#: src/view/com/composer/Composer.tsx:1629
 msgid "Processing video..."
 msgstr "Elaborazione video in corso..."
 
@@ -4867,8 +4859,8 @@ msgstr "Codice QR scaricato!"
 msgid "QR code saved to your camera roll!"
 msgstr "Codice QR salvato nella galleria!"
 
-#: src/view/com/util/post-ctrls/RepostButton.tsx:129
-#: src/view/com/util/post-ctrls/RepostButton.tsx:156
+#: src/view/com/util/post-ctrls/RepostButton.tsx:166
+#: src/view/com/util/post-ctrls/RepostButton.tsx:188
 #: src/view/com/util/post-ctrls/RepostButton.web.tsx:85
 #: src/view/com/util/post-ctrls/RepostButton.web.tsx:92
 msgid "Quote post"
@@ -4883,8 +4875,8 @@ msgid "Quote post was successfully detached"
 msgstr "Citazione post staccata con successo"
 
 #: src/components/dialogs/PostInteractionSettingsDialog.tsx:314
-#: src/view/com/util/post-ctrls/RepostButton.tsx:128
-#: src/view/com/util/post-ctrls/RepostButton.tsx:155
+#: src/view/com/util/post-ctrls/RepostButton.tsx:165
+#: src/view/com/util/post-ctrls/RepostButton.tsx:187
 #: src/view/com/util/post-ctrls/RepostButton.web.tsx:84
 #: src/view/com/util/post-ctrls/RepostButton.web.tsx:91
 msgid "Quote posts disabled"
@@ -5042,8 +5034,8 @@ msgstr "Rimuovi profilo dalla cronologia di ricerca"
 msgid "Remove quote"
 msgstr "Rimuovi citazione"
 
-#: src/view/com/util/post-ctrls/RepostButton.tsx:102
-#: src/view/com/util/post-ctrls/RepostButton.tsx:118
+#: src/view/com/util/post-ctrls/RepostButton.tsx:145
+#: src/view/com/util/post-ctrls/RepostButton.tsx:155
 msgid "Remove repost"
 msgstr "Rimuovi la ripubblicazione"
 
@@ -5103,7 +5095,7 @@ msgstr "Risposte disattivate"
 msgid "Replies to this post are disabled."
 msgstr "Le risposte a questo post sono disattivate."
 
-#: src/view/com/composer/Composer.tsx:915
+#: src/view/com/composer/Composer.tsx:917
 msgctxt "action"
 msgid "Reply"
 msgstr "Risposta"
@@ -5226,9 +5218,9 @@ msgstr "Segnala questo starter pack"
 msgid "Report this user"
 msgstr "Segnala questo utente"
 
-#: src/view/com/util/post-ctrls/RepostButton.tsx:72
-#: src/view/com/util/post-ctrls/RepostButton.tsx:103
-#: src/view/com/util/post-ctrls/RepostButton.tsx:119
+#: src/view/com/util/post-ctrls/RepostButton.tsx:68
+#: src/view/com/util/post-ctrls/RepostButton.tsx:146
+#: src/view/com/util/post-ctrls/RepostButton.tsx:156
 msgctxt "action"
 msgid "Repost"
 msgstr "Ripubblicare"
@@ -5239,7 +5231,7 @@ msgid "Repost"
 msgstr "Ripubblicare"
 
 #: src/screens/StarterPack/StarterPackScreen.tsx:547
-#: src/view/com/util/post-ctrls/RepostButton.tsx:95
+#: src/view/com/util/post-ctrls/RepostButton.tsx:138
 #: src/view/com/util/post-ctrls/RepostButton.web.tsx:49
 #: src/view/com/util/post-ctrls/RepostButton.web.tsx:104
 msgid "Repost or quote post"
@@ -5380,7 +5372,7 @@ msgstr "Ritorna alla pagina precedente"
 msgid "Save"
 msgstr "Salva"
 
-#: src/view/com/lightbox/ImageViewing/index.tsx:545
+#: src/view/com/lightbox/ImageViewing/index.tsx:555
 #: src/view/com/modals/CreateOrEditList.tsx:325
 msgctxt "action"
 msgid "Save"
@@ -5504,11 +5496,11 @@ msgstr "Vedi {truncatedTag} post"
 msgid "See {truncatedTag} posts by user"
 msgstr "Visualizza i post {truncatedTag} per utente"
 
-#: src/components/TagMenu/index.tsx:132
+#: src/components/TagMenu/index.tsx:155
 msgid "See <0>{displayTag}</0> posts"
 msgstr "Vedi <0>{displayTag}</0> posts"
 
-#: src/components/TagMenu/index.tsx:183
+#: src/components/TagMenu/index.tsx:203
 msgid "See <0>{displayTag}</0> posts by this user"
 msgstr "Vedi <0>{displayTag}</0> posts di questo utente"
 
@@ -5733,7 +5725,7 @@ msgstr "Sessualmente allusivo"
 msgid "Share"
 msgstr "Condividi"
 
-#: src/view/com/lightbox/ImageViewing/index.tsx:554
+#: src/view/com/lightbox/ImageViewing/index.tsx:564
 msgctxt "action"
 msgid "Share"
 msgstr "Condividi"
@@ -5796,7 +5788,7 @@ msgstr "Test Preferenze Condiviseha"
 msgid "Shares the linked website"
 msgstr "Condivide il sito Web nel link"
 
-#: src/components/moderation/ContentHider.tsx:178
+#: src/components/moderation/ContentHider.tsx:200
 #: src/components/moderation/LabelPreference.tsx:137
 #: src/components/moderation/PostHider.tsx:122
 msgid "Show"
@@ -5889,7 +5881,7 @@ msgstr ""
 msgid "Show samples of your saved feeds in your Following feed"
 msgstr ""
 
-#: src/components/moderation/ContentHider.tsx:130
+#: src/components/moderation/ContentHider.tsx:152
 #: src/components/moderation/PostHider.tsx:79
 msgid "Show the content"
 msgstr "Mostra il contenuto"
@@ -6017,7 +6009,7 @@ msgstr "Qualcosa è andato male, prova di nuovo."
 msgid "Something went wrong!"
 msgstr "Qualcosa è andato storto!"
 
-#: src/App.native.tsx:112 src/App.web.tsx:95
+#: src/App.native.tsx:113 src/App.web.tsx:95
 msgid "Sorry! Your session expired. Please log in again."
 msgstr "Scusa! La tua sessione è scaduta. Per favore accedi di nuovo."
 
@@ -6170,7 +6162,7 @@ msgstr "Sistema"
 msgid "System log"
 msgstr "Registro di sistema"
 
-#: src/components/TagMenu/index.tsx:87
+#: src/components/TagMenu/index.tsx:110
 msgid "Tag menu: {displayTag}"
 msgstr "Tag menu: {displayTag}"
 
@@ -6178,7 +6170,7 @@ msgstr "Tag menu: {displayTag}"
 msgid "Tags only"
 msgstr "Solo tag"
 
-#: src/components/ProgressGuide/Toast.tsx:150
+#: src/components/ProgressGuide/Toast.tsx:156
 msgid "Tap to dismiss"
 msgstr "Clicca per ignorare"
 
@@ -6606,7 +6598,7 @@ msgstr "Questo post è visibile solo agli utenti registrati. Non sarà visibile 
 msgid "This post will be hidden from feeds and threads. This cannot be undone."
 msgstr "Questo post verrà nascosto dai feed e dai thread. L'azione è irreversibile."
 
-#: src/view/com/composer/Composer.tsx:405
+#: src/view/com/composer/Composer.tsx:407
 msgid "This post's author has disabled quote posts."
 msgstr "L'autore di questo post ha disattivato le citazioni."
 
@@ -6803,7 +6795,7 @@ msgstr "Sblocca Account"
 msgid "Unblock Account?"
 msgstr "Sblocca Account?"
 
-#: src/view/com/util/post-ctrls/RepostButton.tsx:71
+#: src/view/com/util/post-ctrls/RepostButton.tsx:67
 #: src/view/com/util/post-ctrls/RepostButton.web.tsx:72
 #: src/view/com/util/post-ctrls/RepostButton.web.tsx:76
 msgid "Undo repost"
@@ -6827,7 +6819,7 @@ msgstr "Smetti di seguire questo account"
 msgid "Unlike this feed"
 msgstr "Togli il like a questo feed"
 
-#: src/components/TagMenu/index.tsx:248 src/view/screens/ProfileList.tsx:692
+#: src/components/TagMenu/index.tsx:264 src/view/screens/ProfileList.tsx:692
 msgid "Unmute"
 msgstr "Riattiva"
 
@@ -6846,7 +6838,7 @@ msgstr "Riattiva {truncatedTag}"
 msgid "Unmute Account"
 msgstr "Riattiva questo account"
 
-#: src/components/TagMenu/index.tsx:204
+#: src/components/TagMenu/index.tsx:223
 msgid "Unmute all {displayTag} posts"
 msgstr "Riattiva tutti i post di {displayTag}"
 
@@ -6961,7 +6953,7 @@ msgstr "Caricamento immagini..."
 msgid "Uploading link thumbnail..."
 msgstr "Caricamento miniatura del link..."
 
-#: src/view/com/composer/Composer.tsx:1616
+#: src/view/com/composer/Composer.tsx:1626
 msgid "Uploading video..."
 msgstr "Caricamento del video..."
 
@@ -7142,7 +7134,7 @@ msgstr "Video non trovato."
 msgid "Video settings"
 msgstr "Settaggi video"
 
-#: src/view/com/composer/Composer.tsx:1626
+#: src/view/com/composer/Composer.tsx:1636
 msgid "Video uploaded"
 msgstr "Video caricato"
 
@@ -7155,7 +7147,7 @@ msgstr "Video: {0}"
 msgid "Videos must be less than 60 seconds long"
 msgstr "I video devono essere più corti di 60 secondi"
 
-#: src/screens/Profile/Header/Shell.tsx:164
+#: src/screens/Profile/Header/Shell.tsx:160
 msgid "View {0}'s avatar"
 msgstr "Vedi l'avatar di {0}"
 
@@ -7168,11 +7160,11 @@ msgstr "Vedi il profilo di {0}"
 msgid "View {displayName}'s profile"
 msgstr "Vedi il profilo di {displayName}"
 
-#: src/components/TagMenu/index.tsx:149
+#: src/components/TagMenu/index.tsx:172
 msgid "View all posts by @{authorHandle} with tag {displayTag}"
 msgstr "Mostra tutti i post di @{authorHandle} con tag {displayTag}"
 
-#: src/components/TagMenu/index.tsx:103
+#: src/components/TagMenu/index.tsx:126
 msgid "View all posts with tag {displayTag}"
 msgstr "Mostra tutti i post con tag {displayTag}"
 
@@ -7213,7 +7205,7 @@ msgstr "Visualizza le informazioni su queste etichette"
 msgid "View profile"
 msgstr "Vedi il profilo"
 
-#: src/view/com/profile/ProfileSubpageHeader.tsx:163
+#: src/view/com/profile/ProfileSubpageHeader.tsx:159
 msgid "View the avatar"
 msgstr "Vedi l'avatar"
 
@@ -7329,7 +7321,7 @@ msgstr "Siamo spiacenti, ma al momento non siamo riusciti a caricare le parole s
 msgid "We're sorry, but your search could not be completed. Please try again in a few minutes."
 msgstr "Siamo spiacenti, ma non è stato possibile completare la ricerca. Riprova tra qualche minuto."
 
-#: src/view/com/composer/Composer.tsx:402
+#: src/view/com/composer/Composer.tsx:404
 msgid "We're sorry! The post you are replying to has been deleted."
 msgstr "Ci dispiace! Il post a cui cerchi di rispondere è stato cancellato."
 
@@ -7359,7 +7351,7 @@ msgstr "Come vuoi chiamare il tuo starter pack?"
 
 #: src/view/com/auth/SplashScreen.tsx:39
 #: src/view/com/auth/SplashScreen.web.tsx:99
-#: src/view/com/composer/Composer.tsx:714
+#: src/view/com/composer/Composer.tsx:716
 msgid "What's up?"
 msgstr "Come va?"
 
@@ -7416,11 +7408,11 @@ msgstr "Perché questo utente dovrebbe essere revisionato?"
 msgid "Write a message"
 msgstr "Scrivi un messaggio"
 
-#: src/view/com/composer/Composer.tsx:792
+#: src/view/com/composer/Composer.tsx:794
 msgid "Write post"
 msgstr "Scrivi un post"
 
-#: src/view/com/composer/Composer.tsx:712
+#: src/view/com/composer/Composer.tsx:714
 #: src/view/com/post-thread/PostThreadComposePrompt.tsx:71
 msgid "Write your reply"
 msgstr "Scrivi la tua risposta"
@@ -7799,11 +7791,11 @@ msgstr "Le tue parole silenziate"
 msgid "Your password has been changed successfully!"
 msgstr "La tua password è stata modificata correttamente!"
 
-#: src/view/com/composer/Composer.tsx:462
+#: src/view/com/composer/Composer.tsx:464
 msgid "Your post has been published"
 msgstr "Il tuo post è stato pubblicato"
 
-#: src/view/com/composer/Composer.tsx:459
+#: src/view/com/composer/Composer.tsx:461
 msgid "Your posts have been published"
 msgstr "I tuoi post sono stati pubblicati"
 
@@ -7815,7 +7807,7 @@ msgstr "I tuoi post, i tuoi Mi piace e i tuoi blocchi sono pubblici. I conti sil
 msgid "Your profile, posts, feeds, and lists will no longer be visible to other Bluesky users. You can reactivate your account at any time by logging in."
 msgstr "Il tuo profilo, post, feed, e liste non saranno più visibili agli altri utenti. Puoi riattivare il tuo account in qualsiasi momento effettuando l'accesso."
 
-#: src/view/com/composer/Composer.tsx:461
+#: src/view/com/composer/Composer.tsx:463
 msgid "Your reply has been published"
 msgstr "La tua risposta è stata pubblicata"
 
@@ -8231,6 +8223,9 @@ msgstr "Il tuo nome utente"
 
 #~ msgid "Discover learns which posts you like as you browse."
 #~ msgstr "Ricerca imparerà quali post ti piacciono nel mentre cerchi."
+
+#~ msgid "Does not contain adult content."
+#~ msgstr "Non contiene materiale per adulti."
 
 #~ msgid "Domain Value"
 #~ msgstr "Valore del dominio"

--- a/src/locale/locales/it/messages.po
+++ b/src/locale/locales/it/messages.po
@@ -4786,7 +4786,7 @@ msgstr "Lingua principale"
 #: src/screens/Settings/ThreadPreferences.tsx:99
 #: src/screens/Settings/ThreadPreferences.tsx:104
 msgid "Prioritize your Follows"
-msgstr "Dai priorità ai chi segui"
+msgstr "Dai priorità a chi segui"
 
 #: src/screens/Settings/NotificationSettings.tsx:54
 msgid "Priority notifications"

--- a/src/locale/locales/it/messages.po
+++ b/src/locale/locales/it/messages.po
@@ -3,8 +3,8 @@ msgstr ""
 "Project-Id-Version: Italian localization\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-01-05 11:44+0530\n"
-"PO-Revision-Date: 2024-10-16 09:57+0200\n"
-"Last-Translator: Gabriella Nonino <sandswimmer@gmail.com>\n"
+"PO-Revision-Date: 2024-11-18 11:19+0100\n"
+"Last-Translator: Michele Locati <michele@locati.it>\n"
 "Language-Team: Gabriella Nonino\n"
 "Language: it\n"
 "MIME-Version: 1.0\n"
@@ -21,12 +21,7 @@ msgstr "(contiene allegati)"
 #: src/screens/Settings/AccountSettings.tsx:58
 #: src/view/com/modals/VerifyEmail.tsx:150
 msgid "(no email)"
-msgstr "(no email)"
-
-#: src/view/com/notifications/FeedItem.tsx:232
-#: src/view/com/notifications/FeedItem.tsx:327
-#~ msgid "{0, plural, one {{formattedCount} other} other {{formattedCount} others}}"
-#~ msgstr "{0, plural, one {{formattedCount} altro} other {{formattedCount} altri}}"
+msgstr "(nessuna email)"
 
 #: src/lib/hooks/useTimeAgo.ts:156
 msgid "{0, plural, one {# day} other {# days}}"
@@ -60,9 +55,6 @@ msgstr "{0, plural, one {# ripubblicazione} other {# ripubblicazioni}}"
 msgid "{0, plural, one {# second} other {# seconds}}"
 msgstr "{0, plural, one {# secondo} other {# secondi}}"
 
-#~ msgid "{0, plural, one {and # other} other {and # others}}"
-#~ msgstr "{0, plural, one {e # altro} other {e # altri}}"
-
 #: src/components/ProfileHoverCard/index.web.tsx:398
 #: src/screens/Profile/Header/Metrics.tsx:23
 msgid "{0, plural, one {follower} other {followers}}"
@@ -81,8 +73,7 @@ msgstr "{0, plural, one {Like (# like)} other {Like (# like)}}"
 msgid "{0, plural, one {like} other {likes}}"
 msgstr "{0, plural, one {like} other {likes}}"
 
-#: src/components/FeedCard.tsx:213
-#: src/view/com/feeds/FeedSourceCard.tsx:303
+#: src/components/FeedCard.tsx:213 src/view/com/feeds/FeedSourceCard.tsx:303
 msgid "{0, plural, one {Liked by # user} other {Liked by # users}}"
 msgstr "{0, plural, one {# utente ha messo like} other {# utenti hanno messo like}}"
 
@@ -110,9 +101,6 @@ msgstr "{0, plural, one {Unlike (# like)} other {Unlike (# like)}}"
 msgid "{0}"
 msgstr "{0}"
 
-#~ msgid "{0} {purposeLabel} List"
-#~ msgstr "Lista {purposeLabel} {0}"
-
 #. Pattern: {wordValue} in tags
 #: src/components/dialogs/MutedWords.tsx:475
 msgid "{0} <0>in <1>tags</1></0>"
@@ -137,10 +125,7 @@ msgstr "{0} persone hanno usat questo starter pack!"
 
 #: src/view/shell/bottom-bar/BottomBar.tsx:203
 msgid "{0} unread items"
-msgstr ""
-
-#~ msgid "{0} your feeds"
-#~ msgstr "{0} tuoi feed"
+msgstr "{0} elementi non letti"
 
 #: src/view/com/util/UserAvatar.tsx:435
 msgid "{0}'s avatar"
@@ -157,31 +142,31 @@ msgstr "Starter pack di {0}"
 #. How many days have passed, displayed in a narrow form
 #: src/lib/hooks/useTimeAgo.ts:158
 msgid "{0}d"
-msgstr ""
+msgstr "{0}g"
 
 #. How many hours have passed, displayed in a narrow form
 #: src/lib/hooks/useTimeAgo.ts:148
 msgid "{0}h"
-msgstr ""
+msgstr "{0}o"
 
 #. How many minutes have passed, displayed in a narrow form
 #: src/lib/hooks/useTimeAgo.ts:138
 msgid "{0}m"
-msgstr ""
+msgstr "{0}m"
 
 #. How many months have passed, displayed in a narrow form
 #: src/lib/hooks/useTimeAgo.ts:169
 msgid "{0}mo"
-msgstr ""
+msgstr "{0}mesi"
 
 #. How many seconds have passed, displayed in a narrow form
 #: src/lib/hooks/useTimeAgo.ts:128
 msgid "{0}s"
-msgstr ""
+msgstr "{0}s"
 
 #: src/view/shell/bottom-bar/BottomBarWeb.tsx:252
 msgid "{badge} unread items"
-msgstr ""
+msgstr "{badge} elementi non letti"
 
 #: src/components/LabelingServiceCard/index.tsx:96
 msgid "{count, plural, one {Liked by # user} other {Liked by # users}}"
@@ -189,22 +174,7 @@ msgstr "{count, plural, one {# utente ha messo like} other {# utenti hanno messo
 
 #: src/view/shell/desktop/LeftNav.tsx:223
 msgid "{count} unread items"
-msgstr ""
-
-#~ msgid "{diff, plural, one {day} other {days}}"
-#~ msgstr "{diff, plural, one {giorno} other {giorni}}"
-
-#~ msgid "{diff, plural, one {hour} other {hours}}"
-#~ msgstr "{diff, plural, one {ora} other {ore}}"
-
-#~ msgid "{diff, plural, one {minute} other {minutes}}"
-#~ msgstr "{diff, plural, one {minuto} other {minuti}}"
-
-#~ msgid "{diff, plural, one {month} other {months}}"
-#~ msgstr "{diff, plural, one {mese} other {mesi}}"
-
-#~ msgid "{diffSeconds, plural, one {second} other {seconds}}"
-#~ msgstr "{diffSeconds, plural, one {secondo} other {secondi}}"
+msgstr "{count} elementi non letti"
 
 #: src/lib/generate-starterpack.ts:108
 #: src/screens/StarterPack/Wizard/index.tsx:183
@@ -316,23 +286,11 @@ msgstr "{following} following"
 msgid "{handle} can't be messaged"
 msgstr "{handle} non può ricevere messaggi"
 
-#~ msgid "{invitesAvailable, plural, one {Invite codes: # available} other {Invite codes: # available}}"
-#~ msgstr "{invitesAvailable, plural, one {Codici d'invito: # disponibile} other {Codici d'invito: # disponibili}}"
-
-#~ msgid "{invitesAvailable} invite code available"
-#~ msgstr "{invitesAvailable} codice d'invito disponibile"
-
-#~ msgid "{invitesAvailable} invite codes available"
-#~ msgstr "{invitesAvailable} codici d'invito disponibili"
-
 #: src/screens/Profile/Header/ProfileHeaderLabeler.tsx:294
 #: src/screens/Profile/Header/ProfileHeaderLabeler.tsx:307
 #: src/view/screens/ProfileFeed.tsx:591
 msgid "{likeCount, plural, one {Liked by # user} other {Liked by # users}}"
 msgstr "{likeCount, plural, one {# utente ha messo like} other {# utenti hanno messo like}}"
-
-#~ msgid "{message}"
-#~ msgstr "{message}"
 
 #: src/view/shell/Drawer.tsx:448
 msgid "{numUnreadNotifications} unread"
@@ -350,15 +308,6 @@ msgstr "{profileName} si è iscritto a Bluesky {0} giorno/i fa"
 msgid "{profileName} joined Bluesky using a starter pack {0} ago"
 msgstr "{profileName} si è iscritto a Bluesky usando uno starter pack {0} giorno/i fa"
 
-#~ msgid "{value, plural, =0 {Show all replies} one {Show replies with at least # like} other {Show replies with at least # likes}}"
-#~ msgstr "{value, plural, =0 {Mostra tutte le risposte} one {Mostra risposte con almeno # like} other {Mostra risposte con almeno # like}}"
-
-#~ msgid "<0/> members"
-#~ msgstr "<0/> membri"
-
-#~ msgid "<0>{0} </0>and<1> </1><2>{1} </2>are included in your starter pack"
-#~ msgstr "<0>{0} </0>e<1> </1><2>{1} </2>sono inclusi nel tuo starter pack"
-
 #: src/screens/StarterPack/Wizard/index.tsx:475
 msgctxt "profiles"
 msgid "<0>{0}, </0><1>{1}, </1>and {2, plural, one {# other} other {# others}} are included in your starter pack"
@@ -368,9 +317,6 @@ msgstr "<0>{0}, </0><1>{1}, </1>e {2, plural, one {# altro} other {# altri}} son
 msgctxt "feeds"
 msgid "<0>{0}, </0><1>{1}, </1>and {2, plural, one {# other} other {# others}} are included in your starter pack"
 msgstr "<0>{0}, </0><1>{1}, </1>e {2, plural, one {# altro} other {# altri}} sono inclusi nel tuo starter pack"
-
-#~ msgid "<0>{0}, </0><1>{1}, </1>and {2} {3, plural, one {other} other {others}} are included in your starter pack"
-#~ msgstr "<0>{0}, </0><1>{1}, </1>e {2} {3, plural, one {# altro} other {# altri}} sono inclusi nel tuo starter pack"
 
 #: src/view/shell/Drawer.tsx:97
 msgid "<0>{0}</0> {1, plural, one {follower} other {followers}}"
@@ -384,9 +330,6 @@ msgstr "<0>{0}</0> {1, plural, one {following} other {following}}"
 msgid "<0>{0}</0> and<1> </1><2>{1} </2>are included in your starter pack"
 msgstr "<0>{0}</0> e<1> </1><2>{1} </2>sono inclusi nel tuo starter pack"
 
-#~ msgid "<0>{0}</0> following"
-#~ msgstr "<0>{0}</0> seguito"
-
 #: src/screens/StarterPack/Wizard/index.tsx:509
 msgid "<0>{0}</0> is included in your starter pack"
 msgstr "<0>{0}</0> è incluso nel tuo starter pack"
@@ -399,28 +342,9 @@ msgstr "<0>{0}</0> membri"
 msgid "<0>{date}</0> at {time}"
 msgstr "<0>{date}</0> alle {time}"
 
-#~ msgid "<0>{followers} </0><1>{pluralizedFollowers}</1>"
-#~ msgstr "<0>{followers} </0><1>{pluralizedFollowers}</1>"
-
-#~ msgid "<0>{following} </0><1>following</1>"
-#~ msgstr "<0>{following} </0><1>following</1>"
-
-#~ msgid "<0>Choose your</0><1>Recommended</1><2>Feeds</2>"
-#~ msgstr "<0>Scegli i tuoi</0><1>feed/1><2>consigliati</2>"
-
 #: src/screens/Settings/NotificationSettings.tsx:72
 msgid "<0>Experimental:</0> When this preference is enabled, you'll only receive reply and quote notifications from users you follow. We'll continue to add more controls here over time."
 msgstr ""
-
-#~ msgid "<0>Follow some</0><1>Recommended</1><2>Users</2>"
-#~ msgstr "<0>Segui alcuni</0><1>utenti</1><2>consigliati</2>"
-
-#: src/view/com/modals/SelfLabel.tsx:135
-#~ msgid "<0>Not Applicable.</0> This warning is only available for posts with media attached."
-#~ msgstr "<0>Non applicabile.</0> Questo avviso è disponibile solo per i post che contengono media."
-
-#~ msgid "<0>Welcome to</0><1>Bluesky</1>"
-#~ msgstr "<0>Ti diamo il benvenuto su</0><1>Bluesky</1>"
 
 #: src/screens/StarterPack/Wizard/index.tsx:466
 msgid "<0>You</0> and<1> </1><2>{0} </2>are included in your starter pack"
@@ -446,25 +370,12 @@ msgstr "30 giorni"
 msgid "7 days"
 msgstr "7 giorni"
 
-#~ msgid "A content warning has been applied to this {0}."
-#~ msgstr "A questo post è stato applicato un avviso di contenuto {0}."
-
-#: src/tours/Tooltip.tsx:70
-#~ msgid "A help tooltip"
-#~ msgstr ""
-
-#~ msgid "A new version of the app is available. Please update to continue using the app."
-#~ msgstr "È disponibile una nuova versione dell'app. Aggiorna per continuare a utilizzarla."
-
-#: src/Navigation.tsx:361
-#: src/screens/Settings/AboutSettings.tsx:25
-#: src/screens/Settings/Settings.tsx:207
-#: src/screens/Settings/Settings.tsx:210
+#: src/Navigation.tsx:361 src/screens/Settings/AboutSettings.tsx:25
+#: src/screens/Settings/Settings.tsx:207 src/screens/Settings/Settings.tsx:210
 msgid "About"
-msgstr ""
+msgstr "Informazioni su"
 
-#: src/view/com/util/ViewHeader.tsx:89
-#: src/view/screens/Search/Search.tsx:883
+#: src/view/com/util/ViewHeader.tsx:89 src/view/screens/Search/Search.tsx:883
 msgid "Access navigation links and settings"
 msgstr "Accedi alle impostazioni di navigazione"
 
@@ -473,27 +384,17 @@ msgid "Access profile and other navigation links"
 msgstr "Accedi al profilo e ad altre impostazioni di navigazione"
 
 #: src/screens/Settings/AccessibilitySettings.tsx:43
-#: src/screens/Settings/Settings.tsx:183
-#: src/screens/Settings/Settings.tsx:186
+#: src/screens/Settings/Settings.tsx:183 src/screens/Settings/Settings.tsx:186
 msgid "Accessibility"
 msgstr "Accessibilità"
-
-#: src/view/screens/Settings/index.tsx:455
-#~ msgid "Accessibility settings"
-#~ msgstr "Impostazioni di accessibilità"
 
 #: src/Navigation.tsx:321
 msgid "Accessibility Settings"
 msgstr "Impostazioni di Accessibilità"
 
-#~ msgid "account"
-#~ msgstr "account"
-
-#: src/Navigation.tsx:337
-#: src/screens/Login/LoginForm.tsx:176
+#: src/Navigation.tsx:337 src/screens/Login/LoginForm.tsx:176
 #: src/screens/Settings/AccountSettings.tsx:42
-#: src/screens/Settings/Settings.tsx:145
-#: src/screens/Settings/Settings.tsx:148
+#: src/screens/Settings/Settings.tsx:145 src/screens/Settings/Settings.tsx:148
 msgid "Account"
 msgstr "Account"
 
@@ -563,8 +464,7 @@ msgstr "Aggiungi un avviso sul contenuto"
 msgid "Add a user to this list"
 msgstr "Aggiungi un utente a questo elenco"
 
-#: src/components/dialogs/SwitchAccount.tsx:55
-#: src/screens/Deactivated.tsx:198
+#: src/components/dialogs/SwitchAccount.tsx:55 src/screens/Deactivated.tsx:198
 msgid "Add account"
 msgstr "Aggiungi account"
 
@@ -578,43 +478,27 @@ msgstr "Aggiungi account"
 msgid "Add alt text"
 msgstr "Aggiungi testo alternativo"
 
-#~ msgid "Add ALT text"
-#~ msgstr "Agguingo del testo descrittivo"
-
 #: src/view/com/composer/videos/SubtitleDialog.tsx:107
 msgid "Add alt text (optional)"
 msgstr "Aggiungi testo alternativo (opzionale)"
 
-#: src/screens/Settings/Settings.tsx:364
-#: src/screens/Settings/Settings.tsx:367
+#: src/screens/Settings/Settings.tsx:364 src/screens/Settings/Settings.tsx:367
 msgid "Add another account"
-msgstr ""
+msgstr "Aggiungi un altro account"
 
 #: src/view/com/composer/Composer.tsx:713
 msgid "Add another post"
-msgstr ""
+msgstr "Aggiungi un altro post"
 
 #: src/screens/Settings/components/AddAppPasswordDialog.tsx:102
 msgid "Add app password"
-msgstr ""
+msgstr "Aggiungi password delle app"
 
 #: src/screens/Settings/AppPasswords.tsx:67
 #: src/screens/Settings/AppPasswords.tsx:75
 #: src/screens/Settings/components/AddAppPasswordDialog.tsx:111
 msgid "Add App Password"
 msgstr "Aggiungi la Password per l'App"
-
-#~ msgid "Add details"
-#~ msgstr "Aggiungi i dettagli"
-
-#~ msgid "Add details to report"
-#~ msgstr "Aggiungi dettagli da segnalare"
-
-#~ msgid "Add link card"
-#~ msgstr "Aggiungi anteprima del link"
-
-#~ msgid "Add link card:"
-#~ msgstr "Aggiungi anteprima del link:"
 
 #: src/components/dialogs/MutedWords.tsx:321
 msgid "Add mute word for configured settings"
@@ -626,10 +510,7 @@ msgstr "Aggiungi parole e tag silenziati"
 
 #: src/view/com/composer/Composer.tsx:1228
 msgid "Add new post"
-msgstr ""
-
-#~ msgid "Add people to your starter pack that you think others will enjoy following"
-#~ msgstr "Aggiungi persone al tuo starter pack che potrebbero interessare agli altri utenti"
+msgstr "Aggiungi nuovo post"
 
 #: src/screens/Home/NoFeedsPinned.tsx:99
 msgid "Add recommended feeds"
@@ -660,9 +541,6 @@ msgstr "Aggiungi alle Liste"
 msgid "Add to my feeds"
 msgstr "Aggiungi ai miei feed"
 
-#~ msgid "Added"
-#~ msgstr "Aggiunto"
-
 #: src/view/com/modals/ListAddRemoveUsers.tsx:192
 #: src/view/com/modals/UserAddRemoveLists.tsx:162
 msgid "Added to list"
@@ -672,12 +550,9 @@ msgstr "Aggiunto alla lista"
 msgid "Added to my feeds"
 msgstr "Aggiunto ai miei feed"
 
-#~ msgid "Adjust the number of likes a reply must have to be shown in your feed."
-#~ msgstr "Modifica il numero di \"Mi piace\" che una risposta deve avere per essere mostrata nel tuo feed."
-
 #: src/view/com/composer/labels/LabelsBtn.tsx:161
 msgid "Adult"
-msgstr ""
+msgstr "Adulto"
 
 #: src/components/moderation/ContentHider.tsx:83
 #: src/lib/moderation/useGlobalLabelStrings.ts:34
@@ -685,9 +560,6 @@ msgstr ""
 #: src/view/com/composer/labels/LabelsBtn.tsx:129
 msgid "Adult Content"
 msgstr "Contenuto per adulti"
-
-#~ msgid "Adult content can only be enabled via the Web at <0/>."
-#~ msgstr "I contenuti per adulti possono essere abilitati solo dal sito Web a <0/>."
 
 #: src/screens/Moderation/index.tsx:360
 msgid "Adult content can only be enabled via the Web at <0>bsky.app</0>."
@@ -700,7 +572,7 @@ msgstr "Il contenuto per adulti è disattivato."
 #: src/view/com/composer/labels/LabelsBtn.tsx:140
 #: src/view/com/composer/labels/LabelsBtn.tsx:198
 msgid "Adult Content labels"
-msgstr ""
+msgstr "Etichette per contenuti per adulti"
 
 #: src/screens/Moderation/index.tsx:404
 msgid "Advanced"
@@ -723,11 +595,7 @@ msgstr "Tutti i feed che hai salvato, in un unico posto."
 msgid "Allow access to your direct messages"
 msgstr "Consenti l'accesso ai tuoi messaggi"
 
-#~ msgid "Allow messages from"
-#~ msgstr "Permetti tutti i messaggi di"
-
-#: src/screens/Messages/Settings.tsx:64
-#: src/screens/Messages/Settings.tsx:67
+#: src/screens/Messages/Settings.tsx:64 src/screens/Messages/Settings.tsx:67
 msgid "Allow new messages from"
 msgstr "Consenti nuovi messaggi da"
 
@@ -793,9 +661,6 @@ msgstr "Un email è stata inviata! Per favore inserisci qui sotto il codice di c
 msgid "An error has occurred"
 msgstr "Si è verificato un errore"
 
-#~ msgid "An error occured"
-#~ msgstr "Si è verificato un errore"
-
 #: src/view/com/util/post-embeds/VideoEmbedInner/web-controls/VideoControls.tsx:419
 msgid "An error occurred"
 msgstr "Si è verificato un errore"
@@ -816,9 +681,6 @@ msgstr "Si è verificato un errore nel caricare il video. Per favore riprova pi�
 msgid "An error occurred while loading the video. Please try again."
 msgstr "Si è verificato un errore durante il caricamento del video. Per favore ritenta."
 
-#~ msgid "An error occurred while saving the image."
-#~ msgstr "Si è verificato un errore nel caricare l'immagine."
-
 #: src/components/StarterPack/QrCodeDialog.tsx:71
 #: src/components/StarterPack/ShareDialog.tsx:80
 msgid "An error occurred while saving the QR code!"
@@ -826,10 +688,7 @@ msgstr "Si è verificato un errore nel salvare il codice QR!"
 
 #: src/view/com/composer/videos/SelectVideoBtn.tsx:87
 msgid "An error occurred while selecting the video"
-msgstr "Si è verificato un errore durante la selezione del video."
-
-#~ msgid "An error occurred while trying to delete the message. Please try again."
-#~ msgstr "Si è verificato un errore durante la cancellazione del messaggio. Per favore riprova più tardi."
+msgstr "Si è verificato un errore durante la selezione del video"
 
 #: src/screens/StarterPack/StarterPackScreen.tsx:347
 #: src/screens/StarterPack/StarterPackScreen.tsx:369
@@ -854,8 +713,7 @@ msgstr "Si è verificato un problema nell'aprire la chat"
 
 #: src/components/hooks/useFollowMethods.ts:35
 #: src/components/hooks/useFollowMethods.ts:50
-#: src/components/ProfileCard.tsx:326
-#: src/components/ProfileCard.tsx:346
+#: src/components/ProfileCard.tsx:326 src/components/ProfileCard.tsx:346
 #: src/view/com/profile/FollowButton.tsx:36
 #: src/view/com/profile/FollowButton.tsx:46
 msgid "An issue occurred, please try again."
@@ -874,8 +732,7 @@ msgstr "un etichettatore sconosciuto"
 msgid "and"
 msgstr "e"
 
-#: src/screens/Onboarding/index.tsx:29
-#: src/screens/Onboarding/state.ts:81
+#: src/screens/Onboarding/index.tsx:29 src/screens/Onboarding/state.ts:81
 msgid "Animals"
 msgstr "Animali"
 
@@ -890,7 +747,7 @@ msgstr "Comportamento antisociale"
 #: src/view/screens/Search/Search.tsx:347
 #: src/view/screens/Search/Search.tsx:348
 msgid "Any language"
-msgstr "Qualsiasi lingua."
+msgstr "Qualsiasi lingua"
 
 #: src/view/com/composer/threadgate/ThreadgateBtn.tsx:49
 msgid "Anybody can interact"
@@ -902,7 +759,7 @@ msgstr "Lingua dell'app"
 
 #: src/screens/Settings/components/AddAppPasswordDialog.tsx:122
 msgid "App Password"
-msgstr ""
+msgstr "Password dell'app"
 
 #: src/screens/Settings/AppPasswords.tsx:139
 msgid "App password deleted"
@@ -910,37 +767,24 @@ msgstr "Password dell'app eliminata"
 
 #: src/screens/Settings/components/AddAppPasswordDialog.tsx:84
 msgid "App password name must be unique"
-msgstr ""
+msgstr "Il nome della password dell'app deve essere univoco"
 
 #: src/screens/Settings/components/AddAppPasswordDialog.tsx:62
 msgid "App password names can only contain letters, numbers, spaces, dashes, and underscores"
-msgstr ""
-
-#: src/view/com/modals/AddAppPasswords.tsx:138
-#~ msgid "App Password names can only contain letters, numbers, spaces, dashes, and underscores."
-#~ msgstr "Le password dell'app possono contenere solo lettere, numeri, spazi, trattini e trattini bassi."
+msgstr "I nomi delle password delle app possono contenere solo lettere, numeri, spazi, segni meno e caratteri di sottolineatura"
 
 #: src/screens/Settings/components/AddAppPasswordDialog.tsx:80
 msgid "App password names must be at least 4 characters long"
-msgstr ""
-
-#: src/view/com/modals/AddAppPasswords.tsx:103
-#~ msgid "App Password names must be at least 4 characters long."
-#~ msgstr "Le password delle app devono contenere almeno 4 caratteri."
-
-#: src/view/screens/Settings/index.tsx:664
-#~ msgid "App password settings"
-#~ msgstr "Impostazioni della password dell'app"
+msgstr "I nomi delle password devono essere lunghi almeno 4 caratteri"
 
 #: src/screens/Settings/PrivacyAndSecuritySettings.tsx:56
 #: src/screens/Settings/PrivacyAndSecuritySettings.tsx:59
 msgid "App passwords"
-msgstr "Passwords dell'app"
+msgstr "Password delle app"
 
-#: src/Navigation.tsx:289
-#: src/screens/Settings/AppPasswords.tsx:47
+#: src/Navigation.tsx:289 src/screens/Settings/AppPasswords.tsx:47
 msgid "App Passwords"
-msgstr "Password dell'App"
+msgstr "Password delle app"
 
 #: src/components/moderation/LabelsOnMeDialog.tsx:148
 #: src/components/moderation/LabelsOnMeDialog.tsx:151
@@ -951,22 +795,10 @@ msgstr "Ricorso"
 msgid "Appeal \"{0}\" label"
 msgstr "Etichetta \"{0}\" del ricorso"
 
-#~ msgid "Appeal content warning"
-#~ msgstr "Ricorso contro l'avviso sui contenuti"
-
-#~ msgid "Appeal Content Warning"
-#~ msgstr "Ricorso contro l'Avviso sui Contenuti"
-
-#~ msgid "Appeal Decision"
-#~ msgstr "Decisión de apelación"
-
 #: src/components/moderation/LabelsOnMeDialog.tsx:233
 #: src/screens/Messages/components/ChatDisabled.tsx:91
 msgid "Appeal submitted"
 msgstr "Appello inviato"
-
-#~ msgid "Appeal submitted."
-#~ msgstr "Ricorso presentato."
 
 #: src/screens/Messages/components/ChatDisabled.tsx:51
 #: src/screens/Messages/components/ChatDisabled.tsx:53
@@ -975,23 +807,10 @@ msgstr "Appello inviato"
 msgid "Appeal this decision"
 msgstr "Fai ricorso contro questa decisione"
 
-#~ msgid "Appeal this decision."
-#~ msgstr "Appella contro questa decisione."
-
-#: src/Navigation.tsx:329
-#: src/screens/Settings/AppearanceSettings.tsx:76
-#: src/screens/Settings/Settings.tsx:175
-#: src/screens/Settings/Settings.tsx:178
+#: src/Navigation.tsx:329 src/screens/Settings/AppearanceSettings.tsx:76
+#: src/screens/Settings/Settings.tsx:175 src/screens/Settings/Settings.tsx:178
 msgid "Appearance"
 msgstr "Aspetto"
-
-#: src/view/screens/Settings/index.tsx:476
-#~ msgid "Appearance settings"
-#~ msgstr "Impostazioni dell'aspetto"
-
-#: src/Navigation.tsx:325
-#~ msgid "Appearance Settings"
-#~ msgstr "Impostazioni dell'aspetto"
 
 #: src/screens/Feeds/NoSavedFeedsOfAnyType.tsx:47
 #: src/screens/Home/NoFeedsPinned.tsx:93
@@ -1000,23 +819,16 @@ msgstr "Applica i feed raccomandati predefiniti"
 
 #: src/view/com/post-thread/PostThreadItem.tsx:825
 msgid "Archived from {0}"
-msgstr ""
+msgstr "Archiviato da {0}"
 
 #: src/view/com/post-thread/PostThreadItem.tsx:794
 #: src/view/com/post-thread/PostThreadItem.tsx:833
 msgid "Archived post"
-msgstr ""
-
-#~ msgid "Are you sure you want delete this starter pack?"
-#~ msgstr "Sicuro di voler eliminare questo starter pack?"
+msgstr "Post archiviato"
 
 #: src/screens/Settings/AppPasswords.tsx:201
 msgid "Are you sure you want to delete the app password \"{0}\"?"
-msgstr ""
-
-#: src/view/screens/AppPasswords.tsx:283
-#~ msgid "Are you sure you want to delete the app password \"{name}\"?"
-#~ msgstr "Confermi di voler eliminare la password dell'app \"{name}\"?"
+msgstr "Eliminare la password dell'app \"{0}\"?"
 
 #: src/components/dms/MessageMenu.tsx:149
 msgid "Are you sure you want to delete this message? The message will be deleted for you, but not for the other participant."
@@ -1028,7 +840,7 @@ msgstr "Sicuro di voler eliminare questo starter pack?"
 
 #: src/screens/Profile/Header/EditProfileDialog.tsx:82
 msgid "Are you sure you want to discard your changes?"
-msgstr ""
+msgstr "Annullare le modifiche?"
 
 #: src/components/dms/LeaveConvoPrompt.tsx:48
 msgid "Are you sure you want to leave this conversation? Your messages will be deleted for you, but not for the other participant."
@@ -1054,15 +866,11 @@ msgstr ""
 msgid "Are you sure?"
 msgstr "Confermi?"
 
-#~ msgid "Are you sure? This cannot be undone."
-#~ msgstr "Vuoi proseguire? Questa operazione non può essere annullata."
-
 #: src/view/com/composer/select-language/SuggestedLanguage.tsx:61
 msgid "Are you writing in <0>{0}</0>?"
 msgstr "Stai scrivendo in <0>{0}</0>?"
 
-#: src/screens/Onboarding/index.tsx:23
-#: src/screens/Onboarding/state.ts:82
+#: src/screens/Onboarding/index.tsx:23 src/screens/Onboarding/state.ts:82
 msgid "Art"
 msgstr "Arte"
 
@@ -1090,8 +898,7 @@ msgstr ""
 #: src/screens/Login/ChooseAccountForm.tsx:95
 #: src/screens/Login/ForgotPasswordForm.tsx:123
 #: src/screens/Login/ForgotPasswordForm.tsx:129
-#: src/screens/Login/LoginForm.tsx:282
-#: src/screens/Login/LoginForm.tsx:288
+#: src/screens/Login/LoginForm.tsx:282 src/screens/Login/LoginForm.tsx:288
 #: src/screens/Login/SetNewPasswordForm.tsx:154
 #: src/screens/Login/SetNewPasswordForm.tsx:160
 #: src/screens/Messages/components/ChatDisabled.tsx:133
@@ -1103,19 +910,7 @@ msgstr ""
 msgid "Back"
 msgstr "Indietro"
 
-#~ msgctxt "action"
-#~ msgid "Back"
-#~ msgstr "Indietro"
-
-#~ msgid "Based on your interest in {interestsText}"
-#~ msgstr "Basato sui tuoi interessi {interestsText}"
-
-#: src/view/screens/Settings/index.tsx:442
-#~ msgid "Basics"
-#~ msgstr "Preferenze"
-
-#: src/view/screens/Lists.tsx:104
-#: src/view/screens/ModerationModlists.tsx:100
+#: src/view/screens/Lists.tsx:104 src/view/screens/ModerationModlists.tsx:100
 msgid "Before creating a list, you must first verify your email."
 msgstr ""
 
@@ -1138,17 +933,12 @@ msgstr ""
 msgid "Birthday"
 msgstr "Compleanno"
 
-#: src/view/screens/Settings/index.tsx:348
-#~ msgid "Birthday:"
-#~ msgstr "Compleanno:"
-
 #: src/screens/Profile/Header/ProfileHeaderStandard.tsx:283
 #: src/view/com/profile/ProfileMenu.tsx:341
 msgid "Block"
 msgstr "Blocca"
 
-#: src/components/dms/ConvoMenu.tsx:188
-#: src/components/dms/ConvoMenu.tsx:192
+#: src/components/dms/ConvoMenu.tsx:188 src/components/dms/ConvoMenu.tsx:192
 msgid "Block account"
 msgstr "Blocca account"
 
@@ -1173,9 +963,6 @@ msgstr "Lista di account bloccati"
 msgid "Block these accounts?"
 msgstr "Vuoi bloccare questi account?"
 
-#~ msgid "Block this List"
-#~ msgstr "Blocca questa Lista"
-
 #: src/view/com/util/post-embeds/QuoteEmbed.tsx:83
 msgid "Blocked"
 msgstr "Bloccato"
@@ -1184,8 +971,7 @@ msgstr "Bloccato"
 msgid "Blocked accounts"
 msgstr "Accounts bloccati"
 
-#: src/Navigation.tsx:153
-#: src/view/screens/ModerationBlockedAccounts.tsx:108
+#: src/Navigation.tsx:153 src/view/screens/ModerationBlockedAccounts.tsx:108
 msgid "Blocked Accounts"
 msgstr "Accounts bloccati"
 
@@ -1226,9 +1012,6 @@ msgstr "Bluesky"
 msgid "Bluesky cannot confirm the authenticity of the claimed date."
 msgstr ""
 
-#~ msgid "Bluesky is an open network where you can choose your hosting provider. Custom hosting is now available in beta for developers."
-#~ msgstr "Bluesky è un network aperto in cui puoi scegliere il tuo provider di hosting. L'hosting personalizzato è adesso disponibile in versione beta per gli sviluppatori."
-
 #: src/view/com/auth/server-input/index.tsx:151
 msgid "Bluesky is an open network where you can choose your hosting provider. If you're a developer, you can host your own server."
 msgstr "Bluesky è una rete aperta dove puoi scegliere il fornitore di hosting. Se sei uno sviluppatore, puoi ospitare il tuo server."
@@ -1236,18 +1019,6 @@ msgstr "Bluesky è una rete aperta dove puoi scegliere il fornitore di hosting. 
 #: src/components/ProgressGuide/List.tsx:55
 msgid "Bluesky is better with friends!"
 msgstr "Bluesky è meglio con gli amici!"
-
-#~ msgid "Bluesky is flexible."
-#~ msgstr "Bluesky è flessibile."
-
-#~ msgid "Bluesky is open."
-#~ msgstr "Bluesky è aperto."
-
-#~ msgid "Bluesky is public."
-#~ msgstr "Bluesky è pubblico."
-
-#~ msgid "Bluesky uses invites to build a healthier community. If you don't know anybody with an invite, you can sign up for the waitlist and we'll send one soon."
-#~ msgstr "Bluesky utilizza gli inviti per costruire una comunità più sana. Se non conosci nessuno con un invito, puoi iscriverti alla lista d'attesa e te ne invieremo uno al più presto."
 
 #: src/components/StarterPack/ProfileStarterPacks.tsx:300
 msgid "Bluesky will choose a set of recommended accounts from people in your network."
@@ -1257,9 +1028,6 @@ msgstr "Bluesky sceglierà un set di account consigliati dal tuo network."
 msgid "Bluesky will not show your profile and posts to logged-out users. Other apps may not honor this request. This does not make your account private."
 msgstr "Bluesky non mostrerà il tuo profilo e i tuoi post agli utenti non loggati. Altre applicazioni potrebbero non rispettare questa istruzione. Ciò non rende il tuo account privato."
 
-#~ msgid "Bluesky.Social"
-#~ msgstr "Bluesky.Social"
-
 #: src/lib/moderation/useLabelBehaviorDescription.ts:53
 msgid "Blur images"
 msgstr "Sfoca le immagini"
@@ -1268,8 +1036,7 @@ msgstr "Sfoca le immagini"
 msgid "Blur images and filter from feeds"
 msgstr "Sfoca le immagini e filtra dai feed"
 
-#: src/screens/Onboarding/index.tsx:30
-#: src/screens/Onboarding/state.ts:83
+#: src/screens/Onboarding/index.tsx:30 src/screens/Onboarding/state.ts:83
 msgid "Books"
 msgstr "Libri"
 
@@ -1298,44 +1065,29 @@ msgstr "Scopri nuovi suggerimenti dalla Ricerca"
 msgid "Browse other feeds"
 msgstr "Cerca altri feed"
 
-#~ msgid "Build version {0} {1}"
-#~ msgstr "Versione {0} {1}"
-
 #: src/view/com/auth/SplashScreen.web.tsx:168
 msgid "Business"
 msgstr "Attività commerciale"
-
-#~ msgid "Button disabled. Input custom domain to proceed."
-#~ msgstr "Pulsante disabilitato. Inserisci il dominio personalizzato per procedere."
 
 #: src/view/com/profile/ProfileSubpageHeader.tsx:197
 msgid "by —"
 msgstr "da —"
 
-#~ msgid "by {0}"
-#~ msgstr "di {0}"
-
 #: src/components/LabelingServiceCard/index.tsx:62
 msgid "By {0}"
 msgstr "Di {0}"
-
-#~ msgid "by @{0}"
-#~ msgstr "Di @{0}"
 
 #: src/view/com/profile/ProfileSubpageHeader.tsx:201
 msgid "by <0/>"
 msgstr "di <0/>"
 
-#~ msgid "By creating an account you agree to the {els}."
-#~ msgstr "Creando un account accetti i {els}."
-
 #: src/screens/Signup/StepInfo/Policies.tsx:81
 msgid "By creating an account you agree to the <0>Privacy Policy</0>."
-msgstr "Creando un account accetti la <0>Privacy Policy</0>."
+msgstr "Creando un account accetti l'<0>informativa sulla privacy</0>."
 
 #: src/screens/Signup/StepInfo/Policies.tsx:48
 msgid "By creating an account you agree to the <0>Terms of Service</0> and <1>Privacy Policy</1>."
-msgstr "Creando un account accetti i <0>Termini di Servizio</0> e la <1>Privacy Policy</1>. "
+msgstr "Creando un account accetti i <0>termini di servizio</0> e l'<1>informativa sulla privacy</1>."
 
 #: src/screens/Signup/StepInfo/Policies.tsx:68
 msgid "By creating an account you agree to the <0>Terms of Service</0>."
@@ -1349,21 +1101,14 @@ msgstr "da te"
 msgid "Camera"
 msgstr "Fotocamera"
 
-#: src/view/com/modals/AddAppPasswords.tsx:180
-#~ msgid "Can only contain letters, numbers, spaces, dashes, and underscores. Must be at least 4 characters long, but no more than 32 characters long."
-#~ msgstr "Può contenere solo lettere, numeri, spazi, trattini e trattini bassi. Deve contenere almeno 4 caratteri, ma non più di 32 caratteri."
-
-#: src/components/Menu/index.tsx:236
-#: src/components/Prompt.tsx:129
-#: src/components/Prompt.tsx:131
-#: src/components/TagMenu/index.tsx:267
+#: src/components/Menu/index.tsx:236 src/components/Prompt.tsx:129
+#: src/components/Prompt.tsx:131 src/components/TagMenu/index.tsx:267
 #: src/screens/Deactivated.tsx:164
 #: src/screens/Profile/Header/EditProfileDialog.tsx:220
 #: src/screens/Profile/Header/EditProfileDialog.tsx:228
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:72
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:79
-#: src/screens/Settings/Settings.tsx:252
-#: src/view/com/composer/Composer.tsx:891
+#: src/screens/Settings/Settings.tsx:252 src/view/com/composer/Composer.tsx:891
 #: src/view/com/modals/ChangeEmail.tsx:213
 #: src/view/com/modals/ChangeEmail.tsx:215
 #: src/view/com/modals/ChangePassword.tsx:268
@@ -1380,26 +1125,19 @@ msgstr "Fotocamera"
 #: src/view/com/util/post-ctrls/RepostButton.tsx:166
 #: src/view/screens/Search/Search.tsx:911
 msgid "Cancel"
-msgstr "Cancella"
+msgstr "Annulla"
 
 #: src/view/com/modals/CreateOrEditList.tsx:340
 #: src/view/com/modals/DeleteAccount.tsx:174
 #: src/view/com/modals/DeleteAccount.tsx:297
 msgctxt "action"
 msgid "Cancel"
-msgstr "Cancella"
+msgstr "Annulla"
 
 #: src/view/com/modals/DeleteAccount.tsx:170
 #: src/view/com/modals/DeleteAccount.tsx:293
 msgid "Cancel account deletion"
 msgstr "Annulla la cancellazione dell'account"
-
-#~ msgid "Cancel add image alt text"
-#~ msgstr "Annulla inserimento testo alternativo immagine "
-
-#: src/view/com/modals/ChangeHandle.tsx:137
-#~ msgid "Cancel change handle"
-#~ msgstr "Annulla il cambio del tuo nome utente"
 
 #: src/view/com/modals/CropImage.web.tsx:94
 msgid "Cancel image crop"
@@ -1415,15 +1153,12 @@ msgstr "Annnulla la citazione del post"
 
 #: src/screens/Deactivated.tsx:158
 msgid "Cancel reactivation and log out"
-msgstr "Cancella la riattivazione e disconnettiti"
+msgstr "Annulla la riattivazione e disconnettiti"
 
 #: src/view/com/modals/ListAddRemoveUsers.tsx:88
 #: src/view/screens/Search/Search.tsx:903
 msgid "Cancel search"
 msgstr "Annulla la ricerca"
-
-#~ msgid "Cancel waitlist signup"
-#~ msgstr "Annulla l'iscrizione alla lista d'attesa"
 
 #: src/view/com/modals/LinkWarning.tsx:106
 msgid "Cancels opening the linked website"
@@ -1449,61 +1184,43 @@ msgstr "Sottotitoli & testo alternativo"
 msgid "Change"
 msgstr "Cambia"
 
-#: src/view/screens/Settings/index.tsx:342
-#~ msgctxt "action"
-#~ msgid "Change"
-#~ msgstr "Cambia"
-
 #: src/screens/Settings/AccountSettings.tsx:90
 #: src/screens/Settings/AccountSettings.tsx:94
 msgid "Change email"
-msgstr ""
+msgstr "Modifica email"
 
 #: src/components/dialogs/VerifyEmailDialog.tsx:162
 #: src/components/dialogs/VerifyEmailDialog.tsx:187
 msgid "Change email address"
 msgstr "Cambia indirizzo email"
 
-#: src/view/screens/Settings/index.tsx:685
-#~ msgid "Change handle"
-#~ msgstr "Cambia il nome utente"
-
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:88
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:93
 msgid "Change Handle"
-msgstr "Cambia il Nome Utente"
+msgstr "Modifica il nome utente"
 
 #: src/view/com/modals/VerifyEmail.tsx:155
 msgid "Change my email"
-msgstr "Cambia la mia email"
-
-#: src/view/screens/Settings/index.tsx:730
-#~ msgid "Change password"
-#~ msgstr "Cambia la password"
+msgstr "Modifica la mia email"
 
 #: src/view/com/modals/ChangePassword.tsx:142
 msgid "Change Password"
-msgstr "Cambia la Password"
+msgstr "Modifica la password"
 
 #: src/view/com/composer/select-language/SuggestedLanguage.tsx:74
 msgid "Change post language to {0}"
 msgstr "Cambia la lingua del post a {0}"
 
-#~ msgid "Change your Bluesky password"
-#~ msgstr "Cambia la tua password di Bluesky"
-
 #: src/view/com/modals/ChangeEmail.tsx:104
 msgid "Change Your Email"
-msgstr "Cambia la tua email"
+msgstr "Modifica la tua email"
 
 #: src/components/dialogs/VerifyEmailDialog.tsx:171
 msgid "Change your email address"
-msgstr ""
+msgstr "Modifica il tuo indirizzo email"
 
-#: src/Navigation.tsx:373
-#: src/view/shell/bottom-bar/BottomBar.tsx:200
-#: src/view/shell/desktop/LeftNav.tsx:348
-#: src/view/shell/Drawer.tsx:417
+#: src/Navigation.tsx:373 src/view/shell/bottom-bar/BottomBar.tsx:200
+#: src/view/shell/desktop/LeftNav.tsx:348 src/view/shell/Drawer.tsx:417
 msgid "Chat"
 msgstr "Messaggi"
 
@@ -1511,10 +1228,8 @@ msgstr "Messaggi"
 msgid "Chat muted"
 msgstr "Conversazione silenziata"
 
-#: src/components/dms/ConvoMenu.tsx:112
-#: src/components/dms/MessageMenu.tsx:81
-#: src/Navigation.tsx:378
-#: src/screens/Messages/ChatList.tsx:88
+#: src/components/dms/ConvoMenu.tsx:112 src/components/dms/MessageMenu.tsx:81
+#: src/Navigation.tsx:378 src/screens/Messages/ChatList.tsx:88
 msgid "Chat settings"
 msgstr "Impostazioni messaggi"
 
@@ -1526,16 +1241,9 @@ msgstr "Impostazioni messaggi"
 msgid "Chat unmuted"
 msgstr "Conversizione non silenziata"
 
-#: src/screens/SignupQueued.tsx:78
-#: src/screens/SignupQueued.tsx:82
+#: src/screens/SignupQueued.tsx:78 src/screens/SignupQueued.tsx:82
 msgid "Check my status"
 msgstr "Verifica il mio stato"
-
-#~ msgid "Check out some recommended feeds. Tap + to add them to your list of pinned feeds."
-#~ msgstr "Dai un'occhiata ad alcuni feed consigliati. Clicca + per aggiungerli al tuo elenco dei feed."
-
-#~ msgid "Check out some recommended users. Follow them to see similar users."
-#~ msgstr "Scopri alcuni utenti consigliati. Seguili per vedere utenti simili."
 
 #: src/screens/Login/LoginForm.tsx:275
 msgid "Check your email for a login code and enter it here."
@@ -1545,21 +1253,9 @@ msgstr "Controlla la tua email per il codice di accesso e inseriscilo qui."
 msgid "Check your inbox for an email with the confirmation code to enter below:"
 msgstr "Controlla la tua posta in arrivo, dovrebbe contenere un'e-mail con il codice di conferma da inserire di seguito:"
 
-#~ msgid "Choose \"Everybody\" or \"Nobody\""
-#~ msgstr "Scegli \"Tutti\" o \"Nessuno\""
-
-#~ msgid "Choose 3 or more:"
-#~ msgstr "Scegli 3 o più:"
-
-#~ msgid "Choose a new Bluesky username or create"
-#~ msgstr "Scegli un nuovo nome utente Bluesky o creane uno"
-
-#~ msgid "Choose at least {0} more"
-#~ msgstr "Scegli almeno {0} in più"
-
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:370
 msgid "Choose domain verification method"
-msgstr ""
+msgstr "Scegli il metodo di verifica del dominio"
 
 #: src/screens/StarterPack/Wizard/index.tsx:199
 msgid "Choose Feeds"
@@ -1585,28 +1281,13 @@ msgstr "Scegli il servizio"
 msgid "Choose the algorithms that power your custom feeds."
 msgstr "Scegli gli algoritmi che compilano i tuoi feed personalizzati."
 
-#~ msgid "Choose the algorithms that power your experience with custom feeds."
-#~ msgstr "Scegli gli algoritmi che migliorano la tua esperienza con i feed personalizzati."
-
 #: src/screens/Onboarding/StepProfile/AvatarCreatorItems.tsx:107
 msgid "Choose this color as your avatar"
 msgstr "Scegli questo colore per il tuo avatar"
 
-#~ msgid "Choose who can reply"
-#~ msgstr "Scegli chi può rispondere"
-
-#~ msgid "Choose your main feeds"
-#~ msgstr "Scegli i tuoi feed principali"
-
 #: src/screens/Signup/StepInfo/index.tsx:201
 msgid "Choose your password"
 msgstr "Scegli la tua password"
-
-#~ msgid "Clear all legacy storage data"
-#~ msgstr "Cancella tutti i dati legacy in archivio"
-
-#~ msgid "Clear all legacy storage data (restart after this)"
-#~ msgstr "Cancella tutti i dati legacy in archivio (poi ricomincia)"
 
 #: src/screens/Settings/Settings.tsx:342
 msgid "Clear all storage data"
@@ -1620,13 +1301,6 @@ msgstr "Cancella tutti i dati in archivio (poi ricomincia)"
 msgid "Clear search query"
 msgstr "Annulla la ricerca"
 
-#~ msgid "Clears all legacy storage data"
-#~ msgstr "Cancella tutti i dati di archiviazione legacy"
-
-#: src/view/screens/Settings/index.tsx:878
-#~ msgid "Clears all storage data"
-#~ msgstr "Cancella tutti i dati di archiviazione"
-
 #: src/view/screens/Support.tsx:41
 msgid "click here"
 msgstr "clicca qui"
@@ -1639,15 +1313,9 @@ msgstr "Clicca qui per maggiori informazioni riguardo la disattivazione del tuo 
 msgid "Click here for more information."
 msgstr "Clicca qui per maggiori informazioni."
 
-#~ msgid "Click here to add one."
-#~ msgstr "Clicca qui per aggiungerne uno."
-
 #: src/components/TagMenu/index.web.tsx:152
 msgid "Click here to open tag menu for {tag}"
 msgstr "Clicca qui per aprire il menu per {tag}"
-
-#~ msgid "Click here to open tag menu for #{tag}"
-#~ msgstr "Clicca qui per aprire il menu per #{tag}"
 
 #: src/components/dialogs/PostInteractionSettingsDialog.tsx:304
 msgid "Click to disable quote posts of this post."
@@ -1667,13 +1335,12 @@ msgstr "Clima"
 
 #: src/components/dms/ChatEmptyPill.tsx:39
 msgid "Clip 🐴 clop 🐴"
-msgstr ""
+msgstr "Clip 🐴 clop 🐴"
 
 #: src/components/dialogs/GifSelect.tsx:281
 #: src/components/dialogs/VerifyEmailDialog.tsx:289
 #: src/components/dms/dialogs/SearchablePeopleList.tsx:263
-#: src/components/NewskieDialog.tsx:146
-#: src/components/NewskieDialog.tsx:153
+#: src/components/NewskieDialog.tsx:146 src/components/NewskieDialog.tsx:153
 #: src/components/StarterPack/Wizard/WizardEditListDialog.tsx:117
 #: src/components/StarterPack/Wizard/WizardEditListDialog.tsx:123
 #: src/view/com/modals/ChangePassword.tsx:268
@@ -1711,15 +1378,11 @@ msgstr "Chiudi l'immagine"
 msgid "Close image viewer"
 msgstr "Chiudi il visualizzatore di immagini"
 
-#~ msgid "Close modal"
-#~ msgstr "Chiudi finestra"
-
 #: src/view/shell/index.web.tsx:68
 msgid "Close navigation footer"
 msgstr "Chiudi la navigazione del footer"
 
-#: src/components/Menu/index.tsx:230
-#: src/components/TagMenu/index.tsx:261
+#: src/components/Menu/index.tsx:230 src/components/TagMenu/index.tsx:261
 msgid "Close this dialog"
 msgstr "Chiudi la finestra"
 
@@ -1730,10 +1393,6 @@ msgstr "Chiude la barra di navigazione in basso"
 #: src/screens/Login/PasswordUpdatedForm.tsx:33
 msgid "Closes password update alert"
 msgstr "Chiude l'avviso di aggiornamento della password"
-
-#: src/view/com/composer/Composer.tsx:552
-#~ msgid "Closes post composer and discards post draft"
-#~ msgstr "Chiude l'editore del post ed elimina la bozza del post"
 
 #: src/view/com/lightbox/ImageViewing/components/ImageDefaultHeader.tsx:37
 msgid "Closes viewer for header image"
@@ -1751,18 +1410,15 @@ msgstr "Comprime l'elenco degli utenti per una determinata notifica"
 msgid "Color mode"
 msgstr "Modalità colore"
 
-#: src/screens/Onboarding/index.tsx:38
-#: src/screens/Onboarding/state.ts:84
+#: src/screens/Onboarding/index.tsx:38 src/screens/Onboarding/state.ts:84
 msgid "Comedy"
 msgstr "Commedia"
 
-#: src/screens/Onboarding/index.tsx:24
-#: src/screens/Onboarding/state.ts:85
+#: src/screens/Onboarding/index.tsx:24 src/screens/Onboarding/state.ts:85
 msgid "Comics"
 msgstr "Fumetti"
 
-#: src/Navigation.tsx:279
-#: src/view/screens/CommunityGuidelines.tsx:34
+#: src/Navigation.tsx:279 src/view/screens/CommunityGuidelines.tsx:34
 msgid "Community Guidelines"
 msgstr "Linee guida della community"
 
@@ -1776,7 +1432,7 @@ msgstr "Completa la challenge"
 
 #: src/view/shell/desktop/LeftNav.tsx:314
 msgid "Compose new post"
-msgstr ""
+msgstr "Scrivi un nuovo post"
 
 #: src/view/com/composer/Composer.tsx:794
 msgid "Compose posts up to {MAX_GRAPHEME_LENGTH} characters in length"
@@ -1788,13 +1444,7 @@ msgstr "Scrivi la risposta"
 
 #: src/view/com/composer/Composer.tsx:1613
 msgid "Compressing video..."
-msgstr ""
-
-#~ msgid "Compressing..."
-#~ msgstr "Compressione in corso..."
-
-#~ msgid "Configure content filtering setting for category: {0}"
-#~ msgstr "Configura l'impostazione del filtro dei contenuti per la categoria:{0}"
+msgstr "Compressione del video..."
 
 #: src/components/moderation/LabelPreference.tsx:82
 msgid "Configure content filtering setting for category: {name}"
@@ -1807,18 +1457,13 @@ msgstr "Configurato nelle <0>impostazioni di moderazione</0>."
 #: src/components/dialogs/VerifyEmailDialog.tsx:253
 #: src/components/dialogs/VerifyEmailDialog.tsx:260
 #: src/components/dialogs/VerifyEmailDialog.tsx:283
-#: src/components/Prompt.tsx:172
-#: src/components/Prompt.tsx:175
+#: src/components/Prompt.tsx:172 src/components/Prompt.tsx:175
 #: src/screens/Settings/components/DisableEmail2FADialog.tsx:185
 #: src/screens/Settings/components/DisableEmail2FADialog.tsx:188
 #: src/view/com/modals/VerifyEmail.tsx:239
 #: src/view/com/modals/VerifyEmail.tsx:241
 msgid "Confirm"
 msgstr "Conferma"
-
-#~ msgctxt "action"
-#~ msgid "Confirm"
-#~ msgstr "Conferma"
 
 #: src/view/com/modals/ChangeEmail.tsx:188
 #: src/view/com/modals/ChangeEmail.tsx:190
@@ -1832,9 +1477,6 @@ msgstr "Conferma le impostazioni della lingua del contenuto"
 #: src/view/com/modals/DeleteAccount.tsx:283
 msgid "Confirm delete account"
 msgstr "Conferma l'eliminazione dell'account"
-
-#~ msgid "Confirm your age to enable adult content."
-#~ msgstr "Conferma la tua età per abilitare i contenuti per adulti."
 
 #: src/screens/Moderation/index.tsx:308
 msgid "Confirm your age:"
@@ -1859,41 +1501,26 @@ msgstr "Codice di conferma"
 msgid "Confirmation Code"
 msgstr "Codice di conferma"
 
-#~ msgid "Confirms signing up {email} to the waitlist"
-#~ msgstr "Conferma l'iscrizione di {email} alla lista d'attesa"
-
 #: src/screens/Login/LoginForm.tsx:309
 msgid "Connecting..."
 msgstr "Connessione in corso..."
 
-#: src/screens/Signup/index.tsx:175
-#: src/screens/Signup/index.tsx:178
+#: src/screens/Signup/index.tsx:175 src/screens/Signup/index.tsx:178
 msgid "Contact support"
 msgstr "Contatta il supporto"
 
-#~ msgid "content"
-#~ msgstr "contenuto"
-
 #: src/screens/Settings/AccessibilitySettings.tsx:102
-#: src/screens/Settings/Settings.tsx:167
-#: src/screens/Settings/Settings.tsx:170
+#: src/screens/Settings/Settings.tsx:167 src/screens/Settings/Settings.tsx:170
 msgid "Content and media"
-msgstr ""
+msgstr "Contenuti e media"
 
-#: src/Navigation.tsx:353
-#: src/screens/Settings/ContentAndMediaSettings.tsx:36
+#: src/Navigation.tsx:353 src/screens/Settings/ContentAndMediaSettings.tsx:36
 msgid "Content and Media"
-msgstr ""
+msgstr "Contenuti e media"
 
 #: src/lib/moderation/useGlobalLabelStrings.ts:18
 msgid "Content Blocked"
 msgstr "Contenuto Bloccato"
-
-#~ msgid "Content filtering"
-#~ msgstr "Filtro dei contenuti"
-
-#~ msgid "Content Filtering"
-#~ msgstr "Filtro dei Contenuti"
 
 #: src/screens/Moderation/index.tsx:292
 msgid "Content filters"
@@ -1943,12 +1570,6 @@ msgstr "Continua thread..."
 msgid "Continue to next step"
 msgstr "Vai al passaggio successivo"
 
-#~ msgid "Continue to the next step"
-#~ msgstr "Vai al passaggio successivo"
-
-#~ msgid "Continue to the next step without following any accounts"
-#~ msgstr "Vai al passaggio successivo senza seguire nessun account"
-
 #: src/screens/Messages/components/ChatListItem.tsx:164
 msgid "Conversation deleted"
 msgstr "Conversazione cancellata"
@@ -1965,8 +1586,7 @@ msgstr "Copiato"
 msgid "Copied build version to clipboard"
 msgstr "Versione di build copiata nella clipboard"
 
-#: src/components/dms/MessageMenu.tsx:57
-#: src/lib/sharing.ts:25
+#: src/components/dms/MessageMenu.tsx:57 src/lib/sharing.ts:25
 #: src/view/com/modals/InviteCodes.tsx:153
 #: src/view/com/util/forms/PostDropdownBtn.tsx:240
 #: src/view/com/util/post-ctrls/PostCtrls.tsx:386
@@ -1978,38 +1598,29 @@ msgstr "Copiato nel clipboard"
 msgid "Copied!"
 msgstr "Copiato!"
 
-#: src/view/com/modals/AddAppPasswords.tsx:215
-#~ msgid "Copies app password"
-#~ msgstr "Copia la password dell'app"
-
 #: src/components/StarterPack/QrCodeDialog.tsx:175
 msgid "Copy"
 msgstr "Copia"
 
-#: src/view/com/modals/ChangeHandle.tsx:467
-#~ msgid "Copy {0}"
-#~ msgstr "Copia {0}"
-
 #: src/screens/Settings/components/AddAppPasswordDialog.tsx:196
 msgid "Copy App Password"
-msgstr ""
+msgstr "Copia password dell'app"
 
 #: src/screens/Settings/AboutSettings.tsx:61
 msgid "Copy build version to clipboard"
-msgstr ""
+msgstr "Copia versione build negli appunti"
 
-#: src/components/dialogs/Embed.tsx:122
-#: src/components/dialogs/Embed.tsx:141
+#: src/components/dialogs/Embed.tsx:122 src/components/dialogs/Embed.tsx:141
 msgid "Copy code"
 msgstr "Copia il codice"
 
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:472
 msgid "Copy DID"
-msgstr ""
+msgstr "Copia DID"
 
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:405
 msgid "Copy host"
-msgstr ""
+msgstr "Copia host"
 
 #: src/components/StarterPack/ShareDialog.tsx:124
 msgid "Copy link"
@@ -2028,9 +1639,6 @@ msgstr "Copia il link alla lista"
 msgid "Copy link to post"
 msgstr "Copia il link al post"
 
-#~ msgid "Copy link to profile"
-#~ msgstr "Copia il link al profilo"
-
 #: src/components/dms/MessageMenu.tsx:110
 #: src/components/dms/MessageMenu.tsx:112
 msgid "Copy message text"
@@ -2047,15 +1655,11 @@ msgstr "Copia codice QR"
 
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:426
 msgid "Copy TXT record value"
-msgstr ""
+msgstr "Copia valore del record TXT"
 
-#: src/Navigation.tsx:284
-#: src/view/screens/CopyrightPolicy.tsx:31
+#: src/Navigation.tsx:284 src/view/screens/CopyrightPolicy.tsx:31
 msgid "Copyright Policy"
 msgstr "Politica sul diritto d'autore"
-
-#~ msgid "Could not compress video"
-#~ msgstr "Impossibile comprimere il video"
 
 #: src/components/dms/LeaveConvoPrompt.tsx:39
 msgid "Could not leave chat"
@@ -2069,9 +1673,6 @@ msgstr "Feed non caricato"
 msgid "Could not load list"
 msgstr "No si è potuto caricare la lista"
 
-#~ msgid "Could not load profiles. Please try again later."
-#~ msgstr "Impossibile caricare i profili. Per favore riprova più tardi."
-
 #: src/components/dms/ConvoMenu.tsx:88
 msgid "Could not mute chat"
 msgstr "Errore nel silenziare la conversazione"
@@ -2080,19 +1681,9 @@ msgstr "Errore nel silenziare la conversazione"
 msgid "Could not process your video"
 msgstr "Impossibile processare il tuo video"
 
-#~ msgid "Country"
-#~ msgstr "Paese"
-
 #: src/components/StarterPack/ProfileStarterPacks.tsx:290
 msgid "Create"
 msgstr "Crea"
-
-#~ msgid "Create a new account"
-#~ msgstr "Crea un nuovo account"
-
-#: src/view/screens/Settings/index.tsx:403
-#~ msgid "Create a new Bluesky account"
-#~ msgstr "Crea un nuovo account Bluesky"
 
 #: src/components/StarterPack/QrCodeDialog.tsx:153
 msgid "Create a QR code for a starter pack"
@@ -2117,8 +1708,7 @@ msgstr "Crea account"
 msgid "Create Account"
 msgstr "Crea un account"
 
-#: src/components/dialogs/Signin.tsx:86
-#: src/components/dialogs/Signin.tsx:88
+#: src/components/dialogs/Signin.tsx:86 src/components/dialogs/Signin.tsx:88
 msgid "Create an account"
 msgstr "Crea un account"
 
@@ -2130,17 +1720,10 @@ msgstr "In alternativa crea un avatar"
 msgid "Create another"
 msgstr "Creane un altro"
 
-#: src/view/com/modals/AddAppPasswords.tsx:243
-#~ msgid "Create App Password"
-#~ msgstr "Crea un password per l'app"
-
 #: src/view/com/auth/SplashScreen.tsx:48
 #: src/view/com/auth/SplashScreen.web.tsx:109
 msgid "Create new account"
 msgstr "Crea un nuovo account"
-
-#~ msgid "Create QR code"
-#~ msgstr "Crea codice QR"
 
 #: src/components/ReportDialog/SelectReportOptionView.tsx:101
 msgid "Create report for {0}"
@@ -2150,17 +1733,7 @@ msgstr "Crea un report per {0}"
 msgid "Created {0}"
 msgstr "Creato {0}"
 
-#~ msgid "Created by <0/>"
-#~ msgstr "Creato da <0/>"
-
-#~ msgid "Created by you"
-#~ msgstr "Creato da te"
-
-#~ msgid "Creates a card with a thumbnail. The card links to {url}"
-#~ msgstr "Crea una scheda con una miniatura. La scheda si collega a {url}"
-
-#: src/screens/Onboarding/index.tsx:26
-#: src/screens/Onboarding/state.ts:86
+#: src/screens/Onboarding/index.tsx:26 src/screens/Onboarding/state.ts:86
 msgid "Culture"
 msgstr "Cultura"
 
@@ -2169,25 +1742,13 @@ msgstr "Cultura"
 msgid "Custom"
 msgstr "Personalizzato"
 
-#: src/view/com/modals/ChangeHandle.tsx:375
-#~ msgid "Custom domain"
-#~ msgstr "Dominio personalizzato"
-
-#: src/view/screens/Feeds.tsx:761
-#: src/view/screens/Search/Explore.tsx:391
+#: src/view/screens/Feeds.tsx:761 src/view/screens/Search/Explore.tsx:391
 msgid "Custom feeds built by the community bring you new experiences and help you find the content you love."
 msgstr "I feed personalizzati creati dalla comunità ti offrono nuove esperienze e ti aiutano a trovare contenuti interessanti."
-
-#: src/view/screens/PreferencesExternalEmbeds.tsx:54
-#~ msgid "Customize media from external sites."
-#~ msgstr "Personalizza i media da i siti esterni."
 
 #: src/components/dialogs/PostInteractionSettingsDialog.tsx:289
 msgid "Customize who can interact with this post."
 msgstr "Personalizza chi può interagire con questo post."
-
-#~ msgid "Danger Zone"
-#~ msgstr "Zona di Pericolo"
 
 #: src/screens/Settings/AppearanceSettings.tsx:92
 #: src/screens/Settings/AppearanceSettings.tsx:113
@@ -2202,9 +1763,6 @@ msgstr "Aspetto scuro"
 msgid "Dark theme"
 msgstr "Tema scuro"
 
-#~ msgid "Dark Theme"
-#~ msgstr "Tema scuro"
-
 #: src/screens/Signup/StepInfo/index.tsx:222
 msgid "Date of birth"
 msgstr "Data di nascita"
@@ -2214,10 +1772,6 @@ msgstr "Data di nascita"
 #: src/screens/Settings/components/DeactivateAccountDialog.tsx:73
 msgid "Deactivate account"
 msgstr "Disattiva account"
-
-#: src/view/screens/Settings/index.tsx:785
-#~ msgid "Deactivate my account"
-#~ msgstr "Disattiva il mio account"
 
 #: src/screens/Settings/Settings.tsx:323
 msgid "Debug Moderation"
@@ -2246,12 +1800,9 @@ msgstr "Elimina"
 msgid "Delete account"
 msgstr "Elimina l'account"
 
-#~ msgid "Delete Account"
-#~ msgstr "Elimina l'Account"
-
 #: src/view/com/modals/DeleteAccount.tsx:105
 msgid "Delete Account <0>\"</0><1>{0}</1><2>\"</2>"
-msgstr "Cancella l'account <0>\"</0><1>{0}</1><2>\"</2>"
+msgstr "Elimina l'account <0>\"</0><1>{0}</1><2>\"</2>"
 
 #: src/screens/Settings/AppPasswords.tsx:179
 msgid "Delete app password"
@@ -2263,11 +1814,11 @@ msgstr "Eliminare la password dell'app?"
 
 #: src/screens/Settings/Settings.tsx:330
 msgid "Delete chat declaration record"
-msgstr ""
+msgstr "Elimina il record della dichiarazione della chat"
 
 #: src/components/dms/MessageMenu.tsx:124
 msgid "Delete for me"
-msgstr "Cancella per me"
+msgstr "Elimina per me"
 
 #: src/view/screens/ProfileList.tsx:530
 msgid "Delete List"
@@ -2275,22 +1826,15 @@ msgstr "Elimina la lista"
 
 #: src/components/dms/MessageMenu.tsx:147
 msgid "Delete message"
-msgstr "Cancella messaggio"
+msgstr "Elimina messaggio"
 
 #: src/components/dms/MessageMenu.tsx:122
 msgid "Delete message for me"
-msgstr "Cancella messaggio per me"
+msgstr "Elimina messaggio per me"
 
 #: src/view/com/modals/DeleteAccount.tsx:286
 msgid "Delete my account"
 msgstr "Cancellare account"
-
-#~ msgid "Delete my account…"
-#~ msgstr "Cancella il mio account…"
-
-#: src/view/screens/Settings/index.tsx:807
-#~ msgid "Delete My Account…"
-#~ msgstr "Cancellare Account…"
 
 #: src/view/com/composer/Composer.tsx:802
 #: src/view/com/util/forms/PostDropdownBtn.tsx:653
@@ -2322,15 +1866,11 @@ msgstr "Eliminato"
 #: src/components/dms/MessagesListHeader.tsx:150
 #: src/screens/Messages/components/ChatListItem.tsx:107
 msgid "Deleted Account"
-msgstr ""
+msgstr "Elimina account"
 
 #: src/view/com/post-thread/PostThread.tsx:398
 msgid "Deleted post."
 msgstr "Post eliminato."
-
-#: src/view/screens/Settings/index.tsx:858
-#~ msgid "Deletes the chat declaration record"
-#~ msgstr ""
 
 #: src/screens/Profile/Header/EditProfileDialog.tsx:344
 #: src/view/com/modals/CreateOrEditList.tsx:280
@@ -2342,11 +1882,11 @@ msgstr "Descrizione"
 
 #: src/screens/Profile/Header/EditProfileDialog.tsx:364
 msgid "Description is too long"
-msgstr ""
+msgstr "La descrizione è troppo lunga"
 
 #: src/screens/Profile/Header/EditProfileDialog.tsx:365
 msgid "Description is too long. The maximum number of characters is {DESCRIPTION_MAX_GRAPHEMES}."
-msgstr ""
+msgstr "La descrizione è troppo lunga. Il numero massimo di caratteri è {DESCRIPTION_MAX_GRAPHEMES}."
 
 #: src/view/com/composer/GifAltText.tsx:150
 #: src/view/com/composer/photos/ImageAltTextDialog.tsx:114
@@ -2362,38 +1902,17 @@ msgstr "Stacca citazione"
 msgid "Detach quote post?"
 msgstr "Staccare la citazione del post?"
 
-#~ msgid "Dev Server"
-#~ msgstr "Server di sviluppo"
-
-#: src/screens/Settings/Settings.tsx:234
-#: src/screens/Settings/Settings.tsx:237
+#: src/screens/Settings/Settings.tsx:234 src/screens/Settings/Settings.tsx:237
 msgid "Developer options"
-msgstr ""
-
-#~ msgid "Developer Tools"
-#~ msgstr "Strumenti per sviluppatori"
+msgstr "Opzioni sviluppatore"
 
 #: src/components/WhoCanReply.tsx:175
 msgid "Dialog: adjust who can interact with this post"
 msgstr "Dialog: configura chi può interagire con questo post"
 
-#: src/view/com/composer/Composer.tsx:325
-#~ msgid "Did you want to say anything?"
-#~ msgstr "Volevi dire qualcosa?"
-
 #: src/screens/Settings/AppearanceSettings.tsx:109
 msgid "Dim"
 msgstr "Soffuso"
-
-#~ msgid "Direct messages are here!"
-#~ msgstr "I messaggi diretti sono arrivati!"
-
-#~ msgid "Disable autoplay for GIFs"
-#~ msgstr "Disattiva la riproduzione automatica per le GIF"
-
-#: src/view/screens/AccessibilitySettings.tsx:109
-#~ msgid "Disable autoplay for videos and GIFs"
-#~ msgstr "Disabilita riproduzione automatica per video e GIFs."
 
 #: src/screens/Settings/components/DisableEmail2FADialog.tsx:89
 msgid "Disable Email 2FA"
@@ -2411,8 +1930,7 @@ msgstr "Disattiva sottotitoli"
 #: src/lib/moderation/useLabelBehaviorDescription.ts:32
 #: src/lib/moderation/useLabelBehaviorDescription.ts:42
 #: src/lib/moderation/useLabelBehaviorDescription.ts:68
-#: src/screens/Messages/Settings.tsx:133
-#: src/screens/Messages/Settings.tsx:136
+#: src/screens/Messages/Settings.tsx:133 src/screens/Messages/Settings.tsx:136
 #: src/screens/Moderation/index.tsx:350
 msgid "Disabled"
 msgstr "Disabilitato"
@@ -2425,10 +1943,7 @@ msgstr "Scartare"
 
 #: src/screens/Profile/Header/EditProfileDialog.tsx:81
 msgid "Discard changes?"
-msgstr ""
-
-#~ msgid "Discard draft"
-#~ msgstr "Scarta la bozza"
+msgstr "Scartare le modifiche?"
 
 #: src/view/com/composer/Composer.tsx:663
 msgid "Discard draft?"
@@ -2436,15 +1951,12 @@ msgstr "Scartare la bozza?"
 
 #: src/view/com/composer/Composer.tsx:827
 msgid "Discard post?"
-msgstr ""
+msgstr "Scartare il post?"
 
 #: src/screens/Settings/components/PwiOptOut.tsx:80
 #: src/screens/Settings/components/PwiOptOut.tsx:84
 msgid "Discourage apps from showing my account to logged-out users"
 msgstr "Scoraggia le app dal mostrare il mio account agli utenti disconnessi"
-
-#~ msgid "Discover learns which posts you like as you browse."
-#~ msgstr "Ricerca imparerà quali post ti piacciono nel mentre cerchi."
 
 #: src/view/com/posts/FollowingEmptyState.tsx:70
 #: src/view/com/posts/FollowingEndOfFeed.tsx:71
@@ -2485,15 +1997,15 @@ msgstr "Nome visualizzato"
 
 #: src/view/com/modals/EditProfile.tsx:175
 msgid "Display Name"
-msgstr "Nome Visualizzato"
+msgstr "Nome visualizzato"
 
 #: src/screens/Profile/Header/EditProfileDialog.tsx:333
 msgid "Display name is too long"
-msgstr ""
+msgstr "Il nome visualizzato è troppo lungo"
 
 #: src/screens/Profile/Header/EditProfileDialog.tsx:334
 msgid "Display name is too long. The maximum number of characters is {DISPLAY_NAME_MAX_GRAPHEMES}."
-msgstr ""
+msgstr "Il nome visualizzato è troppo lungo. Il numero massimo di caratteri è {DISPLAY_NAME_MAX_GRAPHEMES}."
 
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:373
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:375
@@ -2504,14 +2016,6 @@ msgstr "Pannello DNS"
 msgid "Do not apply this mute word to users you follow"
 msgstr "Non applicare questa parola silenziata agli utenti seguiti"
 
-#: src/view/com/composer/labels/LabelsBtn.tsx:174
-#~ msgid "Does not contain adult content."
-#~ msgstr ""
-
-#: src/view/com/composer/labels/LabelsBtn.tsx:213
-#~ msgid "Does not contain graphic or disturbing content."
-#~ msgstr ""
-
 #: src/lib/moderation/useGlobalLabelStrings.ts:39
 msgid "Does not include nudity."
 msgstr "Non include nudità."
@@ -2520,16 +2024,9 @@ msgstr "Non include nudità."
 msgid "Doesn't begin or end with a hyphen"
 msgstr "Non inizia o termina con un trattino"
 
-#: src/view/com/modals/ChangeHandle.tsx:468
-#~ msgid "Domain Value"
-#~ msgstr "Valore del dominio"
-
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:488
 msgid "Domain verified!"
 msgstr "Dominio verificato!"
-
-#~ msgid "Don't have an invite code?"
-#~ msgstr "Non hai un codice di invito?"
 
 #: src/components/dialogs/BirthDateSettings.tsx:118
 #: src/components/dialogs/BirthDateSettings.tsx:124
@@ -2567,32 +2064,18 @@ msgstr "Fatto{extraText}"
 msgid "Double tap to close the dialog"
 msgstr "Tocca due volte per chiudere la finestra"
 
-#~ msgid "Double tap to sign in"
-#~ msgstr "Usa il doppio tocco per accedere"
-
 #: src/screens/StarterPack/StarterPackLandingScreen.tsx:317
 msgid "Download Bluesky"
 msgstr "Scarica Bluesky"
-
-#~ msgid "Download Bluesky account data (repository)"
-#~ msgstr "Scarica i dati dell'account Bluesky (archivio)"
 
 #: src/screens/Settings/components/ExportCarDialog.tsx:77
 #: src/screens/Settings/components/ExportCarDialog.tsx:82
 msgid "Download CAR file"
 msgstr "Scarica il file CAR"
 
-#: src/view/com/composer/text-input/TextInput.web.tsx:291
-#: src/components/dialogs/nuxs/TenMillion/index.tsx:622
-#~ msgid "Download image"
-#~ msgstr ""
-
 #: src/view/com/composer/text-input/TextInput.web.tsx:327
 msgid "Drop to add images"
 msgstr "Trascina e rilascia per aggiungere immagini"
-
-#~ msgid "Due to Apple policies, adult content can only be enabled on the web after completing sign up."
-#~ msgstr "A causa delle politiche di Apple, i contenuti per adulti possono essere abilitati sul Web solo dopo aver completato la registrazione."
 
 #: src/components/dialogs/MutedWords.tsx:153
 msgid "Duration:"
@@ -2645,8 +2128,7 @@ msgstr "Ogni codice funziona per un solo uso. Riceverai periodicamente più codi
 #: src/screens/Settings/AccountSettings.tsx:105
 #: src/screens/StarterPack/StarterPackScreen.tsx:574
 #: src/screens/StarterPack/Wizard/index.tsx:560
-#: src/screens/StarterPack/Wizard/index.tsx:567
-#: src/view/screens/Feeds.tsx:386
+#: src/screens/StarterPack/Wizard/index.tsx:567 src/view/screens/Feeds.tsx:386
 #: src/view/screens/Feeds.tsx:454
 msgid "Edit"
 msgstr "Modifica"
@@ -2656,8 +2138,7 @@ msgctxt "action"
 msgid "Edit"
 msgstr "Modifica"
 
-#: src/view/com/util/UserAvatar.tsx:347
-#: src/view/com/util/UserBanner.tsx:95
+#: src/view/com/util/UserAvatar.tsx:347 src/view/com/util/UserBanner.tsx:95
 msgid "Edit avatar"
 msgstr "Modifica l'avatar"
 
@@ -2684,10 +2165,8 @@ msgstr "Modifica i dettagli della lista"
 msgid "Edit Moderation List"
 msgstr "Modifica l'elenco di moderazione"
 
-#: src/Navigation.tsx:294
-#: src/view/screens/Feeds.tsx:384
-#: src/view/screens/Feeds.tsx:452
-#: src/view/screens/SavedFeeds.tsx:116
+#: src/Navigation.tsx:294 src/view/screens/Feeds.tsx:384
+#: src/view/screens/Feeds.tsx:452 src/view/screens/SavedFeeds.tsx:116
 msgid "Edit My Feeds"
 msgstr "Modifica i miei feed"
 
@@ -2716,9 +2195,6 @@ msgstr "Modifica il profilo"
 msgid "Edit Profile"
 msgstr "Modifica il Profilo"
 
-#~ msgid "Edit Saved Feeds"
-#~ msgstr "Modifica i feed memorizzati"
-
 #: src/screens/StarterPack/StarterPackScreen.tsx:566
 msgid "Edit starter pack"
 msgstr "Modifica starter pack"
@@ -2743,13 +2219,9 @@ msgstr "Modifica la descrizione del tuo profilo"
 msgid "Edit your starter pack"
 msgstr "Modifica il tuo starter pack"
 
-#: src/screens/Onboarding/index.tsx:31
-#: src/screens/Onboarding/state.ts:88
+#: src/screens/Onboarding/index.tsx:31 src/screens/Onboarding/state.ts:88
 msgid "Education"
 msgstr "Formazione scolastica"
-
-#~ msgid "Either choose \"Everybody\" or \"Nobody\""
-#~ msgstr "Scegli \"Everybody\" o \"Nobody\\"
 
 #: src/screens/Settings/AccountSettings.tsx:53
 #: src/screens/Signup/StepInfo/index.tsx:170
@@ -2790,10 +2262,6 @@ msgstr "Email verificata"
 msgid "Email Verified"
 msgstr "Email Verificata"
 
-#: src/view/screens/Settings/index.tsx:320
-#~ msgid "Email:"
-#~ msgstr "Email:"
-
 #: src/components/dialogs/Embed.tsx:113
 msgid "Embed HTML code"
 msgstr "Incorpora il codice HTML"
@@ -2811,7 +2279,7 @@ msgstr "Incorpora questo post nel tuo sito web. Copia il seguente ritaglio e inc
 #: src/screens/Settings/components/Email2FAToggle.tsx:56
 #: src/screens/Settings/components/Email2FAToggle.tsx:60
 msgid "Enable"
-msgstr ""
+msgstr "Abilita"
 
 #: src/components/dialogs/EmbedConsent.tsx:100
 msgid "Enable {0} only"
@@ -2821,23 +2289,14 @@ msgstr "Attiva {0} solo"
 msgid "Enable adult content"
 msgstr "Attiva il contenuto per adulti"
 
-#~ msgid "Enable Adult Content"
-#~ msgstr "Attiva Contenuto per Adulti"
-
-#~ msgid "Enable adult content in your feeds"
-#~ msgstr "Abilita i contenuti per adulti nei tuoi feed"
-
 #: src/screens/Settings/components/Email2FAToggle.tsx:53
 msgid "Enable Email 2FA"
-msgstr ""
+msgstr "Abilita 2FA via email"
 
 #: src/components/dialogs/EmbedConsent.tsx:81
 #: src/components/dialogs/EmbedConsent.tsx:88
 msgid "Enable external media"
 msgstr "Abilita i media esterni"
-
-#~ msgid "Enable External Media"
-#~ msgstr "Attiva Media Esterna"
 
 #: src/screens/Settings/ExternalMediaPreferences.tsx:43
 msgid "Enable media players for"
@@ -2852,15 +2311,11 @@ msgstr "Attiva notifiche prioritarie"
 msgid "Enable subtitles"
 msgstr "Attiva sottotitoli"
 
-#~ msgid "Enable this setting to only see replies between people you follow."
-#~ msgstr "Abilita questa impostazione per vedere solo le risposte delle persone che segui."
-
 #: src/components/dialogs/EmbedConsent.tsx:93
 msgid "Enable this source only"
 msgstr "Abilita solo questa fonte"
 
-#: src/screens/Messages/Settings.tsx:124
-#: src/screens/Messages/Settings.tsx:127
+#: src/screens/Messages/Settings.tsx:124 src/screens/Messages/Settings.tsx:127
 #: src/screens/Moderation/index.tsx:348
 msgid "Enabled"
 msgstr "Abilitato"
@@ -2872,10 +2327,6 @@ msgstr "Fine del feed"
 #: src/view/com/composer/videos/SubtitleDialog.tsx:159
 msgid "Ensure you have selected a language for each subtitle file."
 msgstr "Assicurati di aver selezionato una lingua per ogni file dei sottotitoli."
-
-#: src/view/com/modals/AddAppPasswords.tsx:161
-#~ msgid "Enter a name for this App Password"
-#~ msgstr "Inserisci un nome per questa password dell'app"
 
 #: src/screens/Login/SetNewPasswordForm.tsx:133
 msgid "Enter a password"
@@ -2894,9 +2345,6 @@ msgstr "Inserisci Codice"
 msgid "Enter Confirmation Code"
 msgstr "Inserire il codice di conferma"
 
-#~ msgid "Enter the address of your provider:"
-#~ msgstr "Inserisci l'indirizzo del tuo provider:"
-
 #: src/view/com/modals/ChangePassword.tsx:154
 msgid "Enter the code you received to change your password."
 msgstr "Inserisci il codice che hai ricevuto per modificare la tua password."
@@ -2913,9 +2361,6 @@ msgstr "Inserisci l'e-mail che hai utilizzato per creare il tuo account. Ti invi
 msgid "Enter your birth date"
 msgstr "Inserisci la tua data di nascita"
 
-#~ msgid "Enter your email"
-#~ msgstr "Inserisci la tua email"
-
 #: src/screens/Login/ForgotPasswordForm.tsx:99
 #: src/screens/Signup/StepInfo/index.tsx:182
 msgid "Enter your email address"
@@ -2929,16 +2374,13 @@ msgstr "Inserisci la tua nuova email qui sopra"
 msgid "Enter your new email address below."
 msgstr "Inserisci il tuo nuovo indirizzo email qui sotto."
 
-#~ msgid "Enter your phone number"
-#~ msgstr "Inserisci il tuo numero di telefono"
-
 #: src/screens/Login/index.tsx:98
 msgid "Enter your username and password"
 msgstr "Inserisci il tuo nome utente e la tua password"
 
 #: src/view/com/composer/Composer.tsx:1622
 msgid "Error"
-msgstr ""
+msgstr "Errore"
 
 #: src/screens/Settings/components/ExportCarDialog.tsx:47
 msgid "Error occurred while saving file"
@@ -2965,8 +2407,7 @@ msgstr "Tutti possono rispondere"
 msgid "Everybody can reply to this post."
 msgstr "Tutto possono rispondere a questo post."
 
-#: src/screens/Messages/Settings.tsx:77
-#: src/screens/Messages/Settings.tsx:80
+#: src/screens/Messages/Settings.tsx:77 src/screens/Messages/Settings.tsx:80
 msgid "Everyone"
 msgstr "Tutti"
 
@@ -2994,10 +2435,6 @@ msgstr "Esci da schermo intero"
 msgid "Exits account deletion process"
 msgstr "Uscita dall'eliminazione dell'account"
 
-#: src/view/com/modals/ChangeHandle.tsx:138
-#~ msgid "Exits handle change process"
-#~ msgstr "Uscita dal processo di modifica"
-
 #: src/view/com/modals/CropImage.web.tsx:95
 msgid "Exits image cropping process"
 msgstr "Uscita dal processo di ritaglio dell'immagine"
@@ -3009,9 +2446,6 @@ msgstr "Uscita dalla visualizzazione dell'immagine"
 #: src/view/com/modals/ListAddRemoveUsers.tsx:89
 msgid "Exits inputting search query"
 msgstr "Uscita dall'inserzione della domanda di ricerca"
-
-#~ msgid "Exits signing up for waitlist with {email}"
-#~ msgstr "Uscita dall'iscrizione alla lista d'attesa con {email}"
 
 #: src/view/com/lightbox/Lightbox.web.tsx:182
 msgid "Expand alt text"
@@ -3033,11 +2467,7 @@ msgstr ""
 #: src/screens/Settings/FollowingFeedPreferences.tsx:116
 #: src/screens/Settings/ThreadPreferences.tsx:124
 msgid "Experimental"
-msgstr ""
-
-#: src/view/screens/NotificationsSettings.tsx:78
-#~ msgid "Experimental: When this preference is enabled, you'll only receive reply and quote notifications from users you follow. We'll continue to add more controls here over time."
-#~ msgstr "SPERIMENTALE: Abilitando questa opzione, riceverai notifiche esclusivamente dagli utenti che segui. Continueremo ad aggiungere nuovi controlli in futuro."
+msgstr "Sperimentale"
 
 #: src/components/dialogs/MutedWords.tsx:500
 msgid "Expired"
@@ -3067,7 +2497,7 @@ msgstr "Esporta i miei dati"
 #: src/screens/Settings/ContentAndMediaSettings.tsx:65
 #: src/screens/Settings/ContentAndMediaSettings.tsx:68
 msgid "External media"
-msgstr ""
+msgstr "Media esterno"
 
 #: src/components/dialogs/EmbedConsent.tsx:54
 #: src/components/dialogs/EmbedConsent.tsx:58
@@ -3079,27 +2509,17 @@ msgstr "Media esterni"
 msgid "External media may allow websites to collect information about you and your device. No information is sent or requested until you press the \"play\" button."
 msgstr "I multimediali esterni possono consentire ai siti web di raccogliere informazioni su di te e sul tuo dispositivo. Nessuna informazione viene inviata o richiesta finché non si preme il pulsante \"Riproduci\"."
 
-#: src/Navigation.tsx:313
-#: src/screens/Settings/ExternalMediaPreferences.tsx:29
+#: src/Navigation.tsx:313 src/screens/Settings/ExternalMediaPreferences.tsx:29
 msgid "External Media Preferences"
 msgstr "Preferenze multimediali esterni"
 
-#: src/view/screens/Settings/index.tsx:637
-#~ msgid "External media settings"
-#~ msgstr "Impostazioni multimediali esterni"
-
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:553
 msgid "Failed to change handle. Please try again."
-msgstr ""
-
-#: src/view/com/modals/AddAppPasswords.tsx:119
-#: src/view/com/modals/AddAppPasswords.tsx:123
-#~ msgid "Failed to create app password."
-#~ msgstr "Impossibile creare la password dell'app."
+msgstr "Non è stato possibile cambiare il nome utente. Riprovare."
 
 #: src/screens/Settings/components/AddAppPasswordDialog.tsx:173
 msgid "Failed to create app password. Please try again."
-msgstr ""
+msgstr "Errore durante la creazione della password dell'app. Riprovare."
 
 #: src/screens/StarterPack/Wizard/index.tsx:238
 #: src/screens/StarterPack/Wizard/index.tsx:246
@@ -3134,9 +2554,6 @@ msgstr "Impossibile caricare GIF"
 #: src/screens/Messages/components/MessageListError.tsx:23
 msgid "Failed to load past messages"
 msgstr "Impossibile caricare messaggi vecchi"
-
-#~ msgid "Failed to load recommended feeds"
-#~ msgstr "Impossibile caricare feed consigliati"
 
 #: src/view/screens/Search/Explore.tsx:420
 #: src/view/screens/Search/Explore.tsx:448
@@ -3180,75 +2597,50 @@ msgstr "Impossbile aggiornare i feed"
 msgid "Failed to update settings"
 msgstr "Errore nell'aggiornamento delle impostazioni"
 
-#: src/lib/media/video/upload.ts:72
-#: src/lib/media/video/upload.web.ts:74
-#: src/lib/media/video/upload.web.ts:78
-#: src/lib/media/video/upload.web.ts:88
+#: src/lib/media/video/upload.ts:72 src/lib/media/video/upload.web.ts:74
+#: src/lib/media/video/upload.web.ts:78 src/lib/media/video/upload.web.ts:88
 msgid "Failed to upload video"
 msgstr "Errore nel caricamento video"
 
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:341
 msgid "Failed to verify handle. Please try again."
-msgstr ""
+msgstr "Impossibile verificare il nome utente. Riprovare."
 
 #: src/Navigation.tsx:229
 msgid "Feed"
 msgstr "Feed"
 
-#: src/components/FeedCard.tsx:134
-#: src/view/com/feeds/FeedSourceCard.tsx:253
+#: src/components/FeedCard.tsx:134 src/view/com/feeds/FeedSourceCard.tsx:253
 msgid "Feed by {0}"
 msgstr "Feed creato da {0}"
-
-#~ msgid "Feed offline"
-#~ msgstr "Feed offline"
-
-#~ msgid "Feed Preferences"
-#~ msgstr "Preferenze del feed"
 
 #: src/components/StarterPack/Wizard/WizardListCard.tsx:55
 msgid "Feed toggle"
 msgstr ""
 
-#: src/view/shell/desktop/RightNav.tsx:70
-#: src/view/shell/Drawer.tsx:319
+#: src/view/shell/desktop/RightNav.tsx:70 src/view/shell/Drawer.tsx:319
 msgid "Feedback"
 msgstr "Commenti"
 
 #: src/view/com/util/forms/PostDropdownBtn.tsx:271
 #: src/view/com/util/forms/PostDropdownBtn.tsx:280
 msgid "Feedback sent!"
-msgstr ""
+msgstr "Feedback inviato!"
 
-#: src/Navigation.tsx:388
-#: src/screens/StarterPack/StarterPackScreen.tsx:183
-#: src/view/screens/Feeds.tsx:446
-#: src/view/screens/Feeds.tsx:552
-#: src/view/screens/Profile.tsx:232
-#: src/view/screens/Search/Search.tsx:537
-#: src/view/shell/desktop/LeftNav.tsx:457
-#: src/view/shell/Drawer.tsx:476
+#: src/Navigation.tsx:388 src/screens/StarterPack/StarterPackScreen.tsx:183
+#: src/view/screens/Feeds.tsx:446 src/view/screens/Feeds.tsx:552
+#: src/view/screens/Profile.tsx:232 src/view/screens/Search/Search.tsx:537
+#: src/view/shell/desktop/LeftNav.tsx:457 src/view/shell/Drawer.tsx:476
 msgid "Feeds"
 msgstr "Feed"
-
-#~ msgid "Feeds are created by users to curate content. Choose some feeds that you find interesting."
-#~ msgstr "I feed vengono creati dagli utenti per curare i contenuti. Scegli alcuni feed che ritieni interessanti."
 
 #: src/view/screens/SavedFeeds.tsx:205
 msgid "Feeds are custom algorithms that users build with a little coding expertise. <0/> for more information."
 msgstr "I feed sono algoritmi personalizzati che gli utenti creano con un minimo di esperienza nella codifica. Vedi <0/> per ulteriori informazioni."
 
-#~ msgid "Feeds can be topical as well!"
-#~ msgstr "I feed possono anche avere tematiche!"
-
-#: src/components/FeedCard.tsx:273
-#: src/view/screens/SavedFeeds.tsx:83
+#: src/components/FeedCard.tsx:273 src/view/screens/SavedFeeds.tsx:83
 msgid "Feeds updated!"
 msgstr "Feed aggiornati!"
-
-#: src/view/com/modals/ChangeHandle.tsx:468
-#~ msgid "File Contents"
-#~ msgstr "Archivia i contenuti"
 
 #: src/screens/Settings/components/ExportCarDialog.tsx:43
 msgid "File saved successfully!"
@@ -3268,39 +2660,13 @@ msgstr "Finalizzando"
 msgid "Find accounts to follow"
 msgstr "Scopri account da seguire"
 
-#~ msgid "Find more feeds and accounts to follow in the Explore page."
-#~ msgstr "Scopri nuovi account e feed da seguire in Esplora."
-
 #: src/view/screens/Search/Search.tsx:612
 msgid "Find posts and users on Bluesky"
 msgstr "Scopri post e utenti su Bluesky"
 
-#~ msgid "Find users on Bluesky"
-#~ msgstr "Scopri utenti su Bluesky"
-
-#~ msgid "Find users with the search tool on the right"
-#~ msgstr "Scopri gli utenti con lo strumento di ricerca sulla destra"
-
-#~ msgid "Finding similar accounts..."
-#~ msgstr "Scoprendo account simili…"
-
-#: src/view/screens/PreferencesFollowingFeed.tsx:52
-#~ msgid "Fine-tune the content you see on your Following feed."
-#~ msgstr "Ottimizza il contenuto che vedi nel tuo Following feed."
-
-#~ msgid "Fine-tune the content you see on your home screen."
-#~ msgstr "Ottimizza il contenuto che vedi nella Home."
-
-#: src/view/screens/PreferencesThreads.tsx:55
-#~ msgid "Fine-tune the discussion threads."
-#~ msgstr "Ottimizza la visualizzazione delle discussioni."
-
 #: src/screens/StarterPack/Wizard/index.tsx:200
 msgid "Finish"
 msgstr "Finalizza"
-
-#~ msgid "Finish tour and begin using the application"
-#~ msgstr "Termina il tour ed inizia ad usare l'app"
 
 #: src/screens/Onboarding/index.tsx:35
 msgid "Fitness"
@@ -3309,12 +2675,6 @@ msgstr "Fitness"
 #: src/screens/Onboarding/StepFinished.tsx:272
 msgid "Flexible"
 msgstr "Flessibile"
-
-#~ msgid "Flip horizontal"
-#~ msgstr "Gira in orizzontale"
-
-#~ msgid "Flip vertically"
-#~ msgstr "Gira in verticale"
 
 #. User is not following this account, click to follow
 #: src/components/ProfileCard.tsx:358
@@ -3353,9 +2713,6 @@ msgstr "Segui l'Account"
 msgid "Follow all"
 msgstr "Segui tutti"
 
-#~ msgid "Follow All"
-#~ msgstr "Segui tutti"
-
 #: src/screens/Profile/Header/ProfileHeaderStandard.tsx:232
 #: src/view/com/post-thread/PostThreadFollowBtn.tsx:130
 msgid "Follow Back"
@@ -3369,18 +2726,6 @@ msgstr ""
 #: src/view/screens/Search/Explore.tsx:334
 msgid "Follow more accounts to get connected to your interests and build your network."
 msgstr "Segui altri account per connetterti ai tuoi interessi e crea il tuo network personale."
-
-#~ msgid "Follow selected accounts and continue to the next step"
-#~ msgstr "Segui gli account selezionati e vai al passaggio successivo"
-
-#~ msgid "Follow some users to get started. We can recommend you more users based on who you find interesting."
-#~ msgstr "Segui alcuni utenti per iniziare. Possiamo consigliarti più utenti in base a chi trovi interessante."
-
-#~ msgid "Followed by"
-#~ msgstr "Seguito da"
-
-#~ msgid "Followed by {0}"
-#~ msgstr "Seguito da {0}"
 
 #: src/components/KnownFollowers.tsx:231
 msgid "Followed by <0>{0}</0>"
@@ -3402,17 +2747,6 @@ msgstr "Seguito da <0>{0}</0>, <1>{1}</1>, e {2, plural, one {# altro} other {# 
 msgid "Followed users"
 msgstr "Utenti seguiti"
 
-#~ msgid "Followed users only"
-#~ msgstr "Solo utenti seguiti"
-
-#: src/view/com/notifications/FeedItem.tsx:207
-#~ msgid "followed you"
-#~ msgstr "ti segue"
-
-#: src/view/com/notifications/FeedItem.tsx:205
-#~ msgid "followed you back"
-#~ msgstr "ti ha seguito"
-
 #: src/view/screens/ProfileFollowers.tsx:30
 #: src/view/screens/ProfileFollowers.tsx:31
 msgid "Followers"
@@ -3427,19 +2761,14 @@ msgstr "Follower di @{0} che conosci"
 msgid "Followers you know"
 msgstr "Follower che conosci"
 
-#~ msgid "following"
-#~ msgstr "following"
-
 #. User is following this account, click to unfollow
 #: src/components/ProfileCard.tsx:352
 #: src/components/ProfileHoverCard/index.web.tsx:448
 #: src/components/ProfileHoverCard/index.web.tsx:459
 #: src/screens/Profile/Header/ProfileHeaderStandard.tsx:230
 #: src/view/com/post-thread/PostThreadFollowBtn.tsx:135
-#: src/view/screens/Feeds.tsx:632
-#: src/view/screens/ProfileFollows.tsx:30
-#: src/view/screens/ProfileFollows.tsx:31
-#: src/view/screens/SavedFeeds.tsx:431
+#: src/view/screens/Feeds.tsx:632 src/view/screens/ProfileFollows.tsx:30
+#: src/view/screens/ProfileFollows.tsx:31 src/view/screens/SavedFeeds.tsx:431
 msgid "Following"
 msgstr "Following"
 
@@ -3457,13 +2786,9 @@ msgstr "Stai segendo {name}"
 msgid "Following feed preferences"
 msgstr "Preferenze del feed Following"
 
-#: src/Navigation.tsx:300
-#: src/screens/Settings/FollowingFeedPreferences.tsx:50
+#: src/Navigation.tsx:300 src/screens/Settings/FollowingFeedPreferences.tsx:50
 msgid "Following Feed Preferences"
 msgstr "Preferenze del Following Feed"
-
-#~ msgid "Following shows the latest posts from people you follow."
-#~ msgstr "Il feed Following mostra i post più recenti delle persone che segui."
 
 #: src/screens/Profile/Header/Handle.tsx:33
 msgid "Follows you"
@@ -3475,14 +2800,13 @@ msgstr "Ti Segue"
 
 #: src/screens/Settings/AppearanceSettings.tsx:125
 msgid "Font"
-msgstr ""
+msgstr "Carattere"
 
 #: src/screens/Settings/AppearanceSettings.tsx:145
 msgid "Font size"
 msgstr "Dimensione font"
 
-#: src/screens/Onboarding/index.tsx:40
-#: src/screens/Onboarding/state.ts:89
+#: src/screens/Onboarding/index.tsx:40 src/screens/Onboarding/state.ts:89
 msgid "Food"
 msgstr "Cibo"
 
@@ -3492,11 +2816,7 @@ msgstr "Per motivi di sicurezza, invieremo un codice di conferma al tuo indirizz
 
 #: src/screens/Settings/components/AddAppPasswordDialog.tsx:209
 msgid "For security reasons, you won't be able to view this again. If you lose this app password, you'll need to generate a new one."
-msgstr ""
-
-#: src/view/com/modals/AddAppPasswords.tsx:233
-#~ msgid "For security reasons, you won't be able to view this again. If you lose this password, you'll need to generate a new one."
-#~ msgstr "Per motivi di sicurezza non potrai visualizzarlo nuovamente. Se perdi questa password, dovrai generarne una nuova."
+msgstr "Per motivi di sicurezza non potrai più visualizzarla. Se perdi questa password dell'app, dovrai generarne una nuova."
 
 #: src/screens/Settings/AppearanceSettings.tsx:127
 msgid "For the best experience, we recommend using the theme font."
@@ -3506,14 +2826,7 @@ msgstr "Per una migliore esperienza, consigliamo di usare un font del tema."
 msgid "Forever"
 msgstr "Per sempre"
 
-#~ msgid "Forgot"
-#~ msgstr "Dimenticato"
-
-#~ msgid "Forgot password"
-#~ msgstr "Ho dimenticato la password"
-
-#: src/screens/Login/index.tsx:126
-#: src/screens/Login/index.tsx:141
+#: src/screens/Login/index.tsx:126 src/screens/Login/index.tsx:141
 msgid "Forgot Password"
 msgstr "Hai dimenticato la Password"
 
@@ -3554,9 +2867,6 @@ msgstr "Genera uno starter pack"
 msgid "Get help"
 msgstr "Ottieni aiuto"
 
-#~ msgid "Get started"
-#~ msgstr "Iniziamo"
-
 #: src/view/com/modals/VerifyEmail.tsx:197
 #: src/view/com/modals/VerifyEmail.tsx:199
 msgid "Get Started"
@@ -3580,34 +2890,28 @@ msgstr "Evidenti violazioni della legge o dei termini di servizio"
 
 #: src/components/moderation/ScreenHider.tsx:154
 #: src/components/moderation/ScreenHider.tsx:163
-#: src/view/com/auth/LoggedOut.tsx:72
-#: src/view/screens/NotFound.tsx:57
-#: src/view/screens/ProfileFeed.tsx:113
-#: src/view/screens/ProfileList.tsx:1029
+#: src/view/com/auth/LoggedOut.tsx:72 src/view/screens/NotFound.tsx:57
+#: src/view/screens/ProfileFeed.tsx:113 src/view/screens/ProfileList.tsx:1029
 #: src/view/shell/desktop/LeftNav.tsx:134
 msgid "Go back"
 msgstr "Torna indietro"
 
-#: src/components/Error.tsx:79
-#: src/screens/List/ListHiddenScreen.tsx:210
-#: src/screens/Profile/ErrorState.tsx:62
-#: src/screens/Profile/ErrorState.tsx:66
+#: src/components/Error.tsx:79 src/screens/List/ListHiddenScreen.tsx:210
+#: src/screens/Profile/ErrorState.tsx:62 src/screens/Profile/ErrorState.tsx:66
 #: src/screens/StarterPack/StarterPackScreen.tsx:757
-#: src/view/screens/NotFound.tsx:56
-#: src/view/screens/ProfileFeed.tsx:118
+#: src/view/screens/NotFound.tsx:56 src/view/screens/ProfileFeed.tsx:118
 #: src/view/screens/ProfileList.tsx:1034
 msgid "Go Back"
 msgstr "Torna Indietro"
 
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:529
 msgid "Go back to previous page"
-msgstr ""
+msgstr "Torna alla pagina precedente"
 
 #: src/components/dms/ReportDialog.tsx:149
 #: src/components/ReportDialog/SelectReportOptionView.tsx:80
 #: src/components/ReportDialog/SubmitView.tsx:109
-#: src/screens/Onboarding/Layout.tsx:102
-#: src/screens/Onboarding/Layout.tsx:191
+#: src/screens/Onboarding/Layout.tsx:102 src/screens/Onboarding/Layout.tsx:191
 #: src/screens/Signup/BackNextButtons.tsx:36
 msgid "Go back to previous step"
 msgstr "Torna al passaggio precedente"
@@ -3624,9 +2928,6 @@ msgstr "Torna alla home"
 msgid "Go Home"
 msgstr "Torna alla Home"
 
-#~ msgid "Go to @{queryMaybeHandle}"
-#~ msgstr "Vai a @{queryMaybeHandle}"
-
 #: src/screens/Messages/components/ChatListItem.tsx:264
 msgid "Go to conversation with {0}"
 msgstr "Vai alla conversazione con {0}"
@@ -3639,9 +2940,6 @@ msgstr "Seguente"
 #: src/components/dms/ConvoMenu.tsx:167
 msgid "Go to profile"
 msgstr "Va al profilo"
-
-#~ msgid "Go to the next step of the tour"
-#~ msgstr "Vai avanti"
 
 #: src/components/dms/ConvoMenu.tsx:164
 msgid "Go to user's profile"
@@ -3660,20 +2958,20 @@ msgstr "Siamo a metà!"
 #: src/screens/Settings/AccountSettings.tsx:119
 #: src/screens/Settings/AccountSettings.tsx:124
 msgid "Handle"
-msgstr "Nome Utente"
+msgstr "Nome utente"
 
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:557
 msgid "Handle already taken. Please try a different one."
-msgstr ""
+msgstr "Nome utente già in uso. Prova con uno diverso."
 
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:188
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:325
 msgid "Handle changed!"
-msgstr ""
+msgstr "Nome utente modificato!"
 
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:561
 msgid "Handle too long. Please try a shorter one."
-msgstr ""
+msgstr "Nome utente troppo lungo. Provarne uno più breve."
 
 #: src/screens/Settings/AccessibilitySettings.tsx:80
 msgid "Haptics"
@@ -3695,10 +2993,8 @@ msgstr "Hashtag: #{tag}"
 msgid "Having trouble?"
 msgstr "Ci sono problemi?"
 
-#: src/screens/Settings/Settings.tsx:199
-#: src/screens/Settings/Settings.tsx:203
-#: src/view/shell/desktop/RightNav.tsx:99
-#: src/view/shell/Drawer.tsx:332
+#: src/screens/Settings/Settings.tsx:199 src/screens/Settings/Settings.tsx:203
+#: src/view/shell/desktop/RightNav.tsx:99 src/view/shell/Drawer.tsx:332
 msgid "Help"
 msgstr "Aiuto"
 
@@ -3706,22 +3002,9 @@ msgstr "Aiuto"
 msgid "Help people know you're not a bot by uploading a picture or creating an avatar."
 msgstr "Aiuta le persone a sapere che tu non sei un bot caricando una immagine o creando un avatar."
 
-#~ msgid "Here are some accounts for you to follow"
-#~ msgstr "Ecco alcuni account da seguire"
-
-#~ msgid "Here are some popular topical feeds. You can choose to follow as many as you like."
-#~ msgstr "Ecco alcuni feed più visitati. Puoi seguire quanti ne vuoi."
-
-#~ msgid "Here are some topical feeds based on your interests: {interestsText}. You can choose to follow as many as you like."
-#~ msgstr "Ecco alcuni feed di attualità scelti in base ai tuoi interessi: {interestsText}. Puoi seguire quanti ne vuoi."
-
 #: src/screens/Settings/components/AddAppPasswordDialog.tsx:187
 msgid "Here is your app password!"
-msgstr ""
-
-#: src/view/com/modals/AddAppPasswords.tsx:204
-#~ msgid "Here is your app password."
-#~ msgstr "Ecco la password dell'app."
+msgstr "Ecco la tua password dell'app!"
 
 #: src/components/ListCard.tsx:130
 msgid "Hidden list"
@@ -3742,9 +3025,6 @@ msgstr "Nascondi"
 msgctxt "action"
 msgid "Hide"
 msgstr "Nascondi"
-
-#~ msgid "Hide post"
-#~ msgstr "Nascondi post"
 
 #: src/view/com/util/forms/PostDropdownBtn.tsx:543
 #: src/view/com/util/forms/PostDropdownBtn.tsx:549
@@ -3779,9 +3059,6 @@ msgstr "Nascondere questa risposta?"
 msgid "Hide user list"
 msgstr "Nascondi elenco utenti"
 
-#~ msgid "Hides posts from {0} in your feed"
-#~ msgstr "Nasconde i post di {0} nel tuo feed"
-
 #: src/view/com/posts/FeedErrorMessage.tsx:117
 msgid "Hmm, some kind of issue occurred when contacting the feed server. Please let the feed owner know about this issue."
 msgstr "Si è verificato un problema durante il contatto con il server del feed. Informa il proprietario del feed del problema."
@@ -3814,16 +3091,11 @@ msgstr "Non siamo riusciti a caricare il servizio di moderazione."
 msgid "Hold up! We’re gradually giving access to video, and you’re still waiting in line. Check back soon!"
 msgstr ""
 
-#: src/Navigation.tsx:585
-#: src/Navigation.tsx:605
+#: src/Navigation.tsx:585 src/Navigation.tsx:605
 #: src/view/shell/bottom-bar/BottomBar.tsx:158
-#: src/view/shell/desktop/LeftNav.tsx:401
-#: src/view/shell/Drawer.tsx:391
+#: src/view/shell/desktop/LeftNav.tsx:401 src/view/shell/Drawer.tsx:391
 msgid "Home"
 msgstr "Home"
-
-#~ msgid "Home Feed Preferences"
-#~ msgstr "Preferenze per i feed per la pagina d'inizio"
 
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:398
 msgid "Host:"
@@ -3834,9 +3106,6 @@ msgstr "Hosting:"
 #: src/screens/Signup/StepInfo/index.tsx:133
 msgid "Hosting provider"
 msgstr "Servizio di hosting"
-
-#~ msgid "Hosting provider address"
-#~ msgstr "Indirizzo del fornitore di hosting"
 
 #: src/view/com/modals/InAppBrowserConsent.tsx:41
 msgid "How should we open this link?"
@@ -3871,10 +3140,6 @@ msgstr "Ho capito"
 msgid "If alt text is long, toggles alt text expanded state"
 msgstr "Se il testo alternativo è lungo, attiva/disattiva lo stato del testo alternativo"
 
-#: src/view/com/modals/SelfLabel.tsx:128
-#~ msgid "If none are selected, suitable for all ages."
-#~ msgstr "Se niente è selezionato, adatto a tutte le età."
-
 #: src/screens/Signup/StepInfo/Policies.tsx:110
 msgid "If you are not yet an adult according to the laws of your country, your parent or legal guardian must read these Terms on your behalf."
 msgstr "Se non sei ancora maggiorenne secondo le leggi del tuo Paese, il tuo genitore o tutore legale deve leggere i Termini a tuo nome."
@@ -3885,7 +3150,7 @@ msgstr "Se elimini questa lista, non potrai recuperarla."
 
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:247
 msgid "If you have your own domain, you can use that as your handle. This lets you self-verify your identity – <0>learn more</0>."
-msgstr ""
+msgstr "Se hai un tuo dominio, puoi usarlo come nome utente. Questo consente di auto-verificare la tua identità – <0>ulteriori informazioni</0>."
 
 #: src/view/com/util/forms/PostDropdownBtn.tsx:670
 msgid "If you remove this post, you won't be able to recover it."
@@ -3897,7 +3162,7 @@ msgstr "Se vuoi modificare la password, ti invieremo un codice per verificare se
 
 #: src/screens/Settings/components/DeactivateAccountDialog.tsx:92
 msgid "If you're trying to change your handle or email, do so before you deactivate."
-msgstr "Se stai cercando di cambiare username o email, fallo prima di disattivare l'account."
+msgstr "Se stai cercando di cambiare nome utente o email, fallo prima di disattivare l'account."
 
 #: src/lib/moderation/useReportOptions.ts:38
 msgid "Illegal and Urgent"
@@ -3906,12 +3171,6 @@ msgstr "Illegale e Urgente"
 #: src/view/com/util/images/Gallery.tsx:74
 msgid "Image"
 msgstr "Immagine"
-
-#~ msgid "Image alt text"
-#~ msgstr "Testo alternativo dell'immagine"
-
-#~ msgid "Image options"
-#~ msgstr "Opzioni per l'immagine"
 
 #: src/components/StarterPack/ShareDialog.tsx:77
 msgid "Image saved to your camera roll!"
@@ -3923,7 +3182,7 @@ msgstr "Furto d'identità o false affermazioni sull'identità o sull'affiliazion
 
 #: src/lib/moderation/useReportOptions.ts:68
 msgid "Impersonation, misinformation, or false claims"
-msgstr "Impersonificazione, disinformazione, o affermazioni false."
+msgstr "Impersonificazione, disinformazione, o affermazioni false"
 
 #: src/lib/moderation/useReportOptions.ts:91
 msgid "Inappropriate messages or explicit links"
@@ -3937,16 +3196,6 @@ msgstr "Inserisci il codice inviato alla tua email per reimpostare la password"
 msgid "Input confirmation code for account deletion"
 msgstr "Inserisci il codice di conferma per la cancellazione dell'account"
 
-#~ msgid "Input email for Bluesky account"
-#~ msgstr "Inserisci l'e-mail per l'account di Bluesky"
-
-#~ msgid "Input invite code to proceed"
-#~ msgstr "Inserisci il codice di invito per procedere"
-
-#: src/view/com/modals/AddAppPasswords.tsx:175
-#~ msgid "Input name for app password"
-#~ msgstr "Inserisci il nome per la password dell'app"
-
 #: src/screens/Login/SetNewPasswordForm.tsx:145
 msgid "Input new password"
 msgstr "Inserisci la nuova password"
@@ -3955,48 +3204,25 @@ msgstr "Inserisci la nuova password"
 msgid "Input password for account deletion"
 msgstr "Inserisci la password per la cancellazione dell'account"
 
-#~ msgid "Input phone number for SMS verification"
-#~ msgstr "Inserisci il numero di telefono per la verifica via SMS"
-
 #: src/screens/Login/LoginForm.tsx:270
 msgid "Input the code which has been emailed to you"
 msgstr "Inserisci il codice che ti è stato inviato via email"
-
-#~ msgid "Input the password tied to {identifier}"
-#~ msgstr "Inserisci la password relazionata a {identifier}"
 
 #: src/screens/Login/LoginForm.tsx:200
 msgid "Input the username or email address you used at signup"
 msgstr "Inserisci il nome utente o l'indirizzo email che hai utilizzato al momento della registrazione"
 
-#~ msgid "Input the verification code we have texted to you"
-#~ msgstr "Inserisci il codice di verifica che ti abbiamo inviato tramite SMS"
-
-#~ msgid "Input your email to get on the Bluesky waitlist"
-#~ msgstr "Inserisci la tua email per entrare nella lista d'attesa di Bluesky"
-
 #: src/screens/Login/LoginForm.tsx:225
 msgid "Input your password"
 msgstr "Inserisci la tua password"
 
-#: src/view/com/modals/ChangeHandle.tsx:376
-#~ msgid "Input your preferred hosting provider"
-#~ msgstr "Inserisci il tuo provider di hosting preferito"
-
 #: src/screens/Signup/StepHandle.tsx:114
 msgid "Input your user handle"
-msgstr "Inserisci il tuo identificatore"
+msgstr "Inserisci il tuo nome utente"
 
 #: src/view/com/composer/threadgate/ThreadgateBtn.tsx:50
 msgid "Interaction limited"
 msgstr "Interazione limitata"
-
-#~ msgid "Introducing Direct Messages"
-#~ msgstr "Introduzione ai Messaggi Diretti"
-
-#: src/components/dialogs/nuxs/NeueTypography.tsx:47
-#~ msgid "Introducing new font settings"
-#~ msgstr "Introduzione di nuovi settaggi per i font"
 
 #: src/screens/Login/LoginForm.tsx:142
 #: src/screens/Settings/components/DisableEmail2FADialog.tsx:70
@@ -4005,23 +3231,19 @@ msgstr "Codice di conferma 2FA non valido."
 
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:563
 msgid "Invalid handle. Please try a different one."
-msgstr ""
+msgstr "Nome utente non valido. Provarne un altro."
 
 #: src/view/com/post-thread/PostThreadItem.tsx:272
 msgid "Invalid or unsupported post record"
 msgstr "Protocollo del post non valido o non supportato"
 
-#: src/screens/Login/LoginForm.tsx:88
-#: src/screens/Login/LoginForm.tsx:147
+#: src/screens/Login/LoginForm.tsx:88 src/screens/Login/LoginForm.tsx:147
 msgid "Invalid username or password"
 msgstr "Nome dell'utente o password errato"
 
 #: src/components/intents/VerifyEmailIntentDialog.tsx:91
 msgid "Invalid Verification Code"
 msgstr "Codice di verifica non valido"
-
-#~ msgid "Invite"
-#~ msgstr "Invita"
 
 #: src/view/com/modals/InviteCodes.tsx:94
 msgid "Invite a Friend"
@@ -4038,9 +3260,6 @@ msgstr "Codice invito non accettato. Controlla di averlo inserito correttamente 
 #: src/view/com/modals/InviteCodes.tsx:171
 msgid "Invite codes: {0} available"
 msgstr "Codici di invito: {0} disponibili"
-
-#~ msgid "Invite codes: {invitesAvailable} available"
-#~ msgstr "Codici di invito: {invitesAvailable} disponibili"
 
 #: src/view/com/modals/InviteCodes.tsx:170
 msgid "Invite codes: 1 available"
@@ -4061,9 +3280,6 @@ msgstr "Inviti, ma personali"
 #: src/screens/Signup/StepInfo/index.tsx:80
 msgid "It looks like you may have entered your email address incorrectly. Are you sure it's right?"
 msgstr "Sembra che tu abbia inserito il tuo indirizzo email in maniera non corretta. Se sicuro che sia giusto?"
-
-#~ msgid "It shows posts from the people you follow as they happen."
-#~ msgstr "Mostra i post delle persone che segui."
 
 #: src/screens/Signup/StepInfo/index.tsx:241
 msgid "It's correct"
@@ -4088,27 +3304,13 @@ msgstr "Lavori"
 msgid "Join Bluesky"
 msgstr "Entra in Bluesky"
 
-#: src/components/StarterPack/QrCode.tsx:61
-#: src/view/shell/NavSignupCard.tsx:40
+#: src/components/StarterPack/QrCode.tsx:61 src/view/shell/NavSignupCard.tsx:40
 msgid "Join the conversation"
 msgstr "Entra nella conversazione"
 
-#~ msgid "Join the waitlist"
-#~ msgstr "Iscriviti alla lista d'attesa"
-
-#~ msgid "Join the waitlist."
-#~ msgstr "Iscriviti alla lista d'attesa."
-
-#~ msgid "Join Waitlist"
-#~ msgstr "Iscriviti alla Lista d'Attesa"
-
-#: src/screens/Onboarding/index.tsx:21
-#: src/screens/Onboarding/state.ts:91
+#: src/screens/Onboarding/index.tsx:21 src/screens/Onboarding/state.ts:91
 msgid "Journalism"
 msgstr "Giornalismo"
-
-#~ msgid "label has been placed on this {labelTarget}"
-#~ msgstr "l'etichetta è stata inserita su questo {labelTarget}"
 
 #: src/components/moderation/ContentHider.tsx:209
 msgid "Labeled by {0}."
@@ -4125,14 +3327,11 @@ msgstr "Etichette"
 
 #: src/view/com/composer/labels/LabelsBtn.tsx:74
 msgid "Labels added"
-msgstr ""
+msgstr "Etichette aggiunte"
 
 #: src/screens/Profile/Sections/Labels.tsx:163
 msgid "Labels are annotations on users and content. They can be used to hide, warn, and categorize the network."
 msgstr "Le etichette sono annotazioni su utenti e contenuti. Possono essere utilizzate per nascondere, avvisare e classificare il network."
-
-#~ msgid "labels have been placed on this {labelTarget}"
-#~ msgstr "le etichette sono state inserite su questo {labelTarget}"
 
 #: src/components/moderation/LabelsOnMeDialog.tsx:71
 msgid "Labels on your account"
@@ -4146,17 +3345,12 @@ msgstr "Etichette sul tuo contenuto"
 msgid "Language selection"
 msgstr "Seleziona la lingua"
 
-#: src/view/screens/Settings/index.tsx:497
-#~ msgid "Language settings"
-#~ msgstr "Impostazione delle lingue"
-
 #: src/Navigation.tsx:163
 msgid "Language Settings"
 msgstr "Impostazione delle Lingue"
 
 #: src/screens/Settings/LanguageSettings.tsx:67
-#: src/screens/Settings/Settings.tsx:191
-#: src/screens/Settings/Settings.tsx:194
+#: src/screens/Settings/Settings.tsx:191 src/screens/Settings/Settings.tsx:194
 msgid "Languages"
 msgstr "Lingue"
 
@@ -4164,20 +3358,13 @@ msgstr "Lingue"
 msgid "Larger"
 msgstr "Molto largo"
 
-#~ msgid "Last step!"
-#~ msgstr "Ultimo passo!"
-
-#: src/screens/Hashtag.tsx:98
-#: src/view/screens/Search/Search.tsx:521
+#: src/screens/Hashtag.tsx:98 src/view/screens/Search/Search.tsx:521
 msgid "Latest"
 msgstr "Ultime"
 
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:251
 msgid "learn more"
-msgstr ""
-
-#~ msgid "Learn more"
-#~ msgstr "Ulteriori informazioni"
+msgstr "ulteriori informazioni"
 
 #: src/components/moderation/ScreenHider.tsx:140
 msgid "Learn More"
@@ -4189,7 +3376,7 @@ msgstr "Scopri di più su Bluesky"
 
 #: src/view/com/auth/server-input/index.tsx:156
 msgid "Learn more about self hosting your PDS."
-msgstr "Maggiori informazioni sull'ospitare il tuo PDS"
+msgstr "Maggiori informazioni sull'ospitare il tuo PDS."
 
 #: src/components/moderation/ContentHider.tsx:127
 #: src/components/moderation/ContentHider.tsx:193
@@ -4220,10 +3407,8 @@ msgstr "Abbandona"
 msgid "Leave chat"
 msgstr "Abbandona la chat"
 
-#: src/components/dms/ConvoMenu.tsx:138
-#: src/components/dms/ConvoMenu.tsx:141
-#: src/components/dms/ConvoMenu.tsx:208
-#: src/components/dms/ConvoMenu.tsx:211
+#: src/components/dms/ConvoMenu.tsx:138 src/components/dms/ConvoMenu.tsx:141
+#: src/components/dms/ConvoMenu.tsx:208 src/components/dms/ConvoMenu.tsx:211
 #: src/components/dms/LeaveConvoPrompt.tsx:46
 msgid "Leave conversation"
 msgstr "Abbandona la conversazione"
@@ -4240,15 +3425,11 @@ msgstr "Stai lasciando Bluesky"
 msgid "left to go."
 msgstr "mancanti."
 
-#~ msgid "Legacy storage cleared, you need to restart the app now."
-#~ msgstr "L'archivio legacy è stato cancellato, riattiva la app."
-
 #: src/components/StarterPack/ProfileStarterPacks.tsx:313
 msgid "Let me choose"
 msgstr "Lascia scegliere a me"
 
-#: src/screens/Login/index.tsx:127
-#: src/screens/Login/index.tsx:142
+#: src/screens/Login/index.tsx:127 src/screens/Login/index.tsx:142
 msgid "Let's get your password reset!"
 msgstr "Reimpostazione della password!"
 
@@ -4256,15 +3437,9 @@ msgstr "Reimpostazione della password!"
 msgid "Let's go!"
 msgstr "Andiamo!"
 
-#~ msgid "Library"
-#~ msgstr "Biblioteca"
-
 #: src/screens/Settings/AppearanceSettings.tsx:88
 msgid "Light"
 msgstr "Chiaro"
-
-#~ msgid "Like"
-#~ msgstr "Mi piace"
 
 #: src/components/ProgressGuide/List.tsx:48
 msgid "Like 10 posts"
@@ -4280,38 +3455,16 @@ msgstr "Metti like a 10 post per allenare il feed Discover"
 msgid "Like this feed"
 msgstr "Metti mi piace a questo feed"
 
-#: src/components/LikesDialog.tsx:85
-#: src/Navigation.tsx:234
+#: src/components/LikesDialog.tsx:85 src/Navigation.tsx:234
 #: src/Navigation.tsx:239
 msgid "Liked by"
 msgstr "Piace a"
 
-#: src/screens/Post/PostLikedBy.tsx:32
-#: src/screens/Post/PostLikedBy.tsx:33
+#: src/screens/Post/PostLikedBy.tsx:32 src/screens/Post/PostLikedBy.tsx:33
 #: src/screens/Profile/ProfileLabelerLikedBy.tsx:29
 #: src/view/screens/ProfileFeedLikedBy.tsx:30
 msgid "Liked By"
 msgstr "Piace A"
-
-#~ msgid "Liked by {0} {1}"
-#~ msgstr "Piace a {0} {1}"
-
-#~ msgid "Liked by {count} {0}"
-#~ msgstr "È piaciuto a {count} {0}"
-
-#~ msgid "Liked by {likeCount} {0}"
-#~ msgstr "Piace a {likeCount} {0}"
-
-#: src/view/com/notifications/FeedItem.tsx:211
-#~ msgid "liked your custom feed"
-#~ msgstr "piace il tuo feed personalizzato"
-
-#~ msgid "liked your custom feed{0}"
-#~ msgstr "piace il feed personalizzato{0}"
-
-#: src/view/com/notifications/FeedItem.tsx:178
-#~ msgid "liked your post"
-#~ msgstr "piace il tuo post"
 
 #: src/view/screens/Profile.tsx:231
 msgid "Likes"
@@ -4333,8 +3486,7 @@ msgstr "Lista avatar"
 msgid "List blocked"
 msgstr "Lista bloccata"
 
-#: src/components/ListCard.tsx:150
-#: src/view/com/feeds/FeedSourceCard.tsx:255
+#: src/components/ListCard.tsx:150 src/view/com/feeds/FeedSourceCard.tsx:255
 msgid "List by {0}"
 msgstr "Lista di {0}"
 
@@ -4366,10 +3518,8 @@ msgstr "Lista sbloccata"
 msgid "List unmuted"
 msgstr "Lista non mutata"
 
-#: src/Navigation.tsx:133
-#: src/view/screens/Profile.tsx:227
-#: src/view/screens/Profile.tsx:234
-#: src/view/shell/desktop/LeftNav.tsx:475
+#: src/Navigation.tsx:133 src/view/screens/Profile.tsx:227
+#: src/view/screens/Profile.tsx:234 src/view/shell/desktop/LeftNav.tsx:475
 #: src/view/shell/Drawer.tsx:491
 msgid "Lists"
 msgstr "Liste"
@@ -4381,9 +3531,6 @@ msgstr "Liste che bloccano questo utente:"
 #: src/view/screens/Search/Explore.tsx:131
 msgid "Load more"
 msgstr "Carica di più"
-
-#~ msgid "Load more posts"
-#~ msgstr "Carica più post"
 
 #: src/view/screens/Search/Explore.tsx:219
 msgid "Load more suggested feeds"
@@ -4397,10 +3544,8 @@ msgstr "Carica più follow consigliati"
 msgid "Load new notifications"
 msgstr "Carica più notifiche"
 
-#: src/screens/Profile/Sections/Feed.tsx:96
-#: src/view/com/feeds/FeedPage.tsx:132
-#: src/view/screens/ProfileFeed.tsx:499
-#: src/view/screens/ProfileList.tsx:808
+#: src/screens/Profile/Sections/Feed.tsx:96 src/view/com/feeds/FeedPage.tsx:132
+#: src/view/screens/ProfileFeed.tsx:499 src/view/screens/ProfileList.tsx:808
 msgid "Load new posts"
 msgstr "Carica nuovi posts"
 
@@ -4408,22 +3553,16 @@ msgstr "Carica nuovi posts"
 msgid "Loading..."
 msgstr "Caricamento..."
 
-#~ msgid "Local dev server"
-#~ msgstr "Server di sviluppo locale"
-
 #: src/Navigation.tsx:259
 msgid "Log"
 msgstr "Log"
 
-#: src/screens/Deactivated.tsx:209
-#: src/screens/Deactivated.tsx:215
+#: src/screens/Deactivated.tsx:209 src/screens/Deactivated.tsx:215
 msgid "Log in or sign up"
 msgstr "Accedi o Iscriviti"
 
-#: src/screens/SignupQueued.tsx:155
-#: src/screens/SignupQueued.tsx:158
-#: src/screens/SignupQueued.tsx:184
-#: src/screens/SignupQueued.tsx:187
+#: src/screens/SignupQueued.tsx:155 src/screens/SignupQueued.tsx:158
+#: src/screens/SignupQueued.tsx:184 src/screens/SignupQueued.tsx:187
 msgid "Log out"
 msgstr "Esci"
 
@@ -4437,18 +3576,15 @@ msgstr "Accedi all'account che non è nella lista"
 
 #: src/view/shell/desktop/RightNav.tsx:104
 msgid "Logo by <0/>"
-msgstr ""
+msgstr "Logo di <0/>"
 
 #: src/view/shell/Drawer.tsx:629
 msgid "Logo by <0>@sawaratsuki.bsky.social</0>"
-msgstr ""
+msgstr "Logo di <0>@sawaratsuki.bsky.social</0>"
 
 #: src/components/RichText.tsx:227
 msgid "Long press to open tag menu for #{tag}"
 msgstr "Tieni premutoper aprire il menu dei tag per #{tag}"
-
-#~ msgid "Looks like this feed is only available to users with a Bluesky account. Please sign up or sign in to view this feed!"
-#~ msgstr "Sembra che questo feed sia disponibile solo per gli utenti con un account Bluesky. Per favore registrati o accedi per visualizzare questo feed!"
 
 #: src/screens/Login/SetNewPasswordForm.tsx:110
 msgid "Looks like XXXXX-XXXXX"
@@ -4477,22 +3613,15 @@ msgstr "Assicurati che questo sia dove intendi andare!"
 #: src/screens/Settings/ContentAndMediaSettings.tsx:41
 #: src/screens/Settings/ContentAndMediaSettings.tsx:44
 msgid "Manage saved feeds"
-msgstr ""
+msgstr "Gestisci i feed salvati"
 
 #: src/components/dialogs/MutedWords.tsx:108
 msgid "Manage your muted words and tags"
 msgstr "Gestisci le parole mute e i tags"
 
-#: src/components/dms/ConvoMenu.tsx:151
-#: src/components/dms/ConvoMenu.tsx:158
+#: src/components/dms/ConvoMenu.tsx:151 src/components/dms/ConvoMenu.tsx:158
 msgid "Mark as read"
 msgstr "Segna come letto"
-
-#~ msgid "May not be longer than 253 characters"
-#~ msgstr "Non può contenere più di 253 caratteri"
-
-#~ msgid "May only contain letters and numbers"
-#~ msgstr "Può contenere solo lettere e numeri"
 
 #: src/view/screens/Profile.tsx:230
 msgid "Media"
@@ -4500,7 +3629,7 @@ msgstr "Media"
 
 #: src/view/com/composer/labels/LabelsBtn.tsx:212
 msgid "Media that may be disturbing or inappropriate for some audiences."
-msgstr ""
+msgstr "Contenuti multimediali che potrebbero disturbare o risultare inappropriati per alcuni tipi di pubblico."
 
 #: src/components/WhoCanReply.tsx:254
 msgid "mentioned users"
@@ -4510,8 +3639,7 @@ msgstr "utenti menzionati"
 msgid "Mentioned users"
 msgstr "Utenti menzionati"
 
-#: src/components/Menu/index.tsx:95
-#: src/view/com/util/ViewHeader.tsx:87
+#: src/components/Menu/index.tsx:95 src/view/com/util/ViewHeader.tsx:87
 #: src/view/screens/Search/Search.tsx:882
 msgid "Menu"
 msgstr "Menù"
@@ -4524,9 +3652,6 @@ msgstr "Messaggio {0}"
 #: src/screens/Messages/components/ChatListItem.tsx:165
 msgid "Message deleted"
 msgstr "Messaggio cancellato"
-
-#~ msgid "Message from server"
-#~ msgstr "Messaggio dal server"
 
 #: src/view/com/posts/FeedErrorMessage.tsx:201
 msgid "Message from server: {0}"
@@ -4545,10 +3670,8 @@ msgstr "Il messaggio è troppo lungo"
 msgid "Message settings"
 msgstr "Impostazioni messaggio"
 
-#: src/Navigation.tsx:600
-#: src/screens/Messages/ChatList.tsx:162
-#: src/screens/Messages/ChatList.tsx:243
-#: src/screens/Messages/ChatList.tsx:314
+#: src/Navigation.tsx:600 src/screens/Messages/ChatList.tsx:162
+#: src/screens/Messages/ChatList.tsx:243 src/screens/Messages/ChatList.tsx:314
 msgid "Messages"
 msgstr "Messaggi"
 
@@ -4560,13 +3683,8 @@ msgstr "Account Ingannevole"
 msgid "Misleading Post"
 msgstr "Post frainteso"
 
-#~ msgid "Mode"
-#~ msgstr "Tema"
-
-#: src/Navigation.tsx:138
-#: src/screens/Moderation/index.tsx:101
-#: src/screens/Settings/Settings.tsx:159
-#: src/screens/Settings/Settings.tsx:162
+#: src/Navigation.tsx:138 src/screens/Moderation/index.tsx:101
+#: src/screens/Settings/Settings.tsx:159 src/screens/Settings/Settings.tsx:162
 msgid "Moderation"
 msgstr "Moderazione"
 
@@ -4600,18 +3718,13 @@ msgstr "Lista di moderazione aggiornata"
 msgid "Moderation lists"
 msgstr "Liste di moderazione"
 
-#: src/Navigation.tsx:143
-#: src/view/screens/ModerationModlists.tsx:72
+#: src/Navigation.tsx:143 src/view/screens/ModerationModlists.tsx:72
 msgid "Moderation Lists"
 msgstr "Liste di Moderazione"
 
 #: src/components/moderation/LabelPreference.tsx:247
 msgid "moderation settings"
 msgstr "impostazioni di moderazione"
-
-#: src/view/screens/Settings/index.tsx:522
-#~ msgid "Moderation settings"
-#~ msgstr "Impostazioni di moderazione"
 
 #: src/Navigation.tsx:249
 msgid "Moderation states"
@@ -4639,9 +3752,6 @@ msgstr "Altri feed"
 msgid "More options"
 msgstr "Altre opzioni"
 
-#~ msgid "More post options"
-#~ msgstr "Altre impostazioni per il post"
-
 #: src/screens/Settings/ThreadPreferences.tsx:81
 msgid "Most-liked first"
 msgstr ""
@@ -4657,9 +3767,6 @@ msgstr "Film"
 #: src/screens/Onboarding/state.ts:93
 msgid "Music"
 msgstr "Musica"
-
-#~ msgid "Must be at least 3 characters"
-#~ msgstr "Deve contenere almeno 3 caratteri"
 
 #: src/components/TagMenu/index.tsx:248
 msgid "Mute"
@@ -4688,16 +3795,9 @@ msgstr "Silenzia gli accounts"
 msgid "Mute all {displayTag} posts"
 msgstr "Silenzia tutti i post {displayTag}"
 
-#: src/components/dms/ConvoMenu.tsx:172
-#: src/components/dms/ConvoMenu.tsx:178
+#: src/components/dms/ConvoMenu.tsx:172 src/components/dms/ConvoMenu.tsx:178
 msgid "Mute conversation"
 msgstr "Silenzia la conversazione"
-
-#~ msgid "Mute in tags only"
-#~ msgstr "Silenzia solo i tags"
-
-#~ msgid "Mute in text & tags"
-#~ msgstr "Silenzia nel testo & tags"
 
 #: src/components/dialogs/MutedWords.tsx:253
 msgid "Mute in:"
@@ -4707,15 +3807,9 @@ msgstr "Silenzia in:"
 msgid "Mute list"
 msgstr "Silenziare la lista"
 
-#~ msgid "Mute notifications"
-#~ msgstr "Silenza notifiche"
-
 #: src/view/screens/ProfileList.tsx:732
 msgid "Mute these accounts?"
 msgstr "Vuoi silenziare queste liste?"
-
-#~ msgid "Mute this List"
-#~ msgstr "Silenzia questa Lista"
 
 #: src/components/dialogs/MutedWords.tsx:185
 msgid "Mute this word for 24 hours"
@@ -4751,15 +3845,11 @@ msgstr "Silenzia questa discussione"
 msgid "Mute words & tags"
 msgstr "Silenzia parole & tags"
 
-#~ msgid "Muted"
-#~ msgstr "Silenziato"
-
 #: src/screens/Moderation/index.tsx:259
 msgid "Muted accounts"
 msgstr "Account silenziato"
 
-#: src/Navigation.tsx:148
-#: src/view/screens/ModerationMutedAccounts.tsx:108
+#: src/Navigation.tsx:148 src/view/screens/ModerationMutedAccounts.tsx:108
 msgid "Muted Accounts"
 msgstr "Accounts Silenziati"
 
@@ -4792,17 +3882,6 @@ msgstr "I miei Feed"
 msgid "My Profile"
 msgstr "Il mio Profilo"
 
-#: src/view/screens/Settings/index.tsx:583
-#~ msgid "My saved feeds"
-#~ msgstr "I miei feed salvati"
-
-#: src/view/screens/Settings/index.tsx:589
-#~ msgid "My Saved Feeds"
-#~ msgstr "I miei Feed Salvati"
-
-#~ msgid "my-server.com"
-#~ msgstr "my-server.com"
-
 #: src/view/com/modals/CreateOrEditList.tsx:270
 msgid "Name"
 msgstr "Nome"
@@ -4818,18 +3897,13 @@ msgstr "Il nome è obbligatorio"
 msgid "Name or Description Violates Community Standards"
 msgstr "Il Nome o la Descrizione Viola gli Standard della Comunità"
 
-#: src/screens/Onboarding/index.tsx:22
-#: src/screens/Onboarding/state.ts:94
+#: src/screens/Onboarding/index.tsx:22 src/screens/Onboarding/state.ts:94
 msgid "Nature"
 msgstr "Natura"
 
 #: src/components/StarterPack/StarterPackCard.tsx:124
 msgid "Navigate to {0}"
 msgstr "Vai a {0}"
-
-#: src/view/com/util/post-embeds/ExternalLinkEmbed.tsx:86
-#~ msgid "Navigate to starter pack"
-#~ msgstr "Vai allo starter pack"
 
 #: src/screens/Login/ForgotPasswordForm.tsx:166
 #: src/screens/Login/LoginForm.tsx:316
@@ -4849,19 +3923,13 @@ msgstr "Serve modificarlo?"
 msgid "Need to report a copyright violation?"
 msgstr "Hai bisogno di segnalare una violazione del copyright?"
 
-#~ msgid "Never load embeds from {0}"
-#~ msgstr "Non caricare mai gli inserimenti di {0}"
-
-#~ msgid "Never lose access to your followers and data."
-#~ msgstr "Non perdere mai l'accesso ai tuoi follower e ai tuoi dati."
-
 #: src/screens/Onboarding/StepFinished.tsx:260
 msgid "Never lose access to your followers or data."
 msgstr "Non perdere mai l'accesso ai tuoi follower o ai tuoi dati."
 
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:533
 msgid "Nevermind, create a handle for me"
-msgstr "Non importa, crea una handle per me"
+msgstr "Non importa, crea un nome utente per me"
 
 #: src/view/screens/Lists.tsx:96
 msgctxt "action"
@@ -4873,20 +3941,15 @@ msgid "New"
 msgstr "Nuova"
 
 #: src/components/dms/dialogs/NewChatDialog.tsx:65
-#: src/screens/Messages/ChatList.tsx:328
-#: src/screens/Messages/ChatList.tsx:335
+#: src/screens/Messages/ChatList.tsx:328 src/screens/Messages/ChatList.tsx:335
 msgid "New chat"
 msgstr "Nuova chat"
-
-#: src/components/dialogs/nuxs/NeueTypography.tsx:51
-#~ msgid "New font settings ✨"
-#~ msgstr "Nuovi settaggi per i font ✨"
 
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:201
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:209
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:356
 msgid "New handle"
-msgstr ""
+msgstr "Nuovo nome utente"
 
 #: src/components/dms/NewMessagesPill.tsx:92
 msgid "New messages"
@@ -4909,12 +3972,9 @@ msgctxt "action"
 msgid "New post"
 msgstr "Nuovo Post"
 
-#: src/view/screens/Feeds.tsx:582
-#: src/view/screens/Notifications.tsx:224
-#: src/view/screens/Profile.tsx:496
-#: src/view/screens/ProfileFeed.tsx:433
-#: src/view/screens/ProfileList.tsx:248
-#: src/view/screens/ProfileList.tsx:287
+#: src/view/screens/Feeds.tsx:582 src/view/screens/Notifications.tsx:224
+#: src/view/screens/Profile.tsx:496 src/view/screens/ProfileFeed.tsx:433
+#: src/view/screens/ProfileList.tsx:248 src/view/screens/ProfileList.tsx:287
 msgid "New post"
 msgstr "Nuovo post"
 
@@ -4922,9 +3982,6 @@ msgstr "Nuovo post"
 msgctxt "action"
 msgid "New Post"
 msgstr "Nuovo post"
-
-#~ msgid "New Post"
-#~ msgstr "Nuovo Post"
 
 #: src/components/NewskieDialog.tsx:83
 msgid "New user info dialog"
@@ -4939,15 +3996,13 @@ msgstr "Nuova lista"
 msgid "Newest replies first"
 msgstr "Mostrare prima le risposte più recenti"
 
-#: src/screens/Onboarding/index.tsx:20
-#: src/screens/Onboarding/state.ts:95
+#: src/screens/Onboarding/index.tsx:20 src/screens/Onboarding/state.ts:95
 msgid "News"
 msgstr "Notizie"
 
 #: src/screens/Login/ForgotPasswordForm.tsx:137
 #: src/screens/Login/ForgotPasswordForm.tsx:143
-#: src/screens/Login/LoginForm.tsx:315
-#: src/screens/Login/LoginForm.tsx:322
+#: src/screens/Login/LoginForm.tsx:315 src/screens/Login/LoginForm.tsx:322
 #: src/screens/Login/SetNewPasswordForm.tsx:168
 #: src/screens/Login/SetNewPasswordForm.tsx:174
 #: src/screens/Settings/components/AddAppPasswordDialog.tsx:157
@@ -4962,29 +4017,15 @@ msgstr "Notizie"
 msgid "Next"
 msgstr "Seguente"
 
-#~ msgctxt "action"
-#~ msgid "Next"
-#~ msgstr "Seguente"
-
 #: src/view/com/lightbox/Lightbox.web.tsx:167
 msgid "Next image"
 msgstr "Immagine seguente"
-
-#: src/view/screens/PreferencesFollowingFeed.tsx:71
-#: src/view/screens/PreferencesFollowingFeed.tsx:97
-#: src/view/screens/PreferencesFollowingFeed.tsx:132
-#: src/view/screens/PreferencesFollowingFeed.tsx:169
-#: src/view/screens/PreferencesThreads.tsx:101
-#: src/view/screens/PreferencesThreads.tsx:124
-#~ msgid "No"
-#~ msgstr "No"
 
 #: src/screens/Settings/AppPasswords.tsx:100
 msgid "No app passwords yet"
 msgstr ""
 
-#: src/view/screens/ProfileFeed.tsx:565
-#: src/view/screens/ProfileList.tsx:882
+#: src/view/screens/ProfileFeed.tsx:565 src/view/screens/ProfileList.tsx:882
 msgid "No description"
 msgstr "Senza descrizione"
 
@@ -5027,8 +4068,7 @@ msgstr "Nessuna conversazione da visualizzare"
 msgid "No notifications yet!"
 msgstr "Ancora nessuna notifica!"
 
-#: src/screens/Messages/Settings.tsx:95
-#: src/screens/Messages/Settings.tsx:98
+#: src/screens/Messages/Settings.tsx:95 src/screens/Messages/Settings.tsx:98
 msgid "No one"
 msgstr "Nessuno"
 
@@ -5085,11 +4125,7 @@ msgstr "No grazie"
 msgid "Nobody"
 msgstr "Nessuno"
 
-#~ msgid "Nobody can reply"
-#~ msgstr "Nessuno puo rispondere"
-
-#: src/components/LikedByList.tsx:80
-#: src/components/LikesDialog.tsx:97
+#: src/components/LikedByList.tsx:80 src/components/LikesDialog.tsx:97
 #: src/view/com/post-thread/PostLikedBy.tsx:87
 msgid "Nobody has liked this yet. Maybe you should be the first!"
 msgstr "Nessuno ha messo like. Fallo tu per primo/a!"
@@ -5110,11 +4146,7 @@ msgstr "Nessun utente trovato. Prova a cercarne altri."
 msgid "Non-sexual Nudity"
 msgstr "Nudità non sessuale"
 
-#~ msgid "Not Applicable."
-#~ msgstr "Non applicabile."
-
-#: src/Navigation.tsx:128
-#: src/view/screens/Profile.tsx:128
+#: src/Navigation.tsx:128 src/view/screens/Profile.tsx:128
 msgid "Not Found"
 msgstr "Non trovato"
 
@@ -5141,8 +4173,7 @@ msgstr "Nulla qui"
 msgid "Notification filters"
 msgstr "Filtri notifiche"
 
-#: src/Navigation.tsx:383
-#: src/view/screens/Notifications.tsx:117
+#: src/Navigation.tsx:383 src/view/screens/Notifications.tsx:117
 msgid "Notification settings"
 msgstr "Notifiche"
 
@@ -5158,13 +4189,11 @@ msgstr "Suoni di notifica"
 msgid "Notification Sounds"
 msgstr "Suoni di notifica"
 
-#: src/Navigation.tsx:595
-#: src/view/screens/Notifications.tsx:143
+#: src/Navigation.tsx:595 src/view/screens/Notifications.tsx:143
 #: src/view/screens/Notifications.tsx:153
 #: src/view/screens/Notifications.tsx:199
 #: src/view/shell/bottom-bar/BottomBar.tsx:226
-#: src/view/shell/desktop/LeftNav.tsx:438
-#: src/view/shell/Drawer.tsx:444
+#: src/view/shell/desktop/LeftNav.tsx:438 src/view/shell/Drawer.tsx:444
 msgid "Notifications"
 msgstr "Notifiche"
 
@@ -5185,12 +4214,6 @@ msgstr "Nudità"
 msgid "Nudity or adult content not labeled as such"
 msgstr "Nudità o contenuti per adulti non etichettati come tali"
 
-#~ msgid "Nudity or pornography not labeled as such"
-#~ msgstr "Nudità o pornografia non etichettata come tale"
-
-#~ msgid "of"
-#~ msgstr "di"
-
 #: src/lib/moderation/useLabelBehaviorDescription.ts:11
 msgid "Off"
 msgstr "Spento"
@@ -5203,11 +4226,6 @@ msgstr "Oh no!"
 #: src/screens/Onboarding/StepInterests/index.tsx:124
 msgid "Oh no! Something went wrong."
 msgstr "Oh no! Qualcosa è andato male."
-
-#: src/screens/Profile/Header/ProfileHeaderLabeler.tsx:334
-#: src/components/dialogs/nuxs/TenMillion/index.tsx:175
-#~ msgid "Oh no! We weren't able to generate an image for you to share. Rest assured, we're glad you're here 🦋"
-#~ msgstr ""
 
 #: src/screens/Profile/Header/ProfileHeaderLabeler.tsx:347
 msgid "OK"
@@ -5223,12 +4241,6 @@ msgstr "Va bene"
 msgid "Oldest replies first"
 msgstr "Mostrare prima le risposte più vecchie"
 
-#~ msgid "on"
-#~ msgstr "su"
-
-#~ msgid "on {str}"
-#~ msgstr "su {str}"
-
 #: src/components/StarterPack/QrCode.tsx:75
 msgid "on<0><1/><2><3/></2></0>"
 msgstr ""
@@ -5236,11 +4248,6 @@ msgstr ""
 #: src/screens/Settings/Settings.tsx:295
 msgid "Onboarding reset"
 msgstr "Reimpostazione dell'onboarding"
-
-#: src/view/com/composer/Composer.tsx:619
-#: src/tours/Tooltip.tsx:118
-#~ msgid "Onboarding tour step {0}: {1}"
-#~ msgstr ""
 
 #: src/view/com/composer/Composer.tsx:323
 msgid "One or more GIFs is missing alt text."
@@ -5257,9 +4264,6 @@ msgstr ""
 #: src/screens/Onboarding/StepProfile/index.tsx:115
 msgid "Only .jpg and .png files are supported"
 msgstr "Solo i file .jpg e .png sono supportati"
-
-#~ msgid "Only {0} can reply"
-#~ msgstr "Solo {0} può rispondere"
 
 #: src/components/WhoCanReply.tsx:217
 msgid "Only {0} can reply."
@@ -5305,7 +4309,7 @@ msgstr "Apri il creatore di avatar"
 
 #: src/screens/Settings/AccountSettings.tsx:120
 msgid "Open change handle dialog"
-msgstr ""
+msgstr "Apri la finestra di dialogo per la modifica del nome utente"
 
 #: src/screens/Messages/components/ChatListItem.tsx:272
 #: src/screens/Messages/components/ChatListItem.tsx:273
@@ -5329,10 +4333,6 @@ msgstr ""
 #: src/view/com/util/post-embeds/ExternalLinkEmbed.tsx:71
 msgid "Open link to {niceUrl}"
 msgstr ""
-
-#: src/view/screens/Settings/index.tsx:703
-#~ msgid "Open links with in-app browser"
-#~ msgstr "Apri i links con il navigatore della app"
 
 #: src/components/dms/ActionsWrapper.tsx:88
 msgid "Open message options"
@@ -5358,8 +4358,7 @@ msgstr "Apri il menu delle opzioni del post"
 msgid "Open starter pack menu"
 msgstr "Apri menu degli starter pack"
 
-#: src/screens/Settings/Settings.tsx:314
-#: src/screens/Settings/Settings.tsx:328
+#: src/screens/Settings/Settings.tsx:314 src/screens/Settings/Settings.tsx:328
 msgid "Open storybook page"
 msgstr "Apri la pagina della cronologia"
 
@@ -5379,47 +4378,21 @@ msgstr ""
 msgid "Opens a dialog to choose who can reply to this thread"
 msgstr "Apre un menu per scegliere chi può rispondere a questo thread"
 
-#: src/view/screens/Settings/index.tsx:456
-#~ msgid "Opens accessibility settings"
-#~ msgstr "Apre le impostazioni di accessibilità"
-
 #: src/view/screens/Log.tsx:59
 msgid "Opens additional details for a debug entry"
 msgstr "Apre dettagli aggiuntivi per una debug entry"
-
-#~ msgid "Opens an expanded list of users in this notification"
-#~ msgstr "Apre un elenco ampliato di utenti in questa notifica"
-
-#: src/view/screens/Settings/index.tsx:477
-#~ msgid "Opens appearance settings"
-#~ msgstr "Apre le impostazioni del tema"
 
 #: src/view/com/composer/photos/OpenCameraBtn.tsx:73
 msgid "Opens camera on device"
 msgstr "Apre la fotocamera sul dispositivo"
 
-#: src/view/screens/Settings/index.tsx:606
-#~ msgid "Opens chat settings"
-#~ msgstr "Apre impostazioni messaggi"
-
 #: src/view/com/post-thread/PostThreadComposePrompt.tsx:36
 msgid "Opens composer"
 msgstr "Apre il compositore"
 
-#: src/view/screens/Settings/index.tsx:498
-#~ msgid "Opens configurable language settings"
-#~ msgstr "Apre le impostazioni configurabili delle lingue"
-
 #: src/view/com/composer/photos/SelectPhotoBtn.tsx:51
 msgid "Opens device photo gallery"
 msgstr "Apre la galleria fotografica del dispositivo"
-
-#~ msgid "Opens editor for profile display name, avatar, background image, and description"
-#~ msgstr "Apre l'editor per il nome configurato del profilo, l'avatar, l'immagine di sfondo e la descrizione"
-
-#: src/view/screens/Settings/index.tsx:638
-#~ msgid "Opens external embeds settings"
-#~ msgstr "Apre le impostazioni esterne per gli incorporamenti"
 
 #: src/view/com/auth/SplashScreen.tsx:50
 #: src/view/com/auth/SplashScreen.web.tsx:111
@@ -5431,102 +4404,21 @@ msgstr "Apre il procedimento per creare un nuovo account Bluesky"
 msgid "Opens flow to sign into your existing Bluesky account"
 msgstr "Apre il procedimento per accedere al tuo account esistente di Bluesky"
 
-#~ msgid "Opens followers list"
-#~ msgstr "Apre la lista dei follower"
-
-#~ msgid "Opens following list"
-#~ msgstr "Apre la lista di chi segui"
-
 #: src/view/com/composer/photos/SelectGifBtn.tsx:36
 msgid "Opens GIF select dialog"
 msgstr "Apre la finestra per selezionare i GIF"
-
-#~ msgid "Opens invite code list"
-#~ msgstr "Apre la lista dei codici di invito"
 
 #: src/view/com/modals/InviteCodes.tsx:173
 msgid "Opens list of invite codes"
 msgstr "Apre la lista dei codici di invito"
 
-#: src/view/screens/Settings/index.tsx:775
-#~ msgid "Opens modal for account deactivation confirmation"
-#~ msgstr "Apre menu per confermare la disattivazione dell'account"
-
-#: src/view/screens/Settings/index.tsx:797
-#~ msgid "Opens modal for account deletion confirmation. Requires email code"
-#~ msgstr "Apre la modale per la conferma dell'eliminazione dell'account. Richiede un codice e-mail"
-
-#~ msgid "Opens modal for account deletion confirmation. Requires email code."
-#~ msgstr "Apre il modal per la conferma dell'eliminazione dell'account. Richiede un codice email."
-
-#: src/view/screens/Settings/index.tsx:732
-#~ msgid "Opens modal for changing your Bluesky password"
-#~ msgstr "Apre la modale per modificare il tuo password di Bluesky"
-
-#: src/view/screens/Settings/index.tsx:687
-#~ msgid "Opens modal for choosing a new Bluesky handle"
-#~ msgstr "Apre la modale per la scelta di un nuovo handle di Bluesky"
-
-#: src/view/screens/Settings/index.tsx:755
-#~ msgid "Opens modal for downloading your Bluesky account data (repository)"
-#~ msgstr "Apre la modale per scaricare i dati del tuo account Bluesky (repository)"
-
-#: src/view/screens/Settings/index.tsx:963
-#~ msgid "Opens modal for email verification"
-#~ msgstr "Apre la modale per la verifica dell'e-mail"
-
-#: src/view/com/modals/ChangeHandle.tsx:269
-#~ msgid "Opens modal for using custom domain"
-#~ msgstr "Apre il modal per l'utilizzo del dominio personalizzato"
-
-#: src/view/screens/Settings/index.tsx:523
-#~ msgid "Opens moderation settings"
-#~ msgstr "Apre le impostazioni di moderazione"
-
 #: src/screens/Login/LoginForm.tsx:231
 msgid "Opens password reset form"
 msgstr "Apre il modulo di reimpostazione della password"
 
-#~ msgid "Opens screen to edit Saved Feeds"
-#~ msgstr "Apre la schermata per modificare i feed salvati"
-
-#: src/view/screens/Settings/index.tsx:584
-#~ msgid "Opens screen with all saved feeds"
-#~ msgstr "Apre la schermata con tutti i feed salvati"
-
-#: src/view/screens/Settings/index.tsx:665
-#~ msgid "Opens the app password settings"
-#~ msgstr "Apre le impostazioni della password dell'app"
-
-#~ msgid "Opens the app password settings page"
-#~ msgstr "Apre la pagina delle impostazioni della password dell'app"
-
-#: src/view/screens/Settings/index.tsx:541
-#~ msgid "Opens the Following feed preferences"
-#~ msgstr "Apre le preferenze del feed Following"
-
-#~ msgid "Opens the home feed preferences"
-#~ msgstr "Apre le preferenze del home feed"
-
 #: src/view/com/modals/LinkWarning.tsx:93
 msgid "Opens the linked website"
 msgstr "Apre il sito Web collegato"
-
-#~ msgid "Opens the message settings page"
-#~ msgstr "Apre le impostazioni dei messaggi"
-
-#: src/view/screens/Settings/index.tsx:828
-#: src/view/screens/Settings/index.tsx:838
-#~ msgid "Opens the storybook page"
-#~ msgstr "Apri la pagina della cronologia"
-
-#: src/view/screens/Settings/index.tsx:816
-#~ msgid "Opens the system log page"
-#~ msgstr "Apre la pagina del registro di sistema"
-
-#: src/view/screens/Settings/index.tsx:562
-#~ msgid "Opens the threads preferences"
-#~ msgstr "Apre le preferenze dei threads"
 
 #: src/view/com/notifications/FeedItem.tsx:678
 #: src/view/com/util/UserAvatar.tsx:436
@@ -5571,13 +4463,6 @@ msgstr "Altri"
 msgid "Other account"
 msgstr "Altro account"
 
-#: src/view/screens/Settings/index.tsx:380
-#~ msgid "Other accounts"
-#~ msgstr "Altri account"
-
-#~ msgid "Other service"
-#~ msgstr "Altro servizio"
-
 #: src/view/com/composer/select-language/SelectLangBtn.tsx:93
 msgid "Other..."
 msgstr "Altro..."
@@ -5586,8 +4471,7 @@ msgstr "Altro..."
 msgid "Our moderators have reviewed reports and decided to disable your access to chats on Bluesky."
 msgstr "I nostri moderatori hanno revisionato i report e deciso di disabilitare il tuo accesso ai messaggi su Bluesky."
 
-#: src/components/Lists.tsx:216
-#: src/view/screens/NotFound.tsx:47
+#: src/components/Lists.tsx:216 src/view/screens/NotFound.tsx:47
 msgid "Page not found"
 msgstr "Pagina non trovata"
 
@@ -5651,13 +4535,9 @@ msgstr "L'autorizzazione per accedere la cartella delle immagini è stata negata
 msgid "Person toggle"
 msgstr ""
 
-#: src/screens/Onboarding/index.tsx:28
-#: src/screens/Onboarding/state.ts:96
+#: src/screens/Onboarding/index.tsx:28 src/screens/Onboarding/state.ts:96
 msgid "Pets"
 msgstr "Animali di compagnia"
-
-#~ msgid "Phone number"
-#~ msgstr "Numero di telefono"
 
 #: src/screens/Onboarding/state.ts:97
 msgid "Photography"
@@ -5667,8 +4547,7 @@ msgstr "Foto"
 msgid "Pictures meant for adults."
 msgstr "Immagini per adulti."
 
-#: src/view/screens/ProfileFeed.tsx:293
-#: src/view/screens/ProfileList.tsx:676
+#: src/view/screens/ProfileFeed.tsx:293 src/view/screens/ProfileList.tsx:676
 msgid "Pin to home"
 msgstr "Fissa su Home"
 
@@ -5725,8 +4604,7 @@ msgstr "Riproduci questa GIF"
 msgid "Please choose your handle."
 msgstr "Scegli il tuo nome utente."
 
-#: src/screens/Signup/state.ts:210
-#: src/screens/Signup/StepInfo/index.tsx:114
+#: src/screens/Signup/state.ts:210 src/screens/Signup/StepInfo/index.tsx:114
 msgid "Please choose your password."
 msgstr "Scegli la tua password."
 
@@ -5738,33 +4616,15 @@ msgstr "Si prega di completare il captcha di verifica."
 msgid "Please confirm your email before changing it. This is a temporary requirement while email-updating tools are added, and it will soon be removed."
 msgstr "Conferma la tua email prima di cambiarla. Si tratta di un requisito temporaneo durante l'aggiunta degli strumenti di aggiornamento della posta elettronica e verrà presto rimosso."
 
-#: src/view/com/modals/AddAppPasswords.tsx:94
-#~ msgid "Please enter a name for your app password. All spaces is not allowed."
-#~ msgstr "Inserisci un nome per la password dell'app. Tutti gli spazi non sono consentiti."
-
-#~ msgid "Please enter a phone number that can receive SMS text messages."
-#~ msgstr "Inserisci un numero di telefono in grado di ricevere messaggi di testo SMS."
-
 #: src/screens/Settings/components/AddAppPasswordDialog.tsx:114
 msgid "Please enter a unique name for this app password or use our randomly generated one."
 msgstr ""
-
-#: src/view/com/modals/AddAppPasswords.tsx:151
-#~ msgid "Please enter a unique name for this App Password or use our randomly generated one."
-#~ msgstr "Inserisci un nome unico per la password dell'app o utilizzane uno generato automaticamente."
 
 #: src/components/dialogs/MutedWords.tsx:86
 msgid "Please enter a valid word, tag, or phrase to mute"
 msgstr "Inserisci una parola, un tag o una frase valida da silenziare"
 
-#~ msgid "Please enter the code you received by SMS."
-#~ msgstr "Inserisci il codice che hai ricevuto via SMS."
-
-#~ msgid "Please enter the verification code sent to {phoneNumberFormatted}."
-#~ msgstr "Inserisci il codice di verifica inviato a {phoneNumberFormatted}."
-
-#: src/screens/Signup/state.ts:196
-#: src/screens/Signup/StepInfo/index.tsx:102
+#: src/screens/Signup/state.ts:196 src/screens/Signup/StepInfo/index.tsx:102
 msgid "Please enter your email."
 msgstr "Inserisci la tua email."
 
@@ -5789,30 +4649,17 @@ msgstr "Per favore spiega perché pensi che i tuoi messaggi siano stati erroneam
 msgid "Please sign in as @{0}"
 msgstr "Accedi come @{0}"
 
-#~ msgid "Please tell us why you think this content warning was incorrectly applied!"
-#~ msgstr "Spiegaci perché ritieni che questo avviso sui contenuti sia stato applicato in modo errato!"
-
-#~ msgid "Please tell us why you think this decision was incorrect."
-#~ msgstr "Per favore spiegaci perché ritieni che questa decisione sia stata sbagliata."
-
 #: src/view/com/modals/VerifyEmail.tsx:109
 msgid "Please Verify Your Email"
 msgstr "Verifica la tua email"
 
-#~ msgid "Please wait for your link card to finish loading"
-#~ msgstr "Attendi il caricamento della scheda di collegamento"
-
-#: src/screens/Onboarding/index.tsx:34
-#: src/screens/Onboarding/state.ts:98
+#: src/screens/Onboarding/index.tsx:34 src/screens/Onboarding/state.ts:98
 msgid "Politics"
 msgstr "Politica"
 
 #: src/view/com/composer/labels/LabelsBtn.tsx:158
 msgid "Porn"
 msgstr "Porno"
-
-#~ msgid "Pornography"
-#~ msgstr "Pornografia"
 
 #: src/view/com/composer/Composer.tsx:919
 msgctxt "action"
@@ -5824,9 +4671,6 @@ msgctxt "description"
 msgid "Post"
 msgstr "Post"
 
-#~ msgid "Post"
-#~ msgstr "Post"
-
 #: src/view/com/composer/Composer.tsx:917
 msgctxt "action"
 msgid "Post All"
@@ -5836,9 +4680,7 @@ msgstr ""
 msgid "Post by {0}"
 msgstr "Pubblicato da {0}"
 
-#: src/Navigation.tsx:202
-#: src/Navigation.tsx:209
-#: src/Navigation.tsx:216
+#: src/Navigation.tsx:202 src/Navigation.tsx:209 src/Navigation.tsx:216
 #: src/Navigation.tsx:223
 msgid "Post by @{0}"
 msgstr "Pubblicato da @{0}"
@@ -5899,9 +4741,6 @@ msgstr "post"
 msgid "Posts"
 msgstr "Post"
 
-#~ msgid "Posts can be muted based on their text, their tags, or both."
-#~ msgstr "I post possono essere silenziati ​​in base al testo, ai tag o entrambi."
-
 #: src/components/dialogs/MutedWords.tsx:115
 msgid "Posts can be muted based on their text, their tags, or both. We recommend avoiding common words that appear in many posts, since it can result in no posts being shown."
 msgstr "I post possono essere mutati a seconda del loro testo, dei loro tag, o entrambi. Consigliamo di evitare parole comuni che appaiono in tanti post, in quanto possa nascondere molti post."
@@ -5926,8 +4765,7 @@ msgstr "Premere per tentare di riconnetterti"
 msgid "Press to change hosting provider"
 msgstr "Premi per cambiare provider di hosting"
 
-#: src/components/Error.tsx:61
-#: src/components/Lists.tsx:93
+#: src/components/Error.tsx:61 src/components/Lists.tsx:93
 #: src/screens/Messages/components/MessageListError.tsx:24
 #: src/screens/Signup/BackNextButtons.tsx:48
 msgid "Press to retry"
@@ -5948,11 +4786,7 @@ msgstr "Lingua principale"
 #: src/screens/Settings/ThreadPreferences.tsx:99
 #: src/screens/Settings/ThreadPreferences.tsx:104
 msgid "Prioritize your Follows"
-msgstr ""
-
-#: src/view/screens/PreferencesThreads.tsx:92
-#~ msgid "Prioritize Your Follows"
-#~ msgstr "Dai priorità a quelli che segui"
+msgstr "Dai priorità ai chi segui"
 
 #: src/screens/Settings/NotificationSettings.tsx:54
 msgid "Priority notifications"
@@ -5962,45 +4796,36 @@ msgstr "Impostazioni di priorità"
 msgid "Privacy"
 msgstr "Privacy"
 
-#: src/screens/Settings/Settings.tsx:153
-#: src/screens/Settings/Settings.tsx:156
+#: src/screens/Settings/Settings.tsx:153 src/screens/Settings/Settings.tsx:156
 msgid "Privacy and security"
-msgstr ""
+msgstr "Privacy e sicurezza"
 
 #: src/Navigation.tsx:345
 #: src/screens/Settings/PrivacyAndSecuritySettings.tsx:33
 msgid "Privacy and Security"
-msgstr ""
+msgstr "Privacy e sicurezza"
 
-#: src/Navigation.tsx:269
-#: src/screens/Settings/AboutSettings.tsx:38
+#: src/Navigation.tsx:269 src/screens/Settings/AboutSettings.tsx:38
 #: src/screens/Settings/AboutSettings.tsx:41
-#: src/view/screens/PrivacyPolicy.tsx:31
-#: src/view/shell/Drawer.tsx:624
+#: src/view/screens/PrivacyPolicy.tsx:31 src/view/shell/Drawer.tsx:624
 #: src/view/shell/Drawer.tsx:625
 msgid "Privacy Policy"
 msgstr "Informativa sulla privacy"
 
-#~ msgid "Privately chat with other users."
-#~ msgstr "Messaggia privatamente con altri utenti."
-
 #: src/view/com/composer/Composer.tsx:1619
 msgid "Processing video..."
-msgstr ""
+msgstr "Elaborazione video in corso..."
 
-#: src/lib/api/index.ts:59
-#: src/screens/Login/ForgotPasswordForm.tsx:149
+#: src/lib/api/index.ts:59 src/screens/Login/ForgotPasswordForm.tsx:149
 msgid "Processing..."
 msgstr "Elaborazione in corso…"
 
-#: src/view/screens/DebugMod.tsx:913
-#: src/view/screens/Profile.tsx:363
+#: src/view/screens/DebugMod.tsx:913 src/view/screens/Profile.tsx:363
 msgid "profile"
 msgstr "profilo"
 
 #: src/view/shell/bottom-bar/BottomBar.tsx:271
-#: src/view/shell/desktop/LeftNav.tsx:493
-#: src/view/shell/Drawer.tsx:71
+#: src/view/shell/desktop/LeftNav.tsx:493 src/view/shell/Drawer.tsx:71
 #: src/view/shell/Drawer.tsx:516
 msgid "Profile"
 msgstr "Profilo"
@@ -6009,10 +4834,6 @@ msgstr "Profilo"
 #: src/view/com/modals/EditProfile.tsx:124
 msgid "Profile updated"
 msgstr "Profilo aggiornato"
-
-#: src/view/screens/Settings/index.tsx:976
-#~ msgid "Protect your account by verifying your email."
-#~ msgstr "Proteggi il tuo account verificando la tua email."
 
 #: src/screens/Onboarding/StepFinished.tsx:242
 msgid "Public"
@@ -6026,14 +4847,6 @@ msgstr "Elenchi pubblici e condivisibili di utenti da disattivare o bloccare in 
 msgid "Public, shareable lists which can drive feeds."
 msgstr "Liste pubbliche e condivisibili che possono impulsare i feed."
 
-#: src/view/com/composer/Composer.tsx:579
-#~ msgid "Publish post"
-#~ msgstr "Pubblica il post"
-
-#: src/view/com/composer/Composer.tsx:579
-#~ msgid "Publish reply"
-#~ msgstr "Pubblica la risposta"
-
 #: src/components/StarterPack/QrCodeDialog.tsx:128
 msgid "QR code copied to your clipboard!"
 msgstr "Codice QR copiato!"
@@ -6046,29 +4859,12 @@ msgstr "Codice QR scaricato!"
 msgid "QR code saved to your camera roll!"
 msgstr "Codice QR salvato nella galleria!"
 
-#: src/view/com/util/post-ctrls/RepostButton.tsx:127
-#: src/view/com/util/post-ctrls/RepostButton.tsx:154
-#: src/tours/Tooltip.tsx:111
-#~ msgid "Quick tip"
-#~ msgstr ""
-
 #: src/view/com/util/post-ctrls/RepostButton.tsx:129
 #: src/view/com/util/post-ctrls/RepostButton.tsx:156
 #: src/view/com/util/post-ctrls/RepostButton.web.tsx:85
 #: src/view/com/util/post-ctrls/RepostButton.web.tsx:92
 msgid "Quote post"
 msgstr "Cita il post"
-
-#~ msgctxt "action"
-#~ msgid "Quote post"
-#~ msgstr "Cita il post"
-
-#~ msgctxt "action"
-#~ msgid "Quote Post"
-#~ msgstr "Cita il post"
-
-#~ msgid "Quote Post"
-#~ msgstr "Cita il post"
 
 #: src/view/com/util/forms/PostDropdownBtn.tsx:308
 msgid "Quote post was re-attached"
@@ -6094,8 +4890,7 @@ msgstr "Citazioni post attivate"
 msgid "Quote settings"
 msgstr "Impostazioni citazioni"
 
-#: src/screens/Post/PostQuotes.tsx:32
-#: src/screens/Post/PostQuotes.tsx:33
+#: src/screens/Post/PostQuotes.tsx:32 src/screens/Post/PostQuotes.tsx:33
 msgid "Quotes"
 msgstr "Citazioni"
 
@@ -6110,10 +4905,7 @@ msgstr "Selezione a caso (nota anche come \"Poster's Roulette\")"
 
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:566
 msgid "Rate limit exceeded – you've tried to change your handle too many times in a short period. Please wait a minute before trying again."
-msgstr ""
-
-#~ msgid "Ratios"
-#~ msgstr "Rapporti"
+msgstr "Limite di richieste superato: hai provato a cambiare il nome utente troppe volte in un breve lasso di tempo. Attendi un minuto prima di riprovare."
 
 #: src/view/com/util/forms/PostDropdownBtn.tsx:585
 #: src/view/com/util/forms/PostDropdownBtn.tsx:595
@@ -6131,12 +4923,12 @@ msgstr "Leggi il blog di Bluesky"
 #: src/screens/Signup/StepInfo/Policies.tsx:58
 #: src/screens/Signup/StepInfo/Policies.tsx:84
 msgid "Read the Bluesky Privacy Policy"
-msgstr "Leggi l'Informativa sulla Privacy di Bluesky"
+msgstr "Leggi l'informativa sulla privacy di Bluesky"
 
 #: src/screens/Signup/StepInfo/Policies.tsx:51
 #: src/screens/Signup/StepInfo/Policies.tsx:71
 msgid "Read the Bluesky Terms of Service"
-msgstr "Leggi i Termini di Servizio di Bluesky"
+msgstr "Leggi i termini di servizio di Bluesky"
 
 #: src/components/dms/ReportDialog.tsx:169
 msgid "Reason:"
@@ -6145,12 +4937,6 @@ msgstr "Motivo:"
 #: src/view/screens/Search/Search.tsx:1057
 msgid "Recent Searches"
 msgstr "Ricerche recenti"
-
-#~ msgid "Recommended Feeds"
-#~ msgstr "Feed consigliati"
-
-#~ msgid "Recommended Users"
-#~ msgstr "Utenti consigliati"
 
 #: src/screens/Messages/components/MessageListError.tsx:20
 msgid "Reconnect"
@@ -6164,8 +4950,7 @@ msgstr "Ricarica notifiche"
 msgid "Reload conversations"
 msgstr "Ricarica conversazioni"
 
-#: src/components/dialogs/MutedWords.tsx:438
-#: src/components/FeedCard.tsx:316
+#: src/components/dialogs/MutedWords.tsx:438 src/components/FeedCard.tsx:316
 #: src/components/StarterPack/Wizard/WizardListCard.tsx:102
 #: src/components/StarterPack/Wizard/WizardListCard.tsx:109
 #: src/screens/Settings/Settings.tsx:458
@@ -6176,15 +4961,11 @@ msgstr "Ricarica conversazioni"
 msgid "Remove"
 msgstr "Rimuovi"
 
-#~ msgid "Remove {0} from my feeds?"
-#~ msgstr "Rimuovere {0} dai miei feed?"
-
 #: src/components/StarterPack/Wizard/WizardListCard.tsx:58
 msgid "Remove {displayName} from starter pack"
 msgstr "Rimuovi {displayName} dallo starter pack"
 
-#: src/screens/Settings/Settings.tsx:437
-#: src/screens/Settings/Settings.tsx:440
+#: src/screens/Settings/Settings.tsx:437 src/screens/Settings/Settings.tsx:440
 msgid "Remove account"
 msgstr "Rimuovi l'account"
 
@@ -6216,15 +4997,12 @@ msgstr "Rimuovere il feed?"
 
 #: src/view/com/feeds/FeedSourceCard.tsx:190
 #: src/view/com/feeds/FeedSourceCard.tsx:268
-#: src/view/screens/ProfileFeed.tsx:337
-#: src/view/screens/ProfileFeed.tsx:343
-#: src/view/screens/ProfileList.tsx:502
-#: src/view/screens/SavedFeeds.tsx:351
+#: src/view/screens/ProfileFeed.tsx:337 src/view/screens/ProfileFeed.tsx:343
+#: src/view/screens/ProfileList.tsx:502 src/view/screens/SavedFeeds.tsx:351
 msgid "Remove from my feeds"
 msgstr "Rimuovi dai miei feed"
 
-#: src/components/FeedCard.tsx:311
-#: src/view/com/feeds/FeedSourceCard.tsx:314
+#: src/components/FeedCard.tsx:311 src/view/com/feeds/FeedSourceCard.tsx:314
 msgid "Remove from my feeds?"
 msgstr "Rimuovere dai miei feed?"
 
@@ -6239,9 +5017,6 @@ msgstr "Rimuovi dai feed salvati"
 #: src/view/com/composer/photos/Gallery.tsx:203
 msgid "Remove image"
 msgstr "Rimuovi l'immagine"
-
-#~ msgid "Remove image preview"
-#~ msgstr "Rimuovi l'anteprima dell'immagine"
 
 #: src/components/dialogs/MutedWords.tsx:523
 msgid "Remove mute word from your list"
@@ -6268,15 +5043,9 @@ msgstr "Rimuovi la ripubblicazione"
 msgid "Remove subtitle file"
 msgstr "Sottotitolo rimosso"
 
-#~ msgid "Remove this feed from my feeds?"
-#~ msgstr "Rimuovere questo feed dai miei feed?"
-
 #: src/view/com/posts/FeedErrorMessage.tsx:211
 msgid "Remove this feed from your saved feeds"
 msgstr "Rimuovi questo feed dai feed salvati"
-
-#~ msgid "Remove this feed from your saved feeds?"
-#~ msgstr "Elimina questo feed dai feed salvati?"
 
 #: src/view/com/util/post-embeds/QuoteEmbed.tsx:109
 msgid "Removed by author"
@@ -6301,23 +5070,13 @@ msgid "Removed from saved feeds"
 msgstr "Rimosso dai feed salvati"
 
 #: src/view/com/posts/FeedShutdownMsg.tsx:44
-#: src/view/screens/ProfileFeed.tsx:197
-#: src/view/screens/ProfileList.tsx:386
+#: src/view/screens/ProfileFeed.tsx:197 src/view/screens/ProfileList.tsx:386
 msgid "Removed from your feeds"
 msgstr "Rimosso dai tuoi feed"
-
-#~ msgid "Removes default thumbnail from {0}"
-#~ msgstr "Elimina la miniatura predefinita da {0}"
 
 #: src/view/com/util/post-embeds/QuoteEmbed.tsx:288
 msgid "Removes quoted post"
 msgstr "Rimuovi post citato"
-
-#~ msgid "Removes the attachment"
-#~ msgstr ""
-
-#~ msgid "Removes the image preview"
-#~ msgstr "Rimuove la preview dell'immagine"
 
 #: src/view/com/posts/FeedShutdownMsg.tsx:129
 #: src/view/com/posts/FeedShutdownMsg.tsx:133
@@ -6332,23 +5091,14 @@ msgstr "Risposte"
 msgid "Replies disabled"
 msgstr "Risposte disattivate"
 
-#~ msgid "Replies on this thread are disabled"
-#~ msgstr "Le risposte a questo thread sono disattivate"
-
 #: src/components/WhoCanReply.tsx:215
 msgid "Replies to this post are disabled."
 msgstr "Le risposte a questo post sono disattivate."
-
-#~ msgid "Replies to this thread are disabled"
-#~ msgstr "Le risposte a questo thread sono disabilitate"
 
 #: src/view/com/composer/Composer.tsx:915
 msgctxt "action"
 msgid "Reply"
 msgstr "Risposta"
-
-#~ msgid "Reply Filters"
-#~ msgstr "Filtri di risposta"
 
 #: src/components/moderation/ModerationDetailsDialog.tsx:115
 #: src/lib/moderation/useModerationCauseDescription.ts:123
@@ -6368,12 +5118,7 @@ msgstr "Impostazioni risposte"
 msgid "Reply settings are chosen by the author of the thread"
 msgstr "Le impostazioni delle risposte sono scelte dall'autore del thread"
 
-#~ msgctxt "description"
-#~ msgid "Reply to <0/>"
-#~ msgstr "In risposta a <0/>"
-
-#: src/view/com/post/Post.tsx:204
-#: src/view/com/posts/FeedItem.tsx:553
+#: src/view/com/post/Post.tsx:204 src/view/com/posts/FeedItem.tsx:553
 msgctxt "description"
 msgid "Reply to <0><1/></0>"
 msgstr "Rispondi a <0><1/></0>"
@@ -6388,8 +5133,7 @@ msgctxt "description"
 msgid "Reply to a post"
 msgstr "Rispondi ad un post"
 
-#: src/view/com/post/Post.tsx:202
-#: src/view/com/posts/FeedItem.tsx:550
+#: src/view/com/post/Post.tsx:202 src/view/com/posts/FeedItem.tsx:550
 msgctxt "description"
 msgid "Reply to you"
 msgstr "Risposta"
@@ -6408,16 +5152,12 @@ msgstr "Risposta nascosta con successo"
 msgid "Report"
 msgstr "Segnala"
 
-#~ msgid "Report {collectionName}"
-#~ msgstr "Segnala {collectionName}"
-
 #: src/view/com/profile/ProfileMenu.tsx:299
 #: src/view/com/profile/ProfileMenu.tsx:302
 msgid "Report Account"
 msgstr "Segnala l'account"
 
-#: src/components/dms/ConvoMenu.tsx:197
-#: src/components/dms/ConvoMenu.tsx:200
+#: src/components/dms/ConvoMenu.tsx:197 src/components/dms/ConvoMenu.tsx:200
 #: src/components/dms/ReportConversationPrompt.tsx:18
 msgid "Report conversation"
 msgstr "Segnala la conversazione"
@@ -6426,8 +5166,7 @@ msgstr "Segnala la conversazione"
 msgid "Report dialog"
 msgstr "Segnala il dialogo"
 
-#: src/view/screens/ProfileFeed.tsx:354
-#: src/view/screens/ProfileFeed.tsx:356
+#: src/view/screens/ProfileFeed.tsx:354 src/view/screens/ProfileFeed.tsx:356
 msgid "Report feed"
 msgstr "Segnala il feed"
 
@@ -6498,9 +5237,6 @@ msgstr "Ripubblicare"
 msgid "Repost or quote post"
 msgstr "Ripubblica o cita il post"
 
-#~ msgid "Reposted by"
-#~ msgstr "Repost di"
-
 #: src/screens/Post/PostRepostedBy.tsx:32
 #: src/screens/Post/PostRepostedBy.tsx:33
 msgid "Reposted By"
@@ -6510,24 +5246,13 @@ msgstr "Ripubblicato da"
 msgid "Reposted by {0}"
 msgstr "Ripubblicato da{0}"
 
-#~ msgid "Reposted by {0})"
-#~ msgstr "Repost di {0})"
-
-#~ msgid "Reposted by <0/>"
-#~ msgstr "Repost di <0/>"
-
 #: src/view/com/posts/FeedItem.tsx:322
 msgid "Reposted by <0><1/></0>"
 msgstr "Ripubblicato da <0><1/></0>"
 
-#: src/view/com/posts/FeedItem.tsx:301
-#: src/view/com/posts/FeedItem.tsx:320
+#: src/view/com/posts/FeedItem.tsx:301 src/view/com/posts/FeedItem.tsx:320
 msgid "Reposted by you"
 msgstr "Ripubblicato da te"
-
-#: src/view/com/notifications/FeedItem.tsx:180
-#~ msgid "reposted your post"
-#~ msgstr "ripubblicato il tuo post"
 
 #: src/view/com/post-thread/PostThreadItem.tsx:217
 msgid "Reposts of this post"
@@ -6537,9 +5262,6 @@ msgstr "Ripubblicazioni di questo post"
 #: src/view/com/modals/ChangeEmail.tsx:178
 msgid "Request Change"
 msgstr "Richiedi un cambio"
-
-#~ msgid "Request code"
-#~ msgstr "Richiedi un codice"
 
 #: src/view/com/modals/ChangePassword.tsx:242
 #: src/view/com/modals/ChangePassword.tsx:244
@@ -6554,10 +5276,6 @@ msgstr "Richiedi il testo alternativo prima di pubblicare"
 #: src/screens/Settings/components/Email2FAToggle.tsx:54
 msgid "Require an email code to log in to your account."
 msgstr ""
-
-#: src/view/screens/Settings/Email2FAToggle.tsx:51
-#~ msgid "Require email code to log into your account"
-#~ msgstr "Richiedi il codice via email per accedere al tuo account"
 
 #: src/screens/Signup/StepInfo/index.tsx:159
 msgid "Required for this provider"
@@ -6590,33 +5308,13 @@ msgstr "Reimpostare il codice"
 msgid "Reset Code"
 msgstr "Reimposta il Codice"
 
-#~ msgid "Reset onboarding"
-#~ msgstr "Reimposta l'incorporazione"
-
-#: src/screens/Settings/Settings.tsx:335
-#: src/screens/Settings/Settings.tsx:337
+#: src/screens/Settings/Settings.tsx:335 src/screens/Settings/Settings.tsx:337
 msgid "Reset onboarding state"
 msgstr "Reimposta lo stato dell' incorporazione"
 
 #: src/screens/Login/ForgotPasswordForm.tsx:80
 msgid "Reset password"
 msgstr "Reimposta la password"
-
-#~ msgid "Reset preferences"
-#~ msgstr "Reimposta le preferenze"
-
-#: src/view/screens/Settings/index.tsx:847
-#: src/view/screens/Settings/index.tsx:850
-#~ msgid "Reset preferences state"
-#~ msgstr "Reimposta lo stato delle preferenze"
-
-#: src/view/screens/Settings/index.tsx:868
-#~ msgid "Resets the onboarding state"
-#~ msgstr "Reimposta lo stato dell'incorporazione"
-
-#: src/view/screens/Settings/index.tsx:848
-#~ msgid "Resets the preferences state"
-#~ msgstr "Reimposta lo stato delle preferenze"
 
 #: src/screens/Login/LoginForm.tsx:296
 msgid "Retries login"
@@ -6627,12 +5325,10 @@ msgstr "Ritenta l'accesso"
 msgid "Retries the last action, which errored out"
 msgstr "Ritenta l'ultima azione che ha generato un errore"
 
-#: src/components/dms/MessageItem.tsx:244
-#: src/components/Error.tsx:66
+#: src/components/dms/MessageItem.tsx:244 src/components/Error.tsx:66
 #: src/components/Lists.tsx:104
 #: src/components/StarterPack/ProfileStarterPacks.tsx:336
-#: src/screens/Login/LoginForm.tsx:295
-#: src/screens/Login/LoginForm.tsx:302
+#: src/screens/Login/LoginForm.tsx:295 src/screens/Login/LoginForm.tsx:302
 #: src/screens/Messages/components/MessageListError.tsx:25
 #: src/screens/Onboarding/StepInterests/index.tsx:217
 #: src/screens/Onboarding/StepInterests/index.tsx:220
@@ -6644,11 +5340,7 @@ msgstr "Ritenta l'ultima azione che ha generato un errore"
 msgid "Retry"
 msgstr "Riprova"
 
-#~ msgid "Retry."
-#~ msgstr "Riprova."
-
-#: src/components/Error.tsx:74
-#: src/screens/List/ListHiddenScreen.tsx:205
+#: src/components/Error.tsx:74 src/screens/List/ListHiddenScreen.tsx:205
 #: src/screens/StarterPack/StarterPackScreen.tsx:751
 #: src/view/screens/ProfileList.tsx:1030
 msgid "Return to previous page"
@@ -6658,13 +5350,9 @@ msgstr "Ritorna alla pagina precedente"
 msgid "Returns to home page"
 msgstr "Ritorna su Home"
 
-#: src/view/screens/NotFound.tsx:60
-#: src/view/screens/ProfileFeed.tsx:114
+#: src/view/screens/NotFound.tsx:60 src/view/screens/ProfileFeed.tsx:114
 msgid "Returns to previous page"
 msgstr "Ritorna alla pagina precedente"
-
-#~ msgid "SANDBOX. Posts and accounts are not permanent."
-#~ msgstr "SANDBOX. I post e gli account non sono permanenti."
 
 #: src/components/dialogs/BirthDateSettings.tsx:124
 #: src/components/dialogs/PostInteractionSettingsDialog.tsx:439
@@ -6680,8 +5368,7 @@ msgstr "Ritorna alla pagina precedente"
 #: src/view/com/composer/photos/ImageAltTextDialog.tsx:150
 #: src/view/com/composer/photos/ImageAltTextDialog.tsx:160
 #: src/view/com/modals/CreateOrEditList.tsx:317
-#: src/view/com/modals/EditProfile.tsx:219
-#: src/view/screens/SavedFeeds.tsx:103
+#: src/view/com/modals/EditProfile.tsx:219 src/view/screens/SavedFeeds.tsx:103
 msgid "Save"
 msgstr "Salva"
 
@@ -6691,25 +5378,17 @@ msgctxt "action"
 msgid "Save"
 msgstr "Salva"
 
-#~ msgid "Save alt text"
-#~ msgstr "Salva il testo alternativo"
-
 #: src/components/dialogs/BirthDateSettings.tsx:118
 msgid "Save birthday"
 msgstr "Salva il compleanno"
 
-#: src/view/screens/SavedFeeds.tsx:98
-#: src/view/screens/SavedFeeds.tsx:103
+#: src/view/screens/SavedFeeds.tsx:98 src/view/screens/SavedFeeds.tsx:103
 msgid "Save changes"
 msgstr "Salva modifiche"
 
 #: src/view/com/modals/EditProfile.tsx:227
 msgid "Save Changes"
-msgstr "Salva i cambi"
-
-#: src/view/com/modals/ChangeHandle.tsx:158
-#~ msgid "Save handle change"
-#~ msgstr "Salva la modifica del tuo identificatore"
+msgstr "Salva modifiche"
 
 #: src/components/StarterPack/ShareDialog.tsx:151
 #: src/components/StarterPack/ShareDialog.tsx:158
@@ -6722,14 +5401,13 @@ msgstr "Salva il ritaglio dell'immagine"
 
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:228
 msgid "Save new handle"
-msgstr ""
+msgstr "Salva nuovo nome utente"
 
 #: src/components/StarterPack/QrCodeDialog.tsx:179
 msgid "Save QR code"
 msgstr "Salva codice QR"
 
-#: src/view/screens/ProfileFeed.tsx:338
-#: src/view/screens/ProfileFeed.tsx:344
+#: src/view/screens/ProfileFeed.tsx:338 src/view/screens/ProfileFeed.tsx:344
 msgid "Save to my feeds"
 msgstr "Salva nei miei feed"
 
@@ -6741,11 +5419,7 @@ msgstr "Canali salvati"
 msgid "Saved to your camera roll"
 msgstr "Salvata nella tua galleria"
 
-#~ msgid "Saved to your camera roll."
-#~ msgstr "Salvato nel rullino fotografico."
-
-#: src/view/screens/ProfileFeed.tsx:206
-#: src/view/screens/ProfileList.tsx:366
+#: src/view/screens/ProfileFeed.tsx:206 src/view/screens/ProfileList.tsx:366
 msgid "Saved to your feeds"
 msgstr "Salvato nei tuoi feed"
 
@@ -6753,23 +5427,17 @@ msgstr "Salvato nei tuoi feed"
 msgid "Saves any changes to your profile"
 msgstr "Salva eventuali modifiche al tuo profilo"
 
-#: src/view/com/modals/ChangeHandle.tsx:159
-#~ msgid "Saves handle change to {handle}"
-#~ msgstr "Salva la modifica del cambio dell'utente in {handle}"
-
 #: src/view/com/modals/CropImage.web.tsx:105
 msgid "Saves image crop settings"
 msgstr "Salva le impostazioni di ritaglio dell'immagine"
 
-#: src/components/dms/ChatEmptyPill.tsx:33
-#: src/components/NewskieDialog.tsx:105
+#: src/components/dms/ChatEmptyPill.tsx:33 src/components/NewskieDialog.tsx:105
 #: src/view/com/notifications/FeedItem.tsx:539
 #: src/view/com/notifications/FeedItem.tsx:564
 msgid "Say hello!"
 msgstr "Di ciao!"
 
-#: src/screens/Onboarding/index.tsx:33
-#: src/screens/Onboarding/state.ts:99
+#: src/screens/Onboarding/index.tsx:33 src/screens/Onboarding/state.ts:99
 msgid "Science"
 msgstr "Scienza"
 
@@ -6779,13 +5447,11 @@ msgstr "Scorri verso l'alto"
 
 #: src/components/dms/dialogs/SearchablePeopleList.tsx:484
 #: src/components/forms/SearchInput.tsx:34
-#: src/components/forms/SearchInput.tsx:36
-#: src/Navigation.tsx:590
+#: src/components/forms/SearchInput.tsx:36 src/Navigation.tsx:590
 #: src/view/com/modals/ListAddRemoveUsers.tsx:76
 #: src/view/screens/Search/Search.tsx:594
 #: src/view/shell/bottom-bar/BottomBar.tsx:178
-#: src/view/shell/desktop/LeftNav.tsx:419
-#: src/view/shell/Drawer.tsx:365
+#: src/view/shell/desktop/LeftNav.tsx:419 src/view/shell/Drawer.tsx:365
 msgid "Search"
 msgstr "Cerca"
 
@@ -6796,14 +5462,6 @@ msgstr "Cerca \"{query}\""
 #: src/view/screens/Search/Search.tsx:1000
 msgid "Search for \"{searchText}\""
 msgstr "Cerca \"{searchText}\""
-
-#: src/components/TagMenu/index.tsx:155
-#~ msgid "Search for all posts by @{authorHandle} with tag {displayTag}"
-#~ msgstr "Cerca tutti i post di @{authorHandle} con tag {displayTag}"
-
-#: src/components/TagMenu/index.tsx:104
-#~ msgid "Search for all posts with tag {displayTag}"
-#~ msgstr "Cerca tutti i post con il tag {displayTag}"
 
 #: src/screens/StarterPack/Wizard/index.tsx:500
 msgid "Search for feeds that you want to suggest to others."
@@ -6850,15 +5508,9 @@ msgstr "Vedi <0>{displayTag}</0> posts di questo utente"
 msgid "See jobs at Bluesky"
 msgstr "Vedi offerte di lavoro in Bluesky"
 
-#~ msgid "See profile"
-#~ msgstr "Vedi il profilo"
-
 #: src/view/screens/SavedFeeds.tsx:212
 msgid "See this guide"
 msgstr "Consulta questa guida"
-
-#~ msgid "See what's next"
-#~ msgstr "Scopri cosa c'è dopo"
 
 #: src/view/com/util/post-embeds/VideoEmbedInner/web-controls/Scrubber.tsx:189
 msgid "Seek slider"
@@ -6884,12 +5536,9 @@ msgstr "Scegli un avatar"
 msgid "Select an emoji"
 msgstr "Scegli un emoji"
 
-#~ msgid "Select Bluesky Social"
-#~ msgstr "Seleziona Bluesky Social"
-
 #: src/screens/Settings/LanguageSettings.tsx:252
 msgid "Select content languages"
-msgstr ""
+msgstr "Seleziona le lingue dei contenuti"
 
 #: src/screens/Login/index.tsx:117
 msgid "Select from an existing account"
@@ -6923,12 +5572,6 @@ msgstr "Seleziona moderatore"
 msgid "Select option {i} of {numItems}"
 msgstr "Seleziona l'opzione {i} di {numItems}"
 
-#~ msgid "Select service"
-#~ msgstr "Selecciona el servei"
-
-#~ msgid "Select some accounts below to follow"
-#~ msgstr "Seleziona alcuni account da seguire qui giù"
-
 #: src/view/com/composer/videos/SubtitleFilePicker.tsx:66
 msgid "Select subtitle file (.vtt)"
 msgstr "Seleziona file dei sottotitoli (.vtt)"
@@ -6945,9 +5588,6 @@ msgstr "Seleziona il/i servizio/i di moderazione per fare la segnalazione"
 msgid "Select the service that hosts your data."
 msgstr "Seleziona il servizio che ospita i tuoi dati."
 
-#~ msgid "Select topical feeds to follow from the list below"
-#~ msgstr "Seleziona i feed con temi da seguire dal seguente elenco"
-
 #: src/view/com/composer/videos/SelectVideoBtn.tsx:106
 msgid "Select video"
 msgstr "Seleziona video"
@@ -6956,15 +5596,9 @@ msgstr "Seleziona video"
 msgid "Select what content this mute word should apply to."
 msgstr "Seleziona dove applicare questa parola silenziata."
 
-#~ msgid "Select what you want to see (or not see), and we’ll handle the rest."
-#~ msgstr "Seleziona ciò che vuoi vedere (o non vedere) e noi gestiremo il resto."
-
 #: src/screens/Settings/LanguageSettings.tsx:245
 msgid "Select which languages you want your subscribed feeds to include. If none are selected, all languages will be shown."
 msgstr "Seleziona le lingue che desideri includere nei feed a cui sei iscritto. Se non ne viene selezionata nessuna, verranno visualizzate tutte le lingue."
-
-#~ msgid "Select your app language for the default text to display in the app"
-#~ msgstr "Seleziona la lingua dell'app per il testo predefinito da visualizzare nell'app"
 
 #: src/screens/Settings/LanguageSettings.tsx:76
 msgid "Select your app language for the default text to display in the app."
@@ -6978,18 +5612,9 @@ msgstr "Seleziona la tua data di nascita"
 msgid "Select your interests from the options below"
 msgstr "Seleziona i tuoi interessi dalle seguenti opzioni"
 
-#~ msgid "Select your phone's country"
-#~ msgstr "Seleziona il Paese del tuo cellulare"
-
 #: src/screens/Settings/LanguageSettings.tsx:162
 msgid "Select your preferred language for translations in your feed."
 msgstr "Seleziona la tua lingua preferita per le traduzioni nel tuo feed."
-
-#~ msgid "Select your primary algorithmic feeds"
-#~ msgstr "Seleziona i tuoi feed algoritmici principali"
-
-#~ msgid "Select your secondary algorithmic feeds"
-#~ msgstr "Seleziona i tuoi feed algoritmici secondari"
 
 #: src/components/dms/ChatEmptyPill.tsx:38
 msgid "Send a neat website!"
@@ -7017,9 +5642,6 @@ msgctxt "action"
 msgid "Send Email"
 msgstr "Invia email"
 
-#~ msgid "Send Email"
-#~ msgstr "Envia Email"
-
 #: src/view/shell/Drawer.tsx:312
 msgid "Send feedback"
 msgstr "Invia feedback"
@@ -7039,9 +5661,6 @@ msgstr "Invia post a..."
 #: src/components/ReportDialog/SubmitView.tsx:224
 msgid "Send report"
 msgstr "Invia la segnalazione"
-
-#~ msgid "Send Report"
-#~ msgstr "Invia segnalazione"
 
 #: src/components/ReportDialog/SelectLabelerView.tsx:43
 msgid "Send report to {0}"
@@ -7065,108 +5684,24 @@ msgstr "Invia un'email con il codice di conferma per la cancellazione dell'accou
 msgid "Server address"
 msgstr "Indirizzo del server"
 
-#~ msgid "Set {value} for {labelGroup} content moderation policy"
-#~ msgstr "Imposta {value} per la politica di moderazione dei contenuti di {labelGroup}"
-
-#~ msgctxt "action"
-#~ msgid "Set Age"
-#~ msgstr "Imposta l'età"
-
 #: src/screens/Moderation/index.tsx:311
 msgid "Set birthdate"
 msgstr "Imposta la data di nascita"
-
-#~ msgid "Set color theme to dark"
-#~ msgstr "Imposta il colore del tema scuro"
-
-#~ msgid "Set color theme to light"
-#~ msgstr "Imposta il colore del tema su chiaro"
-
-#~ msgid "Set color theme to system setting"
-#~ msgstr "Imposta il colore del tema basato sulle impostazioni del tuo sistema"
-
-#~ msgid "Set dark theme to the dark theme"
-#~ msgstr "Imposta il tema scuro sul tema scuro"
-
-#~ msgid "Set dark theme to the dim theme"
-#~ msgstr "Imposta il tema scuro sul tema scuro"
 
 #: src/screens/Login/SetNewPasswordForm.tsx:96
 msgid "Set new password"
 msgstr "Imposta una nuova password"
 
-#~ msgid "Set password"
-#~ msgstr "Imposta la password"
-
-#: src/view/screens/PreferencesFollowingFeed.tsx:122
-#~ msgid "Set this setting to \"No\" to hide all quote posts from your feed. Reposts will still be visible."
-#~ msgstr "Seleziona \"No\" per nascondere tutti i post con le citazioni dal tuo feed. I repost saranno ancora visibili."
-
-#: src/view/screens/PreferencesFollowingFeed.tsx:64
-#~ msgid "Set this setting to \"No\" to hide all replies from your feed."
-#~ msgstr "Seleziona \"No\" per nascondere tutte le risposte dal tuo feed."
-
-#: src/view/screens/PreferencesFollowingFeed.tsx:88
-#~ msgid "Set this setting to \"No\" to hide all reposts from your feed."
-#~ msgstr "Seleziona \"No\" per nascondere tutte le ripubblicazioni dal tuo feed."
-
-#: src/view/screens/PreferencesThreads.tsx:117
-#~ msgid "Set this setting to \"Yes\" to show replies in a threaded view. This is an experimental feature."
-#~ msgstr "Seleziona \"Sì\" per mostrare le risposte in una visualizzazione concatenata. Questa è una funzionalità sperimentale."
-
-#~ msgid "Set this setting to \"Yes\" to show samples of your saved feeds in your following feed. This is an experimental feature."
-#~ msgstr "Seleziona \"Sì\" per mostrare esempi dei feed salvati nel feed successivo. Questa è una funzionalità sperimentale."
-
-#: src/view/screens/PreferencesFollowingFeed.tsx:158
-#~ msgid "Set this setting to \"Yes\" to show samples of your saved feeds in your Following feed. This is an experimental feature."
-#~ msgstr "Imposta questa impostazione su \"Sì\" per mostrare esempi dei tuoi feed salvati nel feed Seguiti. Questa è una funzionalità sperimentale."
-
 #: src/screens/Onboarding/Layout.tsx:48
 msgid "Set up your account"
 msgstr "Configura il tuo account"
-
-#: src/view/com/modals/ChangeHandle.tsx:254
-#~ msgid "Sets Bluesky username"
-#~ msgstr "Imposta il tuo nome utente di Bluesky"
-
-#~ msgid "Sets color theme to dark"
-#~ msgstr "Imposta il tema scuro"
-
-#~ msgid "Sets color theme to light"
-#~ msgstr "Imposta il tema chiaro"
-
-#~ msgid "Sets color theme to system setting"
-#~ msgstr "Imposta il tema basato impostazioni di sistema"
-
-#~ msgid "Sets dark theme to the dark theme"
-#~ msgstr "Imposta il tema scuro"
-
-#~ msgid "Sets dark theme to the dim theme"
-#~ msgstr "Imposta il tema soffuso"
 
 #: src/screens/Login/ForgotPasswordForm.tsx:107
 msgid "Sets email for password reset"
 msgstr "Imposta l'email per la reimpostazione della password"
 
-#~ msgid "Sets hosting provider for password reset"
-#~ msgstr "Imposta il provider del hosting per la reimpostazione della password"
-
-#~ msgid "Sets image aspect ratio to square"
-#~ msgstr "Imposta le proporzioni quadrate sull'immagine"
-
-#~ msgid "Sets image aspect ratio to tall"
-#~ msgstr "Imposta l'altura sulle proporzioni dell'immagine"
-
-#~ msgid "Sets image aspect ratio to wide"
-#~ msgstr "Imposta l'amplio sulle proporzioni dell'immagine"
-
-#~ msgid "Sets server for the Bluesky client"
-#~ msgstr "Imposta il server per il client Bluesky"
-
-#: src/Navigation.tsx:158
-#: src/screens/Settings/Settings.tsx:76
-#: src/view/shell/desktop/LeftNav.tsx:511
-#: src/view/shell/Drawer.tsx:529
+#: src/Navigation.tsx:158 src/screens/Settings/Settings.tsx:76
+#: src/view/shell/desktop/LeftNav.tsx:511 src/view/shell/Drawer.tsx:529
 msgid "Settings"
 msgstr "Impostazioni"
 
@@ -7209,8 +5744,7 @@ msgstr "Condividi un fatto divertente!"
 msgid "Share anyway"
 msgstr "Condividi comunque"
 
-#: src/view/screens/ProfileFeed.tsx:364
-#: src/view/screens/ProfileFeed.tsx:366
+#: src/view/screens/ProfileFeed.tsx:364 src/view/screens/ProfileFeed.tsx:366
 msgid "Share feed"
 msgstr "Condividi il feed"
 
@@ -7260,14 +5794,6 @@ msgstr "Condivide il sito Web nel link"
 msgid "Show"
 msgstr "Mostra"
 
-#: src/view/com/util/post-embeds/GifEmbed.tsx:166
-#: src/view/screens/Search/Search.tsx:889
-#~ msgid "Show advanced filters"
-#~ msgstr ""
-
-#~ msgid "Show all replies"
-#~ msgstr "Mostra tutte le repliche"
-
 #: src/view/com/util/post-embeds/GifEmbed.tsx:178
 msgid "Show alt text"
 msgstr "Mostra testo alternativo"
@@ -7287,12 +5813,6 @@ msgstr "Mostra badge"
 msgid "Show badge and filter from feeds"
 msgstr "Mostra badge e filtra dai feed"
 
-#~ msgid "Show embeds from {0}"
-#~ msgstr "Mostra incorporamenti di {0}"
-
-#~ msgid "Show follows similar to {0}"
-#~ msgstr "Mostra follows simile a {0}"
-
 #: src/view/com/post-thread/PostThreadShowHiddenReplies.tsx:23
 msgid "Show hidden replies"
 msgstr "Mostra risposte nascoste"
@@ -7311,8 +5831,7 @@ msgid "Show list anyway"
 msgstr "Mosta comunque questa lista"
 
 #: src/view/com/post-thread/PostThreadItem.tsx:588
-#: src/view/com/post/Post.tsx:242
-#: src/view/com/posts/FeedItem.tsx:509
+#: src/view/com/post/Post.tsx:242 src/view/com/posts/FeedItem.tsx:509
 msgid "Show More"
 msgstr "Mostra di più"
 
@@ -7329,57 +5848,23 @@ msgstr "Mosta risposte silenziate"
 msgid "Show other accounts you can switch to"
 msgstr ""
 
-#: src/view/screens/PreferencesFollowingFeed.tsx:155
-#~ msgid "Show Posts from My Feeds"
-#~ msgstr "Mostra post dai miei feed"
-
 #: src/screens/Settings/FollowingFeedPreferences.tsx:97
 #: src/screens/Settings/FollowingFeedPreferences.tsx:107
 msgid "Show quote posts"
-msgstr ""
-
-#: src/view/screens/PreferencesFollowingFeed.tsx:119
-#~ msgid "Show Quote Posts"
-#~ msgstr "Mostra post con citazioni"
-
-#~ msgid "Show quote-posts in Following feed"
-#~ msgstr "Mostra i post con citazioni nel feed Seguiti"
-
-#~ msgid "Show quotes in Following"
-#~ msgstr "Mostra le citazioni in Seguiti"
-
-#~ msgid "Show re-posts in Following feed"
-#~ msgstr "Mostra re-post nel feed Seguiti"
+msgstr "Mostra i post con citazione"
 
 #: src/screens/Settings/FollowingFeedPreferences.tsx:61
 #: src/screens/Settings/FollowingFeedPreferences.tsx:71
 msgid "Show replies"
-msgstr ""
-
-#: src/view/screens/PreferencesFollowingFeed.tsx:61
-#~ msgid "Show Replies"
-#~ msgstr "Mostra risposte"
+msgstr "Mostra risposte"
 
 #: src/screens/Settings/ThreadPreferences.tsx:113
 msgid "Show replies by people you follow before all other replies"
-msgstr ""
-
-#: src/view/screens/PreferencesThreads.tsx:95
-#~ msgid "Show replies by people you follow before all other replies."
-#~ msgstr "Mostra le risposte delle persone che segui prima delle altre risposte."
+msgstr "Mostra risposte delle persone che segui prima delle altre risposte"
 
 #: src/screens/Settings/ThreadPreferences.tsx:138
 msgid "Show replies in a threaded view"
-msgstr ""
-
-#~ msgid "Show replies in Following"
-#~ msgstr "Mostra le risposte in Seguiti"
-
-#~ msgid "Show replies in Following feed"
-#~ msgstr "Mostra le risposte nel feed Seguiti"
-
-#~ msgid "Show replies with at least {value} {0}"
-#~ msgstr "Mostra risposte con almeno {value} {0}"
+msgstr "Mostra risposte in modalità a thread"
 
 #: src/view/com/util/forms/PostDropdownBtn.tsx:559
 #: src/view/com/util/forms/PostDropdownBtn.tsx:569
@@ -7391,13 +5876,6 @@ msgstr "Mostra risposta per tutti"
 msgid "Show reposts"
 msgstr ""
 
-#: src/view/screens/PreferencesFollowingFeed.tsx:85
-#~ msgid "Show Reposts"
-#~ msgstr "Mostra ripubblicazioni"
-
-#~ msgid "Show reposts in Following"
-#~ msgstr "Mostra i re-repost in Seguiti"
-
 #: src/screens/Settings/FollowingFeedPreferences.tsx:122
 #: src/screens/Settings/FollowingFeedPreferences.tsx:132
 msgid "Show samples of your saved feeds in your Following feed"
@@ -7408,9 +5886,6 @@ msgstr ""
 msgid "Show the content"
 msgstr "Mostra il contenuto"
 
-#~ msgid "Show users"
-#~ msgstr "Mostra utenti"
-
 #: src/lib/moderation/useLabelBehaviorDescription.ts:58
 msgid "Show warning"
 msgstr "Mostra avviso"
@@ -7419,18 +5894,9 @@ msgstr "Mostra avviso"
 msgid "Show warning and filter from feeds"
 msgstr "Mostra avviso e filtra dai feed"
 
-#~ msgid "Shows a list of users similar to this user."
-#~ msgstr "Mostra un elenco di utenti simili a questo utente."
-
-#~ msgid "Shows posts from {0} in your feed"
-#~ msgstr "Mostra i post di {0} nel tuo feed"
-
-#: src/components/dialogs/Signin.tsx:97
-#: src/components/dialogs/Signin.tsx:99
-#: src/screens/Login/index.tsx:97
-#: src/screens/Login/index.tsx:116
-#: src/screens/Login/LoginForm.tsx:163
-#: src/view/com/auth/SplashScreen.tsx:62
+#: src/components/dialogs/Signin.tsx:97 src/components/dialogs/Signin.tsx:99
+#: src/screens/Login/index.tsx:97 src/screens/Login/index.tsx:116
+#: src/screens/Login/LoginForm.tsx:163 src/view/com/auth/SplashScreen.tsx:62
 #: src/view/com/auth/SplashScreen.tsx:70
 #: src/view/com/auth/SplashScreen.web.tsx:123
 #: src/view/com/auth/SplashScreen.web.tsx:131
@@ -7440,13 +5906,9 @@ msgstr "Mostra avviso e filtra dai feed"
 #: src/view/shell/bottom-bar/BottomBarWeb.tsx:205
 #: src/view/shell/bottom-bar/BottomBarWeb.tsx:206
 #: src/view/shell/bottom-bar/BottomBarWeb.tsx:208
-#: src/view/shell/NavSignupCard.tsx:57
-#: src/view/shell/NavSignupCard.tsx:62
+#: src/view/shell/NavSignupCard.tsx:57 src/view/shell/NavSignupCard.tsx:62
 msgid "Sign in"
 msgstr "Accedi"
-
-#~ msgid "Sign In"
-#~ msgstr "Accedi"
 
 #: src/components/AccountList.tsx:122
 msgid "Sign in as {0}"
@@ -7460,27 +5922,18 @@ msgstr "Accedi come..."
 msgid "Sign in or create your account to join the conversation!"
 msgstr "Accedi o crea il tuo account per partecipare alla conversazione!"
 
-#~ msgid "Sign into"
-#~ msgstr "Accedi a"
-
 #: src/components/dialogs/Signin.tsx:46
 msgid "Sign into Bluesky or create a new account"
 msgstr "Accedi a Bluesky o crea un nuovo account"
 
-#: src/screens/Settings/Settings.tsx:217
-#: src/screens/Settings/Settings.tsx:219
+#: src/screens/Settings/Settings.tsx:217 src/screens/Settings/Settings.tsx:219
 #: src/screens/Settings/Settings.tsx:251
 msgid "Sign out"
 msgstr "Esci"
 
-#: src/view/screens/Settings/index.tsx:421
-#: src/view/screens/Settings/index.tsx:431
-#~ msgid "Sign out of all accounts"
-#~ msgstr "Scollega tutti gli account"
-
 #: src/screens/Settings/Settings.tsx:248
 msgid "Sign out?"
-msgstr ""
+msgstr "Uscire?"
 
 #: src/view/shell/bottom-bar/BottomBar.tsx:301
 #: src/view/shell/bottom-bar/BottomBar.tsx:302
@@ -7488,35 +5941,19 @@ msgstr ""
 #: src/view/shell/bottom-bar/BottomBarWeb.tsx:195
 #: src/view/shell/bottom-bar/BottomBarWeb.tsx:196
 #: src/view/shell/bottom-bar/BottomBarWeb.tsx:198
-#: src/view/shell/NavSignupCard.tsx:47
-#: src/view/shell/NavSignupCard.tsx:52
+#: src/view/shell/NavSignupCard.tsx:47 src/view/shell/NavSignupCard.tsx:52
 msgid "Sign up"
 msgstr "Iscrizione"
-
-#: src/view/shell/NavSignupCard.tsx:47
-#~ msgid "Sign up or sign in to join the conversation"
-#~ msgstr "Iscriviti o accedi per partecipare alla conversazione"
 
 #: src/components/moderation/ScreenHider.tsx:91
 #: src/lib/moderation/useGlobalLabelStrings.ts:28
 msgid "Sign-in Required"
 msgstr "È richiesta l'autenticazione"
 
-#: src/view/screens/Settings/index.tsx:362
-#~ msgid "Signed in as"
-#~ msgstr "Iscritto/a come"
-
 #: src/lib/hooks/useAccountSwitcher.ts:41
 #: src/screens/Login/ChooseAccountForm.tsx:53
 msgid "Signed in as @{0}"
 msgstr "Iscritto/a come @{0}"
-
-#: src/view/com/notifications/FeedItem.tsx:218
-#~ msgid "signed up with your starter pack"
-#~ msgstr "iscritto/a col tuo starter pack"
-
-#~ msgid "Signs {0} out of Bluesky"
-#~ msgstr "Esci da Bluesky con {0}"
 
 #: src/screens/StarterPack/StarterPackLandingScreen.tsx:299
 #: src/screens/StarterPack/StarterPackLandingScreen.tsx:306
@@ -7540,11 +5977,7 @@ msgstr "Salta"
 msgid "Smaller"
 msgstr "Più piccolo"
 
-#~ msgid "SMS verification"
-#~ msgstr "Verifica tramite SMS"
-
-#: src/screens/Onboarding/index.tsx:37
-#: src/screens/Onboarding/state.ts:87
+#: src/screens/Onboarding/index.tsx:37 src/screens/Onboarding/state.ts:87
 msgid "Software Dev"
 msgstr "Sviluppo Software"
 
@@ -7556,15 +5989,9 @@ msgstr "Altri feed che potrebbero piacerti"
 msgid "Some people can reply"
 msgstr "Solo alcune persone possono rispondere"
 
-#~ msgid "Some subtitle"
-#~ msgstr "Altri sottotitoli"
-
 #: src/screens/Messages/Conversation.tsx:112
 msgid "Something went wrong"
 msgstr "Qualcosa è andato storto"
-
-#~ msgid "Something went wrong and we're not sure what."
-#~ msgstr "Qualcosa è andato storto ma non siamo sicuri di cosa."
 
 #: src/screens/Deactivated.tsx:94
 #: src/screens/Settings/components/DeactivateAccountDialog.tsx:59
@@ -7582,25 +6009,17 @@ msgstr "Qualcosa è andato male, prova di nuovo."
 msgid "Something went wrong!"
 msgstr "Qualcosa è andato storto!"
 
-#~ msgid "Something went wrong. Check your email and try again."
-#~ msgstr "Qualcosa è andato storto. Controlla la tua email e riprova."
-
-#: src/App.native.tsx:112
-#: src/App.web.tsx:95
+#: src/App.native.tsx:112 src/App.web.tsx:95
 msgid "Sorry! Your session expired. Please log in again."
 msgstr "Scusa! La tua sessione è scaduta. Per favore accedi di nuovo."
 
 #: src/screens/Settings/ThreadPreferences.tsx:48
 msgid "Sort replies"
-msgstr ""
-
-#: src/view/screens/PreferencesThreads.tsx:64
-#~ msgid "Sort Replies"
-#~ msgstr "Ordina le risposte"
+msgstr "Ordina risposte"
 
 #: src/screens/Settings/ThreadPreferences.tsx:55
 msgid "Sort replies by"
-msgstr ""
+msgstr "Ordina risposte per"
 
 #: src/screens/Settings/ThreadPreferences.tsx:52
 msgid "Sort replies to the same post by:"
@@ -7609,12 +6028,6 @@ msgstr "Ordina le risposte allo stesso post per:"
 #: src/components/moderation/LabelsOnMeDialog.tsx:168
 msgid "Source:"
 msgstr "Origine:"
-
-#~ msgid "Source: <0>{0}</0>"
-#~ msgstr "Fonte: <0>{0}</0>"
-
-#~ msgid "Source: <0>{sourceName}</0>"
-#~ msgstr "Fonte: <0>{sourceName}</0>"
 
 #: src/lib/moderation/useReportOptions.ts:72
 #: src/lib/moderation/useReportOptions.ts:85
@@ -7625,16 +6038,9 @@ msgstr "Spam"
 msgid "Spam; excessive mentions or replies"
 msgstr "Spam; menzioni o risposte eccessive"
 
-#: src/screens/Onboarding/index.tsx:27
-#: src/screens/Onboarding/state.ts:100
+#: src/screens/Onboarding/index.tsx:27 src/screens/Onboarding/state.ts:100
 msgid "Sports"
 msgstr "Sports"
-
-#~ msgid "Square"
-#~ msgstr "Quadrato"
-
-#~ msgid "Staging"
-#~ msgstr "Allestimento"
 
 #: src/components/dms/dialogs/NewChatDialog.tsx:72
 msgid "Start a new chat"
@@ -7644,15 +6050,7 @@ msgstr "Avvia una nuova conversazione"
 msgid "Start chat with {displayName}"
 msgstr "Avvia conversazione con {displayName}"
 
-#~ msgid "Start chatting"
-#~ msgstr "Iniza a conversare"
-
-#: src/tours/Tooltip.tsx:99
-#~ msgid "Start of onboarding tour window. Do not move backward. Instead, go forward for more options, or press to skip."
-#~ msgstr ""
-
-#: src/Navigation.tsx:393
-#: src/Navigation.tsx:398
+#: src/Navigation.tsx:393 src/Navigation.tsx:398
 #: src/screens/StarterPack/Wizard/index.tsx:191
 msgid "Starter Pack"
 msgstr "Starter Pack"
@@ -7677,30 +6075,20 @@ msgstr "Starter pack"
 msgid "Starter packs let you easily share your favorite feeds and people with your friends."
 msgstr "Gli starter pack ti permettono di condividere utenti e feed preferiti coi tuoi amici."
 
-#~ msgid "Status page"
-#~ msgstr "Pagina di stato"
-
 #: src/screens/Settings/AboutSettings.tsx:46
 #: src/screens/Settings/AboutSettings.tsx:49
 msgid "Status Page"
 msgstr "Pagina di stato"
 
-#~ msgid "Step"
-#~ msgstr "Passo"
-
 #: src/screens/Signup/index.tsx:130
 msgid "Step {0} of {1}"
 msgstr "Step {0} di {1}"
-
-#~ msgid "Step {0} of {numSteps}"
-#~ msgstr "Passo {0} di {numSteps}"
 
 #: src/screens/Settings/Settings.tsx:300
 msgid "Storage cleared, you need to restart the app now."
 msgstr "Spazio di archiviazione eliminato. Riavvia l'app."
 
-#: src/Navigation.tsx:244
-#: src/screens/Settings/Settings.tsx:316
+#: src/Navigation.tsx:244 src/screens/Settings/Settings.tsx:316
 msgid "Storybook"
 msgstr "Cronologia"
 
@@ -7723,9 +6111,6 @@ msgstr "Iscriviti a @{0} per utilizzare queste etichette:"
 msgid "Subscribe to Labeler"
 msgstr "Iscriviti a Labeler"
 
-#~ msgid "Subscribe to the {0} feed"
-#~ msgstr "Iscriviti a {0} feed"
-
 #: src/screens/Profile/Header/ProfileHeaderLabeler.tsx:204
 msgid "Subscribe to this labeler"
 msgstr "Iscriviti a questo labeler"
@@ -7742,9 +6127,6 @@ msgstr "Successo!"
 msgid "Suggested accounts"
 msgstr "Account suggeriti"
 
-#~ msgid "Suggested Follows"
-#~ msgstr "Accounts da seguire"
-
 #: src/components/FeedInterstitials.tsx:318
 msgid "Suggested for you"
 msgstr "Suggerito per te"
@@ -7754,36 +6136,20 @@ msgstr "Suggerito per te"
 msgid "Suggestive"
 msgstr "Suggestivo"
 
-#: src/Navigation.tsx:264
-#: src/view/screens/Support.tsx:31
+#: src/Navigation.tsx:264 src/view/screens/Support.tsx:31
 #: src/view/screens/Support.tsx:34
 msgid "Support"
 msgstr "Supporto"
 
-#~ msgid "Swipe up to see more"
-#~ msgstr "Scorri verso l'alto per vedere di più"
-
-#: src/screens/Settings/Settings.tsx:94
-#: src/screens/Settings/Settings.tsx:108
+#: src/screens/Settings/Settings.tsx:94 src/screens/Settings/Settings.tsx:108
 #: src/screens/Settings/Settings.tsx:403
 msgid "Switch account"
-msgstr ""
+msgstr "Cambia account"
 
 #: src/components/dialogs/SwitchAccount.tsx:46
 #: src/components/dialogs/SwitchAccount.tsx:49
 msgid "Switch Account"
 msgstr "Cambia account"
-
-#~ msgid "Switch between feeds to control your experience."
-#~ msgstr "Cambia tra i feed per avere il totale controllo della tua esperienza."
-
-#: src/view/screens/Settings/index.tsx:131
-#~ msgid "Switch to {0}"
-#~ msgstr "Cambia a {0}"
-
-#: src/view/screens/Settings/index.tsx:132
-#~ msgid "Switches the account you are logged in to"
-#~ msgstr "Cambia l'account dal quale hai effettuato l'accesso"
 
 #: src/screens/Settings/AppearanceSettings.tsx:84
 #: src/screens/Settings/AppearanceSettings.tsx:132
@@ -7796,9 +6162,6 @@ msgstr "Sistema"
 msgid "System log"
 msgstr "Registro di sistema"
 
-#~ msgid "tag"
-#~ msgstr "tag"
-
 #: src/components/TagMenu/index.tsx:87
 msgid "Tag menu: {displayTag}"
 msgstr "Tag menu: {displayTag}"
@@ -7806,9 +6169,6 @@ msgstr "Tag menu: {displayTag}"
 #: src/components/dialogs/MutedWords.tsx:282
 msgid "Tags only"
 msgstr "Solo tag"
-
-#~ msgid "Tall"
-#~ msgstr "Alto"
 
 #: src/components/ProgressGuide/Toast.tsx:150
 msgid "Tap to dismiss"
@@ -7831,9 +6191,6 @@ msgstr "Clicca per attivare o disattivare l'audio"
 msgid "Tap to view full image"
 msgstr "Premi per vedere a schermo intero"
 
-#~ msgid "Tap to view fully"
-#~ msgstr "Tocca per visualizzare completamente"
-
 #: src/state/shell/progress-guide.tsx:166
 msgid "Task complete - 10 likes!"
 msgstr "Completato - 10 like!"
@@ -7842,8 +6199,7 @@ msgstr "Completato - 10 like!"
 msgid "Teach our algorithm what you like"
 msgstr "Insegna all'algoritmo cosa ti piace"
 
-#: src/screens/Onboarding/index.tsx:36
-#: src/screens/Onboarding/state.ts:101
+#: src/screens/Onboarding/index.tsx:36 src/screens/Onboarding/state.ts:101
 msgid "Tech"
 msgstr "Tecnologia"
 
@@ -7853,7 +6209,7 @@ msgstr "Racconta una barzalletta!"
 
 #: src/screens/Profile/Header/EditProfileDialog.tsx:352
 msgid "Tell us a bit about yourself"
-msgstr ""
+msgstr "Raccontaci un po' di te"
 
 #: src/screens/StarterPack/Wizard/StepDetails.tsx:63
 msgid "Tell us a little more"
@@ -7863,11 +6219,9 @@ msgstr "Dicci un po' di più"
 msgid "Terms"
 msgstr "Termini"
 
-#: src/Navigation.tsx:274
-#: src/screens/Settings/AboutSettings.tsx:30
+#: src/Navigation.tsx:274 src/screens/Settings/AboutSettings.tsx:30
 #: src/screens/Settings/AboutSettings.tsx:33
-#: src/view/screens/TermsOfService.tsx:31
-#: src/view/shell/Drawer.tsx:617
+#: src/view/screens/TermsOfService.tsx:31 src/view/shell/Drawer.tsx:617
 #: src/view/shell/Drawer.tsx:619
 msgid "Terms of Service"
 msgstr "Termini di servizio"
@@ -7878,9 +6232,6 @@ msgstr "Termini di servizio"
 #: src/lib/moderation/useReportOptions.ts:115
 msgid "Terms used violate community standards"
 msgstr "I termini utilizzati violano gli standard della comunità"
-
-#~ msgid "text"
-#~ msgstr "testo"
 
 #: src/components/dialogs/MutedWords.tsx:266
 msgid "Text & tags"
@@ -7910,7 +6261,7 @@ msgstr "Che contiene il seguente:"
 
 #: src/screens/Signup/StepHandle.tsx:51
 msgid "That handle is already taken."
-msgstr "Questo handle è già stato preso."
+msgstr "Questo nome utente è già stato assegnato."
 
 #: src/screens/StarterPack/StarterPackScreen.tsx:103
 #: src/screens/StarterPack/StarterPackScreen.tsx:104
@@ -7929,9 +6280,6 @@ msgstr "Questo è tutto gente!"
 #: src/view/com/profile/ProfileMenu.tsx:329
 msgid "The account will be able to interact with you after unblocking."
 msgstr "L'account sarà in grado di interagire con te dopo lo sblocco."
-
-#~ msgid "the author"
-#~ msgstr "l'autore"
 
 #: src/components/moderation/ModerationDetailsDialog.tsx:118
 #: src/lib/moderation/useModerationCauseDescription.ts:126
@@ -7986,7 +6334,7 @@ msgstr "Il post potrebbe essere stato cancellato."
 
 #: src/view/screens/PrivacyPolicy.tsx:35
 msgid "The Privacy Policy has been moved to <0/>"
-msgstr "La politica sulla privacy è stata spostata a <0/><0/>"
+msgstr "L'informativa sulla privacy è stata spostata a <0/>"
 
 #: src/view/com/composer/state/video.ts:408
 msgid "The selected video is larger than 50MB."
@@ -8004,12 +6352,9 @@ msgstr "Questo starter pack non è valido. Prova a cancellare questo starter pac
 msgid "The support form has been moved. If you need help, please <0/> or visit {HELP_DESK_URL} to get in touch with us."
 msgstr "Il modulo di supporto è stato spostato. Se hai bisogno di aiuto, <0/> o visita {HELP_DESK_URL} per metterti in contatto con noi."
 
-#~ msgid "The support form has been moved. If you need help, please<0/> or visit {HELP_DESK_URL} to get in touch with us."
-#~ msgstr "Il modulo di supporto è stato spostato. Se hai bisogno di aiuto, <0/> o visita {HELP_DESK_URL} per metterti in contatto con noi."
-
 #: src/view/screens/TermsOfService.tsx:35
 msgid "The Terms of Service have been moved to"
-msgstr "I Termini di Servizio sono stati spostati a"
+msgstr "I Termini di servizio sono stati spostati a"
 
 #: src/components/intents/VerifyEmailIntentDialog.tsx:94
 msgid "The verification code you have provided is invalid. Please make sure that you have used the correct verification link or request a new one."
@@ -8019,39 +6364,16 @@ msgstr "Il codice di verifica che hai fornito non è valido. Per favore assicura
 msgid "Theme"
 msgstr "Tema"
 
-#~ msgid "There are many feeds to try:"
-#~ msgstr "Ci sono molti feed da provare:"
-
 #: src/screens/Settings/components/DeactivateAccountDialog.tsx:86
 msgid "There is no time limit for account deactivation, come back any time."
 msgstr "Non c'è limite di tempo per la disattivazione dell'account, torna quando vuoi."
-
-#: src/screens/Profile/Header/ProfileHeaderLabeler.tsx:112
-#: src/view/screens/ProfileFeed.tsx:539
-#~ msgid "There was an an issue contacting the server, please check your internet connection and try again."
-#~ msgstr "Si è verificato un problema nel contattare il server, controlla la tua connessione Internet e riprova."
-
-#: src/view/com/posts/FeedErrorMessage.tsx:145
-#~ msgid "There was an an issue removing this feed. Please check your internet connection and try again."
-#~ msgstr "Si è verificato un problema durante la rimozione di questo feed. Per favore controlla la tua connessione Internet e prova di nuovo."
-
-#: src/view/com/posts/FeedShutdownMsg.tsx:52
-#: src/view/com/posts/FeedShutdownMsg.tsx:71
-#: src/view/screens/ProfileFeed.tsx:204
-#~ msgid "There was an an issue updating your feeds, please check your internet connection and try again."
-#~ msgstr "Si è verificato un problema durante la rimozione di questo feed. Per favore controlla la tua connessione Internet e prova di nuovo."
 
 #: src/components/dialogs/GifSelect.tsx:226
 msgid "There was an issue connecting to Tenor."
 msgstr "Si è verificato un problema durante la connessione a Tenor."
 
-#~ msgid "There was an issue connecting to the chat."
-#~ msgstr "Si è verificato un errore nel connettersi alla chat."
-
-#: src/view/screens/ProfileFeed.tsx:240
-#: src/view/screens/ProfileList.tsx:369
-#: src/view/screens/ProfileList.tsx:388
-#: src/view/screens/SavedFeeds.tsx:86
+#: src/view/screens/ProfileFeed.tsx:240 src/view/screens/ProfileList.tsx:369
+#: src/view/screens/ProfileList.tsx:388 src/view/screens/SavedFeeds.tsx:86
 msgid "There was an issue contacting the server"
 msgstr "Si è verificato un problema durante il contatto con il server"
 
@@ -8079,7 +6401,7 @@ msgstr "Si è verificato un problema durante il recupero dell'elenco. Tocca qui 
 
 #: src/screens/Settings/AppPasswords.tsx:52
 msgid "There was an issue fetching your app passwords"
-msgstr ""
+msgstr "Si è verificato un problema durante il recupero delle password dell'app"
 
 #: src/view/com/feeds/ProfileFeedgens.tsx:150
 #: src/view/com/lists/ProfileLists.tsx:149
@@ -8088,7 +6410,7 @@ msgstr "Si è verificato un problema durante il recupero delle tue liste. Tocca 
 
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:102
 msgid "There was an issue fetching your service info"
-msgstr ""
+msgstr "Si è verificato un problema durante il recupero delle tue informazioni di servizio"
 
 #: src/view/com/posts/FeedErrorMessage.tsx:145
 msgid "There was an issue removing this feed. Please check your internet connection and try again."
@@ -8099,18 +6421,11 @@ msgstr ""
 msgid "There was an issue sending your report. Please check your internet connection."
 msgstr "Si è verificato un problema durante l'invio della segnalazione. Per favore controlla la tua connessione Internet."
 
-#~ msgid "There was an issue syncing your preferences with the server"
-#~ msgstr "Si è verificato un problema durante la sincronizzazione delle tue preferenze con il server"
-
 #: src/view/com/posts/FeedShutdownMsg.tsx:52
 #: src/view/com/posts/FeedShutdownMsg.tsx:71
 #: src/view/screens/ProfileFeed.tsx:211
 msgid "There was an issue updating your feeds, please check your internet connection and try again."
 msgstr ""
-
-#: src/view/screens/AppPasswords.tsx:75
-#~ msgid "There was an issue with fetching your app passwords"
-#~ msgstr "Si è verificato un problema durante il recupero delle password dell'app"
 
 #: src/screens/Profile/Header/ProfileHeaderStandard.tsx:107
 #: src/screens/Profile/Header/ProfileHeaderStandard.tsx:128
@@ -8130,10 +6445,8 @@ msgstr "Si è verificato un problema! {0}"
 #: src/screens/List/ListHiddenScreen.tsx:63
 #: src/screens/List/ListHiddenScreen.tsx:77
 #: src/screens/List/ListHiddenScreen.tsx:99
-#: src/view/screens/ProfileList.tsx:400
-#: src/view/screens/ProfileList.tsx:413
-#: src/view/screens/ProfileList.tsx:426
-#: src/view/screens/ProfileList.tsx:439
+#: src/view/screens/ProfileList.tsx:400 src/view/screens/ProfileList.tsx:413
+#: src/view/screens/ProfileList.tsx:426 src/view/screens/ProfileList.tsx:439
 msgid "There was an issue. Please check your internet connection and try again."
 msgstr "Si è verificato un problema. Per favore controlla la tua connessione Internet e prova di nuovo."
 
@@ -8146,18 +6459,9 @@ msgstr "Si è verificato un problema imprevisto nell'applicazione. Per favore fa
 msgid "There's been a rush of new users to Bluesky! We'll activate your account as soon as we can."
 msgstr "C'è stata un'ondata di nuovi utenti su Bluesky! Attiveremo il tuo account il prima possibile."
 
-#~ msgid "There's something wrong with this number. Please choose your country and enter your full phone number!"
-#~ msgstr "C'è qualcosa di sbagliato in questo numero. Scegli il tuo Paese e inserisci il tuo numero di telefono completo!"
-
-#~ msgid "These are popular accounts you might like:"
-#~ msgstr "Questi sono gli account popolari che potrebbero piacerti:"
-
 #: src/screens/Settings/FollowingFeedPreferences.tsx:55
 msgid "These settings only apply to the Following feed."
 msgstr ""
-
-#~ msgid "This {0} has been labeled."
-#~ msgstr "Questo {0} è stato etichettato."
 
 #: src/components/moderation/ScreenHider.tsx:111
 msgid "This {screenDescription} has been flagged:"
@@ -8170,9 +6474,6 @@ msgstr "Questo account ha richiesto agli utenti di accedere Bluesky per visualiz
 #: src/components/dms/BlockedByListDialog.tsx:34
 msgid "This account is blocked by one or more of your moderation lists. To unblock, please visit the lists directly and remove this user."
 msgstr "Questo account è bloccato da uno o più appartenente alle tue liste di moderazione. Per sbloccare, visista le liste direttamente e rimuovi l'utente."
-
-#~ msgid "This appeal will be sent to <0>{0}</0>."
-#~ msgstr "Questo ricorso verrà inviato a <0>{0}</0>."
 
 #: src/components/moderation/LabelsOnMeDialog.tsx:246
 msgid "This appeal will be sent to <0>{sourceName}</0>."
@@ -8211,9 +6512,6 @@ msgstr "Questo contenuto non è visualizzabile senza un account Bluesky."
 msgid "This conversation is with a deleted or a deactivated account. Press for options."
 msgstr "L'utente di questa conversazione ha disattivato o cancellato l'account. Premi per le opzioni."
 
-#~ msgid "This feature is in beta. You can read more about repository exports in <0>this blogpost.</0>"
-#~ msgstr "Questa funzionalità è in versione beta. Puoi leggere ulteriori informazioni sulle esportazioni dell' archivio in <0>questo post del blog.</0>"
-
 #: src/screens/Settings/components/ExportCarDialog.tsx:94
 msgid "This feature is in beta. You can read more about repository exports in <0>this blogpost</0>."
 msgstr "Questa funzionalità è in versione beta. Puoi leggere ulteriori informazioni sulle esportazioni del repository in <0>questo post del blog</0>."
@@ -8226,16 +6524,12 @@ msgstr ""
 msgid "This feed is currently receiving high traffic and is temporarily unavailable. Please try again later."
 msgstr "Questo canale al momento sta ricevendo molte visite ed è temporaneamente non disponibile. Riprova più tardi."
 
-#~ msgid "This feed is empty!"
-#~ msgstr "Questo feed è vuoto!"
-
 #: src/view/com/posts/CustomFeedEmptyState.tsx:38
 msgid "This feed is empty! You may need to follow more users or tune your language settings."
 msgstr "Questo feed è vuoto! Prova a seguire più utenti o ottimizza le impostazioni della lingua."
 
 #: src/components/StarterPack/Main/PostsList.tsx:36
-#: src/view/screens/ProfileFeed.tsx:478
-#: src/view/screens/ProfileList.tsx:788
+#: src/view/screens/ProfileFeed.tsx:478 src/view/screens/ProfileList.tsx:788
 msgid "This feed is empty."
 msgstr "Questo feed è vuoto."
 
@@ -8245,7 +6539,7 @@ msgstr "Questo feed non è più online. Stiamo mostrando <0>Discover</0> al suo 
 
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:559
 msgid "This handle is reserved. Please try a different one."
-msgstr ""
+msgstr "Questo nome utente è riservato. Prova con un altro nome utente."
 
 #: src/components/dialogs/BirthDateSettings.tsx:40
 msgid "This information is not shared with other users."
@@ -8254,12 +6548,6 @@ msgstr "Queste informazioni non vengono condivise con altri utenti."
 #: src/view/com/modals/VerifyEmail.tsx:127
 msgid "This is important in case you ever need to change your email or reset your password."
 msgstr "Questo è importante nel caso in cui avessi bisogno di modificare la tua email o reimpostare la password."
-
-#~ msgid "This is the service that keeps you online."
-#~ msgstr "Questo è il servizio che ti mantiene online."
-
-#~ msgid "This label was applied by {0}."
-#~ msgstr "Questa etichetta è stata applicata da {0}."
 
 #: src/components/moderation/ModerationDetailsDialog.tsx:151
 msgid "This label was applied by <0>{0}</0>."
@@ -8293,10 +6581,6 @@ msgstr "Questa lista è vuota!"
 msgid "This moderation service is unavailable. See below for more details. If this issue persists, contact us."
 msgstr "Questo servizio di moderazione non è disponibile. Vedi giù per ulteriori dettagli. Se il problema persiste, contattaci."
 
-#: src/view/com/modals/AddAppPasswords.tsx:110
-#~ msgid "This name is already in use"
-#~ msgstr "Questo nome è già in uso"
-
 #: src/view/com/post-thread/PostThreadItem.tsx:836
 msgid "This post claims to have been created on <0>{0}</0>, but was first seen by Bluesky on <1>{1}</1>."
 msgstr ""
@@ -8313,9 +6597,6 @@ msgstr "Questo post è visibile solo agli utenti registrati. Non sarà visibile 
 #: src/view/com/util/forms/PostDropdownBtn.tsx:681
 msgid "This post will be hidden from feeds and threads. This cannot be undone."
 msgstr "Questo post verrà nascosto dai feed e dai thread. L'azione è irreversibile."
-
-#~ msgid "This post will be hidden from feeds."
-#~ msgstr "Questo post verrà nascosto dai feed."
 
 #: src/view/com/composer/Composer.tsx:405
 msgid "This post's author has disabled quote posts."
@@ -8354,12 +6635,6 @@ msgstr "Questo utente ti ha bloccato. Non è possibile visualizzare il suo conte
 msgid "This user has requested that their content only be shown to signed-in users."
 msgstr "Questo utente ha richiesto che i suoi contenuti vengano mostrati solo agli utenti che hanno effettuato l'accesso."
 
-#~ msgid "This user is included in the <0/> list which you have blocked."
-#~ msgstr "Questo utente è incluso nell'elenco <0/> che hai bloccato."
-
-#~ msgid "This user is included in the <0/> list which you have muted."
-#~ msgstr "Questo utente è incluso nell'elenco <0/> che hai disattivato."
-
 #: src/components/moderation/ModerationDetailsDialog.tsx:58
 msgid "This user is included in the <0>{0}</0> list which you have blocked."
 msgstr "Questo utente è incluso nell'elenco <0>{0}</0> che hai bloccato."
@@ -8367,9 +6642,6 @@ msgstr "Questo utente è incluso nell'elenco <0>{0}</0> che hai bloccato."
 #: src/components/moderation/ModerationDetailsDialog.tsx:90
 msgid "This user is included in the <0>{0}</0> list which you have muted."
 msgstr "Questo utente è incluso nell'elenco <0>{0}</0> che hai silenziato."
-
-#~ msgid "This user is included the <0/> list which you have muted."
-#~ msgstr "Questo utente è incluso nella lista <0/> che hai silenziato."
 
 #: src/components/NewskieDialog.tsx:65
 msgid "This user is new here. Press for more info about when they joined."
@@ -8379,18 +6651,9 @@ msgstr "Questo utente è nuovo qui. Clicca per maggiori informazioni riguardo a 
 msgid "This user isn't following anyone."
 msgstr "Questo utente non sta seguendo nessuno."
 
-#~ msgid "This warning is only available for posts with media attached."
-#~ msgstr "Questo avviso è disponibile solo per i post con contenuti multimediali allegati."
-
 #: src/components/dialogs/MutedWords.tsx:435
 msgid "This will delete \"{0}\" from your muted words. You can always add it back later."
 msgstr "Questo eliminerà \"{0}\" dalle tue parole silenziate. Puoi riaggiungerla quando vuoi qui."
-
-#~ msgid "This will delete {0} from your muted words. You can always add it back later."
-#~ msgstr "Questo eliminerà {0} dalle parole disattivate. Puoi sempre aggiungerla nuovamente in seguito."
-
-#~ msgid "This will hide this post from your feeds."
-#~ msgstr "Questo nasconderà il post dai tuoi feed."
 
 #: src/screens/Settings/Settings.tsx:452
 msgid "This will remove @{0} from the quick access list."
@@ -8409,16 +6672,9 @@ msgstr "Preferenze delle discussioni"
 msgid "Thread Preferences"
 msgstr "Preferenze delle Discussioni"
 
-#~ msgid "Thread settings updated"
-#~ msgstr "Impostazioni thread aggiornate"
-
 #: src/screens/Settings/ThreadPreferences.tsx:129
 msgid "Threaded mode"
-msgstr ""
-
-#: src/view/screens/PreferencesThreads.tsx:114
-#~ msgid "Threaded Mode"
-#~ msgstr "Modalità discussione"
+msgstr "Modalità a thread"
 
 #: src/Navigation.tsx:307
 msgid "Threads Preferences"
@@ -8444,9 +6700,6 @@ msgstr "A chi desideri inviare questo report?"
 msgid "Today"
 msgstr "Oggi"
 
-#~ msgid "Toggle between muted word options."
-#~ msgstr "Alterna tra le opzioni delle parole silenziate."
-
 #: src/view/com/util/forms/DropdownButton.tsx:258
 msgid "Toggle dropdown"
 msgstr "Attiva/disattiva il menu a discesa"
@@ -8455,13 +6708,9 @@ msgstr "Attiva/disattiva il menu a discesa"
 msgid "Toggle to enable or disable adult content"
 msgstr "Seleziona per abilitare o disabilitare i contenuti per adulti"
 
-#: src/screens/Hashtag.tsx:87
-#: src/view/screens/Search/Search.tsx:511
+#: src/screens/Hashtag.tsx:87 src/view/screens/Search/Search.tsx:511
 msgid "Top"
 msgstr "Top"
-
-#~ msgid "Transformations"
-#~ msgstr "Trasformazioni"
 
 #: src/components/dms/MessageMenu.tsx:103
 #: src/components/dms/MessageMenu.tsx:105
@@ -8477,20 +6726,13 @@ msgctxt "action"
 msgid "Try again"
 msgstr "Riprova"
 
-#~ msgid "Try again"
-#~ msgstr "Provalo di nuovo"
-
 #: src/screens/Onboarding/state.ts:102
 msgid "TV"
 msgstr "TV"
 
-#: src/view/screens/Settings/index.tsx:712
-#~ msgid "Two-factor authentication"
-#~ msgstr "Autenticazione a due fattori"
-
 #: src/screens/Settings/PrivacyAndSecuritySettings.tsx:49
 msgid "Two-factor authentication (2FA)"
-msgstr ""
+msgstr "Autenticazione a due fattori (2FA)"
 
 #: src/screens/Messages/components/MessageInput.tsx:148
 msgid "Type your message here"
@@ -8512,11 +6754,9 @@ msgstr "Riattiva questa lista"
 msgid "Unable to connect. Please check your internet connection and try again."
 msgstr ""
 
-#: src/screens/Login/ForgotPasswordForm.tsx:68
-#: src/screens/Login/index.tsx:76
+#: src/screens/Login/ForgotPasswordForm.tsx:68 src/screens/Login/index.tsx:76
 #: src/screens/Login/LoginForm.tsx:152
-#: src/screens/Login/SetNewPasswordForm.tsx:71
-#: src/screens/Signup/index.tsx:71
+#: src/screens/Login/SetNewPasswordForm.tsx:71 src/screens/Signup/index.tsx:71
 #: src/view/com/modals/ChangePassword.tsx:71
 msgid "Unable to contact your service. Please check your Internet connection."
 msgstr "Impossibile contattare il servizio. Per favore controlla la tua connessione Internet."
@@ -8541,8 +6781,7 @@ msgctxt "action"
 msgid "Unblock"
 msgstr "Sblocca"
 
-#: src/components/dms/ConvoMenu.tsx:188
-#: src/components/dms/ConvoMenu.tsx:192
+#: src/components/dms/ConvoMenu.tsx:188 src/components/dms/ConvoMenu.tsx:192
 msgid "Unblock account"
 msgstr "Sblocca l'account"
 
@@ -8567,9 +6806,6 @@ msgctxt "action"
 msgid "Unfollow"
 msgstr "Smetti di seguire"
 
-#~ msgid "Unfollow"
-#~ msgstr "Smetti di seguire"
-
 #: src/screens/Profile/Header/ProfileHeaderStandard.tsx:217
 msgid "Unfollow {0}"
 msgstr "Smetti di seguire {0}"
@@ -8579,18 +6815,11 @@ msgstr "Smetti di seguire {0}"
 msgid "Unfollow Account"
 msgstr "Smetti di seguire questo account"
 
-#~ msgid "Unfortunately, you do not meet the requirements to create an account."
-#~ msgstr "Sfortunatamente, non soddisfi i requisiti per creare un account."
-
-#~ msgid "Unlike"
-#~ msgstr "Togli Mi piace"
-
 #: src/view/screens/ProfileFeed.tsx:576
 msgid "Unlike this feed"
 msgstr "Togli il like a questo feed"
 
-#: src/components/TagMenu/index.tsx:248
-#: src/view/screens/ProfileList.tsx:692
+#: src/components/TagMenu/index.tsx:248 src/view/screens/ProfileList.tsx:692
 msgid "Unmute"
 msgstr "Riattiva"
 
@@ -8626,11 +6855,7 @@ msgstr "Riattiva questa discussione"
 msgid "Unmute video"
 msgstr "Riattiva auto"
 
-#~ msgid "Unmuted"
-#~ msgstr "Audio riattivato"
-
-#: src/view/screens/ProfileFeed.tsx:296
-#: src/view/screens/ProfileList.tsx:676
+#: src/view/screens/ProfileFeed.tsx:296 src/view/screens/ProfileList.tsx:676
 msgid "Unpin"
 msgstr "Stacca dal profilo"
 
@@ -8650,9 +6875,6 @@ msgstr "Stacca la lista di moderazione"
 #: src/view/screens/ProfileList.tsx:356
 msgid "Unpinned from your feeds"
 msgstr "Sblocca dai tuoi feed"
-
-#~ msgid "Unsave"
-#~ msgstr "Rimuovi"
 
 #: src/screens/Profile/Header/ProfileHeaderLabeler.tsx:236
 msgid "Unsubscribe"
@@ -8680,24 +6902,14 @@ msgstr "Tipo video non supportato: {mimeType}"
 msgid "Unwanted Sexual Content"
 msgstr "Contenuti Sessuali Indesiderati"
 
-#~ msgid "Update {displayName} in Lists"
-#~ msgstr "Aggiorna {displayName} negli elenchi"
-
 #: src/view/com/modals/UserAddRemoveLists.tsx:82
 msgid "Update <0>{displayName}</0> in Lists"
 msgstr "Aggiorna <0>{displayName}</0> nelle Liste"
 
-#~ msgid "Update Available"
-#~ msgstr "Aggiornamento disponibile"
-
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:495
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:516
 msgid "Update to {domain}"
-msgstr ""
-
-#: src/view/com/modals/ChangeHandle.tsx:495
-#~ msgid "Update to {handle}"
-#~ msgstr "Aggiorna a {handle}"
+msgstr "Aggiorna a {domain}"
 
 #: src/view/com/util/forms/PostDropdownBtn.tsx:311
 msgid "Updating quote attachment failed"
@@ -8719,53 +6931,35 @@ msgstr "Alternativamente carica una foto"
 msgid "Upload a text file to:"
 msgstr "Carica una file di testo a:"
 
-#: src/view/com/util/UserAvatar.tsx:371
-#: src/view/com/util/UserAvatar.tsx:374
-#: src/view/com/util/UserBanner.tsx:123
-#: src/view/com/util/UserBanner.tsx:126
+#: src/view/com/util/UserAvatar.tsx:371 src/view/com/util/UserAvatar.tsx:374
+#: src/view/com/util/UserBanner.tsx:123 src/view/com/util/UserBanner.tsx:126
 msgid "Upload from Camera"
 msgstr "Carica dalla fotocamera"
 
-#: src/view/com/util/UserAvatar.tsx:388
-#: src/view/com/util/UserBanner.tsx:140
+#: src/view/com/util/UserAvatar.tsx:388 src/view/com/util/UserBanner.tsx:140
 msgid "Upload from Files"
 msgstr "Carica dai Files"
 
-#: src/view/com/util/UserAvatar.tsx:382
-#: src/view/com/util/UserAvatar.tsx:386
-#: src/view/com/util/UserBanner.tsx:134
-#: src/view/com/util/UserBanner.tsx:138
+#: src/view/com/util/UserAvatar.tsx:382 src/view/com/util/UserAvatar.tsx:386
+#: src/view/com/util/UserBanner.tsx:134 src/view/com/util/UserBanner.tsx:138
 msgid "Upload from Library"
 msgstr "Carica dalla Libreria"
 
 #: src/lib/api/index.ts:296
 msgid "Uploading images..."
-msgstr ""
+msgstr "Caricamento immagini..."
 
-#: src/lib/api/index.ts:350
-#: src/lib/api/index.ts:374
+#: src/lib/api/index.ts:350 src/lib/api/index.ts:374
 msgid "Uploading link thumbnail..."
-msgstr ""
+msgstr "Caricamento miniatura del link..."
 
 #: src/view/com/composer/Composer.tsx:1616
 msgid "Uploading video..."
-msgstr ""
-
-#: src/view/com/modals/ChangeHandle.tsx:395
-#~ msgid "Use a file on your server"
-#~ msgstr "Utilizza un file sul tuo server"
-
-#: src/view/screens/AppPasswords.tsx:205
-#~ msgid "Use app passwords to login to other Bluesky clients without giving full access to your account or password."
-#~ msgstr "Utilizza le password dell'app per accedere ad altri client Bluesky senza fornire l'accesso completo al tuo account o alla tua password."
+msgstr "Caricamento del video..."
 
 #: src/screens/Settings/AppPasswords.tsx:59
 msgid "Use app passwords to sign in to other Bluesky clients without giving full access to your account or password."
 msgstr ""
-
-#: src/view/com/modals/ChangeHandle.tsx:506
-#~ msgid "Use bsky.social as hosting provider"
-#~ msgstr "Utilizza bsky.social come provider di hosting"
 
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:528
 msgid "Use default provider"
@@ -8790,16 +6984,9 @@ msgstr "Utilizza il mio browser predefinito"
 msgid "Use recommended"
 msgstr "Usa consigliati"
 
-#: src/view/com/modals/ChangeHandle.tsx:387
-#~ msgid "Use the DNS panel"
-#~ msgstr "Utilizza il pannello DNS"
-
 #: src/screens/Settings/components/AddAppPasswordDialog.tsx:190
 msgid "Use this to sign into the other app along with your handle."
-msgstr "Utilizza questo per accedere all'altra app insieme al tuo nome utente."
-
-#~ msgid "Use your domain as your Bluesky client service provider"
-#~ msgstr "Utilizza il tuo dominio come provider di servizi clienti Bluesky"
+msgstr "Usalo per accedere all'altra app insieme al tuo nome utente."
 
 #: src/view/com/modals/InviteCodes.tsx:201
 msgid "Used by:"
@@ -8829,9 +7016,6 @@ msgstr "Questo Utente ti Blocca"
 #: src/components/moderation/ModerationDetailsDialog.tsx:76
 msgid "User Blocks You"
 msgstr "Questo utente ti blocca"
-
-#~ msgid "User handle"
-#~ msgstr "Handle dell'utente"
 
 #: src/view/com/modals/UserAddRemoveLists.tsx:214
 msgid "User list by {0}"
@@ -8866,15 +7050,11 @@ msgstr "Nome utente o indirizzo Email"
 msgid "Users"
 msgstr "Utenti"
 
-#~ msgid "users followed by <0/>"
-#~ msgstr "utenti seguiti da <0/>"
-
 #: src/components/WhoCanReply.tsx:258
 msgid "users followed by <0>@{0}</0>"
 msgstr "utenti seguiti da <0>@{0}</0>"
 
-#: src/screens/Messages/Settings.tsx:86
-#: src/screens/Messages/Settings.tsx:89
+#: src/screens/Messages/Settings.tsx:86 src/screens/Messages/Settings.tsx:89
 msgid "Users I follow"
 msgstr "Utenti che seguo"
 
@@ -8890,37 +7070,19 @@ msgstr "Utenti a cui è piaciuto questo contenuto o profilo"
 msgid "Value:"
 msgstr "Valore:"
 
-#~ msgid "Verification code"
-#~ msgstr "Codice di verifica"
-
 #: src/view/com/composer/videos/SelectVideoBtn.tsx:131
 msgid "Verified email required"
 msgstr "Email verificata richiesta"
-
-#~ msgid "Verify {0}"
-#~ msgstr "Verifica {0}"
 
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:497
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:518
 msgid "Verify DNS Record"
 msgstr "Verifica record DNS"
 
-#: src/view/screens/Settings/index.tsx:937
-#~ msgid "Verify email"
-#~ msgstr "Verifica Email"
-
 #: src/components/dialogs/VerifyEmailDialog.tsx:134
 #: src/components/intents/VerifyEmailIntentDialog.tsx:67
 msgid "Verify email dialog"
 msgstr "Finestra verifica email"
-
-#: src/view/screens/Settings/index.tsx:962
-#~ msgid "Verify my email"
-#~ msgstr "Verifica la mia email"
-
-#: src/view/screens/Settings/index.tsx:971
-#~ msgid "Verify My Email"
-#~ msgstr "Verifica la Mia Email"
 
 #: src/view/com/modals/ChangeEmail.tsx:200
 #: src/view/com/modals/ChangeEmail.tsx:202
@@ -8939,24 +7101,17 @@ msgstr "Verifica file di testo"
 #: src/screens/Settings/AccountSettings.tsx:68
 #: src/screens/Settings/AccountSettings.tsx:84
 msgid "Verify your email"
-msgstr ""
+msgstr "Verifica il tuo indirizzo email"
 
 #: src/components/dialogs/VerifyEmailDialog.tsx:85
 #: src/view/com/modals/VerifyEmail.tsx:111
 msgid "Verify Your Email"
 msgstr "Verifica la tua email"
 
-#~ msgid "Version {0}"
-#~ msgstr "Versione {0}"
-
 #: src/screens/Settings/AboutSettings.tsx:60
 #: src/screens/Settings/AboutSettings.tsx:70
 msgid "Version {appVersion}"
-msgstr ""
-
-#: src/view/screens/Settings/index.tsx:890
-#~ msgid "Version {appVersion} {bundleInfo}"
-#~ msgstr "Versione {appVersion} {bundleInfo}"
+msgstr "Versione {appVersion}"
 
 #: src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerNative.tsx:84
 #: src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerNative.tsx:135
@@ -8965,10 +7120,9 @@ msgstr "Video"
 
 #: src/view/com/composer/state/video.ts:371
 msgid "Video failed to process"
-msgstr "Elaborazione video fallita "
+msgstr "Elaborazione video fallita"
 
-#: src/screens/Onboarding/index.tsx:39
-#: src/screens/Onboarding/state.ts:90
+#: src/screens/Onboarding/index.tsx:39 src/screens/Onboarding/state.ts:90
 msgid "Video Games"
 msgstr "Video Games"
 
@@ -8982,19 +7136,16 @@ msgstr "Settaggi video"
 
 #: src/view/com/composer/Composer.tsx:1626
 msgid "Video uploaded"
-msgstr ""
+msgstr "Video caricato"
 
 #: src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerNative.tsx:84
 msgid "Video: {0}"
 msgstr "Video: {0}"
 
-#~ msgid "Videos cannot be larger than 50MB"
-#~ msgstr "I video non possono essere più grandi di 50MB"
-
 #: src/view/com/composer/videos/SelectVideoBtn.tsx:79
 #: src/view/com/composer/videos/VideoPreview.web.tsx:44
 msgid "Videos must be less than 60 seconds long"
-msgstr "I video devono essere più corti di 60 secondi."
+msgstr "I video devono essere più corti di 60 secondi"
 
 #: src/screens/Profile/Header/Shell.tsx:164
 msgid "View {0}'s avatar"
@@ -9011,11 +7162,11 @@ msgstr "Vedi il profilo di {displayName}"
 
 #: src/components/TagMenu/index.tsx:149
 msgid "View all posts by @{authorHandle} with tag {displayTag}"
-msgstr ""
+msgstr "Mostra tutti i post di @{authorHandle} con tag {displayTag}"
 
 #: src/components/TagMenu/index.tsx:103
 msgid "View all posts with tag {displayTag}"
-msgstr ""
+msgstr "Mostra tutti i post con tag {displayTag}"
 
 #: src/components/ProfileHoverCard/index.web.tsx:433
 msgid "View blocked user's profile"
@@ -9050,8 +7201,7 @@ msgstr "Visualizza le informazioni su queste etichette"
 #: src/components/ProfileHoverCard/index.web.tsx:466
 #: src/view/com/posts/AviFollowButton.tsx:55
 #: src/view/com/posts/FeedErrorMessage.tsx:175
-#: src/view/com/util/PostMeta.tsx:79
-#: src/view/com/util/PostMeta.tsx:94
+#: src/view/com/util/PostMeta.tsx:79 src/view/com/util/PostMeta.tsx:94
 msgid "View profile"
 msgstr "Vedi il profilo"
 
@@ -9103,9 +7253,6 @@ msgstr "Avvisa il contenuto"
 msgid "Warn content and filter from feeds"
 msgstr "Avvisa i contenuti e filtra dai feed"
 
-#~ msgid "We also think you'll like \"For You\" by Skygaze:"
-#~ msgstr "Pensiamo che ti piacerà anche \"Per Te\" di Skygaze:"
-
 #: src/screens/Hashtag.tsx:218
 msgid "We couldn't find any results for that hashtag."
 msgstr "Non siamo riusciti a trovare alcun risultato per quell'hashtag."
@@ -9130,12 +7277,6 @@ msgstr "Speriamo di darti dei momenti dei bei momenti. Ricorda, Bluesky è:"
 msgid "We ran out of posts from your follows. Here's the latest from <0/>."
 msgstr "Abbiamo esaurito i posts dei tuoi follower. Ecco le ultime novità da <0/>."
 
-#~ msgid "We recommend avoiding common words that appear in many posts, since it can result in no posts being shown."
-#~ msgstr "Ti consigliamo di evitare usare parole comuni che compaiono in molti post, perchè ciò potrebbe comportare la mancata visualizzazione dei post."
-
-#~ msgid "We recommend our \"Discover\" feed:"
-#~ msgstr "Consigliamo il nostro feed \"Scopri\":"
-
 #: src/view/com/composer/state/video.ts:430
 msgid "We were unable to determine if you are allowed to upload videos. Please try again."
 msgstr "Non siamo riusciti a verificare se puoi caricare video. Per favore ritenta."
@@ -9156,9 +7297,6 @@ msgstr "Non siamo riusciti a connetterci. Riprova per continuare a configurare i
 msgid "We will let you know when your account is ready."
 msgstr "Ti faremo sapere quando il tuo account sarà pronto."
 
-#~ msgid "We'll look into your appeal promptly."
-#~ msgstr "Esamineremo il tuo ricorso al più presto."
-
 #: src/screens/Onboarding/StepInterests/index.tsx:134
 msgid "We'll use this to help customize your experience."
 msgstr "Lo useremo per personalizzare la tua esperienza."
@@ -9166,10 +7304,6 @@ msgstr "Lo useremo per personalizzare la tua esperienza."
 #: src/components/dms/dialogs/SearchablePeopleList.tsx:87
 msgid "We're having network issues, try again"
 msgstr "Stiamo riscontrando problemi di rete, riprova"
-
-#: src/components/dialogs/nuxs/NeueTypography.tsx:54
-#~ msgid "We're introducing a new theme font, along with adjustable font sizing."
-#~ msgstr "Abbiamo introdotto un nuovo tema font, assieme alla possibilità di aggiustare le dimensioni del font."
 
 #: src/screens/Signup/index.tsx:94
 msgid "We're so excited to have you join us!"
@@ -9191,13 +7325,9 @@ msgstr "Siamo spiacenti, ma non è stato possibile completare la ricerca. Riprov
 msgid "We're sorry! The post you are replying to has been deleted."
 msgstr "Ci dispiace! Il post a cui cerchi di rispondere è stato cancellato."
 
-#: src/components/Lists.tsx:220
-#: src/view/screens/NotFound.tsx:50
+#: src/components/Lists.tsx:220 src/view/screens/NotFound.tsx:50
 msgid "We're sorry! We can't find the page you were looking for."
 msgstr "Ci dispiace! Non riusciamo a trovare la pagina che stavi cercando."
-
-#~ msgid "We're sorry! You can only subscribe to ten labelers, and you've reached your limit of ten."
-#~ msgstr "Ci dispiace! Puoi iscriverti solo a dieci etichettatori e hai raggiunto il limite di dieci."
 
 #: src/screens/Profile/Header/ProfileHeaderLabeler.tsx:341
 msgid "We're sorry! You can only subscribe to twenty labelers, and you've reached your limit of twenty."
@@ -9206,9 +7336,6 @@ msgstr "Ci dispiace! Puoi iscriverti solo a venti etichettatori e hai raggiunto 
 #: src/screens/Deactivated.tsx:131
 msgid "Welcome back!"
 msgstr "Bentornat*!"
-
-#~ msgid "Welcome to <0>Bluesky</0>"
-#~ msgstr "Ti diamo il benvenuto a <0>Bluesky</0>"
 
 #: src/components/NewskieDialog.tsx:103
 msgid "Welcome, friend!"
@@ -9221,12 +7348,6 @@ msgstr "Quali sono i tuoi interessi?"
 #: src/screens/StarterPack/Wizard/StepDetails.tsx:42
 msgid "What do you want to call your starter pack?"
 msgstr "Come vuoi chiamare il tuo starter pack?"
-
-#~ msgid "What is the issue with this {collectionName}?"
-#~ msgstr "Qual è il problema con questo {collectionName}?"
-
-#~ msgid "What's next?"
-#~ msgstr "Qual è il prossimo?"
 
 #: src/view/com/auth/SplashScreen.tsx:39
 #: src/view/com/auth/SplashScreen.web.tsx:99
@@ -9246,23 +7367,11 @@ msgstr "Quali lingue vorresti vedere negli algoritmi dei tuoi feed?"
 msgid "Who can interact with this post?"
 msgstr "Chi puo interagire a questo post?"
 
-#~ msgid "Who can message you?"
-#~ msgstr "Chi puoi inviarti messaggi?"
-
 #: src/components/WhoCanReply.tsx:87
 msgid "Who can reply"
 msgstr "Chi può rispondere"
 
-#: src/screens/Home/NoFeedsPinned.tsx:NaN
-#: src/components/WhoCanReply.tsx:212
-#~ msgid "Who can reply dialog"
-#~ msgstr ""
-
-#~ msgid "Who can reply?"
-#~ msgstr "Chi può rispondere?"
-
-#: src/screens/Home/NoFeedsPinned.tsx:79
-#: src/screens/Messages/ChatList.tsx:183
+#: src/screens/Home/NoFeedsPinned.tsx:79 src/screens/Messages/ChatList.tsx:183
 msgid "Whoops!"
 msgstr "Ops!"
 
@@ -9294,9 +7403,6 @@ msgstr "Perché questo starter pack dovrebbe essere revisionato?"
 msgid "Why should this user be reviewed?"
 msgstr "Perché questo utente dovrebbe essere revisionato?"
 
-#~ msgid "Wide"
-#~ msgstr "Largo"
-
 #: src/screens/Messages/components/MessageInput.tsx:149
 #: src/screens/Messages/components/MessageInput.web.tsx:198
 msgid "Write a message"
@@ -9311,17 +7417,13 @@ msgstr "Scrivi un post"
 msgid "Write your reply"
 msgstr "Scrivi la tua risposta"
 
-#: src/screens/Onboarding/index.tsx:25
-#: src/screens/Onboarding/state.ts:103
+#: src/screens/Onboarding/index.tsx:25 src/screens/Onboarding/state.ts:103
 msgid "Writers"
 msgstr "Scrittori"
 
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:337
 msgid "Wrong DID returned from server. Received: {0}"
 msgstr ""
-
-#~ msgid "XXXXXX"
-#~ msgstr "XXXXXX"
 
 #: src/view/com/composer/select-language/SuggestedLanguage.tsx:78
 msgid "Yes"
@@ -9352,9 +7454,6 @@ msgstr "Sì, riattiva il mio account"
 msgid "Yesterday"
 msgstr "Ieri"
 
-#~ msgid "Yesterday, {time}"
-#~ msgstr "Ieri, {time}"
-
 #: src/screens/List/ListHiddenScreen.tsx:140
 msgid "you"
 msgstr "io"
@@ -9375,10 +7474,6 @@ msgstr "Non sei autorizzato a caricare video."
 msgid "You are not following anyone."
 msgstr "Non stai seguendo nessuno."
 
-#: src/components/dialogs/nuxs/NeueTypography.tsx:61
-#~ msgid "You can adjust these in your Appearance Settings later."
-#~ msgstr "Puoi modificarli successivamente nelle Impostazioni Aspetto."
-
 #: src/view/com/posts/FollowingEmptyState.tsx:63
 #: src/view/com/posts/FollowingEndOfFeed.tsx:64
 msgid "You can also discover new Custom Feeds to follow."
@@ -9388,21 +7483,11 @@ msgstr "Puoi anche scoprire nuovi feed personalizzati da seguire."
 msgid "You can also temporarily deactivate your account instead, and reactivate it at any time."
 msgstr "Puoi anche disattivare temporaneamente il tuo account, e riattivarlo in qualsiasi momento."
 
-#~ msgid "You can change hosting providers at any time."
-#~ msgstr "Puoi cambiare provider di hosting in qualsiasi momento."
-
-#~ msgid "You can change these settings later."
-#~ msgstr "Potrai modificare queste impostazioni in seguito."
-
-#~ msgid "You can change this at any time."
-#~ msgstr "Puoi modificarlo in qualsiasi momento."
-
 #: src/screens/Messages/Settings.tsx:105
 msgid "You can continue ongoing conversations regardless of which setting you choose."
 msgstr "Puoi proseguire le conversazioni in corso indipendentemente da quale settaggio scegli."
 
-#: src/screens/Login/index.tsx:155
-#: src/screens/Login/PasswordUpdatedForm.tsx:27
+#: src/screens/Login/index.tsx:155 src/screens/Login/PasswordUpdatedForm.tsx:27
 msgid "You can now sign in with your new password."
 msgstr "Adesso puoi accedere con la tua nuova password."
 
@@ -9425,9 +7510,6 @@ msgstr "Non hai ancora alcun codice di invito! Te ne invieremo alcuni quando uti
 #: src/view/screens/SavedFeeds.tsx:144
 msgid "You don't have any pinned feeds."
 msgstr "Non hai fissato nessun feed."
-
-#~ msgid "You don't have any saved feeds!"
-#~ msgstr "Non hai salvato nessun feed!"
 
 #: src/view/screens/SavedFeeds.tsx:184
 msgid "You don't have any saved feeds."
@@ -9471,9 +7553,6 @@ msgstr "Hai silenziato questo account."
 msgid "You have muted this user"
 msgstr "Hai silenziato questo utente"
 
-#~ msgid "You have muted this user."
-#~ msgstr "Hai disattivato questo utente."
-
 #: src/screens/Messages/ChatList.tsx:223
 msgid "You have no conversations yet. Start one!"
 msgstr "Non hai ancora nessuna conversazione. Avviane una!"
@@ -9482,8 +7561,7 @@ msgstr "Non hai ancora nessuna conversazione. Avviane una!"
 msgid "You have no feeds."
 msgstr "Non hai feed."
 
-#: src/view/com/lists/MyLists.tsx:90
-#: src/view/com/lists/ProfileLists.tsx:134
+#: src/view/com/lists/MyLists.tsx:90 src/view/com/lists/ProfileLists.tsx:134
 msgid "You have no lists."
 msgstr "Non hai liste."
 
@@ -9491,19 +7569,9 @@ msgstr "Non hai liste."
 msgid "You have not blocked any accounts yet. To block an account, go to their profile and select \"Block account\" from the menu on their account."
 msgstr "Non hai ancora bloccato nessun account. Per bloccare un account, vai sul profilo e seleziona \"Blocca account\" dal menu dell'account."
 
-#~ msgid "You have not blocked any accounts yet. To block an account, go to their profile and selected \"Block account\" from the menu on their account."
-#~ msgstr "Non hai ancora bloccato nessun conto. Per bloccare un conto, vai al profilo e seleziona \"Blocca conto\" dal menu del suo conto."
-
-#: src/view/screens/AppPasswords.tsx:96
-#~ msgid "You have not created any app passwords yet. You can create one by pressing the button below."
-#~ msgstr "Non hai ancora creato alcuna password per l'app. Puoi crearne uno premendo il pulsante qui sotto."
-
 #: src/view/screens/ModerationMutedAccounts.tsx:132
 msgid "You have not muted any accounts yet. To mute an account, go to their profile and select \"Mute account\" from the menu on their account."
 msgstr "Non hai ancora silenziato nessun account. Per silenziare un account, vai al suo profilo e seleziona \"Silenzia account\" dal menu dell' account."
-
-#~ msgid "You have not muted any accounts yet. To mute an account, go to their profile and selected \"Mute account\" from the menu on their account."
-#~ msgstr "Non hai ancora disattivato alcun account. Per disattivare un account, vai al suo profilo e seleziona \"Disattiva account\" dal menu del account."
 
 #: src/components/Lists.tsx:52
 msgid "You have reached the end"
@@ -9542,25 +7610,13 @@ msgstr "Puoi aggiungere un massimo di {STARTER_PACK_MAX_SIZE} utenti"
 msgid "You may only add up to 3 feeds"
 msgstr "Puoi aggiungere un massimo di 3 feed"
 
-#~ msgid "You may only add up to 50 feeds"
-#~ msgstr "Puoi aggiungere un massimo di 50 feed"
-
-#~ msgid "You may only add up to 50 profiles"
-#~ msgstr "Puoi aggiungere un massimo di 50 utenti"
-
 #: src/lib/media/picker.shared.ts:22
 msgid "You may only select up to 4 images"
-msgstr ""
+msgstr "È possibile selezionare fino a 4 immagini"
 
 #: src/screens/Signup/StepInfo/Policies.tsx:106
 msgid "You must be 13 years of age or older to sign up."
 msgstr "Per iscriverti devi avere almeno 13 anni."
-
-#~ msgid "You must be 18 or older to enable adult content."
-#~ msgstr "Devi avere almeno 18 anni per abilitare i contenuti per adulti."
-
-#~ msgid "You must be 18 years or older to enable adult content"
-#~ msgstr "Devi avere almeno 18 anni per abilitare i contenuti per adulti"
 
 #: src/components/StarterPack/ProfileStarterPacks.tsx:324
 msgid "You must be following at least seven other people to generate a starter pack."
@@ -9634,11 +7690,7 @@ msgstr "Riceverai un email a <0>{0}</0> per verificare che sia tu."
 msgid "You'll stay updated with these feeds"
 msgstr "Resterai aggiornato su questi feed"
 
-#~ msgid "You're in control"
-#~ msgstr "Sei in controllo"
-
-#: src/screens/SignupQueued.tsx:93
-#: src/screens/SignupQueued.tsx:94
+#: src/screens/SignupQueued.tsx:93 src/screens/SignupQueued.tsx:94
 #: src/screens/SignupQueued.tsx:109
 msgid "You're in line"
 msgstr "Sei in fila"
@@ -9701,18 +7753,11 @@ msgstr "Le tue conversazioni sonos state disabiltate"
 msgid "Your choice will be saved, but can be changed later in settings."
 msgstr "La tua scelta verrà salvata, ma potrà essere modificata successivamente nelle impostazioni."
 
-#~ msgid "Your default feed is \"Following\""
-#~ msgstr "Il tuo feed predefinito è \"Following\""
-
-#: src/screens/Login/ForgotPasswordForm.tsx:51
-#: src/screens/Signup/state.ts:203
+#: src/screens/Login/ForgotPasswordForm.tsx:51 src/screens/Signup/state.ts:203
 #: src/screens/Signup/StepInfo/index.tsx:108
 #: src/view/com/modals/ChangePassword.tsx:55
 msgid "Your email appears to be invalid."
 msgstr "Your email appears to be invalid."
-
-#~ msgid "Your email has been saved! We'll be in touch soon."
-#~ msgstr "La tua email è stata salvata! Ci metteremo in contatto al più presto."
 
 #: src/view/com/modals/ChangeEmail.tsx:120
 msgid "Your email has been updated but not verified. As a next step, please verify your new email."
@@ -9732,17 +7777,11 @@ msgstr "Il tuo feed seguente è vuoto! Segui più utenti per vedere cosa sta suc
 
 #: src/screens/Signup/StepHandle.tsx:125
 msgid "Your full handle will be"
-msgstr "Il tuo nome di utente completo sarà"
+msgstr "Il tuo nome utente completo sarà"
 
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:220
 msgid "Your full handle will be <0>@{0}</0>"
-msgstr "Il tuo nome di utente completo sarà <0>@{0}</0>"
-
-#~ msgid "Your hosting provider"
-#~ msgstr "Il tuo fornitore di hosting"
-
-#~ msgid "Your invite codes are hidden when logged in using an App Password"
-#~ msgstr "I tuoi codici di invito vengono celati quando accedi utilizzando una password per l'app"
+msgstr "Il tuo nome utente completo sarà <0>@{0}</0>"
 
 #: src/components/dialogs/MutedWords.tsx:369
 msgid "Your muted words"
@@ -9758,15 +7797,11 @@ msgstr "Il tuo post è stato pubblicato"
 
 #: src/view/com/composer/Composer.tsx:459
 msgid "Your posts have been published"
-msgstr ""
+msgstr "I tuoi post sono stati pubblicati"
 
 #: src/screens/Onboarding/StepFinished.tsx:246
 msgid "Your posts, likes, and blocks are public. Mutes are private."
 msgstr "I tuoi post, i tuoi Mi piace e i tuoi blocchi sono pubblici. I conti silenziati sono privati."
-
-#: src/view/screens/Settings/index.tsx:119
-#~ msgid "Your profile"
-#~ msgstr "Il tuo profilo"
 
 #: src/screens/Settings/components/DeactivateAccountDialog.tsx:75
 msgid "Your profile, posts, feeds, and lists will no longer be visible to other Bluesky users. You can reactivate your account at any time by logging in."
@@ -9782,4 +7817,1566 @@ msgstr "La tua segnalazione verrà inviata al Servizio Moderazione di Bluesky"
 
 #: src/screens/Signup/index.tsx:142
 msgid "Your user handle"
-msgstr "Il tuo handle utente"
+msgstr "Il tuo nome utente"
+
+#~ msgid "{0, plural, one {{formattedCount} other} other {{formattedCount} others}}"
+#~ msgstr "{0, plural, one {{formattedCount} altro} other {{formattedCount} altri}}"
+
+#~ msgid "{0, plural, one {and # other} other {and # others}}"
+#~ msgstr "{0, plural, one {e # altro} other {e # altri}}"
+
+#~ msgid "{0} {purposeLabel} List"
+#~ msgstr "Lista {purposeLabel} {0}"
+
+#~ msgid "{0} your feeds"
+#~ msgstr "{0} tuoi feed"
+
+#~ msgid "{diff, plural, one {day} other {days}}"
+#~ msgstr "{diff, plural, one {giorno} other {giorni}}"
+
+#~ msgid "{diff, plural, one {hour} other {hours}}"
+#~ msgstr "{diff, plural, one {ora} other {ore}}"
+
+#~ msgid "{diff, plural, one {minute} other {minutes}}"
+#~ msgstr "{diff, plural, one {minuto} other {minuti}}"
+
+#~ msgid "{diff, plural, one {month} other {months}}"
+#~ msgstr "{diff, plural, one {mese} other {mesi}}"
+
+#~ msgid "{diffSeconds, plural, one {second} other {seconds}}"
+#~ msgstr "{diffSeconds, plural, one {secondo} other {secondi}}"
+
+#~ msgid "{invitesAvailable, plural, one {Invite codes: # available} other {Invite codes: # available}}"
+#~ msgstr "{invitesAvailable, plural, one {Codici d'invito: # disponibile} other {Codici d'invito: # disponibili}}"
+
+#~ msgid "{invitesAvailable} invite code available"
+#~ msgstr "{invitesAvailable} codice d'invito disponibile"
+
+#~ msgid "{invitesAvailable} invite codes available"
+#~ msgstr "{invitesAvailable} codici d'invito disponibili"
+
+#~ msgid "{message}"
+#~ msgstr "{message}"
+
+#~ msgid "{value, plural, =0 {Show all replies} one {Show replies with at least # like} other {Show replies with at least # likes}}"
+#~ msgstr "{value, plural, =0 {Mostra tutte le risposte} one {Mostra risposte con almeno # like} other {Mostra risposte con almeno # like}}"
+
+#~ msgid "<0/> members"
+#~ msgstr "<0/> membri"
+
+#~ msgid "<0>{0} </0>and<1> </1><2>{1} </2>are included in your starter pack"
+#~ msgstr "<0>{0} </0>e<1> </1><2>{1} </2>sono inclusi nel tuo starter pack"
+
+#~ msgid "<0>{0}, </0><1>{1}, </1>and {2} {3, plural, one {other} other {others}} are included in your starter pack"
+#~ msgstr "<0>{0}, </0><1>{1}, </1>e {2} {3, plural, one {# altro} other {# altri}} sono inclusi nel tuo starter pack"
+
+#~ msgid "<0>{0}</0> following"
+#~ msgstr "<0>{0}</0> seguito"
+
+#~ msgid "<0>{followers} </0><1>{pluralizedFollowers}</1>"
+#~ msgstr "<0>{followers} </0><1>{pluralizedFollowers}</1>"
+
+#~ msgid "<0>{following} </0><1>following</1>"
+#~ msgstr "<0>{following} </0><1>following</1>"
+
+#~ msgid "<0>Choose your</0><1>Recommended</1><2>Feeds</2>"
+#~ msgstr "<0>Scegli i tuoi</0><1>feed/1><2>consigliati</2>"
+
+#~ msgid "<0>Follow some</0><1>Recommended</1><2>Users</2>"
+#~ msgstr "<0>Segui alcuni</0><1>utenti</1><2>consigliati</2>"
+
+#~ msgid "<0>Not Applicable.</0> This warning is only available for posts with media attached."
+#~ msgstr "<0>Non applicabile.</0> Questo avviso è disponibile solo per i post che contengono media."
+
+#~ msgid "<0>Welcome to</0><1>Bluesky</1>"
+#~ msgstr "<0>Ti diamo il benvenuto su</0><1>Bluesky</1>"
+
+#~ msgid "A content warning has been applied to this {0}."
+#~ msgstr "A questo post è stato applicato un avviso di contenuto {0}."
+
+#~ msgid "A new version of the app is available. Please update to continue using the app."
+#~ msgstr "È disponibile una nuova versione dell'app. Aggiorna per continuare a utilizzarla."
+
+#~ msgid "Accessibility settings"
+#~ msgstr "Impostazioni di accessibilità"
+
+#~ msgid "account"
+#~ msgstr "account"
+
+#~ msgid "Add ALT text"
+#~ msgstr "Agguingo del testo descrittivo"
+
+#~ msgid "Add details"
+#~ msgstr "Aggiungi i dettagli"
+
+#~ msgid "Add details to report"
+#~ msgstr "Aggiungi dettagli da segnalare"
+
+#~ msgid "Add link card"
+#~ msgstr "Aggiungi anteprima del link"
+
+#~ msgid "Add link card:"
+#~ msgstr "Aggiungi anteprima del link:"
+
+#~ msgid "Add people to your starter pack that you think others will enjoy following"
+#~ msgstr "Aggiungi persone al tuo starter pack che potrebbero interessare agli altri utenti"
+
+#~ msgid "Added"
+#~ msgstr "Aggiunto"
+
+#~ msgid "Adjust the number of likes a reply must have to be shown in your feed."
+#~ msgstr "Modifica il numero di \"Mi piace\" che una risposta deve avere per essere mostrata nel tuo feed."
+
+#~ msgid "Adult content can only be enabled via the Web at <0/>."
+#~ msgstr "I contenuti per adulti possono essere abilitati solo dal sito Web a <0/>."
+
+#~ msgid "Allow messages from"
+#~ msgstr "Permetti tutti i messaggi di"
+
+#~ msgid "An error occured"
+#~ msgstr "Si è verificato un errore"
+
+#~ msgid "An error occurred while saving the image."
+#~ msgstr "Si è verificato un errore nel caricare l'immagine."
+
+#~ msgid "An error occurred while trying to delete the message. Please try again."
+#~ msgstr "Si è verificato un errore durante la cancellazione del messaggio. Per favore riprova più tardi."
+
+#~ msgid "App Password names can only contain letters, numbers, spaces, dashes, and underscores."
+#~ msgstr "Le password dell'app possono contenere solo lettere, numeri, spazi, trattini e trattini bassi."
+
+#~ msgid "App Password names must be at least 4 characters long."
+#~ msgstr "Le password delle app devono contenere almeno 4 caratteri."
+
+#~ msgid "App password settings"
+#~ msgstr "Impostazioni della password dell'app"
+
+#~ msgid "Appeal content warning"
+#~ msgstr "Ricorso contro l'avviso sui contenuti"
+
+#~ msgid "Appeal Content Warning"
+#~ msgstr "Ricorso contro l'Avviso sui Contenuti"
+
+#~ msgid "Appeal Decision"
+#~ msgstr "Decisión de apelación"
+
+#~ msgid "Appeal submitted."
+#~ msgstr "Ricorso presentato."
+
+#~ msgid "Appeal this decision."
+#~ msgstr "Appella contro questa decisione."
+
+#~ msgid "Appearance settings"
+#~ msgstr "Impostazioni dell'aspetto"
+
+#~ msgid "Appearance Settings"
+#~ msgstr "Impostazioni dell'aspetto"
+
+#~ msgid "Are you sure you want delete this starter pack?"
+#~ msgstr "Sicuro di voler eliminare questo starter pack?"
+
+#~ msgid "Are you sure you want to delete the app password \"{name}\"?"
+#~ msgstr "Confermi di voler eliminare la password dell'app \"{name}\"?"
+
+#~ msgid "Are you sure? This cannot be undone."
+#~ msgstr "Vuoi proseguire? Questa operazione non può essere annullata."
+
+#~ msgctxt "action"
+#~ msgid "Back"
+#~ msgstr "Indietro"
+
+#~ msgid "Based on your interest in {interestsText}"
+#~ msgstr "Basato sui tuoi interessi {interestsText}"
+
+#~ msgid "Basics"
+#~ msgstr "Preferenze"
+
+#~ msgid "Birthday:"
+#~ msgstr "Compleanno:"
+
+#~ msgid "Block this List"
+#~ msgstr "Blocca questa Lista"
+
+#~ msgid "Bluesky is an open network where you can choose your hosting provider. Custom hosting is now available in beta for developers."
+#~ msgstr "Bluesky è un network aperto in cui puoi scegliere il tuo provider di hosting. L'hosting personalizzato è adesso disponibile in versione beta per gli sviluppatori."
+
+#~ msgid "Bluesky is flexible."
+#~ msgstr "Bluesky è flessibile."
+
+#~ msgid "Bluesky is open."
+#~ msgstr "Bluesky è aperto."
+
+#~ msgid "Bluesky is public."
+#~ msgstr "Bluesky è pubblico."
+
+#~ msgid "Bluesky uses invites to build a healthier community. If you don't know anybody with an invite, you can sign up for the waitlist and we'll send one soon."
+#~ msgstr "Bluesky utilizza gli inviti per costruire una comunità più sana. Se non conosci nessuno con un invito, puoi iscriverti alla lista d'attesa e te ne invieremo uno al più presto."
+
+#~ msgid "Bluesky.Social"
+#~ msgstr "Bluesky.Social"
+
+#~ msgid "Build version {0} {1}"
+#~ msgstr "Versione {0} {1}"
+
+#~ msgid "Button disabled. Input custom domain to proceed."
+#~ msgstr "Pulsante disabilitato. Inserisci il dominio personalizzato per procedere."
+
+#~ msgid "by {0}"
+#~ msgstr "di {0}"
+
+#~ msgid "by @{0}"
+#~ msgstr "Di @{0}"
+
+#~ msgid "By creating an account you agree to the {els}."
+#~ msgstr "Creando un account accetti i {els}."
+
+#~ msgid "Can only contain letters, numbers, spaces, dashes, and underscores. Must be at least 4 characters long, but no more than 32 characters long."
+#~ msgstr "Può contenere solo lettere, numeri, spazi, trattini e trattini bassi. Deve contenere almeno 4 caratteri, ma non più di 32 caratteri."
+
+#~ msgid "Cancel add image alt text"
+#~ msgstr "Annulla inserimento testo alternativo immagine "
+
+#~ msgid "Cancel change handle"
+#~ msgstr "Annulla il cambio del tuo nome utente"
+
+#~ msgid "Cancel waitlist signup"
+#~ msgstr "Annulla l'iscrizione alla lista d'attesa"
+
+#~ msgctxt "action"
+#~ msgid "Change"
+#~ msgstr "Cambia"
+
+#~ msgid "Change handle"
+#~ msgstr "Cambia il nome utente"
+
+#~ msgid "Change password"
+#~ msgstr "Cambia la password"
+
+#~ msgid "Change your Bluesky password"
+#~ msgstr "Cambia la tua password di Bluesky"
+
+#~ msgid "Check out some recommended feeds. Tap + to add them to your list of pinned feeds."
+#~ msgstr "Dai un'occhiata ad alcuni feed consigliati. Clicca + per aggiungerli al tuo elenco dei feed."
+
+#~ msgid "Check out some recommended users. Follow them to see similar users."
+#~ msgstr "Scopri alcuni utenti consigliati. Seguili per vedere utenti simili."
+
+#~ msgid "Choose \"Everybody\" or \"Nobody\""
+#~ msgstr "Scegli \"Tutti\" o \"Nessuno\""
+
+#~ msgid "Choose 3 or more:"
+#~ msgstr "Scegli 3 o più:"
+
+#~ msgid "Choose a new Bluesky username or create"
+#~ msgstr "Scegli un nuovo nome utente Bluesky o creane uno"
+
+#~ msgid "Choose at least {0} more"
+#~ msgstr "Scegli almeno {0} in più"
+
+#~ msgid "Choose the algorithms that power your experience with custom feeds."
+#~ msgstr "Scegli gli algoritmi che migliorano la tua esperienza con i feed personalizzati."
+
+#~ msgid "Choose who can reply"
+#~ msgstr "Scegli chi può rispondere"
+
+#~ msgid "Choose your main feeds"
+#~ msgstr "Scegli i tuoi feed principali"
+
+#~ msgid "Clear all legacy storage data"
+#~ msgstr "Cancella tutti i dati legacy in archivio"
+
+#~ msgid "Clear all legacy storage data (restart after this)"
+#~ msgstr "Cancella tutti i dati legacy in archivio (poi ricomincia)"
+
+#~ msgid "Clears all legacy storage data"
+#~ msgstr "Cancella tutti i dati di archiviazione legacy"
+
+#~ msgid "Clears all storage data"
+#~ msgstr "Cancella tutti i dati di archiviazione"
+
+#~ msgid "Click here to add one."
+#~ msgstr "Clicca qui per aggiungerne uno."
+
+#~ msgid "Click here to open tag menu for #{tag}"
+#~ msgstr "Clicca qui per aprire il menu per #{tag}"
+
+#~ msgid "Close modal"
+#~ msgstr "Chiudi finestra"
+
+#~ msgid "Closes post composer and discards post draft"
+#~ msgstr "Chiude l'editore del post ed elimina la bozza del post"
+
+#~ msgid "Compressing..."
+#~ msgstr "Compressione in corso..."
+
+#~ msgid "Configure content filtering setting for category: {0}"
+#~ msgstr "Configura l'impostazione del filtro dei contenuti per la categoria:{0}"
+
+#~ msgctxt "action"
+#~ msgid "Confirm"
+#~ msgstr "Conferma"
+
+#~ msgid "Confirm your age to enable adult content."
+#~ msgstr "Conferma la tua età per abilitare i contenuti per adulti."
+
+#~ msgid "Confirms signing up {email} to the waitlist"
+#~ msgstr "Conferma l'iscrizione di {email} alla lista d'attesa"
+
+#~ msgid "content"
+#~ msgstr "contenuto"
+
+#~ msgid "Content filtering"
+#~ msgstr "Filtro dei contenuti"
+
+#~ msgid "Content Filtering"
+#~ msgstr "Filtro dei Contenuti"
+
+#~ msgid "Continue to the next step"
+#~ msgstr "Vai al passaggio successivo"
+
+#~ msgid "Continue to the next step without following any accounts"
+#~ msgstr "Vai al passaggio successivo senza seguire nessun account"
+
+#~ msgid "Copies app password"
+#~ msgstr "Copia la password dell'app"
+
+#~ msgid "Copy {0}"
+#~ msgstr "Copia {0}"
+
+#~ msgid "Copy link to profile"
+#~ msgstr "Copia il link al profilo"
+
+#~ msgid "Could not compress video"
+#~ msgstr "Impossibile comprimere il video"
+
+#~ msgid "Could not load profiles. Please try again later."
+#~ msgstr "Impossibile caricare i profili. Per favore riprova più tardi."
+
+#~ msgid "Country"
+#~ msgstr "Paese"
+
+#~ msgid "Create a new account"
+#~ msgstr "Crea un nuovo account"
+
+#~ msgid "Create a new Bluesky account"
+#~ msgstr "Crea un nuovo account Bluesky"
+
+#~ msgid "Create App Password"
+#~ msgstr "Crea un password per l'app"
+
+#~ msgid "Create QR code"
+#~ msgstr "Crea codice QR"
+
+#~ msgid "Created by <0/>"
+#~ msgstr "Creato da <0/>"
+
+#~ msgid "Created by you"
+#~ msgstr "Creato da te"
+
+#~ msgid "Creates a card with a thumbnail. The card links to {url}"
+#~ msgstr "Crea una scheda con una miniatura. La scheda si collega a {url}"
+
+#~ msgid "Custom domain"
+#~ msgstr "Dominio personalizzato"
+
+#~ msgid "Customize media from external sites."
+#~ msgstr "Personalizza i media da i siti esterni."
+
+#~ msgid "Danger Zone"
+#~ msgstr "Zona di Pericolo"
+
+#~ msgid "Dark Theme"
+#~ msgstr "Tema scuro"
+
+#~ msgid "Deactivate my account"
+#~ msgstr "Disattiva il mio account"
+
+#~ msgid "Delete Account"
+#~ msgstr "Elimina l'Account"
+
+#~ msgid "Delete my account…"
+#~ msgstr "Cancella il mio account…"
+
+#~ msgid "Delete My Account…"
+#~ msgstr "Cancellare Account…"
+
+#~ msgid "Dev Server"
+#~ msgstr "Server di sviluppo"
+
+#~ msgid "Developer Tools"
+#~ msgstr "Strumenti per sviluppatori"
+
+#~ msgid "Did you want to say anything?"
+#~ msgstr "Volevi dire qualcosa?"
+
+#~ msgid "Direct messages are here!"
+#~ msgstr "I messaggi diretti sono arrivati!"
+
+#~ msgid "Disable autoplay for GIFs"
+#~ msgstr "Disattiva la riproduzione automatica per le GIF"
+
+#~ msgid "Disable autoplay for videos and GIFs"
+#~ msgstr "Disabilita riproduzione automatica per video e GIFs."
+
+#~ msgid "Discard draft"
+#~ msgstr "Scarta la bozza"
+
+#~ msgid "Discover learns which posts you like as you browse."
+#~ msgstr "Ricerca imparerà quali post ti piacciono nel mentre cerchi."
+
+#~ msgid "Domain Value"
+#~ msgstr "Valore del dominio"
+
+#~ msgid "Don't have an invite code?"
+#~ msgstr "Non hai un codice di invito?"
+
+#~ msgid "Double tap to sign in"
+#~ msgstr "Usa il doppio tocco per accedere"
+
+#~ msgid "Download Bluesky account data (repository)"
+#~ msgstr "Scarica i dati dell'account Bluesky (archivio)"
+
+#~ msgid "Due to Apple policies, adult content can only be enabled on the web after completing sign up."
+#~ msgstr "A causa delle politiche di Apple, i contenuti per adulti possono essere abilitati sul Web solo dopo aver completato la registrazione."
+
+#~ msgid "Edit Saved Feeds"
+#~ msgstr "Modifica i feed memorizzati"
+
+#~ msgid "Either choose \"Everybody\" or \"Nobody\""
+#~ msgstr "Scegli \"Everybody\" o \"Nobody\\"
+
+#~ msgid "Email:"
+#~ msgstr "Email:"
+
+#~ msgid "Enable Adult Content"
+#~ msgstr "Attiva Contenuto per Adulti"
+
+#~ msgid "Enable adult content in your feeds"
+#~ msgstr "Abilita i contenuti per adulti nei tuoi feed"
+
+#~ msgid "Enable External Media"
+#~ msgstr "Attiva Media Esterna"
+
+#~ msgid "Enable this setting to only see replies between people you follow."
+#~ msgstr "Abilita questa impostazione per vedere solo le risposte delle persone che segui."
+
+#~ msgid "Enter a name for this App Password"
+#~ msgstr "Inserisci un nome per questa password dell'app"
+
+#~ msgid "Enter the address of your provider:"
+#~ msgstr "Inserisci l'indirizzo del tuo provider:"
+
+#~ msgid "Enter your email"
+#~ msgstr "Inserisci la tua email"
+
+#~ msgid "Enter your phone number"
+#~ msgstr "Inserisci il tuo numero di telefono"
+
+#~ msgid "Exits handle change process"
+#~ msgstr "Uscita dal processo di modifica"
+
+#~ msgid "Exits signing up for waitlist with {email}"
+#~ msgstr "Uscita dall'iscrizione alla lista d'attesa con {email}"
+
+#~ msgid "Experimental: When this preference is enabled, you'll only receive reply and quote notifications from users you follow. We'll continue to add more controls here over time."
+#~ msgstr "SPERIMENTALE: Abilitando questa opzione, riceverai notifiche esclusivamente dagli utenti che segui. Continueremo ad aggiungere nuovi controlli in futuro."
+
+#~ msgid "External media settings"
+#~ msgstr "Impostazioni multimediali esterni"
+
+#~ msgid "Failed to create app password."
+#~ msgstr "Impossibile creare la password dell'app."
+
+#~ msgid "Failed to load recommended feeds"
+#~ msgstr "Impossibile caricare feed consigliati"
+
+#~ msgid "Feed offline"
+#~ msgstr "Feed offline"
+
+#~ msgid "Feed Preferences"
+#~ msgstr "Preferenze del feed"
+
+#~ msgid "Feeds are created by users to curate content. Choose some feeds that you find interesting."
+#~ msgstr "I feed vengono creati dagli utenti per curare i contenuti. Scegli alcuni feed che ritieni interessanti."
+
+#~ msgid "Feeds can be topical as well!"
+#~ msgstr "I feed possono anche avere tematiche!"
+
+#~ msgid "File Contents"
+#~ msgstr "Archivia i contenuti"
+
+#~ msgid "Find more feeds and accounts to follow in the Explore page."
+#~ msgstr "Scopri nuovi account e feed da seguire in Esplora."
+
+#~ msgid "Find users on Bluesky"
+#~ msgstr "Scopri utenti su Bluesky"
+
+#~ msgid "Find users with the search tool on the right"
+#~ msgstr "Scopri gli utenti con lo strumento di ricerca sulla destra"
+
+#~ msgid "Finding similar accounts..."
+#~ msgstr "Scoprendo account simili…"
+
+#~ msgid "Fine-tune the content you see on your Following feed."
+#~ msgstr "Ottimizza il contenuto che vedi nel tuo Following feed."
+
+#~ msgid "Fine-tune the content you see on your home screen."
+#~ msgstr "Ottimizza il contenuto che vedi nella Home."
+
+#~ msgid "Fine-tune the discussion threads."
+#~ msgstr "Ottimizza la visualizzazione delle discussioni."
+
+#~ msgid "Finish tour and begin using the application"
+#~ msgstr "Termina il tour ed inizia ad usare l'app"
+
+#~ msgid "Flip horizontal"
+#~ msgstr "Gira in orizzontale"
+
+#~ msgid "Flip vertically"
+#~ msgstr "Gira in verticale"
+
+#~ msgid "Follow All"
+#~ msgstr "Segui tutti"
+
+#~ msgid "Follow selected accounts and continue to the next step"
+#~ msgstr "Segui gli account selezionati e vai al passaggio successivo"
+
+#~ msgid "Follow some users to get started. We can recommend you more users based on who you find interesting."
+#~ msgstr "Segui alcuni utenti per iniziare. Possiamo consigliarti più utenti in base a chi trovi interessante."
+
+#~ msgid "Followed by"
+#~ msgstr "Seguito da"
+
+#~ msgid "Followed by {0}"
+#~ msgstr "Seguito da {0}"
+
+#~ msgid "Followed users only"
+#~ msgstr "Solo utenti seguiti"
+
+#~ msgid "followed you"
+#~ msgstr "ti segue"
+
+#~ msgid "followed you back"
+#~ msgstr "ti ha seguito"
+
+#~ msgid "following"
+#~ msgstr "following"
+
+#~ msgid "Following shows the latest posts from people you follow."
+#~ msgstr "Il feed Following mostra i post più recenti delle persone che segui."
+
+#~ msgid "For security reasons, you won't be able to view this again. If you lose this password, you'll need to generate a new one."
+#~ msgstr "Per motivi di sicurezza non potrai visualizzarlo nuovamente. Se perdi questa password, dovrai generarne una nuova."
+
+#~ msgid "Forgot"
+#~ msgstr "Dimenticato"
+
+#~ msgid "Forgot password"
+#~ msgstr "Ho dimenticato la password"
+
+#~ msgid "Get started"
+#~ msgstr "Iniziamo"
+
+#~ msgid "Go to @{queryMaybeHandle}"
+#~ msgstr "Vai a @{queryMaybeHandle}"
+
+#~ msgid "Go to the next step of the tour"
+#~ msgstr "Vai avanti"
+
+#~ msgid "Here are some accounts for you to follow"
+#~ msgstr "Ecco alcuni account da seguire"
+
+#~ msgid "Here are some popular topical feeds. You can choose to follow as many as you like."
+#~ msgstr "Ecco alcuni feed più visitati. Puoi seguire quanti ne vuoi."
+
+#~ msgid "Here are some topical feeds based on your interests: {interestsText}. You can choose to follow as many as you like."
+#~ msgstr "Ecco alcuni feed di attualità scelti in base ai tuoi interessi: {interestsText}. Puoi seguire quanti ne vuoi."
+
+#~ msgid "Here is your app password."
+#~ msgstr "Ecco la password dell'app."
+
+#~ msgid "Hide post"
+#~ msgstr "Nascondi post"
+
+#~ msgid "Hides posts from {0} in your feed"
+#~ msgstr "Nasconde i post di {0} nel tuo feed"
+
+#~ msgid "Home Feed Preferences"
+#~ msgstr "Preferenze per i feed per la pagina d'inizio"
+
+#~ msgid "Hosting provider address"
+#~ msgstr "Indirizzo del fornitore di hosting"
+
+#~ msgid "If none are selected, suitable for all ages."
+#~ msgstr "Se niente è selezionato, adatto a tutte le età."
+
+#~ msgid "Image alt text"
+#~ msgstr "Testo alternativo dell'immagine"
+
+#~ msgid "Image options"
+#~ msgstr "Opzioni per l'immagine"
+
+#~ msgid "Input email for Bluesky account"
+#~ msgstr "Inserisci l'e-mail per l'account di Bluesky"
+
+#~ msgid "Input invite code to proceed"
+#~ msgstr "Inserisci il codice di invito per procedere"
+
+#~ msgid "Input name for app password"
+#~ msgstr "Inserisci il nome per la password dell'app"
+
+#~ msgid "Input phone number for SMS verification"
+#~ msgstr "Inserisci il numero di telefono per la verifica via SMS"
+
+#~ msgid "Input the password tied to {identifier}"
+#~ msgstr "Inserisci la password relazionata a {identifier}"
+
+#~ msgid "Input the verification code we have texted to you"
+#~ msgstr "Inserisci il codice di verifica che ti abbiamo inviato tramite SMS"
+
+#~ msgid "Input your email to get on the Bluesky waitlist"
+#~ msgstr "Inserisci la tua email per entrare nella lista d'attesa di Bluesky"
+
+#~ msgid "Input your preferred hosting provider"
+#~ msgstr "Inserisci il tuo provider di hosting preferito"
+
+#~ msgid "Introducing Direct Messages"
+#~ msgstr "Introduzione ai Messaggi Diretti"
+
+#~ msgid "Introducing new font settings"
+#~ msgstr "Introduzione di nuovi settaggi per i font"
+
+#~ msgid "Invite"
+#~ msgstr "Invita"
+
+#~ msgid "Invite codes: {invitesAvailable} available"
+#~ msgstr "Codici di invito: {invitesAvailable} disponibili"
+
+#~ msgid "It shows posts from the people you follow as they happen."
+#~ msgstr "Mostra i post delle persone che segui."
+
+#~ msgid "Join the waitlist"
+#~ msgstr "Iscriviti alla lista d'attesa"
+
+#~ msgid "Join the waitlist."
+#~ msgstr "Iscriviti alla lista d'attesa."
+
+#~ msgid "Join Waitlist"
+#~ msgstr "Iscriviti alla Lista d'Attesa"
+
+#~ msgid "label has been placed on this {labelTarget}"
+#~ msgstr "l'etichetta è stata inserita su questo {labelTarget}"
+
+#~ msgid "labels have been placed on this {labelTarget}"
+#~ msgstr "le etichette sono state inserite su questo {labelTarget}"
+
+#~ msgid "Language settings"
+#~ msgstr "Impostazione delle lingue"
+
+#~ msgid "Last step!"
+#~ msgstr "Ultimo passo!"
+
+#~ msgid "Learn more"
+#~ msgstr "Ulteriori informazioni"
+
+#~ msgid "Legacy storage cleared, you need to restart the app now."
+#~ msgstr "L'archivio legacy è stato cancellato, riattiva la app."
+
+#~ msgid "Library"
+#~ msgstr "Biblioteca"
+
+#~ msgid "Like"
+#~ msgstr "Mi piace"
+
+#~ msgid "Liked by {0} {1}"
+#~ msgstr "Piace a {0} {1}"
+
+#~ msgid "Liked by {count} {0}"
+#~ msgstr "È piaciuto a {count} {0}"
+
+#~ msgid "Liked by {likeCount} {0}"
+#~ msgstr "Piace a {likeCount} {0}"
+
+#~ msgid "liked your custom feed"
+#~ msgstr "piace il tuo feed personalizzato"
+
+#~ msgid "liked your custom feed{0}"
+#~ msgstr "piace il feed personalizzato{0}"
+
+#~ msgid "liked your post"
+#~ msgstr "piace il tuo post"
+
+#~ msgid "Load more posts"
+#~ msgstr "Carica più post"
+
+#~ msgid "Local dev server"
+#~ msgstr "Server di sviluppo locale"
+
+#~ msgid "Looks like this feed is only available to users with a Bluesky account. Please sign up or sign in to view this feed!"
+#~ msgstr "Sembra che questo feed sia disponibile solo per gli utenti con un account Bluesky. Per favore registrati o accedi per visualizzare questo feed!"
+
+#~ msgid "May not be longer than 253 characters"
+#~ msgstr "Non può contenere più di 253 caratteri"
+
+#~ msgid "May only contain letters and numbers"
+#~ msgstr "Può contenere solo lettere e numeri"
+
+#~ msgid "Message from server"
+#~ msgstr "Messaggio dal server"
+
+#~ msgid "Mode"
+#~ msgstr "Tema"
+
+#~ msgid "Moderation settings"
+#~ msgstr "Impostazioni di moderazione"
+
+#~ msgid "More post options"
+#~ msgstr "Altre impostazioni per il post"
+
+#~ msgid "Must be at least 3 characters"
+#~ msgstr "Deve contenere almeno 3 caratteri"
+
+#~ msgid "Mute in tags only"
+#~ msgstr "Silenzia solo i tags"
+
+#~ msgid "Mute in text & tags"
+#~ msgstr "Silenzia nel testo & tags"
+
+#~ msgid "Mute notifications"
+#~ msgstr "Silenza notifiche"
+
+#~ msgid "Mute this List"
+#~ msgstr "Silenzia questa Lista"
+
+#~ msgid "Muted"
+#~ msgstr "Silenziato"
+
+#~ msgid "My saved feeds"
+#~ msgstr "I miei feed salvati"
+
+#~ msgid "My Saved Feeds"
+#~ msgstr "I miei Feed Salvati"
+
+#~ msgid "my-server.com"
+#~ msgstr "my-server.com"
+
+#~ msgid "Navigate to starter pack"
+#~ msgstr "Vai allo starter pack"
+
+#~ msgid "Never load embeds from {0}"
+#~ msgstr "Non caricare mai gli inserimenti di {0}"
+
+#~ msgid "Never lose access to your followers and data."
+#~ msgstr "Non perdere mai l'accesso ai tuoi follower e ai tuoi dati."
+
+#~ msgid "New font settings ✨"
+#~ msgstr "Nuovi settaggi per i font ✨"
+
+#~ msgid "New Post"
+#~ msgstr "Nuovo Post"
+
+#~ msgctxt "action"
+#~ msgid "Next"
+#~ msgstr "Seguente"
+
+#~ msgid "No"
+#~ msgstr "No"
+
+#~ msgid "Nobody can reply"
+#~ msgstr "Nessuno puo rispondere"
+
+#~ msgid "Not Applicable."
+#~ msgstr "Non applicabile."
+
+#~ msgid "Nudity or pornography not labeled as such"
+#~ msgstr "Nudità o pornografia non etichettata come tale"
+
+#~ msgid "of"
+#~ msgstr "di"
+
+#~ msgid "on"
+#~ msgstr "su"
+
+#~ msgid "on {str}"
+#~ msgstr "su {str}"
+
+#~ msgid "Only {0} can reply"
+#~ msgstr "Solo {0} può rispondere"
+
+#~ msgid "Open links with in-app browser"
+#~ msgstr "Apri i links con il navigatore della app"
+
+#~ msgid "Opens accessibility settings"
+#~ msgstr "Apre le impostazioni di accessibilità"
+
+#~ msgid "Opens an expanded list of users in this notification"
+#~ msgstr "Apre un elenco ampliato di utenti in questa notifica"
+
+#~ msgid "Opens appearance settings"
+#~ msgstr "Apre le impostazioni del tema"
+
+#~ msgid "Opens chat settings"
+#~ msgstr "Apre impostazioni messaggi"
+
+#~ msgid "Opens configurable language settings"
+#~ msgstr "Apre le impostazioni configurabili delle lingue"
+
+#~ msgid "Opens editor for profile display name, avatar, background image, and description"
+#~ msgstr "Apre l'editor per il nome configurato del profilo, l'avatar, l'immagine di sfondo e la descrizione"
+
+#~ msgid "Opens external embeds settings"
+#~ msgstr "Apre le impostazioni esterne per gli incorporamenti"
+
+#~ msgid "Opens followers list"
+#~ msgstr "Apre la lista dei follower"
+
+#~ msgid "Opens following list"
+#~ msgstr "Apre la lista di chi segui"
+
+#~ msgid "Opens invite code list"
+#~ msgstr "Apre la lista dei codici di invito"
+
+#~ msgid "Opens modal for account deactivation confirmation"
+#~ msgstr "Apre menu per confermare la disattivazione dell'account"
+
+#~ msgid "Opens modal for account deletion confirmation. Requires email code"
+#~ msgstr "Apre la modale per la conferma dell'eliminazione dell'account. Richiede un codice e-mail"
+
+#~ msgid "Opens modal for account deletion confirmation. Requires email code."
+#~ msgstr "Apre il modal per la conferma dell'eliminazione dell'account. Richiede un codice email."
+
+#~ msgid "Opens modal for changing your Bluesky password"
+#~ msgstr "Apre la modale per modificare il tuo password di Bluesky"
+
+#~ msgid "Opens modal for choosing a new Bluesky handle"
+#~ msgstr "Apre la modale per la scelta di un nuovo handle di Bluesky"
+
+#~ msgid "Opens modal for downloading your Bluesky account data (repository)"
+#~ msgstr "Apre la modale per scaricare i dati del tuo account Bluesky (repository)"
+
+#~ msgid "Opens modal for email verification"
+#~ msgstr "Apre la modale per la verifica dell'e-mail"
+
+#~ msgid "Opens modal for using custom domain"
+#~ msgstr "Apre il modal per l'utilizzo del dominio personalizzato"
+
+#~ msgid "Opens moderation settings"
+#~ msgstr "Apre le impostazioni di moderazione"
+
+#~ msgid "Opens screen to edit Saved Feeds"
+#~ msgstr "Apre la schermata per modificare i feed salvati"
+
+#~ msgid "Opens screen with all saved feeds"
+#~ msgstr "Apre la schermata con tutti i feed salvati"
+
+#~ msgid "Opens the app password settings"
+#~ msgstr "Apre le impostazioni della password dell'app"
+
+#~ msgid "Opens the app password settings page"
+#~ msgstr "Apre la pagina delle impostazioni della password dell'app"
+
+#~ msgid "Opens the Following feed preferences"
+#~ msgstr "Apre le preferenze del feed Following"
+
+#~ msgid "Opens the home feed preferences"
+#~ msgstr "Apre le preferenze del home feed"
+
+#~ msgid "Opens the message settings page"
+#~ msgstr "Apre le impostazioni dei messaggi"
+
+#~ msgid "Opens the storybook page"
+#~ msgstr "Apri la pagina della cronologia"
+
+#~ msgid "Opens the system log page"
+#~ msgstr "Apre la pagina del registro di sistema"
+
+#~ msgid "Opens the threads preferences"
+#~ msgstr "Apre le preferenze dei threads"
+
+#~ msgid "Other accounts"
+#~ msgstr "Altri account"
+
+#~ msgid "Other service"
+#~ msgstr "Altro servizio"
+
+#~ msgid "Phone number"
+#~ msgstr "Numero di telefono"
+
+#~ msgid "Please enter a name for your app password. All spaces is not allowed."
+#~ msgstr "Inserisci un nome per la password dell'app. Tutti gli spazi non sono consentiti."
+
+#~ msgid "Please enter a phone number that can receive SMS text messages."
+#~ msgstr "Inserisci un numero di telefono in grado di ricevere messaggi di testo SMS."
+
+#~ msgid "Please enter a unique name for this App Password or use our randomly generated one."
+#~ msgstr "Inserisci un nome unico per la password dell'app o utilizzane uno generato automaticamente."
+
+#~ msgid "Please enter the code you received by SMS."
+#~ msgstr "Inserisci il codice che hai ricevuto via SMS."
+
+#~ msgid "Please enter the verification code sent to {phoneNumberFormatted}."
+#~ msgstr "Inserisci il codice di verifica inviato a {phoneNumberFormatted}."
+
+#~ msgid "Please tell us why you think this content warning was incorrectly applied!"
+#~ msgstr "Spiegaci perché ritieni che questo avviso sui contenuti sia stato applicato in modo errato!"
+
+#~ msgid "Please tell us why you think this decision was incorrect."
+#~ msgstr "Per favore spiegaci perché ritieni che questa decisione sia stata sbagliata."
+
+#~ msgid "Please wait for your link card to finish loading"
+#~ msgstr "Attendi il caricamento della scheda di collegamento"
+
+#~ msgid "Pornography"
+#~ msgstr "Pornografia"
+
+#~ msgid "Post"
+#~ msgstr "Post"
+
+#~ msgid "Posts can be muted based on their text, their tags, or both."
+#~ msgstr "I post possono essere silenziati ​​in base al testo, ai tag o entrambi."
+
+#~ msgid "Prioritize Your Follows"
+#~ msgstr "Dai priorità a quelli che segui"
+
+#~ msgid "Privately chat with other users."
+#~ msgstr "Messaggia privatamente con altri utenti."
+
+#~ msgid "Protect your account by verifying your email."
+#~ msgstr "Proteggi il tuo account verificando la tua email."
+
+#~ msgid "Publish post"
+#~ msgstr "Pubblica il post"
+
+#~ msgid "Publish reply"
+#~ msgstr "Pubblica la risposta"
+
+#~ msgctxt "action"
+#~ msgid "Quote post"
+#~ msgstr "Cita il post"
+
+#~ msgctxt "action"
+#~ msgid "Quote Post"
+#~ msgstr "Cita il post"
+
+#~ msgid "Quote Post"
+#~ msgstr "Cita il post"
+
+#~ msgid "Ratios"
+#~ msgstr "Rapporti"
+
+#~ msgid "Recommended Feeds"
+#~ msgstr "Feed consigliati"
+
+#~ msgid "Recommended Users"
+#~ msgstr "Utenti consigliati"
+
+#~ msgid "Remove {0} from my feeds?"
+#~ msgstr "Rimuovere {0} dai miei feed?"
+
+#~ msgid "Remove image preview"
+#~ msgstr "Rimuovi l'anteprima dell'immagine"
+
+#~ msgid "Remove this feed from my feeds?"
+#~ msgstr "Rimuovere questo feed dai miei feed?"
+
+#~ msgid "Remove this feed from your saved feeds?"
+#~ msgstr "Elimina questo feed dai feed salvati?"
+
+#~ msgid "Removes default thumbnail from {0}"
+#~ msgstr "Elimina la miniatura predefinita da {0}"
+
+#~ msgid "Removes the image preview"
+#~ msgstr "Rimuove la preview dell'immagine"
+
+#~ msgid "Replies on this thread are disabled"
+#~ msgstr "Le risposte a questo thread sono disattivate"
+
+#~ msgid "Replies to this thread are disabled"
+#~ msgstr "Le risposte a questo thread sono disabilitate"
+
+#~ msgid "Reply Filters"
+#~ msgstr "Filtri di risposta"
+
+#~ msgctxt "description"
+#~ msgid "Reply to <0/>"
+#~ msgstr "In risposta a <0/>"
+
+#~ msgid "Report {collectionName}"
+#~ msgstr "Segnala {collectionName}"
+
+#~ msgid "Reposted by"
+#~ msgstr "Repost di"
+
+#~ msgid "Reposted by {0})"
+#~ msgstr "Repost di {0})"
+
+#~ msgid "Reposted by <0/>"
+#~ msgstr "Repost di <0/>"
+
+#~ msgid "reposted your post"
+#~ msgstr "ripubblicato il tuo post"
+
+#~ msgid "Request code"
+#~ msgstr "Richiedi un codice"
+
+#~ msgid "Require email code to log into your account"
+#~ msgstr "Richiedi il codice via email per accedere al tuo account"
+
+#~ msgid "Reset onboarding"
+#~ msgstr "Reimposta l'incorporazione"
+
+#~ msgid "Reset preferences"
+#~ msgstr "Reimposta le preferenze"
+
+#~ msgid "Reset preferences state"
+#~ msgstr "Reimposta lo stato delle preferenze"
+
+#~ msgid "Resets the onboarding state"
+#~ msgstr "Reimposta lo stato dell'incorporazione"
+
+#~ msgid "Resets the preferences state"
+#~ msgstr "Reimposta lo stato delle preferenze"
+
+#~ msgid "Retry."
+#~ msgstr "Riprova."
+
+#~ msgid "SANDBOX. Posts and accounts are not permanent."
+#~ msgstr "SANDBOX. I post e gli account non sono permanenti."
+
+#~ msgid "Save alt text"
+#~ msgstr "Salva il testo alternativo"
+
+#~ msgid "Save handle change"
+#~ msgstr "Salva la modifica del tuo identificatore"
+
+#~ msgid "Saved to your camera roll."
+#~ msgstr "Salvato nel rullino fotografico."
+
+#~ msgid "Saves handle change to {handle}"
+#~ msgstr "Salva la modifica del cambio dell'utente in {handle}"
+
+#~ msgid "Search for all posts by @{authorHandle} with tag {displayTag}"
+#~ msgstr "Cerca tutti i post di @{authorHandle} con tag {displayTag}"
+
+#~ msgid "Search for all posts with tag {displayTag}"
+#~ msgstr "Cerca tutti i post con il tag {displayTag}"
+
+#~ msgid "See profile"
+#~ msgstr "Vedi il profilo"
+
+#~ msgid "See what's next"
+#~ msgstr "Scopri cosa c'è dopo"
+
+#~ msgid "Select Bluesky Social"
+#~ msgstr "Seleziona Bluesky Social"
+
+#~ msgid "Select service"
+#~ msgstr "Selecciona el servei"
+
+#~ msgid "Select some accounts below to follow"
+#~ msgstr "Seleziona alcuni account da seguire qui giù"
+
+#~ msgid "Select topical feeds to follow from the list below"
+#~ msgstr "Seleziona i feed con temi da seguire dal seguente elenco"
+
+#~ msgid "Select what you want to see (or not see), and we’ll handle the rest."
+#~ msgstr "Seleziona ciò che vuoi vedere (o non vedere) e noi gestiremo il resto."
+
+#~ msgid "Select your app language for the default text to display in the app"
+#~ msgstr "Seleziona la lingua dell'app per il testo predefinito da visualizzare nell'app"
+
+#~ msgid "Select your phone's country"
+#~ msgstr "Seleziona il Paese del tuo cellulare"
+
+#~ msgid "Select your primary algorithmic feeds"
+#~ msgstr "Seleziona i tuoi feed algoritmici principali"
+
+#~ msgid "Select your secondary algorithmic feeds"
+#~ msgstr "Seleziona i tuoi feed algoritmici secondari"
+
+#~ msgid "Send Email"
+#~ msgstr "Envia Email"
+
+#~ msgid "Send Report"
+#~ msgstr "Invia segnalazione"
+
+#~ msgid "Set {value} for {labelGroup} content moderation policy"
+#~ msgstr "Imposta {value} per la politica di moderazione dei contenuti di {labelGroup}"
+
+#~ msgctxt "action"
+#~ msgid "Set Age"
+#~ msgstr "Imposta l'età"
+
+#~ msgid "Set color theme to dark"
+#~ msgstr "Imposta il colore del tema scuro"
+
+#~ msgid "Set color theme to light"
+#~ msgstr "Imposta il colore del tema su chiaro"
+
+#~ msgid "Set color theme to system setting"
+#~ msgstr "Imposta il colore del tema basato sulle impostazioni del tuo sistema"
+
+#~ msgid "Set dark theme to the dark theme"
+#~ msgstr "Imposta il tema scuro sul tema scuro"
+
+#~ msgid "Set dark theme to the dim theme"
+#~ msgstr "Imposta il tema scuro sul tema scuro"
+
+#~ msgid "Set password"
+#~ msgstr "Imposta la password"
+
+#~ msgid "Set this setting to \"No\" to hide all quote posts from your feed. Reposts will still be visible."
+#~ msgstr "Seleziona \"No\" per nascondere tutti i post con le citazioni dal tuo feed. I repost saranno ancora visibili."
+
+#~ msgid "Set this setting to \"No\" to hide all replies from your feed."
+#~ msgstr "Seleziona \"No\" per nascondere tutte le risposte dal tuo feed."
+
+#~ msgid "Set this setting to \"No\" to hide all reposts from your feed."
+#~ msgstr "Seleziona \"No\" per nascondere tutte le ripubblicazioni dal tuo feed."
+
+#~ msgid "Set this setting to \"Yes\" to show replies in a threaded view. This is an experimental feature."
+#~ msgstr "Seleziona \"Sì\" per mostrare le risposte in una visualizzazione concatenata. Questa è una funzionalità sperimentale."
+
+#~ msgid "Set this setting to \"Yes\" to show samples of your saved feeds in your following feed. This is an experimental feature."
+#~ msgstr "Seleziona \"Sì\" per mostrare esempi dei feed salvati nel feed successivo. Questa è una funzionalità sperimentale."
+
+#~ msgid "Set this setting to \"Yes\" to show samples of your saved feeds in your Following feed. This is an experimental feature."
+#~ msgstr "Imposta questa impostazione su \"Sì\" per mostrare esempi dei tuoi feed salvati nel feed Seguiti. Questa è una funzionalità sperimentale."
+
+#~ msgid "Sets Bluesky username"
+#~ msgstr "Imposta il tuo nome utente di Bluesky"
+
+#~ msgid "Sets color theme to dark"
+#~ msgstr "Imposta il tema scuro"
+
+#~ msgid "Sets color theme to light"
+#~ msgstr "Imposta il tema chiaro"
+
+#~ msgid "Sets color theme to system setting"
+#~ msgstr "Imposta il tema basato impostazioni di sistema"
+
+#~ msgid "Sets dark theme to the dark theme"
+#~ msgstr "Imposta il tema scuro"
+
+#~ msgid "Sets dark theme to the dim theme"
+#~ msgstr "Imposta il tema soffuso"
+
+#~ msgid "Sets hosting provider for password reset"
+#~ msgstr "Imposta il provider del hosting per la reimpostazione della password"
+
+#~ msgid "Sets image aspect ratio to square"
+#~ msgstr "Imposta le proporzioni quadrate sull'immagine"
+
+#~ msgid "Sets image aspect ratio to tall"
+#~ msgstr "Imposta l'altura sulle proporzioni dell'immagine"
+
+#~ msgid "Sets image aspect ratio to wide"
+#~ msgstr "Imposta l'amplio sulle proporzioni dell'immagine"
+
+#~ msgid "Sets server for the Bluesky client"
+#~ msgstr "Imposta il server per il client Bluesky"
+
+#~ msgid "Show all replies"
+#~ msgstr "Mostra tutte le repliche"
+
+#~ msgid "Show embeds from {0}"
+#~ msgstr "Mostra incorporamenti di {0}"
+
+#~ msgid "Show follows similar to {0}"
+#~ msgstr "Mostra follows simile a {0}"
+
+#~ msgid "Show Posts from My Feeds"
+#~ msgstr "Mostra post dai miei feed"
+
+#~ msgid "Show Quote Posts"
+#~ msgstr "Mostra post con citazioni"
+
+#~ msgid "Show quote-posts in Following feed"
+#~ msgstr "Mostra i post con citazioni nel feed Seguiti"
+
+#~ msgid "Show quotes in Following"
+#~ msgstr "Mostra le citazioni in Seguiti"
+
+#~ msgid "Show re-posts in Following feed"
+#~ msgstr "Mostra re-post nel feed Seguiti"
+
+#~ msgid "Show Replies"
+#~ msgstr "Mostra risposte"
+
+#~ msgid "Show replies by people you follow before all other replies."
+#~ msgstr "Mostra le risposte delle persone che segui prima delle altre risposte."
+
+#~ msgid "Show replies in Following"
+#~ msgstr "Mostra le risposte in Seguiti"
+
+#~ msgid "Show replies in Following feed"
+#~ msgstr "Mostra le risposte nel feed Seguiti"
+
+#~ msgid "Show replies with at least {value} {0}"
+#~ msgstr "Mostra risposte con almeno {value} {0}"
+
+#~ msgid "Show Reposts"
+#~ msgstr "Mostra ripubblicazioni"
+
+#~ msgid "Show reposts in Following"
+#~ msgstr "Mostra i re-repost in Seguiti"
+
+#~ msgid "Show users"
+#~ msgstr "Mostra utenti"
+
+#~ msgid "Shows a list of users similar to this user."
+#~ msgstr "Mostra un elenco di utenti simili a questo utente."
+
+#~ msgid "Shows posts from {0} in your feed"
+#~ msgstr "Mostra i post di {0} nel tuo feed"
+
+#~ msgid "Sign In"
+#~ msgstr "Accedi"
+
+#~ msgid "Sign into"
+#~ msgstr "Accedi a"
+
+#~ msgid "Sign out of all accounts"
+#~ msgstr "Scollega tutti gli account"
+
+#~ msgid "Sign up or sign in to join the conversation"
+#~ msgstr "Iscriviti o accedi per partecipare alla conversazione"
+
+#~ msgid "Signed in as"
+#~ msgstr "Iscritto/a come"
+
+#~ msgid "signed up with your starter pack"
+#~ msgstr "iscritto/a col tuo starter pack"
+
+#~ msgid "Signs {0} out of Bluesky"
+#~ msgstr "Esci da Bluesky con {0}"
+
+#~ msgid "SMS verification"
+#~ msgstr "Verifica tramite SMS"
+
+#~ msgid "Some subtitle"
+#~ msgstr "Altri sottotitoli"
+
+#~ msgid "Something went wrong and we're not sure what."
+#~ msgstr "Qualcosa è andato storto ma non siamo sicuri di cosa."
+
+#~ msgid "Something went wrong. Check your email and try again."
+#~ msgstr "Qualcosa è andato storto. Controlla la tua email e riprova."
+
+#~ msgid "Sort Replies"
+#~ msgstr "Ordina le risposte"
+
+#~ msgid "Source: <0>{0}</0>"
+#~ msgstr "Fonte: <0>{0}</0>"
+
+#~ msgid "Source: <0>{sourceName}</0>"
+#~ msgstr "Fonte: <0>{sourceName}</0>"
+
+#~ msgid "Square"
+#~ msgstr "Quadrato"
+
+#~ msgid "Staging"
+#~ msgstr "Allestimento"
+
+#~ msgid "Start chatting"
+#~ msgstr "Iniza a conversare"
+
+#~ msgid "Status page"
+#~ msgstr "Pagina di stato"
+
+#~ msgid "Step"
+#~ msgstr "Passo"
+
+#~ msgid "Step {0} of {numSteps}"
+#~ msgstr "Passo {0} di {numSteps}"
+
+#~ msgid "Subscribe to the {0} feed"
+#~ msgstr "Iscriviti a {0} feed"
+
+#~ msgid "Suggested Follows"
+#~ msgstr "Accounts da seguire"
+
+#~ msgid "Swipe up to see more"
+#~ msgstr "Scorri verso l'alto per vedere di più"
+
+#~ msgid "Switch between feeds to control your experience."
+#~ msgstr "Cambia tra i feed per avere il totale controllo della tua esperienza."
+
+#~ msgid "Switch to {0}"
+#~ msgstr "Cambia a {0}"
+
+#~ msgid "Switches the account you are logged in to"
+#~ msgstr "Cambia l'account dal quale hai effettuato l'accesso"
+
+#~ msgid "tag"
+#~ msgstr "tag"
+
+#~ msgid "Tall"
+#~ msgstr "Alto"
+
+#~ msgid "Tap to view fully"
+#~ msgstr "Tocca per visualizzare completamente"
+
+#~ msgid "text"
+#~ msgstr "testo"
+
+#~ msgid "the author"
+#~ msgstr "l'autore"
+
+#~ msgid "The support form has been moved. If you need help, please<0/> or visit {HELP_DESK_URL} to get in touch with us."
+#~ msgstr "Il modulo di supporto è stato spostato. Se hai bisogno di aiuto, <0/> o visita {HELP_DESK_URL} per metterti in contatto con noi."
+
+#~ msgid "There are many feeds to try:"
+#~ msgstr "Ci sono molti feed da provare:"
+
+#~ msgid "There was an an issue contacting the server, please check your internet connection and try again."
+#~ msgstr "Si è verificato un problema nel contattare il server, controlla la tua connessione Internet e riprova."
+
+#~ msgid "There was an an issue removing this feed. Please check your internet connection and try again."
+#~ msgstr "Si è verificato un problema durante la rimozione di questo feed. Per favore controlla la tua connessione Internet e prova di nuovo."
+
+#~ msgid "There was an an issue updating your feeds, please check your internet connection and try again."
+#~ msgstr "Si è verificato un problema durante la rimozione di questo feed. Per favore controlla la tua connessione Internet e prova di nuovo."
+
+#~ msgid "There was an issue connecting to the chat."
+#~ msgstr "Si è verificato un errore nel connettersi alla chat."
+
+#~ msgid "There was an issue syncing your preferences with the server"
+#~ msgstr "Si è verificato un problema durante la sincronizzazione delle tue preferenze con il server"
+
+#~ msgid "There was an issue with fetching your app passwords"
+#~ msgstr "Si è verificato un problema durante il recupero delle password dell'app"
+
+#~ msgid "There's something wrong with this number. Please choose your country and enter your full phone number!"
+#~ msgstr "C'è qualcosa di sbagliato in questo numero. Scegli il tuo Paese e inserisci il tuo numero di telefono completo!"
+
+#~ msgid "These are popular accounts you might like:"
+#~ msgstr "Questi sono gli account popolari che potrebbero piacerti:"
+
+#~ msgid "This {0} has been labeled."
+#~ msgstr "Questo {0} è stato etichettato."
+
+#~ msgid "This appeal will be sent to <0>{0}</0>."
+#~ msgstr "Questo ricorso verrà inviato a <0>{0}</0>."
+
+#~ msgid "This feature is in beta. You can read more about repository exports in <0>this blogpost.</0>"
+#~ msgstr "Questa funzionalità è in versione beta. Puoi leggere ulteriori informazioni sulle esportazioni dell' archivio in <0>questo post del blog.</0>"
+
+#~ msgid "This feed is empty!"
+#~ msgstr "Questo feed è vuoto!"
+
+#~ msgid "This is the service that keeps you online."
+#~ msgstr "Questo è il servizio che ti mantiene online."
+
+#~ msgid "This label was applied by {0}."
+#~ msgstr "Questa etichetta è stata applicata da {0}."
+
+#~ msgid "This name is already in use"
+#~ msgstr "Questo nome è già in uso"
+
+#~ msgid "This post will be hidden from feeds."
+#~ msgstr "Questo post verrà nascosto dai feed."
+
+#~ msgid "This user is included in the <0/> list which you have blocked."
+#~ msgstr "Questo utente è incluso nell'elenco <0/> che hai bloccato."
+
+#~ msgid "This user is included in the <0/> list which you have muted."
+#~ msgstr "Questo utente è incluso nell'elenco <0/> che hai disattivato."
+
+#~ msgid "This user is included the <0/> list which you have muted."
+#~ msgstr "Questo utente è incluso nella lista <0/> che hai silenziato."
+
+#~ msgid "This warning is only available for posts with media attached."
+#~ msgstr "Questo avviso è disponibile solo per i post con contenuti multimediali allegati."
+
+#~ msgid "This will delete {0} from your muted words. You can always add it back later."
+#~ msgstr "Questo eliminerà {0} dalle parole disattivate. Puoi sempre aggiungerla nuovamente in seguito."
+
+#~ msgid "This will hide this post from your feeds."
+#~ msgstr "Questo nasconderà il post dai tuoi feed."
+
+#~ msgid "Thread settings updated"
+#~ msgstr "Impostazioni thread aggiornate"
+
+#~ msgid "Threaded Mode"
+#~ msgstr "Modalità discussione"
+
+#~ msgid "Toggle between muted word options."
+#~ msgstr "Alterna tra le opzioni delle parole silenziate."
+
+#~ msgid "Transformations"
+#~ msgstr "Trasformazioni"
+
+#~ msgid "Try again"
+#~ msgstr "Provalo di nuovo"
+
+#~ msgid "Two-factor authentication"
+#~ msgstr "Autenticazione a due fattori"
+
+#~ msgid "Unfollow"
+#~ msgstr "Smetti di seguire"
+
+#~ msgid "Unfortunately, you do not meet the requirements to create an account."
+#~ msgstr "Sfortunatamente, non soddisfi i requisiti per creare un account."
+
+#~ msgid "Unlike"
+#~ msgstr "Togli Mi piace"
+
+#~ msgid "Unmuted"
+#~ msgstr "Audio riattivato"
+
+#~ msgid "Unsave"
+#~ msgstr "Rimuovi"
+
+#~ msgid "Update {displayName} in Lists"
+#~ msgstr "Aggiorna {displayName} negli elenchi"
+
+#~ msgid "Update Available"
+#~ msgstr "Aggiornamento disponibile"
+
+#~ msgid "Update to {handle}"
+#~ msgstr "Aggiorna a {handle}"
+
+#~ msgid "Use a file on your server"
+#~ msgstr "Utilizza un file sul tuo server"
+
+#~ msgid "Use app passwords to login to other Bluesky clients without giving full access to your account or password."
+#~ msgstr "Utilizza le password dell'app per accedere ad altri client Bluesky senza fornire l'accesso completo al tuo account o alla tua password."
+
+#~ msgid "Use bsky.social as hosting provider"
+#~ msgstr "Utilizza bsky.social come provider di hosting"
+
+#~ msgid "Use the DNS panel"
+#~ msgstr "Utilizza il pannello DNS"
+
+#~ msgid "Use your domain as your Bluesky client service provider"
+#~ msgstr "Utilizza il tuo dominio come provider di servizi clienti Bluesky"
+
+#~ msgid "User handle"
+#~ msgstr "Handle dell'utente"
+
+#~ msgid "users followed by <0/>"
+#~ msgstr "utenti seguiti da <0/>"
+
+#~ msgid "Verification code"
+#~ msgstr "Codice di verifica"
+
+#~ msgid "Verify {0}"
+#~ msgstr "Verifica {0}"
+
+#~ msgid "Verify email"
+#~ msgstr "Verifica Email"
+
+#~ msgid "Verify my email"
+#~ msgstr "Verifica la mia email"
+
+#~ msgid "Verify My Email"
+#~ msgstr "Verifica la Mia Email"
+
+#~ msgid "Version {0}"
+#~ msgstr "Versione {0}"
+
+#~ msgid "Version {appVersion} {bundleInfo}"
+#~ msgstr "Versione {appVersion} {bundleInfo}"
+
+#~ msgid "Videos cannot be larger than 50MB"
+#~ msgstr "I video non possono essere più grandi di 50MB"
+
+#~ msgid "We also think you'll like \"For You\" by Skygaze:"
+#~ msgstr "Pensiamo che ti piacerà anche \"Per Te\" di Skygaze:"
+
+#~ msgid "We recommend avoiding common words that appear in many posts, since it can result in no posts being shown."
+#~ msgstr "Ti consigliamo di evitare usare parole comuni che compaiono in molti post, perchè ciò potrebbe comportare la mancata visualizzazione dei post."
+
+#~ msgid "We recommend our \"Discover\" feed:"
+#~ msgstr "Consigliamo il nostro feed \"Scopri\":"
+
+#~ msgid "We'll look into your appeal promptly."
+#~ msgstr "Esamineremo il tuo ricorso al più presto."
+
+#~ msgid "We're introducing a new theme font, along with adjustable font sizing."
+#~ msgstr "Abbiamo introdotto un nuovo tema font, assieme alla possibilità di aggiustare le dimensioni del font."
+
+#~ msgid "We're sorry! You can only subscribe to ten labelers, and you've reached your limit of ten."
+#~ msgstr "Ci dispiace! Puoi iscriverti solo a dieci etichettatori e hai raggiunto il limite di dieci."
+
+#~ msgid "Welcome to <0>Bluesky</0>"
+#~ msgstr "Ti diamo il benvenuto a <0>Bluesky</0>"
+
+#~ msgid "What is the issue with this {collectionName}?"
+#~ msgstr "Qual è il problema con questo {collectionName}?"
+
+#~ msgid "What's next?"
+#~ msgstr "Qual è il prossimo?"
+
+#~ msgid "Who can message you?"
+#~ msgstr "Chi puoi inviarti messaggi?"
+
+#~ msgid "Who can reply?"
+#~ msgstr "Chi può rispondere?"
+
+#~ msgid "Wide"
+#~ msgstr "Largo"
+
+#~ msgid "XXXXXX"
+#~ msgstr "XXXXXX"
+
+#~ msgid "Yesterday, {time}"
+#~ msgstr "Ieri, {time}"
+
+#~ msgid "You can adjust these in your Appearance Settings later."
+#~ msgstr "Puoi modificarli successivamente nelle Impostazioni Aspetto."
+
+#~ msgid "You can change hosting providers at any time."
+#~ msgstr "Puoi cambiare provider di hosting in qualsiasi momento."
+
+#~ msgid "You can change these settings later."
+#~ msgstr "Potrai modificare queste impostazioni in seguito."
+
+#~ msgid "You can change this at any time."
+#~ msgstr "Puoi modificarlo in qualsiasi momento."
+
+#~ msgid "You don't have any saved feeds!"
+#~ msgstr "Non hai salvato nessun feed!"
+
+#~ msgid "You have muted this user."
+#~ msgstr "Hai disattivato questo utente."
+
+#~ msgid "You have not blocked any accounts yet. To block an account, go to their profile and selected \"Block account\" from the menu on their account."
+#~ msgstr "Non hai ancora bloccato nessun conto. Per bloccare un conto, vai al profilo e seleziona \"Blocca conto\" dal menu del suo conto."
+
+#~ msgid "You have not created any app passwords yet. You can create one by pressing the button below."
+#~ msgstr "Non hai ancora creato alcuna password per l'app. Puoi crearne uno premendo il pulsante qui sotto."
+
+#~ msgid "You have not muted any accounts yet. To mute an account, go to their profile and selected \"Mute account\" from the menu on their account."
+#~ msgstr "Non hai ancora disattivato alcun account. Per disattivare un account, vai al suo profilo e seleziona \"Disattiva account\" dal menu del account."
+
+#~ msgid "You may only add up to 50 feeds"
+#~ msgstr "Puoi aggiungere un massimo di 50 feed"
+
+#~ msgid "You may only add up to 50 profiles"
+#~ msgstr "Puoi aggiungere un massimo di 50 utenti"
+
+#~ msgid "You must be 18 or older to enable adult content."
+#~ msgstr "Devi avere almeno 18 anni per abilitare i contenuti per adulti."
+
+#~ msgid "You must be 18 years or older to enable adult content"
+#~ msgstr "Devi avere almeno 18 anni per abilitare i contenuti per adulti"
+
+#~ msgid "You're in control"
+#~ msgstr "Sei in controllo"
+
+#~ msgid "Your default feed is \"Following\""
+#~ msgstr "Il tuo feed predefinito è \"Following\""
+
+#~ msgid "Your email has been saved! We'll be in touch soon."
+#~ msgstr "La tua email è stata salvata! Ci metteremo in contatto al più presto."
+
+#~ msgid "Your hosting provider"
+#~ msgstr "Il tuo fornitore di hosting"
+
+#~ msgid "Your invite codes are hidden when logged in using an App Password"
+#~ msgstr "I tuoi codici di invito vengono celati quando accedi utilizzando una password per l'app"
+
+#~ msgid "Your profile"
+#~ msgstr "Il tuo profilo"

--- a/src/locale/locales/it/messages.po
+++ b/src/locale/locales/it/messages.po
@@ -1,18 +1,22 @@
+# 
+# Translators:
+# Alessio Restifo, 2024
+# Michele Locati <michele@locati.it>, 2024
+# 
 msgid ""
 msgstr ""
 "Project-Id-Version: Italian localization\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-11-20 10:25+0000\n"
-"PO-Revision-Date: 2024-11-21 20:48+0100\n"
-"Last-Translator: Michele Locati <michele@locati.it>\n"
-"Language-Team: \n"
+"POT-Creation-Date: 2024-11-23 01:06+0000\n"
+"PO-Revision-Date: 2024-11-23 08:06+0000\n"
+"Last-Translator: Michele Locati <michele@locati.it>, 2024\n"
+"Language-Team: Italian (https://app.transifex.com/mlocati/teams/201833/it/)\n"
 "Language: it\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"X-Generator: Poedit 3.5\n"
-"X-Poedit-SourceCharset: UTF-8\n"
+"X-Generator: @lingui/cli\n"
 
 #: src/screens/Messages/components/ChatListItem.tsx:130
 msgid "(contains embedded content)"
@@ -73,7 +77,8 @@ msgstr "{0, plural, one {Like (# like)} other {Like (# like)}}"
 msgid "{0, plural, one {like} other {likes}}"
 msgstr "{0, plural, one {like} other {like}}"
 
-#: src/components/FeedCard.tsx:213 src/view/com/feeds/FeedSourceCard.tsx:303
+#: src/components/FeedCard.tsx:213
+#: src/view/com/feeds/FeedSourceCard.tsx:303
 msgid "{0, plural, one {Liked by # user} other {Liked by # users}}"
 msgstr "{0, plural, one {Piace a # utente} other {Piace a # utenti}}"
 
@@ -115,7 +120,7 @@ msgstr "{0} <0>in <1>testo e tag</1></0>"
 msgid "{0} joined this week"
 msgstr "{0} aggiunti questa settimana"
 
-#: src/view/com/util/post-embeds/VideoEmbedInner/web-controls/Scrubber.tsx:195
+#: src/view/com/util/post-embeds/VideoEmbedInner/web-controls/Scrubber.tsx:197
 msgid "{0} of {1}"
 msgstr "{0} di {1}"
 
@@ -370,12 +375,15 @@ msgstr "30 giorni"
 msgid "7 days"
 msgstr "7 giorni"
 
-#: src/Navigation.tsx:361 src/screens/Settings/AboutSettings.tsx:24
-#: src/screens/Settings/Settings.tsx:207 src/screens/Settings/Settings.tsx:210
+#: src/Navigation.tsx:361
+#: src/screens/Settings/AboutSettings.tsx:24
+#: src/screens/Settings/Settings.tsx:207
+#: src/screens/Settings/Settings.tsx:210
 msgid "About"
 msgstr "Informazioni su"
 
-#: src/view/com/util/ViewHeader.tsx:89 src/view/screens/Search/Search.tsx:883
+#: src/view/com/util/ViewHeader.tsx:89
+#: src/view/screens/Search/Search.tsx:883
 msgid "Access navigation links and settings"
 msgstr "Accedi alle impostazioni di navigazione"
 
@@ -384,7 +392,8 @@ msgid "Access profile and other navigation links"
 msgstr "Accedi al profilo e ad altre impostazioni di navigazione"
 
 #: src/screens/Settings/AccessibilitySettings.tsx:42
-#: src/screens/Settings/Settings.tsx:183 src/screens/Settings/Settings.tsx:186
+#: src/screens/Settings/Settings.tsx:183
+#: src/screens/Settings/Settings.tsx:186
 msgid "Accessibility"
 msgstr "Accessibilità"
 
@@ -392,13 +401,16 @@ msgstr "Accessibilità"
 msgid "Accessibility Settings"
 msgstr "Impostazioni di Accessibilità"
 
-#: src/Navigation.tsx:337 src/screens/Login/LoginForm.tsx:176
+#: src/Navigation.tsx:337
+#: src/screens/Login/LoginForm.tsx:176
 #: src/screens/Settings/AccountSettings.tsx:41
-#: src/screens/Settings/Settings.tsx:145 src/screens/Settings/Settings.tsx:148
+#: src/screens/Settings/Settings.tsx:145
+#: src/screens/Settings/Settings.tsx:148
 msgid "Account"
 msgstr "Account"
 
 #: src/view/com/profile/ProfileMenu.tsx:132
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:360
 msgid "Account blocked"
 msgstr "Account bloccato"
 
@@ -464,7 +476,8 @@ msgstr "Aggiungi un avviso sul contenuto"
 msgid "Add a user to this list"
 msgstr "Aggiungi un utente a questo elenco"
 
-#: src/components/dialogs/SwitchAccount.tsx:55 src/screens/Deactivated.tsx:198
+#: src/components/dialogs/SwitchAccount.tsx:55
+#: src/screens/Deactivated.tsx:198
 msgid "Add account"
 msgstr "Aggiungi account"
 
@@ -482,11 +495,12 @@ msgstr "Aggiungi testo alternativo"
 msgid "Add alt text (optional)"
 msgstr "Aggiungi testo alternativo (opzionale)"
 
-#: src/screens/Settings/Settings.tsx:364 src/screens/Settings/Settings.tsx:367
+#: src/screens/Settings/Settings.tsx:364
+#: src/screens/Settings/Settings.tsx:367
 msgid "Add another account"
 msgstr "Aggiungi un altro account"
 
-#: src/view/com/composer/Composer.tsx:715
+#: src/view/com/composer/Composer.tsx:721
 msgid "Add another post"
 msgstr "Aggiungi un altro post"
 
@@ -508,7 +522,7 @@ msgstr "Aggiungi parola silenziata alle impostazioni configurate"
 msgid "Add muted words and tags"
 msgstr "Aggiungi parole e tag silenziati"
 
-#: src/view/com/composer/Composer.tsx:1230
+#: src/view/com/composer/Composer.tsx:1235
 msgid "Add new post"
 msgstr "Aggiungi nuovo post"
 
@@ -595,7 +609,8 @@ msgstr "Tutti i feed che hai salvato, in un unico posto."
 msgid "Allow access to your direct messages"
 msgstr "Consenti l'accesso ai tuoi messaggi"
 
-#: src/screens/Messages/Settings.tsx:64 src/screens/Messages/Settings.tsx:67
+#: src/screens/Messages/Settings.tsx:64
+#: src/screens/Messages/Settings.tsx:67
 msgid "Allow new messages from"
 msgstr "Consenti nuovi messaggi da"
 
@@ -661,11 +676,11 @@ msgstr "Un email è stata inviata! Inserisci qui sotto il codice di conferma pre
 msgid "An error has occurred"
 msgstr "Si è verificato un errore"
 
-#: src/view/com/util/post-embeds/VideoEmbedInner/web-controls/VideoControls.tsx:419
+#: src/view/com/util/post-embeds/VideoEmbedInner/web-controls/VideoControls.tsx:420
 msgid "An error occurred"
 msgstr "Si è verificato un errore"
 
-#: src/view/com/composer/state/video.ts:411
+#: src/view/com/composer/state/video.ts:398
 msgid "An error occurred while compressing the video."
 msgstr "Si è verificato un errore durante la compressione del video."
 
@@ -686,7 +701,7 @@ msgstr "Si è verificato un errore durante il caricamento del video. Riprova."
 msgid "An error occurred while saving the QR code!"
 msgstr "Si è verificato un errore nel salvare il codice QR!"
 
-#: src/view/com/composer/videos/SelectVideoBtn.tsx:87
+#: src/view/com/composer/videos/SelectVideoBtn.tsx:81
 msgid "An error occurred while selecting the video"
 msgstr "Si è verificato un errore durante la selezione del video"
 
@@ -695,7 +710,7 @@ msgstr "Si è verificato un errore durante la selezione del video"
 msgid "An error occurred while trying to follow all"
 msgstr "Si è verificato un errore nel seguire tutti"
 
-#: src/view/com/composer/state/video.ts:448
+#: src/view/com/composer/state/video.ts:435
 msgid "An error occurred while uploading the video."
 msgstr "Si è verificato un errore nel caricare il video."
 
@@ -713,7 +728,8 @@ msgstr "Si è verificato un problema nell'aprire la chat"
 
 #: src/components/hooks/useFollowMethods.ts:35
 #: src/components/hooks/useFollowMethods.ts:50
-#: src/components/ProfileCard.tsx:326 src/components/ProfileCard.tsx:346
+#: src/components/ProfileCard.tsx:326
+#: src/components/ProfileCard.tsx:346
 #: src/view/com/profile/FollowButton.tsx:35
 #: src/view/com/profile/FollowButton.tsx:45
 msgid "An issue occurred, please try again."
@@ -732,7 +748,8 @@ msgstr "un etichettatore sconosciuto"
 msgid "and"
 msgstr "e"
 
-#: src/screens/Onboarding/index.tsx:29 src/screens/Onboarding/state.ts:81
+#: src/screens/Onboarding/index.tsx:29
+#: src/screens/Onboarding/state.ts:81
 msgid "Animals"
 msgstr "Animali"
 
@@ -782,7 +799,8 @@ msgstr "I nomi delle password devono essere lunghi almeno 4 caratteri"
 msgid "App passwords"
 msgstr "Password delle app"
 
-#: src/Navigation.tsx:289 src/screens/Settings/AppPasswords.tsx:47
+#: src/Navigation.tsx:289
+#: src/screens/Settings/AppPasswords.tsx:47
 msgid "App Passwords"
 msgstr "Password delle app"
 
@@ -807,8 +825,10 @@ msgstr "Appello inviato"
 msgid "Appeal this decision"
 msgstr "Fai ricorso contro questa decisione"
 
-#: src/Navigation.tsx:329 src/screens/Settings/AppearanceSettings.tsx:76
-#: src/screens/Settings/Settings.tsx:175 src/screens/Settings/Settings.tsx:178
+#: src/Navigation.tsx:329
+#: src/screens/Settings/AppearanceSettings.tsx:76
+#: src/screens/Settings/Settings.tsx:175
+#: src/screens/Settings/Settings.tsx:178
 msgid "Appearance"
 msgstr "Aspetto"
 
@@ -854,11 +874,11 @@ msgstr "Confermi di voler rimuovere {0} dai tuoi feed?"
 msgid "Are you sure you want to remove this from your feeds?"
 msgstr "Sicuro di rimuoverlo dai tuoi feed?"
 
-#: src/view/com/composer/Composer.tsx:666
+#: src/view/com/composer/Composer.tsx:672
 msgid "Are you sure you'd like to discard this draft?"
 msgstr "Confermi di voler eliminare questa bozza?"
 
-#: src/view/com/composer/Composer.tsx:830
+#: src/view/com/composer/Composer.tsx:846
 msgid "Are you sure you'd like to discard this post?"
 msgstr "Scartare questo post?"
 
@@ -870,7 +890,8 @@ msgstr "Confermi?"
 msgid "Are you writing in <0>{0}</0>?"
 msgstr "Stai scrivendo in <0>{0}</0>?"
 
-#: src/screens/Onboarding/index.tsx:23 src/screens/Onboarding/state.ts:82
+#: src/screens/Onboarding/index.tsx:23
+#: src/screens/Onboarding/state.ts:82
 msgid "Art"
 msgstr "Arte"
 
@@ -886,8 +907,8 @@ msgstr "Almeno 3 caratteri"
 msgid "Autoplay options have moved to the <0>Content and Media settings</0>."
 msgstr "Le opzioni di riproduzione automatica sono state spostate nelle <0>impostazioni di contenuti e media</0>."
 
+#: src/screens/Settings/ContentAndMediaSettings.tsx:82
 #: src/screens/Settings/ContentAndMediaSettings.tsx:88
-#: src/screens/Settings/ContentAndMediaSettings.tsx:94
 msgid "Autoplay videos and GIFs"
 msgstr "Riproduci automaticamente video e GIF"
 
@@ -898,7 +919,8 @@ msgstr "Riproduci automaticamente video e GIF"
 #: src/screens/Login/ChooseAccountForm.tsx:95
 #: src/screens/Login/ForgotPasswordForm.tsx:123
 #: src/screens/Login/ForgotPasswordForm.tsx:129
-#: src/screens/Login/LoginForm.tsx:282 src/screens/Login/LoginForm.tsx:288
+#: src/screens/Login/LoginForm.tsx:282
+#: src/screens/Login/LoginForm.tsx:288
 #: src/screens/Login/SetNewPasswordForm.tsx:154
 #: src/screens/Login/SetNewPasswordForm.tsx:160
 #: src/screens/Messages/components/ChatDisabled.tsx:133
@@ -910,11 +932,12 @@ msgstr "Riproduci automaticamente video e GIF"
 msgid "Back"
 msgstr "Indietro"
 
-#: src/view/screens/Lists.tsx:104 src/view/screens/ModerationModlists.tsx:100
+#: src/view/screens/Lists.tsx:104
+#: src/view/screens/ModerationModlists.tsx:100
 msgid "Before creating a list, you must first verify your email."
 msgstr "Prima di creare una lista devi verificare il tuo indirizzo email."
 
-#: src/view/com/composer/Composer.tsx:593
+#: src/view/com/composer/Composer.tsx:599
 msgid "Before creating a post, you must first verify your email."
 msgstr "Prima di creare un post, devi verificare la tua email."
 
@@ -935,10 +958,14 @@ msgstr "Compleanno"
 
 #: src/screens/Profile/Header/ProfileHeaderStandard.tsx:283
 #: src/view/com/profile/ProfileMenu.tsx:341
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:744
 msgid "Block"
 msgstr "Blocca"
 
-#: src/components/dms/ConvoMenu.tsx:188 src/components/dms/ConvoMenu.tsx:192
+#: src/components/dms/ConvoMenu.tsx:188
+#: src/components/dms/ConvoMenu.tsx:192
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:603
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:605
 msgid "Block account"
 msgstr "Blocca account"
 
@@ -948,6 +975,7 @@ msgid "Block Account"
 msgstr "Blocca Account"
 
 #: src/view/com/profile/ProfileMenu.tsx:324
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:739
 msgid "Block Account?"
 msgstr "Bloccare Account?"
 
@@ -971,11 +999,13 @@ msgstr "Bloccato"
 msgid "Blocked accounts"
 msgstr "Accounts bloccati"
 
-#: src/Navigation.tsx:153 src/view/screens/ModerationBlockedAccounts.tsx:108
+#: src/Navigation.tsx:153
+#: src/view/screens/ModerationBlockedAccounts.tsx:108
 msgid "Blocked Accounts"
 msgstr "Accounts bloccati"
 
 #: src/view/com/profile/ProfileMenu.tsx:336
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:741
 msgid "Blocked accounts cannot reply in your threads, mention you, or otherwise interact with you."
 msgstr "Gli account bloccati non possono rispondere alle tue discussioni, menzionarti o interagire in nessun altro modo con te."
 
@@ -1036,7 +1066,8 @@ msgstr "Sfoca le immagini"
 msgid "Blur images and filter from feeds"
 msgstr "Sfoca le immagini e filtra dai feed"
 
-#: src/screens/Onboarding/index.tsx:30 src/screens/Onboarding/state.ts:83
+#: src/screens/Onboarding/index.tsx:30
+#: src/screens/Onboarding/state.ts:83
 msgid "Books"
 msgstr "Libri"
 
@@ -1101,15 +1132,17 @@ msgstr "da te"
 msgid "Camera"
 msgstr "Fotocamera"
 
-#: src/components/Menu/index.tsx:236 src/components/Prompt.tsx:129
-#: src/components/Prompt.tsx:131 src/components/TagMenu/index.tsx:283
+#: src/components/Menu/index.tsx:236
+#: src/components/Prompt.tsx:129
+#: src/components/Prompt.tsx:131
+#: src/components/TagMenu/index.tsx:283
 #: src/screens/Deactivated.tsx:164
 #: src/screens/Profile/Header/EditProfileDialog.tsx:220
 #: src/screens/Profile/Header/EditProfileDialog.tsx:228
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:72
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:79
 #: src/screens/Settings/Settings.tsx:252
-#: src/view/com/composer/Composer.tsx:893
+#: src/view/com/composer/Composer.tsx:909
 #: src/view/com/modals/ChangeEmail.tsx:213
 #: src/view/com/modals/ChangeEmail.tsx:215
 #: src/view/com/modals/ChangePassword.tsx:268
@@ -1123,7 +1156,7 @@ msgstr "Fotocamera"
 #: src/view/com/modals/LinkWarning.tsx:107
 #: src/view/com/modals/VerifyEmail.tsx:255
 #: src/view/com/modals/VerifyEmail.tsx:261
-#: src/view/com/util/post-ctrls/RepostButton.tsx:198
+#: src/view/com/util/post-ctrls/RepostButton.tsx:203
 #: src/view/screens/Search/Search.tsx:911
 msgid "Cancel"
 msgstr "Annulla"
@@ -1148,7 +1181,7 @@ msgstr "Annulla il ritaglio dell'immagine"
 msgid "Cancel profile editing"
 msgstr "Annulla la modifica del profilo"
 
-#: src/view/com/util/post-ctrls/RepostButton.tsx:193
+#: src/view/com/util/post-ctrls/RepostButton.tsx:197
 msgid "Cancel quote post"
 msgstr "Annnulla la citazione del post"
 
@@ -1220,8 +1253,10 @@ msgstr "Modifica la tua email"
 msgid "Change your email address"
 msgstr "Modifica il tuo indirizzo email"
 
-#: src/Navigation.tsx:373 src/view/shell/bottom-bar/BottomBar.tsx:200
-#: src/view/shell/desktop/LeftNav.tsx:348 src/view/shell/Drawer.tsx:417
+#: src/Navigation.tsx:373
+#: src/view/shell/bottom-bar/BottomBar.tsx:200
+#: src/view/shell/desktop/LeftNav.tsx:348
+#: src/view/shell/Drawer.tsx:417
 msgid "Chat"
 msgstr "Messaggi"
 
@@ -1229,8 +1264,10 @@ msgstr "Messaggi"
 msgid "Chat muted"
 msgstr "Conversazione silenziata"
 
-#: src/components/dms/ConvoMenu.tsx:112 src/components/dms/MessageMenu.tsx:81
-#: src/Navigation.tsx:378 src/screens/Messages/ChatList.tsx:88
+#: src/components/dms/ConvoMenu.tsx:112
+#: src/components/dms/MessageMenu.tsx:81
+#: src/Navigation.tsx:378
+#: src/screens/Messages/ChatList.tsx:88
 msgid "Chat settings"
 msgstr "Impostazioni messaggi"
 
@@ -1242,7 +1279,8 @@ msgstr "Impostazioni messaggi"
 msgid "Chat unmuted"
 msgstr "Conversizione non silenziata"
 
-#: src/screens/SignupQueued.tsx:79 src/screens/SignupQueued.tsx:83
+#: src/screens/SignupQueued.tsx:79
+#: src/screens/SignupQueued.tsx:83
 msgid "Check my status"
 msgstr "Verifica il mio stato"
 
@@ -1326,7 +1364,7 @@ msgstr "Clicca per disattivare le citazioni di questo post."
 msgid "Click to enable quote posts of this post."
 msgstr "Clicca per attivare le citazioni di questo post."
 
-#: src/components/dms/MessageItem.tsx:240
+#: src/components/dms/MessageItem.tsx:241
 msgid "Click to retry failed message"
 msgstr "Clicca per riprovare l'invio"
 
@@ -1341,7 +1379,8 @@ msgstr "Clop 🐴 clop 🐴"
 #: src/components/dialogs/GifSelect.tsx:281
 #: src/components/dialogs/VerifyEmailDialog.tsx:289
 #: src/components/dms/dialogs/SearchablePeopleList.tsx:263
-#: src/components/NewskieDialog.tsx:146 src/components/NewskieDialog.tsx:153
+#: src/components/NewskieDialog.tsx:146
+#: src/components/NewskieDialog.tsx:153
 #: src/components/StarterPack/Wizard/WizardEditListDialog.tsx:117
 #: src/components/StarterPack/Wizard/WizardEditListDialog.tsx:123
 #: src/view/com/modals/ChangePassword.tsx:268
@@ -1383,7 +1422,8 @@ msgstr "Chiudi il visualizzatore di immagini"
 msgid "Close navigation footer"
 msgstr "Chiudi la navigazione del footer"
 
-#: src/components/Menu/index.tsx:230 src/components/TagMenu/index.tsx:277
+#: src/components/Menu/index.tsx:230
+#: src/components/TagMenu/index.tsx:277
 msgid "Close this dialog"
 msgstr "Chiudi la finestra"
 
@@ -1411,15 +1451,18 @@ msgstr "Comprime l'elenco degli utenti per una determinata notifica"
 msgid "Color mode"
 msgstr "Modalità colore"
 
-#: src/screens/Onboarding/index.tsx:38 src/screens/Onboarding/state.ts:84
+#: src/screens/Onboarding/index.tsx:38
+#: src/screens/Onboarding/state.ts:84
 msgid "Comedy"
 msgstr "Commedia"
 
-#: src/screens/Onboarding/index.tsx:24 src/screens/Onboarding/state.ts:85
+#: src/screens/Onboarding/index.tsx:24
+#: src/screens/Onboarding/state.ts:85
 msgid "Comics"
 msgstr "Fumetti"
 
-#: src/Navigation.tsx:279 src/view/screens/CommunityGuidelines.tsx:34
+#: src/Navigation.tsx:279
+#: src/view/screens/CommunityGuidelines.tsx:34
 msgid "Community Guidelines"
 msgstr "Linee guida della community"
 
@@ -1435,7 +1478,7 @@ msgstr "Completa la challenge"
 msgid "Compose new post"
 msgstr "Scrivi un nuovo post"
 
-#: src/view/com/composer/Composer.tsx:796
+#: src/view/com/composer/Composer.tsx:812
 msgid "Compose posts up to {MAX_GRAPHEME_LENGTH} characters in length"
 msgstr "Componi un post fino a {MAX_GRAPHEME_LENGTH} caratteri"
 
@@ -1443,7 +1486,7 @@ msgstr "Componi un post fino a {MAX_GRAPHEME_LENGTH} caratteri"
 msgid "Compose reply"
 msgstr "Scrivi la risposta"
 
-#: src/view/com/composer/Composer.tsx:1623
+#: src/view/com/composer/Composer.tsx:1628
 msgid "Compressing video..."
 msgstr "Compressione del video..."
 
@@ -1458,7 +1501,8 @@ msgstr "Configurato nelle <0>impostazioni di moderazione</0>."
 #: src/components/dialogs/VerifyEmailDialog.tsx:253
 #: src/components/dialogs/VerifyEmailDialog.tsx:260
 #: src/components/dialogs/VerifyEmailDialog.tsx:283
-#: src/components/Prompt.tsx:172 src/components/Prompt.tsx:175
+#: src/components/Prompt.tsx:172
+#: src/components/Prompt.tsx:175
 #: src/screens/Settings/components/DisableEmail2FADialog.tsx:185
 #: src/screens/Settings/components/DisableEmail2FADialog.tsx:188
 #: src/view/com/modals/VerifyEmail.tsx:239
@@ -1506,16 +1550,19 @@ msgstr "Codice di conferma"
 msgid "Connecting..."
 msgstr "Connessione in corso..."
 
-#: src/screens/Signup/index.tsx:175 src/screens/Signup/index.tsx:178
+#: src/screens/Signup/index.tsx:175
+#: src/screens/Signup/index.tsx:178
 msgid "Contact support"
 msgstr "Contatta il supporto"
 
 #: src/screens/Settings/AccessibilitySettings.tsx:101
-#: src/screens/Settings/Settings.tsx:167 src/screens/Settings/Settings.tsx:170
+#: src/screens/Settings/Settings.tsx:167
+#: src/screens/Settings/Settings.tsx:170
 msgid "Content and media"
 msgstr "Contenuti e media"
 
-#: src/Navigation.tsx:353 src/screens/Settings/ContentAndMediaSettings.tsx:35
+#: src/Navigation.tsx:353
+#: src/screens/Settings/ContentAndMediaSettings.tsx:44
 msgid "Content and Media"
 msgstr "Contenuti e media"
 
@@ -1587,9 +1634,10 @@ msgstr "Copiato"
 msgid "Copied build version to clipboard"
 msgstr "Versione di build copiata nella clipboard"
 
-#: src/components/dms/MessageMenu.tsx:57 src/lib/sharing.ts:25
+#: src/components/dms/MessageMenu.tsx:57
+#: src/lib/sharing.ts:25
 #: src/view/com/modals/InviteCodes.tsx:153
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:229
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:235
 #: src/view/com/util/post-ctrls/PostCtrls.tsx:386
 msgid "Copied to clipboard"
 msgstr "Copiato nel clipboard"
@@ -1611,7 +1659,8 @@ msgstr "Copia password dell'app"
 msgid "Copy build version to clipboard"
 msgstr "Copia versione build negli appunti"
 
-#: src/components/dialogs/Embed.tsx:122 src/components/dialogs/Embed.tsx:141
+#: src/components/dialogs/Embed.tsx:122
+#: src/components/dialogs/Embed.tsx:141
 msgid "Copy code"
 msgstr "Copia il codice"
 
@@ -1635,8 +1684,8 @@ msgstr "Copia link"
 msgid "Copy link to list"
 msgstr "Copia il link alla lista"
 
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:416
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:425
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:434
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:443
 msgid "Copy link to post"
 msgstr "Copia il link al post"
 
@@ -1645,8 +1694,8 @@ msgstr "Copia il link al post"
 msgid "Copy message text"
 msgstr "Copia il testo del messaggio"
 
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:394
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:396
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:412
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:414
 msgid "Copy post text"
 msgstr "Copia il testo del post"
 
@@ -1658,7 +1707,8 @@ msgstr "Copia codice QR"
 msgid "Copy TXT record value"
 msgstr "Copia valore del record TXT"
 
-#: src/Navigation.tsx:284 src/view/screens/CopyrightPolicy.tsx:31
+#: src/Navigation.tsx:284
+#: src/view/screens/CopyrightPolicy.tsx:31
 msgid "Copyright Policy"
 msgstr "Politica sul diritto d'autore"
 
@@ -1678,7 +1728,7 @@ msgstr "No si è potuto caricare la lista"
 msgid "Could not mute chat"
 msgstr "Errore nel silenziare la conversazione"
 
-#: src/view/com/composer/videos/VideoPreview.web.tsx:56
+#: src/view/com/composer/videos/VideoPreview.web.tsx:66
 msgid "Could not process your video"
 msgstr "Impossibile processare il tuo video"
 
@@ -1709,7 +1759,8 @@ msgstr "Crea un account"
 msgid "Create Account"
 msgstr "Crea un account"
 
-#: src/components/dialogs/Signin.tsx:86 src/components/dialogs/Signin.tsx:88
+#: src/components/dialogs/Signin.tsx:86
+#: src/components/dialogs/Signin.tsx:88
 msgid "Create an account"
 msgstr "Crea un account"
 
@@ -1734,7 +1785,8 @@ msgstr "Crea un report per {0}"
 msgid "Created {0}"
 msgstr "Creato {0}"
 
-#: src/screens/Onboarding/index.tsx:26 src/screens/Onboarding/state.ts:86
+#: src/screens/Onboarding/index.tsx:26
+#: src/screens/Onboarding/state.ts:86
 msgid "Culture"
 msgstr "Cultura"
 
@@ -1743,7 +1795,8 @@ msgstr "Cultura"
 msgid "Custom"
 msgstr "Personalizzato"
 
-#: src/view/screens/Feeds.tsx:761 src/view/screens/Search/Explore.tsx:391
+#: src/view/screens/Feeds.tsx:761
+#: src/view/screens/Search/Explore.tsx:391
 msgid "Custom feeds built by the community bring you new experiences and help you find the content you love."
 msgstr "I feed personalizzati creati dalla comunità ti offrono nuove esperienze e ti aiutano a trovare contenuti interessanti."
 
@@ -1791,7 +1844,7 @@ msgstr "Predefinito"
 #: src/screens/StarterPack/StarterPackScreen.tsx:585
 #: src/screens/StarterPack/StarterPackScreen.tsx:664
 #: src/screens/StarterPack/StarterPackScreen.tsx:744
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:632
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:661
 #: src/view/screens/ProfileList.tsx:726
 msgid "Delete"
 msgstr "Elimina"
@@ -1837,9 +1890,9 @@ msgstr "Elimina messaggio per me"
 msgid "Delete my account"
 msgstr "Elimina il mio account"
 
-#: src/view/com/composer/Composer.tsx:804
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:613
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:615
+#: src/view/com/composer/Composer.tsx:820
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:642
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:644
 msgid "Delete post"
 msgstr "Elimina il post"
 
@@ -1856,7 +1909,7 @@ msgstr "Eliminare lo starter pack?"
 msgid "Delete this list?"
 msgstr "Eliminare questa lista?"
 
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:627
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:656
 msgid "Delete this post?"
 msgstr "Eliminare questo post?"
 
@@ -1894,16 +1947,17 @@ msgstr "La descrizione è troppo lunga. Il numero massimo di caratteri è {DESCR
 msgid "Descriptive alt text"
 msgstr "Testo descrittivo alternativo"
 
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:548
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:558
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:566
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:576
 msgid "Detach quote"
 msgstr "Stacca citazione"
 
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:690
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:719
 msgid "Detach quote post?"
 msgstr "Staccare la citazione del post?"
 
-#: src/screens/Settings/Settings.tsx:234 src/screens/Settings/Settings.tsx:237
+#: src/screens/Settings/Settings.tsx:234
+#: src/screens/Settings/Settings.tsx:237
 msgid "Developer options"
 msgstr "Opzioni sviluppatore"
 
@@ -1924,21 +1978,22 @@ msgstr "Disattiva l'email 2FA"
 msgid "Disable haptic feedback"
 msgstr "Disattiva il feedback tattile"
 
-#: src/view/com/util/post-embeds/VideoEmbedInner/web-controls/VideoControls.tsx:385
+#: src/view/com/util/post-embeds/VideoEmbedInner/web-controls/VideoControls.tsx:386
 msgid "Disable subtitles"
 msgstr "Disattiva sottotitoli"
 
 #: src/lib/moderation/useLabelBehaviorDescription.ts:32
 #: src/lib/moderation/useLabelBehaviorDescription.ts:42
 #: src/lib/moderation/useLabelBehaviorDescription.ts:68
-#: src/screens/Messages/Settings.tsx:133 src/screens/Messages/Settings.tsx:136
+#: src/screens/Messages/Settings.tsx:133
+#: src/screens/Messages/Settings.tsx:136
 #: src/screens/Moderation/index.tsx:350
 msgid "Disabled"
 msgstr "Disabilitato"
 
 #: src/screens/Profile/Header/EditProfileDialog.tsx:84
-#: src/view/com/composer/Composer.tsx:668
-#: src/view/com/composer/Composer.tsx:837
+#: src/view/com/composer/Composer.tsx:674
+#: src/view/com/composer/Composer.tsx:853
 msgid "Discard"
 msgstr "Scartare"
 
@@ -1946,11 +2001,11 @@ msgstr "Scartare"
 msgid "Discard changes?"
 msgstr "Scartare le modifiche?"
 
-#: src/view/com/composer/Composer.tsx:665
+#: src/view/com/composer/Composer.tsx:671
 msgid "Discard draft?"
 msgstr "Scartare la bozza?"
 
-#: src/view/com/composer/Composer.tsx:829
+#: src/view/com/composer/Composer.tsx:845
 msgid "Discard post?"
 msgstr "Scartare il post?"
 
@@ -1976,7 +2031,7 @@ msgstr "Scopri nuovi feed"
 msgid "Dismiss"
 msgstr "Ignora"
 
-#: src/view/com/composer/Composer.tsx:1547
+#: src/view/com/composer/Composer.tsx:1552
 msgid "Dismiss error"
 msgstr "Ignora errore"
 
@@ -2129,7 +2184,8 @@ msgstr "Ogni codice funziona per un solo uso. Riceverai periodicamente più codi
 #: src/screens/Settings/AccountSettings.tsx:104
 #: src/screens/StarterPack/StarterPackScreen.tsx:574
 #: src/screens/StarterPack/Wizard/index.tsx:560
-#: src/screens/StarterPack/Wizard/index.tsx:567 src/view/screens/Feeds.tsx:386
+#: src/screens/StarterPack/Wizard/index.tsx:567
+#: src/view/screens/Feeds.tsx:386
 #: src/view/screens/Feeds.tsx:454
 msgid "Edit"
 msgstr "Modifica"
@@ -2139,7 +2195,8 @@ msgctxt "action"
 msgid "Edit"
 msgstr "Modifica"
 
-#: src/view/com/util/UserAvatar.tsx:347 src/view/com/util/UserBanner.tsx:95
+#: src/view/com/util/UserAvatar.tsx:347
+#: src/view/com/util/UserBanner.tsx:95
 msgid "Edit avatar"
 msgstr "Modifica l'avatar"
 
@@ -2153,8 +2210,8 @@ msgstr "Modifica i feed"
 msgid "Edit image"
 msgstr "Modifica l'immagine"
 
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:594
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:607
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:623
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:636
 msgid "Edit interaction settings"
 msgstr "Modifica le impostazioni di interazione"
 
@@ -2166,8 +2223,10 @@ msgstr "Modifica i dettagli della lista"
 msgid "Edit Moderation List"
 msgstr "Modifica l'elenco di moderazione"
 
-#: src/Navigation.tsx:294 src/view/screens/Feeds.tsx:384
-#: src/view/screens/Feeds.tsx:452 src/view/screens/SavedFeeds.tsx:116
+#: src/Navigation.tsx:294
+#: src/view/screens/Feeds.tsx:384
+#: src/view/screens/Feeds.tsx:452
+#: src/view/screens/SavedFeeds.tsx:116
 msgid "Edit My Feeds"
 msgstr "Modifica i miei feed"
 
@@ -2220,7 +2279,8 @@ msgstr "Modifica la descrizione del tuo profilo"
 msgid "Edit your starter pack"
 msgstr "Modifica il tuo starter pack"
 
-#: src/screens/Onboarding/index.tsx:31 src/screens/Onboarding/state.ts:88
+#: src/screens/Onboarding/index.tsx:31
+#: src/screens/Onboarding/state.ts:88
 msgid "Education"
 msgstr "Formazione scolastica"
 
@@ -2268,14 +2328,18 @@ msgid "Embed HTML code"
 msgstr "Incorpora il codice HTML"
 
 #: src/components/dialogs/Embed.tsx:97
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:433
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:435
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:451
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:453
 msgid "Embed post"
 msgstr "Incorpora il post"
 
 #: src/components/dialogs/Embed.tsx:101
 msgid "Embed this post in your website. Simply copy the following snippet and paste it into the HTML code of your website."
 msgstr "Incorpora questo post nel tuo sito web. Copia il seguente ritaglio e incollalo nel codice HTML del tuo sito web."
+
+#: src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerWeb.tsx:57
+msgid "Embedded video player"
+msgstr "Lettore video incorporato"
 
 #: src/screens/Settings/components/Email2FAToggle.tsx:56
 #: src/screens/Settings/components/Email2FAToggle.tsx:60
@@ -2308,7 +2372,7 @@ msgstr "Attiva i lettori multimediali per"
 msgid "Enable priority notifications"
 msgstr "Attiva notifiche prioritarie"
 
-#: src/view/com/util/post-embeds/VideoEmbedInner/web-controls/VideoControls.tsx:386
+#: src/view/com/util/post-embeds/VideoEmbedInner/web-controls/VideoControls.tsx:387
 msgid "Enable subtitles"
 msgstr "Attiva sottotitoli"
 
@@ -2316,7 +2380,8 @@ msgstr "Attiva sottotitoli"
 msgid "Enable this source only"
 msgstr "Abilita solo questa fonte"
 
-#: src/screens/Messages/Settings.tsx:124 src/screens/Messages/Settings.tsx:127
+#: src/screens/Messages/Settings.tsx:124
+#: src/screens/Messages/Settings.tsx:127
 #: src/screens/Moderation/index.tsx:348
 msgid "Enabled"
 msgstr "Abilitato"
@@ -2345,6 +2410,10 @@ msgstr "Inserisci Codice"
 #: src/view/com/modals/VerifyEmail.tsx:113
 msgid "Enter Confirmation Code"
 msgstr "Inserire il codice di conferma"
+
+#: src/view/com/util/post-embeds/VideoEmbedInner/web-controls/VideoControls.tsx:405
+msgid "Enter fullscreen"
+msgstr "Passa a schermo intero"
 
 #: src/view/com/modals/ChangePassword.tsx:154
 msgid "Enter the code you received to change your password."
@@ -2379,7 +2448,7 @@ msgstr "Inserisci il tuo nuovo indirizzo email qui sotto."
 msgid "Enter your username and password"
 msgstr "Inserisci il tuo nome utente e la tua password"
 
-#: src/view/com/composer/Composer.tsx:1632
+#: src/view/com/composer/Composer.tsx:1637
 msgid "Error"
 msgstr "Errore"
 
@@ -2408,7 +2477,8 @@ msgstr "Tutti possono rispondere"
 msgid "Everybody can reply to this post."
 msgstr "Tutto possono rispondere a questo post."
 
-#: src/screens/Messages/Settings.tsx:77 src/screens/Messages/Settings.tsx:80
+#: src/screens/Messages/Settings.tsx:77
+#: src/screens/Messages/Settings.tsx:80
 msgid "Everyone"
 msgstr "Tutti"
 
@@ -2428,7 +2498,7 @@ msgstr "Escludi utenti che segui"
 msgid "Excludes users you follow"
 msgstr "Esclude gli utenti che segui"
 
-#: src/view/com/util/post-embeds/VideoEmbedInner/web-controls/VideoControls.tsx:403
+#: src/view/com/util/post-embeds/VideoEmbedInner/web-controls/VideoControls.tsx:404
 msgid "Exit fullscreen"
 msgstr "Esci da schermo intero"
 
@@ -2495,8 +2565,8 @@ msgstr "Esporta i miei dati"
 msgid "Export My Data"
 msgstr "Esporta i miei dati"
 
-#: src/screens/Settings/ContentAndMediaSettings.tsx:64
-#: src/screens/Settings/ContentAndMediaSettings.tsx:67
+#: src/screens/Settings/ContentAndMediaSettings.tsx:73
+#: src/screens/Settings/ContentAndMediaSettings.tsx:76
 msgid "External media"
 msgstr "Media esterni"
 
@@ -2510,7 +2580,8 @@ msgstr "Media esterni"
 msgid "External media may allow websites to collect information about you and your device. No information is sent or requested until you press the \"play\" button."
 msgstr "I media esterni possono consentire ai siti web di raccogliere informazioni su di te e sul tuo dispositivo. Nessuna informazione viene inviata o richiesta finché non si preme il pulsante \"Riproduci\"."
 
-#: src/Navigation.tsx:313 src/screens/Settings/ExternalMediaPreferences.tsx:29
+#: src/Navigation.tsx:313
+#: src/screens/Settings/ExternalMediaPreferences.tsx:29
 msgid "External Media Preferences"
 msgstr "Preferenze media esterni"
 
@@ -2535,7 +2606,7 @@ msgstr "Impossibile creare l'elenco. Controlla la connessione Internet e riprova
 msgid "Failed to delete message"
 msgstr "Errore nell'eliminazione del messaggio"
 
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:189
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:195
 msgid "Failed to delete post, please try again"
 msgstr "Non possiamo eliminare il post, riprova di nuovo"
 
@@ -2577,7 +2648,7 @@ msgstr "Non è possibile salvare l'immagine: {0}"
 msgid "Failed to save notification preferences, please try again"
 msgstr "Si è verificato un errore durante il salvataggio delle modifiche: riprova"
 
-#: src/components/dms/MessageItem.tsx:233
+#: src/components/dms/MessageItem.tsx:234
 msgid "Failed to send"
 msgstr "Impossibile inviare messaggio"
 
@@ -2586,7 +2657,7 @@ msgstr "Impossibile inviare messaggio"
 msgid "Failed to submit appeal, please try again."
 msgstr "Impossibile inviare appello, per favore riprova."
 
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:218
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:224
 msgid "Failed to toggle thread mute, please try again"
 msgstr "Impossbile abilitare silenziamento thread, per favore riprova"
 
@@ -2598,8 +2669,10 @@ msgstr "Impossbile aggiornare i feed"
 msgid "Failed to update settings"
 msgstr "Errore nell'aggiornamento delle impostazioni"
 
-#: src/lib/media/video/upload.ts:72 src/lib/media/video/upload.web.ts:74
-#: src/lib/media/video/upload.web.ts:78 src/lib/media/video/upload.web.ts:88
+#: src/lib/media/video/upload.ts:72
+#: src/lib/media/video/upload.web.ts:74
+#: src/lib/media/video/upload.web.ts:78
+#: src/lib/media/video/upload.web.ts:88
 msgid "Failed to upload video"
 msgstr "Errore nel caricamento video"
 
@@ -2611,7 +2684,8 @@ msgstr "Impossibile verificare il nome utente. Riprovare."
 msgid "Feed"
 msgstr "Feed"
 
-#: src/components/FeedCard.tsx:134 src/view/com/feeds/FeedSourceCard.tsx:253
+#: src/components/FeedCard.tsx:134
+#: src/view/com/feeds/FeedSourceCard.tsx:253
 msgid "Feed by {0}"
 msgstr "Feed creato da {0}"
 
@@ -2619,19 +2693,24 @@ msgstr "Feed creato da {0}"
 msgid "Feed toggle"
 msgstr "Attiva/disattiva feed"
 
-#: src/view/shell/desktop/RightNav.tsx:69 src/view/shell/Drawer.tsx:319
+#: src/view/shell/desktop/RightNav.tsx:69
+#: src/view/shell/Drawer.tsx:319
 msgid "Feedback"
 msgstr "Commenti"
 
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:260
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:269
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:266
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:275
 msgid "Feedback sent!"
 msgstr "Feedback inviato!"
 
-#: src/Navigation.tsx:388 src/screens/StarterPack/StarterPackScreen.tsx:183
-#: src/view/screens/Feeds.tsx:446 src/view/screens/Feeds.tsx:552
-#: src/view/screens/Profile.tsx:232 src/view/screens/Search/Search.tsx:537
-#: src/view/shell/desktop/LeftNav.tsx:457 src/view/shell/Drawer.tsx:476
+#: src/Navigation.tsx:388
+#: src/screens/StarterPack/StarterPackScreen.tsx:183
+#: src/view/screens/Feeds.tsx:446
+#: src/view/screens/Feeds.tsx:552
+#: src/view/screens/Profile.tsx:232
+#: src/view/screens/Search/Search.tsx:537
+#: src/view/shell/desktop/LeftNav.tsx:457
+#: src/view/shell/Drawer.tsx:476
 msgid "Feeds"
 msgstr "Feed"
 
@@ -2639,7 +2718,8 @@ msgstr "Feed"
 msgid "Feeds are custom algorithms that users build with a little coding expertise. <0/> for more information."
 msgstr "I feed sono algoritmi personalizzati che gli utenti creano con un minimo di competenza di programmazione. Vedi <0/> per ulteriori informazioni."
 
-#: src/components/FeedCard.tsx:273 src/view/screens/SavedFeeds.tsx:83
+#: src/components/FeedCard.tsx:273
+#: src/view/screens/SavedFeeds.tsx:83
 msgid "Feeds updated!"
 msgstr "Feed aggiornati!"
 
@@ -2768,8 +2848,10 @@ msgstr "Follower che conosci"
 #: src/components/ProfileHoverCard/index.web.tsx:459
 #: src/screens/Profile/Header/ProfileHeaderStandard.tsx:230
 #: src/view/com/post-thread/PostThreadFollowBtn.tsx:135
-#: src/view/screens/Feeds.tsx:632 src/view/screens/ProfileFollows.tsx:30
-#: src/view/screens/ProfileFollows.tsx:31 src/view/screens/SavedFeeds.tsx:431
+#: src/view/screens/Feeds.tsx:632
+#: src/view/screens/ProfileFollows.tsx:30
+#: src/view/screens/ProfileFollows.tsx:31
+#: src/view/screens/SavedFeeds.tsx:431
 msgid "Following"
 msgstr "Seguito"
 
@@ -2782,12 +2864,13 @@ msgstr "Stai seguendo {0}"
 msgid "Following {name}"
 msgstr "Stai segendo {name}"
 
-#: src/screens/Settings/ContentAndMediaSettings.tsx:56
-#: src/screens/Settings/ContentAndMediaSettings.tsx:59
+#: src/screens/Settings/ContentAndMediaSettings.tsx:65
+#: src/screens/Settings/ContentAndMediaSettings.tsx:68
 msgid "Following feed preferences"
 msgstr "Preferenze del feed di chi segui"
 
-#: src/Navigation.tsx:300 src/screens/Settings/FollowingFeedPreferences.tsx:49
+#: src/Navigation.tsx:300
+#: src/screens/Settings/FollowingFeedPreferences.tsx:49
 msgid "Following Feed Preferences"
 msgstr "Preferenze del feed di chi segui"
 
@@ -2807,7 +2890,8 @@ msgstr "Carattere"
 msgid "Font size"
 msgstr "Dimensione font"
 
-#: src/screens/Onboarding/index.tsx:40 src/screens/Onboarding/state.ts:89
+#: src/screens/Onboarding/index.tsx:40
+#: src/screens/Onboarding/state.ts:89
 msgid "Food"
 msgstr "Cibo"
 
@@ -2827,7 +2911,8 @@ msgstr "Per una migliore esperienza, consigliamo di usare il font del tema."
 msgid "Forever"
 msgstr "Per sempre"
 
-#: src/screens/Login/index.tsx:126 src/screens/Login/index.tsx:141
+#: src/screens/Login/index.tsx:126
+#: src/screens/Login/index.tsx:141
 msgid "Forgot Password"
 msgstr "Hai dimenticato la Password"
 
@@ -2851,10 +2936,6 @@ msgstr "Di @{sanitizedAuthor}"
 msgctxt "from-feed"
 msgid "From <0/>"
 msgstr "Da <0/>"
-
-#: src/view/com/util/post-embeds/VideoEmbedInner/web-controls/VideoControls.tsx:404
-msgid "Fullscreen"
-msgstr "Schermo intero"
 
 #: src/view/com/composer/photos/SelectPhotoBtn.tsx:50
 msgid "Gallery"
@@ -2891,16 +2972,21 @@ msgstr "Evidenti violazioni della legge o dei termini di servizio"
 
 #: src/components/moderation/ScreenHider.tsx:154
 #: src/components/moderation/ScreenHider.tsx:163
-#: src/view/com/auth/LoggedOut.tsx:72 src/view/screens/NotFound.tsx:57
-#: src/view/screens/ProfileFeed.tsx:113 src/view/screens/ProfileList.tsx:1029
+#: src/view/com/auth/LoggedOut.tsx:72
+#: src/view/screens/NotFound.tsx:57
+#: src/view/screens/ProfileFeed.tsx:113
+#: src/view/screens/ProfileList.tsx:1029
 #: src/view/shell/desktop/LeftNav.tsx:134
 msgid "Go back"
 msgstr "Torna indietro"
 
-#: src/components/Error.tsx:78 src/screens/List/ListHiddenScreen.tsx:210
-#: src/screens/Profile/ErrorState.tsx:62 src/screens/Profile/ErrorState.tsx:66
+#: src/components/Error.tsx:78
+#: src/screens/List/ListHiddenScreen.tsx:210
+#: src/screens/Profile/ErrorState.tsx:62
+#: src/screens/Profile/ErrorState.tsx:66
 #: src/screens/StarterPack/StarterPackScreen.tsx:757
-#: src/view/screens/NotFound.tsx:56 src/view/screens/ProfileFeed.tsx:118
+#: src/view/screens/NotFound.tsx:56
+#: src/view/screens/ProfileFeed.tsx:118
 #: src/view/screens/ProfileList.tsx:1034
 msgid "Go Back"
 msgstr "Torna indietro"
@@ -2912,7 +2998,8 @@ msgstr "Torna alla pagina precedente"
 #: src/components/dms/ReportDialog.tsx:149
 #: src/components/ReportDialog/SelectReportOptionView.tsx:80
 #: src/components/ReportDialog/SubmitView.tsx:109
-#: src/screens/Onboarding/Layout.tsx:102 src/screens/Onboarding/Layout.tsx:191
+#: src/screens/Onboarding/Layout.tsx:103
+#: src/screens/Onboarding/Layout.tsx:192
 #: src/screens/Signup/BackNextButtons.tsx:35
 msgid "Go back to previous step"
 msgstr "Torna al passaggio precedente"
@@ -2976,7 +3063,7 @@ msgstr "Nome utente troppo lungo. Provarne uno più breve."
 
 #: src/screens/Settings/AccessibilitySettings.tsx:79
 msgid "Haptics"
-msgstr "Aptica"
+msgstr "Vibrazione"
 
 #: src/lib/moderation/useReportOptions.ts:34
 msgid "Harassment, trolling, or intolerance"
@@ -2986,7 +3073,7 @@ msgstr "Molestie, trolling o intolleranza"
 msgid "Hashtag"
 msgstr "Hashtag"
 
-#: src/components/RichText.tsx:226
+#: src/components/RichText.tsx:218
 msgid "Hashtag: #{tag}"
 msgstr "Hashtag: #{tag}"
 
@@ -2994,14 +3081,20 @@ msgstr "Hashtag: #{tag}"
 msgid "Having trouble?"
 msgstr "Ci sono problemi?"
 
-#: src/screens/Settings/Settings.tsx:199 src/screens/Settings/Settings.tsx:203
-#: src/view/shell/desktop/RightNav.tsx:98 src/view/shell/Drawer.tsx:332
+#: src/screens/Settings/Settings.tsx:199
+#: src/screens/Settings/Settings.tsx:203
+#: src/view/shell/desktop/RightNav.tsx:98
+#: src/view/shell/Drawer.tsx:332
 msgid "Help"
 msgstr "Aiuto"
 
 #: src/screens/Onboarding/StepProfile/index.tsx:237
 msgid "Help people know you're not a bot by uploading a picture or creating an avatar."
 msgstr "Aiuta le persone a sapere che tu non sei un bot caricando una immagine o creando un avatar."
+
+#: src/screens/Settings/ContentAndMediaSettings.tsx:127
+msgid "Helps external sites estimate traffic from Bluesky."
+msgstr "Aiuta i siti esterni a stimare il traffico da Bluesky."
 
 #: src/screens/Settings/components/AddAppPasswordDialog.tsx:187
 msgid "Here is your app password!"
@@ -3018,7 +3111,7 @@ msgstr "Lista nascosta"
 #: src/lib/moderation/useLabelBehaviorDescription.ts:20
 #: src/lib/moderation/useLabelBehaviorDescription.ts:25
 #: src/lib/moderation/useLabelBehaviorDescription.ts:30
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:643
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:672
 msgid "Hide"
 msgstr "Nascondi"
 
@@ -3027,18 +3120,18 @@ msgctxt "action"
 msgid "Hide"
 msgstr "Nascondi"
 
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:505
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:511
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:523
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:529
 msgid "Hide post for me"
 msgstr "Nascondi post per me"
 
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:522
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:532
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:540
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:550
 msgid "Hide reply for everyone"
 msgstr "Nascondi risposta per tutti"
 
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:504
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:510
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:522
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:528
 msgid "Hide reply for me"
 msgstr "Nascondi risposta per me"
 
@@ -3047,12 +3140,12 @@ msgstr "Nascondi risposta per me"
 msgid "Hide the content"
 msgstr "Nascondere il contenuto"
 
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:638
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:667
 msgid "Hide this post?"
 msgstr "Vuoi nascondere questo post?"
 
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:638
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:700
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:667
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:729
 msgid "Hide this reply?"
 msgstr "Nascondere questa risposta?"
 
@@ -3088,13 +3181,15 @@ msgstr "Stiamo riscontrando problemi a caricare questi dati. Vedi sotto per magg
 msgid "Hmmmm, we couldn't load that moderation service."
 msgstr "Non siamo riusciti a caricare il servizio di moderazione."
 
-#: src/view/com/composer/state/video.ts:426
+#: src/view/com/composer/state/video.ts:413
 msgid "Hold up! We’re gradually giving access to video, and you’re still waiting in line. Check back soon!"
 msgstr "Un po' di pazienza: stiamo gradualmente dando accesso al video e tu sei ancora in coda. Ricontrolla presto!"
 
-#: src/Navigation.tsx:585 src/Navigation.tsx:605
+#: src/Navigation.tsx:579
+#: src/Navigation.tsx:599
 #: src/view/shell/bottom-bar/BottomBar.tsx:158
-#: src/view/shell/desktop/LeftNav.tsx:401 src/view/shell/Drawer.tsx:391
+#: src/view/shell/desktop/LeftNav.tsx:401
+#: src/view/shell/Drawer.tsx:391
 msgid "Home"
 msgstr "Home"
 
@@ -3153,7 +3248,7 @@ msgstr "Se elimini questa lista, non potrai recuperarla."
 msgid "If you have your own domain, you can use that as your handle. This lets you self-verify your identity – <0>learn more</0>."
 msgstr "Se hai un tuo dominio, puoi usarlo come nome utente. Questo consente di auto-verificare la tua identità – <0>ulteriori informazioni</0>."
 
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:629
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:658
 msgid "If you remove this post, you won't be able to recover it."
 msgstr "Se rimuovi questo post, non potrai recuperarlo."
 
@@ -3238,7 +3333,8 @@ msgstr "Nome utente non valido. Provarne un altro."
 msgid "Invalid or unsupported post record"
 msgstr "Protocollo del post non valido o non supportato"
 
-#: src/screens/Login/LoginForm.tsx:88 src/screens/Login/LoginForm.tsx:147
+#: src/screens/Login/LoginForm.tsx:88
+#: src/screens/Login/LoginForm.tsx:147
 msgid "Invalid username or password"
 msgstr "Nome dell'utente o password errato"
 
@@ -3290,7 +3386,7 @@ msgstr "È corretto"
 msgid "It's just you right now! Add more people to your starter pack by searching above."
 msgstr "Sei solo tu al momento! Aggiungi altre persone al tuo starter pack cercandole qui in alto."
 
-#: src/view/com/composer/Composer.tsx:1566
+#: src/view/com/composer/Composer.tsx:1571
 msgid "Job ID: {0}"
 msgstr "ID processo: {0}"
 
@@ -3310,7 +3406,8 @@ msgstr "Entra in Bluesky"
 msgid "Join the conversation"
 msgstr "Entra nella conversazione"
 
-#: src/screens/Onboarding/index.tsx:21 src/screens/Onboarding/state.ts:91
+#: src/screens/Onboarding/index.tsx:21
+#: src/screens/Onboarding/state.ts:91
 msgid "Journalism"
 msgstr "Giornalismo"
 
@@ -3352,7 +3449,8 @@ msgid "Language Settings"
 msgstr "Impostazione delle Lingue"
 
 #: src/screens/Settings/LanguageSettings.tsx:67
-#: src/screens/Settings/Settings.tsx:191 src/screens/Settings/Settings.tsx:194
+#: src/screens/Settings/Settings.tsx:191
+#: src/screens/Settings/Settings.tsx:194
 msgid "Languages"
 msgstr "Lingue"
 
@@ -3360,7 +3458,8 @@ msgstr "Lingue"
 msgid "Larger"
 msgstr "Più grande"
 
-#: src/screens/Hashtag.tsx:98 src/view/screens/Search/Search.tsx:521
+#: src/screens/Hashtag.tsx:98
+#: src/view/screens/Search/Search.tsx:521
 msgid "Latest"
 msgstr "Ultime"
 
@@ -3409,8 +3508,10 @@ msgstr "Abbandona"
 msgid "Leave chat"
 msgstr "Abbandona la chat"
 
-#: src/components/dms/ConvoMenu.tsx:138 src/components/dms/ConvoMenu.tsx:141
-#: src/components/dms/ConvoMenu.tsx:208 src/components/dms/ConvoMenu.tsx:211
+#: src/components/dms/ConvoMenu.tsx:138
+#: src/components/dms/ConvoMenu.tsx:141
+#: src/components/dms/ConvoMenu.tsx:208
+#: src/components/dms/ConvoMenu.tsx:211
 #: src/components/dms/LeaveConvoPrompt.tsx:45
 msgid "Leave conversation"
 msgstr "Abbandona la conversazione"
@@ -3431,7 +3532,8 @@ msgstr "mancanti."
 msgid "Let me choose"
 msgstr "Lascia scegliere a me"
 
-#: src/screens/Login/index.tsx:127 src/screens/Login/index.tsx:142
+#: src/screens/Login/index.tsx:127
+#: src/screens/Login/index.tsx:142
 msgid "Let's get your password reset!"
 msgstr "Reimpostazione della password!"
 
@@ -3457,12 +3559,14 @@ msgstr "Metti like a 10 post per allenare il feed Discover"
 msgid "Like this feed"
 msgstr "Metti mi piace a questo feed"
 
-#: src/components/LikesDialog.tsx:85 src/Navigation.tsx:234
+#: src/components/LikesDialog.tsx:85
+#: src/Navigation.tsx:234
 #: src/Navigation.tsx:239
 msgid "Liked by"
 msgstr "Piace a"
 
-#: src/screens/Post/PostLikedBy.tsx:32 src/screens/Post/PostLikedBy.tsx:33
+#: src/screens/Post/PostLikedBy.tsx:32
+#: src/screens/Post/PostLikedBy.tsx:33
 #: src/screens/Profile/ProfileLabelerLikedBy.tsx:29
 #: src/view/screens/ProfileFeedLikedBy.tsx:30
 msgid "Liked By"
@@ -3488,7 +3592,8 @@ msgstr "Lista avatar"
 msgid "List blocked"
 msgstr "Lista bloccata"
 
-#: src/components/ListCard.tsx:150 src/view/com/feeds/FeedSourceCard.tsx:255
+#: src/components/ListCard.tsx:150
+#: src/view/com/feeds/FeedSourceCard.tsx:255
 msgid "List by {0}"
 msgstr "Lista di {0}"
 
@@ -3520,8 +3625,10 @@ msgstr "Lista sbloccata"
 msgid "List unmuted"
 msgstr "Lista non mutata"
 
-#: src/Navigation.tsx:133 src/view/screens/Profile.tsx:227
-#: src/view/screens/Profile.tsx:234 src/view/shell/desktop/LeftNav.tsx:475
+#: src/Navigation.tsx:133
+#: src/view/screens/Profile.tsx:227
+#: src/view/screens/Profile.tsx:234
+#: src/view/shell/desktop/LeftNav.tsx:475
 #: src/view/shell/Drawer.tsx:491
 msgid "Lists"
 msgstr "Liste"
@@ -3547,12 +3654,13 @@ msgid "Load new notifications"
 msgstr "Carica più notifiche"
 
 #: src/screens/Profile/Sections/Feed.tsx:96
-#: src/view/com/feeds/FeedPage.tsx:132 src/view/screens/ProfileFeed.tsx:499
+#: src/view/com/feeds/FeedPage.tsx:132
+#: src/view/screens/ProfileFeed.tsx:499
 #: src/view/screens/ProfileList.tsx:808
 msgid "Load new posts"
 msgstr "Carica nuovi post"
 
-#: src/view/com/composer/text-input/mobile/Autocomplete.tsx:111
+#: src/view/com/composer/text-input/mobile/Autocomplete.tsx:94
 msgid "Loading..."
 msgstr "Caricamento..."
 
@@ -3560,12 +3668,15 @@ msgstr "Caricamento..."
 msgid "Log"
 msgstr "Log"
 
-#: src/screens/Deactivated.tsx:209 src/screens/Deactivated.tsx:215
+#: src/screens/Deactivated.tsx:209
+#: src/screens/Deactivated.tsx:215
 msgid "Log in or sign up"
 msgstr "Accedi o Iscriviti"
 
-#: src/screens/SignupQueued.tsx:169 src/screens/SignupQueued.tsx:172
-#: src/screens/SignupQueued.tsx:197 src/screens/SignupQueued.tsx:200
+#: src/screens/SignupQueued.tsx:169
+#: src/screens/SignupQueued.tsx:172
+#: src/screens/SignupQueued.tsx:197
+#: src/screens/SignupQueued.tsx:200
 msgid "Log out"
 msgstr "Esci"
 
@@ -3585,7 +3696,7 @@ msgstr "Logo di <0/>"
 msgid "Logo by <0>@sawaratsuki.bsky.social</0>"
 msgstr "Logo di <0>@sawaratsuki.bsky.social</0>"
 
-#: src/components/RichText.tsx:227
+#: src/components/RichText.tsx:219
 msgid "Long press to open tag menu for #{tag}"
 msgstr "Tieni premutoper aprire il menu dei tag per #{tag}"
 
@@ -3613,16 +3724,17 @@ msgstr "Creane uno per me"
 msgid "Make sure this is where you intend to go!"
 msgstr "Assicurati che questo sia dove intendi andare!"
 
-#: src/screens/Settings/ContentAndMediaSettings.tsx:40
-#: src/screens/Settings/ContentAndMediaSettings.tsx:43
+#: src/screens/Settings/ContentAndMediaSettings.tsx:49
+#: src/screens/Settings/ContentAndMediaSettings.tsx:52
 msgid "Manage saved feeds"
 msgstr "Gestisci i feed salvati"
 
 #: src/components/dialogs/MutedWords.tsx:108
 msgid "Manage your muted words and tags"
-msgstr "Gestisci le parole mute e i tags"
+msgstr "Gestisci parole e tag silenziati"
 
-#: src/components/dms/ConvoMenu.tsx:151 src/components/dms/ConvoMenu.tsx:158
+#: src/components/dms/ConvoMenu.tsx:151
+#: src/components/dms/ConvoMenu.tsx:158
 msgid "Mark as read"
 msgstr "Segna come letto"
 
@@ -3642,7 +3754,8 @@ msgstr "utenti menzionati"
 msgid "Mentioned users"
 msgstr "Utenti menzionati"
 
-#: src/components/Menu/index.tsx:95 src/view/com/util/ViewHeader.tsx:87
+#: src/components/Menu/index.tsx:95
+#: src/view/com/util/ViewHeader.tsx:87
 #: src/view/screens/Search/Search.tsx:882
 msgid "Menu"
 msgstr "Menu"
@@ -3673,8 +3786,10 @@ msgstr "Il messaggio è troppo lungo"
 msgid "Message settings"
 msgstr "Impostazioni messaggio"
 
-#: src/Navigation.tsx:600 src/screens/Messages/ChatList.tsx:162
-#: src/screens/Messages/ChatList.tsx:243 src/screens/Messages/ChatList.tsx:314
+#: src/Navigation.tsx:594
+#: src/screens/Messages/ChatList.tsx:162
+#: src/screens/Messages/ChatList.tsx:243
+#: src/screens/Messages/ChatList.tsx:314
 msgid "Messages"
 msgstr "Messaggi"
 
@@ -3686,8 +3801,10 @@ msgstr "Account Ingannevole"
 msgid "Misleading Post"
 msgstr "Post ingannevole"
 
-#: src/Navigation.tsx:138 src/screens/Moderation/index.tsx:101
-#: src/screens/Settings/Settings.tsx:159 src/screens/Settings/Settings.tsx:162
+#: src/Navigation.tsx:138
+#: src/screens/Moderation/index.tsx:101
+#: src/screens/Settings/Settings.tsx:159
+#: src/screens/Settings/Settings.tsx:162
 msgid "Moderation"
 msgstr "Moderazione"
 
@@ -3721,7 +3838,8 @@ msgstr "Lista di moderazione aggiornata"
 msgid "Moderation lists"
 msgstr "Liste di moderazione"
 
-#: src/Navigation.tsx:143 src/view/screens/ModerationModlists.tsx:72
+#: src/Navigation.tsx:143
+#: src/view/screens/ModerationModlists.tsx:72
 msgid "Moderation Lists"
 msgstr "Liste di Moderazione"
 
@@ -3776,7 +3894,7 @@ msgid "Mute"
 msgstr "Silenzia"
 
 #: src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerNative.tsx:156
-#: src/view/com/util/post-embeds/VideoEmbedInner/web-controls/VolumeControl.tsx:94
+#: src/view/com/util/post-embeds/VideoEmbedInner/web-controls/VolumeControl.tsx:95
 msgctxt "video"
 msgid "Mute"
 msgstr "Silenzia"
@@ -3792,13 +3910,14 @@ msgstr "Silenzia l'account"
 
 #: src/view/screens/ProfileList.tsx:631
 msgid "Mute accounts"
-msgstr "Silenzia gli accounts"
+msgstr "Silenzia account"
 
 #: src/components/TagMenu/index.tsx:224
 msgid "Mute all {displayTag} posts"
 msgstr "Silenzia tutti i post {displayTag}"
 
-#: src/components/dms/ConvoMenu.tsx:172 src/components/dms/ConvoMenu.tsx:178
+#: src/components/dms/ConvoMenu.tsx:172
+#: src/components/dms/ConvoMenu.tsx:178
 msgid "Mute conversation"
 msgstr "Silenzia la conversazione"
 
@@ -3838,23 +3957,24 @@ msgstr "Siilenzia questa parola solo nei tags"
 msgid "Mute this word until you unmute it"
 msgstr "Silenzia questa parola finchè non la riattivi"
 
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:471
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:475
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:489
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:493
 msgid "Mute thread"
 msgstr "Silenzia questa discussione"
 
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:485
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:487
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:503
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:505
 msgid "Mute words & tags"
-msgstr "Silenzia parole & tags"
+msgstr "Silenzia parole e tag"
 
 #: src/screens/Moderation/index.tsx:259
 msgid "Muted accounts"
 msgstr "Account silenziato"
 
-#: src/Navigation.tsx:148 src/view/screens/ModerationMutedAccounts.tsx:108
+#: src/Navigation.tsx:148
+#: src/view/screens/ModerationMutedAccounts.tsx:108
 msgid "Muted Accounts"
-msgstr "Accounts Silenziati"
+msgstr "Account silenziati"
 
 #: src/view/screens/ModerationMutedAccounts.tsx:116
 msgid "Muted accounts have their posts removed from your feed and from your notifications. Mutes are completely private."
@@ -3866,7 +3986,7 @@ msgstr "Silenziato da \"{0}\""
 
 #: src/screens/Moderation/index.tsx:229
 msgid "Muted words & tags"
-msgstr "Parole e tags silenziati"
+msgstr "Parole e tag silenziati"
 
 #: src/view/screens/ProfileList.tsx:734
 msgid "Muting is private. Muted accounts can interact with you, but you will not see their posts or receive notifications from them."
@@ -3900,7 +4020,8 @@ msgstr "Il nome è obbligatorio"
 msgid "Name or Description Violates Community Standards"
 msgstr "Il Nome o la Descrizione Viola gli Standard della Comunità"
 
-#: src/screens/Onboarding/index.tsx:22 src/screens/Onboarding/state.ts:94
+#: src/screens/Onboarding/index.tsx:22
+#: src/screens/Onboarding/state.ts:94
 msgid "Nature"
 msgstr "Natura"
 
@@ -3944,7 +4065,8 @@ msgid "New"
 msgstr "Nuova"
 
 #: src/components/dms/dialogs/NewChatDialog.tsx:65
-#: src/screens/Messages/ChatList.tsx:328 src/screens/Messages/ChatList.tsx:335
+#: src/screens/Messages/ChatList.tsx:328
+#: src/screens/Messages/ChatList.tsx:335
 msgid "New chat"
 msgstr "Nuova chat"
 
@@ -3975,9 +4097,12 @@ msgctxt "action"
 msgid "New post"
 msgstr "Nuovo Post"
 
-#: src/view/screens/Feeds.tsx:582 src/view/screens/Notifications.tsx:224
-#: src/view/screens/Profile.tsx:496 src/view/screens/ProfileFeed.tsx:433
-#: src/view/screens/ProfileList.tsx:248 src/view/screens/ProfileList.tsx:287
+#: src/view/screens/Feeds.tsx:582
+#: src/view/screens/Notifications.tsx:224
+#: src/view/screens/Profile.tsx:496
+#: src/view/screens/ProfileFeed.tsx:433
+#: src/view/screens/ProfileList.tsx:248
+#: src/view/screens/ProfileList.tsx:287
 msgid "New post"
 msgstr "Nuovo post"
 
@@ -3999,13 +4124,15 @@ msgstr "Nuova lista"
 msgid "Newest replies first"
 msgstr "Mostrare prima le risposte più recenti"
 
-#: src/screens/Onboarding/index.tsx:20 src/screens/Onboarding/state.ts:95
+#: src/screens/Onboarding/index.tsx:20
+#: src/screens/Onboarding/state.ts:95
 msgid "News"
 msgstr "Notizie"
 
 #: src/screens/Login/ForgotPasswordForm.tsx:137
 #: src/screens/Login/ForgotPasswordForm.tsx:143
-#: src/screens/Login/LoginForm.tsx:315 src/screens/Login/LoginForm.tsx:322
+#: src/screens/Login/LoginForm.tsx:315
+#: src/screens/Login/LoginForm.tsx:322
 #: src/screens/Login/SetNewPasswordForm.tsx:168
 #: src/screens/Login/SetNewPasswordForm.tsx:174
 #: src/screens/Settings/components/AddAppPasswordDialog.tsx:157
@@ -4028,7 +4155,8 @@ msgstr "Immagine successiva"
 msgid "No app passwords yet"
 msgstr "Non è stata ancora definita alcuna password per le app"
 
-#: src/view/screens/ProfileFeed.tsx:565 src/view/screens/ProfileList.tsx:882
+#: src/view/screens/ProfileFeed.tsx:565
+#: src/view/screens/ProfileList.tsx:882
 msgid "No description"
 msgstr "Senza descrizione"
 
@@ -4071,7 +4199,8 @@ msgstr "Nessun'altra conversazione da visualizzare"
 msgid "No notifications yet!"
 msgstr "Ancora nessuna notifica!"
 
-#: src/screens/Messages/Settings.tsx:95 src/screens/Messages/Settings.tsx:98
+#: src/screens/Messages/Settings.tsx:95
+#: src/screens/Messages/Settings.tsx:98
 msgid "No one"
 msgstr "Nessuno"
 
@@ -4091,8 +4220,8 @@ msgstr "Ancora nessuna citazione"
 msgid "No reposts yet"
 msgstr "Ancora nessun repost"
 
-#: src/view/com/composer/text-input/mobile/Autocomplete.tsx:111
-#: src/view/com/composer/text-input/web/Autocomplete.tsx:191
+#: src/view/com/composer/text-input/mobile/Autocomplete.tsx:94
+#: src/view/com/composer/text-input/web/Autocomplete.tsx:195
 msgid "No result"
 msgstr "Nessun risultato"
 
@@ -4128,7 +4257,8 @@ msgstr "No grazie"
 msgid "Nobody"
 msgstr "Nessuno"
 
-#: src/components/LikedByList.tsx:80 src/components/LikesDialog.tsx:97
+#: src/components/LikedByList.tsx:80
+#: src/components/LikesDialog.tsx:97
 #: src/view/com/post-thread/PostLikedBy.tsx:87
 msgid "Nobody has liked this yet. Maybe you should be the first!"
 msgstr "Nessuno ha messo like. Fallo tu per primo/a!"
@@ -4149,7 +4279,8 @@ msgstr "Nessun utente trovato. Prova a cercarne altri."
 msgid "Non-sexual Nudity"
 msgstr "Nudità non sessuale"
 
-#: src/Navigation.tsx:128 src/view/screens/Profile.tsx:128
+#: src/Navigation.tsx:128
+#: src/view/screens/Profile.tsx:128
 msgid "Not Found"
 msgstr "Non trovato"
 
@@ -4159,7 +4290,7 @@ msgid "Not right now"
 msgstr "Non adesso"
 
 #: src/view/com/profile/ProfileMenu.tsx:348
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:657
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:686
 #: src/view/com/util/post-ctrls/PostCtrls.tsx:350
 msgid "Note about sharing"
 msgstr "Nota sulla condivisione"
@@ -4176,7 +4307,8 @@ msgstr "Nulla qui"
 msgid "Notification filters"
 msgstr "Filtri notifiche"
 
-#: src/Navigation.tsx:383 src/view/screens/Notifications.tsx:117
+#: src/Navigation.tsx:383
+#: src/view/screens/Notifications.tsx:117
 msgid "Notification settings"
 msgstr "Notifiche"
 
@@ -4192,11 +4324,13 @@ msgstr "Suoni di notifica"
 msgid "Notification Sounds"
 msgstr "Suoni di notifica"
 
-#: src/Navigation.tsx:595 src/view/screens/Notifications.tsx:143
+#: src/Navigation.tsx:589
+#: src/view/screens/Notifications.tsx:143
 #: src/view/screens/Notifications.tsx:153
 #: src/view/screens/Notifications.tsx:199
 #: src/view/shell/bottom-bar/BottomBar.tsx:226
-#: src/view/shell/desktop/LeftNav.tsx:438 src/view/shell/Drawer.tsx:444
+#: src/view/shell/desktop/LeftNav.tsx:438
+#: src/view/shell/Drawer.tsx:444
 msgid "Notifications"
 msgstr "Notifiche"
 
@@ -4204,7 +4338,7 @@ msgstr "Notifiche"
 msgid "now"
 msgstr "ora"
 
-#: src/components/dms/MessageItem.tsx:197
+#: src/components/dms/MessageItem.tsx:198
 msgid "Now"
 msgstr "Ora"
 
@@ -4252,15 +4386,15 @@ msgstr "su<0><1/><2><3/></2></0>"
 msgid "Onboarding reset"
 msgstr "Reimpostazione dell'onboarding"
 
-#: src/view/com/composer/Composer.tsx:325
+#: src/view/com/composer/Composer.tsx:331
 msgid "One or more GIFs is missing alt text."
 msgstr "Una o più GIF non hanno un testo alternativo."
 
-#: src/view/com/composer/Composer.tsx:322
+#: src/view/com/composer/Composer.tsx:328
 msgid "One or more images is missing alt text."
 msgstr "A una o più immagini manca il testo alternativo."
 
-#: src/view/com/composer/Composer.tsx:332
+#: src/view/com/composer/Composer.tsx:338
 msgid "One or more videos is missing alt text."
 msgstr "In uno o più video manca il testo alternativo."
 
@@ -4320,8 +4454,8 @@ msgid "Open conversation options"
 msgstr "Apri opzioni conversazione"
 
 #: src/screens/Messages/components/MessageInput.web.tsx:165
-#: src/view/com/composer/Composer.tsx:1216
-#: src/view/com/composer/Composer.tsx:1217
+#: src/view/com/composer/Composer.tsx:1221
+#: src/view/com/composer/Composer.tsx:1222
 msgid "Open emoji picker"
 msgstr "Apri il selettore emoji"
 
@@ -4361,7 +4495,8 @@ msgstr "Apri il menu delle opzioni del post"
 msgid "Open starter pack menu"
 msgstr "Apri menu degli starter pack"
 
-#: src/screens/Settings/Settings.tsx:314 src/screens/Settings/Settings.tsx:328
+#: src/screens/Settings/Settings.tsx:314
+#: src/screens/Settings/Settings.tsx:328
 msgid "Open storybook page"
 msgstr "Apri la pagina della cronologia"
 
@@ -4428,7 +4563,7 @@ msgstr "Apre il sito Web collegato"
 msgid "Opens this profile"
 msgstr "Apre questo profilo"
 
-#: src/view/com/composer/videos/SelectVideoBtn.tsx:107
+#: src/view/com/composer/videos/SelectVideoBtn.tsx:101
 msgid "Opens video picker"
 msgstr "Apre selettore video"
 
@@ -4474,7 +4609,8 @@ msgstr "Altro..."
 msgid "Our moderators have reviewed reports and decided to disable your access to chats on Bluesky."
 msgstr "I nostri moderatori hanno revisionato i report e deciso di disabilitare il tuo accesso ai messaggi su Bluesky."
 
-#: src/components/Lists.tsx:216 src/view/screens/NotFound.tsx:47
+#: src/components/Lists.tsx:216
+#: src/view/screens/NotFound.tsx:47
 msgid "Page not found"
 msgstr "Pagina non trovata"
 
@@ -4505,7 +4641,7 @@ msgstr "Password aggiornata!"
 
 #: src/view/com/util/post-embeds/GifEmbed.tsx:43
 #: src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerNative.tsx:140
-#: src/view/com/util/post-embeds/VideoEmbedInner/web-controls/VideoControls.tsx:368
+#: src/view/com/util/post-embeds/VideoEmbedInner/web-controls/VideoControls.tsx:369
 msgid "Pause"
 msgstr "Pausa"
 
@@ -4538,7 +4674,8 @@ msgstr "L'autorizzazione per accedere la cartella delle immagini è stata negata
 msgid "Person toggle"
 msgstr "Attiva/disattiva persona"
 
-#: src/screens/Onboarding/index.tsx:28 src/screens/Onboarding/state.ts:96
+#: src/screens/Onboarding/index.tsx:28
+#: src/screens/Onboarding/state.ts:96
 msgid "Pets"
 msgstr "Animali di compagnia"
 
@@ -4550,7 +4687,8 @@ msgstr "Foto"
 msgid "Pictures meant for adults."
 msgstr "Immagini per adulti."
 
-#: src/view/screens/ProfileFeed.tsx:293 src/view/screens/ProfileList.tsx:676
+#: src/view/screens/ProfileFeed.tsx:293
+#: src/view/screens/ProfileList.tsx:676
 msgid "Pin to home"
 msgstr "Fissa su Home"
 
@@ -4558,8 +4696,8 @@ msgstr "Fissa su Home"
 msgid "Pin to Home"
 msgstr "Fissa su Home"
 
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:362
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:369
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:380
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:387
 msgid "Pin to your profile"
 msgstr "Fissa sul tuo profilo"
 
@@ -4577,7 +4715,7 @@ msgstr "Fissa ai tuoi feed"
 
 #: src/view/com/util/post-embeds/GifEmbed.tsx:43
 #: src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerNative.tsx:140
-#: src/view/com/util/post-embeds/VideoEmbedInner/web-controls/VideoControls.tsx:369
+#: src/view/com/util/post-embeds/VideoEmbedInner/web-controls/VideoControls.tsx:370
 msgid "Play"
 msgstr "Play"
 
@@ -4607,7 +4745,8 @@ msgstr "Riproduci questa GIF"
 msgid "Please choose your handle."
 msgstr "Scegli il tuo nome utente."
 
-#: src/screens/Signup/state.ts:210 src/screens/Signup/StepInfo/index.tsx:114
+#: src/screens/Signup/state.ts:210
+#: src/screens/Signup/StepInfo/index.tsx:114
 msgid "Please choose your password."
 msgstr "Scegli la tua password."
 
@@ -4627,7 +4766,8 @@ msgstr "Inserisci un nome univoco per questa password dell'app o utilizza quello
 msgid "Please enter a valid word, tag, or phrase to mute"
 msgstr "Inserisci una parola, un tag o una frase valida da silenziare"
 
-#: src/screens/Signup/state.ts:196 src/screens/Signup/StepInfo/index.tsx:102
+#: src/screens/Signup/state.ts:196
+#: src/screens/Signup/StepInfo/index.tsx:102
 msgid "Please enter your email."
 msgstr "Inserisci la tua email."
 
@@ -4656,7 +4796,8 @@ msgstr "Accedi come @{0}"
 msgid "Please Verify Your Email"
 msgstr "Verifica la tua email"
 
-#: src/screens/Onboarding/index.tsx:34 src/screens/Onboarding/state.ts:98
+#: src/screens/Onboarding/index.tsx:34
+#: src/screens/Onboarding/state.ts:98
 msgid "Politics"
 msgstr "Politica"
 
@@ -4664,7 +4805,7 @@ msgstr "Politica"
 msgid "Porn"
 msgstr "Porno"
 
-#: src/view/com/composer/Composer.tsx:921
+#: src/view/com/composer/Composer.tsx:937
 msgctxt "action"
 msgid "Post"
 msgstr "Post"
@@ -4674,7 +4815,7 @@ msgctxt "description"
 msgid "Post"
 msgstr "Post"
 
-#: src/view/com/composer/Composer.tsx:919
+#: src/view/com/composer/Composer.tsx:935
 msgctxt "action"
 msgid "Post All"
 msgstr "Posta tutti"
@@ -4683,12 +4824,14 @@ msgstr "Posta tutti"
 msgid "Post by {0}"
 msgstr "Pubblicato da {0}"
 
-#: src/Navigation.tsx:202 src/Navigation.tsx:209 src/Navigation.tsx:216
+#: src/Navigation.tsx:202
+#: src/Navigation.tsx:209
+#: src/Navigation.tsx:216
 #: src/Navigation.tsx:223
 msgid "Post by @{0}"
 msgstr "Pubblicato da @{0}"
 
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:169
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:175
 msgid "Post deleted"
 msgstr "Post eliminato"
 
@@ -4746,7 +4889,7 @@ msgstr "Post"
 
 #: src/components/dialogs/MutedWords.tsx:115
 msgid "Posts can be muted based on their text, their tags, or both. We recommend avoiding common words that appear in many posts, since it can result in no posts being shown."
-msgstr "I post possono essere mutati a seconda del loro testo, dei loro tag, o entrambi. Consigliamo di evitare parole comuni che appaiono in tanti post, in quanto possa nascondere molti post."
+msgstr "I post possono essere silenziati in base al loro testo, ai loro tag o a entrambi. Consigliamo di evitare parole comuni che compaiono in molti post, poiché ciò potrebbe comportare la mancata visualizzazione dei post."
 
 #: src/view/com/posts/FeedErrorMessage.tsx:68
 msgid "Posts hidden"
@@ -4768,7 +4911,8 @@ msgstr "Premere per tentare di riconnetterti"
 msgid "Press to change hosting provider"
 msgstr "Premi per cambiare provider di hosting"
 
-#: src/components/Error.tsx:60 src/components/Lists.tsx:93
+#: src/components/Error.tsx:60
+#: src/components/Lists.tsx:93
 #: src/screens/Messages/components/MessageListError.tsx:24
 #: src/screens/Signup/BackNextButtons.tsx:47
 msgid "Press to retry"
@@ -4799,7 +4943,8 @@ msgstr "Impostazioni di priorità"
 msgid "Privacy"
 msgstr "Privacy"
 
-#: src/screens/Settings/Settings.tsx:153 src/screens/Settings/Settings.tsx:156
+#: src/screens/Settings/Settings.tsx:153
+#: src/screens/Settings/Settings.tsx:156
 msgid "Privacy and security"
 msgstr "Privacy e sicurezza"
 
@@ -4808,27 +4953,32 @@ msgstr "Privacy e sicurezza"
 msgid "Privacy and Security"
 msgstr "Privacy e sicurezza"
 
-#: src/Navigation.tsx:269 src/screens/Settings/AboutSettings.tsx:37
+#: src/Navigation.tsx:269
+#: src/screens/Settings/AboutSettings.tsx:37
 #: src/screens/Settings/AboutSettings.tsx:40
-#: src/view/screens/PrivacyPolicy.tsx:31 src/view/shell/Drawer.tsx:624
+#: src/view/screens/PrivacyPolicy.tsx:31
+#: src/view/shell/Drawer.tsx:624
 #: src/view/shell/Drawer.tsx:625
 msgid "Privacy Policy"
 msgstr "Informativa sulla privacy"
 
-#: src/view/com/composer/Composer.tsx:1629
+#: src/view/com/composer/Composer.tsx:1634
 msgid "Processing video..."
 msgstr "Elaborazione video in corso..."
 
-#: src/lib/api/index.ts:59 src/screens/Login/ForgotPasswordForm.tsx:149
+#: src/lib/api/index.ts:59
+#: src/screens/Login/ForgotPasswordForm.tsx:149
 msgid "Processing..."
 msgstr "Elaborazione in corso…"
 
-#: src/view/screens/DebugMod.tsx:913 src/view/screens/Profile.tsx:363
+#: src/view/screens/DebugMod.tsx:913
+#: src/view/screens/Profile.tsx:363
 msgid "profile"
 msgstr "profilo"
 
 #: src/view/shell/bottom-bar/BottomBar.tsx:271
-#: src/view/shell/desktop/LeftNav.tsx:493 src/view/shell/Drawer.tsx:71
+#: src/view/shell/desktop/LeftNav.tsx:493
+#: src/view/shell/Drawer.tsx:71
 #: src/view/shell/Drawer.tsx:516
 msgid "Profile"
 msgstr "Profilo"
@@ -4862,24 +5012,24 @@ msgstr "Codice QR scaricato!"
 msgid "QR code saved to your camera roll!"
 msgstr "Codice QR salvato nella galleria!"
 
-#: src/view/com/util/post-ctrls/RepostButton.tsx:166
-#: src/view/com/util/post-ctrls/RepostButton.tsx:188
+#: src/view/com/util/post-ctrls/RepostButton.tsx:168
+#: src/view/com/util/post-ctrls/RepostButton.tsx:191
 #: src/view/com/util/post-ctrls/RepostButton.web.tsx:85
 #: src/view/com/util/post-ctrls/RepostButton.web.tsx:92
 msgid "Quote post"
 msgstr "Cita il post"
 
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:297
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:303
 msgid "Quote post was re-attached"
 msgstr "Citazione post riattaccata"
 
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:296
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:302
 msgid "Quote post was successfully detached"
 msgstr "Citazione post staccata con successo"
 
 #: src/components/dialogs/PostInteractionSettingsDialog.tsx:314
-#: src/view/com/util/post-ctrls/RepostButton.tsx:165
-#: src/view/com/util/post-ctrls/RepostButton.tsx:187
+#: src/view/com/util/post-ctrls/RepostButton.tsx:167
+#: src/view/com/util/post-ctrls/RepostButton.tsx:189
 #: src/view/com/util/post-ctrls/RepostButton.web.tsx:84
 #: src/view/com/util/post-ctrls/RepostButton.web.tsx:91
 msgid "Quote posts disabled"
@@ -4893,7 +5043,8 @@ msgstr "Citazioni post attivate"
 msgid "Quote settings"
 msgstr "Impostazioni citazioni"
 
-#: src/screens/Post/PostQuotes.tsx:32 src/screens/Post/PostQuotes.tsx:33
+#: src/screens/Post/PostQuotes.tsx:32
+#: src/screens/Post/PostQuotes.tsx:33
 msgid "Quotes"
 msgstr "Citazioni"
 
@@ -4910,8 +5061,8 @@ msgstr "Selezione a caso (nota anche come \"Poster's Roulette\")"
 msgid "Rate limit exceeded – you've tried to change your handle too many times in a short period. Please wait a minute before trying again."
 msgstr "Limite di richieste superato: hai provato a cambiare il nome utente troppe volte in un breve lasso di tempo. Attendi un minuto prima di riprovare."
 
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:547
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:557
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:565
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:575
 msgid "Re-attach quote"
 msgstr "Riattacca citazioni"
 
@@ -4953,7 +5104,8 @@ msgstr "Ricarica notifiche"
 msgid "Reload conversations"
 msgstr "Ricarica conversazioni"
 
-#: src/components/dialogs/MutedWords.tsx:438 src/components/FeedCard.tsx:316
+#: src/components/dialogs/MutedWords.tsx:438
+#: src/components/FeedCard.tsx:316
 #: src/components/StarterPack/Wizard/WizardListCard.tsx:101
 #: src/components/StarterPack/Wizard/WizardListCard.tsx:108
 #: src/screens/Settings/Settings.tsx:458
@@ -4968,7 +5120,8 @@ msgstr "Rimuovi"
 msgid "Remove {displayName} from starter pack"
 msgstr "Rimuovi {displayName} dallo starter pack"
 
-#: src/screens/Settings/Settings.tsx:437 src/screens/Settings/Settings.tsx:440
+#: src/screens/Settings/Settings.tsx:437
+#: src/screens/Settings/Settings.tsx:440
 msgid "Remove account"
 msgstr "Rimuovi account"
 
@@ -5000,12 +5153,15 @@ msgstr "Rimuovere il feed?"
 
 #: src/view/com/feeds/FeedSourceCard.tsx:190
 #: src/view/com/feeds/FeedSourceCard.tsx:268
-#: src/view/screens/ProfileFeed.tsx:337 src/view/screens/ProfileFeed.tsx:343
-#: src/view/screens/ProfileList.tsx:502 src/view/screens/SavedFeeds.tsx:351
+#: src/view/screens/ProfileFeed.tsx:337
+#: src/view/screens/ProfileFeed.tsx:343
+#: src/view/screens/ProfileList.tsx:502
+#: src/view/screens/SavedFeeds.tsx:351
 msgid "Remove from my feeds"
 msgstr "Rimuovi dai miei feed"
 
-#: src/components/FeedCard.tsx:311 src/view/com/feeds/FeedSourceCard.tsx:314
+#: src/components/FeedCard.tsx:311
+#: src/view/com/feeds/FeedSourceCard.tsx:314
 msgid "Remove from my feeds?"
 msgstr "Rimuovere dai miei feed?"
 
@@ -5073,7 +5229,8 @@ msgid "Removed from saved feeds"
 msgstr "Rimosso dai feed salvati"
 
 #: src/view/com/posts/FeedShutdownMsg.tsx:44
-#: src/view/screens/ProfileFeed.tsx:197 src/view/screens/ProfileList.tsx:386
+#: src/view/screens/ProfileFeed.tsx:197
+#: src/view/screens/ProfileList.tsx:386
 msgid "Removed from your feeds"
 msgstr "Rimosso dai tuoi feed"
 
@@ -5098,7 +5255,7 @@ msgstr "Risposte disattivate"
 msgid "Replies to this post are disabled."
 msgstr "Le risposte a questo post sono disattivate."
 
-#: src/view/com/composer/Composer.tsx:917
+#: src/view/com/composer/Composer.tsx:933
 msgctxt "action"
 msgid "Reply"
 msgstr "Risposta"
@@ -5121,7 +5278,8 @@ msgstr "Impostazioni risposte"
 msgid "Reply settings are chosen by the author of the thread"
 msgstr "Le impostazioni delle risposte sono scelte dall'autore del thread"
 
-#: src/view/com/post/Post.tsx:204 src/view/com/posts/FeedItem.tsx:553
+#: src/view/com/post/Post.tsx:204
+#: src/view/com/posts/FeedItem.tsx:553
 msgctxt "description"
 msgid "Reply to <0><1/></0>"
 msgstr "Risposta a <0><1/></0>"
@@ -5136,16 +5294,17 @@ msgctxt "description"
 msgid "Reply to a post"
 msgstr "Rispondi ad un post"
 
-#: src/view/com/post/Post.tsx:202 src/view/com/posts/FeedItem.tsx:550
+#: src/view/com/post/Post.tsx:202
+#: src/view/com/posts/FeedItem.tsx:550
 msgctxt "description"
 msgid "Reply to you"
 msgstr "Risposta a te"
 
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:327
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:333
 msgid "Reply visibility updated"
 msgstr "Visibilità risposte aggiornata"
 
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:326
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:332
 msgid "Reply was successfully hidden"
 msgstr "Risposta nascosta con successo"
 
@@ -5160,7 +5319,8 @@ msgstr "Segnala"
 msgid "Report Account"
 msgstr "Segnala l'account"
 
-#: src/components/dms/ConvoMenu.tsx:197 src/components/dms/ConvoMenu.tsx:200
+#: src/components/dms/ConvoMenu.tsx:197
+#: src/components/dms/ConvoMenu.tsx:200
 #: src/components/dms/ReportConversationPrompt.tsx:17
 msgid "Report conversation"
 msgstr "Segnala la conversazione"
@@ -5169,7 +5329,8 @@ msgstr "Segnala la conversazione"
 msgid "Report dialog"
 msgstr "Segnala il dialogo"
 
-#: src/view/screens/ProfileFeed.tsx:354 src/view/screens/ProfileFeed.tsx:356
+#: src/view/screens/ProfileFeed.tsx:354
+#: src/view/screens/ProfileFeed.tsx:356
 msgid "Report feed"
 msgstr "Segnala il feed"
 
@@ -5181,8 +5342,8 @@ msgstr "Segnala la lista"
 msgid "Report message"
 msgstr "Segnala il messaggio"
 
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:583
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:585
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:611
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:613
 msgid "Report post"
 msgstr "Segnala il post"
 
@@ -5223,15 +5384,15 @@ msgstr "Segnala questo utente"
 
 #: src/view/com/util/post-ctrls/RepostButton.tsx:68
 #: src/view/com/util/post-ctrls/RepostButton.tsx:146
-#: src/view/com/util/post-ctrls/RepostButton.tsx:156
+#: src/view/com/util/post-ctrls/RepostButton.tsx:157
 msgctxt "action"
 msgid "Repost"
-msgstr "Ripubblicare"
+msgstr "Repost"
 
 #: src/view/com/util/post-ctrls/RepostButton.web.tsx:72
 #: src/view/com/util/post-ctrls/RepostButton.web.tsx:76
 msgid "Repost"
-msgstr "Ripubblicare"
+msgstr "Repost"
 
 #: src/screens/StarterPack/StarterPackScreen.tsx:547
 #: src/view/com/util/post-ctrls/RepostButton.tsx:138
@@ -5253,7 +5414,8 @@ msgstr "Ripubblicato da{0}"
 msgid "Reposted by <0><1/></0>"
 msgstr "Ripubblicato da <0><1/></0>"
 
-#: src/view/com/posts/FeedItem.tsx:301 src/view/com/posts/FeedItem.tsx:320
+#: src/view/com/posts/FeedItem.tsx:301
+#: src/view/com/posts/FeedItem.tsx:320
 msgid "Reposted by you"
 msgstr "Ripubblicato da te"
 
@@ -5311,7 +5473,8 @@ msgstr "Reimpostare il codice"
 msgid "Reset Code"
 msgstr "Reimposta il Codice"
 
-#: src/screens/Settings/Settings.tsx:335 src/screens/Settings/Settings.tsx:337
+#: src/screens/Settings/Settings.tsx:335
+#: src/screens/Settings/Settings.tsx:337
 msgid "Reset onboarding state"
 msgstr "Reimposta lo stato dell' incorporazione"
 
@@ -5328,10 +5491,12 @@ msgstr "Ritenta l'accesso"
 msgid "Retries the last action, which errored out"
 msgstr "Ritenta l'ultima azione che ha generato un errore"
 
-#: src/components/dms/MessageItem.tsx:244 src/components/Error.tsx:65
+#: src/components/dms/MessageItem.tsx:245
+#: src/components/Error.tsx:65
 #: src/components/Lists.tsx:104
 #: src/components/StarterPack/ProfileStarterPacks.tsx:336
-#: src/screens/Login/LoginForm.tsx:295 src/screens/Login/LoginForm.tsx:302
+#: src/screens/Login/LoginForm.tsx:295
+#: src/screens/Login/LoginForm.tsx:302
 #: src/screens/Messages/components/MessageListError.tsx:25
 #: src/screens/Onboarding/StepInterests/index.tsx:217
 #: src/screens/Onboarding/StepInterests/index.tsx:220
@@ -5343,7 +5508,8 @@ msgstr "Ritenta l'ultima azione che ha generato un errore"
 msgid "Retry"
 msgstr "Riprova"
 
-#: src/components/Error.tsx:73 src/screens/List/ListHiddenScreen.tsx:205
+#: src/components/Error.tsx:73
+#: src/screens/List/ListHiddenScreen.tsx:205
 #: src/screens/StarterPack/StarterPackScreen.tsx:751
 #: src/view/screens/ProfileList.tsx:1030
 msgid "Return to previous page"
@@ -5353,7 +5519,8 @@ msgstr "Ritorna alla pagina precedente"
 msgid "Returns to home page"
 msgstr "Ritorna alla home"
 
-#: src/view/screens/NotFound.tsx:60 src/view/screens/ProfileFeed.tsx:114
+#: src/view/screens/NotFound.tsx:60
+#: src/view/screens/ProfileFeed.tsx:114
 msgid "Returns to previous page"
 msgstr "Ritorna alla pagina precedente"
 
@@ -5371,7 +5538,8 @@ msgstr "Ritorna alla pagina precedente"
 #: src/view/com/composer/photos/ImageAltTextDialog.tsx:150
 #: src/view/com/composer/photos/ImageAltTextDialog.tsx:160
 #: src/view/com/modals/CreateOrEditList.tsx:317
-#: src/view/com/modals/EditProfile.tsx:219 src/view/screens/SavedFeeds.tsx:103
+#: src/view/com/modals/EditProfile.tsx:219
+#: src/view/screens/SavedFeeds.tsx:103
 msgid "Save"
 msgstr "Salva"
 
@@ -5385,7 +5553,8 @@ msgstr "Salva"
 msgid "Save birthday"
 msgstr "Salva il compleanno"
 
-#: src/view/screens/SavedFeeds.tsx:98 src/view/screens/SavedFeeds.tsx:103
+#: src/view/screens/SavedFeeds.tsx:98
+#: src/view/screens/SavedFeeds.tsx:103
 msgid "Save changes"
 msgstr "Salva modifiche"
 
@@ -5410,7 +5579,8 @@ msgstr "Salva nuovo nome utente"
 msgid "Save QR code"
 msgstr "Salva codice QR"
 
-#: src/view/screens/ProfileFeed.tsx:338 src/view/screens/ProfileFeed.tsx:344
+#: src/view/screens/ProfileFeed.tsx:338
+#: src/view/screens/ProfileFeed.tsx:344
 msgid "Save to my feeds"
 msgstr "Salva nei miei feed"
 
@@ -5422,7 +5592,8 @@ msgstr "Canali salvati"
 msgid "Saved to your camera roll"
 msgstr "Salvata nella tua galleria"
 
-#: src/view/screens/ProfileFeed.tsx:206 src/view/screens/ProfileList.tsx:366
+#: src/view/screens/ProfileFeed.tsx:206
+#: src/view/screens/ProfileList.tsx:366
 msgid "Saved to your feeds"
 msgstr "Salvato nei tuoi feed"
 
@@ -5441,7 +5612,8 @@ msgstr "Salva le impostazioni di ritaglio dell'immagine"
 msgid "Say hello!"
 msgstr "Di' ciao!"
 
-#: src/screens/Onboarding/index.tsx:33 src/screens/Onboarding/state.ts:99
+#: src/screens/Onboarding/index.tsx:33
+#: src/screens/Onboarding/state.ts:99
 msgid "Science"
 msgstr "Scienza"
 
@@ -5451,11 +5623,13 @@ msgstr "Scorri verso l'alto"
 
 #: src/components/dms/dialogs/SearchablePeopleList.tsx:484
 #: src/components/forms/SearchInput.tsx:34
-#: src/components/forms/SearchInput.tsx:36 src/Navigation.tsx:590
+#: src/components/forms/SearchInput.tsx:36
+#: src/Navigation.tsx:584
 #: src/view/com/modals/ListAddRemoveUsers.tsx:76
 #: src/view/screens/Search/Search.tsx:594
 #: src/view/shell/bottom-bar/BottomBar.tsx:178
-#: src/view/shell/desktop/LeftNav.tsx:419 src/view/shell/Drawer.tsx:365
+#: src/view/shell/desktop/LeftNav.tsx:419
+#: src/view/shell/Drawer.tsx:365
 msgid "Search"
 msgstr "Cerca"
 
@@ -5516,9 +5690,9 @@ msgstr "Vedi offerte di lavoro in Bluesky"
 msgid "See this guide"
 msgstr "Consulta questa guida"
 
-#: src/view/com/util/post-embeds/VideoEmbedInner/web-controls/Scrubber.tsx:189
-msgid "Seek slider"
-msgstr "Cursore di ricerca"
+#: src/view/com/util/post-embeds/VideoEmbedInner/web-controls/Scrubber.tsx:190
+msgid "Seek slider. Use the arrow keys to seek forwards and backwards, and space to play/pause"
+msgstr "Cursore di ricerca. Utilizza i tasti freccia per cercare avanti e indietro, lo spazio per riprodurre/mettere in pausa"
 
 #: src/screens/Onboarding/StepProfile/AvatarCreatorItems.tsx:67
 msgid "Select a color"
@@ -5584,7 +5758,7 @@ msgstr "Seleziona il/i servizio/i di moderazione per fare la segnalazione"
 msgid "Select the service that hosts your data."
 msgstr "Seleziona il servizio che ospita i tuoi dati."
 
-#: src/view/com/composer/videos/SelectVideoBtn.tsx:106
+#: src/view/com/composer/videos/SelectVideoBtn.tsx:100
 msgid "Select video"
 msgstr "Seleziona video"
 
@@ -5615,6 +5789,10 @@ msgstr "Seleziona la tua lingua preferita per le traduzioni nel tuo feed."
 #: src/components/dms/ChatEmptyPill.tsx:38
 msgid "Send a neat website!"
 msgstr "Consiglia un sito!"
+
+#: src/screens/Settings/ContentAndMediaSettings.tsx:118
+msgid "Send Bluesky referrer"
+msgstr "Invia referrer di Bluesky"
 
 #: src/components/dialogs/VerifyEmailDialog.tsx:232
 msgid "Send Confirmation"
@@ -5667,8 +5845,8 @@ msgstr "Invia la segnalazione a {0}"
 msgid "Send verification email"
 msgstr "Invia la email di verifica"
 
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:405
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:408
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:423
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:426
 msgid "Send via direct message"
 msgstr "Invia tramite messaggi"
 
@@ -5688,7 +5866,7 @@ msgstr "Imposta la data di nascita"
 msgid "Set new password"
 msgstr "Imposta una nuova password"
 
-#: src/screens/Onboarding/Layout.tsx:48
+#: src/screens/Onboarding/Layout.tsx:49
 msgid "Set up your account"
 msgstr "Configura il tuo account"
 
@@ -5696,8 +5874,10 @@ msgstr "Configura il tuo account"
 msgid "Sets email for password reset"
 msgstr "Imposta l'email per la reimpostazione della password"
 
-#: src/Navigation.tsx:158 src/screens/Settings/Settings.tsx:76
-#: src/view/shell/desktop/LeftNav.tsx:511 src/view/shell/Drawer.tsx:529
+#: src/Navigation.tsx:158
+#: src/screens/Settings/Settings.tsx:76
+#: src/view/shell/desktop/LeftNav.tsx:511
+#: src/view/shell/Drawer.tsx:529
 msgid "Settings"
 msgstr "Impostazioni"
 
@@ -5714,8 +5894,8 @@ msgstr "Sessualmente allusivo"
 #: src/screens/StarterPack/StarterPackScreen.tsx:594
 #: src/view/com/profile/ProfileMenu.tsx:195
 #: src/view/com/profile/ProfileMenu.tsx:204
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:416
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:425
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:434
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:443
 #: src/view/com/util/post-ctrls/PostCtrls.tsx:339
 #: src/view/screens/ProfileList.tsx:487
 msgid "Share"
@@ -5735,12 +5915,13 @@ msgid "Share a fun fact!"
 msgstr "Condividi un fatto divertente!"
 
 #: src/view/com/profile/ProfileMenu.tsx:353
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:662
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:691
 #: src/view/com/util/post-ctrls/PostCtrls.tsx:355
 msgid "Share anyway"
 msgstr "Condividi comunque"
 
-#: src/view/screens/ProfileFeed.tsx:364 src/view/screens/ProfileFeed.tsx:366
+#: src/view/screens/ProfileFeed.tsx:364
+#: src/view/screens/ProfileFeed.tsx:366
 msgid "Share feed"
 msgstr "Condividi il feed"
 
@@ -5817,28 +5998,29 @@ msgstr "Mostra risposte nascoste"
 msgid "Show information about when this post was created"
 msgstr "Mostra informazioni sulla data di creazione di questo post."
 
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:455
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:457
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:473
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:475
 msgid "Show less like this"
 msgstr "Mostra meno come questo"
 
 #: src/screens/List/ListHiddenScreen.tsx:172
 msgid "Show list anyway"
-msgstr "Mosta comunque questa lista"
+msgstr "Mostra comunque lista"
 
 #: src/view/com/post-thread/PostThreadItem.tsx:588
-#: src/view/com/post/Post.tsx:242 src/view/com/posts/FeedItem.tsx:509
+#: src/view/com/post/Post.tsx:242
+#: src/view/com/posts/FeedItem.tsx:509
 msgid "Show More"
 msgstr "Mostra di più"
 
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:447
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:449
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:465
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:467
 msgid "Show more like this"
-msgstr "Mosta altro come questo"
+msgstr "Mostra altri come questo"
 
 #: src/view/com/post-thread/PostThreadShowHiddenReplies.tsx:22
 msgid "Show muted replies"
-msgstr "Mosta risposte silenziate"
+msgstr "Mostra risposte silenziate"
 
 #: src/screens/Settings/Settings.tsx:96
 msgid "Show other accounts you can switch to"
@@ -5862,8 +6044,8 @@ msgstr "Mostra risposte delle persone che segui prima delle altre risposte"
 msgid "Show replies in a threaded view"
 msgstr "Mostra risposte in modalità a thread"
 
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:521
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:531
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:539
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:549
 msgid "Show reply for everyone"
 msgstr "Mostra risposta per tutti"
 
@@ -5890,9 +6072,12 @@ msgstr "Mostra avviso"
 msgid "Show warning and filter from feeds"
 msgstr "Mostra avviso e filtra dai feed"
 
-#: src/components/dialogs/Signin.tsx:97 src/components/dialogs/Signin.tsx:99
-#: src/screens/Login/index.tsx:97 src/screens/Login/index.tsx:116
-#: src/screens/Login/LoginForm.tsx:163 src/view/com/auth/SplashScreen.tsx:61
+#: src/components/dialogs/Signin.tsx:97
+#: src/components/dialogs/Signin.tsx:99
+#: src/screens/Login/index.tsx:97
+#: src/screens/Login/index.tsx:116
+#: src/screens/Login/LoginForm.tsx:163
+#: src/view/com/auth/SplashScreen.tsx:61
 #: src/view/com/auth/SplashScreen.tsx:69
 #: src/view/com/auth/SplashScreen.web.tsx:123
 #: src/view/com/auth/SplashScreen.web.tsx:131
@@ -5902,7 +6087,8 @@ msgstr "Mostra avviso e filtra dai feed"
 #: src/view/shell/bottom-bar/BottomBarWeb.tsx:205
 #: src/view/shell/bottom-bar/BottomBarWeb.tsx:206
 #: src/view/shell/bottom-bar/BottomBarWeb.tsx:208
-#: src/view/shell/NavSignupCard.tsx:57 src/view/shell/NavSignupCard.tsx:62
+#: src/view/shell/NavSignupCard.tsx:57
+#: src/view/shell/NavSignupCard.tsx:62
 msgid "Sign in"
 msgstr "Accedi"
 
@@ -5922,7 +6108,8 @@ msgstr "Accedi o crea il tuo account per partecipare alla conversazione!"
 msgid "Sign into Bluesky or create a new account"
 msgstr "Accedi a Bluesky o crea un nuovo account"
 
-#: src/screens/Settings/Settings.tsx:217 src/screens/Settings/Settings.tsx:219
+#: src/screens/Settings/Settings.tsx:217
+#: src/screens/Settings/Settings.tsx:219
 #: src/screens/Settings/Settings.tsx:251
 msgid "Sign out"
 msgstr "Esci"
@@ -5937,7 +6124,8 @@ msgstr "Uscire?"
 #: src/view/shell/bottom-bar/BottomBarWeb.tsx:195
 #: src/view/shell/bottom-bar/BottomBarWeb.tsx:196
 #: src/view/shell/bottom-bar/BottomBarWeb.tsx:198
-#: src/view/shell/NavSignupCard.tsx:47 src/view/shell/NavSignupCard.tsx:52
+#: src/view/shell/NavSignupCard.tsx:47
+#: src/view/shell/NavSignupCard.tsx:52
 msgid "Sign up"
 msgstr "Iscrizione"
 
@@ -5973,7 +6161,8 @@ msgstr "Salta"
 msgid "Smaller"
 msgstr "Più piccolo"
 
-#: src/screens/Onboarding/index.tsx:37 src/screens/Onboarding/state.ts:87
+#: src/screens/Onboarding/index.tsx:37
+#: src/screens/Onboarding/state.ts:87
 msgid "Software Dev"
 msgstr "Sviluppo Software"
 
@@ -6005,7 +6194,8 @@ msgstr "Qualcosa è andato male, prova di nuovo."
 msgid "Something went wrong!"
 msgstr "Qualcosa è andato storto!"
 
-#: src/App.native.tsx:113 src/App.web.tsx:95
+#: src/App.native.tsx:113
+#: src/App.web.tsx:95
 msgid "Sorry! Your session expired. Please log in again."
 msgstr "La tua sessione è scaduta: accedi di nuovo."
 
@@ -6034,7 +6224,12 @@ msgstr "Spam"
 msgid "Spam; excessive mentions or replies"
 msgstr "Spam; menzioni o risposte eccessive"
 
-#: src/screens/Onboarding/index.tsx:27 src/screens/Onboarding/state.ts:100
+#: src/screens/Settings/ContentAndMediaSettings.tsx:112
+msgid "Specify Bluesky as a referer"
+msgstr "Indica Blesky come referrer"
+
+#: src/screens/Onboarding/index.tsx:27
+#: src/screens/Onboarding/state.ts:100
 msgid "Sports"
 msgstr "Sports"
 
@@ -6046,7 +6241,8 @@ msgstr "Avvia una nuova conversazione"
 msgid "Start chat with {displayName}"
 msgstr "Avvia conversazione con {displayName}"
 
-#: src/Navigation.tsx:393 src/Navigation.tsx:398
+#: src/Navigation.tsx:393
+#: src/Navigation.tsx:398
 #: src/screens/StarterPack/Wizard/index.tsx:191
 msgid "Starter Pack"
 msgstr "Starter Pack"
@@ -6084,7 +6280,8 @@ msgstr "Step {0} di {1}"
 msgid "Storage cleared, you need to restart the app now."
 msgstr "Spazio di archiviazione eliminato. Riavvia l'app."
 
-#: src/Navigation.tsx:244 src/screens/Settings/Settings.tsx:316
+#: src/Navigation.tsx:244
+#: src/screens/Settings/Settings.tsx:316
 msgid "Storybook"
 msgstr "Cronologia"
 
@@ -6132,12 +6329,14 @@ msgstr "Suggerito per te"
 msgid "Suggestive"
 msgstr "Suggestivo"
 
-#: src/Navigation.tsx:264 src/view/screens/Support.tsx:31
+#: src/Navigation.tsx:264
+#: src/view/screens/Support.tsx:31
 #: src/view/screens/Support.tsx:34
 msgid "Support"
 msgstr "Supporto"
 
-#: src/screens/Settings/Settings.tsx:94 src/screens/Settings/Settings.tsx:108
+#: src/screens/Settings/Settings.tsx:94
+#: src/screens/Settings/Settings.tsx:108
 #: src/screens/Settings/Settings.tsx:403
 msgid "Switch account"
 msgstr "Cambia account"
@@ -6195,7 +6394,8 @@ msgstr "Completato - 10 like!"
 msgid "Teach our algorithm what you like"
 msgstr "Insegna all'algoritmo cosa ti piace"
 
-#: src/screens/Onboarding/index.tsx:36 src/screens/Onboarding/state.ts:101
+#: src/screens/Onboarding/index.tsx:36
+#: src/screens/Onboarding/state.ts:101
 msgid "Tech"
 msgstr "Tecnologia"
 
@@ -6215,9 +6415,11 @@ msgstr "Dicci un po' di più"
 msgid "Terms"
 msgstr "Termini"
 
-#: src/Navigation.tsx:274 src/screens/Settings/AboutSettings.tsx:29
+#: src/Navigation.tsx:274
+#: src/screens/Settings/AboutSettings.tsx:29
 #: src/screens/Settings/AboutSettings.tsx:32
-#: src/view/screens/TermsOfService.tsx:31 src/view/shell/Drawer.tsx:617
+#: src/view/screens/TermsOfService.tsx:31
+#: src/view/shell/Drawer.tsx:617
 #: src/view/shell/Drawer.tsx:619
 msgid "Terms of Service"
 msgstr "Termini di servizio"
@@ -6319,7 +6521,7 @@ msgstr "Al tuo account sono state applicate le seguenti etichette."
 msgid "The following labels were applied to your content."
 msgstr "Ai tuoi contenuti sono state applicate le seguenti etichette."
 
-#: src/screens/Onboarding/Layout.tsx:58
+#: src/screens/Onboarding/Layout.tsx:59
 msgid "The following steps will help customize your Bluesky experience."
 msgstr "I passaggi seguenti ti aiuteranno a personalizzare la tua esperienza con Bluesky."
 
@@ -6332,7 +6534,7 @@ msgstr "Il post potrebbe essere stato eliminato."
 msgid "The Privacy Policy has been moved to <0/>"
 msgstr "L'informativa sulla privacy è stata spostata a <0/>"
 
-#: src/view/com/composer/state/video.ts:408
+#: src/view/com/composer/state/video.ts:395
 msgid "The selected video is larger than 50MB."
 msgstr "Questo video è più grande di 50MB."
 
@@ -6368,8 +6570,10 @@ msgstr "Non c'è limite di tempo per la disattivazione dell'account, torna quand
 msgid "There was an issue connecting to Tenor."
 msgstr "Si è verificato un problema durante la connessione a Tenor."
 
-#: src/view/screens/ProfileFeed.tsx:240 src/view/screens/ProfileList.tsx:369
-#: src/view/screens/ProfileList.tsx:388 src/view/screens/SavedFeeds.tsx:86
+#: src/view/screens/ProfileFeed.tsx:240
+#: src/view/screens/ProfileList.tsx:369
+#: src/view/screens/ProfileList.tsx:388
+#: src/view/screens/SavedFeeds.tsx:86
 msgid "There was an issue contacting the server"
 msgstr "Si è verificato un problema durante il contatto con il server"
 
@@ -6387,7 +6591,7 @@ msgstr "Si è verificato un problema durante il contatto con il tuo server"
 msgid "There was an issue fetching notifications. Tap here to try again."
 msgstr "Si è verificato un problema durante il recupero delle notifiche. Tocca qui per riprovare."
 
-#: src/view/com/posts/Feed.tsx:523
+#: src/view/com/posts/Feed.tsx:458
 msgid "There was an issue fetching posts. Tap here to try again."
 msgstr "Si è verificato un problema nel recupero dei post. Tocca qui per riprovare."
 
@@ -6434,6 +6638,7 @@ msgstr "Si è verificato un problema durante l'aggiornamento dei tuoi feed. Veri
 #: src/view/com/profile/ProfileMenu.tsx:136
 #: src/view/com/profile/ProfileMenu.tsx:149
 #: src/view/com/profile/ProfileMenu.tsx:161
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:364
 msgid "There was an issue! {0}"
 msgstr "Si è verificato un problema! {0}"
 
@@ -6441,8 +6646,10 @@ msgstr "Si è verificato un problema! {0}"
 #: src/screens/List/ListHiddenScreen.tsx:63
 #: src/screens/List/ListHiddenScreen.tsx:77
 #: src/screens/List/ListHiddenScreen.tsx:99
-#: src/view/screens/ProfileList.tsx:400 src/view/screens/ProfileList.tsx:413
-#: src/view/screens/ProfileList.tsx:426 src/view/screens/ProfileList.tsx:439
+#: src/view/screens/ProfileList.tsx:400
+#: src/view/screens/ProfileList.tsx:413
+#: src/view/screens/ProfileList.tsx:426
+#: src/view/screens/ProfileList.tsx:439
 msgid "There was an issue. Please check your internet connection and try again."
 msgstr "Si è verificato un problema. Verifica la tua connessione a internet e prova di nuovo."
 
@@ -6525,7 +6732,8 @@ msgid "This feed is empty! You may need to follow more users or tune your langua
 msgstr "Questo feed è vuoto! Prova a seguire più utenti o ottimizza le impostazioni della lingua."
 
 #: src/components/StarterPack/Main/PostsList.tsx:36
-#: src/view/screens/ProfileFeed.tsx:478 src/view/screens/ProfileList.tsx:788
+#: src/view/screens/ProfileFeed.tsx:478
+#: src/view/screens/ProfileList.tsx:788
 msgid "This feed is empty."
 msgstr "Questo feed è vuoto."
 
@@ -6585,16 +6793,16 @@ msgstr "Questo post dichiara di essere stato creato il <0>{0}</0>, ma è stato v
 msgid "This post has been deleted."
 msgstr "Questo post è stato eliminato."
 
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:659
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:688
 #: src/view/com/util/post-ctrls/PostCtrls.tsx:352
 msgid "This post is only visible to logged-in users. It won't be visible to people who aren't logged in."
 msgstr "Questo post è visibile solo agli utenti registrati. Non sarà visibile alle persone che non hanno effettuato l'accesso."
 
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:640
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:669
 msgid "This post will be hidden from feeds and threads. This cannot be undone."
 msgstr "Questo post verrà nascosto dai feed e dai thread. L'azione è irreversibile."
 
-#: src/view/com/composer/Composer.tsx:407
+#: src/view/com/composer/Composer.tsx:413
 msgid "This post's author has disabled quote posts."
 msgstr "L'autore di questo post ha disattivato le citazioni."
 
@@ -6602,7 +6810,7 @@ msgstr "L'autore di questo post ha disattivato le citazioni."
 msgid "This profile is only visible to logged-in users. It won't be visible to people who aren't logged in."
 msgstr "Questo profilo è visibile solo agli utenti registrati. Non sarà visibile alle persone che non hanno effettuato l'accesso."
 
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:702
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:731
 msgid "This reply will be sorted into a hidden section at the bottom of your thread and will mute notifications for subsequent replies - both for yourself and others."
 msgstr "Questa risposta verrà spostata in una sezione nascosta in basso al thread e disattiverà le notifiche delle risposte - sia per te che per gli altri."
 
@@ -6655,12 +6863,12 @@ msgstr "Questo eliminerà \"{0}\" dalle tue parole silenziate. Puoi riaggiungerl
 msgid "This will remove @{0} from the quick access list."
 msgstr "Questo rimuoverà @{0} dalla lista d'accesso rapido."
 
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:692
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:721
 msgid "This will remove your post from this quote post for all users, and replace it with a placeholder."
 msgstr "Questo rimuoverà il tuo post da questa citazione per tutti gli utenti, e la rimpiazzerà con un placeholder."
 
-#: src/screens/Settings/ContentAndMediaSettings.tsx:48
-#: src/screens/Settings/ContentAndMediaSettings.tsx:51
+#: src/screens/Settings/ContentAndMediaSettings.tsx:57
+#: src/screens/Settings/ContentAndMediaSettings.tsx:60
 msgid "Thread preferences"
 msgstr "Preferenze delle discussioni"
 
@@ -6676,6 +6884,10 @@ msgstr "Modalità a thread"
 msgid "Threads Preferences"
 msgstr "Preferenze per le discussioni"
 
+#: src/view/com/util/post-embeds/VideoEmbedInner/TimeIndicator.tsx:33
+msgid "Time remaining: {time} seconds"
+msgstr "Tempo rimanente: {time} secondi"
+
 #: src/screens/Settings/components/DisableEmail2FADialog.tsx:99
 msgid "To disable the email 2FA method, please verify your access to the email address."
 msgstr "Per disabilitare il metodo 2FA via e-mail, verifica il tuo accesso all'indirizzo e-mail."
@@ -6684,7 +6896,7 @@ msgstr "Per disabilitare il metodo 2FA via e-mail, verifica il tuo accesso all'i
 msgid "To report a conversation, please report one of its messages via the conversation screen. This lets our moderators understand the context of your issue."
 msgstr "Per segnalare una conversazione, segnala uno dei messaggi nella schermata della conversazione. Questo permetterà ai nostri moderatori di capire il contesto del problema."
 
-#: src/view/com/composer/videos/SelectVideoBtn.tsx:133
+#: src/view/com/composer/videos/SelectVideoBtn.tsx:127
 msgid "To upload videos to Bluesky, you must first verify your email."
 msgstr "Per caricare video su Bluesky, devi prima verificare la tua email."
 
@@ -6704,7 +6916,8 @@ msgstr "Attiva/disattiva il menu a discesa"
 msgid "Toggle to enable or disable adult content"
 msgstr "Seleziona per abilitare o disabilitare i contenuti per adulti"
 
-#: src/screens/Hashtag.tsx:87 src/view/screens/Search/Search.tsx:511
+#: src/screens/Hashtag.tsx:87
+#: src/view/screens/Search/Search.tsx:511
 msgid "Top"
 msgstr "Top"
 
@@ -6712,8 +6925,8 @@ msgstr "Top"
 #: src/components/dms/MessageMenu.tsx:105
 #: src/view/com/post-thread/PostThreadItem.tsx:761
 #: src/view/com/post-thread/PostThreadItem.tsx:764
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:386
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:388
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:404
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:406
 msgid "Translate"
 msgstr "Traduci"
 
@@ -6750,9 +6963,11 @@ msgstr "Riattiva questa lista"
 msgid "Unable to connect. Please check your internet connection and try again."
 msgstr "Impossibile connettersi. Verifica la tua connessione a internet e riprova."
 
-#: src/screens/Login/ForgotPasswordForm.tsx:68 src/screens/Login/index.tsx:76
+#: src/screens/Login/ForgotPasswordForm.tsx:68
+#: src/screens/Login/index.tsx:76
 #: src/screens/Login/LoginForm.tsx:152
-#: src/screens/Login/SetNewPasswordForm.tsx:71 src/screens/Signup/index.tsx:71
+#: src/screens/Login/SetNewPasswordForm.tsx:71
+#: src/screens/Signup/index.tsx:71
 #: src/view/com/modals/ChangePassword.tsx:71
 msgid "Unable to contact your service. Please check your Internet connection."
 msgstr "Impossibile contattare il servizio. Verifica la tua connessione a internet."
@@ -6777,7 +6992,8 @@ msgctxt "action"
 msgid "Unblock"
 msgstr "Sblocca"
 
-#: src/components/dms/ConvoMenu.tsx:188 src/components/dms/ConvoMenu.tsx:192
+#: src/components/dms/ConvoMenu.tsx:188
+#: src/components/dms/ConvoMenu.tsx:192
 msgid "Unblock account"
 msgstr "Sblocca l'account"
 
@@ -6815,12 +7031,13 @@ msgstr "Smetti di seguire questo account"
 msgid "Unlike this feed"
 msgstr "Togli il like a questo feed"
 
-#: src/components/TagMenu/index.tsx:264 src/view/screens/ProfileList.tsx:692
+#: src/components/TagMenu/index.tsx:264
+#: src/view/screens/ProfileList.tsx:692
 msgid "Unmute"
 msgstr "Riattiva"
 
 #: src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerNative.tsx:155
-#: src/view/com/util/post-embeds/VideoEmbedInner/web-controls/VolumeControl.tsx:93
+#: src/view/com/util/post-embeds/VideoEmbedInner/web-controls/VolumeControl.tsx:94
 msgctxt "video"
 msgid "Unmute"
 msgstr "Attiva il suono"
@@ -6842,8 +7059,8 @@ msgstr "Riattiva tutti i post di {displayTag}"
 msgid "Unmute conversation"
 msgstr "Riattiva conversazione"
 
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:471
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:475
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:489
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:493
 msgid "Unmute thread"
 msgstr "Riattiva questa discussione"
 
@@ -6851,7 +7068,8 @@ msgstr "Riattiva questa discussione"
 msgid "Unmute video"
 msgstr "Riattiva auto"
 
-#: src/view/screens/ProfileFeed.tsx:296 src/view/screens/ProfileList.tsx:676
+#: src/view/screens/ProfileFeed.tsx:296
+#: src/view/screens/ProfileList.tsx:676
 msgid "Unpin"
 msgstr "Stacca dal profilo"
 
@@ -6859,8 +7077,8 @@ msgstr "Stacca dal profilo"
 msgid "Unpin from home"
 msgstr "Stacca dalla Home"
 
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:361
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:368
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:379
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:386
 msgid "Unpin from profile"
 msgstr "Rimuovi dal profilo"
 
@@ -6889,9 +7107,13 @@ msgstr "Disiscriviti da questo/a labeler"
 msgid "Unsubscribed from list"
 msgstr "Disiscritto dalla lista"
 
-#: src/view/com/composer/videos/SelectVideoBtn.tsx:72
-msgid "Unsupported video type: {mimeType}"
-msgstr "Tipo video non supportato: {mimeType}"
+#: src/view/com/composer/Composer.tsx:759
+msgid "Unsupported video type"
+msgstr "Tipo di video non supportato"
+
+#: src/view/com/composer/videos/SelectVideoBtn.tsx:66
+msgid "Unsupported video type: {0}"
+msgstr "Tipo di video non supportato: {0}"
 
 #: src/lib/moderation/useReportOptions.ts:77
 #: src/lib/moderation/useReportOptions.ts:90
@@ -6907,11 +7129,11 @@ msgstr "Aggiorna <0>{displayName}</0> nelle Liste"
 msgid "Update to {domain}"
 msgstr "Aggiorna a {domain}"
 
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:300
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:306
 msgid "Updating quote attachment failed"
 msgstr "Impossibile aggiornare allegato"
 
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:330
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:336
 msgid "Updating reply visibility failed"
 msgstr "Impossibile aggiornare visibilità risposte"
 
@@ -6927,17 +7149,22 @@ msgstr "Alternativamente carica una foto"
 msgid "Upload a text file to:"
 msgstr "Carica una file di testo a:"
 
-#: src/view/com/util/UserAvatar.tsx:371 src/view/com/util/UserAvatar.tsx:374
-#: src/view/com/util/UserBanner.tsx:123 src/view/com/util/UserBanner.tsx:126
+#: src/view/com/util/UserAvatar.tsx:371
+#: src/view/com/util/UserAvatar.tsx:374
+#: src/view/com/util/UserBanner.tsx:123
+#: src/view/com/util/UserBanner.tsx:126
 msgid "Upload from Camera"
 msgstr "Carica dalla fotocamera"
 
-#: src/view/com/util/UserAvatar.tsx:388 src/view/com/util/UserBanner.tsx:140
+#: src/view/com/util/UserAvatar.tsx:388
+#: src/view/com/util/UserBanner.tsx:140
 msgid "Upload from Files"
 msgstr "Carica dai Files"
 
-#: src/view/com/util/UserAvatar.tsx:382 src/view/com/util/UserAvatar.tsx:386
-#: src/view/com/util/UserBanner.tsx:134 src/view/com/util/UserBanner.tsx:138
+#: src/view/com/util/UserAvatar.tsx:382
+#: src/view/com/util/UserAvatar.tsx:386
+#: src/view/com/util/UserBanner.tsx:134
+#: src/view/com/util/UserBanner.tsx:138
 msgid "Upload from Library"
 msgstr "Carica dalla Libreria"
 
@@ -6945,11 +7172,12 @@ msgstr "Carica dalla Libreria"
 msgid "Uploading images..."
 msgstr "Caricamento immagini..."
 
-#: src/lib/api/index.ts:350 src/lib/api/index.ts:374
+#: src/lib/api/index.ts:350
+#: src/lib/api/index.ts:374
 msgid "Uploading link thumbnail..."
 msgstr "Caricamento miniatura del link..."
 
-#: src/view/com/composer/Composer.tsx:1626
+#: src/view/com/composer/Composer.tsx:1631
 msgid "Uploading video..."
 msgstr "Caricamento del video..."
 
@@ -6966,8 +7194,8 @@ msgstr "Utilizza il tuo provider predefinito"
 msgid "Use in-app browser"
 msgstr "Utilizza il browser dell'app"
 
-#: src/screens/Settings/ContentAndMediaSettings.tsx:74
-#: src/screens/Settings/ContentAndMediaSettings.tsx:80
+#: src/screens/Settings/ContentAndMediaSettings.tsx:96
+#: src/screens/Settings/ContentAndMediaSettings.tsx:102
 msgid "Use in-app browser to open links"
 msgstr "Utilizza il browser dell'app per aprire i link"
 
@@ -7050,7 +7278,8 @@ msgstr "Utenti"
 msgid "users followed by <0>@{0}</0>"
 msgstr "utenti seguiti da <0>@{0}</0>"
 
-#: src/screens/Messages/Settings.tsx:86 src/screens/Messages/Settings.tsx:89
+#: src/screens/Messages/Settings.tsx:86
+#: src/screens/Messages/Settings.tsx:89
 msgid "Users I follow"
 msgstr "Utenti che seguo"
 
@@ -7066,7 +7295,7 @@ msgstr "Utenti a cui è piaciuto questo contenuto o profilo"
 msgid "Value:"
 msgstr "Valore:"
 
-#: src/view/com/composer/videos/SelectVideoBtn.tsx:131
+#: src/view/com/composer/videos/SelectVideoBtn.tsx:125
 msgid "Verified email required"
 msgstr "Email verificata richiesta"
 
@@ -7085,7 +7314,7 @@ msgstr "Finestra verifica email"
 msgid "Verify New Email"
 msgstr "Verifica la nuova email"
 
-#: src/view/com/composer/videos/SelectVideoBtn.tsx:135
+#: src/view/com/composer/videos/SelectVideoBtn.tsx:129
 msgid "Verify now"
 msgstr "Verifica ora"
 
@@ -7114,11 +7343,12 @@ msgstr "Versione {appVersion}"
 msgid "Video"
 msgstr "Video"
 
-#: src/view/com/composer/state/video.ts:371
+#: src/view/com/composer/state/video.ts:358
 msgid "Video failed to process"
 msgstr "Elaborazione video fallita"
 
-#: src/screens/Onboarding/index.tsx:39 src/screens/Onboarding/state.ts:90
+#: src/screens/Onboarding/index.tsx:39
+#: src/screens/Onboarding/state.ts:90
 msgid "Video Games"
 msgstr "Video Games"
 
@@ -7130,7 +7360,7 @@ msgstr "Video non trovato."
 msgid "Video settings"
 msgstr "Settaggi video"
 
-#: src/view/com/composer/Composer.tsx:1636
+#: src/view/com/composer/Composer.tsx:1641
 msgid "Video uploaded"
 msgstr "Video caricato"
 
@@ -7138,8 +7368,8 @@ msgstr "Video caricato"
 msgid "Video: {0}"
 msgstr "Video: {0}"
 
-#: src/view/com/composer/videos/SelectVideoBtn.tsx:79
-#: src/view/com/composer/videos/VideoPreview.web.tsx:44
+#: src/view/com/composer/videos/SelectVideoBtn.tsx:58
+#: src/view/com/composer/videos/SelectVideoBtn.tsx:73
 msgid "Videos must be less than 60 seconds long"
 msgstr "I video devono essere più corti di 60 secondi"
 
@@ -7197,7 +7427,8 @@ msgstr "Visualizza le informazioni su queste etichette"
 #: src/components/ProfileHoverCard/index.web.tsx:466
 #: src/view/com/posts/AviFollowButton.tsx:55
 #: src/view/com/posts/FeedErrorMessage.tsx:175
-#: src/view/com/util/PostMeta.tsx:79 src/view/com/util/PostMeta.tsx:94
+#: src/view/com/util/PostMeta.tsx:79
+#: src/view/com/util/PostMeta.tsx:94
 msgid "View profile"
 msgstr "Vedi il profilo"
 
@@ -7218,7 +7449,7 @@ msgid "View your blocked accounts"
 msgstr "Vedi i tuoi account bloccati"
 
 #: src/view/com/home/HomeHeaderLayout.web.tsx:78
-#: src/view/com/home/HomeHeaderLayoutMobile.tsx:89
+#: src/view/com/home/HomeHeaderLayoutMobile.tsx:88
 msgid "View your feeds and explore more"
 msgstr "Vedi i tuoi feed e scoprine degli altri"
 
@@ -7234,6 +7465,10 @@ msgstr "Vedi i tuoi account silenziati"
 #: src/view/com/modals/LinkWarning.tsx:95
 msgid "Visit Site"
 msgstr "Visita il sito"
+
+#: src/view/com/util/post-embeds/VideoEmbedInner/web-controls/VolumeControl.tsx:80
+msgid "Volume"
+msgstr "Volume"
 
 #: src/components/moderation/LabelPreference.tsx:136
 #: src/lib/moderation/useLabelBehaviorDescription.ts:17
@@ -7273,7 +7508,7 @@ msgstr "Speriamo di darti dei momenti dei bei momenti. Ricorda, Bluesky è:"
 msgid "We ran out of posts from your follows. Here's the latest from <0/>."
 msgstr "Abbiamo esaurito i post di chi segui. Ecco le ultime novità da <0/>."
 
-#: src/view/com/composer/state/video.ts:430
+#: src/view/com/composer/state/video.ts:417
 msgid "We were unable to determine if you are allowed to upload videos. Please try again."
 msgstr "Non è stato possibile verificare se puoi caricare video. Riprova."
 
@@ -7317,11 +7552,12 @@ msgstr "Non è stato possibile caricare le parole silenziate: riprova."
 msgid "We're sorry, but your search could not be completed. Please try again in a few minutes."
 msgstr "Siamo spiacenti, ma non è stato possibile completare la ricerca. Riprova tra qualche minuto."
 
-#: src/view/com/composer/Composer.tsx:404
+#: src/view/com/composer/Composer.tsx:410
 msgid "We're sorry! The post you are replying to has been deleted."
 msgstr "Ci dispiace! Il post a cui cerchi di rispondere è stato eliminato."
 
-#: src/components/Lists.tsx:220 src/view/screens/NotFound.tsx:50
+#: src/components/Lists.tsx:220
+#: src/view/screens/NotFound.tsx:50
 msgid "We're sorry! We can't find the page you were looking for."
 msgstr "Ci dispiace! Non riusciamo a trovare la pagina che stavi cercando."
 
@@ -7347,7 +7583,7 @@ msgstr "Come vuoi chiamare il tuo starter pack?"
 
 #: src/view/com/auth/SplashScreen.tsx:38
 #: src/view/com/auth/SplashScreen.web.tsx:99
-#: src/view/com/composer/Composer.tsx:716
+#: src/view/com/composer/Composer.tsx:722
 msgid "What's up?"
 msgstr "Come va?"
 
@@ -7367,7 +7603,8 @@ msgstr "Chi puo interagire con questo post?"
 msgid "Who can reply"
 msgstr "Chi può rispondere"
 
-#: src/screens/Home/NoFeedsPinned.tsx:79 src/screens/Messages/ChatList.tsx:183
+#: src/screens/Home/NoFeedsPinned.tsx:79
+#: src/screens/Messages/ChatList.tsx:183
 msgid "Whoops!"
 msgstr "Ops!"
 
@@ -7404,16 +7641,17 @@ msgstr "Perché questo utente dovrebbe essere revisionato?"
 msgid "Write a message"
 msgstr "Scrivi un messaggio"
 
-#: src/view/com/composer/Composer.tsx:794
+#: src/view/com/composer/Composer.tsx:810
 msgid "Write post"
 msgstr "Scrivi un post"
 
-#: src/view/com/composer/Composer.tsx:714
+#: src/view/com/composer/Composer.tsx:720
 #: src/view/com/post-thread/PostThreadComposePrompt.tsx:70
 msgid "Write your reply"
 msgstr "Scrivi la tua risposta"
 
-#: src/screens/Onboarding/index.tsx:25 src/screens/Onboarding/state.ts:103
+#: src/screens/Onboarding/index.tsx:25
+#: src/screens/Onboarding/state.ts:103
 msgid "Writers"
 msgstr "Scrittori"
 
@@ -7434,11 +7672,11 @@ msgstr "Sì, disattiva il mio account"
 msgid "Yes, delete this starter pack"
 msgstr "Sì, elimina questo starter pack"
 
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:695
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:724
 msgid "Yes, detach"
 msgstr "Sì"
 
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:705
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:734
 msgid "Yes, hide"
 msgstr "Sì"
 
@@ -7462,7 +7700,7 @@ msgstr "Io"
 msgid "You are in line."
 msgstr "Sei nella lista."
 
-#: src/view/com/composer/state/video.ts:423
+#: src/view/com/composer/state/video.ts:410
 msgid "You are not allowed to upload videos."
 msgstr "Non sei autorizzato a caricare video."
 
@@ -7558,7 +7796,8 @@ msgstr "Non hai ancora nessuna conversazione. Avviane una!"
 msgid "You have no feeds."
 msgstr "Non hai feed."
 
-#: src/view/com/lists/MyLists.tsx:90 src/view/com/lists/ProfileLists.tsx:134
+#: src/view/com/lists/MyLists.tsx:90
+#: src/view/com/lists/ProfileLists.tsx:134
 msgid "You have no lists."
 msgstr "Non hai liste."
 
@@ -7568,7 +7807,7 @@ msgstr "Non hai ancora bloccato nessun account. Per bloccare un account, vai sul
 
 #: src/view/screens/ModerationMutedAccounts.tsx:132
 msgid "You have not muted any accounts yet. To mute an account, go to their profile and select \"Mute account\" from the menu on their account."
-msgstr "Non hai ancora silenziato nessun account. Per silenziare un account, vai al suo profilo e seleziona \"Silenzia account\" dal menu dell' account."
+msgstr "Non hai ancora silenziato nessun account. Per silenziare un account, vai sul suo profilo e seleziona \"Silenzia account\" dal menu dell' account."
 
 #: src/components/Lists.tsx:52
 msgid "You have reached the end"
@@ -7639,11 +7878,11 @@ msgstr "Hai precedentemente disattivato @{0}."
 msgid "You will be signed out of all your accounts."
 msgstr "Verrai disconnesso da tutti i tuoi account."
 
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:211
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:217
 msgid "You will no longer receive notifications for this thread"
 msgstr "Non riceverai più notifiche per questo filo di discussione"
 
-#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:207
+#: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:213
 msgid "You will now receive notifications for this thread"
 msgstr "Adesso riceverai le notifiche per questa discussione"
 
@@ -7709,11 +7948,11 @@ msgstr "Hai scelto di nascondere una parola o un tag in questo post."
 msgid "You've reached the end of your feed! Find some more accounts to follow."
 msgstr "Hai raggiunto la fine del tuo feed! Trova altri account da seguire."
 
-#: src/view/com/composer/state/video.ts:434
+#: src/view/com/composer/state/video.ts:421
 msgid "You've reached your daily limit for video uploads (too many bytes)"
 msgstr "Hai raggiunto il limite giornaliero di video caricati (troppi byte)"
 
-#: src/view/com/composer/state/video.ts:438
+#: src/view/com/composer/state/video.ts:425
 msgid "You've reached your daily limit for video uploads (too many videos)"
 msgstr "Hai raggiunto il limite giornaliero di video caricati (troppi video)"
 
@@ -7725,7 +7964,7 @@ msgstr "Il tuo account"
 msgid "Your account has been deleted"
 msgstr "Il tuo account è stato eliminato"
 
-#: src/view/com/composer/state/video.ts:442
+#: src/view/com/composer/state/video.ts:429
 msgid "Your account is not yet old enough to upload videos. Please try again later."
 msgstr "Il tuo account è troppo recente per caricare video. Riprova più tardi."
 
@@ -7749,7 +7988,8 @@ msgstr "Le tue conversazioni sonos state disabiltate"
 msgid "Your choice will be saved, but can be changed later in settings."
 msgstr "La tua scelta verrà salvata, ma potrà essere modificata successivamente nelle impostazioni."
 
-#: src/screens/Login/ForgotPasswordForm.tsx:51 src/screens/Signup/state.ts:203
+#: src/screens/Login/ForgotPasswordForm.tsx:51
+#: src/screens/Signup/state.ts:203
 #: src/screens/Signup/StepInfo/index.tsx:108
 #: src/view/com/modals/ChangePassword.tsx:55
 msgid "Your email appears to be invalid."
@@ -7787,11 +8027,11 @@ msgstr "Le tue parole silenziate"
 msgid "Your password has been changed successfully!"
 msgstr "La tua password è stata modificata correttamente!"
 
-#: src/view/com/composer/Composer.tsx:464
+#: src/view/com/composer/Composer.tsx:470
 msgid "Your post has been published"
 msgstr "Il tuo post è stato pubblicato"
 
-#: src/view/com/composer/Composer.tsx:461
+#: src/view/com/composer/Composer.tsx:467
 msgid "Your posts have been published"
 msgstr "I tuoi post sono stati pubblicati"
 
@@ -7803,7 +8043,7 @@ msgstr "I tuoi post, i tuoi Mi piace e i tuoi blocchi sono pubblici. I conti sil
 msgid "Your profile, posts, feeds, and lists will no longer be visible to other Bluesky users. You can reactivate your account at any time by logging in."
 msgstr "Il tuo profilo, post, feed, e liste non saranno più visibili agli altri utenti. Puoi riattivare il tuo account in qualsiasi momento effettuando l'accesso."
 
-#: src/view/com/composer/Composer.tsx:463
+#: src/view/com/composer/Composer.tsx:469
 msgid "Your reply has been published"
 msgstr "La tua risposta è stata pubblicata"
 

--- a/src/locale/locales/it/messages.po
+++ b/src/locale/locales/it/messages.po
@@ -1335,7 +1335,7 @@ msgstr "Clima"
 
 #: src/components/dms/ChatEmptyPill.tsx:39
 msgid "Clip 🐴 clop 🐴"
-msgstr "Clip 🐴 clop 🐴"
+msgstr "Clop 🐴 clop 🐴"
 
 #: src/components/dialogs/GifSelect.tsx:281
 #: src/components/dialogs/VerifyEmailDialog.tsx:289
@@ -1702,7 +1702,7 @@ msgstr "Crea uno starter pack per me"
 #: src/view/com/auth/SplashScreen.tsx:56
 #: src/view/com/auth/SplashScreen.web.tsx:117
 msgid "Create account"
-msgstr "Crea account"
+msgstr "Crea un account"
 
 #: src/screens/Signup/index.tsx:93
 msgid "Create Account"
@@ -1882,7 +1882,7 @@ msgstr "Descrizione"
 
 #: src/screens/Profile/Header/EditProfileDialog.tsx:364
 msgid "Description is too long"
-msgstr "La descrizione è troppo lunga"
+msgstr "Descrizione troppo lunga"
 
 #: src/screens/Profile/Header/EditProfileDialog.tsx:365
 msgid "Description is too long. The maximum number of characters is {DESCRIPTION_MAX_GRAPHEMES}."
@@ -2015,6 +2015,14 @@ msgstr "Pannello DNS"
 #: src/components/dialogs/MutedWords.tsx:302
 msgid "Do not apply this mute word to users you follow"
 msgstr "Non applicare questa parola silenziata agli utenti seguiti"
+
+#: src/view/com/composer/labels/LabelsBtn.tsx:174
+msgid "Does not contain adult content."
+msgstr "Non contiene materiale per adulti."
+
+#: src/view/com/composer/labels/LabelsBtn.tsx:213
+msgid "Does not contain graphic or disturbing content."
+msgstr ""
 
 #: src/lib/moderation/useGlobalLabelStrings.ts:39
 msgid "Does not include nudity."

--- a/src/locale/locales/it/messages.po
+++ b/src/locale/locales/it/messages.po
@@ -3,7 +3,7 @@ msgstr ""
 "Project-Id-Version: Italian localization\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2024-01-05 11:44+0530\n"
-"PO-Revision-Date: 2024-11-19 14:23+0100\n"
+"PO-Revision-Date: 2024-11-19 14:38+0100\n"
 "Last-Translator: Michele Locati <michele@locati.it>\n"
 "Language-Team: Gabriella Nonino\n"
 "Language: it\n"
@@ -6172,7 +6172,7 @@ msgstr "Solo tag"
 
 #: src/components/ProgressGuide/Toast.tsx:156
 msgid "Tap to dismiss"
-msgstr "Togga per ignorare"
+msgstr "Tocca per ignorare"
 
 #: src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerNative.tsx:136
 msgid "Tap to enter full screen"


### PR DESCRIPTION
I've added some missing translations, as well as fixed some ugly translations, and used always the same translation terms for some original translation terms (eg "handle" is now always "nome utente").