### PR TITLE
Fix Android crash by try/catch dialog open

### DIFF
--- a/src/components/Dialog/context.ts
+++ b/src/components/Dialog/context.ts
@@ -7,13 +7,13 @@ import {
   useRef,
 } from 'react'
 
-import {logger} from '#/logger'
 import {useDialogStateContext} from '#/state/dialogs'
 import {
   type DialogContextProps,
   type DialogControlRefProps,
   type DialogOuterProps,
 } from '#/components/Dialog/types'
+import {IS_DEV} from '#/env'
 import {BottomSheetSnapPoint} from '../../../modules/bottom-sheet/src/BottomSheet.types'
 
 export const Context = createContext<DialogContextProps>({
@@ -51,18 +51,28 @@ export function useDialogControl(): DialogOuterProps['control'] {
       id,
       ref: control,
       open: () => {
-        try {
+        if (control.current) {
           control.current.open()
-        } catch (err) {
-          // note: we're seeing 100 crashes/day from the composer discard warning
-          // dialog being triggered by the android system back button immediately after posting
-          // Error is "Cannot read property 'open' of null"
-          // Is there a better way to handle this? I've try/catch'd this for now -sfn
-          logger.warn('Could not open dialog', {safeMessage: err})
+        } else {
+          if (IS_DEV) {
+            console.warn(
+              'Attemped to open a dialog control that was not attached to a dialog!\n' +
+                'Please ensure that the Dialog is mounted when calling open/close',
+            )
+          }
         }
       },
       close: cb => {
-        control.current.close(cb)
+        if (control.current) {
+          control.current.close(cb)
+        } else {
+          if (IS_DEV) {
+            console.warn(
+              'Attemped to close a dialog control that was not attached to a dialog!\n' +
+                'Please ensure that the Dialog is mounted when calling open/close',
+            )
+          }
+        }
       },
     }),
     [id, control],


### PR DESCRIPTION
We're seeing 100 crashes/day on Android from "Cannot read property 'open' of null" in `/Dialog/context.tsx`

It seems that the replication is to make a post and then immediately use the system back button. If you time it right, it'll catch it at just the wrong moment - the composer tries to handle the back press by opening the "discard post?" prompt, but the composer is dismissing so the dialog isn't available.

This seems like a flaw in our dialog API, but I don't have sufficient context to do a deeper fix beyond try/catching it. This specific call shouldn't crash the app, so a try/catch is probably good? But clearly something deeper is wrong with the way we're doing things

See [Sentry](https://blueskyweb.sentry.io/issues/6537272327/events/9a8ae09237834df7882d39f401995f01/?project=4508807082278912&query=is%3Aunresolved%20Cannot%20read%20property%20%27open%27%20of%20null&referrer=previous-event)