### PR TITLE
have back button dismiss lightbox on web

### DIFF
--- a/src/alf/atoms.ts
+++ b/src/alf/atoms.ts
@@ -109,6 +109,22 @@ export const atoms = {
   }),
 
   /**
+   * Visually hidden but available to screen readers (web).
+   * Use for live regions or off-screen labels (e.g. "Image 1 of 3").
+   */
+  sr_only: web({
+    position: 'absolute',
+    width: 1,
+    height: 1,
+    padding: 0,
+    margin: -1,
+    overflow: 'hidden',
+    clip: 'rect(0,0,0,0)',
+    whiteSpace: 'nowrap',
+    borderWidth: 0,
+  }),
+
+  /**
    * {@link Layout.SCROLLBAR_OFFSET}
    */
   scrollbar_offset: platform({

--- a/src/components/Post/Embed/VideoEmbed/VideoEmbedInner/VideoEmbedInnerWeb.tsx
+++ b/src/components/Post/Embed/VideoEmbed/VideoEmbedInner/VideoEmbedInnerWeb.tsx
@@ -72,19 +72,7 @@ export function VideoEmbedInnerWeb({
             loop={loop}
           />
           {embed.alt && (
-            <figcaption
-              id={figId}
-              style={{
-                position: 'absolute',
-                width: 1,
-                height: 1,
-                padding: 0,
-                margin: -1,
-                overflow: 'hidden',
-                clip: 'rect(0, 0, 0, 0)',
-                whiteSpace: 'nowrap',
-                borderWidth: 0,
-              }}>
+            <figcaption id={figId} style={a.sr_only}>
               {embed.alt}
             </figcaption>
           )}

--- a/src/view/com/lightbox/Lightbox.web.tsx
+++ b/src/view/com/lightbox/Lightbox.web.tsx
@@ -238,7 +238,7 @@ function LightboxGallery({
         </View>
       ) : null}
       {imgs.length > 1 && (
-        <div aria-live="polite" aria-atomic="true" style={srOnlyStyle}>
+        <div aria-live="polite" aria-atomic="true" style={a.sr_only}>
           <Text>{_(msg`Image ${index + 1} of ${imgs.length}`)}</Text>
         </div>
       )}
@@ -358,18 +358,6 @@ function LightboxGalleryItem({
       )}
     </>
   )
-}
-
-const srOnlyStyle: React.CSSProperties = {
-  position: 'absolute',
-  width: 1,
-  height: 1,
-  padding: 0,
-  margin: -1,
-  overflow: 'hidden',
-  clip: 'rect(0,0,0,0)',
-  whiteSpace: 'nowrap',
-  borderWidth: 0,
 }
 
 const styles = StyleSheet.create({


### PR DESCRIPTION
Allow back button press on web to dismiss a currently open lightbox. Also added some accessibility props for screen reader navigation.

![CleanShot 2026-02-13 at 19 12 00](https://github.com/user-attachments/assets/75d3e895-382d-4bd8-91d3-1cd29e655ab5)