### PR TITLE
Fix ast localization

### DIFF
--- a/src/components/hooks/dates.ts
+++ b/src/components/hooks/dates.ts
@@ -10,7 +10,6 @@
 import React from 'react'
 import {formatDistance, Locale} from 'date-fns'
 import {
-  ast,
   ca,
   de,
   enGB,
@@ -45,7 +44,7 @@ import {useLanguagePrefs} from '#/state/preferences'
  */
 const locales: Record<AppLanguage, Locale | undefined> = {
   en: undefined,
-  ast,
+  ast: undefined,
   an: undefined,
   ca,
   de,

--- a/src/locale/languages.ts
+++ b/src/locale/languages.ts
@@ -43,7 +43,7 @@ interface AppLanguageConfig {
 export const APP_LANGUAGES: AppLanguageConfig[] = [
   {code2: AppLanguage.en, name: 'English'},
   {code2: AppLanguage.an, name: 'Aragonés – Aragonese'},
-  {code3: AppLanguage.ast, name: 'Asturianu - Asturian'},
+  {code2: AppLanguage.ast, name: 'Asturianu - Asturian'},
   {code2: AppLanguage.ca, name: 'Català – Catalan'},
   {code2: AppLanguage.de, name: 'Deutsch – German'},
   {code2: AppLanguage.en_GB, name: 'English (UK)'},


### PR DESCRIPTION
[date-fns](https://www.npmjs.com/package/date-fns) does not define `ast`, we should remove the import, and set `ast` to `undefined`.

Although `ast` is a Code3 language code, the subsequent code requires a Code2 language code. Let's assign it as Code2 (even though it is not correct) so it can passes the check. This should not affect Post Language or other processing, as it is only related to the App Language.

<img src="https://github.com/user-attachments/assets/a31dc807-8f37-482e-980c-e6582eb3f436" width="400" />
