### PR TITLE
Delay toast after posting

### DIFF
--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -564,31 +564,33 @@ export const ComposePost = ({
       onPostSuccess?.(postSuccessData)
     }
     onClose()
-    Toast.show(
-      <Toast.Outer>
-        <Toast.Icon />
-        <Toast.Text>
-          {thread.posts.length > 1
-            ? _(msg`Your posts were sent`)
-            : replyTo
-              ? _(msg`Your reply was sent`)
-              : _(msg`Your post was sent`)}
-        </Toast.Text>
-        {postUri && (
-          <Toast.Action
-            label={_(msg`View post`)}
-            onPress={() => {
-              const {host: name, rkey} = new AtUri(postUri)
-              navigation.navigate('PostThread', {name, rkey})
-            }}>
-            <Trans context="Action to view the post the user just created">
-              View
-            </Trans>
-          </Toast.Action>
-        )}
-      </Toast.Outer>,
-      {type: 'success'},
-    )
+    setTimeout(() => {
+      Toast.show(
+        <Toast.Outer>
+          <Toast.Icon />
+          <Toast.Text>
+            {thread.posts.length > 1
+              ? _(msg`Your posts were sent`)
+              : replyTo
+                ? _(msg`Your reply was sent`)
+                : _(msg`Your post was sent`)}
+          </Toast.Text>
+          {postUri && (
+            <Toast.Action
+              label={_(msg`View post`)}
+              onPress={() => {
+                const {host: name, rkey} = new AtUri(postUri)
+                navigation.navigate('PostThread', {name, rkey})
+              }}>
+              <Trans context="Action to view the post the user just created">
+                View
+              </Trans>
+            </Toast.Action>
+          )}
+        </Toast.Outer>,
+        {type: 'success'},
+      )
+    }, 500)
   }, [
     _,
     agent,


### PR DESCRIPTION
We have a rare crash issue after posting. I cannot repro but my main suspect is the toast. I can't say for sure but I have a hunch that it's due to the modal closing and the toast presenting at the same time. Dumb fix: delay the toast by 500ms. it actually looks a little neater:

https://github.com/user-attachments/assets/d3b36a46-5b20-442c-8daa-b899c406a464

