### PR TITLE
Tweak Who can reply dialog

### DIFF
--- a/src/components/WhoCanReply.tsx
+++ b/src/components/WhoCanReply.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import {Fragment, useMemo} from 'react'
 import {
   Keyboard,
   Platform,
@@ -22,8 +22,8 @@ import {
   type ThreadgateAllowUISetting,
   threadgateViewToAllowUISetting,
 } from '#/state/queries/threadgate'
-import {atoms as a, useTheme} from '#/alf'
-import {Button} from '#/components/Button'
+import {atoms as a, useTheme, web} from '#/alf'
+import {Button, ButtonText} from '#/components/Button'
 import * as Dialog from '#/components/Dialog'
 import {useDialogControl} from '#/components/Dialog'
 import {
@@ -61,7 +61,7 @@ export function WhoCanReply({post, isThreadAuthor, style}: WhoCanReplyProps) {
     ) && post.record.reply?.root
       ? post.record.reply.root.uri
       : post.uri
-  const settings = React.useMemo(() => {
+  const settings = useMemo(() => {
     return threadgateViewToAllowUISetting(post.threadgate)
   }, [post.threadgate])
 
@@ -178,12 +178,13 @@ function WhoCanReplyDialog({
   embeddingDisabled: boolean
 }) {
   const {_} = useLingui()
+
   return (
-    <Dialog.Outer control={control}>
+    <Dialog.Outer control={control} nativeOptions={{preventExpansion: true}}>
       <Dialog.Handle />
       <Dialog.ScrollableInner
         label={_(msg`Dialog: adjust who can interact with this post`)}
-        style={[{width: 'auto', maxWidth: 400, minWidth: 200}]}>
+        style={web({maxWidth: 400})}>
         <View style={[a.gap_sm]}>
           <Text style={[a.font_bold, a.text_xl, a.pb_sm]}>
             <Trans>Who can interact with this post?</Trans>
@@ -194,6 +195,20 @@ function WhoCanReplyDialog({
             embeddingDisabled={embeddingDisabled}
           />
         </View>
+        {isNative && (
+          <Button
+            label={_(msg`Close`)}
+            onPress={() => control.close()}
+            size="small"
+            variant="solid"
+            color="secondary"
+            style={[a.mt_5xl]}>
+            <ButtonText>
+              <Trans>Close</Trans>
+            </ButtonText>
+          </Button>
+        )}
+        <Dialog.Close />
       </Dialog.ScrollableInner>
     </Dialog.Outer>
   )
@@ -232,10 +247,10 @@ function Rules({
           <Trans>
             Only{' '}
             {settings.map((rule, i) => (
-              <React.Fragment key={`rule-${i}`}>
+              <Fragment key={`rule-${i}`}>
                 <Rule rule={rule} post={post} lists={post.threadgate!.lists} />
                 <Separator i={i} length={settings.length} />
-              </React.Fragment>
+              </Fragment>
             ))}{' '}
             can reply.
           </Trans>


### PR DESCRIPTION
Currently the dialog has a few issues

- No close button (especially weird on web)
- You can swipe up on native
- It can be super small on native  

Fixed by adding a close button

# Before

<table>
  <thead>
    <tr>
      <th>Native</th>
      <th>Web</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><img width="200" src="https://github.com/user-attachments/assets/ea82d39d-a157-439c-a8cf-63dd280b4060" /></td>
      <td><img width="300" src="https://github.com/user-attachments/assets/6526d6a2-a18b-41f6-a986-3877f049caf8" /></td>
    </tr>
  </tbody>
</table>

# After

<table>
  <thead>
    <tr>
      <th>Native</th>
      <th>Native</th>
      <th>Web</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><img width="200" src="https://github.com/user-attachments/assets/1f300494-7a6d-4353-8bc6-8bb167479428" /></td>
      <td><img width="200" src="https://github.com/user-attachments/assets/455f4e95-7fd4-4bfb-96ac-6a604d1064e6" /></td>
      <td><img width="300" src="https://github.com/user-attachments/assets/adae82f0-3f4b-4fc2-86b9-9fe260f8e01b" /></td>
    </tr>
  </tbody>
</table>
