### PR TITLE
fix: feed title line heights

### DIFF
--- a/src/screens/Profile/components/ProfileFeedHeader.tsx
+++ b/src/screens/Profile/components/ProfileFeedHeader.tsx
@@ -442,12 +442,13 @@ function DialogInner({
 
         <View style={[a.flex_1, a.gap_2xs]}>
           <Text
-            style={[a.text_2xl, a.font_bold, a.leading_snug]}
-            numberOfLines={2}>
+            style={[a.text_2xl, a.font_bold, a.leading_tight]}
+            numberOfLines={2}
+            emoji>
             {info.displayName}
           </Text>
           <Text
-            style={[a.text_sm, a.leading_snug, t.atoms.text_contrast_medium]}
+            style={[a.text_sm, a.leading_relaxed, t.atoms.text_contrast_medium]}
             numberOfLines={1}>
             <Trans>
               By{' '}


### PR DESCRIPTION
Summary
---

Tall emojis like the box 📦 were being cut off due to too small of a line-height (leading).

So I've adjusted them to fit these emojis. Additionally I've adjusted some of the leading for the creator handle line below the feed title, such that it's a close as possible to the existing visual spacing.

Screenshots
---
<img width="390" height="2242" alt="image" src="https://github.com/user-attachments/assets/c153264d-285d-42b4-b6a5-e1c36bdd0ded" />

<img width="390" height="2242" alt="image" src="https://github.com/user-attachments/assets/482fd3a5-614c-47b2-a969-7e19dacaa644" />

<strong>After adding the emoji and adjusting leading</strong>
<img width="390" height="1414" alt="image" src="https://github.com/user-attachments/assets/647752cf-1359-4c3a-a834-efe749a328bf" />
