### PR TITLE
Increase Labeler Subscription Limit

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -173,7 +173,7 @@ export const GIF_SEARCH = (params: string) =>
 export const GIF_FEATURED = (params: string) =>
   `${GIF_SERVICE}/tenor/v2/featured?${params}`
 
-export const MAX_LABELERS = 20
+export const MAX_LABELERS = 30
 
 export const VIDEO_SERVICE = 'https://video.bsky.app'
 export const VIDEO_SERVICE_DID = 'did:web:video.bsky.app'

--- a/src/screens/Profile/Header/ProfileHeaderLabeler.tsx
+++ b/src/screens/Profile/Header/ProfileHeaderLabeler.tsx
@@ -354,8 +354,8 @@ function CantSubscribePrompt({
       <Prompt.TitleText>Unable to subscribe</Prompt.TitleText>
       <Prompt.DescriptionText>
         <Trans>
-          We're sorry! You can only subscribe to twenty labelers, and you've
-          reached your limit of twenty.
+          We're sorry! You can only subscribe to thirty labelers, and you've
+          reached your limit of thirty.
         </Trans>
       </Prompt.DescriptionText>
       <Prompt.Actions>


### PR DESCRIPTION
This is a draft PR for tracking the changes required for #5618 "Increase Labeler Subscription Limit".

Currently no decision has been made to increase the limit, or to what it would be increased to if it were, but these are the relevant files if the constant and strings need to be changed. I've used 30 for this draft.

During the build process the relevant `.po` localization files should be generated and ready for translation on Crowdin from what I've read in [the localization instructions.](https://github.com/bluesky-social/social-app/blob/main/docs/localization.md)

EDIT 03/28/25: For clarity, the included changes would allow the Bluesky client to subscribe to additional labels and include them on requests, but the Bluesky Appview will only respond with 20 labelers. E.g. this is only one half of the required changes.