### PR TITLE
Message sent time is not updated immediately in ChatList screen

### DIFF
--- a/src/view/com/util/TimeElapsed.tsx
+++ b/src/view/com/util/TimeElapsed.tsx
@@ -22,8 +22,11 @@ export function TimeElapsed({
   )
 
   const [prevTick, setPrevTick] = useState(tick)
-  if (prevTick !== tick) {
+  const [prevTimestamp, setPrevTimestamp] = useState(timestamp)
+
+  if (prevTick !== tick || prevTimestamp !== timestamp) {
     setPrevTick(tick)
+    setPrevTimestamp(timestamp)
     setTimeAgo(
       timeToString ? timeToString(i18n, timestamp) : ago(timestamp, tick),
     )


### PR DESCRIPTION
Hi, I noticed that the message sent time doesn't update immediately but only on next tick. This PR addresses that. Let me know if this was intentional, and feel free to close it if so. Thanks!

closes #7710 

### Before

https://github.com/user-attachments/assets/4faac090-21dc-4dd2-b7ce-5bfdb9078bb6

### After

https://github.com/user-attachments/assets/933a1fd4-20ed-4004-a969-cc934b72169a
