### PR TITLE
[APP-1829] Show "media on other device" for threaded media

### DIFF
--- a/src/view/com/composer/drafts/DraftItem.tsx
+++ b/src/view/com/composer/drafts/DraftItem.tsx
@@ -37,7 +37,7 @@ export function DraftItem({
   const post = draft.posts[0]
 
   const mediaExistsOnOtherDevice =
-    !draft.meta.isOriginatingDevice && draft.meta.hasMissingMedia
+    !draft.meta.isOriginatingDevice && draft.meta.hasMedia
   const mediaIsMissing =
     draft.meta.isOriginatingDevice && draft.meta.hasMissingMedia
   const hasMetadata =


### PR DESCRIPTION
`hasMissingMedia` depends on `storage.mediaExists()`, which checks whether media files exist locally. using `hasMedia` instead ensures that if it's not the originating device and the draft has media, by definition it's on the other device.