### PR TITLE
Configure basic CSP [DO NOT MERGE]

### DIFF
--- a/bskyweb/cmd/bskyweb/server.go
+++ b/bskyweb/cmd/bskyweb/server.go
@@ -135,10 +135,13 @@ func serve(cctx *cli.Context) error {
 
 	// SECURITY: Do not modify without due consideration.
 	e.Use(middleware.SecureWithConfig(middleware.SecureConfig{
-		ContentTypeNosniff:    "nosniff",
-		XFrameOptions:         "SAMEORIGIN",
-		HSTSMaxAge:            31536000, // 365 days
-		ContentSecurityPolicy: fmt.Sprintf("default-src * 'unsafe-inline' blob:; script-src 'self' %s", staticCDNHost),
+		ContentTypeNosniff: "nosniff",
+		XFrameOptions:      "SAMEORIGIN",
+		HSTSMaxAge:         31536000, // 365 days
+		// Note: If you're reading this because CSP broke something important, you can temporarily disable it by commenting the below line.
+		ContentSecurityPolicy: fmt.Sprintf("default-src * 'unsafe-inline' blob:; script-src 'self' %s www.youtube.com;", staticCDNHost),
+		// Our Youtube embeds are double-iframed. The outer iframe is on bsky.app and needs to run scripts from https://www.youtube.com/iframe_api
+
 		// Note: XSSProtection not configured because it is deprecated, superseded by CSP
 	}))
 	e.Use(middleware.LoggerWithConfig(middleware.LoggerConfig{

--- a/bskyweb/cmd/bskyweb/server.go
+++ b/bskyweb/cmd/bskyweb/server.go
@@ -135,12 +135,11 @@ func serve(cctx *cli.Context) error {
 
 	// SECURITY: Do not modify without due consideration.
 	e.Use(middleware.SecureWithConfig(middleware.SecureConfig{
-		ContentTypeNosniff: "nosniff",
-		XFrameOptions:      "SAMEORIGIN",
-		HSTSMaxAge:         31536000, // 365 days
-		// TODO:
-		// ContentSecurityPolicy
-		// XSSProtection
+		ContentTypeNosniff:    "nosniff",
+		XFrameOptions:         "SAMEORIGIN",
+		HSTSMaxAge:            31536000, // 365 days
+		ContentSecurityPolicy: fmt.Sprintf("default-src * 'unsafe-inline' blob:; script-src 'self' %s", staticCDNHost),
+		// Note: XSSProtection not configured because it is deprecated, superseded by CSP
 	}))
 	e.Use(middleware.LoggerWithConfig(middleware.LoggerConfig{
 		// Don't log requests for static content.


### PR DESCRIPTION
This PR configures a basic Content Security Policy.

To avoid breakage, the policy is very permissive by default (we can tighten it later). `script-src` is restricted to 'self' and the CDN host (if configured), notably *not* allowing unsafe-inline (which means we benefit from improved XSS protection).

Despite this, breakage is quite likely and we should test this rigorously before merging.

Also depends on https://github.com/bluesky-social/social-app/pull/9337

May also need `https://www.youtube.com https://s.ytimg.com` to be added to make youtube embeds work properly.