### PR TITLE
Use proper constants.ts exports for Edit Profile Dialog limits

### DIFF
--- a/src/screens/Profile/Header/EditProfileDialog.tsx
+++ b/src/screens/Profile/Header/EditProfileDialog.tsx
@@ -5,7 +5,7 @@ import {msg} from '@lingui/core/macro'
 import {useLingui} from '@lingui/react'
 import {Plural, Trans} from '@lingui/react/macro'
 
-import {urls} from '#/lib/constants'
+import {MAX_DESCRIPTION, MAX_DISPLAY_NAME, urls} from '#/lib/constants'
 import {cleanError} from '#/lib/strings/errors'
 import {isOverMaxGraphemeCount} from '#/lib/strings/helpers'
 import {logger} from '#/logger'
@@ -25,9 +25,6 @@ import * as Prompt from '#/components/Prompt'
 import * as Toast from '#/components/Toast'
 import {Text} from '#/components/Typography'
 import {useSimpleVerificationState} from '#/components/verification'
-
-const DISPLAY_NAME_MAX_GRAPHEMES = 64
-const DESCRIPTION_MAX_GRAPHEMES = 256
 
 export function EditProfileDialog({
   profile,
@@ -205,11 +202,11 @@ function DialogInner({
 
   const displayNameTooLong = isOverMaxGraphemeCount({
     text: displayName,
-    maxCount: DISPLAY_NAME_MAX_GRAPHEMES,
+    maxCount: MAX_DISPLAY_NAME,
   })
   const descriptionTooLong = isOverMaxGraphemeCount({
     text: description,
-    maxCount: DESCRIPTION_MAX_GRAPHEMES,
+    maxCount: MAX_DESCRIPTION,
   })
 
   const cancelButton = useCallback(
@@ -330,7 +327,7 @@ function DialogInner({
                 {color: t.palette.negative_400},
               ]}>
               <Plural
-                value={DISPLAY_NAME_MAX_GRAPHEMES}
+                value={MAX_DISPLAY_NAME}
                 other="Display name is too long. The maximum number of characters is #."
               />
             </Text>
@@ -381,7 +378,7 @@ function DialogInner({
                 {color: t.palette.negative_400},
               ]}>
               <Plural
-                value={DESCRIPTION_MAX_GRAPHEMES}
+                value={MAX_DESCRIPTION}
                 other="Description is too long. The maximum number of characters is #."
               />
             </Text>


### PR DESCRIPTION
Currently EditProfileDialog.tsx specifies its own constant for the max display name and description values

This changes that to use the pre-existing MAX_DISPLAY_NAME & MAX_DESCRIPTION exports from constants.ts 🐙