### PR TITLE
[APP-1291] prevent GestureActionView from hijacking swipe in a direction which no actions are specified

### DIFF
--- a/src/lib/custom-animations/GestureActionView.tsx
+++ b/src/lib/custom-animations/GestureActionView.tsx
@@ -114,6 +114,7 @@ export function GestureActionView({
     },
   )
 
+  // NOTE(haileyok):
   // Absurdly high value so it doesn't interfere with the pan gestures above (i.e., scroll)
   // reanimated doesn't offer great support for disabling y/x axes :/
   const effectivelyDisabledOffset = 200

--- a/src/lib/custom-animations/GestureActionView.tsx
+++ b/src/lib/custom-animations/GestureActionView.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import {ColorValue, Dimensions, StyleSheet, View} from 'react-native'
+import {type ColorValue, Dimensions, StyleSheet, View} from 'react-native'
 import {Gesture, GestureDetector} from 'react-native-gesture-handler'
 import Animated, {
   clamp,
@@ -114,11 +114,15 @@ export function GestureActionView({
     },
   )
 
+  // Absurdly high value so it doesn't interfere with the pan gestures above (i.e., scroll)
+  // reanimated doesn't offer great support for disabling y/x axes :/
+  const effectivelyDisabledOffset = 200
   const panGesture = Gesture.Pan()
-    .activeOffsetX([-10, 10])
-    // Absurdly high value so it doesn't interfere with the pan gestures above (i.e., scroll)
-    // reanimated doesn't offer great support for disabling y/x axes :/
-    .activeOffsetY([-200, 200])
+    .activeOffsetX([
+      actions.leftFirst ? -10 : -effectivelyDisabledOffset,
+      actions.rightFirst ? 10 : effectivelyDisabledOffset,
+    ])
+    .activeOffsetY([-effectivelyDisabledOffset, effectivelyDisabledOffset])
     .onStart(() => {
       'worklet'
       isActive.set(true)


### PR DESCRIPTION
For example, this PR makes it so that if the user swipes right on a GestureActionView with no right actions, GestureActionView will ignore the swipe. This allows the swipe to bubble up and be handled by a parent instead of being swallowed.