### PR TITLE
Post source handling updates

### DIFF
--- a/src/App.native.tsx
+++ b/src/App.native.tsx
@@ -58,7 +58,6 @@ import {Provider as ProgressGuideProvider} from '#/state/shell/progress-guide'
 import {Provider as SelectedFeedProvider} from '#/state/shell/selected-feed'
 import {Provider as StarterPackProvider} from '#/state/shell/starter-pack'
 import {Provider as HiddenRepliesProvider} from '#/state/threadgate-hidden-replies'
-import {Provider as UnstablePostSourceProvider} from '#/state/unstable-post-source'
 import {TestCtrls} from '#/view/com/testing/TestCtrls'
 import {Provider as VideoVolumeProvider} from '#/view/com/util/post-embeds/VideoVolumeContext'
 import * as Toast from '#/view/com/util/Toast'
@@ -151,16 +150,14 @@ function InnerApp() {
                                           <MutedThreadsProvider>
                                             <ProgressGuideProvider>
                                               <ServiceAccountManager>
-                                                <UnstablePostSourceProvider>
-                                                  <GestureHandlerRootView
-                                                    style={s.h100pct}>
-                                                    <IntentDialogProvider>
-                                                      <TestCtrls />
-                                                      <Shell />
-                                                      <NuxDialogs />
-                                                    </IntentDialogProvider>
-                                                  </GestureHandlerRootView>
-                                                </UnstablePostSourceProvider>
+                                                <GestureHandlerRootView
+                                                  style={s.h100pct}>
+                                                  <IntentDialogProvider>
+                                                    <TestCtrls />
+                                                    <Shell />
+                                                    <NuxDialogs />
+                                                  </IntentDialogProvider>
+                                                </GestureHandlerRootView>
                                               </ServiceAccountManager>
                                             </ProgressGuideProvider>
                                           </MutedThreadsProvider>

--- a/src/App.web.tsx
+++ b/src/App.web.tsx
@@ -48,7 +48,6 @@ import {Provider as ProgressGuideProvider} from '#/state/shell/progress-guide'
 import {Provider as SelectedFeedProvider} from '#/state/shell/selected-feed'
 import {Provider as StarterPackProvider} from '#/state/shell/starter-pack'
 import {Provider as HiddenRepliesProvider} from '#/state/threadgate-hidden-replies'
-import {Provider as UnstablePostSourceProvider} from '#/state/unstable-post-source'
 import {Provider as ActiveVideoProvider} from '#/view/com/util/post-embeds/ActiveVideoWebContext'
 import {Provider as VideoVolumeProvider} from '#/view/com/util/post-embeds/VideoVolumeContext'
 import * as Toast from '#/view/com/util/Toast'
@@ -132,12 +131,10 @@ function InnerApp() {
                                             <SafeAreaProvider>
                                               <ProgressGuideProvider>
                                                 <ServiceConfigProvider>
-                                                  <UnstablePostSourceProvider>
-                                                    <IntentDialogProvider>
-                                                      <Shell />
-                                                      <NuxDialogs />
-                                                    </IntentDialogProvider>
-                                                  </UnstablePostSourceProvider>
+                                                  <IntentDialogProvider>
+                                                    <Shell />
+                                                    <NuxDialogs />
+                                                  </IntentDialogProvider>
                                                 </ServiceConfigProvider>
                                               </ProgressGuideProvider>
                                             </SafeAreaProvider>

--- a/src/logger/types.ts
+++ b/src/logger/types.ts
@@ -10,6 +10,8 @@ export enum LogContext {
   ConversationAgent = 'conversation-agent',
   DMsAgent = 'dms-agent',
   ReportDialog = 'report-dialog',
+  FeedFeedback = 'feed-feedback',
+  PostSource = 'post-source',
 
   /**
    * METRIC IS FOR INTERNAL USE ONLY, don't create any other loggers using this

--- a/src/state/feed-feedback.tsx
+++ b/src/state/feed-feedback.tsx
@@ -12,13 +12,15 @@ import throttle from 'lodash.throttle'
 
 import {FEEDBACK_FEEDS, STAGING_FEEDS} from '#/lib/constants'
 import {logEvent} from '#/lib/statsig/statsig'
-import {logger} from '#/logger'
+import {Logger} from '#/logger'
 import {
   type FeedDescriptor,
   type FeedPostSliceItem,
 } from '#/state/queries/post-feed'
 import {getItemsForFeedback} from '#/view/com/posts/PostFeed'
 import {useAgent} from './session'
+
+const logger = Logger.create(Logger.Context.FeedFeedback)
 
 export type StateContext = {
   enabled: boolean
@@ -89,6 +91,7 @@ export function useFeedFeedback(
     }
     sendOrAggregateInteractionsForStats(aggregatedStats.current, interactions)
     throttledFlushAggregatedStats()
+    logger.debug('flushed')
   }, [agent, throttledFlushAggregatedStats, feed])
 
   const sendToFeed = useMemo(
@@ -138,6 +141,9 @@ export function useFeedFeedback(
 
   const sendInteraction = useCallback(
     (interaction: AppBskyFeedDefs.Interaction) => {
+      logger.debug('sendInteraction', {
+        ...interaction,
+      })
       if (!enabled) {
         return
       }

--- a/src/state/feed-feedback.tsx
+++ b/src/state/feed-feedback.tsx
@@ -141,12 +141,12 @@ export function useFeedFeedback(
 
   const sendInteraction = useCallback(
     (interaction: AppBskyFeedDefs.Interaction) => {
-      logger.debug('sendInteraction', {
-        ...interaction,
-      })
       if (!enabled) {
         return
       }
+      logger.debug('sendInteraction', {
+        ...interaction,
+      })
       if (!history.current.has(interaction)) {
         history.current.add(interaction)
         queue.current.add(toString(interaction))

--- a/src/state/unstable-post-source.tsx
+++ b/src/state/unstable-post-source.tsx
@@ -18,7 +18,7 @@ export type PostSource = {
  * A cache of sources that will be consumed by the post thread view. This is
  * cleaned up any time a source is consumed.
  */
-const transientSourcesRef = new Map<string, PostSource>()
+const transientSources = new Map<string, PostSource>()
 
 /**
  * A cache of sources that have been consumed by the post thread view. This is
@@ -26,7 +26,7 @@ const transientSourcesRef = new Map<string, PostSource>()
  * consumes a source, this is never reused unless a user navigates back to a
  * post thread view that has not been dropped from memory.
  */
-const consumedSourcesRef = new Map<string, PostSource>()
+const consumedSources = new Map<string, PostSource>()
 
 /**
  * For stashing the feed that the user was browsing when they clicked on a post.
@@ -39,7 +39,7 @@ export function setUnstablePostSource(key: string, source: PostSource) {
     `setUnstablePostSource key should be a URI containing a handle, received ${key} — use buildPostSourceKey`,
   )
   logger.debug('set', {key, source})
-  transientSourcesRef.set(key, source)
+  transientSources.set(key, source)
 }
 
 /**
@@ -55,11 +55,11 @@ export function useUnstablePostSource(key: string) {
       key,
       `consumeUnstablePostSource key should be a URI containing a handle, received ${key} — use buildPostSourceKey`,
     )
-    const source = consumedSourcesRef.get(id) || transientSourcesRef.get(key)
+    const source = consumedSources.get(id) || transientSources.get(key)
     if (source) {
       logger.debug('consume', {key, source})
-      transientSourcesRef.delete(key)
-      consumedSourcesRef.set(id, source)
+      transientSources.delete(key)
+      consumedSources.set(id, source)
     }
     return source
   })

--- a/src/state/unstable-post-source.tsx
+++ b/src/state/unstable-post-source.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useId, useState} from 'react'
+import {useId, useState} from 'react'
 import {type AppBskyFeedDefs, AtUri} from '@atproto/api'
 
 import {Logger} from '#/logger'
@@ -33,15 +33,13 @@ const consumedSourcesRef = new Map<string, PostSource>()
  *
  * Used for FeedFeedback and other ephemeral non-critical systems.
  */
-export function useSetUnstablePostSource() {
-  return useCallback((key: string, source: PostSource) => {
-    assertValid(
-      key,
-      `setUnstablePostSource key should be a URI containing a handle, received ${key} — use buildPostSourceKey`,
-    )
-    logger.debug('set', {key, source})
-    transientSourcesRef.set(key, source)
-  }, [])
+export function setUnstablePostSource(key: string, source: PostSource) {
+  assertValid(
+    key,
+    `setUnstablePostSource key should be a URI containing a handle, received ${key} — use buildPostSourceKey`,
+  )
+  logger.debug('set', {key, source})
+  transientSourcesRef.set(key, source)
 }
 
 /**

--- a/src/state/unstable-post-source.tsx
+++ b/src/state/unstable-post-source.tsx
@@ -1,7 +1,10 @@
 import {createContext, useCallback, useContext, useRef, useState} from 'react'
 import {type AppBskyFeedDefs} from '@atproto/api'
 
-import {type FeedDescriptor} from './queries/post-feed'
+import {Logger} from '#/logger'
+import {type FeedDescriptor} from '#/state/queries/post-feed'
+
+const logger = Logger.create(Logger.Context.PostSource)
 
 /**
  * For passing the source of the post (i.e. the original post, from the feed) to the threadview,
@@ -15,7 +18,7 @@ type Source = {
 }
 
 const SetUnstablePostSourceContext = createContext<
-  (key: string, source: Source) => void
+  (uri: string, source: Source) => void
 >(() => {})
 const ConsumeUnstablePostSourceContext = createContext<
   (uri: string) => Source | undefined
@@ -24,14 +27,22 @@ const ConsumeUnstablePostSourceContext = createContext<
 export function Provider({children}: {children: React.ReactNode}) {
   const sourcesRef = useRef<Map<string, Source>>(new Map())
 
-  const setUnstablePostSource = useCallback((key: string, source: Source) => {
-    sourcesRef.current.set(key, source)
+  const setUnstablePostSource = useCallback((uri: string, source: Source) => {
+    sourcesRef.current.set(uri, source)
+    logger.debug('set', {
+      uri,
+      source,
+    })
   }, [])
 
   const consumeUnstablePostSource = useCallback((uri: string) => {
     const source = sourcesRef.current.get(uri)
     if (source) {
       sourcesRef.current.delete(uri)
+      logger.debug('consume', {
+        uri,
+        source,
+      })
     }
     return source
   }, [])

--- a/src/state/unstable-post-source.tsx
+++ b/src/state/unstable-post-source.tsx
@@ -1,4 +1,4 @@
-import {useId, useState} from 'react'
+import {useEffect, useId, useState} from 'react'
 import {type AppBskyFeedDefs, AtUri} from '@atproto/api'
 
 import {Logger} from '#/logger'
@@ -57,12 +57,20 @@ export function useUnstablePostSource(key: string) {
     )
     const source = consumedSources.get(id) || transientSources.get(key)
     if (source) {
-      logger.debug('consume', {key, source})
+      logger.debug('consume', {id, key, source})
       transientSources.delete(key)
       consumedSources.set(id, source)
     }
     return source
   })
+
+  useEffect(() => {
+    return () => {
+      consumedSources.delete(id)
+      logger.debug('cleanup', {id})
+    }
+  }, [id])
+
   return source
 }
 

--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -40,7 +40,7 @@ import {useLanguagePrefs} from '#/state/preferences'
 import {type ThreadPost} from '#/state/queries/post-thread'
 import {useSession} from '#/state/session'
 import {useMergedThreadgateHiddenReplies} from '#/state/threadgate-hidden-replies'
-import {type Source} from '#/state/unstable-post-source'
+import {type PostSource} from '#/state/unstable-post-source'
 import {PostThreadFollowBtn} from '#/view/com/post-thread/PostThreadFollowBtn'
 import {ErrorMessage} from '#/view/com/util/error/ErrorMessage'
 import {Link, TextLink} from '#/view/com/util/Link'
@@ -105,7 +105,7 @@ export function PostThreadItem({
   onPostReply: (postUri: string | undefined) => void
   hideTopBorder?: boolean
   threadgateRecord?: AppBskyFeedThreadgate.Record
-  anchorPostSource?: Source
+  anchorPostSource?: PostSource
 }) {
   const postShadowed = usePostShadow(post)
   const richText = useMemo(
@@ -206,7 +206,7 @@ let PostThreadItemLoaded = ({
   onPostReply: (postUri: string | undefined) => void
   hideTopBorder?: boolean
   threadgateRecord?: AppBskyFeedThreadgate.Record
-  anchorPostSource?: Source
+  anchorPostSource?: PostSource
 }): React.ReactNode => {
   const {currentAccount, hasSession} = useSession()
   const feedFeedback = useFeedFeedback(anchorPostSource?.feed, hasSession)

--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -40,7 +40,10 @@ import {useLanguagePrefs} from '#/state/preferences'
 import {type ThreadPost} from '#/state/queries/post-thread'
 import {useSession} from '#/state/session'
 import {useMergedThreadgateHiddenReplies} from '#/state/threadgate-hidden-replies'
-import {useUnstablePostSource} from '#/state/unstable-post-source'
+import {
+  buildPostSourceUri,
+  useUnstablePostSource,
+} from '#/state/unstable-post-source'
 import {PostThreadFollowBtn} from '#/view/com/post-thread/PostThreadFollowBtn'
 import {ErrorMessage} from '#/view/com/util/error/ErrorMessage'
 import {Link, TextLink} from '#/view/com/util/Link'
@@ -204,7 +207,9 @@ let PostThreadItemLoaded = ({
   threadgateRecord?: AppBskyFeedThreadgate.Record
 }): React.ReactNode => {
   const {currentAccount, hasSession} = useSession()
-  const source = useUnstablePostSource(post.uri)
+  const source = useUnstablePostSource(
+    buildPostSourceUri(post.uri, post.author.handle),
+  )
   const feedFeedback = useFeedFeedback(source?.feed, hasSession)
 
   const t = useTheme()

--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -40,10 +40,7 @@ import {useLanguagePrefs} from '#/state/preferences'
 import {type ThreadPost} from '#/state/queries/post-thread'
 import {useSession} from '#/state/session'
 import {useMergedThreadgateHiddenReplies} from '#/state/threadgate-hidden-replies'
-import {
-  buildPostSourceUri,
-  useUnstablePostSource,
-} from '#/state/unstable-post-source'
+import {type Source} from '#/state/unstable-post-source'
 import {PostThreadFollowBtn} from '#/view/com/post-thread/PostThreadFollowBtn'
 import {ErrorMessage} from '#/view/com/util/error/ErrorMessage'
 import {Link, TextLink} from '#/view/com/util/Link'
@@ -90,6 +87,7 @@ export function PostThreadItem({
   onPostReply,
   hideTopBorder,
   threadgateRecord,
+  anchorPostSource,
 }: {
   post: AppBskyFeedDefs.PostView
   record: AppBskyFeedPost.Record
@@ -107,6 +105,7 @@ export function PostThreadItem({
   onPostReply: (postUri: string | undefined) => void
   hideTopBorder?: boolean
   threadgateRecord?: AppBskyFeedThreadgate.Record
+  anchorPostSource?: Source
 }) {
   const postShadowed = usePostShadow(post)
   const richText = useMemo(
@@ -142,6 +141,7 @@ export function PostThreadItem({
         onPostReply={onPostReply}
         hideTopBorder={hideTopBorder}
         threadgateRecord={threadgateRecord}
+        anchorPostSource={anchorPostSource}
       />
     )
   }
@@ -187,6 +187,7 @@ let PostThreadItemLoaded = ({
   onPostReply,
   hideTopBorder,
   threadgateRecord,
+  anchorPostSource,
 }: {
   post: Shadow<AppBskyFeedDefs.PostView>
   record: AppBskyFeedPost.Record
@@ -205,12 +206,10 @@ let PostThreadItemLoaded = ({
   onPostReply: (postUri: string | undefined) => void
   hideTopBorder?: boolean
   threadgateRecord?: AppBskyFeedThreadgate.Record
+  anchorPostSource?: Source
 }): React.ReactNode => {
   const {currentAccount, hasSession} = useSession()
-  const source = useUnstablePostSource(
-    buildPostSourceUri(post.uri, post.author.handle),
-  )
-  const feedFeedback = useFeedFeedback(source?.feed, hasSession)
+  const feedFeedback = useFeedFeedback(anchorPostSource?.feed, hasSession)
 
   const t = useTheme()
   const pal = usePalette('default')
@@ -281,12 +280,12 @@ let PostThreadItemLoaded = ({
   )
 
   const onPressReply = () => {
-    if (source) {
+    if (anchorPostSource && isHighlightedPost) {
       feedFeedback.sendInteraction({
         item: post.uri,
         event: 'app.bsky.feed.defs#interactionReply',
-        feedContext: source.post.feedContext,
-        reqId: source.post.reqId,
+        feedContext: anchorPostSource.post.feedContext,
+        reqId: anchorPostSource.post.reqId,
       })
     }
     openComposer({
@@ -303,23 +302,23 @@ let PostThreadItemLoaded = ({
   }
 
   const onOpenAuthor = () => {
-    if (source) {
+    if (anchorPostSource) {
       feedFeedback.sendInteraction({
         item: post.uri,
         event: 'app.bsky.feed.defs#clickthroughAuthor',
-        feedContext: source.post.feedContext,
-        reqId: source.post.reqId,
+        feedContext: anchorPostSource.post.feedContext,
+        reqId: anchorPostSource.post.reqId,
       })
     }
   }
 
   const onOpenEmbed = () => {
-    if (source) {
+    if (anchorPostSource) {
       feedFeedback.sendInteraction({
         item: post.uri,
         event: 'app.bsky.feed.defs#clickthroughEmbed',
-        feedContext: source.post.feedContext,
-        reqId: source.post.reqId,
+        feedContext: anchorPostSource.post.feedContext,
+        reqId: anchorPostSource.post.reqId,
       })
     }
   }
@@ -330,7 +329,7 @@ let PostThreadItemLoaded = ({
 
   const {isActive: live} = useActorStatus(post.author)
 
-  const reason = source?.post.reason
+  const reason = anchorPostSource?.post.reason
   const viaRepost = useMemo(() => {
     if (AppBskyFeedDefs.isReasonRepost(reason) && reason.uri && reason.cid) {
       return {
@@ -555,8 +554,8 @@ let PostThreadItemLoaded = ({
                   onPostReply={onPostReply}
                   logContext="PostThreadItem"
                   threadgateRecord={threadgateRecord}
-                  feedContext={source?.post?.feedContext}
-                  reqId={source?.post?.reqId}
+                  feedContext={anchorPostSource?.post?.feedContext}
+                  reqId={anchorPostSource?.post?.reqId}
                   viaRepost={viaRepost}
                 />
               </FeedFeedbackProvider>

--- a/src/view/com/posts/PostFeedItem.tsx
+++ b/src/view/com/posts/PostFeedItem.tsx
@@ -37,7 +37,7 @@ import {unstableCacheProfileView} from '#/state/queries/profile'
 import {useSession} from '#/state/session'
 import {useMergedThreadgateHiddenReplies} from '#/state/threadgate-hidden-replies'
 import {
-  buildPostSourceUri,
+  buildPostSourceKey,
   useSetUnstablePostSource,
 } from '#/state/unstable-post-source'
 import {FeedNameText} from '#/view/com/util/FeedInfoText'
@@ -235,7 +235,7 @@ let FeedItemInner = ({
       reqId,
     })
     unstableCacheProfileView(queryClient, post.author)
-    unstableSetPostSource(buildPostSourceUri(post.uri, post.author.handle), {
+    unstableSetPostSource(buildPostSourceKey(post.uri, post.author.handle), {
       feed: feedDescriptor,
       post: {
         post,

--- a/src/view/com/posts/PostFeedItem.tsx
+++ b/src/view/com/posts/PostFeedItem.tsx
@@ -38,7 +38,7 @@ import {useSession} from '#/state/session'
 import {useMergedThreadgateHiddenReplies} from '#/state/threadgate-hidden-replies'
 import {
   buildPostSourceKey,
-  useSetUnstablePostSource,
+  setUnstablePostSource,
 } from '#/state/unstable-post-source'
 import {FeedNameText} from '#/view/com/util/FeedInfoText'
 import {Link, TextLink, TextLinkOnWebOnly} from '#/view/com/util/Link'
@@ -179,7 +179,6 @@ let FeedItemInner = ({
     return makeProfileLink(post.author, 'post', urip.rkey)
   }, [post.uri, post.author])
   const {sendInteraction, feedDescriptor} = useFeedFeedbackContext()
-  const unstableSetPostSource = useSetUnstablePostSource()
 
   const onPressReply = () => {
     sendInteraction({
@@ -235,7 +234,7 @@ let FeedItemInner = ({
       reqId,
     })
     unstableCacheProfileView(queryClient, post.author)
-    unstableSetPostSource(buildPostSourceKey(post.uri, post.author.handle), {
+    setUnstablePostSource(buildPostSourceKey(post.uri, post.author.handle), {
       feed: feedDescriptor,
       post: {
         post,

--- a/src/view/com/posts/PostFeedItem.tsx
+++ b/src/view/com/posts/PostFeedItem.tsx
@@ -36,7 +36,10 @@ import {useFeedFeedbackContext} from '#/state/feed-feedback'
 import {unstableCacheProfileView} from '#/state/queries/profile'
 import {useSession} from '#/state/session'
 import {useMergedThreadgateHiddenReplies} from '#/state/threadgate-hidden-replies'
-import {useSetUnstablePostSource} from '#/state/unstable-post-source'
+import {
+  buildPostSourceUri,
+  useSetUnstablePostSource,
+} from '#/state/unstable-post-source'
 import {FeedNameText} from '#/view/com/util/FeedInfoText'
 import {Link, TextLink, TextLinkOnWebOnly} from '#/view/com/util/Link'
 import {PostEmbeds, PostEmbedViewContext} from '#/view/com/util/post-embeds'
@@ -232,7 +235,7 @@ let FeedItemInner = ({
       reqId,
     })
     unstableCacheProfileView(queryClient, post.author)
-    unstableSetPostSource(post.uri, {
+    unstableSetPostSource(buildPostSourceUri(post.uri, post.author.handle), {
       feed: feedDescriptor,
       post: {
         post,


### PR DESCRIPTION
In testing this with v2, I realized that we weren't tracking reply interactions originating from the reply composer list item itself, only the reply button in `PostControls`. I started implementing that and quickly realized that consuming the post source data in the outer component won't work, because the component can re-render and evacuate the previously cached post source value from state. Also, from the outer `PostThread` component, the URI generated from the URL path params is going to contain a handle (if we nav to a thread via any of our flows e.g. feeds).

So I set about making the post source cache stable between renders, and keying it off the handle.

These commits are in rough order, and essentially what they contain is:
- some debug logs which only appear if you have your `LOG_LEVEL` set to `debug`
- moving towards using the URI w/handle as the "key" of the cache
- persisting _already consumed_ post sources and keying that data by a value from `useId` so that we can always return a source for a given mounted component, if a source is available
- sending reply interactions
- passing down the post source as `anchorPostSource` to the thread components that need it
- realizing that we don't need `useRef`, and therefore don't need a context here at all
- cleaning up `consumedSources` on unmount
- cleaning up naming and adding comments

To give an idea of exactly what's happening here, here's an example:
1. user is browsing the Discover feed
2. user clicks on a post
3. `transientSources` cache is set with `key, source`
4. thread component renders
5. `transientSources` cache is cleared for `key`, `consumedSources` cache is set for `id, source`
6. `useUnstablePostSource` returns the same `source` until the component that rendered it is unmounted
7. user clicks on the avi of the author
8. user clicks on the same post, but from within the author's profile feed
9. (repeat steps 3-6) however this `source.feed` is undefined, since it came from the author feed
10. user clicks "back" in their browser to return to thread view (of the same post) from step 3
11. 2nd thread view runs cleanup and clears `consumedSources` map of its `id`
12. `useUnstablePostSource` _still returns_ the same `source`

To test, set your `LOG_LEVEL=debug` and watch for `feed-feedback` debug logs. After step 3, you should be able to reply/like/quote/etc and see `sendInteractions` fire with the correct content. Then proceed to step 9 and try again. You should not see any `sendInteraction` logs. Then proceed to step 11, and you should once again see `sendInteraction` logs.

If a user were to continue pushing screens onto the navigation stack and end up on the Discover feed via the Feeds screen or something, this will result in another post source entry under a different `useId` value, and it will function exactly the same way. And unwinding the history stack all the way back should _still work_ too.

Potential points of discussion:
- From a feed, do we ever link to a post using a URL with a DID instead of a handle? That will result in no source being found atm.