### PR TITLE
Gate bitdrift integration

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -54,4 +54,4 @@ jobs:
         run: yarn intl:build
       - name: Run tests
         run: |
-          NODE_ENV=test EXPO_PUBLIC_ENV=test yarn test --forceExit
+          NODE_ENV=test yarn test --forceExit

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ build-web-embed: ## Compile web embed bundle, copy to bskyweb/embedr* directorie
 
 .PHONY: test
 test: ## Run all tests
-	NODE_ENV=test EXPO_PUBLIC_ENV=test yarn test
+	NODE_ENV=test yarn test
 
 .PHONY: lint
 lint: ## Run style checks and verify syntax

--- a/index.js
+++ b/index.js
@@ -5,9 +5,8 @@ import {LogBox} from 'react-native'
 import {registerRootComponent} from 'expo'
 
 import App from '#/App'
-import {IS_TEST} from '#/env'
 
-if (IS_TEST) {
+if (process.env.NODE_ENV === 'test') {
   LogBox.ignoreAllLogs() // suppress all logs in tests
 } else {
   LogBox.ignoreLogs(['Require cycle:']) // suppress require-cycle warnings, it's fine

--- a/src/App.native.tsx
+++ b/src/App.native.tsx
@@ -17,11 +17,7 @@ import {useLingui} from '@lingui/react'
 
 import {KeyboardControllerProvider} from '#/lib/hooks/useEnableKeyboardController'
 import {QueryProvider} from '#/lib/react-query'
-import {
-  initialize,
-  Provider as StatsigProvider,
-  tryFetchGates,
-} from '#/lib/statsig/statsig'
+import {Provider as StatsigProvider, tryFetchGates} from '#/lib/statsig/statsig'
 import {s} from '#/lib/styles'
 import {ThemeProvider} from '#/lib/ThemeContext'
 import I18nProvider from '#/locale/i18nProvider'
@@ -101,7 +97,6 @@ function InnerApp() {
         if (account) {
           await resumeSession(account)
         } else {
-          await initialize()
           await tryFetchGates(undefined, 'prefer-fresh-gates')
         }
       } catch (e) {

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,4 +1,3 @@
-export const IS_TEST = process.env.EXPO_PUBLIC_ENV === 'test'
 export const IS_DEV = __DEV__
 export const IS_PROD = !IS_DEV
 export const LOG_DEBUG = process.env.EXPO_PUBLIC_LOG_DEBUG || ''

--- a/src/lib/bitdrift.ts
+++ b/src/lib/bitdrift.ts
@@ -1,7 +1,20 @@
 import {init} from '@bitdrift/react-native'
+import {Statsig} from 'statsig-react-native-expo'
+
+import {initPromise} from './statsig/statsig'
 
 const BITDRIFT_API_KEY = process.env.BITDRIFT_API_KEY
 
-if (BITDRIFT_API_KEY) {
-  init(BITDRIFT_API_KEY, {url: 'https://api-bsky.bitdrift.io'})
-}
+initPromise.then(() => {
+  let isEnabled = false
+  try {
+    if (Statsig.checkGate('enable_bitdrift')) {
+      isEnabled = true
+    }
+  } catch (e) {
+    // Statsig may complain about it being called too early.
+  }
+  if (isEnabled && BITDRIFT_API_KEY) {
+    init(BITDRIFT_API_KEY, {url: 'https://api-bsky.bitdrift.io'})
+  }
+})

--- a/src/lib/statsig/statsig.tsx
+++ b/src/lib/statsig/statsig.tsx
@@ -16,6 +16,8 @@ import {Gate} from './gates'
 
 const SDK_KEY = 'client-SXJakO39w9vIhl3D44u8UupyzFl4oZ2qPIkjwcvuPsV'
 
+export const initPromise = initialize()
+
 type StatsigUser = {
   userID: string | undefined
   // TODO: Remove when enough users have custom.platform:
@@ -219,9 +221,6 @@ export async function tryFetchGates(
       // Use this for less common operations where the user would be OK with a delay.
       timeoutMs = 1500
     }
-    // Note: This condition is currently false the very first render because
-    // Statsig has not initialized yet. In the future, we can fix this by
-    // doing the initialization ourselves instead of relying on the provider.
     if (Statsig.initializeCalled()) {
       await Promise.race([
         timeout(timeoutMs),

--- a/src/logger/README.md
+++ b/src/logger/README.md
@@ -18,7 +18,7 @@ logger.error(error[, metadata])
 #### Modes
 
 The "modes" referred to here are inferred from the values exported from `#/env`.
-Basically, the booleans `IS_DEV`, `IS_TEST`, and `IS_PROD`.
+Basically, the booleans `IS_DEV` and `IS_PROD`.
 
 #### Log Levels
 

--- a/src/logger/__tests__/logger.test.ts
+++ b/src/logger/__tests__/logger.test.ts
@@ -5,7 +5,6 @@ import {nanoid} from 'nanoid/non-secure'
 import {Logger, LogLevel, sentryTransport} from '#/logger'
 
 jest.mock('#/env', () => ({
-  IS_TEST: true,
   IS_DEV: false,
   IS_PROD: false,
   /*

--- a/src/logger/index.ts
+++ b/src/logger/index.ts
@@ -173,7 +173,7 @@ export class Logger {
   protected debugContextRegexes: RegExp[] = []
 
   constructor({
-    enabled = !env.IS_TEST,
+    enabled = process.env.NODE_ENV !== 'test',
     level = env.LOG_LEVEL as LogLevel,
     debug = env.LOG_DEBUG || '',
   }: {
@@ -266,11 +266,11 @@ export class Logger {
  */
 export const logger = new Logger()
 
-if (!env.IS_TEST) {
+if (process.env.NODE_ENV !== 'test') {
   logger.addTransport(createBitdriftTransport())
 }
 
-if (env.IS_DEV && !env.IS_TEST) {
+if (env.IS_DEV && process.env.NODE_ENV !== 'test') {
   logger.addTransport(consoleTransport)
 
   /*

--- a/src/state/session/__tests__/session-test.ts
+++ b/src/state/session/__tests__/session-test.ts
@@ -4,6 +4,15 @@ import {describe, expect, it, jest} from '@jest/globals'
 import {agentToSessionAccountOrThrow} from '../agent'
 import {Action, getInitialState, reducer, State} from '../reducer'
 
+jest.mock('statsig-react-native-expo', () => ({
+  Statsig: {
+    initialize() {},
+    initializeCalled() {
+      return false
+    },
+  },
+}))
+
 jest.mock('jwt-decode', () => ({
   jwtDecode(_token: string) {
     return {}

--- a/src/view/com/util/Toast.tsx
+++ b/src/view/com/util/Toast.tsx
@@ -25,7 +25,6 @@ import {
 import {useNonReactiveCallback} from '#/lib/hooks/useNonReactiveCallback'
 import {atoms as a, useTheme} from '#/alf'
 import {Text} from '#/components/Typography'
-import {IS_TEST} from '#/env'
 
 const TIMEOUT = 2e3
 
@@ -33,7 +32,9 @@ export function show(
   message: string,
   icon: FontAwesomeProps['icon'] = 'check',
 ) {
-  if (IS_TEST) return
+  if (process.env.NODE_ENV === 'test') {
+    return
+  }
   AccessibilityInfo.announceForAccessibility(message)
   const item = new RootSiblings(
     <Toast message={message} icon={icon} destroy={() => item.destroy()} />,


### PR DESCRIPTION
- Moves Statsig initialization much earlier — we'll now initialize unconditionally _before_ we know your user ID and then initialize again. In practice this means that we're able to check cached gates based on StableID almost on startup.
- Makes the Bitdrift integration conditional on an `enable_bitdrift` gate to derisk it.

Our test setup was getting borked by the changes in the init code. I tried to unbork it but something about `env.ts` was not doing it correctly. I ended up ripping out the custom `IS_TEST` thing and doing a raw `process.env.NODE_ENV` inline environment check. I think we should change the rest of the code to match that pattern (for `IS_DEV` and `IS_PROD`) to guarantee dead code elimination but that's out of scope of this PR.

## Test Plan

Verify that allowlisting your StableID for the `enable_bitdrift` gate leads to getting into the conditional block on next app reload. This should work whether you're logged in or not. No effect on web.

Verify that gates work in general.