### PR TITLE
[WIP] Bump bitdrift to latest version (0.10.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   },
   "dependencies": {
     "@atproto/api": "^0.18.8",
-    "@bitdrift/react-native": "^0.6.8",
+    "@bitdrift/react-native": "^0.10.2",
     "@braintree/sanitize-url": "^6.0.2",
     "@bsky.app/alf": "^0.1.6",
     "@bsky.app/react-native-mmkv": "2.12.5",

--- a/src/logger/bitdrift/setup/index.ts
+++ b/src/logger/bitdrift/setup/index.ts
@@ -7,12 +7,16 @@ import {BITDRIFT_API_KEY} from '#/env'
 initPromise.then(() => {
   let isEnabled = false
   let isNetworkEnabled = false
+  let isJsErrorsEnabled = false
   try {
     if (Statsig.checkGate('enable_bitdrift_v2')) {
       isEnabled = true
     }
     if (Statsig.checkGate('enable_bitdrift_v2_networking')) {
       isNetworkEnabled = true
+    }
+    if (Statsig.checkGate('enable_bitdrift_v2_js_errors')) {
+      isJsErrorsEnabled = true
     }
   } catch (e) {
     // Statsig may complain about it being called too early.
@@ -22,6 +26,10 @@ initPromise.then(() => {
       url: 'https://api-bsky.bitdrift.io',
       // Only effects iOS, Android instrumentation is set via Gradle Plugin
       enableNetworkInstrumentation: isNetworkEnabled,
+      crashReporting: {
+        enableNativeFatalIssues: true,
+        UNSTABLE_enableJsErrors: isJsErrorsEnabled,
+      },
     })
   }
 })

--- a/src/logger/bitdrift/setup/index.ts
+++ b/src/logger/bitdrift/setup/index.ts
@@ -7,16 +7,12 @@ import {BITDRIFT_API_KEY} from '#/env'
 initPromise.then(() => {
   let isEnabled = false
   let isNetworkEnabled = false
-  let isJsErrorsEnabled = false
   try {
     if (Statsig.checkGate('enable_bitdrift_v2')) {
       isEnabled = true
     }
     if (Statsig.checkGate('enable_bitdrift_v2_networking')) {
       isNetworkEnabled = true
-    }
-    if (Statsig.checkGate('enable_bitdrift_v2_js_errors')) {
-      isJsErrorsEnabled = true
     }
   } catch (e) {
     // Statsig may complain about it being called too early.
@@ -26,10 +22,6 @@ initPromise.then(() => {
       url: 'https://api-bsky.bitdrift.io',
       // Only effects iOS, Android instrumentation is set via Gradle Plugin
       enableNetworkInstrumentation: isNetworkEnabled,
-      crashReporting: {
-        enableNativeFatalIssues: true,
-        UNSTABLE_enableJsErrors: isJsErrorsEnabled,
-      },
     })
   }
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -3595,10 +3595,10 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
-"@bitdrift/react-native@^0.6.8":
-  version "0.6.8"
-  resolved "https://registry.yarnpkg.com/@bitdrift/react-native/-/react-native-0.6.8.tgz#386495857bc81345de418750b5ca0e3c3b964f6c"
-  integrity sha512-ixjJTEfUz3GeQ7srxpoYpnOGVx+iDA/A8Y3CZe5cg+/b0d8xur8fBKFoRBiXXohzJnYq4W8MIWIhLAwm5sD9oA==
+"@bitdrift/react-native@^0.10.2":
+  version "0.10.2"
+  resolved "https://registry.yarnpkg.com/@bitdrift/react-native/-/react-native-0.10.2.tgz#73704943266e062b724819a30ba8bcfa329b9985"
+  integrity sha512-2o+AOCeEAgiJ9aOTLBXjeNz24E/m4RZpFe07PJNeG3APcp44Eylx5lZJa65BspqBLU2CezbAMG9LQijjy6l5Fw==
   dependencies:
     "@expo/config-plugins" "^9.0.14"
     fast-json-stringify "^6.0.0"


### PR DESCRIPTION
### What

Updates bitdrift to latest version ([0.10.2](https://www.npmjs.com/package/@bitdrift/react-native/v/0.10.2)), 

This comes with many [improvements since 0.6.8](https://docs.bitdrift.io/sdk/releases-react-native#0610) but the main relevant changes are:

- Native fatal issues are captured by default (e.g. JVM crash, native crash, ANRs). See setup docs [here](https://docs.bitdrift.io/product/issues-features.html#status) and [here](https://docs.bitdrift.io/sdk/features-fatal-issues.html#__tabbed_3_1)
- Added new APIs `logScreenView`, `logAppLaunchTTI` 
- Other general improvements

NOTE: As a follow-up will explore adding a new flag `enable_bitdrift_v2_js_errors` to opt-in for experimental global JS errors detection (via `UNSTABLE_enableJsErrors` config)

### Verification WIP

Locally tweak bitdrift config flag to true and verify that session loads

