### PR TITLE
Fix missing pixel row in text rendering on iOS

### DIFF
--- a/patches/react-native-uitextview+1.4.0.patch
+++ b/patches/react-native-uitextview+1.4.0.patch
@@ -1,11 +1,11 @@
 diff --git a/node_modules/react-native-uitextview/ios/RNUITextViewShadow.swift b/node_modules/react-native-uitextview/ios/RNUITextViewShadow.swift
-index c34ba71..13d576a 100644
+index c34ba71..3602856 100644
 --- a/node_modules/react-native-uitextview/ios/RNUITextViewShadow.swift
 +++ b/node_modules/react-native-uitextview/ios/RNUITextViewShadow.swift
-@@ -159,13 +159,23 @@ class RNUITextViewShadow: RCTShadowView {
+@@ -159,13 +159,25 @@ class RNUITextViewShadow: RCTShadowView {
      let maxSize = CGSize(width: CGFloat(maxWidth), height: CGFloat(MAXFLOAT))
      let textSize = self.attributedText.boundingRect(with: maxSize, options: .usesLineFragmentOrigin, context: nil)
-     
+ 
 -    var totalLines = self.lineHeight == 0.0 ? 0 : Int(ceil(textSize.height / self.lineHeight))
 -
 -    if self.numberOfLines != 0, totalLines > self.numberOfLines {
@@ -27,6 +27,8 @@ index c34ba71..13d576a 100644
      }
  
 -    self.frameSize = CGSize(width: CGFloat(maxWidth), height: CGFloat(CGFloat(totalLines) * self.lineHeight))
++    finalHeight = ceil(finalHeight)
++
 +    self.frameSize = CGSize(width: CGFloat(maxWidth), height: finalHeight)
      return YGSize(width: Float(self.frameSize.width), height: Float(self.frameSize.height))
    }


### PR DESCRIPTION
## Summary

Fixes #9836

`react-native-uitextview` calculates the text container height using `boundingRect`, which returns fractional values. Apple's docs recommend ceiling the result. Without it, `clipsToBounds` can clip through a line of text, producing a missing row of pixels.

This patch ceils `finalHeight` in `getNeededSize()` before it's stored and converted to `Float` (a lossy `CGFloat` → `Float` conversion that can further reduce the value).

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><img width="378" height="125" alt="Screenshot 2026-02-16 at 13 49 27" src="https://github.com/user-attachments/assets/221c2a65-b8c0-495d-b6f1-6e7ffc1777ac" /></td>
<td><img width="395" height="131" alt="Screenshot 2026-02-16 at 13 52 29" src="https://github.com/user-attachments/assets/3ab8395a-8c4f-4685-a5b7-6cc67021ca3d" /></td>
</tr>
</table>

## Test plan

- [ ] Open a post with multi-line text on iOS (e.g. [this post](https://bsky.app/profile/samuel.fm/post/3mexxt34vk22r))
- [ ] Verify no lines have missing pixel rows
- [ ] Verify text layout is otherwise unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)