### PR TITLE
[APP-1365]: Ensure toast text meets a11y guidelines

### DIFF
--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -116,15 +116,15 @@ function useToastStyles({type}: {type: ToastType}) {
         backgroundColor: select(t.name, {
           light: t.palette.primary_25,
           dim: t.palette.primary_25,
-          dark: t.palette.primary_50,
+          dark: t.palette.primary_25,
         }),
         borderColor: select(t.name, {
           light: t.palette.primary_300,
           dim: t.palette.primary_600,
-          dark: t.palette.primary_500,
+          dark: t.palette.primary_300,
         }),
         iconColor: select(t.name, {
-          light: t.palette.primary_500,
+          light: t.palette.primary_600,
           dim: t.palette.primary_600,
           dark: t.palette.primary_600,
         }),

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -2,20 +2,20 @@ import {createContext, useContext, useMemo} from 'react'
 import {View} from 'react-native'
 
 import {atoms as a, select, useTheme} from '#/alf'
-import {Check_Stroke2_Corner0_Rounded as SuccessIcon} from '#/components/icons/Check'
 import {CircleInfo_Stroke2_Corner0_Rounded as CircleInfo} from '#/components/icons/CircleInfo'
 import {CircleInfo_Stroke2_Corner0_Rounded as ErrorIcon} from '#/components/icons/CircleInfo'
 import {Warning_Stroke2_Corner0_Rounded as WarningIcon} from '#/components/icons/Warning'
 import {type ToastType} from '#/components/Toast/types'
 import {Text} from '#/components/Typography'
+import {CircleCheck_Stroke2_Corner0_Rounded as CircleCheck} from '../icons/CircleCheck'
 
 type ContextType = {
   type: ToastType
 }
 
 export const ICONS = {
-  default: SuccessIcon,
-  success: SuccessIcon,
+  default: CircleCheck,
+  success: CircleCheck,
   error: ErrorIcon,
   warning: WarningIcon,
   info: CircleInfo,
@@ -93,34 +93,34 @@ function useToastStyles({type}: {type: ToastType}) {
       default: {
         backgroundColor: select(t.name, {
           light: t.atoms.bg_contrast_25.backgroundColor,
-          dim: t.atoms.bg_contrast_100.backgroundColor,
-          dark: t.atoms.bg_contrast_100.backgroundColor,
+          dim: t.atoms.bg_contrast_25.backgroundColor,
+          dark: t.atoms.bg_contrast_25.backgroundColor,
         }),
         borderColor: select(t.name, {
-          light: t.atoms.border_contrast_low.borderColor,
+          light: t.atoms.border_contrast_high.borderColor,
           dim: t.atoms.border_contrast_high.borderColor,
           dark: t.atoms.border_contrast_high.borderColor,
         }),
         iconColor: select(t.name, {
-          light: t.atoms.text_contrast_medium.color,
-          dim: t.atoms.text_contrast_medium.color,
-          dark: t.atoms.text_contrast_medium.color,
+          light: t.atoms.text.color,
+          dim: t.atoms.text.color,
+          dark: t.atoms.text.color,
         }),
         textColor: select(t.name, {
-          light: t.atoms.text_contrast_medium.color,
-          dim: t.atoms.text_contrast_medium.color,
-          dark: t.atoms.text_contrast_medium.color,
+          light: t.atoms.text.color,
+          dim: t.atoms.text.color,
+          dark: t.atoms.text.color,
         }),
       },
       success: {
         backgroundColor: select(t.name, {
-          light: t.palette.primary_100,
-          dim: t.palette.primary_100,
+          light: t.palette.primary_25,
+          dim: t.palette.primary_25,
           dark: t.palette.primary_50,
         }),
         borderColor: select(t.name, {
-          light: t.palette.primary_500,
-          dim: t.palette.primary_500,
+          light: t.palette.primary_300,
+          dim: t.palette.primary_600,
           dark: t.palette.primary_500,
         }),
         iconColor: select(t.name, {
@@ -129,14 +129,14 @@ function useToastStyles({type}: {type: ToastType}) {
           dark: t.palette.primary_600,
         }),
         textColor: select(t.name, {
-          light: t.palette.primary_500,
+          light: t.palette.primary_600,
           dim: t.palette.primary_600,
           dark: t.palette.primary_600,
         }),
       },
       error: {
         backgroundColor: select(t.name, {
-          light: t.palette.negative_200,
+          light: t.palette.negative_25,
           dim: t.palette.negative_25,
           dark: t.palette.negative_25,
         }),
@@ -159,45 +159,45 @@ function useToastStyles({type}: {type: ToastType}) {
       warning: {
         backgroundColor: select(t.name, {
           light: t.atoms.bg_contrast_25.backgroundColor,
-          dim: t.atoms.bg_contrast_100.backgroundColor,
-          dark: t.atoms.bg_contrast_100.backgroundColor,
+          dim: t.atoms.bg_contrast_25.backgroundColor,
+          dark: t.atoms.bg_contrast_25.backgroundColor,
         }),
         borderColor: select(t.name, {
-          light: t.atoms.border_contrast_low.borderColor,
+          light: t.atoms.border_contrast_high.borderColor,
           dim: t.atoms.border_contrast_high.borderColor,
           dark: t.atoms.border_contrast_high.borderColor,
         }),
         iconColor: select(t.name, {
-          light: t.atoms.text_contrast_medium.color,
-          dim: t.atoms.text_contrast_medium.color,
-          dark: t.atoms.text_contrast_medium.color,
+          light: t.atoms.text.color,
+          dim: t.atoms.text.color,
+          dark: t.atoms.text.color,
         }),
         textColor: select(t.name, {
-          light: t.atoms.text_contrast_medium.color,
-          dim: t.atoms.text_contrast_medium.color,
-          dark: t.atoms.text_contrast_medium.color,
+          light: t.atoms.text.color,
+          dim: t.atoms.text.color,
+          dark: t.atoms.text.color,
         }),
       },
       info: {
         backgroundColor: select(t.name, {
           light: t.atoms.bg_contrast_25.backgroundColor,
-          dim: t.atoms.bg_contrast_100.backgroundColor,
-          dark: t.atoms.bg_contrast_100.backgroundColor,
+          dim: t.atoms.bg_contrast_25.backgroundColor,
+          dark: t.atoms.bg_contrast_25.backgroundColor,
         }),
         borderColor: select(t.name, {
-          light: t.atoms.border_contrast_low.borderColor,
+          light: t.atoms.border_contrast_high.borderColor,
           dim: t.atoms.border_contrast_high.borderColor,
           dark: t.atoms.border_contrast_high.borderColor,
         }),
         iconColor: select(t.name, {
-          light: t.atoms.text_contrast_medium.color,
-          dim: t.atoms.text_contrast_medium.color,
-          dark: t.atoms.text_contrast_medium.color,
+          light: t.atoms.text.color,
+          dim: t.atoms.text.color,
+          dark: t.atoms.text.color,
         }),
         textColor: select(t.name, {
-          light: t.atoms.text_contrast_medium.color,
-          dim: t.atoms.text_contrast_medium.color,
-          dark: t.atoms.text_contrast_medium.color,
+          light: t.atoms.text.color,
+          dim: t.atoms.text.color,
+          dark: t.atoms.text.color,
         }),
       },
     }[type]

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -98,17 +98,17 @@ function useToastStyles({type}: {type: ToastType}) {
       },
       success: {
         backgroundColor: t.palette.primary_25,
-        borderColor: select(t.name, {
-          light: t.palette.primary_300,
-          dim: t.palette.primary_600,
-          dark: t.palette.primary_300,
-        }),
+        borderColor: t.palette.primary_300,
         iconColor: t.palette.primary_600,
         textColor: t.palette.primary_600,
       },
       error: {
         backgroundColor: t.palette.negative_25,
-        borderColor: t.palette.negative_300,
+        borderColor: select(t.name, {
+          light: t.palette.negative_300,
+          dim: t.palette.negative_300,
+          dark: t.palette.negative_300,
+        }),
         iconColor: t.palette.negative_600,
         textColor: t.palette.negative_600,
       },

--- a/src/components/Toast/Toast.tsx
+++ b/src/components/Toast/Toast.tsx
@@ -91,114 +91,38 @@ function useToastStyles({type}: {type: ToastType}) {
   return useMemo(() => {
     return {
       default: {
-        backgroundColor: select(t.name, {
-          light: t.atoms.bg_contrast_25.backgroundColor,
-          dim: t.atoms.bg_contrast_25.backgroundColor,
-          dark: t.atoms.bg_contrast_25.backgroundColor,
-        }),
-        borderColor: select(t.name, {
-          light: t.atoms.border_contrast_high.borderColor,
-          dim: t.atoms.border_contrast_high.borderColor,
-          dark: t.atoms.border_contrast_high.borderColor,
-        }),
-        iconColor: select(t.name, {
-          light: t.atoms.text.color,
-          dim: t.atoms.text.color,
-          dark: t.atoms.text.color,
-        }),
-        textColor: select(t.name, {
-          light: t.atoms.text.color,
-          dim: t.atoms.text.color,
-          dark: t.atoms.text.color,
-        }),
+        backgroundColor: t.atoms.bg_contrast_25.backgroundColor,
+        borderColor: t.atoms.border_contrast_high.borderColor,
+        iconColor: t.atoms.text.color,
+        textColor: t.atoms.text.color,
       },
       success: {
-        backgroundColor: select(t.name, {
-          light: t.palette.primary_25,
-          dim: t.palette.primary_25,
-          dark: t.palette.primary_25,
-        }),
+        backgroundColor: t.palette.primary_25,
         borderColor: select(t.name, {
           light: t.palette.primary_300,
           dim: t.palette.primary_600,
           dark: t.palette.primary_300,
         }),
-        iconColor: select(t.name, {
-          light: t.palette.primary_600,
-          dim: t.palette.primary_600,
-          dark: t.palette.primary_600,
-        }),
-        textColor: select(t.name, {
-          light: t.palette.primary_600,
-          dim: t.palette.primary_600,
-          dark: t.palette.primary_600,
-        }),
+        iconColor: t.palette.primary_600,
+        textColor: t.palette.primary_600,
       },
       error: {
-        backgroundColor: select(t.name, {
-          light: t.palette.negative_25,
-          dim: t.palette.negative_25,
-          dark: t.palette.negative_25,
-        }),
-        borderColor: select(t.name, {
-          light: t.palette.negative_300,
-          dim: t.palette.negative_300,
-          dark: t.palette.negative_300,
-        }),
-        iconColor: select(t.name, {
-          light: t.palette.negative_600,
-          dim: t.palette.negative_600,
-          dark: t.palette.negative_600,
-        }),
-        textColor: select(t.name, {
-          light: t.palette.negative_600,
-          dim: t.palette.negative_600,
-          dark: t.palette.negative_600,
-        }),
+        backgroundColor: t.palette.negative_25,
+        borderColor: t.palette.negative_300,
+        iconColor: t.palette.negative_600,
+        textColor: t.palette.negative_600,
       },
       warning: {
-        backgroundColor: select(t.name, {
-          light: t.atoms.bg_contrast_25.backgroundColor,
-          dim: t.atoms.bg_contrast_25.backgroundColor,
-          dark: t.atoms.bg_contrast_25.backgroundColor,
-        }),
-        borderColor: select(t.name, {
-          light: t.atoms.border_contrast_high.borderColor,
-          dim: t.atoms.border_contrast_high.borderColor,
-          dark: t.atoms.border_contrast_high.borderColor,
-        }),
-        iconColor: select(t.name, {
-          light: t.atoms.text.color,
-          dim: t.atoms.text.color,
-          dark: t.atoms.text.color,
-        }),
-        textColor: select(t.name, {
-          light: t.atoms.text.color,
-          dim: t.atoms.text.color,
-          dark: t.atoms.text.color,
-        }),
+        backgroundColor: t.atoms.bg_contrast_25.backgroundColor,
+        borderColor: t.atoms.border_contrast_high.borderColor,
+        iconColor: t.atoms.text.color,
+        textColor: t.atoms.text.color,
       },
       info: {
-        backgroundColor: select(t.name, {
-          light: t.atoms.bg_contrast_25.backgroundColor,
-          dim: t.atoms.bg_contrast_25.backgroundColor,
-          dark: t.atoms.bg_contrast_25.backgroundColor,
-        }),
-        borderColor: select(t.name, {
-          light: t.atoms.border_contrast_high.borderColor,
-          dim: t.atoms.border_contrast_high.borderColor,
-          dark: t.atoms.border_contrast_high.borderColor,
-        }),
-        iconColor: select(t.name, {
-          light: t.atoms.text.color,
-          dim: t.atoms.text.color,
-          dark: t.atoms.text.color,
-        }),
-        textColor: select(t.name, {
-          light: t.atoms.text.color,
-          dim: t.atoms.text.color,
-          dark: t.atoms.text.color,
-        }),
+        backgroundColor: t.atoms.bg_contrast_25.backgroundColor,
+        borderColor: t.atoms.border_contrast_high.borderColor,
+        iconColor: t.atoms.text.color,
+        textColor: t.atoms.text.color,
       },
     }[type]
   }, [t, type])


### PR DESCRIPTION
This PR addresses this [linear ticket ](https://linear.app/blueskyweb/issue/APP-1365/ensure-toast-text-meets-a11y-guidelines) to ensure toast text meets a11y guidelines as well as improves the success icon to match other icon styles in the toast module. 

The latest toast design in Figma:

<img width="495" height="724" alt="Screenshot 2025-08-04 at 11 48 13 PM" src="https://github.com/user-attachments/assets/3d1a276d-26d5-4a0e-874d-d127299f3e61" />


### **Before:**


https://github.com/user-attachments/assets/d6bee570-4c48-404d-9970-4bd2dc118a84



### **After:**

`Note` in Figma the borderWidth is 0.5px but according to @mozzius , since we are using a variable that is platform specific, it’s 0.333px width on native, but that’s not possible to achieve on web so it’s 1px instead. 

<img width="1284" height="786" alt="Screenshot 2025-08-06 at 12 41 07 PM" src="https://github.com/user-attachments/assets/80335920-8fea-4d06-b06c-b576af7dace5" />
<img width="1284" height="786" alt="Screenshot 2025-08-06 at 12 41 22 PM" src="https://github.com/user-attachments/assets/a7ba39c3-bec9-4b49-ab55-e30165351698" />
<img width="1284" height="786" alt="Screenshot 2025-08-06 at 12 41 33 PM" src="https://github.com/user-attachments/assets/afad42bc-e8f0-45df-85d6-aa946b49a1bb" />


