### PR TITLE
Add toki pona (tok) to content languages

### DIFF
--- a/src/locale/languages.ts
+++ b/src/locale/languages.ts
@@ -558,6 +558,7 @@ export const LANGUAGES: Language[] = [
   {code3: 'tli', code2: '', name: 'Tlingit'},
   {code3: 'tmh', code2: '', name: 'Tamashek'},
   {code3: 'tog', code2: '', name: 'Tonga (Nyasa)'},
+  {code3: 'tok', code2: '', name: 'toki pona'},
   {code3: 'ton', code2: 'to', name: 'Tonga (Tonga Islands)'},
   {code3: 'tpi', code2: '', name: 'Tok Pisin'},
   {code3: 'tsi', code2: '', name: 'Tsimshian'},


### PR DESCRIPTION
[**toki pona**](https://tokipona.org/) is a constructed language created by Sonja Lang in 2001. It is considered by some to have the second biggest conlang community online.

toki pona's ISO 639-3 code is `tok`. It does not have an ISO 639-1 code.

Bluesky already supports other constructed languages (Esperanto, Interlingua, Ido), so this feels like a pretty obvious addition. I'm not sure if this would need any extra support elsewhere.