### PR TITLE
Android paper text input padding

### DIFF
--- a/src/components/forms/TextField.tsx
+++ b/src/components/forms/TextField.tsx
@@ -196,7 +196,8 @@ export function createInput(Component: typeof TextInput) {
         minWidth: 0,
       },
       ios({paddingTop: 12, paddingBottom: 13}),
-      android(a.py_md),
+      // Needs to be sm on Paper, md on Fabric for some godforsaken reason -sfn
+      android(a.py_sm),
       // fix for autofill styles covering border
       web({
         paddingTop: 10,


### PR DESCRIPTION
Text input padding on Android is different for paper and fabric. Since we reverted to paper, we need to switch the padding back to `sm`

**Revert this when we switch back to Fabric**