### PR TITLE
Fix DNS TXT record host generation for handles with subdomains

### DIFF
--- a/src/screens/Settings/components/ChangeHandleDialog.tsx
+++ b/src/screens/Settings/components/ChangeHandleDialog.tsx
@@ -309,6 +309,7 @@ function OwnHandlePage({goToServiceHandle}: {goToServiceHandle: () => void}) {
   const {currentAccount} = useSession()
   const [dnsPanel, setDNSPanel] = useState(true)
   const [domain, setDomain] = useState('')
+  const [subDomain, setSubDomain] = useState('')
   const agent = useAgent()
   const control = Dialog.useDialogContext()
   const fetchDid = useFetchDid()
@@ -387,6 +388,13 @@ function OwnHandlePage({goToServiceHandle}: {goToServiceHandle: () => void}) {
               editable={!isPending}
               defaultValue={domain}
               onChangeText={text => {
+                const domainParts = text.trim().split('.').filter(Boolean)
+                if (domainParts.length === 3) {
+                  setSubDomain(domainParts[0])
+                } else {
+                  setSubdomain('')
+                }
+
                 setDomain(text)
                 resetVerification()
               }}
@@ -430,12 +438,14 @@ function OwnHandlePage({goToServiceHandle}: {goToServiceHandle: () => void}) {
               <View style={[a.py_xs]}>
                 <CopyButton
                   color="secondary"
-                  value="_atproto"
+                  value={'_atproto' + subDomain ? '.' + domain : ''}
                   label={_(msg`Copy host`)}
                   style={[a.bg_transparent]}
                   hoverStyle={[a.bg_transparent]}
                   hitSlop={HITSLOP_10}>
-                  <Text style={[a.text_md, a.flex_1]}>_atproto</Text>
+                  <Text style={[a.text_md, a.flex_1]}>
+                    _atproto{subDomain ? '.' + domain : ''}
+                  </Text>
                   <ButtonIcon icon={CopyIcon} />
                 </CopyButton>
               </View>


### PR DESCRIPTION
Previously, the DNS TXT record Host field was hardcoded to always display _atproto, regardless of whether the user’s input domain included a subdomain. This caused verification failures for handles using subdomains (e.g., user.example.com), because the correct DNS record must be placed at _atproto.user.example.com, not _atproto.example.com.

This PR fixes the host generation logic to follow the Atproto specification:
- If the user enters a domain with a subdomain (e.g., user.example.com), the Host should be _atproto.user (so the full record becomes _atproto.user.example.com).
- If the user enters an apex domain (e.g., example.com), the Host should be _atproto (resulting in _atproto.example.com).

The change ensures that users receive the correct DNS instruction based on their input, enabling successful domain verification for both apex and subdomain-based handles.