### PR TITLE
Remove error log when updating email

### DIFF
--- a/src/components/dialogs/EmailDialog/screens/Update.tsx
+++ b/src/components/dialogs/EmailDialog/screens/Update.tsx
@@ -6,7 +6,6 @@ import {validate as validateEmail} from 'email-validator'
 
 import {wait} from '#/lib/async/wait'
 import {useCleanError} from '#/lib/hooks/useCleanError'
-import {logger} from '#/logger'
 import {useSession} from '#/state/session'
 import {atoms as a, useTheme} from '#/alf'
 import {Admonition} from '#/components/Admonition'
@@ -188,7 +187,6 @@ export function Update(_props: ScreenProps<ScreenID.Update>) {
         } catch {}
       }
     } catch (e) {
-      logger.error('EmailDialog: update email failed', {safeMessage: e})
       const {clean} = cleanError(e)
       dispatch({
         type: 'setError',


### PR DESCRIPTION
Since this is an endpoint the user interacts with and it provides validation, and the handling in here is quite simple, the majority of these logs are gonna be validation issues like `Email already taken` or `Rate limited`. We don't have a good way of filtering known vs unknown errors here. We already provide feedback to the user, I think we can remove this to free up some capacity.

https://blueskyweb.sentry.io/issues/6732146906/events/ad95f3a98659454587e83db7562aefe8/?project=4508807082278912&query=is:unresolved%20update%20email%20failed