### PR TITLE
Tweak accessibility label and add translation comment

### DIFF
--- a/src/screens/Profile/components/ProfileFeedHeader.tsx
+++ b/src/screens/Profile/components/ProfileFeedHeader.tsx
@@ -498,7 +498,7 @@ function DialogInner({
           <View style={[a.flex_row, a.gap_sm, a.align_center, a.pt_sm]}>
             <Button
               disabled={isLikePending || isUnlikePending}
-              label={_(msg`Like feed`)}
+              label={_(msg`Like this feed`)}
               size="small"
               variant="solid"
               color="secondary"

--- a/src/view/com/auth/SplashScreen.web.tsx
+++ b/src/view/com/auth/SplashScreen.web.tsx
@@ -175,7 +175,9 @@ function Footer() {
       <InlineLinkText
         label={_(msg`See jobs at Bluesky`)}
         to="https://bsky.social/about/join">
-        <Trans>Jobs</Trans>
+        <Trans comment="Link to a page with job openings at Bluesky">
+          Jobs
+        </Trans>
       </InlineLinkText>
 
       <View style={a.flex_1} />


### PR DESCRIPTION
Following [feedback on Crowdin](https://bluesky.crowdin.com/editor/1/11/en-ia/9#1651) that the `Like feed` label is ambiguous and was being misinterpreted by translators:

> Does this message refer to a feed of likes, or to the action to like a feed? […]
>
> Under "Other languages", most of the languages I can read have translations that assume the first, not the second, so they would be wrong - e.g. Dutch, Spanish, Portuguese, Italian, Catalan, Aragonese are all wrong, and probably many others.

This PR tweaks the label to `Like this feed` which is hopefully clearer and less ambiguous.

Concern was also [raised on Crowdin](https://bluesky.crowdin.com/editor/1/11/en-ia/9#1573) about the `Jobs` string:

> What type of "jobs" are we talking about here? […]
>
> Here too, many of the existing translations are wrong, and assume a job/task as in computing.

So this PR adds a `comment` giving context to translators that this is referring to a `Link to a page with job openings at Bluesky`.