### PR TITLE
Fix web crash

### DIFF
--- a/src/components/interstitials/Trending.tsx
+++ b/src/components/interstitials/Trending.tsx
@@ -41,7 +41,7 @@ export function Inner() {
     setTrendingDisabled(true)
   }, [setTrendingDisabled])
 
-  const drawerGesture = useContext(DrawerGestureContext)!
+  const drawerGesture = useContext(DrawerGestureContext) ?? Gesture.Native() // noop for web
   const trendingScrollGesture =
     Gesture.Native().blocksExternalGesture(drawerGesture)
 

--- a/src/view/com/pager/Pager.tsx
+++ b/src/view/com/pager/Pager.tsx
@@ -130,7 +130,7 @@ export const Pager = forwardRef<PagerRef, React.PropsWithChildren<Props>>(
       [parentOnPageScrollStateChanged],
     )
 
-    const drawerGesture = useContext(DrawerGestureContext)!
+    const drawerGesture = useContext(DrawerGestureContext) ?? Gesture.Native() // noop for web
     const nativeGesture =
       Gesture.Native().requireExternalGestureToFail(drawerGesture)
 


### PR DESCRIPTION
Oops. In the copypaste, the component was shared between web and native, so it didn't work. Let's just not override types here and provide a fallback.