### PR TITLE
Immediately parse pre-filled links in composer state

### DIFF
--- a/src/view/com/composer/text-input/TextInput.tsx
+++ b/src/view/com/composer/text-input/TextInput.tsx
@@ -257,6 +257,10 @@ export const TextInput = forwardRef(function TextInputImpl(
             minHeight: 60,
             includeFontPadding: false,
           },
+          {
+            borderWidth: 1,
+            borderColor: 'transparent',
+          },
         ]}
         {...props}>
         {textDecorated}

--- a/src/view/com/composer/text-input/text-input-util.ts
+++ b/src/view/com/composer/text-input/text-input-util.ts
@@ -6,7 +6,7 @@ export type LinkFacetMatch = {
 }
 
 export function suggestLinkCardUri(
-  mayBePaste: boolean,
+  suggestLinkImmediately: boolean,
   nextDetectedUris: Map<string, LinkFacetMatch>,
   prevDetectedUris: Map<string, LinkFacetMatch>,
   pastSuggestedUris: Set<string>,
@@ -20,8 +20,8 @@ export function suggestLinkCardUri(
       // Don't suggest already added or already dismissed link cards.
       continue
     }
-    if (mayBePaste) {
-      // Immediately add the pasted link without waiting to type more.
+    if (suggestLinkImmediately) {
+      // Immediately add the pasted or intent-prefilled link without waiting to type more.
       suggestedUris.add(uri)
       continue
     }


### PR DESCRIPTION
Some news publications have reached out and notified us that link cards don't automatically show up when opening the composer via an `/intent` link. This PR does the link parsing on composer state creation, and pre-fills any links that might exists so that the card can be rendered.

Tested on web and iOS with no issues. On Android, the post link doesn't resize the `PasteInput` correctly, discussing in Slack.

### Web test links

URL
```
localhost:19006/intent/compose?text=Canned%20Cocktails%20in%20Quarantine%20Make%20Mixing%20a%20One-Step%20Process%20%0D%20%0A%20%0D%0A%20https%3A%2F%2Fwww.nytimes.com%2F2020%2F05%2F14%2Fdining%2Fdrinks%2Fcanned-cocktails-coronavirus.html%3Fsmid%3Dbs-share
```
Post
```
localhost:19006/intent/compose?text=Hello%20world%20https%3A%2F%2Fbsky.app%2Fprofile%2Fesb.lol%2Fpost%2F3l5arskdmkh2u
```

### Native test links

URL
```
https://bsky.app/intent/compose?text=Canned%20Cocktails%20in%20Quarantine%20Make%20Mixing%20a%20One-Step%20Process%20%0D%20%0A%20%0D%0A%20https%3A%2F%2Fwww.nytimes.com%2F2020%2F05%2F14%2Fdining%2Fdrinks%2Fcanned-cocktails-coronavirus.html%3Fsmid%3Dbs-share
```
Post
```
https://bsky.app/intent/compose?text=Hello%20world%20https%3A%2F%2Fbsky.app%2Fprofile%2Fesb.lol%2Fpost%2F3l5arskdmkh2u
```

