### PR TITLE
[@next] Profile handling, migrate `ProfileCard`

### DIFF
--- a/src/types/atproto/index.ts
+++ b/src/types/atproto/index.ts
@@ -1,0 +1,1 @@
+export * as profile from '#/types/atproto/profile'

--- a/src/types/atproto/profile.ts
+++ b/src/types/atproto/profile.ts
@@ -21,15 +21,17 @@ export {
 /**
  * Matches any profile view exported by our SDK
  */
-export type AnyView =
+export type AnyProfileView =
   | AppBskyActorDefs.ProfileViewBasic
   | AppBskyActorDefs.ProfileView
   | AppBskyActorDefs.ProfileViewDetailed
 
 /**
- * Downgrades any profile view to the most basic form.
+ * Maps any profile view type to `ProfileViewBasic`.
  */
-export function anyToBasic(view: AnyView): AppBskyActorDefs.ProfileViewBasic {
+export function anyToBasic(
+  view: AnyProfileView,
+): AppBskyActorDefs.ProfileViewBasic {
   return {
     $type: 'app.bsky.actor.defs#profileViewBasic',
     did: view.did,
@@ -44,7 +46,7 @@ export function anyToBasic(view: AnyView): AppBskyActorDefs.ProfileViewBasic {
 }
 
 /**
- * Downgrades a detailed profile view to the `ProfileView` form.
+ * Maps `ProfileViewDetailed` to `ProfileView`.
  */
 export function detailedToView(
   view: AppBskyActorDefs.ProfileViewDetailed,

--- a/src/view/com/lists/ListMembers.tsx
+++ b/src/view/com/lists/ListMembers.tsx
@@ -11,7 +11,7 @@ import {useModalControls} from '#/state/modals'
 import {useListMembersQuery} from '#/state/queries/list-members'
 import {useSession} from '#/state/session'
 import {ListFooter} from '#/components/Lists'
-import * as Profile from '#/types/profile'
+import * as atp from '#/types/atproto'
 import {ProfileCard} from '../profile/ProfileCard'
 import {ErrorMessage} from '../util/error/ErrorMessage'
 import {Button} from '../util/forms/Button'
@@ -117,7 +117,7 @@ export function ListMembers({
   }, [fetchNextPage])
 
   const onPressEditMembership = React.useCallback(
-    (profile: Profile.AnyView) => {
+    (profile: atp.profile.AnyProfileView) => {
       openModal({
         name: 'user-add-remove-lists',
         subject: profile.did,
@@ -132,7 +132,7 @@ export function ListMembers({
   // =
 
   const renderMemberButton = React.useCallback(
-    (profile: Profile.AnyView) => {
+    (profile: atp.profile.AnyProfileView) => {
       if (!isOwner) {
         return null
       }

--- a/src/view/com/profile/FollowButton.tsx
+++ b/src/view/com/profile/FollowButton.tsx
@@ -4,7 +4,7 @@ import {useLingui} from '@lingui/react'
 
 import {Shadow} from '#/state/cache/types'
 import {useProfileFollowMutationQueue} from '#/state/queries/profile'
-import * as Profile from '#/types/profile'
+import * as atp from '#/types/atproto'
 import {Button, ButtonType} from '../util/forms/Button'
 import * as Toast from '../util/Toast'
 
@@ -17,7 +17,7 @@ export function FollowButton({
 }: {
   unfollowedType?: ButtonType
   followedType?: ButtonType
-  profile: Shadow<Profile.AnyView>
+  profile: Shadow<atp.profile.AnyProfileView>
   labelStyle?: StyleProp<TextStyle>
   logContext: 'ProfileCard' | 'StarterPackProfilesList'
 }) {

--- a/src/view/com/profile/ProfileCard.tsx
+++ b/src/view/com/profile/ProfileCard.tsx
@@ -24,7 +24,7 @@ import {
   shouldShowKnownFollowers,
 } from '#/components/KnownFollowers'
 import * as Pills from '#/components/Pills'
-import * as Profile from '#/types/profile'
+import * as atp from '#/types/atproto'
 import {Link} from '../util/Link'
 import {Text} from '../util/text/Text'
 import {PreviewableUserAvatar} from '../util/UserAvatar'
@@ -42,11 +42,13 @@ export function ProfileCard({
   showKnownFollowers,
 }: {
   testID?: string
-  profile: Profile.AnyView
+  profile: atp.profile.AnyProfileView
   noModFilter?: boolean
   noBg?: boolean
   noBorder?: boolean
-  renderButton?: (profile: Shadow<Profile.AnyView>) => React.ReactNode
+  renderButton?: (
+    profile: Shadow<atp.profile.AnyProfileView>,
+  ) => React.ReactNode
   onPress?: () => void
   style?: StyleProp<ViewStyle>
   showKnownFollowers?: boolean
@@ -59,7 +61,7 @@ export function ProfileCard({
 
   const onBeforePress = React.useCallback(() => {
     onPress?.()
-    precacheProfile(queryClient, Profile.anyToBasic(profile))
+    precacheProfile(queryClient, atp.profile.anyToBasic(profile))
   }, [onPress, profile, queryClient])
 
   if (!moderationOpts) {
@@ -125,7 +127,7 @@ export function ProfileCard({
           <View style={styles.layoutButton}>{renderButton(profile)}</View>
         ) : undefined}
       </View>
-      {Profile.isView(profile) || Profile.isDetailedView(profile) ? (
+      {atp.profile.isView(profile) || atp.profile.isDetailedView(profile) ? (
         <>
           {profile.description || knownFollowersVisible ? (
             <View style={styles.details}>
@@ -142,7 +144,7 @@ export function ProfileCard({
                     a.gap_sm,
                     !!profile.description && a.mt_md,
                   ]}>
-                  {Profile.isDetailedView(profile) && (
+                  {atp.profile.isDetailedView(profile) && (
                     <KnownFollowers
                       minimal
                       profile={profile}


### PR DESCRIPTION
The new SDK adds more strict types and now specifies the `$type` prop on all interfaces. Whereas previously, `ProfileViewBasic` as loosely equal to `ProfileView` and `ProfileViewDetailed`, these now result in type errors. And correctly so.

> NB: These new types still retain open-endedness e.g. `{ [key: string]: unknown }` to allow evolution.

Our app relies a lot of this loose equality e.g.:
- `FollowButton` is passed various views, and it can work with any of them
- `ProfileCard` is passed various views, and has truthy checks for things like `profile.description`, which isn't available on `Basic` views
- `precacheProfile` expects `Basic`, but we feed it `ProfileView` in some cases

In all these cases, it's _technically_ feasible to pass in any of these and handle specific cases downstream. However, we now get specific type errors, which we can use to more safely guard against improper references.

### So now what

This PR started with the old `ProfileCard` since it was a good example of this problem. That component references `profile?.description`, which is only available on `ProfileView` or `ProfileViewDetailed`. One option is to omit the new `$type` values like `Omit<AppBskyActorDefs.ProfileViewBasic, '$type'>`, which then falls back to the open-endedness and allows any profile view to be passed. This sorta works, but it's not clear what's happening to other devs, and it becomes unclear why we'd be using identity utils like `AppBskyActoDefs.isProfileViewDetailed()` where we need to. Example:
- Q: The type says it's a detailed view, why do I need to check again?
- A: Because it's not actually a detailed view in some cases, the types are just overly permissive.

So this PR introduces a new interface for profile view types, intended to be imported as `import * as Profile from "#/types/profile"`. It renames the identity utils for easier access, exports an `AnyView` for cases where we specifically allow multiple view types, and provides utils to _downgrade_ views to more simpler views. The opposite is not possible without lossy definitions e.g. `profile.description` doesn't exist on `ProfileViewBasic` and so couldn't be upgraded into `ProfileView`.

**The intention here** is to begin to use `Profile.AnyView` in place of separate profile views for cases where we allow multiple view types. Then, to use the identity methods to more safely fork logic based on the view type. And in cases where we need to, we can downgrade views to match what's expected by certain utils e.g. `precacheProfile(Profile.anyToBasic({...profileViewDetailed}))` which expects a `ProfileViewBasic` and can be derived from any profile view type.

> If it wasn't clear, profile views have varying levels of detail. In order of least -> most: `ProfileViewBasic`, `ProfileView`, and `ProfileViewDetailed`. Hence the "downgrade" or "upgrade" words I'm using here.

### Why not fix types everywhere to be specifically what we need?
We could, but I think this would be quite an undertaking and could cause some subtle errors.

Some valid use cases like `FollowButton` that only rely on a few props of a profile view _could_ be refactored to _only_ require those props instead of a profile view directly, but this would again require a lot of edits. This should probably be a best practice going forward where possible instead of passing around whole objects.

### Any similar issues to this?
Yep, `StarterPackView` and `StarterPackViewBasic`.

