### PR TITLE
Make multiline (alt) text inputs resizable on web

### DIFF
--- a/src/components/forms/TextField.tsx
+++ b/src/components/forms/TextField.tsx
@@ -1,4 +1,4 @@
-import {createContext, useContext, useMemo, useRef} from 'react'
+import React, {createContext, useContext, useMemo, useRef} from 'react'
 import {
   type AccessibilityProps,
   StyleSheet,
@@ -83,6 +83,20 @@ export function Root({children, isInvalid = false, style}: RootProps) {
     ],
   )
 
+  // Check if any child has multiline prop
+  const hasMultiline = useMemo(() => {
+    let found = false
+    React.Children.forEach(children, child => {
+      if (
+        React.isValidElement(child) &&
+        (child.props as {multiline?: boolean})?.multiline
+      ) {
+        found = true
+      }
+    })
+    return found
+  }, [children])
+
   return (
     <Context.Provider value={context}>
       <View
@@ -91,7 +105,7 @@ export function Root({children, isInvalid = false, style}: RootProps) {
           a.align_center,
           a.relative,
           a.w_full,
-          a.px_md,
+          !hasMultiline && a.px_md,
           style,
         ]}
         {...web({
@@ -222,6 +236,13 @@ export function createInput(Component: typeof TextInput) {
         marginTop: 2,
         marginBottom: 2,
       }),
+      rest.multiline &&
+        web({
+          resize: 'vertical',
+          fieldSizing: 'content',
+          paddingLeft: 16,
+          paddingRight: 16,
+        }),
       style,
     ])
 

--- a/src/components/forms/TextField.tsx
+++ b/src/components/forms/TextField.tsx
@@ -11,6 +11,7 @@ import {
 
 import {HITSLOP_20} from '#/lib/constants'
 import {mergeRefs} from '#/lib/merge-refs'
+import {isWeb} from '#/platform/detection'
 import {
   android,
   applyFonts,
@@ -105,7 +106,7 @@ export function Root({children, isInvalid = false, style}: RootProps) {
           a.align_center,
           a.relative,
           a.w_full,
-          !hasMultiline && a.px_md,
+          !(hasMultiline && isWeb) && a.px_md,
           style,
         ]}
         {...web({


### PR DESCRIPTION
Was really annoyed with how hard it was to enter alt text in a browser, so this change should add a resize indicator and automatically increase the size of the box on chromium browsers. (soon Webkit, Gecko in the future?)

Tested on web, Android (iOS would probably be the same). 
The 'Check if any child has multiline prop' snippet [was AI generated](https://witchsky.app/profile/did:plc:q7suwaz53ztc4mbiqyygbn43/post/3m6lnjylyuk2i).