### PR TITLE
Fix bad copy pasta

### DIFF
--- a/src/components/Toast/index.tsx
+++ b/src/components/Toast/index.tsx
@@ -67,7 +67,7 @@ export function show(
   if (typeof content === 'string') {
     sonner.custom(
       <ToastConfigProvider id={id}>
-        <DefaultToast content={content} type={type} />
+        <Default content={content} type={type} />
       </ToastConfigProvider>,
       {
         ...options,


### PR DESCRIPTION
I copied this from the web file. For native, there are some wrapper overrides in the `index.tsx` file that are captured in `Default`.