### PR TITLE
Fix policy overlay logic

### DIFF
--- a/src/components/PolicyUpdateOverlay/context.tsx
+++ b/src/components/PolicyUpdateOverlay/context.tsx
@@ -20,6 +20,11 @@ const Context = createContext<{
     completed: true,
     complete: () => {},
   },
+  /**
+   * Although our data will be ready to go when the app shell mounts, we don't
+   * want to show the overlay until we actually render it, which happens after
+   * sigin/signup/onboarding in `createNativeStackNavigatorWithAuth`.
+   */
   setIsReadyToShowOverlay: () => {},
 })
 

--- a/src/components/PolicyUpdateOverlay/context.tsx
+++ b/src/components/PolicyUpdateOverlay/context.tsx
@@ -35,7 +35,10 @@ export function usePolicyUpdateContext() {
 
 export function Provider({children}: {children?: ReactNode}) {
   const [isReadyToShowOverlay, setIsReadyToShowOverlay] = useState(false)
-  const state = usePolicyUpdateState({enabled: isReadyToShowOverlay})
+  const state = usePolicyUpdateState({
+    // only enable the policy update overlay in non-test environments
+    enabled: isReadyToShowOverlay && process.env.NODE_ENV !== 'test',
+  })
 
   const ctx = useMemo(
     () => ({

--- a/src/components/PolicyUpdateOverlay/index.tsx
+++ b/src/components/PolicyUpdateOverlay/index.tsx
@@ -1,18 +1,23 @@
+import {useEffect} from 'react'
 import {View} from 'react-native'
 
 import {isIOS} from '#/platform/detection'
 import {atoms as a} from '#/alf'
 import {FullWindowOverlay} from '#/components/FullWindowOverlay'
-import {usePolicyUpdateStateContext} from '#/components/PolicyUpdateOverlay/context'
+import {usePolicyUpdateContext} from '#/components/PolicyUpdateOverlay/context'
 import {Portal} from '#/components/PolicyUpdateOverlay/Portal'
 import {Content} from '#/components/PolicyUpdateOverlay/updates/202508'
 
 export {Provider} from '#/components/PolicyUpdateOverlay/context'
-export {usePolicyUpdateStateContext} from '#/components/PolicyUpdateOverlay/context'
+export {usePolicyUpdateContext} from '#/components/PolicyUpdateOverlay/context'
 export {Outlet} from '#/components/PolicyUpdateOverlay/Portal'
 
 export function PolicyUpdateOverlay() {
-  const state = usePolicyUpdateStateContext()
+  const {state, setIsReadyToShowOverlay} = usePolicyUpdateContext()
+
+  useEffect(() => {
+    setIsReadyToShowOverlay()
+  }, [setIsReadyToShowOverlay])
 
   /*
    * See `window.clearNux` example in `/state/queries/nuxs` for a way to clear

--- a/src/components/PolicyUpdateOverlay/index.tsx
+++ b/src/components/PolicyUpdateOverlay/index.tsx
@@ -16,6 +16,9 @@ export function PolicyUpdateOverlay() {
   const {state, setIsReadyToShowOverlay} = usePolicyUpdateContext()
 
   useEffect(() => {
+    /**
+     * Tell the context that we are ready to show the overlay.
+     */
     setIsReadyToShowOverlay()
   }, [setIsReadyToShowOverlay])
 

--- a/src/components/PolicyUpdateOverlay/usePolicyUpdateState.ts
+++ b/src/components/PolicyUpdateOverlay/usePolicyUpdateState.ts
@@ -11,13 +11,20 @@ export type PolicyUpdateState = {
   complete: () => void
 }
 
-export function usePolicyUpdateState() {
+export function usePolicyUpdateState({enabled}: {enabled: boolean}) {
   const nux = useNux(ACTIVE_UPDATE_ID)
   const {mutate: save, variables} = useSaveNux()
   const deviceStorage = useStorage(device, [ACTIVE_UPDATE_ID])
   const debugOverride =
     !!useStorage(device, ['policyUpdateDebugOverride'])[0] && IS_DEV
   return useMemo(() => {
+    if (!enabled) {
+      return {
+        completed: true,
+        complete() {},
+      }
+    }
+
     const nuxIsReady = nux.status === 'ready'
     const nuxIsCompleted = nux.nux?.completed === true
     const nuxIsOptimisticallyCompleted = !!variables?.completed
@@ -59,7 +66,7 @@ export function usePolicyUpdateState() {
         setCompletedForDevice(true)
       },
     }
-  }, [nux, save, variables, deviceStorage, debugOverride])
+  }, [enabled, nux, save, variables, deviceStorage, debugOverride])
 }
 
 export function computeCompletedState({

--- a/src/components/PolicyUpdateOverlay/usePolicyUpdateState.ts
+++ b/src/components/PolicyUpdateOverlay/usePolicyUpdateState.ts
@@ -11,13 +11,26 @@ export type PolicyUpdateState = {
   complete: () => void
 }
 
-export function usePolicyUpdateState({enabled}: {enabled: boolean}) {
+export function usePolicyUpdateState({
+  enabled,
+}: {
+  /**
+   * Used to skip the policy update overlay until we're actually ready to
+   * show it.
+   */
+  enabled: boolean
+}) {
   const nux = useNux(ACTIVE_UPDATE_ID)
   const {mutate: save, variables} = useSaveNux()
   const deviceStorage = useStorage(device, [ACTIVE_UPDATE_ID])
   const debugOverride =
     !!useStorage(device, ['policyUpdateDebugOverride'])[0] && IS_DEV
+
   return useMemo(() => {
+    /**
+     * If not enabled, then just return a completed state so the app functions
+     * as normal.
+     */
     if (!enabled) {
       return {
         completed: true,

--- a/src/view/shell/index.tsx
+++ b/src/view/shell/index.tsx
@@ -33,7 +33,7 @@ import {MutedWordsDialog} from '#/components/dialogs/MutedWords'
 import {SigninDialog} from '#/components/dialogs/Signin'
 import {
   Outlet as PolicyUpdateOverlayPortalOutlet,
-  usePolicyUpdateStateContext,
+  usePolicyUpdateContext,
 } from '#/components/PolicyUpdateOverlay'
 import {Outlet as PortalOutlet} from '#/components/Portal'
 import {RoutesContainer, TabsNavigator} from '#/Navigation'
@@ -49,7 +49,7 @@ function ShellInner() {
   const setIsDrawerOpen = useSetDrawerOpen()
   const winDim = useWindowDimensions()
   const insets = useSafeAreaInsets()
-  const policyUpdateState = usePolicyUpdateStateContext()
+  const {state: policyUpdateState} = usePolicyUpdateContext()
 
   const renderDrawerContent = useCallback(() => <DrawerContent />, [])
   const onOpenDrawer = useCallback(

--- a/src/view/shell/index.web.tsx
+++ b/src/view/shell/index.web.tsx
@@ -24,7 +24,7 @@ import {MutedWordsDialog} from '#/components/dialogs/MutedWords'
 import {SigninDialog} from '#/components/dialogs/Signin'
 import {
   Outlet as PolicyUpdateOverlayPortalOutlet,
-  usePolicyUpdateStateContext,
+  usePolicyUpdateContext,
 } from '#/components/PolicyUpdateOverlay'
 import {Outlet as PortalOutlet} from '#/components/Portal'
 import {FlatNavigator, RoutesContainer} from '#/Navigation'
@@ -41,7 +41,7 @@ function ShellInner() {
   const {_} = useLingui()
   const showDrawer = !isDesktop && isDrawerOpen
   const [showDrawerDelayedExit, setShowDrawerDelayedExit] = useState(showDrawer)
-  const policyUpdateState = usePolicyUpdateStateContext()
+  const {state: policyUpdateState} = usePolicyUpdateContext()
 
   useLayoutEffect(() => {
     if (showDrawer !== showDrawerDelayedExit) {


### PR DESCRIPTION
We needed to hoist up state so that it could be used in the `shell` to unmount the portal outlets. This meant prior `completed === true`, no dialogs would render. This broke signup and onboarding.

This PR hoists up another piece of state `isReadyToShowOverlay` that is `false` until we actually render the `PolicyUpdateOverlay` in `createNativeStackNavigatorWithAuth`, which only happens _after_ login/signup/onboarding etc.