### PR TITLE
Add `Upstream service unreachable` to network errors

### DIFF
--- a/src/lib/hooks/useCleanError.ts
+++ b/src/lib/hooks/useCleanError.ts
@@ -78,6 +78,7 @@ const NETWORK_ERRORS = [
   'Network request failed',
   'Failed to fetch',
   'Load failed',
+  'Upstream service unreachable',
 ]
 
 export function isNetworkError(e: unknown) {

--- a/src/lib/strings/errors.ts
+++ b/src/lib/strings/errors.ts
@@ -31,6 +31,7 @@ const NETWORK_ERRORS = [
   'Network request failed',
   'Failed to fetch',
   'Load failed',
+  'Upstream service unreachable',
 ]
 
 export function isNetworkError(e: unknown) {


### PR DESCRIPTION
We need to combine these files, but we can do that later.

https://blueskyweb.sentry.io/issues/6964544265/?project=4508807082278912&query=is:unresolved%20release:1.109.0&sort=date