### PR TITLE
Make sure AA admonition text doesn't touch button

### DIFF
--- a/src/components/ageAssurance/AgeAssuranceAdmonition.tsx
+++ b/src/components/ageAssurance/AgeAssuranceAdmonition.tsx
@@ -80,7 +80,7 @@ function Inner({
             ]}>
             <Shield size="md" />
           </View>
-          <View style={[a.flex_1, a.gap_xs, a.pr_2xl]}>
+          <View style={[a.flex_1, a.gap_xs, a.pr_4xl]}>
             <Text style={[a.text_sm, a.leading_snug]}>{children}</Text>
             <Text style={[a.text_sm, a.leading_snug, a.font_bold]}>
               <Trans>


### PR DESCRIPTION
# Before

<table>
  <thead>
    <tr>
      <th>Web</th>
      <th>iOS</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><img width="400" src="https://github.com/user-attachments/assets/3169dd35-9e58-4e78-8ba9-1c70ba625543" /></td>
      <td><img width="300" src="https://github.com/user-attachments/assets/edfa3562-0ebd-4ddb-a7c0-f7212e8843a1" /></td>
    </tr>
  </tbody>
</table>

# After

<table>
  <thead>
    <tr>
      <th>Web</th>
      <th>iOS</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><img width="400" src="https://github.com/user-attachments/assets/b22b400d-5bd1-40e9-a9f8-9d650128c8fb" /></td>
      <td><img width="300" src="https://github.com/user-attachments/assets/c5ee1709-09eb-4d7c-9271-36e229c503a9" /></td>
    </tr>
  </tbody>
</table>
