### PR TITLE
Fix status bar color in video feed

### DIFF
--- a/src/screens/VideoFeed/index.tsx
+++ b/src/screens/VideoFeed/index.tsx
@@ -8,7 +8,6 @@ import {
   type ViewabilityConfig,
   type ViewToken,
 } from 'react-native'
-import {SystemBars} from 'react-native-edge-to-edge'
 import {
   Gesture,
   GestureDetector,
@@ -153,7 +152,6 @@ export function VideoFeed({}: NativeStackScreenProps<
     <ThemeProvider theme="dark">
       <Layout.Screen noInsetTop style={{backgroundColor: 'black'}}>
         <KeepAwake />
-        <SystemBars style={{statusBar: 'light', navigationBar: 'light'}} />
         <View
           style={[
             a.absolute,


### PR DESCRIPTION
Fixes #9394

There was duplicate logic for setting the status bar color in the video feed. This is handled by `useSetLightStatusBar` so we don't need the `StatusBar` component