### PR TITLE
Fix bottom sheet keyboard expansion with preventExpansion on Android

### DIFF
--- a/modules/bottom-sheet/android/src/main/java/expo/modules/bottomsheet/BottomSheetView.kt
+++ b/modules/bottom-sheet/android/src/main/java/expo/modules/bottomsheet/BottomSheetView.kt
@@ -254,8 +254,16 @@ class BottomSheetView(
       val wasKeyboardVisible = isKeyboardVisible
       isKeyboardVisible = imeVisible
 
-      if (imeVisible && behavior?.state == BottomSheetBehavior.STATE_HALF_EXPANDED) {
-        behavior.state = BottomSheetBehavior.STATE_EXPANDED
+      if (imeVisible && behavior != null && bottomSheet != null && behavior.state != BottomSheetBehavior.STATE_EXPANDED && behavior.state != BottomSheetBehavior.STATE_HIDDEN) {
+        if (preventExpansion) {
+          behavior.maxHeight = (screenHeight - getStatusBarHeight()).toInt()
+          bottomSheet.requestLayout()
+          bottomSheet.post {
+            behavior.state = BottomSheetBehavior.STATE_EXPANDED
+          }
+        } else {
+          behavior.state = BottomSheetBehavior.STATE_EXPANDED
+        }
       } else if (!imeVisible && wasKeyboardVisible) {
         updateLayout()
       }


### PR DESCRIPTION
## Summary
- Fixes the keyboard not pushing up a bottom sheet when `preventExpansion` is true on Android
- The `maxHeight` cap was preventing the sheet from expanding when the keyboard appeared — now temporarily lifts the cap (restored on keyboard dismiss via `updateLayout`)
- Broadened the state check from only `STATE_HALF_EXPANDED` to any non-expanded/non-hidden state, fixing a race condition during rapid keyboard open/close where the sheet could be in `STATE_SETTLING`

Fixes #9943

## Test plan
- [ ] Open a bottom sheet with `preventExpansion: true` on Android (e.g. Live Now dialog on your profile)
- [ ] Tap a text input to open the keyboard
- [ ] Verify the sheet moves up above the keyboard
- [ ] Dismiss the keyboard, verify the sheet returns to its original size
- [ ] Rapidly open/close the keyboard, verify it consistently works

🤖 Generated with [Claude Code](https://claude.com/claude-code)