### PR TITLE
feat: resolve pds url from handles in login screen

### DIFF
--- a/src/screens/Login/LoginForm.tsx
+++ b/src/screens/Login/LoginForm.tsx
@@ -47,6 +47,8 @@ export const LoginForm = ({
   onPressForgotPassword,
   onAttemptSuccess,
   onAttemptFailed,
+  debouncedResolveService,
+  isResolvingService,
 }: {
   error: string
   serviceUrl: string
@@ -59,6 +61,8 @@ export const LoginForm = ({
   onPressForgotPassword: () => void
   onAttemptSuccess: () => void
   onAttemptFailed: () => void
+  debouncedResolveService: (identifier: string) => void
+  isResolvingService: boolean
 }) => {
   const t = useTheme()
   const [isProcessing, setIsProcessing] = useState<boolean>(false)
@@ -182,6 +186,13 @@ export const LoginForm = ({
       <View>
         <TextField.LabelText>
           <Trans>Hosting provider</Trans>
+          {isResolvingService && (
+            <ActivityIndicator
+              size={12}
+              color={t.palette.contrast_500}
+              style={a.ml_sm}
+            />
+          )}
         </TextField.LabelText>
         <HostingProvider
           serviceUrl={serviceUrl}
@@ -208,6 +219,10 @@ export const LoginForm = ({
               defaultValue={initialHandle || ''}
               onChangeText={v => {
                 identifierValueRef.current = v
+                // Trigger PDS auto-resolution for handles/DIDs
+                if (v.trim() && (v.includes('.') || v.startsWith('did:'))) {
+                  debouncedResolveService(v.trim())
+                }
               }}
               onSubmitEditing={() => {
                 passwordRef.current?.focus()

--- a/src/state/queries/resolve-identity.ts
+++ b/src/state/queries/resolve-identity.ts
@@ -1,0 +1,24 @@
+/**
+ * Fetches DID document from a DID. Based on {@link https://github.com/a-viv-a/deer-social/blob/main/src/state/queries/direct-fetch-record.ts#L125}
+ * @returns DID document
+ */
+export async function resolvePdsServiceUrl(did: `did:${string}`) {
+  const docUrl = did.startsWith('did:plc:')
+    ? `https://plc.directory/${did}`
+    : `https://${did.substring(8)}/.well-known/did.json`
+
+  // TODO: validate!
+  const doc: {
+    service: {
+      serviceEndpoint: string
+      type: 'AtprotoPersonalDataServer'
+    }[]
+  } = await (await fetch(docUrl)).json()
+  const service = doc.service.find(
+    s => s.type === 'AtprotoPersonalDataServer',
+  )?.serviceEndpoint
+
+  if (service === undefined)
+    throw new Error(`could not find a service for ${did}`)
+  return service
+}


### PR DESCRIPTION
### What's in this PR?

- Implements `resolvePdsServiceUrl` based on [a-viv-a/deer-social](https://github.com/a-viv-a/deer-social/blob/main/src/state/queries/direct-fetch-record.ts#L125) to fetch the DID document using plc.directory or did:web
- In logins screen, after a `.` is detected in the identifier, it will attempts to resolve the PDS URL from the identifier

> [!NOTE]
> Requests are debounced to prevent excessive requests

### Preview

https://github.com/user-attachments/assets/7154ac21-40ea-4479-b534-7b07ac3f1223

