### PR TITLE
Improve language detection accuracy

### DIFF
--- a/src/view/com/composer/select-language/SuggestedLanguage.tsx
+++ b/src/view/com/composer/select-language/SuggestedLanguage.tsx
@@ -33,7 +33,14 @@ export function SuggestedLanguage({text}: {text: string}) {
   const {_} = useLingui()
 
   useEffect(() => {
-    const textTrimmed = text.trim()
+    let textTrimmed = text.trim()
+
+    // remove the last word before guessing to prevent a half-written word 
+    // from botching the confidence of language detection.
+    const lastSpace = textTrimmed.lastIndexOf(' ')
+    if (lastSpace > 0) {
+      textTrimmed = textTrimmed.slice(0, lastSpace)
+    }
 
     // Don't run the language model on small posts, the results are likely
     // to be inaccurate anyway.

--- a/src/view/com/composer/select-language/SuggestedLanguage.tsx
+++ b/src/view/com/composer/select-language/SuggestedLanguage.tsx
@@ -35,8 +35,16 @@ export function SuggestedLanguage({text}: {text: string}) {
   useEffect(() => {
     let textTrimmed = text.trim()
 
-    // remove the last word before guessing to prevent a half-written word 
+    // Remove the last word before guessing to prevent a half-written word 
     // from botching the confidence of language detection.
+    // There are two gotchas with this approach:
+    // First, it might increase the practical minimum length for the language
+    // detection because removing the last word would eat away from the 
+    // 40 character min limit. I think it's worth it though. 
+    // Second, this will also discard the last word that has been typed fully 
+    // which might affect the outcome. One might consider detecting punctuation 
+    // at the end of the last word to include it in the language detection, 
+    // but it's quite hard to do that for all languages correctly.
     const lastSpace = textTrimmed.lastIndexOf(' ')
     if (lastSpace > 0) {
       textTrimmed = textTrimmed.slice(0, lastSpace)


### PR DESCRIPTION
Problem: when you're typing a post, "are you writing in X language?" prompt appears and disappears occasionally. That frequently happens when you press space and start writing the next word too as the half-word is probably unknown to the model. When you finish the word, the prompt appears again, but this makes the prompt unnecessarily blink, and lose opportunity to notify the user. That can cause posts appear with incorrect language settings and can be quite harmful for its reach (as mentioned in #7260).

This change aims to improve the UX of "are you writing in X language?" by discarding the last word from the detection set until a more reliable detection library replaces lande.