### PR TITLE
Reduce checkmark size in thread anchor

### DIFF
--- a/src/components/verification/VerificationCheckButton.tsx
+++ b/src/components/verification/VerificationCheckButton.tsx
@@ -85,7 +85,7 @@ export function Badge({
   if (size === 'lg') {
     dimensions = gtPhone ? 20 : 18
   } else if (size === 'md') {
-    dimensions = 16
+    dimensions = 14
   }
 
   const verifiedByHidden = !state.profile.showBadge && state.profile.isViewer

--- a/src/screens/PostThread/components/ThreadItemAnchor.tsx
+++ b/src/screens/PostThread/components/ThreadItemAnchor.tsx
@@ -354,7 +354,7 @@ const ThreadItemAnchorInner = memo(function ThreadItemAnchorInner({
                     )}
                   </Text>
 
-                  <View style={[{paddingLeft: 3, top: -1}]}>
+                  <View style={[a.pl_xs]}>
                     <VerificationCheckButton profile={authorShadow} size="md" />
                   </View>
                 </View>


### PR DESCRIPTION
It was looking a little large at 16px. `ProfileCard` has the same font size and uses 14px, so switched it to that. It's the only case that uses `md`

# Before

<img width="386" height="177" alt="Screenshot 2025-08-29 at 23 31 10" src="https://github.com/user-attachments/assets/368763dc-1397-4c1b-9e6e-51b52ce74ce7" />

# After

<img width="384" height="175" alt="Screenshot 2025-08-29 at 23 30 42" src="https://github.com/user-attachments/assets/71374e65-bdbf-4f3a-ab19-440edbfae0e6" />
