### PR TITLE
Update `@mozzius/expo-dynamic-app-icon`

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "@lingui/react": "^4.14.1",
     "@mattermost/react-native-paste-input": "mattermost/react-native-paste-input",
     "@miblanchard/react-native-slider": "^2.6.0",
-    "@mozzius/expo-dynamic-app-icon": "1.5.0",
+    "@mozzius/expo-dynamic-app-icon": "^1.7.1",
     "@react-native-async-storage/async-storage": "2.1.2",
     "@react-native-menu/menu": "^1.2.3",
     "@react-native-picker/picker": "2.11.0",

--- a/src/screens/Settings/AppIconSettings/index.tsx
+++ b/src/screens/Settings/AppIconSettings/index.tsx
@@ -28,7 +28,7 @@ export function AppIconSettingsScreen({}: Props) {
     getAppIconName(DynamicAppIcon.getAppIcon()),
   )
 
-  const onSetAppIcon = (icon: string) => {
+  const onSetAppIcon = (icon: DynamicAppIcon.IconName) => {
     if (isAndroid) {
       const next =
         sets.defaults.find(i => i.id === icon) ??
@@ -37,7 +37,7 @@ export function AppIconSettingsScreen({}: Props) {
         next
           ? _(msg`Change app icon to "${next.name}"`)
           : _(msg`Change app icon`),
-        // to determine - can we stop this happening? -sfn
+        // unfortunately necessary -sfn
         _(msg`The app will be restarted`),
         [
           {
@@ -119,7 +119,7 @@ export function AppIconSettingsScreen({}: Props) {
   )
 }
 
-function setAppIcon(icon: string) {
+function setAppIcon(icon: DynamicAppIcon.IconName) {
   if (icon === 'default_light') {
     return getAppIconName(DynamicAppIcon.setAppIcon(null))
   } else {
@@ -127,11 +127,11 @@ function setAppIcon(icon: string) {
   }
 }
 
-function getAppIconName(icon: string | false) {
+function getAppIconName(icon: string | false): DynamicAppIcon.IconName {
   if (!icon || icon === 'DEFAULT') {
     return 'default_light'
   } else {
-    return icon
+    return icon as DynamicAppIcon.IconName
   }
 }
 
@@ -143,8 +143,8 @@ function Group({
 }: {
   children: React.ReactNode
   label: string
-  value: string
-  onChange: (value: string) => void
+  value: DynamicAppIcon.IconName
+  onChange: (value: DynamicAppIcon.IconName) => void
 }) {
   return (
     <Toggle.Group
@@ -153,7 +153,7 @@ function Group({
       values={[value]}
       maxSelections={1}
       onChange={vals => {
-        if (vals[0]) onChange(vals[0])
+        if (vals[0]) onChange(vals[0] as DynamicAppIcon.IconName)
       }}>
       <View style={[a.flex_1, a.rounded_md, a.overflow_hidden]}>
         {children}

--- a/src/screens/Settings/AppIconSettings/types.ts
+++ b/src/screens/Settings/AppIconSettings/types.ts
@@ -1,7 +1,8 @@
-import {ImageSourcePropType} from 'react-native'
+import {type ImageSourcePropType} from 'react-native'
+import type * as DynamicAppIcon from '@mozzius/expo-dynamic-app-icon'
 
 export type AppIconSet = {
-  id: string
+  id: DynamicAppIcon.IconName
   name: string
   iosImage: () => ImageSourcePropType
   androidImage: () => ImageSourcePropType

--- a/yarn.lock
+++ b/yarn.lock
@@ -5134,13 +5134,12 @@
   resolved "https://registry.yarnpkg.com/@miblanchard/react-native-slider/-/react-native-slider-2.6.0.tgz#9f78c805d637ffaff0e3e7429932d2995a67edc9"
   integrity sha512-o7hk/f/8vkqh6QNR5L52m+ws846fQeD/qNCC9CCSRdBqjq66KiCgbxzlhRzKM/gbtxcvMYMIEEJ1yes5cr6I3A==
 
-"@mozzius/expo-dynamic-app-icon@1.5.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@mozzius/expo-dynamic-app-icon/-/expo-dynamic-app-icon-1.5.0.tgz#c5f88c309965b6d6b89cfd5e2c00faa7bda736af"
-  integrity sha512-yE2yEPO+HQmOqsX7cECh7/vu/LXnqhHGsVm3UiVi/3gaK8u5hAkPTNzZ0Qu6vnMwjPnY+uFbN6X+6Aj9c9yjMQ==
+"@mozzius/expo-dynamic-app-icon@^1.7.1":
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/@mozzius/expo-dynamic-app-icon/-/expo-dynamic-app-icon-1.7.1.tgz#20a6475af256ab93112bbaac1c2f3dd052562d16"
+  integrity sha512-zDcY11B3tsQ9WsPTcszUCa6SpygfYz1e4p8PGn/4XhwYbOHJ53sEnGVQ1YlwzQ87SeWPlqrfzY6SUr9GpNq2Kg==
   dependencies:
     "@expo/image-utils" "^0.6.3"
-    expo-modules-core "^2.1.1"
     xcode "^3.0.1"
 
 "@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1":
@@ -11372,13 +11371,6 @@ expo-modules-core@2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/expo-modules-core/-/expo-modules-core-2.4.0.tgz#3081d62fadff913090cc5abfe46d9ec6b0e75789"
   integrity sha512-Ko5eHBdvuMykjw9P9C9PF54/wBSsGOxaOjx92I5BwgKvEmUwN3UrXFV4CXzlLVbLfSYUQaLcB220xmPfgvT7Fg==
-  dependencies:
-    invariant "^2.2.4"
-
-expo-modules-core@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/expo-modules-core/-/expo-modules-core-2.1.1.tgz#970af4cfd70c8aa6fc0096dd0a6578aa003a479f"
-  integrity sha512-yQzYCLR2mre4BNMXuqkeJ0oSNgmGEMI6BcmIzeNZbC2NFEjiaDpKvlV9bclYCtyVhUEVNbJcEPYMr6c1Y4eR4w==
   dependencies:
     invariant "^2.2.4"
 


### PR DESCRIPTION
Updates `@mozzius/expo-dynamic-app-icon` to latest

We don't really use this library yet, but I want to include https://github.com/mozzius/expo-dynamic-app-icon/pull/3 because it fixes a duplicate `expo-module-core` dependency problem. I also improved the lib while I'm at it - should be good to go for when we need it.