### PR TITLE
Fix title/buttons in age date picker not being visible on Android in dark mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -170,7 +170,7 @@
     "react-keyed-flatten-children": "^3.0.0",
     "react-native": "0.74.1",
     "react-native-compressor": "^1.8.24",
-    "react-native-date-picker": "^4.4.2",
+    "react-native-date-picker": "^5.0.7",
     "react-native-drawer-layout": "^4.0.1",
     "react-native-gesture-handler": "2.20.0",
     "react-native-get-random-values": "~1.11.0",

--- a/src/components/forms/DateField/index.android.tsx
+++ b/src/components/forms/DateField/index.android.tsx
@@ -50,11 +50,14 @@ export function DateField({
       />
 
       {open && (
+        // Android implementation of DatePicker currently does not change default button colors according to theme and only takes hex values for buttonColor
+        // Can remove the buttonColor setting if/when this PR is merged: https://github.com/henninghall/react-native-date-picker/pull/871
         <DatePicker
           modal
           open
           timeZoneOffsetInMinutes={0}
           theme={t.name === 'light' ? 'light' : 'dark'}
+          buttonColor={t.name === 'light' ? '#000000' : '#ffffff'}
           date={new Date(value)}
           onConfirm={onChangeInternal}
           onCancel={onCancel}

--- a/yarn.lock
+++ b/yarn.lock
@@ -16110,10 +16110,10 @@ react-native-compressor@^1.8.24:
   resolved "https://registry.yarnpkg.com/react-native-compressor/-/react-native-compressor-1.8.24.tgz#3cc481ad6dfe2787ec4385275dd24791f04d9e71"
   integrity sha512-PdwOBdnyBnpOag1FRX9ks4cb0GiMLKFU9HSaFTHdb/uw6fVIrnCHpELASeliOxlabWb5rOyVPbc58QpGIfZQIQ==
 
-react-native-date-picker@^4.4.2:
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/react-native-date-picker/-/react-native-date-picker-4.4.2.tgz#f7bb9daa8559237e08bd30f907ee8487a6e2a6ec"
-  integrity sha512-wYKN8nYWhETVHJV/+Im30JOdzkFRwYRrDlEOyyYesOjt+1JTFJh9M7K5CqePLOIB4Nxlf2f2lRSI0VoUyFIovA==
+react-native-date-picker@^5.0.7:
+  version "5.0.7"
+  resolved "https://registry.yarnpkg.com/react-native-date-picker/-/react-native-date-picker-5.0.7.tgz#24161d30c6dca8627afe1aa5a55a389421fdfba4"
+  integrity sha512-/RodyCZWjb+f3f4YHqKbWFYczGm+tNngwbVSB6MLGgt5Kl7LQXpv4QE6ybnHW+DM4LteTP8A6lj8LEkQ7+usLQ==
 
 react-native-dotenv@^3.3.1:
   version "3.4.9"


### PR DESCRIPTION
This issue initially hard blocked me from registering a Bluesky account in the Android app because I couldn't see that this dialog had any buttons at all because of the incorrect theming:

![before](https://github.com/user-attachments/assets/b6f1a063-f9f9-422c-9263-b521d32a4030)

# Fix

The title color is fixed automatically by upgrading to the latest version of `react-native-date-picker`. However, it doesn't fix the buttons. These buttons seem like they should switch to white in dark mode too (and I have another [PR](https://github.com/henninghall/react-native-date-picker/pull/871) up against react-native-date-picker to change that), but in the meantime I've just specified the correct colours depending on theme to the `buttonColor` property. 

The reason I'm using hard-coded hex values instead of getting colours from the theme is that the theme has the colours in hsl format, which the buttonColor prop does not currently support (also fixed in the PR above).

# Screenshots of fixed version
![fixed_dark](https://github.com/user-attachments/assets/4446bf91-3e4d-4c7a-a709-6e4ed9a9e000)
![after_light](https://github.com/user-attachments/assets/a5504af1-f4a1-469a-8bc2-7057194cc33d)
