### PR TITLE
Fix perf issue on web - restore pop behaviour to tabs

### DIFF
--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -192,7 +192,7 @@ export function useLink({
               navigation.dispatch(StackActions.replace(screen, params))
             } else if (action === 'navigate') {
               // @ts-expect-error not typed
-              navigation.navigate(screen, params)
+              navigation.navigate(screen, params, {pop: true})
             } else {
               throw Error('Unsupported navigator action.')
             }

--- a/src/components/StarterPack/StarterPackCard.tsx
+++ b/src/components/StarterPack/StarterPackCard.tsx
@@ -156,7 +156,6 @@ export function Link({
 
   return (
     <BaseLink
-      action="push"
       to={`/starter-pack/${handleOrDid}/${rkey}`}
       label={_(msg`Navigate to ${record.name}`)}
       onPress={() => {

--- a/src/lib/hooks/useNavigationDeduped.ts
+++ b/src/lib/hooks/useNavigationDeduped.ts
@@ -7,6 +7,8 @@ import {type NavigationProp} from '#/lib/routes/types'
 export type DebouncedNavigationProp = Pick<
   NavigationProp,
   | 'popToTop'
+  | 'popTo'
+  | 'pop'
   | 'push'
   | 'navigate'
   | 'canGoBack'
@@ -37,6 +39,12 @@ export function useNavigationDeduped() {
       },
       popToTop: () => {
         dedupe(() => navigation.popToTop())
+      },
+      popTo: (...args: Parameters<typeof navigation.popTo>) => {
+        dedupe(() => navigation.popTo(...args))
+      },
+      pop: (...args: Parameters<typeof navigation.pop>) => {
+        dedupe(() => navigation.pop(...args))
       },
       goBack: () => {
         dedupe(() => navigation.goBack())

--- a/src/view/com/util/Link.tsx
+++ b/src/view/com/util/Link.tsx
@@ -410,10 +410,10 @@ function onPressInner(
       const [routeName, params] = router.matchPath(href)
       if (navigationAction === 'push') {
         // @ts-ignore we're not able to type check on this one -prf
-        navigation.push(routeName, params)
+        navigation.dispatch(StackActions.push(routeName, params))
       } else if (navigationAction === 'replace') {
         // @ts-ignore we're not able to type check on this one -prf
-        navigation.replace(routeName, params)
+        navigation.dispatch(StackActions.replace(routeName, params))
       } else if (navigationAction === 'navigate') {
         const state = navigation.getState()
         const tabState = getTabState(state, routeName)
@@ -421,9 +421,9 @@ function onPressInner(
           emitSoftReset()
         } else {
           // note: 'navigate' actually acts the same as 'push' nowadays
-          // therefore we need to use 'popTo' instead -sfn
+          // therefore we need to add 'pop' -sfn
           // @ts-ignore we're not able to type check on this one -prf
-          navigation.popTo(routeName, params)
+          navigation.navigate(routeName, params, {pop: true})
         }
       } else {
         throw Error('Unsupported navigator action.')

--- a/src/view/com/util/Link.tsx
+++ b/src/view/com/util/Link.tsx
@@ -11,7 +11,6 @@ import {
   type ViewStyle,
 } from 'react-native'
 import {sanitizeUrl} from '@braintree/sanitize-url'
-import {StackActions} from '@react-navigation/native'
 
 import {
   type DebouncedNavigationProp,
@@ -411,20 +410,20 @@ function onPressInner(
       const [routeName, params] = router.matchPath(href)
       if (navigationAction === 'push') {
         // @ts-ignore we're not able to type check on this one -prf
-        navigation.dispatch(StackActions.push(routeName, params))
+        navigation.push(routeName, params)
       } else if (navigationAction === 'replace') {
         // @ts-ignore we're not able to type check on this one -prf
-        navigation.dispatch(StackActions.replace(routeName, params))
+        navigation.replace(routeName, params)
       } else if (navigationAction === 'navigate') {
         const state = navigation.getState()
         const tabState = getTabState(state, routeName)
         if (tabState === TabState.InsideAtRoot) {
           emitSoftReset()
         } else {
-          // note: 'navigate' actually acts more like 'push' nowadays
-          // we need to specify {pop: true} to get the desired behavior
+          // note: 'navigate' actually acts the same as 'push' nowadays
+          // therefore we need to use 'popTo' instead -sfn
           // @ts-ignore we're not able to type check on this one -prf
-          navigation.navigate(routeName, params, {pop: true})
+          navigation.popTo(routeName, params)
         }
       } else {
         throw Error('Unsupported navigator action.')

--- a/src/view/com/util/Link.tsx
+++ b/src/view/com/util/Link.tsx
@@ -421,8 +421,10 @@ function onPressInner(
         if (tabState === TabState.InsideAtRoot) {
           emitSoftReset()
         } else {
+          // note: 'navigate' actually acts more like 'push' nowadays
+          // we need to specify {pop: true} to get the desired behavior
           // @ts-ignore we're not able to type check on this one -prf
-          navigation.navigate(routeName, params)
+          navigation.navigate(routeName, params, {pop: true})
         }
       } else {
         throw Error('Unsupported navigator action.')

--- a/src/view/shell/desktop/LeftNav.tsx
+++ b/src/view/shell/desktop/LeftNav.tsx
@@ -3,11 +3,7 @@ import {StyleSheet, View} from 'react-native'
 import {type AppBskyActorDefs} from '@atproto/api'
 import {msg, plural, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
-import {
-  useLinkTo,
-  useNavigation,
-  useNavigationState,
-} from '@react-navigation/native'
+import {useNavigation, useNavigationState} from '@react-navigation/native'
 
 import {useActorStatus} from '#/lib/actor-status'
 import {useAccountSwitcher} from '#/lib/hooks/useAccountSwitcher'
@@ -16,7 +12,10 @@ import {usePalette} from '#/lib/hooks/usePalette'
 import {useWebMediaQueries} from '#/lib/hooks/useWebMediaQueries'
 import {getCurrentRoute, isTab} from '#/lib/routes/helpers'
 import {makeProfileLink} from '#/lib/routes/links'
-import {type CommonNavigatorParams} from '#/lib/routes/types'
+import {
+  type CommonNavigatorParams,
+  type NavigationProp,
+} from '#/lib/routes/types'
 import {useGate} from '#/lib/statsig/statsig'
 import {sanitizeDisplayName} from '#/lib/strings/display-names'
 import {isInvalidHandle, sanitizeHandle} from '#/lib/strings/handles'
@@ -339,7 +338,7 @@ function NavItem({count, hasNew, href, icon, iconFilled, label}: NavItemProps) {
         (currentRouteInfo.params as CommonNavigatorParams['Profile']).name ===
           currentAccount?.handle
       : isTab(currentRouteInfo.name, pathName)
-  const linkTo = useLinkTo()
+  const navigation = useNavigation<NavigationProp>()
   const onPressWrapped = useCallback(
     (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
       if (e.ctrlKey || e.metaKey || e.altKey) {
@@ -349,10 +348,12 @@ function NavItem({count, hasNew, href, icon, iconFilled, label}: NavItemProps) {
       if (isCurrent) {
         emitSoftReset()
       } else {
-        linkTo(href)
+        const [screen, params] = router.matchPath(href)
+        // @ts-expect-error TODO: type matchPath well enough that it can be plugged into navigation.navigate directly
+        navigation.navigate(screen, params, {pop: true})
       }
     },
-    [linkTo, href, isCurrent],
+    [navigation, href, isCurrent],
   )
 
   return (

--- a/src/view/shell/desktop/LeftNav.tsx
+++ b/src/view/shell/desktop/LeftNav.tsx
@@ -350,7 +350,7 @@ function NavItem({count, hasNew, href, icon, iconFilled, label}: NavItemProps) {
       } else {
         const [screen, params] = router.matchPath(href)
         // @ts-expect-error TODO: type matchPath well enough that it can be plugged into navigation.navigate directly
-        navigation.navigate(screen, params, {pop: true})
+        navigation.popTo(screen, params)
       }
     },
     [navigation, href, isCurrent],


### PR DESCRIPTION
Fixes https://github.com/bluesky-social/social-app/issues/8632

React Navigation v7 includes this change:

https://reactnavigation.org/docs/upgrading-from-6.x#the-navigate-method-no-longer-goes-back-use-popto-instead

> The `navigate` method no longer goes back, use `popTo` instead

Since our web version is a giant stack navigator, this means that switching away from a tab and back used to `pop` back to the previous screen. This awkwardly means you lose the ability to use the back button, since technically it was a back action. However, this correctly reused the same screen that you're going back to, so it doesn't need to render the screen again from scratch.

However, since the new version _always pushes_, switching to and from tabs would add a new screen _every single time_. Not only does this mean each new screen has to render from scratch, which is slow, it also means continued use of the app would accumulate more and more dead screens in memory.

You can see in the flamegraph, going from home->search->home over and over just keeps on adding more and more screens

<img width="1011" alt="Screenshot 2025-07-08 at 09 44 48" src="https://github.com/user-attachments/assets/17d949df-098a-47f6-a7b8-faca96365ec1" />

This PR restores the old `pop` behaviour to the tab bars, meaning the old screens are reused.

<img width="1309" alt="Screenshot 2025-07-08 at 10 01 20" src="https://github.com/user-attachments/assets/6ddb4aef-db84-46a1-9c11-0f163ecf20c7" />

**IMO, this is still not ideal behaviour.** The push behaviour makes much more sense in terms of the browser history, and the browser back button behaviour is much more sane. _However_, to my knowledge there's no way to force it to reused old screens without evicting the previous screens via a `pop`, other than `getId` - but that drags the old screen to the top of the stack, breaking the history (see draft PR: #8621)

# Test plan

1. Observe the profiler, confirm that on `main` screens keep getting added and that in this PR it doesn't do that
2. Just use the app for a bit, click around, confirm it doesn't slow down over time