### PR TITLE
Developer mode toggle

### DIFF
--- a/src/screens/Settings/AboutSettings.tsx
+++ b/src/screens/Settings/AboutSettings.tsx
@@ -7,17 +7,22 @@ import {NativeStackScreenProps} from '@react-navigation/native-stack'
 import {appVersion, BUNDLE_DATE, bundleInfo} from '#/lib/app-info'
 import {STATUS_PAGE_URL} from '#/lib/constants'
 import {CommonNavigatorParams} from '#/lib/routes/types'
+import {useDeveloperModeEnabled, useSetDeveloperModeEnabled} from '#/state/preferences'
 import * as Toast from '#/view/com/util/Toast'
 import * as SettingsList from '#/screens/Settings/components/SettingsList'
+import * as Toggle from '#/components/forms/Toggle'
 import {CodeLines_Stroke2_Corner2_Rounded as CodeLinesIcon} from '#/components/icons/CodeLines'
 import {Globe_Stroke2_Corner0_Rounded as GlobeIcon} from '#/components/icons/Globe'
 import {Newspaper_Stroke2_Corner2_Rounded as NewspaperIcon} from '#/components/icons/Newspaper'
 import {Wrench_Stroke2_Corner2_Rounded as WrenchIcon} from '#/components/icons/Wrench'
+import {Atom_Stroke2_Corner0_Rounded as AtomIcon} from '#/components/icons/Atom'
 import * as Layout from '#/components/Layout'
 
 type Props = NativeStackScreenProps<CommonNavigatorParams, 'AboutSettings'>
 export function AboutSettingsScreen({}: Props) {
   const {_} = useLingui()
+  const developerModeEnabledPref = useDeveloperModeEnabled()
+  const setdeveloperModeEnabledPref = useSetDeveloperModeEnabled()
 
   return (
     <Layout.Screen>
@@ -70,6 +75,19 @@ export function AboutSettingsScreen({}: Props) {
             </SettingsList.ItemText>
             <SettingsList.BadgeText>{bundleInfo}</SettingsList.BadgeText>
           </SettingsList.PressableItem>
+          <Toggle.Item
+            name="enable_developer_mode"
+            label={_(msg`Devloper Mode`)}
+            value={developerModeEnabledPref}
+            onChange={value => setdeveloperModeEnabledPref(value)}>
+            <SettingsList.Item>
+              <SettingsList.ItemIcon icon={AtomIcon} />
+              <SettingsList.ItemText>
+                <Trans>Developer mode</Trans>
+              </SettingsList.ItemText>
+              <Toggle.Platform />
+            </SettingsList.Item>
+          </Toggle.Item>
         </SettingsList.Container>
       </Layout.Content>
     </Layout.Screen>

--- a/src/state/persisted/schema.ts
+++ b/src/state/persisted/schema.ts
@@ -122,6 +122,7 @@ const schema = z.object({
   kawaii: z.boolean().optional(),
   hasCheckedForStarterPack: z.boolean().optional(),
   subtitlesEnabled: z.boolean().optional(),
+  developerModeEnabled: z.boolean().optional(),
   /** @deprecated */
   mutedThreads: z.array(z.string()),
 })
@@ -169,6 +170,7 @@ export const defaults: Schema = {
   kawaii: false,
   hasCheckedForStarterPack: false,
   subtitlesEnabled: true,
+  developerModeEnabled: false,
 }
 
 export function tryParse(rawData: string): Schema | undefined {

--- a/src/state/preferences/developer-mode.tsx
+++ b/src/state/preferences/developer-mode.tsx
@@ -1,0 +1,42 @@
+import React from 'react'
+
+import * as persisted from '#/state/persisted'
+
+type StateContext = boolean
+type SetContext = (v: boolean) => void
+
+const stateContext = React.createContext<StateContext>(
+  Boolean(persisted.defaults.developerModeEnabled),
+)
+const setContext = React.createContext<SetContext>((_: boolean) => {})
+
+export function Provider({children}: {children: React.ReactNode}) {
+  const [state, setState] = React.useState(
+    Boolean(persisted.get('developerModeEnabled')),
+  )
+
+  const setStateWrapped = React.useCallback(
+    (developerModeEnabled: persisted.Schema['developerModeEnabled']) => {
+      setState(Boolean(developerModeEnabled))
+      persisted.write('developerModeEnabled', developerModeEnabled)
+    },
+    [setState],
+  )
+
+  React.useEffect(() => {
+    return persisted.onUpdate('developerModeEnabled', nextDeveloperModeEnabled => {
+      setState(Boolean(nextDeveloperModeEnabled))
+    })
+  }, [setStateWrapped])
+
+  return (
+    <stateContext.Provider value={state}>
+      <setContext.Provider value={setStateWrapped}>
+        {children}
+      </setContext.Provider>
+    </stateContext.Provider>
+  )
+}
+
+export const useDeveloperModeEnabled = () => React.useContext(stateContext)
+export const useSetDeveloperModeEnabled = () => React.useContext(setContext)

--- a/src/state/preferences/index.tsx
+++ b/src/state/preferences/index.tsx
@@ -11,6 +11,7 @@ import {Provider as LanguagesProvider} from './languages'
 import {Provider as LargeAltBadgeProvider} from './large-alt-badge'
 import {Provider as SubtitlesProvider} from './subtitles'
 import {Provider as UsedStarterPacksProvider} from './used-starter-packs'
+import {Provider as DeveloperModeProvider} from './developer-mode'
 
 export {
   useRequireAltTextEnabled,
@@ -26,6 +27,7 @@ export * from './hidden-posts'
 export {useLabelDefinitions} from './label-defs'
 export {useLanguagePrefs, useLanguagePrefsApi} from './languages'
 export {useSetSubtitlesEnabled, useSubtitlesEnabled} from './subtitles'
+export {useDeveloperModeEnabled, useSetDeveloperModeEnabled} from './developer-mode'
 
 export function Provider({children}: React.PropsWithChildren<{}>) {
   return (
@@ -39,7 +41,9 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
                   <AutoplayProvider>
                     <UsedStarterPacksProvider>
                       <SubtitlesProvider>
-                        <KawaiiProvider>{children}</KawaiiProvider>
+                        <DeveloperModeProvider>
+                          <KawaiiProvider>{children}</KawaiiProvider>
+                        </DeveloperModeProvider>
                       </SubtitlesProvider>
                     </UsedStarterPacksProvider>
                   </AutoplayProvider>

--- a/src/view/com/profile/ProfileMenu.tsx
+++ b/src/view/com/profile/ProfileMenu.tsx
@@ -3,6 +3,7 @@ import {AppBskyActorDefs} from '@atproto/api'
 import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 import {useQueryClient} from '@tanstack/react-query'
+import * as Clipboard from 'expo-clipboard'
 
 import {HITSLOP_20} from '#/lib/constants'
 import {makeProfileLink} from '#/lib/routes/links'
@@ -24,6 +25,7 @@ import {Button, ButtonIcon} from '#/components/Button'
 import {ArrowOutOfBox_Stroke2_Corner0_Rounded as Share} from '#/components/icons/ArrowOutOfBox'
 import {DotGrid_Stroke2_Corner0_Rounded as Ellipsis} from '#/components/icons/DotGrid'
 import {Flag_Stroke2_Corner0_Rounded as Flag} from '#/components/icons/Flag'
+import {Clipboard_Stroke2_Corner2_Rounded as ClipboardIcon} from '#/components/icons/Clipboard'
 import {ListSparkle_Stroke2_Corner0_Rounded as List} from '#/components/icons/ListSparkle'
 import {Mute_Stroke2_Corner0_Rounded as Mute} from '#/components/icons/Mute'
 import {PeopleRemove2_Stroke2_Corner0_Rounded as UserMinus} from '#/components/icons/PeopleRemove2'
@@ -36,6 +38,7 @@ import {SpeakerVolumeFull_Stroke2_Corner0_Rounded as Unmute} from '#/components/
 import * as Menu from '#/components/Menu'
 import * as Prompt from '#/components/Prompt'
 import {ReportDialog, useReportDialogControl} from '#/components/ReportDialog'
+import {useDeveloperModeEnabled} from '#/state/preferences'
 
 let ProfileMenu = ({
   profile,
@@ -52,6 +55,7 @@ let ProfileMenu = ({
   const isBlocked = profile.viewer?.blocking || profile.viewer?.blockedBy
   const isFollowingBlockedAccount = isFollowing && isBlocked
   const isLabelerAndNotBlocked = !!profile.associated?.labeler && !isBlocked
+  const developerModeEnabled = useDeveloperModeEnabled()
 
   const [queueMute, queueUnmute] = useProfileMuteMutationQueue(profile)
   const [queueBlock, queueUnblock] = useProfileBlockMutationQueue(profile)
@@ -166,6 +170,11 @@ let ProfileMenu = ({
   const onPressReportAccount = React.useCallback(() => {
     reportDialogControl.open()
   }, [reportDialogControl])
+
+  const onPressCopyATProtoUri = React.useCallback(() => {
+    Clipboard.setStringAsync(`at://${profile.did}`)
+    Toast.show(_(msg`Copied to clipboard`), 'clipboard-check')
+  }, [])
 
   return (
     <EventStopper onKeyDown={false}>
@@ -302,6 +311,21 @@ let ProfileMenu = ({
                         <Trans>Report Account</Trans>
                       </Menu.ItemText>
                       <Menu.ItemIcon icon={Flag} />
+                    </Menu.Item>
+                  </>
+                )}
+
+                {developerModeEnabled && (
+                  <>
+                    <Menu.Divider />
+                    <Menu.Item
+                      testID="profileHeaderDropdownCopyUri"
+                      label={_(msg`Copy ATProto URI`)}
+                      onPress={onPressCopyATProtoUri}>
+                      <Menu.ItemText>
+                        <Trans>Copy ATProto URI</Trans>
+                      </Menu.ItemText>
+                      <Menu.ItemIcon icon={ClipboardIcon} />
                     </Menu.Item>
                   </>
                 )}

--- a/src/view/com/util/forms/PostDropdownBtnMenuItems.tsx
+++ b/src/view/com/util/forms/PostDropdownBtnMenuItems.tsx
@@ -33,6 +33,7 @@ import {useProfileShadow} from '#/state/cache/profile-shadow'
 import {useFeedFeedbackContext} from '#/state/feed-feedback'
 import {useLanguagePrefs} from '#/state/preferences'
 import {useHiddenPosts, useHiddenPostsApi} from '#/state/preferences'
+import {useDeveloperModeEnabled} from '#/state/preferences'
 import {usePinnedPostMutation} from '#/state/queries/pinned-post'
 import {
   usePostDeleteMutation,
@@ -106,6 +107,7 @@ let PostDropdownMenuItems = ({
     usePinnedPostMutation()
   const hiddenPosts = useHiddenPosts()
   const {hidePost} = useHiddenPostsApi()
+  const developerModeEnabled = useDeveloperModeEnabled()
   const feedFeedback = useFeedFeedbackContext()
   const openLink = useOpenLink()
   const navigation = useNavigation<NavigationProp>()
@@ -365,6 +367,11 @@ let PostDropdownMenuItems = ({
       }
     }
   }, [_, queueBlock])
+  
+  const onPressCopyATProtoUri = React.useCallback(() => {
+    Clipboard.setStringAsync(post.uri)
+    Toast.show(_(msg`Copied to clipboard`), 'clipboard-check')
+  }, [])
 
   return (
     <>
@@ -649,6 +656,23 @@ let PostDropdownMenuItems = ({
             </Menu.Group>
           </>
         )}
+
+        {developerModeEnabled && (
+          <>
+            <Menu.Divider />
+            <Menu.Item
+              testID="profileHeaderDropdownCopyUri"
+              label={_(msg`Copy ATProto URI`)}
+              onPress={onPressCopyATProtoUri}>
+              <Menu.ItemText>
+                <Trans>Copy ATProto URI</Trans>
+              </Menu.ItemText>
+              <Menu.ItemIcon icon={ClipboardIcon} />
+            </Menu.Item>
+          </>
+        )}
+
+
       </Menu.Outer>
 
       <Prompt.Basic


### PR DESCRIPTION
Adds a developer mode toggle in Settings > About which lets you copy the at uri of any post/profile just like you could on discord

![image](https://github.com/user-attachments/assets/0290dda5-bdf0-47b4-a930-cc6d8ce9038f)

(Note that I am fairly new to contributions so please let me know if I've missed anything such as create any locale strings or if I've totally broken anything. Thank you!)