### PR TITLE
Fix keyboard flicker when selecting a draft in composer

### DIFF
--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -477,12 +477,6 @@ export const ComposePost = ({
 
   const handleSelectDraft = React.useCallback(
     async (draftSummary: DraftSummary) => {
-      // Dismiss keyboard immediately to prevent flicker. Without this,
-      // the text input regains focus (showing the keyboard) after the
-      // drafts sheet closes, then loses it again when the post component
-      // remounts with the draft content, causing a show-hide-show cycle.
-      Keyboard.dismiss()
-
       logger.debug('loading draft for editing', {
         draftId: draftSummary.id,
       })

--- a/src/view/com/composer/drafts/DraftsListDialog.tsx
+++ b/src/view/com/composer/drafts/DraftsListDialog.tsx
@@ -1,5 +1,5 @@
 import {useCallback, useEffect, useMemo} from 'react'
-import {View} from 'react-native'
+import {Keyboard, View} from 'react-native'
 import {msg, Trans} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
@@ -54,6 +54,12 @@ export function DraftsListDialog({
 
   const handleSelectDraft = useCallback(
     (summary: DraftSummary) => {
+      // Dismiss keyboard immediately to prevent flicker. Without this,
+      // the text input regains focus (showing the keyboard) after the
+      // drafts sheet closes, then loses it again when the post component
+      // remounts with the draft content, causing a show-hide-show cycle -sfn
+      Keyboard.dismiss()
+
       control.close(() => {
         onSelectDraft(summary)
       })


### PR DESCRIPTION
When selecting a draft, the drafts sheet closes and the underlying text
input regains focus, showing the keyboard. Then the state update causes
the ComposerPost to remount (key changes), hiding the keyboard. Finally,
the new component mounts with autoFocus, showing it again. This
show-hide-show cycle is visible as a flicker.

Fix by calling Keyboard.dismiss() at the start of handleSelectDraft so
the keyboard stays hidden during the transition and only appears once
when the new component mounts.

https://claude.ai/code/session_01MXNaTWzQNCx8fKR1fxKi6v

## Before

https://github.com/user-attachments/assets/62652c63-8b86-4a17-80bf-b1341ef1370b

## After

https://github.com/user-attachments/assets/f943fbf8-8c14-4b8f-9d78-3477315fe088


