### PR TITLE
Keep profile preview open on new-tab link click

### DIFF
--- a/src/components/ProfileHoverCard/index.web.tsx
+++ b/src/components/ProfileHoverCard/index.web.tsx
@@ -290,7 +290,10 @@ export function ProfileHoverCardInner(props: ProfileHoverCardProps) {
     dispatch('unhovered-card')
   }, [])
 
-  const onPress = React.useCallback(() => {
+  const onPress = React.useCallback((event?: React.MouseEvent) => {
+    if (event?.ctrlKey) {
+      return
+    }
     dispatch('pressed')
   }, [])
 


### PR DESCRIPTION
Fixes #7224: Previously, when Ctrl-clicking a link in a profile preview, the preview would close immediately. This happened because the onPress callback always dispatched a 'pressed' event, which triggered the preview to close.
To fix this, I modified the onPress function to accept an optional `React.MouseEvent` parameter. The function now checks if `event?.ctrlKey` is true before dispatching 'pressed'. If Ctrl is pressed, the function returns early, preventing the preview from closing. This ensures that users can open multiple links from a profile preview without losing visibility of the preview itself.