### PR TITLE
[Experiment] Add Video feed on signup

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -139,6 +139,11 @@ export const TIMELINE_SAVED_FEED = {
   value: 'following',
   pinned: true,
 }
+export const VIDEO_SAVED_FEED = {
+  type: 'feed',
+  value: VIDEO_FEED_URI,
+  pinned: true,
+}
 
 export const RECOMMENDED_SAVED_FEEDS: Pick<
   AppBskyActorDefs.SavedFeed,

--- a/src/lib/statsig/gates.ts
+++ b/src/lib/statsig/gates.ts
@@ -3,6 +3,7 @@ export type Gate =
   | 'debug_show_feedcontext'
   | 'debug_subscriptions'
   | 'new_postonboarding'
+  | 'onboarding_add_video_feed'
   | 'remove_show_latest_button'
   | 'test_gate_1'
   | 'test_gate_2'

--- a/src/screens/Onboarding/StepFinished.tsx
+++ b/src/screens/Onboarding/StepFinished.tsx
@@ -12,6 +12,7 @@ import {
   BSKY_APP_ACCOUNT_DID,
   DISCOVER_SAVED_FEED,
   TIMELINE_SAVED_FEED,
+  VIDEO_SAVED_FEED,
 } from '#/lib/constants'
 import {useRequestNotificationsPermission} from '#/lib/notifications/notifications'
 import {logEvent, useGate} from '#/lib/statsig/statsig'
@@ -111,6 +112,12 @@ export function StepFinished() {
               id: TID.nextStr(),
             },
           ]
+          if (gate('onboarding_add_video_feed')) {
+            feedsToSave.push({
+              ...VIDEO_SAVED_FEED,
+              id: TID.nextStr(),
+            })
+          }
 
           // Any starter pack feeds will be pinned _after_ the defaults
           if (starterPack && starterPack.feeds?.length) {


### PR DESCRIPTION
If you pass the gate, we'll add it as the third tab. If you don't, we won't.

## Test Plan

Create a few accounts. Verify that, if you're in the gate, you get this after signup:

<img width="364" alt="Screenshot 2025-01-21 at 20 17 23" src="https://github.com/user-attachments/assets/668e5a92-6e4b-4d13-b97d-8200f048d8b0" />

Ofc it can be removed later as usual.