### PR TITLE
Enable profile hover card on quoted post authors

### DIFF
--- a/src/components/Post/Embed/index.tsx
+++ b/src/components/Post/Embed/index.tsx
@@ -285,15 +285,14 @@ export function QuoteEmbed({
 
   const contents = (
     <>
-      <View pointerEvents="none">
-        <PostMeta
-          author={quote.author}
-          moderation={moderation}
-          showAvatar
-          postHref={itemHref}
-          timestamp={quote.indexedAt}
-        />
-      </View>
+      <PostMeta
+        author={quote.author}
+        moderation={moderation}
+        showAvatar
+        postHref={itemHref}
+        timestamp={quote.indexedAt}
+        linkDisabled
+      />
       {moderation ? (
         <PostAlerts modui={moderation.ui('contentView')} style={[a.py_xs]} />
       ) : null}

--- a/src/view/com/util/TimeElapsed.tsx
+++ b/src/view/com/util/TimeElapsed.tsx
@@ -1,4 +1,4 @@
-import React, {type JSX} from 'react'
+import {useState} from 'react'
 import {type I18n} from '@lingui/core'
 import {useLingui} from '@lingui/react'
 
@@ -11,17 +11,17 @@ export function TimeElapsed({
   timeToString,
 }: {
   timestamp: string
-  children: ({timeElapsed}: {timeElapsed: string}) => JSX.Element
+  children: ({timeElapsed}: {timeElapsed: string}) => React.ReactElement
   timeToString?: (i18n: I18n, timeElapsed: string) => string
 }) {
   const {i18n} = useLingui()
   const ago = useGetTimeAgo()
   const tick = useTickEveryMinute()
-  const [timeElapsed, setTimeAgo] = React.useState(() =>
+  const [timeElapsed, setTimeAgo] = useState(() =>
     timeToString ? timeToString(i18n, timestamp) : ago(timestamp, tick),
   )
 
-  const [prevTick, setPrevTick] = React.useState(tick)
+  const [prevTick, setPrevTick] = useState(tick)
   if (prevTick !== tick) {
     setPrevTick(tick)
     setTimeAgo(


### PR DESCRIPTION
## Summary
- Remove `pointerEvents="none"` wrapper from `PostMeta` in `QuoteEmbed` and replace with a `linkDisabled` prop that disables navigation links while preserving hover events
- This allows `ProfileHoverCard` to activate when hovering author names/avatars in quoted posts

## Test plan
- [ ] On web, hover over a quoted post author's name/avatar and verify the profile hover card appears
- [ ] Click the author name/avatar in a quoted post and verify it does **not** navigate to the profile (the quote embed click should still navigate to the quoted post)
- [ ] Verify regular (non-quoted) post meta still has working profile links
- [ ] Confirm native is unchanged

Fixes #6340

🤖 Generated with [Claude Code](https://claude.com/claude-code)