### PR TITLE
Fix authentication when signing in with a DID

### DIFF
--- a/src/screens/Login/LoginForm.tsx
+++ b/src/screens/Login/LoginForm.tsx
@@ -108,6 +108,7 @@ export const LoginForm = ({
       if (
         !identifier.includes('@') && // not an email
         !identifier.includes('.') && // not a domain
+        !identifier.startsWith('did:') && // not a DID
         serviceDescription &&
         serviceDescription.availableUserDomains.length > 0
       ) {


### PR DESCRIPTION
Currently, if you enter a DID as the identifier in the login form, you won't be able to authenticate, because the app adds `.bsky.social` (or other configured domain) to any identifier that doesn't contain `.` or `@`. With this change, identifiers starting with `did:` will also be left alone.