### PR TITLE
Android - build React Native from source for production builds

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -246,6 +246,7 @@ module.exports = function (_config) {
               compileSdkVersion: 35,
               targetSdkVersion: 35,
               buildToolsVersion: '35.0.0',
+              buildReactNativeFromSource: IS_PRODUCTION,
             },
           },
         ],


### PR DESCRIPTION
#9436 didn't work, but (obvious in hindsight) the patch didn't do anything because React Native uses prebuilt binaries on Android. Let's enable building from source on Android, but only for prod builds - we don't need the patch to be applied in development, which keeps things snappy.