### PR TITLE
Fix gap between Write Your Reply and bottom bar on web

### DIFF
--- a/src/view/com/post-thread/PostThread.tsx
+++ b/src/view/com/post-thread/PostThread.tsx
@@ -538,13 +538,14 @@ export function PostThread({uri}: {uri: string | undefined}) {
 function MobileComposePrompt({onPressReply}: {onPressReply: () => unknown}) {
   const safeAreaInsets = useSafeAreaInsets()
   const fabMinimalShellTransform = useMinimalShellFabTransform()
+  console.log()
   return (
     <Animated.View
       style={[
         styles.prompt,
         fabMinimalShellTransform,
         {
-          bottom: clamp(safeAreaInsets.bottom, 15, 30),
+          bottom: clamp(safeAreaInsets.bottom, 13, 30),
         },
       ]}>
       <PostThreadComposePrompt onPressCompose={onPressReply} />

--- a/src/view/com/post-thread/PostThread.tsx
+++ b/src/view/com/post-thread/PostThread.tsx
@@ -538,7 +538,6 @@ export function PostThread({uri}: {uri: string | undefined}) {
 function MobileComposePrompt({onPressReply}: {onPressReply: () => unknown}) {
   const safeAreaInsets = useSafeAreaInsets()
   const fabMinimalShellTransform = useMinimalShellFabTransform()
-  console.log()
   return (
     <Animated.View
       style={[


### PR DESCRIPTION
Mobile web only.

Does not affect native (it has a bottom safe inset that's larger), does not affect tablet or desktop.

## Before

<img width="569" alt="Screenshot 2024-11-27 at 14 44 43" src="https://github.com/user-attachments/assets/fe61c873-7614-4d54-a737-28dfc918142e">

## After

<img width="570" alt="Screenshot 2024-11-27 at 14 44 54" src="https://github.com/user-attachments/assets/387bf94c-6ecc-4bc8-ac5a-d6baa3f58700">

