### PR TITLE
Increase parent batch size to reduce onStartReached calls

### DIFF
--- a/src/screens/PostThread/index.tsx
+++ b/src/screens/PostThread/index.tsx
@@ -45,7 +45,7 @@ import * as Layout from '#/components/Layout'
 import {ListFooter} from '#/components/Lists'
 import {useAnalytics} from '#/analytics'
 
-const PARENT_CHUNK_SIZE = 10
+const PARENT_CHUNK_SIZE = 20
 const CHILDREN_CHUNK_SIZE = 50
 
 export function PostThread({uri}: {uri: string}) {


### PR DESCRIPTION
What's happening here is that `onStartReached` is getting called more aggressively now, for whatever reason. I've traced this back to the last-known working commit f390167, and the commit that broke it caa02db87, but haven't identified the root cause.

But some logging makes it pretty clear: `onStartReached` is called, and more parents are prepended to the list, causing content size to change and an additional scroll to happen. On cold load on my screen, `onStartReached` is called 2x.

You can sort-of fix the stutter on cold load by reducing `onStartReachedThreshold` to `0.5` as well, but then reasonably-fast scrolling up still jumps around a bit because items aren't prepended until the user can see them.

In my testing, the better fix is to increase the prepended parent batch size to ensure that `onStartReached` is not called on a cold load, only when scrolling up wards.