### PR TITLE
Remove use left convos

### DIFF
--- a/src/screens/Messages/ChatList.tsx
+++ b/src/screens/Messages/ChatList.tsx
@@ -17,7 +17,6 @@ import {isNative} from '#/platform/detection'
 import {listenSoftReset} from '#/state/events'
 import {MESSAGE_SCREEN_POLL_INTERVAL} from '#/state/messages/convo/const'
 import {useMessagesEventBus} from '#/state/messages/events'
-import {useLeftConvos} from '#/state/queries/messages/leave-conversation'
 import {useListConvosQuery} from '#/state/queries/messages/list-conversations'
 import {useSession} from '#/state/session'
 import {List, type ListRef} from '#/view/com/util/List'
@@ -149,14 +148,11 @@ export function MessagesScreenInner({navigation, route}: Props) {
   useRefreshOnFocus(refetch)
   useRefreshOnFocus(refetchInbox)
 
-  const leftConvos = useLeftConvos()
-
   const inboxAllConvos =
     inboxData?.pages
       .flatMap(page => page.convos)
       .filter(
         convo =>
-          !leftConvos.includes(convo.id) &&
           !convo.muted &&
           convo.members.every(member => member.handle !== 'missing.invalid'),
       ) ?? []
@@ -172,10 +168,7 @@ export function MessagesScreenInner({navigation, route}: Props) {
 
   const conversations = useMemo(() => {
     if (data?.pages) {
-      const conversations = data.pages
-        .flatMap(page => page.convos)
-        // filter out convos that are actively being left
-        .filter(convo => !leftConvos.includes(convo.id))
+      const flattenedConvos = data.pages.flatMap(page => page.convos)
 
       return [
         ...(hasInboxConvos
@@ -187,13 +180,13 @@ export function MessagesScreenInner({navigation, route}: Props) {
               },
             ]
           : []),
-        ...conversations.map(
+        ...flattenedConvos.map(
           convo => ({type: 'CONVERSATION', conversation: convo}) as const,
         ),
       ] satisfies ListItem[]
     }
     return []
-  }, [data, leftConvos, hasInboxConvos, inboxUnreadConvoMembers])
+  }, [data, hasInboxConvos, inboxUnreadConvoMembers])
 
   const onRefresh = useCallback(async () => {
     setIsPTRing(true)

--- a/src/screens/Messages/Inbox.tsx
+++ b/src/screens/Messages/Inbox.tsx
@@ -24,7 +24,6 @@ import {logger} from '#/logger'
 import {isNative} from '#/platform/detection'
 import {MESSAGE_SCREEN_POLL_INTERVAL} from '#/state/messages/convo/const'
 import {useMessagesEventBus} from '#/state/messages/events'
-import {useLeftConvos} from '#/state/queries/messages/leave-conversation'
 import {useListConvosQuery} from '#/state/queries/messages/list-conversations'
 import {useUpdateAllRead} from '#/state/queries/messages/update-all-read'
 import {FAB} from '#/view/com/util/fab/FAB'
@@ -66,19 +65,13 @@ export function MessagesInboxScreenInner({}: Props) {
   const listConvosQuery = useListConvosQuery({status: 'request'})
   const {data} = listConvosQuery
 
-  const leftConvos = useLeftConvos()
-
   const conversations = useMemo(() => {
     if (data?.pages) {
-      const convos = data.pages
-        .flatMap(page => page.convos)
-        // filter out convos that are actively being left
-        .filter(convo => !leftConvos.includes(convo.id))
-
+      const convos = data.pages.flatMap(page => page.convos)
       return convos
     }
     return []
-  }, [data, leftConvos])
+  }, [data])
 
   const hasUnreadConvos = useMemo(() => {
     return conversations.some(

--- a/src/state/queries/messages/leave-conversation.ts
+++ b/src/state/queries/messages/leave-conversation.ts
@@ -12,7 +12,7 @@ import {logger} from '#/logger'
 import {useAgent} from '#/state/session'
 import {RQKEY_ROOT as CONVO_LIST_KEY} from './list-conversations'
 
-const RQKEY_ROOT = 'leave-convo'
+export const RQKEY_ROOT = 'leave-convo'
 export function RQKEY(convoId: string | undefined) {
   return [RQKEY_ROOT, convoId]
 }
@@ -42,7 +42,8 @@ export function useLeaveConvo(
 
       return data
     },
-    onMutate: () => {
+    onMutate: async () => {
+      await queryClient.cancelQueries({queryKey: CONVO_LIST_KEY})
       let prevPages: ChatBskyConvoListConvos.OutputSchema[] = []
       queryClient.setQueryData(
         [CONVO_LIST_KEY],

--- a/src/state/queries/messages/leave-conversation.ts
+++ b/src/state/queries/messages/leave-conversation.ts
@@ -1,11 +1,5 @@
-
-import {
-  type ChatBskyConvoListConvos,
-} from '@atproto/api'
-import {
-  useMutation,
-  useQueryClient,
-} from '@tanstack/react-query'
+import {type ChatBskyConvoListConvos} from '@atproto/api'
+import {useMutation, useQueryClient} from '@tanstack/react-query'
 
 import {DM_SERVICE_HEADERS} from '#/lib/constants'
 import {logger} from '#/logger'
@@ -13,12 +7,13 @@ import {useAgent} from '#/state/session'
 import {RQKEY_ROOT as CONVO_LIST_KEY} from './list-conversations'
 
 export const RQKEY_ROOT = 'leave-convo'
-export function RQKEY(convoId: string | undefined) {
-  return [RQKEY_ROOT, convoId]
+
+export function RQKEY(convoId: string) {
+  return [RQKEY_ROOT, convoId] as const
 }
 
 export function useLeaveConvo(
-  convoId: string | undefined,
+  convoId: string,
   {
     onMutate,
     onError,
@@ -43,7 +38,7 @@ export function useLeaveConvo(
       return data
     },
     onMutate: async () => {
-      await queryClient.cancelQueries({queryKey: CONVO_LIST_KEY})
+      await queryClient.cancelQueries({queryKey: [CONVO_LIST_KEY]})
       let prevPages: ChatBskyConvoListConvos.OutputSchema[] = []
       queryClient.setQueryData(
         [CONVO_LIST_KEY],
@@ -85,7 +80,9 @@ export function useLeaveConvo(
       onError?.(error)
     },
     onSettled: () => {
-      queryClient.invalidateQueries({queryKey: CONVO_LIST_KEY})
+      if (queryClient.isMutating({mutationKey: RQKEY(convoId)}) === 1) {
+        queryClient.invalidateQueries({queryKey: [CONVO_LIST_KEY]})
+      }
     },
   })
 }

--- a/src/state/queries/messages/list-conversations.tsx
+++ b/src/state/queries/messages/list-conversations.tsx
@@ -9,6 +9,7 @@ import {
   type InfiniteData,
   type QueryClient,
   useInfiniteQuery,
+  useMutationState,
   useQueryClient,
 } from '@tanstack/react-query'
 import throttle from 'lodash.throttle'
@@ -17,8 +18,8 @@ import {DM_SERVICE_HEADERS} from '#/lib/constants'
 import {useCurrentConvoId} from '#/state/messages/current-convo-id'
 import {useMessagesEventBus} from '#/state/messages/events'
 import {useModerationOpts} from '#/state/preferences/moderation-opts'
+import {RQKEY_ROOT as LEAVE_CONVO_RQKEY_ROOT} from '#/state/queries/messages/leave-conversation'
 import {useAgent, useSession} from '#/state/session'
-import {useLeftConvos} from './leave-conversation'
 
 export const RQKEY_ROOT = 'convo-list'
 export const RQKEY = (
@@ -38,8 +39,15 @@ export function useListConvosQuery({
 } = {}) {
   const agent = useAgent()
 
+  const leaveConvoMutationStates = useMutationState({
+    filters: {
+      mutationKey: [LEAVE_CONVO_RQKEY_ROOT],
+      status: 'pending',
+    },
+  })
+
   return useInfiniteQuery({
-    enabled,
+    enabled: enabled && leaveConvoMutationStates.length === 0,
     queryKey: RQKEY(status ?? 'all', readState),
     queryFn: async ({pageParam}) => {
       const {data} = await agent.chat.bsky.convo.listConvos(
@@ -97,7 +105,6 @@ export function ListConvosProviderInner({
   const queryClient = useQueryClient()
   const {currentConvoId} = useCurrentConvoId()
   const {currentAccount} = useSession()
-  const leftConvos = useLeftConvos()
 
   const debouncedRefetch = useMemo(() => {
     const refetchAndInvalidate = () => {
@@ -376,15 +383,12 @@ export function ListConvosProviderInner({
   ])
 
   const ctx = useMemo(() => {
-    const convos =
-      data?.pages
-        .flatMap(page => page.convos)
-        .filter(convo => !leftConvos.includes(convo.id)) ?? []
+    const convos = data?.pages.flatMap(page => page.convos) ?? []
     return {
       accepted: convos.filter(conv => conv.status === 'accepted'),
       request: convos.filter(conv => conv.status === 'request'),
     }
-  }, [data, leftConvos])
+  }, [data])
 
   return (
     <ListConvosContext.Provider value={ctx}>

--- a/src/state/queries/messages/list-conversations.tsx
+++ b/src/state/queries/messages/list-conversations.tsx
@@ -47,8 +47,8 @@ export function useListConvosQuery({
   })
 
   return useInfiniteQuery({
-    // Stop refetching if leaving conversation is pending and overriding the
-    // optimistic update.
+    // Stop refetching if leaving conversation is pending, we
+    // do not want to override the optimistic update.
     enabled: enabled && leaveConvoMutationStates.length === 0,
     queryKey: RQKEY(status ?? 'all', readState),
     queryFn: async ({pageParam}) => {

--- a/src/state/queries/messages/list-conversations.tsx
+++ b/src/state/queries/messages/list-conversations.tsx
@@ -47,6 +47,8 @@ export function useListConvosQuery({
   })
 
   return useInfiniteQuery({
+    // Stop refetching if leaving conversation is pending and overriding the
+    // optimistic update.
     enabled: enabled && leaveConvoMutationStates.length === 0,
     queryKey: RQKEY(status ?? 'all', readState),
     queryFn: async ({pageParam}) => {


### PR DESCRIPTION
Follow on from comments in the Tanstack discord made by @mozzius about [`useMutationState`](https://discord.com/channels/719702312431386674/1345072602292686950/1345072602292686950). I've attempted to give a more "straightforward" answer over there, but I'm doing this pr to tackle the problem here

## My understanding of the issue

I may be *horrifically* wrong here, but this is what my current reading of the code entails.

If a user leaves and re-joins the convo, the leave convo mutation is still filtering out the convo they just re-joined, and `useLeftConvos` will still have the successful mutation in the cache, filtering out the convo they just rejoined (this is probably the part I'm most unsure of lol). Hence the need to remove the mutation from the mutation cache, which is somewhat non-trivial.

## A modest proposal

However, it looks like `useLeaveConvo` is already using the cache optimistic update pattern described here: https://tanstack.com/query/latest/docs/framework/react/guides/optimistic-updates#via-the-cache . Tanstack docs only say to use either the UI *or* the cache approach, and hence **I think we can just delete `useLeftConvos` entirely and we'll be fine anyway.**

And that's what the PR does.

We also are disabling `useListConvosQuery` if there are any pending leave convos mutations in flight so that the optimistic updates will not be overwritten (and the convo flashes up again briefly). This was apparently most of the motivation behind `useLeftConvos` in the first place; it makes sense to move that mutation monitoring into the query hook instead.

~~(I've might have another solution as well if you *really* need to hold on to `useLeftConvos`, will make an alternative pr.)~~ Actually I won't make a pr, might comment on it back in the discord.

## Testing

Leave conversations and rejoin them with the same people. Only tested the happy path so far; chat with the local backend doesn't seem great to set up.
