### PR TITLE
Pipe statsig events to logger

### DIFF
--- a/jest/jestSetup.js
+++ b/jest/jestSetup.js
@@ -105,3 +105,19 @@ jest.mock('expo-modules-core', () => ({
     return () => null
   }),
 }))
+
+jest.mock('expo-localization', () => ({
+  getLocales: () => [],
+}))
+
+jest.mock('statsig-react-native-expo', () => ({
+  Statsig: {
+    initialize() {},
+    initializeCalled() {
+      return false
+    },
+  },
+}))
+
+jest.mock('../src/lib/bitdrift', () => ({}))
+jest.mock('../src/lib/statsig/statsig', () => ({}))

--- a/src/lib/bitdrift.ts
+++ b/src/lib/bitdrift.ts
@@ -1,5 +1,6 @@
 import {init} from '@bitdrift/react-native'
 import {Statsig} from 'statsig-react-native-expo'
+export {debug, error, info, warn} from '@bitdrift/react-native'
 
 import {initPromise} from './statsig/statsig'
 

--- a/src/lib/bitdrift.ts
+++ b/src/lib/bitdrift.ts
@@ -6,18 +6,16 @@ import {initPromise} from './statsig/statsig'
 
 const BITDRIFT_API_KEY = process.env.BITDRIFT_API_KEY
 
-if (process.env.NODE_ENV !== 'test') {
-  initPromise.then(() => {
-    let isEnabled = false
-    try {
-      if (Statsig.checkGate('enable_bitdrift')) {
-        isEnabled = true
-      }
-    } catch (e) {
-      // Statsig may complain about it being called too early.
+initPromise.then(() => {
+  let isEnabled = false
+  try {
+    if (Statsig.checkGate('enable_bitdrift')) {
+      isEnabled = true
     }
-    if (isEnabled && BITDRIFT_API_KEY) {
-      init(BITDRIFT_API_KEY, {url: 'https://api-bsky.bitdrift.io'})
-    }
-  })
-}
+  } catch (e) {
+    // Statsig may complain about it being called too early.
+  }
+  if (isEnabled && BITDRIFT_API_KEY) {
+    init(BITDRIFT_API_KEY, {url: 'https://api-bsky.bitdrift.io'})
+  }
+})

--- a/src/lib/bitdrift.ts
+++ b/src/lib/bitdrift.ts
@@ -6,16 +6,18 @@ import {initPromise} from './statsig/statsig'
 
 const BITDRIFT_API_KEY = process.env.BITDRIFT_API_KEY
 
-initPromise.then(() => {
-  let isEnabled = false
-  try {
-    if (Statsig.checkGate('enable_bitdrift')) {
-      isEnabled = true
+if (process.env.NODE_ENV !== 'test') {
+  initPromise.then(() => {
+    let isEnabled = false
+    try {
+      if (Statsig.checkGate('enable_bitdrift')) {
+        isEnabled = true
+      }
+    } catch (e) {
+      // Statsig may complain about it being called too early.
     }
-  } catch (e) {
-    // Statsig may complain about it being called too early.
-  }
-  if (isEnabled && BITDRIFT_API_KEY) {
-    init(BITDRIFT_API_KEY, {url: 'https://api-bsky.bitdrift.io'})
-  }
-})
+    if (isEnabled && BITDRIFT_API_KEY) {
+      init(BITDRIFT_API_KEY, {url: 'https://api-bsky.bitdrift.io'})
+    }
+  })
+}

--- a/src/lib/bitdrift.web.ts
+++ b/src/lib/bitdrift.web.ts
@@ -1,0 +1,4 @@
+export function debug() {}
+export function error() {}
+export function info() {}
+export function warn() {}

--- a/src/lib/statsig/statsig.tsx
+++ b/src/lib/statsig/statsig.tsx
@@ -103,20 +103,11 @@ export function logEvent<E extends keyof LogEvents>(
     if (Statsig.initializeCalled()) {
       Statsig.logEvent(eventName, null, fullMetadata)
     }
-    // Intentionally call console and bitdrift directly so we can pass rich objects.
-    if (isWeb) {
-      console.groupCollapsed(eventName)
-      console.log(fullMetadata)
-      console.groupEnd()
-    } else {
-      bitdrift.info(eventName, fullMetadata)
-      console.log(
-        eventName,
-        '\x1b[2m', // dim
-        fullMetadata,
-        '\x1b[0m', // undim
-      )
-    }
+    // Intentionally bypass the logger abstraction to log rich objects.
+    console.groupCollapsed(eventName)
+    console.log(fullMetadata)
+    console.groupEnd()
+    bitdrift.info(eventName, fullMetadata)
   } catch (e) {
     // A log should never interrupt the calling code, whatever happens.
     logger.error('Failed to log an event', {message: e})

--- a/src/lib/statsig/statsig.tsx
+++ b/src/lib/statsig/statsig.tsx
@@ -104,6 +104,8 @@ export function logEvent<E extends keyof LogEvents>(
     if (Statsig.initializeCalled()) {
       Statsig.logEvent(eventName, null, fullMetadata)
     }
+    logger.info(eventName)
+    logger.debug(JSON.stringify(fullMetadata))
   } catch (e) {
     // A log should never interrupt the calling code, whatever happens.
     logger.error('Failed to log an event', {message: e})

--- a/src/logger/bitdriftTransport.ts
+++ b/src/logger/bitdriftTransport.ts
@@ -3,8 +3,7 @@ import {
   error as bdError,
   info as bdInfo,
   warn as bdWarn,
-} from '@bitdrift/react-native'
-
+} from '../lib/bitdrift'
 import {LogLevel, Transport} from './types'
 
 export function createBitdriftTransport(): Transport {
@@ -18,6 +17,6 @@ export function createBitdriftTransport(): Transport {
 
   return (level, message) => {
     const log = logFunctions[level]
-    log(message.toString())
+    log('' + message)
   }
 }

--- a/src/logger/bitdriftTransport.web.ts
+++ b/src/logger/bitdriftTransport.web.ts
@@ -1,7 +1,0 @@
-import {Transport} from './index'
-
-export function createBitdriftTransport(): Transport {
-  return (_level, _message) => {
-    // noop
-  }
-}

--- a/src/state/session/__tests__/session-test.ts
+++ b/src/state/session/__tests__/session-test.ts
@@ -4,23 +4,10 @@ import {describe, expect, it, jest} from '@jest/globals'
 import {agentToSessionAccountOrThrow} from '../agent'
 import {Action, getInitialState, reducer, State} from '../reducer'
 
-jest.mock('statsig-react-native-expo', () => ({
-  Statsig: {
-    initialize() {},
-    initializeCalled() {
-      return false
-    },
-  },
-}))
-
 jest.mock('jwt-decode', () => ({
   jwtDecode(_token: string) {
     return {}
   },
-}))
-
-jest.mock('expo-localization', () => ({
-  getLocales: () => [],
 }))
 
 describe('session', () => {


### PR DESCRIPTION
This has two purposes:

- Make them more visible in the console so we can spot mistakes (like we used to do with Mixpanel)
- Have them also go into Bitdrift local buffer (so that they're queryable on demand automatically)

I've revamped the way Bitdrift is wired up so that our `logger` still logs into it but you can also log into it directly. So that you can push record maps too. I've noticed Bitdrift crashes with non-string values (it's strict about `Record<string, string>`) so I took the opportunity to clean up how we send Statsig metadata as well (since it also _wants_ `Record<string, string>`). I verified the serialization result is the same to how Statsig currently handles it in practice.

## Test Plan

You'd need to use the JS debugger to see this for native:

https://github.com/user-attachments/assets/ec728dcc-3060-4c6d-8985-50a7aa9e3643

This is because I'm using `groupCollapsed` which just completely omits them from the default console. That's fine, the default Metro console is going away in the future. (I tried a few other ideas but I didn't like how it looked.)

Same UI on web:

https://github.com/user-attachments/assets/80a704cc-d224-4bd0-9b88-aa2e6a4526fa

