### PR TITLE
Revert "Instant Feed Update on Mute or Moderation Action"

### DIFF
--- a/src/state/cache/post-shadow.ts
+++ b/src/state/cache/post-shadow.ts
@@ -15,7 +15,6 @@ import {findAllPostsInQueryData as findAllPostsInQuoteQueryData} from '#/state/q
 import {findAllPostsInQueryData as findAllPostsInThreadQueryData} from '#/state/queries/post-thread'
 import {findAllPostsInQueryData as findAllPostsInSearchQueryData} from '#/state/queries/search-posts'
 import {findAllPostsInQueryData as findAllPostsInThreadV2QueryData} from '#/state/queries/usePostThread/queryCache'
-import {useProfileShadow} from './profile-shadow'
 import {castAsShadow, type Shadow} from './types'
 export type {Shadow} from './types'
 
@@ -45,10 +44,6 @@ export function usePostShadow(
     setShadow(shadows.get(post))
   }
 
-  const authorShadow = useProfileShadow(post.author)
-  const wasMuted = !!authorShadow.viewer?.muted
-  const wasBlocked = !!authorShadow.viewer?.blocking
-
   useEffect(() => {
     function onUpdate() {
       setShadow(shadows.get(post))
@@ -60,18 +55,15 @@ export function usePostShadow(
   }, [post, setShadow])
 
   return useMemo(() => {
-    if (wasMuted || wasBlocked) {
-      return POST_TOMBSTONE
-    }
     if (shadow) {
       return mergeShadow(post, shadow)
     } else {
       return castAsShadow(post)
     }
-  }, [post, shadow, wasMuted, wasBlocked])
+  }, [post, shadow])
 }
 
-export function mergeShadow(
+function mergeShadow(
   post: AppBskyFeedDefs.PostView,
   shadow: Partial<PostShadow>,
 ): Shadow<AppBskyFeedDefs.PostView> | typeof POST_TOMBSTONE {

--- a/src/state/queries/profile.ts
+++ b/src/state/queries/profile.ts
@@ -499,10 +499,9 @@ function useProfileBlockMutation() {
         {subject: did, createdAt: new Date().toISOString()},
       )
     },
-    onSuccess(data, {did}) {
+    onSuccess(_, {did}) {
       queryClient.invalidateQueries({queryKey: RQKEY_MY_BLOCKED()})
       resetProfilePostsQueries(queryClient, did, 1000)
-      updateProfileShadow(queryClient, did, {blockingUri: data.uri})
     },
   })
 }
@@ -524,7 +523,6 @@ function useProfileUnblockMutation() {
     },
     onSuccess(_, {did}) {
       resetProfilePostsQueries(queryClient, did, 1000)
-      updateProfileShadow(queryClient, did, {blockingUri: undefined})
     },
   })
 }


### PR DESCRIPTION
This PR #8463  results in muted people having all their posts appearing as deleted. Needs a different approach