### PR TITLE
Fix bad env substition

### DIFF
--- a/src/env/common.ts
+++ b/src/env/common.ts
@@ -43,9 +43,10 @@ export const BUNDLE_IDENTIFIER: string =
  * for each build. This should only be used for StatSig reporting and shouldn't
  * be used to identify a specific bundle.
  */
-export const BUNDLE_DATE: number = !process.env.EXPO_PUBLIC_BUNDLE_DATE
-  ? 0
-  : Number(process.env.EXPO_PUBLIC_BUNDLE_DATE)
+export const BUNDLE_DATE: number =
+  process.env.EXPO_PUBLIC_BUNDLE_DATE === undefined
+    ? 0
+    : Number(process.env.EXPO_PUBLIC_BUNDLE_DATE)
 
 /**
  * The log level for the app.


### PR DESCRIPTION
When the env vars are inlined, I think this was being evaluated to `false`, because the bundle date was always `0`. Tested this, and ensuring that the substitution is inlined separately works correctly.