### PR TITLE
Prevent Drawer gesture conflicting with Suggestions scroll

### DIFF
--- a/src/components/FeedInterstitials.tsx
+++ b/src/components/FeedInterstitials.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
-import {View} from 'react-native'
-import {ScrollView} from 'react-native-gesture-handler'
+import {ScrollView, View} from 'react-native'
 import {AppBskyActorDefs, AppBskyFeedDefs, AtUri} from '@atproto/api'
 import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
@@ -17,6 +16,7 @@ import {useSuggestedFollowsByActorQuery} from '#/state/queries/suggested-follows
 import {useSession} from '#/state/session'
 import * as userActionHistory from '#/state/userActionHistory'
 import {SeenPost} from '#/state/userActionHistory'
+import {BlockDrawerGesture} from '#/view/shell/BlockDrawerGesture'
 import {atoms as a, useBreakpoints, useTheme, ViewStyleProp, web} from '#/alf'
 import {Button} from '#/components/Button'
 import * as FeedCard from '#/components/FeedCard'
@@ -336,33 +336,37 @@ export function ProfileGrid({
           </View>
         </View>
       ) : (
-        <ScrollView
-          horizontal
-          showsHorizontalScrollIndicator={false}
-          snapToInterval={MOBILE_CARD_WIDTH + a.gap_md.gap}
-          decelerationRate="fast">
-          <View style={[a.px_lg, a.pt_sm, a.pb_lg, a.flex_row, a.gap_md]}>
-            {content}
+        <BlockDrawerGesture>
+          <ScrollView
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            snapToInterval={MOBILE_CARD_WIDTH + a.gap_md.gap}
+            decelerationRate="fast">
+            <View style={[a.px_lg, a.pt_sm, a.pb_lg, a.flex_row, a.gap_md]}>
+              {content}
 
-            <Button
-              label={_(msg`Browse more accounts on the Explore page`)}
-              onPress={() => {
-                navigation.navigate('SearchTab')
-              }}>
-              <CardOuter style={[a.flex_1, {borderWidth: 0}]}>
-                <View style={[a.flex_1, a.justify_center]}>
-                  <View style={[a.flex_row, a.px_lg]}>
-                    <Text style={[a.pr_xl, a.flex_1, a.leading_snug]}>
-                      <Trans>Browse more suggestions on the Explore page</Trans>
-                    </Text>
+              <Button
+                label={_(msg`Browse more accounts on the Explore page`)}
+                onPress={() => {
+                  navigation.navigate('SearchTab')
+                }}>
+                <CardOuter style={[a.flex_1, {borderWidth: 0}]}>
+                  <View style={[a.flex_1, a.justify_center]}>
+                    <View style={[a.flex_row, a.px_lg]}>
+                      <Text style={[a.pr_xl, a.flex_1, a.leading_snug]}>
+                        <Trans>
+                          Browse more suggestions on the Explore page
+                        </Trans>
+                      </Text>
 
-                    <Arrow size="xl" />
+                      <Arrow size="xl" />
+                    </View>
                   </View>
-                </View>
-              </CardOuter>
-            </Button>
-          </View>
-        </ScrollView>
+                </CardOuter>
+              </Button>
+            </View>
+          </ScrollView>
+        </BlockDrawerGesture>
       )}
     </View>
   )
@@ -469,34 +473,38 @@ export function SuggestedFeeds() {
           </View>
         </View>
       ) : (
-        <ScrollView
-          horizontal
-          showsHorizontalScrollIndicator={false}
-          snapToInterval={MOBILE_CARD_WIDTH + a.gap_md.gap}
-          decelerationRate="fast">
-          <View style={[a.px_lg, a.pt_md, a.pb_xl, a.flex_row, a.gap_md]}>
-            {content}
+        <BlockDrawerGesture>
+          <ScrollView
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            snapToInterval={MOBILE_CARD_WIDTH + a.gap_md.gap}
+            decelerationRate="fast">
+            <View style={[a.px_lg, a.pt_md, a.pb_xl, a.flex_row, a.gap_md]}>
+              {content}
 
-            <Button
-              label={_(msg`Browse more feeds on the Explore page`)}
-              onPress={() => {
-                navigation.navigate('SearchTab')
-              }}
-              style={[a.flex_col]}>
-              <CardOuter style={[a.flex_1]}>
-                <View style={[a.flex_1, a.justify_center]}>
-                  <View style={[a.flex_row, a.px_lg]}>
-                    <Text style={[a.pr_xl, a.flex_1, a.leading_snug]}>
-                      <Trans>Browse more suggestions on the Explore page</Trans>
-                    </Text>
+              <Button
+                label={_(msg`Browse more feeds on the Explore page`)}
+                onPress={() => {
+                  navigation.navigate('SearchTab')
+                }}
+                style={[a.flex_col]}>
+                <CardOuter style={[a.flex_1]}>
+                  <View style={[a.flex_1, a.justify_center]}>
+                    <View style={[a.flex_row, a.px_lg]}>
+                      <Text style={[a.pr_xl, a.flex_1, a.leading_snug]}>
+                        <Trans>
+                          Browse more suggestions on the Explore page
+                        </Trans>
+                      </Text>
 
-                    <Arrow size="xl" />
+                      <Arrow size="xl" />
+                    </View>
                   </View>
-                </View>
-              </CardOuter>
-            </Button>
-          </View>
-        </ScrollView>
+                </CardOuter>
+              </Button>
+            </View>
+          </ScrollView>
+        </BlockDrawerGesture>
       )}
     </View>
   )

--- a/src/components/interstitials/Trending.tsx
+++ b/src/components/interstitials/Trending.tsx
@@ -1,7 +1,5 @@
-import React, {useContext} from 'react'
+import React from 'react'
 import {ScrollView, View} from 'react-native'
-import {DrawerGestureContext} from 'react-native-drawer-layout'
-import {Gesture, GestureDetector} from 'react-native-gesture-handler'
 import {msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
@@ -13,6 +11,7 @@ import {
 import {useTrendingTopics} from '#/state/queries/trending/useTrendingTopics'
 import {useTrendingConfig} from '#/state/trending-config'
 import {LoadingPlaceholder} from '#/view/com/util/LoadingPlaceholder'
+import {BlockDrawerGesture} from '#/view/shell/BlockDrawerGesture'
 import {atoms as a, useGutters, useTheme} from '#/alf'
 import {Button, ButtonIcon} from '#/components/Button'
 import {TimesLarge_Stroke2_Corner0_Rounded as X} from '#/components/icons/Times'
@@ -41,13 +40,9 @@ export function Inner() {
     setTrendingDisabled(true)
   }, [setTrendingDisabled])
 
-  const drawerGesture = useContext(DrawerGestureContext) ?? Gesture.Native() // noop for web
-  const trendingScrollGesture =
-    Gesture.Native().blocksExternalGesture(drawerGesture)
-
   return error || noTopics ? null : (
     <View style={[t.atoms.border_contrast_low, a.border_t]}>
-      <GestureDetector gesture={trendingScrollGesture}>
+      <BlockDrawerGesture>
         <ScrollView
           horizontal
           showsHorizontalScrollIndicator={false}
@@ -127,7 +122,7 @@ export function Inner() {
             )}
           </View>
         </ScrollView>
-      </GestureDetector>
+      </BlockDrawerGesture>
 
       <Prompt.Basic
         control={trendingPrompt}

--- a/src/view/shell/BlockDrawerGesture.tsx
+++ b/src/view/shell/BlockDrawerGesture.tsx
@@ -1,0 +1,9 @@
+import {useContext} from 'react'
+import {DrawerGestureContext} from 'react-native-drawer-layout'
+import {Gesture, GestureDetector} from 'react-native-gesture-handler'
+
+export function BlockDrawerGesture({children}: {children: React.ReactNode}) {
+  const drawerGesture = useContext(DrawerGestureContext) ?? Gesture.Native() // noop for web
+  const scrollGesture = Gesture.Native().blocksExternalGesture(drawerGesture)
+  return <GestureDetector gesture={scrollGesture}>{children}</GestureDetector>
+}


### PR DESCRIPTION
Makes sure this gesture doesn't conflict with the drawer:

https://github.com/user-attachments/assets/6377b9bc-330a-4f5d-9b1b-a2b50f411085

Previously the behavior was not consistent (particularly on Android) and scrolling left could make the drawer appear out of the blue. Not anymore.

Implementation-wise, this reuses the approach from https://github.com/bluesky-social/social-app/pull/7424. It's not perfect (ideally the drawer would take precedence on a swipe left when the scroll view is resting at x = 0) but we're not going to bother with that.

## Test Plan

See video above. This was previously sometimes getting stuck on Android. Particularly on device.

Try Android (verified works on device), iOS (I only tried sim but will test on TF).

No changes on web.