### PR TITLE
Disable taps while swiping between feeds

### DIFF
--- a/src/screens/Hashtag.tsx
+++ b/src/screens/Hashtag.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import {ListRenderItemInfo, View} from 'react-native'
+import {runOnJS} from 'react-native-reanimated'
 import {PostView} from '@atproto/api/dist/client/types/app/bsky/feed/defs'
 import {msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
@@ -37,6 +38,7 @@ export default function HashtagScreen({
   route,
 }: NativeStackScreenProps<CommonNavigatorParams, 'Hashtag'>) {
   const {tag, author} = route.params
+  const [isDragging, setIsDragging] = React.useState(false)
   const {_} = useLingui()
 
   const fullTag = React.useMemo(() => {
@@ -78,6 +80,14 @@ export default function HashtagScreen({
     [setMinimalShellMode],
   )
 
+  const onPageScrollStateChanged = React.useCallback(
+    (state: 'idle' | 'dragging' | 'settling') => {
+      'worklet'
+      runOnJS(setIsDragging)(state !== 'idle')
+    },
+    [],
+  )
+
   const sections = React.useMemo(() => {
     return [
       {
@@ -109,6 +119,7 @@ export default function HashtagScreen({
     <Layout.Screen>
       <Pager
         onPageSelected={onPageSelected}
+        onPageScrollStateChanged={onPageScrollStateChanged}
         renderTabBar={props => (
           <Layout.Center style={[a.z_10, web([a.sticky, {top: 0}])]}>
             <Layout.Header.Outer noBottomBorder>
@@ -140,7 +151,13 @@ export default function HashtagScreen({
         )}
         initialPage={0}>
         {sections.map((section, i) => (
-          <View key={i}>{section.component}</View>
+          <View
+            key={i}
+            onMoveShouldSetResponderCapture={() =>
+              isDragging || i !== activeTab
+            }>
+            {section.component}
+          </View>
         ))}
       </Pager>
     </Layout.Screen>

--- a/src/view/com/feeds/FeedPage.tsx
+++ b/src/view/com/feeds/FeedPage.tsx
@@ -34,6 +34,7 @@ export function FeedPage({
   testID,
   isPageFocused,
   isPageAdjacent,
+  isBeingDragged = false,
   feed,
   feedParams,
   renderEmptyState,
@@ -45,6 +46,7 @@ export function FeedPage({
   feedParams?: FeedParams
   isPageFocused: boolean
   isPageAdjacent: boolean
+  isBeingDragged?: boolean
   renderEmptyState: () => JSX.Element
   renderEndOfFeed?: () => JSX.Element
   savedFeedConfig?: AppBskyActorDefs.SavedFeed
@@ -117,7 +119,9 @@ export function FeedPage({
 
   const shouldPrefetch = isNative && isPageAdjacent
   return (
-    <View testID={testID}>
+    <View
+      testID={testID}
+      onMoveShouldSetResponderCapture={() => isBeingDragged || !isPageFocused}>
       <MainScrollProvider>
         <FeedFeedbackProvider value={feedFeedback}>
           <PostFeed

--- a/src/view/com/pager/PagerWithHeader.tsx
+++ b/src/view/com/pager/PagerWithHeader.tsx
@@ -69,6 +69,7 @@ export const PagerWithHeader = React.forwardRef<PagerRef, PagerWithHeaderProps>(
     const [headerOnlyHeight, setHeaderOnlyHeight] = React.useState(0)
     const scrollY = useSharedValue(0)
     const headerHeight = headerOnlyHeight + tabBarHeight
+    const [isDragging, setIsDragging] = React.useState(false)
 
     // capture the header bar sizing
     const onTabBarLayout = useNonReactiveCallback((evt: LayoutChangeEvent) => {
@@ -191,12 +192,21 @@ export const PagerWithHeader = React.forwardRef<PagerRef, PagerWithHeaderProps>(
       [onPageSelected, setCurrentPage],
     )
 
+    const onPageScrollStateChanged = React.useCallback(
+      (state: 'idle' | 'dragging' | 'settling') => {
+        'worklet'
+        runOnJS(setIsDragging)(state !== 'idle')
+      },
+      [],
+    )
+
     return (
       <Pager
         ref={ref}
         testID={testID}
         initialPage={initialPage}
         onPageSelected={onPageSelectedInner}
+        onPageScrollStateChanged={onPageScrollStateChanged}
         renderTabBar={renderTabBar}>
         {toArray(children)
           .filter(Boolean)
@@ -204,7 +214,12 @@ export const PagerWithHeader = React.forwardRef<PagerRef, PagerWithHeaderProps>(
             const isReady =
               isHeaderReady && headerOnlyHeight > 0 && tabBarHeight > 0
             return (
-              <View key={i} collapsable={false}>
+              <View
+                key={i}
+                collapsable={false}
+                onMoveShouldSetResponderCapture={() =>
+                  isDragging || i !== currentPage
+                }>
                 <PagerItem
                   headerHeight={headerHeight}
                   index={i}

--- a/src/view/screens/Home.tsx
+++ b/src/view/screens/Home.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import {ActivityIndicator, StyleSheet} from 'react-native'
+import {runOnJS} from 'react-native-reanimated'
 import {useFocusEffect} from '@react-navigation/native'
 
 import {PROD_DEFAULT_FEED} from '#/lib/constants'
@@ -105,6 +106,7 @@ function HomeScreenReady({
   const selectedIndex = Math.max(0, maybeFoundIndex)
   const selectedFeed = allFeeds[selectedIndex]
   const requestNotificationsPermission = useRequestNotificationsPermission()
+  const [isDragging, setIsDragging] = React.useState(false)
 
   useSetTitle(pinnedFeedInfos[selectedIndex]?.displayName)
   useOTAUpdates()
@@ -173,6 +175,7 @@ function HomeScreenReady({
       if (state === 'dragging') {
         setMinimalShellMode(false)
       }
+      runOnJS(setIsDragging)(state !== 'idle')
     },
     [setMinimalShellMode],
   )
@@ -230,6 +233,7 @@ function HomeScreenReady({
                 testID="followingFeedPage"
                 isPageFocused={selectedFeed === feed}
                 isPageAdjacent={Math.abs(selectedIndex - index) === 1}
+                isBeingDragged={isDragging}
                 feed={feed}
                 feedParams={homeFeedParams}
                 renderEmptyState={renderFollowingEmptyState}
@@ -244,6 +248,7 @@ function HomeScreenReady({
               testID="customFeedPage"
               isPageFocused={selectedFeed === feed}
               isPageAdjacent={Math.abs(selectedIndex - index) === 1}
+              isBeingDragged={isDragging}
               feed={feed}
               renderEmptyState={renderCustomFeedEmptyState}
               savedFeedConfig={savedFeedConfig}
@@ -264,6 +269,7 @@ function HomeScreenReady({
         testID="customFeedPage"
         isPageFocused
         isPageAdjacent={false}
+        isBeingDragged={isDragging}
         feed={`feedgen|${PROD_DEFAULT_FEED('whats-hot')}`}
         renderEmptyState={renderCustomFeedEmptyState}
       />

--- a/src/view/screens/Search/Search.tsx
+++ b/src/view/screens/Search/Search.tsx
@@ -12,6 +12,7 @@ import {
 } from 'react-native'
 import {ScrollView as RNGHScrollView} from 'react-native-gesture-handler'
 import RNPickerSelect from 'react-native-picker-select'
+import {runOnJS} from 'react-native-reanimated'
 import {AppBskyActorDefs, AppBskyFeedDefs, moderateProfile} from '@atproto/api'
 import {
   FontAwesomeIcon,
@@ -481,6 +482,7 @@ let SearchScreenInner = ({
   const {hasSession} = useSession()
   const {isDesktop} = useWebMediaQueries()
   const [activeTab, setActiveTab] = React.useState(0)
+  const [isDragging, setIsDragging] = React.useState(false)
   const {_} = useLingui()
 
   const onPageSelected = React.useCallback(
@@ -489,6 +491,14 @@ let SearchScreenInner = ({
       setActiveTab(index)
     },
     [setMinimalShellMode],
+  )
+
+  const onPageScrollStateChanged = React.useCallback(
+    (state: 'idle' | 'dragging' | 'settling') => {
+      'worklet'
+      runOnJS(setIsDragging)(state !== 'idle')
+    },
+    [],
   )
 
   const sections = React.useMemo(() => {
@@ -536,6 +546,7 @@ let SearchScreenInner = ({
   return queryWithParams ? (
     <Pager
       onPageSelected={onPageSelected}
+      onPageScrollStateChanged={onPageScrollStateChanged}
       renderTabBar={props => (
         <Layout.Center
           style={[
@@ -548,7 +559,11 @@ let SearchScreenInner = ({
       )}
       initialPage={0}>
       {sections.map((section, i) => (
-        <View key={i}>{section.component}</View>
+        <View
+          key={i}
+          onMoveShouldSetResponderCapture={() => isDragging || i !== activeTab}>
+          {section.component}
+        </View>
       ))}
     </Pager>
   ) : hasSession ? (


### PR DESCRIPTION
I've been encountering this behavior on mobile, where sometimes (a lot of the times!) swiping horizontally to go from feed A to feed B registers a tap on feed A. So it would move to the next feed and after a small delay it would unexpectedly expand a post or an image from the previous feed, which makes for a very annoying experience:

https://github.com/user-attachments/assets/ede1d500-1831-4c69-a2ed-6ae0d05722cb

This is most likely a bug with react-native-pager-view, callstack/react-native-pager-view#776.

As a workaround, I made it so that while the page is being dragged, touch events are captured by the corresponding view, so hopefully no presses are triggered further down. It seems to work, and I cannot reproduce the behavior anymore, **except** in the case where one is at the first/last page and swipes away from the edge, like so:

https://github.com/user-attachments/assets/3fe75717-9c02-4446-a581-2e0e2c19b588