### PR TITLE
Tweak prompt title text when removing a feed

### DIFF
--- a/src/components/FeedCard.tsx
+++ b/src/components/FeedCard.tsx
@@ -307,7 +307,7 @@ function SaveButtonInner({
 
       <Prompt.Basic
         control={removePromptControl}
-        title={_(msg`Remove from my feeds?`)}
+        title={_(msg`Remove from your feeds?`)}
         description={_(
           msg`Are you sure you want to remove this from your feeds?`,
         )}

--- a/src/view/com/feeds/FeedSourceCard.tsx
+++ b/src/view/com/feeds/FeedSourceCard.tsx
@@ -314,7 +314,7 @@ export function FeedSourceCardLoaded({
 
       <Prompt.Basic
         control={removePromptControl}
-        title={_(msg`Remove from my feeds?`)}
+        title={_(msg`Remove from your feeds?`)}
         description={_(
           msg`Are you sure you want to remove ${feed.displayName} from your feeds?`,
         )}


### PR DESCRIPTION
[Feedback was raised on Crowdin](https://bluesky.crowdin.com/editor/1/11/en-gd/9#2383) that the title text in the prompt shown when removing a feed is confusingly worded.

This PR tweaks the prompt title text from:
`Remove from my feeds?` ➡️ `Remove from your feeds?`
and thus aligns the title text with the description text.
https://github.com/bluesky-social/social-app/blob/7a3a1a2bd07ba6a38c7886105491bb96df2ebd62/src/components/FeedCard.tsx#L308-L317