### PR TITLE
Fix scroll not working emoji reaction popup

### DIFF
--- a/src/components/dms/EmojiReactionPicker.web.tsx
+++ b/src/components/dms/EmojiReactionPicker.web.tsx
@@ -78,10 +78,12 @@ function MenuInner({
       <DropdownMenu.Content
         sideOffset={5}
         collisionPadding={{left: 5, right: 5, bottom: 5}}>
-        <EmojiPicker
-          onEmojiSelect={handleEmojiPickerResponse}
-          autoFocus={true}
-        />
+        <div onWheel={evt => evt.stopPropagation()}>
+          <EmojiPicker
+            onEmojiSelect={handleEmojiPickerResponse}
+            autoFocus={true}
+          />
+        </div>
       </DropdownMenu.Content>
     </DropdownMenu.Portal>
   ) : (


### PR DESCRIPTION
Fixes #8609 

Uses https://github.com/missive/emoji-mart/issues/752#issuecomment-2795313620 to fix the scroll issue. Seems Radix is swallowing scroll events, so we prevent the scroll events from reaching Radix.