### PR TITLE
Add profile link to switcher menu

### DIFF
--- a/src/view/shell/desktop/LeftNav.tsx
+++ b/src/view/shell/desktop/LeftNav.tsx
@@ -193,6 +193,7 @@ function ProfileCard() {
           </Menu.Trigger>
           <SwitchMenuItems
             accounts={otherAccounts}
+            currentAccount={currentAccount}
             signOutPromptControl={signOutPromptControl}
           />
         </Menu.Root>
@@ -218,6 +219,7 @@ function ProfileCard() {
 
 function SwitchMenuItems({
   accounts,
+  currentAccount,
   signOutPromptControl,
 }: {
   accounts:
@@ -226,16 +228,55 @@ function SwitchMenuItems({
         profile?: AppBskyActorDefs.ProfileViewDetailed
       }[]
     | undefined
+  currentAccount:
+    | {
+        did: string
+        handle: string
+      }
+    | undefined
   signOutPromptControl: DialogControlProps
 }) {
   const {_} = useLingui()
   const {setShowLoggedOut} = useLoggedOutViewControls()
   const closeEverything = useCloseAllActiveElements()
+  const profileLink = currentAccount ? makeProfileLink(currentAccount) : '/'
+  const [pathName] = useMemo(() => router.matchPath(profileLink), [profileLink])
+  const currentRouteInfo = useNavigationState(state => {
+    if (!state) {
+      return {name: 'Home'}
+    }
+    return getCurrentRoute(state)
+  })
+  let isCurrent =
+    currentRouteInfo.name === 'Profile'
+      ? isTab(currentRouteInfo.name, pathName) &&
+        (currentRouteInfo.params as CommonNavigatorParams['Profile']).name ===
+          currentAccount?.handle
+      : isTab(currentRouteInfo.name, pathName)
+  const navigation = useNavigation()
 
   const onAddAnotherAccount = () => {
     setShowLoggedOut(true)
     closeEverything()
   }
+
+  const onProfilePress = useCallback(
+    (e: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => {
+      if (e.ctrlKey || e.metaKey || e.altKey) {
+        return
+      }
+      e.preventDefault()
+      if (isCurrent) {
+        emitSoftReset()
+      } else {
+        const [screen, params] = router.matchPath(profileLink)
+        // @ts-expect-error TODO: type matchPath well enough that it can be plugged into navigation.navigate directly
+        navigation.navigate(screen, params, {pop: true})
+      }
+    },
+    [navigation, profileLink, isCurrent],
+  )
+
   return (
     <Menu.Outer>
       {accounts && accounts.length > 0 && (
@@ -255,6 +296,16 @@ function SwitchMenuItems({
           <Menu.Divider />
         </>
       )}
+      <Menu.Item
+        label={_(msg`Go to profile`)}
+        // @ts-expect-error the function signature differs on web -prf
+        onPress={onProfilePress}
+        href={profileLink}>
+        <Menu.ItemIcon icon={UserCircle} />
+        <Menu.ItemText>
+          <Trans>Go to profile</Trans>
+        </Menu.ItemText>
+      </Menu.Item>
       <Menu.Item
         label={_(msg`Add another account`)}
         onPress={onAddAnotherAccount}>


### PR DESCRIPTION
This is an annoying experience I've run into a bunch where I instinctively click the top avatar button to go to my profile.

This also has more parity with the mobile version, as clicking the avatar on mobile will take you to your profile instead of opening a menu.

<img width="215" height="178" alt="Screenshot 2025-08-18 at 3 32 44 PM" src="https://github.com/user-attachments/assets/96ad44c4-8459-4d6b-8bd5-5c68707b2623" />
<img width="232" height="209" alt="Screenshot 2025-08-18 at 3 41 39 PM" src="https://github.com/user-attachments/assets/4ef768ba-85b7-40eb-af79-7b77a65e9a19" />

