### PR TITLE
Fix dialogs not responding to changes in content height 

### DIFF
--- a/modules/bottom-sheet/src/BottomSheetNativeComponent.tsx
+++ b/modules/bottom-sheet/src/BottomSheetNativeComponent.tsx
@@ -125,7 +125,7 @@ export class BottomSheetNativeComponent extends React.Component<
               onLayout={e => {
                 const {height} = e.nativeEvent.layout
                 this.setState({viewHeight: height})
-                this.updateLayout()
+                setTimeout(() => this.updateLayout())
               }}>
               <BottomSheetPortalProvider>{children}</BottomSheetPortalProvider>
             </View>


### PR DESCRIPTION
~~The dialogs were updating state that changed the native module's props, then immediately triggering an imperative function. I believe this was causing race conditions, with the update function being called before the new state had the chance to render. We simply add a timeout to delay the function call until after the component renders~~

This does improve it, but not for the reason I thought. More research required. There is some sort of race condition going on, but it's not React state update related, since the height measurement is done on the native side.

This improves iOS, but doesn't seem to have helped much with Android - that just seems equally janky as before. Longer timeouts don't work either, so I'm thinking there's some deeper problem at play

# Before

https://github.com/user-attachments/assets/093f7cc8-a2ec-440e-beda-5956869d44cb

# After

https://github.com/user-attachments/assets/4f9a4f55-2bc1-41e4-beca-df816e09d8ea

