### PR TITLE
feat: animate tab indicator position and size on native and web

### DIFF
--- a/src/view/com/home/HomeHeader.tsx
+++ b/src/view/com/home/HomeHeader.tsx
@@ -16,7 +16,7 @@ export function HomeHeader(
     feeds: FeedSourceInfo[]
   },
 ) {
-  const {feeds} = props
+  const {feeds, pageOffset} = props
   const {hasSession} = useSession()
   const navigation = useNavigation<NavigationProp>()
   const pal = usePalette('default')
@@ -62,6 +62,7 @@ export function HomeHeader(
         testID={props.testID}
         items={items}
         indicatorColor={pal.colors.link}
+        pageOffset={pageOffset}
       />
     </HomeHeaderLayout>
   )

--- a/src/view/com/pager/PagerWithHeader.tsx
+++ b/src/view/com/pager/PagerWithHeader.tsx
@@ -97,6 +97,7 @@ export const PagerWithHeader = React.forwardRef<PagerRef, PagerWithHeaderProps>(
               scrollY={scrollY}
               testID={testID}
               allowHeaderOverScroll={allowHeaderOverScroll}
+              pageOffset={props.pageOffset}
             />
           </PagerHeaderProvider>
         )
@@ -231,6 +232,7 @@ let PagerTabBar = ({
   onCurrentPageSelected,
   onSelect,
   allowHeaderOverScroll,
+  pageOffset,
 }: {
   currentPage: number
   headerOnlyHeight: number
@@ -244,6 +246,7 @@ let PagerTabBar = ({
   onCurrentPageSelected?: (index: number) => void
   onSelect?: (index: number) => void
   allowHeaderOverScroll?: boolean
+  pageOffset: SharedValue<number>
 }): React.ReactNode => {
   const headerTransform = useAnimatedStyle(() => {
     const translateY = Math.min(scrollY.get(), headerOnlyHeight) * -1
@@ -302,6 +305,7 @@ let PagerTabBar = ({
           selectedPage={currentPage}
           onSelect={onSelect}
           onPressSelected={onCurrentPageSelected}
+          pageOffset={pageOffset}
         />
       </View>
     </Animated.View>

--- a/src/view/com/pager/PagerWithHeader.web.tsx
+++ b/src/view/com/pager/PagerWithHeader.web.tsx
@@ -1,6 +1,10 @@
 import * as React from 'react'
 import {ScrollView, StyleSheet, View} from 'react-native'
-import {useAnimatedRef} from 'react-native-reanimated'
+import {
+  useAnimatedRef,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated'
 
 import {usePalette} from '#/lib/hooks/usePalette'
 import {useWebMediaQueries} from '#/lib/hooks/useWebMediaQueries'
@@ -128,6 +132,13 @@ let PagerTabBar = ({
 }): React.ReactNode => {
   const pal = usePalette('default')
   const {isMobile} = useWebMediaQueries()
+  const pageOffset = useSharedValue(0)
+
+  React.useEffect(() => {
+    // animate TabBar indicator position and width upon click
+    pageOffset.value = withTiming(currentPage)
+  }, [currentPage, pageOffset])
+
   return (
     <>
       <View
@@ -156,6 +167,7 @@ let PagerTabBar = ({
           selectedPage={currentPage}
           onSelect={onSelect}
           onPressSelected={onCurrentPageSelected}
+          pageOffset={pageOffset}
         />
       </View>
     </>


### PR DESCRIPTION
I tried to make least invasive implementation and just basically extended the logic that was already there. Should work on all platforms including web. Feel free to get inspired for your implementation #6868 (which is very similar in base approach) or if you want, I can extend this one with your suggestions


https://github.com/user-attachments/assets/b14b4db7-9827-40b5-b87e-477c295a49ab

