### PR TITLE
Fix video aspect ratio error - "Record/embed/aspectRatio/width cannot be less than 1"

### DIFF
--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -342,6 +342,12 @@ async function resolveMedia(
     // posting will fail if aspect ratio is set to 0
     const aspectRatio = width > 0 && height > 0 ? {width, height} : undefined
 
+    if (!aspectRatio) {
+      logger.error(
+        `Invalid aspect ratio - got { width: ${videoDraft.asset.width}, height: ${videoDraft.asset.height} }`,
+      )
+    }
+
     return {
       $type: 'app.bsky.embed.video',
       video: videoDraft.pendingPublish.blobRef,

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -333,15 +333,21 @@ async function resolveMedia(
           return {lang: caption.lang, file: data.blob}
         }),
     )
+
+    // lexicon numbers must be floats
+    const width = Math.round(videoDraft.asset.width)
+    const height = Math.round(videoDraft.asset.height)
+
+    // aspect ratio values must be >0 - better to leave as unset otherwise
+    // posting will fail if aspect ratio is set to 0
+    const aspectRatio = width > 0 && height > 0 ? {width, height} : undefined
+
     return {
       $type: 'app.bsky.embed.video',
       video: videoDraft.pendingPublish.blobRef,
       alt: videoDraft.altText || undefined,
       captions: captions.length === 0 ? undefined : captions,
-      aspectRatio: {
-        width: videoDraft.asset.width,
-        height: videoDraft.asset.height,
-      },
+      aspectRatio,
     }
   }
   if (embedDraft.media?.type === 'gif') {

--- a/src/view/com/composer/videos/pickVideo.ts
+++ b/src/view/com/composer/videos/pickVideo.ts
@@ -1,5 +1,5 @@
 import {
-  ImagePickerAsset,
+  type ImagePickerAsset,
   launchImageLibraryAsync,
   UIImagePickerPreferredAssetRepresentationMode,
 } from 'expo-image-picker'


### PR DESCRIPTION
Fix https://github.com/bluesky-social/social-app/issues/5753

Sometimes the video picker appears to return a width or height of 0. This breaks lexicon validation, so it's unable to post - better to just leave the aspect ratio off instead and just log an error

![image](https://github.com/user-attachments/assets/1aae194f-2189-47ba-897a-4348d116d522)
