### PR TITLE
Enable dynamic aspect ratio for embed images

### DIFF
--- a/src/view/com/util/post-embeds/ExternalLinkEmbed.tsx
+++ b/src/view/com/util/post-embeds/ExternalLinkEmbed.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback} from 'react'
+import React, {useCallback, useState} from 'react'
 import {StyleProp, View, ViewStyle} from 'react-native'
 import {Image} from 'expo-image'
 import {AppBskyEmbedExternal} from '@atproto/api'
@@ -44,12 +44,15 @@ export const ExternalLinkEmbed = ({
     }
   }, [link.uri, externalEmbedPrefs])
   const hasMedia = Boolean(imageUri || embedPlayerParams)
+  const [aspectRatio, setAspectRatio] = useState(1.91)
 
   const onShareExternal = useCallback(() => {
     if (link.uri && isNative) {
       shareUrl(link.uri)
     }
   }, [link.uri])
+
+  const clampRatio = (ratio: number) => Math.max(0.5, Math.min(ratio, 3))
 
   if (embedPlayerParams?.source === 'tenor') {
     const parsedAlt = parseAltFromGIFDescription(link.description)
@@ -89,7 +92,11 @@ export const ExternalLinkEmbed = ({
           {imageUri && !embedPlayerParams ? (
             <Image
               style={{
-                aspectRatio: 1.91,
+                aspectRatio,
+              }}
+              onLoad={e => {
+                const {width, height} = e.source
+                setAspectRatio(clampRatio(width / height))
               }}
               source={{uri: imageUri}}
               accessibilityIgnoresInvertColors


### PR DESCRIPTION
For some embed images, the default aspect ratio doesn't work and crops the preview image. In this PR I am setting the aspect ratio between a min-max value that prevents crazy aspect ratios to ruin the users' feed

https://github.com/bluesky-social/social-app/issues/7443

### Before
![image](https://github.com/user-attachments/assets/2ad049f6-c1b9-4742-887e-8a0b9fb484d7)

### After
<img width="748" alt="Screenshot 2025-02-06 at 16 26 37" src="https://github.com/user-attachments/assets/d80708f2-a841-46c7-b5e8-78e62289d508" />

