### PR TITLE
Only parse notifs with a reason

### DIFF
--- a/src/lib/hooks/useNotificationHandler.ts
+++ b/src/lib/hooks/useNotificationHandler.ts
@@ -393,7 +393,7 @@ export function getNotificationPayload(
     isIOS ? e.request.trigger.payload : e.request.content.data
   ) as NotificationPayload
 
-  if (payload) {
+  if (payload && payload.reason) {
     return payload
   } else {
     return null

--- a/src/lib/hooks/useNotificationHandler.ts
+++ b/src/lib/hooks/useNotificationHandler.ts
@@ -301,17 +301,6 @@ export function useNotificationsHandler() {
         const payload = getNotificationPayload(e.notification)
 
         if (payload) {
-          if (!payload.reason) {
-            notyLogger.error(
-              'useNotificationsHandler: received unknown payload',
-              {
-                payload,
-                identifier: e.notification.request.identifier,
-              },
-            )
-            return
-          }
-
           notyLogger.debug(
             'User pressed a notification, opening notifications tab',
             {},
@@ -396,6 +385,12 @@ export function getNotificationPayload(
   if (payload && payload.reason) {
     return payload
   } else {
+    if (payload) {
+      notyLogger.warn('getNotificationPayload: received unknown payload', {
+        payload,
+        identifier: e.request.identifier,
+      })
+    }
     return null
   }
 }


### PR DESCRIPTION
A compliment to #8775, but I realised that would still trigger the metric log even if the notification is invalid

If we don't recognise the shape of the payload, it probably wasn't sent from our notification service. Ergo we should completely ignore it and not log anything
