### PR TITLE
optimistic like and repost counts

### DIFF
--- a/src/state/cache/post-shadow.ts
+++ b/src/state/cache/post-shadow.ts
@@ -25,6 +25,9 @@ export interface PostShadow {
   embed: AppBskyEmbedRecord.View | AppBskyEmbedRecordWithMedia.View | undefined
   pinned: boolean
   optimisticReplyCount: number | undefined
+  optimisticLikeCount: number | undefined
+  optimisticRepostCount: number | undefined
+  optimisticBookmarkCount: number | undefined
   bookmarked: boolean | undefined
 }
 
@@ -82,6 +85,10 @@ function mergeShadow(
   }
 
   let likeCount = post.likeCount ?? 0
+
+  likeCount = shadow.optimisticLikeCount ?? likeCount
+
+  console.log({likeCount, optimisticLikeCount: shadow.optimisticLikeCount})
   if ('likeUri' in shadow) {
     const wasLiked = !!post.viewer?.like
     const isLiked = !!shadow.likeUri
@@ -94,6 +101,8 @@ function mergeShadow(
   }
 
   let bookmarkCount = post.bookmarkCount ?? 0
+
+  bookmarkCount = shadow.optimisticBookmarkCount ?? bookmarkCount
   if ('bookmarked' in shadow) {
     const wasBookmarked = !!post.viewer?.bookmarked
     const isBookmarked = !!shadow.bookmarked
@@ -106,6 +115,8 @@ function mergeShadow(
   }
 
   let repostCount = post.repostCount ?? 0
+
+  repostCount = shadow.optimisticRepostCount ?? repostCount
   if ('repostUri' in shadow) {
     const wasReposted = !!post.viewer?.repost
     const isReposted = !!shadow.repostUri

--- a/src/state/cache/post-shadow.ts
+++ b/src/state/cache/post-shadow.ts
@@ -27,7 +27,6 @@ export interface PostShadow {
   optimisticReplyCount: number | undefined
   optimisticLikeCount: number | undefined
   optimisticRepostCount: number | undefined
-  optimisticBookmarkCount: number | undefined
   bookmarked: boolean | undefined
 }
 
@@ -89,11 +88,6 @@ function mergeShadow(
     likeCount = shadow.optimisticLikeCount ?? likeCount
   }
 
-  let bookmarkCount = post.bookmarkCount ?? 0
-  if ('optimisticBookmarkCount' in shadow) {
-    bookmarkCount = shadow.optimisticBookmarkCount ?? bookmarkCount
-  }
-
   let repostCount = post.repostCount ?? 0
   if ('optimisticRepostCount' in shadow) {
     repostCount = shadow.optimisticRepostCount ?? repostCount
@@ -122,7 +116,6 @@ function mergeShadow(
     likeCount: likeCount,
     repostCount: repostCount,
     replyCount: replyCount,
-    bookmarkCount: bookmarkCount,
     viewer: {
       ...(post.viewer || {}),
       like: 'likeUri' in shadow ? shadow.likeUri : post.viewer?.like,

--- a/src/state/cache/post-shadow.ts
+++ b/src/state/cache/post-shadow.ts
@@ -85,47 +85,18 @@ function mergeShadow(
   }
 
   let likeCount = post.likeCount ?? 0
-
-  likeCount = shadow.optimisticLikeCount ?? likeCount
-
-  console.log({likeCount, optimisticLikeCount: shadow.optimisticLikeCount})
-  if ('likeUri' in shadow) {
-    const wasLiked = !!post.viewer?.like
-    const isLiked = !!shadow.likeUri
-    if (wasLiked && !isLiked) {
-      likeCount--
-    } else if (!wasLiked && isLiked) {
-      likeCount++
-    }
-    likeCount = Math.max(0, likeCount)
+  if ('optimisticLikeCount' in shadow) {
+    likeCount = shadow.optimisticLikeCount ?? likeCount
   }
 
   let bookmarkCount = post.bookmarkCount ?? 0
-
-  bookmarkCount = shadow.optimisticBookmarkCount ?? bookmarkCount
-  if ('bookmarked' in shadow) {
-    const wasBookmarked = !!post.viewer?.bookmarked
-    const isBookmarked = !!shadow.bookmarked
-    if (wasBookmarked && !isBookmarked) {
-      bookmarkCount--
-    } else if (!wasBookmarked && isBookmarked) {
-      bookmarkCount++
-    }
-    bookmarkCount = Math.max(0, bookmarkCount)
+  if ('optimisticBookmarkCount' in shadow) {
+    bookmarkCount = shadow.optimisticBookmarkCount ?? bookmarkCount
   }
 
   let repostCount = post.repostCount ?? 0
-
-  repostCount = shadow.optimisticRepostCount ?? repostCount
-  if ('repostUri' in shadow) {
-    const wasReposted = !!post.viewer?.repost
-    const isReposted = !!shadow.repostUri
-    if (wasReposted && !isReposted) {
-      repostCount--
-    } else if (!wasReposted && isReposted) {
-      repostCount++
-    }
-    repostCount = Math.max(0, repostCount)
+  if ('optimisticRepostCount' in shadow) {
+    repostCount = shadow.optimisticRepostCount ?? repostCount
   }
 
   let replyCount = post.replyCount ?? 0

--- a/src/state/cache/post-shadow.ts
+++ b/src/state/cache/post-shadow.ts
@@ -88,6 +88,18 @@ function mergeShadow(
     likeCount = shadow.optimisticLikeCount ?? likeCount
   }
 
+  let bookmarkCount = post.bookmarkCount ?? 0
+  if ('bookmarked' in shadow) {
+    const wasBookmarked = !!post.viewer?.bookmarked
+    const isBookmarked = !!shadow.bookmarked
+    if (wasBookmarked && !isBookmarked) {
+      bookmarkCount--
+    } else if (!wasBookmarked && isBookmarked) {
+      bookmarkCount++
+    }
+    bookmarkCount = Math.max(0, bookmarkCount)
+  }
+
   let repostCount = post.repostCount ?? 0
   if ('optimisticRepostCount' in shadow) {
     repostCount = shadow.optimisticRepostCount ?? repostCount
@@ -116,6 +128,7 @@ function mergeShadow(
     likeCount: likeCount,
     repostCount: repostCount,
     replyCount: replyCount,
+    bookmarkCount: bookmarkCount,
     viewer: {
       ...(post.viewer || {}),
       like: 'likeUri' in shadow ? shadow.likeUri : post.viewer?.like,

--- a/src/state/queries/post.ts
+++ b/src/state/queries/post.ts
@@ -143,19 +143,23 @@ export function usePostLikeMutationQueue(
 
   const queueLike = useCallback(() => {
     // optimistically update
+    const currentCount = post.likeCount ?? 0
     updatePostShadow(queryClient, postUri, {
       likeUri: 'pending',
+      optimisticLikeCount: currentCount + 1,
     })
     return queueToggle(true)
-  }, [queryClient, postUri, queueToggle])
+  }, [queryClient, postUri, queueToggle, post.likeCount])
 
   const queueUnlike = useCallback(() => {
     // optimistically update
+    const currentCount = post.likeCount ?? 0
     updatePostShadow(queryClient, postUri, {
       likeUri: undefined,
+      optimisticLikeCount: Math.max(0, currentCount - 1),
     })
     return queueToggle(false)
-  }, [queryClient, postUri, queueToggle])
+  }, [queryClient, postUri, queueToggle, post.likeCount])
 
   return [queueLike, queueUnlike]
 }
@@ -258,19 +262,23 @@ export function usePostRepostMutationQueue(
 
   const queueRepost = useCallback(() => {
     // optimistically update
+    const currentCount = post.repostCount ?? 0
     updatePostShadow(queryClient, postUri, {
       repostUri: 'pending',
+      optimisticRepostCount: currentCount + 1,
     })
     return queueToggle(true)
-  }, [queryClient, postUri, queueToggle])
+  }, [queryClient, postUri, queueToggle, post.repostCount])
 
   const queueUnrepost = useCallback(() => {
     // optimistically update
+    const currentCount = post.repostCount ?? 0
     updatePostShadow(queryClient, postUri, {
       repostUri: undefined,
+      optimisticRepostCount: Math.max(0, currentCount - 1),
     })
     return queueToggle(false)
-  }, [queryClient, postUri, queueToggle])
+  }, [queryClient, postUri, queueToggle, post.repostCount])
 
   return [queueRepost, queueUnrepost]
 }

--- a/src/state/queries/usePostThread/index.ts
+++ b/src/state/queries/usePostThread/index.ts
@@ -82,10 +82,10 @@ export function usePostThread({anchor}: {anchor?: string}) {
 
       /*
        * Sync fresh thread data back to feed cache
-       * Find the anchor post and update its shadow with fresh counts
+       * Find the anchor post and update its shadow with fresh
+       * like and repost counts.
        */
       const anchorItem = data.thread?.find(item => item.depth === 0)
-      console.log({anchorItem})
 
       if (
         anchorItem &&
@@ -95,8 +95,6 @@ export function usePostThread({anchor}: {anchor?: string}) {
         updatePostShadow(qc, post.uri, {
           optimisticLikeCount: post.likeCount,
           optimisticRepostCount: post.repostCount,
-          optimisticBookmarkCount: post.bookmarkCount,
-          optimisticReplyCount: post.replyCount,
         })
       }
 


### PR DESCRIPTION
I noticed that like and repost counts were stale after getting newer counts when loading a post from a feed. It seems reasonable to keep a shadow count of updated counts to reflect the newer data in feeds as well.

This PR does the following:
1. Adds optimistic liked and repost counts to post-shadow
2. Increments or decrements shadow counts when queuing like and repost mutations
3. Updates optimistic like and repost counts for anchor post when querying a thread 

Disclaimer: I used this as an opportunity to learn more about the social-app codebase and it's very possible I've misunderstood how to properly use shadows and / or modify state values! 