### PR TITLE
[16KB] use 16kb-compatible fork of react-native-mmkv

### DIFF
--- a/package.json
+++ b/package.json
@@ -192,7 +192,7 @@
     "react-native-gesture-handler": "~2.28.0",
     "react-native-get-random-values": "~1.11.0",
     "react-native-keyboard-controller": "1.18.5",
-    "react-native-mmkv": "^2.12.2",
+    "react-native-mmkv": "npm:@mozzius/react-native-mmkv@2.12.3",
     "react-native-pager-view": "6.8.0",
     "react-native-progress": "bluesky-social/react-native-progress",
     "react-native-qrcode-styled": "^0.3.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17065,10 +17065,10 @@ react-native-keyboard-controller@1.18.5:
   dependencies:
     react-native-is-edge-to-edge "^1.2.1"
 
-react-native-mmkv@^2.12.2:
-  version "2.12.2"
-  resolved "https://registry.yarnpkg.com/react-native-mmkv/-/react-native-mmkv-2.12.2.tgz#4bba0f5f04e2cf222494cce3a9794ba6a4894dee"
-  integrity sha512-6058Aq0p57chPrUutLGe9fYoiDVDNMU2PKV+lLFUJ3GhoHvUrLdsS1PDSCLr00yqzL4WJQ7TTzH+V8cpyrNcfg==
+"react-native-mmkv@npm:@mozzius/react-native-mmkv@2.12.3":
+  version "2.12.3"
+  resolved "https://registry.yarnpkg.com/@mozzius/react-native-mmkv/-/react-native-mmkv-2.12.3.tgz#562e78c608703cfc1ee2b31c7d3ec328167b708a"
+  integrity sha512-w3T9lstT69Xln0gpxGEtB6/L2i7977WFLCa7CCu/9iyLHEXxOGCbzWWdFnR7SW53GlIMMn5/z9/nqoSiprVySQ==
 
 react-native-pager-view@6.8.0:
   version "6.8.0"


### PR DESCRIPTION
Fork here: https://github.com/mozzius/react-native-mmkv/

Updated to the latest MMKV 1.3 LTS which supports 16KB page sizes

# Test plan

Confirm it compiles and mmkv still works on iOS+Android

You might want to check my commits in the fork: https://github.com/mozzius/react-native-mmkv/commits/main/