### PR TITLE
✨ Oxlint 

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,0 +1,349 @@
+{
+  "$schema": "./node_modules/oxlint/configuration_schema.json",
+  "plugins": [
+    "typescript",
+    "react",
+    "import"
+  ],
+  "categories": {
+    "correctness": "off"
+  },
+  "env": {
+    "builtin": true
+  },
+  "ignorePatterns": [
+    "**/__mocks__/*.ts",
+    "src/platform/polyfills.ts",
+    "src/third-party/**",
+    "ios/**",
+    "android/**",
+    "coverage/**",
+    "*.lock",
+    ".husky/**",
+    "patches/**",
+    "*.html",
+    "bskyweb/**",
+    "bskyembed/**",
+    "src/locale/locales/_build/**",
+    "src/locale/locales/**/*.js",
+    "*.e2e.ts",
+    "*.e2e.tsx",
+    "eslint.config.mjs"
+  ],
+  "rules": {
+    "constructor-super": "error",
+    "for-direction": "error",
+    "no-async-promise-executor": "error",
+    "no-case-declarations": "error",
+    "no-class-assign": "error",
+    "no-compare-neg-zero": "error",
+    "no-cond-assign": "error",
+    "no-const-assign": "error",
+    "no-constant-binary-expression": "error",
+    "no-constant-condition": "error",
+    "no-control-regex": "error",
+    "no-debugger": "error",
+    "no-delete-var": "error",
+    "no-dupe-class-members": "error",
+    "no-dupe-else-if": "error",
+    "no-dupe-keys": "error",
+    "no-duplicate-case": "error",
+    "no-empty": "error",
+    "no-empty-character-class": "error",
+    "no-empty-pattern": "error",
+    "no-empty-static-block": "error",
+    "no-ex-assign": "error",
+    "no-extra-boolean-cast": "error",
+    "no-fallthrough": "error",
+    "no-func-assign": "error",
+    "no-global-assign": "error",
+    "no-import-assign": "error",
+    "no-invalid-regexp": "error",
+    "no-irregular-whitespace": "error",
+    "no-loss-of-precision": "error",
+    "no-new-native-nonconstructor": "error",
+    "no-nonoctal-decimal-escape": "error",
+    "no-obj-calls": "error",
+    "no-prototype-builtins": "error",
+    "no-redeclare": "error",
+    "no-regex-spaces": "error",
+    "no-self-assign": "error",
+    "no-setter-return": "error",
+    "no-shadow-restricted-names": "error",
+    "no-sparse-arrays": "error",
+    "no-this-before-super": "error",
+    "no-unexpected-multiline": "error",
+    "no-unsafe-finally": "error",
+    "no-unsafe-negation": "error",
+    "no-unsafe-optional-chaining": "error",
+    "no-unused-labels": "error",
+    "no-unused-private-class-members": "error",
+    "no-unused-vars": "error",
+    "no-useless-backreference": "error",
+    "no-useless-catch": "error",
+    "no-useless-escape": "error",
+    "no-with": "error",
+    "require-yield": "error",
+    "use-isnan": "error",
+    "valid-typeof": "error",
+    "@typescript-eslint/await-thenable": "error",
+    "@typescript-eslint/ban-ts-comment": "error",
+    "no-array-constructor": "error",
+    "@typescript-eslint/no-array-delete": "error",
+    "@typescript-eslint/no-base-to-string": "error",
+    "@typescript-eslint/no-duplicate-enum-values": "error",
+    "@typescript-eslint/no-duplicate-type-constituents": "error",
+    "@typescript-eslint/no-empty-object-type": "error",
+    "@typescript-eslint/no-explicit-any": "error",
+    "@typescript-eslint/no-extra-non-null-assertion": "error",
+    "@typescript-eslint/no-floating-promises": "error",
+    "@typescript-eslint/no-for-in-array": "error",
+    "@typescript-eslint/no-implied-eval": "error",
+    "@typescript-eslint/no-misused-new": "error",
+    "@typescript-eslint/no-misused-promises": "error",
+    "@typescript-eslint/no-namespace": "error",
+    "@typescript-eslint/no-non-null-asserted-optional-chain": "error",
+    "@typescript-eslint/no-redundant-type-constituents": "error",
+    "@typescript-eslint/no-require-imports": "error",
+    "@typescript-eslint/no-this-alias": "error",
+    "@typescript-eslint/no-unnecessary-type-assertion": "error",
+    "@typescript-eslint/no-unnecessary-type-constraint": "error",
+    "@typescript-eslint/no-unsafe-argument": "error",
+    "@typescript-eslint/no-unsafe-assignment": "error",
+    "@typescript-eslint/no-unsafe-call": "error",
+    "@typescript-eslint/no-unsafe-declaration-merging": "error",
+    "@typescript-eslint/no-unsafe-enum-comparison": "error",
+    "@typescript-eslint/no-unsafe-function-type": "error",
+    "@typescript-eslint/no-unsafe-member-access": "error",
+    "@typescript-eslint/no-unsafe-return": "error",
+    "@typescript-eslint/no-unsafe-unary-minus": "error",
+    "no-unused-expressions": "error",
+    "@typescript-eslint/no-wrapper-object-types": "error",
+    "@typescript-eslint/only-throw-error": "error",
+    "@typescript-eslint/prefer-as-const": "error",
+    "@typescript-eslint/prefer-namespace-keyword": "error",
+    "@typescript-eslint/prefer-promise-reject-errors": "error",
+    "@typescript-eslint/require-await": "error",
+    "@typescript-eslint/restrict-plus-operands": "error",
+    "@typescript-eslint/restrict-template-expressions": "error",
+    "@typescript-eslint/triple-slash-reference": "error",
+    "@typescript-eslint/unbound-method": "error",
+    "react-hooks/rules-of-hooks": "error",
+    "react-hooks/exhaustive-deps": "warn",
+    "import-x/namespace": "error",
+    "import-x/default": "error",
+    "import-x/no-named-as-default": "warn",
+    "import-x/no-named-as-default-member": "warn",
+    "import-x/no-duplicates": "warn"
+  },
+  "overrides": [
+    {
+      "files": [
+        "**/*.ts",
+        "**/*.tsx",
+        "**/*.mts",
+        "**/*.cts"
+      ],
+      "rules": {
+        "constructor-super": "off",
+        "no-class-assign": "off",
+        "no-const-assign": "off",
+        "no-dupe-class-members": "off",
+        "no-dupe-keys": "off",
+        "no-func-assign": "off",
+        "no-import-assign": "off",
+        "no-new-native-nonconstructor": "off",
+        "no-obj-calls": "off",
+        "no-redeclare": "off",
+        "no-setter-return": "off",
+        "no-this-before-super": "off",
+        "no-unsafe-negation": "off",
+        "no-var": "error",
+        "no-with": "off",
+        "prefer-rest-params": "error",
+        "prefer-spread": "error"
+      }
+    },
+    {
+      "files": [
+        "**/*.{js,jsx,ts,tsx}"
+      ],
+      "rules": {
+        "bsky-internal/avoid-unwrapped-text": [
+          "error",
+          {
+            "impliedTextComponents": [
+              "H1",
+              "H2",
+              "H3",
+              "H4",
+              "H5",
+              "H6",
+              "P",
+              "Admonition",
+              "Admonition.Admonition",
+              "Toast.Action",
+              "AgeAssuranceAdmonition",
+              "Span",
+              "StackedButton"
+            ],
+            "impliedTextProps": [],
+            "suggestedTextWrappers": {
+              "Button": "ButtonText",
+              "ToggleButton.Button": "ToggleButton.ButtonText",
+              "SegmentedControl.Item": "SegmentedControl.ItemText"
+            }
+          }
+        ],
+        "bsky-internal/use-exact-imports": "error",
+        "bsky-internal/use-prefixed-imports": "error",
+        "react/display-name": "error",
+        "react/jsx-key": "error",
+        "react/jsx-no-comment-textnodes": "error",
+        "react/jsx-no-duplicate-props": "error",
+        "react/jsx-no-target-blank": "error",
+        "react/jsx-no-undef": "error",
+        "react/no-children-prop": "error",
+        "react/no-danger-with-children": "error",
+        "react/no-direct-mutation-state": "error",
+        "react/no-find-dom-node": "error",
+        "react/no-is-mounted": "error",
+        "react/no-render-return-value": "error",
+        "react/no-string-refs": "error",
+        "react/no-unescaped-entities": "off",
+        "react/no-unknown-property": "error",
+        "react/no-unsafe": "off",
+        "react/react-in-jsx-scope": "off",
+        "react-native/no-inline-styles": "off",
+        "react-native-a11y/has-accessibility-hint": "error",
+        "react-native-a11y/has-accessibility-props": "error",
+        "react-native-a11y/has-valid-accessibility-actions": "error",
+        "react-native-a11y/has-valid-accessibility-component-type": "error",
+        "react-native-a11y/has-valid-accessibility-descriptors": "error",
+        "react-native-a11y/has-valid-accessibility-role": "error",
+        "react-native-a11y/has-valid-accessibility-state": "error",
+        "react-native-a11y/has-valid-accessibility-states": "error",
+        "react-native-a11y/has-valid-accessibility-traits": "error",
+        "react-native-a11y/has-valid-accessibility-value": "error",
+        "react-native-a11y/no-nested-touchables": "error",
+        "react-native-a11y/has-valid-accessibility-ignores-invert-colors": "error",
+        "react-native-a11y/has-valid-accessibility-live-region": "error",
+        "react-native-a11y/has-valid-important-for-accessibility": "error",
+        "react-compiler/react-compiler": "warn",
+        "simple-import-sort/imports": [
+          "error",
+          {
+            "groups": [
+              [
+                "^\\u0000"
+              ],
+              [
+                "^node:"
+              ],
+              [
+                "^(react\\/(.*)$)|^(react$)|^(react-native(.*)$)",
+                "^(expo(.*)$)|^(expo$)",
+                "^(?!(?:alf|components|lib|locale|logger|platform|screens|state|view)(?:$|\\/))@?\\w"
+              ],
+              [
+                "^(?:#\\/)?(?:lib|state|logger|platform|locale)(?:$|\\/)",
+                "^(?:#\\/)?view(?:$|\\/)",
+                "^(?:#\\/)?screens(?:$|\\/)",
+                "^(?:#\\/)?alf(?:$|\\/)",
+                "^(?:#\\/)?components(?:$|\\/)",
+                "^#\\/",
+                "^\\."
+              ],
+              [
+                "^"
+              ]
+            ]
+          }
+        ],
+        "simple-import-sort/exports": "error",
+        "import-x/consistent-type-specifier-style": [
+          "warn",
+          "prefer-inline"
+        ],
+        "no-unused-vars": [
+          "error",
+          {
+            "argsIgnorePattern": "^_",
+            "varsIgnorePattern": "^_.+",
+            "caughtErrors": "none",
+            "ignoreRestSiblings": true
+          }
+        ],
+        "@typescript-eslint/consistent-type-imports": [
+          "warn",
+          {
+            "prefer": "type-imports",
+            "fixStyle": "inline-type-imports"
+          }
+        ],
+        "@typescript-eslint/no-require-imports": "off",
+        "@typescript-eslint/no-explicit-any": "off",
+        "@typescript-eslint/ban-ts-comment": "off",
+        "@typescript-eslint/no-empty-object-type": "off",
+        "@typescript-eslint/no-unsafe-function-type": "off",
+        "@typescript-eslint/no-unsafe-assignment": "off",
+        "@typescript-eslint/unbound-method": "off",
+        "@typescript-eslint/no-unsafe-argument": "off",
+        "@typescript-eslint/no-unsafe-return": "off",
+        "@typescript-eslint/no-unsafe-member-access": "warn",
+        "@typescript-eslint/no-unsafe-call": "warn",
+        "@typescript-eslint/no-floating-promises": "warn",
+        "@typescript-eslint/no-misused-promises": "warn",
+        "@typescript-eslint/require-await": "warn",
+        "@typescript-eslint/no-unsafe-enum-comparison": "warn",
+        "@typescript-eslint/no-unnecessary-type-assertion": "warn",
+        "@typescript-eslint/no-redundant-type-constituents": "warn",
+        "@typescript-eslint/no-duplicate-type-constituents": "warn",
+        "@typescript-eslint/no-base-to-string": "warn",
+        "@typescript-eslint/prefer-promise-reject-errors": "warn",
+        "@typescript-eslint/await-thenable": "warn",
+        "no-empty-pattern": "off",
+        "no-async-promise-executor": "off",
+        "no-constant-binary-expression": "warn",
+        "no-empty": "off",
+        "no-unsafe-optional-chaining": "off",
+        "no-prototype-builtins": "off",
+        "no-var": "off",
+        "prefer-rest-params": "off",
+        "no-case-declarations": "off",
+        "no-irregular-whitespace": "off",
+        "no-useless-escape": "off",
+        "no-sparse-arrays": "off",
+        "no-fallthrough": "off",
+        "no-control-regex": "off",
+        "no-unused-expressions": [
+          "error",
+          {
+            "allowTernary": true
+          }
+        ]
+      },
+      "jsPlugins": [
+        "eslint-plugin-bsky-internal",
+        "eslint-plugin-react-native",
+        "eslint-plugin-react-native-a11y",
+        "eslint-plugin-react-compiler",
+        "eslint-plugin-simple-import-sort"
+      ],
+      "env": {
+        "es2026": true,
+        "browser": true,
+        "node": true
+      }
+    },
+    {
+      "files": [
+        "**/__tests__/**/*.{js,jsx,ts,tsx}",
+        "**/*.test.{js,jsx,ts,tsx}"
+      ],
+      "env": {
+        "jest": true
+      }
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "test-watch": "NODE_ENV=test jest --watchAll",
     "test-ci": "NODE_ENV=test jest --ci --forceExit --reporters=default --reporters=jest-junit",
     "test-coverage": "NODE_ENV=test jest --coverage",
-    "lint": "eslint --cache --quiet src",
+    "lint": "oxlint --quiet src",
     "lint-native": "swiftlint ./modules && ktlint ./modules",
     "lint-native:fix": "swiftlint --fix ./modules && ktlint --format ./modules",
     "typecheck": "tsc --project ./tsconfig.check.json",
@@ -275,6 +275,8 @@
     "jest-junit": "^16.0.0",
     "lint-staged": "^13.2.3",
     "lockfile-lint": "^4.14.0",
+    "oxlint": "^1.42.0",
+    "oxlint-tsgolint": "^0.11.2",
     "prettier": "^3.6.0",
     "react-native-dotenv": "^3.4.11",
     "react-refresh": "^0.14.0",
@@ -346,7 +348,7 @@
   },
   "lint-staged": {
     "*{.js,.jsx,.ts,.tsx}": [
-      "eslint --cache --fix"
+      "oxlint --fix"
     ],
     "*{.js,.jsx,.ts,.tsx,.css}": [
       "prettier --cache --write --ignore-unknown"

--- a/src/lib/hooks/useTLDs.ts
+++ b/src/lib/hooks/useTLDs.ts
@@ -1,5 +1,5 @@
 import {useEffect, useState} from 'react'
-import type tldts from 'tldts'
+import type * as tldts from 'tldts'
 
 export function useTLDs() {
   const [tlds, setTlds] = useState<typeof tldts>()

--- a/src/lib/strings/email.ts
+++ b/src/lib/strings/email.ts
@@ -1,4 +1,4 @@
-import type tldts from 'tldts'
+import type * as tldts from 'tldts'
 
 const COMMON_ERROR_PATTERN =
   /([a-zA-Z0-9._%+-]+)@(gnail\.(co|com)|gmaill\.(co|com)|gmai\.(co|com)|gmail\.co|gmal\.(co|com)|iclod\.(co|com)|icloud\.co|outllok\.(co|com)|outlok\.(co|com)|outlook\.co|yaoo\.(co|com)|yaho\.(co|com)|yahoo\.co|yahooo\.(co|com))$/

--- a/src/screens/Signup/StepInfo/index.tsx
+++ b/src/screens/Signup/StepInfo/index.tsx
@@ -3,7 +3,7 @@ import {type TextInput, View} from 'react-native'
 import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 import * as EmailValidator from 'email-validator'
-import type tldts from 'tldts'
+import type * as tldts from 'tldts'
 
 import {isEmailMaybeInvalid} from '#/lib/strings/email'
 import {logger} from '#/logger'

--- a/yarn.lock
+++ b/yarn.lock
@@ -5530,6 +5530,76 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@oxlint-tsgolint/darwin-arm64@0.11.2":
+  version "0.11.2"
+  resolved "https://registry.yarnpkg.com/@oxlint-tsgolint/darwin-arm64/-/darwin-arm64-0.11.2.tgz#92fd65570a52d7683f25c9b15e29ceaa004c7183"
+  integrity sha512-LXQ47SH4MjzgI8xXMMB22N9G6yXojL8YNemPgvwtMw37by5H2rOBXsdViX2r0ubV75ak1/7GlxVAFEKQ9lc+Dw==
+
+"@oxlint-tsgolint/darwin-x64@0.11.2":
+  version "0.11.2"
+  resolved "https://registry.yarnpkg.com/@oxlint-tsgolint/darwin-x64/-/darwin-x64-0.11.2.tgz#46e90d2fc7fd8d0d3b2f3f8155b30c754f2ee0c3"
+  integrity sha512-am1cy2mhq56DhG5gdErCfAnHYr2JiJIxRtRyXfAkAVekteaAwRwK1OytjO7s455oGNUVKPD3M8bkEJ3L/FWk8A==
+
+"@oxlint-tsgolint/linux-arm64@0.11.2":
+  version "0.11.2"
+  resolved "https://registry.yarnpkg.com/@oxlint-tsgolint/linux-arm64/-/linux-arm64-0.11.2.tgz#55f31b563d307cc35b6368552eb52a9de998310f"
+  integrity sha512-KNMXweLVdUevvi7XvDiiJbQSBKZQmRyBAwS2G8R32AxUusdDccmt0yB++0nH5WN+U5tLLEa0BlkaVTVHhxThAw==
+
+"@oxlint-tsgolint/linux-x64@0.11.2":
+  version "0.11.2"
+  resolved "https://registry.yarnpkg.com/@oxlint-tsgolint/linux-x64/-/linux-x64-0.11.2.tgz#6f2f093e8bf133140ed18ae1b611237b6ec18e4c"
+  integrity sha512-bkKayG26rLua4RVhtZOk8GbplBTTD9k+NI8EA+qwP7TSC3ndtIlj/LHNo17+DPa4IYrhd+2vLsUxTvGh7TeTgg==
+
+"@oxlint-tsgolint/win32-arm64@0.11.2":
+  version "0.11.2"
+  resolved "https://registry.yarnpkg.com/@oxlint-tsgolint/win32-arm64/-/win32-arm64-0.11.2.tgz#c5a4effa213020516cfd16a037d197e8a30a63bf"
+  integrity sha512-0imJQy2VhFeOms961lgAEbmlr3LdepBb2ClWYeu0HPc8Mi05x/bT4BReFY7L4gdctajYIrKDS2Dzp2zEqeHn1g==
+
+"@oxlint-tsgolint/win32-x64@0.11.2":
+  version "0.11.2"
+  resolved "https://registry.yarnpkg.com/@oxlint-tsgolint/win32-x64/-/win32-x64-0.11.2.tgz#54f741289256a35841cc64c4442e7db82820dac7"
+  integrity sha512-kAYRB8WP+t6TRzO/4DALoggtw8NjE6mPk8VzEOK3EJRtE3Pdo1fdVVCE2xaPctQEf7JZ+1D55ZNLnTR7lT8Bxg==
+
+"@oxlint/darwin-arm64@1.42.0":
+  version "1.42.0"
+  resolved "https://registry.yarnpkg.com/@oxlint/darwin-arm64/-/darwin-arm64-1.42.0.tgz#28dee385541a2e44af4f3a2dd830a4f496cad60a"
+  integrity sha512-ui5CdAcDsXPQwZQEXOOSWsilJWhgj9jqHCvYBm2tDE8zfwZZuF9q58+hGKH1x5y0SV4sRlyobB2Quq6uU6EgeA==
+
+"@oxlint/darwin-x64@1.42.0":
+  version "1.42.0"
+  resolved "https://registry.yarnpkg.com/@oxlint/darwin-x64/-/darwin-x64-1.42.0.tgz#55aa8fcd5755572a672e1b2df4af0fe010763e3f"
+  integrity sha512-wo0M/hcpHRv7vFje99zHHqheOhVEwUOKjOgBKyi0M99xcLizv04kcSm1rTd6HSCeZgOtiJYZRVAlKhQOQw2byQ==
+
+"@oxlint/linux-arm64-gnu@1.42.0":
+  version "1.42.0"
+  resolved "https://registry.yarnpkg.com/@oxlint/linux-arm64-gnu/-/linux-arm64-gnu-1.42.0.tgz#aac2ea6c4880edcb9b750585ac3f01786f0bc645"
+  integrity sha512-j4QzfCM8ks+OyM+KKYWDiBEQsm5RCW50H1Wz16wUyoFsobJ+X5qqcJxq6HvkE07m8euYmZelyB0WqsiDoz1v8g==
+
+"@oxlint/linux-arm64-musl@1.42.0":
+  version "1.42.0"
+  resolved "https://registry.yarnpkg.com/@oxlint/linux-arm64-musl/-/linux-arm64-musl-1.42.0.tgz#4fc6de318e89768a01105a95c227aa1157d33656"
+  integrity sha512-g5b1Uw7zo6yw4Ymzyd1etKzAY7xAaGA3scwB8tAp3QzuY7CYdfTwlhiLKSAKbd7T/JBgxOXAGNcLDorJyVTXcg==
+
+"@oxlint/linux-x64-gnu@1.42.0":
+  version "1.42.0"
+  resolved "https://registry.yarnpkg.com/@oxlint/linux-x64-gnu/-/linux-x64-gnu-1.42.0.tgz#caf145ba8584b6bb74907856652f971f4d910f42"
+  integrity sha512-HnD99GD9qAbpV4q9iQil7mXZUJFpoBdDavfcC2CgGLPlawfcV5COzQPNwOgvPVkr7C0cBx6uNCq3S6r9IIiEIg==
+
+"@oxlint/linux-x64-musl@1.42.0":
+  version "1.42.0"
+  resolved "https://registry.yarnpkg.com/@oxlint/linux-x64-musl/-/linux-x64-musl-1.42.0.tgz#668384131532c91dd50cd151294f369c240ccd0f"
+  integrity sha512-8NTe8A78HHFn+nBi+8qMwIjgv9oIBh+9zqCPNLH56ah4vKOPvbePLI6NIv9qSkmzrBuu8SB+FJ2TH/G05UzbNA==
+
+"@oxlint/win32-arm64@1.42.0":
+  version "1.42.0"
+  resolved "https://registry.yarnpkg.com/@oxlint/win32-arm64/-/win32-arm64-1.42.0.tgz#b35eb5b7805911a298d58640ef427fe97ccf6dc4"
+  integrity sha512-lAPS2YAuu+qFqoTNPFcNsxXjwSV0M+dOgAzzVTAN7Yo2ifj+oLOx0GsntWoM78PvQWI7Q827ZxqtU2ImBmDapA==
+
+"@oxlint/win32-x64@1.42.0":
+  version "1.42.0"
+  resolved "https://registry.yarnpkg.com/@oxlint/win32-x64/-/win32-x64-1.42.0.tgz#448fd1af33d9ccacc49ffb910e719db029763880"
+  integrity sha512-3/KmyUOHNriL6rLpaFfm9RJxdhpXY2/Ehx9UuorJr2pUA+lrZL15FAEx/DOszYm5r10hfzj40+efAHcCilNvSQ==
+
 "@pkgjs/parseargs@^0.11.0":
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/@pkgjs/parseargs/-/parseargs-0.11.0.tgz#a77ea742fab25775145434eb1d2328cf5013ac33"
@@ -15916,6 +15986,32 @@ own-keys@^1.0.1:
     get-intrinsic "^1.2.6"
     object-keys "^1.1.1"
     safe-push-apply "^1.0.0"
+
+oxlint-tsgolint@^0.11.2:
+  version "0.11.2"
+  resolved "https://registry.yarnpkg.com/oxlint-tsgolint/-/oxlint-tsgolint-0.11.2.tgz#c2a53e2687e160fce851c5ca2f1eb2913f30ade3"
+  integrity sha512-CgtoZ4vAQCWYaJwQRPIFp6aId+db/s1cgIPJky7Sx8hA/nEO/ZSfvL4bee1GmldU84GcVC8nNiF6FJEdj2xDEw==
+  optionalDependencies:
+    "@oxlint-tsgolint/darwin-arm64" "0.11.2"
+    "@oxlint-tsgolint/darwin-x64" "0.11.2"
+    "@oxlint-tsgolint/linux-arm64" "0.11.2"
+    "@oxlint-tsgolint/linux-x64" "0.11.2"
+    "@oxlint-tsgolint/win32-arm64" "0.11.2"
+    "@oxlint-tsgolint/win32-x64" "0.11.2"
+
+oxlint@^1.42.0:
+  version "1.42.0"
+  resolved "https://registry.yarnpkg.com/oxlint/-/oxlint-1.42.0.tgz#eb32cd478126c5f32565403356f89e11ef5feb71"
+  integrity sha512-qnspC/lrp8FgKNaONLLn14dm+W5t0SSlus6V5NJpgI2YNT1tkFYZt4fBf14ESxf9AAh98WBASnW5f0gtw462Lg==
+  optionalDependencies:
+    "@oxlint/darwin-arm64" "1.42.0"
+    "@oxlint/darwin-x64" "1.42.0"
+    "@oxlint/linux-arm64-gnu" "1.42.0"
+    "@oxlint/linux-arm64-musl" "1.42.0"
+    "@oxlint/linux-x64-gnu" "1.42.0"
+    "@oxlint/linux-x64-musl" "1.42.0"
+    "@oxlint/win32-arm64" "1.42.0"
+    "@oxlint/win32-x64" "1.42.0"
 
 p-finally@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Faster linter :) takes `yarn lint` from 40+ seconds to 15 seconds

Ran migrate command, it spat out this:
<img width="578" height="421" alt="Screenshot 2026-01-27 at 15 38 01" src="https://github.com/user-attachments/assets/4a5d5a21-546c-47a5-8a16-7c966651560b" />

## To do

- [ ] Confirm that at least most rules are still applying, and figure out a way to track which ones are missing
- [ ] Update CI
- [ ] Remove Eslint