### PR TITLE
Fix max height of dialog flatlists

### DIFF
--- a/src/components/Dialog/index.web.tsx
+++ b/src/components/Dialog/index.web.tsx
@@ -219,8 +219,8 @@ export const InnerFlatList = React.forwardRef<
       style={[
         a.overflow_hidden,
         a.px_0,
-        // @ts-expect-error web only -sfn
-        {maxHeight: 'calc(-36px + 100vh)'},
+        // 100 minus 10vh of paddingVertical
+        web({maxHeight: '80vh'}),
         webInnerStyle,
       ]}
       contentContainerStyle={[a.px_0, webInnerContentContainerStyle]}>

--- a/src/components/Dialog/index.web.tsx
+++ b/src/components/Dialog/index.web.tsx
@@ -125,15 +125,7 @@ export function Outer({
                   },
                 ]}>
                 <Backdrop />
-                <View
-                  style={[
-                    a.w_full,
-                    a.z_20,
-                    a.align_center,
-                    web({minHeight: '60vh'}),
-                  ]}>
-                  {children}
-                </View>
+                {children}
               </View>
             </TouchableWithoutFeedback>
           </Context.Provider>

--- a/src/components/Dialog/index.web.tsx
+++ b/src/components/Dialog/index.web.tsx
@@ -125,7 +125,20 @@ export function Outer({
                   },
                 ]}>
                 <Backdrop />
-                {children}
+                {/**
+                 * This is needed to prevent centered dialogs from overflowing
+                 * above the screen, and provides a "natural" centering so that
+                 * stacked dialogs appear relatively aligned.
+                 */}
+                <View
+                  style={[
+                    a.w_full,
+                    a.z_20,
+                    a.align_center,
+                    web({minHeight: '60vh', position: 'static'}),
+                  ]}>
+                  {children}
+                </View>
               </View>
             </TouchableWithoutFeedback>
           </Context.Provider>


### PR DESCRIPTION
Also noticed the `Close` button looked wack, and realized I had a wrapper around dialog content that is no longer needed with top-aligned dialogs.
![CleanShot 2025-02-25 at 09 42 13@2x](https://github.com/user-attachments/assets/d2a29037-68de-452e-85e6-b15367cb7d0a)
