### PR TITLE
Ensure headers are set when sending reports (i.e. DMs)

### DIFF
--- a/src/components/ageAssurance/AgeAssuranceAppealDialog.tsx
+++ b/src/components/ageAssurance/AgeAssuranceAppealDialog.tsx
@@ -1,10 +1,11 @@
 import React from 'react'
 import {View} from 'react-native'
-import {BSKY_LABELER_DID, ComAtprotoModerationDefs} from '@atproto/api'
+import {ComAtprotoModerationDefs} from '@atproto/api'
 import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 import {useMutation} from '@tanstack/react-query'
 
+import {BLUESKY_MOD_SERVICE_HEADERS} from '#/lib/constants'
 import {logger} from '#/state/ageAssurance/util'
 import {useAgent, useSession} from '#/state/session'
 import * as Toast from '#/view/com/util/Toast'
@@ -58,9 +59,7 @@ function Inner({control}: {control: Dialog.DialogControlProps}) {
         },
         {
           encoding: 'application/json',
-          headers: {
-            'atproto-proxy': `${BSKY_LABELER_DID}#atproto_labeler`,
-          },
+          headers: BLUESKY_MOD_SERVICE_HEADERS,
         },
       )
     },

--- a/src/components/dms/ReportDialog.tsx
+++ b/src/components/dms/ReportDialog.tsx
@@ -1,19 +1,21 @@
-import React, {memo, useMemo, useState} from 'react'
+import {memo, useMemo, useState} from 'react'
 import {View} from 'react-native'
 import {
-  $Typed,
-  AppBskyActorDefs,
-  ChatBskyConvoDefs,
-  ComAtprotoModerationCreateReport,
+  type $Typed,
+  type AppBskyActorDefs,
+  type ChatBskyConvoDefs,
+  type ComAtprotoModerationCreateReport,
   RichText as RichTextAPI,
 } from '@atproto/api'
 import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 import {StackActions, useNavigation} from '@react-navigation/native'
 import {useMutation} from '@tanstack/react-query'
+import type React from 'react'
 
-import {ReportOption} from '#/lib/moderation/useReportOptions'
-import {NavigationProp} from '#/lib/routes/types'
+import {BLUESKY_MOD_SERVICE_HEADERS} from '#/lib/constants'
+import {type ReportOption} from '#/lib/moderation/useReportOptions'
+import {type NavigationProp} from '#/lib/routes/types'
 import {isNative} from '#/platform/detection'
 import {useProfileShadow} from '#/state/cache/profile-shadow'
 import {useLeaveConvo} from '#/state/queries/messages/leave-conversation'
@@ -168,7 +170,10 @@ function SubmitStep({
           reason: details,
         } satisfies ComAtprotoModerationCreateReport.InputSchema
 
-        await agent.createModerationReport(report)
+        await agent.createModerationReport(report, {
+          encoding: 'application/json',
+          headers: BLUESKY_MOD_SERVICE_HEADERS,
+        })
       }
     },
     onSuccess: onComplete,

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,5 +1,5 @@
 import {type Insets, Platform} from 'react-native'
-import {type AppBskyActorDefs} from '@atproto/api'
+import {type AppBskyActorDefs, BSKY_LABELER_DID} from '@atproto/api'
 
 import {type ProxyHeaderValue} from '#/state/session/agent'
 import {BLUESKY_PROXY_DID, CHAT_PROXY_DID} from '#/env'
@@ -225,6 +225,10 @@ export const BLUESKY_SERVICE_HEADERS = {
 
 export const DM_SERVICE_HEADERS = {
   'atproto-proxy': `${CHAT_PROXY_DID}#bsky_chat`,
+}
+
+export const BLUESKY_MOD_SERVICE_HEADERS = {
+  'atproto-proxy': `${BSKY_LABELER_DID}#atproto_labeler`,
 }
 
 export const webLinks = {

--- a/src/screens/Messages/components/ChatDisabled.tsx
+++ b/src/screens/Messages/components/ChatDisabled.tsx
@@ -5,6 +5,7 @@ import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 import {useMutation} from '@tanstack/react-query'
 
+import {BLUESKY_MOD_SERVICE_HEADERS} from '#/lib/constants'
 import {logger} from '#/logger'
 import {useAgent, useSession} from '#/state/session'
 import * as Toast from '#/view/com/util/Toast'
@@ -73,14 +74,20 @@ function DialogInner() {
     mutationFn: async () => {
       if (!currentAccount)
         throw new Error('No current account, should be unreachable')
-      await agent.createModerationReport({
-        reasonType: ComAtprotoModerationDefs.REASONAPPEAL,
-        subject: {
-          $type: 'com.atproto.admin.defs#repoRef',
-          did: currentAccount.did,
+      await agent.createModerationReport(
+        {
+          reasonType: ComAtprotoModerationDefs.REASONAPPEAL,
+          subject: {
+            $type: 'com.atproto.admin.defs#repoRef',
+            did: currentAccount.did,
+          },
+          reason: details,
         },
-        reason: details,
-      })
+        {
+          encoding: 'application/json',
+          headers: BLUESKY_MOD_SERVICE_HEADERS,
+        },
+      )
     },
     onError: err => {
       logger.error('Failed to submit chat appeal', {message: err})


### PR DESCRIPTION
We were missing the proxy header, which then broke when we started setting it explicitly

# Test plan

Report a chat message