### PR TITLE
Fix long-press loophole for disabled quote posts

### DIFF
--- a/src/components/PostControls/RepostButton.tsx
+++ b/src/components/PostControls/RepostButton.tsx
@@ -6,6 +6,7 @@ import {useLingui} from '@lingui/react'
 import {useHaptics} from '#/lib/haptics'
 import {useRequireAuth} from '#/state/session'
 import {formatCount} from '#/view/com/util/numeric/format'
+import * as Toast from '#/view/com/util/Toast'
 import {atoms as a, useTheme} from '#/alf'
 import {Button, ButtonText} from '#/components/Button'
 import * as Dialog from '#/components/Dialog'
@@ -40,6 +41,17 @@ let RepostButton = ({
   const requireAuth = useRequireAuth()
   const dialogControl = Dialog.useDialogControl()
 
+  const onPress = () => requireAuth(() => dialogControl.open())
+
+  const onLongPress = () =>
+    requireAuth(() => {
+      if (embeddingDisabled) {
+        Toast.show(_(msg`Quote posts are disabled for this post`))
+      } else {
+        onQuote()
+      }
+    })
+
   return (
     <>
       <PostControlButton
@@ -47,8 +59,8 @@ let RepostButton = ({
         active={isReposted}
         activeColor={t.palette.positive_600}
         big={big}
-        onPress={() => requireAuth(() => dialogControl.open())}
-        onLongPress={() => requireAuth(() => onQuote())}
+        onPress={onPress}
+        onLongPress={onLongPress}
         label={
           isReposted
             ? _(

--- a/src/components/PostControls/RepostButton.tsx
+++ b/src/components/PostControls/RepostButton.tsx
@@ -6,7 +6,6 @@ import {useLingui} from '@lingui/react'
 import {useHaptics} from '#/lib/haptics'
 import {useRequireAuth} from '#/state/session'
 import {formatCount} from '#/view/com/util/numeric/format'
-import * as Toast from '#/view/com/util/Toast'
 import {atoms as a, useTheme} from '#/alf'
 import {Button, ButtonText} from '#/components/Button'
 import * as Dialog from '#/components/Dialog'
@@ -46,7 +45,7 @@ let RepostButton = ({
   const onLongPress = () =>
     requireAuth(() => {
       if (embeddingDisabled) {
-        Toast.show(_(msg`Quote posts are disabled for this post`))
+        dialogControl.open()
       } else {
         onQuote()
       }


### PR DESCRIPTION
There's a "loophole" (not really) where if quote posts have been disabled, the long press shortcut still worked. The post would be shadowbanned due to breaking the threadgate rule, but that's not clear to the user

Fixed by falling back to the primary action (showing the dialog)