### PR TITLE
Invalidate existing pull-to-refresh spinner when theme changes

### DIFF
--- a/src/view/com/util/List.tsx
+++ b/src/view/com/util/List.tsx
@@ -132,6 +132,7 @@ let List = React.forwardRef<ListMethods, ListProps>(
     if (refreshing !== undefined || onRefresh !== undefined) {
       refreshControl = (
         <RefreshControl
+          key={t.atoms.text.color}
           refreshing={refreshing ?? false}
           onRefresh={onRefresh}
           tintColor={t.atoms.text.color}


### PR DESCRIPTION
Fixes #7339 

Currently, the pull-to-refresh spinner can remain the wrong color after the theme changes. I don't know enough about React Native to understand why the existing `RefreshControl` doesn't get invalidated when its `tintColor` and `titleColor` props change, but setting a key seems to fix this.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td>

https://github.com/user-attachments/assets/44b952a3-c863-4812-966d-f8cddadb8713

</td><td>

https://github.com/user-attachments/assets/654db4d6-db4b-4f98-acb6-b60c7a3dcea1

</td></tr>
</table>