### PR TITLE
Use built-in documentTitle API from React Navigation

### DIFF
--- a/src/lib/hooks/useSetTitle.ts
+++ b/src/lib/hooks/useSetTitle.ts
@@ -2,14 +2,12 @@ import {useEffect} from 'react'
 import {useNavigation} from '@react-navigation/native'
 
 import {type NavigationProp} from '#/lib/routes/types'
-import {useUnreadNotifications} from '#/state/queries/notifications/unread'
 
 export function useSetTitle(title?: string) {
   const navigation = useNavigation<NavigationProp>()
-  const numUnread = useUnreadNotifications()
   useEffect(() => {
     if (title) {
       navigation.setOptions({title})
     }
-  }, [title, navigation, numUnread])
+  }, [title, navigation])
 }

--- a/src/lib/hooks/useSetTitle.ts
+++ b/src/lib/hooks/useSetTitle.ts
@@ -2,7 +2,6 @@ import {useEffect} from 'react'
 import {useNavigation} from '@react-navigation/native'
 
 import {type NavigationProp} from '#/lib/routes/types'
-import {bskyTitle} from '#/lib/strings/headings'
 import {useUnreadNotifications} from '#/state/queries/notifications/unread'
 
 export function useSetTitle(title?: string) {
@@ -10,7 +9,7 @@ export function useSetTitle(title?: string) {
   const numUnread = useUnreadNotifications()
   useEffect(() => {
     if (title) {
-      navigation.setOptions({title: bskyTitle(title, numUnread)})
+      navigation.setOptions({title})
     }
   }, [title, navigation, numUnread])
 }

--- a/src/screens/PostThread/index.tsx
+++ b/src/screens/PostThread/index.tsx
@@ -1,11 +1,13 @@
 import {useCallback, useEffect, useMemo, useRef, useState} from 'react'
 import {useWindowDimensions, View} from 'react-native'
 import Animated, {useAnimatedStyle} from 'react-native-reanimated'
-import {Trans} from '@lingui/macro'
+import {msg, Trans} from '@lingui/macro'
+import {useLingui} from '@lingui/react'
 
 import {useInitialNumToRender} from '#/lib/hooks/useInitialNumToRender'
 import {useOpenComposer} from '#/lib/hooks/useOpenComposer'
 import {usePostViewTracking} from '#/lib/hooks/usePostViewTracking'
+import {useSetTitle} from '#/lib/hooks/useSetTitle'
 import {logger} from '#/logger'
 import {useFeedFeedback} from '#/state/feed-feedback'
 import {type ThreadViewOption} from '#/state/queries/preferences/useThreadPreferences'
@@ -49,6 +51,7 @@ const PARENT_CHUNK_SIZE = 5
 const CHILDREN_CHUNK_SIZE = 50
 
 export function PostThread({uri}: {uri: string}) {
+  const {_} = useLingui()
   const {gtMobile} = useBreakpoints()
   const {hasSession} = useSession()
   const initialNumToRender = useInitialNumToRender()
@@ -74,6 +77,12 @@ export function PostThread({uri}: {uri: string}) {
     }
     return {hasParents}
   }, [thread.data.items])
+
+  useSetTitle(
+    anchor?.value.post
+      ? _(msg`Post by @${anchor.value.post.author.handle}`)
+      : undefined,
+  )
 
   // Track post:view event when anchor post is viewed
   const seenPostUriRef = useRef<string | null>(null)


### PR DESCRIPTION
Currently when setting the HTML document title on web, we manually append `- Bluesky` to each screen title. There's actually already a built-in way to do this easily, the [`documentTitle.formatter`](https://reactnavigation.org/docs/navigation-container/#documenttitleformatter) API. This PR adopts this API, which is mostly a simplification.

It also fixes two small issues:
- `Post by @...` on post threads - can show DIDs if there's a DID in the URL. Fixed by setting the title once the thread is resolved
- Translations are now dynamic, rather than static (it was using the global i18n instance (bad))