### PR TITLE
Fix invalid password error message

### DIFF
--- a/src/locale/locales/an/messages.po
+++ b/src/locale/locales/an/messages.po
@@ -3497,7 +3497,7 @@ msgstr "Rechistro de publicación invalido u no compatible"
 
 #: src/screens/Login/LoginForm.tsx:90
 #: src/screens/Login/LoginForm.tsx:149
-msgid "Invalid username or password"
+msgid "Incorrect username or password"
 msgstr "Nombre d'usuario u clau no validos"
 
 #: src/components/intents/VerifyEmailIntentDialog.tsx:91

--- a/src/locale/locales/ast/messages.po
+++ b/src/locale/locales/ast/messages.po
@@ -3694,7 +3694,7 @@ msgstr ""
 
 #: src/screens/Login/LoginForm.tsx:90
 #: src/screens/Login/LoginForm.tsx:149
-msgid "Invalid username or password"
+msgid "Incorrect username or password"
 msgstr ""
 
 #: src/components/intents/VerifyEmailIntentDialog.tsx:91

--- a/src/locale/locales/ca/messages.po
+++ b/src/locale/locales/ca/messages.po
@@ -4457,7 +4457,7 @@ msgstr "Registre de publicació no vàlid o no admès"
 
 #: src/screens/Login/LoginForm.tsx:90
 #: src/screens/Login/LoginForm.tsx:149
-msgid "Invalid username or password"
+msgid "Incorrect username or password"
 msgstr "Nom d'usuari o contrasenya incorrectes"
 
 #: src/components/intents/VerifyEmailIntentDialog.tsx:91

--- a/src/locale/locales/de/messages.po
+++ b/src/locale/locales/de/messages.po
@@ -3931,7 +3931,7 @@ msgstr "Ungültiger oder nicht unterstützter Beitragrekord"
 
 #: src/screens/Login/LoginForm.tsx:90
 #: src/screens/Login/LoginForm.tsx:149
-msgid "Invalid username or password"
+msgid "Incorrect username or password"
 msgstr "Ungültiger Benutzername oder Passwort"
 
 #: src/components/intents/VerifyEmailIntentDialog.tsx:91

--- a/src/locale/locales/el/messages.po
+++ b/src/locale/locales/el/messages.po
@@ -3499,7 +3499,7 @@ msgstr "Μη έγκυρη ή μη υποστηριζόμενη εγγραφή α
 
 #: src/screens/Login/LoginForm.tsx:90
 #: src/screens/Login/LoginForm.tsx:149
-msgid "Invalid username or password"
+msgid "Incorrect username or password"
 msgstr "Μη έγκυρο όνομα χρήστη ή κωδικός πρόσβασης"
 
 #: src/components/intents/VerifyEmailIntentDialog.tsx:91

--- a/src/locale/locales/en-GB/messages.po
+++ b/src/locale/locales/en-GB/messages.po
@@ -3694,7 +3694,7 @@ msgstr ""
 
 #: src/screens/Login/LoginForm.tsx:90
 #: src/screens/Login/LoginForm.tsx:149
-msgid "Invalid username or password"
+msgid "Incorrect username or password"
 msgstr ""
 
 #: src/components/intents/VerifyEmailIntentDialog.tsx:91

--- a/src/locale/locales/en/messages.po
+++ b/src/locale/locales/en/messages.po
@@ -3694,7 +3694,7 @@ msgstr ""
 
 #: src/screens/Login/LoginForm.tsx:90
 #: src/screens/Login/LoginForm.tsx:149
-msgid "Invalid username or password"
+msgid "Incorrect username or password"
 msgstr ""
 
 #: src/components/intents/VerifyEmailIntentDialog.tsx:91

--- a/src/locale/locales/es/messages.po
+++ b/src/locale/locales/es/messages.po
@@ -4085,7 +4085,7 @@ msgstr "Registro de publicación inválido o no compatible"
 
 #: src/screens/Login/LoginForm.tsx:90
 #: src/screens/Login/LoginForm.tsx:149
-msgid "Invalid username or password"
+msgid "Incorrect username or password"
 msgstr "Nombre de usuario o contraseña no válidos"
 
 #: src/components/intents/VerifyEmailIntentDialog.tsx:91

--- a/src/locale/locales/fi/messages.po
+++ b/src/locale/locales/fi/messages.po
@@ -3409,7 +3409,7 @@ msgstr "Virheellinen tai ei-tuettu julkaisutietue"
 
 #: src/screens/Login/LoginForm.tsx:90
 #: src/screens/Login/LoginForm.tsx:149
-msgid "Invalid username or password"
+msgid "Incorrect username or password"
 msgstr "Virheellinen käyttäjätunnus tai salasana"
 
 #: src/components/intents/VerifyEmailIntentDialog.tsx:91

--- a/src/locale/locales/fr/messages.po
+++ b/src/locale/locales/fr/messages.po
@@ -3409,7 +3409,7 @@ msgstr "Enregistrement de post invalide ou non pris en charge"
 
 #: src/screens/Login/LoginForm.tsx:90
 #: src/screens/Login/LoginForm.tsx:149
-msgid "Invalid username or password"
+msgid "Incorrect username or password"
 msgstr "Pseudo ou mot de passe incorrect"
 
 #: src/components/intents/VerifyEmailIntentDialog.tsx:91

--- a/src/locale/locales/ga/messages.po
+++ b/src/locale/locales/ga/messages.po
@@ -3693,7 +3693,7 @@ msgstr "Taifead postála atá neamhbhailí nó gan bhunús"
 
 #: src/screens/Login/LoginForm.tsx:90
 #: src/screens/Login/LoginForm.tsx:149
-msgid "Invalid username or password"
+msgid "Incorrect username or password"
 msgstr "Leasainm nó pasfhocal míchruinn"
 
 #: src/components/intents/VerifyEmailIntentDialog.tsx:91

--- a/src/locale/locales/gl/messages.po
+++ b/src/locale/locales/gl/messages.po
@@ -4085,7 +4085,7 @@ msgstr "Rexistro de chío inválido ou non compatíbel"
 
 #: src/screens/Login/LoginForm.tsx:90
 #: src/screens/Login/LoginForm.tsx:149
-msgid "Invalid username or password"
+msgid "Incorrect username or password"
 msgstr "Alcume ou contrasinal incorrectos"
 
 #: src/components/intents/VerifyEmailIntentDialog.tsx:91

--- a/src/locale/locales/hi/messages.po
+++ b/src/locale/locales/hi/messages.po
@@ -3965,7 +3965,7 @@ msgstr "अमान्य या असमर्थित पोस्ट र�
 
 #: src/screens/Login/LoginForm.tsx:90
 #: src/screens/Login/LoginForm.tsx:149
-msgid "Invalid username or password"
+msgid "Incorrect username or password"
 msgstr "अमान्य उपयोगकर्ता नाम या पासवर्ड"
 
 #: src/components/intents/VerifyEmailIntentDialog.tsx:91

--- a/src/locale/locales/hu/messages.po
+++ b/src/locale/locales/hu/messages.po
@@ -3626,7 +3626,7 @@ msgstr "A megadott bejegyzésrekord érvénytelen vagy nem támogatott"
 
 #: src/screens/Login/LoginForm.tsx:90
 #: src/screens/Login/LoginForm.tsx:149
-msgid "Invalid username or password"
+msgid "Incorrect username or password"
 msgstr "Érvénytelen felhasználónév vagy jelszó"
 
 #: src/components/intents/VerifyEmailIntentDialog.tsx:91

--- a/src/locale/locales/id/messages.po
+++ b/src/locale/locales/id/messages.po
@@ -4196,7 +4196,7 @@ msgstr "Catatan postingan tidak valid atau tidak didukung"
 
 #: src/screens/Login/LoginForm.tsx:90
 #: src/screens/Login/LoginForm.tsx:149
-msgid "Invalid username or password"
+msgid "Incorrect username or password"
 msgstr "Nama pengguna atau kata sandi salah"
 
 #: src/components/intents/VerifyEmailIntentDialog.tsx:91

--- a/src/locale/locales/it/messages.po
+++ b/src/locale/locales/it/messages.po
@@ -3415,7 +3415,7 @@ msgstr "Protocollo del post non valido o non supportato"
 
 #: src/screens/Login/LoginForm.tsx:90
 #: src/screens/Login/LoginForm.tsx:149
-msgid "Invalid username or password"
+msgid "Incorrect username or password"
 msgstr "Nome utente o password errati"
 
 #: src/components/intents/VerifyEmailIntentDialog.tsx:91

--- a/src/locale/locales/ja/messages.po
+++ b/src/locale/locales/ja/messages.po
@@ -3409,7 +3409,7 @@ msgstr "無効またはサポートされていない投稿のレコード"
 
 #: src/screens/Login/LoginForm.tsx:90
 #: src/screens/Login/LoginForm.tsx:149
-msgid "Invalid username or password"
+msgid "Incorrect username or password"
 msgstr "無効なユーザー名またはパスワード"
 
 #: src/components/intents/VerifyEmailIntentDialog.tsx:91

--- a/src/locale/locales/km/messages.po
+++ b/src/locale/locales/km/messages.po
@@ -3698,7 +3698,7 @@ msgstr "កំណត់ត្រាប្រកាសមិនត្រឹមត
 
 #: src/screens/Login/LoginForm.tsx:90
 #: src/screens/Login/LoginForm.tsx:149
-msgid "Invalid username or password"
+msgid "Incorrect username or password"
 msgstr "ឈ្មោះអ្នកប្រើ ឬពាក្យសម្ងាត់មិនត្រឹមត្រូវ"
 
 #: src/components/intents/VerifyEmailIntentDialog.tsx:91

--- a/src/locale/locales/ko/messages.po
+++ b/src/locale/locales/ko/messages.po
@@ -3409,7 +3409,7 @@ msgstr "유효하지 않거나 지원되지 않는 게시물 기록"
 
 #: src/screens/Login/LoginForm.tsx:90
 #: src/screens/Login/LoginForm.tsx:149
-msgid "Invalid username or password"
+msgid "Incorrect username or password"
 msgstr "잘못된 사용자 이름 또는 비밀번호"
 
 #: src/components/intents/VerifyEmailIntentDialog.tsx:91

--- a/src/locale/locales/ne/messages.po
+++ b/src/locale/locales/ne/messages.po
@@ -3969,7 +3969,7 @@ msgstr "अवैध वा असमर्थित पोस्ट रेक�
 
 #: src/screens/Login/LoginForm.tsx:90
 #: src/screens/Login/LoginForm.tsx:149
-msgid "Invalid username or password"
+msgid "Incorrect username or password"
 msgstr "अमान्य प्रयोगकर्ता नाम वा पासवर्ड"
 
 #: src/components/intents/VerifyEmailIntentDialog.tsx:91

--- a/src/locale/locales/nl/messages.po
+++ b/src/locale/locales/nl/messages.po
@@ -3497,7 +3497,7 @@ msgstr "Ongeldig of niet-ondersteund berichtrecord"
 
 #: src/screens/Login/LoginForm.tsx:90
 #: src/screens/Login/LoginForm.tsx:149
-msgid "Invalid username or password"
+msgid "Incorrect username or password"
 msgstr "Ongeldige gebruikersnaam of wachtwoord"
 
 #: src/components/intents/VerifyEmailIntentDialog.tsx:91

--- a/src/locale/locales/pl/messages.po
+++ b/src/locale/locales/pl/messages.po
@@ -3498,7 +3498,7 @@ msgstr "Nieprawidłowy lub nieobsługiwany wpis"
 
 #: src/screens/Login/LoginForm.tsx:90
 #: src/screens/Login/LoginForm.tsx:149
-msgid "Invalid username or password"
+msgid "Incorrect username or password"
 msgstr "Nieprawidłowa nazwa lub hasło"
 
 #: src/components/intents/VerifyEmailIntentDialog.tsx:91

--- a/src/locale/locales/pt-BR/messages.po
+++ b/src/locale/locales/pt-BR/messages.po
@@ -4192,7 +4192,7 @@ msgstr "Postagem inválida"
 
 #: src/screens/Login/LoginForm.tsx:90
 #: src/screens/Login/LoginForm.tsx:149
-msgid "Invalid username or password"
+msgid "Incorrect username or password"
 msgstr "Credenciais inválidas"
 
 #: src/components/intents/VerifyEmailIntentDialog.tsx:91

--- a/src/locale/locales/ro/messages.po
+++ b/src/locale/locales/ro/messages.po
@@ -3698,7 +3698,7 @@ msgstr "Înregistrare postare invalidă sau nesuportată"
 
 #: src/screens/Login/LoginForm.tsx:90
 #: src/screens/Login/LoginForm.tsx:149
-msgid "Invalid username or password"
+msgid "Incorrect username or password"
 msgstr "Nume de utilizator sau parolă invalidă"
 
 #: src/components/intents/VerifyEmailIntentDialog.tsx:91

--- a/src/locale/locales/ru/messages.po
+++ b/src/locale/locales/ru/messages.po
@@ -3429,7 +3429,7 @@ msgstr "Неверный или неподдерживаемый пост"
 
 #: src/screens/Login/LoginForm.tsx:90
 #: src/screens/Login/LoginForm.tsx:149
-msgid "Invalid username or password"
+msgid "Incorrect username or password"
 msgstr "Неверное имя пользователя или пароль"
 
 #: src/components/intents/VerifyEmailIntentDialog.tsx:91

--- a/src/locale/locales/th/messages.po
+++ b/src/locale/locales/th/messages.po
@@ -4183,7 +4183,7 @@ msgstr "ระเบียนโพสต์ไม่ถูกต้องหร
 
 #: src/screens/Login/LoginForm.tsx:90
 #: src/screens/Login/LoginForm.tsx:149
-msgid "Invalid username or password"
+msgid "Incorrect username or password"
 msgstr "ชื่อผู้ใช้หรือรหัสผ่านไม่ถูกต้อง"
 
 #: src/components/intents/VerifyEmailIntentDialog.tsx:91

--- a/src/locale/locales/tr/messages.po
+++ b/src/locale/locales/tr/messages.po
@@ -4400,7 +4400,7 @@ msgstr "Geçersiz veya desteklenmeyen gönderi kaydı"
 
 #: src/screens/Login/LoginForm.tsx:90
 #: src/screens/Login/LoginForm.tsx:149
-msgid "Invalid username or password"
+msgid "Incorrect username or password"
 msgstr "Geçersiz kullanıcı adı veya şifre"
 
 #: src/components/intents/VerifyEmailIntentDialog.tsx:91

--- a/src/locale/locales/uk/messages.po
+++ b/src/locale/locales/uk/messages.po
@@ -4196,7 +4196,7 @@ msgstr "Невірний або непідтримуваний пост"
 
 #: src/screens/Login/LoginForm.tsx:90
 #: src/screens/Login/LoginForm.tsx:149
-msgid "Invalid username or password"
+msgid "Incorrect username or password"
 msgstr "Невірне ім'я користувача або пароль"
 
 #: src/components/intents/VerifyEmailIntentDialog.tsx:91

--- a/src/locale/locales/vi/messages.po
+++ b/src/locale/locales/vi/messages.po
@@ -3490,7 +3490,7 @@ msgstr "Bản ghi bài đăng không hợp lệ hoặc không được hỗ tr�
 
 #: src/screens/Login/LoginForm.tsx:90
 #: src/screens/Login/LoginForm.tsx:149
-msgid "Invalid username or password"
+msgid "Incorrect username or password"
 msgstr "Tên người dùng hoặc mật khẩu không hợp lệ"
 
 #: src/components/intents/VerifyEmailIntentDialog.tsx:91

--- a/src/locale/locales/zh-CN/messages.po
+++ b/src/locale/locales/zh-CN/messages.po
@@ -3414,7 +3414,7 @@ msgstr "帖文记录无效或不受支持"
 
 #: src/screens/Login/LoginForm.tsx:90
 #: src/screens/Login/LoginForm.tsx:149
-msgid "Invalid username or password"
+msgid "Incorrect username or password"
 msgstr "用户名或密码无效"
 
 #: src/components/intents/VerifyEmailIntentDialog.tsx:91

--- a/src/locale/locales/zh-HK/messages.po
+++ b/src/locale/locales/zh-HK/messages.po
@@ -3414,7 +3414,7 @@ msgstr "無效抑或唔支援嘅帖文記錄"
 
 #: src/screens/Login/LoginForm.tsx:90
 #: src/screens/Login/LoginForm.tsx:149
-msgid "Invalid username or password"
+msgid "Incorrect username or password"
 msgstr "無效嘅用戶名抑或密碼"
 
 #: src/components/intents/VerifyEmailIntentDialog.tsx:91

--- a/src/locale/locales/zh-TW/messages.po
+++ b/src/locale/locales/zh-TW/messages.po
@@ -3414,7 +3414,7 @@ msgstr "無效或不支援的貼文紀錄"
 
 #: src/screens/Login/LoginForm.tsx:90
 #: src/screens/Login/LoginForm.tsx:149
-msgid "Invalid username or password"
+msgid "Incorrect username or password"
 msgstr "用戶名稱或密碼無效"
 
 #: src/components/intents/VerifyEmailIntentDialog.tsx:91

--- a/src/screens/Login/LoginForm.tsx
+++ b/src/screens/Login/LoginForm.tsx
@@ -87,7 +87,7 @@ export const LoginForm = ({
     const authFactorToken = authFactorTokenValueRef.current
 
     if (!identifier || !password) {
-      setError(_(msg`Invalid username or password`))
+      setError(_(msg`Incorrect username or password`))
       return
     }
 
@@ -146,7 +146,7 @@ export const LoginForm = ({
         logger.debug('Failed to login due to invalid credentials', {
           error: errMsg,
         })
-        setError(_(msg`Invalid username or password`))
+        setError(_(msg`Incorrect username or password`))
       } else if (isNetworkError(e)) {
         logger.warn('Failed to login due to network error', {error: errMsg})
         setError(

--- a/src/screens/Login/LoginForm.tsx
+++ b/src/screens/Login/LoginForm.tsx
@@ -86,8 +86,13 @@ export const LoginForm = ({
     const password = passwordValueRef.current
     const authFactorToken = authFactorTokenValueRef.current
 
-    if (!identifier || !password) {
-      setError(_(msg`Incorrect username or password`))
+    if (!identifier) {
+      setError(_(msg`Please enter your username`))
+      return
+    }
+
+    if (!password) {
+      setError(_(msg`Please enter your password`))
       return
     }
 
@@ -142,7 +147,10 @@ export const LoginForm = ({
           error: errMsg,
         })
         setError(_(msg`Invalid 2FA confirmation code.`))
-      } else if (errMsg.includes('Authentication Required')) {
+      } else if (
+        errMsg.includes('Authentication Required') ||
+        errMsg.includes('Invalid identifier or password')
+      ) {
         logger.debug('Failed to login due to invalid credentials', {
           error: errMsg,
         })


### PR DESCRIPTION
1. Catches backend errors properly - seems this changed at some point
2. Better errors for empty username/password
3. Tweaks wording, and change .po files to avoid translation churn

<img width="652" alt="Screenshot 2025-01-10 at 19 15 06" src="https://github.com/user-attachments/assets/84b2cd4d-f62f-4694-8aef-cca5e98fa141" />
