### PR TITLE
Don't re-sort already fetched post thread items

### DIFF
--- a/src/state/queries/post-thread.ts
+++ b/src/state/queries/post-thread.ts
@@ -242,11 +242,11 @@ export function sortThread(
 
       // Split items from different fetches into separate generations.
       let aFetchedAt = fetchedAtCache.get(a.uri)
-      let bFetchedAt = fetchedAtCache.get(b.uri)
       if (aFetchedAt === undefined) {
         fetchedAtCache.set(a.uri, fetchedAt)
         aFetchedAt = fetchedAt
       }
+      let bFetchedAt = fetchedAtCache.get(b.uri)
       if (bFetchedAt === undefined) {
         fetchedAtCache.set(b.uri, fetchedAt)
         bFetchedAt = fetchedAt
@@ -256,7 +256,7 @@ export function sortThread(
         return aFetchedAt - bFetchedAt // older fetches first
       } else if (opts.sort === 'hotness') {
         const aHotness = getHotness(a.post, aFetchedAt)
-        const bHotness = getHotness(b.post, bFetchedAt)
+        const bHotness = getHotness(b.post, bFetchedAt /* same as aFetchedAt */)
         return bHotness - aHotness
       } else if (opts.sort === 'oldest') {
         return a.post.indexedAt.localeCompare(b.post.indexedAt)

--- a/src/state/queries/post-thread.ts
+++ b/src/state/queries/post-thread.ts
@@ -254,8 +254,8 @@ export function sortThread(
       if (aFetchedAt !== bFetchedAt) {
         return aFetchedAt - bFetchedAt // older fetches first
       } else if (opts.sort === 'hotness') {
-        const aHotness = getHotness(a.post)
-        const bHotness = getHotness(b.post)
+        const aHotness = getHotness(a.post, aFetchedAt)
+        const bHotness = getHotness(b.post, bFetchedAt)
         return bHotness - aHotness
       } else if (opts.sort === 'oldest') {
         return a.post.indexedAt.localeCompare(b.post.indexedAt)
@@ -296,10 +296,12 @@ export function sortThread(
 // We want to give recent comments a real chance (and not bury them deep below the fold)
 // while also surfacing well-liked comments from the past. In the future, we can explore
 // something more sophisticated, but we don't have much data on the client right now.
-function getHotness(post: AppBskyFeedDefs.PostView) {
-  const hoursAgo =
-    (new Date().getTime() - new Date(post.indexedAt).getTime()) /
-    (1000 * 60 * 60)
+function getHotness(post: AppBskyFeedDefs.PostView, fetchedAt: number) {
+  const hoursAgo = Math.max(
+    0,
+    (new Date(fetchedAt).getTime() - new Date(post.indexedAt).getTime()) /
+      (1000 * 60 * 60),
+  )
   const likeCount = post.likeCount ?? 0
   const likeOrder = Math.log(3 + likeCount)
   const timePenaltyExponent = 1.5 + 1.5 / (1 + Math.log(1 + likeCount))

--- a/src/state/queries/post-thread.ts
+++ b/src/state/queries/post-thread.ts
@@ -152,6 +152,7 @@ export function sortThread(
   threadgateRecordHiddenReplies: Set<string>,
   fetchedAtCache: Map<string, number>,
   fetchedAt: number,
+  randomCache: Map<string, number>,
 ): ThreadNode {
   if (node.type !== 'post') {
     return node
@@ -268,7 +269,18 @@ export function sortThread(
           return (b.post.likeCount || 0) - (a.post.likeCount || 0) // most likes
         }
       } else if (opts.sort === 'random') {
-        return 0.5 - Math.random() // this is vaguely criminal but we can get away with it
+        let aRandomScore = randomCache.get(a.uri)
+        if (aRandomScore === undefined) {
+          aRandomScore = Math.random()
+          randomCache.set(a.uri, aRandomScore)
+        }
+        let bRandomScore = randomCache.get(b.uri)
+        if (bRandomScore === undefined) {
+          bRandomScore = Math.random()
+          randomCache.set(b.uri, bRandomScore)
+        }
+        // this is vaguely criminal but we can get away with it
+        return aRandomScore - bRandomScore
       } else {
         return b.post.indexedAt.localeCompare(a.post.indexedAt)
       }
@@ -283,6 +295,7 @@ export function sortThread(
         threadgateRecordHiddenReplies,
         fetchedAtCache,
         fetchedAt,
+        randomCache,
       ),
     )
   }

--- a/src/view/com/post-thread/PostThread.tsx
+++ b/src/view/com/post-thread/PostThread.tsx
@@ -171,6 +171,7 @@ export function PostThread({uri}: {uri: string | undefined}) {
     () => new Set<string>(),
   )
 
+  const [stableOrderCache] = React.useState(() => new Map<string, number>())
   const skeleton = React.useMemo(() => {
     const threadViewPrefs = preferences?.threadViewPrefs
     if (!threadViewPrefs || !thread) return null
@@ -183,6 +184,7 @@ export function PostThread({uri}: {uri: string | undefined}) {
         currentDid,
         justPostedUris,
         threadgateHiddenReplies,
+        stableOrderCache,
       ),
       currentDid,
       treeView,
@@ -199,6 +201,7 @@ export function PostThread({uri}: {uri: string | undefined}) {
     hiddenRepliesState,
     justPostedUris,
     threadgateHiddenReplies,
+    stableOrderCache,
   ])
 
   const error = React.useMemo(() => {

--- a/src/view/com/post-thread/PostThread.tsx
+++ b/src/view/com/post-thread/PostThread.tsx
@@ -104,6 +104,7 @@ export function PostThread({uri}: {uri: string | undefined}) {
     error: threadError,
     refetch,
     data: {thread, threadgate} = {},
+    dataUpdatedAt: fetchedAt,
   } = usePostThreadQuery(uri)
 
   const treeView = React.useMemo(
@@ -172,6 +173,7 @@ export function PostThread({uri}: {uri: string | undefined}) {
   )
 
   const [stableOrderCache] = React.useState(() => new Map<string, number>())
+  const [fetchedAtCache] = React.useState(() => new Map<string, number>())
   const skeleton = React.useMemo(() => {
     const threadViewPrefs = preferences?.threadViewPrefs
     if (!threadViewPrefs || !thread) return null
@@ -185,6 +187,8 @@ export function PostThread({uri}: {uri: string | undefined}) {
         justPostedUris,
         threadgateHiddenReplies,
         stableOrderCache,
+        fetchedAtCache,
+        fetchedAt,
       ),
       currentDid,
       treeView,
@@ -202,6 +206,8 @@ export function PostThread({uri}: {uri: string | undefined}) {
     justPostedUris,
     threadgateHiddenReplies,
     stableOrderCache,
+    fetchedAtCache,
+    fetchedAt,
   ])
 
   const error = React.useMemo(() => {

--- a/src/view/com/post-thread/PostThread.tsx
+++ b/src/view/com/post-thread/PostThread.tsx
@@ -172,7 +172,6 @@ export function PostThread({uri}: {uri: string | undefined}) {
     () => new Set<string>(),
   )
 
-  const [stableOrderCache] = React.useState(() => new Map<string, number>())
   const [fetchedAtCache] = React.useState(() => new Map<string, number>())
   const skeleton = React.useMemo(() => {
     const threadViewPrefs = preferences?.threadViewPrefs
@@ -186,7 +185,6 @@ export function PostThread({uri}: {uri: string | undefined}) {
         currentDid,
         justPostedUris,
         threadgateHiddenReplies,
-        stableOrderCache,
         fetchedAtCache,
         fetchedAt,
       ),
@@ -205,7 +203,6 @@ export function PostThread({uri}: {uri: string | undefined}) {
     hiddenRepliesState,
     justPostedUris,
     threadgateHiddenReplies,
-    stableOrderCache,
     fetchedAtCache,
     fetchedAt,
   ])

--- a/src/view/com/post-thread/PostThread.tsx
+++ b/src/view/com/post-thread/PostThread.tsx
@@ -173,6 +173,7 @@ export function PostThread({uri}: {uri: string | undefined}) {
   )
 
   const [fetchedAtCache] = React.useState(() => new Map<string, number>())
+  const [randomCache] = React.useState(() => new Map<string, number>())
   const skeleton = React.useMemo(() => {
     const threadViewPrefs = preferences?.threadViewPrefs
     if (!threadViewPrefs || !thread) return null
@@ -187,6 +188,7 @@ export function PostThread({uri}: {uri: string | undefined}) {
         threadgateHiddenReplies,
         fetchedAtCache,
         fetchedAt,
+        randomCache,
       ),
       currentDid,
       treeView,
@@ -205,6 +207,7 @@ export function PostThread({uri}: {uri: string | undefined}) {
     threadgateHiddenReplies,
     fetchedAtCache,
     fetchedAt,
+    randomCache,
   ])
 
   const error = React.useMemo(() => {


### PR DESCRIPTION
This took me a little bit to figure out but I think the result works well.
Might be easier to review the entire thing than commit by commit.

## The Problem

Currently, if your thread sorting preference is anything other than "oldest first", the sort order between refetches is not guaranteed to be stable. As a result, you'll often get layout shifts:

1. Start replying to somebody's reply from the parent post thread
2. The thread refetches
3. The order may be different, and now you're looking at a random comment

This is very easily observable with the "random" sort order:

https://github.com/user-attachments/assets/9d3ab603-0b1e-4eb3-9c2f-c6d54f6e948d

Although this was _most_ severe with the "random" sort order (where every attempt to reply reorders everything), it was also an issue with the "newest" or "liked" order. The new "hotness" mode also suffers from this, motivating the fix.

## A Solution

My proposal to fix this is to **avoid changing the order for the items that have previously been fetched and sorted.** Concretely, this means:

1. OP, Self, and Friend posts are still prioritized above everything
2. Other new items from each next refetch are conceptually grouped into a separate new "generation"
3. Items from older generations always sort above items from newer generations
4. Items within the same generation sort using the existing algorithms
5. Comparisons within the same generation are tweaked to be deterministic

All caching is local to the current post thread UI component and doesn't apply to pushes or pops.

Consequences of new behavior:

- On the first fetch, it's identical to the old behavior. The sorting order is applied as usual.
- On a refetch (e.g. due to replying), the previously unseen (newly fetched) items are placed at the bottom.
  - Prioritized items (OP post, self post, friends post) remain an exception. They're "bounded" so shifting a bit is OK.
  - Other than that, unseen items are placed at the bottom.
  - Within that new bottom slice, the unseen items are sorted among themselves with the selected order.
- If you exit the thread and push into it again, you'll see the pristine (everything sorted) state again.

## Test Plan

This is easiest to observe with the Random order. Previously, a newly fetched reply from an unrelated account would cause you to lose your position. With the change (recorded below), newly fetched non-priority replies are placed at the bottom:

https://github.com/user-attachments/assets/096483c3-43e9-4201-a955-ab31611c5a6a

You can also observe this with Hotness. Previously, a newly fetched reply from an unrelated account would cause you to lose your position. With the change (recorded below), newly fetched replies non-priority are placed at the bottom:

https://github.com/user-attachments/assets/6c92d563-7227-4ad3-8169-077ea07659ae

