### PR TITLE
Highlight first feed in sidebar if non selected

### DIFF
--- a/src/view/shell/desktop/Feeds.tsx
+++ b/src/view/shell/desktop/Feeds.tsx
@@ -74,9 +74,11 @@ export function DesktopFeeds() {
           overflowY: 'auto',
         }),
       ]}>
-      {pinnedFeedInfos.map(feedInfo => {
+      {pinnedFeedInfos.map((feedInfo, index) => {
         const feed = feedInfo.feedDescriptor
-        const current = route.name === 'Home' && feed === selectedFeed
+        const current =
+          route.name === 'Home' &&
+          (selectedFeed ? feed === selectedFeed : index === 0)
 
         return (
           <FeedItem


### PR DESCRIPTION
`useSelectedFeed` doesn't return anything until the selected feed changes. That means initially, it's `null`. The feed pager in this case just uses the first available feed - the right nav should too