### PR TITLE
Add crowdin nightly push

### DIFF
--- a/.github/workflows/nightly-update-source-languages.yaml
+++ b/.github/workflows/nightly-update-source-languages.yaml
@@ -36,3 +36,13 @@ jobs:
         with:
           commit_message: Nightly source-language update
           file_pattern: ./src/locale/locales/en/messages.po
+       - name: Push source lang to Crowdin
+        uses: crowdin/github-action@v2
+        with:
+          upload_sources: true
+          upload_translations: false
+          push_translations: false
+          push_sources: false
+          create_pull_request: false
+        env:
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,5 +1,6 @@
 {
-  "project_id": "664276",
+  "project_id": "1",
+  "base_url": "https://bluesky.api.crowdin.com",
   "base_path": ".",
   "preserve_hierarchy": true,
   "files": [


### PR DESCRIPTION
With the switch to the crowdin enterprise, I'm going to make two updates:

1. Gotta update the core config file
2. Change the nightly action to push directly to crowdin after extracting source strings. Previously this was handled by the GitHub integration in crowdin, but that tool only supported bidirectional sync. All we want to do is regularly sync the source strings to crowdin.