### PR TITLE
Update bskyembed/yarn.lock to include only one Zod version

### DIFF
--- a/bskyembed/yarn.lock
+++ b/bskyembed/yarn.lock
@@ -4209,12 +4209,7 @@ yocto-queue@^0.1.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
-zod@^3.21.4:
-  version "3.22.4"
-  resolved "https://registry.yarnpkg.com/zod/-/zod-3.22.4.tgz#f31c3a9386f61b1f228af56faa9255e845cf3fff"
-  integrity sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==
-
-zod@^3.23.8:
+zod@^3.21.4, zod@^3.23.8:
   version "3.23.8"
   resolved "https://registry.yarnpkg.com/zod/-/zod-3.23.8.tgz#e37b957b5d52079769fb8097099b592f0ef4067d"
   integrity sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==


### PR DESCRIPTION
This pull request updates the bskyembed/yarn.lock file so that only one version of Zod is included in the Bluesky embed bundle. This seems to reduce the resulting bundle size by about 9% (from 156kB to 142kB, gzipped).

While looking at the Bluesky embed code with @marvinhagemeister we spotted two versions of Zod in the bundle visualization treemap:

![treemap](https://github.com/user-attachments/assets/e2be3065-0827-4389-a9c7-ecfb2ecc0986)

This could be solved by updating the embed bundle's lockfile. Previously both Zod 3.22.4 and 3.23.8 were included and the bundled code took around 156kB gzipped:

```
dist/static/post-BtQoyJ24.js   763.87 kB │ gzip: 156.07 kB
```

Updating the lockfile to only incldue Zod version 3.23.8 reduces the gzipped bundle size by about 9%:

```
dist/static/post-DOc5yEa0.js   700.56 kB │ gzip: 142.04 kB
```