### PR TITLE
Fix #8239: video-audio desync issue on Firefox

### DIFF
--- a/src/components/Post/Embed/VideoEmbed/VideoEmbedInner/web-controls/VideoControls.tsx
+++ b/src/components/Post/Embed/VideoEmbed/VideoEmbedInner/web-controls/VideoControls.tsx
@@ -190,11 +190,7 @@ export function Controls({
   const onSeek = useCallback(
     (time: number) => {
       if (!videoRef.current) return
-      if (videoRef.current.fastSeek) {
-        videoRef.current.fastSeek(time)
-      } else {
-        videoRef.current.currentTime = time
-      }
+      videoRef.current.currentTime = time
     },
     [videoRef],
   )


### PR DESCRIPTION
Fixes #8239 by not using fastSeek at all. 

Firefox supports fastSeek but even then it's buggy and causes audio-video desync. Setting currentTime just works and doesn't seem to cause any actual performance issues in my testing.

I couldn't find any rationale for using fastSeek when searching commits but it doesn't seem necessary at the pace the usual user scrubs through videos, and in either case it's not supported on most browsers anyway.