### PR TITLE
Expose QueryClient for TanStack Query DevTools browser extension

### DIFF
--- a/src/lib/react-query.tsx
+++ b/src/lib/react-query.tsx
@@ -1,4 +1,4 @@
-import {useRef, useState} from 'react'
+import {useEffect, useRef, useState} from 'react'
 import {AppState, type AppStateStatus} from 'react-native'
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import {createAsyncStoragePersister} from '@tanstack/query-async-storage-persister'
@@ -9,8 +9,14 @@ import {
 } from '@tanstack/react-query-persist-client'
 import type React from 'react'
 
-import {isNative} from '#/platform/detection'
+import {isNative, isWeb} from '#/platform/detection'
 import {listenNetworkConfirmed, listenNetworkLost} from '#/state/events'
+
+declare global {
+  interface Window {
+    __TANSTACK_QUERY_CLIENT__: import('@tanstack/query-core').QueryClient
+  }
+}
 
 // any query keys in this array will be persisted to AsyncStorage
 export const labelersDetailedInfoQueryKeyRoot = 'labelers-detailed-info'
@@ -180,6 +186,11 @@ function QueryProviderInner({
       dehydrateOptions,
     }
   })
+  useEffect(() => {
+    if (isWeb) {
+      window.__TANSTACK_QUERY_CLIENT__ = queryClient
+    }
+  }, [queryClient])
   return (
     <PersistQueryClientProvider
       client={queryClient}


### PR DESCRIPTION
## Summary
- Exposes the QueryClient on `window.__TANSTACK_QUERY_CLIENT__` for the TanStack Query DevTools browser extension (web only)
- NOTE - you need to refresh the page after logging in/out as it replaces the query client

## Install the extension

- [Devtools for Chrome](https://chromewebstore.google.com/detail/tanstack-query-devtools/annajfchloimdhceglpgglpeepfghfai)
- [Devtools for Firefox](https://addons.mozilla.org/en-US/firefox/addon/tanstack-query-devtools/)
- [Devtools for Edge](https://microsoftedge.microsoft.com/addons/detail/tanstack-query-devtools/edmdpkgkacmjopodhfolmphdenmddobj)

## Test plan
- [ ] Install the browser extension
- [ ] Open bsky.app and check that the extension shows query data

🤖 Generated with [Claude Code](https://claude.com/claude-code)