### PR TITLE
Add preventDefault() to thread anchor checkmark

### DIFF
--- a/src/components/verification/VerificationCheckButton.tsx
+++ b/src/components/verification/VerificationCheckButton.tsx
@@ -99,15 +99,15 @@ export function Badge({
             : _(msg`View this user's verifications`)
         }
         hitSlop={20}
-        onPress={() => {
+        onPress={evt => {
+          evt.preventDefault()
           logger.metric('verification:badge:click', {}, {statsig: true})
           if (state.profile.role === 'verifier') {
             verifierDialogControl.open()
           } else {
             verificationsDialogControl.open()
           }
-        }}
-        style={[]}>
+        }}>
         {({hovered}) => (
           <View
             style={[


### PR DESCRIPTION
Another nested link/button issue, this time on the checkmark button in the thread anchor. Currently clicking on it on web reloads the page.

## Test plan

Click on a checkmark and confirm it no longer causes a page reload