### PR TITLE
feat(link-meta): Tweaks `getLinkMeta` to whitelist trusted hostnames

### DIFF
--- a/src/lib/link-meta/link-meta.ts
+++ b/src/lib/link-meta/link-meta.ts
@@ -62,7 +62,10 @@ export async function getLinkMeta(
     likelyType,
     url,
   }
-  if (likelyType !== LikelyType.HTML) {
+  const trustedHostnames: string[] = ['storage.courtlistener.com']
+  const isTrusted = trustedHostnames.includes(urlp.hostname)
+  // Only allow non-HTML links to continue if they're from trusted sources
+  if (likelyType !== LikelyType.HTML && !isTrusted) {
     return meta
   }
 


### PR DESCRIPTION
### What’s changed

Previously, the `getLinkMeta` function would return early for all non-HTML URLs, skipping metadata fetching. This PR introduces a whitelist of trusted hostnames (e.g., `storage.courtlistener.com`) allowing the preview fetcher to process non-HTML links from these hosts and continue fetching metadata.

Additional hosts can be easily added to the whitelist if similar needs arise in the future. This PR closes #1672 .


