### PR TITLE
Apply avatar moderation to quote post

### DIFF
--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -567,7 +567,6 @@ let PostThreadItemLoaded = ({
                 timestamp={post.indexedAt}
                 postHref={postHref}
                 showAvatar={isThreadedChild}
-                avatarModeration={moderation.ui('avatar')}
                 avatarSize={24}
                 style={[a.pb_xs]}
               />

--- a/src/view/com/util/PostMeta.tsx
+++ b/src/view/com/util/PostMeta.tsx
@@ -1,6 +1,6 @@
 import React, {memo, useCallback} from 'react'
 import {StyleProp, View, ViewStyle} from 'react-native'
-import {AppBskyActorDefs, ModerationDecision, ModerationUI} from '@atproto/api'
+import {AppBskyActorDefs, ModerationDecision} from '@atproto/api'
 import {msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 import {useQueryClient} from '@tanstack/react-query'
@@ -26,7 +26,6 @@ interface PostMetaOpts {
   postHref: string
   timestamp: string
   showAvatar?: boolean
-  avatarModeration?: ModerationUI
   avatarSize?: number
   onOpenAuthor?: () => void
   style?: StyleProp<ViewStyle>
@@ -67,7 +66,7 @@ let PostMeta = (opts: PostMetaOpts): React.ReactNode => {
           <PreviewableUserAvatar
             size={opts.avatarSize || 16}
             profile={opts.author}
-            moderation={opts.avatarModeration}
+            moderation={opts.moderation?.ui('avatar')}
             type={opts.author.associated?.labeler ? 'labeler' : 'user'}
           />
         </View>


### PR DESCRIPTION
Avatars in quote posts are not blurred according to moderation.

The `avatarModeration` was introduced in #2325. Later the more general `moderation` attribute was introduced in #2550, which makes `avatarModeration` obsolete.

Fixes #7117.
