### PR TITLE
Disable vertical scrollbars on Android only

### DIFF
--- a/src/view/com/util/List.tsx
+++ b/src/view/com/util/List.tsx
@@ -7,7 +7,7 @@ import {useAnimatedScrollHandler} from '#/lib/hooks/useAnimatedScrollHandler_FIX
 import {useDedupe} from '#/lib/hooks/useDedupe'
 import {useScrollHandlers} from '#/lib/ScrollContext'
 import {addStyle} from '#/lib/styles'
-import {isIOS} from '#/platform/detection'
+import {isAndroid, isIOS} from '#/platform/detection'
 import {useLightbox} from '#/state/lightbox'
 import {useTheme} from '#/alf'
 import {FlatList_INTERNAL} from './Views'
@@ -149,6 +149,7 @@ function ListImpl<ItemT>(
       scrollEventThrottle={1}
       onViewableItemsChanged={onViewableItemsChanged}
       viewabilityConfig={viewabilityConfig}
+      showsVerticalScrollIndicator={!isAndroid}
       style={style}
       ref={ref}
     />


### PR DESCRIPTION
Revisiting https://github.com/bluesky-social/social-app/pull/3855 for two reasons:

- With infinite scroll, they don't really mean anything
- On Android specifically, they get pretty jumpy due to more choppy virtualization
- Them (re)appearing is showing up in traces — it's a tiny bit of extra work to render them
- On Android, they don't work as a navigational element anyway so the justification from https://github.com/bluesky-social/social-app/pull/3855 doesn't apply

So let's remove them but on Android only.

## Test Plan

Can still see them on iOS and web. Can't see them on Android.