### PR TITLE
feat: new design for "Suggested for you" interstitial

### DIFF
--- a/src/components/FeedInterstitials.tsx
+++ b/src/components/FeedInterstitials.tsx
@@ -25,7 +25,7 @@ import {
   type ViewStyleProp,
   web,
 } from '#/alf'
-import {Button} from '#/components/Button'
+import {Button, ButtonText} from '#/components/Button'
 import * as FeedCard from '#/components/FeedCard'
 import {ArrowRight_Stroke2_Corner0_Rounded as Arrow} from '#/components/icons/Arrow'
 import {Hashtag_Stroke2_Corner0_Rounded as Hashtag} from '#/components/icons/Hashtag'
@@ -64,15 +64,30 @@ function CardOuter({
 
 export function SuggestedFollowPlaceholder() {
   const t = useTheme()
+
   return (
-    <CardOuter style={[a.gap_md, t.atoms.border_contrast_low]}>
-      <View style={[a.flex_col, a.align_center, a.gap_sm]}>
-        <ProfileCard.AvatarPlaceholder size={88} />
-        <ProfileCard.NamePlaceholder />
-        <View style={[a.w_full]}>
-          <ProfileCard.DescriptionPlaceholder numberOfLines={2} />
+    <CardOuter
+      style={[a.gap_md, t.atoms.border_contrast_low, t.atoms.shadow_sm]}>
+      <ProfileCard.Outer>
+        <View
+          style={[a.flex_col, a.align_center, a.gap_sm, a.pb_sm, a.mb_auto]}>
+          <ProfileCard.AvatarPlaceholder size={88} />
+          <ProfileCard.NamePlaceholder />
+          <View style={[a.w_full]}>
+            <ProfileCard.DescriptionPlaceholder numberOfLines={2} />
+          </View>
         </View>
-      </View>
+
+        <Button
+          label=""
+          size="small"
+          variant="solid"
+          color="secondary"
+          disabled
+          style={[a.w_full, a.rounded_sm]}>
+          <ButtonText>Follow</ButtonText>
+        </Button>
+      </ProfileCard.Outer>
     </CardOuter>
   )
 }

--- a/src/components/FeedInterstitials.tsx
+++ b/src/components/FeedInterstitials.tsx
@@ -47,8 +47,8 @@ function CardOuter({
     <View
       style={[
         a.w_full,
-        a.p_lg,
-        a.rounded_md,
+        a.p_md,
+        a.rounded_lg,
         a.border,
         t.atoms.bg,
         t.atoms.border_contrast_low,
@@ -281,6 +281,8 @@ export function ProfileGrid({
             <CardOuter
               style={[
                 a.flex_1,
+                a.border,
+                t.atoms.border_contrast_low,
                 (hovered || pressed) && t.atoms.border_contrast_high,
                 t.atoms.shadow_sm,
               ]}>

--- a/src/components/FeedInterstitials.tsx
+++ b/src/components/FeedInterstitials.tsx
@@ -313,7 +313,7 @@ export function ProfileGrid({
                     moderationOpts={moderationOpts}
                     size={88}
                   />
-                  <View style={[a.flex_col, a.align_center]}>
+                  <View style={[a.flex_col, a.align_center, a.max_w_full]}>
                     <ProfileCard.Name
                       profile={profile}
                       moderationOpts={moderationOpts}

--- a/src/components/FeedInterstitials.tsx
+++ b/src/components/FeedInterstitials.tsx
@@ -285,6 +285,7 @@ export function ProfileGrid({
                 t.atoms.border_contrast_low,
                 (hovered || pressed) && t.atoms.border_contrast_high,
                 t.atoms.shadow_sm,
+                {width: 165},
               ]}>
               <ProfileCard.Outer>
                 <ProfileCard.Header>

--- a/src/components/FeedInterstitials.tsx
+++ b/src/components/FeedInterstitials.tsx
@@ -253,7 +253,10 @@ export function ProfileGrid({
       .map((_, i) => (
         <View
           key={i}
-          style={[gtMobile && web([a.flex_0, {width: 'calc(50% - 6px)'}])]}>
+          style={[
+            gtMobile &&
+              web([a.flex_0, {width: `calc(50% - ${a.gap_md.gap / 2}px)`}]),
+          ]}>
           <SuggestedFollowPlaceholder />
         </View>
       ))
@@ -275,7 +278,8 @@ export function ProfileGrid({
           }}
           style={[
             a.flex_1,
-            gtMobile && web([a.flex_0, {width: 'calc(50% - 6px)'}]),
+            gtMobile &&
+              web([a.flex_0, {width: `calc(50% - ${a.gap_md.gap / 2}px)`}]),
           ]}>
           {({hovered, pressed}) => (
             <CardOuter

--- a/src/components/FeedInterstitials.tsx
+++ b/src/components/FeedInterstitials.tsx
@@ -376,8 +376,10 @@ export function ProfileGrid({
             <Trans>Suggested for you</Trans>
           )}
         </Text>
-        <InlineLinkText label={_(msg`See all suggested profiles`)} to="/search">
-          <Trans>See all</Trans>
+        <InlineLinkText
+          label={_(msg`See more suggested profiles on the Explore page`)}
+          to="/search">
+          <Trans>See more</Trans>
         </InlineLinkText>
       </View>
 

--- a/src/components/FeedInterstitials.tsx
+++ b/src/components/FeedInterstitials.tsx
@@ -338,7 +338,7 @@ export function ProfileGrid({
           a.align_center,
           a.justify_between,
         ]}>
-        <Text style={[a.text_sm, a.font_bold, t.atoms.text_contrast_medium]}>
+        <Text style={[a.text_sm, a.font_bold, t.atoms.text]}>
           {viewContext === 'profile' ? (
             <Trans>Similar accounts</Trans>
           ) : (

--- a/src/components/FeedInterstitials.tsx
+++ b/src/components/FeedInterstitials.tsx
@@ -256,7 +256,11 @@ export function ProfileGrid({
           key={i}
           style={[
             gtMobile &&
-              web([a.flex_0, {width: `calc(50% - ${a.gap_md.gap / 2}px)`}]),
+              web([
+                a.flex_0,
+                a.flex_grow,
+                {width: `calc(30% - ${a.gap_md.gap / 2}px)`},
+              ]),
           ]}>
           <SuggestedFollowPlaceholder />
         </View>

--- a/src/components/FeedInterstitials.tsx
+++ b/src/components/FeedInterstitials.tsx
@@ -243,7 +243,6 @@ export function ProfileGrid({
   const t = useTheme()
   const {_} = useLingui()
   const moderationOpts = useModerationOpts()
-  const navigation = useNavigation<NavigationProp>()
   const {gtMobile} = useBreakpoints()
   const isLoading = isSuggestionsLoading || !moderationOpts
   const maxLength = gtMobile ? 3 : 6
@@ -403,26 +402,6 @@ export function ProfileGrid({
               style={[a.overflow_visible]}>
               <View style={[a.px_lg, a.pb_lg, a.flex_row, a.gap_md]}>
                 {content}
-
-                <Button
-                  label={_(msg`Browse more accounts on the Explore page`)}
-                  onPress={() => {
-                    navigation.navigate('SearchTab')
-                  }}>
-                  <CardOuter style={[a.flex_1, {borderWidth: 0}]}>
-                    <View style={[a.flex_1, a.justify_center]}>
-                      <View style={[a.flex_row, a.px_lg]}>
-                        <Text style={[a.pr_xl, a.flex_1, a.leading_snug]}>
-                          <Trans>
-                            Browse more suggestions on the Explore page
-                          </Trans>
-                        </Text>
-
-                        <Arrow size="xl" />
-                      </View>
-                    </View>
-                  </CardOuter>
-                </Button>
               </View>
             </ScrollView>
           </View>

--- a/src/components/FeedInterstitials.tsx
+++ b/src/components/FeedInterstitials.tsx
@@ -29,7 +29,6 @@ import {Button} from '#/components/Button'
 import * as FeedCard from '#/components/FeedCard'
 import {ArrowRight_Stroke2_Corner0_Rounded as Arrow} from '#/components/icons/Arrow'
 import {Hashtag_Stroke2_Corner0_Rounded as Hashtag} from '#/components/icons/Hashtag'
-import {PersonPlus_Stroke2_Corner0_Rounded as Person} from '#/components/icons/Person'
 import {InlineLinkText} from '#/components/Link'
 import * as ProfileCard from '#/components/ProfileCard'
 import {Text} from '#/components/Typography'
@@ -345,7 +344,9 @@ export function ProfileGrid({
             <Trans>Suggested for you</Trans>
           )}
         </Text>
-        <Person fill={t.atoms.text_contrast_low.color} size="sm" />
+        <InlineLinkText label={_(msg`See all suggested profiles`)} to="/search">
+          <Trans>See all</Trans>
+        </InlineLinkText>
       </View>
 
       {gtMobile ? (

--- a/src/components/FeedInterstitials.tsx
+++ b/src/components/FeedInterstitials.tsx
@@ -66,12 +66,14 @@ export function SuggestedFollowPlaceholder() {
   const t = useTheme()
   return (
     <CardOuter style={[a.gap_md, t.atoms.border_contrast_low]}>
-      <ProfileCard.Header>
-        <ProfileCard.AvatarPlaceholder />
-        <ProfileCard.NameAndHandlePlaceholder />
-      </ProfileCard.Header>
-
-      <ProfileCard.DescriptionPlaceholder numberOfLines={2} />
+      <View style={[a.flex_col, a.align_center, a.gap_sm]}>
+        <ProfileCard.AvatarPlaceholder size={88} />
+        <ProfileCard.NamePlaceholder />
+        <ProfileCard.DescriptionPlaceholder
+          numberOfLines={2}
+          style={[a.align_center, a.flex, a.self_stretch]}
+        />
+      </View>
     </CardOuter>
   )
 }

--- a/src/components/FeedInterstitials.tsx
+++ b/src/components/FeedInterstitials.tsx
@@ -378,19 +378,9 @@ export function ProfileGrid({
       </View>
 
       {gtMobile ? (
-        <View style={[a.flex_1, a.px_lg, a.pb_lg, a.gap_md]}>
+        <View style={[a.px_lg, a.pb_lg]}>
           <View style={[a.flex_1, a.flex_row, a.flex_wrap, a.gap_md]}>
             {content}
-          </View>
-
-          <View style={[a.flex_row, a.justify_end, a.align_center, a.gap_md]}>
-            <InlineLinkText
-              label={_(msg`Browse more suggestions`)}
-              to="/search"
-              style={[t.atoms.text_contrast_medium]}>
-              <Trans>Browse more suggestions</Trans>
-            </InlineLinkText>
-            <Arrow size="sm" fill={t.atoms.text_contrast_medium.color} />
           </View>
         </View>
       ) : (

--- a/src/components/FeedInterstitials.tsx
+++ b/src/components/FeedInterstitials.tsx
@@ -294,30 +294,41 @@ export function ProfileGrid({
                     moderationOpts={moderationOpts}
                     size={88}
                   />
-                  <ProfileCard.Name
-                    profile={profile}
-                    moderationOpts={moderationOpts}
-                  />
-                  <ProfileCard.FollowButton
-                    profile={profile}
-                    moderationOpts={moderationOpts}
-                    logContext="FeedInterstitial"
-                    shape="round"
-                    colorInverted
-                    onFollow={() => {
-                      logEvent('suggestedUser:follow', {
-                        logContext:
-                          viewContext === 'feed'
-                            ? 'InterstitialDiscover'
-                            : 'InterstitialProfile',
-                        location: 'Card',
-                        recId,
-                        position: index,
-                      })
-                    }}
-                  />
-                <ProfileCard.Description profile={profile} numberOfLines={2} />
+                  <View style={[a.flex_col, a.align_center]}>
+                    <ProfileCard.Name
+                      profile={profile}
+                      moderationOpts={moderationOpts}
+                    />
+                    <ProfileCard.Description
+                      profile={profile}
+                      numberOfLines={2}
+                      style={[
+                        t.atoms.text_contrast_medium,
+                        a.text_center,
+                        a.text_xs,
+                      ]}
+                    />
+                  </View>
                 </View>
+
+                <ProfileCard.FollowButton
+                  profile={profile}
+                  moderationOpts={moderationOpts}
+                  logContext="FeedInterstitial"
+                  withIcon={false}
+                  style={[a.rounded_sm]}
+                  onFollow={() => {
+                    logEvent('suggestedUser:follow', {
+                      logContext:
+                        viewContext === 'feed'
+                          ? 'InterstitialDiscover'
+                          : 'InterstitialProfile',
+                      location: 'Card',
+                      recId,
+                      position: index,
+                    })
+                  }}
+                />
               </ProfileCard.Outer>
             </CardOuter>
           )}

--- a/src/components/FeedInterstitials.tsx
+++ b/src/components/FeedInterstitials.tsx
@@ -415,12 +415,40 @@ export function ProfileGrid({
               style={[a.overflow_visible]}>
               <View style={[a.px_lg, a.pb_lg, a.flex_row, a.gap_md]}>
                 {content}
+
+                <SeeMoreSuggestedProfilesCard />
               </View>
             </ScrollView>
           </View>
         </BlockDrawerGesture>
       )}
     </View>
+  )
+}
+
+function SeeMoreSuggestedProfilesCard() {
+  const navigation = useNavigation<NavigationProp>()
+  const t = useTheme()
+  const {_} = useLingui()
+
+  return (
+    <Button
+      label={_(msg`Browse more accounts on the Explore page`)}
+      onPress={() => {
+        navigation.navigate('SearchTab')
+      }}>
+      <CardOuter style={[a.flex_1, t.atoms.shadow_sm]}>
+        <View style={[a.flex_1, a.justify_center]}>
+          <View style={[a.flex_col, a.align_center, a.gap_md]}>
+            <Text style={[a.leading_snug, a.text_center]}>
+              <Trans>See more accounts you might like</Trans>
+            </Text>
+
+            <Arrow size="xl" />
+          </View>
+        </View>
+      </CardOuter>
+    </Button>
   )
 }
 

--- a/src/components/FeedInterstitials.tsx
+++ b/src/components/FeedInterstitials.tsx
@@ -288,7 +288,7 @@ export function ProfileGrid({
                 {width: 165},
               ]}>
               <ProfileCard.Outer>
-                <ProfileCard.Header>
+                <View style={[a.flex_col, a.align_center, a.gap_sm, a.pb_sm]}>
                   <ProfileCard.Avatar
                     profile={profile}
                     moderationOpts={moderationOpts}
@@ -315,8 +315,8 @@ export function ProfileGrid({
                       })
                     }}
                   />
-                </ProfileCard.Header>
                 <ProfileCard.Description profile={profile} numberOfLines={2} />
+                </View>
               </ProfileCard.Outer>
             </CardOuter>
           )}

--- a/src/components/FeedInterstitials.tsx
+++ b/src/components/FeedInterstitials.tsx
@@ -69,10 +69,9 @@ export function SuggestedFollowPlaceholder() {
       <View style={[a.flex_col, a.align_center, a.gap_sm]}>
         <ProfileCard.AvatarPlaceholder size={88} />
         <ProfileCard.NamePlaceholder />
-        <ProfileCard.DescriptionPlaceholder
-          numberOfLines={2}
-          style={[a.align_center, a.flex, a.self_stretch]}
-        />
+        <View style={[a.w_full]}>
+          <ProfileCard.DescriptionPlaceholder numberOfLines={2} />
+        </View>
       </View>
     </CardOuter>
   )

--- a/src/components/FeedInterstitials.tsx
+++ b/src/components/FeedInterstitials.tsx
@@ -35,7 +35,7 @@ import {Text} from '#/components/Typography'
 import type * as bsky from '#/types/bsky'
 import {ProgressGuideList} from './ProgressGuide/List'
 
-const MOBILE_CARD_WIDTH = 300
+const MOBILE_CARD_WIDTH = 165
 
 function CardOuter({
   children,
@@ -285,7 +285,6 @@ export function ProfileGrid({
                 t.atoms.border_contrast_low,
                 (hovered || pressed) && t.atoms.border_contrast_high,
                 t.atoms.shadow_sm,
-                {width: 165},
               ]}>
               <ProfileCard.Outer>
                 <View style={[a.flex_col, a.align_center, a.gap_sm, a.pb_sm]}>

--- a/src/components/FeedInterstitials.tsx
+++ b/src/components/FeedInterstitials.tsx
@@ -247,7 +247,7 @@ export function ProfileGrid({
   const navigation = useNavigation<NavigationProp>()
   const {gtMobile} = useBreakpoints()
   const isLoading = isSuggestionsLoading || !moderationOpts
-  const maxLength = gtMobile ? 4 : 6
+  const maxLength = gtMobile ? 3 : 6
 
   const content = isLoading ? (
     Array(maxLength)
@@ -281,7 +281,11 @@ export function ProfileGrid({
           style={[
             a.flex_1,
             gtMobile &&
-              web([a.flex_0, {width: `calc(50% - ${a.gap_md.gap / 2}px)`}]),
+              web([
+                a.flex_0,
+                a.flex_grow,
+                {width: `calc(30% - ${a.gap_md.gap / 2}px)`},
+              ]),
           ]}>
           {({hovered, pressed}) => (
             <CardOuter

--- a/src/components/FeedInterstitials.tsx
+++ b/src/components/FeedInterstitials.tsx
@@ -373,7 +373,7 @@ export function ProfileGrid({
 
       {gtMobile ? (
         <View style={[a.flex_1, a.px_lg, a.pb_lg, a.gap_md]}>
-          <View style={[a.flex_1, a.flex_row, a.flex_wrap, a.gap_sm]}>
+          <View style={[a.flex_1, a.flex_row, a.flex_wrap, a.gap_md]}>
             {content}
           </View>
 

--- a/src/components/FeedInterstitials.tsx
+++ b/src/components/FeedInterstitials.tsx
@@ -282,6 +282,7 @@ export function ProfileGrid({
               style={[
                 a.flex_1,
                 (hovered || pressed) && t.atoms.border_contrast_high,
+                t.atoms.shadow_sm,
               ]}>
               <ProfileCard.Outer>
                 <ProfileCard.Header>
@@ -372,7 +373,8 @@ export function ProfileGrid({
               horizontal
               showsHorizontalScrollIndicator={false}
               snapToInterval={MOBILE_CARD_WIDTH + a.gap_md.gap}
-              decelerationRate="fast">
+              decelerationRate="fast"
+              style={[a.overflow_visible]}>
               <View style={[a.px_lg, a.pb_lg, a.flex_row, a.gap_md]}>
                 {content}
 

--- a/src/components/FeedInterstitials.tsx
+++ b/src/components/FeedInterstitials.tsx
@@ -292,6 +292,7 @@ export function ProfileGrid({
                   <ProfileCard.Avatar
                     profile={profile}
                     moderationOpts={moderationOpts}
+                    size={88}
                   />
                   <ProfileCard.NameAndHandle
                     profile={profile}

--- a/src/components/FeedInterstitials.tsx
+++ b/src/components/FeedInterstitials.tsx
@@ -308,10 +308,8 @@ export function ProfileGrid({
             <CardOuter
               style={[
                 a.flex_1,
-                a.border,
-                t.atoms.border_contrast_low,
-                (hovered || pressed) && t.atoms.border_contrast_high,
                 t.atoms.shadow_sm,
+                (hovered || pressed) && t.atoms.border_contrast_high,
               ]}>
               <ProfileCard.Outer>
                 <View

--- a/src/components/FeedInterstitials.tsx
+++ b/src/components/FeedInterstitials.tsx
@@ -287,7 +287,14 @@ export function ProfileGrid({
                 t.atoms.shadow_sm,
               ]}>
               <ProfileCard.Outer>
-                <View style={[a.flex_col, a.align_center, a.gap_sm, a.pb_sm]}>
+                <View
+                  style={[
+                    a.flex_col,
+                    a.align_center,
+                    a.gap_sm,
+                    a.pb_sm,
+                    a.mb_auto,
+                  ]}>
                   <ProfileCard.Avatar
                     profile={profile}
                     moderationOpts={moderationOpts}

--- a/src/components/FeedInterstitials.tsx
+++ b/src/components/FeedInterstitials.tsx
@@ -333,7 +333,7 @@ export function ProfileGrid({
       <View
         style={[
           a.p_lg,
-          a.pb_xs,
+          a.py_md,
           a.flex_row,
           a.align_center,
           a.justify_between,
@@ -349,7 +349,7 @@ export function ProfileGrid({
       </View>
 
       {gtMobile ? (
-        <View style={[a.flex_1, a.px_lg, a.pt_sm, a.pb_lg, a.gap_md]}>
+        <View style={[a.flex_1, a.px_lg, a.pb_lg, a.gap_md]}>
           <View style={[a.flex_1, a.flex_row, a.flex_wrap, a.gap_sm]}>
             {content}
           </View>
@@ -372,7 +372,7 @@ export function ProfileGrid({
               showsHorizontalScrollIndicator={false}
               snapToInterval={MOBILE_CARD_WIDTH + a.gap_md.gap}
               decelerationRate="fast">
-              <View style={[a.px_lg, a.pt_sm, a.pb_lg, a.flex_row, a.gap_md]}>
+              <View style={[a.px_lg, a.pb_lg, a.flex_row, a.gap_md]}>
                 {content}
 
                 <Button

--- a/src/components/FeedInterstitials.tsx
+++ b/src/components/FeedInterstitials.tsx
@@ -294,7 +294,7 @@ export function ProfileGrid({
                     moderationOpts={moderationOpts}
                     size={88}
                   />
-                  <ProfileCard.NameAndHandle
+                  <ProfileCard.Name
                     profile={profile}
                     moderationOpts={moderationOpts}
                   />

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -20,7 +20,13 @@ import {useProfileFollowMutationQueue} from '#/state/queries/profile'
 import {useSession} from '#/state/session'
 import * as Toast from '#/view/com/util/Toast'
 import {PreviewableUserAvatar, UserAvatar} from '#/view/com/util/UserAvatar'
-import {atoms as a, platform, useTheme} from '#/alf'
+import {
+  atoms as a,
+  platform,
+  TextStyleProp,
+  useTheme,
+  ViewStyleProp,
+} from '#/alf'
 import {
   Button,
   ButtonIcon,
@@ -136,12 +142,14 @@ export function Avatar({
   onPress,
   disabledPreview,
   liveOverride,
+  size = 40,
 }: {
   profile: bsky.profile.AnyProfileView
   moderationOpts: ModerationOpts
   onPress?: () => void
   disabledPreview?: boolean
   liveOverride?: boolean
+  size?: number
 }) {
   const moderation = moderateProfile(profile, moderationOpts)
 
@@ -149,7 +157,7 @@ export function Avatar({
 
   return disabledPreview ? (
     <UserAvatar
-      size={40}
+      size={size}
       avatar={profile.avatar}
       type={profile.associated?.labeler ? 'labeler' : 'user'}
       moderation={moderation.ui('avatar')}
@@ -157,7 +165,7 @@ export function Avatar({
     />
   ) : (
     <PreviewableUserAvatar
-      size={40}
+      size={size}
       profile={profile}
       moderation={moderation.ui('avatar')}
       onBeforePress={onPress}

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -282,7 +282,7 @@ export function Name({
   )
   const verification = useSimpleVerificationState({profile})
   return (
-    <View style={[a.flex_row, a.align_center]}>
+    <View style={[a.flex_row, a.align_center, a.max_w_full]}>
       <Text
         emoji
         style={[

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -354,10 +354,11 @@ export function NameAndHandlePlaceholder() {
 export function Description({
   profile: profileUnshadowed,
   numberOfLines = 3,
+  style,
 }: {
   profile: bsky.profile.AnyProfileView
   numberOfLines?: number
-}) {
+} & TextStyleProp) {
   const profile = useProfileShadow(profileUnshadowed)
   const rt = useMemo(() => {
     if (!('description' in profile)) return
@@ -377,7 +378,7 @@ export function Description({
     <View style={[a.pt_xs]}>
       <RichText
         value={rt}
-        style={[a.leading_snug]}
+        style={[a.leading_snug, style]}
         numberOfLines={numberOfLines}
         disableLinks
       />

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -23,9 +23,9 @@ import {PreviewableUserAvatar, UserAvatar} from '#/view/com/util/UserAvatar'
 import {
   atoms as a,
   platform,
-  TextStyleProp,
+  type TextStyleProp,
   useTheme,
-  ViewStyleProp,
+  type ViewStyleProp,
 } from '#/alf'
 import {
   Button,
@@ -348,6 +348,24 @@ export function NameAndHandlePlaceholder() {
         ]}
       />
     </View>
+  )
+}
+
+export function NamePlaceholder({style}: ViewStyleProp) {
+  const t = useTheme()
+
+  return (
+    <View
+      style={[
+        a.rounded_xs,
+        t.atoms.bg_contrast_25,
+        {
+          width: '60%',
+          height: 14,
+        },
+        style,
+      ]}
+    />
   )
 }
 

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -174,7 +174,7 @@ export function Avatar({
   )
 }
 
-export function AvatarPlaceholder() {
+export function AvatarPlaceholder({size = 40}: {size?: number}) {
   const t = useTheme()
   return (
     <View
@@ -182,8 +182,8 @@ export function AvatarPlaceholder() {
         a.rounded_full,
         t.atoms.bg_contrast_25,
         {
-          width: 40,
-          height: 40,
+          width: size,
+          height: size,
         },
       ]}
     />


### PR DESCRIPTION
Summary
---

- interstitial padding top `16 -> 12`
- replace right side icon (follow person) to be See all
- text Suggested for you color `contrast_medium -> text-default`
- small drop shadow on profile card
- profile card padding all sides `16 -> 12`
- profile card border radius `10 -> 16`
- vertical flex for profile card elements
- remove profile handle
- profile avatar size `40 -> 88`
- profile description text size `sm -> xs`
- replace round follow icon button with standard follow button pill 

Linear: https://linear.app/blueskyweb/issue/APP-1330/new-design-for-suggested-for-you-interstitial

Pictures
---

Old web
<img width="1208" height="675" alt="image" src="https://github.com/user-attachments/assets/27615591-0f66-4b3b-b8fc-8596afe22dfb" />

New web
<img width="1208" height="559" alt="image" src="https://github.com/user-attachments/assets/a242298b-40d5-493e-a754-fff7a4cf7e16" />

Old mobile
<img width="1179" height="526" alt="Simulator Screenshot - BlueSky - 2025-07-28 at 18 57 30" src="https://github.com/user-attachments/assets/0bec1017-4090-4e87-b779-9fdd38e0f03c" />


New mobile
<img width="1179" height="830" alt="Simulator Screenshot - BlueSky - 2025-07-28 at 18 56 44" src="https://github.com/user-attachments/assets/07d23c74-11d4-4fd1-8bbf-b9efe2ec0659" />

Final card on mobile (never on web)
<img width="1179" height="829" alt="Simulator Screenshot - BlueSky - 2025-07-29 at 17 30 07" src="https://github.com/user-attachments/assets/81b3815c-cede-496d-828c-314c206474fb" />
