### PR TITLE
Disable email query if takendown

### DIFF
--- a/src/components/dialogs/EmailDialog/data/useAccountEmailState.ts
+++ b/src/components/dialogs/EmailDialog/data/useAccountEmailState.ts
@@ -47,7 +47,7 @@ export function useAccountEmailState() {
     email2FAEnabled: !!agent.session?.emailAuthFactor,
   }
   const query = useQuery<AccountEmailState>({
-    enabled: !!agent.session,
+    enabled: !!agent.session && agent.session.status !== 'takendown',
     refetchOnWindowFocus: true,
     queryKey: accountEmailStateQueryKey,
     queryFn: async () => {

--- a/src/state/session/index.tsx
+++ b/src/state/session/index.tsx
@@ -119,7 +119,7 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
   )
 
   const logoutCurrentAccount = React.useCallback<
-    SessionApiContext['logoutEveryAccount']
+    SessionApiContext['logoutCurrentAccount']
   >(
     logContext => {
       addSessionDebugLog({type: 'method:start', method: 'logout'})


### PR DESCRIPTION
# Note - I think #8670 is the superior fix

Fixes https://github.com/bluesky-social/social-app/issues/8493

This was causing takendown accounts to be logged out instantly, because the email system was refreshing the session, failing, and causing a logout

# Test plan

Confirm you can see the suspended screen without getting immediately logged out