### PR TITLE
Fix hider alignment in thread

### DIFF
--- a/src/components/moderation/PostHider.tsx
+++ b/src/components/moderation/PostHider.tsx
@@ -34,6 +34,7 @@ interface Props extends ComponentProps<typeof Link> {
   modui: ModerationUI
   profile: AppBskyActorDefs.ProfileViewBasic
   interpretFilterAsBlur?: boolean
+  hiderStyle?: StyleProp<ViewStyle>
 }
 
 export function PostHider({
@@ -42,6 +43,7 @@ export function PostHider({
   disabled,
   modui,
   style,
+  hiderStyle,
   children,
   iconSize,
   iconStyles,
@@ -100,6 +102,7 @@ export function PostHider({
         },
         override ? {paddingBottom: 0} : undefined,
         t.atoms.bg,
+        hiderStyle,
       ]}>
       <ModerationDetailsDialog control={control} modcause={blur} />
       <Pressable

--- a/src/screens/PostThread/components/ThreadItemPost.tsx
+++ b/src/screens/PostThread/components/ThreadItemPost.tsx
@@ -132,9 +132,7 @@ const ThreadItemPostOuterWrapper = memo(function ThreadItemPostOuterWrapper({
     <View
       style={[
         showTopBorder && [a.border_t, t.atoms.border_contrast_low],
-        {
-          paddingHorizontal: OUTER_SPACE,
-        },
+        {paddingHorizontal: OUTER_SPACE},
         // If there's no next child, add a little padding to bottom
         !item.ui.showChildReplyLine &&
           !item.ui.precedesChildReadMore && {
@@ -255,8 +253,9 @@ const ThreadItemPostInner = memo(function ThreadItemPostInner({
           href={postHref}
           disabled={overrides?.moderation === true}
           modui={moderation.ui('contentList')}
+          hiderStyle={[a.pl_0, a.pr_2xs, a.bg_transparent]}
           iconSize={LINEAR_AVI_WIDTH}
-          iconStyles={{marginLeft: 2, marginRight: 2}}
+          iconStyles={[a.mr_xs]}
           profile={post.author}
           interpretFilterAsBlur>
           <ThreadItemPostParentReplyLine item={item} />


### PR DESCRIPTION
I tried to limit the change to *just* the hider in the thread screen, other places should be unaffected

<table>
  <thead>
    <tr>
      <th>Before</th>
      <th>After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><img width="300" src="https://github.com/user-attachments/assets/a5f26f6a-cb67-45de-936a-98349a29a30e" /></td>
      <td><img width="300" src="https://github.com/user-attachments/assets/c1ce204e-1fc3-41fd-a0a4-d5b21e7b2514" /></td>
    </tr>
  </tbody>
</table>
