### PR TITLE
Bug: UI: Fix overlapping issue with Load Latest button

### DIFF
--- a/src/view/com/util/load-latest/LoadLatestBtn.tsx
+++ b/src/view/com/util/load-latest/LoadLatestBtn.tsx
@@ -13,6 +13,10 @@ import {colors} from '#/lib/styles'
 import {isWeb} from '#/platform/detection'
 import {useSession} from '#/state/session'
 
+// Breakpoints for responsive design
+const BREAKPOINT_HEIGHT = 700 // Minimum height for "tall" viewport
+const BREAKPOINT_WIDTH = 940 // Maximum width for "narrow" viewport
+
 const AnimatedTouchableOpacity =
   Animated.createAnimatedComponent(TouchableOpacity)
 
@@ -31,8 +35,9 @@ export function LoadLatestBtn({
   const fabMinimalShellTransform = useMinimalShellFabTransform()
   const insets = useSafeAreaInsets()
 
-  // move button inline if it starts overlapping the left nav
-  const isTallViewport = useMediaQuery({minHeight: 700})
+  // Move button inline if it starts overlapping the left nav
+  const isTallViewport = useMediaQuery({minHeight: BREAKPOINT_HEIGHT})
+  const isNarrowViewport = useMediaQuery({maxWidth: BREAKPOINT_WIDTH})
 
   // Adjust height of the fab if we have a session only on mobile web. If we don't have a session, we want to adjust
   // it on both tablet and mobile since we are showing the bottom bar (see createNativeStackNavigatorWithAuth)
@@ -50,7 +55,10 @@ export function LoadLatestBtn({
           (isTallViewport
             ? styles.loadLatestOutOfLine
             : styles.loadLatestInline),
-        isTablet && styles.loadLatestInline,
+        isTablet &&
+          (isNarrowViewport
+            ? styles.loadLatestInline
+            : styles.loadLatestOutOfLine),
         pal.borderDark,
         pal.view,
         bottomPosition,


### PR DESCRIPTION
**Bug Description:**
Refine alignment logic for the "Load Latest" button to ensure it doesn't overlap content. The previous logic caused the button to obscure important UI elements on smaller viewports (940px - 1300px).

**Steps to Reproduce:**
1. Go to the home page.
2. Resize the screen to a width of 1200px.
3. Scroll down.
4. Notice that the button is not aligned with the left edge of the main container.

**Demo:** https://jam.dev/c/db47948c-3a58-4b0c-bdfb-b864cce9a200

**Related Issues**
https://github.com/bluesky-social/social-app/issues/6902

Environment:
Browser 131.0.6778.86 (Official Build) (arm64)
Operating System macOS 12.0.1