### PR TITLE
Do not render links if uri is invalid

### DIFF
--- a/src/components/RichText.tsx
+++ b/src/components/RichText.tsx
@@ -11,7 +11,7 @@ import {RichTextTag} from '#/components/RichTextTag'
 import {Text, type TextProps} from '#/components/Typography'
 
 const WORD_WRAP = {wordWrap: 1}
-// lifted from facet detection in `RichText` impl
+// lifted from facet detection in `RichText` impl, _without_ `gm` flags
 const URL_REGEX =
   /(^|\s|\()((https?:\/\/[\S]+)|((?<domain>[a-z][a-z0-9]*(\.[a-z0-9]+)+)[\S]*))/i
 


### PR DESCRIPTION
Lifted validation we use in `RichText.detectFacets` so that any `link` facet that comes down the pipe must contain a valid URL in order to be rendered as a URL in our app. No reason to be rendering stuff like this https://bsky.app/profile/scoiattolo.mountainherder.xyz/post/3mbuvztjijs2y