### PR TITLE
Fix DMs input not being able to type newlines

### DIFF
--- a/src/screens/Messages/components/MessageInput.tsx
+++ b/src/screens/Messages/components/MessageInput.tsx
@@ -177,8 +177,8 @@ export function MessageInput({
             {paddingBottom: isIOS ? 5 : 0},
             animatedStyle,
           ]}
-          keyboardAppearance={t.name === 'light' ? 'light' : 'dark'}
-          submitBehavior="submit"
+          keyboardAppearance={t.scheme}
+          submitBehavior="newline"
           onFocus={() => setIsFocused(true)}
           onBlur={() => setIsFocused(false)}
           ref={inputRef}


### PR DESCRIPTION
Did not read the docs closely enough. Changing `blurOnSubmit={false}` to the new `submitBehavior` prop for multiline text inputs needs to go to `"newlines"`, not `"submit"`