### PR TITLE
[Explore] Reduce scroll glitchiness on iOS

### DIFF
--- a/src/screens/Search/Explore.tsx
+++ b/src/screens/Search/Explore.tsx
@@ -766,6 +766,9 @@ export function Explore({
           )
         }
         // feed previews
+        case 'preview:spacer': {
+          return <View style={[a.w_full, a.pt_4xl]} />
+        }
         case 'preview:empty': {
           return null // what should we do here?
         }
@@ -799,7 +802,16 @@ export function Explore({
           )
         }
         case 'preview:footer': {
-          return <View style={[a.w_full, a.pt_2xl]} />
+          return (
+            <View
+              style={[
+                a.border_t,
+                t.atoms.border_contrast_low,
+                a.w_full,
+                a.pt_4xl,
+              ]}
+            />
+          )
         }
         case 'preview:sliceItem': {
           const slice = item.slice

--- a/src/state/queries/explore-feed-previews.tsx
+++ b/src/state/queries/explore-feed-previews.tsx
@@ -37,7 +37,7 @@ const LIMIT = 8 // sliced to 6, overfetch to account for moderation
 
 export type FeedPreviewItem =
   | {
-      type: 'topBorder'
+      type: 'preview:spacer'
       key: string
     }
   | {
@@ -130,6 +130,11 @@ export function useFeedPreviews(
       const items: FeedPreviewItem[] = []
 
       if (!enabled) return items
+
+      items.push({
+        type: 'preview:spacer',
+        key: 'spacer',
+      })
 
       const isEmpty =
         !isPending && !data?.pages?.some(page => page.posts.length)
@@ -240,23 +245,17 @@ export function useFeedPreviews(
             }
 
             if (slices.length > 0) {
-              if (pageIndex > 0) {
-                items.push({
-                  type: 'topBorder',
-                  key: `topBorder-${page.feed.uri}`,
-                })
-              }
               items.push(
-                {
-                  type: 'preview:footer',
-                  key: `footer-${page.feed.uri}`,
-                },
                 {
                   type: 'preview:header',
                   key: `header-${page.feed.uri}`,
                   feed: page.feed,
                 },
                 ...slices,
+                {
+                  type: 'preview:footer',
+                  key: `footer-${page.feed.uri}`,
+                },
               )
             }
           }


### PR DESCRIPTION
# Stacked on #8119 (that PR moves a file)

FlatList's sticky header implementation seems to struggle with having multiple sticky items onscreen at once. Removing use of `topBorder` from between feeds, which was only intended to be used at the very top of the Explore page, cuts down on scroll glitchiness significantly.

# Test plan

Compare to main:
- General scroll perf on iOS
- Whether it does the whiteout when fast scrolling
- Whether it gets jumpy when you manually drag the scrollbar
- Layout (I tried to get it looking the same as before)