### PR TITLE
Add plural formatting, translate and tweak some accessibility strings in composer

### DIFF
--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -481,8 +481,8 @@ export const ComposePost = ({
       thread.posts.length > 1
         ? _(msg`Your posts have been published`)
         : replyTo
-          ? _(msg`Your reply has been published`)
-          : _(msg`Your post has been published`),
+        ? _(msg`Your reply has been published`)
+        : _(msg`Your post has been published`),
     )
   }, [
     _,

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -953,20 +953,36 @@ function ComposerTopBar({
             testID="composerPublishBtn"
             label={
               isReply
-                ? _(
-                    msg({
-                      message: 'Publish reply or replies',
-                      comment:
-                        'Accessibility label for button to publish a reply or thread of replies',
-                    }),
-                  )
-                : _(
-                    msg({
-                      message: 'Publish post or posts',
-                      comment:
-                        'Accessibility label for button to publish a post or thread of posts',
-                    }),
-                  )
+                ? isThread
+                  ? _(
+                      msg({
+                        message: 'Publish replies',
+                        comment:
+                          'Accessibility label for button to publish multiple replies in a thread',
+                      }),
+                    )
+                  : _(
+                      msg({
+                        message: 'Publish reply',
+                        comment:
+                          'Accessibility label for button to publish a single reply',
+                      }),
+                    )
+                : isThread
+                  ? _(
+                      msg({
+                        message: 'Publish posts',
+                        comment:
+                          'Accessibility label for button to publish multiple posts in a thread',
+                      }),
+                    )
+                  : _(
+                      msg({
+                        message: 'Publish post',
+                        comment:
+                          'Accessibility label for button to publish a single post',
+                      }),
+                    )
             }
             variant="solid"
             color="primary"
@@ -985,6 +1001,7 @@ function ComposerTopBar({
               )}
             </ButtonText>
           </Button>
+            }
         )}
       </View>
       {children}

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -105,7 +105,10 @@ import {SelectLangBtn} from '#/view/com/composer/select-language/SelectLangBtn'
 import {SuggestedLanguage} from '#/view/com/composer/select-language/SuggestedLanguage'
 // TODO: Prevent naming components that coincide with RN primitives
 // due to linting false positives
-import {TextInput, type TextInputRef} from '#/view/com/composer/text-input/TextInput'
+import {
+  TextInput,
+  type TextInputRef,
+} from '#/view/com/composer/text-input/TextInput'
 import {ThreadgateBtn} from '#/view/com/composer/threadgate/ThreadgateBtn'
 import {SelectVideoBtn} from '#/view/com/composer/videos/SelectVideoBtn'
 import {SubtitleDialogBtn} from '#/view/com/composer/videos/SubtitleDialog'
@@ -135,7 +138,12 @@ import {
   type PostDraft,
   type ThreadDraft,
 } from './state/composer'
-import {NO_VIDEO, type NoVideoState, processVideo, type VideoState} from './state/video'
+import {
+  NO_VIDEO,
+  type NoVideoState,
+  processVideo,
+  type VideoState,
+} from './state/video'
 import {getVideoMetadata} from './videos/pickVideo'
 import {clearThumbnailCache} from './videos/VideoTranscodeBackdrop'
 

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -49,7 +49,7 @@ import {
   RichText,
 } from '@atproto/api'
 import {FontAwesomeIcon} from '@fortawesome/react-native-fontawesome'
-import {msg, Trans} from '@lingui/macro'
+import {msg, plural, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 import {useQueryClient} from '@tanstack/react-query'
 
@@ -831,7 +831,9 @@ let ComposerPost = React.memo(function ComposerPost({
           accessible={true}
           accessibilityLabel={_(msg`Write post`)}
           accessibilityHint={_(
-            msg`Compose posts up to ${MAX_GRAPHEME_LENGTH} characters in length`,
+            msg`Compose posts up to ${plural(MAX_GRAPHEME_LENGTH || 0, {
+              other: '# characters',
+            })} in length`,
           )}
         />
       </View>
@@ -913,20 +915,23 @@ function ComposerTopBar({
   children?: React.ReactNode
 }) {
   const pal = usePalette('default')
+  const {_} = useLingui()
   return (
     <Animated.View
       style={topBarAnimatedStyle}
       layout={native(LinearTransition)}>
       <View style={styles.topbarInner}>
         <Button
-          label="Cancel"
+          label={_(msg`Cancel`)}
           variant="ghost"
           color="primary"
           shape="default"
           size="small"
           style={[a.rounded_full, a.py_sm, {paddingLeft: 7, paddingRight: 7}]}
           onPress={onCancel}
-          accessibilityHint="Closes post composer and discards post draft">
+          accessibilityHint={_(
+            msg`Closes post composer and discards post draft`,
+          )}>
           <ButtonText style={[a.text_md]}>
             <Trans>Cancel</Trans>
           </ButtonText>
@@ -942,7 +947,7 @@ function ComposerTopBar({
         ) : (
           <Button
             testID="composerPublishBtn"
-            label={isReply ? 'Publish reply' : 'Publish post'}
+            label={isReply ? _(msg`Publish reply`) : _(msg`Publish post`)}
             variant="solid"
             color="primary"
             shape="default"

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -949,16 +949,20 @@ function ComposerTopBar({
             testID="composerPublishBtn"
             label={
               isReply
-                ? _msg({
-                    message: 'Publish reply or replies',
-                    comment:
-                      'Accessibility label for button when publishing a reply or thread of replies',
-                  })
-                : _msg({
-                    message: 'Publish post or posts',
-                    comment:
-                      'Accessibility label for button when publishing a post or thread of posts',
-                  })
+                ? _(
+                    msg({
+                      message: 'Publish reply or replies',
+                      comment:
+                        'Accessibility label for button when publishing a reply or thread of replies',
+                    }),
+                  )
+                : _(
+                    msg({
+                      message: 'Publish post or posts',
+                      comment:
+                        'Accessibility label for button when publishing a post or thread of posts',
+                    }),
+                  )
             }
             variant="solid"
             color="primary"

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -12,17 +12,17 @@ import {
   BackHandler,
   Keyboard,
   KeyboardAvoidingView,
-  LayoutChangeEvent,
+  type LayoutChangeEvent,
   ScrollView,
-  StyleProp,
+  type StyleProp,
   StyleSheet,
   View,
-  ViewStyle,
+  type ViewStyle,
 } from 'react-native'
 // @ts-expect-error no type definition
 import ProgressCircle from 'react-native-progress/Circle'
 import Animated, {
-  AnimatedRef,
+  type AnimatedRef,
   Easing,
   FadeIn,
   FadeOut,
@@ -41,12 +41,12 @@ import Animated, {
   ZoomOut,
 } from 'react-native-reanimated'
 import {useSafeAreaInsets} from 'react-native-safe-area-context'
-import {ImagePickerAsset} from 'expo-image-picker'
+import {type ImagePickerAsset} from 'expo-image-picker'
 import {
   AppBskyFeedDefs,
-  AppBskyFeedGetPostThread,
-  BskyAgent,
-  RichText,
+  type AppBskyFeedGetPostThread,
+  type BskyAgent,
+  type RichText,
 } from '@atproto/api'
 import {FontAwesomeIcon} from '@fortawesome/react-native-fontawesome'
 import {msg, plural, Trans} from '@lingui/macro'
@@ -59,7 +59,7 @@ import {until} from '#/lib/async/until'
 import {
   MAX_GRAPHEME_LENGTH,
   SUPPORTED_MIME_TYPES,
-  SupportedMimeTypes,
+  type SupportedMimeTypes,
 } from '#/lib/constants'
 import {useAnimatedScrollHandler} from '#/lib/hooks/useAnimatedScrollHandler_FIXED'
 import {useEmail} from '#/lib/hooks/useEmail'
@@ -75,7 +75,7 @@ import {logger} from '#/logger'
 import {isAndroid, isIOS, isNative, isWeb} from '#/platform/detection'
 import {useDialogStateControlContext} from '#/state/dialogs'
 import {emitPostCreated} from '#/state/events'
-import {ComposerImage, pasteImage} from '#/state/gallery'
+import {type ComposerImage, pasteImage} from '#/state/gallery'
 import {useModalControls} from '#/state/modals'
 import {useRequireAltTextEnabled} from '#/state/preferences'
 import {
@@ -85,10 +85,10 @@ import {
 } from '#/state/preferences/languages'
 import {usePreferencesQuery} from '#/state/queries/preferences'
 import {useProfileQuery} from '#/state/queries/profile'
-import {Gif} from '#/state/queries/tenor'
+import {type Gif} from '#/state/queries/tenor'
 import {useAgent, useSession} from '#/state/session'
 import {useComposerControls} from '#/state/shell/composer'
-import {ComposerOpts} from '#/state/shell/composer'
+import {type ComposerOpts} from '#/state/shell/composer'
 import {CharProgress} from '#/view/com/composer/char-progress/CharProgress'
 import {ComposerReplyTo} from '#/view/com/composer/ComposerReplyTo'
 import {
@@ -105,7 +105,7 @@ import {SelectLangBtn} from '#/view/com/composer/select-language/SelectLangBtn'
 import {SuggestedLanguage} from '#/view/com/composer/select-language/SuggestedLanguage'
 // TODO: Prevent naming components that coincide with RN primitives
 // due to linting false positives
-import {TextInput, TextInputRef} from '#/view/com/composer/text-input/TextInput'
+import {TextInput, type TextInputRef} from '#/view/com/composer/text-input/TextInput'
 import {ThreadgateBtn} from '#/view/com/composer/threadgate/ThreadgateBtn'
 import {SelectVideoBtn} from '#/view/com/composer/videos/SelectVideoBtn'
 import {SubtitleDialogBtn} from '#/view/com/composer/videos/SubtitleDialog'
@@ -126,16 +126,16 @@ import * as Prompt from '#/components/Prompt'
 import {Text as NewText} from '#/components/Typography'
 import {BottomSheetPortalProvider} from '../../../../modules/bottom-sheet'
 import {
-  ComposerAction,
+  type ComposerAction,
   composerReducer,
   createComposerState,
-  EmbedDraft,
+  type EmbedDraft,
   MAX_IMAGES,
-  PostAction,
-  PostDraft,
-  ThreadDraft,
+  type PostAction,
+  type PostDraft,
+  type ThreadDraft,
 } from './state/composer'
-import {NO_VIDEO, NoVideoState, processVideo, VideoState} from './state/video'
+import {NO_VIDEO, type NoVideoState, processVideo, type VideoState} from './state/video'
 import {getVideoMetadata} from './videos/pickVideo'
 import {clearThumbnailCache} from './videos/VideoTranscodeBackdrop'
 
@@ -969,20 +969,20 @@ function ComposerTopBar({
                       }),
                     )
                 : isThread
-                  ? _(
-                      msg({
-                        message: 'Publish posts',
-                        comment:
-                          'Accessibility label for button to publish multiple posts in a thread',
-                      }),
-                    )
-                  : _(
-                      msg({
-                        message: 'Publish post',
-                        comment:
-                          'Accessibility label for button to publish a single post',
-                      }),
-                    )
+                ? _(
+                    msg({
+                      message: 'Publish posts',
+                      comment:
+                        'Accessibility label for button to publish multiple posts in a thread',
+                    }),
+                  )
+                : _(
+                    msg({
+                      message: 'Publish post',
+                      comment:
+                        'Accessibility label for button to publish a single post',
+                    }),
+                  )
             }
             variant="solid"
             color="primary"

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -947,7 +947,19 @@ function ComposerTopBar({
         ) : (
           <Button
             testID="composerPublishBtn"
-            label={isReply ? _(msg`Publish reply`) : _(msg`Publish post`)}
+            label={
+              isReply
+                ? _msg({
+                    message: 'Publish reply or replies',
+                    comment:
+                      'Accessibility label for button when publishing a reply or thread of replies',
+                  })
+                : _msg({
+                    message: 'Publish post or posts',
+                    comment:
+                      'Accessibility label for button when publishing a post or thread of posts',
+                  })
+            }
             variant="solid"
             color="primary"
             shape="default"

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -1001,7 +1001,6 @@ function ComposerTopBar({
               )}
             </ButtonText>
           </Button>
-            }
         )}
       </View>
       {children}

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -953,14 +953,14 @@ function ComposerTopBar({
                     msg({
                       message: 'Publish reply or replies',
                       comment:
-                        'Accessibility label for button when publishing a reply or thread of replies',
+                        'Accessibility label for button to publish a reply or thread of replies',
                     }),
                   )
                 : _(
                     msg({
                       message: 'Publish post or posts',
                       comment:
-                        'Accessibility label for button when publishing a post or thread of posts',
+                        'Accessibility label for button to publish a post or thread of posts',
                     }),
                   )
             }

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -481,8 +481,8 @@ export const ComposePost = ({
       thread.posts.length > 1
         ? _(msg`Your posts have been published`)
         : replyTo
-        ? _(msg`Your reply has been published`)
-        : _(msg`Your post has been published`),
+          ? _(msg`Your reply has been published`)
+          : _(msg`Your post has been published`),
     )
   }, [
     _,

--- a/src/view/com/composer/labels/LabelsBtn.tsx
+++ b/src/view/com/composer/labels/LabelsBtn.tsx
@@ -113,8 +113,8 @@ function DialogInner({
           </Text>
           <Text style={[t.atoms.text_contrast_medium, a.leading_snug]}>
             <Trans>
-              Please add any content warning labels that are applicable for
-              the media you are posting.
+              Please add any content warning labels that are applicable for the
+              media you are posting.
             </Trans>
           </Text>
         </View>


### PR DESCRIPTION
In response to [feedback on Crowdin](https://bluesky.crowdin.com/editor/1/11/en-gd/7?view=comfortable#675), this PR adds plural formatting for the `accessibilityHint` for the text input in the composer.

Similar to #7984 and #7994, only the `other` prop is included as that is the only plural form relevant in the source locale, English. That will also be the only relevant plural form for translations in most other locales. However, adding plural formatting here means we can ensure that the string can be correctly localized by translators in all supported locales.

Also, I noticed that there were a few untranslatable accessibility strings nearby so I marked those for translation.

I also tweaked two of them to take into account the case where several posts or replies are being published at once. However, if that change would be confusing or clunky then I can easily remove it.

> [!NOTE]
> **I put this PR together partly using ChatGPT and it passes CI but I haven't tested it.**

cc: @akerbeltz