### PR TITLE
Trim profile descriptions in profile screen and ProfileCard

### DIFF
--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -409,7 +409,7 @@ export function Description({
   const profile = useProfileShadow(profileUnshadowed)
   const rt = useMemo(() => {
     if (!('description' in profile)) return
-    const rt = new RichTextApi({text: profile.description || ''})
+    const rt = new RichTextApi({text: (profile.description || '').trim()})
     rt.detectFacetsWithoutResolution()
     return rt
   }, [profile])

--- a/src/view/screens/Profile.tsx
+++ b/src/view/screens/Profile.tsx
@@ -203,7 +203,7 @@ function ProfileScreenLoaded({
 
   useSetTitle(combinedDisplayName(profile))
 
-  const description = profile.description ?? ''
+  const description = (profile.description ?? '').trim()
   const hasDescription = description !== ''
   const [descriptionRT, isResolvingDescriptionRT] = useRichText(description)
   const showPlaceholder = isPlaceholderProfile || isResolvingDescriptionRT


### PR DESCRIPTION
Adds .trim() to profile descriptions to remove leading/trailing
whitespace that can cause layout issues in the UI.