### PR TITLE
Add 'Copy link to post' to post overflow menu

### DIFF
--- a/src/components/PostControls/PostMenu/PostMenuItems.tsx
+++ b/src/components/PostControls/PostMenu/PostMenuItems.tsx
@@ -65,6 +65,7 @@ import {
 } from '#/components/dialogs/PostInteractionSettingsDialog'
 import {Atom_Stroke2_Corner0_Rounded as AtomIcon} from '#/components/icons/Atom'
 import {BubbleQuestion_Stroke2_Corner0_Rounded as Translate} from '#/components/icons/Bubble'
+import {ChainLink_Stroke2_Corner0_Rounded as ChainLinkIcon} from '#/components/icons/ChainLink'
 import {Clipboard_Stroke2_Corner2_Rounded as ClipboardIcon} from '#/components/icons/Clipboard'
 import {
   EmojiSad_Stroke2_Corner0_Rounded as EmojiSad,
@@ -94,7 +95,7 @@ import {
 } from '#/components/moderation/ReportDialog'
 import * as Prompt from '#/components/Prompt'
 import {useAnalytics} from '#/analytics'
-import {IS_INTERNAL} from '#/env'
+import {IS_INTERNAL, IS_IOS} from '#/env'
 import * as bsky from '#/types/bsky'
 
 let PostMenuItems = ({
@@ -254,6 +255,16 @@ let PostMenuItems = ({
     const str = richTextToString(richText, true)
 
     Clipboard.setStringAsync(str)
+    Toast.show(_(msg`Copied to clipboard`), 'clipboard-check')
+  }
+
+  const onCopyPostLink = async () => {
+    const url = toShareUrl(href)
+    if (IS_IOS) {
+      await Clipboard.setUrlAsync(url)
+    } else {
+      await Clipboard.setStringAsync(url)
+    }
     Toast.show(_(msg`Copied to clipboard`), 'clipboard-check')
   }
 
@@ -513,6 +524,14 @@ let PostMenuItems = ({
                 onPress={onCopyPostText}>
                 <Menu.ItemText>{_(msg`Copy post text`)}</Menu.ItemText>
                 <Menu.ItemIcon icon={ClipboardIcon} position="right" />
+              </Menu.Item>
+
+              <Menu.Item
+                testID="postDropdownCopyLinkBtn"
+                label={_(msg`Copy link to post`)}
+                onPress={onCopyPostLink}>
+                <Menu.ItemText>{_(msg`Copy link to post`)}</Menu.ItemText>
+                <Menu.ItemIcon icon={ChainLinkIcon} position="right" />
               </Menu.Item>
             </>
           ) : (


### PR DESCRIPTION
## Summary

- Adds a "Copy link to post" item to the post three-dot (overflow) menu, placed right after "Copy post text"
- Uses the same URL construction (`toShareUrl`) and chain-link icon as the share menu's existing "Copy link" action
- Gives users quicker access to copying the post URL without going through the share sub-menu

This action already exists in the share menu (arrow icon), but users looking for copy actions naturally check the overflow menu where "Copy post text" lives. Grouping both copy actions together improves discoverability.

Related: #8086

## Test plan

- [ ] Open the three-dot menu on any post → "Copy link to post" appears below "Copy post text" with a chain-link icon
- [ ] Tap "Copy link to post" → clipboard contains the full `https://bsky.app/profile/.../post/...` URL
- [ ] Toast "Copied to clipboard" appears
- [ ] Verify on web and native (iOS/Android)
- [ ] Verify the item does not appear for logged-out users viewing `!no-unauthenticated` posts (same gate as "Copy post text")

🤖 Generated with [Claude Code](https://claude.com/claude-code)