### PR TITLE
On-device translation prototype

### DIFF
--- a/package.json
+++ b/package.json
@@ -164,6 +164,7 @@
     "expo-splash-screen": "~31.0.12",
     "expo-system-ui": "~6.0.9",
     "expo-task-manager": "~14.0.9",
+    "expo-translate-text": "^0.1.0",
     "expo-updates": "~29.0.14",
     "expo-video": "~3.0.15",
     "expo-video-thumbnails": "^10.0.8",

--- a/src/analytics/metrics/types.ts
+++ b/src/analytics/metrics/types.ts
@@ -667,6 +667,9 @@ export type Events = {
     targetLanguage: string
     textLength: number
   }
+  'translate:result': {
+    method: 'on-device' | 'google-translate' | 'fallback-alert'
+  }
 
   'verification:create': {}
   'verification:revoke': {}

--- a/src/components/Post/TranslatedPost.tsx
+++ b/src/components/Post/TranslatedPost.tsx
@@ -1,0 +1,77 @@
+import {View} from 'react-native'
+import {Trans} from '@lingui/macro'
+import {useLingui} from '@lingui/react'
+
+import {codeToLanguageName} from '#/locale/helpers'
+import {useTranslationState} from '#/state/translation'
+import {atoms as a, useTheme} from '#/alf'
+import {Loader} from '#/components/Loader'
+import {Text} from '#/components/Typography'
+
+export function TranslatedPost({
+  postUri,
+  hideLoading,
+}: {
+  postUri: string
+  hideLoading?: boolean
+}) {
+  const state = useTranslationState(postUri)
+
+  if (state.status === 'loading' && !hideLoading) {
+    return <TranslationLoading />
+  }
+
+  if (state.status === 'success') {
+    return (
+      <TranslationResult
+        translatedText={state.translatedText}
+        sourceLanguage={state.sourceLanguage}
+      />
+    )
+  }
+
+  return null
+}
+
+function TranslationLoading() {
+  const t = useTheme()
+
+  return (
+    <View style={[a.flex_row, a.align_center, a.gap_sm, a.py_xs]}>
+      <Loader size="sm" />
+      <Text style={[a.text_sm, t.atoms.text_contrast_medium]}>
+        <Trans>Translating...</Trans>
+      </Text>
+    </View>
+  )
+}
+
+function TranslationResult({
+  translatedText,
+  sourceLanguage,
+}: {
+  translatedText: string
+  sourceLanguage: string
+}) {
+  const t = useTheme()
+  const {i18n} = useLingui()
+
+  const langName = sourceLanguage
+    ? codeToLanguageName(sourceLanguage, i18n.locale)
+    : undefined
+
+  return (
+    <View style={[a.py_xs, a.gap_xs]}>
+      <Text style={[a.text_xs, t.atoms.text_contrast_medium]}>
+        {langName ? (
+          <Trans>Translated from {langName}</Trans>
+        ) : (
+          <Trans>Translated</Trans>
+        )}
+      </Text>
+      <Text selectable style={[a.text_md]}>
+        {translatedText}
+      </Text>
+    </View>
+  )
+}

--- a/src/components/PostControls/PostMenu/PostMenuItems.tsx
+++ b/src/components/PostControls/PostMenu/PostMenuItems.tsx
@@ -258,7 +258,7 @@ let PostMenuItems = ({
   }
 
   const onPressTranslate = () => {
-    translate(record.text, langPrefs.primaryLanguage)
+    translate(record.text, langPrefs.primaryLanguage, {postUri: post.uri})
 
     if (
       bsky.dangerousIsType<AppBskyFeedPost.Record>(

--- a/src/lib/hooks/useTranslate.web.ts
+++ b/src/lib/hooks/useTranslate.web.ts
@@ -1,0 +1,16 @@
+import {useCallback} from 'react'
+
+import {getTranslatorLink} from '#/locale/helpers'
+import {useOpenLink} from './useOpenLink'
+
+export function useTranslate() {
+  const openLink = useOpenLink()
+
+  return useCallback(
+    async (text: string, language: string, _opts?: {postUri?: string}) => {
+      const translateUrl = getTranslatorLink(text, language)
+      await openLink(translateUrl)
+    },
+    [openLink],
+  )
+}

--- a/src/state/translation.ts
+++ b/src/state/translation.ts
@@ -1,0 +1,45 @@
+/**
+ * Per-post translation state store. Uses the EventEmitter + Map pattern
+ * (same as post-shadow.ts) so only components subscribed to a specific
+ * post URI re-render when its translation state changes.
+ */
+import {useEffect, useState} from 'react'
+import EventEmitter from 'eventemitter3'
+
+export type TranslationState =
+  | {status: 'idle'}
+  | {status: 'loading'}
+  | {status: 'success'; translatedText: string; sourceLanguage: string}
+
+const IDLE: TranslationState = {status: 'idle'}
+
+const emitter = new EventEmitter()
+const translations = new Map<string, TranslationState>()
+
+export function setTranslationState(postUri: string, state: TranslationState) {
+  translations.set(postUri, state)
+  emitter.emit(postUri)
+}
+
+export function clearTranslation(postUri: string) {
+  translations.delete(postUri)
+  emitter.emit(postUri)
+}
+
+export function useTranslationState(postUri: string): TranslationState {
+  const [state, setState] = useState<TranslationState>(
+    () => translations.get(postUri) ?? IDLE,
+  )
+
+  useEffect(() => {
+    function onUpdate() {
+      setState(translations.get(postUri) ?? IDLE)
+    }
+    emitter.addListener(postUri, onUpdate)
+    return () => {
+      emitter.removeListener(postUri, onUpdate)
+    }
+  }, [postUri])
+
+  return state
+}

--- a/src/view/com/post/Post.tsx
+++ b/src/view/com/post/Post.tsx
@@ -33,6 +33,7 @@ import {PostAlerts} from '#/components/moderation/PostAlerts'
 import {Embed, PostEmbedViewContext} from '#/components/Post/Embed'
 import {PostRepliedTo} from '#/components/Post/PostRepliedTo'
 import {ShowMoreTextButton} from '#/components/Post/ShowMoreTextButton'
+import {TranslatedPost} from '#/components/Post/TranslatedPost'
 import {PostControls} from '#/components/PostControls'
 import {RichText} from '#/components/RichText'
 import {SubtleHover} from '#/components/SubtleHover'
@@ -217,6 +218,7 @@ function PostInner({
                 )}
               </View>
             ) : undefined}
+            <TranslatedPost postUri={post.uri} />
             {post.embed ? (
               <Embed
                 embed={post.embed}

--- a/src/view/com/posts/PostFeedItem.tsx
+++ b/src/view/com/posts/PostFeedItem.tsx
@@ -43,6 +43,7 @@ import {Embed} from '#/components/Post/Embed'
 import {PostEmbedViewContext} from '#/components/Post/Embed/types'
 import {PostRepliedTo} from '#/components/Post/PostRepliedTo'
 import {ShowMoreTextButton} from '#/components/Post/ShowMoreTextButton'
+import {TranslatedPost} from '#/components/Post/TranslatedPost'
 import {PostControls} from '#/components/PostControls'
 import {DiscoverDebug} from '#/components/PostControls/DiscoverDebug'
 import {RichText} from '#/components/RichText'
@@ -481,6 +482,7 @@ let PostContent = ({
           )}
         </View>
       ) : undefined}
+      <TranslatedPost postUri={post.uri} />
       {postEmbed ? (
         <View style={[a.pb_xs]}>
           <Embed

--- a/yarn.lock
+++ b/yarn.lock
@@ -3403,7 +3403,7 @@
     "@babel/parser" "^7.27.2"
     "@babel/types" "^7.27.1"
 
-"@babel/traverse--for-generate-function-map@npm:@babel/traverse@^7.25.3":
+"@babel/traverse--for-generate-function-map@npm:@babel/traverse@^7.25.3", "@babel/traverse@^7.25.3", "@babel/traverse@^7.25.9":
   version "7.25.9"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.25.9.tgz#a50f8fe49e7f69f53de5bea7e413cd35c5e13c84"
   integrity sha512-ZCuvfwOwlz/bawvAuvcj8rrithP2/N55Tzz342AkTvq4qaWbGfmCk/tKhNaV2cthijKrPAA8SRJV5WWe7IBMJw==
@@ -3461,19 +3461,6 @@
     "@babel/helper-split-export-declaration" "^7.24.5"
     "@babel/parser" "^7.24.5"
     "@babel/types" "^7.24.5"
-    debug "^4.3.1"
-    globals "^11.1.0"
-
-"@babel/traverse@^7.25.3", "@babel/traverse@^7.25.9":
-  version "7.25.9"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.25.9.tgz#a50f8fe49e7f69f53de5bea7e413cd35c5e13c84"
-  integrity sha512-ZCuvfwOwlz/bawvAuvcj8rrithP2/N55Tzz342AkTvq4qaWbGfmCk/tKhNaV2cthijKrPAA8SRJV5WWe7IBMJw==
-  dependencies:
-    "@babel/code-frame" "^7.25.9"
-    "@babel/generator" "^7.25.9"
-    "@babel/parser" "^7.25.9"
-    "@babel/template" "^7.25.9"
-    "@babel/types" "^7.25.9"
     debug "^4.3.1"
     globals "^11.1.0"
 
@@ -11777,6 +11764,11 @@ expo-task-manager@~14.0.9:
   dependencies:
     unimodules-app-loader "~6.0.8"
 
+expo-translate-text@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/expo-translate-text/-/expo-translate-text-0.1.0.tgz#16904f1baac126d5a452b4196495d238dcbbb6af"
+  integrity sha512-zrRJ0Do6Gie12yZYzgD4McQNIvb54pfPsBRegkUSuADec9DrXdxJXvw/OieZ+L4oMQu0Fx/NJDnHGQoaa0CVgA==
+
 expo-updates-interface@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/expo-updates-interface/-/expo-updates-interface-2.0.0.tgz#7721cb64c37bcb46b23827b2717ef451a9378749"
@@ -18691,16 +18683,7 @@ string-natural-compare@^3.0.1:
   resolved "https://registry.yarnpkg.com/string-natural-compare/-/string-natural-compare-3.0.1.tgz#7a42d58474454963759e8e8b7ae63d71c1e7fdf4"
   integrity sha512-n3sPwynL1nwKi3WJ6AIsClwBMa0zTi54fn2oLU6ndfTSIO05xaznjSf15PcBZU6FNWbmN5Q6cxT4V5hGvB4taw==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -18859,7 +18842,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -18872,13 +18855,6 @@ strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -20276,7 +20252,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -20289,15 +20265,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
Prototype demonstrating use of the `expo-translate-text` module to provide on-device translation of posts on native, with a fallback to Google Translate. 

https://github.com/user-attachments/assets/a81c3b03-fa55-4461-bb03-0f4cdbd34273

