### PR TITLE
Add bottom border to feed headers in Explore on web

### DIFF
--- a/src/screens/Search/Explore.tsx
+++ b/src/screens/Search/Explore.tsx
@@ -917,11 +917,7 @@ export function Explore({
         case 'preview:header': {
           return (
             <ModuleHeader.Container
-              style={[
-                a.pt_xs,
-                t.atoms.border_contrast_low,
-                native(a.border_b),
-              ]}>
+              style={[a.pt_xs, t.atoms.border_contrast_low, a.border_b]}>
               {/* Very non-scientific way to avoid small gap on scroll */}
               <View style={[a.absolute, a.inset_0, t.atoms.bg, {top: -2}]} />
               <ModuleHeader.FeedLink feed={item.feed}>


### PR DESCRIPTION
I don't know why it was restricted to native only. It looks broken without them imo since the top post will then be missing a border

# Before

<img width="781" height="443" alt="Screenshot 2025-08-08 at 11 55 21" src="https://github.com/user-attachments/assets/f1ff8567-618e-42a2-aba4-ee8945c21c04" />


# After

<img width="780" height="419" alt="Screenshot 2025-08-08 at 11 57 27" src="https://github.com/user-attachments/assets/d9f0dce4-9829-40ac-b066-77d35e91af28" />
