### PR TITLE
Fix "log in", "log out" to "sign in", "sign out"

### DIFF
--- a/src/App.native.tsx
+++ b/src/App.native.tsx
@@ -118,7 +118,7 @@ function InnerApp() {
   useEffect(() => {
     return listenSessionDropped(() => {
       Toast.show(
-        _(msg`Sorry! Your session expired. Please log in again.`),
+        _(msg`Sorry! Your session expired. Please sign in again.`),
         'info',
       )
     })

--- a/src/App.web.tsx
+++ b/src/App.web.tsx
@@ -94,7 +94,7 @@ function InnerApp() {
   useEffect(() => {
     return listenSessionDropped(() => {
       Toast.show(
-        _(msg`Sorry! Your session expired. Please log in again.`),
+        _(msg`Sorry! Your session expired. Please sign in again.`),
         'info',
       )
     })

--- a/src/components/AccountList.tsx
+++ b/src/components/AccountList.tsx
@@ -62,7 +62,7 @@ export function AccountList({
         testID="chooseAddAccountBtn"
         style={[a.flex_1]}
         onPress={pendingDid ? undefined : onPressAddAccount}
-        label={_(msg`Login to account that is not listed`)}>
+        label={_(msg`Sign in to account that is not listed`)}>
         {({hovered, pressed}) => (
           <View
             style={[

--- a/src/components/dialogs/Signin.tsx
+++ b/src/components/dialogs/Signin.tsx
@@ -43,7 +43,7 @@ function SigninDialogInner({}: {control: Dialog.DialogOuterProps['control']}) {
 
   return (
     <Dialog.ScrollableInner
-      label={_(msg`Sign into Bluesky or create a new account`)}
+      label={_(msg`Sign in to Bluesky or create a new account`)}
       style={[gtMobile ? {width: 'auto', maxWidth: 420} : a.w_full]}>
       <View style={[!isNative && a.p_2xl]}>
         <View

--- a/src/screens/Deactivated.tsx
+++ b/src/screens/Deactivated.tsx
@@ -86,7 +86,7 @@ export function Deactivated() {
         case 'Bad token scope':
           setError(
             _(
-              msg`You're logged in with an App Password. Please sign in with your main password to continue deactivating your account.`,
+              msg`You're signed in with an App Password. Please sign in with your main password to continue deactivating your account.`,
             ),
           )
           break

--- a/src/screens/Deactivated.tsx
+++ b/src/screens/Deactivated.tsx
@@ -86,7 +86,7 @@ export function Deactivated() {
         case 'Bad token scope':
           setError(
             _(
-              msg`You're logged in with an App Password. Please log in with your main password to continue deactivating your account.`,
+              msg`You're logged in with an App Password. Please sign in with your main password to continue deactivating your account.`,
             ),
           )
           break
@@ -148,7 +148,7 @@ export function Deactivated() {
                 {pending && <ButtonIcon icon={Loader} position="right" />}
               </Button>
               <Button
-                label={_(msg`Cancel reactivation and log out`)}
+                label={_(msg`Cancel reactivation and sign out`)}
                 size="large"
                 variant="solid"
                 color="secondary"
@@ -183,7 +183,7 @@ export function Deactivated() {
             <>
               <Text
                 style={[t.atoms.text_contrast_medium, a.pb_md, a.leading_snug]}>
-                <Trans>Or, log into one of your other accounts.</Trans>
+                <Trans>Or, sign in to one of your other accounts.</Trans>
               </Text>
               <AccountList
                 onSelectAccount={onSelectAccount}
@@ -199,13 +199,13 @@ export function Deactivated() {
                 <Trans>Or, continue with another account.</Trans>
               </Text>
               <Button
-                label={_(msg`Log in or sign up`)}
+                label={_(msg`Sign in or sign up`)}
                 size="large"
                 variant="solid"
                 color="secondary"
                 onPress={() => setShowLoggedOut(true)}>
                 <ButtonText>
-                  <Trans>Log in or sign up</Trans>
+                  <Trans>Sign in or sign up</Trans>
                 </ButtonText>
               </Button>
             </>

--- a/src/screens/Login/LoginForm.tsx
+++ b/src/screens/Login/LoginForm.tsx
@@ -290,7 +290,9 @@ export const LoginForm = ({
             />
           </TextField.Root>
           <Text style={[a.text_sm, t.atoms.text_contrast_medium, a.mt_sm]}>
-            <Trans>Check your email for a login code and enter it here.</Trans>
+            <Trans>
+              Check your email for a sign in code and enter it here.
+            </Trans>
           </Text>
         </View>
       )}
@@ -311,7 +313,7 @@ export const LoginForm = ({
           <Button
             testID="loginRetryButton"
             label={_(msg`Retry`)}
-            accessibilityHint={_(msg`Retries login`)}
+            accessibilityHint={_(msg`Retries sign in`)}
             variant="solid"
             color="secondary"
             size="large"

--- a/src/screens/Settings/components/AddAppPasswordDialog.tsx
+++ b/src/screens/Settings/components/AddAppPasswordDialog.tsx
@@ -188,7 +188,7 @@ function CreateDialogInner({passwords}: {passwords: string[]}) {
               </Text>
               <Text style={[a.text_md, a.leading_snug]}>
                 <Trans>
-                  Use this to sign into the other app along with your handle.
+                  Use this to sign in to the other app along with your handle.
                 </Trans>
               </Text>
               <CopyButton

--- a/src/screens/Settings/components/DeactivateAccountDialog.tsx
+++ b/src/screens/Settings/components/DeactivateAccountDialog.tsx
@@ -51,7 +51,7 @@ function DeactivateAccountDialogInner({
         case 'Bad token scope':
           setError(
             _(
-              msg`You're logged in with an App Password. Please log in with your main password to continue deactivating your account.`,
+              msg`You're logged in with an App Password. Please sign in with your main password to continue deactivating your account.`,
             ),
           )
           break

--- a/src/screens/Settings/components/DeactivateAccountDialog.tsx
+++ b/src/screens/Settings/components/DeactivateAccountDialog.tsx
@@ -51,7 +51,7 @@ function DeactivateAccountDialogInner({
         case 'Bad token scope':
           setError(
             _(
-              msg`You're logged in with an App Password. Please sign in with your main password to continue deactivating your account.`,
+              msg`You're signed in with an App Password. Please sign in with your main password to continue deactivating your account.`,
             ),
           )
           break

--- a/src/screens/Settings/components/Email2FAToggle.tsx
+++ b/src/screens/Settings/components/Email2FAToggle.tsx
@@ -51,7 +51,7 @@ export function Email2FAToggle() {
       <Prompt.Basic
         control={enableDialogControl}
         title={_(msg`Enable Email 2FA`)}
-        description={_(msg`Require an email code to log in to your account.`)}
+        description={_(msg`Require an email code to sign in to your account.`)}
         onConfirm={enableEmailAuthFactor}
         confirmButtonCta={_(msg`Enable`)}
       />

--- a/src/screens/SignupQueued.tsx
+++ b/src/screens/SignupQueued.tsx
@@ -90,10 +90,10 @@ export function SignupQueued() {
       variant="ghost"
       size="large"
       color="primary"
-      label={_(msg`Log out`)}
+      label={_(msg`Sign out`)}
       onPress={() => logoutCurrentAccount('SignupQueued')}>
       <ButtonText>
-        <Trans>Log out</Trans>
+        <Trans>Sign out</Trans>
       </ButtonText>
     </Button>
   )

--- a/src/screens/Takendown.tsx
+++ b/src/screens/Takendown.tsx
@@ -82,10 +82,10 @@ export function Takendown() {
         variant="solid"
         size="large"
         color="secondary_inverted"
-        label={_(msg`Log out`)}
+        label={_(msg`Sign out`)}
         onPress={() => logoutCurrentAccount('Takendown')}>
         <ButtonText>
-          <Trans>Log Out</Trans>
+          <Trans>Sign Out</Trans>
         </ButtonText>
       </Button>
     )

--- a/src/state/queries/list-memberships.ts
+++ b/src/state/queries/list-memberships.ts
@@ -101,7 +101,7 @@ export function useListMembershipAddMutation() {
   >({
     mutationFn: async ({listUri, actorDid}) => {
       if (!currentAccount) {
-        throw new Error('Not logged in')
+        throw new Error('Not signed in')
       }
       const res = await agent.app.bsky.graph.listitem.create(
         {repo: currentAccount.did},
@@ -160,7 +160,7 @@ export function useListMembershipRemoveMutation() {
   >({
     mutationFn: async ({membershipUri}) => {
       if (!currentAccount) {
-        throw new Error('Not logged in')
+        throw new Error('Not signed in')
       }
       const membershipUrip = new AtUri(membershipUri)
       await agent.app.bsky.graph.listitem.delete({

--- a/src/state/queries/list.ts
+++ b/src/state/queries/list.ts
@@ -60,7 +60,7 @@ export function useListCreateMutation() {
         avatar,
       }) {
         if (!currentAccount) {
-          throw new Error('Not logged in')
+          throw new Error('Not signed in')
         }
         if (
           purpose !== 'app.bsky.graph.defs#curatelist' &&
@@ -126,7 +126,7 @@ export function useListMetadataMutation() {
     async mutationFn({uri, name, description, descriptionFacets, avatar}) {
       const {hostname, rkey} = new AtUri(uri)
       if (!currentAccount) {
-        throw new Error('Not logged in')
+        throw new Error('Not signed in')
       }
       if (currentAccount.did !== hostname) {
         throw new Error('You do not own this list')

--- a/src/state/queries/messages/actor-declaration.ts
+++ b/src/state/queries/messages/actor-declaration.ts
@@ -18,7 +18,7 @@ export function useUpdateActorDeclaration({
 
   return useMutation({
     mutationFn: async (allowIncoming: 'all' | 'none' | 'following') => {
-      if (!currentAccount) throw new Error('Not logged in')
+      if (!currentAccount) throw new Error('Not signed in')
       const result = await agent.api.com.atproto.repo.putRecord({
         repo: currentAccount.did,
         collection: 'chat.bsky.actor.declaration',
@@ -68,7 +68,7 @@ export function useDeleteActorDeclaration() {
 
   return useMutation({
     mutationFn: async () => {
-      if (!currentAccount) throw new Error('Not logged in')
+      if (!currentAccount) throw new Error('Not signed in')
       // TODO(sam): remove validate: false once PDSes have the new lexicon
       const result = await agent.api.com.atproto.repo.deleteRecord({
         repo: currentAccount.did,

--- a/src/state/queries/pinned-post.ts
+++ b/src/state/queries/pinned-post.ts
@@ -32,7 +32,7 @@ export function usePinnedPostMutation() {
         updatePostShadow(queryClient, postUri, {pinned: pinCurrentPost})
 
         // get the currently pinned post so we can optimistically remove the pin from it
-        if (!currentAccount) throw new Error('Not logged in')
+        if (!currentAccount) throw new Error('Not signed in')
         const {data: profile} = await agent.getProfile({
           actor: currentAccount.did,
         })

--- a/src/state/queries/starter-packs.ts
+++ b/src/state/queries/starter-packs.ts
@@ -294,7 +294,7 @@ export function useDeleteStarterPackMutation({
   return useMutation({
     mutationFn: async ({listUri, rkey}: {listUri?: string; rkey: string}) => {
       if (!agent.session) {
-        throw new Error(`Requires logged in user`)
+        throw new Error(`Requires signed in user`)
       }
 
       if (listUri) {

--- a/src/view/com/auth/SplashScreen.tsx
+++ b/src/view/com/auth/SplashScreen.tsx
@@ -60,7 +60,7 @@ export const SplashScreen = ({
             onPress={onPressSignin}
             label={_(msg`Sign in`)}
             accessibilityHint={_(
-              msg`Opens flow to sign into your existing Bluesky account`,
+              msg`Opens flow to sign in to your existing Bluesky account`,
             )}
             size="large"
             variant="solid"

--- a/src/view/com/auth/SplashScreen.web.tsx
+++ b/src/view/com/auth/SplashScreen.web.tsx
@@ -122,7 +122,7 @@ export const SplashScreen = ({
                 onPress={onPressSignin}
                 label={_(msg`Sign in`)}
                 accessibilityHint={_(
-                  msg`Opens flow to sign into your existing Bluesky account`,
+                  msg`Opens flow to sign in to your existing Bluesky account`,
                 )}
                 size="large"
                 variant="solid"

--- a/src/view/com/profile/ProfileMenu.tsx
+++ b/src/view/com/profile/ProfileMenu.tsx
@@ -382,7 +382,7 @@ let ProfileMenu = ({
         control={loggedOutWarningPromptControl}
         title={_(msg`Note about sharing`)}
         description={_(
-          msg`This profile is only visible to logged-in users. It won't be visible to people who aren't logged in.`,
+          msg`This profile is only visible to logged-in users. It won't be visible to people who aren't signed in.`,
         )}
         onConfirm={onPressShare}
         confirmButtonCta={_(msg`Share anyway`)}

--- a/src/view/com/util/forms/PostDropdownBtnMenuItems.tsx
+++ b/src/view/com/util/forms/PostDropdownBtnMenuItems.tsx
@@ -717,7 +717,7 @@ let PostDropdownMenuItems = ({
         control={loggedOutWarningPromptControl}
         title={_(msg`Note about sharing`)}
         description={_(
-          msg`This post is only visible to logged-in users. It won't be visible to people who aren't logged in.`,
+          msg`This post is only visible to logged-in users. It won't be visible to people who aren't signed in.`,
         )}
         onConfirm={onSharePost}
         confirmButtonCta={_(msg`Share anyway`)}

--- a/src/view/com/util/post-ctrls/PostCtrls.tsx
+++ b/src/view/com/util/post-ctrls/PostCtrls.tsx
@@ -366,7 +366,7 @@ let PostCtrls = ({
             control={loggedOutWarningPromptControl}
             title={_(msg`Note about sharing`)}
             description={_(
-              msg`This post is only visible to logged-in users. It won't be visible to people who aren't logged in.`,
+              msg`This post is only visible to logged-in users. It won't be visible to people who aren't signed in.`,
             )}
             onConfirm={onShare}
             confirmButtonCta={_(msg`Share anyway`)}

--- a/src/view/screens/DebugMod.tsx
+++ b/src/view/screens/DebugMod.tsx
@@ -378,9 +378,9 @@ export const DebugModScreen = ({}: NativeStackScreenProps<
                           <Toggle.Checkbox />
                           <Toggle.LabelText>Adult disabled</Toggle.LabelText>
                         </Toggle.Item>
-                        <Toggle.Item name="loggedOut" label="Logged out">
+                        <Toggle.Item name="loggedOut" label="Signed out">
                           <Toggle.Checkbox />
-                          <Toggle.LabelText>Logged out</Toggle.LabelText>
+                          <Toggle.LabelText>Signed out</Toggle.LabelText>
                         </Toggle.Item>
                       </View>
                     </Toggle.Group>


### PR DESCRIPTION
Fixes "log in", "log out" to "sign in", "sign out". Since most of the inside of the app uses "sign", it made sense to unify it to "sign".

Please let me know if "sign" and "log" are used interchangeably.

And based on multiple search results, fixes "sign into" to "sign in to".
https://linguix.com/english/common-mistake/sign_into
https://www.scribbr.com/frequently-asked-questions/log-into-or-log-in-to/