### PR TITLE
Refine plural marks

### DIFF
--- a/src/components/FeedCard.tsx
+++ b/src/components/FeedCard.tsx
@@ -7,7 +7,7 @@ import {
   AtUri,
   RichText as RichTextApi,
 } from '@atproto/api'
-import {msg, plural, Trans} from '@lingui/macro'
+import {msg, Plural, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 import {useQueryClient} from '@tanstack/react-query'
 
@@ -210,10 +210,9 @@ export function Likes({count}: {count: number}) {
   const t = useTheme()
   return (
     <Text style={[a.text_sm, t.atoms.text_contrast_medium]}>
-      {plural(count || 0, {
-        one: 'Liked by # user',
-        other: 'Liked by # users',
-      })}
+      <Trans>
+        Liked by <Plural value={count || 0} one="# user" other="# users" />
+      </Trans>
     </Text>
   )
 }

--- a/src/components/LabelingServiceCard/index.tsx
+++ b/src/components/LabelingServiceCard/index.tsx
@@ -83,7 +83,7 @@ export function RegionalNotice() {
   )
 }
 
-export function LikeCount({count}: {count: number}) {
+export function LikeCount({likeCount}: {likeCount: number}) {
   const t = useTheme()
   return (
     <Text
@@ -93,7 +93,9 @@ export function LikeCount({count}: {count: number}) {
         t.atoms.text_contrast_medium,
         {fontWeight: '600'},
       ]}>
-      <Plural value={count} one="Liked by # user" other="Liked by # users" />
+      <Trans>
+        Liked by <Plural value={likeCount} one="# user" other="# users" />
+      </Trans>
     </Text>
   )
 }
@@ -138,7 +140,7 @@ export function Default({
           value={labeler.creator.description}
           handle={labeler.creator.handle}
         />
-        {labeler.likeCount ? <LikeCount count={labeler.likeCount} /> : null}
+        {labeler.likeCount ? <LikeCount likeCount={labeler.likeCount} /> : null}
       </Content>
     </Outer>
   )

--- a/src/components/moderation/LabelsOnMe.tsx
+++ b/src/components/moderation/LabelsOnMe.tsx
@@ -1,6 +1,6 @@
 import {StyleProp, View, ViewStyle} from 'react-native'
 import {AppBskyFeedDefs, ComAtprotoLabelDefs} from '@atproto/api'
-import {msg, Plural} from '@lingui/macro'
+import {msg, Plural, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
 import {useSession} from '#/state/session'
@@ -50,17 +50,23 @@ export function LabelsOnMe({
         <ButtonIcon position="left" icon={CircleInfo} />
         <ButtonText style={[a.leading_snug]}>
           {type === 'account' ? (
-            <Plural
-              value={labels.length}
-              one="# label has been placed on this account"
-              other="# labels have been placed on this account"
-            />
+            <Trans>
+              <Plural
+                value={labels.length}
+                one="# label has"
+                other="# labels have"
+              />{' '}
+              been placed on this account
+            </Trans>
           ) : (
-            <Plural
-              value={labels.length}
-              one="# label has been placed on this content"
-              other="# labels have been placed on this content"
-            />
+            <Trans>
+              <Plural
+                value={labels.length}
+                one="# label has"
+                other="# labels have"
+              />{' '}
+              been placed on this content
+            </Trans>
           )}
         </ButtonText>
       </Button>

--- a/src/screens/Profile/Header/ProfileHeaderLabeler.tsx
+++ b/src/screens/Profile/Header/ProfileHeaderLabeler.tsx
@@ -291,10 +291,12 @@ let ProfileHeaderLabeler = ({
                       },
                     }}
                     size="tiny"
-                    label={plural(likeCount, {
-                      one: 'Liked by # user',
-                      other: 'Liked by # users',
-                    })}>
+                    label={_(
+                      msg`Liked by ${plural(likeCount, {
+                        one: '# user',
+                        other: '# users',
+                      })}`,
+                    )}>
                     {({hovered, focused, pressed}) => (
                       <Text
                         style={[
@@ -304,11 +306,14 @@ let ProfileHeaderLabeler = ({
                           (hovered || focused || pressed) &&
                             t.atoms.text_contrast_high,
                         ]}>
-                        <Plural
-                          value={likeCount}
-                          one="Liked by # user"
-                          other="Liked by # users"
-                        />
+                        <Trans>
+                          Liked by{' '}
+                          <Plural
+                            value={likeCount}
+                            one="# user"
+                            other="# users"
+                          />
+                        </Trans>
                       </Text>
                     )}
                   </Link>

--- a/src/view/com/feeds/FeedSourceCard.tsx
+++ b/src/view/com/feeds/FeedSourceCard.tsx
@@ -300,11 +300,14 @@ export function FeedSourceCardLoaded({
 
         {showLikes && feed.type === 'feed' ? (
           <Text type="sm-medium" style={[pal.text, pal.textLight]}>
-            <Plural
-              value={feed.likeCount || 0}
-              one="Liked by # user"
-              other="Liked by # users"
-            />
+            <Trans>
+              Liked by{' '}
+              <Plural
+                value={feed.likeCount || 0}
+                one="# user"
+                other="# users"
+              />
+            </Trans>
           </Text>
         ) : null}
       </Pressable>

--- a/src/view/com/util/post-ctrls/PostCtrls.tsx
+++ b/src/view/com/util/post-ctrls/PostCtrls.tsx
@@ -258,10 +258,12 @@ let PostCtrls = ({
             }
           }}
           accessibilityRole="button"
-          accessibilityLabel={plural(post.replyCount || 0, {
-            one: 'Reply (# reply)',
-            other: 'Reply (# replies)',
-          })}
+          accessibilityLabel={_(
+            msg`Reply (${plural(post.replyCount || 0, {
+              one: '# reply',
+              other: '# replies',
+            })})`,
+          )}
           accessibilityHint=""
           hitSlop={POST_CTRL_HITSLOP}>
           <Bubble
@@ -298,14 +300,18 @@ let PostCtrls = ({
           accessibilityRole="button"
           accessibilityLabel={
             post.viewer?.like
-              ? plural(post.likeCount || 0, {
-                  one: 'Unlike (# like)',
-                  other: 'Unlike (# likes)',
-                })
-              : plural(post.likeCount || 0, {
-                  one: 'Like (# like)',
-                  other: 'Like (# likes)',
-                })
+              ? _(
+                  msg`Unlike (${plural(post.likeCount || 0, {
+                    one: '# like',
+                    other: '# likes',
+                  })})`,
+                )
+              : _(
+                  msg`Like (${plural(post.likeCount || 0, {
+                    one: '# like',
+                    other: '# likes',
+                  })})`,
+                )
           }
           accessibilityHint=""
           hitSlop={POST_CTRL_HITSLOP}>

--- a/src/view/com/util/post-ctrls/RepostButton.tsx
+++ b/src/view/com/util/post-ctrls/RepostButton.tsx
@@ -62,11 +62,21 @@ let RepostButton = ({
           {padding: 5},
         ]}
         hoverStyle={t.atoms.bg_contrast_25}
-        label={`${
+        label={
           isReposted
-            ? _(msg`Undo repost`)
-            : _(msg({message: 'Repost', context: 'action'}))
-        } (${plural(repostCount || 0, {one: '# repost', other: '# reposts'})})`}
+            ? _(
+                msg`Undo repost (${plural(repostCount || 0, {
+                  one: '# repost',
+                  other: '# reposts',
+                })})`,
+              )
+            : _(
+                msg`Repost (${plural(repostCount || 0, {
+                  one: '# repost',
+                  other: '# reposts',
+                })})`,
+              )
+        }
         shape="round"
         variant="ghost"
         color="secondary"

--- a/src/view/screens/ProfileFeed.tsx
+++ b/src/view/screens/ProfileFeed.tsx
@@ -587,11 +587,9 @@ function AboutSection({
             label={_(msg`View users who like this feed`)}
             to={makeCustomFeedLink(feedOwnerDid, feedRkey, 'liked-by')}
             style={[t.atoms.text_contrast_medium, a.font_bold]}>
-            <Plural
-              value={likeCount}
-              one="Liked by # user"
-              other="Liked by # users"
-            />
+            <Trans>
+              Liked by <Plural value={likeCount} one="# user" other="# users" />
+            </Trans>
           </InlineLinkText>
         )}
       </View>


### PR DESCRIPTION
* Refines plural marks to reduce the length of strings used for translation.
  * Translations are still free to rearrange words.
  * `NotificationFeedItem.tsx`, `src/screens/StarterPack/Wizard/index.tsx`, etc. are already written this way.
* In `src/components/LabelingServiceCard/index.tsx`, replaces `count` with `likeCount` to consolidate the translation string.
* In `src/view/com/util/post-ctrls/RepostButton.tsx`, provides the full string to the translation so it can be contextualized.