### PR TITLE
Fix text not wrapping in social proof

### DIFF
--- a/src/alf/atoms.ts
+++ b/src/alf/atoms.ts
@@ -70,7 +70,7 @@ export const atoms = {
   }),
 
   /*
-   * Width
+   * Width & Height
    */
   w_full: {
     width: '100%',
@@ -81,6 +81,12 @@ export const atoms = {
   h_full_vh: web({
     height: '100vh',
   }),
+  max_w_full: {
+    maxWidth: '100%',
+  },
+  max_h_full: {
+    maxHeight: '100%',
+  },
 
   /**
    * Used for the outermost components on screens, to ensure that they can fill

--- a/src/components/KnownFollowers.tsx
+++ b/src/components/KnownFollowers.tsx
@@ -171,6 +171,7 @@ function KnownFollowersInner({
 
           <Text
             style={[
+              a.flex_shrink,
               textStyle,
               hovered && {
                 textDecorationLine: 'underline',

--- a/src/components/KnownFollowers.tsx
+++ b/src/components/KnownFollowers.tsx
@@ -127,7 +127,7 @@ function KnownFollowersInner({
       onPress={onLinkPress}
       to={makeProfileLink(profile, 'known-followers')}
       style={[
-        {maxWidth: '100%'},
+        a.max_w_full,
         a.flex_row,
         minimal ? a.gap_sm : a.gap_md,
         a.align_center,

--- a/src/components/KnownFollowers.tsx
+++ b/src/components/KnownFollowers.tsx
@@ -127,6 +127,7 @@ function KnownFollowersInner({
       onPress={onLinkPress}
       to={makeProfileLink(profile, 'known-followers')}
       style={[
+        {maxWidth: '100%'},
         a.flex_row,
         minimal ? a.gap_sm : a.gap_md,
         a.align_center,


### PR DESCRIPTION
Tested iOS, Android, Web

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/f28d1daa-eccd-418d-b21c-1ed212a79e40" width="200" alt="Screenshot 1" /></td>
    <td><img src="https://github.com/user-attachments/assets/bc37bc74-01e0-4ffc-a6b8-168f20f6ebfd" width="200" alt="Screenshot 2" /></td>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/33282d9d-4e6b-4d13-b866-85ec1128e6c8" width="200" alt="Screenshot 3" /></td>
    <td><img src="https://github.com/user-attachments/assets/5f6a7569-25de-46b0-bb4d-504bd65d082d" width="200" alt="Screenshot 4" /></td>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/e05f0209-3b5c-4f04-ae75-0e6900c78646" width="200" alt="Screenshot 5" /></td>
    <td><img src="https://github.com/user-attachments/assets/8359f3ce-0c35-47c7-b14a-78ae1a54cd56" width="200" alt="Screenshot 6" /></td>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/405f2fe2-ba93-45fd-906c-f7c862746e37" width="200" alt="Screenshot 7" /></td>
    <td><img src="https://github.com/user-attachments/assets/d0a1ffc0-a6e4-4d8a-b793-eebd12373c36" width="200" alt="Screenshot 8" /></td>
  </tr>
</table>

# Test plan

Look at social proof in DMs inbox and on profile. Edit the string to be really really long and confirm wrapping behaviour is working properly
Check different platforms