### PR TITLE
Add ban-ts-comment rule as warn

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -93,6 +93,7 @@ module.exports = {
         ],
       },
     ],
+    '@typescript-eslint/ban-ts-comment': 'warn',
   },
   ignorePatterns: [
     '**/__mocks__/*.ts',


### PR DESCRIPTION
I'm strongly in favour of adding this rule to our eslint config.

Using `@ts-ignore` over `@ts-expect-error` leads to sloppy typing, and we have many cases across our codebase where a formerly bad type has since been fixed but typechecking is still disabled. For example `desktopFixedHeight` in the `List` component. This has actually bitten me in the past, since it can let type breakages slip though unexpectedly.

Unfortunately, we have about 180 uses of `@ts-ignore`, so we can't just do it all at once. Let's turn the rule on as `warn`, incrementally fix up commonly touched files as we touch them, then change to `error` later down the line