### PR TITLE
feat: add feed open graph tags

### DIFF
--- a/bskyweb/templates/feed.html
+++ b/bskyweb/templates/feed.html
@@ -16,28 +16,28 @@
   <meta property="og:url" content="{{ requestURI }}">
   <link rel="canonical" href="{{ requestURI|canonicalize_url }}" />
   {% endif -%}
-  
+
   {%- if feedView.DisplayName %}
   <meta property="og:title" content="{{ feedView.DisplayName }} by @{{ feedView.Creator.Handle }}">
   {% else %}
   <meta property="og:title" content="Feed by @{{ feedView.Creator.Handle }}">
   {% endif -%}
-  
+
   {%- if feedView.Description %}
   <meta name="description" content="{{ feedView.Description }}">
   <meta property="og:description" content="{{ feedView.Description }}">
   <meta property="twitter:description" content="{{ feedView.Description }}">
   {% endif -%}
-  
+
   {%- if feedView.Avatar %}
   <meta property="og:image" content="{{ feedView.Avatar }}">
   <meta property="twitter:image" content="{{ feedView.Avatar }}">
   <meta name="twitter:card" content="summary">
   {% endif %}
-  
+
   <meta name="twitter:label1" content="Created by">
   <meta name="twitter:value1" content="@{{ feedView.Creator.Handle }}">
-  
+
   <link rel="alternate" href="{{ feedView.Uri }}" />
 {% endif -%}
 {%- endblock %}

--- a/bskyweb/templates/feed.html
+++ b/bskyweb/templates/feed.html
@@ -1,0 +1,54 @@
+{% extends "base.html" %}
+
+{% block head_title %}
+{%- if feedView -%}
+  {{ feedView.DisplayName }} by @{{ feedView.Creator.Handle }} | Bluesky Feed
+{%- else -%}
+  Bluesky
+{%- endif -%}
+{% endblock %}
+
+{% block html_head_extra -%}
+{%- if feedView -%}
+  <meta property="og:site_name" content="Bluesky Social">
+  <meta property="og:type" content="website">
+  {%- if requestURI %}
+  <meta property="og:url" content="{{ requestURI }}">
+  <link rel="canonical" href="{{ requestURI|canonicalize_url }}" />
+  {% endif -%}
+  
+  {%- if feedView.DisplayName %}
+  <meta property="og:title" content="{{ feedView.DisplayName }} by @{{ feedView.Creator.Handle }}">
+  {% else %}
+  <meta property="og:title" content="Feed by @{{ feedView.Creator.Handle }}">
+  {% endif -%}
+  
+  {%- if feedView.Description %}
+  <meta name="description" content="{{ feedView.Description }}">
+  <meta property="og:description" content="{{ feedView.Description }}">
+  <meta property="twitter:description" content="{{ feedView.Description }}">
+  {% endif -%}
+  
+  {%- if feedView.Avatar %}
+  <meta property="og:image" content="{{ feedView.Avatar }}">
+  <meta property="twitter:image" content="{{ feedView.Avatar }}">
+  <meta name="twitter:card" content="summary">
+  {% endif %}
+  
+  <meta name="twitter:label1" content="Created by">
+  <meta name="twitter:value1" content="@{{ feedView.Creator.Handle }}">
+  
+  <link rel="alternate" href="{{ feedView.Uri }}" />
+{% endif -%}
+{%- endblock %}
+
+{% block noscript_extra -%}
+{%- if feedView -%}
+<div id="bsky_feed_summary">
+  <h3>Feed</h3>
+  <p id="bsky_feed_name">{{ feedView.DisplayName }}</p>
+  <p id="bsky_feed_creator">{{ feedView.Creator.Handle }}</p>
+  <p id="bsky_feed_description">{{ feedView.Description }}</p>
+</div>
+{% endif -%}
+{%- endblock %}


### PR DESCRIPTION
## Summary

Enables rich link previews when Bluesky feed URLs are shared in messaging platforms like iMessage, Slack, Discord, and social media sites. Feed links now unfurl with proper metadata including feed title, description, creator information, and avatar images.

Added dedicated feed unfurling functionality to the bskyweb Go server by:

1. Modified `/profile/:handleOrDID/feed/:rkey` to use new WebFeed handler instead of generic handler
2. Implemented WebFeed handler that fetches feed generator data via the AT Protocol API
3. Created `feed.html` template with comprehensive OpenGraph and Twitter Card metadata

Open Graph tags that showed up during local testing:
```html
<meta property="og:locale" content="en" />
<meta property="og:url" content="https://localhost:8100/profile/bsky.app/feed/whats-hot" />
<meta property="og:type" content="website" />
<meta property="og:title" content="Discover by @bsky.app" />
<meta property="og:description" content="Trending content from your personal network" />
<meta property="og:image" content="https://cdn.bsky.app/img/avatar/plain/did:plc:z72i7hdynmk6r22z27h6tvur/bafkreidljdg62x3zhlweyzshoekrw2znokytt5tmib7g4xsngwvpnf6ule@jpeg" />
```


## Links

https://linear.app/blueskyweb/issue/APP-1040/feed-open-graph-tags