### PR TITLE
Fix anchor text overflow in threads v2

### DIFF
--- a/src/components/ProfileHoverCard/index.web.tsx
+++ b/src/components/ProfileHoverCard/index.web.tsx
@@ -74,7 +74,7 @@ export function ProfileHoverCard(props: ProfileHoverCardProps) {
     return props.children
   } else {
     return (
-      <View onPointerMove={onPointerMove} style={[a.flex_shrink]}>
+      <View onPointerMove={onPointerMove} style={[a.flex_shrink, props.style]}>
         <ProfileHoverCardInner {...props} />
       </View>
     )

--- a/src/components/ProfileHoverCard/types.ts
+++ b/src/components/ProfileHoverCard/types.ts
@@ -1,7 +1,9 @@
 import type React from 'react'
 
-export type ProfileHoverCardProps = {
-  children: React.ReactElement
+import {type ViewStyleProp} from '#/alf'
+
+export type ProfileHoverCardProps = ViewStyleProp & {
+  children: React.ReactNode
   did: string
   disable?: boolean
 }

--- a/src/screens/PostThread/components/ThreadItemAnchor.tsx
+++ b/src/screens/PostThread/components/ThreadItemAnchor.tsx
@@ -311,69 +311,61 @@ const ThreadItemAnchorInner = memo(function ThreadItemAnchorInner({
           isRoot && [a.pt_lg],
         ]}>
         <View style={[a.flex_row, a.gap_md, a.pb_md]}>
-          <PreviewableUserAvatar
-            size={42}
-            profile={post.author}
-            moderation={moderation.ui('avatar')}
-            type={post.author.associated?.labeler ? 'labeler' : 'user'}
-            live={live}
-            onBeforePress={onOpenAuthor}
-          />
-          <View style={[a.flex_1, a.align_start]}>
-            <ProfileHoverCard did={post.author.did}>
-              <View style={[a.flex_1]}>
+          <View collapsable={false}>
+            <PreviewableUserAvatar
+              size={42}
+              profile={post.author}
+              moderation={moderation.ui('avatar')}
+              type={post.author.associated?.labeler ? 'labeler' : 'user'}
+              live={live}
+              onBeforePress={onOpenAuthor}
+            />
+          </View>
+          <Link
+            to={authorHref}
+            style={[a.flex_1]}
+            label={sanitizeDisplayName(
+              post.author.displayName || sanitizeHandle(post.author.handle),
+              moderation.ui('displayName'),
+            )}
+            onPress={onOpenAuthor}>
+            <View style={[a.flex_1, a.align_start]}>
+              <ProfileHoverCard did={post.author.did} style={[a.w_full]}>
                 <View style={[a.flex_row, a.align_center]}>
-                  <Link
-                    to={authorHref}
-                    style={[a.flex_shrink]}
-                    label={sanitizeDisplayName(
+                  <Text
+                    emoji
+                    style={[
+                      a.flex_shrink,
+                      a.text_lg,
+                      a.font_bold,
+                      a.leading_snug,
+                    ]}
+                    numberOfLines={1}>
+                    {sanitizeDisplayName(
                       post.author.displayName ||
                         sanitizeHandle(post.author.handle),
                       moderation.ui('displayName'),
                     )}
-                    onPress={onOpenAuthor}>
-                    <Text
-                      emoji
-                      style={[
-                        a.text_lg,
-                        a.font_bold,
-                        a.leading_snug,
-                        a.self_start,
-                      ]}
-                      numberOfLines={1}>
-                      {sanitizeDisplayName(
-                        post.author.displayName ||
-                          sanitizeHandle(post.author.handle),
-                        moderation.ui('displayName'),
-                      )}
-                    </Text>
-                  </Link>
+                  </Text>
 
                   <View style={[{paddingLeft: 3, top: -1}]}>
                     <VerificationCheckButton profile={authorShadow} size="md" />
                   </View>
                 </View>
-                <View style={[a.align_start]}>
-                  <Link
-                    style={[a.flex_shrink]}
-                    to={authorHref}
-                    label={sanitizeHandle(post.author.handle, '@')}>
-                    <Text
-                      style={[
-                        a.text_md,
-                        a.leading_snug,
-                        t.atoms.text_contrast_medium,
-                      ]}
-                      numberOfLines={1}>
-                      {sanitizeHandle(post.author.handle, '@')}
-                    </Text>
-                  </Link>
-                </View>
-              </View>
-            </ProfileHoverCard>
-          </View>
+                <Text
+                  style={[
+                    a.text_md,
+                    a.leading_snug,
+                    t.atoms.text_contrast_medium,
+                  ]}
+                  numberOfLines={1}>
+                  {sanitizeHandle(post.author.handle, '@')}
+                </Text>
+              </ProfileHoverCard>
+            </View>
+          </Link>
           {showFollowButton && (
-            <View>
+            <View collapsable={false}>
               <PostThreadFollowBtn did={post.author.did} />
             </View>
           )}


### PR DESCRIPTION
Main thing here is hoisting the `Link` up, which also means `onOpenAuthor` is called even when clicking the handle.

Debug shots for clarity:
![CleanShot 2025-06-18 at 13 45 39@2x](https://github.com/user-attachments/assets/507ebd1c-cd9f-4d50-877c-3cbb66801bfb)
![CleanShot 2025-06-18 at 12 57 37@2x](https://github.com/user-attachments/assets/ce23ea56-e71a-4dae-ab33-5eb265557417)
![CleanShot 2025-06-18 at 12 57 29@2x](https://github.com/user-attachments/assets/037b87e8-6fff-43e4-8e05-af322c6a8538)
