### PR TITLE
Update messages.po

### DIFF
--- a/src/locale/locales/fi/messages.po
+++ b/src/locale/locales/fi/messages.po
@@ -4549,7 +4549,7 @@ msgstr "Hups!"
 
 #: src/screens/Onboarding/StepFinished.tsx:260
 msgid "Open"
-msgstr "Avaa"
+msgstr "Avoin"
 
 #: src/view/com/posts/AviFollowButton.tsx:86
 msgid "Open {name} profile shortcut menu"


### PR DESCRIPTION
Changed StepFinished "Avaa" to "Avoin": the StepFinished screen is using Open as an adjective and not as a verb like the Finnish version currently does.