### PR TITLE
Fix lists tab appearing when user has a starterpack but no lists

### DIFF
--- a/src/view/screens/Profile.tsx
+++ b/src/view/screens/Profile.tsx
@@ -212,9 +212,9 @@ function ProfileScreenLoaded({
   const showFeedsTab = isMe || feedGenCount > 0
   const starterPackCount = profile.associated?.starterPacks || 0
   const showStarterPacksTab = isMe || starterPackCount > 0
-  const listCount = profile.associated?.lists || 0
   // subtract starterpack count from list count, since starterpacks are a type of list
-  const showListsTab = hasSession && (isMe || listCount - starterPackCount > 0)
+  const listCount = (profile.associated?.lists || 0) - starterPackCount
+  const showListsTab = hasSession && (isMe || listCount > 0)
 
   const sectionTitles = [
     showFiltersTab ? _(msg`Labels`) : undefined,

--- a/src/view/screens/Profile.tsx
+++ b/src/view/screens/Profile.tsx
@@ -208,11 +208,13 @@ function ProfileScreenLoaded({
   const showMediaTab = !hasLabeler
   const showVideosTab = !hasLabeler
   const showLikesTab = isMe
-  const showFeedsTab = isMe || (profile.associated?.feedgens || 0) > 0
-  const showStarterPacksTab =
-    isMe || (profile.associated?.starterPacks || 0) > 0
-  const showListsTab =
-    hasSession && (isMe || (profile.associated?.lists || 0) > 0)
+  const feedGenCount = profile.associated?.feedgens || 0
+  const showFeedsTab = isMe || feedGenCount > 0
+  const starterPackCount = profile.associated?.starterPacks || 0
+  const showStarterPacksTab = isMe || starterPackCount > 0
+  const listCount = profile.associated?.lists || 0
+  // subtract starterpack count from list count, since starterpacks are a type of list
+  const showListsTab = hasSession && (isMe || listCount - starterPackCount > 0)
 
   const sectionTitles = [
     showFiltersTab ? _(msg`Labels`) : undefined,


### PR DESCRIPTION
Rose for example has a starter pack but no lists, yet the tab appears in her profile:

https://bsky.app/profile/rose.bsky.team

This is because starter packs include a type of list inside of them, but since they don't show in the lists tab the tab appears but is empty.

This can be fixed by subtracting the number of starter packs from the lists agg count.

<table>
  <tr>
    <th>Before</th>
    <th>After</th>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/1cbaa422-ab39-448c-a3aa-12685acefb66" width="200" alt="Before Screenshot" /></td>
    <td><img src="https://github.com/user-attachments/assets/f9ba9d6b-f78e-421a-b021-c413d5722bf3" width="200" alt="After Screenshot" /></td>
  </tr>
</table>

# Test plan

Confirm Rose's profile has the correct tabs

Make a new account, and observe that the `associated` object increases in the way I described (i.e. creating a SP adds +1 to both `lists` and `starterPacks`, and curate/modlist only adds +1 to `lists`)