### PR TITLE
Fix typo in `SettingsInterests.tsx`

### DIFF
--- a/src/screens/Settings/SettingsInterests.tsx
+++ b/src/screens/Settings/SettingsInterests.tsx
@@ -126,7 +126,7 @@ function Inner({
         Toast.show(
           _(
             msg({
-              message: 'Failed to save content prefefences.',
+              message: 'Failed to save content preferences.',
               context: 'toast',
             }),
           ),


### PR DESCRIPTION
This PR fixes a typo in `SettingsInterests.tsx`:

`Failed to save content prefefences.`
⬇️
`Failed to save content preferences.`