### PR TITLE
Add deploy key to nightly commit

### DIFF
--- a/.github/workflows/nightly-update-source-languages.yaml
+++ b/.github/workflows/nightly-update-source-languages.yaml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v3
+        with:
+          ssh-key: ${{secrets.GH_ACTION_DEPLOY_KEY}}
       - name: Install node
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
This PR incorporates the solution described in https://stackoverflow.com/questions/69263843/how-to-push-to-protected-main-branches-in-a-github-action to enable the nightly commit to happen.

Note:

- This secret is dangerous, so we should be mindful that we're giving commit power to that action (or any other action that uses that key)
- The secret is `GH_ACTION_DEPLOY_KEY`
- The deploy key is called `Github Action Commit Key`