### PR TITLE
add dot separated time style

### DIFF
--- a/src/lib/strings/time.ts
+++ b/src/lib/strings/time.ts
@@ -1,11 +1,21 @@
 import {type I18n} from '@lingui/core'
+import {msg} from '@lingui/macro'
 
 export function niceDate(
   i18n: I18n,
   date: number | string | Date,
-  dateStyle: 'short' | 'medium' | 'long' | 'full' = 'long',
+  dateStyle: 'short' | 'medium' | 'long' | 'full' | 'dot separated' = 'long',
 ) {
   const d = new Date(date)
+
+  if (dateStyle === 'dot separated') {
+    return i18n._(
+      msg({
+        context: 'date and time formatted like this: [time] · [date]',
+        message: `${i18n.date(d, {timeStyle: 'short'})} · ${i18n.date(d, {day: 'numeric', month: 'numeric', year: '2-digit'})}`,
+      }),
+    )
+  }
 
   return i18n.date(d, {
     dateStyle,

--- a/src/screens/PostThread/components/ThreadItemAnchor.tsx
+++ b/src/screens/PostThread/components/ThreadItemAnchor.tsx
@@ -570,7 +570,7 @@ function ExpandedPostDetails({
       <BackdatedPostIndicator post={post} />
       <View style={[a.flex_row, a.align_center, a.flex_wrap, a.gap_sm]}>
         <Text style={[a.text_sm, t.atoms.text_contrast_medium]}>
-          {niceDate(i18n, post.indexedAt, 'medium')}
+          {niceDate(i18n, post.indexedAt, 'dot separated')}
         </Text>
         {isRootPost && (
           <WhoCanReply post={post} isThreadAuthor={isThreadAuthor} />
@@ -655,7 +655,7 @@ function BackdatedPostIndicator({post}: {post: AppBskyFeedDefs.PostView}) {
                 a.leading_tight,
                 t.atoms.text_contrast_medium,
               ]}>
-              <Trans>Archived from {niceDate(i18n, createdAt)}</Trans>
+              <Trans>Archived from {niceDate(i18n, createdAt, 'medium')}</Trans>
             </Text>
           </View>
         )}


### PR DESCRIPTION
Adds custom datetime format that is as small as feasible for thread anchors

<img width="184" height="124" alt="Screenshot 2025-11-27 at 14 08 09" src="https://github.com/user-attachments/assets/207553c3-46e6-415b-bee0-d6cab4e2b1c6" />
