### PR TITLE
Fix for avatar preloading

### DIFF
--- a/src/view/com/composer/ComposerReplyTo.tsx
+++ b/src/view/com/composer/ComposerReplyTo.tsx
@@ -15,7 +15,7 @@ import {sanitizeHandle} from '#/lib/strings/handles'
 import {ComposerOptsPostRef} from '#/state/shell/composer'
 import {MaybeQuoteEmbed} from '#/view/com/util/post-embeds/QuoteEmbed'
 import {Text} from '#/view/com/util/text/Text'
-import {UserAvatar} from '#/view/com/util/UserAvatar'
+import {PreviewableUserAvatar} from '#/view/com/util/UserAvatar'
 import {atoms as a, useTheme} from '#/alf'
 
 export function ComposerReplyTo({replyTo}: {replyTo: ComposerOptsPostRef}) {
@@ -72,10 +72,12 @@ export function ComposerReplyTo({replyTo}: {replyTo: ComposerOptsPostRef}) {
       accessibilityHint={_(
         msg`Expands or collapses the full post you are replying to`,
       )}>
-      <UserAvatar
+      <PreviewableUserAvatar
         size={50}
-        avatar={replyTo.author.avatar}
+        profile={replyTo.author}
+        moderation={replyTo.moderation?.ui('avatar')}
         type={replyTo.author.associated?.labeler ? 'labeler' : 'user'}
+        disableNavigation={true} // disable linking when replying
       />
       <View style={styles.replyToPost}>
         <Text type="xl-medium" style={t.atoms.text} numberOfLines={1} emoji>

--- a/src/view/com/composer/ComposerReplyTo.tsx
+++ b/src/view/com/composer/ComposerReplyTo.tsx
@@ -15,7 +15,7 @@ import {sanitizeHandle} from '#/lib/strings/handles'
 import {ComposerOptsPostRef} from '#/state/shell/composer'
 import {MaybeQuoteEmbed} from '#/view/com/util/post-embeds/QuoteEmbed'
 import {Text} from '#/view/com/util/text/Text'
-import {PreviewableUserAvatar} from '#/view/com/util/UserAvatar'
+import {UserAvatar} from '#/view/com/util/UserAvatar'
 import {atoms as a, useTheme} from '#/alf'
 
 export function ComposerReplyTo({replyTo}: {replyTo: ComposerOptsPostRef}) {
@@ -72,10 +72,9 @@ export function ComposerReplyTo({replyTo}: {replyTo: ComposerOptsPostRef}) {
       accessibilityHint={_(
         msg`Expands or collapses the full post you are replying to`,
       )}>
-      <PreviewableUserAvatar
+      <UserAvatar
         size={50}
-        profile={replyTo.author}
-        moderation={replyTo.moderation?.ui('avatar')}
+        avatar={replyTo.author.avatar}
         type={replyTo.author.associated?.labeler ? 'labeler' : 'user'}
       />
       <View style={styles.replyToPost}>

--- a/src/view/com/util/UserAvatar.tsx
+++ b/src/view/com/util/UserAvatar.tsx
@@ -420,9 +420,12 @@ let PreviewableUserAvatar = ({
   moderation,
   profile,
   disableHoverCard,
+  disableNavigation, // new prop
   onBeforePress,
   ...rest
-}: PreviewableUserAvatarProps): React.ReactNode => {
+}: PreviewableUserAvatarProps & {
+  disableNavigation?: boolean
+}): React.ReactNode => {
   const {_} = useLingui()
   const queryClient = useQueryClient()
 
@@ -431,23 +434,31 @@ let PreviewableUserAvatar = ({
     precacheProfile(queryClient, profile)
   }, [profile, queryClient, onBeforePress])
 
+  const avatarEl = (
+    <UserAvatar
+      avatar={profile.avatar}
+      moderation={moderation}
+      type={profile.associated?.labeler ? 'labeler' : 'user'}
+      {...rest}
+    />
+  )
+
   return (
     <ProfileHoverCard did={profile.did} disable={disableHoverCard}>
-      <Link
-        label={_(msg`${profile.displayName || profile.handle}'s avatar`)}
-        accessibilityHint={_(msg`Opens this profile`)}
-        to={makeProfileLink({
-          did: profile.did,
-          handle: profile.handle,
-        })}
-        onPress={onPress}>
-        <UserAvatar
-          avatar={profile.avatar}
-          moderation={moderation}
-          type={profile.associated?.labeler ? 'labeler' : 'user'}
-          {...rest}
-        />
-      </Link>
+      {disableNavigation ? (
+        avatarEl
+      ) : (
+        <Link
+          label={_(msg`${profile.displayName || profile.handle}'s avatar`)}
+          accessibilityHint={_(msg`Opens this profile`)}
+          to={makeProfileLink({
+            did: profile.did,
+            handle: profile.handle,
+          })}
+          onPress={onPress}>
+          {avatarEl}
+        </Link>
+      )}
     </ProfileHoverCard>
   )
 }


### PR DESCRIPTION
Mentioned in #7807  - this fixes the possible unintended preloading/profile switching when pressing the avatar and leaving the feed by adding a prop to remove the link wrapping.