### PR TITLE
Fix likes tab endlessly pagniating

### DIFF
--- a/src/lib/api/feed/likes.ts
+++ b/src/lib/api/feed/likes.ts
@@ -42,8 +42,10 @@ export class LikesFeedAPI implements FeedAPI {
       limit,
     })
     if (res.success) {
+      // HACKFIX: the API incorrectly returns a cursor when there are no items -sfn
+      const isEmptyPage = res.data.feed.length === 0
       return {
-        cursor: res.data.cursor,
+        cursor: isEmptyPage ? undefined : res.data.cursor,
         feed: res.data.feed,
       }
     }


### PR DESCRIPTION
Fixes #4879 #4931 #6179

I believe this is an error on the server side - it returns a cursor even when there are no more results. This is easy enough to detect and fix clientside, so let's do that.

# Test plan

Check the likes tab on an account with no or few likes