### PR TITLE
Bump the initial fetch page size

### DIFF
--- a/src/state/queries/post-feed.ts
+++ b/src/state/queries/post-feed.ts
@@ -146,10 +146,7 @@ export function usePostFeedQuery(
    * unwanted content, we may over-fetch here to try and fill pages by
    * `MIN_POSTS`.
    */
-
-  // TEMPORARILY DISABLING GATE TO PREVENT EVENT CONSUMPTION @TODO EME-GATE
-  // const fetchLimit = gate('post_feed_lang_window') ? 100 : MIN_POSTS
-  const fetchLimit = MIN_POSTS
+  const fetchLimit = MIN_POSTS * 3
 
   // Make sure this doesn't invalidate unless really needed.
   const selectArgs = React.useMemo(


### PR DESCRIPTION
Reverts https://github.com/bluesky-social/social-app/pull/5814 and hardcodes to essentially 90.

## Before

<img width="497" alt="Screenshot 2024-12-02 at 17 44 43" src="https://github.com/user-attachments/assets/331fc9b0-e56e-4adb-928f-8756f948b365">

## After

<img width="418" alt="Screenshot 2024-12-02 at 17 44 50" src="https://github.com/user-attachments/assets/e9d6eef2-9345-4243-bee0-7dbe40753412">
