### PR TITLE
Adjust gates

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -23,16 +23,6 @@ export const STARTER_PACK_MAX_SIZE = 150
 // -prf
 export const JOINED_THIS_WEEK = 2880000 // estimate as of 11/26/24
 
-export const DISCOVER_DEBUG_DIDS: Record<string, true> = {
-  'did:plc:oisofpd7lj26yvgiivf3lxsi': true, // hailey.at
-  'did:plc:fpruhuo22xkm5o7ttr2ktxdo': true, // danabra.mov
-  'did:plc:p2cp5gopk7mgjegy6wadk3ep': true, // samuel.bsky.team
-  'did:plc:ragtjsm2j2vknwkz3zp4oxrd': true, // pfrazee.com
-  'did:plc:vpkhqolt662uhesyj6nxm7ys': true, // why.bsky.team
-  'did:plc:3jpt2mvvsumj2r7eqk4gzzjz': true, // esb.lol
-  'did:plc:vjug55kidv6sye7ykr5faxxn': true, // emilyliu.me
-}
-
 const BASE_FEEDBACK_FORM_URL = `${HELP_DESK_URL}/requests/new`
 export function FEEDBACK_FORM_URL({
   email,

--- a/src/lib/statsig/gates.ts
+++ b/src/lib/statsig/gates.ts
@@ -1,4 +1,3 @@
 export type Gate =
   // Keep this alphabetic please.
-  | 'debug_show_feedcontext' // DISABLED DUE TO EME
-  | 'remove_show_latest_button'
+  'debug_show_feedcontext' | 'debug_subscriptions' | 'remove_show_latest_button'

--- a/src/lib/statsig/gates.ts
+++ b/src/lib/statsig/gates.ts
@@ -1,5 +1,4 @@
 export type Gate =
   // Keep this alphabetic please.
   | 'debug_show_feedcontext' // DISABLED DUE TO EME
-  | 'post_feed_lang_window' // DISABLED DUE TO EME
   | 'remove_show_latest_button'

--- a/src/screens/Settings/AppIconSettings/index.tsx
+++ b/src/screens/Settings/AppIconSettings/index.tsx
@@ -5,11 +5,11 @@ import {useLingui} from '@lingui/react'
 import * as DynamicAppIcon from '@mozzius/expo-dynamic-app-icon'
 import {NativeStackScreenProps} from '@react-navigation/native-stack'
 
-import {DISCOVER_DEBUG_DIDS} from '#/lib/constants'
+import {IS_INTERNAL} from '#/lib/app-info'
 import {PressableScale} from '#/lib/custom-animations/PressableScale'
 import {CommonNavigatorParams} from '#/lib/routes/types'
+import {useGate} from '#/lib/statsig/statsig'
 import {isAndroid} from '#/platform/detection'
-import {useSession} from '#/state/session'
 import {AppIconImage} from '#/screens/Settings/AppIconSettings/AppIconImage'
 import {AppIconSet} from '#/screens/Settings/AppIconSettings/types'
 import {useAppIconSets} from '#/screens/Settings/AppIconSettings/useAppIconSets'
@@ -23,7 +23,7 @@ export function AppIconSettingsScreen({}: Props) {
   const t = useTheme()
   const {_} = useLingui()
   const sets = useAppIconSets()
-  const {currentAccount} = useSession()
+  const gate = useGate()
   const [currentAppIcon, setCurrentAppIcon] = useState(() =>
     getAppIconName(DynamicAppIcon.getAppIcon()),
   )
@@ -86,34 +86,38 @@ export function AppIconSettingsScreen({}: Props) {
           ))}
         </Group>
 
-        {DISCOVER_DEBUG_DIDS[currentAccount?.did ?? ''] && (
-          <>
-            <Text
-              style={[
-                a.text_md,
-                a.mt_xl,
-                a.mb_sm,
-                a.font_bold,
-                t.atoms.text_contrast_medium,
-              ]}>
-              <Trans>Bluesky+</Trans>
-            </Text>
-            <Group
-              label={_(msg`Bluesky+ icons`)}
-              value={currentAppIcon}
-              onChange={onSetAppIcon}>
-              {sets.core.map((icon, i) => (
-                <Row
-                  key={icon.id}
-                  icon={icon}
-                  isEnd={i === sets.core.length - 1}>
-                  <AppIcon icon={icon} key={icon.id} size={40} />
-                  <RowText>{icon.name}</RowText>
-                </Row>
-              ))}
-            </Group>
-          </>
-        )}
+        {IS_INTERNAL &&
+          gate('debug_subscriptions', {
+            // Employee only
+            dangerouslyDisableExposureLogging: true,
+          }) && (
+            <>
+              <Text
+                style={[
+                  a.text_md,
+                  a.mt_xl,
+                  a.mb_sm,
+                  a.font_bold,
+                  t.atoms.text_contrast_medium,
+                ]}>
+                <Trans>Bluesky+</Trans>
+              </Text>
+              <Group
+                label={_(msg`Bluesky+ icons`)}
+                value={currentAppIcon}
+                onChange={onSetAppIcon}>
+                {sets.core.map((icon, i) => (
+                  <Row
+                    key={icon.id}
+                    icon={icon}
+                    isEnd={i === sets.core.length - 1}>
+                    <AppIcon icon={icon} key={icon.id} size={40} />
+                    <RowText>{icon.name}</RowText>
+                  </Row>
+                ))}
+              </Group>
+            </>
+          )}
       </Layout.Content>
     </Layout.Screen>
   )

--- a/src/screens/Settings/AppIconSettings/index.tsx
+++ b/src/screens/Settings/AppIconSettings/index.tsx
@@ -86,38 +86,34 @@ export function AppIconSettingsScreen({}: Props) {
           ))}
         </Group>
 
-        {IS_INTERNAL &&
-          gate('debug_subscriptions', {
-            // Employee only
-            dangerouslyDisableExposureLogging: true,
-          }) && (
-            <>
-              <Text
-                style={[
-                  a.text_md,
-                  a.mt_xl,
-                  a.mb_sm,
-                  a.font_bold,
-                  t.atoms.text_contrast_medium,
-                ]}>
-                <Trans>Bluesky+</Trans>
-              </Text>
-              <Group
-                label={_(msg`Bluesky+ icons`)}
-                value={currentAppIcon}
-                onChange={onSetAppIcon}>
-                {sets.core.map((icon, i) => (
-                  <Row
-                    key={icon.id}
-                    icon={icon}
-                    isEnd={i === sets.core.length - 1}>
-                    <AppIcon icon={icon} key={icon.id} size={40} />
-                    <RowText>{icon.name}</RowText>
-                  </Row>
-                ))}
-              </Group>
-            </>
-          )}
+        {IS_INTERNAL && gate('debug_subscriptions') && (
+          <>
+            <Text
+              style={[
+                a.text_md,
+                a.mt_xl,
+                a.mb_sm,
+                a.font_bold,
+                t.atoms.text_contrast_medium,
+              ]}>
+              <Trans>Bluesky+</Trans>
+            </Text>
+            <Group
+              label={_(msg`Bluesky+ icons`)}
+              value={currentAppIcon}
+              onChange={onSetAppIcon}>
+              {sets.core.map((icon, i) => (
+                <Row
+                  key={icon.id}
+                  icon={icon}
+                  isEnd={i === sets.core.length - 1}>
+                  <AppIcon icon={icon} key={icon.id} size={40} />
+                  <RowText>{icon.name}</RowText>
+                </Row>
+              ))}
+            </Group>
+          </>
+        )}
       </Layout.Content>
     </Layout.Screen>
   )

--- a/src/screens/Settings/AppearanceSettings.tsx
+++ b/src/screens/Settings/AppearanceSettings.tsx
@@ -8,10 +8,10 @@ import Animated, {
 import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
-import {DISCOVER_DEBUG_DIDS} from '#/lib/constants'
+import {IS_INTERNAL} from '#/lib/app-info'
 import {CommonNavigatorParams, NativeStackScreenProps} from '#/lib/routes/types'
+import {useGate} from '#/lib/statsig/statsig'
 import {isNative} from '#/platform/detection'
-import {useSession} from '#/state/session'
 import {useSetThemePrefs, useThemePrefs} from '#/state/shell'
 import {SettingsListItem as AppIconSettingsListItem} from '#/screens/Settings/AppIconSettings/SettingsListItem'
 import {atoms as a, native, useAlf, useTheme} from '#/alf'
@@ -29,6 +29,7 @@ type Props = NativeStackScreenProps<CommonNavigatorParams, 'AppearanceSettings'>
 export function AppearanceSettingsScreen({}: Props) {
   const {_} = useLingui()
   const {fonts} = useAlf()
+  const gate = useGate()
 
   const {colorMode, darkTheme} = useThemePrefs()
   const {setColorMode, setDarkTheme} = useSetThemePrefs()
@@ -73,8 +74,6 @@ export function AppearanceSettingsScreen({}: Props) {
     },
     [fonts],
   )
-
-  const {currentAccount} = useSession()
 
   return (
     <LayoutAnimationConfig skipExiting skipEntering>
@@ -178,12 +177,17 @@ export function AppearanceSettingsScreen({}: Props) {
                 onChange={onChangeFontScale}
               />
 
-              {isNative && DISCOVER_DEBUG_DIDS[currentAccount?.did ?? ''] && (
-                <>
-                  <SettingsList.Divider />
-                  <AppIconSettingsListItem />
-                </>
-              )}
+              {isNative &&
+                IS_INTERNAL &&
+                gate('debug_subscriptions', {
+                  // Employee only
+                  dangerouslyDisableExposureLogging: true,
+                }) && (
+                  <>
+                    <SettingsList.Divider />
+                    <AppIconSettingsListItem />
+                  </>
+                )}
             </Animated.View>
           </SettingsList.Container>
         </Layout.Content>

--- a/src/screens/Settings/AppearanceSettings.tsx
+++ b/src/screens/Settings/AppearanceSettings.tsx
@@ -177,17 +177,12 @@ export function AppearanceSettingsScreen({}: Props) {
                 onChange={onChangeFontScale}
               />
 
-              {isNative &&
-                IS_INTERNAL &&
-                gate('debug_subscriptions', {
-                  // Employee only
-                  dangerouslyDisableExposureLogging: true,
-                }) && (
-                  <>
-                    <SettingsList.Divider />
-                    <AppIconSettingsListItem />
-                  </>
-                )}
+              {isNative && IS_INTERNAL && gate('debug_subscriptions') && (
+                <>
+                  <SettingsList.Divider />
+                  <AppIconSettingsListItem />
+                </>
+              )}
             </Animated.View>
           </SettingsList.Container>
         </Layout.Content>

--- a/src/state/queries/post-feed.ts
+++ b/src/state/queries/post-feed.ts
@@ -144,11 +144,8 @@ export function usePostFeedQuery(
   /**
    * The number of posts to fetch in a single request. Because we filter
    * unwanted content, we may over-fetch here to try and fill pages by
-   * `MIN_POSTS`.
+   * `MIN_POSTS`. But if you're doing this, ask @why if it's ok first.
    */
-
-  // TEMPORARILY DISABLING GATE TO PREVENT EVENT CONSUMPTION @TODO EME-GATE
-  // const fetchLimit = gate('post_feed_lang_window') ? 100 : MIN_POSTS
   const fetchLimit = MIN_POSTS
 
   // Make sure this doesn't invalidate unless really needed.

--- a/src/view/com/util/post-ctrls/PostCtrls.tsx
+++ b/src/view/com/util/post-ctrls/PostCtrls.tsx
@@ -87,12 +87,7 @@ let PostCtrls = ({
   const {captureAction} = useProgressGuideControls()
   const playHaptic = useHaptics()
   const gate = useGate()
-  const isDiscoverDebugUser =
-    IS_INTERNAL ||
-    gate('debug_show_feedcontext', {
-      // Employee only
-      dangerouslyDisableExposureLogging: true,
-    })
+  const isDiscoverDebugUser = IS_INTERNAL || gate('debug_show_feedcontext')
   const isBlocked = Boolean(
     post.author.viewer?.blocking ||
       post.author.viewer?.blockedBy ||

--- a/src/view/com/util/post-ctrls/PostCtrls.tsx
+++ b/src/view/com/util/post-ctrls/PostCtrls.tsx
@@ -18,12 +18,13 @@ import {msg, plural} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
 import {IS_INTERNAL} from '#/lib/app-info'
-import {DISCOVER_DEBUG_DIDS, POST_CTRL_HITSLOP} from '#/lib/constants'
+import {POST_CTRL_HITSLOP} from '#/lib/constants'
 import {CountWheel} from '#/lib/custom-animations/CountWheel'
 import {AnimatedLikeIcon} from '#/lib/custom-animations/LikeIcon'
 import {useHaptics} from '#/lib/haptics'
 import {makeProfileLink} from '#/lib/routes/links'
 import {shareUrl} from '#/lib/sharing'
+import {useGate} from '#/lib/statsig/statsig'
 import {toShareUrl} from '#/lib/strings/url-helpers'
 import {Shadow} from '#/state/cache/types'
 import {useFeedFeedbackContext} from '#/state/feed-feedback'
@@ -85,8 +86,13 @@ let PostCtrls = ({
   const {sendInteraction} = useFeedFeedbackContext()
   const {captureAction} = useProgressGuideControls()
   const playHaptic = useHaptics()
+  const gate = useGate()
   const isDiscoverDebugUser =
-    IS_INTERNAL || DISCOVER_DEBUG_DIDS[currentAccount?.did ?? '']
+    IS_INTERNAL ||
+    gate('debug_show_feedcontext', {
+      // Employee only
+      dangerouslyDisableExposureLogging: true,
+    })
   const isBlocked = Boolean(
     post.author.viewer?.blocking ||
       post.author.viewer?.blockedBy ||


### PR DESCRIPTION
A few things:

- Remove the hardcoded `DISCOVER_DEBUG_DIDS` stuff. It sucks because it's not visible in production.
- Instead, reintroduce two different gates: `debug_subscriptions` and `debug_show_feedcontext`
  - They don't have Metric Lifts enabled so they're free to check
- Narrow down the build conditions
  - Only enable the app icon stuff when `IS_INTERNAL` is _also_ true (we never want it in public builds)
  - Enable the debug context if the gate is true _or_ we're in TestFlight (where we always enable it)

Basically the goal is to get rid of this hardcoded list.

## Test Plan

Probably easiest to test by going to an alt, verifying it has no feed feedback or app icon, then allowlisting it in each gate, and verifying both things show up. Note that feed context _also_ shows up for `IS_INTERNAL` so you'll want to comment that check out before testing.