### PR TITLE
Fix tooltip overflow in right sidebar

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -145,9 +145,11 @@ input:focus {
   background: var(--backgroundLight);
   color: var(--text);
   text-align: center;
-  white-space: nowrap;
+  white-space: pre-wrap;
   font-size: 12px;
   z-index: 10;
+  max-width: min(300px, 90vw);
+  box-sizing: border-box;
 }
 [data-tooltip]::before {
   content: '';


### PR DESCRIPTION
Fixes #9563

Constrains tooltip width to prevent overflow into the right sidebar feed list when hovering over timestamps on profiles with long display names.