### PR TITLE
Disable Pager overscroll on Android

### DIFF
--- a/src/view/com/pager/Pager.tsx
+++ b/src/view/com/pager/Pager.tsx
@@ -156,7 +156,8 @@ export function Pager({
           ref={pagerView}
           style={a.flex_1}
           initialPage={initialPage}
-          onPageScroll={handlePageScroll}>
+          onPageScroll={handlePageScroll}
+          overScrollMode="never">
           {children}
         </MemoizedAnimatedPagerView>
       </DrawerGestureRequireFail>


### PR DESCRIPTION
I think it's really jarring and creates a conflict with the drawer gesture. nice on vertical scrollviews, quite horrible on pagers imo

## Before

https://github.com/user-attachments/assets/de175a1e-e741-4d06-a519-73637ca49ae3



## After  

https://github.com/user-attachments/assets/95814722-6cd0-4ee4-b245-aa82d533cccf


