### PR TITLE
Patch out `PerformanceMonitor` component

### DIFF
--- a/patches/react-native-reanimated+3.19.1.patch
+++ b/patches/react-native-reanimated+3.19.1.patch
@@ -1,15 +1,3 @@
-diff --git a/node_modules/react-native-reanimated/lib/module/ConfigHelper.js b/node_modules/react-native-reanimated/lib/module/ConfigHelper.js
-index 6d5aee3..e72f8b6 100644
---- a/node_modules/react-native-reanimated/lib/module/ConfigHelper.js
-+++ b/node_modules/react-native-reanimated/lib/module/ConfigHelper.js
-@@ -18,6 +18,7 @@ export function configureProps() {
-   jsiConfigureProps(Object.keys(PropsAllowlists.UI_THREAD_PROPS_WHITELIST), Object.keys(PropsAllowlists.NATIVE_THREAD_PROPS_WHITELIST));
- }
- export function addWhitelistedNativeProps(props) {
-+  throw new Error('addWhitelistedNativeProps crash!');
-   const oldSize = Object.keys(PropsAllowlists.NATIVE_THREAD_PROPS_WHITELIST).length;
-   PropsAllowlists.NATIVE_THREAD_PROPS_WHITELIST = {
-     ...PropsAllowlists.NATIVE_THREAD_PROPS_WHITELIST,
 diff --git a/node_modules/react-native-reanimated/lib/module/component/PerformanceMonitor.js b/node_modules/react-native-reanimated/lib/module/component/PerformanceMonitor.js
 index 9c98d6c..70ada9f 100644
 --- a/node_modules/react-native-reanimated/lib/module/component/PerformanceMonitor.js


### PR DESCRIPTION
This Reanimated debug component that we don't even seem to use is causing the crashes with copying text in DMs.

This only happens when using the `--no-dev` flag, hence why we missed it in development

<img width="1094" height="251" alt="Screenshot 2025-10-23 at 11 57 05" src="https://github.com/user-attachments/assets/bb060807-2f77-4d14-b883-660ae8112105" />
