### PR TITLE
Extend clickable area to height of container

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -92,6 +92,9 @@ a[role='link'][data-no-underline='1']:hover {
 }
 
 /* ProseMirror */
+.ProseMirror {
+  min-height: inherit;
+}
 .ProseMirror-dark {
   color: white;
 }


### PR DESCRIPTION
On web, if the text input looses focus, e.g. because you have used the media buttons in the composer footer, it is a bit tricky to refocus the text input in order to continue writing on the post text, because only a small strip at the top of the big white area of the compose dialog is clickable.

The green line shows the current clickable area. This PR extends the clickable area to the one indicated by red line.

<img width="641" alt="image" src="https://github.com/user-attachments/assets/f991667a-d072-4067-b632-d2044534cc3b" />
