### PR TITLE
Sync threaded reply between apps/instances

### DIFF
--- a/src/state/queries/usePostThread/index.ts
+++ b/src/state/queries/usePostThread/index.ts
@@ -47,7 +47,7 @@ export function usePostThread({anchor}: {anchor?: string}) {
     view,
     setView: baseSetView,
     prioritizeFollowedUsers,
-  } = useThreadPreferences()
+  } = useThreadPreferences({save: true})
   const below = useMemo(() => {
     return view === 'linear'
       ? LINEAR_VIEW_BELOW


### PR DESCRIPTION
Previously, the app was not actually storing the user's option to use a threaded/linear view when the option was selected in the modal available above replies; instead, just opting for whatever was present in the server, while not actively updating it. This fixes this issue by calling the function correctly with the save boolean as true, syncing the user's change to the server.