### PR TITLE
More i18n process updates

### DIFF
--- a/.github/workflows/nightly-update-source-languages.yaml
+++ b/.github/workflows/nightly-update-source-languages.yaml
@@ -1,0 +1,36 @@
+name: Nightly Update Source Languages
+on:
+  schedule:
+    - cron: '0 2 * * *' # run at 2 AM UTC
+  workflow_dispatch:
+
+jobs:
+  extract-languages:
+    name: Nightly Update Source Languages
+    runs-on: ubuntu-latest
+
+    permissions:
+      # Give the default GITHUB_TOKEN write permission to commit and push the
+      # added or changed files to the repository.
+      contents: write
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v3
+      - name: Install node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+      - name: Yarn install
+        uses: Wandalen/wretry.action@master
+        with:
+          command: yarn --frozen-lockfile
+          attempt_limit: 3
+          attempt_delay: 2000
+      - name: Extract language strings
+        run: yarn intl:extract
+      - name: Create commit
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: Nightly source-language update
+          file_pattern: /src/locale/locales/en/messages.po

--- a/docs/localization.md
+++ b/docs/localization.md
@@ -40,16 +40,18 @@ Please only request a new language when you are certain you will be able to cont
 
 Install the [Crowdin CLI](https://crowdin.github.io/crowdin-cli/). You will need to [configure your API token](https://crowdin.github.io/crowdin-cli/configuration) to access the project.
 
+### English source-file sync with Crowdin
+
+Every night, a GitHub action will run `yarn intl:extract` to update the english `messages.po` file. This will be automatically synced with Crowdin. Crowdin should notify all subscribed users of new translations.
+
 ### Release process
 
 1. Pull main and create a branch.
 1. Run `yarn intl:pull` to fetch all translation updates from Crowdin.
 1. Create a PR, ensure the translations all look correct, and merge.
-1. Merge all approved translation PRs (contributions from outside crowdin).
-1. Pull main.
-1. Run `yarn intl:extract` to sync the english `.po` file with the state of the app.
-1. Run `yarn intl:push` to sync Crowdin with the state of the repo.
-1. Commit the updated english `.po` and push to GitHub.
+1. If needed:
+  1. Merge all approved translation PRs (contributions from outside crowdin).
+  1. Run `yarn intl:push` to sync Crowdin with the state of the repo.
 
 ### Testing the translations in Crowdin
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "perf:test:results": "NODE_ENV=test flashlight report .perf/results.json",
     "perf:measure": "NODE_ENV=test flashlight measure",
     "intl:build": "yarn intl:extract && yarn intl:compile",
-    "intl:extract": "lingui extract --clean",
+    "intl:extract": "lingui extract --clean --locale en",
     "intl:compile": "lingui compile",
     "intl:pull": "crowdin download translations --verbose -b main",
     "intl:push": "crowdin push translations --verbose -b main",


### PR DESCRIPTION
This update automates the extraction of source-strings into the english `messages.po` file. It runs using a GitHub action every night, which should subsequently sync to Crowdin.