### PR TITLE
Fix missing RecordWithMedia media embed preview in notifications view

### DIFF
--- a/src/components/MediaPreview.tsx
+++ b/src/components/MediaPreview.tsx
@@ -54,6 +54,14 @@ export function Embed({
         <VideoItem thumbnail={e.view.thumbnail} alt={e.view.alt} />
       </Outer>
     )
+  } else if (
+    e.type === 'post_with_media' &&
+    // ignore further "nested" RecordWithMedia
+    e.media.type !== 'post_with_media' &&
+    // ignore any unknowns
+    e.media.view !== null
+  ) {
+    return <Embed embed={e.media.view} style={style} />
   }
 
   return null

--- a/src/types/bsky/post.ts
+++ b/src/types/bsky/post.ts
@@ -1,4 +1,5 @@
 import {
+  $Typed,
   AppBskyEmbedExternal,
   AppBskyEmbedImages,
   AppBskyEmbedRecord,
@@ -12,47 +13,47 @@ import {
 export type Embed =
   | {
       type: 'post'
-      view: AppBskyEmbedRecord.ViewRecord
+      view: $Typed<AppBskyEmbedRecord.ViewRecord>
     }
   | {
       type: 'post_not_found'
-      view: AppBskyEmbedRecord.ViewNotFound
+      view: $Typed<AppBskyEmbedRecord.ViewNotFound>
     }
   | {
       type: 'post_blocked'
-      view: AppBskyEmbedRecord.ViewBlocked
+      view: $Typed<AppBskyEmbedRecord.ViewBlocked>
     }
   | {
       type: 'post_detached'
-      view: AppBskyEmbedRecord.ViewDetached
+      view: $Typed<AppBskyEmbedRecord.ViewDetached>
     }
   | {
       type: 'feed'
-      view: AppBskyFeedDefs.GeneratorView
+      view: $Typed<AppBskyFeedDefs.GeneratorView>
     }
   | {
       type: 'list'
-      view: AppBskyGraphDefs.ListView
+      view: $Typed<AppBskyGraphDefs.ListView>
     }
   | {
       type: 'labeler'
-      view: AppBskyLabelerDefs.LabelerView
+      view: $Typed<AppBskyLabelerDefs.LabelerView>
     }
   | {
       type: 'starter_pack'
-      view: AppBskyGraphDefs.StarterPackViewBasic
+      view: $Typed<AppBskyGraphDefs.StarterPackViewBasic>
     }
   | {
       type: 'images'
-      view: AppBskyEmbedImages.View
+      view: $Typed<AppBskyEmbedImages.View>
     }
   | {
       type: 'link'
-      view: AppBskyEmbedExternal.View
+      view: $Typed<AppBskyEmbedExternal.View>
     }
   | {
       type: 'video'
-      view: AppBskyEmbedVideo.View
+      view: $Typed<AppBskyEmbedVideo.View>
     }
   | {
       type: 'post_with_media'


### PR DESCRIPTION
I missed [this ternary](https://github.com/bluesky-social/social-app/pull/7344/files#diff-fb34c2252d82c53bb675900d3b6b169e3eabd30e5cd37e0ed2c0303d2631283aL33) when I touched this last month. This PR fixes that by doing one recurse of the rendering here.

To do so, I had to adjust the types output of `parseEmbed`. The inputs to `parseEmbed` and `parseEmbedRecordView` both require the `$Typed` generic, and therefore their outputs should match and specify the `$Typed` variant of these views. This change has no effect on runtime code, it's just more type-correct.