### PR TITLE
fix crash when closing open dialogs

### DIFF
--- a/modules/bottom-sheet/ios/SheetView.swift
+++ b/modules/bottom-sheet/ios/SheetView.swift
@@ -145,7 +145,7 @@ class SheetView: ExpoView, UISheetPresentationControllerDelegate {
 
   func updateLayout() {
     // Allow updates either when identifiers match OR when prevLayoutDetentIdentifier is nil (first real content update)
-    if (self.prevLayoutDetentIdentifier == self.selectedDetentIdentifier || self.prevLayoutDetentIdentifier == nil),
+    if self.prevLayoutDetentIdentifier == self.selectedDetentIdentifier || self.prevLayoutDetentIdentifier == nil,
        let contentHeight = self.innerView?.subviews.first?.frame.size.height {
       self.sheetVc?.updateDetents(contentHeight: self.clampHeight(contentHeight),
                                   preventExpansion: self.preventExpansion)
@@ -155,9 +155,15 @@ class SheetView: ExpoView, UISheetPresentationControllerDelegate {
   }
 
   func dismiss() {
+    guard let sheetVc = self.sheetVc else {
+      return
+    }
+
     self.isClosing = true
-    self.sheetVc?.dismiss(animated: true) { [weak self] in
-      self?.destroy()
+    DispatchQueue.main.async {
+      sheetVc.dismiss(animated: true) { [weak self] in
+        self?.destroy()
+      }
     }
   }
 


### PR DESCRIPTION
## Why

We should be dismissing sheets from the main thread, however right now we are not!

## Test Plan

- use an account with an unverified email
-  send yourself an email verification link
- open any dialog e.g. post dropdown menu
- click on link in email
- app will not crash
