### PR TITLE
Give minWidth to tab indicator only

### DIFF
--- a/src/view/com/pager/TabBar.tsx
+++ b/src/view/com/pager/TabBar.tsx
@@ -237,12 +237,25 @@ export function TabBar({
         opacity: 0,
       }
     }
+
+    function getScaleX(index: number) {
+      const textWidth = textLayoutsValue[index].width
+      const itemWidth = layoutsValue[index].width
+      const minIndicatorWidth = 45
+      const maxIndicatorWidth = itemWidth - 2 * CONTENT_PADDING
+      const indicatorWidth = Math.min(
+        Math.max(minIndicatorWidth, textWidth),
+        maxIndicatorWidth,
+      )
+      return indicatorWidth / contentSize.get()
+    }
+
     if (textLayoutsValue.length === 1) {
       return {
         opacity: 1,
         transform: [
           {
-            scaleX: textLayoutsValue[0].width / contentSize.get(),
+            scaleX: getScaleX(0),
           },
         ],
       }
@@ -261,7 +274,7 @@ export function TabBar({
           scaleX: interpolate(
             dragProgress.get(),
             textLayoutsValue.map((l, i) => i),
-            textLayoutsValue.map(l => l.width / contentSize.get()),
+            textLayoutsValue.map((l, i) => getScaleX(i)),
           ),
         },
       ],
@@ -429,7 +442,6 @@ const styles = StyleSheet.create({
   },
   itemText: {
     lineHeight: 20,
-    minWidth: 45,
     textAlign: 'center',
   },
   outerBottomBorder: {

--- a/src/view/com/pager/TabBar.web.tsx
+++ b/src/view/com/pager/TabBar.web.tsx
@@ -25,16 +25,12 @@ export function TabBar({
   testID,
   selectedPage,
   items,
-  indicatorColor,
   onSelect,
   onPressSelected,
 }: TabBarProps) {
   const t = useTheme()
   const scrollElRef = useRef<ScrollView>(null)
   const itemRefs = useRef<Array<Element>>([])
-  const indicatorStyle = {
-    borderBottomColor: indicatorColor || t.palette.primary_500,
-  }
   const {gtMobile} = useBreakpoints()
   const styles = gtMobile ? desktopStyles : mobileStyles
 
@@ -122,12 +118,19 @@ export function TabBar({
                   style={[
                     styles.itemText,
                     selected ? t.atoms.text : t.atoms.text_contrast_medium,
-                    selected && indicatorStyle,
                     a.text_md,
                     a.font_bold,
                     {lineHeight: 20},
                   ]}>
                   {item}
+                  <View
+                    style={[
+                      styles.itemIndicator,
+                      selected && {
+                        backgroundColor: t.palette.primary_500,
+                      },
+                    ]}
+                  />
                 </Text>
               </View>
             </PressableWithHover>
@@ -158,13 +161,20 @@ const desktopStyles = StyleSheet.create({
   },
   itemInner: {
     alignItems: 'center',
+    overflowX: 'hidden',
   },
   itemText: {
     textAlign: 'center',
+    paddingBottom: 10 + 3,
+  },
+  itemIndicator: {
+    position: 'absolute',
+    bottom: 0,
+    height: 3,
+    left: '50%',
+    transform: 'translateX(-50%)',
     minWidth: 45,
-    paddingBottom: 12,
-    borderBottomWidth: 3,
-    borderBottomColor: 'transparent',
+    width: '100%',
   },
   outerBottomBorder: {
     position: 'absolute',
@@ -194,13 +204,20 @@ const mobileStyles = StyleSheet.create({
   itemInner: {
     flexGrow: 1,
     alignItems: 'center',
+    overflowX: 'hidden',
   },
   itemText: {
     textAlign: 'center',
+    paddingBottom: 10 + 3,
+  },
+  itemIndicator: {
+    position: 'absolute',
+    bottom: 0,
+    height: 3,
+    left: '50%',
+    transform: 'translateX(-50%)',
     minWidth: 45,
-    paddingBottom: 10,
-    borderBottomWidth: 3,
-    borderBottomColor: 'transparent',
+    width: '100%',
   },
   outerBottomBorder: {
     position: 'absolute',


### PR DESCRIPTION
Fixes https://github.com/bluesky-social/social-app/pull/7066#issuecomment-2540409035

Instead of giving min width to the tab item itself, instead give it to the indicator line. Also constrain it by the parent size so that it never extends beyond the tab item. As a result, the blue line will be 45px min, but won't inflate the tab bar item.

## Test Plan

Verify "All" in notifications still has some extra minimum width.

Verify profile tab bar items are not inflated anymore.

https://github.com/user-attachments/assets/58a6b313-588c-47a1-877a-195cb9edc4e3

https://github.com/user-attachments/assets/65f277b3-d307-439b-9327-11a9584092c3

<img width="554" alt="Screenshot 2024-12-13 at 17 07 43" src="https://github.com/user-attachments/assets/e8cd71b9-56f6-44fc-b3ce-6369fa026b29" />
