### PR TITLE
Make the pager take full width

### DIFF
--- a/src/screens/Hashtag.tsx
+++ b/src/screens/Hashtag.tsx
@@ -107,7 +107,7 @@ export default function HashtagScreen({
 
   return (
     <Layout.Screen>
-      <Layout.Header.Outer>
+      <Layout.Header.Outer noBottomBorder>
         <Layout.Header.BackButton />
         <Layout.Header.Content>
           <Layout.Header.TitleText>{headerTitle}</Layout.Header.TitleText>

--- a/src/view/com/pager/TabBar.tsx
+++ b/src/view/com/pager/TabBar.tsx
@@ -287,7 +287,7 @@ export function TabBar({
           onLayout={e => {
             contentSize.set(e.nativeEvent.layout.width)
           }}
-          style={{flexDirection: 'row'}}>
+          style={{flexDirection: 'row', flexGrow: 1}}>
           {items.map((item, i) => {
             return (
               <TabBarItem
@@ -359,7 +359,7 @@ function TabBarItem({
   )
 
   return (
-    <View onLayout={handleLayout}>
+    <View onLayout={handleLayout} style={{flexGrow: 1}}>
       <PressableWithHover
         testID={`${testID}-selector-${index}`}
         style={styles.item}
@@ -381,15 +381,19 @@ function TabBarItem({
 
 const styles = StyleSheet.create({
   contentContainer: {
+    flexGrow: 1,
     backgroundColor: 'transparent',
     paddingHorizontal: CONTENT_PADDING,
   },
   item: {
+    flexGrow: 1,
     paddingTop: 10,
     paddingHorizontal: ITEM_PADDING,
     justifyContent: 'center',
   },
   itemInner: {
+    alignItems: 'center',
+    flexGrow: 1,
     paddingBottom: 10,
     borderBottomWidth: 3,
     borderBottomColor: 'transparent',

--- a/src/view/com/pager/TabBar.tsx
+++ b/src/view/com/pager/TabBar.tsx
@@ -237,8 +237,15 @@ export function TabBar({
         opacity: 0,
       }
     }
-    if (layoutsValue.length === 1) {
-      return {opacity: 1}
+    if (textLayoutsValue.length === 1) {
+      return {
+        opacity: 1,
+        transform: [
+          {
+            scaleX: textLayoutsValue[0].width / contentSize.get(),
+          },
+        ],
+      }
     }
     return {
       opacity: 1,

--- a/src/view/com/pager/TabBar.tsx
+++ b/src/view/com/pager/TabBar.tsx
@@ -422,7 +422,7 @@ const styles = StyleSheet.create({
   },
   itemText: {
     lineHeight: 20,
-    minWidth: 60,
+    minWidth: 45,
     textAlign: 'center',
   },
   outerBottomBorder: {

--- a/src/view/com/pager/TabBar.web.tsx
+++ b/src/view/com/pager/TabBar.web.tsx
@@ -115,12 +115,14 @@ export function TabBar({
               hoverStyle={t.atoms.bg_contrast_25}
               onPress={() => onPressItem(i)}
               accessibilityRole="tab">
-              <View style={[styles.itemInner, selected && indicatorStyle]}>
+              <View style={styles.itemInner}>
                 <Text
                   emoji
                   testID={testID ? `${testID}-${item}` : undefined}
                   style={[
+                    styles.itemText,
                     selected ? t.atoms.text : t.atoms.text_contrast_medium,
+                    selected && indicatorStyle,
                     a.text_md,
                     a.font_bold,
                     {lineHeight: 20},
@@ -143,15 +145,23 @@ const desktopStyles = StyleSheet.create({
     width: 598,
   },
   contentContainer: {
+    flexGrow: 1,
     paddingHorizontal: 0,
     backgroundColor: 'transparent',
   },
   item: {
+    flexGrow: 1,
+    alignItems: 'stretch',
     paddingTop: 14,
     paddingHorizontal: 14,
     justifyContent: 'center',
   },
   itemInner: {
+    alignItems: 'center',
+  },
+  itemText: {
+    textAlign: 'center',
+    minWidth: 60,
     paddingBottom: 12,
     borderBottomWidth: 3,
     borderBottomColor: 'transparent',
@@ -170,15 +180,24 @@ const mobileStyles = StyleSheet.create({
     flexDirection: 'row',
   },
   contentContainer: {
+    flexGrow: 1,
     backgroundColor: 'transparent',
     paddingHorizontal: 6,
   },
   item: {
+    flexGrow: 1,
+    alignItems: 'stretch',
     paddingTop: 10,
     paddingHorizontal: 10,
     justifyContent: 'center',
   },
   itemInner: {
+    flexGrow: 1,
+    alignItems: 'center',
+  },
+  itemText: {
+    textAlign: 'center',
+    minWidth: 60,
     paddingBottom: 10,
     borderBottomWidth: 2,
     borderBottomColor: 'transparent',

--- a/src/view/com/pager/TabBar.web.tsx
+++ b/src/view/com/pager/TabBar.web.tsx
@@ -161,7 +161,7 @@ const desktopStyles = StyleSheet.create({
   },
   itemText: {
     textAlign: 'center',
-    minWidth: 60,
+    minWidth: 45,
     paddingBottom: 12,
     borderBottomWidth: 3,
     borderBottomColor: 'transparent',
@@ -197,7 +197,7 @@ const mobileStyles = StyleSheet.create({
   },
   itemText: {
     textAlign: 'center',
-    minWidth: 60,
+    minWidth: 45,
     paddingBottom: 10,
     borderBottomWidth: 2,
     borderBottomColor: 'transparent',


### PR DESCRIPTION
This changes the pager to always fill the entire screen width by spacing out the items. If there are _many_ items (more than a screen's worth), then they are placed like before.

Easier to understand from a demo:

https://github.com/user-attachments/assets/7c28141f-c2c1-4be0-9b61-61c48a24f5c8

## Test Plan

Try these on iOS, Android, and web.

- Check Home the new user experience (Discover, Following)
- Check Home for a user with a lot of feeds
- Check profile tabs (own and others')
- Check hashtag and search screens
- Try it on top of https://github.com/bluesky-social/social-app/pull/7044

Centered item looks a bit weird when there's a single tab but the only case of that is being solved by https://github.com/bluesky-social/social-app/pull/7056.