### PR TITLE
Speculative RN crash fix

### DIFF
--- a/patches/react-native+0.81.5+004+IdleCallbackRunnable-crash-fix.patch
+++ b/patches/react-native+0.81.5+004+IdleCallbackRunnable-crash-fix.patch
@@ -1,0 +1,16 @@
+diff --git a/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/core/JavaTimerManager.kt b/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/core/JavaTimerManager.kt
+index 8b65716..27c97bf 100644
+--- a/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/core/JavaTimerManager.kt
++++ b/node_modules/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/core/JavaTimerManager.kt
+@@ -313,8 +313,9 @@ public open class JavaTimerManager(
+       // We also capture the idleCallbackRunnable to tentatively fix:
+       // https://github.com/facebook/react-native/issues/44842
+       currentIdleCallbackRunnable?.cancel()
+-      currentIdleCallbackRunnable = IdleCallbackRunnable(frameTimeNanos)
+-      reactApplicationContext.runOnJSQueueThread(currentIdleCallbackRunnable)
++      val idleCallbackRunnable = IdleCallbackRunnable(frameTimeNanos)
++      currentIdleCallbackRunnable = idleCallbackRunnable
++      reactApplicationContext.runOnJSQueueThread(idleCallbackRunnable)
+       reactChoreographer.postFrameCallback(ReactChoreographer.CallbackType.IDLE_EVENT, this)
+     }
+   }


### PR DESCRIPTION
# Stacked on #9429 

Weirdly, we're seeing something very similar to https://github.com/facebook/react-native/issues/44842 reappear. A fix for that did indeed get upstreamed, but it's back!

```
Exception java.lang.NullPointerException: Parameter specified as non-null is null: method com.facebook.react.bridge.queue.MessageQueueThreadImpl.runOnQueue, parameter runnable
  at com.facebook.react.bridge.queue.MessageQueueThreadImpl.runOnQueue (Unknown Source:3)
  at com.facebook.react.bridge.ReactContext.runOnJSQueueThread (ReactContext.java:415)
  at com.facebook.react.modules.core.JavaTimerManager$IdleFrameCallback.doFrame (JavaTimerManager.kt:317)
  at com.facebook.react.modules.core.ReactChoreographer.frameCallback$lambda$1 (ReactChoreographer.kt:59)
  at com.facebook.react.modules.core.ReactChoreographer.$r8$lambda$nSkFhrr5T7rop_XKwzlLov4NLLw (Unknown Source)
  at com.facebook.react.modules.core.ReactChoreographer$$ExternalSyntheticLambda0.doFrame (D8$$SyntheticClass)
  at android.view.Choreographer$CallbackRecord.run (Choreographer.java:1542)
  at android.view.Choreographer$CallbackRecord.run (Choreographer.java:1553)
  at android.view.Choreographer.doCallbacks (Choreographer.java:1109)
  at android.view.Choreographer.doFrame (Choreographer.java:984)
  at android.view.Choreographer$FrameDisplayEventReceiver.run (Choreographer.java:1527)
  at android.os.Handler.handleCallback (Handler.java:958)
  at android.os.Handler.dispatchMessage (Handler.java:99)
  at android.os.Looper.loopOnce (Looper.java:257)
  at android.os.Looper.loop (Looper.java:368)
  at android.app.ActivityThread.main (ActivityThread.java:8839)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:572)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1049)
```

## My theory:

The original fix was to capture the value of `mCurrentIdleCallbackRunnable` to a local variable before calling `cancel()`:
https://github.com/cortinico/react-native/commit/54df8fcbc33be075298090824d8e324d9717ea73

Then, the file got converted to Kotlin, where it has optional chaining syntax that handle it automatically.

```kotlin
currentIdleCallbackRunnable?.cancel()
currentIdleCallbackRunnable = IdleCallbackRunnable(frameTimeNanos)
reactApplicationContext.runOnJSQueueThread(currentIdleCallbackRunnable)
```

However, to my eyes, it seems the next two lines of code have the same problem as before:


```kotlin
currentIdleCallbackRunnable?.cancel() // yay, no longer crashes!
currentIdleCallbackRunnable = IdleCallbackRunnable(frameTimeNanos) // writes to currentIdleCallbackRunnable
reactApplicationContext.runOnJSQueueThread(currentIdleCallbackRunnable) // ‼️ reads from currentIdleCallbackRunnable
```

Since `currentIdleCallbackRunnable` apparently has a habit of being changed out from under you, we should probably do the same local capture thing as last time, to ensure we're passing the correct thing to `runOnJSQueueThread`

```kotlin
val idleCallbackRunnable = IdleCallbackRunnable(frameTimeNanos)
currentIdleCallbackRunnable = idleCallbackRunnable
reactApplicationContext.runOnJSQueueThread(idleCallbackRunnable)
```

# Test plan

Confirm it compiles I guess. I have no idea how to repro the crash - I think we should just merge this and then watch the crash monitoring to see if it works, and then upstream it to RN if it does