### PR TITLE
Add checks for invalid syntax post-i18n builds

### DIFF
--- a/.github/workflows/build-submit-android.yml
+++ b/.github/workflows/build-submit-android.yml
@@ -56,7 +56,10 @@ jobs:
         run: yarn install
 
       - name: 🔤 Compile translations
-        run: yarn intl:build
+        run: yarn intl:build 2>&1 | tee i18n.log
+
+      - name: Check for i18n compilation errors
+        run: if grep -q "invalid syntax" "i18n.log"; then echo "\n\nFound compilation errors!\n\n" && exit 1; else echo "\n\nNo compilation errors!\n\n"; fi
 
       - name: ✏️ Write environment variables
         run: |

--- a/.github/workflows/build-submit-ios.yml
+++ b/.github/workflows/build-submit-ios.yml
@@ -69,7 +69,10 @@ jobs:
           key: ${{ runner.os }}-pods-${{ hashFiles('yarn.lock') }}
 
       - name: 🔤 Compile translations
-        run: yarn intl:build
+        run: yarn intl:build 2>&1 | tee i18n.log
+
+      - name: Check for i18n compilation errors
+        run: if grep -q "invalid syntax" "i18n.log"; then echo "\n\nFound compilation errors!\n\n" && exit 1; else echo "\n\nNo compilation errors!\n\n"; fi
 
       - name: ✏️ Write environment variables
         run: |

--- a/.github/workflows/bundle-deploy-eas-update.yml
+++ b/.github/workflows/bundle-deploy-eas-update.yml
@@ -75,8 +75,11 @@ jobs:
       - name: Prettier check
         run: yarn prettier --check .
 
-      - name: Check & compile i18n
-        run: yarn intl:build
+      - name: 🔤 Compile translations
+        run: yarn intl:build 2>&1 | tee i18n.log
+
+      - name: Check for i18n compilation errors
+        run: if grep -q "invalid syntax" "i18n.log"; then echo "\n\nFound compilation errors!\n\n" && exit 1; else echo "\n\nNo compilation errors!\n\n"; fi
 
       - name: Type check
         run: yarn typecheck

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,8 @@ RUN \. "$NVM_DIR/nvm.sh" && \
   echo "EXPO_PUBLIC_BUNDLE_DATE=$(date -u +"%y%m%d%H")" >> .env && \
   npm install --global yarn && \
   yarn && \
-  yarn intl:build && \
+  yarn intl:build 2>&1 | tee i18n.log && \
+  if grep -q "invalid syntax" "i18n.log"; then echo "\n\nFound compilation errors!\n\n" && exit 1; else echo "\n\nNo compile errors!\n\n"; fi && \
   EXPO_PUBLIC_BUNDLE_IDENTIFIER=$EXPO_PUBLIC_BUNDLE_IDENTIFIER EXPO_PUBLIC_BUNDLE_DATE=$() yarn build-web
 
 # DEBUG


### PR DESCRIPTION
Lingui [does not support failing](https://lingui.dev/ref/cli#extract) if there is invalid syntax in the translation files ([callsite here](https://github.com/lingui/js-lingui/blob/main/packages/cli/src/api/compile.ts#L141-L143)). In lieu of multiple patches on the dependencies themselves, I've opted here to output i18n builds to a log file and grepping for known failures. If failures are detected, it'll `exit 1`.

Example failure: https://github.com/bluesky-social/social-app/actions/runs/13726616350/job/38394470053