### PR TITLE
Clear link and gif caches to avoid pointing at missing files

### DIFF
--- a/src/state/queries/resolve-link.ts
+++ b/src/state/queries/resolve-link.ts
@@ -6,10 +6,10 @@ import {STALE} from '#/state/queries/index'
 import {useAgent} from '#/state/session'
 import {type Gif} from './tenor'
 
-const RQKEY_LINK_ROOT = 'resolve-link'
+export const RQKEY_LINK_ROOT = 'resolve-link'
 export const RQKEY_LINK = (url: string) => [RQKEY_LINK_ROOT, url]
 
-const RQKEY_GIF_ROOT = 'resolve-gif'
+export const RQKEY_GIF_ROOT = 'resolve-gif'
 export const RQKEY_GIF = (url: string) => [RQKEY_GIF_ROOT, url]
 
 export function useResolveLinkQuery(url: string) {

--- a/src/state/shell/composer/index.tsx
+++ b/src/state/shell/composer/index.tsx
@@ -12,7 +12,11 @@ import {useQueryClient} from '@tanstack/react-query'
 import {useNonReactiveCallback} from '#/lib/hooks/useNonReactiveCallback'
 import {postUriToRelativePath, toBskyAppUrl} from '#/lib/strings/url-helpers'
 import {purgeTemporaryImageFiles} from '#/state/gallery'
-import {precacheResolveLinkQuery} from '#/state/queries/resolve-link'
+import {
+  precacheResolveLinkQuery,
+  RQKEY_GIF_ROOT,
+  RQKEY_LINK_ROOT,
+} from '#/state/queries/resolve-link'
 import {type EmojiPickerPosition} from '#/view/com/composer/text-input/web/EmojiPicker'
 import * as Toast from '#/view/com/util/Toast'
 
@@ -120,6 +124,12 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
     if (wasOpen) {
       setState(undefined)
       purgeTemporaryImageFiles()
+      // Purging deletes cached thumbnails on disk, so remove the query
+      // caches that may hold references to those now-deleted file paths.
+      // Without this, restoring a draft would serve stale ResolvedLink
+      // data pointing at missing files, causing "Failed to load blob".
+      queryClient.removeQueries({queryKey: [RQKEY_LINK_ROOT]})
+      queryClient.removeQueries({queryKey: [RQKEY_GIF_ROOT]})
     }
 
     return wasOpen


### PR DESCRIPTION
Clear resolve-link and resolve-gif query caches when the composer closes, since purgeTemporaryImageFiles() deletes the cached thumbnails those queries reference. Without this, restoring a draft serves stale ResolvedLink data pointing at missing files.