### PR TITLE
Sync autoplay preference between local storage and server

### DIFF
--- a/src/state/preferences/autoplay.tsx
+++ b/src/state/preferences/autoplay.tsx
@@ -1,6 +1,11 @@
 import React from 'react'
 
 import * as persisted from '#/state/persisted'
+import {
+  usePreferencesQuery,
+  useSetAutoplayDisabledMutation,
+} from '#/state/queries/preferences'
+import {useSession} from '#/state/session'
 
 type StateContext = boolean
 type SetContext = (v: boolean) => void
@@ -13,23 +18,80 @@ const setContext = React.createContext<SetContext>((_: boolean) => {})
 setContext.displayName = 'AutoplaySetContext'
 
 export function Provider({children}: {children: React.ReactNode}) {
-  const [state, setState] = React.useState(
-    Boolean(persisted.get('disableAutoplay')),
-  )
+  const {hasSession} = useSession()
+  const {data: preferences, isSuccess: prefsLoaded} = usePreferencesQuery()
+  const {mutate: setServerAutoplayDisabled} = useSetAutoplayDisabledMutation()
+
+  // Get server preference (undefined if not set or not logged in)
+  const serverAutoplayDisabled = preferences?.bskyAppState?.autoplayDisabled
+
+  // Get local preference
+  const localAutoplayDisabled = Boolean(persisted.get('disableAutoplay'))
+
+  // Determine the effective state:
+  // - If logged in and server has a value, use server value
+  // - Otherwise use local storage value
+  const effectiveState = React.useMemo(() => {
+    if (hasSession && prefsLoaded && serverAutoplayDisabled !== undefined) {
+      return serverAutoplayDisabled
+    }
+    return localAutoplayDisabled
+  }, [hasSession, prefsLoaded, serverAutoplayDisabled, localAutoplayDisabled])
+
+  const [state, setState] = React.useState(effectiveState)
+
+  // Sync state when effective state changes
+  React.useEffect(() => {
+    setState(effectiveState)
+  }, [effectiveState])
+
+  // Migration: When user logs in and server has no value, migrate local preference to server
+  const hasMigrated = React.useRef(false)
+  React.useEffect(() => {
+    if (
+      hasSession &&
+      prefsLoaded &&
+      serverAutoplayDisabled === undefined &&
+      !hasMigrated.current
+    ) {
+      hasMigrated.current = true
+      // Migrate local preference to server
+      if (localAutoplayDisabled !== persisted.defaults.disableAutoplay) {
+        setServerAutoplayDisabled({autoplayDisabled: localAutoplayDisabled})
+      }
+    }
+  }, [
+    hasSession,
+    prefsLoaded,
+    serverAutoplayDisabled,
+    localAutoplayDisabled,
+    setServerAutoplayDisabled,
+  ])
 
   const setStateWrapped = React.useCallback(
-    (autoplayDisabled: persisted.Schema['disableAutoplay']) => {
-      setState(Boolean(autoplayDisabled))
+    (autoplayDisabled: boolean) => {
+      setState(autoplayDisabled)
+
+      // Always write to local storage (for offline/logged-out support)
       persisted.write('disableAutoplay', autoplayDisabled)
+
+      // If logged in, also sync to server
+      if (hasSession) {
+        setServerAutoplayDisabled({autoplayDisabled})
+      }
     },
-    [setState],
+    [hasSession, setServerAutoplayDisabled],
   )
 
+  // Listen for local storage updates (e.g., from other tabs on web)
   React.useEffect(() => {
     return persisted.onUpdate('disableAutoplay', nextDisableAutoplay => {
-      setState(Boolean(nextDisableAutoplay))
+      // Only update from local storage if we're not using server prefs
+      if (!hasSession || serverAutoplayDisabled === undefined) {
+        setState(Boolean(nextDisableAutoplay))
+      }
     })
-  }, [setStateWrapped])
+  }, [hasSession, serverAutoplayDisabled])
 
   return (
     <stateContext.Provider value={state}>

--- a/src/state/queries/preferences/const.ts
+++ b/src/state/queries/preferences/const.ts
@@ -37,6 +37,7 @@ export const DEFAULT_LOGGED_OUT_PREFERENCES: UsePreferencesQueryResponse = {
     queuedNudges: [],
     activeProgressGuide: undefined,
     nuxs: [],
+    autoplayDisabled: undefined,
   },
   postInteractionSettings: {
     threadgateAllowRules: undefined,

--- a/src/state/queries/preferences/types.ts
+++ b/src/state/queries/preferences/types.ts
@@ -2,7 +2,7 @@ import {type BskyFeedViewPreference, type BskyPreferences} from '@atproto/api'
 
 export type UsePreferencesQueryResponse = Omit<
   BskyPreferences,
-  'contentLabels' | 'feedViewPrefs' | 'feeds'
+  'contentLabels' | 'feedViewPrefs' | 'feeds' | 'bskyAppState'
 > & {
   feedViewPrefs: BskyFeedViewPreference & {
     lab_mergeFeedEnabled?: boolean
@@ -12,6 +12,12 @@ export type UsePreferencesQueryResponse = Omit<
    */
   threadViewPrefs: ThreadViewPreferences
   userAge: number | undefined
+  /**
+   * App-specific state, extended to include autoplay preference
+   */
+  bskyAppState: BskyPreferences['bskyAppState'] & {
+    autoplayDisabled?: boolean
+  }
 }
 
 export type ThreadViewPreferences = {


### PR DESCRIPTION
## Summary
This PR adds server-side persistence for the autoplay preference, allowing it to sync across devices when a user is logged in, while maintaining local storage as a fallback for offline and logged-out users.

## Key Changes
- **Autoplay preference syncing**: Modified `src/state/preferences/autoplay.tsx` to:
  - Query server preferences via `usePreferencesQuery()`
  - Sync preference changes to server via new `useSetAutoplayDisabledMutation()`
  - Determine effective state: server preference takes priority when logged in, otherwise use local storage
  - Automatically migrate local preference to server when user logs in (one-time migration)
  - Listen for local storage updates from other tabs/windows

- **New mutation**: Added `useSetAutoplayDisabledMutation()` in `src/state/queries/preferences/index.ts` to:
  - Fetch current preferences from server
  - Update or create `bskyAppStatePref` with autoplay setting
  - Save preferences back to server
  - Log metrics for analytics
  - Invalidate preferences cache to trigger refetch

- **Type updates**: Extended preference types in `src/state/queries/preferences/types.ts` to include `autoplayDisabled` in `bskyAppState`

- **Default preferences**: Added `autoplayDisabled: undefined` to logged-out defaults in `src/state/queries/preferences/const.ts`

## Implementation Details
- Uses a `hasMigrated` ref to ensure one-time migration of local preferences to server
- Respects session state: only syncs to server when `hasSession` is true
- Maintains backward compatibility with local storage for offline support
- Properly handles the case where server preference is undefined (not yet set)