### PR TITLE
Don't override backspace if alt or meta key

### DIFF
--- a/src/view/com/composer/text-input/TextInput.web.tsx
+++ b/src/view/com/composer/text-input/TextInput.web.tsx
@@ -220,7 +220,11 @@ export const TextInput = React.forwardRef(function TextInputImpl(
             textInputWebEmitter.emit('publish')
             return true
           }
-          if (event.code === 'Backspace') {
+
+          if (
+            event.code === 'Backspace' &&
+            !(event.metaKey || event.altKey || event.ctrlKey)
+          ) {
             const isNotSelection = view.state.selection.empty
             if (isNotSelection) {
               const cursorPosition = view.state.selection.$anchor.pos


### PR DESCRIPTION
Following on from https://github.com/bluesky-social/social-app/pull/8829, we need to make sure we don't override backspace when the metaKey or altKey or ctrlKey is pressed

# Before

Backspacing while holding alt:

https://github.com/user-attachments/assets/5e691a6a-f382-403e-94a1-e50e18547b6a


# After

Backspacing while holding alt:

https://github.com/user-attachments/assets/79779431-2288-467d-912b-7e4c3cbd7b0a



# Edge case

Holding alt messes up the adjacent emoji. Life's too short, it's fine

https://github.com/user-attachments/assets/ef14adf1-5e7e-4338-b2e9-94a1ed5057a6

