### PR TITLE
Avoid handling notifications on entry if opened via deep link

### DIFF
--- a/src/Navigation.tsx
+++ b/src/Navigation.tsx
@@ -1,4 +1,5 @@
 import {useCallback, useRef} from 'react'
+import {Linking} from 'react-native'
 import * as Notifications from 'expo-notifications'
 import {i18n, type MessageDescriptor} from '@lingui/core'
 import {msg} from '@lingui/macro'
@@ -884,6 +885,13 @@ function RoutesContainer({children}: React.PropsWithChildren<{}>) {
   async function handlePushNotificationEntry() {
     if (!isNative) return
 
+    // deep links take precedence - on android,
+    // getLastNotificationResponseAsync returns a "notification"
+    // that is actually a deep link. avoid handling it twice -sfn
+    if (await Linking.getInitialURL()) {
+      return
+    }
+
     /**
      * The notification that caused the app to open, if applicable
      */
@@ -1041,39 +1049,6 @@ function reset(): Promise<void> {
   }
 }
 
-function handleLink(url: string) {
-  let path
-  if (url.startsWith('/')) {
-    path = url
-  } else if (url.startsWith('http')) {
-    try {
-      path = new URL(url).pathname
-    } catch (e) {
-      console.error('Invalid url', url, e)
-      return
-    }
-  } else {
-    console.error('Invalid url', url)
-    return
-  }
-
-  const [name, params] = router.matchPath(path)
-  if (isNative) {
-    if (name === 'Search') {
-      resetToTab('SearchTab')
-    } else if (name === 'Notifications') {
-      resetToTab('NotificationsTab')
-    } else {
-      resetToTab('HomeTab')
-      // @ts-ignore matchPath doesnt give us type-checked output -prf
-      navigate(name, params)
-    }
-  } else {
-    // @ts-ignore matchPath doesnt give us type-checked output -prf
-    navigate(name, params)
-  }
-}
-
 let didInit = false
 function logModuleInitTime() {
   if (didInit) {
@@ -1114,7 +1089,6 @@ function logModuleInitTime() {
 
 export {
   FlatNavigator,
-  handleLink,
   navigate,
   reset,
   resetToTab,


### PR DESCRIPTION
Fixes https://github.com/bluesky-social/social-app/issues/8642

Turns out, when opening a deep link on android, `Notifications.getLastNotificationResponseAsync()` returns something like this:

```jsonc
{
  "notification": {
    "request": {
      "trigger": {
        "channelId": null,
        "type": "push"
      },
      "content": {
        "title": null,
        "data": {
          "create_new_tab": true,
          "com.android.browser.application_id": "com.android.chrome",
          "org.chromium.chrome.browser.request_metadata_token": {
            "0": 87,
            "1": 244,
            "2": 60,
            // etc
          },
          "org.chromium.chrome.browser.eenp": [
            "xyz.blueskyweb.app"
          ]
        }
      },
      "identifier": null
    },
    "date": 0
  },
  "actionIdentifier": "expo.modules.notifications.actions.DEFAULT"
}
```

This meant we were treating it like an unknown notification and redirecting to `/notifications`, overriding the deep link. The fix is to skip the push notification entry code if the app was opened via deep link, since it conflicts.

```tsx
  async function handlePushNotificationEntry() {
    if (!isNative) return

    // deep links take precedence - on android,
    // getLastNotificationResponseAsync returns a "notification"
    // that is actually a deep link. avoid handling it twice -sfn
    if (await Linking.getInitialURL()) {
      return
    }
   
   // rest of notification handling
```

# Before

Showing the deep link handling when the app is both alive and dead

https://github.com/user-attachments/assets/131b0725-148c-446a-8512-7e3e6e6fd087



# After

  

https://github.com/user-attachments/assets/b0c44dfe-3045-4c67-bb40-d73b50b6320a

