### PR TITLE
Set displayName and description to undefined if no values are provided during a profile edit

### DIFF
--- a/src/state/queries/profile.ts
+++ b/src/state/queries/profile.ts
@@ -176,8 +176,8 @@ export function useProfileUpdateMutation() {
         if (typeof updates === 'function') {
           next = updates(next)
         } else {
-          next.displayName = updates.displayName
-          next.description = updates.description
+          next.displayName = updates.displayName || undefined
+          next.description = updates.description || undefined
           if ('pinnedPost' in updates) {
             next.pinnedPost = updates.pinnedPost
           }


### PR DESCRIPTION
This issue was mentioned in #7379 but closed as not planned.

Now this isn't a fix for that particularly (since any other app could ignore it) but is intended to keep these fields a little more sanitised when coming from BlueSky! 🐙