### PR TITLE
[APP-1876] Fix pull-to-refresh getting stuck on tab switch

### DIFF
--- a/src/view/com/notifications/NotificationFeed.tsx
+++ b/src/view/com/notifications/NotificationFeed.tsx
@@ -162,6 +162,12 @@ export function NotificationFeed({
     [isFetchingNextPage],
   )
 
+  React.useEffect(() => {
+    if (!enabled) {
+      setIsPTRing(false)
+    }
+  }, [enabled])
+
   return (
     <View style={s.hContentRegion}>
       {error && (

--- a/src/view/com/posts/PostFeed.tsx
+++ b/src/view/com/posts/PostFeed.tsx
@@ -683,6 +683,12 @@ let PostFeed = ({
     blockedOrMutedAuthors,
   ])
 
+  useEffect(() => {
+    if (enabled === false) {
+      setIsPTRing(false)
+    }
+  }, [enabled])
+
   // events
   // =
 


### PR DESCRIPTION
`isPTRing` controls the `refreshing` prop, if you pull to refresh and the component becomes inactive, `isPTRing` remains true until the async refresh completes.