### PR TITLE
Improve label to domain parsing logic

### DIFF
--- a/src/lib/strings/url-helpers.ts
+++ b/src/lib/strings/url-helpers.ts
@@ -279,15 +279,17 @@ export function linkRequiresWarning(uri: string, label: string) {
  * @see https://www.rfc-editor.org/rfc/rfc3986#section-3.2.2
  */
 export function labelToDomain(label: string): string | undefined {
-  // any spaces just immediately consider the label a non-url
-  if (/\s/.test(label)) {
+  // any external spaces can be removed without any effect, just wrong facets
+  const labelTrimmed = label.trim()
+  // any internal spaces just immediately consider the label a non-url
+  if (/\s/.test(labelTrimmed)) {
     return undefined
   }
   try {
-    return new URL(label).hostname.toLowerCase()
+    return new URL(labelTrimmed).hostname.toLowerCase()
   } catch {}
   try {
-    return new URL('https://' + label).hostname.toLowerCase()
+    return new URL('https://' + labelTrimmed).hostname.toLowerCase()
   } catch {}
   return undefined
 }


### PR DESCRIPTION
Some links include spaces due to crooked facets (_f.e. https://bsky.app/profile/vordgi.com/post/3lcc72kesjc2l_).

I haven’t looked at whether this is happening inside Bluesky or from third-party clients, but in any case, this can happen.

Added `trim` to the link comparison check, because it cannot affect the link itself.

https://github.com/user-attachments/assets/e02e2291-5599-4605-b8f5-586dea0835eb
