### PR TITLE
Update Russian phrase

### DIFF
--- a/src/locale/locales/ru/messages.po
+++ b/src/locale/locales/ru/messages.po
@@ -8062,7 +8062,7 @@ msgstr "Вы включили игнорирование этого пользо
 
 #: src/screens/Messages/ChatList.tsx:190
 msgid "You have no conversations yet. Start one!"
-msgstr "У вас ещё нет бесед. Начните одну!"
+msgstr "У вас ещё нет бесед. Создайте первую!"
 
 #: src/view/com/feeds/ProfileFeedgens.tsx:143
 msgid "You have no feeds."


### PR DESCRIPTION
Problem:

Phrase "Начните одну!" is a word-by-word translation of "Start one!" which is not something that we usually say in Russian language, it _doesn't sound right_.

Solution:

A more appropriate ways to translate it would be:
1. Создайте первую!
2. Начните новую!
3. Создайте новую!