### PR TITLE
Trim back prefs exposure in NUXs, make naming more friendly

### DIFF
--- a/src/components/dialogs/nuxs/index.tsx
+++ b/src/components/dialogs/nuxs/index.tsx
@@ -3,12 +3,7 @@ import {AppBskyActorDefs} from '@atproto/api'
 
 import {useGate} from '#/lib/statsig/statsig'
 import {logger} from '#/logger'
-import {
-  Nux,
-  useNuxs,
-  useRemoveNuxsMutation,
-  useUpsertNuxMutation,
-} from '#/state/queries/nuxs'
+import {Nux, useNuxs, useResetNuxs, useSaveNux} from '#/state/queries/nuxs'
 import {
   usePreferencesQuery,
   UsePreferencesQueryResponse,
@@ -85,8 +80,8 @@ function Inner({
     return isSnoozed()
   })
   const [activeNux, setActiveNux] = React.useState<Nux | undefined>()
-  const {mutateAsync: upsertNux} = useUpsertNuxMutation()
-  const {mutate: removeNuxs} = useRemoveNuxsMutation()
+  const {mutateAsync: saveNux} = useSaveNux()
+  const {mutate: resetNuxs} = useResetNuxs()
 
   const snoozeNuxDialog = React.useCallback(() => {
     snooze()
@@ -102,7 +97,7 @@ function Inner({
     // @ts-ignore
     window.clearNuxDialog = (id: Nux) => {
       if (!IS_DEV || !id) return
-      removeNuxs([id])
+      resetNuxs([id])
       unsnooze()
     }
   }
@@ -136,7 +131,7 @@ function Inner({
       snoozeNuxDialog()
 
       // immediately update remote data (affects next reload)
-      upsertNux({
+      saveNux({
         id,
         completed: true,
         data: undefined,
@@ -152,7 +147,7 @@ function Inner({
     nuxs,
     snoozed,
     snoozeNuxDialog,
-    upsertNux,
+    saveNux,
     gate,
     currentAccount,
     currentProfile,

--- a/src/state/queries/nuxs/index.ts
+++ b/src/state/queries/nuxs/index.ts
@@ -10,49 +10,78 @@ import {useAgent} from '#/state/session'
 
 export {Nux} from '#/state/queries/nuxs/definitions'
 
-export function useNuxs() {
-  const {data, ...rest} = usePreferencesQuery()
+export function useNuxs():
+  | {
+      nuxs: AppNux[]
+      status: 'ready'
+    }
+  | {
+      nuxs: undefined
+      status: 'loading' | 'error'
+    } {
+  const {data, isSuccess, isError} = usePreferencesQuery()
+  const status = isSuccess ? 'ready' : isError ? 'error' : 'loading'
 
-  if (data && rest.isSuccess) {
-    const nuxs = data.bskyAppState.nuxs
+  if (status === 'ready') {
+    const nuxs = data?.bskyAppState?.nuxs
       ?.map(parseAppNux)
       ?.filter(Boolean) as AppNux[]
 
     if (nuxs) {
       return {
         nuxs,
-        ...rest,
+        status,
+      }
+    } else {
+      return {
+        nuxs: [],
+        status,
       }
     }
   }
 
   return {
     nuxs: undefined,
-    ...rest,
+    status,
   }
 }
 
-export function useNux<T extends Nux>(id: T) {
-  const {nuxs, ...rest} = useNuxs()
+export function useNux<T extends Nux>(
+  id: T,
+):
+  | {
+      nux: Extract<AppNux, {id: T}> | undefined
+      status: 'ready'
+    }
+  | {
+      nux: undefined
+      status: 'loading' | 'error'
+    } {
+  const {nuxs, status} = useNuxs()
 
-  if (nuxs && rest.isSuccess) {
+  if (status === 'ready') {
     const nux = nuxs.find(nux => nux.id === id)
 
     if (nux) {
       return {
         nux: nux as Extract<AppNux, {id: T}>,
-        ...rest,
+        status,
+      }
+    } else {
+      return {
+        nux: undefined,
+        status,
       }
     }
   }
 
   return {
     nux: undefined,
-    ...rest,
+    status,
   }
 }
 
-export function useUpsertNuxMutation() {
+export function useSaveNux() {
   const queryClient = useQueryClient()
   const agent = useAgent()
 
@@ -68,7 +97,7 @@ export function useUpsertNuxMutation() {
   })
 }
 
-export function useRemoveNuxsMutation() {
+export function useResetNuxs() {
   const queryClient = useQueryClient()
   const agent = useAgent()
 


### PR DESCRIPTION
No NUXs are in use atm, so this doesn't affect anything, but when implementing some new ones, I realized we were passing around all of the user's preferences state uneccessarily. Plus, "reset" and "save" are more easily understandable terms for the end-user contract. The API methods use more technical terms, but these work better here.