### PR TITLE
Add --what-to-test to iOS submissions

### DIFF
--- a/.github/workflows/build-submit-ios.yml
+++ b/.github/workflows/build-submit-ios.yml
@@ -118,7 +118,12 @@ jobs:
           fi
 
       - name: 🚀 Deploy
-        run: eas submit -p ios --non-interactive --path ios-build/ios/build/Bluesky.ipa
+        env:
+          PROFILE: ${{ inputs.profile || 'testflight' }}
+        run: >
+          eas submit -p ios --non-interactive
+          --path ios-build/ios/build/Bluesky.ipa
+          --what-to-test "$([[ "$PROFILE" == "production" ]] && echo "Production build" || echo "TestFlight build")"
 
       - name: 🪲 Upload dSYM to Sentry
         run: >

--- a/.github/workflows/bundle-deploy-eas-update.yml
+++ b/.github/workflows/bundle-deploy-eas-update.yml
@@ -242,7 +242,7 @@ jobs:
           --local --output build.ipa --non-interactive
 
       - name: 🚀 Deploy
-        run: eas submit -p ios --non-interactive --path build.ipa
+        run: eas submit -p ios --non-interactive --path build.ipa --what-to-test "TestFlight build"
 
       - name: ⬇️ Restore Cache
         id: get-base-commit


### PR DESCRIPTION
## Summary
- Adds `--what-to-test` flag to `eas submit` for iOS builds, setting the TestFlight "What to test" field
- `build-submit-ios.yml`: dynamically sets "TestFlight build" or "Production build" based on the selected profile
- `bundle-deploy-eas-update.yml`: always sets "TestFlight build"

## Test plan
- [ ] Trigger a testflight iOS build and verify "What to test" shows "TestFlight build" in TestFlight
- [ ] Trigger a production iOS build and verify "What to test" shows "Production build" in TestFlight

🤖 Generated with [Claude Code](https://claude.com/claude-code)