### PR TITLE
Accessibility - add large content viewer to tabs

### DIFF
--- a/src/view/shell/bottom-bar/BottomBar.tsx
+++ b/src/view/shell/bottom-bar/BottomBar.tsx
@@ -395,7 +395,9 @@ function Btn({
       accessible={accessible}
       accessibilityLabel={accessibilityLabel}
       accessibilityHint={accessibilityHint}
-      targetScale={0.8}>
+      targetScale={0.8}
+      accessibilityLargeContentTitle={accessibilityLabel}
+      accessibilityShowsLargeContentViewer>
       {icon}
       {notificationCount ? (
         <View style={[styles.notificationCount, a.rounded_full]}>


### PR DESCRIPTION
Fixes #7000

Adds support for an iOS accessibility feature. Sorta conflicts with the change tab action, but seems to work fine regardless - shows much quick than the long press anyway

https://github.com/user-attachments/assets/e5049715-2aee-4edc-83fa-1268ee9a2fdd

# test plan

enable ios large text mode, long press the tab buttons