### PR TITLE
Prioritise user over labeller in ContentHider if same labels are applied

### DIFF
--- a/src/components/moderation/ContentHider.tsx
+++ b/src/components/moderation/ContentHider.tsx
@@ -74,7 +74,27 @@ function ContentHiderActive({
   const {labelDefs} = useLabelDefinitions()
   const globalLabelStrings = useGlobalLabelStrings()
   const {i18n} = useLingui()
-  const blur = modui?.blurs[0]
+
+  const blur = React.useMemo(() => {
+    const blurs = modui.blurs!
+    const primary = blurs[0]
+
+    if (primary.type === 'label' && primary.source.type !== 'user') {
+      const userEquivalent = blurs.find(
+        b =>
+          b.type === 'label' &&
+          b.source.type === 'user' &&
+          b.label.val === primary.label.val,
+      )
+
+      if (userEquivalent) {
+        return userEquivalent
+      }
+    }
+
+    return primary
+  }, [modui.blurs])
+
   const desc = useModerationCauseDescription(blur)
 
   const labelName = React.useMemo(() => {


### PR DESCRIPTION
Fixes the issue from #5015 & briefly mentioned in #9539

With the frequency at which the Moderation Service seems to apply the exact same label to a piece of content as the author does, we should should prioritise the user over the labeller for the ContentHider

Appropriately crediting the author for the label instead