### PR TITLE
Fix key issue in trending topics

### DIFF
--- a/src/components/interstitials/Trending.tsx
+++ b/src/components/interstitials/Trending.tsx
@@ -59,26 +59,24 @@ export function Inner() {
           ) : !trending?.topics ? null : (
             <>
               {trending.topics.map(topic => (
-                <>
-                  <TrendingTopicLink
-                    key={topic.link}
-                    topic={topic}
-                    onPress={() => {
-                      logEvent('trendingTopic:click', {context: 'interstitial'})
-                    }}>
-                    <View style={[a.py_lg]}>
-                      <Text
-                        style={[
-                          t.atoms.text,
-                          a.text_sm,
-                          a.font_bold,
-                          {opacity: 0.7}, // NOTE: we use opacity 0.7 instead of a color to match the color of the home pager tab bar
-                        ]}>
-                        {topic.topic}
-                      </Text>
-                    </View>
-                  </TrendingTopicLink>
-                </>
+                <TrendingTopicLink
+                  key={topic.link}
+                  topic={topic}
+                  onPress={() => {
+                    logEvent('trendingTopic:click', {context: 'interstitial'})
+                  }}>
+                  <View style={[a.py_lg]}>
+                    <Text
+                      style={[
+                        t.atoms.text,
+                        a.text_sm,
+                        a.font_bold,
+                        {opacity: 0.7}, // NOTE: we use opacity 0.7 instead of a color to match the color of the home pager tab bar
+                      ]}>
+                      {topic.topic}
+                    </Text>
+                  </View>
+                </TrendingTopicLink>
               ))}
               <Button
                 label={_(msg`Hide trending topics`)}


### PR DESCRIPTION
Ez fix. The key is on the inner element so it isn't being used. This removes the unnecessary wrapper.

## Before

<img width="378" alt="Screenshot 2025-01-02 at 17 07 18" src="https://github.com/user-attachments/assets/1700d018-b5fc-4335-8948-c6c2e6208138" />

## After

Trending still works. No key warning.

<img width="423" alt="Screenshot 2025-01-02 at 17 18 16" src="https://github.com/user-attachments/assets/573ab863-2a6e-4feb-9b04-c680ec75aeec" />
