### PR TITLE
Fix edge-case iOS sheets crash

### DIFF
--- a/modules/bottom-sheet/ios/SheetView.swift
+++ b/modules/bottom-sheet/ios/SheetView.swift
@@ -73,7 +73,7 @@ class SheetView: ExpoView, UISheetPresentationControllerDelegate {
 
   required init (appContext: AppContext? = nil) {
     super.init(appContext: appContext)
-    self.maxHeight = Util.getScreenHeight()
+    self.maxHeight = Util.getScreenHeight() ?? UIScreen.main.bounds.height
     self.touchHandler = RCTTouchHandler(bridge: appContext?.reactBridge)
     SheetManager.shared.add(self)
   }
@@ -124,6 +124,10 @@ class SheetView: ExpoView, UISheetPresentationControllerDelegate {
           let contentHeight = innerView.subviews.first?.frame.height,
           let rvc = self.reactViewController() else {
       return
+    }
+
+    if let screenHeight = Util.getScreenHeight() {
+      self.maxHeight = screenHeight
     }
 
     let sheetVc = SheetViewController()


### PR DESCRIPTION
Some sorta crash here: https://blueskyweb.sentry.io/issues/6979999823/events/32e10f3b65144eaeb05785d0ab6ffc0f/?project=4508807082278912&query=is%3Aunresolved%20os.name%3AiOS%20event.origin%3Aios%20level%3Afatal&referrer=previous-event&sort=freq

I think it's because `self.maxHeight` might be `nil` - let's add a fallback value, and additionally check it again when presenting