### PR TITLE
Fix Android keyboard bug when opening a sheet

### DIFF
--- a/src/screens/Messages/components/MessagesList.tsx
+++ b/src/screens/Messages/components/MessagesList.tsx
@@ -267,7 +267,7 @@ export function MessagesList({
           scrollTo(flatListRef, 0, 1e7, false)
         }
       },
-      onEnd: () => {
+      onEnd: e => {
         'worklet'
         keyboardHeight.set(e.height)
         if (e.height > bottomOffset) {

--- a/src/screens/Messages/components/MessagesList.tsx
+++ b/src/screens/Messages/components/MessagesList.tsx
@@ -1,10 +1,7 @@
 import React, {useCallback, useRef} from 'react'
 import {LayoutChangeEvent, View} from 'react-native'
-import {
-  KeyboardStickyView,
-  useKeyboardHandler,
-} from 'react-native-keyboard-controller'
-import {
+import {useKeyboardHandler} from 'react-native-keyboard-controller'
+import Animated, {
   runOnJS,
   scrollTo,
   useAnimatedRef,
@@ -272,6 +269,10 @@ export function MessagesList({
       },
       onEnd: () => {
         'worklet'
+        keyboardHeight.set(e.height)
+        if (e.height > bottomOffset) {
+          scrollTo(flatListRef, 0, 1e7, false)
+        }
         keyboardIsOpening.set(false)
       },
     },
@@ -279,8 +280,11 @@ export function MessagesList({
   )
 
   const animatedListStyle = useAnimatedStyle(() => ({
-    marginBottom:
-      keyboardHeight.get() > bottomOffset ? keyboardHeight.get() : bottomOffset,
+    marginBottom: Math.max(keyboardHeight.get(), bottomOffset),
+  }))
+
+  const animatedStickyViewStyle = useAnimatedStyle(() => ({
+    transform: [{translateY: -Math.max(keyboardHeight.get(), bottomOffset)}],
   }))
 
   // -- Message sending
@@ -422,7 +426,7 @@ export function MessagesList({
           }
         />
       </ScrollProvider>
-      <KeyboardStickyView offset={{closed: -bottomOffset, opened: 0}}>
+      <Animated.View style={animatedStickyViewStyle}>
         {convoState.status === ConvoStatus.Disabled ? (
           <ChatDisabled />
         ) : blocked ? (
@@ -441,7 +445,7 @@ export function MessagesList({
             </MessageInput>
           </>
         )}
-      </KeyboardStickyView>
+      </Animated.View>
 
       {isWeb && (
         <EmojiPicker


### PR DESCRIPTION
On Android, opening a menu in DMs would cause the keyboard input to enter a strange state. This attempts to fix it by setting the keyboard height on the `onEnd` event and reimplementing KeyboardStickyView manually (turns out it's a very simple component, and we basically are already doing same the logic anyway for the scrollview)

# Before

https://github.com/user-attachments/assets/f53e9374-1d81-48ce-8d0e-63401604825f

# After

https://github.com/user-attachments/assets/91940a5a-b1df-46bd-8c18-f54aa9b540ce

