### PR TITLE
Fix issue where empty state message is not centered

### DIFF
--- a/src/components/Lists.tsx
+++ b/src/components/Lists.tsx
@@ -192,7 +192,9 @@ let ListMaybePlaceholder = ({
 
   if (useEmptyState) {
     return (
-      <View style={[t.atoms.border_contrast_low]}>
+      <CenteredView
+        style={[t.atoms.border_contrast_low]}
+        sideBorders={sideBorders ?? gtMobile}>
         <EmptyState
           icon={emptyStateIcon}
           message={
@@ -203,7 +205,7 @@ let ListMaybePlaceholder = ({
           }
           button={emptyStateButton}
         />
-      </View>
+      </CenteredView>
     )
   }
 


### PR DESCRIPTION
Fixes bug where empty state message is not centered between certain breakpoints on web

<img width="667" height="588" alt="Screenshot 2025-12-06 at 2 22 48 PM" src="https://github.com/user-attachments/assets/84432314-2fe3-4fe8-8f56-62514d6d5dc3" />
