### PR TITLE
Fix format number polyfill for gl locale

### DIFF
--- a/src/view/com/util/numeric/format.ts
+++ b/src/view/com/util/numeric/format.ts
@@ -21,6 +21,7 @@ const hiFactors = [3, 5, 7, 9, 11, 13]
 const esCaFactors = [3, 6, 10, 12]
 const itDeFactors = [6, 9, 12]
 const jaZhFactors = [4, 8, 12]
+const glFactors = [6, 12]
 const restFactors = [3, 6, 9, 12]
 
 export const formatCount = (i18n: I18n, num: number) => {
@@ -36,6 +37,8 @@ export const formatCount = (i18n: I18n, num: number) => {
     truncatedNum = truncateRounding(num, jaZhFactors)
   } else if (locale === 'it' || locale === 'de') {
     truncatedNum = truncateRounding(num, itDeFactors)
+  } else if (locale === 'gl') {
+    truncatedNum = truncateRounding(num, glFactors)
   } else {
     truncatedNum = truncateRounding(num, restFactors)
   }


### PR DESCRIPTION
Fixes the test that started failing on main with https://github.com/bluesky-social/social-app/pull/6463.

cf. https://unicode.org/cldr/charts/42/verify/numbers/gl.html

