### PR TITLE
Include recId with log event for suggested profiles

### DIFF
--- a/src/analytics/metrics/types.ts
+++ b/src/analytics/metrics/types.ts
@@ -518,6 +518,7 @@ export type Events = {
       | 'InterstitialProfile'
       | 'Profile'
       | 'Onboarding'
+    recId?: number | string
   }
   'suggestedUser:dismiss': {
     logContext: 'InterstitialDiscover' | 'InterstitialProfile'

--- a/src/components/FeedInterstitials.tsx
+++ b/src/components/FeedInterstitials.tsx
@@ -215,13 +215,14 @@ export function SuggestedFollows({feed}: {feed: FeedDescriptor}) {
 }
 
 export function SuggestedFollowsProfile({did}: {did: string}) {
-  const {profiles, onDismiss, isLoading, error} =
+  const {profiles, recId, onDismiss, isLoading, error} =
     useSuggestedFollowsByActorWithDismiss({did})
 
   return (
     <ProfileGrid
       isSuggestionsLoading={isLoading}
       profiles={profiles}
+      recId={recId}
       error={error}
       viewContext="profile"
       onDismiss={onDismiss}
@@ -275,6 +276,7 @@ export function ProfileGrid({
   isSuggestionsLoading,
   error,
   profiles,
+  recId,
   totalProfileCount,
   viewContext = 'feed',
   onDismiss,
@@ -283,6 +285,7 @@ export function ProfileGrid({
 }: {
   isSuggestionsLoading: boolean
   profiles: {actor: bsky.profile.AnyProfileView; recId?: string}[]
+  recId?: string
   totalProfileCount?: number
   error: Error | null
   viewContext: 'profile' | 'profileHeader' | 'feed'
@@ -572,6 +575,7 @@ export function ProfileGrid({
               followDialogControl.open()
               ax.metric('suggestedUser:seeMore', {
                 logContext: isFeedContext ? 'Explore' : 'Profile',
+                recId,
               })
             }}>
             {({hovered}) => (

--- a/src/state/queries/suggested-follows.ts
+++ b/src/state/queries/suggested-follows.ts
@@ -92,6 +92,7 @@ export function useSuggestedFollowsByActorWithDismiss({
 
   return {
     profiles,
+    recId: data?.recId,
     onDismiss,
     isLoading,
     error,


### PR DESCRIPTION
So we can associate the `suggestedUser:seeMore` event with the other `suggestedUser` events.