### PR TITLE
Remove unreliable repository

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -232,6 +232,7 @@ module.exports = function (config) {
         './plugins/withAndroidManifestFCMIconPlugin.js',
         './plugins/withAndroidStylesAccentColorPlugin.js',
         './plugins/withAndroidSplashScreenStatusBarTranslucentPlugin.js',
+        './plugins/withAndroidNoJitpackPlugin.js',
         './plugins/shareExtension/withShareExtensions.js',
         './plugins/notificationsExtension/withNotificationsExtension.js',
         './plugins/withAppDelegateReferrer.js',

--- a/plugins/withAndroidNoJitpackPlugin.js
+++ b/plugins/withAndroidNoJitpackPlugin.js
@@ -1,0 +1,20 @@
+const {withProjectBuildGradle} = require('@expo/config-plugins')
+
+const jitpackRepository = "maven { url 'https://www.jitpack.io' }"
+
+module.exports = function withAndroidNoJitpackPlugin(config) {
+  return withProjectBuildGradle(config, config => {
+    if (!config.modResults.contents.includes(jitpackRepository)) {
+      throw Error(
+        'Expected to find the jitpack string in the config. ' +
+          'You MUST verify whether it was actually removed upstream, ' +
+          'or if the format has changed and this plugin no longer recognizes it.',
+      )
+    }
+    config.modResults.contents = config.modResults.contents.replaceAll(
+      jitpackRepository,
+      '',
+    )
+    return config
+  })
+}


### PR DESCRIPTION
We were getting some errors because this repository was down. We don't have anything that uses it, so let's remove it out of the chain to improve predictability. Then, if something upstream fails, we'll have a correct source of error.

I'm not sure where the upstream setup is. I've seen this line in RN (https://github.com/facebook/react-native/pull/25987) and in many places in Expo. But it's pretty easy to remove downstream which I'm doing here.

## Test Plan

Android builds.

Before:

<img width="670" alt="Screenshot 2024-12-19 at 03 10 30" src="https://github.com/user-attachments/assets/513e1cef-46e6-4993-a551-20c12ceb0fe3" />

After:

<img width="565" alt="Screenshot 2024-12-19 at 03 10 55" src="https://github.com/user-attachments/assets/b5e97fb4-c564-42c0-8b39-fffd534d2d1d" />
