### PR TITLE
[Explore] Invalidate queries post-interests edit

### DIFF
--- a/src/screens/Settings/SettingsInterests.tsx
+++ b/src/screens/Settings/SettingsInterests.tsx
@@ -11,6 +11,7 @@ import {
 } from '#/state/queries/preferences'
 import {type UsePreferencesQueryResponse} from '#/state/queries/preferences/types'
 import {createGetSuggestedFeedsQueryKey} from '#/state/queries/trending/useGetSuggestedFeedsQuery'
+import {createGetSuggestedUsersQueryKey} from '#/state/queries/trending/useGetSuggestedUsersQuery'
 import {createSuggestedStarterPacksQueryKey} from '#/state/queries/useSuggestedStarterPacksQuery'
 import {useAgent} from '#/state/session'
 import * as Toast from '#/view/com/util/Toast'
@@ -108,8 +109,16 @@ function Inner({
             return old
           },
         )
-        await qc.resetQueries({queryKey: createSuggestedStarterPacksQueryKey()})
-        await qc.resetQueries({queryKey: createGetSuggestedFeedsQueryKey()})
+        await Promise.all([
+          await qc.resetQueries({
+            queryKey: createSuggestedStarterPacksQueryKey(),
+          }),
+          await qc.resetQueries({queryKey: createGetSuggestedFeedsQueryKey()}),
+          await qc.resetQueries({
+            queryKey: createGetSuggestedUsersQueryKey({}),
+          }),
+        ])
+
         Toast.show(
           _(msg({message: 'Content preferences updated!', context: 'toast'})),
         )

--- a/src/screens/Settings/SettingsInterests.tsx
+++ b/src/screens/Settings/SettingsInterests.tsx
@@ -10,6 +10,8 @@ import {
   usePreferencesQuery,
 } from '#/state/queries/preferences'
 import {type UsePreferencesQueryResponse} from '#/state/queries/preferences/types'
+import {createGetSuggestedFeedsQueryKey} from '#/state/queries/trending/useGetSuggestedFeedsQuery'
+import {createSuggestedStarterPacksQueryKey} from '#/state/queries/useSuggestedStarterPacksQuery'
 import {useAgent} from '#/state/session'
 import * as Toast from '#/view/com/util/Toast'
 import {useInterestsDisplayNames} from '#/screens/Onboarding/state'
@@ -98,7 +100,16 @@ function Inner({
 
       try {
         await agent.setInterestsPref({tags: interests})
-        await qc.invalidateQueries({queryKey: preferencesQueryKey})
+        qc.setQueriesData(
+          {queryKey: preferencesQueryKey},
+          (old?: UsePreferencesQueryResponse) => {
+            if (!old) return old
+            old.interests.tags = interests
+            return old
+          },
+        )
+        await qc.resetQueries({queryKey: createSuggestedStarterPacksQueryKey()})
+        await qc.resetQueries({queryKey: createGetSuggestedFeedsQueryKey()})
         Toast.show(
           _(msg({message: 'Content preferences updated!', context: 'toast'})),
         )

--- a/src/state/queries/trending/useGetSuggestedFeedsQuery.ts
+++ b/src/state/queries/trending/useGetSuggestedFeedsQuery.ts
@@ -11,7 +11,7 @@ import {useAgent} from '#/state/session'
 
 export const DEFAULT_LIMIT = 5
 
-export const createGetTrendsQueryKey = () => ['suggested-feeds']
+export const createGetSuggestedFeedsQueryKey = () => ['suggested-feeds']
 
 export function useGetSuggestedFeedsQuery() {
   const agent = useAgent()
@@ -22,7 +22,7 @@ export function useGetSuggestedFeedsQuery() {
     enabled: !!preferences,
     refetchOnWindowFocus: true,
     staleTime: STALE.MINUTES.ONE,
-    queryKey: createGetTrendsQueryKey(),
+    queryKey: createGetSuggestedFeedsQueryKey(),
     queryFn: async () => {
       const contentLangs = getContentLanguages().join(',')
       const {data} = await agent.app.bsky.unspecced.getSuggestedFeeds(


### PR DESCRIPTION
Realized there was a race here between refetching preferences and getting that data back into the subsequent query re-fetches. Since this is very simple data, I think we can just optimistically insert into the query cache and then refetch.

Not terribly worried about remote data getting out of sync since that would require the user to be editing these interests simultaneously on separate devices, and our goal here is to get the user fresh data after they make edits.

And since these queries have `staleTime` set, we need to fully `reset` them, not just invalidate.

Leaving this open bc we need to refetch:
- [x] starter packs
- [x] feed previews
- [x] suggested users