### PR TITLE
Reduce padding on video overlay

### DIFF
--- a/src/screens/VideoFeed/index.tsx
+++ b/src/screens/VideoFeed/index.tsx
@@ -756,7 +756,7 @@ function Overlay({
               'rgba(0,0,0,0.95)',
             ]}
             style={[a.w_full, a.pt_md]}>
-            <Animated.View style={[a.px_xl, animatedStyle]}>
+            <Animated.View style={[a.px_md, animatedStyle]}>
               <View style={[a.w_full, a.flex_row, a.align_center, a.gap_md]}>
                 <Link
                   label={_(


### PR DESCRIPTION
Currently it's awkwardly narrow compared to the reply prompt

<img src=https://github.com/user-attachments/assets/29e56792-15a5-4096-9a55-e243dbcead24 width=400>
