### PR TITLE
New `ContextMenu` menu type for DM messages

### DIFF
--- a/src/App.native.tsx
+++ b/src/App.native.tsx
@@ -128,55 +128,57 @@ function InnerApp() {
   return (
     <Alf theme={theme}>
       <ThemeProvider theme={theme}>
-        <Splash isReady={isReady && hasCheckedReferrer}>
-          <RootSiblingParent>
-            <VideoVolumeProvider>
-              <React.Fragment
-                // Resets the entire tree below when it changes:
-                key={currentAccount?.did}>
-                <QueryProvider currentDid={currentAccount?.did}>
-                  <ComposerProvider>
-                    <StatsigProvider>
-                      <MessagesProvider>
-                        {/* LabelDefsProvider MUST come before ModerationOptsProvider */}
-                        <LabelDefsProvider>
-                          <ModerationOptsProvider>
-                            <LoggedOutViewProvider>
-                              <SelectedFeedProvider>
-                                <HiddenRepliesProvider>
-                                  <HomeBadgeProvider>
-                                    <UnreadNotifsProvider>
-                                      <BackgroundNotificationPreferencesProvider>
-                                        <MutedThreadsProvider>
-                                          <ProgressGuideProvider>
-                                            <TrendingConfigProvider>
-                                              <GestureHandlerRootView
-                                                style={s.h100pct}>
-                                                <IntentDialogProvider>
-                                                  <TestCtrls />
-                                                  <Shell />
-                                                  <NuxDialogs />
-                                                </IntentDialogProvider>
-                                              </GestureHandlerRootView>
-                                            </TrendingConfigProvider>
-                                          </ProgressGuideProvider>
-                                        </MutedThreadsProvider>
-                                      </BackgroundNotificationPreferencesProvider>
-                                    </UnreadNotifsProvider>
-                                  </HomeBadgeProvider>
-                                </HiddenRepliesProvider>
-                              </SelectedFeedProvider>
-                            </LoggedOutViewProvider>
-                          </ModerationOptsProvider>
-                        </LabelDefsProvider>
-                      </MessagesProvider>
-                    </StatsigProvider>
-                  </ComposerProvider>
-                </QueryProvider>
-              </React.Fragment>
-            </VideoVolumeProvider>
-          </RootSiblingParent>
-        </Splash>
+        <ContextMenuProvider>
+          <Splash isReady={isReady && hasCheckedReferrer}>
+            <RootSiblingParent>
+              <VideoVolumeProvider>
+                <React.Fragment
+                  // Resets the entire tree below when it changes:
+                  key={currentAccount?.did}>
+                  <QueryProvider currentDid={currentAccount?.did}>
+                    <ComposerProvider>
+                      <StatsigProvider>
+                        <MessagesProvider>
+                          {/* LabelDefsProvider MUST come before ModerationOptsProvider */}
+                          <LabelDefsProvider>
+                            <ModerationOptsProvider>
+                              <LoggedOutViewProvider>
+                                <SelectedFeedProvider>
+                                  <HiddenRepliesProvider>
+                                    <HomeBadgeProvider>
+                                      <UnreadNotifsProvider>
+                                        <BackgroundNotificationPreferencesProvider>
+                                          <MutedThreadsProvider>
+                                            <ProgressGuideProvider>
+                                              <TrendingConfigProvider>
+                                                <GestureHandlerRootView
+                                                  style={s.h100pct}>
+                                                  <IntentDialogProvider>
+                                                    <TestCtrls />
+                                                    <Shell />
+                                                    <NuxDialogs />
+                                                  </IntentDialogProvider>
+                                                </GestureHandlerRootView>
+                                              </TrendingConfigProvider>
+                                            </ProgressGuideProvider>
+                                          </MutedThreadsProvider>
+                                        </BackgroundNotificationPreferencesProvider>
+                                      </UnreadNotifsProvider>
+                                    </HomeBadgeProvider>
+                                  </HiddenRepliesProvider>
+                                </SelectedFeedProvider>
+                              </LoggedOutViewProvider>
+                            </ModerationOptsProvider>
+                          </LabelDefsProvider>
+                        </MessagesProvider>
+                      </StatsigProvider>
+                    </ComposerProvider>
+                  </QueryProvider>
+                </React.Fragment>
+              </VideoVolumeProvider>
+            </RootSiblingParent>
+          </Splash>
+        </ContextMenuProvider>
       </ThemeProvider>
     </Alf>
   )
@@ -217,9 +219,7 @@ function App() {
                                 <SafeAreaProvider
                                   initialMetrics={initialWindowMetrics}>
                                   <LightStatusBarProvider>
-                                    <ContextMenuProvider>
-                                      <InnerApp />
-                                    </ContextMenuProvider>
+                                    <InnerApp />
                                   </LightStatusBarProvider>
                                 </SafeAreaProvider>
                               </StarterPackProvider>

--- a/src/App.native.tsx
+++ b/src/App.native.tsx
@@ -65,6 +65,7 @@ import * as Toast from '#/view/com/util/Toast'
 import {Shell} from '#/view/shell'
 import {ThemeProvider as Alf} from '#/alf'
 import {useColorModeTheme} from '#/alf/util/useColorModeTheme'
+import {Provider as ContextMenuProvider} from '#/components/ContextMenu'
 import {NuxDialogs} from '#/components/dialogs/nuxs'
 import {useStarterPackEntry} from '#/components/hooks/useStarterPackEntry'
 import {Provider as IntentDialogProvider} from '#/components/intents/IntentDialogs'
@@ -216,7 +217,9 @@ function App() {
                                 <SafeAreaProvider
                                   initialMetrics={initialWindowMetrics}>
                                   <LightStatusBarProvider>
-                                    <InnerApp />
+                                    <ContextMenuProvider>
+                                      <InnerApp />
+                                    </ContextMenuProvider>
                                   </LightStatusBarProvider>
                                 </SafeAreaProvider>
                               </StarterPackProvider>

--- a/src/App.web.tsx
+++ b/src/App.web.tsx
@@ -55,6 +55,7 @@ import {ToastContainer} from '#/view/com/util/Toast.web'
 import {Shell} from '#/view/shell/index'
 import {ThemeProvider as Alf} from '#/alf'
 import {useColorModeTheme} from '#/alf/util/useColorModeTheme'
+import {Provider as ContextMenuProvider} from '#/components/ContextMenu'
 import {NuxDialogs} from '#/components/dialogs/nuxs'
 import {useStarterPackEntry} from '#/components/hooks/useStarterPackEntry'
 import {Provider as IntentDialogProvider} from '#/components/intents/IntentDialogs'
@@ -190,7 +191,9 @@ function App() {
                         <PortalProvider>
                           <StarterPackProvider>
                             <LightStatusBarProvider>
-                              <InnerApp />
+                              <ContextMenuProvider>
+                                <InnerApp />
+                              </ContextMenuProvider>
                             </LightStatusBarProvider>
                           </StarterPackProvider>
                         </PortalProvider>

--- a/src/App.web.tsx
+++ b/src/App.web.tsx
@@ -107,54 +107,56 @@ function InnerApp() {
   return (
     <Alf theme={theme}>
       <ThemeProvider theme={theme}>
-        <RootSiblingParent>
-          <VideoVolumeProvider>
-            <ActiveVideoProvider>
-              <React.Fragment
-                // Resets the entire tree below when it changes:
-                key={currentAccount?.did}>
-                <QueryProvider currentDid={currentAccount?.did}>
-                  <ComposerProvider>
-                    <StatsigProvider>
-                      <MessagesProvider>
-                        {/* LabelDefsProvider MUST come before ModerationOptsProvider */}
-                        <LabelDefsProvider>
-                          <ModerationOptsProvider>
-                            <LoggedOutViewProvider>
-                              <SelectedFeedProvider>
-                                <HiddenRepliesProvider>
-                                  <HomeBadgeProvider>
-                                    <UnreadNotifsProvider>
-                                      <BackgroundNotificationPreferencesProvider>
-                                        <MutedThreadsProvider>
-                                          <SafeAreaProvider>
-                                            <ProgressGuideProvider>
-                                              <TrendingConfigProvider>
-                                                <IntentDialogProvider>
-                                                  <Shell />
-                                                  <NuxDialogs />
-                                                </IntentDialogProvider>
-                                              </TrendingConfigProvider>
-                                            </ProgressGuideProvider>
-                                          </SafeAreaProvider>
-                                        </MutedThreadsProvider>
-                                      </BackgroundNotificationPreferencesProvider>
-                                    </UnreadNotifsProvider>
-                                  </HomeBadgeProvider>
-                                </HiddenRepliesProvider>
-                              </SelectedFeedProvider>
-                            </LoggedOutViewProvider>
-                          </ModerationOptsProvider>
-                        </LabelDefsProvider>
-                      </MessagesProvider>
-                    </StatsigProvider>
-                  </ComposerProvider>
-                </QueryProvider>
-                <ToastContainer />
-              </React.Fragment>
-            </ActiveVideoProvider>
-          </VideoVolumeProvider>
-        </RootSiblingParent>
+        <ContextMenuProvider>
+          <RootSiblingParent>
+            <VideoVolumeProvider>
+              <ActiveVideoProvider>
+                <React.Fragment
+                  // Resets the entire tree below when it changes:
+                  key={currentAccount?.did}>
+                  <QueryProvider currentDid={currentAccount?.did}>
+                    <ComposerProvider>
+                      <StatsigProvider>
+                        <MessagesProvider>
+                          {/* LabelDefsProvider MUST come before ModerationOptsProvider */}
+                          <LabelDefsProvider>
+                            <ModerationOptsProvider>
+                              <LoggedOutViewProvider>
+                                <SelectedFeedProvider>
+                                  <HiddenRepliesProvider>
+                                    <HomeBadgeProvider>
+                                      <UnreadNotifsProvider>
+                                        <BackgroundNotificationPreferencesProvider>
+                                          <MutedThreadsProvider>
+                                            <SafeAreaProvider>
+                                              <ProgressGuideProvider>
+                                                <TrendingConfigProvider>
+                                                  <IntentDialogProvider>
+                                                    <Shell />
+                                                    <NuxDialogs />
+                                                  </IntentDialogProvider>
+                                                </TrendingConfigProvider>
+                                              </ProgressGuideProvider>
+                                            </SafeAreaProvider>
+                                          </MutedThreadsProvider>
+                                        </BackgroundNotificationPreferencesProvider>
+                                      </UnreadNotifsProvider>
+                                    </HomeBadgeProvider>
+                                  </HiddenRepliesProvider>
+                                </SelectedFeedProvider>
+                              </LoggedOutViewProvider>
+                            </ModerationOptsProvider>
+                          </LabelDefsProvider>
+                        </MessagesProvider>
+                      </StatsigProvider>
+                    </ComposerProvider>
+                  </QueryProvider>
+                  <ToastContainer />
+                </React.Fragment>
+              </ActiveVideoProvider>
+            </VideoVolumeProvider>
+          </RootSiblingParent>
+        </ContextMenuProvider>
       </ThemeProvider>
     </Alf>
   )
@@ -191,9 +193,7 @@ function App() {
                         <PortalProvider>
                           <StarterPackProvider>
                             <LightStatusBarProvider>
-                              <ContextMenuProvider>
-                                <InnerApp />
-                              </ContextMenuProvider>
+                              <InnerApp />
                             </LightStatusBarProvider>
                           </StarterPackProvider>
                         </PortalProvider>

--- a/src/components/ContextMenu/Backdrop.ios.tsx
+++ b/src/components/ContextMenu/Backdrop.ios.tsx
@@ -9,7 +9,7 @@ import {BlurView} from 'expo-blur'
 import {msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
-import {atoms as a, useTheme} from '#/alf'
+import {atoms as a} from '#/alf'
 
 const AnimatedBlurView = Animated.createAnimatedComponent(BlurView)
 
@@ -22,7 +22,6 @@ export function Backdrop({
   intensity?: number
   onPress?: () => void
 }) {
-  const t = useTheme()
   const {_} = useLingui()
 
   const animatedProps = useAnimatedProps(() => ({
@@ -38,11 +37,7 @@ export function Backdrop({
     <AnimatedBlurView
       animatedProps={animatedProps}
       style={[a.absolute, a.inset_0]}
-      tint={
-        t.scheme === 'light'
-          ? 'systemThinMaterialLight'
-          : 'systemThinMaterialDark'
-      }>
+      tint="systemThinMaterialDark">
       <Pressable
         style={a.flex_1}
         accessibilityLabel={_(msg`Close menu`)}

--- a/src/components/ContextMenu/Backdrop.ios.tsx
+++ b/src/components/ContextMenu/Backdrop.ios.tsx
@@ -3,12 +3,15 @@ import Animated, {
   Extrapolation,
   interpolate,
   SharedValue,
-  useAnimatedStyle,
+  useAnimatedProps,
 } from 'react-native-reanimated'
+import {BlurView} from 'expo-blur'
 import {msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
 import {atoms as a, useTheme} from '#/alf'
+
+const AnimatedBlurView = Animated.createAnimatedComponent(BlurView)
 
 export function Backdrop({
   animation,
@@ -22,24 +25,30 @@ export function Backdrop({
   const t = useTheme()
   const {_} = useLingui()
 
-  const animatedStyle = useAnimatedStyle(() => ({
-    opacity: interpolate(
+  const animatedProps = useAnimatedProps(() => ({
+    intensity: interpolate(
       animation.get(),
       [0, 1],
-      [0, intensity / 100],
+      [0, intensity],
       Extrapolation.CLAMP,
     ),
   }))
 
   return (
-    <Animated.View
-      style={[a.absolute, a.inset_0, t.atoms.bg_contrast_975, animatedStyle]}>
+    <AnimatedBlurView
+      animatedProps={animatedProps}
+      style={[a.absolute, a.inset_0]}
+      tint={
+        t.scheme === 'light'
+          ? 'systemThinMaterialLight'
+          : 'systemThinMaterialDark'
+      }>
       <Pressable
         style={a.flex_1}
         accessibilityLabel={_(msg`Close menu`)}
         accessibilityHint={_(msg`Tap to close context menu`)}
         onPress={onPress}
       />
-    </Animated.View>
+    </AnimatedBlurView>
   )
 }

--- a/src/components/ContextMenu/Backdrop.tsx
+++ b/src/components/ContextMenu/Backdrop.tsx
@@ -1,56 +1,48 @@
-import {useEffect} from 'react'
 import {Pressable} from 'react-native'
 import Animated, {
+  Extrapolation,
+  interpolate,
+  SharedValue,
   useAnimatedProps,
-  useSharedValue,
-  withTiming,
 } from 'react-native-reanimated'
 import {BlurView} from 'expo-blur'
 import {msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
-import {atoms as a} from '#/alf'
+import {atoms as a, useTheme} from '#/alf'
 
 const AnimatedBlurView = Animated.createAnimatedComponent(BlurView)
 
 export function Backdrop({
-  active,
-  intensity = 50,
-  onAnimationEnd,
+  animation,
+  intensity = 30,
   onPress,
 }: {
-  active: boolean
+  animation: SharedValue<number>
   intensity?: number
-  onAnimationEnd?: () => void
   onPress?: () => void
 }) {
+  const t = useTheme()
   const {_} = useLingui()
-  const intensitySV = useSharedValue(active ? intensity : 0)
-
-  useEffect(() => {
-    if (active) {
-      intensitySV.set(withTiming(intensity, {duration: 500}))
-
-      return () => {
-        intensitySV.set(
-          withTiming(0, {duration: 500}, finished => {
-            if (finished) {
-              onAnimationEnd?.()
-            }
-          }),
-        )
-      }
-    }
-  }, [intensitySV, active, intensity, onAnimationEnd])
 
   const animatedProps = useAnimatedProps(() => ({
-    intensity: intensitySV.get(),
+    intensity: interpolate(
+      animation.get(),
+      [0, 1],
+      [0, intensity],
+      Extrapolation.CLAMP,
+    ),
   }))
 
   return (
     <AnimatedBlurView
       animatedProps={animatedProps}
-      style={[a.absolute, a.inset_0]}>
+      style={[a.absolute, a.inset_0]}
+      tint={
+        t.scheme === 'light'
+          ? 'systemThinMaterialLight'
+          : 'systemThinMaterialDark'
+      }>
       <Pressable
         style={a.flex_1}
         accessibilityLabel={_(msg`Close menu`)}

--- a/src/components/ContextMenu/Backdrop.tsx
+++ b/src/components/ContextMenu/Backdrop.tsx
@@ -15,7 +15,7 @@ const AnimatedBlurView = Animated.createAnimatedComponent(BlurView)
 
 export function Backdrop({
   animation,
-  intensity = 30,
+  intensity = 50,
   onPress,
 }: {
   animation: SharedValue<number>

--- a/src/components/ContextMenu/Backdrop.tsx
+++ b/src/components/ContextMenu/Backdrop.tsx
@@ -1,0 +1,62 @@
+import {useEffect} from 'react'
+import {Pressable} from 'react-native'
+import Animated, {
+  useAnimatedProps,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated'
+import {BlurView} from 'expo-blur'
+import {msg} from '@lingui/macro'
+import {useLingui} from '@lingui/react'
+
+import {atoms as a} from '#/alf'
+
+const AnimatedBlurView = Animated.createAnimatedComponent(BlurView)
+
+export function Backdrop({
+  active,
+  intensity = 50,
+  onAnimationEnd,
+  onPress,
+}: {
+  active: boolean
+  intensity?: number
+  onAnimationEnd?: () => void
+  onPress?: () => void
+}) {
+  const {_} = useLingui()
+  const intensitySV = useSharedValue(active ? intensity : 0)
+
+  useEffect(() => {
+    if (active) {
+      intensitySV.set(withTiming(intensity, {duration: 500}))
+
+      return () => {
+        intensitySV.set(
+          withTiming(0, {duration: 500}, finished => {
+            if (finished) {
+              onAnimationEnd?.()
+            }
+          }),
+        )
+      }
+    }
+  }, [intensitySV, active, intensity, onAnimationEnd])
+
+  const animatedProps = useAnimatedProps(() => ({
+    intensity: intensitySV.get(),
+  }))
+
+  return (
+    <AnimatedBlurView
+      animatedProps={animatedProps}
+      style={[a.absolute, a.inset_0]}>
+      <Pressable
+        style={a.flex_1}
+        accessibilityLabel={_(msg`Close menu`)}
+        accessibilityHint={_(msg`Tap to close context menu`)}
+        onPress={onPress}
+      />
+    </AnimatedBlurView>
+  )
+}

--- a/src/components/ContextMenu/context.tsx
+++ b/src/components/ContextMenu/context.tsx
@@ -1,0 +1,31 @@
+import React from 'react'
+
+import type {ContextType, ItemContextType} from '#/components/ContextMenu/types'
+
+export const Context = React.createContext<ContextType | null>(null)
+
+export const ItemContext = React.createContext<ItemContextType | null>(null)
+
+export function useContextMenuContext() {
+  const context = React.useContext(Context)
+
+  if (!context) {
+    throw new Error(
+      'useContextMenuContext must be used within a Context.Provider',
+    )
+  }
+
+  return context
+}
+
+export function useContextMenuItemContext() {
+  const context = React.useContext(ItemContext)
+
+  if (!context) {
+    throw new Error(
+      'useContextMenuItemContext must be used within a Context.Provider',
+    )
+  }
+
+  return context
+}

--- a/src/components/ContextMenu/index.tsx
+++ b/src/components/ContextMenu/index.tsx
@@ -389,6 +389,8 @@ export function Outer({
               t.atoms.bg_contrast_25,
               a.w_full,
               // @ts-ignore react-native-web expects string, and this file is platform-split -sfn
+              // note: above @ts-ignore cannot be a @ts-expect-error because this does not cause an error
+              // in the typecheck CI - presumably because of RNW overriding the types
               {
                 transformOrigin:
                   align === 'left' ? [0, 0, 0] : [MENU_WIDTH, 0, 0],

--- a/src/components/ContextMenu/index.tsx
+++ b/src/components/ContextMenu/index.tsx
@@ -388,7 +388,7 @@ export function Outer({
               a.shadow_md,
               t.atoms.bg_contrast_25,
               a.w_full,
-              // @ts-expect-error react-native-web expects string, and this file is platform-split -sfn
+              // @ts-ignore react-native-web expects string, and this file is platform-split -sfn
               {
                 transformOrigin:
                   align === 'left' ? [0, 0, 0] : [MENU_WIDTH, 0, 0],

--- a/src/components/ContextMenu/index.tsx
+++ b/src/components/ContextMenu/index.tsx
@@ -1,0 +1,374 @@
+import React, {useMemo, useRef, useState} from 'react'
+import {
+  Keyboard,
+  Pressable,
+  StyleProp,
+  useWindowDimensions,
+  View,
+  ViewStyle,
+} from 'react-native'
+import {Gesture, GestureDetector} from 'react-native-gesture-handler'
+import Animated, {runOnJS} from 'react-native-reanimated'
+import {useIsFocused} from '@react-navigation/native'
+import flattenReactChildren from 'react-keyed-flatten-children'
+
+import {HITSLOP_10} from '#/lib/constants'
+import {useHaptics} from '#/lib/haptics'
+import {useNonReactiveCallback} from '#/lib/hooks/useNonReactiveCallback'
+import {atoms as a, useTheme} from '#/alf'
+import {
+  Context,
+  ItemContext,
+  useContextMenuContext,
+  useContextMenuItemContext,
+} from '#/components/ContextMenu/context'
+import {
+  ContextType,
+  ItemIconProps,
+  ItemProps,
+  ItemTextProps,
+  Measurement,
+  TriggerProps,
+} from '#/components/ContextMenu/types'
+import {useInteractionState} from '#/components/hooks/useInteractionState'
+import {createPortalGroup} from '#/components/Portal'
+import {Text} from '#/components/Typography'
+import {Backdrop} from './Backdrop'
+
+export {
+  type DialogControlProps as ContextMenuControlProps,
+  useDialogControl as useContextMenuControl,
+} from '#/components/Dialog'
+
+const {Provider: PortalProvider, Outlet, Portal} = createPortalGroup()
+
+export function Provider({children}: {children: React.ReactNode}) {
+  return (
+    <PortalProvider>
+      {children}
+      <Outlet />
+    </PortalProvider>
+  )
+}
+
+export function Root({children}: {children: React.ReactNode}) {
+  const [measurement, setMeasurement] = useState<Measurement | null>(null)
+  const isFocused = useIsFocused()
+
+  const context = useMemo<ContextType>(
+    () => ({
+      isOpen: !!measurement && isFocused,
+      measurement,
+      open: (evt: Measurement) => {
+        setMeasurement(evt)
+      },
+      close: () => {
+        setMeasurement(null)
+      },
+    }),
+    [measurement, setMeasurement, isFocused],
+  )
+
+  return <Context.Provider value={context}>{children}</Context.Provider>
+}
+
+export function Trigger({children, label, style}: TriggerProps) {
+  const context = useContextMenuContext()
+  const playHaptic = useHaptics()
+  const ref = useRef<View>(null)
+
+  const open = useNonReactiveCallback(() => {
+    playHaptic()
+    Keyboard.dismiss()
+    ref.current?.measure((x, y, width, height, pageX, pageY) =>
+      context.open({x, y, width, height, pageX, pageY}),
+    )
+  })
+
+  const doubleTapGesture = useMemo(() => {
+    return Gesture.Tap()
+      .numberOfTaps(2)
+      .hitSlop(HITSLOP_10)
+      .onEnd(open)
+      .runOnJS(true)
+  }, [open])
+
+  const pressAndHoldGesture = useMemo(() => {
+    return Gesture.LongPress()
+      .onStart(() => {
+        runOnJS(open)()
+      })
+      .cancelsTouchesInView(false)
+  }, [open])
+
+  const composedGestures = Gesture.Exclusive(
+    doubleTapGesture,
+    pressAndHoldGesture,
+  )
+
+  console.log(context.measurement)
+
+  return (
+    <>
+      <GestureDetector gesture={composedGestures}>
+        <View ref={ref} style={[{opacity: context.isOpen ? 0 : 1}, style]}>
+          {children({
+            isNative: true,
+            control: {isOpen: context.isOpen, open},
+            state: {
+              pressed: false,
+              hovered: false,
+              focused: false,
+            },
+            props: {
+              ref: null,
+              onPress: null,
+              onFocus: null,
+              onBlur: null,
+              onPressIn: null,
+              onPressOut: null,
+              accessibilityHint: null,
+              accessibilityLabel: label,
+              accessibilityRole: null,
+            },
+          })}
+        </View>
+      </GestureDetector>
+      {context.isOpen && context.measurement && (
+        <Portal>
+          <Animated.View
+            style={[
+              a.absolute,
+              {
+                top: context.measurement.pageY,
+                left: context.measurement.pageX,
+                width: context.measurement.width,
+                height: context.measurement.height,
+              },
+              a.z_10,
+            ]}>
+            {children({
+              isNative: true,
+              control: {isOpen: context.isOpen, open},
+              state: {
+                pressed: false,
+                hovered: false,
+                focused: false,
+              },
+              props: {
+                ref: null,
+                onPress: null,
+                onFocus: null,
+                onBlur: null,
+                onPressIn: null,
+                onPressOut: null,
+                accessibilityHint: null,
+                accessibilityLabel: label,
+                accessibilityRole: null,
+              },
+            })}
+          </Animated.View>
+        </Portal>
+      )}
+    </>
+  )
+}
+
+export function Outer({
+  children,
+  style,
+  align = 'left',
+}: {
+  children: React.ReactNode
+  style?: StyleProp<ViewStyle>
+  align?: 'left' | 'right'
+}) {
+  const t = useTheme()
+  const context = useContextMenuContext()
+  const {width: screenWidth} = useWindowDimensions()
+
+  if (!context.isOpen || !context.measurement) return null
+
+  return (
+    <Portal>
+      <Context.Provider value={context}>
+        <Backdrop active={context.isOpen} onPress={context.close} />
+        <View
+          style={[
+            a.rounded_md,
+            a.overflow_hidden,
+            a.border,
+            t.atoms.border_contrast_low,
+            a.shadow_lg,
+            a.mt_xs,
+            a.w_full,
+            {maxWidth: '60%'},
+            a.absolute,
+            {top: context.measurement.pageY + context.measurement.height},
+            a.z_10,
+            align === 'left'
+              ? {left: context.measurement.pageX}
+              : {
+                  right:
+                    screenWidth -
+                    context.measurement.pageX -
+                    context.measurement.width,
+                },
+            style,
+          ]}>
+          {flattenReactChildren(children).map((child, i) => {
+            return React.isValidElement(child) &&
+              (child.type === Item || child.type === Divider) ? (
+              <React.Fragment key={i}>
+                {i > 0 ? (
+                  <View style={[a.border_b, t.atoms.border_contrast_low]} />
+                ) : null}
+                {React.cloneElement(child, {
+                  // @ts-ignore
+                  style: {
+                    borderRadius: 0,
+                    borderWidth: 0,
+                  },
+                })}
+              </React.Fragment>
+            ) : null
+          })}
+        </View>
+      </Context.Provider>
+    </Portal>
+  )
+}
+
+export function Item({children, label, style, onPress, ...rest}: ItemProps) {
+  const t = useTheme()
+  const context = useContextMenuContext()
+  const {state: focused, onIn: onFocus, onOut: onBlur} = useInteractionState()
+  const {
+    state: pressed,
+    onIn: onPressIn,
+    onOut: onPressOut,
+  } = useInteractionState()
+
+  return (
+    <Pressable
+      {...rest}
+      accessibilityHint=""
+      accessibilityLabel={label}
+      onFocus={onFocus}
+      onBlur={onBlur}
+      onPress={e => {
+        context.close()
+        onPress?.(e)
+      }}
+      onPressIn={e => {
+        onPressIn()
+        rest.onPressIn?.(e)
+      }}
+      onPressOut={e => {
+        onPressOut()
+        rest.onPressOut?.(e)
+      }}
+      style={[
+        a.flex_row,
+        a.align_center,
+        a.gap_sm,
+        a.py_sm,
+        a.px_md,
+        a.rounded_md,
+        a.border,
+        t.atoms.bg_contrast_25,
+        t.atoms.border_contrast_low,
+        {minHeight: 40},
+        style,
+        (focused || pressed) && !rest.disabled && [t.atoms.bg_contrast_50],
+      ]}>
+      <ItemContext.Provider value={{disabled: Boolean(rest.disabled)}}>
+        {children}
+      </ItemContext.Provider>
+    </Pressable>
+  )
+}
+
+export function ItemText({children, style}: ItemTextProps) {
+  const t = useTheme()
+  const {disabled} = useContextMenuItemContext()
+  return (
+    <Text
+      numberOfLines={2}
+      ellipsizeMode="middle"
+      style={[
+        a.flex_1,
+        a.text_sm,
+        a.font_bold,
+        t.atoms.text_contrast_high,
+        {paddingTop: 3},
+        style,
+        disabled && t.atoms.text_contrast_low,
+      ]}>
+      {children}
+    </Text>
+  )
+}
+
+export function ItemIcon({icon: Comp}: ItemIconProps) {
+  const t = useTheme()
+  const {disabled} = useContextMenuItemContext()
+  return (
+    <Comp
+      size="lg"
+      fill={
+        disabled
+          ? t.atoms.text_contrast_low.color
+          : t.atoms.text_contrast_medium.color
+      }
+    />
+  )
+}
+
+export function ItemRadio({selected}: {selected: boolean}) {
+  const t = useTheme()
+  return (
+    <View
+      style={[
+        a.justify_center,
+        a.align_center,
+        a.rounded_full,
+        t.atoms.border_contrast_high,
+        {
+          borderWidth: 1,
+          height: 20,
+          width: 20,
+        },
+      ]}>
+      {selected ? (
+        <View
+          style={[
+            a.absolute,
+            a.rounded_full,
+            {height: 14, width: 14},
+            selected ? {backgroundColor: t.palette.primary_500} : {},
+          ]}
+        />
+      ) : null}
+    </View>
+  )
+}
+
+export function LabelText({children}: {children: React.ReactNode}) {
+  const t = useTheme()
+  return (
+    <Text
+      style={[a.font_bold, t.atoms.text_contrast_medium, {marginBottom: -8}]}>
+      {children}
+    </Text>
+  )
+}
+
+export function Divider() {
+  const t = useTheme()
+  return (
+    <View
+      style={[t.atoms.border_contrast_low, a.flex_1, {borderTopWidth: 3}]}
+    />
+  )
+}

--- a/src/components/ContextMenu/index.tsx
+++ b/src/components/ContextMenu/index.tsx
@@ -301,7 +301,6 @@ export function Outer({
       if (diff > 0) {
         translationSV.set(-diff)
       }
-      console.log('measused, diff:', diff)
       setHasBeenMeasured(true)
     },
     [context.measurement, screenHeight, insets, translationSV],

--- a/src/components/ContextMenu/index.tsx
+++ b/src/components/ContextMenu/index.tsx
@@ -341,21 +341,26 @@ export function Outer({
       if (!context.measurement) return // should not happen
       let translation = 0
 
+      // pure vibes based
+      const TOP_INSET = insets.top + 80
+      const BOTTOM_INSET_IOS = insets.bottom + 20
+      const BOTTOM_INSET_ANDROID = 12 // TODO: revisit when edge-to-edge mode is enabled -sfn
+
       const {height} = evt.nativeEvent.layout
       const topPosition = context.measurement.y + context.measurement.height + 4
       const bottomPosition = topPosition + height
       const safeAreaBottomLimit =
         frame.height -
         platform({
-          ios: insets.bottom + 20,
-          android: 12,
+          ios: BOTTOM_INSET_IOS,
+          android: BOTTOM_INSET_ANDROID,
           default: 0,
         })
       const diff = bottomPosition - safeAreaBottomLimit
       if (diff > 0) {
         translation = -diff
       } else {
-        const distanceMessageFromTop = context.measurement.y - insets.top - 80
+        const distanceMessageFromTop = context.measurement.y - TOP_INSET
         if (distanceMessageFromTop < 0) {
           translation = -Math.max(distanceMessageFromTop, diff)
         }

--- a/src/components/ContextMenu/index.tsx
+++ b/src/components/ContextMenu/index.tsx
@@ -1,5 +1,6 @@
-import React, {useCallback, useMemo, useRef, useState} from 'react'
+import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react'
 import {
+  BackHandler,
   Keyboard,
   LayoutChangeEvent,
   Pressable,
@@ -32,7 +33,7 @@ import flattenReactChildren from 'react-keyed-flatten-children'
 import {HITSLOP_10} from '#/lib/constants'
 import {useHaptics} from '#/lib/haptics'
 import {useNonReactiveCallback} from '#/lib/hooks/useNonReactiveCallback'
-import {isIOS} from '#/platform/detection'
+import {isAndroid, isIOS} from '#/platform/detection'
 import {atoms as a, platform, useTheme} from '#/alf'
 import {
   Context,
@@ -117,6 +118,17 @@ export function Root({children}: {children: React.ReactNode}) {
       clearMeasurement,
     ],
   )
+
+  useEffect(() => {
+    if (isAndroid && context.isOpen) {
+      const listener = BackHandler.addEventListener('hardwareBackPress', () => {
+        context.close()
+        return true
+      })
+
+      return () => listener.remove()
+    }
+  }, [context])
 
   return <Context.Provider value={context}>{children}</Context.Provider>
 }

--- a/src/components/ContextMenu/index.tsx
+++ b/src/components/ContextMenu/index.tsx
@@ -67,6 +67,9 @@ const SPRING: WithSpringConfig = {
   restDisplacementThreshold: 0.01,
 }
 
+/**
+ * Needs placing near the top of the provider stack, but BELOW the theme provider.
+ */
 export function Provider({children}: {children: React.ReactNode}) {
   return (
     <PortalProvider>

--- a/src/components/ContextMenu/index.web.tsx
+++ b/src/components/ContextMenu/index.web.tsx
@@ -1,0 +1,5 @@
+export * from '#/components/Menu'
+
+export function Provider({children}: {children: React.ReactNode}) {
+  return children
+}

--- a/src/components/ContextMenu/types.ts
+++ b/src/components/ContextMenu/types.ts
@@ -1,5 +1,6 @@
 import React from 'react'
 import {AccessibilityRole, StyleProp, ViewStyle} from 'react-native'
+import {SharedValue} from 'react-native-reanimated'
 
 import * as Dialog from '#/components/Dialog'
 import {RadixPassThroughTriggerProps} from '#/components/Menu/types'
@@ -21,6 +22,10 @@ export type Measurement = {
 export type ContextType = {
   isOpen: boolean
   measurement: Measurement | null
+  /* Spring animation between 0 and 1 */
+  animationSV: SharedValue<number>
+  /* Translation in Y axis to ensure everything's onscreen */
+  translationSV: SharedValue<number>
   open: (evt: Measurement) => void
   close: () => void
 }

--- a/src/components/ContextMenu/types.ts
+++ b/src/components/ContextMenu/types.ts
@@ -1,0 +1,87 @@
+import React from 'react'
+import {AccessibilityRole, StyleProp, ViewStyle} from 'react-native'
+
+import * as Dialog from '#/components/Dialog'
+import {RadixPassThroughTriggerProps} from '#/components/Menu/types'
+
+export type {
+  GroupProps,
+  ItemIconProps,
+  ItemProps,
+  ItemTextProps,
+} from '#/components/Menu/types'
+
+export type Measurement = {
+  x: number
+  y: number
+  width: number
+  height: number
+  pageX: number
+  pageY: number
+}
+
+export type ContextType = {
+  isOpen: boolean
+  measurement: Measurement | null
+  open: (evt: Measurement) => void
+  close: () => void
+}
+
+export type ItemContextType = {
+  disabled: boolean
+}
+
+export type TriggerProps = {
+  children(props: TriggerChildProps): React.ReactNode
+  label: string
+  hint?: string
+  role?: AccessibilityRole
+  style?: StyleProp<ViewStyle>
+}
+export type TriggerChildProps =
+  | {
+      isNative: true
+      control: {isOpen: boolean; open: () => void}
+      state: {
+        hovered: false
+        focused: false
+        pressed: false
+      }
+      /**
+       * We don't necessarily know what these will be spread on to, so we
+       * should add props one-by-one.
+       *
+       * On web, these properties are applied to a parent `Pressable`, so this
+       * object is empty.
+       */
+      props: {
+        ref: null
+        onPress: null
+        onFocus: null
+        onBlur: null
+        onPressIn: null
+        onPressOut: null
+        accessibilityHint: null
+        accessibilityLabel: string
+        accessibilityRole: null
+      }
+    }
+  | {
+      isNative: false
+      control: Dialog.DialogOuterProps['control']
+      state: {
+        hovered: false
+        focused: false
+        pressed: false
+      }
+      props: RadixPassThroughTriggerProps & {
+        onPress: () => void
+        onFocus: () => void
+        onBlur: () => void
+        onMouseEnter: () => void
+        onMouseLeave: () => void
+        accessibilityHint?: string
+        accessibilityLabel: string
+        accessibilityRole: AccessibilityRole
+      }
+    }

--- a/src/components/ContextMenu/types.ts
+++ b/src/components/ContextMenu/types.ts
@@ -16,8 +16,6 @@ export type Measurement = {
   y: number
   width: number
   height: number
-  pageX: number
-  pageY: number
 }
 
 export type ContextType = {

--- a/src/components/ContextMenu/types.ts
+++ b/src/components/ContextMenu/types.ts
@@ -37,6 +37,13 @@ export type ItemContextType = {
 export type TriggerProps = {
   children(props: TriggerChildProps): React.ReactNode
   label: string
+  /**
+   * When activated, this is the accessibility label for the entire thing that has been triggered.
+   * For example, if the trigger is a message bubble, use the message content.
+   *
+   * @platform ios, android
+   */
+  contentLabel: string
   hint?: string
   role?: AccessibilityRole
   style?: StyleProp<ViewStyle>

--- a/src/components/Menu/context.tsx
+++ b/src/components/Menu/context.tsx
@@ -2,14 +2,9 @@ import React from 'react'
 
 import type {ContextType, ItemContextType} from '#/components/Menu/types'
 
-export const Context = React.createContext<ContextType>({
-  // @ts-ignore
-  control: null,
-})
+export const Context = React.createContext<ContextType | null>(null)
 
-export const ItemContext = React.createContext<ItemContextType>({
-  disabled: false,
-})
+export const ItemContext = React.createContext<ItemContextType | null>(null)
 
 export function useMenuContext() {
   const context = React.useContext(Context)

--- a/src/components/Menu/index.tsx
+++ b/src/components/Menu/index.tsx
@@ -34,7 +34,7 @@ export function Root({
   children,
   control,
 }: React.PropsWithChildren<{
-  control?: Dialog.DialogOuterProps['control']
+  control?: Dialog.DialogControlProps
 }>) {
   const defaultControl = Dialog.useDialogControl()
   const context = React.useMemo<ContextType>(

--- a/src/components/Menu/index.web.tsx
+++ b/src/components/Menu/index.web.tsx
@@ -50,7 +50,7 @@ export function Root({
   children,
   control,
 }: React.PropsWithChildren<{
-  control?: Dialog.DialogOuterProps['control']
+  control?: Dialog.DialogControlProps
 }>) {
   const {_} = useLingui()
   const defaultControl = useMenuControl()

--- a/src/components/dms/ActionsWrapper.tsx
+++ b/src/components/dms/ActionsWrapper.tsx
@@ -1,22 +1,10 @@
-import React from 'react'
-import {Keyboard} from 'react-native'
-import {Gesture, GestureDetector} from 'react-native-gesture-handler'
-import Animated, {
-  cancelAnimation,
-  runOnJS,
-  useAnimatedStyle,
-  useSharedValue,
-  withTiming,
-} from 'react-native-reanimated'
+import {View} from 'react-native'
 import {ChatBskyConvoDefs} from '@atproto/api'
 import {msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
-import {HITSLOP_10} from '#/lib/constants'
-import {useHaptics} from '#/lib/haptics'
 import {atoms as a} from '#/alf'
-import {MessageMenu} from '#/components/dms/MessageMenu'
-import {useMenuControl} from '#/components/Menu'
+import {MessageContextMenu} from '#/components/dms/MessageContextMenu'
 
 export function ActionsWrapper({
   message,
@@ -28,71 +16,50 @@ export function ActionsWrapper({
   children: React.ReactNode
 }) {
   const {_} = useLingui()
-  const playHaptic = useHaptics()
-  const menuControl = useMenuControl()
-
-  const scale = useSharedValue(1)
-
-  const animatedStyle = useAnimatedStyle(() => ({
-    transform: [{scale: scale.get()}],
-  }))
-
-  const open = React.useCallback(() => {
-    playHaptic()
-    Keyboard.dismiss()
-    menuControl.open()
-  }, [menuControl, playHaptic])
-
-  const shrink = React.useCallback(() => {
-    'worklet'
-    cancelAnimation(scale)
-    scale.set(() => withTiming(1, {duration: 200}))
-  }, [scale])
-
-  const doubleTapGesture = Gesture.Tap()
-    .numberOfTaps(2)
-    .hitSlop(HITSLOP_10)
-    .onEnd(open)
-    .runOnJS(true)
-
-  const pressAndHoldGesture = Gesture.LongPress()
-    .onStart(() => {
-      'worklet'
-      scale.set(() =>
-        withTiming(1.05, {duration: 200}, finished => {
-          if (!finished) return
-          runOnJS(open)()
-          shrink()
-        }),
-      )
-    })
-    .onTouchesUp(shrink)
-    .onTouchesMove(shrink)
-    .cancelsTouchesInView(false)
-
-  const composedGestures = Gesture.Exclusive(
-    doubleTapGesture,
-    pressAndHoldGesture,
-  )
 
   return (
-    <GestureDetector gesture={composedGestures}>
-      <Animated.View
-        style={[
-          {
-            maxWidth: '80%',
-          },
-          isFromSelf ? a.self_end : a.self_start,
-          animatedStyle,
-        ]}
-        accessible={true}
-        accessibilityActions={[
-          {name: 'activate', label: _(msg`Open message options`)},
-        ]}
-        onAccessibilityAction={open}>
-        {children}
-        <MessageMenu message={message} control={menuControl} />
-      </Animated.View>
-    </GestureDetector>
+    <MessageContextMenu message={message}>
+      {trigger =>
+        // will always be true, since this file is platform split
+        trigger.isNative && (
+          <View style={[a.flex_1, a.relative]}>
+            {/* {isNative && (
+              <View
+                style={[
+                  a.rounded_full,
+                  a.absolute,
+                  {bottom: '100%'},
+                  isFromSelf ? a.right_0 : a.left_0,
+                  t.atoms.bg,
+                  a.flex_row,
+                  a.shadow_lg,
+                  a.py_xs,
+                  a.px_md,
+                  a.gap_md,
+                  a.mb_xs,
+                ]}>
+                {['👍', '😆', '❤️', '👀', '😢'].map(emoji => (
+                  <Text key={emoji} style={[a.text_center, {fontSize: 32}]}>
+                    {emoji}
+                  </Text>
+                ))}
+              </View>
+            )} */}
+            <View
+              style={[
+                {maxWidth: '80%'},
+                isFromSelf ? a.self_end : a.self_start,
+              ]}
+              accessible={true}
+              accessibilityActions={[
+                {name: 'activate', label: _(msg`Open message options`)},
+              ]}
+              onAccessibilityAction={trigger.control.open}>
+              {children}
+            </View>
+          </View>
+        )
+      }
+    </MessageContextMenu>
   )
 }

--- a/src/components/dms/ActionsWrapper.tsx
+++ b/src/components/dms/ActionsWrapper.tsx
@@ -48,7 +48,9 @@ export function ActionsWrapper({
             <View
               style={[
                 {maxWidth: '80%'},
-                isFromSelf ? a.self_end : a.self_start,
+                isFromSelf
+                  ? [a.self_end, a.align_end]
+                  : [a.self_start, a.align_start],
               ]}
               accessible={true}
               accessibilityActions={[

--- a/src/components/dms/ActionsWrapper.web.tsx
+++ b/src/components/dms/ActionsWrapper.web.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
-import {StyleSheet, View} from 'react-native'
+import {Pressable, View} from 'react-native'
 import {ChatBskyConvoDefs} from '@atproto/api'
 
-import {atoms as a} from '#/alf'
-import {MessageMenu} from '#/components/dms/MessageMenu'
-import {useMenuControl} from '#/components/Menu'
+import {atoms as a, useTheme} from '#/alf'
+import {MessageContextMenu} from '#/components/dms/MessageContextMenu'
+import {DotGrid_Stroke2_Corner0_Rounded as DotsHorizontalIcon} from '../icons/DotGrid'
 
 export function ActionsWrapper({
   message,
@@ -15,8 +15,8 @@ export function ActionsWrapper({
   isFromSelf: boolean
   children: React.ReactNode
 }) {
-  const menuControl = useMenuControl()
   const viewRef = React.useRef(null)
+  const t = useTheme()
 
   const [showActions, setShowActions] = React.useState(false)
 
@@ -42,39 +42,36 @@ export function ActionsWrapper({
       onMouseLeave={onMouseLeave}
       onFocus={onFocus}
       onBlur={onMouseLeave}
-      style={StyleSheet.flatten([a.flex_1, a.flex_row])}
+      style={[a.flex_1, isFromSelf ? a.flex_row : a.flex_row_reverse]}
       ref={viewRef}>
-      {isFromSelf && (
-        <View
-          style={[
-            a.mr_xl,
-            a.justify_center,
-            {
-              marginLeft: 'auto',
-            },
-          ]}>
-          <MessageMenu
-            message={message}
-            control={menuControl}
-            triggerOpacity={showActions || menuControl.isOpen ? 1 : 0}
-          />
-        </View>
-      )}
       <View
-        style={{
-          maxWidth: '80%',
-        }}>
-        {children}
+        style={[
+          a.justify_center,
+          isFromSelf
+            ? [a.mr_xl, {marginLeft: 'auto'}]
+            : [a.ml_xl, {marginRight: 'auto'}],
+        ]}>
+        <MessageContextMenu message={message}>
+          {({props, state, isNative, control}) => {
+            // always false, file is platform split
+            if (isNative) return null
+            const showMenuTrigger = showActions || control.isOpen ? 1 : 0
+            return (
+              <Pressable
+                {...props}
+                style={[
+                  {opacity: showMenuTrigger},
+                  a.p_sm,
+                  a.rounded_full,
+                  (state.hovered || state.pressed) && t.atoms.bg_contrast_25,
+                ]}>
+                <DotsHorizontalIcon size="md" style={t.atoms.text} />
+              </Pressable>
+            )
+          }}
+        </MessageContextMenu>
       </View>
-      {!isFromSelf && (
-        <View style={[a.flex_row, a.align_center, a.ml_xl]}>
-          <MessageMenu
-            message={message}
-            control={menuControl}
-            triggerOpacity={showActions || menuControl.isOpen ? 1 : 0}
-          />
-        </View>
-      )}
+      <View style={{maxWidth: '80%'}}>{children}</View>
     </View>
   )
 }

--- a/src/components/dms/ActionsWrapper.web.tsx
+++ b/src/components/dms/ActionsWrapper.web.tsx
@@ -71,7 +71,10 @@ export function ActionsWrapper({
           }}
         </MessageContextMenu>
       </View>
-      <View style={{maxWidth: '80%'}}>{children}</View>
+      <View
+        style={[{maxWidth: '80%'}, isFromSelf ? a.align_end : a.align_start]}>
+        {children}
+      </View>
     </View>
   )
 }

--- a/src/components/dms/MessageContextMenu.tsx
+++ b/src/components/dms/MessageContextMenu.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import {LayoutAnimation, Pressable, View} from 'react-native'
+import {LayoutAnimation} from 'react-native'
 import * as Clipboard from 'expo-clipboard'
 import {ChatBskyConvoDefs, RichText} from '@atproto/api'
 import {msg} from '@lingui/macro'
@@ -8,33 +8,28 @@ import {useLingui} from '@lingui/react'
 import {useOpenLink} from '#/lib/hooks/useOpenLink'
 import {richTextToString} from '#/lib/strings/rich-text-helpers'
 import {getTranslatorLink} from '#/locale/helpers'
-import {isWeb} from '#/platform/detection'
 import {useConvoActive} from '#/state/messages/convo'
 import {useLanguagePrefs} from '#/state/preferences'
 import {useSession} from '#/state/session'
 import * as Toast from '#/view/com/util/Toast'
-import {atoms as a, useTheme} from '#/alf'
+import * as ContextMenu from '#/components/ContextMenu'
+import {TriggerProps} from '#/components/ContextMenu/types'
 import {ReportDialog} from '#/components/dms/ReportDialog'
 import {BubbleQuestion_Stroke2_Corner0_Rounded as Translate} from '#/components/icons/Bubble'
-import {DotGrid_Stroke2_Corner0_Rounded as DotsHorizontal} from '#/components/icons/DotGrid'
+import {Clipboard_Stroke2_Corner2_Rounded as ClipboardIcon} from '#/components/icons/Clipboard'
 import {Trash_Stroke2_Corner0_Rounded as Trash} from '#/components/icons/Trash'
 import {Warning_Stroke2_Corner0_Rounded as Warning} from '#/components/icons/Warning'
-import * as Menu from '#/components/Menu'
 import * as Prompt from '#/components/Prompt'
 import {usePromptControl} from '#/components/Prompt'
-import {Clipboard_Stroke2_Corner2_Rounded as ClipboardIcon} from '../icons/Clipboard'
 
-export let MessageMenu = ({
+export let MessageContextMenu = ({
   message,
-  control,
-  triggerOpacity,
+  children,
 }: {
-  triggerOpacity?: number
   message: ChatBskyConvoDefs.MessageView
-  control: Menu.MenuControlProps
+  children: TriggerProps['children']
 }): React.ReactNode => {
   const {_} = useLingui()
-  const t = useTheme()
   const {currentAccount} = useSession()
   const convo = useConvoActive()
   const deleteControl = usePromptControl()
@@ -77,67 +72,51 @@ export let MessageMenu = ({
 
   return (
     <>
-      <Menu.Root control={control}>
-        {isWeb && (
-          <View style={{opacity: triggerOpacity}}>
-            <Menu.Trigger label={_(msg`Chat settings`)}>
-              {({props, state}) => (
-                <Pressable
-                  {...props}
-                  style={[
-                    a.p_sm,
-                    a.rounded_full,
-                    (state.hovered || state.pressed) && t.atoms.bg_contrast_25,
-                  ]}>
-                  <DotsHorizontal size="md" style={t.atoms.text} />
-                </Pressable>
-              )}
-            </Menu.Trigger>
-          </View>
-        )}
+      <ContextMenu.Root>
+        <ContextMenu.Trigger label={_(msg`Message options`)}>
+          {children}
+        </ContextMenu.Trigger>
 
-        <Menu.Outer>
+        <ContextMenu.Outer align={isFromSelf ? 'right' : 'left'}>
           {message.text.length > 0 && (
             <>
-              <Menu.Group>
-                <Menu.Item
-                  testID="messageDropdownTranslateBtn"
-                  label={_(msg`Translate`)}
-                  onPress={onPressTranslateMessage}>
-                  <Menu.ItemText>{_(msg`Translate`)}</Menu.ItemText>
-                  <Menu.ItemIcon icon={Translate} position="right" />
-                </Menu.Item>
-                <Menu.Item
-                  testID="messageDropdownCopyBtn"
-                  label={_(msg`Copy message text`)}
-                  onPress={onCopyMessage}>
-                  <Menu.ItemText>{_(msg`Copy message text`)}</Menu.ItemText>
-                  <Menu.ItemIcon icon={ClipboardIcon} position="right" />
-                </Menu.Item>
-              </Menu.Group>
-              <Menu.Divider />
+              <ContextMenu.Item
+                testID="messageDropdownTranslateBtn"
+                label={_(msg`Translate`)}
+                onPress={onPressTranslateMessage}>
+                <ContextMenu.ItemText>{_(msg`Translate`)}</ContextMenu.ItemText>
+                <ContextMenu.ItemIcon icon={Translate} position="right" />
+              </ContextMenu.Item>
+              <ContextMenu.Item
+                testID="messageDropdownCopyBtn"
+                label={_(msg`Copy message text`)}
+                onPress={onCopyMessage}>
+                <ContextMenu.ItemText>
+                  {_(msg`Copy message text`)}
+                </ContextMenu.ItemText>
+                <ContextMenu.ItemIcon icon={ClipboardIcon} position="right" />
+              </ContextMenu.Item>
+              <ContextMenu.Divider />
             </>
           )}
-          <Menu.Group>
-            <Menu.Item
-              testID="messageDropdownDeleteBtn"
-              label={_(msg`Delete message for me`)}
-              onPress={() => deleteControl.open()}>
-              <Menu.ItemText>{_(msg`Delete for me`)}</Menu.ItemText>
-              <Menu.ItemIcon icon={Trash} position="right" />
-            </Menu.Item>
-            {!isFromSelf && (
-              <Menu.Item
-                testID="messageDropdownReportBtn"
-                label={_(msg`Report message`)}
-                onPress={() => reportControl.open()}>
-                <Menu.ItemText>{_(msg`Report`)}</Menu.ItemText>
-                <Menu.ItemIcon icon={Warning} position="right" />
-              </Menu.Item>
-            )}
-          </Menu.Group>
-        </Menu.Outer>
-      </Menu.Root>
+          <ContextMenu.Item
+            testID="messageDropdownDeleteBtn"
+            label={_(msg`Delete message for me`)}
+            onPress={() => deleteControl.open()}>
+            <ContextMenu.ItemText>{_(msg`Delete for me`)}</ContextMenu.ItemText>
+            <ContextMenu.ItemIcon icon={Trash} position="right" />
+          </ContextMenu.Item>
+          {!isFromSelf && (
+            <ContextMenu.Item
+              testID="messageDropdownReportBtn"
+              label={_(msg`Report message`)}
+              onPress={() => reportControl.open()}>
+              <ContextMenu.ItemText>{_(msg`Report`)}</ContextMenu.ItemText>
+              <ContextMenu.ItemIcon icon={Warning} position="right" />
+            </ContextMenu.Item>
+          )}
+        </ContextMenu.Outer>
+      </ContextMenu.Root>
 
       <ReportDialog
         currentScreen="conversation"
@@ -158,4 +137,4 @@ export let MessageMenu = ({
     </>
   )
 }
-MessageMenu = React.memo(MessageMenu)
+MessageContextMenu = React.memo(MessageContextMenu)

--- a/src/components/dms/MessageContextMenu.tsx
+++ b/src/components/dms/MessageContextMenu.tsx
@@ -70,10 +70,21 @@ export let MessageContextMenu = ({
       .catch(() => Toast.show(_(msg`Failed to delete message`)))
   }, [_, convo, message.id])
 
+  const sender = convo.convo.members.find(
+    member => member.did === message.sender.did,
+  )
+
   return (
     <>
       <ContextMenu.Root>
-        <ContextMenu.Trigger label={_(msg`Message options`)}>
+        <ContextMenu.Trigger
+          label={_(msg`Message options`)}
+          contentLabel={_(
+            msg`Message from @${
+              sender?.handle ?? // should always be defined
+              'unknown'
+            }: ${message.text}`,
+          )}>
           {children}
         </ContextMenu.Trigger>
 

--- a/src/components/dms/MessageItemEmbed.tsx
+++ b/src/components/dms/MessageItemEmbed.tsx
@@ -1,9 +1,9 @@
 import React from 'react'
-import {View} from 'react-native'
+import {useWindowDimensions, View} from 'react-native'
 import {AppBskyEmbedRecord} from '@atproto/api'
 
 import {PostEmbeds, PostEmbedViewContext} from '#/view/com/util/post-embeds'
-import {atoms as a, native, useTheme} from '#/alf'
+import {atoms as a, native, tokens, useTheme} from '#/alf'
 import {MessageContextProvider} from './MessageContext'
 
 let MessageItemEmbed = ({
@@ -12,15 +12,25 @@ let MessageItemEmbed = ({
   embed: AppBskyEmbedRecord.View
 }): React.ReactNode => {
   const t = useTheme()
+  const screen = useWindowDimensions()
 
   return (
     <MessageContextProvider>
-      <View style={[a.my_xs, t.atoms.bg, a.rounded_md, native({flexBasis: 0})]}>
-        <PostEmbeds
-          embed={embed}
-          allowNestedQuotes
-          viewContext={PostEmbedViewContext.Feed}
-        />
+      <View
+        style={[
+          a.my_xs,
+          t.atoms.bg,
+          a.rounded_md,
+          native({flexBasis: 0}),
+          {width: Math.min(screen.width, 600) / 1.7},
+        ]}>
+        <View style={{marginTop: tokens.space.sm * -1}}>
+          <PostEmbeds
+            embed={embed}
+            allowNestedQuotes
+            viewContext={PostEmbedViewContext.Feed}
+          />
+        </View>
       </View>
     </MessageContextProvider>
   )

--- a/src/components/dms/MessageItemEmbed.tsx
+++ b/src/components/dms/MessageItemEmbed.tsx
@@ -3,7 +3,7 @@ import {useWindowDimensions, View} from 'react-native'
 import {AppBskyEmbedRecord} from '@atproto/api'
 
 import {PostEmbeds, PostEmbedViewContext} from '#/view/com/util/post-embeds'
-import {atoms as a, native, tokens, useTheme} from '#/alf'
+import {atoms as a, native, tokens, useTheme,web} from '#/alf'
 import {MessageContextProvider} from './MessageContext'
 
 let MessageItemEmbed = ({
@@ -21,8 +21,15 @@ let MessageItemEmbed = ({
           a.my_xs,
           t.atoms.bg,
           a.rounded_md,
-          native({flexBasis: 0}),
-          {width: Math.min(screen.width, 600) / 1.7},
+          native({
+            flexBasis: 0,
+            width: Math.min(screen.width, 600) / 1.4,
+          }),
+          web({
+            width: '100%',
+            minWidth: 280,
+            maxWidth: 360,
+          }),
         ]}>
         <View style={{marginTop: tokens.space.sm * -1}}>
           <PostEmbeds

--- a/src/components/dms/MessageItemEmbed.tsx
+++ b/src/components/dms/MessageItemEmbed.tsx
@@ -3,7 +3,7 @@ import {useWindowDimensions, View} from 'react-native'
 import {AppBskyEmbedRecord} from '@atproto/api'
 
 import {PostEmbeds, PostEmbedViewContext} from '#/view/com/util/post-embeds'
-import {atoms as a, native, tokens, useTheme,web} from '#/alf'
+import {atoms as a, native, tokens, useTheme, web} from '#/alf'
 import {MessageContextProvider} from './MessageContext'
 
 let MessageItemEmbed = ({

--- a/src/components/dms/MessageItemEmbed.tsx
+++ b/src/components/dms/MessageItemEmbed.tsx
@@ -15,7 +15,7 @@ let MessageItemEmbed = ({
 
   return (
     <MessageContextProvider>
-      <View style={[a.my_xs, t.atoms.bg, native({flexBasis: 0})]}>
+      <View style={[a.my_xs, t.atoms.bg, a.rounded_md, native({flexBasis: 0})]}>
         <PostEmbeds
           embed={embed}
           allowNestedQuotes


### PR DESCRIPTION
Motivation: add a place to add emoji reactions (will be stacked on top of this PR)

This is a new kind of menu, similar to `Menu` on web (and in fact is just a `Menu` on web). On native, it presents a long press menu where the trigger is highlighted and a compact menu presented beneath. 

Double tap will eventually be used to _just_ show the reaction bar, but for now it also opens the menu.

## iOS

https://github.com/user-attachments/assets/35ce98d5-d3e9-4b70-95e9-f08a877ed9d6


## Android

https://github.com/user-attachments/assets/29347f05-78af-4d18-99a3-02b6ce608779

## How it works

The trigger has a RNGH gesture detector on it. When the gesture triggers, it measures the size/position of the trigger element, and renders a PNG of the element using `react-native-view-shot`. This image is then portal-ed to root, along with the menu itself (and a blur background). All elements are then positioned based on the measurements. A single shared value with a spring animation drives the fade/scale/translation animations of all the elements, so that everything is in sync.

## Stretch goal

It would be nice if the menu could be used by just keeping your finger pressed and then moving it over an option and lifting, like on native iOS menus. However, I don't see an obvious way to achieve this, will probably require RNGH hacks

## Test plan

Test iOS/Android. Test long press, double tap. Confirm you can use the menu and dismiss it. Confirm the menu is _always_ on screen, no matter the position/length of the message. Test android perf on device, and check safe areas on android (can be finnicky). Confirm a11y is ok.
Confirm web is unchanged.
