### PR TITLE
`Discover Feeds` ⮕ `Discover New Feeds` on Explore tab

### DIFF
--- a/src/screens/Search/Explore.tsx
+++ b/src/screens/Search/Explore.tsx
@@ -431,7 +431,7 @@ export function Explore({
     i.push({
       type: 'header',
       key: 'suggested-feeds-header',
-      title: _(msg`Discover Feeds`),
+      title: _(msg`Discover New Feeds`),
       icon: ListSparkle,
       searchButton: {
         label: _(msg`Search for more feeds`),


### PR DESCRIPTION
I don't have any actual evidence that this is happening, but I wonder if the `Discover Feeds` heading on the **Explore** tab might be a little confusing for some users, given that the default feed is called **Discover**.

E.g.: "There's a Discover feed on my home tab when I open the app, but when I go to search for something on the Explore tab there are also other Discover Feeds on all these different topics, what's that about?"

![IMG_8374](https://github.com/user-attachments/assets/e40c5f5c-3a80-4403-825e-a6dd2bd97533)

___

So this PR proposes changing the heading on the **Explore** tab from `Discover Feeds` ⮕ `Discover New Feeds`, using the same heading that's used on the **Feeds** screen:

![IMG_8375](https://github.com/user-attachments/assets/5f6a576b-56c9-48dd-ad84-1071c1a86f3b)