### PR TITLE
Add `twitter:image` to profile pages

### DIFF
--- a/bskyweb/templates/profile.html
+++ b/bskyweb/templates/profile.html
@@ -27,6 +27,7 @@
   {% endif -%}
   {%- if profileView.Banner %}
   <meta property="og:image" content="{{ profileView.Banner }}">
+  <meta property="twitter:image" content="{{ profileView.Banner }}">
   <meta name="twitter:card" content="summary_large_image">
   {%- elif profileView.Avatar -%}
   {# Don't use avatar image in cards; usually looks bad #}


### PR DESCRIPTION
This fixes Discord embeds not showing banner images.

Related to #5863