### PR TITLE
Notifications registration

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -201,3 +201,6 @@ export const urls = {
     },
   },
 }
+
+export const PUBLIC_APPVIEW_DID = 'did:web:api.bsky.app'
+export const PUBLIC_STAGING_APPVIEW_DID = 'did:web:api.staging.bsky.dev'

--- a/src/lib/notifications/notifications.ts
+++ b/src/lib/notifications/notifications.ts
@@ -96,10 +96,11 @@ async function getPushToken() {
  * `getPushToken()`. Therefore, as insurance, we also call
  * `registerPushToken` here.
  *
- * Because `registerPushToken` is debounced, we can safely call it on every
- * platform and only a single call will be made to the server. This does race
- * the listener (if it fires), so there's a possibility that multiple calls
- * will be made, but that is acceptable.
+ * Because `registerPushToken` is debounced, even if the the listener _does_
+ * fire, it's OK to also call `registerPushToken` below since only a single
+ * call will be made to the server (ideally). This does race the listener (if
+ * it fires), so there's a possibility that multiple calls will be made, but
+ * that is acceptable.
  *
  * @see https://github.com/bluesky-social/social-app/pull/4467
  * @see https://github.com/expo/expo/issues/28656

--- a/src/lib/notifications/notifications.ts
+++ b/src/lib/notifications/notifications.ts
@@ -78,10 +78,12 @@ export function useNotificationsRegistration() {
       getPushToken()
     }
 
-    /*
+    /**
      * According to the Expo docs, there is a chance that the token will change
      * while the app is open in some rare cases. This will fire
      * `registerPushToken` whenever that happens.
+     *
+     * @see https://docs.expo.dev/versions/latest/sdk/notifications/#addpushtokenlistenerlistener
      */
     const subscription = Notifications.addPushTokenListener(async newToken => {
       registerPushTokenDebounced(agent, currentAccount, newToken)

--- a/src/lib/notifications/notifications.ts
+++ b/src/lib/notifications/notifications.ts
@@ -8,7 +8,7 @@ import debounce from 'lodash.debounce'
 import {Logger} from '#/logger'
 import {isNative} from '#/platform/detection'
 import {type SessionAccount, useAgent, useSession} from '#/state/session'
-import BackgroundNotificationHandler from '../../../modules/expo-background-notification-handler'
+import BackgroundNotificationHandler from '#/../modules/expo-background-notification-handler'
 
 const logger = Logger.create(Logger.Context.Notifications)
 

--- a/src/lib/notifications/notifications.ts
+++ b/src/lib/notifications/notifications.ts
@@ -5,6 +5,7 @@ import {getBadgeCountAsync, setBadgeCountAsync} from 'expo-notifications'
 import {type AtpAgent} from '@atproto/api'
 import debounce from 'lodash.debounce'
 
+import {PUBLIC_APPVIEW_DID, PUBLIC_STAGING_APPVIEW_DID} from '#/lib/constants'
 import {Logger} from '#/logger'
 import {isNative} from '#/platform/detection'
 import {type SessionAccount, useAgent, useSession} from '#/state/session'
@@ -28,13 +29,9 @@ async function _registerPushToken({
   try {
     await agent.app.bsky.notification.registerPush({
       serviceDid: currentAccount.service?.includes('staging')
-        ? 'did:web:api.staging.bsky.dev'
-        : 'did:web:api.bsky.app',
-      platform: Platform.select({
-        ios: 'ios',
-        android: 'android',
-        default: 'web',
-      }),
+        ? PUBLIC_STAGING_APPVIEW_DID
+        : PUBLIC_APPVIEW_DID,
+      platform: Platform.OS,
       token: token.data,
       appId: 'xyz.blueskyweb.app',
     })

--- a/src/lib/notifications/notifications.ts
+++ b/src/lib/notifications/notifications.ts
@@ -1,39 +1,41 @@
 import React from 'react'
+import {Platform} from 'react-native'
 import * as Notifications from 'expo-notifications'
 import {getBadgeCountAsync, setBadgeCountAsync} from 'expo-notifications'
-import {BskyAgent} from '@atproto/api'
+import {type AtpAgent} from '@atproto/api'
 
-import {logEvent} from '#/lib/statsig/statsig'
 import {Logger} from '#/logger'
-import {devicePlatform, isAndroid, isNative} from '#/platform/detection'
-import {SessionAccount, useAgent, useSession} from '#/state/session'
+import {isAndroid, isNative} from '#/platform/detection'
+import {type SessionAccount, useAgent, useSession} from '#/state/session'
 import BackgroundNotificationHandler from '../../../modules/expo-background-notification-handler'
-
-const SERVICE_DID = (serviceUrl?: string) =>
-  serviceUrl?.includes('staging')
-    ? 'did:web:api.staging.bsky.dev'
-    : 'did:web:api.bsky.app'
 
 const logger = Logger.create(Logger.Context.Notifications)
 
 async function registerPushToken(
-  agent: BskyAgent,
+  agent: AtpAgent,
   account: SessionAccount,
   token: Notifications.DevicePushToken,
 ) {
   try {
-    await agent.api.app.bsky.notification.registerPush({
-      serviceDid: SERVICE_DID(account.service),
-      platform: devicePlatform,
+    await agent.app.bsky.notification.registerPush({
+      serviceDid: account.service?.includes('staging')
+        ? 'did:web:api.staging.bsky.dev'
+        : 'did:web:api.bsky.app',
+      platform: Platform.select({
+        ios: 'ios',
+        android: 'android',
+        default: 'web',
+      }),
       token: token.data,
       appId: 'xyz.blueskyweb.app',
     })
-    logger.debug('Notifications: Sent push token (init)', {
+
+    logger.debug(`registerPushToken`, {
       tokenType: token.type,
       token: token.data,
     })
   } catch (error) {
-    logger.error('Notifications: Failed to set push token', {message: error})
+    logger.error(`registerPushToken: failed`, {safeMessage: error})
   }
 }
 
@@ -50,14 +52,16 @@ export function useNotificationsRegistration() {
   const {currentAccount} = useSession()
 
   React.useEffect(() => {
-    if (!currentAccount) {
-      return
-    }
+    if (!currentAccount) return
 
-    // HACK - see https://github.com/bluesky-social/social-app/pull/4467
-    // An apparent regression in expo-notifications causes `addPushTokenListener` to not fire on Android whenever the
-    // token changes by calling `getPushToken()`. This is a workaround to ensure we register the token once it is
-    // generated on Android.
+    /**
+     * HACK — An apparent regression in expo-notifications causes
+     * `addPushTokenListener` to not fire on Android whenever the token changes
+     * by calling `getPushToken()`. This is a workaround to ensure we register
+     * the token once it is generated on Android.
+     *
+     * @see https://github.com/bluesky-social/social-app/pull/4467
+     */
     if (isAndroid) {
       ;(async () => {
         const token = await getPushToken()
@@ -71,8 +75,11 @@ export function useNotificationsRegistration() {
       getPushToken()
     }
 
-    // According to the Expo docs, there is a chance that the token will change while the app is open in some rare
-    // cases. This will fire `registerPushToken` whenever that happens.
+    /*
+     * According to the Expo docs, there is a chance that the token will change
+     * while the app is open in some rare cases. This will fire
+     * `registerPushToken` whenever that happens.
+     */
     const subscription = Notifications.addPushTokenListener(async newToken => {
       registerPushToken(agent, currentAccount, newToken)
     })
@@ -107,24 +114,37 @@ export function useRequestNotificationsPermission() {
     }
 
     const res = await Notifications.requestPermissionsAsync()
-    logEvent('notifications:request', {
+    logger.metric(`notifications:request`, {
       context: context,
       status: res.status,
     })
 
     if (res.granted) {
-      // This will fire a pushTokenEvent, which will handle registration of the token
+      /*
+       * This will fire a pushTokenEvent, which will handle registration of the
+       * token
+       */
       const token = await getPushToken(true)
 
-      // Same hack as above. We cannot rely on the `addPushTokenListener` to fire on Android due to an Expo bug, so we
-      // will manually register it here. Note that this will occur only:
-      // 1. right after the user signs in, leading to no `currentAccount` account being available - this will be instead
-      // picked up from the useEffect above on `currentAccount` change
-      // 2. right after onboarding. In this case, we _need_ this registration, since `currentAccount` will not change
-      // and we need to ensure the token is registered right after permission is granted. `currentAccount` will already
-      // be available in this case, so the registration will succeed.
-      // We should remove this once expo-notifications (and possibly FCMv1) is fixed and the `addPushTokenListener` is
-      // working again. See https://github.com/expo/expo/issues/28656
+      /**
+       * Same hack as above. We cannot rely on the `addPushTokenListener` to
+       * fire on Android due to an Expo bug, so we will manually register it
+       * here. Note that this will occur only:
+       *
+       *    1) Right after the user signs in, leading to no `currentAccount`
+       *    account being available - this will be instead picked up from the
+       *    useEffect above on `currentAccount` change
+       *
+       *    2) Right after onboarding. In this case, we _need_ this
+       *    registration, since `currentAccount` will not change and we need to
+       *    ensure the token is registered right after permission is granted.
+       *    `currentAccount` will already be available in this case, so the
+       *    registration will succeed. We should remove this once
+       *    expo-notifications (and possibly FCMv1) is fixed and the
+       *    `addPushTokenListener` is working again.
+       *
+       * @see https://github.com/expo/expo/issues/28656
+       */
       if (isAndroid && currentAccount && token) {
         registerPushToken(agent, currentAccount, token)
       }

--- a/src/lib/notifications/notifications.ts
+++ b/src/lib/notifications/notifications.ts
@@ -91,6 +91,8 @@ async function getPushToken() {
 
 /**
  * Hook to get the device push token and register it with the Bluesky server.
+ * Should only be called after a user has logged-in, since registration is an
+ * authed endpoint.
  *
  * N.B. A previous regression in `expo-notifications` caused
  * `addPushTokenListener` to not fire on Android after calling

--- a/src/platform/detection.ts
+++ b/src/platform/detection.ts
@@ -3,7 +3,6 @@ import {Platform} from 'react-native'
 export const isIOS = Platform.OS === 'ios'
 export const isAndroid = Platform.OS === 'android'
 export const isNative = isIOS || isAndroid
-export const devicePlatform = isIOS ? 'ios' : isAndroid ? 'android' : 'web'
 export const isWeb = !isNative
 export const isMobileWebMediaQuery = 'only screen and (max-width: 1300px)'
 export const isMobileWeb =


### PR DESCRIPTION
Fixes a small issue of the push token registration endpoint being called 2x, as well as clarifies the token update callback handling. I refactored this into hooks in anticipation of upcoming needs, and left a ton of comments to make it even more clear what's going on in here.

### Testing
Assuming you allow notifications (if you don't, then obviously the token won't be registered), these are the flows that can test call cases. You'll need to set your `LOG_LEVEL=debug` and `LOG_DEBUG=notifications` before running the build process (no need to prebuild).

- [x] iOS
  - [x] From fresh install
    - [x] Log into an existing account
    - [x] Create a new account
  - [x] From an install with one account already logged in
    - [x] Log into a different account
    - [x] Create a new account
- [x] Android
  - [x] From fresh install
    - [x] Log into an existing account
    - [x] Create a new account
  - [x] From an install with one account already logged in
    - [x] Log into a different account
    - [x] Create a new account