### PR TITLE
Add base padding to Dialog.InnerFlatList

### DIFF
--- a/src/components/Dialog/index.tsx
+++ b/src/components/Dialog/index.tsx
@@ -275,6 +275,8 @@ export const InnerFlatList = React.forwardRef<
   const insets = useSafeAreaInsets()
   const {nativeSnapPoint, disableDrag, setDisableDrag} = useDialogContext()
 
+  const basePadding = isIOS ? 30 : 50
+
   const onScroll = (e: ReanimatedScrollEvent) => {
     'worklet'
     if (!isAndroid) {
@@ -294,7 +296,9 @@ export const InnerFlatList = React.forwardRef<
         keyboardShouldPersistTaps="handled"
         bounces={nativeSnapPoint === BottomSheetSnapPoint.Full}
         ListFooterComponent={
-          <View style={{height: insets.bottom + a.pt_5xl.paddingTop}} />
+          <View
+            style={{height: insets.bottom + basePadding + a.pt_5xl.paddingTop}}
+          />
         }
         ref={ref}
         {...props}


### PR DESCRIPTION
Adds the basePadding magic numbers from Dialog.ScrollableInner to Dialog.InnerFlatList, this fixes contents being cut off. This still isn't perfect as it's not square with the bottom without the extra padding applied but it's better than having them cut off.

**Before:**
![Screenshot_20241119-171828](https://github.com/user-attachments/assets/2248069f-30be-47ea-8e45-b658458b273f)


**After:**
![Screenshot_20241119-171615](https://github.com/user-attachments/assets/d8c376e2-d2d4-48e4-b58a-a6b12417aca7)
