### PR TITLE
Point "Continue thread" at last shown post

### DIFF
--- a/src/view/com/post-thread/PostThread.tsx
+++ b/src/view/com/post-thread/PostThread.tsx
@@ -421,9 +421,6 @@ export function PostThread({uri}: {uri: string | undefined}) {
         </View>
       )
     } else if (isThreadPost(item)) {
-      if (!treeView && item.ctx.hasMoreSelfThread) {
-        return <PostThreadLoadMore post={item.post} />
-      }
       const prev = isThreadPost(posts[index - 1])
         ? (posts[index - 1] as ThreadPost)
         : undefined
@@ -435,6 +432,10 @@ export function PostThread({uri}: {uri: string | undefined}) {
         (item.ctx.depth < 0 && !!item.parent) || item.ctx.depth > 1
       const hasUnrevealedParents =
         index === 0 && skeleton?.parents && maxParents < skeleton.parents.length
+
+      if (!treeView && prev && item.ctx.hasMoreSelfThread) {
+        return <PostThreadLoadMore post={prev.post} />
+      }
 
       return (
         <View


### PR DESCRIPTION
The way "Continue thread" works today is confusing even if technically correct. Currently, if we detect a thread, we'll replace the last known self-item in the thread with a link that points to the next post. The problem is that this jump loses context. When the link loads, it shows a post *you've never seen before*. What I believe we should do instead is to point you *at the last post you've seen* so you can scroll down from it without loss of continuity.

## Before

You jump from post 9 directly to post 10:

https://github.com/user-attachments/assets/3b165431-ca6c-4537-9c52-9784b6ab8581

If you thought about something for a moment or the link took a while to load, you'll be disoriented because no context is being explicitly carried forward in the transition. You're looking at a completely different post.

## After

The link points at the last post you've seen. Then you start scrolling down and see the rest of the thread.

https://github.com/user-attachments/assets/b0391509-44d1-436c-b7d9-f6f4f77d59a0
