### PR TITLE
fix: escape user content in profile JSON-LD to prevent malformed JSON

### DIFF
--- a/bskyweb/cmd/bskyweb/filters.go
+++ b/bskyweb/cmd/bskyweb/filters.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"net/url"
 	"strings"
 
@@ -10,6 +11,7 @@ import (
 func init() {
 	pongo2.RegisterFilter("canonicalize_url", filterCanonicalizeURL)
 	pongo2.RegisterFilter("avatar_thumbnail", filterAvatarThumbnail)
+	pongo2.RegisterFilter("json_escape", filterJSONEscape)
 }
 
 func filterCanonicalizeURL(in *pongo2.Value, param *pongo2.Value) (*pongo2.Value, *pongo2.Error) {
@@ -32,4 +34,20 @@ func filterCanonicalizeURL(in *pongo2.Value, param *pongo2.Value) (*pongo2.Value
 func filterAvatarThumbnail(in *pongo2.Value, param *pongo2.Value) (*pongo2.Value, *pongo2.Error) {
 	urlStr := in.String()
 	return pongo2.AsValue(strings.Replace(urlStr, "/img/avatar/plain/", "/img/avatar_thumbnail/plain/", 1)), nil
+}
+
+// filterJSONEscape escapes a string value for safe embedding inside a JSON
+// string literal. It uses encoding/json.Marshal to handle newlines, quotes,
+// backslashes, and other special characters, then strips the surrounding
+// quotes that Marshal adds.
+func filterJSONEscape(in *pongo2.Value, param *pongo2.Value) (*pongo2.Value, *pongo2.Error) {
+	raw := in.String()
+	b, err := json.Marshal(raw)
+	if err != nil {
+		return in, nil
+	}
+	// json.Marshal wraps the result in double quotes; strip them since the
+	// template already provides surrounding quotes.
+	escaped := string(b[1 : len(b)-1])
+	return pongo2.AsSafeValue(escaped), nil
 }

--- a/bskyweb/templates/profile.html
+++ b/bskyweb/templates/profile.html
@@ -60,13 +60,13 @@
     "mainEntity": {
       "@type": "Person",
       {%- if profileView.DisplayName %}
-      "name": "{{ profileView.DisplayName }}",
+      "name": "{{ profileView.DisplayName|json_escape }}",
       "alternateName": "@{{ profileView.Handle }}",
       {% else %}
       "name": "@{{ profileView.Handle }}",
       {% endif -%}
       "identifier": "{{ profileView.Did }}",
-      "description": "{{ profileView.Description }}",
+      "description": "{{ profileView.Description|json_escape }}",
       "image": "{{ profileView.Avatar }}",
       "interactionStatistic": [
         {


### PR DESCRIPTION
## Summary

Fixes #9772

Profile pages with newlines, double quotes, or backslashes in the user's description or display name produce malformed JSON in the `<script type="application/ld+json">` block. This breaks structured data parsing for search engines, social card scrapers, and any tool that tries to consume the ld+json (like [metascraper](https://github.com/microlinkhq/metascraper)).

For example, visiting https://bsky.app/profile/elenatorro.bsky.social produces a `description` value with literal newlines inside a JSON string, which is invalid JSON per the spec.

## Changes

- **`bskyweb/cmd/bskyweb/filters.go`**: Added a `json_escape` pongo2 template filter that uses `encoding/json.Marshal` to properly escape a string for embedding inside a JSON string literal, then strips the outer quotes (since the template already provides them).
- **`bskyweb/templates/profile.html`**: Applied `|json_escape` to `profileView.Description` and `profileView.DisplayName` inside the JSON-LD block.

## Notes

The same issue exists in `post.html` (for `postText` and `postView.Author.DisplayName` in the ld+json block). Happy to add that in a follow-up or in this PR if preferred — kept it scoped to profile for now since that's what #9772 reports.