### PR TITLE
Fall back to v16 picker

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "expo-image": "^2.4.0",
     "expo-image-crop-tool": "^0.1.8",
     "expo-image-manipulator": "~13.1.7",
-    "expo-image-picker": "^17.0.2",
+    "expo-image-picker": "^16.1.4",
     "expo-intent-launcher": "^12.1.5",
     "expo-linear-gradient": "~14.1.5",
     "expo-linking": "~7.1.5",

--- a/patches/expo-image-picker+16.1.4.patch
+++ b/patches/expo-image-picker+16.1.4.patch
@@ -1,0 +1,38 @@
+diff --git a/node_modules/expo-image-picker/android/src/main/java/expo/modules/imagepicker/MediaHandler.kt b/node_modules/expo-image-picker/android/src/main/java/expo/modules/imagepicker/MediaHandler.kt
+index c863fb8..cde8859 100644
+--- a/node_modules/expo-image-picker/android/src/main/java/expo/modules/imagepicker/MediaHandler.kt
++++ b/node_modules/expo-image-picker/android/src/main/java/expo/modules/imagepicker/MediaHandler.kt
+@@ -101,16 +101,30 @@ internal class MediaHandler(
+       val fileData = getAdditionalFileData(sourceUri)
+       val mimeType = getType(context.contentResolver, sourceUri)
+ 
++      // Extract basic metadata
++      var width = metadataRetriever.extractInt(MediaMetadataRetriever.METADATA_KEY_VIDEO_WIDTH)
++      var height = metadataRetriever.extractInt(MediaMetadataRetriever.METADATA_KEY_VIDEO_HEIGHT)
++      val rotation = metadataRetriever.extractInt(MediaMetadataRetriever.METADATA_KEY_VIDEO_ROTATION)
++
++      // Android returns the encoded width/height which do not take the display rotation into
++      // account. For videos recorded in portrait mode the encoded dimensions are often landscape
++      // (e.g. 1920x1080) paired with a 90°/270° rotation flag.  iOS adjusts these values before
++      // reporting them, so to keep the behaviour consistent across platforms we swap the width
++      // and height when the rotation indicates the video should be displayed in portrait.
++      if (rotation % 180 != 0) {
++        width = height.also { height = width }
++      }
++
+       return ImagePickerAsset(
+         type = MediaType.VIDEO,
+         uri = outputUri.toString(),
+-        width = metadataRetriever.extractInt(MediaMetadataRetriever.METADATA_KEY_VIDEO_WIDTH),
+-        height = metadataRetriever.extractInt(MediaMetadataRetriever.METADATA_KEY_VIDEO_HEIGHT),
++        width = width,
++        height = height,
+         fileName = fileData?.fileName,
+         fileSize = fileData?.fileSize,
+         mimeType = mimeType,
+         duration = metadataRetriever.extractInt(MediaMetadataRetriever.METADATA_KEY_DURATION),
+-        rotation = metadataRetriever.extractInt(MediaMetadataRetriever.METADATA_KEY_VIDEO_ROTATION),
++        rotation = rotation,
+         assetId = sourceUri.getMediaStoreAssetId()
+       )
+     } catch (cause: FailedToExtractVideoMetadataException) {

--- a/patches/expo-image-picker+16.1.4.patch.md
+++ b/patches/expo-image-picker+16.1.4.patch.md
@@ -1,0 +1,5 @@
+# Expo Image Picker patch
+
+Cherry-picked https://github.com/expo/expo/pull/37849
+
+Remove when we update to a version that includes this commit.

--- a/yarn.lock
+++ b/yarn.lock
@@ -11327,11 +11327,6 @@ expo-image-loader@~5.1.0:
   resolved "https://registry.yarnpkg.com/expo-image-loader/-/expo-image-loader-5.1.0.tgz#f7d65f9b9a9714eaaf5d50a406cb34cb25262153"
   integrity sha512-sEBx3zDQIODWbB5JwzE7ZL5FJD+DK3LVLWBVJy6VzsqIA6nDEnSFnsnWyCfCTSvbGigMATs1lgkC2nz3Jpve1Q==
 
-expo-image-loader@~6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/expo-image-loader/-/expo-image-loader-6.0.0.tgz#15230442cbb90e101c080a4c81e37d974e43e072"
-  integrity sha512-nKs/xnOGw6ACb4g26xceBD57FKLFkSwEUTDXEDF3Gtcu3MqF3ZIYd3YM+sSb1/z9AKV1dYT7rMSGVNgsveXLIQ==
-
 expo-image-manipulator@~13.1.7:
   version "13.1.7"
   resolved "https://registry.yarnpkg.com/expo-image-manipulator/-/expo-image-manipulator-13.1.7.tgz#e891ce9b49d75962eafdf5b7d670116583379e76"
@@ -11339,12 +11334,12 @@ expo-image-manipulator@~13.1.7:
   dependencies:
     expo-image-loader "~5.1.0"
 
-expo-image-picker@^17.0.2:
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/expo-image-picker/-/expo-image-picker-17.0.2.tgz#79af7192b2947e54686d0ece6ccbb5f6a178a809"
-  integrity sha512-O74FIrc37KB4ZxC/BMUL3fEZwdmIB60As0q5XczRlzPvWismBl7GG3pPy+o5SGUI2jcepTvQAa2PcNcMbUZNYg==
+expo-image-picker@^16.1.4:
+  version "16.1.4"
+  resolved "https://registry.yarnpkg.com/expo-image-picker/-/expo-image-picker-16.1.4.tgz#d4ac2d1f64f6ec9347c3f64f8435b40e6e4dcc40"
+  integrity sha512-bTmmxtw1AohUT+HxEBn2vYwdeOrj1CLpMXKjvi9FKSoSbpcarT4xxI0z7YyGwDGHbrJqyyic3I9TTdP2J2b4YA==
   dependencies:
-    expo-image-loader "~6.0.0"
+    expo-image-loader "~5.1.0"
 
 expo-image@^2.4.0:
   version "2.4.0"


### PR DESCRIPTION
Reverts back `expo-image-picker@16` and re-adds the patch we had prior to #8828. Should be no functional changes.