### PR TITLE
Fix navigation

### DIFF
--- a/src/view/com/util/Link.tsx
+++ b/src/view/com/util/Link.tsx
@@ -11,6 +11,7 @@ import {
   type ViewStyle,
 } from 'react-native'
 import {sanitizeUrl} from '@braintree/sanitize-url'
+import {StackActions} from '@react-navigation/native'
 
 import {
   type DebouncedNavigationProp,

--- a/src/view/shell/desktop/LeftNav.tsx
+++ b/src/view/shell/desktop/LeftNav.tsx
@@ -350,7 +350,7 @@ function NavItem({count, hasNew, href, icon, iconFilled, label}: NavItemProps) {
       } else {
         const [screen, params] = router.matchPath(href)
         // @ts-expect-error TODO: type matchPath well enough that it can be plugged into navigation.navigate directly
-        navigation.popTo(screen, params)
+        navigation.navigate(screen, params, {pop: true})
       }
     },
     [navigation, href, isCurrent],


### PR DESCRIPTION
Incredibly stupid bug - accidentally deleted an import, but all the places it was used were tsignore'd

Also changed a `popTo` to a `navigate(_, _, {pop: true})` which I think is more correct