### PR TITLE
Add underage notice to Moderation screen

### DIFF
--- a/src/screens/Moderation/index.tsx
+++ b/src/screens/Moderation/index.tsx
@@ -22,6 +22,7 @@ import {
 import {isNonConfigurableModerationAuthority} from '#/state/session/additional-moderation-authorities'
 import {useSetMinimalShellMode} from '#/state/shell'
 import {atoms as a, useBreakpoints, useTheme, type ViewStyleProp} from '#/alf'
+import {Admonition} from '#/components/Admonition'
 import {AgeAssuranceAdmonition} from '#/components/ageAssurance/AgeAssuranceAdmonition'
 import {Button, ButtonText} from '#/components/Button'
 import * as Dialog from '#/components/Dialog'
@@ -201,6 +202,24 @@ export function ModerationScreenInner({
 
   return (
     <View style={[a.pt_2xl, a.px_lg, gtMobile && a.px_2xl]}>
+      {isDeclaredUnderage && (
+        <View style={[a.pb_2xl]}>
+          <Admonition type="tip" style={[a.pb_md]}>
+            <Trans>
+              Your declared age is under 18. Some settings below may be
+              disabled. If this was a mistake, you may edit your bithdate in
+              your{' '}
+              <InlineLinkText
+                to="/settings/account"
+                label={_(msg`Account Settings`)}>
+                account settings
+              </InlineLinkText>
+              .
+            </Trans>
+          </Admonition>
+        </View>
+      )}
+
       <Text
         style={[a.text_md, a.font_bold, a.pb_md, t.atoms.text_contrast_high]}>
         <Trans>Moderation tools</Trans>

--- a/src/screens/Moderation/index.tsx
+++ b/src/screens/Moderation/index.tsx
@@ -211,7 +211,7 @@ export function ModerationScreenInner({
               your{' '}
               <InlineLinkText
                 to="/settings/account"
-                label={_(msg`Account Settings`)}>
+                label={_(msg`Go to account settings`)}>
                 account settings
               </InlineLinkText>
               .


### PR DESCRIPTION
This is a small bug left over from Age Assurance. For underage users, we hide adult content settings entirely. However, some adults may mistakenly entered the wrong birthdate, which previously left them in a "underage" state with no instructions on how to fix this. This adds a little admonition to the top of the screen for this case.

<img width="1452" height="1486" alt="CleanShot 2025-08-18 at 19 01 31@2x" src="https://github.com/user-attachments/assets/9fcb7c2f-dd77-4475-9b24-9e20624a752a" />
