### PR TITLE
Tweak image alt text in verification nux dialog

### DIFF
--- a/src/components/dialogs/nuxs/InitialVerificationAnnouncement.tsx
+++ b/src/components/dialogs/nuxs/InitialVerificationAnnouncement.tsx
@@ -115,7 +115,7 @@ export function InitialVerificationAnnouncement() {
                 },
               ]}
               alt={_(
-                msg`An mockup of a iPhone showing the Bluesky app open to the profile of a verified user with a blue checkmark next to their display name.`,
+                msg`A mockup of an iPhone showing the Bluesky app open to the profile of a verified user with a blue checkmark next to their display name.`,
               )}
             />
           </View>


### PR DESCRIPTION
This PR proposes a small grammatical tweak to one of the alt text fields in the verification nux dialog:

`An mockup of a iPhone …`
⬇️
`A mockup of an iPhone …`