### PR TITLE
Reduce startup hang by not querying fonts

### DIFF
--- a/patches/expo-font+14.0.10.patch
+++ b/patches/expo-font+14.0.10.patch
@@ -1,27 +1,13 @@
 diff --git a/node_modules/expo-font/ios/FontLoaderModule.swift b/node_modules/expo-font/ios/FontLoaderModule.swift
-index 183480f..d1bdfb1 100644
+index 183480f..7b64f6e 100644
 --- a/node_modules/expo-font/ios/FontLoaderModule.swift
 +++ b/node_modules/expo-font/ios/FontLoaderModule.swift
-@@ -2,10 +2,23 @@ import ExpoModulesCore
+@@ -2,10 +2,9 @@ import ExpoModulesCore
  
  public final class FontLoaderModule: Module {
    // could be a Set, but to be able to pass to JS we keep it as an array
 -  private var registeredFonts: [String]
-+  private var _registeredFonts: [String] = []
-+  private var hasQueriedNativeFonts = false
-+
-+  private var registeredFonts: [String] {
-+    get {
-+      if !hasQueriedNativeFonts {
-+        hasQueriedNativeFonts = true
-+        _registeredFonts = queryCustomNativeFonts()
-+      }
-+      return _registeredFonts
-+    }
-+    set {
-+      _registeredFonts = newValue
-+    }
-+  }
++  private lazy var registeredFonts: [String] = queryCustomNativeFonts()
  
    public required init(appContext: AppContext) {
 -    self.registeredFonts = queryCustomNativeFonts()


### PR DESCRIPTION
Patch of https://github.com/expo/expo/pull/42033 which contains more details. tl;dr `expo-font` queries all the available fonts at startup. This can be quite expensive (I can see in Xcode it's 26% of our hangs), and we don't even use it because we use the config plugin.

<img width="261" height="121" alt="Screenshot 2026-01-09 at 13 23 19" src="https://github.com/user-attachments/assets/b72f0587-55dd-438a-83a9-4fd07e968d2b" />

Easy fix: make it a `lazy var`, so it only gets queried when it's used.  

## Test plan

- Ensure iOS app builds

I confirmed it does not query fonts until needed (I called `getLoadedFonts` after 10s):

<img width="974" height="315" alt="Screenshot 2026-01-09 at 13 56 34" src="https://github.com/user-attachments/assets/6ad79c6a-fda1-47cd-a076-5be852de049d" />

  