### PR TITLE
Use FULL_SCREEN presentation for IAB

### DIFF
--- a/src/lib/hooks/useOpenLink.ts
+++ b/src/lib/hooks/useOpenLink.ts
@@ -16,13 +16,11 @@ import {isNative} from '#/platform/detection'
 import {useInAppBrowser} from '#/state/preferences/in-app-browser'
 import {useTheme} from '#/alf'
 import {useDialogContext} from '#/components/Dialog'
-import {useSheetWrapper} from '#/components/Dialog/sheet-wrapper'
 import {useGlobalDialogsControlContext} from '#/components/dialogs/Context'
 
 export function useOpenLink() {
   const enabled = useInAppBrowser()
   const t = useTheme()
-  const sheetWrapper = useSheetWrapper()
   const dialogContext = useDialogContext()
   const {inAppBrowserConsentControl} = useGlobalDialogsControlContext()
 
@@ -58,25 +56,23 @@ export function useOpenLink() {
           }
           return
         } else if (override ?? enabled) {
-          await sheetWrapper(
-            WebBrowser.openBrowserAsync(url, {
-              presentationStyle:
-                WebBrowser.WebBrowserPresentationStyle.PAGE_SHEET,
-              toolbarColor: t.atoms.bg.backgroundColor,
-              controlsColor: t.palette.primary_500,
-              createTask: false,
-            }).catch(err => {
-              if (__DEV__)
-                logger.error('Could not open web browser', {message: err})
-              Linking.openURL(url)
-            }),
-          )
+          WebBrowser.openBrowserAsync(url, {
+            presentationStyle:
+              WebBrowser.WebBrowserPresentationStyle.FULL_SCREEN,
+            toolbarColor: t.atoms.bg.backgroundColor,
+            controlsColor: t.palette.primary_500,
+            createTask: false,
+          }).catch(err => {
+            if (__DEV__)
+              logger.error('Could not open web browser', {message: err})
+            Linking.openURL(url)
+          })
           return
         }
       }
       Linking.openURL(url)
     },
-    [enabled, inAppBrowserConsentControl, t, sheetWrapper, dialogContext],
+    [enabled, inAppBrowserConsentControl, t, dialogContext],
   )
 
   return openLink


### PR DESCRIPTION
The sheet presentation is quite annoying to dismiss. Also, Apple says we shouldn't use it lol:
  
<img width="972" height="301" alt="Screenshot 2025-11-26 at 10 17 05" src="https://github.com/user-attachments/assets/63987983-e51e-482e-9d6a-5feaeee94f9e" />

Let's use the FULL_SCREEN presentation like how every other app does:

https://github.com/user-attachments/assets/bd23b209-1af0-4260-825d-f2958271917c

