### PR TITLE
make disabled replies a bit more distinct

### DIFF
--- a/src/components/PostControls/index.tsx
+++ b/src/components/PostControls/index.tsx
@@ -211,7 +211,7 @@ let PostControls = ({
             a.flex_1,
             a.align_start,
             {marginLeft: big ? -2 : -6},
-            replyDisabled ? {opacity: 0.6} : undefined,
+            replyDisabled ? {opacity: 0.3, cursor: 'not-allowed'} : undefined,
           ]}>
           <PostControlButton
             testID="replyBtn"


### PR DESCRIPTION
Ideally I'd also put the reason in the `title="..."` tag, but I couldn't see the data for that right off the bat.