### PR TITLE
Fix translate button not working

### DIFF
--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -1,5 +1,10 @@
 import React, {memo, useMemo} from 'react'
-import {StyleSheet, Text as RNText, View} from 'react-native'
+import {
+  GestureResponderEvent,
+  StyleSheet,
+  Text as RNText,
+  View,
+} from 'react-native'
 import {
   AppBskyFeedDefs,
   AppBskyFeedPost,
@@ -12,6 +17,7 @@ import {msg, Plural, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
 import {MAX_POST_LINES} from '#/lib/constants'
+import {useOpenLink} from '#/lib/hooks/useOpenLink'
 import {usePalette} from '#/lib/hooks/usePalette'
 import {makeProfileLink} from '#/lib/routes/links'
 import {sanitizeDisplayName} from '#/lib/strings/display-names'
@@ -732,7 +738,17 @@ function ExpandedPostDetails({
   const t = useTheme()
   const pal = usePalette('default')
   const {_, i18n} = useLingui()
+  const openLink = useOpenLink()
   const isRootPost = !('reply' in post.record)
+
+  const onTranslatePress = React.useCallback(
+    (e: GestureResponderEvent) => {
+      e.preventDefault()
+      openLink(translatorUrl, true)
+      return false
+    },
+    [openLink, translatorUrl],
+  )
 
   return (
     <View style={[a.gap_md, a.pt_md, a.align_start]}>
@@ -753,7 +769,8 @@ function ExpandedPostDetails({
             <InlineLinkText
               to={translatorUrl}
               label={_(msg`Translate`)}
-              style={[a.text_sm, pal.link]}>
+              style={[a.text_sm, pal.link]}
+              onPress={onTranslatePress}>
               <Trans>Translate</Trans>
             </InlineLinkText>
           </>

--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -12,7 +12,6 @@ import {msg, Plural, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
 import {MAX_POST_LINES} from '#/lib/constants'
-import {useOpenLink} from '#/lib/hooks/useOpenLink'
 import {usePalette} from '#/lib/hooks/usePalette'
 import {makeProfileLink} from '#/lib/routes/links'
 import {sanitizeDisplayName} from '#/lib/strings/display-names'
@@ -733,12 +732,7 @@ function ExpandedPostDetails({
   const t = useTheme()
   const pal = usePalette('default')
   const {_, i18n} = useLingui()
-  const openLink = useOpenLink()
   const isRootPost = !('reply' in post.record)
-
-  const onTranslatePress = React.useCallback(() => {
-    openLink(translatorUrl, true)
-  }, [openLink, translatorUrl])
 
   return (
     <View style={[a.gap_md, a.pt_md, a.align_start]}>
@@ -757,10 +751,9 @@ function ExpandedPostDetails({
             </Text>
 
             <InlineLinkText
-              to="#"
+              to={translatorUrl}
               label={_(msg`Translate`)}
-              style={[a.text_sm, pal.link]}
-              onPress={onTranslatePress}>
+              style={[a.text_sm, pal.link]}>
               <Trans>Translate</Trans>
             </InlineLinkText>
           </>


### PR DESCRIPTION
Based on #6289

Fix #6287
Fix #6446

Sorry I know this is a bit repetitive, but I’m trying to provide more explanation in this PR. I've encountered this issue frequently over the past few days.

Thanks to @surfdude29’s [comment](https://github.com/bluesky-social/social-app/issues/6287#issuecomment-2487721453), made me realize that there is a behavioral difference between clicking "Translate" in the post context menu and directly clicking the translate button under the post, so I started investigating this.

In #6084, to fix the a11y issue, we replaced `<NewText>` with `<InlineLinkText>`, which introduced `to="#"`. But this breaks the translation and redirects the user to the homepage.

I absolutely respect the a11y fix, so I won’t revert this change. Replacing `onPress={onTranslatePress}` with `to={translatorUrl}` seems like the right approach. After removing `onPress` here, it will no longer be used elsewhere, so it can be safely removed import.

After testing, the translation button will work again.

https://github.com/user-attachments/assets/ab260274-005d-483c-b16c-0dfa11c2844c

