### PR TITLE
Per-user search history

### DIFF
--- a/src/state/queries/profile.ts
+++ b/src/state/queries/profile.ts
@@ -10,6 +10,7 @@ import {
   ComAtprotoRepoUploadBlob,
 } from '@atproto/api'
 import {
+  keepPreviousData,
   QueryClient,
   useMutation,
   useQuery,
@@ -81,7 +82,13 @@ export function useProfileQuery({
   })
 }
 
-export function useProfilesQuery({handles}: {handles: string[]}) {
+export function useProfilesQuery({
+  handles,
+  maintainData,
+}: {
+  handles: string[]
+  maintainData?: boolean
+}) {
   const agent = useAgent()
   return useQuery({
     staleTime: STALE.MINUTES.FIVE,
@@ -90,6 +97,7 @@ export function useProfilesQuery({handles}: {handles: string[]}) {
       const res = await agent.getProfiles({actors: handles})
       return res.data
     },
+    placeholderData: maintainData ? keepPreviousData : undefined,
   })
 }
 

--- a/src/storage/schema.ts
+++ b/src/storage/schema.ts
@@ -13,4 +13,5 @@ export type Device = {
 
 export type Account = {
   searchTermHistory?: string[]
+  searchAccountHistory?: string[]
 }

--- a/src/view/screens/Search/Search.tsx
+++ b/src/view/screens/Search/Search.tsx
@@ -427,12 +427,12 @@ function useQueryManager({initialQuery}: {initialQuery: string}) {
   const {query, params: initialParams} = React.useMemo(() => {
     return parseSearchQuery(initialQuery || '')
   }, [initialQuery])
-  const prevInitialQuery = React.useRef(initialQuery)
+  const [prevInitialQuery, setPrevInitialQuery] = React.useState(initialQuery)
   const [lang, setLang] = React.useState(initialParams.lang || '')
 
-  if (initialQuery !== prevInitialQuery.current) {
+  if (initialQuery !== prevInitialQuery) {
     // handle new queryParam change (from manual search entry)
-    prevInitialQuery.current = initialQuery
+    setPrevInitialQuery(initialQuery)
     setLang(initialParams.lang || '')
   }
 
@@ -717,8 +717,14 @@ export function SearchScreen(
     scrollToTopWeb()
     textInput.current?.blur()
     setShowAutocomplete(false)
-    setSearchText(queryParam)
-  }, [setShowAutocomplete, setSearchText, queryParam])
+    if (isWeb) {
+      // Empty params resets the URL to be /search rather than /search?q=
+      navigation.replace('Search', {})
+    } else {
+      setSearchText('')
+      navigation.setParams({q: ''})
+    }
+  }, [setShowAutocomplete, setSearchText, navigation])
 
   const onSubmit = React.useCallback(() => {
     navigateToItem(searchText)

--- a/src/view/screens/Search/Search.tsx
+++ b/src/view/screens/Search/Search.tsx
@@ -633,7 +633,7 @@ export function SearchScreen(
       const newSearchHistory = [
         item,
         ...termHistory.filter(search => search !== item),
-      ]
+      ].slice(0, 6)
       setTermHistory(newSearchHistory)
     },
     [termHistory, setTermHistory],
@@ -644,7 +644,7 @@ export function SearchScreen(
       const newAccountHistory = [
         item.did,
         ...accountHistory.filter(p => p !== item.did),
-      ]
+      ].slice(0, 5)
       setAccountHistory(newAccountHistory)
     },
     [accountHistory, setAccountHistory],


### PR DESCRIPTION
Refactors the search history to partition the history by DID, so that history is unique to the logged-in account

I also changed it to use ~~react-query, since that's better for handling async state~~ the new MMKV storage!

# Test plan

Generate some search history
Switch to and from accounts to confirm it's partitioned