### PR TITLE
Add dynamic scroll indicator insets to profile tabs

### DIFF
--- a/src/components/StarterPack/ProfileStarterPacks.tsx
+++ b/src/components/StarterPack/ProfileStarterPacks.tsx
@@ -201,40 +201,48 @@ export function ProfileStarterPacks({
     [isTabletOrDesktop, t.atoms.border_contrast_low],
   )
 
+  const list = (
+    <List
+      testID={testID ? `${testID}-flatlist` : undefined}
+      ref={scrollElRef}
+      data={items}
+      renderItem={renderItem}
+      keyExtractor={keyExtractor}
+      refreshing={isPTRing}
+      headerOffset={headerOffset}
+      progressViewOffset={ios(0)}
+      contentContainerStyle={{
+        minHeight: height + headerOffset,
+        paddingBottom: bottomBarOffset,
+      }}
+      removeClippedSubviews={true}
+      desktopFixedHeight
+      onEndReached={onEndReached}
+      onRefresh={onRefresh}
+      ListEmptyComponent={
+        data ? (isMe ? EmptyComponent : undefined) : FeedLoadingPlaceholder
+      }
+      ListFooterComponent={
+        !!data && items?.length !== 0 && isMe ? CreateAnother : undefined
+      }
+      animatedProps={IS_IOS ? animatedProps : undefined}
+    />
+  )
+
   return (
     <View testID={testID} style={style}>
-      <ScrollProvider
-        onScroll={onScrollWorklet}
-        onBeginDrag={onBeginDragFromContext}
-        onEndDrag={onEndDragFromContext}
-        onMomentumBegin={onMomentumEndFromContext}
-        onMomentumEnd={onMomentumEndFromContext}>
-        <List
-          testID={testID ? `${testID}-flatlist` : undefined}
-          ref={scrollElRef}
-          data={items}
-          renderItem={renderItem}
-          keyExtractor={keyExtractor}
-          refreshing={isPTRing}
-          headerOffset={headerOffset}
-          progressViewOffset={ios(0)}
-          contentContainerStyle={{
-            minHeight: height + headerOffset,
-            paddingBottom: bottomBarOffset,
-          }}
-          removeClippedSubviews={true}
-          desktopFixedHeight
-          onEndReached={onEndReached}
-          onRefresh={onRefresh}
-          ListEmptyComponent={
-            data ? (isMe ? EmptyComponent : undefined) : FeedLoadingPlaceholder
-          }
-          ListFooterComponent={
-            !!data && items?.length !== 0 && isMe ? CreateAnother : undefined
-          }
-          animatedProps={animatedProps}
-        />
-      </ScrollProvider>
+      {IS_IOS ? (
+        <ScrollProvider
+          onScroll={onScrollWorklet}
+          onBeginDrag={onBeginDragFromContext}
+          onEndDrag={onEndDragFromContext}
+          onMomentumBegin={onMomentumEndFromContext}
+          onMomentumEnd={onMomentumEndFromContext}>
+          {list}
+        </ScrollProvider>
+      ) : (
+        list
+      )}
     </View>
   )
 }

--- a/src/components/StarterPack/ProfileStarterPacks.tsx
+++ b/src/components/StarterPack/ProfileStarterPacks.tsx
@@ -7,11 +7,6 @@ import {
   View,
   type ViewStyle,
 } from 'react-native'
-import {
-  type ScrollHandler,
-  useAnimatedProps,
-  useSharedValue,
-} from 'react-native-reanimated'
 import {type AppBskyGraphDefs} from '@atproto/api'
 import {msg} from '@lingui/core/macro'
 import {useLingui} from '@lingui/react'
@@ -21,20 +16,19 @@ import {useNavigation} from '@react-navigation/native'
 import {useGenerateStarterPackMutation} from '#/lib/generate-starterpack'
 import {useBottomBarOffset} from '#/lib/hooks/useBottomBarOffset'
 import {useRequireEmailVerification} from '#/lib/hooks/useRequireEmailVerification'
-import {useWebMediaQueries} from '#/lib/hooks/useWebMediaQueries'
 import {type NavigationProp} from '#/lib/routes/types'
-import {ScrollProvider, useScrollHandlers} from '#/lib/ScrollContext'
+import {ScrollProvider} from '#/lib/ScrollContext'
 import {parseStarterPackUri} from '#/lib/strings/starter-pack'
 import {logger} from '#/logger'
 import {useActorStarterPacksQuery} from '#/state/queries/actor-starter-packs'
-import {useShellLayout} from '#/state/shell/shell-layout'
 import {
   EmptyState,
   type EmptyStateButtonProps,
 } from '#/view/com/util/EmptyState'
 import {List, type ListRef} from '#/view/com/util/List'
-import {FeedLoadingPlaceholder} from '#/view/com/util/LoadingPlaceholder'
-import {atoms as a, ios, useTheme} from '#/alf'
+import {FeedFeedLoadingPlaceholder} from '#/view/com/util/LoadingPlaceholder'
+import {useProfileScrollbarAdjustment} from '#/screens/Profile/useProfileScrollbarAdjustment'
+import {atoms as a, ios, useBreakpoints, useTheme} from '#/alf'
 import {Button, ButtonIcon, ButtonText} from '#/components/Button'
 import {useDialogControl} from '#/components/Dialog'
 import {PlusSmall_Stroke2_Corner0_Rounded as Plus} from '#/components/icons/Plus'
@@ -88,39 +82,8 @@ export function ProfileStarterPacks({
   const bottomBarOffset = useBottomBarOffset(100)
   const {height} = useWindowDimensions()
   const [isPTRing, setIsPTRing] = useState(false)
+  const {gtMobile} = useBreakpoints()
 
-  const {
-    onBeginDrag: onBeginDragFromContext,
-    onEndDrag: onEndDragFromContext,
-    onScroll: onScrollFromContext,
-    onMomentumEnd: onMomentumEndFromContext,
-  } = useScrollHandlers()
-
-  const scrollY = useSharedValue(0)
-  const onScrollWorklet = useCallback<ScrollHandler<any>>(
-    (e, ctx) => {
-      'worklet'
-      onScrollFromContext?.(e, ctx)
-      scrollY.set(e.contentOffset.y)
-    },
-    [onScrollFromContext, scrollY],
-  )
-
-  const {footerHeight} = useShellLayout()
-
-  const animatedProps = useAnimatedProps(() => {
-    if (IS_IOS) {
-      return {
-        scrollIndicatorInsets: {
-          top: Math.max(headerOffset - scrollY.get(), collapsedHeaderHeight),
-          right: 1,
-          left: 0,
-          bottom: footerHeight.get(),
-        },
-      }
-    }
-    return {}
-  })
   const {
     data,
     refetch,
@@ -129,7 +92,6 @@ export function ProfileStarterPacks({
     isFetchingNextPage,
     fetchNextPage,
   } = useActorStarterPacksQuery({did, enabled})
-  const {isTabletOrDesktop} = useWebMediaQueries()
 
   const items = data?.pages.flatMap(page => page.starterPacks)
   const {_} = useLingui()
@@ -191,58 +153,54 @@ export function ProfileStarterPacks({
         <View
           style={[
             a.p_lg,
-            (isTabletOrDesktop || index !== 0) && a.border_t,
+            (gtMobile || index !== 0) && a.border_t,
             t.atoms.border_contrast_low,
           ]}>
           <StarterPackCard starterPack={item} />
         </View>
       )
     },
-    [isTabletOrDesktop, t.atoms.border_contrast_low],
+    [gtMobile, t.atoms.border_contrast_low],
   )
 
-  const list = (
-    <List
-      testID={testID ? `${testID}-flatlist` : undefined}
-      ref={scrollElRef}
-      data={items}
-      renderItem={renderItem}
-      keyExtractor={keyExtractor}
-      refreshing={isPTRing}
-      headerOffset={headerOffset}
-      progressViewOffset={ios(0)}
-      contentContainerStyle={{
-        minHeight: height + headerOffset,
-        paddingBottom: bottomBarOffset,
-      }}
-      removeClippedSubviews={true}
-      desktopFixedHeight
-      onEndReached={onEndReached}
-      onRefresh={onRefresh}
-      ListEmptyComponent={
-        data ? (isMe ? EmptyComponent : undefined) : FeedLoadingPlaceholder
-      }
-      ListFooterComponent={
-        !!data && items?.length !== 0 && isMe ? CreateAnother : undefined
-      }
-      animatedProps={IS_IOS ? animatedProps : undefined}
-    />
-  )
+  const {scrollHandlers, animatedProps} = useProfileScrollbarAdjustment({
+    headerOffset,
+    collapsedHeaderHeight,
+  })
 
   return (
     <View testID={testID} style={style}>
-      {IS_IOS ? (
-        <ScrollProvider
-          onScroll={onScrollWorklet}
-          onBeginDrag={onBeginDragFromContext}
-          onEndDrag={onEndDragFromContext}
-          onMomentumBegin={onMomentumEndFromContext}
-          onMomentumEnd={onMomentumEndFromContext}>
-          {list}
-        </ScrollProvider>
-      ) : (
-        list
-      )}
+      <ScrollProvider {...scrollHandlers}>
+        <List
+          testID={testID ? `${testID}-flatlist` : undefined}
+          ref={scrollElRef}
+          data={items}
+          renderItem={renderItem}
+          keyExtractor={keyExtractor}
+          refreshing={isPTRing}
+          headerOffset={headerOffset}
+          progressViewOffset={ios(0)}
+          contentContainerStyle={{
+            minHeight: height + headerOffset,
+            paddingBottom: bottomBarOffset,
+          }}
+          removeClippedSubviews={true}
+          desktopFixedHeight
+          onEndReached={onEndReached}
+          onRefresh={onRefresh}
+          ListEmptyComponent={
+            data
+              ? isMe
+                ? EmptyComponent
+                : undefined
+              : FeedFeedLoadingPlaceholder
+          }
+          ListFooterComponent={
+            !!data && items?.length !== 0 && isMe ? CreateAnother : undefined
+          }
+          animatedProps={animatedProps}
+        />
+      </ScrollProvider>
     </View>
   )
 }

--- a/src/components/StarterPack/ProfileStarterPacks.tsx
+++ b/src/components/StarterPack/ProfileStarterPacks.tsx
@@ -7,6 +7,11 @@ import {
   View,
   type ViewStyle,
 } from 'react-native'
+import {
+  type ScrollHandler,
+  useAnimatedProps,
+  useSharedValue,
+} from 'react-native-reanimated'
 import {type AppBskyGraphDefs} from '@atproto/api'
 import {msg} from '@lingui/core/macro'
 import {useLingui} from '@lingui/react'
@@ -18,9 +23,11 @@ import {useBottomBarOffset} from '#/lib/hooks/useBottomBarOffset'
 import {useRequireEmailVerification} from '#/lib/hooks/useRequireEmailVerification'
 import {useWebMediaQueries} from '#/lib/hooks/useWebMediaQueries'
 import {type NavigationProp} from '#/lib/routes/types'
+import {ScrollProvider, useScrollHandlers} from '#/lib/ScrollContext'
 import {parseStarterPackUri} from '#/lib/strings/starter-pack'
 import {logger} from '#/logger'
 import {useActorStarterPacksQuery} from '#/state/queries/actor-starter-packs'
+import {useShellLayout} from '#/state/shell/shell-layout'
 import {
   EmptyState,
   type EmptyStateButtonProps,
@@ -47,6 +54,7 @@ interface ProfileFeedgensProps {
   scrollElRef: ListRef
   did: string
   headerOffset: number
+  collapsedHeaderHeight?: number
   enabled?: boolean
   style?: StyleProp<ViewStyle>
   testID?: string
@@ -66,6 +74,7 @@ export function ProfileStarterPacks({
   scrollElRef,
   did,
   headerOffset,
+  collapsedHeaderHeight = 0,
   enabled,
   style,
   testID,
@@ -79,6 +88,39 @@ export function ProfileStarterPacks({
   const bottomBarOffset = useBottomBarOffset(100)
   const {height} = useWindowDimensions()
   const [isPTRing, setIsPTRing] = useState(false)
+
+  const {
+    onBeginDrag: onBeginDragFromContext,
+    onEndDrag: onEndDragFromContext,
+    onScroll: onScrollFromContext,
+    onMomentumEnd: onMomentumEndFromContext,
+  } = useScrollHandlers()
+
+  const scrollY = useSharedValue(0)
+  const onScrollWorklet = useCallback<ScrollHandler<any>>(
+    (e, ctx) => {
+      'worklet'
+      onScrollFromContext?.(e, ctx)
+      scrollY.set(e.contentOffset.y)
+    },
+    [onScrollFromContext, scrollY],
+  )
+
+  const {footerHeight} = useShellLayout()
+
+  const animatedProps = useAnimatedProps(() => {
+    if (IS_IOS) {
+      return {
+        scrollIndicatorInsets: {
+          top: Math.max(headerOffset - scrollY.get(), collapsedHeaderHeight),
+          right: 1,
+          left: 0,
+          bottom: footerHeight.get(),
+        },
+      }
+    }
+    return {}
+  })
   const {
     data,
     refetch,
@@ -161,30 +203,38 @@ export function ProfileStarterPacks({
 
   return (
     <View testID={testID} style={style}>
-      <List
-        testID={testID ? `${testID}-flatlist` : undefined}
-        ref={scrollElRef}
-        data={items}
-        renderItem={renderItem}
-        keyExtractor={keyExtractor}
-        refreshing={isPTRing}
-        headerOffset={headerOffset}
-        progressViewOffset={ios(0)}
-        contentContainerStyle={{
-          minHeight: height + headerOffset,
-          paddingBottom: bottomBarOffset,
-        }}
-        removeClippedSubviews={true}
-        desktopFixedHeight
-        onEndReached={onEndReached}
-        onRefresh={onRefresh}
-        ListEmptyComponent={
-          data ? (isMe ? EmptyComponent : undefined) : FeedLoadingPlaceholder
-        }
-        ListFooterComponent={
-          !!data && items?.length !== 0 && isMe ? CreateAnother : undefined
-        }
-      />
+      <ScrollProvider
+        onScroll={onScrollWorklet}
+        onBeginDrag={onBeginDragFromContext}
+        onEndDrag={onEndDragFromContext}
+        onMomentumBegin={onMomentumEndFromContext}
+        onMomentumEnd={onMomentumEndFromContext}>
+        <List
+          testID={testID ? `${testID}-flatlist` : undefined}
+          ref={scrollElRef}
+          data={items}
+          renderItem={renderItem}
+          keyExtractor={keyExtractor}
+          refreshing={isPTRing}
+          headerOffset={headerOffset}
+          progressViewOffset={ios(0)}
+          contentContainerStyle={{
+            minHeight: height + headerOffset,
+            paddingBottom: bottomBarOffset,
+          }}
+          removeClippedSubviews={true}
+          desktopFixedHeight
+          onEndReached={onEndReached}
+          onRefresh={onRefresh}
+          ListEmptyComponent={
+            data ? (isMe ? EmptyComponent : undefined) : FeedLoadingPlaceholder
+          }
+          ListFooterComponent={
+            !!data && items?.length !== 0 && isMe ? CreateAnother : undefined
+          }
+          animatedProps={animatedProps}
+        />
+      </ScrollProvider>
     </View>
   )
 }

--- a/src/screens/Profile/Sections/Feed.tsx
+++ b/src/screens/Profile/Sections/Feed.tsx
@@ -28,6 +28,7 @@ interface FeedSectionProps {
   ref?: React.Ref<SectionRef>
   feed: FeedDescriptor
   headerHeight: number
+  collapsedHeaderHeight: number
   isFocused: boolean
   scrollElRef: ListRef
   ignoreFilterFor?: string
@@ -41,6 +42,7 @@ export function ProfileFeedSection({
   ref,
   feed,
   headerHeight,
+  collapsedHeaderHeight,
   isFocused,
   scrollElRef,
   ignoreFilterFor,
@@ -110,6 +112,8 @@ export function ProfileFeedSection({
           shouldUseAdjustedNumToRender ? adjustedInitialNumToRender : undefined
         }
         isVideoFeed={isVideoFeed}
+        adjustScrollIndicators
+        collapsedHeaderHeight={collapsedHeaderHeight}
       />
       {(isScrolledDown || hasNew) && (
         <LoadLatestBtn

--- a/src/screens/Profile/Sections/Labels.tsx
+++ b/src/screens/Profile/Sections/Labels.tsx
@@ -1,6 +1,11 @@
 import {useCallback, useEffect, useImperativeHandle, useMemo} from 'react'
 import {findNodeHandle, type ListRenderItemInfo, View} from 'react-native'
 import {
+  type ScrollHandler,
+  useAnimatedProps,
+  useSharedValue,
+} from 'react-native-reanimated'
+import {
   type AppBskyLabelerDefs,
   type InterpretedLabelValueDefinition,
   interpretLabelValueDefinitions,
@@ -11,6 +16,8 @@ import {useLingui} from '@lingui/react'
 import {Trans} from '@lingui/react/macro'
 
 import {isLabelerSubscribed, lookupLabelValueDefinition} from '#/lib/moderation'
+import {ScrollProvider, useScrollHandlers} from '#/lib/ScrollContext'
+import {useShellLayout} from '#/state/shell/shell-layout'
 import {List, type ListRef} from '#/view/com/util/List'
 import {atoms as a, ios, tokens, useTheme} from '#/alf'
 import {Divider} from '#/components/Divider'
@@ -31,6 +38,7 @@ interface LabelsSectionProps {
   moderationOpts: ModerationOpts
   scrollElRef: ListRef
   headerHeight: number
+  collapsedHeaderHeight: number
   isFocused: boolean
   setScrollViewTag: (tag: number | null) => void
 }
@@ -43,10 +51,44 @@ export function ProfileLabelsSection({
   moderationOpts,
   scrollElRef,
   headerHeight,
+  collapsedHeaderHeight,
   isFocused,
   setScrollViewTag,
 }: LabelsSectionProps) {
   const t = useTheme()
+
+  const {
+    onBeginDrag: onBeginDragFromContext,
+    onEndDrag: onEndDragFromContext,
+    onScroll: onScrollFromContext,
+    onMomentumEnd: onMomentumEndFromContext,
+  } = useScrollHandlers()
+
+  const scrollY = useSharedValue(0)
+  const onScrollWorklet = useCallback<ScrollHandler<any>>(
+    (e, ctx) => {
+      'worklet'
+      onScrollFromContext?.(e, ctx)
+      scrollY.set(e.contentOffset.y)
+    },
+    [onScrollFromContext, scrollY],
+  )
+
+  const {footerHeight} = useShellLayout()
+
+  const animatedProps = useAnimatedProps(() => {
+    if (IS_IOS) {
+      return {
+        scrollIndicatorInsets: {
+          top: Math.max(headerHeight - scrollY.get(), collapsedHeaderHeight),
+          right: 1,
+          left: 0,
+          bottom: footerHeight.get(),
+        },
+      }
+    }
+    return {}
+  })
 
   const onScrollToTop = useCallback(() => {
     scrollElRef.current?.scrollToOffset({
@@ -119,30 +161,38 @@ export function ProfileLabelsSection({
 
   return (
     <View>
-      <List
-        ref={scrollElRef}
-        data={labelValues}
-        renderItem={renderItem}
-        keyExtractor={keyExtractor}
-        contentContainerStyle={a.px_xl}
-        headerOffset={headerHeight}
-        progressViewOffset={ios(0)}
-        ListHeaderComponent={
-          <LabelerListHeader
-            isLabelerLoading={isLabelerLoading}
-            labelerInfo={labelerInfo}
-            labelerError={labelerError}
-            hasValues={labelValues.length !== 0}
-            isSubscribed={isSubscribed}
-          />
-        }
-        ListFooterComponent={
-          <ListFooter
-            height={headerHeight + 180}
-            style={a.border_transparent}
-          />
-        }
-      />
+      <ScrollProvider
+        onScroll={onScrollWorklet}
+        onBeginDrag={onBeginDragFromContext}
+        onEndDrag={onEndDragFromContext}
+        onMomentumBegin={onMomentumEndFromContext}
+        onMomentumEnd={onMomentumEndFromContext}>
+        <List
+          ref={scrollElRef}
+          data={labelValues}
+          renderItem={renderItem}
+          keyExtractor={keyExtractor}
+          contentContainerStyle={a.px_xl}
+          headerOffset={headerHeight}
+          progressViewOffset={ios(0)}
+          ListHeaderComponent={
+            <LabelerListHeader
+              isLabelerLoading={isLabelerLoading}
+              labelerInfo={labelerInfo}
+              labelerError={labelerError}
+              hasValues={labelValues.length !== 0}
+              isSubscribed={isSubscribed}
+            />
+          }
+          ListFooterComponent={
+            <ListFooter
+              height={headerHeight + 180}
+              style={a.border_transparent}
+            />
+          }
+          animatedProps={animatedProps}
+        />
+      </ScrollProvider>
     </View>
   )
 }

--- a/src/screens/Profile/Sections/Labels.tsx
+++ b/src/screens/Profile/Sections/Labels.tsx
@@ -1,11 +1,6 @@
 import {useCallback, useEffect, useImperativeHandle, useMemo} from 'react'
 import {findNodeHandle, type ListRenderItemInfo, View} from 'react-native'
 import {
-  type ScrollHandler,
-  useAnimatedProps,
-  useSharedValue,
-} from 'react-native-reanimated'
-import {
   type AppBskyLabelerDefs,
   type InterpretedLabelValueDefinition,
   interpretLabelValueDefinitions,
@@ -16,9 +11,9 @@ import {useLingui} from '@lingui/react'
 import {Trans} from '@lingui/react/macro'
 
 import {isLabelerSubscribed, lookupLabelValueDefinition} from '#/lib/moderation'
-import {ScrollProvider, useScrollHandlers} from '#/lib/ScrollContext'
-import {useShellLayout} from '#/state/shell/shell-layout'
+import {ScrollProvider} from '#/lib/ScrollContext'
 import {List, type ListRef} from '#/view/com/util/List'
+import {useProfileScrollbarAdjustment} from '#/screens/Profile/useProfileScrollbarAdjustment'
 import {atoms as a, ios, tokens, useTheme} from '#/alf'
 import {Divider} from '#/components/Divider'
 import {CircleInfo_Stroke2_Corner0_Rounded as CircleInfo} from '#/components/icons/CircleInfo'
@@ -56,39 +51,6 @@ export function ProfileLabelsSection({
   setScrollViewTag,
 }: LabelsSectionProps) {
   const t = useTheme()
-
-  const {
-    onBeginDrag: onBeginDragFromContext,
-    onEndDrag: onEndDragFromContext,
-    onScroll: onScrollFromContext,
-    onMomentumEnd: onMomentumEndFromContext,
-  } = useScrollHandlers()
-
-  const scrollY = useSharedValue(0)
-  const onScrollWorklet = useCallback<ScrollHandler<any>>(
-    (e, ctx) => {
-      'worklet'
-      onScrollFromContext?.(e, ctx)
-      scrollY.set(e.contentOffset.y)
-    },
-    [onScrollFromContext, scrollY],
-  )
-
-  const {footerHeight} = useShellLayout()
-
-  const animatedProps = useAnimatedProps(() => {
-    if (IS_IOS) {
-      return {
-        scrollIndicatorInsets: {
-          top: Math.max(headerHeight - scrollY.get(), collapsedHeaderHeight),
-          right: 1,
-          left: 0,
-          bottom: footerHeight.get(),
-        },
-      }
-    }
-    return {}
-  })
 
   const onScrollToTop = useCallback(() => {
     scrollElRef.current?.scrollToOffset({
@@ -159,45 +121,40 @@ export function ProfileLabelsSection({
     [labelerInfo, isSubscribed, numItems, t],
   )
 
-  const list = (
-    <List
-      ref={scrollElRef}
-      data={labelValues}
-      renderItem={renderItem}
-      keyExtractor={keyExtractor}
-      contentContainerStyle={a.px_xl}
-      headerOffset={headerHeight}
-      progressViewOffset={ios(0)}
-      ListHeaderComponent={
-        <LabelerListHeader
-          isLabelerLoading={isLabelerLoading}
-          labelerInfo={labelerInfo}
-          labelerError={labelerError}
-          hasValues={labelValues.length !== 0}
-          isSubscribed={isSubscribed}
-        />
-      }
-      ListFooterComponent={
-        <ListFooter height={headerHeight + 180} style={a.border_transparent} />
-      }
-      animatedProps={IS_IOS ? animatedProps : undefined}
-    />
-  )
+  const {scrollHandlers, animatedProps} = useProfileScrollbarAdjustment({
+    headerOffset: headerHeight,
+    collapsedHeaderHeight,
+  })
 
   return (
     <View>
-      {IS_IOS ? (
-        <ScrollProvider
-          onScroll={onScrollWorklet}
-          onBeginDrag={onBeginDragFromContext}
-          onEndDrag={onEndDragFromContext}
-          onMomentumBegin={onMomentumEndFromContext}
-          onMomentumEnd={onMomentumEndFromContext}>
-          {list}
-        </ScrollProvider>
-      ) : (
-        list
-      )}
+      <ScrollProvider {...scrollHandlers}>
+        <List
+          ref={scrollElRef}
+          data={labelValues}
+          renderItem={renderItem}
+          keyExtractor={keyExtractor}
+          contentContainerStyle={a.px_xl}
+          headerOffset={headerHeight}
+          progressViewOffset={ios(0)}
+          ListHeaderComponent={
+            <LabelerListHeader
+              isLabelerLoading={isLabelerLoading}
+              labelerInfo={labelerInfo}
+              labelerError={labelerError}
+              hasValues={labelValues.length !== 0}
+              isSubscribed={isSubscribed}
+            />
+          }
+          ListFooterComponent={
+            <ListFooter
+              height={headerHeight + 180}
+              style={a.border_transparent}
+            />
+          }
+          animatedProps={animatedProps}
+        />
+      </ScrollProvider>
     </View>
   )
 }

--- a/src/screens/Profile/Sections/Labels.tsx
+++ b/src/screens/Profile/Sections/Labels.tsx
@@ -159,40 +159,45 @@ export function ProfileLabelsSection({
     [labelerInfo, isSubscribed, numItems, t],
   )
 
+  const list = (
+    <List
+      ref={scrollElRef}
+      data={labelValues}
+      renderItem={renderItem}
+      keyExtractor={keyExtractor}
+      contentContainerStyle={a.px_xl}
+      headerOffset={headerHeight}
+      progressViewOffset={ios(0)}
+      ListHeaderComponent={
+        <LabelerListHeader
+          isLabelerLoading={isLabelerLoading}
+          labelerInfo={labelerInfo}
+          labelerError={labelerError}
+          hasValues={labelValues.length !== 0}
+          isSubscribed={isSubscribed}
+        />
+      }
+      ListFooterComponent={
+        <ListFooter height={headerHeight + 180} style={a.border_transparent} />
+      }
+      animatedProps={IS_IOS ? animatedProps : undefined}
+    />
+  )
+
   return (
     <View>
-      <ScrollProvider
-        onScroll={onScrollWorklet}
-        onBeginDrag={onBeginDragFromContext}
-        onEndDrag={onEndDragFromContext}
-        onMomentumBegin={onMomentumEndFromContext}
-        onMomentumEnd={onMomentumEndFromContext}>
-        <List
-          ref={scrollElRef}
-          data={labelValues}
-          renderItem={renderItem}
-          keyExtractor={keyExtractor}
-          contentContainerStyle={a.px_xl}
-          headerOffset={headerHeight}
-          progressViewOffset={ios(0)}
-          ListHeaderComponent={
-            <LabelerListHeader
-              isLabelerLoading={isLabelerLoading}
-              labelerInfo={labelerInfo}
-              labelerError={labelerError}
-              hasValues={labelValues.length !== 0}
-              isSubscribed={isSubscribed}
-            />
-          }
-          ListFooterComponent={
-            <ListFooter
-              height={headerHeight + 180}
-              style={a.border_transparent}
-            />
-          }
-          animatedProps={animatedProps}
-        />
-      </ScrollProvider>
+      {IS_IOS ? (
+        <ScrollProvider
+          onScroll={onScrollWorklet}
+          onBeginDrag={onBeginDragFromContext}
+          onEndDrag={onEndDragFromContext}
+          onMomentumBegin={onMomentumEndFromContext}
+          onMomentumEnd={onMomentumEndFromContext}>
+          {list}
+        </ScrollProvider>
+      ) : (
+        list
+      )}
     </View>
   )
 }

--- a/src/screens/Profile/useProfileScrollbarAdjustment.ios.ts
+++ b/src/screens/Profile/useProfileScrollbarAdjustment.ios.ts
@@ -1,0 +1,81 @@
+import {useCallback, useMemo} from 'react'
+import {
+  type ScrollHandler,
+  useAnimatedProps,
+  useSharedValue,
+} from 'react-native-reanimated'
+
+import {useScrollHandlers} from '#/lib/ScrollContext'
+import {useShellLayout} from '#/state/shell/shell-layout'
+
+/**
+ * Adjusts the scroll indicator insets on iOS to account for the pager header.
+ * Adds another scroll offset listener, so use sparingly.
+ *
+ * HOW TO USE:
+ *
+ * ```tsx
+ * const { scrollHandlers, animatedProps } = useProfileScrollbarAdjustment({
+ *   headerHeight: 600, // full size of the header
+ *   collapsedHeaderHeight: 200, // height of the header when collapsed
+ * })
+ *
+ * return (
+ *   <ScrollContext {...scrollHandlers}>
+ *     <List animatedProps={animatedProps} />
+ *   </ScrollContext>
+ * )
+ * ````
+ */
+export function useProfileScrollbarAdjustment({
+  enabled = true,
+  headerOffset,
+  collapsedHeaderHeight,
+}: {
+  enabled?: boolean
+  headerOffset: number
+  collapsedHeaderHeight: number
+}) {
+  const {onScroll: onScrollFromContext, ...otherScrollHandlers} =
+    useScrollHandlers()
+
+  const scrollY = useSharedValue(0)
+  const onScroll = useCallback<ScrollHandler<any>>(
+    (e, ctx) => {
+      'worklet'
+      onScrollFromContext?.(e, ctx)
+      if (enabled) {
+        scrollY.set(e.contentOffset.y)
+      }
+    },
+    [onScrollFromContext, scrollY, enabled],
+  )
+
+  const {footerHeight} = useShellLayout()
+
+  const animatedProps = useAnimatedProps(() => {
+    return {
+      scrollIndicatorInsets: {
+        top: enabled
+          ? Math.max(headerOffset - scrollY.get(), collapsedHeaderHeight)
+          : headerOffset,
+        right: 1,
+        left: 0,
+        bottom: footerHeight.get(),
+      },
+    }
+  })
+
+  const scrollHandlers = useMemo(
+    () => ({
+      onScroll,
+      ...otherScrollHandlers,
+    }),
+    [onScroll, otherScrollHandlers],
+  )
+
+  return {
+    scrollHandlers,
+    animatedProps,
+  }
+}

--- a/src/screens/Profile/useProfileScrollbarAdjustment.ts
+++ b/src/screens/Profile/useProfileScrollbarAdjustment.ts
@@ -1,0 +1,50 @@
+import {useScrollHandlers} from '#/lib/ScrollContext'
+
+/**
+ * Adjusts the scroll indicator insets on iOS to account for the pager header. Adds another scroll offset
+ *
+ * HOW TO USE:
+ *
+ * ```tsx
+ * const { scrollHandlers, animatedProps } = useScrollbarAdjustment({
+ *   headerHeight: 600, // full size of the header
+ *   collapsedHeaderHeight: 200, // height of the header when collapsed
+ * })
+ *
+ * return (
+ *   <ScrollContext {...scrollHandlers}>
+ *     <List animatedProps={animatedProps} />
+ *   </ScrollContext>
+ * )
+ * ```
+ *
+ * @platform ios
+ */
+export function useProfileScrollbarAdjustment({}: {
+  enabled?: boolean
+  headerOffset: number
+  collapsedHeaderHeight: number
+}): {
+  scrollHandlers: ReturnType<typeof useScrollHandlers>
+  animatedProps:
+    | undefined
+    | Partial<{
+        scrollIndicatorInsets: {
+          top: number
+          right: number
+          left: number
+          bottom: number
+        }
+      }>
+} {
+  // this is a no-op version for android/web
+
+  const scrollHandlers = useScrollHandlers()
+
+  const animatedProps = undefined
+
+  return {
+    scrollHandlers,
+    animatedProps,
+  }
+}

--- a/src/view/com/feeds/ProfileFeedgens.tsx
+++ b/src/view/com/feeds/ProfileFeedgens.tsx
@@ -286,32 +286,40 @@ export function ProfileFeedgens({
     isEmpty,
   ])
 
+  const list = (
+    <List
+      testID={testID ? `${testID}-flatlist` : undefined}
+      ref={scrollElRef}
+      data={items}
+      keyExtractor={keyExtractor}
+      renderItem={renderItem}
+      ListFooterComponent={ProfileFeedgensFooter}
+      refreshing={isPTRing}
+      onRefresh={onRefresh}
+      headerOffset={headerOffset}
+      progressViewOffset={ios(0)}
+      removeClippedSubviews={true}
+      desktopFixedHeight
+      onEndReached={onEndReached}
+      contentContainerStyle={{minHeight: height + headerOffset}}
+      animatedProps={IS_IOS ? animatedProps : undefined}
+    />
+  )
+
   return (
     <View testID={testID} style={style}>
-      <ScrollProvider
-        onScroll={onScrollWorklet}
-        onBeginDrag={onBeginDragFromContext}
-        onEndDrag={onEndDragFromContext}
-        onMomentumBegin={onMomentumEndFromContext}
-        onMomentumEnd={onMomentumEndFromContext}>
-        <List
-          testID={testID ? `${testID}-flatlist` : undefined}
-          ref={scrollElRef}
-          data={items}
-          keyExtractor={keyExtractor}
-          renderItem={renderItem}
-          ListFooterComponent={ProfileFeedgensFooter}
-          refreshing={isPTRing}
-          onRefresh={onRefresh}
-          headerOffset={headerOffset}
-          progressViewOffset={ios(0)}
-          removeClippedSubviews={true}
-          desktopFixedHeight
-          onEndReached={onEndReached}
-          contentContainerStyle={{minHeight: height + headerOffset}}
-          animatedProps={animatedProps}
-        />
-      </ScrollProvider>
+      {IS_IOS ? (
+        <ScrollProvider
+          onScroll={onScrollWorklet}
+          onBeginDrag={onBeginDragFromContext}
+          onEndDrag={onEndDragFromContext}
+          onMomentumBegin={onMomentumEndFromContext}
+          onMomentumEnd={onMomentumEndFromContext}>
+          {list}
+        </ScrollProvider>
+      ) : (
+        list
+      )}
     </View>
   )
 }

--- a/src/view/com/feeds/ProfileFeedgens.tsx
+++ b/src/view/com/feeds/ProfileFeedgens.tsx
@@ -13,16 +13,23 @@ import {
   View,
   type ViewStyle,
 } from 'react-native'
+import {
+  type ScrollHandler,
+  useAnimatedProps,
+  useSharedValue,
+} from 'react-native-reanimated'
 import {msg} from '@lingui/core/macro'
 import {useLingui} from '@lingui/react'
 import {useNavigation} from '@react-navigation/native'
 import {useQueryClient} from '@tanstack/react-query'
 
+import {ScrollProvider, useScrollHandlers} from '#/lib/ScrollContext'
 import {cleanError} from '#/lib/strings/errors'
 import {logger} from '#/logger'
 import {usePreferencesQuery} from '#/state/queries/preferences'
 import {RQKEY, useProfileFeedgensQuery} from '#/state/queries/profile-feedgens'
 import {useSession} from '#/state/session'
+import {useShellLayout} from '#/state/shell/shell-layout'
 import {EmptyState} from '#/view/com/util/EmptyState'
 import {ErrorMessage} from '#/view/com/util/error/ErrorMessage'
 import {List, type ListRef} from '#/view/com/util/List'
@@ -48,6 +55,7 @@ interface ProfileFeedgensProps {
   did: string
   scrollElRef: ListRef
   headerOffset: number
+  collapsedHeaderHeight?: number
   enabled?: boolean
   style?: StyleProp<ViewStyle>
   testID?: string
@@ -59,6 +67,7 @@ export function ProfileFeedgens({
   did,
   scrollElRef,
   headerOffset,
+  collapsedHeaderHeight = 0,
   enabled,
   style,
   testID,
@@ -67,6 +76,39 @@ export function ProfileFeedgens({
   const {_} = useLingui()
   const t = useTheme()
   const [isPTRing, setIsPTRing] = useState(false)
+
+  const {
+    onBeginDrag: onBeginDragFromContext,
+    onEndDrag: onEndDragFromContext,
+    onScroll: onScrollFromContext,
+    onMomentumEnd: onMomentumEndFromContext,
+  } = useScrollHandlers()
+
+  const scrollY = useSharedValue(0)
+  const onScrollWorklet = useCallback<ScrollHandler<any>>(
+    (e, ctx) => {
+      'worklet'
+      onScrollFromContext?.(e, ctx)
+      scrollY.set(e.contentOffset.y)
+    },
+    [onScrollFromContext, scrollY],
+  )
+
+  const {footerHeight} = useShellLayout()
+
+  const animatedProps = useAnimatedProps(() => {
+    if (IS_IOS) {
+      return {
+        scrollIndicatorInsets: {
+          top: Math.max(headerOffset - scrollY.get(), collapsedHeaderHeight),
+          right: 1,
+          left: 0,
+          bottom: footerHeight.get(),
+        },
+      }
+    }
+    return {}
+  })
   const {height} = useWindowDimensions()
   const opts = useMemo(() => ({enabled}), [enabled])
   const {
@@ -246,22 +288,30 @@ export function ProfileFeedgens({
 
   return (
     <View testID={testID} style={style}>
-      <List
-        testID={testID ? `${testID}-flatlist` : undefined}
-        ref={scrollElRef}
-        data={items}
-        keyExtractor={keyExtractor}
-        renderItem={renderItem}
-        ListFooterComponent={ProfileFeedgensFooter}
-        refreshing={isPTRing}
-        onRefresh={onRefresh}
-        headerOffset={headerOffset}
-        progressViewOffset={ios(0)}
-        removeClippedSubviews={true}
-        desktopFixedHeight
-        onEndReached={onEndReached}
-        contentContainerStyle={{minHeight: height + headerOffset}}
-      />
+      <ScrollProvider
+        onScroll={onScrollWorklet}
+        onBeginDrag={onBeginDragFromContext}
+        onEndDrag={onEndDragFromContext}
+        onMomentumBegin={onMomentumEndFromContext}
+        onMomentumEnd={onMomentumEndFromContext}>
+        <List
+          testID={testID ? `${testID}-flatlist` : undefined}
+          ref={scrollElRef}
+          data={items}
+          keyExtractor={keyExtractor}
+          renderItem={renderItem}
+          ListFooterComponent={ProfileFeedgensFooter}
+          refreshing={isPTRing}
+          onRefresh={onRefresh}
+          headerOffset={headerOffset}
+          progressViewOffset={ios(0)}
+          removeClippedSubviews={true}
+          desktopFixedHeight
+          onEndReached={onEndReached}
+          contentContainerStyle={{minHeight: height + headerOffset}}
+          animatedProps={animatedProps}
+        />
+      </ScrollProvider>
     </View>
   )
 }

--- a/src/view/com/feeds/ProfileFeedgens.tsx
+++ b/src/view/com/feeds/ProfileFeedgens.tsx
@@ -13,28 +13,23 @@ import {
   View,
   type ViewStyle,
 } from 'react-native'
-import {
-  type ScrollHandler,
-  useAnimatedProps,
-  useSharedValue,
-} from 'react-native-reanimated'
 import {msg} from '@lingui/core/macro'
 import {useLingui} from '@lingui/react'
 import {useNavigation} from '@react-navigation/native'
 import {useQueryClient} from '@tanstack/react-query'
 
-import {ScrollProvider, useScrollHandlers} from '#/lib/ScrollContext'
+import {ScrollProvider} from '#/lib/ScrollContext'
 import {cleanError} from '#/lib/strings/errors'
 import {logger} from '#/logger'
 import {usePreferencesQuery} from '#/state/queries/preferences'
 import {RQKEY, useProfileFeedgensQuery} from '#/state/queries/profile-feedgens'
 import {useSession} from '#/state/session'
-import {useShellLayout} from '#/state/shell/shell-layout'
 import {EmptyState} from '#/view/com/util/EmptyState'
 import {ErrorMessage} from '#/view/com/util/error/ErrorMessage'
 import {List, type ListRef} from '#/view/com/util/List'
-import {FeedLoadingPlaceholder} from '#/view/com/util/LoadingPlaceholder'
+import {FeedFeedLoadingPlaceholder} from '#/view/com/util/LoadingPlaceholder'
 import {LoadMoreRetryBtn} from '#/view/com/util/LoadMoreRetryBtn'
+import {useProfileScrollbarAdjustment} from '#/screens/Profile/useProfileScrollbarAdjustment'
 import {atoms as a, ios, useTheme} from '#/alf'
 import * as FeedCard from '#/components/FeedCard'
 import {HashtagWide_Stroke1_Corner0_Rounded as HashtagWideIcon} from '#/components/icons/Hashtag'
@@ -77,38 +72,6 @@ export function ProfileFeedgens({
   const t = useTheme()
   const [isPTRing, setIsPTRing] = useState(false)
 
-  const {
-    onBeginDrag: onBeginDragFromContext,
-    onEndDrag: onEndDragFromContext,
-    onScroll: onScrollFromContext,
-    onMomentumEnd: onMomentumEndFromContext,
-  } = useScrollHandlers()
-
-  const scrollY = useSharedValue(0)
-  const onScrollWorklet = useCallback<ScrollHandler<any>>(
-    (e, ctx) => {
-      'worklet'
-      onScrollFromContext?.(e, ctx)
-      scrollY.set(e.contentOffset.y)
-    },
-    [onScrollFromContext, scrollY],
-  )
-
-  const {footerHeight} = useShellLayout()
-
-  const animatedProps = useAnimatedProps(() => {
-    if (IS_IOS) {
-      return {
-        scrollIndicatorInsets: {
-          top: Math.max(headerOffset - scrollY.get(), collapsedHeaderHeight),
-          right: 1,
-          left: 0,
-          bottom: footerHeight.get(),
-        },
-      }
-    }
-    return {}
-  })
   const {height} = useWindowDimensions()
   const opts = useMemo(() => ({enabled}), [enabled])
   const {
@@ -230,7 +193,7 @@ export function ProfileFeedgens({
           />
         )
       } else if (item === LOADING) {
-        return <FeedLoadingPlaceholder />
+        return <FeedFeedLoadingPlaceholder />
       }
       if (preferences) {
         return (
@@ -286,40 +249,32 @@ export function ProfileFeedgens({
     isEmpty,
   ])
 
-  const list = (
-    <List
-      testID={testID ? `${testID}-flatlist` : undefined}
-      ref={scrollElRef}
-      data={items}
-      keyExtractor={keyExtractor}
-      renderItem={renderItem}
-      ListFooterComponent={ProfileFeedgensFooter}
-      refreshing={isPTRing}
-      onRefresh={onRefresh}
-      headerOffset={headerOffset}
-      progressViewOffset={ios(0)}
-      removeClippedSubviews={true}
-      desktopFixedHeight
-      onEndReached={onEndReached}
-      contentContainerStyle={{minHeight: height + headerOffset}}
-      animatedProps={IS_IOS ? animatedProps : undefined}
-    />
-  )
+  const {scrollHandlers, animatedProps} = useProfileScrollbarAdjustment({
+    headerOffset,
+    collapsedHeaderHeight,
+  })
 
   return (
     <View testID={testID} style={style}>
-      {IS_IOS ? (
-        <ScrollProvider
-          onScroll={onScrollWorklet}
-          onBeginDrag={onBeginDragFromContext}
-          onEndDrag={onEndDragFromContext}
-          onMomentumBegin={onMomentumEndFromContext}
-          onMomentumEnd={onMomentumEndFromContext}>
-          {list}
-        </ScrollProvider>
-      ) : (
-        list
-      )}
+      <ScrollProvider {...scrollHandlers}>
+        <List
+          testID={testID ? `${testID}-flatlist` : undefined}
+          ref={scrollElRef}
+          data={items}
+          keyExtractor={keyExtractor}
+          renderItem={renderItem}
+          ListFooterComponent={ProfileFeedgensFooter}
+          refreshing={isPTRing}
+          onRefresh={onRefresh}
+          headerOffset={headerOffset}
+          progressViewOffset={ios(0)}
+          removeClippedSubviews={true}
+          desktopFixedHeight
+          onEndReached={onEndReached}
+          contentContainerStyle={{minHeight: height + headerOffset}}
+          animatedProps={animatedProps}
+        />
+      </ScrollProvider>
     </View>
   )
 }

--- a/src/view/com/lists/ProfileLists.tsx
+++ b/src/view/com/lists/ProfileLists.tsx
@@ -285,32 +285,40 @@ export function ProfileLists({
     isEmpty,
   ])
 
+  const list = (
+    <List
+      testID={testID ? `${testID}-flatlist` : undefined}
+      ref={scrollElRef}
+      data={items}
+      keyExtractor={keyExtractor}
+      renderItem={renderItem}
+      ListFooterComponent={ProfileListsFooter}
+      refreshing={isPTRing}
+      onRefresh={onRefresh}
+      headerOffset={headerOffset}
+      progressViewOffset={ios(0)}
+      removeClippedSubviews={true}
+      desktopFixedHeight
+      onEndReached={onEndReached}
+      contentContainerStyle={{minHeight: height + headerOffset}}
+      animatedProps={IS_IOS ? animatedProps : undefined}
+    />
+  )
+
   return (
     <View testID={testID} style={style}>
-      <ScrollProvider
-        onScroll={onScrollWorklet}
-        onBeginDrag={onBeginDragFromContext}
-        onEndDrag={onEndDragFromContext}
-        onMomentumBegin={onMomentumEndFromContext}
-        onMomentumEnd={onMomentumEndFromContext}>
-        <List
-          testID={testID ? `${testID}-flatlist` : undefined}
-          ref={scrollElRef}
-          data={items}
-          keyExtractor={keyExtractor}
-          renderItem={renderItem}
-          ListFooterComponent={ProfileListsFooter}
-          refreshing={isPTRing}
-          onRefresh={onRefresh}
-          headerOffset={headerOffset}
-          progressViewOffset={ios(0)}
-          removeClippedSubviews={true}
-          desktopFixedHeight
-          onEndReached={onEndReached}
-          contentContainerStyle={{minHeight: height + headerOffset}}
-          animatedProps={animatedProps}
-        />
-      </ScrollProvider>
+      {IS_IOS ? (
+        <ScrollProvider
+          onScroll={onScrollWorklet}
+          onBeginDrag={onBeginDragFromContext}
+          onEndDrag={onEndDragFromContext}
+          onMomentumBegin={onMomentumEndFromContext}
+          onMomentumEnd={onMomentumEndFromContext}>
+          {list}
+        </ScrollProvider>
+      ) : (
+        list
+      )}
     </View>
   )
 }

--- a/src/view/com/lists/ProfileLists.tsx
+++ b/src/view/com/lists/ProfileLists.tsx
@@ -13,28 +13,23 @@ import {
   View,
   type ViewStyle,
 } from 'react-native'
-import {
-  type ScrollHandler,
-  useAnimatedProps,
-  useSharedValue,
-} from 'react-native-reanimated'
 import {msg} from '@lingui/core/macro'
 import {useLingui} from '@lingui/react'
 import {useNavigation} from '@react-navigation/native'
 import {useQueryClient} from '@tanstack/react-query'
 
-import {ScrollProvider, useScrollHandlers} from '#/lib/ScrollContext'
+import {ScrollProvider} from '#/lib/ScrollContext'
 import {cleanError} from '#/lib/strings/errors'
 import {logger} from '#/logger'
 import {usePreferencesQuery} from '#/state/queries/preferences'
 import {RQKEY, useProfileListsQuery} from '#/state/queries/profile-lists'
 import {useSession} from '#/state/session'
-import {useShellLayout} from '#/state/shell/shell-layout'
 import {EmptyState} from '#/view/com/util/EmptyState'
 import {ErrorMessage} from '#/view/com/util/error/ErrorMessage'
 import {List, type ListRef} from '#/view/com/util/List'
-import {FeedLoadingPlaceholder} from '#/view/com/util/LoadingPlaceholder'
+import {FeedFeedLoadingPlaceholder} from '#/view/com/util/LoadingPlaceholder'
 import {LoadMoreRetryBtn} from '#/view/com/util/LoadMoreRetryBtn'
+import {useProfileScrollbarAdjustment} from '#/screens/Profile/useProfileScrollbarAdjustment'
 import {atoms as a, ios, useTheme} from '#/alf'
 import {BulletList_Stroke1_Corner0_Rounded as ListIcon} from '#/components/icons/BulletList'
 import * as ListCard from '#/components/ListCard'
@@ -77,38 +72,6 @@ export function ProfileLists({
   const t = useTheme()
   const [isPTRing, setIsPTRing] = useState(false)
 
-  const {
-    onBeginDrag: onBeginDragFromContext,
-    onEndDrag: onEndDragFromContext,
-    onScroll: onScrollFromContext,
-    onMomentumEnd: onMomentumEndFromContext,
-  } = useScrollHandlers()
-
-  const scrollY = useSharedValue(0)
-  const onScrollWorklet = useCallback<ScrollHandler<any>>(
-    (e, ctx) => {
-      'worklet'
-      onScrollFromContext?.(e, ctx)
-      scrollY.set(e.contentOffset.y)
-    },
-    [onScrollFromContext, scrollY],
-  )
-
-  const {footerHeight} = useShellLayout()
-
-  const animatedProps = useAnimatedProps(() => {
-    if (IS_IOS) {
-      return {
-        scrollIndicatorInsets: {
-          top: Math.max(headerOffset - scrollY.get(), collapsedHeaderHeight),
-          right: 1,
-          left: 0,
-          bottom: footerHeight.get(),
-        },
-      }
-    }
-    return {}
-  })
   const {height} = useWindowDimensions()
   const opts = useMemo(() => ({enabled}), [enabled])
   const {
@@ -229,7 +192,7 @@ export function ProfileLists({
           />
         )
       } else if (item === LOADING) {
-        return <FeedLoadingPlaceholder />
+        return <FeedFeedLoadingPlaceholder />
       }
       if (preferences) {
         return (
@@ -285,40 +248,32 @@ export function ProfileLists({
     isEmpty,
   ])
 
-  const list = (
-    <List
-      testID={testID ? `${testID}-flatlist` : undefined}
-      ref={scrollElRef}
-      data={items}
-      keyExtractor={keyExtractor}
-      renderItem={renderItem}
-      ListFooterComponent={ProfileListsFooter}
-      refreshing={isPTRing}
-      onRefresh={onRefresh}
-      headerOffset={headerOffset}
-      progressViewOffset={ios(0)}
-      removeClippedSubviews={true}
-      desktopFixedHeight
-      onEndReached={onEndReached}
-      contentContainerStyle={{minHeight: height + headerOffset}}
-      animatedProps={IS_IOS ? animatedProps : undefined}
-    />
-  )
+  const {scrollHandlers, animatedProps} = useProfileScrollbarAdjustment({
+    headerOffset,
+    collapsedHeaderHeight,
+  })
 
   return (
     <View testID={testID} style={style}>
-      {IS_IOS ? (
-        <ScrollProvider
-          onScroll={onScrollWorklet}
-          onBeginDrag={onBeginDragFromContext}
-          onEndDrag={onEndDragFromContext}
-          onMomentumBegin={onMomentumEndFromContext}
-          onMomentumEnd={onMomentumEndFromContext}>
-          {list}
-        </ScrollProvider>
-      ) : (
-        list
-      )}
+      <ScrollProvider {...scrollHandlers}>
+        <List
+          testID={testID ? `${testID}-flatlist` : undefined}
+          ref={scrollElRef}
+          data={items}
+          keyExtractor={keyExtractor}
+          renderItem={renderItem}
+          ListFooterComponent={ProfileListsFooter}
+          refreshing={isPTRing}
+          onRefresh={onRefresh}
+          headerOffset={headerOffset}
+          progressViewOffset={ios(0)}
+          removeClippedSubviews={true}
+          desktopFixedHeight
+          onEndReached={onEndReached}
+          contentContainerStyle={{minHeight: height + headerOffset}}
+          animatedProps={animatedProps}
+        />
+      </ScrollProvider>
     </View>
   )
 }

--- a/src/view/com/lists/ProfileLists.tsx
+++ b/src/view/com/lists/ProfileLists.tsx
@@ -13,16 +13,23 @@ import {
   View,
   type ViewStyle,
 } from 'react-native'
+import {
+  type ScrollHandler,
+  useAnimatedProps,
+  useSharedValue,
+} from 'react-native-reanimated'
 import {msg} from '@lingui/core/macro'
 import {useLingui} from '@lingui/react'
 import {useNavigation} from '@react-navigation/native'
 import {useQueryClient} from '@tanstack/react-query'
 
+import {ScrollProvider, useScrollHandlers} from '#/lib/ScrollContext'
 import {cleanError} from '#/lib/strings/errors'
 import {logger} from '#/logger'
 import {usePreferencesQuery} from '#/state/queries/preferences'
 import {RQKEY, useProfileListsQuery} from '#/state/queries/profile-lists'
 import {useSession} from '#/state/session'
+import {useShellLayout} from '#/state/shell/shell-layout'
 import {EmptyState} from '#/view/com/util/EmptyState'
 import {ErrorMessage} from '#/view/com/util/error/ErrorMessage'
 import {List, type ListRef} from '#/view/com/util/List'
@@ -48,6 +55,7 @@ interface ProfileListsProps {
   did: string
   scrollElRef: ListRef
   headerOffset: number
+  collapsedHeaderHeight?: number
   enabled?: boolean
   style?: StyleProp<ViewStyle>
   testID?: string
@@ -59,6 +67,7 @@ export function ProfileLists({
   did,
   scrollElRef,
   headerOffset,
+  collapsedHeaderHeight = 0,
   enabled,
   style,
   testID,
@@ -67,6 +76,39 @@ export function ProfileLists({
   const {_} = useLingui()
   const t = useTheme()
   const [isPTRing, setIsPTRing] = useState(false)
+
+  const {
+    onBeginDrag: onBeginDragFromContext,
+    onEndDrag: onEndDragFromContext,
+    onScroll: onScrollFromContext,
+    onMomentumEnd: onMomentumEndFromContext,
+  } = useScrollHandlers()
+
+  const scrollY = useSharedValue(0)
+  const onScrollWorklet = useCallback<ScrollHandler<any>>(
+    (e, ctx) => {
+      'worklet'
+      onScrollFromContext?.(e, ctx)
+      scrollY.set(e.contentOffset.y)
+    },
+    [onScrollFromContext, scrollY],
+  )
+
+  const {footerHeight} = useShellLayout()
+
+  const animatedProps = useAnimatedProps(() => {
+    if (IS_IOS) {
+      return {
+        scrollIndicatorInsets: {
+          top: Math.max(headerOffset - scrollY.get(), collapsedHeaderHeight),
+          right: 1,
+          left: 0,
+          bottom: footerHeight.get(),
+        },
+      }
+    }
+    return {}
+  })
   const {height} = useWindowDimensions()
   const opts = useMemo(() => ({enabled}), [enabled])
   const {
@@ -245,22 +287,30 @@ export function ProfileLists({
 
   return (
     <View testID={testID} style={style}>
-      <List
-        testID={testID ? `${testID}-flatlist` : undefined}
-        ref={scrollElRef}
-        data={items}
-        keyExtractor={keyExtractor}
-        renderItem={renderItem}
-        ListFooterComponent={ProfileListsFooter}
-        refreshing={isPTRing}
-        onRefresh={onRefresh}
-        headerOffset={headerOffset}
-        progressViewOffset={ios(0)}
-        removeClippedSubviews={true}
-        desktopFixedHeight
-        onEndReached={onEndReached}
-        contentContainerStyle={{minHeight: height + headerOffset}}
-      />
+      <ScrollProvider
+        onScroll={onScrollWorklet}
+        onBeginDrag={onBeginDragFromContext}
+        onEndDrag={onEndDragFromContext}
+        onMomentumBegin={onMomentumEndFromContext}
+        onMomentumEnd={onMomentumEndFromContext}>
+        <List
+          testID={testID ? `${testID}-flatlist` : undefined}
+          ref={scrollElRef}
+          data={items}
+          keyExtractor={keyExtractor}
+          renderItem={renderItem}
+          ListFooterComponent={ProfileListsFooter}
+          refreshing={isPTRing}
+          onRefresh={onRefresh}
+          headerOffset={headerOffset}
+          progressViewOffset={ios(0)}
+          removeClippedSubviews={true}
+          desktopFixedHeight
+          onEndReached={onEndReached}
+          contentContainerStyle={{minHeight: height + headerOffset}}
+          animatedProps={animatedProps}
+        />
+      </ScrollProvider>
     </View>
   )
 }

--- a/src/view/com/pager/PagerWithHeader.tsx
+++ b/src/view/com/pager/PagerWithHeader.tsx
@@ -30,8 +30,9 @@ import {TabBar} from './TabBar'
 
 export interface PagerWithHeaderChildParams {
   headerHeight: number
+  collapsedHeaderHeight: number
   isFocused: boolean
-  scrollElRef: React.MutableRefObject<ListMethods | ScrollView | null>
+  scrollElRef: React.RefObject<ListMethods | ScrollView | null>
 }
 
 export interface PagerWithHeaderProps {
@@ -67,6 +68,7 @@ export function PagerWithHeader({
   const [currentPage, setCurrentPage] = useState(0)
   const [tabBarHeight, setTabBarHeight] = useState(0)
   const [headerOnlyHeight, setHeaderOnlyHeight] = useState(0)
+  const [minimumHeaderHeight, setMinimumHeaderHeight] = useState(0)
   const scrollY = useSharedValue(0)
   const headerHeight = headerOnlyHeight + tabBarHeight
 
@@ -91,6 +93,8 @@ export function PagerWithHeader({
         <PagerHeaderProvider scrollY={scrollY} headerHeight={headerOnlyHeight}>
           <PagerTabBar
             headerOnlyHeight={headerOnlyHeight}
+            minimumHeaderHeight={minimumHeaderHeight}
+            setMinimumHeaderHeight={setMinimumHeaderHeight}
             items={items}
             isHeaderReady={isHeaderReady}
             renderHeader={renderHeader}
@@ -110,6 +114,8 @@ export function PagerWithHeader({
     },
     [
       headerOnlyHeight,
+      minimumHeaderHeight,
+      setMinimumHeaderHeight,
       items,
       isHeaderReady,
       renderHeader,
@@ -202,6 +208,7 @@ export function PagerWithHeader({
             <View key={i} collapsable={false}>
               <PagerItem
                 headerHeight={headerHeight}
+                collapsedHeaderHeight={minimumHeaderHeight + tabBarHeight}
                 index={i}
                 isReady={isReady}
                 isFocused={i === currentPage}
@@ -219,6 +226,8 @@ export function PagerWithHeader({
 let PagerTabBar = ({
   currentPage,
   headerOnlyHeight,
+  minimumHeaderHeight,
+  setMinimumHeaderHeight,
   isHeaderReady,
   items,
   scrollY,
@@ -234,6 +243,8 @@ let PagerTabBar = ({
 }: {
   currentPage: number
   headerOnlyHeight: number
+  minimumHeaderHeight: number
+  setMinimumHeaderHeight: (height: number) => void
   isHeaderReady: boolean
   items: string[]
   testID?: string
@@ -252,7 +263,6 @@ let PagerTabBar = ({
   dragState: SharedValue<'idle' | 'dragging' | 'settling'>
 }): React.ReactNode => {
   const t = useTheme()
-  const [minimumHeaderHeight, setMinimumHeaderHeight] = useState(0)
   const headerTransform = useAnimatedStyle(() => {
     const translateY =
       Math.min(
@@ -344,6 +354,7 @@ PagerTabBar = memo(PagerTabBar)
 
 function PagerItem({
   headerHeight,
+  collapsedHeaderHeight,
   index,
   isReady,
   isFocused,
@@ -352,6 +363,7 @@ function PagerItem({
   registerRef,
 }: {
   headerHeight: number
+  collapsedHeaderHeight: number
   index: number
   isFocused: boolean
   isReady: boolean
@@ -376,6 +388,7 @@ function PagerItem({
     <ScrollProvider onScroll={onScrollWorklet}>
       {renderTab({
         headerHeight,
+        collapsedHeaderHeight,
         isFocused,
         scrollElRef: scrollElRef as React.MutableRefObject<
           ListMethods | ScrollView | null

--- a/src/view/com/pager/PagerWithHeader.web.tsx
+++ b/src/view/com/pager/PagerWithHeader.web.tsx
@@ -15,6 +15,7 @@ import {TabBar} from './TabBar'
 
 export interface PagerWithHeaderChildParams {
   headerHeight: number
+  collapsedHeaderHeight: number
   isFocused: boolean
   scrollElRef: React.MutableRefObject<ListMethods | ScrollView | null>
 }
@@ -177,6 +178,7 @@ function PagerItem({
   }
   return renderTab({
     headerHeight: 0,
+    collapsedHeaderHeight: 0,
     isFocused,
     scrollElRef: scrollElRef as React.MutableRefObject<
       ListMethods | ScrollView | null

--- a/src/view/com/posts/PostFeed.tsx
+++ b/src/view/com/posts/PostFeed.tsx
@@ -11,11 +11,6 @@ import {
   type ViewStyle,
 } from 'react-native'
 import {
-  type ScrollHandler,
-  useAnimatedProps,
-  useSharedValue,
-} from 'react-native-reanimated'
-import {
   type AppBskyActorDefs,
   AppBskyEmbedVideo,
   type AppBskyFeedDefs,
@@ -26,7 +21,7 @@ import {useQueryClient} from '@tanstack/react-query'
 import {DISCOVER_FEED_URI, KNOWN_SHUTDOWN_FEEDS} from '#/lib/constants'
 import {useInitialNumToRender} from '#/lib/hooks/useInitialNumToRender'
 import {useNonReactiveCallback} from '#/lib/hooks/useNonReactiveCallback'
-import {ScrollProvider, useScrollHandlers} from '#/lib/ScrollContext'
+import {ScrollProvider} from '#/lib/ScrollContext'
 import {isNetworkError} from '#/lib/strings/errors'
 import {logger} from '#/logger'
 import {usePostAuthorShadowFilter} from '#/state/cache/profile-shadow'
@@ -48,10 +43,10 @@ import {truncateAndInvalidate} from '#/state/queries/util'
 import {useSession} from '#/state/session'
 import {useProgressGuide} from '#/state/shell/progress-guide'
 import {useSelectedFeed} from '#/state/shell/selected-feed'
-import {useShellLayout} from '#/state/shell/shell-layout'
 import {List, type ListRef} from '#/view/com/util/List'
 import {PostFeedLoadingPlaceholder} from '#/view/com/util/LoadingPlaceholder'
 import {LoadMoreRetryBtn} from '#/view/com/util/LoadMoreRetryBtn'
+import {useProfileScrollbarAdjustment} from '#/screens/Profile/useProfileScrollbarAdjustment'
 import {type VideoFeedSourceContext} from '#/screens/VideoFeed/types'
 import {useBreakpoints, useLayoutBreakpoints} from '#/alf'
 import {
@@ -211,7 +206,7 @@ let PostFeed = ({
   savedFeedConfig,
   initialNumToRender: initialNumToRenderOverride,
   isVideoFeed = false,
-  adjustScrollIndicators,
+  adjustScrollIndicators = false,
   collapsedHeaderHeight = 0,
 }: {
   feed: FeedDescriptor
@@ -1010,88 +1005,46 @@ let PostFeed = ({
     [feedFeedback, feed, liveNowConfig, getPostPosition, ax],
   )
 
-  const {
-    onBeginDrag: onBeginDragFromContext,
-    onEndDrag: onEndDragFromContext,
-    onScroll: onScrollFromContext,
-    onMomentumEnd: onMomentumEndFromContext,
-  } = useScrollHandlers()
-
-  const scrollY = useSharedValue(0)
-  const onScrollWorklet = useCallback<ScrollHandler<any>>(
-    (e, ctx) => {
-      'worklet'
-      onScrollFromContext?.(e, ctx)
-      scrollY.set(e.contentOffset.y)
-    },
-    [onScrollFromContext, scrollY],
-  )
-
-  const {footerHeight} = useShellLayout()
-
-  const animatedProps = useAnimatedProps(() => {
-    if (IS_IOS) {
-      return {
-        scrollIndicatorInsets: {
-          top: adjustScrollIndicators
-            ? Math.max(headerOffset - scrollY.get(), collapsedHeaderHeight)
-            : headerOffset,
-          right: 1,
-          left: 0,
-          bottom: footerHeight.get(),
-        },
-      }
-    }
-    return {}
+  const {scrollHandlers, animatedProps} = useProfileScrollbarAdjustment({
+    enabled: adjustScrollIndicators,
+    headerOffset,
+    collapsedHeaderHeight,
   })
-
-  const list = (
-    <List
-      testID={testID ? `${testID}-flatlist` : undefined}
-      ref={scrollElRef}
-      data={feedItems}
-      keyExtractor={(item: FeedRow) => item.key}
-      renderItem={renderItem}
-      ListFooterComponent={FeedFooter}
-      ListHeaderComponent={ListHeaderComponent}
-      refreshing={isPTRing}
-      onRefresh={() => void onRefresh()}
-      headerOffset={headerOffset}
-      progressViewOffset={progressViewOffset}
-      contentContainerStyle={{
-        minHeight: Dimensions.get('window').height * 1.5,
-      }}
-      onScrolledDownChange={handleScrolledDownChange}
-      onEndReached={() => void onEndReached()}
-      onEndReachedThreshold={2} // number of posts left to trigger load more
-      removeClippedSubviews={true}
-      extraData={extraData}
-      desktopFixedHeight={
-        desktopFixedHeightOffset ? desktopFixedHeightOffset : true
-      }
-      initialNumToRender={initialNumToRenderOverride ?? initialNumToRender}
-      windowSize={9}
-      maxToRenderPerBatch={IS_IOS ? 5 : 1}
-      updateCellsBatchingPeriod={40}
-      onItemSeen={onItemSeen}
-      animatedProps={IS_IOS ? animatedProps : undefined}
-    />
-  )
 
   return (
     <View testID={testID} style={style}>
-      {IS_IOS ? (
-        <ScrollProvider
-          onScroll={onScrollWorklet}
-          onBeginDrag={onBeginDragFromContext}
-          onEndDrag={onEndDragFromContext}
-          onMomentumBegin={onMomentumEndFromContext}
-          onMomentumEnd={onMomentumEndFromContext}>
-          {list}
-        </ScrollProvider>
-      ) : (
-        list
-      )}
+      <ScrollProvider {...scrollHandlers}>
+        <List
+          testID={testID ? `${testID}-flatlist` : undefined}
+          ref={scrollElRef}
+          data={feedItems}
+          keyExtractor={(item: FeedRow) => item.key}
+          renderItem={renderItem}
+          ListFooterComponent={FeedFooter}
+          ListHeaderComponent={ListHeaderComponent}
+          refreshing={isPTRing}
+          onRefresh={() => void onRefresh()}
+          headerOffset={headerOffset}
+          progressViewOffset={progressViewOffset}
+          contentContainerStyle={{
+            minHeight: Dimensions.get('window').height * 1.5,
+          }}
+          onScrolledDownChange={handleScrolledDownChange}
+          onEndReached={() => void onEndReached()}
+          onEndReachedThreshold={2} // number of posts left to trigger load more
+          removeClippedSubviews={true}
+          extraData={extraData}
+          desktopFixedHeight={
+            desktopFixedHeightOffset ? desktopFixedHeightOffset : true
+          }
+          initialNumToRender={initialNumToRenderOverride ?? initialNumToRender}
+          windowSize={9}
+          maxToRenderPerBatch={IS_IOS ? 5 : 1}
+          updateCellsBatchingPeriod={40}
+          onItemSeen={onItemSeen}
+          animatedProps={animatedProps}
+        />
+      </ScrollProvider>
     </View>
   )
 }

--- a/src/view/com/posts/PostFeed.tsx
+++ b/src/view/com/posts/PostFeed.tsx
@@ -1045,45 +1045,53 @@ let PostFeed = ({
     return {}
   })
 
+  const list = (
+    <List
+      testID={testID ? `${testID}-flatlist` : undefined}
+      ref={scrollElRef}
+      data={feedItems}
+      keyExtractor={(item: FeedRow) => item.key}
+      renderItem={renderItem}
+      ListFooterComponent={FeedFooter}
+      ListHeaderComponent={ListHeaderComponent}
+      refreshing={isPTRing}
+      onRefresh={() => void onRefresh()}
+      headerOffset={headerOffset}
+      progressViewOffset={progressViewOffset}
+      contentContainerStyle={{
+        minHeight: Dimensions.get('window').height * 1.5,
+      }}
+      onScrolledDownChange={handleScrolledDownChange}
+      onEndReached={() => void onEndReached()}
+      onEndReachedThreshold={2} // number of posts left to trigger load more
+      removeClippedSubviews={true}
+      extraData={extraData}
+      desktopFixedHeight={
+        desktopFixedHeightOffset ? desktopFixedHeightOffset : true
+      }
+      initialNumToRender={initialNumToRenderOverride ?? initialNumToRender}
+      windowSize={9}
+      maxToRenderPerBatch={IS_IOS ? 5 : 1}
+      updateCellsBatchingPeriod={40}
+      onItemSeen={onItemSeen}
+      animatedProps={IS_IOS ? animatedProps : undefined}
+    />
+  )
+
   return (
     <View testID={testID} style={style}>
-      <ScrollProvider
-        onScroll={onScrollWorklet}
-        onBeginDrag={onBeginDragFromContext}
-        onEndDrag={onEndDragFromContext}
-        onMomentumBegin={onMomentumEndFromContext}
-        onMomentumEnd={onMomentumEndFromContext}>
-        <List
-          testID={testID ? `${testID}-flatlist` : undefined}
-          ref={scrollElRef}
-          data={feedItems}
-          keyExtractor={(item: FeedRow) => item.key}
-          renderItem={renderItem}
-          ListFooterComponent={FeedFooter}
-          ListHeaderComponent={ListHeaderComponent}
-          refreshing={isPTRing}
-          onRefresh={() => void onRefresh()}
-          headerOffset={headerOffset}
-          progressViewOffset={progressViewOffset}
-          contentContainerStyle={{
-            minHeight: Dimensions.get('window').height * 1.5,
-          }}
-          onScrolledDownChange={handleScrolledDownChange}
-          onEndReached={() => void onEndReached()}
-          onEndReachedThreshold={2} // number of posts left to trigger load more
-          removeClippedSubviews={true}
-          extraData={extraData}
-          desktopFixedHeight={
-            desktopFixedHeightOffset ? desktopFixedHeightOffset : true
-          }
-          initialNumToRender={initialNumToRenderOverride ?? initialNumToRender}
-          windowSize={9}
-          maxToRenderPerBatch={IS_IOS ? 5 : 1}
-          updateCellsBatchingPeriod={40}
-          onItemSeen={onItemSeen}
-          animatedProps={animatedProps}
-        />
-      </ScrollProvider>
+      {IS_IOS ? (
+        <ScrollProvider
+          onScroll={onScrollWorklet}
+          onBeginDrag={onBeginDragFromContext}
+          onEndDrag={onEndDragFromContext}
+          onMomentumBegin={onMomentumEndFromContext}
+          onMomentumEnd={onMomentumEndFromContext}>
+          {list}
+        </ScrollProvider>
+      ) : (
+        list
+      )}
     </View>
   )
 }

--- a/src/view/com/posts/PostFeed.tsx
+++ b/src/view/com/posts/PostFeed.tsx
@@ -11,6 +11,11 @@ import {
   type ViewStyle,
 } from 'react-native'
 import {
+  type ScrollHandler,
+  useAnimatedProps,
+  useSharedValue,
+} from 'react-native-reanimated'
+import {
   type AppBskyActorDefs,
   AppBskyEmbedVideo,
   type AppBskyFeedDefs,
@@ -21,6 +26,7 @@ import {useQueryClient} from '@tanstack/react-query'
 import {DISCOVER_FEED_URI, KNOWN_SHUTDOWN_FEEDS} from '#/lib/constants'
 import {useInitialNumToRender} from '#/lib/hooks/useInitialNumToRender'
 import {useNonReactiveCallback} from '#/lib/hooks/useNonReactiveCallback'
+import {ScrollProvider, useScrollHandlers} from '#/lib/ScrollContext'
 import {isNetworkError} from '#/lib/strings/errors'
 import {logger} from '#/logger'
 import {usePostAuthorShadowFilter} from '#/state/cache/profile-shadow'
@@ -42,6 +48,7 @@ import {truncateAndInvalidate} from '#/state/queries/util'
 import {useSession} from '#/state/session'
 import {useProgressGuide} from '#/state/shell/progress-guide'
 import {useSelectedFeed} from '#/state/shell/selected-feed'
+import {useShellLayout} from '#/state/shell/shell-layout'
 import {List, type ListRef} from '#/view/com/util/List'
 import {PostFeedLoadingPlaceholder} from '#/view/com/util/LoadingPlaceholder'
 import {LoadMoreRetryBtn} from '#/view/com/util/LoadMoreRetryBtn'
@@ -204,6 +211,8 @@ let PostFeed = ({
   savedFeedConfig,
   initialNumToRender: initialNumToRenderOverride,
   isVideoFeed = false,
+  adjustScrollIndicators,
+  collapsedHeaderHeight = 0,
 }: {
   feed: FeedDescriptor
   feedParams?: FeedParams
@@ -227,6 +236,8 @@ let PostFeed = ({
   initialNumToRender?: number
   isVideoFeed?: boolean
   lastFetchDate?: () => number
+  adjustScrollIndicators?: boolean
+  collapsedHeaderHeight?: number
 }): React.ReactNode => {
   const ax = useAnalytics()
   const {t: l} = useLingui()
@@ -999,37 +1010,80 @@ let PostFeed = ({
     [feedFeedback, feed, liveNowConfig, getPostPosition, ax],
   )
 
+  const {
+    onBeginDrag: onBeginDragFromContext,
+    onEndDrag: onEndDragFromContext,
+    onScroll: onScrollFromContext,
+    onMomentumEnd: onMomentumEndFromContext,
+  } = useScrollHandlers()
+
+  const scrollY = useSharedValue(0)
+  const onScrollWorklet = useCallback<ScrollHandler<any>>(
+    (e, ctx) => {
+      'worklet'
+      onScrollFromContext?.(e, ctx)
+      scrollY.set(e.contentOffset.y)
+    },
+    [onScrollFromContext, scrollY],
+  )
+
+  const {footerHeight} = useShellLayout()
+
+  const animatedProps = useAnimatedProps(() => {
+    if (IS_IOS) {
+      return {
+        scrollIndicatorInsets: {
+          top: adjustScrollIndicators
+            ? Math.max(headerOffset - scrollY.get(), collapsedHeaderHeight)
+            : headerOffset,
+          right: 1,
+          left: 0,
+          bottom: footerHeight.get(),
+        },
+      }
+    }
+    return {}
+  })
+
   return (
     <View testID={testID} style={style}>
-      <List
-        testID={testID ? `${testID}-flatlist` : undefined}
-        ref={scrollElRef}
-        data={feedItems}
-        keyExtractor={(item: FeedRow) => item.key}
-        renderItem={renderItem}
-        ListFooterComponent={FeedFooter}
-        ListHeaderComponent={ListHeaderComponent}
-        refreshing={isPTRing}
-        onRefresh={() => void onRefresh()}
-        headerOffset={headerOffset}
-        progressViewOffset={progressViewOffset}
-        contentContainerStyle={{
-          minHeight: Dimensions.get('window').height * 1.5,
-        }}
-        onScrolledDownChange={handleScrolledDownChange}
-        onEndReached={() => void onEndReached()}
-        onEndReachedThreshold={2} // number of posts left to trigger load more
-        removeClippedSubviews={true}
-        extraData={extraData}
-        desktopFixedHeight={
-          desktopFixedHeightOffset ? desktopFixedHeightOffset : true
-        }
-        initialNumToRender={initialNumToRenderOverride ?? initialNumToRender}
-        windowSize={9}
-        maxToRenderPerBatch={IS_IOS ? 5 : 1}
-        updateCellsBatchingPeriod={40}
-        onItemSeen={onItemSeen}
-      />
+      <ScrollProvider
+        onScroll={onScrollWorklet}
+        onBeginDrag={onBeginDragFromContext}
+        onEndDrag={onEndDragFromContext}
+        onMomentumBegin={onMomentumEndFromContext}
+        onMomentumEnd={onMomentumEndFromContext}>
+        <List
+          testID={testID ? `${testID}-flatlist` : undefined}
+          ref={scrollElRef}
+          data={feedItems}
+          keyExtractor={(item: FeedRow) => item.key}
+          renderItem={renderItem}
+          ListFooterComponent={FeedFooter}
+          ListHeaderComponent={ListHeaderComponent}
+          refreshing={isPTRing}
+          onRefresh={() => void onRefresh()}
+          headerOffset={headerOffset}
+          progressViewOffset={progressViewOffset}
+          contentContainerStyle={{
+            minHeight: Dimensions.get('window').height * 1.5,
+          }}
+          onScrolledDownChange={handleScrolledDownChange}
+          onEndReached={() => void onEndReached()}
+          onEndReachedThreshold={2} // number of posts left to trigger load more
+          removeClippedSubviews={true}
+          extraData={extraData}
+          desktopFixedHeight={
+            desktopFixedHeightOffset ? desktopFixedHeightOffset : true
+          }
+          initialNumToRender={initialNumToRenderOverride ?? initialNumToRender}
+          windowSize={9}
+          maxToRenderPerBatch={IS_IOS ? 5 : 1}
+          updateCellsBatchingPeriod={40}
+          onItemSeen={onItemSeen}
+          animatedProps={animatedProps}
+        />
+      </ScrollProvider>
     </View>
   )
 }

--- a/src/view/screens/Profile.tsx
+++ b/src/view/screens/Profile.tsx
@@ -420,11 +420,12 @@ function ProfileScreenLoaded({
             )
           : null}
         {showPostsTab
-          ? ({headerHeight, isFocused, scrollElRef}) => (
+          ? ({headerHeight, collapsedHeaderHeight, isFocused, scrollElRef}) => (
               <ProfileFeedSection
                 ref={postsSectionRef}
                 feed={`author|${profile.did}|posts_and_author_threads`}
                 headerHeight={headerHeight}
+                collapsedHeaderHeight={collapsedHeaderHeight}
                 isFocused={isFocused}
                 scrollElRef={scrollElRef as ListRef}
                 ignoreFilterFor={profile.did}
@@ -446,11 +447,12 @@ function ProfileScreenLoaded({
             )
           : null}
         {showRepliesTab
-          ? ({headerHeight, isFocused, scrollElRef}) => (
+          ? ({headerHeight, collapsedHeaderHeight, isFocused, scrollElRef}) => (
               <ProfileFeedSection
                 ref={repliesSectionRef}
                 feed={`author|${profile.did}|posts_with_replies`}
                 headerHeight={headerHeight}
+                collapsedHeaderHeight={collapsedHeaderHeight}
                 isFocused={isFocused}
                 scrollElRef={scrollElRef as ListRef}
                 ignoreFilterFor={profile.did}
@@ -461,11 +463,12 @@ function ProfileScreenLoaded({
             )
           : null}
         {showMediaTab
-          ? ({headerHeight, isFocused, scrollElRef}) => (
+          ? ({headerHeight, collapsedHeaderHeight, isFocused, scrollElRef}) => (
               <ProfileFeedSection
                 ref={mediaSectionRef}
                 feed={`author|${profile.did}|posts_with_media`}
                 headerHeight={headerHeight}
+                collapsedHeaderHeight={collapsedHeaderHeight}
                 isFocused={isFocused}
                 scrollElRef={scrollElRef as ListRef}
                 ignoreFilterFor={profile.did}
@@ -488,11 +491,12 @@ function ProfileScreenLoaded({
             )
           : null}
         {showVideosTab
-          ? ({headerHeight, isFocused, scrollElRef}) => (
+          ? ({headerHeight, collapsedHeaderHeight, isFocused, scrollElRef}) => (
               <ProfileFeedSection
                 ref={videosSectionRef}
                 feed={`author|${profile.did}|posts_with_video`}
                 headerHeight={headerHeight}
+                collapsedHeaderHeight={collapsedHeaderHeight}
                 isFocused={isFocused}
                 scrollElRef={scrollElRef as ListRef}
                 ignoreFilterFor={profile.did}
@@ -515,11 +519,12 @@ function ProfileScreenLoaded({
             )
           : null}
         {showLikesTab
-          ? ({headerHeight, isFocused, scrollElRef}) => (
+          ? ({headerHeight, collapsedHeaderHeight, isFocused, scrollElRef}) => (
               <ProfileFeedSection
                 ref={likesSectionRef}
                 feed={`likes|${profile.did}`}
                 headerHeight={headerHeight}
+                collapsedHeaderHeight={collapsedHeaderHeight}
                 isFocused={isFocused}
                 scrollElRef={scrollElRef as ListRef}
                 ignoreFilterFor={profile.did}

--- a/src/view/screens/Profile.tsx
+++ b/src/view/screens/Profile.tsx
@@ -393,7 +393,7 @@ function ProfileScreenLoaded({
         renderHeader={renderHeader}
         allowHeaderOverScroll>
         {showFiltersTab
-          ? ({headerHeight, isFocused, scrollElRef}) => (
+          ? ({headerHeight, collapsedHeaderHeight, isFocused, scrollElRef}) => (
               <ProfileLabelsSection
                 ref={labelsSectionRef}
                 labelerInfo={labelerInfo}
@@ -402,18 +402,20 @@ function ProfileScreenLoaded({
                 moderationOpts={moderationOpts}
                 scrollElRef={scrollElRef as ListRef}
                 headerHeight={headerHeight}
+                collapsedHeaderHeight={collapsedHeaderHeight}
                 isFocused={isFocused}
                 setScrollViewTag={setScrollViewTag}
               />
             )
           : null}
         {showListsTab && !!profile.associated?.labeler
-          ? ({headerHeight, isFocused, scrollElRef}) => (
+          ? ({headerHeight, collapsedHeaderHeight, isFocused, scrollElRef}) => (
               <ProfileLists
                 ref={listsSectionRef}
                 did={profile.did}
                 scrollElRef={scrollElRef as ListRef}
                 headerOffset={headerHeight}
+                collapsedHeaderHeight={collapsedHeaderHeight}
                 enabled={isFocused}
                 setScrollViewTag={setScrollViewTag}
               />
@@ -535,25 +537,27 @@ function ProfileScreenLoaded({
             )
           : null}
         {showFeedsTab
-          ? ({headerHeight, isFocused, scrollElRef}) => (
+          ? ({headerHeight, collapsedHeaderHeight, isFocused, scrollElRef}) => (
               <ProfileFeedgens
                 ref={feedsSectionRef}
                 did={profile.did}
                 scrollElRef={scrollElRef as ListRef}
                 headerOffset={headerHeight}
+                collapsedHeaderHeight={collapsedHeaderHeight}
                 enabled={isFocused}
                 setScrollViewTag={setScrollViewTag}
               />
             )
           : null}
         {showStarterPacksTab
-          ? ({headerHeight, isFocused, scrollElRef}) => (
+          ? ({headerHeight, collapsedHeaderHeight, isFocused, scrollElRef}) => (
               <ProfileStarterPacks
                 ref={starterPacksSectionRef}
                 did={profile.did}
                 isMe={isMe}
                 scrollElRef={scrollElRef as ListRef}
                 headerOffset={headerHeight}
+                collapsedHeaderHeight={collapsedHeaderHeight}
                 enabled={isFocused}
                 setScrollViewTag={setScrollViewTag}
                 emptyStateMessage={
@@ -579,12 +583,13 @@ function ProfileScreenLoaded({
             )
           : null}
         {showListsTab && !profile.associated?.labeler
-          ? ({headerHeight, isFocused, scrollElRef}) => (
+          ? ({headerHeight, collapsedHeaderHeight, isFocused, scrollElRef}) => (
               <ProfileLists
                 ref={listsSectionRef}
                 did={profile.did}
                 scrollElRef={scrollElRef as ListRef}
                 headerOffset={headerHeight}
+                collapsedHeaderHeight={collapsedHeaderHeight}
                 enabled={isFocused}
                 setScrollViewTag={setScrollViewTag}
               />


### PR DESCRIPTION
Fixes https://bsky.app/profile/logic-denier.hellbhoy.net/post/3meyb4hu3jc25

## Summary
- Hoists `minimumHeaderHeight` from `PagerTabBar` to `PagerWithHeader` and exposes it as `collapsedHeaderHeight` (minimumHeaderHeight + tabBarHeight) through child params
- Adds animated iOS scroll indicator insets to `PostFeed` that track the collapsing header, gated behind an `adjustScrollIndicators` prop so it only activates on profile pages
- Applies the same pattern to Labels, Lists, Feeds, and Starter Packs profile tabs

### Before

See the big old gap when I scroll, and also that it goes behind the profile when I drag down

https://github.com/user-attachments/assets/587e5d0d-7042-4133-ba0f-8814897658a1

### After

https://github.com/user-attachments/assets/f6b4f240-11e3-468d-8662-5f1481862da6

## Test plan
- [ ] Open a profile on iOS, scroll down — scroll indicator should start below the full header and track down to the collapsed header height
- [ ] Verify the scroll indicator clamps at the collapsed header (minimal header + tab bar) and doesn't go above it
- [ ] Verify non-profile feeds (Following, Discover) are unaffected — static scroll indicator positioning
- [ ] Verify web is unaffected (collapsedHeaderHeight defaults to 0)
- [ ] Test on all profile tabs: Posts, Replies, Media, Videos, Likes, Feeds, Lists, Starter Packs, Labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)