### PR TITLE
Fix messages input box visibilty

### DIFF
--- a/src/screens/Messages/components/MessagesList.tsx
+++ b/src/screens/Messages/components/MessagesList.tsx
@@ -299,11 +299,18 @@ export function MessagesList({
     marginBottom: Math.max(keyboardHeight.get(), footerHeight.get()),
   }))
 
-  const animatedStickyViewStyle = useAnimatedStyle(() => ({
-    transform: [
-      {translateY: -Math.max(keyboardHeight.get(), footerHeight.get())},
-    ],
-  }))
+  const animatedStickyViewStyle = useAnimatedStyle(() => {
+    if (!isNative) {
+      return {
+        transform: [{translateY: 0}],
+      }
+    }
+    return {
+      transform: [
+        {translateY: -Math.max(keyboardHeight.get(), footerHeight.get())},
+      ],
+    }
+  })
 
   // -- Message sending
   const onSendMessage = useCallback(

--- a/src/screens/Messages/components/MessagesList.tsx
+++ b/src/screens/Messages/components/MessagesList.tsx
@@ -301,9 +301,7 @@ export function MessagesList({
 
   const animatedStickyViewStyle = useAnimatedStyle(() => {
     if (!isNative) {
-      return {
-        transform: [{translateY: 0}],
-      }
+      return {}
     }
     return {
       transform: [


### PR DESCRIPTION
I noticed when sending messages from the Bluesky website, the input box covered messages. 
<img width="1662" height="1014" alt="image" src="https://github.com/user-attachments/assets/5db80d35-0c6e-47ca-a542-f2b7b8f18fc2" />
This is due to the navigation bar, which is shown under certain viewport widths, but is still taken into account after hiding for that input's position. This PR should fix that for the website!
<img width="1660" height="1012" alt="image" src="https://github.com/user-attachments/assets/6c6bda4d-02b6-4e00-9295-e66e6f2b1fb6" />
I've tested this on web and Android through [my Bluesky fork](https://bitchsky.app), but it should still work on iOS.