### PR TITLE
Fix language picker style in dark mode

### DIFF
--- a/src/components/AppLanguageDropdown.tsx
+++ b/src/components/AppLanguageDropdown.tsx
@@ -34,6 +34,7 @@ export function AppLanguageDropdown(_props: ViewStyleProp) {
   return (
     <View style={a.relative}>
       <RNPickerSelect
+        darkTheme={t.scheme === 'dark'}
         placeholder={{}}
         value={sanitizedLang}
         onValueChange={onChangeAppLanguage}

--- a/src/screens/Settings/LanguageSettings.tsx
+++ b/src/screens/Settings/LanguageSettings.tsx
@@ -80,6 +80,7 @@ export function LanguageSettingsScreen({}: Props) {
               </Text>
               <View style={[a.relative, web([a.w_full, {maxWidth: 400}])]}>
                 <RNPickerSelect
+                  darkTheme={t.scheme === 'dark'}
                   placeholder={{}}
                   value={sanitizeAppLanguageSetting(langPrefs.appLanguage)}
                   onValueChange={onChangeAppLanguage}
@@ -165,6 +166,7 @@ export function LanguageSettingsScreen({}: Props) {
               </Text>
               <View style={[a.relative, web([a.w_full, {maxWidth: 400}])]}>
                 <RNPickerSelect
+                  darkTheme={t.scheme === 'dark'}
                   placeholder={{}}
                   value={langPrefs.primaryLanguage}
                   onValueChange={onChangePrimaryLanguage}

--- a/src/view/screens/Search/Search.tsx
+++ b/src/view/screens/Search/Search.tsx
@@ -394,6 +394,7 @@ function SearchLanguageDropdown({
 
   return (
     <RNPickerSelect
+      darkTheme={t.scheme === 'dark'}
       placeholder={{}}
       value={value}
       onValueChange={onChange}


### PR DESCRIPTION
Fixes: #6803 
I don't have any Android devices nor can successfully test it with emulator so the picker in Android should still in wrong style under dark mode

### Before
| Splash Screen  | Sign Up Page | Languages Setting Page  | Search |
|---|---|---|---|
| <img src='https://github.com/user-attachments/assets/661c257f-7e82-41ec-8699-6bbd7d3b6d6c' width = 450 />  | <img src='https://github.com/user-attachments/assets/bdce127e-20a9-4505-b0d5-f56a746c5f3d' width = 450 />  | <img src='https://github.com/user-attachments/assets/25724447-2c83-4c35-bbee-be0c723f1b64' width = 450 />  | <img src='https://github.com/user-attachments/assets/52793d8b-0620-46f8-96f9-d1621aad7ae0' width = 450 />  | 

### After
| Splash Screen  | Sign Up Page | Languages Setting Page  | Search |
|---|---|---|---|
| <img src='https://github.com/user-attachments/assets/e9b0b58c-0ac0-4ee8-9fd0-7981643d9019' width = 450 /> | <img src='https://github.com/user-attachments/assets/095b07f5-9e74-477e-9be0-9049cd1c8d33' width = 450 /> | <img src='https://github.com/user-attachments/assets/696d541e-c5fc-4b3f-af00-427af56a1921' width = 450 /> | <img src='https://github.com/user-attachments/assets/586722f1-49d2-431a-804d-6ade5cccdb3c' width = 450 /> |

