### PR TITLE
Cache pages in explore feed previews

### DIFF
--- a/src/screens/Search/Explore.tsx
+++ b/src/screens/Search/Explore.tsx
@@ -922,7 +922,7 @@ export function Explore({
               <View style={[a.absolute, a.inset_0, t.atoms.bg, {top: -2}]} />
               <ModuleHeader.FeedLink feed={item.feed}>
                 <ModuleHeader.FeedAvatar feed={item.feed} />
-                <View style={[a.flex_1, a.gap_xs]}>
+                <View style={[a.flex_1, a.gap_2xs]}>
                   <ModuleHeader.TitleText style={[a.text_lg]}>
                     {item.feed.displayName}
                   </ModuleHeader.TitleText>


### PR DESCRIPTION
Whoopsie daisy. 850ms render for a single hook.

<img width="297" height="70" alt="Screenshot 2025-09-25 at 15 37 11" src="https://github.com/user-attachments/assets/f7b68de6-0126-464f-ab1b-b5e177d71cd2" />

It's the feed preview - was recalculating all the moderation, feed tuning etc for every feed every time a new one was added. Added a simple cache which fixed it:

<img width="826" height="181" alt="Screenshot 2025-09-25 at 16 07 12" src="https://github.com/user-attachments/assets/d1941c46-8798-4238-ab55-5651418e57b4" />
