### PR TITLE
[APP-1364] fix suggested follows small web view

### DIFF
--- a/src/components/FeedInterstitials.tsx
+++ b/src/components/FeedInterstitials.tsx
@@ -433,6 +433,7 @@ function SeeMoreSuggestedProfilesCard() {
   return (
     <Button
       label={_(msg`Browse more accounts on the Explore page`)}
+      style={[a.flex_col]}
       onPress={() => {
         navigation.navigate('SearchTab')
       }}>


### PR DESCRIPTION
The suggested follows interstitial on a small width web view was overflowing out of the page bounds. This was due to a mistake on my part, in that I set `overflow: 'visible'` on the `ScrollView` to prevent the drop shadow from being cut off.

This PR fixes the overflow issue by removing the overflow and instead shuffling the padding of a few elements so that the cards have proper room to display their drop shadow without being cut off.

Here's a visual of the overflow bug:
<img width="1264" height="982" alt="image" src="https://github.com/user-attachments/assets/3853ea0d-a27a-4666-bc79-4440dbe54d7b" />
