### PR TITLE
Rearrange `followLabel` translation logic

### DIFF
--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -513,12 +513,19 @@ export function FollowButtonInner({
       comment: 'User is following this account, click to unfollow',
     }),
   )
-  const followLabel = _(
-    msg({
-      message: profile.viewer?.followedBy ? 'Follow back' : 'Follow',
-      comment: 'User is not following this account, click to follow',
-    }),
-  )
+  const followLabel = profile.viewer?.followedBy
+    ? _(
+        msg({
+          message: 'Follow back',
+          comment: 'User is not following this account, click to follow back',
+        }),
+      )
+    : _(
+        msg({
+          message: 'Follow',
+          comment: 'User is not following this account, click to follow',
+        }),
+      )
 
   if (!profile.viewer) return null
   if (


### PR DESCRIPTION
As a follow-up to #8875, this PR suggests rearranging the translation logic for `followLabel` in `src/components/ProfileCard.tsx`.

Currently, Lingui shows these messages:

![IMG_9706](https://github.com/user-attachments/assets/7ce420ed-bb7f-4f07-adfd-e57194270c76)

The explanation of the issue and how to fix it which follows is from Claude.

___

The issue is that Lingui's extraction process cannot handle dynamic expressions in the `message` field. The ternary operator `profile.viewer?.followedBy ? 'Follow back' : 'Follow'` depends on runtime data, but Lingui needs to extract all translatable strings at build time.

Here's how to fix it:

## Solution

Replace the problematic code (lines 516-521) with:

```typescript
const followLabel = profile.viewer?.followedBy
  ? _(
      msg({
        message: 'Follow back',
        comment: 'User is not following this account, click to follow back',
      }),
    )
  : _(
      msg({
        message: 'Follow',
        comment: 'User is not following this account, click to follow',
      }),
    )
```

## Explanation

The key changes are:
1. **Move the conditional logic outside** the `msg()` call
2. **Create two separate `msg()` calls** – one for "Follow back" and one for "Follow"
3. Each message now has a **static string** that Lingui can extract at build time

This way:
- Lingui can successfully extract both strings during the build process
- The runtime behavior remains exactly the same
- Both messages will be available for translation
- The appropriate message is still chosen based on the `profile.viewer?.followedBy` condition at runtime

This pattern should be followed whenever you need conditional messages in Lingui – always define each message separately with static strings, then use JavaScript logic to choose between them.