### PR TITLE
Fix language prompt text wrap issue

### DIFF
--- a/src/view/com/composer/select-language/SuggestedLanguage.tsx
+++ b/src/view/com/composer/select-language/SuggestedLanguage.tsx
@@ -162,7 +162,6 @@ function LanguageSuggestionButton({
         <View style={[a.flex_1]}>
           <Text
             style={[
-              a.flex_1,
               a.leading_snug,
               {
                 maxWidth: 400,


### PR DESCRIPTION
Lowkey dislike the copy here but at least it's not broken anymore

<table>
  <thead>
    <tr>
      <th>Before</th>
      <th>After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><img width="300" src="https://github.com/user-attachments/assets/463966f6-dd99-436c-b0ac-eb7eeacc3f38" /></td>
      <td><img width="300" src="https://github.com/user-attachments/assets/27f37698-0c90-4a82-8f00-fb574faaf67d" /></td>
    </tr>
  </tbody>
</table>