### PR TITLE
A simpler fix for trending swipe issue

### DIFF
--- a/patches/react-native-gesture-handler+2.20.2.patch
+++ b/patches/react-native-gesture-handler+2.20.2.patch
@@ -1,0 +1,36 @@
+diff --git a/node_modules/react-native-gesture-handler/apple/RNGestureHandler.mm b/node_modules/react-native-gesture-handler/apple/RNGestureHandler.mm
+index 43d11b4..5bf0d32 100644
+--- a/node_modules/react-native-gesture-handler/apple/RNGestureHandler.mm
++++ b/node_modules/react-native-gesture-handler/apple/RNGestureHandler.mm
+@@ -461,16 +461,23 @@ - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
+ - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
+     shouldRequireFailureOfGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
+ {
+-  if ([_handlersToWaitFor count]) {
+-    RNGestureHandler *handler = [RNGestureHandler findGestureHandlerByRecognizer:otherGestureRecognizer];
+-    if (handler != nil) {
+-      for (NSNumber *handlerTag in _handlersToWaitFor) {
+-        if ([handler.tag isEqual:handlerTag]) {
+-          return YES;
+-        }
+-      }
++  RNGestureHandler *handler = [RNGestureHandler findGestureHandlerByRecognizer:otherGestureRecognizer];
++  if (handler == nil) {
++    return NO;
++  }
++
++  for (NSNumber *handlerTag in _handlersToWaitFor) {
++    if ([handler.tag isEqual:handlerTag]) {
++      return YES;
+     }
+   }
++
++  for (NSNumber *handlerTag in handler->_handlersThatShouldWait) {
++    if ([_tag isEqual:handlerTag]) {
++      return YES;
++    }
++  }
++
+   return NO;
+ }
+ 

--- a/src/components/interstitials/Trending.tsx
+++ b/src/components/interstitials/Trending.tsx
@@ -1,6 +1,7 @@
 import React, {useContext} from 'react'
 import {ScrollView, View} from 'react-native'
-import {GestureDetector} from 'react-native-gesture-handler'
+import {DrawerGestureContext} from 'react-native-drawer-layout'
+import {Gesture, GestureDetector} from 'react-native-gesture-handler'
 import {msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
@@ -12,7 +13,6 @@ import {
 import {useTrendingTopics} from '#/state/queries/trending/useTrendingTopics'
 import {useTrendingConfig} from '#/state/trending-config'
 import {LoadingPlaceholder} from '#/view/com/util/LoadingPlaceholder'
-import {TrendingGestureContext} from '#/view/shell/TrendingGestureContext'
 import {atoms as a, useGutters, useTheme} from '#/alf'
 import {Button, ButtonIcon} from '#/components/Button'
 import {TimesLarge_Stroke2_Corner0_Rounded as X} from '#/components/icons/Times'
@@ -41,8 +41,9 @@ export function Inner() {
     setTrendingDisabled(true)
   }, [setTrendingDisabled])
 
-  // This is coordinated to take precedence over the drawer pan gesture.
-  const trendingScrollGesture = useContext(TrendingGestureContext)
+  const drawerGesture = useContext(DrawerGestureContext)!
+  const trendingScrollGesture =
+    Gesture.Native().blocksExternalGesture(drawerGesture)
 
   return error || noTopics ? null : (
     <View style={[t.atoms.border_contrast_low, a.border_t]}>

--- a/src/view/shell/TrendingGestureContext.tsx
+++ b/src/view/shell/TrendingGestureContext.tsx
@@ -1,7 +1,0 @@
-import {createContext} from 'react'
-import {Gesture} from 'react-native-gesture-handler'
-
-// Not really used but serves as a fallback for types.
-const noopGesture = Gesture.Native()
-
-export const TrendingGestureContext = createContext(noopGesture)

--- a/src/view/shell/index.tsx
+++ b/src/view/shell/index.tsx
@@ -34,7 +34,6 @@ import {BottomSheetOutlet} from '../../../modules/bottom-sheet'
 import {updateActiveViewAsync} from '../../../modules/expo-bluesky-swiss-army/src/VisibilityView'
 import {Composer} from './Composer'
 import {DrawerContent} from './Drawer'
-import {TrendingGestureContext} from './TrendingGestureContext'
 
 function ShellInner() {
   const t = useTheme()
@@ -145,9 +144,7 @@ function ShellInner() {
                 dim: 'rgba(10, 13, 16, 0.8)',
               }),
             }}>
-            <TrendingGestureContext.Provider value={trendingScrollGesture}>
-              <TabsNavigator />
-            </TrendingGestureContext.Provider>
+            <TabsNavigator />
           </Drawer>
         </ErrorBoundary>
       </View>


### PR DESCRIPTION
A simpler solution than https://github.com/bluesky-social/social-app/pull/7417.

Relies on patching in https://github.com/software-mansion/react-native-gesture-handler/pull/3322.

On iOS, this is equivalent to https://github.com/bluesky-social/social-app/pull/7417 (but simpler in code).

On Android, this seems to actually _fully fix_ the gesture conflict. I can't repro it anymore.