### PR TITLE
Fix stutter when swiping feeds on Android

### DIFF
--- a/src/state/shell/minimal-mode.tsx
+++ b/src/state/shell/minimal-mode.tsx
@@ -1,10 +1,5 @@
 import React from 'react'
-import {
-  cancelAnimation,
-  SharedValue,
-  useSharedValue,
-  withSpring,
-} from 'react-native-reanimated'
+import {SharedValue, useSharedValue, withSpring} from 'react-native-reanimated'
 
 type StateContext = {
   headerMode: SharedValue<number>
@@ -42,14 +37,11 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
   const setMode = React.useCallback(
     (v: boolean) => {
       'worklet'
-      // Cancel any existing animation
-      cancelAnimation(headerMode)
       headerMode.set(() =>
         withSpring(v ? 1 : 0, {
           overshootClamping: true,
         }),
       )
-      cancelAnimation(footerMode)
       footerMode.set(() =>
         withSpring(v ? 1 : 0, {
           overshootClamping: true,

--- a/src/view/com/util/MainScrollProvider.tsx
+++ b/src/view/com/util/MainScrollProvider.tsx
@@ -1,7 +1,6 @@
 import React, {useCallback, useEffect} from 'react'
 import {NativeScrollEvent} from 'react-native'
 import {
-  cancelAnimation,
   interpolate,
   makeMutable,
   useSharedValue,
@@ -43,7 +42,6 @@ export function MainScrollProvider({children}: {children: React.ReactNode}) {
   const setMode = React.useCallback(
     (v: boolean) => {
       'worklet'
-      cancelAnimation(headerMode)
       headerMode.set(v ? V1.get() : V0.get())
     },
     [headerMode],
@@ -149,8 +147,6 @@ export function MainScrollProvider({children}: {children: React.ReactNode}) {
         const newValue = clamp(startModeValue + dProgress, 0, 1)
         if (newValue !== headerMode.get()) {
           // Manually adjust the value. This won't be (and shouldn't be) animated.
-          // Cancel any any existing animation
-          cancelAnimation(headerMode)
           headerMode.set(newValue)
         }
       } else {


### PR DESCRIPTION
This was originally added in https://github.com/bluesky-social/social-app/pull/4386. I don't think we ever truly established that it was necessary. It does, however, definitely cause problems now so I think we should rip it out.

To reproduce the issue, swipe to another feed while the header is not visible.

## Before

The animation effectively happens twice and interrupts itself. (Due to multiple identical calls to `setMode`.)

https://github.com/user-attachments/assets/d67c110f-8aee-480c-8dec-61b5318cd121

## After

The animation doesn't interrupt itself.

https://github.com/user-attachments/assets/b5113c02-4090-46d0-afa2-36711dfc7950

I verified it works well on the device too.