### PR TITLE
feat(sign-up): Add tip about domain name handles

### DIFF
--- a/src/screens/Signup/StepHandle.tsx
+++ b/src/screens/Signup/StepHandle.tsx
@@ -13,6 +13,7 @@ import {useAgent} from '#/state/session'
 import {ScreenTransition} from '#/screens/Login/ScreenTransition'
 import {useSignupContext} from '#/screens/Signup/state'
 import {atoms as a, useTheme} from '#/alf'
+import {Admonition} from '#/components/Admonition'
 import * as TextField from '#/components/forms/TextField'
 import {useThrottledValue} from '#/components/hooks/useThrottledValue'
 import {At_Stroke2_Corner0_Rounded as At} from '#/components/icons/At'
@@ -183,6 +184,16 @@ export function StepHandle() {
             </View>
           </View>
         )}
+        <View>
+          <Admonition type="tip">
+            <Trans>
+              <Text style={[a.font_bold]}>Did you know?</Text> Bluesky supports
+              domain name handles like @example.com. Sign up with a username
+              first and then switch to your domain name when you are ready to
+              self-verify.
+            </Trans>
+          </Admonition>
+        </View>
       </View>
       <BackNextButtons
         isLoading={isLoading}


### PR DESCRIPTION
A point of confusion when registering for Bluesky is the use of "username". Many people signing up only know of Bluesky as a Twitter alternative and do not have context around the protocol. During the sign up process, a user may be unable to find an available username and be discouraged from signing up[1].

In the most technically correct world, the sign-up process would not use the term "username" and would allow a user to choose between a handle using the `.bsky.social` domain or a handle using their own domain... but that is much more complicated ux -- most users do not understand domain names, nor do they want to.

A good middle-ground is informing users about support for domain names (with the term "verify" to plant the seeds that domain names can be used for verification) while allowing them to choose a username.

I don't love the phrasing but "did you know?" is intended to _inform_ without instructing, i.e: a user reads it and learns something but doesn't think they need to take any specific action. A user with an established online identity, or a user frustrated their chosen usernames are taken might think "ah! I know that domains can be used, I'll sign up with whatever as my username and then switch to my domain after" whereas a _normal_ user might think something on the spectrum of "neat, I know what domains are, it's cool that Bluesky uses them" to "I don't know what a domain is but verification sounds positive".

<img width="1548" alt="Screenshot 2025-01-26 at 16 28 18" src="https://github.com/user-attachments/assets/5764997c-84e8-4edd-9d24-358848eded80" />

[1] https://bsky.app/profile/luciferrari.tifosi.social/post/3lgl7s7n4ok2c