### PR TITLE
Call setAppBadge when new notifications are received via broadcast

### DIFF
--- a/src/state/queries/notifications/unread.tsx
+++ b/src/state/queries/notifications/unread.tsx
@@ -86,16 +86,19 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
   // listen for broadcasts
   React.useEffect(() => {
     const listener = ({data}: MessageEvent) => {
+      const unreadCount = data.event === '30+'
+            ? 30
+            : data.event === ''
+            ? 0
+            : parseInt(data.event, 10) || 1;
       cacheRef.current = {
         usableInFeed: false,
         syncedAt: new Date(),
         data: undefined,
-        unreadCount:
-          data.event === '30+'
-            ? 30
-            : data.event === ''
-            ? 0
-            : parseInt(data.event, 10) || 1,
+        unreadCount,
+      }
+      if ('setAppBadge' in navigator) {
+        navigator.setAppBadge(unreadCount)
       }
       setNumUnread(data.event)
     }

--- a/src/state/queries/notifications/unread.tsx
+++ b/src/state/queries/notifications/unread.tsx
@@ -120,6 +120,9 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
         )
 
         // update & broadcast
+        if ('setAppBadge' in navigator) {
+          navigator.setAppBadge(0)
+        }
         setNumUnread('')
         broadcast.postMessage({event: ''})
         resetBadgeCount()
@@ -184,6 +187,9 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
           }
 
           // update & broadcast
+          if ('setAppBadge' in navigator) {
+            navigator.setAppBadge(unreadCount)
+          }
           setNumUnread(unreadCountStr)
           if (invalidate) {
             truncateAndInvalidate(queryClient, RQKEY_NOTIFS('all'))


### PR DESCRIPTION
If bsky.app is installed as an app in e.g. Google Chrome, this will now display the unread notification count as a badge on the dock icon.