### PR TITLE
[TOP SECRET] Enable 3 minute videos

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -168,6 +168,9 @@ export const MAX_LABELERS = 20
 export const VIDEO_SERVICE = 'https://video.bsky.app'
 export const VIDEO_SERVICE_DID = 'did:web:video.bsky.app'
 
+export const VIDEO_MAX_DURATION_MS = 3 * 60 * 1000 // 3 minutes in milliseconds
+export const VIDEO_MAX_SIZE = 1000 * 1000 * 100 // 100mb
+
 export const SUPPORTED_MIME_TYPES = [
   'video/mp4',
   'video/mpeg',

--- a/src/lib/media/video/compress.web.ts
+++ b/src/lib/media/video/compress.web.ts
@@ -1,9 +1,8 @@
 import {ImagePickerAsset} from 'expo-image-picker'
 
+import {VIDEO_MAX_SIZE} from '#/lib/constants'
 import {VideoTooLargeError} from '#/lib/media/video/errors'
 import {CompressedVideo} from './types'
-
-const MAX_VIDEO_SIZE = 1000 * 1000 * 50 // 50mb
 
 // doesn't actually compress, converts to ArrayBuffer
 export async function compressVideo(
@@ -17,7 +16,7 @@ export async function compressVideo(
   const blob = base64ToBlob(base64, mimeType)
   const uri = URL.createObjectURL(blob)
 
-  if (blob.size > MAX_VIDEO_SIZE) {
+  if (blob.size > VIDEO_MAX_SIZE) {
     throw new VideoTooLargeError()
   }
 

--- a/src/view/com/composer/videos/SelectVideoBtn.tsx
+++ b/src/view/com/composer/videos/SelectVideoBtn.tsx
@@ -4,7 +4,11 @@ import {ImagePickerAsset} from 'expo-image-picker'
 import {msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
-import {SUPPORTED_MIME_TYPES, SupportedMimeTypes} from '#/lib/constants'
+import {
+  SUPPORTED_MIME_TYPES,
+  SupportedMimeTypes,
+  VIDEO_MAX_DURATION_MS,
+} from '#/lib/constants'
 import {BSKY_SERVICE} from '#/lib/constants'
 import {useVideoLibraryPermission} from '#/lib/hooks/usePermissions'
 import {getHostnameFromUrl} from '#/lib/strings/url-helpers'
@@ -18,8 +22,6 @@ import {VerifyEmailDialog} from '#/components/dialogs/VerifyEmailDialog'
 import {VideoClip_Stroke2_Corner0_Rounded as VideoClipIcon} from '#/components/icons/VideoClip'
 import * as Prompt from '#/components/Prompt'
 import {pickVideo} from './pickVideo'
-
-const VIDEO_MAX_DURATION = 60 * 1000 // 60s in milliseconds
 
 type Props = {
   onSelectVideo: (video: ImagePickerAsset) => void
@@ -54,8 +56,8 @@ export function SelectVideoBtn({onSelectVideo, disabled, setError}: Props) {
         try {
           if (isWeb) {
             // asset.duration is null for gifs (see the TODO in pickVideo.web.ts)
-            if (asset.duration && asset.duration > VIDEO_MAX_DURATION) {
-              throw Error(_(msg`Videos must be less than 60 seconds long`))
+            if (asset.duration && asset.duration > VIDEO_MAX_DURATION_MS) {
+              throw Error(_(msg`Videos must be less than 3 minutes long`))
             }
             // compression step on native converts to mp4, so no need to check there
             if (
@@ -69,8 +71,8 @@ export function SelectVideoBtn({onSelectVideo, disabled, setError}: Props) {
             if (typeof asset.duration !== 'number') {
               throw Error('Asset is not a video')
             }
-            if (asset.duration > VIDEO_MAX_DURATION) {
-              throw Error(_(msg`Videos must be less than 60 seconds long`))
+            if (asset.duration > VIDEO_MAX_DURATION_MS) {
+              throw Error(_(msg`Videos must be less than 3 minutes long`))
             }
           }
           onSelectVideo(asset)

--- a/src/view/com/composer/videos/pickVideo.ts
+++ b/src/view/com/composer/videos/pickVideo.ts
@@ -1,18 +1,20 @@
 import {
   ImagePickerAsset,
   launchImageLibraryAsync,
-  MediaTypeOptions,
   UIImagePickerPreferredAssetRepresentationMode,
 } from 'expo-image-picker'
+
+import {VIDEO_MAX_DURATION_MS} from '#/lib/constants'
 
 export async function pickVideo() {
   return await launchImageLibraryAsync({
     exif: false,
-    mediaTypes: MediaTypeOptions.Videos,
+    mediaTypes: ['videos'],
     quality: 1,
     legacy: true,
     preferredAssetRepresentationMode:
       UIImagePickerPreferredAssetRepresentationMode.Current,
+    videoMaxDuration: VIDEO_MAX_DURATION_MS / 1000,
   })
 }
 


### PR DESCRIPTION
# NOTHING TO SEE HERE

Touches several areas:
- Moving constants to `#/lib/constants`
- Bumped to 3 minutes / 100mb
- Set a video max duration on the picker (unclear why we weren't doing that before? doesn't seem to cause issues)

## Test plan

- Upload 2 minute 59 second video from all platforms
- Test >3 minute videos
- Confirm no regressions on 60 second videos