### PR TITLE
Downgrade paste input dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@haileyok/bluesky-video": "0.2.6",
     "@ipld/dag-cbor": "^9.2.0",
     "@lingui/react": "^4.14.1",
-    "@mattermost/react-native-paste-input": "^0.8.1",
+    "@mattermost/react-native-paste-input": "^0.7.1",
     "@miblanchard/react-native-slider": "^2.3.1",
     "@mozzius/expo-dynamic-app-icon": "^1.5.0",
     "@radix-ui/react-dismissable-layer": "^1.1.1",

--- a/patches/@mattermost+react-native-paste-input+0.7.1.patch
+++ b/patches/@mattermost+react-native-paste-input+0.7.1.patch
@@ -1,19 +1,17 @@
+
 diff --git a/node_modules/@mattermost/react-native-paste-input/ios/PasteInputView.m b/node_modules/@mattermost/react-native-paste-input/ios/PasteInputView.m
-index e916023..9968f3c 100644
+index e916023..5049c33 100644
 --- a/node_modules/@mattermost/react-native-paste-input/ios/PasteInputView.m
 +++ b/node_modules/@mattermost/react-native-paste-input/ios/PasteInputView.m
-@@ -3,58 +3,87 @@
- //  PasteInput
+@@ -4,6 +4,7 @@
  //
  //  Created by Elias Nahum on 04-11-20.
--//  Copyright © 2020 Facebook. All rights reserved.
+ //  Copyright © 2020 Facebook. All rights reserved.
 +//  Updated to remove parent’s default text view
  //
  
  #import "PasteInputView.h"
- #import "PasteInputTextView.h"
--#import <React/RCTUtils.h>
-+#import <React/RCTUtils.h> // for RCTDirectEventBlock, etc.
+@@ -12,49 +13,78 @@
  
  @implementation PasteInputView
  {
@@ -117,7 +115,7 @@ index e916023..9968f3c 100644
  }
  
  #pragma mark - UIScrollViewDelegate
-@@ -62,7 +91,6 @@
+@@ -62,7 +92,6 @@
  - (void)scrollViewDidScroll:(UIScrollView *)scrollView
  {
    RCTDirectEventBlock onScroll = self.onScroll;
@@ -125,7 +123,7 @@ index e916023..9968f3c 100644
    if (onScroll) {
      CGPoint contentOffset = scrollView.contentOffset;
      CGSize contentSize = scrollView.contentSize;
-@@ -71,22 +99,22 @@
+@@ -71,22 +100,22 @@
  
      onScroll(@{
        @"contentOffset": @{

--- a/patches/@mattermost+react-native-paste-input+0.7.1.patch
+++ b/patches/@mattermost+react-native-paste-input+0.7.1.patch
@@ -1,4 +1,3 @@
-
 diff --git a/node_modules/@mattermost/react-native-paste-input/ios/PasteInputView.m b/node_modules/@mattermost/react-native-paste-input/ios/PasteInputView.m
 index e916023..5049c33 100644
 --- a/node_modules/@mattermost/react-native-paste-input/ios/PasteInputView.m

--- a/yarn.lock
+++ b/yarn.lock
@@ -4990,12 +4990,12 @@
     "@babel/runtime" "^7.20.13"
     "@lingui/core" "4.14.1"
 
-"@mattermost/react-native-paste-input@^0.8.1":
-  version "0.8.1"
-  resolved "https://registry.yarnpkg.com/@mattermost/react-native-paste-input/-/react-native-paste-input-0.8.1.tgz#944ec69d0c49c3607265a02ad04103cc5b556caf"
-  integrity sha512-QHpwWORPALmX5FczCewRlJkVqtltD84mlpMpto5IGLKdHMAoHeXMiG4VJVh2XkRQvTyUhYegtrUrJzf8dkJokA==
+"@mattermost/react-native-paste-input@^0.7.1":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/@mattermost/react-native-paste-input/-/react-native-paste-input-0.7.1.tgz#f14585030b992cf7c9bbd0921225eefa501756ba"
+  integrity sha512-kY8LKtqRX2T/rtn/HNrzTitijuATvyzd6yl5WNWOsszmyzNcssKStjjCTBup04CyMxfwutUU1CWrYUb3hQO7oA==
   dependencies:
-    semver "7.6.3"
+    semver "7.6.0"
 
 "@messageformat/parser@^5.0.0":
   version "5.1.0"
@@ -16903,10 +16903,12 @@ semver-compare@^1.0.0:
   resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
   integrity sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==
 
-semver@7.6.3, semver@^7.1.3, semver@^7.6.3:
-  version "7.6.3"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.3.tgz#980f7b5550bc175fb4dc09403085627f9eb33143"
-  integrity sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==
+semver@7.6.0:
+  version "7.6.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.0.tgz#1a46a4db4bffcccd97b743b5005c8325f23d4e2d"
+  integrity sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==
+  dependencies:
+    lru-cache "^6.0.0"
 
 semver@^5.5.0, semver@^5.6.0:
   version "5.7.2"
@@ -16917,6 +16919,11 @@ semver@^6.0.0, semver@^6.3.0, semver@^6.3.1:
   version "6.3.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
+
+semver@^7.1.3, semver@^7.6.3:
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.6.3.tgz#980f7b5550bc175fb4dc09403085627f9eb33143"
+  integrity sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==
 
 semver@^7.3.5, semver@^7.3.7, semver@^7.3.8, semver@^7.5.3, semver@^7.5.4:
   version "7.5.4"


### PR DESCRIPTION
v0.8.1 causes crashes on Android. To be figured out in future.