### PR TITLE
Use push to convo mechanism in startup notification handling

### DIFF
--- a/src/Navigation.tsx
+++ b/src/Navigation.tsx
@@ -872,9 +872,9 @@ function RoutesContainer({children}: React.PropsWithChildren<{}>) {
       } else {
         // @ts-expect-error nested navigators aren't typed -sfn
         navigate('MessagesTab', {
-          screen: 'MessagesConversation',
+          screen: 'Messages',
           params: {
-            conversation: payload.convoId,
+            pushToConversation: payload.convoId,
           },
         })
       }


### PR DESCRIPTION
Ensures that you can go back to the chat list screen if opening the app from a chat message push notif

Hailey had figured this all out before - it now reuses the logic from here: https://github.com/bluesky-social/social-app/blob/main/src/lib/hooks/useNotificationHandler.ts#L235-L240
We don't need the rest of the handling there btw because that's only if you're already on the messages tab - obviously not the case at startup