### PR TITLE
Simplify text elements and add `BoldText` component in starter pack wizard

### DIFF
--- a/src/screens/StarterPack/Wizard/index.tsx
+++ b/src/screens/StarterPack/Wizard/index.tsx
@@ -384,14 +384,8 @@ function Footer({
 
   const textStyles = [a.text_md]
 
-  const BoldText = ({
-    children,
-    emoji,
-  }: {
-    children: React.ReactNode
-    emoji?: boolean
-  }) => (
-    <Text style={[a.font_bold, textStyles]} emoji={emoji}>
+  const BoldText = ({children}: {children: React.ReactNode}) => (
+    <Text style={[a.font_bold, textStyles]} emoji>
       {children}
     </Text>
   )
@@ -451,17 +445,17 @@ function Footer({
               ) : items.length === 2 ? (
                 <Trans>
                   <BoldText>You</BoldText> and{' '}
-                  <BoldText emoji>
+                  <BoldText>
                     {getName(items[1] /* [0] is self, skip it */)}
                   </BoldText>{' '}
                   are included in your starter pack
                 </Trans>
               ) : items.length > 2 ? (
                 <Trans context="profiles">
-                  <BoldText emoji>
+                  <BoldText>
                     {getName(items[1] /* [0] is self, skip it */)},
                   </BoldText>{' '}
-                  <BoldText emoji>{getName(items[2])},</BoldText> and{' '}
+                  <BoldText>{getName(items[2])},</BoldText> and{' '}
                   <Plural
                     value={items.length - 2}
                     one="# other"
@@ -489,19 +483,19 @@ function Footer({
               {
                 items.length === 1 ? (
                   <Trans>
-                    <BoldText emoji>{getName(items[0])}</BoldText> is included
+                    <BoldText>{getName(items[0])}</BoldText> is included
                     in your starter pack
                   </Trans>
                 ) : items.length === 2 ? (
                   <Trans>
-                    <BoldText emoji>{getName(items[0])}</BoldText> and{' '}
-                    <BoldText emoji>{getName(items[1])}</BoldText> are included
+                    <BoldText>{getName(items[0])}</BoldText> and{' '}
+                    <BoldText>{getName(items[1])}</BoldText> are included
                     in your starter pack
                   </Trans>
                 ) : items.length > 2 ? (
                   <Trans context="feeds">
-                    <BoldText emoji>{getName(items[0])},</BoldText>{' '}
-                    <BoldText emoji>{getName(items[1])},</BoldText> and{' '}
+                    <BoldText>{getName(items[0])},</BoldText>{' '}
+                    <BoldText>{getName(items[1])},</BoldText> and{' '}
                     <Plural
                       value={items.length - 2}
                       one="# other"

--- a/src/screens/StarterPack/Wizard/index.tsx
+++ b/src/screens/StarterPack/Wizard/index.tsx
@@ -483,14 +483,14 @@ function Footer({
               {
                 items.length === 1 ? (
                   <Trans>
-                    <BoldText>{getName(items[0])}</BoldText> is included
-                    in your starter pack
+                    <BoldText>{getName(items[0])}</BoldText> is included in your
+                    starter pack
                   </Trans>
                 ) : items.length === 2 ? (
                   <Trans>
                     <BoldText>{getName(items[0])}</BoldText> and{' '}
-                    <BoldText>{getName(items[1])}</BoldText> are included
-                    in your starter pack
+                    <BoldText>{getName(items[1])}</BoldText> are included in
+                    your starter pack
                   </Trans>
                 ) : items.length > 2 ? (
                   <Trans context="feeds">

--- a/src/screens/StarterPack/Wizard/index.tsx
+++ b/src/screens/StarterPack/Wizard/index.tsx
@@ -384,6 +384,18 @@ function Footer({
 
   const textStyles = [a.text_md]
 
+  const BoldText = ({
+    children,
+    emoji,
+  }: {
+    children: React.ReactNode
+    emoji?: boolean
+  }) => (
+    <Text style={[a.font_bold, textStyles]} emoji={emoji}>
+      {children}
+    </Text>
+  )
+
   return (
     <View
       style={[
@@ -438,22 +450,18 @@ function Footer({
                 </Trans>
               ) : items.length === 2 ? (
                 <Trans>
-                  <Text style={[a.font_bold, textStyles]}>You</Text> and
-                  <Text> </Text>
-                  <Text style={[a.font_bold, textStyles]} emoji>
-                    {getName(items[1] /* [0] is self, skip it */)}{' '}
-                  </Text>
+                  <BoldText>You</BoldText> and{' '}
+                  <BoldText emoji>
+                    {getName(items[1] /* [0] is self, skip it */)}
+                  </BoldText>{' '}
                   are included in your starter pack
                 </Trans>
               ) : items.length > 2 ? (
                 <Trans context="profiles">
-                  <Text style={[a.font_bold, textStyles]} emoji>
-                    {getName(items[1] /* [0] is self, skip it */)},{' '}
-                  </Text>
-                  <Text style={[a.font_bold, textStyles]} emoji>
-                    {getName(items[2])},{' '}
-                  </Text>
-                  and{' '}
+                  <BoldText emoji>
+                    {getName(items[1] /* [0] is self, skip it */)},
+                  </BoldText>{' '}
+                  <BoldText emoji>{getName(items[2])},</BoldText> and{' '}
                   <Plural
                     value={items.length - 2}
                     one="# other"
@@ -481,32 +489,19 @@ function Footer({
               {
                 items.length === 1 ? (
                   <Trans>
-                    <Text style={[a.font_bold, textStyles]} emoji>
-                      {getName(items[0])}
-                    </Text>{' '}
-                    is included in your starter pack
+                    <BoldText emoji>{getName(items[0])}</BoldText> is included
+                    in your starter pack
                   </Trans>
                 ) : items.length === 2 ? (
                   <Trans>
-                    <Text style={[a.font_bold, textStyles]} emoji>
-                      {getName(items[0])}
-                    </Text>{' '}
-                    and
-                    <Text> </Text>
-                    <Text style={[a.font_bold, textStyles]} emoji>
-                      {getName(items[1])}{' '}
-                    </Text>
-                    are included in your starter pack
+                    <BoldText emoji>{getName(items[0])}</BoldText> and{' '}
+                    <BoldText emoji>{getName(items[1])}</BoldText> are included
+                    in your starter pack
                   </Trans>
                 ) : items.length > 2 ? (
                   <Trans context="feeds">
-                    <Text style={[a.font_bold, textStyles]} emoji>
-                      {getName(items[0])},{' '}
-                    </Text>
-                    <Text style={[a.font_bold, textStyles]} emoji>
-                      {getName(items[1])},{' '}
-                    </Text>
-                    and{' '}
+                    <BoldText emoji>{getName(items[0])},</BoldText>{' '}
+                    <BoldText emoji>{getName(items[1])},</BoldText> and{' '}
                     <Plural
                       value={items.length - 2}
                       one="# other"


### PR DESCRIPTION
Following a bit of confusion on Crowdin about the two places in `src/screens/StarterPack/Wizard/index.tsx` where there's only a space inside a `Text` element:

```typescript
<Text> </Text>
```

which generates these strings:

`<0>{0}</0> and<1> </1><2>{1} </2>are included in your starter pack`
`<0>You</0> and<1> </1><2>{0} </2>are included in your starter pack`

I asked Claude to simplify the code. Claude offered to further simplify and ended up making the following improvements in this PR which:

1. Adds a reusable `BoldText` component in the `Footer` function that encapsulates the common styling pattern:
   ```typescript
   const BoldText = ({children, emoji}: {children: React.ReactNode, emoji?: boolean}) => (
     <Text style={[a.font_bold, textStyles]} emoji={emoji}>{children}</Text>
   )
   ```

2. Simplifies the problematic text element structures on lines 442 and 495 (and similar instances) by:
   - Using the new `BoldText` component
   - Replacing the separate `<Text> </Text>` elements with the JSX space syntax `{' '}`
   - Ensuring proper spacing between elements
   - Removing the optional `emoji` parameter completely
   - Always setting the `emoji` prop to true (implicitly by just including it)
   - Simplifying all the component calls by removing the need to specify the `emoji` prop

3. Makes the code more consistent throughout by applying the same text styling approach to all similar instances

These changes make the code:
- More maintainable: The styling pattern is consistent and reusable
- Easier to read: The text flow is more natural without unnecessary nested elements
- More translator-friendly: The text structure is simplified, making it easier to understand and translate

The functionality remains identical, but the code is now cleaner and less likely to confuse translators or developers working with it in the future.

> [!NOTE]
> **As stated, Claude wrote the code for this PR (and most of the description). It passes CI but I have not tested it.**