### PR TITLE
[Lightbox perf 2] Prevent lightbox initial jitter

### DIFF
--- a/src/view/com/lightbox/ImageViewing/index.tsx
+++ b/src/view/com/lightbox/ImageViewing/index.tsx
@@ -9,7 +9,13 @@
 // https://github.com/jobtoday/react-native-image-viewing
 
 import React, {useCallback, useEffect, useMemo, useState} from 'react'
-import {LayoutAnimation, PixelRatio, StyleSheet, View} from 'react-native'
+import {
+  LayoutAnimation,
+  PixelRatio,
+  StyleSheet,
+  useWindowDimensions,
+  View,
+} from 'react-native'
 import {SystemBars} from 'react-native-edge-to-edge'
 import {Gesture} from 'react-native-gesture-handler'
 import PagerView from 'react-native-pager-view'
@@ -30,11 +36,7 @@ import Animated, {
   withSpring,
   type WithSpringConfig,
 } from 'react-native-reanimated'
-import {
-  SafeAreaView,
-  useSafeAreaFrame,
-  useSafeAreaInsets,
-} from 'react-native-safe-area-context'
+import {SafeAreaView} from 'react-native-safe-area-context'
 import * as ScreenOrientation from 'expo-screen-orientation'
 import {FontAwesomeIcon} from '@fortawesome/react-native-fontawesome'
 import {Trans} from '@lingui/macro'
@@ -427,8 +429,10 @@ function LightboxImage({
     }
   }
 
-  const safeFrameDelayedForJSThreadOnly = useSafeAreaFrame()
-  const safeInsetsDelayedForJSThreadOnly = useSafeAreaInsets()
+  const {
+    width: widthDelayedForJSThreadOnly,
+    height: heightDelayedForJSThreadOnly,
+  } = useWindowDimensions()
   const measureSafeArea = React.useCallback(() => {
     'worklet'
     let safeArea: Rect | null = measure(safeAreaRef)
@@ -436,21 +440,15 @@ function LightboxImage({
       if (_WORKLET) {
         console.error('Expected to always be able to measure safe area.')
       }
-      const frame = safeFrameDelayedForJSThreadOnly
-      const insets = safeInsetsDelayedForJSThreadOnly
       safeArea = {
-        x: frame.x + insets.left,
-        y: frame.y + insets.top,
-        width: frame.width - insets.left - insets.right,
-        height: frame.height - insets.top - insets.bottom,
+        x: 0,
+        y: 0,
+        width: widthDelayedForJSThreadOnly,
+        height: heightDelayedForJSThreadOnly,
       }
     }
     return safeArea
-  }, [
-    safeFrameDelayedForJSThreadOnly,
-    safeInsetsDelayedForJSThreadOnly,
-    safeAreaRef,
-  ])
+  }, [safeAreaRef, heightDelayedForJSThreadOnly, widthDelayedForJSThreadOnly])
 
   const {thumbRect} = imageSrc
   const transforms = useDerivedValue(() => {


### PR DESCRIPTION
There's a jitter when the lightbox initially opens

https://github.com/user-attachments/assets/5891bfbc-c392-474b-9f1c-5d6f8b8f7aff

This is because when an animated style initially renders, it runs on the JS thread, and so we had custom logic to estimate the safe area frame that it would be animating to.

However! Since enabling edge-to-edge mode, we removed the safe area logic, and thus this holdover is now incorrect. The fix is to change it to just be the window size, rather than accounting for the insets.

Note that this is the minimal possible change I could make to fix this, I really don't want to do any deeper reworking as it's all a bit of a house of cards. Maybe one day...

## Test plan

If you can repro the jitter (I can see it in the simulator more than a real device), confirm this fixes it

I added logging and confirm the JS thread size and the UI thread size do indeed match