### PR TITLE
Tweak accessibility strings

### DIFF
--- a/src/components/dialogs/MutedWords.tsx
+++ b/src/components/dialogs/MutedWords.tsx
@@ -318,7 +318,7 @@ function MutedWordsInner() {
           <View style={[a.pt_xs]}>
             <Button
               disabled={isPending || !field}
-              label={_(msg`Add mute word with configured settings`)}
+              label={_(msg`Add mute word with chosen settings`)}
               size="large"
               color="primary"
               variant="solid"

--- a/src/components/dialogs/MutedWords.tsx
+++ b/src/components/dialogs/MutedWords.tsx
@@ -318,7 +318,7 @@ function MutedWordsInner() {
           <View style={[a.pt_xs]}>
             <Button
               disabled={isPending || !field}
-              label={_(msg`Add mute word for configured settings`)}
+              label={_(msg`Add mute word with configured settings`)}
               size="large"
               color="primary"
               variant="solid"

--- a/src/screens/Login/LoginForm.tsx
+++ b/src/screens/Login/LoginForm.tsx
@@ -321,7 +321,7 @@ export const LoginForm = ({
           <Button
             testID="loginRetryButton"
             label={_(msg`Retry`)}
-            accessibilityHint={_(msg`Retries sign in`)}
+            accessibilityHint={_(msg`Retries signing in`)}
             variant="solid"
             color="secondary"
             size="large"


### PR DESCRIPTION
Following feedback on Crowdin, this PR suggests tweaking a few accessibility strings to make them clearer:

- [`Retries sign in` `accessibilityHint`](https://bluesky.crowdin.com/editor/1/11/en-gd/9#2531) on Crowdin:

Tweaks the `accessibilityHint` for the `Retry` button when there's been an issue signing in from:
`Retries sign in` ➡️ `Retries signing in`

https://github.com/bluesky-social/social-app/blob/7a3a1a2bd07ba6a38c7886105491bb96df2ebd62/src/screens/Login/LoginForm.tsx#L321-L332

- [`Add mute word for configured setting` label](https://bluesky.crowdin.com/editor/1/11/en-gd/9#219) on Crowdin:

Tweaks the `label` for the button which adds a mute word from:
`Add mute word for configured settings` ➡️ `Add mute word with chosen settings`

https://github.com/bluesky-social/social-app/blob/7a3a1a2bd07ba6a38c7886105491bb96df2ebd62/src/components/dialogs/MutedWords.tsx#L319-L331