### PR TITLE
Patch fractional font size issue

### DIFF
--- a/patches/react-native-uitextview+1.4.0.patch
+++ b/patches/react-native-uitextview+1.4.0.patch
@@ -1,0 +1,33 @@
+diff --git a/node_modules/react-native-uitextview/ios/RNUITextViewShadow.swift b/node_modules/react-native-uitextview/ios/RNUITextViewShadow.swift
+index c34ba71..13d576a 100644
+--- a/node_modules/react-native-uitextview/ios/RNUITextViewShadow.swift
++++ b/node_modules/react-native-uitextview/ios/RNUITextViewShadow.swift
+@@ -159,13 +159,23 @@ class RNUITextViewShadow: RCTShadowView {
+     let maxSize = CGSize(width: CGFloat(maxWidth), height: CGFloat(MAXFLOAT))
+     let textSize = self.attributedText.boundingRect(with: maxSize, options: .usesLineFragmentOrigin, context: nil)
+     
+-    var totalLines = self.lineHeight == 0.0 ? 0 : Int(ceil(textSize.height / self.lineHeight))
+-
+-    if self.numberOfLines != 0, totalLines > self.numberOfLines {
+-      totalLines = self.numberOfLines
++    var finalHeight: CGFloat
++
++    if self.numberOfLines != 0 && self.lineHeight != 0.0 {
++      // numberOfLines is set with custom line height - need to calculate lines and snap to lineHeight multiples
++      // NOTE: this calculation can be inaccurate with fractional font sizes
++      var totalLines = Int(ceil(textSize.height / self.lineHeight))
++      if totalLines > self.numberOfLines {
++        totalLines = self.numberOfLines
++      }
++      finalHeight = CGFloat(totalLines) * self.lineHeight
++    } else {
++      // Either no numberOfLines limit, or no custom lineHeight - use actual text height
++      // (numberOfLines without custom lineHeight is handled by the UITextView's textContainer.maximumNumberOfLines)
++      finalHeight = textSize.height
+     }
+ 
+-    self.frameSize = CGSize(width: CGFloat(maxWidth), height: CGFloat(CGFloat(totalLines) * self.lineHeight))
++    self.frameSize = CGSize(width: CGFloat(maxWidth), height: finalHeight)
+     return YGSize(width: Float(self.frameSize.width), height: Float(self.frameSize.height))
+   }
+ 


### PR DESCRIPTION
Patch of https://github.com/bluesky-social/react-native-uitextview/pull/39

<table>
  <thead>
    <tr>
      <th>Before</th>
      <th>After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><img width="300" src="https://github.com/user-attachments/assets/d9e589bf-00b3-41d0-98e5-cc16fa330547" /></td>
      <td><img width="300" src="https://github.com/user-attachments/assets/eab1ee48-d81e-4a61-8e78-6610146d7c6e" /></td>
    </tr>
  </tbody>
</table>


uitextview pr description below:

---

Certain fractional font sizes cause the calculation where we estimate the number of lines to be off, causing a phantom extra line.

This code path is really only needed for when the `numberOfLines` prop is set along with a custom line height. This PR just skips this codepath where possible - thus the bug remains when `numberOfLines` is set, but fixes the common case.

<table>
  <thead>
    <tr>
      <th>Before</th>
      <th>After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><img width="300" src="https://github.com/user-attachments/assets/a6914551-cadf-4897-a0db-b41691ee736e" /></td>
      <td><img width="300" src="https://github.com/user-attachments/assets/f1af5ab1-283f-451f-bc29-55d1307ee584" /></td>
    </tr>
  </tbody>
</table>