### PR TITLE
BUGFIX: Adds support for `node > 20`

### DIFF
--- a/package.json
+++ b/package.json
@@ -278,6 +278,7 @@
     "@react-native/babel-preset": "0.81.4",
     "@react-native/normalize-colors": "0.81.4",
     "**/@expo/image-utils": "0.8.7",
+    "**/better-sqlite3": "^12.4.1",
     "**/expo-constants": "18.0.8",
     "**/expo-device": "7.1.4",
     "**/zod": "3.23.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8746,10 +8746,10 @@ better-opn@~3.0.2:
   dependencies:
     open "^8.0.4"
 
-better-sqlite3@^10.0.0:
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/better-sqlite3/-/better-sqlite3-10.1.0.tgz#8dc07e496fc014a7cd2211f79e591f6ba92838e8"
-  integrity sha512-hqpHJaCfKEZFaAWdMh6crdzRWyzQzfP6Ih8TYI0vFn01a6ZTDSbJIMXN+6AMBaBOh99DzUy8l3PsV9R3qnJDng==
+better-sqlite3@^10.0.0, better-sqlite3@^12.4.1:
+  version "12.4.1"
+  resolved "https://registry.yarnpkg.com/better-sqlite3/-/better-sqlite3-12.4.1.tgz#f78df6c80530d1a0b750b538033e6199b7d30d26"
+  integrity sha512-3yVdyZhklTiNrtg+4WqHpJpFDd+WHTg2oM7UcR80GqL05AOV0xEJzc6qNvFYoEtE+hRp1n9MpN6/+4yhlGkDXQ==
   dependencies:
     bindings "^1.5.0"
     prebuild-install "^7.1.1"


### PR DESCRIPTION
The transitive dependency `better-sqlite3` resolves to version `^10.0.0`, which was before support for `node > 20` was added to the library. They have since fixed the issue. Forcing the resolution of `better-sqlite3` to the latest version corrects the error.