### PR TITLE
Catch errors on geolocation request, reduce Sentry logs

### DIFF
--- a/src/state/geolocation/useSyncedDeviceGeolocation.ts
+++ b/src/state/geolocation/useSyncedDeviceGeolocation.ts
@@ -7,7 +7,7 @@ import {getDeviceGeolocation} from '#/state/geolocation/util'
 import {device, useStorage} from '#/storage'
 
 /**
- * Location.useForegroundPermission on web just errors if the navigator.permissions API is not available.
+ * Location.useForegroundPermissions on web just errors if the navigator.permissions API is not available.
  * We need to catch and ignore it, since it's effectively denied.
  */
 const useForegroundPermissions = createPermissionHook({

--- a/src/state/geolocation/useSyncedDeviceGeolocation.ts
+++ b/src/state/geolocation/useSyncedDeviceGeolocation.ts
@@ -9,6 +9,7 @@ import {device, useStorage} from '#/storage'
 /**
  * Location.useForegroundPermissions on web just errors if the navigator.permissions API is not available.
  * We need to catch and ignore it, since it's effectively denied.
+ * @see https://github.com/expo/expo/blob/72f1562ed9cce5ff6dfe04aa415b71632a3d4b87/packages/expo-location/src/Location.ts#L290-L293
  */
 const useForegroundPermissions = createPermissionHook({
   getMethod: () =>


### PR DESCRIPTION
We're seeing [a lot of errors on sentry](https://blueskyweb.sentry.io/issues/6895909008/?project=4508807082278912) about the `navigation.permissions` API being unavailable.

Since failing to request/query permissions is effectively the same as them being denied, we should just catch this error and act if it's been denied - better than an unhandled error

I have reimplemented `useForegroundPermissions` and just added a `.catch()` to the get/request calls. [Here is original code from `expo-location`](https://github.com/expo/expo/blob/main/packages/expo-location/src/Location.ts#L290-L293)