### PR TITLE
Partially fix trending/drawer gesture conflict

### DIFF
--- a/src/components/interstitials/Trending.tsx
+++ b/src/components/interstitials/Trending.tsx
@@ -1,6 +1,6 @@
-import React from 'react'
-import {View} from 'react-native'
-import {ScrollView} from 'react-native-gesture-handler'
+import React, {useContext} from 'react'
+import {ScrollView, View} from 'react-native'
+import {GestureDetector} from 'react-native-gesture-handler'
 import {msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
@@ -12,6 +12,7 @@ import {
 import {useTrendingTopics} from '#/state/queries/trending/useTrendingTopics'
 import {useTrendingConfig} from '#/state/trending-config'
 import {LoadingPlaceholder} from '#/view/com/util/LoadingPlaceholder'
+import {TrendingGestureContext} from '#/view/shell/TrendingGestureContext'
 import {atoms as a, useGutters, useTheme} from '#/alf'
 import {Button, ButtonIcon} from '#/components/Button'
 import {TimesLarge_Stroke2_Corner0_Rounded as X} from '#/components/icons/Times'
@@ -40,83 +41,92 @@ export function Inner() {
     setTrendingDisabled(true)
   }, [setTrendingDisabled])
 
+  // This is coordinated to take precedence over the drawer pan gesture.
+  const trendingScrollGesture = useContext(TrendingGestureContext)
+
   return error || noTopics ? null : (
     <View style={[t.atoms.border_contrast_low, a.border_t]}>
-      <ScrollView
-        horizontal
-        showsHorizontalScrollIndicator={false}
-        decelerationRate="fast">
-        <View style={[gutters, a.flex_row, a.align_center, a.gap_lg]}>
-          <View style={{paddingLeft: 4, paddingRight: 2}}>
-            <Graph size="sm" />
-          </View>
-          {isLoading ? (
-            <View style={[a.py_lg, a.flex_row, a.gap_lg, a.align_center]}>
-              <LoadingPlaceholder
-                width={80}
-                height={undefined}
-                style={{alignSelf: 'stretch'}}
-              />
-              <LoadingPlaceholder
-                width={50}
-                height={undefined}
-                style={{alignSelf: 'stretch'}}
-              />
-              <LoadingPlaceholder
-                width={120}
-                height={undefined}
-                style={{alignSelf: 'stretch'}}
-              />
-              <LoadingPlaceholder
-                width={30}
-                height={undefined}
-                style={{alignSelf: 'stretch'}}
-              />
-              <LoadingPlaceholder
-                width={180}
-                height={undefined}
-                style={{alignSelf: 'stretch'}}
-              />
-              <Text
-                style={[t.atoms.text_contrast_medium, a.text_sm, a.font_bold]}>
-                {' '}
-              </Text>
+      <GestureDetector gesture={trendingScrollGesture}>
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          decelerationRate="fast">
+          <View style={[gutters, a.flex_row, a.align_center, a.gap_lg]}>
+            <View style={{paddingLeft: 4, paddingRight: 2}}>
+              <Graph size="sm" />
             </View>
-          ) : !trending?.topics ? null : (
-            <>
-              {trending.topics.map(topic => (
-                <TrendingTopicLink
-                  key={topic.link}
-                  topic={topic}
-                  onPress={() => {
-                    logEvent('trendingTopic:click', {context: 'interstitial'})
-                  }}>
-                  <View style={[a.py_lg]}>
-                    <Text
-                      style={[
-                        t.atoms.text,
-                        a.text_sm,
-                        a.font_bold,
-                        {opacity: 0.7}, // NOTE: we use opacity 0.7 instead of a color to match the color of the home pager tab bar
-                      ]}>
-                      {topic.topic}
-                    </Text>
-                  </View>
-                </TrendingTopicLink>
-              ))}
-              <Button
-                label={_(msg`Hide trending topics`)}
-                size="tiny"
-                variant="ghost"
-                color="secondary"
-                shape="round"
-                onPress={() => trendingPrompt.open()}>
-                <ButtonIcon icon={X} />
-              </Button>
-            </>
-          )}
-        </View>
-      </ScrollView>
+            {isLoading ? (
+              <View style={[a.py_lg, a.flex_row, a.gap_lg, a.align_center]}>
+                <LoadingPlaceholder
+                  width={80}
+                  height={undefined}
+                  style={{alignSelf: 'stretch'}}
+                />
+                <LoadingPlaceholder
+                  width={50}
+                  height={undefined}
+                  style={{alignSelf: 'stretch'}}
+                />
+                <LoadingPlaceholder
+                  width={120}
+                  height={undefined}
+                  style={{alignSelf: 'stretch'}}
+                />
+                <LoadingPlaceholder
+                  width={30}
+                  height={undefined}
+                  style={{alignSelf: 'stretch'}}
+                />
+                <LoadingPlaceholder
+                  width={180}
+                  height={undefined}
+                  style={{alignSelf: 'stretch'}}
+                />
+                <Text
+                  style={[
+                    t.atoms.text_contrast_medium,
+                    a.text_sm,
+                    a.font_bold,
+                  ]}>
+                  {' '}
+                </Text>
+              </View>
+            ) : !trending?.topics ? null : (
+              <>
+                {trending.topics.map(topic => (
+                  <TrendingTopicLink
+                    key={topic.link}
+                    topic={topic}
+                    onPress={() => {
+                      logEvent('trendingTopic:click', {context: 'interstitial'})
+                    }}>
+                    <View style={[a.py_lg]}>
+                      <Text
+                        style={[
+                          t.atoms.text,
+                          a.text_sm,
+                          a.font_bold,
+                          {opacity: 0.7}, // NOTE: we use opacity 0.7 instead of a color to match the color of the home pager tab bar
+                        ]}>
+                        {topic.topic}
+                      </Text>
+                    </View>
+                  </TrendingTopicLink>
+                ))}
+                <Button
+                  label={_(msg`Hide trending topics`)}
+                  size="tiny"
+                  variant="ghost"
+                  color="secondary"
+                  shape="round"
+                  onPress={() => trendingPrompt.open()}>
+                  <ButtonIcon icon={X} />
+                </Button>
+              </>
+            )}
+          </View>
+        </ScrollView>
+      </GestureDetector>
 
       <Prompt.Basic
         control={trendingPrompt}

--- a/src/view/shell/TrendingGestureContext.tsx
+++ b/src/view/shell/TrendingGestureContext.tsx
@@ -1,0 +1,7 @@
+import {createContext} from 'react'
+import {Gesture} from 'react-native-gesture-handler'
+
+// Not really used but serves as a fallback for types.
+const noopGesture = Gesture.Native()
+
+export const TrendingGestureContext = createContext(noopGesture)

--- a/src/view/shell/index.tsx
+++ b/src/view/shell/index.tsx
@@ -1,6 +1,7 @@
-import {useCallback, useEffect} from 'react'
+import {useCallback, useEffect, useState} from 'react'
 import {BackHandler, useWindowDimensions, View} from 'react-native'
 import {Drawer} from 'react-native-drawer-layout'
+import {Gesture} from 'react-native-gesture-handler'
 import {useSafeAreaInsets} from 'react-native-safe-area-context'
 import {StatusBar} from 'expo-status-bar'
 import {useNavigation, useNavigationState} from '@react-navigation/native'
@@ -33,6 +34,7 @@ import {BottomSheetOutlet} from '../../../modules/bottom-sheet'
 import {updateActiveViewAsync} from '../../../modules/expo-bluesky-swiss-army/src/VisibilityView'
 import {Composer} from './Composer'
 import {DrawerContent} from './Drawer'
+import {TrendingGestureContext} from './TrendingGestureContext'
 
 function ShellInner() {
   const t = useTheme()
@@ -92,6 +94,7 @@ function ShellInner() {
   }, [dedupe, navigation])
 
   const swipeEnabled = !canGoBack && hasSession && !isDrawerSwipeDisabled
+  const [trendingScrollGesture] = useState(() => Gesture.Native())
   return (
     <>
       <View style={[a.h_full]}>
@@ -101,6 +104,10 @@ function ShellInner() {
             renderDrawerContent={renderDrawerContent}
             drawerStyle={{width: Math.min(400, winDim.width * 0.8)}}
             configureGestureHandler={handler => {
+              handler = handler.requireExternalGestureToFail(
+                trendingScrollGesture,
+              )
+
               if (swipeEnabled) {
                 if (isDrawerOpen) {
                   return handler.activeOffsetX([-1, 1])
@@ -138,7 +145,9 @@ function ShellInner() {
                 dim: 'rgba(10, 13, 16, 0.8)',
               }),
             }}>
-            <TabsNavigator />
+            <TrendingGestureContext.Provider value={trendingScrollGesture}>
+              <TabsNavigator />
+            </TrendingGestureContext.Provider>
           </Drawer>
         </ErrorBoundary>
       </View>


### PR DESCRIPTION
Not sure this is a full solution because it still triggers for me sometimes. But this seems to improve the situation on iOS. I'm not sure it has any effect on Android.

[Review without whitespace](https://github.com/bluesky-social/social-app/pull/7417/files?w=1)

## Before

https://github.com/user-attachments/assets/0ce1e75a-6c45-4022-926e-120f98b2c0e4

## After

https://github.com/user-attachments/assets/d6586ee7-fd0d-4f8e-b988-e342fead29f4

## Test Plan

See videos above. On Android this fix doesn't seem to make it better or worse but on iOS, anecdotally, it does seem to help quite a bit. At least on the simulator.

I've also prepared a minimal repro case:

```js
import {ScrollView, Text, View} from 'react-native'
import {
  Gesture,
  GestureDetector,
  GestureHandlerRootView,
} from 'react-native-gesture-handler'
import Animated, {
  useAnimatedStyle,
  useSharedValue,
} from 'react-native-reanimated'

export default function App() {
  const val = useSharedValue(0)

  const native = Gesture.Native()
  const pan = Gesture.Pan()
    .requireExternalGestureToFail(native)
    .onBegin(() => {
      'worklet'
      console.log('begin')
      val.set(0)
    })
    .onUpdate(e => {
      'worklet'
      console.log('update')
      val.set(e.translationX)
    })
    .onEnd(() => {
      'worklet'
      console.log('end')
      val.set(0)
    })
    .onFinalize(() => {
      'worklet'
      console.log('finalize')
      val.set(0)
    })
    .failOffsetX(-1)
    .activeOffsetX(5)

  const style = useAnimatedStyle(() => {
    return {
      transform: [
        {
          translateX: val.value,
        },
      ],
    }
  })
  return (
    <GestureHandlerRootView>
      <GestureDetector gesture={pan}>
        <View style={{flex: 1, backgroundColor: 'blue'}}>
          <Animated.View style={style}>
            <InnerScrollView native={native} />
          </Animated.View>
        </View>
      </GestureDetector>
    </GestureHandlerRootView>
  )
}

function InnerScrollView({native}) {
  return (
    <View
      style={{
        paddingTop: 200,
        alignItems: 'center',
      }}>
      <GestureDetector gesture={native}>
        <ScrollView
          horizontal
          pagingEnabled
          style={{
            width: 300,
            backgroundColor: 'yellow',
            height: 200,
          }}>
          <Text
            style={{
              width: 1000,
            }}>
            1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26
            27 28 29 30 31 32 33 34 35 36 37 38 39 40
          </Text>
        </ScrollView>
      </GestureDetector>
    </View>
  )
}
```

You can see that `requireExternalGestureToFail` really _does_ make a difference here (both on iOS and on Android):

https://github.com/user-attachments/assets/a38b015f-88de-4669-9bee-43e595b1fee2

This gives me confidence that even if this isn't the entire fix, it's at least a step in the right direction.

This should have no effect on web.