### PR TITLE
Fix `isPartOfLastBranchFromDepth` assignment

### DIFF
--- a/src/state/queries/usePostThread/traversal.ts
+++ b/src/state/queries/usePostThread/traversal.ts
@@ -307,9 +307,16 @@ export function sortAndAnnotateThreadItems(
               metadata.isPartOfLastBranchFromDepth = metadata.depth
 
               /**
-               * If the parent is part of the last branch of the sub-tree, so is the child.
+               * If the parent is part of the last branch of the sub-tree, so
+               * is the child. However, if the child is also a last sibling,
+               * then we need to start tracking `isPartOfLastBranchFromDepth`
+               * from this point onwards, always updating it to the depth of
+               * the last sibling as we go down.
                */
-              if (metadata.parentMetadata.isPartOfLastBranchFromDepth) {
+              if (
+                !metadata.isLastSibling &&
+                metadata.parentMetadata.isPartOfLastBranchFromDepth
+              ) {
                 metadata.isPartOfLastBranchFromDepth =
                   metadata.parentMetadata.isPartOfLastBranchFromDepth
               }

--- a/src/state/queries/usePostThread/types.ts
+++ b/src/state/queries/usePostThread/types.ts
@@ -151,8 +151,8 @@ export type TraversalMetadata = {
    */
   isLastChild: boolean
   /**
-   * Indicates if the post is the left/lower-most branch of the reply tree.
-   * Value corresponds to the depth at which this branch started.
+   * Indicates if the post is the left-most AND lower-most branch of the reply
+   * tree. Value corresponds to the depth at which this branch started.
    */
   isPartOfLastBranchFromDepth?: number
   /**


### PR DESCRIPTION
Fixes a bug where `isPartOfLastBranchFromDepth` was not updated if further replies down the tree were in fact _also_ "the last branch from `depth`".

See screenshot, where the posts should have the following values:

A. `isPartOfLastBranchFromDepth: 1`, since it's the last sibling, and its depth is `1`
B. `isPartOfLastBranchFromDepth: undefined` since it's not the last sibling (there's a post further down)
C. `isPartOfLastBranchFromDepth: 3` since it's a last sibling and its depth is `3`
D. `isPartOfLastBranchFromDepth: 4` since it _itself_ is also a last sibling and its depth is `4`
E. `isPartOfLastBranchFromDepth: undefined` since it's not a last sibling (it's the first)

Case `D` is what this PR fixes.

<img width="1394" height="2386" alt="CleanShot 2025-08-15 at 16 07 00@2x" src="https://github.com/user-attachments/assets/5d08d280-181e-4383-b65a-3762637255a0" />
