### PR TITLE
Image saving - fix extension, increase download timeout

### DIFF
--- a/src/lib/media/manip.ts
+++ b/src/lib/media/manip.ts
@@ -86,7 +86,7 @@ export async function shareImageModal({uri}: {uri: string}) {
 
   // we're currently relying on the fact our CDN only serves jpegs
   // -prf
-  const imageUri = await downloadImage(uri, createPath('jpg'), 5e3)
+  const imageUri = await downloadImage(uri, createPath('jpg'), 15e3)
   const imagePath = await moveToPermanentPath(imageUri, '.jpg')
   safeDeleteAsync(imageUri)
   await Sharing.shareAsync(imagePath, {
@@ -103,7 +103,7 @@ export async function saveImageToMediaLibrary({uri}: {uri: string}) {
   // assuming JPEG
   // we're currently relying on the fact our CDN only serves jpegs
   // -prf
-  const imageUri = await downloadImage(uri, createPath('jpg'), 5e3)
+  const imageUri = await downloadImage(uri, createPath('jpg'), 15e3)
   const imagePath = await moveToPermanentPath(imageUri, '.jpg')
 
   // save


### PR DESCRIPTION
Fixes https://github.com/bluesky-social/social-app/issues/9372

Two parts to this

# 1. We save files as `.png` even though they're JPEGs

There'a funny Paul comment from 2023 that says "assuming PNG, we're currently relying on the fact our CDN only serves pngs". reasonable except for the fact our CDN only serves JPEGs. Fixed to save as `.jpg` instead.

I don't foresee this causing any issues, but we should maybe keep an eye out for it.

This fixes a bug I didn't even know about, in that the share menu had the wrong mime type and thus couldn't display a thumbnail!

<table>
  <thead>
    <tr>
      <th>Before</th>
      <th>After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>
        <img width="300" src="https://github.com/user-attachments/assets/623a2973-5747-4394-8f22-045b060029ff" />
      </td>
      <td>
        <img width="300" src="https://github.com/user-attachments/assets/73881266-77e7-4a7c-bdd2-d1727acaef14" />
      </td>
    </tr>
  </tbody>
</table>

# 2. Increase download timeout to 15secs.

The "dlRes is undefined" (#9372) is from the image download timing out. Currently it's at the rather severe 5 seconds. I tried downloading a random feed image with my speed throttled to 450kb/s, and it took 9 seconds. I think we should increase this to at least 15 seconds.

Future thing we might want to is add a pending state here? Maybe to the toast? If there was feedback, I'd make it even longer tbh. For now let's just bump the number