### PR TITLE
Cropper - opt out of edge-to-edge enforcement on Android 15

### DIFF
--- a/patches/react-native-image-crop-picker+0.41.6.patch
+++ b/patches/react-native-image-crop-picker+0.41.6.patch
@@ -35,7 +35,7 @@ diff --git a/node_modules/react-native-image-crop-picker/ios/src/ImageCropPicker
 index 9f20973..68d4766 100644
 --- a/node_modules/react-native-image-crop-picker/ios/src/ImageCropPicker.m
 +++ b/node_modules/react-native-image-crop-picker/ios/src/ImageCropPicker.m
-@@ -126,7 +126,8 @@ RCT_EXPORT_MODULE();
+@@ -126,7 +126,8 @@ - (void) setConfiguration:(NSDictionary *)options
  
  - (UIViewController*) getRootVC {
      UIViewController *root = [[[[UIApplication sharedApplication] delegate] window] rootViewController];

--- a/patches/react-native-image-crop-picker+0.41.6.patch
+++ b/patches/react-native-image-crop-picker+0.41.6.patch
@@ -1,8 +1,41 @@
+diff --git a/node_modules/react-native-image-crop-picker/android/src/main/AndroidManifest.xml b/node_modules/react-native-image-crop-picker/android/src/main/AndroidManifest.xml
+index 391f303..8e2c3db 100644
+--- a/node_modules/react-native-image-crop-picker/android/src/main/AndroidManifest.xml
++++ b/node_modules/react-native-image-crop-picker/android/src/main/AndroidManifest.xml
+@@ -24,7 +24,7 @@
+ 
+         <activity
+             android:name="com.yalantis.ucrop.UCropActivity"
+-            android:theme="@style/Theme.AppCompat.Light.NoActionBar" />
++            android:theme="@style/Theme.UCropNoEdgeToEdge" />
+     </application>
+ 
+ </manifest>
+diff --git a/node_modules/react-native-image-crop-picker/android/src/main/res/values-v35/styles.xml b/node_modules/react-native-image-crop-picker/android/src/main/res/values-v35/styles.xml
+new file mode 100644
+index 0000000..396d5a8
+--- /dev/null
++++ b/node_modules/react-native-image-crop-picker/android/src/main/res/values-v35/styles.xml
+@@ -0,0 +1,5 @@
++<resources>
++    <style name="Theme.UCropNoEdgeToEdge" parent="Theme.AppCompat.Light.NoActionBar">
++        <item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
++    </style>
++</resources>
+diff --git a/node_modules/react-native-image-crop-picker/android/src/main/res/values/styles.xml b/node_modules/react-native-image-crop-picker/android/src/main/res/values/styles.xml
+new file mode 100644
+index 0000000..50129b6
+--- /dev/null
++++ b/node_modules/react-native-image-crop-picker/android/src/main/res/values/styles.xml
+@@ -0,0 +1,3 @@
++<resources>
++    <style name="Theme.UCropNoEdgeToEdge" parent="Theme.AppCompat.Light.NoActionBar"/>
++</resources>
 diff --git a/node_modules/react-native-image-crop-picker/ios/src/ImageCropPicker.m b/node_modules/react-native-image-crop-picker/ios/src/ImageCropPicker.m
 index 9f20973..68d4766 100644
 --- a/node_modules/react-native-image-crop-picker/ios/src/ImageCropPicker.m
 +++ b/node_modules/react-native-image-crop-picker/ios/src/ImageCropPicker.m
-@@ -126,7 +126,8 @@ - (void) setConfiguration:(NSDictionary *)options
+@@ -126,7 +126,8 @@ RCT_EXPORT_MODULE();
  
  - (UIViewController*) getRootVC {
      UIViewController *root = [[[[UIApplication sharedApplication] delegate] window] rootViewController];


### PR DESCRIPTION
Breakdown of changes:

1. Changed theme to custom `UCropNoEdgeToEdge`
2. Added new theme which just extends the old theme
3. For API level 35+ (Android 15), add `<item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>` to the theme


<img width="404" alt="Screenshot 2024-12-23 at 13 44 40" src="https://github.com/user-attachments/assets/88efde7a-9870-4885-8bb0-e86e8436aa26" />

# Test plan

Test main on Android 15 with 3-button navigation - observe overlap
Test this PR - overlap should be fixed
Test this PR on Android 14 or lower to check no regressions
