### PR TITLE
Add data-at-uri attributes for identifying posts and profiles on pages

### DIFF
--- a/src/screens/PostThread/components/ThreadItemAnchor.tsx
+++ b/src/screens/PostThread/components/ThreadItemAnchor.tsx
@@ -306,6 +306,7 @@ const ThreadItemAnchorInner = memo(function ThreadItemAnchorInner({
       <ThreadItemAnchorParentReplyLine isRoot={isRoot} />
 
       <View
+        dataSet={{'at-uri': post.uri}}
         testID={`postThreadItem-by-${post.author.handle}`}
         style={[
           {

--- a/src/screens/PostThread/components/ThreadItemPost.tsx
+++ b/src/screens/PostThread/components/ThreadItemPost.tsx
@@ -249,6 +249,7 @@ const ThreadItemPostInner = memo(function ThreadItemPostInner({
     <SubtleHoverWrapper>
       <ThreadItemPostOuterWrapper item={item} overrides={overrides}>
         <PostHider
+          dataSet={{'at-uri': post.uri}}
           testID={`postThreadItem-by-${post.author.handle}`}
           href={postHref}
           disabled={overrides?.moderation === true}

--- a/src/screens/PostThread/components/ThreadItemTreePost.tsx
+++ b/src/screens/PostThread/components/ThreadItemTreePost.tsx
@@ -312,6 +312,7 @@ const ThreadItemTreePostInner = memo(function ThreadItemTreePostInner({
     <ThreadItemTreePostOuterWrapper item={item}>
       <SubtleHoverWrapper>
         <PostHider
+          dataSet={{'at-uri': post.uri}}
           testID={`postThreadItem-by-${post.author.handle}`}
           href={postHref}
           disabled={overrides?.moderation === true}

--- a/src/screens/Profile/Header/Shell.tsx
+++ b/src/screens/Profile/Header/Shell.tsx
@@ -8,7 +8,11 @@ import Animated, {
   useAnimatedRef,
 } from 'react-native-reanimated'
 import {useSafeAreaInsets} from 'react-native-safe-area-context'
-import {type AppBskyActorDefs, type ModerationDecision} from '@atproto/api'
+import {
+  type AppBskyActorDefs,
+  AtUri,
+  type ModerationDecision,
+} from '@atproto/api'
 import {msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 import {useNavigation} from '@react-navigation/native'
@@ -63,6 +67,10 @@ let ProfileHeaderShell = ({
   const liveStatusControl = useDialogControl()
 
   const aviRef = useAnimatedRef()
+
+  const atUri = useMemo(() => {
+    return AtUri.make(profile.did).href
+  }, [profile.did])
 
   const onPressBack = useCallback(() => {
     if (navigation.canGoBack()) {
@@ -143,7 +151,10 @@ let ProfileHeaderShell = ({
   ])
 
   return (
-    <View style={t.atoms.bg} pointerEvents={isIOS ? 'auto' : 'box-none'}>
+    <View
+      style={t.atoms.bg}
+      pointerEvents={isIOS ? 'auto' : 'box-none'}
+      dataSet={{'at-uri': atUri}}>
       <View
         pointerEvents={isIOS ? 'auto' : 'box-none'}
         style={[a.relative, {height: 150}]}>

--- a/src/view/com/posts/PostFeedItem.tsx
+++ b/src/view/com/posts/PostFeedItem.tsx
@@ -168,9 +168,13 @@ let FeedItemInner = ({
 
   const [hover, setHover] = useState(false)
 
-  const [href, rkey] = useMemo(() => {
+  const [href, rkey, atUri] = useMemo(() => {
     const urip = new AtUri(post.uri)
-    return [makeProfileLink(post.author, 'post', urip.rkey), urip.rkey]
+    return [
+      makeProfileLink(post.author, 'post', urip.rkey),
+      urip.rkey,
+      urip.href,
+    ]
   }, [post.uri, post.author])
   const {sendInteraction, feedSourceInfo} = useFeedFeedbackContext()
 
@@ -296,7 +300,10 @@ let FeedItemInner = ({
       noFeedback
       accessible={false}
       onBeforePress={onBeforePress}
-      dataSet={{feedContext}}
+      dataSet={{
+        feedContext,
+        'at-uri': atUri,
+      }}
       onPointerEnter={() => {
         setHover(true)
       }}


### PR DESCRIPTION
This provides extensions the ability to find the relevant area of the page for a post or profile, allowing for extensions to add additional features to those elements.

My primary use-case is around adding community notes or other data associated with posts based on their `at://` URIs. For instance, an extension could do the following:

```ts
const rkey = window.location.pathname.split('/').at(-1)
const postNode = document.querySelector(`[data-at-uri$="/${rkey}"]`) 
```

And then the extension can use both the value of the `data-at-uri` via `postNode.dataset.atUri` and identify the area on page where an element may be anchored to.

The extension would need to probably handle re-renders of the subtree and navigation events, but it's possibly better than nothing & would enable third-party extensions to do interesting layered behavior on top of the existing experience.

It is perhaps a bit more complicated for profiles, since you'd need to do the handle to did resolution in order to know the `at://` URI to look for.