### PR TITLE
Fix composer reply display name being clipped

### DIFF
--- a/src/view/com/composer/ComposerReplyTo.tsx
+++ b/src/view/com/composer/ComposerReplyTo.tsx
@@ -94,7 +94,7 @@ export function ComposerReplyTo({replyTo}: {replyTo: ComposerOptsPostRef}) {
       <View style={[a.flex_1, a.pl_md, a.pr_sm, a.gap_2xs]}>
         <View style={[a.flex_row, a.align_center, a.pr_xs]}>
           <Text
-            style={[a.font_bold, a.text_md, a.flex_shrink]}
+            style={[a.font_bold, a.text_md, a.leading_snug, a.flex_shrink]}
             numberOfLines={1}
             emoji>
             {sanitizeDisplayName(


### PR DESCRIPTION

## Before 
<img width="344" alt="Screenshot 2025-05-01 at 11 47 32" src="https://github.com/user-attachments/assets/cb89a80c-53e7-4226-88d1-a9919ba434de" />

## After
<img width="346" alt="Screenshot 2025-05-01 at 11 47 41" src="https://github.com/user-attachments/assets/0034e983-c6d8-4a0f-8c6c-a9aaea4a1558" />
