### PR TITLE
Tweak copy to remove remaining uses of `sign up`

### DIFF
--- a/src/screens/Deactivated.tsx
+++ b/src/screens/Deactivated.tsx
@@ -200,13 +200,13 @@ export function Deactivated() {
                 <Trans>Or, continue with another account.</Trans>
               </Text>
               <Button
-                label={_(msg`Sign in or sign up`)}
+                label={_(msg`Sign in or create account`)}
                 size="large"
                 variant="solid"
                 color="secondary"
                 onPress={() => setShowLoggedOut(true)}>
                 <ButtonText>
-                  <Trans>Sign in or sign up</Trans>
+                  <Trans>Sign in or create account</Trans>
                 </ButtonText>
               </Button>
             </>

--- a/src/screens/Login/LoginForm.tsx
+++ b/src/screens/Login/LoginForm.tsx
@@ -215,7 +215,7 @@ export const LoginForm = ({
               blurOnSubmit={false} // prevents flickering due to onSubmitEditing going to next field
               editable={!isProcessing}
               accessibilityHint={_(
-                msg`Input the username or email address you used at signup`,
+                msg`Enter the username or email address you used when you created your account`,
               )}
             />
           </TextField.Root>

--- a/src/screens/Signup/StepInfo/Policies.tsx
+++ b/src/screens/Signup/StepInfo/Policies.tsx
@@ -103,7 +103,7 @@ export const Policies = ({
 
       {under13 ? (
         <Text style={[a.font_bold, a.leading_snug, t.atoms.text_contrast_high]}>
-          <Trans>You must be 13 years of age or older to sign up.</Trans>
+          <Trans>You must be 13 years of age or older to create an account.</Trans>
         </Text>
       ) : needsGuardian ? (
         <Text style={[a.font_bold, a.leading_snug, t.atoms.text_contrast_high]}>

--- a/src/screens/Signup/StepInfo/Policies.tsx
+++ b/src/screens/Signup/StepInfo/Policies.tsx
@@ -103,7 +103,9 @@ export const Policies = ({
 
       {under13 ? (
         <Text style={[a.font_bold, a.leading_snug, t.atoms.text_contrast_high]}>
-          <Trans>You must be 13 years of age or older to create an account.</Trans>
+          <Trans>
+            You must be 13 years of age or older to create an account.
+          </Trans>
         </Text>
       ) : needsGuardian ? (
         <Text style={[a.font_bold, a.leading_snug, t.atoms.text_contrast_high]}>

--- a/src/screens/StarterPack/StarterPackLandingScreen.tsx
+++ b/src/screens/StarterPack/StarterPackLandingScreen.tsx
@@ -300,14 +300,14 @@ function LandingScreenLoaded({
             ) : null}
           </View>
           <Button
-            label={_(msg`Signup without a starter pack`)}
+            label={_(msg`Create account without a starter pack`)}
             variant="solid"
             color="secondary"
             size="large"
             style={[a.py_lg]}
             onPress={onJoinWithoutPress}>
             <ButtonText>
-              <Trans>Signup without a starter pack</Trans>
+              <Trans>Create account without a starter pack</Trans>
             </ButtonText>
           </Button>
         </View>

--- a/src/view/shell/createNativeStackNavigatorWithAuth.tsx
+++ b/src/view/shell/createNativeStackNavigatorWithAuth.tsx
@@ -137,7 +137,7 @@ function NativeStackNavigator({
   }
 
   // Show the bottom bar if we have a session only on mobile web. If we don't have a session, we want to show it
-  // on both tablet and mobile web so that we see the sign up CTA.
+  // on both tablet and mobile web so that we see the create account CTA.
   const showBottomBar = hasSession ? isMobile : isTabletOrMobile
 
   return (


### PR DESCRIPTION
This is a follow-up to #6931 which changed `Sign up` to `Create account`.

I noticed a few lower-profile uses of `sign up` and `signup`, so this PR tweaks the visible copy (and one `accessibilityHint` & one comment) in a few places.