### PR TITLE
Try and guard against play/pause function being called after player is destroyed

### DIFF
--- a/src/screens/VideoFeed/index.tsx
+++ b/src/screens/VideoFeed/index.tsx
@@ -57,6 +57,7 @@ import {
 import {sanitizeDisplayName} from '#/lib/strings/display-names'
 import {cleanError} from '#/lib/strings/errors'
 import {sanitizeHandle} from '#/lib/strings/handles'
+import {logger} from '#/logger'
 import {isAndroid} from '#/platform/detection'
 import {useA11y} from '#/state/a11y'
 import {
@@ -1057,10 +1058,14 @@ function PlayPauseTapArea({
     // gets called after a timeout, so guard against being called after unmount -sfn
     if (!player || !isMounted.current) return
     doubleTapRef.current = null
-    if (player.playing) {
-      player.pause()
-    } else {
-      player.play()
+    try {
+      if (player.playing) {
+        player.pause()
+      } else {
+        player.play()
+      }
+    } catch (err) {
+      logger.error('Could not toggle play/pause', {safeMessage: err})
     }
   })
 


### PR DESCRIPTION
In the video feed, due to the double-tap feature, we call `player.pause()` etc after a short timeout. We can see this is causing errors due to the player getting destroyed while the timeout is in flight, and then we have a stale value for player meaning `player.playing` throws.

[Sentry here](https://blueskyweb.sentry.io/issues/6534817820/events/recommended/?project=4508807082278912&query=release%3A1.109.0%20level%3Afatal&referrer=recommended-event&sort=freq) - affects iOS and Android

The fix is two-pronged - we use `useNonReactiveCallback` and track if the component is mounted in an effect and use `isMounted.current` to try and avoid calling stale players, and then just to be safe I try/catch'd it, to stop this being a fatal error.