### PR TITLE
Better animations for dialogs, animate web composer

### DIFF
--- a/src/alf/atoms.ts
+++ b/src/alf/atoms.ts
@@ -981,9 +981,8 @@ export const atoms = {
     animate: 'zoomOut ease-out 0.1s',
   }),
   // special composite animation for dialogs
-  delayed_zoom_fade_in: web({
-    animation:
-      'zoomIn ease-out 0.1s 0.1s backwards, fadeIn ease-out 0.1s 0.1s backwards',
+  zoom_fade_in: web({
+    animation: 'zoomIn ease-out 0.1s, fadeIn ease-out 0.1s',
   }),
 
   /**

--- a/src/alf/atoms.ts
+++ b/src/alf/atoms.ts
@@ -969,16 +969,16 @@ export const atoms = {
    * Animaations
    */
   fade_in: web({
-    animate: 'fadeIn ease-out 0.15s',
+    animation: 'fadeIn ease-out 0.15s',
   }),
   fade_out: web({
-    animate: 'fadeOut ease-out 0.15s',
+    animation: 'fadeOut ease-out 0.15s',
   }),
   zoom_in: web({
-    animate: 'zoomIn ease-out 0.1s',
+    animation: 'zoomIn ease-out 0.1s',
   }),
   zoom_out: web({
-    animate: 'zoomOut ease-out 0.1s',
+    animation: 'zoomOut ease-out 0.1s',
   }),
   // special composite animation for dialogs
   zoom_fade_in: web({

--- a/src/alf/atoms.ts
+++ b/src/alf/atoms.ts
@@ -965,6 +965,27 @@ export const atoms = {
     transitionDelay: '50ms',
   }),
 
+  /*
+   * Animaations
+   */
+  fade_in: web({
+    animate: 'fadeIn ease-out 0.15s',
+  }),
+  fade_out: web({
+    animate: 'fadeOut ease-out 0.15s',
+  }),
+  zoom_in: web({
+    animate: 'zoomIn ease-out 0.1s',
+  }),
+  zoom_out: web({
+    animate: 'zoomOut ease-out 0.1s',
+  }),
+  // special composite animation for dialogs
+  delayed_zoom_fade_in: web({
+    animation:
+      'zoomIn ease-out 0.1s 0.1s backwards, fadeIn ease-out 0.1s 0.1s backwards',
+  }),
+
   /**
    * {@link Layout.SCROLLBAR_OFFSET}
    */

--- a/src/components/Dialog/index.web.tsx
+++ b/src/components/Dialog/index.web.tsx
@@ -161,7 +161,7 @@ export function Inner({
         aria-label={label}
         aria-labelledby={accessibilityLabelledBy}
         aria-describedby={accessibilityDescribedBy}
-        // @ts-ignore web only -prf
+        // @ts-expect-error web only -prf
         onClick={stopPropagation}
         onStartShouldSetResponder={_ => true}
         onTouchEnd={stopPropagation}
@@ -177,10 +177,9 @@ export function Inner({
             shadowColor: t.palette.black,
             shadowOpacity: t.name === 'light' ? 0.1 : 0.4,
             shadowRadius: 30,
-            // @ts-ignore web only
-            animation: 'fadeIn ease-out 0.1s',
           },
-          flatten(style),
+          a.delayed_zoom_fade_in,
+          style,
         ])}>
         <DismissableLayer
           onInteractOutside={preventDefault}
@@ -216,7 +215,7 @@ export const InnerFlatList = React.forwardRef<
       style={[
         a.overflow_hidden,
         a.px_0,
-        // @ts-ignore web only -sfn
+        // @ts-expect-error web only -sfn
         {maxHeight: 'calc(-36px + 100vh)'},
         webInnerStyle,
       ]}
@@ -271,11 +270,8 @@ function Backdrop() {
         style={[
           a.fixed,
           a.inset_0,
-          {
-            backgroundColor: t.palette.black,
-            // @ts-ignore web only
-            animation: 'fadeIn ease-out 0.15s',
-          },
+          {backgroundColor: t.palette.black},
+          a.fade_in,
         ]}
       />
     </View>

--- a/src/components/Dialog/index.web.tsx
+++ b/src/components/Dialog/index.web.tsx
@@ -15,6 +15,7 @@ import {FocusScope} from '@radix-ui/react-focus-scope'
 import {RemoveScrollBar} from 'react-remove-scroll-bar'
 
 import {logger} from '#/logger'
+import {useA11y} from '#/state/a11y'
 import {useDialogStateControlContext} from '#/state/dialogs'
 import {atoms as a, flatten, useBreakpoints, useTheme, web} from '#/alf'
 import {Button, ButtonIcon} from '#/components/Button'
@@ -152,6 +153,7 @@ export function Inner({
   const t = useTheme()
   const {close} = React.useContext(Context)
   const {gtMobile} = useBreakpoints()
+  const {reduceMotionEnabled} = useA11y()
   useFocusGuards()
   return (
     <FocusScope loop asChild trapped>
@@ -178,7 +180,7 @@ export function Inner({
             shadowOpacity: t.name === 'light' ? 0.1 : 0.4,
             shadowRadius: 30,
           },
-          a.delayed_zoom_fade_in,
+          !reduceMotionEnabled && a.delayed_zoom_fade_in,
           style,
         ])}>
         <DismissableLayer
@@ -261,17 +263,15 @@ export function Handle() {
 
 function Backdrop() {
   const t = useTheme()
+  const {reduceMotionEnabled} = useA11y()
   return (
-    <View
-      style={{
-        opacity: 0.8,
-      }}>
+    <View style={{opacity: 0.8}}>
       <View
         style={[
           a.fixed,
           a.inset_0,
           {backgroundColor: t.palette.black},
-          a.fade_in,
+          !reduceMotionEnabled && a.fade_in,
         ]}
       />
     </View>

--- a/src/components/Dialog/index.web.tsx
+++ b/src/components/Dialog/index.web.tsx
@@ -180,7 +180,7 @@ export function Inner({
             shadowOpacity: t.name === 'light' ? 0.1 : 0.4,
             shadowRadius: 30,
           },
-          !reduceMotionEnabled && a.delayed_zoom_fade_in,
+          !reduceMotionEnabled && a.zoom_fade_in,
           style,
         ])}>
         <DismissableLayer

--- a/src/style.css
+++ b/src/style.css
@@ -205,6 +205,15 @@ input:focus {
   }
 }
 
+@keyframes zoomIn {
+  from {
+    transform: scale(0.95);
+  }
+  to {
+    transform: scale(1);
+  }
+}
+
 .force-no-clicks > *,
 .force-no-clicks * {
   pointer-events: none !important;

--- a/src/view/shell/Composer.web.tsx
+++ b/src/view/shell/Composer.web.tsx
@@ -96,7 +96,11 @@ function Inner({state}: {state: ComposerOpts}) {
             !gtMobile && styles.containerMobile,
             t.atoms.bg,
             t.atoms.border_contrast_medium,
-            !reduceMotionEnabled && a.delayed_zoom_fade_in,
+            !reduceMotionEnabled && [
+              a.zoom_fade_in,
+              {animationDelay: 0.1},
+              {animationFillMode: 'backwards'},
+            ],
           ]}>
           <ComposePost
             cancelRef={ref}

--- a/src/view/shell/Composer.web.tsx
+++ b/src/view/shell/Composer.web.tsx
@@ -12,7 +12,7 @@ import {
   EmojiPickerPosition,
   EmojiPickerState,
 } from '#/view/com/composer/text-input/web/EmojiPicker.web'
-import {useBreakpoints, useTheme} from '#/alf'
+import {atoms as a, flatten, useBreakpoints, useTheme} from '#/alf'
 import {ComposePost, useComposerCancelRef} from '../com/composer/Composer'
 
 const BOTTOM_BAR_HEIGHT = 61
@@ -71,17 +71,15 @@ function Inner({state}: {state: ComposerOpts}) {
       <DismissableLayer
         role="dialog"
         aria-modal
-        style={{
-          position: 'fixed',
-          top: 0,
-          left: 0,
-          width: '100%',
-          height: '100%',
-          backgroundColor: '#000c',
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-        }}
+        style={flatten([
+          {position: 'fixed'},
+          a.inset_0,
+          {backgroundColor: '#000c'},
+          a.flex,
+          a.flex_col,
+          a.align_center,
+          a.fade_in,
+        ])}
         onFocusOutside={evt => evt.preventDefault()}
         onInteractOutside={evt => evt.preventDefault()}
         onDismiss={() => {
@@ -96,6 +94,7 @@ function Inner({state}: {state: ComposerOpts}) {
             !gtMobile && styles.containerMobile,
             t.atoms.bg,
             t.atoms.border_contrast_medium,
+            a.delayed_zoom_fade_in,
           ]}>
           <ComposePost
             cancelRef={ref}
@@ -123,14 +122,14 @@ const styles = StyleSheet.create({
     borderRadius: 8,
     marginBottom: 0,
     borderWidth: 1,
-    // @ts-ignore web only
+    // @ts-expect-error web only
     maxHeight: 'calc(100% - (40px * 2))',
     overflow: 'hidden',
   },
   containerMobile: {
     borderRadius: 0,
     marginBottom: BOTTOM_BAR_HEIGHT,
-    // @ts-ignore web only
+    // @ts-expect-error web only
     maxHeight: `calc(100% - ${BOTTOM_BAR_HEIGHT}px)`,
   },
 })

--- a/src/view/shell/Composer.web.tsx
+++ b/src/view/shell/Composer.web.tsx
@@ -5,6 +5,7 @@ import {useFocusGuards} from '@radix-ui/react-focus-guards'
 import {FocusScope} from '@radix-ui/react-focus-scope'
 import {RemoveScrollBar} from 'react-remove-scroll-bar'
 
+import {useA11y} from '#/state/a11y'
 import {useModals} from '#/state/modals'
 import {ComposerOpts, useComposerState} from '#/state/shell/composer'
 import {
@@ -41,6 +42,7 @@ function Inner({state}: {state: ComposerOpts}) {
   const {isModalActive} = useModals()
   const t = useTheme()
   const {gtMobile} = useBreakpoints()
+  const {reduceMotionEnabled} = useA11y()
   const [pickerState, setPickerState] = React.useState<EmojiPickerState>({
     isOpen: false,
     pos: {top: 0, left: 0, right: 0, bottom: 0, nextFocusRef: null},
@@ -78,7 +80,7 @@ function Inner({state}: {state: ComposerOpts}) {
           a.flex,
           a.flex_col,
           a.align_center,
-          a.fade_in,
+          !reduceMotionEnabled && a.fade_in,
         ])}
         onFocusOutside={evt => evt.preventDefault()}
         onInteractOutside={evt => evt.preventDefault()}
@@ -94,7 +96,7 @@ function Inner({state}: {state: ComposerOpts}) {
             !gtMobile && styles.containerMobile,
             t.atoms.bg,
             t.atoms.border_contrast_medium,
-            a.delayed_zoom_fade_in,
+            !reduceMotionEnabled && a.delayed_zoom_fade_in,
           ]}>
           <ComposePost
             cancelRef={ref}


### PR DESCRIPTION
Adds new animation atoms with some preset animations, and animates dialogs (including the composer) with a combined fade/zoom animation. Respects prefers-reduced-motion

It'd be nice to have exit animations on these, but the elements are unmounted on hide so would require deeper reworking to get that functional

https://github.com/user-attachments/assets/582de7a3-6f45-486d-8459-1d51b22094e6

# Test plan

Test different browsers, check that all the animations look good and don't impede functionality