### PR TITLE
Fix emoji picker position

### DIFF
--- a/src/view/com/composer/text-input/web/EmojiPicker.web.tsx
+++ b/src/view/com/composer/text-input/web/EmojiPicker.web.tsx
@@ -10,6 +10,7 @@ import {DismissableLayer} from '@radix-ui/react-dismissable-layer'
 
 import {textInputWebEmitter} from '#/view/com/composer/text-input/textInputWebEmitter'
 import {atoms as a} from '#/alf'
+import {Portal} from '#/components/Portal'
 
 const HEIGHT_OFFSET = 40
 const WIDTH_OFFSET = 100
@@ -125,39 +126,41 @@ export function EmojiPicker({state, close, pinToTop}: IProps) {
   }
 
   return (
-    <TouchableWithoutFeedback
-      accessibilityRole="button"
-      onPress={onPressBackdrop}
-      accessibilityViewIsModal>
-      <View
-        style={[
-          a.fixed,
-          a.w_full,
-          a.h_full,
-          a.align_center,
-          {
-            top: 0,
-            left: 0,
-            right: 0,
-          },
-        ]}>
-        {/* eslint-disable-next-line react-native-a11y/has-valid-accessibility-descriptors */}
-        <TouchableWithoutFeedback onPress={e => e.stopPropagation()}>
-          <View style={[{position: 'absolute'}, position]}>
-            <DismissableLayer
-              onFocusOutside={evt => evt.preventDefault()}
-              onDismiss={close}>
-              <Picker
-                data={async () => {
-                  return (await import('./EmojiPickerData.json')).default
-                }}
-                onEmojiSelect={onInsert}
-                autoFocus={true}
-              />
-            </DismissableLayer>
-          </View>
-        </TouchableWithoutFeedback>
-      </View>
-    </TouchableWithoutFeedback>
+    <Portal>
+      <TouchableWithoutFeedback
+        accessibilityRole="button"
+        onPress={onPressBackdrop}
+        accessibilityViewIsModal>
+        <View
+          style={[
+            a.fixed,
+            a.w_full,
+            a.h_full,
+            a.align_center,
+            {
+              top: 0,
+              left: 0,
+              right: 0,
+            },
+          ]}>
+          {/* eslint-disable-next-line react-native-a11y/has-valid-accessibility-descriptors */}
+          <TouchableWithoutFeedback onPress={e => e.stopPropagation()}>
+            <View style={[{position: 'absolute'}, position]}>
+              <DismissableLayer
+                onFocusOutside={evt => evt.preventDefault()}
+                onDismiss={close}>
+                <Picker
+                  data={async () => {
+                    return (await import('./EmojiPickerData.json')).default
+                  }}
+                  onEmojiSelect={onInsert}
+                  autoFocus={true}
+                />
+              </DismissableLayer>
+            </View>
+          </TouchableWithoutFeedback>
+        </View>
+      </TouchableWithoutFeedback>
+    </Portal>
   )
 }


### PR DESCRIPTION
Just needed to be wrapped in a Portal, otherwise it was being positioned relative to the center column. Floating elements like this should always be moved out to the root so they never conflict with other UI.

Test: chat and composer on web

After, before
![CleanShot 2024-12-17 at 18 18 27@2x](https://github.com/user-attachments/assets/f90df5f5-4a15-4995-974e-be586eea0378)
![CleanShot 2024-12-17 at 18 18 43@2x](https://github.com/user-attachments/assets/1037ebde-bfa7-4312-835e-3ef640f52e6e)
