### PR TITLE
Refactor GrowthHack to always render on iOS with enabled prop

### DIFF
--- a/src/screens/PostThread/components/ThreadItemAnchor.tsx
+++ b/src/screens/PostThread/components/ThreadItemAnchor.tsx
@@ -380,11 +380,12 @@ const ThreadItemAnchorInner = memo(function ThreadItemAnchorInner({
               </ProfileHoverCard>
             </View>
           </Link>
-          {showFollowButton && (
-            <View collapsable={false} style={[a.self_center]}>
-              <ThreadItemAnchorFollowButton did={post.author.did} />
-            </View>
-          )}
+          <View collapsable={false} style={[a.self_center]}>
+            <ThreadItemAnchorFollowButton
+              did={post.author.did}
+              enabled={showFollowButton}
+            />
+          </View>
         </View>
         <View style={[a.pb_sm]}>
           <LabelsOnMyPost post={post} style={[a.pb_sm]} />

--- a/src/screens/PostThread/components/ThreadItemAnchorFollowButton.tsx
+++ b/src/screens/PostThread/components/ThreadItemAnchorFollowButton.tsx
@@ -19,24 +19,36 @@ import {PlusLarge_Stroke2_Corner0_Rounded as PlusIcon} from '#/components/icons/
 import {IS_IOS} from '#/env'
 import {GrowthHack} from './GrowthHack'
 
-export function ThreadItemAnchorFollowButton({did}: {did: string}) {
+export function ThreadItemAnchorFollowButton({
+  did,
+  enabled = true,
+}: {
+  did: string
+  enabled?: boolean
+}) {
   if (IS_IOS) {
     return (
       <GrowthHack>
-        <ThreadItemAnchorFollowButtonInner did={did} />
+        <ThreadItemAnchorFollowButtonInner did={did} enabled={enabled} />
       </GrowthHack>
     )
   }
 
-  return <ThreadItemAnchorFollowButtonInner did={did} />
+  return <ThreadItemAnchorFollowButtonInner did={did} enabled={enabled} />
 }
 
-export function ThreadItemAnchorFollowButtonInner({did}: {did: string}) {
+export function ThreadItemAnchorFollowButtonInner({
+  did,
+  enabled = true,
+}: {
+  did: string
+  enabled?: boolean
+}) {
   const {data: profile, isLoading} = useProfileQuery({did})
 
   // We will never hit this - the profile will always be cached or loaded above
   // but it keeps the typechecker happy
-  if (isLoading || !profile) return null
+  if (!enabled || isLoading || !profile) return null
 
   return <PostThreadFollowBtnLoaded profile={profile} />
 }


### PR DESCRIPTION
Instead of conditionally rendering the GrowthHack component, drill down
an `enabled` prop to control whether the follow button is shown. This
ensures the GrowthHack wrapper (with the Bluesky logo) is always
rendered on iOS, even when the follow button shouldn't be displayed.