### PR TITLE
[Discover] Filter out globally seen posts client-side

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "base64-js": "^1.5.1",
     "bcp-47": "^2.1.0",
     "bcp-47-match": "^2.0.3",
-    "bloomfilter": "^0.0.18",
+    "bloomfilter": "^0.0.19",
     "date-fns": "^2.30.0",
     "deprecated-react-native-prop-types": "^5.0.0",
     "email-validator": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "base64-js": "^1.5.1",
     "bcp-47": "^2.1.0",
     "bcp-47-match": "^2.0.3",
+    "bloomfilter": "^0.0.18",
     "date-fns": "^2.30.0",
     "deprecated-react-native-prop-types": "^5.0.0",
     "email-validator": "^2.0.4",

--- a/src/state/feed-feedback.tsx
+++ b/src/state/feed-feedback.tsx
@@ -20,7 +20,15 @@ type StateContext = {
 
 const stateContext = React.createContext<StateContext>({
   enabled: false,
-  onItemSeen: (_item: any) => {},
+  onItemSeen: (feedItem: any) => {
+    const slice = getFeedPostSlice(feedItem)
+    if (slice === null) {
+      return
+    }
+    for (const postItem of slice.items) {
+      markGloballySeenPost(postItem.uri)
+    }
+  },
   sendInteraction: (_interaction: AppBskyFeedDefs.Interaction) => {},
 })
 

--- a/src/state/feed-feedback.tsx
+++ b/src/state/feed-feedback.tsx
@@ -265,7 +265,7 @@ const m = Math.ceil((n * Math.log(p)) / Math.log(1 / Math.pow(2, Math.log(2))))
 const k = Math.round((m / n) * Math.log(2))
 let globalBloomFilter = new BloomFilter(m, k)
 
-function markGloballySeenPost(uri: string) {
+export function markGloballySeenPost(uri: string) {
   if (globalBloomFilter.size >= n) {
     // If we ever get here, just restart to avoid saturation.
     globalBloomFilter = new BloomFilter(m, k)

--- a/src/state/feed-feedback.tsx
+++ b/src/state/feed-feedback.tsx
@@ -274,7 +274,7 @@ const k = Math.round((m / n) * Math.log(2))
 let globalBloomFilter = new BloomFilter(m, k)
 
 export function markGloballySeenPost(uri: string) {
-  if (globalBloomFilter.size >= n) {
+  if (globalBloomFilter.size() >= n) {
     // If we ever get here, just restart to avoid saturation.
     globalBloomFilter = new BloomFilter(m, k)
   }

--- a/src/state/feed-feedback.tsx
+++ b/src/state/feed-feedback.tsx
@@ -273,14 +273,18 @@ const m = Math.ceil((n * Math.log(p)) / Math.log(1 / Math.pow(2, Math.log(2))))
 const k = Math.round((m / n) * Math.log(2))
 let globalBloomFilter = new BloomFilter(m, k)
 
+const salt = Math.random().toString(36).slice(2)
+
 export function markGloballySeenPost(uri: string) {
   if (globalBloomFilter.size() >= n) {
     // If we ever get here, just restart to avoid saturation.
     globalBloomFilter = new BloomFilter(m, k)
   }
-  globalBloomFilter.add(uri)
+  const key = uri + salt
+  globalBloomFilter.add(key)
 }
 
 export function isLikelyGloballySeenPost(uri: string) {
-  return globalBloomFilter.test(uri)
+  const key = uri + salt
+  return globalBloomFilter.test(key)
 }

--- a/src/state/feed-feedback.tsx
+++ b/src/state/feed-feedback.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import {AppState, AppStateStatus} from 'react-native'
 import {AppBskyFeedDefs} from '@atproto/api'
+// @ts-ignore
+import {BloomFilter} from 'bloomfilter'
 import throttle from 'lodash.throttle'
 
 import {PROD_DEFAULT_FEED} from '#/lib/constants'
@@ -93,24 +95,25 @@ export function useFeedFeedback(feed: FeedDescriptor, hasSession: boolean) {
 
   const onItemSeen = React.useCallback(
     (feedItem: any) => {
-      if (!enabled) {
-        return
-      }
       const slice = getFeedPostSlice(feedItem)
       if (slice === null) {
         return
       }
       for (const postItem of slice.items) {
-        if (!history.current.has(postItem)) {
-          history.current.add(postItem)
-          queue.current.add(
-            toString({
-              item: postItem.uri,
-              event: 'app.bsky.feed.defs#interactionSeen',
-              feedContext: slice.feedContext,
-            }),
-          )
-          sendToFeed()
+        markGloballySeenPost(postItem.uri)
+
+        if (enabled) {
+          if (!history.current.has(postItem)) {
+            history.current.add(postItem)
+            queue.current.add(
+              toString({
+                item: postItem.uri,
+                event: 'app.bsky.feed.defs#interactionSeen',
+                feedContext: slice.feedContext,
+              }),
+            )
+            sendToFeed()
+          }
         }
       }
     },
@@ -253,4 +256,23 @@ function flushToStatsig(stats: AggregatedStats | null) {
     })
     stats.seenCount = 0
   }
+}
+
+// https://hur.st/bloomfilter/?n=50k&p=0.001&m=&k=
+const p = 0.001 // 0.1% probability of collisions...
+const n = 50_000 // ...while we stay below 50k expected items
+const m = Math.ceil((n * Math.log(p)) / Math.log(1 / Math.pow(2, Math.log(2))))
+const k = Math.round((m / n) * Math.log(2))
+let globalBloomFilter = new BloomFilter(m, k)
+
+function markGloballySeenPost(uri: string) {
+  if (globalBloomFilter.size >= n) {
+    // If we ever get here, just restart to avoid saturation.
+    globalBloomFilter = new BloomFilter(m, k)
+  }
+  globalBloomFilter.add(uri)
+}
+
+export function isLikelyGloballySeenPost(uri: string) {
+  return globalBloomFilter.test(uri)
 }

--- a/src/view/com/post-thread/PostThread.tsx
+++ b/src/view/com/post-thread/PostThread.tsx
@@ -395,7 +395,7 @@ export function PostThread({uri}: {uri: string | undefined}) {
   useEffect(() => {
     if (skeleton) {
       // We're not tracking linger time here so conservatively mark
-      // just the highlighted post and the parent. Presumably,
+      // just the highlighted post and the parents. Presumably,
       // if you're already midthread, you know what was above.
       const {parents, highlightedPost} = skeleton
       markGloballySeenPost(highlightedPost.uri)

--- a/yarn.lock
+++ b/yarn.lock
@@ -8200,6 +8200,11 @@ bl@^4.0.3, bl@^4.1.0:
     inherits "^2.0.4"
     readable-stream "^3.4.0"
 
+bloomfilter@^0.0.18:
+  version "0.0.18"
+  resolved "https://registry.yarnpkg.com/bloomfilter/-/bloomfilter-0.0.18.tgz#6d55d34f0a214b235287b4eac9203ac623413dab"
+  integrity sha512-CbnyHE78gY1tpXS/Ap+B0RJxKdRWCDzjBnX97UJSG8rdLv1PK8GiTWc/CCQyWu6PWVD4lUceeFrqC6Mf3nMgOA==
+
 bn.js@^4.0.0, bn.js@^4.11.8, bn.js@^4.11.9:
   version "4.12.0"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.12.0.tgz#775b3f278efbb9718eec7361f483fb36fbbfea88"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3261,7 +3261,7 @@
     "@babel/parser" "^7.25.9"
     "@babel/types" "^7.25.9"
 
-"@babel/traverse--for-generate-function-map@npm:@babel/traverse@^7.25.3", "@babel/traverse@^7.25.3", "@babel/traverse@^7.25.9":
+"@babel/traverse--for-generate-function-map@npm:@babel/traverse@^7.25.3":
   version "7.25.9"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.25.9.tgz#a50f8fe49e7f69f53de5bea7e413cd35c5e13c84"
   integrity sha512-ZCuvfwOwlz/bawvAuvcj8rrithP2/N55Tzz342AkTvq4qaWbGfmCk/tKhNaV2cthijKrPAA8SRJV5WWe7IBMJw==
@@ -3319,6 +3319,19 @@
     "@babel/helper-split-export-declaration" "^7.24.5"
     "@babel/parser" "^7.24.5"
     "@babel/types" "^7.24.5"
+    debug "^4.3.1"
+    globals "^11.1.0"
+
+"@babel/traverse@^7.25.3", "@babel/traverse@^7.25.9":
+  version "7.25.9"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.25.9.tgz#a50f8fe49e7f69f53de5bea7e413cd35c5e13c84"
+  integrity sha512-ZCuvfwOwlz/bawvAuvcj8rrithP2/N55Tzz342AkTvq4qaWbGfmCk/tKhNaV2cthijKrPAA8SRJV5WWe7IBMJw==
+  dependencies:
+    "@babel/code-frame" "^7.25.9"
+    "@babel/generator" "^7.25.9"
+    "@babel/parser" "^7.25.9"
+    "@babel/template" "^7.25.9"
+    "@babel/types" "^7.25.9"
     debug "^4.3.1"
     globals "^11.1.0"
 
@@ -8200,10 +8213,10 @@ bl@^4.0.3, bl@^4.1.0:
     inherits "^2.0.4"
     readable-stream "^3.4.0"
 
-bloomfilter@^0.0.18:
-  version "0.0.18"
-  resolved "https://registry.yarnpkg.com/bloomfilter/-/bloomfilter-0.0.18.tgz#6d55d34f0a214b235287b4eac9203ac623413dab"
-  integrity sha512-CbnyHE78gY1tpXS/Ap+B0RJxKdRWCDzjBnX97UJSG8rdLv1PK8GiTWc/CCQyWu6PWVD4lUceeFrqC6Mf3nMgOA==
+bloomfilter@^0.0.19:
+  version "0.0.19"
+  resolved "https://registry.yarnpkg.com/bloomfilter/-/bloomfilter-0.0.19.tgz#3d0e62ce41fc8fe402533902cd27e09e6a738d43"
+  integrity sha512-WPhd8qNG79Gnz3i3Uk/wx/Dm6ghYV5sUsTmWGbiQNV7WvnsC8OTGZSe0WNXfPPsKDdxV2g6Q7JiO6af1BOGmXA==
 
 bn.js@^4.0.0, bn.js@^4.11.8, bn.js@^4.11.9:
   version "4.12.0"
@@ -17462,7 +17475,16 @@ string-natural-compare@^3.0.1:
   resolved "https://registry.yarnpkg.com/string-natural-compare/-/string-natural-compare-3.0.1.tgz#7a42d58474454963759e8e8b7ae63d71c1e7fdf4"
   integrity sha512-n3sPwynL1nwKi3WJ6AIsClwBMa0zTi54fn2oLU6ndfTSIO05xaznjSf15PcBZU6FNWbmN5Q6cxT4V5hGvB4taw==
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -17562,7 +17584,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -17575,6 +17597,13 @@ strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -18850,7 +18879,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -18863,6 +18892,15 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
We have a tension between two wants:

- We want Discover to avoid showing posts you've already seen
- Actually sending _every post you see_ (e.g. in Following) to Discover would be both too expensive on the server side to store and would have privacy implications if we ever wanted to extend this to third party feeds
  - But special-casing Discover forever, even though it is the primary feed in the app, isn't great either

The proposed solution here, which we arrived at after a discussion with @pfrazee and @whyrusleeping, is client-side deduplication. It's not perfect but it hits these points:

- It'll avoid showing posts you've already seen on the mobile app during the same session
  - Could be extended to multiple sessions if we serialize the buffer (it doesn't need to survive long)
  - Could be shared between browsers tabs in the future as well (for now it's not)
- It doesn't require any server computation
- In the longer run, we could imagine third party feeds declaring they want this capability on. Then Discover wouldn't need to be special-cased. Most third party feeds probably _don't_ want this so it would be opt-in.

## Test Plan

Add a log, verify posts get added to the buffer. Currently they get added:

- In any feeds, on linger
- In post thread, immediately for highlighted post + parent chain (we don't count linger there)

You can verify that with a log.

https://github.com/user-attachments/assets/4fbf5484-a0ee-44ac-ba28-e09cd9bdd27c

Then you can verify that it does the filtering. For that, add a log to where the filtering happens and log the post being filtered out. Then spend some time scrolling Following. Then go to Discover and repeatedly request it — if you're lucky, you'll trigger the behavior. Observe that the filtered post is not being displayed.

Verify logged-out Discover still works.

Verify the filtering is not being applied to other feeds.

## The Mechanism

I used a Bloom filter because it's cool. (?) No seriously, it's relatively light in memory (see the linked formula), otherwise a Set would be a lot larger. If we want to maintain continuity and serialize it or sync it between tabs, it'll get more complicated, but I think this is an OK start for now.

I'm doing this in the response handler rather than in the query or the feed tuner because it's not deterministic. The filter is mutable so we need to make sure we apply it once and consistently. Right before handing off the response seems like the perfect time.