### PR TITLE
[Layout] Asymmetric header on native

### DIFF
--- a/src/components/Layout/Header/index.tsx
+++ b/src/components/Layout/Header/index.tsx
@@ -9,6 +9,7 @@ import {isIOS} from '#/platform/detection'
 import {useSetDrawerOpen} from '#/state/shell'
 import {
   atoms as a,
+  platform,
   TextStyleProp,
   useBreakpoints,
   useGutterStyles,
@@ -38,7 +39,10 @@ export function Outer({children}: {children: React.ReactNode}) {
         a.align_center,
         a.gap_sm,
         gutter,
-        a.py_sm,
+        platform({
+          native: [a.pb_sm, a.pt_xs],
+          web: [a.py_sm],
+        }),
         t.atoms.border_contrast_low,
         gtMobile && [a.mx_auto, {maxWidth: 600}],
         !isWithinOffsetView && a.scrollbar_offset,


### PR DESCRIPTION
# Based on #6907 

Very slight adjustment on native due to the safe area already providing some visual padding

## Before

![Screenshot 2024-12-05 at 15 21 28](https://github.com/user-attachments/assets/9e6cadd9-e007-44f6-82a3-87e9e544ad87)

## After

![Screenshot 2024-12-05 at 15 21 08](https://github.com/user-attachments/assets/d4fae309-3eb8-4805-8d74-196869d03708)
