### PR TITLE
Follow redirects for soundcloud shortlinks

### DIFF
--- a/src/lib/api/resolve.ts
+++ b/src/lib/api/resolve.ts
@@ -204,7 +204,6 @@ async function resolveExternal(
   uri: string,
 ): Promise<ResolvedExternalLink> {
   const result = await getLinkMeta(agent, uri)
-  console.log(result)
   return {
     type: 'external',
     uri: result.url,

--- a/src/lib/api/resolve.ts
+++ b/src/lib/api/resolve.ts
@@ -204,6 +204,7 @@ async function resolveExternal(
   uri: string,
 ): Promise<ResolvedExternalLink> {
   const result = await getLinkMeta(agent, uri)
+  console.log(result)
   return {
     type: 'external',
     uri: result.url,

--- a/src/lib/link-meta/link-meta.ts
+++ b/src/lib/link-meta/link-meta.ts
@@ -1,4 +1,4 @@
-import {BskyAgent} from '@atproto/api'
+import {type BskyAgent} from '@atproto/api'
 
 import {LINK_META_PROXY} from '#/lib/constants'
 import {getGiphyMetaUri} from '#/lib/strings/embed-player'
@@ -37,6 +37,7 @@ export async function getLinkMeta(
   }
 
   let urlp
+  let shouldFollowRedirect = false
   try {
     urlp = new URL(url)
 
@@ -46,6 +47,9 @@ export async function getLinkMeta(
       url = giphyMetaUri
       urlp = new URL(url)
     }
+    // follow redirects for soundcloud shortlinks
+    // QUESTION - do we want to follow redirects in other cases? -sfn
+    shouldFollowRedirect = urlp.hostname === 'on.soundcloud.com'
   } catch (e) {
     return {
       error: 'Invalid URL',
@@ -76,15 +80,16 @@ export async function getLinkMeta(
     const body = await response.json()
     clearTimeout(to)
 
-    const {description, error, image, title} = body
-
-    if (error !== '') {
-      throw new Error(error)
+    if (body.error !== '') {
+      throw new Error(body.error)
     }
 
-    meta.description = description
-    meta.image = image
-    meta.title = title
+    meta.description = body.description
+    meta.image = body.image
+    meta.title = body.title
+    if (shouldFollowRedirect) {
+      meta.url = body.url
+    }
   } catch (e) {
     // failed
     console.error(e)

--- a/src/lib/link-meta/link-meta.ts
+++ b/src/lib/link-meta/link-meta.ts
@@ -66,19 +66,18 @@ export async function getLinkMeta(
     return meta
   }
 
-  try {
-    const controller = new AbortController()
-    const to = setTimeout(() => controller.abort(), timeout || 5e3)
+  const controller = new AbortController()
+  const to = setTimeout(() => controller.abort(), timeout || 5e3)
 
+  try {
     const response = await fetch(
-      `${LINK_META_PROXY(agent.service.toString() || '')}${encodeURIComponent(
+      `${LINK_META_PROXY(agent.serviceUrl.toString() || '')}${encodeURIComponent(
         url,
       )}`,
       {signal: controller.signal},
     )
 
     const body = await response.json()
-    clearTimeout(to)
 
     if (body.error !== '') {
       throw new Error(body.error)
@@ -94,6 +93,8 @@ export async function getLinkMeta(
     // failed
     console.error(e)
     meta.error = e instanceof Error ? e.toString() : 'Failed to fetch link'
+  } finally {
+    clearTimeout(to)
   }
 
   return meta


### PR DESCRIPTION
Allows embed card to work for their shortlinks

## Test plan

Post https://on.soundcloud.com/AgZAAwLT3iRjNrhqp3 and confirm the player now appears