### PR TITLE
implement collapsible tree

### DIFF
--- a/src/components/icons/CircleMinus.tsx
+++ b/src/components/icons/CircleMinus.tsx
@@ -1,0 +1,5 @@
+import {createSinglePathSVG} from './TEMPLATE'
+
+export const CircleMinus_Stroke2_Corner0_Rounded = createSinglePathSVG({
+  path: 'M12 2c5.523 0 10 4.477 10 10s-4.477 10-10 10S2 17.523 2 12 6.477 2 12 2Zm0 2a8 8 0 1 0 0 16 8 8 0 0 0 0-16ZM8 12a1 1 0 0 1 1-1h6a1 1 0 0 1 0 2H9a1 1 0 0 1-1-1Z',
+})

--- a/src/screens/PostThread/useCollapsibleThreadItems.ts
+++ b/src/screens/PostThread/useCollapsibleThreadItems.ts
@@ -1,0 +1,93 @@
+import {useCallback, useState} from 'react'
+
+import {type ThreadItem} from '#/state/queries/usePostThread'
+
+export function useCollapsibleThreadItems() {
+  // only viewable posts can be collapsed
+  type CollapsibleThreadItem = Extract<ThreadItem, {type: 'threadPost'}>
+
+  const [collapsedPostUris, setCollapsedPostUris] = useState(
+    new Set<CollapsibleThreadItem['uri']>(),
+  )
+
+  const isPostCollapsed = useCallback(
+    (item: CollapsibleThreadItem) => collapsedPostUris.has(item.uri),
+    [collapsedPostUris],
+  )
+
+  const togglePostCollapse = useCallback(
+    (item: CollapsibleThreadItem) => {
+      setCollapsedPostUris(prev => {
+        const next = new Set(prev)
+        if (!next.delete(item.uri)) next.add(item.uri)
+        return next
+      })
+    },
+    [setCollapsedPostUris],
+  )
+
+  /**
+   * Filters out children of collapsed posts.
+   */
+  const filterCollapsedChildren = useCallback(
+    (threadItems: ThreadItem[]) => {
+      if (!collapsedPostUris.size) return threadItems
+
+      const visibleItems: ThreadItem[] = []
+
+      let collapsedAncestor: CollapsibleThreadItem | undefined
+      for (const item of threadItems) {
+        switch (item.type) {
+          case 'readMoreUp':
+          case 'replyComposer':
+          case 'showOtherReplies':
+          case 'skeleton':
+            item satisfies Exclude<ThreadItem, {depth: number}>
+
+            if (!collapsedAncestor) {
+              visibleItems.push(item)
+            }
+
+            break
+
+          case 'readMore':
+          case 'threadPost':
+          case 'threadPostBlocked':
+          case 'threadPostNotFound':
+          case 'threadPostNoUnauthenticated':
+            item satisfies Extract<ThreadItem, {depth: number}>
+
+            if (collapsedAncestor && collapsedAncestor.depth >= item.depth) {
+              // iteration has exited a collapsed subtree
+              collapsedAncestor = undefined
+            }
+
+            if (!collapsedAncestor) {
+              visibleItems.push(item)
+
+              if (
+                item.type === 'threadPost' &&
+                collapsedPostUris.has(item.uri)
+              ) {
+                collapsedAncestor = item
+              }
+            }
+
+            break
+
+          default: // enforce exhaustive switch
+            item satisfies never
+        }
+      }
+
+      return visibleItems
+    },
+    [collapsedPostUris],
+  )
+
+  return {
+    filterCollapsedChildren,
+    isPostCollapsed,
+    togglePostCollapse,
+  }
+}

--- a/src/view/com/util/PostMeta.tsx
+++ b/src/view/com/util/PostMeta.tsx
@@ -16,6 +16,8 @@ import {isAndroid} from '#/platform/detection'
 import {useProfileShadow} from '#/state/cache/profile-shadow'
 import {precacheProfile} from '#/state/queries/profile'
 import {atoms as a, platform, useTheme, web} from '#/alf'
+import {Button} from '#/components/Button'
+import {CirclePlus_Stroke2_Corner0_Rounded as ExpandIcon} from '#/components/icons/CirclePlus'
 import {WebOnlyInlineLinkText} from '#/components/Link'
 import {ProfileHoverCard} from '#/components/ProfileHoverCard'
 import {Text} from '#/components/Typography'
@@ -33,6 +35,7 @@ interface PostMetaOpts {
   avatarSize?: number
   onOpenAuthor?: () => void
   style?: StyleProp<ViewStyle>
+  onExpand?: () => void
 }
 
 let PostMeta = (opts: PostMetaOpts): React.ReactNode => {
@@ -68,16 +71,29 @@ let PostMeta = (opts: PostMetaOpts): React.ReactNode => {
         a.z_20,
         opts.style,
       ]}>
-      {opts.showAvatar && (
+      {(opts.onExpand || opts.showAvatar) && (
         <View style={[a.self_center, a.mr_2xs]}>
-          <PreviewableUserAvatar
-            size={opts.avatarSize || 16}
-            profile={author}
-            moderation={opts.moderation?.ui('avatar')}
-            type={author.associated?.labeler ? 'labeler' : 'user'}
-            live={live}
-            hideLiveBadge
-          />
+          {opts.onExpand ? (
+            <Button
+              label="Expand branch"
+              onPress={opts.onExpand}
+              style={[
+                {width: opts.avatarSize || 16, height: opts.avatarSize || 16},
+              ]}>
+              <ExpandIcon fill={t.atoms.text_contrast_low.color} />
+            </Button>
+          ) : (
+            opts.showAvatar && (
+              <PreviewableUserAvatar
+                size={opts.avatarSize || 16}
+                profile={author}
+                moderation={opts.moderation?.ui('avatar')}
+                type={author.associated?.labeler ? 'labeler' : 'user'}
+                live={live}
+                hideLiveBadge
+              />
+            )
+          )}
         </View>
       )}
       <View style={[a.flex_row, a.align_end, a.flex_shrink]}>


### PR DESCRIPTION
Add collapsible thread branches. Tap the minus icon on a reply line to collapse, plus icon to expand.

Collapse state lives in the `PostThread` component.

State is not cleared by app navigation, but won't apply anywhere but the original view anchor.

State is reset on refresh or browser navigation.

https://github.com/user-attachments/assets/2e88ae89-7cfc-469c-ae71-2d05fc6482d7
