### PR TITLE
Separate strings for translation in `ListHiddenScreen.tsx`

### DIFF
--- a/src/screens/List/ListHiddenScreen.tsx
+++ b/src/screens/List/ListHiddenScreen.tsx
@@ -142,15 +142,18 @@ export function ListHiddenScreen({
                 Either the creator of this list has blocked you or you have
                 blocked the creator.
               </Trans>
+            ) : isOwner ? (
+              <Trans>
+                This list – created by you – contains possible violations of
+                Bluesky's community guidelines in its name or description.
+              </Trans>
             ) : (
               <Trans>
-                This list - created by{' '}
-                <Text style={[a.text_md, !isOwner && a.font_bold]}>
-                  {isOwner
-                    ? _(msg`you`)
-                    : sanitizeHandle(list.creator.handle, '@')}
+                This list – created by{' '}
+                <Text style={[a.font_bold]}>
+                  {sanitizeHandle(list.creator.handle, '@')}
                 </Text>{' '}
-                - contains possible violations of Bluesky's community guidelines
+                – contains possible violations of Bluesky's community guidelines
                 in its name or description.
               </Trans>
             )}


### PR DESCRIPTION
Following [feedback on Crowdin](https://bluesky.crowdin.com/editor/1/11/en-engb/9#3577):
> It's a really really bad idea to use pronouns for concatenation because they are heavily inflected in many languages depening on the context. For example, while you as the subject may be _thu_ in ScG, _from you_ becomes _uat_ and _to you_ _dhut_ or _thugad_ depending on context. UI strings with pronouns are best hard coded. Or need a detailed explanation of context.

I used ChatGPT and trial and error to put together this PR. Instead of the current combined string, where either `you` or the handle is used:
https://github.com/bluesky-social/social-app/blob/7a3a1a2bd07ba6a38c7886105491bb96df2ebd62/src/screens/List/ListHiddenScreen.tsx#L145-L156

This PR creates separate strings that can be fully translated:

`This list – created by you – contains possible violations of Bluesky's community guidelines in its name or description.`

and

`This list – created by {0} – contains possible violations of Bluesky's community guidelines in its name or description.`

I also took the opportunity to use em-dashes instead of hyphens.

**This PR passes CI but I haven't tested it.**