### PR TITLE
Restructure notification/linking handling to use synchronous APIs

### DIFF
--- a/src/Navigation.tsx
+++ b/src/Navigation.tsx
@@ -885,7 +885,7 @@ function RoutesContainer({children}: React.PropsWithChildren<{}>) {
   const emailDialogControl = useEmailDialogControl()
   const closeAllActiveElements = useCloseAllActiveElements()
   const linkingUrl = Linking.useLinkingURL()
-  const notificationResponse = Notifications.getLastNotificationResponse()
+  const notificationResponse = Notifications.useLastNotificationResponse()
 
   /**
    * Handle navigation to a conversation, or prepares for account switch.


### PR DESCRIPTION
Switches notification and linking handling from async to synchronous APIs:

- `Linking` from `react-native` → `expo-linking` with `useLinkingURL()`
- `getLastNotificationResponseAsync()` → `getLastNotificationResponse()` (synchronous)
- Dedup via `clearLastNotificationResponse()` instead of a module-level date variable

This makes the notification entry handler synchronous and simpler, and is a prerequisite for #2 (nav state persistence) which needs these values available synchronously at render time.

## Test plan

- Ensure opening the app via a push notification still navigates to the correct screen
- Ensure opening the app via a deep link still works
- Ensure chat message notifications still trigger account switch when needed