### PR TITLE
Reduce excessive empty space on profile with no bio

### DIFF
--- a/src/screens/Profile/Header/Metrics.tsx
+++ b/src/screens/Profile/Header/Metrics.tsx
@@ -30,7 +30,7 @@ export function ProfileHeaderMetrics({
 
   return (
     <View
-      style={[a.flex_row, a.gap_sm, a.align_center, a.pb_md]}
+      style={[a.flex_row, a.gap_sm, a.align_center]}
       pointerEvents="box-none">
       <InlineLinkText
         testID="profileHeaderFollowersButton"

--- a/src/screens/Profile/Header/ProfileHeaderStandard.tsx
+++ b/src/screens/Profile/Header/ProfileHeaderStandard.tsx
@@ -244,7 +244,7 @@ let ProfileHeaderStandard = ({
           <ProfileHeaderHandle profile={profile} />
         </View>
         {!isPlaceholderProfile && !isBlockedUser && (
-          <>
+          <View style={a.gap_md}>
             <ProfileHeaderMetrics profile={profile} />
             {descriptionRT && !moderation.ui('profileView').blur ? (
               <View pointerEvents="auto">
@@ -262,14 +262,14 @@ let ProfileHeaderStandard = ({
             {!isMe &&
               !isBlockedUser &&
               shouldShowKnownFollowers(profile.viewer?.knownFollowers) && (
-                <View style={[a.flex_row, a.align_center, a.gap_sm, a.pt_md]}>
+                <View style={[a.flex_row, a.align_center, a.gap_sm]}>
                   <KnownFollowers
                     profile={profile}
                     moderationOpts={moderationOpts}
                   />
                 </View>
               )}
-          </>
+          </View>
         )}
       </View>
       <Prompt.Basic


### PR DESCRIPTION
We had a structure like this:

- Parent view with `paddingBottom`
  - Metrics with `paddingBottom`
  - Conditional bio with no padding
  - Conditional social proof with `paddingTop`
 - Tabs 

As a result, when something conditional is missing, the padding were getting combined in an awkward way. For example:

- No bio or social proof: The metrics' `paddingBottom` was getting combined with the parent view's `paddingBottom`, resulting in double padding
- No bio, but has social proof: The metrics' `paddingBottom` was getting combined with the social proof's `paddingTop`, resulting in double padding

The fix is to treat these as three items with a gap, and to remove those paddings.

## Test Plan

Check that these cases now work well:

- No bio, no social proof (this used to be too spacey)
- No bio but has social proof (this used to be too spacey)

Check that if there _is_ a bio, layout hasn't changed.

## Before

<img width="554" alt="Screenshot 2024-12-11 at 20 14 09" src="https://github.com/user-attachments/assets/ab24070e-ca26-4905-9695-faccc9dcb1ed" />

## After

<img width="554" alt="Screenshot 2024-12-11 at 20 14 03" src="https://github.com/user-attachments/assets/9c74e449-0482-40b8-90d2-5952a9f0d94e" />
