### PR TITLE
Fix web scrollable select unwanted overflow

### DIFF
--- a/src/components/Select/index.web.tsx
+++ b/src/components/Select/index.web.tsx
@@ -190,6 +190,7 @@ export function Content<T>({items, renderItem}: ContentProps<T>) {
             a.border,
             t.atoms.border_contrast_low,
             a.rounded_sm,
+            a.overflow_hidden,
           ]}>
           <RadixSelect.ScrollUpButton style={flatten(up)}>
             <ChevronUpIcon style={[t.atoms.text]} size="xs" />


### PR DESCRIPTION
# Why

Recently I have spotted a small visual issue with the Radix select on the web. When options list does not fit on the viewport and scroll buttons are visible they stick out outside of the select content container.

<img width="972" height="394" alt="Screenshot 2025-08-06 at 17 56 48" src="https://github.com/user-attachments/assets/0c2be5db-7860-48e0-9723-195d93e34992" />

# How

Add overflow style to the wrapper view used in web variant of the component.

# Preview

<img width="972" height="394" alt="Screenshot 2025-08-06 at 17 56 25" src="https://github.com/user-attachments/assets/dce6f0e0-63e5-4d5e-a392-ca69ac999e40" />

