### PR TITLE
Rectify a constant +1 to liked feeds

### DIFF
--- a/src/screens/Profile/components/ProfileFeedHeader.tsx
+++ b/src/screens/Profile/components/ProfileFeedHeader.tsx
@@ -94,9 +94,8 @@ export function ProfileFeedHeader({info}: {info: FeedSourceFeedInfo}) {
   const {data: preferences} = usePreferencesQuery()
 
   const [likeUri, setLikeUri] = React.useState(info.likeUri || '')
-  const isLiked = !!likeUri
   const likeCount =
-    isLiked && likeUri ? (info.likeCount || 0) + 1 : info.likeCount || 0
+    (info.likeCount || 0) + (likeUri && !info.likeUri ? 1 : !likeUri && info.likeUri ? -1 : 0)
 
   const {mutateAsync: addSavedFeeds, isPending: isAddSavedFeedPending} =
     useAddSavedFeedsMutation()


### PR DESCRIPTION
This sees to rectify #8371

This could have been done by simply removing the +1 but that was for instantly reflecting a users like to them

So in trying to keep that, this seems to work without issue! 🙃

🩵🩷🩵🩷