### PR TITLE
[APP-1317] update: chat request ui to hide chat requests when there are no messages

### DIFF
--- a/src/screens/Messages/ChatList.tsx
+++ b/src/screens/Messages/ChatList.tsx
@@ -229,6 +229,7 @@ export function MessagesScreenInner({navigation, route}: Props) {
     return listenSoftReset(onSoftReset)
   }, [onSoftReset, isScreenFocused])
 
+  // NOTE(APiligrim)
   // Show empty state only if there are no conversations at all
   const actualConversations = conversations.filter(
     item => item.type === 'CONVERSATION',

--- a/src/screens/Messages/ChatList.tsx
+++ b/src/screens/Messages/ChatList.tsx
@@ -164,12 +164,18 @@ export function MessagesScreenInner({navigation, route}: Props) {
         // filter out convos that are actively being left
         .filter(convo => !leftConvos.includes(convo.id))
 
+      const hasInboxRequests = inboxPreviewConvos?.length > 0
+
       return [
-        {
-          type: 'INBOX',
-          count: inboxPreviewConvos.length,
-          profiles: inboxPreviewConvos.slice(0, 3),
-        },
+        ...(hasInboxRequests
+          ? [
+              {
+                type: 'INBOX' as const,
+                count: inboxPreviewConvos.length,
+                profiles: inboxPreviewConvos.slice(0, 3),
+              },
+            ]
+          : []),
         ...conversations.map(
           convo => ({type: 'CONVERSATION', conversation: convo}) as const,
         ),
@@ -223,16 +229,23 @@ export function MessagesScreenInner({navigation, route}: Props) {
     return listenSoftReset(onSoftReset)
   }, [onSoftReset, isScreenFocused])
 
-  // Will always have 1 item - the inbox button
-  if (conversations.length < 2) {
+  // Show empty state only if there are no conversations at all
+  const actualConversations = conversations.filter(
+    item => item.type === 'CONVERSATION',
+  )
+  const hasInboxRequests = inboxPreviewConvos?.length > 0
+
+  if (actualConversations.length === 0) {
     return (
       <Layout.Screen>
         <Header newChatControl={newChatControl} />
         <Layout.Center>
-          <InboxPreview
-            count={inboxPreviewConvos.length}
-            profiles={inboxPreviewConvos}
-          />
+          {hasInboxRequests && (
+            <InboxPreview
+              count={inboxPreviewConvos.length}
+              profiles={inboxPreviewConvos}
+            />
+          )}
           {isLoading ? (
             <ChatListLoadingPlaceholder />
           ) : (


### PR DESCRIPTION
This PR addresses this [linear ticket](https://linear.app/blueskyweb/issue/APP-1317/chat-request-ui-is-confusing) about hiding `chat requests` when there are no messages in the inbox. This implementation updates the logic to only render the "Inbox" request types if at least 1 request is present.

Before:
<img width="1215" height="804" alt="Screenshot 2025-07-23 at 2 50 42 PM" src="https://github.com/user-attachments/assets/cce97be6-a535-4359-bd92-4a1747569d48" />



After: 
<img width="1215" height="804" alt="Screenshot 2025-07-23 at 2 52 57 PM" src="https://github.com/user-attachments/assets/7a961d06-eb43-41f7-813e-25cd523c2077" />
<img width="1215" height="804" alt="Screenshot 2025-07-23 at 4 28 17 PM" src="https://github.com/user-attachments/assets/3d6e27d9-fbac-46a7-b311-b693b7c35345" />

