### PR TITLE
Fix Wordle rendering

### DIFF
--- a/bskyweb/templates/base.html
+++ b/bskyweb/templates/base.html
@@ -29,6 +29,7 @@
       font-weight: 300 1000;
       font-style: normal;
       font-display: swap;
+      unicode-range: U+0000-2B1A, U+2B1D-10FFFF; /* everything except the wordle squares */
     }
     @font-face {
       font-family: 'InterVariableItalic';
@@ -36,6 +37,7 @@
       font-weight: 300 1000;
       font-style: italic;
       font-display: swap;
+      unicode-range: U+0000-2B1A, U+2B1D-10FFFF; /* everything except the wordle squares */
     }
     html {
       background-color: white;

--- a/web/index.html
+++ b/web/index.html
@@ -34,6 +34,7 @@
         font-weight: 300 1000;
         font-style: normal;
         font-display: swap;
+        unicode-range: U+0000-2B1A, U+2B1D-10FFFF; /* everything except the wordle squares */
       }
       @font-face {
         font-family: 'InterVariableItalic';
@@ -41,6 +42,7 @@
         font-weight: 300 1000;
         font-style: italic;
         font-display: swap;
+        unicode-range: U+0000-2B1A, U+2B1D-10FFFF; /* everything except the wordle squares */
       }
       html {
         background-color: white;


### PR DESCRIPTION
Web only - use the CSS `unicode-range` property to exclude the Wordle squares from Inter

<table>
  <thead>
    <tr>
      <th>Before</th>
      <th>After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><img width="300" src="https://github.com/user-attachments/assets/4d1de63f-d658-410a-99c5-42092234c58b" /></td>
      <td><img width="300" src="https://github.com/user-attachments/assets/aa059017-9e16-410d-8192-5563034a4e01" /></td>
    </tr>
  </tbody>
</table>

iOS doesn't have this problem, because all emoji are rendered with the system font. This is a problem on Android too, but I am not sure if enabling the iOS solution is the right move - will it have perf impacts? Unsure. Out of caution, let's just do web for now. Will return to this if I find a better solution!