### PR TITLE
Fix invalid tweaking to date string

### DIFF
--- a/src/components/live/GoLiveDialog.tsx
+++ b/src/components/live/GoLiveDialog.tsx
@@ -56,10 +56,7 @@ function DialogInner({profile}: {profile: bsky.profile.AnyProfileView}) {
 
       const date = new Date()
       date.setMinutes(date.getMinutes() + offset)
-      return i18n
-        .date(date, {hour: 'numeric', minute: '2-digit', hour12: true})
-        .toLocaleUpperCase()
-        .replace(' ', '')
+      return i18n.date(date, {hour: 'numeric', minute: '2-digit', hour12: true})
     },
     [tick, i18n],
   )


### PR DESCRIPTION
This hack to make the i18n'd date match the designs when using American english does not work in other languages. Let's just show what Intl.DateTimeFormat gives us