### PR TITLE
Fixes to support Android Notification Channels

### DIFF
--- a/src/lib/hooks/useNotificationHandler.ts
+++ b/src/lib/hooks/useNotificationHandler.ts
@@ -1,15 +1,16 @@
+import React from 'react'
 import {useEffect} from 'react'
 import * as Notifications from 'expo-notifications'
-import {AtUri} from '@atproto/api'
+import {type AppBskyNotificationListNotifications} from '@atproto/api'
 import {msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 import {CommonActions, useNavigation} from '@react-navigation/native'
 import {useQueryClient} from '@tanstack/react-query'
 
 import {useAccountSwitcher} from '#/lib/hooks/useAccountSwitcher'
-import {logger as notyLogger} from '#/lib/notifications/util'
 import {type NavigationProp} from '#/lib/routes/types'
-import {isAndroid, isIOS} from '#/platform/detection'
+import {Logger} from '#/logger'
+import {isAndroid} from '#/platform/detection'
 import {useCurrentConvoId} from '#/state/messages/current-convo-id'
 import {RQKEY as RQKEY_NOTIFS} from '#/state/queries/notifications/feed'
 import {invalidateCachedUnreadPage} from '#/state/queries/notifications/unread'
@@ -18,8 +19,6 @@ import {useSession} from '#/state/session'
 import {useLoggedOutViewControls} from '#/state/shell/logged-out'
 import {useCloseAllActiveElements} from '#/state/util'
 import {resetToTab} from '#/Navigation'
-import {router} from '#/routes'
-
 export type NotificationReason =
   | 'like'
   | 'repost'
@@ -29,24 +28,17 @@ export type NotificationReason =
   | 'quote'
   | 'chat-message'
   | 'starterpack-joined'
-  | 'like-via-repost'
-  | 'repost-via-repost'
-  | 'verified'
-  | 'unverified'
-  | 'subscribed-post'
-
 /**
  * Manually overridden type, but retains the possibility of
  * `notification.request.trigger.payload` being `undefined`, as specified in
  * the source types.
  */
-export type NotificationPayload =
+type NotificationPayload =
   | undefined
   | {
       reason: Exclude<NotificationReason, 'chat-message'>
       uri: string
       subject: string
-      recipientDid: string
     }
   | {
       reason: 'chat-message'
@@ -54,26 +46,16 @@ export type NotificationPayload =
       messageId: string
       recipientDid: string
     }
-
 const DEFAULT_HANDLER_OPTIONS = {
   shouldShowBanner: false,
   shouldShowList: false,
   shouldPlaySound: false,
   shouldSetBadge: true,
 } satisfies Notifications.NotificationBehavior
-
-/**
- * Cached notification payload if we handled a notification while the user was
- * using a different account. This is consumed after we finish switching
- * accounts.
- */
-let storedAccountSwitchPayload: NotificationPayload
-
-/**
- * Used to ensure we don't handle the same notification twice
- */
-let lastHandledNotificationDateDedupe = 0
-
+// These need to stay outside the hook to persist between account switches
+let storedPayload: NotificationPayload
+let prevDate = 0
+const logger = Logger.create(Logger.Context.Notifications)
 export function useNotificationsHandler() {
   const queryClient = useQueryClient()
   const {currentAccount, accounts} = useSession()
@@ -89,6 +71,7 @@ export function useNotificationsHandler() {
   // which has the sounds we want in the configuration for that channel. These two
   // channels allow for the mute/unmute functionality we want for the background
   // handler.
+  React.useEffect(() => {
   useEffect(() => {
     if (!isAndroid) return
     // assign both chat notifications to a group
@@ -102,7 +85,7 @@ export function useNotificationsHandler() {
       ),
     })
     Notifications.setNotificationChannelAsync('chat-messages', {
-      name: _(msg`Chat messages - sound`),
+      name: _(msg`Chat messages - sound`,
       groupId: CHAT_GROUP,
       importance: Notifications.AndroidImportance.MAX,
       sound: 'dm.mp3',
@@ -110,6 +93,7 @@ export function useNotificationsHandler() {
       vibrationPattern: [250],
       lockscreenVisibility: Notifications.AndroidNotificationVisibility.PRIVATE,
     })
+
     Notifications.setNotificationChannelAsync('chat-messages-muted', {
       name: _(msg`Chat messages - silent`),
       groupId: CHAT_GROUP,
@@ -119,67 +103,69 @@ export function useNotificationsHandler() {
       vibrationPattern: [250],
       lockscreenVisibility: Notifications.AndroidNotificationVisibility.PRIVATE,
     })
+  }, [])
 
+  React.useEffect(() => {
     Notifications.setNotificationChannelAsync(
-      'like' satisfies NotificationReason,
+      'like' satisfies AppBskyNotificationListNotifications.Notification['reason'],
       {
         name: _(msg`Likes`),
         importance: Notifications.AndroidImportance.HIGH,
       },
     )
     Notifications.setNotificationChannelAsync(
-      'repost' satisfies NotificationReason,
+      'repost' satisfies AppBskyNotificationListNotifications.Notification['reason'],
       {
         name: _(msg`Reposts`),
         importance: Notifications.AndroidImportance.HIGH,
       },
     )
     Notifications.setNotificationChannelAsync(
-      'reply' satisfies NotificationReason,
+      'reply' satisfies AppBskyNotificationListNotifications.Notification['reason'],
       {
         name: _(msg`Replies`),
         importance: Notifications.AndroidImportance.HIGH,
       },
     )
     Notifications.setNotificationChannelAsync(
-      'mention' satisfies NotificationReason,
+      'mention' satisfies AppBskyNotificationListNotifications.Notification['reason'],
       {
         name: _(msg`Mentions`),
         importance: Notifications.AndroidImportance.HIGH,
       },
     )
     Notifications.setNotificationChannelAsync(
-      'quote' satisfies NotificationReason,
+      'quote' satisfies AppBskyNotificationListNotifications.Notification['reason'],
       {
         name: _(msg`Quotes`),
         importance: Notifications.AndroidImportance.HIGH,
       },
     )
     Notifications.setNotificationChannelAsync(
-      'follow' satisfies NotificationReason,
+      'follow' satisfies AppBskyNotificationListNotifications.Notification['reason'],
       {
         name: _(msg`New followers`),
         importance: Notifications.AndroidImportance.HIGH,
       },
     )
     Notifications.setNotificationChannelAsync(
-      'like-via-repost' satisfies NotificationReason,
+      'like-via-repost' satisfies AppBskyNotificationListNotifications.Notification['reason'],
       {
         name: _(msg`Likes of your reposts`),
         importance: Notifications.AndroidImportance.HIGH,
       },
     )
     Notifications.setNotificationChannelAsync(
-      'repost-via-repost' satisfies NotificationReason,
+      'repost-via-repost' satisfies AppBskyNotificationListNotifications.Notification['reason'],
       {
         name: _(msg`Reposts of your reposts`),
         importance: Notifications.AndroidImportance.HIGH,
       },
     )
     Notifications.setNotificationChannelAsync(
-      'subscribed-post' satisfies NotificationReason,
+      'subscribed-post' satisfies AppBskyNotificationListNotifications.Notification['reason'],
       {
-        name: _(msg`Activity from others`),
+        name: _(msg`New posts from subscriptions`),
         importance: Notifications.AndroidImportance.HIGH,
       },
     )
@@ -190,17 +176,9 @@ export function useNotificationsHandler() {
       if (!payload) return
 
       if (payload.reason === 'chat-message') {
-        notyLogger.debug(`useNotificationsHandler: handling chat message`, {
-          payload,
-        })
-
-        if (
-          payload.recipientDid !== currentAccount?.did &&
-          !storedAccountSwitchPayload
-        ) {
-          storePayloadForAccountSwitch(payload)
+        if (payload.recipientDid !== currentAccount?.did && !storedPayload) {
+          storedPayload = payload
           closeAllActiveElements()
-
           const account = accounts.find(a => a.did === payload.recipientDid)
           if (account) {
             onPressSwitchAccount(account, 'Notification')
@@ -242,30 +220,60 @@ export function useNotificationsHandler() {
           })
         }
       } else {
-        const url = notificationToURL(payload)
-
-        if (url === '/notifications') {
-          resetToTab('NotificationsTab')
-        } else if (url) {
-          const [screen, params] = router.matchPath(url)
-          // @ts-expect-error router is not typed :/ -sfn
-          navigation.navigate('HomeTab', {screen, params})
-          notyLogger.debug(`useNotificationsHandler: navigate`, {
-            screen,
-            params,
-          })
+        switch (payload.reason) {
+          case 'like':
+          case 'repost':
+          case 'follow':
+          case 'mention':
+          case 'quote':
+          case 'reply':
+          case 'starterpack-joined':
+            resetToTab('NotificationsTab')
+            break
+          // TODO implement these after we have an idea of how to handle each individual case
+          // case 'follow':
+          //   const uri = new AtUri(payload.uri)
+          //   setTimeout(() => {
+          //     // @ts-expect-error types are weird here
+          //     navigation.navigate('HomeTab', {
+          //       screen: 'Profile',
+          //       params: {
+          //         name: uri.host,
+          //       },
+          //     })
+          //   }, 500)
+          //   break
+          // case 'mention':
+          // case 'reply':
+          //   const urip = new AtUri(payload.uri)
+          //   setTimeout(() => {
+          //     // @ts-expect-error types are weird here
+          //     navigation.navigate('HomeTab', {
+          //       screen: 'PostThread',
+          //       params: {
+          //         name: urip.host,
+          //         rkey: urip.rkey,
+          //       },
+          //     })
+          //   }, 500)
         }
       }
     }
-
     Notifications.setNotificationHandler({
       handleNotification: async e => {
-        const payload = getNotificationPayload(e)
-
-        if (!payload) return DEFAULT_HANDLER_OPTIONS
-
-        notyLogger.debug('useNotificationsHandler: incoming', {e, payload})
-
+        if (
+          e.request.trigger == null ||
+          typeof e.request.trigger !== 'object' ||
+          !('type' in e.request.trigger) ||
+          e.request.trigger.type !== 'push'
+        ) {
+          return DEFAULT_HANDLER_OPTIONS
+        }
+        logger.debug('Notifications: received', {e})
+        const payload = e.request.trigger.payload as NotificationPayload
+        if (!payload) {
+          return DEFAULT_HANDLER_OPTIONS
+        }
         if (
           payload.reason === 'chat-message' &&
           payload.recipientDid === currentAccount?.did
@@ -278,42 +286,41 @@ export function useNotificationsHandler() {
             shouldSetBadge: false,
           } satisfies Notifications.NotificationBehavior
         }
-
         // Any notification other than a chat message should invalidate the unread page
         invalidateCachedUnreadPage()
         return DEFAULT_HANDLER_OPTIONS
       },
     })
-
     const responseReceivedListener =
       Notifications.addNotificationResponseReceivedListener(e => {
-        if (e.notification.date === lastHandledNotificationDateDedupe) return
-        lastHandledNotificationDateDedupe = e.notification.date
-
-        notyLogger.debug('useNotificationsHandler: response received', {
-          actionIdentifier: e.actionIdentifier,
-        })
-
-        if (e.actionIdentifier !== Notifications.DEFAULT_ACTION_IDENTIFIER) {
+        if (e.notification.date === prevDate) {
           return
         }
-
-        const payload = getNotificationPayload(e.notification)
-
-        if (payload) {
-          notyLogger.debug(
+        prevDate = e.notification.date
+        logger.debug('Notifications: response received', {
+          actionIdentifier: e.actionIdentifier,
+        })
+        if (
+          e.actionIdentifier === Notifications.DEFAULT_ACTION_IDENTIFIER &&
+          e.notification.request.trigger != null &&
+          typeof e.notification.request.trigger === 'object' &&
+          'type' in e.notification.request.trigger &&
+          e.notification.request.trigger.type === 'push'
+        ) {
+          const payload = e.notification.request.trigger
+            .payload as NotificationPayload
+          if (!payload) return
+          logger.debug(
             'User pressed a notification, opening notifications tab',
             {},
           )
-          notyLogger.metric(
+          logger.metric(
             'notifications:openApp',
-            {reason: payload.reason, causedBoot: false},
+            {reason: payload.reason},
             {statsig: false},
           )
-
           invalidateCachedUnreadPage()
           truncateAndInvalidate(queryClient, RQKEY_NOTIFS('all'))
-
           if (
             payload.reason === 'mention' ||
             payload.reason === 'quote' ||
@@ -321,31 +328,23 @@ export function useNotificationsHandler() {
           ) {
             truncateAndInvalidate(queryClient, RQKEY_NOTIFS('mentions'))
           }
-
-          notyLogger.debug('Notifications: handleNotification', {
+          logger.debug('Notifications: handleNotification', {
             content: e.notification.request.content,
-            payload: payload,
+            payload: e.notification.request.trigger.payload,
           })
-
           handleNotification(payload)
           Notifications.dismissAllNotificationsAsync()
-        } else {
-          notyLogger.error('useNotificationsHandler: received no payload', {
-            identifier: e.notification.request.identifier,
-          })
         }
       })
-
     // Whenever there's a stored payload, that means we had to switch accounts before handling the notification.
     // Whenever currentAccount changes, we should try to handle it again.
     if (
-      storedAccountSwitchPayload?.reason === 'chat-message' &&
-      currentAccount?.did === storedAccountSwitchPayload.recipientDid
+      storedPayload?.reason === 'chat-message' &&
+      currentAccount?.did === storedPayload.recipientDid
     ) {
-      handleNotification(storedAccountSwitchPayload)
-      storedAccountSwitchPayload = undefined
+      handleNotification(storedPayload)
+      storedPayload = undefined
     }
-
     return () => {
       responseReceivedListener.remove()
     }
@@ -360,78 +359,4 @@ export function useNotificationsHandler() {
     onPressSwitchAccount,
     setShowLoggedOut,
   ])
-}
-
-export function storePayloadForAccountSwitch(payload: NotificationPayload) {
-  storedAccountSwitchPayload = payload
-}
-
-export function getNotificationPayload(
-  e: Notifications.Notification,
-): NotificationPayload | null {
-  if (
-    e.request.trigger == null ||
-    typeof e.request.trigger !== 'object' ||
-    !('type' in e.request.trigger) ||
-    e.request.trigger.type !== 'push'
-  ) {
-    return null
-  }
-
-  const payload = (
-    isIOS ? e.request.trigger.payload : e.request.content.data
-  ) as NotificationPayload
-
-  if (payload && payload.reason) {
-    return payload
-  } else {
-    if (payload) {
-      notyLogger.debug('getNotificationPayload: received unknown payload', {
-        payload,
-        identifier: e.request.identifier,
-      })
-    }
-    return null
-  }
-}
-
-export function notificationToURL(payload: NotificationPayload): string | null {
-  switch (payload?.reason) {
-    case 'like':
-    case 'repost':
-    case 'like-via-repost':
-    case 'repost-via-repost': {
-      const urip = new AtUri(payload.subject)
-      if (urip.collection === 'app.bsky.feed.post') {
-        return `/profile/${urip.host}/post/${urip.rkey}`
-      } else {
-        return '/notifications'
-      }
-    }
-    case 'reply':
-    case 'quote':
-    case 'mention':
-    case 'subscribed-post': {
-      const urip = new AtUri(payload.uri)
-      if (urip.collection === 'app.bsky.feed.post') {
-        return `/profile/${urip.host}/post/${urip.rkey}`
-      } else {
-        return '/notifications'
-      }
-    }
-    case 'follow':
-    case 'starterpack-joined': {
-      const urip = new AtUri(payload.uri)
-      return `/profile/${urip.host}`
-    }
-    case 'chat-message':
-      // should be handled separately
-      return null
-    case 'verified':
-    case 'unverified':
-      return '/notifications'
-    default:
-      // do nothing if we don't know what to do with it
-      return null
-  }
 }


### PR DESCRIPTION
A few changes to get Android notification channels working properly.

1. Your mutateWithOtherReason function in Kotlin prepares to assign a channel ID for "subscribed-post", but you never create this channel in your React Native code. If a notification with this reason is received, Android may use a default channel, which won't have the name or settings you desire.

2. In your chat channel definitions, you have a duplicate name property. This isn't a critical bug, as the last one defined will be used, but it's good practice to remove the redundant code.