### PR TITLE
Proper fix for iOS cropper being stuck

### DIFF
--- a/patches/react-native-image-crop-picker+0.41.6.patch
+++ b/patches/react-native-image-crop-picker+0.41.6.patch
@@ -1,0 +1,14 @@
+diff --git a/node_modules/react-native-image-crop-picker/ios/src/ImageCropPicker.m b/node_modules/react-native-image-crop-picker/ios/src/ImageCropPicker.m
+index 9f20973..68d4766 100644
+--- a/node_modules/react-native-image-crop-picker/ios/src/ImageCropPicker.m
++++ b/node_modules/react-native-image-crop-picker/ios/src/ImageCropPicker.m
+@@ -126,7 +126,8 @@ - (void) setConfiguration:(NSDictionary *)options
+ 
+ - (UIViewController*) getRootVC {
+     UIViewController *root = [[[[UIApplication sharedApplication] delegate] window] rootViewController];
+-    while (root.presentedViewController != nil) {
++    while (root.presentedViewController != nil &&
++           !root.presentedViewController.isBeingDismissed) {
+         root = root.presentedViewController;
+     }
+     

--- a/src/screens/Onboarding/StepProfile/index.tsx
+++ b/src/screens/Onboarding/StepProfile/index.tsx
@@ -15,7 +15,7 @@ import {openCropper} from '#/lib/media/picker'
 import {getDataUriSize} from '#/lib/media/util'
 import {useRequestNotificationsPermission} from '#/lib/notifications/notifications'
 import {logEvent, useGate} from '#/lib/statsig/statsig'
-import {isIOS, isNative, isWeb} from '#/platform/detection'
+import {isNative, isWeb} from '#/platform/detection'
 import {
   DescriptionText,
   OnboardingControls,
@@ -181,10 +181,6 @@ export function StepProfile() {
     if (!image) return
 
     if (!isWeb) {
-      if (isIOS) {
-        // https://github.com/ivpusic/react-native-image-crop-picker/issues/1631
-        await new Promise(resolve => setTimeout(resolve, 800))
-      }
       image = await openCropper({
         mediaType: 'photo',
         cropperCircleOverlay: true,

--- a/src/view/com/util/UserAvatar.tsx
+++ b/src/view/com/util/UserAvatar.tsx
@@ -16,7 +16,7 @@ import {
 import {makeProfileLink} from '#/lib/routes/links'
 import {colors} from '#/lib/styles'
 import {logger} from '#/logger'
-import {isAndroid, isIOS, isNative, isWeb} from '#/platform/detection'
+import {isAndroid, isNative, isWeb} from '#/platform/detection'
 import {precacheProfile} from '#/state/queries/profile'
 import {HighPriorityImage} from '#/view/com/util/images/Image'
 import {tokens, useTheme} from '#/alf'
@@ -319,10 +319,6 @@ let EditableUserAvatar = ({
     }
 
     try {
-      if (isIOS) {
-        // https://github.com/ivpusic/react-native-image-crop-picker/issues/1631
-        await new Promise(resolve => setTimeout(resolve, 800))
-      }
       const croppedImage = await openCropper({
         mediaType: 'photo',
         cropperCircleOverlay: true,

--- a/src/view/com/util/UserBanner.tsx
+++ b/src/view/com/util/UserBanner.tsx
@@ -14,7 +14,7 @@ import {
 import {colors} from '#/lib/styles'
 import {useTheme} from '#/lib/ThemeContext'
 import {logger} from '#/logger'
-import {isAndroid, isIOS, isNative} from '#/platform/detection'
+import {isAndroid, isNative} from '#/platform/detection'
 import {EventStopper} from '#/view/com/util/EventStopper'
 import {tokens, useTheme as useAlfTheme} from '#/alf'
 import {useSheetWrapper} from '#/components/Dialog/sheet-wrapper'
@@ -68,10 +68,6 @@ export function UserBanner({
     }
 
     try {
-      if (isIOS) {
-        // https://github.com/ivpusic/react-native-image-crop-picker/issues/1631
-        await new Promise(resolve => setTimeout(resolve, 800))
-      }
       onSelectNewBanner?.(
         await openCropper({
           mediaType: 'photo',


### PR DESCRIPTION
Reverts https://github.com/bluesky-social/social-app/pull/7191 and adds a proper fix.

The root problem is hinted at in the error message in https://github.com/ivpusic/react-native-image-crop-picker/issues/1631:

>[Presentation] Attempt to present <TOCropViewController: 0x10d126a00> on <PHPickerViewController: 0x10be14b80> (from <PHPickerViewController: 0x10be14b80>) whose view is not in the window hierarchy.

We're trying to present the cropper _from_ the picker but the picker is being dismissed — so it's not valid to present _from_. I'm not sure why this wasn't hitting us before but the problem makes sense.

The issue is how the cropper determines the controller to be presented _from_. It currently looks for the innermost controller, but it doesn't take it into account that the innermost controller might be animating _out_ (and thus is not valid to present from). The fix is to add a condition for that.

## Test Plan

Set an Xcode breakpoint on that line. Confirm that before the fix, it would select the picker controller as the "current" one, but after the fix, it selects the parent (as it should).

Verify all usages of the cropper:

- [x] Avi
- [x] Banner
- [x] Onboarding

https://github.com/user-attachments/assets/386ab55a-aaa9-4089-8a62-dfd1f817d960


