### PR TITLE
feat: widen recent search profile link for mobile devices

### DIFF
--- a/src/view/screens/Search/Search.tsx
+++ b/src/view/screens/Search/Search.tsx
@@ -1058,10 +1058,7 @@ function SearchHistory({
                     asAnchor
                     anchorNoUnderline
                     onBeforePress={() => onProfileClick(profile)}
-                    style={[
-                      styles.profilePressable,
-                      isMobile && styles.profilePressableMobile,
-                    ]}>
+                    style={styles.profilePressable}>
                     <Image
                       source={{uri: profile.avatar}}
                       style={styles.profileAvatar as StyleProp<ImageStyle>}
@@ -1196,8 +1193,6 @@ const styles = StyleSheet.create({
   },
   profilePressable: {
     alignItems: 'center',
-  },
-  profilePressableMobile: {
     width: '100%',
   },
   profileAvatar: {

--- a/src/view/screens/Search/Search.tsx
+++ b/src/view/screens/Search/Search.tsx
@@ -1058,7 +1058,10 @@ function SearchHistory({
                     asAnchor
                     anchorNoUnderline
                     onBeforePress={() => onProfileClick(profile)}
-                    style={styles.profilePressable}>
+                    style={[
+                      styles.profilePressable,
+                      isMobile && styles.profilePressableMobile,
+                    ]}>
                     <Image
                       source={{uri: profile.avatar}}
                       style={styles.profileAvatar as StyleProp<ImageStyle>}
@@ -1193,6 +1196,9 @@ const styles = StyleSheet.create({
   },
   profilePressable: {
     alignItems: 'center',
+  },
+  profilePressableMobile: {
+    width: '100%',
   },
   profileAvatar: {
     width: 60,


### PR DESCRIPTION
Hi,

In response to issue #7111, I prepared a solution to set width of profile links' text in "Recent Searches" to 100% for mobile devices. Change does not affect current profiles layout. Below I place before and after screenshots.

I tested it on Chrome 131.0.6778.140 and Firefox 133.0.3 as problem appeared on web version for screens with width smaller than 900px.

Before:
![chrome_3qxhet01Vr](https://github.com/user-attachments/assets/e3646a47-645a-4e20-b39e-4c0528a6424c)

After:
![chrome_AeaqRlNvNM](https://github.com/user-attachments/assets/f7f3a533-0abd-4e55-93a6-323a8be9dcc7)

Greetings
Karol
