### PR TITLE
Set max width on feed context string

### DIFF
--- a/src/components/PostControls/DiscoverDebug.tsx
+++ b/src/components/PostControls/DiscoverDebug.tsx
@@ -32,8 +32,7 @@ export function DiscoverDebug({
         hitSlop={10}
         style={[
           a.absolute,
-          a.bottom_0,
-          {zIndex: 1000},
+          {zIndex: 1000, maxWidth: 65, bottom: -4},
           gtMobile ? a.right_0 : a.left_0,
         ]}
         onPress={e => {
@@ -42,6 +41,7 @@ export function DiscoverDebug({
           Toast.show(t`Copied to clipboard`, 'clipboard-check')
         }}>
         <Text
+          numberOfLines={1}
           style={{
             color: theme.palette.contrast_400,
             fontSize: 7,


### PR DESCRIPTION

<table>
  <thead>
    <tr>
      <th>Before</th>
      <th>After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><img width="300" src="https://github.com/user-attachments/assets/152e7e80-aa3e-4342-8274-1e7749cd831a" /></td>
      <td><img width="300" src="https://github.com/user-attachments/assets/d2c3f4a7-91e2-4c6d-b1b7-3757232c897a" /></td>
    </tr>
  </tbody>
</table>