### PR TITLE
Conversation-level reporting by reporting most recent message available

### DIFF
--- a/src/components/ReportDialog/SelectReportOptionView.tsx
+++ b/src/components/ReportDialog/SelectReportOptionView.tsx
@@ -23,15 +23,18 @@ import {
 } from '#/components/icons/Chevron'
 import {SquareArrowTopRight_Stroke2_Corner0_Rounded as SquareArrowTopRight} from '#/components/icons/SquareArrowTopRight'
 import {Text} from '#/components/Typography'
+import {Admonition} from '../Admonition'
 import {ReportDialogProps} from './types'
 
 export function SelectReportOptionView({
+  showConversationWarning,
   ...props
 }: {
   params: ReportDialogProps['params']
   labelers: AppBskyLabelerDefs.LabelerViewDetailed[]
   onSelectReportOption: (reportOption: ReportOption) => void
   goBack: () => void
+  showConversationWarning?: boolean
 }) {
   const t = useTheme()
   const {_} = useLingui()
@@ -88,6 +91,14 @@ export function SelectReportOptionView({
         <Text style={[a.text_md, t.atoms.text_contrast_medium]}>
           {i18n.description}
         </Text>
+        {showConversationWarning && (
+          <Admonition type="info" style={a.mt_xs}>
+            <Trans>
+              Note: Only the most recent messages in this conversation will be
+              reported.
+            </Trans>
+          </Admonition>
+        )}
       </View>
 
       <Divider />

--- a/src/components/ReportDialog/SelectReportOptionView.tsx
+++ b/src/components/ReportDialog/SelectReportOptionView.tsx
@@ -23,18 +23,13 @@ import {
 } from '#/components/icons/Chevron'
 import {SquareArrowTopRight_Stroke2_Corner0_Rounded as SquareArrowTopRight} from '#/components/icons/SquareArrowTopRight'
 import {Text} from '#/components/Typography'
-import {Admonition} from '../Admonition'
 import {ReportDialogProps} from './types'
 
-export function SelectReportOptionView({
-  showConversationWarning,
-  ...props
-}: {
+export function SelectReportOptionView(props: {
   params: ReportDialogProps['params']
   labelers: AppBskyLabelerDefs.LabelerViewDetailed[]
   onSelectReportOption: (reportOption: ReportOption) => void
   goBack: () => void
-  showConversationWarning?: boolean
 }) {
   const t = useTheme()
   const {_} = useLingui()
@@ -91,14 +86,6 @@ export function SelectReportOptionView({
         <Text style={[a.text_md, t.atoms.text_contrast_medium]}>
           {i18n.description}
         </Text>
-        {showConversationWarning && (
-          <Admonition type="info" style={a.mt_xs}>
-            <Trans>
-              Note: Only the most recent messages in this conversation will be
-              reported.
-            </Trans>
-          </Admonition>
-        )}
       </View>
 
       <Divider />

--- a/src/components/dms/ConvoMenu.tsx
+++ b/src/components/dms/ConvoMenu.tsx
@@ -232,7 +232,6 @@ let ConvoMenu = ({
             convoId: convo.id,
             message: latestReportableMessage,
           }}
-          showConversationWarning
           control={reportControl}
         />
       ) : (

--- a/src/components/dms/ConvoMenu.tsx
+++ b/src/components/dms/ConvoMenu.tsx
@@ -35,6 +35,7 @@ import {SpeakerVolumeFull_Stroke2_Corner0_Rounded as Unmute} from '#/components/
 import * as Menu from '#/components/Menu'
 import * as Prompt from '#/components/Prompt'
 import {Bubble_Stroke2_Corner2_Rounded as Bubble} from '../icons/Bubble'
+import {ReportDialog} from './ReportDialog'
 
 let ConvoMenu = ({
   convo: initialConvo,
@@ -44,6 +45,7 @@ let ConvoMenu = ({
   showMarkAsRead,
   hideTrigger,
   blockInfo,
+  latestReportableMessage,
   style,
 }: {
   convo: ChatBskyConvoDefs.ConvoView
@@ -56,6 +58,7 @@ let ConvoMenu = ({
     listBlocks: ModerationCause[]
     userBlock?: ModerationCause
   }
+  latestReportableMessage?: ChatBskyConvoDefs.MessageView
   style?: ViewStyleProp['style']
 }): React.ReactNode => {
   const navigation = useNavigation<NavigationProp>()
@@ -222,7 +225,20 @@ let ConvoMenu = ({
         convoId={convo.id}
         currentScreen={currentScreen}
       />
-      <ReportConversationPrompt control={reportControl} />
+      {latestReportableMessage ? (
+        <ReportDialog
+          params={{
+            type: 'convoMessage',
+            convoId: convo.id,
+            message: latestReportableMessage,
+          }}
+          showConversationWarning
+          control={reportControl}
+        />
+      ) : (
+        <ReportConversationPrompt control={reportControl} />
+      )}
+
       <BlockedByListDialog
         control={blockedByListControl}
         listBlocks={listBlocks}

--- a/src/components/dms/MessagesListHeader.tsx
+++ b/src/components/dms/MessagesListHeader.tsx
@@ -151,11 +151,13 @@ function HeaderReady({
         moderation.ui('displayName'),
       )
 
-  const latestMessage = convoState.items.at(-1)
+  const latestMessageFromOther = convoState.items.findLast(
+    item => item.type === 'message' && item.message.sender.did === profile.did,
+  )
+
   const latestReportableMessage =
-    latestMessage?.type === 'message' &&
-    latestMessage.message.sender?.did === profile.did
-      ? latestMessage.message
+    latestMessageFromOther?.type === 'message'
+      ? latestMessageFromOther.message
       : undefined
 
   return (

--- a/src/components/dms/MessagesListHeader.tsx
+++ b/src/components/dms/MessagesListHeader.tsx
@@ -151,6 +151,13 @@ function HeaderReady({
         moderation.ui('displayName'),
       )
 
+  const latestMessage = convoState.items.at(-1)
+  const latestReportableMessage =
+    latestMessage?.type === 'message' &&
+    latestMessage.message.sender?.did === profile.did
+      ? latestMessage.message
+      : undefined
+
   return (
     <View style={[a.flex_1]}>
       <View style={[a.w_full, a.flex_row, a.align_center, a.justify_between]}>
@@ -208,6 +215,7 @@ function HeaderReady({
             profile={profile}
             currentScreen="conversation"
             blockInfo={blockInfo}
+            latestReportableMessage={latestReportableMessage}
           />
         )}
       </View>

--- a/src/components/dms/ReportDialog.tsx
+++ b/src/components/dms/ReportDialog.tsx
@@ -33,16 +33,21 @@ type ReportDialogParams = {
 let ReportDialog = ({
   control,
   params,
+  showConversationWarning,
 }: {
   control: Dialog.DialogControlProps
   params: ReportDialogParams
+  showConversationWarning: boolean
 }): React.ReactNode => {
   const {_} = useLingui()
   return (
     <Dialog.Outer control={control}>
       <Dialog.Handle />
       <Dialog.ScrollableInner label={_(msg`Report this message`)}>
-        <DialogInner params={params} />
+        <DialogInner
+          params={params}
+          showConversationWarning={showConversationWarning}
+        />
         <Dialog.Close />
       </Dialog.ScrollableInner>
     </Dialog.Outer>
@@ -51,7 +56,13 @@ let ReportDialog = ({
 ReportDialog = memo(ReportDialog)
 export {ReportDialog}
 
-function DialogInner({params}: {params: ReportDialogParams}) {
+function DialogInner({
+  params,
+  showConversationWarning,
+}: {
+  params: ReportDialogParams
+  showConversationWarning: boolean
+}) {
   const [reportOption, setReportOption] = useState<ReportOption | null>(null)
 
   return reportOption ? (
@@ -61,15 +72,21 @@ function DialogInner({params}: {params: ReportDialogParams}) {
       goBack={() => setReportOption(null)}
     />
   ) : (
-    <ReasonStep params={params} setReportOption={setReportOption} />
+    <ReasonStep
+      params={params}
+      setReportOption={setReportOption}
+      showConversationWarning={showConversationWarning}
+    />
   )
 }
 
 function ReasonStep({
   setReportOption,
+  showConversationWarning,
 }: {
   setReportOption: (reportOption: ReportOption) => void
   params: ReportDialogParams
+  showConversationWarning?: boolean
 }) {
   const control = Dialog.useDialogContext()
 
@@ -81,6 +98,7 @@ function ReasonStep({
         type: 'convoMessage',
       }}
       onSelectReportOption={setReportOption}
+      showConversationWarning={showConversationWarning}
     />
   )
 }

--- a/src/components/dms/ReportDialog.tsx
+++ b/src/components/dms/ReportDialog.tsx
@@ -37,7 +37,7 @@ let ReportDialog = ({
 }: {
   control: Dialog.DialogControlProps
   params: ReportDialogParams
-  showConversationWarning: boolean
+  showConversationWarning?: boolean
 }): React.ReactNode => {
   const {_} = useLingui()
   return (
@@ -61,7 +61,7 @@ function DialogInner({
   showConversationWarning,
 }: {
   params: ReportDialogParams
-  showConversationWarning: boolean
+  showConversationWarning?: boolean
 }) {
   const [reportOption, setReportOption] = useState<ReportOption | null>(null)
 

--- a/src/components/dms/ReportDialog.tsx
+++ b/src/components/dms/ReportDialog.tsx
@@ -33,21 +33,16 @@ type ReportDialogParams = {
 let ReportDialog = ({
   control,
   params,
-  showConversationWarning,
 }: {
   control: Dialog.DialogControlProps
   params: ReportDialogParams
-  showConversationWarning?: boolean
 }): React.ReactNode => {
   const {_} = useLingui()
   return (
     <Dialog.Outer control={control}>
       <Dialog.Handle />
       <Dialog.ScrollableInner label={_(msg`Report this message`)}>
-        <DialogInner
-          params={params}
-          showConversationWarning={showConversationWarning}
-        />
+        <DialogInner params={params} />
         <Dialog.Close />
       </Dialog.ScrollableInner>
     </Dialog.Outer>
@@ -56,13 +51,7 @@ let ReportDialog = ({
 ReportDialog = memo(ReportDialog)
 export {ReportDialog}
 
-function DialogInner({
-  params,
-  showConversationWarning,
-}: {
-  params: ReportDialogParams
-  showConversationWarning?: boolean
-}) {
+function DialogInner({params}: {params: ReportDialogParams}) {
   const [reportOption, setReportOption] = useState<ReportOption | null>(null)
 
   return reportOption ? (
@@ -72,21 +61,15 @@ function DialogInner({
       goBack={() => setReportOption(null)}
     />
   ) : (
-    <ReasonStep
-      params={params}
-      setReportOption={setReportOption}
-      showConversationWarning={showConversationWarning}
-    />
+    <ReasonStep params={params} setReportOption={setReportOption} />
   )
 }
 
 function ReasonStep({
   setReportOption,
-  showConversationWarning,
 }: {
   setReportOption: (reportOption: ReportOption) => void
   params: ReportDialogParams
-  showConversationWarning?: boolean
 }) {
   const control = Dialog.useDialogContext()
 
@@ -98,7 +81,6 @@ function ReasonStep({
         type: 'convoMessage',
       }}
       onSelectReportOption={setReportOption}
-      showConversationWarning={showConversationWarning}
     />
   )
 }

--- a/src/screens/Messages/components/ChatListItem.tsx
+++ b/src/screens/Messages/components/ChatListItem.tsx
@@ -112,64 +112,74 @@ function ChatListItemReady({
 
   const isDimStyle = convo.muted || moderation.blocked || isDeletedAccount
 
-  const {lastMessage, lastMessageSentAt} = useMemo(() => {
-    let lastMessage = _(msg`No messages yet`)
-    let lastMessageSentAt: string | null = null
+  const {lastMessage, lastMessageSentAt, latestReportableMessage} =
+    useMemo(() => {
+      // eslint-disable-next-line @typescript-eslint/no-shadow
+      let lastMessage = _(msg`No messages yet`)
+      // eslint-disable-next-line @typescript-eslint/no-shadow
+      let lastMessageSentAt: string | null = null
+      // eslint-disable-next-line @typescript-eslint/no-shadow
+      let latestReportableMessage: ChatBskyConvoDefs.MessageView | undefined
 
-    if (ChatBskyConvoDefs.isMessageView(convo.lastMessage)) {
-      const isFromMe = convo.lastMessage.sender?.did === currentAccount?.did
+      if (ChatBskyConvoDefs.isMessageView(convo.lastMessage)) {
+        const isFromMe = convo.lastMessage.sender?.did === currentAccount?.did
 
-      if (convo.lastMessage.text) {
-        if (isFromMe) {
-          lastMessage = _(msg`You: ${convo.lastMessage.text}`)
-        } else {
-          lastMessage = convo.lastMessage.text
+        if (!isFromMe) {
+          latestReportableMessage = convo.lastMessage
         }
-      } else if (convo.lastMessage.embed) {
-        const defaultEmbeddedContentMessage = _(
-          msg`(contains embedded content)`,
-        )
 
-        if (AppBskyEmbedRecord.isView(convo.lastMessage.embed)) {
-          const embed = convo.lastMessage.embed
+        if (convo.lastMessage.text) {
+          if (isFromMe) {
+            lastMessage = _(msg`You: ${convo.lastMessage.text}`)
+          } else {
+            lastMessage = convo.lastMessage.text
+          }
+        } else if (convo.lastMessage.embed) {
+          const defaultEmbeddedContentMessage = _(
+            msg`(contains embedded content)`,
+          )
 
-          if (AppBskyEmbedRecord.isViewRecord(embed.record)) {
-            const record = embed.record
-            const path = postUriToRelativePath(record.uri, {
-              handle: record.author.handle,
-            })
-            const href = path ? toBskyAppUrl(path) : undefined
-            const short = href
-              ? toShortUrl(href)
-              : defaultEmbeddedContentMessage
+          if (AppBskyEmbedRecord.isView(convo.lastMessage.embed)) {
+            const embed = convo.lastMessage.embed
+
+            if (AppBskyEmbedRecord.isViewRecord(embed.record)) {
+              const record = embed.record
+              const path = postUriToRelativePath(record.uri, {
+                handle: record.author.handle,
+              })
+              const href = path ? toBskyAppUrl(path) : undefined
+              const short = href
+                ? toShortUrl(href)
+                : defaultEmbeddedContentMessage
+              if (isFromMe) {
+                lastMessage = _(msg`You: ${short}`)
+              } else {
+                lastMessage = short
+              }
+            }
+          } else {
             if (isFromMe) {
-              lastMessage = _(msg`You: ${short}`)
+              lastMessage = _(msg`You: ${defaultEmbeddedContentMessage}`)
             } else {
-              lastMessage = short
+              lastMessage = defaultEmbeddedContentMessage
             }
           }
-        } else {
-          if (isFromMe) {
-            lastMessage = _(msg`You: ${defaultEmbeddedContentMessage}`)
-          } else {
-            lastMessage = defaultEmbeddedContentMessage
-          }
         }
+
+        lastMessageSentAt = convo.lastMessage.sentAt
+      }
+      if (ChatBskyConvoDefs.isDeletedMessageView(convo.lastMessage)) {
+        lastMessage = isDeletedAccount
+          ? _(msg`Conversation deleted`)
+          : _(msg`Message deleted`)
       }
 
-      lastMessageSentAt = convo.lastMessage.sentAt
-    }
-    if (ChatBskyConvoDefs.isDeletedMessageView(convo.lastMessage)) {
-      lastMessage = isDeletedAccount
-        ? _(msg`Conversation deleted`)
-        : _(msg`Message deleted`)
-    }
-
-    return {
-      lastMessage,
-      lastMessageSentAt,
-    }
-  }, [_, convo.lastMessage, currentAccount?.did, isDeletedAccount])
+      return {
+        lastMessage,
+        lastMessageSentAt,
+        latestReportableMessage,
+      }
+    }, [_, convo.lastMessage, currentAccount?.did, isDeletedAccount])
 
   const [showActions, setShowActions] = useState(false)
 
@@ -412,6 +422,7 @@ function ChatListItemReady({
               opacity: !gtMobile || showActions || menuControl.isOpen ? 1 : 0,
             },
           ]}
+          latestReportableMessage={latestReportableMessage}
         />
         <LeaveConvoPrompt
           control={leaveConvoControl}


### PR DESCRIPTION
Allows conversation-level reporting by reporting the most recent message available. In the chat list screen, this is the latest message that we get for the little preview, and in the chat screen itself we use the most recent message from the other person. Comes with a little note indicating that only the last few messages in the convo will be reported.

If it can't find a message to report, it falls back to the old prompt - for example if you're reporting from the chat list screen and you sent the last message

https://github.com/user-attachments/assets/eefa6cbf-94d1-48f1-91ab-e63aa230430e

# Test plan

Report different conversations from different menus. It should always only report the most recent message from the other person in the convo.
