### PR TITLE
Tweak spacing in composer bar

### DIFF
--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -1442,7 +1442,7 @@ function ComposerFooter({
           <Button
             label={_(msg`Add new post`)}
             onPress={onAddPost}
-            style={[a.p_sm, a.m_2xs]}
+            style={[a.p_sm]}
             variant="ghost"
             shape="round"
             color="primary">

--- a/src/view/com/composer/select-language/SelectPostLanguagesDialog.tsx
+++ b/src/view/com/composer/select-language/SelectPostLanguagesDialog.tsx
@@ -56,7 +56,7 @@ export function SelectPostLanguagesBtn() {
           }),
         )}
         accessibilityHint={_(msg`Opens post language settings`)}
-        style={[a.mx_md]}>
+        style={[a.mr_xs]}>
         {({pressed, hovered, focused}) => {
           const color =
             pressed || hovered || focused


### PR DESCRIPTION
Composer lang select has a bunch of horizontal margin for some reason. It already has padding, so we can cut it down a bit. Includes a bit of right margin for visual alignment

# Before

<img width="406" height="157" alt="Screenshot 2025-09-03 at 16 42 50" src="https://github.com/user-attachments/assets/42e1b972-bf75-4406-a568-f80cea495ffb" />

# After

<img width="409" height="155" alt="Screenshot 2025-09-03 at 16 41 40" src="https://github.com/user-attachments/assets/996d2ad5-42be-4035-abe9-4822af94df74" />
