### PR TITLE
Fix video uploads on native

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@lingui/react": "^4.14.1",
     "@mattermost/react-native-paste-input": "^0.7.1",
     "@miblanchard/react-native-slider": "^2.3.1",
-    "@mozzius/expo-dynamic-app-icon": "^1.4.1",
+    "@mozzius/expo-dynamic-app-icon": "^1.5.0",
     "@radix-ui/react-dismissable-layer": "^1.1.1",
     "@radix-ui/react-dropdown-menu": "2.0.1",
     "@radix-ui/react-focus-guards": "^1.1.1",

--- a/patches/expo-modules-core+2.1.1.patch
+++ b/patches/expo-modules-core+2.1.1.patch
@@ -13,3 +13,23 @@ index 47c4d15..afe138d 100644
    // Check for Content-Type
    val skipContentTypes = listOf(
      "text/event-stream", // Server Sent Events
+diff --git a/node_modules/expo-modules-core/src/uuid/uuid.ts b/node_modules/expo-modules-core/src/uuid/uuid.ts
+index 148beac..fabdff5 100644
+--- a/node_modules/expo-modules-core/src/uuid/uuid.ts
++++ b/node_modules/expo-modules-core/src/uuid/uuid.ts
+@@ -5,6 +5,7 @@ const nativeUuidv4 = globalThis?.expo?.uuidv4;
+ const nativeUuidv5 = globalThis?.expo?.uuidv5;
+ 
+ function uuidv4(): string {
++  const nativeUuidv4 = globalThis?.expo?.uuidv4;
+   if (!nativeUuidv4) {
+     throw Error(
+       "Native UUID version 4 generator implementation wasn't found in `expo-modules-core`"
+@@ -23,6 +24,7 @@ function uuidv5(name: string, namespace: string | number[]) {
+     throw new Error('`namespace` must be a valid UUID string or an Array of 16 byte values');
+   }
+ 
++  const nativeUuidv5 = globalThis?.expo?.uuidv5;
+   if (!nativeUuidv5) {
+     throw Error("Native UUID type 5 generator implementation wasn't found in `expo-modules-core`");
+   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3962,7 +3962,7 @@
   resolved "https://registry.yarnpkg.com/@expo/html-elements/-/html-elements-0.4.3.tgz#32b4ca05dd13582164ed1be34ae87e22adfd1d5b"
   integrity sha512-UwEEdnpyhUEIDe/AkFSBUmCuwcknjAuu73fd5L9Rm/BbHczYXCrtyZmzCNVBsAiHhwUjmhNWzFlr9cAkp/sxIA==
 
-"@expo/image-utils@0.3.23", "@expo/image-utils@0.6.3", "@expo/image-utils@^0.3.23", "@expo/image-utils@^0.6.0":
+"@expo/image-utils@0.3.23", "@expo/image-utils@0.6.3", "@expo/image-utils@^0.6.0", "@expo/image-utils@^0.6.3":
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/@expo/image-utils/-/image-utils-0.6.3.tgz#89c744460beefc686989b969121357bbd5520c8a"
   integrity sha512-v/JbCKBrHeudxn1gN1TgfPE/pWJSlLPrl29uXJBgrJFQVkViQvUHQNDhaS+UEa9wYI5HHh7XYmtzAehyG4L+GA==
@@ -5090,13 +5090,13 @@
   resolved "https://registry.yarnpkg.com/@miblanchard/react-native-slider/-/react-native-slider-2.3.1.tgz#79e0f1f9b1ce43ef25ee51ee9256c012e5dfa412"
   integrity sha512-J/hZDBWmXq8fJeOnTVHqIUVDHshqMSpJVxJ4WqwuCBKl5Rke9OBYXIdkSlgi75OgtScAr8FKK5KNkDKHUf6JIg==
 
-"@mozzius/expo-dynamic-app-icon@^1.4.1":
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/@mozzius/expo-dynamic-app-icon/-/expo-dynamic-app-icon-1.4.1.tgz#245e54c31347e3ec2a1ce10f0df8cf07a0c1be6e"
-  integrity sha512-IiL6OiuW4kP5Jz/vrZ6U1t0m4gK1rW5VZAQzszdVcZy1cadX3EdR2/uA6jMU0qSwuesk028RhO6S0uBI9ckxBw==
+"@mozzius/expo-dynamic-app-icon@^1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@mozzius/expo-dynamic-app-icon/-/expo-dynamic-app-icon-1.5.0.tgz#c5f88c309965b6d6b89cfd5e2c00faa7bda736af"
+  integrity sha512-yE2yEPO+HQmOqsX7cECh7/vu/LXnqhHGsVm3UiVi/3gaK8u5hAkPTNzZ0Qu6vnMwjPnY+uFbN6X+6Aj9c9yjMQ==
   dependencies:
-    "@expo/image-utils" "^0.3.23"
-    expo-modules-core "^1.0.3"
+    "@expo/image-utils" "^0.6.3"
+    expo-modules-core "^2.1.1"
     xcode "^3.0.1"
 
 "@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1":
@@ -10618,17 +10618,10 @@ expo-modules-autolinking@2.0.3:
     require-from-string "^2.0.2"
     resolve-from "^5.0.0"
 
-expo-modules-core@2.1.1:
+expo-modules-core@2.1.1, expo-modules-core@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/expo-modules-core/-/expo-modules-core-2.1.1.tgz#970af4cfd70c8aa6fc0096dd0a6578aa003a479f"
   integrity sha512-yQzYCLR2mre4BNMXuqkeJ0oSNgmGEMI6BcmIzeNZbC2NFEjiaDpKvlV9bclYCtyVhUEVNbJcEPYMr6c1Y4eR4w==
-  dependencies:
-    invariant "^2.2.4"
-
-expo-modules-core@^1.0.3:
-  version "1.12.26"
-  resolved "https://registry.yarnpkg.com/expo-modules-core/-/expo-modules-core-1.12.26.tgz#86c4087dc6246abfc4d7f5e61097dc8cc4b22262"
-  integrity sha512-y8yDWjOi+rQRdO+HY+LnUlz8qzHerUaw/LUjKPU/mX8PRXP4UUPEEp5fjAwBU44xjNmYSHWZDwet4IBBE+yQUA==
   dependencies:
     invariant "^2.2.4"
 


### PR DESCRIPTION
Video uploads got broken by the Expo upgrade. I'm patching https://github.com/expo/expo/pull/33621 to fix it. That fix hasn't made it into a release yet but it's pretty trivial.

I'm additionally bumping the dynamic icon package because it was pulling in old `expo-modules-core`. Doesn't matter (maybe?) but this seems safer.

## Test Plan

Verify you can again upload videos on iOS and Android.

Verify web still works.

Verify dynamic icon still works.