### PR TITLE
Add plural formatting for `STARTER_PACK_MAX_SIZE` toast

### DIFF
--- a/src/screens/StarterPack/Wizard/State.tsx
+++ b/src/screens/StarterPack/Wizard/State.tsx
@@ -73,10 +73,12 @@ function reducer(state: State, action: Action): State {
     case 'AddProfile':
       if (state.profiles.length > STARTER_PACK_MAX_SIZE) {
         Toast.show(
-          msg`You may only add up to ` +
+          (
+            msg`You may only add up to ` +
             plural(STARTER_PACK_MAX_SIZE, {
               other: `${STARTER_PACK_MAX_SIZE} profiles`,
-            }).message ?? '',
+            })
+          ).message ?? '',
           'info',
         )
       } else {

--- a/src/screens/StarterPack/Wizard/State.tsx
+++ b/src/screens/StarterPack/Wizard/State.tsx
@@ -73,12 +73,9 @@ function reducer(state: State, action: Action): State {
     case 'AddProfile':
       if (state.profiles.length > STARTER_PACK_MAX_SIZE) {
         Toast.show(
-          (
-            msg`You may only add up to ` +
-            plural(STARTER_PACK_MAX_SIZE, {
-              other: `${STARTER_PACK_MAX_SIZE} profiles`,
-            })
-          ).message ?? '',
+          msg`You may only add up to ${plural(STARTER_PACK_MAX_SIZE, {
+            other: `${STARTER_PACK_MAX_SIZE} profiles`,
+          })}`.message ?? '',
           'info',
         )
       } else {

--- a/src/screens/StarterPack/Wizard/State.tsx
+++ b/src/screens/StarterPack/Wizard/State.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import {AppBskyGraphDefs, AppBskyGraphStarterpack} from '@atproto/api'
 import {GeneratorView} from '@atproto/api/dist/client/types/app/bsky/feed/defs'
-import {msg} from '@lingui/macro'
+import {msg, plural} from '@lingui/macro'
 
 import {STARTER_PACK_MAX_SIZE} from '#/lib/constants'
 import {useSession} from '#/state/session'
@@ -73,8 +73,10 @@ function reducer(state: State, action: Action): State {
     case 'AddProfile':
       if (state.profiles.length > STARTER_PACK_MAX_SIZE) {
         Toast.show(
-          msg`You may only add up to ${STARTER_PACK_MAX_SIZE} profiles`
-            .message ?? '',
+          msg`You may only add up to ` +
+            plural(STARTER_PACK_MAX_SIZE, {
+              other: `${STARTER_PACK_MAX_SIZE} profiles`,
+            }).message ?? '',
           'info',
         )
       } else {


### PR DESCRIPTION
In response to [feedback on Crowdin](https://bluesky.crowdin.com/editor/1/11/en-gd/7?view=comfortable#3651), this PR adds plural formatting for the `You may only add up to ${STARTER_PACK_MAX_SIZE} profiles` toast which is shown when a user tries to add more than the maximum number of profiles to a starter pack.

Similar to previous recent PRs from me adding plural formatting, only the `other` prop is included as that is the only plural form relevant in the source locale, English. That will also be the only relevant plural form for translations in most other locales. However, adding plural formatting here means we can ensure that the string can be correctly localized by translators in all supported locales.

> [!NOTE]
> **I put this PR together using ChatGPT and it passes CI but I haven't tested it.**

cc: @akerbeltz