### PR TITLE
Fix color theme for embed

### DIFF
--- a/bskyembed/snippet/embed.ts
+++ b/bskyembed/snippet/embed.ts
@@ -68,8 +68,8 @@ function scan(node = document) {
     if (ref_url.startsWith('http')) {
       searchParams.set('ref_url', encodeURIComponent(ref_url))
     }
-    if (embed.dataset.blueskyColorMode) {
-      searchParams.set('colorMode', embed.dataset.blueskyColorMode)
+    if (embed.dataset.blueskyEmbedColorMode) {
+      searchParams.set('colorMode', embed.dataset.blueskyEmbedColorMode)
     }
 
     const iframe = document.createElement('iframe')

--- a/bskyembed/snippet/embed.ts
+++ b/bskyembed/snippet/embed.ts
@@ -68,7 +68,9 @@ function scan(node = document) {
     if (ref_url.startsWith('http')) {
       searchParams.set('ref_url', encodeURIComponent(ref_url))
     }
-    searchParams.set('colorMode', embed.dataset.blueskyColorMode || 'system')
+    if (embed.dataset.blueskyColorMode) {
+      searchParams.set('colorMode', embed.dataset.blueskyColorMode)
+    }
 
     const iframe = document.createElement('iframe')
     iframe.setAttribute('data-bluesky-id', id)


### PR DESCRIPTION
Two problems:
1. Color theme was defaulting to system - it should just not add the param if missing
2. String did not match what is passed to embeds

# Test plan

Spot check confirm that `data-bluesky-embed-color-mode` is the right string 