### PR TITLE
[APP-1932] fix scroll header jumping on profiles with large headers

### DIFF
--- a/modules/expo-scroll-forwarder/ios/ExpoScrollForwarderView.swift
+++ b/modules/expo-scroll-forwarder/ios/ExpoScrollForwarderView.swift
@@ -77,8 +77,9 @@ class ExpoScrollForwarderView: ExpoView, UIGestureRecognizerDelegate {
 
     if sender.state == .began {
       // Use max(0) so gesture deltas compute correctly, but don't mutate
-      // contentOffset — snapping it to 0 causes a visible jump on profiles
-      // with large headers where the user is scrolled into negative territory.
+      // contentOffset
+      // snapping it to 0 causes a visible jump on profiles with large headers
+      // where the user is scrolled into negative territory. - sfp
       self.initialOffset = max(sv.contentOffset.y, 0)
     }
 

--- a/modules/expo-scroll-forwarder/ios/ExpoScrollForwarderView.swift
+++ b/modules/expo-scroll-forwarder/ios/ExpoScrollForwarderView.swift
@@ -76,11 +76,10 @@ class ExpoScrollForwarderView: ExpoView, UIGestureRecognizerDelegate {
     let translation = sender.translation(in: self).y
 
     if sender.state == .began {
-      if sv.contentOffset.y < 0 {
-        sv.contentOffset.y = 0
-      }
-
-      self.initialOffset = sv.contentOffset.y
+      // Use max(0) so gesture deltas compute correctly, but don't mutate
+      // contentOffset — snapping it to 0 causes a visible jump on profiles
+      // with large headers where the user is scrolled into negative territory.
+      self.initialOffset = max(sv.contentOffset.y, 0)
     }
 
     if sender.state == .changed {

--- a/src/view/com/pager/PagerWithHeader.tsx
+++ b/src/view/com/pager/PagerWithHeader.tsx
@@ -156,17 +156,23 @@ export function PagerWithHeader({
     [currentPage, headerOnlyHeight, lastForcedScrollY, scrollRefs, scrollY],
   )
 
-  // HACK: onScroll reports a bogus value of exactly -headerHeight on initial
-  // load. We filter it out, but only until the first real scroll event has
-  // been accepted. After that we stop filtering so that legitimate
-  // scroll-to-top events (which also target -headerHeight) are not rejected.
-  // profiles with very large headers do scroll to -headerHeight normally,
-  // so we need to adjust the heuristic. - sfp
+  // HACK: onScroll reports bogus values of exactly -headerHeight on initial
+  // load and again after header height changes. We filter them out until
+  // the first real scroll event arrives for each header height. This lets
+  // legitimate scroll-to-top events through while still rejecting the
+  // spurious ones that would cause visual jumps. - sfp
   const hasReceivedScroll = useSharedValue(false)
+  const lastKnownHeaderHeight = useSharedValue(0)
   const onScrollWorklet = useCallback(
     (e: NativeScrollEvent) => {
       'worklet'
       const nextScrollY = e.contentOffset.y
+      // Reset the filter whenever the header height changes, because
+      // a new batch of bogus -headerHeight events will appear.
+      if (headerHeight !== lastKnownHeaderHeight.get()) {
+        lastKnownHeaderHeight.set(headerHeight)
+        hasReceivedScroll.set(false)
+      }
       if (!hasReceivedScroll.get()) {
         const isPossiblyInvalid =
           headerHeight > 0 && Math.round(nextScrollY * 2) / 2 === -headerHeight
@@ -177,7 +183,7 @@ export function PagerWithHeader({
       }
       scrollY.set(nextScrollY)
     },
-    [scrollY, headerHeight, hasReceivedScroll],
+    [scrollY, headerHeight, hasReceivedScroll, lastKnownHeaderHeight],
   )
 
   const onPageSelectedInner = useCallback(
@@ -277,35 +283,30 @@ let PagerTabBar = ({
       ],
     }
   })
-  const headerRef = useRef<View>(null)
-  const fallbackHeaderOnlyHeight = useRef(0)
+  const pendingHeaderHeightForWhenSentinelReady = useRef<number | undefined>(
+    undefined,
+  )
+  const sentinelHasRenderedRef = useRef(false)
   return (
     <Animated.View
       pointerEvents={IS_IOS ? 'auto' : 'box-none'}
       style={[styles.tabBarMobile, headerTransform, t.atoms.bg]}>
       <View
-        ref={headerRef}
         pointerEvents={IS_IOS ? 'auto' : 'box-none'}
         collapsable={false}
         onLayout={(e: LayoutChangeEvent) => {
+          // we want to measure this view's height to get the header height.
+          // however, we risk doing it too early if the header hasn't rendered yet.
+          // therefore, we use a sentinel view and wait for *that* to layout before
+          // we set the header height, using the last measured height from this
+          // onLayout. after the sentinel has rendered for the first time, we can
+          // just straightforwardly set the header height here directly -sfn
           const height = e.nativeEvent.layout.height
-          // Fallback measurement using onLayout directly on the header wrapper.
-          // This is more reliable than .measure() on Android after certain
-          // navigation transitions (e.g. returning from the logged-out view)
-          // where .measure() can fail to return a height. in general though,
-          // we should prefer using .measure() when possible as this can
-          // fire too early and cause layout thrashing.
-          // ref: https://github.com/bluesky-social/social-app/pull/9964 -sfp
-          if (isHeaderReady) {
-            fallbackHeaderOnlyHeight.current = height
-            // Re-measure when the header content changes size (e.g.
-            // SuggestedFollows accordion expanding/collapsing). The sentinel
-            // view below only fires onLayout once on mount, so without this
-            // the headerOnlyHeight goes stale. - sfp
-            const rounded = Math.round(height * 2) / 2
-            if (rounded > 0 && rounded !== headerOnlyHeight) {
-              onHeaderOnlyLayout(height)
-            }
+          // note: sentinel only renders after `isHeaderReady` has turned `true`
+          if (sentinelHasRenderedRef.current) {
+            onHeaderOnlyLayout(height)
+          } else {
+            pendingHeaderHeightForWhenSentinelReady.current = height
           }
         }}>
         {renderHeader?.({setMinimumHeight: setMinimumHeaderHeight})}
@@ -320,17 +321,13 @@ let PagerTabBar = ({
               // even if `isHeaderReady` might have turned `true`, the associated
               // layout might not have been performed yet on the native side.
               onLayout={() => {
-                headerRef.current?.measure(
-                  (_x: number, _y: number, _width: number, height: number) => {
-                    // sometimes height is `undefined` on Android, see above
-                    if (height !== undefined) {
-                      onHeaderOnlyLayout(height)
-                    } else {
-                      // if measure fails, use the value we got from `onLayout`
-                      onHeaderOnlyLayout(fallbackHeaderOnlyHeight.current)
-                    }
-                  },
-                )
+                if (!sentinelHasRenderedRef.current) {
+                  sentinelHasRenderedRef.current = true
+                  const height = pendingHeaderHeightForWhenSentinelReady.current
+                  if (height !== undefined) {
+                    onHeaderOnlyLayout(height)
+                  }
+                }
               }}
             />
           )

--- a/src/view/com/pager/PagerWithHeader.tsx
+++ b/src/view/com/pager/PagerWithHeader.tsx
@@ -156,20 +156,28 @@ export function PagerWithHeader({
     [currentPage, headerOnlyHeight, lastForcedScrollY, scrollRefs, scrollY],
   )
 
+  // HACK: onScroll reports a bogus value of exactly -headerHeight on initial
+  // load. We filter it out, but only until the first real scroll event has
+  // been accepted. After that we stop filtering so that legitimate
+  // scroll-to-top events (which also target -headerHeight) are not rejected.
+  // The old heuristic assumed "you'd never be overscrolled by 400px" but
+  // profiles with very large headers DO scroll to -headerHeight normally. -sfn
+  const hasReceivedScroll = useSharedValue(false)
   const onScrollWorklet = useCallback(
     (e: NativeScrollEvent) => {
       'worklet'
       const nextScrollY = e.contentOffset.y
-      // HACK: onScroll is reporting some strange values on load (negative header height).
-      // Highly improbable that you'd be overscrolled by over 400px -
-      // in fact, I actually can't do it, so let's just ignore those. -sfn
-      const isPossiblyInvalid =
-        headerHeight > 0 && Math.round(nextScrollY * 2) / 2 === -headerHeight
-      if (!isPossiblyInvalid) {
-        scrollY.set(nextScrollY)
+      if (!hasReceivedScroll.get()) {
+        const isPossiblyInvalid =
+          headerHeight > 0 && Math.round(nextScrollY * 2) / 2 === -headerHeight
+        if (isPossiblyInvalid) {
+          return
+        }
+        hasReceivedScroll.set(true)
       }
+      scrollY.set(nextScrollY)
     },
-    [scrollY, headerHeight],
+    [scrollY, headerHeight, hasReceivedScroll],
   )
 
   const onPageSelectedInner = useCallback(
@@ -280,6 +288,7 @@ let PagerTabBar = ({
         pointerEvents={IS_IOS ? 'auto' : 'box-none'}
         collapsable={false}
         onLayout={(e: LayoutChangeEvent) => {
+          const height = e.nativeEvent.layout.height
           // Fallback measurement using onLayout directly on the header wrapper.
           // This is more reliable than .measure() on Android after certain
           // navigation transitions (e.g. returning from the logged-out view)
@@ -288,7 +297,15 @@ let PagerTabBar = ({
           // fire too early and cause layout thrashing.
           // ref: https://github.com/bluesky-social/social-app/pull/9964 -sfp
           if (isHeaderReady) {
-            fallbackHeaderOnlyHeight.current = e.nativeEvent.layout.height
+            fallbackHeaderOnlyHeight.current = height
+            // Re-measure when the header content changes size (e.g.
+            // SuggestedFollows accordion expanding/collapsing). The sentinel
+            // view below only fires onLayout once on mount, so without this
+            // the headerOnlyHeight goes stale.
+            const rounded = Math.round(height * 2) / 2
+            if (rounded > 0 && rounded !== headerOnlyHeight) {
+              onHeaderOnlyLayout(height)
+            }
           }
         }}>
         {renderHeader?.({setMinimumHeight: setMinimumHeaderHeight})}

--- a/src/view/com/pager/PagerWithHeader.tsx
+++ b/src/view/com/pager/PagerWithHeader.tsx
@@ -160,8 +160,8 @@ export function PagerWithHeader({
   // load. We filter it out, but only until the first real scroll event has
   // been accepted. After that we stop filtering so that legitimate
   // scroll-to-top events (which also target -headerHeight) are not rejected.
-  // The old heuristic assumed "you'd never be overscrolled by 400px" but
-  // profiles with very large headers DO scroll to -headerHeight normally. -sfn
+  // profiles with very large headers DO scroll to -headerHeight normally,
+  // so we need to adjust the heuristic. - sfp
   const hasReceivedScroll = useSharedValue(false)
   const onScrollWorklet = useCallback(
     (e: NativeScrollEvent) => {
@@ -301,7 +301,7 @@ let PagerTabBar = ({
             // Re-measure when the header content changes size (e.g.
             // SuggestedFollows accordion expanding/collapsing). The sentinel
             // view below only fires onLayout once on mount, so without this
-            // the headerOnlyHeight goes stale.
+            // the headerOnlyHeight goes stale. - sfp
             const rounded = Math.round(height * 2) / 2
             if (rounded > 0 && rounded !== headerOnlyHeight) {
               onHeaderOnlyLayout(height)

--- a/src/view/com/pager/PagerWithHeader.tsx
+++ b/src/view/com/pager/PagerWithHeader.tsx
@@ -277,35 +277,30 @@ let PagerTabBar = ({
       ],
     }
   })
-  const headerRef = useRef<View>(null)
-  const fallbackHeaderOnlyHeight = useRef(0)
+  const pendingHeaderHeightForWhenSentinelReady = useRef<number | undefined>(
+    undefined,
+  )
+  const sentinelHasRenderedRef = useRef(false)
   return (
     <Animated.View
       pointerEvents={IS_IOS ? 'auto' : 'box-none'}
       style={[styles.tabBarMobile, headerTransform, t.atoms.bg]}>
       <View
-        ref={headerRef}
         pointerEvents={IS_IOS ? 'auto' : 'box-none'}
         collapsable={false}
         onLayout={(e: LayoutChangeEvent) => {
+          // we want to measure this view's height to get the header height.
+          // however, we risk doing it too early if the header hasn't rendered yet.
+          // therefore, we use a sentinel view and wait for *that* to layout before
+          // we set the header height, using the last measured height from this
+          // onLayout. after the sentinel has rendered for the first time, we can
+          // just straightforwardly set the header height here directly -sfn
           const height = e.nativeEvent.layout.height
-          // Fallback measurement using onLayout directly on the header wrapper.
-          // This is more reliable than .measure() on Android after certain
-          // navigation transitions (e.g. returning from the logged-out view)
-          // where .measure() can fail to return a height. in general though,
-          // we should prefer using .measure() when possible as this can
-          // fire too early and cause layout thrashing.
-          // ref: https://github.com/bluesky-social/social-app/pull/9964 -sfp
-          if (isHeaderReady) {
-            fallbackHeaderOnlyHeight.current = height
-            // Re-measure when the header content changes size (e.g.
-            // SuggestedFollows accordion expanding/collapsing). The sentinel
-            // view below only fires onLayout once on mount, so without this
-            // the headerOnlyHeight goes stale. - sfp
-            const rounded = Math.round(height * 2) / 2
-            if (rounded > 0 && rounded !== headerOnlyHeight) {
-              onHeaderOnlyLayout(height)
-            }
+          // note: sentinel only renders after `isHeaderReady` has turned `true`
+          if (sentinelHasRenderedRef.current) {
+            onHeaderOnlyLayout(height)
+          } else {
+            pendingHeaderHeightForWhenSentinelReady.current = height
           }
         }}>
         {renderHeader?.({setMinimumHeight: setMinimumHeaderHeight})}
@@ -315,22 +310,19 @@ let PagerTabBar = ({
           // Instead, we'll render a brand node conditionally and get fresh layout.
           isHeaderReady && (
             <View
+              testID="layout-sentinel"
               collapsable={false}
               // It wouldn't be enough to do this in a `ref` of an effect because,
               // even if `isHeaderReady` might have turned `true`, the associated
               // layout might not have been performed yet on the native side.
               onLayout={() => {
-                headerRef.current?.measure(
-                  (_x: number, _y: number, _width: number, height: number) => {
-                    // sometimes height is `undefined` on Android, see above
-                    if (height !== undefined) {
-                      onHeaderOnlyLayout(height)
-                    } else {
-                      // if measure fails, use the value we got from `onLayout`
-                      onHeaderOnlyLayout(fallbackHeaderOnlyHeight.current)
-                    }
-                  },
-                )
+                if (!sentinelHasRenderedRef.current) {
+                  sentinelHasRenderedRef.current = true
+                  const height = pendingHeaderHeightForWhenSentinelReady.current
+                  if (height !== undefined) {
+                    onHeaderOnlyLayout(height)
+                  }
+                }
               }}
             />
           )

--- a/src/view/com/pager/PagerWithHeader.tsx
+++ b/src/view/com/pager/PagerWithHeader.tsx
@@ -160,7 +160,7 @@ export function PagerWithHeader({
   // load. We filter it out, but only until the first real scroll event has
   // been accepted. After that we stop filtering so that legitimate
   // scroll-to-top events (which also target -headerHeight) are not rejected.
-  // profiles with very large headers DO scroll to -headerHeight normally,
+  // profiles with very large headers do scroll to -headerHeight normally,
   // so we need to adjust the heuristic. - sfp
   const hasReceivedScroll = useSharedValue(false)
   const onScrollWorklet = useCallback(


### PR DESCRIPTION
i think there are a few things at play here:

1. in `ExpoScrollForwarder`, every pan gesture on the header set `contentOffset.y` to `0` when it was negative. since the list's position "at top" is a negative contentOffset, it would snap past the entire header on profiles with large headers. 
   - updated this to record `max(contentOffset.y, 0) as the gesture starting point without mutating scroll position

2. the previous heuristic in `PagerWithHeader` rejected scroll events at exactly `-headerHeight`, but with large headers we can get in a position where >400px is a valid position. 
    - updated this to keep filtering the first event on initial load, and then accept all subsequent events

3. the header height was measured once via `onLayout` and then never updated and the parent `onLayout` fires when the header resizes (from suggested follows guide, etc.) 
    - updated this to also call `onHeaderOnlyLayout` when the height differs from the current value so `headerOnlyHeight` is in sync
