### PR TITLE
Improve alt text dialog, and dialog keyboard handling in general

### DIFF
--- a/src/view/com/composer/photos/ImageAltTextDialog.tsx
+++ b/src/view/com/composer/photos/ImageAltTextDialog.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import {ImageStyle, useWindowDimensions, View} from 'react-native'
+import {type ImageStyle, useWindowDimensions, View} from 'react-native'
 import {Image} from 'expo-image'
 import {msg, Plural, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
@@ -7,12 +7,12 @@ import {useLingui} from '@lingui/react'
 import {MAX_ALT_TEXT} from '#/lib/constants'
 import {enforceLen} from '#/lib/strings/helpers'
 import {isAndroid, isWeb} from '#/platform/detection'
-import {ComposerImage} from '#/state/gallery'
+import {type ComposerImage} from '#/state/gallery'
 import {AltTextCounterWrapper} from '#/view/com/composer/AltTextCounterWrapper'
 import {atoms as a, useTheme} from '#/alf'
 import {Button, ButtonText} from '#/components/Button'
 import * as Dialog from '#/components/Dialog'
-import {DialogControlProps} from '#/components/Dialog'
+import {type DialogControlProps} from '#/components/Dialog'
 import * as TextField from '#/components/forms/TextField'
 import {CircleInfo_Stroke2_Corner0_Rounded as CircleInfo} from '#/components/icons/CircleInfo'
 import {Text} from '#/components/Typography'
@@ -85,7 +85,13 @@ const ImageAltTextInner = ({
   }, [image, windim])
 
   return (
-    <Dialog.ScrollableInner label={_(msg`Add alt text`)}>
+    <Dialog.ScrollableInner
+      label={_(msg`Add alt text`)}
+      // make sure that the save button is visible when the dialog is opened.
+      // the keyboardawarescrollview will scroll to make the text input visible
+      // on mount, and the text input is autofocusing. adding extra bottomOffset
+      // makes sure that input is scrolled far enough to show the save button -sfn
+      bottomOffset={100}>
       <Dialog.Close />
 
       <View>

--- a/src/view/com/composer/photos/ImageAltTextDialog.tsx
+++ b/src/view/com/composer/photos/ImageAltTextDialog.tsx
@@ -29,10 +29,12 @@ export const ImageAltTextDialog = ({
   onChange,
 }: Props): React.ReactNode => {
   const [altText, setAltText] = React.useState(image.alt)
+  const {height} = useWindowDimensions()
 
   return (
     <Dialog.Outer
       control={control}
+      nativeOptions={{minHeight: height}}
       onClose={() => {
         onChange({
           ...image,


### PR DESCRIPTION
The alt text dialog is currently quite janky - this is because extra padding is added when a dialog becomes full height, and also when the keyboard is opened. This causes relayouting when the keyboard changes, which is especially apparent in the alt text dialog. This PR:

- Adds a consistent amount of padding when the keyboard is open on iOS rather than dividing the keyboard height by 4 (which obviously was not a scientific number, just a hack to get ~80px)
- Uses a simpler (non-reanimated) hook to get the keyboard state
- Removes the keyboard padding code from Android (since that was always 0 anyway, because keyboard-controller was disabled there)
- Increases the `extraOffset` of the `KeyboardAwareScrollView` for the alt text dialog, so that the save button is visible (to match current behaviour)
- Keeps the alt text dialog height at max height so it moves around less

# Before

https://github.com/user-attachments/assets/76372a2c-2d91-4804-8658-a02ad2845462

# After

https://github.com/user-attachments/assets/9e548c4b-69eb-461c-9626-6821a566f9ca

# Test plan

- Confirm the alt text dialog is less janky on iOS
- Confirm it's still pretty much the same on Android and web
- Confirm other dialogs with text inputs in them are not impacted