### PR TITLE
Fix DM message input placement on web

### DIFF
--- a/src/screens/Messages/components/MessagesList.tsx
+++ b/src/screens/Messages/components/MessagesList.tsx
@@ -301,7 +301,11 @@ export function MessagesList({
 
   const animatedStickyViewStyle = useAnimatedStyle(() => ({
     transform: [
-      {translateY: -Math.max(keyboardHeight.get(), footerHeight.get())},
+      {
+        translateY: isWeb
+          ? 0
+          : -Math.max(keyboardHeight.get(), footerHeight.get()),
+      },
     ],
   }))
 


### PR DESCRIPTION
| Before | After |
| -- | -- |
| <img width="1148" height="1172" alt="Screenshot 2025-11-01 at 8 37 14 AM" src="https://github.com/user-attachments/assets/19e547e6-de62-4bc7-8b52-e70d880f5766" /> | <img width="1148" height="1172" alt="Screenshot 2025-11-01 at 8 37 17 AM" src="https://github.com/user-attachments/assets/012e85c5-b31d-46e1-9835-b7185eef17ca" /> |

On web, `animatedStickyViewStyle` has been leaving space for the footer nav looking at `footerHeight.get()`. In my browsers, this looks like `58px`, so the message input box gets elevated by `58px`. The problem is, the footer nav is hidden in this view, so the message input box looks elevated and actually covers the last message.

I don't have a working setup for testing iOS so I've scoped this to `isWeb`. It's at least a starting point.