### PR TITLE
Make gifs square again

### DIFF
--- a/src/components/dialogs/GifSelect.tsx
+++ b/src/components/dialogs/GifSelect.tsx
@@ -300,7 +300,7 @@ export function GifPreview({
             a.flex_1,
             a.mb_sm,
             a.rounded_sm,
-            a.aspect_card,
+            a.aspect_square,
             {opacity: pressed ? 0.8 : 1},
             t.atoms.bg_contrast_25,
           ]}


### PR DESCRIPTION
I accidentally made them rectangles in #9171 

<img width="1170" height="2532" alt="image" src="https://github.com/user-attachments/assets/603e121b-9adb-4777-a1c3-3d5b4f50f7c6" />
