### PR TITLE
Add darkreader lock (`<meta name="darkreader-lock">`)

### DIFF
--- a/bskyweb/templates/base.html
+++ b/bskyweb/templates/base.html
@@ -96,6 +96,7 @@
   <meta name="generator" content="bskyweb">
   <meta property="og:site_name" content="Bluesky Social" />
   <link type="application/activity+json" href="" />
+  <meta name="darkreader-lock">
 
   {% block html_head_extra -%}{%- endblock %}
 </head>


### PR DESCRIPTION
There's a popular browser extension called Dark Reader, which automatically attempts to make websites into a dark theme.
This works "ok" on Bluesky, but messes up quite alot of the theming, making the background grayscale but leaving the blue tinted borders and buttons, ends up looking quite messy.

<img width="1696" height="1369" alt="image" src="https://github.com/user-attachments/assets/8f939d13-a9b0-41b0-b393-c83becd1292d" />


This PR adds what's referred to as a "darkreader lock", which stops Dark Reader from affecting the websites. They don't specify when this should be done, but since Bluesky already has a dark mode, I don't see the point in allowing the extension to mess up the theming and colours.

Dark Reader docs: https://github.com/darkreader/darkreader/blob/main/CONTRIBUTING.md#disabling-dark-reader-on-your-site

Let me know if this is an okay place to put it in the HTML, and hopefully it's okay to include in general. Should improve usability for users of that extension - thanks!

