### PR TITLE
[Android] Save photos to "Bluesky" folder

### DIFF
--- a/src/components/StarterPack/ShareDialog.tsx
+++ b/src/components/StarterPack/ShareDialog.tsx
@@ -73,7 +73,7 @@ function ShareDialogInner({
 
     try {
       await saveImageToMediaLibrary({uri: imageUrl})
-      Toast.show(_(msg`Image saved to your camera roll!`))
+      Toast.show(_(msg`Image saved`))
       control.close()
     } catch (e: unknown) {
       Toast.show(_(msg`An error occurred while saving the QR code!`), 'xmark')

--- a/src/view/com/lightbox/Lightbox.tsx
+++ b/src/view/com/lightbox/Lightbox.tsx
@@ -41,7 +41,7 @@ export function Lightbox() {
       }
       try {
         await saveImageToMediaLibrary({uri})
-        Toast.show(_(msg`Saved to your camera roll`))
+        Toast.show(_(msg`Image saved`))
       } catch (e: any) {
         Toast.show(_(msg`Failed to save image: ${String(e)}`), 'xmark')
       }


### PR DESCRIPTION
Fixes https://github.com/bluesky-social/social-app/issues/1360

Saves images on android to a "Bluesky" folder, rather than DCIM.

<img width="200" alt="Screenshot 2025-04-28 at 20 57 58" src="https://github.com/user-attachments/assets/aaf5fb11-a933-464b-9767-bba1b863186c" />

# Test plan:

Save 2 or more images. The first image will create the album, the second will be placed directly into the album.
Confirm there are no annoying permission prompts when saving.

---

#### Previous PR description prior to SDK 53 upgrade

Works fine, except it pops up a permission prompt every time, which is probably a deal-breaker. ~~Looking into workarounds.~~ ~~Waiting on upstream fix 🎉~~ ~~Need these PRs for `expo-media-library` to land (will be SDK-53)~~ Lets goooo:
- https://github.com/expo/expo/pull/35686
- https://github.com/expo/expo/pull/35692
