### PR TITLE
Add internal discover debug topic misclassification report button

### DIFF
--- a/src/view/com/util/forms/PostDropdownBtnMenuItems.tsx
+++ b/src/view/com/util/forms/PostDropdownBtnMenuItems.tsx
@@ -17,6 +17,8 @@ import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 import {useNavigation} from '@react-navigation/native'
 
+import {IS_INTERNAL} from '#/lib/app-info'
+import {DISCOVER_DEBUG_DIDS} from '#/lib/constants'
 import {useOpenLink} from '#/lib/hooks/useOpenLink'
 import {getCurrentRoute} from '#/lib/routes/helpers'
 import {makeProfileLink} from '#/lib/routes/links'
@@ -60,6 +62,7 @@ import {
 } from '#/components/dialogs/PostInteractionSettingsDialog'
 import {SendViaChatDialog} from '#/components/dms/dialogs/ShareViaChatDialog'
 import {ArrowOutOfBox_Stroke2_Corner0_Rounded as Share} from '#/components/icons/ArrowOutOfBox'
+import {Atom_Stroke2_Corner0_Rounded as AtomIcon} from '#/components/icons/Atom'
 import {BubbleQuestion_Stroke2_Corner0_Rounded as Translate} from '#/components/icons/Bubble'
 import {Clipboard_Stroke2_Corner2_Rounded as ClipboardIcon} from '#/components/icons/Clipboard'
 import {CodeBrackets_Stroke2_Corner0_Rounded as CodeBrackets} from '#/components/icons/CodeBrackets'
@@ -430,6 +433,13 @@ let PostDropdownMenuItems = ({
     shareText(postAuthor.did)
   }, [postAuthor.did])
 
+  const onReportMisclassification = useCallback(() => {
+    const url = `https://docs.google.com/forms/d/e/1FAIpQLSd0QPqhNFksDQf1YyOos7r1ofCLvmrKAH1lU042TaS3GAZaWQ/viewform?entry.1756031717=${toShareUrl(
+      href,
+    )}`
+    openLink(url)
+  }, [href, openLink])
+
   return (
     <>
       <Menu.Outer>
@@ -539,6 +549,19 @@ let PostDropdownMenuItems = ({
                 <Menu.ItemText>{_(msg`Show less like this`)}</Menu.ItemText>
                 <Menu.ItemIcon icon={EmojiSad} position="right" />
               </Menu.Item>
+
+              {IS_INTERNAL &&
+                DISCOVER_DEBUG_DIDS[currentAccount?.did ?? ''] && (
+                  <Menu.Item
+                    testID="postDropdownReportMisclassificationBtn"
+                    label={_(msg`Report topic misclassification`)}
+                    onPress={onReportMisclassification}>
+                    <Menu.ItemText>
+                      {_(msg`Report topic misclassification`)}
+                    </Menu.ItemText>
+                    <Menu.ItemIcon icon={AtomIcon} position="right" />
+                  </Menu.Item>
+                )}
             </Menu.Group>
           </>
         )}


### PR DESCRIPTION
<img width="617" alt="Screenshot 2025-05-06 at 10 01 56" src="https://github.com/user-attachments/assets/e856de64-7ee3-495d-9135-10601cd10cd4" />

Opens the topic misclassification report form. Internal only, and the form is private