### PR TITLE
Fix reply failures caused by fetching posts from PDS

### DIFF
--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -5,8 +5,7 @@ import {
   type AppBskyEmbedRecord,
   type AppBskyEmbedRecordWithMedia,
   type AppBskyEmbedVideo,
-  type AppBskyFeedPost,
-  AtUri,
+  AppBskyFeedPost,
   BlobRef,
   type BskyAgent,
   type ComAtprotoLabelDefs,
@@ -39,6 +38,7 @@ import {
   type PostDraft,
   type ThreadDraft,
 } from '#/view/com/composer/state/composer'
+import * as bsky from '#/types/bsky'
 import {createGIFDescription} from '../gif-alt-text'
 import {uploadBlob} from './upload-blob'
 
@@ -214,21 +214,41 @@ async function resolveRT(agent: BskyAgent, richtext: RichText) {
   return rt
 }
 
+export class ReplyDeletedError extends Error {
+  constructor() {
+    super('Could not resolve reply')
+  }
+}
+
 async function resolveReply(agent: BskyAgent, replyTo: string) {
-  const replyToUrip = new AtUri(replyTo)
-  const parentPost = await agent.getPost({
-    repo: replyToUrip.host,
-    rkey: replyToUrip.rkey,
+  const {data} = await agent.app.bsky.feed.getPosts({
+    uris: [replyTo],
   })
-  if (parentPost) {
-    const parentRef = {
-      uri: parentPost.uri,
-      cid: parentPost.cid,
+  const parentPost = data.posts[0]
+  if (!parentPost) {
+    throw new ReplyDeletedError()
+  }
+
+  const parentRef = {
+    uri: parentPost.uri,
+    cid: parentPost.cid,
+  }
+  let rootRef = parentRef
+
+  if (
+    bsky.dangerousIsType<AppBskyFeedPost.Record>(
+      parentPost.record,
+      AppBskyFeedPost.isRecord,
+    )
+  ) {
+    if (parentPost.record.reply) {
+      rootRef = parentPost.record.reply.root
     }
-    return {
-      root: parentPost.value.reply?.root || parentRef,
-      parent: parentRef,
-    }
+  }
+
+  return {
+    root: rootRef,
+    parent: parentRef,
   }
 }
 

--- a/src/view/com/composer/Composer.tsx
+++ b/src/view/com/composer/Composer.tsx
@@ -948,7 +948,10 @@ export const ComposePost = ({
       })
 
       let err = cleanError(e.message)
-      if (err.includes('not locate record')) {
+      if (
+        e instanceof apilib.ReplyDeletedError ||
+        err.includes('not locate record')
+      ) {
         err = l`We're sorry! The post you are replying to has been deleted.`
       } else if (e instanceof EmbeddingDisabledError) {
         err = l`This post's author has disabled quote posts.`


### PR DESCRIPTION
Fixes https://bsky.app/profile/numb.comfortab.ly/post/3mfdbrispuk2z

What I think is happening:

- the client calls `agent.getPost()` to get the replyRef, which under the hood is `com.atproto.repo.getRecord`
- the PDS checks if the DID is local to that PDS
  - if yes: fetch the record from it's own DB
  - if no: forward request to appview

what's happened is `numb.comfortab.ly` has migrated from Amanita to Northsky. when I try and reply to their post, Amanita looks up their DID, thinks it's one of theirs, and fails to find the post so errors

## The fix

use `getPosts` instead of `getPost`, since that always goes straight through to the AppView