### PR TITLE
Add even more optional chaining to navigation logic

### DIFF
--- a/src/components/Link.tsx
+++ b/src/components/Link.tsx
@@ -166,7 +166,7 @@ export function useLink({
               const state = navigation.getState()
               // if screen is not in the current navigator, it means it's
               // most likely a tab screen. note: state can be undefined
-              if (!state?.routeNames.includes(screen)) {
+              if (!state?.routeNames?.includes?.(screen)) {
                 const parent = navigation.getParent()
                 if (
                   parent &&


### PR DESCRIPTION
This is absurd, but apparently we need even more optional chaining on top of #9102 

Sentry errors are way down but not gone, because apparently `routeNames` can also be undefined (wtf)

Stupid I know

https://blueskyweb.sentry.io/issues/6720430884/events/982c38ce88d5438fabeac6fe849dda87/?project=4508807082278912&query=level%3Afatal&referrer=next-event