### PR TITLE
Fix Android bottom sheet lint warnings

### DIFF
--- a/modules/bottom-sheet/android/src/main/java/expo/modules/bottomsheet/BottomSheetView.kt
+++ b/modules/bottom-sheet/android/src/main/java/expo/modules/bottomsheet/BottomSheetView.kt
@@ -8,6 +8,8 @@ import android.view.ViewStructure
 import android.view.Window
 import android.view.accessibility.AccessibilityEvent
 import android.widget.FrameLayout
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import com.facebook.react.bridge.LifecycleEventListener
 import com.facebook.react.bridge.ReactContext
@@ -16,7 +18,6 @@ import com.facebook.react.uimanager.UIManagerHelper
 import com.facebook.react.uimanager.events.EventDispatcher
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
-import com.google.android.material.internal.EdgeToEdgeUtils
 import expo.modules.kotlin.AppContext
 import expo.modules.kotlin.viewevent.EventDispatcher
 import expo.modules.kotlin.views.ExpoView
@@ -47,13 +48,15 @@ class BottomSheetView(
     }
 
   private fun getNavigationBarHeight(): Int {
-    val resourceId = resources.getIdentifier("navigation_bar_height", "dimen", "android")
-    return if (resourceId > 0) resources.getDimensionPixelSize(resourceId) else 0
+    val insets = ViewCompat.getRootWindowInsets(this)
+      ?: return 0
+    return insets.getInsets(WindowInsetsCompat.Type.navigationBars()).bottom
   }
 
   private fun getStatusBarHeight(): Int {
-    val resourceId = resources.getIdentifier("status_bar_height", "dimen", "android")
-    return if (resourceId > 0) resources.getDimensionPixelSize(resourceId) else 0
+    val insets = ViewCompat.getRootWindowInsets(this)
+      ?: return 0
+    return insets.getInsets(WindowInsetsCompat.Type.statusBars()).top
   }
 
   private val onAttemptDismiss by EventDispatcher()
@@ -199,7 +202,7 @@ class BottomSheetView(
           insetsController.isAppearanceLightNavigationBars = originalNavBarAppearance
         }
         if (originalStatusBarAppearance != null) {
-          EdgeToEdgeUtils.setLightStatusBar(window, originalStatusBarAppearance)
+          insetsController.isAppearanceLightStatusBars = originalStatusBarAppearance
         }
       }
     }
@@ -258,6 +261,8 @@ class BottomSheetView(
               BottomSheetBehavior.STATE_COLLAPSED -> selectedSnapPoint = 1
               BottomSheetBehavior.STATE_HALF_EXPANDED -> selectedSnapPoint = 1
               BottomSheetBehavior.STATE_HIDDEN -> selectedSnapPoint = 0
+              BottomSheetBehavior.STATE_DRAGGING,
+              BottomSheetBehavior.STATE_SETTLING -> { /* transient states, no snap point change */ }
             }
             // Apply deferred layout update after gesture completes
             if (newState != BottomSheetBehavior.STATE_DRAGGING &&


### PR DESCRIPTION
## Summary

Fixes lint warnings in the Android bottom sheet module:

- **Replace internal Material API**: `EdgeToEdgeUtils.setLightStatusBar` is `@RestrictTo(LIBRARY_GROUP)`. Replaced with the public `WindowInsetsControllerCompat.isAppearanceLightStatusBars` (which is what it wraps internally).

- **Replace resource reflection**: `getIdentifier("status_bar_height")` / `getIdentifier("navigation_bar_height")` use internal framework resources. Replaced with `ViewCompat.getRootWindowInsets()` + `WindowInsetsCompat.getInsets()`.

- **Add missing `when` cases**: DRAGGING and SETTLING were missing from the state change `when` block.

## Test plan

- [ ] Sheets should still restore the correct status bar / nav bar light/dark appearance after closing
- [ ] Sheet height calculations should be unchanged (same inset values, different API)

🤖 Generated with [Claude Code](https://claude.com/claude-code)