### PR TITLE
Make Steam uri validate

### DIFF
--- a/src/components/RichText.tsx
+++ b/src/components/RichText.tsx
@@ -13,7 +13,7 @@ import {Text, type TextProps} from '#/components/Typography'
 const WORD_WRAP = {wordWrap: 1}
 // lifted from facet detection in `RichText` impl, _without_ `gm` flags
 const URL_REGEX =
-  /(^|\s|\()((https?:\/\/[\S]+)|((?<domain>[a-z][a-z0-9]*(\.[a-z0-9]+)+)[\S]*))/i
+  /(^|\s|\()((https?:\/\/[\S]+)|(steam:\/\/[\S]+)|((?<domain>[a-z][a-z0-9]*(\.[a-z0-9]+)+)[\S]*))/i
 
 export type RichTextProps = TextStyleProp &
   Pick<TextProps, 'selectable' | 'onLayout' | 'onTextLayout'> & {


### PR DESCRIPTION
This fixes a regression caused by #9663 where links using the [steam:// protocol](https://developer.valvesoftware.com/wiki/Steam_browser_protocol) will fail the check. Example: https://bsky.app/profile/hatlink.bsky.social/post/3leh2gsfu4u23