### PR TITLE
Fix unnecessary loading of feeds

### DIFF
--- a/src/components/FeedCard.tsx
+++ b/src/components/FeedCard.tsx
@@ -214,7 +214,7 @@ export function DescriptionPlaceholder() {
 export function Likes({count}: {count: number}) {
   const t = useTheme()
   return (
-    <Text style={[a.text_sm, t.atoms.text_contrast_medium]}>
+    <Text style={[a.text_sm, t.atoms.text_contrast_medium, a.font_bold]}>
       <Trans>
         Liked by <Plural value={count || 0} one="# user" other="# users" />
       </Trans>

--- a/src/components/ListCard.tsx
+++ b/src/components/ListCard.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import {View} from 'react-native'
 import {
-  AppBskyGraphDefs,
+  type AppBskyGraphDefs,
   AtUri,
   moderateUserList,
-  ModerationUI,
+  type ModerationUI,
 } from '@atproto/api'
 import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
@@ -22,10 +22,10 @@ import {
   Outer,
   SaveButton,
 } from '#/components/FeedCard'
-import {Link as InternalLink, LinkProps} from '#/components/Link'
+import {Link as InternalLink, type LinkProps} from '#/components/Link'
 import * as Hider from '#/components/moderation/Hider'
 import {Text} from '#/components/Typography'
-import * as bsky from '#/types/bsky'
+import type * as bsky from '#/types/bsky'
 
 /*
  * This component is based on `FeedCard` and is tightly coupled with that

--- a/src/components/Post/Embed/FeedEmbed.tsx
+++ b/src/components/Post/Embed/FeedEmbed.tsx
@@ -1,10 +1,9 @@
 import React from 'react'
-import {StyleSheet} from 'react-native'
 import {moderateFeedGenerator} from '@atproto/api'
 
-import {usePalette} from '#/lib/hooks/usePalette'
 import {useModerationOpts} from '#/state/preferences/moderation-opts'
 import {FeedSourceCard} from '#/view/com/feeds/FeedSourceCard'
+import {atoms as a, useTheme} from '#/alf'
 import {ContentHider} from '#/components/moderation/ContentHider'
 import {type EmbedType} from '#/types/bsky/post'
 import {type CommonProps} from './types'
@@ -14,11 +13,18 @@ export function FeedEmbed({
 }: CommonProps & {
   embed: EmbedType<'feed'>
 }) {
-  const pal = usePalette('default')
+  const t = useTheme()
   return (
     <FeedSourceCard
       feedUri={embed.view.uri}
-      style={[pal.view, pal.border, styles.customFeedOuter]}
+      feedData={embed.view}
+      style={[
+        t.atoms.bg,
+        t.atoms.border_contrast_low,
+        a.p_md,
+        a.rounded_sm,
+        a.border,
+      ]}
       showLikes
     />
   )
@@ -41,12 +47,3 @@ export function ModeratedFeedEmbed({
     </ContentHider>
   )
 }
-
-const styles = StyleSheet.create({
-  customFeedOuter: {
-    borderWidth: StyleSheet.hairlineWidth,
-    borderRadius: 8,
-    paddingHorizontal: 12,
-    paddingVertical: 12,
-  },
-})

--- a/src/components/Post/Embed/FeedEmbed.tsx
+++ b/src/components/Post/Embed/FeedEmbed.tsx
@@ -1,9 +1,9 @@
-import React from 'react'
+import {useMemo} from 'react'
 import {moderateFeedGenerator} from '@atproto/api'
 
 import {useModerationOpts} from '#/state/preferences/moderation-opts'
-import {FeedSourceCard} from '#/view/com/feeds/FeedSourceCard'
 import {atoms as a, useTheme} from '#/alf'
+import * as FeedCard from '#/components/FeedCard'
 import {ContentHider} from '#/components/moderation/ContentHider'
 import {type EmbedType} from '#/types/bsky/post'
 import {type CommonProps} from './types'
@@ -15,18 +15,20 @@ export function FeedEmbed({
 }) {
   const t = useTheme()
   return (
-    <FeedSourceCard
-      feedUri={embed.view.uri}
-      feedData={embed.view}
-      style={[
-        t.atoms.bg,
-        t.atoms.border_contrast_low,
-        a.p_md,
-        a.rounded_sm,
-        a.border,
-      ]}
-      showLikes
-    />
+    <FeedCard.Link
+      view={embed.view}
+      style={[a.border, t.atoms.border_contrast_medium, a.p_md, a.rounded_sm]}>
+      <FeedCard.Outer>
+        <FeedCard.Header>
+          <FeedCard.Avatar src={embed.view.avatar} />
+          <FeedCard.TitleAndByline
+            title={embed.view.displayName}
+            creator={embed.view.creator}
+          />
+        </FeedCard.Header>
+        <FeedCard.Likes count={embed.view.likeCount || 0} />
+      </FeedCard.Outer>
+    </FeedCard.Link>
   )
 }
 
@@ -36,7 +38,7 @@ export function ModeratedFeedEmbed({
   embed: EmbedType<'feed'>
 }) {
   const moderationOpts = useModerationOpts()
-  const moderation = React.useMemo(() => {
+  const moderation = useMemo(() => {
     return moderationOpts
       ? moderateFeedGenerator(embed.view, moderationOpts)
       : undefined

--- a/src/components/Post/Embed/ListEmbed.tsx
+++ b/src/components/Post/Embed/ListEmbed.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import {useMemo} from 'react'
 import {View} from 'react-native'
 import {moderateUserList} from '@atproto/api'
 
@@ -29,7 +29,7 @@ export function ModeratedListEmbed({
   embed: EmbedType<'list'>
 }) {
   const moderationOpts = useModerationOpts()
-  const moderation = React.useMemo(() => {
+  const moderation = useMemo(() => {
     return moderationOpts
       ? moderateUserList(embed.view, moderationOpts)
       : undefined

--- a/src/view/com/feeds/FeedSourceCard.tsx
+++ b/src/view/com/feeds/FeedSourceCard.tsx
@@ -2,7 +2,6 @@ import {
   Linking,
   Pressable,
   type StyleProp,
-  StyleSheet,
   View,
   type ViewStyle,
 } from 'react-native'
@@ -15,9 +14,7 @@ import {
 import {Plural, Trans} from '@lingui/macro'
 
 import {useNavigationDeduped} from '#/lib/hooks/useNavigationDeduped'
-import {usePalette} from '#/lib/hooks/usePalette'
 import {sanitizeHandle} from '#/lib/strings/handles'
-import {s} from '#/lib/styles'
 import {
   type FeedSourceInfo,
   hydrateFeedGenerator,
@@ -25,11 +22,11 @@ import {
   useFeedSourceInfoQuery,
 } from '#/state/queries/feed'
 import {FeedLoadingPlaceholder} from '#/view/com/util/LoadingPlaceholder'
-import {Text} from '#/view/com/util/text/Text'
 import {UserAvatar} from '#/view/com/util/UserAvatar'
 import {atoms as a, useTheme} from '#/alf'
 import {shouldClickOpenNewTab} from '#/components/Link'
 import {RichText} from '#/components/RichText'
+import {Text} from '#/components/Typography'
 
 type FeedSourceCardProps = {
   feedUri: string
@@ -90,8 +87,6 @@ export function FeedSourceCardLoaded({
   hideTopBorder?: boolean
 }) {
   const t = useTheme()
-  const pal = usePalette('default')
-
   const navigation = useNavigationDeduped()
 
   /*
@@ -102,30 +97,16 @@ export function FeedSourceCardLoaded({
    */
   if (!feed)
     return (
-      <View
+      <FeedLoadingPlaceholder
         style={[
-          pal.border,
-          {
-            borderTopWidth:
-              showMinimalPlaceholder || hideTopBorder
-                ? 0
-                : StyleSheet.hairlineWidth,
-            flexDirection: 'row',
-            alignItems: 'center',
-            flex: 1,
-            paddingRight: 18,
-          },
-        ]}>
-        {showMinimalPlaceholder ? (
-          <FeedLoadingPlaceholder
-            style={[a.flex_1]}
-            showTopBorder={false}
-            showLowerPlaceholder={false}
-          />
-        ) : (
-          <FeedLoadingPlaceholder style={[a.flex_1]} showTopBorder={false} />
-        )}
-      </View>
+          t.atoms.border_contrast_low,
+          !(showMinimalPlaceholder || hideTopBorder) && a.border_t,
+          a.flex_1,
+          style,
+        ]}
+        showTopBorder={false}
+        showLowerPlaceholder={!showMinimalPlaceholder}
+      />
     )
 
   return (
@@ -168,14 +149,19 @@ export function FeedSourceCardLoaded({
       }}
       key={feed.uri}>
       <View style={[a.flex_row, a.align_center]}>
-        <View style={[s.mr10]}>
+        <View style={[a.mr_md]}>
           <UserAvatar type="algo" size={36} avatar={feed.avatar} />
         </View>
-        <View style={[a.flex_1, a.gap_2xs]}>
-          <Text emoji style={[pal.text, s.bold]} numberOfLines={1}>
+        <View style={[a.flex_1, a.gap_xs]}>
+          <Text
+            emoji
+            style={[a.text_md, a.font_bold, a.leading_tight]}
+            numberOfLines={1}>
             {feed.displayName}
           </Text>
-          <Text type="sm" style={[pal.textLight]} numberOfLines={1}>
+          <Text
+            style={[a.text_sm, t.atoms.text_contrast_medium, a.leading_tight]}
+            numberOfLines={1}>
             {feed.type === 'feed' ? (
               <Trans>Feed by {sanitizeHandle(feed.creatorHandle, '@')}</Trans>
             ) : (
@@ -194,7 +180,13 @@ export function FeedSourceCardLoaded({
       ) : null}
 
       {showLikes && feed.type === 'feed' ? (
-        <Text type="sm-medium" style={[pal.text, pal.textLight]}>
+        <Text
+          style={[
+            a.text_sm,
+            a.font_bold,
+            t.atoms.text_contrast_medium,
+            a.leading_tight,
+          ]}>
           <Trans>
             Liked by{' '}
             <Plural value={feed.likeCount || 0} one="# user" other="# users" />

--- a/src/view/com/feeds/FeedSourceCard.tsx
+++ b/src/view/com/feeds/FeedSourceCard.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import {
   Linking,
   Pressable,
@@ -13,33 +12,23 @@ import {
   type AppBskyGraphDefs,
   AtUri,
 } from '@atproto/api'
-import {FontAwesomeIcon} from '@fortawesome/react-native-fontawesome'
-import {msg, Plural, Trans} from '@lingui/macro'
-import {useLingui} from '@lingui/react'
+import {Plural, Trans} from '@lingui/macro'
 
 import {useNavigationDeduped} from '#/lib/hooks/useNavigationDeduped'
 import {usePalette} from '#/lib/hooks/usePalette'
 import {sanitizeHandle} from '#/lib/strings/handles'
 import {s} from '#/lib/styles'
-import {logger} from '#/logger'
 import {
   type FeedSourceInfo,
   hydrateFeedGenerator,
   hydrateList,
   useFeedSourceInfoQuery,
 } from '#/state/queries/feed'
-import {
-  useAddSavedFeedsMutation,
-  usePreferencesQuery,
-  useRemoveFeedMutation,
-} from '#/state/queries/preferences'
 import {FeedLoadingPlaceholder} from '#/view/com/util/LoadingPlaceholder'
 import {Text} from '#/view/com/util/text/Text'
-import * as Toast from '#/view/com/util/Toast'
 import {UserAvatar} from '#/view/com/util/UserAvatar'
 import {atoms as a, useTheme} from '#/alf'
 import {shouldClickOpenNewTab} from '#/components/Link'
-import * as Prompt from '#/components/Prompt'
 import {RichText} from '#/components/RichText'
 
 type FeedSourceCardProps = {
@@ -68,7 +57,7 @@ export function FeedSourceCard({
     } else {
       feed = hydrateList(feedData)
     }
-    return <FeedSourceCardLoaded feedUri={feedUri} feed={feed} {...props} />
+    return <FeedSourceCardLoaded feed={feed} {...props} />
   } else {
     return <FeedSourceCardWithoutData feedUri={feedUri} {...props} />
   }
@@ -82,85 +71,28 @@ export function FeedSourceCardWithoutData({
     uri: feedUri,
   })
 
-  return <FeedSourceCardLoaded feedUri={feedUri} feed={feed} {...props} />
+  return <FeedSourceCardLoaded feed={feed} {...props} />
 }
 
 export function FeedSourceCardLoaded({
-  feedUri,
   feed,
   style,
-  showSaveBtn = false,
   showDescription = false,
   showLikes = false,
-  pinOnSave = false,
   showMinimalPlaceholder,
   hideTopBorder,
 }: {
-  feedUri: string
   feed?: FeedSourceInfo
   style?: StyleProp<ViewStyle>
-  showSaveBtn?: boolean
   showDescription?: boolean
   showLikes?: boolean
-  pinOnSave?: boolean
   showMinimalPlaceholder?: boolean
   hideTopBorder?: boolean
 }) {
-  const {data: preferences} = usePreferencesQuery()
   const t = useTheme()
   const pal = usePalette('default')
-  const {_} = useLingui()
-  const removePromptControl = Prompt.usePromptControl()
+
   const navigation = useNavigationDeduped()
-
-  const {isPending: isAddSavedFeedPending, mutateAsync: addSavedFeeds} =
-    useAddSavedFeedsMutation()
-  const {isPending: isRemovePending, mutateAsync: removeFeed} =
-    useRemoveFeedMutation()
-
-  const savedFeedConfig = preferences?.savedFeeds?.find(
-    f => f.value === feedUri,
-  )
-  const isSaved = Boolean(savedFeedConfig)
-
-  const onSave = React.useCallback(async () => {
-    if (!feed || isSaved) return
-
-    try {
-      await addSavedFeeds([
-        {
-          type: 'feed',
-          value: feed.uri,
-          pinned: pinOnSave,
-        },
-      ])
-      Toast.show(_(msg`Added to my feeds`))
-    } catch (e) {
-      Toast.show(_(msg`There was an issue contacting your server`), 'xmark')
-      logger.error('Failed to save feed', {message: e})
-    }
-  }, [_, feed, pinOnSave, addSavedFeeds, isSaved])
-
-  const onUnsave = React.useCallback(async () => {
-    if (!savedFeedConfig) return
-
-    try {
-      await removeFeed(savedFeedConfig)
-      // await item.unsave()
-      Toast.show(_(msg`Removed from my feeds`))
-    } catch (e) {
-      Toast.show(_(msg`There was an issue contacting your server`), 'xmark')
-      logger.error('Failed to unsave feed', {message: e})
-    }
-  }, [_, removeFeed, savedFeedConfig])
-
-  const onToggleSaved = React.useCallback(async () => {
-    if (isSaved) {
-      removePromptControl.open()
-    } else {
-      await onSave()
-    }
-  }, [isSaved, removePromptControl, onSave])
 
   /*
    * LOAD STATE
@@ -168,7 +100,7 @@ export function FeedSourceCardLoaded({
    * This state also captures the scenario where a feed can't load for whatever
    * reason.
    */
-  if (!feed || !preferences)
+  if (!feed)
     return (
       <View
         style={[
@@ -186,162 +118,89 @@ export function FeedSourceCardLoaded({
         ]}>
         {showMinimalPlaceholder ? (
           <FeedLoadingPlaceholder
-            style={{flex: 1}}
+            style={[a.flex_1]}
             showTopBorder={false}
             showLowerPlaceholder={false}
           />
         ) : (
-          <FeedLoadingPlaceholder style={{flex: 1}} showTopBorder={false} />
-        )}
-
-        {showSaveBtn && (
-          <Pressable
-            testID={`feed-${feedUri}-toggleSave`}
-            disabled={isRemovePending}
-            accessibilityRole="button"
-            accessibilityLabel={_(msg`Remove from my feeds`)}
-            accessibilityHint=""
-            onPress={onUnsave}
-            hitSlop={15}
-            style={styles.btn}>
-            <FontAwesomeIcon
-              icon={['far', 'trash-can']}
-              size={19}
-              color={pal.colors.icon}
-            />
-          </Pressable>
+          <FeedLoadingPlaceholder style={[a.flex_1]} showTopBorder={false} />
         )}
       </View>
     )
 
   return (
-    <>
-      <Pressable
-        testID={`feed-${feed.displayName}`}
-        accessibilityRole="button"
-        style={[
-          a.flex_1,
-          a.p_lg,
-          a.gap_md,
-          !hideTopBorder && !a.border_t,
-          t.atoms.border_contrast_low,
-          style,
-        ]}
-        onPress={e => {
-          const shouldOpenInNewTab = shouldClickOpenNewTab(e)
-          if (feed.type === 'feed') {
-            if (shouldOpenInNewTab) {
-              Linking.openURL(
-                `/profile/${feed.creatorDid}/feed/${new AtUri(feed.uri).rkey}`,
-              )
-            } else {
-              navigation.push('ProfileFeed', {
-                name: feed.creatorDid,
-                rkey: new AtUri(feed.uri).rkey,
-              })
-            }
-          } else if (feed.type === 'list') {
-            if (shouldOpenInNewTab) {
-              Linking.openURL(
-                `/profile/${feed.creatorDid}/lists/${new AtUri(feed.uri).rkey}`,
-              )
-            } else {
-              navigation.push('ProfileList', {
-                name: feed.creatorDid,
-                rkey: new AtUri(feed.uri).rkey,
-              })
-            }
+    <Pressable
+      testID={`feed-${feed.displayName}`}
+      accessibilityRole="button"
+      style={[
+        a.flex_1,
+        a.p_lg,
+        a.gap_md,
+        !hideTopBorder && !a.border_t,
+        t.atoms.border_contrast_low,
+        style,
+      ]}
+      onPress={e => {
+        const shouldOpenInNewTab = shouldClickOpenNewTab(e)
+        if (feed.type === 'feed') {
+          if (shouldOpenInNewTab) {
+            Linking.openURL(
+              `/profile/${feed.creatorDid}/feed/${new AtUri(feed.uri).rkey}`,
+            )
+          } else {
+            navigation.push('ProfileFeed', {
+              name: feed.creatorDid,
+              rkey: new AtUri(feed.uri).rkey,
+            })
           }
-        }}
-        key={feed.uri}>
-        <View style={[a.flex_row, a.align_center]}>
-          <View style={[s.mr10]}>
-            <UserAvatar type="algo" size={36} avatar={feed.avatar} />
-          </View>
-          <View style={[a.flex_1, a.gap_2xs]}>
-            <Text emoji style={[pal.text, s.bold]} numberOfLines={1}>
-              {feed.displayName}
-            </Text>
-            <Text type="sm" style={[pal.textLight]} numberOfLines={1}>
-              {feed.type === 'feed' ? (
-                <Trans>Feed by {sanitizeHandle(feed.creatorHandle, '@')}</Trans>
-              ) : (
-                <Trans>List by {sanitizeHandle(feed.creatorHandle, '@')}</Trans>
-              )}
-            </Text>
-          </View>
-
-          {showSaveBtn && (
-            <View style={{alignSelf: 'center'}}>
-              <Pressable
-                testID={`feed-${feed.displayName}-toggleSave`}
-                disabled={isAddSavedFeedPending || isRemovePending}
-                accessibilityRole="button"
-                accessibilityLabel={
-                  isSaved
-                    ? _(msg`Remove from my feeds`)
-                    : _(msg`Add to my feeds`)
-                }
-                accessibilityHint=""
-                onPress={onToggleSaved}
-                hitSlop={15}
-                style={styles.btn}>
-                {isSaved ? (
-                  <FontAwesomeIcon
-                    icon={['far', 'trash-can']}
-                    size={19}
-                    color={pal.colors.icon}
-                  />
-                ) : (
-                  <FontAwesomeIcon
-                    icon="plus"
-                    size={18}
-                    color={pal.colors.link}
-                  />
-                )}
-              </Pressable>
-            </View>
-          )}
+        } else if (feed.type === 'list') {
+          if (shouldOpenInNewTab) {
+            Linking.openURL(
+              `/profile/${feed.creatorDid}/lists/${new AtUri(feed.uri).rkey}`,
+            )
+          } else {
+            navigation.push('ProfileList', {
+              name: feed.creatorDid,
+              rkey: new AtUri(feed.uri).rkey,
+            })
+          }
+        }
+      }}
+      key={feed.uri}>
+      <View style={[a.flex_row, a.align_center]}>
+        <View style={[s.mr10]}>
+          <UserAvatar type="algo" size={36} avatar={feed.avatar} />
         </View>
-
-        {showDescription && feed.description ? (
-          <RichText
-            style={[t.atoms.text_contrast_high, a.flex_1, a.flex_wrap]}
-            value={feed.description}
-            numberOfLines={3}
-          />
-        ) : null}
-
-        {showLikes && feed.type === 'feed' ? (
-          <Text type="sm-medium" style={[pal.text, pal.textLight]}>
-            <Trans>
-              Liked by{' '}
-              <Plural
-                value={feed.likeCount || 0}
-                one="# user"
-                other="# users"
-              />
-            </Trans>
+        <View style={[a.flex_1, a.gap_2xs]}>
+          <Text emoji style={[pal.text, s.bold]} numberOfLines={1}>
+            {feed.displayName}
           </Text>
-        ) : null}
-      </Pressable>
+          <Text type="sm" style={[pal.textLight]} numberOfLines={1}>
+            {feed.type === 'feed' ? (
+              <Trans>Feed by {sanitizeHandle(feed.creatorHandle, '@')}</Trans>
+            ) : (
+              <Trans>List by {sanitizeHandle(feed.creatorHandle, '@')}</Trans>
+            )}
+          </Text>
+        </View>
+      </View>
 
-      <Prompt.Basic
-        control={removePromptControl}
-        title={_(msg`Remove from your feeds?`)}
-        description={_(
-          msg`Are you sure you want to remove ${feed.displayName} from your feeds?`,
-        )}
-        onConfirm={onUnsave}
-        confirmButtonCta={_(msg`Remove`)}
-        confirmButtonColor="negative"
-      />
-    </>
+      {showDescription && feed.description ? (
+        <RichText
+          style={[t.atoms.text_contrast_high, a.flex_1, a.flex_wrap]}
+          value={feed.description}
+          numberOfLines={3}
+        />
+      ) : null}
+
+      {showLikes && feed.type === 'feed' ? (
+        <Text type="sm-medium" style={[pal.text, pal.textLight]}>
+          <Trans>
+            Liked by{' '}
+            <Plural value={feed.likeCount || 0} one="# user" other="# users" />
+          </Trans>
+        </Text>
+      ) : null}
+    </Pressable>
   )
 }
-
-const styles = StyleSheet.create({
-  btn: {
-    paddingVertical: 6,
-  },
-})

--- a/src/view/com/feeds/FeedSourceCard.tsx
+++ b/src/view/com/feeds/FeedSourceCard.tsx
@@ -152,15 +152,15 @@ export function FeedSourceCardLoaded({
         <View style={[a.mr_md]}>
           <UserAvatar type="algo" size={36} avatar={feed.avatar} />
         </View>
-        <View style={[a.flex_1, a.gap_xs]}>
+        <View style={[a.flex_1]}>
           <Text
             emoji
-            style={[a.text_md, a.font_bold, a.leading_tight]}
+            style={[a.text_sm, a.font_bold, a.leading_snug]}
             numberOfLines={1}>
             {feed.displayName}
           </Text>
           <Text
-            style={[a.text_sm, t.atoms.text_contrast_medium, a.leading_tight]}
+            style={[a.text_sm, t.atoms.text_contrast_medium, a.leading_snug]}
             numberOfLines={1}>
             {feed.type === 'feed' ? (
               <Trans>Feed by {sanitizeHandle(feed.creatorHandle, '@')}</Trans>
@@ -185,7 +185,7 @@ export function FeedSourceCardLoaded({
             a.text_sm,
             a.font_bold,
             t.atoms.text_contrast_medium,
-            a.leading_tight,
+            a.leading_snug,
           ]}>
           <Trans>
             Liked by{' '}

--- a/src/view/com/feeds/FeedSourceCard.tsx
+++ b/src/view/com/feeds/FeedSourceCard.tsx
@@ -220,10 +220,12 @@ export function FeedSourceCardLoaded({
         testID={`feed-${feed.displayName}`}
         accessibilityRole="button"
         style={[
-          styles.container,
-          pal.border,
+          a.flex_1,
+          a.p_lg,
+          a.gap_md,
+          !hideTopBorder && !a.border_t,
+          t.atoms.border_contrast_low,
           style,
-          {borderTopWidth: hideTopBorder ? 0 : StyleSheet.hairlineWidth},
         ]}
         onPress={e => {
           const shouldOpenInNewTab = shouldClickOpenNewTab(e)
@@ -252,11 +254,11 @@ export function FeedSourceCardLoaded({
           }
         }}
         key={feed.uri}>
-        <View style={[styles.headerContainer, a.align_center]}>
+        <View style={[a.flex_row, a.align_center]}>
           <View style={[s.mr10]}>
             <UserAvatar type="algo" size={36} avatar={feed.avatar} />
           </View>
-          <View style={[styles.headerTextContainer]}>
+          <View style={[a.flex_1, a.gap_2xs]}>
             <Text emoji style={[pal.text, s.bold]} numberOfLines={1}>
               {feed.displayName}
             </Text>
@@ -304,7 +306,7 @@ export function FeedSourceCardLoaded({
 
         {showDescription && feed.description ? (
           <RichText
-            style={[t.atoms.text_contrast_high, styles.description]}
+            style={[t.atoms.text_contrast_high, a.flex_1, a.flex_wrap]}
             value={feed.description}
             numberOfLines={3}
           />
@@ -339,28 +341,6 @@ export function FeedSourceCardLoaded({
 }
 
 const styles = StyleSheet.create({
-  container: {
-    paddingHorizontal: 18,
-    paddingVertical: 20,
-    flexDirection: 'column',
-    flex: 1,
-    gap: 14,
-  },
-  border: {
-    borderTopWidth: StyleSheet.hairlineWidth,
-  },
-  headerContainer: {
-    flexDirection: 'row',
-  },
-  headerTextContainer: {
-    flexDirection: 'column',
-    columnGap: 4,
-    flex: 1,
-  },
-  description: {
-    flex: 1,
-    flexWrap: 'wrap',
-  },
   btn: {
     paddingVertical: 6,
   },

--- a/src/view/com/notifications/NotificationFeedItem.tsx
+++ b/src/view/com/notifications/NotificationFeedItem.tsx
@@ -625,6 +625,7 @@ let NotificationFeedItem = ({
                   t.atoms.bg,
                   t.atoms.border_contrast_low,
                   a.border,
+                  a.p_md,
                   styles.feedcard,
                 ]}
                 showLikes
@@ -950,7 +951,6 @@ const styles = StyleSheet.create({
   },
   feedcard: {
     borderRadius: 8,
-    paddingVertical: 12,
     marginTop: 6,
   },
   addedContainer: {

--- a/src/view/com/util/LoadingPlaceholder.tsx
+++ b/src/view/com/util/LoadingPlaceholder.tsx
@@ -1,10 +1,10 @@
 import {useMemo} from 'react'
 import {
-  DimensionValue,
-  StyleProp,
+  type DimensionValue,
+  type StyleProp,
   StyleSheet,
   View,
-  ViewStyle,
+  type ViewStyle,
 } from 'react-native'
 
 import {usePalette} from '#/lib/hooks/usePalette'
@@ -234,7 +234,7 @@ export function FeedLoadingPlaceholder({
       style={[
         {
           paddingHorizontal: 12,
-          paddingVertical: 18,
+          paddingVertical: 20,
           borderTopWidth: showTopBorder ? StyleSheet.hairlineWidth : 0,
         },
         pal.border,

--- a/src/view/com/util/LoadingPlaceholder.tsx
+++ b/src/view/com/util/LoadingPlaceholder.tsx
@@ -233,8 +233,7 @@ export function FeedLoadingPlaceholder({
     <View
       style={[
         {
-          paddingHorizontal: 16,
-          paddingVertical: 16,
+          padding: 16,
           borderTopWidth: showTopBorder ? StyleSheet.hairlineWidth : 0,
         },
         pal.border,
@@ -252,12 +251,7 @@ export function FeedLoadingPlaceholder({
         </View>
       </View>
       {showLowerPlaceholder && (
-        <View style={{paddingHorizontal: 5, marginTop: 10}}>
-          <LoadingPlaceholder
-            width={260}
-            height={8}
-            style={{marginVertical: 12}}
-          />
+        <View style={{marginTop: 12}}>
           <LoadingPlaceholder width={120} height={8} />
         </View>
       )}
@@ -352,7 +346,7 @@ const styles = StyleSheet.create({
   },
   avatar: {
     borderRadius: 999,
-    marginRight: 10,
+    marginRight: 12,
   },
   notification: {
     flexDirection: 'row',

--- a/src/view/com/util/LoadingPlaceholder.tsx
+++ b/src/view/com/util/LoadingPlaceholder.tsx
@@ -233,8 +233,8 @@ export function FeedLoadingPlaceholder({
     <View
       style={[
         {
-          paddingHorizontal: 12,
-          paddingVertical: 20,
+          paddingHorizontal: 16,
+          paddingVertical: 16,
           borderTopWidth: showTopBorder ? StyleSheet.hairlineWidth : 0,
         },
         pal.border,
@@ -353,7 +353,6 @@ const styles = StyleSheet.create({
   avatar: {
     borderRadius: 999,
     marginRight: 10,
-    marginLeft: 8,
   },
   notification: {
     flexDirection: 'row',

--- a/src/view/screens/SavedFeeds.tsx
+++ b/src/view/screens/SavedFeeds.tsx
@@ -1,25 +1,28 @@
 import React from 'react'
 import {ActivityIndicator, Pressable, StyleSheet, View} from 'react-native'
 import Animated, {LinearTransition} from 'react-native-reanimated'
-import {AppBskyActorDefs} from '@atproto/api'
+import {type AppBskyActorDefs} from '@atproto/api'
 import {FontAwesomeIcon} from '@fortawesome/react-native-fontawesome'
 import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 import {useFocusEffect} from '@react-navigation/native'
 import {useNavigation} from '@react-navigation/native'
-import {NativeStackScreenProps} from '@react-navigation/native-stack'
+import {type NativeStackScreenProps} from '@react-navigation/native-stack'
 
 import {useHaptics} from '#/lib/haptics'
 import {usePalette} from '#/lib/hooks/usePalette'
 import {useWebMediaQueries} from '#/lib/hooks/useWebMediaQueries'
-import {CommonNavigatorParams, NavigationProp} from '#/lib/routes/types'
+import {
+  type CommonNavigatorParams,
+  type NavigationProp,
+} from '#/lib/routes/types'
 import {colors, s} from '#/lib/styles'
 import {logger} from '#/logger'
 import {
   useOverwriteSavedFeedsMutation,
   usePreferencesQuery,
 } from '#/state/queries/preferences'
-import {UsePreferencesQueryResponse} from '#/state/queries/preferences/types'
+import {type UsePreferencesQueryResponse} from '#/state/queries/preferences/types'
 import {useSetMinimalShellMode} from '#/state/shell'
 import {FeedSourceCard} from '#/view/com/feeds/FeedSourceCard'
 import {TextLink} from '#/view/com/util/Link'

--- a/src/view/screens/SavedFeeds.tsx
+++ b/src/view/screens/SavedFeeds.tsx
@@ -393,8 +393,8 @@ function FollowingFeedCard() {
         a.align_center,
         a.flex_1,
         {
-          paddingHorizontal: 18,
-          paddingVertical: 20,
+          paddingHorizontal: 16,
+          paddingVertical: 16,
         },
       ]}>
       <View

--- a/src/view/screens/SavedFeeds.tsx
+++ b/src/view/screens/SavedFeeds.tsx
@@ -292,7 +292,7 @@ function ListItem({
         <FeedSourceCard
           key={feedUri}
           feedUri={feedUri}
-          style={[isPinned && {paddingRight: 8}]}
+          style={[isPinned && a.pr_sm]}
           showMinimalPlaceholder
           hideTopBorder={true}
         />
@@ -387,26 +387,17 @@ function ListItem({
 function FollowingFeedCard() {
   const t = useTheme()
   return (
-    <View
-      style={[
-        a.flex_row,
-        a.align_center,
-        a.flex_1,
-        {
-          paddingHorizontal: 16,
-          paddingVertical: 16,
-        },
-      ]}>
+    <View style={[a.flex_row, a.align_center, a.flex_1, a.p_lg]}>
       <View
         style={[
           a.align_center,
           a.justify_center,
           a.rounded_sm,
+          a.mr_md,
           {
             width: 36,
             height: 36,
             backgroundColor: t.palette.primary_500,
-            marginRight: 10,
           },
         ]}>
         <FilterTimeline
@@ -419,8 +410,7 @@ function FollowingFeedCard() {
           fill={t.palette.white}
         />
       </View>
-      <View
-        style={{flex: 1, flexDirection: 'row', gap: 8, alignItems: 'center'}}>
+      <View style={[a.flex_1, a.flex_row, a.gap_sm, a.align_center]}>
         <Text type="lg-medium" style={[t.atoms.text]} numberOfLines={1}>
           <Trans>Following</Trans>
         </Text>


### PR DESCRIPTION
There's currently a bug with feed embeds in posts - they flash a loading state, even though they have the requisite data already. I spend a bunch of time cleaning up the legacy feed card before realising we should just swap in the new `FeedCard` component in `/Post/Embed/FeedEmbed.tsx` - really simple. But all the other tweaks have now fixed layout shifts from the skeletons in notifications and in the feeds edit screen

Reduced layout shift in notifications:

https://github.com/user-attachments/assets/f11cd865-48a9-4c12-a9c0-5ad8c0654418

Zero layout shift in Edit feeds

https://github.com/user-attachments/assets/f9ba6656-f61b-4865-bbad-6ecfaf957fc0

# Test plan

See that there's no loading state on a post with a feed embed https://bsky.app/profile/samuel.bsky.team/post/3lsl5ptbwfc2z

See that there's no layout shifts in edit feeds

