### PR TITLE
Limit feed prefetching to native

### DIFF
--- a/src/view/com/feeds/FeedPage.tsx
+++ b/src/view/com/feeds/FeedPage.tsx
@@ -107,13 +107,14 @@ export function FeedPage({
     })
   }, [scrollToTop, feed, queryClient, setHasNew])
 
+  const shouldPrefetch = isNative && isPageAdjacent
   return (
     <View testID={testID}>
       <MainScrollProvider>
         <FeedFeedbackProvider value={feedFeedback}>
           <Feed
             testID={testID ? `${testID}-feed` : undefined}
-            enabled={isPageFocused || isPageAdjacent}
+            enabled={isPageFocused || shouldPrefetch}
             feed={feed}
             feedParams={feedParams}
             pollInterval={POLL_FREQ}


### PR DESCRIPTION
Adjust https://github.com/bluesky-social/social-app/pull/6904 to only do this for native. On web it causes too many requests that aren't being used due to opening in new tab.

## Test Plan

On web, there's a noticeable loading state when switching Following -> Discover. Which confirms the change.

On native, the switch feels instant like before.