### PR TITLE
Extract center column offset, reduce by 20px

### DIFF
--- a/src/alf/breakpoints.ts
+++ b/src/alf/breakpoints.ts
@@ -27,6 +27,8 @@ export function useBreakpoints(): Record<Breakpoint, boolean> & {
   }, [gtPhone, gtMobile, gtTablet])
 }
 
+export const CENTER_COLUMN_OFFSET = -130
+
 /**
  * Fine-tuned breakpoints for the shell layout
  */

--- a/src/components/Layout/Header/index.tsx
+++ b/src/components/Layout/Header/index.tsx
@@ -10,6 +10,7 @@ import {isIOS} from '#/platform/detection'
 import {useSetDrawerOpen} from '#/state/shell'
 import {
   atoms as a,
+  CENTER_COLUMN_OFFSET,
   platform,
   TextStyleProp,
   useBreakpoints,
@@ -65,7 +66,7 @@ export function Outer({
         gtMobile && [a.mx_auto, {maxWidth: 600}],
         !isWithinOffsetView && {
           transform: [
-            {translateX: centerColumnOffset ? -150 : 0},
+            {translateX: centerColumnOffset ? CENTER_COLUMN_OFFSET : 0},
             {translateX: web(SCROLLBAR_OFFSET) ?? 0},
           ],
         },

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -15,6 +15,7 @@ import {isWeb} from '#/platform/detection'
 import {useShellLayout} from '#/state/shell/shell-layout'
 import {
   atoms as a,
+  CENTER_COLUMN_OFFSET,
   useBreakpoints,
   useLayoutBreakpoints,
   useTheme,
@@ -173,7 +174,7 @@ export const Center = React.memo(function LayoutContent({
                 centerColumnOffset &&
                 !ignoreTabletLayoutOffset &&
                 !isWithinDialog
-                  ? -150
+                  ? CENTER_COLUMN_OFFSET
                   : 0,
             },
             {translateX: web(SCROLLBAR_OFFSET) ?? 0},
@@ -209,7 +210,7 @@ const WebCenterBorders = React.memo(function LayoutContent() {
           left: '50%',
           transform: [
             {translateX: '-50%'},
-            {translateX: centerColumnOffset ? -150 : 0},
+            {translateX: centerColumnOffset ? CENTER_COLUMN_OFFSET : 0},
             ...a.scrollbar_offset.transform,
           ],
         }),

--- a/src/view/com/util/Views.web.tsx
+++ b/src/view/com/util/Views.web.tsx
@@ -26,7 +26,7 @@ import Animated from 'react-native-reanimated'
 import {usePalette} from '#/lib/hooks/usePalette'
 import {useWebMediaQueries} from '#/lib/hooks/useWebMediaQueries'
 import {addStyle} from '#/lib/styles'
-import {useLayoutBreakpoints} from '#/alf'
+import {CENTER_COLUMN_OFFSET, useLayoutBreakpoints} from '#/alf'
 import {useDialogContext} from '#/components/Dialog'
 
 interface AddedProps {
@@ -179,7 +179,7 @@ const styles = StyleSheet.create({
     marginRight: 'auto',
   },
   containerOffset: {
-    transform: [{translateX: -150}],
+    transform: [{translateX: CENTER_COLUMN_OFFSET}],
   },
   containerScroll: {
     width: '100%',

--- a/src/view/shell/desktop/LeftNav.tsx
+++ b/src/view/shell/desktop/LeftNav.tsx
@@ -32,7 +32,13 @@ import {LoadingPlaceholder} from '#/view/com/util/LoadingPlaceholder'
 import {PressableWithHover} from '#/view/com/util/PressableWithHover'
 import {UserAvatar} from '#/view/com/util/UserAvatar'
 import {NavSignupCard} from '#/view/shell/NavSignupCard'
-import {atoms as a, tokens, useLayoutBreakpoints, useTheme} from '#/alf'
+import {
+  atoms as a,
+  CENTER_COLUMN_OFFSET,
+  tokens,
+  useLayoutBreakpoints,
+  useTheme,
+} from '#/alf'
 import {Button, ButtonIcon, ButtonText} from '#/components/Button'
 import {DialogControlProps} from '#/components/Dialog'
 import {ArrowBoxLeft_Stroke2_Corner0_Rounded as LeaveIcon} from '#/components/icons/ArrowBoxLeft'
@@ -559,7 +565,10 @@ export function DesktopLeftNav() {
         leftNavMinimal && styles.leftNavMinimal,
         {
           transform: [
-            {translateX: centerColumnOffset ? -450 : -300},
+            {
+              translateX:
+                -300 + (centerColumnOffset ? CENTER_COLUMN_OFFSET : 0),
+            },
             {translateX: '-100%'},
             ...a.scrollbar_offset.transform,
           ],

--- a/src/view/shell/desktop/RightNav.tsx
+++ b/src/view/shell/desktop/RightNav.tsx
@@ -12,6 +12,7 @@ import {DesktopSearch} from '#/view/shell/desktop/Search'
 import {SidebarTrendingTopics} from '#/view/shell/desktop/SidebarTrendingTopics'
 import {
   atoms as a,
+  CENTER_COLUMN_OFFSET,
   useGutters,
   useLayoutBreakpoints,
   useTheme,
@@ -66,7 +67,7 @@ export function DesktopRightNav({routeName}: {routeName: string}) {
           position: 'fixed',
           left: '50%',
           transform: [
-            {translateX: centerColumnOffset ? 150 : 300},
+            {translateX: 300 + (centerColumnOffset ? CENTER_COLUMN_OFFSET : 0)},
             ...a.scrollbar_offset.transform,
           ],
           width: 300 + gutters.paddingLeft,


### PR DESCRIPTION
After inspecting closely, I think that the tablet mode offset is a little too far to the left. I extracted the offset to a constant, then adjusted it slightly

# Test plan

See if on tablet breakpoint the whitespace to the sides is more even