### PR TITLE
Update intl:build to extract for all languages

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "perf:test:measure": "NODE_ENV=test flashlight test --bundleId xyz.blueskyweb.app --testCommand \"yarn perf:test\" --duration 150000 --resultsFilePath .perf/results.json",
     "perf:test:results": "NODE_ENV=test flashlight report .perf/results.json",
     "perf:measure": "NODE_ENV=test flashlight measure",
-    "intl:build": "yarn intl:extract && yarn intl:compile",
+    "intl:build": "yarn intl:extract:all && yarn intl:compile",
     "intl:extract": "lingui extract --clean --locale en",
     "intl:extract:all": "lingui extract --clean",
     "intl:compile": "lingui compile",


### PR DESCRIPTION
We suspect that the reason OTA is dropping translation strings is because the extract call isn't running on all languages.