### PR TITLE
Fix posting images on web

### DIFF
--- a/patches/expo-image-manipulator+13.0.5.patch
+++ b/patches/expo-image-manipulator+13.0.5.patch
@@ -25,7 +25,7 @@ index 120d8d3..f8aa49c 100644
  
  export default ExpoImageManipulator.Context as typeof ImageManipulatorContext;
 diff --git a/node_modules/expo-image-manipulator/src/web/ImageManipulatorContext.web.ts b/node_modules/expo-image-manipulator/src/web/ImageManipulatorContext.web.ts
-index 428848c..a851332 100644
+index 428848c..363a57a 100644
 --- a/node_modules/expo-image-manipulator/src/web/ImageManipulatorContext.web.ts
 +++ b/node_modules/expo-image-manipulator/src/web/ImageManipulatorContext.web.ts
 @@ -41,7 +41,7 @@ export default class ImageManipulatorContext extends SharedObject {
@@ -42,7 +42,7 @@ index 428848c..a851332 100644
  
          resolve(new ImageManipulatorImageRef(url, canvas.width, canvas.height));
 -      });
-+      }, 'image/jpeg', compress);
++      }, typeof compress === 'number' ? 'image/jpeg' : undefined, compress);
      });
    }
  

--- a/patches/expo-image-manipulator+13.0.5.patch
+++ b/patches/expo-image-manipulator+13.0.5.patch
@@ -1,0 +1,48 @@
+diff --git a/node_modules/expo-image-manipulator/src/ImageManipulator.ts b/node_modules/expo-image-manipulator/src/ImageManipulator.ts
+index a80d9c8..babbb3b 100644
+--- a/node_modules/expo-image-manipulator/src/ImageManipulator.ts
++++ b/node_modules/expo-image-manipulator/src/ImageManipulator.ts
+@@ -43,7 +43,7 @@ export async function manipulateAsync(
+       context.extent(action.extent);
+     }
+   }
+-  const image = await context.renderAsync();
++  const image = await context.renderAsync(saveOptions.compress);
+   const result = await image.saveAsync({ format, ...rest });
+ 
+   // These shared objects will not be used anymore, so free up some memory.
+diff --git a/node_modules/expo-image-manipulator/src/ImageManipulatorContext.ts b/node_modules/expo-image-manipulator/src/ImageManipulatorContext.ts
+index 120d8d3..f8aa49c 100644
+--- a/node_modules/expo-image-manipulator/src/ImageManipulatorContext.ts
++++ b/node_modules/expo-image-manipulator/src/ImageManipulatorContext.ts
+@@ -52,7 +52,7 @@ export declare class ImageManipulatorContext extends SharedObject {
+   /**
+    * Awaits for all manipulation tasks to finish and resolves with a reference to the resulted native image.
+    */
+-  renderAsync(): Promise<ImageRef>;
++  renderAsync(compress?: number): Promise<ImageRef>;
+ }
+ 
+ export default ExpoImageManipulator.Context as typeof ImageManipulatorContext;
+diff --git a/node_modules/expo-image-manipulator/src/web/ImageManipulatorContext.web.ts b/node_modules/expo-image-manipulator/src/web/ImageManipulatorContext.web.ts
+index 428848c..a851332 100644
+--- a/node_modules/expo-image-manipulator/src/web/ImageManipulatorContext.web.ts
++++ b/node_modules/expo-image-manipulator/src/web/ImageManipulatorContext.web.ts
+@@ -41,7 +41,7 @@ export default class ImageManipulatorContext extends SharedObject {
+     return this;
+   }
+ 
+-  async renderAsync(): Promise<ImageManipulatorImageRef> {
++  async renderAsync(compress?: number): Promise<ImageManipulatorImageRef> {
+     const canvas = await this.currentTask;
+ 
+     return new Promise((resolve) => {
+@@ -49,7 +49,7 @@ export default class ImageManipulatorContext extends SharedObject {
+         const url = blob ? URL.createObjectURL(blob) : canvas.toDataURL();
+ 
+         resolve(new ImageManipulatorImageRef(url, canvas.width, canvas.height));
+-      });
++      }, 'image/jpeg', compress);
+     });
+   }
+ 

--- a/src/lib/api/upload-blob.web.ts
+++ b/src/lib/api/upload-blob.web.ts
@@ -11,7 +11,10 @@ export async function uploadBlob(
   input: string | Blob,
   encoding?: string,
 ): Promise<ComAtprotoRepoUploadBlob.Response> {
-  if (typeof input === 'string' && input.startsWith('data:')) {
+  if (
+    typeof input === 'string' &&
+    (input.startsWith('data:') || input.startsWith('blob:'))
+  ) {
     const blob = await fetch(input).then(r => r.blob())
     return agent.uploadBlob(blob, {encoding})
   }


### PR DESCRIPTION
Fixes https://github.com/bluesky-social/social-app/issues/7097

If this isn't enough or we find some other issue, we'll fork the package by version instead, but let's try this first.

There were two issues:

- The library we use now emits `blob:` URIs rather than `data:` URIs
- It also accidentally lost support for the `compress` option on web, so it became a no-op

So this fixes both problems.

## Test Plan

Verify you can upload both _small_ images and _large_ images.

For small image, just use something small.

For large image, I was testing with https://apod.nasa.gov/apod/image/2412/M51_HaLRGB_APOD2048.jpg

No changes on native.