### PR TITLE
[Reactions] Get reactions in chat list working again with new lexicon

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "icons:optimize": "svgo -f ./assets/icons"
   },
   "dependencies": {
-    "@atproto/api": "^0.14.14",
+    "@atproto/api": "^0.14.16",
     "@bitdrift/react-native": "^0.6.8",
     "@braintree/sanitize-url": "^6.0.2",
     "@discord/bottom-sheet": "bluesky-social/react-native-bottom-sheet",

--- a/src/components/dms/EmojiReactionPicker.tsx
+++ b/src/components/dms/EmojiReactionPicker.tsx
@@ -95,9 +95,9 @@ export function EmojiReactionPicker({
                           ? t.palette.negative_100
                           : t.palette.primary_500,
                       }
-                    : alreadyReacted && {
-                        backgroundColor: t.palette.primary_200,
-                      },
+                    : alreadyReacted
+                    ? {backgroundColor: t.palette.primary_200}
+                    : t.atoms.bg,
                   {height: 40, width: 40},
                   a.justify_center,
                   a.align_center,

--- a/src/screens/Messages/components/ChatListItem.tsx
+++ b/src/screens/Messages/components/ChatListItem.tsx
@@ -185,50 +185,61 @@ function ChatListItemReady({
         lastMessageSentAt = convo.lastMessage.sentAt
       }
       if (ChatBskyConvoDefs.isDeletedMessageView(convo.lastMessage)) {
+        lastMessageSentAt = convo.lastMessage.sentAt
+
         lastMessage = isDeletedAccount
           ? _(msg`Conversation deleted`)
           : _(msg`Message deleted`)
       }
-      if (ChatBskyConvoDefs.isMessageAndReactionView(convo.lastMessage)) {
-        const isFromMe =
-          convo.lastMessage.reaction.sender.did === currentAccount?.did
-        const lastMessageText = convo.lastMessage.message.text
-        const fallbackMessage = _(
-          msg({
-            message: 'a message',
-            comment: `If last message does not contain text, fall back to "{user} reacted to {a message}"`,
-          }),
-        )
 
-        if (isFromMe) {
-          lastMessage = _(
-            msg`You reacted ${convo.lastMessage.reaction.value} to ${
-              lastMessageText
-                ? `"${convo.lastMessage.message.text}"`
-                : fallbackMessage
-            }`,
+      if (ChatBskyConvoDefs.isMessageAndReactionView(convo.lastReaction)) {
+        if (
+          !lastMessageSentAt ||
+          new Date(lastMessageSentAt) <
+            new Date(convo.lastReaction.reaction.createdAt)
+        ) {
+          const isFromMe =
+            convo.lastReaction.reaction.sender.did === currentAccount?.did
+          const lastMessageText = convo.lastReaction.message.text
+          const fallbackMessage = _(
+            msg({
+              message: 'a message',
+              comment: `If last message does not contain text, fall back to "{user} reacted to {a message}"`,
+            }),
           )
-        } else {
-          const senderDid = convo.lastMessage.reaction.sender.did
-          const sender = convo.members.find(member => member.did === senderDid)
-          if (sender) {
+
+          if (isFromMe) {
             lastMessage = _(
-              msg`${sanitizeDisplayName(
-                sender.displayName || sender.handle,
-              )} reacted ${convo.lastMessage.reaction.value} to ${
+              msg`You reacted ${convo.lastReaction.reaction.value} to ${
                 lastMessageText
-                  ? `"${convo.lastMessage.message.text}"`
+                  ? `"${convo.lastReaction.message.text}"`
                   : fallbackMessage
               }`,
             )
           } else {
-            lastMessage = _(
-              msg`Someone reacted ${convo.lastMessage.reaction.value} to ${
-                lastMessageText
-                  ? `"${convo.lastMessage.message.text}"`
-                  : fallbackMessage
-              }`,
+            const senderDid = convo.lastReaction.reaction.sender.did
+            const sender = convo.members.find(
+              member => member.did === senderDid,
             )
+            if (sender) {
+              lastMessage = _(
+                msg`${sanitizeDisplayName(
+                  sender.displayName || sender.handle,
+                )} reacted ${convo.lastReaction.reaction.value} to ${
+                  lastMessageText
+                    ? `"${convo.lastReaction.message.text}"`
+                    : fallbackMessage
+                }`,
+              )
+            } else {
+              lastMessage = _(
+                msg`Someone reacted ${convo.lastReaction.reaction.value} to ${
+                  lastMessageText
+                    ? `"${convo.lastReaction.message.text}"`
+                    : fallbackMessage
+                }`,
+              )
+            }
           }
         }
       }
@@ -241,6 +252,7 @@ function ChatListItemReady({
     }, [
       _,
       convo.lastMessage,
+      convo.lastReaction,
       currentAccount?.did,
       isDeletedAccount,
       convo.members,

--- a/yarn.lock
+++ b/yarn.lock
@@ -80,10 +80,10 @@
     tlds "^1.234.0"
     zod "^3.23.8"
 
-"@atproto/api@^0.14.14":
-  version "0.14.14"
-  resolved "https://registry.yarnpkg.com/@atproto/api/-/api-0.14.14.tgz#5d2d2e6156eab6ca0d463c114b4a3865275e9aac"
-  integrity sha512-ryawcnmazVSWYfq11ujPHauY77GfkM3mF0rZOkqENN2Ptnl6BZXJvpA0zLA/sQ5YBLcHXSEWg5Xdq+8i1l+8gA==
+"@atproto/api@^0.14.16":
+  version "0.14.16"
+  resolved "https://registry.yarnpkg.com/@atproto/api/-/api-0.14.16.tgz#7b59eb83a27e906e0dc442d3de0f0d3869092b4a"
+  integrity sha512-xzUK3KVdp1TDJJ09Di2rvS/fisVctvMHO7Er0XhYviL3V4lxGQPNT3pHwbTbbb22QP7xH/d5ghCgfdIoS5Z8/A==
   dependencies:
     "@atproto/common-web" "^0.4.0"
     "@atproto/lexicon" "^0.4.9"


### PR DESCRIPTION
For backwards compatibility, we removed `messageAndReactionView` from the union in `lastMessage` and added a new field `lastReaction`. We now have to compare the sentAt/createdAt dates to decide which one to show.

Also includes a minor android style fix on the reaction palette

# Test plan

Send messages and add/remove reactions in various orders and confirm the chat list is looking as it should
Confirm the log updates work correctly - esp. removing reactions