### PR TITLE
Make the right sidebar smaller when offset, reduce total offset

### DIFF
--- a/src/alf/breakpoints.ts
+++ b/src/alf/breakpoints.ts
@@ -31,8 +31,8 @@ export function useBreakpoints(): Record<Breakpoint, boolean> & {
  * Fine-tuned breakpoints for the shell layout
  */
 export function useLayoutBreakpoints() {
-  const rightNavVisible = useMediaQuery({minWidth: 1075})
-  const centerColumnOffset = useMediaQuery({minWidth: 1075, maxWidth: 1300})
+  const rightNavVisible = useMediaQuery({minWidth: 1100})
+  const centerColumnOffset = useMediaQuery({minWidth: 1100, maxWidth: 1300})
   const leftNavMinimal = useMediaQuery({maxWidth: 1300})
 
   return {

--- a/src/components/Layout/const.ts
+++ b/src/components/Layout/const.ts
@@ -18,4 +18,4 @@ export const HEADER_SLOT_SIZE = 34
 /**
  * How far to shift the center column when in the tablet breakpoint
  */
-export const CENTER_COLUMN_OFFSET = -130
+export const CENTER_COLUMN_OFFSET = -105

--- a/src/view/shell/desktop/RightNav.tsx
+++ b/src/view/shell/desktop/RightNav.tsx
@@ -58,6 +58,8 @@ export function DesktopRightNav({routeName}: {routeName: string}) {
     return null
   }
 
+  const width = centerColumnOffset ? 250 : 300
+
   return (
     <View
       style={[
@@ -67,10 +69,12 @@ export function DesktopRightNav({routeName}: {routeName: string}) {
           position: 'fixed',
           left: '50%',
           transform: [
-            {translateX: 300 + (centerColumnOffset ? CENTER_COLUMN_OFFSET : 0)},
+            {
+              translateX: 300 + (centerColumnOffset ? CENTER_COLUMN_OFFSET : 0),
+            },
             ...a.scrollbar_offset.transform,
           ],
-          width: 300 + gutters.paddingLeft,
+          width: width + gutters.paddingLeft,
           maxHeight: '100%',
           overflowY: 'auto',
         }),


### PR DESCRIPTION
Aim: reduce the intensity of the offset when in the tablet breakpoint
Solution: reduce the width of the sidebar when in that breakpoint, so less offset is required to keep things centered. Also, slightly reduce the range of the breakpoint, so that the min-sized right nav doesn't reach the edge of the screen

# Before

https://github.com/user-attachments/assets/03cb90d1-1379-4167-82f5-55a577b82142



# After


https://github.com/user-attachments/assets/6088b5a3-a22a-4640-9c6c-1a5a6735eabc

