### PR TITLE
feat: long press like button to see likes

### DIFF
--- a/src/view/com/util/post-ctrls/PostCtrls.tsx
+++ b/src/view/com/util/post-ctrls/PostCtrls.tsx
@@ -16,6 +16,7 @@ import {
 } from '@atproto/api'
 import {msg, plural} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
+import {useNavigation} from '@react-navigation/native'
 
 import {IS_INTERNAL} from '#/lib/app-info'
 import {POST_CTRL_HITSLOP} from '#/lib/constants'
@@ -23,6 +24,7 @@ import {CountWheel} from '#/lib/custom-animations/CountWheel'
 import {AnimatedLikeIcon} from '#/lib/custom-animations/LikeIcon'
 import {useHaptics} from '#/lib/haptics'
 import {makeProfileLink} from '#/lib/routes/links'
+import {NavigationProp} from '#/lib/routes/types'
 import {shareUrl} from '#/lib/sharing'
 import {useGate} from '#/lib/statsig/statsig'
 import {toShareUrl} from '#/lib/strings/url-helpers'
@@ -81,6 +83,7 @@ let PostCtrls = ({
     post,
     logContext,
   )
+  const navigation = useNavigation<NavigationProp>()
   const requireAuth = useRequireAuth()
   const loggedOutWarningPromptControl = useDialogControl()
   const {sendInteraction} = useFeedFeedbackContext()
@@ -151,6 +154,14 @@ let PostCtrls = ({
     feedContext,
     isBlocked,
   ])
+
+  const onLongPressToggleLike = React.useCallback(async () => {
+    const urip = new AtUri(post.uri)
+    navigation.navigate('PostLikedBy', {
+      name: post.author.handle,
+      rkey: urip.rkey,
+    })
+  }, [navigation, post.author.handle, post.uri])
 
   const onRepost = useCallback(async () => {
     if (isBlocked) {
@@ -298,6 +309,7 @@ let PostCtrls = ({
           testID="likeBtn"
           style={btnStyle}
           onPress={() => requireAuth(() => onPressToggleLike())}
+          onLongPress={() => onLongPressToggleLike()}
           accessibilityRole="button"
           accessibilityLabel={
             post.viewer?.like


### PR DESCRIPTION
Implement long press action on the like button to navigate to the list of users who liked the post.

It's nice to be able to quickly see the likes without having to open the post first.

https://github.com/user-attachments/assets/6a74afa0-10cc-4bd7-922a-14054528afd5

