### PR TITLE
Fix quote embed clickability in composer on web

### DIFF
--- a/src/components/Post/Embed/LazyQuoteEmbed.tsx
+++ b/src/components/Post/Embed/LazyQuoteEmbed.tsx
@@ -6,7 +6,13 @@ import {useResolveLinkQuery} from '#/state/queries/resolve-link'
 import {atoms as a, useTheme} from '#/alf'
 import {QuoteEmbed} from '#/components/Post/Embed'
 
-export function LazyQuoteEmbed({uri}: {uri: string}) {
+export function LazyQuoteEmbed({
+  uri,
+  linkDisabled,
+}: {
+  uri: string
+  linkDisabled?: boolean
+}) {
   const t = useTheme()
   const {data} = useResolveLinkQuery(uri)
 
@@ -21,6 +27,7 @@ export function LazyQuoteEmbed({uri}: {uri: string}) {
         type: 'post',
         view,
       }}
+      linkDisabled={linkDisabled}
     />
   ) : (
     <View

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -1725,9 +1725,7 @@ function ComposerEmbeds({
         <View
           style={[a.pb_sm, video ? [a.pt_md] : [a.pt_xl], IS_WEB && [a.pb_md]]}>
           <View style={[a.relative]}>
-            <View style={{pointerEvents: 'none'}}>
-              <LazyQuoteEmbed uri={embed.quote.uri} />
-            </View>
+            <LazyQuoteEmbed uri={embed.quote.uri} linkDisabled />
             {canRemoveQuote && (
               <ExternalEmbedRemoveBtn
                 onRemove={() => dispatch({type: 'embed_remove_quote'})}

--- a/src/view/com/composer/ComposerReplyTo.tsx
+++ b/src/view/com/composer/ComposerReplyTo.tsx
@@ -132,7 +132,7 @@ export function ComposerReplyTo({replyTo}: {replyTo: ComposerOptsPostRef}) {
           )}
         </View>
         {showFull && parsedQuoteEmbed && parsedQuoteEmbed.type === 'post' && (
-          <QuoteEmbed embed={parsedQuoteEmbed} />
+          <QuoteEmbed embed={parsedQuoteEmbed} linkDisabled />
         )}
       </View>
     </Pressable>


### PR DESCRIPTION
## Summary
- Quote embeds in the composer were unintentionally clickable on web (the `pointerEvents: 'none'` style wrapper wasn't working reliably on web - seems there's a functionality difference between the style version and the prop version?)
- Added a `linkDisabled` prop to `QuoteEmbed` that replaces the `Link` wrapper with a plain `View` and applies `pointerEvents="none"` to block nested interactive elements (external links, image lightbox, feed cards, etc.)
  - It always irked me that we had an `<a>` tag here, seems bad for a11y
- Applied `linkDisabled` in both composer embed and composer reply-to contexts

## Test plan
- [ ] Open the composer on web with a quote post attached — verify the quote is not clickable
- [ ] Verify the remove (X) button on the quote still works
- [ ] Open a reply in the composer where the parent post has a quote — verify the quote in the reply-to preview is not clickable
- [ ] Verify quote embeds in the feed are still clickable as normal
- [ ] Test on iOS to confirm no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)