### PR TITLE
Fix searching for phrases by replacing smart quotes with normal ones

### DIFF
--- a/src/lib/strings/helpers.ts
+++ b/src/lib/strings/helpers.ts
@@ -84,6 +84,10 @@ export function augmentSearchQuery(query: string, {did}: {did?: string}) {
     return query
   }
 
+  // replace “smart quotes” with normal ones
+  // iOS keyboard will add fancy unicode quotes, but only normal ones work
+  query = query.replaceAll(/[“”]/g, '"')
+
   // We don't want to replace substrings that are being "quoted" because those
   // are exact string matches, so what we'll do here is to split them apart
 


### PR DESCRIPTION
Alternative to #4876 - decided I wanted a more precise fix by just swapping out the quotes

<table>
  <thead>
    <tr>
      <th>Before</th>
      <th>After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><img width="300" src="https://github.com/user-attachments/assets/b363d411-c163-4c4f-be1a-6ae4cc92f14e" /></td>
      <td><img width="300" src="https://github.com/user-attachments/assets/4635598d-4b4c-4bc7-b339-82be2b1a72a4" /></td>
    </tr>
  </tbody>
</table>

# Test plan

Search for a phrase on iOS