### PR TITLE
Remove shadowed follow gate handling

### DIFF
--- a/src/view/com/util/post-ctrls/PostCtrls.tsx
+++ b/src/view/com/util/post-ctrls/PostCtrls.tsx
@@ -26,7 +26,6 @@ import {makeProfileLink} from '#/lib/routes/links'
 import {shareUrl} from '#/lib/sharing'
 import {useGate} from '#/lib/statsig/statsig'
 import {toShareUrl} from '#/lib/strings/url-helpers'
-import {useProfileShadow} from '#/state/cache/profile-shadow'
 import {Shadow} from '#/state/cache/types'
 import {useFeedFeedbackContext} from '#/state/feed-feedback'
 import {
@@ -94,15 +93,7 @@ let PostCtrls = ({
       post.author.viewer?.blockedBy ||
       post.author.viewer?.blockingByList,
   )
-
-  const shadowedAuthor = useProfileShadow(post.author)
-  const followersCanReply = !!threadgateRecord?.allow?.find(
-    rule => rule.$type === 'app.bsky.feed.threadgate#followerRule',
-  )
-  const canOverrideReplyDisabled =
-    followersCanReply &&
-    shadowedAuthor.viewer?.following?.startsWith('at://did')
-  const replyDisabled = post.viewer?.replyDisabled && !canOverrideReplyDisabled
+  const replyDisabled = post.viewer?.replyDisabled
 
   const shouldShowLoggedOutWarning = React.useMemo(() => {
     return (


### PR DESCRIPTION
This handling was supposed to use the profile shadow cache to check if the viewer was following the root post author, but instead it was checking only the highlighted post and not the root.

Unfortunately, we do not have the root `PostView` available to us in all post contexts e.g. reply notifications. This means we can't pull a profile out of the cache, and therefore we can't optimistically handle follows when calculating reply disablement.

We _can_ do this in some contexts, namely threads and feeds, but a closer eye needs to be given to this problem to ensure that we accurately compute `replyDisabled` overrides on the client.

So this PR opts to leave this logic entirely up to the server, and we'll follow up with improvements.

What this means for an end user is this:
- OP adds the `Your followers` threadgate
- viewer cannot reply
- viewer goes to OP's profile and follows OP
- viewer navigates back to post
- reply for viewer is still disabled
- viewer needs to refresh data in order to reply