### PR TITLE
Fix labels section not scrolling at all on Android

### DIFF
--- a/src/screens/Profile/Sections/Labels.tsx
+++ b/src/screens/Profile/Sections/Labels.tsx
@@ -99,7 +99,7 @@ export const ProfileLabelsSection = React.forwardRef<
   }, [isFocused, scrollElRef, setScrollViewTag])
 
   return (
-    <Layout.Center style={{flex: 1, minHeight}}>
+    <Layout.Center style={{minHeight}}>
       <Layout.Content
         ref={scrollElRef as React.Ref<Animated.ScrollView>}
         scrollEventThrottle={1}


### PR DESCRIPTION
# Stacked on #8088 

I haven't determined _when_ this started breaking, but currently scrolling on the labels section of a labeller profile is completely broken on Android. It appears to be due to a `flex:1` on the containing element

# Test plan

Test scrolling the label section on _all_ platforms. Test a labeller with a lot of labels, like bsky mod service, and one with few, like kiki-bouba. Confirm scrolling works on all of them