### PR TITLE
Fix avatar shape in Account switch menu

### DIFF
--- a/src/components/AccountList.tsx
+++ b/src/components/AccountList.tsx
@@ -131,7 +131,11 @@ function AccountItem({
             (hovered || pressed || isPendingAccount) && t.atoms.bg_contrast_25,
           ]}>
           <View style={a.p_md}>
-            <UserAvatar avatar={profile?.avatar} size={24} />
+            <UserAvatar
+              avatar={profile?.avatar}
+              size={24}
+              type={profile?.associated?.labeler ? 'labeler' : 'user'}
+            />
           </View>
           <Text style={[a.align_baseline, a.flex_1, a.flex_row, a.py_sm]}>
             <Text emoji style={[a.font_bold]}>

--- a/src/components/AvatarStack.tsx
+++ b/src/components/AvatarStack.tsx
@@ -65,6 +65,7 @@ export function AvatarStack({
             <UserAvatar
               size={size - 2}
               avatar={item.profile.avatar}
+              type={item.profile.associated?.labeler ? 'labeler' : 'user'}
               moderation={item.moderation.ui('avatar')}
             />
           )}

--- a/src/components/KnownFollowers.tsx
+++ b/src/components/KnownFollowers.tsx
@@ -163,6 +163,7 @@ function KnownFollowersInner({
                   size={SIZE}
                   avatar={prof.avatar}
                   moderation={moderation.ui('avatar')}
+                  type={prof.associated?.labeler ? 'labeler' : 'user'}
                 />
               </View>
             ))}

--- a/src/components/Pills.tsx
+++ b/src/components/Pills.tsx
@@ -126,7 +126,7 @@ export function Label({
                 fill={t.atoms.text_contrast_medium.color}
               />
             ) : (
-              <UserAvatar avatar={desc.sourceAvi} size={avi} />
+              <UserAvatar avatar={desc.sourceAvi} type="user" size={avi} />
             )}
 
             <Text

--- a/src/screens/Settings/Settings.tsx
+++ b/src/screens/Settings/Settings.tsx
@@ -284,6 +284,7 @@ function ProfilePreview({
         size={80}
         avatar={shadow.avatar}
         moderation={moderation.ui('avatar')}
+        type={shadow.associated?.labeler ? 'labeler' : 'user'}
       />
       <ProfileHeaderDisplayName profile={shadow} moderation={moderation} />
       <ProfileHeaderHandle profile={shadow} />
@@ -414,6 +415,7 @@ function AccountRow({
             size={28}
             avatar={profile.avatar}
             moderation={moderateProfile(profile, moderationOpts).ui('avatar')}
+            type={profile.associated?.labeler ? 'labeler' : 'user'}
           />
         ) : (
           <View style={[{width: 28}]} />

--- a/src/view/com/post-thread/PostThreadLoadMore.tsx
+++ b/src/view/com/post-thread/PostThreadLoadMore.tsx
@@ -33,7 +33,11 @@ export function PostThreadLoadMore({post}: {post: AppBskyFeedDefs.PostView}) {
             backgroundColor: t.atoms.bg.backgroundColor,
             marginRight: -20,
           }}>
-          <UserAvatar avatar={post.author.avatar} size={30} />
+          <UserAvatar
+            avatar={post.author.avatar}
+            size={30}
+            type={post.author.associated?.labeler ? 'labeler' : 'user'}
+          />
         </View>
         <View
           style={{
@@ -44,7 +48,11 @@ export function PostThreadLoadMore({post}: {post: AppBskyFeedDefs.PostView}) {
             borderRadius: 18,
             backgroundColor: t.atoms.bg.backgroundColor,
           }}>
-          <UserAvatar avatar={post.author.avatar} size={30} />
+          <UserAvatar
+            avatar={post.author.avatar}
+            size={30}
+            type={post.author.associated?.labeler ? 'labeler' : 'user'}
+          />
         </View>
       </View>
       <View style={[a.px_sm]}>

--- a/src/view/com/util/UserAvatar.tsx
+++ b/src/view/com/util/UserAvatar.tsx
@@ -43,6 +43,7 @@ interface BaseUserAvatarProps {
 }
 
 interface UserAvatarProps extends BaseUserAvatarProps {
+  type: UserAvatarType
   moderation?: ModerationUI
   usePlainRNImage?: boolean
   onLoad?: () => void
@@ -439,7 +440,12 @@ let PreviewableUserAvatar = ({
           handle: profile.handle,
         })}
         onPress={onPress}>
-        <UserAvatar avatar={profile.avatar} moderation={moderation} {...rest} />
+        <UserAvatar
+          avatar={profile.avatar}
+          moderation={moderation}
+          type={profile.associated?.labeler ? 'labeler' : 'user'}
+          {...rest}
+        />
       </Link>
     </ProfileHoverCard>
   )

--- a/src/view/screens/Search/Explore.tsx
+++ b/src/view/screens/Search/Explore.tsx
@@ -194,6 +194,7 @@ function LoadMore({
                             size={28}
                             avatar={_item.avatar}
                             moderation={_item.moderation.ui('avatar')}
+                            type="user"
                           />
                         ) : _item.type === 'feed' ? (
                           <UserAvatar


### PR DESCRIPTION
Prop was missing in a couple of places, so labellers were showing up as circles

<img width="318" alt="Screenshot 2025-01-07 at 22 12 31" src="https://github.com/user-attachments/assets/99876ce8-aa99-4949-b16b-f41fab41a5b8" />
