### PR TITLE
6888 fix overflow issue for timestamp not being visible 

### DIFF
--- a/src/alf/atoms.ts
+++ b/src/alf/atoms.ts
@@ -46,7 +46,9 @@ export const atoms = {
   overflow_hidden: {
     overflow: 'hidden',
   },
-
+  overflow_visible: {
+    overflow: 'visible',
+  },
   /*
    * Width
    */

--- a/src/view/com/notifications/FeedItem.tsx
+++ b/src/view/com/notifications/FeedItem.tsx
@@ -384,7 +384,7 @@ let FeedItem = ({
               borderColor: pal.colors.unreadNotifBorder,
             },
         {borderTopWidth: hideTopBorder ? 0 : StyleSheet.hairlineWidth},
-        a.overflow_hidden,
+        a.overflow_visible,
       ]}
       href={itemHref}
       noFeedback


### PR DESCRIPTION
before:
![image](https://github.com/user-attachments/assets/a38de6a2-36b7-45d0-a351-6117adeabcbd)

after:
![image](https://github.com/user-attachments/assets/614ea7b4-d1c6-4337-bd87-44b05919cfc1)

explanation: overflow was set to hidden in the FeedItem comp in notifications, this caused the timestamp in the notification item to be hidden. issue was described: in the https://github.com/bluesky-social/social-app/issues/6888 