### PR TITLE
Enable ccache for dev builds on iOS

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -241,6 +241,7 @@ module.exports = function (_config) {
             ios: {
               deploymentTarget: '15.1',
               buildReactNativeFromSource: true,
+              ccacheEnabled: IS_DEV,
             },
             android: {
               compileSdkVersion: 35,


### PR DESCRIPTION
Enables ccache for dev builds on iOS. Let's avoid using it for TF/prod builds to avoid cache poisoning

RN docs: https://reactnative.dev/docs/build-speed#local-caches

## Test plan

App still compiles