### PR TITLE
If birth date is not set, ensure AA still shows

### DIFF
--- a/src/state/ageAssurance/useAgeAssurance.ts
+++ b/src/state/ageAssurance/useAgeAssurance.ts
@@ -28,7 +28,8 @@ export function useAgeAssurance(): AgeAssurance {
 
   return useMemo(() => {
     const isReady = aa.isReady && preferencesLoaded
-    const isDeclaredUnderage = (declaredAge || 0) < 18
+    const isDeclaredUnderage =
+      declaredAge !== undefined ? declaredAge < 18 : false
     const state: AgeAssurance = {
       isReady,
       status: aa.status,


### PR DESCRIPTION
If a user has self-declared to be under 18, we don't need to pester them with AA, and we just leave moderation settings and DMs disabled. However, if we don't have a birthdate for them, we don't know, and therefore we _should_ encourage them to complete AA.

This logic really is more accurate to the intent of this variable: is _declared_ underage. If they haven't declared, then, well, this should be false.