### PR TITLE
Add KnownFollowers to follow suggestion cards

### DIFF
--- a/src/components/FeedInterstitials.tsx
+++ b/src/components/FeedInterstitials.tsx
@@ -37,6 +37,10 @@ import * as FeedCard from '#/components/FeedCard'
 import {ArrowRight_Stroke2_Corner0_Rounded as ArrowRight} from '#/components/icons/Arrow'
 import {Hashtag_Stroke2_Corner0_Rounded as Hashtag} from '#/components/icons/Hashtag'
 import {TimesLarge_Stroke2_Corner0_Rounded as X} from '#/components/icons/Times'
+import {
+  KnownFollowers,
+  shouldShowKnownFollowers,
+} from '#/components/KnownFollowers'
 import {InlineLinkText} from '#/components/Link'
 import * as ProfileCard from '#/components/ProfileCard'
 import {Text} from '#/components/Typography'
@@ -503,6 +507,16 @@ export function ProfileGrid({
                         />
                       </View>
                     </View>
+
+                    {shouldShowKnownFollowers(
+                      profile.actor.viewer?.knownFollowers,
+                    ) && (
+                      <KnownFollowers
+                        profile={profile.actor}
+                        moderationOpts={moderationOpts}
+                        minimal
+                      />
+                    )}
 
                     <ProfileCard.FollowButton
                       profile={profile.actor}


### PR DESCRIPTION
## Summary
- Show known followers on each suggested profile card in the `ProfileGrid` component
- Uses compact/minimal display, positioned between profile description and follow button
- Only renders when the profile has known followers data

## Dependencies
- Depends on https://github.com/bluesky-social/atproto/pull/4767

## Test plan
- [ ] Verify known followers appear on suggestion cards when data is available
- [ ] Verify cards without known followers render unchanged
- [ ] Test on mobile (horizontal scroll) and desktop (grid layout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)