### PR TITLE
[Embed] Fix 3-image grid on Safari

### DIFF
--- a/bskyembed/src/components/embed.tsx
+++ b/bskyembed/src/components/embed.tsx
@@ -250,18 +250,20 @@ function ImageEmbed({
     case 3:
       return (
         <div className="flex gap-1 rounded-xl overflow-hidden w-full aspect-[2/1]">
-          <img
-            src={content.images[0].thumb}
-            alt={content.images[0].alt}
-            className="flex-1 aspect-square object-cover rounded-sm"
-          />
-          <div className="flex flex-col gap-1 flex-1 aspect-square">
+          <div className="flex-1 aspect-square">
+            <img
+              src={content.images[0].thumb}
+              alt={content.images[0].alt}
+              className="w-full h-full object-cover rounded-sm"
+            />
+          </div>
+          <div className="flex flex-col gap-1 flex-1">
             {content.images.slice(1).map((image, i) => (
               <img
                 key={i}
                 src={image.thumb}
                 alt={image.alt}
-                className="w-full h-full object-cover rounded-sm"
+                className="flex-1 object-cover rounded-sm min-h-0"
               />
             ))}
           </div>

--- a/bskyembed/src/components/embed.tsx
+++ b/bskyembed/src/components/embed.tsx
@@ -277,7 +277,7 @@ function ImageEmbed({
               key={i}
               src={image.thumb}
               alt={image.alt}
-              className="aspect-video w-full object-cover rounded-sm"
+              className="aspect-[3/2] w-full object-cover rounded-sm"
             />
           ))}
         </div>


### PR DESCRIPTION
Turns out https://github.com/bluesky-social/social-app/pull/8185 doesn't work on safari - its aspect ratio support seems a bit sketchy? This changes it to lean harder on flexbox for the layout so that it works on all browsers

<img width="1705" alt="Screenshot 2025-04-15 at 14 43 11" src="https://github.com/user-attachments/assets/17f2ae38-d1b7-4239-b004-8da83c1896f2" />

# Test plan

Test a 3-image grid on _all_ browsers, _especially_ safari.
Example post: https://bsky.app/profile/samuel.bsky.team/post/3lmscjwnu2k2k