### PR TITLE
Make sure local web builds set debug environment flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,6 @@
 # Copy this to `.env` and `.env.test` files
 
 SENTRY_AUTH_TOKEN=
-EXPO_PUBLIC_ENV=development
 EXPO_PUBLIC_LOG_LEVEL=debug
 EXPO_PUBLIC_LOG_DEBUG=
 EXPO_PUBLIC_BUNDLE_IDENTIFIER=

--- a/src/lib/app-info.ts
+++ b/src/lib/app-info.ts
@@ -1,7 +1,7 @@
 import {nativeApplicationVersion, nativeBuildVersion} from 'expo-application'
 
 export const BUILD_ENV = process.env.EXPO_PUBLIC_ENV || 'development'
-export const IS_DEV = process.env.EXPO_PUBLIC_ENV !== 'production'
+export const IS_DEV = BUILD_ENV === 'development'
 export const IS_TESTFLIGHT = process.env.EXPO_PUBLIC_ENV === 'testflight'
 export const IS_INTERNAL = IS_DEV || IS_TESTFLIGHT
 

--- a/src/lib/app-info.ts
+++ b/src/lib/app-info.ts
@@ -1,7 +1,7 @@
 import {nativeApplicationVersion, nativeBuildVersion} from 'expo-application'
 
-export const BUILD_ENV = process.env.EXPO_PUBLIC_ENV
-export const IS_DEV = process.env.EXPO_PUBLIC_ENV === 'development'
+export const BUILD_ENV = process.env.EXPO_PUBLIC_ENV || 'development'
+export const IS_DEV = process.env.EXPO_PUBLIC_ENV !== 'production'
 export const IS_TESTFLIGHT = process.env.EXPO_PUBLIC_ENV === 'testflight'
 export const IS_INTERNAL = IS_DEV || IS_TESTFLIGHT
 

--- a/src/lib/app-info.web.ts
+++ b/src/lib/app-info.web.ts
@@ -1,7 +1,7 @@
 import {version} from '../../package.json'
 
-export const BUILD_ENV = process.env.EXPO_PUBLIC_ENV
-export const IS_DEV = process.env.EXPO_PUBLIC_ENV === 'development'
+export const BUILD_ENV = process.env.EXPO_PUBLIC_ENV || 'development'
+export const IS_DEV = process.env.EXPO_PUBLIC_ENV !== 'production'
 export const IS_TESTFLIGHT = false
 export const IS_INTERNAL = IS_DEV
 

--- a/src/lib/app-info.web.ts
+++ b/src/lib/app-info.web.ts
@@ -1,7 +1,7 @@
 import {version} from '../../package.json'
 
 export const BUILD_ENV = process.env.EXPO_PUBLIC_ENV || 'development'
-export const IS_DEV = process.env.EXPO_PUBLIC_ENV !== 'production'
+export const IS_DEV = BUILD_ENV === 'development'
 export const IS_TESTFLIGHT = false
 export const IS_INTERNAL = IS_DEV
 


### PR DESCRIPTION
We shouldn't be relying on a developer copying the `.env.example` file into `.env` — so far we haven't needed that. The defaults just need to be correct.

Previously, if your `EXPO_PUBLIC_ENV` isn't explicitly set to `development`, you got a weird setup where `IS_DEV` is `false` in dev environment. With this change, if `EXPO_PUBLIC_ENV` isn't set, it's _assumed_ to be dev environment.

## Test Plan

Read the code. Verify that deleting `.env` still recognizes web localhost as being a dev environment. We're assuming that all production build systems already always set `EXPO_PUBLIC_ENV` since otherwise it wouldn't get set to `production` before either.