### PR TITLE
Fix composer shortcut detaching a reply

### DIFF
--- a/src/state/shell/composer/index.tsx
+++ b/src/state/shell/composer/index.tsx
@@ -83,7 +83,13 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
         'exclamation-circle',
       )
     } else {
-      setState(opts)
+      setState(prevOpts => {
+        if (prevOpts) {
+          // Never replace an already open composer.
+          return prevOpts
+        }
+        return opts
+      })
     }
   })
 


### PR DESCRIPTION
Fixes https://github.com/bluesky-social/social-app/issues/6951

1. Start typing a reply
2. Focus outside the text field
3. Press N

Before, it would detach the reply.

After the fix, it doesn't.

The fix itself is a bit more generic — basically, never auto-dismiss a reply in progress without a manual user action. This might apply to other cases (intents?) but I think the principle still holds. Dismiss the composer manually first, then something new can appear in there. If some piece of code wants to intentionally close the composer, it can call `closeComposer`.

## Before

https://github.com/user-attachments/assets/5f65d75a-56b7-4945-b92e-63f2e84c19a2

## After

https://github.com/user-attachments/assets/66d76769-2232-4d9d-af1c-63fc9e9cecd3

