### PR TITLE
Plural formatting for `TimeIndicator` `accessibilityLabel`

### DIFF
--- a/src/view/com/util/post-embeds/VideoEmbedInner/TimeIndicator.tsx
+++ b/src/view/com/util/post-embeds/VideoEmbedInner/TimeIndicator.tsx
@@ -1,6 +1,6 @@
 import {StyleProp, ViewStyle} from 'react-native'
 import {View} from 'react-native'
-import {msg} from '@lingui/macro'
+import {msg, plural} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
 import {atoms as a, useTheme} from '#/alf'
@@ -30,7 +30,10 @@ export function TimeIndicator({
   return (
     <View
       pointerEvents="none"
-      accessibilityLabel={_(msg`Time remaining: ${time} seconds`)}
+      accessibilityLabel={_(msg`Time remaining: ${plural(Number(time) || 0, {
+        one: '# second',
+        other: '# seconds',
+      })}`)}
       accessibilityHint=""
       style={[
         {

--- a/src/view/com/util/post-embeds/VideoEmbedInner/TimeIndicator.tsx
+++ b/src/view/com/util/post-embeds/VideoEmbedInner/TimeIndicator.tsx
@@ -30,10 +30,12 @@ export function TimeIndicator({
   return (
     <View
       pointerEvents="none"
-      accessibilityLabel={_(msg`Time remaining: ${plural(Number(time) || 0, {
-        one: '# second',
-        other: '# seconds',
-      })}`)}
+      accessibilityLabel={_(
+        msg`Time remaining: ${plural(Number(time) || 0, {
+          one: '# second',
+          other: '# seconds',
+        })}`,
+      )}
       accessibilityHint=""
       style={[
         {


### PR DESCRIPTION
Following [feedback raised on Crowdin](https://bluesky.crowdin.com/editor/1/11/en-gd/9#3175), this PR adds plural formatting to the `accessibilityLabel` for the video time indicator.