### PR TITLE
Fix scroll issues on Starter Packs profile tab

### DIFF
--- a/src/components/StarterPack/ProfileStarterPacks.tsx
+++ b/src/components/StarterPack/ProfileStarterPacks.tsx
@@ -161,6 +161,9 @@ export function ProfileStarterPacks({
   )
 
   const renderFooter = useCallback(() => {
+    if (!data || items?.length === 0) {
+      return null
+    }
     if (isMe) {
       return <CreateAnother style={{paddingBottom: bottomBarOffset}} />
     }
@@ -174,6 +177,8 @@ export function ProfileStarterPacks({
       />
     )
   }, [
+    data,
+    items?.length,
     isMe,
     bottomBarOffset,
     isFetchingNextPage,

--- a/src/components/StarterPack/ProfileStarterPacks.tsx
+++ b/src/components/StarterPack/ProfileStarterPacks.tsx
@@ -161,9 +161,6 @@ export function ProfileStarterPacks({
   )
 
   const renderFooter = useCallback(() => {
-    if (!data || items?.length === 0) {
-      return null
-    }
     if (isMe) {
       return <CreateAnother style={{paddingBottom: bottomBarOffset}} />
     }
@@ -177,8 +174,6 @@ export function ProfileStarterPacks({
       />
     )
   }, [
-    data,
-    items?.length,
     isMe,
     bottomBarOffset,
     isFetchingNextPage,

--- a/src/components/StarterPack/ProfileStarterPacks.tsx
+++ b/src/components/StarterPack/ProfileStarterPacks.tsx
@@ -175,6 +175,7 @@ export function ProfileStarterPacks({
       />
     )
   }, [
+    _,
     data,
     items?.length,
     isMe,

--- a/src/components/StarterPack/ProfileStarterPacks.tsx
+++ b/src/components/StarterPack/ProfileStarterPacks.tsx
@@ -164,17 +164,17 @@ export function ProfileStarterPacks({
     if (!data || items?.length === 0) {
       return null
     }
-    if (isMe) {
-      return <CreateAnother style={{paddingBottom: bottomBarOffset}} />
-    }
     return (
-      <ListFooter
-        isFetchingNextPage={isFetchingNextPage}
-        hasNextPage={hasNextPage}
-        error={isError ? 'Could not load more starter packs' : undefined}
-        onRetry={fetchNextPage}
-        style={{paddingBottom: bottomBarOffset}}
-      />
+      <>
+        <ListFooter
+          isFetchingNextPage={isFetchingNextPage}
+          hasNextPage={hasNextPage}
+          error={isError ? 'Could not load more starter packs' : undefined}
+          onRetry={fetchNextPage}
+          style={!isMe ? {paddingBottom: bottomBarOffset} : undefined}
+        />
+        {isMe && <CreateAnother style={{paddingBottom: bottomBarOffset}} />}
+      </>
     )
   }, [
     data,

--- a/src/components/StarterPack/ProfileStarterPacks.tsx
+++ b/src/components/StarterPack/ProfileStarterPacks.tsx
@@ -168,9 +168,24 @@ export function ProfileStarterPacks({
       return <CreateAnother style={{paddingBottom: bottomBarOffset}} />
     }
     return (
-      <ListFooter style={{paddingBottom: bottomBarOffset, borderTopWidth: 0}} />
+      <ListFooter
+        isFetchingNextPage={isFetchingNextPage}
+        hasNextPage={hasNextPage}
+        error={isError ? 'Could not load more starter packs' : undefined}
+        onRetry={fetchNextPage}
+        style={{paddingBottom: bottomBarOffset}}
+      />
     )
-  }, [data, items?.length, isMe, bottomBarOffset])
+  }, [
+    data,
+    items?.length,
+    isMe,
+    bottomBarOffset,
+    isFetchingNextPage,
+    hasNextPage,
+    isError,
+    fetchNextPage,
+  ])
 
   return (
     <View testID={testID} style={style}>

--- a/src/components/StarterPack/ProfileStarterPacks.tsx
+++ b/src/components/StarterPack/ProfileStarterPacks.tsx
@@ -8,9 +8,7 @@ import {
   type ViewStyle,
 } from 'react-native'
 import {type AppBskyGraphDefs} from '@atproto/api'
-import {msg} from '@lingui/core/macro'
-import {useLingui} from '@lingui/react'
-import {Trans} from '@lingui/react/macro'
+import {Trans, useLingui} from '@lingui/react/macro'
 import {useNavigation} from '@react-navigation/native'
 
 import {useGenerateStarterPackMutation} from '#/lib/generate-starterpack'
@@ -91,7 +89,7 @@ export function ProfileStarterPacks({
   const {isTabletOrDesktop} = useWebMediaQueries()
 
   const items = data?.pages.flatMap(page => page.starterPacks)
-  const {_} = useLingui()
+  const {t: l} = useLingui()
 
   const EmptyComponent = useCallback(() => {
     if (emptyStateMessage || emptyStateButton || emptyStateIcon) {
@@ -102,9 +100,7 @@ export function ProfileStarterPacks({
             iconSize="3xl"
             message={
               emptyStateMessage ??
-              _(
-                msg`Starter packs let you share your favorite feeds and people with your friends.`,
-              )
+              l`Starter packs let you share your favorite feeds and people with your friends.`
             }
             button={emptyStateButton}
           />
@@ -112,7 +108,7 @@ export function ProfileStarterPacks({
       )
     }
     return <Empty />
-  }, [_, emptyStateMessage, emptyStateButton, emptyStateIcon])
+  }, [l, emptyStateMessage, emptyStateButton, emptyStateIcon])
 
   useImperativeHandle(ref, () => ({
     scrollToTop: () => {},
@@ -169,13 +165,13 @@ export function ProfileStarterPacks({
       <ListFooter
         isFetchingNextPage={isFetchingNextPage}
         hasNextPage={hasNextPage}
-        error={isError ? _(msg`Could not load more starter packs`) : undefined}
+        error={isError ? l`Could not load more starter packs` : undefined}
         onRetry={fetchNextPage}
         style={{paddingBottom: bottomBarOffset}}
       />
     )
   }, [
-    _,
+    l,
     data,
     items?.length,
     isMe,
@@ -214,7 +210,7 @@ export function ProfileStarterPacks({
 }
 
 function CreateAnother({style}: {style?: StyleProp<ViewStyle>}) {
-  const {_} = useLingui()
+  const {t: l} = useLingui()
   const t = useTheme()
   const navigation = useNavigation<NavigationProp>()
 
@@ -229,7 +225,7 @@ function CreateAnother({style}: {style?: StyleProp<ViewStyle>}) {
         style,
       ]}>
       <Button
-        label={_(msg`Create a starter pack`)}
+        label={l`Create a starter pack`}
         variant="solid"
         color="secondary"
         size="small"
@@ -245,7 +241,7 @@ function CreateAnother({style}: {style?: StyleProp<ViewStyle>}) {
 }
 
 function Empty() {
-  const {_} = useLingui()
+  const {t: l} = useLingui()
   const navigation = useNavigation<NavigationProp>()
   const confirmDialogControl = useDialogControl()
   const followersDialogControl = useDialogControl()
@@ -325,7 +321,7 @@ function Empty() {
       </View>
       <View style={[a.flex_row, a.gap_md, {marginLeft: 'auto'}]}>
         <Button
-          label={_(msg`Create a starter pack for me`)}
+          label={l`Create a starter pack for me`}
           variant="ghost"
           color="primary"
           size="small"
@@ -338,7 +334,7 @@ function Empty() {
           {isGenerating && <Loader size="md" />}
         </Button>
         <Button
-          label={_(msg`Create a starter pack`)}
+          label={l`Create a starter pack`}
           variant="ghost"
           color="primary"
           size="small"
@@ -355,7 +351,6 @@ function Empty() {
           </ButtonText>
         </Button>
       </View>
-
       <Prompt.Outer control={confirmDialogControl}>
         <Prompt.Content>
           <Prompt.TitleText>
@@ -371,12 +366,12 @@ function Empty() {
         <Prompt.Actions>
           <Prompt.Action
             color="primary"
-            cta={_(msg`Choose for me`)}
+            cta={l`Choose for me`}
             onPress={generate}
           />
           <Prompt.Action
             color="secondary"
-            cta={_(msg`Let me choose`)}
+            cta={l`Let me choose`}
             onPress={() => {
               navigation.navigate('StarterPackWizard', {})
             }}
@@ -385,21 +380,17 @@ function Empty() {
       </Prompt.Outer>
       <Prompt.Basic
         control={followersDialogControl}
-        title={_(msg`Oops!`)}
-        description={_(
-          msg`You must be following at least seven other people to generate a starter pack.`,
-        )}
+        title={l`Oops!`}
+        description={l`You must be following at least seven other people to generate a starter pack.`}
         onConfirm={() => {}}
         showCancel={false}
       />
       <Prompt.Basic
         control={errorDialogControl}
-        title={_(msg`Oops!`)}
-        description={_(
-          msg`An error occurred while generating your starter pack. Want to try again?`,
-        )}
+        title={l`Oops!`}
+        description={l`An error occurred while generating your starter pack. Want to try again?`}
         onConfirm={generate}
-        confirmButtonCta={_(msg`Retry`)}
+        confirmButtonCta={l`Retry`}
       />
     </LinearGradientBackground>
   )

--- a/src/components/StarterPack/ProfileStarterPacks.tsx
+++ b/src/components/StarterPack/ProfileStarterPacks.tsx
@@ -169,7 +169,7 @@ export function ProfileStarterPacks({
       <ListFooter
         isFetchingNextPage={isFetchingNextPage}
         hasNextPage={hasNextPage}
-        error={isError ? 'Could not load more starter packs' : undefined}
+        error={isError ? _(msg`Could not load more starter packs`) : undefined}
         onRetry={fetchNextPage}
         style={{paddingBottom: bottomBarOffset}}
       />

--- a/src/components/StarterPack/ProfileStarterPacks.tsx
+++ b/src/components/StarterPack/ProfileStarterPacks.tsx
@@ -159,6 +159,17 @@ export function ProfileStarterPacks({
     [isTabletOrDesktop, t.atoms.border_contrast_low],
   )
 
+  const renderFooter = useCallback(() => {
+    if (!data || items?.length === 0) {
+      return null
+    }
+    return (
+      <View style={[{paddingBottom: bottomBarOffset}]}>
+        {isMe && <CreateAnother />}
+      </View>
+    )
+  }, [data, items?.length, isMe, bottomBarOffset])
+
   return (
     <View testID={testID} style={style}>
       <List
@@ -172,7 +183,6 @@ export function ProfileStarterPacks({
         progressViewOffset={ios(0)}
         contentContainerStyle={{
           minHeight: height + headerOffset,
-          paddingBottom: bottomBarOffset,
         }}
         removeClippedSubviews={true}
         desktopFixedHeight
@@ -181,9 +191,7 @@ export function ProfileStarterPacks({
         ListEmptyComponent={
           data ? (isMe ? EmptyComponent : undefined) : FeedLoadingPlaceholder
         }
-        ListFooterComponent={
-          !!data && items?.length !== 0 && isMe ? CreateAnother : undefined
-        }
+        ListFooterComponent={renderFooter}
       />
     </View>
   )

--- a/src/components/StarterPack/ProfileStarterPacks.tsx
+++ b/src/components/StarterPack/ProfileStarterPacks.tsx
@@ -164,17 +164,18 @@ export function ProfileStarterPacks({
     if (!data || items?.length === 0) {
       return null
     }
+    // Show CreateAnother only at the end of the list on own profile
+    if (isMe && !hasNextPage && !isFetchingNextPage) {
+      return <CreateAnother style={{paddingBottom: bottomBarOffset}} />
+    }
     return (
-      <>
-        <ListFooter
-          isFetchingNextPage={isFetchingNextPage}
-          hasNextPage={hasNextPage}
-          error={isError ? 'Could not load more starter packs' : undefined}
-          onRetry={fetchNextPage}
-          style={!isMe ? {paddingBottom: bottomBarOffset} : undefined}
-        />
-        {isMe && <CreateAnother style={{paddingBottom: bottomBarOffset}} />}
-      </>
+      <ListFooter
+        isFetchingNextPage={isFetchingNextPage}
+        hasNextPage={hasNextPage}
+        error={isError ? 'Could not load more starter packs' : undefined}
+        onRetry={fetchNextPage}
+        style={{paddingBottom: bottomBarOffset}}
+      />
     )
   }, [
     data,

--- a/src/components/StarterPack/ProfileStarterPacks.tsx
+++ b/src/components/StarterPack/ProfileStarterPacks.tsx
@@ -32,6 +32,7 @@ import {Button, ButtonIcon, ButtonText} from '#/components/Button'
 import {useDialogControl} from '#/components/Dialog'
 import {PlusSmall_Stroke2_Corner0_Rounded as Plus} from '#/components/icons/Plus'
 import {LinearGradientBackground} from '#/components/LinearGradientBackground'
+import {ListFooter} from '#/components/Lists'
 import {Loader} from '#/components/Loader'
 import * as Prompt from '#/components/Prompt'
 import {Default as StarterPackCard} from '#/components/StarterPack/StarterPackCard'
@@ -163,10 +164,11 @@ export function ProfileStarterPacks({
     if (!data || items?.length === 0) {
       return null
     }
+    if (isMe) {
+      return <CreateAnother style={{paddingBottom: bottomBarOffset}} />
+    }
     return (
-      <View style={[{paddingBottom: bottomBarOffset}]}>
-        {isMe && <CreateAnother />}
-      </View>
+      <ListFooter style={{paddingBottom: bottomBarOffset, borderTopWidth: 0}} />
     )
   }, [data, items?.length, isMe, bottomBarOffset])
 
@@ -197,7 +199,7 @@ export function ProfileStarterPacks({
   )
 }
 
-function CreateAnother() {
+function CreateAnother({style}: {style?: StyleProp<ViewStyle>}) {
   const {_} = useLingui()
   const t = useTheme()
   const navigation = useNavigation<NavigationProp>()
@@ -210,6 +212,7 @@ function CreateAnother() {
         a.gap_lg,
         a.border_t,
         t.atoms.border_contrast_low,
+        style,
       ]}>
       <Button
         label={_(msg`Create a starter pack`)}

--- a/src/components/StarterPack/ProfileStarterPacks.tsx
+++ b/src/components/StarterPack/ProfileStarterPacks.tsx
@@ -161,11 +161,8 @@ export function ProfileStarterPacks({
   )
 
   const renderFooter = useCallback(() => {
-    if (!data || items?.length === 0) {
-      return null
-    }
     // Show CreateAnother only at the end of the list on own profile
-    if (isMe && !hasNextPage && !isFetchingNextPage) {
+    if (isMe && !hasNextPage && !isFetchingNextPage && data && items?.length) {
       return <CreateAnother style={{paddingBottom: bottomBarOffset}} />
     }
     return (


### PR DESCRIPTION
Add proper ListFooterComponent with bottom padding to ensure the last
starter pack item is always visible and scrollable. Previously, when
viewing someone else's profile, no footer was rendered, causing the
last item to be cut off - especially when starter packs had long
descriptions.

This follows the same pattern used in ProfilesList (fixed in #8039)
and FeedsList components.

Fixes #9296