### PR TITLE
Fix ternary in moderation settings that caused a double title

### DIFF
--- a/src/screens/Moderation/index.tsx
+++ b/src/screens/Moderation/index.tsx
@@ -328,19 +328,21 @@ export function ModerationScreenInner({
         </Link>
       </View>
 
-      {declaredAge === undefined && (
-        <>
-          <Text
-            style={[
-              a.pt_2xl,
-              a.pb_md,
-              a.text_md,
-              a.font_semi_bold,
-              t.atoms.text_contrast_high,
-            ]}>
-            <Trans>Content filters</Trans>
-          </Text>
+      {(!isDeclaredUnderage || declaredAge === undefined) && (
+        <Text
+          style={[
+            a.pt_2xl,
+            a.pb_md,
+            a.text_md,
+            a.font_semi_bold,
+            t.atoms.text_contrast_high,
+          ]}>
+          <Trans>Content filters</Trans>
+        </Text>
+      )}
 
+      {declaredAge === undefined ? (
+        <>
           <Button
             label={_(msg`Confirm your birthdate`)}
             size="small"
@@ -360,21 +362,8 @@ export function ModerationScreenInner({
 
           <BirthDateSettingsDialog control={birthdateDialogControl} />
         </>
-      )}
-
-      {!isDeclaredUnderage && (
+      ) : !isDeclaredUnderage ? (
         <>
-          <Text
-            style={[
-              a.pt_2xl,
-              a.pb_md,
-              a.text_md,
-              a.font_semi_bold,
-              t.atoms.text_contrast_high,
-            ]}>
-            <Trans>Content filters</Trans>
-          </Text>
-
           <AgeAssuranceAdmonition style={[a.pb_md]}>
             <Trans>
               You must complete age assurance in order to access the settings
@@ -466,7 +455,7 @@ export function ModerationScreenInner({
             </View>
           </View>
         </>
-      )}
+      ) : null}
 
       <Text
         style={[


### PR DESCRIPTION
We've tweaked this a couple times and missed an obvious edge case: users with no birthdate set will see a double `Content filters` title.

The logic is:
- if not `isDeclaredUnderage` or we don't have a bday at all, show the title
  - else, no title, and no Content Filter settings
- if declared underage, show "Confirm your bday" button
  - else if not `isDeclaredUnderage`, show settings
  - else `null`

This PR just copies the UI into new ternary logic. No other changes.

You can test this by manually setting `userAge` in `queries/preferences/index.ts` to `undefined` or passing in an arbitrary date like `getAge(new Date('2010-01-01'))` to test the states.