### PR TITLE
[bskylink] URL-encode apostrophes before HTML escaping

### DIFF
--- a/bskylink/src/html/linkRedirectContents.ts
+++ b/bskylink/src/html/linkRedirectContents.ts
@@ -1,10 +1,20 @@
 import escapeHTML from 'escape-html'
 
 export function linkRedirectContents(link: string): string {
+  // Encode characters that could break out of the single-quoted URL in meta refresh.
+  // HTML entity escaping (&#39;) is insufficient because the browser decodes entities
+  // before the meta refresh parser processes the URL, allowing apostrophes to
+  // prematurely terminate the URL string.
+  //
+  // Example: "They're" with HTML escaping becomes "They&#39;re" in HTML, but after
+  // the browser decodes the content attribute, the meta refresh parser sees "They're"
+  // and interprets the apostrophe as the closing quote, truncating the URL to "They".
+  const safeLink = link.replace(/'/g, '%27')
+
   return `
     <html>
       <head>
-        <meta http-equiv="refresh" content="0; URL='${escapeHTML(link)}'" />
+        <meta http-equiv="refresh" content="0; URL='${escapeHTML(safeLink)}'" />
         <meta
           http-equiv="Cache-Control"
           content="no-store, no-cache, must-revalidate, max-age=0" />


### PR DESCRIPTION
> [!WARNING]
> **This bug was diagnosed and the PR and description [put together by Claude](https://claude.ai/share/6c310fc1-f885-4331-8e29-c3f60fe71c01). I have not tested the fix.**

## Bug Summary

I noticed a bug when tapping the Wikipedia link in [this post](https://bsky.app/profile/lasertrapperkeeper.bsky.social/post/3ma2zw6ufls2g): URLs containing unencoded apostrophes (e.g., `They're`) are truncated when redirecting through the `bskylink` service, causing users to be redirected to incomplete URLs.

**EDIT:** I see this bug in the iOS app and in mobile Safari, but @layeredstrange [reported](https://bsky.app/profile/mikejay.link/post/3ma3b2fa7l22x) that he is unable to reproduce it in the Android app.

## Example

**Original URL:**
```
https://en.wikipedia.org/wiki/They're_Coming_to_Take_Me_Away%2C_Ha-Haaa
```

**Actual redirect destination:**
```
https://en.wikipedia.org/wiki/They
```

## Root Cause

The bug is in `src/html/linkRedirectContents.ts`. The code uses `escapeHTML()` to sanitize the URL before embedding it in a meta refresh tag:

```html
<meta http-equiv="refresh" content="0; URL='${escapeHTML(link)}'" />
```

The problem is a **two-stage parsing issue**:

1. **HTML Entity Escaping**: `escapeHTML()` converts `'` to `&#39;`
2. **Browser HTML Parsing**: The browser decodes `&#39;` back to `'` when reading the `content` attribute
3. **Meta Refresh Parsing**: The meta refresh parser then sees the raw apostrophe and interprets it as the closing quote for the URL

### Step-by-step breakdown

| Stage | Value |
|-------|-------|
| Input URL | `https://en.wikipedia.org/wiki/They're_Coming...` |
| After `escapeHTML()` | `https://en.wikipedia.org/wiki/They&#39;re_Coming...` |
| HTML output | `content="0; URL='https://en.wikipedia.org/wiki/They&#39;re_Coming...'"` |
| After browser HTML decode | `content="0; URL='https://en.wikipedia.org/wiki/They're_Coming...'"` |
| Meta refresh sees | URL starts with `'`, ends at next `'` → `https://en.wikipedia.org/wiki/They` |

## The Fix

URL-encode the apostrophe as `%27` **before** HTML escaping. This ensures the meta refresh parser never sees a raw apostrophe:

```typescript
export function linkRedirectContents(link: string): string {
  // Encode apostrophes to prevent breaking out of single-quoted URL
  const safeLink = link.replace(/'/g, '%27')

  return `
    <html>
      <head>
        <meta http-equiv="refresh" content="0; URL='${escapeHTML(safeLink)}'" />
        ...
      </head>
    </html>
  `
}
```

### Result after fix

| Stage | Value |
|-------|-------|
| Input URL | `https://en.wikipedia.org/wiki/They're_Coming...` |
| After `replace()` | `https://en.wikipedia.org/wiki/They%27re_Coming...` |
| HTML output | `content="0; URL='https://en.wikipedia.org/wiki/They%27re_Coming...'"` |
| After browser HTML decode | `content="0; URL='https://en.wikipedia.org/wiki/They%27re_Coming...'"` |
| Meta refresh sees | Full URL with `%27` preserved ✓ |

## Files Changed

- `bskylink/src/html/linkRedirectContents.ts` – Add apostrophe encoding before HTML escaping

## Testing

1. Create a post with a link containing an apostrophe in the path
2. Click the link on Bluesky
3. Verify you're redirected to the correct full URL, not a truncated version