### PR TITLE
Add dark mode option to in-app embed snippet dialog

### DIFF
--- a/src/components/dialogs/Embed.tsx
+++ b/src/components/dialogs/Embed.tsx
@@ -14,8 +14,8 @@ import * as TextField from '#/components/forms/TextField'
 import * as ToggleButton from '#/components/forms/ToggleButton'
 import {Check_Stroke2_Corner0_Rounded as CheckIcon} from '#/components/icons/Check'
 import {
+  ChevronBottom_Stroke2_Corner0_Rounded as ChevronBottomIcon,
   ChevronRight_Stroke2_Corner0_Rounded as ChevronRightIcon,
-  ChevronTop_Stroke2_Corner0_Rounded as ChevronTopIcon,
 } from '#/components/icons/Chevron'
 import {CodeBrackets_Stroke2_Corner0_Rounded as CodeBracketsIcon} from '#/components/icons/CodeBrackets'
 import {Text} from '#/components/Typography'
@@ -139,7 +139,7 @@ function EmbedDialogInner({
               showCustomisation && t.atoms.bg_contrast_25,
             ]}>
             <ButtonIcon
-              icon={showCustomisation ? ChevronTopIcon : ChevronRightIcon}
+              icon={showCustomisation ? ChevronBottomIcon : ChevronRightIcon}
             />
             <ButtonText>
               <Trans>Customization options</Trans>

--- a/src/components/dialogs/Embed.tsx
+++ b/src/components/dialogs/Embed.tsx
@@ -1,5 +1,5 @@
-import {memo, useEffect, useMemo, useRef, useState} from 'react'
-import {TextInput, View} from 'react-native'
+import {memo, useEffect, useMemo, useState} from 'react'
+import {View} from 'react-native'
 import {AppBskyActorDefs, AppBskyFeedPost, AtUri} from '@atproto/api'
 import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
@@ -51,7 +51,6 @@ function EmbedDialogInner({
 }: Omit<EmbedDialogProps, 'control'>) {
   const t = useTheme()
   const {_, i18n} = useLingui()
-  const ref = useRef<TextInput>(null)
   const [copied, setCopied] = useState(false)
   const [showCustomisation, setShowCustomisation] = useState(false)
   const [colorMode, setColorMode] = useState<ColorModeValues>('system')
@@ -192,8 +191,6 @@ function EmbedDialogInner({
             variant="solid"
             size="large"
             onPress={() => {
-              ref.current?.focus()
-              ref.current?.setSelection(0, snippet.length)
               navigator.clipboard.writeText(snippet)
               setCopied(true)
             }}>

--- a/src/components/dialogs/Embed.tsx
+++ b/src/components/dialogs/Embed.tsx
@@ -12,12 +12,12 @@ import {Button, ButtonIcon, ButtonText} from '#/components/Button'
 import * as Dialog from '#/components/Dialog'
 import * as TextField from '#/components/forms/TextField'
 import * as ToggleButton from '#/components/forms/ToggleButton'
-import {Check_Stroke2_Corner0_Rounded as Check} from '#/components/icons/Check'
+import {Check_Stroke2_Corner0_Rounded as CheckIcon} from '#/components/icons/Check'
 import {
-  ChevronBottom_Stroke2_Corner0_Rounded,
-  ChevronTop_Stroke2_Corner0_Rounded,
+  ChevronRight_Stroke2_Corner0_Rounded as ChevronRightIcon,
+  ChevronTop_Stroke2_Corner0_Rounded as ChevronTopIcon,
 } from '#/components/icons/Chevron'
-import {CodeBrackets_Stroke2_Corner0_Rounded as CodeBrackets} from '#/components/icons/CodeBrackets'
+import {CodeBrackets_Stroke2_Corner0_Rounded as CodeBracketsIcon} from '#/components/icons/CodeBrackets'
 import {Text} from '#/components/Typography'
 
 export type ColorModeValues = 'system' | 'light' | 'dark'
@@ -139,11 +139,7 @@ function EmbedDialogInner({
               showCustomisation && t.atoms.bg_contrast_25,
             ]}>
             <ButtonIcon
-              icon={
-                showCustomisation
-                  ? ChevronTop_Stroke2_Corner0_Rounded
-                  : ChevronBottom_Stroke2_Corner0_Rounded
-              }
+              icon={showCustomisation ? ChevronTopIcon : ChevronRightIcon}
             />
             <ButtonText>
               <Trans>Customization options</Trans>
@@ -181,7 +177,7 @@ function EmbedDialogInner({
         <View style={[a.flex_row, a.gap_sm]}>
           <View style={[a.flex_1]}>
             <TextField.Root>
-              <TextField.Icon icon={CodeBrackets} />
+              <TextField.Icon icon={CodeBracketsIcon} />
               <TextField.Input
                 label={_(msg`Embed HTML code`)}
                 editable={false}
@@ -203,7 +199,7 @@ function EmbedDialogInner({
             }}>
             {copied ? (
               <>
-                <ButtonIcon icon={Check} />
+                <ButtonIcon icon={CheckIcon} />
                 <ButtonText>
                   <Trans>Copied!</Trans>
                 </ButtonText>

--- a/src/components/dialogs/Embed.tsx
+++ b/src/components/dialogs/Embed.tsx
@@ -1,4 +1,4 @@
-import React, {memo, useRef, useState} from 'react'
+import {memo, useEffect, useMemo, useRef, useState} from 'react'
 import {TextInput, View} from 'react-native'
 import {AppBskyActorDefs, AppBskyFeedPost, AtUri} from '@atproto/api'
 import {msg, Trans} from '@lingui/macro'
@@ -8,12 +8,19 @@ import {EMBED_SCRIPT} from '#/lib/constants'
 import {niceDate} from '#/lib/strings/time'
 import {toShareUrl} from '#/lib/strings/url-helpers'
 import {atoms as a, useTheme} from '#/alf'
+import {Button, ButtonIcon, ButtonText} from '#/components/Button'
 import * as Dialog from '#/components/Dialog'
 import * as TextField from '#/components/forms/TextField'
+import * as ToggleButton from '#/components/forms/ToggleButton'
 import {Check_Stroke2_Corner0_Rounded as Check} from '#/components/icons/Check'
+import {
+  ChevronBottom_Stroke2_Corner0_Rounded,
+  ChevronTop_Stroke2_Corner0_Rounded,
+} from '#/components/icons/Chevron'
 import {CodeBrackets_Stroke2_Corner0_Rounded as CodeBrackets} from '#/components/icons/CodeBrackets'
 import {Text} from '#/components/Typography'
-import {Button, ButtonIcon, ButtonText} from '../Button'
+
+export type ColorModeValues = 'system' | 'light' | 'dark'
 
 type EmbedDialogProps = {
   control: Dialog.DialogControlProps
@@ -46,9 +53,11 @@ function EmbedDialogInner({
   const {_, i18n} = useLingui()
   const ref = useRef<TextInput>(null)
   const [copied, setCopied] = useState(false)
+  const [showCustomisation, setShowCustomisation] = useState(false)
+  const [colorMode, setColorMode] = useState<ColorModeValues>('system')
 
   // reset copied state after 2 seconds
-  React.useEffect(() => {
+  useEffect(() => {
     if (copied) {
       const timeout = setTimeout(() => {
         setCopied(false)
@@ -57,7 +66,7 @@ function EmbedDialogInner({
     }
   }, [copied])
 
-  const snippet = React.useMemo(() => {
+  const snippet = useMemo(() => {
     function toEmbedUrl(href: string) {
       return toShareUrl(href) + '?ref_src=embed'
     }
@@ -75,9 +84,11 @@ function EmbedDialogInner({
     // x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x-x
     return `<blockquote class="bluesky-embed" data-bluesky-uri="${escapeHtml(
       postUri,
-    )}" data-bluesky-cid="${escapeHtml(postCid)}"><p lang="${escapeHtml(
-      lang,
-    )}">${escapeHtml(record.text)}${
+    )}" data-bluesky-cid="${escapeHtml(
+      postCid,
+    )}" data-bluesky-embed-color-mode="${escapeHtml(
+      colorMode,
+    )}"><p lang="${escapeHtml(lang)}">${escapeHtml(record.text)}${
       record.embed
         ? `<br><br><a href="${escapeHtml(href)}">[image or embed]</a>`
         : ''
@@ -88,60 +99,122 @@ function EmbedDialogInner({
     )}</a>) <a href="${escapeHtml(href)}">${escapeHtml(
       niceDate(i18n, timestamp),
     )}</a></blockquote><script async src="${EMBED_SCRIPT}" charset="utf-8"></script>`
-  }, [i18n, postUri, postCid, record, timestamp, postAuthor])
+  }, [i18n, postUri, postCid, record, timestamp, postAuthor, colorMode])
 
   return (
-    <Dialog.Inner label="Embed post" style={[a.gap_md, {maxWidth: 500}]}>
-      <View style={[a.gap_sm, a.pb_lg]}>
-        <Text style={[a.text_2xl, a.font_bold]}>
-          <Trans>Embed post</Trans>
-        </Text>
-        <Text
-          style={[a.text_md, t.atoms.text_contrast_medium, a.leading_normal]}>
-          <Trans>
-            Embed this post in your website. Simply copy the following snippet
-            and paste it into the HTML code of your website.
-          </Trans>
-        </Text>
-      </View>
-
-      <View style={[a.flex_row, a.gap_sm]}>
-        <View style={[a.flex_1]}>
-          <TextField.Root>
-            <TextField.Icon icon={CodeBrackets} />
-            <TextField.Input
-              label={_(msg`Embed HTML code`)}
-              editable={false}
-              selection={{start: 0, end: snippet.length}}
-              value={snippet}
-              style={{}}
-            />
-          </TextField.Root>
+    <Dialog.Inner label="Embed post" style={[{maxWidth: 500}]}>
+      <View style={[a.gap_lg]}>
+        <View style={[a.gap_sm]}>
+          <Text style={[a.text_2xl, a.font_heavy]}>
+            <Trans>Embed post</Trans>
+          </Text>
+          <Text
+            style={[a.text_md, t.atoms.text_contrast_medium, a.leading_normal]}>
+            <Trans>
+              Embed this post in your website. Simply copy the following snippet
+              and paste it into the HTML code of your website.
+            </Trans>
+          </Text>
         </View>
-        <Button
-          label={_(msg`Copy code`)}
-          color="primary"
-          variant="solid"
-          size="large"
-          onPress={() => {
-            ref.current?.focus()
-            ref.current?.setSelection(0, snippet.length)
-            navigator.clipboard.writeText(snippet)
-            setCopied(true)
-          }}>
-          {copied ? (
-            <>
-              <ButtonIcon icon={Check} />
-              <ButtonText>
-                <Trans>Copied!</Trans>
-              </ButtonText>
-            </>
-          ) : (
+        <View
+          style={[
+            a.border,
+            t.atoms.border_contrast_low,
+            a.rounded_sm,
+            a.overflow_hidden,
+          ]}>
+          <Button
+            label={
+              showCustomisation
+                ? _(msg`Hide customization options`)
+                : _(msg`Show customization options`)
+            }
+            color="secondary"
+            variant="ghost"
+            size="small"
+            shape="default"
+            onPress={() => setShowCustomisation(c => !c)}
+            style={[
+              a.justify_start,
+              showCustomisation && t.atoms.bg_contrast_25,
+            ]}>
+            <ButtonIcon
+              icon={
+                showCustomisation
+                  ? ChevronTop_Stroke2_Corner0_Rounded
+                  : ChevronBottom_Stroke2_Corner0_Rounded
+              }
+            />
             <ButtonText>
-              <Trans>Copy code</Trans>
+              <Trans>Customization options</Trans>
             </ButtonText>
+          </Button>
+
+          {showCustomisation && (
+            <View style={[a.gap_sm, a.p_md]}>
+              <Text style={[t.atoms.text_contrast_medium, a.font_bold]}>
+                <Trans>Color theme</Trans>
+              </Text>
+              <ToggleButton.Group
+                label={_(msg`Color mode`)}
+                values={[colorMode]}
+                onChange={([value]) => setColorMode(value as ColorModeValues)}>
+                <ToggleButton.Button name="system" label={_(msg`System`)}>
+                  <ToggleButton.ButtonText>
+                    <Trans>System</Trans>
+                  </ToggleButton.ButtonText>
+                </ToggleButton.Button>
+                <ToggleButton.Button name="light" label={_(msg`Light`)}>
+                  <ToggleButton.ButtonText>
+                    <Trans>Light</Trans>
+                  </ToggleButton.ButtonText>
+                </ToggleButton.Button>
+                <ToggleButton.Button name="dark" label={_(msg`Dark`)}>
+                  <ToggleButton.ButtonText>
+                    <Trans>Dark</Trans>
+                  </ToggleButton.ButtonText>
+                </ToggleButton.Button>
+              </ToggleButton.Group>
+            </View>
           )}
-        </Button>
+        </View>
+        <View style={[a.flex_row, a.gap_sm]}>
+          <View style={[a.flex_1]}>
+            <TextField.Root>
+              <TextField.Icon icon={CodeBrackets} />
+              <TextField.Input
+                label={_(msg`Embed HTML code`)}
+                editable={false}
+                selection={{start: 0, end: snippet.length}}
+                value={snippet}
+              />
+            </TextField.Root>
+          </View>
+          <Button
+            label={_(msg`Copy code`)}
+            color="primary"
+            variant="solid"
+            size="large"
+            onPress={() => {
+              ref.current?.focus()
+              ref.current?.setSelection(0, snippet.length)
+              navigator.clipboard.writeText(snippet)
+              setCopied(true)
+            }}>
+            {copied ? (
+              <>
+                <ButtonIcon icon={Check} />
+                <ButtonText>
+                  <Trans>Copied!</Trans>
+                </ButtonText>
+              </>
+            ) : (
+              <ButtonText>
+                <Trans>Copy code</Trans>
+              </ButtonText>
+            )}
+          </Button>
+        </View>
       </View>
       <Dialog.Close />
     </Dialog.Inner>


### PR DESCRIPTION
# Stacked on https://github.com/bluesky-social/social-app/pull/7186

Following on from #7186, this adds the option to select a colour mode in-app. Defaults to `system`

<table>
  <tbody>
    <tr>
      <td><img width="400" alt="Screenshot 2025-01-06 at 22 16 57" src="https://github.com/user-attachments/assets/11aa6756-5b5e-4557-b17e-287647b946cb" /></td>
      <td><img width="400" alt="Screenshot 2025-01-06 at 22 17 03" src="https://github.com/user-attachments/assets/3f44b835-4817-46da-896f-617425a5c8f9" /></td>
    </tr>
  </tbody>
</table>



# Test plan

- Confirm snippet matches output from base PR (vibe checking snippet is fine)
- Check my American English spelling is correct
