### PR TITLE
Force relayout to fix stuck header blur

### DIFF
--- a/src/lib/hooks/useMinimalShellTransform.ts
+++ b/src/lib/hooks/useMinimalShellTransform.ts
@@ -16,16 +16,39 @@ export function useMinimalShellHeaderTransform() {
 
   const headerTransform = useAnimatedStyle(() => {
     const headerModeValue = headerMode.get()
+    const hHeight = headerHeight.get()
+
+    if (IS_LIQUID_GLASS) {
+      // bit of a hackfix, but: the header can get affected by scrollEdgeEffects
+      // when animating from closed to open. workaround is to trigger a relayout
+      // by offsetting the top position. the actual value doesn't matter, and we
+      // simultaneously offset it using the translate transform.
+      // I think a cleaner way to do it would be to use UIScrollEdgeElementContainerInteraction
+      // manually or something like that, because this kinda sucks -sfn
+      const relayoutingOffset = headerModeValue === 0 ? 1 : 0
+      return {
+        top: relayoutingOffset,
+        pointerEvents: headerModeValue === 0 ? 'auto' : 'none',
+        opacity: Math.pow(1 - headerModeValue, 2),
+        transform: [
+          {
+            translateY:
+              interpolate(
+                headerModeValue,
+                [0, 1],
+                [0, headerPinnedHeight - hHeight],
+              ) - relayoutingOffset,
+          },
+        ],
+      }
+    }
+
     return {
       pointerEvents: headerModeValue === 0 ? 'auto' : 'none',
       opacity: Math.pow(1 - headerModeValue, 2),
       transform: [
         {
-          translateY: interpolate(
-            headerModeValue,
-            [0, 1],
-            [0, headerPinnedHeight - headerHeight.get()],
-          ),
+          translateY: interpolate(headerModeValue, [0, 1], [0, -hHeight]),
         },
       ],
     }


### PR DESCRIPTION
The header blur introduced by #9935 has a bug where scrolling down, then swiping to the side causes the text in the tab bar to be affected by the blur. This is because when invisible, it sits in the blur area and gets blurred. Transforming the element over into place doesn't consistently clear the blur, especially when swiping between pages.

The fix is not great, but forcing a relayout by changing `top` by 1px seems to do it. 

If you have a better idea for forcing a relayout, I'm all ears. zIndex did not work.

## Before

https://github.com/user-attachments/assets/149cc722-7ad3-42d1-babf-d0fd4e21591f


## After

https://github.com/user-attachments/assets/800af664-6263-4d54-882e-6cde6525970a
