### PR TITLE
fix(android): bump react-native-date-picker for dark mode button support

### DIFF
--- a/package.json
+++ b/package.json
@@ -170,7 +170,7 @@
     "react-keyed-flatten-children": "^3.0.0",
     "react-native": "0.76.3",
     "react-native-compressor": "1.10.3",
-    "react-native-date-picker": "^5.0.7",
+    "react-native-date-picker": "^5.0.8",
     "react-native-drawer-layout": "^4.1.1",
     "react-native-gesture-handler": "2.20.2",
     "react-native-get-random-values": "~1.11.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15947,10 +15947,10 @@ react-native-compressor@1.10.3:
   resolved "https://registry.yarnpkg.com/react-native-compressor/-/react-native-compressor-1.10.3.tgz#4e44fa8395de17fd6dc63c074e5a8c2ef06b80a1"
   integrity sha512-i51DfTwfLcKorWbTXtnPOcQC4SQDuC+DqKkSl9wF9qAUmNS9PtipYZCXOvWShYFnX0mmcWw5vwEp2b2V73PaDQ==
 
-react-native-date-picker@^5.0.7:
-  version "5.0.7"
-  resolved "https://registry.yarnpkg.com/react-native-date-picker/-/react-native-date-picker-5.0.7.tgz#24161d30c6dca8627afe1aa5a55a389421fdfba4"
-  integrity sha512-/RodyCZWjb+f3f4YHqKbWFYczGm+tNngwbVSB6MLGgt5Kl7LQXpv4QE6ybnHW+DM4LteTP8A6lj8LEkQ7+usLQ==
+react-native-date-picker@^5.0.8:
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/react-native-date-picker/-/react-native-date-picker-5.0.8.tgz#1820fccc194bfa6907ea4382f94677f11e831b92"
+  integrity sha512-1l4w4+iLuhOZUSyQrt5DclXnNx3RwEyp+wUrSaBfaHr/3FWtRWjLjS0E9FL4FWuq6vn09Hy9hn8lZJ1DmPc9YQ==
 
 react-native-dotenv@^3.4.11:
   version "3.4.11"


### PR DESCRIPTION
## Description
- Addresses part of #4220
- Fixes issue on Android where the `Cancel` / `Confirm` buttons were hard to see in Dark Mode
- Bumps `react-native-date-picker` to adopt the change that fixes this in https://github.com/henninghall/react-native-date-picker/pull/871

## Screenshots
| Before | After | 
| ----- | ----- |
| ![image](https://github.com/user-attachments/assets/175444f6-a5a7-491e-9b6d-124ad547a710) | ![image](https://github.com/user-attachments/assets/3a6cb9bc-91d9-4b98-9a87-89cb8e6c9bc0) |
