### PR TITLE
Added Portal to ErrorMessage to stack it on top of the view

### DIFF
--- a/src/view/com/util/error/ErrorMessage.tsx
+++ b/src/view/com/util/error/ErrorMessage.tsx
@@ -14,6 +14,7 @@ import {useLingui} from '@lingui/react'
 
 import {usePalette} from '#/lib/hooks/usePalette'
 import {useTheme} from '#/lib/ThemeContext'
+import {Portal} from '#/components/Portal'
 import {Text} from '../text/Text'
 
 export function ErrorMessage({
@@ -31,44 +32,51 @@ export function ErrorMessage({
   const pal = usePalette('error')
   const {_} = useLingui()
   return (
-    <View testID="errorMessageView" style={[styles.outer, pal.view, style]}>
-      <View
-        style={[styles.errorIcon, {backgroundColor: theme.palette.error.icon}]}>
-        <FontAwesomeIcon
-          icon="exclamation"
-          style={pal.text as FontAwesomeIconStyle}
-          size={16}
-        />
-      </View>
-      <Text
-        type="sm-medium"
-        style={[styles.message, pal.text]}
-        numberOfLines={numberOfLines}>
-        {message}
-      </Text>
-      {onPressTryAgain && (
-        <TouchableOpacity
-          testID="errorMessageTryAgainButton"
-          style={styles.btn}
-          onPress={onPressTryAgain}
-          accessibilityRole="button"
-          accessibilityLabel={_(msg`Retry`)}
-          accessibilityHint={_(
-            msg`Retries the last action, which errored out`,
-          )}>
+    <Portal>
+      <View testID="errorMessageView" style={[styles.outer, pal.view, style]}>
+        <View
+          style={[
+            styles.errorIcon,
+            {backgroundColor: theme.palette.error.icon},
+          ]}>
           <FontAwesomeIcon
-            icon="arrows-rotate"
-            style={{color: theme.palette.error.icon}}
-            size={18}
+            icon="exclamation"
+            style={pal.text as FontAwesomeIconStyle}
+            size={16}
           />
-        </TouchableOpacity>
-      )}
-    </View>
+        </View>
+        <Text
+          type="sm-medium"
+          style={[styles.message, pal.text]}
+          numberOfLines={numberOfLines}>
+          {message}
+        </Text>
+        {onPressTryAgain && (
+          <TouchableOpacity
+            testID="errorMessageTryAgainButton"
+            style={styles.btn}
+            onPress={onPressTryAgain}
+            accessibilityRole="button"
+            accessibilityLabel={_(msg`Retry`)}
+            accessibilityHint={_(
+              msg`Retries the last action, which errored out`,
+            )}>
+            <FontAwesomeIcon
+              icon="arrows-rotate"
+              style={{color: theme.palette.error.icon}}
+              size={18}
+            />
+          </TouchableOpacity>
+        )}
+      </View>
+    </Portal>
   )
 }
 
 const styles = StyleSheet.create({
   outer: {
+    position: 'fixed',
+    width: '100%',
     flexDirection: 'row',
     alignItems: 'center',
     paddingVertical: 8,


### PR DESCRIPTION
## 📝 Summary

Added <Portal> to <ErrorMessage> so that it correctly positions it above all the other elements.

Right now, it seems every <View /> has a z-index: 0, which makes it very tricky to work with the children z-index, causing the issue described here https://github.com/bluesky-social/social-app/issues/7524

I think using a Portal could be the right idea here.

## 📝 Related Issues

https://github.com/bluesky-social/social-app/issues/7524

## 🚀 Demos

https://github.com/user-attachments/assets/fada6cfb-6f11-42f3-ba70-4ea9b15c6d60

(Testing the scroll to guarantee that the error message stays pinned)

https://github.com/user-attachments/assets/5fd6b38a-ef95-42ba-919a-3c7fd47f4087





