### PR TITLE
Tweak string on threadgate button to use `Anyone` rather than `Anybody`

### DIFF
--- a/src/view/com/composer/threadgate/ThreadgateBtn.tsx
+++ b/src/view/com/composer/threadgate/ThreadgateBtn.tsx
@@ -126,7 +126,7 @@ export function ThreadgateBtn({
     !postgate.embeddingRules || postgate.embeddingRules.length === 0
   const anyoneCanInteract = anyoneCanReply && anyoneCanQuote
   const label = anyoneCanInteract
-    ? _(msg`Anybody can interact`)
+    ? _(msg`Anyone can interact`)
     : _(msg`Interaction limited`)
 
   return (


### PR DESCRIPTION
While using main, I noticed that there's a slight inconsistency in the language used to describe who can interact with a post. The threadgate button says `Anybody can interact`, whereas `Anyone` is used in the dialog.

![IMG_6084](https://github.com/user-attachments/assets/828d5582-b462-4a78-8394-ac9defbdfc18)
![IMG_6085](https://github.com/user-attachments/assets/3688629e-fcc5-4748-bafa-74cd1df716f8)

In fact, this is the only string in the app that uses `Anybody`, whereas there are six strings that use `Anyone`.

So for consistency, this PR suggests changing the string to `Anyone can interact`.