### PR TITLE
Explicitly declare worklets for useAnimatedScrollHandler_FIXED.web.ts

### DIFF
--- a/src/lib/hooks/useAnimatedScrollHandler_FIXED.web.ts
+++ b/src/lib/hooks/useAnimatedScrollHandler_FIXED.web.ts
@@ -12,26 +12,31 @@ export const useAnimatedScrollHandler: typeof useAnimatedScrollHandler_BUGGY = (
   return useAnimatedScrollHandler_BUGGY(
     {
       onBeginDrag(e, ctx) {
+        'worklet'
         if (typeof ref.current !== 'function' && ref.current.onBeginDrag) {
           ref.current.onBeginDrag(e, ctx)
         }
       },
       onEndDrag(e, ctx) {
+        'worklet'
         if (typeof ref.current !== 'function' && ref.current.onEndDrag) {
           ref.current.onEndDrag(e, ctx)
         }
       },
       onMomentumBegin(e, ctx) {
+        'worklet'
         if (typeof ref.current !== 'function' && ref.current.onMomentumBegin) {
           ref.current.onMomentumBegin(e, ctx)
         }
       },
       onMomentumEnd(e, ctx) {
+        'worklet'
         if (typeof ref.current !== 'function' && ref.current.onMomentumEnd) {
           ref.current.onMomentumEnd(e, ctx)
         }
       },
       onScroll(e, ctx) {
+        'worklet'
         if (typeof ref.current === 'function') {
           ref.current(e, ctx)
         } else if (ref.current.onScroll) {


### PR DESCRIPTION
Worklet validation was added for `3.19.0` in https://github.com/software-mansion/react-native-reanimated/pull/7604

Though the docblocks for this hook state that the callbacks are automatically workletized, the actual docs site for the hook states that the callbacks should be workletized manually. According to [this conversation](https://github.com/software-mansion/react-native-reanimated/issues/7493#issuecomment-3112869389) we need to workletize these callbacks.

For us, this seems to only affect web. And the nested worklets in this case don't seem to have any negative effect. You can just toss a log into the `FIXED` hook or it's higher-level usages and see that it fires just fine.

We added this due to https://github.com/software-mansion/react-native-reanimated/issues/5360, which I think is also fixed by https://github.com/software-mansion/react-native-reanimated/pull/7604. I'll investigate further.

