### PR TITLE
Ensure mute state stays in sync after mutation

### DIFF
--- a/src/state/messages/convo/agent.ts
+++ b/src/state/messages/convo/agent.ts
@@ -850,6 +850,16 @@ export class Convo {
     this.commit()
   }
 
+  updateMuted(muted: boolean) {
+    if (this.convo) {
+      this.convo = {
+        ...this.convo,
+        muted,
+      }
+    }
+    this.commit()
+  }
+
   async processPendingMessages() {
     logger.debug(
       `processing messages (${this.pendingMessages.size} remaining)`,

--- a/src/state/messages/convo/index.tsx
+++ b/src/state/messages/convo/index.tsx
@@ -119,5 +119,20 @@ export function ConvoProvider({
     })
   }, [convo, queryClient])
 
+  useEffect(() => {
+    const [root, id] = getConvoKey(convoId)
+    return queryClient.getQueryCache().subscribe(event => {
+      const queryKey = event.query.queryKey as string[]
+      if (queryKey[0] === root && queryKey[1] === id) {
+        const data = event.query.state.data as
+          | ChatBskyConvoDefs.ConvoView
+          | undefined
+        if (data && convo.convo && data.muted !== convo.convo.muted) {
+          convo.updateMuted(data.muted)
+        }
+      }
+    })
+  }, [convo, convoId, queryClient])
+
   return <ChatContext.Provider value={service}>{children}</ChatContext.Provider>
 }

--- a/src/state/queries/messages/mute-conversation.ts
+++ b/src/state/queries/messages/mute-conversation.ts
@@ -44,39 +44,62 @@ export function useMuteConvo(
         return data
       }
     },
-    onSuccess: (data, params) => {
+    onMutate: ({mute}) => {
+      if (!convoId) return
+
+      const prevConvo = queryClient.getQueryData<ChatBskyConvoDefs.ConvoView>(
+        CONVO_KEY(convoId),
+      )
+      const prevListEntries = queryClient.getQueriesData<
+        InfiniteData<ChatBskyConvoListConvos.OutputSchema>
+      >({queryKey: [CONVO_LIST_KEY]})
+
+      // Update for a single chat thread
       queryClient.setQueryData<ChatBskyConvoDefs.ConvoView>(
-        CONVO_KEY(data.convo.id),
+        CONVO_KEY(convoId),
         prev => {
           if (!prev) return
           return {
             ...prev,
-            muted: params.mute,
+            muted: mute,
           }
         },
       )
-      queryClient.setQueryData<
+
+      // Update for the chat list
+      queryClient.setQueriesData<
         InfiniteData<ChatBskyConvoListConvos.OutputSchema>
-      >([CONVO_LIST_KEY], prev => {
+      >({queryKey: [CONVO_LIST_KEY]}, prev => {
         if (!prev?.pages) return
         return {
           ...prev,
           pages: prev.pages.map(page => ({
             ...page,
             convos: page.convos.map(convo => {
-              if (convo.id !== data.convo.id) return convo
+              if (convo.id !== convoId) return convo
               return {
                 ...convo,
-                muted: params.mute,
+                muted: mute,
               }
             }),
           })),
         }
       })
 
+      return {prevConvo, prevListEntries}
+    },
+    onSuccess: data => {
       onSuccess?.(data)
     },
-    onError: e => {
+    onError: (e, _variables, context) => {
+      if (context?.prevConvo && convoId) {
+        queryClient.setQueryData(CONVO_KEY(convoId), context.prevConvo)
+      }
+      if (context?.prevListEntries) {
+        for (const [key, data] of context.prevListEntries) {
+          queryClient.setQueryData(key, data)
+        }
+      }
       onError?.(e)
     },
   })


### PR DESCRIPTION
The bell icon in the chat list and header wasn’t updating when muting/unmuting a conversation until after a hard refresh.

This [optimistically updates](https://tanstack.com/query/latest/docs/framework/react/guides/optimistic-updates#via-the-cache) the query cache after the mutation, with rollback in case it fails. It then uses the optimistic value in `ChatContext`, keeping that as the source of truth for the `mute` value via `useConvo()`. Notably, this means no changes were required to `MessagesListHeader.tsx` or `ChatListItem.tsx`.

The icon now updates properly:

https://github.com/user-attachments/assets/52dd4573-6474-4c11-b099-fff6766f9d8c

Tested on Android (device), iOS (simulator), and web.