### PR TITLE
Fix android datepicker height

### DIFF
--- a/src/components/forms/DateField/index.shared.tsx
+++ b/src/components/forms/DateField/index.shared.tsx
@@ -1,7 +1,7 @@
 import {Pressable, View} from 'react-native'
 import {useLingui} from '@lingui/react'
 
-import {android, atoms as a, useTheme, web} from '#/alf'
+import {atoms as a, native, useTheme, web} from '#/alf'
 import * as TextField from '#/components/forms/TextField'
 import {useInteractionState} from '#/components/hooks/useInteractionState'
 import {CalendarDays_Stroke2_Corner0_Rounded as CalendarDays} from '#/components/icons/CalendarDays'
@@ -60,16 +60,16 @@ export function DateFieldButton({
         onBlur={onBlur}
         style={[
           {
-            paddingTop: 12,
-            paddingBottom: 12,
             paddingLeft: 14,
             paddingRight: 14,
             borderColor: 'transparent',
             borderWidth: 2,
           },
-          android({
-            minHeight: 57.5,
+          native({
+            paddingTop: 10,
+            paddingBottom: 10,
           }),
+          web(a.py_md),
           a.flex_row,
           a.flex_1,
           a.w_full,

--- a/src/components/forms/TextField.tsx
+++ b/src/components/forms/TextField.tsx
@@ -15,6 +15,7 @@ import {
   android,
   applyFonts,
   atoms as a,
+  ios,
   TextStyleProp,
   useAlf,
   useTheme,
@@ -189,23 +190,19 @@ export function createInput(Component: typeof TextInput) {
       a.px_xs,
       {
         // paddingVertical doesn't work w/multiline - esb
-        paddingTop: 12,
-        paddingBottom: 13,
         lineHeight: a.text_md.fontSize * 1.1875,
         textAlignVertical: rest.multiline ? 'top' : undefined,
         minHeight: rest.multiline ? 80 : undefined,
         minWidth: 0,
       },
+      ios({paddingTop: 12, paddingBottom: 13}),
+      android(a.py_sm),
       // fix for autofill styles covering border
       web({
         paddingTop: 10,
         paddingBottom: 11,
         marginTop: 2,
         marginBottom: 2,
-      }),
-      android({
-        paddingTop: 8,
-        paddingBottom: 8,
       }),
       style,
     ])

--- a/src/components/forms/TextField.tsx
+++ b/src/components/forms/TextField.tsx
@@ -352,17 +352,9 @@ export function SuffixText({
         a.pr_sm,
         a.text_md,
         t.atoms.text_contrast_medium,
-        {
-          pointerEvents: 'none',
-        },
-        web({
-          marginTop: -2,
-        }),
-        ctx.hovered || ctx.focused
-          ? {
-              color: t.palette.contrast_800,
-            }
-          : {},
+        a.pointer_events_none,
+        web([{marginTop: -2}, a.leading_snug]),
+        (ctx.hovered || ctx.focused) && {color: t.palette.contrast_800},
         style,
       ]}>
       {children}


### PR DESCRIPTION
At some point, our android text inputs got shorter, but the datefield didn't follow suit. this aligns the height properly and cleans up a bit of the conditional logic

Also fixes a clipping issue with `SuffixText` on web
<table>
  <thead>
    <tr>
      <th>Before</th>
      <th>After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><img width="400" src="https://github.com/user-attachments/assets/d4382f3d-ccff-41d4-af38-33627de5e0d1" /></td>
      <td><img width="400" src="https://github.com/user-attachments/assets/74ecfc9f-5ee7-46d0-9957-c0cfd179c479" /></td>
    </tr>
  </tbody>
</table>

<table>
  <thead>
    <tr>
      <th>Before</th>
      <th>After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><img width="400" src="https://github.com/user-attachments/assets/ecdcbf46-f9d4-40d8-a40f-88a23e0883b3" /></td>
      <td><img width="400" src="https://github.com/user-attachments/assets/eeaa8203-1348-45b8-9064-1c3fbec929a1" /></td>
    </tr>
  </tbody>
</table>
