### PR TITLE
Help Siri to correctly pronounce Blue Sky.

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -92,8 +92,7 @@ module.exports = function (config) {
             'Used to save images to your library.',
           NSPhotoLibraryUsageDescription:
             'Used for profile pictures, posts, and other kinds of content',
-          CFBundleSpokenName:
-            'Blue Sky',
+          CFBundleSpokenName: 'Blue Sky',
         },
         associatedDomains: ASSOCIATED_DOMAINS,
         splash: {


### PR DESCRIPTION
Help Siri to correctly pronounce Blue Sky. Instead of pronouncing it like “Lebowski”, i.e. “bluski”.