### PR TITLE
Fix issue with site loading on older versions of Safari

### DIFF
--- a/src/lib/media/util.ts
+++ b/src/lib/media/util.ts
@@ -36,12 +36,14 @@ export type ImgproxyPreset =
   | 'feed_thumbnail'
   | 'download'
 
+// Using capturing groups here instead of lookbehinds in order to support older versions of Safari.
+// https://bugs.webkit.org/show_bug.cgi?id=174931
 const IMGPROXY_PRESET_RE =
-  /(?<=\/img\/)(default|avatar_thumbnail|avatar|banner|feed_fullsize|feed_thumbnail|download)(?=\/)/
+  /(\/img\/)(default|avatar_thumbnail|avatar|banner|feed_fullsize|feed_thumbnail|download)(\/)/
 
 /**
  * Replaces any imgproxy preset in a CDN URI with the given preset.
  */
 export function convertCdnPreset(uri: string, preset: ImgproxyPreset): string {
-  return uri.replace(IMGPROXY_PRESET_RE, preset)
+  return uri.replace(IMGPROXY_PRESET_RE, `$1${preset}$3`)
 }


### PR DESCRIPTION
Lookbehind assertions [weren’t supported in WebKit](https://bugs.webkit.org/show_bug.cgi?id=174931) until 2023.

This PR updates the `IMGPROXY_PRESET_RE` to use capturing groups instead.

* [Before](https://regex101.com/r/FBq7mG/1)
* [After](https://regex101.com/r/EHTwQn/1)

The site works again on older versions of Safari. Tested on a simulator with iOS 15.5.
