### PR TITLE
Optimize ContentHider

### DIFF
--- a/src/components/moderation/ContentHider.tsx
+++ b/src/components/moderation/ContentHider.tsx
@@ -32,6 +32,37 @@ export function ContentHider({
   style?: StyleProp<ViewStyle>
   childContainerStyle?: StyleProp<ViewStyle>
 }>) {
+  const blur = modui?.blurs[0]
+  if (!blur || (ignoreMute && isJustAMute(modui))) {
+    return (
+      <View testID={testID} style={style}>
+        {children}
+      </View>
+    )
+  }
+  return (
+    <ContentHiderActive
+      testID={testID}
+      modui={modui}
+      style={style}
+      childContainerStyle={childContainerStyle}>
+      {children}
+    </ContentHiderActive>
+  )
+}
+
+function ContentHiderActive({
+  testID,
+  modui,
+  style,
+  childContainerStyle,
+  children,
+}: React.PropsWithChildren<{
+  testID?: string
+  modui: ModerationUI
+  style?: StyleProp<ViewStyle>
+  childContainerStyle?: StyleProp<ViewStyle>
+}>) {
   const t = useTheme()
   const {_} = useLingui()
   const {gtMobile} = useBreakpoints()
@@ -40,7 +71,6 @@ export function ContentHider({
   const {labelDefs} = useLabelDefinitions()
   const globalLabelStrings = useGlobalLabelStrings()
   const {i18n} = useLingui()
-
   const blur = modui?.blurs[0]
   const desc = useModerationCauseDescription(blur)
 
@@ -98,14 +128,6 @@ export function ContentHider({
     i18n.locale,
     globalLabelStrings,
   ])
-
-  if (!blur || (ignoreMute && isJustAMute(modui))) {
-    return (
-      <View testID={testID} style={style}>
-        {children}
-      </View>
-    )
-  }
 
   return (
     <View testID={testID} style={[a.overflow_hidden, style]}>


### PR DESCRIPTION
Currently inside the `ContentHider` we're running a lot of Hooks (which read context, loop through stuff, create intermediate object, memoize them, and so on). However, none of those values are used if there's no actual blurring.

I'm splitting the component in two. The top part is a fast path if there's no blurring.

Note that this means that if the "has blur" condition flips somehow while the component is onscreen (is this possible?), the state of the inner component will reinintialize from scratch. I'm not sure whether this is an issue.

## Test Plan

Verify both blurred and non-blurred posts show up. (You'll need to find some posts that are blurred under your settings.)

## Before

The `ContentHider` self-time shows up in traces:

<img width="358" alt="Screenshot 2024-11-18 at 17 08 59" src="https://github.com/user-attachments/assets/2c2bbdd6-2e27-457d-927e-ec6dcbf0504a">

## After

The `ContentHider` self-time doesn't show up in traces:

<img width="409" alt="Screenshot 2024-11-18 at 17 10 15" src="https://github.com/user-attachments/assets/82fbc91b-e884-4a1d-b59b-a7cd05e2ec74">
