### PR TITLE
feat: use OP's language as recommendation when replying

### DIFF
--- a/src/screens/PostThread/components/ThreadItemAnchor.tsx
+++ b/src/screens/PostThread/components/ThreadItemAnchor.tsx
@@ -254,6 +254,7 @@ const ThreadItemAnchorInner = memo(function ThreadItemAnchorInner({
         author: post.author,
         embed: post.embed,
         moderation,
+        langs: record.langs,
       },
       onPostSuccess: onPostSuccess,
     })

--- a/src/screens/PostThread/components/ThreadItemPost.tsx
+++ b/src/screens/PostThread/components/ThreadItemPost.tsx
@@ -234,6 +234,7 @@ const ThreadItemPostInner = memo(function ThreadItemPostInner({
         author: post.author,
         embed: post.embed,
         moderation,
+        langs: post.record.langs,
       },
       onPostSuccess: onPostSuccess,
     })

--- a/src/screens/PostThread/components/ThreadItemTreePost.tsx
+++ b/src/screens/PostThread/components/ThreadItemTreePost.tsx
@@ -298,6 +298,7 @@ const ThreadItemTreePostInner = memo(function ThreadItemTreePostInner({
         author: post.author,
         embed: post.embed,
         moderation,
+        langs: post.record.langs,
       },
       onPostSuccess: onPostSuccess,
     })

--- a/src/screens/PostThread/index.tsx
+++ b/src/screens/PostThread/index.tsx
@@ -91,6 +91,7 @@ export function PostThread({uri}: {uri: string}) {
         author: post.author,
         embed: post.embed,
         moderation: anchor.moderation,
+        langs: post.record.langs,
       },
       onPostSuccess: optimisticOnPostReply,
     })

--- a/src/screens/VideoFeed/index.tsx
+++ b/src/screens/VideoFeed/index.tsx
@@ -753,6 +753,7 @@ function Overlay({
         text: record?.text || '',
         author: post.author,
         embed: post.embed,
+        langs: record?.langs,
       },
     })
   }, [openComposer, post, record])

--- a/src/state/shell/composer/index.tsx
+++ b/src/state/shell/composer/index.tsx
@@ -20,6 +20,7 @@ export interface ComposerOptsPostRef {
   uri: string
   cid: string
   text: string
+  langs?: string[]
   author: AppBskyActorDefs.ProfileViewBasic
   embed?: AppBskyFeedDefs.PostView['embed']
   moderation?: ModerationDecision

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -621,7 +621,11 @@ export const ComposePost = ({
 
   const footer = (
     <>
-      <SuggestedLanguage text={activePost.richtext.text} />
+      <SuggestedLanguage
+        text={activePost.richtext.text}
+        // NOTE(@elijaharita): currently just choosing the first language if any exists
+        fallback={replyTo?.langs?.[0]}
+      />
       <ComposerPills
         isReply={!!replyTo}
         post={activePost}

--- a/src/view/com/composer/select-language/SuggestedLanguage.tsx
+++ b/src/view/com/composer/select-language/SuggestedLanguage.tsx
@@ -19,10 +19,16 @@ import {Text} from '#/components/Typography'
 const onIdle = globalThis.requestIdleCallback || (cb => setTimeout(cb, 1))
 const cancelIdle = globalThis.cancelIdleCallback || clearTimeout
 
-export function SuggestedLanguage({text}: {text: string}) {
+export function SuggestedLanguage({
+  text,
+  fallback,
+}: {
+  text: string
+  fallback?: string
+}) {
   const [suggestedLanguage, setSuggestedLanguage] = useState<
     string | undefined
-  >()
+  >(fallback)
   const langPrefs = useLanguagePrefs()
   const setLangPrefs = useLanguagePrefsApi()
   const t = useTheme()
@@ -34,7 +40,7 @@ export function SuggestedLanguage({text}: {text: string}) {
     // Don't run the language model on small posts, the results are likely
     // to be inaccurate anyway.
     if (textTrimmed.length < 40) {
-      setSuggestedLanguage(undefined)
+      setSuggestedLanguage(fallback)
       return
     }
 
@@ -43,7 +49,7 @@ export function SuggestedLanguage({text}: {text: string}) {
     })
 
     return () => cancelIdle(idle)
-  }, [text])
+  }, [text, fallback])
 
   if (
     suggestedLanguage &&

--- a/src/view/com/post-thread/PostThread.tsx
+++ b/src/view/com/post-thread/PostThread.tsx
@@ -420,6 +420,7 @@ export function PostThread({uri}: {uri: string}) {
         author: thread.post.author,
         embed: thread.post.embed,
         moderation: threadModerationCache.get(thread),
+        langs: thread.record.langs,
       },
       onPost: onPostReply,
     })

--- a/src/view/com/post-thread/PostThreadItem.tsx
+++ b/src/view/com/post-thread/PostThreadItem.tsx
@@ -299,6 +299,7 @@ let PostThreadItemLoaded = ({
         author: post.author,
         embed: post.embed,
         moderation,
+        langs: record.langs,
       },
       onPost: onPostReply,
       onPostSuccess: onPostSuccess,

--- a/src/view/com/post/Post.tsx
+++ b/src/view/com/post/Post.tsx
@@ -136,6 +136,7 @@ function PostInner({
         author: post.author,
         embed: post.embed,
         moderation,
+        langs: record.langs,
       },
     })
   }, [openComposer, post, record, moderation])

--- a/src/view/com/posts/PostFeedItem.tsx
+++ b/src/view/com/posts/PostFeedItem.tsx
@@ -197,6 +197,7 @@ let FeedItemInner = ({
         author: post.author,
         embed: post.embed,
         moderation,
+        langs: record.langs,
       },
     })
   }


### PR DESCRIPTION
This immediately suggests the language of the post you are replying to. Once you start typing and the language model kicks in, it will update with the computed language based on the content of your reply like it would have before.

Since langs is an array, I am just taking the first entry as the suggested language. Not sure if this makes sense since I'm not sure in which situations multiple languages can be applied to a post.

<img width="1440" height="1125" alt="image" src="https://github.com/user-attachments/assets/05e36365-3953-4ddf-adca-c5952a66d752" />
