### PR TITLE
Don't send some "activity no longer available" errors to Sentry

### DIFF
--- a/src/App.native.tsx
+++ b/src/App.native.tsx
@@ -84,7 +84,11 @@ if (isIOS) {
 }
 if (isAndroid) {
   // iOS is handled by the config plugin -sfn
-  ScreenOrientation.lockAsync(ScreenOrientation.OrientationLock.PORTRAIT_UP)
+  ScreenOrientation.lockAsync(
+    ScreenOrientation.OrientationLock.PORTRAIT_UP,
+  ).catch(error =>
+    logger.debug('Could not lock orientation', {safeMessage: error}),
+  )
 }
 
 /**

--- a/src/alf/util/systemUI.ts
+++ b/src/alf/util/systemUI.ts
@@ -1,14 +1,20 @@
 import * as SystemUI from 'expo-system-ui'
 import {type Theme} from '@bsky.app/alf'
 
+import {logger} from '#/logger'
 import {isAndroid} from '#/platform/detection'
 
 export function setSystemUITheme(themeType: 'theme' | 'lightbox', t: Theme) {
   if (isAndroid) {
-    if (themeType === 'theme') {
-      SystemUI.setBackgroundColorAsync(t.atoms.bg.backgroundColor)
-    } else {
-      SystemUI.setBackgroundColorAsync('black')
+    try {
+      if (themeType === 'theme') {
+        SystemUI.setBackgroundColorAsync(t.atoms.bg.backgroundColor)
+      } else {
+        SystemUI.setBackgroundColorAsync('black')
+      }
+    } catch (error) {
+      // Can reject with 'The current activity is no longer available' - no big deal
+      logger.debug('Could not set system UI theme', {safeMessage: error})
     }
   }
 }


### PR DESCRIPTION
Seeing a lot of these in Sentry

`Call to function 'ExpoSystemUI.setBackgroundColorAsync' has been rejected. → Caused by: The current activity is no longer available`
`Call to function 'ExpoScreenOrientation.lockAsync' has been rejected.
→ Caused by: The current activity is no longer available`

If the current activity is not available that's fine, we can just ignore these errors I think. Saves 500k events of our statsig quota