### PR TITLE
[Perf] Fix drawer jank issue (maybe)

### DIFF
--- a/src/state/shell/drawer-open.tsx
+++ b/src/state/shell/drawer-open.tsx
@@ -1,15 +1,15 @@
-import React from 'react'
+import {createContext, useContext, useState} from 'react'
 
 type StateContext = boolean
 type SetContext = (v: boolean) => void
 
-const stateContext = React.createContext<StateContext>(false)
+const stateContext = createContext<StateContext>(false)
 stateContext.displayName = 'DrawerOpenStateContext'
-const setContext = React.createContext<SetContext>((_: boolean) => {})
+const setContext = createContext<SetContext>((_: boolean) => {})
 setContext.displayName = 'DrawerOpenSetContext'
 
 export function Provider({children}: React.PropsWithChildren<{}>) {
-  const [state, setState] = React.useState(false)
+  const [state, setState] = useState(false)
 
   return (
     <stateContext.Provider value={state}>
@@ -19,9 +19,9 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
 }
 
 export function useIsDrawerOpen() {
-  return React.useContext(stateContext)
+  return useContext(stateContext)
 }
 
 export function useSetDrawerOpen() {
-  return React.useContext(setContext)
+  return useContext(setContext)
 }

--- a/src/view/com/home/HomeHeader.tsx
+++ b/src/view/com/home/HomeHeader.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import {useNavigation} from '@react-navigation/native'
 
-import {NavigationProp} from '#/lib/routes/types'
-import {FeedSourceInfo} from '#/state/queries/feed'
+import {type NavigationProp} from '#/lib/routes/types'
+import {type FeedSourceInfo} from '#/state/queries/feed'
 import {useSession} from '#/state/session'
-import {RenderTabBarFnProps} from '#/view/com/pager/Pager'
+import {type RenderTabBarFnProps} from '#/view/com/pager/Pager'
 import {TabBar} from '../pager/TabBar'
 import {HomeHeaderLayout} from './HomeHeaderLayout'
 
@@ -15,7 +15,7 @@ export function HomeHeader(
     feeds: FeedSourceInfo[]
   },
 ) {
-  const {feeds} = props
+  const {feeds, onSelect: onSelectProp} = props
   const {hasSession} = useSession()
   const navigation = useNavigation<NavigationProp>()
 
@@ -43,11 +43,11 @@ export function HomeHeader(
     (index: number) => {
       if (!hasPinnedCustom && index === items.length - 1) {
         onPressFeedsLink()
-      } else if (props.onSelect) {
-        props.onSelect(index)
+      } else if (onSelectProp) {
+        onSelectProp(index)
       }
     },
-    [items.length, onPressFeedsLink, props, hasPinnedCustom],
+    [items.length, onPressFeedsLink, onSelectProp, hasPinnedCustom],
   )
 
   return (

--- a/src/view/shell/index.tsx
+++ b/src/view/shell/index.tsx
@@ -45,25 +45,10 @@ import {Composer} from './Composer'
 import {DrawerContent} from './Drawer'
 
 function ShellInner() {
-  const t = useTheme()
-  const isDrawerOpen = useIsDrawerOpen()
-  const isDrawerSwipeDisabled = useIsDrawerSwipeDisabled()
-  const setIsDrawerOpen = useSetDrawerOpen()
   const winDim = useWindowDimensions()
   const insets = useSafeAreaInsets()
   const {state: policyUpdateState} = usePolicyUpdateContext()
 
-  const renderDrawerContent = useCallback(() => <DrawerContent />, [])
-  const onOpenDrawer = useCallback(
-    () => setIsDrawerOpen(true),
-    [setIsDrawerOpen],
-  )
-  const onCloseDrawer = useCallback(
-    () => setIsDrawerOpen(false),
-    [setIsDrawerOpen],
-  )
-  const canGoBack = useNavigationState(state => !isStateAtTabRoot(state))
-  const {hasSession} = useSession()
   const closeAnyActiveElement = useCloseAnyActiveElement()
 
   useNotificationsRegistration()
@@ -102,60 +87,14 @@ function ShellInner() {
     }
   }, [dedupe, navigation])
 
-  const swipeEnabled = !canGoBack && hasSession && !isDrawerSwipeDisabled
-  const [trendingScrollGesture] = useState(() => Gesture.Native())
   return (
     <>
       <View style={[a.h_full]}>
         <ErrorBoundary
           style={{paddingTop: insets.top, paddingBottom: insets.bottom}}>
-          <Drawer
-            renderDrawerContent={renderDrawerContent}
-            drawerStyle={{width: Math.min(400, winDim.width * 0.8)}}
-            configureGestureHandler={handler => {
-              handler = handler.requireExternalGestureToFail(
-                trendingScrollGesture,
-              )
-
-              if (swipeEnabled) {
-                if (isDrawerOpen) {
-                  return handler.activeOffsetX([-1, 1])
-                } else {
-                  return (
-                    handler
-                      // Any movement to the left is a pager swipe
-                      // so fail the drawer gesture immediately.
-                      .failOffsetX(-1)
-                      // Don't rush declaring that a movement to the right
-                      // is a drawer swipe. It could be a vertical scroll.
-                      .activeOffsetX(5)
-                  )
-                }
-              } else {
-                // Fail the gesture immediately.
-                // This seems more reliable than the `swipeEnabled` prop.
-                // With `swipeEnabled` alone, the gesture may freeze after toggling off/on.
-                return handler.failOffsetX([0, 0]).failOffsetY([0, 0])
-              }
-            }}
-            open={isDrawerOpen}
-            onOpen={onOpenDrawer}
-            onClose={onCloseDrawer}
-            swipeEdgeWidth={winDim.width}
-            swipeMinVelocity={100}
-            swipeMinDistance={10}
-            drawerType={isIOS ? 'slide' : 'front'}
-            overlayStyle={{
-              backgroundColor: select(t.name, {
-                light: 'rgba(0, 57, 117, 0.1)',
-                dark: isAndroid
-                  ? 'rgba(16, 133, 254, 0.1)'
-                  : 'rgba(1, 82, 168, 0.1)',
-                dim: 'rgba(10, 13, 16, 0.8)',
-              }),
-            }}>
+          <DrawerLayout>
             <TabsNavigator />
-          </Drawer>
+          </DrawerLayout>
         </ErrorBoundary>
       </View>
 
@@ -179,6 +118,76 @@ function ShellInner() {
 
       <PolicyUpdateOverlayPortalOutlet />
     </>
+  )
+}
+
+function DrawerLayout({children}: {children: React.ReactNode}) {
+  const t = useTheme()
+  const isDrawerOpen = useIsDrawerOpen()
+  const setIsDrawerOpen = useSetDrawerOpen()
+  const isDrawerSwipeDisabled = useIsDrawerSwipeDisabled()
+  const winDim = useWindowDimensions()
+
+  const canGoBack = useNavigationState(state => !isStateAtTabRoot(state))
+  const {hasSession} = useSession()
+
+  const swipeEnabled = !canGoBack && hasSession && !isDrawerSwipeDisabled
+  const [trendingScrollGesture] = useState(() => Gesture.Native())
+
+  const renderDrawerContent = useCallback(() => <DrawerContent />, [])
+  const onOpenDrawer = useCallback(
+    () => setIsDrawerOpen(true),
+    [setIsDrawerOpen],
+  )
+  const onCloseDrawer = useCallback(
+    () => setIsDrawerOpen(false),
+    [setIsDrawerOpen],
+  )
+
+  return (
+    <Drawer
+      renderDrawerContent={renderDrawerContent}
+      drawerStyle={{width: Math.min(400, winDim.width * 0.8)}}
+      configureGestureHandler={handler => {
+        handler = handler.requireExternalGestureToFail(trendingScrollGesture)
+
+        if (swipeEnabled) {
+          if (isDrawerOpen) {
+            return handler.activeOffsetX([-1, 1])
+          } else {
+            return (
+              handler
+                // Any movement to the left is a pager swipe
+                // so fail the drawer gesture immediately.
+                .failOffsetX(-1)
+                // Don't rush declaring that a movement to the right
+                // is a drawer swipe. It could be a vertical scroll.
+                .activeOffsetX(5)
+            )
+          }
+        } else {
+          // Fail the gesture immediately.
+          // This seems more reliable than the `swipeEnabled` prop.
+          // With `swipeEnabled` alone, the gesture may freeze after toggling off/on.
+          return handler.failOffsetX([0, 0]).failOffsetY([0, 0])
+        }
+      }}
+      open={isDrawerOpen}
+      onOpen={onOpenDrawer}
+      onClose={onCloseDrawer}
+      swipeEdgeWidth={winDim.width}
+      swipeMinVelocity={100}
+      swipeMinDistance={10}
+      drawerType={isIOS ? 'slide' : 'front'}
+      overlayStyle={{
+        backgroundColor: select(t.name, {
+          light: 'rgba(0, 57, 117, 0.1)',
+          dark: isAndroid ? 'rgba(16, 133, 254, 0.1)' : 'rgba(1, 82, 168, 0.1)',
+          dim: 'rgba(10, 13, 16, 0.8)',
+        }),
+      }}>
+      {children}
+    </Drawer>
   )
 }
 


### PR DESCRIPTION
The cause of the drawer jank is due to our use of the drawer gesture, as we use it to set `requireExternalGestureToFail` on the main home screen pager.

Unfortunately, the drawer gesture is in a `useMemo` that depends on the open/close state of the drawer, so currently it causes a rerender of the `GestureDetector` around the pager view, which then rerenders the pager and all of it's contents.

See the flamegraph here, each time the drawer opens/closes there's a 25ms commit which leads to jank

<img width="733" height="526" alt="Screenshot 2025-09-01 at 21 14 50" src="https://github.com/user-attachments/assets/af765ad6-0cd3-4244-843f-6a5bcfd33823" />

One fix is to keep the gesture we pass to the gesture detector the same, and add the drawer gesture to it using an effect.

```tsx
function DrawerGestureRequireFail({children}: {children: React.ReactNode}) {
  const drawerGesture = useContext(DrawerGestureContext)

  const nativeGesture = useMemo(() => Gesture.Native(), [])

  useEffect(() => {
    if (drawerGesture) {
      nativeGesture.requireExternalGestureToFail(drawerGesture)
    }
  }, [drawerGesture, nativeGesture])

  return <GestureDetector gesture={nativeGesture}>{children}</GestureDetector>
}
```

Here's the flamegraph after:

<img width="891" height="481" alt="Screenshot 2025-09-01 at 21 14 15" src="https://github.com/user-attachments/assets/efd398ab-3233-4a01-8c06-2f03a3230227" />

I don't love this fix though. Seems suspicious to me to be endlessly adding gestures to the other one without cleaning them up - is this allowed?

PR also includes some other cleanups to try and reduce the size of renders slightly

# Test plan

Confirm perf improvement
Confirm the drawer gesture synchronisation still works
Vibe check the fix