### PR TITLE
[Inbox] Separate avatar stack into two components

### DIFF
--- a/src/components/AvatarStack.tsx
+++ b/src/components/AvatarStack.tsx
@@ -11,68 +11,11 @@ import * as bsky from '#/types/bsky'
 export function AvatarStack({
   profiles,
   size = 26,
-  backgroundColor,
-}: {
-  profiles: string[] | bsky.profile.AnyProfileView[]
-  size?: number
-  backgroundColor?: string
-}) {
-  if (typeof profiles[0] === 'string') {
-    return (
-      <AvatarStackWithFetch
-        profiles={profiles as string[]}
-        size={size}
-        backgroundColor={backgroundColor}
-      />
-    )
-  }
-  return (
-    <AvatarStackInner
-      profiles={profiles as bsky.profile.AnyProfileView[]}
-      size={size}
-      backgroundColor={backgroundColor}
-    />
-  )
-}
-
-function AvatarStackWithFetch({
-  profiles,
-  size,
-  backgroundColor,
-}: {
-  profiles: string[]
-  size: number
-  backgroundColor?: string
-}) {
-  const {data, error} = useProfilesQuery({handles: profiles})
-
-  if (error) {
-    if (error.name !== 'AbortError') {
-      logger.error('Error fetching profiles for AvatarStack', {
-        safeMessage: error,
-      })
-    }
-    return null
-  }
-
-  return (
-    <AvatarStackInner
-      numPending={profiles.length}
-      profiles={data?.profiles || []}
-      size={size}
-      backgroundColor={backgroundColor}
-    />
-  )
-}
-
-function AvatarStackInner({
-  profiles,
-  size,
   numPending,
   backgroundColor,
 }: {
   profiles: bsky.profile.AnyProfileView[]
-  size: number
+  size?: number
   numPending?: number
   backgroundColor?: string
 }) {
@@ -80,7 +23,7 @@ function AvatarStackInner({
   const t = useTheme()
   const moderationOpts = useModerationOpts()
 
-  const isPending = numPending || !moderationOpts
+  const isPending = (numPending && profiles.length === 0) || !moderationOpts
 
   const items = isPending
     ? Array.from({length: numPending ?? profiles.length}).map((_, i) => ({
@@ -129,5 +72,35 @@ function AvatarStackInner({
         </View>
       ))}
     </View>
+  )
+}
+
+export function AvatarStackWithFetch({
+  profiles,
+  size,
+  backgroundColor,
+}: {
+  profiles: string[]
+  size?: number
+  backgroundColor?: string
+}) {
+  const {data, error} = useProfilesQuery({handles: profiles})
+
+  if (error) {
+    if (error.name !== 'AbortError') {
+      logger.error('Error fetching profiles for AvatarStack', {
+        safeMessage: error,
+      })
+    }
+    return null
+  }
+
+  return (
+    <AvatarStack
+      numPending={profiles.length}
+      profiles={data?.profiles || []}
+      size={size}
+      backgroundColor={backgroundColor}
+    />
   )
 }

--- a/src/screens/Settings/Settings.tsx
+++ b/src/screens/Settings/Settings.tsx
@@ -28,7 +28,7 @@ import {ProfileHeaderDisplayName} from '#/screens/Profile/Header/DisplayName'
 import {ProfileHeaderHandle} from '#/screens/Profile/Header/Handle'
 import * as SettingsList from '#/screens/Settings/components/SettingsList'
 import {atoms as a, tokens, useTheme} from '#/alf'
-import {AvatarStack} from '#/components/AvatarStack'
+import {AvatarStackWithFetch} from '#/components/AvatarStack'
 import {useDialogControl} from '#/components/Dialog'
 import {SwitchAccountDialog} from '#/components/dialogs/SwitchAccount'
 import {Accessibility_Stroke2_Corner2_Rounded as AccessibilityIcon} from '#/components/icons/Accessibility'
@@ -118,7 +118,7 @@ export function SettingsScreen({}: Props) {
                 {showAccounts ? (
                   <SettingsList.ItemIcon icon={ChevronUpIcon} size="md" />
                 ) : (
-                  <AvatarStack
+                  <AvatarStackWithFetch
                     profiles={accounts
                       .map(acc => acc.did)
                       .filter(did => did !== currentAccount?.did)


### PR DESCRIPTION
AvatarStack now has two versions, rather than squishing both use cases into one
1. AvatarStack takes an array of AnyProfileViews
2. AvatarStackWithFetch takes an array of DIDs and performs a fetch first