### PR TITLE
[APP-1406] follow suggestions card to show follow back

### DIFF
--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -515,7 +515,7 @@ export function FollowButtonInner({
   )
   const followLabel = _(
     msg({
-      message: profile.viewer?.followedBy ? 'Follow back' : 'Follow',
+      message: profile.viewer?.followedBy ? 'Follow Back' : 'Follow',
       comment: 'User is not following this account, click to follow',
     }),
   )

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -515,7 +515,7 @@ export function FollowButtonInner({
   )
   const followLabel = _(
     msg({
-      message: 'Follow',
+      message: profile.viewer?.followedBy ? 'Follow back' : 'Follow',
       comment: 'User is not following this account, click to follow',
     }),
   )

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -515,7 +515,7 @@ export function FollowButtonInner({
   )
   const followLabel = _(
     msg({
-      message: profile.viewer?.followedBy ? 'Follow Back' : 'Follow',
+      message: profile.viewer?.followedBy ? 'Follow back' : 'Follow',
       comment: 'User is not following this account, click to follow',
     }),
   )

--- a/src/screens/Profile/Header/ProfileHeaderStandard.tsx
+++ b/src/screens/Profile/Header/ProfileHeaderStandard.tsx
@@ -247,7 +247,7 @@ let ProfileHeaderStandard = ({
                     {profile.viewer?.following ? (
                       <Trans>Following</Trans>
                     ) : profile.viewer?.followedBy ? (
-                      <Trans>Follow Back</Trans>
+                      <Trans>Follow back</Trans>
                     ) : (
                       <Trans>Follow</Trans>
                     )}

--- a/src/view/com/post-thread/PostThreadFollowBtn.tsx
+++ b/src/view/com/post-thread/PostThreadFollowBtn.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import {AppBskyActorDefs} from '@atproto/api'
+import {type AppBskyActorDefs} from '@atproto/api'
 import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 import {useNavigation} from '@react-navigation/native'
@@ -126,7 +126,7 @@ function PostThreadFollowBtnLoaded({
       <ButtonText>
         {!isFollowing ? (
           isFollowedBy ? (
-            <Trans>Follow Back</Trans>
+            <Trans>Follow back</Trans>
           ) : (
             <Trans>Follow</Trans>
           )

--- a/src/view/com/profile/FollowButton.tsx
+++ b/src/view/com/profile/FollowButton.tsx
@@ -1,11 +1,11 @@
-import {StyleProp, TextStyle, View} from 'react-native'
+import {type StyleProp, type TextStyle, View} from 'react-native'
 import {msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
-import {Shadow} from '#/state/cache/types'
+import {type Shadow} from '#/state/cache/types'
 import {useProfileFollowMutationQueue} from '#/state/queries/profile'
-import * as bsky from '#/types/bsky'
-import {Button, ButtonType} from '../util/forms/Button'
+import type * as bsky from '#/types/bsky'
+import {Button, type ButtonType} from '../util/forms/Button'
 import * as Toast from '../util/Toast'
 
 export function FollowButton({
@@ -78,7 +78,7 @@ export function FollowButton({
         type={unfollowedType}
         labelStyle={labelStyle}
         onPress={onPressFollow}
-        label={_(msg({message: 'Follow Back', context: 'action'}))}
+        label={_(msg({message: 'Follow back', context: 'action'}))}
       />
     )
   }


### PR DESCRIPTION
Summary
---

When a user already follows you, the profile cards "Follow" button now shows "Follow back" instead. This helps keep the follow button consistent across the app.

In addition, I noticed that since this component is used in a few other places among the app we also have it updated there for free. Such as on the search page under the "Suggested Accounts" section.

Edit: updated all uses of "Follow Back" through out the app (only a handful of spots) to be "Follow back"

Screenshots
---
_Note: I manually swapped the "Follow" and "Follow back" to get these screenshots, as it's tricky to find it naturally._

**Profile header suggested accounts**
<img width="1208" height="1317" alt="image" src="https://github.com/user-attachments/assets/35730637-ee07-4313-aede-81e181640dd7" />

**Search page suggested accounts section**
<img width="1251" height="403" alt="image" src="https://github.com/user-attachments/assets/61115c34-89f1-448c-8fc5-0f981441a69f" />