### PR TITLE
Disable automaticallyAdjustsScrollIndicatorInsets

### DIFF
--- a/src/view/com/util/List.tsx
+++ b/src/view/com/util/List.tsx
@@ -53,6 +53,7 @@ let List = React.forwardRef<ListMethods, ListProps>(
       headerOffset,
       style,
       progressViewOffset,
+      automaticallyAdjustsScrollIndicatorInsets = false,
       ...props
     },
     ref,
@@ -151,6 +152,9 @@ let List = React.forwardRef<ListMethods, ListProps>(
     return (
       <FlatList_INTERNAL
         {...props}
+        automaticallyAdjustsScrollIndicatorInsets={
+          automaticallyAdjustsScrollIndicatorInsets
+        }
         scrollIndicatorInsets={{top: headerOffset, right: 1}}
         contentOffset={contentOffset}
         refreshControl={refreshControl}


### PR DESCRIPTION
iOS automatically adds in the safe area to the scroll indicator insets, even though the overwhelming majority of our ScrollViews do not stretch from edge to edge. we should just disable this behaviour by default

Can't take screenshots rn but you can see on the testflight that the scroll indicators on the post thread screen doesn't go all the way to the top. this PR fixes that