### PR TITLE
Add 'Clear All' button for search history

### DIFF
--- a/src/view/screens/Search/Search.tsx
+++ b/src/view/screens/Search/Search.tsx
@@ -847,6 +847,17 @@ export function SearchScreen(
     [selectedProfiles],
   )
 
+  const handleClearAll = React.useCallback(async () => {
+    setSearchHistory([])
+    setSelectedProfiles([])
+    try {
+      await AsyncStorage.setItem('searchHistory', JSON.stringify([]))
+      await AsyncStorage.setItem('selectedProfiles', JSON.stringify([]))
+    } catch (e) {
+      logger.error('Failed to clear search history and profiles', {message: e})
+    }
+  }, [])
+
   const onSearchInputFocus = React.useCallback(() => {
     if (isWeb) {
       // Prevent a jump on iPad by ensuring that
@@ -951,6 +962,7 @@ export function SearchScreen(
             onProfileClick={handleProfileClick}
             onRemoveItemClick={handleRemoveHistoryItem}
             onRemoveProfileClick={handleRemoveProfile}
+            onClearAll={handleClearAll}
           />
         )}
       </View>
@@ -1034,6 +1046,7 @@ function SearchHistory({
   onProfileClick,
   onRemoveItemClick,
   onRemoveProfileClick,
+  onClearAll,
 }: {
   searchHistory: string[]
   selectedProfiles: AppBskyActorDefs.ProfileViewBasic[]
@@ -1041,6 +1054,7 @@ function SearchHistory({
   onProfileClick: (profile: AppBskyActorDefs.ProfileViewBasic) => void
   onRemoveItemClick: (item: string) => void
   onRemoveProfileClick: (profile: AppBskyActorDefs.ProfileViewBasic) => void
+  onClearAll: () => void
 }) {
   const {isTabletOrDesktop, isMobile} = useWebMediaQueries()
   const pal = usePalette('default')
@@ -1055,9 +1069,21 @@ function SearchHistory({
       }}>
       <View style={styles.searchHistoryContainer}>
         {(searchHistory.length > 0 || selectedProfiles.length > 0) && (
-          <Text style={[pal.text, styles.searchHistoryTitle]}>
-            <Trans>Recent Searches</Trans>
-          </Text>
+          <View style={[a.flex_row, a.justify_between, a.align_center]}>
+            <Text style={[pal.text, styles.searchHistoryTitle]}>
+              <Trans>Recent Searches</Trans>
+            </Text>
+            <Button
+              label={_(msg`Clear all`)}
+              size="tiny"
+              variant="ghost"
+              color="primary"
+              onPress={() => onClearAll()}>
+              <ButtonText>
+                <Trans>Clear all</Trans>
+              </ButtonText>
+            </Button>
+          </View>
         )}
         {selectedProfiles.length > 0 && (
           <View

--- a/src/view/screens/Search/Search.tsx
+++ b/src/view/screens/Search/Search.tsx
@@ -850,12 +850,13 @@ export function SearchScreen(
   const handleClearAll = React.useCallback(async () => {
     setSearchHistory([])
     setSelectedProfiles([])
-    try {
-      await AsyncStorage.setItem('searchHistory', JSON.stringify([]))
-      await AsyncStorage.setItem('selectedProfiles', JSON.stringify([]))
-    } catch (e) {
-      logger.error('Failed to clear search history and profiles', {message: e})
-    }
+    await AsyncStorage.multiRemove(['searchHistory', 'selectedProfiles']).catch(
+      e => {
+        logger.error('Failed to clear search history and profiles', {
+          message: e,
+        })
+      },
+    )
   }, [])
 
   const onSearchInputFocus = React.useCallback(() => {


### PR DESCRIPTION
Regarding this issue https://github.com/bluesky-social/social-app/issues/4700

This PR adds a simple "Clear All" button to the search history interface. The button allows users to quickly delete all saved search entries `searchHistory` and selected profiles `selectedProfiles` in one action, without introducing unnecessary complexity.

## Why this change?
Currently, users must manually delete each search entry one at a time, which can be frustrating. This addition aligns with user expectations and mirrors similar features found in other platforms, like Twitter.

## Test plan

1. Confirm the button appears when there is search history to clear.
2. Verify clicking the button removes all entries immediately.
3. Ensure the button disappears when there is no search history.
4. Test the button’s behavior across devices and themes (e.g., light mode).


https://github.com/user-attachments/assets/9221641c-f1a3-404d-9a58-f05a0d00d02d


