### PR TITLE
Fix interstitials to not interrupt feed slices

### DIFF
--- a/src/lib/statsig/gates.ts
+++ b/src/lib/statsig/gates.ts
@@ -2,4 +2,3 @@ export type Gate =
   // Keep this alphabetic please.
   | 'debug_show_feedcontext' // DISABLED DUE TO EME
   | 'post_feed_lang_window' // DISABLED DUE TO EME
-  | 'suggested_feeds_interstitial'


### PR DESCRIPTION
I regressed on this in https://github.com/bluesky-social/social-app/pull/6507. We never want to put an interstitial in between two items of the same slice. To fix this, I'm moving the logic to where we enumerate over the slices. While we're at it, I'm also ripping out a bit of abstraction that hasn't proven out to be useful and was making my mistake harder to spot. (Plus removing the experiment we didn't ship.)

## Test Plan

Reset onboarding state, observe the progress bar on Discover:

<img width="804" alt="Screenshot 2024-11-22 at 20 13 05" src="https://github.com/user-attachments/assets/53a21070-38f5-408d-93f3-cede8c8e4173">

Discover still shows suggestions:

<img width="887" alt="Screenshot 2024-11-22 at 20 05 01" src="https://github.com/user-attachments/assets/5fc26e13-d690-47b4-8d90-ad2f7b8ffe7f">

They change after Discover invalidation.

Profiles still show suggestions:

<img width="872" alt="Screenshot 2024-11-22 at 20 12 57" src="https://github.com/user-attachments/assets/d83e2359-af90-453a-ae9f-e55c488d3fba">
