### PR TITLE
Tweak accessibility labels

### DIFF
--- a/src/components/dms/AfterReportDialog.tsx
+++ b/src/components/dms/AfterReportDialog.tsx
@@ -46,7 +46,7 @@ export const AfterReportDialog = memo(function BlockOrDeleteDialogInner({
       <Dialog.Handle />
       <Dialog.ScrollableInner
         label={_(
-          msg`Would you like to block this account or delete this conversation?`,
+          msg`Would you like to block this user and/or delete this conversation?`,
         )}
         style={[web({maxWidth: 400})]}>
         <DialogInner params={params} currentScreen={currentScreen} />
@@ -177,7 +177,7 @@ function DoneStep({
         </Text>
       </View>
       <Toggle.Group
-        label={_(msg`Block and/or delete this conversation`)}
+        label={_(msg`Block user and/or delete this conversation`)}
         values={actions}
         onChange={setActions}>
         <View style={[a.gap_md]}>


### PR DESCRIPTION
This PR suggests a few minor tweaks to a couple of accessibility labels added in #9213:

Change `account` to `user` for consistency with other usages in the dialog, and change `or` to `and/or` as both options may be selected:

`Would you like to block this account or delete this conversation?`
⬇️
`Would you like to block this user and/or delete this conversation?`

___

Add `user` to this string to improve clarity and for consistency with other strings in the dialog:

`Block and/or delete this conversation`
⬇️
`Block user and/or delete this conversation`

cc: @smileyhead