### PR TITLE
Remove system-ui from font family when set to Theme in Font Settings

### DIFF
--- a/src/alf/fonts.ts
+++ b/src/alf/fonts.ts
@@ -3,7 +3,7 @@ import {TextStyle} from 'react-native'
 import {isAndroid, isWeb} from '#/platform/detection'
 import {Device, device} from '#/storage'
 
-const WEB_FONT_FAMILIES = `system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji"`
+const WEB_FONT_FAMILIES = `-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji"`
 
 const factor = 0.0625 // 1 - (15/16)
 const fontScaleMultipliers: Record<Device['fontScale'], number> = {

--- a/src/alf/fonts.ts
+++ b/src/alf/fonts.ts
@@ -3,6 +3,9 @@ import {TextStyle} from 'react-native'
 import {isAndroid, isWeb} from '#/platform/detection'
 import {Device, device} from '#/storage'
 
+const WEB_FALLBACK_FONT_FAMILIES =
+  'sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"'
+
 const factor = 0.0625 // 1 - (15/16)
 const fontScaleMultipliers: Record<Device['fontScale'], number> = {
   '-2': 1 - factor * 3,
@@ -71,7 +74,7 @@ export function applyFonts(style: TextStyle, fontFamily: 'system' | 'theme') {
 
     if (isWeb) {
       // fallback families only supported on web
-      style.fontFamily += `, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji"`
+      style.fontFamily += `, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, ${WEB_FALLBACK_FONT_FAMILIES}`
     }
 
     /**
@@ -82,7 +85,9 @@ export function applyFonts(style: TextStyle, fontFamily: 'system' | 'theme') {
   } else {
     // fallback families only supported on web
     if (isWeb) {
-      style.fontFamily = style.fontFamily || `system-ui`
+      style.fontFamily =
+        style.fontFamily ||
+        `-apple-system, BlinkMacSystemFont, ${WEB_FALLBACK_FONT_FAMILIES}`
     }
 
     /**

--- a/src/alf/fonts.ts
+++ b/src/alf/fonts.ts
@@ -84,7 +84,7 @@ export function applyFonts(style: TextStyle, fontFamily: 'system' | 'theme') {
   } else {
     // fallback families only supported on web
     if (isWeb) {
-      style.fontFamily = style.fontFamily || WEB_FONT_FAMILIES
+      style.fontFamily = style.fontFamily || `system-ui`
     }
 
     /**

--- a/src/alf/fonts.ts
+++ b/src/alf/fonts.ts
@@ -3,8 +3,6 @@ import {TextStyle} from 'react-native'
 import {isAndroid, isWeb} from '#/platform/detection'
 import {Device, device} from '#/storage'
 
-const WEB_FONT_FAMILIES = `-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji"`
-
 const factor = 0.0625 // 1 - (15/16)
 const fontScaleMultipliers: Record<Device['fontScale'], number> = {
   '-2': 1 - factor * 3,
@@ -73,7 +71,7 @@ export function applyFonts(style: TextStyle, fontFamily: 'system' | 'theme') {
 
     if (isWeb) {
       // fallback families only supported on web
-      style.fontFamily += `, ${WEB_FONT_FAMILIES}`
+      style.fontFamily += `, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji"`
     }
 
     /**

--- a/src/alf/fonts.ts
+++ b/src/alf/fonts.ts
@@ -4,7 +4,7 @@ import {isAndroid, isWeb} from '#/platform/detection'
 import {Device, device} from '#/storage'
 
 const WEB_FALLBACK_FONT_FAMILIES =
-  'sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji"'
+  'sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Noto Color Emoji"'
 
 const factor = 0.0625 // 1 - (15/16)
 const fontScaleMultipliers: Record<Device['fontScale'], number> = {


### PR DESCRIPTION
The difference with #6139 is that the font family still includes system-ui when set to System in the font settings. If system-ui is included in the alternate fonts in the theme font settings, it can cause issues with font readability in CJK Windows environments, as pointed out in #6139. However, some people prefer the systme-ui font, so this PR ensures that system-ui is included in the font family when set to System.