### PR TITLE
Fix android 2fa input not being paste-able

### DIFF
--- a/src/screens/Login/LoginForm.tsx
+++ b/src/screens/Login/LoginForm.tsx
@@ -65,11 +65,9 @@ export const LoginForm = ({
   const [isProcessing, setIsProcessing] = useState<boolean>(false)
   const [isAuthFactorTokenNeeded, setIsAuthFactorTokenNeeded] =
     useState<boolean>(false)
-  const [isAuthFactorTokenValueEmpty, setIsAuthFactorTokenValueEmpty] =
-    useState<boolean>(true)
   const identifierValueRef = useRef<string>(initialHandle || '')
   const passwordValueRef = useRef<string>('')
-  const authFactorTokenValueRef = useRef<string>('')
+  const [authFactorToken, setAuthFactorToken] = useState('')
   const identifierRef = useRef<TextInput>(null)
   const passwordRef = useRef<TextInput>(null)
   const hasFocusedOnce = useRef<boolean>(false)
@@ -91,7 +89,6 @@ export const LoginForm = ({
 
     const identifier = identifierValueRef.current.toLowerCase().trim()
     const password = passwordValueRef.current
-    const authFactorToken = authFactorTokenValueRef.current
 
     if (!identifier) {
       setError(_(msg`Please enter your username`))
@@ -290,24 +287,17 @@ export const LoginForm = ({
               autoCorrect={false}
               autoComplete="one-time-code"
               returnKeyType="done"
-              textContentType="username"
               blurOnSubmit={false} // prevents flickering due to onSubmitEditing going to next field
-              onChangeText={v => {
-                setIsAuthFactorTokenValueEmpty(v === '')
-                authFactorTokenValueRef.current = v
-              }}
+              onChangeText={setAuthFactorToken}
+              value={authFactorToken} // controlled input due to uncontrolled input not receiving pasted values properly
               onSubmitEditing={onPressNext}
               editable={!isProcessing}
               accessibilityHint={_(
                 msg`Input the code which has been emailed to you`,
               )}
-              style={[
-                {
-                  textTransform: isAuthFactorTokenValueEmpty
-                    ? 'none'
-                    : 'uppercase',
-                },
-              ]}
+              style={{
+                textTransform: authFactorToken === '' ? 'none' : 'uppercase',
+              }}
             />
           </TextField.Root>
           <Text style={[a.text_sm, t.atoms.text_contrast_medium, a.mt_sm]}>


### PR DESCRIPTION
Something weird about the 2fa input - it ignores the first time you try to paste into it on Android. the paste event does fire, but for some reason the uncontrolled input drops it 🙃

Fix is to make it controlled - it's not an input people are gonna speed type into anyway so no harm

I rate limited myself so I didn't get a "before" video but here's the "after":

https://github.com/user-attachments/assets/a00ea7d7-cd2c-4881-8b94-5c67950f6d00

