### PR TITLE
Ensure there is a thumbnail for videos on web

### DIFF
--- a/src/components/Post/Embed/VideoEmbed/VideoEmbedInner/VideoFallback.tsx
+++ b/src/components/Post/Embed/VideoEmbed/VideoEmbedInner/VideoFallback.tsx
@@ -3,7 +3,9 @@ import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
 import {atoms as a, useTheme} from '#/alf'
-import {Button, ButtonText} from '#/components/Button'
+import {Button, ButtonIcon, ButtonText} from '#/components/Button'
+import {ArrowRotateCounterClockwise_Stroke2_Corner0_Rounded as ArrowRotateIcon} from '#/components/icons/ArrowRotateCounterClockwise'
+import {MediaInsetBorder} from '#/components/MediaInsetBorder'
 import {Text as TypoText} from '#/components/Typography'
 
 export function Container({children}: {children: React.ReactNode}) {
@@ -16,12 +18,12 @@ export function Container({children}: {children: React.ReactNode}) {
         a.justify_center,
         a.align_center,
         a.px_lg,
-        a.border,
-        t.atoms.border_contrast_low,
-        a.rounded_sm,
+        a.rounded_md,
+        a.overflow_hidden,
         a.gap_lg,
       ]}>
       {children}
+      <MediaInsetBorder />
     </View>
   )
 }
@@ -50,8 +52,8 @@ export function RetryButton({onPress}: {onPress: () => void}) {
       onPress={onPress}
       size="small"
       color="secondary_inverted"
-      variant="solid"
       label={_(msg`Retry`)}>
+      <ButtonIcon icon={ArrowRotateIcon} />
       <ButtonText>
         <Trans>Retry</Trans>
       </ButtonText>

--- a/src/components/Post/Embed/VideoEmbed/index.web.tsx
+++ b/src/components/Post/Embed/VideoEmbed/index.web.tsx
@@ -86,7 +86,13 @@ export function VideoEmbed({
   const contents = (
     <div
       ref={ref}
-      style={{display: 'flex', flex: 1, cursor: 'default'}}
+      style={{
+        display: 'flex',
+        flex: 1,
+        cursor: 'default',
+        backgroundImage: `url(${embed.thumbnail})`,
+        backgroundSize: 'cover',
+      }}
       onClick={evt => evt.stopPropagation()}>
       <ErrorBoundary renderError={renderError} key={key}>
         <OnlyNearScreen>


### PR DESCRIPTION
This is a "perceived speed" improvement. Because the video element is not loaded until it's within 100vh of the screen, the thumbnail often doesn't have enough time to load before you can see it.

Fix is to always display the thumbnail whether or not the player is mounted. I opted to do this via putting a background image on the containing div, then trust the browser to cache the image when it then loads it for the video `poster` prop when the player mounts

## Before (observe the gray rectangles)

https://github.com/user-attachments/assets/9ac95cec-af96-4893-b013-4f43a443d483

## After

https://github.com/user-attachments/assets/ac689744-7559-49b6-9c76-837f14ecf49a

and for good measure, here's the network calls - each page load fetches every thumbnail, and then you can see the additional request made as you scroll for the `poster` is simply cached

https://github.com/user-attachments/assets/0cd704e1-5463-429b-99ad-b975ff4171ca

## Test plan

Have a scroll on the video feed on web, confirm it feels better