### PR TITLE
Override Reduce Motion on load-bearing animation

### DIFF
--- a/src/view/com/lightbox/ImageViewing/index.tsx
+++ b/src/view/com/lightbox/ImageViewing/index.tsx
@@ -18,6 +18,7 @@ import Animated, {
   cancelAnimation,
   interpolate,
   measure,
+  ReduceMotion,
   runOnJS,
   type SharedValue,
   useAnimatedReaction,
@@ -516,6 +517,7 @@ function LightboxImage({
             velocity: e.velocityY,
             velocityFactor: Math.max(3500 / Math.abs(e.velocityY), 1), // Speed up if it's too slow.
             deceleration: 1, // Danger! This relies on the reaction below stopping it.
+            reduceMotion: ReduceMotion.Never, // If this animation doesn't run, the image gets stuck - therefore override Reduce Motion
           })
         })
       } else {
@@ -524,6 +526,7 @@ function LightboxImage({
           return withSpring(0, {
             stiffness: 700,
             damping: 50,
+            reduceMotion: ReduceMotion.Never,
           })
         })
       }


### PR DESCRIPTION
Fixes #9292 

When the Reduce Motion a11y setting is enabled and the app is running in `--no-dev` (i.e. in prod), the lightbox fly away animation gets frozen in place.

Seems like after the fly-away is triggered, there's a load-bearing animation where it leaves the screen. once it's offscreen, the lightbox gets closed. However, when Reduce Motion is enabled the animation doesn't run (idk why this is prod-only), so it never leaves the screen, so it gets stuck.

Simple fix is to override it so it always runs regardless of the Reduce Motion setting. I also overrode the spring-back-to-center cancel animation, since looking at iOS system apps, pan gesture animations are generally preserved.

As for why this only started cropping up recently - no idea. We updated Reanimated but nothing in the changelog stands out.