### PR TITLE
[Android] Lower Feed maxRenderPerBatch

### DIFF
--- a/src/view/com/posts/Feed.tsx
+++ b/src/view/com/posts/Feed.tsx
@@ -19,7 +19,7 @@ import {useInitialNumToRender} from '#/lib/hooks/useInitialNumToRender'
 import {logEvent, useGate} from '#/lib/statsig/statsig'
 import {useTheme} from '#/lib/ThemeContext'
 import {logger} from '#/logger'
-import {isWeb} from '#/platform/detection'
+import {isIOS, isWeb} from '#/platform/detection'
 import {listenPostCreated} from '#/state/events'
 import {useFeedFeedbackContext} from '#/state/feed-feedback'
 import {STALE} from '#/state/queries'
@@ -636,7 +636,7 @@ let Feed = ({
         }
         initialNumToRender={initialNumToRenderOverride ?? initialNumToRender}
         windowSize={9}
-        maxToRenderPerBatch={5}
+        maxToRenderPerBatch={isIOS ? 5 : 1}
         updateCellsBatchingPeriod={40}
         onItemSeen={feedFeedback.onItemSeen}
       />


### PR DESCRIPTION
These batches can drop frames really hard since each row is a feed story (which may have embeds etc).

Let's just be conservative on Android and try to unblock as much as possible. I'm not seeing a lot of blank spaces in practice unless I scroll super hard. Whereas the frame-by-frame improvement is quite noticeable, especially on embed-heavy feeds like the News feed. And I assume on higher end it'll work even better.

## Test Plan

Scroll up and down different feeds.

Also try "scroll to top" and scrolling down after to try to trigger blanks.

## Before

This was captured with the News feed (which has embeds and is consistently ordered). Five scrolls down with momentum.

<img width="1417" alt="Screenshot 2024-11-22 at 04 16 22" src="https://github.com/user-attachments/assets/2bbe5105-6d5e-404e-bb95-45adfa27d762">

## After

Same, five scrolls on News feed.

<img width="1415" alt="Screenshot 2024-11-22 at 04 13 55" src="https://github.com/user-attachments/assets/d41c042b-d8f8-4cde-854a-79601910ceb4">

And it just _feels_ better, you know.  