### PR TITLE
Fix first sheet height change not registering (iOS)

### DIFF
--- a/modules/bottom-sheet/ios/SheetView.swift
+++ b/modules/bottom-sheet/ios/SheetView.swift
@@ -144,7 +144,8 @@ class SheetView: ExpoView, UISheetPresentationControllerDelegate {
   }
 
   func updateLayout() {
-    if self.prevLayoutDetentIdentifier == self.selectedDetentIdentifier,
+    // Allow updates either when identifiers match OR when prevLayoutDetentIdentifier is nil (first real content update)
+    if (self.prevLayoutDetentIdentifier == self.selectedDetentIdentifier || self.prevLayoutDetentIdentifier == nil),
        let contentHeight = self.innerView?.subviews.first?.frame.size.height {
       self.sheetVc?.updateDetents(contentHeight: self.clampHeight(contentHeight),
                                   preventExpansion: self.preventExpansion)

--- a/modules/bottom-sheet/src/BottomSheetNativeComponent.tsx
+++ b/modules/bottom-sheet/src/BottomSheetNativeComponent.tsx
@@ -1,18 +1,21 @@
 import * as React from 'react'
 import {
   Dimensions,
-  LayoutChangeEvent,
-  NativeSyntheticEvent,
+  type LayoutChangeEvent,
+  type NativeSyntheticEvent,
   Platform,
-  StyleProp,
+  type StyleProp,
   View,
-  ViewStyle,
+  type ViewStyle,
 } from 'react-native'
 import {useSafeAreaInsets} from 'react-native-safe-area-context'
 import {requireNativeModule, requireNativeViewManager} from 'expo-modules-core'
 
 import {isIOS} from '#/platform/detection'
-import {BottomSheetState, BottomSheetViewProps} from './BottomSheet.types'
+import {
+  type BottomSheetState,
+  type BottomSheetViewProps,
+} from './BottomSheet.types'
 import {BottomSheetPortalProvider} from './BottomSheetPortal'
 import {Context as PortalContext} from './BottomSheetPortal'
 

--- a/modules/bottom-sheet/src/BottomSheetNativeComponent.web.tsx
+++ b/modules/bottom-sheet/src/BottomSheetNativeComponent.web.tsx
@@ -1,4 +1,4 @@
-import {BottomSheetViewProps} from './BottomSheet.types'
+import {type BottomSheetViewProps} from './BottomSheet.types'
 
 export function BottomSheetNativeComponent(_: BottomSheetViewProps) {
   throw new Error('BottomSheetNativeComponent is not available on web')


### PR DESCRIPTION
Shout out to Claude who spotted this error state

This fixes an issue on iOS where the dialogs would not respond to content size changes - as it turns out, this was happening every time on the _second_ render.

The issue occurred because the initial detent identifier check blocked updates when identifiers didn't match, which always happened on first meaningful render. Now we properly allow updates during this initial transition phase while maintaining existing behaviour for subsequent updates.

# Before

https://github.com/user-attachments/assets/e7709865-bc4c-4c28-af2d-3b6da4952b02


# After


https://github.com/user-attachments/assets/97b98c3f-a450-4822-b5e2-14381a6ff930

# Test plan

Test sheets where the content size changes - good ones are the Starter Pack share dialog, and the report post dialog