### PR TITLE
Prevent double border on web explore page

### DIFF
--- a/src/screens/Search/Explore.tsx
+++ b/src/screens/Search/Explore.tsx
@@ -14,6 +14,7 @@ import {cleanError} from '#/lib/strings/errors'
 import {sanitizeHandle} from '#/lib/strings/handles'
 import {logger} from '#/logger'
 import {type MetricEvents} from '#/logger/metrics'
+import {isNative} from '#/platform/detection'
 import {useLanguagePrefs} from '#/state/preferences/languages'
 import {useModerationOpts} from '#/state/preferences/moderation-opts'
 import {RQKEY_ROOT_PAGINATED as useActorSearchPaginatedQueryKeyRoot} from '#/state/queries/actor-search'
@@ -916,8 +917,7 @@ export function Explore({
         }
         case 'preview:header': {
           return (
-            <ModuleHeader.Container
-              style={[a.pt_xs, t.atoms.border_contrast_low, a.border_b]}>
+            <ModuleHeader.Container style={[a.pt_xs]} bottomBorder={isNative}>
               {/* Very non-scientific way to avoid small gap on scroll */}
               <View style={[a.absolute, a.inset_0, t.atoms.bg, {top: -2}]} />
               <ModuleHeader.FeedLink feed={item.feed}>


### PR DESCRIPTION
# Before

<img width="635" height="121" alt="Screenshot 2025-08-29 at 14 30 41" src="https://github.com/user-attachments/assets/8b4d9a00-945b-409a-bda7-0a86fe56cd6f" />

# After

<img width="624" height="144" alt="Screenshot 2025-08-29 at 14 30 29" src="https://github.com/user-attachments/assets/488c4501-0cdb-46c6-8d47-cb38e8c53a79" />
