### PR TITLE
[Perf] Better fix for drawer jitter (maybe)

### DIFF
--- a/patches/react-native-drawer-layout+4.1.10.patch
+++ b/patches/react-native-drawer-layout+4.1.10.patch
@@ -1,0 +1,12 @@
+diff --git a/node_modules/react-native-drawer-layout/lib/module/views/Drawer.native.js b/node_modules/react-native-drawer-layout/lib/module/views/Drawer.native.js
+index efa71f9..24dbb68 100644
+--- a/node_modules/react-native-drawer-layout/lib/module/views/Drawer.native.js
++++ b/node_modules/react-native-drawer-layout/lib/module/views/Drawer.native.js
+@@ -171,6 +171,7 @@ export function Drawer({
+     }).onEnd((event, success) => {
+       'worklet';
+ 
++      translationX.value = startX.value + event.translationX;
+       gestureState.value = event.state;
+       if (!success) {
+         runOnJS(onGestureAbort)();


### PR DESCRIPTION
Better fix for #8947 

I found a better fix for the jitter issue! While #8947 improves things by reducing the amount of work the device is doing and thus hiding the problem better, the real issue is that the final translation value from the gesture isn't being used, and thus it jumps back slightly to an old position when the animation ends. A one-line patch seems to fix it(?)

Both PRs together would probably be the best fix - there is still a big rerender problem

# Before

https://github.com/user-attachments/assets/650b9c52-9e8b-44bf-90f6-59584e31f829

# After

https://github.com/user-attachments/assets/03a08090-9658-498e-8bb2-f0f902eedd68

# Test plan

Confirm jitter is gone