### PR TITLE
Rename 'People' label to 'Accounts'

### DIFF
--- a/src/screens/StarterPack/StarterPackScreen.tsx
+++ b/src/screens/StarterPack/StarterPackScreen.tsx
@@ -173,13 +173,13 @@ function StarterPackScreenLoaded({
   routeParams: StarterPackScreeProps['route']['params']
   moderationOpts: ModerationOpts
 }) {
-  const showPeopleTab = Boolean(starterPack.list)
+  const showAccountsTab = Boolean(starterPack.list)
   const showFeedsTab = Boolean(starterPack.feeds?.length)
   const showPostsTab = Boolean(starterPack.list)
   const {_} = useLingui()
 
   const tabs = [
-    ...(showPeopleTab ? [_(msg`People`)] : []),
+    ...(showAccountsTab ? [_(msg`Accounts`)] : []),
     ...(showFeedsTab ? [_(msg`Feeds`)] : []),
     ...(showPostsTab ? [_(msg`Posts`)] : []),
   ]

--- a/src/view/screens/Search/Search.tsx
+++ b/src/view/screens/Search/Search.tsx
@@ -517,7 +517,7 @@ let SearchScreenInner = ({
         ),
       },
       noParams && {
-        title: _(msg`People`),
+        title: _(msg`Accounts`),
         component: (
           <SearchScreenUserResults query={query} active={activeTab === 2} />
         ),


### PR DESCRIPTION
More accurate representation of tab listing all users.