### PR TITLE
Fix dataSet for noFeedback links

### DIFF
--- a/src/view/com/util/Link.tsx
+++ b/src/view/com/util/Link.tsx
@@ -101,13 +101,9 @@ export const Link = memo(function Link({
     {name: 'activate', label: title},
   ]
 
-  const dataSet = useMemo(() => {
-    const ds = {...dataSetProp}
-    if (anchorNoUnderline) {
-      ds.noUnderline = 1
-    }
-    return ds
-  }, [dataSetProp, anchorNoUnderline])
+  const dataSet = anchorNoUnderline
+    ? {...dataSetProp, noUnderline: 1}
+    : {...dataSetProp}
 
   if (noFeedback) {
     return (
@@ -200,13 +196,9 @@ export const TextLink = memo(function TextLink({
     console.error('Unable to detect mismatching label')
   }
 
-  const dataSet = useMemo(() => {
-    const ds = {...dataSetProp}
-    if (anchorNoUnderline) {
-      ds.noUnderline = 1
-    }
-    return ds
-  }, [dataSetProp, anchorNoUnderline])
+  const dataSet = anchorNoUnderline
+    ? {...dataSetProp, noUnderline: 1}
+    : {...dataSetProp}
 
   const onPress = useCallback(
     (e?: Event) => {

--- a/src/view/com/util/Link.tsx
+++ b/src/view/com/util/Link.tsx
@@ -125,6 +125,8 @@ export const Link = memo(function Link({
               onAccessibilityAction?.(e)
             }
           }}
+          // @ts-ignore web only -sfn
+          dataSet={dataSet}
           {...props}
           android_ripple={{
             color: t.atoms.bg_contrast_25.backgroundColor,

--- a/src/view/com/util/Link.tsx
+++ b/src/view/com/util/Link.tsx
@@ -103,7 +103,7 @@ export const Link = memo(function Link({
 
   const dataSet = anchorNoUnderline
     ? {...dataSetProp, noUnderline: 1}
-    : {...dataSetProp}
+    : dataSetProp
 
   if (noFeedback) {
     return (
@@ -198,7 +198,7 @@ export const TextLink = memo(function TextLink({
 
   const dataSet = anchorNoUnderline
     ? {...dataSetProp, noUnderline: 1}
-    : {...dataSetProp}
+    : dataSetProp
 
   const onPress = useCallback(
     (e?: Event) => {


### PR DESCRIPTION
In #5967, I made a change to the link component to fix some suspicious-looking prop mutation of `dataSet`. However, I neglected to notice that props gets spread into two possible components, so if a link has `noFeedback` it wouldn't get passed the `dataSet`. Easy fix - just need to pass the prop.

This fixes feedContext not showing in Discover

Also while I'm here, the useMemo is completely useless since dataSet is almost certainly not stable. Replaced with a simple ternary.