### PR TITLE
Simplify play icon shadow

### DIFF
--- a/src/components/video/PlayButtonIcon.tsx
+++ b/src/components/video/PlayButtonIcon.tsx
@@ -13,9 +13,12 @@ export function PlayButtonIcon({size = 32}: {size?: number}) {
       <View
         style={[
           a.rounded_full,
-          t.atoms.shadow_lg,
           {
             backgroundColor: bg,
+            shadowColor: 'black',
+            shadowRadius: 32,
+            shadowOpacity: 0.5,
+            elevation: 24,
             width: size + size / 1.5,
             height: size + size / 1.5,
             opacity: 0.7,

--- a/src/components/video/PlayButtonIcon.tsx
+++ b/src/components/video/PlayButtonIcon.tsx
@@ -9,39 +9,20 @@ export function PlayButtonIcon({size = 32}: {size?: number}) {
   const fg = t.name === 'light' ? t.palette.contrast_975 : t.palette.contrast_25
 
   return (
-    <View
-      style={[
-        a.rounded_full,
-        a.overflow_hidden,
-        a.align_center,
-        a.justify_center,
-        t.atoms.shadow_lg,
-        {
-          width: size + size / 1.5,
-          height: size + size / 1.5,
-        },
-      ]}>
+    <>
       <View
         style={[
-          a.absolute,
-          a.inset_0,
+          a.rounded_full,
+          t.atoms.shadow_lg,
           {
             backgroundColor: bg,
+            width: size + size / 1.5,
+            height: size + size / 1.5,
             opacity: 0.7,
           },
         ]}
       />
-      <PlayIcon
-        width={size}
-        fill={fg}
-        style={[
-          a.relative,
-          a.z_10,
-          {
-            left: size / 50,
-          },
-        ]}
-      />
-    </View>
+      <PlayIcon width={size} fill={fg} style={a.absolute} />
+    </>
   )
 }


### PR DESCRIPTION
This solves a few things:

- The shadow was almost invisible on light theme because the `shadowColor` was theme-dependent (which doesn't make sense when overlaying a video).
- We were getting `Raised button causing error: View #... of type RCTView has a shadow set but cannot calculate shadow efficiently` which is only solveable by putting a solid background color on the element _with_ the shadow.

Should overall look the same-ish. Here it is against different backgrounds:

<img width="925" alt="Screenshot 2024-11-22 at 19 18 43" src="https://github.com/user-attachments/assets/690ac71b-eced-4317-9ea9-96924781d121">
<img width="940" alt="Screenshot 2024-11-22 at 19 18 52" src="https://github.com/user-attachments/assets/de307fc5-0e35-42b0-893b-40c781749a9d">
<img width="924" alt="Screenshot 2024-11-22 at 19 19 38" src="https://github.com/user-attachments/assets/b2165f3e-ff4e-4627-8fa3-a1634ba55ea9">
