### PR TITLE
Add profile hover card to notification item author names

### DIFF
--- a/src/alf/atoms.ts
+++ b/src/alf/atoms.ts
@@ -976,6 +976,12 @@ export const atoms = {
   hidden: {
     display: 'none',
   },
+  inline: web({
+    display: 'inline',
+  }),
+  block: web({
+    display: 'block',
+  }),
 
   /*
    * Transition

--- a/src/components/ProfileHoverCard/index.tsx
+++ b/src/components/ProfileHoverCard/index.tsx
@@ -1,4 +1,4 @@
-import {ProfileHoverCardProps} from './types'
+import {type ProfileHoverCardProps} from './types'
 
 export function ProfileHoverCard({children}: ProfileHoverCardProps) {
   return children

--- a/src/components/ProfileHoverCard/index.web.tsx
+++ b/src/components/ProfileHoverCard/index.web.tsx
@@ -74,7 +74,9 @@ export function ProfileHoverCard(props: ProfileHoverCardProps) {
     return props.children
   } else {
     return (
-      <View onPointerMove={onPointerMove} style={[a.flex_shrink, props.style]}>
+      <View
+        onPointerMove={onPointerMove}
+        style={[a.flex_shrink, props.inline && a.inline, props.style]}>
         <ProfileHoverCardInner {...props} />
       </View>
     )
@@ -326,7 +328,7 @@ export function ProfileHoverCardInner(props: ProfileHoverCardProps) {
       onPointerLeave={onPointerLeaveTarget}
       // @ts-ignore web only prop
       onMouseUp={onPress}
-      style={{flexShrink: 1}}>
+      style={[a.flex_shrink, props.inline && a.inline]}>
       {props.children}
       {isVisible && (
         <Portal>

--- a/src/components/ProfileHoverCard/types.ts
+++ b/src/components/ProfileHoverCard/types.ts
@@ -6,4 +6,5 @@ export type ProfileHoverCardProps = ViewStyleProp & {
   children: React.ReactNode
   did: string
   disable?: boolean
+  inline?: boolean
 }

--- a/src/view/com/notifications/NotificationFeedItem.tsx
+++ b/src/view/com/notifications/NotificationFeedItem.tsx
@@ -209,33 +209,35 @@ let NotificationFeedItem = ({
   }
 
   const firstAuthorLink = (
-    <InlineLinkText
-      key={firstAuthor.href}
-      style={[t.atoms.text, a.font_bold, a.text_md, a.leading_tight]}
-      to={firstAuthor.href}
-      disableMismatchWarning
-      emoji
-      label={_(msg`Go to ${firstAuthorName}'s profile`)}>
-      {forceLTR(firstAuthorName)}
-      {firstAuthorVerification.showBadge && (
-        <View
-          style={[
-            a.relative,
-            {
-              paddingTop: platform({android: 2}),
-              marginBottom: platform({ios: -7}),
-              top: platform({web: 1}),
-              paddingLeft: 3,
-              paddingRight: 2,
-            },
-          ]}>
-          <VerificationCheck
-            width={14}
-            verifier={firstAuthorVerification.role === 'verifier'}
-          />
-        </View>
-      )}
-    </InlineLinkText>
+    <ProfileHoverCard did={firstAuthor.profile.did} inline>
+      <InlineLinkText
+        key={firstAuthor.href}
+        style={[t.atoms.text, a.font_bold, a.text_md, a.leading_tight]}
+        to={firstAuthor.href}
+        disableMismatchWarning
+        emoji
+        label={_(msg`Go to ${firstAuthorName}'s profile`)}>
+        {forceLTR(firstAuthorName)}
+        {firstAuthorVerification.showBadge && (
+          <View
+            style={[
+              a.relative,
+              {
+                paddingTop: platform({android: 2}),
+                marginBottom: platform({ios: -7}),
+                top: platform({web: 1}),
+                paddingLeft: 3,
+                paddingRight: 2,
+              },
+            ]}>
+            <VerificationCheck
+              width={14}
+              verifier={firstAuthorVerification.role === 'verifier'}
+            />
+          </View>
+        )}
+      </InlineLinkText>
+    </ProfileHoverCard>
   )
   const additionalAuthorsCount = authors.length - 1
   const hasMultipleAuthors = additionalAuthorsCount > 0


### PR DESCRIPTION
Fixes https://github.com/bluesky-social/social-app/issues/8587

Adds profile hover card to the author name in the grouped notification card
  
<img width="751" height="429" alt="Screenshot 2025-07-18 at 11 07 44" src="https://github.com/user-attachments/assets/87546163-a846-4f36-b3a3-13c3d7eeda8d" />

I had to add an `inline` prop to get it to work, which adds `display: inline` to both of the wrapper elements (didn't want to do it universally due to risk of breaking other places accidentally). This ensures it wraps properly:

<img width="747" height="462" alt="Screenshot 2025-07-18 at 11 08 03" src="https://github.com/user-attachments/assets/3db0cfa4-e691-4d52-bb2a-447d1e50be00" />
