### PR TITLE
Skip `intl:compile` if not needed

### DIFF
--- a/.github/workflows/pull-request-commit.yml
+++ b/.github/workflows/pull-request-commit.yml
@@ -50,7 +50,7 @@ jobs:
           git config --global user.name "github-actions[bot]"
           git merge --no-edit ${{ github.head_ref }}
           yarn install
-          yarn intl:compile
+          yarn intl:build
 
       - name: 🔦 Generate stats file for PR
         run: |
@@ -74,7 +74,7 @@ jobs:
         if: ${{ !steps.get-base-stats.outputs.cache-hit }}
         run: |
           yarn install
-          yarn intl:compile
+          yarn intl:build
           yarn generate-webpack-stats-file
           mv stats.json stats-base.json
 

--- a/.github/workflows/pull-request-commit.yml
+++ b/.github/workflows/pull-request-commit.yml
@@ -50,6 +50,7 @@ jobs:
           git config --global user.name "github-actions[bot]"
           git merge --no-edit ${{ github.head_ref }}
           yarn install
+          yarn intl:compile
 
       - name: 🔦 Generate stats file for PR
         run: |
@@ -73,6 +74,7 @@ jobs:
         if: ${{ !steps.get-base-stats.outputs.cache-hit }}
         run: |
           yarn install
+          yarn intl:compile
           yarn generate-webpack-stats-file
           mv stats.json stats-base.json
 
@@ -143,4 +145,3 @@ jobs:
         with:
           header: fingerprint-diff
           delete: true
-

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "prepare": "is-ci || husky install",
-    "postinstall": "patch-package && yarn intl:compile",
+    "postinstall": "patch-package && yarn intl:compile-if-needed",
     "prebuild": "expo prebuild --clean",
     "android": "expo run:android",
     "android:prod": "expo run:android --variant release",
@@ -58,6 +58,7 @@
     "intl:extract": "lingui extract --clean --locale en",
     "intl:extract:all": "lingui extract --clean",
     "intl:compile": "lingui compile",
+    "intl:compile-if-needed": "is-ci || [ -f src/locale/locales/en/messages.js ] || yarn intl:compile",
     "intl:pull": "crowdin download translations --verbose -b main",
     "intl:push": "crowdin push translations --verbose -b main",
     "nuke": "rm -rf ./node_modules && rm -rf ./ios && rm -rf ./android",


### PR DESCRIPTION
Skips `intl:compile` if:

- is CI since that is typically its own step, or
- if the `messages.js` file exists, at least for english