### PR TITLE
Implement Frontend functionality for Images in DMs

### DIFF
--- a/__tests__/components/dms/DMImageContentHider.test.tsx
+++ b/__tests__/components/dms/DMImageContentHider.test.tsx
@@ -1,0 +1,482 @@
+import React from 'react'
+import {Text} from 'react-native'
+import {type ChatBskyConvoDefs, ModerationUI} from '@atproto/api'
+import {render} from '@testing-library/react-native'
+
+import * as preferences from '#/state/preferences'
+import {useSession} from '#/state/session'
+import {DMImageContentHider} from '#/components/dms/DMImageContentHider'
+
+// Mock dependencies
+jest.mock('#/state/preferences', () => ({
+  useDmImageAlwaysBlur: jest.fn(() => false),
+  useDmImageBlurFromNonFollows: jest.fn(() => false),
+}))
+
+jest.mock('#/state/session', () => ({
+  useSession: jest.fn(() => ({
+    currentAccount: {did: 'did:plc:current-user'},
+  })),
+}))
+
+jest.mock('#/components/moderation/ContentHider', () => {
+  const {View: MockView} = require('react-native')
+  return {
+    ContentHider: ({
+      children,
+      testID,
+      modui,
+    }: {
+      children: React.ReactNode
+      testID?: string
+      modui: {blurs?: Array<unknown>} | undefined
+    }) => {
+      // Match real ContentHider behavior: check if there are blurs
+      const hasBlur = !!(modui?.blurs && modui.blurs.length > 0)
+      return (
+        <MockView testID={hasBlur ? testID : undefined}>
+          {typeof children === 'function'
+            ? children({active: hasBlur})
+            : children}
+        </MockView>
+      )
+    },
+  }
+})
+
+describe('DMImageContentHider', () => {
+  const mockCurrentUserDid = 'did:plc:current-user'
+  const mockSenderDid = 'did:plc:sender'
+  const mockFollowingUri = 'at://did:plc:sender/app.bsky.graph.follow/123'
+
+  // Helper to create test data
+  const createMessage = (
+    senderDid: string = mockSenderDid,
+  ): ChatBskyConvoDefs.MessageView =>
+    ({
+      id: 'msg-1',
+      sender: {did: senderDid},
+      sentAt: new Date().toISOString(),
+    }) as ChatBskyConvoDefs.MessageView
+
+  const createConvo = (
+    members: Array<{
+      did: string
+      following?: string
+    }>,
+  ): ChatBskyConvoDefs.ConvoView =>
+    ({
+      id: 'convo-1',
+      members: members.map(m => ({
+        did: m.did,
+        handle: `${m.did}.bsky.social`,
+        viewer: m.following ? {following: m.following} : undefined,
+      })),
+    }) as ChatBskyConvoDefs.ConvoView
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    ;(useSession as jest.Mock).mockReturnValue({
+      currentAccount: {did: mockCurrentUserDid},
+    })
+    ;(preferences.useDmImageAlwaysBlur as jest.Mock).mockReturnValue(false)
+    ;(preferences.useDmImageBlurFromNonFollows as jest.Mock).mockReturnValue(
+      false,
+    )
+  })
+
+  describe('Own Messages', () => {
+    it('should never blur images from yourself', () => {
+      const message = createMessage(mockCurrentUserDid)
+      const convo = createConvo([{did: mockCurrentUserDid}])
+
+      const {queryByTestId} = render(
+        <DMImageContentHider message={message} convo={convo}>
+          <Text>Image Content</Text>
+        </DMImageContentHider>,
+      )
+
+      // Should render directly without ContentHider wrapper
+      expect(queryByTestId('dm-image-content-hider')).toBeNull()
+    })
+
+    it('should not blur own images even when alwaysBlur is true', () => {
+      ;(preferences.useDmImageAlwaysBlur as jest.Mock).mockReturnValue(true)
+
+      const message = createMessage(mockCurrentUserDid)
+      const convo = createConvo([{did: mockCurrentUserDid}])
+
+      const {queryByTestId} = render(
+        <DMImageContentHider message={message} convo={convo}>
+          <Text>Image Content</Text>
+        </DMImageContentHider>,
+      )
+
+      expect(queryByTestId('dm-image-content-hider')).toBeNull()
+    })
+
+    it('should not blur own images even when blurFromNonFollows is true', () => {
+      ;(preferences.useDmImageBlurFromNonFollows as jest.Mock).mockReturnValue(
+        true,
+      )
+
+      const message = createMessage(mockCurrentUserDid)
+      const convo = createConvo([{did: mockCurrentUserDid}])
+
+      const {queryByTestId} = render(
+        <DMImageContentHider message={message} convo={convo}>
+          <Text>Image Content</Text>
+        </DMImageContentHider>,
+      )
+
+      expect(queryByTestId('dm-image-content-hider')).toBeNull()
+    })
+  })
+
+  describe('Backend Moderation Priority', () => {
+    it('should use backend moderation when provided', () => {
+      const backendModui = new ModerationUI()
+      backendModui.blurs = [
+        {
+          type: 'label',
+          source: {type: 'user'},
+          label: {
+            val: 'porn',
+            uri: '',
+            cid: '',
+            src: 'did:plc:labeler',
+            cts: new Date().toISOString(),
+          },
+          labelDef: {} as any,
+          target: 'content',
+          setting: 'warn',
+          behavior: {},
+          noOverride: false,
+          priority: 2,
+        },
+      ]
+
+      const message = createMessage()
+      const convo = createConvo([
+        {did: mockSenderDid, following: mockFollowingUri},
+      ])
+
+      const {getByTestId} = render(
+        <DMImageContentHider
+          message={message}
+          convo={convo}
+          moderation={backendModui}>
+          <Text>Image Content</Text>
+        </DMImageContentHider>,
+      )
+
+      // Should use ContentHider with backend moderation
+      expect(getByTestId('dm-image-content-hider')).toBeTruthy()
+    })
+
+    it('should prioritize backend moderation over user preferences', () => {
+      ;(preferences.useDmImageAlwaysBlur as jest.Mock).mockReturnValue(true)
+
+      const backendModui = new ModerationUI() // Empty moderation (no blurs)
+
+      const message = createMessage()
+      const convo = createConvo([{did: mockSenderDid}])
+
+      const {queryByTestId} = render(
+        <DMImageContentHider
+          message={message}
+          convo={convo}
+          moderation={backendModui}>
+          <Text>Image Content</Text>
+        </DMImageContentHider>,
+      )
+
+      // Backend says no blur, so shouldn't blur despite user preference
+      expect(queryByTestId('dm-image-content-hider')).toBeNull()
+    })
+  })
+
+  describe('Always Blur Preference', () => {
+    const testCases = [
+      {
+        description: 'following user',
+        following: mockFollowingUri,
+        shouldBlur: true,
+      },
+      {
+        description: 'non-following user',
+        following: undefined,
+        shouldBlur: true,
+      },
+    ]
+
+    testCases.forEach(({description, following, shouldBlur}) => {
+      it(`should blur images from ${description} when alwaysBlur is enabled`, () => {
+        ;(preferences.useDmImageAlwaysBlur as jest.Mock).mockReturnValue(true)
+
+        const message = createMessage()
+        const convo = createConvo([{did: mockSenderDid, following}])
+
+        const {queryByTestId} = render(
+          <DMImageContentHider message={message} convo={convo}>
+            <Text>Image Content</Text>
+          </DMImageContentHider>,
+        )
+
+        if (shouldBlur) {
+          expect(queryByTestId('dm-image-content-hider')).toBeTruthy()
+        } else {
+          expect(queryByTestId('dm-image-content-hider')).toBeNull()
+        }
+      })
+    })
+
+    it('should not blur when alwaysBlur is disabled', () => {
+      ;(preferences.useDmImageAlwaysBlur as jest.Mock).mockReturnValue(false)
+
+      const message = createMessage()
+      const convo = createConvo([{did: mockSenderDid}])
+
+      const {queryByTestId} = render(
+        <DMImageContentHider message={message} convo={convo}>
+          <Text>Image Content</Text>
+        </DMImageContentHider>,
+      )
+
+      expect(queryByTestId('dm-image-content-hider')).toBeNull()
+    })
+  })
+
+  describe('Blur From Non-Follows Preference', () => {
+    const testCases = [
+      {
+        description: 'user you follow',
+        following: mockFollowingUri,
+        shouldBlur: false,
+      },
+      {
+        description: 'user you do not follow',
+        following: undefined,
+        shouldBlur: true,
+      },
+    ]
+
+    testCases.forEach(({description, following, shouldBlur}) => {
+      it(`should ${shouldBlur ? 'blur' : 'not blur'} images from ${description}`, () => {
+        ;(
+          preferences.useDmImageBlurFromNonFollows as jest.Mock
+        ).mockReturnValue(true)
+
+        const message = createMessage()
+        const convo = createConvo([{did: mockSenderDid, following}])
+
+        const {queryByTestId} = render(
+          <DMImageContentHider message={message} convo={convo}>
+            <Text>Image Content</Text>
+          </DMImageContentHider>,
+        )
+
+        if (shouldBlur) {
+          expect(queryByTestId('dm-image-content-hider')).toBeTruthy()
+        } else {
+          expect(queryByTestId('dm-image-content-hider')).toBeNull()
+        }
+      })
+    })
+
+    it('should not blur when blurFromNonFollows is disabled', () => {
+      ;(preferences.useDmImageBlurFromNonFollows as jest.Mock).mockReturnValue(
+        false,
+      )
+
+      const message = createMessage()
+      const convo = createConvo([{did: mockSenderDid}])
+
+      const {queryByTestId} = render(
+        <DMImageContentHider message={message} convo={convo}>
+          <Text>Image Content</Text>
+        </DMImageContentHider>,
+      )
+
+      expect(queryByTestId('dm-image-content-hider')).toBeNull()
+    })
+  })
+
+  describe('Edge Cases', () => {
+    it('should render directly when message has no sender', () => {
+      const message = {
+        id: 'msg-1',
+        sender: undefined,
+        sentAt: new Date().toISOString(),
+      } as any
+
+      const convo = createConvo([])
+
+      const {queryByTestId} = render(
+        <DMImageContentHider message={message} convo={convo}>
+          <Text>Image Content</Text>
+        </DMImageContentHider>,
+      )
+
+      expect(queryByTestId('dm-image-content-hider')).toBeNull()
+    })
+
+    it('should blur when sender is not found in convo members', () => {
+      ;(preferences.useDmImageBlurFromNonFollows as jest.Mock).mockReturnValue(
+        true,
+      )
+
+      const message = createMessage('did:plc:unknown-sender')
+      const convo = createConvo([{did: mockSenderDid}]) // Different DID
+
+      const {queryByTestId} = render(
+        <DMImageContentHider message={message} convo={convo}>
+          <Text>Image Content</Text>
+        </DMImageContentHider>,
+      )
+
+      // Should blur as a safer default
+      expect(queryByTestId('dm-image-content-hider')).toBeTruthy()
+    })
+
+    it('should blur when sender has no viewer data', () => {
+      ;(preferences.useDmImageBlurFromNonFollows as jest.Mock).mockReturnValue(
+        true,
+      )
+
+      const message = createMessage()
+      const convo = {
+        id: 'convo-1',
+        members: [
+          {
+            did: mockSenderDid,
+            handle: 'sender.bsky.social',
+            viewer: undefined, // No viewer data
+          },
+        ],
+      } as any
+
+      const {queryByTestId} = render(
+        <DMImageContentHider message={message} convo={convo}>
+          <Text>Image Content</Text>
+        </DMImageContentHider>,
+      )
+
+      // Should blur when viewer data is missing
+      expect(queryByTestId('dm-image-content-hider')).toBeTruthy()
+    })
+
+    it('should handle empty convo members array', () => {
+      ;(preferences.useDmImageBlurFromNonFollows as jest.Mock).mockReturnValue(
+        true,
+      )
+
+      const message = createMessage()
+      const convo = {
+        id: 'convo-1',
+        members: [],
+      } as any
+
+      const {queryByTestId} = render(
+        <DMImageContentHider message={message} convo={convo}>
+          <Text>Image Content</Text>
+        </DMImageContentHider>,
+      )
+
+      // Should blur as safer default
+      expect(queryByTestId('dm-image-content-hider')).toBeTruthy()
+    })
+
+    it('should handle null/undefined current user DID', () => {
+      ;(useSession as jest.Mock).mockReturnValue({
+        currentAccount: undefined,
+      })
+
+      const message = createMessage()
+      const convo = createConvo([{did: mockSenderDid}])
+
+      const {queryByTestId} = render(
+        <DMImageContentHider message={message} convo={convo}>
+          <Text>Image Content</Text>
+        </DMImageContentHider>,
+      )
+
+      // Should not crash and render without blur
+      expect(queryByTestId('dm-image-content-hider')).toBeNull()
+    })
+  })
+
+  describe('Preference Priority', () => {
+    it('should prioritize alwaysBlur over blurFromNonFollows', () => {
+      ;(preferences.useDmImageAlwaysBlur as jest.Mock).mockReturnValue(true)
+      ;(preferences.useDmImageBlurFromNonFollows as jest.Mock).mockReturnValue(
+        true,
+      )
+
+      const message = createMessage()
+      const convo = createConvo([
+        {did: mockSenderDid, following: mockFollowingUri},
+      ])
+
+      const {queryByTestId} = render(
+        <DMImageContentHider message={message} convo={convo}>
+          <Text>Image Content</Text>
+        </DMImageContentHider>,
+      )
+
+      // Should blur because alwaysBlur is true (even though we follow the sender)
+      expect(queryByTestId('dm-image-content-hider')).toBeTruthy()
+    })
+
+    it('should not blur following users when only blurFromNonFollows is enabled', () => {
+      ;(preferences.useDmImageAlwaysBlur as jest.Mock).mockReturnValue(false)
+      ;(preferences.useDmImageBlurFromNonFollows as jest.Mock).mockReturnValue(
+        true,
+      )
+
+      const message = createMessage()
+      const convo = createConvo([
+        {did: mockSenderDid, following: mockFollowingUri},
+      ])
+
+      const {queryByTestId} = render(
+        <DMImageContentHider message={message} convo={convo}>
+          <Text>Image Content</Text>
+        </DMImageContentHider>,
+      )
+
+      // Should not blur because we follow the sender
+      expect(queryByTestId('dm-image-content-hider')).toBeNull()
+    })
+  })
+
+  describe('Cross-Platform Compatibility', () => {
+    it('should render children correctly', () => {
+      const message = createMessage(mockCurrentUserDid)
+      const convo = createConvo([{did: mockCurrentUserDid}])
+
+      const {getByText} = render(
+        <DMImageContentHider message={message} convo={convo}>
+          <Text>Test Image Content</Text>
+        </DMImageContentHider>,
+      )
+
+      expect(getByText('Test Image Content')).toBeTruthy()
+    })
+
+    it('should pass correct testID to ContentHider', () => {
+      ;(preferences.useDmImageAlwaysBlur as jest.Mock).mockReturnValue(true)
+
+      const message = createMessage()
+      const convo = createConvo([{did: mockSenderDid}])
+
+      const {getByTestId} = render(
+        <DMImageContentHider message={message} convo={convo}>
+          <Text>Image Content</Text>
+        </DMImageContentHider>,
+      )
+
+      expect(getByTestId('dm-image-content-hider')).toBeTruthy()
+    })
+  })
+})

--- a/__tests__/state/preferences/dm-image-blur.test.tsx
+++ b/__tests__/state/preferences/dm-image-blur.test.tsx
@@ -1,0 +1,185 @@
+import React from 'react'
+import {act, renderHook} from '@testing-library/react-native'
+
+import * as persisted from '#/state/persisted'
+import {
+  Provider as DmImageBlurProvider,
+  useDmImageAlwaysBlur,
+  useDmImageBlurFromNonFollows,
+  useSetDmImageAlwaysBlur,
+  useSetDmImageBlurFromNonFollows,
+} from '#/state/preferences/dm-image-blur'
+
+// Mock the persisted module
+jest.mock('#/state/persisted', () => ({
+  defaults: {
+    dmImageBlurFromNonFollows: false,
+    dmImageAlwaysBlur: false,
+  },
+  get: jest.fn((key: string) => {
+    if (key === 'dmImageBlurFromNonFollows') return false
+    if (key === 'dmImageAlwaysBlur') return false
+    return undefined
+  }),
+  write: jest.fn(),
+  onUpdate: jest.fn(() => () => {}),
+}))
+
+const wrapper = ({children}: {children: React.ReactNode}) => (
+  <DmImageBlurProvider>{children}</DmImageBlurProvider>
+)
+
+describe('DM Image Blur Preferences', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe('Default Values', () => {
+    it('should return false for dmImageBlurFromNonFollows by default', () => {
+      const {result} = renderHook(() => useDmImageBlurFromNonFollows(), {
+        wrapper,
+      })
+      expect(result.current).toBe(false)
+    })
+
+    it('should return false for dmImageAlwaysBlur by default', () => {
+      const {result} = renderHook(() => useDmImageAlwaysBlur(), {wrapper})
+      expect(result.current).toBe(false)
+    })
+  })
+
+  describe('Persisted Values', () => {
+    it('should read initial value from persisted storage for blurFromNonFollows', () => {
+      ;(persisted.get as jest.Mock).mockImplementation((key: string) => {
+        if (key === 'dmImageBlurFromNonFollows') return true
+        return false
+      })
+
+      const {result} = renderHook(() => useDmImageBlurFromNonFollows(), {
+        wrapper,
+      })
+      expect(persisted.get).toHaveBeenCalledWith('dmImageBlurFromNonFollows')
+      expect(result.current).toBe(true)
+    })
+
+    it('should read initial value from persisted storage for alwaysBlur', () => {
+      ;(persisted.get as jest.Mock).mockImplementation((key: string) => {
+        if (key === 'dmImageAlwaysBlur') return true
+        return false
+      })
+
+      const {result} = renderHook(() => useDmImageAlwaysBlur(), {wrapper})
+      expect(persisted.get).toHaveBeenCalledWith('dmImageAlwaysBlur')
+      expect(result.current).toBe(true)
+    })
+  })
+
+  describe('Setting Values', () => {
+    it('should update blurFromNonFollows and call persisted.write', () => {
+      const {result: setter} = renderHook(
+        () => useSetDmImageBlurFromNonFollows(),
+        {wrapper},
+      )
+
+      act(() => {
+        setter.current(true)
+      })
+
+      expect(persisted.write).toHaveBeenCalledWith(
+        'dmImageBlurFromNonFollows',
+        true,
+      )
+    })
+
+    it('should update alwaysBlur and call persisted.write', () => {
+      const {result: setter} = renderHook(() => useSetDmImageAlwaysBlur(), {
+        wrapper,
+      })
+
+      act(() => {
+        setter.current(true)
+      })
+
+      expect(persisted.write).toHaveBeenCalledWith('dmImageAlwaysBlur', true)
+    })
+  })
+
+  describe('Edge Cases', () => {
+    it('should handle undefined values from persisted storage', () => {
+      ;(persisted.get as jest.Mock).mockReturnValue(undefined)
+
+      const {result: blurFromNonFollows} = renderHook(
+        () => useDmImageBlurFromNonFollows(),
+        {wrapper},
+      )
+      const {result: alwaysBlur} = renderHook(() => useDmImageAlwaysBlur(), {
+        wrapper,
+      })
+
+      expect(blurFromNonFollows.current).toBe(false)
+      expect(alwaysBlur.current).toBe(false)
+    })
+
+    it('should coerce truthy values to boolean true', () => {
+      ;(persisted.get as jest.Mock).mockImplementation((key: string) => {
+        if (key === 'dmImageBlurFromNonFollows') return 1 // truthy non-boolean
+        if (key === 'dmImageAlwaysBlur') return 'yes' // truthy non-boolean
+        return false
+      })
+
+      const {result: blurFromNonFollows} = renderHook(
+        () => useDmImageBlurFromNonFollows(),
+        {wrapper},
+      )
+      const {result: alwaysBlur} = renderHook(() => useDmImageAlwaysBlur(), {
+        wrapper,
+      })
+
+      expect(blurFromNonFollows.current).toBe(true)
+      expect(alwaysBlur.current).toBe(true)
+    })
+
+    it('should register onUpdate listeners', () => {
+      renderHook(() => useDmImageBlurFromNonFollows(), {wrapper})
+      renderHook(() => useDmImageAlwaysBlur(), {wrapper})
+
+      expect(persisted.onUpdate).toHaveBeenCalledWith(
+        'dmImageBlurFromNonFollows',
+        expect.any(Function),
+      )
+      expect(persisted.onUpdate).toHaveBeenCalledWith(
+        'dmImageAlwaysBlur',
+        expect.any(Function),
+      )
+    })
+  })
+
+  describe('Multiple Hook Instances', () => {
+    it('should share state across multiple hook instances', () => {
+      const {result: getter1} = renderHook(
+        () => useDmImageBlurFromNonFollows(),
+        {
+          wrapper,
+        },
+      )
+      const {result: getter2} = renderHook(
+        () => useDmImageBlurFromNonFollows(),
+        {
+          wrapper,
+        },
+      )
+      const {result: setter} = renderHook(
+        () => useSetDmImageBlurFromNonFollows(),
+        {wrapper},
+      )
+
+      expect(getter1.current).toBe(getter2.current)
+
+      act(() => {
+        setter.current(true)
+      })
+
+      expect(getter1.current).toBe(getter2.current)
+    })
+  })
+})

--- a/src/components/dms/DMImageContentHider.tsx
+++ b/src/components/dms/DMImageContentHider.tsx
@@ -1,0 +1,135 @@
+import React from 'react'
+import {type ChatBskyConvoDefs, ModerationUI} from '@atproto/api'
+
+import {
+  useDmImageAlwaysBlur,
+  useDmImageBlurFromNonFollows,
+} from '#/state/preferences'
+import {useSession} from '#/state/session'
+import {ContentHider} from '#/components/moderation/ContentHider'
+
+/**
+ * DMImageContentHider - Wrapper component for blurring DM images with user preferences
+ *
+ * This component provides privacy-focused image blurring for Direct Messages with a
+ * forward-compatible design that seamlessly integrates with future backend moderation.
+ *
+ * ARCHITECTURE:
+ * -------------
+ * The component uses a priority system that ensures smooth transition from user preferences
+ * to platform moderation:
+ *
+ * 1. Backend Moderation (highest priority, future)
+ *    - When AT Protocol adds optional `moderation` field to MessageView
+ *    - Platform-level content filtering based on user's existing Content Filter preferences
+ *    - Automatically takes precedence over user preferences
+ *
+ * 2. User Preferences (current implementation)
+ *    - dmImageAlwaysBlur: Blur all images in DMs
+ *    - dmImageBlurFromNonFollows: Blur images from accounts the user doesn't follow
+ *    - Stored in persisted state, managed via React Context
+ *
+ * 3. No Blur (default)
+ *    - Images from yourself are never blurred
+ *    - Images that don't match any blur criteria render directly
+ *
+ * FUTURE INTEGRATION:
+ * -------------------
+ * When backend moderation becomes available:
+ *
+ * 1. AT Protocol adds: ChatBskyConvoDefs.MessageView.moderation?: ModerationUI
+ * 2. In MessageItem.tsx, call: moderateMessage(message, moderationOpts)
+ * 3. Pass resulting ModerationUI to MessageItemEmbed as new prop
+ * 4. DMImageContentHider receives it via `moderation` prop
+ * 5. No other code changes needed - the conditional logic handles the rest
+ *
+ * This means user preferences become a fallback when backend moderation is unavailable,
+ * and Content Filter settings (porn, nudity, etc.) will automatically apply to DMs.
+ *
+ * SYNTHETIC MODERATION:
+ * ---------------------
+ * When user preferences trigger a blur, we create a synthetic ModerationUI object
+ * with label 'dm-user-blur' to maintain compatibility with the existing ContentHider
+ * component. This allows us to reuse all ContentHider UI/UX without duplication.
+ */
+export function DMImageContentHider({
+  message,
+  convo,
+  moderation,
+  children,
+}: {
+  message: ChatBskyConvoDefs.MessageView
+  convo: ChatBskyConvoDefs.ConvoView
+  moderation?: ModerationUI // Future: from moderateMessage(message, moderationOpts)
+  children: React.ReactNode
+}) {
+  const {currentAccount} = useSession()
+  const alwaysBlur = useDmImageAlwaysBlur()
+  const blurFromNonFollows = useDmImageBlurFromNonFollows()
+
+  const currentUserDid = currentAccount?.did
+
+  // Edge case: If message has no sender (shouldn't happen), render without blur
+  if (!message.sender) {
+    return <>{children}</>
+  }
+
+  // NEVER blur your own images - this takes precedence over all preferences
+  if (currentUserDid && message.sender.did === currentUserDid) {
+    return <>{children}</>
+  }
+
+  // PRIORITY 1: Backend moderation (when available)
+  // If the message includes platform-level moderation data, use it directly.
+  // This allows Content Filter preferences to automatically apply to DMs.
+  if (moderation) {
+    return (
+      <ContentHider testID="dm-image-content-hider" modui={moderation}>
+        {children}
+      </ContentHider>
+    )
+  }
+
+  // PRIORITY 2: User preferences (current implementation)
+  // Check if user has enabled any DM-specific blur preferences
+  let shouldBlur = false
+
+  if (alwaysBlur) {
+    // User wants all DM images blurred
+    shouldBlur = true
+  } else if (blurFromNonFollows) {
+    // User wants images blurred from accounts they don't follow
+    // Find the sender in the conversation members list
+    const sender = convo.members.find(
+      member => member.did === message.sender?.did,
+    )
+    // Blur if: sender not found in members OR user is not following the sender
+    // Note: viewer.following is truthy when the current user follows this account
+    if (!sender || !sender.viewer?.following) {
+      shouldBlur = true
+    }
+  }
+
+  // If no blur criteria matched, render children directly
+  if (!shouldBlur) {
+    return <>{children}</>
+  }
+
+  // Create synthetic ModerationUI for user preference-based blur
+  // This mimics the structure of backend moderation to work with ContentHider
+  // We use 'hidden' type which is simpler than 'label' and appropriate for user preferences
+  const syntheticModui = new ModerationUI()
+  syntheticModui.blurs = [
+    {
+      type: 'hidden',
+      source: {type: 'user'},
+      priority: 6,
+    },
+  ]
+
+  return (
+    <ContentHider testID="dm-image-content-hider" modui={syntheticModui}>
+      {children}
+    </ContentHider>
+  )
+}

--- a/src/components/dms/DMImageContentHider.tsx
+++ b/src/components/dms/DMImageContentHider.tsx
@@ -1,134 +1,103 @@
 import React from 'react'
-import {type ChatBskyConvoDefs, ModerationUI} from '@atproto/api'
+import {type ChatBskyConvoDefs, type ModerationUI} from '@atproto/api'
 
-import {
-  useDmImageAlwaysBlur,
-  useDmImageBlurFromNonFollows,
-} from '#/state/preferences'
 import {useSession} from '#/state/session'
 import {ContentHider} from '#/components/moderation/ContentHider'
+import {useModerationDecision} from './moderation/useModerationDecision'
 
 /**
- * DMImageContentHider - Wrapper component for blurring DM images with user preferences
+ * DMImageContentHider - Privacy-focused image blur for Direct Messages
  *
- * This component provides privacy-focused image blurring for Direct Messages with a
- * forward-compatible design that seamlessly integrates with future backend moderation.
+ * DESIGN PHILOSOPHY:
+ * ------------------
+ * This component addresses the immediate user need for DM image privacy while
+ * the AT Protocol team designs the "permissioned data" infrastructure needed
+ * for platform-level moderation (ref: bnewbold's comment on operational security,
+ * abuse prevention, and administrative access policies).
+ *
+ * CLIENT-SIDE PRIVACY LAYER (Current):
+ * - User-controlled blur preferences
+ * - No backend dependency
+ * - Immediate protection without waiting for protocol changes
+ *
+ * PLATFORM MODERATION (Future):
+ * - Protocol-level content labeling
+ * - Centralized abuse reporting
+ * - Administrative policy enforcement
  *
  * ARCHITECTURE:
  * -------------
- * The component uses a priority system that ensures smooth transition from user preferences
- * to platform moderation:
+ * The component uses a pluggable moderation pipeline with clear extension points:
  *
- * 1. Backend Moderation (highest priority, future)
- *    - When AT Protocol adds optional `moderation` field to MessageView
- *    - Platform-level content filtering based on user's existing Content Filter preferences
- *    - Automatically takes precedence over user preferences
+ * 1. Backend Moderation (highest priority - when AT Protocol adds support)
+ *    - Passed via `moderation` prop
+ *    - Automatically takes precedence
+ *    - Integrates with existing Content Filter preferences
  *
- * 2. User Preferences (current implementation)
- *    - dmImageAlwaysBlur: Blur all images in DMs
- *    - dmImageBlurFromNonFollows: Blur images from accounts the user doesn't follow
- *    - Stored in persisted state, managed via React Context
+ * 2. Custom Policies (extensible via options)
+ *    - Bluesky can inject regional rules, A/B tests, etc.
+ *    - Sorted by priority
+ *    - No component changes needed
  *
- * 3. No Blur (default)
- *    - Images from yourself are never blurred
- *    - Images that don't match any blur criteria render directly
+ * 3. User Preferences (current implementation)
+ *    - Always blur or blur from non-follows
+ *    - Fallback when no platform moderation exists
  *
- * FUTURE INTEGRATION:
- * -------------------
- * When backend moderation becomes available:
+ * INTEGRATION PATH:
+ * -----------------
+ * When AT Protocol adds moderation support:
  *
- * 1. AT Protocol adds: ChatBskyConvoDefs.MessageView.moderation?: ModerationUI
- * 2. In MessageItem.tsx, call: moderateMessage(message, moderationOpts)
- * 3. Pass resulting ModerationUI to MessageItemEmbed as new prop
- * 4. DMImageContentHider receives it via `moderation` prop
- * 5. No other code changes needed - the conditional logic handles the rest
+ * 1. Protocol adds: MessageView.moderation?: ModerationUI
+ * 2. Call moderateMessage(message, moderationOpts) in parent
+ * 3. Pass result to this component via `moderation` prop
+ * 4. Pipeline automatically prioritizes it
  *
- * This means user preferences become a fallback when backend moderation is unavailable,
- * and Content Filter settings (porn, nudity, etc.) will automatically apply to DMs.
- *
- * SYNTHETIC MODERATION:
- * ---------------------
- * When user preferences trigger a blur, we create a synthetic ModerationUI object
- * with label 'dm-user-blur' to maintain compatibility with the existing ContentHider
- * component. This allows us to reuse all ContentHider UI/UX without duplication.
+ * The separation between client privacy (user preferences) and platform
+ * moderation (backend policies) is intentional - they serve different needs
+ * and can coexist.
  */
 export function DMImageContentHider({
   message,
   convo,
   moderation,
   children,
+  customPolicies,
+  onModerationDecision,
 }: {
   message: ChatBskyConvoDefs.MessageView
   convo: ChatBskyConvoDefs.ConvoView
-  moderation?: ModerationUI // Future: from moderateMessage(message, moderationOpts)
+  moderation?: ModerationUI // Future: from moderateMessage()
   children: React.ReactNode
+  customPolicies?: Array<{
+    name: string
+    priority: number
+    evaluate: (ctx: any) => any
+  }> // Extension point for Bluesky
+  onModerationDecision?: (decision: any) => void // Analytics/reporting hook
 }) {
   const {currentAccount} = useSession()
-  const alwaysBlur = useDmImageAlwaysBlur()
-  const blurFromNonFollows = useDmImageBlurFromNonFollows()
 
-  const currentUserDid = currentAccount?.did
-
-  // Edge case: If message has no sender (shouldn't happen), render without blur
-  if (!message.sender) {
-    return <>{children}</>
-  }
-
-  // NEVER blur your own images - this takes precedence over all preferences
-  if (currentUserDid && message.sender.did === currentUserDid) {
-    return <>{children}</>
-  }
-
-  // PRIORITY 1: Backend moderation (when available)
-  // If the message includes platform-level moderation data, use it directly.
-  // This allows Content Filter preferences to automatically apply to DMs.
-  if (moderation) {
-    return (
-      <ContentHider testID="dm-image-content-hider" modui={moderation}>
-        {children}
-      </ContentHider>
-    )
-  }
-
-  // PRIORITY 2: User preferences (current implementation)
-  // Check if user has enabled any DM-specific blur preferences
-  let shouldBlur = false
-
-  if (alwaysBlur) {
-    // User wants all DM images blurred
-    shouldBlur = true
-  } else if (blurFromNonFollows) {
-    // User wants images blurred from accounts they don't follow
-    // Find the sender in the conversation members list
-    const sender = convo.members.find(
-      member => member.did === message.sender?.did,
-    )
-    // Blur if: sender not found in members OR user is not following the sender
-    // Note: viewer.following is truthy when the current user follows this account
-    if (!sender || !sender.viewer?.following) {
-      shouldBlur = true
-    }
-  }
-
-  // If no blur criteria matched, render children directly
-  if (!shouldBlur) {
-    return <>{children}</>
-  }
-
-  // Create synthetic ModerationUI for user preference-based blur
-  // This mimics the structure of backend moderation to work with ContentHider
-  // We use 'hidden' type which is simpler than 'label' and appropriate for user preferences
-  const syntheticModui = new ModerationUI()
-  syntheticModui.blurs = [
+  const decision = useModerationDecision(
     {
-      type: 'hidden',
-      source: {type: 'user'},
-      priority: 6,
+      message,
+      convo,
+      currentUserDid: currentAccount?.did,
     },
-  ]
+    {
+      backendModeration: moderation,
+      customPolicies,
+      onDecision: onModerationDecision,
+    },
+  )
 
+  // No blur needed - render directly
+  if (!decision.shouldBlur) {
+    return <>{children}</>
+  }
+
+  // Blur with moderation UI
   return (
-    <ContentHider testID="dm-image-content-hider" modui={syntheticModui}>
+    <ContentHider testID="dm-image-content-hider" modui={decision.modui}>
       {children}
     </ContentHider>
   )

--- a/src/components/dms/MessageItem.tsx
+++ b/src/components/dms/MessageItem.tsx
@@ -12,6 +12,7 @@ import Animated, {
   ZoomOut,
 } from 'react-native-reanimated'
 import {
+  AppBskyEmbedImages,
   AppBskyEmbedRecord,
   ChatBskyConvoDefs,
   RichText as RichTextAPI,
@@ -181,7 +182,8 @@ let MessageItem = ({
           nextIsMessage && !isNextFromSameSender && a.mb_md,
         ]}>
         <ActionsWrapper isFromSelf={isFromSelf} message={message}>
-          {AppBskyEmbedRecord.isView(message.embed) && (
+          {(AppBskyEmbedRecord.isView(message.embed) ||
+            AppBskyEmbedImages.isView(message.embed)) && (
             <MessageItemEmbed embed={message.embed} />
           )}
           {rt.text.length > 0 && (

--- a/src/components/dms/MessageItem.tsx
+++ b/src/components/dms/MessageItem.tsx
@@ -184,7 +184,11 @@ let MessageItem = ({
         <ActionsWrapper isFromSelf={isFromSelf} message={message}>
           {(AppBskyEmbedRecord.isView(message.embed) ||
             AppBskyEmbedImages.isView(message.embed)) && (
-            <MessageItemEmbed embed={message.embed} />
+            <MessageItemEmbed
+              embed={message.embed}
+              message={message}
+              convo={convo}
+            />
           )}
           {rt.text.length > 0 && (
             <View

--- a/src/components/dms/MessageItemEmbed.tsx
+++ b/src/components/dms/MessageItemEmbed.tsx
@@ -1,16 +1,19 @@
 import React from 'react'
 import {useWindowDimensions, View} from 'react-native'
-import {type $Typed, type AppBskyEmbedRecord} from '@atproto/api'
+import {
+  type $Typed,
+  type AppBskyEmbedImages,
+  type AppBskyEmbedRecord,
+} from '@atproto/api'
 
 import {atoms as a, native, tokens, useTheme, web} from '#/alf'
-import {PostEmbedViewContext} from '#/components/Post/Embed'
-import {Embed} from '#/components/Post/Embed'
+import {Embed, PostEmbedViewContext} from '#/components/Post/Embed'
 import {MessageContextProvider} from './MessageContext'
 
 let MessageItemEmbed = ({
   embed,
 }: {
-  embed: $Typed<AppBskyEmbedRecord.View>
+  embed: $Typed<AppBskyEmbedRecord.View> | $Typed<AppBskyEmbedImages.View>
 }): React.ReactNode => {
   const t = useTheme()
   const screen = useWindowDimensions()

--- a/src/components/dms/MessageItemEmbed.tsx
+++ b/src/components/dms/MessageItemEmbed.tsx
@@ -2,21 +2,35 @@ import React from 'react'
 import {useWindowDimensions, View} from 'react-native'
 import {
   type $Typed,
-  type AppBskyEmbedImages,
+  AppBskyEmbedImages,
   type AppBskyEmbedRecord,
+  type ChatBskyConvoDefs,
 } from '@atproto/api'
 
 import {atoms as a, native, tokens, useTheme, web} from '#/alf'
 import {Embed, PostEmbedViewContext} from '#/components/Post/Embed'
+import {DMImageContentHider} from './DMImageContentHider'
 import {MessageContextProvider} from './MessageContext'
 
 let MessageItemEmbed = ({
   embed,
+  message,
+  convo,
 }: {
   embed: $Typed<AppBskyEmbedRecord.View> | $Typed<AppBskyEmbedImages.View>
+  message: ChatBskyConvoDefs.MessageView
+  convo: ChatBskyConvoDefs.ConvoView
 }): React.ReactNode => {
   const t = useTheme()
   const screen = useWindowDimensions()
+
+  const embedContent = (
+    <Embed
+      embed={embed}
+      allowNestedQuotes
+      viewContext={PostEmbedViewContext.Feed}
+    />
+  )
 
   return (
     <MessageContextProvider>
@@ -36,11 +50,13 @@ let MessageItemEmbed = ({
           }),
         ]}>
         <View style={{marginTop: tokens.space.sm * -1}}>
-          <Embed
-            embed={embed}
-            allowNestedQuotes
-            viewContext={PostEmbedViewContext.Feed}
-          />
+          {AppBskyEmbedImages.isView(embed) ? (
+            <DMImageContentHider message={message} convo={convo}>
+              {embedContent}
+            </DMImageContentHider>
+          ) : (
+            embedContent
+          )}
         </View>
       </View>
     </MessageContextProvider>

--- a/src/components/dms/moderation/README.md
+++ b/src/components/dms/moderation/README.md
@@ -1,0 +1,160 @@
+# DM Image Moderation System
+
+This module provides a pluggable, extensible architecture for moderating images in Direct Messages.
+
+## Design Philosophy
+
+**Separation of Concerns:**
+- **Client-Side Privacy**: User preferences for personal control (current)
+- **Platform Moderation**: Backend policies for abuse prevention (future)
+
+These serve different needs and can coexist. User preferences give immediate control while AT Protocol designs the "permissioned data" infrastructure for platform-level moderation.
+
+## Architecture
+
+The system uses a priority-based pipeline:
+
+```
+1. Backend Moderation (highest priority - future)
+   ↓
+2. Custom Policies (extensible)
+   ↓
+3. User Preferences (current)
+   ↓
+4. No Blur (default)
+```
+
+## Current Implementation
+
+### User Preferences
+- **Always Blur**: Blur all DM images
+- **Blur From Non-Follows**: Blur images from accounts not followed
+
+Settings: `Messages Settings > Image Privacy`
+
+## Future Integration
+
+### Adding Backend Moderation
+
+When AT Protocol adds moderation support:
+
+```typescript
+// 1. Protocol adds moderation field
+interface MessageView {
+  moderation?: ModerationUI
+}
+
+// 2. In parent component, call moderation function
+const modui = moderateMessage(message, moderationOpts)
+
+// 3. Pass to DMImageContentHider
+<DMImageContentHider
+  message={message}
+  convo={convo}
+  moderation={modui}  // ← Automatically takes priority
+>
+  {children}
+</DMImageContentHider>
+```
+
+**No component changes needed** - the pipeline automatically prioritizes backend moderation.
+
+### Adding Custom Policies
+
+Create policies that match your needs:
+
+```typescript
+import {ModerationPolicy} from './moderation/types'
+
+const myCustomPolicy: ModerationPolicy = {
+  name: 'my-policy',
+  priority: 5,  // Lower = higher priority
+  evaluate: (context) => {
+    // Your logic here
+    if (shouldBlur) {
+      return {
+        shouldBlur: true,
+        source: 'user-preference',
+        modui: createModerationUI(),
+        reason: 'custom-rule',
+      }
+    }
+    return null  // Pass to next policy
+  },
+}
+
+// Use it
+<DMImageContentHider
+  message={message}
+  convo={convo}
+  customPolicies={[myCustomPolicy]}
+>
+  {children}
+</DMImageContentHider>
+```
+
+See `example-policies.ts` for more examples.
+
+### Adding Analytics
+
+Track moderation decisions:
+
+```typescript
+<DMImageContentHider
+  message={message}
+  convo={convo}
+  onModerationDecision={(decision) => {
+    analytics.track('dm_image_moderation', {
+      source: decision.source,
+      reason: decision.reason,
+      shouldBlur: decision.shouldBlur,
+    })
+  }}
+>
+  {children}
+</DMImageContentHider>
+```
+
+## Extension Points
+
+### For Product Team
+
+1. **Regional Policies**: Different content standards per region
+2. **A/B Testing**: Test new moderation approaches
+3. **ML Integration**: Machine learning-based content detection
+4. **Reputation System**: Blur based on sender trust scores
+5. **Reporting Integration**: Connect to abuse reporting pipeline
+
+### For Protocol Team
+
+1. **Moderation Field**: Add `MessageView.moderation?: ModerationUI`
+2. **Moderation Function**: Implement `moderateMessage(message, opts)`
+3. **Label Definitions**: Define DM-specific content labels
+4. **Policy Config**: Server-driven policy configuration
+
+## File Structure
+
+```
+moderation/
+├── README.md                 # This file
+├── index.ts                  # Public exports
+├── types.ts                  # Type definitions
+├── useModerationDecision.ts  # Decision pipeline hook
+└── example-policies.ts       # Policy examples
+```
+
+## Testing
+
+See `__tests__/components/dms/DMImageContentHider.test.tsx` for comprehensive test coverage including:
+- User preference logic
+- Priority system verification
+- Edge case handling
+- Backend moderation integration
+
+## Principles
+
+1. **Extensible**: Easy to add new policies without modifying core code
+2. **Predictable**: Clear priority system and decision flow
+3. **Testable**: Isolated decision logic for comprehensive testing
+4. **Future-Proof**: Designed for backend integration without breaking changes
+5. **Respectful**: Acknowledges moderation is complex, not trivial

--- a/src/components/dms/moderation/example-policies.ts
+++ b/src/components/dms/moderation/example-policies.ts
@@ -1,0 +1,149 @@
+/**
+ * Example Custom Moderation Policies
+ *
+ * This file demonstrates how Bluesky can add new moderation policies
+ * without modifying the core DMImageContentHider component.
+ *
+ * USAGE:
+ * ------
+ * Import these policies and pass to DMImageContentHider via customPolicies prop:
+ *
+ * ```tsx
+ * <DMImageContentHider
+ *   message={message}
+ *   convo={convo}
+ *   customPolicies={[regionalPolicy, betaTestPolicy]}
+ *   onModerationDecision={analyticsCallback}
+ * >
+ *   {children}
+ * </DMImageContentHider>
+ * ```
+ *
+ * ADDING NEW POLICIES:
+ * --------------------
+ * 1. Define policy with name, priority, and evaluate function
+ * 2. Priority determines order (lower = higher priority)
+ * 3. Return ModerationDecision or null to pass to next policy
+ * 4. Can access full message/convo context
+ */
+
+import {type ModerationContext, type ModerationPolicy} from './types'
+
+/**
+ * Example: Regional content policy
+ * Different regions may have different content standards
+ */
+export const regionalContentPolicy: ModerationPolicy = {
+  name: 'regional-content',
+  priority: 5, // Between backend (1-4) and user prefs (10+)
+  evaluate: (_context: ModerationContext) => {
+    // Example: Check if user is in EU and apply stricter standards
+    const userRegion = getUserRegion() // Implement based on your geo system
+
+    if (userRegion === 'EU') {
+      // Could check message metadata, sender reputation, etc.
+      // For now, just an example structure
+      return null // Pass to next policy
+    }
+
+    return null
+  },
+}
+
+/**
+ * Example: Beta testing policy
+ * Enable new moderation features for subset of users
+ */
+export const betaTestPolicy: ModerationPolicy = {
+  name: 'beta-test',
+  priority: 8,
+  evaluate: (context: ModerationContext) => {
+    const isBetaUser = checkBetaStatus(context.currentUserDid)
+
+    if (isBetaUser) {
+      // Beta users get experimental ML-based blur
+      // const mlScore = await checkImageSafety(message.embed)
+      // if (mlScore < threshold) {
+      //   return createBlurDecision('ml-based-blur')
+      // }
+    }
+
+    return null
+  },
+}
+
+/**
+ * Example: Sender reputation policy
+ * Could blur images from senders with poor reputation scores
+ */
+export const senderReputationPolicy: ModerationPolicy = {
+  name: 'sender-reputation',
+  priority: 7,
+  evaluate: (_context: ModerationContext) => {
+    // Example: Check sender's reputation from trust & safety system
+    // const reputation = await getSenderReputation(_context.message.sender.did)
+    //
+    // if (reputation.score < THRESHOLD) {
+    //   return {
+    //     shouldBlur: true,
+    //     source: 'user-preference', // Custom source types could be added
+    //     modui: createModerationUI(),
+    //     reason: 'low-sender-reputation',
+    //   }
+    // }
+
+    return null
+  },
+}
+
+/**
+ * Example: Time-based policy
+ * Different rules for late-night messages, etc.
+ */
+export const timeBasedPolicy: ModerationPolicy = {
+  name: 'time-based',
+  priority: 9,
+  evaluate: (context: ModerationContext) => {
+    const messageTime = new Date(context.message.sentAt)
+    const _hour = messageTime.getHours()
+
+    // Example: Be more cautious with late-night messages
+    // if (_hour >= 23 || _hour <= 5) {
+    //   Could apply stricter checks
+    // }
+
+    return null
+  },
+}
+
+// Helper functions (implement based on your systems)
+function getUserRegion(): string {
+  // Implement geolocation check
+  return 'US'
+}
+
+function checkBetaStatus(_did: string | undefined): boolean {
+  // Check if user is in beta program
+  return false
+}
+
+/**
+ * ANALYTICS CALLBACK EXAMPLE:
+ * ----------------------------
+ * Track moderation decisions for metrics and improvements
+ */
+export function exampleAnalyticsCallback(decision: any) {
+  // Log to analytics system
+  console.log('Moderation decision:', {
+    source: decision.source,
+    reason: decision.reason,
+    timestamp: new Date().toISOString(),
+  })
+
+  // Could send to Sentry, PostHog, etc.
+  // analytics.track('dm_image_moderation', {
+  //   source: decision.source,
+  //   shouldBlur: decision.shouldBlur,
+  //   reason: decision.reason,
+  // })
+}

--- a/src/components/dms/moderation/index.ts
+++ b/src/components/dms/moderation/index.ts
@@ -1,0 +1,19 @@
+/**
+ * DM Image Moderation System
+ *
+ * This module provides a pluggable architecture for moderating images in Direct Messages.
+ * It's designed to handle both client-side privacy preferences and future platform-level
+ * moderation without requiring architectural changes.
+ *
+ * CURRENT USE:
+ * - User privacy preferences (blur from non-follows, always blur)
+ *
+ * FUTURE EXTENSIBILITY:
+ * - Backend moderation via AT Protocol
+ * - Custom regional policies
+ * - A/B testing different moderation approaches
+ * - Analytics and reporting hooks
+ */
+
+export * from './types'
+export {useModerationDecision} from './useModerationDecision'

--- a/src/components/dms/moderation/types.ts
+++ b/src/components/dms/moderation/types.ts
@@ -1,0 +1,52 @@
+import {type ChatBskyConvoDefs, type ModerationUI} from '@atproto/api'
+
+/**
+ * Moderation decision pipeline for DM images
+ *
+ * This type system provides extension points for additional moderation sources
+ * as the AT Protocol evolves. Each source has a clear priority and can be
+ * independently enabled/disabled.
+ */
+
+export type ModerationSource = 'backend' | 'user-preference' | 'none'
+
+export interface ModerationDecision {
+  shouldBlur: boolean
+  source: ModerationSource
+  modui?: ModerationUI
+  reason?: string
+}
+
+/**
+ * Context passed to moderation decision functions
+ * Extensible - add new fields as AT Protocol adds capabilities
+ */
+export interface ModerationContext {
+  message: ChatBskyConvoDefs.MessageView
+  convo: ChatBskyConvoDefs.ConvoView
+  currentUserDid: string | undefined
+
+  // Future extensions can add:
+  // - reportingCallback?: (decision: ModerationDecision) => void
+  // - analyticsCallback?: (decision: ModerationDecision) => void
+  // - customPolicies?: ModerationPolicy[]
+}
+
+/**
+ * Moderation policy interface - allows Bluesky to inject custom policies
+ * without modifying component code
+ */
+export interface ModerationPolicy {
+  name: string
+  priority: number
+  evaluate: (context: ModerationContext) => ModerationDecision | null
+}
+
+/**
+ * User preference for DM image blurring
+ * Separate from platform policies to maintain clear separation of concerns
+ */
+export interface UserBlurPreferences {
+  blurFromNonFollows: boolean
+  alwaysBlur: boolean
+}

--- a/src/components/dms/moderation/useModerationDecision.ts
+++ b/src/components/dms/moderation/useModerationDecision.ts
@@ -1,0 +1,173 @@
+import {ModerationUI} from '@atproto/api'
+
+import {
+  useDmImageAlwaysBlur,
+  useDmImageBlurFromNonFollows,
+} from '#/state/preferences'
+import {useSession} from '#/state/session'
+import {
+  type ModerationContext,
+  type ModerationDecision,
+  type ModerationPolicy,
+  type UserBlurPreferences,
+} from './types'
+
+/**
+ * Moderation decision hook for DM images
+ *
+ * This hook implements a pluggable moderation pipeline that provides clear
+ * extension points for backend moderation when ready. The architecture follows
+ * a clear priority system:
+ *
+ * 1. BACKEND MODERATION (highest priority - not yet available)
+ *    - When AT Protocol adds moderation field to MessageView
+ *    - Platform policies based on content labeling
+ *    - Automatically takes precedence over everything else
+ *
+ * 2. CUSTOM POLICIES (extensible - easy to add)
+ *    - Can inject via customPolicies parameter
+ *    - Sorted by priority
+ *    - Enables A/B testing, regional rules, etc.
+ *
+ * 3. USER PREFERENCES (current implementation)
+ *    - Client-side privacy controls
+ *    - Always blur or blur from non-follows
+ *    - Fallback when no platform moderation exists
+ *
+ * EXTENSION POINTS:
+ * - Add customPolicies array to inject new moderation sources
+ * - Pass onDecision callback for analytics/reporting
+ * - Backend just needs to populate message.moderation field
+ *
+ * NO CODE CHANGES needed when backend moderation arrives - it automatically
+ * takes priority via the pipeline.
+ */
+export function useModerationDecision(
+  context: ModerationContext,
+  options?: {
+    backendModeration?: ModerationUI
+    customPolicies?: ModerationPolicy[]
+    onDecision?: (decision: ModerationDecision) => void
+  },
+): ModerationDecision {
+  const {currentAccount} = useSession()
+  const alwaysBlur = useDmImageAlwaysBlur()
+  const blurFromNonFollows = useDmImageBlurFromNonFollows()
+
+  const currentUserDid = currentAccount?.did
+  const {message} = context
+
+  // STAGE 0: Safety checks - never moderate own messages or invalid data
+  if (
+    !message.sender ||
+    (currentUserDid && message.sender.did === currentUserDid)
+  ) {
+    const decision: ModerationDecision = {
+      shouldBlur: false,
+      source: 'none',
+      reason: 'own-message',
+    }
+    options?.onDecision?.(decision)
+    return decision
+  }
+
+  // STAGE 1: Backend moderation (future - highest priority)
+  // When AT Protocol adds: message.moderation or passes via props
+  if (options?.backendModeration) {
+    const decision: ModerationDecision = {
+      shouldBlur: true,
+      source: 'backend',
+      modui: options.backendModeration,
+      reason: 'platform-policy',
+    }
+    options?.onDecision?.(decision)
+    return decision
+  }
+
+  // STAGE 2: Custom policies (extensible)
+  // Bluesky can inject policies here without modifying this component
+  if (options?.customPolicies) {
+    const sortedPolicies = [...options.customPolicies].sort(
+      (a, b) => a.priority - b.priority,
+    )
+    for (const policy of sortedPolicies) {
+      const policyDecision = policy.evaluate(context)
+      if (policyDecision) {
+        options?.onDecision?.(policyDecision)
+        return policyDecision
+      }
+    }
+  }
+
+  // STAGE 3: User preferences (current implementation)
+  const userPrefs: UserBlurPreferences = {
+    alwaysBlur: alwaysBlur ?? false,
+    blurFromNonFollows: blurFromNonFollows ?? false,
+  }
+
+  const decision = evaluateUserPreferences(context, userPrefs, currentUserDid)
+  options?.onDecision?.(decision)
+  return decision
+}
+
+/**
+ * Evaluate user preference-based blur decisions
+ * Isolated for easier testing and policy updates
+ */
+function evaluateUserPreferences(
+  context: ModerationContext,
+  prefs: UserBlurPreferences,
+  _currentUserDid: string | undefined,
+): ModerationDecision {
+  const {message, convo} = context
+
+  // User wants all images blurred
+  if (prefs.alwaysBlur) {
+    return {
+      shouldBlur: true,
+      source: 'user-preference',
+      modui: createSyntheticModeration(),
+      reason: 'user-always-blur',
+    }
+  }
+
+  // User wants non-follows blurred
+  if (prefs.blurFromNonFollows) {
+    const sender = convo.members.find(
+      member => member.did === message.sender?.did,
+    )
+
+    // Blur if: sender not in members (safer default) OR not following
+    if (!sender || !sender.viewer?.following) {
+      return {
+        shouldBlur: true,
+        source: 'user-preference',
+        modui: createSyntheticModeration(),
+        reason: 'user-non-follow',
+      }
+    }
+  }
+
+  // No blur conditions met
+  return {
+    shouldBlur: false,
+    source: 'none',
+    reason: 'no-blur-policy',
+  }
+}
+
+/**
+ * Create synthetic ModerationUI for user preferences
+ * Uses 'hidden' type which is appropriate for user-driven blur
+ */
+function createSyntheticModeration(): ModerationUI {
+  const modui = new ModerationUI()
+  modui.blurs = [
+    {
+      type: 'hidden',
+      source: {type: 'user'},
+      priority: 6,
+    },
+  ]
+  return modui
+}

--- a/src/locale/locales/en/messages.po
+++ b/src/locale/locales/en/messages.po
@@ -180,7 +180,7 @@ msgstr ""
 msgid "{0} out of 50"
 msgstr ""
 
-#: src/components/dms/MessageItem.tsx:143
+#: src/components/dms/MessageItem.tsx:144
 msgid "{0} reacted {1}"
 msgstr ""
 
@@ -732,6 +732,7 @@ msgstr ""
 msgid "Add account"
 msgstr ""
 
+#: src/screens/Messages/components/MessageInputImages.tsx:118
 #: src/view/com/composer/GifAltText.tsx:76
 #: src/view/com/composer/GifAltText.tsx:144
 #: src/view/com/composer/GifAltText.tsx:211
@@ -771,12 +772,20 @@ msgstr ""
 msgid "Add App Password"
 msgstr ""
 
+#: src/screens/Messages/components/MessageInputImages.tsx:120
+msgid "Add descriptive alt text for accessibility"
+msgstr ""
+
 #: src/components/dms/EmojiReactionPicker.web.tsx:35
 msgid "Add emoji reaction"
 msgstr ""
 
 #: src/view/com/feeds/ComposerPrompt.tsx:223
 msgid "Add image"
+msgstr ""
+
+#: src/screens/Messages/components/MessageInput.tsx:235
+msgid "Add images"
 msgstr ""
 
 #. Accessibility label for button in composer to add images, a video, or a GIF to a post
@@ -968,8 +977,8 @@ msgstr ""
 msgid "Allow location access"
 msgstr ""
 
-#: src/screens/Messages/Settings.tsx:75
-#: src/screens/Messages/Settings.tsx:78
+#: src/screens/Messages/Settings.tsx:85
+#: src/screens/Messages/Settings.tsx:88
 msgid "Allow new messages from"
 msgstr ""
 
@@ -1047,6 +1056,11 @@ msgstr ""
 #: src/view/com/composer/GifAltText.tsx:179
 #: src/view/com/composer/photos/ImageAltTextDialog.tsx:138
 msgid "Alt text will be truncated. {MAX_ALT_TEXT, plural, other {Limit: {0} characters.}}"
+msgstr ""
+
+#: src/screens/Messages/Settings.tsx:189
+#: src/screens/Messages/Settings.tsx:194
+msgid "Always blur images in messages"
 msgstr ""
 
 #: src/screens/Settings/components/DisableEmail2FADialog.tsx:93
@@ -1648,6 +1662,11 @@ msgstr ""
 msgid "Blur images and filter from feeds"
 msgstr ""
 
+#: src/screens/Messages/Settings.tsx:178
+#: src/screens/Messages/Settings.tsx:183
+msgid "Blur images from accounts you don't follow"
+msgstr ""
+
 #: src/lib/interests.ts:54
 msgid "Books"
 msgstr ""
@@ -1942,7 +1961,7 @@ msgstr ""
 msgid "Chat settings"
 msgstr ""
 
-#: src/screens/Messages/Settings.tsx:67
+#: src/screens/Messages/Settings.tsx:77
 msgid "Chat Settings"
 msgstr ""
 
@@ -2072,7 +2091,7 @@ msgstr ""
 msgid "Click to open tag menu for {0}"
 msgstr ""
 
-#: src/components/dms/MessageItem.tsx:318
+#: src/components/dms/MessageItem.tsx:324
 msgid "Click to retry failed message"
 msgstr ""
 
@@ -2421,6 +2440,10 @@ msgstr ""
 #: src/screens/Onboarding/StepSuggestedStarterpacks/index.tsx:113
 #: src/screens/Signup/BackNextButtons.tsx:60
 msgid "Continue to next step"
+msgstr ""
+
+#: src/screens/Messages/Settings.tsx:170
+msgid "Control when images in messages are blurred. Your own images are never blurred."
 msgstr ""
 
 #: src/screens/Messages/Conversation.tsx:57
@@ -2985,8 +3008,8 @@ msgstr ""
 #: src/lib/moderation/useLabelBehaviorDescription.ts:35
 #: src/lib/moderation/useLabelBehaviorDescription.ts:45
 #: src/lib/moderation/useLabelBehaviorDescription.ts:71
-#: src/screens/Messages/Settings.tsx:144
-#: src/screens/Messages/Settings.tsx:147
+#: src/screens/Messages/Settings.tsx:154
+#: src/screens/Messages/Settings.tsx:157
 #: src/screens/Moderation/index.tsx:384
 msgid "Disabled"
 msgstr ""
@@ -3143,7 +3166,7 @@ msgstr ""
 msgid "Done{extraText}"
 msgstr ""
 
-#: src/components/dms/MessageItem.tsx:161
+#: src/components/dms/MessageItem.tsx:162
 msgid "Double tap or long press the message to add a reaction"
 msgstr ""
 
@@ -3441,8 +3464,8 @@ msgstr ""
 msgid "Enable trending videos in your Discover feed"
 msgstr ""
 
-#: src/screens/Messages/Settings.tsx:135
-#: src/screens/Messages/Settings.tsx:138
+#: src/screens/Messages/Settings.tsx:145
+#: src/screens/Messages/Settings.tsx:148
 #: src/screens/Moderation/index.tsx:382
 msgid "Enabled"
 msgstr ""
@@ -3560,8 +3583,8 @@ msgstr ""
 msgid "Everybody can reply to this post."
 msgstr ""
 
-#: src/screens/Messages/Settings.tsx:88
-#: src/screens/Messages/Settings.tsx:91
+#: src/screens/Messages/Settings.tsx:98
+#: src/screens/Messages/Settings.tsx:101
 #: src/screens/Settings/NotificationSettings/components/PreferenceControls.tsx:168
 #: src/screens/Settings/NotificationSettings/components/PreferenceControls.tsx:178
 msgid "Everyone"
@@ -3853,7 +3876,11 @@ msgctxt "toast"
 msgid "Failed to save your interests."
 msgstr ""
 
-#: src/components/dms/MessageItem.tsx:311
+#: src/screens/Messages/components/MessageInput.tsx:165
+msgid "Failed to select images"
+msgstr ""
+
+#: src/components/dms/MessageItem.tsx:317
 msgid "Failed to send"
 msgstr ""
 
@@ -3893,8 +3920,12 @@ msgstr ""
 msgid "Failed to update notification declaration"
 msgstr ""
 
-#: src/screens/Messages/Settings.tsx:39
+#: src/screens/Messages/Settings.tsx:49
 msgid "Failed to update settings"
+msgstr ""
+
+#: src/screens/Messages/components/MessagesList.tsx:375
+msgid "Failed to upload images"
 msgstr ""
 
 #: src/lib/media/video/upload.ts:72
@@ -3925,6 +3956,7 @@ msgid "Feed"
 msgstr ""
 
 #: src/components/FeedCard.tsx:171
+#: src/state/queries/feed.ts:121
 #: src/view/com/feeds/FeedSourceCard.tsx:150
 msgid "Feed by {0}"
 msgstr ""
@@ -4899,6 +4931,10 @@ msgstr ""
 msgid "Image cache cleared, freed {0}"
 msgstr ""
 
+#: src/screens/Messages/Settings.tsx:167
+msgid "Image Privacy"
+msgstr ""
+
 #: src/lib/media/save-image.ios.ts:25
 #: src/lib/media/save-image.ts:29
 msgid "Image saved"
@@ -5711,11 +5747,11 @@ msgstr ""
 msgid "Message from server: {0}"
 msgstr ""
 
-#: src/screens/Messages/components/MessageInput.tsx:152
+#: src/screens/Messages/components/MessageInput.tsx:194
 msgid "Message input field"
 msgstr ""
 
-#: src/screens/Messages/components/MessageInput.tsx:79
+#: src/screens/Messages/components/MessageInput.tsx:91
 #: src/screens/Messages/components/MessageInput.web.tsx:60
 msgid "Message is too long"
 msgstr ""
@@ -6208,8 +6244,8 @@ msgstr ""
 msgid "No notifications yet!"
 msgstr ""
 
-#: src/screens/Messages/Settings.tsx:106
-#: src/screens/Messages/Settings.tsx:109
+#: src/screens/Messages/Settings.tsx:116
+#: src/screens/Messages/Settings.tsx:119
 #: src/screens/Settings/ActivityPrivacySettings.tsx:129
 #: src/screens/Settings/ActivityPrivacySettings.tsx:134
 #: src/screens/Settings/PrivacyAndSecuritySettings.tsx:159
@@ -6363,11 +6399,11 @@ msgstr ""
 msgid "Notification settings"
 msgstr ""
 
-#: src/screens/Messages/Settings.tsx:128
+#: src/screens/Messages/Settings.tsx:138
 msgid "Notification sounds"
 msgstr ""
 
-#: src/screens/Messages/Settings.tsx:125
+#: src/screens/Messages/Settings.tsx:135
 msgid "Notification Sounds"
 msgstr ""
 
@@ -6402,7 +6438,7 @@ msgstr ""
 msgid "now"
 msgstr ""
 
-#: src/components/dms/MessageItem.tsx:275
+#: src/components/dms/MessageItem.tsx:281
 msgid "Now"
 msgstr ""
 
@@ -6459,6 +6495,7 @@ msgstr ""
 msgid "One or more GIFs is missing alt text."
 msgstr ""
 
+#: src/screens/Messages/components/MessagesList.tsx:322
 #: src/view/com/composer/Composer.tsx:704
 msgid "One or more images is missing alt text."
 msgstr ""
@@ -7638,6 +7675,7 @@ msgstr ""
 msgid "Remove from your feeds?"
 msgstr ""
 
+#: src/screens/Messages/components/MessageInputImages.tsx:133
 #: src/view/com/composer/photos/Gallery.tsx:204
 msgid "Remove image"
 msgstr ""
@@ -7722,6 +7760,10 @@ msgstr ""
 
 #: src/components/verification/VerificationRemovePrompt.tsx:32
 msgid "Removed verification"
+msgstr ""
+
+#: src/screens/Messages/components/MessageInputImages.tsx:134
+msgid "Removes this image from the message"
 msgstr ""
 
 #: src/view/com/posts/FeedShutdownMsg.tsx:129
@@ -8037,7 +8079,7 @@ msgstr ""
 #: src/components/ageAssurance/AgeAssuranceErrors.tsx:30
 #: src/components/contacts/screens/VerifyNumber.tsx:349
 #: src/components/contacts/screens/VerifyNumber.tsx:354
-#: src/components/dms/MessageItem.tsx:322
+#: src/components/dms/MessageItem.tsx:328
 #: src/components/Error.tsx:65
 #: src/components/Lists.tsx:114
 #: src/components/moderation/ReportDialog/index.tsx:281
@@ -8447,6 +8489,10 @@ msgstr ""
 msgid "Select how long to mute this word for."
 msgstr ""
 
+#: src/screens/Messages/components/MessageInput.tsx:236
+msgid "Select images to send"
+msgstr ""
+
 #: src/components/AppLanguageDropdown.tsx:69
 #: src/components/LanguageSelect.tsx:37
 #: src/components/LanguageSelect.tsx:38
@@ -8520,6 +8566,10 @@ msgstr ""
 msgid "Select your preferred notification channels"
 msgstr ""
 
+#: src/screens/Messages/components/MessageInputImages.tsx:111
+msgid "Selected image"
+msgstr ""
+
 #: src/view/com/composer/SelectMediaButton.tsx:396
 msgid "Selecting multiple media types is not supported."
 msgstr ""
@@ -8553,7 +8603,7 @@ msgstr ""
 msgid "Send feedback"
 msgstr ""
 
-#: src/screens/Messages/components/MessageInput.tsx:192
+#: src/screens/Messages/components/MessageInput.tsx:258
 #: src/screens/Messages/components/MessageInput.web.tsx:235
 msgid "Send message"
 msgstr ""
@@ -9035,7 +9085,7 @@ msgstr ""
 msgid "Some people can reply"
 msgstr ""
 
-#: src/components/dms/MessageItem.tsx:148
+#: src/components/dms/MessageItem.tsx:149
 msgid "Someone reacted {0}"
 msgstr ""
 
@@ -10104,7 +10154,7 @@ msgstr ""
 msgid "Two-factor authentication (2FA)"
 msgstr ""
 
-#: src/screens/Messages/components/MessageInput.tsx:153
+#: src/screens/Messages/components/MessageInput.tsx:195
 msgid "Type your message here"
 msgstr ""
 
@@ -10517,6 +10567,10 @@ msgstr ""
 msgid "User list by {0}"
 msgstr ""
 
+#: src/state/queries/feed.ts:162
+msgid "User List by {0}"
+msgstr ""
+
 #: src/view/com/modals/UserAddRemoveLists.tsx:212
 msgid "User list by you"
 msgstr ""
@@ -10555,8 +10609,8 @@ msgstr ""
 msgid "users following <0>@{0}</0>"
 msgstr ""
 
-#: src/screens/Messages/Settings.tsx:97
-#: src/screens/Messages/Settings.tsx:100
+#: src/screens/Messages/Settings.tsx:107
+#: src/screens/Messages/Settings.tsx:110
 msgid "Users I follow"
 msgstr ""
 
@@ -11100,6 +11154,10 @@ msgstr ""
 msgid "What's up?"
 msgstr ""
 
+#: src/screens/Messages/Settings.tsx:200
+msgid "When available, platform moderation will also apply to message images based on your content filter preferences."
+msgstr ""
+
 #: src/components/dialogs/nuxs/InitialVerificationAnnouncement.tsx:147
 msgid "When you tap on a check, you’ll see which organizations have granted verification."
 msgstr ""
@@ -11180,7 +11238,7 @@ msgstr ""
 msgid "Would you like to save this as a draft to edit later?"
 msgstr ""
 
-#: src/screens/Messages/components/MessageInput.tsx:154
+#: src/screens/Messages/components/MessageInput.tsx:196
 #: src/screens/Messages/components/MessageInput.web.tsx:214
 msgid "Write a message"
 msgstr ""
@@ -11320,7 +11378,7 @@ msgstr ""
 msgid "You can choose whether chat notifications have sound in the chat settings within the app"
 msgstr ""
 
-#: src/screens/Messages/Settings.tsx:116
+#: src/screens/Messages/Settings.tsx:126
 msgid "You can continue ongoing conversations regardless of which setting you choose."
 msgstr ""
 
@@ -11336,6 +11394,10 @@ msgstr ""
 #: src/screens/Login/index.tsx:197
 #: src/screens/Login/PasswordUpdatedForm.tsx:26
 msgid "You can now sign in with your new password."
+msgstr ""
+
+#: src/screens/Messages/components/MessageInput.tsx:148
+msgid "You can only add up to 4 images"
 msgstr ""
 
 #: src/view/com/composer/SelectMediaButton.tsx:413
@@ -11556,7 +11618,7 @@ msgstr ""
 msgid "You probably want to restart the app now."
 msgstr ""
 
-#: src/components/dms/MessageItem.tsx:135
+#: src/components/dms/MessageItem.tsx:136
 msgid "You reacted {0}"
 msgstr ""
 

--- a/src/screens/Messages/Settings.tsx
+++ b/src/screens/Messages/Settings.tsx
@@ -5,6 +5,12 @@ import {useLingui} from '@lingui/react'
 import {type NativeStackScreenProps} from '@react-navigation/native-stack'
 
 import {type CommonNavigatorParams} from '#/lib/routes/types'
+import {
+  useDmImageAlwaysBlur,
+  useDmImageBlurFromNonFollows,
+  useSetDmImageAlwaysBlur,
+  useSetDmImageBlurFromNonFollows,
+} from '#/state/preferences'
 import {useUpdateActorDeclaration} from '#/state/queries/messages/actor-declaration'
 import {useProfileQuery} from '#/state/queries/profile'
 import {useSession} from '#/state/session'
@@ -33,6 +39,10 @@ export function MessagesSettingsScreenInner({}: Props) {
     did: currentAccount!.did,
   })
   const {preferences, setPref} = useBackgroundNotificationPreferences()
+  const blurFromNonFollows = useDmImageBlurFromNonFollows()
+  const setBlurFromNonFollows = useSetDmImageBlurFromNonFollows()
+  const alwaysBlur = useDmImageAlwaysBlur()
+  const setAlwaysBlur = useSetDmImageAlwaysBlur()
 
   const {mutate: updateDeclaration} = useUpdateActorDeclaration({
     onError: () => {
@@ -152,6 +162,46 @@ export function MessagesSettingsScreenInner({}: Props) {
               </Toggle.Group>
             </>
           )}
+          <Divider style={a.my_md} />
+          <Text style={[a.text_lg, a.font_semi_bold]}>
+            <Trans>Image Privacy</Trans>
+          </Text>
+          <Text style={[a.text_sm, a.pb_md, a.leading_snug]}>
+            <Trans>
+              Control when images in messages are blurred. Your own images are
+              never blurred.
+            </Trans>
+          </Text>
+          <View>
+            <Toggle.Item
+              name="dmImageBlurFromNonFollows"
+              label={_(msg`Blur images from accounts you don't follow`)}
+              value={blurFromNonFollows ?? false}
+              onChange={setBlurFromNonFollows}
+              style={[a.justify_between, a.py_sm]}>
+              <Toggle.LabelText>
+                <Trans>Blur images from accounts you don't follow</Trans>
+              </Toggle.LabelText>
+              <Toggle.Checkbox />
+            </Toggle.Item>
+            <Toggle.Item
+              name="dmImageAlwaysBlur"
+              label={_(msg`Always blur images in messages`)}
+              value={alwaysBlur ?? false}
+              onChange={setAlwaysBlur}
+              style={[a.justify_between, a.py_sm]}>
+              <Toggle.LabelText>
+                <Trans>Always blur images in messages</Trans>
+              </Toggle.LabelText>
+              <Toggle.Checkbox />
+            </Toggle.Item>
+          </View>
+          <Admonition type="tip" style={[a.mt_md]}>
+            <Trans>
+              When available, platform moderation will also apply to message
+              images based on your content filter preferences.
+            </Trans>
+          </Admonition>
         </View>
       </Layout.Content>
     </Layout.Screen>

--- a/src/screens/Messages/components/MessageInput.tsx
+++ b/src/screens/Messages/components/MessageInput.tsx
@@ -18,7 +18,9 @@ import {countGraphemes} from 'unicode-segmenter/grapheme'
 
 import {HITSLOP_10, MAX_DM_GRAPHEME_LENGTH} from '#/lib/constants'
 import {useHaptics} from '#/lib/haptics'
+import {openPicker} from '#/lib/media/picker'
 import {useEmail} from '#/state/email-verification'
+import {type ComposerImage, createComposerImage} from '#/state/gallery'
 import {
   useMessageDraft,
   useSaveMessageDraft,
@@ -27,6 +29,7 @@ import {type EmojiPickerPosition} from '#/view/com/composer/text-input/web/Emoji
 import * as Toast from '#/view/com/util/Toast'
 import {android, atoms as a, useTheme} from '#/alf'
 import {useSharedInputStyles} from '#/components/forms/TextField'
+import {Image_Stroke2_Corner0_Rounded as ImageIcon} from '#/components/icons/Image'
 import {PaperPlane_Stroke2_Corner0_Rounded as PaperPlane} from '#/components/icons/PaperPlane'
 import {IS_IOS, IS_WEB} from '#/env'
 import {useExtractEmbedFromFacets} from './MessageInputEmbed'
@@ -38,12 +41,16 @@ export function MessageInput({
   hasEmbed,
   setEmbed,
   children,
+  onSelectImages,
+  imageCount = 0,
 }: {
   onSendMessage: (message: string) => void
   hasEmbed: boolean
   setEmbed: (embedUrl: string | undefined) => void
   children?: React.ReactNode
   openEmojiPicker?: (pos: EmojiPickerPosition) => void
+  onSelectImages?: (images: ComposerImage[]) => void
+  imageCount?: number
 }) {
   const {_} = useLingui()
   const t = useTheme()
@@ -131,6 +138,28 @@ export function MessageInput({
     scrollEnabled: isInputScrollable.get(),
   }))
 
+  const onPressSelectImages = useCallback(async () => {
+    if (imageCount >= 4) {
+      Toast.show(_(msg`You can only add up to 4 images`), 'xmark')
+      return
+    }
+    try {
+      const pickedImages = await openPicker({
+        selectionLimit: 4 - imageCount,
+      })
+      if (pickedImages.length === 0) return
+
+      const composerImages = await Promise.all(
+        pickedImages.map(img => createComposerImage(img)),
+      )
+      onSelectImages?.(composerImages)
+    } catch (err) {
+      // User cancelled or error occurred
+      if (String(err).includes('cancel')) return
+      Toast.show(_(msg`Failed to select images`), 'xmark')
+    }
+  }, [_, imageCount, onSelectImages])
+
   return (
     <View style={[a.px_md, a.pb_sm, a.pt_xs]}>
       {children}
@@ -187,6 +216,30 @@ export function MessageInput({
           animatedProps={animatedProps}
           editable={!needsEmailVerification}
         />
+        {onSelectImages && (
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={_(msg`Add images`)}
+            accessibilityHint={_(msg`Select images to send`)}
+            hitSlop={HITSLOP_10}
+            style={[
+              a.rounded_full,
+              a.align_center,
+              a.justify_center,
+              {height: 30, width: 30},
+            ]}
+            onPress={onPressSelectImages}
+            disabled={needsEmailVerification || imageCount >= 4}>
+            <ImageIcon
+              size="lg"
+              fill={
+                imageCount >= 4
+                  ? t.palette.contrast_300
+                  : t.palette.contrast_600
+              }
+            />
+          </Pressable>
+        )}
         <Pressable
           accessibilityRole="button"
           accessibilityLabel={_(msg`Send message`)}

--- a/src/screens/Messages/components/MessageInput.tsx
+++ b/src/screens/Messages/components/MessageInput.tsx
@@ -146,6 +146,7 @@ export function MessageInput({
     try {
       const pickedImages = await openPicker({
         selectionLimit: 4 - imageCount,
+        allowsMultipleSelection: true,
       })
       if (pickedImages.length === 0) return
 

--- a/src/screens/Messages/components/MessageInput.tsx
+++ b/src/screens/Messages/components/MessageInput.tsx
@@ -31,6 +31,7 @@ import {android, atoms as a, useTheme} from '#/alf'
 import {useSharedInputStyles} from '#/components/forms/TextField'
 import {Image_Stroke2_Corner0_Rounded as ImageIcon} from '#/components/icons/Image'
 import {PaperPlane_Stroke2_Corner0_Rounded as PaperPlane} from '#/components/icons/PaperPlane'
+import {Text} from '#/components/Typography'
 import {IS_IOS, IS_WEB} from '#/env'
 import {useExtractEmbedFromFacets} from './MessageInputEmbed'
 
@@ -43,6 +44,8 @@ export function MessageInput({
   children,
   onSelectImages,
   imageCount = 0,
+  error,
+  disabled = false,
 }: {
   onSendMessage: (message: string) => void
   hasEmbed: boolean
@@ -51,6 +54,8 @@ export function MessageInput({
   openEmojiPicker?: (pos: EmojiPickerPosition) => void
   onSelectImages?: (images: ComposerImage[]) => void
   imageCount?: number
+  error?: string
+  disabled?: boolean
 }) {
   const {_} = useLingui()
   const t = useTheme()
@@ -164,6 +169,13 @@ export function MessageInput({
   return (
     <View style={[a.px_md, a.pb_sm, a.pt_xs]}>
       {children}
+      {error && (
+        <View style={[a.px_sm, a.pb_xs]}>
+          <Text style={[a.text_sm, t.atoms.text_contrast_high, {color: t.palette.negative_500}]}>
+            {error}
+          </Text>
+        </View>
+      )}
       <View
         style={[
           a.w_full,
@@ -250,10 +262,17 @@ export function MessageInput({
             a.rounded_full,
             a.align_center,
             a.justify_center,
-            {height: 30, width: 30, backgroundColor: t.palette.primary_500},
+            {
+              height: 30,
+              width: 30,
+              backgroundColor:
+                disabled || needsEmailVerification
+                  ? t.palette.contrast_300
+                  : t.palette.primary_500,
+            },
           ]}
           onPress={onSubmit}
-          disabled={needsEmailVerification}>
+          disabled={disabled || needsEmailVerification}>
           <PaperPlane fill={t.palette.white} style={[a.relative, {left: 1}]} />
         </Pressable>
       </View>

--- a/src/screens/Messages/components/MessageInputImages.tsx
+++ b/src/screens/Messages/components/MessageInputImages.tsx
@@ -4,7 +4,10 @@ import {msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
 import {type ComposerImage} from '#/state/gallery'
+import {ImageAltTextDialog} from '#/view/com/composer/photos/ImageAltTextDialog'
 import {atoms as a, useTheme} from '#/alf'
+import * as Dialog from '#/components/Dialog'
+import {Pencil_Stroke2_Corner0_Rounded as Pencil} from '#/components/icons/Pencil'
 import {TimesLarge_Stroke2_Corner0_Rounded as X} from '#/components/icons/Times'
 import {Text} from '#/components/Typography'
 
@@ -18,6 +21,10 @@ export function useMessageImages() {
     })
   }, [])
 
+  const updateImage = useCallback((index: number, image: ComposerImage) => {
+    setImages(prev => prev.map((img, i) => (i === index ? image : img)))
+  }, [])
+
   const removeImage = useCallback((index: number) => {
     setImages(prev => prev.filter((_, i) => i !== index))
   }, [])
@@ -29,6 +36,7 @@ export function useMessageImages() {
   return {
     images,
     addImages,
+    updateImage,
     removeImage,
     clearImages,
   }
@@ -36,13 +44,14 @@ export function useMessageImages() {
 
 export function MessageInputImages({
   images,
+  onUpdate,
   onRemove,
 }: {
   images: ComposerImage[]
+  onUpdate: (index: number, image: ComposerImage) => void
   onRemove: (index: number) => void
 }) {
   const t = useTheme()
-  const {_} = useLingui()
 
   if (images.length === 0) {
     return null
@@ -50,43 +59,15 @@ export function MessageInputImages({
 
   return (
     <View style={[a.flex_row, a.gap_xs, a.flex_wrap, a.pb_xs]}>
-      {images.map((image, index) => {
-        const source = image.transformed || image.source
-        return (
-          <View
-            key={source.id}
-            style={[
-              {width: 80, height: 80},
-              a.rounded_sm,
-              a.overflow_hidden,
-              t.atoms.border_contrast_low,
-              a.border,
-            ]}>
-            <Image
-              source={{uri: source.path}}
-              style={[{width: '100%', height: '100%'}]}
-              accessibilityLabel={image.alt || _(msg`Selected image`)}
-              accessibilityHint=""
-              accessibilityIgnoresInvertColors
-            />
-            <Pressable
-              onPress={() => onRemove(index)}
-              accessibilityLabel={_(msg`Remove image`)}
-              accessibilityHint={_(msg`Removes this image from the message`)}
-              style={[
-                a.absolute,
-                {top: 4, right: 4},
-                a.rounded_full,
-                {
-                  backgroundColor: 'rgba(0, 0, 0, 0.7)',
-                  padding: 4,
-                },
-              ]}>
-              <X size="xs" fill="white" />
-            </Pressable>
-          </View>
-        )
-      })}
+      {images.map((image, index) => (
+        <ImageThumbnail
+          key={(image.transformed || image.source).id}
+          image={image}
+          index={index}
+          onUpdate={onUpdate}
+          onRemove={onRemove}
+        />
+      ))}
       {images.length > 0 && (
         <View style={[a.justify_center, a.px_sm]}>
           <Text style={[a.text_xs, t.atoms.text_contrast_medium]}>
@@ -95,5 +76,99 @@ export function MessageInputImages({
         </View>
       )}
     </View>
+  )
+}
+
+function ImageThumbnail({
+  image,
+  index,
+  onUpdate,
+  onRemove,
+}: {
+  image: ComposerImage
+  index: number
+  onUpdate: (index: number, image: ComposerImage) => void
+  onRemove: (index: number) => void
+}) {
+  const t = useTheme()
+  const {_} = useLingui()
+  const altTextControl = Dialog.useDialogControl()
+  const source = image.transformed || image.source
+
+  return (
+    <>
+      <View
+        style={[
+          {width: 80, height: 80},
+          a.rounded_sm,
+          a.overflow_hidden,
+          t.atoms.border_contrast_low,
+          a.border,
+        ]}>
+        <Image
+          source={{uri: source.path}}
+          style={[{width: '100%', height: '100%'}]}
+          accessibilityLabel={image.alt || _(msg`Selected image`)}
+          accessibilityHint=""
+          accessibilityIgnoresInvertColors
+        />
+        <View style={[a.absolute, {top: 4, right: 4}, a.flex_row, a.gap_2xs]}>
+          <Pressable
+            onPress={() => altTextControl.open()}
+            accessibilityLabel={_(msg`Add alt text`)}
+            accessibilityHint={_(
+              msg`Add descriptive alt text for accessibility`,
+            )}
+            style={[
+              a.rounded_full,
+              {
+                backgroundColor: 'rgba(0, 0, 0, 0.7)',
+                padding: 4,
+              },
+            ]}>
+            <Pencil size="xs" fill="white" />
+          </Pressable>
+          <Pressable
+            onPress={() => onRemove(index)}
+            accessibilityLabel={_(msg`Remove image`)}
+            accessibilityHint={_(msg`Removes this image from the message`)}
+            style={[
+              a.rounded_full,
+              {
+                backgroundColor: 'rgba(0, 0, 0, 0.7)',
+                padding: 4,
+              },
+            ]}>
+            <X size="xs" fill="white" />
+          </Pressable>
+        </View>
+        {image.alt && (
+          <View
+            style={[
+              a.absolute,
+              {bottom: 4, left: 4, right: 4},
+              a.rounded_sm,
+              {
+                backgroundColor: 'rgba(0, 0, 0, 0.7)',
+                paddingHorizontal: 4,
+                paddingVertical: 2,
+              },
+            ]}>
+            <Text
+              style={[a.text_2xs, {color: 'white'}]}
+              numberOfLines={1}
+              ellipsizeMode="tail">
+              ALT
+            </Text>
+          </View>
+        )}
+      </View>
+
+      <ImageAltTextDialog
+        control={altTextControl}
+        image={image}
+        onChange={newImage => onUpdate(index, newImage)}
+      />
+    </>
   )
 }

--- a/src/screens/Messages/components/MessageInputImages.tsx
+++ b/src/screens/Messages/components/MessageInputImages.tsx
@@ -1,0 +1,99 @@
+import {useCallback, useState} from 'react'
+import {Image, Pressable, View} from 'react-native'
+import {msg} from '@lingui/macro'
+import {useLingui} from '@lingui/react'
+
+import {type ComposerImage} from '#/state/gallery'
+import {atoms as a, useTheme} from '#/alf'
+import {TimesLarge_Stroke2_Corner0_Rounded as X} from '#/components/icons/Times'
+import {Text} from '#/components/Typography'
+
+export function useMessageImages() {
+  const [images, setImages] = useState<ComposerImage[]>([])
+
+  const addImages = useCallback((newImages: ComposerImage[]) => {
+    setImages(prev => {
+      const combined = [...prev, ...newImages]
+      return combined.slice(0, 4)
+    })
+  }, [])
+
+  const removeImage = useCallback((index: number) => {
+    setImages(prev => prev.filter((_, i) => i !== index))
+  }, [])
+
+  const clearImages = useCallback(() => {
+    setImages([])
+  }, [])
+
+  return {
+    images,
+    addImages,
+    removeImage,
+    clearImages,
+  }
+}
+
+export function MessageInputImages({
+  images,
+  onRemove,
+}: {
+  images: ComposerImage[]
+  onRemove: (index: number) => void
+}) {
+  const t = useTheme()
+  const {_} = useLingui()
+
+  if (images.length === 0) {
+    return null
+  }
+
+  return (
+    <View style={[a.flex_row, a.gap_xs, a.flex_wrap, a.pb_xs]}>
+      {images.map((image, index) => {
+        const source = image.transformed || image.source
+        return (
+          <View
+            key={source.id}
+            style={[
+              {width: 80, height: 80},
+              a.rounded_sm,
+              a.overflow_hidden,
+              t.atoms.border_contrast_low,
+              a.border,
+            ]}>
+            <Image
+              source={{uri: source.path}}
+              style={[{width: '100%', height: '100%'}]}
+              accessibilityLabel={image.alt || _(msg`Selected image`)}
+              accessibilityHint=""
+              accessibilityIgnoresInvertColors
+            />
+            <Pressable
+              onPress={() => onRemove(index)}
+              accessibilityLabel={_(msg`Remove image`)}
+              accessibilityHint={_(msg`Removes this image from the message`)}
+              style={[
+                a.absolute,
+                {top: 4, right: 4},
+                a.rounded_full,
+                {
+                  backgroundColor: 'rgba(0, 0, 0, 0.7)',
+                  padding: 4,
+                },
+              ]}>
+              <X size="xs" fill="white" />
+            </Pressable>
+          </View>
+        )
+      })}
+      {images.length > 0 && (
+        <View style={[a.justify_center, a.px_sm]}>
+          <Text style={[a.text_xs, t.atoms.text_contrast_medium]}>
+            {images.length}/4
+          </Text>
+        </View>
+      )}
+    </View>
+  )
+}

--- a/src/state/messages/convo/agent.ts
+++ b/src/state/messages/convo/agent.ts
@@ -1099,7 +1099,7 @@ export class Convo {
         key: m.id,
         message: {
           ...m.message,
-          embed: undefined,
+          embed: undefined, // Hide embeds in pending messages - they use input format, not view format
           $type: 'chat.bsky.convo.defs#messageView',
           id: nanoid(),
           rev: '__fake__',

--- a/src/state/persisted/schema.ts
+++ b/src/state/persisted/schema.ts
@@ -128,6 +128,8 @@ const schema = z.object({
   mutedThreads: z.array(z.string()),
   trendingDisabled: z.boolean().optional(),
   trendingVideoDisabled: z.boolean().optional(),
+  dmImageBlurFromNonFollows: z.boolean().optional(),
+  dmImageAlwaysBlur: z.boolean().optional(),
 })
 export type Schema = z.infer<typeof schema>
 
@@ -175,6 +177,8 @@ export const defaults: Schema = {
   subtitlesEnabled: true,
   trendingDisabled: false,
   trendingVideoDisabled: false,
+  dmImageBlurFromNonFollows: false,
+  dmImageAlwaysBlur: false,
 }
 
 export function tryParse(rawData: string): Schema | undefined {

--- a/src/state/preferences/dm-image-blur.tsx
+++ b/src/state/preferences/dm-image-blur.tsx
@@ -1,0 +1,88 @@
+import React from 'react'
+
+import * as persisted from '#/state/persisted'
+
+type BlurFromNonFollowsStateContext = boolean
+type BlurFromNonFollowsSetContext = (v: boolean) => void
+type AlwaysBlurStateContext = boolean
+type AlwaysBlurSetContext = (v: boolean) => void
+
+const blurFromNonFollowsStateContext =
+  React.createContext<BlurFromNonFollowsStateContext>(
+    Boolean(persisted.defaults.dmImageBlurFromNonFollows),
+  )
+blurFromNonFollowsStateContext.displayName =
+  'DmImageBlurFromNonFollowsStateContext'
+
+const blurFromNonFollowsSetContext =
+  React.createContext<BlurFromNonFollowsSetContext>((_: boolean) => {})
+blurFromNonFollowsSetContext.displayName = 'DmImageBlurFromNonFollowsSetContext'
+
+const alwaysBlurStateContext = React.createContext<AlwaysBlurStateContext>(
+  Boolean(persisted.defaults.dmImageAlwaysBlur),
+)
+alwaysBlurStateContext.displayName = 'DmImageAlwaysBlurStateContext'
+
+const alwaysBlurSetContext = React.createContext<AlwaysBlurSetContext>(
+  (_: boolean) => {},
+)
+alwaysBlurSetContext.displayName = 'DmImageAlwaysBlurSetContext'
+
+export function Provider({children}: {children: React.ReactNode}) {
+  const [blurFromNonFollowsState, setBlurFromNonFollowsState] = React.useState(
+    Boolean(persisted.get('dmImageBlurFromNonFollows')),
+  )
+  const [alwaysBlurState, setAlwaysBlurState] = React.useState(
+    Boolean(persisted.get('dmImageAlwaysBlur')),
+  )
+
+  const setBlurFromNonFollowsWrapped = React.useCallback(
+    (value: persisted.Schema['dmImageBlurFromNonFollows']) => {
+      setBlurFromNonFollowsState(Boolean(value))
+      void persisted.write('dmImageBlurFromNonFollows', value)
+    },
+    [setBlurFromNonFollowsState],
+  )
+
+  const setAlwaysBlurWrapped = React.useCallback(
+    (value: persisted.Schema['dmImageAlwaysBlur']) => {
+      setAlwaysBlurState(Boolean(value))
+      void persisted.write('dmImageAlwaysBlur', value)
+    },
+    [setAlwaysBlurState],
+  )
+
+  React.useEffect(() => {
+    return persisted.onUpdate('dmImageBlurFromNonFollows', nextValue => {
+      setBlurFromNonFollowsState(Boolean(nextValue))
+    })
+  }, [setBlurFromNonFollowsWrapped])
+
+  React.useEffect(() => {
+    return persisted.onUpdate('dmImageAlwaysBlur', nextValue => {
+      setAlwaysBlurState(Boolean(nextValue))
+    })
+  }, [setAlwaysBlurWrapped])
+
+  return (
+    <blurFromNonFollowsStateContext.Provider value={blurFromNonFollowsState}>
+      <blurFromNonFollowsSetContext.Provider
+        value={setBlurFromNonFollowsWrapped}>
+        <alwaysBlurStateContext.Provider value={alwaysBlurState}>
+          <alwaysBlurSetContext.Provider value={setAlwaysBlurWrapped}>
+            {children}
+          </alwaysBlurSetContext.Provider>
+        </alwaysBlurStateContext.Provider>
+      </blurFromNonFollowsSetContext.Provider>
+    </blurFromNonFollowsStateContext.Provider>
+  )
+}
+
+export const useDmImageBlurFromNonFollows = () =>
+  React.useContext(blurFromNonFollowsStateContext)
+export const useSetDmImageBlurFromNonFollows = () =>
+  React.useContext(blurFromNonFollowsSetContext)
+export const useDmImageAlwaysBlur = () =>
+  React.useContext(alwaysBlurStateContext)
+export const useSetDmImageAlwaysBlur = () =>
+  React.useContext(alwaysBlurSetContext)

--- a/src/state/preferences/index.tsx
+++ b/src/state/preferences/index.tsx
@@ -3,6 +3,7 @@ import type React from 'react'
 import {Provider as AltTextRequiredProvider} from './alt-text-required'
 import {Provider as AutoplayProvider} from './autoplay'
 import {Provider as DisableHapticsProvider} from './disable-haptics'
+import {Provider as DmImageBlurProvider} from './dm-image-blur'
 import {Provider as ExternalEmbedsProvider} from './external-embeds-prefs'
 import {Provider as HiddenPostsProvider} from './hidden-posts'
 import {Provider as InAppBrowserProvider} from './in-app-browser'
@@ -19,6 +20,12 @@ export {
 } from './alt-text-required'
 export {useAutoplayDisabled, useSetAutoplayDisabled} from './autoplay'
 export {useHapticsDisabled, useSetHapticsDisabled} from './disable-haptics'
+export {
+  useDmImageAlwaysBlur,
+  useDmImageBlurFromNonFollows,
+  useSetDmImageAlwaysBlur,
+  useSetDmImageBlurFromNonFollows,
+} from './dm-image-blur'
 export {
   useExternalEmbedsPrefs,
   useSetExternalEmbedPref,
@@ -37,15 +44,17 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
             <HiddenPostsProvider>
               <InAppBrowserProvider>
                 <DisableHapticsProvider>
-                  <AutoplayProvider>
-                    <UsedStarterPacksProvider>
-                      <SubtitlesProvider>
-                        <TrendingSettingsProvider>
-                          <KawaiiProvider>{children}</KawaiiProvider>
-                        </TrendingSettingsProvider>
-                      </SubtitlesProvider>
-                    </UsedStarterPacksProvider>
-                  </AutoplayProvider>
+                  <DmImageBlurProvider>
+                    <AutoplayProvider>
+                      <UsedStarterPacksProvider>
+                        <SubtitlesProvider>
+                          <TrendingSettingsProvider>
+                            <KawaiiProvider>{children}</KawaiiProvider>
+                          </TrendingSettingsProvider>
+                        </SubtitlesProvider>
+                      </UsedStarterPacksProvider>
+                    </AutoplayProvider>
+                  </DmImageBlurProvider>
                 </DisableHapticsProvider>
               </InAppBrowserProvider>
             </HiddenPostsProvider>


### PR DESCRIPTION
# Add Image Upload Support to Direct Messages

This PR adds the frontend ability to upload and send images in Direct Messages. Ability to upload up to 4 images per DM with full accessibility support including alt text, also giving reminder message if one has "Remind alt text" setting on.

Includes user-controlled privacy settings for blurring images in DMs, with built-in support for future platform-level moderation.

## Reason Behind Change

Partially to add address  #5276, #9393

But most importantly;

I just want to be able to upload dank memes and pictures of my cat, Sophie.

## What's been implemented

### Core Functionality
- Image selection from photo library (up to 4 images)
- Multi-select support for efficient bulk uploads
- Client-side image compression (reuses existing post infrastructure)
- Blob storage upload with progress handling
- Image display in message threads
- Full-screen image viewer (tap to expand)

### Accessibility
- Alt text editor for each image (matching post composer UX)
- Alt text requirement enforcement (respects user settings)
- Visual indicator (ALT badge) for images with alt text

### Image Privacy Controls
- **User Preferences** (Settings > Chat Settings > Image Privacy):
  - "Blur images from accounts you don't follow"
  - "Always blur images in messages"
  - Your own images are never blurred
- **Reveal Control**: Tap "Show" to reveal any blurred image
- **Pluggable Architecture**:
  - Modular decision pipeline with clear priority system
  - Extension points for custom policies and analytics
  - Backend moderation integration ready (zero code changes needed)
  - Comprehensive test coverage (30 tests, 100% pass rate)

## Commit Breakdown

| Commit Hash | Description |
|-------------|-------------|
| [`90ed7801a`](https://github.com/aliofonzy43/social-app/commit/90ed7801a) | Add image picker to DM message input |
| [`5f27d1b7c`](https://github.com/aliofonzy43/social-app/commit/5f27d1b7c) | Add image upload and send to DM messages |
| [`671ad609d`](https://github.com/aliofonzy43/social-app/commit/671ad609d) | Add image embed display in DM messages |
| [`532967311`](https://github.com/aliofonzy43/social-app/commit/532967311) | Enable multi-select for DM image picker |
| [`5c46aa025`](https://github.com/aliofonzy43/social-app/commit/5c46aa025) | Add alt text support for DM images |
| [`2a06297e0`](https://github.com/aliofonzy43/social-app/commit/2a06297e0) | Enforce alt text requirement for DM images |
| [`6d75453c9`](https://github.com/aliofonzy43/social-app/commit/6d75453c9) | Hide embeds in pending DM messages |
| [`19ed60eb5`](https://github.com/aliofonzy43/social-app/commit/19ed60eb5) | Add user-controlled blur for DM images |
| [`4ede7339a`](https://github.com/aliofonzy43/social-app/commit/4ede7339a) | Add comprehensive tests for DM image blur |
| [`3335481eb`](https://github.com/aliofonzy43/social-app/commit/3335481eb) | Refactor into pluggable moderation architecture |


### Data Flow

```
User selects images
  ↓
createComposerImage() - Cache image locally
  ↓
compressImage() - Compress to meet size limits (reuses post logic)
  ↓
uploadBlob() - Upload to blob storage
  ↓
sendMessage() - Send with app.bsky.embed.images embed
  ↓
[Backend Processing] ← REQUIRES BACKEND IMPLEMENTATION
  ↓
Message appears with images
```

### Embed Format

**Input Format** (sent to server):
```typescript
{
  "$type": "app.bsky.embed.images",
  "images": [
    {
      "image": BlobRef,
      "alt": string,
      "aspectRatio": { width: number, height: number }
    }
  ]
}
```

**View Format** (expected from server):
```typescript
{
  "$type": "app.bsky.embed.images#view",
  "images": [
    {
      "thumb": string,  // CDN URL
      "fullsize": string, // CDN URL
      "alt": string,
      "aspectRatio": { width: number, height: number }
    }
  ]
}
```

### Image Privacy Architecture

The system uses a modular, pluggable architecture that addresses immediate privacy needs while providing clear integration paths for future platform moderation:

**Design Philosophy:**
- **Client-Side Privacy Layer** (current): User-controlled blur preferences
- **Platform Moderation Layer** (future): Backend content labeling and policies
- Clear separation of concerns - both can coexist without conflict

**Moderation Pipeline:**
```
1. Backend Moderation (highest priority - future AT Protocol support)
   ↓
2. Custom Policies (extensible - regional rules, A/B tests, ML)
   ↓
3. User Preferences (current - always blur, blur from non-follows)
   ↓
4. No Blur (default)
```

**Key Components:**
- `useModerationDecision`: Isolated decision logic with priority-based evaluation
- `DMImageContentHider`: Thin wrapper that applies moderation decisions
- Type system: Clear interfaces for policies, decisions, and context
- Example policies: Demonstrates regional rules, reputation scores, time-based logic

**Extension Points:**
- Custom policy injection: Add new moderation sources without code changes
- Analytics hooks: Track decisions for metrics and improvements
- Backend integration: Just pass `moderation` prop when AT Protocol ready

## Future Backend Integration (If ever done)

When AT Protocol adds moderation support for DM images, the system will automatically upgrade with minimal changes:

### Backend Changes Required
```typescript
// AT Protocol adds optional moderation field to MessageView
interface ChatBskyConvoDefs.MessageView {
  // ... existing fields
  moderation?: ModerationUI  // New: Platform-level content labels
}
```

### Frontend Changes Required
```typescript
// In MessageItem.tsx (or similar)
import {moderateMessage} from '@atproto/api'

// Add moderation check (similar to moderatePost)
const modui = moderateMessage(message, moderationOpts)

// Pass to MessageItemEmbed
<MessageItemEmbed
  embed={message.embed}
  message={message}
  convo={convo}
  moderation={modui}  // New prop
/>
```

### What Happens Then
1. `DMImageContentHider` receives backend moderation via `moderation` prop
2. Backend moderation automatically takes priority over user preferences
3. User's Content Filter settings (porn, nudity, graphic content, etc.) apply to DMs
4. User preferences become a fallback for additional privacy control
5. No changes needed to `DMImageContentHider` component logic

### User Experience
- **Before backend support**: Users manually control DM blurring via Messages Settings
- **After backend support**: Content Filters from Moderation settings automatically apply to DMs
- **User preferences**: Remain available for additional DM-specific filtering on top of platform moderation

Goal was to make the moderation-part somewhat feasible to expand on.

Screenshot enforcing user Alt text settings:
<img width="414" height="886" alt="Screenshot 2026-02-02 at 2 50 24 PM" src="https://github.com/user-attachments/assets/fe639859-0692-4d05-9029-5284738bb4fa" />

Screen recording of local testing(yes I do typos a lot lol--actual showcase of sending can only be done when backend is incorporated):

https://github.com/user-attachments/assets/680b0e23-5b68-4eeb-8af4-66989973bfcf

