### PR TITLE
[ELI5] Tweak wording on the signup screen

### DIFF
--- a/src/locale/locales/an/messages.po
+++ b/src/locale/locales/an/messages.po
@@ -3613,7 +3613,7 @@ msgstr "Escribe la tuya clau"
 #~ msgstr "Escribe lo tuyo furnidor d'aloch preferiu"
 
 #: src/screens/Signup/StepHandle.tsx:114
-msgid "Input your user handle"
+msgid "Type your desired username"
 msgstr "Escribe lo tuyo identificador"
 
 #: src/view/com/composer/threadgate/ThreadgateBtn.tsx:49
@@ -8877,7 +8877,7 @@ msgid "Your following feed is empty! Follow more users to see what's happening."
 msgstr "La tuya canal de Seguindo ye vueda! Sigue a mas usuarios pa veyer las suyas publicacions aquí."
 
 #: src/screens/Signup/StepHandle.tsx:125
-msgid "Your full handle will be"
+msgid "Your full username will be"
 msgstr "Lo tuyo identificador completo será"
 
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:219
@@ -8921,5 +8921,5 @@ msgid "Your report will be sent to the Bluesky Moderation Service"
 msgstr "Lo tuyo reporte s'ha ninviau a lo servicio de moderación de Bluesky"
 
 #: src/screens/Signup/index.tsx:142
-msgid "Your user handle"
+msgid "Choose your username"
 msgstr "Lo tuyo identificador"

--- a/src/locale/locales/ast/messages.po
+++ b/src/locale/locales/ast/messages.po
@@ -3509,7 +3509,7 @@ msgstr ""
 #~ msgstr ""
 
 #: src/screens/Signup/StepHandle.tsx:114
-msgid "Input your user handle"
+msgid "Type your desired username"
 msgstr ""
 
 #: src/view/com/composer/threadgate/ThreadgateBtn.tsx:49
@@ -8543,7 +8543,7 @@ msgid "Your following feed is empty! Follow more users to see what's happening."
 msgstr "¡El feed siguiente ta baleru! Sigui a más usuarios pa ver qué pasó."
 
 #: src/screens/Signup/StepHandle.tsx:125
-msgid "Your full handle will be"
+msgid "Your full username will be"
 msgstr "L'identificador completu va ser"
 
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:219
@@ -8587,5 +8587,5 @@ msgid "Your report will be sent to the Bluesky Moderation Service"
 msgstr "L'informe unvióse al serviciu de moderación de Bluesky"
 
 #: src/screens/Signup/index.tsx:142
-msgid "Your user handle"
+msgid "Choose your username"
 msgstr ""

--- a/src/locale/locales/ca/messages.po
+++ b/src/locale/locales/ca/messages.po
@@ -4268,7 +4268,7 @@ msgstr "Introdueix la teva contrasenya"
 #~ msgstr "Introdueix el teu proveïdor d'allotjament preferit"
 
 #: src/screens/Signup/StepHandle.tsx:114
-msgid "Input your user handle"
+msgid "Type your desired username"
 msgstr "Introdueix el teu identificador d'usuari"
 
 #: src/view/com/composer/threadgate/ThreadgateBtn.tsx:49
@@ -10404,7 +10404,7 @@ msgid "Your following feed is empty! Follow more users to see what's happening."
 msgstr "El teu canal de seguint està buit! Segueix a més usuaris per a saber què està passant."
 
 #: src/screens/Signup/StepHandle.tsx:125
-msgid "Your full handle will be"
+msgid "Your full username will be"
 msgstr "El teu identificador complet serà"
 
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:219
@@ -10458,5 +10458,5 @@ msgid "Your report will be sent to the Bluesky Moderation Service"
 msgstr "El teu informe s'enviarà al servei de moderació de Bluesky"
 
 #: src/screens/Signup/index.tsx:142
-msgid "Your user handle"
+msgid "Choose your username"
 msgstr "El teu identificador d'usuari"

--- a/src/locale/locales/de/messages.po
+++ b/src/locale/locales/de/messages.po
@@ -3742,7 +3742,7 @@ msgstr "Gib dein Passwort ein"
 #~ msgstr ""
 
 #: src/screens/Signup/StepHandle.tsx:114
-msgid "Input your user handle"
+msgid "Type your desired username"
 msgstr "Gib deinen Handle ein"
 
 #: src/view/com/composer/threadgate/ThreadgateBtn.tsx:49
@@ -9663,7 +9663,7 @@ msgid "Your following feed is empty! Follow more users to see what's happening."
 msgstr "Dein Following-Feed ist leer! Folge mehr Benutzern, um auf dem Laufenden zu bleiben."
 
 #: src/screens/Signup/StepHandle.tsx:125
-msgid "Your full handle will be"
+msgid "Your full username will be"
 msgstr "Dein vollständiger Handle lautet"
 
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:219
@@ -9707,5 +9707,5 @@ msgid "Your report will be sent to the Bluesky Moderation Service"
 msgstr ""
 
 #: src/screens/Signup/index.tsx:142
-msgid "Your user handle"
+msgid "Choose your username"
 msgstr "Dein Benutzerhandle"

--- a/src/locale/locales/en-GB/messages.po
+++ b/src/locale/locales/en-GB/messages.po
@@ -3509,7 +3509,7 @@ msgstr ""
 #~ msgstr ""
 
 #: src/screens/Signup/StepHandle.tsx:114
-msgid "Input your user handle"
+msgid "Type your desired username"
 msgstr ""
 
 #: src/view/com/composer/threadgate/ThreadgateBtn.tsx:49
@@ -8543,7 +8543,7 @@ msgid "Your following feed is empty! Follow more users to see what's happening."
 msgstr ""
 
 #: src/screens/Signup/StepHandle.tsx:125
-msgid "Your full handle will be"
+msgid "Your full username will be"
 msgstr ""
 
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:219
@@ -8587,5 +8587,5 @@ msgid "Your report will be sent to the Bluesky Moderation Service"
 msgstr ""
 
 #: src/screens/Signup/index.tsx:142
-msgid "Your user handle"
+msgid "Choose your username"
 msgstr ""

--- a/src/locale/locales/en/messages.po
+++ b/src/locale/locales/en/messages.po
@@ -3509,7 +3509,7 @@ msgstr ""
 #~ msgstr ""
 
 #: src/screens/Signup/StepHandle.tsx:114
-msgid "Input your user handle"
+msgid "Type your desired username"
 msgstr ""
 
 #: src/view/com/composer/threadgate/ThreadgateBtn.tsx:49
@@ -8543,7 +8543,7 @@ msgid "Your following feed is empty! Follow more users to see what's happening."
 msgstr ""
 
 #: src/screens/Signup/StepHandle.tsx:125
-msgid "Your full handle will be"
+msgid "Your full username will be"
 msgstr ""
 
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:219
@@ -8587,5 +8587,5 @@ msgid "Your report will be sent to the Bluesky Moderation Service"
 msgstr ""
 
 #: src/screens/Signup/index.tsx:142
-msgid "Your user handle"
+msgid "Choose your username"
 msgstr ""

--- a/src/locale/locales/es/messages.po
+++ b/src/locale/locales/es/messages.po
@@ -3896,7 +3896,7 @@ msgstr "Introduce tu contraseña"
 #~ msgstr "Introduce tu proveedor de alojamiento preferido"
 
 #: src/screens/Signup/StepHandle.tsx:114
-msgid "Input your user handle"
+msgid "Type your desired username"
 msgstr "Introduce tu nombre de usuario"
 
 #: src/view/com/composer/threadgate/ThreadgateBtn.tsx:49
@@ -9518,7 +9518,7 @@ msgid "Your following feed is empty! Follow more users to see what's happening."
 msgstr "¡Tu feed de Siguiendo esta vacío! Sigue a más usuarios para ver sus posts aquí."
 
 #: src/screens/Signup/StepHandle.tsx:125
-msgid "Your full handle will be"
+msgid "Your full username will be"
 msgstr "Tu nombre de usuario completo será"
 
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:219
@@ -9562,5 +9562,5 @@ msgid "Your report will be sent to the Bluesky Moderation Service"
 msgstr "Tu reporte ha sido enviado al servicio de moderación de Bluesky"
 
 #: src/screens/Signup/index.tsx:142
-msgid "Your user handle"
+msgid "Choose your username"
 msgstr "Tu nombre de usuario"

--- a/src/locale/locales/fi/messages.po
+++ b/src/locale/locales/fi/messages.po
@@ -3970,7 +3970,7 @@ msgstr "Syötä salasanasi"
 #~ msgstr "Syötä haluamasi palveluntarjoaja"
 
 #: src/screens/Signup/StepHandle.tsx:114
-msgid "Input your user handle"
+msgid "Type your desired username"
 msgstr "Syötä käyttäjätunnuksesi"
 
 #: src/view/com/composer/threadgate/ThreadgateBtn.tsx:49
@@ -9627,7 +9627,7 @@ msgid "Your following feed is empty! Follow more users to see what's happening."
 msgstr "Seuraamiesi syöte on tyhjä! Seuraa lisää käyttäjiä nähdäksesi, mitä tapahtuu."
 
 #: src/screens/Signup/StepHandle.tsx:125
-msgid "Your full handle will be"
+msgid "Your full username will be"
 msgstr "Käyttäjätunnuksesi tulee olemaan"
 
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:219
@@ -9671,5 +9671,5 @@ msgid "Your report will be sent to the Bluesky Moderation Service"
 msgstr ""
 
 #: src/screens/Signup/index.tsx:142
-msgid "Your user handle"
+msgid "Choose your username"
 msgstr "Käyttäjätunnuksesi"

--- a/src/locale/locales/fr/messages.po
+++ b/src/locale/locales/fr/messages.po
@@ -3501,7 +3501,7 @@ msgstr "Entrez votre mot de passe"
 #~ msgstr "Entrez votre hébergeur préféré"
 
 #: src/screens/Signup/StepHandle.tsx:114
-msgid "Input your user handle"
+msgid "Type your desired username"
 msgstr "Entrez votre pseudo"
 
 #: src/view/com/composer/threadgate/ThreadgateBtn.tsx:49
@@ -8519,7 +8519,7 @@ msgid "Your following feed is empty! Follow more users to see what's happening."
 msgstr "Votre fil d’actu des comptes suivis est vide ! Suivez plus de comptes pour voir ce qui se passe."
 
 #: src/screens/Signup/StepHandle.tsx:125
-msgid "Your full handle will be"
+msgid "Your full username will be"
 msgstr "Votre nom complet sera"
 
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:219
@@ -8563,5 +8563,5 @@ msgid "Your report will be sent to the Bluesky Moderation Service"
 msgstr "Votre rapport sera envoyé au Service de Modération de Bluesky"
 
 #: src/screens/Signup/index.tsx:142
-msgid "Your user handle"
+msgid "Choose your username"
 msgstr "Votre pseudo"

--- a/src/locale/locales/ga/messages.po
+++ b/src/locale/locales/ga/messages.po
@@ -3508,7 +3508,7 @@ msgstr "Cuir isteach do phasfhocal"
 #~ msgstr "Cuir isteach an soláthraí óstála is fearr leat"
 
 #: src/screens/Signup/StepHandle.tsx:114
-msgid "Input your user handle"
+msgid "Type your desired username"
 msgstr "Cuir isteach do leasainm"
 
 #: src/view/com/composer/threadgate/ThreadgateBtn.tsx:49
@@ -8542,7 +8542,7 @@ msgid "Your following feed is empty! Follow more users to see what's happening."
 msgstr "Tá an fotha de na daoine a leanann tú folamh! Lean tuilleadh úsáideoirí le feiceáil céard atá ar siúl."
 
 #: src/screens/Signup/StepHandle.tsx:125
-msgid "Your full handle will be"
+msgid "Your full username will be"
 msgstr "Do leasainm iomlán anseo:"
 
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:219
@@ -8586,5 +8586,5 @@ msgid "Your report will be sent to the Bluesky Moderation Service"
 msgstr "Seolfar do thuairisc go dtí Seirbhís Modhnóireachta Bluesky"
 
 #: src/screens/Signup/index.tsx:142
-msgid "Your user handle"
+msgid "Choose your username"
 msgstr "Do leasainm"

--- a/src/locale/locales/gl/messages.po
+++ b/src/locale/locales/gl/messages.po
@@ -3896,7 +3896,7 @@ msgstr "Introduce o teu contrasinal"
 #~ msgstr "Introduce o teu proveedor de aloxamento preferido"
 
 #: src/screens/Signup/StepHandle.tsx:114
-msgid "Input your user handle"
+msgid "Type your desired username"
 msgstr "Introduce o teu alcume"
 
 #: src/view/com/composer/threadgate/ThreadgateBtn.tsx:49
@@ -9523,7 +9523,7 @@ msgid "Your following feed is empty! Follow more users to see what's happening."
 msgstr "A seguinte canle está baleira! Sigue a máis persoas para ver o que está a acontecer."
 
 #: src/screens/Signup/StepHandle.tsx:125
-msgid "Your full handle will be"
+msgid "Your full username will be"
 msgstr "O teu alcume completo será"
 
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:219
@@ -9567,5 +9567,5 @@ msgid "Your report will be sent to the Bluesky Moderation Service"
 msgstr "O teu informe enviarase ao Servizo de moderación de Bluesky"
 
 #: src/screens/Signup/index.tsx:142
-msgid "Your user handle"
+msgid "Choose your username"
 msgstr "O teu alcume"

--- a/src/locale/locales/hi/messages.po
+++ b/src/locale/locales/hi/messages.po
@@ -3780,7 +3780,7 @@ msgstr "अपना पासवर्ड दर्ज करें"
 #~ msgstr "अपना पसंदीदा होस्टिंग प्रदाता दर्ज करें"
 
 #: src/screens/Signup/StepHandle.tsx:114
-msgid "Input your user handle"
+msgid "Type your desired username"
 msgstr "अपना उपयोगकर्ता हैंडल दर्ज करें"
 
 #: src/view/com/composer/threadgate/ThreadgateBtn.tsx:49
@@ -9026,7 +9026,7 @@ msgid "Your following feed is empty! Follow more users to see what's happening."
 msgstr "आपका फ़ॉलोइंग फ़ीड खाली है! क्या चल रहा है जानने के लिए और उपयोगकर्ताओं को फ़ॉलो करें।"
 
 #: src/screens/Signup/StepHandle.tsx:125
-msgid "Your full handle will be"
+msgid "Your full username will be"
 msgstr "आपका पूरा हैंडल होगा"
 
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:219
@@ -9070,5 +9070,5 @@ msgid "Your report will be sent to the Bluesky Moderation Service"
 msgstr "आपके शिकायत को Bluesky मॉडरेशन सेवा को भेजा जाएगा।"
 
 #: src/screens/Signup/index.tsx:142
-msgid "Your user handle"
+msgid "Choose your username"
 msgstr "आपका उपयोगकर्ता हैंडल"

--- a/src/locale/locales/hu/messages.po
+++ b/src/locale/locales/hu/messages.po
@@ -3465,7 +3465,7 @@ msgstr "Jelszó megadása"
 #~ msgstr "Kívánt tárhelyszolgáltató megadása"
 
 #: src/screens/Signup/StepHandle.tsx:114
-msgid "Input your user handle"
+msgid "Type your desired username"
 msgstr "Felhasználónév megadása"
 
 #: src/view/com/composer/threadgate/ThreadgateBtn.tsx:49
@@ -8439,7 +8439,7 @@ msgid "Your following feed is empty! Follow more users to see what's happening."
 msgstr "A Követett hírfolyamod üres. Kövess több felhasználót, hogy lásd, mi történik!"
 
 #: src/screens/Signup/StepHandle.tsx:125
-msgid "Your full handle will be"
+msgid "Your full username will be"
 msgstr "A teljes felhasználóneved:"
 
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:219
@@ -8482,5 +8482,5 @@ msgid "Your report will be sent to the Bluesky Moderation Service"
 msgstr "Ez a jelentés a Bluesky moderálási szolgáltatásának lesz elküldve"
 
 #: src/screens/Signup/index.tsx:142
-msgid "Your user handle"
+msgid "Choose your username"
 msgstr "Saját felhasználónév"

--- a/src/locale/locales/id/messages.po
+++ b/src/locale/locales/id/messages.po
@@ -4007,7 +4007,7 @@ msgstr "Masukkan kata sandi Anda"
 #~ msgstr "Masukkan penyedia hosting pilihan Anda"
 
 #: src/screens/Signup/StepHandle.tsx:114
-msgid "Input your user handle"
+msgid "Type your desired username"
 msgstr "Masukkan panggilan Anda"
 
 #: src/view/com/composer/threadgate/ThreadgateBtn.tsx:49
@@ -9678,7 +9678,7 @@ msgid "Your following feed is empty! Follow more users to see what's happening."
 msgstr "Feed mengikuti Anda kosong! Ikuti lebih banyak pengguna untuk melihat apa yang terjadi."
 
 #: src/screens/Signup/StepHandle.tsx:125
-msgid "Your full handle will be"
+msgid "Your full username will be"
 msgstr "Panggilan lengkap Anda akan menjadi"
 
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:219
@@ -9722,5 +9722,5 @@ msgid "Your report will be sent to the Bluesky Moderation Service"
 msgstr "Laporan Anda akan dikirim ke Layanan Moderasi Bluesky"
 
 #: src/screens/Signup/index.tsx:142
-msgid "Your user handle"
+msgid "Choose your username"
 msgstr "Panggilan Anda"

--- a/src/locale/locales/it/messages.po
+++ b/src/locale/locales/it/messages.po
@@ -3318,7 +3318,7 @@ msgid "Input your password"
 msgstr "Inserisci la tua password"
 
 #: src/screens/Signup/StepHandle.tsx:114
-msgid "Input your user handle"
+msgid "Type your desired username"
 msgstr "Inserisci il tuo nome utente"
 
 #: src/view/com/composer/threadgate/ThreadgateBtn.tsx:49
@@ -8016,7 +8016,7 @@ msgid "Your following feed is empty! Follow more users to see what's happening."
 msgstr "Il tuo feed seguente è vuoto! Segui più utenti per vedere cosa sta succedendo."
 
 #: src/screens/Signup/StepHandle.tsx:125
-msgid "Your full handle will be"
+msgid "Your full username will be"
 msgstr "Il tuo nome utente completo sarà"
 
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:219
@@ -8056,5 +8056,5 @@ msgid "Your report will be sent to the Bluesky Moderation Service"
 msgstr "La tua segnalazione verrà inviata al Servizio Moderazione di Bluesky"
 
 #: src/screens/Signup/index.tsx:142
-msgid "Your user handle"
+msgid "Choose your username"
 msgstr "Il tuo nome utente"

--- a/src/locale/locales/ja/messages.po
+++ b/src/locale/locales/ja/messages.po
@@ -3317,7 +3317,7 @@ msgid "Input your password"
 msgstr "あなたのパスワードを入力"
 
 #: src/screens/Signup/StepHandle.tsx:114
-msgid "Input your user handle"
+msgid "Type your desired username"
 msgstr "あなたのユーザーハンドルを入力"
 
 #: src/view/com/composer/threadgate/ThreadgateBtn.tsx:49
@@ -8047,7 +8047,7 @@ msgid "Your following feed is empty! Follow more users to see what's happening."
 msgstr "Followingフィードは空です！もっと多くのユーザーをフォローして、近況を確認しましょう。"
 
 #: src/screens/Signup/StepHandle.tsx:125
-msgid "Your full handle will be"
+msgid "Your full username will be"
 msgstr "フルハンドルは"
 
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:219
@@ -8087,5 +8087,5 @@ msgid "Your report will be sent to the Bluesky Moderation Service"
 msgstr "あなたの報告はBluesky Moderation Serviceに送られます"
 
 #: src/screens/Signup/index.tsx:142
-msgid "Your user handle"
+msgid "Choose your username"
 msgstr "あなたのユーザーハンドル"

--- a/src/locale/locales/ko/messages.po
+++ b/src/locale/locales/ko/messages.po
@@ -3317,7 +3317,7 @@ msgid "Input your password"
 msgstr "비밀번호를 입력합니다"
 
 #: src/screens/Signup/StepHandle.tsx:114
-msgid "Input your user handle"
+msgid "Type your desired username"
 msgstr "사용자 핸들을 입력합니다"
 
 #: src/view/com/composer/threadgate/ThreadgateBtn.tsx:49
@@ -8019,7 +8019,7 @@ msgid "Your following feed is empty! Follow more users to see what's happening."
 msgstr "팔로우 중 피드가 비어 있습니다. 더 많은 사용자를 팔로우하여 무슨 일이 일어나고 있는지 확인하세요."
 
 #: src/screens/Signup/StepHandle.tsx:125
-msgid "Your full handle will be"
+msgid "Your full username will be"
 msgstr "내 전체 핸들:"
 
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:219
@@ -8059,5 +8059,5 @@ msgid "Your report will be sent to the Bluesky Moderation Service"
 msgstr "신고가 Bluesky Moderation Service로 보내집니다."
 
 #: src/screens/Signup/index.tsx:142
-msgid "Your user handle"
+msgid "Choose your username"
 msgstr "내 사용자 핸들"

--- a/src/locale/locales/nl/messages.po
+++ b/src/locale/locales/nl/messages.po
@@ -3496,7 +3496,7 @@ msgstr "Vul je wachtwoord in"
 #~ msgstr "Vul je voorkeurshostingprovider in"
 
 #: src/screens/Signup/StepHandle.tsx:114
-msgid "Input your user handle"
+msgid "Type your desired username"
 msgstr "Vul je gebruikershandle in."
 
 #: src/view/com/composer/threadgate/ThreadgateBtn.tsx:49
@@ -8506,7 +8506,7 @@ msgid "Your following feed is empty! Follow more users to see what's happening."
 msgstr "Je volgende feed is leeg! Volg meer gebruikers om te zien wat er gebeurt."
 
 #: src/screens/Signup/StepHandle.tsx:125
-msgid "Your full handle will be"
+msgid "Your full username will be"
 msgstr "Je volledige handle wordt"
 
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:219
@@ -8550,5 +8550,5 @@ msgid "Your report will be sent to the Bluesky Moderation Service"
 msgstr "Je melding wordt verzonden naar de Bluesky-moderatieservice"
 
 #: src/screens/Signup/index.tsx:142
-msgid "Your user handle"
+msgid "Choose your username"
 msgstr "Je gebruikershandle"

--- a/src/locale/locales/pl/messages.po
+++ b/src/locale/locales/pl/messages.po
@@ -3317,7 +3317,7 @@ msgid "Input your password"
 msgstr "Wpisz hasło"
 
 #: src/screens/Signup/StepHandle.tsx:114
-msgid "Input your user handle"
+msgid "Type your desired username"
 msgstr "Wpisz nazwę użytkownika"
 
 #: src/view/com/composer/threadgate/ThreadgateBtn.tsx:49
@@ -8031,7 +8031,7 @@ msgid "Your following feed is empty! Follow more users to see what's happening."
 msgstr "Twój kanał osób obserwowanych jest pusty! Zaobserwuj trochę więcej osób."
 
 #: src/screens/Signup/StepHandle.tsx:125
-msgid "Your full handle will be"
+msgid "Your full username will be"
 msgstr "Twoją pełna nazwa będzie"
 
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:219
@@ -8071,5 +8071,5 @@ msgid "Your report will be sent to the Bluesky Moderation Service"
 msgstr "Zgłoszenie będzie wysłane do usługi moderacji Bluesky"
 
 #: src/screens/Signup/index.tsx:142
-msgid "Your user handle"
+msgid "Choose your username"
 msgstr "Twoja nazwa użytkownika"

--- a/src/locale/locales/pt-BR/messages.po
+++ b/src/locale/locales/pt-BR/messages.po
@@ -4003,7 +4003,7 @@ msgstr "Insira sua senha"
 #~ msgstr "Insira seu provedor de hospedagem"
 
 #: src/screens/Signup/StepHandle.tsx:114
-msgid "Input your user handle"
+msgid "Type your desired username"
 msgstr "Insira o usuário"
 
 #: src/view/com/composer/threadgate/ThreadgateBtn.tsx:49
@@ -9667,7 +9667,7 @@ msgid "Your following feed is empty! Follow more users to see what's happening."
 msgstr "Seu feed inicial está vazio! Siga mais usuários para acompanhar o que está acontecendo."
 
 #: src/screens/Signup/StepHandle.tsx:125
-msgid "Your full handle will be"
+msgid "Your full username will be"
 msgstr "Seu identificador completo será"
 
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:219
@@ -9711,5 +9711,5 @@ msgid "Your report will be sent to the Bluesky Moderation Service"
 msgstr "Sua denúncia será enviada para o serviço de moderação do Bluesky"
 
 #: src/screens/Signup/index.tsx:142
-msgid "Your user handle"
+msgid "Choose your username"
 msgstr "Seu identificador de usuário"

--- a/src/locale/locales/ru/messages.po
+++ b/src/locale/locales/ru/messages.po
@@ -3578,7 +3578,7 @@ msgstr "Введите ваш пароль"
 #~ msgstr "Введите желаемого хостинг-провайдера"
 
 #: src/screens/Signup/StepHandle.tsx:114
-msgid "Input your user handle"
+msgid "Type your desired username"
 msgstr "Введите ваш псевдоним"
 
 #: src/view/com/composer/threadgate/ThreadgateBtn.tsx:49
@@ -8768,7 +8768,7 @@ msgid "Your following feed is empty! Follow more users to see what's happening."
 msgstr "Ваша домашняя лента пуста! Подпишитесь на больше пользователей чтобы получать больше постов."
 
 #: src/screens/Signup/StepHandle.tsx:125
-msgid "Your full handle will be"
+msgid "Your full username will be"
 msgstr "Ваш полный псевдоним будет"
 
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:219
@@ -8812,5 +8812,5 @@ msgid "Your report will be sent to the Bluesky Moderation Service"
 msgstr "Ваш отчет будет отправлен в Службу Модерации Bluesky."
 
 #: src/screens/Signup/index.tsx:142
-msgid "Your user handle"
+msgid "Choose your username"
 msgstr "Ваш псевдоним"

--- a/src/locale/locales/th/messages.po
+++ b/src/locale/locales/th/messages.po
@@ -3994,7 +3994,7 @@ msgstr "ป้อนรหัสผ่านของคุณ"
 #~ msgstr "กรอกผู้ให้บริการโฮสติ้งที่คุณต้องการ"
 
 #: src/screens/Signup/StepHandle.tsx:114
-msgid "Input your user handle"
+msgid "Type your desired username"
 msgstr "กรอกชื่อผู้ใช้ของคุณ"
 
 #: src/view/com/composer/threadgate/ThreadgateBtn.tsx:49
@@ -9665,7 +9665,7 @@ msgid "Your following feed is empty! Follow more users to see what's happening."
 msgstr "ฟีดผู้ติดตามของคุณว่างเปล่า! ติดตามผู้ใช้เพิ่มเติมเพื่อดูความเคลื่อนไหว"
 
 #: src/screens/Signup/StepHandle.tsx:125
-msgid "Your full handle will be"
+msgid "Your full username will be"
 msgstr "ชื่อผู้ใช้เต็มของคุณจะเป็น"
 
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:219
@@ -9709,5 +9709,5 @@ msgid "Your report will be sent to the Bluesky Moderation Service"
 msgstr "รายงานของคุณจะถูกส่งไปยัง Bluesky Moderation Service"
 
 #: src/screens/Signup/index.tsx:142
-msgid "Your user handle"
+msgid "Choose your username"
 msgstr "แฮนด์เดิลผู้ใช้ของคุณ"

--- a/src/locale/locales/tr/messages.po
+++ b/src/locale/locales/tr/messages.po
@@ -4211,7 +4211,7 @@ msgstr "Şifrenizi girin"
 #~ msgstr ""
 
 #: src/screens/Signup/StepHandle.tsx:114
-msgid "Input your user handle"
+msgid "Type your desired username"
 msgstr "Kullanıcı adınızı girin"
 
 #: src/view/com/composer/threadgate/ThreadgateBtn.tsx:49
@@ -10212,7 +10212,7 @@ msgid "Your following feed is empty! Follow more users to see what's happening."
 msgstr "Takip ettiğiniz besleme boş! Neler olduğunu görmek için daha fazla kullanıcı takip edin."
 
 #: src/screens/Signup/StepHandle.tsx:125
-msgid "Your full handle will be"
+msgid "Your full username will be"
 msgstr "Tam kullanıcı adınız"
 
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:219
@@ -10261,5 +10261,5 @@ msgid "Your report will be sent to the Bluesky Moderation Service"
 msgstr ""
 
 #: src/screens/Signup/index.tsx:142
-msgid "Your user handle"
+msgid "Choose your username"
 msgstr "Kullanıcı adınız"

--- a/src/locale/locales/uk/messages.po
+++ b/src/locale/locales/uk/messages.po
@@ -4007,7 +4007,7 @@ msgstr "Введіть ваш пароль"
 #~ msgstr "Введіть бажаного хостинг-провайдера"
 
 #: src/screens/Signup/StepHandle.tsx:114
-msgid "Input your user handle"
+msgid "Type your desired username"
 msgstr "Введіть ваш псевдонім"
 
 #: src/view/com/composer/threadgate/ThreadgateBtn.tsx:49
@@ -9678,7 +9678,7 @@ msgid "Your following feed is empty! Follow more users to see what's happening."
 msgstr "Ваша домашня стрічка порожня! Підпишіться на більше користувачів щоб отримувати більше постів."
 
 #: src/screens/Signup/StepHandle.tsx:125
-msgid "Your full handle will be"
+msgid "Your full username will be"
 msgstr "Ваш повний псевдонім буде"
 
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:219
@@ -9722,5 +9722,5 @@ msgid "Your report will be sent to the Bluesky Moderation Service"
 msgstr ""
 
 #: src/screens/Signup/index.tsx:142
-msgid "Your user handle"
+msgid "Choose your username"
 msgstr "Ваш псевдонім"

--- a/src/locale/locales/vi/messages.po
+++ b/src/locale/locales/vi/messages.po
@@ -3509,7 +3509,7 @@ msgstr "Nhập mật khẩu của bạn"
 #~ msgstr "Nhập nhà cung cấp lưu trữ theo lựa chọn của bạn"
 
 #: src/screens/Signup/StepHandle.tsx:114
-msgid "Input your user handle"
+msgid "Type your desired username"
 msgstr "Nhập tên người dùng của bạn"
 
 #: src/view/com/composer/threadgate/ThreadgateBtn.tsx:49
@@ -8543,7 +8543,7 @@ msgid "Your following feed is empty! Follow more users to see what's happening."
 msgstr "Bảng tin theo dõi còn trống! Hãy theo dõi thêm người dùng để biết có gì đang diễn ra."
 
 #: src/screens/Signup/StepHandle.tsx:125
-msgid "Your full handle will be"
+msgid "Your full username will be"
 msgstr "Tên người dùng đầy đủ của bạn sẽ là"
 
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:219
@@ -8587,5 +8587,5 @@ msgid "Your report will be sent to the Bluesky Moderation Service"
 msgstr "Báo cáo của bạn sẽ được gởi đến dịch vụ kiểm duyệt của Bluesky"
 
 #: src/screens/Signup/index.tsx:142
-msgid "Your user handle"
+msgid "Choose your username"
 msgstr "Tên người dùng của bạn"

--- a/src/locale/locales/zh-CN/messages.po
+++ b/src/locale/locales/zh-CN/messages.po
@@ -3314,7 +3314,7 @@ msgid "Input your password"
 msgstr "输入你的密码"
 
 #: src/screens/Signup/StepHandle.tsx:114
-msgid "Input your user handle"
+msgid "Type your desired username"
 msgstr "输入你的账户代码"
 
 #: src/view/com/composer/threadgate/ThreadgateBtn.tsx:49
@@ -8004,7 +8004,7 @@ msgid "Your following feed is empty! Follow more users to see what's happening."
 msgstr "你的“Following”动态源是空的！关注更多用户去看看他们发了什么。"
 
 #: src/screens/Signup/StepHandle.tsx:125
-msgid "Your full handle will be"
+msgid "Your full username will be"
 msgstr "你的完整账户代码将修改为"
 
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:219
@@ -8044,5 +8044,5 @@ msgid "Your report will be sent to the Bluesky Moderation Service"
 msgstr "你的举报将发送至 Bluesky 内容审核服务"
 
 #: src/screens/Signup/index.tsx:142
-msgid "Your user handle"
+msgid "Choose your username"
 msgstr "你的账户代码"

--- a/src/locale/locales/zh-HK/messages.po
+++ b/src/locale/locales/zh-HK/messages.po
@@ -3314,7 +3314,7 @@ msgid "Input your password"
 msgstr "輸入你嘅密碼"
 
 #: src/screens/Signup/StepHandle.tsx:114
-msgid "Input your user handle"
+msgid "Type your desired username"
 msgstr "輸入你嘅帳號頭銜"
 
 #: src/view/com/composer/threadgate/ThreadgateBtn.tsx:49
@@ -8004,7 +8004,7 @@ msgid "Your following feed is empty! Follow more users to see what's happening."
 msgstr "你嘅「Following」動態源得個吉！跟多啲用戶睇吓發生緊啲咩事。"
 
 #: src/screens/Signup/StepHandle.tsx:125
-msgid "Your full handle will be"
+msgid "Your full username will be"
 msgstr "你嘅完整帳號頭銜會係"
 
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:219
@@ -8044,5 +8044,5 @@ msgid "Your report will be sent to the Bluesky Moderation Service"
 msgstr "你嘅上報會傳送去 Bluesky 審核服務"
 
 #: src/screens/Signup/index.tsx:142
-msgid "Your user handle"
+msgid "Choose your username"
 msgstr "你嘅帳號頭銜"

--- a/src/locale/locales/zh-TW/messages.po
+++ b/src/locale/locales/zh-TW/messages.po
@@ -3314,7 +3314,7 @@ msgid "Input your password"
 msgstr "輸入您的密碼"
 
 #: src/screens/Signup/StepHandle.tsx:114
-msgid "Input your user handle"
+msgid "Type your desired username"
 msgstr "輸入您的帳號代碼"
 
 #: src/view/com/composer/threadgate/ThreadgateBtn.tsx:49
@@ -8004,7 +8004,7 @@ msgid "Your following feed is empty! Follow more users to see what's happening."
 msgstr "您的「Following」動態源是空的！跟隨更多用戶來看看發生了什麼事情。"
 
 #: src/screens/Signup/StepHandle.tsx:125
-msgid "Your full handle will be"
+msgid "Your full username will be"
 msgstr "您的完整帳號代碼將修改為"
 
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:219
@@ -8044,5 +8044,5 @@ msgid "Your report will be sent to the Bluesky Moderation Service"
 msgstr "您的檢舉將傳送至 Bluesky 內容管理服務"
 
 #: src/screens/Signup/index.tsx:142
-msgid "Your user handle"
+msgid "Choose your username"
 msgstr "您的帳號代碼"

--- a/src/screens/Signup/StepHandle.tsx
+++ b/src/screens/Signup/StepHandle.tsx
@@ -111,7 +111,7 @@ export function StepHandle() {
                 handleValueRef.current = val
                 setDraftValue(val)
               }}
-              label={_(msg`Input your user handle`)}
+              label={_(msg`Type your desired username`)}
               defaultValue={draftValue}
               autoCapitalize="none"
               autoCorrect={false}
@@ -122,7 +122,7 @@ export function StepHandle() {
         </View>
         {draftValue !== '' && (
           <Text style={[a.text_md]}>
-            <Trans>Your full handle will be</Trans>{' '}
+            <Trans>Your full username will be</Trans>{' '}
             <Text style={[a.text_md, a.font_bold]}>
               @{createFullHandle(draftValue, state.userDomain)}
             </Text>

--- a/src/screens/Signup/index.tsx
+++ b/src/screens/Signup/index.tsx
@@ -139,7 +139,7 @@ export function Signup({onPressBack}: {onPressBack: () => void}) {
                 {state.activeStep === SignupStep.INFO ? (
                   <Trans>Your account</Trans>
                 ) : state.activeStep === SignupStep.HANDLE ? (
-                  <Trans>Your user handle</Trans>
+                  <Trans>Choose your username</Trans>
                 ) : (
                   <Trans>Complete the challenge</Trans>
                 )}


### PR DESCRIPTION
People get confused here unsure what "handle" is. "Input your handle" is also confusing.

The first commit replaces the wordings.

<img width="371" alt="Screenshot 2024-12-17 at 00 02 59" src="https://github.com/user-attachments/assets/cbc9d449-3ee4-47ab-a3bb-bc9aa46062e2" />

This matches our usage of "username" on the login screen.

The second commit is a bit unusual — I'm updating all translations as if this was the wording all along. That's to avoid regressions to translations just before the release. It's fine to update them later (if needed per language) since conceptually the phrasing is the same and the meaning has not changed.

It's a little inconsistent with what we have in Settings. Maybe in the future we'll change it there too. But for now let's make sure people are able to create an account.

## Test Plan

Verify above for English.

Then `yarn intl:build` and verify translations have not regressed and show old strings:

<img width="388" alt="Screenshot 2024-12-17 at 00 01 50" src="https://github.com/user-attachments/assets/324a3b3c-c168-4aaf-8253-2ad219c4f813" />
