### PR TITLE
feat: add plyr.fm embed support

### DIFF
--- a/src/lib/strings/embed-player.ts
+++ b/src/lib/strings/embed-player.ts
@@ -62,7 +62,7 @@ export const externalEmbedLabels: Record<EmbedPlayerSource, string> = {
   soundcloud: 'SoundCloud',
   flickr: 'Flickr',
   bandcamp: 'Bandcamp',
-  plyr: 'Plyr.fm',
+  plyr: 'plyr.fm',
 }
 
 export interface EmbedPlayerParams {

--- a/src/lib/strings/embed-player.ts
+++ b/src/lib/strings/embed-player.ts
@@ -25,6 +25,7 @@ export const embedPlayerSources = [
   'tenor',
   'flickr',
   'bandcamp',
+  'plyr',
 ] as const
 
 export type EmbedPlayerSource = (typeof embedPlayerSources)[number]
@@ -47,6 +48,7 @@ export type EmbedPlayerType =
   | 'flickr_album'
   | 'bandcamp_album'
   | 'bandcamp_track'
+  | 'plyr_track'
 
 export const externalEmbedLabels: Record<EmbedPlayerSource, string> = {
   youtube: 'YouTube',
@@ -60,6 +62,7 @@ export const externalEmbedLabels: Record<EmbedPlayerSource, string> = {
   soundcloud: 'SoundCloud',
   flickr: 'Flickr',
   bandcamp: 'Bandcamp',
+  plyr: 'Plyr.fm',
 }
 
 export interface EmbedPlayerParams {
@@ -86,6 +89,19 @@ export function parseEmbedPlayerFromUrl(
     urlp = new URL(url)
   } catch (e) {
     return undefined
+  }
+
+  // plyr.fm
+  if (urlp.hostname === 'plyr.fm' || urlp.hostname === 'www.plyr.fm') {
+    const [__, type, id] = urlp.pathname.split('/')
+
+    if (type === 'track' && id) {
+      return {
+        type: 'plyr_track',
+        source: 'plyr',
+        playerUri: `https://plyr.fm/embed/track/${id}?autoplay=1`,
+      }
+    }
   }
 
   // youtube
@@ -525,6 +541,8 @@ export function getPlayerAspect({
       }
       return {height: 232}
     case 'soundcloud_track':
+      return {height: 165}
+    case 'plyr_track':
       return {height: 165}
     case 'apple_music_song':
       return {height: 150}

--- a/src/lib/strings/embed-player.ts
+++ b/src/lib/strings/embed-player.ts
@@ -26,6 +26,7 @@ export const embedPlayerSources = [
   'klipy',
   'flickr',
   'bandcamp',
+  'plyr',
 ] as const
 
 export type EmbedPlayerSource = (typeof embedPlayerSources)[number]
@@ -49,6 +50,7 @@ export type EmbedPlayerType =
   | 'flickr_album'
   | 'bandcamp_album'
   | 'bandcamp_track'
+  | 'plyr_track'
 
 export const externalEmbedLabels: Record<EmbedPlayerSource, string> = {
   youtube: 'YouTube',
@@ -63,6 +65,7 @@ export const externalEmbedLabels: Record<EmbedPlayerSource, string> = {
   soundcloud: 'SoundCloud',
   flickr: 'Flickr',
   bandcamp: 'Bandcamp',
+  plyr: 'plyr.fm',
 }
 
 /**
@@ -105,6 +108,19 @@ export function parseEmbedPlayerFromUrl(
     urlp = new URL(url)
   } catch (e) {
     return undefined
+  }
+
+  // plyr.fm
+  if (urlp.hostname === 'plyr.fm' || urlp.hostname === 'www.plyr.fm') {
+    const [__, type, id] = urlp.pathname.split('/')
+
+    if (type === 'track' && id) {
+      return {
+        type: 'plyr_track',
+        source: 'plyr',
+        playerUri: `https://plyr.fm/embed/track/${id}?autoplay=1`,
+      }
+    }
   }
 
   // youtube
@@ -560,6 +576,8 @@ export function getPlayerAspect({
       }
       return {height: 232}
     case 'soundcloud_track':
+      return {height: 165}
+    case 'plyr_track':
       return {height: 165}
     case 'apple_music_song':
       return {height: 150}

--- a/src/state/persisted/schema.ts
+++ b/src/state/persisted/schema.ts
@@ -107,6 +107,7 @@ const schema = z.object({
       soundcloud: z.enum(externalEmbedOptions).optional(),
       flickr: z.enum(externalEmbedOptions).optional(),
       bandcamp: z.enum(externalEmbedOptions).optional(),
+      plyr: z.enum(externalEmbedOptions).optional(),
     })
     .optional(),
   invites: z.object({

--- a/src/state/persisted/schema.ts
+++ b/src/state/persisted/schema.ts
@@ -108,6 +108,7 @@ const schema = z.object({
       soundcloud: z.enum(externalEmbedOptions).optional(),
       flickr: z.enum(externalEmbedOptions).optional(),
       bandcamp: z.enum(externalEmbedOptions).optional(),
+      plyr: z.enum(externalEmbedOptions).optional(),
     })
     .optional(),
   invites: z.object({


### PR DESCRIPTION
this PR adds support for [plyr.fm](https://plyr.fm) audio embeds, similar to the existing SoundCloud integration.

**changes:**
- adds 'plyr' to `embedPlayerSources` and `externalEmbedLabels`.
- adds 'plyr_track' to `EmbedPlayerType`.
- implements URL parsing for `plyr.fm` and `www.plyr.fm` to detect track paths.
- configures the embed aspect ratio (height: 165px) to roughly match the plyr.fm player

plyr.fm is an atproto-native music streaming platform. This integration allows users to share tracks that can be played directly within the timeline.


<img width="832" height="529" alt="image" src="https://github.com/user-attachments/assets/a2ac313c-035f-42cc-90d4-c0bdb4e5f9df" />

https://bsky.app/profile/plyr.fm/post/3m6cvbcytu22i