### PR TITLE
[APP-1161] Fix crash when closing open dialogs

### DIFF
--- a/src/lib/hooks/useIntentHandler.ts
+++ b/src/lib/hooks/useIntentHandler.ts
@@ -2,6 +2,7 @@ import React from 'react'
 import * as Linking from 'expo-linking'
 
 import {logEvent} from '#/lib/statsig/statsig'
+import {logger} from '#/logger'
 import {isNative} from '#/platform/detection'
 import {useSession} from '#/state/session'
 import {useComposerControls} from '#/state/shell'
@@ -73,6 +74,9 @@ export function useIntentHandler() {
 
     if (incomingUrl) {
       if (previousIntentUrl === incomingUrl) {
+        logger.debug(`useIntentHandler: ignoring duplicate incoming URL`, {
+          incomingUrl,
+        })
         return
       }
       handleIncomingURL(incomingUrl)

--- a/src/state/dialogs/index.tsx
+++ b/src/state/dialogs/index.tsx
@@ -1,9 +1,7 @@
 import React from 'react'
 
-import {isWeb} from '#/platform/detection'
-import {DialogControlRefProps} from '#/components/Dialog'
+import {type DialogControlRefProps} from '#/components/Dialog'
 import {Provider as GlobalDialogsProvider} from '#/components/dialogs/Context'
-import {BottomSheetNativeComponent} from '../../../modules/bottom-sheet'
 
 interface IDialogContext {
   /**
@@ -53,17 +51,15 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
   const openDialogs = React.useRef<Set<string>>(new Set())
 
   const closeAllDialogs = React.useCallback(() => {
-    if (isWeb) {
-      openDialogs.current.forEach(id => {
-        const dialog = activeDialogs.current.get(id)
-        if (dialog) dialog.current.close()
-      })
+    openDialogs.current.forEach(id => {
+      const dialog = activeDialogs.current.get(id)
+      if (dialog) {
+        dialog.current.close()
+        openDialogs.current.delete(id)
+      }
+    })
 
-      return openDialogs.current.size > 0
-    } else {
-      BottomSheetNativeComponent.dismissAll()
-      return false
-    }
+    return openDialogs.current.size > 0
   }, [])
 
   const setDialogIsOpen = React.useCallback((id: string, isOpen: boolean) => {


### PR DESCRIPTION
Potential fix for a crash when handling email verification intent links.

To repro from main using a dev build on a physical device:
- create a new account with an unverified email
- send yourself an email verification link
- open any dialog e.g. post dropdown menu
- click on link in email
- app will crash

**However,** it seems the issue is not necessarily `BottomSheetNativeComponent.dismissAll()`, bc I can independently trigger this method and close open sheets just fine. It seems only to be an issue when calling this native method after going from background-foreground.