### PR TITLE
Allow creating profileable builds on Android

### DIFF
--- a/app.config.js
+++ b/app.config.js
@@ -289,6 +289,7 @@ module.exports = function (_config) {
         './plugins/withAndroidNoJitpackPlugin.js',
         './plugins/shareExtension/withShareExtensions.js',
         './plugins/notificationsExtension/withNotificationsExtension.js',
+        './plugins/withProfileableAndroid.js',
         [
           'expo-font',
           {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "prepare": "is-ci || husky install",
     "postinstall": "patch-package && yarn intl:compile-if-needed",
     "prebuild": "EXPO_NO_GIT_STATUS=1 expo prebuild --clean",
+    "prebuild:profile": "BSKY_PROFILE=1 EXPO_NO_GIT_STATUS=1 expo prebuild --clean",
     "android": "expo run:android",
     "android:prod": "expo run:android --variant release",
     "android:profile": "BSKY_PROFILE=1 expo run:android --variant release",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "prepare": "is-ci || husky install",
     "postinstall": "patch-package && yarn intl:compile-if-needed",
     "prebuild": "EXPO_NO_GIT_STATUS=1 expo prebuild --clean",
-    "prebuild:profile": "BSKY_PROFILE=1 EXPO_NO_GIT_STATUS=1 expo prebuild --clean",
     "android": "expo run:android",
     "android:prod": "expo run:android --variant release",
     "android:profile": "BSKY_PROFILE=1 expo run:android --variant release",

--- a/plugins/withProfileableAndroid.js
+++ b/plugins/withProfileableAndroid.js
@@ -2,8 +2,6 @@ const {withAndroidManifest} = require('@expo/config-plugins')
 
 module.exports = function withProfileableAndroid(config) {
   return withAndroidManifest(config, mod => {
-    if (process.env.BSKY_PROFILE !== '1') return mod
-
     const manifest = mod.modResults.manifest
 
     // Ensure <manifest xmlns:tools="...">

--- a/plugins/withProfileableAndroid.js
+++ b/plugins/withProfileableAndroid.js
@@ -1,0 +1,32 @@
+const {withAndroidManifest} = require('@expo/config-plugins')
+
+module.exports = function withProfileableAndroid(config) {
+  return withAndroidManifest(config, mod => {
+    if (process.env.BSKY_PROFILE !== '1') return mod
+
+    const manifest = mod.modResults.manifest
+
+    // Ensure <manifest xmlns:tools="...">
+    manifest.$ = manifest.$ || {}
+    manifest.$['xmlns:tools'] =
+      manifest.$['xmlns:tools'] || 'http://schemas.android.com/tools'
+
+    const app = manifest.application?.[0]
+    if (!app) return mod
+
+    app.profileable = app.profileable || []
+    const already = app.profileable.some(
+      p => p.$ && p.$['android:shell'] === 'true',
+    )
+    if (!already) {
+      app.profileable.push({
+        $: {
+          'android:shell': 'true',
+          'tools:targetApi': 'q',
+        },
+      })
+    }
+
+    return mod
+  })
+}


### PR DESCRIPTION
Allows creating a profileable build, so it shows up in Android studio like this:

<img width="537" height="211" alt="Screenshot 2026-01-30 at 15 15 03" src="https://github.com/user-attachments/assets/6d7b9ae9-3d90-45e4-abc2-76ea8f2a708a" />
