### PR TITLE
[Perf] Drawer jitter fix (final) (final)

### DIFF
--- a/patches/react-native-drawer-layout+4.1.10.patch
+++ b/patches/react-native-drawer-layout+4.1.10.patch
@@ -1,0 +1,38 @@
+diff --git a/node_modules/react-native-drawer-layout/lib/module/views/Drawer.native.js b/node_modules/react-native-drawer-layout/lib/module/views/Drawer.native.js
+index efa71f9..a23c624 100644
+--- a/node_modules/react-native-drawer-layout/lib/module/views/Drawer.native.js
++++ b/node_modules/react-native-drawer-layout/lib/module/views/Drawer.native.js
+@@ -124,15 +124,21 @@ export function Drawer({
+     }
+     onTransitionEnd?.(!open);
+   });
++  const animatingTo = useSharedValue(null)
+   const toggleDrawer = React.useCallback((open, velocity) => {
+     'worklet';
+ 
++    if (animatingTo.value === (open ? 'open' : 'close')) {
++      return;
++    }
++
+     const translateX = getDrawerTranslationX(open);
+     if (velocity === undefined) {
+       runOnJS(onAnimationStart)(open);
+     }
+     touchStartX.value = 0;
+     touchX.value = 0;
++    animatingTo.value = open ? 'open' : 'close';
+     translationX.value = withSpring(translateX, {
+       velocity,
+       stiffness: 1000,
+@@ -142,7 +148,10 @@ export function Drawer({
+       restDisplacementThreshold: 0.01,
+       restSpeedThreshold: 0.01,
+       reduceMotion: ReduceMotion.Never
+-    }, finished => runOnJS(onAnimationEnd)(open, finished));
++    }, finished => {
++      animatingTo.value = null;
++      runOnJS(onAnimationEnd)(open, finished)
++    });
+     if (open) {
+       runOnJS(onOpen)();
+     } else {


### PR DESCRIPTION
Supercedes #8947 and #8949 

Ok this time I think I have it 🙃

Turns out the _true_ cause was `toggleDrawer()` (which starts the animation) fires twice - first when the gesture ends, and then a second time in an effect when `open` changes.

Luckily, this is already fixed upstream! https://github.com/react-navigation/react-navigation/blob/main/packages/react-native-drawer-layout/src/views/Drawer.native.tsx#L241C7-L243C8

It's not yet released though, so here's a patch of just the relevant changes