### PR TITLE
Add bookmarks to thread placeholder candidates

### DIFF
--- a/src/state/queries/usePostThread/queryCache.ts
+++ b/src/state/queries/usePostThread/queryCache.ts
@@ -14,6 +14,7 @@ import {
   dangerousGetPostShadow,
   updatePostShadow,
 } from '#/state/cache/post-shadow'
+import {findAllPostsInQueryData as findAllPostsInBookmarksQueryData} from '#/state/queries/bookmarks/useBookmarksQuery'
 import {findAllPostsInQueryData as findAllPostsInExploreFeedPreviewsQueryData} from '#/state/queries/explore-feed-previews'
 import {findAllPostsInQueryData as findAllPostsInNotifsQueryData} from '#/state/queries/notifications/feed'
 import {findAllPostsInQueryData as findAllPostsInFeedQueryData} from '#/state/queries/post-feed'
@@ -30,8 +31,11 @@ import {
 } from '#/state/queries/usePostThread/types'
 import {getRootPostAtUri} from '#/state/queries/usePostThread/utils'
 import {postViewToThreadPlaceholder} from '#/state/queries/usePostThread/views'
-import {didOrHandleUriMatches, getEmbeddedPost} from '#/state/queries/util'
-import {embedViewRecordToPostView} from '#/state/queries/util'
+import {
+  didOrHandleUriMatches,
+  embedViewRecordToPostView,
+  getEmbeddedPost,
+} from '#/state/queries/util'
 
 export function createCacheMutator({
   queryClient,
@@ -256,6 +260,9 @@ export function* getThreadPlaceholderCandidates(
     yield postViewToThreadPlaceholder(post)
   }
   for (let post of findAllPostsInSearchQueryData(queryClient, uri)) {
+    yield postViewToThreadPlaceholder(post)
+  }
+  for (let post of findAllPostsInBookmarksQueryData(queryClient, uri)) {
     yield postViewToThreadPlaceholder(post)
   }
   for (let post of findAllPostsInExploreFeedPreviewsQueryData(


### PR DESCRIPTION
## Summary
- Clicking a post in the bookmarks list now pre-caches the post data for the thread view, matching the behavior of feeds, notifications, search, and other lists
- The bookmarks `findAllPostsInQueryData` already existed but wasn't wired into `getThreadPlaceholderCandidates`

## Test plan
- [ ] Open the bookmarks/saved posts screen
- [ ] Tap on a bookmarked post
- [ ] Verify the post content appears immediately (placeholder) instead of showing a full skeleton

🤖 Generated with [Claude Code](https://claude.com/claude-code)