### PR TITLE
Add 2px margin below post text

### DIFF
--- a/src/screens/PostThread/components/ThreadItemPost.tsx
+++ b/src/screens/PostThread/components/ThreadItemPost.tsx
@@ -302,7 +302,7 @@ const ThreadItemPostInner = memo(function ThreadItemPostInner({
                 additionalCauses={additionalPostAlerts}
               />
               {richText?.text ? (
-                <>
+                <View style={[a.mb_2xs]}>
                   <RichText
                     enableTags
                     value={richText}
@@ -317,7 +317,7 @@ const ThreadItemPostInner = memo(function ThreadItemPostInner({
                       onPress={onPressShowMore}
                     />
                   )}
-                </>
+                </View>
               ) : undefined}
               {post.embed && (
                 <View style={[a.pb_xs]}>

--- a/src/screens/PostThread/components/ThreadItemTreePost.tsx
+++ b/src/screens/PostThread/components/ThreadItemTreePost.tsx
@@ -342,7 +342,7 @@ const ThreadItemTreePostInner = memo(function ThreadItemTreePostInner({
                     additionalCauses={additionalPostAlerts}
                   />
                   {richText?.text ? (
-                    <>
+                    <View style={[a.mb_2xs]}>
                       <RichText
                         enableTags
                         value={richText}
@@ -357,7 +357,7 @@ const ThreadItemTreePostInner = memo(function ThreadItemTreePostInner({
                           onPress={onPressShowMore}
                         />
                       )}
-                    </>
+                    </View>
                   ) : null}
                   {post.embed && (
                     <View style={[a.pb_xs]}>

--- a/src/view/com/post/Post.tsx
+++ b/src/view/com/post/Post.tsx
@@ -198,7 +198,7 @@ function PostInner({
               style={[a.pb_xs]}
             />
             {richText.text ? (
-              <View>
+              <View style={[a.mb_2xs]}>
                 <RichText
                   enableTags
                   testID="postText"

--- a/src/view/com/posts/PostFeedItem.tsx
+++ b/src/view/com/posts/PostFeedItem.tsx
@@ -465,7 +465,7 @@ let PostContent = ({
         additionalCauses={additionalPostAlerts}
       />
       {richText.text ? (
-        <>
+        <View style={[a.mb_2xs]}>
           <RichText
             enableTags
             testID="postText"
@@ -478,7 +478,7 @@ let PostContent = ({
           {limitLines && (
             <ShowMoreTextButton style={[a.text_md]} onPress={onPressShowMore} />
           )}
-        </>
+        </View>
       ) : undefined}
       {postEmbed ? (
         <View style={[a.pb_xs]}>


### PR DESCRIPTION
Gives the text a bit more space to breathe, while keeping the post controls <-> embed spacing the same (as I think that one is fine)

<img width="400" alt="Screenshot 2026-01-25 at 16 37 44" src="https://github.com/user-attachments/assets/e1a0f910-0d0e-4034-8508-16024846c9f0" />
<img width="400" alt="Screenshot 2026-01-25 at 16 39 20" src="https://github.com/user-attachments/assets/470adb1b-d639-4d36-a9c6-2e07b3d3e9a1" />
