### PR TITLE
Use new async method for `player.replace`

### DIFF
--- a/src/screens/VideoFeed/index.tsx
+++ b/src/screens/VideoFeed/index.tsx
@@ -341,13 +341,13 @@ function Feed() {
         const nextPlayer = [player1, player2, player3][(index + 1) % 3]
 
         if (prevVideo && prevVideo !== prevPlayerCurrentSource?.source) {
-          prevPlayer.replace(prevVideo)
+          prevPlayer.replaceAsync(prevVideo)
         }
         prevPlayer.pause()
 
         if (currVideo) {
           if (currVideo !== currPlayerCurrentSource?.source) {
-            currPlayer.replace(currVideo)
+            currPlayer.replaceAsync(currVideo)
           }
           if (
             currVideoModeration &&
@@ -361,7 +361,7 @@ function Feed() {
         }
 
         if (nextVideo && nextVideo !== nextPlayerCurrentSource?.source) {
-          nextPlayer.replace(nextVideo)
+          nextPlayer.replaceAsync(nextVideo)
         }
         nextPlayer.pause()
       }


### PR DESCRIPTION
In the video feed, we use `player.replace` to replace the video source as you swipe. on iOS this is synchronous and leads to main thread hangs. `expo-video` has since added a new async method which does the loading on a different thread, with the sync method deprecated and soon to be removed, so we should use this new, better method.