### PR TITLE
Change search cancel behaviour

### DIFF
--- a/src/view/screens/Search/Search.tsx
+++ b/src/view/screens/Search/Search.tsx
@@ -741,8 +741,14 @@ export function SearchScreen(
     scrollToTopWeb()
     textInput.current?.blur()
     setShowAutocomplete(false)
-    setSearchText(queryParam)
-  }, [setShowAutocomplete, setSearchText, queryParam])
+    if (isWeb) {
+      // Empty params resets the URL to be /search rather than /search?q=
+      navigation.replace('Search', {})
+    } else {
+      setSearchText('')
+      navigation.setParams({q: ''})
+    }
+  }, [setShowAutocomplete, setSearchText, navigation])
 
   const onSubmit = React.useCallback(() => {
     navigateToItem(searchText)


### PR DESCRIPTION
Before: cancel closes the input and restores previous search input (i.e. search "hello", delete input, press cancel restores input to "hello")
After: cancel clears input and returns to explore page

It is currently frustrating to return to the explore page from the search page. This change aligns behaviour with iOS search inputs (see apple music or whatever)