### PR TITLE
Fix 404 error handling for Web

### DIFF
--- a/bskyweb/templates/error.html
+++ b/bskyweb/templates/error.html
@@ -12,14 +12,14 @@
 {# don't include the bundle on non-404 error pages #}
 {% block head_bundle %}
   {% if statusCode == 404 %}
-    {{ super() }}
+    {{ block.Super }}
   {% else %}
   {% endif %}
 {% endblock %}
 
 {%- block body_all %}
   {% if statusCode == 404 %}
-    {{ super() }}
+    {{ block.Super }}
   {% else %}
     <h1>{{ statusCode }}: Server Error</h1>
     <p>Sorry about that! Our <a href="https://bluesky.statuspage.io/">Status Page</a> might have more context.


### PR DESCRIPTION
Fixes #6989: in Go-Server templates/error.html `super()` used instead of pongo2 `block.Super`.

It's the only place in Go-Server where `super()` is used and it's limited to 404 error handling only.

### Recording of behavior after this change

https://github.com/user-attachments/assets/d7c7a605-d1aa-4053-a5da-69c3fabfdc86

### Redirect to homepage

As you can see from the video above there is a redirect from 404 to homepage happening automatically. It happens in `@react-navigation/native/src/useLinking.tsx` in a useEffect this code is executed: `history.replace({ path, state });`