### PR TITLE
Fix link crash

### DIFF
--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -165,8 +165,8 @@ export function useLink({
             if (isNative && screen !== 'NotFound') {
               const state = navigation.getState()
               // if screen is not in the current navigator, it means it's
-              // most likely a tab screen
-              if (state && !state.routeNames.includes(screen)) {
+              // most likely a tab screen. note: state can be undefined
+              if (!state?.routeNames.includes(screen)) {
                 const parent = navigation.getParent()
                 if (
                   parent &&

--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -166,7 +166,7 @@ export function useLink({
               const state = navigation.getState()
               // if screen is not in the current navigator, it means it's
               // most likely a tab screen
-              if (!state.routeNames.includes(screen)) {
+              if (state && !state.routeNames.includes(screen)) {
                 const parent = navigation.getParent()
                 if (
                   parent &&


### PR DESCRIPTION
Crash was introduced by #8520. Seems `navigation.getState()` can be undefined

https://blueskyweb.sentry.io/issues/6720430884/events/b496d8eaf9e24d2bb508d5aaedd86f34/?query=&referrer=previous-event

Simply adds optional chaining