### PR TITLE
Generate separate strings for join messages in Newskie dialog

### DIFF
--- a/src/components/NewskieDialog.tsx
+++ b/src/components/NewskieDialog.tsx
@@ -85,17 +85,32 @@ function DialogInner({
   const isMe = profile.did === currentAccount?.did
 
   const profileName = useMemo(() => {
-    const name = profile.displayName || profile.handle
-
-    if (isMe) {
-      return _(msg`You`)
-    }
-
-    if (!moderationOpts) return name
+    if (!moderationOpts) return profile.displayName || profile.handle
     const moderation = moderateProfile(profile, moderationOpts)
+    return sanitizeDisplayName(
+      profile.displayName || profile.handle, 
+      moderation.ui('displayName')
+    )
+  }, [moderationOpts, profile])
 
-    return sanitizeDisplayName(name, moderation.ui('displayName'))
-  }, [_, isMe, moderationOpts, profile])
+  // Generate the join message based on the conditions
+  const getJoinMessage = () => {
+    const timeAgoString = timeAgo(createdAt, now, {format: 'long'})
+    
+    if (isMe) {
+      if (profile.joinedViaStarterPack) {
+        return _(msg`You joined Bluesky using a starter pack ${timeAgoString} ago`)
+      } else {
+        return _(msg`You joined Bluesky ${timeAgoString} ago`)
+      }
+    } else {
+      if (profile.joinedViaStarterPack) {
+        return _(msg`${profileName} joined Bluesky using a starter pack ${timeAgoString} ago`)
+      } else {
+        return _(msg`${profileName} joined Bluesky ${timeAgoString} ago`)
+      }
+    }
+  }
 
   return (
     <Dialog.ScrollableInner
@@ -122,17 +137,7 @@ function DialogInner({
           </Text>
         </View>
         <Text style={[a.text_md, a.text_center, a.leading_snug]}>
-          {profile.joinedViaStarterPack ? (
-            <Trans>
-              {profileName} joined Bluesky using a starter pack{' '}
-              {timeAgo(createdAt, now, {format: 'long'})} ago
-            </Trans>
-          ) : (
-            <Trans>
-              {profileName} joined Bluesky{' '}
-              {timeAgo(createdAt, now, {format: 'long'})} ago
-            </Trans>
-          )}
+          {getJoinMessage()}
         </Text>
         {profile.joinedViaStarterPack ? (
           <StarterPackCard.Link


### PR DESCRIPTION
In response to [feedback on Crowdin](https://bluesky.crowdin.com/editor/1/11/en-gd/7?view=comfortable#3579):

> It's a really really bad idea to use pronouns for concatenation because they are heavily inflected in many languages depending on the context. For example, while you as the subject may be _thu_ in ScG, _from you_ becomes _uat_ and _to you_ _dhut_ or _thugad_ depending on context. UI strings with pronouns are best hard coded. Or need a detailed explanation of context.

This PR rewrites the code in the newskie dialog to make a few changes, so that separate strings with full sentences are generated for each of the four scenarios:

1. Removes the special "You" transformation logic from the `profileName` calculation, so it now just contains the sanitized display name.
2. Creates a new `getJoinMessage()` function that:
- Generates the appropriate message based on whether it's the current user (`isMe`) and if they joined via starter pack
- Uses the Lingui `msg` macro for each of the four distinct messages
- Each message has proper interpolation for the time ago string and profile name where appropriate
3. Simplifies the JSX by using this function directly in the `Text` component instead of conditionally rendering different `Trans` components.

> [!NOTE]
> **Claude wrote the code for this PR (I certainly couldn't 😅) and although it passes CI I have not tested it.**

Fixes #8940