### PR TITLE
[DMs] Use new convo availability API

### DIFF
--- a/src/components/dms/MessageProfileButton.tsx
+++ b/src/components/dms/MessageProfileButton.tsx
@@ -8,13 +8,15 @@ import {useNavigation} from '@react-navigation/native'
 import {useEmail} from '#/lib/hooks/useEmail'
 import {NavigationProp} from '#/lib/routes/types'
 import {logEvent} from '#/lib/statsig/statsig'
-import {useMaybeConvoForUser} from '#/state/queries/messages/get-convo-for-members'
+import {useGetConvoAvailabilityQuery} from '#/state/queries/messages/get-convo-availability'
+import {useGetConvoForMembers} from '#/state/queries/messages/get-convo-for-members'
+import * as Toast from '#/view/com/util/Toast'
 import {atoms as a, useTheme} from '#/alf'
 import {Button, ButtonIcon} from '#/components/Button'
+import {useDialogControl} from '#/components/Dialog'
+import {VerifyEmailDialog} from '#/components/dialogs/VerifyEmailDialog'
 import {canBeMessaged} from '#/components/dms/util'
 import {Message_Stroke2_Corner0_Rounded as Message} from '#/components/icons/Message'
-import {useDialogControl} from '../Dialog'
-import {VerifyEmailDialog} from '../dialogs/VerifyEmailDialog'
 
 export function MessageProfileButton({
   profile,
@@ -27,10 +29,19 @@ export function MessageProfileButton({
   const {needsEmailVerification} = useEmail()
   const verifyEmailControl = useDialogControl()
 
-  const {data: convo, isPending} = useMaybeConvoForUser(profile.did)
+  const {data: convoAvailability} = useGetConvoAvailabilityQuery(profile.did)
+  const {mutate: initiateConvo} = useGetConvoForMembers({
+    onSuccess: ({convo}) => {
+      logEvent('chat:open', {logContext: 'ProfileHeader'})
+      navigation.navigate('MessagesConversation', {conversation: convo.id})
+    },
+    onError: () => {
+      Toast.show(_(msg`Failed to create conversation`))
+    },
+  })
 
   const onPress = React.useCallback(() => {
-    if (!convo?.id) {
+    if (!convoAvailability?.canChat) {
       return
     }
 
@@ -39,15 +50,25 @@ export function MessageProfileButton({
       return
     }
 
-    if (convo && !convo.lastMessage) {
+    if (convoAvailability.convo) {
+      logEvent('chat:open', {logContext: 'ProfileHeader'})
+      navigation.navigate('MessagesConversation', {
+        conversation: convoAvailability.convo.id,
+      })
+    } else {
       logEvent('chat:create', {logContext: 'ProfileHeader'})
+      initiateConvo([profile.did])
     }
-    logEvent('chat:open', {logContext: 'ProfileHeader'})
+  }, [
+    needsEmailVerification,
+    verifyEmailControl,
+    navigation,
+    profile.did,
+    initiateConvo,
+    convoAvailability,
+  ])
 
-    navigation.navigate('MessagesConversation', {conversation: convo.id})
-  }, [needsEmailVerification, verifyEmailControl, convo, navigation])
-
-  if (isPending) {
+  if (!convoAvailability) {
     // show pending state based on declaration
     if (canBeMessaged(profile)) {
       return (
@@ -69,7 +90,7 @@ export function MessageProfileButton({
     }
   }
 
-  if (convo) {
+  if (convoAvailability.canChat) {
     return (
       <>
         <Button

--- a/src/state/queries/messages/get-convo-availability.ts
+++ b/src/state/queries/messages/get-convo-availability.ts
@@ -1,0 +1,25 @@
+import {useQuery} from '@tanstack/react-query'
+
+import {DM_SERVICE_HEADERS} from '#/state/queries/messages/const'
+import {useAgent} from '#/state/session'
+import {STALE} from '..'
+
+const RQKEY_ROOT = 'convo-availability'
+export const RQKEY = (did: string) => [RQKEY_ROOT, did]
+
+export function useGetConvoAvailabilityQuery(did: string) {
+  const agent = useAgent()
+
+  return useQuery({
+    queryKey: RQKEY(did),
+    queryFn: async () => {
+      const {data} = await agent.chat.bsky.convo.getConvoAvailability(
+        {members: [did]},
+        {headers: DM_SERVICE_HEADERS},
+      )
+
+      return data
+    },
+    staleTime: STALE.INFINITY,
+  })
+}

--- a/src/state/queries/messages/get-convo-for-members.ts
+++ b/src/state/queries/messages/get-convo-for-members.ts
@@ -1,14 +1,10 @@
 import {ChatBskyConvoGetConvoForMembers} from '@atproto/api'
-import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query'
+import {useMutation, useQueryClient} from '@tanstack/react-query'
 
 import {logger} from '#/logger'
 import {DM_SERVICE_HEADERS} from '#/state/queries/messages/const'
 import {useAgent} from '#/state/session'
-import {STALE} from '..'
-import {RQKEY as CONVO_KEY} from './conversation'
-
-const RQKEY_ROOT = 'convo-for-user'
-export const RQKEY = (did: string) => [RQKEY_ROOT, did]
+import {precacheConvoQuery} from './conversation'
 
 export function useGetConvoForMembers({
   onSuccess,
@@ -22,7 +18,7 @@ export function useGetConvoForMembers({
 
   return useMutation({
     mutationFn: async (members: string[]) => {
-      const {data} = await agent.api.chat.bsky.convo.getConvoForMembers(
+      const {data} = await agent.chat.bsky.convo.getConvoForMembers(
         {members: members},
         {headers: DM_SERVICE_HEADERS},
       )
@@ -30,35 +26,12 @@ export function useGetConvoForMembers({
       return data
     },
     onSuccess: data => {
-      queryClient.setQueryData(CONVO_KEY(data.convo.id), data.convo)
+      precacheConvoQuery(queryClient, data.convo)
       onSuccess?.(data)
     },
     onError: error => {
       logger.error(error)
       onError?.(error)
     },
-  })
-}
-
-/**
- * Gets the conversation ID for a given DID. Returns null if it's not possible to message them.
- */
-export function useMaybeConvoForUser(did: string) {
-  const agent = useAgent()
-
-  return useQuery({
-    queryKey: RQKEY(did),
-    queryFn: async () => {
-      const convo = await agent.api.chat.bsky.convo
-        .getConvoForMembers({members: [did]}, {headers: DM_SERVICE_HEADERS})
-        .catch(() => ({success: null}))
-
-      if (convo.success) {
-        return convo.data.convo
-      } else {
-        return null
-      }
-    },
-    staleTime: STALE.INFINITY,
   })
 }


### PR DESCRIPTION
# Stacked on #7778 

Should cut down on "ghost convos" when visiting people's profiles

# Test plan

Check profile DM button still works as before, with pending state, different declarations, and still being able to DM someone you already have a convo with even if they have since closed their DMs