### PR TITLE
Fix unknown threadgates causing crashes

### DIFF
--- a/src/components/WhoCanReply.tsx
+++ b/src/components/WhoCanReply.tsx
@@ -204,10 +204,10 @@ function Rules({
     <>
       <Text
         style={[
-          a.text_md,
+          a.text_sm,
           a.leading_snug,
           a.flex_wrap,
-          t.atoms.text_contrast_high,
+          t.atoms.text_contrast_medium,
         ]}>
         {settings.length === 0 ? (
           <Trans>
@@ -234,10 +234,10 @@ function Rules({
       {embeddingDisabled && (
         <Text
           style={[
-            a.text_md,
+            a.text_sm,
             a.leading_snug,
             a.flex_wrap,
-            t.atoms.text_contrast_high,
+            t.atoms.text_contrast_medium,
           ]}>
           <Trans>No one but the author can quote this post.</Trans>
         </Text>

--- a/src/components/WhoCanReply.tsx
+++ b/src/components/WhoCanReply.tsx
@@ -204,12 +204,17 @@ function Rules({
     <>
       <Text
         style={[
-          a.text_sm,
+          a.text_md,
           a.leading_snug,
           a.flex_wrap,
-          t.atoms.text_contrast_medium,
+          t.atoms.text_contrast_high,
         ]}>
-        {settings[0].type === 'everybody' ? (
+        {settings.length === 0 ? (
+          <Trans>
+            This post has an unknown type of threadgate on it. Your app may be
+            out of date.
+          </Trans>
+        ) : settings[0].type === 'everybody' ? (
           <Trans>Everybody can reply to this post.</Trans>
         ) : settings[0].type === 'nobody' ? (
           <Trans>Replies to this post are disabled.</Trans>
@@ -229,10 +234,10 @@ function Rules({
       {embeddingDisabled && (
         <Text
           style={[
-            a.text_sm,
+            a.text_md,
             a.leading_snug,
             a.flex_wrap,
-            t.atoms.text_contrast_medium,
+            t.atoms.text_contrast_high,
           ]}>
           <Trans>No one but the author can quote this post.</Trans>
         </Text>


### PR DESCRIPTION
If the app doesn't know about a threadgate, it'll crash when clicking on the threadgate detail modal. not great.

See it in action here: https://bsky.app/profile/samuel.bsky.team/post/3lhmnrxyppc2j
(will stop working once we release https://github.com/bluesky-social/social-app/pull/7681)

# Fix
<img width="650" alt="Screenshot 2025-02-07 at 22 42 09" src="https://github.com/user-attachments/assets/cbae445a-9a2d-4218-8d1f-3fcada47791c" />

# Test plan
Click on the threadgate details on this post
https://bsky.app/profile/samuel.bsky.team/post/3lhmnrxyppc2j