### PR TITLE
Fix back button issue for Profiles on Web

### DIFF
--- a/src/Navigation.tsx
+++ b/src/Navigation.tsx
@@ -226,6 +226,7 @@ function commonScreens(Stack: typeof Flat, unreadCountLabel?: string) {
         options={({route}) => ({
           title: bskyTitle(`@${route.params.name}`, unreadCountLabel),
         })}
+        getId={({params}) => params.name}
       />
       <Stack.Screen
         name="ProfileFollowers"


### PR DESCRIPTION
This fixes https://github.com/bluesky-social/social-app/issues/6619 where on Web, in certain scenarios pressing the browser back button would not bring you back to the profile you were previously at, giving an unexpected user experience.

## Where it works correctly

Within the main feed, clicking on profiles will create a new "Profile" within react-navigation for that user, and clicking back, will pop those out of the states and work as expected.

https://github.com/user-attachments/assets/06b122e7-e631-4792-b739-21b1db1bb9a6

## Where it doesn't work

On the LeftNav, clicking "Profile" results in overwriting the "Profile", so that clicking back, the screen no longer exists.

https://github.com/user-attachments/assets/83e24be9-bdae-430c-90ca-df508e2895e5

There's other weird issues related to this like visiting a profile, visiting another profile through the feed, clicking "Profile", and then clicking back.

## The fix

What this change does is use the `params.name` attribute for the `Stack.Screen` `getId` attribute.  The profile username is unique, so as far as I'm aware and tested, I think is acceptable as a solution.  Clicking profile creates a new Profile state like what we see clicking a profile in the main feed area.

https://github.com/user-attachments/assets/f8c0118e-9cd0-4009-afff-aa82dac24592

Tested on
- Brave 1.85.118 Chromium: 143.0.7499.169
- iPhone 17 (simulator)
- Firefox 147.0.1

I've not added any tests as I'm not entirely sure the expectations.