### PR TITLE
Skip dirty git tree check in prebuild

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "prepare": "is-ci || husky install",
     "postinstall": "patch-package && yarn intl:compile-if-needed",
-    "prebuild": "echo y | expo prebuild --clean",
+    "prebuild": "EXPO_NO_GIT_STATUS=1 expo prebuild --clean",
     "android": "expo run:android",
     "android:prod": "expo run:android --variant release",
     "android:profile": "BSKY_PROFILE=1 expo run:android --variant release",


### PR DESCRIPTION
Silences the stupid dirty git tree check in `yarn prebuild`

# Before 🤮

```
$ expo prebuild --clean
env: load .env
env: export EXPO_PUBLIC_LOG_LEVEL EXPO_PUBLIC_BUNDLE_DATE CROWDIN_API_TOKEN
! Git branch has uncommited file changes
› It's recommended to commit all changes before proceeding in case you want to revert generated changes.

? Continue with uncommited changes? › (Y/n)
```

# After 🥰

```
$ EXPO_NO_GIT_STATUS=1 expo prebuild --clean
env: load .env
env: export EXPO_PUBLIC_LOG_LEVEL EXPO_PUBLIC_BUNDLE_DATE CROWDIN_API_TOKEN
Git status is dirty but the command will continue because EXPO_NO_GIT_STATUS is enabled...
✔ Cleared android, ios code
✔ Created native directories
```