### PR TITLE
bskyweb: use avatar thumbnail for post og:image fallback

### DIFF
--- a/bskyweb/cmd/bskyweb/filters.go
+++ b/bskyweb/cmd/bskyweb/filters.go
@@ -2,12 +2,14 @@ package main
 
 import (
 	"net/url"
+	"strings"
 
 	"github.com/flosch/pongo2/v6"
 )
 
 func init() {
 	pongo2.RegisterFilter("canonicalize_url", filterCanonicalizeURL)
+	pongo2.RegisterFilter("avatar_thumbnail", filterAvatarThumbnail)
 }
 
 func filterCanonicalizeURL(in *pongo2.Value, param *pongo2.Value) (*pongo2.Value, *pongo2.Error) {
@@ -25,4 +27,9 @@ func filterCanonicalizeURL(in *pongo2.Value, param *pongo2.Value) (*pongo2.Value
 
 	// Return the cleaned URL
 	return pongo2.AsValue(parsedURL.String()), nil
+}
+
+func filterAvatarThumbnail(in *pongo2.Value, param *pongo2.Value) (*pongo2.Value, *pongo2.Error) {
+	urlStr := in.String()
+	return pongo2.AsValue(strings.Replace(urlStr, "/img/avatar/plain/", "/img/avatar_thumbnail/plain/", 1)), nil
 }

--- a/bskyweb/templates/post.html
+++ b/bskyweb/templates/post.html
@@ -35,8 +35,8 @@
   {% endfor %}
   <meta name="twitter:card" content="summary_large_image">
   {% else %}
-  <meta property="og:image" content="{{ postView.Author.Avatar }}">
-  <meta property="twitter:image" content="{{ postView.Author.Avatar }}">
+  <meta property="og:image" content="{{ postView.Author.Avatar|avatar_thumbnail }}">
+  <meta property="twitter:image" content="{{ postView.Author.Avatar|avatar_thumbnail }}">
   <meta name="twitter:card" content="summary">
   {% endif %}
   <meta name="twitter:label1" content="Posted At">


### PR DESCRIPTION
## Summary

When a post has no image embeds, `post.html` falls back to the author's full-size avatar (typically 1000×1000px) for `og:image` / `twitter:image`. This causes messaging apps like Signal to render an oversized "hero" link preview, because Signal-iOS shows a large preview for any image ≥~600px wide. A giant square profile picture as the hero image looks bad.

Bluesky's CDN already serves a 128×128 `avatar_thumbnail` variant at the same path with `/img/avatar/plain/` replaced by `/img/avatar_thumbnail/plain/`. This PR uses that thumbnail instead, which keeps the image below Signal's hero threshold so text-only posts get the smaller, more appropriate link preview style.

### Before (1000×1000 avatar → hero preview in Signal)
```
og:image: https://cdn.bsky.app/img/avatar/plain/did:plc:xxx/bafkrei...@jpeg
```

### After (128×128 thumbnail → compact preview in Signal)
```
og:image: https://cdn.bsky.app/img/avatar_thumbnail/plain/did:plc:xxx/bafkrei...@jpeg
```

### Context

- Signal-iOS decides hero vs small preview based on image pixel dimensions. Images ≥\~600px wide and ≥\~200px tall get the large "hero" style.
- Signal-Desktop has a separate check that rejects square images for hero display, so it already handles this correctly — but the server-side fix is more robust and benefits all clients.
- The profile template (`profile.html`) already avoids using avatars in OG cards entirely, with the comment `{# Don't use avatar image in cards; usually looks bad #}`.

## Changes

- **`bskyweb/cmd/bskyweb/filters.go`**: Added `avatar_thumbnail` pongo2 template filter
- **`bskyweb/templates/post.html`**: Applied filter on the avatar fallback `og:image` and `twitter:image` tags

## Test plan

- [x] `go build ./...` passes
- [x] Tested locally against live posts — verified `og:image` URL now contains `/img/avatar_thumbnail/plain/` for text-only posts
- [x] Verified image-embed posts are unaffected (they use `feed_thumbnail` path, not `avatar`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)