### PR TITLE
Remove broken translated strings

### DIFF
--- a/src/locale/locales/gl/messages.po
+++ b/src/locale/locales/gl/messages.po
@@ -191,7 +191,7 @@ msgstr ""
 
 #: src/components/LabelingServiceCard/index.tsx:96
 msgid "{count, plural, one {Liked by # user} other {Liked by # users}}"
-msgstr "{count, plural, one {Liked by # user} outro {Liked by # users}}"
+msgstr ""
 
 #: src/view/shell/desktop/LeftNav.tsx:223
 msgid "{count} unread items"
@@ -367,8 +367,6 @@ msgstr "{profileName} uniuse a Bluesky empregando un paquete de comezo fai {0}"
 msgctxt "profiles"
 msgid "<0>{0}, </0><1>{1}, </1>and {2, plural, one {# other} other {# others}} are included in your starter pack"
 msgstr ""
-"<0>{0}, </0><1>{1}, </1>e {2, plural, un {# outro} outro {# outros}} foron incluídos no teu paquete\n"
-""
 
 #: src/screens/StarterPack/Wizard/index.tsx:528
 msgctxt "feeds"
@@ -382,14 +380,10 @@ msgstr "<0>{0}, </0><1>{1}, </1>e {2, plural, one {# other} other {# others}} in
 #: src/view/shell/Drawer.tsx:97
 msgid "<0>{0}</0> {1, plural, one {follower} other {followers}}"
 msgstr ""
-"<0>{0}</0> {1, plural, one {follower} outros {followers}}\n"
-""
 
 #: src/view/shell/Drawer.tsx:108
 msgid "<0>{0}</0> {1, plural, one {following} other {following}}"
 msgstr ""
-"<0>{0}</0> {1, plural, one {following} outro {following}}\n"
-""
 
 #: src/screens/StarterPack/Wizard/index.tsx:516
 msgid "<0>{0}</0> and<1> </1><2>{1} </2>are included in your starter pack"

--- a/src/locale/locales/it/messages.po
+++ b/src/locale/locales/it/messages.po
@@ -196,7 +196,7 @@ msgstr "{estimatedTimeMins, plural, one {minuto} other {minuti}}"
 
 #: src/view/com/notifications/FeedItem.tsx:300
 msgid "{firstAuthorLink} and <0>{additionalAuthorsCount, plural, one {{formattedAuthorsCount} other} other {{formattedAuthorsCount} others}}</0> followed you"
-msgstr "{firstAuthorLink} e <0>{additionalAuthorsCount, plural, one {{formattedAuthorsCount} other} altro {{formattedAuthorsCount} altri}}</0> ti hanno seguito"
+msgstr ""
 
 #: src/view/com/notifications/FeedItem.tsx:326
 msgid "{firstAuthorLink} and <0>{additionalAuthorsCount, plural, one {{formattedAuthorsCount} other} other {{formattedAuthorsCount} others}}</0> liked your custom feed"


### PR DESCRIPTION
Something got borked with some translations during the last release: https://github.com/bluesky-social/social-app/pull/6463#issuecomment-2496116888

I'm removing things that give me build errors.

## Test Plan

Running `yarn` no longer errors