### PR TITLE
Be more descriptive with video errors, log less

### DIFF
--- a/src/lib/strings/errors.ts
+++ b/src/lib/strings/errors.ts
@@ -54,6 +54,7 @@ const NETWORK_ERRORS = [
   'Failed to fetch',
   'Load failed',
   'Upstream service unreachable',
+  'NetworkError when attempting to fetch resource',
 ]
 
 export function isNetworkError(e: unknown) {


### PR DESCRIPTION
The sentry issue is way too noisy to figure out why sometimes Android uploads fail: https://blueskyweb.sentry.io/issues/6732134886

Let's cut down the noise, and also show the user what the exact error is so we can tell from screenshots what's going on