### PR TITLE
Better copy for "must be signed in" message

### DIFF
--- a/bskyweb/templates/post.html
+++ b/bskyweb/templates/post.html
@@ -108,9 +108,9 @@
   {% else %}
   <meta property="og:title" content="@{{ profileHandle }}">
   {% endif -%}
-  <meta name="description" content="This post requires authentication to view.">
-  <meta property="og:description" content="This post requires authentication to view.">
-  <meta property="twitter:description" content="This post requires authentication to view.">
+  <meta name="description" content="This author has chosen to make their posts visible only to people who are signed in.">
+  <meta property="og:description" content="This author has chosen to make their posts visible only to people who are signed in.">
+  <meta property="twitter:description" content="This author has chosen to make their posts visible only to people who are signed in.">
   <meta name="twitter:card" content="summary">
 {% endif -%}
 {%- endblock %}
@@ -129,7 +129,7 @@
 <div id="bsky_post_summary">
   <h3>Post</h3>
   <p id="bsky_handle">{{ profileHandle }}</p>
-  <p id="bsky_post_text">This post requires authentication to view.</p>
+      <p id="bsky_post_text">This author has chosen to make their posts visible only to people who are signed in.</p>
 </div>
 {% endif -%}
 {%- endblock %}

--- a/src/screens/PostThread/components/ThreadItemAnchorNoUnauthenticated.tsx
+++ b/src/screens/PostThread/components/ThreadItemAnchorNoUnauthenticated.tsx
@@ -24,7 +24,10 @@ export function ThreadItemAnchorNoUnauthenticated() {
 
       <View style={[a.py_sm]}>
         <Text style={[a.text_xl, a.italic, t.atoms.text_contrast_medium]}>
-          <Trans>You must sign in to view this post.</Trans>
+          <Trans>
+            This author has chosen to make their posts visible only to people
+            who are signed in.
+          </Trans>
         </Text>
       </View>
     </View>

--- a/src/screens/PostThread/components/ThreadItemPostNoUnauthenticated.tsx
+++ b/src/screens/PostThread/components/ThreadItemPostNoUnauthenticated.tsx
@@ -44,7 +44,10 @@ export function ThreadItemPostNoUnauthenticated({
         </Skele.Circle>
 
         <Text style={[a.text_md, a.italic, t.atoms.text_contrast_medium]}>
-          <Trans>You must sign in to view this post.</Trans>
+          <Trans>
+            This author has chosen to make their posts visible only to people
+            who are signed in.
+          </Trans>
         </Text>
       </Skele.Row>
       <View


### PR DESCRIPTION
Changes the "you must be signed in to view this post" message to clarify that this setting is set by the post author, not Bluesky. 