### PR TITLE
Ask before navigating away from composer

### DIFF
--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, {useContext} from 'react'
 import {GestureResponderEvent} from 'react-native'
 import {sanitizeUrl} from '@braintree/sanitize-url'
 import {StackActions, useLinkProps} from '@react-navigation/native'
@@ -17,6 +17,7 @@ import {
 import {isNative, isWeb} from '#/platform/detection'
 import {shouldClickOpenNewTab} from '#/platform/urls'
 import {useModalControls} from '#/state/modals'
+import {ComposerContext} from '#/view/com/composer/Composer'
 import {atoms as a, flatten, TextStyleProp, useTheme, web} from '#/alf'
 import {Button, ButtonProps} from '#/components/Button'
 import {useInteractionState} from '#/components/hooks/useInteractionState'
@@ -84,9 +85,10 @@ export function useLink({
   const isExternal = isExternalUrl(href)
   const {openModal, closeModal} = useModalControls()
   const openLink = useOpenLink()
+  const composerContext = useContext(ComposerContext)
 
   const onPress = React.useCallback(
-    (e: GestureResponderEvent) => {
+    async (e: GestureResponderEvent) => {
       const exitEarlyIfFalse = outerOnPress?.(e)
 
       if (exitEarlyIfFalse === false) return
@@ -100,6 +102,10 @@ export function useLink({
 
       if (isWeb) {
         e.preventDefault()
+      }
+
+      if (composerContext) {
+        await composerContext.attemptNavigation()
       }
 
       if (requiresWarning) {
@@ -152,6 +158,7 @@ export function useLink({
       closeModal,
       action,
       navigation,
+      composerContext,
     ],
   )
 

--- a/src/components/ProfileHoverCard/index.web.tsx
+++ b/src/components/ProfileHoverCard/index.web.tsx
@@ -14,6 +14,7 @@ import {useProfileShadow} from '#/state/cache/profile-shadow'
 import {useModerationOpts} from '#/state/preferences/moderation-opts'
 import {usePrefetchProfileQuery, useProfileQuery} from '#/state/queries/profile'
 import {useSession} from '#/state/session'
+import {ComposerContext} from '#/view/com/composer/Composer'
 import {formatCount} from '#/view/com/util/numeric/format'
 import {UserAvatar} from '#/view/com/util/UserAvatar'
 import {ProfileHeaderHandle} from '#/screens/Profile/Header/Handle'
@@ -306,6 +307,8 @@ export function ProfileHoverCardInner(props: ProfileHoverCardProps) {
         : `fadeIn ${SHOW_DURATION}ms both`,
   }
 
+  const composerContext = React.useContext(ComposerContext)
+
   return (
     <View
       // @ts-ignore View is being used as div
@@ -318,15 +321,17 @@ export function ProfileHoverCardInner(props: ProfileHoverCardProps) {
       {props.children}
       {isVisible && (
         <Portal>
-          <div
-            ref={refs.setFloating}
-            style={floatingStyles}
-            onPointerEnter={onPointerEnterCard}
-            onPointerLeave={onPointerLeaveCard}>
-            <div style={{willChange: 'transform', ...animationStyle}}>
-              <Card did={props.did} hide={onPress} />
+          <ComposerContext.Provider value={composerContext}>
+            <div
+              ref={refs.setFloating}
+              style={floatingStyles}
+              onPointerEnter={onPointerEnterCard}
+              onPointerLeave={onPointerLeaveCard}>
+              <div style={{willChange: 'transform', ...animationStyle}}>
+                <Card did={props.did} hide={onPress} />
+              </div>
             </div>
-          </div>
+          </ComposerContext.Provider>
         </Portal>
       )}
     </View>

--- a/src/components/Prompt.tsx
+++ b/src/components/Prompt.tsx
@@ -27,10 +27,12 @@ export function Outer({
   control,
   testID,
   nativeOptions,
+  onCancel,
 }: React.PropsWithChildren<{
   control: Dialog.DialogControlProps
   testID?: string
   nativeOptions?: Omit<BottomSheetViewProps, 'children'>
+  onCancel?: () => void
 }>) {
   const {gtMobile} = useBreakpoints()
   const titleId = React.useId()
@@ -45,6 +47,7 @@ export function Outer({
     <Dialog.Outer
       control={control}
       testID={testID}
+      onClose={onCancel}
       nativeOptions={{preventExpansion: true, ...nativeOptions}}>
       <Dialog.Handle />
       <Context.Provider value={context}>
@@ -108,18 +111,21 @@ export function Actions({children}: React.PropsWithChildren<{}>) {
 
 export function Cancel({
   cta,
+  onCancel,
 }: {
   /**
    * Optional i18n string. If undefined, it will default to "Cancel".
    */
   cta?: string
+  onCancel?: () => void
 }) {
   const {_} = useLingui()
   const {gtMobile} = useBreakpoints()
   const {close} = Dialog.useDialogContext()
   const onPress = React.useCallback(() => {
+    onCancel?.()
     close()
-  }, [close])
+  }, [onCancel, close])
 
   return (
     <Button
@@ -184,6 +190,7 @@ export function Basic({
   cancelButtonCta,
   confirmButtonCta,
   onConfirm,
+  onCancel,
   confirmButtonColor,
   showCancel = true,
 }: React.PropsWithChildren<{
@@ -200,11 +207,12 @@ export function Basic({
    * should NOT close the dialog as a side effect of this method.
    */
   onConfirm: (e: GestureResponderEvent) => void
+  onCancel?: () => void
   confirmButtonColor?: ButtonColor
   showCancel?: boolean
 }>) {
   return (
-    <Outer control={control} testID="confirmModal">
+    <Outer control={control} testID="confirmModal" onCancel={onCancel}>
       <TitleText>{title}</TitleText>
       <DescriptionText>{description}</DescriptionText>
       <Actions>
@@ -214,7 +222,7 @@ export function Basic({
           color={confirmButtonColor}
           testID="confirmBtn"
         />
-        {showCancel && <Cancel cta={cancelButtonCta} />}
+        {showCancel && <Cancel onCancel={onCancel} cta={cancelButtonCta} />}
       </Actions>
     </Outer>
   )


### PR DESCRIPTION
This makes the **Discard draft?** post show up if you click on a link within the composer.

That fixes a bug where you write a reply to a post and then lose the reply by clicking on the avatar of the person who you’re responding to. You would not be prompted whether you want to discard your draft like when clicking on **Cancel**. This bug also applies to hovering over the avatar and clicking on one of the links there, which this fixes too.

This is done by introducing a `ComposerContext` that provides an async function that resolves if the user decided to discard the draft and navigation was thus allowed.

## Videos

| Situation | Before | After |
| --- | --- | --- |
| Clicking on avatar | https://github.com/user-attachments/assets/a902baf9-c9cb-4af6-a417-99fe600a1686 | https://github.com/user-attachments/assets/b7bc3057-2deb-427a-a93d-d7dff86c17db |
| Clicking on card | https://github.com/user-attachments/assets/b47afa4c-c5e1-4430-aa37-c3e78aba101c | https://github.com/user-attachments/assets/2da47587-4557-4284-b790-915d5c843f5c |