### PR TITLE
[Explore] Run refresh queries in parallel

### DIFF
--- a/src/screens/Search/Explore.tsx
+++ b/src/screens/Search/Explore.tsx
@@ -303,19 +303,19 @@ export function Explore({
   const onPTR = useCallback(async () => {
     setIsPTR(true)
     await Promise.all([
-      await qc.resetQueries({
+      qc.resetQueries({
         queryKey: createGetTrendsQueryKey(),
       }),
-      await qc.resetQueries({
+      qc.resetQueries({
         queryKey: createSuggestedStarterPacksQueryKey(),
       }),
-      await qc.resetQueries({
+      qc.resetQueries({
         queryKey: [getSuggestedUsersQueryKeyRoot],
       }),
-      await qc.resetQueries({
+      qc.resetQueries({
         queryKey: [useActorSearchPaginatedQueryKeyRoot],
       }),
-      await qc.resetQueries({
+      qc.resetQueries({
         queryKey: createGetSuggestedFeedsQueryKey(),
       }),
     ])


### PR DESCRIPTION
The PTR mechanism has a Promise.all, but it accidentally awaits each of the promises, so it runs sequentially. Removing the awaits runs them in parallel