### PR TITLE
Avoid unintended/unnecessary zooms due to font size on mobile web

### DIFF
--- a/src/components/forms/TextField.tsx
+++ b/src/components/forms/TextField.tsx
@@ -21,6 +21,8 @@ import {
   useTheme,
   web,
 } from '#/alf'
+import {normalizeTextStyles} from '#/alf/typography'
+import {isMobileWeb} from '#/platform/detection'
 import {useInteractionState} from '#/components/hooks/useInteractionState'
 import {type Props as SVGIconProps} from '#/components/icons/common'
 import {Text} from '#/components/Typography'
@@ -181,7 +183,7 @@ export function createInput(Component: typeof TextInput) {
 
     const refs = mergeRefs([ctx.inputRef, inputRef!].filter(Boolean))
 
-    const flattened = StyleSheet.flatten([
+    const flattened = normalizeTextStyles([
       a.relative,
       a.z_20,
       a.flex_1,
@@ -205,19 +207,11 @@ export function createInput(Component: typeof TextInput) {
         marginBottom: 2,
       }),
       style,
-    ])
-
-    applyFonts(flattened, fonts.family)
-
-    // should always be defined on `typography`
-    // @ts-ignore
-    if (flattened.fontSize) {
-      // @ts-ignore
-      flattened.fontSize = Math.round(
-        // @ts-ignore
-        flattened.fontSize * fonts.scaleMultiplier,
-      )
-    }
+    ], {
+      fontScale: isMobileWeb ? 1 : fonts.scaleMultiplier,
+      fontFamily: fonts.family,
+      flags: {},
+    })
 
     return (
       <>


### PR DESCRIPTION
fixes https://github.com/bluesky-social/social-app/issues/8494

On iOS, text inputs with a <16px font-size trigger an automatic zoom when focused. This requires manually zooming back out each time, which impedes the flow of using the site. (Cuts off text, images, etc.) 

This PR bumps the font-size from 15px->16px for mobile web only.

**demo:** 

### Before: 
https://github.com/user-attachments/assets/47deef78-883c-4161-ba4d-56c7326c9a79

### After:
https://github.com/user-attachments/assets/a4aa6c53-c9af-4421-9a31-38f608b389b9

Note: It's not in the example vid, but it also happens occasionally with auth inputs, which makes zooming out the first action you have to do after logging in.