### PR TITLE
Fix console logging in Firefox and other browsers

### DIFF
--- a/src/logger/transports/console.ts
+++ b/src/logger/transports/console.ts
@@ -15,37 +15,52 @@ export const consoleTransport: Transport = (
   timestamp,
 ) => {
   const hasMetadata = Object.keys(metadata).length
-  const colorize = withColor(
-    {
-      [LogLevel.Debug]: colors.magenta,
-      [LogLevel.Info]: colors.blue,
-      [LogLevel.Log]: colors.green,
-      [LogLevel.Warn]: colors.yellow,
-      [LogLevel.Error]: colors.red,
-    }[level],
-  )
-
-  let msg = `${colorize(format(timestamp, 'HH:mm:ss'))}`
-  if (context) {
-    msg += ` ${colorize(`(${context})`)}`
-  }
-  if (message) {
-    msg += ` ${message.toString()}`
-  }
 
   if (IS_WEB) {
+    const cssColor = {
+      [LogLevel.Debug]: 'magenta',
+      [LogLevel.Info]: 'dodgerblue',
+      [LogLevel.Log]: 'green',
+      [LogLevel.Warn]: 'orange',
+      [LogLevel.Error]: 'red',
+    }[level]
+
+    const timestampStr = format(timestamp, 'HH:mm:ss')
+    const contextStr = context ? ` (${context})` : ''
+    const messageStr = message ? ` ${message.toString()}` : ''
+
+    const styledPart = `%c${timestampStr}${contextStr}%c${messageStr}`
+    const styles = [`color: ${cssColor}; font-weight: bold`, 'color: inherit']
+
     if (hasMetadata) {
-      console.groupCollapsed(msg)
+      console.groupCollapsed(styledPart, ...styles)
       console.log(prepareMetadata(metadata))
       console.groupEnd()
     } else {
-      console.log(msg)
+      console.log(styledPart, ...styles)
     }
     if (message instanceof Error) {
       // for stacktrace
       console.error(message)
     }
   } else {
+    const colorize = withColor(
+      {
+        [LogLevel.Debug]: colors.magenta,
+        [LogLevel.Info]: colors.blue,
+        [LogLevel.Log]: colors.green,
+        [LogLevel.Warn]: colors.yellow,
+        [LogLevel.Error]: colors.red,
+      }[level],
+    )
+
+    let msg = `${colorize(format(timestamp, 'HH:mm:ss'))}`
+    if (context) {
+      msg += ` ${colorize(`(${context})`)}`
+    }
+    if (message) {
+      msg += ` ${message.toString()}`
+    }
     if (hasMetadata) {
       msg += ` ${JSON.stringify(prepareMetadata(metadata), null, 2)}`
     }


### PR DESCRIPTION
Console output used ANSI escape codes on all platforms, which don't render in browser consoles (especially Firefox). This fix uses proper CSS-based %c styling for web while keeping ANSI codes for native/terminal environments.

<img width="1090" height="303" alt="Screenshot 2026-01-27 at 23 15 49" src="https://github.com/user-attachments/assets/dc37f464-8867-45d6-a51a-6a6dec43f365" />



## Implementation details

- Branched web/native console logging logic in `consoleTransport`
- Web now uses `%c` format specifier with inline CSS styles for colors
- Native still uses ANSI escape codes via the `withColor` helper
- Changed warn color to `orange` on web for better visibility (yellow is hard to read on light backgrounds)

## Test plan

- Open the app in Firefox and verify console logs display with proper colors
- Test on Chrome/Safari to ensure web styling works across browsers
- Test native platforms to verify ANSI coloring still works in terminal
- Verify both grouped (with metadata) and ungrouped logs display correctly