### PR TITLE
[Layout] Hashtag header

### DIFF
--- a/src/screens/Hashtag.tsx
+++ b/src/screens/Hashtag.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import {ListRenderItemInfo, Pressable, View} from 'react-native'
+import {ListRenderItemInfo, View} from 'react-native'
 import {PostView} from '@atproto/api/dist/client/types/app/bsky/feed/defs'
 import {msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
@@ -13,16 +13,16 @@ import {shareUrl} from '#/lib/sharing'
 import {cleanError} from '#/lib/strings/errors'
 import {sanitizeHandle} from '#/lib/strings/handles'
 import {enforceLen} from '#/lib/strings/helpers'
-import {isNative, isWeb} from '#/platform/detection'
+import {isWeb} from '#/platform/detection'
 import {useSearchPostsQuery} from '#/state/queries/search-posts'
 import {useSetDrawerSwipeDisabled, useSetMinimalShellMode} from '#/state/shell'
 import {Pager} from '#/view/com/pager/Pager'
 import {TabBar} from '#/view/com/pager/TabBar'
 import {Post} from '#/view/com/post/Post'
 import {List} from '#/view/com/util/List'
-import {ViewHeader} from '#/view/com/util/ViewHeader'
 import {CenteredView} from '#/view/com/util/Views'
-import {ArrowOutOfBox_Stroke2_Corner0_Rounded} from '#/components/icons/ArrowOutOfBox'
+import {Button, ButtonIcon} from '#/components/Button'
+import {ArrowOutOfBox_Stroke2_Corner0_Rounded as Share} from '#/components/icons/ArrowOutOfBox'
 import * as Layout from '#/components/Layout'
 import {ListFooter, ListMaybePlaceholder} from '#/components/Lists'
 
@@ -111,27 +111,30 @@ export default function HashtagScreen({
   return (
     <Layout.Screen>
       <CenteredView sideBorders={true}>
-        <ViewHeader
-          showOnDesktop
-          title={headerTitle}
-          subtitle={author ? _(msg`From @${sanitizedAuthor}`) : undefined}
-          canGoBack
-          renderButton={
-            isNative
-              ? () => (
-                  <Pressable
-                    accessibilityRole="button"
-                    onPress={onShare}
-                    hitSlop={HITSLOP_10}>
-                    <ArrowOutOfBox_Stroke2_Corner0_Rounded
-                      size="lg"
-                      onPress={onShare}
-                    />
-                  </Pressable>
-                )
-              : undefined
-          }
-        />
+        <Layout.Header.Outer>
+          <Layout.Header.BackButton />
+          <Layout.Header.Content>
+            <Layout.Header.TitleText>{headerTitle}</Layout.Header.TitleText>
+            {author && (
+              <Layout.Header.SubtitleText>
+                {_(msg`From @${sanitizedAuthor}`)}
+              </Layout.Header.SubtitleText>
+            )}
+          </Layout.Header.Content>
+          <Layout.Header.Slot>
+            <Button
+              label={_(msg`Share`)}
+              size="small"
+              variant="ghost"
+              color="primary"
+              shape="round"
+              onPress={onShare}
+              hitSlop={HITSLOP_10}
+              style={[{right: -3}]}>
+              <ButtonIcon icon={Share} size="md" />
+            </Button>
+          </Layout.Header.Slot>
+        </Layout.Header.Outer>
       </CenteredView>
       <Pager
         onPageSelected={onPageSelected}


### PR DESCRIPTION
Simple one. Only changes:
- back button exists on desktop now too
- share button exists on desktop now too (just copies to clipboard)

![CleanShot 2024-12-03 at 13 11 22@2x](https://github.com/user-attachments/assets/ce488b93-4d45-4a71-a132-f536488ecfb7)
![CleanShot 2024-12-03 at 13 11 27@2x](https://github.com/user-attachments/assets/0bfee115-0fb3-4625-b531-52f95af68d12)
![CleanShot 2024-12-03 at 13 11 07@2x](https://github.com/user-attachments/assets/f7455708-f322-41e0-a566-f206fe6c33c5)
![CleanShot 2024-12-03 at 13 11 03@2x](https://github.com/user-attachments/assets/1eaf0a7f-f396-4ab7-a9b8-cca7f82e27c2)
![Screenshot_20241203-131039](https://github.com/user-attachments/assets/41c55bd8-5cad-4690-baf3-8ca338f46fd8)
![Screenshot_20241203-131048](https://github.com/user-attachments/assets/290ae790-532f-4097-8750-a5aea62eeff8)
