### PR TITLE
Move NUXDialogs into shell

### DIFF
--- a/src/App.native.tsx
+++ b/src/App.native.tsx
@@ -61,7 +61,6 @@ import {Shell} from '#/view/shell'
 import {ThemeProvider as Alf} from '#/alf'
 import {useColorModeTheme} from '#/alf/util/useColorModeTheme'
 import {Provider as ContextMenuProvider} from '#/components/ContextMenu'
-import {NuxDialogs} from '#/components/dialogs/nuxs'
 import {useStarterPackEntry} from '#/components/hooks/useStarterPackEntry'
 import {Provider as IntentDialogProvider} from '#/components/intents/IntentDialogs'
 import {Provider as PolicyUpdateOverlayProvider} from '#/components/PolicyUpdateOverlay'
@@ -165,7 +164,6 @@ function InnerApp() {
                                                           <IntentDialogProvider>
                                                             <TestCtrls />
                                                             <Shell />
-                                                            <NuxDialogs />
                                                             <ToastOutlet />
                                                           </IntentDialogProvider>
                                                         </GlobalGestureEventsProvider>

--- a/src/App.web.tsx
+++ b/src/App.web.tsx
@@ -48,7 +48,6 @@ import {Shell} from '#/view/shell/index'
 import {ThemeProvider as Alf} from '#/alf'
 import {useColorModeTheme} from '#/alf/util/useColorModeTheme'
 import {Provider as ContextMenuProvider} from '#/components/ContextMenu'
-import {NuxDialogs} from '#/components/dialogs/nuxs'
 import {useStarterPackEntry} from '#/components/hooks/useStarterPackEntry'
 import {Provider as IntentDialogProvider} from '#/components/intents/IntentDialogs'
 import {Provider as PolicyUpdateOverlayProvider} from '#/components/PolicyUpdateOverlay'
@@ -138,7 +137,6 @@ function InnerApp() {
                                                       <HideBottomBarBorderProvider>
                                                         <IntentDialogProvider>
                                                           <Shell />
-                                                          <NuxDialogs />
                                                           <ToastOutlet />
                                                         </IntentDialogProvider>
                                                       </HideBottomBarBorderProvider>

--- a/src/view/shell/index.tsx
+++ b/src/view/shell/index.tsx
@@ -32,6 +32,7 @@ import {EmailDialog} from '#/components/dialogs/EmailDialog'
 import {InAppBrowserConsentDialog} from '#/components/dialogs/InAppBrowserConsent'
 import {LinkWarningDialog} from '#/components/dialogs/LinkWarning'
 import {MutedWordsDialog} from '#/components/dialogs/MutedWords'
+import {NuxDialogs} from '#/components/dialogs/nuxs'
 import {SigninDialog} from '#/components/dialogs/Signin'
 import {
   Outlet as PolicyUpdateOverlayPortalOutlet,
@@ -110,6 +111,7 @@ function ShellInner() {
       <InAppBrowserConsentDialog />
       <LinkWarningDialog />
       <Lightbox />
+      <NuxDialogs />
 
       {/* Until policy update has been completed by the user, don't render anything that is portaled */}
       {policyUpdateState.completed && (

--- a/src/view/shell/index.web.tsx
+++ b/src/view/shell/index.web.tsx
@@ -22,6 +22,7 @@ import {AgeAssuranceRedirectDialog} from '#/components/ageAssurance/AgeAssurance
 import {EmailDialog} from '#/components/dialogs/EmailDialog'
 import {LinkWarningDialog} from '#/components/dialogs/LinkWarning'
 import {MutedWordsDialog} from '#/components/dialogs/MutedWords'
+import {NuxDialogs} from '#/components/dialogs/nuxs'
 import {SigninDialog} from '#/components/dialogs/Signin'
 import {useWelcomeModal} from '#/components/hooks/useWelcomeModal'
 import {
@@ -86,6 +87,7 @@ function ShellInner() {
       <AgeAssuranceRedirectDialog />
       <LinkWarningDialog />
       <Lightbox />
+      <NuxDialogs />
 
       {welcomeModalControl.isOpen && (
         <WelcomeModal control={welcomeModalControl} />


### PR DESCRIPTION
This ensures that if Age Assurance `NoAccessScreen` is active, the NUX won't show on top.

Reported here: https://github.com/bluesky-social/social-app/issues/9568#issuecomment-3667911842