### PR TITLE
Pass feed context to video feed post controls

### DIFF
--- a/src/screens/VideoFeed/index.tsx
+++ b/src/screens/VideoFeed/index.tsx
@@ -869,6 +869,7 @@ function Overlay({
                     richText={richText}
                     post={post}
                     record={record}
+                    feedContext={feedContext}
                     logContext="FeedItem"
                     onPressReply={() =>
                       navigation.navigate('PostThread', {


### PR DESCRIPTION
This should fix the bug described here:

https://bsky.app/profile/spacecowboy17.bsky.social/post/3lybruty2rk2e

<img width="600" height="234" alt="Screenshot 2025-09-07 at 8 22 58 PM" src="https://github.com/user-attachments/assets/e4e6cfeb-4408-4571-ae2a-1595cf0bcf71" />

Note, I don't have the mobile build working, so I haven't been able to test this change myself.