### PR TITLE
Move the FeedItem overflow hidden to the inside text

### DIFF
--- a/src/view/com/notifications/FeedItem.tsx
+++ b/src/view/com/notifications/FeedItem.tsx
@@ -384,7 +384,6 @@ let FeedItem = ({
               borderColor: pal.colors.unreadNotifBorder,
             },
         {borderTopWidth: hideTopBorder ? 0 : StyleSheet.hairlineWidth},
-        a.overflow_hidden,
       ]}
       href={itemHref}
       noFeedback
@@ -721,7 +720,7 @@ function AdditionalPostText({post}: {post?: AppBskyFeedDefs.PostView}) {
     return (
       <>
         {text?.length > 0 && (
-          <Text emoji style={pal.textLight}>
+          <Text emoji style={[a.overflow_hidden, pal.textLight]}>
             {text}
           </Text>
         )}


### PR DESCRIPTION
## Description

Fixing #6888 which was an unintended consequence of https://github.com/bluesky-social/social-app/pull/4899.  This keeps the text still from overflowing while showing the tooltip.

| Before | After |
| -------- | -------- |
| <img width="634" alt="image" src="https://github.com/user-attachments/assets/ae0e0c85-b5ed-4dcb-9023-cd6f9005b7d0"> |<img width="618" alt="image" src="https://github.com/user-attachments/assets/cf792620-b4c8-4499-89b0-e5304378ce36"> |

## Test plan
Hover over timestamps in notification page.  Also test zalgo text in notification posts.  Can use @mozzius 's original helpful test post:
https://bsky.app/profile/samuel.bsky.team/post/3kz7qimdhjd27