### PR TITLE
Fix lightbox animation snapping

### DIFF
--- a/src/view/com/lightbox/ImageViewing/index.tsx
+++ b/src/view/com/lightbox/ImageViewing/index.tsx
@@ -61,13 +61,13 @@ const SLOW_SPRING: WithSpringConfig = {
   mass: isIOS ? 1.25 : 0.75,
   damping: 300,
   stiffness: 800,
-  restDisplacementThreshold: 0.01,
+  restDisplacementThreshold: 0.001,
 }
 const FAST_SPRING: WithSpringConfig = {
   mass: isIOS ? 1.25 : 0.75,
   damping: 150,
   stiffness: 900,
-  restDisplacementThreshold: 0.01,
+  restDisplacementThreshold: 0.001,
 }
 
 function canAnimate(lightbox: Lightbox): boolean {


### PR DESCRIPTION
You can see at the end of the lightbox animation the animation "snaps" into it's final position a little early

https://github.com/user-attachments/assets/0275d6f0-2811-46fe-bb9d-6445606a3d3a

We can fix this by specifying a smaller `restDisplacementThreshold`. This is smaller than the default value, but I don't think this will be an issue because this spring animation is very damped, so there's no danger of it oscillating around 0 (which this is designed to catch)

https://github.com/user-attachments/assets/d1002ed2-4ad2-4393-8428-100d8ed6368e

