### PR TITLE
Add plural formatting for handle too long error

### DIFF
--- a/src/screens/Signup/StepHandle.tsx
+++ b/src/screens/Signup/StepHandle.tsx
@@ -1,6 +1,6 @@
 import React, {useRef} from 'react'
 import {View} from 'react-native'
-import {msg, Trans} from '@lingui/macro'
+import {msg, Plural, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
 import {logEvent} from '#/lib/statsig/statsig'
@@ -174,7 +174,11 @@ export function StepHandle() {
               draftValue.length > MAX_SERVICE_HANDLE_LENGTH ? (
                 <Text style={[a.text_md, a.flex_1]}>
                   <Trans>
-                    No longer than {MAX_SERVICE_HANDLE_LENGTH} characters
+                    No longer than{' '}
+                    <Plural
+                      value={MAX_SERVICE_HANDLE_LENGTH}
+                      other="# characters"
+                    />
                   </Trans>
                 </Text>
               ) : (


### PR DESCRIPTION
In response to [feedback on Crowdin](https://bluesky.crowdin.com/editor/1/11/en-gd/7?view=comfortable#7543), this PR adds plural formatting for the `No longer than {MAX_SERVICE_HANDLE_LENGTH} characters` error message which is shown on signup if the user types in a username longer than the constant (currently 18 characters).

Similar to previous recent PRs from me adding plural formatting, only the `other` prop is included as that is the only plural form relevant in the source locale, English. That will also be the only relevant plural form for translations in most other locales. However, adding plural formatting here means we can ensure that the string can be correctly localized by translators in all supported locales.

> [!NOTE]
> **This PR passes CI but I haven't tested it.**

cc: @akerbeltz