### PR TITLE
Disable avatar preview in searchable people list

### DIFF
--- a/src/components/dialogs/SearchablePeopleList.tsx
+++ b/src/components/dialogs/SearchablePeopleList.tsx
@@ -397,6 +397,7 @@ function DefaultProfileCard({
             <ProfileCard.Avatar
               profile={profile}
               moderationOpts={moderationOpts}
+              disabledPreview
             />
             <View style={[a.flex_1]}>
               <ProfileCard.Name


### PR DESCRIPTION
Row is supposed to be pressable, but currently pressing the avatar takes you to the profile instead