### PR TITLE
Fix policy state

### DIFF
--- a/src/screens/Signup/StepInfo/index.tsx
+++ b/src/screens/Signup/StepInfo/index.tsx
@@ -20,6 +20,7 @@ import {Envelope_Stroke2_Corner0_Rounded as Envelope} from '#/components/icons/E
 import {Lock_Stroke2_Corner0_Rounded as Lock} from '#/components/icons/Lock'
 import {Ticket_Stroke2_Corner0_Rounded as Ticket} from '#/components/icons/Ticket'
 import {Loader} from '#/components/Loader'
+import {usePreemptivelyCompleteActivePolicyUpdate} from '#/components/PolicyUpdateOverlay/usePreemptivelyCompleteActivePolicyUpdate'
 import {BackNextButtons} from '../BackNextButtons'
 
 function sanitizeDate(date: Date): Date {
@@ -45,6 +46,8 @@ export function StepInfo({
 }) {
   const {_} = useLingui()
   const {state, dispatch} = useSignupContext()
+  const preemptivelyCompleteActivePolicyUpdate =
+    usePreemptivelyCompleteActivePolicyUpdate()
 
   const inviteCodeValueRef = useRef<string>(state.inviteCode)
   const emailValueRef = useRef<string>(state.email)
@@ -129,6 +132,7 @@ export function StepInfo({
       })
     }
 
+    preemptivelyCompleteActivePolicyUpdate()
     dispatch({type: 'setInviteCode', value: inviteCode})
     dispatch({type: 'setEmail', value: email})
     dispatch({type: 'setPassword', value: password})

--- a/src/screens/Signup/state.ts
+++ b/src/screens/Signup/state.ts
@@ -308,6 +308,15 @@ export function useSubmitSignup() {
       dispatch({type: 'setIsLoading', value: true})
 
       try {
+        /**
+         * Marks any active policy update as completed, since user just agreed
+         * to TOS/privacy during sign up.
+         *
+         * THIS MUST RUN BEFORE createAccount, which will re-render the whole
+         * app with the new account.
+         */
+        preemptivelyCompleteActivePolicyUpdate()
+
         await createAccount(
           {
             service: state.serviceUrl,
@@ -327,12 +336,6 @@ export function useSubmitSignup() {
             backgroundCount: state.backgroundCount,
           },
         )
-
-        /**
-         * Marks any active policy update as completed, since user just agreed
-         * to TOS/privacy during sign up
-         */
-        preemptivelyCompleteActivePolicyUpdate()
 
         /*
          * Must happen last so that if the user has multiple tabs open and

--- a/src/screens/Signup/state.ts
+++ b/src/screens/Signup/state.ts
@@ -15,7 +15,6 @@ import {getAge} from '#/lib/strings/time'
 import {logger} from '#/logger'
 import {useSessionApi} from '#/state/session'
 import {useOnboardingDispatch} from '#/state/shell'
-import {usePreemptivelyCompleteActivePolicyUpdate} from '#/components/PolicyUpdateOverlay/usePreemptivelyCompleteActivePolicyUpdate'
 
 export type ServiceDescription = ComAtprotoServerDescribeServer.OutputSchema
 
@@ -253,8 +252,6 @@ export function useSubmitSignup() {
   const {_} = useLingui()
   const {createAccount} = useSessionApi()
   const onboardingDispatch = useOnboardingDispatch()
-  const preemptivelyCompleteActivePolicyUpdate =
-    usePreemptivelyCompleteActivePolicyUpdate()
 
   return useCallback(
     async (state: SignupState, dispatch: (action: SignupAction) => void) => {
@@ -308,15 +305,6 @@ export function useSubmitSignup() {
       dispatch({type: 'setIsLoading', value: true})
 
       try {
-        /**
-         * Marks any active policy update as completed, since user just agreed
-         * to TOS/privacy during sign up.
-         *
-         * THIS MUST RUN BEFORE createAccount, which will re-render the whole
-         * app with the new account.
-         */
-        preemptivelyCompleteActivePolicyUpdate()
-
         await createAccount(
           {
             service: state.serviceUrl,
@@ -375,11 +363,6 @@ export function useSubmitSignup() {
         dispatch({type: 'setIsLoading', value: false})
       }
     },
-    [
-      _,
-      onboardingDispatch,
-      createAccount,
-      preemptivelyCompleteActivePolicyUpdate,
-    ],
+    [_, onboardingDispatch, createAccount],
   )
 }


### PR DESCRIPTION
There seems to be a subtle race condition when marking `completedForDevice = true` _after_ account creation, due to the app re-rendering with the new account in place.

Really, these policies can be marked as complete after the first step of the create account flow, which removes any chance of the race condition when the app re-renders after the account is created.