### PR TITLE
Don't animate images that will be posted as JPGs

### DIFF
--- a/src/view/com/composer/photos/Gallery.tsx
+++ b/src/view/com/composer/photos/Gallery.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import {
+  type ImageStyle,
   Keyboard,
   type LayoutChangeEvent,
   StyleSheet,
@@ -124,7 +125,7 @@ type GalleryItemProps = {
   image: ComposerImage
   altTextControlStyle?: ViewStyle
   imageControlsStyle?: ViewStyle
-  imageStyle?: ViewStyle
+  imageStyle?: ImageStyle
   onChange: (next: ComposerImage) => void
   onRemove: () => void
 }
@@ -160,7 +161,7 @@ const GalleryItem = ({
 
   return (
     <View
-      style={imageStyle}
+      style={imageStyle as ViewStyle}
       // Fixes ALT and icons appearing with half opacity when the post is inactive
       renderToHardwareTextureAndroid>
       <TouchableOpacity


### PR DESCRIPTION
iOS/Android: When selecting images in the composer, the preview will show the image animating if it's in an animated format. This is misleading because it will be converted to JPG when posting. Solution is to set the `autoplay` prop to `false`

Also set `cachePolicy` to none since it does not need caching

# Before

https://github.com/user-attachments/assets/81c451c5-88ed-4729-904e-621f57f3fa5b

# After

https://github.com/user-attachments/assets/93a78a2f-eeb5-4368-a8ef-cd43b5521ee4

# Test plan

Select a GIF on iOS. Confirm it stays still