### PR TITLE
Add plural formatting for "too long" error messages when editing profile info

### DIFF
--- a/src/screens/Profile/Header/EditProfileDialog.tsx
+++ b/src/screens/Profile/Header/EditProfileDialog.tsx
@@ -335,7 +335,7 @@ function DialogInner({
                 Display name is too long.{' '}
                 <Plural
                   value={DISPLAY_NAME_MAX_GRAPHEMES}
-                  other={`The maximum number of characters is ${DISPLAY_NAME_MAX_GRAPHEMES}.`}
+                  other="The maximum number of characters is #."
                 />
               </Trans>
             </TextField.SuffixText>
@@ -369,7 +369,7 @@ function DialogInner({
                 Description is too long.{' '}
                 <Plural
                   value={DESCRIPTION_MAX_GRAPHEMES}
-                  other={`The maximum number of characters is ${DESCRIPTION_MAX_GRAPHEMES}.`}
+                  other="The maximum number of characters is #."
                 />
               </Trans>
             </TextField.SuffixText>

--- a/src/screens/Profile/Header/EditProfileDialog.tsx
+++ b/src/screens/Profile/Header/EditProfileDialog.tsx
@@ -371,6 +371,7 @@ function DialogInner({
                   value={DESCRIPTION_MAX_GRAPHEMES}
                   other={`The maximum number of characters is ${DESCRIPTION_MAX_GRAPHEMES}.`}
                 />
+              </Trans>
             </TextField.SuffixText>
           )}
         </View>

--- a/src/screens/Profile/Header/EditProfileDialog.tsx
+++ b/src/screens/Profile/Header/EditProfileDialog.tsx
@@ -2,7 +2,7 @@ import {useCallback, useEffect, useState} from 'react'
 import {Dimensions, View} from 'react-native'
 import {Image as RNImage} from 'react-native-image-crop-picker'
 import {AppBskyActorDefs} from '@atproto/api'
-import {msg, Trans} from '@lingui/macro'
+import {msg, Plural, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
 import {compressIfNeeded} from '#/lib/media/manip'
@@ -332,8 +332,11 @@ function DialogInner({
               ]}
               label={_(msg`Display name is too long`)}>
               <Trans>
-                Display name is too long. The maximum number of characters is{' '}
-                {DISPLAY_NAME_MAX_GRAPHEMES}.
+                Display name is too long.{' '}
+                <Plural
+                  value={DISPLAY_NAME_MAX_GRAPHEMES}
+                  other={`The maximum number of characters is ${DISPLAY_NAME_MAX_GRAPHEMES}.`}
+                />
               </Trans>
             </TextField.SuffixText>
           )}
@@ -363,9 +366,11 @@ function DialogInner({
               ]}
               label={_(msg`Description is too long`)}>
               <Trans>
-                Description is too long. The maximum number of characters is{' '}
-                {DESCRIPTION_MAX_GRAPHEMES}.
-              </Trans>
+                Description is too long.{' '}
+                <Plural
+                  value={DESCRIPTION_MAX_GRAPHEMES}
+                  other={`The maximum number of characters is ${DESCRIPTION_MAX_GRAPHEMES}.`}
+                />
             </TextField.SuffixText>
           )}
         </View>


### PR DESCRIPTION
In response to feedback for [two](https://bluesky.crowdin.com/editor/1/11/en-gd/7?view=comfortable#891) [strings](https://bluesky.crowdin.com/editor/1/11/en-gd/7?view=comfortable#949) on Crowdin, this PR adds plural formatting for the `Display name is too long` and `Description is too long` error messages that can be shown when a user is editing their profile info.

Similar to #7984, #7994 and #7997, only the `other` prop is included as that is the only plural form relevant in the source locale, English. That will also be the only relevant plural form for translations in most other locales. However, adding plural formatting here means we can ensure that the string can be correctly localized by translators in all supported locales.

> [!NOTE]
> **I put this PR together partly using ChatGPT and it passes CI but I haven't tested it.**

cc: @akerbeltz