### PR TITLE
Set minimum birthday to 13 years ago in birthday edit dialog

### DIFF
--- a/src/components/dialogs/BirthDateSettings.tsx
+++ b/src/components/dialogs/BirthDateSettings.tsx
@@ -4,6 +4,7 @@ import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
 import {cleanError} from '#/lib/strings/errors'
+import {getDateAgo} from '#/lib/strings/time'
 import {logger} from '#/logger'
 import {isIOS, isWeb} from '#/platform/detection'
 import {
@@ -101,7 +102,7 @@ function BirthdayInner({
           onChangeDate={newDate => setDate(new Date(newDate))}
           label={_(msg`Birthday`)}
           accessibilityHint={_(msg`Enter your birth date`)}
-          maximumDate={new Date()}
+          maximumDate={getDateAgo(13)}
         />
       </View>
 

--- a/src/lib/strings/time.ts
+++ b/src/lib/strings/time.ts
@@ -20,6 +20,17 @@ export function getAge(birthDate: Date): number {
 }
 
 /**
+ * Get a Date object that is N years ago from now
+ * @param years number of years
+ * @returns Date object
+ */
+export function getDateAgo(years: number): Date {
+  const date = new Date()
+  date.setFullYear(date.getFullYear() - years)
+  return date
+}
+
+/**
  * Compares two dates by year, month, and day only
  */
 export function simpleAreDatesEqual(a: Date, b: Date): boolean {


### PR DESCRIPTION
Sets the minimum birthday you can set your birthday to to 13 years ago from today. Accounts cannot be created with an earlier birthday than that anyway

# Test plan

Confirm the min date is correct, and that the date picker limit works