### PR TITLE
Improve error handling on Explore page

### DIFF
--- a/src/screens/Search/Explore.tsx
+++ b/src/screens/Search/Explore.tsx
@@ -362,7 +362,7 @@ export function Explore({
     i.push({
       type: 'tabbedHeader',
       key: 'suggested-accounts-header',
-      title: _(msg`Suggested Accounts`),
+      title: _(msg`Suggested accounts`),
       icon: Person,
       searchButton: {
         label: _(msg`Search for more accounts`),
@@ -439,7 +439,7 @@ export function Explore({
     i.push({
       type: 'header',
       key: 'suggested-feeds-header',
-      title: _(msg`Discover New Feeds`),
+      title: _(msg`Discover new feeds`),
       icon: ListSparkle,
       searchButton: {
         label: _(msg`Search for more feeds`),


### PR DESCRIPTION
The Explore screen would indefinitely display the placeholder for the **Discover new feeds** section in some error cases (see **Before** screenshot). This adds [a check](https://github.com/bluesky-social/social-app/pull/9890/changes/3bdb80f9fb62302d5df0d904c04c6b2a67c9da0a) for `suggestedFeedsError` to ensure we display an appropriate error message instead.

| Before | After |
| - | - |
| <img width="1206" height="2622" alt="before" src="https://github.com/user-attachments/assets/6637bf59-c0f3-4f07-bc3a-e865a1a17c89" /> | <img width="1206" height="2622" alt="after" src="https://github.com/user-attachments/assets/a2373f0d-b0bf-405a-a252-81837649be06" /> |