### PR TITLE
Various explore fixes: old type definition and rare header alignment issue

### DIFF
--- a/src/logger/metrics.ts
+++ b/src/logger/metrics.ts
@@ -330,7 +330,6 @@ export type MetricEvents = {
       | 'suggestedFeeds'
       | 'suggestedStarterPacks'
       | `feed:${FeedDescriptor}`
-    index: number
   }
   'explore:module:searchButtonPress': {
     module: 'suggestedAccounts' | 'suggestedFeeds'

--- a/src/screens/Search/Explore.tsx
+++ b/src/screens/Search/Explore.tsx
@@ -854,7 +854,7 @@ export function Explore({
     }
     if (!alreadyReportedRef.current.has(module)) {
       alreadyReportedRef.current.set(module, module)
-      logger.metric('explore:module:seen', {module}) //, index: index ?? -1})
+      logger.metric('explore:module:seen', {module})
     }
   }, [])
 

--- a/src/screens/Search/Explore.tsx
+++ b/src/screens/Search/Explore.tsx
@@ -737,7 +737,6 @@ export function Explore({
         case 'preview:header': {
           return (
             <ModuleHeader.Container
-              headerHeight={headerHeight}
               style={[a.pt_xs, a.border_b, t.atoms.border_contrast_low]}>
               <ModuleHeader.FeedLink feed={item.feed}>
                 <ModuleHeader.FeedAvatar feed={item.feed} />

--- a/src/screens/Search/components/ModuleHeader.tsx
+++ b/src/screens/Search/components/ModuleHeader.tsx
@@ -6,7 +6,7 @@ import {PressableScale} from '#/lib/custom-animations/PressableScale'
 import {makeCustomFeedLink} from '#/lib/routes/links'
 import {logger} from '#/logger'
 import {UserAvatar} from '#/view/com/util/UserAvatar'
-import {atoms as a, native, useTheme, type ViewStyleProp, web} from '#/alf'
+import {atoms as a, native, useTheme, type ViewStyleProp} from '#/alf'
 import {Button, ButtonIcon} from '#/components/Button'
 import * as FeedCard from '#/components/FeedCard'
 import {sizes as iconSizes} from '#/components/icons/common'
@@ -17,8 +17,7 @@ import {Text, type TextProps} from '#/components/Typography'
 export function Container({
   style,
   children,
-  headerHeight,
-}: {children: React.ReactNode; headerHeight?: number} & ViewStyleProp) {
+}: {children: React.ReactNode} & ViewStyleProp) {
   const t = useTheme()
   return (
     <View
@@ -30,7 +29,6 @@ export function Container({
         a.pb_md,
         a.gap_sm,
         t.atoms.bg,
-        headerHeight && web({position: 'sticky', top: headerHeight}),
         style,
       ]}>
       {/* Very non-scientific way to avoid small gap on scroll */}


### PR DESCRIPTION
1. Old type definition: this is a metric type definition change I missed in a previous PR 6e26670cf36e33a832347f2d5deda508dcf6d08a
2. Removed position: sticky from the feed headers (more below) 706db5d8920ca905e46102bb23f5e040512726d2

There is a case in Chrome, which we believe to be on certain pixel densities, where certain window widths will trigger an incorrect layout:

![image](https://github.com/user-attachments/assets/71ccd3e6-885c-4072-81a0-75d40b133da4)

This can be triggered by a `position: sticky` inside of a `margin: 0 auto`. The one clue I found is that chrome uses integers for margin calculations, and so my theory is that `position: sticky` is causing the element positioning to get calculated at a different precision. This theory is backed up by the fact that the condition occurs when the margin calculation comes out to `.5` pixels.

Unfortunately this is an issue that hits us anywhere we use `position: sticky`, but for now I'm just fixing it here