### PR TITLE
Align lightbox status bar behaviour on Android 15 with iOS

### DIFF
--- a/src/view/com/lightbox/ImageViewing/components/ImageDefaultHeader.tsx
+++ b/src/view/com/lightbox/ImageViewing/components/ImageDefaultHeader.tsx
@@ -5,12 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  *
  */
-import {
-  SafeAreaView,
-  StyleSheet,
-  TouchableOpacity,
-  ViewStyle,
-} from 'react-native'
+import {StyleSheet, TouchableOpacity, ViewStyle} from 'react-native'
+import {SafeAreaView} from 'react-native-safe-area-context'
 import {FontAwesomeIcon} from '@fortawesome/react-native-fontawesome'
 import {msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'

--- a/src/view/com/lightbox/ImageViewing/index.tsx
+++ b/src/view/com/lightbox/ImageViewing/index.tsx
@@ -62,9 +62,9 @@ type Rect = {x: number; y: number; width: number; height: number}
 
 const PIXEL_RATIO = PixelRatio.get()
 const EDGES =
-  Platform.OS === 'android'
+  Platform.OS === 'android' && Platform.Version < 35
     ? (['top', 'bottom', 'left', 'right'] satisfies Edge[])
-    : (['left', 'right'] satisfies Edge[]) // iOS, so no top/bottom safe area
+    : (['left', 'right'] satisfies Edge[]) // iOS or Android 15+, so no top/bottom safe area
 
 const SLOW_SPRING: WithSpringConfig = {
   mass: isIOS ? 1.25 : 0.75,


### PR DESCRIPTION
# Based on #7221 

Now that we have edge to edge mode, we can do what I always intended to do: hide the system bar with the other lightbox controls, like how iOS works

I don't know why the nav bar disappears so slowly - `react-native-edge-to-edge` claims that `expo-navigation-bars` uses depreciated android APIs, which might be it

https://github.com/user-attachments/assets/6c82d96e-2450-48b2-8622-86016a436b6e

