### PR TITLE
Make live now gate fail-open

### DIFF
--- a/src/components/dialogs/nuxs/LiveNowBetaDialog.tsx
+++ b/src/components/dialogs/nuxs/LiveNowBetaDialog.tsx
@@ -25,7 +25,7 @@ export const enabled = createIsEnabledCheck(props => {
       '2026-01-16T00:00:00.000Z',
       props.currentProfile.createdAt,
     ) &&
-    props.gate('live_now_beta')
+    !props.gate('disable_live_now_beta')
   )
 })
 

--- a/src/lib/statsig/gates.ts
+++ b/src/lib/statsig/gates.ts
@@ -3,12 +3,12 @@ export type Gate =
   | 'alt_share_icon'
   | 'debug_show_feedcontext'
   | 'debug_subscriptions'
+  | 'disable_live_now_beta'
   | 'disable_onboarding_find_contacts'
   | 'disable_settings_find_contacts'
   | 'explore_show_suggested_feeds'
   | 'feed_reply_button_open_thread'
   | 'is_bsky_team_member' // special, do not remove
-  | 'live_now_beta'
   | 'old_postonboarding'
   | 'onboarding_add_video_feed'
   | 'onboarding_suggested_starterpacks'

--- a/src/state/service-config.tsx
+++ b/src/state/service-config.tsx
@@ -106,7 +106,7 @@ export function useCanGoLive() {
   const gate = useGate()
   const {hasSession} = useSession()
   if (!hasSession) return false
-  return IS_DEV ? true : gate('live_now_beta')
+  return IS_DEV ? true : !gate('disable_live_now_beta')
 }
 
 export function useCheckEmailConfirmed() {


### PR DESCRIPTION
Allows adblock users to use Live Now

**NOT TESTED**