### PR TITLE
Fix Hosting Provider button height on Android

### DIFF
--- a/src/components/forms/HostingProvider.tsx
+++ b/src/components/forms/HostingProvider.tsx
@@ -4,7 +4,6 @@ import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
 import {toNiceDomain} from '#/lib/strings/url-helpers'
-import {isAndroid} from '#/platform/detection'
 import {ServerInputDialog} from '#/view/com/auth/server-input'
 import {atoms as a, tokens, useTheme} from '#/alf'
 import {Button, ButtonIcon, ButtonText} from '#/components/Button'
@@ -75,10 +74,10 @@ export function HostingProvider({
             a.flex_row,
             a.align_center,
             a.rounded_sm,
+            a.py_sm,
             a.pl_md,
             a.pr_sm,
             a.gap_xs,
-            {paddingVertical: isAndroid ? 14 : 8},
           ]}
           onPress={onPressSelectService}>
           {({hovered, pressed}) => {


### PR DESCRIPTION
Inputs used to be taller on Android for some reason. No longer, so let's make the hosting provider button consistent

<table>
  <thead>
    <tr>
      <th>Before</th>
      <th>After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><img width="400" src="https://github.com/user-attachments/assets/a2bab8f3-60a9-4bd6-906b-4dccf83b1fcc" /></td>
      <td><img width="400" src="https://github.com/user-attachments/assets/ff0cdda6-fac0-4405-9d12-86feec0de12f" /></td>
    </tr>
  </tbody>
</table>