### PR TITLE
Catch thrown error for autoplay in Safari

### DIFF
--- a/src/view/com/util/post-embeds/VideoEmbedInner/web-controls/utils.tsx
+++ b/src/view/com/util/post-embeds/VideoEmbedInner/web-controls/utils.tsx
@@ -68,14 +68,22 @@ export function useVideoElement(ref: React.RefObject<HTMLVideoElement>) {
       setError(true)
     }
 
-    const handleCanPlay = () => {
+    const handleCanPlay = async () => {
       if (bufferingTimeout) clearTimeout(bufferingTimeout)
       setBuffering(false)
       setCanPlay(true)
 
       if (!ref.current) return
       if (playWhenReadyRef.current) {
-        ref.current.play()
+        try {
+          await ref.current.play()
+        } catch (e: any) {
+          if (
+            !e.message?.includes(`The request is not allowed by the user agent`)
+          ) {
+            throw e
+          }
+        }
         playWhenReadyRef.current = false
       }
     }


### PR DESCRIPTION
Handling failed autoplay in Safari. If the error is anything other than what we're aware of, let it throw.