### PR TITLE
Don't show chat notification if viewer is age gated

### DIFF
--- a/src/ageAssurance/index.tsx
+++ b/src/ageAssurance/index.tsx
@@ -2,8 +2,10 @@ import {createContext, useCallback, useContext, useEffect, useMemo} from 'react'
 
 import {useGetAndRegisterPushToken} from '#/lib/notifications/notifications'
 import {Provider as RedirectOverlayProvider} from '#/ageAssurance/components/RedirectOverlay'
-import {AgeAssuranceDataProvider} from '#/ageAssurance/data'
-import {useAgeAssuranceDataContext} from '#/ageAssurance/data'
+import {
+  AgeAssuranceDataProvider,
+  useAgeAssuranceDataContext,
+} from '#/ageAssurance/data'
 import {logger} from '#/ageAssurance/logger'
 import {
   useAgeAssuranceState,

--- a/src/view/shell/bottom-bar/BottomBar.tsx
+++ b/src/view/shell/bottom-bar/BottomBar.tsx
@@ -215,7 +215,9 @@ export function BottomBar({navigation}: BottomTabBarProps) {
                 )
               }
               onPress={onPressMessages}
-              notificationCount={numUnreadMessages.numUnread}
+              notificationCount={
+                aa.flags.chatDisabled ? undefined : numUnreadMessages.numUnread
+              }
               hasNew={aa.flags.chatDisabled ? false : numUnreadMessages.hasNew}
               accessible={true}
               accessibilityRole="tab"

--- a/src/view/shell/bottom-bar/BottomBarWeb.tsx
+++ b/src/view/shell/bottom-bar/BottomBarWeb.tsx
@@ -43,6 +43,7 @@ import {
   Message_Stroke2_Corner0_Rounded_Filled as MessageFilled,
 } from '#/components/icons/Message'
 import {Text} from '#/components/Typography'
+import {useAgeAssurance} from '#/ageAssurance'
 import {styles} from './BottomBarStyles'
 
 export function BottomBarWeb() {
@@ -60,6 +61,7 @@ export function BottomBarWeb() {
 
   const unreadMessageCount = useUnreadMessageCount()
   const notificationCountStr = useUnreadNotifications()
+  const aa = useAgeAssurance()
 
   const showSignIn = React.useCallback(() => {
     closeAllActiveElements()
@@ -124,8 +126,14 @@ export function BottomBarWeb() {
                 <NavItem
                   routeName="Messages"
                   href="/messages"
-                  notificationCount={unreadMessageCount.numUnread}
-                  hasNew={unreadMessageCount.hasNew}>
+                  notificationCount={
+                    aa.flags.chatDisabled
+                      ? undefined
+                      : unreadMessageCount.numUnread
+                  }
+                  hasNew={
+                    aa.flags.chatDisabled ? false : unreadMessageCount.hasNew
+                  }>
                   {({isActive}) => {
                     const Icon = isActive ? MessageFilled : Message
                     return (

--- a/src/view/shell/desktop/LeftNav.tsx
+++ b/src/view/shell/desktop/LeftNav.tsx
@@ -74,6 +74,7 @@ import {CENTER_COLUMN_OFFSET} from '#/components/Layout'
 import * as Menu from '#/components/Menu'
 import * as Prompt from '#/components/Prompt'
 import {Text} from '#/components/Typography'
+import {useAgeAssurance} from '#/ageAssurance'
 import {useActorStatus} from '#/features/liveNow'
 import {PlatformInfo} from '../../../../modules/expo-bluesky-swiss-army'
 import {router} from '../../../routes'
@@ -349,7 +350,7 @@ function SwitchMenuItem({
           '@',
         )}`,
       )}
-      onPress={() => onPressSwitchAccount(account, 'SwitchAccount')}>
+      onPress={() => void onPressSwitchAccount(account, 'SwitchAccount')}>
       <View>
         <UserAvatar
           avatar={profile?.avatar}
@@ -572,7 +573,7 @@ function ComposeBtn() {
       <Button
         disabled={isFetchingHandle}
         label={_(msg`Compose new post`)}
-        onPress={onPressCompose}
+        onPress={() => void onPressCompose()}
         size="large"
         variant="solid"
         color="primary"
@@ -590,12 +591,13 @@ function ChatNavItem() {
   const pal = usePalette('default')
   const {_} = useLingui()
   const numUnreadMessages = useUnreadMessageCount()
+  const aa = useAgeAssurance()
 
   return (
     <NavItem
       href="/messages"
-      count={numUnreadMessages.numUnread}
-      hasNew={numUnreadMessages.hasNew}
+      count={aa.flags.chatDisabled ? undefined : numUnreadMessages.numUnread}
+      hasNew={aa.flags.chatDisabled ? false : numUnreadMessages.hasNew}
       icon={
         <Message style={pal.text} aria-hidden={true} width={NAV_ICON_WIDTH} />
       }


### PR DESCRIPTION
Age-restricted viewers can’t access chat, so this notification badge isn’t actionable and can’t be dismissed.