### PR TITLE
Fix web video ViewportObserver component

### DIFF
--- a/src/components/Post/Embed/VideoEmbed/index.web.tsx
+++ b/src/components/Post/Embed/VideoEmbed/index.web.tsx
@@ -138,53 +138,22 @@ function ViewportObserver({
   useEffect(() => {
     if (!ref.current) return
     if (isFullscreen && !isFirefox) return
-
-    let scrollTimeout: NodeJS.Timeout | null = null
-    let lastObserverEntry: IntersectionObserverEntry | null = null
-
-    const updatePositionFromEntry = () => {
-      if (!lastObserverEntry) return
-      const rect = lastObserverEntry.boundingClientRect
-      const position = rect.y + rect.height / 2
-      sendPosition(position)
-    }
-
-    const handleScroll = () => {
-      if (scrollTimeout) {
-        clearTimeout(scrollTimeout)
-      }
-      scrollTimeout = setTimeout(updatePositionFromEntry, 4) // ~240fps
-    }
-
     const observer = new IntersectionObserver(
       entries => {
         const entry = entries[0]
         if (!entry) return
-        lastObserverEntry = entry
-        setNearScreen(entry.isIntersecting)
-        const rect = entry.boundingClientRect
-        const position = rect.y + rect.height / 2
+        const position =
+          entry.boundingClientRect.y + entry.boundingClientRect.height / 2
         sendPosition(position)
+        setNearScreen(entry.isIntersecting)
       },
-      {threshold: [0, 0.1, 0.25, 0.5, 0.75, 1.0]},
+      {threshold: Array.from({length: 101}, (_, i) => i / 100)},
     )
-
     observer.observe(ref.current)
+    return () => observer.disconnect()
+  }, [sendPosition, isFullscreen])
 
-    if (nearScreen) {
-      window.addEventListener('scroll', handleScroll, {passive: true})
-    }
-
-    return () => {
-      observer.disconnect()
-      if (scrollTimeout) {
-        clearTimeout(scrollTimeout)
-      }
-      window.removeEventListener('scroll', handleScroll)
-    }
-  }, [sendPosition, isFullscreen, nearScreen])
-
-  // In case scrolling hasn't started yet, send the original position
+  // In case scrolling hasn't started yet, send up the position
   useEffect(() => {
     if (ref.current && !isAnyViewActive) {
       const rect = ref.current.getBoundingClientRect()


### PR DESCRIPTION
Reverts #8692 

Deeper investigation reveals that when we changed the video cropping logic, we were cutting off the "sensor" div that sticks out of the post. This is the root cause of #8692, so we can revert.

Code to review is https://github.com/bluesky-social/social-app/pull/8776/commits/86757f004e43c72009a8d101f2ffdaf719794487

# Before

Position only updates when the video touches the edge of the screen

https://github.com/user-attachments/assets/3cb96857-d256-4d70-8c5d-7e82193ee523

# After

https://github.com/user-attachments/assets/cf2a11da-300e-4add-9fbd-4f45e92dc344

