### PR TITLE
Fix suggested follow card size

### DIFF
--- a/src/components/FeedInterstitials.tsx
+++ b/src/components/FeedInterstitials.tsx
@@ -56,6 +56,7 @@ function CardOuter({
   const {gtMobile} = useBreakpoints()
   return (
     <View
+      testID="CardOuter"
       style={[
         a.flex_1,
         a.w_full,
@@ -575,7 +576,8 @@ export function ProfileGrid({
                   suggestedDid: profile.did,
                   category: null,
                 })
-              }}>
+              }}
+              style={[a.flex_1]}>
               {({hovered, pressed}) => (
                 <CardOuter
                   style={[


### PR DESCRIPTION
Cards just need to flex to full height, otherwise ones without bios are too short

## Before

<img width="670" height="341" alt="Screenshot 2026-01-05 at 14 23 50" src="https://github.com/user-attachments/assets/34cce32a-c0b1-4433-ac66-ebc27d144634" />

## After

<table>
  <thead>
    <tr>
      <th>Web</th>
      <th>iOS</th>
      <th>Android</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><img width="300" src="https://github.com/user-attachments/assets/671b1c54-6981-47ca-8a51-9adaa2c5a707" /></td>
      <td><img width="300" src="https://github.com/user-attachments/assets/16044e25-ddf3-4009-84db-8016bdd81dfa" /></td>
      <td><img width="300" src="https://github.com/user-attachments/assets/4cdb4479-44c2-4b3b-b42a-2e99f35f4253" /></td>
    </tr>
  </tbody>
</table>

# Test plan

Try on all platforms
I tested iOS + web + Android