### PR TITLE
Fix: Fullscreen Youtube Bug

### DIFF
--- a/bskyweb/static/iframe/youtube.html
+++ b/bskyweb/static/iframe/youtube.html
@@ -1,5 +1,9 @@
 <!DOCTYPE html><meta name="viewport" content="width=device-width, initial-scale=1" />
 <style>
+:-webkit-full-screen-ancestor > :not(:-webkit-full-screen-ancestor):not(:-webkit-full-screen) {
+        display: initial !important;
+        transform: none !important;
+    }
     body {
         margin: 0;
     }

--- a/src/view/com/util/post-embeds/ExternalPlayerEmbed.tsx
+++ b/src/view/com/util/post-embeds/ExternalPlayerEmbed.tsx
@@ -169,6 +169,8 @@ export function ExternalPlayer({
 
     if (userActivated) return
 
+    // Interval for scrolling works in most cases, However, for twitch embeds, if we navigate away from the screen the webview will
+    // continue playing. We need to watch for the blur event
     const unsubscribe = navigation.addListener('blur', () => {
       setPlayerActive(false)
       setUserActivated(false)

--- a/src/view/com/util/post-embeds/ExternalPlayerEmbed.tsx
+++ b/src/view/com/util/post-embeds/ExternalPlayerEmbed.tsx
@@ -127,8 +127,6 @@ export function ExternalPlayer({
 
   const [isPlayerActive, setPlayerActive] = React.useState(false)
   const [isLoading, setIsLoading] = React.useState(true)
-
-  // Add a state to track if user has manually activated the player
   const [userActivated, setUserActivated] = React.useState(false)
 
   const aspect = React.useMemo(() => {
@@ -141,7 +139,6 @@ export function ExternalPlayer({
 
   const viewRef = useAnimatedRef()
   const frameCallback = useFrameCallback(() => {
-    // If user has manually activated the player, don't disable it based on visibility
     if (userActivated) return
 
     const measurement = measure(viewRef)
@@ -167,17 +164,12 @@ export function ExternalPlayer({
     }
   }, false) // False here disables autostarting the callback
 
-  // Watch for leaving the viewport due to scrolling, but only if not user activated
   React.useEffect(() => {
-    // Don't do anything if player isn't active
     if (!isPlayerActive) return
 
-    // Skip visibility checking entirely if user has manually activated
     if (userActivated) return
 
-    // Only watch for navigation changes
     const unsubscribe = navigation.addListener('blur', () => {
-      // Always stop playing when navigating away
       setPlayerActive(false)
       setUserActivated(false)
     })
@@ -205,7 +197,6 @@ export function ExternalPlayer({
         return
       }
 
-      // Mark that user has explicitly activated this player
       setUserActivated(true)
       setPlayerActive(true)
     },


### PR DESCRIPTION
Hey there again! This fixes the 1) bug that prevents fullscreen mode with embedded youtube videos by disabling viewport checking when full screen mode is active and 2) the reset to the top of the feed that occurs after leaving fullscreen in Chrome browsers.

Issue Ref: #7850 
