### PR TITLE
Tweak label in `FollowDialog.tsx`

### DIFF
--- a/src/components/ProgressGuide/FollowDialog.tsx
+++ b/src/components/ProgressGuide/FollowDialog.tsx
@@ -423,7 +423,7 @@ let Tab = ({
       )
     : _(
         msg({
-          message: `Search for "${interestsDisplayName}`,
+          message: `Search for "${interestsDisplayName}"`,
           comment:
             'Accessibility label for a tab that searches for accounts in a category (e.g. Art, Video Games, Sports, etc.) that are suggested for the user to follow. The tab is not currently active and can be selected.',
         }),


### PR DESCRIPTION
This tiny PR fixes an error I made in #8879 where a quotation mark got left off the end of a label (oops).