### PR TITLE
Remove unnecessary addEventListener call for video

### DIFF
--- a/src/view/com/util/post-embeds/VideoEmbedInner/web-controls/utils.tsx
+++ b/src/view/com/util/post-embeds/VideoEmbedInner/web-controls/utils.tsx
@@ -149,9 +149,6 @@ export function useVideoElement(ref: React.RefObject<HTMLVideoElement>) {
     ref.current.addEventListener('ended', handleEnded, {
       signal: abortController.signal,
     })
-    ref.current.addEventListener('volumechange', handleVolumeChange, {
-      signal: abortController.signal,
-    })
 
     return () => {
       abortController.abort()


### PR DESCRIPTION
### Problem:

**useVideoElement** repeatedly adds listener for **volumechange** event. We already add that listener [here](https://github.com/bluesky-social/social-app/blob/main/src/view/com/util/post-embeds/VideoEmbedInner/web-controls/utils.tsx#L128)

### Solution:

Removed call to **addEventListener** that's not needed