### PR TITLE
Rework discover-feed trending interstitial

### DIFF
--- a/src/components/hooks/useHeaderOffset.ts
+++ b/src/components/hooks/useHeaderOffset.ts
@@ -12,5 +12,5 @@ export function useHeaderOffset() {
   const tabBarPad = 10 + 10 + 3 // padding + border
   const normalLineHeight = 20 // matches tab bar
   const tabBarText = normalLineHeight * fontScale
-  return navBarHeight + tabBarPad + tabBarText
+  return navBarHeight + tabBarPad + tabBarText - 4 // for some reason, this calculation is wrong by 4 pixels, which we adjust
 }

--- a/src/components/interstitials/Trending.tsx
+++ b/src/components/interstitials/Trending.tsx
@@ -9,20 +9,14 @@ import {
   useTrendingSettings,
   useTrendingSettingsApi,
 } from '#/state/preferences/trending'
-import {
-  DEFAULT_LIMIT as TRENDING_TOPICS_COUNT,
-  useTrendingTopics,
-} from '#/state/queries/trending/useTrendingTopics'
+import {useTrendingTopics} from '#/state/queries/trending/useTrendingTopics'
 import {useTrendingConfig} from '#/state/trending-config'
 import {atoms as a, useGutters, useTheme} from '#/alf'
 import {Button, ButtonIcon} from '#/components/Button'
 import {TimesLarge_Stroke2_Corner0_Rounded as X} from '#/components/icons/Times'
 import {Trending2_Stroke2_Corner2_Rounded as Graph} from '#/components/icons/Trending2'
 import * as Prompt from '#/components/Prompt'
-import {
-  TrendingTopicLink,
-  TrendingTopicSkeleton,
-} from '#/components/TrendingTopics'
+import {TrendingTopicLink} from '#/components/TrendingTopics'
 import {Text} from '#/components/Typography'
 
 export function TrendingInterstitial() {
@@ -54,11 +48,12 @@ export function Inner() {
         <View style={[gutters, a.flex_row, a.align_center, a.gap_lg]}>
           <Graph size="sm" />
           {isLoading ? (
-            Array(TRENDING_TOPICS_COUNT)
-              .fill(0)
-              .map((_n, i) => (
-                <TrendingTopicSkeleton key={i} index={i} size="small" />
-              ))
+            <View style={[a.py_lg]}>
+              <Text
+                style={[t.atoms.text_contrast_medium, a.text_sm, a.font_bold]}>
+                {' '}
+              </Text>
+            </View>
           ) : !trending?.topics ? null : (
             <>
               {trending.topics.map(topic => (

--- a/src/components/interstitials/Trending.tsx
+++ b/src/components/interstitials/Trending.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import {View} from 'react-native'
-import {msg, Trans} from '@lingui/macro'
+import {ScrollView} from 'react-native-gesture-handler'
+import {msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
 import {logEvent} from '#/lib/statsig/statsig'
@@ -13,14 +14,12 @@ import {
   useTrendingTopics,
 } from '#/state/queries/trending/useTrendingTopics'
 import {useTrendingConfig} from '#/state/trending-config'
-import {atoms as a, tokens, useGutters, useTheme} from '#/alf'
+import {atoms as a, useGutters, useTheme} from '#/alf'
 import {Button, ButtonIcon} from '#/components/Button'
-import {GradientFill} from '#/components/GradientFill'
 import {TimesLarge_Stroke2_Corner0_Rounded as X} from '#/components/icons/Times'
 import {Trending2_Stroke2_Corner2_Rounded as Graph} from '#/components/icons/Trending2'
 import * as Prompt from '#/components/Prompt'
 import {
-  TrendingTopic,
   TrendingTopicLink,
   TrendingTopicSkeleton,
 } from '#/components/TrendingTopics'
@@ -35,7 +34,7 @@ export function TrendingInterstitial() {
 export function Inner() {
   const t = useTheme()
   const {_} = useLingui()
-  const gutters = useGutters(['wide', 'base'])
+  const gutters = useGutters([0, 'base', 0, 'base'])
   const trendingPrompt = Prompt.usePromptControl()
   const {setTrendingDisabled} = useTrendingSettingsApi()
   const {data: trending, error, isLoading} = useTrendingTopics()
@@ -47,69 +46,55 @@ export function Inner() {
   }, [setTrendingDisabled])
 
   return error || noTopics ? null : (
-    <View
-      style={[
-        gutters,
-        a.gap_lg,
-        a.border_t,
-        t.atoms.border_contrast_low,
-        t.atoms.bg_contrast_25,
-      ]}>
-      <View style={[a.flex_row, a.align_center, a.gap_sm]}>
-        <View style={[a.flex_1, a.flex_row, a.align_center, a.gap_sm]}>
-          <Graph size="lg" />
-          <Text style={[a.text_lg, a.font_heavy]}>
-            <Trans>Trending</Trans>
-          </Text>
-          <View style={[a.py_xs, a.px_sm, a.rounded_sm, a.overflow_hidden]}>
-            <GradientFill gradient={tokens.gradients.primary} />
-            <Text style={[a.text_sm, a.font_heavy, {color: 'white'}]}>
-              <Trans>BETA</Trans>
-            </Text>
-          </View>
-        </View>
-
-        <Button
-          label={_(msg`Hide trending topics`)}
-          size="tiny"
-          variant="outline"
-          color="secondary"
-          shape="round"
-          onPress={() => trendingPrompt.open()}>
-          <ButtonIcon icon={X} />
-        </Button>
-      </View>
-
-      <View style={[a.flex_row, a.flex_wrap, {rowGap: 8, columnGap: 6}]}>
-        {isLoading ? (
-          Array(TRENDING_TOPICS_COUNT)
-            .fill(0)
-            .map((_n, i) => <TrendingTopicSkeleton key={i} index={i} />)
-        ) : !trending?.topics ? null : (
-          <>
-            {trending.topics.map(topic => (
-              <TrendingTopicLink
-                key={topic.link}
-                topic={topic}
-                onPress={() => {
-                  logEvent('trendingTopic:click', {context: 'interstitial'})
-                }}>
-                {({hovered}) => (
-                  <TrendingTopic
+    <View style={[t.atoms.border_contrast_low, a.border_t]}>
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        decelerationRate="fast">
+        <View style={[gutters, a.flex_row, a.align_center, a.gap_lg]}>
+          <Graph size="sm" />
+          {isLoading ? (
+            Array(TRENDING_TOPICS_COUNT)
+              .fill(0)
+              .map((_n, i) => (
+                <TrendingTopicSkeleton key={i} index={i} size="small" />
+              ))
+          ) : !trending?.topics ? null : (
+            <>
+              {trending.topics.map(topic => (
+                <>
+                  <TrendingTopicLink
+                    key={topic.link}
                     topic={topic}
-                    style={[
-                      hovered && [
-                        t.atoms.border_contrast_high,
-                        t.atoms.bg_contrast_25,
-                      ],
-                    ]}
-                  />
-                )}
-              </TrendingTopicLink>
-            ))}
-          </>
-        )}
-      </View>
+                    onPress={() => {
+                      logEvent('trendingTopic:click', {context: 'interstitial'})
+                    }}>
+                    <View style={[a.py_lg]}>
+                      <Text
+                        style={[
+                          t.atoms.text_contrast_medium,
+                          a.text_sm,
+                          a.font_bold,
+                        ]}>
+                        {topic.topic}
+                      </Text>
+                    </View>
+                  </TrendingTopicLink>
+                </>
+              ))}
+              <Button
+                label={_(msg`Hide trending topics`)}
+                size="tiny"
+                variant="ghost"
+                color="secondary"
+                shape="round"
+                onPress={() => trendingPrompt.open()}>
+                <ButtonIcon icon={X} />
+              </Button>
+            </>
+          )}
+        </View>
+      </ScrollView>
 
       <Prompt.Basic
         control={trendingPrompt}

--- a/src/components/interstitials/Trending.tsx
+++ b/src/components/interstitials/Trending.tsx
@@ -67,9 +67,10 @@ export function Inner() {
                     <View style={[a.py_lg]}>
                       <Text
                         style={[
-                          t.atoms.text_contrast_medium,
+                          t.atoms.text,
                           a.text_sm,
                           a.font_bold,
+                          {opacity: 0.7}, // NOTE: we use opacity 0.7 instead of a color to match the color of the home pager tab bar
                         ]}>
                         {topic.topic}
                       </Text>

--- a/src/components/interstitials/Trending.tsx
+++ b/src/components/interstitials/Trending.tsx
@@ -46,7 +46,9 @@ export function Inner() {
         showsHorizontalScrollIndicator={false}
         decelerationRate="fast">
         <View style={[gutters, a.flex_row, a.align_center, a.gap_lg]}>
-          <Graph size="sm" />
+          <View style={{paddingLeft: 4, paddingRight: 2}}>
+            <Graph size="sm" />
+          </View>
           {isLoading ? (
             <View style={[a.py_lg]}>
               <Text

--- a/src/view/com/posts/PostFeed.tsx
+++ b/src/view/com/posts/PostFeed.tsx
@@ -314,11 +314,7 @@ let PostFeed = ({
                     type: 'interstitialProgressGuide',
                     key: 'interstitial-' + sliceIndex + '-' + lastFetchedAt,
                   })
-                } else if (
-                  sliceIndex === 15 &&
-                  !gtTablet &&
-                  !trendingDisabled
-                ) {
+                } else if (sliceIndex === 1 && !gtTablet && !trendingDisabled) {
                   arr.push({
                     type: 'interstitialTrending',
                     key: 'interstitial-' + sliceIndex + '-' + lastFetchedAt,

--- a/src/view/com/posts/PostFeed.tsx
+++ b/src/view/com/posts/PostFeed.tsx
@@ -309,16 +309,19 @@ let PostFeed = ({
 
             if (hasSession) {
               if (feedKind === 'discover') {
-                if (sliceIndex === 0 && showProgressIntersitial) {
-                  arr.push({
-                    type: 'interstitialProgressGuide',
-                    key: 'interstitial-' + sliceIndex + '-' + lastFetchedAt,
-                  })
-                } else if (sliceIndex === 0 && !gtTablet && !trendingDisabled) {
-                  arr.push({
-                    type: 'interstitialTrending',
-                    key: 'interstitial-' + sliceIndex + '-' + lastFetchedAt,
-                  })
+                if (sliceIndex === 0) {
+                  if (showProgressIntersitial) {
+                    arr.push({
+                      type: 'interstitialProgressGuide',
+                      key: 'interstitial-' + sliceIndex + '-' + lastFetchedAt,
+                    })
+                  }
+                  if (!gtTablet && !trendingDisabled) {
+                    arr.push({
+                      type: 'interstitialTrending',
+                      key: 'interstitial2-' + sliceIndex + '-' + lastFetchedAt,
+                    })
+                  }
                 } else if (sliceIndex === 30) {
                   arr.push({
                     type: 'interstitialFollows',

--- a/src/view/com/posts/PostFeed.tsx
+++ b/src/view/com/posts/PostFeed.tsx
@@ -314,7 +314,7 @@ let PostFeed = ({
                     type: 'interstitialProgressGuide',
                     key: 'interstitial-' + sliceIndex + '-' + lastFetchedAt,
                   })
-                } else if (sliceIndex === 1 && !gtTablet && !trendingDisabled) {
+                } else if (sliceIndex === 0 && !gtTablet && !trendingDisabled) {
                   arr.push({
                     type: 'interstitialTrending',
                     key: 'interstitial-' + sliceIndex + '-' + lastFetchedAt,


### PR DESCRIPTION
Issues with the Trending discover interstitial currently:

- The variable-height interstitial has the ability to cause scroll-position glitches.
- It is overly large.
- It isn't reliably above-the-fold, making it a somewhat rare thing to see.

This PR shrinks it down to one line, making it easier to digest, then puts it underneath the tab bar of the home screen. It retains the X button at the far right.

|Before|After|
|-|-|
|![CleanShot 2024-12-30 at 18 02 42@2x](https://github.com/user-attachments/assets/e254b7e1-4ed0-4add-be1b-3e1bef3dcc66)|![CleanShot 2024-12-30 at 22 23 08@2x](https://github.com/user-attachments/assets/9d7a718b-a725-49bf-97dd-f1d8a136ff19)|


https://github.com/user-attachments/assets/1411d59b-a826-406b-b625-0597d3195a7b

