### PR TITLE
fix: do not render external embed if the domain is not valid

### DIFF
--- a/src/lib/link-meta/errors.ts
+++ b/src/lib/link-meta/errors.ts
@@ -1,0 +1,35 @@
+/**
+ * Custom error classes for specific link metadata errors we need to handle differently
+ */
+
+/**
+ * Thrown when a URL contains a host IP address, which is not allowed
+ * This is a security restriction to prevent access to internal/private IPs
+ */
+export class InvalidUrlHostIPError extends Error {
+  constructor(
+    message: string = 'Invalid URL: host IP addresses are not allowed',
+  ) {
+    super(message)
+    this.name = 'InvalidUrlHostIPError'
+  }
+}
+
+/**
+ * Thrown when a URL is malformed or invalid (but not specifically due to host IP)
+ */
+export class InvalidUrlError extends Error {
+  constructor(message: string = 'Invalid URL') {
+    super(message)
+    this.name = 'InvalidUrlError'
+  }
+}
+
+/**
+ * Type guard to check if an error is specifically an InvalidUrlHostIPError
+ */
+export function isInvalidUrlHostIPError(
+  error: unknown,
+): error is InvalidUrlHostIPError {
+  return error instanceof InvalidUrlHostIPError
+}

--- a/src/lib/link-meta/errors.ts
+++ b/src/lib/link-meta/errors.ts
@@ -24,12 +24,3 @@ export class InvalidUrlError extends Error {
     this.name = 'InvalidUrlError'
   }
 }
-
-/**
- * Type guard to check if an error is specifically an InvalidUrlHostIPError
- */
-export function isInvalidUrlHostIPError(
-  error: unknown,
-): error is InvalidUrlHostIPError {
-  return error instanceof InvalidUrlHostIPError
-}

--- a/src/lib/link-meta/link-meta.ts
+++ b/src/lib/link-meta/link-meta.ts
@@ -16,7 +16,6 @@ export enum LikelyType {
 }
 
 export interface LinkMeta {
-  error?: string
   likelyType: LikelyType
   url: string
   title?: string
@@ -51,11 +50,7 @@ export async function getLinkMeta(
     // QUESTION - do we want to follow redirects in other cases? -sfn
     shouldFollowRedirect = urlp.hostname === 'on.soundcloud.com'
   } catch (e) {
-    return {
-      error: 'Invalid URL',
-      likelyType: LikelyType.Other,
-      url,
-    }
+    throw new Error('Invalid URL')
   }
   const likelyType = getLikelyType(urlp)
   const meta: LinkMeta = {
@@ -93,9 +88,8 @@ export async function getLinkMeta(
       meta.url = body.url
     }
   } catch (e) {
-    // failed
-    console.error(e)
-    meta.error = e instanceof Error ? e.toString() : 'Failed to fetch link'
+    // Re-throw the error so React Query can handle it properly
+    throw e instanceof Error ? e : new Error('Failed to fetch link')
   } finally {
     clearTimeout(to)
   }

--- a/src/lib/link-meta/link-meta.ts
+++ b/src/lib/link-meta/link-meta.ts
@@ -77,8 +77,8 @@ export async function getLinkMeta(
 
     const body = await response.json()
 
-    if (body.error !== '') {
-      throw new Error(body.error)
+    if (body.Error !== '') {
+      throw new Error(body.Error)
     }
 
     meta.description = body.description
@@ -87,9 +87,6 @@ export async function getLinkMeta(
     if (shouldFollowRedirect) {
       meta.url = body.url
     }
-  } catch (e) {
-    // Re-throw the error so React Query can handle it properly
-    throw e instanceof Error ? e : new Error('Failed to fetch link')
   } finally {
     clearTimeout(to)
   }

--- a/src/view/com/composer/ExternalEmbed.tsx
+++ b/src/view/com/composer/ExternalEmbed.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import {type StyleProp, View, type ViewStyle} from 'react-native'
 
-import {InvalidUrlHostIPError} from '#/lib/link-meta/errors'
 import {cleanError} from '#/lib/strings/errors'
 import {
   useResolveGifQuery,
@@ -122,10 +121,10 @@ export const ExternalEmbedLink = ({
     }
   }, [data, uri])
 
-  if (error instanceof InvalidUrlHostIPError) {
+  if (error instanceof Error) {
     // Remove the embed so that the user can try again with a different link
     onRemove()
-    // Don't preview links with IP hosts
+    // Don't preview links that have errors
     return null
   }
 
@@ -138,15 +137,6 @@ export const ExternalEmbedLink = ({
     <View style={[a.mb_xl, a.overflow_hidden, t.atoms.border_contrast_medium]}>
       {linkComponent ? (
         <View style={{pointerEvents: 'none'}}>{linkComponent}</View>
-      ) : error ? (
-        <Container style={[a.align_start, a.p_md, a.gap_xs]}>
-          <Text numberOfLines={1} style={t.atoms.text_contrast_high}>
-            {uri}
-          </Text>
-          <Text numberOfLines={2} style={[{color: t.palette.negative_400}]}>
-            {cleanError(error)}
-          </Text>
-        </Container>
       ) : (
         <Container>
           <Loader size="xl" />

--- a/src/view/com/composer/ExternalEmbed.tsx
+++ b/src/view/com/composer/ExternalEmbed.tsx
@@ -123,7 +123,9 @@ export const ExternalEmbedLink = ({
   }, [data, uri])
 
   if (isInvalidUrlHostIPError(error)) {
-    // Don't preview links with IP hosts for security reasons.
+    // Remove the embed so that the user can try again with a different link
+    onRemove()
+    // Don't preview links with IP hosts
     return null
   }
 

--- a/src/view/com/composer/ExternalEmbed.tsx
+++ b/src/view/com/composer/ExternalEmbed.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import {type StyleProp, View, type ViewStyle} from 'react-native'
 
-import {isInvalidUrlHostIPError} from '#/lib/link-meta/errors'
+import {InvalidUrlHostIPError} from '#/lib/link-meta/errors'
 import {cleanError} from '#/lib/strings/errors'
 import {
   useResolveGifQuery,
@@ -122,7 +122,7 @@ export const ExternalEmbedLink = ({
     }
   }, [data, uri])
 
-  if (isInvalidUrlHostIPError(error)) {
+  if (error instanceof InvalidUrlHostIPError) {
     // Remove the embed so that the user can try again with a different link
     onRemove()
     // Don't preview links with IP hosts

--- a/src/view/com/composer/ExternalEmbed.tsx
+++ b/src/view/com/composer/ExternalEmbed.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import {type StyleProp, View, type ViewStyle} from 'react-native'
 
+import {isInvalidUrlHostIPError} from '#/lib/link-meta/errors'
 import {cleanError} from '#/lib/strings/errors'
 import {
   useResolveGifQuery,
@@ -120,6 +121,11 @@ export const ExternalEmbedLink = ({
       }
     }
   }, [data, uri])
+
+  if (isInvalidUrlHostIPError(error)) {
+    // Don't preview links with IP hosts for security reasons.
+    return null
+  }
 
   if (data?.type === 'record' && hasQuote) {
     // This is not currently supported by the data model so don't preview it.


### PR DESCRIPTION
Summary
---

Ensure that for errors returned from the link metadata service, we should not show a embed card.

Part of the issue here was that the errors were not properly being propagated through the react query hook. I've updated the code to properly throw errors so that it works as expected.

Created some custom error classes so that we can better handle the various cases of failure. I've started simply with the existing errors we were throwing. ~~This allows us to handle the different types of failures, and to ensure that we can show an error embed card when we have an unexpected error, otherwise when we encounter specific errors from the service we can remove the card entirely.~~ Updated to not show any error cards and to remove the embed if we encounter any error.


