### PR TITLE
"Contain" images with missing dimensions instead of cropping them

### DIFF
--- a/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.android.tsx
+++ b/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.android.tsx
@@ -392,9 +392,9 @@ const ImageItem = ({
           <Animated.View style={imageCropStyle}>
             <Animated.View style={imageStyle}>
               <Image
-                contentFit="cover"
+                contentFit="contain"
                 source={{uri: imageSrc.uri}}
-                placeholderContentFit="cover"
+                placeholderContentFit="contain"
                 placeholder={{uri: imageSrc.thumbUri}}
                 accessibilityLabel={imageSrc.alt}
                 onLoad={

--- a/src/view/com/lightbox/ImageViewing/index.tsx
+++ b/src/view/com/lightbox/ImageViewing/index.tsx
@@ -8,7 +8,7 @@
 // Original code copied and simplified from the link below as the codebase is currently not maintained:
 // https://github.com/jobtoday/react-native-image-viewing
 
-import React, {useCallback, useEffect, useState} from 'react'
+import React, {useCallback, useEffect, useMemo, useState} from 'react'
 import {
   LayoutAnimation,
   PixelRatio,
@@ -79,6 +79,15 @@ const FAST_SPRING: WithSpringConfig = {
   restDisplacementThreshold: 0.01,
 }
 
+function canAnimate(lightbox: Lightbox): boolean {
+  return (
+    !PlatformInfo.getIsReducedMotionEnabled() &&
+    lightbox.images.every(
+      img => img.thumbRect && (img.dimensions || img.thumbDimensions),
+    )
+  )
+}
+
 export default function ImageViewRoot({
   lightbox: nextLightbox,
   onRequestClose,
@@ -104,23 +113,19 @@ export default function ImageViewRoot({
       return
     }
 
-    const canAnimate =
-      !PlatformInfo.getIsReducedMotionEnabled() &&
-      nextLightbox.images.every(
-        img => img.thumbRect && (img.dimensions || img.thumbDimensions),
-      )
+    const isAnimated = canAnimate(nextLightbox)
 
     // https://github.com/software-mansion/react-native-reanimated/issues/6677
     rAF_FIXED(() => {
       openProgress.set(() =>
-        canAnimate ? withClampedSpring(1, SLOW_SPRING) : 1,
+        isAnimated ? withClampedSpring(1, SLOW_SPRING) : 1,
       )
     })
     return () => {
       // https://github.com/software-mansion/react-native-reanimated/issues/6677
       rAF_FIXED(() => {
         openProgress.set(() =>
-          canAnimate ? withClampedSpring(0, SLOW_SPRING) : 0,
+          isAnimated ? withClampedSpring(0, SLOW_SPRING) : 0,
         )
       })
     }
@@ -185,6 +190,7 @@ function ImageView({
   openProgress: SharedValue<number>
 }) {
   const {images, index: initialImageIndex} = lightbox
+  const isAnimated = useMemo(() => canAnimate(lightbox), [lightbox])
   const [isScaled, setIsScaled] = useState(false)
   const [isDragging, setIsDragging] = useState(false)
   const [imageIndex, setImageIndex] = useState(initialImageIndex)
@@ -194,10 +200,19 @@ function ImageView({
   const isFlyingAway = useSharedValue(false)
 
   const containerStyle = useAnimatedStyle(() => {
-    if (openProgress.get() < 1 || isFlyingAway.get()) {
-      return {pointerEvents: 'none'}
+    if (openProgress.get() < 1) {
+      return {
+        pointerEvents: 'none',
+        opacity: isAnimated ? 1 : 0,
+      }
     }
-    return {pointerEvents: 'auto'}
+    if (isFlyingAway.get()) {
+      return {
+        pointerEvents: 'none',
+        opacity: 1,
+      }
+    }
+    return {pointerEvents: 'auto', opacity: 1}
   })
 
   const backdropStyle = useAnimatedStyle(() => {

--- a/src/view/com/util/images/AutoSizedImage.tsx
+++ b/src/view/com/util/images/AutoSizedImage.tsx
@@ -85,10 +85,6 @@ export function AutoSizedImage({
     if (Number.isNaN(aspectRatio)) {
       aspectRatio = undefined
     }
-  } else {
-    // If we don't know it synchronously, treat it like a square.
-    // We won't use fetched dimensions to avoid a layout shift.
-    aspectRatio = 1
   }
 
   let constrained: number | undefined
@@ -103,11 +99,13 @@ export function AutoSizedImage({
 
   const cropDisabled = crop === 'none'
   const isCropped = rawIsCropped && !cropDisabled
+  const isContain = aspectRatio === undefined
   const hasAlt = !!image.alt
 
   const contents = (
     <View ref={containerRef} collapsable={false} style={{flex: 1}}>
       <Image
+        contentFit={isContain ? 'contain' : 'cover'}
         style={[a.w_full, a.h_full]}
         source={image.thumb}
         accessible={true} // Must set for `accessibilityLabel` to work
@@ -115,9 +113,11 @@ export function AutoSizedImage({
         accessibilityLabel={image.alt}
         accessibilityHint=""
         onLoad={e => {
-          fetchedDimsRef.current = {
-            width: e.source.width,
-            height: e.source.height,
+          if (!isContain) {
+            fetchedDimsRef.current = {
+              width: e.source.width,
+              height: e.source.height,
+            }
           }
         }}
       />


### PR DESCRIPTION
Addresses https://github.com/bluesky-social/social-app/issues/6800

As noted in https://github.com/bluesky-social/social-app/pull/6474, we don't want to use dynamically fetched dimensions on the client because it causes layout shifts for any post(s) after the image. In the worst case this can cause an entire cascade of relayouts which is absolutely terrible for performance.

However, as discussed in https://github.com/bluesky-social/social-app/issues/6800, cropping can feel pretty disruptive. Instead, let's try "containing" when the aspect ratio is unknown.

This only affects images with missing dimensions. (Currently, it's up to the client to specify the dimensions.) In longer term it would be nice if the server could somehow fill out the missing ones, but fixing that is out of scope of this PR.

I had to disable the lightbox animation for such images because the initial sizing is going to be different in the "contains" layout. While disabling the animation, I noticed flashes on first and last frames, which the two last commits take care of.

## Test Plan

Find an account with images that are missing dimensions, for example https://bsky.app/profile/wrtrstat.bsky.social

Verify that images with unknown aspect ratio are now "contained" instead of cropped.

Verify that opening them in the lightbox works, but skips the expanding animation.

Verify that opening images _with_ dimensions remains fluid and animated.

Test all platforms.

## Before

<img width="386" alt="Screenshot 2024-11-28 at 17 36 26" src="https://github.com/user-attachments/assets/1a90f35b-82fe-40ac-8d8c-cea8de0e62c3">

<img width="387" alt="Screenshot 2024-11-28 at 17 36 33" src="https://github.com/user-attachments/assets/45906333-d98b-4693-b6b3-9554e16b9891">

## After

<img width="395" alt="Screenshot 2024-11-28 at 17 36 11" src="https://github.com/user-attachments/assets/d6a13af6-d43d-466e-a5de-9aa933164ab6">
<img width="396" alt="Screenshot 2024-11-28 at 17 36 17" src="https://github.com/user-attachments/assets/c7e33a85-88d4-421f-b026-ca29f16aec8b">
