### PR TITLE
Add missing <Trans> to SetNewPasswordForm.tsx

### DIFF
--- a/src/screens/Login/SetNewPasswordForm.tsx
+++ b/src/screens/Login/SetNewPasswordForm.tsx
@@ -112,7 +112,9 @@ export const SetNewPasswordForm = ({
       </Text>
 
       <View>
-        <TextField.LabelText>Reset code</TextField.LabelText>
+        <TextField.LabelText>
+          <Trans>Reset code</Trans>
+        </TextField.LabelText>
         <TextField.Root>
           <TextField.Icon icon={Ticket} />
           <TextField.Input
@@ -135,7 +137,9 @@ export const SetNewPasswordForm = ({
       </View>
 
       <View>
-        <TextField.LabelText>New password</TextField.LabelText>
+        <TextField.LabelText>
+          <Trans>New password</Trans>
+        </TextField.LabelText>
         <TextField.Root>
           <TextField.Icon icon={Lock} />
           <TextField.Input


### PR DESCRIPTION
Makes “Reset code”, “New password” on the password reset page translatable.