### PR TITLE
Android sheets edge to edge

### DIFF
--- a/modules/bottom-sheet/android/src/main/java/expo/modules/bottomsheet/BottomSheetView.kt
+++ b/modules/bottom-sheet/android/src/main/java/expo/modules/bottomsheet/BottomSheetView.kt
@@ -37,7 +37,7 @@ class BottomSheetView(
       val resourceId = resources.getIdentifier("navigation_bar_height", "dimen", "android")
       return if (resourceId > 0) resources.getDimensionPixelSize(resourceId) else 0
   }
-  
+
   private fun getStatusBarHeight(): Int {
       val resourceId = resources.getIdentifier("status_bar_height", "dimen", "android")
       return if (resourceId > 0) resources.getDimensionPixelSize(resourceId) else 0
@@ -165,10 +165,6 @@ class BottomSheetView(
     return when {
       // Full height sheets
       contentHeight >= screenHeight -> 0.99f
-      // Medium height sheets (>50% but <100%)
-      contentHeight >= screenHeight / 2 ->
-        this.clampRatio(this.getTargetHeight() / screenHeight)
-      // Small height sheets (<50%)
       else ->
         this.clampRatio(this.getTargetHeight() / screenHeight)
     }
@@ -185,13 +181,13 @@ class BottomSheetView(
       this.isClosing = true
       this.destroy()
     }
-    
+
     // Configure dialog window for edge-to-edge mode
     dialog.window?.apply {
       // Make status bar and navigation bar transparent
       setNavigationBarColor(android.graphics.Color.TRANSPARENT)
       setStatusBarColor(android.graphics.Color.TRANSPARENT)
-      
+
       // Set FLAG_LAYOUT_NO_LIMITS to allow layout to extend beyond system UI boundaries
       // Use FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS to properly handle transparent system bars
       setFlags(
@@ -200,7 +196,7 @@ class BottomSheetView(
         android.view.WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS or
         android.view.WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS
       )
-      
+
       // Configure system UI visibility to allow layout behind both status and navigation bars
       decorView.systemUiVisibility = android.view.View.SYSTEM_UI_FLAG_LAYOUT_STABLE or
                                      android.view.View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION or
@@ -210,9 +206,9 @@ class BottomSheetView(
     val bottomSheet = dialog.findViewById<FrameLayout>(com.google.android.material.R.id.design_bottom_sheet)
     bottomSheet?.let {
       it.setBackgroundColor(0)
-      
+
       it.fitsSystemWindows = false
-      
+
       // Add padding to respect the status bar but not the navigation bar
       val statusBarHeight = getStatusBarHeight()
       it.setPadding(0, statusBarHeight, 0, 0)
@@ -270,13 +266,13 @@ class BottomSheetView(
   fun updateLayout() {
     val dialog = this.dialog ?: return
     val contentHeight = this.getContentHeight()
-    
+
     // Ensure edge-to-edge mode settings are maintained
     dialog.window?.apply {
       // Maintain transparent status and navigation bars
       setNavigationBarColor(android.graphics.Color.TRANSPARENT)
       setStatusBarColor(android.graphics.Color.TRANSPARENT)
-      
+
       // Ensure layout flags are still set
       setFlags(
         android.view.WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS or
@@ -284,7 +280,7 @@ class BottomSheetView(
         android.view.WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS or
         android.view.WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS
       )
-      
+
       // Re-apply system UI visibility settings
       decorView.systemUiVisibility = android.view.View.SYSTEM_UI_FLAG_LAYOUT_STABLE or
                                      android.view.View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION or
@@ -294,10 +290,10 @@ class BottomSheetView(
     val bottomSheet = dialog.findViewById<FrameLayout>(com.google.android.material.R.id.design_bottom_sheet)
     bottomSheet?.let {
       it.fitsSystemWindows = false
-      
+
       val statusBarHeight = getStatusBarHeight()
       it.setPadding(0, statusBarHeight, 0, 0)
-      
+
       val behavior = BottomSheetBehavior.from(it)
 
       behavior.halfExpandedRatio = getHalfExpandedRatio(contentHeight)

--- a/modules/bottom-sheet/android/src/main/java/expo/modules/bottomsheet/BottomSheetView.kt
+++ b/modules/bottom-sheet/android/src/main/java/expo/modules/bottomsheet/BottomSheetView.kt
@@ -254,13 +254,32 @@ class BottomSheetView(
           override fun onSlide(
             bottomSheet: View,
             slideOffset: Float,
-          ) { }
+          ) {
+            // Reset any translation we applied to fix initial position
+            // This ensures normal behavior once the user starts interacting
+            if (bottomSheet.translationY != 0f) {
+              bottomSheet.translationY = 0f
+            }
+          }
         },
       )
     }
     this.isOpening = true
     dialog.show()
     this.dialog = dialog
+
+    // When the sheet first opens, the position is too low - it's beneath the nav bars
+    // We fix by applying a translation initially, and then removing in `onSlide`
+    // since after the user starts interacting, it behaves properly. Probably not the neatest
+    // solution but seems to work consistently -sfn
+    dialog.window?.decorView?.post {
+      val bottomSheet = dialog.findViewById<FrameLayout>(com.google.android.material.R.id.design_bottom_sheet)
+      bottomSheet?.let { sheet ->
+        // Apply negative translation to counteract the navigation bar offset
+        val navHeight = getNavigationBarHeight()
+        sheet.translationY = -navHeight.toFloat()
+      }
+    }
   }
 
   fun updateLayout() {

--- a/modules/bottom-sheet/android/src/main/java/expo/modules/bottomsheet/BottomSheetView.kt
+++ b/modules/bottom-sheet/android/src/main/java/expo/modules/bottomsheet/BottomSheetView.kt
@@ -32,10 +32,15 @@ class BottomSheetView(
   private var eventDispatcher: EventDispatcher? = null
 
   private val rawScreenHeight = context.resources.displayMetrics.heightPixels.toFloat()
-  private val safeScreenHeight = (rawScreenHeight - getNavigationBarHeight()).toFloat()
+  private val safeScreenHeight = rawScreenHeight
 
   private fun getNavigationBarHeight(): Int {
       val resourceId = resources.getIdentifier("navigation_bar_height", "dimen", "android")
+      return if (resourceId > 0) resources.getDimensionPixelSize(resourceId) else 0
+  }
+  
+  private fun getStatusBarHeight(): Int {
+      val resourceId = resources.getIdentifier("status_bar_height", "dimen", "android")
       return if (resourceId > 0) resources.getDimensionPixelSize(resourceId) else 0
   }
 
@@ -181,10 +186,37 @@ class BottomSheetView(
       this.isClosing = true
       this.destroy()
     }
+    
+    // Configure dialog window for edge-to-edge mode
+    dialog.window?.apply {
+      // Make status bar and navigation bar transparent
+      setNavigationBarColor(android.graphics.Color.TRANSPARENT)
+      setStatusBarColor(android.graphics.Color.TRANSPARENT)
+      
+      // Set FLAG_LAYOUT_NO_LIMITS to allow layout to extend beyond system UI boundaries
+      // Use FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS to properly handle transparent system bars
+      setFlags(
+        android.view.WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS or
+        android.view.WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS,
+        android.view.WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS or
+        android.view.WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS
+      )
+      
+      // Configure system UI visibility to allow layout behind both status and navigation bars
+      decorView.systemUiVisibility = android.view.View.SYSTEM_UI_FLAG_LAYOUT_STABLE or 
+                                     android.view.View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION or
+                                     android.view.View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+    }
 
     val bottomSheet = dialog.findViewById<FrameLayout>(com.google.android.material.R.id.design_bottom_sheet)
     bottomSheet?.let {
       it.setBackgroundColor(0)
+      
+      it.fitsSystemWindows = false
+      
+      // Add padding to respect the status bar but not the navigation bar
+      val statusBarHeight = getStatusBarHeight()
+      it.setPadding(0, statusBarHeight, 0, 0)
 
       val behavior = BottomSheetBehavior.from(it)
       behavior.state = BottomSheetBehavior.STATE_HIDDEN
@@ -239,9 +271,34 @@ class BottomSheetView(
   fun updateLayout() {
     val dialog = this.dialog ?: return
     val contentHeight = this.getContentHeight()
+    
+    // Ensure edge-to-edge mode settings are maintained
+    dialog.window?.apply {
+      // Maintain transparent status and navigation bars
+      setNavigationBarColor(android.graphics.Color.TRANSPARENT)
+      setStatusBarColor(android.graphics.Color.TRANSPARENT)
+      
+      // Ensure layout flags are still set
+      setFlags(
+        android.view.WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS or
+        android.view.WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS,
+        android.view.WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS or
+        android.view.WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS
+      )
+      
+      // Re-apply system UI visibility settings
+      decorView.systemUiVisibility = android.view.View.SYSTEM_UI_FLAG_LAYOUT_STABLE or 
+                                     android.view.View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION or
+                                     android.view.View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+    }
 
     val bottomSheet = dialog.findViewById<FrameLayout>(com.google.android.material.R.id.design_bottom_sheet)
     bottomSheet?.let {
+      it.fitsSystemWindows = false
+      
+      val statusBarHeight = getStatusBarHeight()
+      it.setPadding(0, statusBarHeight, 0, 0)
+      
       val behavior = BottomSheetBehavior.from(it)
 
       behavior.halfExpandedRatio = getHalfExpandedRatio(contentHeight)

--- a/modules/bottom-sheet/android/src/main/java/expo/modules/bottomsheet/BottomSheetView.kt
+++ b/modules/bottom-sheet/android/src/main/java/expo/modules/bottomsheet/BottomSheetView.kt
@@ -31,8 +31,7 @@ class BottomSheetView(
   private lateinit var dialogRootViewGroup: DialogRootViewGroup
   private var eventDispatcher: EventDispatcher? = null
 
-  private val rawScreenHeight = context.resources.displayMetrics.heightPixels.toFloat()
-  private val safeScreenHeight = rawScreenHeight
+  private val screenHeight = context.resources.displayMetrics.heightPixels.toFloat()
 
   private fun getNavigationBarHeight(): Int {
       val resourceId = resources.getIdentifier("navigation_bar_height", "dimen", "android")
@@ -72,12 +71,12 @@ class BottomSheetView(
         }
     }
 
-  var maxHeight = this.safeScreenHeight
+  var maxHeight = this.screenHeight
     set(value) {
       val px = dpToPx(value)
       field =
-        if (px > this.safeScreenHeight) {
-          this.safeScreenHeight
+        if (px > this.screenHeight) {
+          this.screenHeight
         } else {
           px
         }
@@ -165,13 +164,13 @@ class BottomSheetView(
   private fun getHalfExpandedRatio(contentHeight: Float): Float {
     return when {
       // Full height sheets
-      contentHeight >= safeScreenHeight -> 0.99f
+      contentHeight >= screenHeight -> 0.99f
       // Medium height sheets (>50% but <100%)
-      contentHeight >= safeScreenHeight / 2 ->
-        this.clampRatio(this.getTargetHeight() / safeScreenHeight)
+      contentHeight >= screenHeight / 2 ->
+        this.clampRatio(this.getTargetHeight() / screenHeight)
       // Small height sheets (<50%)
       else ->
-        this.clampRatio(this.getTargetHeight() / rawScreenHeight)
+        this.clampRatio(this.getTargetHeight() / screenHeight)
     }
   }
 
@@ -203,7 +202,7 @@ class BottomSheetView(
       )
       
       // Configure system UI visibility to allow layout behind both status and navigation bars
-      decorView.systemUiVisibility = android.view.View.SYSTEM_UI_FLAG_LAYOUT_STABLE or 
+      decorView.systemUiVisibility = android.view.View.SYSTEM_UI_FLAG_LAYOUT_STABLE or
                                      android.view.View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION or
                                      android.view.View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
     }
@@ -226,7 +225,7 @@ class BottomSheetView(
       behavior.isDraggable = true
       behavior.isHideable = true
 
-      if (contentHeight >= this.safeScreenHeight || this.minHeight >= this.safeScreenHeight) {
+      if (contentHeight >= this.screenHeight || this.minHeight >= this.screenHeight) {
         behavior.state = BottomSheetBehavior.STATE_EXPANDED
         this.selectedSnapPoint = 2
       } else {
@@ -287,7 +286,7 @@ class BottomSheetView(
       )
       
       // Re-apply system UI visibility settings
-      decorView.systemUiVisibility = android.view.View.SYSTEM_UI_FLAG_LAYOUT_STABLE or 
+      decorView.systemUiVisibility = android.view.View.SYSTEM_UI_FLAG_LAYOUT_STABLE or
                                      android.view.View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION or
                                      android.view.View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
     }
@@ -303,9 +302,9 @@ class BottomSheetView(
 
       behavior.halfExpandedRatio = getHalfExpandedRatio(contentHeight)
 
-      if (contentHeight > this.safeScreenHeight && behavior.state != BottomSheetBehavior.STATE_EXPANDED) {
+      if (contentHeight > this.screenHeight && behavior.state != BottomSheetBehavior.STATE_EXPANDED) {
         behavior.state = BottomSheetBehavior.STATE_EXPANDED
-      } else if (contentHeight < this.safeScreenHeight && behavior.state != BottomSheetBehavior.STATE_HALF_EXPANDED) {
+      } else if (contentHeight < this.screenHeight && behavior.state != BottomSheetBehavior.STATE_HALF_EXPANDED) {
         behavior.state = BottomSheetBehavior.STATE_HALF_EXPANDED
       }
     }

--- a/modules/bottom-sheet/android/src/main/java/expo/modules/bottomsheet/DialogRootViewGroup.kt
+++ b/modules/bottom-sheet/android/src/main/java/expo/modules/bottomsheet/DialogRootViewGroup.kt
@@ -52,6 +52,8 @@ class DialogRootViewGroup(
     if (ReactFeatureFlags.dispatchPointerEvents) {
       jSPointerDispatcher = JSPointerDispatcher(this)
     }
+    
+    fitsSystemWindows = false
   }
 
   override fun onSizeChanged(

--- a/modules/bottom-sheet/src/BottomSheetNativeComponent.tsx
+++ b/modules/bottom-sheet/src/BottomSheetNativeComponent.tsx
@@ -163,6 +163,7 @@ function BottomSheetNativeComponentInner({
           Platform.OS === 'android' && {
             borderTopLeftRadius: cornerRadius,
             borderTopRightRadius: cornerRadius,
+            overflow: 'hidden',
           },
           extraStyles,
         ]}>

--- a/src/view/com/auth/server-input/index.tsx
+++ b/src/view/com/auth/server-input/index.tsx
@@ -8,7 +8,7 @@ import {BSKY_SERVICE} from '#/lib/constants'
 import {logEvent} from '#/lib/statsig/statsig'
 import * as persisted from '#/state/persisted'
 import {useSession} from '#/state/session'
-import {atoms as a, useBreakpoints, useTheme} from '#/alf'
+import {android, atoms as a, useBreakpoints, useTheme} from '#/alf'
 import {Admonition} from '#/components/Admonition'
 import {Button, ButtonText} from '#/components/Button'
 import * as Dialog from '#/components/Dialog'
@@ -49,7 +49,9 @@ export function ServerInputDialog({
     <Dialog.Outer
       control={control}
       onClose={onClose}
-      nativeOptions={{minHeight: height / 2}}>
+      nativeOptions={{
+        minHeight: android(height),
+      }}>
       <Dialog.Handle />
       <DialogInner
         formRef={formRef}


### PR DESCRIPTION
Enables the sheets to present under the nav buttons, which looks much nicer.

<table>
  <tbody>
    <tr>
      <td><img width="300" src="https://github.com/user-attachments/assets/3e8f43d2-83d4-4116-a5f9-a2f85f3306c9" /></td>
      <td><img width="300" src="https://github.com/user-attachments/assets/90688a92-e751-40ed-b132-9ea4f550fd5a" /></td>
      <td><img width="300" src="https://github.com/user-attachments/assets/8348104d-4907-4bf8-a26b-66d184560f7f" /></td>
      <td><img width="300" src="https://github.com/user-attachments/assets/0d297c63-3fe2-4344-88c0-044df19dbebb" /></td>
    </tr>
  </tbody>
</table>

# Test plan

Test as many sheets as you can find, ensure no functional regressions

The server input/hosting provider input seemed a bit dodgy, but also seems dodgy on main too. setting that sheet to 100% height improved it significantly