### PR TITLE
Send interests to all feeds

### DIFF
--- a/src/lib/api/feed/custom.ts
+++ b/src/lib/api/feed/custom.ts
@@ -10,7 +10,7 @@ import {
   getContentLanguages,
 } from '#/state/preferences/languages'
 import {type FeedAPI, type FeedAPIResponse} from './types'
-import {createBskyTopicsHeader, isBlueskyOwnedFeed} from './utils'
+import {createBskyTopicsHeader} from './utils'
 
 export class CustomFeedAPI implements FeedAPI {
   agent: BskyAgent
@@ -52,7 +52,6 @@ export class CustomFeedAPI implements FeedAPI {
   }): Promise<FeedAPIResponse> {
     const contentLangs = getContentLanguages().join(',')
     const agent = this.agent
-    const isBlueskyOwned = isBlueskyOwnedFeed(this.params.feed)
 
     const res = agent.did
       ? await this.agent.app.bsky.feed.getFeed(
@@ -63,9 +62,7 @@ export class CustomFeedAPI implements FeedAPI {
           },
           {
             headers: {
-              ...(isBlueskyOwned
-                ? createBskyTopicsHeader(this.userInterests)
-                : {}),
+              ...createBskyTopicsHeader(this.userInterests),
               'Accept-Language': contentLangs,
             },
           },

--- a/src/lib/api/feed/merge.ts
+++ b/src/lib/api/feed/merge.ts
@@ -17,7 +17,7 @@ import {
   type FeedAPIResponse,
   type ReasonFeedSource,
 } from './types'
-import {createBskyTopicsHeader, isBlueskyOwnedFeed} from './utils'
+import {createBskyTopicsHeader} from './utils'
 
 const REQUEST_WAIT_MS = 500 // 500ms
 const POST_AGE_CUTOFF = 60e3 * 60 * 24 // 24hours
@@ -290,7 +290,6 @@ class MergeFeedSource_Custom extends MergeFeedSource {
   ): Promise<AppBskyFeedGetTimeline.Response> {
     try {
       const contentLangs = getContentLanguages().join(',')
-      const isBlueskyOwned = isBlueskyOwnedFeed(this.feedUri)
       const res = await this.agent.app.bsky.feed.getFeed(
         {
           cursor,
@@ -299,9 +298,7 @@ class MergeFeedSource_Custom extends MergeFeedSource {
         },
         {
           headers: {
-            ...(isBlueskyOwned
-              ? createBskyTopicsHeader(this.userInterests)
-              : {}),
+            ...createBskyTopicsHeader(this.userInterests),
             'Accept-Language': contentLangs,
           },
         },

--- a/src/lib/api/feed/utils.ts
+++ b/src/lib/api/feed/utils.ts
@@ -1,6 +1,3 @@
-import {AtUri} from '@atproto/api'
-
-import {BSKY_FEED_OWNER_DIDS} from '#/lib/constants'
 import {isWeb} from '#/platform/detection'
 import {type UsePreferencesQueryResponse} from '#/state/queries/preferences'
 
@@ -20,9 +17,4 @@ export function aggregateUserInterests(
   preferences?: UsePreferencesQueryResponse,
 ) {
   return preferences?.interests?.tags?.join(',') || ''
-}
-
-export function isBlueskyOwnedFeed(feedUri: string) {
-  const uri = new AtUri(feedUri)
-  return BSKY_FEED_OWNER_DIDS.includes(uri.host)
 }

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -131,12 +131,6 @@ export const MAX_POST_LINES = 25
 
 export const BSKY_APP_ACCOUNT_DID = 'did:plc:z72i7hdynmk6r22z27h6tvur'
 
-export const BSKY_FEED_OWNER_DIDS = [
-  BSKY_APP_ACCOUNT_DID,
-  'did:plc:vpkhqolt662uhesyj6nxm7ys',
-  'did:plc:q6gjnaw2blty4crticxkmujt',
-]
-
 export const DISCOVER_FEED_URI =
   'at://did:plc:z72i7hdynmk6r22z27h6tvur/app.bsky.feed.generator/whats-hot'
 export const VIDEO_FEED_URI =


### PR DESCRIPTION
## Why

Given that Bluesky's algorithmic feeds are still a bit "meh", third-party feeds such as [For You](https://bsky.app/profile/did:plc:3guzzweuqraryl3rdkimjamk/feed/for-you) have become indispensable to the ecosystem. Although they're now competitive for users with existing data like Follows and Likes, they're still at a disadvantage compared to Discover for the cold start case where the only known information about the user is their selected list of interests.

This PR makes the selected list of interests available to all feeds, solving the problem.

## Why this is fine

The current list of interests itself is pretty tame:

```
  animals, art, books, comedy, comics, culture, dev, education,
  finance, food, gaming, journalism, movies, music, nature, news,
  pets, photography, politics, science, sports, tech, tv, writers
```

There's nothing embarrassing in either of those. It is also stored per-account so there is no risk of identifying alts by a unique combination or something like that.

I don't think there is any meaningful reason to keep it only available to the Bluesky-operated feeds. And there is a significant upside to opening it up.

For simplicity, I opted to open it up to all feeds (rather than, say, just to Saved or Pinned feeds). This is to avoid thinking about weird race conditions where you might see different things depending on whether you just pinned it or not. This also avoids the problem where a feed preview is inaccurate and doesn't match your experience if you actually started using it. It seems important to serve relevant content right away.

## When to reconsider this

If the list of interests is significantly expanded to include something that people might prefer to keep private, this approach may no longer make sense. In that case something separate could be added. I'd also say any strategy that relies on privileging Bluesky's feeds is probably bad anyway though.

## Implementation

I kept the existing `x-bsky-topics` header name. Yes it's "non-standard" but the point of headers is you can tack on things that you don't have a better place for. It would be a one-line change to read it from some more official place if this gets "standardized" later. I think it's fine.

## Test Plan

Observe it being sent (when present):

<img width="680" height="454" alt="Screenshot 2026-01-09 at 18 10 20" src="https://github.com/user-attachments/assets/c7f705ef-4771-4fb8-ac2a-0dda8551db8e" />

