### PR TITLE
update bitdrift to 0.6.7 and enable iOS network integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@atproto/api": "^0.13.31",
-    "@bitdrift/react-native": "^0.6.5",
+    "@bitdrift/react-native": "^0.6.7",
     "@braintree/sanitize-url": "^6.0.2",
     "@discord/bottom-sheet": "bluesky-social/react-native-bottom-sheet",
     "@emoji-mart/react": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   },
   "dependencies": {
     "@atproto/api": "^0.13.31",
-    "@bitdrift/react-native": "^0.6.2",
+    "@bitdrift/react-native": "^0.6.5",
     "@braintree/sanitize-url": "^6.0.2",
     "@discord/bottom-sheet": "bluesky-social/react-native-bottom-sheet",
     "@emoji-mart/react": "^1.1.1",

--- a/src/lib/bitdrift.ts
+++ b/src/lib/bitdrift.ts
@@ -18,6 +18,7 @@ initPromise.then(() => {
   if (isEnabled && BITDRIFT_API_KEY) {
     init(BITDRIFT_API_KEY, SessionStrategy.Activity, {
       url: 'https://api-bsky.bitdrift.io',
+      enableNetworkInstrumentation: true,
     })
   }
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -3422,10 +3422,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bitdrift/react-native@^0.6.2":
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/@bitdrift/react-native/-/react-native-0.6.2.tgz#8e75d45a63fccad38b310fdea8069fa929cb97c3"
-  integrity sha512-4DIsZwAr9/Q1RI7lsnUphRoMuOuLWWESNXI759niSmU8XHTJISwwOQzUm7qWn7waBJGhxaq+jn+vlTV5Fai6zw==
+"@bitdrift/react-native@^0.6.5":
+  version "0.6.5"
+  resolved "https://registry.yarnpkg.com/@bitdrift/react-native/-/react-native-0.6.5.tgz#bfeca68aca7895c96854b9972bca843f74d17b0f"
+  integrity sha512-W32GaA5e1Q6rtFnVSg9mk/zO3ZLqCpB7CcNShSd0oD6HVPE38sMm9LfkMCNm0ZqcwXrq1h3SPBX2dPdT1al9kw==
   dependencies:
     "@expo/config-plugins" "^9.0.14"
     fast-json-stringify "^6.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3422,10 +3422,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bitdrift/react-native@^0.6.5":
-  version "0.6.5"
-  resolved "https://registry.yarnpkg.com/@bitdrift/react-native/-/react-native-0.6.5.tgz#bfeca68aca7895c96854b9972bca843f74d17b0f"
-  integrity sha512-W32GaA5e1Q6rtFnVSg9mk/zO3ZLqCpB7CcNShSd0oD6HVPE38sMm9LfkMCNm0ZqcwXrq1h3SPBX2dPdT1al9kw==
+"@bitdrift/react-native@^0.6.7":
+  version "0.6.7"
+  resolved "https://registry.yarnpkg.com/@bitdrift/react-native/-/react-native-0.6.7.tgz#cc64b3c0563a083341f2d974a371178fc43dd93f"
+  integrity sha512-Cf3hKuYHHTx57HAEd1pwX4fWgJ6iUYqjtsdzNTPPLHlyU2ChWskKizyNcPFhZlWSVzMszlFTzVkP4dBVHNhlJg==
   dependencies:
     "@expo/config-plugins" "^9.0.14"
     fast-json-stringify "^6.0.0"


### PR DESCRIPTION
This updates the bitdrift library to 0.6.7, which brings in a new version of the Capture SDK that addresses the limitations with the iOS networking integration that caused it to not play well with the bluesky app. 