### PR TITLE
[APP-1882] fix email not updating in session state after email change

### DIFF
--- a/src/components/dialogs/EmailDialog/data/useConfirmEmail.ts
+++ b/src/components/dialogs/EmailDialog/data/useConfirmEmail.ts
@@ -1,6 +1,6 @@
 import {useMutation} from '@tanstack/react-query'
 
-import {useAgent, useSession} from '#/state/session'
+import {useAgent, useSession, useSessionApi} from '#/state/session'
 
 export function useConfirmEmail({
   onSuccess,
@@ -8,6 +8,7 @@ export function useConfirmEmail({
 }: {onSuccess?: () => void; onError?: () => void} = {}) {
   const agent = useAgent()
   const {currentAccount} = useSession()
+  const {partialRefreshSession} = useSessionApi()
 
   return useMutation({
     mutationFn: async ({token}: {token: string}) => {
@@ -19,8 +20,7 @@ export function useConfirmEmail({
         email: currentAccount.email.trim(),
         token: token.trim(),
       })
-      // will update session state at root of app
-      await agent.resumeSession(agent.session!)
+      await partialRefreshSession()
     },
     onSuccess,
     onError,

--- a/src/components/dialogs/EmailDialog/data/useManageEmail2FA.ts
+++ b/src/components/dialogs/EmailDialog/data/useManageEmail2FA.ts
@@ -1,10 +1,11 @@
 import {useMutation} from '@tanstack/react-query'
 
-import {useAgent, useSession} from '#/state/session'
+import {useAgent, useSession, useSessionApi} from '#/state/session'
 
 export function useManageEmail2FA() {
   const agent = useAgent()
   const {currentAccount} = useSession()
+  const {partialRefreshSession} = useSessionApi()
 
   return useMutation({
     mutationFn: async ({
@@ -22,8 +23,7 @@ export function useManageEmail2FA() {
         emailAuthFactor: enabled,
         token,
       })
-      // will update session state at root of app
-      await agent.resumeSession(agent.session!)
+      await partialRefreshSession()
     },
   })
 }

--- a/src/state/session/index.tsx
+++ b/src/state/session/index.tsx
@@ -284,6 +284,7 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
       type: 'partial-refresh-session',
       accountDid: agent.session!.did,
       patch: {
+        email: data.email,
         emailConfirmed: data.emailConfirmed,
         emailAuthFactor: data.emailAuthFactor,
       },

--- a/src/state/session/reducer.ts
+++ b/src/state/session/reducer.ts
@@ -58,7 +58,10 @@ export type Action =
   | {
       type: 'partial-refresh-session'
       accountDid: string
-      patch: Pick<SessionAccount, 'emailConfirmed' | 'emailAuthFactor'>
+      patch: Pick<
+        SessionAccount,
+        'email' | 'emailConfirmed' | 'emailAuthFactor'
+      >
     }
 
 function createPublicAgentState(): AgentState {
@@ -239,6 +242,7 @@ let reducer = (state: State, action: Action): State => {
        * Only mutating values that are safe. Be very careful with this.
        */
       if (agent.session) {
+        agent.session.email = patch.email ?? agent.session.email
         agent.session.emailConfirmed =
           patch.emailConfirmed ?? agent.session.emailConfirmed
         agent.session.emailAuthFactor =
@@ -255,6 +259,7 @@ let reducer = (state: State, action: Action): State => {
           if (a.did === accountDid) {
             return {
               ...a,
+              email: patch.email ?? a.email,
               emailConfirmed: patch.emailConfirmed ?? a.emailConfirmed,
               emailAuthFactor: patch.emailAuthFactor ?? a.emailAuthFactor,
             }


### PR DESCRIPTION
`agent.resumeSession()` silently discards the `getSession` response when the refresh token matches the current session, so email/email confirmed changes never propagate to local state