### PR TITLE
further increase target area of scrubber

### DIFF
--- a/src/view/com/util/post-embeds/VideoEmbedInner/web-controls/Scrubber.tsx
+++ b/src/view/com/util/post-embeds/VideoEmbedInner/web-controls/Scrubber.tsx
@@ -148,7 +148,7 @@ export function Scrubber({
   return (
     <View
       testID="scrubber"
-      style={[{height: 18, width: '100%'}, a.flex_shrink_0, a.px_xs]}
+      style={[{height: 32, width: '100%'}, a.flex_shrink_0, a.px_xs]}
       onPointerEnter={onStartHover}
       onPointerLeave={onEndHover}>
       <div


### PR DESCRIPTION
18px height -> 32px height.
[still](https://github.com/bluesky-social/social-app/pull/5265) too finicky on touchscreens for my fingers + [passes WCAG 2.2 AA](https://www.w3.org/WAI/WCAG22/quickref/?currentsidebar=%23col_overview&showtechniques=255#target-size-minimum) now 👍🏼