### PR TITLE
Closes #6817 (proposal)

### DIFF
--- a/src/locale/locales/it/messages.po
+++ b/src/locale/locales/it/messages.po
@@ -162,7 +162,7 @@ msgstr "{0}m"
 #. How many months have passed, displayed in a narrow form
 #: src/lib/hooks/useTimeAgo.ts:169
 msgid "{0}mo"
-msgstr "{0}mesi"
+msgstr "{0}me"
 
 #. How many seconds have passed, displayed in a narrow form
 #: src/lib/hooks/useTimeAgo.ts:128


### PR DESCRIPTION
A tiny, minor thing about the narrow Italian month translation. As Michele mentioned in #6817 , the current "2mesi" is pretty ugly, so my proposition is to use "2me".

Another option is to have "2 mesi" but that would be inconsistent with all the other narrow translations.

Of course we would consider the same approach for all other languages.