### PR TITLE
Fix prefetching starter pack query

### DIFF
--- a/src/state/queries/starter-packs.ts
+++ b/src/state/queries/starter-packs.ts
@@ -373,6 +373,8 @@ export async function precacheStarterPack(
     if (starterPack.record.feeds) {
       feeds = []
       for (const feed of starterPack.record.feeds) {
+        // note: types are wrong? claims to be `FeedItem`, but we actually
+        // get un$typed `GeneratorView` objects here -sfn
         if (bsky.validate(feed, AppBskyFeedDefs.validateGeneratorView)) {
           feeds.push(feed)
         }


### PR DESCRIPTION
Fixes #9593 

Navigating to a starter pack is broken (you can't see the feeds) because the helper function that creates a `StarterPackView` doesn't add the `feeds` field. There's something wrong with the types - `starterpack.record.feeds claims to be `FeedItem[]`, but we actually see un$typed `GeneratorView` objects.