### PR TITLE
[Fix Logouts] Remove buggy hackfix

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "icons:optimize": "svgo -f ./assets/icons"
   },
   "dependencies": {
-    "@atproto/api": "^0.16.7",
+    "@atproto/api": "^0.17.0",
     "@bitdrift/react-native": "^0.6.8",
     "@braintree/sanitize-url": "^6.0.2",
     "@bsky.app/alf": "^0.1.2",

--- a/src/state/session/agent.ts
+++ b/src/state/session/agent.ts
@@ -321,15 +321,7 @@ class BskyAppAgent extends BskyAgent {
 
     // Now the agent is ready.
     const account = agentToSessionAccountOrThrow(this)
-    let lastSession = this.sessionManager.session
     this.persistSessionHandler = event => {
-      if (this.sessionManager.session) {
-        lastSession = this.sessionManager.session
-      } else if (event === 'network-error') {
-        // Put it back, we'll try again later.
-        this.sessionManager.session = lastSession
-      }
-
       onSessionChange(this, account.did, event)
       if (event !== 'create' && event !== 'update') {
         addSessionErrorLog(account.did, event)

--- a/src/state/session/agent.ts
+++ b/src/state/session/agent.ts
@@ -322,6 +322,7 @@ class BskyAppAgent extends BskyAgent {
     // Now the agent is ready.
     const account = agentToSessionAccountOrThrow(this)
     this.persistSessionHandler = event => {
+      console.log('persistSessionHandler', {event})
       onSessionChange(this, account.did, event)
       if (event !== 'create' && event !== 'update') {
         addSessionErrorLog(account.did, event)

--- a/src/state/session/agent.ts
+++ b/src/state/session/agent.ts
@@ -322,7 +322,6 @@ class BskyAppAgent extends BskyAgent {
     // Now the agent is ready.
     const account = agentToSessionAccountOrThrow(this)
     this.persistSessionHandler = event => {
-      console.log('persistSessionHandler', {event})
       onSessionChange(this, account.did, event)
       if (event !== 'create' && event !== 'update') {
         addSessionErrorLog(account.did, event)

--- a/yarn.lock
+++ b/yarn.lock
@@ -77,6 +77,20 @@
     tlds "^1.234.0"
     zod "^3.23.8"
 
+"@atproto/api@^0.17.0":
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/@atproto/api/-/api-0.17.0.tgz#1fe87ef703f8020dbe00bb5e5cc18622b8b91f4a"
+  integrity sha512-FNS9SW7/3kslAnJH7F4fO9/jPjXzC0NMD6u9NjJ/h4EnaIEpWHZQPkmD9Q2hvAwD6+Uo2boYZEPKkOa55Lr5Dg==
+  dependencies:
+    "@atproto/common-web" "^0.4.3"
+    "@atproto/lexicon" "^0.5.1"
+    "@atproto/syntax" "^0.4.1"
+    "@atproto/xrpc" "^0.7.5"
+    await-lock "^2.2.2"
+    multiformats "^9.9.0"
+    tlds "^1.234.0"
+    zod "^3.23.8"
+
 "@atproto/aws@^0.2.28":
   version "0.2.28"
   resolved "https://registry.yarnpkg.com/@atproto/aws/-/aws-0.2.28.tgz#17bd88a6276e323ebb094a3f01bd94b1173a29a4"
@@ -164,6 +178,16 @@
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/@atproto/common-web/-/common-web-0.4.2.tgz#6e3add6939da93d3dfbc8f87e26dc4f57fad7259"
   integrity sha512-vrXwGNoFGogodjQvJDxAeP3QbGtawgZute2ed1XdRO0wMixLk3qewtikZm06H259QDJVu6voKC5mubml+WgQUw==
+  dependencies:
+    graphemer "^1.4.0"
+    multiformats "^9.9.0"
+    uint8arrays "3.0.0"
+    zod "^3.23.8"
+
+"@atproto/common-web@^0.4.3":
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/@atproto/common-web/-/common-web-0.4.3.tgz#b4480220b5682db09da45f4ef906eb7619c838b5"
+  integrity sha512-nRDINmSe4VycJzPo6fP/hEltBcULFxt9Kw7fQk6405FyAWZiTluYHlXOnU7GkQfeUK44OENG1qFTBcmCJ7e8pg==
   dependencies:
     graphemer "^1.4.0"
     multiformats "^9.9.0"
@@ -298,6 +322,17 @@
   integrity sha512-3aAzEAy9EAPs3CxznzMhEcqDd7m3vz1eze/ya9/ThbB7yleqJIhz5GY2q76tCCwHPhn5qDDMhlA9kKV6fG23gA==
   dependencies:
     "@atproto/common-web" "^0.4.2"
+    "@atproto/syntax" "^0.4.1"
+    iso-datestring-validator "^2.2.2"
+    multiformats "^9.9.0"
+    zod "^3.23.8"
+
+"@atproto/lexicon@^0.5.1":
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/@atproto/lexicon/-/lexicon-0.5.1.tgz#e9b7d5c70dc5a38518a8069cd80fea77ab526947"
+  integrity sha512-y8AEtYmfgVl4fqFxqXAeGvhesiGkxiy3CWoJIfsFDDdTlZUC8DFnZrYhcqkIop3OlCkkljvpSJi1hbeC1tbi8A==
+  dependencies:
+    "@atproto/common-web" "^0.4.3"
     "@atproto/syntax" "^0.4.1"
     iso-datestring-validator "^2.2.2"
     multiformats "^9.9.0"
@@ -514,6 +549,14 @@
   integrity sha512-sDi68+QE1XHegTaNAndlX41Gp827pouSzSs8CyAwhrqZdsJUxE3P7TMtrA0z+zAjvxVyvzscRc0TsN/fGUGrhw==
   dependencies:
     "@atproto/lexicon" "^0.5.0"
+    zod "^3.23.8"
+
+"@atproto/xrpc@^0.7.5":
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/@atproto/xrpc/-/xrpc-0.7.5.tgz#40cef1a657b5f28af8ebec9e3dac5872e58e88ea"
+  integrity sha512-MUYNn5d2hv8yVegRL0ccHvTHAVj5JSnW07bkbiaz96UH45lvYNRVwt44z+yYVnb0/mvBzyD3/ZQ55TRGt7fHkA==
+  dependencies:
+    "@atproto/lexicon" "^0.5.1"
     zod "^3.23.8"
 
 "@aws-crypto/crc32@3.0.0":


### PR DESCRIPTION
## Depends on https://github.com/bluesky-social/atproto/pull/4238

Once https://github.com/bluesky-social/atproto/pull/4238 is merged, this removes the hackfix working around it. That resolves one of the potential issues that @mackuba identified in https://github.com/bluesky-social/social-app/issues/8695#issuecomment-3103433871, namely the `lastSession` variable getting stale.

I don't know if there's an actual repro case for that problem, but removing clearly buggy code in favor of upstream fix seems like a good idea anyway.

## Test Plan

Apply this PR first. We should see bad behavior on network errors, same as before the hackfix was added in https://github.com/bluesky-social/social-app/pull/4911.

Then apply https://github.com/bluesky-social/atproto/pull/4238. The test plan from https://github.com/bluesky-social/social-app/pull/4911 should pass although the hackfix is no longer present.

I have not done this myself yet.