### PR TITLE
Fix full-screen back gesture over PagerView on iOS 26

### DIFF
--- a/patches/react-native-pager-view+6.8.0.patch
+++ b/patches/react-native-pager-view+6.8.0.patch
@@ -1,0 +1,30 @@
+diff --git a/node_modules/react-native-pager-view/ios/RNCPagerView.m b/node_modules/react-native-pager-view/ios/RNCPagerView.m
+index adfc7c6..366df60 100644
+--- a/node_modules/react-native-pager-view/ios/RNCPagerView.m
++++ b/node_modules/react-native-pager-view/ios/RNCPagerView.m
+@@ -498,6 +498,25 @@ - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRecogni
+         return YES;
+     }
+ 
++    // iOS 26+ full-screen back gesture (interactiveContentPopGestureRecognizer)
++    if (@available(iOS 26, *)) {
++        if (gestureRecognizer == self.panGestureRecognizer &&
++            otherGestureRecognizer == self.reactViewController.navigationController.interactiveContentPopGestureRecognizer) {
++            UIPanGestureRecognizer* panGestureRecognizer = (UIPanGestureRecognizer*) gestureRecognizer;
++            CGPoint velocity = [panGestureRecognizer velocityInView:self];
++            BOOL isLTR = [self isLtrLayout];
++            BOOL isBackGesture = (isLTR && velocity.x > 0) || (!isLTR && velocity.x < 0);
++
++            if (self.currentIndex == 0 && isBackGesture) {
++                self.scrollView.panGestureRecognizer.enabled = false;
++            } else {
++                self.scrollView.panGestureRecognizer.enabled = self.scrollEnabled;
++            }
++
++            return YES;
++        }
++    }
++
+     self.scrollView.panGestureRecognizer.enabled = self.scrollEnabled;
+     return NO;
+ }

--- a/patches/react-native-pager-view+6.8.0.patch.md
+++ b/patches/react-native-pager-view+6.8.0.patch.md
@@ -1,0 +1,11 @@
+# react-native-pager-view+6.8.0.patch
+
+Adds support for iOS 26's `interactiveContentPopGestureRecognizer` (full-screen back gesture).
+
+The pager already handles `RNSPanGestureRecognizer` (react-native-screens' custom full-screen gesture for pre-iOS 26) in `shouldRecognizeSimultaneouslyWithGestureRecognizer:`. It checks if the user is on the leftmost page and swiping right - if so, it disables the scrollview's pan gesture to let the back gesture through.
+
+This patch adds the same logic for iOS 26's native `interactiveContentPopGestureRecognizer`, so the back gesture works on the leftmost page while the pager still handles swipes on other pages.
+
+Related issues:
+- https://github.com/software-mansion/react-native-screens/issues/3512
+- https://github.com/software-mansion/react-native-screens/pull/3420


### PR DESCRIPTION
## Summary
- Patches `react-native-pager-view` to support iOS 26's `interactiveContentPopGestureRecognizer` (full-screen back gesture)
- Uses the same logic already present for `RNSPanGestureRecognizer`: checks if on leftmost page and swiping right, then disables the pager's scrollview pan to let the back gesture through

## Related
- https://github.com/callstack/react-native-pager-view/issues/1050
- https://github.com/software-mansion/react-native-screens/issues/3512
- https://github.com/software-mansion/react-native-screens/pull/3420

## Test Plan
1. Open a profile with a PagerView (e.g. Posts/Replies/Media tabs)
2. On leftmost tab, swipe right from anywhere → should navigate back
3. Swipe right on non-leftmost tab → should switch to previous tab
4. Swipe left on any tab → should switch to next tab