### PR TITLE
docs: how to build after deps change

### DIFF
--- a/docs/build.md
+++ b/docs/build.md
@@ -32,7 +32,7 @@ This is NOT required when developing for web.
     - `bundler install` (this will install Cocoapods)
 - After initial setup:
   - Copy `google-services.json.example` to `google-services.json` or provide your own `google-services.json`. (A real firebase project is NOT required)
-  - `npx expo prebuild` -> you will also need to run this anytime `app.json` or native `package.json` deps change
+  - `yarn prebuild` -> you will also need to run this anytime `app.json` or native `package.json` deps change
  
 ### Running the Native App
 


### PR DESCRIPTION
`npx expo prebuild` gave me hard to understand errors after a deps change, the package.json script worked though.