### PR TITLE
[APP-1399] trending videos icon missing

### DIFF
--- a/src/components/interstitials/TrendingVideos.tsx
+++ b/src/components/interstitials/TrendingVideos.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect} from 'react'
+import {useCallback, useEffect, useMemo} from 'react'
 import {ScrollView, View} from 'react-native'
 import {AppBskyEmbedVideo, AtUri} from '@atproto/api'
 import {msg, Trans} from '@lingui/macro'
@@ -55,7 +55,7 @@ export function TrendingVideos() {
   const {setTrendingVideoDisabled} = useTrendingSettingsApi()
   const trendingPrompt = Prompt.usePromptControl()
 
-  const onConfirmHide = React.useCallback(() => {
+  const onConfirmHide = useCallback(() => {
     setTrendingVideoDisabled(true)
     logEvent('trendingVideos:hide', {context: 'interstitial:discover'})
   }, [setTrendingVideoDisabled])
@@ -147,9 +147,7 @@ function VideoCards({
 }: {
   data: Exclude<ReturnType<typeof usePostFeedQuery>['data'], undefined>
 }) {
-  const t = useTheme()
-  const {_} = useLingui()
-  const items = React.useMemo(() => {
+  const items = useMemo(() => {
     return data.pages
       .flatMap(page => page.slices)
       .map(slice => slice.items[0])
@@ -157,10 +155,6 @@ function VideoCards({
       .filter(item => AppBskyEmbedVideo.isView(item.post.embed))
       .slice(0, 8)
   }, [data])
-  const href = React.useMemo(() => {
-    const urip = new AtUri(VIDEO_FEED_URI)
-    return makeCustomFeedLink(urip.host, urip.rkey, undefined, 'discover')
-  }, [])
 
   return (
     <>
@@ -183,50 +177,64 @@ function VideoCards({
         </View>
       ))}
 
-      <View style={[{width: CARD_WIDTH * 2}]}>
-        <Link
-          to={href}
-          label={_(msg`View more`)}
-          style={[
-            a.justify_center,
-            a.align_center,
-            a.flex_1,
-            a.rounded_lg,
-            a.border,
-            t.atoms.border_contrast_low,
-            t.atoms.bg,
-            t.atoms.shadow_sm,
-          ]}>
-          {({pressed}) => (
+      <ViewMoreCard />
+    </>
+  )
+}
+
+function ViewMoreCard() {
+  const t = useTheme()
+  const {_} = useLingui()
+
+  const href = useMemo(() => {
+    const urip = new AtUri(VIDEO_FEED_URI)
+    return makeCustomFeedLink(urip.host, urip.rkey, undefined, 'discover')
+  }, [])
+
+  return (
+    <View style={[{width: CARD_WIDTH * 2}]}>
+      <Link
+        to={href}
+        label={_(msg`View more`)}
+        style={[
+          a.justify_center,
+          a.align_center,
+          a.flex_1,
+          a.rounded_lg,
+          a.border,
+          t.atoms.border_contrast_low,
+          t.atoms.bg,
+          t.atoms.shadow_sm,
+        ]}>
+        {({pressed}) => (
+          <View
+            style={[
+              a.flex_row,
+              a.align_center,
+              a.gap_md,
+              {
+                opacity: pressed ? 0.6 : 1,
+              },
+            ]}>
+            <Text style={[a.text_md]}>
+              <Trans>View more</Trans>
+            </Text>
             <View
               style={[
-                a.flex_row,
                 a.align_center,
-                a.gap_md,
+                a.justify_center,
+                a.rounded_full,
                 {
-                  opacity: pressed ? 0.6 : 1,
+                  width: 34,
+                  height: 34,
+                  backgroundColor: t.palette.primary_500,
                 },
               ]}>
-              <Text style={[a.text_md]}>
-                <Trans>View more</Trans>
-              </Text>
-              <View
-                style={[
-                  a.align_center,
-                  a.justify_center,
-                  a.rounded_full,
-                  {
-                    width: 34,
-                    height: 34,
-                    backgroundColor: t.palette.primary_500,
-                  },
-                ]}>
-                <ButtonIcon icon={ChevronRight} />
-              </View>
+              <ButtonIcon icon={ChevronRight} />
             </View>
-          )}
-        </Link>
-      </View>
-    </>
+          </View>
+        )}
+      </Link>
+    </View>
   )
 }

--- a/src/components/interstitials/TrendingVideos.tsx
+++ b/src/components/interstitials/TrendingVideos.tsx
@@ -219,19 +219,13 @@ function ViewMoreCard() {
             <Text style={[a.text_md]}>
               <Trans>View more</Trans>
             </Text>
-            <View
-              style={[
-                a.align_center,
-                a.justify_center,
-                a.rounded_full,
-                {
-                  width: 34,
-                  height: 34,
-                  backgroundColor: t.palette.primary_500,
-                },
-              ]}>
+            <Button
+              color="primary"
+              size="small"
+              shape="round"
+              label={_(msg`View more trending videos`)}>
               <ButtonIcon icon={ChevronRight} />
-            </View>
+            </Button>
           </View>
         )}
       </Link>


### PR DESCRIPTION
Summary
---
The icon was "missing" but really it was just the same color as the background. I've updated the component to use the actual `Button` and `ButtonIcon` instead of a `View`.

During my investigation of the code I realized no one had introduced any changes specifically for that icon (according to git blame). So after poking around a bit I found out that the issue was that the `ButtonIcon` was updated to use these hooks:
```typescript
  const {size: buttonSize} = useButtonContext()
  const textStyles = useSharedButtonTextStyles()
```

Which means that the icon was using the primary color because there was no present button context and thus thought it had no background.

I've also extracted a new `ViewMoreCard` component out of the `VideoCards` component to help clean up the structure and provide a better separation of concerns (`VideoCards` had lots of hooks that were solely for the `ViewMoreCard`.

Additionally I've refactored some of the code, mostly the imports, to be in alignment with the new code guidelines. Replacing `import React from 'react'` with `import {useState, useCallback} from 'react'`.

*Hint for reviewers, turn on the "Hide whitespace" setting in the github diff view to better see the changes that I made (as the refactor shows a lot more than what was actually changed).*

Screenshots
---
Tested on all themes.

<img width="250" height="2556" alt="image" src="https://github.com/user-attachments/assets/5a9c9ff0-324a-4930-b2ef-f15a170e83e2" />

<img width="250" height="2556" alt="image" src="https://github.com/user-attachments/assets/06b34120-b997-4061-b643-a3f4ee4b844c" />

<img width="250" height="2556" alt="image" src="https://github.com/user-attachments/assets/c8b370a0-df54-4396-86e0-a75aa628ac85" />
