### PR TITLE
Mark label for translation in `LoggedOutCTA.tsx`

### DIFF
--- a/src/components/LoggedOutCTA.tsx
+++ b/src/components/LoggedOutCTA.tsx
@@ -1,5 +1,5 @@
 import {View, type ViewStyle} from 'react-native'
-import {Trans} from '@lingui/macro'
+import {msg, Trans} from '@lingui/macro'
 
 import {type Gate} from '#/lib/statsig/gates'
 import {useGate} from '#/lib/statsig/statsig'
@@ -21,6 +21,7 @@ export function LoggedOutCTA({style, gateName}: LoggedOutCTAProps) {
   const {requestSwitchToAccount} = useLoggedOutViewControls()
   const gate = useGate()
   const t = useTheme()
+  const {_} = useLingui()
 
   // Only show for logged-out users on web
   if (hasSession || !isWeb) {
@@ -66,7 +67,7 @@ export function LoggedOutCTA({style, gateName}: LoggedOutCTAProps) {
           onPress={() => {
             requestSwitchToAccount({requestedAccount: 'new'})
           }}
-          label="Create account"
+          label={_(msg`Create account`)}
           size="small"
           variant="solid"
           color="primary">

--- a/src/components/LoggedOutCTA.tsx
+++ b/src/components/LoggedOutCTA.tsx
@@ -1,5 +1,6 @@
 import {View, type ViewStyle} from 'react-native'
 import {msg, Trans} from '@lingui/macro'
+import {useLingui} from '@lingui/react'
 
 import {type Gate} from '#/lib/statsig/gates'
 import {useGate} from '#/lib/statsig/statsig'


### PR DESCRIPTION
As a follow-up to #8906, this small PR marks the `Create account` label in `LoggedOutCTA.tsx` for translation.