### PR TITLE
Fix typo in `DeleteAccountDialog` message

### DIFF
--- a/src/screens/Settings/components/DeleteAccountDialog.tsx
+++ b/src/screens/Settings/components/DeleteAccountDialog.tsx
@@ -340,7 +340,7 @@ function DeleteAccountDialogInner({
             </Prompt.TitleText>
             <Prompt.DescriptionText>
               <Trans>
-                This will irreversably delete your Bluesky account{' '}
+                This will irreversibly delete your Bluesky account{' '}
                 <Span style={[a.font_semi_bold, t.atoms.text]}>
                   {currentHandle}
                 </Span>{' '}


### PR DESCRIPTION
As a follow-up to #9863, a small typo fix:

`irreversably` ➡️ `irreversibly`