### PR TITLE
Fix chat button placeholder size on profile

### DIFF
--- a/src/components/dms/MessageProfileButton.tsx
+++ b/src/components/dms/MessageProfileButton.tsx
@@ -73,7 +73,7 @@ export function MessageProfileButton({
             a.align_center,
             t.atoms.bg_contrast_25,
             a.rounded_full,
-            {width: 34, height: 34},
+            {width: 33, height: 33},
           ]}>
           <Message style={[t.atoms.text, {opacity: 0.3}]} size="md" />
         </View>

--- a/src/components/dms/MessageProfileButton.tsx
+++ b/src/components/dms/MessageProfileButton.tsx
@@ -73,6 +73,7 @@ export function MessageProfileButton({
             a.align_center,
             t.atoms.bg_contrast_25,
             a.rounded_full,
+            // Matches size of button below to avoid layout shift
             {width: 33, height: 33},
           ]}>
           <Message style={[t.atoms.text, {opacity: 0.3}]} size="md" />


### PR DESCRIPTION
Button size changed by 1px, so the load state of the chat button was causing layout shift

# Before


https://github.com/user-attachments/assets/db0da504-3b6a-43e5-904a-2b34bfda61e1



# After


https://github.com/user-attachments/assets/4aeb0283-644e-4b3f-80ca-3e15dd32d7fc

