### PR TITLE
Fix display name clipping in hover card

### DIFF
--- a/src/components/ProfileHoverCard/index.web.tsx
+++ b/src/components/ProfileHoverCard/index.web.tsx
@@ -515,7 +515,12 @@ function Inner({
           <View style={[a.flex_row, a.align_center, a.pt_md, a.pb_xs]}>
             <Text
               numberOfLines={1}
-              style={[a.text_lg, a.font_semi_bold, a.self_start]}>
+              style={[
+                a.text_lg,
+                a.leading_snug,
+                a.font_semi_bold,
+                a.self_start,
+              ]}>
               {sanitizeDisplayName(
                 profile.displayName || sanitizeHandle(profile.handle),
                 moderation.ui('displayName'),


### PR DESCRIPTION
adds `a.leading_snug` to display name

<img width="286" height="119" alt="Screenshot 2025-10-27 at 15 49 32" src="https://github.com/user-attachments/assets/7964968c-866b-4005-901e-feed0bc6be49" />
