### PR TITLE
Bump keyboard controller and add missing provider on web

### DIFF
--- a/package.json
+++ b/package.json
@@ -209,7 +209,7 @@
     "react-native-drawer-layout": "^4.2.2",
     "react-native-edge-to-edge": "^1.6.0",
     "react-native-gesture-handler": "~2.28.0",
-    "react-native-keyboard-controller": "^1.20.7",
+    "react-native-keyboard-controller": "^1.21.0",
     "react-native-pager-view": "6.8.0",
     "react-native-progress": "bluesky-social/react-native-progress",
     "react-native-qrcode-styled": "^0.3.3",

--- a/src/App.web.tsx
+++ b/src/App.web.tsx
@@ -3,6 +3,7 @@ import '#/view/icons'
 import './style.css'
 
 import {Fragment, useEffect, useState} from 'react'
+import {KeyboardProvider as KeyboardControllerProvider} from 'react-native-keyboard-controller'
 import {SafeAreaProvider} from 'react-native-safe-area-context'
 import {msg} from '@lingui/core/macro'
 import {useLingui} from '@lingui/react'
@@ -211,29 +212,31 @@ function App() {
     <Geo.Provider>
       <AppConfigProvider>
         <A11yProvider>
-          <OnboardingProvider>
-            <AnalyticsContext>
-              <SessionProvider>
-                <PrefsStateProvider>
-                  <I18nProvider>
-                    <ShellStateProvider>
-                      <ModalStateProvider>
-                        <DialogStateProvider>
-                          <LightboxStateProvider>
-                            <PortalProvider>
-                              <StarterPackProvider>
-                                <InnerApp />
-                              </StarterPackProvider>
-                            </PortalProvider>
-                          </LightboxStateProvider>
-                        </DialogStateProvider>
-                      </ModalStateProvider>
-                    </ShellStateProvider>
-                  </I18nProvider>
-                </PrefsStateProvider>
-              </SessionProvider>
-            </AnalyticsContext>
-          </OnboardingProvider>
+          <KeyboardControllerProvider>
+            <OnboardingProvider>
+              <AnalyticsContext>
+                <SessionProvider>
+                  <PrefsStateProvider>
+                    <I18nProvider>
+                      <ShellStateProvider>
+                        <ModalStateProvider>
+                          <DialogStateProvider>
+                            <LightboxStateProvider>
+                              <PortalProvider>
+                                <StarterPackProvider>
+                                  <InnerApp />
+                                </StarterPackProvider>
+                              </PortalProvider>
+                            </LightboxStateProvider>
+                          </DialogStateProvider>
+                        </ModalStateProvider>
+                      </ShellStateProvider>
+                    </I18nProvider>
+                  </PrefsStateProvider>
+                </SessionProvider>
+              </AnalyticsContext>
+            </OnboardingProvider>
+          </KeyboardControllerProvider>
         </A11yProvider>
       </AppConfigProvider>
     </Geo.Provider>

--- a/yarn.lock
+++ b/yarn.lock
@@ -14343,10 +14343,10 @@ react-native-is-edge-to-edge@^1.2.1:
   resolved "https://registry.yarnpkg.com/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.2.1.tgz#64e10851abd9d176cbf2b40562f751622bde3358"
   integrity sha512-FLbPWl/MyYQWz+KwqOZsSyj2JmLKglHatd3xLZWskXOpRaio4LfEDEz8E/A6uD8QoTHW6Aobw1jbEwK7KMgR7Q==
 
-react-native-keyboard-controller@^1.20.7:
-  version "1.20.7"
-  resolved "https://registry.yarnpkg.com/react-native-keyboard-controller/-/react-native-keyboard-controller-1.20.7.tgz#e1be1c15a5eb10b96a40a0812d8472e6e4bd8f29"
-  integrity sha512-G8S5jz1FufPrcL1vPtReATx+jJhT/j+sTqxMIb30b1z7cYEfMlkIzOCyaHgf6IMB2KA9uBmnA5M6ve2A9Ou4kw==
+react-native-keyboard-controller@^1.21.0:
+  version "1.21.0"
+  resolved "https://registry.yarnpkg.com/react-native-keyboard-controller/-/react-native-keyboard-controller-1.21.0.tgz#79ad48c67e6f5ec572b7dc896c7b05a98662a2a2"
+  integrity sha512-mLHJysehhSzYoM8BAD2DSjVZEcF69t16ZCJrCAos6sfVtbB3tL+kgGZFX+jNVz/f9BEhqnBFO0EA1tc/V6Hkgw==
   dependencies:
     react-native-is-edge-to-edge "^1.2.1"
 


### PR DESCRIPTION
Bumps keyboard controller since there was a bugfix release, and adds the provider to web.

The motivation here was fixing an error I noticed when clicking "Edit" on one of my starter packs `PromiseResolve called on non-object`. This occurs in prod as well, and points to [this call](https://github.com/kirillzyusko/react-native-keyboard-controller/blob/ecd3bbd8e337cfde910fb4cedd0319e0503448f2/src/components/KeyboardAwareScrollView/index.tsx#L502), which is acting on the [default context](https://github.com/kirillzyusko/react-native-keyboard-controller/blob/ecd3bbd8e337cfde910fb4cedd0319e0503448f2/src/context.ts#L76) since we didn't have a provider in there. You can repro this really easily, so technically kind of a bug in the library, but we're also using it wrong. Their example app is web and native and has a [provider in the root.](https://github.com/kirillzyusko/react-native-keyboard-controller/blob/ecd3bbd8e337cfde910fb4cedd0319e0503448f2/example/src/App.tsx)

<img width="882" height="260" alt="CleanShot 2026-03-18 at 15 30 44" src="https://github.com/user-attachments/assets/c3150860-f25c-4bdd-a4fa-7a9b9e5c6dbf" />

I don't know if there's history here or why this was missing, but adding the provider both avoids this error being throw and improves the experience significantly. I've tested this on desktop and mobile web (iOS).