### PR TITLE
Give prompts a little more breathing room on web

### DIFF
--- a/src/components/Prompt.tsx
+++ b/src/components/Prompt.tsx
@@ -61,7 +61,7 @@ export function Outer({
         <Dialog.ScrollableInner
           accessibilityLabelledBy={titleId}
           accessibilityDescribedBy={descriptionId}
-          style={web([{maxWidth: 320, borderRadius: 36}])}>
+          style={web([{maxWidth: 360, borderRadius: 36}])}>
           {children}
         </Dialog.ScrollableInner>
       </Context.Provider>


### PR DESCRIPTION
| Before | After |
| - | - |
| <img width="604" height="579" alt="before" src="https://github.com/user-attachments/assets/bd7c033e-62d9-4cbc-9ce4-bf18145064ec" /> | <img width="601" height="575" alt="after" src="https://github.com/user-attachments/assets/84952ef1-1307-4bb1-b169-e00c75ed63f2" /> |
