### PR TITLE
Fix iOS build

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -14,6 +14,8 @@ if (process.env.BSKY_PROFILE) {
   cfg.cacheVersion += ':PROFILE'
 }
 
+cfg.resolver.assetExts = [...cfg.resolver.assetExts, 'woff2']
+
 cfg.resolver.resolveRequest = (context, moduleName, platform) => {
   // HACK: manually resolve a few packages that use `exports` in `package.json`.
   // A proper solution is to enable `unstable_enablePackageExports` but this needs careful testing.


### PR DESCRIPTION
It got borked by #6993. I thought the change was web-only but it wasn't.

Using the fix from https://github.com/expo/expo/issues/4626#issuecomment-506563568. Seems to work.

iOS and Android build fine. Web not affected by this change.

## Before

<img width="393" alt="Screenshot 2024-12-10 at 22 04 57" src="https://github.com/user-attachments/assets/e5a47c0e-7abc-44b2-83ca-40d0e91a869e">

## After

<img width="554" alt="Screenshot 2024-12-10 at 22 09 13" src="https://github.com/user-attachments/assets/5a8e87e1-8302-43ea-97de-e98d7416dd8c">
