### PR TITLE
introduce context for "Following" as the feed name.

### DIFF
--- a/src/view/screens/Feeds.tsx
+++ b/src/view/screens/Feeds.tsx
@@ -596,7 +596,7 @@ function FollowingFeed() {
             fill={t.palette.white}
           />
         </View>
-        <FeedCard.TitleAndByline title={_(msg`Following`)} />
+        <FeedCard.TitleAndByline title={_(msg({message: 'Following', context: 'feed-name'}))} />
       </FeedCard.Header>
     </View>
   )

--- a/src/view/screens/SavedFeeds.tsx
+++ b/src/view/screens/SavedFeeds.tsx
@@ -419,7 +419,7 @@ function FollowingFeedCard() {
       <View
         style={{flex: 1, flexDirection: 'row', gap: 8, alignItems: 'center'}}>
         <Text type="lg-medium" style={[t.atoms.text]} numberOfLines={1}>
-          <Trans>Following</Trans>
+          <Trans context="feed-name">Following</Trans>
         </Text>
       </View>
     </View>


### PR DESCRIPTION
"Following" has different translations as the name of the main feed and the state of following someone in languages like Turkish. This allows "Following" as the feed name to be translated correctly.

This may introduce a regression if some languages are okay using the same translation for both uses of "Following", but since their purpose are different, I think the contextual split is warranted.

This change only affects the two strings in this patch, not the other uses of "Following".