### PR TITLE
Fix "resizeMode is depreciated" depreciation warning

### DIFF
--- a/src/view/com/util/UserBanner.tsx
+++ b/src/view/com/util/UserBanner.tsx
@@ -170,7 +170,7 @@ export function UserBanner({
         styles.bannerImage,
         {backgroundColor: theme.palette.default.backgroundLight},
       ]}
-      resizeMode="cover"
+      contentFit="cover"
       source={{uri: banner}}
       blurRadius={moderation?.blur ? 100 : 0}
       accessible={true}


### PR DESCRIPTION
Very simple, does what the warning has been telling us to do

<img width="366" alt="Screenshot 2025-01-22 at 18 45 14" src="https://github.com/user-attachments/assets/c5f6f53e-c861-46c3-81ae-ab79aa7cc891" />

# test plan

Look at banner. it should be the same
