### PR TITLE
Optimize compressImage method to also use binary search

### DIFF
--- a/src/lib/media/manip.web.ts
+++ b/src/lib/media/manip.web.ts
@@ -72,17 +72,28 @@ interface DoResizeOpts {
 async function doResize(dataUri: string, opts: DoResizeOpts): Promise<RNImage> {
   let newDataUri
 
-  for (let i = 0; i <= 10; i++) {
-    newDataUri = await createResizedImage(dataUri, {
+  let minQualityPercentage = 0
+  let maxQualityPercentage = 101 //exclusive
+
+  while (maxQualityPercentage - minQualityPercentage > 1) {
+    const qualityPercentage = Math.round(
+      (maxQualityPercentage + minQualityPercentage) / 2,
+    )
+    const tempDataUri = await createResizedImage(dataUri, {
       width: opts.width,
       height: opts.height,
-      quality: 1 - i * 0.1,
+      quality: qualityPercentage / 100,
       mode: opts.mode,
     })
-    if (getDataUriSize(newDataUri) < opts.maxSize) {
-      break
+
+    if (getDataUriSize(tempDataUri) < opts.maxSize) {
+      minQualityPercentage = qualityPercentage
+      newDataUri = tempDataUri
+    } else {
+      maxQualityPercentage = qualityPercentage
     }
   }
+
   if (!newDataUri) {
     throw new Error('Failed to compress image')
   }

--- a/src/state/gallery.ts
+++ b/src/state/gallery.ts
@@ -13,7 +13,7 @@ import {
 import {nanoid} from 'nanoid/non-secure'
 
 import {POST_IMG_MAX} from '#/lib/constants'
-import {getImageDim} from '#/lib/media/manip'
+import {getImageDim, safeDeleteAsync} from '#/lib/media/manip'
 import {openCropper} from '#/lib/media/picker'
 import {getDataUriSize} from '#/lib/media/util'
 import {isIOS, isNative} from '#/platform/detection'
@@ -244,7 +244,7 @@ export async function compressImage(img: ComposerImage): Promise<ImageMeta> {
     } else {
       maxQualityPercentage = qualityPercentage
       if (cacheDir) {
-        await deleteAsync(res.uri)
+        await safeDeleteAsync(res.uri)
       }
     }
   }

--- a/src/state/gallery.ts
+++ b/src/state/gallery.ts
@@ -212,15 +212,20 @@ export async function compressImage(img: ComposerImage): Promise<ImageMeta> {
   const [w, h] = containImageRes(source.width, source.height, POST_IMG_MAX)
   const cacheDir = isNative && getImageCacheDirectory()
 
-  for (let i = 10; i > 0; i--) {
-    // Float precision
-    const factor = i / 10
+  let minQualityPercentage = 0
+  let maxQualityPercentage = 101 // exclusive
+  let newDataUri
+
+  while (maxQualityPercentage - minQualityPercentage > 1) {
+    const qualityPercentage = Math.round(
+      (maxQualityPercentage + minQualityPercentage) / 2,
+    )
 
     const res = await manipulateAsync(
       source.path,
       [{resize: {width: w, height: h}}],
       {
-        compress: factor,
+        compress: qualityPercentage / 100,
         format: SaveFormat.JPEG,
         base64: true,
       },
@@ -229,17 +234,23 @@ export async function compressImage(img: ComposerImage): Promise<ImageMeta> {
     const base64 = res.base64
 
     if (base64 !== undefined && getDataUriSize(base64) <= POST_IMG_MAX.size) {
-      return {
+      minQualityPercentage = qualityPercentage
+      newDataUri = {
         path: await moveIfNecessary(res.uri),
         width: res.width,
         height: res.height,
         mime: 'image/jpeg',
       }
+    } else {
+      maxQualityPercentage = qualityPercentage
+      if (cacheDir) {
+        await deleteAsync(res.uri)
+      }
     }
+  }
 
-    if (cacheDir) {
-      await deleteAsync(res.uri)
-    }
+  if (newDataUri) {
+    return newDataUri
   }
 
   throw new Error(`Unable to compress image`)


### PR DESCRIPTION
I've been waiting for https://github.com/bluesky-social/social-app/pull/6137 to get merged for a while, but it seems to have stagnated after the contributor was asked to apply the same optimization to `src/state/gallery` back in November.

This PR simply implements the same binary search optimization to the compressImage method in gallery.ts as well.