### PR TITLE
Fix: `flatten` may return undefined

### DIFF
--- a/src/alf/typography.tsx
+++ b/src/alf/typography.tsx
@@ -25,7 +25,8 @@ export function normalizeTextStyles(
     fontFamily: Alf['fonts']['family']
   } & Pick<Alf, 'flags'>,
 ) {
-  const s = flatten(styles)
+  const s = flatten(styles) ?? {}
+
   // should always be defined on these components
   s.fontSize = (s.fontSize || atoms.text_md.fontSize) * fontScale
 

--- a/src/components/RichText.tsx
+++ b/src/components/RichText.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import {type TextStyle} from 'react-native'
+import {type StyleProp, type TextStyle} from 'react-native'
 import {AppBskyRichtextFacet, RichText as RichTextAPI} from '@atproto/api'
 
 import {toShortUrl} from '#/lib/strings/url-helpers'
@@ -21,7 +21,7 @@ export type RichTextProps = TextStyleProp &
     enableTags?: boolean
     authorHandle?: string
     onLinkPress?: LinkProps['onPress']
-    interactiveStyle?: TextStyle
+    interactiveStyle?: StyleProp<TextStyle>
     emojiMultiplier?: number
     shouldProxyLinks?: boolean
   }
@@ -55,7 +55,7 @@ export function RichText({
 
   if (!facets?.length) {
     if (isOnlyEmoji(text)) {
-      const flattenedStyle = flatten(style)
+      const flattenedStyle = flatten(style) ?? {}
       const fontSize =
         (flattenedStyle.fontSize ?? a.text_sm.fontSize) * emojiMultiplier
       return (


### PR DESCRIPTION
The style types annoyingly swallow the fact that style is optional, and thus `flatten(style)` may in fact be undefined when `style` is undefined. However, the types suggest that it is an object.

The crash was happening when `RichText` rendered only an emoji without extra styles being specified. This happened in the Feed card in search, hence why this was causing issues in search.

I also found and fixed another place where the result of `flatten()` is assumed to be an object.

# Test plan

Override `FeedCard.Description` to render just an emoji, and observe that the crash is now fixed