### PR TITLE
Fix other case of `Promise.all` misuse

### DIFF
--- a/src/screens/Settings/InterestsSettings.tsx
+++ b/src/screens/Settings/InterestsSettings.tsx
@@ -113,13 +113,9 @@ function Inner({
           },
         )
         await Promise.all([
-          await qc.resetQueries({
-            queryKey: createSuggestedStarterPacksQueryKey(),
-          }),
-          await qc.resetQueries({queryKey: createGetSuggestedFeedsQueryKey()}),
-          await qc.resetQueries({
-            queryKey: createGetSuggestedUsersQueryKey({}),
-          }),
+          qc.resetQueries({queryKey: createSuggestedStarterPacksQueryKey()}),
+          qc.resetQueries({queryKey: createGetSuggestedFeedsQueryKey()}),
+          qc.resetQueries({queryKey: createGetSuggestedUsersQueryKey({})}),
         ])
 
         Toast.show(


### PR DESCRIPTION
```diff
        await Promise.all([
-          await qc.resetQueries({
-            queryKey: createSuggestedStarterPacksQueryKey(),
-          }),
-          await qc.resetQueries({queryKey: createGetSuggestedFeedsQueryKey()}),
-          await qc.resetQueries({
-            queryKey: createGetSuggestedUsersQueryKey({}),
-          }),
+          qc.resetQueries({queryKey: createSuggestedStarterPacksQueryKey()}),
+          qc.resetQueries({queryKey: createGetSuggestedFeedsQueryKey()}),
+          qc.resetQueries({queryKey: createGetSuggestedUsersQueryKey({})}),
        ])
```