### PR TITLE
Bitdrift integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "@atproto/api": "^0.13.35",
-    "@bitdrift/react-native": "^0.6.7",
+    "@bitdrift/react-native": "^0.6.8",
     "@braintree/sanitize-url": "^6.0.2",
     "@discord/bottom-sheet": "bluesky-social/react-native-bottom-sheet",
     "@emoji-mart/react": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "@atproto/api": "^0.13.35",
-    "@bitdrift/react-native": "^0.6.2",
+    "@bitdrift/react-native": "^0.6.7",
     "@braintree/sanitize-url": "^6.0.2",
     "@discord/bottom-sheet": "bluesky-social/react-native-bottom-sheet",
     "@emoji-mart/react": "^1.1.1",

--- a/src/lib/bitdrift.ts
+++ b/src/lib/bitdrift.ts
@@ -1,16 +1,21 @@
 import {init, SessionStrategy} from '@bitdrift/react-native'
 import {Statsig} from 'statsig-react-native-expo'
-export {debug, error, info, warn} from '@bitdrift/react-native'
 
 import {initPromise} from './statsig/statsig'
+
+export {debug, error, info, warn} from '@bitdrift/react-native'
 
 const BITDRIFT_API_KEY = process.env.BITDRIFT_API_KEY
 
 initPromise.then(() => {
   let isEnabled = false
+  let isNetworkEnabled = false
   try {
-    if (Statsig.checkGate('enable_bitdrift')) {
+    if (Statsig.checkGate('enable_bitdrift_v2')) {
       isEnabled = true
+    }
+    if (Statsig.checkGate('enable_bitdrift_v2_networking')) {
+      isNetworkEnabled = true
     }
   } catch (e) {
     // Statsig may complain about it being called too early.
@@ -18,6 +23,8 @@ initPromise.then(() => {
   if (isEnabled && BITDRIFT_API_KEY) {
     init(BITDRIFT_API_KEY, SessionStrategy.Activity, {
       url: 'https://api-bsky.bitdrift.io',
+      // Only effects iOS, Android instrumentation is set via Gradle Plugin
+      enableNetworkInstrumentation: isNetworkEnabled,
     })
   }
 })

--- a/src/lib/bitdrift.ts
+++ b/src/lib/bitdrift.ts
@@ -1,9 +1,8 @@
 import {init, SessionStrategy} from '@bitdrift/react-native'
 import {Statsig} from 'statsig-react-native-expo'
-
-import {initPromise} from '#/lib/statsig/statsig'
-
 export {debug, error, info, warn} from '@bitdrift/react-native'
+
+import {initPromise} from './statsig/statsig'
 
 const BITDRIFT_API_KEY = process.env.BITDRIFT_API_KEY
 
@@ -19,8 +18,6 @@ initPromise.then(() => {
   if (isEnabled && BITDRIFT_API_KEY) {
     init(BITDRIFT_API_KEY, SessionStrategy.Activity, {
       url: 'https://api-bsky.bitdrift.io',
-      // TODO gate?
-      enableNetworkInstrumentation: true, // Only effects iOS, Android instrumentation is set via Gradle Plugin
     })
   }
 })

--- a/src/lib/bitdrift.ts
+++ b/src/lib/bitdrift.ts
@@ -2,6 +2,7 @@ import {init, SessionStrategy} from '@bitdrift/react-native'
 import {Statsig} from 'statsig-react-native-expo'
 
 import {initPromise} from '#/lib/statsig/statsig'
+import {logger} from '#/logger'
 
 export {debug, error, info, warn} from '@bitdrift/react-native'
 
@@ -18,10 +19,13 @@ initPromise.then(() => {
     // Statsig may complain about it being called too early.
   }
   if (isEnabled && BITDRIFT_API_KEY) {
+    logger.info('Bitdrift is enabled')
     init(BITDRIFT_API_KEY, SessionStrategy.Activity, {
       url: 'https://api-bsky.bitdrift.io',
       // TODO gate
       enableNetworkInstrumentation: true, // Only effects iOS, Android instrumentation is set via Gradle Plugin
     })
+  } else {
+    logger.info('Bitdrift is disabled')
   }
 })

--- a/src/lib/bitdrift.ts
+++ b/src/lib/bitdrift.ts
@@ -8,7 +8,8 @@ export {debug, error, info, warn} from '@bitdrift/react-native'
 const BITDRIFT_API_KEY = process.env.BITDRIFT_API_KEY
 
 initPromise.then(() => {
-  let isEnabled = false
+  // TODO revert
+  let isEnabled = true
   try {
     if (Statsig.checkGate('enable_bitdrift')) {
       isEnabled = true

--- a/src/lib/bitdrift.ts
+++ b/src/lib/bitdrift.ts
@@ -18,6 +18,7 @@ initPromise.then(() => {
   if (isEnabled && BITDRIFT_API_KEY) {
     init(BITDRIFT_API_KEY, SessionStrategy.Activity, {
       url: 'https://api-bsky.bitdrift.io',
+      // TODO gate
       enableNetworkInstrumentation: true, // Only effects iOS, Android instrumentation is set via Gradle Plugin
     })
   }

--- a/src/lib/bitdrift.ts
+++ b/src/lib/bitdrift.ts
@@ -2,15 +2,13 @@ import {init, SessionStrategy} from '@bitdrift/react-native'
 import {Statsig} from 'statsig-react-native-expo'
 
 import {initPromise} from '#/lib/statsig/statsig'
-import {logger} from '#/logger'
 
 export {debug, error, info, warn} from '@bitdrift/react-native'
 
 const BITDRIFT_API_KEY = process.env.BITDRIFT_API_KEY
 
 initPromise.then(() => {
-  // TODO revert
-  let isEnabled = true
+  let isEnabled = false
   try {
     if (Statsig.checkGate('enable_bitdrift')) {
       isEnabled = true
@@ -19,13 +17,10 @@ initPromise.then(() => {
     // Statsig may complain about it being called too early.
   }
   if (isEnabled && BITDRIFT_API_KEY) {
-    logger.info('Bitdrift is enabled')
     init(BITDRIFT_API_KEY, SessionStrategy.Activity, {
       url: 'https://api-bsky.bitdrift.io',
-      // TODO gate
+      // TODO gate?
       enableNetworkInstrumentation: true, // Only effects iOS, Android instrumentation is set via Gradle Plugin
     })
-  } else {
-    logger.info('Bitdrift is disabled')
   }
 })

--- a/src/lib/bitdrift.ts
+++ b/src/lib/bitdrift.ts
@@ -18,6 +18,7 @@ initPromise.then(() => {
   if (isEnabled && BITDRIFT_API_KEY) {
     init(BITDRIFT_API_KEY, SessionStrategy.Activity, {
       url: 'https://api-bsky.bitdrift.io',
+      enableNetworkInstrumentation: true, // Only effects iOS, Android instrumentation is set via Gradle Plugin
     })
   }
 })

--- a/src/lib/bitdrift.ts
+++ b/src/lib/bitdrift.ts
@@ -1,8 +1,9 @@
 import {init, SessionStrategy} from '@bitdrift/react-native'
 import {Statsig} from 'statsig-react-native-expo'
-export {debug, error, info, warn} from '@bitdrift/react-native'
 
-import {initPromise} from './statsig/statsig'
+import {initPromise} from '#/lib/statsig/statsig'
+
+export {debug, error, info, warn} from '@bitdrift/react-native'
 
 const BITDRIFT_API_KEY = process.env.BITDRIFT_API_KEY
 

--- a/src/lib/statsig/statsig.tsx
+++ b/src/lib/statsig/statsig.tsx
@@ -4,7 +4,6 @@ import {AppState, AppStateStatus} from 'react-native'
 import {Statsig, StatsigProvider} from 'statsig-react-native-expo'
 
 import {BUNDLE_DATE, BUNDLE_IDENTIFIER, IS_TESTFLIGHT} from '#/lib/app-info'
-import * as bitdrift from '#/lib/bitdrift'
 import {logger} from '#/logger'
 import {isWeb} from '#/platform/detection'
 import * as persisted from '#/state/persisted'
@@ -106,7 +105,7 @@ export function logEvent<E extends keyof LogEvents>(
     console.groupCollapsed(eventName)
     console.log(fullMetadata)
     console.groupEnd()
-    bitdrift.info(eventName, fullMetadata)
+    logger.info(eventName, fullMetadata)
   } catch (e) {
     // A log should never interrupt the calling code, whatever happens.
     logger.error('Failed to log an event', {message: e})

--- a/src/lib/statsig/statsig.tsx
+++ b/src/lib/statsig/statsig.tsx
@@ -4,6 +4,7 @@ import {AppState, AppStateStatus} from 'react-native'
 import {Statsig, StatsigProvider} from 'statsig-react-native-expo'
 
 import {BUNDLE_DATE, BUNDLE_IDENTIFIER, IS_TESTFLIGHT} from '#/lib/app-info'
+import * as bitdrift from '#/lib/bitdrift'
 import {logger} from '#/logger'
 import {isWeb} from '#/platform/detection'
 import * as persisted from '#/state/persisted'
@@ -105,7 +106,7 @@ export function logEvent<E extends keyof LogEvents>(
     console.groupCollapsed(eventName)
     console.log(fullMetadata)
     console.groupEnd()
-    logger.info(eventName, fullMetadata)
+    bitdrift.info(eventName, fullMetadata)
   } catch (e) {
     // A log should never interrupt the calling code, whatever happens.
     logger.error('Failed to log an event', {message: e})

--- a/src/screens/Settings/AboutSettings.tsx
+++ b/src/screens/Settings/AboutSettings.tsx
@@ -1,8 +1,10 @@
+import {useMemo} from 'react'
 import {Platform} from 'react-native'
 import {setStringAsync} from 'expo-clipboard'
 import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 import {NativeStackScreenProps} from '@react-navigation/native-stack'
+import {Statsig} from 'statsig-react-native-expo'
 
 import {appVersion, BUNDLE_DATE, bundleInfo} from '#/lib/app-info'
 import {STATUS_PAGE_URL} from '#/lib/constants'
@@ -20,6 +22,7 @@ type Props = NativeStackScreenProps<CommonNavigatorParams, 'AboutSettings'>
 export function AboutSettingsScreen({}: Props) {
   const {_} = useLingui()
   const [devModeEnabled, setDevModeEnabled] = useDevModeEnabled()
+  const stableID = useMemo(() => Statsig.getStableID(), [])
 
   return (
     <Layout.Screen>
@@ -79,7 +82,7 @@ export function AboutSettingsScreen({}: Props) {
             }}
             onPress={() => {
               setStringAsync(
-                `Build version: ${appVersion}; Bundle info: ${bundleInfo}; Bundle date: ${BUNDLE_DATE}; Platform: ${Platform.OS}; Platform version: ${Platform.Version}`,
+                `Build version: ${appVersion}; Bundle info: ${bundleInfo}; Bundle date: ${BUNDLE_DATE}; Platform: ${Platform.OS}; Platform version: ${Platform.Version}; Anonymous ID: ${stableID}`,
               )
               Toast.show(_(msg`Copied build version to clipboard`))
             }}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3427,10 +3427,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bitdrift/react-native@^0.6.7":
-  version "0.6.7"
-  resolved "https://registry.yarnpkg.com/@bitdrift/react-native/-/react-native-0.6.7.tgz#cc64b3c0563a083341f2d974a371178fc43dd93f"
-  integrity sha512-Cf3hKuYHHTx57HAEd1pwX4fWgJ6iUYqjtsdzNTPPLHlyU2ChWskKizyNcPFhZlWSVzMszlFTzVkP4dBVHNhlJg==
+"@bitdrift/react-native@^0.6.8":
+  version "0.6.8"
+  resolved "https://registry.yarnpkg.com/@bitdrift/react-native/-/react-native-0.6.8.tgz#386495857bc81345de418750b5ca0e3c3b964f6c"
+  integrity sha512-ixjJTEfUz3GeQ7srxpoYpnOGVx+iDA/A8Y3CZe5cg+/b0d8xur8fBKFoRBiXXohzJnYq4W8MIWIhLAwm5sD9oA==
   dependencies:
     "@expo/config-plugins" "^9.0.14"
     fast-json-stringify "^6.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3427,10 +3427,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bitdrift/react-native@^0.6.2":
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/@bitdrift/react-native/-/react-native-0.6.2.tgz#8e75d45a63fccad38b310fdea8069fa929cb97c3"
-  integrity sha512-4DIsZwAr9/Q1RI7lsnUphRoMuOuLWWESNXI759niSmU8XHTJISwwOQzUm7qWn7waBJGhxaq+jn+vlTV5Fai6zw==
+"@bitdrift/react-native@^0.6.7":
+  version "0.6.7"
+  resolved "https://registry.yarnpkg.com/@bitdrift/react-native/-/react-native-0.6.7.tgz#cc64b3c0563a083341f2d974a371178fc43dd93f"
+  integrity sha512-Cf3hKuYHHTx57HAEd1pwX4fWgJ6iUYqjtsdzNTPPLHlyU2ChWskKizyNcPFhZlWSVzMszlFTzVkP4dBVHNhlJg==
   dependencies:
     "@expo/config-plugins" "^9.0.14"
     fast-json-stringify "^6.0.0"


### PR DESCRIPTION
Includes two PRs relating to version bumps, which puts us at the latest version.

This PR then integrates two new feature flags:
- `enable_bitdrift_v2` which replaces the initial flag
- `enable_bitdrift_v2_networking` which conditionally enables network logging (which caused a bug previously)

Decided to replace the initial flag so that as we ramp this new version, we don't ramp older clients that are still using the old version of the Bitdrift library.

Tested on TF and APK. Web should have no changes.