### PR TITLE
Mark label for translation

### DIFF
--- a/src/components/dialogs/Embed.tsx
+++ b/src/components/dialogs/Embed.tsx
@@ -101,7 +101,7 @@ function EmbedDialogInner({
   }, [i18n, postUri, postCid, record, timestamp, postAuthor, colorMode])
 
   return (
-    <Dialog.Inner label="Embed post" style={[{maxWidth: 500}]}>
+    <Dialog.Inner label={_(msg`Embed post`)} style={[{maxWidth: 500}]}>
       <View style={[a.gap_lg]}>
         <View style={[a.gap_sm]}>
           <Text style={[a.text_2xl, a.font_heavy]}>


### PR DESCRIPTION
I noticed a label in the embed dialog isn't marked for translation, this PR does that.

https://github.com/bluesky-social/social-app/blob/a62fe855c3625a1798eae38cca08bc6c1686c863/src/components/dialogs/Embed.tsx#L104