### PR TITLE
Fix Android composer padding: Director's Cut

### DIFF
--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -264,7 +264,12 @@ export const ComposePost = ({
     () => ({
       paddingTop: isAndroid ? insets.top : 0,
       paddingBottom:
-        (isIOS && !isKeyboardVisible) || (isAndroid && isKeyboardVisible)
+        // iOS - when keyboard is closed, keep the bottom bar in the safe area
+        (isIOS && !isKeyboardVisible) ||
+        // Android - Android >=35 KeyboardAvoidingView adds double padding when
+        // keyboard is closed, so we subtract that in the offset and add it back
+        // here when the keyboard is open
+        (isAndroid && isKeyboardVisible)
           ? insets.bottom
           : 0,
     }),

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -264,7 +264,9 @@ export const ComposePost = ({
     () => ({
       paddingTop: isAndroid ? insets.top : 0,
       paddingBottom:
-        isAndroid || (isIOS && !isKeyboardVisible) ? insets.bottom : 0,
+        (isIOS && !isKeyboardVisible) || (isAndroid && isKeyboardVisible)
+          ? insets.bottom
+          : 0,
     }),
     [insets, isKeyboardVisible],
   )
@@ -642,7 +644,7 @@ export const ComposePost = ({
             ref={scrollViewRef}
             layout={native(LinearTransition)}
             onScroll={scrollHandler}
-            style={styles.scrollView}
+            style={a.flex_1}
             keyboardShouldPersistTaps="always"
             onContentSizeChange={onScrollViewContentSizeChange}
             onLayout={onScrollViewLayout}>
@@ -1396,10 +1398,14 @@ function useScrollTracker({
 }
 
 function useKeyboardVerticalOffset() {
-  const {top} = useSafeAreaInsets()
+  const {top, bottom} = useSafeAreaInsets()
 
   // Android etc
-  if (!isIOS) return 0
+  if (!isIOS) {
+    // if Android <35 or web, bottom is 0 anyway. if >=35, this is needed to account
+    // for the edge-to-edge nav bar
+    return bottom * -1
+  }
 
   // iPhone SE
   if (top === 20) return 40
@@ -1488,9 +1494,6 @@ const styles = StyleSheet.create({
   },
   inactivePost: {
     opacity: 0.5,
-  },
-  scrollView: {
-    flex: 1,
   },
   textInputLayout: {
     flexDirection: 'row',

--- a/src/view/shell/Composer.tsx
+++ b/src/view/shell/Composer.tsx
@@ -1,14 +1,14 @@
 import {useEffect} from 'react'
-import {Animated, Easing, StyleSheet, View} from 'react-native'
+import {Animated, Easing} from 'react-native'
 
 import {useAnimatedValue} from '#/lib/hooks/useAnimatedValue'
-import {usePalette} from '#/lib/hooks/usePalette'
 import {useComposerState} from '#/state/shell/composer'
+import {atoms as a, useTheme} from '#/alf'
 import {ComposePost} from '../com/composer/Composer'
 
 export function Composer({winHeight}: {winHeight: number}) {
   const state = useComposerState()
-  const pal = usePalette('default')
+  const t = useTheme()
   const initInterp = useAnimatedValue(0)
 
   useEffect(() => {
@@ -38,12 +38,12 @@ export function Composer({winHeight}: {winHeight: number}) {
   // =
 
   if (!state) {
-    return <View />
+    return null
   }
 
   return (
     <Animated.View
-      style={[styles.wrapper, pal.view, wrapperAnimStyle]}
+      style={[a.absolute, a.inset_0, t.atoms.bg, wrapperAnimStyle]}
       aria-modal
       accessibilityViewIsModal>
       <ComposePost
@@ -58,12 +58,3 @@ export function Composer({winHeight}: {winHeight: number}) {
     </Animated.View>
   )
 }
-
-const styles = StyleSheet.create({
-  wrapper: {
-    position: 'absolute',
-    top: 0,
-    bottom: 0,
-    width: '100%',
-  },
-})

--- a/src/view/shell/Composer.web.tsx
+++ b/src/view/shell/Composer.web.tsx
@@ -25,7 +25,7 @@ export function Composer({}: {winHeight: number}) {
   // =
 
   if (!isActive) {
-    return <View />
+    return null
   }
 
   return (


### PR DESCRIPTION
Supercedes https://github.com/bluesky-social/social-app/pull/7228

As far as I can tell, `KeyboardAvoidingView` is adding too much padding when the keyboard is closed on Android 15. We add a negative offset to the `KeyboardAvoidingView`, then remove the containing padding when the keyboard is open - seems to do the trick. We already do something similar for iOS.

# Button nav

<table>
  <thead>
    <tr>
      <th>Before</th>
      <th>Before</th>
      <th>After</th>
      <th>After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><img width="200" alt="Before" src="https://github.com/user-attachments/assets/0c330ac0-de42-427e-b857-a246b4913e4c" /></td>
      <td><img width="200" alt="Before" src="https://github.com/user-attachments/assets/72f8cdac-a845-45b7-91b0-d23dae7e5d94" /></td>
      <td><img width="200" alt="After" src="https://github.com/user-attachments/assets/e43f5cb9-844a-4b7d-855c-72816abc4ee2" /></td>
      <td><img width="200" alt="After" src="https://github.com/user-attachments/assets/a43fab1d-0f2f-408e-b0e7-1c645084aeb7" /></td>
    </tr>
  </tbody>
</table>

# Gesture nav

<table>  <thead>
    <tr>
      <th>Before</th>
      <th>Before</th>
      <th>After</th>
      <th>After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><img width="200" alt="Before" src="https://github.com/user-attachments/assets/60bc82b6-6302-4762-adb9-6b0482f7cfb3" /></td>
      <td><img width="200" alt="Before" src="https://github.com/user-attachments/assets/c52d200d-171f-4a1c-a8eb-cc7142aa01c9" /></td>
      <td><img width="200" alt="After" src="https://github.com/user-attachments/assets/56bd7852-5998-4202-92d9-d6d4da27459c" /></td>
      <td><img width="200" alt="After" src="https://github.com/user-attachments/assets/7927500a-b43a-4b88-b47c-8b8929af8bee" /></td>
    </tr>
  </tbody>
</table>

# Android 11 (unchanged)

<table>
  <thead>
    <tr>
      <th>Before</th>
      <th>Before</th>
      <th>After</th>
      <th>After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><img width="200" src="https://github.com/user-attachments/assets/18be764c-b546-495d-afb4-b85b19bcff3e" /></td>
      <td><img width="200" src="https://github.com/user-attachments/assets/afccba42-6c16-41b2-9481-39b1fe4732b5" /><td><img width="200" src="https://github.com/user-attachments/assets/18be764c-b546-495d-afb4-b85b19bcff3e" /></td>
      <td><img width="200" src="https://github.com/user-attachments/assets/afccba42-6c16-41b2-9481-39b1fe4732b5" /></td>
    </tr>
  </tbody>
</table>

Web is unchanged, since this all hinges on safe area insets which don't exist on web

# Test plan

Test the various combinations of Android version and Navigation mode, with keyboard open and closed