### PR TITLE
Compact quote post display for media-on-media quotes

### DIFF
--- a/src/components/Post/Embed/LazyQuoteEmbed.tsx
+++ b/src/components/Post/Embed/LazyQuoteEmbed.tsx
@@ -4,9 +4,17 @@ import {View} from 'react-native'
 import {createEmbedViewRecordFromPost} from '#/state/queries/postgate/util'
 import {useResolveLinkQuery} from '#/state/queries/resolve-link'
 import {atoms as a, useTheme} from '#/alf'
-import {QuoteEmbed} from '#/components/Post/Embed'
+import {QuoteEmbed, QuoteEmbedViewContext} from '#/components/Post/Embed'
+import {embedHasMedia} from '#/components/Post/Embed/util'
+import {parseEmbed} from '#/types/bsky/post'
 
-export function LazyQuoteEmbed({uri}: {uri: string}) {
+export function LazyQuoteEmbed({
+  uri,
+  parentHasMedia,
+}: {
+  uri: string
+  parentHasMedia?: boolean
+}) {
   const t = useTheme()
   const {data} = useResolveLinkQuery(uri)
 
@@ -15,12 +23,25 @@ export function LazyQuoteEmbed({uri}: {uri: string}) {
     return createEmbedViewRecordFromPost(data.view)
   }, [data])
 
+  // Determine if we should use compact layout
+  const viewContext = useMemo(() => {
+    if (!parentHasMedia || !view) return undefined
+    const quotedEmbed = view.embeds?.[0]
+      ? parseEmbed(view.embeds[0])
+      : undefined
+    if (embedHasMedia(quotedEmbed)) {
+      return QuoteEmbedViewContext.CompactWithMedia
+    }
+    return undefined
+  }, [parentHasMedia, view])
+
   return view ? (
     <QuoteEmbed
       embed={{
         type: 'post',
         view,
       }}
+      viewContext={viewContext}
     />
   ) : (
     <View

--- a/src/components/Post/Embed/index.tsx
+++ b/src/components/Post/Embed/index.tsx
@@ -1,5 +1,6 @@
 import {useCallback, useMemo} from 'react'
 import {View} from 'react-native'
+import {Image} from 'expo-image'
 import {
   type $Typed,
   type AppBskyFeedDefs,
@@ -8,10 +9,12 @@ import {
   moderatePost,
   RichText as RichTextAPI,
 } from '@atproto/api'
-import {Trans} from '@lingui/macro'
+import {msg, Trans} from '@lingui/macro'
+import {useLingui} from '@lingui/react'
 import {useQueryClient} from '@tanstack/react-query'
 
 import {makeProfileLink} from '#/lib/routes/links'
+import {parseEmbedPlayerFromUrl} from '#/lib/strings/embed-player'
 import {useModerationOpts} from '#/state/preferences/moderation-opts'
 import {unstableCacheProfileView} from '#/state/queries/profile'
 import {useSession} from '#/state/session'
@@ -19,11 +22,13 @@ import {Link} from '#/view/com/util/Link'
 import {PostMeta} from '#/view/com/util/PostMeta'
 import {atoms as a, useTheme} from '#/alf'
 import {useInteractionState} from '#/components/hooks/useInteractionState'
+import {MediaInsetBorder} from '#/components/MediaInsetBorder'
 import {ContentHider} from '#/components/moderation/ContentHider'
 import {PostAlerts} from '#/components/moderation/PostAlerts'
 import {RichText} from '#/components/RichText'
 import {Embed as StarterPackCard} from '#/components/StarterPack/StarterPackCard'
 import {SubtleHover} from '#/components/SubtleHover'
+import {Text} from '#/components/Typography'
 import * as bsky from '#/types/bsky'
 import {
   type Embed as TEmbed,
@@ -44,6 +49,177 @@ import {
 import {VideoEmbed} from './VideoEmbed'
 
 export {PostEmbedViewContext, QuoteEmbedViewContext} from './types'
+export {embedHasMedia} from './util'
+
+import {embedHasMedia} from './util'
+
+type CompactMediaInfo = {
+  type: 'image' | 'video' | 'gif'
+  thumbnails: Array<{uri: string; alt?: string}>
+}
+
+/**
+ * Extract compact media info from an embed for thumbnail display
+ */
+function extractCompactMedia(embed: TEmbed | null): CompactMediaInfo | null {
+  if (!embed) return null
+
+  switch (embed.type) {
+    case 'images': {
+      const images = embed.view.images
+      if (!images.length) return null
+      return {
+        type: 'image',
+        thumbnails: images
+          .slice(0, 4)
+          .map(img => ({uri: img.thumb, alt: img.alt})),
+      }
+    }
+    case 'video': {
+      if (!embed.view.thumbnail) return null
+      return {
+        type: 'video',
+        thumbnails: [{uri: embed.view.thumbnail, alt: embed.view.alt}],
+      }
+    }
+    case 'link': {
+      const player = parseEmbedPlayerFromUrl(embed.view.external.uri)
+      if (player?.isGif && embed.view.external.thumb) {
+        return {
+          type: 'gif',
+          thumbnails: [
+            {uri: embed.view.external.thumb, alt: embed.view.external.title},
+          ],
+        }
+      }
+      return null
+    }
+    case 'post_with_media':
+      return extractCompactMedia(embed.media)
+    default:
+      return null
+  }
+}
+
+/**
+ * Renders compact media thumbnails in a grid layout
+ * - 1 image: full size
+ * - 2 images: side by side
+ * - 3 images: 1st on left half, 2nd and 3rd stacked on right half
+ * - 4 images: 2x2 grid
+ */
+function CompactMediaThumbnails({
+  media,
+  accessibilityHint,
+}: {
+  media: CompactMediaInfo
+  accessibilityHint: string
+}) {
+  const {thumbnails} = media
+  const count = thumbnails.length
+  const gap = 2
+
+  if (count === 1) {
+    return (
+      <Image
+        source={{uri: thumbnails[0].uri}}
+        style={[a.w_full, a.h_full]}
+        contentFit="cover"
+        accessibilityLabel={thumbnails[0].alt || ''}
+        accessibilityHint={accessibilityHint}
+      />
+    )
+  }
+
+  if (count === 2) {
+    return (
+      <View style={[a.flex_row, a.w_full, a.h_full]}>
+        <Image
+          source={{uri: thumbnails[0].uri}}
+          style={[{width: '50%'}, a.h_full, {marginRight: gap / 2}]}
+          contentFit="cover"
+          accessibilityLabel={thumbnails[0].alt || ''}
+          accessibilityHint={accessibilityHint}
+        />
+        <Image
+          source={{uri: thumbnails[1].uri}}
+          style={[{width: '50%'}, a.h_full, {marginLeft: gap / 2}]}
+          contentFit="cover"
+          accessibilityLabel={thumbnails[1].alt || ''}
+          accessibilityHint={accessibilityHint}
+        />
+      </View>
+    )
+  }
+
+  if (count === 3) {
+    return (
+      <View style={[a.flex_row, a.w_full, a.h_full]}>
+        <Image
+          source={{uri: thumbnails[0].uri}}
+          style={[{width: '50%'}, a.h_full, {marginRight: gap / 2}]}
+          contentFit="cover"
+          accessibilityLabel={thumbnails[0].alt || ''}
+          accessibilityHint={accessibilityHint}
+        />
+        <View style={[{width: '50%'}, a.h_full, {marginLeft: gap / 2}]}>
+          <Image
+            source={{uri: thumbnails[1].uri}}
+            style={[a.w_full, {height: '50%'}, {marginBottom: gap / 2}]}
+            contentFit="cover"
+            accessibilityLabel={thumbnails[1].alt || ''}
+            accessibilityHint={accessibilityHint}
+          />
+          <Image
+            source={{uri: thumbnails[2].uri}}
+            style={[a.w_full, {height: '50%'}, {marginTop: gap / 2}]}
+            contentFit="cover"
+            accessibilityLabel={thumbnails[2].alt || ''}
+            accessibilityHint={accessibilityHint}
+          />
+        </View>
+      </View>
+    )
+  }
+
+  // 4 images: 2x2 grid
+  return (
+    <View style={[a.w_full, a.h_full]}>
+      <View style={[a.flex_row, {height: '50%'}, {marginBottom: gap / 2}]}>
+        <Image
+          source={{uri: thumbnails[0].uri}}
+          style={[{width: '50%'}, a.h_full, {marginRight: gap / 2}]}
+          contentFit="cover"
+          accessibilityLabel={thumbnails[0].alt || ''}
+          accessibilityHint={accessibilityHint}
+        />
+        <Image
+          source={{uri: thumbnails[1].uri}}
+          style={[{width: '50%'}, a.h_full, {marginLeft: gap / 2}]}
+          contentFit="cover"
+          accessibilityLabel={thumbnails[1].alt || ''}
+          accessibilityHint={accessibilityHint}
+        />
+      </View>
+      <View style={[a.flex_row, {height: '50%'}, {marginTop: gap / 2}]}>
+        <Image
+          source={{uri: thumbnails[2].uri}}
+          style={[{width: '50%'}, a.h_full, {marginRight: gap / 2}]}
+          contentFit="cover"
+          accessibilityLabel={thumbnails[2].alt || ''}
+          accessibilityHint={accessibilityHint}
+        />
+        <Image
+          source={{uri: thumbnails[3].uri}}
+          style={[{width: '50%'}, a.h_full, {marginLeft: gap / 2}]}
+          contentFit="cover"
+          accessibilityLabel={thumbnails[3].alt || ''}
+          accessibilityHint={accessibilityHint}
+        />
+      </View>
+    </View>
+  )
+}
 
 export function Embed({embed: rawEmbed, ...rest}: EmbedProps) {
   const embed = parseEmbed(rawEmbed)
@@ -68,7 +244,7 @@ export function Embed({embed: rawEmbed, ...rest}: EmbedProps) {
       return (
         <View style={rest.style}>
           <MediaEmbed embed={embed.media} {...rest} />
-          <RecordEmbed embed={embed.view} {...rest} />
+          <RecordEmbed embed={embed.view} {...rest} parentHasMedia />
         </View>
       )
     }
@@ -124,9 +300,11 @@ function MediaEmbed({
 
 function RecordEmbed({
   embed,
+  parentHasMedia,
   ...rest
 }: CommonProps & {
   embed: TEmbed
+  parentHasMedia?: boolean
 }) {
   switch (embed.type) {
     case 'feed': {
@@ -159,14 +337,27 @@ function RecordEmbed({
         return null
       }
 
+      // Determine the view context for the quote embed
+      // Use compact layout when: parent has media AND quoted post has media AND we're in feed view
+      const quotedPostEmbed = embed.view.embeds?.[0]
+        ? parseEmbed(embed.view.embeds[0])
+        : undefined
+      const quotedPostHasMedia = embedHasMedia(quotedPostEmbed)
+      const shouldUseCompact =
+        parentHasMedia &&
+        quotedPostHasMedia &&
+        rest.viewContext === PostEmbedViewContext.Feed
+
       return (
         <QuoteEmbed
           {...rest}
           embed={embed}
           viewContext={
-            rest.viewContext === PostEmbedViewContext.Feed
-              ? QuoteEmbedViewContext.FeedEmbedRecordWithMedia
-              : undefined
+            shouldUseCompact
+              ? QuoteEmbedViewContext.CompactWithMedia
+              : rest.viewContext === PostEmbedViewContext.Feed
+                ? QuoteEmbedViewContext.FeedEmbedRecordWithMedia
+                : undefined
           }
           isWithinQuote={rest.isWithinQuote}
           allowNestedQuotes={rest.allowNestedQuotes}
@@ -225,12 +416,14 @@ export function QuoteEmbed({
   embed,
   onOpen,
   style,
+  viewContext,
   isWithinQuote: parentIsWithinQuote,
   allowNestedQuotes: parentAllowNestedQuotes,
 }: Omit<CommonProps, 'viewContext'> & {
   embed: EmbedType<'post'>
   viewContext?: QuoteEmbedViewContext
 }) {
+  const {_} = useLingui()
   const moderationOpts = useModerationOpts()
   const quote = useMemo<$Typed<AppBskyFeedDefs.PostView>>(
     () => ({
@@ -280,6 +473,142 @@ export function QuoteEmbed({
     onIn: onPressIn,
     onOut: onPressOut,
   } = useInteractionState()
+
+  // Extract compact media info if we're in compact mode
+  const parsedEmbed = quote.embed ? parseEmbed(quote.embed) : null
+  const compactMedia =
+    viewContext === QuoteEmbedViewContext.CompactWithMedia
+      ? extractCompactMedia(parsedEmbed)
+      : null
+
+  // Use compact layout when in compact mode and we have media to show
+  if (viewContext === QuoteEmbedViewContext.CompactWithMedia && compactMedia) {
+    return (
+      <View
+        style={[a.mt_sm]}
+        onPointerEnter={onPointerEnter}
+        onPointerLeave={onPointerLeave}>
+        <ContentHider
+          modui={moderation?.ui('contentList')}
+          style={[a.rounded_md, a.border, t.atoms.border_contrast_low, style]}
+          activeStyle={[a.p_md, a.pt_sm]}
+          childContainerStyle={[a.pt_sm]}>
+          {({active}) => (
+            <>
+              {!active && (
+                <SubtleHover
+                  native
+                  hover={hover || pressed}
+                  style={[a.rounded_md]}
+                />
+              )}
+              <Link
+                style={[!active && a.p_md]}
+                hoverStyle={t.atoms.border_contrast_high}
+                href={itemHref}
+                title={itemTitle}
+                onBeforePress={onBeforePress}
+                onPressIn={onPressIn}
+                onPressOut={onPressOut}>
+                <View pointerEvents="none">
+                  {/* User info on top like normal */}
+                  <PostMeta
+                    author={quote.author}
+                    moderation={moderation}
+                    showAvatar
+                    postHref={itemHref}
+                    timestamp={quote.indexedAt}
+                  />
+                  {moderation ? (
+                    <PostAlerts
+                      modui={moderation.ui('contentView')}
+                      style={[a.py_xs]}
+                    />
+                  ) : null}
+                  {/* Thumbnail and text side by side */}
+                  <View style={[a.flex_row, a.gap_md, a.mt_xs]}>
+                    {/* Thumbnail(s) on the left */}
+                    <View
+                      style={[
+                        a.rounded_sm,
+                        a.overflow_hidden,
+                        {width: 98, height: 98},
+                      ]}>
+                      <CompactMediaThumbnails
+                        media={compactMedia}
+                        accessibilityHint={_(
+                          msg`Thumbnail of quoted post media`,
+                        )}
+                      />
+                      <MediaInsetBorder style={[a.rounded_sm]} />
+                      {/* Video or GIF label overlay */}
+                      {compactMedia.type === 'video' && (
+                        <View
+                          style={[
+                            a.absolute,
+                            {
+                              left: 4,
+                              bottom: 4,
+                              backgroundColor: 'rgba(0, 0, 0, 0.6)',
+                              borderRadius: 4,
+                              paddingHorizontal: 4,
+                              paddingVertical: 2,
+                            },
+                          ]}>
+                          <Text
+                            style={[
+                              {color: t.palette.white, fontSize: 9},
+                              a.font_bold,
+                            ]}>
+                            ▶
+                          </Text>
+                        </View>
+                      )}
+                      {compactMedia.type === 'gif' && (
+                        <View
+                          style={[
+                            a.absolute,
+                            {
+                              left: 4,
+                              bottom: 4,
+                              backgroundColor: 'rgba(0, 0, 0, 0.6)',
+                              borderRadius: 4,
+                              paddingHorizontal: 4,
+                              paddingVertical: 2,
+                            },
+                          ]}>
+                          <Text
+                            style={[
+                              {color: t.palette.white, fontSize: 9},
+                              a.font_bold,
+                            ]}>
+                            GIF
+                          </Text>
+                        </View>
+                      )}
+                    </View>
+                    {/* Text content on the right */}
+                    <View style={[a.flex_1, {maxHeight: 98}]}>
+                      {richText ? (
+                        <RichText
+                          value={richText}
+                          style={a.text_md}
+                          numberOfLines={4}
+                          disableLinks
+                        />
+                      ) : null}
+                    </View>
+                  </View>
+                </View>
+              </Link>
+            </>
+          )}
+        </ContentHider>
+      </View>
+    )
+  }
+
+  // Normal vertical layout
   return (
     <View
       style={[a.mt_sm]}

--- a/src/components/Post/Embed/types.ts
+++ b/src/components/Post/Embed/types.ts
@@ -9,6 +9,7 @@ export enum PostEmbedViewContext {
 
 export enum QuoteEmbedViewContext {
   FeedEmbedRecordWithMedia = PostEmbedViewContext.FeedEmbedRecordWithMedia,
+  CompactWithMedia = 'CompactWithMedia',
 }
 
 export type CommonProps = {

--- a/src/components/Post/Embed/util.ts
+++ b/src/components/Post/Embed/util.ts
@@ -1,0 +1,16 @@
+import {parseEmbedPlayerFromUrl} from '#/lib/strings/embed-player'
+import {type Embed as TEmbed} from '#/types/bsky/post'
+
+/**
+ * Check if an embed contains media (images, video, or GIF)
+ */
+export function embedHasMedia(embed: TEmbed | undefined): boolean {
+  if (!embed) return false
+  return (
+    embed.type === 'images' ||
+    embed.type === 'video' ||
+    (embed.type === 'link' &&
+      !!parseEmbedPlayerFromUrl(embed.view.external.uri)?.isGif) ||
+    (embed.type === 'post_with_media' && embedHasMedia(embed.media))
+  )
+}

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -1246,7 +1246,10 @@ function ComposerEmbeds({
           style={[a.pb_sm, video ? [a.pt_md] : [a.pt_xl], IS_WEB && [a.pb_md]]}>
           <View style={[a.relative]}>
             <View style={{pointerEvents: 'none'}}>
-              <LazyQuoteEmbed uri={embed.quote.uri} />
+              <LazyQuoteEmbed
+                uri={embed.quote.uri}
+                parentHasMedia={!!embed.media}
+              />
             </View>
             {canRemoveQuote && (
               <ExternalEmbedRemoveBtn


### PR DESCRIPTION
Adds Twitter-style compact view for quoted posts when both inner and outer posts have media attached.

<img width="600" height="793" alt="quote1" src="https://github.com/user-attachments/assets/c1e559a4-8974-4de8-aaea-063e0c7da3c6" />

-----------------------
Also functions in the post composer:

<img width="662" height="781" alt="quote2" src="https://github.com/user-attachments/assets/49ab1150-91b6-4ea9-a6e1-9c6e104775c8" />


