### PR TITLE
Remove title casing of `Intl.DisplayNames` language names

### DIFF
--- a/src/locale/helpers.ts
+++ b/src/locale/helpers.ts
@@ -45,8 +45,7 @@ function getLocalizedLanguage(
     const translatedName = allNames.of(langCode)
 
     if (translatedName) {
-      // force simple title case (as languages do not always start with an uppercase in Unicode data)
-      return translatedName[0].toLocaleUpperCase() + translatedName.slice(1)
+      return translatedName
     }
   } catch (e) {
     // ignore RangeError from Intl.DisplayNames APIs


### PR DESCRIPTION
Language names are localized on web using `Intl.DisplayNames`, however, where the value returned is in lowercase we currently convert it to title case. As discussed in #7829, this is not ideal in some languages.

This PR removes the title casing so that the value returned by `Intl.DisplayNames` is simply passed through as-is.

cc: @Signez @smileyhead