### PR TITLE
Prevent esc key from exiting the browser full screen mode

### DIFF
--- a/src/view/com/lightbox/Lightbox.web.tsx
+++ b/src/view/com/lightbox/Lightbox.web.tsx
@@ -102,7 +102,6 @@ function LightboxInner({
   const isAvi = img.type === 'circle-avi' || img.type === 'rect-avi'
   return (
     <View style={styles.mask}>
-      <Text style={{backgroundColor: 'blue'}}>this is a test</Text>
       <TouchableWithoutFeedback
         onPress={onClose}
         accessibilityRole="button"

--- a/src/view/com/lightbox/Lightbox.web.tsx
+++ b/src/view/com/lightbox/Lightbox.web.tsx
@@ -74,6 +74,7 @@ function LightboxInner({
   const onKeyDown = useCallback(
     (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
+        e.preventDefault()
         onClose()
       } else if (e.key === 'ArrowLeft') {
         onPressLeft()
@@ -101,6 +102,7 @@ function LightboxInner({
   const isAvi = img.type === 'circle-avi' || img.type === 'rect-avi'
   return (
     <View style={styles.mask}>
+      <Text style={{backgroundColor: 'blue'}}>this is a test</Text>
       <TouchableWithoutFeedback
         onPress={onClose}
         accessibilityRole="button"


### PR DESCRIPTION
Fixes #6763 

1. Summary
When the image is displayed in the full-screen mode and the esc button is pressed, it exits the full-screen mode for both the image and browser. It happens on only Safari and Firefox. The event that exits the full-screen mode for image occurs from our code base and browser one seems to be a default behavior.

2. Solution
Prevented the default behavior of the Esc key exiting the browser full-screen mode when the image is displayed in the full-screen mode.

3. Recording

https://github.com/user-attachments/assets/e0ac3a05-c38c-4175-8b32-e8d3046821e7

