### PR TITLE
Force refresh camera permission status after user returns from settings

### DIFF
--- a/src/lib/hooks/usePermissions.ts
+++ b/src/lib/hooks/usePermissions.ts
@@ -1,5 +1,8 @@
 import {Linking} from 'react-native'
-import {useCameraPermissions as useExpoCameraPermissions} from 'expo-camera'
+import {
+  PermissionStatus,
+  useCameraPermissions as useExpoCameraPermissions,
+} from 'expo-camera'
 import * as MediaLibrary from 'expo-media-library'
 
 import {isWeb} from '#/platform/detection'
@@ -78,18 +81,29 @@ export function useVideoLibraryPermission() {
 }
 
 export function useCameraPermission() {
-  const [res, requestPermission] = useExpoCameraPermissions()
+  const [permission, requestPermission] = useExpoCameraPermissions()
 
-  const requestCameraAccessIfNeeded = async () => {
-    if (res?.granted) {
-      return true
-    } else if (!res || res?.status === 'undetermined' || res?.canAskAgain) {
-      const updatedRes = await requestPermission()
-      return updatedRes?.granted
-    } else {
-      openPermissionAlert('camera')
-      return false
+  const requestCameraAccessIfNeeded = async (): Promise<boolean> => {
+    if (permission?.granted) return true
+
+    if (
+      !permission ||
+      permission.status === PermissionStatus.UNDETERMINED ||
+      permission.canAskAgain
+    ) {
+      const updated = await requestPermission()
+      return updated?.granted ?? false
     }
+
+    if (permission.status === PermissionStatus.DENIED) {
+      const updated = await requestPermission()
+      if (updated.status === PermissionStatus.DENIED) {
+        openPermissionAlert('camera')
+      }
+      return updated?.granted ?? false
+    }
+
+    return false
   }
 
   return {requestCameraAccessIfNeeded}


### PR DESCRIPTION
Improves the camera permission handling by ensuring the permission status is re-checked when the user attempts to access the camera. Previously, if the permission was denied, the app would only show an alert and not attempt to refresh the status.

### Changes
- Updated `useCameraPermission` hook to handle `DENIED` permissions by re-requesting permission.
- Returns the updated permission status, allowing proper handling on both iOS and Android.
- Ensures `openPermissionAlert` is only shown if permission remains denied after re-request.

### Issue
Fixes: [#9088](https://github.com/bluesky-social/social-app/issues/9088)

### Testing:
1. Deny camera permission in the app.
2. Attempt to access the camera.
3. Hook now re-requests permission.
4. Alert is displayed only if permission remains denied.