### PR TITLE
Fix check for whether string is only emoji using more accurate unicode groups.

### DIFF
--- a/src/alf/typography.tsx
+++ b/src/alf/typography.tsx
@@ -122,7 +122,11 @@ export function renderChildrenWithEmoji(
   })
 }
 
-const SINGLE_EMOJI_RE = /^[\p{Emoji_Presentation}\p{Extended_Pictographic}]+$/u
+const CONTAINS_EMOJI_RE = /[\p{Extended_Pictographic}]/u
+const ALL_EMOJI_OR_COMPONENT_RE = /^[\p{Emoji}\p{Emoji_Component}]+$/u
 export function isOnlyEmoji(text: string) {
-  return text.length <= 15 && SINGLE_EMOJI_RE.test(text)
+  if (text.length > 15) {
+    return false
+  }
+  return ALL_EMOJI_OR_COMPONENT_RE.test(text) && CONTAINS_EMOJI_RE.test(text)
 }


### PR DESCRIPTION
This breaks up the original check into two separate regexes, but the original failed on like 90% of the emoji I tried. The culprit, nine times out of ten, was either a variation selector 16 or a zwj, which (as it turns out) are used a lot!!! This should account for that. Anyway I'm not getting paid nor do I enjoy writing typescript, I'm just chronically online, so please accept my PR.
(also, thanks to xan.lol for bringing this onto my feed, I love a good nerd sniping)