### PR TITLE
Make profile description text selectable

### DIFF
--- a/src/screens/Profile/Header/ProfileHeaderStandard.tsx
+++ b/src/screens/Profile/Header/ProfileHeaderStandard.tsx
@@ -157,6 +157,7 @@ let ProfileHeaderStandard = ({
                     testID="profileHeaderDescription"
                     style={[a.text_md]}
                     numberOfLines={15}
+                    selectable
                     value={descriptionRT}
                     enableTags
                     authorHandle={profile.handle}


### PR DESCRIPTION
## Summary
- Adds `selectable` prop to the `RichText` component in the profile header, allowing users to highlight and copy text from profile descriptions.

<img width="400" alt="Simulator Screenshot - iPhone 17 - 2026-02-16 at 15 01 53" src="https://github.com/user-attachments/assets/a60ccd1e-fb81-4b8a-8062-a28602a4cb38" />



## Test plan
- [ ] Open a profile with a bio on iOS/Android and verify the text can be long-pressed to select
- [ ] Open a profile with a bio on web and verify the text can be selected with click-drag
- [ ] Verify links, mentions, and tags in the bio still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)