### PR TITLE
Tweak location-related strings and labels

### DIFF
--- a/src/components/BlockedGeoOverlay.tsx
+++ b/src/components/BlockedGeoOverlay.tsx
@@ -156,7 +156,7 @@ export function BlockedGeoOverlay() {
                     props.disableDialogAction()
                     props.setDialogError(
                       _(
-                        msg`We're sorry, but based on your device's location, you are currently located in a region we cannot provide access at this time.`,
+                        msg`We're sorry, but based on your device's location, you are currently located in a region where we cannot provide access at this time.`,
                       ),
                     )
                   } else {

--- a/src/components/ageAssurance/AgeAssuranceAccountCard.tsx
+++ b/src/components/ageAssurance/AgeAssuranceAccountCard.tsx
@@ -90,7 +90,7 @@ function Inner({style}: ViewStyleProp & {}) {
                       {...createStaticClick(() => {
                         locationControl.open()
                       })}>
-                      Click here to confirm your location.
+                      Tap here to confirm your location.
                     </InlineLinkText>{' '}
                   </Trans>
                 </Text>

--- a/src/components/dialogs/DeviceLocationRequestDialog.tsx
+++ b/src/components/dialogs/DeviceLocationRequestDialog.tsx
@@ -114,7 +114,7 @@ function DeviceLocationRequestDialogInner({onLocationAcquired}: Props) {
       <View style={[a.gap_sm, a.pb_xs]}>
         <Text style={[a.text_md, a.leading_snug, t.atoms.text_contrast_medium]}>
           <Trans>
-            Click below to allow Bluesky to access your GPS location. We will
+            Tap below to allow Bluesky to access your GPS location. We will
             then use that data to more accurately determine the content and
             features available in your region.
           </Trans>
@@ -143,7 +143,7 @@ function DeviceLocationRequestDialogInner({onLocationAcquired}: Props) {
         {!dialogDisabled && (
           <Button
             disabled={isRequesting}
-            label={_(msg`Confirm your location`)}
+            label={_(msg`Allow location access`)}
             onPress={onPressConfirm}
             size={isWeb ? 'small' : 'large'}
             color="primary">
@@ -156,7 +156,7 @@ function DeviceLocationRequestDialogInner({onLocationAcquired}: Props) {
 
         {!isWeb && (
           <Button
-            label={_(msg`Confirm your location`)}
+            label={_(msg`Cancel`)}
             onPress={() => close()}
             size={isWeb ? 'small' : 'large'}
             color="secondary">

--- a/src/components/dialogs/DeviceLocationRequestDialog.tsx
+++ b/src/components/dialogs/DeviceLocationRequestDialog.tsx
@@ -114,9 +114,9 @@ function DeviceLocationRequestDialogInner({onLocationAcquired}: Props) {
       <View style={[a.gap_sm, a.pb_xs]}>
         <Text style={[a.text_md, a.leading_snug, t.atoms.text_contrast_medium]}>
           <Trans>
-            Tap below to allow Bluesky to access your GPS location. We will
-            then use that data to more accurately determine the content and
-            features available in your region.
+            Tap below to allow Bluesky to access your GPS location. We will then
+            use that data to more accurately determine the content and features
+            available in your region.
           </Trans>
         </Text>
 


### PR DESCRIPTION
As a follow-up to 8973, this PR proposes a few small tweaks to the strings and labels added in that PR:
- Add `where` to the string in `src/components/BlockedGeoOverlay.tsx` to enhance clarity and readability
- Given that providing GPS location is only an option on mobile, change `Click` to `Tap` in strings in `src/components/ageAssurance/AgeAssuranceAccountCard.tsx` and `src/components/dialogs/DeviceLocationRequestDialog.tsx`
- Fix two accessibility labels in `src/components/dialogs/DeviceLocationRequestDialog.tsx`