### PR TITLE
Disable KeyboardProvider preload for faster initial load

### DIFF
--- a/src/lib/hooks/useEnableKeyboardController.tsx
+++ b/src/lib/hooks/useEnableKeyboardController.tsx
@@ -28,7 +28,7 @@ export function KeyboardControllerProvider({
   children: React.ReactNode
 }) {
   return (
-    <KeyboardProvider enabled={false}>
+    <KeyboardProvider enabled={false} preload={false}>
       <KeyboardControllerProviderInner>
         {children}
       </KeyboardControllerProviderInner>


### PR DESCRIPTION
Adds preload={false} to KeyboardProvider to prevent unnecessary keyboard controller initialization during app startup, improving initial load performance.

## Implementation details

- Added `preload={false}` prop to KeyboardProvider in KeyboardControllerProvider

## Test plan

- Verify app launches and keyboard input still works on screens that need it
- Check that keyboard controller still initializes on demand when useEnableKeyboardController is used