### PR TITLE
Move interests nux, make neater

### DIFF
--- a/src/screens/Search/Explore.tsx
+++ b/src/screens/Search/Explore.tsx
@@ -682,15 +682,16 @@ export function Explore({
     // Dynamic module ordering
 
     i.push(topBorder)
-    i.push(...interestsNuxModule)
 
     if (useFullExperience) {
       i.push(trendingTopicsModule)
+      i.push(...interestsNuxModule)
       i.push(...suggestedFeedsModule)
       i.push(...suggestedFollowsModule)
       i.push(...suggestedStarterPacksModule)
       i.push(...feedPreviewsModule)
     } else {
+      i.push(...interestsNuxModule)
       i.push(...suggestedFollowsModule)
     }
 

--- a/src/screens/Search/modules/ExploreInterestsCard.tsx
+++ b/src/screens/Search/modules/ExploreInterestsCard.tsx
@@ -97,7 +97,7 @@ export function ExploreInterestsCard() {
                     a.top_0,
                     a.right_0,
                     a.bottom_0,
-                    {width: 20},
+                    {width: 30},
                   ]}
                 />
               </View>

--- a/src/screens/Search/modules/ExploreInterestsCard.tsx
+++ b/src/screens/Search/modules/ExploreInterestsCard.tsx
@@ -116,13 +116,13 @@ export function ExploreInterestsCard() {
             </View>
           ) : (
             <Link
-              label={_(msg`Edit interests`)}
+              label={_(msg`Add interests`)}
               to="/settings/interests"
-              size="large"
+              size="small"
               color="primary"
               style={[a.justify_center]}>
               <ButtonText>
-                <Trans>Tell us what you're interested in!</Trans>
+                <Trans>Add interests</Trans>
               </ButtonText>
             </Link>
           )}

--- a/src/screens/Search/modules/ExploreInterestsCard.tsx
+++ b/src/screens/Search/modules/ExploreInterestsCard.tsx
@@ -66,7 +66,7 @@ export function ExploreInterestsCard() {
 
           {preferences?.interests?.tags &&
           preferences.interests.tags.length > 0 ? (
-            <View style={[a.flex_row, a.w_full]}>
+            <View style={[a.flex_row, a.w_full, a.gap_xs]}>
               <View style={[a.flex_1, a.flex_row, a.overflow_hidden, {gap: 6}]}>
                 {preferences.interests.tags.map(tag => (
                   <View

--- a/src/screens/Search/modules/ExploreInterestsCard.tsx
+++ b/src/screens/Search/modules/ExploreInterestsCard.tsx
@@ -1,5 +1,7 @@
 import {useState} from 'react'
 import {View} from 'react-native'
+import {LinearGradient} from 'expo-linear-gradient'
+import {utils} from '@bsky.app/alf'
 import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
@@ -54,13 +56,7 @@ export function ExploreInterestsCard() {
       />
 
       <View style={[a.pb_2xs]}>
-        <View
-          style={[
-            a.p_lg,
-            a.border_b,
-            a.gap_md,
-            t.atoms.border_contrast_medium,
-          ]}>
+        <View style={[a.p_lg, a.gap_md]}>
           <View style={[a.flex_row, a.gap_sm, a.align_center]}>
             <Shapes />
             <Text style={[a.text_xl, a.font_semi_bold, a.leading_tight]}>
@@ -70,41 +66,70 @@ export function ExploreInterestsCard() {
 
           {preferences?.interests?.tags &&
           preferences.interests.tags.length > 0 ? (
-            <View style={[a.flex_row, a.flex_wrap, {gap: 6}]}>
-              {preferences.interests.tags.map(tag => (
-                <View
-                  key={tag}
+            <View style={[a.flex_row, a.w_full]}>
+              <View style={[a.flex_1, a.flex_row, a.overflow_hidden, {gap: 6}]}>
+                {preferences.interests.tags.map(tag => (
+                  <View
+                    key={tag}
+                    style={[
+                      a.justify_center,
+                      a.align_center,
+                      a.rounded_full,
+                      t.atoms.bg_contrast_25,
+                      a.px_lg,
+                      {height: 32},
+                    ]}>
+                    <Text style={[a.text_sm, t.atoms.text_contrast_high]}>
+                      {interestsDisplayNames[tag]}
+                    </Text>
+                  </View>
+                ))}
+                <LinearGradient
+                  key={t.name} // android does not update when you change the colors. sigh.
+                  start={[0, 0.5]}
+                  end={[1, 0.5]}
+                  colors={[
+                    utils.alpha(t.atoms.bg.backgroundColor, 0),
+                    t.atoms.bg.backgroundColor,
+                  ]}
                   style={[
-                    a.justify_center,
-                    a.align_center,
-                    a.rounded_full,
-                    t.atoms.bg_contrast_25,
-                    a.px_lg,
-                    {height: 32},
-                  ]}>
-                  <Text style={[a.text_sm, t.atoms.text_contrast_high]}>
-                    {interestsDisplayNames[tag]}
-                  </Text>
-                </View>
-              ))}
+                    a.absolute,
+                    a.top_0,
+                    a.right_0,
+                    a.bottom_0,
+                    {width: 20},
+                  ]}
+                />
+              </View>
+              <View style={[a.h_full, t.atoms.bg]}>
+                <Link
+                  label={_(msg`Edit interests`)}
+                  to="/settings/interests"
+                  size="small"
+                  color="primary_subtle"
+                  style={[a.justify_center]}>
+                  <ButtonText>
+                    <Trans>Edit</Trans>
+                  </ButtonText>
+                </Link>
+              </View>
             </View>
-          ) : null}
+          ) : (
+            <Link
+              label={_(msg`Edit interests`)}
+              to="/settings/interests"
+              size="large"
+              color="primary"
+              style={[a.justify_center]}>
+              <ButtonText>
+                <Trans>Tell us what you're interested in!</Trans>
+              </ButtonText>
+            </Link>
+          )}
 
           <Text style={[a.text_sm, a.leading_snug]}>
             <Trans>Your interests help us find what you like!</Trans>
           </Text>
-
-          <Link
-            label={_(msg`Edit interests`)}
-            to="/settings/interests"
-            size="small"
-            variant="solid"
-            color="primary"
-            style={[a.justify_center]}>
-            <ButtonText>
-              <Trans>Edit interests</Trans>
-            </ButtonText>
-          </Link>
 
           <Button
             label={_(msg`Hide this card`)}


### PR DESCRIPTION
I always found this to be really intrusive and annoying. I think we can make this much neater and more appealing. I made it one line, with the button overlapping on the right with a nice gradient. the button is smaller and less loud if you've already got some interests - still really loud if you don't have any yet. I also moved it below trending, which is still above the fold on all platforms, but feels more natural

# Before


<table>
  <tbody>
    <tr>
      <td><img width="300" src="https://github.com/user-attachments/assets/d9335b52-0126-460e-95c3-dc0015b7861f" /></td>
      <td><img width="300" src="https://github.com/user-attachments/assets/ab1bf289-b903-4ea0-a4e0-188ec4bc5cde" /></td>
      <td><img width="300" src="https://github.com/user-attachments/assets/00b2fb26-ab51-4c53-b49b-40ef3053f89a" /></td>
    </tr>
  </tbody>
</table>

# After

<table>
  <tbody>
    <tr>
      <td><img width="300" src="https://github.com/user-attachments/assets/7d289486-84fa-4034-b58e-cf71dd8266fa" /></td>
      <td><img width="300" src="https://github.com/user-attachments/assets/24e27ca2-f41d-44e1-bb68-f61a384f915a" /></td>
      <td><img width="300" src="https://github.com/user-attachments/assets/0902a5ec-ff3d-428d-a04f-a3845dd54a96" /></td>
    </tr>
  </tbody>
</table>

It still kinda sucks on web when empty, but it's a start

<img width="696" height="451" alt="Screenshot 2025-11-19 at 16 16 01" src="https://github.com/user-attachments/assets/671fdd71-6afb-4a17-9dc0-e00008c0ac16" />


