### PR TITLE
Fix timezone issue when using polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@expo/webpack-config": "^19.0.0",
     "@floating-ui/dom": "^1.6.3",
     "@floating-ui/react-dom": "^2.0.8",
+    "@formatjs/intl-datetimeformat": "^6.17.1",
     "@formatjs/intl-locale": "^4.2.8",
     "@formatjs/intl-numberformat": "^8.15.1",
     "@formatjs/intl-pluralrules": "^5.4.1",

--- a/src/locale/i18n.ts
+++ b/src/locale/i18n.ts
@@ -7,6 +7,7 @@ import '@formatjs/intl-numberformat/polyfill-force'
 import '@formatjs/intl-datetimeformat/locale-data/en'
 import '@formatjs/intl-pluralrules/locale-data/en'
 import '@formatjs/intl-numberformat/locale-data/en'
+import '@formatjs/intl-datetimeformat/add-all-tz.js'
 
 import {useEffect} from 'react'
 import {getCalendars} from 'expo-localization'
@@ -56,7 +57,6 @@ import {useLanguagePrefs} from '#/state/preferences'
  * {@link https://docs.expo.dev/versions/latest/sdk/localization/#localizationgetcalendars}
  */
 if ('__setDefaultTimeZone' in Intl.DateTimeFormat) {
-  console.log('Setting default time zone', getCalendars()[0].timeZone)
   // @ts-ignore
   Intl.DateTimeFormat.__setDefaultTimeZone(getCalendars()[0].timeZone)
 }

--- a/src/locale/i18n.ts
+++ b/src/locale/i18n.ts
@@ -1,8 +1,10 @@
 // Don't remove -force from these because detection is VERY slow on low-end Android.
 // https://github.com/formatjs/formatjs/issues/4463#issuecomment-2176070577
 import '@formatjs/intl-locale/polyfill-force'
+import '@formatjs/intl-datetimeformat/polyfill-force'
 import '@formatjs/intl-pluralrules/polyfill-force'
 import '@formatjs/intl-numberformat/polyfill-force'
+import '@formatjs/intl-datetimeformat/locale-data/en'
 import '@formatjs/intl-pluralrules/locale-data/en'
 import '@formatjs/intl-numberformat/locale-data/en'
 
@@ -52,6 +54,7 @@ export async function dynamicActivate(locale: AppLanguage) {
     case AppLanguage.an: {
       i18n.loadAndActivate({locale, messages: messagesAn})
       await Promise.all([
+        import('@formatjs/intl-datetimeformat/locale-data/es'),
         import('@formatjs/intl-pluralrules/locale-data/an'),
         import('@formatjs/intl-numberformat/locale-data/es'),
       ])
@@ -60,6 +63,7 @@ export async function dynamicActivate(locale: AppLanguage) {
     case AppLanguage.ast: {
       i18n.loadAndActivate({locale, messages: messagesAst})
       await Promise.all([
+        import('@formatjs/intl-datetimeformat/locale-data/ast'),
         import('@formatjs/intl-pluralrules/locale-data/ast'),
         import('@formatjs/intl-numberformat/locale-data/ast'),
       ])
@@ -68,6 +72,7 @@ export async function dynamicActivate(locale: AppLanguage) {
     case AppLanguage.ca: {
       i18n.loadAndActivate({locale, messages: messagesCa})
       await Promise.all([
+        import('@formatjs/intl-datetimeformat/locale-data/ca'),
         import('@formatjs/intl-pluralrules/locale-data/ca'),
         import('@formatjs/intl-numberformat/locale-data/ca'),
       ])
@@ -76,6 +81,7 @@ export async function dynamicActivate(locale: AppLanguage) {
     case AppLanguage.de: {
       i18n.loadAndActivate({locale, messages: messagesDe})
       await Promise.all([
+        import('@formatjs/intl-datetimeformat/locale-data/de'),
         import('@formatjs/intl-pluralrules/locale-data/de'),
         import('@formatjs/intl-numberformat/locale-data/de'),
       ])
@@ -84,6 +90,7 @@ export async function dynamicActivate(locale: AppLanguage) {
     case AppLanguage.en_GB: {
       i18n.loadAndActivate({locale, messages: messagesEn_GB})
       await Promise.all([
+        import('@formatjs/intl-datetimeformat/locale-data/en-GB'),
         import('@formatjs/intl-pluralrules/locale-data/en'),
         import('@formatjs/intl-numberformat/locale-data/en-GB'),
       ])
@@ -92,6 +99,7 @@ export async function dynamicActivate(locale: AppLanguage) {
     case AppLanguage.es: {
       i18n.loadAndActivate({locale, messages: messagesEs})
       await Promise.all([
+        import('@formatjs/intl-datetimeformat/locale-data/es'),
         import('@formatjs/intl-pluralrules/locale-data/es'),
         import('@formatjs/intl-numberformat/locale-data/es'),
       ])
@@ -100,6 +108,7 @@ export async function dynamicActivate(locale: AppLanguage) {
     case AppLanguage.fi: {
       i18n.loadAndActivate({locale, messages: messagesFi})
       await Promise.all([
+        import('@formatjs/intl-datetimeformat/locale-data/fi'),
         import('@formatjs/intl-pluralrules/locale-data/fi'),
         import('@formatjs/intl-numberformat/locale-data/fi'),
       ])
@@ -108,6 +117,7 @@ export async function dynamicActivate(locale: AppLanguage) {
     case AppLanguage.fr: {
       i18n.loadAndActivate({locale, messages: messagesFr})
       await Promise.all([
+        import('@formatjs/intl-datetimeformat/locale-data/fr'),
         import('@formatjs/intl-pluralrules/locale-data/fr'),
         import('@formatjs/intl-numberformat/locale-data/fr'),
       ])
@@ -116,6 +126,7 @@ export async function dynamicActivate(locale: AppLanguage) {
     case AppLanguage.ga: {
       i18n.loadAndActivate({locale, messages: messagesGa})
       await Promise.all([
+        import('@formatjs/intl-datetimeformat/locale-data/ga'),
         import('@formatjs/intl-pluralrules/locale-data/ga'),
         import('@formatjs/intl-numberformat/locale-data/ga'),
       ])
@@ -124,6 +135,7 @@ export async function dynamicActivate(locale: AppLanguage) {
     case AppLanguage.gl: {
       i18n.loadAndActivate({locale, messages: messagesGl})
       await Promise.all([
+        import('@formatjs/intl-datetimeformat/locale-data/gl'),
         import('@formatjs/intl-pluralrules/locale-data/gl'),
         import('@formatjs/intl-numberformat/locale-data/gl'),
       ])
@@ -132,6 +144,7 @@ export async function dynamicActivate(locale: AppLanguage) {
     case AppLanguage.hi: {
       i18n.loadAndActivate({locale, messages: messagesHi})
       await Promise.all([
+        import('@formatjs/intl-datetimeformat/locale-data/hi'),
         import('@formatjs/intl-pluralrules/locale-data/hi'),
         import('@formatjs/intl-numberformat/locale-data/hi'),
       ])
@@ -140,6 +153,7 @@ export async function dynamicActivate(locale: AppLanguage) {
     case AppLanguage.hu: {
       i18n.loadAndActivate({locale, messages: messagesHu})
       await Promise.all([
+        import('@formatjs/intl-datetimeformat/locale-data/hu'),
         import('@formatjs/intl-pluralrules/locale-data/hu'),
         import('@formatjs/intl-numberformat/locale-data/hu'),
       ])
@@ -148,6 +162,7 @@ export async function dynamicActivate(locale: AppLanguage) {
     case AppLanguage.id: {
       i18n.loadAndActivate({locale, messages: messagesId})
       await Promise.all([
+        import('@formatjs/intl-datetimeformat/locale-data/id'),
         import('@formatjs/intl-pluralrules/locale-data/id'),
         import('@formatjs/intl-numberformat/locale-data/id'),
       ])
@@ -156,6 +171,7 @@ export async function dynamicActivate(locale: AppLanguage) {
     case AppLanguage.it: {
       i18n.loadAndActivate({locale, messages: messagesIt})
       await Promise.all([
+        import('@formatjs/intl-datetimeformat/locale-data/it'),
         import('@formatjs/intl-pluralrules/locale-data/it'),
         import('@formatjs/intl-numberformat/locale-data/it'),
       ])
@@ -164,6 +180,7 @@ export async function dynamicActivate(locale: AppLanguage) {
     case AppLanguage.ja: {
       i18n.loadAndActivate({locale, messages: messagesJa})
       await Promise.all([
+        import('@formatjs/intl-datetimeformat/locale-data/ja'),
         import('@formatjs/intl-pluralrules/locale-data/ja'),
         import('@formatjs/intl-numberformat/locale-data/ja'),
       ])
@@ -172,6 +189,8 @@ export async function dynamicActivate(locale: AppLanguage) {
     case AppLanguage.km: {
       i18n.loadAndActivate({locale, messages: messagesKm})
       await Promise.all([
+        import('@formatjs/intl-datetimeformat/locale-data/km'),
+        import('@formatjs/intl-datetimeformat/locale-data/km'),
         import('@formatjs/intl-pluralrules/locale-data/km'),
         import('@formatjs/intl-numberformat/locale-data/km'),
       ])
@@ -180,6 +199,7 @@ export async function dynamicActivate(locale: AppLanguage) {
     case AppLanguage.ko: {
       i18n.loadAndActivate({locale, messages: messagesKo})
       await Promise.all([
+        import('@formatjs/intl-datetimeformat/locale-data/ko'),
         import('@formatjs/intl-pluralrules/locale-data/ko'),
         import('@formatjs/intl-numberformat/locale-data/ko'),
       ])
@@ -188,6 +208,7 @@ export async function dynamicActivate(locale: AppLanguage) {
     case AppLanguage.nl: {
       i18n.loadAndActivate({locale, messages: messagesNl})
       await Promise.all([
+        import('@formatjs/intl-datetimeformat/locale-data/nl'),
         import('@formatjs/intl-pluralrules/locale-data/nl'),
         import('@formatjs/intl-numberformat/locale-data/nl'),
       ])
@@ -200,6 +221,7 @@ export async function dynamicActivate(locale: AppLanguage) {
     case AppLanguage.pl: {
       i18n.loadAndActivate({locale, messages: messagesPl})
       await Promise.all([
+        import('@formatjs/intl-datetimeformat/locale-data/pl'),
         import('@formatjs/intl-pluralrules/locale-data/pl'),
         import('@formatjs/intl-numberformat/locale-data/pl'),
       ])
@@ -208,6 +230,7 @@ export async function dynamicActivate(locale: AppLanguage) {
     case AppLanguage.pt_BR: {
       i18n.loadAndActivate({locale, messages: messagesPt_BR})
       await Promise.all([
+        import('@formatjs/intl-datetimeformat/locale-data/pt'),
         import('@formatjs/intl-pluralrules/locale-data/pt'),
         import('@formatjs/intl-numberformat/locale-data/pt'),
       ])
@@ -216,6 +239,7 @@ export async function dynamicActivate(locale: AppLanguage) {
     case AppLanguage.ro: {
       i18n.loadAndActivate({locale, messages: messagesRo})
       await Promise.all([
+        import('@formatjs/intl-datetimeformat/locale-data/ro'),
         import('@formatjs/intl-pluralrules/locale-data/ro'),
         import('@formatjs/intl-numberformat/locale-data/ro'),
       ])
@@ -224,6 +248,7 @@ export async function dynamicActivate(locale: AppLanguage) {
     case AppLanguage.ru: {
       i18n.loadAndActivate({locale, messages: messagesRu})
       await Promise.all([
+        import('@formatjs/intl-datetimeformat/locale-data/ru'),
         import('@formatjs/intl-pluralrules/locale-data/ru'),
         import('@formatjs/intl-numberformat/locale-data/ru'),
       ])
@@ -232,6 +257,7 @@ export async function dynamicActivate(locale: AppLanguage) {
     case AppLanguage.th: {
       i18n.loadAndActivate({locale, messages: messagesTh})
       await Promise.all([
+        import('@formatjs/intl-datetimeformat/locale-data/th'),
         import('@formatjs/intl-pluralrules/locale-data/th'),
         import('@formatjs/intl-numberformat/locale-data/th'),
       ])
@@ -240,6 +266,7 @@ export async function dynamicActivate(locale: AppLanguage) {
     case AppLanguage.tr: {
       i18n.loadAndActivate({locale, messages: messagesTr})
       await Promise.all([
+        import('@formatjs/intl-datetimeformat/locale-data/tr'),
         import('@formatjs/intl-pluralrules/locale-data/tr'),
         import('@formatjs/intl-numberformat/locale-data/tr'),
       ])
@@ -248,6 +275,7 @@ export async function dynamicActivate(locale: AppLanguage) {
     case AppLanguage.uk: {
       i18n.loadAndActivate({locale, messages: messagesUk})
       await Promise.all([
+        import('@formatjs/intl-datetimeformat/locale-data/uk'),
         import('@formatjs/intl-pluralrules/locale-data/uk'),
         import('@formatjs/intl-numberformat/locale-data/uk'),
       ])
@@ -256,6 +284,7 @@ export async function dynamicActivate(locale: AppLanguage) {
     case AppLanguage.vi: {
       i18n.loadAndActivate({locale, messages: messagesVi})
       await Promise.all([
+        import('@formatjs/intl-datetimeformat/locale-data/vi'),
         import('@formatjs/intl-pluralrules/locale-data/vi'),
         import('@formatjs/intl-numberformat/locale-data/vi'),
       ])
@@ -264,6 +293,7 @@ export async function dynamicActivate(locale: AppLanguage) {
     case AppLanguage.zh_CN: {
       i18n.loadAndActivate({locale, messages: messagesZh_CN})
       await Promise.all([
+        import('@formatjs/intl-datetimeformat/locale-data/zh-Hans'),
         import('@formatjs/intl-pluralrules/locale-data/zh'),
         import('@formatjs/intl-numberformat/locale-data/zh'),
       ])
@@ -272,6 +302,7 @@ export async function dynamicActivate(locale: AppLanguage) {
     case AppLanguage.zh_HK: {
       i18n.loadAndActivate({locale, messages: messagesZh_HK})
       await Promise.all([
+        import('@formatjs/intl-datetimeformat/locale-data/yue'),
         import('@formatjs/intl-pluralrules/locale-data/zh'),
         import('@formatjs/intl-numberformat/locale-data/zh'),
       ])
@@ -280,6 +311,7 @@ export async function dynamicActivate(locale: AppLanguage) {
     case AppLanguage.zh_TW: {
       i18n.loadAndActivate({locale, messages: messagesZh_TW})
       await Promise.all([
+        import('@formatjs/intl-datetimeformat/locale-data/zh-Hant'),
         import('@formatjs/intl-pluralrules/locale-data/zh'),
         import('@formatjs/intl-numberformat/locale-data/zh'),
       ])

--- a/src/locale/i18n.ts
+++ b/src/locale/i18n.ts
@@ -205,7 +205,6 @@ export async function dynamicActivate(locale: AppLanguage) {
       i18n.loadAndActivate({locale, messages: messagesKm})
       await Promise.all([
         import('@formatjs/intl-datetimeformat/locale-data/km'),
-        import('@formatjs/intl-datetimeformat/locale-data/km'),
         import('@formatjs/intl-pluralrules/locale-data/km'),
         import('@formatjs/intl-numberformat/locale-data/km'),
       ])

--- a/src/locale/i18n.ts
+++ b/src/locale/i18n.ts
@@ -9,6 +9,7 @@ import '@formatjs/intl-pluralrules/locale-data/en'
 import '@formatjs/intl-numberformat/locale-data/en'
 
 import {useEffect} from 'react'
+import {getCalendars} from 'expo-localization'
 import {i18n} from '@lingui/core'
 
 import {sanitizeAppLanguageSetting} from '#/locale/helpers'
@@ -45,6 +46,20 @@ import {messages as messagesZh_CN} from '#/locale/locales/zh-CN/messages'
 import {messages as messagesZh_HK} from '#/locale/locales/zh-HK/messages'
 import {messages as messagesZh_TW} from '#/locale/locales/zh-TW/messages'
 import {useLanguagePrefs} from '#/state/preferences'
+
+/**
+ * Set default time zone for Intl.DateTimeFormat polyfill from formatjs
+ * {@link https://formatjs.github.io/docs/polyfills/intl-datetimeformat/#default-timezone}
+ *
+ * According to docs, `getCalendars` is guaranteed to have at least one
+ * calendar, and for now this ONLY returns one calendar.
+ * {@link https://docs.expo.dev/versions/latest/sdk/localization/#localizationgetcalendars}
+ */
+if ('__setDefaultTimeZone' in Intl.DateTimeFormat) {
+  console.log('Setting default time zone', getCalendars()[0].timeZone)
+  // @ts-ignore
+  Intl.DateTimeFormat.__setDefaultTimeZone(getCalendars()[0].timeZone)
+}
 
 /**
  * We do a dynamic import of just the catalog that we need

--- a/yarn.lock
+++ b/yarn.lock
@@ -4202,6 +4202,15 @@
   dependencies:
     tslib "2"
 
+"@formatjs/intl-datetimeformat@^6.17.1":
+  version "6.17.1"
+  resolved "https://registry.yarnpkg.com/@formatjs/intl-datetimeformat/-/intl-datetimeformat-6.17.1.tgz#d5e800891f9d79c8f1af1999f51db51f1384eca1"
+  integrity sha512-a18NqRo6R73xpREuMZo8FqjO+LnYFDHoeoviTh5de4ebI46wqLSDgbAIKoceuWblTQt8bvCpJIwvKgLItea88Q==
+  dependencies:
+    "@formatjs/ecma402-abstract" "2.3.1"
+    "@formatjs/intl-localematcher" "0.5.9"
+    tslib "2"
+
 "@formatjs/intl-enumerator@1.8.7":
   version "1.8.7"
   resolved "https://registry.yarnpkg.com/@formatjs/intl-enumerator/-/intl-enumerator-1.8.7.tgz#3f004753333f80cc468ae34046bd8416772a0412"


### PR DESCRIPTION
Stack on [#7195(commit)](https://github.com/bluesky-social/social-app/commit/a09c5d6d8ea346a3a044dbed8aa9d8bbfeca9503).

According to the [documentation](https://formatjs.github.io/docs/polyfills/intl-datetimeformat/#default-timezone), I imported the missing `add-all-tz.js`, and it should work properly again.

Checked on the Galaxy S22 and iOS simulator, the timezone in the screenshot is based on Central Time (UTC-6).

<img src="https://github.com/user-attachments/assets/bac91d0d-5e29-46c3-ac0d-f7c02f0a82d0" width="450">