### PR TITLE
Fix label preference alignment

### DIFF
--- a/src/components/moderation/LabelPreference.tsx
+++ b/src/components/moderation/LabelPreference.tsx
@@ -268,6 +268,7 @@ export function LabelerLabelPreference({
                 a.rounded_sm,
                 a.border,
                 t.atoms.border_contrast_low,
+                a.self_start,
               ]}>
               <Text emoji style={[a.font_bold, t.atoms.text_contrast_low]}>
                 {currentPrefLabel}


### PR DESCRIPTION
<table>
  <thead>
    <tr>
      <th>Before</th>
      <th>After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><img width="680" src="https://github.com/user-attachments/assets/61babede-d322-45a6-a621-5bfb9cf62ec6" /></td>
      <td><img width="645" src="https://github.com/user-attachments/assets/9f0ce8a9-6b09-4656-8fd5-5afb24624244" /></td>
    </tr>
  </tbody>
</table>