### PR TITLE
Fix camera orientation on Android

### DIFF
--- a/patches/react-native-image-crop-picker+0.41.2.patch
+++ b/patches/react-native-image-crop-picker+0.41.2.patch
@@ -1,0 +1,39 @@
+diff --git a/node_modules/react-native-image-crop-picker/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java b/node_modules/react-native-image-crop-picker/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
+index 5de0845..fa477e7 100644
+--- a/node_modules/react-native-image-crop-picker/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
++++ b/node_modules/react-native-image-crop-picker/android/src/main/java/com/reactnative/ivpusic/imagepicker/PickerModule.java
+@@ -21,6 +21,7 @@ import android.webkit.MimeTypeMap;
+ 
+ import androidx.core.app.ActivityCompat;
+ import androidx.core.content.FileProvider;
++import androidx.exifinterface.media.ExifInterface;
+ 
+ import com.facebook.react.bridge.ActivityEventListener;
+ import com.facebook.react.bridge.Callback;
+@@ -678,6 +679,15 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
+             throw new Exception("Cannot select remote files");
+         }
+         BitmapFactory.Options original = validateImage(path);
++        ExifInterface originalExif = new ExifInterface(path);
++        int orientation = originalExif.getAttributeInt(ExifInterface.TAG_ORIENTATION, 1);
++        boolean invertDimensions = (
++                orientation == ExifInterface.ORIENTATION_ROTATE_90 ||
++                        orientation == ExifInterface.ORIENTATION_ROTATE_270 ||
++                        orientation == ExifInterface.ORIENTATION_TRANSPOSE ||
++                        orientation == ExifInterface.ORIENTATION_TRANSVERSE
++        );
++
+ 
+         // if compression options are provided image will be compressed. If none options is provided,
+         // then original image will be returned
+@@ -687,8 +697,8 @@ class PickerModule extends ReactContextBaseJavaModule implements ActivityEventLi
+         long modificationDate = new File(path).lastModified();
+ 
+         image.putString("path", "file://" + compressedImagePath);
+-        image.putInt("width", options.outWidth);
+-        image.putInt("height", options.outHeight);
++        image.putInt("width", invertDimensions ? options.outHeight : options.outWidth);
++        image.putInt("height", invertDimensions ? options.outWidth : options.outHeight);
+         image.putString("mime", options.outMimeType);
+         image.putInt("size", (int) new File(compressedImagePath).length());
+         image.putString("modificationDate", String.valueOf(modificationDate));


### PR DESCRIPTION
Fixes a bug where using the camera button would produce a stretched image on Android. The issue was that the `width`/`height` were misreported by not taking the EXIF tags into account. The iOS version does this correctly.

Upstream PR: https://github.com/ivpusic/react-native-image-crop-picker/pull/2110

## Test Plan

Try taking a camera image in all orientations (landscape/rotate with both front/back camera), verify it appears correctly both before posting (in the composer preview) and after posting.