### PR TITLE
Fix avi button hitslops

### DIFF
--- a/src/view/com/posts/AviFollowButton.tsx
+++ b/src/view/com/posts/AviFollowButton.tsx
@@ -88,14 +88,21 @@ export function AviFollowButton({
             a.rounded_full,
             a.absolute,
             {
-              bottom: -4,
-              right: -4,
+              bottom: -7,
+              right: -7,
             },
           ]}>
           <NativeDropdown items={items}>
             <View
               style={[
-                {width: 24, height: 24},
+                {
+                  // An asymmetric hit slop
+                  // to prioritize bottom right taps.
+                  paddingTop: 2,
+                  paddingLeft: 2,
+                  paddingBottom: 6,
+                  paddingRight: 6,
+                },
                 a.align_center,
                 a.justify_center,
                 a.rounded_full,

--- a/src/view/com/posts/AviFollowButton.tsx
+++ b/src/view/com/posts/AviFollowButton.tsx
@@ -88,14 +88,14 @@ export function AviFollowButton({
             a.rounded_full,
             a.absolute,
             {
-              bottom: -7,
-              right: -7,
+              bottom: -4,
+              right: -4,
             },
           ]}>
           <NativeDropdown items={items}>
             <View
               style={[
-                {width: 30, height: 30},
+                {width: 24, height: 24},
                 a.align_center,
                 a.justify_center,
                 a.rounded_full,

--- a/src/view/com/posts/FeedItem.tsx
+++ b/src/view/com/posts/FeedItem.tsx
@@ -618,10 +618,10 @@ const styles = StyleSheet.create({
   layout: {
     flexDirection: 'row',
     marginTop: 1,
-    gap: 10,
   },
   layoutAvi: {
     paddingLeft: 8,
+    paddingRight: 10,
     position: 'relative',
     zIndex: 999,
   },

--- a/src/view/com/util/forms/NativeDropdown.tsx
+++ b/src/view/com/util/forms/NativeDropdown.tsx
@@ -8,7 +8,7 @@ import {MenuItemCommonProps} from 'zeego/lib/typescript/menu'
 import {HITSLOP_10} from '#/lib/constants'
 import {usePalette} from '#/lib/hooks/usePalette'
 import {useTheme} from '#/lib/ThemeContext'
-import {isIOS, isWeb} from '#/platform/detection'
+import {isIOS} from '#/platform/detection'
 import {Portal} from '#/components/Portal'
 
 // Custom Dropdown Menu Components
@@ -30,19 +30,6 @@ export const DropdownMenuTrigger = DropdownMenu.create(
   (props: TriggerProps) => {
     const theme = useTheme()
     const defaultCtrlColor = theme.palette.default.postCtrl
-    const ref = React.useRef<View>(null)
-
-    // HACK
-    // fire a click event on the keyboard press to trigger the dropdown
-    // -prf
-    const onPress = isWeb
-      ? (evt: any) => {
-          if (evt instanceof KeyboardEvent) {
-            // @ts-ignore web only -prf
-            ref.current?.click()
-          }
-        }
-      : undefined
 
     return (
       <Pressable
@@ -51,10 +38,9 @@ export const DropdownMenuTrigger = DropdownMenu.create(
         accessibilityLabel={props.accessibilityLabel}
         accessibilityHint={props.accessibilityHint}
         style={({pressed}) => [{opacity: pressed ? 0.5 : 1}]}
-        hitSlop={HITSLOP_10}
-        onPress={onPress}>
+        hitSlop={HITSLOP_10}>
         <DropdownMenu.Trigger action="press">
-          <View ref={ref}>
+          <View>
             {props.children ? (
               props.children
             ) : (

--- a/src/view/com/util/forms/NativeDropdown.tsx
+++ b/src/view/com/util/forms/NativeDropdown.tsx
@@ -38,7 +38,7 @@ export const DropdownMenuTrigger = DropdownMenu.create(
         accessibilityRole="button"
         accessibilityLabel={props.accessibilityLabel}
         accessibilityHint={props.accessibilityHint}
-        style={({pressed}) => [{opacity: pressed ? 0.5 : 1}]}>
+        style={({pressed}) => [{opacity: pressed ? 0.8 : 1}]}>
         <DropdownMenu.Trigger action="press">
           <View>
             {props.children ? (

--- a/src/view/com/util/forms/NativeDropdown.tsx
+++ b/src/view/com/util/forms/NativeDropdown.tsx
@@ -5,7 +5,6 @@ import {FontAwesomeIcon} from '@fortawesome/react-native-fontawesome'
 import * as DropdownMenu from 'zeego/dropdown-menu'
 import {MenuItemCommonProps} from 'zeego/lib/typescript/menu'
 
-import {HITSLOP_10} from '#/lib/constants'
 import {usePalette} from '#/lib/hooks/usePalette'
 import {useTheme} from '#/lib/ThemeContext'
 import {isIOS} from '#/platform/detection'
@@ -32,13 +31,14 @@ export const DropdownMenuTrigger = DropdownMenu.create(
     const defaultCtrlColor = theme.palette.default.postCtrl
 
     return (
+      // This Pressable doesn't actually do anything other than
+      // provide the "pressed state" visual feedback.
       <Pressable
         testID={props.testID}
         accessibilityRole="button"
         accessibilityLabel={props.accessibilityLabel}
         accessibilityHint={props.accessibilityHint}
-        style={({pressed}) => [{opacity: pressed ? 0.5 : 1}]}
-        hitSlop={HITSLOP_10}>
+        style={({pressed}) => [{opacity: pressed ? 0.5 : 1}]}>
         <DropdownMenu.Trigger action="press">
           <View>
             {props.children ? (


### PR DESCRIPTION
We're trying to fix the avi button hitslops on Android. Currently, Android has significant dead zones where you can't click:

https://github.com/user-attachments/assets/15f4b502-211f-4ce2-a5ef-d59bae9cfa3d

https://github.com/bluesky-social/social-app/pull/6639 seemed like it would work but it did not. We're doing some wonky stuff with pressables and positioning so I tried to simplify it. See commit by commit.

In short:

- Remove `hitSlop` on a wrong Pressable that was swallowing taps (but not handling them) on Android
- Fix a clipping issue that caused touches outside the avi "column" layout getting dropped on Android
- Adjust hitslops for the avi button to get out of the way for pressing the pic (nudge them bottom-right)

Tested on a real device on Android and iOS.

## Test Plan

- Verify there are no dead zones (especially on Android). Tapping _always_ does something.
- Tapping in the center of the avi on a real device no longer brings up the menu.
- Tapping in the right bottom works reliably (especially on Android).
- There is still visual feedback (I tweaked the opacity though).
- Other `NativeDropdown` usages keep working ("..." dropdown in `ProfileList`).
- Other `AviFollowButton` usages keep working (post in search, post in notifications).

https://github.com/user-attachments/assets/eedcb085-e735-48fa-adf8-157008f6b271

https://github.com/user-attachments/assets/3cd3d1e0-0dc4-4715-9108-b4669606f658

