### PR TITLE
Exempt video-gifs from active video system

### DIFF
--- a/src/components/Post/Embed/VideoEmbed/VideoEmbedInner/web-controls/VideoControls.tsx
+++ b/src/components/Post/Embed/VideoEmbed/VideoEmbedInner/web-controls/VideoControls.tsx
@@ -128,13 +128,14 @@ export function Controls({
   const autoplayDisabled = useAutoplayDisabled() || isWithinMessage
   useEffect(() => {
     if (active) {
-      if (onScreen) {
+      // GIFs play immediately, videos wait until onScreen
+      if (onScreen || isGif) {
         if (!autoplayDisabled) play()
       } else {
         pause()
       }
     }
-  }, [onScreen, pause, active, play, autoplayDisabled])
+  }, [onScreen, pause, active, play, autoplayDisabled, isGif])
 
   // use minimal quality when not focused
   useEffect(() => {


### PR DESCRIPTION
Videos have a system to ensure only one plays at a time. On web, we can allow video-gifs to skip this system and let multiple play at once

# Before


https://github.com/user-attachments/assets/11495560-f22f-40c3-8026-effdd98c9712


# After


https://github.com/user-attachments/assets/1e4d874e-a054-4d30-abf3-4bdfabeb5a1e

