### PR TITLE
Fix accessibility label

### DIFF
--- a/src/screens/Profile/Header/ProfileHeaderLabeler.tsx
+++ b/src/screens/Profile/Header/ProfileHeaderLabeler.tsx
@@ -272,7 +272,7 @@ let ProfileHeaderLabeler = ({
                   color="secondary"
                   variant="solid"
                   shape="round"
-                  label={_(msg`Like this feed`)}
+                  label={_(msg`Like this labeler`)}
                   disabled={!hasSession || isLikePending || isUnlikePending}
                   onPress={onToggleLiked}>
                   {likeUri ? (


### PR DESCRIPTION
I noticed that in `src/screens/Profile/Header/ProfileHeaderLabeler.tsx` the label for the heart icon mistakenly reads `Like this feed`. This PR fixes that by changing it to `Like this labeler`.