### PR TITLE
Use effective filtering for feeds

### DIFF
--- a/src/state/queries/feed.ts
+++ b/src/state/queries/feed.ts
@@ -330,7 +330,7 @@ export function useSearchPopularFeedsMutation() {
       if (moderationOpts) {
         return res.data.feeds.filter(feed => {
           const decision = moderateFeedGenerator(feed, moderationOpts)
-          return !decision.ui('contentList').filter
+          return !decision.ui('contentMedia').blur
         })
       }
 
@@ -371,7 +371,7 @@ export function usePopularFeedsSearch({
     select(data) {
       return data.filter(feed => {
         const decision = moderateFeedGenerator(feed, moderationOpts!)
-        return !decision.ui('contentList').filter
+        return !decision.ui('contentMedia').blur
       })
     },
   })


### PR DESCRIPTION
In #4818 we added filtering for labels on feeds, but in most cases it was not effective. This PR opts to use `contentMedia` view for feeds, which is technically not correct for this use case, but does the job it should be doing for now.

We will follow-up with improvements to make this more sound in the near future.