### PR TITLE
Fix long handles in account switch

### DIFF
--- a/src/screens/Settings/Settings.tsx
+++ b/src/screens/Settings/Settings.tsx
@@ -495,7 +495,9 @@ function AccountRow({
         ) : (
           <View style={[{width: 28}]} />
         )}
-        <SettingsList.ItemText>
+        <SettingsList.ItemText
+          numberOfLines={1}
+          style={[a.pr_2xl, a.leading_snug]}>
           {sanitizeHandle(account.handle, '@')}
         </SettingsList.ItemText>
         {pendingDid === account.did && <SettingsList.ItemIcon icon={Loader} />}


### PR DESCRIPTION
Currently it just overflows

<table>
  <tbody>
    <tr>
      <td><img width="300" src="https://github.com/user-attachments/assets/c02367a6-be74-4fce-be26-e171e8194636" /></td>
      <td><img width="200" src="https://github.com/user-attachments/assets/2a0464b9-f383-474a-8776-ae277c2ed997" /></td>
    </tr>
  </tbody>
</table>