### PR TITLE
Add display of pronouns when composing replies

### DIFF
--- a/src/view/com/composer/ComposerReplyTo.tsx
+++ b/src/view/com/composer/ComposerReplyTo.tsx
@@ -108,6 +108,18 @@ export function ComposerReplyTo({replyTo}: {replyTo: ComposerOptsPostRef}) {
               replyTo.author.displayName ||
                 sanitizeHandle(replyTo.author.handle),
             )}
+            {typeof replyTo.author.pronouns === 'string' && (
+              <Text
+                style={[
+                  a.pl_xs,
+                  a.font_normal,
+                  a.flex_shrink,
+                  t.atoms.text_contrast_medium,
+                ]}
+                numberOfLines={1}>
+                ({replyTo.author.pronouns})
+              </Text>
+            )}
           </Text>
           {verification.showBadge && (
             <View style={[a.pl_xs]}>


### PR DESCRIPTION
When replying to a post where the account that posted it has a pronouns field, display their pronouns next to their display name / handle.

<img width="692" height="424" alt="Screenshot 2025-10-27 at 19 59 53" src="https://github.com/user-attachments/assets/95d02212-1094-492b-82f5-ff1a503330a7" />

This is the most minimal step towards integrating the [new pronouns field](https://github.com/bluesky-social/atproto/pull/4232) into the social-app, it doesn't allow adding a pronoun yet, just displaying them if present.

There is a case where this would be hard to support, which is when you click the `ComposeBtn` from a profile page. Ideally there we'd show something above the composer saying "Mentioning [display name / handle] (pronouns)" and then hide that if they backspaced out the mention text. But that would be much more difficult to implement, since the `ComposeBtn` doesn't actually pass through a mention to the actor, [just their handle](https://github.com/bluesky-social/social-app/blob/bd17f0481054f23aa2e0bb5aecf88566fdfe9d6a/src/view/shell/desktop/LeftNav.tsx#L563) as a string, if their handle is valid.

Someone's also mentioned to me that it'd be useful when composing quote posts, but I'm not sure there's a good way to add it without redesigning the quote post in the composer to split display name and handle to separate lines?
<img width="1374" height="762" alt="Existing quote post composer" src="https://github.com/user-attachments/assets/48fd6445-1bac-4ada-b284-88825027816d" />
