### PR TITLE
Better alignment on web

### DIFF
--- a/src/screens/Profile/components/ProfileFeedHeader.tsx
+++ b/src/screens/Profile/components/ProfileFeedHeader.tsx
@@ -12,6 +12,7 @@ import {shareUrl} from '#/lib/sharing'
 import {sanitizeHandle} from '#/lib/strings/handles'
 import {toShareUrl} from '#/lib/strings/url-helpers'
 import {logger} from '#/logger'
+import {isWeb} from '#/platform/detection'
 import {FeedSourceFeedInfo} from '#/state/queries/feed'
 import {useLikeMutation, useUnlikeMutation} from '#/state/queries/like'
 import {
@@ -161,7 +162,7 @@ export function ProfileFeedHeader({info}: {info: FeedSourceFeedInfo}) {
               style={[
                 a.justify_start,
                 {
-                  paddingVertical: 6,
+                  paddingVertical: isWeb ? 4 : 6,
                   paddingHorizontal: 8,
                   paddingRight: 12,
                 },
@@ -198,7 +199,7 @@ export function ProfileFeedHeader({info}: {info: FeedSourceFeedInfo}) {
                           a.text_md,
                           a.font_heavy,
                           a.leading_tight,
-                          gtMobile && a.text_xl,
+                          gtMobile && a.text_lg,
                         ]}
                         numberOfLines={2}>
                         {info.displayName}


### PR DESCRIPTION
Was a little big on web, was bothering me, and affecting the alignment of the header as compared to other headers in the app. This aligns those things, looks better now.

Before and after:
![CleanShot 2024-12-13 at 12 05 29@2x](https://github.com/user-attachments/assets/0907b7d3-147c-40d9-85c0-80173e284254)
![CleanShot 2024-12-13 at 12 05 06@2x](https://github.com/user-attachments/assets/e21612ad-86ba-4265-a002-d1947d7ce003)
