### PR TITLE
Animate dropdown menus

### DIFF
--- a/src/components/Menu/index.web.tsx
+++ b/src/components/Menu/index.web.tsx
@@ -4,6 +4,7 @@ import {msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 import * as DropdownMenu from '@radix-ui/react-dropdown-menu'
 
+import {useA11y} from '#/state/a11y'
 import {atoms as a, flatten, useTheme, web} from '#/alf'
 import * as Dialog from '#/components/Dialog'
 import {useInteractionState} from '#/components/hooks/useInteractionState'
@@ -177,10 +178,15 @@ export function Outer({
   style?: StyleProp<ViewStyle>
 }>) {
   const t = useTheme()
+  const {reduceMotionEnabled} = useA11y()
 
   return (
     <DropdownMenu.Portal>
-      <DropdownMenu.Content sideOffset={5} loop aria-label="Test">
+      <DropdownMenu.Content
+        sideOffset={5}
+        loop
+        aria-label="Test"
+        className="dropdown-menu-transform-origin">
         <View
           style={[
             a.rounded_sm,
@@ -189,6 +195,7 @@ export function Outer({
             t.name === 'light' ? t.atoms.bg : t.atoms.bg_contrast_25,
             t.atoms.shadow_md,
             t.atoms.border_contrast_low,
+            !reduceMotionEnabled && a.zoom_fade_in,
             style,
           ]}>
           {children}

--- a/src/style.css
+++ b/src/style.css
@@ -187,6 +187,7 @@ input:focus {
   animation: rotate 500ms linear infinite;
 }
 
+/* animations for atoms */
 @keyframes fadeIn {
   from {
     opacity: 0;
@@ -211,24 +212,6 @@ input:focus {
   }
   to {
     transform: scale(1);
-  }
-}
-
-@keyframes slideInTop {
-  from {
-    transform: translateY(-0.5rem);
-  }
-  to {
-    transform: translateY(0);
-  }
-}
-
-@keyframes slideInBottom {
-  from {
-    transform: translateY(0.5rem);
-  }
-  to {
-    transform: translateY(0);
   }
 }
 

--- a/src/style.css
+++ b/src/style.css
@@ -214,6 +214,29 @@ input:focus {
   }
 }
 
+@keyframes slideInTop {
+  from {
+    transform: translateY(-0.5rem);
+  }
+  to {
+    transform: translateY(0);
+  }
+}
+
+@keyframes slideInBottom {
+  from {
+    transform: translateY(0.5rem);
+  }
+  to {
+    transform: translateY(0);
+  }
+}
+
+/* animating radix dropdowns requires knowing the data attributes */
+.dropdown-menu-transform-origin > * {
+  transform-origin: var(--radix-dropdown-menu-content-transform-origin);
+}
+
 .force-no-clicks > *,
 .force-no-clicks * {
   pointer-events: none !important;


### PR DESCRIPTION
# Stacked on https://github.com/bluesky-social/social-app/pull/7703

Animates dropdown menus with a fade/zoom, with the origin being towards the direction of the trigger. Works in both directions thanks to a special radix css variable. Respects prefers-reduced-motion

https://github.com/user-attachments/assets/6caa5372-6772-4fee-95f5-0e5fa66d5da4

