### PR TITLE
Fix QR code text alignment on Android

### DIFF
--- a/src/components/StarterPack/QrCode.tsx
+++ b/src/components/StarterPack/QrCode.tsx
@@ -76,16 +76,12 @@ export function QrCode({
             <QrCodeInner link={link} />
           </View>
 
-          <Text
-            style={[
-              a.flex,
-              a.flex_row,
-              a.align_center,
-              a.font_semi_bold,
-              {color: 'white', fontSize: 18, gap: 6},
-            ]}>
+          <View style={[a.flex, a.flex_row, a.align_center, {gap: 6}]}>
+            {/* eslint-disable-next-line bsky-internal/avoid-unwrapped-text */}
             <Trans>
-              on
+              <Text style={[{color: 'white', fontSize: 18}, a.font_semi_bold]}>
+                on
+              </Text>
               <View style={[a.flex_row, a.align_center, {gap: 6}]}>
                 <Logo width={25} fill="white" />
                 <View style={[{marginTop: 3.5}]}>
@@ -93,7 +89,7 @@ export function QrCode({
                 </View>
               </View>
             </Trans>
-          </Text>
+          </View>
         </View>
       </LinearGradientBackground>
     </LazyViewShot>


### PR DESCRIPTION
The "on Bluesky" part. Putting views inside Text on Android never works out the way you want it :(

<table>
  <tbody>
    <tr>
      <td><img width="300" src="https://github.com/user-attachments/assets/dedb2a25-4466-4b59-b97d-70ace39b2ff0" /></td>
      <td><img width="300" src="https://github.com/user-attachments/assets/fafebff9-be4c-4a35-b4bb-3c8cb0ee8ea2" /></td>
    </tr>
  </tbody>
</table>