### PR TITLE
Maybe fix broken step in android testflight CI

### DIFF
--- a/.github/workflows/build-submit-android.yml
+++ b/.github/workflows/build-submit-android.yml
@@ -182,11 +182,11 @@ jobs:
       - name: ⬇️ Restore Cache
         id: get-base-commit
         uses: actions/cache@v4
-        if: ${{ inputs.profile == 'testflight' }}
+        if: ${{ inputs.profile == 'testflight-android' }}
         with:
           path: most-recent-testflight-commit.txt
           key: most-recent-testflight-commit
 
       - name: ✏️ Write commit hash to cache
-        if: ${{ inputs.profile == 'testflight' }}
+        if: ${{ inputs.profile == 'testflight-android' }}
         run: echo ${{ github.sha }} > most-recent-testflight-commit.txt


### PR DESCRIPTION
Noticed that part of the Android CI referenced the "testflight" profile, when it should probably be "testflight-android". Is this correct?