### PR TITLE
Use post context to generate consistent filenames for saved images (fixes #7280)

### DIFF
--- a/src/components/Lightbox/Lightbox.tsx
+++ b/src/components/Lightbox/Lightbox.tsx
@@ -19,7 +19,7 @@ export function Lightbox() {
     <ImageView
       lightbox={activeLightbox}
       onRequestClose={onClose}
-      onPressSave={uri => void saveImageToAlbum(uri)}
+      onPressSave={opts => void saveImageToAlbum(opts)}
       onPressShare={uri => void shareImageModal({uri})}
     />
   )

--- a/src/components/Lightbox/Lightbox.web.tsx
+++ b/src/components/Lightbox/Lightbox.web.tsx
@@ -311,7 +311,10 @@ function LightboxGallery({
             <Menu.Item
               label={l`Download image`}
               onPress={() => {
-                saveImageToMediaLibrary({uri: img.uri}).then(
+                saveImageToMediaLibrary({
+                  uri: img.uri,
+                  baseSaveName: img.baseSaveName,
+                }).then(
                   () => {
                     Toast.show(l`Image saved`)
                   },

--- a/src/components/Lightbox/pager/ImagePager.tsx
+++ b/src/components/Lightbox/pager/ImagePager.tsx
@@ -85,7 +85,7 @@ export default function ImageViewRoot({
 }: {
   lightbox: Lightbox | null
   onRequestClose: () => void
-  onPressSave: (uri: string) => void
+  onPressSave: (opts: {uri: string; baseSaveName?: string}) => void
   onPressShare: (uri: string) => void
 }) {
   'use no memo'
@@ -232,7 +232,7 @@ function ImageView({
   setImageIndex: React.Dispatch<React.SetStateAction<number>>
   orientation: 'portrait' | 'landscape'
   onRequestClose: () => void
-  onPressSave: (uri: string) => void
+  onPressSave: (opts: {uri: string; baseSaveName?: string}) => void
   onPressShare: (uri: string) => void
   onFlyAway: () => void
   safeAreaRef: AnimatedRef<View>
@@ -442,7 +442,12 @@ function ImageView({
           <Header
             onRequestClose={handleRequestClose}
             onPressShare={() => onPressShare(images[imageIndex].uri)}
-            onPressSave={() => onPressSave(images[imageIndex].uri)}
+            onPressSave={() =>
+              onPressSave({
+                uri: images[imageIndex].uri,
+                baseSaveName: images[imageIndex].baseSaveName,
+              })
+            }
             imageCount={images.length}
             activeIndex={imageIndex}
           />

--- a/src/components/Lightbox/types.ts
+++ b/src/components/Lightbox/types.ts
@@ -32,6 +32,7 @@ export type ImageSource = {
   thumbRef?: AnimatedRef<Component> | null
   thumbBorderRadius?: number
   alt?: string
+  baseSaveName?: string
   type: 'image' | 'circle-avi' | 'rect-avi'
 }
 

--- a/src/components/MediaPreview.tsx
+++ b/src/components/MediaPreview.tsx
@@ -226,7 +226,7 @@ function PeekableImageItem({image}: {image: AppBskyEmbedImages.ViewImage}) {
       <PeekMenu.Menu>
         <PeekMenu.MenuItem
           id="save"
-          onSelect={() => void saveImage(image.fullsize)}>
+          onSelect={() => void saveImage({uri: image.fullsize})}>
           <PeekMenu.MenuItemIcon icon={DownloadIcon} />
           <PeekMenu.MenuItemText>{l`Save image`}</PeekMenu.MenuItemText>
         </PeekMenu.MenuItem>

--- a/src/components/Post/Embed/ImageContextMenu.tsx
+++ b/src/components/Post/Embed/ImageContextMenu.tsx
@@ -45,7 +45,7 @@ export function ImageContextMenu({
   }
 
   const handleSave = () => {
-    void saveImage(fullsizeUri)
+    void saveImage({uri: fullsizeUri})
   }
   const handleShare = () => {
     void shareImageModal({uri: fullsizeUri})

--- a/src/components/Post/Embed/ImageEmbed.tsx
+++ b/src/components/Post/Embed/ImageEmbed.tsx
@@ -2,7 +2,13 @@ import {useRef} from 'react'
 import {InteractionManager, View} from 'react-native'
 import {type AnimatedRef} from 'react-native-reanimated'
 import {Image} from 'expo-image'
-import {AppBskyEmbedGallery, type AppBskyEmbedImages} from '@atproto/api'
+import {
+  AppBskyEmbedGallery,
+  type AppBskyEmbedImages,
+  AppBskyFeedPost,
+  AtUri,
+} from '@atproto/api'
+import {format, parseISO} from 'date-fns'
 
 import {atoms as a, tokens} from '#/alf'
 import {AutoSizedImage} from '#/components/images/AutoSizedImage'
@@ -16,6 +22,7 @@ import {type Dimensions} from '#/components/Lightbox/types'
 import {ImageContextMenu} from '#/components/Post/Embed/ImageContextMenu'
 import {PostEmbedViewContext} from '#/components/Post/Embed/types'
 import {useAnalytics} from '#/analytics'
+import * as bsky from '#/types/bsky'
 import {type EmbedType} from '#/types/bsky/post'
 import {type CommonProps} from './types'
 
@@ -42,6 +49,22 @@ export function ImageEmbed({
     embed.type === 'gallery'
       ? images.length > MAX_GRID_IMAGES
       : ax.features.enabled(ax.features.PostGalleryEmbedEnable)
+  // Derive a stable base filename from the owning post so saved images can be
+  // traced back to their post. Falls back to a UUID downstream when absent.
+  const postRkey = rest.post ? new AtUri(rest.post.uri).rkey : undefined
+  const handle = rest.post?.author.handle
+  const postCreatedAt =
+    rest.post &&
+    bsky.dangerousIsType<AppBskyFeedPost.Record>(
+      rest.post.record,
+      AppBskyFeedPost.isRecord,
+    )
+      ? rest.post.record.createdAt
+      : undefined
+  const timestamp = postCreatedAt
+    ? format(parseISO(postCreatedAt), "yyyy-MM-dd'T'HHmmss")
+    : undefined
+  const canName = !!(handle && postRkey)
 
   const layout: 'single' | 'grid' | 'carousel' =
     images.length === 1 ? 'single' : useExpandedLayout ? 'carousel' : 'grid'
@@ -63,11 +86,17 @@ export function ImageEmbed({
   const singleDimsRef = useRef<Dimensions | null>(null)
 
   if (images.length > 0) {
-    const items = images.map(img => ({
+    const items = images.map((img, idx) => ({
       uri: img.fullsize,
       thumbUri: img.thumb,
       alt: img.alt,
       dimensions: img.aspectRatio ?? null,
+      baseSaveName: canName
+        ? (() => {
+            const base = `${handle}_${postRkey}_img${idx + 1}`
+            return timestamp ? `${base}_${timestamp}` : base
+          })()
+        : undefined,
     }))
     const onPress = (
       index: number,

--- a/src/components/StarterPack/ShareDialog.tsx
+++ b/src/components/StarterPack/ShareDialog.tsx
@@ -66,7 +66,7 @@ function ShareDialogInner({
   const saveImageToAlbum = useSaveImageToMediaLibrary()
 
   const onSave = async () => {
-    await saveImageToAlbum(imageUrl)
+    await saveImageToAlbum({uri: imageUrl})
   }
 
   return (

--- a/src/lib/media/manip.ts
+++ b/src/lib/media/manip.ts
@@ -98,14 +98,24 @@ const ALBUM_NAME = 'Bluesky'
  * `attachment; filename=<filename>`. On native this saves to the media library;
  * on web it triggers a browser download.
  */
-export async function saveImageToMediaLibrary({uri}: {uri: string}) {
+export async function saveImageToMediaLibrary({
+  uri,
+  baseSaveName,
+}: {
+  uri: string
+  baseSaveName?: string
+}) {
   const downloadUri = convertCdnPreset(uri, 'download')
   const downloadedPath = await downloadImage(
     downloadUri,
     String(uuid.v4()),
     20e3,
   )
-  const imagePath = await moveToPermanentPath(downloadedPath, '.jpg')
+  const imagePath = await moveToPermanentPath(
+    downloadedPath,
+    '.jpg',
+    baseSaveName,
+  )
 
   // save
   try {
@@ -265,13 +275,17 @@ async function doResize(
   )
 }
 
-async function moveToPermanentPath(path: string, ext: string): Promise<string> {
+async function moveToPermanentPath(
+  path: string,
+  ext: string,
+  baseFilename?: string,
+): Promise<string> {
   /*
   Since this package stores images in a temp directory, we need to move the file to a permanent location.
   Relevant: IOS bug when trying to open a second time:
   https://github.com/ivpusic/react-native-image-crop-picker/issues/1199
   */
-  const filename = uuid.v4()
+  const filename = baseFilename || uuid.v4()
 
   // cacheDirectory will not ever be null on native, but it could be on web. This function only ever gets called on
   // native so we assert as a string.

--- a/src/lib/media/manip.web.ts
+++ b/src/lib/media/manip.web.ts
@@ -52,10 +52,18 @@ export async function shareImageModal(_opts: {uri: string}) {
  * `attachment; filename=<filename>`. On native this saves to the media library;
  * on web it triggers a browser download.
  */
-export async function saveImageToMediaLibrary({uri}: {uri: string}) {
+export async function saveImageToMediaLibrary({
+  uri,
+  baseSaveName,
+}: {
+  uri: string
+  baseSaveName?: string
+}) {
   const downloadUri = convertCdnPreset(uri, 'download')
   const segments = downloadUri.split('/')
-  const filename = `bluesky-${segments.at(-1)}.jpg`
+  const filename = baseSaveName
+    ? `${baseSaveName}.jpg`
+    : `bluesky-${segments.at(-1)}.jpg`
   downloadUrl(downloadUri, filename)
 }
 

--- a/src/lib/media/save-image.ios.ts
+++ b/src/lib/media/save-image.ios.ts
@@ -15,13 +15,13 @@ import {saveImageToMediaLibrary} from './manip'
 export function useSaveImageToMediaLibrary() {
   const {_} = useLingui()
   return useCallback(
-    async (uri: string) => {
+    async ({uri, baseSaveName}: {uri: string; baseSaveName?: string}) => {
       if (!IS_NATIVE) {
         throw new Error('useSaveImageToMediaLibrary is native only')
       }
 
       try {
-        await saveImageToMediaLibrary({uri})
+        await saveImageToMediaLibrary({uri, baseSaveName})
         Toast.show(_(msg`Image saved`))
       } catch (e: any) {
         Toast.show(_(msg`Failed to save image: ${String(e)}`), {type: 'error'})

--- a/src/lib/media/save-image.ts
+++ b/src/lib/media/save-image.ts
@@ -17,14 +17,14 @@ export function useSaveImageToMediaLibrary() {
       granularPermissions: ['photo'],
     })
   return useCallback(
-    async (uri: string) => {
+    async ({uri, baseSaveName}: {uri: string; baseSaveName?: string}) => {
       if (!IS_NATIVE) {
         throw new Error('useSaveImageToMediaLibrary is native only')
       }
 
       async function save() {
         try {
-          await saveImageToMediaLibrary({uri})
+          await saveImageToMediaLibrary({uri, baseSaveName})
 
           Toast.show(_(msg`Image saved`))
         } catch (e: any) {


### PR DESCRIPTION
# What / Why

When saving images from the lightbox view, the filename was previously generic/non-deterministic (UUID), which made it hard to relate saved files back to the original post and search for them later in a filesystem.

This change makes saved post-image filenames deterministic based on post metadata.

This was originally requested in #7280.

# Changes

- derives a stable save name for image lightbox items in `ImageEmbed` from the owning post (`CommonProps.post`) that the embed layer already receives, so no new props or call-site changes are needed
- generates a `baseSaveName` for post images using the format: `handle_postRkey_imgN_postCreatedAtUtc`
- threads that optional `baseSaveName`  through the current lightbox save flow and media save pipeline
- preserves UUID fallback behavior when post context is unavailable
- applies the same filename behavior to the current web lightbox download path as well as native save flows

# Filename format

Example filename:

```
15delicious.bsky.social_3me7qo3xdyc23_img1_2026-02-06T223014.jpg
```

If the required post context is unavailable when determining the save name, the save flow falls back to a generated UUID filename. That still covers cases like saving a profile picture from a non-post lightbox entry point.

# Testing

I have tested this on my Android 15 device. It would be helpful if someone could also test this on an iOS device.

- Post with multiple images:
  1. Open the post
  2. Tap the first image to open lightbox
  3. Tap Save → swipe right (repeat for each image)
  4. Save one of the images a second time
- User profile picture:
  1. Navigate to a user's profile
  2. Tap the profile picture
  3. Tap Save
- Verify filenames:
  1. Open your gallery app and navigate to the Bluesky album
  2. Verify the post filenames match the format `${handle}_${postRkey}_img{N}_{postCreatedAtUtc}`
  3. On Android, verify that the post image that was saved twice has two files, with the newer one having the suffix ` (1)`
  4. Verify that the saved profile picture uses a UUID filename (such as `f94ff601-ff56-4bf1-9758-84fc49666ed3.jpg`)

### Other notes

Let me know if this should be behind a configuration option rather than default behavior.

---

Closes #7280.