### PR TITLE
Disable `KeyboardAvoidingView` when keyboard is open on Android 15

### DIFF
--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -13,6 +13,7 @@ import {
   Keyboard,
   KeyboardAvoidingView,
   LayoutChangeEvent,
+  Platform,
   ScrollView,
   StyleProp,
   StyleSheet,
@@ -263,8 +264,7 @@ export const ComposePost = ({
   const viewStyles = useMemo(
     () => ({
       paddingTop: isAndroid ? insets.top : 0,
-      paddingBottom:
-        isAndroid || (isIOS && !isKeyboardVisible) ? insets.bottom : 0,
+      paddingBottom: isNative && !isKeyboardVisible ? insets.bottom : 0,
     }),
     [insets, isKeyboardVisible],
   )
@@ -610,6 +610,14 @@ export const ComposePost = ({
         testID="composePostView"
         behavior={isIOS ? 'padding' : 'height'}
         keyboardVerticalOffset={keyboardVerticalOffset}
+        // disable when android edge-to-edge
+        enabled={
+          !(
+            Platform.OS === 'android' &&
+            Platform.Version >= 35 &&
+            !isKeyboardVisible
+          )
+        }
         style={a.flex_1}>
         <View
           style={[a.flex_1, viewStyles]}

--- a/src/view/shell/Composer.tsx
+++ b/src/view/shell/Composer.tsx
@@ -1,14 +1,14 @@
 import {useEffect} from 'react'
-import {Animated, Easing, StyleSheet, View} from 'react-native'
+import {Animated, Easing, View} from 'react-native'
 
 import {useAnimatedValue} from '#/lib/hooks/useAnimatedValue'
-import {usePalette} from '#/lib/hooks/usePalette'
 import {useComposerState} from '#/state/shell/composer'
+import {atoms as a, useTheme} from '#/alf'
 import {ComposePost} from '../com/composer/Composer'
 
 export function Composer({winHeight}: {winHeight: number}) {
   const state = useComposerState()
-  const pal = usePalette('default')
+  const t = useTheme()
   const initInterp = useAnimatedValue(0)
 
   useEffect(() => {
@@ -43,7 +43,7 @@ export function Composer({winHeight}: {winHeight: number}) {
 
   return (
     <Animated.View
-      style={[styles.wrapper, pal.view, wrapperAnimStyle]}
+      style={[a.absolute, a.inset_0, t.atoms.bg, wrapperAnimStyle]}
       aria-modal
       accessibilityViewIsModal>
       <ComposePost
@@ -58,12 +58,3 @@ export function Composer({winHeight}: {winHeight: number}) {
     </Animated.View>
   )
 }
-
-const styles = StyleSheet.create({
-  wrapper: {
-    position: 'absolute',
-    top: 0,
-    bottom: 0,
-    width: '100%',
-  },
-})


### PR DESCRIPTION
<table>
  <thead>
    <tr>
      <th>Before</th>
      <th>After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><img width="200" alt="Screenshot 2024-12-20 at 21 57 02" src="https://github.com/user-attachments/assets/b4ae8d48-894f-484b-9abc-86593a8a0ff0" /></td>
      <td><img width="200" alt="Screenshot 2024-12-20 at 21 56 21" src="https://github.com/user-attachments/assets/68f73406-3883-4e90-92f7-b6b84ff18fec" /></td>
    </tr>
    <tr>
      <td><img width="200" alt="Screenshot 2024-12-20 at 21 56 48" src="https://github.com/user-attachments/assets/70dc45b5-01ff-45d4-8225-b53ffef584f2" /></td>
      <td><img width="200" alt="Screenshot 2024-12-20 at 21 56 35" src="https://github.com/user-attachments/assets/0960b625-4cbb-4984-b3b9-36d6e077e68b" /></td>
    </tr>
  </tbody>
</table>

Only downside: closing -> opening keyboard makes the top border appear. worthwhile compromise

<img width="200" alt="Screenshot 2024-12-20 at 21 58 57" src="https://github.com/user-attachments/assets/39aab555-d3a7-440d-bdd2-dde650aec07b" />

