### PR TITLE
Add video volume to persisted state

### DIFF
--- a/src/components/Post/Embed/VideoEmbed/VideoVolumeContext.tsx
+++ b/src/components/Post/Embed/VideoEmbed/VideoVolumeContext.tsx
@@ -1,17 +1,19 @@
 import {createContext, useContext, useMemo, useState} from 'react'
 
+import {device, useStorage} from '#/storage'
+
 const Context = createContext<{
   muted: boolean
-  setMuted: React.Dispatch<React.SetStateAction<boolean>>
+  setMuted: (v: boolean) => void
   // web
   volume: number
-  setVolume: React.Dispatch<React.SetStateAction<number>>
+  setVolume: (v: number) => void
 } | null>(null)
 Context.displayName = 'VideoVolumeContext'
 
 export function Provider({children}: {children: React.ReactNode}) {
   const [muted, setMuted] = useState(true)
-  const [volume, setVolume] = useState(1)
+  const [volume = 1, setVolume] = useStorage(device, ['videoVolume'])
 
   const value = useMemo(
     () => ({

--- a/src/storage/schema.ts
+++ b/src/storage/schema.ts
@@ -66,6 +66,7 @@ export type Device = {
    */
   policyUpdateDebugOverride?: boolean
   [PolicyUpdate202508]?: boolean
+  videoVolume: number
 }
 
 export type Account = {


### PR DESCRIPTION
Store video volume state in localStorage, just like Twitter. Closes #7124 

~~Not entirely sure if it's necessary but I've also separated the volume and mute state Contexts and only included the mute state Provider on native as it doesn't use in-player volume controls. I've also moved them to `#/state/video` as that seems to be where everything that persists state is located, but let me know if that's not the right place.~~ No longer the case

Tested on web and Android.