### PR TITLE
Add context for toast messages

### DIFF
--- a/src/components/FeedCard.tsx
+++ b/src/components/FeedCard.tsx
@@ -269,7 +269,7 @@ function SaveButtonInner({
             },
           ])
         }
-        Toast.show(_(msg`Feeds updated!`))
+        Toast.show(_(msg({message: 'Feeds updated!', context: 'toast'})))
       } catch (err: any) {
         logger.error(err, {message: `FeedCard: failed to update feeds`, pin})
         Toast.show(_(msg`Failed to update feeds`), 'xmark')

--- a/src/components/dms/ConvoMenu.tsx
+++ b/src/components/dms/ConvoMenu.tsx
@@ -173,9 +173,9 @@ function MenuContent({
   const {mutate: muteConvo} = useMuteConvo(convoId, {
     onSuccess: data => {
       if (data.convo.muted) {
-        Toast.show(_(msg`Chat muted`))
+        Toast.show(_(msg({message: 'Chat muted', context: 'toast'})))
       } else {
-        Toast.show(_(msg`Chat unmuted`))
+        Toast.show(_(msg({message: 'Chat unmuted', context: 'toast'})))
       }
     },
     onError: () => {

--- a/src/components/dms/MessageMenu.tsx
+++ b/src/components/dms/MessageMenu.tsx
@@ -69,7 +69,9 @@ export let MessageMenu = ({
     LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut)
     convo
       .deleteMessage(message.id)
-      .then(() => Toast.show(_(msg`Message deleted`)))
+      .then(() =>
+        Toast.show(_(msg({message: 'Message deleted', context: 'toast'}))),
+      )
       .catch(() => Toast.show(_(msg`Failed to delete message`)))
   }, [_, convo, message.id])
 

--- a/src/components/dms/ReportDialog.tsx
+++ b/src/components/dms/ReportDialog.tsx
@@ -315,13 +315,13 @@ function DoneStep({
   let toastMsg: string | undefined
   if (actions.includes('leave') && actions.includes('block')) {
     btnText = _(msg`Block and Delete`)
-    toastMsg = _(msg`Conversation deleted`)
+    toastMsg = _(msg({message: 'Conversation deleted', context: 'toast'}))
   } else if (actions.includes('leave')) {
     btnText = _(msg`Delete Conversation`)
-    toastMsg = _(msg`Conversation deleted`)
+    toastMsg = _(msg({message: 'Conversation deleted', context: 'toast'}))
   } else if (actions.includes('block')) {
     btnText = _(msg`Block User`)
-    toastMsg = _(msg`User blocked`)
+    toastMsg = _(msg({message: 'User blocked', context: 'toast'}))
   }
 
   const onPressPrimaryAction = () => {

--- a/src/components/moderation/LabelsOnMeDialog.tsx
+++ b/src/components/moderation/LabelsOnMeDialog.tsx
@@ -255,7 +255,7 @@ function AppealForm({
     },
     onSuccess: () => {
       control.close()
-      Toast.show(_(msg`Appeal submitted`))
+      Toast.show(_(msg({message: 'Appeal submitted', context: 'toast'})))
     },
   })
 

--- a/src/screens/Messages/components/ChatDisabled.tsx
+++ b/src/screens/Messages/components/ChatDisabled.tsx
@@ -88,7 +88,7 @@ function DialogInner() {
     },
     onSuccess: () => {
       control.close()
-      Toast.show(_(msg`Appeal submitted`))
+      Toast.show(_(msg({message: 'Appeal submitted', context: 'toast'})))
     },
   })
 

--- a/src/screens/ModerationInteractionSettings/index.tsx
+++ b/src/screens/ModerationInteractionSettings/index.tsx
@@ -99,7 +99,7 @@ function Inner({preferences}: {preferences: UsePreferencesQueryResponse}) {
           threadgateAllowUISettingToAllowRecordValue(maybeEditedAllowUI),
         postgateEmbeddingRules: maybeEditedPostgate.embeddingRules ?? [],
       })
-      Toast.show(_(msg`Settings saved`))
+      Toast.show(_(msg({message: 'Settings saved', context: 'toast'})))
     } catch (e: any) {
       logger.error(`Failed to save post interaction settings`, {
         source: 'ModerationInteractionSettingsScreen',

--- a/src/screens/Profile/Header/EditProfileDialog.tsx
+++ b/src/screens/Profile/Header/EditProfileDialog.tsx
@@ -188,7 +188,7 @@ function DialogInner({
       })
       onUpdate?.()
       control.close()
-      Toast.show(_(msg`Profile updated`))
+      Toast.show(_(msg({message: 'Profile updated', context: 'toast'})))
     } catch (e: any) {
       logger.error('Failed to update user profile', {message: String(e)})
     }

--- a/src/screens/Profile/Header/ProfileHeaderStandard.tsx
+++ b/src/screens/Profile/Header/ProfileHeaderStandard.tsx
@@ -134,7 +134,7 @@ let ProfileHeaderStandard = ({
   const unblockAccount = React.useCallback(async () => {
     try {
       await queueUnblock()
-      Toast.show(_(msg`Account unblocked`))
+      Toast.show(_(msg({message: 'Account unblocked', context: 'toast'})))
     } catch (e: any) {
       if (e?.name !== 'AbortError') {
         logger.error('Failed to unblock account', {message: e})

--- a/src/screens/Settings/AboutSettings.tsx
+++ b/src/screens/Settings/AboutSettings.tsx
@@ -76,8 +76,18 @@ export function AboutSettingsScreen({}: Props) {
               setDevModeEnabled(newDevModeEnabled)
               Toast.show(
                 newDevModeEnabled
-                  ? _(msg`Developer mode enabled`)
-                  : _(msg`Developer mode disabled`),
+                  ? _(
+                      msg({
+                        message: 'Developer mode enabled',
+                        context: 'toast',
+                      }),
+                    )
+                  : _(
+                      msg({
+                        message: 'Developer mode disabled',
+                        context: 'toast',
+                      }),
+                    ),
               )
             }}
             onPress={() => {

--- a/src/screens/Settings/AppPasswords.tsx
+++ b/src/screens/Settings/AppPasswords.tsx
@@ -144,7 +144,7 @@ function AppPasswordCard({
 
   const onDelete = useCallback(async () => {
     await deleteMutation({name: appPassword.name})
-    Toast.show(_(msg`App password deleted`))
+    Toast.show(_(msg({message: 'App password deleted', context: 'toast'})))
   }, [deleteMutation, appPassword.name, _])
 
   return (

--- a/src/screens/Settings/components/DisableEmail2FADialog.tsx
+++ b/src/screens/Settings/components/DisableEmail2FADialog.tsx
@@ -61,7 +61,7 @@ export function DisableEmail2FADialog({
           emailAuthFactor: false,
         })
         await agent.resumeSession(agent.session!)
-        Toast.show(_(msg`Email 2FA disabled`))
+        Toast.show(_(msg({message: 'Email 2FA disabled', context: 'toast'})))
       }
       control.close()
     } catch (e) {

--- a/src/state/queries/notifications/settings.ts
+++ b/src/state/queries/notifications/settings.ts
@@ -41,7 +41,7 @@ export function useNotificationSettingsMutation() {
       )
     },
     onSuccess: () => {
-      Toast.show(_(msg`Preference saved`))
+      Toast.show(_(msg({message: 'Preference saved', context: 'toast'})))
     },
     onSettled: () => {
       invalidateCachedUnreadPage()

--- a/src/state/queries/pinned-post.ts
+++ b/src/state/queries/pinned-post.ts
@@ -56,9 +56,9 @@ export function usePinnedPostMutation() {
         })
 
         if (pinCurrentPost) {
-          Toast.show(_(msg`Post pinned`))
+          Toast.show(_(msg({message: 'Post pinned', context: 'toast'})))
         } else {
-          Toast.show(_(msg`Post unpinned`))
+          Toast.show(_(msg({message: 'Post unpinned', context: 'toast'})))
         }
 
         queryClient.invalidateQueries({

--- a/src/view/com/modals/ChangeEmail.tsx
+++ b/src/view/com/modals/ChangeEmail.tsx
@@ -51,7 +51,7 @@ export function Component() {
       } else {
         await agent.com.atproto.server.updateEmail({email: email.trim()})
         await agent.resumeSession(agent.session!)
-        Toast.show(_(msg`Email updated`))
+        Toast.show(_(msg({message: 'Email updated', context: 'toast'})))
         setStage(Stages.Done)
       }
     } catch (e) {
@@ -80,7 +80,7 @@ export function Component() {
         token: confirmationCode.trim(),
       })
       await agent.resumeSession(agent.session!)
-      Toast.show(_(msg`Email updated`))
+      Toast.show(_(msg({message: 'Email updated', context: 'toast'})))
       setStage(Stages.Done)
     } catch (e) {
       setError(cleanError(String(e)))

--- a/src/view/com/modals/CreateOrEditList.tsx
+++ b/src/view/com/modals/CreateOrEditList.tsx
@@ -159,8 +159,8 @@ export function Component({
         })
         Toast.show(
           isCurateList
-            ? _(msg`User list updated`)
-            : _(msg`Moderation list updated`),
+            ? _(msg({message: 'User list updated', context: 'toast'}))
+            : _(msg({message: 'Moderation list updated', context: 'toast'})),
         )
         onSave?.(list.uri)
       } else {
@@ -173,8 +173,8 @@ export function Component({
         })
         Toast.show(
           isCurateList
-            ? _(msg`User list created`)
-            : _(msg`Moderation list created`),
+            ? _(msg({message: 'User list created', context: 'toast'}))
+            : _(msg({message: 'Moderation list created', context: 'toast'})),
         )
         onSave?.(res.uri)
       }

--- a/src/view/com/modals/EditProfile.tsx
+++ b/src/view/com/modals/EditProfile.tsx
@@ -121,7 +121,7 @@ export function Component({
         newUserAvatar,
         newUserBanner,
       })
-      Toast.show(_(msg`Profile updated`))
+      Toast.show(_(msg({message: 'Profile updated', context: 'toast'})))
       onUpdate?.()
       closeModal()
     } catch (e: any) {

--- a/src/view/com/modals/VerifyEmail.tsx
+++ b/src/view/com/modals/VerifyEmail.tsx
@@ -82,7 +82,7 @@ export function Component({
         token: confirmationCode.trim(),
       })
       await agent.resumeSession(agent.session!)
-      Toast.show(_(msg`Email verified`))
+      Toast.show(_(msg({message: 'Email verified', context: 'toast'})))
       closeModal()
       onSuccess?.()
     } catch (e) {

--- a/src/view/com/profile/ProfileMenu.tsx
+++ b/src/view/com/profile/ProfileMenu.tsx
@@ -104,7 +104,7 @@ let ProfileMenu = ({
     if (profile.viewer?.muted) {
       try {
         await queueUnmute()
-        Toast.show(_(msg`Account unmuted`))
+        Toast.show(_(msg({message: 'Account unmuted', context: 'toast'})))
       } catch (e: any) {
         if (e?.name !== 'AbortError') {
           logger.error('Failed to unmute account', {message: e})
@@ -114,7 +114,7 @@ let ProfileMenu = ({
     } else {
       try {
         await queueMute()
-        Toast.show(_(msg`Account muted`))
+        Toast.show(_(msg({message: 'Account muted', context: 'toast'})))
       } catch (e: any) {
         if (e?.name !== 'AbortError') {
           logger.error('Failed to mute account', {message: e})
@@ -128,7 +128,7 @@ let ProfileMenu = ({
     if (profile.viewer?.blocking) {
       try {
         await queueUnblock()
-        Toast.show(_(msg`Account unblocked`))
+        Toast.show(_(msg({message: 'Account unblocked', context: 'toast'})))
       } catch (e: any) {
         if (e?.name !== 'AbortError') {
           logger.error('Failed to unblock account', {message: e})
@@ -138,7 +138,7 @@ let ProfileMenu = ({
     } else {
       try {
         await queueBlock()
-        Toast.show(_(msg`Account blocked`))
+        Toast.show(_(msg({message: 'Account blocked', context: 'toast'})))
       } catch (e: any) {
         if (e?.name !== 'AbortError') {
           logger.error('Failed to block account', {message: e})
@@ -151,7 +151,7 @@ let ProfileMenu = ({
   const onPressFollowAccount = React.useCallback(async () => {
     try {
       await queueFollow()
-      Toast.show(_(msg`Account followed`))
+      Toast.show(_(msg({message: 'Account followed', context: 'toast'})))
     } catch (e: any) {
       if (e?.name !== 'AbortError') {
         logger.error('Failed to follow account', {message: e})
@@ -163,7 +163,7 @@ let ProfileMenu = ({
   const onPressUnfollowAccount = React.useCallback(async () => {
     try {
       await queueUnfollow()
-      Toast.show(_(msg`Account unfollowed`))
+      Toast.show(_(msg({message: 'Account unfollowed', context: 'toast'})))
     } catch (e: any) {
       if (e?.name !== 'AbortError') {
         logger.error('Failed to unfollow account', {message: e})

--- a/src/view/com/util/forms/PostDropdownBtnMenuItems.tsx
+++ b/src/view/com/util/forms/PostDropdownBtnMenuItems.tsx
@@ -274,7 +274,7 @@ let PostDropdownMenuItems = ({
       item: postUri,
       feedContext: postFeedContext,
     })
-    Toast.show(_(msg`Feedback sent!`))
+    Toast.show(_(msg({message: 'Feedback sent!', context: 'toast'})))
   }, [feedFeedback, postUri, postFeedContext, _])
 
   const onPressShowLess = React.useCallback(() => {
@@ -283,7 +283,7 @@ let PostDropdownMenuItems = ({
       item: postUri,
       feedContext: postFeedContext,
     })
-    Toast.show(_(msg`Feedback sent!`))
+    Toast.show(_(msg({message: 'Feedback sent!', context: 'toast'})))
   }, [feedFeedback, postUri, postFeedContext, _])
 
   const onSelectChatToShareTo = React.useCallback(

--- a/src/view/com/util/forms/PostDropdownBtnMenuItems.tsx
+++ b/src/view/com/util/forms/PostDropdownBtnMenuItems.tsx
@@ -183,7 +183,7 @@ let PostDropdownMenuItems = ({
   const onDeletePost = React.useCallback(() => {
     deletePostMutate({uri: postUri}).then(
       () => {
-        Toast.show(_(msg`Post deleted`))
+        Toast.show(_(msg({message: 'Post deleted', context: 'toast'})))
 
         const route = getCurrentRoute(navigation.getState())
         if (route.name === 'PostThread') {
@@ -314,7 +314,9 @@ let PostDropdownMenuItems = ({
           : _(msg`Quote post was re-attached`),
       )
     } catch (e: any) {
-      Toast.show(_(msg`Updating quote attachment failed`))
+      Toast.show(
+        _(msg({message: 'Updating quote attachment failed', context: 'toast'})),
+      )
       logger.error(`Failed to ${action} quote`, {safeMessage: e.message})
     }
   }, [_, quoteEmbed, post, toggleQuoteDetachment])
@@ -341,10 +343,12 @@ let PostDropdownMenuItems = ({
       Toast.show(
         isHide
           ? _(msg`Reply was successfully hidden`)
-          : _(msg`Reply visibility updated`),
+          : _(msg({message: 'Reply visibility updated', context: 'toast'})),
       )
     } catch (e: any) {
-      Toast.show(_(msg`Updating reply visibility failed`))
+      Toast.show(
+        _(msg({message: 'Updating reply visibility failed', context: 'toast'})),
+      )
       logger.error(`Failed to ${action} reply`, {safeMessage: e.message})
     }
   }, [
@@ -368,7 +372,7 @@ let PostDropdownMenuItems = ({
   const onBlockAuthor = useCallback(async () => {
     try {
       await queueBlock()
-      Toast.show(_(msg`Account blocked`))
+      Toast.show(_(msg({message: 'Account blocked', context: 'toast'})))
     } catch (e: any) {
       if (e?.name !== 'AbortError') {
         logger.error('Failed to block account', {message: e})
@@ -381,7 +385,7 @@ let PostDropdownMenuItems = ({
     if (postAuthor.viewer?.muted) {
       try {
         await queueUnmute()
-        Toast.show(_(msg`Account unmuted`))
+        Toast.show(_(msg({message: 'Account unmuted', context: 'toast'})))
       } catch (e: any) {
         if (e?.name !== 'AbortError') {
           logger.error('Failed to unmute account', {message: e})
@@ -391,7 +395,7 @@ let PostDropdownMenuItems = ({
     } else {
       try {
         await queueMute()
-        Toast.show(_(msg`Account muted`))
+        Toast.show(_(msg({message: 'Account muted', context: 'toast'})))
       } catch (e: any) {
         if (e?.name !== 'AbortError') {
           logger.error('Failed to mute account', {message: e})

--- a/src/view/screens/ProfileList.tsx
+++ b/src/view/screens/ProfileList.tsx
@@ -392,7 +392,7 @@ function Header({
   const onSubscribeMute = useCallback(async () => {
     try {
       await listMuteMutation.mutateAsync({uri: list.uri, mute: true})
-      Toast.show(_(msg`List muted`))
+      Toast.show(_(msg({message: 'List muted', context: 'toast'})))
     } catch {
       Toast.show(
         _(
@@ -405,7 +405,7 @@ function Header({
   const onUnsubscribeMute = useCallback(async () => {
     try {
       await listMuteMutation.mutateAsync({uri: list.uri, mute: false})
-      Toast.show(_(msg`List unmuted`))
+      Toast.show(_(msg({message: 'List unmuted', context: 'toast'})))
     } catch {
       Toast.show(
         _(
@@ -418,7 +418,7 @@ function Header({
   const onSubscribeBlock = useCallback(async () => {
     try {
       await listBlockMutation.mutateAsync({uri: list.uri, block: true})
-      Toast.show(_(msg`List blocked`))
+      Toast.show(_(msg({message: 'List blocked', context: 'toast'})))
     } catch {
       Toast.show(
         _(
@@ -431,7 +431,7 @@ function Header({
   const onUnsubscribeBlock = useCallback(async () => {
     try {
       await listBlockMutation.mutateAsync({uri: list.uri, block: false})
-      Toast.show(_(msg`List unblocked`))
+      Toast.show(_(msg({message: 'List unblocked', context: 'toast'})))
     } catch {
       Toast.show(
         _(
@@ -455,7 +455,7 @@ function Header({
       await removeSavedFeed(savedFeedConfig)
     }
 
-    Toast.show(_(msg`List deleted`))
+    Toast.show(_(msg({message: 'List deleted', context: 'toast'})))
     if (navigation.canGoBack()) {
       navigation.goBack()
     } else {

--- a/src/view/screens/SavedFeeds.tsx
+++ b/src/view/screens/SavedFeeds.tsx
@@ -79,7 +79,7 @@ function SavedFeedsInner({
   const onSaveChanges = React.useCallback(async () => {
     try {
       await overwriteSavedFeeds(currentFeeds)
-      Toast.show(_(msg`Feeds updated!`))
+      Toast.show(_(msg({message: 'Feeds updated!', context: 'toast'})))
       navigation.navigate('Feeds')
     } catch (e) {
       Toast.show(_(msg`There was an issue contacting the server`), 'xmark')


### PR DESCRIPTION
Adds context info to the messages in toast which is written as "**verb**", or "**noun + verb**".

This is to differentiate between translations in Korean as sentence form for toasts and noun form for other parts.

Example:
| | English | Korean |
|-:|---------|--------|
| **Toast** | Message deleted | 메시지를 삭제했습니다 |
| **Other parts** | Message deleted | 메시지 삭제됨 |

It looks like #7817 needs to be resolved first before merge this.