### PR TITLE
Remove undefined strings from mute list search

### DIFF
--- a/src/state/queries/trending/useTrendingTopics.ts
+++ b/src/state/queries/trending/useTrendingTopics.ts
@@ -34,13 +34,17 @@ export function useTrendingTopics() {
         topics: topics.filter(t => {
           return !hasMutedWord({
             mutedWords,
-            text: t.topic + ' ' + t.displayName + ' ' + t.description,
+            text: [t.topic, t.displayName, t.description]
+              .filter(Boolean)
+              .join(' '),
           })
         }),
         suggested: suggested.filter(t => {
           return !hasMutedWord({
             mutedWords,
-            text: t.topic + ' ' + t.displayName + ' ' + t.description,
+            text: [t.topic, t.displayName, t.description]
+              .filter(Boolean)
+              .join(' '),
           })
         }),
       }


### PR DESCRIPTION
Fixes a small bug where the text being passed to the `hasMutedWord` function is something like `"{topic} undefined undefined"`. This is happening because there are currently no `displayName` or `description` properties on the topic object being returned from the API:

![No displayName or description property](https://github.com/user-attachments/assets/62164b76-f3fb-475c-8bbf-5bb4a4c6d371)

Since these properties don't exist, `text: t.topic + ' ' + t.displayName + ' ' + t.description` evaluates to `t.topic + ' ' + undefined + ' ' + undefined`, and `undefined` gets coerced to a string.

## Impact

I suspect there is little impact of this bug, but it is _possible_ a subset of the word `undefined` or that concatenated with a topic may accidentally cause topics to get incorrectly muted.

## Change

Applies a `Boolean` filter to removed falsey values from the topic properties prior to concatenating with a space.