### PR TITLE
Use FromCache Rather Than FromFile on Template Render

### DIFF
--- a/bskyweb/cmd/bskyweb/renderer.go
+++ b/bskyweb/cmd/bskyweb/renderer.go
@@ -71,7 +71,7 @@ func (r Renderer) Render(w io.Writer, name string, data interface{}, c echo.Cont
 	if r.Debug {
 		t, err = pongo2.FromFile(name)
 	} else {
-		t, err = r.TemplateSet.FromFile(name)
+		t, err = r.TemplateSet.FromCache(name)
 	}
 
 	if err != nil {


### PR DESCRIPTION
Been looking for any performance wins we can get on page load times, and this is one thing that jumped out at me right away.

Even if we're loading from the embedded file system rather than actually having to load from the real file system, we still should use `FromCache` so we don't have to parse and recompile each template on each request.