### PR TITLE
Fix embed iframe transparency by unspecifying color-scheme

### DIFF
--- a/bskyembed/src/index.css
+++ b/bskyembed/src/index.css
@@ -6,7 +6,7 @@
   word-break: break-word;
 }
 
-:root {
+#app {
   color-scheme: light dark;
 }
 


### PR DESCRIPTION
This was a rabbit hole...

Iframes were rendering with opaque backgrounds, causing them to look square:

<img width="627" alt="Screenshot 2025-03-11 at 21 13 57" src="https://github.com/user-attachments/assets/a638518a-8cd4-4907-be83-4a5e84a6f303" />

Thanks to [this blog post](https://fvsch.com/transparent-iframes), I learned that if a parent page and a child page have conflicting `color-scheme`s, the browser will give the iframe an appropriate background. We don't want this behaviour, so we need to remove the `color-scheme` from `:root` and only apply it the containing element of the app.

After:

<img width="639" alt="Screenshot 2025-03-11 at 21 15 42" src="https://github.com/user-attachments/assets/2047c3a9-45a1-415a-b44d-171a9950bc16" />

# Test plan

Paste an embed into a codepen, with your OS in dark mode. Observe opaque background. Now, edit `:root` of the iframe content with your dev tools to remove color-scheme and observe the corners fixing themselves