### PR TITLE
Fix checkmark overflow in profile card

### DIFF
--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -277,12 +277,18 @@ export function Name({
     <View style={[a.flex_row, a.align_center]}>
       <Text
         emoji
-        style={[a.text_md, a.font_bold, a.leading_snug, a.self_start]}
+        style={[
+          a.text_md,
+          a.font_bold,
+          a.leading_snug,
+          a.self_start,
+          a.flex_shrink,
+        ]}
         numberOfLines={1}>
         {name}
       </Text>
       {verification.showBadge && (
-        <View style={[a.pl_xs]}>
+        <View style={[a.pl_xs, a.flex_grow_0]}>
           <VerificationCheck
             width={14}
             verifier={verification.role === 'verifier'}

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import {useMemo} from 'react'
 import {type GestureResponderEvent, View} from 'react-native'
 import {
   moderateProfile,
@@ -288,7 +288,7 @@ export function Name({
         {name}
       </Text>
       {verification.showBadge && (
-        <View style={[a.pl_xs, a.flex_grow_0]}>
+        <View style={[a.pl_xs]}>
           <VerificationCheck
             width={14}
             verifier={verification.role === 'verifier'}
@@ -351,7 +351,7 @@ export function Description({
   numberOfLines?: number
 }) {
   const profile = useProfileShadow(profileUnshadowed)
-  const rt = React.useMemo(() => {
+  const rt = useMemo(() => {
     if (!('description' in profile)) return
     const rt = new RichTextApi({text: profile.description || ''})
     rt.detectFacetsWithoutResolution()


### PR DESCRIPTION
<table>
  <thead>
    <tr>
      <th>Before</th>
      <th>After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><img width="250" src="https://github.com/user-attachments/assets/431f116a-1e41-405e-9fba-e6bfe6d33087" /></td>
      <td><img width="250" src="https://github.com/user-attachments/assets/7e2fc332-60ea-4b39-ac28-a7b30471a14d" /></td>
    </tr>
  </tbody>
</table>
# Test plan

Check iOS, look at places we use ProfileCard such as Explore/Search. confirm long names such as AOC no longer overflow.

Confirm other platforms are the same (web still fine, android still kinda borked 😞)