### PR TITLE
Change thread post text size to `lg` from `xl`

### DIFF
--- a/src/screens/PostThread/components/ThreadItemAnchor.tsx
+++ b/src/screens/PostThread/components/ThreadItemAnchor.tsx
@@ -391,7 +391,7 @@ const ThreadItemAnchorInner = memo(function ThreadItemAnchorInner({
                 enableTags
                 selectable
                 value={richText}
-                style={[a.flex_1, a.text_xl]}
+                style={[a.flex_1, a.text_lg]}
                 authorHandle={post.author.handle}
                 shouldProxyLinks={true}
               />


### PR DESCRIPTION
Its too big

<table>
  <thead>
    <tr>
      <th>Before</th>
      <th>After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><img width="300" src="https://github.com/user-attachments/assets/030474b0-e66d-4cae-84cf-17d989d353e0" /></td>
      <td><img width="300" src="https://github.com/user-attachments/assets/42a7339b-339b-485c-9563-10ba97bfa28d" /></td>
    </tr>
  </tbody>
</table>
<table>
  <thead>
    <tr>
      <th>Before</th>
      <th>After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><img width="300" src="https://github.com/user-attachments/assets/258604b8-ce4e-49dd-a516-525423523d97" /></td>
      <td><img width="300" src="https://github.com/user-attachments/assets/8c63a958-cebc-4a99-a771-3e10d8f01304" /></td>
    </tr>
  </tbody>
</table>