### PR TITLE
Make ALT labels translatable

### DIFF
--- a/src/components/images/AutoSizedImage.tsx
+++ b/src/components/images/AutoSizedImage.tsx
@@ -9,6 +9,7 @@ import {type AppBskyEmbedImages} from '@atproto/api'
 import {utils} from '@bsky.app/alf'
 import {msg} from '@lingui/core/macro'
 import {useLingui} from '@lingui/react'
+import {Trans} from '@lingui/react/macro'
 
 import {type Dimensions} from '#/lib/media/types'
 import {useLargeAltBadgeEnabled} from '#/state/preferences/large-alt-badge'

--- a/src/components/images/Gallery.tsx
+++ b/src/components/images/Gallery.tsx
@@ -5,6 +5,7 @@ import {type AppBskyEmbedImages} from '@atproto/api'
 import {utils} from '@bsky.app/alf'
 import {msg} from '@lingui/core/macro'
 import {useLingui} from '@lingui/react'
+import {Trans} from '@lingui/react/macro'
 
 import {type Dimensions} from '#/lib/media/types'
 import {useLargeAltBadgeEnabled} from '#/state/preferences/large-alt-badge'


### PR DESCRIPTION
The ALT labels in the corners of GIFs have always been translatable, but this is not the case with regular images, which keep the English-only ‘ALT’ string.

This PR wraps the two leftover instances of ‘ALT’ strings in Trans tags so as to make them translatable. I believe that these should reuse the existing translation for the tag, if present – which should be fine as the context does not differ – so further action from translators is not required.