### PR TITLE
Add security policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Please be sure to:
 
 ## Security disclosures
 
-If you discover any security issues, please send an email to security@bsky.app. The email is automatically CCed to the entire team and we'll respond promptly.
+If you discover any security issues, please send an email to security@bsky.app. The email is automatically CCed to the entire team, and we'll respond promptly. See [SECURITY.md](https://github.com/social-app/atproto/blob/main/SECURITY.md) for more info.
 
 ## Are you a developer interested in building on atproto?
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,9 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please do NOT report possible security vulnerabilities in public channels such as GitHub Issues. If you believe you have found a security vulnerability, please email us at `security@bsky.app` with a description of the issue.
+
+We will acknowledge the vulnerability as soon as possible - within 3 business days - and follow up when a fix lands. Please avoid discussing the vulnerability until we do so.
+
+With your consent, we will add you to the repository [CONTRIBUTORS](https://github.com/bluesky-social/social-app/blob/main/CONTRIBUTORS.md) file.


### PR DESCRIPTION
Added a [security policy](https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository), using the same one from [bluesky-social/atproto](https://github.com/bluesky-social/atproto/blob/main/SECURITY.md)