### PR TITLE
Fix bottom sheet styling in dark mode

### DIFF
--- a/src/view/com/modals/Modal.tsx
+++ b/src/view/com/modals/Modal.tsx
@@ -120,6 +120,7 @@ export function ModalsContainer() {
         }
         handleIndicatorStyle={{backgroundColor: pal.text.color}}
         handleStyle={[styles.handle, pal.view]}
+        backgroundStyle={pal.view}
         onChange={onBottomSheetChange}>
         {element}
       </BottomSheet>


### PR DESCRIPTION
Currently, some bottom sheets in the app use @discord/bottom-sheet. There is a visual bug where in dark mode, if you drag the handle, the background is white.

This fixes it by adding the `backgroundStyle` prop to the BottomSheet component and setting the background using that.


Before:
<video src="https://github.com/user-attachments/assets/db91aeed-1dac-487b-a306-56ac8e110d12" />

After:
<video src="https://github.com/user-attachments/assets/1b93fccc-8f00-45f9-84ea-f60a2232891b" />
