### PR TITLE
Improve display name in Settings

### DIFF
--- a/src/screens/Settings/Settings.tsx
+++ b/src/screens/Settings/Settings.tsx
@@ -290,6 +290,10 @@ function ProfilePreview({
   if (!moderationOpts) return null
 
   const moderation = moderateProfile(profile, moderationOpts)
+  const displayName = sanitizeDisplayName(
+    profile.displayName || sanitizeHandle(profile.handle),
+    moderation.ui('displayName'),
+  )
 
   return (
     <>
@@ -300,7 +304,14 @@ function ProfilePreview({
         type={shadow.associated?.labeler ? 'labeler' : 'user'}
       />
 
-      <View style={[a.flex_row, a.gap_xs, a.align_center]}>
+      <View
+        style={[
+          a.flex_row,
+          a.gap_xs,
+          a.align_center,
+          a.justify_center,
+          a.w_full,
+        ]}>
         <Text
           emoji
           testID="profileHeaderDisplayName"
@@ -311,10 +322,7 @@ function ProfilePreview({
             gtMobile ? a.text_4xl : a.text_3xl,
             a.font_heavy,
           ]}>
-          {sanitizeDisplayName(
-            profile.displayName || sanitizeHandle(profile.handle),
-            moderation.ui('displayName'),
-          )}
+          {displayName}
         </Text>
         {shouldShowVerificationCheckButton(verificationState) && (
           <View


### PR DESCRIPTION
This improves the rendering so that long display names don't overflow the container on web, but does not resolve why on Android, _some_ display names are truncated more than necessary.

No change to verification checks if they exist.

![CleanShot 2025-04-21 at 14 56 50@2x](https://github.com/user-attachments/assets/d40053d4-1aa9-49c8-b91e-260a03e7cd5a)
