### PR TITLE
Trim leading whitespace-only lines

### DIFF
--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -193,7 +193,12 @@ export async function post(
 }
 
 async function resolveRT(agent: BskyAgent, richtext: RichText) {
-  let rt = new RichText({text: richtext.text.trimEnd()}, {cleanNewlines: true})
+  const trimmedText = richtext.text
+    // Trim leading whitespace-only lines (but don't break ASCII art).
+    .replace(/^(\s*\n)+/, '')
+    // Trim any trailing whitespace.
+    .trimEnd()
+  let rt = new RichText({text: trimmedText}, {cleanNewlines: true})
   await rt.detectFacets(agent)
 
   rt = shortenLinks(rt)


### PR DESCRIPTION
This adds trimming of *leading whitespace-only lines* to posting.

The goal is to reduce cases where people accidentally linebreak before their replies.

This doesn't break ASCII art — we don't trim whitespace on leading lines that contain non-whitespace characters.

## Test Plan

Read the regex, convince yourself it's correct.

Try cases like this:

```
 
    

  test
test
  test  
  
```

Expected output:

```
  test
test
  test
```