### PR TITLE
[Perf - part 3] Stop every dialog control in the entire app rerendering when opening a dialog

### DIFF
--- a/src/state/dialogs/index.tsx
+++ b/src/state/dialogs/index.tsx
@@ -25,25 +25,18 @@ interface IDialogControlContext {
   setFullyExpandedCount: React.Dispatch<React.SetStateAction<number>>
 }
 
-interface IDialogFullyExpandedContext {
-  /**
-   * The number of dialogs that are fully expanded. This is used to determine the background color of the status bar
-   * on iOS.
-   */
-  fullyExpandedCount: number
-}
-
 const DialogContext = React.createContext<IDialogContext>({} as IDialogContext)
 
 const DialogControlContext = React.createContext<IDialogControlContext>(
   {} as IDialogControlContext,
 )
 
-const DialogFullyExpandedContext =
-  React.createContext<IDialogFullyExpandedContext>({
-    fullyExpandedCount: 0,
-  } as IDialogFullyExpandedContext)
-DialogFullyExpandedContext.displayName = 'DialogFullyExpandedContext'
+/**
+ * The number of dialogs that are fully expanded. This is used to determine the background color of the status bar
+ * on iOS.
+ */
+const DialogFullyExpandedCountContext = React.createContext<number>(0)
+DialogFullyExpandedCountContext.displayName = 'DialogFullyExpandedCountContext'
 
 export function useDialogStateContext() {
   return React.useContext(DialogContext)
@@ -53,8 +46,9 @@ export function useDialogStateControlContext() {
   return React.useContext(DialogControlContext)
 }
 
-export function useDialogFullyExpandedContext() {
-  return React.useContext(DialogFullyExpandedContext)
+/** The number of dialogs that are fully expanded */
+export function useDialogFullyExpandedCountContext() {
+  return React.useContext(DialogFullyExpandedCountContext)
 }
 
 export function Provider({children}: React.PropsWithChildren<{}>) {
@@ -103,19 +97,12 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
     [closeAllDialogs, setDialogIsOpen, setFullyExpandedCount],
   )
 
-  const fullyExpanded = React.useMemo(
-    () => ({
-      fullyExpandedCount,
-    }),
-    [fullyExpandedCount],
-  )
-
   return (
     <DialogContext.Provider value={context}>
       <DialogControlContext.Provider value={controls}>
-        <DialogFullyExpandedContext.Provider value={fullyExpanded}>
+        <DialogFullyExpandedCountContext.Provider value={fullyExpandedCount}>
           <GlobalDialogsProvider>{children}</GlobalDialogsProvider>
-        </DialogFullyExpandedContext.Provider>
+        </DialogFullyExpandedCountContext.Provider>
       </DialogControlContext.Provider>
     </DialogContext.Provider>
   )

--- a/src/view/shell/index.tsx
+++ b/src/view/shell/index.tsx
@@ -12,7 +12,7 @@ import {useNotificationsHandler} from '#/lib/hooks/useNotificationHandler'
 import {useNotificationsRegistration} from '#/lib/notifications/notifications'
 import {isStateAtTabRoot} from '#/lib/routes/helpers'
 import {isAndroid, isIOS} from '#/platform/detection'
-import {useDialogFullyExpandedContext} from '#/state/dialogs'
+import {useDialogFullyExpandedCountContext} from '#/state/dialogs'
 import {useSession} from '#/state/session'
 import {
   useIsDrawerOpen,
@@ -181,7 +181,7 @@ function ShellInner() {
 }
 
 export const Shell: React.FC = function ShellImpl() {
-  const {fullyExpandedCount} = useDialogFullyExpandedContext()
+  const fullyExpandedCount = useDialogFullyExpandedCountContext()
   const t = useTheme()
   useIntentHandler()
 

--- a/src/view/shell/index.tsx
+++ b/src/view/shell/index.tsx
@@ -12,7 +12,7 @@ import {useNotificationsHandler} from '#/lib/hooks/useNotificationHandler'
 import {useNotificationsRegistration} from '#/lib/notifications/notifications'
 import {isStateAtTabRoot} from '#/lib/routes/helpers'
 import {isAndroid, isIOS} from '#/platform/detection'
-import {useDialogStateControlContext} from '#/state/dialogs'
+import {useDialogFullyExpandedContext} from '#/state/dialogs'
 import {useSession} from '#/state/session'
 import {
   useIsDrawerOpen,
@@ -181,7 +181,7 @@ function ShellInner() {
 }
 
 export const Shell: React.FC = function ShellImpl() {
-  const {fullyExpandedCount} = useDialogStateControlContext()
+  const {fullyExpandedCount} = useDialogFullyExpandedContext()
   const t = useTheme()
   useIntentHandler()
 


### PR DESCRIPTION
**This PR is not stacked on anything**

This is the primary driver of the composer being so slow to open. Because we'd stuffed `fullyExpandedCount` into the dialog control context, every consumer of the context (i.e. every single `useDialogControl`) would rerender when `fullyExpandedCount` changed, such as when the composer opens on iOS, or when a full-height dialog opens.

# Before

On the profiler the commits are the following:

Commits 1 & 2: debug toast, ignore

Commit 3: actually rendering the composer. This takes ~30ms

Commit 4: by far the largest one, this is updating the `fullyExpandedCount` from 0 -> 1. This causes a rerender of every component with a dialog control, of which there are multiple in every post. In the simulator this takes 180ms.

<img width="948" height="934" alt="Screenshot 2025-08-11 at 15 59 52" src="https://github.com/user-attachments/assets/bc800dee-32e0-4d80-8d96-176815de28f2" />

# After

There is only one spike, which is the composer rendering. Note the long tail is fixed by #8813 

<img width="478" height="692" alt="Screenshot 2025-08-11 at 15 55 52" src="https://github.com/user-attachments/assets/9ab865a7-0276-4569-8db6-0e52c6b762ac" />

# Solution

Just move `fullyExpandedCount` to a separate context. This then only triggers a rerender of the component that needs it, which is only 1 place (the shell).

# Test plan

Confirm that the profiler no longer shows everything rerendering when opening the composer. Confirm that the status bar still is the correct color when opening the sheet to max.
