### PR TITLE
Select account redesign

### DIFF
--- a/src/components/AccountList.tsx
+++ b/src/components/AccountList.tsx
@@ -11,12 +11,13 @@ import {useProfilesQuery} from '#/state/queries/profile'
 import {type SessionAccount, useSession} from '#/state/session'
 import {UserAvatar} from '#/view/com/util/UserAvatar'
 import {atoms as a, useTheme} from '#/alf'
-import {Check_Stroke2_Corner0_Rounded as Check} from '#/components/icons/Check'
-import {ChevronRight_Stroke2_Corner0_Rounded as Chevron} from '#/components/icons/Chevron'
+import {Button} from '#/components/Button'
+import {CheckThick_Stroke2_Corner0_Rounded as CheckIcon} from '#/components/icons/Check'
+import {ChevronRight_Stroke2_Corner0_Rounded as ChevronIcon} from '#/components/icons/Chevron'
+import {PlusLarge_Stroke2_Corner0_Rounded as PlusIcon} from '#/components/icons/Plus'
+import {Text} from '#/components/Typography'
 import {useSimpleVerificationState} from '#/components/verification'
 import {VerificationCheck} from '#/components/verification/VerificationCheck'
-import {Button} from './Button'
-import {Text} from './Typography'
 
 export function AccountList({
   onSelectAccount,
@@ -44,9 +45,9 @@ export function AccountList({
     <View
       pointerEvents={pendingDid ? 'none' : 'auto'}
       style={[
-        a.rounded_md,
+        a.rounded_lg,
         a.overflow_hidden,
-        {borderWidth: 1},
+        a.border,
         t.atoms.border_contrast_low,
       ]}>
       {accounts.map(account => (
@@ -58,7 +59,7 @@ export function AccountList({
             isCurrentAccount={account.did === currentAccount?.did}
             isPendingAccount={account.did === pendingDid}
           />
-          <View style={[{borderBottomWidth: 1}, t.atoms.border_contrast_low]} />
+          <View style={[a.border_b, t.atoms.border_contrast_low]} />
         </React.Fragment>
       ))}
       <Button
@@ -72,22 +73,25 @@ export function AccountList({
               a.flex_1,
               a.flex_row,
               a.align_center,
-              {height: 48},
+              a.p_lg,
+              a.gap_sm,
               (hovered || pressed) && t.atoms.bg_contrast_25,
             ]}>
-            <Text
+            <View
               style={[
-                a.font_bold,
-                a.flex_1,
-                a.flex_row,
-                a.py_sm,
-                a.leading_tight,
-                t.atoms.text_contrast_medium,
-                {paddingLeft: 56},
+                t.atoms.bg_contrast_25,
+                a.rounded_full,
+                {width: 48, height: 48},
+                a.justify_center,
+                a.align_center,
+                (hovered || pressed) && t.atoms.bg_contrast_50,
               ]}>
+              <PlusIcon style={[t.atoms.text_contrast_low]} size="md" />
+            </View>
+            <Text style={[a.flex_1, a.leading_tight, a.text_md, a.font_medium]}>
               {otherLabel ?? <Trans>Other account</Trans>}
             </Text>
-            <Chevron size="sm" style={[t.atoms.text, a.mr_md]} />
+            <ChevronIcon size="md" style={[t.atoms.text_contrast_low]} />
           </View>
         )}
       </Button>
@@ -134,14 +138,13 @@ function AccountItem({
             a.flex_1,
             a.flex_row,
             a.align_center,
-            a.px_md,
+            a.p_lg,
             a.gap_sm,
-            {height: 56},
             (hovered || pressed || isPendingAccount) && t.atoms.bg_contrast_25,
           ]}>
           <UserAvatar
             avatar={profile?.avatar}
-            size={36}
+            size={48}
             type={profile?.associated?.labeler ? 'labeler' : 'user'}
             live={live}
             hideLiveBadge
@@ -151,7 +154,7 @@ function AccountItem({
             <View style={[a.flex_row, a.align_center, a.gap_xs]}>
               <Text
                 emoji
-                style={[a.font_bold, a.leading_tight]}
+                style={[a.font_medium, a.leading_tight, a.text_md]}
                 numberOfLines={1}>
                 {sanitizeDisplayName(
                   profile?.displayName || profile?.handle || account.handle,
@@ -166,15 +169,32 @@ function AccountItem({
                 </View>
               )}
             </View>
-            <Text style={[a.leading_tight, t.atoms.text_contrast_medium]}>
+            <Text
+              style={[
+                a.leading_tight,
+                t.atoms.text_contrast_medium,
+                a.text_sm,
+              ]}>
               {sanitizeHandle(account.handle, '@')}
             </Text>
           </View>
 
           {isCurrentAccount ? (
-            <Check size="sm" style={[{color: t.palette.positive_600}]} />
+            <View
+              style={[
+                {
+                  width: 20,
+                  height: 20,
+                  backgroundColor: t.palette.positive_600,
+                },
+                a.rounded_full,
+                a.justify_center,
+                a.align_center,
+              ]}>
+              <CheckIcon size="xs" style={[{color: t.palette.white}]} />
+            </View>
           ) : (
-            <Chevron size="sm" style={[t.atoms.text]} />
+            <ChevronIcon size="md" style={[t.atoms.text_contrast_low]} />
           )}
         </View>
       )}

--- a/src/components/dialogs/SwitchAccount.tsx
+++ b/src/components/dialogs/SwitchAccount.tsx
@@ -41,7 +41,7 @@ export function SwitchAccountDialog({
   }, [setShowLoggedOut, control])
 
   return (
-    <Dialog.Outer control={control}>
+    <Dialog.Outer control={control} nativeOptions={{preventExpansion: true}}>
       <Dialog.Handle />
       <Dialog.ScrollableInner label={_(msg`Switch Account`)}>
         <View style={[a.gap_lg]}>

--- a/src/components/icons/TEMPLATE.tsx
+++ b/src/components/icons/TEMPLATE.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import Svg, {Path} from 'react-native-svg'
 
-import {Props, useCommonSVGProps} from '#/components/icons/common'
+import {type Props, useCommonSVGProps} from '#/components/icons/common'
 
 export const IconTemplate_Stroke2_Corner0_Rounded = React.forwardRef(
   function LogoImpl(props: Props, ref) {


### PR DESCRIPTION
Part of auth flow rework - remembered I already did it in the stalled #8650 PR so cherry-picked it out

<table>
  <tbody>
    <tr>
      <td><img width="300" src="https://github.com/user-attachments/assets/79b05554-3b0c-4a19-bb9a-2f9cc769cbdf" /></td>
      <td><img width="300" src="https://github.com/user-attachments/assets/662896a3-7ced-4e66-810a-46ec9440b5cc" /></td>
    </tr>
  </tbody>
</table>

<img width="1728" height="993" alt="Screenshot 2025-08-26 at 16 35 09" src="https://github.com/user-attachments/assets/ca448ff8-05ce-413a-bfba-8bd32e44414b" />
