### PR TITLE
Debounce thread preferences on leading edge, reduce to 2s

### DIFF
--- a/src/state/queries/preferences/index.ts
+++ b/src/state/queries/preferences/index.ts
@@ -200,7 +200,13 @@ export function useSetFeedViewPreferencesMutation() {
   })
 }
 
-export function useSetThreadViewPreferencesMutation() {
+export function useSetThreadViewPreferencesMutation({
+  onSuccess,
+  onError,
+}: {
+  onSuccess?: (data: void, variables: Partial<ThreadViewPreferences>) => void
+  onError?: (error: unknown) => void
+}) {
   const queryClient = useQueryClient()
   const agent = useAgent()
 
@@ -212,6 +218,8 @@ export function useSetThreadViewPreferencesMutation() {
         queryKey: preferencesQueryKey,
       })
     },
+    onSuccess,
+    onError,
   })
 }
 


### PR DESCRIPTION
Currently it waits 4 seconds before saving preferences. Fix is to debounce on leading + trailing edges, and reduces timeout to 2 seconds