### PR TITLE
Remove "bsky.network" from preconnect

### DIFF
--- a/bskyweb/templates/base.html
+++ b/bskyweb/templates/base.html
@@ -8,7 +8,6 @@
     Preconnect to essential domains
   -->
   <link rel="preconnect" href="https://bsky.social">
-  <link rel="preconnect" href="https://bsky.network">
   <title>{%- block head_title -%}Bluesky{%- endblock -%}</title>
 
   <!-- Hello Humans! API docs at https://atproto.com -->

--- a/web/index.html
+++ b/web/index.html
@@ -15,7 +15,6 @@
       Preconnect to essential domains
     -->
     <link rel="preconnect" href="https://bsky.social">
-    <link rel="preconnect" href="https://bsky.network">
     <title>%WEB_TITLE%</title>
 
     <link rel="preload" as="font" type="font/woff2" href="/static/media/InterVariable.c504db5c06caaf7cdfba.woff2" crossorigin>


### PR DESCRIPTION
Since the migration to the mushroom PDS's the app no longer needs a pre-established connection to `bsky.network` which should no longer be used by the App.