### PR TITLE
Fix right nav overflow

### DIFF
--- a/src/view/shell/desktop/Feeds.tsx
+++ b/src/view/shell/desktop/Feeds.tsx
@@ -27,13 +27,7 @@ export function DesktopFeeds() {
 
   if (isLoading) {
     return (
-      <View
-        style={[
-          {
-            gap: 10,
-            paddingVertical: 2,
-          },
-        ]}>
+      <View style={[{gap: 10}]}>
         {Array(5)
           .fill(0)
           .map((_, i) => (
@@ -60,6 +54,7 @@ export function DesktopFeeds() {
   return (
     <View
       style={[
+        a.flex_1,
         web({
           gap: 10,
           /*
@@ -89,6 +84,7 @@ export function DesktopFeeds() {
             style={[
               a.text_md,
               a.leading_snug,
+              a.flex_shrink_0,
               current
                 ? [a.font_semi_bold, t.atoms.text]
                 : [t.atoms.text_contrast_medium],

--- a/src/view/shell/desktop/RightNav.tsx
+++ b/src/view/shell/desktop/RightNav.tsx
@@ -79,8 +79,7 @@ export function DesktopRightNav({routeName}: {routeName: string}) {
            * Compensate for the right padding above (2px) to retain intended width.
            */
           width: width + gutters.paddingLeft + 2,
-          maxHeight: '100%',
-          overflowY: 'auto',
+          maxHeight: '100vh',
         }),
       ]}>
       {!isSearchScreen && <DesktopSearch />}


### PR DESCRIPTION
Makes it so the feeds section is the only part that scrolls. This was the original behaviour, but we lost it at some point

# Before - entire sidebar scrolls

<img width="392" height="967" alt="Screenshot 2025-10-22 at 15 06 55" src="https://github.com/user-attachments/assets/8d7cd685-3bea-4791-8a2f-0023a8561e8a" />

# After - only feed section scrolls

<img width="459" height="967" alt="Screenshot 2025-10-22 at 15 02 39" src="https://github.com/user-attachments/assets/6538fe5f-b017-4de7-be51-8b3c07b17353" />

If you don't have too many, the behaviour remains the same as before

<img width="403" height="967" alt="Screenshot 2025-10-22 at 15 02 59" src="https://github.com/user-attachments/assets/d9b4562b-231a-42a4-a5ca-7e08f1dc28e8" />
