### PR TITLE
Fix hover card width

### DIFF
--- a/src/components/ProfileHoverCard/index.web.tsx
+++ b/src/components/ProfileHoverCard/index.web.tsx
@@ -381,8 +381,8 @@ let Card = ({
         t.atoms.bg,
         t.atoms.border_contrast_low,
         t.atoms.shadow_lg,
-        a.w_full,
-        {maxWidth: status.isActive ? 500 : 300},
+        {width: status.isActive ? 350 : 300},
+        a.max_w_full,
       ]}>
       {data && moderationOpts ? (
         status.isActive ? (
@@ -396,7 +396,13 @@ let Card = ({
           <Inner profile={data} moderationOpts={moderationOpts} hide={hide} />
         )
       ) : (
-        <View style={[a.justify_center, a.align_center, {minHeight: 200}]}>
+        <View
+          style={[
+            a.justify_center,
+            a.align_center,
+            {minHeight: 200},
+            a.w_full,
+          ]}>
           <Loader size="xl" />
         </View>
       )}


### PR DESCRIPTION
There were a couple issues here. One was it was dependant on the intrinsic size of the content, but the spinner is obviously much smaller - thus the offset was wrong once the content loaded. the other is that the live version max size was much too big.

Solution is to just set a fixed size.

# Before

https://github.com/user-attachments/assets/45d6b7ef-0dd9-4cee-88dd-de18577b0821



# After


https://github.com/user-attachments/assets/93c0d106-c589-4bf0-9332-5d806d9a6066

