### PR TITLE
improve(bskyweb): enhance post OpenGraph metadata with engagement data and auth handling

### DIFF
--- a/bskyweb/cmd/bskyweb/server.go
+++ b/bskyweb/cmd/bskyweb/server.go
@@ -492,6 +492,14 @@ func (srv *Server) WebPost(c echo.Context) error {
 
 	if !unauthedViewingOkay {
 		log.Warnf("WebPost: profile %s requires authentication", identifier)
+		// Provide minimal OpenGraph data for auth-required posts
+		req := c.Request()
+		data["requestURI"] = fmt.Sprintf("https://%s%s", req.Host, req.URL.Path)
+		data["requiresAuth"] = true
+		data["profileHandle"] = pv.Handle
+		if pv.DisplayName != nil {
+			data["profileDisplayName"] = *pv.DisplayName
+		}
 		return c.Render(http.StatusOK, "post.html", data)
 	}
 	did := pv.Did

--- a/bskyweb/cmd/bskyweb/server.go
+++ b/bskyweb/cmd/bskyweb/server.go
@@ -465,11 +465,13 @@ func (srv *Server) WebPost(c echo.Context) error {
 	rkeyParam := c.Param("rkey")
 	rkey, err := syntax.ParseRecordKey(rkeyParam)
 	if err != nil {
+		log.Warnf("WebPost: failed to parse rkey %s: %v", rkeyParam, err)
 		return c.Render(http.StatusOK, "post.html", data)
 	}
 	handleOrDIDParam := c.Param("handleOrDID")
 	handleOrDID, err := syntax.ParseAtIdentifier(handleOrDIDParam)
 	if err != nil {
+		log.Warnf("WebPost: failed to parse identifier %s: %v", handleOrDIDParam, err)
 		return c.Render(http.StatusOK, "post.html", data)
 	}
 
@@ -489,6 +491,7 @@ func (srv *Server) WebPost(c echo.Context) error {
 	}
 
 	if !unauthedViewingOkay {
+		log.Warnf("WebPost: profile %s requires authentication", identifier)
 		return c.Render(http.StatusOK, "post.html", data)
 	}
 	did := pv.Did

--- a/bskyweb/cmd/bskyweb/server.go
+++ b/bskyweb/cmd/bskyweb/server.go
@@ -465,13 +465,11 @@ func (srv *Server) WebPost(c echo.Context) error {
 	rkeyParam := c.Param("rkey")
 	rkey, err := syntax.ParseRecordKey(rkeyParam)
 	if err != nil {
-		log.Warnf("WebPost: failed to parse rkey %s: %v", rkeyParam, err)
 		return c.Render(http.StatusOK, "post.html", data)
 	}
 	handleOrDIDParam := c.Param("handleOrDID")
 	handleOrDID, err := syntax.ParseAtIdentifier(handleOrDIDParam)
 	if err != nil {
-		log.Warnf("WebPost: failed to parse identifier %s: %v", handleOrDIDParam, err)
 		return c.Render(http.StatusOK, "post.html", data)
 	}
 
@@ -491,7 +489,6 @@ func (srv *Server) WebPost(c echo.Context) error {
 	}
 
 	if !unauthedViewingOkay {
-		log.Warnf("WebPost: profile %s requires authentication", identifier)
 		// Provide minimal OpenGraph data for auth-required posts
 		req := c.Request()
 		data["requestURI"] = fmt.Sprintf("https://%s%s", req.Host, req.URL.Path)

--- a/bskyweb/templates/post.html
+++ b/bskyweb/templates/post.html
@@ -11,7 +11,7 @@
 {% block html_head_extra -%}
 {%- if postView -%}
   <meta property="og:type" content="article">
-  <meta property="profile:username" content="{{ profileView.Handle }}">
+  <meta property="profile:username" content="{{ postView.Author.Handle }}">
   {%- if requestURI %}
   <meta property="og:url" content="{{ requestURI }}">
   <link rel="canonical" href="{{ requestURI|canonicalize_url }}" />

--- a/bskyweb/templates/post.html
+++ b/bskyweb/templates/post.html
@@ -3,6 +3,8 @@
 {% block head_title %}
 {%- if postView -%}
   @{{ postView.Author.Handle }} on Bluesky
+{%- elif requiresAuth and profileHandle -%}
+  @{{ profileHandle }} on Bluesky
 {%- else -%}
   Bluesky
 {%- endif -%}
@@ -43,6 +45,22 @@
   <meta name="article:published_time" content="{{ postView.IndexedAt }}">
   <link rel="alternate" type="application/json+oembed" href="https://embed.bsky.app/oembed?format=json&url={{ postView.Uri | urlencode }}" />
   <link rel="alternate" href="{{ postView.Uri }}" />
+{%- elif requiresAuth and profileHandle -%}
+  <meta property="og:type" content="article">
+  <meta property="profile:username" content="{{ profileHandle }}">
+  {%- if requestURI %}
+  <meta property="og:url" content="{{ requestURI }}">
+  <link rel="canonical" href="{{ requestURI|canonicalize_url }}" />
+  {% endif -%}
+  {%- if profileDisplayName %}
+  <meta property="og:title" content="{{ profileDisplayName }} (@{{ profileHandle }})">
+  {% else %}
+  <meta property="og:title" content="@{{ profileHandle }}">
+  {% endif -%}
+  <meta name="description" content="This post requires authentication to view.">
+  <meta property="og:description" content="This post requires authentication to view.">
+  <meta property="twitter:description" content="This post requires authentication to view.">
+  <meta name="twitter:card" content="summary">
 {% endif -%}
 {%- endblock %}
 
@@ -55,6 +73,12 @@
   <p id="bsky_did">{{ postView.Author.Did }}</p>
   <p id="bsky_post_text">{{ postText }}</p>
   <p id="bsky_post_indexedat">{{ postView.IndexedAt }}</p>
+</div>
+{%- elif requiresAuth and profileHandle -%}
+<div id="bsky_post_summary">
+  <h3>Post</h3>
+  <p id="bsky_handle">{{ profileHandle }}</p>
+  <p id="bsky_post_text">This post requires authentication to view.</p>
 </div>
 {% endif -%}
 {%- endblock %}

--- a/bskyweb/templates/post.html
+++ b/bskyweb/templates/post.html
@@ -12,6 +12,7 @@
 
 {% block html_head_extra -%}
 {%- if postView -%}
+  <meta property="og:site_name" content="Bluesky Social">
   <meta property="og:type" content="article">
   <meta property="profile:username" content="{{ postView.Author.Handle }}">
   {%- if requestURI %}
@@ -41,11 +42,11 @@
   {% endif %}
   <meta name="twitter:label1" content="Posted At">
   <meta name="twitter:value1" content="{{ postView.IndexedAt }}">
-  <meta name="article:published_time" content="{{ postView.IndexedAt }}">
-  <meta name="article:published_time" content="{{ postView.IndexedAt }}">
+  <meta property="article:published_time" content="{{ postView.IndexedAt }}">
   <link rel="alternate" type="application/json+oembed" href="https://embed.bsky.app/oembed?format=json&url={{ postView.Uri | urlencode }}" />
   <link rel="alternate" href="{{ postView.Uri }}" />
 {%- elif requiresAuth and profileHandle -%}
+  <meta property="og:site_name" content="Bluesky Social">
   <meta property="og:type" content="article">
   <meta property="profile:username" content="{{ profileHandle }}">
   {%- if requestURI %}

--- a/bskyweb/templates/post.html
+++ b/bskyweb/templates/post.html
@@ -42,6 +42,18 @@
   {% endif %}
   <meta name="twitter:label1" content="Posted At">
   <meta name="twitter:value1" content="{{ postView.IndexedAt }}">
+  {%- if postView.LikeCount %}
+  <meta name="twitter:label2" content="Likes">
+  <meta name="twitter:value2" content="{{ postView.LikeCount }}">
+  {% endif -%}
+  {%- if postView.ReplyCount %}
+  <meta name="twitter:label3" content="Replies">
+  <meta name="twitter:value3" content="{{ postView.ReplyCount }}">
+  {% endif -%}
+  {%- if postView.RepostCount %}
+  <meta name="twitter:label4" content="Reposts">
+  <meta name="twitter:value4" content="{{ postView.RepostCount }}">
+  {% endif -%}
   <meta property="article:published_time" content="{{ postView.IndexedAt }}">
   <link rel="alternate" type="application/json+oembed" href="https://embed.bsky.app/oembed?format=json&url={{ postView.Uri | urlencode }}" />
   <link rel="alternate" href="{{ postView.Uri }}" />


### PR DESCRIPTION
## Summary
- Implement proper OpenGraph metadata for authentication-required posts to ensure meaningful previews when shared
- Add engagement metrics (likes, replies, reposts) to post OpenGraph metadata for richer social sharing experience
- Fix profile username field mapping and clean up debug logging from development process