### PR TITLE
Add bookmarks natively to Bluesky

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,6 +152,7 @@
     "js-sha256": "^0.9.0",
     "jwt-decode": "^4.0.0",
     "lande": "^1.0.10",
+    "@lexicon-community/types": "^1.0.0",
     "lodash.chunk": "^4.2.0",
     "lodash.debounce": "^4.0.8",
     "lodash.isequal": "^4.5.0",

--- a/src/Navigation.tsx
+++ b/src/Navigation.tsx
@@ -21,6 +21,7 @@ import {useWebScrollRestoration} from '#/lib/hooks/useWebScrollRestoration'
 import {buildStateObject} from '#/lib/routes/helpers'
 import {
   AllNavigatorParams,
+  BookmarksTabNavigatorParams,
   BottomTabNavigatorParams,
   FlatNavigatorParams,
   HomeTabNavigatorParams,
@@ -40,6 +41,7 @@ import {
   shouldRequestEmailConfirmation,
   snoozeEmailConfirmationPrompt,
 } from '#/state/shell/reminders'
+import {BookmarksScreen} from '#/view/screens/Bookmarks'
 import {CommunityGuidelinesScreen} from '#/view/screens/CommunityGuidelines'
 import {CopyrightPolicyScreen} from '#/view/screens/CopyrightPolicy'
 import {DebugModScreen} from '#/view/screens/DebugMod'
@@ -108,6 +110,8 @@ const HomeTab = createNativeStackNavigatorWithAuth<HomeTabNavigatorParams>()
 const SearchTab = createNativeStackNavigatorWithAuth<SearchTabNavigatorParams>()
 const NotificationsTab =
   createNativeStackNavigatorWithAuth<NotificationsTabNavigatorParams>()
+const BookmarksTab =
+  createNativeStackNavigatorWithAuth<BookmarksTabNavigatorParams>()
 const MyProfileTab =
   createNativeStackNavigatorWithAuth<MyProfileTabNavigatorParams>()
 const MessagesTab =
@@ -128,6 +132,11 @@ function commonScreens(Stack: typeof HomeTab, unreadCountLabel?: string) {
         name="NotFound"
         getComponent={() => NotFoundScreen}
         options={{title: title(msg`Not Found`)}}
+      />
+      <Stack.Screen
+        name="Bookmarks"
+        getComponent={() => BookmarksScreen}
+        options={{title: title(msg`Bookmarks`), requireAuth: true}}
       />
       <Stack.Screen
         name="Lists"
@@ -451,6 +460,10 @@ function TabsNavigator() {
         getComponent={() => NotificationsTabNavigator}
       />
       <Tab.Screen
+        name="BookmarksTab"
+        getComponent={() => BookmarksTabNavigator}
+      />
+      <Tab.Screen
         name="MyProfileTab"
         getComponent={() => MyProfileTabNavigator}
       />
@@ -516,6 +529,27 @@ function NotificationsTabNavigator() {
       />
       {commonScreens(NotificationsTab as typeof HomeTab)}
     </NotificationsTab.Navigator>
+  )
+}
+
+function BookmarksTabNavigator() {
+  const t = useTheme()
+  return (
+    <BookmarksTab.Navigator
+      screenOptions={{
+        animationDuration: 285,
+        gestureEnabled: true,
+        fullScreenGestureEnabled: true,
+        headerShown: false,
+        contentStyle: t.atoms.bg,
+      }}>
+      <BookmarksTab.Screen
+        name="Bookmarks"
+        getComponent={() => BookmarksScreen}
+        options={{requireAuth: true}}
+      />
+      {commonScreens(BookmarksTab as typeof HomeTab)}
+    </BookmarksTab.Navigator>
   )
 }
 

--- a/src/components/icons/Bookmark.tsx
+++ b/src/components/icons/Bookmark.tsx
@@ -1,0 +1,9 @@
+import {createSinglePathSVG} from './TEMPLATE'
+
+export const Bookmark_Stroke2_Corner0_Rounded = createSinglePathSVG({
+  path: 'M19.5 22.5c-.2 0-.3 0-.5-.1l-6.5-3.7L6 22.4c-.3.2-.7.2-1 0-.3-.2-.5-.5-.5-.9v-18c0-.6.4-1 1-1h14c.6 0 1 .4 1 1v18c0 .4-.2.7-.5.9-.2.1-.3.1-.5.1zm-7-6c.2 0 .3 0 .5.1l5.5 3.1V4.5h-12v15.3l5.5-3.1c.2-.2.3-.2.5-.2z',
+})
+
+export const Bookmark_Filled_Corner0_Rounded = createSinglePathSVG({
+  path: 'M19 22c-.2 0-.3 0-.5-.1L12 18.2l-6.5 3.7c-.3.2-.7.2-1 0-.3-.2-.5-.5-.5-.9V3c0-.6.4-1 1-1h14c.6 0 1 .4 1 1v18c0 .4-.2.7-.5.9-.2.1-.3.1-.5.1z',
+})

--- a/src/lib/hooks/useNavigationTabState.ts
+++ b/src/lib/hooks/useNavigationTabState.ts
@@ -11,6 +11,7 @@ export function useNavigationTabState() {
       isAtFeeds: getTabState(state, 'Feeds') !== TabState.Outside,
       isAtNotifications:
         getTabState(state, 'Notifications') !== TabState.Outside,
+      isAtBookmarks: getTabState(state, 'Bookmarks') !== TabState.Outside,
       isAtMyProfile: getTabState(state, 'MyProfile') !== TabState.Outside,
       isAtMessages: getTabState(state, 'Messages') !== TabState.Outside,
     }

--- a/src/lib/routes/types.ts
+++ b/src/lib/routes/types.ts
@@ -6,6 +6,7 @@ export type {NativeStackScreenProps} from '@react-navigation/native-stack'
 export type CommonNavigatorParams = {
   NotFound: undefined
   Lists: undefined
+  Bookmarks: undefined
   Moderation: undefined
   ModerationModlists: undefined
   ModerationMutedAccounts: undefined
@@ -63,6 +64,7 @@ export type BottomTabNavigatorParams = CommonNavigatorParams & {
   HomeTab: undefined
   SearchTab: undefined
   NotificationsTab: undefined
+  BookmarksTab: undefined
   MyProfileTab: undefined
   MessagesTab: undefined
 }
@@ -77,6 +79,10 @@ export type SearchTabNavigatorParams = CommonNavigatorParams & {
 
 export type NotificationsTabNavigatorParams = CommonNavigatorParams & {
   Notifications: undefined
+}
+
+export type BookmarksTabNavigatorParams = CommonNavigatorParams & {
+  Bookmarks: undefined
 }
 
 export type MyProfileTabNavigatorParams = CommonNavigatorParams & {

--- a/src/lib/statsig/events.ts
+++ b/src/lib/statsig/events.ts
@@ -136,6 +136,9 @@ export type LogEvents = {
   'post:bookmark': {
     logContext: 'FeedItem' | 'PostThreadItem' | 'Post'
   }
+  'post:unbookmark': {
+    logContext: 'FeedItem' | 'PostThreadItem' | 'Post'
+  }
   'post:repost': {
     logContext: 'FeedItem' | 'PostThreadItem' | 'Post'
   }

--- a/src/lib/statsig/events.ts
+++ b/src/lib/statsig/events.ts
@@ -133,6 +133,9 @@ export type LogEvents = {
     postClout: number | undefined
     logContext: 'FeedItem' | 'PostThreadItem' | 'Post'
   }
+  'post:bookmark': {
+    logContext: 'FeedItem' | 'PostThreadItem' | 'Post'
+  }
   'post:repost': {
     logContext: 'FeedItem' | 'PostThreadItem' | 'Post'
   }

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -5,6 +5,7 @@ export const router = new Router({
   Search: '/search',
   Feeds: '/feeds',
   Notifications: '/notifications',
+  Bookmarks: '/bookmarks',
   NotificationSettings: '/notifications/settings',
   Settings: '/settings',
   Lists: '/lists',

--- a/src/state/queries/bookmark.ts
+++ b/src/state/queries/bookmark.ts
@@ -1,6 +1,6 @@
 import {useCallback} from 'react'
 import {AppBskyFeedDefs, ComAtprotoRepoPutRecord} from '@atproto/api'
-import {TID} from '@atproto/common'
+import {TID} from '@atproto/common-web'
 import {useMutation} from '@tanstack/react-query'
 
 import {useToggleMutationQueue} from '#/lib/hooks/useToggleMutationQueue'
@@ -34,6 +34,10 @@ export function usePostBookmarkMutationQueue(
   const queueBookmark = useCallback(() => {
     return queueToggle(true)
   }, [queueToggle])
+
+  // const queueunbookmark = useCallback(() => {
+  //   return queueToggle(true)
+  // }, [queueToggle])
   return [queueBookmark]
 }
 
@@ -64,3 +68,20 @@ function usePostBookmarkMutation(
     },
   })
 }
+
+// function usePostUnBookmarkMutation(
+//   logContext: LogEvents['post:unbookmark']['logContext'],
+// ) {
+//   const agent = useAgent()
+//   return useMutation<void, Error, {postUri: string; likeUri: string}>({
+//     mutationFn: ({likeUri}) => {
+//       logEvent('post:unbookmark', {logContext})
+//       return agent.com.atproto.repo.deleteRecord({
+//         repo: agent.assertDid,
+//         collection: 'community.lexicon.bookmarks.bookmark',
+//         rkey: '3ldrdnt4eys2p',
+//       })
+//       return agent.deleteLike(likeUri)
+//     },
+//   })
+// }

--- a/src/state/queries/bookmark.ts
+++ b/src/state/queries/bookmark.ts
@@ -1,0 +1,66 @@
+import {useCallback} from 'react'
+import {AppBskyFeedDefs, ComAtprotoRepoPutRecord} from '@atproto/api'
+import {TID} from '@atproto/common'
+import {useMutation} from '@tanstack/react-query'
+
+import {useToggleMutationQueue} from '#/lib/hooks/useToggleMutationQueue'
+import {LogEvents} from '#/lib/statsig/events'
+import {logEvent} from '#/lib/statsig/statsig'
+import {Shadow} from '../cache/types'
+import {useAgent} from '../session'
+
+export function usePostBookmarkMutationQueue(
+  post: Shadow<AppBskyFeedDefs.PostView>,
+  logContext: LogEvents['post:bookmark']['logContext'],
+) {
+  const bookmarkUri = 'someuri'
+  const bookmarkMutation = usePostBookmarkMutation(logContext, post)
+
+  const queueToggle = useToggleMutationQueue({
+    initialState: bookmarkUri,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    runMutation: async (prev, shouldBookmark = true) => {
+      const {data, success} = await bookmarkMutation.mutateAsync()
+      if (!success) {
+        throw new Error('Failed to toggle bookmark')
+      }
+      return data.uri
+    },
+    onSuccess(finalBookmarkUri) {
+      console.log('onSuccess', finalBookmarkUri)
+    },
+  })
+
+  const queueBookmark = useCallback(() => {
+    return queueToggle(true)
+  }, [queueToggle])
+  return [queueBookmark]
+}
+
+function usePostBookmarkMutation(
+  logContext: LogEvents['post:bookmark']['logContext'],
+  post: Shadow<AppBskyFeedDefs.PostView>,
+) {
+  const agent = useAgent()
+  return useMutation<ComAtprotoRepoPutRecord.Response, Error>({
+    mutationFn: () => {
+      logEvent('post:bookmark', {
+        logContext,
+      })
+
+      const rkey = TID.nextStr()
+      const record = {
+        $type: 'community.lexicon.bookmarks.bookmark',
+        subject: post.uri,
+        createdAt: new Date().toISOString(),
+      }
+      return agent.com.atproto.repo.putRecord({
+        repo: agent.assertDid,
+        collection: 'community.lexicon.bookmarks.bookmark',
+        rkey,
+        record,
+        validate: false,
+      })
+    },
+  })
+}

--- a/src/state/queries/bookmark.ts
+++ b/src/state/queries/bookmark.ts
@@ -5,34 +5,41 @@ import {
   ComAtprotoRepoDeleteRecord,
   ComAtprotoRepoPutRecord,
 } from '@atproto/api'
-import {useMutation} from '@tanstack/react-query'
+import {useMutation, useQueryClient} from '@tanstack/react-query'
 
 import {useToggleMutationQueue} from '#/lib/hooks/useToggleMutationQueue'
 import {LogEvents} from '#/lib/statsig/events'
 import {logEvent} from '#/lib/statsig/statsig'
 import {Shadow} from '../cache/types'
 import {useAgent} from '../session'
+import {getBookmarkUri, invalidate, RQKEY} from './my-bookmarks'
 
 export function usePostBookmarkMutationQueue(
   post: Shadow<AppBskyFeedDefs.PostView>,
   logContext: LogEvents['post:bookmark']['logContext'],
 ) {
-  const initialBookmarkUri = post.bookmarkUri as string | undefined
+  const initialBookmarkUri = getBookmarkUri(post.uri)
   const bookmarkMutation = usePostBookmarkMutation(logContext, post)
   const unBookmarkMutation = usePostUnBookmarkMutation(logContext)
+  const queryClient = useQueryClient()
 
   const queueToggle = useToggleMutationQueue({
     initialState: initialBookmarkUri,
     runMutation: async (prevBookmarkUri, shouldBookmark) => {
       if (shouldBookmark) {
         const {data} = await bookmarkMutation.mutateAsync()
+        invalidate(queryClient)
+        queryClient.invalidateQueries({queryKey: RQKEY()})
         return data.uri
       } else {
         if (prevBookmarkUri) {
+          console.log('unbookmarking', prevBookmarkUri)
           await unBookmarkMutation.mutateAsync({
             bookmarkUri: prevBookmarkUri,
           })
         }
+        invalidate(queryClient)
+        queryClient.invalidateQueries({queryKey: RQKEY()})
         return undefined
       }
     },

--- a/src/state/queries/bookmark.ts
+++ b/src/state/queries/bookmark.ts
@@ -37,9 +37,7 @@ export function usePostBookmarkMutationQueue(
         return undefined
       }
     },
-    onSuccess(finalBookmarkUri) {
-      console.log('onSuccess', finalBookmarkUri)
-    },
+    onSuccess() {},
   })
 
   const queueBookmark = useCallback(() => {

--- a/src/state/queries/bookmark.ts
+++ b/src/state/queries/bookmark.ts
@@ -87,7 +87,6 @@ function usePostUnBookmarkMutation(
   >({
     mutationFn: ({bookmarkUri}) => {
       logEvent('post:unbookmark', {logContext})
-      console.log('unbookmark', bookmarkUri)
       const bookmarkUrip = new AtUri(bookmarkUri)
       return agent.com.atproto.repo.deleteRecord({
         repo: agent.assertDid,

--- a/src/state/queries/my-bookmarks.ts
+++ b/src/state/queries/my-bookmarks.ts
@@ -1,5 +1,5 @@
 import {CommunityLexiconBookmarksBookmark} from '@lexicon-community/types'
-import {QueryClient, useQuery} from '@tanstack/react-query'
+import {QueryClient, useQuery, UseQueryResult} from '@tanstack/react-query'
 
 import {accumulate} from '#/lib/async/accumulate'
 import {STALE} from '#/state/queries'
@@ -8,7 +8,10 @@ import {useAgent, useSession} from '#/state/session'
 const RQKEY_ROOT = 'my-bookmarks'
 export const RQKEY = () => [RQKEY_ROOT]
 
-export function useMyBookmarksQuery() {
+export function useMyBookmarksQuery(): UseQueryResult<
+  CommunityLexiconBookmarksBookmark.Record[],
+  Error
+> {
   const {currentAccount} = useSession()
   const agent = useAgent()
   return useQuery<CommunityLexiconBookmarksBookmark.Record[]>({
@@ -22,7 +25,6 @@ export function useMyBookmarksQuery() {
             .listRecords({
               repo: agent!.did ?? '',
               collection: 'community.lexicon.bookmarks.bookmark',
-              limit: 2,
               cursor,
             })
             .then(res => ({
@@ -42,6 +44,7 @@ export function useMyBookmarksQuery() {
           if (isValid) {
             const recordVal =
               bookmark.value as CommunityLexiconBookmarksBookmark.Record
+            recordVal.uri = bookmark.uri
             bookmarks.push(recordVal)
           }
         }

--- a/src/state/queries/my-bookmarks.ts
+++ b/src/state/queries/my-bookmarks.ts
@@ -68,6 +68,15 @@ export function invalidate(qc: QueryClient) {
   qc.invalidateQueries({queryKey: [RQKEY_ROOT]})
 }
 
+export function addBookmark(postUri: string, bookmarkUri: string): void {
+  bookmarkMap.set(postUri, bookmarkUri)
+}
+
+// Function to remove a bookmark from the map
+export function removeBookmark(postUri: string): void {
+  bookmarkMap.delete(postUri)
+}
+
 export const convertAtUriToBlueskyUrl = (subject: string): string | null => {
   try {
     ensureValidAtUri(subject)

--- a/src/state/queries/my-bookmarks.ts
+++ b/src/state/queries/my-bookmarks.ts
@@ -1,0 +1,57 @@
+import {CommunityLexiconBookmarksBookmark} from '@lexicon-community/types'
+import {QueryClient, useQuery} from '@tanstack/react-query'
+
+import {accumulate} from '#/lib/async/accumulate'
+import {STALE} from '#/state/queries'
+import {useAgent, useSession} from '#/state/session'
+
+const RQKEY_ROOT = 'my-bookmarks'
+export const RQKEY = () => [RQKEY_ROOT]
+
+export function useMyBookmarksQuery() {
+  const {currentAccount} = useSession()
+  const agent = useAgent()
+  return useQuery<CommunityLexiconBookmarksBookmark.Record[]>({
+    staleTime: STALE.MINUTES.ONE,
+    queryKey: RQKEY(),
+    async queryFn() {
+      let bookmarks: CommunityLexiconBookmarksBookmark.Record[] = []
+      const promises = [
+        accumulate(cursor =>
+          agent.com.atproto.repo
+            .listRecords({
+              repo: agent!.did ?? '',
+              collection: 'community.lexicon.bookmarks.bookmark',
+              limit: 2,
+              cursor,
+            })
+            .then(res => ({
+              cursor: res.data.cursor,
+              items: res.data.records,
+            })),
+        ),
+      ]
+
+      const resultset = await Promise.all(promises)
+      for (const res of resultset) {
+        for (let bookmark of res) {
+          const isValid =
+            CommunityLexiconBookmarksBookmark.isRecord(bookmark.value) &&
+            CommunityLexiconBookmarksBookmark.validateRecord(bookmark.value)
+              .success
+          if (isValid) {
+            const recordVal =
+              bookmark.value as CommunityLexiconBookmarksBookmark.Record
+            bookmarks.push(recordVal)
+          }
+        }
+      }
+      return bookmarks
+    },
+    enabled: !!currentAccount,
+  })
+}
+
+export function invalidate(qc: QueryClient) {
+  qc.invalidateQueries({queryKey: [RQKEY_ROOT]})
+}

--- a/src/view/com/bookmarks/MyBookmarks.tsx
+++ b/src/view/com/bookmarks/MyBookmarks.tsx
@@ -10,6 +10,7 @@ import {
 import {ensureValidAtUri} from '@atproto/syntax'
 import {msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
+import {cloneDeep} from 'lodash'
 
 import {usePalette} from '#/lib/hooks/usePalette'
 import {cleanError} from '#/lib/strings/errors'
@@ -84,10 +85,8 @@ export function MyBookmarks({
         const fetchedPosts = await Promise.all(
           validData!.map(async d => {
             const post = await getPost({uri: d.subject})
-            const p = JSON.parse(JSON.stringify(post))
+            const p = cloneDeep(post)
             p.bookmarkUri = d.uri
-            console.log('post after getPost:', p) // Debugging line
-            console.log('post.bookmarkUri after getPost:', p.bookmarkUri) // Debugging line
             return p
           }),
         )

--- a/src/view/com/bookmarks/MyBookmarks.tsx
+++ b/src/view/com/bookmarks/MyBookmarks.tsx
@@ -109,7 +109,6 @@ export function MyBookmarks({
 
   const renderItemInner = React.useCallback(
     ({item}: {item: any}) => {
-      console.log('ETHAN item:', item)
       if (item === EMPTY) {
         return (
           <View style={[a.flex_1, a.align_center, a.gap_sm, a.px_xl, a.pt_xl]}>
@@ -153,7 +152,7 @@ export function MyBookmarks({
           </View>
         )
       }
-      return <Post post={item} />
+      return <Post isBookmarked={true} post={item} />
     },
     [
       t.atoms.bg_contrast_25,

--- a/src/view/com/bookmarks/MyBookmarks.tsx
+++ b/src/view/com/bookmarks/MyBookmarks.tsx
@@ -1,0 +1,211 @@
+import React, {useEffect, useState} from 'react'
+import {
+  ActivityIndicator,
+  FlatList as RNFlatList,
+  RefreshControl,
+  StyleProp,
+  View,
+  ViewStyle,
+} from 'react-native'
+import {ensureValidAtUri} from '@atproto/syntax'
+import {msg} from '@lingui/macro'
+import {useLingui} from '@lingui/react'
+
+import {usePalette} from '#/lib/hooks/usePalette'
+import {cleanError} from '#/lib/strings/errors'
+import {s} from '#/lib/styles'
+import {logger} from '#/logger'
+import {useModerationOpts} from '#/state/preferences/moderation-opts'
+import {useMyBookmarksQuery} from '#/state/queries/my-bookmarks'
+import {useGetPost} from '#/state/queries/post'
+import {atoms as a, useTheme} from '#/alf'
+import {BulletList_Stroke2_Corner0_Rounded as ListIcon} from '#/components/icons/BulletList'
+import {Text} from '#/components/Typography'
+import {Post} from '../post/Post'
+import {ErrorMessage} from '../util/error/ErrorMessage'
+import {List} from '../util/List'
+
+const LOADING = {_reactKey: '__loading__'}
+const EMPTY = {_reactKey: '__empty__'}
+const ERROR_ITEM = {_reactKey: '__error__'}
+
+const convertAtUriToBlueskyUrl = (subject: string): string | null => {
+  try {
+    ensureValidAtUri(subject)
+    const uriWithoutPrefix = subject.slice(5)
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const [handle, collection, id] = uriWithoutPrefix.split('/')
+    if (collection !== 'app.bsky.feed.post') {
+      return null
+    }
+    return subject
+  } catch (error) {
+    return null
+  }
+}
+
+export function MyBookmarks({
+  inline,
+  style,
+  testID,
+}: {
+  inline?: boolean
+  style?: StyleProp<ViewStyle>
+  testID?: string
+}) {
+  const pal = usePalette('default')
+  const getPost = useGetPost()
+  const t = useTheme()
+  const {_} = useLingui()
+  const moderationOpts = useModerationOpts()
+  const [isPTRing, setIsPTRing] = React.useState(false)
+  const {data, isFetching, isFetched, isError, error, refetch} =
+    useMyBookmarksQuery()
+  const isEmpty = !isFetching && !data?.length
+
+  const [posts, setPosts] = useState<any[]>([])
+
+  useEffect(() => {
+    const fetchPosts = async () => {
+      let items: any[] = []
+      if (isError && isEmpty) {
+        items = items.concat([ERROR_ITEM])
+      }
+      if ((!isFetched && isFetching) || !moderationOpts) {
+        items = items.concat([LOADING])
+      } else if (isEmpty) {
+        items = items.concat([EMPTY])
+      } else {
+        const validData = data
+          ?.map(d => convertAtUriToBlueskyUrl(d.subject))
+          .filter(d => d != null)
+
+        const fetchedPosts = await Promise.all(
+          validData!.map(async uri => {
+            const post = await getPost({uri})
+            return post
+          }),
+        )
+
+        items = items.concat(fetchedPosts)
+      }
+      setPosts(items)
+    }
+
+    fetchPosts()
+  }, [data, isError, isEmpty, isFetched, isFetching, moderationOpts, getPost])
+
+  const emptyText = _(msg`You have no bookmarks.`)
+
+  const onRefresh = React.useCallback(async () => {
+    setIsPTRing(true)
+    try {
+      await refetch()
+    } catch (err) {
+      logger.error('Failed to refresh bookmarks', {message: err})
+    }
+    setIsPTRing(false)
+  }, [refetch, setIsPTRing])
+
+  const renderItemInner = React.useCallback(
+    ({item}: {item: any}) => {
+      console.log('ETHAN item:', item)
+      if (item === EMPTY) {
+        return (
+          <View style={[a.flex_1, a.align_center, a.gap_sm, a.px_xl, a.pt_xl]}>
+            <View
+              style={[
+                a.align_center,
+                a.justify_center,
+                a.rounded_full,
+                t.atoms.bg_contrast_25,
+                {
+                  width: 32,
+                  height: 32,
+                },
+              ]}>
+              <ListIcon size="md" fill={t.atoms.text_contrast_low.color} />
+            </View>
+            <Text
+              style={[
+                a.text_center,
+                a.flex_1,
+                a.text_sm,
+                a.leading_snug,
+                t.atoms.text_contrast_medium,
+                {
+                  maxWidth: 200,
+                },
+              ]}>
+              {emptyText}
+            </Text>
+          </View>
+        )
+      } else if (item === ERROR_ITEM) {
+        console.log('error:', error)
+        return (
+          <ErrorMessage message={cleanError(error)} onPressTryAgain={refetch} />
+        )
+      } else if (item === LOADING) {
+        return (
+          <View style={{padding: 20}}>
+            <ActivityIndicator />
+          </View>
+        )
+      }
+      return <Post post={item} />
+    },
+    [
+      t.atoms.bg_contrast_25,
+      t.atoms.text_contrast_low.color,
+      t.atoms.text_contrast_medium,
+      emptyText,
+      error,
+      refetch,
+    ],
+  )
+
+  if (inline) {
+    return (
+      <View testID={testID} style={style}>
+        {posts.length > 0 && (
+          <RNFlatList
+            testID={testID ? `${testID}-flatlist` : undefined}
+            data={posts}
+            keyExtractor={item => (item.uri ? item.uri : item._reactKey)}
+            renderItem={renderItemInner}
+            refreshControl={
+              <RefreshControl
+                refreshing={isPTRing}
+                onRefresh={onRefresh}
+                tintColor={pal.colors.text}
+                titleColor={pal.colors.text}
+              />
+            }
+            contentContainerStyle={[s.contentContainer]}
+            removeClippedSubviews={true}
+          />
+        )}
+      </View>
+    )
+  } else {
+    return (
+      <View testID={testID} style={style}>
+        {posts.length > 0 && (
+          <List
+            testID={testID ? `${testID}-flatlist` : undefined}
+            data={posts}
+            keyExtractor={item => (item.uri ? item.uri : item._reactKey)}
+            renderItem={renderItemInner}
+            refreshing={isPTRing}
+            onRefresh={onRefresh}
+            contentContainerStyle={[s.contentContainer]}
+            removeClippedSubviews={true}
+            desktopFixedHeight
+            sideBorders={false}
+          />
+        )}
+      </View>
+    )
+  }
+}

--- a/src/view/com/bookmarks/MyBookmarks.tsx
+++ b/src/view/com/bookmarks/MyBookmarks.tsx
@@ -84,7 +84,7 @@ export function MyBookmarks({
         const fetchedPosts = await Promise.all(
           validData!.map(async d => {
             const post = await getPost({uri: d.subject})
-            const p = structuredClone(post)
+            const p = JSON.parse(JSON.stringify(post))
             p.bookmarkUri = d.uri
             console.log('post after getPost:', p) // Debugging line
             console.log('post.bookmarkUri after getPost:', p.bookmarkUri) // Debugging line
@@ -175,7 +175,6 @@ export function MyBookmarks({
   )
 
   if (inline) {
-    console.log('posts:', posts.length)
     return (
       <View testID={testID} style={style}>
         {posts.length > 0 ? (

--- a/src/view/com/bookmarks/MyBookmarks.tsx
+++ b/src/view/com/bookmarks/MyBookmarks.tsx
@@ -7,7 +7,6 @@ import {
   View,
   ViewStyle,
 } from 'react-native'
-import {ensureValidAtUri} from '@atproto/syntax'
 import {msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 import {cloneDeep} from 'lodash'
@@ -30,21 +29,6 @@ import {List} from '../util/List'
 const LOADING = {_reactKey: '__loading__'}
 const EMPTY = {_reactKey: '__empty__'}
 const ERROR_ITEM = {_reactKey: '__error__'}
-
-const convertAtUriToBlueskyUrl = (subject: string): string | null => {
-  try {
-    ensureValidAtUri(subject)
-    const uriWithoutPrefix = subject.slice(5)
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const [handle, collection, id] = uriWithoutPrefix.split('/')
-    if (collection !== 'app.bsky.feed.post') {
-      return null
-    }
-    return subject
-  } catch (error) {
-    return null
-  }
-}
 
 export function MyBookmarks({
   inline,
@@ -78,19 +62,14 @@ export function MyBookmarks({
       } else if (isEmpty) {
         items = items.concat([EMPTY])
       } else {
-        const validData = data?.filter(
-          d => convertAtUriToBlueskyUrl(d.subject) != null,
-        )
-
         const fetchedPosts = await Promise.all(
-          validData!.map(async d => {
+          data!.map(async d => {
             const post = await getPost({uri: d.subject})
             const p = cloneDeep(post)
             p.bookmarkUri = d.uri
             return p
           }),
         )
-        console.log('fetchedPosts:', fetchedPosts)
         items = items.concat(fetchedPosts)
       }
       setPosts(items)
@@ -112,7 +91,6 @@ export function MyBookmarks({
   }, [refetch, setIsPTRing])
 
   const keyExtractor = (item: any, index: number) => {
-    console.log('keyextractor:', item.bookmarkUri, index)
     return item.bookmarkUri ? item.bookmarkUri.toString() : index.toString()
   }
 

--- a/src/view/com/post/Post.tsx
+++ b/src/view/com/post/Post.tsx
@@ -41,13 +41,11 @@ import {UserInfoText} from '../util/UserInfoText'
 
 export function Post({
   post,
-  isBookmarked = false,
   showReplyLine,
   hideTopBorder,
   style,
 }: {
   post: AppBskyFeedDefs.PostView
-  isBookmarked?: boolean
   showReplyLine?: boolean
   hideTopBorder?: boolean
   style?: StyleProp<ViewStyle>
@@ -83,7 +81,6 @@ export function Post({
     return (
       <PostInner
         post={postShadowed}
-        isBookmarked={isBookmarked}
         record={record}
         richText={richText}
         moderation={moderation}
@@ -98,7 +95,6 @@ export function Post({
 
 function PostInner({
   post,
-  isBookmarked,
   record,
   richText,
   moderation,
@@ -107,7 +103,6 @@ function PostInner({
   style,
 }: {
   post: Shadow<AppBskyFeedDefs.PostView>
-  isBookmarked?: boolean
   record: AppBskyFeedPost.Record
   richText: RichTextAPI
   moderation: ModerationDecision
@@ -260,7 +255,7 @@ function PostInner({
           </ContentHider>
           <PostCtrls
             post={post}
-            isBookmarked={isBookmarked ?? false}
+            bookmarkUri={post.bookmarkUri as string | undefined}
             record={record}
             richText={richText}
             onPressReply={onPressReply}

--- a/src/view/com/post/Post.tsx
+++ b/src/view/com/post/Post.tsx
@@ -51,6 +51,7 @@ export function Post({
   style?: StyleProp<ViewStyle>
 }) {
   const moderationOpts = useModerationOpts()
+
   const record = useMemo<AppBskyFeedPost.Record | undefined>(
     () =>
       AppBskyFeedPost.isRecord(post.record) &&
@@ -255,7 +256,6 @@ function PostInner({
           </ContentHider>
           <PostCtrls
             post={post}
-            bookmarkUri={post.bookmarkUri as string | undefined}
             record={record}
             richText={richText}
             onPressReply={onPressReply}

--- a/src/view/com/post/Post.tsx
+++ b/src/view/com/post/Post.tsx
@@ -41,11 +41,13 @@ import {UserInfoText} from '../util/UserInfoText'
 
 export function Post({
   post,
+  isBookmarked = false,
   showReplyLine,
   hideTopBorder,
   style,
 }: {
   post: AppBskyFeedDefs.PostView
+  isBookmarked?: boolean
   showReplyLine?: boolean
   hideTopBorder?: boolean
   style?: StyleProp<ViewStyle>
@@ -81,6 +83,7 @@ export function Post({
     return (
       <PostInner
         post={postShadowed}
+        isBookmarked={isBookmarked}
         record={record}
         richText={richText}
         moderation={moderation}
@@ -95,6 +98,7 @@ export function Post({
 
 function PostInner({
   post,
+  isBookmarked,
   record,
   richText,
   moderation,
@@ -103,6 +107,7 @@ function PostInner({
   style,
 }: {
   post: Shadow<AppBskyFeedDefs.PostView>
+  isBookmarked?: boolean
   record: AppBskyFeedPost.Record
   richText: RichTextAPI
   moderation: ModerationDecision
@@ -255,6 +260,7 @@ function PostInner({
           </ContentHider>
           <PostCtrls
             post={post}
+            isBookmarked={isBookmarked ?? false}
             record={record}
             richText={richText}
             onPressReply={onPressReply}

--- a/src/view/com/util/post-ctrls/BookmarkButton.tsx
+++ b/src/view/com/util/post-ctrls/BookmarkButton.tsx
@@ -5,7 +5,6 @@ import {useHaptics} from '#/lib/haptics'
 import {useRequireAuth} from '#/state/session'
 import {atoms as a, useTheme} from '#/alf'
 import {Button} from '#/components/Button'
-import * as Dialog from '#/components/Dialog'
 import {Bookmark_Stroke2_Corner0_Rounded as Bookmark} from '#/components/icons/Bookmark'
 
 interface Props {
@@ -21,7 +20,6 @@ let BookmarkButton = ({
 }: Props): React.ReactNode => {
   const t = useTheme()
   const requireAuth = useRequireAuth()
-  const dialogControl = Dialog.useDialogControl()
   const playHaptic = useHaptics()
   const color = React.useMemo(
     () => ({
@@ -35,7 +33,7 @@ let BookmarkButton = ({
         testID="bookmarkBtn"
         onPress={() => {
           playHaptic('Light')
-          requireAuth(() => dialogControl.open())
+          requireAuth(() => onBookmark())
         }}
         onLongPress={() => {
           playHaptic('Heavy')

--- a/src/view/com/util/post-ctrls/BookmarkButton.tsx
+++ b/src/view/com/util/post-ctrls/BookmarkButton.tsx
@@ -23,9 +23,9 @@ let BookmarkButton = ({
   const playHaptic = useHaptics()
   const color = React.useMemo(
     () => ({
-      color: isBookmarked ? t.palette.positive_600 : t.palette.contrast_500,
+      color: isBookmarked ? t.palette.primary_500 : t.palette.contrast_500,
     }),
-    [isBookmarked, t.palette.positive_600, t.palette.contrast_500],
+    [isBookmarked, t.palette.primary_500, t.palette.contrast_500],
   )
   return (
     <>

--- a/src/view/com/util/post-ctrls/BookmarkButton.tsx
+++ b/src/view/com/util/post-ctrls/BookmarkButton.tsx
@@ -1,0 +1,63 @@
+import React, {memo} from 'react'
+
+import {POST_CTRL_HITSLOP} from '#/lib/constants'
+import {useHaptics} from '#/lib/haptics'
+import {useRequireAuth} from '#/state/session'
+import {atoms as a, useTheme} from '#/alf'
+import {Button} from '#/components/Button'
+import * as Dialog from '#/components/Dialog'
+import {Bookmark_Stroke2_Corner0_Rounded as Bookmark} from '#/components/icons/Bookmark'
+
+interface Props {
+  isBookmarked: boolean
+  onBookmark: () => void
+  big?: boolean
+}
+
+let BookmarkButton = ({
+  isBookmarked,
+  onBookmark,
+  big,
+}: Props): React.ReactNode => {
+  const t = useTheme()
+  const requireAuth = useRequireAuth()
+  const dialogControl = Dialog.useDialogControl()
+  const playHaptic = useHaptics()
+  const color = React.useMemo(
+    () => ({
+      color: isBookmarked ? t.palette.positive_600 : t.palette.contrast_500,
+    }),
+    [isBookmarked, t.palette.positive_600, t.palette.contrast_500],
+  )
+  return (
+    <>
+      <Button
+        testID="bookmarkBtn"
+        onPress={() => {
+          playHaptic('Light')
+          requireAuth(() => dialogControl.open())
+        }}
+        onLongPress={() => {
+          playHaptic('Heavy')
+          requireAuth(() => onBookmark())
+        }}
+        style={[
+          a.flex_row,
+          a.align_center,
+          a.gap_xs,
+          a.bg_transparent,
+          {padding: 5},
+        ]}
+        label="Bookmark"
+        hoverStyle={t.atoms.bg_contrast_25}
+        shape="round"
+        variant="ghost"
+        color="secondary"
+        hitSlop={POST_CTRL_HITSLOP}>
+        <Bookmark style={color} width={big ? 22 : 18} />
+      </Button>
+    </>
+  )
+}
+BookmarkButton = memo(BookmarkButton)
+export {BookmarkButton}

--- a/src/view/com/util/post-ctrls/PostCtrls.tsx
+++ b/src/view/com/util/post-ctrls/PostCtrls.tsx
@@ -29,6 +29,7 @@ import {toShareUrl} from '#/lib/strings/url-helpers'
 import {Shadow} from '#/state/cache/types'
 import {useFeedFeedbackContext} from '#/state/feed-feedback'
 import {usePostBookmarkMutationQueue} from '#/state/queries/bookmark'
+import {getBookmarkUri} from '#/state/queries/my-bookmarks'
 import {
   usePostLikeMutationQueue,
   usePostRepostMutationQueue,
@@ -54,7 +55,6 @@ import {RepostButton} from './RepostButton'
 let PostCtrls = ({
   big,
   post,
-  bookmarkUri,
   record,
   richText,
   feedContext,
@@ -66,7 +66,6 @@ let PostCtrls = ({
 }: {
   big?: boolean
   post: Shadow<AppBskyFeedDefs.PostView>
-  bookmarkUri?: string | undefined
   record: AppBskyFeedPost.Record
   richText: RichTextAPI
   feedContext?: string | undefined
@@ -160,10 +159,10 @@ let PostCtrls = ({
     isBlocked,
   ])
 
+  const bookmarkUri = getBookmarkUri(post.uri)
+
   const [hasBookmarkIconBeenToggled, setHasBookmarkIconBeenToggled] =
-    React.useState(
-      bookmarkUri !== undefined && bookmarkUri !== null && bookmarkUri !== '',
-    )
+    React.useState(bookmarkUri !== undefined)
 
   const onPressToggleBookmark = React.useCallback(async () => {
     if (isBlocked) {
@@ -179,12 +178,10 @@ let PostCtrls = ({
       setHasBookmarkIconBeenToggled(!hasBookmarkIconBeenToggled)
 
       if (hasBeenToggled) {
-        unQueueBookmark()
-        post.bookmarkUri = undefined
+        await unQueueBookmark()
       } else {
         playHaptic('Light')
-        const newBookmarkUri = await queueBookmark()
-        post.bookmarkUri = newBookmarkUri
+        await queueBookmark()
       }
     } catch (e: any) {
       if (e?.name !== 'AbortError') {
@@ -196,7 +193,6 @@ let PostCtrls = ({
     _,
     hasBookmarkIconBeenToggled,
     unQueueBookmark,
-    post,
     playHaptic,
     queueBookmark,
   ])

--- a/src/view/com/util/post-ctrls/PostCtrls.tsx
+++ b/src/view/com/util/post-ctrls/PostCtrls.tsx
@@ -36,6 +36,7 @@ import {
   invalidate,
   removeBookmark,
   RQKEY,
+  useMyBookmarksQuery,
 } from '#/state/queries/my-bookmarks'
 import {
   usePostLikeMutationQueue,
@@ -82,6 +83,7 @@ let PostCtrls = ({
   logContext: 'FeedItem' | 'PostThreadItem' | 'Post'
   threadgateRecord?: AppBskyFeedThreadgate.Record
 }): React.ReactNode => {
+  const {isFetching} = useMyBookmarksQuery()
   const t = useTheme()
   const {_, i18n} = useLingui()
   const {openComposer} = useComposerControls()
@@ -166,10 +168,18 @@ let PostCtrls = ({
     feedContext,
     isBlocked,
   ])
-  const bookmarkUri = getBookmarkUri(post.uri)
 
+  const bookmarkUri = getBookmarkUri(post.uri) // Fetches the bookmark URI for the post
   const [hasBookmarkIconBeenToggled, setHasBookmarkIconBeenToggled] =
     React.useState(bookmarkUri !== undefined)
+
+  // Update the state when bookmarkUri or isFetching changes
+  React.useEffect(() => {
+    if (!isFetching) {
+      const b = getBookmarkUri(post.uri)
+      setHasBookmarkIconBeenToggled(b !== undefined)
+    }
+  }, [bookmarkUri, isFetching, post.uri])
 
   const onPressToggleBookmark = React.useCallback(async () => {
     if (isBlocked) {

--- a/src/view/com/util/post-ctrls/PostCtrls.tsx
+++ b/src/view/com/util/post-ctrls/PostCtrls.tsx
@@ -54,6 +54,7 @@ import {RepostButton} from './RepostButton'
 let PostCtrls = ({
   big,
   post,
+  isBookmarked = false,
   record,
   richText,
   feedContext,
@@ -65,6 +66,7 @@ let PostCtrls = ({
 }: {
   big?: boolean
   post: Shadow<AppBskyFeedDefs.PostView>
+  isBookmarked: boolean
   record: AppBskyFeedPost.Record
   richText: RichTextAPI
   feedContext?: string | undefined
@@ -156,7 +158,7 @@ let PostCtrls = ({
   ])
 
   const [hasBookmarkIconBeenToggled, setHasBookmarkIconBeenToggled] =
-    React.useState(false)
+    React.useState(isBookmarked)
 
   const onPressToggleBookmark = React.useCallback(async () => {
     if (isBlocked) {
@@ -168,26 +170,23 @@ let PostCtrls = ({
     }
 
     try {
-      setHasBookmarkIconBeenToggled(true)
-      await queueBookmark()
-      // if (!post.viewer?.like) {
-      //   playHaptic('Light')
-      //   sendInteraction({
-      //     item: post.uri,
-      //     event: 'app.bsky.feed.defs#interactionLike',
-      //     feedContext,
-      //   })
-      //   // captureAction(ProgressGuideAction.Like)
+      const hasBeenToggled = hasBookmarkIconBeenToggled
+      setHasBookmarkIconBeenToggled(!hasBookmarkIconBeenToggled)
 
-      // } else {
-      //   await queueUnlike()
-      // }
+      if (hasBeenToggled) {
+        playHaptic('Light')
+        console.log('queueBookmark')
+        const bookmarkUri = await queueBookmark()
+        console.log('bookmarkUri', bookmarkUri)
+      } else {
+        // await queueUnbookmark()
+      }
     } catch (e: any) {
       if (e?.name !== 'AbortError') {
         throw e
       }
     }
-  }, [isBlocked, _, queueBookmark])
+  }, [isBlocked, _, hasBookmarkIconBeenToggled, playHaptic, queueBookmark])
 
   const onRepost = useCallback(async () => {
     if (isBlocked) {

--- a/src/view/com/util/post-ctrls/PostCtrls.tsx
+++ b/src/view/com/util/post-ctrls/PostCtrls.tsx
@@ -180,9 +180,11 @@ let PostCtrls = ({
 
       if (hasBeenToggled) {
         unQueueBookmark()
+        post.bookmarkUri = undefined
       } else {
         playHaptic('Light')
-        await queueBookmark()
+        const newBookmarkUri = await queueBookmark()
+        post.bookmarkUri = newBookmarkUri
       }
     } catch (e: any) {
       if (e?.name !== 'AbortError') {
@@ -194,6 +196,7 @@ let PostCtrls = ({
     _,
     hasBookmarkIconBeenToggled,
     unQueueBookmark,
+    post,
     playHaptic,
     queueBookmark,
   ])

--- a/src/view/screens/Bookmarks.tsx
+++ b/src/view/screens/Bookmarks.tsx
@@ -7,6 +7,7 @@ import {
   NativeStackScreenProps,
 } from '#/lib/routes/types'
 import {s} from '#/lib/styles'
+import {useMyBookmarksQuery} from '#/state/queries/my-bookmarks'
 import {useComposerControls} from '#/state/shell/composer'
 import {FAB} from '#/view/com/util/fab/FAB'
 import {atoms as a} from '#/alf'
@@ -17,6 +18,7 @@ type Props = NativeStackScreenProps<BookmarksTabNavigatorParams, 'Bookmarks'>
 export function BookmarksScreen({}: Props) {
   const {_} = useLingui()
   const {openComposer} = useComposerControls()
+  const {} = useMyBookmarksQuery()
 
   return (
     <Layout.Screen testID="bookmarksScreen">

--- a/src/view/screens/Bookmarks.tsx
+++ b/src/view/screens/Bookmarks.tsx
@@ -7,7 +7,6 @@ import {
   NativeStackScreenProps,
 } from '#/lib/routes/types'
 import {s} from '#/lib/styles'
-import {useMyBookmarksQuery} from '#/state/queries/my-bookmarks'
 import {useComposerControls} from '#/state/shell/composer'
 import {FAB} from '#/view/com/util/fab/FAB'
 import {atoms as a} from '#/alf'
@@ -18,7 +17,6 @@ type Props = NativeStackScreenProps<BookmarksTabNavigatorParams, 'Bookmarks'>
 export function BookmarksScreen({}: Props) {
   const {_} = useLingui()
   const {openComposer} = useComposerControls()
-  const {} = useMyBookmarksQuery()
 
   return (
     <Layout.Screen testID="bookmarksScreen">

--- a/src/view/screens/Bookmarks.tsx
+++ b/src/view/screens/Bookmarks.tsx
@@ -1,0 +1,42 @@
+import {msg, Trans} from '@lingui/macro'
+import {useLingui} from '@lingui/react'
+
+import {ComposeIcon2} from '#/lib/icons'
+import {
+  BookmarksTabNavigatorParams,
+  NativeStackScreenProps,
+} from '#/lib/routes/types'
+import {s} from '#/lib/styles'
+import {useComposerControls} from '#/state/shell/composer'
+import {FAB} from '#/view/com/util/fab/FAB'
+import {atoms as a} from '#/alf'
+import * as Layout from '#/components/Layout'
+import {MyBookmarks} from '../com/bookmarks/MyBookmarks'
+
+type Props = NativeStackScreenProps<BookmarksTabNavigatorParams, 'Bookmarks'>
+export function BookmarksScreen({}: Props) {
+  const {_} = useLingui()
+  const {openComposer} = useComposerControls()
+
+  return (
+    <Layout.Screen testID="bookmarksScreen">
+      <Layout.Header.Outer noBottomBorder sticky={false}>
+        <Layout.Header.MenuButton />
+        <Layout.Header.Content>
+          <Layout.Header.TitleText>
+            <Trans>Bookmarks</Trans>
+          </Layout.Header.TitleText>
+        </Layout.Header.Content>
+      </Layout.Header.Outer>
+      <MyBookmarks style={a.flex_grow} />
+      <FAB
+        testID="composeFAB"
+        onPress={() => openComposer({})}
+        icon={<ComposeIcon2 strokeWidth={1.5} size={29} style={s.white} />}
+        accessibilityRole="button"
+        accessibilityLabel={_(msg`New post`)}
+        accessibilityHint=""
+      />
+    </Layout.Screen>
+  )
+}

--- a/src/view/screens/Home.tsx
+++ b/src/view/screens/Home.tsx
@@ -15,7 +15,6 @@ import {logEvent} from '#/lib/statsig/statsig'
 import {isWeb} from '#/platform/detection'
 import {emitSoftReset} from '#/state/events'
 import {SavedFeedSourceInfo, usePinnedFeedsInfos} from '#/state/queries/feed'
-import {useMyBookmarksQuery} from '#/state/queries/my-bookmarks'
 import {FeedParams} from '#/state/queries/post-feed'
 import {usePreferencesQuery} from '#/state/queries/preferences'
 import {UsePreferencesQueryResponse} from '#/state/queries/preferences/types'
@@ -36,7 +35,6 @@ type Props = NativeStackScreenProps<HomeTabNavigatorParams, 'Home' | 'Start'>
 export function HomeScreen(props: Props) {
   const {setShowLoggedOut} = useLoggedOutViewControls()
   const {data: preferences} = usePreferencesQuery()
-  const {} = useMyBookmarksQuery()
   const {currentAccount} = useSession()
   const {data: pinnedFeedInfos, isLoading: isPinnedFeedsLoading} =
     usePinnedFeedsInfos()

--- a/src/view/screens/Home.tsx
+++ b/src/view/screens/Home.tsx
@@ -15,6 +15,7 @@ import {logEvent} from '#/lib/statsig/statsig'
 import {isWeb} from '#/platform/detection'
 import {emitSoftReset} from '#/state/events'
 import {SavedFeedSourceInfo, usePinnedFeedsInfos} from '#/state/queries/feed'
+import {useMyBookmarksQuery} from '#/state/queries/my-bookmarks'
 import {FeedParams} from '#/state/queries/post-feed'
 import {usePreferencesQuery} from '#/state/queries/preferences'
 import {UsePreferencesQueryResponse} from '#/state/queries/preferences/types'
@@ -35,6 +36,7 @@ type Props = NativeStackScreenProps<HomeTabNavigatorParams, 'Home' | 'Start'>
 export function HomeScreen(props: Props) {
   const {setShowLoggedOut} = useLoggedOutViewControls()
   const {data: preferences} = usePreferencesQuery()
+  const {} = useMyBookmarksQuery()
   const {currentAccount} = useSession()
   const {data: pinnedFeedInfos, isLoading: isPinnedFeedsLoading} =
     usePinnedFeedsInfos()

--- a/src/view/shell/Drawer.tsx
+++ b/src/view/shell/Drawer.tsx
@@ -29,6 +29,10 @@ import {
   Bell_Filled_Corner0_Rounded as BellFilled,
   Bell_Stroke2_Corner0_Rounded as Bell,
 } from '#/components/icons/Bell'
+import {
+  Bookmark_Filled_Corner0_Rounded as BookmarkFilled,
+  Bookmark_Stroke2_Corner0_Rounded as Bookmark,
+} from '#/components/icons/Bookmark'
 import {BulletList_Stroke2_Corner0_Rounded as List} from '#/components/icons/BulletList'
 import {
   Hashtag_Filled_Corner0_Rounded as HashtagFilled,
@@ -132,6 +136,7 @@ let DrawerContent = ({}: React.PropsWithoutRef<{}>): React.ReactNode => {
     isAtSearch,
     isAtFeeds,
     isAtNotifications,
+    isAtBookmarks,
     isAtMyProfile,
     isAtMessages,
   } = useNavigationTabState()
@@ -181,6 +186,11 @@ let DrawerContent = ({}: React.PropsWithoutRef<{}>): React.ReactNode => {
 
   const onPressNotifications = React.useCallback(
     () => onPressTab('Notifications'),
+    [onPressTab],
+  )
+
+  const onPressBookmarks = React.useCallback(
+    () => onPressTab('Bookmarks'),
     [onPressTab],
   )
 
@@ -256,6 +266,10 @@ let DrawerContent = ({}: React.PropsWithoutRef<{}>): React.ReactNode => {
             <NotificationsMenuItem
               isActive={isAtNotifications}
               onPress={onPressNotifications}
+            />
+            <BookmarksMenuItem
+              isActive={isAtBookmarks}
+              onPress={onPressBookmarks}
             />
             <FeedsMenuItem isActive={isAtFeeds} onPress={onPressMyFeeds} />
             <ListsMenuItem onPress={onPressLists} />
@@ -454,6 +468,32 @@ let NotificationsMenuItem = ({
   )
 }
 NotificationsMenuItem = React.memo(NotificationsMenuItem)
+
+let BookmarksMenuItem = ({
+  isActive,
+  onPress,
+}: {
+  isActive: boolean
+  onPress: () => void
+}): React.ReactNode => {
+  const {_} = useLingui()
+  const t = useTheme()
+  return (
+    <MenuItem
+      icon={
+        isActive ? (
+          <BookmarkFilled width={iconWidth} style={[t.atoms.text]} />
+        ) : (
+          <Bookmark width={iconWidth} style={[t.atoms.text]} />
+        )
+      }
+      label={_(msg`Bookmarks`)}
+      bold={isActive}
+      onPress={onPress}
+    />
+  )
+}
+BookmarksMenuItem = React.memo(BookmarksMenuItem)
 
 let FeedsMenuItem = ({
   isActive,

--- a/src/view/shell/bottom-bar/BottomBar.tsx
+++ b/src/view/shell/bottom-bar/BottomBar.tsx
@@ -39,6 +39,10 @@ import {
   Bell_Stroke2_Corner0_Rounded as Bell,
 } from '#/components/icons/Bell'
 import {
+  Bookmark_Filled_Corner0_Rounded as BookmarkFilled,
+  Bookmark_Stroke2_Corner0_Rounded as Bookmark,
+} from '#/components/icons/Bookmark'
+import {
   HomeOpen_Filled_Corner0_Rounded as HomeFilled,
   HomeOpen_Stoke2_Corner0_Rounded as Home,
 } from '#/components/icons/HomeOpen'
@@ -54,6 +58,7 @@ type TabOptions =
   | 'Home'
   | 'Search'
   | 'Notifications'
+  | 'Bookmarks'
   | 'MyProfile'
   | 'Feeds'
   | 'Messages'
@@ -64,8 +69,14 @@ export function BottomBar({navigation}: BottomTabBarProps) {
   const {_} = useLingui()
   const safeAreaInsets = useSafeAreaInsets()
   const {footerHeight} = useShellLayout()
-  const {isAtHome, isAtSearch, isAtNotifications, isAtMyProfile, isAtMessages} =
-    useNavigationTabState()
+  const {
+    isAtHome,
+    isAtSearch,
+    isAtNotifications,
+    isAtBookmarks,
+    isAtMyProfile,
+    isAtMessages,
+  } = useNavigationTabState()
   const numUnreadNotifications = useUnreadNotifications()
   const numUnreadMessages = useUnreadMessageCount()
   const footerMinimalShellTransform = useMinimalShellFooterTransform()
@@ -111,6 +122,10 @@ export function BottomBar({navigation}: BottomTabBarProps) {
   )
   const onPressNotifications = React.useCallback(
     () => onPressTab('Notifications'),
+    [onPressTab],
+  )
+  const onPressBookmarks = React.useCallback(
+    () => onPressTab('Bookmarks'),
     [onPressTab],
   )
   const onPressProfile = React.useCallback(() => {
@@ -234,6 +249,27 @@ export function BottomBar({navigation}: BottomTabBarProps) {
                   ? ''
                   : _(msg`${numUnreadNotifications} unread items`)
               }
+            />
+            <Btn
+              testID="bottomBarNotificationsBtn"
+              icon={
+                isAtBookmarks ? (
+                  <BookmarkFilled
+                    width={iconWidth}
+                    style={[styles.ctrlIcon, pal.text, styles.bellIcon]}
+                  />
+                ) : (
+                  <Bookmark
+                    width={iconWidth}
+                    style={[styles.ctrlIcon, pal.text, styles.bellIcon]}
+                  />
+                )
+              }
+              onPress={onPressBookmarks}
+              accessible={true}
+              accessibilityRole="tab"
+              accessibilityLabel={_(msg`Bookmarks`)}
+              accessibilityHint=""
             />
             <Btn
               testID="bottomBarProfileBtn"

--- a/src/view/shell/bottom-bar/BottomBar.tsx
+++ b/src/view/shell/bottom-bar/BottomBar.tsx
@@ -251,7 +251,7 @@ export function BottomBar({navigation}: BottomTabBarProps) {
               }
             />
             <Btn
-              testID="bottomBarNotificationsBtn"
+              testID="bottomBarBookmarksBtn"
               icon={
                 isAtBookmarks ? (
                   <BookmarkFilled

--- a/src/view/shell/bottom-bar/BottomBarWeb.tsx
+++ b/src/view/shell/bottom-bar/BottomBarWeb.tsx
@@ -27,6 +27,10 @@ import {
   Bell_Stroke2_Corner0_Rounded as Bell,
 } from '#/components/icons/Bell'
 import {
+  Bookmark_Filled_Corner0_Rounded as BookmarkFilled,
+  Bookmark_Stroke2_Corner0_Rounded as Bookmark,
+} from '#/components/icons/Bookmark'
+import {
   HomeOpen_Filled_Corner0_Rounded as HomeFilled,
   HomeOpen_Stoke2_Corner0_Rounded as Home,
 } from '#/components/icons/HomeOpen'
@@ -138,6 +142,18 @@ export function BottomBarWeb() {
                 notificationCount={notificationCountStr}>
                 {({isActive}) => {
                   const Icon = isActive ? BellFilled : Bell
+                  return (
+                    <Icon
+                      aria-hidden={true}
+                      width={iconWidth}
+                      style={[styles.ctrlIcon, t.atoms.text, styles.bellIcon]}
+                    />
+                  )
+                }}
+              </NavItem>
+              <NavItem routeName="Bookmarks" href="/bookmarks">
+                {({isActive}) => {
+                  const Icon = isActive ? BookmarkFilled : Bookmark
                   return (
                     <Icon
                       aria-hidden={true}

--- a/src/view/shell/desktop/LeftNav.tsx
+++ b/src/view/shell/desktop/LeftNav.tsx
@@ -36,6 +36,10 @@ import {
   Bell_Stroke2_Corner0_Rounded as Bell,
 } from '#/components/icons/Bell'
 import {
+  Bookmark_Filled_Corner0_Rounded as BookmarkFilled,
+  Bookmark_Stroke2_Corner0_Rounded as Bookmark,
+} from '#/components/icons/Bookmark'
+import {
   BulletList_Filled_Corner0_Rounded as ListFilled,
   BulletList_Stroke2_Corner0_Rounded as List,
 } from '#/components/icons/BulletList'
@@ -424,6 +428,24 @@ export function DesktopLeftNav() {
               />
             }
             label={_(msg`Notifications`)}
+          />
+          <NavItem
+            href="/bookmarks"
+            icon={
+              <Bookmark
+                aria-hidden={true}
+                width={NAV_ICON_WIDTH}
+                style={pal.text}
+              />
+            }
+            iconFilled={
+              <BookmarkFilled
+                aria-hidden={true}
+                width={NAV_ICON_WIDTH}
+                style={pal.text}
+              />
+            }
+            label={_(msg`Bookmarks`)}
           />
           <ChatNavItem />
           <NavItem

--- a/yarn.lock
+++ b/yarn.lock
@@ -4892,6 +4892,13 @@
   resolved "https://registry.yarnpkg.com/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz#b2ac626d6cb9c8718ab459166d4bb405b8ffa78b"
   integrity sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==
 
+"@lexicon-community/types@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@lexicon-community/types/-/types-1.0.0.tgz#e86f37b58c08ac5def1fd34845ab9c12be41f88e"
+  integrity sha512-y7zNrgjzgeKfhoG9K5DfN+mFG7G/vBUHus1OKe4pj4rc/XKO/15cI+slfzzNRYEZ3b9+9BE1Jl6/HVH/odARsg==
+  dependencies:
+    "@atproto/xrpc" "^0.6.5"
+
 "@lingui/babel-plugin-extract-messages@4.14.1":
   version "4.14.1"
   resolved "https://registry.yarnpkg.com/@lingui/babel-plugin-extract-messages/-/babel-plugin-extract-messages-4.14.1.tgz#12f5a83bad1f9fef65fc22b8136ebd1052a31add"


### PR DESCRIPTION
This PR adds native bookmarking to Bluesky. I understand it is likely this PR will implement Bluesky's bookmarking feature, so here are the:
## Goals
### Groundwork for eventual bsky-team supported bookmarks implementation
- Get community feedback on initial bookmarking design
- Write code that can be used as a starting point for feature development
### Personal interest
- Introduce a [3rd party lexicon](https://github.com/lexicon-community/lexicon/blob/main/community/lexicon/bookmarks/bookmark.json) inside of Bluesky
- Bring a long-awaited feature to Bluesky that I’m also excited about

## Non-UI design choices
### Using community.lexicon.bookmarks
> **Note:** There is an [active discussion thread in the atproto repo](https://github.com/bluesky-social/atproto/discussions/3338#discussioncomment-11789889) on using 3rd party lexicons in Bluesky

Implementation was done using `community.lexicon.bookmarks` for the following reasons:
1. Flexibility: Bluesky `at://` URIs are a subset of the `uri` type, meaning developers can more easily integrate bookmarks from Bluesky into other apps
2. Avoid duplication: Simply put, a bookmarking lexicon [already exists](https://github.com/lexicon-community/lexicon/pull/12) along with a [types package](https://www.npmjs.com/package/@lexicon-community/types), both of which have gone through a community design review. That lexicon will also be integrated into more 3rd party clients to come, so it makes sense to reuse it or extend it rather than make a new bookmarks schema
3. Open source collaboration: Adopting a third-party lexicon in Bluesky aligns with its goals of true decentralization and interoperability within the larger Atmosphere

### Public bookmarking
There is currently no way of making a private lexicon on `atproto`. This is generally a limitation within the protocol and I don't believe it should block development of bookmarks. There are workarounds for privacy, such as creating an anonymous account and bookmarking to that account, as well as extensions and labelers. 

## UI design choices
### Putting bookmarks in the side bar
INSERT PICTURE HERE
I put bookmarks in the side bar for easier access. Another placement option is inside of the user profile, next to `your likes`.

## Potential problems
### Hydrating the equivalent of an `isBookmarked` on every post
Showing a user if they've already bookmarked a post through icon highlighting is important so they don't make duplicates. However, since bookmarks are not build in to the response of `getPost()`, a post has no notion of a bookmark. To compensate, I fetch **all bookmarks by the current user**, cache them in memory, and then do a `bookmarks.contains(post.uri)` for each post rendered to the page. When a bookmark is removed/added, the cache is updated.
I can see this becoming a problem if a user has thousands of bookmarks, and am curious about other designs, tradeoffs, or approaches here. Some possibilities I can think of are
1. Building bookmarks into `PostView` at the protocol level, simiar to likes
2. Only caching bookmarks that have been created recently, which could fail when a user pulls up a post they've bookmarked from a while ago
3. Not highlighting bookmarks on posts in the feed view, and allowing duplicates

### Pagination of bookmarks
On the "my bookmarks" page, rather than fetching the entire list of user bookmarks, they should be paginated and shown on scroll. However, I was not able to figure out pagination, since the `getActorBookmarks` method does not exist on the Bluesky PDS. For this feature to move forward, this is a blocker that I'd need some help on.
    
## Future work
### Filtering and searching bookmarks
The `community.lexicon.bookmarks.bookmark` allows for tagging bookmarks. This brings up more complicated UI designs that might not be worth fleshing out right now. However, in the future I can some popup when a bookmark is created for adding tags, and then searching/filtering on the "My Bookmarks" page.

## Screen shots and other links
Bookmarking on a feed:
![400950259-00625ecd-3a71-48da-bf05-65a2cdffeace](https://github.com/user-attachments/assets/f488c590-e100-4c85-8c86-26ce70e630a6)
Bookmarks page
![400950248-8d481435-25c0-461f-96fc-19de7c6ef68d](https://github.com/user-attachments/assets/cd3c4650-2dce-4eac-a7ed-19a8e5891b29)

[Discord thread with gif
](https://discord.com/channels/1097580399187738645/1326213989553803357)