### PR TITLE
[APP-1357] profile header follow recommendations

### DIFF
--- a/src/components/FeedInterstitials.tsx
+++ b/src/components/FeedInterstitials.tsx
@@ -82,7 +82,6 @@ export function SuggestedFollowPlaceholder() {
         <Button
           label={_(msg`Follow account placeholder`)}
           size="small"
-          variant="solid"
           color="secondary"
           disabled
           style={[a.w_full, a.rounded_sm]}>

--- a/src/components/FeedInterstitials.tsx
+++ b/src/components/FeedInterstitials.tsx
@@ -8,6 +8,7 @@ import {useNavigation} from '@react-navigation/native'
 import {type NavigationProp} from '#/lib/routes/types'
 import {logEvent} from '#/lib/statsig/statsig'
 import {logger} from '#/logger'
+import {isIOS} from '#/platform/detection'
 import {useModerationOpts} from '#/state/preferences/moderation-opts'
 import {useGetPopularFeedsQuery} from '#/state/queries/feed'
 import {type FeedDescriptor} from '#/state/queries/post-feed'
@@ -367,7 +368,8 @@ export function ProfileGrid({
         !isProfileHeaderContext && a.border_t,
         t.atoms.border_contrast_low,
         t.atoms.bg_contrast_25,
-      ]}>
+      ]}
+      pointerEvents={isIOS ? 'auto' : 'box-none'}>
       <View
         style={[
           a.px_lg,
@@ -375,7 +377,8 @@ export function ProfileGrid({
           a.flex_row,
           a.align_center,
           a.justify_between,
-        ]}>
+        ]}
+        pointerEvents={isIOS ? 'auto' : 'box-none'}>
         <Text style={[a.text_sm, a.font_bold, t.atoms.text]}>
           {isFeedContext ? (
             <Trans>Suggested for you</Trans>

--- a/src/components/FeedInterstitials.tsx
+++ b/src/components/FeedInterstitials.tsx
@@ -256,107 +256,105 @@ export function ProfileGrid({
   const maxLength = gtMobile ? 3 : isProfileHeaderContext ? 12 : 6
   const minLength = gtMobile ? 3 : 4
 
-  const content = isLoading ? (
-    Array(maxLength)
-      .fill(0)
-      .map((_, i) => (
-        <View
-          key={i}
-          style={[
-            a.flex_1,
-            gtMobile &&
-              web([
-                a.flex_0,
-                a.flex_grow,
-                {width: `calc(30% - ${a.gap_md.gap / 2}px)`},
-              ]),
-          ]}>
-          <SuggestedFollowPlaceholder />
-        </View>
-      ))
-  ) : error || !profiles.length ? null : (
-    <>
-      {profiles.slice(0, maxLength).map((profile, index) => (
-        <ProfileCard.Link
-          key={profile.did}
-          profile={profile}
-          onPress={() => {
-            logEvent('suggestedUser:press', {
-              logContext: isFeedContext
-                ? 'InterstitialDiscover'
-                : 'InterstitialProfile',
-              recId,
-              position: index,
-            })
-          }}
-          style={[
-            a.flex_1,
-            gtMobile &&
-              web([
-                a.flex_0,
-                a.flex_grow,
-                {width: `calc(30% - ${a.gap_md.gap / 2}px)`},
-              ]),
-          ]}>
-          {({hovered, pressed}) => (
-            <CardOuter
-              style={[(hovered || pressed) && t.atoms.border_contrast_high]}>
-              <ProfileCard.Outer>
-                <View
-                  style={[
-                    a.flex_col,
-                    a.align_center,
-                    a.gap_sm,
-                    a.pb_sm,
-                    a.mb_auto,
-                  ]}>
-                  <ProfileCard.Avatar
-                    profile={profile}
-                    moderationOpts={moderationOpts}
-                    disabledPreview
-                    size={88}
-                  />
-                  <View style={[a.flex_col, a.align_center, a.max_w_full]}>
-                    <ProfileCard.Name
+  const content = isLoading
+    ? Array(maxLength)
+        .fill(0)
+        .map((_, i) => (
+          <View
+            key={i}
+            style={[
+              a.flex_1,
+              gtMobile &&
+                web([
+                  a.flex_0,
+                  a.flex_grow,
+                  {width: `calc(30% - ${a.gap_md.gap / 2}px)`},
+                ]),
+            ]}>
+            <SuggestedFollowPlaceholder />
+          </View>
+        ))
+    : error || !profiles.length
+      ? null
+      : profiles.slice(0, maxLength).map((profile, index) => (
+          <ProfileCard.Link
+            key={profile.did}
+            profile={profile}
+            onPress={() => {
+              logEvent('suggestedUser:press', {
+                logContext: isFeedContext
+                  ? 'InterstitialDiscover'
+                  : 'InterstitialProfile',
+                recId,
+                position: index,
+              })
+            }}
+            style={[
+              a.flex_1,
+              gtMobile &&
+                web([
+                  a.flex_0,
+                  a.flex_grow,
+                  {width: `calc(30% - ${a.gap_md.gap / 2}px)`},
+                ]),
+            ]}>
+            {({hovered, pressed}) => (
+              <CardOuter
+                style={[(hovered || pressed) && t.atoms.border_contrast_high]}>
+                <ProfileCard.Outer>
+                  <View
+                    style={[
+                      a.flex_col,
+                      a.align_center,
+                      a.gap_sm,
+                      a.pb_sm,
+                      a.mb_auto,
+                    ]}>
+                    <ProfileCard.Avatar
                       profile={profile}
                       moderationOpts={moderationOpts}
+                      disabledPreview
+                      size={88}
                     />
-                    <ProfileCard.Description
-                      profile={profile}
-                      numberOfLines={2}
-                      style={[
-                        t.atoms.text_contrast_medium,
-                        a.text_center,
-                        a.text_xs,
-                      ]}
-                    />
+                    <View style={[a.flex_col, a.align_center, a.max_w_full]}>
+                      <ProfileCard.Name
+                        profile={profile}
+                        moderationOpts={moderationOpts}
+                      />
+                      <ProfileCard.Description
+                        profile={profile}
+                        numberOfLines={2}
+                        style={[
+                          t.atoms.text_contrast_medium,
+                          a.text_center,
+                          a.text_xs,
+                        ]}
+                      />
+                    </View>
                   </View>
-                </View>
 
-                <ProfileCard.FollowButton
-                  profile={profile}
-                  moderationOpts={moderationOpts}
-                  logContext="FeedInterstitial"
-                  withIcon={false}
-                  style={[a.rounded_sm]}
-                  onFollow={() => {
-                    logEvent('suggestedUser:follow', {
-                      logContext: isFeedContext
-                        ? 'InterstitialDiscover'
-                        : 'InterstitialProfile',
-                      location: 'Card',
-                      recId,
-                      position: index,
-                    })
-                  }}
-                />
-              </ProfileCard.Outer>
-            </CardOuter>
-          )}
-        </ProfileCard.Link>
-      ))}
-    </>
-  )
+                  <ProfileCard.FollowButton
+                    profile={profile}
+                    moderationOpts={moderationOpts}
+                    logContext="FeedInterstitial"
+                    withIcon={false}
+                    style={[a.rounded_sm]}
+                    onFollow={() => {
+                      logEvent('suggestedUser:follow', {
+                        logContext: isFeedContext
+                          ? 'InterstitialDiscover'
+                          : 'InterstitialProfile',
+                        location: 'Card',
+                        recId,
+                        position: index,
+                      })
+                    }}
+                  />
+                </ProfileCard.Outer>
+              </CardOuter>
+            )}
+          </ProfileCard.Link>
+        ))
 
   if (error || (!isLoading && profiles.length < minLength)) {
     logger.debug(`Not enough profiles to show suggested follows`)

--- a/src/components/FeedInterstitials.tsx
+++ b/src/components/FeedInterstitials.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
-import {View} from 'react-native'
-import {ScrollView} from 'react-native-gesture-handler'
+import {ScrollView, View} from 'react-native'
 import {type AppBskyFeedDefs, AtUri} from '@atproto/api'
 import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
@@ -400,21 +399,19 @@ export function ProfileGrid({
         </View>
       ) : (
         <BlockDrawerGesture>
-          <View>
-            <ScrollView
-              horizontal
-              showsHorizontalScrollIndicator={false}
-              snapToInterval={MOBILE_CARD_WIDTH + a.gap_md.gap}
-              decelerationRate="fast">
-              <View style={[a.p_lg, a.pt_md, a.flex_row, a.gap_md]}>
-                {content}
+          <ScrollView
+            horizontal
+            showsHorizontalScrollIndicator={false}
+            snapToInterval={MOBILE_CARD_WIDTH + a.gap_md.gap}
+            decelerationRate="fast">
+            <View style={[a.p_lg, a.pt_md, a.flex_row, a.gap_md]}>
+              {content}
 
-                {viewContext !== 'profileHeader' && (
-                  <SeeMoreSuggestedProfilesCard />
-                )}
-              </View>
-            </ScrollView>
-          </View>
+              {viewContext !== 'profileHeader' && (
+                <SeeMoreSuggestedProfilesCard />
+              )}
+            </View>
+          </ScrollView>
         </BlockDrawerGesture>
       )}
     </View>

--- a/src/components/FeedInterstitials.tsx
+++ b/src/components/FeedInterstitials.tsx
@@ -323,6 +323,7 @@ export function ProfileGrid({
                   <ProfileCard.Avatar
                     profile={profile}
                     moderationOpts={moderationOpts}
+                    disabledPreview
                     size={88}
                   />
                   <View style={[a.flex_col, a.align_center, a.max_w_full]}>

--- a/src/components/FeedInterstitials.tsx
+++ b/src/components/FeedInterstitials.tsx
@@ -409,7 +409,9 @@ export function ProfileGrid({
               <View style={[a.p_lg, a.pt_md, a.flex_row, a.gap_md]}>
                 {content}
 
-                <SeeMoreSuggestedProfilesCard />
+                {viewContext !== 'profileHeader' && (
+                  <SeeMoreSuggestedProfilesCard />
+                )}
               </View>
             </ScrollView>
           </View>

--- a/src/components/FeedInterstitials.tsx
+++ b/src/components/FeedInterstitials.tsx
@@ -389,10 +389,10 @@ export function ProfileGrid({
           a.justify_between,
         ]}>
         <Text style={[a.text_sm, a.font_bold, t.atoms.text]}>
-          {viewContext === 'profile' ? (
-            <Trans>Similar accounts</Trans>
-          ) : (
+          {viewContext === 'feed' ? (
             <Trans>Suggested for you</Trans>
+          ) : (
+            <Trans>Similar accounts</Trans>
           )}
         </Text>
         {viewContext !== 'profileHeader' && (

--- a/src/components/FeedInterstitials.tsx
+++ b/src/components/FeedInterstitials.tsx
@@ -253,7 +253,7 @@ export function ProfileGrid({
   profiles: bsky.profile.AnyProfileView[]
   recId?: number
   error: Error | null
-  viewContext: 'profile' | 'feed'
+  viewContext: 'profile' | 'profileHeader' | 'feed'
 }) {
   const t = useTheme()
   const {_} = useLingui()
@@ -375,7 +375,11 @@ export function ProfileGrid({
 
   return (
     <View
-      style={[a.border_t, t.atoms.border_contrast_low, t.atoms.bg_contrast_25]}>
+      style={[
+        viewContext !== 'profileHeader' && a.border_t,
+        t.atoms.border_contrast_low,
+        t.atoms.bg_contrast_25,
+      ]}>
       <View
         style={[
           a.px_lg,
@@ -391,11 +395,13 @@ export function ProfileGrid({
             <Trans>Suggested for you</Trans>
           )}
         </Text>
-        <InlineLinkText
-          label={_(msg`See more suggested profiles on the Explore page`)}
-          to="/search">
-          <Trans>See more</Trans>
-        </InlineLinkText>
+        {viewContext !== 'profileHeader' && (
+          <InlineLinkText
+            label={_(msg`See more suggested profiles on the Explore page`)}
+            to="/search">
+            <Trans>See more</Trans>
+          </InlineLinkText>
+        )}
       </View>
 
       {gtMobile ? (

--- a/src/components/FeedInterstitials.tsx
+++ b/src/components/FeedInterstitials.tsx
@@ -63,6 +63,7 @@ function CardOuter({
 }
 
 export function SuggestedFollowPlaceholder() {
+  const {_} = useLingui()
   const t = useTheme()
 
   return (
@@ -79,7 +80,7 @@ export function SuggestedFollowPlaceholder() {
         </View>
 
         <Button
-          label=""
+          label={_(msg`Follow account placeholder`)}
           size="small"
           variant="solid"
           color="secondary"

--- a/src/components/FeedInterstitials.tsx
+++ b/src/components/FeedInterstitials.tsx
@@ -25,7 +25,7 @@ import {
   type ViewStyleProp,
   web,
 } from '#/alf'
-import {Button, ButtonText} from '#/components/Button'
+import {Button} from '#/components/Button'
 import * as FeedCard from '#/components/FeedCard'
 import {ArrowRight_Stroke2_Corner0_Rounded as Arrow} from '#/components/icons/Arrow'
 import {Hashtag_Stroke2_Corner0_Rounded as Hashtag} from '#/components/icons/Hashtag'
@@ -63,7 +63,6 @@ function CardOuter({
 }
 
 export function SuggestedFollowPlaceholder() {
-  const {_} = useLingui()
   const t = useTheme()
 
   return (
@@ -79,14 +78,7 @@ export function SuggestedFollowPlaceholder() {
           </View>
         </View>
 
-        <Button
-          label={_(msg`Follow account placeholder`)}
-          size="small"
-          color="secondary"
-          disabled
-          style={[a.w_full, a.rounded_sm]}>
-          <ButtonText>Follow</ButtonText>
-        </Button>
+        <ProfileCard.FollowButtonPlaceholder />
       </ProfileCard.Outer>
     </CardOuter>
   )

--- a/src/components/FeedInterstitials.tsx
+++ b/src/components/FeedInterstitials.tsx
@@ -46,11 +46,13 @@ function CardOuter({
   return (
     <View
       style={[
+        a.flex_1,
         a.w_full,
         a.p_md,
         a.rounded_lg,
         a.border,
         t.atoms.bg,
+        t.atoms.shadow_sm,
         t.atoms.border_contrast_low,
         !gtMobile && {
           width: MOBILE_CARD_WIDTH,
@@ -63,11 +65,8 @@ function CardOuter({
 }
 
 export function SuggestedFollowPlaceholder() {
-  const t = useTheme()
-
   return (
-    <CardOuter
-      style={[a.gap_md, t.atoms.border_contrast_low, t.atoms.shadow_sm]}>
+    <CardOuter>
       <ProfileCard.Outer>
         <View
           style={[a.flex_col, a.align_center, a.gap_sm, a.pb_sm, a.mb_auto]}>
@@ -85,9 +84,8 @@ export function SuggestedFollowPlaceholder() {
 }
 
 export function SuggestedFeedsCardPlaceholder() {
-  const t = useTheme()
   return (
-    <CardOuter style={[a.gap_sm, t.atoms.border_contrast_low]}>
+    <CardOuter style={[a.gap_sm]}>
       <FeedCard.Header>
         <FeedCard.AvatarPlaceholder />
         <FeedCard.TitleAndBylinePlaceholder creator />
@@ -261,6 +259,7 @@ export function ProfileGrid({
         <View
           key={i}
           style={[
+            a.flex_1,
             gtMobile &&
               web([
                 a.flex_0,
@@ -298,11 +297,7 @@ export function ProfileGrid({
           ]}>
           {({hovered, pressed}) => (
             <CardOuter
-              style={[
-                a.flex_1,
-                t.atoms.shadow_sm,
-                (hovered || pressed) && t.atoms.border_contrast_high,
-              ]}>
+              style={[(hovered || pressed) && t.atoms.border_contrast_high]}>
               <ProfileCard.Outer>
                 <View
                   style={[
@@ -426,7 +421,6 @@ export function ProfileGrid({
 
 function SeeMoreSuggestedProfilesCard() {
   const navigation = useNavigation<NavigationProp>()
-  const t = useTheme()
   const {_} = useLingui()
 
   return (
@@ -436,7 +430,7 @@ function SeeMoreSuggestedProfilesCard() {
       onPress={() => {
         navigation.navigate('SearchTab')
       }}>
-      <CardOuter style={[a.flex_1, t.atoms.shadow_sm]}>
+      <CardOuter>
         <View style={[a.flex_1, a.justify_center]}>
           <View style={[a.flex_col, a.align_center, a.gap_md]}>
             <Text style={[a.leading_snug, a.text_center]}>
@@ -490,10 +484,7 @@ export function SuggestedFeeds() {
           }}>
           {({hovered, pressed}) => (
             <CardOuter
-              style={[
-                a.flex_1,
-                (hovered || pressed) && t.atoms.border_contrast_high,
-              ]}>
+              style={[(hovered || pressed) && t.atoms.border_contrast_high]}>
               <FeedCard.Outer>
                 <FeedCard.Header>
                   <FeedCard.Avatar src={feed.avatar} />
@@ -567,7 +558,7 @@ export function SuggestedFeeds() {
                   navigation.navigate('SearchTab')
                 }}
                 style={[a.flex_col]}>
-                <CardOuter style={[a.flex_1]}>
+                <CardOuter>
                   <View style={[a.flex_1, a.justify_center]}>
                     <View style={[a.flex_row, a.px_lg]}>
                       <Text style={[a.pr_xl, a.flex_1, a.leading_snug]}>

--- a/src/components/FeedInterstitials.tsx
+++ b/src/components/FeedInterstitials.tsx
@@ -260,7 +260,7 @@ export function ProfileGrid({
   const moderationOpts = useModerationOpts()
   const {gtMobile} = useBreakpoints()
   const isLoading = isSuggestionsLoading || !moderationOpts
-  const maxLength = gtMobile ? 3 : 6
+  const maxLength = gtMobile ? 3 : viewContext === 'profileHeader' ? 12 : 6
 
   const content = isLoading ? (
     Array(maxLength)

--- a/src/components/FeedInterstitials.tsx
+++ b/src/components/FeedInterstitials.tsx
@@ -406,13 +406,12 @@ export function ProfileGrid({
           <ScrollView
             horizontal
             showsHorizontalScrollIndicator={false}
+            contentContainerStyle={[a.p_lg, a.pt_md, a.flex_row, a.gap_md]}
             snapToInterval={MOBILE_CARD_WIDTH + a.gap_md.gap}
             decelerationRate="fast">
-            <View style={[a.p_lg, a.pt_md, a.flex_row, a.gap_md]}>
-              {content}
+            {content}
 
-              {!isProfileHeaderContext && <SeeMoreSuggestedProfilesCard />}
-            </View>
+            {!isProfileHeaderContext && <SeeMoreSuggestedProfilesCard />}
           </ScrollView>
         </BlockDrawerGesture>
       )}

--- a/src/components/FeedInterstitials.tsx
+++ b/src/components/FeedInterstitials.tsx
@@ -248,8 +248,12 @@ export function ProfileGrid({
   const {_} = useLingui()
   const moderationOpts = useModerationOpts()
   const {gtMobile} = useBreakpoints()
+
   const isLoading = isSuggestionsLoading || !moderationOpts
-  const maxLength = gtMobile ? 3 : viewContext === 'profileHeader' ? 12 : 6
+  const isProfileHeaderContext = viewContext === 'profileHeader'
+  const isFeedContext = viewContext === 'feed'
+
+  const maxLength = gtMobile ? 3 : isProfileHeaderContext ? 12 : 6
   const minLength = gtMobile ? 3 : 4
 
   const content = isLoading ? (
@@ -278,10 +282,9 @@ export function ProfileGrid({
           profile={profile}
           onPress={() => {
             logEvent('suggestedUser:press', {
-              logContext:
-                viewContext === 'feed'
-                  ? 'InterstitialDiscover'
-                  : 'InterstitialProfile',
+              logContext: isFeedContext
+                ? 'InterstitialDiscover'
+                : 'InterstitialProfile',
               recId,
               position: index,
             })
@@ -338,10 +341,9 @@ export function ProfileGrid({
                   style={[a.rounded_sm]}
                   onFollow={() => {
                     logEvent('suggestedUser:follow', {
-                      logContext:
-                        viewContext === 'feed'
-                          ? 'InterstitialDiscover'
-                          : 'InterstitialProfile',
+                      logContext: isFeedContext
+                        ? 'InterstitialDiscover'
+                        : 'InterstitialProfile',
                       location: 'Card',
                       recId,
                       position: index,
@@ -364,7 +366,7 @@ export function ProfileGrid({
   return (
     <View
       style={[
-        viewContext !== 'profileHeader' && a.border_t,
+        !isProfileHeaderContext && a.border_t,
         t.atoms.border_contrast_low,
         t.atoms.bg_contrast_25,
       ]}>
@@ -377,13 +379,13 @@ export function ProfileGrid({
           a.justify_between,
         ]}>
         <Text style={[a.text_sm, a.font_bold, t.atoms.text]}>
-          {viewContext === 'feed' ? (
+          {isFeedContext ? (
             <Trans>Suggested for you</Trans>
           ) : (
             <Trans>Similar accounts</Trans>
           )}
         </Text>
-        {viewContext !== 'profileHeader' && (
+        {!isProfileHeaderContext && (
           <InlineLinkText
             label={_(msg`See more suggested profiles on the Explore page`)}
             to="/search">
@@ -408,9 +410,7 @@ export function ProfileGrid({
             <View style={[a.p_lg, a.pt_md, a.flex_row, a.gap_md]}>
               {content}
 
-              {viewContext !== 'profileHeader' && (
-                <SeeMoreSuggestedProfilesCard />
-              )}
+              {!isProfileHeaderContext && <SeeMoreSuggestedProfilesCard />}
             </View>
           </ScrollView>
         </BlockDrawerGesture>

--- a/src/components/FeedInterstitials.tsx
+++ b/src/components/FeedInterstitials.tsx
@@ -250,6 +250,7 @@ export function ProfileGrid({
   const {gtMobile} = useBreakpoints()
   const isLoading = isSuggestionsLoading || !moderationOpts
   const maxLength = gtMobile ? 3 : viewContext === 'profileHeader' ? 12 : 6
+  const minLength = gtMobile ? 3 : 4
 
   const content = isLoading ? (
     Array(maxLength)
@@ -355,7 +356,7 @@ export function ProfileGrid({
     </>
   )
 
-  if (error || (!isLoading && profiles.length < 4)) {
+  if (error || (!isLoading && profiles.length < minLength)) {
     logger.debug(`Not enough profiles to show suggested follows`)
     return null
   }

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -561,6 +561,24 @@ export function FollowButtonInner({
   )
 }
 
+export function FollowButtonPlaceholder({style}: ViewStyleProp) {
+  const t = useTheme()
+
+  return (
+    <View
+      style={[
+        a.rounded_sm,
+        t.atoms.bg_contrast_25,
+        a.w_full,
+        {
+          height: 33,
+        },
+        style,
+      ]}
+    />
+  )
+}
+
 export function Labels({
   profile,
   moderationOpts,

--- a/src/lib/custom-animations/AccordionAnimation.tsx
+++ b/src/lib/custom-animations/AccordionAnimation.tsx
@@ -6,8 +6,8 @@ import {
 } from 'react-native'
 import Animated, {
   Easing,
-  FadeIn,
-  FadeOut,
+  FadeInUp,
+  FadeOutDown,
   useAnimatedStyle,
   useSharedValue,
   withTiming,
@@ -54,6 +54,7 @@ function WebAccordion({
 
 function MobileAccordion({
   isExpanded,
+  duration = 200,
   style,
   children,
 }: AccordionAnimationProps) {
@@ -62,8 +63,8 @@ function MobileAccordion({
   return (
     <Animated.View
       style={style}
-      entering={FadeIn.duration(150)}
-      exiting={FadeOut.duration(100)}>
+      entering={FadeInUp.duration(duration)}
+      exiting={FadeOutDown.duration(duration / 2)}>
       {children}
     </Animated.View>
   )

--- a/src/lib/custom-animations/AccordionAnimation.tsx
+++ b/src/lib/custom-animations/AccordionAnimation.tsx
@@ -30,8 +30,9 @@ function WebAccordion({
   const heightValue = useSharedValue(0)
 
   const animatedStyle = useAnimatedStyle(() => {
+    const targetHeight = isExpanded ? heightValue.get() : 0
     return {
-      height: withTiming(isExpanded ? heightValue.value : 0, {
+      height: withTiming(targetHeight, {
         duration,
         easing: Easing.out(Easing.cubic),
       }),
@@ -40,8 +41,8 @@ function WebAccordion({
   })
 
   const onLayout = (e: LayoutChangeEvent) => {
-    if (heightValue.value === 0) {
-      heightValue.value = e.nativeEvent.layout.height
+    if (heightValue.get() === 0) {
+      heightValue.set(e.nativeEvent.layout.height)
     }
   }
 

--- a/src/lib/custom-animations/AccordionAnimation.tsx
+++ b/src/lib/custom-animations/AccordionAnimation.tsx
@@ -1,0 +1,41 @@
+import {View} from 'react-native'
+import Animated, {
+  type SharedValue,
+  useAnimatedStyle,
+  useDerivedValue,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated'
+
+import {atoms as a, type ViewStyleProp} from '#/alf'
+
+interface AccordionAnimationProps {
+  isExpanded: SharedValue<boolean>
+  duration?: number
+}
+
+export function AccordionAnimation({
+  isExpanded,
+  duration = 300,
+  children,
+  style,
+}: AccordionAnimationProps & React.PropsWithChildren & ViewStyleProp) {
+  const height = useSharedValue(0)
+  const derivedHeight = useDerivedValue(() =>
+    withTiming(height.value * Number(isExpanded.value), {duration}),
+  )
+
+  const bodyStyle = useAnimatedStyle(() => ({
+    height: derivedHeight.value,
+  }))
+
+  return (
+    <Animated.View style={[a.overflow_hidden, bodyStyle, style]}>
+      <View
+        style={[a.absolute]}
+        onLayout={e => (height.value = e.nativeEvent.layout.height)}>
+        {children}
+      </View>
+    </Animated.View>
+  )
+}

--- a/src/lib/custom-animations/AccordionAnimation.tsx
+++ b/src/lib/custom-animations/AccordionAnimation.tsx
@@ -7,7 +7,7 @@ import {
 import Animated, {
   Easing,
   FadeInUp,
-  FadeOutDown,
+  FadeOutUp,
   useAnimatedStyle,
   useSharedValue,
   withTiming,
@@ -65,7 +65,7 @@ function MobileAccordion({
     <Animated.View
       style={style}
       entering={FadeInUp.duration(duration)}
-      exiting={FadeOutDown.duration(duration / 2)}>
+      exiting={FadeOutUp.duration(duration / 2)}>
       {children}
     </Animated.View>
   )

--- a/src/lib/custom-animations/AccordionAnimation.tsx
+++ b/src/lib/custom-animations/AccordionAnimation.tsx
@@ -1,5 +1,6 @@
 import {type StyleProp, View, type ViewStyle} from 'react-native'
 import Animated, {
+  Easing,
   useAnimatedStyle,
   useDerivedValue,
   useSharedValue,
@@ -23,7 +24,10 @@ export function AccordionAnimation({
   const height = useSharedValue(0)
   const derivedHeight = useDerivedValue(() => {
     const targetHeight = isExpanded ? height.value : 0
-    return withTiming(targetHeight, {duration})
+    return withTiming(targetHeight, {
+      duration,
+      easing: Easing.out(Easing.cubic),
+    })
   }, [isExpanded, duration])
 
   const bodyStyle = useAnimatedStyle(() => ({

--- a/src/lib/custom-animations/AccordionAnimation.tsx
+++ b/src/lib/custom-animations/AccordionAnimation.tsx
@@ -1,12 +1,15 @@
 import {type StyleProp, View, type ViewStyle} from 'react-native'
 import Animated, {
   Easing,
+  FadeIn,
+  FadeOut,
   useAnimatedStyle,
   useDerivedValue,
   useSharedValue,
   withTiming,
 } from 'react-native-reanimated'
 
+import {isWeb} from '#/platform/detection'
 import {atoms as a} from '#/alf'
 
 type AccordionAnimationProps = React.PropsWithChildren<{
@@ -15,7 +18,7 @@ type AccordionAnimationProps = React.PropsWithChildren<{
   style?: StyleProp<ViewStyle>
 }>
 
-export function AccordionAnimation({
+function WebAccordion({
   isExpanded,
   duration = 300,
   style,
@@ -43,4 +46,25 @@ export function AccordionAnimation({
       </View>
     </Animated.View>
   )
+}
+
+function MobileAccordion({
+  isExpanded,
+  style,
+  children,
+}: AccordionAnimationProps) {
+  if (!isExpanded) return null
+
+  return (
+    <Animated.View
+      style={style}
+      entering={FadeIn.duration(150)}
+      exiting={FadeOut.duration(100)}>
+      {children}
+    </Animated.View>
+  )
+}
+
+export function AccordionAnimation(props: AccordionAnimationProps) {
+  return isWeb ? <WebAccordion {...props} /> : <MobileAccordion {...props} />
 }

--- a/src/lib/custom-animations/AccordionAnimation.tsx
+++ b/src/lib/custom-animations/AccordionAnimation.tsx
@@ -21,9 +21,10 @@ export function AccordionAnimation({
   children,
 }: AccordionAnimationProps) {
   const height = useSharedValue(0)
-  const derivedHeight = useDerivedValue(() =>
-    withTiming(height.value * Number(isExpanded.value), {duration}),
-  )
+  const derivedHeight = useDerivedValue(() => {
+    const targetHeight = isExpanded ? height.value : 0
+    return withTiming(targetHeight, {duration})
+  }, [isExpanded, duration])
 
   const bodyStyle = useAnimatedStyle(() => ({
     height: derivedHeight.value,

--- a/src/lib/custom-animations/AccordionAnimation.tsx
+++ b/src/lib/custom-animations/AccordionAnimation.tsx
@@ -1,25 +1,25 @@
-import {View} from 'react-native'
+import {type StyleProp, View, type ViewStyle} from 'react-native'
 import Animated, {
-  type SharedValue,
   useAnimatedStyle,
   useDerivedValue,
   useSharedValue,
   withTiming,
 } from 'react-native-reanimated'
 
-import {atoms as a, type ViewStyleProp} from '#/alf'
+import {atoms as a} from '#/alf'
 
-interface AccordionAnimationProps {
-  isExpanded: SharedValue<boolean>
+type AccordionAnimationProps = React.PropsWithChildren<{
+  isExpanded: boolean
   duration?: number
-}
+  style?: StyleProp<ViewStyle>
+}>
 
 export function AccordionAnimation({
   isExpanded,
   duration = 300,
-  children,
   style,
-}: AccordionAnimationProps & React.PropsWithChildren & ViewStyleProp) {
+  children,
+}: AccordionAnimationProps) {
   const height = useSharedValue(0)
   const derivedHeight = useDerivedValue(() =>
     withTiming(height.value * Number(isExpanded.value), {duration}),

--- a/src/lib/custom-animations/AccordionAnimation.tsx
+++ b/src/lib/custom-animations/AccordionAnimation.tsx
@@ -13,7 +13,7 @@ import Animated, {
   withTiming,
 } from 'react-native-reanimated'
 
-import {isWeb} from '#/platform/detection'
+import {isIOS, isWeb} from '#/platform/detection'
 
 type AccordionAnimationProps = React.PropsWithChildren<{
   isExpanded: boolean
@@ -65,7 +65,8 @@ function MobileAccordion({
     <Animated.View
       style={style}
       entering={FadeInUp.duration(duration)}
-      exiting={FadeOutUp.duration(duration / 2)}>
+      exiting={FadeOutUp.duration(duration / 2)}
+      pointerEvents={isIOS ? 'auto' : 'box-none'}>
       {children}
     </Animated.View>
   )

--- a/src/lib/statsig/gates.ts
+++ b/src/lib/statsig/gates.ts
@@ -8,6 +8,7 @@ export type Gate =
   | 'handle_suggestions'
   | 'old_postonboarding'
   | 'onboarding_add_video_feed'
+  | 'post_follow_profile_suggested_accounts'
   | 'post_threads_v2_unspecced'
   | 'remove_show_latest_button'
   | 'test_gate_1'

--- a/src/screens/Profile/Header/ProfileHeaderStandard.tsx
+++ b/src/screens/Profile/Header/ProfileHeaderStandard.tsx
@@ -74,7 +74,7 @@ let ProfileHeaderStandard = ({
   const [_queueBlock, queueUnblock] = useProfileBlockMutationQueue(profile)
   const unblockPromptControl = Prompt.usePromptControl()
   const requireAuth = useRequireAuth()
-  const [showSuggestedFollows, _setShowSuggestedFollows] = useState(true)
+  const [showSuggestedFollows, setShowSuggestedFollows] = useState(false)
   const isBlockedUser =
     profile.viewer?.blocking ||
     profile.viewer?.blockedBy ||
@@ -94,6 +94,7 @@ let ProfileHeaderStandard = ({
             )}`,
           ),
         )
+        setShowSuggestedFollows(true)
       } catch (e: any) {
         if (e?.name !== 'AbortError') {
           logger.error('Failed to follow', {message: String(e)})

--- a/src/screens/Profile/Header/ProfileHeaderStandard.tsx
+++ b/src/screens/Profile/Header/ProfileHeaderStandard.tsx
@@ -157,176 +157,182 @@ let ProfileHeaderStandard = ({
   }, [profile])
 
   return (
-    <ProfileHeaderShell
-      profile={profile}
-      moderation={moderation}
-      hideBackButton={hideBackButton}
-      isPlaceholderProfile={isPlaceholderProfile}>
-      <View
-        style={[a.px_lg, a.pt_md, a.pb_sm, a.overflow_hidden]}
-        pointerEvents={isIOS ? 'auto' : 'box-none'}>
+    <>
+      <ProfileHeaderShell
+        profile={profile}
+        moderation={moderation}
+        hideBackButton={hideBackButton}
+        isPlaceholderProfile={isPlaceholderProfile}>
         <View
-          style={[
-            {paddingLeft: 90},
-            a.flex_row,
-            a.align_center,
-            a.justify_end,
-            a.gap_xs,
-            a.pb_sm,
-            a.flex_wrap,
-          ]}
+          style={[a.px_lg, a.pt_md, a.pb_sm, a.overflow_hidden]}
           pointerEvents={isIOS ? 'auto' : 'box-none'}>
-          {isMe ? (
-            <>
-              <Button
-                testID="profileHeaderEditProfileButton"
-                size="small"
-                color="secondary"
-                variant="solid"
-                onPress={editProfileControl.open}
-                label={_(msg`Edit profile`)}
-                style={[a.rounded_full]}>
-                <ButtonText>
-                  <Trans>Edit Profile</Trans>
-                </ButtonText>
-              </Button>
-              <EditProfileDialog
-                profile={profile}
-                control={editProfileControl}
-              />
-            </>
-          ) : profile.viewer?.blocking ? (
-            profile.viewer?.blockingByList ? null : (
-              <Button
-                testID="unblockBtn"
-                size="small"
-                color="secondary"
-                variant="solid"
-                label={_(msg`Unblock`)}
-                disabled={!hasSession}
-                onPress={() => unblockPromptControl.open()}
-                style={[a.rounded_full]}>
-                <ButtonText>
-                  <Trans context="action">Unblock</Trans>
-                </ButtonText>
-              </Button>
-            )
-          ) : !profile.viewer?.blockedBy ? (
-            <>
-              {hasSession && subscriptionsAllowed && (
-                <SubscribeProfileButton
+          <View
+            style={[
+              {paddingLeft: 90},
+              a.flex_row,
+              a.align_center,
+              a.justify_end,
+              a.gap_xs,
+              a.pb_sm,
+              a.flex_wrap,
+            ]}
+            pointerEvents={isIOS ? 'auto' : 'box-none'}>
+            {isMe ? (
+              <>
+                <Button
+                  testID="profileHeaderEditProfileButton"
+                  size="small"
+                  color="secondary"
+                  variant="solid"
+                  onPress={editProfileControl.open}
+                  label={_(msg`Edit profile`)}
+                  style={[a.rounded_full]}>
+                  <ButtonText>
+                    <Trans>Edit Profile</Trans>
+                  </ButtonText>
+                </Button>
+                <EditProfileDialog
                   profile={profile}
-                  moderationOpts={moderationOpts}
+                  control={editProfileControl}
                 />
-              )}
-              {hasSession && <MessageProfileButton profile={profile} />}
-
-              <Button
-                testID={profile.viewer?.following ? 'unfollowBtn' : 'followBtn'}
-                size="small"
-                color={profile.viewer?.following ? 'secondary' : 'primary'}
-                variant="solid"
-                label={
-                  profile.viewer?.following
-                    ? _(msg`Unfollow ${profile.handle}`)
-                    : _(msg`Follow ${profile.handle}`)
-                }
-                onPress={
-                  profile.viewer?.following ? onPressUnfollow : onPressFollow
-                }
-                style={[a.rounded_full]}>
-                {!profile.viewer?.following && (
-                  <ButtonIcon position="left" icon={Plus} />
-                )}
-                <ButtonText>
-                  {profile.viewer?.following ? (
-                    <Trans>Following</Trans>
-                  ) : profile.viewer?.followedBy ? (
-                    <Trans>Follow Back</Trans>
-                  ) : (
-                    <Trans>Follow</Trans>
-                  )}
-                </ButtonText>
-              </Button>
-            </>
-          ) : null}
-          <ProfileMenu profile={profile} />
-        </View>
-        <View
-          style={[a.flex_col, a.gap_xs, a.pb_sm, live ? a.pt_sm : a.pt_2xs]}>
-          <View style={[a.flex_row, a.align_center, a.gap_xs, a.flex_1]}>
-            <Text
-              emoji
-              testID="profileHeaderDisplayName"
-              style={[
-                t.atoms.text,
-                gtMobile ? a.text_4xl : a.text_3xl,
-                a.self_start,
-                a.font_heavy,
-                a.leading_tight,
-              ]}>
-              {sanitizeDisplayName(
-                profile.displayName || sanitizeHandle(profile.handle),
-                moderation.ui('displayName'),
-              )}
-              <View
-                style={[
-                  a.pl_xs,
-                  {
-                    marginTop: platform({ios: 2}),
-                  },
-                ]}>
-                <VerificationCheckButton profile={profile} size="lg" />
-              </View>
-            </Text>
-          </View>
-          <ProfileHeaderHandle profile={profile} />
-        </View>
-        {!isPlaceholderProfile && !isBlockedUser && (
-          <View style={a.gap_md}>
-            <ProfileHeaderMetrics profile={profile} />
-            {descriptionRT && !moderation.ui('profileView').blur ? (
-              <View pointerEvents="auto">
-                <RichText
-                  testID="profileHeaderDescription"
-                  style={[a.text_md]}
-                  numberOfLines={15}
-                  value={descriptionRT}
-                  enableTags
-                  authorHandle={profile.handle}
-                />
-              </View>
-            ) : undefined}
-
-            {!isMe &&
-              !isBlockedUser &&
-              shouldShowKnownFollowers(profile.viewer?.knownFollowers) && (
-                <View style={[a.flex_row, a.align_center, a.gap_sm]}>
-                  <KnownFollowers
+              </>
+            ) : profile.viewer?.blocking ? (
+              profile.viewer?.blockingByList ? null : (
+                <Button
+                  testID="unblockBtn"
+                  size="small"
+                  color="secondary"
+                  variant="solid"
+                  label={_(msg`Unblock`)}
+                  disabled={!hasSession}
+                  onPress={() => unblockPromptControl.open()}
+                  style={[a.rounded_full]}>
+                  <ButtonText>
+                    <Trans context="action">Unblock</Trans>
+                  </ButtonText>
+                </Button>
+              )
+            ) : !profile.viewer?.blockedBy ? (
+              <>
+                {hasSession && subscriptionsAllowed && (
+                  <SubscribeProfileButton
                     profile={profile}
                     moderationOpts={moderationOpts}
                   />
-                </View>
-              )}
+                )}
+                {hasSession && <MessageProfileButton profile={profile} />}
+
+                <Button
+                  testID={
+                    profile.viewer?.following ? 'unfollowBtn' : 'followBtn'
+                  }
+                  size="small"
+                  color={profile.viewer?.following ? 'secondary' : 'primary'}
+                  variant="solid"
+                  label={
+                    profile.viewer?.following
+                      ? _(msg`Unfollow ${profile.handle}`)
+                      : _(msg`Follow ${profile.handle}`)
+                  }
+                  onPress={
+                    profile.viewer?.following ? onPressUnfollow : onPressFollow
+                  }
+                  style={[a.rounded_full]}>
+                  {!profile.viewer?.following && (
+                    <ButtonIcon position="left" icon={Plus} />
+                  )}
+                  <ButtonText>
+                    {profile.viewer?.following ? (
+                      <Trans>Following</Trans>
+                    ) : profile.viewer?.followedBy ? (
+                      <Trans>Follow Back</Trans>
+                    ) : (
+                      <Trans>Follow</Trans>
+                    )}
+                  </ButtonText>
+                </Button>
+              </>
+            ) : null}
+            <ProfileMenu profile={profile} />
           </View>
-        )}
-      </View>
+          <View
+            style={[a.flex_col, a.gap_xs, a.pb_sm, live ? a.pt_sm : a.pt_2xs]}>
+            <View style={[a.flex_row, a.align_center, a.gap_xs, a.flex_1]}>
+              <Text
+                emoji
+                testID="profileHeaderDisplayName"
+                style={[
+                  t.atoms.text,
+                  gtMobile ? a.text_4xl : a.text_3xl,
+                  a.self_start,
+                  a.font_heavy,
+                  a.leading_tight,
+                ]}>
+                {sanitizeDisplayName(
+                  profile.displayName || sanitizeHandle(profile.handle),
+                  moderation.ui('displayName'),
+                )}
+                <View
+                  style={[
+                    a.pl_xs,
+                    {
+                      marginTop: platform({ios: 2}),
+                    },
+                  ]}>
+                  <VerificationCheckButton profile={profile} size="lg" />
+                </View>
+              </Text>
+            </View>
+            <ProfileHeaderHandle profile={profile} />
+          </View>
+          {!isPlaceholderProfile && !isBlockedUser && (
+            <View style={a.gap_md}>
+              <ProfileHeaderMetrics profile={profile} />
+              {descriptionRT && !moderation.ui('profileView').blur ? (
+                <View pointerEvents="auto">
+                  <RichText
+                    testID="profileHeaderDescription"
+                    style={[a.text_md]}
+                    numberOfLines={15}
+                    value={descriptionRT}
+                    enableTags
+                    authorHandle={profile.handle}
+                  />
+                </View>
+              ) : undefined}
+
+              {!isMe &&
+                !isBlockedUser &&
+                shouldShowKnownFollowers(profile.viewer?.knownFollowers) && (
+                  <View style={[a.flex_row, a.align_center, a.gap_sm]}>
+                    <KnownFollowers
+                      profile={profile}
+                      moderationOpts={moderationOpts}
+                    />
+                  </View>
+                )}
+            </View>
+          )}
+        </View>
+
+        <Prompt.Basic
+          control={unblockPromptControl}
+          title={_(msg`Unblock Account?`)}
+          description={_(
+            msg`The account will be able to interact with you after unblocking.`,
+          )}
+          onConfirm={unblockAccount}
+          confirmButtonCta={
+            profile.viewer?.blocking ? _(msg`Unblock`) : _(msg`Block`)
+          }
+          confirmButtonColor="negative"
+        />
+      </ProfileHeaderShell>
+
       {showSuggestedFollows && (
         <ProfileHeaderSuggestedFollows actorDid={profile.did} />
       )}
-      <Prompt.Basic
-        control={unblockPromptControl}
-        title={_(msg`Unblock Account?`)}
-        description={_(
-          msg`The account will be able to interact with you after unblocking.`,
-        )}
-        onConfirm={unblockAccount}
-        confirmButtonCta={
-          profile.viewer?.blocking ? _(msg`Unblock`) : _(msg`Block`)
-        }
-        confirmButtonColor="negative"
-      />
-    </ProfileHeaderShell>
+    </>
   )
 }
 ProfileHeaderStandard = memo(ProfileHeaderStandard)

--- a/src/screens/Profile/Header/ProfileHeaderStandard.tsx
+++ b/src/screens/Profile/Header/ProfileHeaderStandard.tsx
@@ -1,11 +1,5 @@
-import {memo, useCallback, useEffect, useMemo, useState} from 'react'
+import {memo, useCallback, useMemo, useState} from 'react'
 import {View} from 'react-native'
-import Animated, {
-  Easing,
-  useAnimatedStyle,
-  useSharedValue,
-  withTiming,
-} from 'react-native-reanimated'
 import {
   type AppBskyActorDefs,
   moderateProfile,
@@ -46,7 +40,7 @@ import {EditProfileDialog} from './EditProfileDialog'
 import {ProfileHeaderHandle} from './Handle'
 import {ProfileHeaderMetrics} from './Metrics'
 import {ProfileHeaderShell} from './Shell'
-import {ProfileHeaderSuggestedFollows} from './SuggestedFollows'
+import {AnimatedSuggestedFollows} from './SuggestedFollows'
 
 interface Props {
   profile: AppBskyActorDefs.ProfileViewDetailed
@@ -340,33 +334,6 @@ let ProfileHeaderStandard = ({
         <AnimatedSuggestedFollows actorDid={profile.did} />
       )}
     </>
-  )
-}
-
-const AnimatedSuggestedFollows = ({actorDid}: {actorDid: string}) => {
-  const [contentHeight, setContentHeight] = useState(0)
-  const animatedHeight = useSharedValue(0)
-
-  useEffect(() => {
-    if (contentHeight > 0) {
-      animatedHeight.value = withTiming(contentHeight, {
-        duration: 300,
-        easing: Easing.inOut(Easing.cubic),
-      })
-    }
-  }, [contentHeight, animatedHeight])
-
-  const animatedStyle = useAnimatedStyle(() => ({
-    height: animatedHeight.value,
-    overflow: 'hidden',
-  }))
-
-  return (
-    <Animated.View style={animatedStyle}>
-      <View onLayout={e => setContentHeight(e.nativeEvent.layout.height)}>
-        <ProfileHeaderSuggestedFollows actorDid={actorDid} />
-      </View>
-    </Animated.View>
   )
 }
 

--- a/src/screens/Profile/Header/ProfileHeaderStandard.tsx
+++ b/src/screens/Profile/Header/ProfileHeaderStandard.tsx
@@ -1,6 +1,5 @@
-import {memo, useCallback, useMemo} from 'react'
+import {memo, useCallback, useMemo, useState} from 'react'
 import {View} from 'react-native'
-import {useSharedValue} from 'react-native-reanimated'
 import {
   type AppBskyActorDefs,
   moderateProfile,
@@ -11,7 +10,6 @@ import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
 import {useActorStatus} from '#/lib/actor-status'
-import {AccordionAnimation} from '#/lib/custom-animations/AccordionAnimation'
 import {sanitizeDisplayName} from '#/lib/strings/display-names'
 import {sanitizeHandle} from '#/lib/strings/handles'
 import {logger} from '#/logger'
@@ -42,7 +40,7 @@ import {EditProfileDialog} from './EditProfileDialog'
 import {ProfileHeaderHandle} from './Handle'
 import {ProfileHeaderMetrics} from './Metrics'
 import {ProfileHeaderShell} from './Shell'
-import {ProfileHeaderSuggestedFollows} from './SuggestedFollows'
+import {AnimatedProfileHeaderSuggestedFollows} from './SuggestedFollows'
 
 interface Props {
   profile: AppBskyActorDefs.ProfileViewDetailed
@@ -76,7 +74,7 @@ let ProfileHeaderStandard = ({
   const [_queueBlock, queueUnblock] = useProfileBlockMutationQueue(profile)
   const unblockPromptControl = Prompt.usePromptControl()
   const requireAuth = useRequireAuth()
-  const showSuggestedFollows = useSharedValue(false)
+  const [showSuggestedFollows, setShowSuggestedFollows] = useState(false)
   const isBlockedUser =
     profile.viewer?.blocking ||
     profile.viewer?.blockedBy ||
@@ -85,7 +83,7 @@ let ProfileHeaderStandard = ({
   const editProfileControl = useDialogControl()
 
   const onPressFollow = () => {
-    showSuggestedFollows.value = true
+    setShowSuggestedFollows(true)
     requireAuth(async () => {
       try {
         await queueFollow()
@@ -107,7 +105,7 @@ let ProfileHeaderStandard = ({
   }
 
   const onPressUnfollow = () => {
-    showSuggestedFollows.value = false
+    setShowSuggestedFollows(false)
     requireAuth(async () => {
       try {
         await queueUnfollow()
@@ -333,9 +331,10 @@ let ProfileHeaderStandard = ({
         />
       </ProfileHeaderShell>
 
-      <AccordionAnimation isExpanded={showSuggestedFollows}>
-        <ProfileHeaderSuggestedFollows actorDid={profile.did} />
-      </AccordionAnimation>
+      <AnimatedProfileHeaderSuggestedFollows
+        isExpanded={showSuggestedFollows}
+        actorDid={profile.did}
+      />
     </>
   )
 }

--- a/src/screens/Profile/Header/ProfileHeaderStandard.tsx
+++ b/src/screens/Profile/Header/ProfileHeaderStandard.tsx
@@ -1,4 +1,4 @@
-import React, {memo, useMemo} from 'react'
+import {memo, useCallback, useMemo, useState} from 'react'
 import {View} from 'react-native'
 import {
   type AppBskyActorDefs,
@@ -40,6 +40,7 @@ import {EditProfileDialog} from './EditProfileDialog'
 import {ProfileHeaderHandle} from './Handle'
 import {ProfileHeaderMetrics} from './Metrics'
 import {ProfileHeaderShell} from './Shell'
+import {ProfileHeaderSuggestedFollows} from './SuggestedFollows'
 
 interface Props {
   profile: AppBskyActorDefs.ProfileViewDetailed
@@ -73,6 +74,7 @@ let ProfileHeaderStandard = ({
   const [_queueBlock, queueUnblock] = useProfileBlockMutationQueue(profile)
   const unblockPromptControl = Prompt.usePromptControl()
   const requireAuth = useRequireAuth()
+  const [showSuggestedFollows, _setShowSuggestedFollows] = useState(true)
   const isBlockedUser =
     profile.viewer?.blocking ||
     profile.viewer?.blockedBy ||
@@ -122,7 +124,7 @@ let ProfileHeaderStandard = ({
     })
   }
 
-  const unblockAccount = React.useCallback(async () => {
+  const unblockAccount = useCallback(async () => {
     try {
       await queueUnblock()
       Toast.show(_(msg({message: 'Account unblocked', context: 'toast'})))
@@ -309,6 +311,9 @@ let ProfileHeaderStandard = ({
           </View>
         )}
       </View>
+      {showSuggestedFollows && (
+        <ProfileHeaderSuggestedFollows actorDid={profile.did} />
+      )}
       <Prompt.Basic
         control={unblockPromptControl}
         title={_(msg`Unblock Account?`)}

--- a/src/screens/Profile/Header/ProfileHeaderStandard.tsx
+++ b/src/screens/Profile/Header/ProfileHeaderStandard.tsx
@@ -1,5 +1,11 @@
-import {memo, useCallback, useMemo, useState} from 'react'
+import {memo, useCallback, useEffect, useMemo, useState} from 'react'
 import {View} from 'react-native'
+import Animated, {
+  Easing,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated'
 import {
   type AppBskyActorDefs,
   moderateProfile,
@@ -331,10 +337,38 @@ let ProfileHeaderStandard = ({
       </ProfileHeaderShell>
 
       {showSuggestedFollows && (
-        <ProfileHeaderSuggestedFollows actorDid={profile.did} />
+        <AnimatedSuggestedFollows actorDid={profile.did} />
       )}
     </>
   )
 }
+
+const AnimatedSuggestedFollows = ({actorDid}: {actorDid: string}) => {
+  const [contentHeight, setContentHeight] = useState(0)
+  const animatedHeight = useSharedValue(0)
+
+  useEffect(() => {
+    if (contentHeight > 0) {
+      animatedHeight.value = withTiming(contentHeight, {
+        duration: 300,
+        easing: Easing.inOut(Easing.cubic),
+      })
+    }
+  }, [contentHeight, animatedHeight])
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    height: animatedHeight.value,
+    overflow: 'hidden',
+  }))
+
+  return (
+    <Animated.View style={animatedStyle}>
+      <View onLayout={e => setContentHeight(e.nativeEvent.layout.height)}>
+        <ProfileHeaderSuggestedFollows actorDid={actorDid} />
+      </View>
+    </Animated.View>
+  )
+}
+
 ProfileHeaderStandard = memo(ProfileHeaderStandard)
 export {ProfileHeaderStandard}

--- a/src/screens/Profile/Header/ProfileHeaderStandard.tsx
+++ b/src/screens/Profile/Header/ProfileHeaderStandard.tsx
@@ -89,6 +89,7 @@ let ProfileHeaderStandard = ({
   const editProfileControl = useDialogControl()
 
   const onPressFollow = () => {
+    setShowSuggestedFollows(true)
     requireAuth(async () => {
       try {
         await queueFollow()
@@ -100,7 +101,6 @@ let ProfileHeaderStandard = ({
             )}`,
           ),
         )
-        setShowSuggestedFollows(true)
       } catch (e: any) {
         if (e?.name !== 'AbortError') {
           logger.error('Failed to follow', {message: String(e)})

--- a/src/screens/Profile/Header/ProfileHeaderStandard.tsx
+++ b/src/screens/Profile/Header/ProfileHeaderStandard.tsx
@@ -1,5 +1,6 @@
-import {memo, useCallback, useMemo, useState} from 'react'
+import {memo, useCallback, useMemo} from 'react'
 import {View} from 'react-native'
+import {useSharedValue} from 'react-native-reanimated'
 import {
   type AppBskyActorDefs,
   moderateProfile,
@@ -10,6 +11,7 @@ import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
 import {useActorStatus} from '#/lib/actor-status'
+import {AccordionAnimation} from '#/lib/custom-animations/AccordionAnimation'
 import {sanitizeDisplayName} from '#/lib/strings/display-names'
 import {sanitizeHandle} from '#/lib/strings/handles'
 import {logger} from '#/logger'
@@ -40,7 +42,7 @@ import {EditProfileDialog} from './EditProfileDialog'
 import {ProfileHeaderHandle} from './Handle'
 import {ProfileHeaderMetrics} from './Metrics'
 import {ProfileHeaderShell} from './Shell'
-import {AnimatedSuggestedFollows} from './SuggestedFollows'
+import {ProfileHeaderSuggestedFollows} from './SuggestedFollows'
 
 interface Props {
   profile: AppBskyActorDefs.ProfileViewDetailed
@@ -74,7 +76,7 @@ let ProfileHeaderStandard = ({
   const [_queueBlock, queueUnblock] = useProfileBlockMutationQueue(profile)
   const unblockPromptControl = Prompt.usePromptControl()
   const requireAuth = useRequireAuth()
-  const [showSuggestedFollows, setShowSuggestedFollows] = useState(false)
+  const showSuggestedFollows = useSharedValue(false)
   const isBlockedUser =
     profile.viewer?.blocking ||
     profile.viewer?.blockedBy ||
@@ -83,7 +85,7 @@ let ProfileHeaderStandard = ({
   const editProfileControl = useDialogControl()
 
   const onPressFollow = () => {
-    setShowSuggestedFollows(true)
+    showSuggestedFollows.value = true
     requireAuth(async () => {
       try {
         await queueFollow()
@@ -105,6 +107,7 @@ let ProfileHeaderStandard = ({
   }
 
   const onPressUnfollow = () => {
+    showSuggestedFollows.value = false
     requireAuth(async () => {
       try {
         await queueUnfollow()
@@ -330,9 +333,9 @@ let ProfileHeaderStandard = ({
         />
       </ProfileHeaderShell>
 
-      {showSuggestedFollows && (
-        <AnimatedSuggestedFollows actorDid={profile.did} />
-      )}
+      <AccordionAnimation isExpanded={showSuggestedFollows}>
+        <ProfileHeaderSuggestedFollows actorDid={profile.did} />
+      </AccordionAnimation>
     </>
   )
 }

--- a/src/screens/Profile/Header/Shell.tsx
+++ b/src/screens/Profile/Header/Shell.tsx
@@ -211,7 +211,7 @@ let ProfileHeaderShell = ({
 
       {!isPlaceholderProfile && (
         <View
-          style={[a.px_lg, a.py_xs]}
+          style={[a.px_lg, a.pt_xs, a.pb_sm]}
           pointerEvents={isIOS ? 'auto' : 'box-none'}>
           {isMe ? (
             <LabelsOnMe type="account" labels={profile.labels} />

--- a/src/screens/Profile/Header/SuggestedFollows.tsx
+++ b/src/screens/Profile/Header/SuggestedFollows.tsx
@@ -55,15 +55,13 @@ export function SuggestedFollowPlaceholder() {
 }
 
 export function ProfileHeaderSuggestedFollows({actorDid}: {actorDid: string}) {
-  const {
-    isPending: isSuggestionsPending,
-    data,
-    error,
-  } = useSuggestedFollowsByActorQuery({did: actorDid})
+  const {isLoading, data, error} = useSuggestedFollowsByActorQuery({
+    did: actorDid,
+  })
 
   return (
     <ProfileGrid
-      isSuggestionsLoading={isSuggestionsPending}
+      isSuggestionsLoading={isLoading}
       profiles={data?.suggestions ?? []}
       recId={data?.recId}
       error={error}

--- a/src/screens/Profile/Header/SuggestedFollows.tsx
+++ b/src/screens/Profile/Header/SuggestedFollows.tsx
@@ -1,4 +1,11 @@
+import {useEffect, useState} from 'react'
 import {View} from 'react-native'
+import Animated, {
+  Easing,
+  useAnimatedStyle,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated'
 
 import {useSuggestedFollowsByActorQuery} from '#/state/queries/suggested-follows'
 import {atoms as a, useTheme, type ViewStyleProp} from '#/alf'
@@ -67,5 +74,32 @@ export function ProfileHeaderSuggestedFollows({actorDid}: {actorDid: string}) {
       error={error}
       viewContext="profileHeader"
     />
+  )
+}
+
+export const AnimatedSuggestedFollows = ({actorDid}: {actorDid: string}) => {
+  const [contentHeight, setContentHeight] = useState(0)
+  const animatedHeight = useSharedValue(0)
+
+  useEffect(() => {
+    if (contentHeight > 0) {
+      animatedHeight.value = withTiming(contentHeight, {
+        duration: 300,
+        easing: Easing.inOut(Easing.cubic),
+      })
+    }
+  }, [contentHeight, animatedHeight])
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    height: animatedHeight.value,
+    overflow: 'hidden',
+  }))
+
+  return (
+    <Animated.View style={animatedStyle}>
+      <View onLayout={e => setContentHeight(e.nativeEvent.layout.height)}>
+        <ProfileHeaderSuggestedFollows actorDid={actorDid} />
+      </View>
+    </Animated.View>
   )
 }

--- a/src/screens/Profile/Header/SuggestedFollows.tsx
+++ b/src/screens/Profile/Header/SuggestedFollows.tsx
@@ -1,0 +1,190 @@
+import {ScrollView, View} from 'react-native'
+import {msg, Trans} from '@lingui/macro'
+import {useLingui} from '@lingui/react'
+
+import {logger} from '#/logger'
+import {isWeb} from '#/platform/detection'
+import {useModerationOpts} from '#/state/preferences/moderation-opts'
+import {useSuggestedFollowsByActorQuery} from '#/state/queries/suggested-follows'
+import {BlockDrawerGesture} from '#/view/shell/BlockDrawerGesture'
+import {atoms as a, tokens, useTheme, type ViewStyleProp} from '#/alf'
+import {Button, ButtonText} from '#/components/Button'
+import * as ProfileCard from '#/components/ProfileCard'
+import * as Skellie from '#/components/Skeleton'
+import {Text} from '#/components/Typography'
+
+const INNER_PADDING = tokens.space.lg
+const CARD_HEIGHT = 200
+const MOBILE_CARD_WIDTH = 150
+
+function CardOuter({
+  children,
+  style,
+}: {children: React.ReactNode | React.ReactNode[]} & ViewStyleProp) {
+  const t = useTheme()
+  return (
+    <View
+      style={[
+        a.p_md,
+        a.align_center,
+        a.justify_between,
+        a.rounded_lg,
+        a.curve_continuous,
+        a.border,
+        t.atoms.bg,
+        t.atoms.border_contrast_low,
+        {height: CARD_HEIGHT, width: MOBILE_CARD_WIDTH},
+        style,
+      ]}>
+      {children}
+    </View>
+  )
+}
+
+export function SuggestedFollowPlaceholder() {
+  return (
+    <CardOuter>
+      <Skellie.Circle size={64} />
+      <View
+        style={[
+          a.w_full,
+          a.flex_col,
+          a.align_center,
+          a.flex_1,
+          a.pt_md,
+          a.pb_sm,
+        ]}>
+        <Skellie.Text style={[a.text_sm, {width: '60%'}]} />
+        <Skellie.Text style={[a.text_sm, {width: '90%'}]} />
+        <Skellie.Text style={[a.text_sm, {width: '80%'}]} />
+      </View>
+      <Skellie.Pill size={33} style={[a.rounded_sm, a.w_full, a.flex_grow_0]} />
+    </CardOuter>
+  )
+}
+
+export function ProfileHeaderSuggestedFollows({actorDid}: {actorDid: string}) {
+  const t = useTheme()
+  const {_} = useLingui()
+  const {isPending: isSuggestionsPending, data} =
+    useSuggestedFollowsByActorQuery({did: actorDid})
+  const moderationOpts = useModerationOpts()
+  const isPending = isSuggestionsPending || !moderationOpts
+
+  const followAll = () => {}
+
+  return (
+    <>
+      <View
+        style={[
+          a.flex_row,
+          a.justify_between,
+          a.align_center,
+          a.pb_xs,
+          {
+            paddingLeft: INNER_PADDING,
+            paddingRight: INNER_PADDING / 2,
+          },
+        ]}>
+        <Text style={[a.text_sm, a.font_bold]}>
+          <Trans>Suggested for you</Trans>
+        </Text>
+
+        <Button
+          onPress={followAll}
+          hitSlop={10}
+          label={_(msg`Follow all`)}
+          size="small"
+          variant="ghost"
+          color="primary">
+          <ButtonText>
+            <Trans>Follow all</Trans>
+          </ButtonText>
+        </Button>
+      </View>
+      <View style={[{height: CARD_HEIGHT}]}>
+        <BlockDrawerGesture>
+          <ScrollView
+            horizontal={true}
+            showsHorizontalScrollIndicator={isWeb}
+            persistentScrollbar={true}
+            scrollIndicatorInsets={{bottom: 0}}
+            decelerationRate="fast"
+            contentContainerStyle={[
+              a.flex_row,
+              a.gap_sm,
+              {
+                paddingHorizontal: INNER_PADDING,
+              },
+            ]}>
+            {isPending ? (
+              <>
+                <SuggestedFollowPlaceholder />
+                <SuggestedFollowPlaceholder />
+                <SuggestedFollowPlaceholder />
+                <SuggestedFollowPlaceholder />
+                <SuggestedFollowPlaceholder />
+              </>
+            ) : data ? (
+              data.suggestions
+                .filter(s => (s.associated?.labeler ? false : true))
+                .map(profile => (
+                  <ProfileCard.Link
+                    key={profile.did}
+                    profile={profile}
+                    onPress={() => {
+                      logger.metric(
+                        'profile:header:suggestedFollowsCard:press',
+                        {},
+                      )
+                    }}
+                    style={[a.flex_1]}>
+                    {({hovered, pressed}) => (
+                      <CardOuter
+                        style={[
+                          a.flex_1,
+                          (hovered || pressed) && t.atoms.border_contrast_high,
+                        ]}>
+                        <ProfileCard.Avatar
+                          size={64}
+                          profile={profile}
+                          moderationOpts={moderationOpts}
+                        />
+                        <View style={[a.flex_grow_0, a.pt_sm]}>
+                          <ProfileCard.Name
+                            profile={profile}
+                            moderationOpts={moderationOpts}
+                          />
+                        </View>
+                        <View
+                          style={[
+                            a.flex_grow_0,
+                            {minHeight: 38},
+                            a.justify_start,
+                          ]}>
+                          <ProfileCard.Description
+                            profile={profile}
+                            numberOfLines={2}
+                            style={[a.text_center]}
+                          />
+                        </View>
+                        <View style={[a.pt_md, a.flex_grow, a.w_full]}>
+                          <ProfileCard.FollowButton
+                            profile={profile}
+                            moderationOpts={moderationOpts}
+                            logContext="ProfileHeaderSuggestedFollows"
+                            color="primary"
+                            withIcon={false}
+                          />
+                        </View>
+                      </CardOuter>
+                    )}
+                  </ProfileCard.Link>
+                ))
+            ) : null}
+          </ScrollView>
+        </BlockDrawerGesture>
+      </View>
+    </>
+  )
+}

--- a/src/screens/Profile/Header/SuggestedFollows.tsx
+++ b/src/screens/Profile/Header/SuggestedFollows.tsx
@@ -1,5 +1,6 @@
 import {AccordionAnimation} from '#/lib/custom-animations/AccordionAnimation'
 import {useGate} from '#/lib/statsig/statsig'
+import {isAndroid} from '#/platform/detection'
 import {useSuggestedFollowsByActorQuery} from '#/state/queries/suggested-follows'
 import {ProfileGrid} from '#/components/FeedInterstitials'
 
@@ -28,6 +29,13 @@ export function AnimatedProfileHeaderSuggestedFollows({
 }) {
   const gate = useGate()
   if (!gate('post_follow_profile_suggested_accounts')) return null
+
+  /* NOTE (caidanw):
+   * Android does not work well with this feature yet.
+   * This issue stems from Android not allowing dragging on clickable elements in the profile header.
+   * Blocking the ability to scroll on Android is too much of a trade-off for now.
+   **/
+  if (isAndroid) return null
 
   return (
     <AccordionAnimation isExpanded={isExpanded}>

--- a/src/screens/Profile/Header/SuggestedFollows.tsx
+++ b/src/screens/Profile/Header/SuggestedFollows.tsx
@@ -1,3 +1,5 @@
+import {AccordionAnimation} from '#/lib/custom-animations/AccordionAnimation'
+import {useGate} from '#/lib/statsig/statsig'
 import {useSuggestedFollowsByActorQuery} from '#/state/queries/suggested-follows'
 import {ProfileGrid} from '#/components/FeedInterstitials'
 
@@ -14,5 +16,22 @@ export function ProfileHeaderSuggestedFollows({actorDid}: {actorDid: string}) {
       error={error}
       viewContext="profileHeader"
     />
+  )
+}
+
+export function AnimatedProfileHeaderSuggestedFollows({
+  isExpanded,
+  actorDid,
+}: {
+  isExpanded: boolean
+  actorDid: string
+}) {
+  const gate = useGate()
+  if (!gate('post_follow_profile_suggested_accounts')) return null
+
+  return (
+    <AccordionAnimation isExpanded={isExpanded}>
+      <ProfileHeaderSuggestedFollows actorDid={actorDid} />
+    </AccordionAnimation>
   )
 }

--- a/src/screens/Profile/Header/SuggestedFollows.tsx
+++ b/src/screens/Profile/Header/SuggestedFollows.tsx
@@ -1,12 +1,3 @@
-import {useEffect, useState} from 'react'
-import {View} from 'react-native'
-import Animated, {
-  Easing,
-  useAnimatedStyle,
-  useSharedValue,
-  withTiming,
-} from 'react-native-reanimated'
-
 import {useSuggestedFollowsByActorQuery} from '#/state/queries/suggested-follows'
 import {ProfileGrid} from '#/components/FeedInterstitials'
 
@@ -23,32 +14,5 @@ export function ProfileHeaderSuggestedFollows({actorDid}: {actorDid: string}) {
       error={error}
       viewContext="profileHeader"
     />
-  )
-}
-
-export const AnimatedSuggestedFollows = ({actorDid}: {actorDid: string}) => {
-  const [contentHeight, setContentHeight] = useState(0)
-  const animatedHeight = useSharedValue(0)
-
-  useEffect(() => {
-    if (contentHeight > 0) {
-      animatedHeight.value = withTiming(contentHeight, {
-        duration: 300,
-        easing: Easing.inOut(Easing.cubic),
-      })
-    }
-  }, [contentHeight, animatedHeight])
-
-  const animatedStyle = useAnimatedStyle(() => ({
-    height: animatedHeight.value,
-    overflow: 'hidden',
-  }))
-
-  return (
-    <Animated.View style={animatedStyle}>
-      <View onLayout={e => setContentHeight(e.nativeEvent.layout.height)}>
-        <ProfileHeaderSuggestedFollows actorDid={actorDid} />
-      </View>
-    </Animated.View>
   )
 }

--- a/src/screens/Profile/Header/SuggestedFollows.tsx
+++ b/src/screens/Profile/Header/SuggestedFollows.tsx
@@ -1,19 +1,10 @@
-import {ScrollView, View} from 'react-native'
-import {msg, Trans} from '@lingui/macro'
-import {useLingui} from '@lingui/react'
+import {View} from 'react-native'
 
-import {logger} from '#/logger'
-import {isWeb} from '#/platform/detection'
-import {useModerationOpts} from '#/state/preferences/moderation-opts'
 import {useSuggestedFollowsByActorQuery} from '#/state/queries/suggested-follows'
-import {BlockDrawerGesture} from '#/view/shell/BlockDrawerGesture'
-import {atoms as a, tokens, useTheme, type ViewStyleProp} from '#/alf'
-import {Button, ButtonText} from '#/components/Button'
-import * as ProfileCard from '#/components/ProfileCard'
+import {atoms as a, useTheme, type ViewStyleProp} from '#/alf'
+import {ProfileGrid} from '#/components/FeedInterstitials'
 import * as Skellie from '#/components/Skeleton'
-import {Text} from '#/components/Typography'
 
-const INNER_PADDING = tokens.space.lg
 const CARD_HEIGHT = 200
 const MOBILE_CARD_WIDTH = 150
 
@@ -64,127 +55,19 @@ export function SuggestedFollowPlaceholder() {
 }
 
 export function ProfileHeaderSuggestedFollows({actorDid}: {actorDid: string}) {
-  const t = useTheme()
-  const {_} = useLingui()
-  const {isPending: isSuggestionsPending, data} =
-    useSuggestedFollowsByActorQuery({did: actorDid})
-  const moderationOpts = useModerationOpts()
-  const isPending = isSuggestionsPending || !moderationOpts
-
-  const followAll = () => {}
+  const {
+    isPending: isSuggestionsPending,
+    data,
+    error,
+  } = useSuggestedFollowsByActorQuery({did: actorDid})
 
   return (
-    <>
-      <View
-        style={[
-          a.flex_row,
-          a.justify_between,
-          a.align_center,
-          a.pb_xs,
-          {
-            paddingLeft: INNER_PADDING,
-            paddingRight: INNER_PADDING / 2,
-          },
-        ]}>
-        <Text style={[a.text_sm, a.font_bold]}>
-          <Trans>Suggested for you</Trans>
-        </Text>
-
-        <Button
-          onPress={followAll}
-          hitSlop={10}
-          label={_(msg`Follow all`)}
-          size="small"
-          variant="ghost"
-          color="primary">
-          <ButtonText>
-            <Trans>Follow all</Trans>
-          </ButtonText>
-        </Button>
-      </View>
-      <View style={[{height: CARD_HEIGHT}]}>
-        <BlockDrawerGesture>
-          <ScrollView
-            horizontal={true}
-            showsHorizontalScrollIndicator={isWeb}
-            persistentScrollbar={true}
-            scrollIndicatorInsets={{bottom: 0}}
-            decelerationRate="fast"
-            contentContainerStyle={[
-              a.flex_row,
-              a.gap_sm,
-              {
-                paddingHorizontal: INNER_PADDING,
-              },
-            ]}>
-            {isPending ? (
-              <>
-                <SuggestedFollowPlaceholder />
-                <SuggestedFollowPlaceholder />
-                <SuggestedFollowPlaceholder />
-                <SuggestedFollowPlaceholder />
-                <SuggestedFollowPlaceholder />
-              </>
-            ) : data ? (
-              data.suggestions
-                .filter(s => (s.associated?.labeler ? false : true))
-                .map(profile => (
-                  <ProfileCard.Link
-                    key={profile.did}
-                    profile={profile}
-                    onPress={() => {
-                      logger.metric(
-                        'profile:header:suggestedFollowsCard:press',
-                        {},
-                      )
-                    }}
-                    style={[a.flex_1]}>
-                    {({hovered, pressed}) => (
-                      <CardOuter
-                        style={[
-                          a.flex_1,
-                          (hovered || pressed) && t.atoms.border_contrast_high,
-                        ]}>
-                        <ProfileCard.Avatar
-                          size={64}
-                          profile={profile}
-                          moderationOpts={moderationOpts}
-                        />
-                        <View style={[a.flex_grow_0, a.pt_sm]}>
-                          <ProfileCard.Name
-                            profile={profile}
-                            moderationOpts={moderationOpts}
-                          />
-                        </View>
-                        <View
-                          style={[
-                            a.flex_grow_0,
-                            {minHeight: 38},
-                            a.justify_start,
-                          ]}>
-                          <ProfileCard.Description
-                            profile={profile}
-                            numberOfLines={2}
-                            style={[a.text_center]}
-                          />
-                        </View>
-                        <View style={[a.pt_md, a.flex_grow, a.w_full]}>
-                          <ProfileCard.FollowButton
-                            profile={profile}
-                            moderationOpts={moderationOpts}
-                            logContext="ProfileHeaderSuggestedFollows"
-                            color="primary"
-                            withIcon={false}
-                          />
-                        </View>
-                      </CardOuter>
-                    )}
-                  </ProfileCard.Link>
-                ))
-            ) : null}
-          </ScrollView>
-        </BlockDrawerGesture>
-      </View>
-    </>
+    <ProfileGrid
+      isSuggestionsLoading={isSuggestionsPending}
+      profiles={data?.suggestions ?? []}
+      recId={data?.recId}
+      error={error}
+      viewContext="profileHeader"
+    />
   )
 }

--- a/src/screens/Profile/Header/SuggestedFollows.tsx
+++ b/src/screens/Profile/Header/SuggestedFollows.tsx
@@ -8,58 +8,7 @@ import Animated, {
 } from 'react-native-reanimated'
 
 import {useSuggestedFollowsByActorQuery} from '#/state/queries/suggested-follows'
-import {atoms as a, useTheme, type ViewStyleProp} from '#/alf'
 import {ProfileGrid} from '#/components/FeedInterstitials'
-import * as Skellie from '#/components/Skeleton'
-
-const CARD_HEIGHT = 200
-const MOBILE_CARD_WIDTH = 150
-
-function CardOuter({
-  children,
-  style,
-}: {children: React.ReactNode | React.ReactNode[]} & ViewStyleProp) {
-  const t = useTheme()
-  return (
-    <View
-      style={[
-        a.p_md,
-        a.align_center,
-        a.justify_between,
-        a.rounded_lg,
-        a.curve_continuous,
-        a.border,
-        t.atoms.bg,
-        t.atoms.border_contrast_low,
-        {height: CARD_HEIGHT, width: MOBILE_CARD_WIDTH},
-        style,
-      ]}>
-      {children}
-    </View>
-  )
-}
-
-export function SuggestedFollowPlaceholder() {
-  return (
-    <CardOuter>
-      <Skellie.Circle size={64} />
-      <View
-        style={[
-          a.w_full,
-          a.flex_col,
-          a.align_center,
-          a.flex_1,
-          a.pt_md,
-          a.pb_sm,
-        ]}>
-        <Skellie.Text style={[a.text_sm, {width: '60%'}]} />
-        <Skellie.Text style={[a.text_sm, {width: '90%'}]} />
-        <Skellie.Text style={[a.text_sm, {width: '80%'}]} />
-      </View>
-      <Skellie.Pill size={33} style={[a.rounded_sm, a.w_full, a.flex_grow_0]} />
-    </CardOuter>
-  )
-}
 
 export function ProfileHeaderSuggestedFollows({actorDid}: {actorDid: string}) {
   const {isLoading, data, error} = useSuggestedFollowsByActorQuery({

--- a/src/state/queries/suggested-follows.ts
+++ b/src/state/queries/suggested-follows.ts
@@ -1,13 +1,13 @@
 import {
-  AppBskyActorDefs,
-  AppBskyActorGetSuggestions,
-  AppBskyGraphGetSuggestedFollowsByActor,
+  type AppBskyActorDefs,
+  type AppBskyActorGetSuggestions,
+  type AppBskyGraphGetSuggestedFollowsByActor,
   moderateProfile,
 } from '@atproto/api'
 import {
-  InfiniteData,
-  QueryClient,
-  QueryKey,
+  type InfiniteData,
+  type QueryClient,
+  type QueryKey,
   useInfiniteQuery,
   useQuery,
 } from '@tanstack/react-query'
@@ -106,12 +106,15 @@ export function useSuggestedFollowsQuery(options?: SuggestedFollowsOptions) {
 export function useSuggestedFollowsByActorQuery({
   did,
   enabled,
+  staleTime = STALE.MINUTES.FIVE,
 }: {
   did: string
   enabled?: boolean
+  staleTime?: number
 }) {
   const agent = useAgent()
   return useQuery({
+    staleTime,
     queryKey: suggestedFollowsByActorQueryKey(did),
     queryFn: async () => {
       const res = await agent.app.bsky.graph.getSuggestedFollowsByActor({


### PR DESCRIPTION
Fixes https://github.com/bluesky-social/social-app/issues/8849

Summary
---

Add a new feature to show suggested follow recommendations when you follow an account.

New components:
- `ProfileHeaderSuggestedFollows` is the main component that implements the layout of the suggested profiles.
- `AnimatedProfileHeaderSuggestedFollows` is a wrapper that uses `AccordionAnimation` to wrap the `ProfileHeaderSuggestedFollows`, also handles the gated feature for A/B testing (prevents any data loading or component rendering early to avoid extra work).
- `AccordionAnimation` is a generic animation component that is reusable should we need to re-use the same animation somewhere.

Other changes:
- Add new `statsig` gate name, `post_follow_profile_suggested_accounts`
- Some changes were cherry-picked from @mozzius branch.
- Disable preview on card Avatar to avoid nested `<a>` tags.
- Add label for `SuggestedFolllowPlaceholder` button.
- There are two separate animations for web and mobile, as mobile couldn't handle the constant amount of layout calculations during animation.

This is a gated feature for use with A/B testing, if you pull down this branch and use it locally you may need to comment out the gated feature logic.

Due to issues stemming from Androids gesture handling, we can not support this feature on Android yet. It's been discussed and agreed upon that we should omit this feature on Android for now, and use iOS and web to gather metrics about engagement. Hopefully in the future when the profile header is re-architected it'll be in a better state to handle this on Android.

Screenshots
---

Web:

https://github.com/user-attachments/assets/32d69708-67f9-4b63-b96b-8025fb22949c

Mobile:

https://github.com/user-attachments/assets/cba28d83-57b2-48e4-a081-97f56e225174