### PR TITLE
Fix composer scroll position when switching apps

### DIFF
--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -62,6 +62,7 @@ import {
   type SupportedMimeTypes,
 } from '#/lib/constants'
 import {useAnimatedScrollHandler} from '#/lib/hooks/useAnimatedScrollHandler_FIXED'
+import {useAppState} from '#/lib/hooks/useAppState'
 import {useIsKeyboardVisible} from '#/lib/hooks/useIsKeyboardVisible'
 import {useNonReactiveCallback} from '#/lib/hooks/useNonReactiveCallback'
 import {usePalette} from '#/lib/hooks/usePalette'
@@ -782,6 +783,8 @@ let ComposerPost = React.memo(function ComposerPost({
     [post.id, onSelectVideo, onImageAdd, _],
   )
 
+  useHideKeyboardOnBackground()
+
   return (
     <View
       style={[
@@ -1480,6 +1483,18 @@ function isEmptyPost(post: PostDraft) {
     !post.embed.link &&
     !post.embed.quote
   )
+}
+
+function useHideKeyboardOnBackground() {
+  const appState = useAppState()
+
+  useEffect(() => {
+    if (isIOS) {
+      if (appState === 'inactive') {
+        Keyboard.dismiss()
+      }
+    }
+  }, [appState])
 }
 
 const styles = StyleSheet.create({


### PR DESCRIPTION
There's a bug introduced when we upgrade RN where switching between apps with the post composer open would cause the composer to be scrolled to a weird position when focusing the app. Usually it would immediately fix itself but not always.

This seems to be caused by the keyboard being open, so let's just close the keyboard on background

# Before

https://github.com/user-attachments/assets/09f9decc-58cd-400a-b4ec-89134ee80442



# After


https://github.com/user-attachments/assets/e773e289-6bc3-46c0-8f0c-c0a63d425e1c

