### PR TITLE
Remove deactivate dialog link from delete modal

### DIFF
--- a/src/view/com/modals/DeleteAccount.tsx
+++ b/src/view/com/modals/DeleteAccount.tsx
@@ -210,7 +210,6 @@ export function Component({}: {}) {
                     to="#"
                     onPress={e => {
                       e.preventDefault()
-                      closeModal()
                       deactivateAccountControl.open()
                       return false
                     }}>

--- a/src/view/com/modals/DeleteAccount.tsx
+++ b/src/view/com/modals/DeleteAccount.tsx
@@ -19,11 +19,8 @@ import {isAndroid, isWeb} from '#/platform/detection'
 import {useModalControls} from '#/state/modals'
 import {DM_SERVICE_HEADERS} from '#/state/queries/messages/const'
 import {useAgent, useSession, useSessionApi} from '#/state/session'
-import {DeactivateAccountDialog} from '#/screens/Settings/components/DeactivateAccountDialog'
 import {atoms as a, useTheme as useNewTheme} from '#/alf'
-import {useDialogControl} from '#/components/Dialog'
 import {CircleInfo_Stroke2_Corner0_Rounded as CircleInfo} from '#/components/icons/CircleInfo'
-import {InlineLinkText} from '#/components/Link'
 import {Text as NewText} from '#/components/Typography'
 import {resetToTab} from '../../../Navigation'
 import {ErrorMessage} from '../util/error/ErrorMessage'
@@ -48,7 +45,6 @@ export function Component({}: {}) {
   const [password, setPassword] = React.useState<string>('')
   const [isProcessing, setIsProcessing] = React.useState<boolean>(false)
   const [error, setError] = React.useState<string>('')
-  const deactivateAccountControl = useDialogControl()
   const onPressSendEmail = async () => {
     setError('')
     setIsProcessing(true)
@@ -202,24 +198,10 @@ export function Component({}: {}) {
                   <Trans>
                     You can also temporarily deactivate your account instead,
                     and reactivate it at any time.
-                  </Trans>{' '}
-                  <InlineLinkText
-                    label={_(
-                      msg`Click here for more information on deactivating your account`,
-                    )}
-                    to="#"
-                    onPress={e => {
-                      e.preventDefault()
-                      deactivateAccountControl.open()
-                      return false
-                    }}>
-                    <Trans>Click here for more information.</Trans>
-                  </InlineLinkText>
+                  </Trans>
                 </NewText>
               </View>
             </View>
-
-            <DeactivateAccountDialog control={deactivateAccountControl} />
           </>
         ) : (
           <>


### PR DESCRIPTION
Our old `Modal` and new `Dialog`s don't play well together. This is currently broken on all platforms, so let's rm for now and replace the delete modal with new code next.