### PR TITLE
make video posts which are quote posts show up in video feeds

### DIFF
--- a/src/components/VideoPostCard.tsx
+++ b/src/components/VideoPostCard.tsx
@@ -12,6 +12,7 @@ import {
 import {msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
+import {getVideoEmbed} from '#/lib/embeds'
 import {sanitizeHandle} from '#/lib/strings/handles'
 import {formatCount} from '#/view/com/util/numeric/format'
 import {UserAvatar} from '#/view/com/util/UserAvatar'
@@ -52,7 +53,7 @@ export function VideoPostCard({
 }) {
   const t = useTheme()
   const {_, i18n} = useLingui()
-  const embed = post.embed
+  const embed = getVideoEmbed(post.embed)
   const {
     state: pressed,
     onIn: onPressIn,

--- a/src/components/feeds/PostFeedVideoGridRow.tsx
+++ b/src/components/feeds/PostFeedVideoGridRow.tsx
@@ -1,6 +1,6 @@
 import {View} from 'react-native'
-import {AppBskyEmbedVideo} from '@atproto/api'
 
+import {isVideoView} from '#/lib/embeds'
 import {logEvent} from '#/lib/statsig/statsig'
 import {FeedPostSliceItem} from '#/state/queries/post-feed'
 import {VideoFeedSourceContext} from '#/screens/VideoFeed/types'
@@ -20,7 +20,7 @@ export function PostFeedVideoGridRow({
 }) {
   const gutters = useGutters(['base', 'base', 0, 'base'])
   const posts = slices
-    .filter(slice => AppBskyEmbedVideo.isView(slice.post.embed))
+    .filter(slice => isVideoView(slice.post.embed))
     .map(slice => ({
       post: slice.post,
       moderation: slice.moderation,

--- a/src/lib/embeds.ts
+++ b/src/lib/embeds.ts
@@ -1,6 +1,7 @@
 import {
   AppBskyEmbedRecord,
   AppBskyEmbedRecordWithMedia,
+  AppBskyEmbedVideo,
   AppBskyFeedDefs,
 } from '@atproto/api'
 
@@ -21,4 +22,28 @@ export function isEmbedByEmbedder(
     return embed.record.record.author.did === did
   }
   return true
+}
+
+export function isVideoView(
+  v: unknown,
+): v is
+  | AppBskyEmbedVideo.View
+  | (AppBskyEmbedRecordWithMedia.View & {media: AppBskyEmbedVideo.View}) {
+  return (
+    AppBskyEmbedVideo.isView(v) ||
+    (AppBskyEmbedRecordWithMedia.isView(v) && AppBskyEmbedVideo.isView(v.media))
+  )
+}
+
+export function getVideoEmbed(v: unknown): AppBskyEmbedVideo.View | null {
+  if (AppBskyEmbedVideo.isView(v)) {
+    return v
+  }
+  if (
+    AppBskyEmbedRecordWithMedia.isView(v) &&
+    AppBskyEmbedVideo.isView(v.media)
+  ) {
+    return v.media
+  }
+  return null
 }

--- a/src/screens/VideoFeed/index.tsx
+++ b/src/screens/VideoFeed/index.tsx
@@ -46,6 +46,7 @@ import {
 import {NativeStackScreenProps} from '@react-navigation/native-stack'
 
 import {HITSLOP_20} from '#/lib/constants'
+import {getVideoEmbed, isVideoView} from '#/lib/embeds'
 import {useHaptics} from '#/lib/haptics'
 import {useNonReactiveCallback} from '#/lib/hooks/useNonReactiveCallback'
 import {CommonNavigatorParams, NavigationProp} from '#/lib/routes/types'
@@ -210,14 +211,17 @@ function Feed() {
           const feedPost = slice.items.find(
             item => item.uri === slice.feedPostUri,
           )
-          if (feedPost && AppBskyEmbedVideo.isView(feedPost.post.embed)) {
-            items.push({
-              _reactKey: feedPost._reactKey,
-              moderation: feedPost.moderation,
-              post: feedPost.post,
-              video: feedPost.post.embed,
-              feedContext: slice.feedContext,
-            })
+          if (feedPost && isVideoView(feedPost.post.embed)) {
+            const video = getVideoEmbed(feedPost.post.embed)
+            if (video) {
+              items.push({
+                _reactKey: feedPost._reactKey,
+                moderation: feedPost.moderation,
+                post: feedPost.post,
+                video: video,
+                feedContext: slice.feedContext,
+              })
+            }
           }
         }
         return items

--- a/src/view/com/posts/PostFeed.tsx
+++ b/src/view/com/posts/PostFeed.tsx
@@ -9,12 +9,13 @@ import {
   View,
   ViewStyle,
 } from 'react-native'
-import {AppBskyActorDefs, AppBskyEmbedVideo} from '@atproto/api'
+import {AppBskyActorDefs} from '@atproto/api'
 import {msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 import {useQueryClient} from '@tanstack/react-query'
 
 import {DISCOVER_FEED_URI, KNOWN_SHUTDOWN_FEEDS} from '#/lib/constants'
+import {isVideoView} from '#/lib/embeds'
 import {useInitialNumToRender} from '#/lib/hooks/useInitialNumToRender'
 import {useWebMediaQueries} from '#/lib/hooks/useWebMediaQueries'
 import {logEvent} from '#/lib/statsig/statsig'
@@ -350,7 +351,7 @@ let PostFeed = ({
               const item = slice.items.find(
                 item => item.uri === slice.feedPostUri,
               )
-              if (item && AppBskyEmbedVideo.isView(item.post.embed)) {
+              if (item && isVideoView(item.post.embed)) {
                 videos.push({item, feedContext: slice.feedContext})
               }
             }


### PR DESCRIPTION
Because Video posts are fundamentally `EmbedRecordWithMedia` whereas plain video posts are `EmbedVideo`, the shape of the object and where the user's uploaded video exist within the post are different. This PR extracts the relevant `EmbedVideo` wherever relevant and passes it to the renderer.

# Testing

Check this feed on live mobile / dev mobile / desktop: https://bsky.app/profile/feedtester.bsky.social/feed/videos

On desktop it's got 3 videos, on this branch on iOS it has 3 videos, on live it only shows 1 video (the non-quote-post one).