### PR TITLE
Fix feedfeedback metrics not distinguishing which feed it's from

### DIFF
--- a/src/logger/metrics.ts
+++ b/src/logger/metrics.ts
@@ -191,6 +191,27 @@ export type MetricEvents = {
     count: number
   }
 
+  'feed:showMore': {
+    feed: string
+    feedContext: string
+  }
+  'feed:showLess': {
+    feed: string
+    feedContext: string
+  }
+  'feed:clickthrough': {
+    feed: string
+    count: number
+  }
+  'feed:engaged': {
+    feed: string
+    count: number
+  }
+  'feed:seen': {
+    feed: string
+    count: number
+  }
+
   'composer:gif:open': {}
   'composer:gif:select': {}
 

--- a/src/logger/metrics.ts
+++ b/src/logger/metrics.ts
@@ -175,22 +175,6 @@ export type MetricEvents = {
   'feed:suggestion:press': {
     feedUrl: string
   }
-  'discover:showMore': {
-    feedContext: string
-  }
-  'discover:showLess': {
-    feedContext: string
-  }
-  'discover:clickthrough': {
-    count: number
-  }
-  'discover:engaged': {
-    count: number
-  }
-  'discover:seen': {
-    count: number
-  }
-
   'feed:showMore': {
     feed: string
     feedContext: string


### PR DESCRIPTION
Since #8672, we now allow show more/show less on third party feeds. However, we didn't update the metrics and thus that's all being logged as `discover:showMore`/`discover:showLess`.

I've added some metrics - generic `feed:showMore` etc for all the previously `discover:`-prefixed events, which now includes the feed descriptor. ~~I've opted to still send `discover:` ones when using discover for backwards compatibility, but not to statsig~~. For forwards compatibility I have made sure to include seen/interacted events in case we merge #9094 

## test plan

look at logs, confirm new events are being sent. confirm `discover:` ones are only sent when on discover