### PR TITLE
Make "Retry" button label translatable

### DIFF
--- a/src/locale/locales/en/messages.po
+++ b/src/locale/locales/en/messages.po
@@ -1415,7 +1415,7 @@ msgstr ""
 #: src/components/dms/ConvoMenu.tsx:112
 #: src/components/dms/MessageMenu.tsx:81
 #: src/Navigation.tsx:393
-#: src/screens/Messages/ChatList.tsx:244
+#: src/screens/Messages/ChatList.tsx:246
 msgid "Chat settings"
 msgstr ""
 
@@ -4191,8 +4191,8 @@ msgstr ""
 #~ msgstr ""
 
 #: src/Navigation.tsx:609
-#: src/screens/Messages/ChatList.tsx:260
-#: src/screens/Messages/ChatList.tsx:284
+#: src/screens/Messages/ChatList.tsx:262
+#: src/screens/Messages/ChatList.tsx:286
 msgid "Messages"
 msgstr ""
 
@@ -4484,8 +4484,8 @@ msgstr ""
 #~ msgstr ""
 
 #: src/components/dms/dialogs/NewChatDialog.tsx:65
-#: src/screens/Messages/ChatList.tsx:267
-#: src/screens/Messages/ChatList.tsx:274
+#: src/screens/Messages/ChatList.tsx:269
+#: src/screens/Messages/ChatList.tsx:276
 msgid "New chat"
 msgstr ""
 
@@ -4630,7 +4630,7 @@ msgstr ""
 msgid "No messages yet"
 msgstr ""
 
-#: src/screens/Messages/ChatList.tsx:223
+#: src/screens/Messages/ChatList.tsx:225
 msgid "No more conversations to show"
 msgstr ""
 
@@ -4743,7 +4743,7 @@ msgstr ""
 msgid "Note: Bluesky is an open and public network. This setting only limits the visibility of your content on the Bluesky app and website, and other apps may not respect this setting. Your content may still be shown to logged-out users by other apps and websites."
 msgstr ""
 
-#: src/screens/Messages/ChatList.tsx:178
+#: src/screens/Messages/ChatList.tsx:180
 msgid "Nothing here"
 msgstr ""
 
@@ -6118,6 +6118,7 @@ msgstr ""
 #: src/components/StarterPack/ProfileStarterPacks.tsx:336
 #: src/screens/Login/LoginForm.tsx:305
 #: src/screens/Login/LoginForm.tsx:312
+#: src/screens/Messages/ChatList.tsx:169
 #: src/screens/Messages/components/MessageListError.tsx:25
 #: src/screens/Onboarding/StepInterests/index.tsx:217
 #: src/screens/Onboarding/StepInterests/index.tsx:220
@@ -8690,7 +8691,7 @@ msgstr ""
 msgid "You have muted this user"
 msgstr ""
 
-#: src/screens/Messages/ChatList.tsx:188
+#: src/screens/Messages/ChatList.tsx:190
 msgid "You have no conversations yet. Start one!"
 msgstr ""
 

--- a/src/screens/Messages/ChatList.tsx
+++ b/src/screens/Messages/ChatList.tsx
@@ -165,7 +165,9 @@ export function MessagesScreen({navigation, route}: Props) {
                       color="secondary"
                       variant="solid"
                       onPress={() => refetch()}>
-                      <ButtonText>Retry</ButtonText>
+                      <ButtonText>
+                        <Trans>Retry</Trans>
+                      </ButtonText>
                       <ButtonIcon icon={Retry} position="right" />
                     </Button>
                   </View>


### PR DESCRIPTION
The Retry button on https://bsky.app/messages is not translatable. The button is shown when logged in with an app password.

(change originally included in [PR #7220](https://github.com/bluesky-social/social-app/pull/7220#discussion_r1894612488))