### PR TITLE
Disable default stack traces that are causing issues

### DIFF
--- a/src/logger/sentry/setup/index.ts
+++ b/src/logger/sentry/setup/index.ts
@@ -38,4 +38,12 @@ init({
      */
     `Network request failed`,
   ],
+  /**
+   * Does not affect traces of error events or other logs, just disables
+   * automatically attaching stack traces to events. This helps us group events
+   * and prevents explosions of separate issues.
+   *
+   * @see https://docs.sentry.io/platforms/react-native/configuration/options/#attach-stacktrace
+   */
+  attachStacktrace: false,
 })


### PR DESCRIPTION
These auto stack traces are causing the same issue to be reported separately instead of as a group. Disabling this does not affect our error handling otherwise.