### PR TITLE
Remove the top safe area inset on profile

### DIFF
--- a/src/screens/Profile/Header/GrowableBanner.tsx
+++ b/src/screens/Profile/Header/GrowableBanner.tsx
@@ -10,6 +10,7 @@ import Animated, {
   useAnimatedReaction,
   useAnimatedStyle,
 } from 'react-native-reanimated'
+import {useSafeAreaInsets} from 'react-native-safe-area-context'
 import {BlurView} from 'expo-blur'
 import {useIsFetching} from '@tanstack/react-query'
 
@@ -60,13 +61,15 @@ function GrowableBannerInner({
   backButton?: React.ReactNode
   children: React.ReactNode
 }) {
+  const {top: topInset} = useSafeAreaInsets()
   const isFetching = useIsProfileFetching()
   const animateSpinner = useShouldAnimateSpinner({isFetching, scrollY})
+  const BASE_HEIGHT = -150 - topInset
 
   const animatedStyle = useAnimatedStyle(() => ({
     transform: [
       {
-        scale: interpolate(scrollY.get(), [-150, 0], [2, 1], {
+        scale: interpolate(scrollY.get(), [BASE_HEIGHT, 0], [2, 1], {
           extrapolateRight: Extrapolation.CLAMP,
         }),
       },
@@ -95,7 +98,7 @@ function GrowableBannerInner({
         Extrapolation.CLAMP,
       ),
       transform: [
-        {translateY: interpolate(scrollYValue, [-150, 0], [-75, 0])},
+        {translateY: interpolate(scrollYValue, [BASE_HEIGHT, 0], [-75, 0])},
         {rotate: '90deg'},
       ],
     }
@@ -104,9 +107,14 @@ function GrowableBannerInner({
   const animatedBackButtonStyle = useAnimatedStyle(() => ({
     transform: [
       {
-        translateY: interpolate(scrollY.get(), [-150, 60], [-150, 60], {
-          extrapolateRight: Extrapolation.CLAMP,
-        }),
+        translateY: interpolate(
+          scrollY.get(),
+          [BASE_HEIGHT, 60],
+          [BASE_HEIGHT, 60],
+          {
+            extrapolateRight: Extrapolation.CLAMP,
+          },
+        ),
       },
     ],
   }))
@@ -117,7 +125,7 @@ function GrowableBannerInner({
         style={[
           a.absolute,
           {left: 0, right: 0, bottom: 0},
-          {height: 150},
+          {height: BASE_HEIGHT},
           {transformOrigin: 'bottom'},
           animatedStyle,
         ]}>

--- a/src/screens/Profile/Header/Shell.tsx
+++ b/src/screens/Profile/Header/Shell.tsx
@@ -1,6 +1,7 @@
 import React, {memo} from 'react'
 import {StyleSheet, TouchableWithoutFeedback, View} from 'react-native'
 import {MeasuredDimensions, runOnJS, runOnUI} from 'react-native-reanimated'
+import {useSafeAreaInsets} from 'react-native-safe-area-context'
 import {AppBskyActorDefs, ModerationDecision} from '@atproto/api'
 import {FontAwesomeIcon} from '@fortawesome/react-native-fontawesome'
 import {msg} from '@lingui/macro'
@@ -45,6 +46,7 @@ let ProfileHeaderShell = ({
   const navigation = useNavigation<NavigationProp>()
   const {isDesktop} = useWebMediaQueries()
   const aviRef = useHandleRef()
+  const {top: topInset} = useSafeAreaInsets()
 
   const onPressBack = React.useCallback(() => {
     if (navigation.canGoBack()) {
@@ -99,26 +101,34 @@ let ProfileHeaderShell = ({
     <View style={t.atoms.bg} pointerEvents={isIOS ? 'auto' : 'box-none'}>
       <View
         pointerEvents={isIOS ? 'auto' : 'box-none'}
-        style={[a.relative, {height: 150}]}>
+        style={[a.relative, {height: 150 + topInset}]}>
         <GrowableBanner
           backButton={
             <>
               {!isDesktop && !hideBackButton && (
-                <TouchableWithoutFeedback
-                  testID="profileHeaderBackBtn"
-                  onPress={onPressBack}
-                  hitSlop={BACK_HITSLOP}
-                  accessibilityRole="button"
-                  accessibilityLabel={_(msg`Back`)}
-                  accessibilityHint="">
-                  <View style={styles.backBtnWrapper}>
-                    <FontAwesomeIcon
-                      size={18}
-                      icon="angle-left"
-                      color="white"
-                    />
-                  </View>
-                </TouchableWithoutFeedback>
+                <View
+                  style={[
+                    styles.backBtnWrapper,
+                    {
+                      top: topInset + 10,
+                    },
+                  ]}>
+                  <TouchableWithoutFeedback
+                    testID="profileHeaderBackBtn"
+                    onPress={onPressBack}
+                    hitSlop={BACK_HITSLOP}
+                    accessibilityRole="button"
+                    accessibilityLabel={_(msg`Back`)}
+                    accessibilityHint="">
+                    <View>
+                      <FontAwesomeIcon
+                        size={18}
+                        icon="angle-left"
+                        color="white"
+                      />
+                    </View>
+                  </TouchableWithoutFeedback>
+                </View>
               )}
             </>
           }>
@@ -133,6 +143,7 @@ let ProfileHeaderShell = ({
               type={profile.associated?.labeler ? 'labeler' : 'default'}
               banner={profile.banner}
               moderation={moderation.ui('banner')}
+              topInset={topInset}
             />
           )}
         </GrowableBanner>
@@ -152,7 +163,13 @@ let ProfileHeaderShell = ({
         </View>
       )}
 
-      <GrowableAvatar style={styles.aviPosition}>
+      <GrowableAvatar
+        style={[
+          styles.aviPosition,
+          {
+            top: 110 + topInset,
+          },
+        ]}>
         <TouchableWithoutFeedback
           testID="profileHeaderAviButton"
           onPress={onPressAvi}

--- a/src/screens/Profile/Header/index.tsx
+++ b/src/screens/Profile/Header/index.tsx
@@ -1,5 +1,6 @@
 import React, {memo} from 'react'
 import {StyleSheet, View} from 'react-native'
+import {useSafeAreaInsets} from 'react-native-safe-area-context'
 import {
   AppBskyActorDefs,
   AppBskyLabelerDefs,
@@ -13,14 +14,19 @@ import {ProfileHeaderLabeler} from './ProfileHeaderLabeler'
 import {ProfileHeaderStandard} from './ProfileHeaderStandard'
 
 let ProfileHeaderLoading = (_props: {}): React.ReactNode => {
+  const {top: topInset} = useSafeAreaInsets()
   const t = useTheme()
   return (
     <View style={t.atoms.bg}>
-      <LoadingPlaceholder width="100%" height={150} style={{borderRadius: 0}} />
+      <LoadingPlaceholder
+        width="100%"
+        height={150 + topInset}
+        style={{borderRadius: 0}}
+      />
       <View
         style={[
           t.atoms.bg,
-          {borderColor: t.atoms.bg.backgroundColor},
+          {borderColor: t.atoms.bg.backgroundColor, top: 110 + topInset},
           styles.avi,
         ]}>
         <LoadingPlaceholder width={90} height={90} style={styles.br45} />
@@ -60,7 +66,6 @@ export {ProfileHeader}
 const styles = StyleSheet.create({
   avi: {
     position: 'absolute',
-    top: 110,
     left: 10,
     width: 94,
     height: 94,

--- a/src/view/com/util/UserBanner.tsx
+++ b/src/view/com/util/UserBanner.tsx
@@ -32,11 +32,13 @@ export function UserBanner({
   banner,
   moderation,
   onSelectNewBanner,
+  topInset = 0,
 }: {
   type?: 'labeler' | 'default'
   banner?: string | null
   moderation?: ModerationUI
   onSelectNewBanner?: (img: RNImage | null) => void
+  topInset?: number
 }) {
   const pal = usePalette('default')
   const theme = useTheme()
@@ -45,6 +47,10 @@ export function UserBanner({
   const {requestCameraAccessIfNeeded} = useCameraPermission()
   const {requestPhotoAccessIfNeeded} = usePhotoLibraryPermission()
   const sheetWrapper = useSheetWrapper()
+
+  const bannerHeightStyle = {
+    height: 150 + topInset,
+  }
 
   const onOpenCamera = React.useCallback(async () => {
     if (!(await requestCameraAccessIfNeeded())) {
@@ -98,7 +104,7 @@ export function UserBanner({
               {banner ? (
                 <Image
                   testID="userBannerImage"
-                  style={styles.bannerImage}
+                  style={[styles.bannerImage, bannerHeightStyle]}
                   source={{uri: banner}}
                   accessible={true}
                   accessibilityIgnoresInvertColors
@@ -106,7 +112,11 @@ export function UserBanner({
               ) : (
                 <View
                   testID="userBannerFallback"
-                  style={[styles.bannerImage, t.atoms.bg_contrast_25]}
+                  style={[
+                    styles.placeholderImage,
+                    t.atoms.bg_contrast_25,
+                    bannerHeightStyle,
+                  ]}
                 />
               )}
               <View style={[styles.editButtonContainer, pal.btn]}>
@@ -168,6 +178,7 @@ export function UserBanner({
       testID="userBannerImage"
       style={[
         styles.bannerImage,
+        bannerHeightStyle,
         {backgroundColor: theme.palette.default.backgroundLight},
       ]}
       resizeMode="cover"
@@ -181,6 +192,7 @@ export function UserBanner({
       testID="userBannerFallback"
       style={[
         styles.bannerImage,
+        bannerHeightStyle,
         type === 'labeler' ? styles.labelerBanner : t.atoms.bg_contrast_25,
       ]}
     />
@@ -202,6 +214,10 @@ const styles = StyleSheet.create({
   bannerImage: {
     width: '100%',
     height: 150,
+  },
+  placeholderImage: {
+    width: '100%',
+    height: 100,
   },
   labelerBanner: {
     backgroundColor: tokens.color.temp_purple,

--- a/src/view/screens/Profile.tsx
+++ b/src/view/screens/Profile.tsx
@@ -58,7 +58,7 @@ interface SectionRef {
 type Props = NativeStackScreenProps<CommonNavigatorParams, 'Profile'>
 export function ProfileScreen(props: Props) {
   return (
-    <Layout.Screen testID="profileScreen">
+    <Layout.Screen testID="profileScreen" disableTopPadding>
       <ProfileScreenInner {...props} />
     </Layout.Screen>
   )


### PR DESCRIPTION
Taking inspiration from this [post](https://bsky.app/profile/samuel.bsky.team/post/3lc6kibs7r225) from Sam, this PR removes the top safe area blank on profile.

- Disabling the blank space by setting the `disableTopPadding` on `Layout.Screen`
- Updating lot of style to add the `topInset` value on `height` or `top` position
- Updating some values into `useAnimatedStyle`, instead of repeating the `150 - topInset` value I created a constant
- Updating the loading component
- The `topInset` prop has been added to handle the case on the edit modal where we don't want to handler the top inset

Wondering how we can handle the status bar color properly, before the status bar was always black over the blank space content. Now it should adapt the status bar's color according to the user banner but I don't really know how to handle this point.

This is my first open source contribution, please do feel free to tell me if something is wrong on the process/communication.
Greeting 🫶 


### Preview

**iOS** 
https://github.com/user-attachments/assets/5b95064f-4183-49ce-9d37-da04fff0a73a

**Android**
https://github.com/user-attachments/assets/ac2e0692-934f-4557-b1f5-19fb2bc66777

