### PR TITLE
Prevent <ProfileHeaderHandle /> from breaking out of its parent view

### DIFF
--- a/src/screens/Profile/Header/Handle.tsx
+++ b/src/screens/Profile/Header/Handle.tsx
@@ -23,7 +23,7 @@ export function ProfileHeaderHandle({
   const blockHide = profile.viewer?.blocking || profile.viewer?.blockedBy
   return (
     <View
-      style={[a.flex_row, a.gap_xs, a.align_center]}
+      style={[a.flex_row, a.gap_xs, a.align_center, {maxWidth: '100%'}]}
       pointerEvents={disableTaps ? 'none' : isIOS ? 'auto' : 'box-none'}>
       <NewskieDialog profile={profile} disabled={disableTaps} />
       {profile.viewer?.followedBy && !blockHide ? (


### PR DESCRIPTION
**What changes?**
Sets a max width of 100% for the `ProfileHeaderHandle` component to prevent it from overflowing in views like Settings.

Fixes #6569.

**How to test**
The easiest way is to clone the branch, replace this line with a very long handle and visualize the changes:
https://github.com/HorusGoul/bsky-social-app/blob/a7aaeaec11dba45d1c1654b2cd6c5ed344d669bc/src/screens/Profile/Header/Handle.tsx#L52

I used this handle: `@verylonghandlewithsomanycharacters.thatitmightbreaktheblueskyimplementationforhandles.orletsseehowthisshowsupintheuilol.hibtwandimsosorry.therearestillsomanymorecharacterstofillidk.imightaswellgototwohundredorsomethinglikethat.bye.horus.dev`

**Screenshot showing the fix**
The issue seems to be present on Web but not on Android. I can't check iOS at the moment.

| Before (production) | After (this branch, localhost) |
|--------|--------|
| ![image](https://github.com/user-attachments/assets/7b98711c-da8c-484b-9b6d-72402e245632) | ![image](https://github.com/user-attachments/assets/df54d1db-076f-49f1-91c6-bd34250c3604) |
| ![image](https://github.com/user-attachments/assets/b913fb55-09ec-42e7-9957-08cedfbb9609) | ![image](https://github.com/user-attachments/assets/ed8050dd-9ca6-4ce4-9492-e83bfcb1633b) |

**Testing for both short and long handles:**

Settings:
![image](https://github.com/user-attachments/assets/1a4b9c95-90a9-4c6f-be4b-66b3b300b432)
 ![image](https://github.com/user-attachments/assets/df54d1db-076f-49f1-91c6-bd34250c3604) 

Profile:
![image](https://github.com/user-attachments/assets/d73ecc49-f8ae-49de-8fd7-ee2afad649e5)
![image](https://github.com/user-attachments/assets/f9b6cff1-0750-4b90-aea7-8c92edc569b8)


Labeler profile:
![image](https://github.com/user-attachments/assets/b9e15d83-9e3e-4e7d-a405-cff156030212)
![image](https://github.com/user-attachments/assets/fb4fa0e0-e5e4-4d59-8f31-c9e994d1223b)

 