### PR TITLE
Change flatlist configuration for Explore page

### DIFF
--- a/src/screens/Search/Explore.tsx
+++ b/src/screens/Search/Explore.tsx
@@ -1072,12 +1072,26 @@ export function Explore({
       windowSize={platform({android: 11})}
       /**
        * Default: 10
+       *
+       * NOTE: This was 1 on Android. Unfortunately this leads to the list totally freaking out
+       * when the sticky headers changed. I made a minimal reproduction and yeah, it's this prop.
+       * Totally fine when the sticky headers are static, but when they're dynamic, it's a mess.
+       *
+       * Repro: https://github.com/mozzius/stickyindices-repro
+       *
+       * I then found doubling this prop on iOS also reduced it freaking out there as well.
+       *
+       * Trades off seeing more blank space due to it having to render more items before it can show anything.
+       * -sfn
        */
-      maxToRenderPerBatch={platform({android: 1})}
+      maxToRenderPerBatch={platform({android: 10, ios: 20})}
       /**
        * Default: 50
+       *
+       * NOTE: This was 25 on Android. However, due to maxToRenderPerBatch being set to 10,
+       * the lower batching period is no longer necessary (?)
        */
-      updateCellsBatchingPeriod={platform({android: 25})}
+      updateCellsBatchingPeriod={50}
       refreshing={isPTR}
       onRefresh={onPTR}
     />


### PR DESCRIPTION
In trying to chase down the android perf/crashing issues, I focused in on the explore page (as I got a crash there). while I am no closer on the crashes, I _think_ I may have figured out how to improve the issue of the sticky headers in the feed preview freaking out.

Seems like setting a low `maxToRenderPerBatch` and then having `stickyHeaderIndices` that change dynamically don't mix well at all. I made a minimal repro so you can play around with it: https://github.com/mozzius/stickyindices-repro

You can fix the freakout by either:
- Using a higher `maxToRenderPerBatch`
- Keeping `stickyHeaderIndices` static

Since we have to have dynamic `stickyHeaderIndices` (as we add one every time we load another feed), the fix is to increase `maxToRenderPerBatch`. Surprisingly, increasing it improves both platforms, but has the downside of more "blank-outs" where nothing is visible. Hopefully new arch fixes this?   

# Before

https://github.com/user-attachments/assets/647a158f-dfe1-4359-9e88-1679bcacff1e

# After

https://github.com/user-attachments/assets/77656ced-ee25-433a-9d68-f793f38e70f5
