### PR TITLE
Init log using `getLog`

### DIFF
--- a/src/state/messages/events/agent.ts
+++ b/src/state/messages/events/agent.ts
@@ -235,20 +235,21 @@ export class MessagesEventBus {
 
     try {
       const response = await networkRetry(2, () => {
-        return this.agent.api.chat.bsky.convo.listConvos(
-          {
-            limit: 1,
-          },
+        return this.agent.chat.bsky.convo.getLog(
+          {},
           {headers: DM_SERVICE_HEADERS},
         )
       })
       // throw new Error('UNCOMMENT TO TEST INIT FAILURE')
 
-      const {convos} = response.data
+      const {cursor} = response.data
 
-      for (const convo of convos) {
-        if (convo.rev > (this.latestRev = this.latestRev || convo.rev)) {
-          this.latestRev = convo.rev
+      // should always be defined
+      if (cursor) {
+        if (!this.latestRev) {
+          this.latestRev = cursor
+        } else if (cursor > this.latestRev) {
+          this.latestRev = cursor
         }
       }
 


### PR DESCRIPTION
Fixes #7882

Currently we init log polling using `listConvos?limit=1` and use the `rev` of the most recent convo. however, we have loads of "non-embodied" log events now, so starting the tail from the most recent message can often result in hundreds of logs at startup. Instead, we should just call `getLog` initially with no cursor, and use the cursor it returns.

# Test plan

Look at `getLog` in the network request. The getLog calls at startup should have no logs inside them