### PR TITLE
Add accessibilityRole to single images

### DIFF
--- a/src/view/com/util/images/AutoSizedImage.tsx
+++ b/src/view/com/util/images/AutoSizedImage.tsx
@@ -204,6 +204,7 @@ export function AutoSizedImage({
         // alt here is what screen readers actually use
         accessibilityLabel={image.alt}
         accessibilityHint={_(msg`Views full image`)}
+        accessibilityRole="button"
         style={[
           a.w_full,
           a.rounded_md,
@@ -226,6 +227,7 @@ export function AutoSizedImage({
           // alt here is what screen readers actually use
           accessibilityLabel={image.alt}
           accessibilityHint={_(msg`Views full image`)}
+          accessibilityRole="button"
           style={[a.h_full]}>
           {contents}
         </Pressable>


### PR DESCRIPTION
Fixes https://github.com/bluesky-social/social-app/issues/9142

Image grids already use `accessibilityRole="button"`, this adds it to single images too