### PR TITLE
Clicking "Post Sent" toast on web app will open the post

### DIFF
--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -477,12 +477,25 @@ export const ComposePost = ({
       onPost?.(postUri)
     }
     onClose()
+
+    const baseUrl =
+      typeof window !== 'undefined'
+        ? window.location.origin
+        : 'https://bsky.app' // fallback if window is not defined
+    const postUrl = `${baseUrl}/profile/${currentAccount?.handle}/post/${postUri
+      .split('/')
+      .pop()}`
+
     Toast.show(
       thread.posts.length > 1
         ? _(msg`Your posts have been published`)
         : replyTo
         ? _(msg`Your reply has been published`)
         : _(msg`Your post has been published`),
+      undefined,
+      () => {
+        window.location.replace(postUrl)
+      },
     )
   }, [
     _,
@@ -497,6 +510,7 @@ export const ComposePost = ({
     replyTo,
     setLangPrefs,
     queryClient,
+    currentAccount?.handle,
   ])
 
   // Preserves the referential identity passed to each post item.

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -494,7 +494,7 @@ export const ComposePost = ({
         : _(msg`Your post has been published`),
       undefined,
       () => {
-        window.location.replace(postUrl)
+        window.location.href = postUrl
       },
     )
   }, [

--- a/src/view/com/util/Toast.tsx
+++ b/src/view/com/util/Toast.tsx
@@ -31,6 +31,7 @@ const TIMEOUT = 2e3
 export function show(
   message: string,
   icon: FontAwesomeProps['icon'] = 'check',
+  _onClick?: () => void,
 ) {
   if (process.env.NODE_ENV === 'test') {
     return

--- a/src/view/com/util/Toast.web.tsx
+++ b/src/view/com/util/Toast.web.tsx
@@ -49,7 +49,6 @@ export const ToastContainer: React.FC<ToastContainerProps> = ({}) => {
             accessibilityLabel="Dismiss"
             accessibilityHint=""
             onPress={() => {
-              console.log('Toast clicked')
               activeToast.onClick?.()
               setActiveToast(undefined)
             }}

--- a/src/view/com/util/Toast.web.tsx
+++ b/src/view/com/util/Toast.web.tsx
@@ -15,6 +15,7 @@ const DURATION = 3500
 interface ActiveToast {
   text: string
   icon: FontAwesomeProps['icon']
+  onClick?: () => void
 }
 type GlobalSetActiveToast = (_activeToast: ActiveToast | undefined) => void
 
@@ -48,6 +49,8 @@ export const ToastContainer: React.FC<ToastContainerProps> = ({}) => {
             accessibilityLabel="Dismiss"
             accessibilityHint=""
             onPress={() => {
+              console.log('Toast clicked')
+              activeToast.onClick?.()
               setActiveToast(undefined)
             }}
           />
@@ -60,11 +63,15 @@ export const ToastContainer: React.FC<ToastContainerProps> = ({}) => {
 // methods
 // =
 
-export function show(text: string, icon: FontAwesomeProps['icon'] = 'check') {
+export function show(
+  text: string,
+  icon: FontAwesomeProps['icon'] = 'check',
+  onClick?: () => void,
+) {
   if (toastTimeout) {
     clearTimeout(toastTimeout)
   }
-  globalSetActiveToast?.({text, icon})
+  globalSetActiveToast?.({text, icon, onClick})
   toastTimeout = setTimeout(() => {
     globalSetActiveToast?.(undefined)
   }, DURATION)


### PR DESCRIPTION
This is QoL and mimics twitter behavior (for web) instead of having to go Sidebar => Profile => Scroll => Click tweet.

Text not adjusted, unsure how to handle localization.

Imo best solution would be parity between mobile & web with toasts appearing center top/bottom of screen, like twitter.