### PR TITLE
Add semantic markup for timestamps

### DIFF
--- a/bskyweb/templates/post.html
+++ b/bskyweb/templates/post.html
@@ -11,7 +11,7 @@
 {% block html_head_extra -%}
 {%- if postView -%}
   <meta property="og:type" content="article">
-  <meta property="profile:username" content="{{ profileView.Handle }}">
+  <meta property="profile:username" content="{{ postView.Author.Handle }}">
   {%- if requestURI %}
   <meta property="og:url" content="{{ requestURI }}">
   {% endif -%}

--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -858,7 +858,9 @@ function ExpandedPostDetails({
       <BackdatedPostIndicator post={post} />
       <View style={[a.flex_row, a.align_center, a.flex_wrap, a.gap_sm]}>
         <Text style={[a.text_sm, t.atoms.text_contrast_medium]}>
-          {niceDate(i18n, post.indexedAt)}
+          <time dateTime={post.index}>
+            {niceDate(i18n, post.indexedAt)}
+          </time>
         </Text>
         {isRootPost && (
           <WhoCanReply post={post} isThreadAuthor={isThreadAuthor} />

--- a/src/view/com/util/PostMeta.tsx
+++ b/src/view/com/util/PostMeta.tsx
@@ -169,7 +169,9 @@ let PostMeta = (opts: PostMetaOpts): React.ReactNode => {
                   &middot;{' '}
                 </Text>
               )}
-              {timeElapsed}
+              <time dateTime={opts.timestamp}>
+                {timeElapsed}
+              </time>
             </WebOnlyInlineLinkText>
           )}
         </TimeElapsed>


### PR DESCRIPTION
This is a minimalist change to add `time` HTML tags with a `datetime` attribute to posts when viewed on the web.

As of right now tools like Obsidian's Web Clipper have no way of reliably accessing the `indexedAt` timestamp when invoked on a `bsky.app` page.  The Clipper's default strategy is to read a page's `meta` tags to extract author and publication info.  However, the currently loaded post may have no relationship to the initially loaded meta tags, as the user navigates to new posts which load via javascript.  The only other solution is to extract post data from the DOM.  

Extracting post data from the DOM currently isn't possible because a post's timestamp has no structured elements or attributes allowing a user or the clipper to extract it using a meaningful CSS selector.

This PR wraps the `indexedAt` values displayed w/ posts w/ a `time` element.  I _think_ this doesn't impact React Native implementations, but would appreciate further guidance on that front!

This also fixes a meta tag in `post.html` that never actually displays the right content for `profile:username`.