### PR TITLE
Tweak string in Content Languages modal

### DIFF
--- a/src/view/com/modals/lang-settings/ContentLanguagesSettings.tsx
+++ b/src/view/com/modals/lang-settings/ContentLanguagesSettings.tsx
@@ -81,7 +81,7 @@ export function Component({}: {}) {
         </Trans>
       </Text>
       <Text style={[pal.textLight, styles.description]}>
-        <Trans>Leave them all unchecked to see any language.</Trans>
+        <Trans>Leave them all unselected to see any language.</Trans>
       </Text>
       <ScrollView style={styles.scrollContainer}>
         {languages.map(lang => (


### PR DESCRIPTION
As [mentioned on Crowdin](https://bluesky.crowdin.com/editor/1/11/en-gd/9?view=comfortable#1629), the current string shown in the **Content Languages** modal could perhaps be a little clearer, as even on web they are toggle switches rather than checkboxes:

![IMG_7348](https://github.com/user-attachments/assets/e4294050-5d35-41f6-bda2-0cff02270cce)

This PR proposes tweaking it from `unchecked` ➡️ `unselected`

cc: @akerbeltz