### PR TITLE
Push in post-post toast

### DIFF
--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -580,7 +580,7 @@ export const ComposePost = ({
               label={_(msg`View post`)}
               onPress={() => {
                 const {host: name, rkey} = new AtUri(postUri)
-                navigation.navigate('PostThread', {name, rkey})
+                navigation.push('PostThread', {name, rkey})
               }}>
               <Trans context="Action to view the post the user just created">
                 View


### PR DESCRIPTION
currently it uses `navigation.navigate`, so if you're already in *any* post thread screen, it will just replace the current params. we always want to push a new screen onto the stack