### PR TITLE
Logger metrics

### DIFF
--- a/src/Navigation.tsx
+++ b/src/Navigation.tsx
@@ -32,6 +32,7 @@ import {
 import {RouteParams, State} from '#/lib/routes/types'
 import {attachRouteToLogEvents, logEvent} from '#/lib/statsig/statsig'
 import {bskyTitle} from '#/lib/strings/headings'
+import {logger} from '#/logger'
 import {isNative, isWeb} from '#/platform/detection'
 import {useModalControls} from '#/state/modals'
 import {useUnreadNotifications} from '#/state/queries/notifications/unread'
@@ -729,20 +730,16 @@ function RoutesContainer({children}: React.PropsWithChildren<{}>) {
       linking={LINKING}
       theme={theme}
       onStateChange={() => {
-        logEvent(
-          'router:navigate',
-          {
-            from: prevLoggedRouteName.current,
-          },
-          {lake: true},
-        )
+        logger.metric('router:navigate', {
+          from: prevLoggedRouteName.current,
+        })
         prevLoggedRouteName.current = getCurrentRouteName()
       }}
       onReady={() => {
         attachRouteToLogEvents(getCurrentRouteName)
         logModuleInitTime()
         onReady()
-        logEvent('router:navigate', {}, {lake: true})
+        logger.metric('router:navigate', {})
       }}>
       {children}
     </NavigationContainer>

--- a/src/Navigation.tsx
+++ b/src/Navigation.tsx
@@ -729,16 +729,20 @@ function RoutesContainer({children}: React.PropsWithChildren<{}>) {
       linking={LINKING}
       theme={theme}
       onStateChange={() => {
-        logEvent('lake:router:navigate', {
-          from: prevLoggedRouteName.current,
-        })
+        logEvent(
+          'router:navigate',
+          {
+            from: prevLoggedRouteName.current,
+          },
+          {lake: true},
+        )
         prevLoggedRouteName.current = getCurrentRouteName()
       }}
       onReady={() => {
         attachRouteToLogEvents(getCurrentRouteName)
         logModuleInitTime()
         onReady()
-        logEvent('lake:router:navigate', {})
+        logEvent('router:navigate', {}, {lake: true})
       }}>
       {children}
     </NavigationContainer>

--- a/src/lib/statsig/statsig.tsx
+++ b/src/lib/statsig/statsig.tsx
@@ -5,12 +5,12 @@ import {Statsig, StatsigProvider} from 'statsig-react-native-expo'
 
 import {BUNDLE_DATE, BUNDLE_IDENTIFIER, IS_TESTFLIGHT} from '#/lib/app-info'
 import {logger} from '#/logger'
+import {MetricEvents} from '#/logger/metrics'
 import {isWeb} from '#/platform/detection'
 import * as persisted from '#/state/persisted'
 import {useSession} from '../../state/session'
 import {timeout} from '../async/timeout'
 import {useNonReactiveCallback} from '../hooks/useNonReactiveCallback'
-import {LogEvents} from './events'
 import {Gate} from './gates'
 
 const SDK_KEY = 'client-SXJakO39w9vIhl3D44u8UupyzFl4oZ2qPIkjwcvuPsV'
@@ -42,7 +42,7 @@ if (isWeb && typeof window !== 'undefined') {
   refUrl = decodeURIComponent(params.get('ref_url') ?? '')
 }
 
-export type {LogEvents}
+export type {MetricEvents as LogEvents}
 
 function createStatsigOptions(prefetchUsers: StatsigUser[]) {
   return {
@@ -91,15 +91,25 @@ export function toClout(n: number | null | undefined): number | undefined {
   }
 }
 
-export function logEvent<E extends keyof LogEvents>(
+export function logEvent<E extends keyof MetricEvents>(
   eventName: E & string,
-  rawMetadata: LogEvents[E] & FlatJSONRecord,
+  rawMetadata: MetricEvents[E] & FlatJSONRecord,
+  options: {
+    /**
+     * Send to our data lake only, not to StatSig
+     */
+    lake?: boolean
+  } = {lake: false},
 ) {
   try {
     const fullMetadata = toStringRecord(rawMetadata)
     fullMetadata.routeName = getCurrentRouteName() ?? '(Uninitialized)'
     if (Statsig.initializeCalled()) {
-      Statsig.logEvent(eventName, null, fullMetadata)
+      let ev: string = eventName
+      if (options.lake) {
+        ev = `lake:${ev}`
+      }
+      Statsig.logEvent(ev, null, fullMetadata)
     }
     logger.info(eventName, fullMetadata)
   } catch (e) {
@@ -108,8 +118,8 @@ export function logEvent<E extends keyof LogEvents>(
   }
 }
 
-function toStringRecord<E extends keyof LogEvents>(
-  metadata: LogEvents[E] & FlatJSONRecord,
+function toStringRecord<E extends keyof MetricEvents>(
+  metadata: MetricEvents[E] & FlatJSONRecord,
 ): Record<string, string> {
   const record: Record<string, string> = {}
   for (let key in metadata) {

--- a/src/lib/statsig/statsig.tsx
+++ b/src/lib/statsig/statsig.tsx
@@ -91,6 +91,9 @@ export function toClout(n: number | null | undefined): number | undefined {
   }
 }
 
+/**
+ * @deprecated use `logger.metric()` instead
+ */
 export function logEvent<E extends keyof MetricEvents>(
   eventName: E & string,
   rawMetadata: MetricEvents[E] & FlatJSONRecord,
@@ -111,7 +114,13 @@ export function logEvent<E extends keyof MetricEvents>(
       }
       Statsig.logEvent(ev, null, fullMetadata)
     }
-    logger.info(eventName, fullMetadata)
+    /**
+     * All datalake events should be sent using `logger.metric`, and we don't
+     * want to double-emit logs to other transports.
+     */
+    if (!options.lake) {
+      logger.info(eventName, fullMetadata)
+    }
   } catch (e) {
     // A log should never interrupt the calling code, whatever happens.
     logger.error('Failed to log an event', {message: e})

--- a/src/logger/metrics.ts
+++ b/src/logger/metrics.ts
@@ -1,4 +1,4 @@
-export type LogEvents = {
+export type MetricEvents = {
   // App events
   init: {
     initMs: number
@@ -30,7 +30,7 @@ export type LogEvents = {
     secondsActive: number
   }
   'state:foreground': {}
-  'lake:router:navigate': {
+  'router:navigate': {
     from?: string
   }
   'deepLink:referrerReceived': {

--- a/src/logger/transports/bitdrift.ts
+++ b/src/logger/transports/bitdrift.ts
@@ -18,7 +18,6 @@ export const bitdriftTransport: Transport = (
 ) => {
   const log = logFunctions[level]
   log(message.toString(), {
-    // match Sentry payload
     __context__: context,
     ...prepareMetadata(metadata),
   })

--- a/src/logger/transports/bitdrift.ts
+++ b/src/logger/transports/bitdrift.ts
@@ -19,7 +19,7 @@ export const bitdriftTransport: Transport = (
   const log = logFunctions[level]
   log(message.toString(), {
     // match Sentry payload
-    context,
+    __context__: context,
     ...prepareMetadata(metadata),
   })
 }

--- a/src/logger/transports/sentry.ts
+++ b/src/logger/transports/sentry.ts
@@ -11,7 +11,6 @@ export const sentryTransport: Transport = (
   timestamp,
 ) => {
   const meta = {
-    // match Bitdrift payload
     __context__: context,
     ...prepareMetadata(metadata),
   }

--- a/src/logger/transports/sentry.ts
+++ b/src/logger/transports/sentry.ts
@@ -12,7 +12,7 @@ export const sentryTransport: Transport = (
 ) => {
   const meta = {
     // match Bitdrift payload
-    context,
+    __context__: context,
     ...prepareMetadata(metadata),
   }
   let _tags = tags || {}

--- a/src/logger/types.ts
+++ b/src/logger/types.ts
@@ -5,6 +5,7 @@
  */
 export enum LogContext {
   Default = 'logger',
+  Metric = 'metric',
   Session = 'session',
   Notifications = 'notifications',
   ConversationAgent = 'conversation-agent',
@@ -35,7 +36,7 @@ export type Metadata = {
   /**
    * Reserved for appending `LogContext` to logging payloads
    */
-  context?: undefined
+  __context__?: undefined
 
   /**
    * Applied as Sentry breadcrumb types. Defaults to `default`.

--- a/src/logger/types.ts
+++ b/src/logger/types.ts
@@ -5,11 +5,16 @@
  */
 export enum LogContext {
   Default = 'logger',
-  Metric = 'metric',
   Session = 'session',
   Notifications = 'notifications',
   ConversationAgent = 'conversation-agent',
   DMsAgent = 'dms-agent',
+
+  /**
+   * METRIC IS FOR INTERNAL USE ONLY, don't create any other loggers using this
+   * context
+   */
+  Metric = 'metric',
 }
 
 export enum LogLevel {
@@ -34,7 +39,7 @@ export type Transport = (
  */
 export type Metadata = {
   /**
-   * Reserved for appending `LogContext` to logging payloads
+   * Reserved for appending `LogContext` in logging payloads
    */
   __context__?: undefined
 


### PR DESCRIPTION
Adds a `logger.metric()` method for more convenience emission of metrics. By default, this new method sends events to the datalake and _not_ to StatSig. This method also calls all configured logger transports e.g. Bitdrift and relays the same information.

```typescript
logger.metric('router:navigate', {from: <route>})
// also send to StatSig
logger.metric('init', {...}, {statsig: true})
```

This is powered by our existing `logEvent` from StatSig. However, I made a small update there to replace the manual `lake:` prefixing with an additional param:

```typescript
logEvent('lake:router:navigate', {from: <route>})
// becomes
logEvent('router:navigate', {from: <route>}, {lake: true})
```

Notable change here: event types no longer have the explicit `lake:` prefix, but I don't anticipate that being an issue atm. Should discuss.

Since these events are now called via the logger, I moved their definitions over there. I left StatSig otherwise untouched to avoid too much churn. Eventually I think we could set StatSig up as just another logger transport, but for the same reason I haven't done that here.