### PR TITLE
[APP-1794] respect mute words for live event feed banners

### DIFF
--- a/src/features/liveEvents/context.tsx
+++ b/src/features/liveEvents/context.tsx
@@ -43,6 +43,7 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
     () => preferences?.moderationPrefs?.mutedWords ?? [],
     [preferences?.moderationPrefs?.mutedWords],
   )
+
   const {data, refetch} = useQuery(
     {
       // keep this, prefectching handles initial load
@@ -57,7 +58,7 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
   )
 
   useOnAppStateChange(state => {
-    if (state === 'active') refetch()
+    if (state === 'active') void refetch()
   })
 
   const ctx = useMemo(() => {


### PR DESCRIPTION
Utilize `hasMutedWord` to ensure live event feed banners with muted words don't display (with the exception of bsky team and dev mode). 

Tested with both a mock event (porsche) and the dev live event (ncaa) on web and mobile.

![CleanShot 2026-02-05 at 10 03 26](https://github.com/user-attachments/assets/0bdbf9a5-4d3f-468f-b7bb-b94715e1aec1)
![CleanShot 2026-02-05 at 10 11 23](https://github.com/user-attachments/assets/f2592971-1fe4-4b67-a87b-6dbb9b72e075)