### PR TITLE
Fix handle input text being cut off on Windows

### DIFF
--- a/src/components/forms/TextField.tsx
+++ b/src/components/forms/TextField.tsx
@@ -203,7 +203,7 @@ export function createInput(Component: typeof TextInput) {
               // paddingVertical doesn't work w/multiline - esb
               paddingTop: 12,
               paddingBottom: 13,
-              lineHeight: a.text_md.fontSize * 1.1875,
+              lineHeight: a.text_md.fontSize * 1.3,
               textAlignVertical: rest.multiline ? 'top' : undefined,
               minHeight: rest.multiline ? 80 : undefined,
               minWidth: 0,


### PR DESCRIPTION
Fixes #6949 

1. Summary
This issue is caused by `lineHeight` prop and occurs only on Windows operating system. It seems the multiplier used for `lineHeight` is too small (1.1875 currently)

2. Solution
Increased the `lineHeight` multiplier from `1.1875` to `1.3`. `1.3` is a totally arbitrary number I came up with but it can be adjusted as necessary. It seems 1.2 - 1.5 is the recommended range.

3. Screenshots
    Windows
![image_2024_12_05T20_24_16_355Z](https://github.com/user-attachments/assets/47fc3cf2-7afd-4c78-9c45-7f721f234780)

    MacOS
![CleanShot 2024-12-05 at 15 24 25](https://github.com/user-attachments/assets/4d3f8af8-4a87-4717-acdf-f082a76a6c76)
