### PR TITLE
feat: add canonical URLs to improve SEO

### DIFF
--- a/bskyweb/templates/home.html
+++ b/bskyweb/templates/home.html
@@ -12,6 +12,7 @@
 
   <meta property="og:url" content="https://bsky.app" />
   <meta name="twitter:url" content="https://bsky.app" />
+  <link rel="canonical" href="https://bsky.app" />
 
   <meta property="og:image" content="https://bsky.app/static/social-card-default-gradient.png" />
   <meta property="twitter:image" content="https://bsky.app/static/social-card-default-gradient.png"  />

--- a/bskyweb/templates/post.html
+++ b/bskyweb/templates/post.html
@@ -14,6 +14,7 @@
   <meta property="profile:username" content="{{ profileView.Handle }}">
   {%- if requestURI %}
   <meta property="og:url" content="{{ requestURI }}">
+  <link rel="canonical" href="{{ requestURI }}" />
   {% endif -%}
   {%- if postView.Author.DisplayName %}
   <meta property="og:title" content="{{ postView.Author.DisplayName }} (@{{ postView.Author.Handle }})">

--- a/bskyweb/templates/profile.html
+++ b/bskyweb/templates/profile.html
@@ -15,6 +15,7 @@
   <meta property="profile:username" content="{{ profileView.Handle }}">
   {%- if requestURI %}
   <meta property="og:url" content="{{ requestURI }}">
+  <link rel="canonical" href="{{ requestURI }}" />
   {% endif -%}
   {%- if profileView.DisplayName %}
   <meta property="og:title" content="{{ profileView.DisplayName }} (@{{ profileView.Handle }})">


### PR DESCRIPTION
## Summary
- Add canonical URLs to home page, post pages, and profile pages to improve SEO and prevent duplicate content issues
- Use existing `requestURI` template variable for dynamic canonical URLs on post and profile pages
- Set static canonical URL for home page

## Changes
- **Home page**: Added static canonical URL pointing to `https://bsky.app`
- **Post pages**: Added dynamic canonical URL using `requestURI` template variable
- **Profile pages**: Added dynamic canonical URL using `requestURI` template variable