### PR TITLE
Show hashtag symbol for Mute option in menu

### DIFF
--- a/src/components/RichTextTag.tsx
+++ b/src/components/RichTextTag.tsx
@@ -148,7 +148,11 @@ export function RichTextTag({
         </Menu.Group>
         <Menu.Divider />
         <Menu.Item
-          label={isMuted ? _(msg`Unmute ${tag}`) : _(msg`Mute ${tag}`)}
+          label={
+            isMuted
+              ? _(msg`Unmute ${isCashtag ? tag : `#${tag}`}`)
+              : _(msg`Mute ${isCashtag ? tag : `#${tag}`}`)
+          }
           onPress={() => {
             if (isMuted) {
               resetUpsert()
@@ -161,7 +165,9 @@ export function RichTextTag({
             }
           }}>
           <Menu.ItemText>
-            {isMuted ? _(msg`Unmute ${tag}`) : _(msg`Mute ${tag}`)}
+            {isMuted
+              ? _(msg`Unmute ${isCashtag ? tag : `#${tag}`}`)
+              : _(msg`Mute ${isCashtag ? tag : `#${tag}`}`)}
           </Menu.ItemText>
           <Menu.ItemIcon icon={isPreferencesLoading ? Loader : Mute} />
         </Menu.Item>


### PR DESCRIPTION
When a user clicks or long-presses a hashtag (depending on whether they're on web or native), the menu that opens will have an option saying **Mute/Unmute {tag}**. However, no **#** symbol is shown in front of the tag.

![IMG_9745](https://github.com/user-attachments/assets/a9835d4a-e74f-464e-931c-d48515ff5077)

This could be a bit confusing, because selecting that option will only mute posts where that text appears in a tag, not posts where it appears in text.

So this PR proposes showing **#** in front of the tag when it's a hashtag (but not for a cashtag, of course).

> [!NOTE]
> **Claude wrote the code for this PR, and although it passes CI I have not tested it.**