### PR TITLE
Allow swipe dismissal of the composer on iOS

### DIFF
--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -173,8 +173,10 @@ export const ComposePost = ({
   imageUris: initImageUris,
   videoUri: initVideoUri,
   cancelRef,
+  setIsDirty,
 }: Props & {
   cancelRef?: React.RefObject<CancelRef | null>
+  setIsDirty?: React.Dispatch<React.SetStateAction<boolean>>
 }) => {
   const {currentAccount} = useSession()
   const agent = useAgent()
@@ -342,24 +344,37 @@ export const ComposePost = ({
     [insets, isKeyboardVisible],
   )
 
-  const onPressCancel = useCallback(() => {
-    if (textInput.current?.maybeClosePopup()) {
+  const isDirty = thread.posts.some(
+    post =>
+      post.shortenedGraphemeLength > 0 || post.embed.media || post.embed.link,
+  )
+
+  // very unfortunate, but we need to pass state back up to the parent on iOS
+  //
+  // WARNING - if the Modal on iOS thinks it's not dirty,
+  // `allowSwipeDismissal` will be true, and if we don't then close the composer
+  // when `onPressCancel` is called it will be bad (might even softlock)
+  // so we need to keep the parent state and the behaviour of onPressCancel in
+  // tight sync. do NOT force the modal to stay open without marking it as dirty! -sfn
+  useEffect(() => {
+    if (isIOS) {
+      setIsDirty?.(isDirty)
+    }
+  }, [isDirty, setIsDirty])
+
+  const onPressCancel = useNonReactiveCallback(() => {
+    // web only, so it's fine w.r.t. the Modal
+    const didCloseAutocomplete = textInput.current?.maybeClosePopup()
+    if (isWeb && didCloseAutocomplete) {
       return
-    } else if (
-      thread.posts.some(
-        post =>
-          post.shortenedGraphemeLength > 0 ||
-          post.embed.media ||
-          post.embed.link,
-      )
-    ) {
+    } else if (isDirty) {
       closeAllDialogs()
       Keyboard.dismiss()
       discardPromptControl.open()
     } else {
       onClose()
     }
-  }, [thread, closeAllDialogs, discardPromptControl, onClose])
+  })
 
   useImperativeHandle(cancelRef, () => ({onPressCancel}))
 

--- a/src/view/shell/Composer.ios.tsx
+++ b/src/view/shell/Composer.ios.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import {useEffect, useRef, useState} from 'react'
 import {Modal, View} from 'react-native'
 
 import {useDialogStateControlContext} from '#/state/dialogs'
@@ -11,11 +11,17 @@ export function Composer({}: {winHeight: number}) {
   const t = useTheme()
   const state = useComposerState()
   const ref = useComposerCancelRef()
+  const [isDirty, setIsDirty] = useState(
+    !!state?.text ||
+      !!state?.imageUris ||
+      !!state?.videoUri ||
+      !!state?.mention,
+  )
 
   const open = !!state
-  const prevOpen = React.useRef(open)
+  const prevOpen = useRef(open)
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (open && !prevOpen.current) {
       setFullyExpandedCount(c => c + 1)
     } else if (!open && prevOpen.current) {
@@ -31,7 +37,8 @@ export function Composer({}: {winHeight: number}) {
       visible={open}
       presentationStyle="pageSheet"
       animationType="slide"
-      onRequestClose={() => ref.current?.onPressCancel()}>
+      onRequestClose={() => ref.current?.onPressCancel()}
+      allowSwipeDismissal={!isDirty}>
       <View style={[t.atoms.bg, a.flex_1]}>
         <ComposePost
           cancelRef={ref}
@@ -43,6 +50,7 @@ export function Composer({}: {winHeight: number}) {
           text={state?.text}
           imageUris={state?.imageUris}
           videoUri={state?.videoUri}
+          setIsDirty={setIsDirty}
         />
       </View>
     </Modal>

--- a/src/view/shell/Composer.ios.tsx
+++ b/src/view/shell/Composer.ios.tsx
@@ -1,34 +1,31 @@
-import {useEffect, useRef, useState} from 'react'
+import {useEffect} from 'react'
 import {Modal, View} from 'react-native'
+import {SystemBars} from 'react-native-edge-to-edge'
 
-import {useDialogStateControlContext} from '#/state/dialogs'
 import {useComposerState} from '#/state/shell/composer'
+import {useComposerReducer} from '#/view/com/composer/state/composer'
 import {atoms as a, useTheme} from '#/alf'
 import {ComposePost, useComposerCancelRef} from '../com/composer/Composer'
 
 export function Composer({}: {winHeight: number}) {
-  const {setFullyExpandedCount} = useDialogStateControlContext()
   const t = useTheme()
   const state = useComposerState()
   const ref = useComposerCancelRef()
-  const [isDirty, setIsDirty] = useState(
-    !!state?.text ||
-      !!state?.imageUris ||
-      !!state?.videoUri ||
-      !!state?.mention,
-  )
 
   const open = !!state
-  const prevOpen = useRef(open)
+
+  const [composerState, composerDispatch, isDirty] = useComposerReducer(state)
 
   useEffect(() => {
-    if (open && !prevOpen.current) {
-      setFullyExpandedCount(c => c + 1)
-    } else if (!open && prevOpen.current) {
-      setFullyExpandedCount(c => c - 1)
+    if (open) {
+      const entry = SystemBars.pushStackEntry({
+        style: {statusBar: 'light'},
+      })
+      return () => {
+        SystemBars.popStackEntry(entry)
+      }
     }
-    prevOpen.current = open
-  }, [open, setFullyExpandedCount])
+  }, [open])
 
   return (
     <Modal
@@ -50,7 +47,9 @@ export function Composer({}: {winHeight: number}) {
           text={state?.text}
           imageUris={state?.imageUris}
           videoUri={state?.videoUri}
-          setIsDirty={setIsDirty}
+          composerState={composerState}
+          composerDispatch={composerDispatch}
+          isDirty={isDirty}
         />
       </View>
     </Modal>

--- a/src/view/shell/Composer.tsx
+++ b/src/view/shell/Composer.tsx
@@ -1,18 +1,35 @@
 import {useEffect} from 'react'
 import {Animated, Easing} from 'react-native'
+import {SystemBars} from 'react-native-edge-to-edge'
 
 import {useAnimatedValue} from '#/lib/hooks/useAnimatedValue'
 import {useComposerState} from '#/state/shell/composer'
 import {atoms as a, useTheme} from '#/alf'
 import {ComposePost} from '../com/composer/Composer'
+import {useComposerReducer} from '../com/composer/state/composer'
 
 export function Composer({winHeight}: {winHeight: number}) {
   const state = useComposerState()
   const t = useTheme()
   const initInterp = useAnimatedValue(0)
 
+  const open = !!state
+
+  const [composerState, composerDispatch, isDirty] = useComposerReducer(state)
+
   useEffect(() => {
-    if (state) {
+    if (open) {
+      const entry = SystemBars.pushStackEntry({
+        style: {statusBar: t.scheme === 'light' ? 'dark' : 'light'},
+      })
+      return () => {
+        SystemBars.popStackEntry(entry)
+      }
+    }
+  }, [open, t.scheme])
+
+  useEffect(() => {
+    if (open) {
       Animated.timing(initInterp, {
         toValue: 1,
         duration: 300,
@@ -22,7 +39,7 @@ export function Composer({winHeight}: {winHeight: number}) {
     } else {
       initInterp.setValue(0)
     }
-  }, [initInterp, state])
+  }, [initInterp, open])
   const wrapperAnimStyle = {
     transform: [
       {
@@ -37,7 +54,7 @@ export function Composer({winHeight}: {winHeight: number}) {
   // rendering
   // =
 
-  if (!state) {
+  if (!open) {
     return null
   }
 
@@ -55,6 +72,9 @@ export function Composer({winHeight}: {winHeight: number}) {
         text={state.text}
         imageUris={state.imageUris}
         videoUri={state.videoUri}
+        composerState={composerState}
+        composerDispatch={composerDispatch}
+        isDirty={isDirty}
       />
     </Animated.View>
   )


### PR DESCRIPTION
# Stacked on #8931 

The latest version of React Native comes with a new prop on the built-in Modal - [allowSwipeDismissal](https://reactnative.dev/docs/modal#allowswipedismissal-ios)

This allows much smooth and natural swipe dismiss gesture of the composer. In this PR, I use it for when the composer is empty, i.e. for when we don't show the "discard draft" prompt. if we are going to show the prompt, we disable the prop so the swipe gesture has "resistance" - I think it feels really nice

~~This requires some awkward useEffect usage, but it's pretty limited in scope and fairly obvious what's going on at least.~~

https://github.com/user-attachments/assets/bf885c20-5d01-4854-9d87-a0245f626797

