### PR TITLE
Tweak `SelectMediaButton` error string, `accessibilityHint`, and comments

### DIFF
--- a/src/view/com/composer/SelectMediaButton.tsx
+++ b/src/view/com/composer/SelectMediaButton.tsx
@@ -481,7 +481,7 @@ export function SelectMediaButton({
       label={_(
         msg({
           message: `Add media to post`,
-          comment: `Accessibility label for button in composer to add photos or a video to a post`,
+          comment: `Accessibility label for button in composer to add images, a video, or a GIF to a post`,
         }),
       )}
       accessibilityHint={_(


### PR DESCRIPTION
After seeing the new strings that were added in #8828 appear on Crowdin, I noticed a few things that I'd previously missed.

So this PR suggests a few tweaks:

- As Claude reminded me when I checked: "_With the phrase “one or more,” standard English grammar calls for plural verb agreement._" So the `FileTooBig` error string should read `One or more of your selected files are too large. …` rather than `… is too large. …`, similar to the `Unsupported` error string.
- Now that GIFs are supported on native too, there's no need for the `isNative` check in the `accessibilityHint`, so I suggest removing the check and consequently simplifying the `accessibilityHint` slightly.
- A minor tweak to the comment for translators for the `Add media to post` label to use the same language as the `accessibilityHint`.