### PR TITLE
[Android] Patch react-native-svg to cache parsed paths

### DIFF
--- a/patches/react-native-svg+15.3.0.patch
+++ b/patches/react-native-svg+15.3.0.patch
@@ -1,0 +1,57 @@
+diff --git a/node_modules/react-native-svg/android/src/main/java/com/horcrux/svg/PathView.java b/node_modules/react-native-svg/android/src/main/java/com/horcrux/svg/PathView.java
+index 06829bd..1b15818 100644
+--- a/node_modules/react-native-svg/android/src/main/java/com/horcrux/svg/PathView.java
++++ b/node_modules/react-native-svg/android/src/main/java/com/horcrux/svg/PathView.java
+@@ -14,17 +14,33 @@ import android.graphics.Paint;
+ import android.graphics.Path;
+ import com.facebook.react.bridge.ReactContext;
+ 
++import java.util.ArrayList;
++import java.util.HashMap;
++
++class ParsedPath {
++  final Path path;
++  final ArrayList<PathElement> elements;
++
++  ParsedPath(Path path, ArrayList<PathElement> elements) {
++    this.path = path;
++    this.elements = elements;
++  }
++}
++
+ @SuppressLint("ViewConstructor")
+ class PathView extends RenderableView {
+   private Path mPath;
+ 
++  // This grows forever but for our use case (static icons) it's ok.
++  private static final HashMap<String, ParsedPath> sPathCache = new HashMap<>();
++
+   public PathView(ReactContext reactContext) {
+     super(reactContext);
+     PathParser.mScale = mScale;
+     mPath = new Path();
+   }
+ 
+-  public void setD(String d) {
++  void setDByParsing(String d) {
+     mPath = PathParser.parse(d);
+     elements = PathParser.elements;
+     for (PathElement elem : elements) {
+@@ -33,6 +49,17 @@ class PathView extends RenderableView {
+         point.y *= mScale;
+       }
+     }
++  }
++
++  public void setD(String d) {
++    ParsedPath cached = sPathCache.get(d);
++    if (cached != null) {
++      mPath = cached.path;
++      elements = cached.elements;
++    } else {
++      setDByParsing(d);
++      sPathCache.put(d, new ParsedPath(mPath, elements));
++    }
+     invalidate();
+   }
+ 


### PR DESCRIPTION
Kind of a hackfix. See https://github.com/software-mansion/react-native-svg/pull/2548.

We don't want to parse these icons' paths every time we create a view with them — this is downright silly.

This caches them forever but it's ok because our SVGs are not dynamic and we have a limited number of them.

## Test Plan

Verify we're hitting the cache as expected. As you scroll feed, you have fewer cold parses and soon run out of them.

https://github.com/user-attachments/assets/b8b378d0-9898-441a-9406-5617887ca430

## Before

This function is a significant part of the `createViewInstance` trace.

<img width="923" alt="Screenshot 2024-11-21 at 00 40 30" src="https://github.com/user-attachments/assets/4da7a0a1-a792-4604-9c84-7f75956bd13e">

## After

It's a smaller part of the overall picture.

<img width="992" alt="Screenshot 2024-11-21 at 01 14 22" src="https://github.com/user-attachments/assets/4f5e76a8-d5d9-4ed4-b16b-b6a68bc6c118">

## Proper fix

This doesn't fully solve the issue — this library is still showing up in `onDraw`, for example. I think ideally we'd move to https://github.com/zamplyy/react-native-vector-image-plugin or something like it, but let's land this for now.