### PR TITLE
Use Automatic representation for all image pickers

### DIFF
--- a/src/lib/media/picker.shared.ts
+++ b/src/lib/media/picker.shared.ts
@@ -23,6 +23,8 @@ export async function openPicker(opts?: ImagePickerOptions) {
     selectionLimit: 1,
     ...opts,
     legacy: true,
+    preferredAssetRepresentationMode:
+      UIImagePickerPreferredAssetRepresentationMode.Automatic,
   })
 
   return (response.assets ?? [])
@@ -54,7 +56,7 @@ export async function openUnifiedPicker({
     base64: isWeb,
     selectionLimit: isIOS ? selectionCountRemaining : undefined,
     preferredAssetRepresentationMode:
-      UIImagePickerPreferredAssetRepresentationMode.Current,
+      UIImagePickerPreferredAssetRepresentationMode.Automatic,
     videoMaxDuration: VIDEO_MAX_DURATION_MS / 1000,
   })
 }

--- a/src/screens/Onboarding/StepProfile/index.tsx
+++ b/src/screens/Onboarding/StepProfile/index.tsx
@@ -4,7 +4,7 @@ import {Image as ExpoImage} from 'expo-image'
 import {
   type ImagePickerOptions,
   launchImageLibraryAsync,
-  MediaTypeOptions,
+  UIImagePickerPreferredAssetRepresentationMode,
 } from 'expo-image-picker'
 import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
@@ -97,10 +97,12 @@ export function StepProfile() {
       const response = await sheetWrapper(
         launchImageLibraryAsync({
           exif: false,
-          mediaTypes: MediaTypeOptions.Images,
+          mediaTypes: ['images'],
           quality: 1,
           ...opts,
           legacy: true,
+          preferredAssetRepresentationMode:
+            UIImagePickerPreferredAssetRepresentationMode.Automatic,
         }),
       )
 


### PR DESCRIPTION
This fixes a regression caused by our [picker library upgrade](https://github.com/expo/expo/blob/main/packages/expo-image-picker/CHANGELOG.md#-breaking-changes-1). Although `Current` seems to work for most use cases, our handling of images is inconsistent. `Automatic` (the old default) is the safer route. It also fixes the regression we noticed where `.heif` images were no longer supported.

The only difference between this and what's in production is that `Automatic` applies to picked videos as well. I don't anticipate that causing issues, since `Automatic` "[chooses the appropriate asset representation](https://developer.apple.com/documentation/photokit/phpickerconfigurationassetrepresentationmode/automatic)", and the later compression step will convert further if needed.