### PR TITLE
dedupe trending topics

### DIFF
--- a/src/state/queries/trending/useTrendingTopics.ts
+++ b/src/state/queries/trending/useTrendingTopics.ts
@@ -29,9 +29,10 @@ export const trendingTopicsQueryKey = ['trending-topics']
 export function useTrendingTopics() {
   const agent = useAgent()
   const {data: preferences} = usePreferencesQuery()
-  const mutedWords = React.useMemo(() => {
-    return preferences?.moderationPrefs?.mutedWords || []
-  }, [preferences?.moderationPrefs])
+  const mutedWords = React.useMemo(
+    () => preferences?.moderationPrefs?.mutedWords ?? [],
+    [preferences?.moderationPrefs?.mutedWords],
+  )
 
   return useQuery<Response>({
     refetchOnWindowFocus: true,


### PR DESCRIPTION
<img width="1284" height="834" alt="image" src="https://github.com/user-attachments/assets/7487cd9b-c02a-4856-b6c5-d9b26e42be18" />

API can return duped topics, added filter by the link (the unique id) so that its deduped across the sidebar/interstitial/etc.