### PR TITLE
Typo fix

### DIFF
--- a/src/components/dms/ReportDialog.tsx
+++ b/src/components/dms/ReportDialog.tsx
@@ -336,7 +336,7 @@ function DoneStep({
           <Trans>Report submitted</Trans>
         </Text>
         <Text style={[a.text_md, t.atoms.text_contrast_medium]}>
-          <Trans>Our moderation team has recieved your report.</Trans>
+          <Trans>Our moderation team has received your report.</Trans>
         </Text>
       </View>
       <Toggle.Group

--- a/src/locale/locales/fr/messages.po
+++ b/src/locale/locales/fr/messages.po
@@ -4820,7 +4820,7 @@ msgid "Other..."
 msgstr "Autre…"
 
 #: src/components/dms/ReportDialog.tsx:339
-msgid "Our moderation team has recieved your report."
+msgid "Our moderation team has received your report."
 msgstr "Notre équipe de modération a reçu votre signalement."
 
 #: src/screens/Messages/components/ChatDisabled.tsx:28

--- a/src/locale/locales/it/messages.po
+++ b/src/locale/locales/it/messages.po
@@ -4826,7 +4826,7 @@ msgid "Other..."
 msgstr "Altro..."
 
 #: src/components/dms/ReportDialog.tsx:339
-msgid "Our moderation team has recieved your report."
+msgid "Our moderation team has received your report."
 msgstr "Il nostro team di moderazione ha ricevuto la segnalazione."
 
 #: src/screens/Messages/components/ChatDisabled.tsx:28

--- a/src/locale/locales/ja/messages.po
+++ b/src/locale/locales/ja/messages.po
@@ -4820,7 +4820,7 @@ msgid "Other..."
 msgstr "その他…"
 
 #: src/components/dms/ReportDialog.tsx:339
-msgid "Our moderation team has recieved your report."
+msgid "Our moderation team has received your report."
 msgstr "あなたの報告をモデレーションチームが受け付けました。"
 
 #: src/screens/Messages/components/ChatDisabled.tsx:28

--- a/src/locale/locales/ko/messages.po
+++ b/src/locale/locales/ko/messages.po
@@ -4820,7 +4820,7 @@ msgid "Other..."
 msgstr "기타…"
 
 #: src/components/dms/ReportDialog.tsx:339
-msgid "Our moderation team has recieved your report."
+msgid "Our moderation team has received your report."
 msgstr "Bluesky 검토 팀에서 신고를 접수했습니다."
 
 #: src/screens/Messages/components/ChatDisabled.tsx:28

--- a/src/locale/locales/zh-CN/messages.po
+++ b/src/locale/locales/zh-CN/messages.po
@@ -4825,7 +4825,7 @@ msgid "Other..."
 msgstr "其他……"
 
 #: src/components/dms/ReportDialog.tsx:339
-msgid "Our moderation team has recieved your report."
+msgid "Our moderation team has received your report."
 msgstr "我们的审核团队已收到你的举报。"
 
 #: src/screens/Messages/components/ChatDisabled.tsx:28

--- a/src/locale/locales/zh-HK/messages.po
+++ b/src/locale/locales/zh-HK/messages.po
@@ -4825,7 +4825,7 @@ msgid "Other..."
 msgstr "其他..."
 
 #: src/components/dms/ReportDialog.tsx:339
-msgid "Our moderation team has recieved your report."
+msgid "Our moderation team has received your report."
 msgstr "我哋嘅內容審覈團隊經已收到你嘅上報。"
 
 #: src/screens/Messages/components/ChatDisabled.tsx:28

--- a/src/locale/locales/zh-TW/messages.po
+++ b/src/locale/locales/zh-TW/messages.po
@@ -4825,7 +4825,7 @@ msgid "Other..."
 msgstr "其他…"
 
 #: src/components/dms/ReportDialog.tsx:339
-msgid "Our moderation team has recieved your report."
+msgid "Our moderation team has received your report."
 msgstr "我們的內容審查團隊已收到您的檢舉。"
 
 #: src/screens/Messages/components/ChatDisabled.tsx:28


### PR DESCRIPTION
Typo fix in string shown after DM report sent:
`recieved` ➡️ `received`

h/t @mackuba for [pointing it out](https://bsky.app/profile/mackuba.eu/post/3lha2lval2s2h)

EDIT: As suggested by @prohr, to avoid string churn this PR also amends the relevant strings in the .po files that have been updated so far (they don't seem to have all been updated as part of the 1.97 release).