### PR TITLE
[Explore] Tweak performance settings on Android

### DIFF
--- a/src/screens/Search/Explore.tsx
+++ b/src/screens/Search/Explore.tsx
@@ -9,7 +9,6 @@ import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 import {useQueryClient} from '@tanstack/react-query'
 
-import {useInitialNumToRender} from '#/lib/hooks/useInitialNumToRender'
 import {useGate} from '#/lib/statsig/statsig'
 import {cleanError} from '#/lib/strings/errors'
 import {sanitizeHandle} from '#/lib/strings/handles'
@@ -208,7 +207,6 @@ export function Explore({
 }) {
   const {_} = useLingui()
   const t = useTheme()
-  const initialNumToRender = useInitialNumToRender()
   const {data: preferences, error: preferencesError} = usePreferencesQuery()
   const moderationOpts = useModerationOpts()
   const gate = useGate()
@@ -931,11 +929,26 @@ export function Explore({
       viewabilityConfig={viewabilityConfig}
       onItemSeen={onItemSeen}
       onEndReached={onLoadMoreFeedPreviews}
-      onEndReachedThreshold={3}
-      initialNumToRender={initialNumToRender}
-      windowSize={9}
-      maxToRenderPerBatch={platform({ios: 5, default: 1})}
-      updateCellsBatchingPeriod={40}
+      /**
+       * Default: 2
+       */
+      onEndReachedThreshold={4}
+      /**
+       * Default: 10
+       */
+      initialNumToRender={10}
+      /**
+       * Default: 21
+       */
+      windowSize={platform({android: 11})}
+      /**
+       * Default: 10
+       */
+      maxToRenderPerBatch={platform({android: 1})}
+      /**
+       * Default: 50
+       */
+      updateCellsBatchingPeriod={platform({android: 25})}
       refreshing={isPTR}
       onRefresh={onPTR}
     />


### PR DESCRIPTION
In general, the approach I'm taking here is to prioritize responsiveness over preventing blank sections. At a reasonable scrolling speed, I'm getting hardly any blank sections, and scrolling does not glitch.

- `maxToRenderPerBatch` lowered this to prioritize responsiveness
- `updateCellsBatchingPeriod` with a lower `maxToRenderPerBatch`, halving this value seems to make renders snappier
- `windowSize` dropped this to 5 above, 5 below, with one in the middle (the active one), seemed to help with blank screens
- `onEndReachedThreshold` doubled this — with the smaller values above, my intention here is to have the data ready once the `List` renders those components to avoid the loading state rendering and flashing
- `initialNumToRender` the hook we have is designed for posts — this screen needs about 9 slices to fill the screen on native, so I left this as the default 10

iOS on my 14 pro is as snappy as ever.