### PR TITLE
Fix display language not switching correctly to Chinese on native.

### DIFF
--- a/src/locale/deviceLocales.ts
+++ b/src/locale/deviceLocales.ts
@@ -13,6 +13,12 @@ type LocalWithLanguageCode = Locale & {
  *
  * {@link https://github.com/bluesky-social/social-app/pull/4461}
  * {@link https://xml.coverpages.org/iso639a.html}
+ *
+ * Convert Chinese language tags for Native.
+ *
+ * {@link https://datatracker.ietf.org/doc/html/rfc5646#appendix-A}
+ * {@link https://developer.apple.com/documentation/packagedescription/languagetag}
+ * {@link https://gist.github.com/amake/0ac7724681ac1c178c6f95a5b09f03ce#new-locales-vs-old-locales-chinese}
  */
 export function getLocales() {
   const locales = defaultGetLocales?.() ?? []
@@ -32,10 +38,25 @@ export function getLocales() {
         // yiddish
         locale.languageCode = 'yi'
       }
-
-      // @ts-ignore checked above
-      output.push(locale)
     }
+
+    if (typeof locale.languageTag === 'string') {
+      if (locale.languageTag === 'zh-Hans-CN') {
+        // Simplified Chinese (China)
+        locale.languageTag = 'zh-CN'
+      }
+      if (locale.languageTag === 'zh-Hant-TW') {
+        // Traditional Chinese (Taiwan)
+        locale.languageTag = 'zh-TW'
+      }
+      if (locale.languageTag === 'zh-Hant-HK') {
+        // Traditional Chinese (Hong Kong)
+        locale.languageTag = 'zh-HK'
+      }
+    }
+
+    // @ts-ignore checked above
+    output.push(locale)
   }
 
   return output

--- a/src/locale/deviceLocales.ts
+++ b/src/locale/deviceLocales.ts
@@ -41,16 +41,16 @@ export function getLocales() {
     }
 
     if (typeof locale.languageTag === 'string') {
-      if (locale.languageTag === 'zh-Hans-CN') {
-        // Simplified Chinese (China)
+      if (locale.languageTag.startsWith('zh-Hans')) {
+        // Simplified Chinese to zh-CN
         locale.languageTag = 'zh-CN'
       }
-      if (locale.languageTag === 'zh-Hant-TW') {
-        // Traditional Chinese (Taiwan)
+      if (locale.languageTag.startsWith('zh-Hant')) {
+        // Traditional Chinese to zh-TW
         locale.languageTag = 'zh-TW'
       }
-      if (locale.languageTag === 'zh-Hant-HK') {
-        // Traditional Chinese (Hong Kong)
+      if (locale.languageTag.startsWith('yue')) {
+        // Cantonese (Yue) to zh-HK
         locale.languageTag = 'zh-HK'
       }
     }


### PR DESCRIPTION
### Why
In web development, language codes generally follow the [RFC 1766](https://learn.microsoft.com/en-us/windows/win32/wmformat/language-strings) standard. In this standard, the language tag for Chinese is typically written as: `zh-CN`, `zh-TW`, `zh-HK`.

However, in Android and iOS, language codes follow the [RFC 4646](https://www.iana.org/assignments/language-tags/language-tags.xhtml) standard, which further distinguishes Simplified Chinese (Hans) and Traditional Chinese (Hant). The language tags in this standard look like: `zh-Hans-CN`, `zh-Hant-TW`, `zh-Hant-HK`

When using `getLocales().languageTag` from [expo-localization](https://docs.expo.dev/versions/latest/sdk/localization/#locale) on an Android device (with system language set to Simplified Chinese), it will return this output:
```
[{"languageTag": "zh-Hans-CN"}]
```

This cannot be matched to existing `AppLanguage`, so it will rollback to English. Because `AppLanguage` naming follows RFC 1766, which is still widely used in browsers. Therefore, we cannot rename Chinese `AppLanguage` to following RFC 4646.

This patch is meant to solve this issue by converting the RFC 4646 output from the device into RFC 1766, just like how we handle incorrect languageCode on legacy Java devices (#4461).

With this patch, now using `getLocales().languageTag` will return the following output:
```
[{"languageTag": "zh-CN"}]
```

Based on #5384, the app can now correctly handle language tags with region codes. This allows it to match the existing `zh-CN` in `AppLanguage` and display Chinese when the app is opened for the first time, instead of rolling back to English.

It's hard to say RFC 1766 or RFC 4646 which standard is better, but both will likely coexist for a long time. Web development is unlikely to transition to RFC 4646, as it would break browser behavior, and [W3C](https://www.w3.org/International/questions/qa-choosing-language-tags.en.html) seem to prefer RFC 1766.

> Always bear in mind that the golden rule is to keep your language tag as short as possible. Only add further subtags to your language tag if they are needed to distinguish the language from something else in the context where your content is used.

For now, Chinese is one of the few languages that requires mapping conversion. Most languages work as expected under either standard. So this patch only includes conversion mapping for Chinese. I prefer not to rewrite the logic in the later parts of the code.

 Before:

https://github.com/user-attachments/assets/fc8dda1d-0099-47a7-a6c2-4772bbfe2cf3

After:

https://github.com/user-attachments/assets/8169186c-a71f-4a7d-91f1-d8845b1fc514

