### PR TITLE
feat(settings): add search bar to filter settings

### DIFF
--- a/src/locale/locales/en/messages.po
+++ b/src/locale/locales/en/messages.po
@@ -574,10 +574,11 @@ msgstr ""
 msgid "A screenshot of a profile page with a bell icon next to the follow button, indicating the new activity notifications feature."
 msgstr ""
 
-#: src/Navigation.tsx:535
+#: src/Navigation.tsx:534
 #: src/screens/Settings/AboutSettings.tsx:75
-#: src/screens/Settings/Settings.tsx:262
-#: src/screens/Settings/Settings.tsx:265
+#: src/screens/Settings/Settings.tsx:295
+#: src/screens/Settings/Settings.tsx:298
+#: src/screens/Settings/settingsSearchConfig.ts:172
 msgid "About"
 msgstr ""
 
@@ -604,20 +605,22 @@ msgid "Accept this language suggestion"
 msgstr ""
 
 #: src/screens/Settings/AccessibilitySettings.tsx:44
-#: src/screens/Settings/Settings.tsx:238
-#: src/screens/Settings/Settings.tsx:241
+#: src/screens/Settings/Settings.tsx:271
+#: src/screens/Settings/Settings.tsx:274
+#: src/screens/Settings/settingsSearchConfig.ts:141
 msgid "Accessibility"
 msgstr ""
 
-#: src/Navigation.tsx:386
+#: src/Navigation.tsx:385
 msgid "Accessibility Settings"
 msgstr ""
 
-#: src/Navigation.tsx:402
+#: src/Navigation.tsx:401
 #: src/screens/Login/LoginForm.tsx:194
 #: src/screens/Settings/AccountSettings.tsx:51
-#: src/screens/Settings/Settings.tsx:180
-#: src/screens/Settings/Settings.tsx:183
+#: src/screens/Settings/Settings.tsx:213
+#: src/screens/Settings/Settings.tsx:216
+#: src/screens/Settings/settingsSearchConfig.ts:38
 msgid "Account"
 msgstr ""
 
@@ -648,7 +651,7 @@ msgstr ""
 msgid "Account Muted by List"
 msgstr ""
 
-#: src/screens/Settings/Settings.tsx:646
+#: src/screens/Settings/Settings.tsx:681
 msgid "Account options"
 msgstr ""
 
@@ -656,7 +659,7 @@ msgstr ""
 msgid "Account provider"
 msgstr ""
 
-#: src/screens/Settings/Settings.tsx:682
+#: src/screens/Settings/Settings.tsx:717
 msgid "Account removed from quick access"
 msgstr ""
 
@@ -685,10 +688,11 @@ msgstr ""
 #: src/lib/hooks/useNotificationHandler.ts:182
 #: src/screens/Settings/NotificationSettings/ActivityNotificationSettings.tsx:102
 #: src/screens/Settings/NotificationSettings/index.tsx:192
+#: src/screens/Settings/settingsSearchConfig.ts:94
 msgid "Activity from others"
 msgstr ""
 
-#: src/Navigation.tsx:503
+#: src/Navigation.tsx:502
 msgid "Activity notifications"
 msgstr ""
 
@@ -737,12 +741,12 @@ msgstr ""
 msgid "Add alt text"
 msgstr ""
 
-#: src/view/com/composer/videos/SubtitleDialog.tsx:106
+#: src/view/com/composer/videos/SubtitleDialog.tsx:110
 msgid "Add alt text (optional)"
 msgstr ""
 
-#: src/screens/Settings/Settings.tsx:584
-#: src/screens/Settings/Settings.tsx:587
+#: src/screens/Settings/Settings.tsx:619
+#: src/screens/Settings/Settings.tsx:622
 #: src/view/shell/desktop/LeftNav.tsx:262
 #: src/view/shell/desktop/LeftNav.tsx:266
 msgid "Add another account"
@@ -779,8 +783,8 @@ msgstr ""
 msgid "Add media to post"
 msgstr ""
 
-#: src/components/moderation/ReportDialog/index.tsx:507
-#: src/components/moderation/ReportDialog/index.tsx:511
+#: src/components/moderation/ReportDialog/index.tsx:506
+#: src/components/moderation/ReportDialog/index.tsx:510
 msgid "Add more details (optional)"
 msgstr ""
 
@@ -861,7 +865,7 @@ msgstr ""
 msgid "Additional details (limit 1000 characters)"
 msgstr ""
 
-#: src/components/moderation/ReportDialog/index.tsx:525
+#: src/components/moderation/ReportDialog/index.tsx:524
 msgid "Additional details (limit 300 characters)"
 msgstr ""
 
@@ -970,6 +974,7 @@ msgstr ""
 
 #: src/screens/Settings/ActivityPrivacySettings.tsx:52
 #: src/screens/Settings/PrivacyAndSecuritySettings.tsx:91
+#: src/screens/Settings/settingsSearchConfig.ts:61
 msgid "Allow others to be notified of your posts"
 msgstr ""
 
@@ -1018,12 +1023,13 @@ msgid "ALT"
 msgstr ""
 
 #: src/screens/Settings/AccessibilitySettings.tsx:54
+#: src/screens/Settings/settingsSearchConfig.ts:145
 #: src/view/com/composer/GifAltText.tsx:154
 #: src/view/com/composer/photos/ImageAltTextDialog.tsx:117
 #: src/view/com/composer/videos/SubtitleDialog.tsx:40
 #: src/view/com/composer/videos/SubtitleDialog.tsx:55
-#: src/view/com/composer/videos/SubtitleDialog.tsx:101
 #: src/view/com/composer/videos/SubtitleDialog.tsx:105
+#: src/view/com/composer/videos/SubtitleDialog.tsx:109
 msgid "Alt text"
 msgstr ""
 
@@ -1033,6 +1039,10 @@ msgstr ""
 
 #: src/view/com/composer/photos/Gallery.tsx:261
 msgid "Alt text describes images for blind and low-vision users, and helps give context to everyone."
+msgstr ""
+
+#: src/view/com/composer/videos/SubtitleDialog.tsx:133
+msgid "Alt text must be less than {MAX_ALT_TEXT} characters."
 msgstr ""
 
 #: src/view/com/composer/GifAltText.tsx:179
@@ -1193,7 +1203,7 @@ msgstr ""
 msgid "Anyone who follows me"
 msgstr ""
 
-#: src/Navigation.tsx:543
+#: src/Navigation.tsx:542
 #: src/screens/Settings/AppIconSettings/index.tsx:67
 #: src/screens/Settings/AppIconSettings/SettingsListItem.tsx:18
 #: src/screens/Settings/AppIconSettings/SettingsListItem.tsx:23
@@ -1205,6 +1215,7 @@ msgid "App language"
 msgstr ""
 
 #: src/screens/Settings/LanguageSettings.tsx:87
+#: src/screens/Settings/settingsSearchConfig.ts:158
 msgid "App Language"
 msgstr ""
 
@@ -1231,10 +1242,11 @@ msgstr ""
 
 #: src/screens/Settings/PrivacyAndSecuritySettings.tsx:71
 #: src/screens/Settings/PrivacyAndSecuritySettings.tsx:74
+#: src/screens/Settings/settingsSearchConfig.ts:60
 msgid "App passwords"
 msgstr ""
 
-#: src/Navigation.tsx:354
+#: src/Navigation.tsx:353
 #: src/screens/Settings/AppPasswords.tsx:50
 msgid "App Passwords"
 msgstr ""
@@ -1254,12 +1266,12 @@ msgctxt "toast"
 msgid "Appeal submitted"
 msgstr ""
 
-#: src/screens/Takendown.tsx:119
-#: src/screens/Takendown.tsx:147
+#: src/screens/Takendown.tsx:114
+#: src/screens/Takendown.tsx:142
 msgid "Appeal suspension"
 msgstr ""
 
-#: src/screens/Takendown.tsx:122
+#: src/screens/Takendown.tsx:117
 msgid "Appeal Suspension"
 msgstr ""
 
@@ -1270,10 +1282,11 @@ msgstr ""
 msgid "Appeal this decision"
 msgstr ""
 
-#: src/Navigation.tsx:394
+#: src/Navigation.tsx:393
 #: src/screens/Settings/AppearanceSettings.tsx:73
-#: src/screens/Settings/Settings.tsx:230
-#: src/screens/Settings/Settings.tsx:233
+#: src/screens/Settings/Settings.tsx:263
+#: src/screens/Settings/Settings.tsx:266
+#: src/screens/Settings/settingsSearchConfig.ts:129
 msgid "Appearance"
 msgstr ""
 
@@ -1282,8 +1295,8 @@ msgstr ""
 msgid "Apply default recommended feeds"
 msgstr ""
 
-#: src/screens/Settings/Settings.tsx:516
-#: src/screens/Settings/Settings.tsx:518
+#: src/screens/Settings/Settings.tsx:551
+#: src/screens/Settings/Settings.tsx:553
 msgid "Apply Pull Request"
 msgstr ""
 
@@ -1365,6 +1378,7 @@ msgstr ""
 
 #: src/screens/Settings/ContentAndMediaSettings.tsx:116
 #: src/screens/Settings/ContentAndMediaSettings.tsx:122
+#: src/screens/Settings/settingsSearchConfig.ts:111
 msgid "Autoplay videos and GIFs"
 msgstr ""
 
@@ -1453,6 +1467,7 @@ msgid "Birthdate"
 msgstr ""
 
 #: src/screens/Settings/AccountSettings.tsx:142
+#: src/screens/Settings/settingsSearchConfig.ts:46
 msgid "Birthday"
 msgstr ""
 
@@ -1517,10 +1532,11 @@ msgid "Blocked"
 msgstr ""
 
 #: src/screens/Moderation/index.tsx:311
+#: src/screens/Settings/settingsSearchConfig.ts:75
 msgid "Blocked accounts"
 msgstr ""
 
-#: src/Navigation.tsx:195
+#: src/Navigation.tsx:194
 #: src/view/screens/ModerationBlockedAccounts.tsx:104
 msgid "Blocked Accounts"
 msgstr ""
@@ -1593,7 +1609,7 @@ msgstr ""
 msgid "Bluesky is more fun with friends. Do you want to invite some of yours? <0/>"
 msgstr ""
 
-#: src/screens/Takendown.tsx:220
+#: src/screens/Takendown.tsx:215
 msgid "Bluesky Social Terms of Service"
 msgstr ""
 
@@ -1693,7 +1709,7 @@ msgid "Button to go back to the home timeline"
 msgstr ""
 
 #: src/components/LabelingServiceCard/index.tsx:62
-#: src/components/moderation/ReportDialog/index.tsx:834
+#: src/components/moderation/ReportDialog/index.tsx:833
 #: src/screens/Search/components/StarterPackCard.tsx:106
 #: src/screens/Search/Explore.tsx:936
 msgid "By {0}"
@@ -1761,9 +1777,9 @@ msgstr ""
 #: src/screens/Settings/components/ChangeHandleDialog.tsx:85
 #: src/screens/Settings/components/ChangePasswordDialog.tsx:247
 #: src/screens/Settings/components/ChangePasswordDialog.tsx:253
-#: src/screens/Settings/Settings.tsx:307
-#: src/screens/Takendown.tsx:107
-#: src/screens/Takendown.tsx:110
+#: src/screens/Settings/Settings.tsx:342
+#: src/screens/Takendown.tsx:102
+#: src/screens/Takendown.tsx:105
 #: src/view/com/composer/Composer.tsx:1050
 #: src/view/com/composer/Composer.tsx:1061
 #: src/view/com/composer/photos/EditImageDialog.web.tsx:43
@@ -1802,7 +1818,7 @@ msgstr ""
 msgid "Cannot interact with a blocked user"
 msgstr ""
 
-#: src/view/com/composer/videos/SubtitleDialog.tsx:132
+#: src/view/com/composer/videos/SubtitleDialog.tsx:148
 msgid "Captions (.vtt)"
 msgstr ""
 
@@ -1833,7 +1849,7 @@ msgstr ""
 msgid "Change Handle"
 msgstr ""
 
-#: src/components/moderation/ReportDialog/index.tsx:424
+#: src/components/moderation/ReportDialog/index.tsx:423
 msgid "Change moderation service"
 msgstr ""
 
@@ -1846,11 +1862,11 @@ msgstr ""
 msgid "Change password dialog"
 msgstr ""
 
-#: src/components/moderation/ReportDialog/index.tsx:289
+#: src/components/moderation/ReportDialog/index.tsx:288
 msgid "Change report category"
 msgstr ""
 
-#: src/components/moderation/ReportDialog/index.tsx:369
+#: src/components/moderation/ReportDialog/index.tsx:368
 msgid "Change report reason"
 msgstr ""
 
@@ -1872,7 +1888,7 @@ msgid "Changes saved"
 msgstr ""
 
 #: src/lib/hooks/useNotificationHandler.ts:99
-#: src/Navigation.tsx:560
+#: src/Navigation.tsx:559
 #: src/view/shell/bottom-bar/BottomBar.tsx:221
 #: src/view/shell/desktop/LeftNav.tsx:608
 #: src/view/shell/Drawer.tsx:466
@@ -1898,7 +1914,7 @@ msgctxt "toast"
 msgid "Chat muted"
 msgstr ""
 
-#: src/Navigation.tsx:570
+#: src/Navigation.tsx:569
 #: src/screens/Messages/components/InboxPreview.tsx:22
 msgid "Chat request inbox"
 msgstr ""
@@ -1910,7 +1926,7 @@ msgid "Chat requests"
 msgstr ""
 
 #: src/components/dms/ConvoMenu.tsx:78
-#: src/Navigation.tsx:565
+#: src/Navigation.tsx:564
 #: src/screens/Messages/ChatList.tsx:81
 #: src/screens/Messages/ChatList.tsx:85
 #: src/screens/Messages/ChatList.tsx:380
@@ -1997,16 +2013,17 @@ msgstr ""
 msgid "Choose your username"
 msgstr ""
 
-#: src/screens/Settings/Settings.tsx:508
+#: src/screens/Settings/Settings.tsx:543
 msgid "Clear all storage data"
 msgstr ""
 
-#: src/screens/Settings/Settings.tsx:510
+#: src/screens/Settings/Settings.tsx:545
 msgid "Clear all storage data (restart after this)"
 msgstr ""
 
 #: src/screens/Settings/AboutSettings.tsx:116
 #: src/screens/Settings/AboutSettings.tsx:120
+#: src/screens/Settings/settingsSearchConfig.ts:180
 msgid "Clear image cache"
 msgstr ""
 
@@ -2121,7 +2138,7 @@ msgstr ""
 msgid "Close dialog"
 msgstr ""
 
-#: src/view/shell/index.web.tsx:113
+#: src/view/shell/index.web.tsx:128
 msgid "Close drawer menu"
 msgstr ""
 
@@ -2183,6 +2200,7 @@ msgstr ""
 
 #: src/components/dialogs/Embed.tsx:154
 #: src/screens/Settings/AppearanceSettings.tsx:81
+#: src/screens/Settings/settingsSearchConfig.ts:133
 msgid "Color mode"
 msgstr ""
 
@@ -2199,7 +2217,7 @@ msgid "Comics"
 msgstr ""
 
 #: src/components/PolicyUpdateOverlay/updates/202508/index.tsx:45
-#: src/Navigation.tsx:344
+#: src/Navigation.tsx:343
 #: src/view/screens/CommunityGuidelines.tsx:37
 msgid "Community Guidelines"
 msgstr ""
@@ -2297,6 +2315,7 @@ msgid "Contact sync is not available on this device, as the app is unable to acc
 msgstr ""
 
 #: src/components/ageAssurance/AgeAssuranceAppealDialog.tsx:93
+#: src/screens/Settings/settingsSearchConfig.ts:168
 msgid "Contact us"
 msgstr ""
 
@@ -2312,12 +2331,13 @@ msgstr ""
 msgid "Content & Media"
 msgstr ""
 
-#: src/screens/Settings/Settings.tsx:210
-#: src/screens/Settings/Settings.tsx:213
+#: src/screens/Settings/Settings.tsx:243
+#: src/screens/Settings/Settings.tsx:246
+#: src/screens/Settings/settingsSearchConfig.ts:101
 msgid "Content and media"
 msgstr ""
 
-#: src/Navigation.tsx:519
+#: src/Navigation.tsx:518
 msgid "Content and Media"
 msgstr ""
 
@@ -2326,6 +2346,7 @@ msgid "Content Blocked"
 msgstr ""
 
 #: src/screens/Moderation/index.tsx:344
+#: src/screens/Settings/settingsSearchConfig.ts:77
 msgid "Content filters"
 msgstr ""
 
@@ -2334,6 +2355,7 @@ msgid "Content from across the network we think you might like."
 msgstr ""
 
 #: src/screens/Settings/LanguageSettings.tsx:155
+#: src/screens/Settings/settingsSearchConfig.ts:160
 #: src/view/com/modals/lang-settings/ContentLanguagesSettings.tsx:76
 msgid "Content Languages"
 msgstr ""
@@ -2515,7 +2537,7 @@ msgstr ""
 
 #: src/components/PolicyUpdateOverlay/updates/202508/index.tsx:40
 #: src/components/PolicyUpdateOverlay/updates/202508/index.tsx:107
-#: src/Navigation.tsx:349
+#: src/Navigation.tsx:348
 #: src/view/screens/CopyrightPolicy.tsx:34
 msgid "Copyright Policy"
 msgstr ""
@@ -2604,7 +2626,7 @@ msgstr ""
 
 #: src/components/StarterPack/ProfileStarterPacks.tsx:206
 #: src/components/StarterPack/ProfileStarterPacks.tsx:315
-#: src/Navigation.tsx:600
+#: src/Navigation.tsx:599
 msgid "Create a starter pack"
 msgstr ""
 
@@ -2664,8 +2686,8 @@ msgid "Create new account"
 msgstr ""
 
 #. Accessibility label for button to create a moderation report for the selected option
-#: src/components/moderation/ReportDialog/index.tsx:689
-#: src/components/moderation/ReportDialog/index.tsx:735
+#: src/components/moderation/ReportDialog/index.tsx:688
+#: src/components/moderation/ReportDialog/index.tsx:734
 msgid "Create report for {0}"
 msgstr ""
 
@@ -2728,6 +2750,7 @@ msgid "Dark mode"
 msgstr ""
 
 #: src/screens/Settings/AppearanceSettings.tsx:106
+#: src/screens/Settings/settingsSearchConfig.ts:134
 msgid "Dark theme"
 msgstr ""
 
@@ -2738,10 +2761,11 @@ msgstr ""
 #: src/screens/Settings/AccountSettings.tsx:161
 #: src/screens/Settings/AccountSettings.tsx:166
 #: src/screens/Settings/components/DeactivateAccountDialog.tsx:73
+#: src/screens/Settings/settingsSearchConfig.ts:48
 msgid "Deactivate account"
 msgstr ""
 
-#: src/screens/Settings/Settings.tsx:473
+#: src/screens/Settings/Settings.tsx:508
 msgid "Debug Moderation"
 msgstr ""
 
@@ -2774,6 +2798,7 @@ msgstr ""
 
 #: src/screens/Settings/AccountSettings.tsx:171
 #: src/screens/Settings/AccountSettings.tsx:176
+#: src/screens/Settings/settingsSearchConfig.ts:49
 msgid "Delete account"
 msgstr ""
 
@@ -2794,7 +2819,7 @@ msgstr ""
 msgid "Delete chat"
 msgstr ""
 
-#: src/screens/Settings/Settings.tsx:480
+#: src/screens/Settings/Settings.tsx:515
 msgid "Delete chat declaration record"
 msgstr ""
 
@@ -2907,8 +2932,8 @@ msgctxt "toast"
 msgid "Developer mode enabled"
 msgstr ""
 
-#: src/screens/Settings/Settings.tsx:289
-#: src/screens/Settings/Settings.tsx:292
+#: src/screens/Settings/Settings.tsx:322
+#: src/screens/Settings/Settings.tsx:325
 msgid "Developer options"
 msgstr ""
 
@@ -2935,6 +2960,7 @@ msgstr ""
 
 #: src/screens/Settings/AccessibilitySettings.tsx:89
 #: src/screens/Settings/AccessibilitySettings.tsx:94
+#: src/screens/Settings/settingsSearchConfig.ts:149
 msgid "Disable haptic feedback"
 msgstr ""
 
@@ -3024,6 +3050,7 @@ msgstr ""
 
 #: src/screens/Settings/AccessibilitySettings.tsx:69
 #: src/screens/Settings/AccessibilitySettings.tsx:74
+#: src/screens/Settings/settingsSearchConfig.ts:147
 msgid "Display larger alt text badges"
 msgstr ""
 
@@ -3089,8 +3116,8 @@ msgstr ""
 #: src/view/com/composer/labels/LabelsBtn.tsx:218
 #: src/view/com/composer/labels/LabelsBtn.tsx:225
 #: src/view/com/composer/select-language/PostLanguageSelectDialog.tsx:303
-#: src/view/com/composer/videos/SubtitleDialog.tsx:168
-#: src/view/com/composer/videos/SubtitleDialog.tsx:178
+#: src/view/com/composer/videos/SubtitleDialog.tsx:184
+#: src/view/com/composer/videos/SubtitleDialog.tsx:195
 msgid "Done"
 msgstr ""
 
@@ -3230,7 +3257,7 @@ msgstr ""
 msgid "Edit moderation list"
 msgstr ""
 
-#: src/Navigation.tsx:359
+#: src/Navigation.tsx:358
 #: src/view/screens/Feeds.tsx:518
 msgid "Edit My Feeds"
 msgstr ""
@@ -3272,7 +3299,7 @@ msgstr ""
 msgid "Edit who can reply"
 msgstr ""
 
-#: src/Navigation.tsx:605
+#: src/Navigation.tsx:604
 msgid "Edit your starter pack"
 msgstr ""
 
@@ -3285,8 +3312,13 @@ msgid "Either the creator of this list has blocked you or you have blocked the c
 msgstr ""
 
 #: src/screens/Settings/AccountSettings.tsx:66
+#: src/screens/Settings/settingsSearchConfig.ts:42
 #: src/screens/Signup/StepInfo/index.tsx:196
 msgid "Email"
+msgstr ""
+
+#: src/screens/Settings/settingsSearchConfig.ts:59
+msgid "Email 2FA"
 msgstr ""
 
 #: src/screens/Settings/components/DisableEmail2FADialog.tsx:64
@@ -3348,6 +3380,7 @@ msgid "Enable {0} only"
 msgstr ""
 
 #: src/screens/Moderation/index.tsx:371
+#: src/screens/Settings/settingsSearchConfig.ts:78
 msgid "Enable adult content"
 msgstr ""
 
@@ -3371,6 +3404,7 @@ msgstr ""
 
 #: src/screens/Settings/NotificationSettings/index.tsx:102
 #: src/screens/Settings/NotificationSettings/index.tsx:106
+#: src/screens/Settings/settingsSearchConfig.ts:87
 msgid "Enable push notifications"
 msgstr ""
 
@@ -3388,7 +3422,12 @@ msgstr ""
 
 #: src/screens/Settings/ContentAndMediaSettings.tsx:132
 #: src/screens/Settings/ContentAndMediaSettings.tsx:146
+#: src/screens/Settings/settingsSearchConfig.ts:112
 msgid "Enable trending topics"
+msgstr ""
+
+#: src/screens/Settings/settingsSearchConfig.ts:113
+msgid "Enable trending videos"
 msgstr ""
 
 #: src/screens/Settings/ContentAndMediaSettings.tsx:153
@@ -3406,7 +3445,7 @@ msgstr ""
 msgid "End of feed"
 msgstr ""
 
-#: src/view/com/composer/videos/SubtitleDialog.tsx:158
+#: src/view/com/composer/videos/SubtitleDialog.tsx:174
 msgid "Ensure you have selected a language for each subtitle file."
 msgstr ""
 
@@ -3601,7 +3640,7 @@ msgstr ""
 msgid "Explicit sexual images."
 msgstr ""
 
-#: src/Navigation.tsx:780
+#: src/Navigation.tsx:788
 #: src/screens/Search/Shell.tsx:327
 #: src/view/shell/desktop/LeftNav.tsx:690
 #: src/view/shell/Drawer.tsx:414
@@ -3615,6 +3654,7 @@ msgstr ""
 
 #: src/screens/Settings/AccountSettings.tsx:152
 #: src/screens/Settings/AccountSettings.tsx:156
+#: src/screens/Settings/settingsSearchConfig.ts:47
 msgid "Export my data"
 msgstr ""
 
@@ -3624,6 +3664,7 @@ msgstr ""
 
 #: src/screens/Settings/ContentAndMediaSettings.tsx:84
 #: src/screens/Settings/ContentAndMediaSettings.tsx:87
+#: src/screens/Settings/settingsSearchConfig.ts:108
 msgid "External media"
 msgstr ""
 
@@ -3637,7 +3678,7 @@ msgstr ""
 msgid "External media may allow websites to collect information about you and your device. No information is sent or requested until you press the \"play\" button."
 msgstr ""
 
-#: src/Navigation.tsx:378
+#: src/Navigation.tsx:377
 #: src/screens/Settings/ExternalMediaPreferences.tsx:34
 msgid "External Media Preferences"
 msgstr ""
@@ -3874,7 +3915,11 @@ msgstr ""
 msgid "False information about elections"
 msgstr ""
 
-#: src/Navigation.tsx:294
+#: src/screens/Settings/settingsSearchConfig.ts:168
+msgid "FAQ"
+msgstr ""
+
+#: src/Navigation.tsx:293
 msgid "Feed"
 msgstr ""
 
@@ -3915,7 +3960,7 @@ msgctxt "toast"
 msgid "Feedback sent to feed operator"
 msgstr ""
 
-#: src/Navigation.tsx:585
+#: src/Navigation.tsx:584
 #: src/screens/SavedFeeds.tsx:108
 #: src/screens/Search/SearchResults.tsx:78
 #: src/screens/StarterPack/StarterPackScreen.tsx:190
@@ -3986,17 +4031,22 @@ msgstr ""
 msgid "Find accounts to follow"
 msgstr ""
 
-#: src/Navigation.tsx:426
-#: src/Navigation.tsx:627
+#: src/Navigation.tsx:425
+#: src/Navigation.tsx:626
 msgid "Find Contacts"
+msgstr ""
+
+#: src/screens/Settings/settingsSearchConfig.ts:121
+msgid "Find friends"
 msgstr ""
 
 #: src/screens/Settings/FindContactsSettings.tsx:76
 msgid "Find Friends"
 msgstr ""
 
-#: src/screens/Settings/Settings.tsx:221
-#: src/screens/Settings/Settings.tsx:224
+#: src/screens/Settings/Settings.tsx:254
+#: src/screens/Settings/Settings.tsx:257
+#: src/screens/Settings/settingsSearchConfig.ts:118
 msgid "Find friends from contacts"
 msgstr ""
 
@@ -4141,7 +4191,7 @@ msgstr ""
 msgid "Followed by <0>{0}</0>, <1>{1}</1>, and {2, plural, one {# other} other {# others}}"
 msgstr ""
 
-#: src/Navigation.tsx:248
+#: src/Navigation.tsx:247
 msgid "Followers of @{0} that you know"
 msgstr ""
 
@@ -4181,10 +4231,11 @@ msgstr ""
 
 #: src/screens/Settings/ContentAndMediaSettings.tsx:76
 #: src/screens/Settings/ContentAndMediaSettings.tsx:79
+#: src/screens/Settings/settingsSearchConfig.ts:107
 msgid "Following feed preferences"
 msgstr ""
 
-#: src/Navigation.tsx:365
+#: src/Navigation.tsx:364
 #: src/screens/Settings/FollowingFeedPreferences.tsx:56
 msgid "Following Feed Preferences"
 msgstr ""
@@ -4198,10 +4249,12 @@ msgid "Follows You"
 msgstr ""
 
 #: src/screens/Settings/AppearanceSettings.tsx:128
+#: src/screens/Settings/settingsSearchConfig.ts:135
 msgid "Font"
 msgstr ""
 
 #: src/screens/Settings/AppearanceSettings.tsx:148
+#: src/screens/Settings/settingsSearchConfig.ts:136
 msgid "Font size"
 msgstr ""
 
@@ -4478,6 +4531,7 @@ msgstr ""
 
 #: src/screens/Settings/AccountSettings.tsx:130
 #: src/screens/Settings/AccountSettings.tsx:135
+#: src/screens/Settings/settingsSearchConfig.ts:45
 msgid "Handle"
 msgstr ""
 
@@ -4495,6 +4549,7 @@ msgid "Handle too long. Please try a shorter one."
 msgstr ""
 
 #: src/screens/Settings/AccessibilitySettings.tsx:85
+#: src/screens/Settings/settingsSearchConfig.ts:148
 msgid "Haptics"
 msgstr ""
 
@@ -4510,7 +4565,7 @@ msgstr ""
 msgid "Harming or endangering minors"
 msgstr ""
 
-#: src/Navigation.tsx:550
+#: src/Navigation.tsx:549
 msgid "Hashtag"
 msgstr ""
 
@@ -4535,8 +4590,9 @@ msgstr ""
 msgid "Held by Bluesky for 7 days to prevent abuse, then deleted"
 msgstr ""
 
-#: src/screens/Settings/Settings.tsx:254
-#: src/screens/Settings/Settings.tsx:258
+#: src/screens/Settings/Settings.tsx:287
+#: src/screens/Settings/Settings.tsx:291
+#: src/screens/Settings/settingsSearchConfig.ts:165
 #: src/view/shell/desktop/RightNav.tsx:123
 #: src/view/shell/desktop/RightNav.tsx:124
 #: src/view/shell/Drawer.tsx:381
@@ -4696,8 +4752,8 @@ msgstr ""
 msgid "Hold up! We’re gradually giving access to video, and you’re still waiting in line. Check back soon!"
 msgstr ""
 
-#: src/Navigation.tsx:775
-#: src/Navigation.tsx:795
+#: src/Navigation.tsx:783
+#: src/Navigation.tsx:803
 #: src/view/shell/bottom-bar/BottomBar.tsx:178
 #: src/view/shell/desktop/LeftNav.tsx:672
 #: src/view/shell/Drawer.tsx:440
@@ -4923,6 +4979,7 @@ msgid "Interaction limited"
 msgstr ""
 
 #: src/screens/Moderation/index.tsx:251
+#: src/screens/Settings/settingsSearchConfig.ts:71
 msgid "Interaction settings"
 msgstr ""
 
@@ -4957,7 +5014,7 @@ msgstr ""
 msgid "Invalid phone number"
 msgstr ""
 
-#: src/components/moderation/ReportDialog/index.tsx:81
+#: src/components/moderation/ReportDialog/index.tsx:80
 msgid "Invalid report subject"
 msgstr ""
 
@@ -5085,13 +5142,14 @@ msgstr ""
 msgid "Labels on your content"
 msgstr ""
 
-#: src/Navigation.tsx:221
+#: src/Navigation.tsx:220
 msgid "Language Settings"
 msgstr ""
 
 #: src/screens/Settings/LanguageSettings.tsx:78
-#: src/screens/Settings/Settings.tsx:246
-#: src/screens/Settings/Settings.tsx:249
+#: src/screens/Settings/Settings.tsx:279
+#: src/screens/Settings/Settings.tsx:282
+#: src/screens/Settings/settingsSearchConfig.ts:154
 msgid "Languages"
 msgstr ""
 
@@ -5262,7 +5320,7 @@ msgstr ""
 msgid "Like 10 posts to train the Discover feed"
 msgstr ""
 
-#: src/Navigation.tsx:463
+#: src/Navigation.tsx:462
 msgid "Like notifications"
 msgstr ""
 
@@ -5274,8 +5332,8 @@ msgstr ""
 msgid "Like this labeler"
 msgstr ""
 
-#: src/Navigation.tsx:299
-#: src/Navigation.tsx:304
+#: src/Navigation.tsx:298
+#: src/Navigation.tsx:303
 msgid "Liked by"
 msgstr ""
 
@@ -5300,6 +5358,7 @@ msgstr ""
 #: src/lib/hooks/useNotificationHandler.ts:126
 #: src/screens/Settings/NotificationSettings/index.tsx:126
 #: src/screens/Settings/NotificationSettings/LikeNotificationSettings.tsx:41
+#: src/screens/Settings/settingsSearchConfig.ts:88
 #: src/view/screens/Profile.tsx:238
 msgid "Likes"
 msgstr ""
@@ -5307,10 +5366,11 @@ msgstr ""
 #: src/lib/hooks/useNotificationHandler.ts:168
 #: src/screens/Settings/NotificationSettings/index.tsx:207
 #: src/screens/Settings/NotificationSettings/LikesOnRepostsNotificationSettings.tsx:41
+#: src/screens/Settings/settingsSearchConfig.ts:95
 msgid "Likes of your reposts"
 msgstr ""
 
-#: src/Navigation.tsx:487
+#: src/Navigation.tsx:486
 msgid "Likes of your reposts notifications"
 msgstr ""
 
@@ -5323,7 +5383,7 @@ msgstr ""
 msgid "Linear"
 msgstr ""
 
-#: src/Navigation.tsx:254
+#: src/Navigation.tsx:253
 msgid "List"
 msgstr ""
 
@@ -5403,7 +5463,7 @@ msgctxt "toast"
 msgid "List unmuted"
 msgstr ""
 
-#: src/Navigation.tsx:175
+#: src/Navigation.tsx:174
 #: src/view/screens/Lists.tsx:67
 #: src/view/screens/Profile.tsx:233
 #: src/view/screens/Profile.tsx:241
@@ -5468,7 +5528,7 @@ msgstr ""
 msgid "Loading..."
 msgstr ""
 
-#: src/Navigation.tsx:324
+#: src/Navigation.tsx:323
 msgid "Log"
 msgstr ""
 
@@ -5477,6 +5537,7 @@ msgid "Logged out"
 msgstr ""
 
 #: src/screens/Settings/PrivacyAndSecuritySettings.tsx:106
+#: src/screens/Settings/settingsSearchConfig.ts:62
 msgid "Logged-out visibility"
 msgstr ""
 
@@ -5523,6 +5584,7 @@ msgstr ""
 
 #: src/screens/Settings/ContentAndMediaSettings.tsx:60
 #: src/screens/Settings/ContentAndMediaSettings.tsx:63
+#: src/screens/Settings/settingsSearchConfig.ts:105
 msgid "Manage saved feeds"
 msgstr ""
 
@@ -5563,7 +5625,7 @@ msgstr ""
 msgid "Media that may be disturbing or inappropriate for some audiences."
 msgstr ""
 
-#: src/Navigation.tsx:447
+#: src/Navigation.tsx:446
 msgid "Mention notifications"
 msgstr ""
 
@@ -5574,6 +5636,7 @@ msgstr ""
 #: src/lib/hooks/useNotificationHandler.ts:147
 #: src/screens/Settings/NotificationSettings/index.tsx:159
 #: src/screens/Settings/NotificationSettings/MentionNotificationSettings.tsx:41
+#: src/screens/Settings/settingsSearchConfig.ts:91
 #: src/view/screens/Notifications.tsx:101
 msgid "Mentions"
 msgstr ""
@@ -5616,7 +5679,7 @@ msgstr ""
 msgid "Message options"
 msgstr ""
 
-#: src/Navigation.tsx:790
+#: src/Navigation.tsx:798
 msgid "Messages"
 msgstr ""
 
@@ -5629,7 +5692,7 @@ msgstr ""
 msgid "Minor harassment or bullying"
 msgstr ""
 
-#: src/Navigation.tsx:511
+#: src/Navigation.tsx:510
 msgid "Miscellaneous notifications"
 msgstr ""
 
@@ -5637,10 +5700,11 @@ msgstr ""
 msgid "Misleading"
 msgstr ""
 
-#: src/Navigation.tsx:180
+#: src/Navigation.tsx:179
 #: src/screens/Moderation/index.tsx:99
-#: src/screens/Settings/Settings.tsx:194
-#: src/screens/Settings/Settings.tsx:197
+#: src/screens/Settings/Settings.tsx:227
+#: src/screens/Settings/Settings.tsx:230
+#: src/screens/Settings/settingsSearchConfig.ts:67
 msgid "Moderation"
 msgstr ""
 
@@ -5673,10 +5737,11 @@ msgid "Moderation list updated"
 msgstr ""
 
 #: src/screens/Moderation/index.tsx:281
+#: src/screens/Settings/settingsSearchConfig.ts:73
 msgid "Moderation lists"
 msgstr ""
 
-#: src/Navigation.tsx:185
+#: src/Navigation.tsx:184
 #: src/view/screens/ModerationModlists.tsx:67
 msgid "Moderation Lists"
 msgstr ""
@@ -5685,7 +5750,7 @@ msgstr ""
 msgid "moderation settings"
 msgstr ""
 
-#: src/Navigation.tsx:314
+#: src/Navigation.tsx:313
 msgid "Moderation states"
 msgstr ""
 
@@ -5805,10 +5870,11 @@ msgid "Mute words & tags"
 msgstr ""
 
 #: src/screens/Moderation/index.tsx:296
+#: src/screens/Settings/settingsSearchConfig.ts:74
 msgid "Muted accounts"
 msgstr ""
 
-#: src/Navigation.tsx:190
+#: src/Navigation.tsx:189
 #: src/view/screens/ModerationMutedAccounts.tsx:116
 msgid "Muted Accounts"
 msgstr ""
@@ -5822,6 +5888,7 @@ msgid "Muted by \"{0}\""
 msgstr ""
 
 #: src/screens/Moderation/index.tsx:266
+#: src/screens/Settings/settingsSearchConfig.ts:72
 msgid "Muted words & tags"
 msgstr ""
 
@@ -5864,8 +5931,8 @@ msgstr ""
 msgid "Navigates to your profile"
 msgstr ""
 
-#: src/components/moderation/ReportDialog/index.tsx:320
-#: src/components/moderation/ReportDialog/index.tsx:337
+#: src/components/moderation/ReportDialog/index.tsx:319
+#: src/components/moderation/ReportDialog/index.tsx:336
 msgid "Need to report a copyright violation, legal request, or regulatory compliance issue?"
 msgstr ""
 
@@ -5907,13 +5974,14 @@ msgstr ""
 msgid "New Feature"
 msgstr ""
 
-#: src/Navigation.tsx:479
+#: src/Navigation.tsx:478
 msgid "New follower notifications"
 msgstr ""
 
 #: src/lib/hooks/useNotificationHandler.ts:161
 #: src/screens/Settings/NotificationSettings/index.tsx:137
 #: src/screens/Settings/NotificationSettings/NewFollowerNotificationSettings.tsx:41
+#: src/screens/Settings/settingsSearchConfig.ts:89
 msgid "New followers"
 msgstr ""
 
@@ -6158,6 +6226,10 @@ msgstr ""
 msgid "No search results found for \"{search}\"."
 msgstr ""
 
+#: src/screens/Settings/components/SettingsSearchEmpty.tsx:19
+msgid "No settings found for \"{query}\""
+msgstr ""
+
 #: src/view/screens/Profile.tsx:555
 msgid "No Starter Packs yet"
 msgstr ""
@@ -6213,7 +6285,7 @@ msgstr ""
 msgid "Not followed by anyone you're following"
 msgstr ""
 
-#: src/Navigation.tsx:170
+#: src/Navigation.tsx:169
 #: src/view/screens/Profile.tsx:132
 msgid "Not Found"
 msgstr ""
@@ -6239,8 +6311,8 @@ msgstr ""
 msgid "Nothing saved yet"
 msgstr ""
 
-#: src/Navigation.tsx:433
-#: src/Navigation.tsx:580
+#: src/Navigation.tsx:432
+#: src/Navigation.tsx:579
 #: src/view/screens/Notifications.tsx:136
 msgid "Notification settings"
 msgstr ""
@@ -6253,8 +6325,8 @@ msgstr ""
 msgid "Notification Sounds"
 msgstr ""
 
-#: src/Navigation.tsx:575
-#: src/Navigation.tsx:785
+#: src/Navigation.tsx:574
+#: src/Navigation.tsx:793
 #: src/screens/Notifications/ActivityList.tsx:30
 #: src/screens/Settings/NotificationSettings/ActivityNotificationSettings.tsx:90
 #: src/screens/Settings/NotificationSettings/index.tsx:92
@@ -6267,8 +6339,9 @@ msgstr ""
 #: src/screens/Settings/NotificationSettings/ReplyNotificationSettings.tsx:30
 #: src/screens/Settings/NotificationSettings/RepostNotificationSettings.tsx:30
 #: src/screens/Settings/NotificationSettings/RepostsOnRepostsNotificationSettings.tsx:30
-#: src/screens/Settings/Settings.tsx:202
-#: src/screens/Settings/Settings.tsx:205
+#: src/screens/Settings/Settings.tsx:235
+#: src/screens/Settings/Settings.tsx:238
+#: src/screens/Settings/settingsSearchConfig.ts:83
 #: src/view/screens/Notifications.tsx:130
 #: src/view/shell/bottom-bar/BottomBar.tsx:252
 #: src/view/shell/desktop/LeftNav.tsx:709
@@ -6333,7 +6406,7 @@ msgstr ""
 msgid "on<0><1/><2><3/></2></0>"
 msgstr ""
 
-#: src/screens/Settings/Settings.tsx:406
+#: src/screens/Settings/Settings.tsx:441
 msgid "Onboarding reset"
 msgstr ""
 
@@ -6435,7 +6508,7 @@ msgstr ""
 msgid "Open message options"
 msgstr ""
 
-#: src/screens/Settings/Settings.tsx:471
+#: src/screens/Settings/Settings.tsx:506
 msgid "Open moderation debug page"
 msgstr ""
 
@@ -6464,12 +6537,12 @@ msgstr ""
 msgid "Open starter pack menu"
 msgstr ""
 
-#: src/screens/Settings/Settings.tsx:464
-#: src/screens/Settings/Settings.tsx:478
+#: src/screens/Settings/Settings.tsx:499
+#: src/screens/Settings/Settings.tsx:513
 msgid "Open storybook page"
 msgstr ""
 
-#: src/screens/Settings/Settings.tsx:457
+#: src/screens/Settings/Settings.tsx:492
 msgid "Open system log"
 msgstr ""
 
@@ -6532,12 +6605,16 @@ msgstr ""
 msgid "Opens GIF select dialog"
 msgstr ""
 
-#: src/screens/Settings/Settings.tsx:255
+#: src/screens/Settings/Settings.tsx:288
 msgid "Opens helpdesk in browser"
 msgstr ""
 
 #: src/view/com/feeds/ComposerPrompt.tsx:223
 msgid "Opens image picker"
+msgstr ""
+
+#: src/screens/Settings/components/SettingsSearchResultItem.tsx:39
+msgid "Opens in browser"
 msgstr ""
 
 #: src/components/dialogs/LinkWarning.tsx:97
@@ -6657,6 +6734,7 @@ msgstr ""
 #: src/screens/Login/LoginForm.tsx:229
 #: src/screens/Settings/AccountSettings.tsx:121
 #: src/screens/Settings/AccountSettings.tsx:125
+#: src/screens/Settings/settingsSearchConfig.ts:44
 #: src/screens/Signup/StepInfo/index.tsx:231
 #: src/view/com/modals/DeleteAccount.tsx:239
 #: src/view/com/modals/DeleteAccount.tsx:246
@@ -6695,11 +6773,11 @@ msgstr ""
 msgid "People"
 msgstr ""
 
-#: src/Navigation.tsx:241
+#: src/Navigation.tsx:240
 msgid "People followed by @{0}"
 msgstr ""
 
-#: src/Navigation.tsx:234
+#: src/Navigation.tsx:233
 msgid "People following @{0}"
 msgstr ""
 
@@ -6730,6 +6808,10 @@ msgstr ""
 
 #: src/lib/interests.ts:68
 msgid "Pets"
+msgstr ""
+
+#: src/screens/Settings/settingsSearchConfig.ts:121
+msgid "Phone contacts"
 msgstr ""
 
 #: src/components/contacts/screens/PhoneInput.tsx:189
@@ -7011,10 +7093,10 @@ msgstr ""
 msgid "Post blocked"
 msgstr ""
 
-#: src/Navigation.tsx:267
-#: src/Navigation.tsx:274
-#: src/Navigation.tsx:281
-#: src/Navigation.tsx:288
+#: src/Navigation.tsx:266
+#: src/Navigation.tsx:273
+#: src/Navigation.tsx:280
+#: src/Navigation.tsx:287
 msgid "Post by @{0}"
 msgstr ""
 
@@ -7048,7 +7130,7 @@ msgstr ""
 msgid "Post interaction settings"
 msgstr ""
 
-#: src/Navigation.tsx:201
+#: src/Navigation.tsx:200
 #: src/screens/ModerationInteractionSettings/index.tsx:34
 msgid "Post Interaction Settings"
 msgstr ""
@@ -7134,6 +7216,7 @@ msgid "Primary language"
 msgstr ""
 
 #: src/screens/Settings/LanguageSettings.tsx:121
+#: src/screens/Settings/settingsSearchConfig.ts:159
 msgid "Primary Language"
 msgstr ""
 
@@ -7142,13 +7225,14 @@ msgstr ""
 msgid "Privacy"
 msgstr ""
 
-#: src/screens/Settings/Settings.tsx:188
-#: src/screens/Settings/Settings.tsx:191
+#: src/screens/Settings/Settings.tsx:221
+#: src/screens/Settings/Settings.tsx:224
+#: src/screens/Settings/settingsSearchConfig.ts:54
 msgid "Privacy and security"
 msgstr ""
 
-#: src/Navigation.tsx:410
-#: src/Navigation.tsx:418
+#: src/Navigation.tsx:409
+#: src/Navigation.tsx:417
 #: src/screens/Settings/ActivityPrivacySettings.tsx:40
 #: src/screens/Settings/PrivacyAndSecuritySettings.tsx:44
 msgid "Privacy and Security"
@@ -7161,9 +7245,10 @@ msgstr ""
 
 #: src/components/PolicyUpdateOverlay/updates/202508/index.tsx:35
 #: src/components/PolicyUpdateOverlay/updates/202508/index.tsx:102
-#: src/Navigation.tsx:334
+#: src/Navigation.tsx:333
 #: src/screens/Settings/AboutSettings.tsx:92
 #: src/screens/Settings/AboutSettings.tsx:95
+#: src/screens/Settings/settingsSearchConfig.ts:177
 #: src/view/screens/PrivacyPolicy.tsx:34
 #: src/view/shell/Drawer.tsx:704
 #: src/view/shell/Drawer.tsx:705
@@ -7260,7 +7345,7 @@ msgstr ""
 msgid "QR code saved to your camera roll!"
 msgstr ""
 
-#: src/Navigation.tsx:455
+#: src/Navigation.tsx:454
 msgid "Quote notifications"
 msgstr ""
 
@@ -7290,6 +7375,7 @@ msgstr ""
 #: src/screens/Post/PostQuotes.tsx:41
 #: src/screens/Settings/NotificationSettings/index.tsx:170
 #: src/screens/Settings/NotificationSettings/QuoteNotificationSettings.tsx:41
+#: src/screens/Settings/settingsSearchConfig.ts:92
 msgid "Quotes"
 msgstr ""
 
@@ -7370,8 +7456,8 @@ msgstr ""
 msgid "Real people."
 msgstr ""
 
-#: src/screens/Takendown.tsx:165
-#: src/screens/Takendown.tsx:173
+#: src/screens/Takendown.tsx:160
+#: src/screens/Takendown.tsx:168
 msgid "Reason for appeal"
 msgstr ""
 
@@ -7421,7 +7507,7 @@ msgstr ""
 #: src/components/StarterPack/Wizard/WizardListCard.tsx:105
 #: src/components/StarterPack/Wizard/WizardListCard.tsx:112
 #: src/screens/Bookmarks/index.tsx:266
-#: src/screens/Settings/Settings.tsx:684
+#: src/screens/Settings/Settings.tsx:719
 #: src/view/com/modals/UserAddRemoveLists.tsx:235
 #: src/view/com/posts/PostFeedErrorMessage.tsx:220
 msgid "Remove"
@@ -7435,8 +7521,8 @@ msgstr ""
 msgid "Remove {historyItem}"
 msgstr ""
 
-#: src/screens/Settings/Settings.tsx:663
-#: src/screens/Settings/Settings.tsx:666
+#: src/screens/Settings/Settings.tsx:698
+#: src/screens/Settings/Settings.tsx:701
 msgid "Remove account"
 msgstr ""
 
@@ -7481,7 +7567,7 @@ msgstr ""
 msgid "Remove from my feeds"
 msgstr ""
 
-#: src/screens/Settings/Settings.tsx:676
+#: src/screens/Settings/Settings.tsx:711
 msgid "Remove from quick access?"
 msgstr ""
 
@@ -7521,7 +7607,7 @@ msgstr ""
 msgid "Remove repost"
 msgstr ""
 
-#: src/view/com/composer/videos/SubtitleDialog.tsx:261
+#: src/view/com/composer/videos/SubtitleDialog.tsx:278
 msgid "Remove subtitle file"
 msgstr ""
 
@@ -7616,6 +7702,7 @@ msgstr ""
 #: src/screens/Settings/NotificationSettings/ActivityNotificationSettings.tsx:218
 #: src/screens/Settings/NotificationSettings/index.tsx:148
 #: src/screens/Settings/NotificationSettings/ReplyNotificationSettings.tsx:41
+#: src/screens/Settings/settingsSearchConfig.ts:90
 #: src/view/screens/Profile.tsx:235
 msgid "Replies"
 msgstr ""
@@ -7648,7 +7735,7 @@ msgstr ""
 msgid "Reply Hidden by You"
 msgstr ""
 
-#: src/Navigation.tsx:439
+#: src/Navigation.tsx:438
 msgid "Reply notifications"
 msgstr ""
 
@@ -7688,8 +7775,8 @@ msgstr ""
 msgid "Report conversation"
 msgstr ""
 
-#: src/components/moderation/ReportDialog/index.tsx:79
-#: src/components/moderation/ReportDialog/index.tsx:240
+#: src/components/moderation/ReportDialog/index.tsx:78
+#: src/components/moderation/ReportDialog/index.tsx:239
 msgid "Report dialog"
 msgstr ""
 
@@ -7763,7 +7850,7 @@ msgstr ""
 msgid "Repost ({0, plural, one {# repost} other {# reposts}})"
 msgstr ""
 
-#: src/Navigation.tsx:471
+#: src/Navigation.tsx:470
 msgid "Repost notifications"
 msgstr ""
 
@@ -7791,6 +7878,7 @@ msgstr ""
 #: src/lib/hooks/useNotificationHandler.ts:133
 #: src/screens/Settings/NotificationSettings/index.tsx:181
 #: src/screens/Settings/NotificationSettings/RepostNotificationSettings.tsx:41
+#: src/screens/Settings/settingsSearchConfig.ts:93
 msgid "Reposts"
 msgstr ""
 
@@ -7801,10 +7889,11 @@ msgstr ""
 #: src/lib/hooks/useNotificationHandler.ts:175
 #: src/screens/Settings/NotificationSettings/index.tsx:222
 #: src/screens/Settings/NotificationSettings/RepostsOnRepostsNotificationSettings.tsx:41
+#: src/screens/Settings/settingsSearchConfig.ts:96
 msgid "Reposts of your reposts"
 msgstr ""
 
-#: src/Navigation.tsx:495
+#: src/Navigation.tsx:494
 msgid "Reposts of your reposts notifications"
 msgstr ""
 
@@ -7815,6 +7904,7 @@ msgstr ""
 
 #: src/screens/Settings/AccessibilitySettings.tsx:58
 #: src/screens/Settings/AccessibilitySettings.tsx:63
+#: src/screens/Settings/settingsSearchConfig.ts:146
 msgid "Require alt text before posting"
 msgstr ""
 
@@ -7856,8 +7946,8 @@ msgstr ""
 msgid "Resend Verification Email"
 msgstr ""
 
-#: src/screens/Settings/Settings.tsx:500
-#: src/screens/Settings/Settings.tsx:502
+#: src/screens/Settings/Settings.tsx:535
+#: src/screens/Settings/Settings.tsx:537
 msgid "Reset activity subscription nudge"
 msgstr ""
 
@@ -7865,8 +7955,8 @@ msgstr ""
 msgid "Reset code"
 msgstr ""
 
-#: src/screens/Settings/Settings.tsx:485
-#: src/screens/Settings/Settings.tsx:487
+#: src/screens/Settings/Settings.tsx:520
+#: src/screens/Settings/Settings.tsx:522
 msgid "Reset onboarding state"
 msgstr ""
 
@@ -7893,7 +7983,7 @@ msgstr ""
 #: src/components/dms/MessageItem.tsx:322
 #: src/components/Error.tsx:65
 #: src/components/Lists.tsx:114
-#: src/components/moderation/ReportDialog/index.tsx:274
+#: src/components/moderation/ReportDialog/index.tsx:273
 #: src/components/Post/Embed/VideoEmbed/VideoEmbedInner/VideoFallback.tsx:55
 #: src/components/Post/Embed/VideoEmbed/VideoEmbedInner/VideoFallback.tsx:58
 #: src/components/StarterPack/ProfileStarterPacks.tsx:374
@@ -7915,7 +8005,7 @@ msgstr ""
 msgid "Retry"
 msgstr ""
 
-#: src/components/moderation/ReportDialog/index.tsx:271
+#: src/components/moderation/ReportDialog/index.tsx:270
 #: src/view/screens/Storybook/Admonitions.tsx:60
 msgid "Retry loading report options"
 msgstr ""
@@ -8013,7 +8103,7 @@ msgid "Saved Feeds"
 msgstr ""
 
 #: src/components/dialogs/nuxs/BookmarksAnnouncement.tsx:143
-#: src/Navigation.tsx:619
+#: src/Navigation.tsx:618
 #: src/screens/Bookmarks/index.tsx:60
 msgid "Saved Posts"
 msgstr ""
@@ -8059,12 +8149,12 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: src/Navigation.tsx:260
+#: src/Navigation.tsx:259
 #: src/screens/Profile/ProfileSearch.tsx:37
 msgid "Search @{0}'s posts"
 msgstr ""
 
-#: src/components/ProgressGuide/FollowDialog.tsx:656
+#: src/components/ProgressGuide/FollowDialog.tsx:657
 msgid "Search by name or interest"
 msgstr ""
 
@@ -8134,8 +8224,13 @@ msgid "Search posts"
 msgstr ""
 
 #: src/components/dialogs/SearchablePeopleList.tsx:534
-#: src/components/ProgressGuide/FollowDialog.tsx:675
+#: src/components/ProgressGuide/FollowDialog.tsx:676
 msgid "Search profiles"
+msgstr ""
+
+#: src/screens/Settings/Settings.tsx:144
+#: src/screens/Settings/Settings.tsx:145
+msgid "Search settings"
 msgstr ""
 
 #: src/components/dialogs/GifSelect.tsx:168
@@ -8147,7 +8242,7 @@ msgid "Search..."
 msgstr ""
 
 #: src/components/dialogs/SearchablePeopleList.tsx:535
-#: src/components/ProgressGuide/FollowDialog.tsx:676
+#: src/components/ProgressGuide/FollowDialog.tsx:677
 msgid "Searches for profiles"
 msgstr ""
 
@@ -8215,7 +8310,7 @@ msgstr ""
 msgid "Select a color"
 msgstr ""
 
-#: src/components/moderation/ReportDialog/index.tsx:359
+#: src/components/moderation/ReportDialog/index.tsx:358
 msgid "Select a reason"
 msgstr ""
 
@@ -8281,7 +8376,7 @@ msgstr ""
 msgid "Select language"
 msgstr ""
 
-#: src/view/com/composer/videos/SubtitleDialog.tsx:248
+#: src/view/com/composer/videos/SubtitleDialog.tsx:265
 msgid "Select language..."
 msgstr ""
 
@@ -8290,7 +8385,7 @@ msgstr ""
 msgid "Select languages"
 msgstr ""
 
-#: src/components/moderation/ReportDialog/index.tsx:409
+#: src/components/moderation/ReportDialog/index.tsx:408
 msgid "Select moderation service"
 msgstr ""
 
@@ -8394,7 +8489,7 @@ msgstr ""
 msgid "Send post to..."
 msgstr ""
 
-#: src/components/moderation/ReportDialog/index.tsx:800
+#: src/components/moderation/ReportDialog/index.tsx:799
 msgid "Send report to {title}"
 msgstr ""
 
@@ -8455,8 +8550,8 @@ msgstr ""
 msgid "Sets email for password reset"
 msgstr ""
 
-#: src/Navigation.tsx:216
-#: src/screens/Settings/Settings.tsx:105
+#: src/Navigation.tsx:215
+#: src/screens/Settings/Settings.tsx:117
 #: src/view/shell/desktop/LeftNav.tsx:805
 #: src/view/shell/Drawer.tsx:609
 msgid "Settings"
@@ -8600,7 +8695,7 @@ msgstr ""
 msgid "Share your favorite feed!"
 msgstr ""
 
-#: src/Navigation.tsx:319
+#: src/Navigation.tsx:318
 msgid "Shared Preferences Tester"
 msgstr ""
 
@@ -8706,7 +8801,7 @@ msgstr ""
 msgid "Shows information about when this post was created"
 msgstr ""
 
-#: src/screens/Settings/Settings.tsx:131
+#: src/screens/Settings/Settings.tsx:164
 msgid "Shows other accounts you can switch to"
 msgstr ""
 
@@ -8767,23 +8862,23 @@ msgstr ""
 msgid "Sign in to view post"
 msgstr ""
 
-#: src/screens/Settings/Settings.tsx:272
-#: src/screens/Settings/Settings.tsx:274
-#: src/screens/Settings/Settings.tsx:306
+#: src/screens/Settings/Settings.tsx:305
+#: src/screens/Settings/Settings.tsx:307
+#: src/screens/Settings/Settings.tsx:341
 #: src/screens/SignupQueued.tsx:93
 #: src/screens/SignupQueued.tsx:96
-#: src/screens/Takendown.tsx:93
+#: src/screens/Takendown.tsx:88
 #: src/view/shell/desktop/LeftNav.tsx:212
 #: src/view/shell/desktop/LeftNav.tsx:269
 #: src/view/shell/desktop/LeftNav.tsx:272
 msgid "Sign out"
 msgstr ""
 
-#: src/screens/Takendown.tsx:96
+#: src/screens/Takendown.tsx:91
 msgid "Sign Out"
 msgstr ""
 
-#: src/screens/Settings/Settings.tsx:303
+#: src/screens/Settings/Settings.tsx:338
 #: src/view/shell/desktop/LeftNav.tsx:209
 msgid "Sign out?"
 msgstr ""
@@ -8865,7 +8960,7 @@ msgstr ""
 msgid "Someone reacted {0} to {1}"
 msgstr ""
 
-#: src/components/moderation/ReportDialog/index.tsx:84
+#: src/components/moderation/ReportDialog/index.tsx:83
 msgid "Something wasn't quite right with the data you're trying to report. Please contact support."
 msgstr ""
 
@@ -8874,7 +8969,7 @@ msgid "Something went wrong"
 msgstr ""
 
 #: src/components/ageAssurance/AgeAssuranceInitDialog.tsx:138
-#: src/components/moderation/ReportDialog/index.tsx:266
+#: src/components/moderation/ReportDialog/index.tsx:265
 #: src/screens/Deactivated.tsx:85
 #: src/screens/Settings/components/DeactivateAccountDialog.tsx:59
 #: src/view/screens/Storybook/Admonitions.tsx:55
@@ -8894,7 +8989,7 @@ msgstr ""
 msgid "Something went wrong. Please try again in a moment."
 msgstr ""
 
-#: src/components/moderation/ReportDialog/index.tsx:220
+#: src/components/moderation/ReportDialog/index.tsx:219
 msgid "Something went wrong. Please try again."
 msgstr ""
 
@@ -8963,8 +9058,8 @@ msgstr ""
 msgid "Start chat with {displayName}"
 msgstr ""
 
-#: src/Navigation.tsx:590
-#: src/Navigation.tsx:595
+#: src/Navigation.tsx:589
+#: src/Navigation.tsx:594
 #: src/screens/StarterPack/Wizard/index.tsx:209
 msgid "Starter Pack"
 msgstr ""
@@ -9001,6 +9096,7 @@ msgstr ""
 
 #: src/screens/Settings/AboutSettings.tsx:100
 #: src/screens/Settings/AboutSettings.tsx:103
+#: src/screens/Settings/settingsSearchConfig.ts:178
 msgid "Status Page"
 msgstr ""
 
@@ -9009,7 +9105,7 @@ msgstr ""
 msgid "Step {0} of {1}"
 msgstr ""
 
-#: src/screens/Settings/Settings.tsx:411
+#: src/screens/Settings/Settings.tsx:446
 msgid "Storage cleared, you need to restart the app now."
 msgstr ""
 
@@ -9017,8 +9113,8 @@ msgstr ""
 msgid "Stored as part of a secure code for matching with others"
 msgstr ""
 
-#: src/Navigation.tsx:309
-#: src/screens/Settings/Settings.tsx:466
+#: src/Navigation.tsx:308
+#: src/screens/Settings/Settings.tsx:501
 msgid "Storybook"
 msgstr ""
 
@@ -9031,17 +9127,17 @@ msgstr ""
 msgid "Submit"
 msgstr ""
 
-#: src/screens/Takendown.tsx:78
+#: src/screens/Takendown.tsx:76
 msgid "Submit appeal"
 msgstr ""
 
-#: src/screens/Takendown.tsx:84
+#: src/screens/Takendown.tsx:80
 msgid "Submit Appeal"
 msgstr ""
 
-#: src/components/moderation/ReportDialog/index.tsx:487
-#: src/components/moderation/ReportDialog/index.tsx:548
-#: src/components/moderation/ReportDialog/index.tsx:555
+#: src/components/moderation/ReportDialog/index.tsx:486
+#: src/components/moderation/ReportDialog/index.tsx:547
+#: src/components/moderation/ReportDialog/index.tsx:554
 msgid "Submit report"
 msgstr ""
 
@@ -9108,7 +9204,8 @@ msgctxt "Name of app icon variant"
 msgid "Sunset"
 msgstr ""
 
-#: src/Navigation.tsx:329
+#: src/Navigation.tsx:328
+#: src/screens/Settings/settingsSearchConfig.ts:168
 #: src/view/screens/Support.tsx:34
 #: src/view/screens/Support.tsx:37
 msgid "Support"
@@ -9118,9 +9215,9 @@ msgstr ""
 msgid "Support for this feature in your country has not been enabled yet! Please check back later."
 msgstr ""
 
-#: src/screens/Settings/Settings.tsx:129
-#: src/screens/Settings/Settings.tsx:143
-#: src/screens/Settings/Settings.tsx:624
+#: src/screens/Settings/Settings.tsx:162
+#: src/screens/Settings/Settings.tsx:176
+#: src/screens/Settings/Settings.tsx:659
 #: src/view/shell/desktop/LeftNav.tsx:247
 msgid "Switch account"
 msgstr ""
@@ -9148,7 +9245,8 @@ msgstr ""
 #: src/screens/Log.tsx:58
 #: src/screens/Settings/AboutSettings.tsx:107
 #: src/screens/Settings/AboutSettings.tsx:110
-#: src/screens/Settings/Settings.tsx:459
+#: src/screens/Settings/Settings.tsx:494
+#: src/screens/Settings/settingsSearchConfig.ts:179
 msgid "System log"
 msgstr ""
 
@@ -9222,9 +9320,10 @@ msgstr ""
 #: src/components/dialogs/BirthDateSettings.tsx:182
 #: src/components/PolicyUpdateOverlay/updates/202508/index.tsx:30
 #: src/components/PolicyUpdateOverlay/updates/202508/index.tsx:97
-#: src/Navigation.tsx:339
+#: src/Navigation.tsx:338
 #: src/screens/Settings/AboutSettings.tsx:84
 #: src/screens/Settings/AboutSettings.tsx:87
+#: src/screens/Settings/settingsSearchConfig.ts:176
 #: src/view/screens/TermsOfService.tsx:34
 #: src/view/shell/Drawer.tsx:697
 #: src/view/shell/Drawer.tsx:699
@@ -9749,7 +9848,7 @@ msgstr ""
 msgid "This will delete \"{0}\" from your muted words. You can always add it back later."
 msgstr ""
 
-#: src/screens/Settings/Settings.tsx:678
+#: src/screens/Settings/Settings.tsx:713
 msgid "This will remove @{0} from the quick access list."
 msgstr ""
 
@@ -9764,6 +9863,7 @@ msgstr ""
 
 #: src/screens/Settings/ContentAndMediaSettings.tsx:68
 #: src/screens/Settings/ContentAndMediaSettings.tsx:71
+#: src/screens/Settings/settingsSearchConfig.ts:106
 msgid "Thread preferences"
 msgstr ""
 
@@ -9776,7 +9876,7 @@ msgstr ""
 msgid "Threaded"
 msgstr ""
 
-#: src/Navigation.tsx:372
+#: src/Navigation.tsx:371
 msgid "Threads Preferences"
 msgstr ""
 
@@ -9842,7 +9942,7 @@ msgstr ""
 msgid "Top replies first"
 msgstr ""
 
-#: src/Navigation.tsx:555
+#: src/Navigation.tsx:554
 msgid "Topic"
 msgstr ""
 
@@ -9890,6 +9990,10 @@ msgstr ""
 msgid "TV"
 msgstr ""
 
+#: src/screens/Settings/settingsSearchConfig.ts:58
+msgid "Two-factor authentication"
+msgstr ""
+
 #: src/screens/Settings/PrivacyAndSecuritySettings.tsx:64
 msgid "Two-factor authentication (2FA)"
 msgstr ""
@@ -9928,11 +10032,11 @@ msgstr ""
 msgid "Unable to delete"
 msgstr ""
 
-#: src/screens/Settings/Settings.tsx:525
+#: src/screens/Settings/Settings.tsx:560
 msgid "Unapply Pull Request"
 msgstr ""
 
-#: src/screens/Settings/Settings.tsx:527
+#: src/screens/Settings/Settings.tsx:562
 msgid "Unapply Pull Request {currentChannel}"
 msgstr ""
 
@@ -10008,7 +10112,7 @@ msgstr ""
 msgid "Unfollows the user"
 msgstr ""
 
-#: src/components/moderation/ReportDialog/index.tsx:471
+#: src/components/moderation/ReportDialog/index.tsx:470
 msgid "Unfortunately, none of your subscribed labelers supports this report type."
 msgstr ""
 
@@ -10120,8 +10224,8 @@ msgstr ""
 msgid "Unpinned list"
 msgstr ""
 
-#: src/screens/Settings/Settings.tsx:492
-#: src/screens/Settings/Settings.tsx:494
+#: src/screens/Settings/Settings.tsx:527
+#: src/screens/Settings/Settings.tsx:529
 msgid "Unsnooze email reminder"
 msgstr ""
 
@@ -10240,6 +10344,7 @@ msgstr ""
 
 #: src/screens/Settings/ContentAndMediaSettings.tsx:102
 #: src/screens/Settings/ContentAndMediaSettings.tsx:108
+#: src/screens/Settings/settingsSearchConfig.ts:110
 msgid "Use in-app browser to open links"
 msgstr ""
 
@@ -10346,10 +10451,11 @@ msgid "Verification failed, please try again."
 msgstr ""
 
 #: src/screens/Moderation/index.tsx:326
+#: src/screens/Settings/settingsSearchConfig.ts:76
 msgid "Verification settings"
 msgstr ""
 
-#: src/Navigation.tsx:209
+#: src/Navigation.tsx:208
 #: src/screens/Moderation/VerificationSettings.tsx:32
 msgid "Verification Settings"
 msgstr ""
@@ -10424,6 +10530,7 @@ msgstr ""
 #: src/components/dialogs/EmailDialog/screens/Verify.tsx:211
 #: src/screens/Settings/AccountSettings.tsx:81
 #: src/screens/Settings/AccountSettings.tsx:101
+#: src/screens/Settings/settingsSearchConfig.ts:43
 msgid "Verify your email"
 msgstr ""
 
@@ -10441,6 +10548,10 @@ msgstr ""
 msgid "Verifying..."
 msgstr ""
 
+#: src/screens/Settings/settingsSearchConfig.ts:181
+msgid "Version"
+msgstr ""
+
 #: src/screens/Settings/AboutSettings.tsx:126
 #: src/screens/Settings/AboutSettings.tsx:155
 msgid "Version {0}"
@@ -10455,7 +10566,7 @@ msgstr ""
 msgid "Video failed to process"
 msgstr ""
 
-#: src/Navigation.tsx:611
+#: src/Navigation.tsx:610
 msgid "Video Feed"
 msgstr ""
 
@@ -10480,7 +10591,7 @@ msgstr ""
 msgid "Video not found."
 msgstr ""
 
-#: src/view/com/composer/videos/SubtitleDialog.tsx:98
+#: src/view/com/composer/videos/SubtitleDialog.tsx:102
 msgid "Video settings"
 msgstr ""
 
@@ -10902,7 +11013,7 @@ msgstr ""
 msgid "Whoops! Trending videos failed to load."
 msgstr ""
 
-#: src/screens/Takendown.tsx:176
+#: src/screens/Takendown.tsx:171
 msgid "Why are you appealing?"
 msgstr ""
 
@@ -11298,7 +11409,7 @@ msgstr ""
 msgid "You previously deactivated @{0}."
 msgstr ""
 
-#: src/screens/Settings/Settings.tsx:422
+#: src/screens/Settings/Settings.tsx:457
 msgid "You probably want to restart the app now."
 msgstr ""
 
@@ -11315,7 +11426,7 @@ msgstr ""
 msgid "You recently changed your birthdate"
 msgstr ""
 
-#: src/screens/Settings/Settings.tsx:304
+#: src/screens/Settings/Settings.tsx:339
 #: src/view/shell/desktop/LeftNav.tsx:210
 msgid "You will be signed out of all your accounts."
 msgstr ""
@@ -11438,7 +11549,7 @@ msgstr ""
 msgid "Your account has been deleted"
 msgstr ""
 
-#: src/screens/Takendown.tsx:149
+#: src/screens/Takendown.tsx:144
 msgid "Your account has been suspended"
 msgstr ""
 
@@ -11450,11 +11561,11 @@ msgstr ""
 msgid "Your account repository, containing all public data records, can be downloaded as a \"CAR\" file. This file does not include media embeds, such as images, or your private data, which must be fetched separately."
 msgstr ""
 
-#: src/screens/Takendown.tsx:217
+#: src/screens/Takendown.tsx:212
 msgid "Your account was found to be in violation of the <0>Bluesky Social Terms of Service</0>. You have been sent an email outlining the specific violation and suspension period, if applicable. You can appeal this decision if you believe it was made in error."
 msgstr ""
 
-#: src/screens/Takendown.tsx:157
+#: src/screens/Takendown.tsx:152
 msgid "Your appeal has been submitted. If your appeal succeeds, you will receive an email."
 msgstr ""
 
@@ -11527,11 +11638,12 @@ msgstr ""
 msgid "Your full handle will be <0>@{0}</0>"
 msgstr ""
 
-#: src/Navigation.tsx:527
+#: src/Navigation.tsx:526
 #: src/screens/Search/modules/ExploreInterestsCard.tsx:67
 #: src/screens/Settings/ContentAndMediaSettings.tsx:92
 #: src/screens/Settings/ContentAndMediaSettings.tsx:95
 #: src/screens/Settings/InterestsSettings.tsx:46
+#: src/screens/Settings/settingsSearchConfig.ts:109
 msgid "Your interests"
 msgstr ""
 
@@ -11589,7 +11701,7 @@ msgstr ""
 msgid "Your reply was sent"
 msgstr ""
 
-#: src/components/moderation/ReportDialog/index.tsx:498
+#: src/components/moderation/ReportDialog/index.tsx:497
 msgid "Your report will be sent to <0>{0}</0>."
 msgstr ""
 

--- a/src/screens/Settings/components/SettingsSearchEmpty.tsx
+++ b/src/screens/Settings/components/SettingsSearchEmpty.tsx
@@ -1,0 +1,23 @@
+import {View} from 'react-native'
+import {msg} from '@lingui/macro'
+import {useLingui} from '@lingui/react'
+
+import {atoms as a, useTheme} from '#/alf'
+import {MagnifyingGlass_Stroke2_Corner0_Rounded as SearchIcon} from '#/components/icons/MagnifyingGlass'
+import {Text} from '#/components/Typography'
+
+export function SettingsSearchEmpty({query}: {query: string}) {
+  const t = useTheme()
+  const {_} = useLingui()
+
+  return (
+    <View style={[a.py_xl, a.px_xl, a.align_center, a.gap_sm]}>
+      <SearchIcon size="lg" style={[t.atoms.text_contrast_low]} />
+      <Text
+        style={[a.text_md, t.atoms.text_contrast_medium, a.text_center]}
+        numberOfLines={2}>
+        {_(msg`No settings found for "${query}"`)}
+      </Text>
+    </View>
+  )
+}

--- a/src/screens/Settings/components/SettingsSearchResultItem.tsx
+++ b/src/screens/Settings/components/SettingsSearchResultItem.tsx
@@ -1,0 +1,51 @@
+import {View} from 'react-native'
+import {Linking} from 'react-native'
+import {msg} from '@lingui/macro'
+import {useLingui} from '@lingui/react'
+
+import * as SettingsList from '#/screens/Settings/components/SettingsList'
+import {atoms as a, useTheme} from '#/alf'
+import {Text} from '#/components/Typography'
+import {type SettingsSearchResult} from '../useSettingsSearch'
+
+export function SettingsSearchResultItem({
+  item,
+  matchedKeywords,
+}: SettingsSearchResult) {
+  const t = useTheme()
+  const {_} = useLingui()
+
+  const content = (
+    <>
+      <SettingsList.ItemIcon icon={item.icon} />
+      <View style={[a.flex_1, a.gap_2xs]}>
+        <SettingsList.ItemText>{_(item.titleKey)}</SettingsList.ItemText>
+        {matchedKeywords.length > 0 && (
+          <Text
+            style={[a.text_sm, a.leading_normal, t.atoms.text_contrast_medium]}
+            numberOfLines={2}>
+            {matchedKeywords.join(', ')}
+          </Text>
+        )}
+      </View>
+    </>
+  )
+
+  if (item.externalUrl) {
+    return (
+      <SettingsList.PressableItem
+        onPress={() => Linking.openURL(item.externalUrl!)}
+        label={_(item.titleKey)}
+        accessibilityHint={_(msg`Opens in browser`)}>
+        {content}
+        <SettingsList.Chevron />
+      </SettingsList.PressableItem>
+    )
+  }
+
+  return (
+    <SettingsList.LinkItem to={item.to!} label={_(item.titleKey)}>
+      {content}
+    </SettingsList.LinkItem>
+  )
+}

--- a/src/screens/Settings/settingsSearchConfig.ts
+++ b/src/screens/Settings/settingsSearchConfig.ts
@@ -1,0 +1,184 @@
+import {type MessageDescriptor} from '@lingui/core'
+import {msg} from '@lingui/macro'
+
+import {HELP_DESK_URL} from '#/lib/constants'
+import {type Gate} from '#/lib/statsig/gates'
+import {Accessibility_Stroke2_Corner2_Rounded as AccessibilityIcon} from '#/components/icons/Accessibility'
+import {Bell_Stroke2_Corner0_Rounded as NotificationIcon} from '#/components/icons/Bell'
+import {BubbleInfo_Stroke2_Corner2_Rounded as BubbleInfoIcon} from '#/components/icons/BubbleInfo'
+import {CircleQuestion_Stroke2_Corner2_Rounded as CircleQuestionIcon} from '#/components/icons/CircleQuestion'
+import {type Props as SVGIconProps} from '#/components/icons/common'
+import {Contacts_Stroke2_Corner2_Rounded as ContactsIcon} from '#/components/icons/Contacts'
+import {Earth_Stroke2_Corner2_Rounded as EarthIcon} from '#/components/icons/Globe'
+import {Lock_Stroke2_Corner2_Rounded as LockIcon} from '#/components/icons/Lock'
+import {PaintRoller_Stroke2_Corner2_Rounded as PaintRollerIcon} from '#/components/icons/PaintRoller'
+import {Person_Stroke2_Corner2_Rounded as PersonIcon} from '#/components/icons/Person'
+import {RaisingHand4Finger_Stroke2_Corner2_Rounded as HandIcon} from '#/components/icons/RaisingHand'
+import {Window_Stroke2_Corner2_Rounded as WindowIcon} from '#/components/icons/Window'
+
+export type SettingsSearchContext = {
+  isNative: boolean
+  findContactsEnabled: boolean
+  gate: (name: Gate) => boolean
+}
+
+export type SettingsSearchItem = {
+  id: string
+  titleKey: MessageDescriptor
+  icon: React.ComponentType<SVGIconProps>
+  to?: string
+  externalUrl?: string
+  keywords?: MessageDescriptor[]
+  condition?: (ctx: SettingsSearchContext) => boolean
+}
+
+export const SETTINGS_SEARCH_ITEMS: SettingsSearchItem[] = [
+  {
+    id: 'account',
+    titleKey: msg`Account`,
+    icon: PersonIcon,
+    to: '/settings/account',
+    keywords: [
+      msg`Email`,
+      msg`Verify your email`,
+      msg`Password`,
+      msg`Handle`,
+      msg`Birthday`,
+      msg`Export my data`,
+      msg`Deactivate account`,
+      msg`Delete account`,
+    ],
+  },
+  {
+    id: 'privacy-and-security',
+    titleKey: msg`Privacy and security`,
+    icon: LockIcon,
+    to: '/settings/privacy-and-security',
+    keywords: [
+      msg`Two-factor authentication`,
+      msg`Email 2FA`,
+      msg`App passwords`,
+      msg`Allow others to be notified of your posts`,
+      msg`Logged-out visibility`,
+    ],
+  },
+  {
+    id: 'moderation',
+    titleKey: msg`Moderation`,
+    icon: HandIcon,
+    to: '/moderation',
+    keywords: [
+      msg`Interaction settings`,
+      msg`Muted words & tags`,
+      msg`Moderation lists`,
+      msg`Muted accounts`,
+      msg`Blocked accounts`,
+      msg`Verification settings`,
+      msg`Content filters`,
+      msg`Enable adult content`,
+    ],
+  },
+  {
+    id: 'notifications',
+    titleKey: msg`Notifications`,
+    icon: NotificationIcon,
+    to: '/settings/notifications',
+    keywords: [
+      msg`Enable push notifications`,
+      msg`Likes`,
+      msg`New followers`,
+      msg`Replies`,
+      msg`Mentions`,
+      msg`Quotes`,
+      msg`Reposts`,
+      msg`Activity from others`,
+      msg`Likes of your reposts`,
+      msg`Reposts of your reposts`,
+    ],
+  },
+  {
+    id: 'content-and-media',
+    titleKey: msg`Content and media`,
+    icon: WindowIcon,
+    to: '/settings/content-and-media',
+    keywords: [
+      msg`Manage saved feeds`,
+      msg`Thread preferences`,
+      msg`Following feed preferences`,
+      msg`External media`,
+      msg`Your interests`,
+      msg`Use in-app browser to open links`,
+      msg`Autoplay videos and GIFs`,
+      msg`Enable trending topics`,
+      msg`Enable trending videos`,
+    ],
+  },
+  {
+    id: 'find-contacts',
+    titleKey: msg`Find friends from contacts`,
+    icon: ContactsIcon,
+    to: '/settings/find-contacts',
+    keywords: [msg`Phone contacts`, msg`Find friends`],
+    condition: ctx =>
+      ctx.isNative &&
+      ctx.findContactsEnabled &&
+      !ctx.gate('disable_settings_find_contacts'),
+  },
+  {
+    id: 'appearance',
+    titleKey: msg`Appearance`,
+    icon: PaintRollerIcon,
+    to: '/settings/appearance',
+    keywords: [
+      msg`Color mode`,
+      msg`Dark theme`,
+      msg`Font`,
+      msg`Font size`,
+    ],
+  },
+  {
+    id: 'accessibility',
+    titleKey: msg`Accessibility`,
+    icon: AccessibilityIcon,
+    to: '/settings/accessibility',
+    keywords: [
+      msg`Alt text`,
+      msg`Require alt text before posting`,
+      msg`Display larger alt text badges`,
+      msg`Haptics`,
+      msg`Disable haptic feedback`,
+    ],
+  },
+  {
+    id: 'language',
+    titleKey: msg`Languages`,
+    icon: EarthIcon,
+    to: '/settings/language',
+    keywords: [
+      msg`App Language`,
+      msg`Primary Language`,
+      msg`Content Languages`,
+    ],
+  },
+  {
+    id: 'help',
+    titleKey: msg`Help`,
+    icon: CircleQuestionIcon,
+    externalUrl: HELP_DESK_URL,
+    keywords: [msg`Support`, msg`FAQ`, msg`Contact us`],
+  },
+  {
+    id: 'about',
+    titleKey: msg`About`,
+    icon: BubbleInfoIcon,
+    to: '/settings/about',
+    keywords: [
+      msg`Terms of Service`,
+      msg`Privacy Policy`,
+      msg`Status Page`,
+      msg`System log`,
+      msg`Clear image cache`,
+      msg`Version`,
+    ],
+  },
+]

--- a/src/screens/Settings/useSettingsSearch.ts
+++ b/src/screens/Settings/useSettingsSearch.ts
@@ -1,0 +1,72 @@
+import {useMemo, useState} from 'react'
+import {useLingui} from '@lingui/react'
+
+import {
+  SETTINGS_SEARCH_ITEMS,
+  type SettingsSearchContext,
+  type SettingsSearchItem,
+} from './settingsSearchConfig'
+
+export type SettingsSearchResult = {
+  item: SettingsSearchItem
+  matchedKeywords: string[] // Keywords that matched (empty if title matched)
+}
+
+export function useSettingsSearch(ctx: SettingsSearchContext) {
+  const {_} = useLingui()
+  const [query, setQuery] = useState('')
+
+  const filteredItems = useMemo((): SettingsSearchResult[] => {
+    // Filter by visibility conditions first
+    const visibleItems = SETTINGS_SEARCH_ITEMS.filter(
+      item => !item.condition || item.condition(ctx),
+    )
+
+    // If no search query or only 1 character, return all visible items with no matched keywords
+    const trimmedQuery = query.trim()
+    if (trimmedQuery.length < 2) {
+      return visibleItems.map(item => ({item, matchedKeywords: []}))
+    }
+
+    const lowerQuery = trimmedQuery.toLowerCase()
+    const results: SettingsSearchResult[] = []
+
+    for (const item of visibleItems) {
+      // Check title first
+      const title = _(item.titleKey).toLowerCase()
+      if (title.includes(lowerQuery)) {
+        results.push({item, matchedKeywords: []})
+        continue
+      }
+
+      // Check keywords - collect ALL matching keywords
+      if (item.keywords) {
+        const matchedKeywords: string[] = []
+        for (const keyword of item.keywords) {
+          const keywordText = _(keyword)
+          if (keywordText.toLowerCase().includes(lowerQuery)) {
+            matchedKeywords.push(keywordText)
+          }
+        }
+        if (matchedKeywords.length > 0) {
+          results.push({item, matchedKeywords})
+        }
+      }
+    }
+
+    return results
+  }, [query, _, ctx])
+
+  const clearQuery = () => setQuery('')
+
+  return {
+    query,
+    setQuery,
+    clearQuery,
+    filteredItems,
+    isSearching: query.trim().length >= 2,
+    hasResults: filteredItems.length > 0,
+  }
+}
+
+export type {SettingsSearchItem}


### PR DESCRIPTION
Adds a search input to the Settings screen that filters settings in real-time, similar to X or iPhone settings. 

Users can search by setting title or keywords (actual UI labels from settings screens). Requires 2+ characters to trigger filtering. Shows matched keywords below results.

- Add settingsSearchConfig.ts with searchable settings categories
- Add useSettingsSearch hook for filtering logic
- Add SettingsSearchEmpty component for no-results state
- Add SettingsSearchResultItem component for search results
- Integrate search bar into Settings.tsx

One note on maintainability: This does require a static list of all the search items. It's a simpler implementation but if settings change, this would add overhead for a dev to update search.