### PR TITLE
Fix squashed content on mod screens

### DIFF
--- a/src/view/screens/Feeds.tsx
+++ b/src/view/screens/Feeds.tsx
@@ -487,6 +487,7 @@ export function FeedsScreen(_props: Props) {
       return null
     },
     [
+      _,
       pal.border,
       pal.textLight,
       query,

--- a/src/view/screens/ModerationBlockedAccounts.tsx
+++ b/src/view/screens/ModerationBlockedAccounts.tsx
@@ -23,6 +23,7 @@ import {ProfileCard} from '#/view/com/profile/ProfileCard'
 import {ErrorScreen} from '#/view/com/util/error/ErrorScreen'
 import {Text} from '#/view/com/util/text/Text'
 import {ViewHeader} from '#/view/com/util/ViewHeader'
+import {atoms as a} from '#/alf'
 import * as Layout from '#/components/Layout'
 
 type Props = NativeStackScreenProps<
@@ -96,7 +97,7 @@ export function ModerationBlockedAccounts({}: Props) {
   )
   return (
     <Layout.Screen testID="blockedAccountsScreen">
-      <Layout.Center>
+      <Layout.Center style={[a.flex_1, {paddingBottom: 100}]}>
         <ViewHeader title={_(msg`Blocked Accounts`)} showOnDesktop />
         <Text
           type="sm"

--- a/src/view/screens/ModerationMutedAccounts.tsx
+++ b/src/view/screens/ModerationMutedAccounts.tsx
@@ -23,6 +23,7 @@ import {ProfileCard} from '#/view/com/profile/ProfileCard'
 import {ErrorScreen} from '#/view/com/util/error/ErrorScreen'
 import {Text} from '#/view/com/util/text/Text'
 import {ViewHeader} from '#/view/com/util/ViewHeader'
+import {atoms as a} from '#/alf'
 import * as Layout from '#/components/Layout'
 
 type Props = NativeStackScreenProps<
@@ -97,7 +98,7 @@ export function ModerationMutedAccounts({}: Props) {
   return (
     <Layout.Screen testID="mutedAccountsScreen">
       <ViewHeader title={_(msg`Muted Accounts`)} showOnDesktop />
-      <Layout.Center>
+      <Layout.Center style={[a.flex_1, {paddingBottom: 100}]}>
         <Text
           type="sm"
           style={[


### PR DESCRIPTION
These were load-bearing `flex: 1`. Added back old padding for good measure.

Both these screens and the `Lists` screen use RN's `FlatList` directly, which we should probably swap for our wrapped `List`. All three screens have flex styles to grow to fill screen.

Test: on mobile and web