### PR TITLE
Don't add unused keydown listeners

### DIFF
--- a/src/view/com/util/forms/NativeDropdown.web.tsx
+++ b/src/view/com/util/forms/NativeDropdown.web.tsx
@@ -70,6 +70,10 @@ export function NativeDropdown({
   const menuRef = React.useRef<HTMLDivElement>(null)
 
   React.useEffect(() => {
+    if (!open) {
+      return
+    }
+
     function clickHandler(e: MouseEvent) {
       const t = e.target
 


### PR DESCRIPTION
Web-only.

We have hundreds of these listeners at any moment in time but usually they're not doing anything:

<img width="696" alt="Screenshot 2024-12-20 at 17 15 21" src="https://github.com/user-attachments/assets/9c53033d-9829-4e46-a9ce-1e3eb8f78abf" />

They're only relevant when `open` is `true`, as seen in the code of the handlers.

So let's attach these listeners only if `open` is true.

## Test Plan

Place `console.log` into the listeners. Verify they run on every keystroke across the app.

Apply the fix.

Verify they no longer run.

Verify the hashtag link web dropdown menu still responds to "Escape".