### PR TITLE
Patch in proguard rules to fix video fullscreen

### DIFF
--- a/patches/@haileyok+bluesky-video+0.3.2.patch
+++ b/patches/@haileyok+bluesky-video+0.3.2.patch
@@ -1,0 +1,20 @@
+diff --git a/node_modules/@haileyok/bluesky-video/android/build.gradle b/node_modules/@haileyok/bluesky-video/android/build.gradle
+index b988d3f..7743421 100644
+--- a/node_modules/@haileyok/bluesky-video/android/build.gradle
++++ b/node_modules/@haileyok/bluesky-video/android/build.gradle
+@@ -36,6 +36,7 @@ android {
+   defaultConfig {
+     versionCode 1
+     versionName "0.1.0"
++    consumerProguardFiles 'proguard-rules.pro'
+   }
+   lintOptions {
+     abortOnError false
+diff --git a/node_modules/@haileyok/bluesky-video/android/proguard-rules.pro b/node_modules/@haileyok/bluesky-video/android/proguard-rules.pro
+new file mode 100644
+index 0000000..3b5b864
+--- /dev/null
++++ b/node_modules/@haileyok/bluesky-video/android/proguard-rules.pro
+@@ -0,0 +1,2 @@
++# Keep FullscreenActivity from being stripped by R8/ProGuard
++-keep class expo.modules.blueskyvideo.FullscreenActivity { *; }


### PR DESCRIPTION
Maybe fixes #9437 

Video fullscreen mode has an issue with sometimes it not being able to find the activity. My theory is that when google play generates the builds from the AAB, it accidentally strips out the activity. I'm hoping explicitly whitelisting the file will do... something.

## Test plan

If you have the issue already, see if it fixes it.

If not...
¯\\_(ツ)_/¯