### PR TITLE
Remove double decode of URI

### DIFF
--- a/bskylink/src/routes/redirect.ts
+++ b/bskylink/src/routes/redirect.ts
@@ -21,7 +21,6 @@ export default function (ctx: AppContext, app: Express) {
         typeof link === 'string',
         'express guarantees link query parameter is a string',
       )
-      link = decodeURIComponent(link)
 
       let url: URL | undefined
       try {


### PR DESCRIPTION
At this point the URI is already decoded and decoding again will alter the uri 

```
      let link = req.query.u
```

example  of a link that has `%` encoding... the initial redirect link is properly encoded.

```
curl -vv "https://go.bsky.app/redirect?u=https%3A%2F%2Fsurf.social%2Ffeed%2Fsurf%252Fcustom%252F01jpz5vyjwvw5yaa8bfkha5xn4" 
```
The result is "double decoded", the proper link in this case should be `https://surf.social/feed/surf%2Fcustom%2F01jpz5vyjwvw5yaa8bfkha5xn4`

```
<html><head><meta http-equiv="refresh" content="0; URL='https://surf.social/feed/surf/custom/01jpz5vyjwvw5yaa8bfkha5xn4'" /><style>:root { color-scheme: light dark; }</style></head></html>
```

After changes:

```
curl -s "http://localhost:3000/redirect?u=https%3A%2F%2Fsurf.social%2Ffeed%2Fsurf%252Fcustom%252F01jpz5vyjwvw5yaa8bfkha5xn4"
<html><head><meta http-equiv="refresh" content="0; URL='https://surf.social/feed/surf%2Fcustom%2F01jpz5vyjwvw5yaa8bfkha5xn4'" /><style>:root { color-scheme: light dark; }</style></head></html>
```