### PR TITLE
Update `VideoTooLargeError` strings

### DIFF
--- a/src/lib/media/video/errors.ts
+++ b/src/lib/media/video/errors.ts
@@ -1,6 +1,6 @@
 export class VideoTooLargeError extends Error {
   constructor() {
-    super('Videos cannot be larger than 50mb')
+    super('Videos cannot be larger than 100MB')
     this.name = 'VideoTooLargeError'
   }
 }

--- a/src/lib/media/video/errors.ts
+++ b/src/lib/media/video/errors.ts
@@ -1,6 +1,6 @@
 export class VideoTooLargeError extends Error {
   constructor() {
-    super('Videos cannot be larger than 100MB')
+    super('Videos cannot be larger than 100 MB')
     this.name = 'VideoTooLargeError'
   }
 }

--- a/src/view/com/composer/state/video.ts
+++ b/src/view/com/composer/state/video.ts
@@ -392,7 +392,7 @@ function getCompressErrorMessage(e: unknown, _: I18n['_']): string | null {
     return null
   }
   if (e instanceof VideoTooLargeError) {
-    return _(msg`The selected video is larger than 100MB.`)
+    return _(msg`The selected video is larger than 100 MB.`)
   }
   logger.error('Error compressing video', {safeMessage: e})
   return _(msg`An error occurred while compressing the video.`)

--- a/src/view/com/composer/state/video.ts
+++ b/src/view/com/composer/state/video.ts
@@ -392,7 +392,7 @@ function getCompressErrorMessage(e: unknown, _: I18n['_']): string | null {
     return null
   }
   if (e instanceof VideoTooLargeError) {
-    return _(msg`The selected video is larger than 100 MB.`)
+    return _(msg`The selected video is larger than 100 MB.`)
   }
   logger.error('Error compressing video', {safeMessage: e})
   return _(msg`An error occurred while compressing the video.`)

--- a/src/view/com/composer/state/video.ts
+++ b/src/view/com/composer/state/video.ts
@@ -392,7 +392,7 @@ function getCompressErrorMessage(e: unknown, _: I18n['_']): string | null {
     return null
   }
   if (e instanceof VideoTooLargeError) {
-    return _(msg`The selected video is larger than 50MB.`)
+    return _(msg`The selected video is larger than 100MB.`)
   }
   logger.error('Error compressing video', {safeMessage: e})
   return _(msg`An error occurred while compressing the video.`)


### PR DESCRIPTION
Following #7916, I think these two strings about the maximum size for videos probably need updating too?