### PR TITLE
Reduce overdraw

### DIFF
--- a/src/view/com/home/HomeHeaderLayoutMobile.tsx
+++ b/src/view/com/home/HomeHeaderLayoutMobile.tsx
@@ -41,12 +41,12 @@ export function HomeHeaderLayoutMobile({
 
   return (
     <Animated.View
-      style={[pal.view, pal.border, styles.tabBar, headerMinimalShellTransform]}
+      style={[pal.border, styles.tabBar, headerMinimalShellTransform]}
       onLayout={e => {
         headerHeight.set(e.nativeEvent.layout.height)
       }}>
       <View style={[pal.view, styles.topBar]}>
-        <View style={[pal.view, {width: 100}]}>
+        <View style={[{width: 100}]}>
           <TouchableOpacity
             testID="viewHeaderDrawerBtn"
             onPress={onPressAvi}
@@ -68,7 +68,6 @@ export function HomeHeaderLayoutMobile({
             atoms.justify_end,
             atoms.align_center,
             atoms.gap_md,
-            pal.view,
             {width: 100},
           ]}>
           {IS_DEV && (

--- a/src/view/shell/index.tsx
+++ b/src/view/shell/index.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import {BackHandler, StyleSheet, useWindowDimensions, View} from 'react-native'
 import {Drawer} from 'react-native-drawer-layout'
-import Animated from 'react-native-reanimated'
 import {useSafeAreaInsets} from 'react-native-safe-area-context'
 import * as NavigationBar from 'expo-navigation-bar'
 import {StatusBar} from 'expo-status-bar'
@@ -10,7 +9,6 @@ import {useNavigation, useNavigationState} from '@react-navigation/native'
 import {useDedupe} from '#/lib/hooks/useDedupe'
 import {useIntentHandler} from '#/lib/hooks/useIntentHandler'
 import {useNotificationsHandler} from '#/lib/hooks/useNotificationHandler'
-import {usePalette} from '#/lib/hooks/usePalette'
 import {useNotificationsRegistration} from '#/lib/notifications/notifications'
 import {isStateAtTabRoot} from '#/lib/routes/helpers'
 import {useTheme} from '#/lib/ThemeContext'
@@ -95,7 +93,7 @@ function ShellInner() {
 
   return (
     <>
-      <Animated.View style={[a.h_full]}>
+      <View style={[a.h_full]}>
         <ErrorBoundary
           style={{paddingTop: insets.top, paddingBottom: insets.bottom}}>
           <Drawer
@@ -119,7 +117,7 @@ function ShellInner() {
             <TabsNavigator />
           </Drawer>
         </ErrorBoundary>
-      </Animated.View>
+      </View>
       <Composer winHeight={winDim.height} />
       <ModalsContainer />
       <MutedWordsDialog />
@@ -133,7 +131,6 @@ function ShellInner() {
 
 export const Shell: React.FC = function ShellImpl() {
   const {fullyExpandedCount} = useDialogStateControlContext()
-  const pal = usePalette('default')
   const theme = useTheme()
   useIntentHandler()
 
@@ -147,7 +144,7 @@ export const Shell: React.FC = function ShellImpl() {
     }
   }, [theme])
   return (
-    <View testID="mobileShellView" style={[styles.outerContainer, pal.view]}>
+    <View testID="mobileShellView" style={[styles.outerContainer]}>
       <StatusBar
         style={
           theme.colorScheme === 'dark' || (isIOS && fullyExpandedCount > 0)


### PR DESCRIPTION
This probably isn't very important but I figured we might as well do it.

These don't need explicit backgrounds because there's a background above.

## Test Plan

Walk around the screens, everything looks the same visually. The home/profile tabbar still has a solid background. Same for the bottom bar.

## Before

<img width="516" alt="Screenshot 2024-11-21 at 23 03 42" src="https://github.com/user-attachments/assets/9feed85b-34f8-4565-ac44-25937cec4ede">

## After

<img width="516" alt="Screenshot 2024-11-21 at 23 03 35" src="https://github.com/user-attachments/assets/87decf16-caa1-4ef0-9835-e0fb7edf1286">

(The bottom bar isn't actually transparent, it's just how "Debug GPU Overdraw" visualizes it.)