### PR TITLE
(fix): Fix router to handle trailing slashes in URLs

### DIFF
--- a/src/lib/routes/router.ts
+++ b/src/lib/routes/router.ts
@@ -1,4 +1,4 @@
-import {Route, RouteParams} from './types'
+import {type Route, type RouteParams} from './types'
 
 export class Router {
   routes: [string, Route][] = []
@@ -49,7 +49,10 @@ function createRoute(pattern: string): Route {
       const {pathname, searchParams} = new URL(path, 'http://throwaway.com')
       const addedParams = Object.fromEntries(searchParams.entries())
 
-      const res = matcherRe.exec(pathname)
+      const normalizedPathname =
+        pathname === '/' ? pathname : pathname.replace(/\/+$/, '')
+
+      const res = matcherRe.exec(normalizedPathname)
       if (res) {
         return {params: Object.assign(addedParams, res.groups || {})}
       }


### PR DESCRIPTION
# Fix router to handle URLs with trailing slashes

Fixes #8456

## Problem

URLs with trailing slashes were returning "404 Not Found" errors instead of loading the correct page. This affected both web and Android platforms when users clicked on links that had trailing slashes added (commonly happens when copying/pasting URLs).

### Examples:
- ✅ **Working**: `https://bsky.app/profile/pfrazee.com/post/3lqvsoj4dh22o`
- ❌ **Broken**: `https://bsky.app/profile/pfrazee.com/post/3lqvsoj4dh22o/`

## Root Cause

The router's `createRoute` function was using a regex pattern that only matched URLs ending with query parameters (`?`) or end of string (`$`), but not trailing slashes (`/`). This caused URLs like `/profile/user/post/123/` to fail route matching and fall through to the "NotFound" route.

## Solution

Modified the router to normalize pathnames by removing trailing slashes before route matching, while preserving the root path `/` correctly.

**Key changes:**
- Added pathname normalization in `src/lib/routes/router.ts`
- Strips trailing slashes from all paths except root (`/`) before matching
- Maintains exact route matching behavior to prevent regressions

## Testing

- [x] Existing test suite passes
- [x] Manual testing confirms both URLs now work:
  - `/profile/pfrazee.com/post/3lqvsoj4dh22o` ✅
  - `/profile/pfrazee.com/post/3lqvsoj4dh22o/` ✅
- [x] No regressions in other route patterns
- [x] Query parameters still work with trailing slashes

This fix ensures that users can share and click on URLs regardless of whether they have trailing slashes, improving the overall user experience when sharing links from the app.