### PR TITLE
Add android intent handling for app launch

### DIFF
--- a/modules/expo-receive-android-intents/android/src/main/java/xyz/blueskyweb/app/exporeceiveandroidintents/ExpoReceiveAndroidIntentsModule.kt
+++ b/modules/expo-receive-android-intents/android/src/main/java/xyz/blueskyweb/app/exporeceiveandroidintents/ExpoReceiveAndroidIntentsModule.kt
@@ -23,8 +23,17 @@ class ExpoReceiveAndroidIntentsModule : Module() {
     ModuleDefinition {
       Name("ExpoReceiveAndroidIntents")
 
+      // Handle new intents received while the app is already running
+      // This is called when the app receives a share intent or other ACTION_SEND intent
+      // while it's already active in memory
       OnNewIntent {
         handleIntent(it)
+      }
+
+      // Handle the initial intent when the app is first created/launched
+      // This ensures we process share intents that were used to launch the app
+      OnCreate {
+        checkForInitialIntent()
       }
     }
 
@@ -50,6 +59,20 @@ class ExpoReceiveAndroidIntentsModule : Module() {
       } else if (it.action == Intent.ACTION_SEND_MULTIPLE) {
         handleAttachmentsIntent(it, type)
       }
+    }
+  }
+
+  // Check for and process any intent that was used to initially launch the app
+  private fun checkForInitialIntent() {
+    val activity = appContext.currentActivity ?: return
+    val intent = activity.intent
+
+    if (intent != null) {
+      // We delay processing by 1 second to ensure the app has fully initialized
+      // before attempting to handle the share intent
+      android.os.Handler(android.os.Looper.getMainLooper()).postDelayed({
+        handleIntent(intent)
+      }, 1000)
     }
   }
 


### PR DESCRIPTION
Fixes https://github.com/bluesky-social/social-app/issues/8513

### What's broken
Right now if you share something on android to Bluesky and the app isn't already open, the app launches but your shared content disappears into the void.

### How it works
- Added an OnCreate handler that grabs the launch intent and processes it.

The new checkForInitialIntent() method:
- Grabs whatever intent launched the app
- Waits 1 second for the app to boot
- Hands it off to the existing intent handling code

#### About that 1-second delay...
I tried to find an easy way around it, but wasn't successful. The app seemingly needs time to boot up before it can handle deep links properly.

I considered storing the intent and having the app call back when it was ready, but I wanted to keep it simple. There might be other ways to solve it that I'm missing, I'm not an expert android developer. The 1-second delay is hacky but it is way better than losing people's shared content entirely.

### Testing
I was testing using `yarn android:prod` because otherwise I believe expo dev client will get in the way.