### PR TITLE
Fully support languages with 3-character codes

### DIFF
--- a/src/locale/deviceLocales.ts
+++ b/src/locale/deviceLocales.ts
@@ -67,7 +67,7 @@ export function getLocales() {
 export const deviceLocales = getLocales()
 
 /**
- * BCP-47 language tag without region e.g. array of 2-char lang codes
+ * BCP-47 language tag without region
  *
  * {@link https://docs.expo.dev/versions/latest/sdk/localization/#locale}
  */

--- a/src/locale/helpers.ts
+++ b/src/locale/helpers.ts
@@ -6,30 +6,11 @@ import {hasProp} from '#/lib/type-guards'
 import {
   AppLanguage,
   type Language,
-  LANGUAGES_MAP_CODE2,
-  LANGUAGES_MAP_CODE3,
+  LANGUAGES_MAP,
 } from './languages'
 
-export function code2ToCode3(lang: string): string {
-  if (lang.length === 2) {
-    return LANGUAGES_MAP_CODE2[lang]?.code3 || lang
-  }
-  return lang
-}
-
-export function code3ToCode2(lang: string): string {
-  if (lang.length === 3) {
-    return LANGUAGES_MAP_CODE3[lang]?.code2 || lang
-  }
-  return lang
-}
-
-export function code3ToCode2Strict(lang: string): string | undefined {
-  if (lang.length === 3) {
-    return LANGUAGES_MAP_CODE3[lang]?.code2
-  }
-
-  return undefined
+function canonicalCode(lang: string): string {
+  return LANGUAGES_MAP[lang]?.code || lang
 }
 
 function getLocalizedLanguage(
@@ -62,14 +43,13 @@ export function languageName(language: Language, appLang: string): string {
     return language.name
   }
 
-  return getLocalizedLanguage(language.code2, appLang) || language.name
+  return getLocalizedLanguage(language.code, appLang) || language.name
 }
 
-export function codeToLanguageName(lang2or3: string, appLang: string): string {
-  const code2 = code3ToCode2(lang2or3)
-  const knownLanguage = LANGUAGES_MAP_CODE2[code2]
+export function codeToLanguageName(lang: string, appLang: string): string {
+  const knownLanguage = LANGUAGES_MAP[lang]
 
-  return knownLanguage ? languageName(knownLanguage, appLang) : code2
+  return knownLanguage ? languageName(knownLanguage, appLang) : lang
 }
 
 export function getPostLanguage(
@@ -89,6 +69,8 @@ export function getPostLanguage(
     candidates = post.record.langs
   }
 
+  candidates = candidates.map(canonicalCode)
+
   // if there's only one declared language, use that
   if (candidates?.length === 1) {
     return candidates[0]
@@ -106,13 +88,13 @@ export function getPostLanguage(
   if (candidates?.length) {
     langsProbabilityMap = langsProbabilityMap.filter(
       ([lang, _probability]: [string, number]) => {
-        return candidates.includes(code3ToCode2(lang))
+        return candidates.includes(canonicalCode(lang))
       },
     )
   }
 
   if (langsProbabilityMap[0]) {
-    return code3ToCode2(langsProbabilityMap[0][0])
+    return canonicalCode(langsProbabilityMap[0][0])
   }
 }
 

--- a/src/locale/languages.ts
+++ b/src/locale/languages.ts
@@ -1,6 +1,6 @@
 export interface Language {
-  code3: string
-  code2: string
+  code: string
+  aliases: string[]
   name: string
 }
 
@@ -628,15 +628,30 @@ export const LANGUAGES: Language[] = [
     name: 'Zaza; Dimili; Dimli; Kirdki; Kirmanjki; Zazaki',
   },
 ]
+  .map(({code3, code2, name}) => {
+    let code = code2 || code3
+    let aliases = [code2, code3].filter(c => !!c && c !== code)
+    return {
+      code,
+      aliases,
+      name,
+    }
+  })
+  .filter((lang, index, self) => {
+    // Merge dupes
+    let firstIndex = self.findIndex(t => t.code === lang.code)
+    if (index !== firstIndex) {
+      self[firstIndex].aliases.push(...self[index].aliases)
+      return false
+    }
+    return true
+  })
 
-export const LANGUAGES_MAP_CODE2 = Object.fromEntries(
-  LANGUAGES.map(lang => [lang.code2, lang]),
-)
+// `lande` outputs 'pes', meaning 'Iranian Persian' instead of 'Persian' in general, for some reason. Since there is no Iranian Persion language currently, map this to Persian.
+LANGUAGES.find(lang => lang.code === 'fa')?.aliases.push('pes')
 
-export const LANGUAGES_MAP_CODE3 = Object.fromEntries(
-  LANGUAGES.map(lang => [lang.code3, lang]),
+export const LANGUAGES_MAP = Object.fromEntries(
+  LANGUAGES.flatMap(lang =>
+    [lang.code].concat(lang.aliases).map(code => [code, lang]),
+  ),
 )
-// some additional manual mappings (not clear if these should be in the "official" mappings)
-if (LANGUAGES_MAP_CODE2.fa) {
-  LANGUAGES_MAP_CODE3.pes = LANGUAGES_MAP_CODE2.fa
-}

--- a/src/screens/Search/components/SearchLanguageDropdown.tsx
+++ b/src/screens/Search/components/SearchLanguageDropdown.tsx
@@ -27,13 +27,12 @@ export function SearchLanguageDropdown({
   const languages = useMemo(() => {
     return LANGUAGES.filter(
       (lang, index, self) =>
-        Boolean(lang.code2) && // reduce to the code2 varieties
-        index === self.findIndex(t => t.code2 === lang.code2), // remove dupes (which will happen)
+        index === self.findIndex(t => t.code === lang.code), // remove dupes (which will happen)
     )
       .map(l => ({
         label: languageName(l, appLanguage),
-        value: l.code2,
-        key: l.code2 + l.code3,
+        value: l.code,
+        key: l.code,
       }))
       .sort((a, b) => {
         // prioritize user's languages
@@ -44,14 +43,13 @@ export function SearchLanguageDropdown({
         // prioritize "common" langs in the network
         const aIsCommon = !!APP_LANGUAGES.find(
           al =>
-            // skip `ast`, because it uses a 3-letter code which conflicts with `as`
-            // it begins with `a` anyway so still is top of the list
-            al.code2 !== 'ast' && al.code2.startsWith(a.value),
+            // some app langs have regions, like `zh-Hant-TW`, so check a prefix of `zh-` too
+            al.code2 === a.value || al.code2.startsWith(a.value + '-'),
         )
         const bIsCommon = !!APP_LANGUAGES.find(
           al =>
             // ditto
-            al.code2 !== 'ast' && al.code2.startsWith(b.value),
+            al.code2 === b.value || al.code2.startsWith(b.value + '-'),
         )
         if (aIsCommon && !bIsCommon) return -1
         if (bIsCommon && !aIsCommon) return 1

--- a/src/screens/Settings/LanguageSettings.tsx
+++ b/src/screens/Settings/LanguageSettings.tsx
@@ -4,7 +4,11 @@ import RNPickerSelect, {PickerSelectProps} from 'react-native-picker-select'
 import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
-import {APP_LANGUAGES, LANGUAGES} from '#/lib/../locale/languages'
+import {
+  APP_LANGUAGES,
+  LANGUAGES,
+  LANGUAGES_MAP,
+} from '#/lib/../locale/languages'
 import {CommonNavigatorParams, NativeStackScreenProps} from '#/lib/routes/types'
 import {languageName, sanitizeAppLanguageSetting} from '#/locale/helpers'
 import {useModalControls} from '#/state/modals'
@@ -54,7 +58,7 @@ export function LanguageSettingsScreen({}: Props) {
   const myLanguages = useMemo(() => {
     return (
       langPrefs.contentLanguages
-        .map(lang => LANGUAGES.find(l => l.code2 === lang))
+        .map(lang => LANGUAGES_MAP[lang])
         .filter(Boolean)
         // @ts-ignore
         .map(l => languageName(l, langPrefs.appLanguage))
@@ -177,10 +181,10 @@ export function LanguageSettingsScreen({}: Props) {
                   placeholder={{}}
                   value={langPrefs.primaryLanguage}
                   onValueChange={onChangePrimaryLanguage}
-                  items={LANGUAGES.filter(l => Boolean(l.code2)).map(l => ({
+                  items={LANGUAGES.map(l => ({
                     label: languageName(l, langPrefs.appLanguage),
-                    value: l.code2,
-                    key: l.code2 + l.code3,
+                    value: l.code,
+                    key: l.code,
                   }))}
                   style={{
                     inputAndroid: {

--- a/src/state/preferences/languages.tsx
+++ b/src/state/preferences/languages.tsx
@@ -8,13 +8,13 @@ type SetStateCb = (
 ) => persisted.Schema['languagePrefs']
 type StateContext = persisted.Schema['languagePrefs']
 type ApiContext = {
-  setPrimaryLanguage: (code2: string) => void
+  setPrimaryLanguage: (code: string) => void
   setPostLanguage: (commaSeparatedLangCodes: string) => void
-  setContentLanguage: (code2: string) => void
-  toggleContentLanguage: (code2: string) => void
-  togglePostLanguage: (code2: string) => void
+  setContentLanguage: (code: string) => void
+  toggleContentLanguage: (code: string) => void
+  togglePostLanguage: (code: string) => void
   savePostLanguageToHistory: () => void
-  setAppLanguage: (code2: AppLanguage) => void
+  setAppLanguage: (code: AppLanguage) => void
 }
 
 const stateContext = React.createContext<StateContext>(
@@ -50,40 +50,40 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
 
   const api = React.useMemo(
     () => ({
-      setPrimaryLanguage(code2: string) {
-        setStateWrapped(s => ({...s, primaryLanguage: code2}))
+      setPrimaryLanguage(code: string) {
+        setStateWrapped(s => ({...s, primaryLanguage: code}))
       },
       setPostLanguage(commaSeparatedLangCodes: string) {
         setStateWrapped(s => ({...s, postLanguage: commaSeparatedLangCodes}))
       },
-      setContentLanguage(code2: string) {
-        setStateWrapped(s => ({...s, contentLanguages: [code2]}))
+      setContentLanguage(code: string) {
+        setStateWrapped(s => ({...s, contentLanguages: [code]}))
       },
-      toggleContentLanguage(code2: string) {
+      toggleContentLanguage(code: string) {
         setStateWrapped(s => {
-          const exists = s.contentLanguages.includes(code2)
+          const exists = s.contentLanguages.includes(code)
           const next = exists
-            ? s.contentLanguages.filter(lang => lang !== code2)
-            : s.contentLanguages.concat(code2)
+            ? s.contentLanguages.filter(lang => lang !== code)
+            : s.contentLanguages.concat(code)
           return {
             ...s,
             contentLanguages: next,
           }
         })
       },
-      togglePostLanguage(code2: string) {
+      togglePostLanguage(code: string) {
         setStateWrapped(s => {
-          const exists = hasPostLanguage(state.postLanguage, code2)
+          const exists = hasPostLanguage(state.postLanguage, code)
           let next = s.postLanguage
 
           if (exists) {
             next = toPostLanguages(s.postLanguage)
-              .filter(lang => lang !== code2)
+              .filter(lang => lang !== code)
               .join(',')
           } else {
             // sort alphabetically for deterministic comparison in context menu
             next = toPostLanguages(s.postLanguage)
-              .concat([code2])
+              .concat([code])
               .sort((a, b) => a.localeCompare(b))
               .join(',')
           }
@@ -113,8 +113,8 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
             .slice(0, 6),
         }))
       },
-      setAppLanguage(code2: AppLanguage) {
-        setStateWrapped(s => ({...s, appLanguage: code2}))
+      setAppLanguage(code: AppLanguage) {
+        setStateWrapped(s => ({...s, appLanguage: code}))
       },
     }),
     [state, setStateWrapped],
@@ -154,6 +154,6 @@ export function toPostLanguages(postLanguage: string): string[] {
   return postLanguage.split(',').filter(Boolean)
 }
 
-export function hasPostLanguage(postLanguage: string, code2: string): boolean {
-  return toPostLanguages(postLanguage).includes(code2)
+export function hasPostLanguage(postLanguage: string, code: string): boolean {
+  return toPostLanguages(postLanguage).includes(code)
 }

--- a/src/view/com/composer/select-language/SuggestedLanguage.tsx
+++ b/src/view/com/composer/select-language/SuggestedLanguage.tsx
@@ -10,7 +10,8 @@ import lande from 'lande'
 
 import {usePalette} from '#/lib/hooks/usePalette'
 import {s} from '#/lib/styles'
-import {code3ToCode2Strict, codeToLanguageName} from '#/locale/helpers'
+import {codeToLanguageName} from '#/locale/helpers'
+import {LANGUAGES_MAP} from '#/locale/languages'
 import {
   toPostLanguages,
   useLanguagePrefs,
@@ -123,5 +124,5 @@ function guessLanguage(text: string): string | undefined {
   if (value < 0.97) {
     return undefined
   }
-  return code3ToCode2Strict(lang)
+  return LANGUAGES_MAP[lang]?.code
 }

--- a/src/view/com/composer/videos/SubtitleDialog.tsx
+++ b/src/view/com/composer/videos/SubtitleDialog.tsx
@@ -147,8 +147,8 @@ function SubtitleDialogInner({
                   setCaptions={setCaptions}
                   otherLanguages={LANGUAGES.filter(
                     lang =>
-                      langCode(lang) === subtitle.lang ||
-                      !captions.some(s => s.lang === langCode(lang)),
+                      lang.code === subtitle.lang ||
+                      !captions.some(s => s.lang === lang.code),
                   )}
                   style={[i % 2 === 0 && t.atoms.bg_contrast_25]}
                 />
@@ -195,7 +195,7 @@ function SubtitleFileRow({
 }: {
   language: string
   file: File
-  otherLanguages: {code2: string; code3: string; name: string}[]
+  otherLanguages: {code: string; name: string}[]
   setCaptions: (updater: (prev: CaptionsTrack[]) => CaptionsTrack[]) => void
   style: StyleProp<ViewStyle>
 }) {
@@ -248,8 +248,8 @@ function SubtitleFileRow({
             value={language}
             onValueChange={handleValueChange}
             items={otherLanguages.map(lang => ({
-              label: `${lang.name} (${langCode(lang)})`,
-              value: langCode(lang),
+              label: `${lang.name} (${lang.code})`,
+              value: lang.code,
             }))}
             style={{viewContainer: {maxWidth: 200, flex: 1}}}
           />
@@ -270,8 +270,4 @@ function SubtitleFileRow({
       </Button>
     </View>
   )
-}
-
-function langCode(lang: {code2: string; code3: string}) {
-  return lang.code2 || lang.code3
 }

--- a/src/view/com/modals/lang-settings/ContentLanguagesSettings.tsx
+++ b/src/view/com/modals/lang-settings/ContentLanguagesSettings.tsx
@@ -11,7 +11,7 @@ import {
   useLanguagePrefs,
   useLanguagePrefsApi,
 } from '#/state/preferences/languages'
-import {LANGUAGES, LANGUAGES_MAP_CODE2} from '../../../../locale/languages'
+import {LANGUAGES} from '../../../../locale/languages'
 import {Text} from '../../util/text/Text'
 import {ScrollView} from '../util'
 import {ConfirmLanguagesButton} from './ConfirmLanguagesButton'
@@ -30,19 +30,15 @@ export function Component({}: {}) {
   }, [closeModal])
 
   const languages = React.useMemo(() => {
-    const langs = LANGUAGES.filter(
-      lang =>
-        !!lang.code2.trim() &&
-        LANGUAGES_MAP_CODE2[lang.code2].code3 === lang.code3,
-    )
+    const langs = [...LANGUAGES]
     // sort so that device & selected languages are on top, then alphabetically
     langs.sort((a, b) => {
       const hasA =
-        langPrefs.contentLanguages.includes(a.code2) ||
-        deviceLanguageCodes.includes(a.code2)
+        langPrefs.contentLanguages.includes(a.code) ||
+        deviceLanguageCodes.includes(a.code)
       const hasB =
-        langPrefs.contentLanguages.includes(b.code2) ||
-        deviceLanguageCodes.includes(b.code2)
+        langPrefs.contentLanguages.includes(b.code) ||
+        deviceLanguageCodes.includes(b.code)
       if (hasA === hasB) return a.name.localeCompare(b.name)
       if (hasA) return -1
       return 1
@@ -51,8 +47,8 @@ export function Component({}: {}) {
   }, [langPrefs])
 
   const onPress = React.useCallback(
-    (code2: string) => {
-      setLangPrefs.toggleContentLanguage(code2)
+    (code: string) => {
+      setLangPrefs.toggleContentLanguage(code)
     },
     [setLangPrefs],
   )
@@ -86,12 +82,12 @@ export function Component({}: {}) {
       <ScrollView style={styles.scrollContainer}>
         {languages.map(lang => (
           <LanguageToggle
-            key={lang.code2}
-            code2={lang.code2}
+            key={lang.code}
+            code={lang.code}
             langType="contentLanguages"
             name={languageName(lang, langPrefs.appLanguage)}
             onPress={() => {
-              onPress(lang.code2)
+              onPress(lang.code)
             }}
           />
         ))}

--- a/src/view/com/modals/lang-settings/LanguageToggle.tsx
+++ b/src/view/com/modals/lang-settings/LanguageToggle.tsx
@@ -5,12 +5,12 @@ import {toPostLanguages, useLanguagePrefs} from '#/state/preferences/languages'
 import {ToggleButton} from '#/view/com/util/forms/ToggleButton'
 
 export function LanguageToggle({
-  code2,
+  code,
   name,
   onPress,
   langType,
 }: {
-  code2: string
+  code: string
   name: string
   onPress: () => void
   langType: 'contentLanguages' | 'postLanguages'
@@ -22,7 +22,7 @@ export function LanguageToggle({
     langType === 'contentLanguages'
       ? langPrefs.contentLanguages
       : toPostLanguages(langPrefs.postLanguage)
-  const isSelected = values.includes(code2)
+  const isSelected = values.includes(code)
 
   // enforce a max of 3 selections for post languages
   let isDisabled = false

--- a/src/view/com/modals/lang-settings/PostLanguagesSettings.tsx
+++ b/src/view/com/modals/lang-settings/PostLanguagesSettings.tsx
@@ -13,7 +13,7 @@ import {
   useLanguagePrefsApi,
 } from '#/state/preferences/languages'
 import {ToggleButton} from '#/view/com/util/forms/ToggleButton'
-import {LANGUAGES, LANGUAGES_MAP_CODE2} from '../../../../locale/languages'
+import {LANGUAGES} from '../../../../locale/languages'
 import {Text} from '../../util/text/Text'
 import {ScrollView} from '../util'
 import {ConfirmLanguagesButton} from './ConfirmLanguagesButton'
@@ -31,19 +31,14 @@ export function Component() {
   }, [closeModal])
 
   const languages = React.useMemo(() => {
-    const langs = LANGUAGES.filter(
-      lang =>
-        !!lang.code2.trim() &&
-        LANGUAGES_MAP_CODE2[lang.code2].code3 === lang.code3,
-    )
-    // sort so that device & selected languages are on top, then alphabetically
+    const langs = [...LANGUAGES] // sort so that device & selected languages are on top, then alphabetically
     langs.sort((a, b) => {
       const hasA =
-        hasPostLanguage(langPrefs.postLanguage, a.code2) ||
-        deviceLanguageCodes.includes(a.code2)
+        hasPostLanguage(langPrefs.postLanguage, a.code) ||
+        deviceLanguageCodes.includes(a.code)
       const hasB =
-        hasPostLanguage(langPrefs.postLanguage, b.code2) ||
-        deviceLanguageCodes.includes(b.code2)
+        hasPostLanguage(langPrefs.postLanguage, b.code) ||
+        deviceLanguageCodes.includes(b.code)
       if (hasA === hasB) return a.name.localeCompare(b.name)
       if (hasA) return -1
       return 1
@@ -52,8 +47,8 @@ export function Component() {
   }, [langPrefs])
 
   const onPress = React.useCallback(
-    (code2: string) => {
-      setLangPrefs.togglePostLanguage(code2)
+    (code: string) => {
+      setLangPrefs.togglePostLanguage(code)
     },
     [setLangPrefs],
   )
@@ -81,7 +76,7 @@ export function Component() {
       </Text>
       <ScrollView style={styles.scrollContainer}>
         {languages.map(lang => {
-          const isSelected = hasPostLanguage(langPrefs.postLanguage, lang.code2)
+          const isSelected = hasPostLanguage(langPrefs.postLanguage, lang.code)
 
           // enforce a max of 3 selections for post languages
           let isDisabled = false
@@ -91,10 +86,10 @@ export function Component() {
 
           return (
             <ToggleButton
-              key={lang.code2}
+              key={lang.code}
               label={languageName(lang, langPrefs.appLanguage)}
               isSelected={isSelected}
-              onPress={() => (isDisabled ? undefined : onPress(lang.code2))}
+              onPress={() => (isDisabled ? undefined : onPress(lang.code))}
               style={[
                 pal.border,
                 styles.languageToggle,


### PR DESCRIPTION
Most languages do not have 2 character codes and will never get them, because the ISO committee no longer assigns them.

There are more things wrong with this language list, but I stopped here for now. Future work:

- Take the list from https://www.iana.org/assignments/language-subtag-registry/language-subtag-registry, which is the list referenced by the HTML standard for possible values of `lang` attributes in HTML
- Get localized language names from CLDR
- Uh...figure out what to do about the fact that `lande` outputs `pes` for Persian, which actually means specifically Iranian Persian while `per` and `fas` and `fa` are Persian in general... man, no one really knows how to handle language families.

Have tested this on web on
- Language selector on post compose box
- Subtitle language selector
- Content language selector in settings
- Primary language selector in settings
- Language filter in search