### PR TITLE
Fix background color in emoji reactions

### DIFF
--- a/src/components/dms/EmojiReactionPicker.tsx
+++ b/src/components/dms/EmojiReactionPicker.tsx
@@ -53,15 +53,17 @@ export function EmojiReactionPicker({
 
   const limitReacted = hasReachedReactionLimit(message, currentAccount?.did)
 
+  const bgColor = t.scheme === 'light' ? t.atoms.bg : t.atoms.bg_contrast_25
+
   return (
     <View
       onLayout={evt => setLayout(evt.nativeEvent.layout)}
       style={[
+        bgColor,
         a.rounded_full,
         a.absolute,
         {bottom: '100%'},
         isFromSelf ? a.right_0 : a.left_0,
-        t.scheme === 'light' ? t.atoms.bg : t.atoms.bg_contrast_25,
         a.flex_row,
         a.p_xs,
         a.gap_xs,
@@ -97,7 +99,7 @@ export function EmojiReactionPicker({
                       }
                     : alreadyReacted
                     ? {backgroundColor: t.palette.primary_200}
-                    : t.atoms.bg,
+                    : bgColor,
                   {height: 40, width: 40},
                   a.justify_center,
                   a.align_center,


### PR DESCRIPTION
Forgot dark mode had a different bg color when fixing an android bug

Before

<img width="352" alt="Screenshot 2025-04-03 at 00 22 09" src="https://github.com/user-attachments/assets/7bcae4d1-a2d0-447d-a18b-3c874c5cf323" />

After
    
<img width="334" alt="Screenshot 2025-04-03 at 00 21 54" src="https://github.com/user-attachments/assets/d59d4fbb-f536-4324-b6a4-088b35acde4b" />
