### PR TITLE
Get sheet padding working consistently

### DIFF
--- a/modules/bottom-sheet/android/src/main/java/expo/modules/bottomsheet/BottomSheetView.kt
+++ b/modules/bottom-sheet/android/src/main/java/expo/modules/bottomsheet/BottomSheetView.kt
@@ -31,9 +31,13 @@ class BottomSheetView(
   private lateinit var dialogRootViewGroup: DialogRootViewGroup
   private var eventDispatcher: EventDispatcher? = null
 
-  private val screenHeight =
-    context.resources.displayMetrics.heightPixels
-      .toFloat()
+  private val rawScreenHeight = context.resources.displayMetrics.heightPixels.toFloat()
+  private val safeScreenHeight = (rawScreenHeight - getNavigationBarHeight()).toFloat()
+
+  private fun getNavigationBarHeight(): Int {
+      val resourceId = resources.getIdentifier("navigation_bar_height", "dimen", "android")
+      return if (resourceId > 0) resources.getDimensionPixelSize(resourceId) else 0
+  }
 
   private val onAttemptDismiss by EventDispatcher()
   private val onSnapPointChange by EventDispatcher()
@@ -63,12 +67,12 @@ class BottomSheetView(
         }
     }
 
-  var maxHeight = this.screenHeight
+  var maxHeight = this.safeScreenHeight
     set(value) {
       val px = dpToPx(value)
       field =
-        if (px > this.screenHeight) {
-          this.screenHeight
+        if (px > this.safeScreenHeight) {
+          this.safeScreenHeight
         } else {
           px
         }
@@ -153,6 +157,19 @@ class BottomSheetView(
 
   // Presentation
 
+  private fun getHalfExpandedRatio(contentHeight: Float): Float {
+    return when {
+      // Full height sheets
+      contentHeight >= safeScreenHeight -> 0.99f
+      // Medium height sheets (>50% but <100%)
+      contentHeight >= safeScreenHeight / 2 ->
+        this.clampRatio(this.getTargetHeight() / safeScreenHeight)
+      // Small height sheets (<50%)
+      else ->
+        this.clampRatio(this.getTargetHeight() / rawScreenHeight)
+    }
+  }
+
   private fun present() {
     if (this.isOpen || this.isOpening || this.isClosing) return
 
@@ -172,12 +189,12 @@ class BottomSheetView(
       val behavior = BottomSheetBehavior.from(it)
       behavior.state = BottomSheetBehavior.STATE_HIDDEN
       behavior.isFitToContents = true
-      behavior.halfExpandedRatio = this.clampRatio(this.getTargetHeight() / this.screenHeight)
+      behavior.halfExpandedRatio = getHalfExpandedRatio(contentHeight)
       behavior.skipCollapsed = true
       behavior.isDraggable = true
       behavior.isHideable = true
 
-      if (contentHeight >= this.screenHeight || this.minHeight >= this.screenHeight) {
+      if (contentHeight >= this.safeScreenHeight || this.minHeight >= this.safeScreenHeight) {
         behavior.state = BottomSheetBehavior.STATE_EXPANDED
         this.selectedSnapPoint = 2
       } else {
@@ -227,11 +244,11 @@ class BottomSheetView(
     bottomSheet?.let {
       val behavior = BottomSheetBehavior.from(it)
 
-      behavior.halfExpandedRatio = this.clampRatio(this.getTargetHeight() / this.screenHeight)
+      behavior.halfExpandedRatio = getHalfExpandedRatio(contentHeight)
 
-      if (contentHeight > this.screenHeight && behavior.state != BottomSheetBehavior.STATE_EXPANDED) {
+      if (contentHeight > this.safeScreenHeight && behavior.state != BottomSheetBehavior.STATE_EXPANDED) {
         behavior.state = BottomSheetBehavior.STATE_EXPANDED
-      } else if (contentHeight < this.screenHeight && behavior.state != BottomSheetBehavior.STATE_HALF_EXPANDED) {
+      } else if (contentHeight < this.safeScreenHeight && behavior.state != BottomSheetBehavior.STATE_HALF_EXPANDED) {
         behavior.state = BottomSheetBehavior.STATE_HALF_EXPANDED
       }
     }

--- a/src/components/Dialog/index.tsx
+++ b/src/components/Dialog/index.tsx
@@ -222,7 +222,7 @@ export const ScrollableInner = React.forwardRef<ScrollView, DialogInnerProps>(
     if (isIOS) {
       paddingBottom += keyboardHeight / 4
       if (nativeSnapPoint === BottomSheetSnapPoint.Full) {
-        paddingBottom += insets.bottom
+        paddingBottom += insets.bottom + tokens.space.md
       }
       paddingBottom = Math.max(paddingBottom, tokens.space._2xl)
     } else {

--- a/src/components/Dialog/index.tsx
+++ b/src/components/Dialog/index.tsx
@@ -26,7 +26,7 @@ import {isAndroid, isIOS} from '#/platform/detection'
 import {useA11y} from '#/state/a11y'
 import {useDialogStateControlContext} from '#/state/dialogs'
 import {List, ListMethods, ListProps} from '#/view/com/util/List'
-import {atoms as a, useTheme} from '#/alf'
+import {atoms as a, tokens, useTheme} from '#/alf'
 import {useThemeName} from '#/alf/util/useColorModeTheme'
 import {Context, useDialogContext} from '#/components/Dialog/context'
 import {
@@ -46,7 +46,7 @@ export {useDialogContext, useDialogControl} from '#/components/Dialog/context'
 export * from '#/components/Dialog/shared'
 export * from '#/components/Dialog/types'
 export * from '#/components/Dialog/utils'
-// @ts-ignore
+
 export const Input = createInput(TextInput)
 
 export function Outer({
@@ -168,7 +168,9 @@ export function Outer({
       onStateChange={onStateChange}
       disableDrag={disableDrag}>
       <Context.Provider value={context}>
-        <View testID={testID}>{children}</View>
+        <View testID={testID} style={[a.relative]}>
+          {children}
+        </View>
       </Context.Provider>
     </BottomSheet>
   )
@@ -196,7 +198,7 @@ export function Inner({children, style, header}: DialogInnerProps) {
 
 export const ScrollableInner = React.forwardRef<ScrollView, DialogInnerProps>(
   function ScrollableInner(
-    {children, style, contentContainerStyle, header, ...props},
+    {children, contentContainerStyle, header, ...props},
     ref,
   ) {
     const {nativeSnapPoint, disableDrag, setDisableDrag} = useDialogContext()
@@ -216,13 +218,21 @@ export const ScrollableInner = React.forwardRef<ScrollView, DialogInnerProps>(
       [],
     )
 
-    const basePading =
-      (isIOS ? 30 : 50) + (isIOS ? keyboardHeight / 4 : keyboardHeight)
-    const fullPaddingBase = insets.bottom + insets.top + basePading
-    const fullPadding = isIOS ? fullPaddingBase : fullPaddingBase + 50
-
-    const paddingBottom =
-      nativeSnapPoint === BottomSheetSnapPoint.Full ? fullPadding : basePading
+    let paddingBottom = 0
+    if (isIOS) {
+      paddingBottom += keyboardHeight / 4
+      if (nativeSnapPoint === BottomSheetSnapPoint.Full) {
+        paddingBottom += insets.bottom
+      }
+      paddingBottom = Math.max(paddingBottom, tokens.space._2xl)
+    } else {
+      paddingBottom += keyboardHeight
+      if (nativeSnapPoint === BottomSheetSnapPoint.Full) {
+        paddingBottom += insets.top
+      }
+      paddingBottom +=
+        Math.max(insets.bottom, tokens.space._5xl) + tokens.space._2xl
+    }
 
     const onScroll = (e: NativeSyntheticEvent<NativeScrollEvent>) => {
       if (!isAndroid) {
@@ -238,7 +248,6 @@ export const ScrollableInner = React.forwardRef<ScrollView, DialogInnerProps>(
 
     return (
       <KeyboardAwareScrollView
-        style={[style]}
         contentContainerStyle={[
           a.pt_2xl,
           a.px_xl,
@@ -316,7 +325,7 @@ export function Handle() {
           style={[
             a.rounded_sm,
             {
-              top: 10,
+              top: tokens.space._2xl / 2 - 2.5,
               width: 35,
               height: 5,
               alignSelf: 'center',

--- a/src/components/Menu/index.tsx
+++ b/src/components/Menu/index.tsx
@@ -100,7 +100,7 @@ export function Outer({
       <Dialog.Handle />
       {/* Re-wrap with context since Dialogs are portal-ed to root */}
       <Context.Provider value={context}>
-        <Dialog.ScrollableInner label={_(msg`Menu`)} style={[a.py_sm]}>
+        <Dialog.ScrollableInner label={_(msg`Menu`)}>
           <View style={[a.gap_lg]}>
             {children}
             {isNative && showCancel && <Cancel />}


### PR DESCRIPTION
This resolves a longstanding bugbear I've had with our sheets for a long time and is a cluster of issues that we were fixing with horrible magic numbers in the bottom padding.

**iOS**:
We were setting the height of the sheet as screen height, but actually the sheet presentation does not include the top safe area. so all our sheets were <top inset> too tall with content going off the screen below, invisibly. This was forcing us to add extra padding, which meant that the behaviour to switch to the full-height mode was triggering way too early (which is why I set about fixing all this).

**Android**:
I haven't totally resolved this one yet, but I *think* the issue is that the half expanded ratio calculate isn't accurate. I tried to patch it, but ended up not being able to completely remove the magic numbers in `Dialog/index.tsx`. We're a *lot* closer though, with all navigation bar heights looking approximately the same now.
      
<table>
  <thead>
    <tr>
      <th>Android (gesture)</th>
      <th>Android (3 button)</th>
      <th>iOS</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><img width="200" src="https://github.com/user-attachments/assets/41b04352-016e-4b60-84bc-72217ffaf2cf" /></td>
      <td><img width="200" src="https://github.com/user-attachments/assets/13c96c10-f58f-4ad2-bc21-e795bd392c46" /></td>
      <td><img width="250" src="https://github.com/user-attachments/assets/7158b79b-d59d-4cae-a621-e6845858e8ed" /></td>
    </tr>
  </tbody>
</table>

<table>
  <thead>
    <tr>
      <th>Android (gesture)</th>
      <th>Android (3 button)</th>
      <th>iOS</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><img width="200" src="https://github.com/user-attachments/assets/79bbe155-f4a6-41e9-a175-a358a51becaa" /></td>
      <td><img width="200" src="https://github.com/user-attachments/assets/b1d2b011-e40d-4e3f-94c1-86f4faf3e709" /></td>
      <td><img width="250" src="https://github.com/user-attachments/assets/d4e6761f-6413-4a58-b145-3f9a0115db0e" /></td>
    </tr>
  </tbody>
</table>

<table>
  <thead>
    <tr>
      <th>Android (gesture)</th>
      <th>Android (3 button)</th>
      <th>iOS</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><img width="200" src="https://github.com/user-attachments/assets/e7023b45-290a-4ef5-ac2f-0b351a06ed6c" /></td>
      <td><img width="200" src="https://github.com/user-attachments/assets/3108dc0c-3180-4f02-b332-35efacf44dbd" /></td>
      <td><img width="250" src="https://github.com/user-attachments/assets/c0a1e827-74af-43f5-bed2-47249ddf156d" /></td>
    </tr>
  </tbody>
</table>

<table>
  <thead>
    <tr>
      <th>Android (gesture)</th>
      <th>Android (3 button)</th>
      <th>iOS</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><img width="200" src="https://github.com/user-attachments/assets/22ef0ecd-173e-4630-95aa-976714e760a7" /></td>
      <td><img width="200" src="https://github.com/user-attachments/assets/39f57ecb-af0a-49bd-8d2e-c47852cc1880" /></td>
      <td><img width="250" src="https://github.com/user-attachments/assets/e7cb077d-2074-42aa-9a02-f2585292bf2a" /></td>
    </tr>
  </tbody>
</table>

# Test plan

Check as many dialogs as you can, esp different heights. On Android, sheets >50% height, <50%, and >=100% height all have different behaviours.
Check Android <15, and 15 with and without the 3-button navigation