### PR TITLE
Set webpack public path to auto to load from CDN (hopefully)

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,6 +30,9 @@ module.exports = async function (env, argv) {
     config.plugins.push(new ReactRefreshWebpackPlugin())
   }
 
+  // Support static CDN for chunks
+  config.output.publicPath = 'auto'
+
   if (GENERATE_STATS || OPEN_ANALYZER) {
     config.plugins.push(
       new BundleAnalyzerPlugin({


### PR DESCRIPTION
Webpack produces chunk and static files with references that aren't pointing to where the browser loaded the script from. When we serve the main script from a static asset CDN, the references to chunkfiles don't share the path of the CDN.

To fully leverage a static asset CDN, we should fix that hopefully with this patch.