### PR TITLE
Double the framerate

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -55,6 +55,7 @@ module.exports = function (_config) {
           usesNonExemptEncryption: false,
         },
         infoPlist: {
+          CADisableMinimumFrameDurationOnPhone: true,
           UIBackgroundModes: ['remote-notification'],
           NSCameraUsageDescription:
             'Used for profile pictures, posts, and other kinds of content.',


### PR DESCRIPTION
Enables 120fps animations on iOS

# Test plan

- Confirms it builds ok
- See if it feels smoother on a compatible iPhone. Requires Pro/Pro Max models iiuc