### PR TITLE
Fix profile feed liked by double tablet offset

### DIFF
--- a/src/view/screens/ProfileFeedLikedBy.tsx
+++ b/src/view/screens/ProfileFeedLikedBy.tsx
@@ -1,5 +1,5 @@
-import React from 'react'
-import {msg} from '@lingui/macro'
+import {useCallback} from 'react'
+import {Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 import {useFocusEffect} from '@react-navigation/native'
 
@@ -10,8 +10,6 @@ import {
 import {makeRecordUri} from '#/lib/strings/url-helpers'
 import {useSetMinimalShellMode} from '#/state/shell'
 import {PostLikedBy as PostLikedByComponent} from '#/view/com/post-thread/PostLikedBy'
-import {ViewHeader} from '#/view/com/util/ViewHeader'
-import {CenteredView} from '#/view/com/util/Views'
 import * as Layout from '#/components/Layout'
 
 type Props = NativeStackScreenProps<CommonNavigatorParams, 'ProfileFeedLikedBy'>
@@ -22,17 +20,23 @@ export const ProfileFeedLikedByScreen = ({route}: Props) => {
   const {_} = useLingui()
 
   useFocusEffect(
-    React.useCallback(() => {
+    useCallback(() => {
       setMinimalShellMode(false)
     }, [setMinimalShellMode]),
   )
 
   return (
     <Layout.Screen testID="postLikedByScreen">
-      <CenteredView sideBorders={true}>
-        <ViewHeader title={_(msg`Liked By`)} />
-        <PostLikedByComponent uri={uri} />
-      </CenteredView>
+      <Layout.Header.Outer>
+        <Layout.Header.BackButton />
+        <Layout.Header.Content>
+          <Layout.Header.TitleText>
+            <Trans>Liked By</Trans>
+          </Layout.Header.TitleText>
+        </Layout.Header.Content>
+        <Layout.Header.Slot />
+      </Layout.Header.Outer>
+      <PostLikedByComponent uri={uri} />
     </Layout.Screen>
   )
 }


### PR DESCRIPTION
List was wrapped in a CenteredView, which was causing double offset

# Before

<img width="2546" height="1622" alt="image" src="https://github.com/user-attachments/assets/acd85596-e9c7-4280-8d80-ccbd04cc0fa8" />

# After

<img width="1085" height="731" alt="Screenshot 2025-09-23 at 18 14 55" src="https://github.com/user-attachments/assets/b5589554-07b6-48b2-a0f4-d8e9b80c3849" />
