### PR TITLE
fix(video): round and consistently format TimeIndicator to nearest second

### DIFF
--- a/src/components/Post/Embed/VideoEmbed/VideoEmbedInner/TimeIndicator.tsx
+++ b/src/components/Post/Embed/VideoEmbed/VideoEmbedInner/TimeIndicator.tsx
@@ -24,14 +24,16 @@ export function TimeIndicator({
     return null
   }
 
-  const minutes = Math.floor(time / 60)
-  const seconds = String(time % 60).padStart(2, '0')
+  const roundedTime = Math.round(time)
+  const minutes = Math.floor(roundedTime / 60)
+  const secondsNum = roundedTime % 60
+  const seconds = secondsNum < 10 ? `0${secondsNum}` : `${secondsNum}`
 
   return (
     <View
       pointerEvents="none"
       accessibilityLabel={_(
-        msg`Time remaining: ${plural(Number(time) || 0, {
+        msg`Time remaining: ${plural(roundedTime, {
           one: '# second',
           other: '# seconds',
         })}`,


### PR DESCRIPTION
**Summary**
This PR makes a minor update to `TimeIndicator` so displayed time is **rounded to the nearest second** and **always rendered as MM:SS** (two-digit seconds). This avoids float/precision artifacts in the visible label (e.g., `0:59.6`, `1:0.1`).

**Changes**

* `src/components/Post/Embed/VideoEmbed/VideoEmbedInner/TimeIndicator.tsx`

  * Use `const roundedTime = Math.round(time)` before formatting.
  * Compute minutes via `Math.floor(roundedTime / 60)`.
  * Compute seconds via `const secondsNum = roundedTime % 60` and pad with a leading `0` when `< 10`.
  * No other behavior changes.

**Why**
Incoming time can be fractional (e.g., 59.6, 60.1), which led to odd visual displays. Rounding before formatting aligns with user expectations at boundaries (e.g., `59.6` → `1:00`) and keeps the label stable.

**Examples**

* 0 → `0:00`
* 5 → `0:05`
* 59.4 → `0:59`
* 59.6 → `1:00`
* 60.4 → `1:00`
* 121.2 → `2:01`

**Related**

* Possibly related to bluesky-social/social-app#7471, especially when the forward button is pressed at fractional seconds.
* Upstream **bluesky-video** has an open PR#17 to harden native time reporting and prevent downstream crashes when unexpected time values arrive; this change ensures the UI remains robust regardless.

**Risk/Impact**

* Very low. Only affects display/labels. Behavior change is limited to rounding near boundaries (e.g., `59.6` now shows `1:00`).
