### PR TITLE
Lazy load `psl`

### DIFF
--- a/__tests__/lib/strings/url-helpers.test.ts
+++ b/__tests__/lib/strings/url-helpers.test.ts
@@ -146,7 +146,8 @@ describe('splitApexDomain', () => {
 })
 
 describe('isTrustedUrl', () => {
-  const cases = [
+  type Case = [string, boolean]
+  const cases: Case[] = [
     ['#', true],
     ['#profile', true],
     ['/', true],
@@ -171,7 +172,7 @@ describe('isTrustedUrl', () => {
     ['https://docs.google.com', false],
     ['https://google.com/#', false],
     ['https://blueskywebxzendesk.com', false],
-  ] as [string, boolean][]
+  ]
 
   it.each(cases)('given input uri %p, returns %p', (str, expected) => {
     const output = isTrustedUrl(str)

--- a/__tests__/lib/strings/url-helpers.test.ts
+++ b/__tests__/lib/strings/url-helpers.test.ts
@@ -1,10 +1,11 @@
 import {describe, expect, it} from '@jest/globals'
 
+// co-located with LinkBox.tsx so we can lazy load PSL
+import {splitApexDomain} from '../../../src/components/dialogs/LinkWarning/LinkBox'
 import {
   isPossiblyAUrl,
   isTrustedUrl,
   linkRequiresWarning,
-  splitApexDomain,
 } from '../../../src/lib/strings/url-helpers'
 
 describe('linkRequiresWarning', () => {

--- a/__tests__/lib/strings/url-helpers.test.ts
+++ b/__tests__/lib/strings/url-helpers.test.ts
@@ -171,7 +171,7 @@ describe('isTrustedUrl', () => {
     ['https://docs.google.com', false],
     ['https://google.com/#', false],
     ['https://blueskywebxzendesk.com', false],
-  ]
+  ] as [string, boolean][]
 
   it.each(cases)('given input uri %p, returns %p', (str, expected) => {
     const output = isTrustedUrl(str)

--- a/__tests__/lib/strings/url-helpers.test.ts
+++ b/__tests__/lib/strings/url-helpers.test.ts
@@ -1,7 +1,6 @@
 import {describe, expect, it} from '@jest/globals'
 
-// co-located with LinkBox.tsx so we can lazy load PSL
-import {splitApexDomain} from '../../../src/components/dialogs/LinkWarning/LinkBox'
+import {splitApexDomain} from '../../../src/lib/strings/url-apex-split'
 import {
   isPossiblyAUrl,
   isTrustedUrl,

--- a/src/components/dialogs/LinkWarning/LinkBox.tsx
+++ b/src/components/dialogs/LinkWarning/LinkBox.tsx
@@ -1,0 +1,54 @@
+import {useMemo} from 'react'
+import {View} from 'react-native'
+import psl from 'psl'
+
+import {atoms as a, useTheme} from '#/alf'
+import {Text} from '#/components/Typography'
+
+export function splitApexDomain(hostname: string): [string, string] {
+  const hostnamep = psl.parse(hostname)
+  if (hostnamep.error || !hostnamep.listed || !hostnamep.domain) {
+    return ['', hostname]
+  }
+  return [
+    hostnamep.subdomain ? `${hostnamep.subdomain}.` : '',
+    hostnamep.domain,
+  ]
+}
+
+export default function LinkBox({href}: {href: string}) {
+  const t = useTheme()
+  const [scheme, hostname, rest] = useMemo(() => {
+    try {
+      const urlp = new URL(href)
+      const [subdomain, apexdomain] = splitApexDomain(urlp.hostname)
+      return [
+        urlp.protocol + '//' + subdomain,
+        apexdomain,
+        urlp.pathname.replace(/\/$/, '') + urlp.search + urlp.hash,
+      ]
+    } catch {
+      return ['', href, '']
+    }
+  }, [href])
+  return (
+    <View
+      style={[
+        t.atoms.bg,
+        t.atoms.border_contrast_medium,
+        a.px_md,
+        {paddingVertical: 10},
+        a.rounded_sm,
+        a.border,
+      ]}>
+      <Text style={[a.text_md, a.leading_snug, t.atoms.text_contrast_medium]}>
+        {scheme}
+        <Text
+          style={[a.text_md, a.leading_snug, t.atoms.text, a.font_semi_bold]}>
+          {hostname}
+        </Text>
+        {rest}
+      </Text>
+    </View>
+  )
+}

--- a/src/components/dialogs/LinkWarning/LinkBox.tsx
+++ b/src/components/dialogs/LinkWarning/LinkBox.tsx
@@ -1,20 +1,9 @@
 import {useMemo} from 'react'
 import {View} from 'react-native'
-import psl from 'psl'
 
+import {splitApexDomain} from '#/lib/strings/url-apex-split'
 import {atoms as a, useTheme} from '#/alf'
 import {Text} from '#/components/Typography'
-
-export function splitApexDomain(hostname: string): [string, string] {
-  const hostnamep = psl.parse(hostname)
-  if (hostnamep.error || !hostnamep.listed || !hostnamep.domain) {
-    return ['', hostname]
-  }
-  return [
-    hostnamep.subdomain ? `${hostnamep.subdomain}.` : '',
-    hostnamep.domain,
-  ]
-}
 
 export default function LinkBox({href}: {href: string}) {
   const t = useTheme()

--- a/src/lib/strings/url-apex-split.ts
+++ b/src/lib/strings/url-apex-split.ts
@@ -1,0 +1,15 @@
+import psl from 'psl'
+
+/**
+ * NOTE: Expensive import! Try to lazy load when using it.
+ */
+export function splitApexDomain(hostname: string): [string, string] {
+  const hostnamep = psl.parse(hostname)
+  if (hostnamep.error || !hostnamep.listed || !hostnamep.domain) {
+    return ['', hostname]
+  }
+  return [
+    hostnamep.subdomain ? `${hostnamep.subdomain}.` : '',
+    hostnamep.domain,
+  ]
+}

--- a/src/lib/strings/url-helpers.ts
+++ b/src/lib/strings/url-helpers.ts
@@ -1,5 +1,4 @@
 import {AtUri} from '@atproto/api'
-import psl from 'psl'
 import TLDs from 'tlds'
 
 import {BSKY_SERVICE} from '#/lib/constants'
@@ -308,17 +307,6 @@ export function isPossiblyAUrl(str: string): boolean {
   }
   const [firstWord] = str.split(/[\s\/]/)
   return isValidDomain(firstWord)
-}
-
-export function splitApexDomain(hostname: string): [string, string] {
-  const hostnamep = psl.parse(hostname)
-  if (hostnamep.error || !hostnamep.listed || !hostnamep.domain) {
-    return ['', hostname]
-  }
-  return [
-    hostnamep.subdomain ? `${hostnamep.subdomain}.` : '',
-    hostnamep.domain,
-  ]
 }
 
 export function createBskyAppAbsoluteUrl(path: string): string {


### PR DESCRIPTION
Should reduce bundle size by a good few kb

We only use it in the link warning component to split the apex domain from the subdomain. I made a fallback component that just doesn't do that part, for while it's loading