### PR TITLE
Make quote post enabled switch label text static

### DIFF
--- a/src/components/dialogs/PostInteractionSettingsDialog.tsx
+++ b/src/components/dialogs/PostInteractionSettingsDialog.tsx
@@ -311,7 +311,7 @@ export function PostInteractionSettingsForm({
               onChange={onChangeQuotesEnabled}
               style={[a.justify_between, a.pt_xs]}>
               <Text style={[t.atoms.text_contrast_medium]}>
-                <Trans>Quote posts enabled</Trans>
+                <Trans>Allow quote posts</Trans>
               </Text>
               <Toggle.Switch />
             </Toggle.Item>

--- a/src/components/dialogs/PostInteractionSettingsDialog.tsx
+++ b/src/components/dialogs/PostInteractionSettingsDialog.tsx
@@ -311,11 +311,7 @@ export function PostInteractionSettingsForm({
               onChange={onChangeQuotesEnabled}
               style={[a.justify_between, a.pt_xs]}>
               <Text style={[t.atoms.text_contrast_medium]}>
-                {quotesEnabled ? (
-                  <Trans>Quote posts enabled</Trans>
-                ) : (
-                  <Trans>Quote posts disabled</Trans>
-                )}
+                <Trans>Allow quote posts</Trans>
               </Text>
               <Toggle.Switch />
             </Toggle.Item>

--- a/src/components/dialogs/PostInteractionSettingsDialog.tsx
+++ b/src/components/dialogs/PostInteractionSettingsDialog.tsx
@@ -311,7 +311,7 @@ export function PostInteractionSettingsForm({
               onChange={onChangeQuotesEnabled}
               style={[a.justify_between, a.pt_xs]}>
               <Text style={[t.atoms.text_contrast_medium]}>
-                <Trans>Allow quote posts</Trans>
+                <Trans>Quote posts enabled</Trans>
               </Text>
               <Toggle.Switch />
             </Toggle.Item>


### PR DESCRIPTION
Fixes https://github.com/bluesky-social/social-app/issues/6687

Switches should not change text to reflect state as the state is already reflected in the switch itself; changing the text makes it more confusing to the user.