### PR TITLE
Fix: Prevent modal from closing when selecting text and moving mouse outside

### DIFF
--- a/src/view/com/modals/Modal.web.tsx
+++ b/src/view/com/modals/Modal.web.tsx
@@ -91,7 +91,7 @@ function Modal({modal}: {modal: ModalIface}) {
 
   return (
     // eslint-disable-next-line react-native-a11y/has-valid-accessibility-descriptors
-    <TouchableWithoutFeedback onPress={onPressMask}>
+    <TouchableWithoutFeedback onPressOut={onPressMask}>
       <Animated.View
         style={styles.mask}
         entering={FadeIn.duration(150)}


### PR DESCRIPTION
**Bug Description:**
When interacting with a modal, if you select text within the modal and then move the mouse outside the modal while still holding the mouse button, the modal closes when the mouse button is released.

**Steps to Reproduce:**
- Open the modal.
- Select text inside the modal.
- Drag the mouse outside the modal while holding the mouse button.
- Release the mouse button.

**Expected Behavior:** The modal should remain open even if the mouse moves outside the modal while selecting text.
**Actual Behavior:** The modal unexpectedly closes when the mouse button is released after moving outside the modal.

**Example:** https://jam.dev/c/7b0a02d2-e130-491c-a2c6-68ac0fbd91e5

**Environment:**
Browser 131.0.6778.86 (Official Build) (arm64)
Operating System macOS 12.0.1 