### PR TITLE
Prefetch adjacent Home pages

### DIFF
--- a/src/view/com/feeds/FeedPage.tsx
+++ b/src/view/com/feeds/FeedPage.tsx
@@ -32,6 +32,7 @@ const POLL_FREQ = 60e3 // 60sec
 export function FeedPage({
   testID,
   isPageFocused,
+  isPageAdjacent,
   feed,
   feedParams,
   renderEmptyState,
@@ -42,6 +43,7 @@ export function FeedPage({
   feed: FeedDescriptor
   feedParams?: FeedParams
   isPageFocused: boolean
+  isPageAdjacent: boolean
   renderEmptyState: () => JSX.Element
   renderEndOfFeed?: () => JSX.Element
   savedFeedConfig?: AppBskyActorDefs.SavedFeed
@@ -111,11 +113,11 @@ export function FeedPage({
         <FeedFeedbackProvider value={feedFeedback}>
           <Feed
             testID={testID ? `${testID}-feed` : undefined}
-            enabled={isPageFocused}
+            enabled={isPageFocused || isPageAdjacent}
             feed={feed}
             feedParams={feedParams}
             pollInterval={POLL_FREQ}
-            disablePoll={hasNew}
+            disablePoll={hasNew || !isPageFocused}
             scrollElRef={scrollElRef}
             onScrolledDownChange={setIsScrolledDown}
             onHasNew={setHasNew}

--- a/src/view/com/posts/Feed.tsx
+++ b/src/view/com/posts/Feed.tsx
@@ -216,7 +216,7 @@ let Feed = ({
     checkForNewRef.current = checkForNew
   }, [checkForNew])
   React.useEffect(() => {
-    if (enabled) {
+    if (enabled && !disablePoll) {
       const timeSinceFirstLoad = Date.now() - lastFetchRef.current
       // DISABLED need to check if this is causing random feed refreshes -prf
       /*if (timeSinceFirstLoad > REFRESH_AFTER) {
@@ -231,7 +231,7 @@ let Feed = ({
         checkForNewRef.current()
       }
     }
-  }, [enabled, feed, queryClient, scrollElRef])
+  }, [enabled, disablePoll, feed, queryClient, scrollElRef])
   React.useEffect(() => {
     let cleanup1: () => void | undefined, cleanup2: () => void | undefined
     const subscription = AppState.addEventListener('change', nextAppState => {

--- a/src/view/screens/Home.tsx
+++ b/src/view/screens/Home.tsx
@@ -233,7 +233,7 @@ function HomeScreenReady({
       onPageScrollStateChanged={onPageScrollStateChanged}
       renderTabBar={renderTabBar}>
       {pinnedFeedInfos.length ? (
-        pinnedFeedInfos.map(feedInfo => {
+        pinnedFeedInfos.map((feedInfo, index) => {
           const feed = feedInfo.feedDescriptor
           if (feed === 'following') {
             return (
@@ -241,6 +241,7 @@ function HomeScreenReady({
                 key={feed}
                 testID="followingFeedPage"
                 isPageFocused={selectedFeed === feed}
+                isPageAdjacent={Math.abs(selectedIndex - index) === 1}
                 feed={feed}
                 feedParams={homeFeedParams}
                 renderEmptyState={renderFollowingEmptyState}
@@ -254,6 +255,7 @@ function HomeScreenReady({
               key={feed}
               testID="customFeedPage"
               isPageFocused={selectedFeed === feed}
+              isPageAdjacent={Math.abs(selectedIndex - index) === 1}
               feed={feed}
               renderEmptyState={renderCustomFeedEmptyState}
               savedFeedConfig={savedFeedConfig}
@@ -273,6 +275,7 @@ function HomeScreenReady({
       <FeedPage
         testID="customFeedPage"
         isPageFocused
+        isPageAdjacent={false}
         feed={`feedgen|${PROD_DEFAULT_FEED('whats-hot')}`}
         renderEmptyState={renderCustomFeedEmptyState}
       />


### PR DESCRIPTION
Enables prefetching for adjacent Home tabs. This is similar to what would happen today if you just navigated around the tabs (thus warming them up). Prefetching only happens once and there is no continuous polling until you focus. 

## Test Plan

Add `console.log` to `post-feed` fetch, verify it is being hit for adjacent tabs.

Verify that `checkForNew` in `Feed.tsx` exits early for all non-focused tabs (even adjacent ones), like before.

Verify that the effect computing `const timeSinceFirstLoad = ...` in `Feed.tsx` still always gets triggered on tab focus — i.e. it doesn't get "stuck" for adjacent tabs. In other words, verify the focused tab always gets into this check's body. In practical sense, we want to ensure that continuously switching between two tabs will eventually trigger the `timeSinceFirstLoad`-based 30 second condition for the one you're activating at that point:

```diff
diff --git a/src/view/com/posts/Feed.tsx b/src/view/com/posts/Feed.tsx
index fb5484919..eaf955dca 100644
--- a/src/view/com/posts/Feed.tsx
+++ b/src/view/com/posts/Feed.tsx
@@ -184,6 +184,7 @@ let Feed = ({
       return
     }
     try {
+      console.log('hell yeah polling', feed)
       if (await pollLatest(data.pages[0])) {
         onHasNew(true)
       }
@@ -217,6 +218,7 @@ let Feed = ({
   }, [checkForNew])
   React.useEffect(() => {
     if (enabled && !disablePoll) {
+      console.log('checking time since load for', feed)
       const timeSinceFirstLoad = Date.now() - lastFetchRef.current
       // DISABLED need to check if this is causing random feed refreshes -prf
       /*if (timeSinceFirstLoad > REFRESH_AFTER) {
@@ -227,6 +229,7 @@ let Feed = ({
         timeSinceFirstLoad > CHECK_LATEST_AFTER &&
         checkForNewRef.current
       ) {
+        console.log('gonna try to poll', feed)
         // check for new on enable (aka on focus)
         checkForNewRef.current()
       }
```

As you navigate between tabs, you should always see `checking time since load for` for the focused tab. If more than 30 seconds passed since you last visited it, you should expect `hell yeah polling` for it.
## Before

https://github.com/user-attachments/assets/7fc53e4b-c94c-4507-8d28-1411ecbc5350

## After

https://github.com/user-attachments/assets/59bc918a-2edc-42c6-9db9-4e6286804bd8

