### PR TITLE
Fix composer reply line height

### DIFF
--- a/src/view/com/composer/ComposerReplyTo.tsx
+++ b/src/view/com/composer/ComposerReplyTo.tsx
@@ -76,6 +76,7 @@ export function ComposerReplyTo({replyTo}: {replyTo: ComposerOptsPostRef}) {
         a.mx_lg,
         a.border_b,
         t.atoms.border_contrast_medium,
+        a.user_select_text,
       ]}
       onPress={onPress}
       accessibilityRole="button"
@@ -113,7 +114,7 @@ export function ComposerReplyTo({replyTo}: {replyTo: ComposerOptsPostRef}) {
         <View style={[a.flex_row, a.gap_md]}>
           <View style={[a.flex_1, a.flex_grow]}>
             <Text
-              style={[a.text_md]}
+              style={[a.text_md, a.leading_snug, t.atoms.text_contrast_high]}
               numberOfLines={!showFull ? 6 : undefined}
               emoji>
               {replyTo.text}


### PR DESCRIPTION
Follow up from #8226 

<table>
  <thead>
    <tr>
      <th>Pre verification change</th>
      <th>Currently on `main`</th>
      <th>After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><img width="600" src="https://github.com/user-attachments/assets/f36805f8-b8af-4f61-b330-eb9d65afa8cb" /></td>
      <td><img width="600" src="https://github.com/user-attachments/assets/0b7fc7c1-0d82-4eb9-9507-79ab58337a7c" /></td>
      <td><img width="600" src="https://github.com/user-attachments/assets/5695d1d6-fd16-42c4-82b1-632a5a163aa1" /></td>
    </tr>
  </tbody>
</table>