### PR TITLE
Fix z-indexes to make tabbar scroll on Android

### DIFF
--- a/src/screens/Hashtag.tsx
+++ b/src/screens/Hashtag.tsx
@@ -134,7 +134,7 @@ export default function HashtagScreen({
       <Pager
         onPageSelected={onPageSelected}
         renderTabBar={props => (
-          <Layout.Center style={web([a.sticky, a.z_10, {top: 0}])}>
+          <Layout.Center style={[a.z_10, web([a.sticky, {top: 0}])]}>
             <TabBar items={sections.map(section => section.title)} {...props} />
           </Layout.Center>
         )}

--- a/src/view/com/pager/Pager.tsx
+++ b/src/view/com/pager/Pager.tsx
@@ -136,14 +136,12 @@ export const Pager = forwardRef<PagerRef, React.PropsWithChildren<Props>>(
 
     return (
       <View testID={testID} style={[a.flex_1, native(a.overflow_hidden)]}>
-        <View style={a.z_10 /* Let tabbar bottom border cover the glimmer */}>
-          {renderTabBar({
-            selectedPage,
-            onSelect: onTabBarSelect,
-            dragProgress,
-            dragState,
-          })}
-        </View>
+        {renderTabBar({
+          selectedPage,
+          onSelect: onTabBarSelect,
+          dragProgress,
+          dragState,
+        })}
         <GestureDetector gesture={nativeGesture}>
           <AnimatedPagerView
             ref={pagerView}

--- a/src/view/com/pager/PagerWithHeader.web.tsx
+++ b/src/view/com/pager/PagerWithHeader.web.tsx
@@ -134,14 +134,16 @@ let PagerTabBar = ({
       <Layout.Center>{renderHeader?.({setMinimumHeight: noop})}</Layout.Center>
       {tabBarAnchor}
       <Layout.Center
-        style={web([
-          a.sticky,
+        style={[
           a.z_10,
-          {
-            top: 0,
-            display: isHeaderReady ? undefined : 'none',
-          },
-        ])}>
+          web([
+            a.sticky,
+            {
+              top: 0,
+              display: isHeaderReady ? undefined : 'none',
+            },
+          ]),
+        ]}>
         <TabBar
           testID={testID}
           items={items}

--- a/src/view/screens/Notifications.tsx
+++ b/src/view/screens/Notifications.tsx
@@ -144,7 +144,7 @@ export function NotificationsScreen({}: Props) {
       <Pager
         onPageSelected={onPageSelected}
         renderTabBar={props => (
-          <Layout.Center style={web([a.sticky, a.z_10, {top: 0}])}>
+          <Layout.Center style={[a.z_10, web([a.sticky, {top: 0}])]}>
             <TabBar
               {...props}
               items={sections.map(section => section.title)}

--- a/src/view/screens/Search/Search.tsx
+++ b/src/view/screens/Search/Search.tsx
@@ -532,7 +532,8 @@ let SearchScreenInner = ({
       renderTabBar={props => (
         <Layout.Center
           style={[
-            web([a.sticky, a.z_10]),
+            a.z_10,
+            web([a.sticky]),
             {top: isWeb ? headerHeight : undefined},
           ]}>
           <TabBar items={sections.map(section => section.title)} {...props} />


### PR DESCRIPTION
Reverts this change: https://github.com/bluesky-social/social-app/pull/7044/commits/b3381b5180e5eff33342dde009d0918056e80df2#diff-65932679e7a40da6746980329ec9b70b756d28bfc7980c1ffe03c2e49f7a5bb3

I did it to make sure the tabbar is always drawn on top of the content (so the Notifications glimmer doesn't obscure the tabbar's bottom border) but this zIndex being there causes Android to break horizontal scroll on the tabbar itself (it is interpreted as a pager swipe).

This alternative set of changes (just plumbing zIndex through) seems to work.

## Test Plan

Dragging the tabbar works again on Android:

https://github.com/user-attachments/assets/b6a101aa-47b6-45ec-8b5a-5f171d82ffe5

On iOS, while Notifications are loading, the border is visible:

https://github.com/user-attachments/assets/c790ce25-b3b8-423c-9d01-741753b33f43

Without the zIndex hackery, it would not be visible.

Web works like before.