### PR TITLE
Fix mute words in trending

### DIFF
--- a/src/state/queries/trending/useTrendingTopics.ts
+++ b/src/state/queries/trending/useTrendingTopics.ts
@@ -28,7 +28,10 @@ export function useTrendingTopics() {
       const {data} = await agent.api.app.bsky.unspecced.getTrendingTopics({
         limit: DEFAULT_LIMIT,
       })
-      return data
+      return {
+        topics: data.topics ?? [],
+        suggested: data.suggested ?? [],
+      }
     },
     select(data) {
       return {

--- a/src/state/queries/trending/useTrendingTopics.ts
+++ b/src/state/queries/trending/useTrendingTopics.ts
@@ -28,16 +28,17 @@ export function useTrendingTopics() {
       const {data} = await agent.api.app.bsky.unspecced.getTrendingTopics({
         limit: DEFAULT_LIMIT,
       })
-
-      const {topics, suggested} = data
+      return data
+    },
+    select(data) {
       return {
-        topics: topics.filter(t => {
+        topics: data.topics.filter(t => {
           return !hasMutedWord({
             mutedWords,
             text: t.topic + ' ' + t.displayName + ' ' + t.description,
           })
         }),
-        suggested: suggested.filter(t => {
+        suggested: data.suggested.filter(t => {
           return !hasMutedWord({
             mutedWords,
             text: t.topic + ' ' + t.displayName + ' ' + t.description,

--- a/src/state/queries/trending/useTrendingTopics.ts
+++ b/src/state/queries/trending/useTrendingTopics.ts
@@ -9,6 +9,11 @@ import {useAgent} from '#/state/session'
 
 export type TrendingTopic = AppBskyUnspeccedDefs.TrendingTopic
 
+type Response = {
+  topics: TrendingTopic[]
+  suggested: TrendingTopic[]
+}
+
 export const DEFAULT_LIMIT = 14
 
 export const trendingTopicsQueryKey = ['trending-topics']
@@ -20,7 +25,7 @@ export function useTrendingTopics() {
     return preferences?.moderationPrefs?.mutedWords || []
   }, [preferences?.moderationPrefs])
 
-  return useQuery({
+  return useQuery<Response>({
     refetchOnWindowFocus: true,
     staleTime: STALE.MINUTES.THREE,
     queryKey: trendingTopicsQueryKey,
@@ -33,21 +38,24 @@ export function useTrendingTopics() {
         suggested: data.suggested ?? [],
       }
     },
-    select(data) {
-      return {
-        topics: data.topics.filter(t => {
-          return !hasMutedWord({
-            mutedWords,
-            text: t.topic + ' ' + t.displayName + ' ' + t.description,
-          })
-        }),
-        suggested: data.suggested.filter(t => {
-          return !hasMutedWord({
-            mutedWords,
-            text: t.topic + ' ' + t.displayName + ' ' + t.description,
-          })
-        }),
-      }
-    },
+    select: React.useCallback(
+      (data: Response) => {
+        return {
+          topics: data.topics.filter(t => {
+            return !hasMutedWord({
+              mutedWords,
+              text: t.topic + ' ' + t.displayName + ' ' + t.description,
+            })
+          }),
+          suggested: data.suggested.filter(t => {
+            return !hasMutedWord({
+              mutedWords,
+              text: t.topic + ' ' + t.displayName + ' ' + t.description,
+            })
+          }),
+        }
+      },
+      [mutedWords],
+    ),
   })
 }


### PR DESCRIPTION
Fixes #7284

Moves mute word filtering into the `select` handler. This matches other queries in the app.