### PR TITLE
Fix: people list tab content is hidden behind the navigation bar

### DIFF
--- a/src/view/com/lists/ListMembers.tsx
+++ b/src/view/com/lists/ListMembers.tsx
@@ -4,6 +4,7 @@ import {AppBskyActorDefs, AppBskyGraphDefs} from '@atproto/api'
 import {msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
+import {useBottomBarOffset} from '#/lib/hooks/useBottomBarOffset'
 import {useWebMediaQueries} from '#/lib/hooks/useWebMediaQueries'
 import {cleanError} from '#/lib/strings/errors'
 import {logger} from '#/logger'
@@ -51,6 +52,7 @@ export function ListMembers({
   const {isMobile} = useWebMediaQueries()
   const {openModal} = useModalControls()
   const {currentAccount} = useSession()
+  const bottomBarOffset = useBottomBarOffset()
 
   const {
     data,
@@ -201,9 +203,17 @@ export function ListMembers({
         error={cleanError(error)}
         isFetchingNextPage={isFetchingNextPage}
         onRetry={fetchNextPage}
+        style={{marginBottom: headerOffset}}
       />
     )
-  }, [hasNextPage, error, isFetchingNextPage, fetchNextPage, isEmpty])
+  }, [
+    isEmpty,
+    hasNextPage,
+    error,
+    isFetchingNextPage,
+    fetchNextPage,
+    headerOffset,
+  ])
 
   return (
     <View testID={testID} style={style}>
@@ -227,6 +237,9 @@ export function ListMembers({
         removeClippedSubviews={true}
         // @ts-ignore our .web version only -prf
         desktopFixedHeight={desktopFixedHeightOffset || true}
+        scrollIndicatorInsets={{
+          bottom: bottomBarOffset,
+        }}
       />
     </View>
   )


### PR DESCRIPTION
When accessing a user-created list and navigating to the 'People' tab, the content is hidden by the navigation bar because the list flows behind the component.

Fixes https://github.com/bluesky-social/social-app/issues/7929

Bug

https://github.com/user-attachments/assets/1b5519ca-e864-49e2-bd18-2f8fbd4a2e24

Bug without BottomTab component

https://github.com/user-attachments/assets/4aac8946-9004-474a-aa2e-f70dbd8e608e

Fix

https://github.com/user-attachments/assets/e63db813-8713-4c3d-a9ee-3535cf1f7590

Fix without BottomTab component

https://github.com/user-attachments/assets/04985b99-483d-4d32-995b-ad690ef7e977


