### PR TITLE
Correct font preload

### DIFF
--- a/bskyweb/templates/base.html
+++ b/bskyweb/templates/base.html
@@ -13,7 +13,7 @@
 
   <!-- Hello Humans! API docs at https://atproto.com -->
 
-  <link rel="preload" as="font" type="font/ttf" href="{{ staticCDNHost }}/static/media/InterVariable.c504db5c06caaf7cdfba.woff2">
+  <link rel="preload" as="font" type="font/woff2" href="{{ staticCDNHost }}/static/media/InterVariable.c504db5c06caaf7cdfba.woff2" crossorigin>
 
   <style>
     /**


### PR DESCRIPTION
Missed these updated from #6993.

This means the font is still being loaded twice:

https://www.webpagetest.org/result/241222_BiDcC9_64Z/1/details/cached/#waterfall_view_step1

Down from four times (as Italic is no longer preloaded), and smaller (as woff2), so it’s better, but still double what’s needed!