### PR TITLE
Adjust feed scroll bar top offset

### DIFF
--- a/src/view/com/util/List.tsx
+++ b/src/view/com/util/List.tsx
@@ -151,7 +151,7 @@ let List = React.forwardRef<ListMethods, ListProps>(
     return (
       <FlatList_INTERNAL
         {...props}
-        scrollIndicatorInsets={{right: 1}}
+        scrollIndicatorInsets={{top: headerOffset, right: 1}}
         contentOffset={contentOffset}
         refreshControl={refreshControl}
         onScroll={scrollHandler}


### PR DESCRIPTION
iOS only, add top offset to the feed scroll bar so the scroll bar won't cover by the tab bar

| Before | After |
|----|----|
| <video src='https://github.com/user-attachments/assets/ce7d4165-cbdc-4eb7-9d04-fb147383ae71' /> | <video src='https://github.com/user-attachments/assets/41fcb5f2-9d2d-4f5e-84a1-d55d3402950b' /> |







