### PR TITLE
Stop incorrectly using `SuffixText`

### DIFF
--- a/src/screens/Profile/Header/EditProfileDialog.tsx
+++ b/src/screens/Profile/Header/EditProfileDialog.tsx
@@ -23,6 +23,7 @@ import * as TextField from '#/components/forms/TextField'
 import {InlineLinkText} from '#/components/Link'
 import {Loader} from '#/components/Loader'
 import * as Prompt from '#/components/Prompt'
+import {Text} from '#/components/Typography'
 import {useSimpleVerificationState} from '#/components/verification'
 
 const DISPLAY_NAME_MAX_GRAPHEMES = 64
@@ -329,22 +330,18 @@ function DialogInner({
             />
           </TextField.Root>
           {displayNameTooLong && (
-            <TextField.SuffixText
+            <Text
               style={[
                 a.text_sm,
                 a.mt_xs,
                 a.font_bold,
                 {color: t.palette.negative_400},
-              ]}
-              label={_(msg`Display name is too long`)}>
-              <Trans>
-                Display name is too long.{' '}
-                <Plural
-                  value={DISPLAY_NAME_MAX_GRAPHEMES}
-                  other="The maximum number of characters is #."
-                />
-              </Trans>
-            </TextField.SuffixText>
+              ]}>
+              <Plural
+                value={DISPLAY_NAME_MAX_GRAPHEMES}
+                other="Display name is too long. The maximum number of characters is #."
+              />
+            </Text>
           )}
         </View>
 
@@ -379,22 +376,18 @@ function DialogInner({
             />
           </TextField.Root>
           {descriptionTooLong && (
-            <TextField.SuffixText
+            <Text
               style={[
                 a.text_sm,
                 a.mt_xs,
                 a.font_bold,
                 {color: t.palette.negative_400},
-              ]}
-              label={_(msg`Description is too long`)}>
-              <Trans>
-                Description is too long.{' '}
-                <Plural
-                  value={DESCRIPTION_MAX_GRAPHEMES}
-                  other="The maximum number of characters is #."
-                />
-              </Trans>
-            </TextField.SuffixText>
+              ]}>
+              <Plural
+                value={DESCRIPTION_MAX_GRAPHEMES}
+                other="Description is too long. The maximum number of characters is #."
+              />
+            </Text>
           )}
         </View>
       </View>


### PR DESCRIPTION
<img width="392" alt="Screenshot 2025-05-09 at 10 23 23" src="https://github.com/user-attachments/assets/28456b3f-c805-4446-b8a0-6393766559c5" />


