### PR TITLE
fix: ensure `com.atproto.*` calls go through without proxying

### DIFF
--- a/src/ageAssurance/data.tsx
+++ b/src/ageAssurance/data.tsx
@@ -20,6 +20,7 @@ import {
   snoozeBirthdateUpdateAllowedForDid,
 } from '#/state/birthdate'
 import {useAgent, useSession} from '#/state/session'
+import {pdsAgent} from '#/state/session/agent'
 import * as debug from '#/ageAssurance/debug'
 import {logger} from '#/ageAssurance/logger'
 import {
@@ -323,7 +324,7 @@ export async function getOtherRequiredData({
   agent: AtpAgent
 }): Promise<OtherRequiredData> {
   if (debug.enabled) return debug.resolve(debug.otherRequiredData)
-  const [prefs] = await Promise.all([agent.getPreferences()])
+  const [prefs] = await Promise.all([pdsAgent(agent).getPreferences()])
   const data: OtherRequiredData = {
     birthdate: prefs.birthDate ? prefs.birthDate.toISOString() : undefined,
   }

--- a/src/ageAssurance/useBeginAgeAssurance.ts
+++ b/src/ageAssurance/useBeginAgeAssurance.ts
@@ -10,6 +10,7 @@ import {
 } from '#/lib/constants'
 import {isNetworkError} from '#/lib/hooks/useCleanError'
 import {useAgent} from '#/state/session'
+import {pdsAgent} from '#/state/session/agent'
 import {usePatchAgeAssuranceServerState} from '#/ageAssurance'
 import {logger} from '#/ageAssurance/logger'
 import {BLUESKY_PROXY_DID} from '#/env'
@@ -38,7 +39,7 @@ export function useBeginAgeAssurance() {
 
       const {
         data: {token},
-      } = await agent.com.atproto.server.getServiceAuth({
+      } = await pdsAgent(agent).com.atproto.server.getServiceAuth({
         aud: BLUESKY_PROXY_DID,
         lxm: `app.bsky.ageassurance.begin`,
       })

--- a/src/components/dialogs/EmailDialog/data/useConfirmEmail.ts
+++ b/src/components/dialogs/EmailDialog/data/useConfirmEmail.ts
@@ -1,6 +1,7 @@
 import {useMutation} from '@tanstack/react-query'
 
 import {useAgent, useSession} from '#/state/session'
+import {pdsAgent} from '#/state/session/agent'
 
 export function useConfirmEmail({
   onSuccess,
@@ -15,7 +16,7 @@ export function useConfirmEmail({
         throw new Error('No email found for the current account')
       }
 
-      await agent.com.atproto.server.confirmEmail({
+      await pdsAgent(agent).com.atproto.server.confirmEmail({
         email: currentAccount.email.trim(),
         token: token.trim(),
       })

--- a/src/components/dialogs/EmailDialog/data/useManageEmail2FA.ts
+++ b/src/components/dialogs/EmailDialog/data/useManageEmail2FA.ts
@@ -1,6 +1,7 @@
 import {useMutation} from '@tanstack/react-query'
 
 import {useAgent, useSession} from '#/state/session'
+import {pdsAgent} from '#/state/session/agent'
 
 export function useManageEmail2FA() {
   const agent = useAgent()
@@ -17,7 +18,7 @@ export function useManageEmail2FA() {
         throw new Error('No email found for the current account')
       }
 
-      await agent.com.atproto.server.updateEmail({
+      await pdsAgent(agent).com.atproto.server.updateEmail({
         email: currentAccount.email,
         emailAuthFactor: enabled,
         token,

--- a/src/components/dialogs/EmailDialog/data/useRequestEmailUpdate.ts
+++ b/src/components/dialogs/EmailDialog/data/useRequestEmailUpdate.ts
@@ -1,13 +1,15 @@
 import {useMutation} from '@tanstack/react-query'
 
 import {useAgent} from '#/state/session'
+import {pdsAgent} from '#/state/session/agent'
 
 export function useRequestEmailUpdate() {
   const agent = useAgent()
 
   return useMutation({
     mutationFn: async () => {
-      return (await agent.com.atproto.server.requestEmailUpdate()).data
+      return (await pdsAgent(agent).com.atproto.server.requestEmailUpdate())
+        .data
     },
   })
 }

--- a/src/components/dialogs/EmailDialog/data/useRequestEmailVerification.ts
+++ b/src/components/dialogs/EmailDialog/data/useRequestEmailVerification.ts
@@ -1,13 +1,14 @@
 import {useMutation} from '@tanstack/react-query'
 
 import {useAgent} from '#/state/session'
+import {pdsAgent} from '#/state/session/agent'
 
 export function useRequestEmailVerification() {
   const agent = useAgent()
 
   return useMutation({
     mutationFn: async () => {
-      await agent.com.atproto.server.requestEmailConfirmation()
+      await pdsAgent(agent).com.atproto.server.requestEmailConfirmation()
     },
   })
 }

--- a/src/components/dialogs/EmailDialog/data/useUpdateEmail.ts
+++ b/src/components/dialogs/EmailDialog/data/useUpdateEmail.ts
@@ -1,6 +1,7 @@
 import {useMutation} from '@tanstack/react-query'
 
 import {useAgent} from '#/state/session'
+import {pdsAgent} from '#/state/session/agent'
 import {useRequestEmailUpdate} from '#/components/dialogs/EmailDialog/data/useRequestEmailUpdate'
 
 async function updateEmailAndRefreshSession(
@@ -8,7 +9,10 @@ async function updateEmailAndRefreshSession(
   email: string,
   token?: string,
 ) {
-  await agent.com.atproto.server.updateEmail({email: email.trim(), token})
+  await pdsAgent(agent).com.atproto.server.updateEmail({
+    email: email.trim(),
+    token,
+  })
   await agent.resumeSession(agent.session!)
 }
 

--- a/src/components/intents/VerifyEmailIntentDialog.tsx
+++ b/src/components/intents/VerifyEmailIntentDialog.tsx
@@ -5,6 +5,7 @@ import {useLingui} from '@lingui/react'
 
 import {isNative} from '#/platform/detection'
 import {useAgent, useSession} from '#/state/session'
+import {pdsAgent} from '#/state/session/agent'
 import {atoms as a, useBreakpoints, useTheme} from '#/alf'
 import {Button, ButtonIcon, ButtonText} from '#/components/Button'
 import * as Dialog from '#/components/Dialog'
@@ -51,7 +52,7 @@ function Inner({}: {control: DialogControlProps}) {
 
   const onPressResendEmail = async () => {
     setSending(true)
-    await agent.com.atproto.server.requestEmailConfirmation()
+    await pdsAgent(agent).com.atproto.server.requestEmailConfirmation()
     setSending(false)
     setStatus('resent')
   }

--- a/src/components/live/queries.ts
+++ b/src/components/live/queries.ts
@@ -16,6 +16,7 @@ import {logger} from '#/logger'
 import {updateProfileShadow} from '#/state/cache/profile-shadow'
 import {useLiveNowConfig} from '#/state/service-config'
 import {useAgent, useSession} from '#/state/session'
+import {pdsAgent} from '#/state/session/agent'
 import * as Toast from '#/view/com/util/Toast'
 import {useDialogContext} from '#/components/Dialog'
 
@@ -108,11 +109,11 @@ export function useUpsertLiveStatusMutation(
         const repo = currentAccount.did
         const collection = 'app.bsky.actor.status'
 
-        const existing = await agent.com.atproto.repo
-          .getRecord({repo, collection, rkey: 'self'})
+        const existing = await pdsAgent(agent)
+          .com.atproto.repo.getRecord({repo, collection, rkey: 'self'})
           .catch(_e => undefined)
 
-        await agent.com.atproto.repo.putRecord({
+        await pdsAgent(agent).com.atproto.repo.putRecord({
           repo,
           collection,
           rkey: 'self',

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -34,6 +34,7 @@ import {
   createThreadgateRecord,
   threadgateAllowUISettingToAllowRecordValue,
 } from '#/state/queries/threadgate'
+import {pdsAgent} from '#/state/session/agent'
 import {
   type EmbedDraft,
   type PostDraft,
@@ -172,7 +173,7 @@ export async function post(
   }
 
   try {
-    await agent.com.atproto.repo.applyWrites({
+    await pdsAgent(agent).com.atproto.repo.applyWrites({
       repo: agent.assertDid,
       writes: writes,
       validate: true,

--- a/src/lib/generate-starterpack.ts
+++ b/src/lib/generate-starterpack.ts
@@ -15,6 +15,7 @@ import {sanitizeDisplayName} from '#/lib/strings/display-names'
 import {sanitizeHandle} from '#/lib/strings/handles'
 import {enforceLen} from '#/lib/strings/helpers'
 import {useAgent} from '#/state/session'
+import {pdsAgent} from '#/state/session/agent'
 import type * as bsky from '#/types/bsky'
 
 export const createStarterPackList = async ({
@@ -44,7 +45,7 @@ export const createStarterPackList = async ({
     },
   )
   if (!list) throw new Error('List creation failed')
-  await agent.com.atproto.repo.applyWrites({
+  await pdsAgent(agent).com.atproto.repo.applyWrites({
     repo: agent.session!.did,
     writes: profiles.map(p => createListItem({did: p.did, listUri: list.uri})),
   })

--- a/src/lib/media/video/upload.shared.ts
+++ b/src/lib/media/video/upload.shared.ts
@@ -5,6 +5,7 @@ import {msg} from '@lingui/macro'
 import {VIDEO_SERVICE_DID} from '#/lib/constants'
 import {UploadLimitError} from '#/lib/media/video/errors'
 import {getServiceAuthAudFromUrl} from '#/lib/strings/url-helpers'
+import {pdsAgent} from '#/state/session/agent'
 import {createVideoAgent} from './util'
 
 export async function getServiceAuthToken({
@@ -22,7 +23,9 @@ export async function getServiceAuthToken({
   if (!pdsAud) {
     throw new Error('Agent does not have a PDS URL')
   }
-  const {data: serviceAuth} = await agent.com.atproto.server.getServiceAuth({
+  const {data: serviceAuth} = await pdsAgent(
+    agent,
+  ).com.atproto.server.getServiceAuth({
     aud: aud ?? pdsAud,
     lxm,
     exp,

--- a/src/screens/Deactivated.tsx
+++ b/src/screens/Deactivated.tsx
@@ -14,6 +14,7 @@ import {
   useSession,
   useSessionApi,
 } from '#/state/session'
+import {pdsAgent} from '#/state/session/agent'
 import {useLoggedOutViewControls} from '#/state/shell/logged-out'
 import {Logo} from '#/view/icons/Logo'
 import {atoms as a, useTheme} from '#/alf'
@@ -69,7 +70,7 @@ export function Deactivated() {
   const handleActivate = React.useCallback(async () => {
     try {
       setPending(true)
-      await agent.com.atproto.server.activateAccount()
+      await pdsAgent(agent).com.atproto.server.activateAccount()
       await queryClient.resetQueries()
       await agent.resumeSession(agent.session!)
     } catch (e: any) {

--- a/src/screens/Onboarding/util.ts
+++ b/src/screens/Onboarding/util.ts
@@ -9,6 +9,7 @@ import {TID} from '@atproto/common-web'
 import chunk from 'lodash.chunk'
 
 import {until} from '#/lib/async/until'
+import {pdsAgent} from '#/state/session/agent'
 
 export async function bulkWriteFollows(agent: BskyAgent, dids: string[]) {
   const session = agent.session
@@ -35,7 +36,7 @@ export async function bulkWriteFollows(agent: BskyAgent, dids: string[]) {
 
   const chunks = chunk(followWrites, 50)
   for (const chunk of chunks) {
-    await agent.com.atproto.repo.applyWrites({
+    await pdsAgent(agent).com.atproto.repo.applyWrites({
       repo: session.did,
       writes: chunk,
     })

--- a/src/screens/Settings/components/ChangePasswordDialog.tsx
+++ b/src/screens/Settings/components/ChangePasswordDialog.tsx
@@ -9,6 +9,7 @@ import {checkAndFormatResetCode} from '#/lib/strings/password'
 import {logger} from '#/logger'
 import {isNative} from '#/platform/detection'
 import {useAgent, useSession} from '#/state/session'
+import {pdsAgent} from '#/state/session/agent'
 import {ErrorMessage} from '#/view/com/util/error/ErrorMessage'
 import {android, atoms as a, web} from '#/alf'
 import {Button, ButtonIcon, ButtonText} from '#/components/Button'
@@ -84,7 +85,7 @@ function Inner() {
     setError('')
     setIsProcessing(true)
     try {
-      await agent.com.atproto.server.requestPasswordReset({
+      await pdsAgent(agent).com.atproto.server.requestPasswordReset({
         email: currentAccount.email,
       })
       setStage(Stages.ChangePassword)
@@ -128,7 +129,7 @@ function Inner() {
     setError('')
     setIsProcessing(true)
     try {
-      await agent.com.atproto.server.resetPassword({
+      await pdsAgent(agent).com.atproto.server.resetPassword({
         token: formattedCode,
         password: newPassword,
       })

--- a/src/screens/Settings/components/DeactivateAccountDialog.tsx
+++ b/src/screens/Settings/components/DeactivateAccountDialog.tsx
@@ -5,6 +5,7 @@ import {useLingui} from '@lingui/react'
 
 import {logger} from '#/logger'
 import {useAgent, useSessionApi} from '#/state/session'
+import {pdsAgent} from '#/state/session/agent'
 import {atoms as a, useBreakpoints, useTheme} from '#/alf'
 import {Button, ButtonIcon, ButtonText} from '#/components/Button'
 import {type DialogOuterProps} from '#/components/Dialog'
@@ -42,7 +43,7 @@ function DeactivateAccountDialogInner({
   const handleDeactivate = React.useCallback(async () => {
     try {
       setPending(true)
-      await agent.com.atproto.server.deactivateAccount({})
+      await pdsAgent(agent).com.atproto.server.deactivateAccount({})
       control.close(() => {
         logoutCurrentAccount('Deactivated')
       })

--- a/src/screens/Settings/components/DisableEmail2FADialog.tsx
+++ b/src/screens/Settings/components/DisableEmail2FADialog.tsx
@@ -6,6 +6,7 @@ import {useLingui} from '@lingui/react'
 import {cleanError} from '#/lib/strings/errors'
 import {isNative} from '#/platform/detection'
 import {useAgent, useSession} from '#/state/session'
+import {pdsAgent} from '#/state/session/agent'
 import {ErrorMessage} from '#/view/com/util/error/ErrorMessage'
 import * as Toast from '#/view/com/util/Toast'
 import {atoms as a, useBreakpoints, useTheme} from '#/alf'
@@ -41,7 +42,7 @@ export function DisableEmail2FADialog({
     setError('')
     setIsProcessing(true)
     try {
-      await agent.com.atproto.server.requestEmailUpdate()
+      await pdsAgent(agent).com.atproto.server.requestEmailUpdate()
       setStage(Stages.ConfirmCode)
     } catch (e) {
       setError(cleanError(String(e)))
@@ -55,7 +56,7 @@ export function DisableEmail2FADialog({
     setIsProcessing(true)
     try {
       if (currentAccount?.email) {
-        await agent.com.atproto.server.updateEmail({
+        await pdsAgent(agent).com.atproto.server.updateEmail({
           email: currentAccount!.email,
           token: confirmationCode.trim(),
           emailAuthFactor: false,

--- a/src/screens/Settings/components/ExportCarDialog.tsx
+++ b/src/screens/Settings/components/ExportCarDialog.tsx
@@ -6,6 +6,7 @@ import {useLingui} from '@lingui/react'
 import {saveBytesToDisk} from '#/lib/media/manip'
 import {logger} from '#/logger'
 import {useAgent} from '#/state/session'
+import {pdsAgent} from '#/state/session/agent'
 import {atoms as a, useTheme, web} from '#/alf'
 import {Button, ButtonIcon, ButtonText} from '#/components/Button'
 import * as Dialog from '#/components/Dialog'
@@ -32,7 +33,7 @@ export function ExportCarDialog({
     try {
       setLoading(true)
       const did = agent.session.did
-      const downloadRes = await agent.com.atproto.sync.getRepo({did})
+      const downloadRes = await pdsAgent(agent).com.atproto.sync.getRepo({did})
       const saveRes = await saveBytesToDisk(
         'repo.car',
         downloadRes.data,

--- a/src/screens/SignupQueued.tsx
+++ b/src/screens/SignupQueued.tsx
@@ -8,6 +8,7 @@ import {useLingui} from '@lingui/react'
 import {logger} from '#/logger'
 import {isIOS, isWeb} from '#/platform/detection'
 import {isSignupQueued, useAgent, useSessionApi} from '#/state/session'
+import {pdsAgent} from '#/state/session/agent'
 import {useOnboardingDispatch} from '#/state/shell'
 import {Logo} from '#/view/icons/Logo'
 import {atoms as a, native, useBreakpoints, useTheme, web} from '#/alf'
@@ -37,7 +38,7 @@ export function SignupQueued() {
   const checkStatus = React.useCallback(async () => {
     setProcessing(true)
     try {
-      const res = await agent.com.atproto.temp.checkSignupQueue()
+      const res = await pdsAgent(agent).com.atproto.temp.checkSignupQueue()
       if (res.data.activated) {
         // ready to go, exchange the access token for a usable one and kick off onboarding
         await agent.sessionManager.refreshSession()

--- a/src/state/queries/app-passwords.ts
+++ b/src/state/queries/app-passwords.ts
@@ -3,6 +3,7 @@ import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query'
 
 import {STALE} from '#/state/queries'
 import {useAgent} from '../session'
+import {pdsAgent} from '../session/agent'
 
 const RQKEY_ROOT = 'app-passwords'
 export const RQKEY = () => [RQKEY_ROOT]
@@ -13,7 +14,7 @@ export function useAppPasswordsQuery() {
     staleTime: STALE.MINUTES.FIVE,
     queryKey: RQKEY(),
     queryFn: async () => {
-      const res = await agent.com.atproto.server.listAppPasswords({})
+      const res = await pdsAgent(agent).com.atproto.server.listAppPasswords({})
       return res.data.passwords
     },
   })
@@ -29,7 +30,7 @@ export function useAppPasswordCreateMutation() {
   >({
     mutationFn: async ({name, privileged}) => {
       return (
-        await agent.com.atproto.server.createAppPassword({
+        await pdsAgent(agent).com.atproto.server.createAppPassword({
           name,
           privileged,
         })
@@ -48,7 +49,7 @@ export function useAppPasswordDeleteMutation() {
   const agent = useAgent()
   return useMutation<void, Error, {name: string}>({
     mutationFn: async ({name}) => {
-      await agent.com.atproto.server.revokeAppPassword({
+      await pdsAgent(agent).com.atproto.server.revokeAppPassword({
         name,
       })
     },

--- a/src/state/queries/list.ts
+++ b/src/state/queries/list.ts
@@ -17,6 +17,7 @@ import {until} from '#/lib/async/until'
 import {type ImageMeta} from '#/state/gallery'
 import {STALE} from '#/state/queries'
 import {useAgent, useSession} from '#/state/session'
+import {pdsAgent} from '#/state/session/agent'
 import {invalidate as invalidateMyLists} from './my-lists'
 import {RQKEY as PROFILE_LISTS_RQKEY} from './profile-lists'
 
@@ -152,7 +153,7 @@ export function useListMetadataMutation() {
         record.avatar = undefined
       }
       const res = (
-        await agent.com.atproto.repo.putRecord({
+        await pdsAgent(agent).com.atproto.repo.putRecord({
           repo: currentAccount.did,
           collection: 'app.bsky.graph.list',
           rkey,
@@ -231,7 +232,7 @@ export function useListDeleteMutation() {
 
       // apply in chunks
       for (const writesChunk of chunk(writes, 10)) {
-        await agent.com.atproto.repo.applyWrites({
+        await pdsAgent(agent).com.atproto.repo.applyWrites({
           repo: currentAccount.did,
           writes: writesChunk,
         })

--- a/src/state/queries/messages/actor-declaration.ts
+++ b/src/state/queries/messages/actor-declaration.ts
@@ -3,6 +3,7 @@ import {useMutation, useQueryClient} from '@tanstack/react-query'
 
 import {logger} from '#/logger'
 import {useAgent, useSession} from '#/state/session'
+import {pdsAgent} from '#/state/session/agent'
 import {RQKEY as PROFILE_RKEY} from '../profile'
 
 export function useUpdateActorDeclaration({
@@ -19,7 +20,7 @@ export function useUpdateActorDeclaration({
   return useMutation({
     mutationFn: async (allowIncoming: 'all' | 'none' | 'following') => {
       if (!currentAccount) throw new Error('Not signed in')
-      const result = await agent.com.atproto.repo.putRecord({
+      const result = await pdsAgent(agent).com.atproto.repo.putRecord({
         repo: currentAccount.did,
         collection: 'chat.bsky.actor.declaration',
         rkey: 'self',
@@ -69,7 +70,7 @@ export function useDeleteActorDeclaration() {
   return useMutation({
     mutationFn: async () => {
       if (!currentAccount) throw new Error('Not signed in')
-      const result = await agent.api.com.atproto.repo.deleteRecord({
+      const result = await pdsAgent(agent).com.atproto.repo.deleteRecord({
         repo: currentAccount.did,
         collection: 'chat.bsky.actor.declaration',
         rkey: 'self',

--- a/src/state/queries/postgate/index.ts
+++ b/src/state/queries/postgate/index.ts
@@ -21,6 +21,7 @@ import {
   POSTGATE_COLLECTION,
 } from '#/state/queries/postgate/util'
 import {useAgent} from '#/state/session'
+import {pdsAgent} from '#/state/session/agent'
 import * as bsky from '#/types/bsky'
 
 export async function getPostgateRecord({
@@ -96,7 +97,7 @@ export async function writePostgateRecord({
   const postUrip = new AtUri(postUri)
 
   await networkRetry(2, () =>
-    agent.api.com.atproto.repo.putRecord({
+    pdsAgent(agent).com.atproto.repo.putRecord({
       repo: agent.session!.did,
       collection: POSTGATE_COLLECTION,
       rkey: postUrip.rkey,

--- a/src/state/queries/preferences/index.ts
+++ b/src/state/queries/preferences/index.ts
@@ -21,6 +21,7 @@ import {
   type UsePreferencesQueryResponse,
 } from '#/state/queries/preferences/types'
 import {useAgent} from '#/state/session'
+import {pdsAgent} from '#/state/session/agent'
 import {saveLabelers} from '#/state/session/agent-config'
 import {useAgeAssurance} from '#/ageAssurance'
 import {makeAgeRestrictedModerationPrefs} from '#/ageAssurance/util'
@@ -45,7 +46,7 @@ export function usePreferencesQuery() {
       if (!agent.did) {
         return DEFAULT_LOGGED_OUT_PREFERENCES
       } else {
-        const res = await agent.getPreferences()
+        const res = await pdsAgent(agent).getPreferences()
 
         // save to local storage to ensure there are labels on initial requests
         saveLabelers(
@@ -100,7 +101,7 @@ export function useClearPreferencesMutation() {
 
   return useMutation({
     mutationFn: async () => {
-      await agent.app.bsky.actor.putPreferences({preferences: []})
+      await pdsAgent(agent).app.bsky.actor.putPreferences({preferences: []})
       // triggers a refetch
       await queryClient.invalidateQueries({
         queryKey: preferencesQueryKey,

--- a/src/state/queries/starter-packs.ts
+++ b/src/state/queries/starter-packs.ts
@@ -27,6 +27,7 @@ import {invalidateActorStarterPacksQuery} from '#/state/queries/actor-starter-pa
 import {STALE} from '#/state/queries/index'
 import {invalidateListMembersQuery} from '#/state/queries/list-members'
 import {useAgent} from '#/state/session'
+import {pdsAgent} from '#/state/session/agent'
 import * as bsky from '#/types/bsky'
 
 const RQKEY_ROOT = 'starter-pack'
@@ -203,7 +204,7 @@ export function useEditStarterPackMutation({
       if (removedItems.length !== 0) {
         const chunks = chunk(removedItems, 50)
         for (const chunk of chunks) {
-          await agent.com.atproto.repo.applyWrites({
+          await pdsAgent(agent).com.atproto.repo.applyWrites({
             repo: agent.session!.did,
             writes: chunk.map(i => ({
               $type: 'com.atproto.repo.applyWrites#delete',
@@ -220,7 +221,7 @@ export function useEditStarterPackMutation({
       if (addedProfiles.length > 0) {
         const chunks = chunk(addedProfiles, 50)
         for (const chunk of chunks) {
-          await agent.com.atproto.repo.applyWrites({
+          await pdsAgent(agent).com.atproto.repo.applyWrites({
             repo: agent.session!.did,
             writes: chunk.map(p => ({
               $type: 'com.atproto.repo.applyWrites#create',
@@ -237,7 +238,7 @@ export function useEditStarterPackMutation({
       }
 
       const rkey = parseStarterPackUri(currentStarterPack.uri)!.rkey
-      await agent.com.atproto.repo.putRecord({
+      await pdsAgent(agent).com.atproto.repo.putRecord({
         repo: agent.session!.did,
         collection: 'app.bsky.graph.starterpack',
         rkey,

--- a/src/state/queries/threadgate/index.ts
+++ b/src/state/queries/threadgate/index.ts
@@ -18,6 +18,7 @@ import {
 } from '#/state/queries/threadgate/util'
 import {useUpdatePostThreadThreadgateQueryCache} from '#/state/queries/usePostThread'
 import {useAgent} from '#/state/session'
+import {pdsAgent} from '#/state/session/agent'
 import {useThreadgateHiddenReplyUrisAPI} from '#/state/threadgate-hidden-replies'
 import * as bsky from '#/types/bsky'
 
@@ -162,7 +163,7 @@ export async function writeThreadgateRecord({
   })
 
   await networkRetry(2, () =>
-    agent.api.com.atproto.repo.putRecord({
+    pdsAgent(agent).com.atproto.repo.putRecord({
       repo: agent.session!.did,
       collection: 'app.bsky.feed.threadgate',
       rkey: postUrip.rkey,

--- a/src/state/session/agent.ts
+++ b/src/state/session/agent.ts
@@ -234,7 +234,7 @@ export async function createAgentAndCreateAccount(
         }),
         getAge(birthDate) < 18 &&
           networkRetry(3, () => {
-            return agent.com.atproto.repo.putRecord({
+            return pdsAgent(agent).com.atproto.repo.putRecord({
               repo: account.did,
               collection: 'chat.bsky.actor.declaration',
               rkey: 'self',
@@ -437,6 +437,17 @@ class BskyAppAgent extends BskyAgent {
     this.sessionManager.session = undefined
     this.persistSessionHandler = undefined
   }
+}
+
+/**
+ * Returns an agent configured to make requests directly to the user's PDS
+ * without the appview proxy header. Use this for com.atproto.* methods and
+ * other PDS-specific operations like preferences.
+ */
+export function pdsAgent<T extends BaseAgent>(agent: T): T {
+  const clone = agent.clone() as T
+  clone.configureProxy(null)
+  return clone
 }
 
 export type {BskyAppAgent}

--- a/src/state/session/index.tsx
+++ b/src/state/session/index.tsx
@@ -12,6 +12,7 @@ import {
   createAgentAndCreateAccount,
   createAgentAndLogin,
   createAgentAndResume,
+  pdsAgent,
   sessionAccountToSession,
 } from './agent'
 import {type Action, getInitialState, reducer, type State} from './reducer'
@@ -248,7 +249,7 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
   >(async () => {
     const agent = state.currentAgentState.agent as BskyAppAgent
     const signal = cancelPendingTask()
-    const {data} = await agent.com.atproto.server.getSession()
+    const {data} = await pdsAgent(agent).com.atproto.server.getSession()
     if (signal.aborted) return
     store.dispatch({
       type: 'partial-refresh-session',

--- a/src/view/com/modals/DeleteAccount.tsx
+++ b/src/view/com/modals/DeleteAccount.tsx
@@ -19,6 +19,7 @@ import {useTheme} from '#/lib/ThemeContext'
 import {isAndroid, isWeb} from '#/platform/detection'
 import {useModalControls} from '#/state/modals'
 import {useAgent, useSession, useSessionApi} from '#/state/session'
+import {pdsAgent} from '#/state/session/agent'
 import {atoms as a, useTheme as useNewTheme} from '#/alf'
 import {CircleInfo_Stroke2_Corner0_Rounded as CircleInfo} from '#/components/icons/CircleInfo'
 import {Text as NewText} from '#/components/Typography'
@@ -49,7 +50,7 @@ export function Component({}: {}) {
     setError('')
     setIsProcessing(true)
     try {
-      await agent.com.atproto.server.requestAccountDelete()
+      await pdsAgent(agent).com.atproto.server.requestAccountDelete()
       setIsEmailSent(true)
     } catch (e: any) {
       setError(cleanError(e))
@@ -76,7 +77,7 @@ export function Component({}: {}) {
       if (!success) {
         throw new Error('Failed to inform chat service of account deletion')
       }
-      await agent.com.atproto.server.deleteAccount({
+      await pdsAgent(agent).com.atproto.server.deleteAccount({
         did: currentAccount.did,
         password,
         token,


### PR DESCRIPTION
`atproto-proxy` behavior seems ambiguous right now, it's not really clear whether PDS implementors should interpret atproto-proxy *before* or *after* PDS' own route handlers. This PR ensures that `com.atproto.*` calls go through without a proxy set (with some exception)

