### PR TITLE
Only show pins on Posts and Replies

### DIFF
--- a/src/lib/api/feed/author.ts
+++ b/src/lib/api/feed/author.ts
@@ -23,7 +23,9 @@ export class AuthorFeedAPI implements FeedAPI {
 
   get params() {
     const params = {...this._params}
-    params.includePins = params.filter !== 'posts_with_media'
+    params.includePins =
+      params.filter === 'posts_with_replies' ||
+      params.filter === 'posts_and_author_threads'
     return params
   }
 


### PR DESCRIPTION
Just moving to an allowlist which solves the problem for Videos tab (currently it shows non-video pins on the web).

In the future we might make pins per-tab but that future is not now.

## Test Plan

Not seeing the pin here anymore.

<img width="694" alt="Screenshot 2025-01-22 at 19 35 50" src="https://github.com/user-attachments/assets/87f54a02-5cac-4c4d-99cc-623818402b44" />

Posts and Replies retain the pin.