### PR TITLE
Fix Discover posts showing up in Following with no explanation

### DIFF
--- a/src/view/com/posts/PostFeed.tsx
+++ b/src/view/com/posts/PostFeed.tsx
@@ -75,9 +75,8 @@ type FeedRow =
       key: string
     }
   | {
-      type: 'slice' // TODO can we remove?
+      type: 'fallbackMarker'
       key: string
-      slice: FeedPostSlice
     }
   | {
       type: 'sliceItem'
@@ -425,7 +424,13 @@ let PostFeed = ({
                 }
               }
 
-              if (slice.isIncompleteThread && slice.items.length >= 3) {
+              if (slice.isFallbackMarker) {
+                arr.push({
+                  type: 'fallbackMarker',
+                  key:
+                    'sliceFallbackMarker-' + sliceIndex + '-' + lastFetchedAt,
+                })
+              } else if (slice.isIncompleteThread && slice.items.length >= 3) {
                 const beforeLast = slice.items.length - 2
                 const last = slice.items.length - 1
                 arr.push({
@@ -599,15 +604,14 @@ let PostFeed = ({
         return <TrendingInterstitial />
       } else if (row.type === 'interstitialTrendingVideos') {
         return <TrendingVideosInterstitial />
+      } else if (row.type === 'fallbackMarker') {
+        // HACK
+        // tell the user we fell back to discover
+        // see home.ts (feed api) for more info
+        // -prf
+        return <DiscoverFallbackHeader />
       } else if (row.type === 'sliceItem') {
         const slice = row.slice
-        if (slice.isFallbackMarker) {
-          // HACK
-          // tell the user we fell back to discover
-          // see home.ts (feed api) for more info
-          // -prf
-          return <DiscoverFallbackHeader />
-        }
         const indexInSlice = row.indexInSlice
         const item = slice.items[indexInSlice]
         return (


### PR DESCRIPTION
When we run out of posts in Following, we fall back to showing posts from Discover.

This shouldn't generally happen unless you run out of posts from your follows. However, a few days ago we had a backend migration that caused the timelines to restart. So we were falling back into this mode even for who folks who follow people.

Unfortunately the conditions that caused the UI to show up got lost with one of the refactors so they were showing up without explanation. This restores the explanation.

## Test Plan

<img width="382" alt="Screenshot 2025-01-20 at 01 58 52" src="https://github.com/user-attachments/assets/a1f66649-4876-407e-938f-06692bd786a4" />

<img width="398" alt="Screenshot 2025-01-20 at 02 03 20" src="https://github.com/user-attachments/assets/5043be12-5a05-46c2-896f-179dd0ec85a8" />

<img width="1225" alt="Screenshot 2025-01-20 at 01 59 41" src="https://github.com/user-attachments/assets/5c81a2ed-5313-4561-8f9b-7cb7e97ab9bb" />
