### PR TITLE
Update bad token error message

### DIFF
--- a/src/lib/hooks/useCleanError.ts
+++ b/src/lib/hooks/useCleanError.ts
@@ -42,7 +42,7 @@ export function useCleanError() {
         }
       }
 
-      if (raw.includes('Bad token scope')) {
+      if (raw.includes('Bad token scope') || raw.includes('Bad token method')) {
         return {
           raw,
           clean: _(

--- a/src/lib/strings/errors.ts
+++ b/src/lib/strings/errors.ts
@@ -17,7 +17,7 @@ export function cleanError(str: any): string {
   ) {
     return t`The server appears to be experiencing issues. Please try again in a few moments.`
   }
-  if (str.includes('Bad token scope')) {
+  if (str.includes('Bad token scope') || str.includes('Bad token method')) {
     return t`This feature is not available while using an App Password. Please sign in with your main password.`
   }
   if (str.startsWith('Error: ')) {


### PR DESCRIPTION
At some point it seems like the error you got from the DM service when you tried to view DMs with an App Password changed from `Bad token scope` to `Bad token method`

<img width="602" height="408" alt="Screenshot 2025-09-02 at 15 35 03" src="https://github.com/user-attachments/assets/6914a18a-c28d-4213-a118-6ebd0d40b4a9" />

This PR updates `cleanError` accordingly