### PR TITLE
Specify `autoCapitalize` value

### DIFF
--- a/src/view/com/composer/text-input/TextInput.tsx
+++ b/src/view/com/composer/text-input/TextInput.tsx
@@ -249,6 +249,9 @@ export const TextInput = forwardRef(function TextInputImpl(
         multiline
         scrollEnabled={false}
         numberOfLines={2}
+        // Note: should be the default value, but as of v1.104
+        // it switched to "none" on Android
+        autoCapitalize="sentences"
         {...props}
         style={[
           inputTextStyle,


### PR DESCRIPTION
Android seems to default to "none" instead of "sentences" now. Probably an issue with the paste-input library, but let's just fix it the easy way for now