### PR TITLE
fix: show both DisplayName and Handle in google structured data (or only Handle if DisplayName not set)

### DIFF
--- a/bskyweb/templates/post.html
+++ b/bskyweb/templates/post.html
@@ -63,7 +63,8 @@
       "author": {
         "@type": "Person",
         {%- if postView.Author.DisplayName %}
-        "name": "{{ postView.Author.DisplayName }} (@{{ postView.Author.Handle }})",
+        "name": "{{ postView.Author.DisplayName }}",
+        "alternateName": "@{{ postView.Author.Handle }}",
         {% else %}
         "name": "@{{ postView.Author.Handle }}",
         {% endif -%}

--- a/bskyweb/templates/profile.html
+++ b/bskyweb/templates/profile.html
@@ -59,12 +59,12 @@
     "dateCreated": "{{ profileView.CreatedAt }}",
     "mainEntity": {
       "@type": "Person",
-      {%- if postView.Author.DisplayName %}
-      "name": "{{ postView.Author.DisplayName }} (@{{ postView.Author.Handle }})",
-      {% else %}
-      "name": "@{{ postView.Author.Handle }}",
-      {% endif -%}
+      {%- if profileView.DisplayName %}
+      "name": "{{ profileView.DisplayName }}",
       "alternateName": "@{{ profileView.Handle }}",
+      {% else %}
+      "name": "@{{ profileView.Handle }}",
+      {% endif -%}
       "identifier": "{{ profileView.Did }}",
       "description": "{{ profileView.Description }}",
       "image": "{{ profileView.Avatar }}",


### PR DESCRIPTION
This fixes invalid structured data being generated when `DisplayName` is not set, and makes post.html and profile.html consistent.

If `DisplayName` is set, `name` will be `DisplayName` and `alternateName` will be `Handle`. Otherwise, `name` will be `Handle`.

[with DisplayName](https://search.google.com/test/rich-results/result?id=vdxiiCo8rBpDErpY-yoy1g)
[without DisplayName](https://search.google.com/test/rich-results/result?id=F9tjkJygq4nsQDqPUznEzw)