### PR TITLE
Add chat data export to Export My Data dialog

### DIFF
--- a/src/screens/Settings/components/ExportCarDialog.tsx
+++ b/src/screens/Settings/components/ExportCarDialog.tsx
@@ -121,6 +121,14 @@ export function ExportCarDialog({
             {loading === 'repo' && <ButtonIcon icon={Loader} />}
           </Button>
 
+          <Text style={[a.text_sm, a.leading_snug, t.atoms.text_contrast_high]}>
+            <Trans>
+              You can also download your chat data as a "JSONL" file. This file
+              only includes chat messages that you have sent and does not
+              include chat messages that you have received.
+            </Trans>
+          </Text>
+
           <Button
             color="secondary"
             size="large"


### PR DESCRIPTION
Not the prettiest but it gets the job done

<img width="689" height="539" alt="Screenshot 2026-02-18 at 10 37 12" src="https://github.com/user-attachments/assets/7805f992-2a7c-4470-b6e9-3b2b884b1adf" />



## Summary
- Adds a secondary "Download chat data" button to the Export My Data dialog, using the `chat.bsky.actor.exportAccountData` endpoint
- Uses raw fetch via `agent.sessionManager.fetchHandler` instead of the typed XRPC client because the client's `httpResponseBodyParse` incorrectly matches `application/jsonl` as `application/json` (substring match), causing a JSON parse error
- Tracks loading state per-button (`'repo' | 'chat' | false`) so each button shows its own spinner while both are disabled during a download

## Test plan
- [ ] Open Settings > Account > Export My Data
- [ ] Tap "Download CAR file" — verify it still works as before
- [ ] Tap "Download chat data" — verify it downloads a `.jsonl` file
- [ ] Verify both buttons are disabled while either download is in progress
- [ ] Test on web + native

🤖 Generated with [Claude Code](https://claude.com/claude-code)