### PR TITLE
Add more client events to profile followers/following pages

### DIFF
--- a/src/logger/metrics.ts
+++ b/src/logger/metrics.ts
@@ -299,7 +299,6 @@ export type MetricEvents = {
   'profile:followers:view': {
     contextProfileDid: string
     isOwnProfile: boolean
-    logContext?: 'ProfileHeader'
   }
   'profile:followers:paginate': {
     contextProfileDid: string
@@ -309,7 +308,6 @@ export type MetricEvents = {
   'profile:following:view': {
     contextProfileDid: string
     isOwnProfile: boolean
-    logContext?: 'ProfileHeader'
   }
   'profile:following:paginate': {
     contextProfileDid: string

--- a/src/view/com/profile/ProfileFollowers.tsx
+++ b/src/view/com/profile/ProfileFollowers.tsx
@@ -128,7 +128,6 @@ export function ProfileFollowers({name}: {name: string}) {
       logger.metric('profile:followers:view', {
         contextProfileDid: resolvedDid,
         isOwnProfile: isMe,
-        logContext: 'ProfileHeader',
       })
     }
   }, [resolvedDid, isMe])

--- a/src/view/com/profile/ProfileFollows.tsx
+++ b/src/view/com/profile/ProfileFollows.tsx
@@ -139,7 +139,6 @@ export function ProfileFollows({name}: {name: string}) {
       logger.metric('profile:following:view', {
         contextProfileDid: resolvedDid,
         isOwnProfile: isMe,
-        logContext: 'ProfileHeader',
       })
     }
   }, [resolvedDid, isMe])


### PR DESCRIPTION
Adds client events that fire when the following/followers page is viewed and when the user's scroll triggers a pagination in the list. 

```
  'profile:followers:view': {
    contextProfileDid: string
    isOwnProfile: boolean
  }
  'profile:followers:paginate': {
    contextProfileDid: string
    itemCount: number
    page: number
  }
  'profile:following:view': {
    contextProfileDid: string
    isOwnProfile: boolean
  }
  'profile:following:paginate': {
    contextProfileDid: string
    itemCount: number
    page: number
  }
```