### PR TITLE
Auto-select search results tab

### DIFF
--- a/src/lib/routes/types.ts
+++ b/src/lib/routes/types.ts
@@ -67,7 +67,7 @@ export type CommonNavigatorParams = {
   InterestsSettings: undefined
   AboutSettings: undefined
   AppIconSettings: undefined
-  Search: {q?: string}
+  Search: {q?: string; tab?: 'user' | 'profile' | 'feed'}
   Hashtag: {tag: string; author?: string}
   Topic: {topic: string}
   MessagesConversation: {conversation: string; embed?: string; accept?: true}
@@ -102,7 +102,7 @@ export type HomeTabNavigatorParams = CommonNavigatorParams & {
 }
 
 export type SearchTabNavigatorParams = CommonNavigatorParams & {
-  Search: {q?: string}
+  Search: {q?: string; tab?: 'user' | 'profile' | 'feed'}
 }
 
 export type NotificationsTabNavigatorParams = CommonNavigatorParams & {
@@ -119,7 +119,7 @@ export type MessagesTabNavigatorParams = CommonNavigatorParams & {
 
 export type FlatNavigatorParams = CommonNavigatorParams & {
   Home: undefined
-  Search: {q?: string}
+  Search: {q?: string; tab?: 'user' | 'profile' | 'feed'}
   Feeds: undefined
   Notifications: undefined
   Messages: {pushToConversation?: string; animation?: 'push' | 'pop'}
@@ -129,7 +129,7 @@ export type AllNavigatorParams = CommonNavigatorParams & {
   HomeTab: undefined
   Home: undefined
   SearchTab: undefined
-  Search: {q?: string}
+  Search: {q?: string; tab?: 'user' | 'profile' | 'feed'}
   Feeds: undefined
   NotificationsTab: undefined
   Notifications: undefined

--- a/src/screens/Search/Explore.tsx
+++ b/src/screens/Search/Explore.tsx
@@ -726,7 +726,12 @@ export function Explore({
                 <ModuleHeader.SearchButton
                   {...item.searchButton}
                   onPress={() =>
-                    focusSearchInput(item.searchButton?.tab || 'user')
+                    focusSearchInput(
+                      (item.searchButton?.tab || 'user') as
+                        | 'user'
+                        | 'profile'
+                        | 'feed',
+                    )
                   }
                 />
               )}
@@ -743,7 +748,12 @@ export function Explore({
                   <ModuleHeader.SearchButton
                     {...item.searchButton}
                     onPress={() =>
-                      focusSearchInput(item.searchButton?.tab || 'user')
+                      focusSearchInput(
+                        (item.searchButton?.tab || 'user') as
+                          | 'user'
+                          | 'profile'
+                          | 'feed',
+                      )
                     }
                   />
                 )}

--- a/src/screens/Search/SearchResults.tsx
+++ b/src/screens/Search/SearchResults.tsx
@@ -30,12 +30,14 @@ let SearchResults = ({
   activeTab,
   onPageSelected,
   headerHeight,
+  initialPage = 0,
 }: {
   query: string
   queryWithParams: string
   activeTab: number
   onPageSelected: (page: number) => void
   headerHeight: number
+  initialPage?: number
 }): React.ReactNode => {
   const {_} = useLingui()
 
@@ -89,7 +91,7 @@ let SearchResults = ({
           <TabBar items={sections.map(section => section.title)} {...props} />
         </Layout.Center>
       )}
-      initialPage={0}>
+      initialPage={initialPage}>
       {sections.map((section, i) => (
         <View key={i}>{section.component}</View>
       ))}


### PR DESCRIPTION
When the user clicks the search button next to "Discover New Feeds" or "Suggested Accounts" on the Explore page, we'll auto-select the respective search results tab (feeds or users).