### PR TITLE
Mark admonition text for translation in `CreateListFromStarterPackDialog`

### DIFF
--- a/src/components/dialogs/lists/CreateListFromStarterPackDialog.tsx
+++ b/src/components/dialogs/lists/CreateListFromStarterPackDialog.tsx
@@ -160,8 +160,10 @@ export function CreateListFromStarterPackDialog({
             </Text>
 
             <Admonition type="tip">
-              Changes to the starter pack will not be reflected in the list
-              after creation. The list will be an independent copy.
+              <Trans>
+                Changes to the starter pack will not be reflected in the list
+                after creation. The list will be an independent copy.
+              </Trans>
             </Admonition>
 
             <View


### PR DESCRIPTION
I missed something in my review of #9675: the admonition text isn't marked for translation. This PR fixes that.