### PR TITLE
Update issue templates to take uploads, and fix typo

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,5 @@
 name: "Bug Report"
-description: "Create a report for an issue you have experience in the app."
+description: "Create a report for an issue you have experienced in the app."
 labels: ["bug"]
 body:
   - type: markdown
@@ -19,13 +19,14 @@ body:
         4. See error
     validations:
       required: true
-  - type: textarea
+  - type: upload
     attributes:
       label: Attachments
       description: |
         If possible, please provide any images or videos that may help us understand the issue you are experiencing.
     validations:
       required: false
+      accept: ".png,.jpg,.jpeg,.gif,.webp,.mp4,.mov,.webm"
   - type: dropdown
     attributes:
       label: What platform(s) does this occur on?

--- a/.github/ISSUE_TEMPLATE/bug_report_fabric.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_fabric.yml
@@ -26,13 +26,14 @@ body:
         4. See error
     validations:
       required: true
-  - type: textarea
+  - type: upload
     attributes:
       label: Attachments
       description: |
         If possible, please provide any images or videos that may help us understand the issue you are experiencing.
     validations:
       required: false
+      accept: ".png,.jpg,.jpeg,.gif,.webp,.mp4,.mov,.webm"
   - type: dropdown
     attributes:
       label: What platform(s) does this occur on?

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -15,7 +15,7 @@ body:
         implement it in a timely manner.
     validations:
       required: true
-  - type: textarea
+  - type: upload
     attributes:
       label: Attachments
       description: |
@@ -24,6 +24,7 @@ body:
         in or is missing from.
     validations:
       required: false
+      accept: ".png,.jpg,.jpeg,.gif,.webp,.mp4,.mov,.webm"
   - type: textarea
     attributes:
       label: Describe Alternatives


### PR DESCRIPTION
Updated the issue templates to take the new `upload` type, and fixed a typo in the bug report template:
https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-githubs-form-schema#upload 