### PR TITLE
Force resolution of ESM version of `unicode-segmenter` on web

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,6 +23,10 @@ module.exports = async function (env, argv) {
   config = withAlias(config, {
     'react-native$': 'react-native-web',
     'react-native-webview': 'react-native-web-webview',
+    // Force ESM version
+    'unicode-segmenter/grapheme': require
+      .resolve('unicode-segmenter/grapheme')
+      .replace(/\.cjs$/, '.js'),
   })
   config.module.rules = [
     ...(config.module.rules || []),


### PR DESCRIPTION
The fallback for old browsers that don't have Intl.Segmenter wasn't working, as it was resolving to the `.cjs` version of `unicode-segmenter` which got lost in the build pipeline (it got added as an image lmao). We can force a resolution to the ESM version to fix.

# Before 
<img width="1728" height="711" alt="Screenshot 2025-12-11 at 14 41 37" src="https://github.com/user-attachments/assets/eb1977cf-66bf-43b2-951b-1d7028707d71" />

# After

<img width="1728" height="797" alt="Screenshot 2025-12-11 at 14 40 00" src="https://github.com/user-attachments/assets/143001e6-d248-4f4b-8b31-c016971ca6bf" />
