### PR TITLE
Fix notifications borders

### DIFF
--- a/src/view/com/notifications/NotificationFeed.tsx
+++ b/src/view/com/notifications/NotificationFeed.tsx
@@ -134,7 +134,7 @@ export function NotificationFeed({
           highlightUnread={filter === 'all'}
           item={item}
           moderationOpts={moderationOpts!}
-          hideTopBorder={index === 0 && item.notification.isRead}
+          hideTopBorder={index === 0}
         />
       )
     },

--- a/src/view/com/pager/TabBar.web.tsx
+++ b/src/view/com/pager/TabBar.web.tsx
@@ -145,7 +145,7 @@ export function TabBar({
 const desktopStyles = StyleSheet.create({
   outer: {
     flexDirection: 'row',
-    width: 598,
+    width: 600,
   },
   contentContainer: {
     flexGrow: 1,


### PR DESCRIPTION
Fixes the layout shift when marking notification as read. I regressed on this in #7044. Also fixes the web border being off by 2 pixels on the right (might be post layout refactor).

## Test Plan

No longer shifting layout:


https://github.com/user-attachments/assets/e6056f52-fda4-42ac-a0f9-61719a650c15


Note that this makes a solo highlighted notif have no top border on PTR:


https://github.com/user-attachments/assets/5d6a67d3-cc0a-4c0a-b8fe-6e370d868fc5


I think that's fine personally. We could maybe special case it to add border but meh.