### PR TITLE
Prevent webview from showing during device attest

### DIFF
--- a/src/screens/Signup/StepCaptcha/CaptchaWebView.tsx
+++ b/src/screens/Signup/StepCaptcha/CaptchaWebView.tsx
@@ -21,12 +21,14 @@ export function CaptchaWebView({
   url,
   stateParam,
   state,
+  onComplete,
   onSuccess,
   onError,
 }: {
   url: string
   stateParam: string
   state?: SignupState
+  onComplete: () => void
   onSuccess: (code: string) => void
   onError: (error: unknown) => void
 }) {
@@ -71,6 +73,7 @@ export function CaptchaWebView({
 
     // We want to delay the completion of this screen ever so slightly so that it doesn't appear to be a glitch if it completes too fast
     wasSuccessful.current = true
+    onComplete()
     const now = Date.now()
     const timeTaken = now - startedAt.current
     if (timeTaken < MIN_DELAY) {

--- a/src/screens/Signup/StepCaptcha/index.tsx
+++ b/src/screens/Signup/StepCaptcha/index.tsx
@@ -156,6 +156,7 @@ function StepCaptchaInner({
               url={url}
               stateParam={stateParam}
               state={state}
+              onComplete={() => setCompleted(true)}
               onSuccess={onSuccess}
               onError={onError}
             />


### PR DESCRIPTION
Fixes https://bsky.app/profile/surfdude29.ispost.ing/post/3m62my2adpc2a

There's a timeout to make it feel less janky, however we keep showing the webview - we should show a spinner when it's in this pending state