### PR TITLE
Tweak case of labels in `SearchResults.tsx`

### DIFF
--- a/src/screens/Search/SearchResults.tsx
+++ b/src/screens/Search/SearchResults.tsx
@@ -255,7 +255,7 @@ let SearchScreenPostResults = ({
           <Trans>
             <InlineLinkText
               style={[pal.link]}
-              label={_(msg`sign in`)}
+              label={_(msg`Sign in`)}
               to={'#'}
               onPress={showSignIn}>
               Sign in
@@ -263,7 +263,7 @@ let SearchScreenPostResults = ({
             <Text style={t.atoms.text_contrast_medium}> or </Text>
             <InlineLinkText
               style={[pal.link]}
-              label={_(msg`create an account`)}
+              label={_(msg`Create an account`)}
               to={'#'}
               onPress={showCreateAccount}>
               create an account


### PR DESCRIPTION
This small PR tweaks the case of two accessibility labels in `SearchResults.tsx` to reduce string duplication:

`sign in` ➡️ `Sign in`
`create an account` ➡️ `Create an account`