### PR TITLE
Fix quality of first seconds of videos on web

### DIFF
--- a/src/components/Post/Embed/VideoEmbed/VideoEmbedInner/VideoEmbedInnerWeb.tsx
+++ b/src/components/Post/Embed/VideoEmbed/VideoEmbedInner/VideoEmbedInnerWeb.tsx
@@ -224,15 +224,19 @@ function useHLS({
       throw new HLSUnsupportedError()
     }
 
+    const latestEstimate = BandwidthEstimate.get()
     const hls = new Hls({
       maxMaxBufferLength: 10, // only load 10s ahead
       // note: the amount buffered is affected by both maxBufferLength and maxBufferSize
       // it will buffer until it is greater than *both* of those values
       // so we use maxMaxBufferLength to set the actual maximum amount of buffering instead
+      startLevel:
+        latestEstimate === undefined ? -1 : Hls.DefaultConfig.startLevel,
+      // the '-1' value makes a test request to estimate bandwidth and quality level
+      // before showing the first fragment
     })
     hlsRef.current = hls
 
-    const latestEstimate = BandwidthEstimate.get()
     if (latestEstimate !== undefined) {
       hls.bandwidthEstimate = latestEstimate
     }


### PR DESCRIPTION
This PR fixes #8761 where the first seconds of the first loaded video in a session (or "refresh") is always showed in the lowest quality.

The fix is only **one line** (plus comments) that uses [a documented feature of HLS.js](https://github.com/video-dev/hls.js/blob/master/docs/API.md#testbandwidth) to make a test request to estimate the bandwidth before showing the first fragment of the video to the user.

The test request consists of the first fragment of the video in the lowest quality. If the device of the user has fast internet, the first fragment is requested again, in a greater quality, and that's what the user sees first. Otherwise, the first fragment is still requested again in the same quality, but only for the first video of the session (I couldn't figure out how to prevent this).

## Possible concerns

**1. Number of request to the video server**

The number of requests, compared to the current code, is increased by one only when a user with slow internet sees the first video of their session.

On users with medium or fast internet, the number of request remain the same. In the current code the first fragment is updated in the second loop with higher quality.

**2. Delay to see the first video**

Users with very slow internet may perceive an additional time loading the **first video of their sessions.**

Tests were made with the limited internet option of Firefox. The average size of the first fragment of a video in 360p seems to be **400kb**. In "regular 4g" (4Mbps, 20ms of latency) this takes extras 400ms to load. In "good 3G" (1536Kbps, 40ms of latency) the delay observed was 2 seconds.

## Overall impact

Several artists (3d/2d animation mainly) have requested videos to be displayed in full quality from the start since the first experiments with video. The improvement in apparent quality of videos shared with direct link (new session always) could also increase the reputation of the site. 
The extra delay to see the first video of a session seems less significant given the fact that only [4 countries in the world](https://en.wikipedia.org/wiki/List_of_countries_by_Internet_connection_speeds) may experience a half-second delay in average (close to "regular 4g"). I don't know the demographic of bluesky and I don't know how valuable are load speeds to you, but I know is a important metric.

Tests below made with [this video](https://bsky.app/profile/video-testing.bsky.social/post/3lvbbbfpi5k2m).

Before change (current code):

https://github.com/user-attachments/assets/e974c0dc-b2d0-4673-b0ed-584319af5589

After change:

https://github.com/user-attachments/assets/7fc5170c-ff20-48b9-a3a6-cdf2f56ed9e4

Tests were also made in the discovery feed, looking at the HTTP requests both in Firefox 141.0 and Chrome 138.0.7204.183 (OS: Linux Mint).