### PR TITLE
Patch in upstream expo updates crash fix

### DIFF
--- a/patches/expo-updates+29.0.12.patch
+++ b/patches/expo-updates+29.0.12.patch
@@ -1,5 +1,26 @@
+diff --git a/node_modules/expo-updates/android/src/main/java/expo/modules/updates/loader/LoaderTask.kt b/node_modules/expo-updates/android/src/main/java/expo/modules/updates/loader/LoaderTask.kt
+index e9a8e3d..3c684e0 100644
+--- a/node_modules/expo-updates/android/src/main/java/expo/modules/updates/loader/LoaderTask.kt
++++ b/node_modules/expo-updates/android/src/main/java/expo/modules/updates/loader/LoaderTask.kt
+@@ -296,14 +296,13 @@ class LoaderTask(
+       ) {
+         try {
+           val embeddedLoader = EmbeddedLoader(context, configuration, logger, database, directory)
+-          val result = embeddedLoader.load { updateResponse ->
++          embeddedLoader.load { _ ->
+             Loader.OnUpdateResponseLoadedResult(shouldDownloadManifestIfPresentInResponse = true)
+           }
+-          launcher.launch(database)
+         } catch (e: Exception) {
+           logger.error("Unexpected error copying embedded update", e, UpdatesErrorCode.Unknown)
+-          launcher.launch(database)
+         }
++        launcher.launch(database)
+       } else {
+         launcher.launch(database)
+       }
 diff --git a/node_modules/expo-updates/ios/EXUpdates/Update/ExpoUpdatesUpdate.swift b/node_modules/expo-updates/ios/EXUpdates/Update/ExpoUpdatesUpdate.swift
-index b85291e..546709d 100644
+index 68086bd..78c7761 100644
 --- a/node_modules/expo-updates/ios/EXUpdates/Update/ExpoUpdatesUpdate.swift
 +++ b/node_modules/expo-updates/ios/EXUpdates/Update/ExpoUpdatesUpdate.swift
 @@ -78,13 +78,20 @@ public final class ExpoUpdatesUpdate: Update {


### PR DESCRIPTION
We're seeing a small number of crashes at launch on Android coming from expo-updates. I finally sat down to fix this and found it just got fixed like an hour ago in https://github.com/expo/expo/pull/41152. Thanks for reading my mind @alanjhughes!

It's super small so let's just patch it in until it gets released properly

**Test plan**: confirm my patch matches https://github.com/expo/expo/pull/41152/files