### PR TITLE
Enable lightbox for profile banner

### DIFF
--- a/src/screens/Profile/Header/Shell.tsx
+++ b/src/screens/Profile/Header/Shell.tsx
@@ -77,7 +77,7 @@ let ProfileHeaderShell = ({
     (
       uri: string,
       thumbRect: MeasuredDimensions | null,
-      type: 'circle-avi' | 'profile-banner' = 'circle-avi',
+      type: 'circle-avi' | 'image' = 'circle-avi',
     ) => {
       openLightbox({
         images: [
@@ -93,6 +93,7 @@ let ProfileHeaderShell = ({
                     width: 1000,
                   }
                 : {
+                    // Banner aspect ratio is 3:1
                     width: 3000,
                     height: 1000,
                   },
@@ -160,7 +161,7 @@ let ProfileHeaderShell = ({
       runOnUI(() => {
         'worklet'
         const rect = measure(bannerRef)
-        runOnJS(_openLightbox)(banner, rect, 'profile-banner')
+        runOnJS(_openLightbox)(banner, rect, 'image')
       })()
     }
   }, [profile.banner, moderation, _openLightbox, bannerRef])

--- a/src/view/com/lightbox/ImageViewing/@types/index.ts
+++ b/src/view/com/lightbox/ImageViewing/@types/index.ts
@@ -26,7 +26,7 @@ export type ImageSource = {
   thumbDimensions: Dimensions | null
   thumbRect: MeasuredDimensions | null
   alt?: string
-  type: 'image' | 'circle-avi' | 'rect-avi' | 'profile-banner'
+  type: 'image' | 'circle-avi' | 'rect-avi'
 }
 
 export type Transform = Exclude<


### PR DESCRIPTION
Makes the profile banner pressable, opening the image lightbox

https://github.com/user-attachments/assets/ccd25c13-2460-4202-b4bf-b18b5402e15b

