### PR TITLE
Hide menu button when search is focused

### DIFF
--- a/src/view/screens/Search/Search.tsx
+++ b/src/view/screens/Search/Search.tsx
@@ -856,7 +856,7 @@ export function SearchScreen(
         <Layout.Center>
           <View style={[a.p_md, a.pb_sm, a.gap_sm, t.atoms.bg]}>
             <View style={[a.flex_row, a.gap_sm]}>
-              {!gtMobile && (
+              {!gtMobile && !showAutocomplete && (
                 <Button
                   testID="viewHeaderBackOrMenuBtn"
                   onPress={onPressMenu}

--- a/src/view/screens/Search/Search.tsx
+++ b/src/view/screens/Search/Search.tsx
@@ -3,7 +3,6 @@ import {
   ActivityIndicator,
   Image,
   ImageStyle,
-  Platform,
   Pressable,
   StyleProp,
   StyleSheet,
@@ -221,7 +220,6 @@ let SearchScreenPostResults = ({
               refreshing={isPTR}
               onRefresh={onPullToRefresh}
               onEndReached={onEndReached}
-              // @ts-ignore web only -prf
               desktopFixedHeight
               contentContainerStyle={{paddingBottom: 100}}
             />
@@ -260,7 +258,6 @@ let SearchScreenUserResults = ({
             <ProfileCardWithFollowBtn profile={item} noBg />
           )}
           keyExtractor={item => item.did}
-          // @ts-ignore web only -prf
           desktopFixedHeight
           contentContainerStyle={{paddingBottom: 100}}
         />
@@ -306,7 +303,6 @@ let SearchScreenFeedsResults = ({
             </View>
           )}
           keyExtractor={item => item.uri}
-          // @ts-ignore web only -prf
           desktopFixedHeight
           contentContainerStyle={{paddingBottom: 100}}
         />
@@ -556,11 +552,7 @@ let SearchScreenInner = ({
     <Explore />
   ) : (
     <Layout.Center>
-      <View
-        // @ts-ignore web only -esb
-        style={{
-          height: Platform.select({web: '100vh'}),
-        }}>
+      <View style={web({height: '100vh'})}>
         {isDesktop && (
           <Text
             type="title"


### PR DESCRIPTION
Currently, the space available to the search input is at its smallest when focused. Let's remove the menu btn when focused to give it more space

<table>
  <thead>
    <tr>
      <th>Before</th>
      <th>After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><img width="200" alt="Screenshot 2025-01-06 at 15 32 55" src="https://github.com/user-attachments/assets/dd9ea008-5746-4ade-88d7-cbcdd83754c8" /></td>
      <td><img width="200" alt="Screenshot 2025-01-06 at 15 27 35" src="https://github.com/user-attachments/assets/bb0870b7-6a01-4f95-a2e4-caf2bba69684" /></td>
    </tr>
  </tbody>
</table>