### PR TITLE
Improve image download timeout handling

### DIFF
--- a/src/lib/media/manip.ts
+++ b/src/lib/media/manip.ts
@@ -378,14 +378,21 @@ function createPath(ext: string) {
 
 async function downloadImage(uri: string, path: string, timeout: number) {
   const dlResumable = createDownloadResumable(uri, path, {cache: true})
-
-  const to1 = setTimeout(() => dlResumable.cancelAsync(), timeout)
+  let timedOut = false
+  const to1 = setTimeout(() => {
+    timedOut = true
+    dlResumable.cancelAsync()
+  }, timeout)
 
   const dlRes = await dlResumable.downloadAsync()
   clearTimeout(to1)
 
   if (!dlRes?.uri) {
-    throw new Error('Failed to download image - dlRes is undefined')
+    if (timedOut) {
+      throw new Error('Failed to download image - timed out')
+    } else {
+      throw new Error('Failed to download image - dlRes is undefined')
+    }
   }
 
   return normalizePath(dlRes.uri)


### PR DESCRIPTION
Added a `timedOut` flag to track if the download was cancelled due to a timeout, and updated the error message to indicate when a timeout is the cause of failure.