### PR TITLE
feat: google structured data for profiles and posts

### DIFF
--- a/bskyweb/templates/post.html
+++ b/bskyweb/templates/post.html
@@ -62,16 +62,16 @@
       "@type": "DiscussionForumPosting",
       "author": {
         "@type": "Person",
-        "name": "{{ postView.Author.DisplayName|escapejs }}",
-        "url": "https://bsky.app/@{{ postView.Author.Handle|escapejs }}"
+        "name": "{{ postView.Author.DisplayName }}",
+        "url": "https://bsky.app/profile/{{ postView.Author.Handle }}"
       },
       {%- if postText %}
-      "text": "{{ postText|escapejs }}",
+      "text": "{{ postText }}",
       {% endif %}
       {%- if imageThumbUrls %}
-      "image": "{{ imageThumbUrls[0]|escapejs }}",
+      "image": "{{ imageThumbUrls[0] }}",
       {% endif %}
-      "datePublished": "{{ postView.IndexedAt|escapejs }}",
+      "datePublished": "{{ postView.IndexedAt }}",
       "interactionStatistic": [
         {
           "@type": "InteractionCounter",

--- a/bskyweb/templates/profile.html
+++ b/bskyweb/templates/profile.html
@@ -56,20 +56,20 @@
   {
     "@context": "https://schema.org",
     "@type": "ProfilePage",
-    "dateCreated": "{{ profileView.CreatedAt|escapejs }}",
+    "dateCreated": "{{ profileView.CreatedAt }}",
     "mainEntity": {
       "@type": "Person",
-      "name": "{{ profileView.DisplayName|escapejs }}",
-      "alternateName": "@{{ profileView.Handle|escapejs }}",
-      "identifier": "{{ profileView.Did|escapejs }}",
-      "description": "{{ profileView.Description|escapejs }}",
-      "image": "{{ profileView.Avatar|escapejs }}",
+      "name": "{{ profileView.DisplayName }}",
+      "alternateName": "@{{ profileView.Handle }}",
+      "identifier": "{{ profileView.Did }}",
+      "description": "{{ profileView.Description }}",
+      "image": "{{ profileView.Avatar }}",
       "interactionStatistic": [
         {
           "@type": "InteractionCounter",
           "interactionType": "https://schema.org/FollowAction",
           "userInteractionCount": {{ profileView.FollowersCount }}
-        },
+        }
       ],
       "agentInteractionStatistic": [
         {
@@ -81,7 +81,7 @@
           "@type": "InteractionCounter",
           "interactionType": "https://schema.org/WriteAction",
           "userInteractionCount": {{ profileView.PostsCount }}
-        },
+        }
       ]
     }
   }


### PR DESCRIPTION
Adds structured data for profiles and posts to the corresponding templates in bskyweb. 

I had to pass some new data to the pongo template for posts:
- post record key
- post record creation date
- video thumbnail URL

Some test results showing the current state of things:

- [Post w/ video](https://search.google.com/test/rich-results/result?id=i3I4Odf6Pybnr3BRNLhVhg)
- [Post w/ images](https://search.google.com/test/rich-results/result?id=xF1XtG3B6MXmDjfVwpJEYw)
- [Profile](https://search.google.com/test/rich-results/result?id=h4v4geSPFGIrqaY6XDPB0Q)

Question - do we potentially need to escape the provided strings? I tried `|escapejs` but it had some unintended side effects, like turning emojis into escape codes.