### PR TITLE
Fix DMs on mobile web by using `dvh`

### DIFF
--- a/src/App.native.tsx
+++ b/src/App.native.tsx
@@ -227,40 +227,39 @@ function App() {
    * that is set up in the InnerApp component above.
    */
   return (
-    <Geo.Provider>
-      <A11yProvider>
-        <KeyboardControllerProvider>
-          <OnboardingProvider>
-            <AnalyticsContext>
-              <SessionProvider>
-                <PrefsStateProvider>
-                  <I18nProvider>
-                    <ShellStateProvider>
-                      <ModalStateProvider>
-                        <DialogStateProvider>
-                          <LightboxStateProvider>
-                            <PortalProvider>
-                              <BottomSheetProvider>
-                                <StarterPackProvider>
-                                  <SafeAreaProvider
-                                    initialMetrics={initialWindowMetrics}>
+    <SafeAreaProvider initialMetrics={initialWindowMetrics}>
+      <Geo.Provider>
+        <A11yProvider>
+          <KeyboardControllerProvider>
+            <OnboardingProvider>
+              <AnalyticsContext>
+                <SessionProvider>
+                  <PrefsStateProvider>
+                    <I18nProvider>
+                      <ShellStateProvider>
+                        <ModalStateProvider>
+                          <DialogStateProvider>
+                            <LightboxStateProvider>
+                              <PortalProvider>
+                                <BottomSheetProvider>
+                                  <StarterPackProvider>
                                     <InnerApp />
-                                  </SafeAreaProvider>
-                                </StarterPackProvider>
-                              </BottomSheetProvider>
-                            </PortalProvider>
-                          </LightboxStateProvider>
-                        </DialogStateProvider>
-                      </ModalStateProvider>
-                    </ShellStateProvider>
-                  </I18nProvider>
-                </PrefsStateProvider>
-              </SessionProvider>
-            </AnalyticsContext>
-          </OnboardingProvider>
-        </KeyboardControllerProvider>
-      </A11yProvider>
-    </Geo.Provider>
+                                  </StarterPackProvider>
+                                </BottomSheetProvider>
+                              </PortalProvider>
+                            </LightboxStateProvider>
+                          </DialogStateProvider>
+                        </ModalStateProvider>
+                      </ShellStateProvider>
+                    </I18nProvider>
+                  </PrefsStateProvider>
+                </SessionProvider>
+              </AnalyticsContext>
+            </OnboardingProvider>
+          </KeyboardControllerProvider>
+        </A11yProvider>
+      </Geo.Provider>
+    </SafeAreaProvider>
   )
 }
 

--- a/src/App.web.tsx
+++ b/src/App.web.tsx
@@ -3,7 +3,10 @@ import '#/view/icons'
 import './style.css'
 
 import {Fragment, useEffect, useState} from 'react'
-import {SafeAreaProvider} from 'react-native-safe-area-context'
+import {
+  initialWindowMetrics,
+  SafeAreaProvider,
+} from 'react-native-safe-area-context'
 import {msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 import * as Sentry from '@sentry/react-native'
@@ -143,20 +146,18 @@ function InnerApp() {
                                             <UnreadNotifsProvider>
                                               <BackgroundNotificationPreferencesProvider>
                                                 <MutedThreadsProvider>
-                                                  <SafeAreaProvider>
-                                                    <ProgressGuideProvider>
-                                                      <ServiceConfigProvider>
-                                                        <EmailVerificationProvider>
-                                                          <HideBottomBarBorderProvider>
-                                                            <IntentDialogProvider>
-                                                              <Shell />
-                                                              <ToastOutlet />
-                                                            </IntentDialogProvider>
-                                                          </HideBottomBarBorderProvider>
-                                                        </EmailVerificationProvider>
-                                                      </ServiceConfigProvider>
-                                                    </ProgressGuideProvider>
-                                                  </SafeAreaProvider>
+                                                  <ProgressGuideProvider>
+                                                    <ServiceConfigProvider>
+                                                      <EmailVerificationProvider>
+                                                        <HideBottomBarBorderProvider>
+                                                          <IntentDialogProvider>
+                                                            <Shell />
+                                                            <ToastOutlet />
+                                                          </IntentDialogProvider>
+                                                        </HideBottomBarBorderProvider>
+                                                      </EmailVerificationProvider>
+                                                    </ServiceConfigProvider>
+                                                  </ProgressGuideProvider>
                                                 </MutedThreadsProvider>
                                               </BackgroundNotificationPreferencesProvider>
                                             </UnreadNotifsProvider>
@@ -201,33 +202,35 @@ function App() {
    * that is set up in the InnerApp component above.
    */
   return (
-    <Geo.Provider>
-      <A11yProvider>
-        <OnboardingProvider>
-          <AnalyticsContext>
-            <SessionProvider>
-              <PrefsStateProvider>
-                <I18nProvider>
-                  <ShellStateProvider>
-                    <ModalStateProvider>
-                      <DialogStateProvider>
-                        <LightboxStateProvider>
-                          <PortalProvider>
-                            <StarterPackProvider>
-                              <InnerApp />
-                            </StarterPackProvider>
-                          </PortalProvider>
-                        </LightboxStateProvider>
-                      </DialogStateProvider>
-                    </ModalStateProvider>
-                  </ShellStateProvider>
-                </I18nProvider>
-              </PrefsStateProvider>
-            </SessionProvider>
-          </AnalyticsContext>
-        </OnboardingProvider>
-      </A11yProvider>
-    </Geo.Provider>
+    <SafeAreaProvider initialMetrics={initialWindowMetrics}>
+      <Geo.Provider>
+        <A11yProvider>
+          <OnboardingProvider>
+            <AnalyticsContext>
+              <SessionProvider>
+                <PrefsStateProvider>
+                  <I18nProvider>
+                    <ShellStateProvider>
+                      <ModalStateProvider>
+                        <DialogStateProvider>
+                          <LightboxStateProvider>
+                            <PortalProvider>
+                              <StarterPackProvider>
+                                <InnerApp />
+                              </StarterPackProvider>
+                            </PortalProvider>
+                          </LightboxStateProvider>
+                        </DialogStateProvider>
+                      </ModalStateProvider>
+                    </ShellStateProvider>
+                  </I18nProvider>
+                </PrefsStateProvider>
+              </SessionProvider>
+            </AnalyticsContext>
+          </OnboardingProvider>
+        </A11yProvider>
+      </Geo.Provider>
+    </SafeAreaProvider>
   )
 }
 

--- a/src/alf/atoms.ts
+++ b/src/alf/atoms.ts
@@ -20,7 +20,7 @@ export const atoms = {
    */
   util_screen_outer: [
     web({
-      minHeight: '100vh',
+      minHeight: '100dvh',
     }),
     native({
       height: '100%',

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -82,11 +82,7 @@ export const Content = memo(
         ref={ref}
         id="content"
         automaticallyAdjustsScrollIndicatorInsets={false}
-        scrollIndicatorInsets={{
-          bottom: footerHeight,
-          top: 0,
-          right: 1,
-        }}
+        scrollIndicatorInsets={{bottom: footerHeight, top: 0, right: 1}}
         indicatorStyle={t.scheme === 'dark' ? 'white' : 'black'}
         style={[scrollViewStyles.common, style]}
         contentInset={ios({top: 0, left: 0, bottom: footerHeight, right: 0})}
@@ -133,6 +129,8 @@ export const KeyboardAwareContent = memo(function LayoutKeyboardAwareContent({
   return (
     <KeyboardAwareScrollView
       style={[scrollViewStyles.common, style]}
+      automaticallyAdjustsScrollIndicatorInsets={false}
+      scrollIndicatorInsets={{bottom: footerHeight, top: 0, right: 1}}
       contentInset={ios({top: 0, left: 0, bottom: footerHeight, right: 0})}
       contentContainerStyle={[
         !isIOS && {paddingBottom: footerHeight},

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -1,19 +1,24 @@
 import {forwardRef, memo, useContext, useMemo} from 'react'
-import {StyleSheet, View, type ViewProps, type ViewStyle} from 'react-native'
-import {type StyleProp} from 'react-native'
+import {
+  ScrollView,
+  type ScrollViewProps,
+  type StyleProp,
+  StyleSheet,
+  View,
+  type ViewProps,
+  type ViewStyle,
+} from 'react-native'
 import {
   KeyboardAwareScrollView,
   type KeyboardAwareScrollViewProps,
 } from 'react-native-keyboard-controller'
-import Animated, {
-  type AnimatedScrollViewProps,
-  useAnimatedProps,
-} from 'react-native-reanimated'
 import {useSafeAreaInsets} from 'react-native-safe-area-context'
 
 import {useShellLayout} from '#/state/shell/shell-layout'
 import {
+  android,
   atoms as a,
+  ios,
   useBreakpoints,
   useLayoutBreakpoints,
   useTheme,
@@ -22,7 +27,7 @@ import {
 import {useDialogContext} from '#/components/Dialog'
 import {CENTER_COLUMN_OFFSET, SCROLLBAR_OFFSET} from '#/components/Layout/const'
 import {ScrollbarOffsetContext} from '#/components/Layout/context'
-import {IS_WEB} from '#/env'
+import {IS_IOS, IS_WEB} from '#/env'
 
 export * from '#/components/Layout/const'
 export * as Header from '#/components/Layout/Header'
@@ -52,9 +57,7 @@ export const Screen = memo(function Screen({
   )
 })
 
-export type ContentProps = AnimatedScrollViewProps & {
-  style?: StyleProp<ViewStyle>
-  contentContainerStyle?: StyleProp<ViewStyle>
+export type ContentProps = ScrollViewProps & {
   ignoreTabletLayoutOffset?: boolean
 }
 
@@ -62,7 +65,7 @@ export type ContentProps = AnimatedScrollViewProps & {
  * Default scroll view for simple pages
  */
 export const Content = memo(
-  forwardRef<Animated.ScrollView, ContentProps>(function Content(
+  forwardRef<ScrollView, ContentProps>(function Content(
     {
       children,
       style,
@@ -74,39 +77,33 @@ export const Content = memo(
   ) {
     const t = useTheme()
     const {footerHeight} = useShellLayout()
-    const animatedProps = useAnimatedProps(() => {
-      return {
-        scrollIndicatorInsets: {
-          bottom: footerHeight.get(),
-          top: 0,
-          right: 1,
-        },
-      } satisfies AnimatedScrollViewProps
-    })
 
     return (
-      <Animated.ScrollView
+      <ScrollView
         ref={ref}
         id="content"
         automaticallyAdjustsScrollIndicatorInsets={false}
+        scrollIndicatorInsets={{
+          bottom: footerHeight,
+          top: 0,
+          right: 1,
+        }}
         indicatorStyle={t.scheme === 'dark' ? 'white' : 'black'}
-        // sets the scroll inset to the height of the footer
-        animatedProps={animatedProps}
         style={[scrollViewStyles.common, style]}
+        contentInset={ios({top: 0, left: 0, bottom: footerHeight, right: 0})}
         contentContainerStyle={[
-          scrollViewStyles.contentContainer,
+          !IS_IOS && {paddingBottom: footerHeight},
           contentContainerStyle,
         ]}
         {...props}>
         {IS_WEB ? (
           <Center ignoreTabletLayoutOffset={ignoreTabletLayoutOffset}>
-            {/* @ts-expect-error web only -esb */}
             {children}
           </Center>
         ) : (
           children
         )}
-      </Animated.ScrollView>
+      </ScrollView>
     )
   }),
 )
@@ -114,9 +111,6 @@ export const Content = memo(
 const scrollViewStyles = StyleSheet.create({
   common: {
     width: '100%',
-  },
-  contentContainer: {
-    paddingBottom: 100,
   },
 })
 
@@ -136,11 +130,14 @@ export const KeyboardAwareContent = memo(function LayoutKeyboardAwareContent({
   contentContainerStyle,
   ...props
 }: KeyboardAwareContentProps) {
+  const {footerHeight} = useShellLayout()
   return (
     <KeyboardAwareScrollView
       style={[scrollViewStyles.common, style]}
+      contentInset={ios({top: 0, left: 0, bottom: footerHeight, right: 0})}
       contentContainerStyle={[
-        scrollViewStyles.contentContainer,
+        android({paddingBottom: footerHeight}),
+        web({paddingBottom: footerHeight}),
         contentContainerStyle,
       ]}
       keyboardShouldPersistTaps="handled"

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -2,7 +2,11 @@ import {forwardRef, memo, useContext, useMemo} from 'react'
 import {
   ScrollView,
   type ScrollViewProps,
+<<<<<<< HEAD
   type StyleProp,
+=======
+  StyleSheet,
+>>>>>>> c74c5a431 (Revert "rm stylesheet")
   View,
   type ViewProps,
   type ViewStyle,
@@ -83,7 +87,7 @@ export const Content = memo(
         automaticallyAdjustsScrollIndicatorInsets={false}
         scrollIndicatorInsets={{bottom: footerHeight, top: 0, right: 1}}
         indicatorStyle={t.scheme === 'dark' ? 'white' : 'black'}
-        style={[a.w_full, style]}
+        style={[scrollViewStyles.common, style]}
         contentInset={ios({top: 0, left: 0, bottom: footerHeight, right: 0})}
         contentContainerStyle={[
           !IS_IOS && {paddingBottom: footerHeight},
@@ -101,6 +105,12 @@ export const Content = memo(
     )
   }),
 )
+
+const scrollViewStyles = StyleSheet.create({
+  common: {
+    width: '100%',
+  },
+})
 
 export type KeyboardAwareContentProps = KeyboardAwareScrollViewProps & {
   children: React.ReactNode

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -3,7 +3,6 @@ import {
   ScrollView,
   type ScrollViewProps,
   type StyleProp,
-  StyleSheet,
   View,
   type ViewProps,
   type ViewStyle,
@@ -84,7 +83,7 @@ export const Content = memo(
         automaticallyAdjustsScrollIndicatorInsets={false}
         scrollIndicatorInsets={{bottom: footerHeight, top: 0, right: 1}}
         indicatorStyle={t.scheme === 'dark' ? 'white' : 'black'}
-        style={[scrollViewStyles.common, style]}
+        style={[a.w_full, style]}
         contentInset={ios({top: 0, left: 0, bottom: footerHeight, right: 0})}
         contentContainerStyle={[
           !IS_IOS && {paddingBottom: footerHeight},
@@ -102,12 +101,6 @@ export const Content = memo(
     )
   }),
 )
-
-const scrollViewStyles = StyleSheet.create({
-  common: {
-    width: '100%',
-  },
-})
 
 export type KeyboardAwareContentProps = KeyboardAwareScrollViewProps & {
   children: React.ReactNode

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -1,12 +1,9 @@
-import {forwardRef, memo, useContext, useMemo} from 'react'
+import {memo, useContext, useMemo} from 'react'
 import {
   ScrollView,
   type ScrollViewProps,
-<<<<<<< HEAD
   type StyleProp,
-=======
   StyleSheet,
->>>>>>> c74c5a431 (Revert "rm stylesheet")
   View,
   type ViewProps,
   type ViewStyle,
@@ -60,51 +57,48 @@ export const Screen = memo(function Screen({
 })
 
 export type ContentProps = ScrollViewProps & {
+  ref?: React.Ref<ScrollView>
   ignoreTabletLayoutOffset?: boolean
 }
 
 /**
  * Default scroll view for simple pages
  */
-export const Content = memo(
-  forwardRef<ScrollView, ContentProps>(function Content(
-    {
-      children,
-      style,
-      contentContainerStyle,
-      ignoreTabletLayoutOffset,
-      ...props
-    },
-    ref,
-  ) {
-    const t = useTheme()
-    const {footerHeight} = useShellLayout()
+export const Content = memo(function Content({
+  ref,
+  children,
+  style,
+  contentContainerStyle,
+  ignoreTabletLayoutOffset,
+  ...props
+}: ContentProps) {
+  const t = useTheme()
+  const {footerHeight} = useShellLayout()
 
-    return (
-      <ScrollView
-        ref={ref}
-        id="content"
-        automaticallyAdjustsScrollIndicatorInsets={false}
-        scrollIndicatorInsets={{bottom: footerHeight, top: 0, right: 1}}
-        indicatorStyle={t.scheme === 'dark' ? 'white' : 'black'}
-        style={[scrollViewStyles.common, style]}
-        contentInset={ios({top: 0, left: 0, bottom: footerHeight, right: 0})}
-        contentContainerStyle={[
-          !IS_IOS && {paddingBottom: footerHeight},
-          contentContainerStyle,
-        ]}
-        {...props}>
-        {IS_WEB ? (
-          <Center ignoreTabletLayoutOffset={ignoreTabletLayoutOffset}>
-            {children}
-          </Center>
-        ) : (
-          children
-        )}
-      </ScrollView>
-    )
-  }),
-)
+  return (
+    <ScrollView
+      ref={ref}
+      id="content"
+      automaticallyAdjustsScrollIndicatorInsets={false}
+      scrollIndicatorInsets={{bottom: footerHeight, top: 0, right: 1}}
+      indicatorStyle={t.scheme === 'dark' ? 'white' : 'black'}
+      style={[scrollViewStyles.common, style]}
+      contentInset={ios({top: 0, left: 0, bottom: footerHeight, right: 0})}
+      contentContainerStyle={[
+        !IS_IOS && {paddingBottom: footerHeight},
+        contentContainerStyle,
+      ]}
+      {...props}>
+      {IS_WEB ? (
+        <Center ignoreTabletLayoutOffset={ignoreTabletLayoutOffset}>
+          {children}
+        </Center>
+      ) : (
+        children
+      )}
+    </ScrollView>
+  )
+})
 
 const scrollViewStyles = StyleSheet.create({
   common: {
@@ -136,7 +130,7 @@ export const KeyboardAwareContent = memo(function LayoutKeyboardAwareContent({
       scrollIndicatorInsets={{bottom: footerHeight, top: 0, right: 1}}
       contentInset={ios({top: 0, left: 0, bottom: footerHeight, right: 0})}
       contentContainerStyle={[
-        !isIOS && {paddingBottom: footerHeight},
+        !IS_IOS && {paddingBottom: footerHeight},
         contentContainerStyle,
       ]}
       keyboardShouldPersistTaps="handled"

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -16,7 +16,6 @@ import {useSafeAreaInsets} from 'react-native-safe-area-context'
 
 import {useShellLayout} from '#/state/shell/shell-layout'
 import {
-  android,
   atoms as a,
   ios,
   useBreakpoints,
@@ -136,8 +135,7 @@ export const KeyboardAwareContent = memo(function LayoutKeyboardAwareContent({
       style={[scrollViewStyles.common, style]}
       contentInset={ios({top: 0, left: 0, bottom: footerHeight, right: 0})}
       contentContainerStyle={[
-        android({paddingBottom: footerHeight}),
-        web({paddingBottom: footerHeight}),
+        !isIOS && {paddingBottom: footerHeight},
         contentContainerStyle,
       ]}
       keyboardShouldPersistTaps="handled"

--- a/src/lib/hooks/useMinimalShellTransform.ts
+++ b/src/lib/hooks/useMinimalShellTransform.ts
@@ -40,11 +40,7 @@ export function useMinimalShellFooterTransform() {
       opacity: Math.pow(1 - footerModeValue, 2),
       transform: [
         {
-          translateY: interpolate(
-            footerModeValue,
-            [0, 1],
-            [0, footerHeight.get()],
-          ),
+          translateY: interpolate(footerModeValue, [0, 1], [0, footerHeight]),
         },
       ],
     }

--- a/src/screens/Messages/components/MessagesList.tsx
+++ b/src/screens/Messages/components/MessagesList.tsx
@@ -279,14 +279,14 @@ export function MessagesList({
       onMove: e => {
         'worklet'
         keyboardHeight.set(e.height)
-        if (e.height > footerHeight.get()) {
+        if (e.height > footerHeight) {
           scrollTo(flatListRef, 0, 1e7, false)
         }
       },
       onEnd: e => {
         'worklet'
         keyboardHeight.set(e.height)
-        if (e.height > footerHeight.get()) {
+        if (e.height > footerHeight) {
           scrollTo(flatListRef, 0, 1e7, false)
         }
         keyboardIsOpening.set(false)
@@ -296,13 +296,11 @@ export function MessagesList({
   )
 
   const animatedListStyle = useAnimatedStyle(() => ({
-    marginBottom: Math.max(keyboardHeight.get(), footerHeight.get()),
+    marginBottom: Math.max(keyboardHeight.get(), footerHeight),
   }))
 
   const animatedStickyViewStyle = useAnimatedStyle(() => ({
-    transform: [
-      {translateY: -Math.max(keyboardHeight.get(), footerHeight.get())},
-    ],
+    transform: [{translateY: -Math.max(keyboardHeight.get(), footerHeight)}],
   }))
 
   // -- Message sending
@@ -446,6 +444,8 @@ export function MessagesList({
           ListHeaderComponent={
             <MaybeLoader isLoading={convoState.isFetchingHistory} />
           }
+          contentInset={{bottom: 0}}
+          contentContainerStyle={{paddingBottom: 0}}
         />
       </ScrollProvider>
       <Animated.View style={animatedStickyViewStyle}>

--- a/src/screens/Messages/components/MessagesList.tsx
+++ b/src/screens/Messages/components/MessagesList.tsx
@@ -50,8 +50,7 @@ import {MessageItem} from '#/components/dms/MessageItem'
 import {NewMessagesPill} from '#/components/dms/NewMessagesPill'
 import {Loader} from '#/components/Loader'
 import {Text} from '#/components/Typography'
-import {IS_NATIVE} from '#/env'
-import {IS_WEB} from '#/env'
+import {IS_NATIVE, IS_WEB} from '#/env'
 import {ChatStatusInfo} from './ChatStatusInfo'
 import {MessageInputEmbed, useMessageEmbed} from './MessageInputEmbed'
 
@@ -255,7 +254,7 @@ export function MessagesList({
 
   // -- Keyboard animation handling
   const {footerHeight: nativeFooterHeight} = useShellLayout()
-  const footerHeight = isWeb ? 0 : nativeFooterHeight
+  const footerHeight = IS_WEB ? 0 : nativeFooterHeight
 
   const keyboardHeight = useSharedValue(0)
   const keyboardIsOpening = useSharedValue(false)

--- a/src/screens/Messages/components/MessagesList.tsx
+++ b/src/screens/Messages/components/MessagesList.tsx
@@ -254,7 +254,8 @@ export function MessagesList({
   )
 
   // -- Keyboard animation handling
-  const {footerHeight} = useShellLayout()
+  const {footerHeight: nativeFooterHeight} = useShellLayout()
+  const footerHeight = isWeb ? 0 : nativeFooterHeight
 
   const keyboardHeight = useSharedValue(0)
   const keyboardIsOpening = useSharedValue(false)

--- a/src/screens/Messages/components/MessagesList.tsx
+++ b/src/screens/Messages/components/MessagesList.tsx
@@ -446,6 +446,7 @@ export function MessagesList({
           }
           contentInset={{bottom: 0}}
           contentContainerStyle={{paddingBottom: 0}}
+          scrollIndicatorInsets={{bottom: 0}}
         />
       </ScrollProvider>
       <Animated.View style={animatedStickyViewStyle}>

--- a/src/screens/PostThread/index.tsx
+++ b/src/screens/PostThread/index.tsx
@@ -1,6 +1,5 @@
 import {useCallback, useEffect, useMemo, useRef, useState} from 'react'
-import {useWindowDimensions, View} from 'react-native'
-import Animated, {useAnimatedStyle} from 'react-native-reanimated'
+import {type LayoutChangeEvent, useWindowDimensions, View} from 'react-native'
 import {Trans} from '@lingui/macro'
 
 import {useInitialNumToRender} from '#/lib/hooks/useInitialNumToRender'
@@ -59,6 +58,8 @@ export function PostThread({uri}: {uri: string}) {
     anchorPostSource?.feedSourceInfo,
     hasSession,
   )
+
+  const [promptHeight, setPromptHeight] = useState(43)
 
   /*
    * One query to rule them all
@@ -519,6 +520,7 @@ export function PostThread({uri}: {uri: string}) {
   )
 
   const defaultListFooterHeight = hasParents ? windowHeight - 200 : undefined
+  const hasPrompt = !gtMobile && canReply && hasSession
 
   return (
     <PostThreadContextProvider context={thread.context}>
@@ -604,29 +606,37 @@ export function PostThread({uri}: {uri: string}) {
            * Default: 50
            */
           updateCellsBatchingPeriod={100}
+          footerExtensionHeight={hasPrompt ? promptHeight : 0}
         />
       )}
 
-      {!gtMobile && canReply && hasSession && (
-        <MobileComposePrompt onPressReply={onReplyToAnchor} />
+      {hasPrompt && (
+        <MobileComposePrompt
+          onPressReply={onReplyToAnchor}
+          onLayout={evt =>
+            setPromptHeight(Math.round(evt.nativeEvent.layout.height))
+          }
+        />
       )}
     </PostThreadContextProvider>
   )
 }
 
-function MobileComposePrompt({onPressReply}: {onPressReply: () => unknown}) {
+function MobileComposePrompt({
+  onPressReply,
+  onLayout,
+}: {
+  onPressReply: () => unknown
+  onLayout?: (event: LayoutChangeEvent) => void
+}) {
   const {footerHeight} = useShellLayout()
 
-  const animatedStyle = useAnimatedStyle(() => {
-    return {
-      bottom: footerHeight.get(),
-    }
-  })
-
   return (
-    <Animated.View style={[a.fixed, a.left_0, a.right_0, animatedStyle]}>
+    <View
+      style={[a.fixed, a.left_0, a.right_0, {bottom: footerHeight}]}
+      onLayout={onLayout}>
       <ThreadComposePrompt onPressCompose={onPressReply} />
-    </Animated.View>
+    </View>
   )
 }
 

--- a/src/state/shell/shell-layout.tsx
+++ b/src/state/shell/shell-layout.tsx
@@ -1,6 +1,9 @@
 import {createContext, useContext, useMemo, useState} from 'react'
 import {type SharedValue, useSharedValue} from 'react-native-reanimated'
-import {useSafeAreaInsets} from 'react-native-safe-area-context'
+import {
+  type EdgeInsets,
+  useSafeAreaInsets,
+} from 'react-native-safe-area-context'
 
 import {clamp} from '#/lib/numbers'
 import {isWeb} from '#/platform/detection'
@@ -33,16 +36,7 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
   const insets = useSafeAreaInsets()
   const {gtMobile} = useBreakpoints()
   const [footerHeight, setFooterHeight] = useState(() =>
-    platform({
-      // try and precisely guess the footer height, then round it to 4 decimal places
-      // to remove floating point imprecision. if we can guess it exactly,
-      // we get to skip a rerender
-      native: round4dp(
-        47 + a.border.borderWidth + clamp(insets.bottom, 15, 60),
-      ),
-      web: 58,
-      default: 0,
-    }),
+    estimateInitialHeight(insets),
   )
 
   const value = useMemo(
@@ -61,6 +55,17 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
 
 export function useShellLayout() {
   return useContext(LayoutContext)
+}
+
+function estimateInitialHeight(insets: EdgeInsets): number {
+  return platform({
+    // try and precisely guess the footer height, then round it to 4 decimal places
+    // to remove floating point imprecision. if we can guess it exactly,
+    // we get to skip a rerender
+    native: round4dp(47 + a.border.borderWidth + clamp(insets.bottom, 15, 60)),
+    web: 58,
+    default: 0,
+  })
 }
 
 function round4dp(value: number) {

--- a/src/state/shell/shell-layout.tsx
+++ b/src/state/shell/shell-layout.tsx
@@ -6,8 +6,8 @@ import {
 } from 'react-native-safe-area-context'
 
 import {clamp} from '#/lib/numbers'
-import {isWeb} from '#/platform/detection'
 import {atoms as a, platform, useBreakpoints} from '#/alf'
+import {IS_WEB} from '#/env'
 
 type LayoutContextValue = {
   headerHeight: SharedValue<number>
@@ -42,7 +42,7 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
   const value = useMemo(
     () => ({
       headerHeight,
-      footerHeight: isWeb && gtMobile ? 0 : footerHeight,
+      footerHeight: IS_WEB && gtMobile ? 0 : footerHeight,
       setFooterHeight: (height: number) => setFooterHeight(round4dp(height)),
     }),
     [headerHeight, footerHeight, setFooterHeight, gtMobile],

--- a/src/view/com/util/List.tsx
+++ b/src/view/com/util/List.tsx
@@ -14,8 +14,8 @@ import {useScrollHandlers} from '#/lib/ScrollContext'
 import {addStyle} from '#/lib/styles'
 import {useLightbox} from '#/state/lightbox'
 import {useShellLayout} from '#/state/shell/shell-layout'
-import {ios, useTheme} from '#/alf'
-import {IS_ANDROID, IS_IOS} from '#/env'
+import {useTheme} from '#/alf'
+import {IS_IOS} from '#/env'
 import {FlatList_INTERNAL} from './Views'
 
 export type ListMethods = FlatList_INTERNAL
@@ -165,7 +165,7 @@ let List = forwardRef<ListMethods, ListProps>(
         viewabilityConfig={viewabilityConfig}
         {...props}
         contentContainerStyle={[
-          IS_ANDROID && {paddingBottom: footerHeight + footerExtensionHeight},
+          !IS_IOS && {paddingBottom: footerHeight + footerExtensionHeight},
           contentContainerStyle,
         ]}
         automaticallyAdjustsScrollIndicatorInsets={
@@ -177,13 +177,13 @@ let List = forwardRef<ListMethods, ListProps>(
           bottom: footerHeight + footerExtensionHeight,
           ...props.scrollIndicatorInsets,
         }}
-        contentInset={ios({
+        contentInset={{
           top: 0,
           left: 0,
           right: 0,
           bottom: footerHeight + footerExtensionHeight,
           ...props.contentInset,
-        })}
+        }}
         indicatorStyle={t.scheme === 'dark' ? 'white' : 'black'}
         contentOffset={contentOffset}
         refreshControl={refreshControl}

--- a/src/view/com/util/List.tsx
+++ b/src/view/com/util/List.tsx
@@ -13,8 +13,9 @@ import {useNonReactiveCallback} from '#/lib/hooks/useNonReactiveCallback'
 import {useScrollHandlers} from '#/lib/ScrollContext'
 import {addStyle} from '#/lib/styles'
 import {useLightbox} from '#/state/lightbox'
-import {useTheme} from '#/alf'
-import {IS_IOS} from '#/env'
+import {useShellLayout} from '#/state/shell/shell-layout'
+import {ios, useTheme} from '#/alf'
+import {IS_ANDROID, IS_IOS} from '#/env'
 import {FlatList_INTERNAL} from './Views'
 
 export type ListMethods = FlatList_INTERNAL
@@ -39,6 +40,7 @@ export type ListProps<ItemT = any> = Omit<
   disableFullWindowScroll?: boolean
   sideBorders?: boolean
   progressViewOffset?: number
+  footerExtensionHeight?: number
 }
 export type ListRef = React.RefObject<FlatList_INTERNAL | null>
 
@@ -55,6 +57,8 @@ let List = forwardRef<ListMethods, ListProps>(
       style,
       progressViewOffset,
       automaticallyAdjustsScrollIndicatorInsets = false,
+      contentContainerStyle,
+      footerExtensionHeight = 0,
       ...props
     },
     ref,
@@ -63,6 +67,7 @@ let List = forwardRef<ListMethods, ListProps>(
     const t = useTheme()
     const dedupe = useDedupe(400)
     const scrollsToTop = useAllowScrollToTop()
+    const {footerHeight} = useShellLayout()
 
     const handleScrolledDownChange = useNonReactiveCallback(
       (didScrollDown: boolean) => {
@@ -159,14 +164,26 @@ let List = forwardRef<ListMethods, ListProps>(
         onViewableItemsChanged={onViewableItemsChanged}
         viewabilityConfig={viewabilityConfig}
         {...props}
+        contentContainerStyle={[
+          IS_ANDROID && {paddingBottom: footerHeight + footerExtensionHeight},
+          contentContainerStyle,
+        ]}
         automaticallyAdjustsScrollIndicatorInsets={
           automaticallyAdjustsScrollIndicatorInsets
         }
         scrollIndicatorInsets={{
           top: headerOffset,
           right: 1,
+          bottom: footerHeight + footerExtensionHeight,
           ...props.scrollIndicatorInsets,
         }}
+        contentInset={ios({
+          top: 0,
+          left: 0,
+          right: 0,
+          bottom: footerHeight + footerExtensionHeight,
+          ...props.contentInset,
+        })}
         indicatorStyle={t.scheme === 'dark' ? 'white' : 'black'}
         contentOffset={contentOffset}
         refreshControl={refreshControl}

--- a/src/view/shell/bottom-bar/BottomBar.tsx
+++ b/src/view/shell/bottom-bar/BottomBar.tsx
@@ -59,7 +59,7 @@ export function BottomBar({navigation}: BottomTabBarProps) {
   const t = useTheme()
   const {_} = useLingui()
   const safeAreaInsets = useSafeAreaInsets()
-  const {footerHeight} = useShellLayout()
+  const {setFooterHeight} = useShellLayout()
   const {isAtHome, isAtSearch, isAtNotifications, isAtMyProfile, isAtMessages} =
     useNavigationTabState()
   const numUnreadNotifications = useUnreadNotifications()
@@ -151,9 +151,7 @@ export function BottomBar({navigation}: BottomTabBarProps) {
           {paddingBottom: clamp(safeAreaInsets.bottom, 15, 60)},
           footerMinimalShellTransform,
         ]}
-        onLayout={e => {
-          footerHeight.set(e.nativeEvent.layout.height)
-        }}>
+        onLayout={evt => setFooterHeight(evt.nativeEvent.layout.height)}>
         {hasSession ? (
           <>
             <Btn

--- a/src/view/shell/bottom-bar/BottomBarWeb.tsx
+++ b/src/view/shell/bottom-bar/BottomBarWeb.tsx
@@ -51,7 +51,7 @@ export function BottomBarWeb() {
   const footerMinimalShellTransform = useMinimalShellFooterTransform()
   const {requestSwitchToAccount} = useLoggedOutViewControls()
   const closeAllActiveElements = useCloseAllActiveElements()
-  const {footerHeight} = useShellLayout()
+  const {setFooterHeight} = useShellLayout()
   const hideBorder = useHideBottomBarBorder()
   const accountSwitchControl = useDialogControl()
   const {data: profile} = useProfileQuery({did: currentAccount?.did})
@@ -90,7 +90,7 @@ export function BottomBarWeb() {
             : t.atoms.border_contrast_low,
           footerMinimalShellTransform,
         ]}
-        onLayout={event => footerHeight.set(event.nativeEvent.layout.height)}>
+        onLayout={event => setFooterHeight(event.nativeEvent.layout.height)}>
         {hasSession ? (
           <>
             <NavItem routeName="Home" href="/">


### PR DESCRIPTION
# Stacked on #8543 

Changes `a.util_screen_outer` to be `100dvh` instead of `100vh`

Using a dynamic viewport height means that the DM screen now fits within the dynamic viewport area, and the input no longer gets stuck below the browser UI, and there's no double scrollbars.

This is a separate PR from the base because the implications may be a little far-reaching, as this globally changes every screen. However, just using the feed etc seems to work just fine. On a desktop browser, `dvh === vh`, and just using the app normally on my phone doesn't seem to have broken anything.

https://github.com/user-attachments/assets/b5fc68ea-7b9e-4075-af2a-0ec39cfade63

