### PR TITLE
Tweak adjustment in the formula

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "icons:optimize": "svgo -f ./assets/icons"
   },
   "dependencies": {
-    "@atproto/api": "^0.13.28",
+    "@atproto/api": "^0.13.30",
     "@bitdrift/react-native": "^0.6.2",
     "@braintree/sanitize-url": "^6.0.2",
     "@discord/bottom-sheet": "bluesky-social/react-native-bottom-sheet",

--- a/src/state/queries/post-thread.ts
+++ b/src/state/queries/post-thread.ts
@@ -359,7 +359,6 @@ function responseToThreadNodes(
               // do not show blocked posts in replies
               .filter(node => node.type !== 'blocked')
           : undefined,
-      // @ts-ignore TODO: Update API package.
       hasOPLike: Boolean(node?.threadContext?.rootAuthorLike),
       ctx: {
         depth,

--- a/src/state/queries/post-thread.ts
+++ b/src/state/queries/post-thread.ts
@@ -318,9 +318,9 @@ function getHotness(threadPost: ThreadPost, fetchedAt: number) {
       (1000 * 60 * 60),
   )
   const likeCount = post.likeCount ?? 0
-  const likeOrder = Math.log(3 + likeCount)
+  const likeOrder = Math.log(3 + likeCount) * (hasOPLike ? 1.45 : 1.0)
   const timePenaltyExponent = 1.5 + 1.5 / (1 + Math.log(1 + likeCount))
-  const opLikeBoost = hasOPLike ? 0.85 : 1.0
+  const opLikeBoost = hasOPLike ? 0.8 : 1.0
   const timePenalty = Math.pow(hoursAgo + 2, timePenaltyExponent * opLikeBoost)
   return likeOrder / timePenalty
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -72,10 +72,10 @@
     tlds "^1.234.0"
     zod "^3.23.8"
 
-"@atproto/api@^0.13.28":
-  version "0.13.28"
-  resolved "https://registry.yarnpkg.com/@atproto/api/-/api-0.13.28.tgz#b36d4ad9485724ec030e7292599f048ab62a9fcc"
-  integrity sha512-qBuEI5aNe2/KjmtmtLMilnpZc+FRAsAM3/5nFOQPEudUk388ctNsmKdz2Nti4OvCebn+50EB6V3lju596CTUNA==
+"@atproto/api@^0.13.30":
+  version "0.13.30"
+  resolved "https://registry.yarnpkg.com/@atproto/api/-/api-0.13.30.tgz#073165003303995d0b6b7dfc24dafb8a58a1db6f"
+  integrity sha512-U+3XUACcCuoEvszh48vnzZITr1D7xZ8yz3EqjadYtV+zb3KjBmGroa50eaSRqHyeaDUZF38knumHPyUe9tTuqg==
   dependencies:
     "@atproto/common-web" "^0.3.2"
     "@atproto/lexicon" "^0.4.5"


### PR DESCRIPTION
Follow-up to https://github.com/bluesky-social/social-app/pull/7535 adjustments in Hotness formula. I'm tweaking based on first impressions after living with this for a day. It didn't feel strong enough in my testing so I'm bumping it up a bit.

- Changing the OP-liked decay from `0.85` to `0.8` to make it slightly more pronounced
- Adding a fixed linear score boost (setting it to `1.45`), which makes them stickier

Also drive-by removal of `ts-ignore`.

## Test Plan

Verify OP like is a bit stronger now, e.g. on Jay's swords post.