### PR TITLE
Instant Feed Update on Mute or Moderation Action

### DIFF
--- a/__tests__/lib/removePosts.test.ts
+++ b/__tests__/lib/removePosts.test.ts
@@ -1,0 +1,131 @@
+jest.mock('react-native-reanimated', () => ({
+  __esModule: true,
+  default: {
+    call: () => {},
+    createAnimatedComponent: (comp: any) => comp,
+  },
+  NativeReanimatedModule: {
+    get: () => {},
+  },
+  addWhitelistedUIProps: () => {},
+}))
+
+jest.mock('react-native', () => ({
+  Platform: {
+    OS: 'ios',
+    Version: '16.0',
+    select: (options: any) => options.native ?? Object.values(options)[0],
+  },
+  StyleSheet: {create: (styles: any) => styles},
+  Dimensions: {
+    get: (_dim: string) => ({width: 375, height: 667}),
+  },
+  AppState: {
+    addEventListener: jest.fn(() => ({
+      remove: jest.fn(),
+    })),
+    removeEventListener: jest.fn(),
+    currentState: 'active',
+  },
+}))
+jest.mock('../../src/lib/react-query', () => ({}))
+
+import React from 'react'
+
+import * as postShadowModule from '../../src/state/cache/post-shadow'
+import {POST_TOMBSTONE} from '../../src/state/cache/post-shadow'
+import * as profileShadowModule from '../../src/state/cache/profile-shadow'
+import * as typesModule from '../../src/state/cache/types'
+
+function runHook(hook: () => any) {
+  let result: any
+  function TestComponent() {
+    result = hook()
+    return null
+  }
+  const {act} = require('react-test-renderer')
+  act(() => {
+    require('react-test-renderer').create(React.createElement(TestComponent))
+  })
+  return {result}
+}
+
+describe('isAuthorMuted', () => {
+  const {isAuthorMuted} = postShadowModule as any
+
+  it('returns true if viewer.muted is true', () => {
+    expect(isAuthorMuted({viewer: {muted: true}})).toBe(true)
+  })
+
+  it('returns false if viewer.muted is false', () => {
+    expect(isAuthorMuted({viewer: {muted: false}})).toBe(false)
+  })
+
+  it('returns false if viewer is undefined', () => {
+    expect(isAuthorMuted({})).toBe(false)
+  })
+
+  it('returns false if viewer.muted is undefined', () => {
+    expect(isAuthorMuted({viewer: {}})).toBe(false)
+  })
+})
+
+describe('isAuthorBlocked', () => {
+  const {isAuthorBlocked} = postShadowModule as any
+
+  it('returns true if viewer.blocking is true', () => {
+    expect(isAuthorBlocked({viewer: {blocking: true}})).toBe(true)
+  })
+
+  it('returns false if viewer.blocking is false', () => {
+    expect(isAuthorBlocked({viewer: {blocking: false}})).toBe(false)
+  })
+
+  it('returns false if viewer is undefined', () => {
+    expect(isAuthorBlocked({})).toBe(false)
+  })
+
+  it('returns false if viewer.blocking is undefined', () => {
+    expect(isAuthorBlocked({viewer: {}})).toBe(false)
+  })
+})
+
+describe('usePostShadow', () => {
+  const post = {
+    uri: 'test:uri',
+    author: {did: 'did:author'},
+    likeCount: 1,
+    repostCount: 2,
+    viewer: {},
+  } as any
+
+  beforeEach(() => {
+    jest.spyOn(profileShadowModule, 'useProfileShadow')
+    jest
+      .spyOn(typesModule, 'castAsShadow')
+      .mockImplementation(p => ({...p, _shadow: true}))
+    jest
+      .spyOn(postShadowModule, 'mergeShadow')
+      .mockImplementation((p, s) => ({...p, ...s, _merged: true}))
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('returns POST_TOMBSTONE if author is muted', () => {
+    ;(profileShadowModule.useProfileShadow as jest.Mock).mockReturnValue({
+      viewer: {muted: true},
+    })
+    const {result} = runHook(() => postShadowModule.usePostShadow(post))
+    expect(result).toBe(POST_TOMBSTONE)
+  })
+
+  it('returns POST_TOMBSTONE if author is blocked', () => {
+    ;(profileShadowModule.useProfileShadow as jest.Mock).mockReturnValue({
+      viewer: {blocking: true},
+    })
+    const {result} = runHook(() => postShadowModule.usePostShadow(post))
+    expect(result).toBe(POST_TOMBSTONE)
+  })
+})

--- a/src/components/PostControls/PostMenu/PostMenuItems.tsx
+++ b/src/components/PostControls/PostMenu/PostMenuItems.tsx
@@ -120,6 +120,7 @@ let PostMenuItems = ({
   const navigation = useNavigation<NavigationProp>()
   const {mutedWordsDialogControl} = useGlobalDialogsControlContext()
   const blockPromptControl = useDialogControl()
+  const mutePromptControl = useDialogControl()
   const reportDialogControl = useReportDialogControl()
   const deletePromptControl = useDialogControl()
   const hidePromptControl = useDialogControl()
@@ -609,7 +610,7 @@ let PostMenuItems = ({
                         ? _(msg`Unmute account`)
                         : _(msg`Mute account`)
                     }
-                    onPress={onMuteAuthor}>
+                    onPress={() => mutePromptControl.open()}>
                     <Menu.ItemText>
                       {postAuthor.viewer?.muted
                         ? _(msg`Unmute account`)
@@ -740,6 +741,29 @@ let PostMenuItems = ({
         )}
         onConfirm={onBlockAuthor}
         confirmButtonCta={_(msg`Block`)}
+        confirmButtonColor="negative"
+      />
+
+      <Prompt.Basic
+        control={mutePromptControl}
+        title={
+          postAuthor.viewer?.muted
+            ? _(msg`Unmute account?`)
+            : _(msg`Mute account?`)
+        }
+        description={
+          postAuthor.viewer?.muted
+            ? _(
+                msg`Unmuted accounts have their posts restored to your feed and notifications.`,
+              )
+            : _(
+                msg`Muted accounts have their posts removed from your feed and from your notifications. Mutes are completely private.`,
+              )
+        }
+        onConfirm={onMuteAuthor}
+        confirmButtonCta={
+          postAuthor.viewer?.muted ? _(msg`Unmute`) : _(msg`Mute`)
+        }
         confirmButtonColor="negative"
       />
     </>

--- a/src/state/cache/post-shadow.ts
+++ b/src/state/cache/post-shadow.ts
@@ -14,6 +14,7 @@ import {findAllPostsInQueryData as findAllPostsInFeedQueryData} from '#/state/qu
 import {findAllPostsInQueryData as findAllPostsInQuoteQueryData} from '#/state/queries/post-quotes'
 import {findAllPostsInQueryData as findAllPostsInThreadQueryData} from '#/state/queries/post-thread'
 import {findAllPostsInQueryData as findAllPostsInSearchQueryData} from '#/state/queries/search-posts'
+import {useProfileShadow} from './profile-shadow'
 import {castAsShadow, type Shadow} from './types'
 export type {Shadow} from './types'
 
@@ -33,6 +34,31 @@ const shadows: WeakMap<
   Partial<PostShadow>
 > = new WeakMap()
 
+export function isAuthorMuted(
+  authorShadow: ReturnType<typeof useProfileShadow>,
+): boolean {
+  if (authorShadow.viewer && typeof authorShadow.viewer.muted !== 'undefined') {
+    if (authorShadow.viewer.muted) {
+      return true
+    }
+  }
+  return false
+}
+
+export function isAuthorBlocked(
+  authorShadow: ReturnType<typeof useProfileShadow>,
+): boolean {
+  if (
+    authorShadow.viewer &&
+    typeof authorShadow.viewer.blocking !== 'undefined'
+  ) {
+    if (authorShadow.viewer.blocking) {
+      return true
+    }
+  }
+  return false
+}
+
 export function usePostShadow(
   post: AppBskyFeedDefs.PostView,
 ): Shadow<AppBskyFeedDefs.PostView> | typeof POST_TOMBSTONE {
@@ -42,6 +68,10 @@ export function usePostShadow(
     setPrevPost(post)
     setShadow(shadows.get(post))
   }
+
+  const authorShadow = useProfileShadow(post.author)
+  const wasMuted = isAuthorMuted(authorShadow)
+  const wasBlocked = isAuthorBlocked(authorShadow)
 
   useEffect(() => {
     function onUpdate() {
@@ -54,15 +84,18 @@ export function usePostShadow(
   }, [post, setShadow])
 
   return useMemo(() => {
+    if (wasMuted || wasBlocked) {
+      return POST_TOMBSTONE
+    }
     if (shadow) {
       return mergeShadow(post, shadow)
     } else {
       return castAsShadow(post)
     }
-  }, [post, shadow])
+  }, [post, shadow, wasMuted, wasBlocked])
 }
 
-function mergeShadow(
+export function mergeShadow(
   post: AppBskyFeedDefs.PostView,
   shadow: Partial<PostShadow>,
 ): Shadow<AppBskyFeedDefs.PostView> | typeof POST_TOMBSTONE {

--- a/src/state/queries/profile.ts
+++ b/src/state/queries/profile.ts
@@ -499,9 +499,10 @@ function useProfileBlockMutation() {
         {subject: did, createdAt: new Date().toISOString()},
       )
     },
-    onSuccess(_, {did}) {
+    onSuccess(data, {did}) {
       queryClient.invalidateQueries({queryKey: RQKEY_MY_BLOCKED()})
       resetProfilePostsQueries(queryClient, did, 1000)
+      updateProfileShadow(queryClient, did, {blockingUri: data.uri})
     },
   })
 }
@@ -523,6 +524,7 @@ function useProfileUnblockMutation() {
     },
     onSuccess(_, {did}) {
       resetProfilePostsQueries(queryClient, did, 1000)
+      updateProfileShadow(queryClient, did, {blockingUri: undefined})
     },
   })
 }


### PR DESCRIPTION
Implemented #2406:  Posts from muted or blocked users are now removed immediately from the feed. This is achieved by extending the ```usePostShadow``` hook to check if the post author is muted or blocked and return ```POST_TOMBSTONE``` accordingly.
Additionally, a confirmation prompt was added to the mute action, aligning it with the existing block flow for consistency. A unit test was also added to validate the new logic.