### PR TITLE
Fix post thread item hider line height crop

### DIFF
--- a/src/components/moderation/PostHider.tsx
+++ b/src/components/moderation/PostHider.tsx
@@ -114,7 +114,9 @@ export function PostHider({
           <desc.icon size="sm" fill={t.atoms.text_contrast_medium.color} />
         </View>
       </Pressable>
-      <Text style={[t.atoms.text_contrast_medium, a.flex_1]} numberOfLines={1}>
+      <Text
+        style={[t.atoms.text_contrast_medium, a.flex_1, a.leading_snug]}
+        numberOfLines={1}>
         {desc.name}
       </Text>
       {!modui.noOverride && (

--- a/src/view/com/post-thread/PostThread.tsx
+++ b/src/view/com/post-thread/PostThread.tsx
@@ -122,7 +122,7 @@ export function PostThread({uri}: {uri: string | undefined}) {
   const serverTreeViewEnabled = serverPrefs?.lab_treeViewEnabled ?? false
   const serverSortReplies = serverPrefs?.sort ?? 'hotness'
 
-  // However, we also need these to work locally for PWI (without persistance).
+  // However, we also need these to work locally for PWI (without persistence).
   // So we're mirroring them locally.
   const prioritizeFollowedUsers = serverPrioritizeFollowedUsers
   const [treeViewEnabled, setTreeViewEnabled] = useState(serverTreeViewEnabled)
@@ -566,7 +566,6 @@ export function PostThread({uri}: {uri: string | undefined}) {
               ? MAINTAIN_VISIBLE_CONTENT_POSITION
               : undefined
           }
-          // @ts-ignore our .web version only -prf
           desktopFixedHeight
           removeClippedSubviews={isAndroid ? false : undefined}
           ListFooterComponent={

--- a/src/view/com/post-thread/PostThreadShowHiddenReplies.tsx
+++ b/src/view/com/post-thread/PostThreadShowHiddenReplies.tsx
@@ -51,7 +51,7 @@ export function PostThreadShowHiddenReplies({
             <EyeSlash size="sm" fill={t.atoms.text_contrast_medium.color} />
           </View>
           <Text
-            style={[t.atoms.text_contrast_medium, a.flex_1]}
+            style={[t.atoms.text_contrast_medium, a.flex_1, a.leading_snug]}
             numberOfLines={1}>
             {label}
           </Text>


### PR DESCRIPTION
Fixes some line height based cropping
<table>
  <tr>
    <th>Before 1</th>
    <th>After 1</th>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/1530ea7a-ae62-4be4-8707-b4ea1fa1b5e5" width="400" alt="Before Screenshot 1" /></td>
    <td><img src="https://github.com/user-attachments/assets/f320cd3f-f7e4-40af-bcf2-246a0da7a4d9" width="400" alt="After Screenshot 1" /></td>
  </tr>
  <tr>
    <th>Before 2</th>
    <th>After 2</th>
  </tr>
  <tr>
    <td><img src="https://github.com/user-attachments/assets/072f0b1c-4ebe-49bc-9923-ebb6d07c2344" width="400" alt="Before Screenshot 2" /></td>
    <td><img src="https://github.com/user-attachments/assets/6dcc1515-992a-430c-b3db-6b07f1f0389d" width="400" alt="After Screenshot 2" /></td>
  </tr>
</table>
