### PR TITLE
Fix mention tab flicker

### DIFF
--- a/src/view/com/notifications/NotificationFeed.tsx
+++ b/src/view/com/notifications/NotificationFeed.tsx
@@ -59,7 +59,13 @@ export function NotificationFeed({
     enabled: enabled && !!moderationOpts,
     filter,
   })
-  const isEmpty = !isFetching && !data?.pages[0]?.items.length
+  // previously, this was `!isFetching && !data?.pages[0]?.items.length`
+  // however, if the first page had no items (can happen in the mentions tab!)
+  // it would flicker the empty state whenever it was loading.
+  // therefore, we need to find if *any* page has items. in 99.9% of cases,
+  // the `.find()` won't need to go any further than the first page -sfn
+  const isEmpty =
+    !isFetching && !data?.pages.find(page => page.items.length > 0)
 
   const items = React.useMemo(() => {
     let arr: any[] = []

--- a/src/view/com/util/PostMeta.tsx
+++ b/src/view/com/util/PostMeta.tsx
@@ -122,6 +122,7 @@ let PostMeta = (opts: PostMetaOpts): React.ReactNode => {
               </View>
             )}
             <WebOnlyInlineLinkText
+              emoji
               numberOfLines={1}
               to={profileLink}
               label={_(msg`View profile`)}


### PR DESCRIPTION
Flickering was caused by the condition for showing the empty state:

```js
const isEmpty = !isFetching && !data?.pages[0]?.items.length
```

If the first page had no items, which can happen in the mention tab, it would always be just equal to the `!isFetching` part. Thus, every time it loaded another page, it would flicker the empty state - therefore we need to check if *any* page has items.

```js
const isEmpty = !isFetching && !data?.pages.find(page => page.items.length > 0)
```

In 99.9% of cases, the `find` clause will just stop at the first page, so it shouldn't result in a performance hit.