### PR TITLE
clarify in content hider if label is on overall account

### DIFF
--- a/src/components/moderation/ContentHider.tsx
+++ b/src/components/moderation/ContentHider.tsx
@@ -85,7 +85,7 @@ function ContentHiderActive({
       blur.type !== 'label' ||
       (blur.type === 'label' && blur.source.type !== 'user')
     ) {
-      if (desc.subjectAccount) {
+      if (desc.isSubjectAccount) {
         return _(msg`${desc.name} (Account)`)
       } else {
         return desc.name
@@ -131,7 +131,7 @@ function ContentHiderActive({
     modui?.blurs,
     blur,
     desc.name,
-    desc.subjectAccount,
+    desc.isSubjectAccount,
     labelDefs,
     i18n.locale,
     globalLabelStrings,

--- a/src/lib/moderation/useModerationCauseDescription.ts
+++ b/src/lib/moderation/useModerationCauseDescription.ts
@@ -28,7 +28,7 @@ export interface ModerationCauseDescription {
   sourceType?: ModerationCauseSource['type']
   sourceAvi?: string
   sourceDid?: string
-  subjectAccount?: boolean
+  isSubjectAccount?: boolean
 }
 
 export function useModerationCauseDescription(
@@ -163,7 +163,7 @@ export function useModerationCauseDescription(
         sourceType: cause.source.type,
         sourceAvi: labeler?.creator.avatar,
         sourceDid: cause.label.src,
-        subjectAccount: cause.label.uri.startsWith('did:'),
+        isSubjectAccount: cause.label.uri.startsWith('did:'),
       }
     }
     // should never happen


### PR DESCRIPTION
Test account example (with "rude" label on overall account):

<img width="619" height="176" alt="2025-10-22T23:02:15,386330688-07:00" src="https://github.com/user-attachments/assets/5edc41da-c7cb-473b-98a4-e2c79c4f89f1" />
