### PR TITLE
Add embed support for Scaniverse 3D scans

### DIFF
--- a/__tests__/lib/string.test.ts
+++ b/__tests__/lib/string.test.ts
@@ -436,6 +436,13 @@ describe('parseEmbedPlayerFromUrl', () => {
 
     'https://www.flickr.com/groups/898944@N23/',
     'https://www.flickr.com/groups',
+
+    'https://scaniverse.com/test/fail/',
+    'https://scaniverse.com/test_fail',
+    'https://scaniverse.com',
+    'https://scaniverse.com/scan/complete',
+    'https://scaniverse.com/scan/complete/',
+    'https://scaniverse.com/scan/complete?embed=1',
   ]
 
   const outputs = [
@@ -809,6 +816,28 @@ describe('parseEmbedPlayerFromUrl', () => {
 
     undefined,
     undefined,
+
+
+
+
+    undefined,
+    undefined,
+    undefined,
+    {
+      type: 'scaniverse_model',
+      source: 'scaniverse',
+      playerUri: 'https://scaniverse.com/scan/complete?embed=1'
+    },
+    {
+      type: 'scaniverse_model',
+      source: 'scaniverse',
+      playerUri: 'https://scaniverse.com/scan/complete?embed=1'
+    },
+    {
+      type: 'scaniverse_model',
+      source: 'scaniverse',
+      playerUri: 'https://scaniverse.com/scan/complete?embed=1'
+    },
   ]
 
   it('correctly grabs the correct id from uri', () => {

--- a/__tests__/lib/string.test.ts
+++ b/__tests__/lib/string.test.ts
@@ -817,26 +817,23 @@ describe('parseEmbedPlayerFromUrl', () => {
     undefined,
     undefined,
 
-
-
-
     undefined,
     undefined,
     undefined,
     {
       type: 'scaniverse_model',
       source: 'scaniverse',
-      playerUri: 'https://scaniverse.com/scan/complete?embed=1'
+      playerUri: 'https://scaniverse.com/scan/complete?embed=1',
     },
     {
       type: 'scaniverse_model',
       source: 'scaniverse',
-      playerUri: 'https://scaniverse.com/scan/complete?embed=1'
+      playerUri: 'https://scaniverse.com/scan/complete?embed=1',
     },
     {
       type: 'scaniverse_model',
       source: 'scaniverse',
-      playerUri: 'https://scaniverse.com/scan/complete?embed=1'
+      playerUri: 'https://scaniverse.com/scan/complete?embed=1',
     },
   ]
 

--- a/src/lib/strings/embed-player.ts
+++ b/src/lib/strings/embed-player.ts
@@ -464,8 +464,8 @@ export function parseEmbedPlayerFromUrl(
 
     const path_components = urlp.pathname.slice(1, i + 1).split('/')
     if (path_components.length === 2) {
-      const [scan_embed_type, scan_id] =  path_components;
-      if (scan_embed_type === 'scan') { 
+      const [scan_embed_type, scan_id] = path_components
+      if (scan_embed_type === 'scan') {
         return {
           type: 'scaniverse_model',
           source: 'scaniverse',

--- a/src/lib/strings/embed-player.ts
+++ b/src/lib/strings/embed-player.ts
@@ -25,6 +25,7 @@ export const embedPlayerSources = [
   'giphy',
   'tenor',
   'flickr',
+  'scaniverse',
 ] as const
 
 export type EmbedPlayerSource = (typeof embedPlayerSources)[number]
@@ -45,6 +46,7 @@ export type EmbedPlayerType =
   | 'giphy_gif'
   | 'tenor_gif'
   | 'flickr_album'
+  | 'scaniverse_model'
 
 export const externalEmbedLabels: Record<EmbedPlayerSource, string> = {
   youtube: 'YouTube',
@@ -57,6 +59,7 @@ export const externalEmbedLabels: Record<EmbedPlayerSource, string> = {
   appleMusic: 'Apple Music',
   soundcloud: 'SoundCloud',
   flickr: 'Flickr',
+  scaniverse: 'Scaniverse',
 }
 
 export interface EmbedPlayerParams {
@@ -449,6 +452,32 @@ export function parseEmbedPlayerFromUrl(
       default:
         // we don't know what this is so we can't embed it
         return undefined
+    }
+  }
+
+  // scaniverse link
+  if (urlp.hostname == 'scaniverse.com') {
+    let i = urlp.pathname.length - 1
+    while (i > 0 && urlp.pathname.charAt(i) === '/') {
+      --i
+    }
+
+    const path_components = urlp.pathname.slice(1, i + 1).split('/')
+    if (path_components.length === 2) {
+      const [scan_embed_type, scan_id] =  path_components;
+      if (scan_embed_type === 'scan') { 
+        return {
+          type: 'scaniverse_model',
+          source: 'scaniverse',
+          playerUri: `https://scaniverse.com/scan/${scan_id}?embed=1`,
+        }
+      } else {
+        // unknown path component
+        return undefined
+      }
+    } else {
+      // unknown path format
+      return undefined
     }
   }
 }

--- a/src/state/persisted/schema.ts
+++ b/src/state/persisted/schema.ts
@@ -106,6 +106,7 @@ const schema = z.object({
       appleMusic: z.enum(externalEmbedOptions).optional(),
       soundcloud: z.enum(externalEmbedOptions).optional(),
       flickr: z.enum(externalEmbedOptions).optional(),
+      scaniverse: z.enum(externalEmbedOptions).optional(),
     })
     .optional(),
   invites: z.object({


### PR DESCRIPTION
Recognizes and embeds Scaniverse scan links so that users can share and view 3D content in the Bluesky app.

Scaniverse's moderation policies can be found here: https://scaniverse.com/about/guidelines Scaniverse is available through the US Apple App Store, suggesting it is compliant with the same Apple T&Cs that Bluesky must comply with it. Scaniverse is a product of Niantic, a well known tech company.