### PR TITLE
deps: Bumps bitdrift to 0.6.8 & fixes iOS network instrumentation bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "@atproto/api": "^0.13.35",
-    "@bitdrift/react-native": "^0.6.2",
+    "@bitdrift/react-native": "^0.6.8",
     "@braintree/sanitize-url": "^6.0.2",
     "@discord/bottom-sheet": "bluesky-social/react-native-bottom-sheet",
     "@emoji-mart/react": "^1.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3427,10 +3427,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bitdrift/react-native@^0.6.2":
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/@bitdrift/react-native/-/react-native-0.6.2.tgz#8e75d45a63fccad38b310fdea8069fa929cb97c3"
-  integrity sha512-4DIsZwAr9/Q1RI7lsnUphRoMuOuLWWESNXI759niSmU8XHTJISwwOQzUm7qWn7waBJGhxaq+jn+vlTV5Fai6zw==
+"@bitdrift/react-native@^0.6.8":
+  version "0.6.8"
+  resolved "https://registry.yarnpkg.com/@bitdrift/react-native/-/react-native-0.6.8.tgz#386495857bc81345de418750b5ca0e3c3b964f6c"
+  integrity sha512-ixjJTEfUz3GeQ7srxpoYpnOGVx+iDA/A8Y3CZe5cg+/b0d8xur8fBKFoRBiXXohzJnYq4W8MIWIhLAwm5sD9oA==
   dependencies:
     "@expo/config-plugins" "^9.0.14"
     fast-json-stringify "^6.0.0"


### PR DESCRIPTION
This PR supersedes https://github.com/bluesky-social/social-app/pull/7575, the PR that added network instrumentation. 
It's important this PR is merged before adding `enableNetworkInstrumentation:true` to the bitdrift .init config since versions before 0.6.8 had a permission issue that caused the app to crash when backgrounded.

It may make sense to add the value of `enableNetworkInstrumentation` behind a feature flag. I'm going to leave that up to the maintainers if they want to enable the instrumentation, and if it should be feature flagged.

Take care :—)