### PR TITLE
Fix android starting at notif screen

### DIFF
--- a/src/lib/hooks/useNotificationHandler.ts
+++ b/src/lib/hooks/useNotificationHandler.ts
@@ -400,9 +400,7 @@ export function getNotificationPayload(
   }
 }
 
-export function notificationToURL(
-  payload: NotificationPayload,
-): string | undefined {
+export function notificationToURL(payload: NotificationPayload): string | null {
   switch (payload?.reason) {
     case 'like':
     case 'repost':
@@ -433,10 +431,19 @@ export function notificationToURL(
     }
     case 'chat-message':
       // should be handled separately
-      return undefined
+      return null
     case 'verified':
     case 'unverified':
-    default:
       return '/notifications'
+    default:
+      // little heuristic - if it's an unknown notification type with a `uri`,
+      // assume it's a valid notification that we don't know about yet.
+      if (payload && (payload as any)?.uri) {
+        return '/notifications'
+      } else {
+        // unknown notification type without a uri - android can give us notifications
+        // when booting that aren't actually our notifications, so just ignore them
+        return null
+      }
   }
 }

--- a/src/lib/hooks/useNotificationHandler.ts
+++ b/src/lib/hooks/useNotificationHandler.ts
@@ -436,14 +436,7 @@ export function notificationToURL(payload: NotificationPayload): string | null {
     case 'unverified':
       return '/notifications'
     default:
-      // little heuristic - if it's an unknown notification type with a `uri`,
-      // assume it's a valid notification that we don't know about yet.
-      if (payload && (payload as any)?.uri) {
-        return '/notifications'
-      } else {
-        // unknown notification type without a uri - android can give us notifications
-        // when booting that aren't actually our notifications, so just ignore them
-        return null
-      }
+      // do nothing if we don't know what to do with it
+      return null
   }
 }


### PR DESCRIPTION
Not tested, because I can't repro, but we're getting reports of something similar to https://github.com/bluesky-social/social-app/pull/8657

The cause last time was deep links showing up as "notification" when fetching them at launch. Clearly, some devices have something similar going on, where it shows some sort of notification at boot. Our fallback behaviour is to redirect to `/notifications` by default, but clearly this is a bad default. Let's redirect to `/notifications` only if it seems to be one our _our_ notifications, by checking for `uri` in the payload

# Test plan

If your android device launches to the notif screen, confirm this fixes it. Otherwise idk. yolo i guess