### PR TITLE
Add typescript sort import suggestions plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -272,6 +272,7 @@
     "react-refresh": "^0.14.0",
     "svgo": "^3.3.2",
     "ts-node": "^10.9.1",
+    "ts-plugin-sort-import-suggestions": "^1.0.4",
     "typescript": "^5.9.2",
     "webpack-bundle-analyzer": "^4.10.1"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,14 @@
       "crypto": ["./src/platform/crypto.ts"],
       "multiformats/cid": ["node_modules/multiformats/types/src/cid.d.ts"],
       "multiformats/hashes/hasher": ["node_modules/multiformats/types/src/hashes/hasher.d.ts"]
-    }
+    },
+    "plugins": [
+      {
+        "name": "ts-plugin-sort-import-suggestions",
+        "moveUpPatterns": ["#/", "@lingui/macro"],
+        "moveDownPatterns": ["react-native-reanimated/lib"],
+      }
+    ]
   },
   "exclude": ["bskyweb", "bskyembed", "web-build"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -19216,6 +19216,11 @@ ts-node@^10.9.1:
     v8-compile-cache-lib "^3.0.1"
     yn "3.1.1"
 
+ts-plugin-sort-import-suggestions@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/ts-plugin-sort-import-suggestions/-/ts-plugin-sort-import-suggestions-1.0.4.tgz#d1ed6c235feb8c8bb8b34c625ea75b46e3e62925"
+  integrity sha512-85n5lm2OQQ+b7aRNK9omU1gmjMNXRsgeLwojm5u4OSY5sVBkAHTcgMQPEeHMNlyyfFW0uXnwgqAU0pNfhD96Bw==
+
 tsconfig-paths@^3.15.0:
   version "3.15.0"
   resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz#5299ec605e55b1abb23ec939ef15edaf483070d4"


### PR DESCRIPTION
Boosts `#/` and `@lingui/macro`, and penalises Reanimated internals in the import suggestions in your code editor.

[See setup instructions here](https://github.com/tidalhq/ts-plugin-sort-import-suggestions). Some code editors (such as vscode) will need you to use the workspace typescript version explicitly 