### PR TITLE
Update: search on Gif select component to add small padding to match other search experiences

### DIFF
--- a/src/components/dialogs/GifSelect.tsx
+++ b/src/components/dialogs/GifSelect.tsx
@@ -147,10 +147,8 @@ function GifList({
           a.align_center,
           !gtMobile && web(a.gap_md),
           a.pb_sm,
+          t.atoms.bg,
         ]}>
-        {/* cover top corners */}
-        <View style={[a.absolute, a.inset_0, t.atoms.bg]} />
-
         {!gtMobile && isWeb && (
           <Button
             size="small"


### PR DESCRIPTION
This PR makes a minor update to the `GifSelect` search to add small spacing under the search for consistency with other search inputs in the app. 

Before (web):
<img width="1066" height="518" alt="Screenshot 2025-08-27 at 9 28 00 PM" src="https://github.com/user-attachments/assets/088c3a4d-ddb2-4c87-9e8f-f4ed23a836d7" />

After (web):
<img width="1066" height="518" alt="Screenshot 2025-08-27 at 9 27 28 PM" src="https://github.com/user-attachments/assets/7654ecb2-97c0-499f-99f3-0890746aac29" />

Before (mobile):
<img width="800" height="518" alt="Screenshot 2025-08-27 at 9 28 22 PM" src="https://github.com/user-attachments/assets/e85c045b-c5f2-475f-9df2-9f06ac878204" />

After (mobile):
<img width="401" height="503" alt="Screenshot 2025-08-27 at 9 29 32 PM" src="https://github.com/user-attachments/assets/eda68ccb-2cd6-4cdc-b61b-d6772c76d51e" />
