### PR TITLE
Only load relevent fonts for each platform

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -278,19 +278,24 @@ module.exports = function (_config) {
         [
           'expo-font',
           {
-            fonts: [
-              './assets/fonts/inter/InterVariable.woff2',
-              './assets/fonts/inter/InterVariable-Italic.woff2',
-              // Android only
-              './assets/fonts/inter/Inter-Regular.otf',
-              './assets/fonts/inter/Inter-Italic.otf',
-              './assets/fonts/inter/Inter-Medium.otf',
-              './assets/fonts/inter/Inter-MediumItalic.otf',
-              './assets/fonts/inter/Inter-SemiBold.otf',
-              './assets/fonts/inter/Inter-SemiBoldItalic.otf',
-              './assets/fonts/inter/Inter-Bold.otf',
-              './assets/fonts/inter/Inter-BoldItalic.otf',
-            ],
+            ios: {
+              fonts: [
+                './assets/fonts/inter/InterVariable.woff2',
+                './assets/fonts/inter/InterVariable-Italic.woff2',
+              ],
+            },
+            android: {
+              fonts: [
+                './assets/fonts/inter/Inter-Regular.otf',
+                './assets/fonts/inter/Inter-Italic.otf',
+                './assets/fonts/inter/Inter-Medium.otf',
+                './assets/fonts/inter/Inter-MediumItalic.otf',
+                './assets/fonts/inter/Inter-SemiBold.otf',
+                './assets/fonts/inter/Inter-SemiBoldItalic.otf',
+                './assets/fonts/inter/Inter-Bold.otf',
+                './assets/fonts/inter/Inter-BoldItalic.otf',
+              ],
+            },
           },
         ],
         [


### PR DESCRIPTION
Before, we used to load all font files for each platform. We can actually just specify which font files to use for each platform. This is a little speculative, please check it properly

## Test plan

See if the fonts work? They seem to?

Using `getLoadedFonts()` does show a decrease - idk why there's so many duplicates. presumably it's the variable font

<img width="234" height="201" alt="Screenshot 2026-01-09 at 14 15 36" src="https://github.com/user-attachments/assets/91090628-f5d4-4fb9-b263-89822b5e9263" />
