### PR TITLE
feat: hide reposts from specific users in Following feed

### DIFF
--- a/src/Navigation.tsx
+++ b/src/Navigation.tsx
@@ -108,6 +108,7 @@ import {ContentAndMediaSettingsScreen} from '#/screens/Settings/ContentAndMediaS
 import {ExternalMediaPreferencesScreen} from '#/screens/Settings/ExternalMediaPreferences'
 import {FindContactsSettingsScreen} from '#/screens/Settings/FindContactsSettings'
 import {FollowingFeedPreferencesScreen} from '#/screens/Settings/FollowingFeedPreferences'
+import {HiddenRepostsFromScreen} from '#/screens/Settings/HiddenRepostsFrom'
 import {InterestsSettingsScreen} from '#/screens/Settings/InterestsSettings'
 import {LanguageSettingsScreen} from '#/screens/Settings/LanguageSettings'
 import {LegacyNotificationSettingsScreen} from '#/screens/Settings/LegacyNotificationSettings'
@@ -364,6 +365,14 @@ function commonScreens(Stack: typeof Flat, unreadCountLabel?: string) {
         getComponent={() => FollowingFeedPreferencesScreen}
         options={{
           title: title(msg`Following Feed Preferences`),
+          requireAuth: true,
+        }}
+      />
+      <Stack.Screen
+        name="HiddenRepostsFrom"
+        getComponent={() => HiddenRepostsFromScreen}
+        options={{
+          title: title(msg`Hidden Reposts`),
           requireAuth: true,
         }}
       />

--- a/src/lib/api/feed-manip.ts
+++ b/src/lib/api/feed-manip.ts
@@ -335,6 +335,27 @@ export class FeedTuner {
     return slices
   }
 
+  static removeRepostsFrom(dids: Set<string>) {
+    return (
+      tuner: FeedTuner,
+      slices: FeedViewPostsSlice[],
+      _dryRun: boolean,
+    ): FeedViewPostsSlice[] => {
+      for (let i = 0; i < slices.length; i++) {
+        const slice = slices[i]
+        if (
+          slice.isRepost &&
+          AppBskyFeedDefs.isReasonRepost(slice._feedPost.reason) &&
+          dids.has(slice._feedPost.reason.by.did)
+        ) {
+          slices.splice(i, 1)
+          i--
+        }
+      }
+      return slices
+    }
+  }
+
   static removeQuotePosts(
     tuner: FeedTuner,
     slices: FeedViewPostsSlice[],

--- a/src/lib/routes/types.ts
+++ b/src/lib/routes/types.ts
@@ -45,6 +45,7 @@ export type CommonNavigatorParams = {
   AppPasswords: undefined
   SavedFeeds: undefined
   PreferencesFollowingFeed: undefined
+  HiddenRepostsFrom: undefined
   PreferencesThreads: undefined
   PreferencesExternalEmbeds: undefined
   AccessibilitySettings: undefined

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -44,6 +44,7 @@ export const router = new Router<AllNavigatableRoutes>({
   LanguageSettings: '/settings/language',
   AppPasswords: '/settings/app-passwords',
   PreferencesFollowingFeed: '/settings/following-feed',
+  HiddenRepostsFrom: '/settings/hidden-reposts',
   PreferencesThreads: '/settings/threads',
   PreferencesExternalEmbeds: '/settings/external-embeds',
   AccessibilitySettings: '/settings/accessibility',

--- a/src/screens/Settings/FollowingFeedPreferences.tsx
+++ b/src/screens/Settings/FollowingFeedPreferences.tsx
@@ -102,6 +102,14 @@ export function FollowingFeedPreferencesScreen({}: Props) {
               <Toggle.Platform />
             </SettingsList.Item>
           </Toggle.Item>
+          <SettingsList.LinkItem
+            to="/settings/hidden-reposts"
+            label={_(msg`Manage hidden reposts`)}>
+            <SettingsList.ItemIcon icon={RepostIcon} />
+            <SettingsList.ItemText>
+              <Trans>Hidden reposts</Trans>
+            </SettingsList.ItemText>
+          </SettingsList.LinkItem>
           <Toggle.Item
             type="checkbox"
             name="show-quotes"

--- a/src/screens/Settings/HiddenRepostsFrom.tsx
+++ b/src/screens/Settings/HiddenRepostsFrom.tsx
@@ -1,0 +1,182 @@
+import {type StyleProp, View, type ViewStyle} from 'react-native'
+import {type AppBskyActorDefs as ActorDefs} from '@atproto/api'
+import {msg} from '@lingui/core/macro'
+import {useLingui} from '@lingui/react'
+import {Trans} from '@lingui/react/macro'
+import {type NativeStackScreenProps} from '@react-navigation/native-stack'
+import {useQueries} from '@tanstack/react-query'
+
+import {type CommonNavigatorParams} from '#/lib/routes/types'
+import {
+  useHiddenRepostsFrom,
+  useHiddenRepostsFromApi,
+} from '#/state/preferences'
+import {useModerationOpts} from '#/state/preferences/moderation-opts'
+import {STALE} from '#/state/queries'
+import {profilesQueryKey} from '#/state/queries/profile'
+import {useAgent} from '#/state/session'
+import {List} from '#/view/com/util/List'
+import {atoms as a, useTheme} from '#/alf'
+import {Button, ButtonText} from '#/components/Button'
+import * as Layout from '#/components/Layout'
+import * as ProfileCard from '#/components/ProfileCard'
+import {Text} from '#/components/Typography'
+
+const BATCH_SIZE = 25
+
+type Props = NativeStackScreenProps<CommonNavigatorParams, 'HiddenRepostsFrom'>
+
+export function HiddenRepostsFromScreen({}: Props) {
+  const {_} = useLingui()
+  const t = useTheme()
+  const agent = useAgent()
+  const moderationOpts = useModerationOpts()
+  const hiddenRepostsFrom = useHiddenRepostsFrom()
+  const {unhideRepostsFrom} = useHiddenRepostsFromApi()
+  const dids = hiddenRepostsFrom ?? []
+
+  // Batch DIDs into chunks of 25 (API limit for getProfiles)
+  const batches: string[][] = []
+  for (let i = 0; i < dids.length; i += BATCH_SIZE) {
+    batches.push(dids.slice(i, i + BATCH_SIZE))
+  }
+
+  const batchQueries = useQueries({
+    queries: batches.map(batch => ({
+      queryKey: profilesQueryKey(batch),
+      queryFn: async () => {
+        const res = await agent.getProfiles({actors: batch})
+        return res.data
+      },
+      staleTime: STALE.MINUTES.FIVE,
+    })),
+  })
+
+  const profiles = batchQueries.flatMap(q => q.data?.profiles ?? [])
+
+  const renderItem = ({
+    item,
+    index,
+  }: {
+    item: ActorDefs.ProfileViewDetailed
+    index: number
+  }) => {
+    if (!moderationOpts) return null
+    return (
+      <View
+        style={[a.py_md, a.px_xl, a.border_t, t.atoms.border_contrast_low]}
+        key={item.did}>
+        <ProfileCard.Link
+          profile={item}
+          testID={`hiddenRepostAccount-${index}`}>
+          <ProfileCard.Outer>
+            <ProfileCard.Header>
+              <ProfileCard.Avatar
+                profile={item}
+                moderationOpts={moderationOpts}
+              />
+              <ProfileCard.NameAndHandle
+                profile={item}
+                moderationOpts={moderationOpts}
+              />
+              <Button
+                label={_(msg`Show reposts`)}
+                size="small"
+                variant="solid"
+                color="secondary"
+                onPress={e => {
+                  e.preventDefault()
+                  e.stopPropagation()
+                  unhideRepostsFrom({did: item.did})
+                }}>
+                <ButtonText>
+                  <Trans>Unhide</Trans>
+                </ButtonText>
+              </Button>
+            </ProfileCard.Header>
+          </ProfileCard.Outer>
+        </ProfileCard.Link>
+      </View>
+    )
+  }
+
+  return (
+    <Layout.Screen testID="hiddenRepostsFromScreen">
+      <Layout.Header.Outer>
+        <Layout.Header.BackButton />
+        <Layout.Header.Content>
+          <Layout.Header.TitleText>
+            <Trans>Hidden Reposts</Trans>
+          </Layout.Header.TitleText>
+        </Layout.Header.Content>
+        <Layout.Header.Slot />
+      </Layout.Header.Outer>
+      {dids.length === 0 ? (
+        <Layout.Content>
+          <Info />
+          <Empty />
+        </Layout.Content>
+      ) : (
+        <Layout.Center>
+          <List
+            data={profiles}
+            keyExtractor={item => item.did}
+            renderItem={renderItem}
+            initialNumToRender={15}
+            ListHeaderComponent={Info}
+          />
+        </Layout.Center>
+      )}
+    </Layout.Screen>
+  )
+}
+
+function Empty() {
+  const t = useTheme()
+  return (
+    <View style={[a.pt_2xl, a.px_xl, a.align_center]}>
+      <View
+        style={[
+          a.py_md,
+          a.px_lg,
+          a.rounded_sm,
+          t.atoms.bg_contrast_25,
+          a.border,
+          t.atoms.border_contrast_low,
+          {maxWidth: 400},
+        ]}>
+        <Text style={[a.text_sm, a.text_center, t.atoms.text_contrast_high]}>
+          <Trans>
+            You haven't hidden reposts from any accounts yet. To hide reposts,
+            go to a user's profile and select "Hide reposts" from their profile
+            menu.
+          </Trans>
+        </Text>
+      </View>
+    </View>
+  )
+}
+
+function Info({style}: {style?: StyleProp<ViewStyle>}) {
+  const t = useTheme()
+  return (
+    <View
+      style={[
+        a.w_full,
+        t.atoms.bg_contrast_25,
+        a.py_md,
+        a.px_xl,
+        a.border_t,
+        {marginTop: a.border.borderWidth * -1},
+        t.atoms.border_contrast_low,
+        style,
+      ]}>
+      <Text style={[a.text_center, a.text_sm, t.atoms.text_contrast_high]}>
+        <Trans>
+          Reposts from these accounts are hidden in your Following feed. Their
+          original posts will still appear.
+        </Trans>
+      </Text>
+    </View>
+  )
+}

--- a/src/state/persisted/schema.ts
+++ b/src/state/persisted/schema.ts
@@ -116,6 +116,7 @@ const schema = z.object({
     step: z.string(),
   }),
   hiddenPosts: z.array(z.string()).optional(), // should move to server
+  hiddenRepostsFrom: z.array(z.string()).optional(), // should move to server
   useInAppBrowser: z.boolean().optional(),
   /** @deprecated */
   lastSelectedHomeFeed: z.string().optional(),
@@ -166,6 +167,7 @@ export const defaults: Schema = {
     step: 'Home',
   },
   hiddenPosts: [],
+  hiddenRepostsFrom: [],
   useInAppBrowser: undefined,
   lastSelectedHomeFeed: undefined,
   pdsAddressHistory: [],

--- a/src/state/preferences/feed-tuners.tsx
+++ b/src/state/preferences/feed-tuners.tsx
@@ -4,12 +4,14 @@ import {FeedTuner} from '#/lib/api/feed-manip'
 import {type FeedDescriptor} from '../queries/post-feed'
 import {usePreferencesQuery} from '../queries/preferences'
 import {useSession} from '../session'
+import {useHiddenRepostsFrom} from './hidden-reposts-from'
 import {useLanguagePrefs} from './languages'
 
 export function useFeedTuners(feedDesc: FeedDescriptor) {
   const langPrefs = useLanguagePrefs()
   const {data: preferences} = usePreferencesQuery()
   const {currentAccount} = useSession()
+  const hiddenRepostsFrom = useHiddenRepostsFrom()
 
   return useMemo(() => {
     if (feedDesc.startsWith('author')) {
@@ -27,6 +29,9 @@ export function useFeedTuners(feedDesc: FeedDescriptor) {
     if (feedDesc === 'following' || feedDesc.startsWith('list')) {
       const feedTuners = [FeedTuner.removeOrphans]
 
+      if (hiddenRepostsFrom?.length) {
+        feedTuners.push(FeedTuner.removeRepostsFrom(new Set(hiddenRepostsFrom)))
+      }
       if (preferences?.feedViewPrefs.hideReposts) {
         feedTuners.push(FeedTuner.removeReposts)
       }
@@ -48,5 +53,5 @@ export function useFeedTuners(feedDesc: FeedDescriptor) {
       return feedTuners
     }
     return []
-  }, [feedDesc, currentAccount, preferences, langPrefs])
+  }, [feedDesc, currentAccount, preferences, langPrefs, hiddenRepostsFrom])
 }

--- a/src/state/preferences/hidden-reposts-from.tsx
+++ b/src/state/preferences/hidden-reposts-from.tsx
@@ -1,0 +1,74 @@
+import React from 'react'
+
+import * as persisted from '#/state/persisted'
+
+export const MAX_HIDDEN_REPOST_ACCOUNTS = 200
+
+type SetStateCb = (
+  s: persisted.Schema['hiddenRepostsFrom'],
+) => persisted.Schema['hiddenRepostsFrom']
+type StateContext = persisted.Schema['hiddenRepostsFrom']
+type ApiContext = {
+  hideRepostsFrom: ({did}: {did: string}) => boolean
+  unhideRepostsFrom: ({did}: {did: string}) => void
+}
+
+const stateContext = React.createContext<StateContext>(
+  persisted.defaults.hiddenRepostsFrom,
+)
+stateContext.displayName = 'HiddenRepostsFromStateContext'
+const apiContext = React.createContext<ApiContext>({
+  hideRepostsFrom: () => false,
+  unhideRepostsFrom: () => {},
+})
+apiContext.displayName = 'HiddenRepostsFromApiContext'
+
+export function Provider({children}: React.PropsWithChildren<{}>) {
+  const [state, setState] = React.useState(persisted.get('hiddenRepostsFrom'))
+
+  const setStateWrapped = React.useCallback(
+    (fn: SetStateCb) => {
+      const s = fn(persisted.get('hiddenRepostsFrom'))
+      setState(s)
+      persisted.write('hiddenRepostsFrom', s)
+    },
+    [setState],
+  )
+
+  const api = React.useMemo(
+    () => ({
+      hideRepostsFrom: ({did}: {did: string}): boolean => {
+        const current = persisted.get('hiddenRepostsFrom') || []
+        if (current.length >= MAX_HIDDEN_REPOST_ACCOUNTS) {
+          return false
+        }
+        setStateWrapped(s => [...(s || []), did])
+        return true
+      },
+      unhideRepostsFrom: ({did}: {did: string}) => {
+        setStateWrapped(s => (s || []).filter(d => d !== did))
+      },
+    }),
+    [setStateWrapped],
+  )
+
+  React.useEffect(() => {
+    return persisted.onUpdate('hiddenRepostsFrom', nextHiddenRepostsFrom => {
+      setState(nextHiddenRepostsFrom)
+    })
+  }, [setStateWrapped])
+
+  return (
+    <stateContext.Provider value={state}>
+      <apiContext.Provider value={api}>{children}</apiContext.Provider>
+    </stateContext.Provider>
+  )
+}
+
+export function useHiddenRepostsFrom() {
+  return React.useContext(stateContext)
+}
+
+export function useHiddenRepostsFromApi() {
+  return React.useContext(apiContext)
+}

--- a/src/state/preferences/index.tsx
+++ b/src/state/preferences/index.tsx
@@ -3,6 +3,7 @@ import {Provider as AutoplayProvider} from './autoplay'
 import {Provider as DisableHapticsProvider} from './disable-haptics'
 import {Provider as ExternalEmbedsProvider} from './external-embeds-prefs'
 import {Provider as HiddenPostsProvider} from './hidden-posts'
+import {Provider as HiddenRepostsFromProvider} from './hidden-reposts-from'
 import {Provider as InAppBrowserProvider} from './in-app-browser'
 import {Provider as KawaiiProvider} from './kawaii'
 import {Provider as LanguagesProvider} from './languages'
@@ -22,6 +23,10 @@ export {
   useSetExternalEmbedPref,
 } from './external-embeds-prefs'
 export {useHiddenPosts, useHiddenPostsApi} from './hidden-posts'
+export {
+  useHiddenRepostsFrom,
+  useHiddenRepostsFromApi,
+} from './hidden-reposts-from'
 export {useLabelDefinitions} from './label-defs'
 export {useLanguagePrefs, useLanguagePrefsApi} from './languages'
 export {useSetSubtitlesEnabled, useSubtitlesEnabled} from './subtitles'
@@ -33,19 +38,21 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
         <LargeAltBadgeProvider>
           <ExternalEmbedsProvider>
             <HiddenPostsProvider>
-              <InAppBrowserProvider>
-                <DisableHapticsProvider>
-                  <AutoplayProvider>
-                    <UsedStarterPacksProvider>
-                      <SubtitlesProvider>
-                        <TrendingSettingsProvider>
-                          <KawaiiProvider>{children}</KawaiiProvider>
-                        </TrendingSettingsProvider>
-                      </SubtitlesProvider>
-                    </UsedStarterPacksProvider>
-                  </AutoplayProvider>
-                </DisableHapticsProvider>
-              </InAppBrowserProvider>
+              <HiddenRepostsFromProvider>
+                <InAppBrowserProvider>
+                  <DisableHapticsProvider>
+                    <AutoplayProvider>
+                      <UsedStarterPacksProvider>
+                        <SubtitlesProvider>
+                          <TrendingSettingsProvider>
+                            <KawaiiProvider>{children}</KawaiiProvider>
+                          </TrendingSettingsProvider>
+                        </SubtitlesProvider>
+                      </UsedStarterPacksProvider>
+                    </AutoplayProvider>
+                  </DisableHapticsProvider>
+                </InAppBrowserProvider>
+              </HiddenRepostsFromProvider>
             </HiddenPostsProvider>
           </ExternalEmbedsProvider>
         </LargeAltBadgeProvider>

--- a/src/view/com/profile/ProfileMenu.tsx
+++ b/src/view/com/profile/ProfileMenu.tsx
@@ -13,6 +13,10 @@ import {shareText, shareUrl} from '#/lib/sharing'
 import {toShareUrl} from '#/lib/strings/url-helpers'
 import {type Shadow} from '#/state/cache/types'
 import {useModalControls} from '#/state/modals'
+import {
+  useHiddenRepostsFrom,
+  useHiddenRepostsFromApi,
+} from '#/state/preferences'
 import {Nux, useNux, useSaveNux} from '#/state/queries/nuxs'
 import {
   RQKEY as profileQueryKey,
@@ -43,6 +47,7 @@ import {
   PersonX_Stroke2_Corner0_Rounded as PersonX,
 } from '#/components/icons/Person'
 import {PlusLarge_Stroke2_Corner0_Rounded as Plus} from '#/components/icons/Plus'
+import {Repost_Stroke2_Corner2_Rounded as RepostIcon} from '#/components/icons/Repost'
 import {SpeakerVolumeFull_Stroke2_Corner0_Rounded as Unmute} from '#/components/icons/Speaker'
 import {StarterPack} from '#/components/icons/StarterPack'
 import * as Menu from '#/components/Menu'
@@ -94,6 +99,10 @@ let ProfileMenu = ({
     statusNudge.status === 'ready' &&
     !statusNudge.nux?.completed
   const {mutate: saveNux} = useSaveNux()
+
+  const hiddenRepostsFrom = useHiddenRepostsFrom()
+  const {hideRepostsFrom, unhideRepostsFrom} = useHiddenRepostsFromApi()
+  const isHidingReposts = hiddenRepostsFrom?.includes(profile.did) ?? false
 
   const [queueMute, queueUnmute] = useProfileMuteMutationQueue(profile)
   const [queueBlock, queueUnblock] = useProfileBlockMutationQueue(profile)
@@ -224,6 +233,28 @@ let ProfileMenu = ({
       }
     }
   }, [_, ax, queueUnfollow])
+
+  const onPressToggleHideReposts = () => {
+    if (isHidingReposts) {
+      unhideRepostsFrom({did: profile.did})
+      Toast.show(_(msg({message: 'Reposts unhidden', context: 'toast'})))
+    } else {
+      const success = hideRepostsFrom({did: profile.did})
+      if (success) {
+        Toast.show(_(msg({message: 'Reposts hidden', context: 'toast'})))
+      } else {
+        Toast.show(
+          _(
+            msg({
+              message: `Limit reached for hidden reposts. Unhide some accounts, or turn off all reposts in settings.`,
+              context: 'toast',
+            }),
+          ),
+          'xmark',
+        )
+      }
+    }
+  }
 
   const onPressReportAccount = useCallback(() => {
     reportDialogControl.open()
@@ -440,6 +471,25 @@ let ProfileMenu = ({
                   ))}
                 {!isSelf && (
                   <>
+                    {!isBlocked && (
+                      <Menu.Item
+                        testID="profileHeaderDropdownHideRepostsBtn"
+                        label={
+                          isHidingReposts
+                            ? _(msg`Show reposts`)
+                            : _(msg`Hide reposts`)
+                        }
+                        onPress={onPressToggleHideReposts}>
+                        <Menu.ItemText>
+                          {isHidingReposts ? (
+                            <Trans>Show reposts</Trans>
+                          ) : (
+                            <Trans>Hide reposts</Trans>
+                          )}
+                        </Menu.ItemText>
+                        <Menu.ItemIcon icon={RepostIcon} />
+                      </Menu.Item>
+                    )}
                     {!profile.viewer?.blocking &&
                       !profile.viewer?.mutedByList && (
                         <Menu.Item


### PR DESCRIPTION
This is the feature I miss most from Twitter. Currently local only, similar to the way hidden posts are currently implemented.

I tested locally and it works for me.

## Summary

Adds the ability to hide reposts from specific users in your Following feed, without muting or unfollowing them.

- **Profile menu**: New "Hide reposts" / "Show reposts" toggle in the profile `...` menu for any non-blocked user
- **Feed filtering**: Client-side filtering via `FeedTuner.removeRepostsFrom()` applied to Following and list feeds
- **Persistence**: Stored locally via the persisted preferences layer (same pattern as `hiddenPosts`), capped at 200 accounts with a user-facing limit message
- **Future**: Marked `// should move to server` — ideally this syncs via AT Protocol preferences so it follows the user across devices

### How it works

1. User taps `...` on a profile → "Hide reposts"
2. DID is added to `hiddenRepostsFrom` in local persisted storage
3. `useFeedTuners` picks up the list and pushes `FeedTuner.removeRepostsFrom(new Set(dids))` into the Following feed pipeline
4. The tuner splices out any `FeedViewPostsSlice` where the repost reason's `by.did` is in the set

### Files changed

| File | What |
|------|------|
| `src/state/persisted/schema.ts` | New `hiddenRepostsFrom` field in persisted schema |
| `src/state/preferences/hidden-reposts-from.tsx` | New Context provider with `hideRepostsFrom`/`unhideRepostsFrom` API |
| `src/state/preferences/index.tsx` | Wire up the new provider and re-export hooks |
| `src/state/preferences/feed-tuners.tsx` | Apply the tuner to Following/list feeds |
| `src/lib/api/feed-manip.ts` | New `FeedTuner.removeRepostsFrom()` static method |
| `src/view/com/profile/ProfileMenu.tsx` | Menu item UI with toggle + toast feedback |

## Test plan

- [ ] Go to a user's profile → `...` menu → "Hide reposts" → toast confirms
- [ ] Return to Following feed → that user's reposts are no longer visible
- [ ] Go back to profile → `...` menu → "Show reposts" → toast confirms
- [ ] Reposts reappear in Following feed
- [ ] Verify it also works on list feeds
- [ ] Hit the 200 account limit → error toast appears
- [ ] Original posts from hidden-repost users still appear (only reposts filtered)
- [ ] Global "hide all reposts" setting still works independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)