### PR TITLE
Fix android admonition flex collapse issue

### DIFF
--- a/src/components/Admonition.tsx
+++ b/src/components/Admonition.tsx
@@ -87,7 +87,7 @@ export function Row({
   style?: StyleProp<ViewStyle>
 }) {
   return (
-    <View style={[a.flex_1, a.flex_row, a.align_start, a.gap_sm, style]}>
+    <View style={[a.w_full, a.flex_row, a.align_start, a.gap_sm, style]}>
       {children}
     </View>
   )


### PR DESCRIPTION
I don't know why Android (and only Android) does this occasionally. Happened with the previous iterations of Admonitions too. Something about `flex_1` views in a scrollview that contains Text.

<table>
  <thead>
    <tr>
      <th>Before</th>
      <th>After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><img width="300" src="https://github.com/user-attachments/assets/774c6b36-f7e8-4885-ab93-1904ce936121" /></td>
      <td><img width="300" src="https://github.com/user-attachments/assets/8368f8c4-e3a9-407f-bd45-d8bb3121cef8" /></td>
    </tr>
  </tbody>
</table>

Other platforms are visually unchanged

<img width="300" alt="Screenshot 2025-10-02 at 14 22 38" src="https://github.com/user-attachments/assets/5d6a083f-49cc-4472-a19b-e4d865d31322" />
