### PR TITLE
Move translation tags on `Choose your username` screen

### DIFF
--- a/src/screens/Signup/StepHandle.tsx
+++ b/src/screens/Signup/StepHandle.tsx
@@ -126,10 +126,12 @@ export function StepHandle() {
         </View>
         {draftValue !== '' && (
           <Text style={[a.text_md]}>
-            <Trans>Your full username will be</Trans>{' '}
-            <Text style={[a.text_md, a.font_bold]}>
-              @{createFullHandle(draftValue, state.userDomain)}
-            </Text>
+            <Trans>
+              Your full username will be{' '}
+              <Text style={[a.text_md, a.font_bold]}>
+                @{createFullHandle(draftValue, state.userDomain)}
+              </Text>
+            </Trans>
           </Text>
         )}
 


### PR DESCRIPTION
Following [feedback on Crowdin](https://bluesky.crowdin.com/editor/1/11/en-gd/9#3751):
> This needs a place holder for languages where the {0} does not come last in this phrase

This PR moves the translation tags on the `Choose your username` screen from where they are currently:
https://github.com/bluesky-social/social-app/blob/7a3a1a2bd07ba6a38c7886105491bb96df2ebd62/src/screens/Signup/StepHandle.tsx#L127-L134

to include the username as well, so that it can be positioned appropriately in all translated strings:

https://github.com/bluesky-social/social-app/blob/b0c4844290c26c1eeb25474f59f862b9cd20c795/src/screens/Signup/StepHandle.tsx#L127-L136

[Link to review without whitespace](https://github.com/bluesky-social/social-app/pull/7823/files?diff=unified&w=1)