### PR TITLE
Android - add fallbacks when saving image to gallery

### DIFF
--- a/src/lib/media/manip.ts
+++ b/src/lib/media/manip.ts
@@ -120,7 +120,7 @@ export async function saveImageToMediaLibrary({uri}: {uri: string}) {
             await MediaLibrary.migrateAlbumIfNeededAsync(album)
           }
         } catch (err) {
-          logger.debug('Attempted and failed to migrate album', {
+          logger.info('Attempted and failed to migrate album', {
             safeMessage: err,
           })
         }
@@ -129,7 +129,7 @@ export async function saveImageToMediaLibrary({uri}: {uri: string}) {
           // if album exists, put the image straight in there
           await MediaLibrary.createAssetAsync(imagePath, album)
         } catch (err) {
-          logger.debug('Failed to create asset', {safeMessage: err})
+          logger.info('Failed to create asset', {safeMessage: err})
           // however, it's possible that we don't have write permission to the album
           // try making a new one!
           try {
@@ -140,7 +140,7 @@ export async function saveImageToMediaLibrary({uri}: {uri: string}) {
               imagePath,
             )
           } catch (err2) {
-            logger.debug('Failed to create asset in a fresh album', {
+            logger.info('Failed to create asset in a fresh album', {
               safeMessage: err2,
             })
             // ... and if all else fails, just put it in DCIM


### PR DESCRIPTION
Fixes https://github.com/bluesky-social/social-app/issues/8457

Since #1360, we've been saving images to a "Bluesky" folder on Android. However, this has resulted in an issue where a small % of users cannot save images.

Turns out that you're only allowed to save images to directories if they reside in the `Pictures` or `DCIM` folders. If a user creates their own folder, say in `Downloads` or on an SD card, we will successfully fetch the album but be unable to save to it - `expo-media-library` queries albums by name, so turns out this can happen. Even worse, some bad defensive programming on my part meant that the success toast got triggered even if it failed :/ whoops

## Issue reproduction

On Android:

1. Save an initial image. This creates `Pictures` > `Bluesky` > `[name].jpg`
2. Create a folder in `Downloads`, move the `Bluesky` folder to `Downloads` > `Example` > `Bluesky`
3. Trying to save another image. It finds the album but it can no longer write to it

## The fix

The fix is to add a couple of fallback paths

1. Add album migration step. Not the immediate problem, but can't hurt - have wrapped in try/catch
2. If the `createAssetAsync` call fails, create a new Bluesky folder instead
3. If creating a new folder fails, save the image to DCIM

This ensures the image will always save, even if it has to fall back to DCIM

Also rethrows the error in the outer try/catch so it correctly shows a failure toast

# Test plan

Follow the issue reproduction steps. confirm that either a new Bluesky folder is created _or_ the image is saved to DCIM