### PR TITLE
Fix intent dialogs theming

### DIFF
--- a/src/App.native.tsx
+++ b/src/App.native.tsx
@@ -151,9 +151,11 @@ function InnerApp() {
                                             <TrendingConfigProvider>
                                               <GestureHandlerRootView
                                                 style={s.h100pct}>
-                                                <TestCtrls />
-                                                <Shell />
-                                                <NuxDialogs />
+                                                <IntentDialogProvider>
+                                                  <TestCtrls />
+                                                  <Shell />
+                                                  <NuxDialogs />
+                                                </IntentDialogProvider>
                                               </GestureHandlerRootView>
                                             </TrendingConfigProvider>
                                           </ProgressGuideProvider>
@@ -213,11 +215,9 @@ function App() {
                               <StarterPackProvider>
                                 <SafeAreaProvider
                                   initialMetrics={initialWindowMetrics}>
-                                  <IntentDialogProvider>
-                                    <LightStatusBarProvider>
-                                      <InnerApp />
-                                    </LightStatusBarProvider>
-                                  </IntentDialogProvider>
+                                  <LightStatusBarProvider>
+                                    <InnerApp />
+                                  </LightStatusBarProvider>
                                 </SafeAreaProvider>
                               </StarterPackProvider>
                             </BottomSheetProvider>

--- a/src/App.web.tsx
+++ b/src/App.web.tsx
@@ -129,8 +129,10 @@ function InnerApp() {
                                           <SafeAreaProvider>
                                             <ProgressGuideProvider>
                                               <TrendingConfigProvider>
-                                                <Shell />
-                                                <NuxDialogs />
+                                                <IntentDialogProvider>
+                                                  <Shell />
+                                                  <NuxDialogs />
+                                                </IntentDialogProvider>
                                               </TrendingConfigProvider>
                                             </ProgressGuideProvider>
                                           </SafeAreaProvider>
@@ -187,11 +189,9 @@ function App() {
                       <LightboxStateProvider>
                         <PortalProvider>
                           <StarterPackProvider>
-                            <IntentDialogProvider>
-                              <LightStatusBarProvider>
-                                <InnerApp />
-                              </LightStatusBarProvider>
-                            </IntentDialogProvider>
+                            <LightStatusBarProvider>
+                              <InnerApp />
+                            </LightStatusBarProvider>
                           </StarterPackProvider>
                         </PortalProvider>
                       </LightboxStateProvider>


### PR DESCRIPTION
Noticed that the verify email intent dialog was not themed correctly and was defaulting to the default light theme. This was because the dialogs were not nested within the `Alf` provider.

These providers can safely be nested much further down. They just need to wrap the `Shell`, which is where intent handling actually takes place.