### PR TITLE
Unify build concurrency to one build per platform

### DIFF
--- a/.github/workflows/build-submit-android.yml
+++ b/.github/workflows/build-submit-android.yml
@@ -16,6 +16,9 @@ jobs:
     if: github.repository == 'bluesky-social/social-app'
     name: Build and Submit Android
     runs-on: Linux-x64-32core
+    concurrency:
+      group: android-build
+      cancel-in-progress: false
     steps:
       - name: Check for EXPO_TOKEN
         run: >

--- a/.github/workflows/build-submit-ios.yml
+++ b/.github/workflows/build-submit-ios.yml
@@ -16,6 +16,9 @@ jobs:
     if: github.repository == 'bluesky-social/social-app'
     name: Build and Submit iOS
     runs-on: macos-26-xlarge
+    concurrency:
+      group: ios-build
+      cancel-in-progress: false
     steps:
       - name: Check for EXPO_TOKEN
         run: >

--- a/.github/workflows/bundle-deploy-eas-update.yml
+++ b/.github/workflows/bundle-deploy-eas-update.yml
@@ -157,8 +157,8 @@ jobs:
     name: Build and Submit iOS
     runs-on: macos-26
     concurrency:
-      group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}-build-ios
-      cancel-in-progress: true
+      group: ios-build
+      cancel-in-progress: false
     needs: [bundleDeploy]
     # Gotta check if its NOT '[]' because any md5 hash in the outputs is detected as a possible secret and won't be
     # available here
@@ -262,7 +262,7 @@ jobs:
     name: Build and Submit Android
     runs-on: ubuntu-latest
     concurrency:
-      group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}-build-android
+      group: android-build
       cancel-in-progress: false
     needs: [bundleDeploy]
     # Gotta check if its NOT '[]' because any md5 hash in the outputs is detected as a possible secret and won't be


### PR DESCRIPTION
Ensures only one iOS build and one Android build can run at a time across all workflows.