### PR TITLE
Tweak plural formatting in `ThreadItemReadMore.tsx`

### DIFF
--- a/src/screens/PostThread/components/ThreadItemReadMore.tsx
+++ b/src/screens/PostThread/components/ThreadItemReadMore.tsx
@@ -90,10 +90,10 @@ export const ThreadItemReadMore = memo(function ThreadItemReadMore({
                   interacted && a.underline,
                 ]}>
                 <Trans>
-                  Read {item.moreReplies} more{' '}
+                  Read{' '}
                   <Plural
-                    one="reply"
-                    other="replies"
+                    one="# more reply"
+                    other="# more replies"
                     value={item.moreReplies}
                   />
                 </Trans>


### PR DESCRIPTION
This [feedback on Crowdin](https://bluesky.crowdin.com/editor/1/11/en-sv/9#8330) was left by @nilaallj for the `Read 1 more reply`/`Read x more replies` string that's shown in threads:

> Maybe the reply count could be included in the plural formatting? For example: {0, plural, one {# more reply} other {# more replies}}. It’s not strictly needed for Swedish, but it would allow a more natural translation by leaving out the number in the singular form. I think other languages might benefit from this too in different ways. :)

So this PR suggests adjusting the plural formatting here to give translators more flexibility.