### PR TITLE
Fix typo in `ListHiddenScreen.tsx`

### DIFF
--- a/src/screens/List/ListHiddenScreen.tsx
+++ b/src/screens/List/ListHiddenScreen.tsx
@@ -171,7 +171,7 @@ export function ListHiddenScreen({
               onPress={onRemoveList}
               disabled={isProcessing}>
               <ButtonText>
-                <Trans>Removed from saved feeds</Trans>
+                <Trans>Remove from saved feeds</Trans>
               </ButtonText>
               {isProcessing ? (
                 <ButtonIcon icon={Loader} position="right" />


### PR DESCRIPTION
This PR fixes a typo in the `list hidden` screen added in #4958. The button text displays `Removed from saved feeds`, however it's an action that the user can take, not a toast confirming an action has been taken. So the button text should say `Remove from saved feed`, like the accessibility label correctly says.

![IMG_3633](https://github.com/user-attachments/assets/8636e9f9-6c15-439c-8861-0ca7114c5088)

https://github.com/bluesky-social/social-app/blob/d16c80d928a4e2955e3cf3e2f9efa9b18b6e0140/src/screens/List/ListHiddenScreen.tsx#L166-L174