### PR TITLE
Tweak Cantonese language tag in `CFBundleLocalizations` key

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -99,7 +99,7 @@ module.exports = function (config) {
             'tr',
             'uk',
             'vi',
-            'yue-Hant',
+            'yue',
             'zh-Hans',
             'zh-Hant',
           ],


### PR DESCRIPTION
In #6835 the language tag for Cantonese in the `CFBundleLocalizations` key was changed from `zh_HK` to `yue-Hant` in an effort to get Cantonese listed as one of the supported languages on the App Store page.

Unfortunately, that doesn't seem to have worked:

![IMG_4335](https://github.com/user-attachments/assets/04e6ee5c-f0a4-49c9-86b5-2cb3c88cfac6)

So as discussed in https://github.com/bluesky-social/social-app/pull/6835#issuecomment-2507264652, this follow-up PR tweaks the language tag to simply `yue`.

Pinging @auroursa for feedback.