### PR TITLE
Web: fix Suggested Accounts tabs end of scroll detection

### DIFF
--- a/src/components/InterestTabs.tsx
+++ b/src/components/InterestTabs.tsx
@@ -90,7 +90,7 @@ export function InterestTabs({
   }
 
   const canScrollLeft = scrollX > 0
-  const canScrollRight = scrollX < contentWidth - totalWidth
+  const canScrollRight = Math.ceil(scrollX) < contentWidth - totalWidth
 
   const cleanupRef = useRef<(() => void) | null>(null)
 


### PR DESCRIPTION
# Why

Spotted that on web "Suggested Accounts" tabs always display right scroll button, even when end of list has been reached.

https://github.com/user-attachments/assets/41e6e2f2-204f-4b42-a55f-c6647e24bdc5

# How

After debugging, it looks like `scrollX` was set to sub-pixel (float) value which made the check never fulfilled.

I have added the scroll value ceiling to circumvent that, which lead to existing logic properly hiding the right scroll button when the end of list has been reached.

# Preview

https://github.com/user-attachments/assets/21b74837-3929-441a-899a-56b9b09140df


