### PR TITLE
Fix post action wording in German

### DIFF
--- a/src/locale/locales/de/messages.po
+++ b/src/locale/locales/de/messages.po
@@ -5837,7 +5837,7 @@ msgstr "Porno"
 #: src/view/com/composer/Composer.tsx:944
 msgctxt "action"
 msgid "Post"
-msgstr "Beitrag"
+msgstr "Posten"
 
 #: src/view/com/post-thread/PostThread.tsx:536
 msgctxt "description"


### PR DESCRIPTION
"Beitrag" does not specify the verb "to post", but instead "post" (noun). This PR fixes that grammar issue.