### PR TITLE
Remove `noreferrer` from external links on web

### DIFF
--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -255,7 +255,7 @@ export function Link({
       {...web({
         hrefAttrs: {
           target: download ? undefined : isExternal ? 'blank' : undefined,
-          rel: isExternal ? 'noopener noreferrer' : undefined,
+          rel: isExternal ? 'noopener' : undefined,
           download,
         },
         dataSet: {
@@ -345,7 +345,7 @@ export function InlineLinkText({
       {...web({
         hrefAttrs: {
           target: download ? undefined : isExternal ? 'blank' : undefined,
-          rel: isExternal ? 'noopener noreferrer' : undefined,
+          rel: isExternal ? 'noopener' : undefined,
           download,
         },
         dataSet: {

--- a/src/lib/hooks/useOpenLink.ts
+++ b/src/lib/hooks/useOpenLink.ts
@@ -37,7 +37,7 @@ export function useOpenLink() {
           url,
         })
 
-        if (shouldProxy) {
+        if (isNative && shouldProxy) {
           url = createProxiedUrl(url)
         }
       }


### PR DESCRIPTION
Removes the need to redirect to a proxy for that referrer header as well.