### PR TITLE
Fix view containers not showing properly in other languages

### DIFF
--- a/src/components/ProgressGuide/Toast.tsx
+++ b/src/components/ProgressGuide/Toast.tsx
@@ -159,7 +159,7 @@ export const ProgressGuideToast = React.forwardRef<
               fill={t.palette.primary_500}
               ref={animatedCheckRef}
             />
-            <View>
+            <View style={[a.flex_1]}>
               <Text style={[a.text_md, a.font_bold]}>{title}</Text>
               {subtitle && (
                 <Text style={[a.text_sm, t.atoms.text_contrast_medium]}>

--- a/src/view/shell/desktop/LeftNav.tsx
+++ b/src/view/shell/desktop/LeftNav.tsx
@@ -501,7 +501,7 @@ function ComposeBtn() {
         size="large"
         variant="solid"
         color="primary"
-        style={[a.rounded_full]}>
+        style={[a.rounded_full, a.flex_shrink]}>
         <ButtonIcon icon={EditBig} position="left" />
         <ButtonText>
           <Trans context="action">New Post</Trans>


### PR DESCRIPTION
Some text and containers seem to not act properly when they use more words like in other languages, this should hopefully address the bigger issues that are found: New Post button seems to go outside of the container that is `LeftNav` and the `Toast` text overflows and hides the icon if it doesn't have enough space.

| Before | After |
| --- | --- |
| ![overflow](https://github.com/user-attachments/assets/aafb91da-cb59-42b3-a617-ebc06459cf68) | ![nooverflow](https://github.com/user-attachments/assets/905d0d4c-4835-44c7-b30d-f6ed4c97c766) |

| Before | After |
| --- | --- |
| ![zen_17-22-34-50](https://github.com/user-attachments/assets/35faae20-470f-4fbf-a117-2b09bb9576ef) | ![zen_17-22-50-17](https://github.com/user-attachments/assets/daf353e6-bcda-466c-910b-1e128d16c3d3) |
