### PR TITLE
Exclude pins when polling author feed for updates

### DIFF
--- a/src/lib/api/feed/author.ts
+++ b/src/lib/api/feed/author.ts
@@ -33,6 +33,7 @@ export class AuthorFeedAPI implements FeedAPI {
     const res = await this.agent.getAuthorFeed({
       ...this.params,
       limit: 1,
+      includePins: false,
     })
     return res.data.feed[0]
   }


### PR DESCRIPTION
Fix the “new post” indicator (blue dot) for profiles with a pinned post.

Fixes #7697.