### PR TITLE
Make activity notif button blue when tooltip is visible

### DIFF
--- a/src/components/activity-notifications/SubscribeProfileButton.tsx
+++ b/src/components/activity-notifications/SubscribeProfileButton.tsx
@@ -68,10 +68,12 @@ export function SubscribeProfileButton({
 
   const Icon = isSubscribed ? BellRingingIcon : BellPlusIcon
 
+  const tooltipVisible = showTooltip && !disableHint
+
   return (
     <>
       <Tooltip.Outer
-        visible={showTooltip && !disableHint}
+        visible={tooltipVisible}
         onVisibleChange={onDismissTooltip}
         position="bottom">
         <Tooltip.Target>
@@ -79,7 +81,7 @@ export function SubscribeProfileButton({
             accessibilityRole="button"
             testID="dmBtn"
             size="small"
-            color="secondary"
+            color={tooltipVisible ? 'primary_subtle' : 'secondary'}
             shape="round"
             label={_(msg`Get notified when ${name} posts`)}
             onPress={wrappedOnPress}>


### PR DESCRIPTION
It's a pattern we started using in the composer tooltip, and it looks quite good

<img width="399" height="249" alt="Screenshot 2026-01-09 at 12 05 37" src="https://github.com/user-attachments/assets/57cbe5d2-914c-4374-806c-b157c5126d3e" />
