### PR TITLE
Improve toasts in dark mode

### DIFF
--- a/src/view/com/util/Toast.tsx
+++ b/src/view/com/util/Toast.tsx
@@ -171,7 +171,7 @@ function Toast({
             onAccessibilityEscape={hideAndDestroyImmediately}
             style={[
               a.flex_1,
-              t.atoms.bg,
+              t.name === 'dark' ? t.atoms.bg_contrast_25 : t.atoms.bg,
               a.shadow_lg,
               t.atoms.border_contrast_medium,
               a.rounded_sm,
@@ -185,9 +185,14 @@ function Toast({
                     a.flex_shrink_0,
                     a.rounded_full,
                     {width: 32, height: 32},
-                    {backgroundColor: t.palette.primary_50},
                     a.align_center,
                     a.justify_center,
+                    {
+                      backgroundColor:
+                        t.name === 'dark'
+                          ? t.palette.black
+                          : t.palette.primary_50,
+                    },
                   ]}>
                   <FontAwesomeIcon
                     icon={icon}


### PR DESCRIPTION
Increases contrast for toasts in dark mode. Currently, they're really hard to make out compared to the background, since the shadow doesn't really do anything

<table>
  <thead>
    <tr>
      <th>Before</th>
      <th>After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><img width="200" src="https://github.com/user-attachments/assets/d53de70c-2158-4185-97f7-e10eee7e118a" /></td>
      <td><img width="200" src="https://github.com/user-attachments/assets/caba2eee-1f08-412e-99eb-f6f1404c7faf" /></td>
    </tr>
  </tbody>
</table>


# Test plan

Set theme to dark dark mode.
Observe toast