### PR TITLE
Run lint-staged without concurrency

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-npx lint-staged
+npx lint-staged --concurrent false


### PR DESCRIPTION
Run `prettier` _after_ `eslint --fix` by forcing `lint-staged` to run linearly.