### PR TITLE
Fix linking to specific search results

### DIFF
--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -9,7 +9,7 @@ import {
 import {BSKY_DOWNLOAD_URL} from '#/lib/constants'
 import {useNavigationDeduped} from '#/lib/hooks/useNavigationDeduped'
 import {useOpenLink} from '#/lib/hooks/useOpenLink'
-import {type AllNavigatorParams} from '#/lib/routes/types'
+import {type AllNavigatorParams, type RouteParams} from '#/lib/routes/types'
 import {shareUrl} from '#/lib/sharing'
 import {
   convertBskyAppUrlIfNeeded,
@@ -155,15 +155,44 @@ export function useLink({
           } else {
             closeModal() // close any active modals
 
+            const [screen, params] = router.matchPath(href) as [
+              screen: keyof AllNavigatorParams,
+              params?: RouteParams,
+            ]
+
+            // does not apply to web's flat navigator
+            if (isNative) {
+              const state = navigation.getState()
+              // if screen is not in the current navigator, it means it's
+              // most likely a tab screen
+              if (!state.routeNames.includes(screen)) {
+                const parent = navigation.getParent()
+                if (
+                  parent &&
+                  parent.getState().routeNames.includes(`${screen}Tab`)
+                ) {
+                  // yep, it's a tab screen. i.e. SearchTab
+                  // thus we need to navigate to the child screen
+                  // via the parent navigator
+                  // see https://reactnavigation.org/docs/upgrading-from-6.x/#changes-to-the-navigate-action
+                  // TODO: can we support the other kinds of actions? push/replace
+
+                  // @ts-expect-error include does not narrow the type unfortunately
+                  parent.navigate(`${screen}Tab`, {screen, params})
+                  return
+                } else {
+                  // will probably fail, but let's try anyway
+                }
+              }
+            }
+
             if (action === 'push') {
-              navigation.dispatch(StackActions.push(...router.matchPath(href)))
+              navigation.dispatch(StackActions.push(screen, params))
             } else if (action === 'replace') {
-              navigation.dispatch(
-                StackActions.replace(...router.matchPath(href)),
-              )
+              navigation.dispatch(StackActions.replace(screen, params))
             } else if (action === 'navigate') {
-              // @ts-ignore
-              navigation.navigate(...router.matchPath(href))
+              // @ts-expect-error not typed
+              navigation.navigate(screen, params)
             } else {
               throw Error('Unsupported navigator action.')
             }

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -161,7 +161,7 @@ export function useLink({
             ]
 
             // does not apply to web's flat navigator
-            if (isNative) {
+            if (isNative && screen !== 'NotFound') {
               const state = navigation.getState()
               // if screen is not in the current navigator, it means it's
               // most likely a tab screen

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -175,7 +175,7 @@ export function useLink({
                   // thus we need to navigate to the child screen
                   // via the parent navigator
                   // see https://reactnavigation.org/docs/upgrading-from-6.x/#changes-to-the-navigate-action
-                  // TODO: can we support the other kinds of actions? push/replace
+                  // TODO: can we support the other kinds of actions? push/replace -sfn
 
                   // @ts-expect-error include does not narrow the type unfortunately
                   parent.navigate(`${screen}Tab`, {screen, params})

--- a/src/lib/hooks/useNavigationDeduped.ts
+++ b/src/lib/hooks/useNavigationDeduped.ts
@@ -14,6 +14,7 @@ export type DebouncedNavigationProp = Pick<
   | 'dispatch'
   | 'goBack'
   | 'getState'
+  | 'getParent'
 >
 
 export function useNavigationDeduped() {
@@ -45,6 +46,9 @@ export function useNavigationDeduped() {
       },
       getState: () => {
         return navigation.getState()
+      },
+      getParent: (...args: Parameters<typeof navigation.getParent>) => {
+        return navigation.getParent(...args)
       },
     }),
     [dedupe, navigation],

--- a/src/lib/strings/url-helpers.ts
+++ b/src/lib/strings/url-helpers.ts
@@ -193,6 +193,11 @@ export function convertBskyAppUrlIfNeeded(url: string): string {
         return startUriToStarterPackUri(urlp.pathname)
       }
 
+      // special-case search links
+      if (urlp.pathname === '/search') {
+        return `/search?q=${urlp.searchParams.get('q')}`
+      }
+
       return urlp.pathname
     } catch (e) {
       console.error('Unexpected error in convertBskyAppUrlIfNeeded()', e)


### PR DESCRIPTION
Fix #1384, #4749

Part of it is stopping `convertBskyAppUrlIfNeeded` from stripping the search param. this is all that's needed for web

However, for native, the search screen is only available in the search tab. so we need to add some custom logic to the link component to support switching to a child route in a different tab, which is used if `screen` is not in `routeNames`.

I opted to only add this to the new link component since that's what we use within posts.

# Test plan

Test web + native. I can't think of any scenario where this code would run other than a link to another tab? so links to `/notifications` or `/chat` should also hit it, but that should be fine.
https://bsky.app/profile/samuel.bsky.team/post/3lruzfzrios2u