### PR TITLE
Support Android share button

### DIFF
--- a/assets/icons/divergingNodes_stroke2_corner0_rounded.svg
+++ b/assets/icons/divergingNodes_stroke2_corner0_rounded.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"><path fill="#000" fill-rule="evenodd" d="M8.08 9.84A3 3 0 1 0 8.08 14.16L15.02 17.63A3 3 0 1 0 15.92 15.84L8.98 12.37A3 3 0 0 0 8.98 11.63L15.92 8.16A3 3 0 1 0 15.02 6.37Z" clip-rule="evenodd"/></svg>

--- a/src/components/icons/DivergingNodes.tsx
+++ b/src/components/icons/DivergingNodes.tsx
@@ -1,0 +1,5 @@
+import {createSinglePathSVG} from './TEMPLATE'
+
+export const DivergingNodes_Stroke2_Corner0_Rounded = createSinglePathSVG({
+  path: 'M8.08 9.84A3 3 0 1 0 8.08 14.16L15.02 17.63A3 3 0 1 0 15.92 15.84L8.98 12.37A3 3 0 0 0 8.98 11.63L15.92 8.16A3 3 0 1 0 15.02 6.37Z'
+})

--- a/src/screens/Hashtag.tsx
+++ b/src/screens/Hashtag.tsx
@@ -13,6 +13,7 @@ import {shareUrl} from '#/lib/sharing'
 import {cleanError} from '#/lib/strings/errors'
 import {sanitizeHandle} from '#/lib/strings/handles'
 import {enforceLen} from '#/lib/strings/helpers'
+import {isAndroid} from '#/platform/detection'
 import {useSearchPostsQuery} from '#/state/queries/search-posts'
 import {useSetMinimalShellMode} from '#/state/shell'
 import {Pager} from '#/view/com/pager/Pager'
@@ -22,6 +23,7 @@ import {List} from '#/view/com/util/List'
 import {atoms as a, web} from '#/alf'
 import {Button, ButtonIcon} from '#/components/Button'
 import {ArrowOutOfBox_Stroke2_Corner0_Rounded as Share} from '#/components/icons/ArrowOutOfBox'
+import {DivergingNodes_Stroke2_Corner0_Rounded as ShareAndroid} from '#/components/icons/DivergingNodes'
 import * as Layout from '#/components/Layout'
 import {ListFooter, ListMaybePlaceholder} from '#/components/Lists'
 
@@ -131,7 +133,7 @@ export default function HashtagScreen({
                   onPress={onShare}
                   hitSlop={HITSLOP_10}
                   style={[{right: -3}]}>
-                  <ButtonIcon icon={Share} size="md" />
+                  <ButtonIcon icon={isAndroid ? ShareAndroid : Share} size="md" />
                 </Button>
               </Layout.Header.Slot>
             </Layout.Header.Outer>

--- a/src/screens/Profile/components/ProfileFeedHeader.tsx
+++ b/src/screens/Profile/components/ProfileFeedHeader.tsx
@@ -11,7 +11,7 @@ import {shareUrl} from '#/lib/sharing'
 import {sanitizeHandle} from '#/lib/strings/handles'
 import {toShareUrl} from '#/lib/strings/url-helpers'
 import {logger} from '#/logger'
-import {isWeb} from '#/platform/detection'
+import {isAndroid, isWeb} from '#/platform/detection'
 import {FeedSourceFeedInfo} from '#/state/queries/feed'
 import {useLikeMutation, useUnlikeMutation} from '#/state/queries/like'
 import {
@@ -31,6 +31,7 @@ import {Divider} from '#/components/Divider'
 import {useRichText} from '#/components/hooks/useRichText'
 import {ArrowOutOfBox_Stroke2_Corner0_Rounded as Share} from '#/components/icons/ArrowOutOfBox'
 import {CircleInfo_Stroke2_Corner0_Rounded as CircleInfo} from '#/components/icons/CircleInfo'
+import {DivergingNodes_Stroke2_Corner0_Rounded as ShareAndroid} from '#/components/icons/DivergingNodes'
 import {DotGrid_Stroke2_Corner0_Rounded as Ellipsis} from '#/components/icons/DotGrid'
 import {
   Heart2_Filled_Stroke2_Corner0_Rounded as HeartFilled,
@@ -469,7 +470,7 @@ function DialogInner({
           color="secondary"
           shape="round"
           onPress={onPressShare}>
-          <ButtonIcon icon={Share} size="lg" />
+          <ButtonIcon icon={isAndroid ? ShareAndroid : Share} size="lg" />
         </Button>
       </View>
 

--- a/src/screens/StarterPack/StarterPackScreen.tsx
+++ b/src/screens/StarterPack/StarterPackScreen.tsx
@@ -24,6 +24,7 @@ import {logEvent} from '#/lib/statsig/statsig'
 import {cleanError} from '#/lib/strings/errors'
 import {getStarterPackOgCard} from '#/lib/strings/starter-pack'
 import {logger} from '#/logger'
+import {isAndroid} from '#/platform/detection'
 import {updateProfileShadow} from '#/state/cache/profile-shadow'
 import {useModerationOpts} from '#/state/preferences/moderation-opts'
 import {getAllListMembers} from '#/state/queries/list-members'
@@ -46,8 +47,9 @@ import {bulkWriteFollows} from '#/screens/Onboarding/util'
 import {atoms as a, useBreakpoints, useTheme} from '#/alf'
 import {Button, ButtonIcon, ButtonText} from '#/components/Button'
 import {useDialogControl} from '#/components/Dialog'
-import {ArrowOutOfBox_Stroke2_Corner0_Rounded as ArrowOutOfBox} from '#/components/icons/ArrowOutOfBox'
+import {ArrowOutOfBox_Stroke2_Corner0_Rounded as Share} from '#/components/icons/ArrowOutOfBox'
 import {CircleInfo_Stroke2_Corner0_Rounded as CircleInfo} from '#/components/icons/CircleInfo'
+import {DivergingNodes_Stroke2_Corner0_Rounded as ShareAndroid} from '#/components/icons/DivergingNodes'
 import {DotGrid_Stroke2_Corner0_Rounded as Ellipsis} from '#/components/icons/DotGrid'
 import {Pencil_Stroke2_Corner0_Rounded as Pencil} from '#/components/icons/Pencil'
 import {Trash_Stroke2_Corner0_Rounded as Trash} from '#/components/icons/Trash'
@@ -606,7 +608,7 @@ function OverflowMenu({
                   <Menu.ItemText>
                     <Trans>Share link</Trans>
                   </Menu.ItemText>
-                  <Menu.ItemIcon icon={ArrowOutOfBox} position="right" />
+                  <Menu.ItemIcon icon={isAndroid ? ShareAndroid : Share} position="right" />
                 </Menu.Item>
               </Menu.Group>
 

--- a/src/screens/Topic.tsx
+++ b/src/screens/Topic.tsx
@@ -12,6 +12,7 @@ import {CommonNavigatorParams} from '#/lib/routes/types'
 import {shareUrl} from '#/lib/sharing'
 import {cleanError} from '#/lib/strings/errors'
 import {enforceLen} from '#/lib/strings/helpers'
+import {isAndroid} from '#/platform/detection'
 import {useSearchPostsQuery} from '#/state/queries/search-posts'
 import {useSetMinimalShellMode} from '#/state/shell'
 import {Pager} from '#/view/com/pager/Pager'
@@ -21,6 +22,7 @@ import {List} from '#/view/com/util/List'
 import {atoms as a, web} from '#/alf'
 import {Button, ButtonIcon} from '#/components/Button'
 import {ArrowOutOfBox_Stroke2_Corner0_Rounded as Share} from '#/components/icons/ArrowOutOfBox'
+import {DivergingNodes_Stroke2_Corner0_Rounded as ShareAndroid} from '#/components/icons/DivergingNodes'
 import * as Layout from '#/components/Layout'
 import {ListFooter, ListMaybePlaceholder} from '#/components/Lists'
 
@@ -107,7 +109,7 @@ export default function TopicScreen({
                   onPress={onShare}
                   hitSlop={HITSLOP_10}
                   style={[{right: -3}]}>
-                  <ButtonIcon icon={Share} size="md" />
+                  <ButtonIcon icon={isAndroid ? ShareAndroid : Share} size="md" />
                 </Button>
               </Layout.Header.Slot>
             </Layout.Header.Outer>

--- a/src/view/com/profile/ProfileMenu.tsx
+++ b/src/view/com/profile/ProfileMenu.tsx
@@ -11,6 +11,7 @@ import {NavigationProp} from '#/lib/routes/types'
 import {shareText, shareUrl} from '#/lib/sharing'
 import {toShareUrl} from '#/lib/strings/url-helpers'
 import {logger} from '#/logger'
+import {isAndroid} from '#/platform/detection'
 import {Shadow} from '#/state/cache/types'
 import {useModalControls} from '#/state/modals'
 import {useDevModeEnabled} from '#/state/preferences/dev-mode'
@@ -25,6 +26,7 @@ import {EventStopper} from '#/view/com/util/EventStopper'
 import * as Toast from '#/view/com/util/Toast'
 import {Button, ButtonIcon} from '#/components/Button'
 import {ArrowOutOfBox_Stroke2_Corner0_Rounded as Share} from '#/components/icons/ArrowOutOfBox'
+import {DivergingNodes_Stroke2_Corner0_Rounded as ShareAndroid} from '#/components/icons/DivergingNodes'
 import {DotGrid_Stroke2_Corner0_Rounded as Ellipsis} from '#/components/icons/DotGrid'
 import {Flag_Stroke2_Corner0_Rounded as Flag} from '#/components/icons/Flag'
 import {ListSparkle_Stroke2_Corner0_Rounded as List} from '#/components/icons/ListSparkle'
@@ -224,7 +226,7 @@ let ProfileMenu = ({
               <Menu.ItemText>
                 <Trans>Share</Trans>
               </Menu.ItemText>
-              <Menu.ItemIcon icon={Share} />
+              <Menu.ItemIcon icon={isAndroid ? ShareAndroid : Share} />
             </Menu.Item>
             <Menu.Item
               testID="profileHeaderDropdownSearchBtn"
@@ -349,7 +351,7 @@ let ProfileMenu = ({
                   <Menu.ItemText>
                     <Trans>Copy at:// URI</Trans>
                   </Menu.ItemText>
-                  <Menu.ItemIcon icon={Share} />
+                  <Menu.ItemIcon icon={isAndroid ? ShareAndroid : Share} />
                 </Menu.Item>
                 <Menu.Item
                   testID="profileHeaderDropdownShareDIDBtn"
@@ -358,7 +360,7 @@ let ProfileMenu = ({
                   <Menu.ItemText>
                     <Trans>Copy DID</Trans>
                   </Menu.ItemText>
-                  <Menu.ItemIcon icon={Share} />
+                  <Menu.ItemIcon icon={isAndroid ? ShareAndroid : Share} />
                 </Menu.Item>
               </Menu.Group>
             </>

--- a/src/view/com/util/forms/PostDropdownBtnMenuItems.tsx
+++ b/src/view/com/util/forms/PostDropdownBtnMenuItems.tsx
@@ -27,7 +27,7 @@ import {richTextToString} from '#/lib/strings/rich-text-helpers'
 import {toShareUrl} from '#/lib/strings/url-helpers'
 import {getTranslatorLink} from '#/locale/helpers'
 import {logger} from '#/logger'
-import {isWeb} from '#/platform/detection'
+import {isAndroid, isWeb} from '#/platform/detection'
 import {Shadow} from '#/state/cache/post-shadow'
 import {useProfileShadow} from '#/state/cache/profile-shadow'
 import {useFeedFeedbackContext} from '#/state/feed-feedback'
@@ -61,6 +61,7 @@ import {ArrowOutOfBox_Stroke2_Corner0_Rounded as Share} from '#/components/icons
 import {BubbleQuestion_Stroke2_Corner0_Rounded as Translate} from '#/components/icons/Bubble'
 import {Clipboard_Stroke2_Corner2_Rounded as ClipboardIcon} from '#/components/icons/Clipboard'
 import {CodeBrackets_Stroke2_Corner0_Rounded as CodeBrackets} from '#/components/icons/CodeBrackets'
+import {DivergingNodes_Stroke2_Corner0_Rounded as ShareAndroid} from '#/components/icons/DivergingNodes'
 import {
   EmojiSad_Stroke2_Corner0_Rounded as EmojiSad,
   EmojiSmile_Stroke2_Corner0_Rounded as EmojiSmile,
@@ -489,7 +490,7 @@ let PostDropdownMenuItems = ({
             <Menu.ItemText>
               {isWeb ? _(msg`Copy link to post`) : _(msg`Share`)}
             </Menu.ItemText>
-            <Menu.ItemIcon icon={Share} position="right" />
+            <Menu.ItemIcon icon={isAndroid ? ShareAndroid : Share} position="right" />
           </Menu.Item>
 
           {canEmbed && (
@@ -724,14 +725,14 @@ let PostDropdownMenuItems = ({
                     label={_(msg`Copy post at:// URI`)}
                     onPress={onShareATURI}>
                     <Menu.ItemText>{_(msg`Copy post at:// URI`)}</Menu.ItemText>
-                    <Menu.ItemIcon icon={Share} position="right" />
+                    <Menu.ItemIcon icon={isAndroid ? ShareAndroid : Share} position="right" />
                   </Menu.Item>
                   <Menu.Item
                     testID="postAuthorDIDShareBtn"
                     label={_(msg`Copy author DID`)}
                     onPress={onShareAuthorDID}>
                     <Menu.ItemText>{_(msg`Copy author DID`)}</Menu.ItemText>
-                    <Menu.ItemIcon icon={Share} position="right" />
+                    <Menu.ItemIcon icon={isAndroid ? ShareAndroid : Share} position="right" />
                   </Menu.Item>
                 </Menu.Group>
               </>

--- a/src/view/com/util/post-ctrls/PostCtrls.tsx
+++ b/src/view/com/util/post-ctrls/PostCtrls.tsx
@@ -26,6 +26,7 @@ import {makeProfileLink} from '#/lib/routes/links'
 import {shareUrl} from '#/lib/sharing'
 import {useGate} from '#/lib/statsig/statsig'
 import {toShareUrl} from '#/lib/strings/url-helpers'
+import {isAndroid} from '#/platform/detection'
 import {Shadow} from '#/state/cache/types'
 import {useFeedFeedbackContext} from '#/state/feed-feedback'
 import {
@@ -40,8 +41,9 @@ import {
 } from '#/state/shell/progress-guide'
 import {atoms as a, useTheme} from '#/alf'
 import {useDialogControl} from '#/components/Dialog'
-import {ArrowOutOfBox_Stroke2_Corner0_Rounded as ArrowOutOfBox} from '#/components/icons/ArrowOutOfBox'
+import {ArrowOutOfBox_Stroke2_Corner0_Rounded as Share} from '#/components/icons/ArrowOutOfBox'
 import {Bubble_Stroke2_Corner2_Rounded as Bubble} from '#/components/icons/Bubble'
+import {DivergingNodes_Stroke2_Corner0_Rounded as ShareAndroid} from '#/components/icons/DivergingNodes'
 import * as Prompt from '#/components/Prompt'
 import {PostDropdownBtn} from '../forms/PostDropdownBtn'
 import {formatCount} from '../numeric/format'
@@ -350,10 +352,17 @@ let PostCtrls = ({
               accessibilityLabel={_(msg`Share`)}
               accessibilityHint=""
               hitSlop={POST_CTRL_HITSLOP}>
-              <ArrowOutOfBox
-                style={[defaultCtrlColor, {pointerEvents: 'none'}]}
-                width={22}
-              />
+              {isAndroid ? (
+                <ShareAndroid
+                  style={[defaultCtrlColor, {pointerEvents: 'none'}]}
+                  width={22}
+                />
+              ) : (
+                <Share
+                  style={[defaultCtrlColor, {pointerEvents: 'none'}]}
+                  width={22}
+                />
+              )}
             </Pressable>
           </View>
           <Prompt.Basic


### PR DESCRIPTION
Fixes #6360

The Android share icon is distinct from that of iOS and should be displayed in its appropriate context. The shape here is manual (i.e. not from a font or icon set) so adjustments in scale and relative size can be made, if necessary.