### PR TITLE
Fix whitespace collapse in web composer when changing color scheme

### DIFF
--- a/src/view/com/composer/text-input/TextInput.web.tsx
+++ b/src/view/com/composer/text-input/TextInput.web.tsx
@@ -221,7 +221,9 @@ export const TextInput = React.forwardRef(function TextInputImpl(
           }
         },
       },
-      content: generateJSON(richtext.text.toString(), extensions),
+      content: generateJSON(richtext.text.toString(), extensions, {
+        preserveWhitespace: 'full',
+      }),
       autofocus: 'end',
       editable: true,
       injectCSS: true,


### PR DESCRIPTION
Changing the color scheme re-renders the ProseMirror editor. However, by default, it collapses whitespace via HTML rules when initializing the composer, and thus when it has to recreate the text input from its previous serialised state on re-render it loses the whitespace. We can turn off this behaviour to get the expected result.

# Before

https://github.com/user-attachments/assets/ad37a811-7cfe-47cf-86a5-6a312f164ace

# After

https://github.com/user-attachments/assets/98f16706-aab8-4e1c-b894-555db7600bf7

# Test plan

Confirm the specific bug is fixed
Can you think of any side effects from this? I don't think there would be, as it's only when recreating the composer from a prior state, which is pretty rare (basically only on color scheme change)