### PR TITLE
Fix GIFs breaking mute state/pausing phone audio

### DIFF
--- a/src/components/Post/Embed/VideoEmbed/VideoEmbedInner/VideoEmbedInnerNative.tsx
+++ b/src/components/Post/Embed/VideoEmbed/VideoEmbedInner/VideoEmbedInnerNative.tsx
@@ -67,7 +67,9 @@ export function VideoEmbedInnerNative({
           setIsLoading(e.nativeEvent.isLoading)
         }}
         onMutedChange={e => {
-          setMuted(e.nativeEvent.isMuted)
+          if (!isGif) {
+            setMuted(e.nativeEvent.isMuted)
+          }
         }}
         onStatusChange={e => {
           setStatus(e.nativeEvent.status)


### PR DESCRIPTION
A classic operator precedence mistake. I wrote:

```tsx
        beginMuted={isGif || autoplayDisabled ? false : muted}
```

which I _wanted_ to work like


```tsx
        beginMuted={isGif || (autoplayDisabled ? false : muted)}
```

But instead worked like


```tsx
        beginMuted={(isGif || autoplayDisabled) ? false : muted}
```

which meant GIFs would pause the system audio, and cause future videos to become unmuted. Whoops

This PR also ensures that GIFs cannot change the global mute state