### PR TITLE
Adding check for duplicated muted word

### DIFF
--- a/src/components/dialogs/MutedWords.tsx
+++ b/src/components/dialogs/MutedWords.tsx
@@ -61,6 +61,12 @@ function MutedWordsInner() {
   const [durations, setDurations] = React.useState(['forever'])
   const [excludeFollowing, setExcludeFollowing] = React.useState(false)
 
+  const isDuplicated = (value: string) => Boolean(
+    (preferences?.moderationPrefs.mutedWords?.find(
+      m => m.value === value,
+    )
+  ))
+
   const submit = React.useCallback(async () => {
     const sanitizedValue = sanitizeMutedWordValue(field)
     const surfaces = ['tag', targets.includes('content') && 'content'].filter(
@@ -84,6 +90,12 @@ function MutedWordsInner() {
     if (!sanitizedValue || !surfaces.length) {
       setField('')
       setError(_(msg`Please enter a valid word, tag, or phrase to mute`))
+      return
+    }
+
+    if (isDuplicated(sanitizedValue)) {
+      setField('')
+      setError(_(msg`This word has already been muted`))
       return
     }
 

--- a/src/components/dialogs/MutedWords.tsx
+++ b/src/components/dialogs/MutedWords.tsx
@@ -45,6 +45,12 @@ export function MutedWordsDialog() {
   )
 }
 
+type MutedWordsWarning = {
+  message: string
+  shouldShow: boolean
+  isNegative?: boolean
+}
+
 function MutedWordsInner() {
   const t = useTheme()
   const {_} = useLingui()
@@ -57,7 +63,11 @@ function MutedWordsInner() {
   const {isPending, mutateAsync: addMutedWord} = useUpsertMutedWordsMutation()
   const [field, setField] = React.useState('')
   const [targets, setTargets] = React.useState(['content'])
-  const [error, setError] = React.useState('')
+  const [warning, setWarning] = React.useState<MutedWordsWarning>({
+    message: '',
+    shouldShow:  false,
+    isNegative: undefined,
+  })
   const [durations, setDurations] = React.useState(['forever'])
   const [excludeFollowing, setExcludeFollowing] = React.useState(false)
 
@@ -89,13 +99,21 @@ function MutedWordsInner() {
 
     if (!sanitizedValue || !surfaces.length) {
       setField('')
-      setError(_(msg`Please enter a valid word, tag, or phrase to mute`))
+      setWarning({
+        message: _(msg`Please select a valid duration and target`),
+        shouldShow: true,
+        isNegative: true,
+      });
       return
     }
 
     if (isDuplicated(sanitizedValue)) {
       setField('')
-      setError(_(msg`This word has already been muted`))
+      setWarning({
+        message: _(msg`This word has already been muted`),
+        shouldShow:  true,
+        isNegative: false,
+      });
       return
     }
 
@@ -112,7 +130,11 @@ function MutedWordsInner() {
       setField('')
     } catch (e: any) {
       logger.error(`Failed to save muted word`, {message: e.message})
-      setError(e.message)
+      setWarning({
+        message: e.message,
+        shouldShow: true,
+        isNegative: true,
+      });
     }
   }, [_, field, targets, addMutedWord, setField, durations, excludeFollowing])
 
@@ -140,8 +162,12 @@ function MutedWordsInner() {
             placeholder={_(msg`Enter a word or tag`)}
             value={field}
             onChangeText={value => {
-              if (error) {
-                setError('')
+              if (warning.message || warning.shouldShow) {
+                setWarning({
+                  message: '',
+                  shouldShow: false,
+                  isNegative: undefined,
+                });
               }
               setField(value)
             }}
@@ -343,7 +369,7 @@ function MutedWordsInner() {
             </Button>
           </View>
 
-          {error && (
+          { warning.shouldShow && (
             <View
               style={[
                 a.mb_lg,
@@ -353,7 +379,7 @@ function MutedWordsInner() {
                 a.mb_xs,
                 t.atoms.bg_contrast_25,
                 {
-                  backgroundColor: t.palette.negative_400,
+                  backgroundColor: warning.isNegative ? t.palette.negative_400 : t.palette.positive_200,
                 },
               ]}>
               <Text
@@ -362,7 +388,7 @@ function MutedWordsInner() {
                   {color: t.palette.white},
                   native({marginTop: 2}),
                 ]}>
-                {error}
+                {warning.message}
               </Text>
             </View>
           )}

--- a/src/locale/locales/an/messages.po
+++ b/src/locale/locales/an/messages.po
@@ -7195,6 +7195,10 @@ msgstr "Esto eliminará @{0} d'a lista d'acceso rapido."
 msgid "This will remove your post from this quote post for all users, and replace it with a placeholder."
 msgstr "Esto eliminará la tuya publicación d'esta cita pa toz los usuarios y la reemplazará con un marcador de posición."
 
+#: src/components/dialogs/MutedWords.tsx:98
+msgid "This word has already been muted"
+msgstr ""
+
 #: src/view/com/post-thread/PostThread.tsx:606
 #: src/view/com/post-thread/PostThread.tsx:609
 msgid "Thread options"

--- a/src/locale/locales/ast/messages.po
+++ b/src/locale/locales/ast/messages.po
@@ -7671,6 +7671,10 @@ msgstr ""
 msgid "This will remove your post from this quote post for all users, and replace it with a placeholder."
 msgstr "Esta aición va quitar la publicación d'esta cita pa tolos usuarios y va sustituyila con un espaciu acutáu."
 
+#: src/components/dialogs/MutedWords.tsx:98
+msgid "This word has already been muted"
+msgstr ""
+
 #: src/view/com/post-thread/PostThread.tsx:606
 #: src/view/com/post-thread/PostThread.tsx:609
 msgid "Thread options"

--- a/src/locale/locales/ca/messages.po
+++ b/src/locale/locales/ca/messages.po
@@ -9324,6 +9324,10 @@ msgstr "Això eliminarà @{0} de la llista d'accés ràpid."
 msgid "This will remove your post from this quote post for all users, and replace it with a placeholder."
 msgstr "Això eliminarà la teva publicació d'aquesta citació per a tots els usuaris i la substituirà per un marcador de posició."
 
+#: src/components/dialogs/MutedWords.tsx:98
+msgid "This word has already been muted"
+msgstr ""
+
 #: src/view/com/post-thread/PostThread.tsx:606
 #: src/view/com/post-thread/PostThread.tsx:609
 msgid "Thread options"

--- a/src/locale/locales/de/messages.po
+++ b/src/locale/locales/de/messages.po
@@ -8614,6 +8614,10 @@ msgstr ""
 msgid "This will remove your post from this quote post for all users, and replace it with a placeholder."
 msgstr ""
 
+#: src/components/dialogs/MutedWords.tsx:98
+msgid "This word has already been muted"
+msgstr ""
+
 #: src/view/com/post-thread/PostThread.tsx:606
 #: src/view/com/post-thread/PostThread.tsx:609
 msgid "Thread options"

--- a/src/locale/locales/de/messages.po
+++ b/src/locale/locales/de/messages.po
@@ -8616,7 +8616,7 @@ msgstr ""
 
 #: src/components/dialogs/MutedWords.tsx:98
 msgid "This word has already been muted"
-msgstr ""
+msgstr "Dieses Wort wurde bereits stummgeschaltet"
 
 #: src/view/com/post-thread/PostThread.tsx:606
 #: src/view/com/post-thread/PostThread.tsx:609

--- a/src/locale/locales/el/messages.po
+++ b/src/locale/locales/el/messages.po
@@ -7208,6 +7208,10 @@ msgstr "Αυτό θα αφαιρέσει τον @{0} από τη λίστα γρ
 msgid "This will remove your post from this quote post for all users, and replace it with a placeholder."
 msgstr ""
 
+#: src/components/dialogs/MutedWords.tsx:98
+msgid "This word has already been muted"
+msgstr ""
+
 #: src/view/com/post-thread/PostThread.tsx:606
 #: src/view/com/post-thread/PostThread.tsx:609
 msgid "Thread options"

--- a/src/locale/locales/en-GB/messages.po
+++ b/src/locale/locales/en-GB/messages.po
@@ -7671,6 +7671,10 @@ msgstr ""
 msgid "This will remove your post from this quote post for all users, and replace it with a placeholder."
 msgstr ""
 
+#: src/components/dialogs/MutedWords.tsx:98
+msgid "This word has already been muted"
+msgstr ""
+
 #: src/view/com/post-thread/PostThread.tsx:606
 #: src/view/com/post-thread/PostThread.tsx:609
 msgid "Thread options"

--- a/src/locale/locales/en/messages.po
+++ b/src/locale/locales/en/messages.po
@@ -7671,6 +7671,10 @@ msgstr ""
 msgid "This will remove your post from this quote post for all users, and replace it with a placeholder."
 msgstr ""
 
+#: src/components/dialogs/MutedWords.tsx:98
+msgid "This word has already been muted"
+msgstr ""
+
 #: src/view/com/post-thread/PostThread.tsx:606
 #: src/view/com/post-thread/PostThread.tsx:609
 msgid "Thread options"

--- a/src/locale/locales/es/messages.po
+++ b/src/locale/locales/es/messages.po
@@ -8521,6 +8521,10 @@ msgstr "Esto eliminará @{0} de la lista de acceso rápido."
 msgid "This will remove your post from this quote post for all users, and replace it with a placeholder."
 msgstr "Esto eliminará tu publicación de esta cita para todos los usuarios y la reemplazará con un marcador de posición."
 
+#: src/components/dialogs/MutedWords.tsx:98
+msgid "This word has already been muted"
+msgstr ""
+
 #: src/view/com/post-thread/PostThread.tsx:606
 #: src/view/com/post-thread/PostThread.tsx:609
 msgid "Thread options"

--- a/src/locale/locales/fi/messages.po
+++ b/src/locale/locales/fi/messages.po
@@ -7056,6 +7056,10 @@ msgstr "Tämä poistaa tilin @{0} pikakäyttöluettelosta."
 msgid "This will remove your post from this quote post for all users, and replace it with a placeholder."
 msgstr "Tämä poistaa julkaisusi tästä lainausjulkaisusta kaikilta käyttäjiltä ja korvaa sen paikkamerkillä."
 
+#: src/components/dialogs/MutedWords.tsx:98
+msgid "This word has already been muted"
+msgstr ""
+
 #: src/view/com/post-thread/PostThread.tsx:606
 #: src/view/com/post-thread/PostThread.tsx:609
 msgid "Thread options"

--- a/src/locale/locales/fr/messages.po
+++ b/src/locale/locales/fr/messages.po
@@ -7056,6 +7056,10 @@ msgstr "Cela supprimera @{0} de la liste d’accès rapide."
 msgid "This will remove your post from this quote post for all users, and replace it with a placeholder."
 msgstr "Cela retirera votre post de cette citation pour tout le monde, et le remplacera par un espace vide."
 
+#: src/components/dialogs/MutedWords.tsx:98
+msgid "This word has already been muted"
+msgstr ""
+
 #: src/view/com/post-thread/PostThread.tsx:606
 #: src/view/com/post-thread/PostThread.tsx:609
 msgid "Thread options"

--- a/src/locale/locales/ga/messages.po
+++ b/src/locale/locales/ga/messages.po
@@ -7670,6 +7670,10 @@ msgstr "Leis seo, bainfear @{0} den mhearliosta."
 msgid "This will remove your post from this quote post for all users, and replace it with a placeholder."
 msgstr "Leis seo, bainfear do phostáil seo den phostáil athluaite seo do gach úsáideoir, agus cuirfear ionadchoinneálaí ina háit."
 
+#: src/components/dialogs/MutedWords.tsx:98
+msgid "This word has already been muted"
+msgstr ""
+
 #: src/view/com/post-thread/PostThread.tsx:606
 #: src/view/com/post-thread/PostThread.tsx:609
 msgid "Thread options"

--- a/src/locale/locales/gl/messages.po
+++ b/src/locale/locales/gl/messages.po
@@ -8526,6 +8526,10 @@ msgstr "Isto eliminará @{0} da listaxe de acceso rápido."
 msgid "This will remove your post from this quote post for all users, and replace it with a placeholder."
 msgstr "Esto eliminará o teu chío desta cita para todas as persoas e substituirase por un marcador de posición."
 
+#: src/components/dialogs/MutedWords.tsx:98
+msgid "This word has already been muted"
+msgstr ""
+
 #: src/view/com/post-thread/PostThread.tsx:606
 #: src/view/com/post-thread/PostThread.tsx:609
 msgid "Thread options"

--- a/src/locale/locales/hi/messages.po
+++ b/src/locale/locales/hi/messages.po
@@ -8102,6 +8102,10 @@ msgstr "यह @{0} को जल्द पहुँच सूची से ह�
 msgid "This will remove your post from this quote post for all users, and replace it with a placeholder."
 msgstr "यह आपके पोस्ट को इस क्वोट पोस्ट से सभी उपयोगकर्ताओं के लिए हटा देगा, और उसके बदले एक स्थानधारक छोड़ देगा।"
 
+#: src/components/dialogs/MutedWords.tsx:98
+msgid "This word has already been muted"
+msgstr ""
+
 #: src/view/com/post-thread/PostThread.tsx:606
 #: src/view/com/post-thread/PostThread.tsx:609
 msgid "Thread options"

--- a/src/locale/locales/hu/messages.po
+++ b/src/locale/locales/hu/messages.po
@@ -7541,6 +7541,10 @@ msgstr "Ezzel @{0} el lesz távolítva a fióklistáról."
 msgid "This will remove your post from this quote post for all users, and replace it with a placeholder."
 msgstr "Ezzel el fogod távolítani a bejegyzést az idézésből mindenki számára, ami egy helyőrzővel lesz helyettesítve."
 
+#: src/components/dialogs/MutedWords.tsx:98
+msgid "This word has already been muted"
+msgstr ""
+
 #: src/view/com/post-thread/PostThread.tsx:606
 #: src/view/com/post-thread/PostThread.tsx:609
 msgid "Thread options"

--- a/src/locale/locales/id/messages.po
+++ b/src/locale/locales/id/messages.po
@@ -8673,6 +8673,10 @@ msgstr "Ini akan menghapus @{0} dari daftar akses cepat."
 msgid "This will remove your post from this quote post for all users, and replace it with a placeholder."
 msgstr "Ini akan menghapus postingan Anda dari kutipan ini untuk semua pengguna, dan menempatkan teks pengganti."
 
+#: src/components/dialogs/MutedWords.tsx:98
+msgid "This word has already been muted"
+msgstr ""
+
 #: src/view/com/post-thread/PostThread.tsx:606
 #: src/view/com/post-thread/PostThread.tsx:609
 msgid "Thread options"

--- a/src/locale/locales/it/messages.po
+++ b/src/locale/locales/it/messages.po
@@ -7062,6 +7062,10 @@ msgstr "Questo rimuoverà @{0} dalla lista d'accesso rapido."
 msgid "This will remove your post from this quote post for all users, and replace it with a placeholder."
 msgstr "Il tuo post verrà rimosso da questa citazione per tutti gli utenti, ed al suo posto verrà mostrato un avviso."
 
+#: src/components/dialogs/MutedWords.tsx:98
+msgid "This word has already been muted"
+msgstr ""
+
 #: src/view/com/post-thread/PostThread.tsx:606
 #: src/view/com/post-thread/PostThread.tsx:609
 msgid "Thread options"

--- a/src/locale/locales/ja/messages.po
+++ b/src/locale/locales/ja/messages.po
@@ -7056,6 +7056,10 @@ msgstr "クイックアクセスのリストから@{0}を削除します。"
 msgid "This will remove your post from this quote post for all users, and replace it with a placeholder."
 msgstr "これによってあなたの投稿が全員に見える引用投稿からは削除され、プレースホルダーに置き換えられます。"
 
+#: src/components/dialogs/MutedWords.tsx:98
+msgid "This word has already been muted"
+msgstr ""
+
 #: src/view/com/post-thread/PostThread.tsx:606
 #: src/view/com/post-thread/PostThread.tsx:609
 msgid "Thread options"

--- a/src/locale/locales/km/messages.po
+++ b/src/locale/locales/km/messages.po
@@ -7675,6 +7675,10 @@ msgstr "វានឹងដក @{0} ចេញពីបញ្ជីចូលប្
 msgid "This will remove your post from this quote post for all users, and replace it with a placeholder."
 msgstr "វានឹងលុបការបង្ហោះរបស់អ្នកចេញពីប្រកាសសម្រង់នេះសម្រាប់អ្នកប្រើប្រាស់ទាំងអស់ ហើយជំនួសវាដោយកន្លែងដាក់"
 
+#: src/components/dialogs/MutedWords.tsx:98
+msgid "This word has already been muted"
+msgstr ""
+
 #: src/view/com/post-thread/PostThread.tsx:606
 #: src/view/com/post-thread/PostThread.tsx:609
 msgid "Thread options"

--- a/src/locale/locales/ko/messages.po
+++ b/src/locale/locales/ko/messages.po
@@ -7056,6 +7056,10 @@ msgstr "빠른 액세스 목록에서 @{0}을(를) 제거합니다."
 msgid "This will remove your post from this quote post for all users, and replace it with a placeholder."
 msgstr "모든 사용자의 인용 게시물에서 해당 게시물이 삭제되고 자리 표시자로 대체됩니다."
 
+#: src/components/dialogs/MutedWords.tsx:98
+msgid "This word has already been muted"
+msgstr ""
+
 #: src/view/com/post-thread/PostThread.tsx:606
 #: src/view/com/post-thread/PostThread.tsx:609
 msgid "Thread options"

--- a/src/locale/locales/ne/messages.po
+++ b/src/locale/locales/ne/messages.po
@@ -8106,6 +8106,10 @@ msgstr "यसले @{0}लाई क्विक एक्सेस सूच�
 msgid "This will remove your post from this quote post for all users, and replace it with a placeholder."
 msgstr "यसले तपाईंको पोस्टलाई यो उद्धरण पोस्टबाट सबै प्रयोगकर्ताहरूको लागि हटाउनेछ र यसलाई एक स्थानधारक सँग प्रतिस्थापित गर्नेछ।"
 
+#: src/components/dialogs/MutedWords.tsx:98
+msgid "This word has already been muted"
+msgstr ""
+
 #: src/view/com/post-thread/PostThread.tsx:606
 #: src/view/com/post-thread/PostThread.tsx:609
 msgid "Thread options"

--- a/src/locale/locales/nl/messages.po
+++ b/src/locale/locales/nl/messages.po
@@ -7195,6 +7195,10 @@ msgstr "Hiermee wordt @{0} verwijderd uit de snelle toegangslijst."
 msgid "This will remove your post from this quote post for all users, and replace it with a placeholder."
 msgstr "Hiermee wordt je bericht voor alle gebruikers uit het citaat verwijderd en vervangen door een plaatshouder."
 
+#: src/components/dialogs/MutedWords.tsx:98
+msgid "This word has already been muted"
+msgstr ""
+
 #: src/view/com/post-thread/PostThread.tsx:606
 #: src/view/com/post-thread/PostThread.tsx:609
 msgid "Thread options"

--- a/src/locale/locales/pl/messages.po
+++ b/src/locale/locales/pl/messages.po
@@ -7215,6 +7215,10 @@ msgstr "Spowoduje to usunięcie @{0} z listy szybkiego dostępu."
 msgid "This will remove your post from this quote post for all users, and replace it with a placeholder."
 msgstr "Spowoduje to usunięcie Twojego wpisu z tego cytatu dla wszystkich i zastąpi go placeholderem."
 
+#: src/components/dialogs/MutedWords.tsx:98
+msgid "This word has already been muted"
+msgstr ""
+
 #: src/view/com/post-thread/PostThread.tsx:606
 #: src/view/com/post-thread/PostThread.tsx:609
 msgid "Thread options"

--- a/src/locale/locales/pt-BR/messages.po
+++ b/src/locale/locales/pt-BR/messages.po
@@ -8659,7 +8659,7 @@ msgstr "Isso removerá sua postagem desta postagem de citação para todos os us
 
 #: src/components/dialogs/MutedWords.tsx:98
 msgid "This word has already been muted"
-msgstr ""
+msgstr "Essa palavra já foi silenciada"
 
 #: src/view/com/post-thread/PostThread.tsx:606
 #: src/view/com/post-thread/PostThread.tsx:609

--- a/src/locale/locales/pt-BR/messages.po
+++ b/src/locale/locales/pt-BR/messages.po
@@ -8657,6 +8657,10 @@ msgstr "Isso removerá @{0} da lista de acesso rápido."
 msgid "This will remove your post from this quote post for all users, and replace it with a placeholder."
 msgstr "Isso removerá sua postagem desta postagem de citação para todos os usuários e a substituirá por um espaço reservado."
 
+#: src/components/dialogs/MutedWords.tsx:98
+msgid "This word has already been muted"
+msgstr ""
+
 #: src/view/com/post-thread/PostThread.tsx:606
 #: src/view/com/post-thread/PostThread.tsx:609
 msgid "Thread options"

--- a/src/locale/locales/ro/messages.po
+++ b/src/locale/locales/ro/messages.po
@@ -7675,6 +7675,10 @@ msgstr "Aceasta va elimina @{0} din lista de acces rapid."
 msgid "This will remove your post from this quote post for all users, and replace it with a placeholder."
 msgstr "Aceasta va elimina postarea ta din acestă citare pentru toți utilizatorii și o va înlocui cu un substitut."
 
+#: src/components/dialogs/MutedWords.tsx:98
+msgid "This word has already been muted"
+msgstr ""
+
 #: src/view/com/post-thread/PostThread.tsx:606
 #: src/view/com/post-thread/PostThread.tsx:609
 msgid "Thread options"

--- a/src/locale/locales/ru/messages.po
+++ b/src/locale/locales/ru/messages.po
@@ -7096,6 +7096,10 @@ msgstr "Это удалит @{0} из списка быстрого доступ
 msgid "This will remove your post from this quote post for all users, and replace it with a placeholder."
 msgstr "Это удалит ваш пост из этой цитаты для всех пользователей, и заменит его на заглушку."
 
+#: src/components/dialogs/MutedWords.tsx:98
+msgid "This word has already been muted"
+msgstr ""
+
 #: src/view/com/post-thread/PostThread.tsx:606
 #: src/view/com/post-thread/PostThread.tsx:609
 msgid "Thread options"

--- a/src/locale/locales/th/messages.po
+++ b/src/locale/locales/th/messages.po
@@ -8660,6 +8660,10 @@ msgstr "นี่จะลบ @{0} ออกจากลิสต์เข้า
 msgid "This will remove your post from this quote post for all users, and replace it with a placeholder."
 msgstr "นี่จะลบโพสต์ของคุณออกจากโพสต์อ้างอิงนี้สำหรับผู้ใช้ทุกคน และแทนที่ด้วยข้อความแทน"
 
+#: src/components/dialogs/MutedWords.tsx:98
+msgid "This word has already been muted"
+msgstr ""
+
 #: src/view/com/post-thread/PostThread.tsx:606
 #: src/view/com/post-thread/PostThread.tsx:609
 msgid "Thread options"

--- a/src/locale/locales/tr/messages.po
+++ b/src/locale/locales/tr/messages.po
@@ -9147,6 +9147,10 @@ msgstr ""
 msgid "This will remove your post from this quote post for all users, and replace it with a placeholder."
 msgstr ""
 
+#: src/components/dialogs/MutedWords.tsx:98
+msgid "This word has already been muted"
+msgstr ""
+
 #: src/view/com/post-thread/PostThread.tsx:606
 #: src/view/com/post-thread/PostThread.tsx:609
 msgid "Thread options"

--- a/src/locale/locales/uk/messages.po
+++ b/src/locale/locales/uk/messages.po
@@ -8673,6 +8673,10 @@ msgstr ""
 msgid "This will remove your post from this quote post for all users, and replace it with a placeholder."
 msgstr ""
 
+#: src/components/dialogs/MutedWords.tsx:98
+msgid "This word has already been muted"
+msgstr ""
+
 #: src/view/com/post-thread/PostThread.tsx:606
 #: src/view/com/post-thread/PostThread.tsx:609
 msgid "Thread options"

--- a/src/locale/locales/vi/messages.po
+++ b/src/locale/locales/vi/messages.po
@@ -7187,6 +7187,10 @@ msgstr "Tác vụ này sẽ xóa @{0} khỏi danh sách truy cập nhanh."
 msgid "This will remove your post from this quote post for all users, and replace it with a placeholder."
 msgstr "Tác vụ này sẽ xóa bài đăng của bạn khỏi bài đăng trích dẫn này cho tất cả người dùng, và thay thế nó bằng một chỗ trống."
 
+#: src/components/dialogs/MutedWords.tsx:98
+msgid "This word has already been muted"
+msgstr ""
+
 #: src/view/com/post-thread/PostThread.tsx:606
 #: src/view/com/post-thread/PostThread.tsx:609
 msgid "Thread options"

--- a/src/locale/locales/zh-CN/messages.po
+++ b/src/locale/locales/zh-CN/messages.po
@@ -7061,6 +7061,10 @@ msgstr "这将从你的快速访问中移除 @{0}。"
 msgid "This will remove your post from this quote post for all users, and replace it with a placeholder."
 msgstr "你的帖文将从这则引用中删除，并替换为一个占位符。"
 
+#: src/components/dialogs/MutedWords.tsx:98
+msgid "This word has already been muted"
+msgstr ""
+
 #: src/view/com/post-thread/PostThread.tsx:606
 #: src/view/com/post-thread/PostThread.tsx:609
 msgid "Thread options"

--- a/src/locale/locales/zh-HK/messages.po
+++ b/src/locale/locales/zh-HK/messages.po
@@ -7063,6 +7063,10 @@ msgstr "噉樣會喺快速存取清單入邊移除 @{0}。"
 msgid "This will remove your post from this quote post for all users, and replace it with a placeholder."
 msgstr "你嘅帖文會喺呢篇引用嘅帖文入邊刪除，兼且將佢換成一個佔位標記。"
 
+#: src/components/dialogs/MutedWords.tsx:98
+msgid "This word has already been muted"
+msgstr ""
+
 #: src/view/com/post-thread/PostThread.tsx:606
 #: src/view/com/post-thread/PostThread.tsx:609
 msgid "Thread options"

--- a/src/locale/locales/zh-TW/messages.po
+++ b/src/locale/locales/zh-TW/messages.po
@@ -7061,6 +7061,10 @@ msgstr "這將從快速存取列表中移除 @{0}。"
 msgid "This will remove your post from this quote post for all users, and replace it with a placeholder."
 msgstr "您的貼文將從這則引用貼文中刪除，並取代為一個佔位標記。"
 
+#: src/components/dialogs/MutedWords.tsx:98
+msgid "This word has already been muted"
+msgstr ""
+
 #: src/view/com/post-thread/PostThread.tsx:606
 #: src/view/com/post-thread/PostThread.tsx:609
 msgid "Thread options"


### PR DESCRIPTION
Closes #7472 

1. Added a check to detect if the word already exists in the array of muted words. If yes, show an error message and do not save
2. Added a new translatable string for this specific scenario
3. Added translations in German and brazilian Portuguese

### Screen recording

https://github.com/user-attachments/assets/f751265a-61ec-4693-bb1d-5c5a3ada1e7f




