### PR TITLE
fix(dialog): prevent unintended dialog closure on releasing pressing

### DIFF
--- a/src/components/Dialog/index.web.tsx
+++ b/src/components/Dialog/index.web.tsx
@@ -44,6 +44,7 @@ export function Outer({
   const {_} = useLingui()
   const {gtMobile} = useBreakpoints()
   const [isOpen, setIsOpen] = React.useState(false)
+  const [pressStartedInside, setPressStartedInside] = React.useState(false)
   const {setDialogIsOpen} = useDialogStateControlContext()
 
   const open = React.useCallback(() => {
@@ -75,9 +76,16 @@ export function Outer({
     [control.id, onClose, setDialogIsOpen],
   )
 
-  const handleBackgroundPress = React.useCallback(async () => {
-    close()
-  }, [close])
+  const handlePressIn = React.useCallback(() => {
+    setPressStartedInside(true)
+  }, [])
+
+  const handlePressOut = React.useCallback(() => {
+    if (pressStartedInside) {
+      close()
+    }
+    setPressStartedInside(false)
+  }, [close, pressStartedInside])
 
   useImperativeHandle(
     control.ref,
@@ -108,7 +116,8 @@ export function Outer({
             <TouchableWithoutFeedback
               accessibilityHint={undefined}
               accessibilityLabel={_(msg`Close active dialog`)}
-              onPress={handleBackgroundPress}>
+              onPressIn={handlePressIn}
+              onPressOut={handlePressOut}>
               <View
                 style={[
                   web(a.fixed),


### PR DESCRIPTION
## Problem

When users try to select text within a dialog, if they start the selection inside the dialog but move their cursor outside and release pressing, it would unexpectedly trigger the dialog to close. This creates a poor user experience, especially when users are trying to interact with text content (e.g. move to select something).

## Solution

Implemented press state tracking to ensure the dialog only closes when both the press start AND end events occur inside the background area.

## Reproduction

https://github.com/user-attachments/assets/cd403b15-985f-437b-b4d0-e473da45fbca

This screen recording demostrating me trying to full-text select the gif alt text.

