### PR TITLE
Wait for preferences before fetching trending data

### DIFF
--- a/src/state/queries/trending/useGetSuggestedFeedsQuery.ts
+++ b/src/state/queries/trending/useGetSuggestedFeedsQuery.ts
@@ -19,7 +19,7 @@ export function useGetSuggestedFeedsQuery() {
   const savedFeeds = preferences?.savedFeeds
 
   return useQuery({
-    enabled: !!savedFeeds,
+    enabled: !!preferences,
     refetchOnWindowFocus: true,
     staleTime: STALE.MINUTES.ONE,
     queryKey: createGetTrendsQueryKey(),

--- a/src/state/queries/trending/useGetTrendsQuery.ts
+++ b/src/state/queries/trending/useGetTrendsQuery.ts
@@ -24,6 +24,7 @@ export function useGetTrendsQuery() {
   }, [preferences?.moderationPrefs])
 
   return useQuery({
+    enabled: !!preferences,
     refetchOnWindowFocus: true,
     staleTime: STALE.MINUTES.THREE,
     queryKey: createGetTrendsQueryKey(),

--- a/src/state/queries/useSuggestedStarterPacksQuery.ts
+++ b/src/state/queries/useSuggestedStarterPacksQuery.ts
@@ -19,6 +19,7 @@ export function useSuggestedStarterPacksQuery() {
   const contentLangs = getContentLanguages().join(',')
 
   return useQuery({
+    enabled: !!preferences,
     refetchOnWindowFocus: true,
     staleTime: STALE.MINUTES.ONE,
     queryKey: createSuggestedStarterPacksQueryKey(),


### PR DESCRIPTION
We need to delay these loads until we have user interests back from the prefs API. This is only a delay on a cold load of this screen. Otherwise, prefs will be already loaded by the time the user lands here. So this is not a significant performance hit.