### PR TITLE
feat: adds sponsored post UI

### DIFF
--- a/src/view/com/posts/PostFeed.tsx
+++ b/src/view/com/posts/PostFeed.tsx
@@ -9,7 +9,11 @@ import {
   View,
   ViewStyle,
 } from 'react-native'
-import {AppBskyActorDefs, AppBskyEmbedVideo} from '@atproto/api'
+import {
+  AppBskyActorDefs,
+  AppBskyEmbedVideo,
+  AppBskyFeedDefs,
+} from '@atproto/api'
 import {msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 import {useQueryClient} from '@tanstack/react-query'
@@ -618,7 +622,13 @@ let PostFeed = ({
           <PostFeedItem
             post={item.post}
             record={item.record}
-            reason={indexInSlice === 0 ? slice.reason : undefined}
+            reason={
+              (indexInSlice === 0 &&
+                AppBskyFeedDefs.isReasonPin(slice.reason)) ||
+              AppBskyFeedDefs.isReasonSponsored(slice.reason)
+                ? slice.reason
+                : undefined
+            }
             feedContext={slice.feedContext}
             moderation={item.moderation}
             parentAuthor={item.parentAuthor}

--- a/src/view/com/posts/PostFeed.tsx
+++ b/src/view/com/posts/PostFeed.tsx
@@ -625,7 +625,7 @@ let PostFeed = ({
             reason={
               (indexInSlice === 0 &&
                 AppBskyFeedDefs.isReasonPin(slice.reason)) ||
-              AppBskyFeedDefs.isReasonSponsored(slice.reason)
+              AppBskyFeedDefs.isReasonPromoted(slice.reason)
                 ? slice.reason
                 : undefined
             }

--- a/src/view/com/posts/PostFeedItem.tsx
+++ b/src/view/com/posts/PostFeedItem.tsx
@@ -56,7 +56,7 @@ interface FeedItemProps {
   reason:
     | AppBskyFeedDefs.ReasonRepost
     | AppBskyFeedDefs.ReasonPin
-    | AppBskyFeedDefs.ReasonSponsored
+    | AppBskyFeedDefs.ReasonPromoted
     | ReasonFeedSource
     | {[k: string]: unknown; $type: string}
     | undefined
@@ -230,7 +230,7 @@ let FeedItemInner = ({
     AppBskyFeedDefs.isReasonRepost(reason) &&
     reason.by.did === currentAccount?.did
 
-  const isSponsored = AppBskyFeedDefs.isReasonSponsored(reason)
+  const isPromoted = AppBskyFeedDefs.isReasonPromoted(reason)
 
   /**
    * If `post[0]` in this slice is the actual root post (not an orphan thread),
@@ -367,7 +367,7 @@ let FeedItemInner = ({
                 <Trans>Pinned</Trans>
               </Text>
             </View>
-          ) : AppBskyFeedDefs.isReasonSponsored(reason) ? (
+          ) : AppBskyFeedDefs.isReasonPromoted(reason) ? (
             <View style={styles.includeReason}>
               <SponsoredIcon
                 style={{color: pal.colors.textLight, marginRight: 3}}
@@ -379,7 +379,59 @@ let FeedItemInner = ({
                 style={pal.textLight}
                 lineHeight={1.2}
                 numberOfLines={1}>
-                <Trans>Sponsored</Trans>
+                {isOwner ? (
+                  <Trans>
+                    Promoted by you on
+                    <FeedNameText
+                      type="sm-bold"
+                      uri={reason.on}
+                      href={
+                        reason.href /* Not sure if this is right or how to provide this value */
+                      }
+                      lineHeight={1.2}
+                      numberOfLines={1}
+                      style={pal.textLight}
+                    />
+                  </Trans>
+                ) : (
+                  <Trans>
+                    Promoted by{' '}
+                    <ProfileHoverCard inline did={reason.by.did}>
+                      <TextLinkOnWebOnly
+                        type="sm-bold"
+                        style={pal.textLight}
+                        lineHeight={1.2}
+                        numberOfLines={1}
+                        text={
+                          <Text
+                            emoji
+                            type="sm-bold"
+                            style={pal.textLight}
+                            lineHeight={1.2}>
+                            {sanitizeDisplayName(
+                              reason.by.displayName ||
+                                sanitizeHandle(reason.by.handle),
+                              moderation.ui('displayName'),
+                            )}
+                          </Text>
+                        }
+                        href={makeProfileLink(reason.by)}
+                        onBeforePress={onOpenReposter}
+                      />
+                    </ProfileHoverCard>
+                    {' on '}
+                    <FeedNameText
+                      type="sm-bold"
+                      uri={reason.uri}
+                      href={
+                        reason.href /* Not sure if this is right or how to provide this value */
+                      }
+                      lineHeight={1.2}
+                      numberOfLines={1}
+                      style={pal.textLight}
+                    />
+                  </Trans>
+                )}
               </Text>
             </View>
           ) : null}

--- a/src/view/com/posts/PostFeedItem.tsx
+++ b/src/view/com/posts/PostFeedItem.tsx
@@ -39,6 +39,7 @@ import {Text} from '#/view/com/util/text/Text'
 import {PreviewableUserAvatar} from '#/view/com/util/UserAvatar'
 import {atoms as a} from '#/alf'
 import {Pin_Stroke2_Corner0_Rounded as PinIcon} from '#/components/icons/Pin'
+import {Zap_Stroke2_Corner0_Rounded as SponsoredIcon} from '#/components/icons/Zap'
 import {Repost_Stroke2_Corner2_Rounded as RepostIcon} from '#/components/icons/Repost'
 import {ContentHider} from '#/components/moderation/ContentHider'
 import {LabelsOnMyPost} from '#/components/moderation/LabelsOnMe'
@@ -55,6 +56,7 @@ interface FeedItemProps {
   reason:
     | AppBskyFeedDefs.ReasonRepost
     | AppBskyFeedDefs.ReasonPin
+    | AppBskyFeedDefs.ReasonSponsored
     | ReasonFeedSource
     | {[k: string]: unknown; $type: string}
     | undefined
@@ -228,6 +230,8 @@ let FeedItemInner = ({
     AppBskyFeedDefs.isReasonRepost(reason) &&
     reason.by.did === currentAccount?.did
 
+  const isSponsored = AppBskyFeedDefs.isReasonSponsored(reason)
+
   /**
    * If `post[0]` in this slice is the actual root post (not an orphan thread),
    * then we may have a threadgate record to reference
@@ -361,6 +365,21 @@ let FeedItemInner = ({
                 lineHeight={1.2}
                 numberOfLines={1}>
                 <Trans>Pinned</Trans>
+              </Text>
+            </View>
+          ) : AppBskyFeedDefs.isReasonSponsored(reason) ? (
+            <View style={styles.includeReason}>
+              <SponsoredIcon
+                style={{color: pal.colors.textLight, marginRight: 3}}
+                width={13}
+                height={13}
+              />
+              <Text
+                type="sm-bold"
+                style={pal.textLight}
+                lineHeight={1.2}
+                numberOfLines={1}>
+                <Trans>Sponsored</Trans>
               </Text>
             </View>
           ) : null}


### PR DESCRIPTION
I haven't been able to test this at all because I can't get Yarn to install and also because it's reliant on bluesky-social/atproto#3419. If someone could review this with that in mind I'd be most appreciative, it's not a particularly complex PR once the lexicon change gets merged. 🙏 

This adds a "⚡ Sponsored" label to any post that has the forthcoming `app.bsky.graph.defs#skeletonReasonSponsored` reason attached to the post. I have chosen the icon and text completely arbitrarily; I have also not provided translations because I don't know how you're generating locales. It's possible another icon (possibly something like `ⓘ`) would be better.

Please see bluesky-social/atproto#3386 for the rationale for this request.