### PR TITLE
Optimize post real-estate on timelines

### DIFF
--- a/src/view/com/posts/FeedItem.tsx
+++ b/src/view/com/posts/FeedItem.tsx
@@ -366,9 +366,8 @@ let FeedItemInner = ({
           ) : null}
         </View>
       </View>
-
-      <View style={styles.layout}>
-        <View style={styles.layoutAvi}>
+      <View style={[styles.layout]}>
+        <View style={styles.layoutHeader}>
           <AviFollowButton author={post.author} moderation={moderation}>
             <PreviewableUserAvatar
               size={42}
@@ -378,55 +377,44 @@ let FeedItemInner = ({
               onBeforePress={onOpenAuthor}
             />
           </AviFollowButton>
-          {isThreadParent && (
-            <View
-              style={[
-                styles.replyLine,
-                {
-                  flexGrow: 1,
-                  backgroundColor: pal.colors.replyLine,
-                  marginTop: 4,
-                },
-              ]}
+          <View style={styles.metaContent}>
+            <PostMeta
+              author={post.author}
+              moderation={moderation}
+              timestamp={post.indexedAt}
+              postHref={href}
+              onOpenAuthor={onOpenAuthor}
+            />
+          </View>
+        </View>
+        {showReplyTo &&
+          (parentAuthor || isParentBlocked || isParentNotFound) && (
+            <ReplyToLabel
+              blocked={isParentBlocked}
+              notFound={isParentNotFound}
+              profile={parentAuthor}
             />
           )}
-        </View>
-        <View style={styles.layoutContent}>
-          <PostMeta
-            author={post.author}
-            moderation={moderation}
-            timestamp={post.indexedAt}
-            postHref={href}
-            onOpenAuthor={onOpenAuthor}
-          />
-          {showReplyTo &&
-            (parentAuthor || isParentBlocked || isParentNotFound) && (
-              <ReplyToLabel
-                blocked={isParentBlocked}
-                notFound={isParentNotFound}
-                profile={parentAuthor}
-              />
-            )}
-          <LabelsOnMyPost post={post} />
-          <PostContent
-            moderation={moderation}
-            richText={richText}
-            postEmbed={post.embed}
-            postAuthor={post.author}
-            onOpenEmbed={onOpenEmbed}
-            post={post}
-            threadgateRecord={threadgateRecord}
-          />
-          <PostCtrls
-            post={post}
-            record={record}
-            richText={richText}
-            onPressReply={onPressReply}
-            logContext="FeedItem"
-            feedContext={feedContext}
-            threadgateRecord={threadgateRecord}
-          />
-        </View>
+
+        <LabelsOnMyPost post={post} />
+        <PostContent
+          moderation={moderation}
+          richText={richText}
+          postEmbed={post.embed}
+          postAuthor={post.author}
+          onOpenEmbed={onOpenEmbed}
+          post={post}
+          threadgateRecord={threadgateRecord}
+        />
+        <PostCtrls
+          post={post}
+          record={record}
+          richText={richText}
+          onPressReply={onPressReply}
+          logContext="FeedItem"
+          feedContext={feedContext}
+          threadgateRecord={threadgateRecord}
+        />
       </View>
     </Link>
   )
@@ -598,8 +586,8 @@ function ReplyToLabel({
 
 const styles = StyleSheet.create({
   outer: {
-    paddingLeft: 10,
-    paddingRight: 15,
+    paddingLeft: 20,
+    paddingRight: 20,
     // @ts-ignore web only -prf
     cursor: 'pointer',
   },
@@ -616,11 +604,15 @@ const styles = StyleSheet.create({
     marginLeft: -16,
   },
   layout: {
+    width: '100%',
+    flexDirection: 'column',
+  },
+  layoutHeader: {
     flexDirection: 'row',
-    marginTop: 1,
+    alignItems: 'center',
+    marginBottom: 6,
   },
   layoutAvi: {
-    paddingLeft: 8,
     paddingRight: 10,
     position: 'relative',
     zIndex: 999,
@@ -649,5 +641,9 @@ const styles = StyleSheet.create({
   },
   translateLink: {
     marginBottom: 6,
+  },
+  metaContent: {
+    flex: 1,
+    paddingLeft: 10,
   },
 })

--- a/src/view/com/posts/FeedItem.tsx
+++ b/src/view/com/posts/FeedItem.tsx
@@ -238,6 +238,15 @@ let FeedItemInner = ({
     ? rootPost.threadgate.record
     : undefined
 
+  const isThread = isThreadChild || isThreadParent || isThreadLastChild
+
+  const contentPadding = useMemo(() => {
+    if (isThread) {
+      return {paddingLeft: 50} // Adjust content padding for thread alignment
+    }
+    return {paddingLeft: 0}
+  }, [isThread])
+
   const [hover, setHover] = useState(false)
   return (
     <Link
@@ -256,22 +265,7 @@ let FeedItemInner = ({
       }}>
       <SubtleWebHover hover={hover} />
       <View style={{flexDirection: 'row', gap: 10, paddingLeft: 8}}>
-        <View style={{width: 42}}>
-          {isThreadChild && (
-            <View
-              style={[
-                styles.replyLine,
-                {
-                  flexGrow: 1,
-                  backgroundColor: pal.colors.replyLine,
-                  marginBottom: 4,
-                },
-              ]}
-            />
-          )}
-        </View>
-
-        <View style={{paddingTop: 12, flexShrink: 1}}>
+        <View style={{paddingTop: 6, paddingBottom: 6, flexShrink: 1}}>
           {isReasonFeedSource(reason) ? (
             <Link href={reason.href}>
               <Text
@@ -395,26 +389,41 @@ let FeedItemInner = ({
               profile={parentAuthor}
             />
           )}
-
         <LabelsOnMyPost post={post} />
-        <PostContent
-          moderation={moderation}
-          richText={richText}
-          postEmbed={post.embed}
-          postAuthor={post.author}
-          onOpenEmbed={onOpenEmbed}
-          post={post}
-          threadgateRecord={threadgateRecord}
-        />
-        <PostCtrls
-          post={post}
-          record={record}
-          richText={richText}
-          onPressReply={onPressReply}
-          logContext="FeedItem"
-          feedContext={feedContext}
-          threadgateRecord={threadgateRecord}
-        />
+        {isThreadParent && (
+          <View
+            style={[
+              styles.replyLine,
+              {
+                flexGrow: 1,
+                position: 'absolute',
+                height: '100%',
+                backgroundColor: pal.colors.replyLine,
+                marginTop: 40,
+              },
+            ]}
+          />
+        )}
+        <View style={[styles.contentContainer, contentPadding]}>
+          <PostContent
+            moderation={moderation}
+            richText={richText}
+            postEmbed={post.embed}
+            postAuthor={post.author}
+            onOpenEmbed={onOpenEmbed}
+            post={post}
+            threadgateRecord={threadgateRecord}
+          />
+          <PostCtrls
+            post={post}
+            record={record}
+            richText={richText}
+            onPressReply={onPressReply}
+            logContext="FeedItem"
+            feedContext={feedContext}
+            threadgateRecord={threadgateRecord}
+          />
+        </View>
       </View>
     </Link>
   )
@@ -593,8 +602,13 @@ const styles = StyleSheet.create({
   },
   replyLine: {
     width: 2,
-    marginLeft: 'auto',
-    marginRight: 'auto',
+    marginLeft: 20,
+    marginRight: 20,
+    flexGrow: 1,
+  },
+  replyContainer: {
+    flexDirection: 'row',
+    alignItems: 'flex-start',
   },
   includeReason: {
     flexDirection: 'row',
@@ -616,11 +630,6 @@ const styles = StyleSheet.create({
     paddingRight: 10,
     position: 'relative',
     zIndex: 999,
-  },
-  layoutContent: {
-    position: 'relative',
-    flex: 1,
-    zIndex: 0,
   },
   alert: {
     marginTop: 6,
@@ -645,5 +654,8 @@ const styles = StyleSheet.create({
   metaContent: {
     flex: 1,
     paddingLeft: 10,
+  },
+  contentContainer: {
+    flex: 1,
   },
 })


### PR DESCRIPTION
closes #6903

This PR offers a more tidey layout for posts on timelines.

## Preview:
Regular text:
![image](https://github.com/user-attachments/assets/e8e1a63e-22eb-4c03-b587-988d61647303)
images:
![image](https://github.com/user-attachments/assets/7a112b46-c49b-470b-b8e0-707f509d0075)
quotes & reposts:
![image](https://github.com/user-attachments/assets/952fffa6-8e02-4d49-ad79-50dfbbdfd18c)
threads:
![image](https://github.com/user-attachments/assets/46320bdd-8310-4b10-820f-4475bd8c5a74)

# Notes:
- My CSS isn't the best, and I'm pretty sure the maintainers here aren't going to be too happy about what I did with lines in threads; feel free to correct me if I did anything wrong.
- I don't expect this PR to be merged for a multitude of reasons, but I hope it can be at least considered and used as a point of reference for others when thinking about an adding more layout options that are more "cozy" to bluesky's frontend.