### PR TITLE
Restore notification count in bottom bar

### DIFF
--- a/src/view/shell/bottom-bar/BottomBar.tsx
+++ b/src/view/shell/bottom-bar/BottomBar.tsx
@@ -418,7 +418,7 @@ function Btn({
             a.rounded_full,
             {backgroundColor: t.palette.primary_500},
           ]}>
-          <Text style={styles.notificationCountLabel}>1</Text>
+          <Text style={styles.notificationCountLabel}>{notificationCount}</Text>
         </View>
       ) : hasNew ? (
         <View style={[styles.hasNewBadge, a.rounded_full]} />


### PR DESCRIPTION
Fixes #9543
Fixes #9553

In #9435 the notification counter in the bottom bar was mistakenly hardcoded to `1`. This PR restores it to be `notificationCount`.

Thanks to @0x00evil for pointing out where the bug in the code is.