### PR TITLE
Improve post spacing

### DIFF
--- a/src/components/PostControls/index.tsx
+++ b/src/components/PostControls/index.tsx
@@ -185,7 +185,14 @@ let PostControls = ({
   }
 
   return (
-    <View style={[a.flex_row, a.justify_between, a.align_center, style]}>
+    <View
+      style={[
+        a.flex_row,
+        a.justify_between,
+        a.align_center,
+        !big && a.pt_2xs,
+        style,
+      ]}>
       <View
         style={[
           big ? a.align_center : [a.flex_1, a.align_start, {marginLeft: -6}],

--- a/src/screens/PostThread/components/ThreadItemTreePost.tsx
+++ b/src/screens/PostThread/components/ThreadItemTreePost.tsx
@@ -218,17 +218,13 @@ const ThreadItemTreeReplyChildReplyLine = memo(
   }) {
     const t = useTheme()
     return (
-      <View style={[a.relative, {width: TREE_AVI_PLUS_SPACE}]}>
+      <View style={[a.relative, a.pt_2xs, {width: TREE_AVI_PLUS_SPACE}]}>
         {item.ui.showChildReplyLine && (
           <View
             style={[
               a.flex_1,
               t.atoms.border_contrast_low,
-              {
-                borderRightWidth: 2,
-                width: '50%',
-                left: -1,
-              },
+              {borderRightWidth: 2, width: '50%', left: -1},
             ]}
           />
         )}
@@ -331,7 +327,7 @@ const ThreadItemTreePostInner = memo(function ThreadItemTreePostInner({
                 timestamp={post.indexedAt}
                 postHref={postHref}
                 avatarSize={TREE_AVI_WIDTH}
-                style={[a.pb_2xs]}
+                style={[a.pb_0]}
                 showAvatar
               />
               <View style={[a.flex_row]}>
@@ -360,7 +356,7 @@ const ThreadItemTreePostInner = memo(function ThreadItemTreePostInner({
                         />
                       )}
                     </>
-                  ) : undefined}
+                  ) : null}
                   {post.embed && (
                     <View style={[a.pb_xs]}>
                       <Embed

--- a/src/screens/PostThread/components/ThreadItemTreePost.tsx
+++ b/src/screens/PostThread/components/ThreadItemTreePost.tsx
@@ -332,7 +332,7 @@ const ThreadItemTreePostInner = memo(function ThreadItemTreePostInner({
               />
               <View style={[a.flex_row]}>
                 <ThreadItemTreeReplyChildReplyLine item={item} />
-                <View style={[a.flex_1]}>
+                <View style={[a.flex_1, a.pl_2xs]}>
                   <LabelsOnMyPost post={post} style={[a.pb_2xs]} />
                   <PostAlerts
                     modui={moderation.ui('contentList')}

--- a/src/view/com/posts/PostFeedItem.tsx
+++ b/src/view/com/posts/PostFeedItem.tsx
@@ -319,7 +319,7 @@ let FeedItemInner = ({
           )}
         </View>
 
-        <View style={{paddingTop: 12, flexShrink: 1}}>
+        <View style={{paddingTop: 10, flexShrink: 1}}>
           {isReasonFeedSource(reason) ? (
             <Link href={reason.href}>
               <Text
@@ -660,7 +660,6 @@ const styles = StyleSheet.create({
   includeReason: {
     flexDirection: 'row',
     alignItems: 'center',
-    marginTop: 2,
     marginBottom: 2,
     marginLeft: -16,
   },


### PR DESCRIPTION
- Added top padding to PostControls
- Reduced padding between PostMeta and content in treeview by only adding gap to line, not whole row (avi was pushing content down)
- Line up content with display name (6px gap between avi and name)
- Reduce top padding of feed posts (currently 12px, which is far bigger than the other sides. changed to 10px)

<table>
  <thead>
    <tr>
      <th>Before</th>
      <th>After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><img width="400" src="https://github.com/user-attachments/assets/c9493a2a-735b-4a1f-8358-91a708f4d095" /></td>
      <td><img width="400" src="https://github.com/user-attachments/assets/58eb0d29-b9c8-45af-81d7-011b73e1a6fb" /></td>
    </tr>
  </tbody>
</table>

<table>
  <thead>
    <tr>
      <th>Before</th>
      <th>After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><img width="400" src="https://github.com/user-attachments/assets/1aff0fec-dbc2-4f2e-9554-401dfefdbfc5" /></td>
      <td><img width="400" src="https://github.com/user-attachments/assets/6a32b87f-7ee2-4f92-8055-9d66d5ff97d7" /></td>
    </tr>
  </tbody>
</table>
