### PR TITLE
Fix handle length error message

### DIFF
--- a/src/lib/strings/handles.ts
+++ b/src/lib/strings/handles.ts
@@ -5,6 +5,8 @@ import {forceLTR} from '#/lib/strings/bidi'
 const VALIDATE_REGEX =
   /^([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$/
 
+export const MAX_SERVICE_HANDLE_LENGTH = 18
+
 export function makeValidHandle(str: string): string {
   if (str.length > 20) {
     str = str.slice(0, 20)
@@ -17,10 +19,6 @@ export function createFullHandle(name: string, domain: string): string {
   name = (name || '').replace(/[.]+$/, '')
   domain = (domain || '').replace(/^[.]+/, '')
   return `${name}.${domain}`
-}
-
-export function maxServiceHandleLength(domain: string): number {
-  return 30 - `.${(domain || '').replace(/^[.]+/, '')}`.length
 }
 
 export function isInvalidHandle(handle: string): boolean {
@@ -52,7 +50,7 @@ export function validateServiceHandle(
     handleChars:
       !str || (VALIDATE_REGEX.test(fullHandle) && !str.includes('.')),
     hyphenStartOrEnd: !str.startsWith('-') && !str.endsWith('-'),
-    frontLength: str.length >= 3 && str.length <= 18,
+    frontLength: str.length >= 3 && str.length <= MAX_SERVICE_HANDLE_LENGTH,
     totalLength: fullHandle.length <= 253,
   }
 

--- a/src/screens/Signup/StepHandle.tsx
+++ b/src/screens/Signup/StepHandle.tsx
@@ -6,7 +6,7 @@ import {useLingui} from '@lingui/react'
 import {logEvent} from '#/lib/statsig/statsig'
 import {
   createFullHandle,
-  maxServiceHandleLength,
+  MAX_SERVICE_HANDLE_LENGTH,
   validateServiceHandle,
 } from '#/lib/strings/handles'
 import {useAgent} from '#/state/session'
@@ -168,11 +168,11 @@ export function StepHandle() {
               <IsValidIcon
                 valid={validCheck.frontLength && validCheck.totalLength}
               />
-              {!validCheck.totalLength ? (
+              {!validCheck.totalLength ||
+              draftValue.length > MAX_SERVICE_HANDLE_LENGTH ? (
                 <Text style={[a.text_md, a.flex_1]}>
                   <Trans>
-                    No longer than {maxServiceHandleLength(state.userDomain)}{' '}
-                    characters
+                    No longer than {MAX_SERVICE_HANDLE_LENGTH} characters
                   </Trans>
                 </Text>
               ) : (


### PR DESCRIPTION
# Before

<img width="394" alt="Screenshot 2025-02-21 at 14 23 46" src="https://github.com/user-attachments/assets/8fc7138b-d145-4718-acc8-aaa2bdb8c2fc" />

# After

<img width="395" alt="Screenshot 2025-02-21 at 14 23 11" src="https://github.com/user-attachments/assets/a6db975d-1062-4175-95ea-9d4d30b4355b" />

# Test plan

Enter handles of different lengths, ensure error message is correct