### PR TITLE
Update spacing of post ctrls to have dynamic width based on their content

### DIFF
--- a/src/view/com/util/post-ctrls/PostCtrls.tsx
+++ b/src/view/com/util/post-ctrls/PostCtrls.tsx
@@ -245,7 +245,7 @@ let PostCtrls = ({
     <View style={[a.flex_row, a.justify_between, a.align_center, style]}>
       <View
         style={[
-          big ? a.align_center : [a.flex_1, a.align_start, {marginLeft: -6}],
+          !big ? {marginLeft: -6} : undefined,
           post.viewer?.replyDisabled ? {opacity: 0.5} : undefined,
         ]}>
         <Pressable
@@ -280,7 +280,7 @@ let PostCtrls = ({
           ) : undefined}
         </Pressable>
       </View>
-      <View style={big ? a.align_center : [a.flex_1, a.align_start]}>
+      <View>
         <RepostButton
           isReposted={!!post.viewer?.repost}
           repostCount={(post.repostCount ?? 0) + (post.quoteCount ?? 0)}
@@ -290,7 +290,7 @@ let PostCtrls = ({
           embeddingDisabled={Boolean(post.viewer?.embeddingDisabled)}
         />
       </View>
-      <View style={big ? a.align_center : [a.flex_1, a.align_start]}>
+      <View>
         <Pressable
           testID="likeBtn"
           style={btnStyle}
@@ -356,7 +356,7 @@ let PostCtrls = ({
           />
         </>
       )}
-      <View style={big ? a.align_center : [a.flex_1, a.align_start]}>
+      <View>
         <PostDropdownBtn
           testID="postDropdownBtn"
           post={post}


### PR DESCRIPTION
Fixes #6829 

1. Summary
The issue occurs because the width of each control is not determined by its content but rather by the parent container. Four controls will have the same width(25%) proportional to the parent container. 
This causes an issue on small devices with languages that use lengthy formatting for follower/repost counts.

2. Solution
I found a couple of issues in the current code. 
[big ? a.align_center : [a.flex_1, a.align_start, {marginLeft: -6}],](https://github.com/bluesky-social/social-app/blob/5f4a0f2881b9420f3a3f3fb6527352f58a99d9ea/src/view/com/util/post-ctrls/PostCtrls.tsx#L248)
In this code, when big is true, the width will be the same as its content, thus `a.align_start` doesn't really have any effects.
And I am not sure if it was intentional to make 4 ctrls have the same width across all posts regardless of the length of each ctrl.
While I understand this fix might not be the best solution to the reported issue, I updated ctrls to have the dynamic width based on their contents, so if the number formatting gets lengthy, the control width gets bigger accordingly.  
It seems `marginLeft: -6` still makes sense because the repost icon has some left margin around it and we have to compensate that for the alignment with the post content.

3. Screenshots
[Android]
![Screenshot_1732890984](https://github.com/user-attachments/assets/155da5ff-195b-4daf-85aa-f305833fd5dd)
![Screenshot_1732891040](https://github.com/user-attachments/assets/dc93f275-7f7c-44dd-adec-594cb30480a6)

[iOS]
![image](https://github.com/user-attachments/assets/4f9490da-3678-46aa-926b-1ff204e60331)

![image](https://github.com/user-attachments/assets/e14c3907-e140-4560-8009-e2aa9e2f4821)

