### PR TITLE
Make composer pills tappable when keyboard is active

### DIFF
--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -1124,6 +1124,7 @@ function ComposerPills({
         contentContainerStyle={[a.gap_sm]}
         horizontal={true}
         bounces={false}
+        keyboardShouldPersistTaps="always"
         showsHorizontalScrollIndicator={false}>
         {isReply ? null : (
           <ThreadgateBtn


### PR DESCRIPTION
The pill buttons at the bottom of the composer are inside a scrollview and pressing them while the keyboard is active does nothing besides dismiss the keyboard. This is inconsistent with the other composer controls which register presses even when the keyboard is active

Before | After
--- | ---
<video src="https://github.com/user-attachments/assets/fafb2e90-23da-4e76-9abc-012211775ebf"> | <video src="https://github.com/user-attachments/assets/5255fd6e-c7fa-4cc2-92e5-8bb215f20a73">