### PR TITLE
Fix v2 tree view bug caused by moderation settings

### DIFF
--- a/src/state/queries/usePostThread/traversal.ts
+++ b/src/state/queries/usePostThread/traversal.ts
@@ -270,7 +270,7 @@ export function sortAndAnnotateThreadItems(
              */
             metadata.isLastSibling =
               metadata.replyIndex ===
-              metadata.parentMetadata.repliesSeenCounter - 1
+              metadata.parentMetadata.repliesIndexCounter - 1
             metadata.isLastChild =
               metadata.nextItemDepth === undefined ||
               metadata.nextItemDepth <= metadata.depth

--- a/src/state/queries/usePostThread/traversal.ts
+++ b/src/state/queries/usePostThread/traversal.ts
@@ -265,12 +265,36 @@ export function sortAndAnnotateThreadItems(
               metadata.nextItemDepth = nextItem?.depth
 
             /*
-             * We can now officially calculate `isLastSibling` and `isLastChild`
-             * based on the actual data that we've seen.
+             * Item is the last "sibling" if we know for sure we're out of
+             * replies on the parent (even though this item itself may have its
+             * own reply branches).
              */
-            metadata.isLastSibling =
+            const isLastSiblingByCounts =
               metadata.replyIndex ===
               metadata.parentMetadata.repliesIndexCounter - 1
+
+            /*
+             * Item can also be the last "sibling" if we know we don't have a
+             * next item, OR if that next item's depth is less than this item's
+             * depth (meaning it's a sibling of the parent, not a child of this
+             * item).
+             */
+            const isImplicitlyLastSibling =
+              metadata.nextItemDepth === undefined ||
+              metadata.nextItemDepth < metadata.depth
+
+            /*
+             * Ok now we can set the last sibling state.
+             */
+            metadata.isLastSibling =
+              isLastSiblingByCounts || isImplicitlyLastSibling
+
+            /*
+             * Item is the last "child" in a branch if there is no next item,
+             * or if the next item's depth is less than this item's depth (a
+             * sibling of the parent) or equal to this item's depth (a sibling
+             * of this item)
+             */
             metadata.isLastChild =
               metadata.nextItemDepth === undefined ||
               metadata.nextItemDepth <= metadata.depth


### PR DESCRIPTION
First commit: if posts are moderated (such as a mute word) then `repliesSeenCounter` will not match `repliesIndexCounter`. However, to accurately compute what reply is the last sibling in a chain, we should be comparing if the `replyIndex` matches the actual `replyIndexCounter`, that way any omitted replies further up the chain are not taken into account.

Second commit: what if the last sibling in a chain is moderated? If that's the case, then we need to use a more implicit check for `isLastSibling`, since we know the next item in the list is not a sibling of the current item.

