### PR TITLE
[APP-1960] Fix current session refresh bug

### DIFF
--- a/src/state/session/agent.ts
+++ b/src/state/session/agent.ts
@@ -72,19 +72,6 @@ export async function createAgentAndResume(
     await networkRetry(1, () => agent.resumeSession(prevSession))
   } else {
     agent.sessionManager.session = prevSession
-    if (!storedAccount.signupQueued) {
-      networkRetry(3, () => agent.resumeSession(prevSession)).catch(
-        (e: any) => {
-          logger.error(`networkRetry failed to resume session`, {
-            status: e?.status || 'unknown',
-            // this field name is ignored by Sentry scrubbers
-            safeMessage: e?.message || 'unknown',
-          })
-
-          throw e
-        },
-      )
-    }
   }
 
   // after session is attached

--- a/src/state/session/index.tsx
+++ b/src/state/session/index.tsx
@@ -321,6 +321,12 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
       )
       if (syncedAccount && syncedAccount.refreshJwt) {
         if (syncedAccount.did !== state.currentAgentState.did) {
+          /*
+           * Web handling: if leader tab has switched to a diff account that is
+           * stale, it will refresh the session before triggering the update to
+           * follower tabs. Follower tabs will therefore receive the fresh
+           * session. See APP-1960, or ask Eric.
+           */
           resumeSession(syncedAccount)
         } else {
           const agent = state.currentAgentState.agent as BskyAgent


### PR DESCRIPTION
In atproto [#4713](https://github.com/bluesky-social/atproto/pull/4713), we attempted to restore previous functionality whereby the app's calls resumeSession always results in the persistSession callback firing and thereby updating state within the app.

This functionality differed slightly from the previous logic (prior to [#4470](https://github.com/bluesky-social/atproto/pull/4470)), where we called getSession first, and only refreshSession if the first call failed.

We shipped this, and immediately noticed a concurrent session update detected but when signing in and out (and maybe other repros) on web with multiple tabs open.

Upon investigation, my hypothesis is this:
1. login() calls agent.login() and succeeds
2. our cross-tab persisted state fires, and follower-tabs get the new account session state
3. follower-tabs then in-turn call resumeSession in the app codebase, which in turn calls refreshSession unnecessarily

Point #3 previously called getSession first, as mentioned above, so we did not previously trigger a session update. But because our logic within resumeSession calls agent.resumeSession even for sessions we know are not expired, we now have this unnecessary call to refreshSession.

* * *

I believe the fix for this is to remove the un-awaited call to agent.resumeSession for sessions we know are not expired. This fixes the login issue.

Switching accounts to another account that is expired is slightly different. In this case, the leader tab will call resumeSession and await the result before sending updates to the follower tabs. The follower tabs will in-turn call resumeSession, but with the removal of the un-awaited agent.resumeSession call, no calls to refresSession will occur. So the fix works for this too.