### PR TITLE
Fix random app crashes caused by reanimated animations

### DIFF
--- a/package.json
+++ b/package.json
@@ -188,7 +188,7 @@
     "react-native-picker-select": "^9.3.1",
     "react-native-progress": "bluesky-social/react-native-progress",
     "react-native-qrcode-styled": "^0.3.3",
-    "react-native-reanimated": "~3.16.1",
+    "react-native-reanimated": "~3.17.4",
     "react-native-root-siblings": "^4.1.1",
     "react-native-safe-area-context": "4.12.0",
     "react-native-screens": "~4.4.0",


### PR DESCRIPTION
Small change, I was getting crashes when liking certain posts with the stacktrace pointing to [this](https://github.com/software-mansion/react-native-reanimated/pull/6897) being the issue. Updating reanimated to a newer version that includes a fix seems to have fixed this issue for me, though clearing the image cache is necessary for animations to appear correctly again. No other issues afaik after testing this.