### PR TITLE
Emoji picker portaling

### DIFF
--- a/src/screens/Messages/components/MessageInput.web.tsx
+++ b/src/screens/Messages/components/MessageInput.web.tsx
@@ -3,6 +3,7 @@ import {Pressable, StyleSheet, View} from 'react-native'
 import {msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 import Graphemer from 'graphemer'
+import {flushSync} from 'react-dom'
 import TextareaAutosize from 'react-textarea-autosize'
 
 import {isSafari, isTouchDevice} from '#/lib/browser'
@@ -106,11 +107,19 @@ export function MessageInput({
 
   const onEmojiInserted = React.useCallback(
     (emoji: Emoji) => {
-      const position = textAreaRef.current?.selectionStart ?? 0
-      setMessage(
-        message =>
-          message.slice(0, position) + emoji.native + message.slice(position),
-      )
+      if (!textAreaRef.current) {
+        return
+      }
+      const position = textAreaRef.current.selectionStart ?? 0
+      textAreaRef.current.focus()
+      flushSync(() => {
+        setMessage(
+          message =>
+            message.slice(0, position) + emoji.native + message.slice(position),
+        )
+      })
+      textAreaRef.current.selectionStart = position + emoji.native.length
+      textAreaRef.current.selectionEnd = position + emoji.native.length
     },
     [setMessage],
   )

--- a/src/screens/Messages/components/MessageInput.web.tsx
+++ b/src/screens/Messages/components/MessageInput.web.tsx
@@ -157,7 +157,14 @@ export function MessageInput({
         <Button
           onPress={e => {
             e.currentTarget.measure((_fx, _fy, _width, _height, px, py) => {
-              openEmojiPicker?.({top: py, left: px, right: px, bottom: py})
+              openEmojiPicker?.({
+                top: py,
+                left: px,
+                right: px,
+                bottom: py,
+                nextFocusRef:
+                  textAreaRef as unknown as React.MutableRefObject<HTMLElement>,
+              })
             })
           }}
           style={[

--- a/src/screens/Messages/components/MessagesList.tsx
+++ b/src/screens/Messages/components/MessagesList.tsx
@@ -101,7 +101,7 @@ export function MessagesList({
   const [emojiPickerState, setEmojiPickerState] =
     React.useState<EmojiPickerState>({
       isOpen: false,
-      pos: {top: 0, left: 0, right: 0, bottom: 0},
+      pos: {top: 0, left: 0, right: 0, bottom: 0, nextFocusRef: null},
     })
 
   // We need to keep track of when the scroll offset is at the bottom of the list to know when to scroll as new items

--- a/src/screens/Messages/components/MessagesList.tsx
+++ b/src/screens/Messages/components/MessagesList.tsx
@@ -38,7 +38,6 @@ import {ChatEmptyPill} from '#/components/dms/ChatEmptyPill'
 import {MessageItem} from '#/components/dms/MessageItem'
 import {NewMessagesPill} from '#/components/dms/NewMessagesPill'
 import {Loader} from '#/components/Loader'
-import {Portal} from '#/components/Portal'
 import {Text} from '#/components/Typography'
 import {MessageInputEmbed, useMessageEmbed} from './MessageInputEmbed'
 
@@ -449,15 +448,12 @@ export function MessagesList({
       </Animated.View>
 
       {isWeb && (
-        <Portal>
-          <EmojiPicker
-            pinToTop
-            state={emojiPickerState}
-            close={() =>
-              setEmojiPickerState(prev => ({...prev, isOpen: false}))
-            }
-          />
-        </Portal>
+        <EmojiPicker
+          portal
+          pinToTop
+          state={emojiPickerState}
+          close={() => setEmojiPickerState(prev => ({...prev, isOpen: false}))}
+        />
       )}
 
       {newMessagesPill.show && <NewMessagesPill onPress={scrollToEndOnPress} />}

--- a/src/screens/Messages/components/MessagesList.tsx
+++ b/src/screens/Messages/components/MessagesList.tsx
@@ -38,6 +38,7 @@ import {ChatEmptyPill} from '#/components/dms/ChatEmptyPill'
 import {MessageItem} from '#/components/dms/MessageItem'
 import {NewMessagesPill} from '#/components/dms/NewMessagesPill'
 import {Loader} from '#/components/Loader'
+import {Portal} from '#/components/Portal'
 import {Text} from '#/components/Typography'
 import {MessageInputEmbed, useMessageEmbed} from './MessageInputEmbed'
 
@@ -448,11 +449,15 @@ export function MessagesList({
       </Animated.View>
 
       {isWeb && (
-        <EmojiPicker
-          pinToTop
-          state={emojiPickerState}
-          close={() => setEmojiPickerState(prev => ({...prev, isOpen: false}))}
-        />
+        <Portal>
+          <EmojiPicker
+            pinToTop
+            state={emojiPickerState}
+            close={() =>
+              setEmojiPickerState(prev => ({...prev, isOpen: false}))
+            }
+          />
+        </Portal>
       )}
 
       {newMessagesPill.show && <NewMessagesPill onPress={scrollToEndOnPress} />}

--- a/src/screens/Messages/components/MessagesList.tsx
+++ b/src/screens/Messages/components/MessagesList.tsx
@@ -449,7 +449,6 @@ export function MessagesList({
 
       {isWeb && (
         <EmojiPicker
-          portal
           pinToTop
           state={emojiPickerState}
           close={() => setEmojiPickerState(prev => ({...prev, isOpen: false}))}

--- a/src/state/shell/composer/index.tsx
+++ b/src/state/shell/composer/index.tsx
@@ -13,6 +13,7 @@ import {useNonReactiveCallback} from '#/lib/hooks/useNonReactiveCallback'
 import {postUriToRelativePath, toBskyAppUrl} from '#/lib/strings/url-helpers'
 import {purgeTemporaryImageFiles} from '#/state/gallery'
 import {precacheResolveLinkQuery} from '#/state/queries/resolve-link'
+import type {EmojiPickerPosition} from '#/view/com/composer/text-input/web/EmojiPicker.web'
 import * as Toast from '#/view/com/util/Toast'
 
 export interface ComposerOptsPostRef {
@@ -29,7 +30,7 @@ export interface ComposerOpts {
   onPost?: (postUri: string | undefined) => void
   quote?: AppBskyFeedDefs.PostView
   mention?: string // handle of user to mention
-  openEmojiPicker?: (pos: DOMRect | undefined) => void
+  openEmojiPicker?: (pos: EmojiPickerPosition | undefined) => void
   text?: string
   imageUris?: {uri: string; width: number; height: number; altText?: string}[]
   videoUri?: {uri: string; width: number; height: number}

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -530,7 +530,14 @@ export const ComposePost = ({
   }
 
   const onEmojiButtonPress = useCallback(() => {
-    openEmojiPicker?.(textInput.current?.getCursorPosition())
+    const rect = textInput.current?.getCursorPosition()
+    if (rect) {
+      openEmojiPicker?.({
+        ...rect,
+        nextFocusRef:
+          textInput as unknown as React.MutableRefObject<HTMLElement>,
+      })
+    }
   }, [openEmojiPicker])
 
   const scrollViewRef = useAnimatedRef<Animated.ScrollView>()

--- a/src/view/com/composer/text-input/web/EmojiPicker.web.tsx
+++ b/src/view/com/composer/text-input/web/EmojiPicker.web.tsx
@@ -10,7 +10,6 @@ import {DismissableLayer} from '@radix-ui/react-dismissable-layer'
 
 import {textInputWebEmitter} from '#/view/com/composer/text-input/textInputWebEmitter'
 import {atoms as a} from '#/alf'
-import {Portal} from '#/components/Portal'
 
 const HEIGHT_OFFSET = 40
 const WIDTH_OFFSET = 100
@@ -126,41 +125,39 @@ export function EmojiPicker({state, close, pinToTop}: IProps) {
   }
 
   return (
-    <Portal>
-      <TouchableWithoutFeedback
-        accessibilityRole="button"
-        onPress={onPressBackdrop}
-        accessibilityViewIsModal>
-        <View
-          style={[
-            a.fixed,
-            a.w_full,
-            a.h_full,
-            a.align_center,
-            {
-              top: 0,
-              left: 0,
-              right: 0,
-            },
-          ]}>
-          {/* eslint-disable-next-line react-native-a11y/has-valid-accessibility-descriptors */}
-          <TouchableWithoutFeedback onPress={e => e.stopPropagation()}>
-            <View style={[{position: 'absolute'}, position]}>
-              <DismissableLayer
-                onFocusOutside={evt => evt.preventDefault()}
-                onDismiss={close}>
-                <Picker
-                  data={async () => {
-                    return (await import('./EmojiPickerData.json')).default
-                  }}
-                  onEmojiSelect={onInsert}
-                  autoFocus={true}
-                />
-              </DismissableLayer>
-            </View>
-          </TouchableWithoutFeedback>
-        </View>
-      </TouchableWithoutFeedback>
-    </Portal>
+    <TouchableWithoutFeedback
+      accessibilityRole="button"
+      onPress={onPressBackdrop}
+      accessibilityViewIsModal>
+      <View
+        style={[
+          a.fixed,
+          a.w_full,
+          a.h_full,
+          a.align_center,
+          {
+            top: 0,
+            left: 0,
+            right: 0,
+          },
+        ]}>
+        {/* eslint-disable-next-line react-native-a11y/has-valid-accessibility-descriptors */}
+        <TouchableWithoutFeedback onPress={e => e.stopPropagation()}>
+          <View style={[{position: 'absolute'}, position]}>
+            <DismissableLayer
+              onFocusOutside={evt => evt.preventDefault()}
+              onDismiss={close}>
+              <Picker
+                data={async () => {
+                  return (await import('./EmojiPickerData.json')).default
+                }}
+                onEmojiSelect={onInsert}
+                autoFocus={true}
+              />
+            </DismissableLayer>
+          </View>
+        </TouchableWithoutFeedback>
+      </View>
+    </TouchableWithoutFeedback>
   )
 }

--- a/src/view/com/composer/text-input/web/EmojiPicker.web.tsx
+++ b/src/view/com/composer/text-input/web/EmojiPicker.web.tsx
@@ -10,6 +10,7 @@ import {DismissableLayer} from '@radix-ui/react-dismissable-layer'
 
 import {textInputWebEmitter} from '#/view/com/composer/text-input/textInputWebEmitter'
 import {atoms as a} from '#/alf'
+import {Portal} from '#/components/Portal'
 
 const HEIGHT_OFFSET = 40
 const WIDTH_OFFSET = 100
@@ -47,9 +48,14 @@ interface IProps {
    * the target element.
    */
   pinToTop?: boolean
+  /**
+   * If `true`, renders the picker in a portal at the document root. Useful if
+   * the positioning is getting wacky due to other wrapping elements.
+   */
+  portal?: boolean
 }
 
-export function EmojiPicker({state, close, pinToTop}: IProps) {
+export function EmojiPicker({state, close, pinToTop, portal}: IProps) {
   const {height, width} = useWindowDimensions()
 
   const isShiftDown = React.useRef(false)
@@ -124,7 +130,7 @@ export function EmojiPicker({state, close, pinToTop}: IProps) {
     close()
   }
 
-  return (
+  const picker = (
     <TouchableWithoutFeedback
       accessibilityRole="button"
       onPress={onPressBackdrop}
@@ -160,4 +166,5 @@ export function EmojiPicker({state, close, pinToTop}: IProps) {
       </View>
     </TouchableWithoutFeedback>
   )
+  return portal ? <Portal>{picker}</Portal> : picker
 }

--- a/src/view/com/composer/text-input/web/EmojiPicker.web.tsx
+++ b/src/view/com/composer/text-input/web/EmojiPicker.web.tsx
@@ -7,6 +7,7 @@ import {
 } from 'react-native'
 import Picker from '@emoji-mart/react'
 import {DismissableLayer} from '@radix-ui/react-dismissable-layer'
+import {FocusScope} from '@radix-ui/react-focus-scope'
 
 import {textInputWebEmitter} from '#/view/com/composer/text-input/textInputWebEmitter'
 import {atoms as a} from '#/alf'
@@ -48,14 +49,9 @@ interface IProps {
    * the target element.
    */
   pinToTop?: boolean
-  /**
-   * If `true`, renders the picker in a portal at the document root. Useful if
-   * the positioning is getting wacky due to other wrapping elements.
-   */
-  portal?: boolean
 }
 
-export function EmojiPicker({state, close, pinToTop, portal}: IProps) {
+export function EmojiPicker({state, close, pinToTop}: IProps) {
   const {height, width} = useWindowDimensions()
 
   const isShiftDown = React.useRef(false)
@@ -130,41 +126,44 @@ export function EmojiPicker({state, close, pinToTop, portal}: IProps) {
     close()
   }
 
-  const picker = (
-    <TouchableWithoutFeedback
-      accessibilityRole="button"
-      onPress={onPressBackdrop}
-      accessibilityViewIsModal>
-      <View
-        style={[
-          a.fixed,
-          a.w_full,
-          a.h_full,
-          a.align_center,
-          {
-            top: 0,
-            left: 0,
-            right: 0,
-          },
-        ]}>
-        {/* eslint-disable-next-line react-native-a11y/has-valid-accessibility-descriptors */}
-        <TouchableWithoutFeedback onPress={e => e.stopPropagation()}>
-          <View style={[{position: 'absolute'}, position]}>
-            <DismissableLayer
-              onFocusOutside={evt => evt.preventDefault()}
-              onDismiss={close}>
-              <Picker
-                data={async () => {
-                  return (await import('./EmojiPickerData.json')).default
-                }}
-                onEmojiSelect={onInsert}
-                autoFocus={true}
-              />
-            </DismissableLayer>
+  return (
+    <Portal>
+      <FocusScope loop asChild trapped>
+        <TouchableWithoutFeedback
+          accessibilityRole="button"
+          onPress={onPressBackdrop}
+          accessibilityViewIsModal>
+          <View
+            style={[
+              a.fixed,
+              a.w_full,
+              a.h_full,
+              a.align_center,
+              {
+                top: 0,
+                left: 0,
+                right: 0,
+              },
+            ]}>
+            {/* eslint-disable-next-line react-native-a11y/has-valid-accessibility-descriptors */}
+            <TouchableWithoutFeedback onPress={e => e.stopPropagation()}>
+              <View style={[{position: 'absolute'}, position]}>
+                <DismissableLayer
+                  onFocusOutside={evt => evt.preventDefault()}
+                  onDismiss={close}>
+                  <Picker
+                    data={async () => {
+                      return (await import('./EmojiPickerData.json')).default
+                    }}
+                    onEmojiSelect={onInsert}
+                    autoFocus={true}
+                  />
+                </DismissableLayer>
+              </View>
+            </TouchableWithoutFeedback>
           </View>
         </TouchableWithoutFeedback>
-      </View>
-    </TouchableWithoutFeedback>
+      </FocusScope>
+    </Portal>
   )
-  return portal ? <Portal>{picker}</Portal> : picker
 }

--- a/src/view/com/composer/text-input/web/EmojiPicker.web.tsx
+++ b/src/view/com/composer/text-input/web/EmojiPicker.web.tsx
@@ -120,7 +120,7 @@ export function EmojiPicker({state, close, pinToTop}: IProps) {
 
   return (
     <Portal>
-      <FocusScope loop trapped>
+      <FocusScope loop trapped onUnmountAutoFocus={e => e.preventDefault()}>
         <Pressable
           accessible
           accessibilityLabel={_(msg`Close emoji picker`)}

--- a/src/view/com/composer/text-input/web/EmojiPicker.web.tsx
+++ b/src/view/com/composer/text-input/web/EmojiPicker.web.tsx
@@ -1,16 +1,13 @@
 import React from 'react'
-import {
-  GestureResponderEvent,
-  TouchableWithoutFeedback,
-  useWindowDimensions,
-  View,
-} from 'react-native'
+import {Pressable, useWindowDimensions, View} from 'react-native'
 import Picker from '@emoji-mart/react'
+import {msg} from '@lingui/macro'
+import {useLingui} from '@lingui/react'
 import {DismissableLayer} from '@radix-ui/react-dismissable-layer'
 import {FocusScope} from '@radix-ui/react-focus-scope'
 
 import {textInputWebEmitter} from '#/view/com/composer/text-input/textInputWebEmitter'
-import {atoms as a} from '#/alf'
+import {atoms as a, flatten} from '#/alf'
 import {Portal} from '#/components/Portal'
 
 const HEIGHT_OFFSET = 40
@@ -52,6 +49,7 @@ interface IProps {
 }
 
 export function EmojiPicker({state, close, pinToTop}: IProps) {
+  const {_} = useLingui()
   const {height, width} = useWindowDimensions()
 
   const isShiftDown = React.useRef(false)
@@ -120,49 +118,52 @@ export function EmojiPicker({state, close, pinToTop}: IProps) {
 
   if (!state.isOpen) return null
 
-  const onPressBackdrop = (e: GestureResponderEvent) => {
-    // @ts-ignore web only
-    if (e.nativeEvent?.pointerId === -1) return
-    close()
-  }
-
   return (
     <Portal>
-      <FocusScope loop asChild trapped>
-        <TouchableWithoutFeedback
-          accessibilityRole="button"
-          onPress={onPressBackdrop}
-          accessibilityViewIsModal>
-          <View
-            style={[
-              a.fixed,
-              a.w_full,
-              a.h_full,
-              a.align_center,
-              {
-                top: 0,
-                left: 0,
-                right: 0,
-              },
-            ]}>
-            {/* eslint-disable-next-line react-native-a11y/has-valid-accessibility-descriptors */}
-            <TouchableWithoutFeedback onPress={e => e.stopPropagation()}>
-              <View style={[{position: 'absolute'}, position]}>
-                <DismissableLayer
-                  onFocusOutside={evt => evt.preventDefault()}
-                  onDismiss={close}>
-                  <Picker
-                    data={async () => {
-                      return (await import('./EmojiPickerData.json')).default
-                    }}
-                    onEmojiSelect={onInsert}
-                    autoFocus={true}
-                  />
-                </DismissableLayer>
-              </View>
-            </TouchableWithoutFeedback>
+      <FocusScope loop trapped>
+        <Pressable
+          accessible
+          accessibilityLabel={_(msg`Close emoji picker`)}
+          accessibilityHint={_(msg`Tap to close the emoji picker`)}
+          onPress={close}
+          style={[a.fixed, a.inset_0]}
+        />
+
+        <View
+          style={flatten([
+            a.fixed,
+            a.w_full,
+            a.h_full,
+            a.align_center,
+            a.z_10,
+            {
+              top: 0,
+              left: 0,
+              right: 0,
+            },
+          ])}>
+          <View style={[{position: 'absolute'}, position]}>
+            <DismissableLayer
+              onFocusOutside={evt => evt.preventDefault()}
+              onDismiss={close}>
+              <Picker
+                data={async () => {
+                  return (await import('./EmojiPickerData.json')).default
+                }}
+                onEmojiSelect={onInsert}
+                autoFocus={true}
+              />
+            </DismissableLayer>
           </View>
-        </TouchableWithoutFeedback>
+        </View>
+
+        <Pressable
+          accessible
+          accessibilityLabel={_(msg`Close emoji picker`)}
+          accessibilityHint={_(msg`Tap to close the emoji picker`)}
+          onPress={close}
+          style={[a.fixed, a.inset_0]}
+        />
       </FocusScope>
     </Portal>
   )

--- a/src/view/com/composer/text-input/web/EmojiPicker.web.tsx
+++ b/src/view/com/composer/text-input/web/EmojiPicker.web.tsx
@@ -31,6 +31,7 @@ export interface EmojiPickerPosition {
   left: number
   right: number
   bottom: number
+  nextFocusRef: React.MutableRefObject<HTMLElement> | null
 }
 
 export interface EmojiPickerState {
@@ -120,7 +121,17 @@ export function EmojiPicker({state, close, pinToTop}: IProps) {
 
   return (
     <Portal>
-      <FocusScope loop trapped onUnmountAutoFocus={e => e.preventDefault()}>
+      <FocusScope
+        loop
+        trapped
+        onUnmountAutoFocus={e => {
+          const nextFocusRef = state.pos.nextFocusRef
+          const node = nextFocusRef?.current
+          if (node) {
+            e.preventDefault()
+            node.focus()
+          }
+        }}>
         <Pressable
           accessible
           accessibilityLabel={_(msg`Close emoji picker`)}

--- a/src/view/shell/Composer.web.tsx
+++ b/src/view/shell/Composer.web.tsx
@@ -9,6 +9,7 @@ import {useModals} from '#/state/modals'
 import {ComposerOpts, useComposerState} from '#/state/shell/composer'
 import {
   EmojiPicker,
+  EmojiPickerPosition,
   EmojiPickerState,
 } from '#/view/com/composer/text-input/web/EmojiPicker.web'
 import {useBreakpoints, useTheme} from '#/alf'
@@ -42,16 +43,19 @@ function Inner({state}: {state: ComposerOpts}) {
   const {gtMobile} = useBreakpoints()
   const [pickerState, setPickerState] = React.useState<EmojiPickerState>({
     isOpen: false,
-    pos: {top: 0, left: 0, right: 0, bottom: 0},
+    pos: {top: 0, left: 0, right: 0, bottom: 0, nextFocusRef: null},
   })
 
-  const onOpenPicker = React.useCallback((pos: DOMRect | undefined) => {
-    if (!pos) return
-    setPickerState({
-      isOpen: true,
-      pos,
-    })
-  }, [])
+  const onOpenPicker = React.useCallback(
+    (pos: EmojiPickerPosition | undefined) => {
+      if (!pos) return
+      setPickerState({
+        isOpen: true,
+        pos,
+      })
+    },
+    [],
+  )
 
   const onClosePicker = React.useCallback(() => {
     setPickerState(prev => ({


### PR DESCRIPTION
The emoji picker within the composer wasn't allowing users to focus the input, although the individual buttons still worked. This was due to the `FocusScope` wrapping the `Composer`, which prevents focus from leaving the composer dialog.

In #7146, I wrapped the picker in `Portal` so that its positioning was independent of wrapping elements and their styles. This had the unintentional result of portal-ing the picker _outside_ the `FocusScope`, meaning focus couldn't be applied to the picker's search input.

<s>The fix here is to wrap the picker in `Portal` only when needed, which is currently just on the `Conversation` screen. Instead of doing this in situ (first commit), I've added a `portal?: boolean` prop to the picker that optionally wraps it in a `Portal`.</s> We fixed this an explicit nested `FocusScope` instead.

Testing: make sure all features of picker are accessible in both the composer and the conversation screen.