### PR TITLE
Fix hcap clipping

### DIFF
--- a/src/screens/Signup/StepCaptcha/index.tsx
+++ b/src/screens/Signup/StepCaptcha/index.tsx
@@ -80,9 +80,8 @@ export function StepCaptcha() {
         <View
           style={[
             a.w_full,
-            a.pb_xl,
             a.overflow_hidden,
-            {minHeight: 500},
+            {minHeight: 510},
             completed && [a.align_center, a.justify_center],
           ]}>
           {!completed ? (


### PR DESCRIPTION
The containing element had a fixed height, but also extra padding. There is already spacing between elements, so this is unnecessary. I also increased the height by 10px to be safe.

Testable on native. The image grid is the tallest hcap test I was able to get, so you might need to go back and forth a couple times. I cannot test on web but theoretically, it should be exactly the same.

<table>
  <thead>
    <tr>
      <th>Before</th>
      <th>After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><img width="200" src="https://github.com/user-attachments/assets/3a54c065-e9af-4379-92f2-e19181c8d5d8" /></td>
      <td><img width="200" src="https://github.com/user-attachments/assets/bb4d2435-ace4-4430-aaf9-85b3aa9b37c3" /></td>
    </tr>
  </tbody>
</table>