### PR TITLE
add correct error reporting for blank password

### DIFF
--- a/src/screens/Login/SetNewPasswordForm.tsx
+++ b/src/screens/Login/SetNewPasswordForm.tsx
@@ -41,11 +41,21 @@ export const SetNewPasswordForm = ({
     // Check that the code is correct. We do this again just incase the user enters the code after their pw and we
     // don't get to call onBlur first
     const formattedCode = checkAndFormatResetCode(resetCode)
-    // TODO Better password strength check
-    if (!formattedCode || !password) {
+    
+    if (!formattedCode) {
       setError(
         _(
           msg`You have entered an invalid code. It should look like XXXXX-XXXXX.`,
+        ),
+      )
+      return
+    }
+    
+    // TODO Better password strength check
+    if (!password) {
+      setError(
+        _(
+          msg`Please enter a password.`,
         ),
       )
       return

--- a/src/screens/Login/SetNewPasswordForm.tsx
+++ b/src/screens/Login/SetNewPasswordForm.tsx
@@ -41,7 +41,7 @@ export const SetNewPasswordForm = ({
     // Check that the code is correct. We do this again just incase the user enters the code after their pw and we
     // don't get to call onBlur first
     const formattedCode = checkAndFormatResetCode(resetCode)
-    
+
     if (!formattedCode) {
       setError(
         _(
@@ -50,14 +50,10 @@ export const SetNewPasswordForm = ({
       )
       return
     }
-    
+
     // TODO Better password strength check
     if (!password) {
-      setError(
-        _(
-          msg`Please enter a password.`,
-        ),
-      )
+      setError(_(msg`Please enter a password.`))
       return
     }
 


### PR DESCRIPTION
Supercedes https://github.com/bluesky-social/social-app/pull/6447 - CI didn't run

the error reporting currently shows `You have entered an invalid code. It should look like XXXXX-XXXXX.` even if you enter the right code but leave the password blank. 

<img width="412" alt="image" src="https://github.com/user-attachments/assets/c19a9094-0654-4ded-becd-141d50a6c375">
