### PR TITLE
Composer photos - make sure border radius matches inset border

### DIFF
--- a/src/view/com/composer/photos/Gallery.tsx
+++ b/src/view/com/composer/photos/Gallery.tsx
@@ -19,7 +19,7 @@ import {colors, s} from '#/lib/styles'
 import {isNative} from '#/platform/detection'
 import {type ComposerImage, cropImage} from '#/state/gallery'
 import {Text} from '#/view/com/util/text/Text'
-import {useTheme} from '#/alf'
+import {tokens, useTheme} from '#/alf'
 import * as Dialog from '#/components/Dialog'
 import {MediaInsetBorder} from '#/components/MediaInsetBorder'
 import {type PostAction} from '../state/composer'
@@ -275,12 +275,12 @@ const styles = StyleSheet.create({
   },
   image: {
     resizeMode: 'cover',
-    borderRadius: 8,
+    borderRadius: tokens.borderRadius.md,
   },
   imageControl: {
     width: 24,
     height: 24,
-    borderRadius: 12,
+    borderRadius: tokens.borderRadius.md,
     backgroundColor: 'rgba(0, 0, 0, 0.75)',
     alignItems: 'center',
     justifyContent: 'center',


### PR DESCRIPTION
<table>
  <thead>
    <tr>
      <th>Before</th>
      <th>After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><img width="300" src="https://github.com/user-attachments/assets/8680bfe7-3c91-40ae-9c4f-960ea68e8420" /></td>
      <td><img width="300" src="https://github.com/user-attachments/assets/2524828a-5c1f-4556-b67a-f9e976f08ae3" /></td>
    </tr>
  </tbody>
</table>