### PR TITLE
Always send #interactionReply

### DIFF
--- a/src/view/com/posts/PostFeedItem.tsx
+++ b/src/view/com/posts/PostFeedItem.tsx
@@ -175,24 +175,18 @@ let FeedItemInner = ({
   const {sendInteraction, feedSourceInfo} = useFeedFeedbackContext()
 
   const onPressReply = () => {
+    sendInteraction({
+      item: post.uri,
+      event: 'app.bsky.feed.defs#interactionReply',
+      feedContext,
+      reqId,
+    })
     if (gate('feed_reply_button_open_thread')) {
-      sendInteraction({
-        item: post.uri,
-        event: 'app.bsky.feed.defs#clickthroughItem',
-        feedContext,
-        reqId,
-      })
       navigation.navigate('PostThread', {
         name: post.author.did,
         rkey,
       })
     } else {
-      sendInteraction({
-        item: post.uri,
-        event: 'app.bsky.feed.defs#interactionReply',
-        feedContext,
-        reqId,
-      })
       openComposer({
         replyTo: {
           uri: post.uri,


### PR DESCRIPTION
We switched the event here for the AB test. However, since the interaction is more about intent-to-reply, we should keep the same event as before