### PR TITLE
Blur profile avatar on recent searches for consistency

### DIFF
--- a/src/view/screens/Search/Search.tsx
+++ b/src/view/screens/Search/Search.tsx
@@ -1079,7 +1079,7 @@ function SearchHistory({
                       moderation={moderateProfile(profile, moderationOpts).ui(
                         'avatar',
                       )}
-                      type="user"
+                      type={profile?.associated?.labeler ? 'labeler' : 'user'}
                       size={60}
                       usePlainRNImage
                     />


### PR DESCRIPTION
Fixes #7586 

### Summary
I could not reproduce the originally reported issue where the profile avatar is not blurred in the reply dialog. Instead, I identified that the profile avatar is not blurred in the search results but in the auto completions dropdown. So, for consistency, I made it blurred in the search results as well. 

### Recording
Before:

https://github.com/user-attachments/assets/7186284a-54c6-453f-b3d0-1b32cbd3ff68



After: 

https://github.com/user-attachments/assets/af766437-18ed-47a1-bb88-ff256ee9240d

