### PR TITLE
Remove `accessibilityHint` and tweak labels in post interaction settings dialog

### DIFF
--- a/src/components/dialogs/PostInteractionSettingsDialog.tsx
+++ b/src/components/dialogs/PostInteractionSettingsDialog.tsx
@@ -513,7 +513,6 @@ export function PostInteractionSettingsForm({
                     ? _(msg`Hide lists`)
                     : _(msg`Show lists of users to select from`)
                 }
-                accessibilityHint={_(msg`Toggle showing lists`)}
                 accessibilityRole="togglebutton"
                 hitSlop={0}
                 onPress={() => {
@@ -606,8 +605,8 @@ export function PostInteractionSettingsForm({
         type="checkbox"
         label={
           quotesEnabled
-            ? _(msg`Disable quote posts of this post.`)
-            : _(msg`Enable quote posts of this post.`)
+            ? _(msg`Disable quote posts of this post`)
+            : _(msg`Enable quote posts of this post`)
         }
         value={quotesEnabled}
         onChange={onChangeQuotesEnabled}>


### PR DESCRIPTION
I'm obviously no accessibility expert, but I don't think the `accessibilityHint` for the toggle button that shows or hides user lists in the post interaction settings dialog will be particularly helpful to screen reader users; it seems kind of redundant to me.

I asked Claude and this is what he said:

According to accessibility best practices:

- `accessibilityLabel` should describe what the element is
- `accessibilityHint` should describe what happens when you interact with it
- Hints should be used sparingly and only when the action isn't obvious from the label

The `accessibilityHint` isn't particularly helpful here and could be removed.

The dynamic `label` already clearly describes the action:
- "Show lists of users to select from" – unambiguous about what will happen
- "Hide lists" – equally clear

Combined with `accessibilityRole="togglebutton"`, screen reader users already have sufficient context. The hint "Toggle showing lists" doesn't add meaningful information beyond what the label provides; it's somewhat redundant.

**Recommendation**: Remove the `accessibilityHint`. The label is already action-oriented and clear enough on its own.

If you wanted to keep a hint for some reason, it should at least be more concise or provide additional value (e.g., describing *what* the lists are used for), but in this case, the lengthy label already does that job.

___

So this PR proposes removing it. It also suggests removing the trailing period/full stop from a couple of accessibility labels.