### PR TITLE
Filter activity notifications for muted words

### DIFF
--- a/src/state/queries/notifications/util.ts
+++ b/src/state/queries/notifications/util.ts
@@ -7,6 +7,7 @@ import {
   AppBskyGraphStarterpack,
   type AppBskyNotificationListNotifications,
   type BskyAgent,
+  hasMutedWord,
   moderateNotification,
   type ModerationOpts,
 } from '@atproto/api'
@@ -124,6 +125,23 @@ export function shouldFilterNotif(
   }
   if (!moderationOpts) {
     return false
+  }
+  if (
+    notif.reason === 'subscribed-post' &&
+    bsky.dangerousIsType<AppBskyFeedPost.Record>(
+      notif.record,
+      AppBskyFeedPost.isRecord,
+    ) &&
+    hasMutedWord({
+      mutedWords: moderationOpts.prefs.mutedWords,
+      text: notif.record.text,
+      facets: notif.record.facets,
+      outlineTags: notif.record.tags,
+      languages: notif.record.langs,
+      actor: notif.author,
+    })
+  ) {
+    return true
   }
   if (notif.author.viewer?.following) {
     return false


### PR DESCRIPTION
Currently we don't filter activity notification post context for muted words. They don't show in the list, but they do show in the little preview. We should filter them

# Test plan

Get an activity notif
Mute a word from it
Confirm it disappears from the list