### PR TITLE
add search input focus shortcut

### DIFF
--- a/src/components/forms/SearchInput.tsx
+++ b/src/components/forms/SearchInput.tsx
@@ -4,7 +4,9 @@ import {msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
 import {HITSLOP_10} from '#/lib/constants'
+import {mergeRefs} from '#/lib/merge-refs'
 import {isNative} from '#/platform/detection'
+import {useSearchInputKeyboardShortcut} from '#/state/shell/useSearchInputKeyboardShortcut'
 import {atoms as a, useTheme} from '#/alf'
 import {Button, ButtonIcon} from '#/components/Button'
 import * as TextField from '#/components/forms/TextField'
@@ -24,13 +26,15 @@ export const SearchInput = React.forwardRef<TextInput, SearchInputProps>(
     const t = useTheme()
     const {_} = useLingui()
     const showClear = value && value.length > 0
+    const inputRef = React.useRef<TextInput>(null)
+    useSearchInputKeyboardShortcut(inputRef)
 
     return (
       <View style={[a.w_full, a.relative]}>
         <TextField.Root>
           <TextField.Icon icon={MagnifyingGlassIcon} />
           <TextField.Input
-            inputRef={ref}
+            inputRef={mergeRefs([inputRef, ref])}
             label={label || _(msg`Search`)}
             value={value}
             placeholder={_(msg`Search`)}

--- a/src/state/shell/useSearchInputKeyboardShortcut.tsx
+++ b/src/state/shell/useSearchInputKeyboardShortcut.tsx
@@ -1,0 +1,68 @@
+import React from 'react'
+import {TextInput} from 'react-native'
+
+import {useDialogStateContext} from '#/state/dialogs'
+import {useLightbox} from '#/state/lightbox'
+import {useModals} from '#/state/modals'
+import {useIsDrawerOpen} from '#/state/shell/drawer-open'
+
+/**
+ * Based on {@link https://github.com/jaywcjlove/hotkeys-js/blob/b0038773f3b902574f22af747f3bb003a850f1da/src/index.js#L51C1-L64C2}
+ */
+function shouldIgnore(event: KeyboardEvent) {
+  const target: any = event.target || event.srcElement
+  if (!target) return false
+  const {tagName} = target
+  if (!tagName) return false
+  const isInput =
+    tagName === 'INPUT' &&
+    ![
+      'checkbox',
+      'radio',
+      'range',
+      'button',
+      'file',
+      'reset',
+      'submit',
+      'color',
+    ].includes(target.type)
+  // ignore: isContentEditable === 'true', <input> and <textarea> when readOnly state is false, <select>
+  if (
+    target.isContentEditable ||
+    ((isInput || tagName === 'TEXTAREA' || tagName === 'SELECT') &&
+      !target.readOnly)
+  ) {
+    return true
+  }
+  return false
+}
+
+export function useSearchInputKeyboardShortcut(
+  inputRef: React.RefObject<TextInput>,
+) {
+  const {openDialogs} = useDialogStateContext()
+  const {isModalActive} = useModals()
+  const {activeLightbox} = useLightbox()
+  const isDrawerOpen = useIsDrawerOpen()
+
+  React.useEffect(() => {
+    function handler(event: KeyboardEvent) {
+      if (shouldIgnore(event)) return
+      if (
+        openDialogs?.current.size > 0 ||
+        isModalActive ||
+        activeLightbox ||
+        isDrawerOpen
+      )
+        return
+
+      if (event.key === '/' && !event.ctrlKey && !event.metaKey) {
+        event.preventDefault()
+        inputRef.current?.focus()
+      }
+    }
+
+    document.addEventListener('keydown', handler)
+    return () => document.removeEventListener('keydown', handler)
+  }, [inputRef, isModalActive, openDialogs, activeLightbox, isDrawerOpen])
+}


### PR DESCRIPTION
lets `/` key focus the search input when not in a text field or ui overlay (modals, dialogs, lightbox).
feature in other sites like google, youtube, twitter and github.

changes:
- new hook in `src/state/shell/useSearchInputKeyboardShortcut.tsx` with same patterns as `src/state/shell/composer/useComposerKeyboardShortcut.tsx`
- added local ref for keyboard shortcut and merged with forwarded ref using `src/lib/merge-refs.ts` utility in `src/components/forms/SearchInput.tsx`