### PR TITLE
Fix gap on profile

### DIFF
--- a/src/components/moderation/LabelsOnMeDialog.tsx
+++ b/src/components/moderation/LabelsOnMeDialog.tsx
@@ -32,7 +32,9 @@ export interface LabelsOnMeDialogProps {
 
 export function LabelsOnMeDialog(props: LabelsOnMeDialogProps) {
   return (
-    <Dialog.Outer control={props.control}>
+    <Dialog.Outer
+      control={props.control}
+      nativeOptions={{preventExpansion: true}}>
       <Dialog.Handle />
       <LabelsOnMeDialogInner {...props} />
     </Dialog.Outer>

--- a/src/components/moderation/ModerationDetailsDialog.tsx
+++ b/src/components/moderation/ModerationDetailsDialog.tsx
@@ -24,7 +24,9 @@ export interface ModerationDetailsDialogProps {
 
 export function ModerationDetailsDialog(props: ModerationDetailsDialogProps) {
   return (
-    <Dialog.Outer control={props.control}>
+    <Dialog.Outer
+      control={props.control}
+      nativeOptions={{preventExpansion: true}}>
       <Dialog.Handle />
       <ModerationDetailsDialogInner {...props} />
     </Dialog.Outer>

--- a/src/components/moderation/ProfileHeaderAlerts.tsx
+++ b/src/components/moderation/ProfileHeaderAlerts.tsx
@@ -6,6 +6,7 @@ import * as Pills from '#/components/Pills'
 
 export function ProfileHeaderAlerts({
   moderation,
+  style,
 }: {
   moderation: ModerationDecision
   style?: StyleProp<ViewStyle>
@@ -16,7 +17,7 @@ export function ProfileHeaderAlerts({
   }
 
   return (
-    <Pills.Row size="lg">
+    <Pills.Row size="lg" style={style}>
       {modui.alerts.filter(unique).map(cause => (
         <Pills.Label
           size="lg"

--- a/src/screens/Profile/Header/Shell.tsx
+++ b/src/screens/Profile/Header/Shell.tsx
@@ -209,17 +209,29 @@ let ProfileHeaderShell = ({
 
       {children}
 
-      {!isPlaceholderProfile && (
-        <View
-          style={[a.px_lg, a.pt_xs, a.pb_sm]}
-          pointerEvents={isIOS ? 'auto' : 'box-none'}>
-          {isMe ? (
-            <LabelsOnMe type="account" labels={profile.labels} />
-          ) : (
-            <ProfileHeaderAlerts moderation={moderation} />
-          )}
-        </View>
-      )}
+      {!isPlaceholderProfile &&
+        (isMe ? (
+          <LabelsOnMe
+            type="account"
+            labels={profile.labels}
+            style={[
+              a.px_lg,
+              a.pt_xs,
+              a.pb_sm,
+              isIOS ? a.pointer_events_auto : {pointerEvents: 'box-none'},
+            ]}
+          />
+        ) : (
+          <ProfileHeaderAlerts
+            moderation={moderation}
+            style={[
+              a.px_lg,
+              a.pt_xs,
+              a.pb_sm,
+              isIOS ? a.pointer_events_auto : {pointerEvents: 'box-none'},
+            ]}
+          />
+        ))}
 
       <GrowableAvatar style={[a.absolute, {top: 104, left: 10}]}>
         <TouchableWithoutFeedback


### PR DESCRIPTION
When a profile has no labels, there's a gap between the description and the tabs. This is because the containing View for the labels is always present, even if there's no content. Simple fix - move padding to the actual label components, remove wrapping View.

We can also move the `pointerEvent` prop to a style, so we can pass it down with the other style thing. I opened a PR to add the missing atoms for this: https://tangled.org/@esb.lol/alf/pulls/1 - in the meantime I just inlined the `box-none` one

<table>
  <thead>
    <tr>
      <th>Before</th>
      <th>After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><img width="300" src="https://github.com/user-attachments/assets/3a5587b0-1708-4c71-a7df-6f0eeac0741c" /></td>
      <td><img width="300" src="https://github.com/user-attachments/assets/7276e798-897a-457f-a923-05c3b379b142" /></td>
    </tr>
  </tbody>
</table>