### PR TITLE
[APP-1327] Remove pinned post from replies tab on profiles

### DIFF
--- a/src/lib/api/feed/author.ts
+++ b/src/lib/api/feed/author.ts
@@ -1,10 +1,10 @@
 import {
   AppBskyFeedDefs,
-  AppBskyFeedGetAuthorFeed as GetAuthorFeed,
-  BskyAgent,
+  type AppBskyFeedGetAuthorFeed as GetAuthorFeed,
+  type BskyAgent,
 } from '@atproto/api'
 
-import {FeedAPI, FeedAPIResponse} from './types'
+import {type FeedAPI, type FeedAPIResponse} from './types'
 
 export class AuthorFeedAPI implements FeedAPI {
   agent: BskyAgent
@@ -23,9 +23,7 @@ export class AuthorFeedAPI implements FeedAPI {
 
   get params() {
     const params = {...this._params}
-    params.includePins =
-      params.filter === 'posts_with_replies' ||
-      params.filter === 'posts_and_author_threads'
+    params.includePins = params.filter === 'posts_and_author_threads'
     return params
   }
 


### PR DESCRIPTION
Summary
---
Removes the pinned posts from the "Replies" tab on a user profile page.

Previously, pins were included for both 'posts_with_replies' and 'posts_and_author_threads' filters. This change restricts pin inclusion to only the 'posts_and_author_threads' filter.

Screenshots
---

<img width="350" height="715" alt="image" src="https://github.com/user-attachments/assets/9daa9845-ce0f-443d-8356-e581475e75f0" />

<img width="350" height="752" alt="image" src="https://github.com/user-attachments/assets/6df4ba69-0476-4f25-9be8-c530d9364d96" />