### PR TITLE
Clean up language before suggesting it in composer

### DIFF
--- a/src/view/com/composer/select-language/SuggestedLanguage.tsx
+++ b/src/view/com/composer/select-language/SuggestedLanguage.tsx
@@ -1,5 +1,6 @@
 import {useEffect, useState} from 'react'
 import {View} from 'react-native'
+import {parseLanguage} from '@atproto/api'
 import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 import lande from 'lande'
@@ -21,11 +22,12 @@ const cancelIdle = globalThis.cancelIdleCallback || clearTimeout
 
 export function SuggestedLanguage({
   text,
-  replyToLanguage,
+  replyToLanguage: replyToLanguageProp,
 }: {
   text: string
   replyToLanguage?: string
 }) {
+  const replyToLanguage = cleanUpLanguage(replyToLanguageProp)
   const [suggestedLanguage, setSuggestedLanguage] = useState<
     string | undefined
   >(text.length === 0 ? replyToLanguage : undefined)
@@ -124,4 +126,12 @@ function guessLanguage(text: string): string | undefined {
     return undefined
   }
   return code3ToCode2Strict(lang)
+}
+
+function cleanUpLanguage(text: string | undefined): string | undefined {
+  if (!text) {
+    return undefined
+  }
+
+  return parseLanguage(text)?.language
 }


### PR DESCRIPTION
Some clients/bots use non-2 letter language codes. We should parse it before doing the suggestion thing

<table>
  <thead>
    <tr>
      <th>Before</th>
      <th>After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><img width="300" src="https://github.com/user-attachments/assets/f2caa6f3-8ad5-4b07-943f-e62d55aa968d" /></td>
      <td><img width="300" src="https://github.com/user-attachments/assets/bbaa61b5-aca4-4d78-b8ed-5c3002d89654" /></td>
    </tr>
  </tbody>
</table>