### PR TITLE
Guess source language if unavailable

### DIFF
--- a/src/lib/translation/index.tsx
+++ b/src/lib/translation/index.tsx
@@ -4,8 +4,10 @@ import {getLocales} from 'expo-localization'
 import {type TranslationTaskResult} from '@bsky.app/expo-translate-text/build/ExpoTranslateText.types'
 import {useLingui} from '@lingui/react/macro'
 import {useFocusEffect} from '@react-navigation/native'
+import lande from 'lande'
 
 import {useGoogleTranslate} from '#/lib/hooks/useGoogleTranslate'
+import {code3ToCode2Strict} from '#/locale/helpers'
 import {logger} from '#/logger'
 import {useAnalytics} from '#/analytics'
 import {Context} from './context'
@@ -73,8 +75,19 @@ async function attemptTranslation(
   return {
     translatedText,
     targetLanguage: result.targetLanguage,
-    sourceLanguage: result.sourceLanguage ?? sourceLangCode ?? null, // iOS doesn't return the source language
+    sourceLanguage:
+      result.sourceLanguage ?? sourceLangCode ?? guessLanguage(input), // iOS doesn't return the source language
   }
+}
+
+// TODO: Replace with expo-guess-language
+function guessLanguage(text: string): string | null {
+  const results = lande(text)
+  // only return high-confidence results
+  if (results[0] && results[0][1] > 0.97) {
+    return code3ToCode2Strict(results[0][0]) ?? null
+  }
+  return null
 }
 
 /**


### PR DESCRIPTION
# Stacked on #9987 

Uses `lande` to guess the source language if unavailable