### PR TITLE
Dismiss keyboard on drag in starter pack screens

### DIFF
--- a/src/screens/StarterPack/Wizard/StepFeeds.tsx
+++ b/src/screens/StarterPack/Wizard/StepFeeds.tsx
@@ -97,6 +97,7 @@ export function StepFeeds({moderationOpts}: {moderationOpts: ModerationOpts}) {
           !query && !screenReaderEnabled ? () => fetchNextPage() : undefined
         }
         onEndReachedThreshold={2}
+        keyboardDismissMode="on-drag"
         renderScrollComponent={props => <KeyboardAwareScrollView {...props} />}
         keyboardShouldPersistTaps="handled"
         disableFullWindowScroll={true}

--- a/src/screens/StarterPack/Wizard/StepProfiles.tsx
+++ b/src/screens/StarterPack/Wizard/StepProfiles.tsx
@@ -86,6 +86,7 @@ export function StepProfiles({
           !query && !screenReaderEnabled ? () => fetchNextPage() : undefined
         }
         onEndReachedThreshold={isNative ? 2 : 0.25}
+        keyboardDismissMode="on-drag"
         ListEmptyComponent={
           <View style={[a.flex_1, a.align_center, a.mt_lg, a.px_lg]}>
             {isLoading ? (


### PR DESCRIPTION
Dismisses the keyboard from List component embedded within `StepProfiles` and `StepFeeds` with the `on-drag` mode provided by the native `ScrollView` component.

Prior to this PR, users would have to click a user to add them and then unclick, or hit the back button and come back to the screen in order to dismiss the keyboard as other controls are hidden behind the keyboard in a `BottomSheetDialog`.

- Follows pattern established in the `Explore` screen to dismiss keyboard on drag from the List component. -