### PR TITLE
Modify hosting provider text for better localization

### DIFF
--- a/src/components/forms/HostingProvider.tsx
+++ b/src/components/forms/HostingProvider.tsx
@@ -43,21 +43,23 @@ export function HostingProvider({
       {minimal ? (
         <View style={[a.flex_row, a.align_center, a.flex_wrap]}>
           <Text style={[a.text_sm, t.atoms.text_contrast_medium]}>
-            <Trans>You are creating an account on </Trans>
+            <Trans>
+              You are creating an account on{' '}
+              <Button
+                label={toNiceDomain(serviceUrl)}
+                accessibilityHint={_(msg`Changes hosting provider`)}
+                onPress={onPressSelectService}
+                variant="ghost"
+                color="secondary"
+                size="tiny"
+                style={[a.px_xs, {margin: tokens.space.xs * -1}]}>
+                <ButtonText style={[a.text_sm]}>
+                  {toNiceDomain(serviceUrl)}
+                </ButtonText>
+                <ButtonIcon icon={PencilIcon} />
+              </Button>
+            </Trans>
           </Text>
-          <Button
-            label={toNiceDomain(serviceUrl)}
-            accessibilityHint={_(msg`Changes hosting provider`)}
-            onPress={onPressSelectService}
-            variant="ghost"
-            color="secondary"
-            size="tiny"
-            style={[a.px_xs, {marginLeft: tokens.space.xs * -1}]}>
-            <ButtonText style={[a.text_sm]}>
-              {toNiceDomain(serviceUrl)}
-            </ButtonText>
-            <ButtonIcon icon={PencilIcon} />
-          </Button>
         </View>
       ) : (
         <Button

--- a/src/components/forms/HostingProvider.tsx
+++ b/src/components/forms/HostingProvider.tsx
@@ -52,7 +52,7 @@ export function HostingProvider({
                 variant="ghost"
                 color="secondary"
                 size="tiny"
-                style={[a.px_xs, {margin: tokens.space.xs * -1}]}>
+                style={[a.px_xs, {marginHorizontal: tokens.space.xs * -1}]}>
                 <ButtonText style={[a.text_sm]}>
                   {toNiceDomain(serviceUrl)}
                 </ButtonText>


### PR DESCRIPTION
I moved the `<Button>` to inside the `<Trans>` because some languages need to be able to move the position of the hosting provider name.

Also modified the margin style to eliminate line height differences.