### PR TITLE
[Nicer Tabs] New native pager

### DIFF
--- a/src/view/com/home/HomeHeader.tsx
+++ b/src/view/com/home/HomeHeader.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import {useNavigation} from '@react-navigation/native'
 
-import {usePalette} from '#/lib/hooks/usePalette'
 import {NavigationProp} from '#/lib/routes/types'
 import {FeedSourceInfo} from '#/state/queries/feed'
 import {useSession} from '#/state/session'
@@ -19,7 +18,6 @@ export function HomeHeader(
   const {feeds} = props
   const {hasSession} = useSession()
   const navigation = useNavigation<NavigationProp>()
-  const pal = usePalette('default')
 
   const hasPinnedCustom = React.useMemo<boolean>(() => {
     if (!hasSession) return false
@@ -61,7 +59,6 @@ export function HomeHeader(
         onSelect={onSelect}
         testID={props.testID}
         items={items}
-        indicatorColor={pal.colors.link}
         dragGesture={props.dragGesture}
       />
     </HomeHeaderLayout>

--- a/src/view/com/home/HomeHeader.tsx
+++ b/src/view/com/home/HomeHeader.tsx
@@ -59,7 +59,8 @@ export function HomeHeader(
         onSelect={onSelect}
         testID={props.testID}
         items={items}
-        dragGesture={props.dragGesture}
+        dragProgress={props.dragProgress}
+        dragState={props.dragState}
       />
     </HomeHeaderLayout>
   )

--- a/src/view/com/home/HomeHeader.tsx
+++ b/src/view/com/home/HomeHeader.tsx
@@ -62,6 +62,7 @@ export function HomeHeader(
         testID={props.testID}
         items={items}
         indicatorColor={pal.colors.link}
+        dragGesture={props.dragGesture}
       />
     </HomeHeaderLayout>
   )

--- a/src/view/com/pager/Pager.tsx
+++ b/src/view/com/pager/Pager.tsx
@@ -99,6 +99,7 @@ export const Pager = forwardRef<PagerRef, React.PropsWithChildren<Props>>(
         onPageSelected(e: PagerViewOnPageSelectedEventData) {
           'worklet'
           dragPage.set(e.position)
+          dragProgress.set(0)
           runOnJS(onPageSelectedJSThread)(e.position)
         },
       },

--- a/src/view/com/pager/Pager.tsx
+++ b/src/view/com/pager/Pager.tsx
@@ -52,7 +52,7 @@ export const Pager = forwardRef<PagerRef, React.PropsWithChildren<Props>>(
     }: React.PropsWithChildren<Props>,
     ref,
   ) {
-    const [selectedPage, setSelectedPage] = React.useState(0)
+    const [selectedPage, setSelectedPage] = React.useState(initialPage)
     const pagerView = React.useRef<PagerView>(null)
 
     React.useImperativeHandle(ref, () => ({

--- a/src/view/com/pager/Pager.tsx
+++ b/src/view/com/pager/Pager.tsx
@@ -8,6 +8,7 @@ import PagerView, {
 } from 'react-native-pager-view'
 import Animated, {
   runOnJS,
+  SharedValue,
   useEvent,
   useHandler,
   useSharedValue,
@@ -25,6 +26,8 @@ export interface RenderTabBarFnProps {
   selectedPage: number
   onSelect?: (index: number) => void
   tabBarAnchor?: JSX.Element | null | undefined // Ignored on native.
+  dragProgress: SharedValue<number> // Ignored on web.
+  dragState: SharedValue<'idle' | 'dragging' | 'settling'> // Ignored on web.
 }
 export type RenderTabBarFn = (props: RenderTabBarFnProps) => JSX.Element
 
@@ -107,10 +110,8 @@ export const Pager = forwardRef<PagerRef, React.PropsWithChildren<Props>>(
         {renderTabBar({
           selectedPage,
           onSelect: onTabBarSelect,
-          dragGesture: {
-            dragProgress,
-            dragState,
-          },
+          dragProgress,
+          dragState,
         })}
         <AnimatedPagerView
           ref={pagerView}

--- a/src/view/com/pager/PagerWithHeader.tsx
+++ b/src/view/com/pager/PagerWithHeader.tsx
@@ -97,6 +97,8 @@ export const PagerWithHeader = React.forwardRef<PagerRef, PagerWithHeaderProps>(
               scrollY={scrollY}
               testID={testID}
               allowHeaderOverScroll={allowHeaderOverScroll}
+              dragProgress={props.dragProgress}
+              dragState={props.dragState}
             />
           </PagerHeaderProvider>
         )
@@ -226,6 +228,8 @@ let PagerTabBar = ({
   onCurrentPageSelected,
   onSelect,
   allowHeaderOverScroll,
+  dragProgress,
+  dragState,
 }: {
   currentPage: number
   headerOnlyHeight: number
@@ -239,6 +243,8 @@ let PagerTabBar = ({
   onCurrentPageSelected?: (index: number) => void
   onSelect?: (index: number) => void
   allowHeaderOverScroll?: boolean
+  dragProgress: SharedValue<number>
+  dragState: SharedValue<'idle' | 'dragging' | 'settling'>
 }): React.ReactNode => {
   const headerTransform = useAnimatedStyle(() => {
     const translateY = Math.min(scrollY.get(), headerOnlyHeight) * -1
@@ -297,6 +303,8 @@ let PagerTabBar = ({
           selectedPage={currentPage}
           onSelect={onSelect}
           onPressSelected={onCurrentPageSelected}
+          dragProgress={dragProgress}
+          dragState={dragState}
         />
       </View>
     </Animated.View>

--- a/src/view/com/pager/PagerWithHeader.web.tsx
+++ b/src/view/com/pager/PagerWithHeader.web.tsx
@@ -151,6 +151,8 @@ let PagerTabBar = ({
           selectedPage={currentPage}
           onSelect={onSelect}
           onPressSelected={onCurrentPageSelected}
+          dragProgress={undefined as any /* native-only */}
+          dragState={undefined as any /* native-only */}
         />
       </View>
     </>

--- a/src/view/com/pager/TabBar.tsx
+++ b/src/view/com/pager/TabBar.tsx
@@ -104,23 +104,11 @@ export function TabBar({
 
   // When we know the entire layout for the first time, scroll selection into view.
   useAnimatedReaction(
-    () => {
-      return {
-        layoutsLength: layouts.get().length,
-        containerSizeValue: containerSize.get(),
-        contentSizeValue: contentSize.get(),
-      }
-    },
-    (nextLayouts, prevLayouts) => {
-      if (
-        nextLayouts.containerSizeValue !== prevLayouts?.containerSizeValue ||
-        nextLayouts.contentSizeValue !== prevLayouts?.contentSizeValue ||
-        nextLayouts.layoutsLength !== prevLayouts?.layoutsLength
-      ) {
+    () => layouts.get().length,
+    (nextLayoutsLength, prevLayoutsLength) => {
+      if (nextLayoutsLength !== prevLayoutsLength) {
         if (
-          nextLayouts.containerSizeValue !== 0 &&
-          nextLayouts.contentSizeValue !== 0 &&
-          nextLayouts.layoutsLength === itemsLength &&
+          nextLayoutsLength === itemsLength &&
           didInitialScroll.get() === false
         ) {
           didInitialScroll.set(true)

--- a/src/view/com/pager/TabBar.tsx
+++ b/src/view/com/pager/TabBar.tsx
@@ -4,6 +4,7 @@ import Animated, {
   interpolate,
   runOnUI,
   scrollTo,
+  SharedValue,
   useAnimatedReaction,
   useAnimatedRef,
   useAnimatedStyle,
@@ -189,7 +190,7 @@ export function TabBar({
                 <TabBarItem
                   index={i}
                   testID={testID}
-                  selected={i === selectedPage}
+                  dragProgress={dragProgress}
                   item={item}
                   onPressItem={onPressItem}
                 />
@@ -221,17 +222,25 @@ export function TabBar({
 function TabBarItem({
   index,
   testID,
-  selected,
+  dragProgress,
   item,
   onPressItem,
 }: {
   index: number
   testID: string | undefined
-  selected: boolean
+  dragProgress: SharedValue<number>
   item: string
   onPressItem: (index: number) => void
 }) {
   const pal = usePalette('default')
+  const style = useAnimatedStyle(() => ({
+    opacity: interpolate(
+      dragProgress.get(),
+      [index - 1, index, index + 1],
+      [0.7, 1, 0.7],
+      'clamp',
+    ),
+  }))
   return (
     <PressableWithHover
       testID={`${testID}-selector-${index}`}
@@ -239,15 +248,15 @@ function TabBarItem({
       hoverStyle={pal.viewLight}
       onPress={() => onPressItem(index)}
       accessibilityRole="tab">
-      <View style={[styles.itemInner]}>
+      <Animated.View style={[style, styles.itemInner]}>
         <Text
           emoji
           type="lg-bold"
           testID={testID ? `${testID}-${item}` : undefined}
-          style={[selected ? pal.text : pal.textLight, {lineHeight: 20}]}>
+          style={[pal.text, {lineHeight: 20}]}>
           {item}
         </Text>
-      </View>
+      </Animated.View>
     </PressableWithHover>
   )
 }

--- a/src/view/com/pager/TabBar.tsx
+++ b/src/view/com/pager/TabBar.tsx
@@ -88,6 +88,7 @@ export function TabBar({
         const offsetPerPage = contentSize.get() - containerSize.get()
         const progressDiff = index - dragProgress.get()
         const offsetDiff = (progressDiff / (itemsLength - 1)) * offsetPerPage
+        // TODO: Get into view if obscured
         const offset = scrollX.get() + offsetDiff
         scrollTo(scrollElRef, offset, 0, true)
       }

--- a/src/view/com/pager/TabBar.tsx
+++ b/src/view/com/pager/TabBar.tsx
@@ -59,14 +59,43 @@ export function TabBar({
     [scrollElRef],
   )
 
+  const indexToOffset = useCallback(
+    (index: number) => {
+      'worklet'
+      const layout = layouts.get()[index]
+      const availableSize = containerSize.get() - 2 * CONTENT_PADDING
+      if (!layout) {
+        const offsetPerPage = contentSize.get() - availableSize
+        return (index / (itemsLength - 1)) * offsetPerPage
+      }
+      const freeSpace = availableSize - layout.width
+      const accumulatingOffset = interpolate(
+        index,
+        // Gradually shift every next item to the left so that the first item
+        // is positioned like "left: 0" but the last item is like "right: 0".
+        [0, itemsLength - 1],
+        [0, freeSpace],
+        'clamp',
+      )
+      return layout.x - accumulatingOffset
+    },
+    [itemsLength, contentSize, containerSize, layouts],
+  )
+
   const progressToOffset = useCallback(
     (progress: number) => {
       'worklet'
-      const offsetPerPage =
-        contentSize.get() + 2 * CONTENT_PADDING - containerSize.get()
-      return (progress / (itemsLength - 1)) * offsetPerPage
+      return interpolate(
+        progress,
+        [Math.floor(progress), Math.ceil(progress)],
+        [
+          indexToOffset(Math.floor(progress)),
+          indexToOffset(Math.ceil(progress)),
+        ],
+        'clamp',
+      )
     },
-    [itemsLength, contentSize, containerSize],
+    [indexToOffset],
   )
 
   // When we know the entire layout for the first time, scroll selection into view.

--- a/src/view/com/pager/TabBar.tsx
+++ b/src/view/com/pager/TabBar.tsx
@@ -21,6 +21,8 @@ export interface TabBarProps {
   items: string[]
   onSelect?: (index: number) => void
   onPressSelected?: (index: number) => void
+  dragProgress: SharedValue<number>
+  dragState: SharedValue<'idle' | 'dragging' | 'settling'>
 }
 
 export function TabBar({
@@ -29,17 +31,17 @@ export function TabBar({
   items,
   onSelect,
   onPressSelected,
-  dragGesture,
+  dragProgress,
+  dragState,
 }: TabBarProps) {
   const pal = usePalette('default')
-  const scrollElRef = useAnimatedRef()
+  const scrollElRef = useAnimatedRef<ScrollView>()
   const isSyncingScroll = useSharedValue(true)
   const contentSize = useSharedValue(0)
   const containerSize = useSharedValue(0)
   const scrollX = useSharedValue(0)
   const layouts = useSharedValue<{x: number; width: number}[]>([])
   const itemsLength = items.length
-  const {dragProgress, dragState} = dragGesture
 
   // When you swipe the pager, the tabbar should scroll automatically
   // as you're dragging the page and then even during deceleration.

--- a/src/view/com/pager/TabBar.tsx
+++ b/src/view/com/pager/TabBar.tsx
@@ -4,7 +4,6 @@ import Animated, {
   scrollTo,
   useAnimatedReaction,
   useAnimatedRef,
-  useAnimatedStyle,
   useSharedValue,
 } from 'react-native-reanimated'
 
@@ -47,23 +46,16 @@ export function TabBar({
   const {dragPage, dragProgress} = dragGesture
 
   useAnimatedReaction(
-    () => dragPage.get(),
-    (page, prevPage) => {
-      if (page !== prevPage) {
+    () => dragPage.get() + dragProgress.get(),
+    (next, prev) => {
+      if (next !== prev) {
         const offsetPerPage = contentSize.get() - containerSize.get()
-        const offset = (dragPage.get() / (itemsLength - 1)) * offsetPerPage
+        const offset = (next / (itemsLength - 1)) * offsetPerPage
         scrollTo(scrollElRef, offset, 0, false)
+        return
       }
     },
   )
-
-  const contentStyle = useAnimatedStyle(() => {
-    const offsetPerPage = contentSize.get() - containerSize.get()
-    const offset = (dragProgress.get() / (itemsLength - 1)) * offsetPerPage
-    return {
-      transform: [{translateX: -offset}],
-    }
-  })
 
   return (
     <View
@@ -83,12 +75,7 @@ export function TabBar({
           onLayout={e => {
             contentSize.set(e.nativeEvent.layout.width)
           }}
-          style={[
-            contentStyle,
-            {
-              flexDirection: 'row',
-            },
-          ]}>
+          style={{flexDirection: 'row'}}>
           {items.map((item, i) => {
             return (
               <TabBarItem

--- a/src/view/com/pager/TabBar.tsx
+++ b/src/view/com/pager/TabBar.tsx
@@ -65,9 +65,7 @@ export function TabBar({
   // We'll re-sync it here (with an animation) if you interact with the pager again.
   // From that point on, it'll remain synced again (unless you scroll the tabbar again).
   useAnimatedReaction(
-    () => {
-      return dragState.value
-    },
+    () => dragState.value,
     (nextDragState, prevDragState) => {
       if (
         nextDragState !== prevDragState &&
@@ -121,6 +119,9 @@ export function TabBar({
   )
 
   const indicatorStyle = useAnimatedStyle(() => {
+    if (!_WORKLET) {
+      return {opacity: 0}
+    }
     const layoutsValue = layouts.get()
     if (
       layoutsValue.length !== itemsLength ||
@@ -238,14 +239,19 @@ function TabBarItem({
   onItemLayout: (index: number, layout: {x: number; width: number}) => void
 }) {
   const pal = usePalette('default')
-  const style = useAnimatedStyle(() => ({
-    opacity: interpolate(
-      dragProgress.get(),
-      [index - 1, index, index + 1],
-      [0.7, 1, 0.7],
-      'clamp',
-    ),
-  }))
+  const style = useAnimatedStyle(() => {
+    if (!_WORKLET) {
+      return {opacity: 0.7}
+    }
+    return {
+      opacity: interpolate(
+        dragProgress.get(),
+        [index - 1, index, index + 1],
+        [0.7, 1, 0.7],
+        'clamp',
+      ),
+    }
+  })
 
   const handleLayout = useCallback(
     (e: LayoutChangeEvent) => {

--- a/src/view/com/pager/TabBar.tsx
+++ b/src/view/com/pager/TabBar.tsx
@@ -144,13 +144,31 @@ export function TabBar({
       if (isSyncingScroll.get() === true) {
         const progressDiff = index - dragProgress.get()
         const offsetDiff = progressToOffset(progressDiff)
-        // TODO: Get into view if obscured
-        const offset = scrollX.get() + offsetDiff
+        let offset = scrollX.get() + offsetDiff
+        const itemLayout = layouts.get()[index]
+        if (itemLayout) {
+          if (
+            itemLayout.x < offset ||
+            itemLayout.x + itemLayout.width > offset + containerSize.get()
+          ) {
+            // If the proposed offset is still out of view, don't bother with
+            // proportional scroll and ensure the target is scrolled into view.
+            offset = progressToOffset(index)
+          }
+        }
         scrollTo(scrollElRef, offset, 0, true)
       }
       isSyncingScroll.set(true)
     },
-    [isSyncingScroll, scrollElRef, scrollX, dragProgress, progressToOffset],
+    [
+      isSyncingScroll,
+      scrollElRef,
+      scrollX,
+      dragProgress,
+      progressToOffset,
+      containerSize,
+      layouts,
+    ],
   )
 
   const onItemLayout = useCallback(

--- a/src/view/com/pager/TabBar.tsx
+++ b/src/view/com/pager/TabBar.tsx
@@ -1,5 +1,5 @@
-import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react'
-import {LayoutChangeEvent, ScrollView, StyleSheet, View} from 'react-native'
+import {useCallback, useMemo, useRef} from 'react'
+import {ScrollView, StyleSheet, View} from 'react-native'
 
 import {usePalette} from '#/lib/hooks/usePalette'
 import {PressableWithHover} from '../util/PressableWithHover'
@@ -14,10 +14,6 @@ export interface TabBarProps {
   onPressSelected?: (index: number) => void
 }
 
-// How much of the previous/next item we're showing
-// to give the user a hint there's more to scroll.
-const OFFSCREEN_ITEM_WIDTH = 20
-
 export function TabBar({
   testID,
   selectedPage,
@@ -28,20 +24,10 @@ export function TabBar({
 }: TabBarProps) {
   const pal = usePalette('default')
   const scrollElRef = useRef<ScrollView>(null)
-  const [itemXs, setItemXs] = useState<number[]>([])
   const indicatorStyle = useMemo(
     () => ({borderBottomColor: indicatorColor || pal.colors.link}),
     [indicatorColor, pal],
   )
-
-  useEffect(() => {
-    // On native, the primary interaction is swiping.
-    // We adjust the scroll little by little on every tab change.
-    // Scroll into view but keep the end of the previous item visible.
-    let x = itemXs[selectedPage] || 0
-    x = Math.max(0, x - OFFSCREEN_ITEM_WIDTH)
-    scrollElRef.current?.scrollTo({x})
-  }, [scrollElRef, itemXs, selectedPage])
 
   const onPressItem = useCallback(
     (index: number) => {
@@ -51,19 +37,6 @@ export function TabBar({
       }
     },
     [onSelect, selectedPage, onPressSelected],
-  )
-
-  // calculates the x position of each item on mount and on layout change
-  const onItemLayout = React.useCallback(
-    (e: LayoutChangeEvent, index: number) => {
-      const x = e.nativeEvent.layout.x
-      setItemXs(prev => {
-        const Xs = [...prev]
-        Xs[index] = x
-        return Xs
-      })
-    },
-    [],
   )
 
   return (
@@ -83,7 +56,6 @@ export function TabBar({
             <PressableWithHover
               testID={`${testID}-selector-${i}`}
               key={`${item}-${i}`}
-              onLayout={e => onItemLayout(e, i)}
               style={styles.item}
               hoverStyle={pal.viewLight}
               onPress={() => onPressItem(i)}

--- a/src/view/com/pager/TabBar.tsx
+++ b/src/view/com/pager/TabBar.tsx
@@ -26,6 +26,9 @@ export interface TabBarProps {
   dragState: SharedValue<'idle' | 'dragging' | 'settling'>
 }
 
+const ITEM_PADDING = 10
+const CONTENT_PADDING = 6
+
 export function TabBar({
   testID,
   selectedPage,
@@ -59,7 +62,8 @@ export function TabBar({
   const progressToOffset = useCallback(
     (progress: number) => {
       'worklet'
-      const offsetPerPage = contentSize.get() - containerSize.get()
+      const offsetPerPage =
+        contentSize.get() + 2 * CONTENT_PADDING - containerSize.get()
       return (progress / (itemsLength - 1)) * offsetPerPage
     },
     [itemsLength, contentSize, containerSize],
@@ -187,7 +191,9 @@ export function TabBar({
           scaleX: interpolate(
             dragProgress.get(),
             layoutsValue.map((l, i) => i),
-            layoutsValue.map(l => (l.width - 12) / contentSize.get()),
+            layoutsValue.map(
+              l => (l.width - ITEM_PADDING * 2) / contentSize.get(),
+            ),
           ),
         },
       ],
@@ -330,11 +336,11 @@ const styles = StyleSheet.create({
   },
   contentContainer: {
     backgroundColor: 'transparent',
-    paddingHorizontal: 6,
+    paddingHorizontal: CONTENT_PADDING,
   },
   item: {
     paddingTop: 10,
-    paddingHorizontal: 10,
+    paddingHorizontal: ITEM_PADDING,
     justifyContent: 'center',
   },
   itemInner: {

--- a/src/view/com/pager/TabBar.tsx
+++ b/src/view/com/pager/TabBar.tsx
@@ -224,6 +224,9 @@ export function TabBar({
         opacity: 0,
       }
     }
+    if (layoutsValue.length === 1) {
+      return {opacity: 1}
+    }
     return {
       opacity: 1,
       transform: [

--- a/src/view/com/pager/TabBar.tsx
+++ b/src/view/com/pager/TabBar.tsx
@@ -35,20 +35,20 @@ export function TabBar({
   const containerSize = useSharedValue(0)
   const scrollX = useSharedValue(0)
   const itemsLength = items.length
-  const {dragPage, dragProgress, dragState} = dragGesture
+  const {dragProgress, dragState} = dragGesture
 
   // When you swipe the pager, the tabbar should scroll automatically
   // as you're dragging the page and then even during deceleration.
   useAnimatedReaction(
-    () => dragPage.get() + dragProgress.get(),
-    (nextValue, prevValue) => {
+    () => dragProgress.get(),
+    (nextProgress, prevProgress) => {
       if (
-        nextValue !== prevValue &&
+        nextProgress !== prevProgress &&
         dragState.value !== 'idle' &&
         isSyncingScroll.get() === true
       ) {
         const offsetPerPage = contentSize.get() - containerSize.get()
-        const offset = (nextValue / (itemsLength - 1)) * offsetPerPage
+        const offset = (nextProgress / (itemsLength - 1)) * offsetPerPage
         scrollTo(scrollElRef, offset, 0, false)
         return
       }
@@ -69,8 +69,8 @@ export function TabBar({
         isSyncingScroll.get() === false
       ) {
         const offsetPerPage = contentSize.get() - containerSize.get()
-        const value = dragPage.get() + dragProgress.get()
-        const offset = (value / (itemsLength - 1)) * offsetPerPage
+        const progress = dragProgress.get()
+        const offset = (progress / (itemsLength - 1)) * offsetPerPage
         scrollTo(scrollElRef, offset, 0, true)
         isSyncingScroll.set(true)
       }
@@ -84,8 +84,8 @@ export function TabBar({
       'worklet'
       if (isSyncingScroll.get() === true) {
         const offsetPerPage = contentSize.get() - containerSize.get()
-        const valueDiff = index - dragPage.get()
-        const offsetDiff = (valueDiff / (itemsLength - 1)) * offsetPerPage
+        const progressDiff = index - dragProgress.get()
+        const offsetDiff = (progressDiff / (itemsLength - 1)) * offsetPerPage
         const offset = scrollX.get() + offsetDiff
         scrollTo(scrollElRef, offset, 0, true)
       }
@@ -98,7 +98,7 @@ export function TabBar({
       itemsLength,
       scrollElRef,
       scrollX,
-      dragPage,
+      dragProgress,
     ],
   )
 

--- a/src/view/com/pager/TabBar.tsx
+++ b/src/view/com/pager/TabBar.tsx
@@ -43,7 +43,7 @@ export function TabBar({
 }: TabBarProps) {
   const pal = usePalette('default')
   const scrollElRef = useAnimatedRef<ScrollView>()
-  const isSyncingScroll = useSharedValue(true)
+  const syncScrollState = useSharedValue<'synced' | 'unsynced'>('synced')
   const didInitialScroll = useSharedValue(false)
   const contentSize = useSharedValue(0)
   const containerSize = useSharedValue(0)
@@ -129,7 +129,7 @@ export function TabBar({
       if (
         nextProgress !== prevProgress &&
         dragState.value !== 'idle' &&
-        isSyncingScroll.get() === true
+        syncScrollState.get() === 'synced'
       ) {
         const offset = progressToOffset(nextProgress)
         scrollTo(scrollElRef, offset, 0, false)
@@ -147,12 +147,12 @@ export function TabBar({
       if (
         nextDragState !== prevDragState &&
         nextDragState === 'idle' &&
-        isSyncingScroll.get() === false
+        syncScrollState.get() === 'unsynced'
       ) {
         const progress = dragProgress.get()
         const offset = progressToOffset(progress)
         scrollTo(scrollElRef, offset, 0, true)
-        isSyncingScroll.set(true)
+        syncScrollState.set('synced')
       }
     },
   )
@@ -172,14 +172,14 @@ export function TabBar({
       const scrollLeft = scrollX.get()
       const scrollRight = scrollLeft + containerSize.get()
       const scrollIntoView = leftEdge < scrollLeft || rightEdge > scrollRight
-      if (isSyncingScroll.get() === true || scrollIntoView) {
+      if (syncScrollState.get() === 'synced' || scrollIntoView) {
         const offset = progressToOffset(index)
         scrollTo(scrollElRef, offset, 0, true)
       }
-      isSyncingScroll.set(true)
+      syncScrollState.set('synced')
     },
     [
-      isSyncingScroll,
+      syncScrollState,
       scrollElRef,
       scrollX,
       progressToOffset,
@@ -266,7 +266,7 @@ export function TabBar({
         onScrollBeginDrag={() => {
           // Remember that you've manually messed with the tabbar scroll.
           // This will disable auto-adjustment until after next pager swipe or item tap.
-          isSyncingScroll.set(false)
+          syncScrollState.set('unsynced')
         }}
         onScroll={e => {
           scrollX.value = Math.round(e.nativeEvent.contentOffset.x)

--- a/src/view/com/pager/TabBar.tsx
+++ b/src/view/com/pager/TabBar.tsx
@@ -1,5 +1,12 @@
-import {useCallback, useMemo, useRef} from 'react'
+import {useCallback, useMemo} from 'react'
 import {ScrollView, StyleSheet, View} from 'react-native'
+import Animated, {
+  scrollTo,
+  useAnimatedReaction,
+  useAnimatedRef,
+  useAnimatedStyle,
+  useSharedValue,
+} from 'react-native-reanimated'
 
 import {usePalette} from '#/lib/hooks/usePalette'
 import {PressableWithHover} from '../util/PressableWithHover'
@@ -21,9 +28,10 @@ export function TabBar({
   indicatorColor,
   onSelect,
   onPressSelected,
+  dragGesture,
 }: TabBarProps) {
   const pal = usePalette('default')
-  const scrollElRef = useRef<ScrollView>(null)
+  const scrollElRef = useAnimatedRef()
   const indicatorStyle = useMemo(
     () => ({borderBottomColor: indicatorColor || pal.colors.link}),
     [indicatorColor, pal],
@@ -39,6 +47,30 @@ export function TabBar({
     [onSelect, selectedPage, onPressSelected],
   )
 
+  const contentSize = useSharedValue(0)
+  const containerSize = useSharedValue(0)
+  const itemsLength = items.length
+  const {dragPage, dragProgress} = dragGesture
+
+  useAnimatedReaction(
+    () => dragPage.get(),
+    (page, prevPage) => {
+      if (page !== prevPage) {
+        const offsetPerPage = contentSize.get() - containerSize.get()
+        const offset = (dragPage.get() / (itemsLength - 1)) * offsetPerPage
+        scrollTo(scrollElRef, offset, 0, false)
+      }
+    },
+  )
+
+  const contentStyle = useAnimatedStyle(() => {
+    const offsetPerPage = contentSize.get() - containerSize.get()
+    const offset = (dragProgress.get() / (itemsLength - 1)) * offsetPerPage
+    return {
+      transform: [{translateX: -offset}],
+    }
+  })
+
   return (
     <View
       testID={testID}
@@ -49,32 +81,46 @@ export function TabBar({
         horizontal={true}
         showsHorizontalScrollIndicator={false}
         ref={scrollElRef}
-        contentContainerStyle={styles.contentContainer}>
-        {items.map((item, i) => {
-          const selected = i === selectedPage
-          return (
-            <PressableWithHover
-              testID={`${testID}-selector-${i}`}
-              key={`${item}-${i}`}
-              style={styles.item}
-              hoverStyle={pal.viewLight}
-              onPress={() => onPressItem(i)}
-              accessibilityRole="tab">
-              <View style={[styles.itemInner, selected && indicatorStyle]}>
-                <Text
-                  emoji
-                  type="lg-bold"
-                  testID={testID ? `${testID}-${item}` : undefined}
-                  style={[
-                    selected ? pal.text : pal.textLight,
-                    {lineHeight: 20},
-                  ]}>
-                  {item}
-                </Text>
-              </View>
-            </PressableWithHover>
-          )
-        })}
+        contentContainerStyle={styles.contentContainer}
+        onLayout={e => {
+          containerSize.set(e.nativeEvent.layout.width)
+        }}>
+        <Animated.View
+          onLayout={e => {
+            contentSize.set(e.nativeEvent.layout.width)
+          }}
+          style={[
+            contentStyle,
+            {
+              flexDirection: 'row',
+            },
+          ]}>
+          {items.map((item, i) => {
+            const selected = i === selectedPage
+            return (
+              <PressableWithHover
+                testID={`${testID}-selector-${i}`}
+                key={`${item}-${i}`}
+                style={styles.item}
+                hoverStyle={pal.viewLight}
+                onPress={() => onPressItem(i)}
+                accessibilityRole="tab">
+                <View style={[styles.itemInner, selected && indicatorStyle]}>
+                  <Text
+                    emoji
+                    type="lg-bold"
+                    testID={testID ? `${testID}-${item}` : undefined}
+                    style={[
+                      selected ? pal.text : pal.textLight,
+                      {lineHeight: 20},
+                    ]}>
+                    {item}
+                  </Text>
+                </View>
+              </PressableWithHover>
+            )
+          })}
+        </Animated.View>
       </ScrollView>
       <View style={[pal.border, styles.outerBottomBorder]} />
     </View>

--- a/src/view/com/pager/TabBar.tsx
+++ b/src/view/com/pager/TabBar.tsx
@@ -16,7 +16,6 @@ export interface TabBarProps {
   testID?: string
   selectedPage: number
   items: string[]
-  indicatorColor?: string
   onSelect?: (index: number) => void
   onPressSelected?: (index: number) => void
 }
@@ -25,17 +24,12 @@ export function TabBar({
   testID,
   selectedPage,
   items,
-  indicatorColor,
   onSelect,
   onPressSelected,
   dragGesture,
 }: TabBarProps) {
   const pal = usePalette('default')
   const scrollElRef = useAnimatedRef()
-  const indicatorStyle = useMemo(
-    () => ({borderBottomColor: indicatorColor || pal.colors.link}),
-    [indicatorColor, pal],
-  )
 
   const onPressItem = useCallback(
     (index: number) => {
@@ -96,34 +90,59 @@ export function TabBar({
             },
           ]}>
           {items.map((item, i) => {
-            const selected = i === selectedPage
             return (
-              <PressableWithHover
-                testID={`${testID}-selector-${i}`}
-                key={`${item}-${i}`}
-                style={styles.item}
-                hoverStyle={pal.viewLight}
-                onPress={() => onPressItem(i)}
-                accessibilityRole="tab">
-                <View style={[styles.itemInner, selected && indicatorStyle]}>
-                  <Text
-                    emoji
-                    type="lg-bold"
-                    testID={testID ? `${testID}-${item}` : undefined}
-                    style={[
-                      selected ? pal.text : pal.textLight,
-                      {lineHeight: 20},
-                    ]}>
-                    {item}
-                  </Text>
-                </View>
-              </PressableWithHover>
+              <TabBarItem
+                key={i}
+                index={i}
+                testID={testID}
+                selected={i === selectedPage}
+                item={item}
+                onPressItem={onPressItem}
+              />
             )
           })}
         </Animated.View>
       </ScrollView>
       <View style={[pal.border, styles.outerBottomBorder]} />
     </View>
+  )
+}
+
+function TabBarItem({
+  index,
+  testID,
+  selected,
+  item,
+  onPressItem,
+}: {
+  index: number
+  testID: string | undefined
+  selected: boolean
+  item: string
+  onPressItem: (index: number) => void
+}) {
+  const pal = usePalette('default')
+  const indicatorStyle = useMemo(
+    () => ({borderBottomColor: pal.colors.link}),
+    [pal],
+  )
+  return (
+    <PressableWithHover
+      testID={`${testID}-selector-${index}`}
+      style={styles.item}
+      hoverStyle={pal.viewLight}
+      onPress={() => onPressItem(index)}
+      accessibilityRole="tab">
+      <View style={[styles.itemInner, selected && indicatorStyle]}>
+        <Text
+          emoji
+          type="lg-bold"
+          testID={testID ? `${testID}-${item}` : undefined}
+          style={[selected ? pal.text : pal.textLight, {lineHeight: 20}]}>
+          {item}
+        </Text>
+      </View>
+    </PressableWithHover>
   )
 }
 

--- a/src/view/com/pager/TabBar.tsx
+++ b/src/view/com/pager/TabBar.tsx
@@ -137,7 +137,6 @@ export function TabBar({
       ) {
         const offset = progressToOffset(nextProgress)
         scrollTo(scrollElRef, offset, 0, false)
-        return
       }
     },
   )

--- a/src/view/screens/Home.tsx
+++ b/src/view/screens/Home.tsx
@@ -173,6 +173,7 @@ function HomeScreenReady({
 
   const onPageScrollStateChanged = React.useCallback(
     (state: 'idle' | 'dragging' | 'settling') => {
+      'worklet'
       if (state === 'dragging') {
         setMinimalShellMode(false)
       }

--- a/src/view/screens/Home.tsx
+++ b/src/view/screens/Home.tsx
@@ -156,8 +156,10 @@ function HomeScreenReady({
       setMinimalShellMode(false)
       setDrawerSwipeDisabled(index > 0)
       const feed = allFeeds[index]
-      setSelectedFeed(feed)
+      // Mutate the ref before setting state to avoid the imperative syncing effect
+      // above from starting a loop on Android when swiping back and forth.
       lastPagerReportedIndexRef.current = index
+      setSelectedFeed(feed)
       logEvent('home:feedDisplayed', {
         index,
         feedType: feed.split('|')[0],


### PR DESCRIPTION
This revives https://github.com/bluesky-social/social-app/pull/1696 but in a performant way.

## Test Plan

Try different interactions on iOS and Android:

- **Initial load:** The pager should autoscroll to the initially selected tab on reload. (Ideally this would not be animated, but since I couldn't figure out a reliable way to do it on the first frame on both platforms, I have to animate it.)
- **Swiping the pager drives tabbar scroll:** The swiping gesture should stay in sync with the tabbar scroll. A full page swipe should bring you to the same position as tapping the next item. Note that if you continuously swipe page after page, by the time you arrive at the last page, the blue line should naturally be at the right edge of the screen. This also means that by the time you're halfway through the feeds, the blue line should be _exactly_ centered in the middle. This is easy to see if you have an odd number of feeds.
- **Tapping predictably aligns the tabbar:** Tapping to select an item will adjust the tabbar to its "synced" position, same as a swipe. There is one exception to this, which I'll cover next.
- **Scrolling the tabbar itself temporarily unsyncs it:** If you start scrolling the tabbar and *then* tap on an item there, if that item is fully visible in view (with a margin of 20 on each side), that tap will _not_ change the tabbar scroll position. This is to avoid things shifting from "right under you" on tap. However, the *next* tap will be synced as usual (unless you scroll again). If the item was _not_ fully visible into view (with a margin of 20 on each side), we always sync.
- **Unsyncing, then swiping:** You can unsync the tabbar (by scrolling it) and _then_ swipe. In this case, we won't mess with the tabbar scroll position *during* the swipe — but it'll get re-sync immediately after you release the gesture.
- **Unsyncing, then tapping, then swiping:** Unsync the tabbar (by scrolling it as far as you want). Then tap on some item that's fully in view. The item should get selected but the tabbar shouldn't scroll "under" you. _Now_ start swiping. Notice that the gesture will not be jumpy — it'll gradually move as always but then _resync after you release_.

Verify non-primary cases:

- Just one tab: Check a feed's page
- Just two tabs: Delete feeds other than Following and Discover
- The profile: Verify profile tabs behave as expected
- Web: Should have no changes

Verify perf on Android and iOS devices.

Known issues:

- <s>Due to the change in https://github.com/bluesky-social/social-app/pull/6762, there's no prewarming during swipe, so each feed loads a bit "too late" (after swipe). I'll stack something on top of this PR to resolve that, but not in scope.</s>
  - Actually, this doesn't seem very relevant — we were only starting load when we got into a "settling" state so it was pretty late anyway. I'll look at improving this regardless but doesn't block land.

- On Android, swipes are sometimes interpreted as taps and bring up the lightbox or navigate into the post. This is not a new issue, and has always been broken — I'll likely look at it but not today.

https://github.com/user-attachments/assets/8a941234-fc98-4982-b652-9874151be3a5

