### PR TITLE
Close IAB when it triggers an intent

### DIFF
--- a/src/lib/hooks/useIntentHandler.ts
+++ b/src/lib/hooks/useIntentHandler.ts
@@ -1,5 +1,6 @@
 import React from 'react'
 import * as Linking from 'expo-linking'
+import * as WebBrowser from 'expo-web-browser'
 
 import {useOpenComposer} from '#/lib/hooks/useOpenComposer'
 import {logEvent} from '#/lib/statsig/statsig'
@@ -22,7 +23,10 @@ export function useIntentHandler() {
   const verifyEmailIntent = useVerifyEmailIntent()
 
   React.useEffect(() => {
-    const handleIncomingURL = (url: string) => {
+    const handleIncomingURL = async (url: string) => {
+      // Close in-app browser if it's open
+      WebBrowser.dismissBrowser().catch(() => {})
+
       const referrerInfo = Referrer.getReferrerInfo()
       if (referrerInfo && referrerInfo.hostname !== 'bsky.app') {
         logEvent('deepLink:referrerReceived', {

--- a/src/lib/hooks/useIntentHandler.ts
+++ b/src/lib/hooks/useIntentHandler.ts
@@ -24,8 +24,10 @@ export function useIntentHandler() {
 
   React.useEffect(() => {
     const handleIncomingURL = async (url: string) => {
-      // Close in-app browser if it's open
-      WebBrowser.dismissBrowser().catch(() => {})
+      if (isNative) {
+        // Close in-app browser if it's open
+        WebBrowser.dismissBrowser().catch(() => {})
+      }
 
       const referrerInfo = Referrer.getReferrerInfo()
       if (referrerInfo && referrerInfo.hostname !== 'bsky.app') {


### PR DESCRIPTION
If you use the in-app browser to go to a bsky.app URL, it will do the navigation in the background. We should attempt to close the IAB when handling intents.

Is this the right way of doing it? Are there any cases where intents will get fired but we want to keep the IAB open? (I don't think so)

See: https://docs.expo.dev/versions/latest/sdk/webbrowser/#handling-deep-links-from-the-webbrowser

https://github.com/user-attachments/assets/baa7eb18-55c5-4c46-a2a7-9d8ae816b538

Tested iOS/Android
