### PR TITLE
Search - clean up refs in render

### DIFF
--- a/src/view/screens/Search/Search.tsx
+++ b/src/view/screens/Search/Search.tsx
@@ -427,12 +427,12 @@ function useQueryManager({initialQuery}: {initialQuery: string}) {
   const {query, params: initialParams} = React.useMemo(() => {
     return parseSearchQuery(initialQuery || '')
   }, [initialQuery])
-  const prevInitialQuery = React.useRef(initialQuery)
+  const [prevInitialQuery, setPrevInitialQuery] = React.useState(initialQuery)
   const [lang, setLang] = React.useState(initialParams.lang || '')
 
-  if (initialQuery !== prevInitialQuery.current) {
+  if (initialQuery !== prevInitialQuery) {
     // handle new queryParam change (from manual search entry)
-    prevInitialQuery.current = initialQuery
+    setPrevInitialQuery(initialQuery)
     setLang(initialParams.lang || '')
   }
 


### PR DESCRIPTION
Should have zero functionality change, but fixes up bad React code

# Test plan

Confirm it works the same. I am pretty sure this case occurs when the query string is modified - i.e. when the search input is cleared