### PR TITLE
Disable wake-from-background OTA reload on Android

### DIFF
--- a/src/lib/hooks/useOTAUpdates.ts
+++ b/src/lib/hooks/useOTAUpdates.ts
@@ -12,7 +12,7 @@ import {
 
 import {isNetworkError} from '#/lib/strings/errors'
 import {logger} from '#/logger'
-import {isIOS} from '#/platform/detection'
+import {isAndroid, isIOS} from '#/platform/detection'
 import {IS_TESTFLIGHT} from '#/env'
 
 const MINIMUM_MINIMIZE_TIME = 15 * 60e3
@@ -192,6 +192,13 @@ export function useOTAUpdates() {
     if (!isEnabled || currentChannel?.startsWith('pull-request')) {
       return
     }
+
+    // TEMP: disable wake-from-background OTA loading on Android.
+    // This is causing a crash when the thread view is open due to
+    // `maintainVisibleContentPosition`. See repro repo for more details:
+    // https://github.com/mozzius/ota-crash-repro
+    // Old Arch only - re-enable once we're on the New Archictecture! -sfn
+    if (isAndroid) return
 
     const subscription = AppState.addEventListener(
       'change',


### PR DESCRIPTION
We can very clearly see a spike in crashes on Android every time we do an OTA:

<img width="314" height="269" alt="Screenshot 2025-11-01 at 14 21 58" src="https://github.com/user-attachments/assets/7cae69a2-53fa-454a-adc9-662cd1d7acc9" />

If we do too many OTAs in quick succession, it can take us over the bad behaviour threshold pretty easily.

I narrowed this down to having a ScrollView with `maintainVisibleContentPosition` enabled, minimal repro here:
https://github.com/mozzius/ota-crash-repro

Turns out there are two places we attempt to apply an OTA that has been downloaded:
1. on app start
2. after waking from background after being backgrounded for at least 15mins

If the user was looking at a thread, or even just had a thread in their nav stack, then attempted to apply the OTA via option 2, this would crash Android.

This crash is Old Architecture only. The only realistic fix is to upgrade to the New Architecture. As a temporary measure, let's remove this wake-from-background behaviour on Android until we can upgrade to New Architecture. OTAs will still be applied, but the rollout will be a little slower as the app needs to be hard booting to receive it.

**Revert this PR when the New Arch migration is done!**