### PR TITLE
Android: Handle share intents when app first launches

### DIFF
--- a/modules/expo-receive-android-intents/android/src/main/java/xyz/blueskyweb/app/exporeceiveandroidintents/ExpoReceiveAndroidIntentsModule.kt
+++ b/modules/expo-receive-android-intents/android/src/main/java/xyz/blueskyweb/app/exporeceiveandroidintents/ExpoReceiveAndroidIntentsModule.kt
@@ -23,6 +23,10 @@ class ExpoReceiveAndroidIntentsModule : Module() {
     ModuleDefinition {
       Name("ExpoReceiveAndroidIntents")
 
+      OnCreate {
+        handleIntent(appContext.currentActivity?.intent)
+      }
+
       OnNewIntent {
         handleIntent(it)
       }

--- a/src/lib/hooks/useIntentHandler.ts
+++ b/src/lib/hooks/useIntentHandler.ts
@@ -24,7 +24,7 @@ const VALID_IMAGE_REGEX = /^[\w.:\-_/]+\|\d+(\.\d+)?\|\d+(\.\d+)?$/
 let previousIntentUrl = ''
 
 export function useIntentHandler() {
-  const incomingUrl = Linking.useURL()
+  const incomingUrl = Linking.useLinkingURL()
   const composeIntent = useComposeIntent()
   const verifyEmailIntent = useVerifyEmailIntent()
   const ageAssuranceRedirectDialogControl =
@@ -108,6 +108,7 @@ export function useIntentHandler() {
           } else {
             tryApplyUpdate(channel)
           }
+          return
         }
         default: {
           return


### PR DESCRIPTION
Fixes #8513

The share intent handler only handles new incoming intents - if the app was initialised with an intent, it doesn't get picked up. Fix is to read the current intent in `OnCreate` and handle that

This is similar to #8513 but that one also adds a timeout - in my testing the timeout is not necessary. I checked it on a mid-range and low-end real device and it works fine.

# Test plan

Create a production build on a real device. Make sure the app is fully dead. Share something (i.e. a link) to Bluesky and confirm it works.

- [x] I have tested thoroughly myself