### PR TITLE
Fix LD+JSON

### DIFF
--- a/bskyweb/cmd/bskyweb/filters.go
+++ b/bskyweb/cmd/bskyweb/filters.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"net/url"
 
 	"github.com/flosch/pongo2/v6"
@@ -8,6 +9,7 @@ import (
 
 func init() {
 	pongo2.RegisterFilter("canonicalize_url", filterCanonicalizeURL)
+	pongo2.RegisterFilter("json_escape", filterJSONEscape)
 }
 
 func filterCanonicalizeURL(in *pongo2.Value, param *pongo2.Value) (*pongo2.Value, *pongo2.Error) {
@@ -25,4 +27,26 @@ func filterCanonicalizeURL(in *pongo2.Value, param *pongo2.Value) (*pongo2.Value
 
 	// Return the cleaned URL
 	return pongo2.AsValue(parsedURL.String()), nil
+}
+
+// filterJSONEscape escapes a string for safe inclusion in JSON.
+// It properly handles line breaks, quotes, backslashes, and control characters.
+func filterJSONEscape(in *pongo2.Value, param *pongo2.Value) (*pongo2.Value, *pongo2.Error) {
+	str := in.String()
+
+	// Use json.Marshal to properly escape the string
+	// Marshal adds quotes around the string, so we need to remove them
+	escaped, err := json.Marshal(str)
+	if err != nil {
+		// If marshaling fails, return the original string
+		return in, nil
+	}
+
+	// Remove the surrounding quotes added by json.Marshal
+	// escaped is guaranteed to be at least 2 bytes (the quotes) if Marshal succeeded
+	if len(escaped) >= 2 {
+		escaped = escaped[1 : len(escaped)-1]
+	}
+
+	return pongo2.AsValue(string(escaped)), nil
 }

--- a/bskyweb/cmd/bskyweb/filters.go
+++ b/bskyweb/cmd/bskyweb/filters.go
@@ -48,5 +48,7 @@ func filterJSONEscape(in *pongo2.Value, param *pongo2.Value) (*pongo2.Value, *po
 		escaped = escaped[1 : len(escaped)-1]
 	}
 
-	return pongo2.AsValue(string(escaped)), nil
+	// Mark the result as safe to prevent pongo2 from HTML-escaping it
+	result := pongo2.AsSafeValue(string(escaped))
+	return result, nil
 }

--- a/bskyweb/cmd/bskyweb/filters_test.go
+++ b/bskyweb/cmd/bskyweb/filters_test.go
@@ -59,3 +59,82 @@ func TestCanonicalizeURLFilter(t *testing.T) {
 		})
 	}
 }
+
+func TestJSONEscapeFilter(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "simple text",
+			input:    "Hello world",
+			expected: "Hello world",
+		},
+		{
+			name:     "text with newline",
+			input:    "Hello\nworld",
+			expected: "Hello\\nworld",
+		},
+		{
+			name:     "text with multiple newlines",
+			input:    "Line 1\nLine 2\nLine 3",
+			expected: "Line 1\\nLine 2\\nLine 3",
+		},
+		{
+			name:     "text with carriage return",
+			input:    "Hello\rworld",
+			expected: "Hello\\rworld",
+		},
+		{
+			name:     "text with tab",
+			input:    "Hello\tworld",
+			expected: "Hello\\tworld",
+		},
+		{
+			name:     "text with double quotes",
+			input:    `Say "hello"`,
+			expected: `Say \"hello\"`,
+		},
+		{
+			name:     "text with backslash",
+			input:    `C:\path\to\file`,
+			expected: `C:\\path\\to\\file`,
+		},
+		{
+			name:     "complex profile description",
+			input:    "I code, I write, I puzzle\n🌐 elenatorro.com\n📬 conexionaleatoria.ghost.io",
+			expected: "I code, I write, I puzzle\\n🌐 elenatorro.com\\n📬 conexionaleatoria.ghost.io",
+		},
+		{
+			name:     "text with emoji",
+			input:    "Hello 👋 World 🌍",
+			expected: "Hello 👋 World 🌍",
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "text with mixed special chars",
+			input:    "Line 1\nQuoted \"text\"\tTabbed",
+			expected: `Line 1\nQuoted \"text\"\tTabbed`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inputValue := pongo2.AsValue(tt.input)
+			result, err := filterJSONEscape(inputValue, nil)
+			if err != nil {
+				t.Errorf("filterJSONEscape() error = %v", err)
+				return
+			}
+
+			if result.String() != tt.expected {
+				t.Errorf("filterJSONEscape() = %q, want %q", result.String(), tt.expected)
+			}
+		})
+	}
+}

--- a/bskyweb/cmd/bskyweb/template_integration_test.go
+++ b/bskyweb/cmd/bskyweb/template_integration_test.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/flosch/pongo2/v6"
+)
+
+// TestProfileTemplateJSONEscape tests that the profile template properly escapes JSON
+func TestProfileTemplateJSONEscape(t *testing.T) {
+	// Create a simple test template that mimics the LD+JSON structure
+	templateStr := `{
+  "description": "{{ description|json_escape }}"
+}`
+
+	tpl, err := pongo2.FromString(templateStr)
+	if err != nil {
+		t.Fatalf("Failed to parse template: %v", err)
+	}
+
+	tests := []struct {
+		name        string
+		description string
+		wantContain string
+	}{
+		{
+			name:        "description with newlines",
+			description: "I code, I write, I puzzle\n🌐 elenatorro.com\n📬 conexionaleatoria.ghost.io",
+			wantContain: `"description": "I code, I write, I puzzle\n🌐 elenatorro.com\n📬 conexionaleatoria.ghost.io"`,
+		},
+		{
+			name:        "description with quotes",
+			description: `He said "hello"`,
+			wantContain: `"description": "He said \"hello\""`,
+		},
+		{
+			name:        "simple description",
+			description: "Just a simple bio",
+			wantContain: `"description": "Just a simple bio"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := pongo2.Context{
+				"description": tt.description,
+			}
+
+			out, err := tpl.Execute(ctx)
+			if err != nil {
+				t.Fatalf("Failed to execute template: %v", err)
+			}
+
+			if !strings.Contains(out, tt.wantContain) {
+				t.Errorf("Template output missing expected content.\nGot:\n%s\n\nWant to contain:\n%s", out, tt.wantContain)
+			}
+		})
+	}
+}

--- a/bskyweb/templates/post.html
+++ b/bskyweb/templates/post.html
@@ -63,7 +63,7 @@
       "author": {
         "@type": "Person",
         {%- if postView.Author.DisplayName %}
-        "name": "{{ postView.Author.DisplayName }}",
+        "name": "{{ postView.Author.DisplayName|json_escape }}",
         "alternateName": "@{{ postView.Author.Handle }}",
         {% else %}
         "name": "@{{ postView.Author.Handle }}",
@@ -71,7 +71,7 @@
         "url": "https://bsky.app/profile/{{ postView.Author.Handle }}"
       },
       {%- if postText %}
-      "text": "{{ postText }}",
+      "text": "{{ postText|json_escape }}",
       {% endif %}
       {%- if imageThumbUrls %}
       "image": "{{ imageThumbUrls[0] }}",

--- a/bskyweb/templates/profile.html
+++ b/bskyweb/templates/profile.html
@@ -60,13 +60,13 @@
     "mainEntity": {
       "@type": "Person",
       {%- if profileView.DisplayName %}
-      "name": "{{ profileView.DisplayName }}",
+      "name": "{{ profileView.DisplayName|json_escape }}",
       "alternateName": "@{{ profileView.Handle }}",
       {% else %}
       "name": "@{{ profileView.Handle }}",
       {% endif -%}
       "identifier": "{{ profileView.Did }}",
-      "description": "{{ profileView.Description }}",
+      "description": "{{ profileView.Description|json_escape }}",
       "image": "{{ profileView.Avatar }}",
       "interactionStatistic": [
         {


### PR DESCRIPTION
Closes https://github.com/bluesky-social/social-app/issues/9772

—

Profile descriptions and post text containing line breaks and special characters were generating malformed JSON in `application/ld+json` script tags, breaking structured data parsing.

**Example of the issue:**
```json
{
  "description": "I code, I write, I puzzle
🌐 elenatorro.com
📬 conexionaleatoria.ghost.io"
}
```

## Changes

- **Added `json_escape` pongo2 filter** that uses `encoding/json.Marshal` to properly escape strings for JSON context (newlines, quotes, backslashes, control characters, unicode)
- **Applied filter to user-generated content** in LD+JSON blocks:
  - `profileView.Description` and `profileView.DisplayName` in `profile.html`
  - `postText` and `postView.Author.DisplayName` in `post.html`
- **Marked output as safe** via `pongo2.AsSafeValue` to prevent double-escaping

**Result:**
```json
{
  "description": "I code, I write, I puzzle\n🌐 elenatorro.com\n📬 conexionaleatoria.ghost.io"
}
```

**Template usage:**
```django
"description": "{{ profileView.Description|json_escape }}"
```

<!-- START COPILOT ORIGINAL PROMPT -->



<details>

<summary>Original prompt</summary>

> The LD+JSON script tag generated for public profiles in the Bluesky app may produce syntax errors if profile descriptions contain line breaks. This leads to a malformed JSON structure for the `application/ld+json` content. These errors can result in improper parsing of structured data by tools that consume this content.
> 
> ### Steps to Reproduce
> 1. Visit any Bluesky public profile containing line breaks in the description, such as https://bsky.app/profile/elenatorro.bsky.social.
> 2. Inspect the `application/ld+json` script tag in the HTML source.
> 3. Note that the JSON's `description` field contains unescaped line breaks.
> 
> #### Example
> Here is an example of malformed JSON output due to line breaks:
> ```json
> {
>   "description": "I code, I write, I puzzle
> 🌐 elenatorro.com\n📬 conexionaleatoria.ghost.io
> ```
> 
> ### Proposed Solution
> To fix this issue:
> 1. Update the server-side code responsible for generating the `description` field within the `application/ld+json` script tag.
> 2. Ensure any line breaks or invalid characters are escaped correctly when serializing the profile data to JSON.
> 3. Test the fix against profiles with varying descriptions, including ones with multiple line breaks.
> 
> ### Workaround
> Currently, tools like [jsonrepair](https://github.com/microlinkhq/metascraper/blob/b49f1cd9aa131c2ba5abe8aa55f5a33b0afdabca/packages/metascraper-helpers/src/index.js#L363) can handle these inconsistencies by repairing malformed JSON, but the source data should be corrected at the root cause for better reliability.


</details>



<!-- START COPILOT CODING AGENT SUFFIX -->

*This pull request was created from Copilot chat.*
>

<!-- START COPILOT CODING AGENT TIPS -->
---

✨ Let Copilot coding agent [set things up for you](https://github.com/Kikobeats/social-app/issues/new?title=✨+Set+up+Copilot+instructions&body=Configure%20instructions%20for%20this%20repository%20as%20documented%20in%20%5BBest%20practices%20for%20Copilot%20coding%20agent%20in%20your%20repository%5D%28https://gh.io/copilot-coding-agent-tips%29%2E%0A%0A%3COnboard%20this%20repo%3E&assignees=copilot) — coding agent works faster and does higher quality work when set up for your repo.
