### PR TITLE
Don't show NUXs to brand new users

### DIFF
--- a/src/components/dialogs/nuxs/index.tsx
+++ b/src/components/dialogs/nuxs/index.tsx
@@ -16,6 +16,7 @@ import {InitialVerificationAnnouncement} from '#/components/dialogs/nuxs/Initial
  * NUXs
  */
 import {isSnoozed, snooze, unsnooze} from '#/components/dialogs/nuxs/snoozing'
+import {isDaysOld} from '#/components/dialogs/nuxs/utils'
 
 type Context = {
   activeNux: Nux | undefined
@@ -33,7 +34,9 @@ const queuedNuxs: {
 }[] = [
   {
     id: Nux.InitialVerificationAnnouncement,
-    enabled: () => true,
+    enabled: ({currentProfile}) => {
+      return isDaysOld(2, currentProfile.createdAt)
+    },
   },
 ]
 

--- a/src/components/dialogs/nuxs/utils.ts
+++ b/src/components/dialogs/nuxs/utils.ts
@@ -2,9 +2,12 @@ const ONE_DAY = 1000 * 60 * 60 * 24
 
 export function isDaysOld(days: number, createdAt?: string) {
   /*
-   * Should never happen, but if it does, the account is likely quite old
+   * Should never happen because we gate NUXs to only accounts with a valid
+   * profile and a `createdAt` (see `nuxs/index.tsx`). But if it ever did, the
+   * account is either old enough to be pre-onboarding, or some failure happened
+   * during account creation. Fail closed. - esb
    */
-  if (!createdAt) return true
+  if (!createdAt) return false
 
   const now = Date.now()
   const then = new Date(createdAt).getTime()

--- a/src/components/dialogs/nuxs/utils.ts
+++ b/src/components/dialogs/nuxs/utils.ts
@@ -1,0 +1,15 @@
+const ONE_DAY = 1000 * 60 * 60 * 24
+
+export function isDaysOld(days: number, createdAt?: string) {
+  /*
+   * Should never happen, but if it does, the account is likely quite old
+   */
+  if (!createdAt) return true
+
+  const now = Date.now()
+  const then = new Date(createdAt).getTime()
+  const isOldEnough = then + ONE_DAY * days < now
+
+  if (isOldEnough) return true
+  return false
+}


### PR DESCRIPTION
Adds a reusable util to gate NUXs to accounts older than `n` days old.