### PR TITLE
Tweak app language string in Settings

### DIFF
--- a/src/screens/Settings/LanguageSettings.tsx
+++ b/src/screens/Settings/LanguageSettings.tsx
@@ -82,8 +82,8 @@ export function LanguageSettingsScreen({}: Props) {
             <View style={[a.gap_md, a.w_full]}>
               <Text style={[a.leading_snug]}>
                 <Trans>
-                  Select your app language for the default text to display in
-                  the app.
+                  Select which language you'd like to use for the app's user
+                  interface.
                 </Trans>
               </Text>
               <View style={[a.relative, web([a.w_full, {maxWidth: 400}])]}>

--- a/src/screens/Settings/LanguageSettings.tsx
+++ b/src/screens/Settings/LanguageSettings.tsx
@@ -82,8 +82,7 @@ export function LanguageSettingsScreen({}: Props) {
             <View style={[a.gap_md, a.w_full]}>
               <Text style={[a.leading_snug]}>
                 <Trans>
-                  Select which language you'd like to use for the app's user
-                  interface.
+                  Select which language to use for the app's user interface.
                 </Trans>
               </Text>
               <View style={[a.relative, web([a.w_full, {maxWidth: 400}])]}>


### PR DESCRIPTION
Following [feedback on Crowdin](https://bluesky.crowdin.com/editor/1/11/en-gd/9#2667):
> This is a rather tortured English sentence for selecting the UI language and should be revisited. Something like "Select a language for the apps user-interface" would be much easier to understand. The way it's now, it first made me wonder if this was a language selector for some sort of dummy text in certain fields until I found it in the UI language selection menu.

This PR proposes slightly different wording, changing the text from:
`Select your app language for the default text to display in the app.`
to
`Select which language to use for the app's user interface.`