### PR TITLE
fix `VideoPostCardPlaceholder` and `VideoPostCard` bg color

### DIFF
--- a/src/components/VideoPostCard.tsx
+++ b/src/components/VideoPostCard.tsx
@@ -192,8 +192,8 @@ export function VideoPostCard({
               a.justify_center,
               a.rounded_md,
               a.overflow_hidden,
+              t.atoms.bg_contrast_50,
               {
-                backgroundColor: black,
                 aspectRatio: 9 / 16,
               },
             ]}>

--- a/src/components/VideoPostCard.tsx
+++ b/src/components/VideoPostCard.tsx
@@ -255,7 +255,6 @@ export function VideoPostCard({
 
 export function VideoPostCardPlaceholder() {
   const t = useTheme()
-  const black = getBlackColor(t)
 
   return (
     <View style={[a.flex_1]}>
@@ -263,8 +262,8 @@ export function VideoPostCardPlaceholder() {
         style={[
           a.rounded_md,
           a.overflow_hidden,
+          t.atoms.bg_contrast_50,
           {
-            backgroundColor: black,
             aspectRatio: 9 / 16,
           },
         ]}>


### PR DESCRIPTION
Before:

<img width="200" alt="C2084FCD-FC1F-4B46-A6C3-CC9F810FF585" src="https://github.com/user-attachments/assets/308ced15-b899-4515-913f-b1b1b785e421" />

with a black background blinking (reduce video speed)

https://github.com/user-attachments/assets/24aa41d7-bb9e-4f82-a326-cd7b8f2fa199


After:

<img width="200" alt="4AB2109F-7A2C-45D6-BCD9-44DACFB65D7B" src="https://github.com/user-attachments/assets/b145f556-1df5-4e32-a251-3fccd9e9cadb" />

https://github.com/user-attachments/assets/00a8026a-3e9c-4b9a-b5d0-59b8c7530309

