### PR TITLE
Add optional props to Prompt.Action

### DIFF
--- a/src/components/Prompt.tsx
+++ b/src/components/Prompt.tsx
@@ -4,8 +4,14 @@ import {msg} from '@lingui/macro'
 import {useLingui} from '@lingui/react'
 
 import {atoms as a, useTheme, type ViewStyleProp, web} from '#/alf'
-import {Button, type ButtonColor, ButtonText} from '#/components/Button'
+import {
+  Button,
+  type ButtonColor,
+  ButtonIcon,
+  ButtonText,
+} from '#/components/Button'
 import * as Dialog from '#/components/Dialog'
+import {type Props as SVGIconProps} from '#/components/icons/common'
 import {Text} from '#/components/Typography'
 import {type BottomSheetViewProps} from '../../modules/bottom-sheet'
 
@@ -126,7 +132,7 @@ export function Cancel({
     <Button
       variant="solid"
       color="secondary"
-      size={'large'}
+      size="large"
       label={cta || _(msg`Cancel`)}
       onPress={onPress}>
       <ButtonText>{cta || _(msg`Cancel`)}</ButtonText>
@@ -138,6 +144,9 @@ export function Action({
   onPress,
   color = 'primary',
   cta,
+  disabled = false,
+  icon,
+  shouldCloseOnPress,
   testID,
 }: {
   /**
@@ -153,25 +162,41 @@ export function Action({
    * Optional i18n string. If undefined, it will default to "Confirm".
    */
   cta?: string
+  /**
+   * If undefined, it will default to false.
+   */
+  disabled?: boolean
+  icon?: React.ComponentType<SVGIconProps>
+  /**
+   * Optionally close dialog automatically on press. If undefined, it will
+   * default to true.
+   */
+  shouldCloseOnPress?: boolean
   testID?: string
 }) {
   const {_} = useLingui()
   const {close} = Dialog.useDialogContext()
   const handleOnPress = useCallback(
     (e: GestureResponderEvent) => {
-      close(() => onPress?.(e))
+      if (shouldCloseOnPress) {
+        close(() => onPress?.(e))
+      } else {
+        onPress?.(e)
+      }
     },
-    [close, onPress],
+    [close, onPress, shouldCloseOnPress],
   )
 
   return (
     <Button
       color={color}
-      size={'large'}
+      disabled={disabled}
+      size="large"
       label={cta || _(msg`Confirm`)}
       onPress={handleOnPress}
       testID={testID}>
       <ButtonText>{cta || _(msg`Confirm`)}</ButtonText>
+      {icon && <ButtonIcon icon={icon} />}
     </Button>
   )
 }


### PR DESCRIPTION
Adds three new optional props to `Prompt.Action` for use in ALF dialogs, e.g., `DeleteAccountDialog` (see #9863).

* `disabled?: boolean = false` – passthrough to `Button`’s disabled prop
* `icon?: React.ComponentType<SVGIconProps>` – conditionally render `ButtonIcon`
* `shouldClose?: boolean = true` – whether to close the associated `control` in `handleOnPress`