### PR TITLE
Invert new postonboarding gate

### DIFF
--- a/src/lib/statsig/gates.ts
+++ b/src/lib/statsig/gates.ts
@@ -2,7 +2,7 @@ export type Gate =
   // Keep this alphabetic please.
   | 'debug_show_feedcontext'
   | 'debug_subscriptions'
-  | 'new_postonboarding'
+  | 'old_postonboarding'
   | 'onboarding_add_video_feed'
   | 'remove_show_latest_button'
   | 'test_gate_1'

--- a/src/screens/Onboarding/StepFinished.tsx
+++ b/src/screens/Onboarding/StepFinished.tsx
@@ -199,7 +199,7 @@ export function StepFinished() {
     setActiveStarterPack(undefined)
     setHasCheckedForStarterPack(true)
     startProgressGuide(
-      gate('new_postonboarding') ? 'follow-10' : 'like-10-and-follow-7',
+      gate('old_postonboarding') ? 'like-10-and-follow-7' : 'follow-10',
     )
     dispatch({type: 'finish'})
     onboardDispatch({type: 'finish'})


### PR DESCRIPTION
I want to keep this gate around because I still want to run the experiment to see how effective it is.

However, on the assumption it's a good change, we need it to fail open, since if statsig fails (adblock etc) they'll get the rubbish old one. Therefore, we invert it from a 100% rolled out gate to enable the new onboarding to a 0% rolled out get to disable it