### PR TITLE
Better dead feed handling

### DIFF
--- a/src/components/Divider.tsx
+++ b/src/components/Divider.tsx
@@ -1,18 +1,11 @@
 import {View} from 'react-native'
 
-import {atoms as a, flatten, useTheme, ViewStyleProp} from '#/alf'
+import {atoms as a, useTheme, type ViewStyleProp} from '#/alf'
 
 export function Divider({style}: ViewStyleProp) {
   const t = useTheme()
 
   return (
-    <View
-      style={[
-        a.w_full,
-        a.border_t,
-        t.atoms.border_contrast_low,
-        flatten(style),
-      ]}
-    />
+    <View style={[a.w_full, a.border_t, t.atoms.border_contrast_low, style]} />
   )
 }

--- a/src/components/Post/Embed/FeedEmbed.tsx
+++ b/src/components/Post/Embed/FeedEmbed.tsx
@@ -44,7 +44,9 @@ export function ModeratedFeedEmbed({
       : undefined
   }, [embed.view, moderationOpts])
   return (
-    <ContentHider modui={moderation?.ui('contentList')}>
+    <ContentHider
+      modui={moderation?.ui('contentList')}
+      childContainerStyle={[a.pt_xs]}>
       <FeedEmbed embed={embed} />
     </ContentHider>
   )

--- a/src/view/com/feeds/FeedSourceCard.tsx
+++ b/src/view/com/feeds/FeedSourceCard.tsx
@@ -8,6 +8,7 @@ import {
 import {msg, Plural, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
+import {cleanError} from '#/lib/strings/errors'
 import {sanitizeHandle} from '#/lib/strings/handles'
 import {isNative, isWeb} from '#/platform/detection'
 import {useModerationOpts} from '#/state/preferences/moderation-opts'
@@ -362,7 +363,7 @@ function MissingFeed({
                   <Trans>Error message</Trans>
                 </Text>
                 <Text style={[a.text_md, t.atoms.text_contrast_high, a.italic]}>
-                  {error.message}
+                  {cleanError(error.message)}
                 </Text>
               </>
             )}

--- a/src/view/com/feeds/FeedSourceCard.tsx
+++ b/src/view/com/feeds/FeedSourceCard.tsx
@@ -8,29 +8,20 @@ import {
 import {msg, Plural, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
-import {cleanError} from '#/lib/strings/errors'
 import {sanitizeHandle} from '#/lib/strings/handles'
-import {isNative, isWeb} from '#/platform/detection'
-import {useModerationOpts} from '#/state/preferences/moderation-opts'
 import {
   type FeedSourceInfo,
-  getFeedTypeFromUri,
   hydrateFeedGenerator,
   hydrateList,
   useFeedSourceInfoQuery,
 } from '#/state/queries/feed'
-import {useProfileQuery} from '#/state/queries/profile'
 import {FeedLoadingPlaceholder} from '#/view/com/util/LoadingPlaceholder'
 import {UserAvatar} from '#/view/com/util/UserAvatar'
-import {atoms as a, useTheme, web} from '#/alf'
-import {Button, ButtonText} from '#/components/Button'
-import * as Dialog from '#/components/Dialog'
-import {Divider} from '#/components/Divider'
-import {Warning_Stroke2_Corner0_Rounded as WarningIcon} from '#/components/icons/Warning'
+import {atoms as a, useTheme} from '#/alf'
 import {Link} from '#/components/Link'
-import * as ProfileCard from '#/components/ProfileCard'
 import {RichText} from '#/components/RichText'
 import {Text} from '#/components/Typography'
+import {MissingFeed} from './MissingFeed'
 
 type FeedSourceCardProps = {
   feedUri: string
@@ -226,194 +217,4 @@ export function FeedSourceCardLoaded({
       </View>
     )
   }
-}
-
-function MissingFeed({
-  style,
-  hideTopBorder,
-  uri,
-  error,
-}: {
-  style?: StyleProp<ViewStyle>
-  hideTopBorder?: boolean
-  uri: string
-  error?: unknown
-}) {
-  const t = useTheme()
-  const {_} = useLingui()
-  const atUri = new AtUri(uri)
-  const {data: profile, isError: isProfileError} = useProfileQuery({
-    did: atUri.host,
-  })
-  const moderationOpts = useModerationOpts()
-  const control = Dialog.useDialogControl()
-
-  const type = getFeedTypeFromUri(uri)
-
-  return (
-    <>
-      <Button
-        label={
-          type === 'feed'
-            ? _(msg`Could not connect to custom feed`)
-            : _(msg`Deleted list`)
-        }
-        accessibilityHint={_(msg`Tap for more information`)}
-        onPress={control.open}
-        style={[
-          a.flex_1,
-          a.p_lg,
-          a.gap_md,
-          !hideTopBorder && !a.border_t,
-          t.atoms.border_contrast_low,
-          a.justify_start,
-          style,
-        ]}>
-        <View style={[a.flex_row, a.align_center]}>
-          <View
-            style={[
-              {width: 36, height: 36},
-              t.atoms.bg_contrast_25,
-              a.rounded_sm,
-              a.mr_md,
-              a.align_center,
-              a.justify_center,
-            ]}>
-            <WarningIcon size="lg" />
-          </View>
-          <View style={[a.flex_1]}>
-            <Text
-              emoji
-              style={[a.text_sm, a.font_bold, a.leading_snug, a.italic]}
-              numberOfLines={1}>
-              {type === 'feed' ? (
-                <Trans>Feed unavailable</Trans>
-              ) : (
-                <Trans>Deleted list</Trans>
-              )}
-            </Text>
-            <Text
-              style={[
-                a.text_sm,
-                t.atoms.text_contrast_medium,
-                a.leading_snug,
-                a.italic,
-              ]}
-              numberOfLines={1}>
-              {isWeb ? (
-                <Trans>Click for information</Trans>
-              ) : (
-                <Trans>Tap for information</Trans>
-              )}
-            </Text>
-          </View>
-        </View>
-      </Button>
-
-      <Dialog.Outer control={control} nativeOptions={{preventExpansion: true}}>
-        <Dialog.Handle />
-
-        <Dialog.ScrollableInner
-          label={_(msg`Unavailable feed information`)}
-          style={web({maxWidth: 500})}>
-          <View style={[a.gap_sm]}>
-            <Text style={[a.font_heavy, a.text_2xl]}>
-              {type === 'feed' ? (
-                <Trans>Could not connect to feed service</Trans>
-              ) : (
-                <Trans>Deleted list</Trans>
-              )}
-            </Text>
-            <Text style={[t.atoms.text_contrast_high, a.leading_snug]}>
-              {type === 'feed' ? (
-                <Trans>
-                  We could not connect to the service that provides this custom
-                  feed. It may be temporarily unavailable and experiencing
-                  issues, or permanently unavailable.
-                </Trans>
-              ) : (
-                <Trans>
-                  We could not find this list. It was probably deleted.
-                </Trans>
-              )}
-            </Text>
-            <Divider style={[a.my_md]} />
-            <Text style={[a.font_bold, t.atoms.text_contrast_high]}>
-              {type === 'feed' ? (
-                <Trans>Feed creator</Trans>
-              ) : (
-                <Trans>List creator</Trans>
-              )}
-            </Text>
-            {profile && moderationOpts && (
-              <View style={[a.w_full, a.align_start]}>
-                <ProfileCard.Link
-                  profile={profile}
-                  onPress={() => control.close()}>
-                  <ProfileCard.Header>
-                    <ProfileCard.Avatar
-                      profile={profile}
-                      moderationOpts={moderationOpts}
-                      disabledPreview
-                    />
-                    <ProfileCard.NameAndHandle
-                      profile={profile}
-                      moderationOpts={moderationOpts}
-                    />
-                  </ProfileCard.Header>
-                </ProfileCard.Link>
-              </View>
-            )}
-            {isProfileError && (
-              <Text
-                style={[
-                  t.atoms.text_contrast_high,
-                  a.italic,
-                  a.text_center,
-                  a.w_full,
-                ]}>
-                <Trans>Could not find profile</Trans>
-              </Text>
-            )}
-            {type === 'feed' && (
-              <>
-                <Text
-                  style={[a.font_bold, t.atoms.text_contrast_high, a.mt_md]}>
-                  <Trans>Feed identifier</Trans>
-                </Text>
-                <Text style={[a.text_md, t.atoms.text_contrast_high, a.italic]}>
-                  {atUri.rkey}
-                </Text>
-              </>
-            )}
-            {error instanceof Error && (
-              <>
-                <Text
-                  style={[a.font_bold, t.atoms.text_contrast_high, a.mt_md]}>
-                  <Trans>Error message</Trans>
-                </Text>
-                <Text style={[a.text_md, t.atoms.text_contrast_high, a.italic]}>
-                  {cleanError(error.message)}
-                </Text>
-              </>
-            )}
-          </View>
-          {isNative && (
-            <Button
-              label={_(msg`Close`)}
-              onPress={() => control.close()}
-              size="small"
-              variant="solid"
-              color="secondary"
-              style={[a.mt_5xl]}>
-              <ButtonText>
-                <Trans>Close</Trans>
-              </ButtonText>
-            </Button>
-          )}
-          <Dialog.Close />
-        </Dialog.ScrollableInner>
-      </Dialog.Outer>
-    </>
-  )
 }

--- a/src/view/com/feeds/FeedSourceCard.tsx
+++ b/src/view/com/feeds/FeedSourceCard.tsx
@@ -14,6 +14,7 @@ import {isNative, isWeb} from '#/platform/detection'
 import {useModerationOpts} from '#/state/preferences/moderation-opts'
 import {
   type FeedSourceInfo,
+  getFeedTypeFromUri,
   hydrateFeedGenerator,
   hydrateList,
   useFeedSourceInfoQuery,
@@ -25,7 +26,7 @@ import {atoms as a, useTheme, web} from '#/alf'
 import {Button, ButtonText} from '#/components/Button'
 import * as Dialog from '#/components/Dialog'
 import {Divider} from '#/components/Divider'
-import {Warning_Stroke2_Corner0_Rounded} from '#/components/icons/Warning'
+import {Warning_Stroke2_Corner0_Rounded as WarningIcon} from '#/components/icons/Warning'
 import {Link} from '#/components/Link'
 import * as ProfileCard from '#/components/ProfileCard'
 import {RichText} from '#/components/RichText'
@@ -247,10 +248,16 @@ function MissingFeed({
   const moderationOpts = useModerationOpts()
   const control = Dialog.useDialogControl()
 
+  const type = getFeedTypeFromUri(uri)
+
   return (
     <>
       <Button
-        label={_(msg`Could not connect to custom feed`)}
+        label={
+          type === 'feed'
+            ? _(msg`Could not connect to custom feed`)
+            : _(msg`Deleted list`)
+        }
         accessibilityHint={_(msg`Tap for more information`)}
         onPress={control.open}
         style={[
@@ -272,14 +279,18 @@ function MissingFeed({
               a.align_center,
               a.justify_center,
             ]}>
-            <Warning_Stroke2_Corner0_Rounded size="lg" />
+            <WarningIcon size="lg" />
           </View>
           <View style={[a.flex_1]}>
             <Text
               emoji
               style={[a.text_sm, a.font_bold, a.leading_snug, a.italic]}
               numberOfLines={1}>
-              <Trans>Feed unavailable</Trans>
+              {type === 'feed' ? (
+                <Trans>Feed unavailable</Trans>
+              ) : (
+                <Trans>Deleted list</Trans>
+              )}
             </Text>
             <Text
               style={[
@@ -307,18 +318,32 @@ function MissingFeed({
           style={web({maxWidth: 500})}>
           <View style={[a.gap_sm]}>
             <Text style={[a.font_heavy, a.text_2xl]}>
-              <Trans>Could not connect to feed service</Trans>
+              {type === 'feed' ? (
+                <Trans>Could not connect to feed service</Trans>
+              ) : (
+                <Trans>Deleted list</Trans>
+              )}
             </Text>
             <Text style={[t.atoms.text_contrast_high, a.leading_snug]}>
-              <Trans>
-                We could not connect to the service that provides this custom
-                feed. It may be temporarily unavailable and experiencing issues,
-                or permanently unavailable.
-              </Trans>
+              {type === 'feed' ? (
+                <Trans>
+                  We could not connect to the service that provides this custom
+                  feed. It may be temporarily unavailable and experiencing
+                  issues, or permanently unavailable.
+                </Trans>
+              ) : (
+                <Trans>
+                  We could not find this list. It was probably deleted.
+                </Trans>
+              )}
             </Text>
             <Divider style={[a.my_md]} />
             <Text style={[a.font_bold, t.atoms.text_contrast_high]}>
-              <Trans>Feed creator</Trans>
+              {type === 'feed' ? (
+                <Trans>Feed creator</Trans>
+              ) : (
+                <Trans>List creator</Trans>
+              )}
             </Text>
             {profile && moderationOpts && (
               <View style={[a.w_full, a.align_start]}>
@@ -350,12 +375,17 @@ function MissingFeed({
                 <Trans>Could not find profile</Trans>
               </Text>
             )}
-            <Text style={[a.font_bold, t.atoms.text_contrast_high, a.mt_md]}>
-              <Trans>Feed identifier</Trans>
-            </Text>
-            <Text style={[a.text_md, t.atoms.text_contrast_high, a.italic]}>
-              {atUri.rkey}
-            </Text>
+            {type === 'feed' && (
+              <>
+                <Text
+                  style={[a.font_bold, t.atoms.text_contrast_high, a.mt_md]}>
+                  <Trans>Feed identifier</Trans>
+                </Text>
+                <Text style={[a.text_md, t.atoms.text_contrast_high, a.italic]}>
+                  {atUri.rkey}
+                </Text>
+              </>
+            )}
             {error instanceof Error && (
               <>
                 <Text

--- a/src/view/com/feeds/MissingFeed.tsx
+++ b/src/view/com/feeds/MissingFeed.tsx
@@ -1,0 +1,222 @@
+import {type StyleProp, View, type ViewStyle} from 'react-native'
+import {AtUri} from '@atproto/api'
+import {msg, Trans} from '@lingui/macro'
+import {useLingui} from '@lingui/react'
+
+import {cleanError} from '#/lib/strings/errors'
+import {isNative, isWeb} from '#/platform/detection'
+import {useModerationOpts} from '#/state/preferences/moderation-opts'
+import {getFeedTypeFromUri} from '#/state/queries/feed'
+import {useProfileQuery} from '#/state/queries/profile'
+import {atoms as a, useTheme, web} from '#/alf'
+import {Button, ButtonText} from '#/components/Button'
+import * as Dialog from '#/components/Dialog'
+import {Divider} from '#/components/Divider'
+import {Warning_Stroke2_Corner0_Rounded as WarningIcon} from '#/components/icons/Warning'
+import * as ProfileCard from '#/components/ProfileCard'
+import {Text} from '#/components/Typography'
+
+export function MissingFeed({
+  style,
+  hideTopBorder,
+  uri,
+  error,
+}: {
+  style?: StyleProp<ViewStyle>
+  hideTopBorder?: boolean
+  uri: string
+  error?: unknown
+}) {
+  const t = useTheme()
+  const {_} = useLingui()
+  const control = Dialog.useDialogControl()
+
+  const type = getFeedTypeFromUri(uri)
+
+  return (
+    <>
+      <Button
+        label={
+          type === 'feed'
+            ? _(msg`Could not connect to custom feed`)
+            : _(msg`Deleted list`)
+        }
+        accessibilityHint={_(msg`Tap for more information`)}
+        onPress={control.open}
+        style={[
+          a.flex_1,
+          a.p_lg,
+          a.gap_md,
+          !hideTopBorder && !a.border_t,
+          t.atoms.border_contrast_low,
+          a.justify_start,
+          style,
+        ]}>
+        <View style={[a.flex_row, a.align_center]}>
+          <View
+            style={[
+              {width: 36, height: 36},
+              t.atoms.bg_contrast_25,
+              a.rounded_sm,
+              a.mr_md,
+              a.align_center,
+              a.justify_center,
+            ]}>
+            <WarningIcon size="lg" />
+          </View>
+          <View style={[a.flex_1]}>
+            <Text
+              emoji
+              style={[a.text_sm, a.font_bold, a.leading_snug, a.italic]}
+              numberOfLines={1}>
+              {type === 'feed' ? (
+                <Trans>Feed unavailable</Trans>
+              ) : (
+                <Trans>Deleted list</Trans>
+              )}
+            </Text>
+            <Text
+              style={[
+                a.text_sm,
+                t.atoms.text_contrast_medium,
+                a.leading_snug,
+                a.italic,
+              ]}
+              numberOfLines={1}>
+              {isWeb ? (
+                <Trans>Click for information</Trans>
+              ) : (
+                <Trans>Tap for information</Trans>
+              )}
+            </Text>
+          </View>
+        </View>
+      </Button>
+
+      <Dialog.Outer control={control} nativeOptions={{preventExpansion: true}}>
+        <Dialog.Handle />
+        <DialogInner uri={uri} type={type} error={error} />
+      </Dialog.Outer>
+    </>
+  )
+}
+
+function DialogInner({
+  uri,
+  type,
+  error,
+}: {
+  uri: string
+  type: 'feed' | 'list'
+  error: unknown
+}) {
+  const control = Dialog.useDialogContext()
+  const t = useTheme()
+  const {_} = useLingui()
+  const atUri = new AtUri(uri)
+  const {data: profile, isError: isProfileError} = useProfileQuery({
+    did: atUri.host,
+  })
+  const moderationOpts = useModerationOpts()
+
+  return (
+    <Dialog.ScrollableInner
+      label={
+        type === 'feed'
+          ? _(msg`Unavailable feed information`)
+          : _(msg`Deleted list`)
+      }
+      style={web({maxWidth: 500})}>
+      <View style={[a.gap_sm]}>
+        <Text style={[a.font_heavy, a.text_2xl]}>
+          {type === 'feed' ? (
+            <Trans>Could not connect to feed service</Trans>
+          ) : (
+            <Trans>Deleted list</Trans>
+          )}
+        </Text>
+        <Text style={[t.atoms.text_contrast_high, a.leading_snug]}>
+          {type === 'feed' ? (
+            <Trans>
+              We could not connect to the service that provides this custom
+              feed. It may be temporarily unavailable and experiencing issues,
+              or permanently unavailable.
+            </Trans>
+          ) : (
+            <Trans>We could not find this list. It was probably deleted.</Trans>
+          )}
+        </Text>
+        <Divider style={[a.my_md]} />
+        <Text style={[a.font_bold, t.atoms.text_contrast_high]}>
+          {type === 'feed' ? (
+            <Trans>Feed creator</Trans>
+          ) : (
+            <Trans>List creator</Trans>
+          )}
+        </Text>
+        {profile && moderationOpts && (
+          <View style={[a.w_full, a.align_start]}>
+            <ProfileCard.Link profile={profile} onPress={() => control.close()}>
+              <ProfileCard.Header>
+                <ProfileCard.Avatar
+                  profile={profile}
+                  moderationOpts={moderationOpts}
+                  disabledPreview
+                />
+                <ProfileCard.NameAndHandle
+                  profile={profile}
+                  moderationOpts={moderationOpts}
+                />
+              </ProfileCard.Header>
+            </ProfileCard.Link>
+          </View>
+        )}
+        {isProfileError && (
+          <Text
+            style={[
+              t.atoms.text_contrast_high,
+              a.italic,
+              a.text_center,
+              a.w_full,
+            ]}>
+            <Trans>Could not find profile</Trans>
+          </Text>
+        )}
+        {type === 'feed' && (
+          <>
+            <Text style={[a.font_bold, t.atoms.text_contrast_high, a.mt_md]}>
+              <Trans>Feed identifier</Trans>
+            </Text>
+            <Text style={[a.text_md, t.atoms.text_contrast_high, a.italic]}>
+              {atUri.rkey}
+            </Text>
+          </>
+        )}
+        {error instanceof Error && (
+          <>
+            <Text style={[a.font_bold, t.atoms.text_contrast_high, a.mt_md]}>
+              <Trans>Error message</Trans>
+            </Text>
+            <Text style={[a.text_md, t.atoms.text_contrast_high, a.italic]}>
+              {cleanError(error.message)}
+            </Text>
+          </>
+        )}
+      </View>
+      {isNative && (
+        <Button
+          label={_(msg`Close`)}
+          onPress={() => control.close()}
+          size="small"
+          variant="solid"
+          color="secondary"
+          style={[a.mt_5xl]}>
+          <ButtonText>
+            <Trans>Close</Trans>
+          </ButtonText>
+        </Button>
+      )}
+      <Dialog.Close />
+    </Dialog.ScrollableInner>
+  )
+}

--- a/src/view/com/util/LoadingPlaceholder.tsx
+++ b/src/view/com/util/LoadingPlaceholder.tsx
@@ -243,7 +243,7 @@ export function FeedLoadingPlaceholder({
         <LoadingPlaceholder
           width={36}
           height={36}
-          style={[styles.avatar, {borderRadius: 6}]}
+          style={[styles.avatar, {borderRadius: 8}]}
         />
         <View style={[s.flex1]}>
           <LoadingPlaceholder width={100} height={8} style={[s.mt5, s.mb10]} />


### PR DESCRIPTION
# Stacked on #8578 

Currently we just show a perma-loading state for dead feeds, which sucks. This adds a little info popup so you can actually find out what the feed is

"click for information" is a bit awkward but since it's an edge case it's probably best to be clear and awkward rather than stylish and obtuse


<table>
  <thead>
    <tr>
      <th>Web</th>
      <th>Web</th>
      <th>Native</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><img width="300" src="https://github.com/user-attachments/assets/fe749062-ba63-45bc-acf5-cae7e4d49ab5" /></td>
      <td><img width="300" src="https://github.com/user-attachments/assets/17c3754f-239f-4bf9-9cfe-0b2d0b7f6c99" /></td>
      <td><img width="200" src="https://github.com/user-attachments/assets/705eba95-3cd0-44f3-ba40-6f5a429785fd" /></td>
    </tr>
  </tbody>
</table>

Also includes handling of deleted lists

<img width="300" alt="Screenshot 2025-06-27 at 14 07 28" src="https://github.com/user-attachments/assets/b8875aeb-dd00-4ec0-ac61-1e0fb2146a5b" />
