### PR TITLE
Add Unfollow Confirmation Dialog to profiles, search, notifications and suggested accounts.

### DIFF
--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -595,7 +595,7 @@ export function FollowButtonInner({
 
       <Prompt.Basic
         control={unfollowPromptControl}
-        title={l(msg`Unfollow account?`)}
+        title={l(msg`Unfollow Account?`)}
         description={l(
           msg`You will no longer follow this account. If you have a prior DM conversation, this account can still message you.`,
         )}

--- a/src/components/ProfileCard.tsx
+++ b/src/components/ProfileCard.tsx
@@ -11,6 +11,7 @@ import {
   type ModerationOpts,
   RichText as RichTextApi,
 } from '@atproto/api'
+import {msg} from '@lingui/core/macro'
 import {useLingui} from '@lingui/react/macro'
 
 import {getModerationCauseKey} from '#/lib/moderation'
@@ -41,6 +42,7 @@ import {PlusLarge_Stroke2_Corner0_Rounded as Plus} from '#/components/icons/Plus
 import {Link as InternalLink, type LinkProps} from '#/components/Link'
 import * as Pills from '#/components/Pills'
 import {ProfileBadges} from '#/components/ProfileBadges'
+import * as Prompt from '#/components/Prompt'
 import {RichText} from '#/components/RichText'
 import * as Toast from '#/components/Toast'
 import {Text} from '#/components/Typography'
@@ -479,6 +481,7 @@ export function FollowButtonInner({
   ...rest
 }: FollowButtonProps) {
   const {t: l} = useLingui()
+  const unfollowPromptControl = Prompt.usePromptControl()
   const profile = useProfileShadow(profileUnshadowed)
   const moderation = moderateProfile(profile, moderationOpts)
   const [queueFollow, queueUnfollow] = useProfileFollowMutationQueue(
@@ -512,9 +515,7 @@ export function FollowButtonInner({
     }
   }
 
-  const onPressUnfollow = async (e: GestureResponderEvent) => {
-    e.preventDefault()
-    e.stopPropagation()
+  const onPressUnfollow = async () => {
     try {
       await queueUnfollow()
       Toast.show(
@@ -523,7 +524,7 @@ export function FollowButtonInner({
           moderation.ui('displayName'),
         )}`,
       )
-      onPressProp?.(e)
+      onPressProp?.()
     } catch (e) {
       const err = e as Error
       if (err?.name !== 'AbortError') {
@@ -566,7 +567,9 @@ export function FollowButtonInner({
           color="secondary"
           {...rest}
           onPress={(e: GestureResponderEvent) => {
-            void onPressUnfollow(e)
+            e.preventDefault()
+            e.stopPropagation()
+            unfollowPromptControl.open()
           }}>
           {withIcon && (
             <ButtonIcon icon={Check} position={isRound ? undefined : 'left'} />
@@ -589,6 +592,17 @@ export function FollowButtonInner({
           {isRound ? null : <ButtonText>{followLabel}</ButtonText>}
         </Button>
       )}
+
+      <Prompt.Basic
+        control={unfollowPromptControl}
+        title={l(msg`Unfollow account?`)}
+        description={l(
+          msg`You will no longer follow this account. If you have a prior DM conversation, this account can still message you.`,
+        )}
+        onConfirm={onPressUnfollow}
+        confirmButtonCta={l(msg`Unfollow`)}
+        confirmButtonColor="negative"
+      />
     </View>
   )
 }

--- a/src/screens/Profile/Header/ProfileHeaderStandard.tsx
+++ b/src/screens/Profile/Header/ProfileHeaderStandard.tsx
@@ -413,7 +413,7 @@ export function HeaderStandardButtons({
 
       <Prompt.Basic
         control={unfollowPromptControl}
-        title={_(msg`Unfollow account?`)}
+        title={_(msg`Unfollow Account?`)}
         description={_(
           msg`You will no longer follow this account. If you have a prior DM conversation, this account can still message you.`,
         )}

--- a/src/screens/Profile/Header/ProfileHeaderStandard.tsx
+++ b/src/screens/Profile/Header/ProfileHeaderStandard.tsx
@@ -247,6 +247,7 @@ export function HeaderStandardButtons({
   )
   const [, queueUnblock] = useProfileBlockMutationQueue(profile)
   const editProfileControl = useDialogControl()
+  const unfollowPromptControl = Prompt.usePromptControl()
   const unblockPromptControl = Prompt.usePromptControl()
 
   const isMe = currentAccount?.did === profile.did
@@ -390,7 +391,9 @@ export function HeaderStandardButtons({
                   : _(msg`Follow ${profile.handle}`)
               }
               onPress={
-                profile.viewer?.following ? onPressUnfollow : onPressFollow
+                profile.viewer?.following
+                  ? unfollowPromptControl.open
+                  : onPressFollow
               }>
               {!profile.viewer?.following && <ButtonIcon icon={Plus} />}
               <ButtonText>
@@ -407,6 +410,17 @@ export function HeaderStandardButtons({
         </>
       ) : null}
       <ProfileMenu profile={profile} />
+
+      <Prompt.Basic
+        control={unfollowPromptControl}
+        title={_(msg`Unfollow account?`)}
+        description={_(
+          msg`You will no longer follow this account. If you have a prior DM conversation, this account can still message you.`,
+        )}
+        onConfirm={onPressUnfollow}
+        confirmButtonCta={_(msg`Unfollow`)}
+        confirmButtonColor="negative"
+      />
 
       <Prompt.Basic
         control={unblockPromptControl}

--- a/src/view/com/notifications/NotificationFeedItem.tsx
+++ b/src/view/com/notifications/NotificationFeedItem.tsx
@@ -64,6 +64,7 @@ import {InlineLinkText, Link} from '#/components/Link'
 import * as MediaPreview from '#/components/MediaPreview'
 import {ProfileBadges} from '#/components/ProfileBadges'
 import {ProfileHoverCard} from '#/components/ProfileHoverCard'
+import * as Prompt from '#/components/Prompt'
 import {Notification as StarterPackCard} from '#/components/StarterPack/StarterPackCard'
 import {SubtleHover} from '#/components/SubtleHover'
 import * as Toast from '#/components/Toast'
@@ -742,6 +743,7 @@ function ExpandListPressable({
 
 function FollowBackButton({profile}: {profile: AppBskyActorDefs.ProfileView}) {
   const {_} = useLingui()
+  const unfollowPromptControl = Prompt.usePromptControl()
   const {currentAccount, hasSession} = useSession()
   const profileShadow = useProfileShadow(profile)
   const [queueFollow, queueUnfollow] = useProfileFollowMutationQueue(
@@ -776,10 +778,7 @@ function FollowBackButton({profile}: {profile: AppBskyActorDefs.ProfileView}) {
     }
   }
 
-  const onPressUnfollow = async (e: GestureResponderEvent) => {
-    e.preventDefault()
-    e.stopPropagation()
-
+  const onPressUnfollow = async () => {
     try {
       await queueUnfollow()
       Toast.show(
@@ -827,7 +826,11 @@ function FollowBackButton({profile}: {profile: AppBskyActorDefs.ProfileView}) {
           color="secondary"
           size="small"
           style={[a.self_start]}
-          onPress={onPressUnfollow}>
+          onPress={(e: GestureResponderEvent) => {
+            e.preventDefault()
+            e.stopPropagation()
+            unfollowPromptControl.open()
+          }}>
           <ButtonIcon icon={CheckIcon} />
           <ButtonText>
             <Trans>Following</Trans>
@@ -846,6 +849,17 @@ function FollowBackButton({profile}: {profile: AppBskyActorDefs.ProfileView}) {
           </ButtonText>
         </Button>
       )}
+
+      <Prompt.Basic
+        control={unfollowPromptControl}
+        title={_(msg`Unfollow account?`)}
+        description={_(
+          msg`You will no longer follow this account. If you have a prior DM conversation, this account can still message you.`,
+        )}
+        onConfirm={onPressUnfollow}
+        confirmButtonCta={_(msg`Unfollow`)}
+        confirmButtonColor="negative"
+      />
     </View>
   )
 }

--- a/src/view/com/notifications/NotificationFeedItem.tsx
+++ b/src/view/com/notifications/NotificationFeedItem.tsx
@@ -852,7 +852,7 @@ function FollowBackButton({profile}: {profile: AppBskyActorDefs.ProfileView}) {
 
       <Prompt.Basic
         control={unfollowPromptControl}
-        title={_(msg`Unfollow account?`)}
+        title={_(msg`Unfollow Account?`)}
         description={_(
           msg`You will no longer follow this account. If you have a prior DM conversation, this account can still message you.`,
         )}


### PR DESCRIPTION
I keep accidentally unfollowing mutuals, it's awkward and involves me DM'ing to explain the unfollow was accidental.

This PR implements an unfollow confirmation dialog to profiles, search, notifications and suggested accounts with the exception of:
- [Irrelevant] The follow button on posts: Irrelevant because it doesn't show if you already follow the author.
- [Annoying] The video feed: It's largely unused and is annoying to test.

<img width="611" height="583" alt="Screenshot 2026-03-21 at 1 23 41 AM" src="https://github.com/user-attachments/assets/21473eb9-834c-43b5-ab0e-7727a802e506" />

_A note about src/components/ProfileCard.tsx:527 (onPressPop): I removed it as it doesn't appear to be used and GestureResponderEvent is no longer passed due to the dialog. Instead e.preventDefault() and e.stopPropagation() are passed before opening the dialog to prevent the double-click behaviour. This seemed like the simplest fix without overcomplicating the unfollow logic._