### PR TITLE
Reenable router events

### DIFF
--- a/src/Navigation.tsx
+++ b/src/Navigation.tsx
@@ -721,15 +721,20 @@ function RoutesContainer({children}: React.PropsWithChildren<{}>) {
       linking={LINKING}
       theme={theme}
       onStateChange={() => {
-        const routeName = getCurrentRouteName()
-        if (routeName === 'Notifications') {
-          logEvent('router:navigate:notifications', {})
-        }
+        const currentRouteName = getCurrentRouteName()
+        logEvent('lake:router:navigate', {
+          from: prevLoggedRouteName.current,
+          to: currentRouteName,
+        })
+        prevLoggedRouteName.current = currentRouteName
       }}
       onReady={() => {
         attachRouteToLogEvents(getCurrentRouteName)
         logModuleInitTime()
         onReady()
+        logEvent('lake:router:navigate', {
+          to: getCurrentRouteName(),
+        })
       }}>
       {children}
     </NavigationContainer>

--- a/src/lib/statsig/events.ts
+++ b/src/lib/statsig/events.ts
@@ -30,7 +30,10 @@ export type LogEvents = {
     secondsActive: number
   }
   'state:foreground': {}
-  'router:navigate:notifications': {}
+  'lake:router:navigate': {
+    to?: string
+    from?: string
+  }
   'deepLink:referrerReceived': {
     to: string
     referrer: string


### PR DESCRIPTION
# DO NOT MERGE UNTIL MIDDLEMAN IS READY

Reenables `router:navigate`, except not sent to statsig using `lake:` prefix

Sends the previous and next route.

# Test plan

Replace `logEvent` with `console.log`, confirm it looks good