### PR TITLE
Fix mention autocomplete

### DIFF
--- a/src/view/com/composer/text-input/TextInput.tsx
+++ b/src/view/com/composer/text-input/TextInput.tsx
@@ -253,7 +253,7 @@ export const TextInput = forwardRef(function TextInputImpl(
         style={[
           inputTextStyle,
           a.w_full,
-          a.h_full,
+          !autocompletePrefix && a.h_full,
           {
             textAlignVertical: 'top',
             minHeight: 60,

--- a/src/view/com/composer/text-input/mobile/Autocomplete.tsx
+++ b/src/view/com/composer/text-input/mobile/Autocomplete.tsx
@@ -49,7 +49,7 @@ export function Autocomplete({
                 a.px_sm,
                 a.py_md,
               ]}
-              key={item.handle}>
+              key={item.did}>
               <PressableScale
                 testID="autocompleteButton"
                 style={[


### PR DESCRIPTION
# Before

https://github.com/user-attachments/assets/d2838f6c-342d-43d4-bb62-7e0f2fb99c61

# After

https://github.com/user-attachments/assets/74c13342-3187-43c1-a7a1-f109c6a7dc40

# Test plan

Confirm these are working on iOS and Android:
1. Autocomplete list is visible, with and without embeds/images/quotes
2. Tapping anywhere on the sheet focuses the input (open gif menu to blur the input)