### PR TITLE
Fix some auto complete issues on mobile

### DIFF
--- a/__tests__/lib/strings/mention-manip.test.ts
+++ b/__tests__/lib/strings/mention-manip.test.ts
@@ -32,6 +32,7 @@ describe('getMentionAt', () => {
     ['@alice hello', 7, undefined],
     ['alice@alice', 0, undefined],
     ['alice@alice', 6, undefined],
+    ['hello @alice-com goodbye', 8, 'alice-com'],
   ]
 
   it.each(cases)(
@@ -72,6 +73,7 @@ describe('insertMentionAt', () => {
     ['@alice hello', 7, '@alice hello'],
     ['alice@alice', 0, 'alice@alice'],
     ['alice@alice', 6, 'alice@alice'],
+    ['hello @alice-com goodbye', 10, 'hello @alice.com  goodbye'],
   ]
 
   it.each(cases)(

--- a/src/lib/strings/mention-manip.ts
+++ b/src/lib/strings/mention-manip.ts
@@ -7,7 +7,7 @@ export function getMentionAt(
   text: string,
   cursorPos: number,
 ): FoundMention | undefined {
-  let re = /(^|\s)@([a-z0-9.]*)/gi
+  let re = /(^|\s)@([a-z0-9.-]*)/gi
   let match
   while ((match = re.exec(text))) {
     const spaceOffset = match[1].length

--- a/src/view/com/composer/text-input/TextInput.tsx
+++ b/src/view/com/composer/text-input/TextInput.tsx
@@ -96,10 +96,11 @@ export const TextInput = forwardRef(function TextInputImpl(
       newRt.detectFacetsWithoutResolution()
       setRichText(newRt)
 
-      const prefix = getMentionAt(
-        newText,
-        textInputSelection.current?.start || 0,
-      )
+      // NOTE: BinaryFiddler
+      // onChangeText happens before onSelectionChange, cursorPos is out of bound if the user deletes characters,
+      const cursorPos = textInputSelection.current?.start ?? 0
+      const prefix = getMentionAt(newText, Math.min(cursorPos, newText.length))
+
       if (prefix) {
         setAutocompletePrefix(prefix.value)
       } else if (autocompletePrefix) {


### PR DESCRIPTION
Fixing 2 issues:

1. Include hyphen in `getMentionAt` 's regex
2. Fix an issue where cursorPos is out of bound when user deletes character from the end

Web uses a different component, these fixes should only affect native

https://github.com/user-attachments/assets/07f02d61-ab57-43e4-908a-004b80d7b1f9



ticket:
1. https://linear.app/blueskyweb/issue/APP-1332/handle-autocomplete-broken-for-handles-with-hyphens
2. https://linear.app/blueskyweb/issue/APP-1337/autocomplete-system-on-mobile-isnt-properly-re-triggering-when