### PR TITLE
Fix conflicts in sequential mutations for following feed preferences

### DIFF
--- a/src/screens/Settings/FollowingFeedPreferences.tsx
+++ b/src/screens/Settings/FollowingFeedPreferences.tsx
@@ -24,24 +24,16 @@ export function FollowingFeedPreferencesScreen({}: Props) {
   const {_} = useLingui()
 
   const {data: preferences} = usePreferencesQuery()
-  const {mutate: setFeedViewPref, variables} =
-    useSetFeedViewPreferencesMutation()
+  const {mutate: setFeedViewPref} = useSetFeedViewPreferencesMutation()
 
-  const showReplies = !(
-    variables?.hideReplies ?? preferences?.feedViewPrefs?.hideReplies
-  )
+  const showReplies = !preferences?.feedViewPrefs?.hideReplies
 
-  const showReposts = !(
-    variables?.hideReposts ?? preferences?.feedViewPrefs?.hideReposts
-  )
+  const showReposts = !preferences?.feedViewPrefs?.hideReposts
 
-  const showQuotePosts = !(
-    variables?.hideQuotePosts ?? preferences?.feedViewPrefs?.hideQuotePosts
-  )
+  const showQuotePosts = !preferences?.feedViewPrefs?.hideQuotePosts
 
   const mergeFeedEnabled = Boolean(
-    variables?.lab_mergeFeedEnabled ??
-      preferences?.feedViewPrefs?.lab_mergeFeedEnabled,
+    preferences?.feedViewPrefs?.lab_mergeFeedEnabled,
   )
 
   return (

--- a/src/state/queries/preferences/index.ts
+++ b/src/state/queries/preferences/index.ts
@@ -28,6 +28,10 @@ export * from '#/state/queries/preferences/types'
 const preferencesQueryKeyRoot = 'getPreferences'
 export const preferencesQueryKey = [preferencesQueryKeyRoot]
 
+type SetFeedViewPreferencesMutationContext = {
+  prevPrefs?: UsePreferencesQueryResponse
+}
+
 export function usePreferencesQuery() {
   const agent = useAgent()
   return useQuery({
@@ -161,17 +165,51 @@ export function useSetFeedViewPreferencesMutation() {
   const queryClient = useQueryClient()
   const agent = useAgent()
 
-  return useMutation<void, unknown, Partial<BskyFeedViewPreference>>({
+  return useMutation<
+    void,
+    unknown,
+    Partial<BskyFeedViewPreference>,
+    SetFeedViewPreferencesMutationContext
+  >({
     mutationFn: async prefs => {
       /*
        * special handling here, merged into `feedViewPrefs` above, since
        * following was previously called `home`
        */
       await agent.setFeedViewPrefs('home', prefs)
-      // triggers a refetch
-      await queryClient.invalidateQueries({
+    },
+    onMutate: async newFeedViewPrefs => {
+      // Cancel any outgoing refetches
+      await queryClient.cancelQueries({
         queryKey: preferencesQueryKey,
       })
+
+      // Snapshot the previous value
+      const prevPrefs =
+        queryClient.getQueryData<UsePreferencesQueryResponse>(
+          preferencesQueryKey,
+        )
+
+      // Optimistically update the cache
+      queryClient.setQueryData(
+        preferencesQueryKey,
+        (old: UsePreferencesQueryResponse) => ({
+          ...old,
+          feedViewPrefs: {
+            ...old.feedViewPrefs,
+            ...newFeedViewPrefs,
+          },
+        }),
+      )
+
+      // Return a context object with the snapshotted value
+      return {prevPrefs}
+    },
+    // On error, rollback to the previous state
+    onError: (_err, _newPrefs, context) => {
+      if (context?.prevPrefs) {
+        queryClient.setQueryData(preferencesQueryKey, context?.prevPrefs)
+      }
     },
   })
 }


### PR DESCRIPTION
Fixes #6631 
1. Summary
This issue happens whenever multiple toggle mutations happen contiguously. The problem is we invalidate the fetch query(and re-fetch it) right after executing the mutation and at that time, another mutation is in the queue and the user's selection in the second mutation is overwritten by the first mutation's re-fetch. And it goes back to the correct state when the second re-fetch is finished which is made after the second mutation. The optimistic update is not done in an idiomatic way either.

2. Solution
https://tanstack.com/query/latest/docs/framework/react/guides/optimistic-updates#optimistic-updates
I utilized useMutation's `onMutate`, `onError` callbacks to have the cache in sync with the back-end. So before we call the mutation endpoint, we make an optimistic update and roll it back if that fails for whatever reason. I figured we don't need to invalidate the query and make a fetch request for every mutation because, for most cases, `Following Feed Preferences` page is the only place where users can mutate the data associated with those toggles.

3. Recording

https://github.com/user-attachments/assets/11450a5a-2680-4ea7-9106-9073000581ff

