### PR TITLE
Allow .webp thumbnail preview when pasting urls

### DIFF
--- a/src/lib/media/util.ts
+++ b/src/lib/media/util.ts
@@ -8,8 +8,8 @@ export function getDataUriSize(uri: string): number {
   return Math.round((uri.length * 3) / 4)
 }
 
-export function isUriImage(uri: string) {
-  return /\.(jpg|jpeg|png).*$/.test(uri)
+export function isUriImage(uri: string): boolean {
+  return /\.(jpg|jpeg|png|webp).*$/.test(uri)
 }
 
 export function blobToDataUri(blob: Blob): Promise<string> {


### PR DESCRIPTION
## 📝 Summary

Allow .webp thumbnail preview when pasting urls


## 🚀 Demos

### Before (No preview when pasting .webp urls)

https://github.com/user-attachments/assets/8d7dbe3b-94d7-4e4e-b237-6ae855b9888b

### After (Preview enabled when pasting .webp urls)

https://github.com/user-attachments/assets/bdd0702c-b17e-4342-805f-9ba39a7997ed



