### PR TITLE
Remove double close button

### DIFF
--- a/src/components/verification/VerifierDialog.tsx
+++ b/src/components/verification/VerifierDialog.tsx
@@ -146,8 +146,6 @@ function Inner({
           </Button>
         </View>
       </View>
-
-      <Dialog.Close />
     </Dialog.ScrollableInner>
   )
 }


### PR DESCRIPTION
Decided to keep the outer one, since the inner one overlaps with the content