### PR TITLE
Add Search Input focus shortcut on Web

### DIFF
--- a/src/lib/hooks/useFocusSearchInputKeyboardShortcut.tsx
+++ b/src/lib/hooks/useFocusSearchInputKeyboardShortcut.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+import {type TextInput as RNTextInput} from 'react-native'
+import {type TextInput} from 'react-native-gesture-handler'
+
+import {shouldIgnore} from '../keyboard-shortcuts'
+
+export function useFocusSearchInputKeyboardShortcut(
+  isSearchActive: boolean,
+  inputRef: React.RefObject<(TextInput | RNTextInput) | null>,
+) {
+  React.useEffect(() => {
+    if (isSearchActive) return
+
+    function handler(event: KeyboardEvent) {
+      if (shouldIgnore(event) || !inputRef.current) return
+      event.preventDefault()
+      if (event.key === '/') {
+        inputRef.current.focus()
+      }
+    }
+    document.addEventListener('keydown', handler)
+    return () => document.removeEventListener('keydown', handler)
+  }, [isSearchActive, inputRef])
+}

--- a/src/lib/keyboard-shortcuts.ts
+++ b/src/lib/keyboard-shortcuts.ts
@@ -1,0 +1,30 @@
+/**
+ * Based on {@link https://github.com/jaywcjlove/hotkeys-js/blob/b0038773f3b902574f22af747f3bb003a850f1da/src/index.js#L51C1-L64C2}
+ */
+export function shouldIgnore(event: KeyboardEvent) {
+  const target: any = event.target || event.srcElement
+  if (!target) return false
+  const {tagName} = target
+  if (!tagName) return false
+  const isInput =
+    tagName === 'INPUT' &&
+    ![
+      'checkbox',
+      'radio',
+      'range',
+      'button',
+      'file',
+      'reset',
+      'submit',
+      'color',
+    ].includes(target.type)
+  // ignore: isContentEditable === 'true', <input> and <textarea> when readOnly state is false, <select>
+  if (
+    target.isContentEditable ||
+    ((isInput || tagName === 'TEXTAREA' || tagName === 'SELECT') &&
+      !target.readOnly)
+  ) {
+    return true
+  }
+  return false
+}

--- a/src/screens/Search/Shell.tsx
+++ b/src/screens/Search/Shell.tsx
@@ -17,6 +17,7 @@ import {useFocusEffect, useNavigation, useRoute} from '@react-navigation/native'
 import {useQueryClient} from '@tanstack/react-query'
 
 import {HITSLOP_10, HITSLOP_20} from '#/lib/constants'
+import {useFocusSearchInputKeyboardShortcut} from '#/lib/hooks/useFocusSearchInputKeyboardShortcut'
 import {useNonReactiveCallback} from '#/lib/hooks/useNonReactiveCallback'
 import {MagnifyingGlassIcon} from '#/lib/icons'
 import {type NavigationProp} from '#/lib/routes/types'
@@ -282,6 +283,8 @@ export function SearchScreenShell({
       return listenSoftReset(onSoftReset)
     }, [onSoftReset, setMinimalShellMode]),
   )
+
+  useFocusSearchInputKeyboardShortcut(showAutocomplete, textInput)
 
   const onSearchInputFocus = useCallback(() => {
     if (IS_WEB) {

--- a/src/state/shell/composer/useComposerKeyboardShortcut.tsx
+++ b/src/state/shell/composer/useComposerKeyboardShortcut.tsx
@@ -1,42 +1,12 @@
 import React from 'react'
 
 import {useOpenComposer} from '#/lib/hooks/useOpenComposer'
+import {shouldIgnore} from '#/lib/keyboard-shortcuts'
 import {useDialogStateContext} from '#/state/dialogs'
 import {useLightbox} from '#/state/lightbox'
 import {useModals} from '#/state/modals'
 import {useSession} from '#/state/session'
 import {useIsDrawerOpen} from '#/state/shell/drawer-open'
-
-/**
- * Based on {@link https://github.com/jaywcjlove/hotkeys-js/blob/b0038773f3b902574f22af747f3bb003a850f1da/src/index.js#L51C1-L64C2}
- */
-function shouldIgnore(event: KeyboardEvent) {
-  const target: any = event.target || event.srcElement
-  if (!target) return false
-  const {tagName} = target
-  if (!tagName) return false
-  const isInput =
-    tagName === 'INPUT' &&
-    ![
-      'checkbox',
-      'radio',
-      'range',
-      'button',
-      'file',
-      'reset',
-      'submit',
-      'color',
-    ].includes(target.type)
-  // ignore: isContentEditable === 'true', <input> and <textarea> when readOnly state is false, <select>
-  if (
-    target.isContentEditable ||
-    ((isInput || tagName === 'TEXTAREA' || tagName === 'SELECT') &&
-      !target.readOnly)
-  ) {
-    return true
-  }
-  return false
-}
 
 export function useComposerKeyboardShortcut() {
   const {openComposer} = useOpenComposer()

--- a/src/view/shell/desktop/Search.tsx
+++ b/src/view/shell/desktop/Search.tsx
@@ -6,10 +6,12 @@ import {
   View,
   type ViewStyle,
 } from 'react-native'
+import {TextInput} from 'react-native-gesture-handler'
 import {msg} from '@lingui/core/macro'
 import {useLingui} from '@lingui/react'
 import {StackActions, useNavigation} from '@react-navigation/native'
 
+import {useFocusSearchInputKeyboardShortcut} from '#/lib/hooks/useFocusSearchInputKeyboardShortcut'
 import {usePalette} from '#/lib/hooks/usePalette'
 import {type NavigationProp} from '#/lib/routes/types'
 import {useModerationOpts} from '#/state/preferences/moderation-opts'
@@ -77,12 +79,15 @@ export function DesktopSearch() {
   const navigation = useNavigation<NavigationProp>()
   const [isActive, setIsActive] = React.useState<boolean>(false)
   const [query, setQuery] = React.useState<string>('')
+  const inputRef = React.useRef<TextInput>(null)
   const {data: autocompleteData, isFetching} = useActorAutocompleteQuery(
     query,
     true,
   )
 
   const moderationOpts = useModerationOpts()
+
+  useFocusSearchInputKeyboardShortcut(isActive, inputRef)
 
   const onChangeText = React.useCallback((text: string) => {
     setQuery(text)
@@ -109,6 +114,7 @@ export function DesktopSearch() {
     <View style={[styles.container, pal.view]}>
       <SearchInput
         value={query}
+        inputRef={inputRef}
         onChangeText={onChangeText}
         onClearText={onPressCancelSearch}
         onSubmitEditing={onSubmit}


### PR DESCRIPTION
This PR adds a keyboard shortcut `/` to focus the desktop Search Input and that on the Search page.

I used #5197 for reference to try add this shortcut with the smallest touch. Also took a look at #552.

---

I saw a link on Bluesky that mentioned #640 and lacking accessibility on the web app, and thought I would give implementing `/` a shot. 

I would be very happy to continue on with `j`/`k`, `l`, `r` etc. but I thought those might require more discussion. 
