### PR TITLE
Fix avi follow deadzone

### DIFF
--- a/src/view/com/posts/AviFollowButton.tsx
+++ b/src/view/com/posts/AviFollowButton.tsx
@@ -84,25 +84,22 @@ export function AviFollowButton({
       {!isFollowing && (
         <Button
           label={_(msg`Open ${name} profile shortcut menu`)}
-          hitSlop={{
-            top: 0,
-            left: 0,
-            right: 5,
-            bottom: 5,
-          }}
           style={[
             a.rounded_full,
             a.absolute,
             {
-              height: 30,
-              width: 30,
               bottom: -7,
               right: -7,
             },
           ]}>
           <NativeDropdown items={items}>
             <View
-              style={[a.h_full, a.w_full, a.justify_center, a.align_center]}>
+              style={[
+                {width: 30, height: 30},
+                a.align_center,
+                a.justify_center,
+                a.rounded_full,
+              ]}>
               <View
                 style={[
                   a.rounded_full,


### PR DESCRIPTION
Before/after: where red is the deadzone and green is the actual touch target

<table>
  <thead>
    <tr>
      <th>Before</th>
      <th>After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><img width="200" alt="Screenshot 2024-11-22 at 18 42 35" src="https://github.com/user-attachments/assets/8aa9d64d-faab-4769-ad09-a7c77ab112d4" /></td>
      <td><img width="200" alt="Screenshot 2024-11-22 at 18 41 05" src="https://github.com/user-attachments/assets/a055b53f-2e9e-4de7-8af3-f153486d611b" /></td>
    </tr>
  </tbody>
</table>

# Test plan

Confirm there's no deadzone on iOS + Android
