### PR TITLE
Add plural formatting for alt text truncated string

### DIFF
--- a/src/view/com/composer/GifAltText.tsx
+++ b/src/view/com/composer/GifAltText.tsx
@@ -1,6 +1,6 @@
 import {useState} from 'react'
 import {TouchableOpacity, View} from 'react-native'
-import {msg, Trans} from '@lingui/macro'
+import {msg, Plural, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
 import {HITSLOP_10, MAX_ALT_TEXT} from '#/lib/constants'
@@ -177,8 +177,11 @@ function AltTextInner({
                     t.atoms.text_contrast_medium,
                   ]}>
                   <Trans>
-                    Alt text will be truncated. Limit:{' '}
-                    {i18n.number(MAX_ALT_TEXT)} characters.
+                    Alt text will be truncated.{' '}
+                    <Plural
+                      value={MAX_ALT_TEXT}
+                      other={`Limit: ${i18n.number(MAX_ALT_TEXT)} characters.`}
+                    />
                   </Trans>
                 </Text>
               </View>

--- a/src/view/com/composer/photos/ImageAltTextDialog.tsx
+++ b/src/view/com/composer/photos/ImageAltTextDialog.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import {ImageStyle, useWindowDimensions, View} from 'react-native'
 import {Image} from 'expo-image'
-import {msg, Trans} from '@lingui/macro'
+import {msg, Plural, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
 import {MAX_ALT_TEXT} from '#/lib/constants'

--- a/src/view/com/composer/photos/ImageAltTextDialog.tsx
+++ b/src/view/com/composer/photos/ImageAltTextDialog.tsx
@@ -137,8 +137,11 @@ const ImageAltTextInner = ({
                   t.atoms.text_contrast_medium,
                 ]}>
                 <Trans>
-                  Alt text will be truncated. Limit: {i18n.number(MAX_ALT_TEXT)}{' '}
-                  characters.
+                  Alt text will be truncated.{' '}
+                    <Plural
+                      value={MAX_ALT_TEXT}
+                      other={`Limit: ${i18n.number(MAX_ALT_TEXT)} characters.`}
+                    />
                 </Trans>
               </Text>
             </View>

--- a/src/view/com/composer/photos/ImageAltTextDialog.tsx
+++ b/src/view/com/composer/photos/ImageAltTextDialog.tsx
@@ -138,10 +138,10 @@ const ImageAltTextInner = ({
                 ]}>
                 <Trans>
                   Alt text will be truncated.{' '}
-                    <Plural
-                      value={MAX_ALT_TEXT}
-                      other={`Limit: ${i18n.number(MAX_ALT_TEXT)} characters.`}
-                    />
+                  <Plural
+                    value={MAX_ALT_TEXT}
+                    other={`Limit: ${i18n.number(MAX_ALT_TEXT)} characters.`}
+                  />
                 </Trans>
               </Text>
             </View>


### PR DESCRIPTION
Following [feedback raised on Crowdin](https://bluesky.crowdin.com/editor/1/11/en-gd/7?view=comfortable#287), this PR adds plural formatting for part of the string shown when alt text will be truncated.

As in #7984, only the `other` prop is included as that is the only plural form relevant in the source locale, English. That will also be the only relevant plural form for translations in most other locales. However, adding plural formatting here means we can ensure that the string can be correctly localized by translators in all supported locales.

> [!NOTE]
> **I put this PR together partly using ChatGPT and it passes CI but I haven't tested it.**

cc: @akerbeltz