### PR TITLE
[embedr] check for AtIdentifier in sanity check, allowing `handle` in addition to `did`

### DIFF
--- a/bskyembed/test.html
+++ b/bskyembed/test.html
@@ -1050,5 +1050,27 @@
         </div>
       </div>
     </section>
+	
+    <!-- AT ID types - with data-bluesky-uri only -->
+    <section>
+      <h1>AT ID types</h1>
+      <div class="grid">
+        <div class="item">
+          <blockquote class="bluesky-embed" data-bluesky-uri="at://did:plc:p2cp5gopk7mgjegy6wadk3ep/app.bsky.feed.post/3lxciw4rf4c2p">
+            <p lang="en">static html to be replaced with generated iframe</p>
+          </blockquote>
+
+          <div>did:plc</div>
+        </div>
+
+        <div class="item">
+          <blockquote class="bluesky-embed" data-bluesky-uri="at://samuel.fm/app.bsky.feed.post/3lxciw4rf4c2p">
+            <p lang="en">static html to be replaced with generated iframe</p>
+          </blockquote>
+
+          <div>handle</div>
+        </div>
+      </div>
+    </section>
   </body>
 </html>

--- a/bskyweb/cmd/embedr/handlers.go
+++ b/bskyweb/cmd/embedr/handlers.go
@@ -191,17 +191,17 @@ func (srv *Server) WebPostEmbed(c echo.Context) error {
 	if err != nil {
 		return c.String(http.StatusBadRequest, fmt.Sprintf("Invalid RecordKey: %v", err))
 	}
-	didParam := c.Param("did")
-	did, err := syntax.ParseAtIdentifier(didParam)
+	atidParam := c.Param("atid")
+	atid, err := syntax.ParseAtIdentifier(atidParam)
 	if err != nil {
-		return c.String(http.StatusBadRequest, fmt.Sprintf("Invalid DID: %v", err))
+		return c.String(http.StatusBadRequest, fmt.Sprintf("Invalid Identifier: %v", err))
 	}
 	_ = rkey
-	_ = did
+	_ = atid
 
 	// NOTE: this request was't really necessary; the JS will do the same fetch
 	/*
-		postView, err := srv.getBlueskyPost(ctx, did, rkey)
+		postView, err := srv.getBlueskyPost(ctx, atid, rkey)
 		if err == ErrPostNotFound {
 			return c.String(http.StatusNotFound, fmt.Sprintf("%v", err))
 		} else if err == ErrPostNotPublic {

--- a/bskyweb/cmd/embedr/handlers.go
+++ b/bskyweb/cmd/embedr/handlers.go
@@ -192,7 +192,7 @@ func (srv *Server) WebPostEmbed(c echo.Context) error {
 		return c.String(http.StatusBadRequest, fmt.Sprintf("Invalid RecordKey: %v", err))
 	}
 	didParam := c.Param("did")
-	did, err := syntax.ParseDID(didParam)
+	did, err := syntax.ParseAtIdentifier(didParam)
 	if err != nil {
 		return c.String(http.StatusBadRequest, fmt.Sprintf("Invalid DID: %v", err))
 	}

--- a/bskyweb/cmd/embedr/server.go
+++ b/bskyweb/cmd/embedr/server.go
@@ -206,7 +206,7 @@ func serve(cctx *cli.Context) error {
 	e.GET("/iframe-resize.js", echo.WrapHandler(staticHandler))
 	e.GET("/embed.js", echo.WrapHandler(staticHandler))
 	e.GET("/oembed", server.WebOEmbed)
-	e.GET("/embed/:did/app.bsky.feed.post/:rkey", server.WebPostEmbed)
+	e.GET("/embed/:atid/app.bsky.feed.post/:rkey", server.WebPostEmbed)
 
 	// Start the server.
 	log.Infof("starting server address=%s", httpAddress)


### PR DESCRIPTION
This PR updates the embed iframe url `https://embed.bsky.app/embed/:atid/app.bsky.feed.post/:post` sanity check to accept either `handle` or `did`, instead of only accepting `did`.

**Current behaviour:**
`https://embed.bsky.app/embed/did:plc:p2cp5gopk7mgjegy6wadk3ep/app.bsky.feed.post/3lxciw4rf4c2p` = functional embed iframe
`https://embed.bsky.app/embed/samuel.fm/app.bsky.feed.post/3lxciw4rf4c2p` = "Invalid DID: DID syntax didn't validate via regex"

**PR behaviour:**
`https://embed.bsky.app/embed/did:plc:p2cp5gopk7mgjegy6wadk3ep/app.bsky.feed.post/3lxciw4rf4c2p` = functional embed iframe
`https://embed.bsky.app/embed/samuel.fm/app.bsky.feed.post/3lxciw4rf4c2p` = functional embed iframe

### Details

Bluesky's embed iframe page is actually already fully functional with handles. You can test this by building the current version of [bskyembed](https://github.com/bluesky-social/social-app/tree/main/bskyembed) locally and you'll see that `http://localhost:5173/embed/samuel.fm/app.bsky.feed.post/3lxciw4rf4c2p` loads without issue.
The reason it doesn't currently work on `https://embed.bsky.app/embed/*` is because the sanity check on generating the page explicitly checks for `syntax.ParseDID`. This PR changes that sanity check to use `syntax.ParseAtIdentifier` instead. That single change fixes it, but I've made additional changes to rename the variables to reflect how they now represent an At ID instead of just a did.