### PR TITLE
correct space after . on android username login field

### DIFF
--- a/src/screens/Login/LoginForm.tsx
+++ b/src/screens/Login/LoginForm.tsx
@@ -205,6 +205,7 @@ export const LoginForm = ({
               autoComplete="username"
               returnKeyType="next"
               textContentType="username"
+              keyboardType="email-address"
               defaultValue={initialHandle || ''}
               onChangeText={v => {
                 identifierValueRef.current = v


### PR DESCRIPTION
Sets the login username field's keyboard type to "email-address", which prevents the automatic space after the period character on android. 