### PR TITLE
Include avatar in RSS feed.

### DIFF
--- a/bskyweb/cmd/bskyweb/rss.go
+++ b/bskyweb/cmd/bskyweb/rss.go
@@ -31,11 +31,19 @@ type Item struct {
 	GUID        ItemGUID
 }
 
+type Image struct {
+	XMLName xml.Name `xml:"image"`
+	URL     string   `xml:"url"`
+	Title   string   `xml:"title"`
+	Link    string   `xml:"link"`
+}
+
 type rss struct {
 	Version     string `xml:"version,attr"`
 	Description string `xml:"channel>description,omitempty"`
 	Link        string `xml:"channel>link"`
 	Title       string `xml:"channel>title"`
+	Image       Image  `xml:"channel>image"`
 
 	Item []Item `xml:"channel>item"`
 }
@@ -130,11 +138,20 @@ func (srv *Server) WebProfileRSS(c echo.Context) error {
 	if pv.Description != nil {
 		desc = *pv.Description
 	}
+
+	profileLink := fmt.Sprintf("https://%s/profile/%s", req.Host, pv.Handle)
+	image := Image{
+		URL:   *pv.Avatar,
+		Title: title,
+		Link:  profileLink,
+	}
+
 	feed := &rss{
 		Version:     "2.0",
 		Description: desc,
-		Link:        fmt.Sprintf("https://%s/profile/%s", req.Host, pv.Handle),
+		Link:        profileLink,
 		Title:       title,
+		Image:       image,
 		Item:        posts,
 	}
 	return c.XML(http.StatusOK, feed)


### PR DESCRIPTION
Hello,

This adds an [`<image>`](https://www.rssboard.org/rss-specification#ltimagegtSubelementOfLtchannelgt) element containing the author's avatar. 

This way RSS readers would gain the option of displaying a nice avatar alongside the post. Maybe something like this:

![bsky](https://github.com/user-attachments/assets/2ae7ac3b-be7f-4b2d-ba41-8af0470d26cd)

This would close #3170.

Thanks!