### PR TITLE
Fix singular words in translated strings

### DIFF
--- a/src/screens/Post/PostRepostedBy.tsx
+++ b/src/screens/Post/PostRepostedBy.tsx
@@ -40,7 +40,7 @@ export const PostRepostedByScreen = ({route}: Props) => {
               <Layout.Header.SubtitleText>
                 <Plural
                   value={quoteCount ?? 0}
-                  one="# reposts"
+                  one="# repost"
                   other="# reposts"
                 />
               </Layout.Header.SubtitleText>


### PR DESCRIPTION
Maybe it's a typo, but `repost` should be the correct singular word, not `reposts`.