### PR TITLE
Preserve whitespace after @mention on web

### DIFF
--- a/src/view/com/composer/text-input/TextInput.web.tsx
+++ b/src/view/com/composer/text-input/TextInput.web.tsx
@@ -221,7 +221,9 @@ export const TextInput = React.forwardRef(function TextInputImpl(
           }
         },
       },
-      content: generateJSON(richtext.text.toString(), extensions),
+      content: generateJSON(richtext.text.toString(), extensions, {
+        preserveWhitespace: true,
+      }),
       autofocus: 'end',
       editable: true,
       injectCSS: true,


### PR DESCRIPTION
On web, clicking _New post_ from the Profile page should open the composer prefilled with _“@account ”_, but the trailing space is missing.

Fixes #7476.

Fix described on https://github.com/ueberdosis/tiptap/pull/5158.