### PR TITLE
Prevent sparse arrays in snapToOffsets

### DIFF
--- a/src/components/InterestTabs.tsx
+++ b/src/components/InterestTabs.tsx
@@ -210,7 +210,7 @@ export function InterestTabs({
         showsHorizontalScrollIndicator={false}
         decelerationRate="fast"
         snapToOffsets={
-          tabOffsets.length === interests.length && tabOffsets.filter(o => !!o)
+          tabOffsets.filter(o => !!o).length === interests.length
             ? tabOffsets.map(o => o.x - tokens.space.xl)
             : undefined
         }


### PR DESCRIPTION
I accidentally introduced something quite stupid in #7128 - it would lay out all the interest tabs, and then when all the tabs had been all laid out, it would set the offsets to `snapToOffsets`. However, it would simplely compare lengths. If these rendered out-of-order, this could lead to a sparse array being committed, which would lead to NaNs, which breaks ScrollView internals.

To fix, we need to check that the array isn't sparse. the important one is `handleTabLayout()`, but for safety I have done a backup check during the render

Should fix https://blueskyweb.sentry.io/issues/6635168999/events/recommended/?project=4508807082278912&query=level%3Afatal&referrer=recommended-event