### PR TITLE
Unlock orientation when lightbox is open

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -50,7 +50,6 @@ module.exports = function (config) {
       runtimeVersion: {
         policy: 'appVersion',
       },
-      orientation: 'portrait',
       icon: './assets/app-icons/ios_icon_default_light.png',
       userInterfaceStyle: 'automatic',
       primaryColor: '#1083fe',
@@ -346,6 +345,7 @@ module.exports = function (config) {
             },
           },
         ],
+        ['expo-screen-orientation', {initialOrientation: 'PORTRAIT_UP'}],
       ].filter(Boolean),
       extra: {
         eas: {

--- a/package.json
+++ b/package.json
@@ -138,6 +138,7 @@
     "expo-media-library": "~17.0.3",
     "expo-navigation-bar": "~4.0.4",
     "expo-notifications": "~0.29.11",
+    "expo-screen-orientation": "^8.0.2",
     "expo-sharing": "^13.0.0",
     "expo-splash-screen": "~0.29.18",
     "expo-status-bar": "~2.0.0",

--- a/src/App.native.tsx
+++ b/src/App.native.tsx
@@ -10,6 +10,7 @@ import {
   initialWindowMetrics,
   SafeAreaProvider,
 } from 'react-native-safe-area-context'
+import * as ScreenOrientation from 'expo-screen-orientation'
 import * as SplashScreen from 'expo-splash-screen'
 import * as SystemUI from 'expo-system-ui'
 import {msg} from '@lingui/macro'
@@ -22,7 +23,7 @@ import {s} from '#/lib/styles'
 import {ThemeProvider} from '#/lib/ThemeContext'
 import I18nProvider from '#/locale/i18nProvider'
 import {logger} from '#/logger'
-import {isIOS} from '#/platform/detection'
+import {isAndroid, isIOS} from '#/platform/detection'
 import {Provider as A11yProvider} from '#/state/a11y'
 import {Provider as MutedThreadsProvider} from '#/state/cache/thread-mutes'
 import {Provider as DialogStateProvider} from '#/state/dialogs'
@@ -76,6 +77,10 @@ import {BackgroundNotificationPreferencesProvider} from '../modules/expo-backgro
 SplashScreen.preventAutoHideAsync()
 if (isIOS) {
   SystemUI.setBackgroundColorAsync('black')
+}
+if (isAndroid) {
+  // iOS is handled by the config plugin -sfn
+  ScreenOrientation.lockAsync(ScreenOrientation.OrientationLock.PORTRAIT_UP)
 }
 
 /**

--- a/src/App.native.tsx
+++ b/src/App.native.tsx
@@ -80,9 +80,7 @@ if (isIOS) {
 }
 if (isAndroid) {
   // iOS is handled by the config plugin -sfn
-  ScreenOrientation.lockAsync(
-    ScreenOrientation.OrientationLock.PORTRAIT_UP,
-  ).catch(() => console.error('Could not lock screen orientation'))
+  ScreenOrientation.lockAsync(ScreenOrientation.OrientationLock.PORTRAIT_UP)
 }
 
 /**

--- a/src/App.native.tsx
+++ b/src/App.native.tsx
@@ -80,7 +80,9 @@ if (isIOS) {
 }
 if (isAndroid) {
   // iOS is handled by the config plugin -sfn
-  ScreenOrientation.lockAsync(ScreenOrientation.OrientationLock.PORTRAIT_UP)
+  ScreenOrientation.lockAsync(
+    ScreenOrientation.OrientationLock.PORTRAIT_UP,
+  ).catch(() => console.error('Could not lock screen orientation'))
 }
 
 /**

--- a/src/alf/util/navigationBar.ts
+++ b/src/alf/util/navigationBar.ts
@@ -1,4 +1,5 @@
 import * as NavigationBar from 'expo-navigation-bar'
+import * as SystemUI from 'expo-system-ui'
 
 import {isAndroid} from '#/platform/detection'
 import {Theme} from '../types'
@@ -9,10 +10,12 @@ export function setNavigationBar(themeType: 'theme' | 'lightbox', t: Theme) {
       NavigationBar.setBackgroundColorAsync(t.atoms.bg.backgroundColor)
       NavigationBar.setBorderColorAsync(t.atoms.bg.backgroundColor)
       NavigationBar.setButtonStyleAsync(t.name !== 'light' ? 'light' : 'dark')
+      SystemUI.setBackgroundColorAsync(t.atoms.bg.backgroundColor)
     } else {
       NavigationBar.setBackgroundColorAsync('black')
       NavigationBar.setBorderColorAsync('black')
       NavigationBar.setButtonStyleAsync('light')
+      SystemUI.setBackgroundColorAsync('black')
     }
   }
 }

--- a/src/view/com/lightbox/ImageViewing/index.tsx
+++ b/src/view/com/lightbox/ImageViewing/index.tsx
@@ -150,14 +150,12 @@ export default function ImageViewRoot({
 
   useEffect(() => {
     if (activeLightbox) {
-      ScreenOrientation.unlockAsync().catch(() =>
-        console.error('Could not unlock screen orientation'),
-      )
+      ScreenOrientation.unlockAsync()
       return () => {
         // default is PORTRAIT_UP - set via config plugin in app.config.js -sfn
         ScreenOrientation.lockAsync(
           ScreenOrientation.OrientationLock.PORTRAIT_UP,
-        ).catch(() => console.error('Could not lock screen orientation'))
+        )
       }
     }
   }, [activeLightbox])

--- a/src/view/com/lightbox/ImageViewing/index.tsx
+++ b/src/view/com/lightbox/ImageViewing/index.tsx
@@ -9,13 +9,7 @@
 // https://github.com/jobtoday/react-native-image-viewing
 
 import React, {useCallback, useEffect, useMemo, useState} from 'react'
-import {
-  LayoutAnimation,
-  PixelRatio,
-  Platform,
-  StyleSheet,
-  View,
-} from 'react-native'
+import {LayoutAnimation, PixelRatio, StyleSheet, View} from 'react-native'
 import {Gesture} from 'react-native-gesture-handler'
 import PagerView from 'react-native-pager-view'
 import Animated, {
@@ -35,7 +29,6 @@ import Animated, {
   WithSpringConfig,
 } from 'react-native-reanimated'
 import {
-  Edge,
   SafeAreaView,
   useSafeAreaFrame,
   useSafeAreaInsets,
@@ -62,10 +55,6 @@ import ImageItem from './components/ImageItem/ImageItem'
 type Rect = {x: number; y: number; width: number; height: number}
 
 const PIXEL_RATIO = PixelRatio.get()
-const EDGES =
-  Platform.OS === 'android' && Platform.Version < 35
-    ? (['top', 'bottom', 'left', 'right'] satisfies Edge[])
-    : (['left', 'right'] satisfies Edge[]) // iOS or Android 15+, so no top/bottom safe area
 
 const SLOW_SPRING: WithSpringConfig = {
   mass: isIOS ? 1.25 : 0.75,
@@ -161,9 +150,8 @@ export default function ImageViewRoot({
 
   return (
     // Keep it always mounted to avoid flicker on the first frame.
-    <SafeAreaView
+    <View
       style={[styles.screen, !activeLightbox && styles.screenHidden]}
-      edges={EDGES}
       aria-modal
       accessibilityViewIsModal
       aria-hidden={!activeLightbox}>
@@ -181,7 +169,7 @@ export default function ImageViewRoot({
           />
         )}
       </Animated.View>
-    </SafeAreaView>
+    </View>
   )
 }
 
@@ -572,7 +560,7 @@ function LightboxFooter({
         paddingVertical: 12,
         paddingHorizontal: 24,
       }}>
-      <SafeAreaView edges={['bottom']}>
+      <SafeAreaView edges={['bottom', 'left', 'right']}>
         {altText ? (
           <View accessibilityRole="button" style={styles.footerText}>
             <Text

--- a/src/view/com/lightbox/ImageViewing/index.tsx
+++ b/src/view/com/lightbox/ImageViewing/index.tsx
@@ -104,7 +104,9 @@ export default function ImageViewRoot({
   'use no memo'
   const ref = useAnimatedRef<View>()
   const [activeLightbox, setActiveLightbox] = useState(nextLightbox)
-  const [safeAreaRelayout, setSafeAreaRelayout] = useState(0)
+  const [orientation, setOrientation] = useState<'portrait' | 'landscape'>(
+    'portrait',
+  )
   const openProgress = useSharedValue(0)
 
   if (!activeLightbox && nextLightbox) {
@@ -163,11 +165,6 @@ export default function ImageViewRoot({
     runOnJS(onRequestClose)()
   }, [onRequestClose, openProgress])
 
-  // reset children state on relayout, most likely due to orientation change
-  // it's a counter, and 0 -> 1 is the first render. so we can let the key start at 1
-  // -sfn
-  const layoutKey = String(Math.max(safeAreaRelayout, 1))
-
   return (
     // Keep it always mounted to avoid flicker on the first frame.
     <SafeAreaView
@@ -180,13 +177,15 @@ export default function ImageViewRoot({
         ref={ref}
         style={{flex: 1}}
         collapsable={false}
-        onLayout={() => {
-          // most likely due to orientation change
-          setSafeAreaRelayout(i => i + 1)
+        onLayout={e => {
+          const layout = e.nativeEvent.layout
+          setOrientation(
+            layout.height > layout.width ? 'portrait' : 'landscape',
+          )
         }}>
         {activeLightbox && (
           <ImageView
-            key={activeLightbox.id + '-' + layoutKey}
+            key={activeLightbox.id + '-' + orientation}
             lightbox={activeLightbox}
             onRequestClose={onRequestClose}
             onPressSave={onPressSave}

--- a/src/view/com/lightbox/ImageViewing/index.tsx
+++ b/src/view/com/lightbox/ImageViewing/index.tsx
@@ -9,7 +9,13 @@
 // https://github.com/jobtoday/react-native-image-viewing
 
 import React, {useCallback, useEffect, useMemo, useState} from 'react'
-import {LayoutAnimation, PixelRatio, StyleSheet, View} from 'react-native'
+import {
+  LayoutAnimation,
+  PixelRatio,
+  Platform,
+  StyleSheet,
+  View,
+} from 'react-native'
 import {Gesture} from 'react-native-gesture-handler'
 import PagerView from 'react-native-pager-view'
 import Animated, {
@@ -29,6 +35,7 @@ import Animated, {
   WithSpringConfig,
 } from 'react-native-reanimated'
 import {
+  Edge,
   SafeAreaView,
   useSafeAreaFrame,
   useSafeAreaInsets,
@@ -55,6 +62,10 @@ import ImageItem from './components/ImageItem/ImageItem'
 type Rect = {x: number; y: number; width: number; height: number}
 
 const PIXEL_RATIO = PixelRatio.get()
+const EDGES =
+  Platform.OS === 'android' && Platform.Version < 35
+    ? (['top', 'bottom', 'left', 'right'] satisfies Edge[])
+    : ([] satisfies Edge[]) // iOS or Android 15+ bleeds into safe area
 
 const SLOW_SPRING: WithSpringConfig = {
   mass: isIOS ? 1.25 : 0.75,
@@ -150,8 +161,9 @@ export default function ImageViewRoot({
 
   return (
     // Keep it always mounted to avoid flicker on the first frame.
-    <View
+    <SafeAreaView
       style={[styles.screen, !activeLightbox && styles.screenHidden]}
+      edges={EDGES}
       aria-modal
       accessibilityViewIsModal
       aria-hidden={!activeLightbox}>
@@ -169,7 +181,7 @@ export default function ImageViewRoot({
           />
         )}
       </Animated.View>
-    </View>
+    </SafeAreaView>
   )
 }
 
@@ -560,7 +572,7 @@ function LightboxFooter({
         paddingVertical: 12,
         paddingHorizontal: 24,
       }}>
-      <SafeAreaView edges={['bottom', 'left', 'right']}>
+      <SafeAreaView edges={['bottom']}>
         {altText ? (
           <View accessibilityRole="button" style={styles.footerText}>
             <Text

--- a/src/view/com/lightbox/ImageViewing/index.tsx
+++ b/src/view/com/lightbox/ImageViewing/index.tsx
@@ -150,12 +150,14 @@ export default function ImageViewRoot({
 
   useEffect(() => {
     if (activeLightbox) {
-      ScreenOrientation.unlockAsync()
+      ScreenOrientation.unlockAsync().catch(() =>
+        console.error('Could not unlock screen orientation'),
+      )
       return () => {
         // default is PORTRAIT_UP - set via config plugin in app.config.js -sfn
         ScreenOrientation.lockAsync(
           ScreenOrientation.OrientationLock.PORTRAIT_UP,
-        )
+        ).catch(() => console.error('Could not lock screen orientation'))
       }
     }
   }, [activeLightbox])

--- a/src/view/com/lightbox/ImageViewing/index.tsx
+++ b/src/view/com/lightbox/ImageViewing/index.tsx
@@ -187,6 +187,7 @@ export default function ImageViewRoot({
           <ImageView
             key={activeLightbox.id + '-' + orientation}
             lightbox={activeLightbox}
+            orientation={orientation}
             onRequestClose={onRequestClose}
             onPressSave={onPressSave}
             onPressShare={onPressShare}
@@ -202,6 +203,7 @@ export default function ImageViewRoot({
 
 function ImageView({
   lightbox,
+  orientation,
   onRequestClose,
   onPressSave,
   onPressShare,
@@ -210,6 +212,7 @@ function ImageView({
   openProgress,
 }: {
   lightbox: Lightbox
+  orientation: 'portrait' | 'landscape'
   onRequestClose: () => void
   onPressSave: (uri: string) => void
   onPressShare: (uri: string) => void
@@ -249,7 +252,7 @@ function ImageView({
     const openProgressValue = openProgress.get()
     if (openProgressValue < 1) {
       opacity = Math.sqrt(openProgressValue)
-    } else if (screenSize) {
+    } else if (screenSize && orientation === 'portrait') {
       const dragProgress = Math.min(
         Math.abs(dismissSwipeTranslateY.get()) / (screenSize.height / 2),
         1,

--- a/src/view/com/lightbox/ImageViewing/index.tsx
+++ b/src/view/com/lightbox/ImageViewing/index.tsx
@@ -40,6 +40,7 @@ import {
   useSafeAreaFrame,
   useSafeAreaInsets,
 } from 'react-native-safe-area-context'
+import * as ScreenOrientation from 'expo-screen-orientation'
 import {StatusBar} from 'expo-status-bar'
 import {FontAwesomeIcon} from '@fortawesome/react-native-fontawesome'
 import {Trans} from '@lingui/macro'
@@ -145,6 +146,18 @@ export default function ImageViewRoot({
     openProgress.set(0)
     runOnJS(onRequestClose)()
   }, [onRequestClose, openProgress])
+
+  useEffect(() => {
+    if (activeLightbox) {
+      ScreenOrientation.unlockAsync()
+      return () => {
+        // default is PORTRAIT_UP - set via config plugin in app.config.js -sfn
+        ScreenOrientation.lockAsync(
+          ScreenOrientation.OrientationLock.PORTRAIT_UP,
+        )
+      }
+    }
+  }, [activeLightbox])
 
   return (
     // Keep it always mounted to avoid flicker on the first frame.

--- a/yarn.lock
+++ b/yarn.lock
@@ -10621,6 +10621,11 @@ expo-pwa@0.0.127:
     commander "2.20.0"
     update-check "1.5.3"
 
+expo-screen-orientation@^8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/expo-screen-orientation/-/expo-screen-orientation-8.0.2.tgz#69139a1967557a331188d36b4dd615a0e220c2a0"
+  integrity sha512-YsY7Oumlv1WsHLQVgl1f+vAiMZfzUPGyVF2xc7jxmHKtM+jMzIflDl2qKLGfoB0S9Pgg6Z8V4+c+A8wlCURw4A==
+
 expo-sharing@^13.0.0:
   version "13.0.0"
   resolved "https://registry.yarnpkg.com/expo-sharing/-/expo-sharing-13.0.0.tgz#fbc46f4afdaa265a2811fe88c2a589aae2d2de0f"


### PR DESCRIPTION
Fixes https://github.com/bluesky-social/social-app/issues/624

Unlocks device rotation when lightbox is open

Details:
- Screen orientation is locked to portrait normally. on iOS this is acheived via the config plugin, on Android we just have to call `lockAsync` as soon as it starts up
- Locking/unlocked achieved via an effect in the lightbox component
- Safe area for iOS/Android 15 was changed to not include the sides either - this was 0 anyway for portrait mode, and now allows it to be full-screen when rotated
- Lightbox state (so zoom, position etc) is cleared via key whenever an orientation change happens to ensure that it doesn't get into a wonky state
- There's some sort of double nav bar inset when sideways on Android <15. It's entirely outside of the app, not anything we're doing as far as I can tell. Not sure what's up with that, I just painted it black.

https://github.com/user-attachments/assets/f81f8fe9-d654-4eaf-bfb4-5be916d956fb

https://github.com/user-attachments/assets/05fe6a97-c85c-4fae-bc66-405eb5e7817e
    
# Test plan

Test iOS, Android <=14, Android 15
Test rotating, test lightbox gesture behaviour while/after rotating
Try and test on device where possible

