### PR TITLE
[ELI5] Validate too long handles in signup

### DIFF
--- a/src/lib/strings/handles.ts
+++ b/src/lib/strings/handles.ts
@@ -45,7 +45,7 @@ export interface IsValidHandle {
 export function validateHandle(
   str: string,
   userDomain: string,
-  serviceHandle?: boolean,
+  isServiceHandle?: boolean,
 ): IsValidHandle {
   const fullHandle = createFullHandle(str, userDomain)
 
@@ -54,7 +54,7 @@ export function validateHandle(
       !str || (VALIDATE_REGEX.test(fullHandle) && !str.includes('.')),
     hyphenStartOrEnd: !str.startsWith('-') && !str.endsWith('-'),
     frontLength: str.length >= 3,
-    totalLength: fullHandle.length <= (serviceHandle ? 30 : 253),
+    totalLength: fullHandle.length <= (isServiceHandle ? 30 : 253),
   }
 
   return {

--- a/src/lib/strings/handles.ts
+++ b/src/lib/strings/handles.ts
@@ -19,6 +19,10 @@ export function createFullHandle(name: string, domain: string): string {
   return `${name}.${domain}`
 }
 
+export function maxServiceHandleLength(domain: string): number {
+  return 30 - `.${(domain || '').replace(/^[.]+/, '')}`.length
+}
+
 export function isInvalidHandle(handle: string): boolean {
   return handle === 'handle.invalid'
 }
@@ -38,7 +42,11 @@ export interface IsValidHandle {
 }
 
 // More checks from https://github.com/bluesky-social/atproto/blob/main/packages/pds/src/handle/index.ts#L72
-export function validateHandle(str: string, userDomain: string): IsValidHandle {
+export function validateHandle(
+  str: string,
+  userDomain: string,
+  serviceHandle?: boolean,
+): IsValidHandle {
   const fullHandle = createFullHandle(str, userDomain)
 
   const results = {
@@ -46,7 +54,7 @@ export function validateHandle(str: string, userDomain: string): IsValidHandle {
       !str || (VALIDATE_REGEX.test(fullHandle) && !str.includes('.')),
     hyphenStartOrEnd: !str.startsWith('-') && !str.endsWith('-'),
     frontLength: str.length >= 3,
-    totalLength: fullHandle.length <= 253,
+    totalLength: fullHandle.length <= (serviceHandle ? 30 : 253),
   }
 
   return {

--- a/src/screens/Settings/components/ChangeHandleDialog.tsx
+++ b/src/screens/Settings/components/ChangeHandleDialog.tsx
@@ -172,13 +172,11 @@ function ProvidedHandlePage({
   const host = serviceInfo.availableUserDomains[0]
 
   const validation = useMemo(
-    () => validateHandle(subdomain, host),
+    () => validateHandle(subdomain, host, true),
     [subdomain, host],
   )
 
-  const isTooLong = subdomain.length > 18
   const isInvalid =
-    isTooLong ||
     !validation.handleChars ||
     !validation.hyphenStartOrEnd ||
     !validation.totalLength
@@ -231,10 +229,10 @@ function ProvidedHandlePage({
             label={_(msg`Save new handle`)}
             variant="solid"
             size="large"
-            color={validation.overall && !isTooLong ? 'primary' : 'secondary'}
-            disabled={!validation.overall && !isTooLong}
+            color={validation.overall ? 'primary' : 'secondary'}
+            disabled={!validation.overall}
             onPress={() => {
-              if (validation.overall && !isTooLong) {
+              if (validation.overall) {
                 changeHandle({handle: createFullHandle(subdomain, host)})
               }
             }}>

--- a/src/screens/Signup/StepHandle.tsx
+++ b/src/screens/Signup/StepHandle.tsx
@@ -4,7 +4,11 @@ import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
 import {logEvent} from '#/lib/statsig/statsig'
-import {createFullHandle, validateHandle} from '#/lib/strings/handles'
+import {
+  createFullHandle,
+  maxServiceHandleLength,
+  validateHandle,
+} from '#/lib/strings/handles'
 import {useAgent} from '#/state/session'
 import {ScreenTransition} from '#/screens/Login/ScreenTransition'
 import {useSignupContext} from '#/screens/Signup/state'
@@ -93,7 +97,7 @@ export function StepHandle() {
     })
   }, [dispatch, state.activeStep])
 
-  const validCheck = validateHandle(draftValue, state.userDomain)
+  const validCheck = validateHandle(draftValue, state.userDomain, true)
   return (
     <ScreenTransition>
       <View style={[a.gap_lg]}>
@@ -166,7 +170,10 @@ export function StepHandle() {
               />
               {!validCheck.totalLength ? (
                 <Text style={[a.text_md, a.flex_1]}>
-                  <Trans>No longer than 253 characters</Trans>
+                  <Trans>
+                    No longer than {maxServiceHandleLength(state.userDomain)}{' '}
+                    characters
+                  </Trans>
                 </Text>
               ) : (
                 <Text style={[a.text_md, a.flex_1]}>


### PR DESCRIPTION
Checks if a handle is too long in the signup flow. Handles can be up to 253 chars normally, but for PDS service handles the max is 30, including domain. I added an additional flag to the `validateHandle` function to lower the length check appropriately. I made it generic for other PDSes, rather than hard-coding 18 chars. I also corrected the logic in the change handle screen since that was hardcoded to 18.

<img width="663" alt="Screenshot 2025-01-10 at 13 49 13" src="https://github.com/user-attachments/assets/dabeedef-02f1-4123-93eb-868b2d0f7af5" />

# Test plan

1. Confirm that the limit really is 30 chars - go through the signup process on main with a 19 char username and confirm it fails
2. Check that the PR change catches it, and check that the error message is correct