### PR TITLE
Fix post interaction selectable text being cut off

### DIFF
--- a/src/components/dialogs/PostInteractionSettingsDialog.tsx
+++ b/src/components/dialogs/PostInteractionSettingsDialog.tsx
@@ -306,7 +306,7 @@ export function PostInteractionSettingsForm({
               }
               value={quotesEnabled}
               onChange={onChangeQuotesEnabled}
-              style={[, a.justify_between, a.pt_xs]}>
+              style={[a.justify_between, a.pt_xs]}>
               <Text style={[t.atoms.text_contrast_medium]}>
                 {quotesEnabled ? (
                   <Trans>Quote posts enabled</Trans>
@@ -483,7 +483,7 @@ function Selectable({
             a.justify_between,
             a.rounded_sm,
             a.p_md,
-            {height: 40}, // for consistency with checkmark icon visible or not
+            {minHeight: 40}, // for consistency with checkmark icon visible or not
             t.atoms.bg_contrast_50,
             (hovered || focused) && t.atoms.bg_contrast_100,
             isSelected && {


### PR DESCRIPTION
Fixes https://github.com/bluesky-social/social-app/issues/6438

This allows the text to expand the container when needed but keeps the minimum size for consistency. I've also removed a random empty list element.

**Before:**
![image](https://github.com/user-attachments/assets/f1a8e6c4-efd6-49fa-852b-44c1692a46b6)

**After:**
![image](https://github.com/user-attachments/assets/2d42c4f1-9a09-451d-8d28-463d382fd64b)
