### PR TITLE
Update the ContentFilter setting for tenor gif search

### DIFF
--- a/src/state/queries/tenor.ts
+++ b/src/state/queries/tenor.ts
@@ -54,7 +54,7 @@ function createTenorApi<Input extends object>(
     // 30 is divisible by 2 and 3, so both 2 and 3 column layouts can be used
     params.set('limit', '30')
 
-    params.set('contentfilter', 'high')
+    params.set('contentfilter', 'low')
 
     params.set(
       'media_filter',


### PR DESCRIPTION
No other media "upload" (it's... Not really an upload here I guess, but still) limits content at post time, it is instead restricted at read-time by the client/viewer.

Per the [tenor docs](https://tenor.com/gifapi/documentation#contentfilter) the current "high" setting restricts it to the equivalent of "G-rated" gifs which quite frankly seems absurdly restrictive considering the other content that is permitted. This change as currently written bumps it to pg-13. 

I personally would just turn it "off" ("R-rated") but thought that was less likely to be accepted.