### PR TITLE
Add reply sorting in-thread

### DIFF
--- a/src/components/Menu/index.tsx
+++ b/src/components/Menu/index.tsx
@@ -190,6 +190,55 @@ export function ItemIcon({icon: Comp}: ItemIconProps) {
   )
 }
 
+export function ItemRadio({selected}: {selected: boolean}) {
+  const t = useTheme()
+  return (
+    <View
+      style={[
+        a.justify_center,
+        a.align_center,
+        a.rounded_full,
+        t.atoms.border_contrast_high,
+        {
+          borderWidth: 1,
+          height: 24,
+          width: 24,
+        },
+      ]}>
+      {selected ? (
+        <View
+          style={[
+            a.absolute,
+            a.rounded_full,
+            {height: 16, width: 16},
+            selected
+              ? {
+                  backgroundColor: t.palette.primary_500,
+                }
+              : {},
+          ]}
+        />
+      ) : null}
+    </View>
+  )
+}
+
+export function LabelText({children}: {children: React.ReactNode}) {
+  const t = useTheme()
+  return (
+    <Text
+      style={[
+        a.font_bold,
+        t.atoms.text_contrast_medium,
+        {
+          marginBottom: -10,
+        },
+      ]}>
+      {children}
+    </Text>
+  )
+}
+
 export function Group({children, style}: GroupProps) {
   const t = useTheme()
   return (

--- a/src/components/Menu/index.tsx
+++ b/src/components/Menu/index.tsx
@@ -231,7 +231,7 @@ export function LabelText({children}: {children: React.ReactNode}) {
         a.font_bold,
         t.atoms.text_contrast_medium,
         {
-          marginBottom: -10,
+          marginBottom: -8,
         },
       ]}>
       {children}

--- a/src/components/Menu/index.web.tsx
+++ b/src/components/Menu/index.web.tsx
@@ -304,6 +304,57 @@ export function ItemIcon({icon: Comp, position = 'left'}: ItemIconProps) {
   )
 }
 
+export function ItemRadio({selected}: {selected: boolean}) {
+  const t = useTheme()
+  return (
+    <View
+      style={[
+        a.justify_center,
+        a.align_center,
+        a.rounded_full,
+        t.atoms.border_contrast_high,
+        {
+          borderWidth: 1,
+          height: 24,
+          width: 24,
+        },
+      ]}>
+      {selected ? (
+        <View
+          style={[
+            a.absolute,
+            a.rounded_full,
+            {height: 16, width: 16},
+            selected
+              ? {
+                  backgroundColor: t.palette.primary_500,
+                }
+              : {},
+          ]}
+        />
+      ) : null}
+    </View>
+  )
+}
+
+export function LabelText({children}: {children: React.ReactNode}) {
+  const t = useTheme()
+  return (
+    <Text
+      style={[
+        a.font_bold,
+        a.pt_lg,
+        a.pb_sm,
+        t.atoms.text_contrast_low,
+        {
+          paddingHorizontal: 10,
+        },
+      ]}>
+      {children}
+    </Text>
+  )
+}
+
 export function Group({children}: GroupProps) {
   return children
 }

--- a/src/screens/Settings/ThreadPreferences.tsx
+++ b/src/screens/Settings/ThreadPreferences.tsx
@@ -148,7 +148,7 @@ export function ThreadPreferencesScreen({}: Props) {
               }
               style={[a.w_full, a.gap_md]}>
               <Toggle.LabelText style={[a.flex_1]}>
-                <Trans>Show replies in a threaded view</Trans>
+                <Trans>Show replies as a tree</Trans>
               </Toggle.LabelText>
               <Toggle.Platform />
             </Toggle.Item>

--- a/src/screens/Settings/ThreadPreferences.tsx
+++ b/src/screens/Settings/ThreadPreferences.tsx
@@ -148,7 +148,7 @@ export function ThreadPreferencesScreen({}: Props) {
               }
               style={[a.w_full, a.gap_md]}>
               <Toggle.LabelText style={[a.flex_1]}>
-                <Trans>Show replies as a tree</Trans>
+                <Trans>Show replies as threaded</Trans>
               </Toggle.LabelText>
               <Toggle.Platform />
             </Toggle.Item>

--- a/src/view/com/post-thread/PostThread.tsx
+++ b/src/view/com/post-thread/PostThread.tsx
@@ -619,26 +619,26 @@ let ThreadMenu = ({
       </Menu.Trigger>
       <Menu.Outer>
         <Menu.LabelText>
-          <Trans>Thread display</Trans>
+          <Trans>Show replies as</Trans>
         </Menu.LabelText>
         <Menu.Group>
           <Menu.Item
-            label={_(msg`Show replies as a list`)}
+            label={_(msg`Linear`)}
             onPress={() => {
               setTreeViewEnabled(false)
             }}>
             <Menu.ItemText>
-              <Trans>Show replies as a list</Trans>
+              <Trans>Linear</Trans>
             </Menu.ItemText>
             <Menu.ItemRadio selected={!treeViewEnabled} />
           </Menu.Item>
           <Menu.Item
-            label={_(msg`Show replies as a tree`)}
+            label={_(msg`Threaded`)}
             onPress={() => {
               setTreeViewEnabled(true)
             }}>
             <Menu.ItemText>
-              <Trans>Show replies as a tree</Trans>
+              <Trans>Threaded</Trans>
             </Menu.ItemText>
             <Menu.ItemRadio selected={treeViewEnabled} />
           </Menu.Item>

--- a/src/view/com/post-thread/PostThread.tsx
+++ b/src/view/com/post-thread/PostThread.tsx
@@ -7,6 +7,7 @@ import {AppBskyFeedDefs, AppBskyFeedThreadgate} from '@atproto/api'
 import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
+import {HITSLOP_10} from '#/lib/constants'
 import {useInitialNumToRender} from '#/lib/hooks/useInitialNumToRender'
 import {useMinimalShellFabTransform} from '#/lib/hooks/useMinimalShellTransform'
 import {useSetTitle} from '#/lib/hooks/useSetTitle'
@@ -34,8 +35,11 @@ import {useComposerControls} from '#/state/shell'
 import {useMergedThreadgateHiddenReplies} from '#/state/threadgate-hidden-replies'
 import {List, ListMethods} from '#/view/com/util/List'
 import {atoms as a, useTheme} from '#/alf'
+import {Button, ButtonIcon} from '#/components/Button'
+import {SettingsSliderVertical_Stroke2_Corner0_Rounded as SettingsSlider} from '#/components/icons/SettingsSlider'
 import {Header} from '#/components/Layout'
 import {ListFooter, ListMaybePlaceholder} from '#/components/Lists'
+import * as Menu from '#/components/Menu'
 import {Text} from '#/components/Typography'
 import {PostThreadComposePrompt} from './PostThreadComposePrompt'
 import {PostThreadItem} from './PostThreadItem'
@@ -491,7 +495,60 @@ export function PostThread({uri}: {uri: string | undefined}) {
             <Trans context="description">Post</Trans>
           </Header.TitleText>
         </Header.Content>
-        <Header.Slot />
+        <Header.Slot>
+          <Menu.Root>
+            <Menu.Trigger label={_(msg`Account options`)}>
+              {({props}) => (
+                <Button
+                  label={_(msg`Thread options`)}
+                  size="small"
+                  variant="ghost"
+                  color="secondary"
+                  shape="round"
+                  hitSlop={HITSLOP_10}
+                  style={[{right: -3}]}
+                  {...props}>
+                  <ButtonIcon icon={SettingsSlider} size="md" />
+                </Button>
+              )}
+            </Menu.Trigger>
+            <Menu.Outer>
+              <Menu.Item label={_(msg`Hot replies first`)} onPress={() => {}}>
+                <Menu.ItemText>
+                  <Trans>Hot replies first</Trans>
+                </Menu.ItemText>
+              </Menu.Item>
+              <Menu.Item
+                label={_(msg`Oldest replies first`)}
+                onPress={() => {}}>
+                <Menu.ItemText>
+                  <Trans>Oldest replies first</Trans>
+                </Menu.ItemText>
+              </Menu.Item>
+              <Menu.Item
+                label={_(msg`Newest replies first`)}
+                onPress={() => {}}>
+                <Menu.ItemText>
+                  <Trans>Newest replies first</Trans>
+                </Menu.ItemText>
+              </Menu.Item>
+              <Menu.Item
+                label={_(msg`Most-liked replies first`)}
+                onPress={() => {}}>
+                <Menu.ItemText>
+                  <Trans>Most-liked replies first</Trans>
+                </Menu.ItemText>
+              </Menu.Item>
+              <Menu.Item
+                label={_(msg`Random (aka "Poster's Roulette")`)}
+                onPress={() => {}}>
+                <Menu.ItemText>
+                  <Trans>Random (aka "Poster's Roulette")</Trans>
+                </Menu.ItemText>
+              </Menu.Item>
+            </Menu.Outer>
+          </Menu.Root>
+        </Header.Slot>
       </Header.Outer>
 
       <ScrollProvider onMomentumEnd={onMomentumEnd}>

--- a/src/view/com/post-thread/PostThread.tsx
+++ b/src/view/com/post-thread/PostThread.tsx
@@ -1,4 +1,4 @@
-import React, {useRef} from 'react'
+import React, {memo, useRef} from 'react'
 import {StyleSheet, useWindowDimensions, View} from 'react-native'
 import {runOnJS} from 'react-native-reanimated'
 import Animated from 'react-native-reanimated'
@@ -498,7 +498,7 @@ export function PostThread({uri}: {uri: string | undefined}) {
           </Header.TitleText>
         </Header.Content>
         <Header.Slot>
-          <SortMenu />
+          <ThreadMenu />
         </Header.Slot>
       </Header.Outer>
 
@@ -545,15 +545,19 @@ export function PostThread({uri}: {uri: string | undefined}) {
   )
 }
 
-function SortMenu() {
+let ThreadMenu = ({}: {}): React.ReactNode => {
   const {_} = useLingui()
   const {data: preferences} = usePreferencesQuery()
   const {mutate: setThreadViewPrefs, variables} =
     useSetThreadViewPreferencesMutation()
-  const sortReplies = variables?.sort ?? preferences?.threadViewPrefs?.sort // TODO: Use it
+  const sortReplies = variables?.sort ?? preferences?.threadViewPrefs?.sort
+  const treeViewEnabled = Boolean(
+    variables?.lab_treeViewEnabled ??
+      preferences?.threadViewPrefs?.lab_treeViewEnabled,
+  )
   return (
     <Menu.Root>
-      <Menu.Trigger label={_(msg`Account options`)}>
+      <Menu.Trigger label={_(msg`Thread options`)}>
         {({props}) => (
           <Button
             label={_(msg`Thread options`)}
@@ -562,13 +566,39 @@ function SortMenu() {
             color="secondary"
             shape="round"
             hitSlop={HITSLOP_10}
-            style={[{right: -3}]}
             {...props}>
             <ButtonIcon icon={SettingsSlider} size="md" />
           </Button>
         )}
       </Menu.Trigger>
       <Menu.Outer>
+        <Menu.Group>
+          <Menu.Item
+            label={_(msg`Show replies as a list`)}
+            onPress={() => {
+              setThreadViewPrefs({
+                lab_treeViewEnabled: false,
+              })
+            }}>
+            <Menu.ItemText>
+              <Trans>Show replies as a list</Trans>
+            </Menu.ItemText>
+            <RadioCircle isSelected={!treeViewEnabled} />
+          </Menu.Item>
+          <Menu.Item
+            label={_(msg`Show replies as a tree`)}
+            onPress={() => {
+              setThreadViewPrefs({
+                lab_treeViewEnabled: true,
+              })
+            }}>
+            <Menu.ItemText>
+              <Trans>Show replies as a tree</Trans>
+            </Menu.ItemText>
+            <RadioCircle isSelected={treeViewEnabled} />
+          </Menu.Item>
+        </Menu.Group>
+        <Menu.Divider />
         <Menu.Group>
           <Menu.Item
             label={_(msg`Hot replies first`)}
@@ -625,6 +655,7 @@ function SortMenu() {
     </Menu.Root>
   )
 }
+ThreadMenu = memo(ThreadMenu)
 
 function MobileComposePrompt({onPressReply}: {onPressReply: () => unknown}) {
   const safeAreaInsets = useSafeAreaInsets()

--- a/src/view/com/post-thread/PostThread.tsx
+++ b/src/view/com/post-thread/PostThread.tsx
@@ -19,7 +19,6 @@ import {sanitizeDisplayName} from '#/lib/strings/display-names'
 import {cleanError} from '#/lib/strings/errors'
 import {isAndroid, isNative, isWeb} from '#/platform/detection'
 import {useModerationOpts} from '#/state/preferences/moderation-opts'
-import {useSetThreadViewPreferencesMutation} from '#/state/queries/preferences'
 import {
   fillThreadModerationCache,
   sortThread,
@@ -30,6 +29,7 @@ import {
   ThreadPost,
   usePostThreadQuery,
 } from '#/state/queries/post-thread'
+import {useSetThreadViewPreferencesMutation} from '#/state/queries/preferences'
 import {usePreferencesQuery} from '#/state/queries/preferences'
 import {useSession} from '#/state/session'
 import {useComposerControls} from '#/state/shell'
@@ -42,6 +42,7 @@ import {Header} from '#/components/Layout'
 import {ListFooter, ListMaybePlaceholder} from '#/components/Lists'
 import * as Menu from '#/components/Menu'
 import {Text} from '#/components/Typography'
+import {RadioCircle} from '../util/forms/RadioButton'
 import {PostThreadComposePrompt} from './PostThreadComposePrompt'
 import {PostThreadItem} from './PostThreadItem'
 import {PostThreadLoadMore} from './PostThreadLoadMore'
@@ -549,7 +550,7 @@ function SortMenu() {
   const {data: preferences} = usePreferencesQuery()
   const {mutate: setThreadViewPrefs, variables} =
     useSetThreadViewPreferencesMutation()
-  const _sortReplies = variables?.sort ?? preferences?.threadViewPrefs?.sort // TODO: Use it
+  const sortReplies = variables?.sort ?? preferences?.threadViewPrefs?.sort // TODO: Use it
   return (
     <Menu.Root>
       <Menu.Trigger label={_(msg`Account options`)}>
@@ -568,51 +569,58 @@ function SortMenu() {
         )}
       </Menu.Trigger>
       <Menu.Outer>
-        <Menu.Item
-          label={_(msg`Hot replies first`)}
-          onPress={() => {
-            setThreadViewPrefs({sort: 'hotness'})
-          }}>
-          <Menu.ItemText>
-            <Trans>Hot replies first</Trans>
-          </Menu.ItemText>
-        </Menu.Item>
-        <Menu.Item
-          label={_(msg`Oldest replies first`)}
-          onPress={() => {
-            setThreadViewPrefs({sort: 'oldest'})
-          }}>
-          <Menu.ItemText>
-            <Trans>Oldest replies first</Trans>
-          </Menu.ItemText>
-        </Menu.Item>
-        <Menu.Item
-          label={_(msg`Newest replies first`)}
-          onPress={() => {
-            setThreadViewPrefs({sort: 'newest'})
-          }}>
-          <Menu.ItemText>
-            <Trans>Newest replies first</Trans>
-          </Menu.ItemText>
-        </Menu.Item>
-        <Menu.Item
-          label={_(msg`Most-liked replies first`)}
-          onPress={() => {
-            setThreadViewPrefs({sort: 'most-likes'})
-          }}>
-          <Menu.ItemText>
-            <Trans>Most-liked replies first</Trans>
-          </Menu.ItemText>
-        </Menu.Item>
-        <Menu.Item
-          label={_(msg`Random (aka "Poster's Roulette")`)}
-          onPress={() => {
-            setThreadViewPrefs({sort: 'random'})
-          }}>
-          <Menu.ItemText>
-            <Trans>Random (aka "Poster's Roulette")</Trans>
-          </Menu.ItemText>
-        </Menu.Item>
+        <Menu.Group>
+          <Menu.Item
+            label={_(msg`Hot replies first`)}
+            onPress={() => {
+              setThreadViewPrefs({sort: 'hotness'})
+            }}>
+            <Menu.ItemText>
+              <Trans>Hot replies first</Trans>
+            </Menu.ItemText>
+            <RadioCircle isSelected={sortReplies === 'hotness'} />
+          </Menu.Item>
+          <Menu.Item
+            label={_(msg`Oldest replies first`)}
+            onPress={() => {
+              setThreadViewPrefs({sort: 'oldest'})
+            }}>
+            <Menu.ItemText>
+              <Trans>Oldest replies first</Trans>
+            </Menu.ItemText>
+            <RadioCircle isSelected={sortReplies === 'oldest'} />
+          </Menu.Item>
+          <Menu.Item
+            label={_(msg`Newest replies first`)}
+            onPress={() => {
+              setThreadViewPrefs({sort: 'newest'})
+            }}>
+            <Menu.ItemText>
+              <Trans>Newest replies first</Trans>
+            </Menu.ItemText>
+            <RadioCircle isSelected={sortReplies === 'newest'} />
+          </Menu.Item>
+          <Menu.Item
+            label={_(msg`Most-liked replies first`)}
+            onPress={() => {
+              setThreadViewPrefs({sort: 'most-likes'})
+            }}>
+            <Menu.ItemText>
+              <Trans>Most-liked replies first</Trans>
+            </Menu.ItemText>
+            <RadioCircle isSelected={sortReplies === 'most-likes'} />
+          </Menu.Item>
+          <Menu.Item
+            label={_(msg`Random (aka "Poster's Roulette")`)}
+            onPress={() => {
+              setThreadViewPrefs({sort: 'random'})
+            }}>
+            <Menu.ItemText>
+              <Trans>Random (aka "Poster's Roulette")</Trans>
+            </Menu.ItemText>
+            <RadioCircle isSelected={sortReplies === 'random'} />
+          </Menu.Item>
+        </Menu.Group>
       </Menu.Outer>
     </Menu.Root>
   )

--- a/src/view/com/post-thread/PostThread.tsx
+++ b/src/view/com/post-thread/PostThread.tsx
@@ -1,4 +1,4 @@
-import React, {memo, useRef} from 'react'
+import React, {memo, useRef, useState} from 'react'
 import {StyleSheet, useWindowDimensions, View} from 'react-native'
 import {runOnJS} from 'react-native-reanimated'
 import Animated from 'react-native-reanimated'
@@ -547,6 +547,7 @@ export function PostThread({uri}: {uri: string | undefined}) {
 
 let ThreadMenu = ({}: {}): React.ReactNode => {
   const {_} = useLingui()
+  const {hasSession} = useSession()
   const {data: preferences} = usePreferencesQuery()
   const {mutate: setThreadViewPrefs, variables} =
     useSetThreadViewPreferencesMutation()
@@ -555,6 +556,11 @@ let ThreadMenu = ({}: {}): React.ReactNode => {
     variables?.lab_treeViewEnabled ??
       preferences?.threadViewPrefs?.lab_treeViewEnabled,
   )
+  // Prioritize these for optimistic feedback and so that PWI works.
+  // It's fine to cache the server values inside because we don't have to "respond" to pref changes.
+  const [localSortReplies, setLocalSortReplies] = useState(sortReplies)
+  const [localTreeViewEnabled, setLocalTreeViewEnabled] =
+    useState(treeViewEnabled)
   return (
     <Menu.Root>
       <Menu.Trigger label={_(msg`Thread options`)}>
@@ -576,26 +582,32 @@ let ThreadMenu = ({}: {}): React.ReactNode => {
           <Menu.Item
             label={_(msg`Show replies as a list`)}
             onPress={() => {
-              setThreadViewPrefs({
-                lab_treeViewEnabled: false,
-              })
+              setLocalTreeViewEnabled(false)
+              if (hasSession) {
+                setThreadViewPrefs({
+                  lab_treeViewEnabled: false,
+                })
+              }
             }}>
             <Menu.ItemText>
               <Trans>Show replies as a list</Trans>
             </Menu.ItemText>
-            <RadioCircle isSelected={!treeViewEnabled} />
+            <RadioCircle isSelected={!localTreeViewEnabled} />
           </Menu.Item>
           <Menu.Item
             label={_(msg`Show replies as a tree`)}
             onPress={() => {
-              setThreadViewPrefs({
-                lab_treeViewEnabled: true,
-              })
+              setLocalTreeViewEnabled(true)
+              if (hasSession) {
+                setThreadViewPrefs({
+                  lab_treeViewEnabled: true,
+                })
+              }
             }}>
             <Menu.ItemText>
               <Trans>Show replies as a tree</Trans>
             </Menu.ItemText>
-            <RadioCircle isSelected={treeViewEnabled} />
+            <RadioCircle isSelected={localTreeViewEnabled} />
           </Menu.Item>
         </Menu.Group>
         <Menu.Divider />
@@ -603,52 +615,67 @@ let ThreadMenu = ({}: {}): React.ReactNode => {
           <Menu.Item
             label={_(msg`Hot replies first`)}
             onPress={() => {
-              setThreadViewPrefs({sort: 'hotness'})
+              setLocalSortReplies('hotness')
+              if (hasSession) {
+                setThreadViewPrefs({sort: 'hotness'})
+              }
             }}>
             <Menu.ItemText>
               <Trans>Hot replies first</Trans>
             </Menu.ItemText>
-            <RadioCircle isSelected={sortReplies === 'hotness'} />
+            <RadioCircle isSelected={localSortReplies === 'hotness'} />
           </Menu.Item>
           <Menu.Item
             label={_(msg`Oldest replies first`)}
             onPress={() => {
-              setThreadViewPrefs({sort: 'oldest'})
+              setLocalSortReplies('oldest')
+              if (hasSession) {
+                setThreadViewPrefs({sort: 'oldest'})
+              }
             }}>
             <Menu.ItemText>
               <Trans>Oldest replies first</Trans>
             </Menu.ItemText>
-            <RadioCircle isSelected={sortReplies === 'oldest'} />
+            <RadioCircle isSelected={localSortReplies === 'oldest'} />
           </Menu.Item>
           <Menu.Item
             label={_(msg`Newest replies first`)}
             onPress={() => {
-              setThreadViewPrefs({sort: 'newest'})
+              setLocalSortReplies('newest')
+              if (hasSession) {
+                setThreadViewPrefs({sort: 'newest'})
+              }
             }}>
             <Menu.ItemText>
               <Trans>Newest replies first</Trans>
             </Menu.ItemText>
-            <RadioCircle isSelected={sortReplies === 'newest'} />
+            <RadioCircle isSelected={localSortReplies === 'newest'} />
           </Menu.Item>
           <Menu.Item
             label={_(msg`Most-liked replies first`)}
             onPress={() => {
-              setThreadViewPrefs({sort: 'most-likes'})
+              setLocalSortReplies('most')
+              if (hasSession) {
+                setThreadViewPrefs({sort: 'most-likes'})
+              }
             }}>
             <Menu.ItemText>
               <Trans>Most-liked replies first</Trans>
             </Menu.ItemText>
-            <RadioCircle isSelected={sortReplies === 'most-likes'} />
+            <RadioCircle isSelected={localSortReplies === 'most-likes'} />
           </Menu.Item>
           <Menu.Item
             label={_(msg`Random (aka "Poster's Roulette")`)}
             onPress={() => {
-              setThreadViewPrefs({sort: 'random'})
+              setLocalSortReplies('random')
+              if (hasSession) {
+                setThreadViewPrefs({sort: 'random'})
+              }
             }}>
             <Menu.ItemText>
               <Trans>Random (aka "Poster's Roulette")</Trans>
             </Menu.ItemText>
-            <RadioCircle isSelected={sortReplies === 'random'} />
+            <RadioCircle isSelected={localSortReplies === 'random'} />
           </Menu.Item>
         </Menu.Group>
       </Menu.Outer>

--- a/src/view/com/post-thread/PostThread.tsx
+++ b/src/view/com/post-thread/PostThread.tsx
@@ -496,58 +496,7 @@ export function PostThread({uri}: {uri: string | undefined}) {
           </Header.TitleText>
         </Header.Content>
         <Header.Slot>
-          <Menu.Root>
-            <Menu.Trigger label={_(msg`Account options`)}>
-              {({props}) => (
-                <Button
-                  label={_(msg`Thread options`)}
-                  size="small"
-                  variant="ghost"
-                  color="secondary"
-                  shape="round"
-                  hitSlop={HITSLOP_10}
-                  style={[{right: -3}]}
-                  {...props}>
-                  <ButtonIcon icon={SettingsSlider} size="md" />
-                </Button>
-              )}
-            </Menu.Trigger>
-            <Menu.Outer>
-              <Menu.Item label={_(msg`Hot replies first`)} onPress={() => {}}>
-                <Menu.ItemText>
-                  <Trans>Hot replies first</Trans>
-                </Menu.ItemText>
-              </Menu.Item>
-              <Menu.Item
-                label={_(msg`Oldest replies first`)}
-                onPress={() => {}}>
-                <Menu.ItemText>
-                  <Trans>Oldest replies first</Trans>
-                </Menu.ItemText>
-              </Menu.Item>
-              <Menu.Item
-                label={_(msg`Newest replies first`)}
-                onPress={() => {}}>
-                <Menu.ItemText>
-                  <Trans>Newest replies first</Trans>
-                </Menu.ItemText>
-              </Menu.Item>
-              <Menu.Item
-                label={_(msg`Most-liked replies first`)}
-                onPress={() => {}}>
-                <Menu.ItemText>
-                  <Trans>Most-liked replies first</Trans>
-                </Menu.ItemText>
-              </Menu.Item>
-              <Menu.Item
-                label={_(msg`Random (aka "Poster's Roulette")`)}
-                onPress={() => {}}>
-                <Menu.ItemText>
-                  <Trans>Random (aka "Poster's Roulette")</Trans>
-                </Menu.ItemText>
-              </Menu.Item>
-            </Menu.Outer>
-          </Menu.Root>
+          <SortMenu />
         </Header.Slot>
       </Header.Outer>
 
@@ -591,6 +540,58 @@ export function PostThread({uri}: {uri: string | undefined}) {
         <MobileComposePrompt onPressReply={onPressReply} />
       )}
     </>
+  )
+}
+
+function SortMenu() {
+  const {_} = useLingui()
+  return (
+    <Menu.Root>
+      <Menu.Trigger label={_(msg`Account options`)}>
+        {({props}) => (
+          <Button
+            label={_(msg`Thread options`)}
+            size="small"
+            variant="ghost"
+            color="secondary"
+            shape="round"
+            hitSlop={HITSLOP_10}
+            style={[{right: -3}]}
+            {...props}>
+            <ButtonIcon icon={SettingsSlider} size="md" />
+          </Button>
+        )}
+      </Menu.Trigger>
+      <Menu.Outer>
+        <Menu.Item label={_(msg`Hot replies first`)} onPress={() => {}}>
+          <Menu.ItemText>
+            <Trans>Hot replies first</Trans>
+          </Menu.ItemText>
+        </Menu.Item>
+        <Menu.Item label={_(msg`Oldest replies first`)} onPress={() => {}}>
+          <Menu.ItemText>
+            <Trans>Oldest replies first</Trans>
+          </Menu.ItemText>
+        </Menu.Item>
+        <Menu.Item label={_(msg`Newest replies first`)} onPress={() => {}}>
+          <Menu.ItemText>
+            <Trans>Newest replies first</Trans>
+          </Menu.ItemText>
+        </Menu.Item>
+        <Menu.Item label={_(msg`Most-liked replies first`)} onPress={() => {}}>
+          <Menu.ItemText>
+            <Trans>Most-liked replies first</Trans>
+          </Menu.ItemText>
+        </Menu.Item>
+        <Menu.Item
+          label={_(msg`Random (aka "Poster's Roulette")`)}
+          onPress={() => {}}>
+          <Menu.ItemText>
+            <Trans>Random (aka "Poster's Roulette")</Trans>
+          </Menu.ItemText>
+        </Menu.Item>
+      </Menu.Outer>
+    </Menu.Root>
   )
 }
 

--- a/src/view/com/post-thread/PostThread.tsx
+++ b/src/view/com/post-thread/PostThread.tsx
@@ -19,6 +19,7 @@ import {sanitizeDisplayName} from '#/lib/strings/display-names'
 import {cleanError} from '#/lib/strings/errors'
 import {isAndroid, isNative, isWeb} from '#/platform/detection'
 import {useModerationOpts} from '#/state/preferences/moderation-opts'
+import {useSetThreadViewPreferencesMutation} from '#/state/queries/preferences'
 import {
   fillThreadModerationCache,
   sortThread,
@@ -545,6 +546,10 @@ export function PostThread({uri}: {uri: string | undefined}) {
 
 function SortMenu() {
   const {_} = useLingui()
+  const {data: preferences} = usePreferencesQuery()
+  const {mutate: setThreadViewPrefs, variables} =
+    useSetThreadViewPreferencesMutation()
+  const _sortReplies = variables?.sort ?? preferences?.threadViewPrefs?.sort // TODO: Use it
   return (
     <Menu.Root>
       <Menu.Trigger label={_(msg`Account options`)}>
@@ -563,29 +568,47 @@ function SortMenu() {
         )}
       </Menu.Trigger>
       <Menu.Outer>
-        <Menu.Item label={_(msg`Hot replies first`)} onPress={() => {}}>
+        <Menu.Item
+          label={_(msg`Hot replies first`)}
+          onPress={() => {
+            setThreadViewPrefs({sort: 'hotness'})
+          }}>
           <Menu.ItemText>
             <Trans>Hot replies first</Trans>
           </Menu.ItemText>
         </Menu.Item>
-        <Menu.Item label={_(msg`Oldest replies first`)} onPress={() => {}}>
+        <Menu.Item
+          label={_(msg`Oldest replies first`)}
+          onPress={() => {
+            setThreadViewPrefs({sort: 'oldest'})
+          }}>
           <Menu.ItemText>
             <Trans>Oldest replies first</Trans>
           </Menu.ItemText>
         </Menu.Item>
-        <Menu.Item label={_(msg`Newest replies first`)} onPress={() => {}}>
+        <Menu.Item
+          label={_(msg`Newest replies first`)}
+          onPress={() => {
+            setThreadViewPrefs({sort: 'newest'})
+          }}>
           <Menu.ItemText>
             <Trans>Newest replies first</Trans>
           </Menu.ItemText>
         </Menu.Item>
-        <Menu.Item label={_(msg`Most-liked replies first`)} onPress={() => {}}>
+        <Menu.Item
+          label={_(msg`Most-liked replies first`)}
+          onPress={() => {
+            setThreadViewPrefs({sort: 'most-likes'})
+          }}>
           <Menu.ItemText>
             <Trans>Most-liked replies first</Trans>
           </Menu.ItemText>
         </Menu.Item>
         <Menu.Item
           label={_(msg`Random (aka "Poster's Roulette")`)}
-          onPress={() => {}}>
+          onPress={() => {
+            setThreadViewPrefs({sort: 'random'})
+          }}>
           <Menu.ItemText>
             <Trans>Random (aka "Poster's Roulette")</Trans>
           </Menu.ItemText>

--- a/src/view/com/post-thread/PostThread.tsx
+++ b/src/view/com/post-thread/PostThread.tsx
@@ -113,12 +113,12 @@ export function PostThread({uri}: {uri: string | undefined}) {
     dataUpdatedAt: fetchedAt,
   } = usePostThreadQuery(uri)
 
+  const threadViewPrefs = preferences?.threadViewPrefs
   const treeView = React.useMemo(
-    () =>
-      !!preferences?.threadViewPrefs?.lab_treeViewEnabled &&
-      hasBranchingReplies(thread),
-    [preferences?.threadViewPrefs, thread],
+    () => !!threadViewPrefs?.lab_treeViewEnabled && hasBranchingReplies(thread),
+    [threadViewPrefs, thread],
   )
+
   const rootPost = thread?.type === 'post' ? thread.post : undefined
   const rootPostRecord = thread?.type === 'post' ? thread.record : undefined
   const threadgateRecord = threadgate?.record as
@@ -181,7 +181,6 @@ export function PostThread({uri}: {uri: string | undefined}) {
   const [fetchedAtCache] = React.useState(() => new Map<string, number>())
   const [randomCache] = React.useState(() => new Map<string, number>())
   const skeleton = React.useMemo(() => {
-    const threadViewPrefs = preferences?.threadViewPrefs
     if (!threadViewPrefs || !thread) return null
 
     return createThreadSkeleton(
@@ -204,7 +203,7 @@ export function PostThread({uri}: {uri: string | undefined}) {
     )
   }, [
     thread,
-    preferences?.threadViewPrefs,
+    threadViewPrefs,
     currentDid,
     treeView,
     threadModerationCache,

--- a/src/view/com/post-thread/PostThread.tsx
+++ b/src/view/com/post-thread/PostThread.tsx
@@ -42,7 +42,6 @@ import {Header} from '#/components/Layout'
 import {ListFooter, ListMaybePlaceholder} from '#/components/Lists'
 import * as Menu from '#/components/Menu'
 import {Text} from '#/components/Typography'
-import {RadioCircle} from '../util/forms/RadioButton'
 import {PostThreadComposePrompt} from './PostThreadComposePrompt'
 import {PostThreadItem} from './PostThreadItem'
 import {PostThreadLoadMore} from './PostThreadLoadMore'
@@ -530,7 +529,7 @@ export function PostThread({uri}: {uri: string | undefined}) {
 
   return (
     <>
-      <Header.Outer sticky={true} headerRef={headerRef}>
+      <Header.Outer headerRef={headerRef}>
         <Header.BackButton />
         <Header.Content>
           <Header.TitleText>
@@ -619,6 +618,9 @@ let ThreadMenu = ({
         )}
       </Menu.Trigger>
       <Menu.Outer>
+        <Menu.LabelText>
+          <Trans>Thread display</Trans>
+        </Menu.LabelText>
         <Menu.Group>
           <Menu.Item
             label={_(msg`Show replies as a list`)}
@@ -628,7 +630,7 @@ let ThreadMenu = ({
             <Menu.ItemText>
               <Trans>Show replies as a list</Trans>
             </Menu.ItemText>
-            <RadioCircle isSelected={!treeViewEnabled} />
+            <Menu.ItemRadio selected={!treeViewEnabled} />
           </Menu.Item>
           <Menu.Item
             label={_(msg`Show replies as a tree`)}
@@ -638,10 +640,13 @@ let ThreadMenu = ({
             <Menu.ItemText>
               <Trans>Show replies as a tree</Trans>
             </Menu.ItemText>
-            <RadioCircle isSelected={treeViewEnabled} />
+            <Menu.ItemRadio selected={treeViewEnabled} />
           </Menu.Item>
         </Menu.Group>
         <Menu.Divider />
+        <Menu.LabelText>
+          <Trans>Reply sorting</Trans>
+        </Menu.LabelText>
         <Menu.Group>
           <Menu.Item
             label={_(msg`Hot replies first`)}
@@ -651,7 +656,7 @@ let ThreadMenu = ({
             <Menu.ItemText>
               <Trans>Hot replies first</Trans>
             </Menu.ItemText>
-            <RadioCircle isSelected={sortReplies === 'hotness'} />
+            <Menu.ItemRadio selected={sortReplies === 'hotness'} />
           </Menu.Item>
           <Menu.Item
             label={_(msg`Oldest replies first`)}
@@ -661,7 +666,7 @@ let ThreadMenu = ({
             <Menu.ItemText>
               <Trans>Oldest replies first</Trans>
             </Menu.ItemText>
-            <RadioCircle isSelected={sortReplies === 'oldest'} />
+            <Menu.ItemRadio selected={sortReplies === 'oldest'} />
           </Menu.Item>
           <Menu.Item
             label={_(msg`Newest replies first`)}
@@ -671,7 +676,7 @@ let ThreadMenu = ({
             <Menu.ItemText>
               <Trans>Newest replies first</Trans>
             </Menu.ItemText>
-            <RadioCircle isSelected={sortReplies === 'newest'} />
+            <Menu.ItemRadio selected={sortReplies === 'newest'} />
           </Menu.Item>
           <Menu.Item
             label={_(msg`Most-liked replies first`)}
@@ -681,7 +686,7 @@ let ThreadMenu = ({
             <Menu.ItemText>
               <Trans>Most-liked replies first</Trans>
             </Menu.ItemText>
-            <RadioCircle isSelected={sortReplies === 'most-likes'} />
+            <Menu.ItemRadio selected={sortReplies === 'most-likes'} />
           </Menu.Item>
           <Menu.Item
             label={_(msg`Random (aka "Poster's Roulette")`)}
@@ -691,7 +696,7 @@ let ThreadMenu = ({
             <Menu.ItemText>
               <Trans>Random (aka "Poster's Roulette")</Trans>
             </Menu.ItemText>
-            <RadioCircle isSelected={sortReplies === 'random'} />
+            <Menu.ItemRadio selected={sortReplies === 'random'} />
           </Menu.Item>
         </Menu.Group>
       </Menu.Outer>

--- a/src/view/com/util/forms/RadioButton.tsx
+++ b/src/view/com/util/forms/RadioButton.tsx
@@ -21,70 +21,6 @@ export function RadioButton({
   onPress: () => void
 }) {
   const theme = useTheme()
-  const labelStyle = choose<TextStyle, Record<ButtonType, TextStyle>>(type, {
-    primary: {
-      color: theme.palette.primary.text,
-      fontWeight: theme.palette.primary.isLowContrast ? '600' : undefined,
-    },
-    secondary: {
-      color: theme.palette.secondary.text,
-      fontWeight: theme.palette.secondary.isLowContrast ? '600' : undefined,
-    },
-    inverted: {
-      color: theme.palette.inverted.text,
-      fontWeight: theme.palette.inverted.isLowContrast ? '600' : undefined,
-    },
-    'primary-outline': {
-      color: theme.palette.primary.textInverted,
-      fontWeight: theme.palette.primary.isLowContrast ? '600' : undefined,
-    },
-    'secondary-outline': {
-      color: theme.palette.secondary.textInverted,
-      fontWeight: theme.palette.secondary.isLowContrast ? '600' : undefined,
-    },
-    'primary-light': {
-      color: theme.palette.primary.textInverted,
-      fontWeight: theme.palette.primary.isLowContrast ? '600' : undefined,
-    },
-    'secondary-light': {
-      color: theme.palette.secondary.textInverted,
-      fontWeight: theme.palette.secondary.isLowContrast ? '600' : undefined,
-    },
-    default: {
-      color: theme.palette.default.text,
-      fontWeight: theme.palette.default.isLowContrast ? '600' : undefined,
-    },
-    'default-light': {
-      color: theme.palette.default.text,
-      fontWeight: theme.palette.default.isLowContrast ? '600' : undefined,
-    },
-  })
-  return (
-    <Button testID={testID} type={type} onPress={onPress} style={style}>
-      <View style={styles.outer}>
-        <RadioCircle type={type} isSelected={isSelected} marginRight={10} />
-        {typeof label === 'string' ? (
-          <Text type="button" style={[labelStyle, styles.label]}>
-            {label}
-          </Text>
-        ) : (
-          <View style={styles.label}>{label}</View>
-        )}
-      </View>
-    </Button>
-  )
-}
-
-export function RadioCircle({
-  isSelected,
-  marginRight,
-  type = 'default-light',
-}: {
-  isSelected: boolean
-  type?: ButtonType
-  marginRight?: number
-}) {
-  const theme = useTheme()
   const circleStyle = choose<TextStyle, Record<ButtonType, TextStyle>>(type, {
     primary: {
       borderColor: theme.palette.primary.text,
@@ -146,12 +82,61 @@ export function RadioCircle({
       },
     },
   )
+  const labelStyle = choose<TextStyle, Record<ButtonType, TextStyle>>(type, {
+    primary: {
+      color: theme.palette.primary.text,
+      fontWeight: theme.palette.primary.isLowContrast ? '600' : undefined,
+    },
+    secondary: {
+      color: theme.palette.secondary.text,
+      fontWeight: theme.palette.secondary.isLowContrast ? '600' : undefined,
+    },
+    inverted: {
+      color: theme.palette.inverted.text,
+      fontWeight: theme.palette.inverted.isLowContrast ? '600' : undefined,
+    },
+    'primary-outline': {
+      color: theme.palette.primary.textInverted,
+      fontWeight: theme.palette.primary.isLowContrast ? '600' : undefined,
+    },
+    'secondary-outline': {
+      color: theme.palette.secondary.textInverted,
+      fontWeight: theme.palette.secondary.isLowContrast ? '600' : undefined,
+    },
+    'primary-light': {
+      color: theme.palette.primary.textInverted,
+      fontWeight: theme.palette.primary.isLowContrast ? '600' : undefined,
+    },
+    'secondary-light': {
+      color: theme.palette.secondary.textInverted,
+      fontWeight: theme.palette.secondary.isLowContrast ? '600' : undefined,
+    },
+    default: {
+      color: theme.palette.default.text,
+      fontWeight: theme.palette.default.isLowContrast ? '600' : undefined,
+    },
+    'default-light': {
+      color: theme.palette.default.text,
+      fontWeight: theme.palette.default.isLowContrast ? '600' : undefined,
+    },
+  })
   return (
-    <View style={[circleStyle, styles.circle, {marginRight}]}>
-      {isSelected ? (
-        <View style={[circleFillStyle, styles.circleFill]} />
-      ) : undefined}
-    </View>
+    <Button testID={testID} type={type} onPress={onPress} style={style}>
+      <View style={styles.outer}>
+        <View style={[circleStyle, styles.circle]}>
+          {isSelected ? (
+            <View style={[circleFillStyle, styles.circleFill]} />
+          ) : undefined}
+        </View>
+        {typeof label === 'string' ? (
+          <Text type="button" style={[labelStyle, styles.label]}>
+            {label}
+          </Text>
+        ) : (
+          <View style={styles.label}>{label}</View>
+        )}
+      </View>
+    </Button>
   )
 }
 
@@ -166,6 +151,7 @@ const styles = StyleSheet.create({
     borderRadius: 15,
     padding: 4,
     borderWidth: 1,
+    marginRight: 10,
   },
   circleFill: {
     width: 16,

--- a/src/view/com/util/forms/RadioButton.tsx
+++ b/src/view/com/util/forms/RadioButton.tsx
@@ -21,6 +21,70 @@ export function RadioButton({
   onPress: () => void
 }) {
   const theme = useTheme()
+  const labelStyle = choose<TextStyle, Record<ButtonType, TextStyle>>(type, {
+    primary: {
+      color: theme.palette.primary.text,
+      fontWeight: theme.palette.primary.isLowContrast ? '600' : undefined,
+    },
+    secondary: {
+      color: theme.palette.secondary.text,
+      fontWeight: theme.palette.secondary.isLowContrast ? '600' : undefined,
+    },
+    inverted: {
+      color: theme.palette.inverted.text,
+      fontWeight: theme.palette.inverted.isLowContrast ? '600' : undefined,
+    },
+    'primary-outline': {
+      color: theme.palette.primary.textInverted,
+      fontWeight: theme.palette.primary.isLowContrast ? '600' : undefined,
+    },
+    'secondary-outline': {
+      color: theme.palette.secondary.textInverted,
+      fontWeight: theme.palette.secondary.isLowContrast ? '600' : undefined,
+    },
+    'primary-light': {
+      color: theme.palette.primary.textInverted,
+      fontWeight: theme.palette.primary.isLowContrast ? '600' : undefined,
+    },
+    'secondary-light': {
+      color: theme.palette.secondary.textInverted,
+      fontWeight: theme.palette.secondary.isLowContrast ? '600' : undefined,
+    },
+    default: {
+      color: theme.palette.default.text,
+      fontWeight: theme.palette.default.isLowContrast ? '600' : undefined,
+    },
+    'default-light': {
+      color: theme.palette.default.text,
+      fontWeight: theme.palette.default.isLowContrast ? '600' : undefined,
+    },
+  })
+  return (
+    <Button testID={testID} type={type} onPress={onPress} style={style}>
+      <View style={styles.outer}>
+        <RadioCircle type={type} isSelected={isSelected} marginRight={10} />
+        {typeof label === 'string' ? (
+          <Text type="button" style={[labelStyle, styles.label]}>
+            {label}
+          </Text>
+        ) : (
+          <View style={styles.label}>{label}</View>
+        )}
+      </View>
+    </Button>
+  )
+}
+
+export function RadioCircle({
+  isSelected,
+  marginRight,
+  type = 'default-light',
+}: {
+  isSelected: boolean
+  type?: ButtonType
+  marginRight?: number
+}) {
+  const theme = useTheme()
   const circleStyle = choose<TextStyle, Record<ButtonType, TextStyle>>(type, {
     primary: {
       borderColor: theme.palette.primary.text,
@@ -82,61 +146,12 @@ export function RadioButton({
       },
     },
   )
-  const labelStyle = choose<TextStyle, Record<ButtonType, TextStyle>>(type, {
-    primary: {
-      color: theme.palette.primary.text,
-      fontWeight: theme.palette.primary.isLowContrast ? '600' : undefined,
-    },
-    secondary: {
-      color: theme.palette.secondary.text,
-      fontWeight: theme.palette.secondary.isLowContrast ? '600' : undefined,
-    },
-    inverted: {
-      color: theme.palette.inverted.text,
-      fontWeight: theme.palette.inverted.isLowContrast ? '600' : undefined,
-    },
-    'primary-outline': {
-      color: theme.palette.primary.textInverted,
-      fontWeight: theme.palette.primary.isLowContrast ? '600' : undefined,
-    },
-    'secondary-outline': {
-      color: theme.palette.secondary.textInverted,
-      fontWeight: theme.palette.secondary.isLowContrast ? '600' : undefined,
-    },
-    'primary-light': {
-      color: theme.palette.primary.textInverted,
-      fontWeight: theme.palette.primary.isLowContrast ? '600' : undefined,
-    },
-    'secondary-light': {
-      color: theme.palette.secondary.textInverted,
-      fontWeight: theme.palette.secondary.isLowContrast ? '600' : undefined,
-    },
-    default: {
-      color: theme.palette.default.text,
-      fontWeight: theme.palette.default.isLowContrast ? '600' : undefined,
-    },
-    'default-light': {
-      color: theme.palette.default.text,
-      fontWeight: theme.palette.default.isLowContrast ? '600' : undefined,
-    },
-  })
   return (
-    <Button testID={testID} type={type} onPress={onPress} style={style}>
-      <View style={styles.outer}>
-        <View style={[circleStyle, styles.circle]}>
-          {isSelected ? (
-            <View style={[circleFillStyle, styles.circleFill]} />
-          ) : undefined}
-        </View>
-        {typeof label === 'string' ? (
-          <Text type="button" style={[labelStyle, styles.label]}>
-            {label}
-          </Text>
-        ) : (
-          <View style={styles.label}>{label}</View>
-        )}
-      </View>
-    </Button>
+    <View style={[circleStyle, styles.circle, {marginRight}]}>
+      {isSelected ? (
+        <View style={[circleFillStyle, styles.circleFill]} />
+      ) : undefined}
+    </View>
   )
 }
 
@@ -151,7 +166,6 @@ const styles = StyleSheet.create({
     borderRadius: 15,
     padding: 4,
     borderWidth: 1,
-    marginRight: 10,
   },
   circleFill: {
     width: 16,


### PR DESCRIPTION
Now that the header is always visible on all platforms, it seems like a nice place to put the sorting options.

The behavior is not perfect (e.g. it's a bit slower than I would have liked) but seems like we can ship and iterate.

## Test Plan

https://github.com/user-attachments/assets/15424c68-9d71-44b2-9067-5401eb4e4a35

https://github.com/user-attachments/assets/3df43707-d3fd-4508-a3b0-b5914973c725

