### PR TITLE
Fix webpack dev server freezing after repeated refreshes

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -35,6 +35,15 @@ module.exports = async function (env, argv) {
   ]
   if (env.mode === 'development') {
     config.plugins.push(new ReactRefreshWebpackPlugin())
+    // Reap zombie HMR WebSocket connections that linger after refresh.
+    // Without this, dead sockets exhaust the browser's per-origin connection
+    // pool and the dev server stops responding.
+    config.devServer.onListening = devServer => {
+      devServer.server.on('connection', socket => {
+        socket.setTimeout(10000)
+        socket.on('timeout', () => socket.destroy())
+      })
+    }
   } else {
     // Support static CDN for chunks
     config.output.publicPath = 'auto'


### PR DESCRIPTION
## Summary
- Adds a 10-second idle timeout to TCP connections on the webpack dev server
- Each browser hard refresh creates a new WebSocket connection for HMR, but old ones aren't properly closed. These zombie sockets accumulate and exhaust the browser's per-origin TCP connection pool (6 for HTTP/1.1), causing the dev server to stop responding to new requests.
- Active connections (WebSocket with ping/pong, in-flight HTTP) reset the timer on data transfer, so they're unaffected. Only truly dead zombie sockets get destroyed.

## Test plan
- [x] Run `yarn web`, hard refresh repeatedly, confirm the dev server no longer freezes
- [ ] Confirm HMR still works (edit a file, see the update without full reload)

🤖 Generated with [Claude Code](https://claude.com/claude-code)