### PR TITLE
Set mute word dialog text input return key type to "done"

### DIFF
--- a/src/components/dialogs/MutedWords.tsx
+++ b/src/components/dialogs/MutedWords.tsx
@@ -132,6 +132,7 @@ function MutedWordsInner() {
             autoCorrect={false}
             autoCapitalize="none"
             autoComplete="off"
+            returnKeyType="done"
             label={_(msg`Enter a word or tag`)}
             placeholder={_(msg`Enter a word or tag`)}
             value={field}


### PR DESCRIPTION
It's a single line input, and pressing enter submits the form anyway, so this makes sense