### PR TITLE
Clean up GIF Search Placeholder Text

### DIFF
--- a/src/components/dialogs/GifSelect.tsx
+++ b/src/components/dialogs/GifSelect.tsx
@@ -5,7 +5,7 @@ import React, {
   useRef,
   useState,
 } from 'react'
-import {TextInput, View} from 'react-native'
+import {type TextInput, View} from 'react-native'
 import {useWindowDimensions} from 'react-native'
 import {Image} from 'expo-image'
 import {msg, Trans} from '@lingui/macro'
@@ -15,13 +15,13 @@ import {logEvent} from '#/lib/statsig/statsig'
 import {cleanError} from '#/lib/strings/errors'
 import {isWeb} from '#/platform/detection'
 import {
-  Gif,
+  type Gif,
   useFeaturedGifsQuery,
   useGifSearchQuery,
 } from '#/state/queries/tenor'
 import {ErrorScreen} from '#/view/com/util/error/ErrorScreen'
 import {ErrorBoundary} from '#/view/com/util/ErrorBoundary'
-import {ListMethods} from '#/view/com/util/List'
+import {type ListMethods} from '#/view/com/util/List'
 import {atoms as a, ios, native, useBreakpoints, useTheme, web} from '#/alf'
 import {Button, ButtonIcon, ButtonText} from '#/components/Button'
 import * as Dialog from '#/components/Dialog'
@@ -175,7 +175,7 @@ function GifList({
           <TextField.Icon icon={Search} />
           <TextField.Input
             label={_(msg`Search GIFs`)}
-            placeholder={_(msg`Search Tenor`)}
+            placeholder={_(msg`Search GIFs`)}
             onChangeText={text => {
               setSearch(text)
               listRef.current?.scrollToOffset({offset: 0, animated: false})


### PR DESCRIPTION
Quick PR I wanted while doing a bit of work on the GIF search backend.

I think it's kinda odd that we're exposing that you're searching Tenor to the user. What if we want to swap our GIF search backend? The average user has no idea what Tenor is, so this placeholder text is just odd.

How does this play with i18n, if at all? I see lots of usages of the term `Tenor` in our translation files?

```
$ rg Tenor | wc -l
     254
```

Also, all the import changes I think were from the linter pre-commit hook?

<img width="1115" alt="Screenshot 2025-06-30 at 08 37 13" src="https://github.com/user-attachments/assets/aa81c19d-4876-4043-9d78-3483a028a405" />
