### PR TITLE
Improve Turkish translations

### DIFF
--- a/src/locale/locales/tr/messages.po
+++ b/src/locale/locales/tr/messages.po
@@ -1480,7 +1480,7 @@ msgstr ""
 
 #: src/screens/Onboarding/StepFinished.tsx:298
 msgid "Choose the algorithms that power your custom feeds."
-msgstr "Özel beslemelerinizi destekleyen algoritmaları seçin."
+msgstr "Özel akışlarınızı destekleyen algoritmaları seçin."
 
 #: src/screens/Onboarding/StepProfile/AvatarCreatorItems.tsx:107
 msgid "Choose this color as your avatar"
@@ -2102,7 +2102,7 @@ msgstr "Uygulama şifresini sil"
 
 #: src/screens/Settings/AppPasswords.tsx:207
 msgid "Delete app password?"
-msgstr "Uygulama şifresini sil ?"
+msgstr "Uygulama şifresi silinsin mi ?"
 
 #: src/screens/Messages/components/RequestButtons.tsx:292
 #: src/screens/Messages/components/RequestButtons.tsx:299
@@ -2208,7 +2208,7 @@ msgstr "Alıntıyı ayır"
 
 #: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:807
 msgid "Detach quote post?"
-msgstr "Alıntıyı ayır ?"
+msgstr "Alıntı ayırılsın mı ?"
 
 #: src/screens/Settings/AboutSettings.tsx:87
 msgctxt "toast"
@@ -2271,7 +2271,7 @@ msgstr "Taslak silinsin mi?"
 
 #: src/view/com/composer/Composer.tsx:867
 msgid "Discard post?"
-msgstr ""
+msgstr "Gönderi iptal edilsin mi ?"
 
 #: src/screens/Settings/components/PwiOptOut.tsx:87
 #: src/screens/Settings/components/PwiOptOut.tsx:91
@@ -3025,20 +3025,20 @@ msgstr ""
 
 #: src/Navigation.tsx:251
 msgid "Feed"
-msgstr "Besleme"
+msgstr "Akış"
 
 #: src/components/FeedCard.tsx:134
 #: src/view/com/feeds/FeedSourceCard.tsx:253
 msgid "Feed by {0}"
-msgstr "{0} tarafından besleme"
+msgstr "{0} tarafından akış"
 
 #: src/screens/Profile/components/ProfileFeedHeader.tsx:349
 msgid "Feed menu"
-msgstr ""
+msgstr "Akış menüsü"
 
 #: src/components/StarterPack/Wizard/WizardListCard.tsx:55
 msgid "Feed toggle"
-msgstr ""
+msgstr "Akış geçişi"
 
 #: src/view/shell/desktop/RightNav.tsx:97
 #: src/view/shell/desktop/RightNav.tsx:98
@@ -3061,21 +3061,21 @@ msgstr "Geri bildirim gönderildi!"
 #: src/view/shell/desktop/LeftNav.tsx:651
 #: src/view/shell/Drawer.tsx:486
 msgid "Feeds"
-msgstr "Beslemeler"
+msgstr "Akışlar"
 
 #: src/view/screens/SavedFeeds.tsx:198
 msgid "Feeds are custom algorithms that users build with a little coding expertise. <0/> for more information."
-msgstr "Beslemeler, kullanıcıların biraz kodlama uzmanlığı ile oluşturduğu özel algoritmalardır. Daha fazla bilgi için <0/>."
+msgstr "Akışlar, kullanıcıların biraz kodlama uzmanlığı ile oluşturduğu özel algoritmalardır. Daha fazla bilgi için <0/>."
 
 #: src/components/FeedCard.tsx:272
 #: src/view/screens/SavedFeeds.tsx:82
 msgctxt "toast"
 msgid "Feeds updated!"
-msgstr ""
+msgstr "Akışlar güncellendi!"
 
 #: src/screens/Search/components/ExploreRecommendations.tsx:63
 msgid "Feeds we think you might like."
-msgstr ""
+msgstr "Beğenebileceğinizi düşündüğümüz akışlar"
 
 #: src/screens/Settings/components/OTAInfo.tsx:58
 msgid "Fetch update"
@@ -3577,23 +3577,23 @@ msgstr ""
 
 #: src/view/com/posts/PostFeedErrorMessage.tsx:117
 msgid "Hmm, some kind of issue occurred when contacting the feed server. Please let the feed owner know about this issue."
-msgstr "Hmm, besleme sunucusuna ulaşırken bir tür sorun oluştu. Lütfen bu konuda besleme sahibini bilgilendirin."
+msgstr "Hmm, akış sunucusuna ulaşırken bir tür sorun oluştu. Lütfen bu konuda akış sahibini bilgilendirin."
 
 #: src/view/com/posts/PostFeedErrorMessage.tsx:105
 msgid "Hmm, the feed server appears to be misconfigured. Please let the feed owner know about this issue."
-msgstr "Hmm, besleme sunucusunun yanlış yapılandırılmış görünüyor. Lütfen bu konuda besleme sahibini bilgilendirin."
+msgstr "Hmm, akış sunucusunun yanlış yapılandırılmış görünüyor. Lütfen bu konuda akış sahibini bilgilendirin."
 
 #: src/view/com/posts/PostFeedErrorMessage.tsx:111
 msgid "Hmm, the feed server appears to be offline. Please let the feed owner know about this issue."
-msgstr "Hmm, besleme sunucusunun çevrimdışı görünüyor. Lütfen bu konuda besleme sahibini bilgilendirin."
+msgstr "Hmm, akış sunucusunun çevrimdışı görünüyor. Lütfen bu konuda akış sahibini bilgilendirin."
 
 #: src/view/com/posts/PostFeedErrorMessage.tsx:108
 msgid "Hmm, the feed server gave a bad response. Please let the feed owner know about this issue."
-msgstr "Hmm, besleme sunucusu kötü bir yanıt verdi. Lütfen bu konuda besleme sahibini bilgilendirin."
+msgstr "Hmm, akış sunucusu kötü bir yanıt verdi. Lütfen bu konuda akış sahibini bilgilendirin."
 
 #: src/view/com/posts/PostFeedErrorMessage.tsx:102
 msgid "Hmm, we're having trouble finding this feed. It may have been deleted."
-msgstr "Hmm, bu beslemeyi bulmakta sorun yaşıyoruz. Silinmiş olabilir."
+msgstr "Hmm, bu akışı bulmakta sorun yaşıyoruz. Silinmiş olabilir."
 
 #: src/screens/Moderation/index.tsx:54
 msgid "Hmmmm, it seems we're having trouble loading this data. See below for more details. If this issue persists, please contact us."
@@ -4012,7 +4012,7 @@ msgstr "Keşfet akışını eğitmek için 10 gönderiyi beğen"
 
 #: src/screens/Profile/components/ProfileFeedHeader.tsx:497
 msgid "Like this feed"
-msgstr "Bu beslemeyi beğen"
+msgstr "Bu akışı beğen"
 
 #: src/screens/Profile/Header/ProfileHeaderLabeler.tsx:285
 msgid "Like this labeler"
@@ -4360,7 +4360,7 @@ msgstr "Daha fazla"
 #: src/view/shell/desktop/Feeds.tsx:102
 #: src/view/shell/desktop/Feeds.tsx:105
 msgid "More feeds"
-msgstr "Daha fazla besleme"
+msgstr "Daha fazla akış"
 
 #: src/view/com/profile/ProfileMenu.tsx:194
 #: src/view/com/profile/ProfileMenu.tsx:200
@@ -4470,7 +4470,7 @@ msgstr "Sessize Alınan Hesaplar"
 
 #: src/view/screens/ModerationMutedAccounts.tsx:112
 msgid "Muted accounts have their posts removed from your feed and from your notifications. Mutes are completely private."
-msgstr "Sessize alınan hesapların gönderileri beslemenizden ve bildirimlerinizden kaldırılır. Sessizlik tamamen özeldir."
+msgstr "Sessize alınan hesapların gönderileri akışınızdan ve bildirimlerinizden kaldırılır. Sessizlik tamamen özeldir."
 
 #: src/lib/moderation/useModerationCauseDescription.ts:92
 msgid "Muted by \"{0}\""
@@ -4491,7 +4491,7 @@ msgstr "Doğum Günüm"
 
 #: src/view/screens/Feeds.tsx:699
 msgid "My Feeds"
-msgstr "Beslemelerim"
+msgstr "Akışlarım"
 
 #: src/view/com/modals/CreateOrEditList.tsx:270
 msgid "Name"
@@ -5258,11 +5258,11 @@ msgstr ""
 
 #: src/view/screens/SavedFeeds.tsx:123
 msgid "Pinned Feeds"
-msgstr "Sabitleme Beslemeleri"
+msgstr "Sabitlenmiş Akışlar"
 
 #: src/view/screens/ProfileList.tsx:354
 msgid "Pinned to your feeds"
-msgstr ""
+msgstr "Akışlarınıza sabitlendi"
 
 #: src/view/com/util/post-embeds/GifEmbed.tsx:43
 #: src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerNative.tsx:140
@@ -5767,7 +5767,7 @@ msgstr ""
 #: src/view/com/posts/FeedShutdownMsg.tsx:120
 #: src/view/com/posts/PostFeedErrorMessage.tsx:169
 msgid "Remove feed"
-msgstr "Beslemeyi kaldır"
+msgstr "Akışı kaldır"
 
 #: src/view/com/posts/PostFeedErrorMessage.tsx:210
 msgid "Remove feed?"
@@ -5780,7 +5780,7 @@ msgstr ""
 #: src/view/screens/ProfileList.tsx:521
 #: src/view/screens/SavedFeeds.tsx:342
 msgid "Remove from my feeds"
-msgstr "Beslemelerimden kaldır"
+msgstr "Akışlarımdan kaldır"
 
 #: src/screens/Settings/Settings.tsx:460
 msgid "Remove from quick access?"
@@ -5840,7 +5840,7 @@ msgstr "Listeden kaldırıldı"
 
 #: src/view/com/feeds/FeedSourceCard.tsx:138
 msgid "Removed from my feeds"
-msgstr "Beslemelerimden kaldırıldı"
+msgstr "Akışlarımdan kaldırıldı"
 
 #: src/screens/List/ListHiddenScreen.tsx:94
 msgid "Removed from saved feeds"
@@ -5967,7 +5967,7 @@ msgstr ""
 #: src/screens/Profile/components/ProfileFeedHeader.tsx:538
 #: src/screens/Profile/components/ProfileFeedHeader.tsx:544
 msgid "Report feed"
-msgstr "Beslemeyi raporla"
+msgstr "Akışı raporla"
 
 #: src/view/screens/ProfileList.tsx:563
 msgid "Report List"
@@ -6246,7 +6246,7 @@ msgstr ""
 
 #: src/view/screens/SavedFeeds.tsx:164
 msgid "Saved Feeds"
-msgstr "Kayıtlı Beslemeler"
+msgstr "Kayıtlı Akışlar"
 
 #: src/view/com/lightbox/Lightbox.tsx:44
 msgid "Saved to your camera roll"
@@ -6473,7 +6473,7 @@ msgstr ""
 
 #: src/screens/Settings/LanguageSettings.tsx:254
 msgid "Select which languages you want your subscribed feeds to include. If none are selected, all languages will be shown."
-msgstr "Abone olduğunuz beslemelerin hangi dilleri içermesini istediğinizi seçin. Hiçbiri seçilmezse, tüm diller gösterilir."
+msgstr "Abone olduğunuz akışların hangi dilleri içermesini istediğinizi seçin. Hiçbiri seçilmezse, tüm diller gösterilir."
 
 #: src/screens/Signup/StepInfo/index.tsx:267
 msgid "Select your date of birth"
@@ -6485,7 +6485,7 @@ msgstr "Aşağıdaki seçeneklerden ilgi alanlarınızı seçin"
 
 #: src/screens/Settings/LanguageSettings.tsx:170
 msgid "Select your preferred language for translations in your feed."
-msgstr "Beslemenizdeki çeviriler için tercih ettiğiniz dili seçin."
+msgstr "Akışınızdaki çeviriler için tercih ettiğiniz dili seçin."
 
 #: src/view/com/util/forms/DropdownButton.tsx:297
 msgid "Selects option {0} of {numItems}"
@@ -6782,7 +6782,7 @@ msgstr "Uyarı göster"
 
 #: src/lib/moderation/useLabelBehaviorDescription.ts:56
 msgid "Show warning and filter from feeds"
-msgstr "Uyarı göster ve beslemelerden filtrele"
+msgstr "Uyarı göster ve akışlardan filtrele"
 
 #: src/view/com/post-thread/PostThreadItem.tsx:816
 msgid "Shows information about when this post was created"
@@ -6900,7 +6900,7 @@ msgstr "Yazılım Geliştirme"
 
 #: src/components/FeedInterstitials.tsx:472
 msgid "Some other feeds you might like"
-msgstr "Beğenebileceğiniz diğer beslemeler"
+msgstr "Beğenebileceğiniz diğer akışlar"
 
 #: src/components/WhoCanReply.tsx:74
 msgid "Some people can reply"
@@ -7025,7 +7025,7 @@ msgstr "Başlangıç Paketleri"
 
 #: src/components/StarterPack/ProfileStarterPacks.tsx:242
 msgid "Starter packs let you easily share your favorite feeds and people with your friends."
-msgstr "Başlangıç paketleri favori kişilerinizi ve beslemelerinizi arkadaşlarınızla kolaylıkla paylaşmanızı sağlar."
+msgstr "Başlangıç paketleri favori kişilerinizi ve akışlarınızı arkadaşlarınızla kolaylıkla paylaşmanızı sağlar."
 
 #: src/screens/Settings/AboutSettings.tsx:59
 #: src/screens/Settings/AboutSettings.tsx:62
@@ -7521,11 +7521,11 @@ msgstr ""
 
 #: src/view/com/posts/PostFeedErrorMessage.tsx:120
 msgid "This feed is currently receiving high traffic and is temporarily unavailable. Please try again later."
-msgstr "Bu besleme şu anda yüksek trafik alıyor ve geçici olarak kullanılamıyor. Lütfen daha sonra tekrar deneyin."
+msgstr "Bu akış şu anda yüksek trafik alıyor ve geçici olarak kullanılamıyor. Lütfen daha sonra tekrar deneyin."
 
 #: src/view/com/posts/CustomFeedEmptyState.tsx:38
 msgid "This feed is empty! You may need to follow more users or tune your language settings."
-msgstr "Bu besleme boş! Daha fazla kullanıcı takip etmeniz veya dil ayarlarınızı ayarlamanız gerekebilir."
+msgstr "Bu akış boş! Daha fazla kullanıcı takip etmeniz veya dil ayarlarınızı ayarlamanız gerekebilir."
 
 #: src/components/StarterPack/Main/PostsList.tsx:36
 #: src/screens/Profile/ProfileFeed/index.tsx:189
@@ -8507,7 +8507,7 @@ msgstr "Bu gönderide hangi diller kullanılıyor?"
 
 #: src/view/com/modals/lang-settings/ContentLanguagesSettings.tsx:79
 msgid "Which languages would you like to see in your algorithmic feeds?"
-msgstr "Algoritmik beslemelerinizde hangi dilleri görmek istersiniz?"
+msgstr "Algoritmik akışlarınızda hangi dilleri görmek istersiniz?"
 
 #: src/components/WhoCanReply.tsx:183
 msgid "Who can interact with this post?"
@@ -8641,7 +8641,7 @@ msgstr ""
 #: src/view/com/posts/FollowingEmptyState.tsx:63
 #: src/view/com/posts/FollowingEndOfFeed.tsx:64
 msgid "You can also discover new Custom Feeds to follow."
-msgstr "Ayrıca takip edebileceğiniz yeni Özel Beslemeler keşfedebilirsiniz."
+msgstr "Ayrıca takip edebileceğiniz yeni Özel Akışlar keşfedebilirsiniz."
 
 #: src/view/com/modals/DeleteAccount.tsx:198
 msgid "You can also temporarily deactivate your account instead, and reactivate it at any time."
@@ -8689,11 +8689,11 @@ msgstr "Henüz hiç davet kodunuz yok! Bluesky'de biraz daha uzun süre kaldıkt
 
 #: src/view/screens/SavedFeeds.tsx:137
 msgid "You don't have any pinned feeds."
-msgstr "Sabitlemiş beslemeniz yok."
+msgstr "Sabitlemiş akışınız yok."
 
 #: src/view/screens/SavedFeeds.tsx:177
 msgid "You don't have any saved feeds."
-msgstr "Kaydedilmiş beslemeniz yok."
+msgstr "Kaydedilmiş akışınız yok."
 
 #: src/view/com/post-thread/PostThread.tsx:271
 msgid "You have blocked the author or you have been blocked by the author."
@@ -8739,7 +8739,7 @@ msgstr "Henüz hiç görüşmeniz yok. Bir tane başlatın!"
 
 #: src/view/com/feeds/ProfileFeedgens.tsx:143
 msgid "You have no feeds."
-msgstr "Beslemeniz yok."
+msgstr "Akışınız yok."
 
 #: src/view/com/lists/MyLists.tsx:81
 #: src/view/com/lists/ProfileLists.tsx:139
@@ -8870,7 +8870,7 @@ msgstr ""
 
 #: src/screens/StarterPack/StarterPackLandingScreen.tsx:274
 msgid "You'll stay updated with these feeds"
-msgstr "Bu beslemelerden haberdar edileceksiniz"
+msgstr "Bu akışlardan haberdar edileceksiniz"
 
 #: src/screens/SignupQueued.tsx:127
 msgid "You're in line"
@@ -8896,7 +8896,7 @@ msgstr ""
 
 #: src/view/com/posts/FollowingEndOfFeed.tsx:44
 msgid "You've reached the end of your feed! Find some more accounts to follow."
-msgstr "Beslemenizin sonuna ulaştınız! Takip edebileceğiniz daha fazla hesap bulun."
+msgstr "Akışlarınızın sonuna ulaştınız! Takip edebileceğiniz daha fazla hesap bulun."
 
 #: src/view/com/composer/state/video.ts:421
 msgid "You've reached your daily limit for video uploads (too many bytes)"
@@ -8983,7 +8983,7 @@ msgstr ""
 
 #: src/view/com/posts/FollowingEmptyState.tsx:43
 msgid "Your following feed is empty! Follow more users to see what's happening."
-msgstr "Takip ettiğiniz besleme boş! Neler olduğunu görmek için daha fazla kullanıcı takip edin."
+msgstr "Takip ettiğiniz akış boş! Neler olduğunu görmek için daha fazla kullanıcı takip edin."
 
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:221
 msgid "Your full handle will be <0>@{0}</0>"

--- a/src/locale/locales/tr/messages.po
+++ b/src/locale/locales/tr/messages.po
@@ -37,11 +37,11 @@ msgstr "{0, plural, one {# gün} other {# gün}}"
 
 #: src/screens/Profile/ProfileFollowers.tsx:40
 msgid "{0, plural, one {# follower} other {# followers}}"
-msgstr ""
+msgstr "{0, plural, one {# takipçi} other {# takipçi}}"
 
 #: src/screens/Profile/ProfileFollows.tsx:40
 msgid "{0, plural, one {# following} other {# following}}"
-msgstr ""
+msgstr "{0, plural, one {# takip edilen} other {# takip edilen}}"
 
 #: src/lib/hooks/useTimeAgo.ts:159
 msgid "{0, plural, one {# hour} other {# hours}}"
@@ -49,27 +49,27 @@ msgstr "{0, plural, one {# saat} other {# saat}}"
 
 #: src/components/moderation/LabelsOnMe.tsx:53
 msgid "{0, plural, one {# label has} other {# labels have}} been placed on this account"
-msgstr ""
+msgstr "{0, plural, one {# etiket} other {# etiket}} bu hesaba yerleştirildi"
 
 #: src/components/moderation/LabelsOnMe.tsx:62
 msgid "{0, plural, one {# label has} other {# labels have}} been placed on this content"
-msgstr ""
+msgstr "{0, plural, one {# etiket} other {# etiket}} bu içeriğe yerleştirildi"
 
 #: src/screens/Post/PostLikedBy.tsx:41
 msgid "{0, plural, one {# like} other {# likes}}"
-msgstr ""
+msgstr "{0, plural, one {# beğeni} other {# beğeni}}"
 
 #: src/lib/hooks/useTimeAgo.ts:149
 msgid "{0, plural, one {# minute} other {# minutes}}"
-msgstr ""
+msgstr "{0, plural, one {# dakika} other {# dakika}}"
 
 #: src/lib/hooks/useTimeAgo.ts:180
 msgid "{0, plural, one {# month} other {# months}}"
-msgstr ""
+msgstr "{0, plural, one {# ay} other {# ay}}"
 
 #: src/screens/Post/PostQuotes.tsx:41
 msgid "{0, plural, one {# quote} other {# quotes}}"
-msgstr ""
+msgstr "{0, plural, one {# alıntı} other {# alıntı}}"
 
 #: src/screens/Post/PostRepostedBy.tsx:41
 msgid "{0, plural, one {# repost} other {# reposts}}"
@@ -77,54 +77,54 @@ msgstr "{0, plural, one {# yeniden gönderi} other {# yeniden gönderi}}"
 
 #: src/lib/hooks/useTimeAgo.ts:139
 msgid "{0, plural, one {# second} other {# seconds}}"
-msgstr ""
+msgstr "{0, plural, one {# saniye} other {# saniye}}"
 
 #: src/view/shell/bottom-bar/BottomBar.tsx:209
 #: src/view/shell/bottom-bar/BottomBar.tsx:241
 #: src/view/shell/Drawer.tsx:454
 msgid "{0, plural, one {# unread item} other {# unread items}}"
-msgstr ""
+msgstr "{0, plural, one {# okunmamış öğe} other {# okunmamış öğe}}"
 
 #. How many months have passed, displayed in a narrow form
 #: src/lib/hooks/useTimeAgo.ts:182
 msgid "{0, plural, one {#mo} other {#mo}}"
-msgstr ""
+msgstr "{0, plural, one {#ay} other {#ay}}"
 
 #: src/components/ProfileHoverCard/index.web.tsx:398
 #: src/screens/Profile/Header/Metrics.tsx:22
 msgid "{0, plural, one {follower} other {followers}}"
-msgstr ""
+msgstr "{0, plural, one {takipçi} other {takipçi}}"
 
 #: src/components/ProfileHoverCard/index.web.tsx:402
 #: src/screens/Profile/Header/Metrics.tsx:26
 msgid "{0, plural, one {following} other {following}}"
-msgstr ""
+msgstr "{0, plural, one {takip edilen} other {takip edilen}}"
 
 #: src/view/com/post-thread/PostThreadItem.tsx:454
 msgid "{0, plural, one {like} other {likes}}"
-msgstr ""
+msgstr "{0, plural, one {beğeni} other {beğeni}}"
 
 #: src/screens/Profile/Header/Metrics.tsx:58
 msgid "{0, plural, one {post} other {posts}}"
-msgstr ""
+msgstr "{0, plural, one {gönderi} other {gönderi}}"
 
 #: src/view/com/post-thread/PostThreadItem.tsx:438
 msgid "{0, plural, one {quote} other {quotes}}"
-msgstr ""
+msgstr "{0, plural, one {alıntı} other {alıntı}}"
 
 #: src/view/com/post-thread/PostThreadItem.tsx:420
 msgid "{0, plural, one {repost} other {reposts}}"
-msgstr ""
+msgstr "{0, plural, one {yeniden gönderi} other {yeniden gönderi}}"
 
 #. Pattern: {wordValue} in tags
 #: src/components/dialogs/MutedWords.tsx:475
 msgid "{0} <0>in <1>tags</1></0>"
-msgstr ""
+msgstr "{0} <0><1>etiketlerde</1></0>"
 
 #. Pattern: {wordValue} in text, tags
 #: src/components/dialogs/MutedWords.tsx:465
 msgid "{0} <0>in <1>text & tags</1></0>"
-msgstr ""
+msgstr "{0} <0><1>metin ve etiketlerde</1></0>"
 
 #: src/screens/StarterPack/StarterPackLandingScreen.tsx:223
 msgid "{0} joined this week"
@@ -137,7 +137,7 @@ msgstr "{0}/{1}"
 #. Accessibility label describing how many characters the user has entered out of a 50-character limit in a text input field
 #: src/screens/StarterPack/Wizard/StepDetails.tsx:55
 msgid "{0} out of 50"
-msgstr ""
+msgstr "50 karakterden {0} kullanıldı"
 
 #: src/screens/StarterPack/StarterPackScreen.tsx:485
 msgid "{0} people have used this starter pack!"
@@ -149,11 +149,11 @@ msgstr "{0}'ın avatarı"
 
 #: src/screens/StarterPack/Wizard/StepDetails.tsx:74
 msgid "{0}'s favorite feeds and people - join me!"
-msgstr ""
+msgstr "{0}'ın favori akışları ve kişileri - bana katılın!"
 
 #: src/screens/StarterPack/Wizard/StepDetails.tsx:46
 msgid "{0}'s starter pack"
-msgstr ""
+msgstr "{0}'ın başlangıç paketi"
 
 #. How many days have passed, displayed in a narrow form
 #: src/lib/hooks/useTimeAgo.ts:171
@@ -177,7 +177,7 @@ msgstr "{0}sn"
 
 #: src/view/shell/desktop/LeftNav.tsx:382
 msgid "{count, plural, one {# unread item} other {# unread items}}"
-msgstr ""
+msgstr "{count, plural, one {# okunmamış öğe} other {# okunmamış öğe}}"
 
 #: src/lib/generate-starterpack.ts:111
 #: src/screens/StarterPack/Wizard/index.tsx:178
@@ -194,23 +194,23 @@ msgstr "{estimatedTimeMins, plural, one {dakika} other {dakika}}"
 
 #: src/view/com/notifications/NotificationFeedItem.tsx:305
 msgid "{firstAuthorLink} and <0>{additionalAuthorsCount, plural, one {{formattedAuthorsCount} other} other {{formattedAuthorsCount} others}}</0> followed you"
-msgstr ""
+msgstr "{firstAuthorLink} ve <0>{additionalAuthorsCount, plural, one {{formattedAuthorsCount} kişi} other {{formattedAuthorsCount} kişi}}</0> seni takip etti"
 
 #: src/view/com/notifications/NotificationFeedItem.tsx:331
 msgid "{firstAuthorLink} and <0>{additionalAuthorsCount, plural, one {{formattedAuthorsCount} other} other {{formattedAuthorsCount} others}}</0> liked your custom feed"
-msgstr ""
+msgstr "{firstAuthorLink} ve <0>{additionalAuthorsCount, plural, one {{formattedAuthorsCount} kişi} other {{formattedAuthorsCount} kişi}}</0> özel akışını beğendi"
 
 #: src/view/com/notifications/NotificationFeedItem.tsx:224
 msgid "{firstAuthorLink} and <0>{additionalAuthorsCount, plural, one {{formattedAuthorsCount} other} other {{formattedAuthorsCount} others}}</0> liked your post"
-msgstr ""
+msgstr "{firstAuthorLink} ve <0>{additionalAuthorsCount, plural, one {{formattedAuthorsCount} kişi} other {{formattedAuthorsCount} kişi}}</0> gönderini beğendi"
 
 #: src/view/com/notifications/NotificationFeedItem.tsx:248
 msgid "{firstAuthorLink} and <0>{additionalAuthorsCount, plural, one {{formattedAuthorsCount} other} other {{formattedAuthorsCount} others}}</0> reposted your post"
-msgstr ""
+msgstr "{firstAuthorLink} ve <0>{additionalAuthorsCount, plural, one {{formattedAuthorsCount} kişi} other {{formattedAuthorsCount} kişi}}</0> gönderini yeniden gönderdi"
 
 #: src/view/com/notifications/NotificationFeedItem.tsx:355
 msgid "{firstAuthorLink} and <0>{additionalAuthorsCount, plural, one {{formattedAuthorsCount} other} other {{formattedAuthorsCount} others}}</0> signed up with your starter pack"
-msgstr ""
+msgstr "{firstAuthorLink} ve <0>{additionalAuthorsCount, plural, one {{formattedAuthorsCount} kişi} other {{formattedAuthorsCount} kişi}}</0> senin başlangıç paketin ile kaydoldu"
 
 #: src/view/com/notifications/NotificationFeedItem.tsx:317
 msgid "{firstAuthorLink} followed you"
@@ -222,7 +222,7 @@ msgstr "{firstAuthorLink} seni geri takip etti"
 
 #: src/view/com/notifications/NotificationFeedItem.tsx:343
 msgid "{firstAuthorLink} liked your custom feed"
-msgstr ""
+msgstr "{firstAuthorLink} özel akışını beğendi"
 
 #: src/view/com/notifications/NotificationFeedItem.tsx:236
 msgid "{firstAuthorLink} liked your post"
@@ -234,27 +234,27 @@ msgstr "{firstAuthorLink} gönderini yeniden gönderdi"
 
 #: src/view/com/notifications/NotificationFeedItem.tsx:367
 msgid "{firstAuthorLink} signed up with your starter pack"
-msgstr ""
+msgstr "{firstAuthorLink} senin başlangıç paketin ile kaydoldu"
 
 #: src/view/com/notifications/NotificationFeedItem.tsx:298
 msgid "{firstAuthorName} and {additionalAuthorsCount, plural, one {{formattedAuthorsCount} other} other {{formattedAuthorsCount} others}} followed you"
-msgstr ""
+msgstr "{firstAuthorName} ve {additionalAuthorsCount, plural, one {{formattedAuthorsCount} kişi} other {{formattedAuthorsCount} kişi}} seni takip etti"
 
 #: src/view/com/notifications/NotificationFeedItem.tsx:324
 msgid "{firstAuthorName} and {additionalAuthorsCount, plural, one {{formattedAuthorsCount} other} other {{formattedAuthorsCount} others}} liked your custom feed"
-msgstr ""
+msgstr "{firstAuthorName} ve {additionalAuthorsCount, plural, one {{formattedAuthorsCount} kişi} other {{formattedAuthorsCount} kişi}} özel akışını beğendi"
 
 #: src/view/com/notifications/NotificationFeedItem.tsx:217
 msgid "{firstAuthorName} and {additionalAuthorsCount, plural, one {{formattedAuthorsCount} other} other {{formattedAuthorsCount} others}} liked your post"
-msgstr ""
+msgstr "{firstAuthorName} ve {additionalAuthorsCount, plural, one {{formattedAuthorsCount} kişi} other {{formattedAuthorsCount} kişi}} gönderini beğendi"
 
 #: src/view/com/notifications/NotificationFeedItem.tsx:241
 msgid "{firstAuthorName} and {additionalAuthorsCount, plural, one {{formattedAuthorsCount} other} other {{formattedAuthorsCount} others}} reposted your post"
-msgstr ""
+msgstr "{firstAuthorName} ve {additionalAuthorsCount, plural, one {{formattedAuthorsCount} kişi} other {{formattedAuthorsCount} kişi}} gönderini yeniden gönderdi"
 
 #: src/view/com/notifications/NotificationFeedItem.tsx:348
 msgid "{firstAuthorName} and {additionalAuthorsCount, plural, one {{formattedAuthorsCount} other} other {{formattedAuthorsCount} others}} signed up with your starter pack"
-msgstr ""
+msgstr "{firstAuthorName} ve {additionalAuthorsCount, plural, one {{formattedAuthorsCount} kişi} other {{formattedAuthorsCount} kişi}} senin başlangıç paketin ile kaydoldu"
 
 #: src/view/com/notifications/NotificationFeedItem.tsx:303
 msgid "{firstAuthorName} followed you"
@@ -266,7 +266,7 @@ msgstr "{firstAuthorName} seni geri takip etti"
 
 #: src/view/com/notifications/NotificationFeedItem.tsx:329
 msgid "{firstAuthorName} liked your custom feed"
-msgstr ""
+msgstr "{firstAuthorName} özel akışını beğendi"
 
 #: src/view/com/notifications/NotificationFeedItem.tsx:222
 msgid "{firstAuthorName} liked your post"
@@ -291,7 +291,7 @@ msgstr "{handle} kullanıcısına mesaj gönderilemez"
 
 #: src/view/shell/bottom-bar/BottomBarWeb.tsx:270
 msgid "{notificationCount, plural, one {# unread item} other {# unread items}}"
-msgstr ""
+msgstr "{notificationCount, plural, one {# okunmamış öğe} other {# okunmamış öğe}}"
 
 #: src/components/NewskieDialog.tsx:116
 msgid "{profileName} joined Bluesky {0} ago"
@@ -304,44 +304,44 @@ msgstr "{profileName} Bluesky'a başlangıç paketi kullanarak {0} önce katıld
 #: src/screens/StarterPack/Wizard/index.tsx:449
 msgctxt "profiles"
 msgid "<0>{0}, </0><1>{1}, </1>and {2, plural, one {# other} other {# others}} are included in your starter pack"
-msgstr ""
+msgstr "<0>{0}, </0><1>{1}, </1>ve {2, plural, one {# diğer} other {# diğer}} başlangıç paketinizde yer alıyor"
 
 #: src/screens/StarterPack/Wizard/index.tsx:502
 msgctxt "feeds"
 msgid "<0>{0}, </0><1>{1}, </1>and {2, plural, one {# other} other {# others}} are included in your starter pack"
-msgstr ""
+msgstr "<0>{0}, </0><1>{1}, </1>ve {2, plural, one {# diğer} other {# diğer}} başlangıç paketinizde yer alıyor"
 
 #: src/view/shell/Drawer.tsx:97
 msgid "<0>{0}</0> {1, plural, one {follower} other {followers}}"
-msgstr ""
+msgstr "<0>{0}</0> {1, plural, one {takipçi} other {takipçi}}"
 
 #: src/view/shell/Drawer.tsx:108
 msgid "<0>{0}</0> {1, plural, one {following} other {following}}"
-msgstr ""
+msgstr "<0>{0}</0> {1, plural, one {takip edilen} other {takip edilen}}"
 
 #: src/screens/StarterPack/Wizard/index.tsx:490
 msgid "<0>{0}</0> and<1> </1><2>{1} </2>are included in your starter pack"
-msgstr ""
+msgstr "<0>{0}</0> ve<1> </1><2>{1} </2>başlangıç paketinizde yer alıyor"
 
 #: src/screens/StarterPack/Wizard/index.tsx:483
 msgid "<0>{0}</0> is included in your starter pack"
-msgstr ""
+msgstr "<0>{0}</0> başlangıç paketinizde yer alıyor"
 
 #: src/components/WhoCanReply.tsx:296
 msgid "<0>{0}</0> members"
-msgstr ""
+msgstr "<0>{0}</0> üye"
 
 #: src/components/dms/DateDivider.tsx:69
 msgid "<0>{date}</0> at {time}"
-msgstr ""
+msgstr "<0>{date}</0> {time}"
 
 #: src/screens/Settings/NotificationSettings.tsx:85
 msgid "<0>Experimental:</0> When this preference is enabled, you'll only receive reply and quote notifications from users you follow. We'll continue to add more controls here over time."
-msgstr ""
+msgstr "<0>Deneysel:</0> Bu tercih etkinleştirildiğinde, yalnızca takip ettiğiniz kullanıcılardan yanıt ve alıntı bildirimleri alacaksınız. Zaman içinde buraya daha fazla kontrol ekleyeceğiz."
 
 #: src/screens/StarterPack/Wizard/index.tsx:440
 msgid "<0>You</0> and<1> </1><2>{0} </2>are included in your starter pack"
-msgstr ""
+msgstr "<0>Siz</0> ve<1> </1><2>{0} </2>başlangıç paketinizde yer alıyor"
 
 #: src/screens/Profile/Header/Handle.tsx:52
 msgid "⚠Invalid Handle"
@@ -373,16 +373,16 @@ msgstr "Hakkında"
 #. Accept a chat request
 #: src/screens/Messages/components/RequestButtons.tsx:235
 msgid "Accept"
-msgstr ""
+msgstr "Kabul Et"
 
 #: src/screens/Messages/components/RequestButtons.tsx:225
 msgid "Accept chat request"
-msgstr ""
+msgstr "Sohbet isteğini kabul et"
 
 #. Accept a chat request
 #: src/screens/Messages/components/RequestListItem.tsx:42
 msgid "Accept Request"
-msgstr ""
+msgstr "İsteği Kabul Et"
 
 #: src/screens/Settings/AccessibilitySettings.tsx:46
 #: src/screens/Settings/Settings.tsx:191
@@ -466,7 +466,7 @@ msgstr "Devam etmek için {0} tane daha ekleyin"
 
 #: src/components/StarterPack/Wizard/WizardListCard.tsx:59
 msgid "Add {displayName} to starter pack"
-msgstr ""
+msgstr "{displayName} başlangıç paketine ekle"
 
 #: src/view/com/composer/labels/LabelsBtn.tsx:107
 #: src/view/com/composer/labels/LabelsBtn.tsx:112
@@ -521,15 +521,15 @@ msgstr "Uygulama Şifresi Ekle"
 #: src/components/moderation/ReportDialog/index.tsx:392
 #: src/components/moderation/ReportDialog/index.tsx:396
 msgid "Add more details (optional)"
-msgstr ""
+msgstr "Daha fazla detay ekle (isteğe bağlı)"
 
 #: src/components/dialogs/MutedWords.tsx:321
 msgid "Add mute word with chosen settings"
-msgstr ""
+msgstr "Seçilen ayarlarla susturma kelimesi ekle"
 
 #: src/components/dialogs/MutedWords.tsx:112
 msgid "Add muted words and tags"
-msgstr ""
+msgstr "Susturulan kelimeleri ve etiketleri ekle"
 
 #: src/view/com/composer/Composer.tsx:1258
 msgid "Add new post"
@@ -538,19 +538,19 @@ msgstr "Yeni gönderi ekle"
 #: src/view/screens/ProfileList.tsx:925
 #: src/view/screens/ProfileList.tsx:943
 msgid "Add people"
-msgstr ""
+msgstr "Kişi ekle"
 
 #: src/screens/Home/NoFeedsPinned.tsx:99
 msgid "Add recommended feeds"
-msgstr ""
+msgstr "Önerilen akışları ekle"
 
 #: src/screens/StarterPack/Wizard/index.tsx:471
 msgid "Add some feeds to your starter pack!"
-msgstr ""
+msgstr "Başlangıç paketinize bazı akışlar ekleyin!"
 
 #: src/screens/Feeds/NoFollowingFeed.tsx:41
 msgid "Add the default feed of only people you follow"
-msgstr ""
+msgstr "Yalnızca takip ettiğiniz kişilerin varsayılan akışını ekleyin"
 
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:387
 msgid "Add the following DNS record to your domain:"
@@ -558,16 +558,16 @@ msgstr "Alan adınıza aşağıdaki DNS kaydını ekleyin:"
 
 #: src/components/FeedCard.tsx:295
 msgid "Add this feed to your feeds"
-msgstr ""
+msgstr "Bu akışı akışlarınıza ekleyin"
 
 #: src/view/com/profile/ProfileMenu.tsx:273
 #: src/view/com/profile/ProfileMenu.tsx:276
 msgid "Add to lists"
-msgstr ""
+msgstr "Listelere ekle"
 
 #: src/view/com/feeds/FeedSourceCard.tsx:269
 msgid "Add to my feeds"
-msgstr "Beslemelerime ekle"
+msgstr "Akışlarıma ekle"
 
 #: src/view/com/modals/ListAddRemoveUsers.tsx:192
 #: src/view/com/modals/UserAddRemoveLists.tsx:162
@@ -576,15 +576,15 @@ msgstr "Listeye eklendi"
 
 #: src/view/com/feeds/FeedSourceCard.tsx:125
 msgid "Added to my feeds"
-msgstr "Beslemelerime eklendi"
+msgstr "Akışlarıma eklendi"
 
 #: src/components/moderation/ReportDialog/index.tsx:410
 msgid "Additional details (limit 300 characters)"
-msgstr ""
+msgstr "Ek detaylar (300 karakter sınırı)"
 
 #: src/view/com/composer/labels/LabelsBtn.tsx:160
 msgid "Adult"
-msgstr ""
+msgstr "Yetişkin"
 
 #: src/components/moderation/ContentHider.tsx:113
 #: src/lib/moderation/useGlobalLabelStrings.ts:34
@@ -604,7 +604,7 @@ msgstr "Yetişkin içerik devre dışı bırakıldı."
 #: src/view/com/composer/labels/LabelsBtn.tsx:139
 #: src/view/com/composer/labels/LabelsBtn.tsx:197
 msgid "Adult Content labels"
-msgstr ""
+msgstr "Yetişkin İçerik etiketleri"
 
 #: src/screens/Moderation/index.tsx:399
 msgid "Advanced"
@@ -626,7 +626,7 @@ msgstr "Tüm Diller"
 
 #: src/view/screens/Feeds.tsx:702
 msgid "All the feeds you've saved, right in one place."
-msgstr ""
+msgstr "Kaydettiğiniz tüm akışlar, tek bir yerde."
 
 #: src/screens/Settings/components/AddAppPasswordDialog.tsx:146
 #: src/screens/Settings/components/AddAppPasswordDialog.tsx:153
@@ -640,7 +640,7 @@ msgstr "Yeni mesajlara izin ver"
 
 #: src/components/dialogs/PostInteractionSettingsDialog.tsx:344
 msgid "Allow quote posts"
-msgstr ""
+msgstr "Alıntı gönderilerine izin ver"
 
 #: src/components/dialogs/PostInteractionSettingsDialog.tsx:389
 msgid "Allow replies from:"
@@ -746,7 +746,7 @@ msgstr "Video yüklenirken bir hata oluştu."
 #: src/components/moderation/ReportDialog/utils/useReportOptions.ts:28
 #: src/lib/moderation/useReportOptions.ts:28
 msgid "An issue not included in these options"
-msgstr ""
+msgstr "Sorun bu seçenekler arasında değil"
 
 #: src/components/dms/dialogs/NewChatDialog.tsx:41
 msgid "An issue occurred starting the chat"
@@ -772,7 +772,7 @@ msgstr "bilinmeyen bir hata oluştu"
 #: src/components/moderation/ModerationDetailsDialog.tsx:134
 #: src/lib/moderation/useModerationCauseDescription.ts:144
 msgid "an unknown labeler"
-msgstr ""
+msgstr "bilinmeyen etiketçi"
 
 #: src/components/WhoCanReply.tsx:317
 msgid "and"
@@ -818,7 +818,7 @@ msgstr "Uygulama şifresi silindi"
 
 #: src/screens/Settings/components/AddAppPasswordDialog.tsx:84
 msgid "App password name must be unique"
-msgstr ""
+msgstr "Uygulama şifresi özgün olmalı"
 
 #: src/screens/Settings/components/AddAppPasswordDialog.tsx:62
 msgid "App password names can only contain letters, numbers, spaces, dashes, and underscores"
@@ -986,7 +986,7 @@ msgstr "Geri"
 
 #: src/screens/Messages/Inbox.tsx:238
 msgid "Back to Chats"
-msgstr ""
+msgstr "Sohbetlere Dön"
 
 #: src/view/screens/Lists.tsx:81
 #: src/view/screens/ModerationModlists.tsx:81
@@ -1010,7 +1010,7 @@ msgstr "Başka bir kullanıcıya mesaj gönderebilmeniz için öncelikle e-posta
 #: src/screens/Search/components/ExploreTrendingTopics.tsx:74
 #: src/screens/Search/components/ExploreTrendingVideos.tsx:111
 msgid "BETA"
-msgstr ""
+msgstr "BETA"
 
 #: src/components/dialogs/BirthDateSettings.tsx:103
 #: src/screens/Settings/AccountSettings.tsx:109
@@ -1049,7 +1049,7 @@ msgstr "Engelle ve Sil"
 
 #: src/components/dms/ReportDialog.tsx:352
 msgid "Block and/or delete this conversation"
-msgstr ""
+msgstr "Bu görüşmeyi engelle ve/veya sil"
 
 #: src/view/screens/ProfileList.tsx:782
 msgid "Block list"
@@ -1057,7 +1057,7 @@ msgstr "Listeyi engelle"
 
 #: src/screens/Messages/components/ChatStatusInfo.tsx:46
 msgid "Block or report"
-msgstr ""
+msgstr "Engelle veya rapor et"
 
 #: src/view/screens/ProfileList.tsx:777
 msgid "Block these accounts?"
@@ -1121,12 +1121,12 @@ msgstr "Bluesky"
 
 #: src/view/com/post-thread/PostThreadItem.tsx:870
 msgid "Bluesky cannot confirm the authenticity of the claimed date."
-msgstr ""
+msgstr "Bluesky, iddia edilen tarihin gerçekliğini onaylayamaz."
 
 #: src/screens/Settings/AppIconSettings/useAppIconSets.ts:129
 msgctxt "Name of app icon variant"
 msgid "Bluesky Classic™"
-msgstr ""
+msgstr "Bluesky Klasik™"
 
 #: src/view/com/auth/server-input/index.tsx:212
 msgid "Bluesky is an open network where you can choose your hosting provider. If you're a developer, you can host your own server."
@@ -1303,7 +1303,7 @@ msgstr "Alıntı gönderiyi iptal et"
 
 #: src/screens/Deactivated.tsx:152
 msgid "Cancel reactivation and sign out"
-msgstr ""
+msgstr "Yeniden etkinleştirmeyi iptal et ve oturumu kapat"
 
 #: src/view/com/modals/ListAddRemoveUsers.tsx:88
 #: src/view/screens/Search/Search.tsx:882
@@ -1930,7 +1930,7 @@ msgstr "Sohbetten ayrılınamadı"
 
 #: src/screens/Profile/ProfileFeed/index.tsx:80
 msgid "Could not load feed"
-msgstr "Besleme yüklenemedi"
+msgstr "Akış yüklenemedi"
 
 #: src/view/screens/ProfileList.tsx:1022
 msgid "Could not load list"
@@ -2058,7 +2058,7 @@ msgstr "Doğum tarihi"
 #: src/screens/Settings/AccountSettings.tsx:151
 #: src/screens/Settings/components/DeactivateAccountDialog.tsx:73
 msgid "Deactivate account"
-msgstr ""
+msgstr "Hesabı devre dışı bırak"
 
 #: src/screens/Settings/Settings.tsx:332
 msgid "Debug Moderation"
@@ -2074,7 +2074,7 @@ msgstr "Varsayılan"
 
 #: src/screens/Settings/AppIconSettings/index.tsx:75
 msgid "Default icons"
-msgstr ""
+msgstr "Varsayılan simgeler"
 
 #: src/components/dms/MessageMenu.tsx:154
 #: src/screens/Messages/components/ChatStatusInfo.tsx:55
@@ -2094,7 +2094,7 @@ msgstr "Hesabı sil"
 
 #: src/view/com/modals/DeleteAccount.tsx:101
 msgid "Delete Account <0>\"</0><1>{0}</1><2>\"</2>"
-msgstr ""
+msgstr "Hesabı Sil <0>\"</0><1>{0}</1><2>\"</2>"
 
 #: src/screens/Settings/AppPasswords.tsx:187
 msgid "Delete app password"
@@ -2102,31 +2102,31 @@ msgstr "Uygulama şifresini sil"
 
 #: src/screens/Settings/AppPasswords.tsx:207
 msgid "Delete app password?"
-msgstr ""
+msgstr "Uygulama şifresini sil ?"
 
 #: src/screens/Messages/components/RequestButtons.tsx:292
 #: src/screens/Messages/components/RequestButtons.tsx:299
 msgid "Delete chat"
-msgstr ""
+msgstr "Sohbeti sil"
 
 #: src/screens/Settings/Settings.tsx:339
 msgid "Delete chat declaration record"
-msgstr ""
+msgstr "Sohbet beyan kaydını sil"
 
 #: src/components/dms/ReportDialog.tsx:362
 #: src/components/dms/ReportDialog.tsx:365
 #: src/screens/Messages/components/RequestButtons.tsx:126
 #: src/screens/Messages/components/RequestButtons.tsx:129
 msgid "Delete conversation"
-msgstr ""
+msgstr "Sohbeti sil"
 
 #: src/components/dms/ReportDialog.tsx:320
 msgid "Delete Conversation"
-msgstr ""
+msgstr "Sohbeti Sil"
 
 #: src/components/dms/MessageMenu.tsx:126
 msgid "Delete for me"
-msgstr ""
+msgstr "Benim için sil"
 
 #: src/view/screens/ProfileList.tsx:549
 msgid "Delete List"
@@ -2138,7 +2138,7 @@ msgstr "Mesajı sil"
 
 #: src/components/dms/MessageMenu.tsx:124
 msgid "Delete message for me"
-msgstr ""
+msgstr "Mesajları benim için sil"
 
 #: src/view/com/modals/DeleteAccount.tsx:267
 msgid "Delete my account"
@@ -2199,16 +2199,16 @@ msgstr "Açıklama çok uzun. Maksimum {DESCRIPTION_MAX_GRAPHEMES} karaktere izi
 #: src/view/com/composer/GifAltText.tsx:150
 #: src/view/com/composer/photos/ImageAltTextDialog.tsx:114
 msgid "Descriptive alt text"
-msgstr ""
+msgstr "Açıklayıcı alternatif yazı"
 
 #: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:613
 #: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:623
 msgid "Detach quote"
-msgstr ""
+msgstr "Alıntıyı ayır"
 
 #: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:807
 msgid "Detach quote post?"
-msgstr ""
+msgstr "Alıntıyı ayır ?"
 
 #: src/screens/Settings/AboutSettings.tsx:87
 msgctxt "toast"
@@ -2281,11 +2281,11 @@ msgstr "Uygulamaların hesabımı oturum açmamış kullanıcılara göstermesin
 #: src/view/com/posts/FollowingEmptyState.tsx:70
 #: src/view/com/posts/FollowingEndOfFeed.tsx:71
 msgid "Discover new custom feeds"
-msgstr "Yeni özel beslemeler keşfet"
+msgstr "Yeni özel akışlar keşfet"
 
 #: src/view/screens/Search/Explore.tsx:425
 msgid "Discover new feeds"
-msgstr "Yeni beslemeler keşfet"
+msgstr "Yeni akışlar keşfet"
 
 #: src/view/screens/Feeds.tsx:725
 msgid "Discover New Feeds"
@@ -2497,7 +2497,7 @@ msgstr "Düzenleme Listesini Düzenle"
 #: src/Navigation.tsx:316
 #: src/view/screens/Feeds.tsx:515
 msgid "Edit My Feeds"
-msgstr "Beslemelerimi Düzenle"
+msgstr "Akışlarımı Düzenle"
 
 #: src/view/com/modals/EditProfile.tsx:147
 msgid "Edit my profile"
@@ -2566,11 +2566,11 @@ msgstr "E-posta"
 #: src/screens/Settings/components/DisableEmail2FADialog.tsx:64
 msgctxt "toast"
 msgid "Email 2FA disabled"
-msgstr ""
+msgstr "E-posta 2FA kaldırıldı"
 
 #: src/screens/Settings/PrivacyAndSecuritySettings.tsx:54
 msgid "Email 2FA enabled"
-msgstr ""
+msgstr "E-posta 2FA etkinleştirildi"
 
 #: src/screens/Login/ForgotPasswordForm.tsx:93
 msgid "Email address"
@@ -2578,7 +2578,7 @@ msgstr "E-posta adresi"
 
 #: src/components/intents/VerifyEmailIntentDialog.tsx:104
 msgid "Email Resent"
-msgstr ""
+msgstr "E-posta yeniden gönderildi"
 
 #: src/view/com/modals/ChangeEmail.tsx:54
 #: src/view/com/modals/ChangeEmail.tsx:83
@@ -2608,11 +2608,11 @@ msgstr ""
 #: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:498
 #: src/view/com/util/forms/PostDropdownBtnMenuItems.tsx:500
 msgid "Embed post"
-msgstr ""
+msgstr "Gönderiyi yerleştir"
 
 #: src/components/dialogs/Embed.tsx:112
 msgid "Embed this post in your website. Simply copy the following snippet and paste it into the HTML code of your website."
-msgstr ""
+msgstr "Bu gönderiyi web sitenize yerleştirin. Aşağıdaki kod parçacığını kopyalayın ve web sitenizin HTML koduna yapıştırın."
 
 #: src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerWeb.tsx:57
 msgid "Embedded video player"
@@ -2633,7 +2633,7 @@ msgstr "Yetişkin içeriği etkinleştirin"
 
 #: src/screens/Settings/components/Email2FAToggle.tsx:53
 msgid "Enable Email 2FA"
-msgstr ""
+msgstr "E-posta 2FA'yı etkinleştir"
 
 #: src/components/dialogs/EmbedConsent.tsx:81
 #: src/components/dialogs/EmbedConsent.tsx:88
@@ -2660,15 +2660,15 @@ msgstr "Yalnızca bu kaynağı etkinleştir"
 #: src/screens/Settings/ContentAndMediaSettings.tsx:123
 #: src/screens/Settings/ContentAndMediaSettings.tsx:137
 msgid "Enable trending topics"
-msgstr ""
+msgstr "Popüler konuları etkinleştir"
 
 #: src/screens/Settings/ContentAndMediaSettings.tsx:158
 msgid "Enable trending videos in your Discover feed"
-msgstr ""
+msgstr "Keşfet akışınızda popüler videoları etkinleştirin"
 
 #: src/screens/Settings/ContentAndMediaSettings.tsx:144
 msgid "Enable trending videos in your Discover feed."
-msgstr ""
+msgstr "Keşfet akışınızda popüler videoları etkinleştirin."
 
 #: src/screens/Messages/Settings.tsx:130
 #: src/screens/Messages/Settings.tsx:133
@@ -2678,24 +2678,24 @@ msgstr "Etkinleştirildi"
 
 #: src/screens/Profile/Sections/Feed.tsx:116
 msgid "End of feed"
-msgstr "Beslemenin sonu"
+msgstr "Akışın sonu"
 
 #: src/view/com/composer/videos/SubtitleDialog.tsx:159
 msgid "Ensure you have selected a language for each subtitle file."
-msgstr ""
+msgstr "Her altyazı dosyası için bir dil seçtiğinizden emin olun."
 
 #: src/screens/Login/SetNewPasswordForm.tsx:143
 msgid "Enter a password"
-msgstr ""
+msgstr "Bir şifre girin"
 
 #: src/components/dialogs/MutedWords.tsx:127
 #: src/components/dialogs/MutedWords.tsx:128
 msgid "Enter a word or tag"
-msgstr ""
+msgstr "Bir kelime veya etiket girin"
 
 #: src/components/dialogs/VerifyEmailDialog.tsx:89
 msgid "Enter Code"
-msgstr ""
+msgstr "Kodu Girin"
 
 #: src/view/com/modals/VerifyEmail.tsx:113
 msgid "Enter Confirmation Code"
@@ -2703,7 +2703,7 @@ msgstr "Onay Kodunu Girin"
 
 #: src/view/com/util/post-embeds/VideoEmbedInner/web-controls/VideoControls.tsx:405
 msgid "Enter fullscreen"
-msgstr ""
+msgstr "Tam ekrana gir"
 
 #: src/view/com/modals/ChangePassword.tsx:165
 msgid "Enter the code you received to change your password."
@@ -2736,7 +2736,7 @@ msgstr "Yeni e-posta adresinizi aşağıya girin."
 
 #: src/screens/Login/LoginForm.tsx:243
 msgid "Enter your password"
-msgstr ""
+msgstr "Şifrenizi girin"
 
 #: src/screens/Login/index.tsx:123
 msgid "Enter your username and password"
@@ -2744,7 +2744,7 @@ msgstr "Kullanıcı adınızı ve şifrenizi girin"
 
 #: src/view/com/util/post-embeds/VideoEmbedInner/VideoEmbedInnerNative.tsx:135
 msgid "Enters full screen"
-msgstr ""
+msgstr "Tam ekranı açar"
 
 #: src/view/com/composer/Composer.tsx:1661
 #: src/view/com/util/error/ErrorScreen.tsx:42
@@ -2757,7 +2757,7 @@ msgstr "Dosya kaydedilirken bir hata oluştu"
 
 #: src/screens/Signup/StepCaptcha/index.tsx:56
 msgid "Error receiving captcha response."
-msgstr ""
+msgstr "Captcha yanıtı alınırken bir hata oluştu."
 
 #: src/screens/Onboarding/StepInterests/index.tsx:183
 #: src/view/screens/Search/Search.tsx:114
@@ -2784,20 +2784,20 @@ msgstr "Herkes"
 #: src/components/moderation/ReportDialog/utils/useReportOptions.ts:73
 #: src/lib/moderation/useReportOptions.ts:73
 msgid "Excessive mentions or replies"
-msgstr ""
+msgstr "Fazla bahsetme veya yanıt"
 
 #: src/components/moderation/ReportDialog/utils/useReportOptions.ts:86
 #: src/lib/moderation/useReportOptions.ts:86
 msgid "Excessive or unwanted messages"
-msgstr ""
+msgstr "Fazla veya istenmeyen mesajlar"
 
 #: src/components/dialogs/MutedWords.tsx:311
 msgid "Exclude users you follow"
-msgstr ""
+msgstr "Takip ettiğiniz kullanıcıları hariç tut"
 
 #: src/components/dialogs/MutedWords.tsx:514
 msgid "Excludes users you follow"
-msgstr ""
+msgstr "Takip ettiğiniz kullanıcıları hariç tutar"
 
 #: src/view/com/util/post-embeds/VideoEmbedInner/web-controls/VideoControls.tsx:404
 msgid "Exit fullscreen"
@@ -2805,11 +2805,11 @@ msgstr "Tam ekrandan çık"
 
 #: src/view/com/modals/DeleteAccount.tsx:275
 msgid "Exits account deletion process"
-msgstr ""
+msgstr "Hesap silme işlemini iptal eder"
 
 #: src/view/com/modals/CropImage.web.tsx:95
 msgid "Exits image cropping process"
-msgstr ""
+msgstr "Resim kırpma işlemini iptal eder"
 
 #: src/view/com/lightbox/Lightbox.web.tsx:110
 msgid "Exits image view"
@@ -2825,7 +2825,7 @@ msgstr "Alternatif metni genişlet"
 
 #: src/view/com/notifications/NotificationFeedItem.tsx:406
 msgid "Expand list of users"
-msgstr ""
+msgstr "Kullanıcı listesini genişlet"
 
 #: src/view/com/composer/ComposerReplyTo.tsx:70
 msgid "Expand or collapse the full post you are replying to"
@@ -2833,15 +2833,15 @@ msgstr "Yanıt verdiğiniz tam gönderiyi genişletin veya daraltın"
 
 #: src/screens/VideoFeed/index.tsx:941
 msgid "Expands or collapses post text"
-msgstr ""
+msgstr "Gönderi metnini genişletir veya daraltır"
 
 #: src/view/com/composer/ComposerReplyTo.tsx:73
 msgid "Expands or collapses the full post you are replying to"
-msgstr ""
+msgstr "Yanıt verdiğiniz tam gönderiyi genişletir veya daraltır"
 
 #: src/lib/api/index.ts:406
 msgid "Expected uri to resolve to a record"
-msgstr ""
+msgstr "URI'nin bir kayda çözümlenmesi bekleniyordu"
 
 #: src/screens/Settings/FollowingFeedPreferences.tsx:123
 #: src/screens/Settings/ThreadPreferences.tsx:137
@@ -2854,35 +2854,35 @@ msgstr "Süresi dolmuş"
 
 #: src/components/dialogs/MutedWords.tsx:502
 msgid "Expires {0}"
-msgstr ""
+msgstr "Süresi dolacak: {0}"
 
 #: src/components/moderation/LabelsOnMeDialog.tsx:199
 #: src/components/moderation/ModerationDetailsDialog.tsx:208
 msgid "Expires in {0}"
-msgstr ""
+msgstr "{0} içinde sona erecek"
 
 #: src/lib/moderation/useGlobalLabelStrings.ts:47
 #: src/lib/moderation/useGlobalLabelStrings.ts:51
 msgid "Explicit or potentially disturbing media."
-msgstr ""
+msgstr "Açıkça belirtilmiş veya rahatsız edici olabilecek medya."
 
 #: src/lib/moderation/useGlobalLabelStrings.ts:35
 msgid "Explicit sexual images."
-msgstr ""
+msgstr "Açık seksüel resimler."
 
 #: src/screens/Settings/AccountSettings.tsx:137
 #: src/screens/Settings/AccountSettings.tsx:141
 msgid "Export my data"
-msgstr ""
+msgstr "Verilerimi dışa aktar"
 
 #: src/screens/Settings/components/ExportCarDialog.tsx:62
 msgid "Export My Data"
-msgstr ""
+msgstr "Verilerimi Dışa Aktar"
 
 #: src/screens/Settings/ContentAndMediaSettings.tsx:83
 #: src/screens/Settings/ContentAndMediaSettings.tsx:86
 msgid "External media"
-msgstr ""
+msgstr "Harici medya"
 
 #: src/components/dialogs/EmbedConsent.tsx:54
 #: src/components/dialogs/EmbedConsent.tsx:58
@@ -2902,19 +2902,19 @@ msgstr "Harici Medya Tercihleri"
 #: src/screens/Messages/components/RequestButtons.tsx:208
 msgctxt "toast"
 msgid "Failed to accept chat"
-msgstr ""
+msgstr "Sohbet kabul edilemedi"
 
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:568
 msgid "Failed to change handle. Please try again."
-msgstr ""
+msgstr "Kullanıcı adı değiştirilemedi. Lütfen tekrar deneyin."
 
 #: src/screens/Settings/components/AddAppPasswordDialog.tsx:173
 msgid "Failed to create app password. Please try again."
-msgstr ""
+msgstr "Uygulama şifresi oluşturulamadı. Lütfen tekrar deneyin."
 
 #: src/components/dms/MessageProfileButton.tsx:39
 msgid "Failed to create conversation"
-msgstr ""
+msgstr "Sohbet oluşturulamadı"
 
 #: src/screens/StarterPack/Wizard/index.tsx:233
 #: src/screens/StarterPack/Wizard/index.tsx:241
@@ -2929,7 +2929,7 @@ msgstr "Liste oluşturulamadı. İnternet bağlantınızı kontrol edin ve tekra
 #: src/screens/Messages/components/RequestButtons.tsx:267
 msgctxt "toast"
 msgid "Failed to delete chat"
-msgstr ""
+msgstr "Sohbet silinemedi"
 
 #: src/components/dms/MessageMenu.tsx:75
 msgid "Failed to delete message"
@@ -2946,12 +2946,12 @@ msgstr "Başlangıç paketi silinemedi"
 #: src/screens/Messages/ChatList.tsx:243
 #: src/screens/Messages/Inbox.tsx:187
 msgid "Failed to load conversations"
-msgstr ""
+msgstr "Sohbetler yüklenemedi"
 
 #: src/view/screens/Search/Explore.tsx:463
 #: src/view/screens/Search/Explore.tsx:491
 msgid "Failed to load feeds preferences"
-msgstr ""
+msgstr "Akış tercihleri yüklenemedi"
 
 #: src/components/dialogs/GifSelect.tsx:225
 msgid "Failed to load GIFs"
@@ -2964,16 +2964,16 @@ msgstr "Eski mesajlar yüklenemedi"
 #: src/view/screens/Search/Explore.tsx:456
 #: src/view/screens/Search/Explore.tsx:484
 msgid "Failed to load suggested feeds"
-msgstr ""
+msgstr "Önerilen akışlar yüklenemedi"
 
 #: src/view/screens/Search/Explore.tsx:414
 msgid "Failed to load suggested follows"
-msgstr ""
+msgstr "Önerilen takip edilecekler yüklenemedi"
 
 #: src/screens/Messages/Inbox.tsx:295
 #: src/screens/Messages/Inbox.tsx:318
 msgid "Failed to mark all requests as read"
-msgstr ""
+msgstr "Tüm istekler okunmuş olarak işaretlenemedi"
 
 #: src/state/queries/pinned-post.ts:75
 msgid "Failed to pin post"


### PR DESCRIPTION
As the Turkish exodus to Bluesky is still happening, many complained about the translation of the word **besleme** of **feed**. Which is not the most correct representation about the continuity/flow of posts. I'm suggesting using word **akış** for more correct translation as native Turkish speaker.

In this PR, there are some other improvements and additions that may make Turkish users experience smoother.