### PR TITLE
Update image crop tool to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "expo-font": "~14.0.9",
     "expo-haptics": "~15.0.7",
     "expo-image": "~3.0.10",
-    "expo-image-crop-tool": "^0.1.8",
+    "expo-image-crop-tool": "^0.4.0",
     "expo-image-manipulator": "~14.0.7",
     "expo-image-picker": "~17.0.8",
     "expo-intent-launcher": "~13.0.7",

--- a/src/lib/media/picker.e2e.tsx
+++ b/src/lib/media/picker.e2e.tsx
@@ -67,7 +67,7 @@ export async function openCropper(opts: OpenCropperOptions) {
 
   return {
     path: item.path,
-    mime: item.mime,
+    mime: item.mimeType,
     size: item.size,
     width: item.width,
     height: item.height,

--- a/src/lib/media/picker.tsx
+++ b/src/lib/media/picker.tsx
@@ -1,5 +1,6 @@
 import ExpoImageCropTool, {type OpenCropperOptions} from 'expo-image-crop-tool'
 import {type ImagePickerOptions, launchCameraAsync} from 'expo-image-picker'
+import {t} from '@lingui/macro'
 
 export {
   openPicker,
@@ -31,13 +32,15 @@ export async function openCamera(customOpts: ImagePickerOptions) {
 
 export async function openCropper(opts: OpenCropperOptions) {
   const item = await ExpoImageCropTool.openCropperAsync({
+    doneButtonText: t`Done`,
+    cancelButtonText: t`Cancel`,
     ...opts,
     format: 'jpeg',
   })
 
   return {
     path: item.path,
-    mime: item.mime,
+    mime: item.mimeType,
     size: item.size,
     width: item.width,
     height: item.height,

--- a/yarn.lock
+++ b/yarn.lock
@@ -11348,10 +11348,10 @@ expo-haptics@~15.0.7:
   resolved "https://registry.yarnpkg.com/expo-haptics/-/expo-haptics-15.0.7.tgz#384bb873d7eca7b141f85e4f300b75eab68ebfe9"
   integrity sha512-7flWsYPrwjJxZ8x82RiJtzsnk1Xp9ahnbd9PhCy3NnsemyMApoWIEUr4waPqFr80DtiLZfhD9VMLL1CKa8AImQ==
 
-expo-image-crop-tool@^0.1.8:
-  version "0.1.8"
-  resolved "https://registry.yarnpkg.com/expo-image-crop-tool/-/expo-image-crop-tool-0.1.8.tgz#3e9f34825cf5d7dad1ef2786615571b078ece4e7"
-  integrity sha512-UlS1zV7JewUzuZzVT9aA0vFD1+dt+pU60ILgt3ntQl4G9SeDJ9bB/+ylz9dzn6BjZecUQkGJmbCQ3H7jGZeZMA==
+expo-image-crop-tool@^0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/expo-image-crop-tool/-/expo-image-crop-tool-0.4.0.tgz#c376b0695e8b2bf6b38fff5595ce30aaf9cddd64"
+  integrity sha512-2KZI016tb2i0yb0ZRMdH8h1I4YofD78fG/l6KrQTFzy4DtKaQlmJwU2VSJ8AYV5/nxusbHxgro7RQnr1BQ5lJg==
 
 expo-image-loader@~6.0.0:
   version "6.0.0"


### PR DESCRIPTION
Pulls in the changes from https://github.com/bluesky-social/expo-image-crop-tool/pull/14

In summary:
- Bug fixes
- Button labels are now translatable
- Fix crash on Android