### PR TITLE
fix(composer): preserve selected assets order on image selection

### DIFF
--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -1405,9 +1405,7 @@ function ComposerFooter({
 
       if (assets.length) {
         if (type === 'image') {
-          const images: ComposerImage[] = []
-
-          await Promise.all(
+          const images: ComposerImage[] = await Promise.allSettled(
             assets.map(async image => {
               const composerImage = await createComposerImage({
                 path: image.uri,
@@ -1415,13 +1413,18 @@ function ComposerFooter({
                 height: image.height,
                 mime: image.mimeType!,
               })
-              images.push(composerImage)
+              return composerImage
             }),
-          ).catch(e => {
-            logger.error(`createComposerImage failed`, {
-              safeMessage: e.message,
-            })
-          })
+          ).then(res =>
+            res
+              .map<ComposerImage | undefined>(result => {
+                if (result.status === 'fulfilled') return result.value
+                logger.error(`createComposerImage failed`, {
+                  safeMessage: result.reason.message,
+                })
+              })
+              .filter((img): img is ComposerImage => img != null),
+          )
 
           onImageAdd(images)
         } else if (type === 'video') {


### PR DESCRIPTION
# Summary
Preserve original assets order when selecting images for the composer so the order of selected photos is retained when attaching multiple images to a post.
Japan has many users who post manga with storylines. For them, disrupting the sequence is a critical issue.
# Example
When attaching multiple photos in the following order,
<img width="1072" height="280" alt="image" src="https://github.com/user-attachments/assets/bbbe7454-22c0-483c-82e7-af5d0aff0529" />
In this way, the order may become disrupted.
<img width="1192" height="844" alt="image" src="https://github.com/user-attachments/assets/9472f38f-f8e1-426d-b90f-1927e6a45184" />
# Cause of the problem
## Problem code
```TS
const images: ComposerImage[] = []

await Promise.all(
  assets.map(async image => {
    const composerImage = await createComposerImage({
      path: image.uri,
      width: image.width,
      height: image.height,
      mime: image.mimeType!,
    })
    images.push(composerImage)
  }),
).catch(e => {
  logger.error(`createComposerImage failed`, {
    safeMessage: e.message,
  })
})
```
Concurrent pushes into a shared array cause a race condition that breaks the selected assets order.
## Fixed code
```TS
const images: ComposerImage[] = await Promise.allSettled(
  assets.map(async image => {
    const composerImage = await createComposerImage({
      path: image.uri,
      width: image.width,
      height: image.height,
      mime: image.mimeType!,
    })
    return composerImage
  }),
).then(res =>
  res
    .map<ComposerImage | undefined>(result => {
      if (result.status === 'fulfilled') return result.value
      logger.error(`createComposerImage failed`, {
        safeMessage: result.reason.message,
      })
    })
    .filter((img): img is ComposerImage => img != null),
)
```
It preserves the original assets order while keeping image processing concurrent (no serialization added).
# Environment
- Mac, Chrome
- Windows, Chrome, 1.108.0