### PR TITLE
[Web] Fix thread jumps

### DIFF
--- a/src/screens/PostThread/index.tsx
+++ b/src/screens/PostThread/index.tsx
@@ -148,7 +148,9 @@ export function PostThread({uri}: {uri: string}) {
    */
   const shouldHandleScroll = useRef(true)
   /**
-   * Called any time the content size of the list changes, _just_ before paint.
+   * Called any time the content size of the list changes. Could be a fresh
+   * render, items being added to the list, or any resize that changes the
+   * scrollable size of the content.
    *
    * We want this to fire every time we change params (which will reset
    * `deferParents` via `onLayout` on the anchor post, due to the key change),
@@ -197,17 +199,17 @@ export function PostThread({uri}: {uri: string}) {
       list.scrollToOffset({offset})
 
       /*
-       * After we manage to do a positive adjustment, we need
-       * to ensure this doesn't run again until scroll handling is requested
-       * again via `shouldHandleScroll.current === true` and a params
-       * change via `prepareForParamsUpdate`.
+       * After we manage to do a positive adjustment, we need to ensure this
+       * doesn't run again until scroll handling is requested again via
+       * `shouldHandleScroll.current === true` and a params change via
+       * `prepareForParamsUpdate`.
        *
        * The `isRoot` here is needed because if we're looking at the anchor
        * post, this handler will not fire after `deferParents` is set to
        * `false`, since there are no parents to render above it. In this case,
-       * we want to make sure `shouldHandleScroll` is set to `false` so that
-       * subsequent size changes unrelated to a params change (like pagination)
-       * do not affect scroll.
+       * we want to make sure `shouldHandleScroll` is set to `false` right away
+       * so that subsequent size changes unrelated to a params change (like
+       * pagination) do not affect scroll.
        */
       if (offset > 0 || isRoot) shouldHandleScroll.current = false
     }


### PR DESCRIPTION
Fixes https://github.com/bluesky-social/social-app/issues/9095

This logic is luckily web-only.

To repro, you have to navigate to a reply *and then* navigate to another one (e.g. upwards).

I don't understand the logic quite enough to tell what's happening, but for some reason we were setting `shouldHandleScroll.current = false` a bit too early. This function runs an extra time in this scenario and we end up missing the last event when we actually *should* scroll.

I changed the condition to what seems to make it work: only stop attempting after one positive scroll. I don't know if this is a perfect heuristic but seems to work at least on Chrome. You'll probably want to test FF, Safari, and Mobile Safari.

## Test Plan

I was doing stuff like this. Previously it would lose scroll position.

https://github.com/user-attachments/assets/6b4e9699-3990-4034-9186-2f6692b6f0bd

