### PR TITLE
Remove "More" on PostThreadItem

### DIFF
--- a/src/state/queries/post-thread.ts
+++ b/src/state/queries/post-thread.ts
@@ -45,7 +45,6 @@ type ThreadViewNode = AppBskyFeedGetPostThread.OutputSchema['thread']
 export interface ThreadCtx {
   depth: number
   isHighlightedPost?: boolean
-  hasMore?: boolean
   isParentLoading?: boolean
   isChildLoading?: boolean
   isSelfThread?: boolean
@@ -370,8 +369,6 @@ function responseToThreadNodes(
       ctx: {
         depth,
         isHighlightedPost: depth === 0,
-        hasMore:
-          direction === 'down' && !node.replies?.length && !!post.replyCount,
         isSelfThread: false, // populated `annotateSelfThread`
         hasMoreSelfThread: false, // populated in `annotateSelfThread`
       },
@@ -579,7 +576,6 @@ function threadNodeToPlaceholderThread(
     ctx: {
       depth: 0,
       isHighlightedPost: true,
-      hasMore: false,
       isParentLoading: !!node.record.reply,
       isChildLoading: !!node.post.replyCount,
     },
@@ -601,7 +597,6 @@ function postViewToPlaceholderThread(
     ctx: {
       depth: 0,
       isHighlightedPost: true,
-      hasMore: false,
       isParentLoading: !!(post.record as AppBskyFeedPost.Record).reply,
       isChildLoading: true, // assume yes (show the spinner) just in case
     },
@@ -623,7 +618,6 @@ function embedViewRecordToPlaceholderThread(
     ctx: {
       depth: 0,
       isHighlightedPost: true,
-      hasMore: false,
       isParentLoading: !!(record.value as AppBskyFeedPost.Record).reply,
       isChildLoading: true, // not available, so assume yes (to show the spinner)
     },

--- a/src/view/com/post-thread/PostThread.tsx
+++ b/src/view/com/post-thread/PostThread.tsx
@@ -5,7 +5,7 @@ import Animated from 'react-native-reanimated'
 import {useSafeAreaInsets} from 'react-native-safe-area-context'
 import {
   AppBskyFeedDefs,
-  AppBskyFeedThreadgate,
+  type AppBskyFeedThreadgate,
   moderatePost,
 } from '@atproto/api'
 import {msg, Trans} from '@lingui/macro'
@@ -25,11 +25,11 @@ import {useModerationOpts} from '#/state/preferences/moderation-opts'
 import {
   fillThreadModerationCache,
   sortThread,
-  ThreadBlocked,
-  ThreadModerationCache,
-  ThreadNode,
-  ThreadNotFound,
-  ThreadPost,
+  type ThreadBlocked,
+  type ThreadModerationCache,
+  type ThreadNode,
+  type ThreadNotFound,
+  type ThreadPost,
   usePostThreadQuery,
 } from '#/state/queries/post-thread'
 import {useSetThreadViewPreferencesMutation} from '#/state/queries/preferences'
@@ -37,7 +37,7 @@ import {usePreferencesQuery} from '#/state/queries/preferences'
 import {useSession} from '#/state/session'
 import {useComposerControls} from '#/state/shell'
 import {useMergedThreadgateHiddenReplies} from '#/state/threadgate-hidden-replies'
-import {List, ListMethods} from '#/view/com/util/List'
+import {List, type ListMethods} from '#/view/com/util/List'
 import {atoms as a, useTheme} from '#/alf'
 import {Button, ButtonIcon} from '#/components/Button'
 import {SettingsSliderVertical_Stroke2_Corner0_Rounded as SettingsSlider} from '#/components/icons/SettingsSlider'
@@ -500,7 +500,6 @@ export function PostThread({uri}: {uri: string | undefined}) {
             prevPost={prev}
             nextPost={next}
             isHighlightedPost={item.ctx.isHighlightedPost}
-            hasMore={item.ctx.hasMore}
             showChildReplyLine={showChildReplyLine}
             showParentReplyLine={showParentReplyLine}
             hasPrecedingItem={showParentReplyLine || !!hasUnrevealedParents}

--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -51,7 +51,6 @@ import {colors} from '#/components/Admonition'
 import {Button} from '#/components/Button'
 import {useInteractionState} from '#/components/hooks/useInteractionState'
 import {CalendarClock_Stroke2_Corner0_Rounded as CalendarClockIcon} from '#/components/icons/CalendarClock'
-import {ChevronRight_Stroke2_Corner0_Rounded as ChevronRightIcon} from '#/components/icons/Chevron'
 import {Trash_Stroke2_Corner0_Rounded as TrashIcon} from '#/components/icons/Trash'
 import {InlineLinkText} from '#/components/Link'
 import {ContentHider} from '#/components/moderation/ContentHider'
@@ -76,7 +75,6 @@ export function PostThreadItem({
   prevPost,
   nextPost,
   isHighlightedPost,
-  hasMore,
   showChildReplyLine,
   showParentReplyLine,
   hasPrecedingItem,
@@ -93,7 +91,6 @@ export function PostThreadItem({
   prevPost: ThreadPost | undefined
   nextPost: ThreadPost | undefined
   isHighlightedPost?: boolean
-  hasMore?: boolean
   showChildReplyLine?: boolean
   showParentReplyLine?: boolean
   hasPrecedingItem: boolean
@@ -128,7 +125,6 @@ export function PostThreadItem({
         treeView={treeView}
         depth={depth}
         isHighlightedPost={isHighlightedPost}
-        hasMore={hasMore}
         showChildReplyLine={showChildReplyLine}
         showParentReplyLine={showParentReplyLine}
         hasPrecedingItem={hasPrecedingItem}
@@ -173,7 +169,6 @@ let PostThreadItemLoaded = ({
   prevPost,
   nextPost,
   isHighlightedPost,
-  hasMore,
   showChildReplyLine,
   showParentReplyLine,
   hasPrecedingItem,
@@ -191,7 +186,6 @@ let PostThreadItemLoaded = ({
   prevPost: ThreadPost | undefined
   nextPost: ThreadPost | undefined
   isHighlightedPost?: boolean
-  hasMore?: boolean
   showChildReplyLine?: boolean
   showParentReplyLine?: boolean
   hasPrecedingItem: boolean
@@ -215,7 +209,6 @@ let PostThreadItemLoaded = ({
     const urip = new AtUri(post.uri)
     return makeProfileLink(post.author, 'post', urip.rkey)
   }, [post.uri, post.author])
-  const itemTitle = _(msg`Post by ${post.author.handle}`)
   const authorHref = makeProfileLink(post.author)
   const authorTitle = post.author.handle
   const isThreadAuthor = getThreadAuthor(post, record) === currentAccount?.did
@@ -647,29 +640,6 @@ let PostThreadItemLoaded = ({
               />
             </View>
           </View>
-          {hasMore ? (
-            <Link
-              style={[
-                styles.loadMore,
-                {
-                  paddingLeft: treeView ? 8 : 70,
-                  paddingTop: 0,
-                  paddingBottom: treeView ? 4 : 12,
-                },
-              ]}
-              href={postHref}
-              title={itemTitle}
-              noFeedback>
-              <Text
-                style={[t.atoms.text_contrast_medium, a.font_bold, a.text_sm]}>
-                <Trans>More</Trans>
-              </Text>
-              <ChevronRightIcon
-                size="xs"
-                style={[t.atoms.text_contrast_medium]}
-              />
-            </Link>
-          ) : undefined}
         </PostHider>
       </PostOuterWrapper>
     )


### PR DESCRIPTION
I don't understand what this is for. It looks misaligned and it doesn't say anything that isn't already said by the number of replies below. I suspect it started showing up by accident due to some change in the data model.

Can we pleeease kill it.

I nuked both the UI and the viewmodel part for it because it wasn't used by anything else, and simpler = better.

## Before

<img width="764" alt="Screenshot 2025-04-20 at 14 37 31" src="https://github.com/user-attachments/assets/ef22765a-61bc-46da-9390-587ac462a3d4" />

## After

<img width="801" alt="Screenshot 2025-04-20 at 14 38 09" src="https://github.com/user-attachments/assets/82f93f32-9eb2-4af3-a5b9-00dc992a6f58" />
