### PR TITLE
Fix email dialog width on large phones

### DIFF
--- a/src/components/dialogs/EmailDialog/index.tsx
+++ b/src/components/dialogs/EmailDialog/index.tsx
@@ -2,6 +2,7 @@ import {useCallback, useState} from 'react'
 import {msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
+import {useBreakpoints} from '#/alf'
 import * as Dialog from '#/components/Dialog'
 import {type StatefulControl} from '#/components/dialogs/Context'
 import {useGlobalDialogsControlContext} from '#/components/dialogs/Context'
@@ -21,6 +22,7 @@ export function useEmailDialogControl() {
 
 export function EmailDialog() {
   const {_} = useLingui()
+  const {gtMobile} = useBreakpoints()
   const emailDialogControl = useEmailDialogControl()
   const {isEmailVerified} = useAccountEmailState()
   const onClose = useCallback(() => {
@@ -38,7 +40,7 @@ export function EmailDialog() {
 
       <Dialog.ScrollableInner
         label={_(msg`Make adjustments to email settings for your account`)}
-        style={[{maxWidth: 400}]}>
+        style={{width: gtMobile ? 400 : '100%'}}>
         <Inner control={emailDialogControl} />
         <Dialog.Close />
       </Dialog.ScrollableInner>


### PR DESCRIPTION
Applies the same styling we used for our `Prompt` component. Fixes this:

![image](https://github.com/user-attachments/assets/aecdcfbb-0c08-4924-ac74-b6f0f7cceed6)
