### PR TITLE
Upgrade prettier to 3.6

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -29,8 +29,8 @@ module.exports = function (_config) {
   const UPDATES_CHANNEL = IS_TESTFLIGHT
     ? 'testflight'
     : IS_PRODUCTION
-    ? 'production'
-    : undefined
+      ? 'production'
+      : undefined
   const UPDATES_ENABLED = !!UPDATES_CHANNEL
 
   const USE_SENTRY = Boolean(process.env.SENTRY_AUTH_TOKEN)

--- a/bskyembed/tailwind.config.cjs
+++ b/bskyembed/tailwind.config.cjs
@@ -1,9 +1,7 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
-  darkMode: ['variant', [
-    '&:is(.dark *):not(:is(.dark .light *))',
-  ]],
+  darkMode: ['variant', ['&:is(.dark *):not(:is(.dark .light *))']],
   theme: {
     extend: {
       colors: {

--- a/bskyembed/tsconfig.snippet.json
+++ b/bskyembed/tsconfig.snippet.json
@@ -1,4 +1,3 @@
-
 {
   "compilerOptions": {
     "target": "ES5",

--- a/bskylink/src/db/index.ts
+++ b/bskylink/src/db/index.ts
@@ -1,27 +1,30 @@
 import assert from 'assert'
 import {
   Kysely,
-  KyselyPlugin,
+  type KyselyPlugin,
   Migrator,
-  PluginTransformQueryArgs,
-  PluginTransformResultArgs,
+  type PluginTransformQueryArgs,
+  type PluginTransformResultArgs,
   PostgresDialect,
-  QueryResult,
-  RootOperationNode,
-  UnknownRow,
+  type QueryResult,
+  type RootOperationNode,
+  type UnknownRow,
 } from 'kysely'
 import {default as Pg} from 'pg'
 
 import {dbLogger as log} from '../logger.js'
 import {default as migrations} from './migrations/index.js'
 import {DbMigrationProvider} from './migrations/provider.js'
-import {DbSchema} from './schema.js'
+import {type DbSchema} from './schema.js'
 
 export class Database {
   migrator: Migrator
   destroyed = false
 
-  constructor(public db: Kysely<DbSchema>, public cfg: PgConfig) {
+  constructor(
+    public db: Kysely<DbSchema>,
+    public cfg: PgConfig,
+  ) {
     this.migrator = new Migrator({
       db,
       migrationTableSchema: cfg.schema,

--- a/bskylink/src/index.ts
+++ b/bskylink/src/index.ts
@@ -1,11 +1,11 @@
 import events from 'node:events'
-import http from 'node:http'
+import type http from 'node:http'
 
 import cors from 'cors'
 import express from 'express'
-import {createHttpTerminator, HttpTerminator} from 'http-terminator'
+import {createHttpTerminator, type HttpTerminator} from 'http-terminator'
 
-import {Config} from './config.js'
+import {type Config} from './config.js'
 import {AppContext} from './context.js'
 import {default as routes, errorHandler} from './routes/index.js'
 
@@ -17,7 +17,10 @@ export class LinkService {
   public server?: http.Server
   private terminator?: HttpTerminator
 
-  constructor(public app: express.Application, public ctx: AppContext) {}
+  constructor(
+    public app: express.Application,
+    public ctx: AppContext,
+  ) {}
 
   static async create(cfg: Config): Promise<LinkService> {
     let app = express()

--- a/bskyogcard/src/index.ts
+++ b/bskyogcard/src/index.ts
@@ -1,10 +1,10 @@
 import events from 'node:events'
-import http from 'node:http'
+import type http from 'node:http'
 
 import express from 'express'
-import {createHttpTerminator, HttpTerminator} from 'http-terminator'
+import {createHttpTerminator, type HttpTerminator} from 'http-terminator'
 
-import {Config} from './config.js'
+import {type Config} from './config.js'
 import {AppContext} from './context.js'
 import {default as routes, errorHandler} from './routes/index.js'
 
@@ -15,7 +15,10 @@ export class CardService {
   public server?: http.Server
   private terminator?: HttpTerminator
 
-  constructor(public app: express.Application, public ctx: AppContext) {}
+  constructor(
+    public app: express.Application,
+    public ctx: AppContext,
+  ) {}
 
   static async create(cfg: Config): Promise<CardService> {
     let app = express()

--- a/modules/expo-emoji-picker/src/EmojiPicker.android.tsx
+++ b/modules/expo-emoji-picker/src/EmojiPicker.android.tsx
@@ -12,7 +12,7 @@ const EmojiPicker = ({onEmojiSelected}: EmojiPickerViewProps) => {
         flex: 1,
         width: '100%',
         backgroundColor: scheme === 'dark' ? '#000' : '#fff',
-      } as const),
+      }) as const,
     [scheme],
   )
 

--- a/package.json
+++ b/package.json
@@ -266,7 +266,7 @@
     "lint-staged": "^13.2.3",
     "lockfile-lint": "^4.14.0",
     "metro-react-native-babel-preset": "^0.77.0",
-    "prettier": "^2.8.3",
+    "prettier": "^3.6.0",
     "react-native-dotenv": "^3.4.11",
     "react-refresh": "^0.14.0",
     "svgo": "^3.3.2",

--- a/scripts/post-web-build.js
+++ b/scripts/post-web-build.js
@@ -9,10 +9,9 @@ const templateFile = path.join(
   'scripts.html',
 )
 
-const {entrypoints} = require(path.join(
-  projectRoot,
-  'web-build/asset-manifest.json',
-))
+const {entrypoints} = require(
+  path.join(projectRoot, 'web-build/asset-manifest.json'),
+)
 
 console.log(`Found ${entrypoints.length} entrypoints`)
 console.log(`Writing ${templateFile}`)

--- a/src/components/ContextMenu/index.tsx
+++ b/src/components/ContextMenu/index.tsx
@@ -190,7 +190,7 @@ export function Root({children}: {children: React.ReactNode}) {
           if (item) playHaptic('Light')
           setHoveredMenuItem(item)
         },
-      } satisfies ContextType),
+      }) satisfies ContextType,
     [
       measurement,
       setMeasurement,
@@ -710,8 +710,8 @@ export function Item({
       const xOffset = position
         ? position.x
         : align === 'left'
-        ? measurement.x
-        : measurement.x + measurement.width - layout.width
+          ? measurement.x
+          : measurement.x + measurement.width - layout.width
 
       registerHoverable(
         id,

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -99,10 +99,10 @@ export function useLink({
     return typeof to === 'string'
       ? convertBskyAppUrlIfNeeded(sanitizeUrl(to))
       : to.screen
-      ? router.matchName(to.screen)?.build(to.params)
-      : to.href
-      ? convertBskyAppUrlIfNeeded(sanitizeUrl(to.href))
-      : undefined
+        ? router.matchName(to.screen)?.build(to.params)
+        : to.href
+          ? convertBskyAppUrlIfNeeded(sanitizeUrl(to.href))
+          : undefined
   }, [to])
 
   if (!href) {

--- a/src/components/Post/Embed/ImageEmbed.tsx
+++ b/src/components/Post/Embed/ImageEmbed.tsx
@@ -77,9 +77,9 @@ export function ImageEmbed({
               rest.viewContext === PostEmbedViewContext.ThreadHighlighted
                 ? 'none'
                 : rest.viewContext ===
-                  PostEmbedViewContext.FeedEmbedRecordWithMedia
-                ? 'square'
-                : 'constrained'
+                    PostEmbedViewContext.FeedEmbedRecordWithMedia
+                  ? 'square'
+                  : 'constrained'
             }
             image={image}
             onPress={(containerRef, dims) => onPress(0, [containerRef], [dims])}

--- a/src/components/Post/Embed/VideoEmbed/VideoEmbedInner/web-controls/VideoControls.tsx
+++ b/src/components/Post/Embed/VideoEmbed/VideoEmbedInner/web-controls/VideoControls.tsx
@@ -317,8 +317,8 @@ export function Controls({
           !focused
             ? msg`Unmute video`
             : playing
-            ? msg`Pause video`
-            : msg`Play video`,
+              ? msg`Pause video`
+              : msg`Play video`,
         )}
         accessibilityHint=""
         style={[

--- a/src/components/PostControls/PostMenu/PostMenuItems.tsx
+++ b/src/components/PostControls/PostMenu/PostMenuItems.tsx
@@ -600,8 +600,8 @@ let PostMenuItems = ({
                         isDetachPending
                           ? Loader
                           : quoteEmbed.isDetached
-                          ? Eye
-                          : EyeSlash
+                            ? Eye
+                            : EyeSlash
                       }
                       position="right"
                     />

--- a/src/components/Select/index.web.tsx
+++ b/src/components/Select/index.web.tsx
@@ -111,8 +111,8 @@ export function Trigger({children, label}: TriggerProps) {
             borderColor: focused
               ? t.palette.primary_500
               : hovered
-              ? t.palette.contrast_100
-              : t.palette.contrast_25,
+                ? t.palette.contrast_100
+                : t.palette.contrast_25,
           },
         ])}>
         {children}

--- a/src/components/WhoCanReply.tsx
+++ b/src/components/WhoCanReply.tsx
@@ -1,9 +1,15 @@
 import React from 'react'
-import {Keyboard, Platform, StyleProp, View, ViewStyle} from 'react-native'
 import {
-  AppBskyFeedDefs,
+  Keyboard,
+  Platform,
+  type StyleProp,
+  View,
+  type ViewStyle,
+} from 'react-native'
+import {
+  type AppBskyFeedDefs,
   AppBskyFeedPost,
-  AppBskyGraphDefs,
+  type AppBskyGraphDefs,
   AtUri,
 } from '@atproto/api'
 import {msg, Trans} from '@lingui/macro'
@@ -13,7 +19,7 @@ import {HITSLOP_10} from '#/lib/constants'
 import {makeListLink, makeProfileLink} from '#/lib/routes/links'
 import {isNative} from '#/platform/detection'
 import {
-  ThreadgateAllowUISetting,
+  type ThreadgateAllowUISetting,
   threadgateViewToAllowUISetting,
 } from '#/state/queries/threadgate'
 import {atoms as a, useTheme} from '#/alf'
@@ -70,8 +76,8 @@ export function WhoCanReply({post, isThreadAuthor, style}: WhoCanReplyProps) {
   const description = anyoneCanReply
     ? _(msg`Everybody can reply`)
     : noOneCanReply
-    ? _(msg`Replies disabled`)
-    : _(msg`Some people can reply`)
+      ? _(msg`Replies disabled`)
+      : _(msg`Some people can reply`)
 
   const onPressOpen = () => {
     if (isNative && Keyboard.isVisible()) {

--- a/src/components/dialogs/EmailDialog/screens/Manage2FA/Disable.tsx
+++ b/src/components/dialogs/EmailDialog/screens/Manage2FA/Disable.tsx
@@ -185,8 +185,8 @@ export function Disable() {
                   state.emailStatus === 'pending'
                     ? Loader
                     : state.emailStatus === 'success'
-                    ? Check
-                    : Envelope
+                      ? Check
+                      : Envelope
                 }
               />
             </Button>

--- a/src/components/dialogs/EmailDialog/screens/Manage2FA/Enable.tsx
+++ b/src/components/dialogs/EmailDialog/screens/Manage2FA/Enable.tsx
@@ -116,8 +116,8 @@ export function Enable() {
               state.status === 'pending'
                 ? Loader
                 : state.status === 'success'
-                ? Check
-                : ShieldIcon
+                  ? Check
+                  : ShieldIcon
             }
           />
         </Button>

--- a/src/components/dialogs/SearchablePeopleList.tsx
+++ b/src/components/dialogs/SearchablePeopleList.tsx
@@ -390,8 +390,8 @@ function DefaultProfileCard({
             !enabled
               ? {opacity: 0.5}
               : pressed || focused || hovered
-              ? t.atoms.bg_contrast_25
-              : t.atoms.bg,
+                ? t.atoms.bg_contrast_25
+                : t.atoms.bg,
           ]}>
           <ProfileCard.Header>
             <ProfileCard.Avatar

--- a/src/components/dms/EmojiReactionPicker.tsx
+++ b/src/components/dms/EmojiReactionPicker.tsx
@@ -98,8 +98,8 @@ export function EmojiReactionPicker({
                           : t.palette.primary_500,
                       }
                     : alreadyReacted
-                    ? {backgroundColor: t.palette.primary_200}
-                    : bgColor,
+                      ? {backgroundColor: t.palette.primary_200}
+                      : bgColor,
                   {height: 40, width: 40},
                   a.justify_center,
                   a.align_center,

--- a/src/components/dms/MessageContextMenu.tsx
+++ b/src/components/dms/MessageContextMenu.tsx
@@ -128,8 +128,7 @@ export let MessageContextMenu = ({
           label={_(msg`Message options`)}
           contentLabel={_(
             msg`Message from @${
-              sender?.handle ?? // should always be defined
-              'unknown'
+              sender?.handle ?? 'unknown' // should always be defined
             }: ${message.text}`,
           )}>
           {children}

--- a/src/components/icons/VerifiedCheck.tsx
+++ b/src/components/icons/VerifiedCheck.tsx
@@ -3,28 +3,27 @@ import Svg, {Circle, Path} from 'react-native-svg'
 
 import {type Props, useCommonSVGProps} from '#/components/icons/common'
 
-export const VerifiedCheck = React.forwardRef<Svg, Props>(function LogoImpl(
-  props,
-  ref,
-) {
-  const {fill, size, style, ...rest} = useCommonSVGProps(props)
+export const VerifiedCheck = React.forwardRef<Svg, Props>(
+  function LogoImpl(props, ref) {
+    const {fill, size, style, ...rest} = useCommonSVGProps(props)
 
-  return (
-    <Svg
-      fill="none"
-      {...rest}
-      ref={ref}
-      viewBox="0 0 24 24"
-      width={size}
-      height={size}
-      style={[style]}>
-      <Circle cx="12" cy="12" r="11.5" fill={fill} />
-      <Path
-        fill="#fff"
-        fillRule="evenodd"
-        clipRule="evenodd"
-        d="M17.659 8.175a1.361 1.361 0 0 1 0 1.925l-6.224 6.223a1.361 1.361 0 0 1-1.925 0L6.4 13.212a1.361 1.361 0 0 1 1.925-1.925l2.149 2.148 5.26-5.26a1.361 1.361 0 0 1 1.925 0Z"
-      />
-    </Svg>
-  )
-})
+    return (
+      <Svg
+        fill="none"
+        {...rest}
+        ref={ref}
+        viewBox="0 0 24 24"
+        width={size}
+        height={size}
+        style={[style]}>
+        <Circle cx="12" cy="12" r="11.5" fill={fill} />
+        <Path
+          fill="#fff"
+          fillRule="evenodd"
+          clipRule="evenodd"
+          d="M17.659 8.175a1.361 1.361 0 0 1 0 1.925l-6.224 6.223a1.361 1.361 0 0 1-1.925 0L6.4 13.212a1.361 1.361 0 0 1 1.925-1.925l2.149 2.148 5.26-5.26a1.361 1.361 0 0 1 1.925 0Z"
+        />
+      </Svg>
+    )
+  },
+)

--- a/src/components/icons/VerifierCheck.tsx
+++ b/src/components/icons/VerifierCheck.tsx
@@ -3,33 +3,32 @@ import Svg, {Path} from 'react-native-svg'
 
 import {type Props, useCommonSVGProps} from '#/components/icons/common'
 
-export const VerifierCheck = React.forwardRef<Svg, Props>(function LogoImpl(
-  props,
-  ref,
-) {
-  const {fill, size, style, ...rest} = useCommonSVGProps(props)
+export const VerifierCheck = React.forwardRef<Svg, Props>(
+  function LogoImpl(props, ref) {
+    const {fill, size, style, ...rest} = useCommonSVGProps(props)
 
-  return (
-    <Svg
-      fill="none"
-      {...rest}
-      ref={ref}
-      viewBox="0 0 24 24"
-      width={size}
-      height={size}
-      style={[style]}>
-      <Path
-        fill={fill}
-        fillRule="evenodd"
-        clipRule="evenodd"
-        d="M8.792 1.615a4.154 4.154 0 0 1 6.416 0 4.154 4.154 0 0 0 3.146 1.515 4.154 4.154 0 0 1 4 5.017 4.154 4.154 0 0 0 .777 3.404 4.154 4.154 0 0 1-1.427 6.255 4.153 4.153 0 0 0-2.177 2.73 4.154 4.154 0 0 1-5.781 2.784 4.154 4.154 0 0 0-3.492 0 4.154 4.154 0 0 1-5.78-2.784 4.154 4.154 0 0 0-2.178-2.73A4.154 4.154 0 0 1 .87 11.551a4.154 4.154 0 0 0 .776-3.404A4.154 4.154 0 0 1 5.646 3.13a4.154 4.154 0 0 0 3.146-1.515Z"
-      />
-      <Path
-        fill="#fff"
-        fillRule="evenodd"
-        clipRule="evenodd"
-        d="M17.861 8.26a1.438 1.438 0 0 1 0 2.033l-6.571 6.571a1.437 1.437 0 0 1-2.033 0L5.97 13.58a1.438 1.438 0 0 1 2.033-2.033l2.27 2.269 5.554-5.555a1.437 1.437 0 0 1 2.033 0Z"
-      />
-    </Svg>
-  )
-})
+    return (
+      <Svg
+        fill="none"
+        {...rest}
+        ref={ref}
+        viewBox="0 0 24 24"
+        width={size}
+        height={size}
+        style={[style]}>
+        <Path
+          fill={fill}
+          fillRule="evenodd"
+          clipRule="evenodd"
+          d="M8.792 1.615a4.154 4.154 0 0 1 6.416 0 4.154 4.154 0 0 0 3.146 1.515 4.154 4.154 0 0 1 4 5.017 4.154 4.154 0 0 0 .777 3.404 4.154 4.154 0 0 1-1.427 6.255 4.153 4.153 0 0 0-2.177 2.73 4.154 4.154 0 0 1-5.781 2.784 4.154 4.154 0 0 0-3.492 0 4.154 4.154 0 0 1-5.78-2.784 4.154 4.154 0 0 0-2.178-2.73A4.154 4.154 0 0 1 .87 11.551a4.154 4.154 0 0 0 .776-3.404A4.154 4.154 0 0 1 5.646 3.13a4.154 4.154 0 0 0 3.146-1.515Z"
+        />
+        <Path
+          fill="#fff"
+          fillRule="evenodd"
+          clipRule="evenodd"
+          d="M17.861 8.26a1.438 1.438 0 0 1 0 2.033l-6.571 6.571a1.437 1.437 0 0 1-2.033 0L5.97 13.58a1.438 1.438 0 0 1 2.033-2.033l2.27 2.269 5.554-5.555a1.437 1.437 0 0 1 2.033 0Z"
+        />
+      </Svg>
+    )
+  },
+)

--- a/src/components/moderation/ContentHider.tsx
+++ b/src/components/moderation/ContentHider.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
-import {StyleProp, View, ViewStyle} from 'react-native'
-import {ModerationUI} from '@atproto/api'
+import {type StyleProp, View, type ViewStyle} from 'react-native'
+import {type ModerationUI} from '@atproto/api'
 import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
@@ -148,8 +148,8 @@ function ContentHiderActive({
           modui.noOverride
             ? _(msg`Learn more about the moderation applied to this content`)
             : override
-            ? _(msg`Hides the content`)
-            : _(msg`Shows the content`)
+              ? _(msg`Hides the content`)
+              : _(msg`Shows the content`)
         }>
         {state => (
           <View

--- a/src/components/moderation/ReportDialog/index.tsx
+++ b/src/components/moderation/ReportDialog/index.tsx
@@ -512,13 +512,13 @@ function StepTitle({
             backgroundColor: active
               ? t.palette.primary_500
               : completed
-              ? t.palette.primary_100
-              : t.atoms.bg_contrast_25.backgroundColor,
+                ? t.palette.primary_100
+                : t.atoms.bg_contrast_25.backgroundColor,
             borderColor: active
               ? t.palette.primary_500
               : completed
-              ? t.palette.primary_400
-              : t.atoms.border_contrast_low.borderColor,
+                ? t.palette.primary_400
+                : t.atoms.border_contrast_low.borderColor,
           },
         ]}>
         {completed ? (
@@ -533,8 +533,8 @@ function StepTitle({
                 color: active
                   ? 'white'
                   : completed
-                  ? t.palette.primary_700
-                  : t.atoms.text_contrast_medium.color,
+                    ? t.palette.primary_700
+                    : t.atoms.text_contrast_medium.color,
                 fontVariant: ['tabular-nums'],
                 width: 24,
                 height: 24,

--- a/src/components/verification/VerificationCheckButton.tsx
+++ b/src/components/verification/VerificationCheckButton.tsx
@@ -130,8 +130,8 @@ export function Badge({
                 verifiedByHidden
                   ? t.atoms.bg_contrast_100.backgroundColor
                   : state.profile.isVerified
-                  ? t.palette.primary_500
-                  : t.atoms.bg_contrast_100.backgroundColor
+                    ? t.palette.primary_500
+                    : t.atoms.bg_contrast_100.backgroundColor
               }
               verifier={state.profile.role === 'verifier'}
             />

--- a/src/components/verification/VerificationsDialog.tsx
+++ b/src/components/verification/VerificationsDialog.tsx
@@ -64,13 +64,13 @@ function Inner({
       ? _(msg`You are verified`)
       : _(msg`Your verifications`)
     : state.profile.isVerified
-    ? _(msg`${userName} is verified`)
-    : _(
-        msg({
-          message: `${userName}'s verifications`,
-          comment: `Possessive, meaning "the verifications of {userName}"`,
-        }),
-      )
+      ? _(msg`${userName} is verified`)
+      : _(
+          msg({
+            message: `${userName}'s verifications`,
+            comment: `Possessive, meaning "the verifications of {userName}"`,
+          }),
+        )
 
   return (
     <Dialog.ScrollableInner

--- a/src/lib/moderation.ts
+++ b/src/lib/moderation.ts
@@ -1,18 +1,18 @@
 import React from 'react'
 import {
-  AppBskyLabelerDefs,
+  type AppBskyLabelerDefs,
   BskyAgent,
-  ComAtprotoLabelDefs,
-  InterpretedLabelValueDefinition,
+  type ComAtprotoLabelDefs,
+  type InterpretedLabelValueDefinition,
   LABELS,
-  ModerationCause,
-  ModerationOpts,
-  ModerationUI,
+  type ModerationCause,
+  type ModerationOpts,
+  type ModerationUI,
 } from '@atproto/api'
 
 import {sanitizeDisplayName} from '#/lib/strings/display-names'
 import {sanitizeHandle} from '#/lib/strings/handles'
-import {AppModerationCause} from '#/components/Pills'
+import {type AppModerationCause} from '#/components/Pills'
 
 export const ADULT_CONTENT_LABELS = ['sexual', 'nudity', 'porn']
 export const OTHER_SELF_LABELS = ['graphic-media']
@@ -29,8 +29,8 @@ export function getModerationCauseKey(
     cause.source.type === 'labeler'
       ? cause.source.did
       : cause.source.type === 'list'
-      ? cause.source.list.uri
-      : 'user'
+        ? cause.source.list.uri
+        : 'user'
   if (cause.type === 'label') {
     return `label:${cause.label.val}:${source}`
   }

--- a/src/lib/moderation/useModerationCauseDescription.ts
+++ b/src/lib/moderation/useModerationCauseDescription.ts
@@ -1,8 +1,8 @@
 import React from 'react'
 import {
   BSKY_LABELER_DID,
-  ModerationCause,
-  ModerationCauseSource,
+  type ModerationCause,
+  type ModerationCauseSource,
 } from '@atproto/api'
 import {msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
@@ -12,10 +12,10 @@ import {useLabelDefinitions} from '#/state/preferences'
 import {useSession} from '#/state/session'
 import {CircleBanSign_Stroke2_Corner0_Rounded as CircleBanSign} from '#/components/icons/CircleBanSign'
 import {CircleInfo_Stroke2_Corner0_Rounded as CircleInfo} from '#/components/icons/CircleInfo'
-import {Props as SVGIconProps} from '#/components/icons/common'
+import {type Props as SVGIconProps} from '#/components/icons/common'
 import {EyeSlash_Stroke2_Corner0_Rounded as EyeSlash} from '#/components/icons/EyeSlash'
 import {Warning_Stroke2_Corner0_Rounded as Warning} from '#/components/icons/Warning'
-import {AppModerationCause} from '#/components/Pills'
+import {type AppModerationCause} from '#/components/Pills'
 import {useGlobalLabelStrings} from './useGlobalLabelStrings'
 import {getDefinition, getLabelStrings} from './useLabelInfo'
 
@@ -153,8 +153,8 @@ export function useModerationCauseDescription(
           def.identifier === '!no-unauthenticated'
             ? EyeSlash
             : def.severity === 'alert'
-            ? Warning
-            : CircleInfo,
+              ? Warning
+              : CircleInfo,
         name: strings.name,
         description: strings.description,
         source,

--- a/src/lib/statsig/statsig.tsx
+++ b/src/lib/statsig/statsig.tsx
@@ -1,17 +1,17 @@
 import React from 'react'
 import {Platform} from 'react-native'
-import {AppState, AppStateStatus} from 'react-native'
+import {AppState, type AppStateStatus} from 'react-native'
 import {Statsig, StatsigProvider} from 'statsig-react-native-expo'
 
 import {BUNDLE_DATE, BUNDLE_IDENTIFIER, IS_TESTFLIGHT} from '#/lib/app-info'
 import {logger} from '#/logger'
-import {MetricEvents} from '#/logger/metrics'
+import {type MetricEvents} from '#/logger/metrics'
 import {isWeb} from '#/platform/detection'
 import * as persisted from '#/state/persisted'
 import {useSession} from '../../state/session'
 import {timeout} from '../async/timeout'
 import {useNonReactiveCallback} from '../hooks/useNonReactiveCallback'
-import {Gate} from './gates'
+import {type Gate} from './gates'
 
 const SDK_KEY = 'client-SXJakO39w9vIhl3D44u8UupyzFl4oZ2qPIkjwcvuPsV'
 
@@ -51,8 +51,8 @@ function createStatsigOptions(prefetchUsers: StatsigUser[]) {
         process.env.NODE_ENV === 'development'
           ? 'development'
           : IS_TESTFLIGHT
-          ? 'staging'
-          : 'production',
+            ? 'staging'
+            : 'production',
     },
     // Don't block on waiting for network. The fetched config will kick in on next load.
     // This ensures the UI is always consistent and doesn't update mid-session.

--- a/src/lib/strings/embed-player.ts
+++ b/src/lib/strings/embed-player.ts
@@ -11,8 +11,8 @@ const IFRAME_HOST = isWeb
     ? 'http://localhost:8100'
     : 'https://bsky.app'
   : __DEV__ && !process.env.JEST_WORKER_ID
-  ? 'http://localhost:8100'
-  : 'https://bsky.app'
+    ? 'http://localhost:8100'
+    : 'https://bsky.app'
 
 export const embedPlayerSources = [
   'youtube',

--- a/src/platform/polyfills.ts
+++ b/src/platform/polyfills.ts
@@ -41,12 +41,12 @@ globalThis.atob = (str: string): string => {
       r1 === 64
         ? String.fromCharCode((bitmap >> 16) & 255)
         : r2 === 64
-        ? String.fromCharCode((bitmap >> 16) & 255, (bitmap >> 8) & 255)
-        : String.fromCharCode(
-            (bitmap >> 16) & 255,
-            (bitmap >> 8) & 255,
-            bitmap & 255,
-          )
+          ? String.fromCharCode((bitmap >> 16) & 255, (bitmap >> 8) & 255)
+          : String.fromCharCode(
+              (bitmap >> 16) & 255,
+              (bitmap >> 8) & 255,
+              bitmap & 255,
+            )
   }
   return result
 }

--- a/src/screens/Login/index.tsx
+++ b/src/screens/Login/index.tsx
@@ -49,8 +49,8 @@ export const Login = ({onPressBack}: {onPressBack: () => void}) => {
     requestedAccount
       ? Forms.Login
       : accounts.length
-      ? Forms.ChooseAccount
-      : Forms.Login,
+        ? Forms.ChooseAccount
+        : Forms.Login,
   )
 
   const {

--- a/src/screens/Messages/ChatList.tsx
+++ b/src/screens/Messages/ChatList.tsx
@@ -155,7 +155,7 @@ export function MessagesScreen({navigation, route}: Props) {
           profiles: inboxPreviewConvos.slice(0, 3),
         },
         ...conversations.map(
-          convo => ({type: 'CONVERSATION', conversation: convo} as const),
+          convo => ({type: 'CONVERSATION', conversation: convo}) as const,
         ),
       ] satisfies ListItem[]
     }

--- a/src/screens/Onboarding/StepFinished.tsx
+++ b/src/screens/Onboarding/StepFinished.tsx
@@ -176,8 +176,8 @@ export function StepFinished() {
             avatarResult: profileStepResults.isCreatedAvatar
               ? 'created'
               : profileStepResults.image
-              ? 'uploaded'
-              : 'default',
+                ? 'uploaded'
+                : 'default',
           })
         })(),
         requestNotificationsPermission('AfterOnboarding'),

--- a/src/screens/Profile/Header/ProfileHeaderLabeler.tsx
+++ b/src/screens/Profile/Header/ProfileHeaderLabeler.tsx
@@ -214,8 +214,8 @@ let ProfileHeaderLabeler = ({
                             ? t.palette.contrast_50
                             : t.palette.contrast_25
                           : state.hovered || state.pressed
-                          ? tokens.color.temp_purple_dark
-                          : tokens.color.temp_purple,
+                            ? tokens.color.temp_purple_dark
+                            : tokens.color.temp_purple,
                       },
                     ]}>
                     <Text

--- a/src/screens/Search/Explore.tsx
+++ b/src/screens/Search/Explore.tsx
@@ -342,11 +342,11 @@ export function Explore({
   ])
 
   const topBorder = useMemo(
-    () => ({type: 'topBorder', key: 'top-border'} as const),
+    () => ({type: 'topBorder', key: 'top-border'}) as const,
     [],
   )
   const trendingTopicsModule = useMemo(
-    () => ({type: 'trendingTopics', key: 'trending-topics'} as const),
+    () => ({type: 'trendingTopics', key: 'trending-topics'}) as const,
     [],
   )
   const suggestedFollowsModule = useMemo(() => {

--- a/src/screens/Settings/AppIconSettings/useAppIconSets.ts
+++ b/src/screens/Settings/AppIconSettings/useAppIconSets.ts
@@ -2,7 +2,7 @@ import {useMemo} from 'react'
 import {msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
-import {AppIconSet} from '#/screens/Settings/AppIconSettings/types'
+import {type AppIconSet} from '#/screens/Settings/AppIconSettings/types'
 
 export function useAppIconSets() {
   const {_} = useLingui()
@@ -13,20 +13,28 @@ export function useAppIconSets() {
         id: 'default_light',
         name: _(msg({context: 'Name of app icon variant', message: 'Light'})),
         iosImage: () => {
-          return require(`../../../../assets/app-icons/ios_icon_default_light.png`)
+          return require(
+            `../../../../assets/app-icons/ios_icon_default_light.png`,
+          )
         },
         androidImage: () => {
-          return require(`../../../../assets/app-icons/android_icon_default_light.png`)
+          return require(
+            `../../../../assets/app-icons/android_icon_default_light.png`,
+          )
         },
       },
       {
         id: 'default_dark',
         name: _(msg({context: 'Name of app icon variant', message: 'Dark'})),
         iosImage: () => {
-          return require(`../../../../assets/app-icons/ios_icon_default_dark.png`)
+          return require(
+            `../../../../assets/app-icons/ios_icon_default_dark.png`,
+          )
         },
         androidImage: () => {
-          return require(`../../../../assets/app-icons/android_icon_default_dark.png`)
+          return require(
+            `../../../../assets/app-icons/android_icon_default_dark.png`,
+          )
         },
       },
     ] satisfies AppIconSet[]
@@ -39,10 +47,14 @@ export function useAppIconSets() {
         id: 'core_aurora',
         name: _(msg({context: 'Name of app icon variant', message: 'Aurora'})),
         iosImage: () => {
-          return require(`../../../../assets/app-icons/ios_icon_core_aurora.png`)
+          return require(
+            `../../../../assets/app-icons/ios_icon_core_aurora.png`,
+          )
         },
         androidImage: () => {
-          return require(`../../../../assets/app-icons/android_icon_core_aurora.png`)
+          return require(
+            `../../../../assets/app-icons/android_icon_core_aurora.png`,
+          )
         },
       },
       // {
@@ -59,20 +71,28 @@ export function useAppIconSets() {
         id: 'core_sunrise',
         name: _(msg({context: 'Name of app icon variant', message: 'Sunrise'})),
         iosImage: () => {
-          return require(`../../../../assets/app-icons/ios_icon_core_sunrise.png`)
+          return require(
+            `../../../../assets/app-icons/ios_icon_core_sunrise.png`,
+          )
         },
         androidImage: () => {
-          return require(`../../../../assets/app-icons/android_icon_core_sunrise.png`)
+          return require(
+            `../../../../assets/app-icons/android_icon_core_sunrise.png`,
+          )
         },
       },
       {
         id: 'core_sunset',
         name: _(msg({context: 'Name of app icon variant', message: 'Sunset'})),
         iosImage: () => {
-          return require(`../../../../assets/app-icons/ios_icon_core_sunset.png`)
+          return require(
+            `../../../../assets/app-icons/ios_icon_core_sunset.png`,
+          )
         },
         androidImage: () => {
-          return require(`../../../../assets/app-icons/android_icon_core_sunset.png`)
+          return require(
+            `../../../../assets/app-icons/android_icon_core_sunset.png`,
+          )
         },
       },
       {
@@ -81,10 +101,14 @@ export function useAppIconSets() {
           msg({context: 'Name of app icon variant', message: 'Midnight'}),
         ),
         iosImage: () => {
-          return require(`../../../../assets/app-icons/ios_icon_core_midnight.png`)
+          return require(
+            `../../../../assets/app-icons/ios_icon_core_midnight.png`,
+          )
         },
         androidImage: () => {
-          return require(`../../../../assets/app-icons/android_icon_core_midnight.png`)
+          return require(
+            `../../../../assets/app-icons/android_icon_core_midnight.png`,
+          )
         },
       },
       {
@@ -93,10 +117,14 @@ export function useAppIconSets() {
           msg({context: 'Name of app icon variant', message: 'Flat Blue'}),
         ),
         iosImage: () => {
-          return require(`../../../../assets/app-icons/ios_icon_core_flat_blue.png`)
+          return require(
+            `../../../../assets/app-icons/ios_icon_core_flat_blue.png`,
+          )
         },
         androidImage: () => {
-          return require(`../../../../assets/app-icons/android_icon_core_flat_blue.png`)
+          return require(
+            `../../../../assets/app-icons/android_icon_core_flat_blue.png`,
+          )
         },
       },
       {
@@ -105,10 +133,14 @@ export function useAppIconSets() {
           msg({context: 'Name of app icon variant', message: 'Flat White'}),
         ),
         iosImage: () => {
-          return require(`../../../../assets/app-icons/ios_icon_core_flat_white.png`)
+          return require(
+            `../../../../assets/app-icons/ios_icon_core_flat_white.png`,
+          )
         },
         androidImage: () => {
-          return require(`../../../../assets/app-icons/android_icon_core_flat_white.png`)
+          return require(
+            `../../../../assets/app-icons/android_icon_core_flat_white.png`,
+          )
         },
       },
       {
@@ -117,10 +149,14 @@ export function useAppIconSets() {
           msg({context: 'Name of app icon variant', message: 'Flat Black'}),
         ),
         iosImage: () => {
-          return require(`../../../../assets/app-icons/ios_icon_core_flat_black.png`)
+          return require(
+            `../../../../assets/app-icons/ios_icon_core_flat_black.png`,
+          )
         },
         androidImage: () => {
-          return require(`../../../../assets/app-icons/android_icon_core_flat_black.png`)
+          return require(
+            `../../../../assets/app-icons/android_icon_core_flat_black.png`,
+          )
         },
       },
       {
@@ -132,10 +168,14 @@ export function useAppIconSets() {
           }),
         ),
         iosImage: () => {
-          return require(`../../../../assets/app-icons/ios_icon_core_classic.png`)
+          return require(
+            `../../../../assets/app-icons/ios_icon_core_classic.png`,
+          )
         },
         androidImage: () => {
-          return require(`../../../../assets/app-icons/android_icon_core_classic.png`)
+          return require(
+            `../../../../assets/app-icons/android_icon_core_classic.png`,
+          )
         },
       },
     ] satisfies AppIconSet[]

--- a/src/screens/Settings/components/ChangeHandleDialog.tsx
+++ b/src/screens/Settings/components/ChangeHandleDialog.tsx
@@ -525,8 +525,8 @@ function OwnHandlePage({goToServiceHandle}: {goToServiceHandle: () => void}) {
             isVerified
               ? _(msg`Update to ${domain}`)
               : dnsPanel
-              ? _(msg`Verify DNS Record`)
-              : _(msg`Verify Text File`)
+                ? _(msg`Verify DNS Record`)
+                : _(msg`Verify Text File`)
           }
           variant="solid"
           size="large"

--- a/src/state/cache/profile-shadow.ts
+++ b/src/state/cache/profile-shadow.ts
@@ -144,8 +144,8 @@ function mergeShadow<TProfileView extends bsky.profile.AnyProfileView>(
       'status' in shadow
         ? shadow.status
         : 'status' in profile
-        ? profile.status
-        : undefined,
+          ? profile.status
+          : undefined,
   })
 }
 

--- a/src/state/queries/explore-feed-previews.tsx
+++ b/src/state/queries/explore-feed-previews.tsx
@@ -36,38 +36,27 @@ const RQKEY = (feeds: string[]) => [RQKEY_ROOT, feeds]
 const LIMIT = 8 // sliced to 6, overfetch to account for moderation
 const PINNED_POST_URIS: Record<string, boolean> = {
   // 📰 News
-  'at://did:plc:kkf4naxqmweop7dv4l2iqqf5/app.bsky.feed.post/3lgh27w2ngc2b':
-    true,
+  'at://did:plc:kkf4naxqmweop7dv4l2iqqf5/app.bsky.feed.post/3lgh27w2ngc2b': true,
   // Gardening
-  'at://did:plc:5rw2on4i56btlcajojaxwcat/app.bsky.feed.post/3kjorckgcwc27':
-    true,
+  'at://did:plc:5rw2on4i56btlcajojaxwcat/app.bsky.feed.post/3kjorckgcwc27': true,
   // Web Development Trending
-  'at://did:plc:m2sjv3wncvsasdapla35hzwj/app.bsky.feed.post/3lfaw445axs22':
-    true,
+  'at://did:plc:m2sjv3wncvsasdapla35hzwj/app.bsky.feed.post/3lfaw445axs22': true,
   // Anime & Manga EN
-  'at://did:plc:tazrmeme4dzahimsykusrwrk/app.bsky.feed.post/3knxx2gmkns2y':
-    true,
+  'at://did:plc:tazrmeme4dzahimsykusrwrk/app.bsky.feed.post/3knxx2gmkns2y': true,
   // 📽️ Film
-  'at://did:plc:2hwwem55ce6djnk6bn62cstr/app.bsky.feed.post/3llhpzhbq7c2g':
-    true,
+  'at://did:plc:2hwwem55ce6djnk6bn62cstr/app.bsky.feed.post/3llhpzhbq7c2g': true,
   // PopSky
-  'at://did:plc:lfdf4srj43iwdng7jn35tjsp/app.bsky.feed.post/3lbblgly65c2g':
-    true,
+  'at://did:plc:lfdf4srj43iwdng7jn35tjsp/app.bsky.feed.post/3lbblgly65c2g': true,
   // Science
-  'at://did:plc:hu2obebw3nhfj667522dahfg/app.bsky.feed.post/3kl33otd6ob2s':
-    true,
+  'at://did:plc:hu2obebw3nhfj667522dahfg/app.bsky.feed.post/3kl33otd6ob2s': true,
   // Birds! 🦉
-  'at://did:plc:ffkgesg3jsv2j7aagkzrtcvt/app.bsky.feed.post/3lbg4r57yk22d':
-    true,
+  'at://did:plc:ffkgesg3jsv2j7aagkzrtcvt/app.bsky.feed.post/3lbg4r57yk22d': true,
   // Astronomy
-  'at://did:plc:xy2zorw2ys47poflotxthlzg/app.bsky.feed.post/3kyzye4lujs2w':
-    true,
+  'at://did:plc:xy2zorw2ys47poflotxthlzg/app.bsky.feed.post/3kyzye4lujs2w': true,
   // What's Cooking 🍽️
-  'at://did:plc:geoqe3qls5mwezckxxsewys2/app.bsky.feed.post/3lfqhgvxbqc2q':
-    true,
+  'at://did:plc:geoqe3qls5mwezckxxsewys2/app.bsky.feed.post/3lfqhgvxbqc2q': true,
   // BookSky 💙📚 #booksky
-  'at://did:plc:geoqe3qls5mwezckxxsewys2/app.bsky.feed.post/3kgrm2rw5ww2e':
-    true,
+  'at://did:plc:geoqe3qls5mwezckxxsewys2/app.bsky.feed.post/3kgrm2rw5ww2e': true,
 }
 
 export type FeedPreviewItem =

--- a/src/state/queries/notifications/settings.ts
+++ b/src/state/queries/notifications/settings.ts
@@ -36,9 +36,8 @@ export function useNotificationSettingsUpdateMutation() {
     mutationFn: async (
       update: Partial<AppBskyNotificationDefs.Preferences>,
     ) => {
-      const response = await agent.app.bsky.notification.putPreferencesV2(
-        update,
-      )
+      const response =
+        await agent.app.bsky.notification.putPreferencesV2(update)
       return response.data.preferences
     },
     onMutate: update => {

--- a/src/state/queries/notifications/unread.tsx
+++ b/src/state/queries/notifications/unread.tsx
@@ -14,7 +14,7 @@ import {useAgent, useSession} from '#/state/session'
 import {useModerationOpts} from '../../preferences/moderation-opts'
 import {truncateAndInvalidate} from '../util'
 import {RQKEY as RQKEY_NOTIFS} from './feed'
-import {CachedFeedPage, FeedPage} from './types'
+import {type CachedFeedPage, type FeedPage} from './types'
 import {fetchPage} from './util'
 
 const UPDATE_INTERVAL = 30 * 1e3 // 30sec
@@ -94,8 +94,8 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
           data.event === '30+'
             ? 30
             : data.event === ''
-            ? 0
-            : parseInt(data.event, 10) || 1,
+              ? 0
+              : parseInt(data.event, 10) || 1,
       }
       setNumUnread(data.event)
     }
@@ -164,8 +164,8 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
             unreadCount >= 30
               ? '30+'
               : unreadCount === 0
-              ? ''
-              : String(unreadCount)
+                ? ''
+                : String(unreadCount)
 
           // track last sync
           const now = new Date()

--- a/src/state/queries/usePostThread/index.ts
+++ b/src/state/queries/usePostThread/index.ts
@@ -52,8 +52,8 @@ export function usePostThread({anchor}: {anchor?: string}) {
     return view === 'linear'
       ? LINEAR_VIEW_BELOW
       : isWeb && gtPhone
-      ? TREE_VIEW_BELOW_DESKTOP
-      : TREE_VIEW_BELOW
+        ? TREE_VIEW_BELOW_DESKTOP
+        : TREE_VIEW_BELOW
   }, [view, gtPhone])
 
   const postThreadQueryKey = createPostThreadQueryKey({

--- a/src/state/queries/usePostThread/traversal.ts
+++ b/src/state/queries/usePostThread/traversal.ts
@@ -444,7 +444,7 @@ export function buildThread({
     const anchorPost = items.at(0)
     const hasAnchorFromCache = anchorPost && anchorPost.type === 'threadPost'
     const skeletonReplies = hasAnchorFromCache
-      ? anchorPost.value.post.replyCount ?? 4
+      ? (anchorPost.value.post.replyCount ?? 4)
       : 4
 
     if (!items.length) {

--- a/src/storage/index.ts
+++ b/src/storage/index.ts
@@ -1,7 +1,7 @@
 import {useCallback, useEffect, useState} from 'react'
 import {MMKV} from 'react-native-mmkv'
 
-import {Account, Device} from '#/storage/schema'
+import {type Account, type Device} from '#/storage/schema'
 
 export * from '#/storage/schema'
 
@@ -83,18 +83,10 @@ export class Storage<Scopes extends unknown[], Schema> {
   }
 }
 
-type StorageSchema<T extends Storage<any, any>> = T extends Storage<
-  any,
-  infer U
->
-  ? U
-  : never
-type StorageScopes<T extends Storage<any, any>> = T extends Storage<
-  infer S,
-  any
->
-  ? S
-  : never
+type StorageSchema<T extends Storage<any, any>> =
+  T extends Storage<any, infer U> ? U : never
+type StorageScopes<T extends Storage<any, any>> =
+  T extends Storage<infer S, any> ? S : never
 
 /**
  * Hook to use a storage instance. Acts like a useState hook, but persists the

--- a/src/style.css
+++ b/src/style.css
@@ -328,7 +328,8 @@ input[type='range'][orient='vertical']::-moz-range-thumb {
 
 /* #/components/Select/index.web.tsx */
 .radix-select-content {
-  box-shadow: 0px 6px 24px -10px rgba(22, 23, 24, 0.25),
+  box-shadow:
+    0px 6px 24px -10px rgba(22, 23, 24, 0.25),
     0px 6px 12px -12px rgba(22, 23, 24, 0.15);
   min-width: var(--radix-select-trigger-width);
   max-height: var(--radix-select-content-available-height);

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -518,8 +518,8 @@ export const ComposePost = ({
       thread.posts.length > 1
         ? _(msg`Your posts have been published`)
         : replyTo
-        ? _(msg`Your reply has been published`)
-        : _(msg`Your post has been published`),
+          ? _(msg`Your reply has been published`)
+          : _(msg`Your post has been published`),
     )
   }, [
     _,
@@ -1000,20 +1000,20 @@ function ComposerTopBar({
                       }),
                     )
                 : isThread
-                ? _(
-                    msg({
-                      message: 'Publish posts',
-                      comment:
-                        'Accessibility label for button to publish multiple posts in a thread',
-                    }),
-                  )
-                : _(
-                    msg({
-                      message: 'Publish post',
-                      comment:
-                        'Accessibility label for button to publish a single post',
-                    }),
-                  )
+                  ? _(
+                      msg({
+                        message: 'Publish posts',
+                        comment:
+                          'Accessibility label for button to publish multiple posts in a thread',
+                      }),
+                    )
+                  : _(
+                      msg({
+                        message: 'Publish post',
+                        comment:
+                          'Accessibility label for button to publish a single post',
+                      }),
+                    )
             }
             variant="solid"
             color="primary"

--- a/src/view/com/composer/photos/Gallery.tsx
+++ b/src/view/com/composer/photos/Gallery.tsx
@@ -1,12 +1,12 @@
 import React from 'react'
 import {
-  ImageStyle,
+  type ImageStyle,
   Keyboard,
-  LayoutChangeEvent,
+  type LayoutChangeEvent,
   StyleSheet,
   TouchableOpacity,
   View,
-  ViewStyle,
+  type ViewStyle,
 } from 'react-native'
 import {Image} from 'expo-image'
 import {FontAwesomeIcon} from '@fortawesome/react-native-fontawesome'
@@ -14,14 +14,14 @@ import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
 import {useWebMediaQueries} from '#/lib/hooks/useWebMediaQueries'
-import {Dimensions} from '#/lib/media/types'
+import {type Dimensions} from '#/lib/media/types'
 import {colors, s} from '#/lib/styles'
 import {isNative} from '#/platform/detection'
-import {ComposerImage, cropImage} from '#/state/gallery'
+import {type ComposerImage, cropImage} from '#/state/gallery'
 import {Text} from '#/view/com/util/text/Text'
 import {useTheme} from '#/alf'
 import * as Dialog from '#/components/Dialog'
-import {PostAction} from '../state/composer'
+import {type PostAction} from '../state/composer'
 import {EditImageDialog} from './EditImageDialog'
 import {ImageAltTextDialog} from './ImageAltTextDialog'
 
@@ -74,8 +74,8 @@ const GalleryInner = ({images, containerInfo, dispatch}: GalleryInnerProps) => {
         altTextControlStyle: isOverflow
           ? {left: 4, bottom: 4}
           : !isMobile && images.length < 3
-          ? {left: 8, top: 8}
-          : {left: 4, top: 4},
+            ? {left: 8, top: 8}
+            : {left: 4, top: 4},
         imageControlsStyle: {
           display: 'flex' as const,
           flexDirection: 'row' as const,
@@ -83,8 +83,8 @@ const GalleryInner = ({images, containerInfo, dispatch}: GalleryInnerProps) => {
           ...(isOverflow
             ? {top: 4, right: 4, gap: 4}
             : !isMobile && images.length < 3
-            ? {top: 8, right: 8, gap: 8}
-            : {top: 4, right: 4, gap: 4}),
+              ? {top: 8, right: 8, gap: 8}
+              : {top: 4, right: 4, gap: 4}),
           zIndex: 1,
         },
         imageStyle: {

--- a/src/view/com/composer/state/composer.ts
+++ b/src/view/com/composer/state/composer.ts
@@ -1,13 +1,13 @@
-import {ImagePickerAsset} from 'expo-image-picker'
+import {type ImagePickerAsset} from 'expo-image-picker'
 import {
-  AppBskyFeedPostgate,
+  type AppBskyFeedPostgate,
   AppBskyRichtextFacet,
-  BskyPreferences,
+  type BskyPreferences,
   RichText,
 } from '@atproto/api'
 import {nanoid} from 'nanoid/non-secure'
 
-import {SelfLabel} from '#/lib/moderation'
+import {type SelfLabel} from '#/lib/moderation'
 import {insertMentionAt} from '#/lib/strings/mention-manip'
 import {shortenLinks} from '#/lib/strings/rich-text-manip'
 import {
@@ -15,17 +15,22 @@ import {
   postUriToRelativePath,
   toBskyAppUrl,
 } from '#/lib/strings/url-helpers'
-import {ComposerImage, createInitialImages} from '#/state/gallery'
+import {type ComposerImage, createInitialImages} from '#/state/gallery'
 import {createPostgateRecord} from '#/state/queries/postgate/util'
-import {Gif} from '#/state/queries/tenor'
+import {type Gif} from '#/state/queries/tenor'
 import {threadgateRecordToAllowUISetting} from '#/state/queries/threadgate'
-import {ThreadgateAllowUISetting} from '#/state/queries/threadgate'
-import {ComposerOpts} from '#/state/shell/composer'
+import {type ThreadgateAllowUISetting} from '#/state/queries/threadgate'
+import {type ComposerOpts} from '#/state/shell/composer'
 import {
-  LinkFacetMatch,
+  type LinkFacetMatch,
   suggestLinkCardUri,
 } from '#/view/com/composer/text-input/text-input-util'
-import {createVideoState, VideoAction, videoReducer, VideoState} from './video'
+import {
+  createVideoState,
+  type VideoAction,
+  videoReducer,
+  type VideoState,
+} from './video'
 
 type ImagesMedia = {
   type: 'images'
@@ -514,12 +519,12 @@ export function createComposerState({
     text: initText
       ? initText
       : initMention
-      ? insertMentionAt(
-          `@${initMention}`,
-          initMention.length + 1,
-          `${initMention}`,
-        )
-      : '',
+        ? insertMentionAt(
+            `@${initMention}`,
+            initMention.length + 1,
+            `${initMention}`,
+          )
+        : '',
   })
 
   let link: Link | undefined

--- a/src/view/com/composer/text-input/web/Autocomplete.tsx
+++ b/src/view/com/composer/text-input/web/Autocomplete.tsx
@@ -209,8 +209,8 @@ function AutocompleteProfileCard({
         itemIndex === 0
           ? styles.firstMention
           : itemIndex === totalItems - 1
-          ? styles.lastMention
-          : undefined,
+            ? styles.lastMention
+            : undefined,
       ]}
       onPress={onPress}
       accessibilityRole="button">

--- a/src/view/com/lightbox/Lightbox.web.tsx
+++ b/src/view/com/lightbox/Lightbox.web.tsx
@@ -1,17 +1,17 @@
 import React, {useCallback, useEffect, useState} from 'react'
 import {
   Image,
-  ImageStyle,
+  type ImageStyle,
   Pressable,
   StyleSheet,
   TouchableOpacity,
   TouchableWithoutFeedback,
   View,
-  ViewStyle,
+  type ViewStyle,
 } from 'react-native'
 import {
   FontAwesomeIcon,
-  FontAwesomeIconStyle,
+  type FontAwesomeIconStyle,
 } from '@fortawesome/react-native-fontawesome'
 import {msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
@@ -21,7 +21,7 @@ import {useWebMediaQueries} from '#/lib/hooks/useWebMediaQueries'
 import {colors, s} from '#/lib/styles'
 import {useLightbox, useLightboxControls} from '#/state/lightbox'
 import {Text} from '../util/text/Text'
-import {ImageSource} from './ImageViewing/@types'
+import {type ImageSource} from './ImageViewing/@types'
 import ImageDefaultHeader from './ImageViewing/components/ImageDefaultHeader'
 
 export function Lightbox() {
@@ -121,8 +121,8 @@ function LightboxInner({
                     img.type === 'circle-avi'
                       ? '50%'
                       : img.type === 'rect-avi'
-                      ? '10%'
-                      : 0,
+                        ? '10%'
+                        : 0,
                 } as ImageStyle
               }
               alt={img.alt}

--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -630,8 +630,8 @@ let PostThreadItemLoaded = ({
                   showChildReplyLine && !isThreadedChild
                     ? 0
                     : isThreadedChildAdjacentBot
-                    ? 4
-                    : 8,
+                      ? 4
+                      : 8,
               },
             ]}>
             {/* If we are in threaded mode, the avatar is rendered in PostMeta */}

--- a/src/view/com/posts/PostFeed.tsx
+++ b/src/view/com/posts/PostFeed.tsx
@@ -132,12 +132,11 @@ type FeedRow =
       key: string
     }
 
-export function getItemsForFeedback(feedRow: FeedRow):
-  | {
-      item: FeedPostSliceItem
-      feedContext: string | undefined
-      reqId: string | undefined
-    }[] {
+export function getItemsForFeedback(feedRow: FeedRow): {
+  item: FeedPostSliceItem
+  feedContext: string | undefined
+  reqId: string | undefined
+}[] {
   if (feedRow.type === 'sliceItem') {
     return feedRow.slice.items.map(item => ({
       item,

--- a/src/view/com/posts/PostFeedErrorMessage.tsx
+++ b/src/view/com/posts/PostFeedErrorMessage.tsx
@@ -1,15 +1,19 @@
 import React from 'react'
 import {View} from 'react-native'
-import {AppBskyActorDefs, AppBskyFeedGetAuthorFeed, AtUri} from '@atproto/api'
+import {
+  type AppBskyActorDefs,
+  AppBskyFeedGetAuthorFeed,
+  AtUri,
+} from '@atproto/api'
 import {msg as msgLingui, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 import {useNavigation} from '@react-navigation/native'
 
 import {usePalette} from '#/lib/hooks/usePalette'
-import {NavigationProp} from '#/lib/routes/types'
+import {type NavigationProp} from '#/lib/routes/types'
 import {cleanError} from '#/lib/strings/errors'
 import {logger} from '#/logger'
-import {FeedDescriptor} from '#/state/queries/post-feed'
+import {type FeedDescriptor} from '#/state/queries/post-feed'
 import {useRemoveFeedMutation} from '#/state/queries/preferences'
 import * as Prompt from '#/components/Prompt'
 import {EmptyState} from '../util/EmptyState'
@@ -119,7 +123,7 @@ function FeedgenErrorMessage({
         [KnownError.FeedTooManyRequests]: _l(
           msgLingui`This feed is currently receiving high traffic and is temporarily unavailable. Please try again later.`,
         ),
-      }[knownError]),
+      })[knownError],
     [_l, knownError],
   )
   const [_, uri] = feedDesc.split('|')

--- a/src/view/com/profile/ProfileMenu.tsx
+++ b/src/view/com/profile/ProfileMenu.tsx
@@ -461,12 +461,12 @@ let ProfileMenu = ({
                 msg`The account will be able to interact with you after unblocking.`,
               )
             : profile.associated?.labeler
-            ? _(
-                msg`Blocking will not prevent labels from being applied on your account, but it will stop this account from replying in your threads or interacting with you.`,
-              )
-            : _(
-                msg`Blocked accounts cannot reply in your threads, mention you, or otherwise interact with you.`,
-              )
+              ? _(
+                  msg`Blocking will not prevent labels from being applied on your account, but it will stop this account from replying in your threads or interacting with you.`,
+                )
+              : _(
+                  msg`Blocked accounts cannot reply in your threads, mention you, or otherwise interact with you.`,
+                )
         }
         onConfirm={blockAccount}
         confirmButtonCta={

--- a/src/view/com/util/List.web.tsx
+++ b/src/view/com/util/List.web.tsx
@@ -1,6 +1,11 @@
 import React, {isValidElement, memo, startTransition, useRef} from 'react'
-import {FlatListProps, StyleSheet, View, ViewProps} from 'react-native'
-import {ReanimatedScrollEvent} from 'react-native-reanimated/lib/typescript/hook/commonTypes'
+import {
+  type FlatListProps,
+  StyleSheet,
+  View,
+  type ViewProps,
+} from 'react-native'
+import {type ReanimatedScrollEvent} from 'react-native-reanimated/lib/typescript/hook/commonTypes'
 
 import {batchedUpdates} from '#/lib/batchedUpdates'
 import {useNonReactiveCallback} from '#/lib/hooks/useNonReactiveCallback'
@@ -205,7 +210,7 @@ function ListImpl<ItemT>(
             behavior: animated ? 'smooth' : 'instant',
           })
         },
-      } as any), // TODO: Better types.
+      }) as any, // TODO: Better types.
     [getScrollableNode],
   )
 

--- a/src/view/screens/DebugMod.tsx
+++ b/src/view/screens/DebugMod.tsx
@@ -112,14 +112,14 @@ export const DebugModScreen = ({}: NativeStackScreenProps<
               }),
             ]
           : scenario[0] === 'label' && target[0] === 'profile'
-          ? [
-              mock.label({
-                src: isSelfLabel ? did : undefined,
-                val: label[0],
-                uri: `at://${did}/app.bsky.actor.profile/self`,
-              }),
-            ]
-          : undefined,
+            ? [
+                mock.label({
+                  src: isSelfLabel ? did : undefined,
+                  val: label[0],
+                  uri: `at://${did}/app.bsky.actor.profile/self`,
+                }),
+              ]
+            : undefined,
       viewer: mock.actorViewerState({
         following: isFollowing
           ? `at://${currentAccount?.did || ''}/app.bsky.graph.follow/1234`

--- a/svgo.config.mjs
+++ b/svgo.config.mjs
@@ -1,64 +1,66 @@
 const preset = [
-  "removeDoctype",
-  "removeXMLProcInst",
-  "removeComments",
-  "removeMetadata",
-  "removeEditorsNSData",
-  "cleanupAttrs",
-  "mergeStyles",
-  "inlineStyles",
-  "minifyStyles",
-  "cleanupIds",
-  "removeUselessDefs",
-  "cleanupNumericValues",
-  "convertColors",
-  "removeUnknownsAndDefaults",
-  "removeNonInheritableGroupAttrs",
-  "removeUselessStrokeAndFill",
-  "removeDimensions",
-  "cleanupEnableBackground",
-  "removeHiddenElems",
-  "removeEmptyText",
-  "convertShapeToPath",
-  "convertEllipseToCircle",
-  "moveElemsAttrsToGroup",
-  "moveGroupAttrsToElems",
-  "collapseGroups",
-  "convertPathData",
-  "convertTransform",
-  "removeEmptyAttrs",
-  "removeEmptyContainers",
-  "removeUnusedNS",
-  "mergePaths",
-  "sortAttrs",
-  "sortDefsChildren",
-  "removeTitle",
-  "removeDesc",
+  'removeDoctype',
+  'removeXMLProcInst',
+  'removeComments',
+  'removeMetadata',
+  'removeEditorsNSData',
+  'cleanupAttrs',
+  'mergeStyles',
+  'inlineStyles',
+  'minifyStyles',
+  'cleanupIds',
+  'removeUselessDefs',
+  'cleanupNumericValues',
+  'convertColors',
+  'removeUnknownsAndDefaults',
+  'removeNonInheritableGroupAttrs',
+  'removeUselessStrokeAndFill',
+  'removeDimensions',
+  'cleanupEnableBackground',
+  'removeHiddenElems',
+  'removeEmptyText',
+  'convertShapeToPath',
+  'convertEllipseToCircle',
+  'moveElemsAttrsToGroup',
+  'moveGroupAttrsToElems',
+  'collapseGroups',
+  'convertPathData',
+  'convertTransform',
+  'removeEmptyAttrs',
+  'removeEmptyContainers',
+  'removeUnusedNS',
+  'mergePaths',
+  'sortAttrs',
+  'sortDefsChildren',
+  'removeTitle',
+  'removeDesc',
 ]
 
 export default {
-  plugins: [...preset.map(name => ({
-    name,
-    params: {
-      floatPrecision: 3,
-      transformPrecision: 5,
-      // minimise diff in ouput from svgomg
-      // maybe remove in future? will produce smaller output
-      convertToZ: false,
-      removeUseless: false,
-    }
-  })),
-  {
-    name: 'addTrailingWhitespace',
-    fn() {
-      return {
-        root: {
-          exit (root) {
-            root.children.push({ type: 'text', value: '\n' })
-            return root
-          }
+  plugins: [
+    ...preset.map(name => ({
+      name,
+      params: {
+        floatPrecision: 3,
+        transformPrecision: 5,
+        // minimise diff in ouput from svgomg
+        // maybe remove in future? will produce smaller output
+        convertToZ: false,
+        removeUseless: false,
+      },
+    })),
+    {
+      name: 'addTrailingWhitespace',
+      fn() {
+        return {
+          root: {
+            exit(root) {
+              root.children.push({type: 'text', value: '\n'})
+              return root
+            },
+          },
         }
-      }
-    }
-  }]
-};
+      },
+    },
+  ],
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -16220,10 +16220,10 @@ prelude-ls@^1.2.1:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
-prettier@^2.8.3:
-  version "2.8.8"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
-  integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
+prettier@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.6.0.tgz#18ec98d62cb0757a5d4eab40253ff3e6d0fc8dea"
+  integrity sha512-ujSB9uXHJKzM/2GBuE0hBOUgC77CN3Bnpqa+g80bkv3T3A93wL/xlzDATHhnhkzifz/UE2SNOvmbTz5hSkDlHw==
 
 pretty-bytes@^5.6.0:
   version "5.6.0"


### PR DESCRIPTION
We're on a fairly old version, and they're putting out some really cool new performance features: https://prettier.io/blog/2025/06/23/3.6.0

In particular, `--experimental-cli` has huge perf gains on our repo

<img width="831" alt="Screenshot 2025-06-23 at 16 50 39" src="https://github.com/user-attachments/assets/faa7a08c-933c-46a7-868b-c9f282157d20" />


Would be fun to turn on `--experimental-cli` for our CI, but for now let's just bump the version. Some minor things changed between versions but I read through it and all looks good