### PR TITLE
fix: escape special characters in JSON-LD structured data

### DIFF
--- a/bskyweb/cmd/bskyweb/filters.go
+++ b/bskyweb/cmd/bskyweb/filters.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"net/url"
 
 	"github.com/flosch/pongo2/v6"
@@ -8,6 +9,24 @@ import (
 
 func init() {
 	pongo2.RegisterFilter("canonicalize_url", filterCanonicalizeURL)
+	pongo2.RegisterFilter("json_escape", filterJSONEscape)
+}
+
+// filterJSONEscape escapes a string for safe embedding within a JSON string literal.
+// This handles newlines, tabs, quotes, backslashes, and other control characters.
+func filterJSONEscape(in *pongo2.Value, param *pongo2.Value) (*pongo2.Value, *pongo2.Error) {
+	str := in.String()
+	// json.Marshal will produce a valid JSON string with all special characters escaped
+	escaped, err := json.Marshal(str)
+	if err != nil {
+		return in, nil
+	}
+	// json.Marshal wraps the string in quotes, so strip them
+	// escaped will be like: "hello\nworld" - we want just: hello\nworld
+	if len(escaped) >= 2 {
+		escaped = escaped[1 : len(escaped)-1]
+	}
+	return pongo2.AsValue(string(escaped)), nil
 }
 
 func filterCanonicalizeURL(in *pongo2.Value, param *pongo2.Value) (*pongo2.Value, *pongo2.Error) {

--- a/bskyweb/cmd/bskyweb/filters_test.go
+++ b/bskyweb/cmd/bskyweb/filters_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/flosch/pongo2/v6"
@@ -55,6 +56,77 @@ func TestCanonicalizeURLFilter(t *testing.T) {
 
 			if result.String() != tt.expected {
 				t.Errorf("filterCanonicalizeURL() = %v, want %v", result.String(), tt.expected)
+			}
+		})
+	}
+}
+
+func TestJSONEscapeFilter(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "simple string",
+			input:    "hello world",
+			expected: "hello world",
+		},
+		{
+			name:     "string with newlines",
+			input:    "hello\nworld",
+			expected: `hello\nworld`,
+		},
+		{
+			name:     "string with quotes",
+			input:    `say "hello"`,
+			expected: `say \"hello\"`,
+		},
+		{
+			name:     "string with backslashes",
+			input:    `path\to\file`,
+			expected: `path\\to\\file`,
+		},
+		{
+			name:     "string with tabs",
+			input:    "col1\tcol2",
+			expected: `col1\tcol2`,
+		},
+		{
+			name:     "string with carriage return",
+			input:    "line1\r\nline2",
+			expected: `line1\r\nline2`,
+		},
+		{
+			name:     "complex bio with emojis and newlines",
+			input:    "I code, I write, I puzzle\n\n🌐 elenatorro.com\n📬 newsletter@example.com",
+			expected: `I code, I write, I puzzle\n\n🌐 elenatorro.com\n📬 newsletter@example.com`,
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			inputValue := pongo2.AsValue(tt.input)
+			result, err := filterJSONEscape(inputValue, nil)
+			if err != nil {
+				t.Errorf("filterJSONEscape() error = %v", err)
+				return
+			}
+
+			if result.String() != tt.expected {
+				t.Errorf("filterJSONEscape() = %v, want %v", result.String(), tt.expected)
+			}
+
+			// Verify the result produces valid JSON when used in a string literal
+			jsonStr := `{"test":"` + result.String() + `"}`
+			var parsed map[string]interface{}
+			if err := json.Unmarshal([]byte(jsonStr), &parsed); err != nil {
+				t.Errorf("filterJSONEscape() result does not produce valid JSON: %v", err)
 			}
 		})
 	}

--- a/bskyweb/templates/post.html
+++ b/bskyweb/templates/post.html
@@ -63,7 +63,7 @@
       "author": {
         "@type": "Person",
         {%- if postView.Author.DisplayName %}
-        "name": "{{ postView.Author.DisplayName }}",
+        "name": "{{ postView.Author.DisplayName|json_escape }}",
         "alternateName": "@{{ postView.Author.Handle }}",
         {% else %}
         "name": "@{{ postView.Author.Handle }}",
@@ -71,7 +71,7 @@
         "url": "https://bsky.app/profile/{{ postView.Author.Handle }}"
       },
       {%- if postText %}
-      "text": "{{ postText }}",
+      "text": "{{ postText|json_escape }}",
       {% endif %}
       {%- if imageThumbUrls %}
       "image": "{{ imageThumbUrls[0] }}",

--- a/bskyweb/templates/profile.html
+++ b/bskyweb/templates/profile.html
@@ -60,13 +60,13 @@
     "mainEntity": {
       "@type": "Person",
       {%- if profileView.DisplayName %}
-      "name": "{{ profileView.DisplayName }}",
+      "name": "{{ profileView.DisplayName|json_escape }}",
       "alternateName": "@{{ profileView.Handle }}",
       {% else %}
       "name": "@{{ profileView.Handle }}",
       {% endif -%}
       "identifier": "{{ profileView.Did }}",
-      "description": "{{ profileView.Description }}",
+      "description": "{{ profileView.Description|json_escape }}",
       "image": "{{ profileView.Avatar }}",
       "interactionStatistic": [
         {


### PR DESCRIPTION
## Summary

Fixes #9772

The JSON-LD structured data embedded in profile and post pages was being generated with unescaped string values. This caused invalid JSON when users had newlines, quotes, backslashes, or other special characters in their profile descriptions, display names, or post text.

## Problem

Profile descriptions containing line breaks would produce invalid JSON like:
```json
"description": "I code, I write

🌐 example.com"
```

Which fails `JSON.parse()`.

## Solution

Added a `json_escape` Pongo2 template filter that properly escapes strings for embedding in JSON literals. The filter uses Go's `json.Marshal` (which handles all JSON escaping correctly), then strips the surrounding quotes.

Applied the filter to all user-generated text fields in JSON-LD:
- `profile.html`: DisplayName, Description
- `post.html`: Author DisplayName, postText

## Changes

1. **bskyweb/cmd/bskyweb/filters.go**: Added `filterJSONEscape` function
2. **bskyweb/cmd/bskyweb/filters_test.go**: Added comprehensive tests
3. **bskyweb/templates/profile.html**: Applied `|json_escape` filter
4. **bskyweb/templates/post.html**: Applied `|json_escape` filter

## Testing

Added test cases covering:
- Simple strings (no change)
- Newlines (`\n`, `\r\n`)
- Tabs
- Double quotes
- Backslashes
- Complex strings with emojis and multiple newlines
- Empty strings

Each test also verifies the escaped output produces valid JSON when embedded in a string literal.