### PR TITLE
Link to profile via handle vs did

### DIFF
--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -14,6 +14,7 @@ import {
 import {useLingui} from '@lingui/react/macro'
 
 import {getModerationCauseKey} from '#/lib/moderation'
+import {makeProfileLink} from '#/lib/routes/links'
 import {forceLTR} from '#/lib/strings/bidi'
 import {NON_BREAKING_SPACE} from '#/lib/strings/constants'
 import {sanitizeDisplayName} from '#/lib/strings/display-names'
@@ -138,15 +139,17 @@ export function Link({
 } & Omit<LinkProps, 'to' | 'label'>) {
   const {t: l} = useLingui()
 
+  const profileURL = makeProfileLink({
+    did: profile.did,
+    handle: profile.handle,
+  })
+
   return (
     <InternalLink
       label={l`View ${
         profile.displayName || sanitizeHandle(profile.handle)
       }’s profile`}
-      to={{
-        screen: 'Profile',
-        params: {name: profile.did},
-      }}
+      to={profileURL}
       style={[a.flex_col, style]}
       {...rest}>
       {children}


### PR DESCRIPTION
Updates `ProfileCard` to link to the user’s profile via handle.

<img width="611" height="282" alt="suggested" src="https://github.com/user-attachments/assets/99e50441-1ab3-4d55-bcdd-6e155a9eb4c6" />
<br />
<img width="125" height="25" alt="uri" src="https://github.com/user-attachments/assets/2d4df22f-9dfc-487b-8a84-637f1975b49b" />

