### PR TITLE
Fix optimistic rendering of profile page

### DIFF
--- a/src/state/queries/actor-starter-packs.ts
+++ b/src/state/queries/actor-starter-packs.ts
@@ -11,7 +11,13 @@ import {useAgent} from '#/state/session'
 export const RQKEY_ROOT = 'actor-starter-packs'
 export const RQKEY = (did?: string) => [RQKEY_ROOT, did]
 
-export function useActorStarterPacksQuery({did}: {did?: string}) {
+export function useActorStarterPacksQuery({
+  did,
+  enabled = true,
+}: {
+  did?: string
+  enabled?: boolean
+}) {
   const agent = useAgent()
 
   return useInfiniteQuery<
@@ -30,7 +36,7 @@ export function useActorStarterPacksQuery({did}: {did?: string}) {
       })
       return res.data
     },
-    enabled: Boolean(did),
+    enabled: Boolean(did) && enabled,
     initialPageParam: undefined,
     getNextPageParam: lastPage => lastPage.cursor,
   })

--- a/src/view/com/feeds/ProfileFeedgens.tsx
+++ b/src/view/com/feeds/ProfileFeedgens.tsx
@@ -76,7 +76,7 @@ export const ProfileFeedgens = React.forwardRef<
     if (isError && isEmpty) {
       items = items.concat([ERROR_ITEM])
     }
-    if (!isFetched && isFetching) {
+    if (!isFetched || isFetching) {
       items = items.concat([LOADING])
     } else if (isEmpty) {
       items = items.concat([EMPTY])

--- a/src/view/com/lists/ProfileLists.tsx
+++ b/src/view/com/lists/ProfileLists.tsx
@@ -72,7 +72,7 @@ export const ProfileLists = React.forwardRef<SectionRef, ProfileListsProps>(
       if (isError && isEmpty) {
         items = items.concat([ERROR_ITEM])
       }
-      if (!isFetched && isFetching) {
+      if (!isFetched || isFetching) {
         items = items.concat([LOADING])
       } else if (isEmpty) {
         items = items.concat([EMPTY])

--- a/src/view/screens/Profile.tsx
+++ b/src/view/screens/Profile.tsx
@@ -3,7 +3,6 @@ import {StyleSheet} from 'react-native'
 import {SafeAreaView} from 'react-native-safe-area-context'
 import {
   AppBskyActorDefs,
-  AppBskyGraphGetActorStarterPacks,
   moderateProfile,
   ModerationOpts,
   RichText as RichTextAPI,
@@ -11,11 +10,7 @@ import {
 import {msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 import {useFocusEffect} from '@react-navigation/native'
-import {
-  InfiniteData,
-  UseInfiniteQueryResult,
-  useQueryClient,
-} from '@tanstack/react-query'
+import {useQueryClient} from '@tanstack/react-query'
 
 import {useSetTitle} from '#/lib/hooks/useSetTitle'
 import {ComposeIcon2} from '#/lib/icons'
@@ -27,7 +22,6 @@ import {colors, s} from '#/lib/styles'
 import {useProfileShadow} from '#/state/cache/profile-shadow'
 import {listenSoftReset} from '#/state/events'
 import {useModerationOpts} from '#/state/preferences/moderation-opts'
-import {useActorStarterPacksQuery} from '#/state/queries/actor-starter-packs'
 import {useLabelerInfoQuery} from '#/state/queries/labeler'
 import {resetProfilePostsQueries} from '#/state/queries/post-feed'
 import {useProfileQuery} from '#/state/queries/profile'
@@ -86,7 +80,6 @@ function ProfileScreenInner({route}: Props) {
   } = useProfileQuery({
     did: resolvedDid,
   })
-  const starterPacksQuery = useActorStarterPacksQuery({did: resolvedDid})
 
   const onPressTryAgain = React.useCallback(() => {
     if (resolveError) {
@@ -138,7 +131,6 @@ function ProfileScreenInner({route}: Props) {
     return (
       <ProfileScreenLoaded
         profile={profile}
-        starterPacksQuery={starterPacksQuery}
         moderationOpts={moderationOpts}
         isPlaceholderProfile={isPlaceholderProfile}
         hideBackButton={!!route.params.hideBackButton}
@@ -164,16 +156,11 @@ function ProfileScreenLoaded({
   isPlaceholderProfile,
   moderationOpts,
   hideBackButton,
-  starterPacksQuery,
 }: {
   profile: AppBskyActorDefs.ProfileViewDetailed
   moderationOpts: ModerationOpts
   hideBackButton: boolean
   isPlaceholderProfile: boolean
-  starterPacksQuery: UseInfiniteQueryResult<
-    InfiniteData<AppBskyGraphGetActorStarterPacks.OutputSchema, unknown>,
-    Error
-  >
 }) {
   const profile = useProfileShadow(profileUnshadowed)
   const {hasSession, currentAccount} = useSession()
@@ -223,9 +210,7 @@ function ProfileScreenLoaded({
   const showLikesTab = isMe
   const showFeedsTab = isMe || (profile.associated?.feedgens || 0) > 0
   const showStarterPacksTab =
-    isMe ||
-    (profile.associated?.starterPacks || 0) > 0 ||
-    !!starterPacksQuery.data?.pages?.[0].starterPacks.length
+    isMe || (profile.associated?.starterPacks || 0) > 0
   const showListsTab =
     hasSession && (isMe || (profile.associated?.lists || 0) > 0)
 
@@ -489,8 +474,8 @@ function ProfileScreenLoaded({
           ? ({headerHeight, isFocused, scrollElRef}) => (
               <ProfileStarterPacks
                 ref={starterPacksSectionRef}
+                did={profile.did}
                 isMe={isMe}
-                starterPacksQuery={starterPacksQuery}
                 scrollElRef={scrollElRef as ListRef}
                 headerOffset={headerHeight}
                 enabled={isFocused}

--- a/src/view/screens/Profile.tsx
+++ b/src/view/screens/Profile.tsx
@@ -223,7 +223,9 @@ function ProfileScreenLoaded({
   const showLikesTab = isMe
   const showFeedsTab = isMe || (profile.associated?.feedgens || 0) > 0
   const showStarterPacksTab =
-    isMe || !!starterPacksQuery.data?.pages?.[0].starterPacks.length
+    isMe ||
+    (profile.associated?.starterPacks || 0) > 0 ||
+    !!starterPacksQuery.data?.pages?.[0].starterPacks.length
   const showListsTab =
     hasSession && (isMe || (profile.associated?.lists || 0) > 0)
 

--- a/src/view/screens/Profile.tsx
+++ b/src/view/screens/Profile.tsx
@@ -114,7 +114,7 @@ function ProfileScreenInner({route}: Props) {
   }, [queryClient, profile?.viewer?.blockedBy, resolvedDid])
 
   // Most pushes will happen here, since we will have only placeholder data
-  if (isLoadingDid || isLoadingProfile || starterPacksQuery.isLoading) {
+  if (isLoadingDid || isLoadingProfile) {
     return (
       <Layout.Content>
         <ProfileHeaderLoading />


### PR DESCRIPTION
We have a mechanism for precaching profile data before you navigate to it - however, this mechanism is broken, because we hold up rendering by waiting for the starter pack query to come in. However, we already know if they have starter packs. because it's in the `profile.associated` object, so we can just render the tab based on that like we do with feeds and lists. Navigation is thus instant again 🚀

This hack also mean that the starter pack query was run eagerly rather than lazily. I moved it down into the list component, so it only fetches lazily like the other tabs - this meant patching up the pending states, since they were broken due to the data typically being already available. While here, I also fixed the pending states for the feed list and list list.

# Navigation before

https://github.com/user-attachments/assets/5b99908a-0a88-495b-a1d1-a3815fc0ee8f

# Navigation after

https://github.com/user-attachments/assets/d1dfac05-de53-49f3-abb5-b87cec0316b9

# Pending states before

https://github.com/user-attachments/assets/85e71862-835f-450b-9ce7-813324102dcd


# Pending states after

https://github.com/user-attachments/assets/cc6042f0-1a53-4032-90b5-b7838b6b3d6d

# Test plan

Confirm navigation is instant again
Test starter packs are appearing on profiles as expected. Confirm extra UI (like the empty state banner and create another button) are working as expected

