### PR TITLE
fix: keyboard handler memoization

### DIFF
--- a/src/components/Dialog/index.tsx
+++ b/src/components/Dialog/index.tsx
@@ -214,12 +214,15 @@ export const ScrollableInner = React.forwardRef<ScrollView, DialogInnerProps>(
       }
     })
 
-    useKeyboardHandler({
-      onEnd: e => {
-        'worklet'
-        runOnJS(setKeyboardHeight)(e.height)
+    useKeyboardHandler(
+      {
+        onEnd: e => {
+          'worklet'
+          runOnJS(setKeyboardHeight)(e.height)
+        },
       },
-    })
+      [],
+    )
 
     const basePading =
       (isIOS ? 30 : 50) + (isIOS ? keyboardHeight / 4 : keyboardHeight)

--- a/src/screens/Messages/components/MessagesList.tsx
+++ b/src/screens/Messages/components/MessagesList.tsx
@@ -250,30 +250,33 @@ export function MessagesList({
   // We use this value to keep track of when we want to disable the animation.
   const layoutScrollWithoutAnimation = useSharedValue(false)
 
-  useKeyboardHandler({
-    onStart: e => {
-      'worklet'
-      // Immediate updates - like opening the emoji picker - will have a duration of zero. In those cases, we should
-      // just update the height here instead of having the `onMove` event do it (that event will not fire!)
-      if (e.duration === 0) {
-        layoutScrollWithoutAnimation.set(true)
+  useKeyboardHandler(
+    {
+      onStart: e => {
+        'worklet'
+        // Immediate updates - like opening the emoji picker - will have a duration of zero. In those cases, we should
+        // just update the height here instead of having the `onMove` event do it (that event will not fire!)
+        if (e.duration === 0) {
+          layoutScrollWithoutAnimation.set(true)
+          keyboardHeight.set(e.height)
+        } else {
+          keyboardIsOpening.set(true)
+        }
+      },
+      onMove: e => {
+        'worklet'
         keyboardHeight.set(e.height)
-      } else {
-        keyboardIsOpening.set(true)
-      }
+        if (e.height > bottomOffset) {
+          scrollTo(flatListRef, 0, 1e7, false)
+        }
+      },
+      onEnd: () => {
+        'worklet'
+        keyboardIsOpening.set(false)
+      },
     },
-    onMove: e => {
-      'worklet'
-      keyboardHeight.set(e.height)
-      if (e.height > bottomOffset) {
-        scrollTo(flatListRef, 0, 1e7, false)
-      }
-    },
-    onEnd: () => {
-      'worklet'
-      keyboardIsOpening.set(false)
-    },
-  })
+    [],
+  )
 
   const animatedListStyle = useAnimatedStyle(() => ({
     marginBottom:

--- a/src/screens/Messages/components/MessagesList.tsx
+++ b/src/screens/Messages/components/MessagesList.tsx
@@ -275,7 +275,7 @@ export function MessagesList({
         keyboardIsOpening.set(false)
       },
     },
-    [],
+    [bottomOffset],
   )
 
   const animatedListStyle = useAnimatedStyle(() => ({


### PR DESCRIPTION
The array of dependencies is needed to prevent frequent re-attaching handlers. Internally `useKeyboardHandler` is based on `useEffect` and without dependencies `useEffect` will be fired on each re-render (which may affect performance).