### PR TITLE
Unmark string for translation

### DIFF
--- a/src/screens/Settings/Settings.tsx
+++ b/src/screens/Settings/Settings.tsx
@@ -421,7 +421,7 @@ function AccountRow({
           <View style={[{width: 28}]} />
         )}
         <SettingsList.ItemText>
-          <Trans>{sanitizeHandle(account.handle, '@')}</Trans>
+          {sanitizeHandle(account.handle, '@')}
         </SettingsList.ItemText>
         {pendingDid === account.did && <SettingsList.ItemIcon icon={Loader} />}
       </SettingsList.PressableItem>


### PR DESCRIPTION
There's a string in Settings which is currently marked for translation but it consists only of the user's handle:

https://github.com/bluesky-social/social-app/blob/b12d39b4cff0fe1b91fb16496c3fea1ed22de5cf/src/screens/Settings/Settings.tsx#L423-L425

And thus it contains no translatable text:

https://github.com/bluesky-social/social-app/blob/b12d39b4cff0fe1b91fb16496c3fea1ed22de5cf/src/locale/locales/en/messages.po#L103-L105

So this PR removes the translation tags.