### PR TITLE
Handle notifications on first load

### DIFF
--- a/src/App.native.tsx
+++ b/src/App.native.tsx
@@ -17,6 +17,7 @@ import {useLingui} from '@lingui/react'
 import * as Sentry from '@sentry/react-native'
 
 import {KeyboardControllerProvider} from '#/lib/hooks/useEnableKeyboardController'
+import {Provider as HideBottomBarBorderProvider} from '#/lib/hooks/useHideBottomBarBorder'
 import {QueryProvider} from '#/lib/react-query'
 import {Provider as StatsigProvider, tryFetchGates} from '#/lib/statsig/statsig'
 import {s} from '#/lib/styles'
@@ -73,7 +74,6 @@ import {Provider as VideoVolumeProvider} from '#/components/Post/Embed/VideoEmbe
 import {Splash} from '#/Splash'
 import {BottomSheetProvider} from '../modules/bottom-sheet'
 import {BackgroundNotificationPreferencesProvider} from '../modules/expo-background-notification-handler/src/BackgroundNotificationHandlerProvider'
-import {Provider as HideBottomBarBorderProvider} from './lib/hooks/useHideBottomBarBorder'
 
 SplashScreen.preventAutoHideAsync()
 if (isIOS) {

--- a/src/Navigation.tsx
+++ b/src/Navigation.tsx
@@ -871,7 +871,8 @@ function RoutesContainer({children}: React.PropsWithChildren<{}>) {
 
   async function handlePushNotificationEntry() {
     if (!isNative) return
-    // Handle URL from expo push notifications
+
+    // gets the notification that caused the app to open, if applicable
     const response = await Notifications.getLastNotificationResponseAsync()
 
     if (response) {

--- a/src/Navigation.tsx
+++ b/src/Navigation.tsx
@@ -879,6 +879,11 @@ function RoutesContainer({children}: React.PropsWithChildren<{}>) {
       const payload = getNotificationPayload(response.notification)
 
       if (payload) {
+        logger.metric(
+          'notifications:openApp',
+          {reason: payload.reason, causedBoot: true},
+          {statsig: false},
+        )
         if (payload.reason === 'chat-message') {
           handleMessage(payload)
         } else {

--- a/src/Navigation.tsx
+++ b/src/Navigation.tsx
@@ -833,6 +833,8 @@ const LINKING = {
   },
 } satisfies LinkingOptions<AllNavigatorParams>
 
+let previousNotificationDate: number | undefined
+
 function RoutesContainer({children}: React.PropsWithChildren<{}>) {
   const theme = useColorSchemeStyle(DefaultTheme, DarkTheme)
   const {currentAccount, accounts} = useSession()
@@ -876,6 +878,11 @@ function RoutesContainer({children}: React.PropsWithChildren<{}>) {
     const response = await Notifications.getLastNotificationResponseAsync()
 
     if (response) {
+      if (response.notification.date === previousNotificationDate) {
+        return
+      }
+      previousNotificationDate = response.notification.date
+
       const payload = getNotificationPayload(response.notification)
 
       if (payload) {
@@ -893,7 +900,7 @@ function RoutesContainer({children}: React.PropsWithChildren<{}>) {
           } else if (path) {
             const [screen, params] = router.matchPath(path)
             // @ts-expect-error nested navigators aren't typed -sfn
-            navigate('NotificationsTab', {screen, params})
+            navigate('HomeTab', {screen, params})
           }
         }
       }

--- a/src/Navigation.tsx
+++ b/src/Navigation.tsx
@@ -769,6 +769,7 @@ const FlatNavigator = () => {
 
 const LINKING = {
   // TODO figure out what we are going to use
+  // note: `bluesky://` is what is used in app.config.js
   prefixes: ['bsky://', 'bluesky://', 'https://bsky.app'],
 
   getPathFromState(state: State) {
@@ -787,7 +788,6 @@ const LINKING = {
   },
 
   getStateFromPath(path: string) {
-    console.log('getting state from path', path)
     const [name, params] = router.matchPath(path)
 
     // Any time we receive a url that starts with `intent/` we want to ignore it here. It will be handled in the
@@ -802,8 +802,6 @@ const LINKING = {
     }
 
     if (isNative) {
-      console.log(name, params)
-
       if (name === 'Search') {
         return buildStateObject('SearchTab', 'Search', params)
       }
@@ -843,8 +841,7 @@ const LINKING = {
       const payload = getNotificationPayload(response.notification)
 
       if (payload) {
-        console.log('initial url', notificationToURL(payload))
-        return notificationToURL(payload)
+        return `bluesky://${notificationToURL(payload)}`
       }
     }
 
@@ -877,9 +874,7 @@ function RoutesContainer({children}: React.PropsWithChildren<{}>) {
         onStateChange={() => {
           logger.metric(
             'router:navigate',
-            {
-              from: prevLoggedRouteName.current,
-            },
+            {from: prevLoggedRouteName.current},
             {statsig: false},
           )
           prevLoggedRouteName.current = getCurrentRouteName()

--- a/src/Navigation.tsx
+++ b/src/Navigation.tsx
@@ -870,6 +870,7 @@ function RoutesContainer({children}: React.PropsWithChildren<{}>) {
   )
 
   async function handlePushNotificationEntry() {
+    if (!isNative) return
     // Handle URL from expo push notifications
     const response = await Notifications.getLastNotificationResponseAsync()
 
@@ -886,7 +887,7 @@ function RoutesContainer({children}: React.PropsWithChildren<{}>) {
           } else if (path) {
             const [screen, params] = router.matchPath(path)
             // @ts-expect-error nested navigators aren't typed -sfn
-            navigate('HomeTab', {screen, params})
+            navigate('NotificationsTab', {screen, params})
           }
         }
       }

--- a/src/lib/hooks/useNotificationHandler.ts
+++ b/src/lib/hooks/useNotificationHandler.ts
@@ -310,7 +310,7 @@ export function useNotificationsHandler() {
           )
           logger.metric(
             'notifications:openApp',
-            {reason: payload.reason},
+            {reason: payload.reason, causedBoot: false},
             {statsig: false},
           )
 

--- a/src/lib/hooks/useNotificationHandler.ts
+++ b/src/lib/hooks/useNotificationHandler.ts
@@ -40,7 +40,7 @@ export type NotificationReason =
  * `notification.request.trigger.payload` being `undefined`, as specified in
  * the source types.
  */
-type NotificationPayload =
+export type NotificationPayload =
   | undefined
   | {
       reason: Exclude<NotificationReason, 'chat-message'>
@@ -185,7 +185,7 @@ export function useNotificationsHandler() {
 
       if (payload.reason === 'chat-message') {
         if (payload.recipientDid !== currentAccount?.did && !storedPayload) {
-          storedPayload = payload
+          storePayload(payload)
           closeAllActiveElements()
 
           const account = accounts.find(a => a.did === payload.recipientDid)
@@ -359,6 +359,10 @@ export function useNotificationsHandler() {
     onPressSwitchAccount,
     setShowLoggedOut,
   ])
+}
+
+export function storePayload(payload: NotificationPayload) {
+  storedPayload = payload
 }
 
 export function getNotificationPayload(

--- a/src/lib/hooks/useNotificationHandler.ts
+++ b/src/lib/hooks/useNotificationHandler.ts
@@ -418,7 +418,8 @@ export function notificationToURL(
       return `/profile/${urip.host}`
     }
     case 'chat-message':
-      return '/messages'
+      // should be handled separately
+      return undefined
     case 'verified':
     case 'unverified':
     default:

--- a/src/lib/notifications/notifications.ts
+++ b/src/lib/notifications/notifications.ts
@@ -6,12 +6,10 @@ import {type AtpAgent} from '@atproto/api'
 import debounce from 'lodash.debounce'
 
 import {PUBLIC_APPVIEW_DID, PUBLIC_STAGING_APPVIEW_DID} from '#/lib/constants'
-import {Logger} from '#/logger'
+import {logger as notyLogger} from '#/lib/notifications/util'
 import {isNative} from '#/platform/detection'
 import {type SessionAccount, useAgent, useSession} from '#/state/session'
 import BackgroundNotificationHandler from '#/../modules/expo-background-notification-handler'
-
-const logger = Logger.create(Logger.Context.Notifications)
 
 /**
  * @private
@@ -36,12 +34,12 @@ async function _registerPushToken({
       appId: 'xyz.blueskyweb.app',
     })
 
-    logger.debug(`registerPushToken: success`, {
+    notyLogger.debug(`registerPushToken: success`, {
       tokenType: token.type,
       token: token.data,
     })
   } catch (error) {
-    logger.error(`registerPushToken: failed`, {safeMessage: error})
+    notyLogger.error(`registerPushToken: failed`, {safeMessage: error})
   }
 }
 
@@ -80,7 +78,7 @@ export function useRegisterPushToken() {
  */
 async function getPushToken() {
   const granted = (await Notifications.getPermissionsAsync()).granted
-  logger.debug(`getPushToken`, {granted})
+  notyLogger.debug(`getPushToken`, {granted})
   if (granted) {
     return Notifications.getDevicePushTokenAsync()
   }
@@ -115,7 +113,9 @@ export function useGetAndRegisterPushToken() {
      */
     const token = await getPushToken()
 
-    logger.debug(`useGetAndRegisterPushToken`, {token: token ?? 'undefined'})
+    notyLogger.debug(`useGetAndRegisterPushToken`, {
+      token: token ?? 'undefined',
+    })
 
     if (token) {
       /**
@@ -147,7 +147,7 @@ export function useNotificationsRegistration() {
      */
     if (!currentAccount) return
 
-    logger.debug(`useNotificationsRegistration`)
+    notyLogger.debug(`useNotificationsRegistration`)
 
     /**
      * Init push token, if permissions are granted already. If they weren't,
@@ -168,7 +168,7 @@ export function useNotificationsRegistration() {
      */
     const subscription = Notifications.addPushTokenListener(async token => {
       registerPushToken({token})
-      logger.debug(`addPushTokenListener callback`, {token})
+      notyLogger.debug(`addPushTokenListener callback`, {token})
     })
 
     return () => {
@@ -202,7 +202,7 @@ export function useRequestNotificationsPermission() {
 
     const res = await Notifications.requestPermissionsAsync()
 
-    logger.metric(`notifications:request`, {
+    notyLogger.metric(`notifications:request`, {
       context: context,
       status: res.status,
     })

--- a/src/lib/notifications/util.ts
+++ b/src/lib/notifications/util.ts
@@ -1,0 +1,3 @@
+import {Logger} from '#/logger'
+
+export const logger = Logger.create(Logger.Context.Notifications)

--- a/src/lib/routes/links.ts
+++ b/src/lib/routes/links.ts
@@ -1,4 +1,4 @@
-import {AppBskyGraphDefs, AtUri} from '@atproto/api'
+import {type AppBskyGraphDefs, AtUri} from '@atproto/api'
 
 import {isInvalidHandle} from '#/lib/strings/handles'
 

--- a/src/logger/metrics.ts
+++ b/src/logger/metrics.ts
@@ -26,6 +26,7 @@ export type MetricEvents = {
   }
   'notifications:openApp': {
     reason: NotificationReason
+    causedBoot: boolean
   }
   'notifications:request': {
     context: 'StartOnboarding' | 'AfterOnboarding' | 'Login' | 'Home'


### PR DESCRIPTION
Rather than using `getInitialURL`, we actually want to read the latest notification (i.e. the notification that caused the app to open) in `onReady`, then push to it. `getInitialURL` meant that you couldn't swipe to go back to home, because it becomes the root screen of the stack.

This _should_ also fix notification handling (for both cold start and backgrounded notifs) on android, as apparently the shape of the object changed at some point. Let's get it into prod and verify - no harm if it doesn't work since the current approach doesn't work either lol

This also now handles all types of notification properly!

- like, repost, *-via-repost: takes you to the subject post
- reply, mention, quote, activity notif: takes to the post
- follow, join via starterpack: takes you to the profile
- message: takes you to the convo, including account switching logic
- verification: takes you to the verification screen

# Test plan

1. Hard close the app
2. Tap on a notification
3. See that you're taken to the right place
4. Confirm account switching works for chat messages