### PR TITLE
Read storage on window.onstorage

### DIFF
--- a/src/state/persisted/index.web.ts
+++ b/src/state/persisted/index.web.ts
@@ -24,6 +24,7 @@ const _emitter = new EventEmitter()
 
 export async function init() {
   broadcast.onmessage = onBroadcastMessage
+  window.onstorage = onStorage
   const stored = readFromStorage()
   if (stored) {
     _state = stored
@@ -89,6 +90,17 @@ export async function clearStorage() {
   }
 }
 clearStorage satisfies PersistedApi['clearStorage']
+
+function onStorage() {
+  const next = readFromStorage()
+  if (next === _state) {
+    return
+  }
+  if (next) {
+    _state = next
+    _emitter.emit('update')
+  }
+}
 
 async function onBroadcastMessage({data}: MessageEvent) {
   if (


### PR DESCRIPTION
This fixes an issue @estrattonbailey discovered. `BroadcastChannel` is arriving sooner than `localStorage` flushes the write to disk so we'd often read the storage data prematurely. This results in tabs failing to sync. This is most noticeable if you open two Settings screen in different windows and try to toggle some settings.

The fix I'm suggesting here is to rely on the window `storage` which fires when another document (i.e. another tab/window) has changed the storage. In either case we would bail if the contents of the storage is the same as before so it doesn't hurt to add an extra check like this.

## Test Plan


### Before

https://github.com/user-attachments/assets/41914c86-c2b1-4d11-b609-59919507dcca

https://github.com/user-attachments/assets/9dd66721-ebea-4353-9fc7-d7108273ab04

https://github.com/user-attachments/assets/c231d186-3103-4ea4-9709-d408075b6df7

### After

https://github.com/user-attachments/assets/6f5ea56e-8833-411a-9080-d9a2a7f30d3a

https://github.com/user-attachments/assets/38d7797e-9b41-4af3-8a43-67b0d7f867aa

https://github.com/user-attachments/assets/e2cb45f2-d9d8-4fc4-8d87-576a850f689a

