### PR TITLE
feat(composer): add an account switcher

### DIFF
--- a/src/components/AccountList.tsx
+++ b/src/components/AccountList.tsx
@@ -23,11 +23,15 @@ export function AccountList({
   onSelectOther,
   otherLabel,
   pendingDid,
+  currentAccountDid,
+  showAddAccount = true,
 }: {
   onSelectAccount: (account: SessionAccount) => void
-  onSelectOther: () => void
+  onSelectOther?: () => void
   otherLabel?: string
   pendingDid: string | null
+  currentAccountDid?: string
+  showAddAccount?: boolean
 }) {
   const {currentAccount, accounts} = useSession()
   const t = useTheme()
@@ -37,8 +41,10 @@ export function AccountList({
   })
 
   const onPressAddAccount = useCallback(() => {
-    onSelectOther()
+    onSelectOther?.()
   }, [onSelectOther])
+
+  const activeDid = currentAccountDid || currentAccount?.did
 
   return (
     <View
@@ -55,42 +61,44 @@ export function AccountList({
             profile={profiles?.profiles.find(p => p.did === account.did)}
             account={account}
             onSelect={onSelectAccount}
-            isCurrentAccount={account.did === currentAccount?.did}
+            isCurrentAccount={account.did === activeDid}
             isPendingAccount={account.did === pendingDid}
           />
           <View style={[{borderBottomWidth: 1}, t.atoms.border_contrast_low]} />
         </React.Fragment>
       ))}
-      <Button
-        testID="chooseAddAccountBtn"
-        style={[a.flex_1]}
-        onPress={pendingDid ? undefined : onPressAddAccount}
-        label={_(msg`Sign in to account that is not listed`)}>
-        {({hovered, pressed}) => (
-          <View
-            style={[
-              a.flex_1,
-              a.flex_row,
-              a.align_center,
-              {height: 48},
-              (hovered || pressed) && t.atoms.bg_contrast_25,
-            ]}>
-            <Text
+      {showAddAccount && (
+        <Button
+          testID="chooseAddAccountBtn"
+          style={[a.flex_1]}
+          onPress={pendingDid ? undefined : onPressAddAccount}
+          label={_(msg`Sign in to account that is not listed`)}>
+          {({hovered, pressed}) => (
+            <View
               style={[
-                a.font_bold,
                 a.flex_1,
                 a.flex_row,
-                a.py_sm,
-                a.leading_tight,
-                t.atoms.text_contrast_medium,
-                {paddingLeft: 56},
+                a.align_center,
+                {height: 48},
+                (hovered || pressed) && t.atoms.bg_contrast_25,
               ]}>
-              {otherLabel ?? <Trans>Other account</Trans>}
-            </Text>
-            <Chevron size="sm" style={[t.atoms.text, a.mr_md]} />
-          </View>
-        )}
-      </Button>
+              <Text
+                style={[
+                  a.font_bold,
+                  a.flex_1,
+                  a.flex_row,
+                  a.py_sm,
+                  a.leading_tight,
+                  t.atoms.text_contrast_medium,
+                  {paddingLeft: 56},
+                ]}>
+                {otherLabel ?? <Trans>Other account</Trans>}
+              </Text>
+              <Chevron size="sm" style={[t.atoms.text, a.mr_md]} />
+            </View>
+          )}
+        </Button>
+      )}
     </View>
   )
 }

--- a/src/components/Menu/index.web.tsx
+++ b/src/components/Menu/index.web.tsx
@@ -84,7 +84,7 @@ export function Root({
       {context.control.isOpen && (
         <Portal>
           <Pressable
-            style={[a.fixed, a.inset_0, a.z_50]}
+            style={[a.fixed, a.inset_0, a.z_50, web({cursor: 'default'})]}
             onPress={() => context.control.close()}
             accessibilityHint=""
             accessibilityLabel={_(

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -188,7 +188,15 @@ export const ComposePost = ({
   const [selectedAccount, setSelectedAccount] = useState(currentAccount!)
 
   const {data: agent = defaultAgent} = useQuery({
-    queryKey: ['composer-agent', currentAccount, selectedAccount],
+    queryKey: [
+      'composer-agent',
+      currentAccount?.did,
+      currentAccount?.service,
+      selectedAccount?.did,
+      selectedAccount?.service,
+      selectedAccount?.accessJwt,
+      selectedAccount?.refreshJwt,
+    ],
     queryFn: async () => {
       if (selectedAccount.did === currentAccount!.did) {
         return defaultAgent
@@ -269,7 +277,15 @@ export const ComposePost = ({
         await tempAgent.getProfile({actor: account.did})
         // lets cache the agent for this account to avoid double resume
         queryClient.setQueryData(
-          ['composer-agent', currentAccount, selectedAccount],
+          [
+            'composer-agent',
+            currentAccount?.did,
+            currentAccount?.service,
+            account.did,
+            account.service,
+            account.accessJwt,
+            account.refreshJwt,
+          ],
           tempAgent,
         )
         // if it succeeds, update the selected account
@@ -291,11 +307,12 @@ export const ComposePost = ({
       }
     },
     [
-      selectedAccount,
+      selectedAccount.did,
       closeComposer,
       requestSwitchToAccount,
       _,
-      currentAccount,
+      currentAccount?.did,
+      currentAccount?.service,
       queryClient,
     ],
   )

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -192,10 +192,12 @@ export const ComposePost = ({
       'composer-agent',
       currentAccount?.did,
       currentAccount?.service,
+      currentAccount?.active,
       selectedAccount?.did,
       selectedAccount?.service,
       selectedAccount?.accessJwt,
       selectedAccount?.refreshJwt,
+      selectedAccount?.active,
     ],
     queryFn: async () => {
       if (selectedAccount.did === currentAccount!.did) {
@@ -281,10 +283,12 @@ export const ComposePost = ({
             'composer-agent',
             currentAccount?.did,
             currentAccount?.service,
+            currentAccount?.active,
             account.did,
             account.service,
             account.accessJwt,
             account.refreshJwt,
+            account.active,
           ],
           tempAgent,
         )
@@ -313,6 +317,7 @@ export const ComposePost = ({
       _,
       currentAccount?.did,
       currentAccount?.service,
+      currentAccount?.active,
       queryClient,
     ],
   )

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -95,6 +95,7 @@ import {
   useLanguagePrefs,
   useLanguagePrefsApi,
 } from '#/state/preferences/languages'
+import {STALE} from '#/state/queries'
 import {usePreferencesQuery} from '#/state/queries/preferences'
 import {useProfilesQuery} from '#/state/queries/profile'
 import {type Gif} from '#/state/queries/tenor'
@@ -214,7 +215,7 @@ export const ComposePost = ({
       }
       return new AtpAgent(session)
     },
-    staleTime: 5 * 60 * 1000,
+    staleTime: STALE.MINUTES.FIVE,
   })
 
   const queryClient = useQueryClient()

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -267,7 +267,10 @@ export const ComposePost = ({
         // if it succeeds, update the selected account
         setSelectedAccount(account)
       } catch (e: any) {
-        if (String(e.message).toLowerCase().includes('token has expired')) {
+        if (
+          String(e.message).toLowerCase().includes('token has expired') ||
+          String(e.message).toLowerCase().includes('authentication required')
+        ) {
           closeComposer()
           requestSwitchToAccount({requestedAccount: account.did})
           LegacyToast.show(

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -258,6 +258,13 @@ export const ComposePost = ({
     handles: accounts.map(acc => acc.did),
   })
 
+  // if accounts array changes, invalidate agent so we still have fresh tokens
+  useEffect(() => {
+    queryClient.invalidateQueries({
+      queryKey: ['composer-agent'],
+    })
+  }, [accounts, queryClient])
+
   const [isKeyboardVisible] = useIsKeyboardVisible({iosUseWillEvents: true})
   const [isPublishing, setIsPublishing] = useState(false)
   const [publishingStage, setPublishingStage] = useState('')

--- a/src/view/com/composer/SwitchAccount.tsx
+++ b/src/view/com/composer/SwitchAccount.tsx
@@ -1,0 +1,57 @@
+import React from 'react'
+import {View} from 'react-native'
+import {msg, Trans} from '@lingui/macro'
+import {useLingui} from '@lingui/react'
+
+import {type SessionAccount} from '#/state/session'
+import {atoms as a} from '#/alf'
+import {AccountList} from '#/components/AccountList'
+import * as Dialog from '#/components/Dialog'
+import {Text} from '#/components/Typography'
+
+export function SwitchAccountDialog({
+  control,
+  onSelectAccount,
+  currentAccountDid,
+}: {
+  control: Dialog.DialogControlProps
+  onSelectAccount: (account: SessionAccount) => void
+  currentAccountDid: string
+}) {
+  const {_} = useLingui()
+
+  const onSelect = React.useCallback(
+    (account: SessionAccount) => {
+      if (account.did !== currentAccountDid) {
+        control.close(() => {
+          onSelectAccount(account)
+        })
+      } else {
+        control.close()
+      }
+    },
+    [currentAccountDid, control, onSelectAccount],
+  )
+
+  return (
+    <Dialog.Outer control={control}>
+      <Dialog.Handle />
+      <Dialog.ScrollableInner label={_(msg`Switch Account`)}>
+        <View style={[a.gap_lg]}>
+          <Text style={[a.text_2xl, a.font_bold]}>
+            <Trans>Switch Account</Trans>
+          </Text>
+
+          <AccountList
+            onSelectAccount={onSelect}
+            pendingDid={null}
+            currentAccountDid={currentAccountDid}
+            showAddAccount={false}
+          />
+        </View>
+
+        <Dialog.Close />
+      </Dialog.ScrollableInner>
+    </Dialog.Outer>
+  )
+}

--- a/src/view/com/composer/account-switcher/AccountSwitcher.tsx
+++ b/src/view/com/composer/account-switcher/AccountSwitcher.tsx
@@ -10,21 +10,21 @@ import * as Dialog from '#/components/Dialog'
 import {SwitchAccountDialog} from '../SwitchAccount'
 
 interface AccountSwitcherProps {
-  selectedAccount: SessionAccount
-  onSelectAccount: (account: SessionAccount) => void
+  selectedAccountDid: string
+  onSelectAccount: (accountDid: string) => void
   profiles: AppBskyActorDefs.ProfileViewDetailed[] | undefined
 }
 
 export const AccountSwitcher: React.FC<AccountSwitcherProps> = ({
-  selectedAccount,
+  selectedAccountDid,
   onSelectAccount,
   profiles,
 }) => {
   const {accounts} = useSession()
   const {_} = useLingui()
-  const currentProfile = profiles?.find(p => p.did === selectedAccount.did)
+  const currentProfile = profiles?.find(p => p.did === selectedAccountDid)
   const otherAccounts = accounts
-    .filter((acc: SessionAccount) => acc.did !== selectedAccount.did)
+    .filter((acc: SessionAccount) => acc.did !== selectedAccountDid)
     .map((account: SessionAccount) => ({
       account,
       profile: profiles?.find(p => p.did === account.did),
@@ -48,8 +48,8 @@ export const AccountSwitcher: React.FC<AccountSwitcherProps> = ({
       </Button>
       <SwitchAccountDialog
         control={switchAccountControl}
-        onSelectAccount={onSelectAccount}
-        currentAccountDid={selectedAccount.did}
+        onSelectAccount={account => onSelectAccount(account.did)}
+        currentAccountDid={selectedAccountDid}
       />
     </>
   )

--- a/src/view/com/composer/account-switcher/AccountSwitcher.tsx
+++ b/src/view/com/composer/account-switcher/AccountSwitcher.tsx
@@ -1,0 +1,56 @@
+import {type AppBskyActorDefs} from '@atproto/api'
+import {msg} from '@lingui/macro'
+import {useLingui} from '@lingui/react'
+import type React from 'react'
+
+import {type SessionAccount, useSession} from '#/state/session'
+import {UserAvatar} from '#/view/com/util/UserAvatar'
+import {Button} from '#/components/Button'
+import * as Dialog from '#/components/Dialog'
+import {SwitchAccountDialog} from '../SwitchAccount'
+
+interface AccountSwitcherProps {
+  selectedAccount: SessionAccount
+  onSelectAccount: (account: SessionAccount) => void
+  profiles: AppBskyActorDefs.ProfileViewDetailed[] | undefined
+}
+
+export const AccountSwitcher: React.FC<AccountSwitcherProps> = ({
+  selectedAccount,
+  onSelectAccount,
+  profiles,
+}) => {
+  const {accounts} = useSession()
+  const {_} = useLingui()
+  const currentProfile = profiles?.find(p => p.did === selectedAccount.did)
+  const otherAccounts = accounts
+    .filter((acc: SessionAccount) => acc.did !== selectedAccount.did)
+    .map((account: SessionAccount) => ({
+      account,
+      profile: profiles?.find(p => p.did === account.did),
+    }))
+  const switchAccountControl = Dialog.useDialogControl()
+
+  return (
+    <>
+      <Button
+        disabled={otherAccounts.length === 0}
+        label={_(msg`Switch account`)}
+        variant="ghost"
+        color="primary"
+        shape="round"
+        onPress={switchAccountControl.open}>
+        <UserAvatar
+          avatar={currentProfile?.avatar}
+          size={42}
+          type={currentProfile?.associated?.labeler ? 'labeler' : 'user'}
+        />
+      </Button>
+      <SwitchAccountDialog
+        control={switchAccountControl}
+        onSelectAccount={onSelectAccount}
+        currentAccountDid={selectedAccount.did}
+      />
+    </>
+  )
+}

--- a/src/view/com/composer/account-switcher/AccountSwitcher.web.tsx
+++ b/src/view/com/composer/account-switcher/AccountSwitcher.web.tsx
@@ -1,0 +1,87 @@
+import {View} from 'react-native'
+import {type AppBskyActorDefs} from '@atproto/api'
+import {msg, Trans} from '@lingui/macro'
+import {useLingui} from '@lingui/react'
+import type React from 'react'
+
+import {sanitizeHandle} from '#/lib/strings/handles'
+import {type SessionAccount, useSession} from '#/state/session'
+import {UserAvatar} from '#/view/com/util/UserAvatar'
+import {atoms as a} from '#/alf'
+import {Button} from '#/components/Button'
+import * as Menu from '#/components/Menu'
+
+interface AccountSwitcherProps {
+  selectedAccount: SessionAccount
+  onSelectAccount: (account: SessionAccount) => void
+  profiles: AppBskyActorDefs.ProfileViewDetailed[] | undefined
+}
+
+export const AccountSwitcher: React.FC<AccountSwitcherProps> = ({
+  selectedAccount,
+  onSelectAccount,
+  profiles,
+}) => {
+  const {accounts} = useSession()
+  const {_} = useLingui()
+  const currentProfile = profiles?.find(p => p.did === selectedAccount.did)
+  const otherAccounts = accounts
+    .filter((acc: SessionAccount) => acc.did !== selectedAccount.did)
+    .map((account: SessionAccount) => ({
+      account,
+      profile: profiles?.find(p => p.did === account.did),
+    }))
+
+  return (
+    <Menu.Root>
+      <Menu.Trigger label={_(msg`Switch account`)}>
+        {({props}) => (
+          <Button
+            {...props}
+            disabled={otherAccounts.length === 0}
+            label={_(msg`Switch account`)}
+            variant="ghost"
+            color="primary"
+            shape="round">
+            <UserAvatar
+              avatar={currentProfile?.avatar}
+              size={42}
+              type={currentProfile?.associated?.labeler ? 'labeler' : 'user'}
+            />
+          </Button>
+        )}
+      </Menu.Trigger>
+      <Menu.Outer>
+        <Menu.LabelText>
+          <Trans>Switch account</Trans>
+        </Menu.LabelText>
+        <Menu.Group>
+          {otherAccounts.map(({account, profile}) => (
+            <Menu.Item
+              style={[a.gap_sm, {minWidth: 150}]}
+              key={account.did}
+              label={_(
+                msg`Switch to ${sanitizeHandle(
+                  profile?.handle ?? account.handle,
+                  '@',
+                )}`,
+              )}
+              onPress={() => onSelectAccount(account)}>
+              <View>
+                <UserAvatar
+                  avatar={profile?.avatar}
+                  size={20}
+                  type={profile?.associated?.labeler ? 'labeler' : 'user'}
+                  hideLiveBadge
+                />
+              </View>
+              <Menu.ItemText>
+                {sanitizeHandle(profile?.handle ?? account.handle, '@')}
+              </Menu.ItemText>
+            </Menu.Item>
+          ))}
+        </Menu.Group>
+      </Menu.Outer>
+    </Menu.Root>
+  )
+}

--- a/src/view/com/composer/account-switcher/AccountSwitcher.web.tsx
+++ b/src/view/com/composer/account-switcher/AccountSwitcher.web.tsx
@@ -12,21 +12,21 @@ import {Button} from '#/components/Button'
 import * as Menu from '#/components/Menu'
 
 interface AccountSwitcherProps {
-  selectedAccount: SessionAccount
-  onSelectAccount: (account: SessionAccount) => void
+  selectedAccountDid: string
+  onSelectAccount: (accountDid: string) => void
   profiles: AppBskyActorDefs.ProfileViewDetailed[] | undefined
 }
 
 export const AccountSwitcher: React.FC<AccountSwitcherProps> = ({
-  selectedAccount,
+  selectedAccountDid,
   onSelectAccount,
   profiles,
 }) => {
   const {accounts} = useSession()
   const {_} = useLingui()
-  const currentProfile = profiles?.find(p => p.did === selectedAccount.did)
+  const currentProfile = profiles?.find(p => p.did === selectedAccountDid)
   const otherAccounts = accounts
-    .filter((acc: SessionAccount) => acc.did !== selectedAccount.did)
+    .filter((acc: SessionAccount) => acc.did !== selectedAccountDid)
     .map((account: SessionAccount) => ({
       account,
       profile: profiles?.find(p => p.did === account.did),
@@ -66,7 +66,7 @@ export const AccountSwitcher: React.FC<AccountSwitcherProps> = ({
                   '@',
                 )}`,
               )}
-              onPress={() => onSelectAccount(account)}>
+              onPress={() => onSelectAccount(account.did)}>
               <View>
                 <UserAvatar
                   avatar={profile?.avatar}


### PR DESCRIPTION
This pull request adds an account switcher to the post composer. Closes #6708 and closes #5531.

## Technical details
When the user clicks on their user avatar, the account switcher is triggered. If there is only one account, the switcher is disabled.

It temporarily assumes an identity just for the composer and goes away if the modal is dismissed. The global site identity remains unaffected.

It uses the same strings as [src/components/dialogs/SwitchAccount.tsx](https://github.com/bluesky-social/social-app/blob/main/src/components/dialogs/SwitchAccount.tsx). The expired token logic is more or less the same as [src/lib/hooks/useAccountSwitcher.ts](https://github.com/bluesky-social/social-app/blob/main/src/lib/hooks/useAccountSwitcher.ts), only that I temporarily spawn an agent beforehand to check if the identity is valid.

Feature tested on Web and Android. I don't have an iOS device at hand, so I was unable to test the changes there.

## Screenshots
### Web

<img width="699" height="346" alt="msedge_hFg5pBmZBG" src="https://github.com/user-attachments/assets/1c561a30-8a23-43b8-a4a7-713c714a8d04" />

### Android

<details>
<summary>(long screenshot)</summary>
<img width="1080" height="2400" alt="Screenshot_20250918-224358_Bluesky" src="https://github.com/user-attachments/assets/4daa54db-505c-4784-b421-289c521e6bfb" />
</details>