### PR TITLE
Support `from:@me` in addition to `from:me` in the search box

### DIFF
--- a/src/lib/strings/helpers.ts
+++ b/src/lib/strings/helpers.ts
@@ -93,7 +93,7 @@ export function augmentSearchQuery(query: string, {did}: {did?: string}) {
   return splits
     .map((str, idx) => {
       if (idx % 2 === 0) {
-        return str.replaceAll(/(^|\s)from:me(\s|$)/g, `$1${did}$2`)
+        return str.replaceAll(/(^|\s)from:@?me(\s|$)/g, `$1${did}$2`)
       }
 
       return str


### PR DESCRIPTION
You can already do both `from:@handle` and `from:handle`, but previously `from:me` only worked without the @ sign.

This would be useful because Discord only supports the `from:@me` syntax and it's annoying to have to remember and switch between the two...

Draft PR because this is completely untested.