### PR TITLE
PostThread perf: reduce time wasted on rendering skeletons

### DIFF
--- a/src/screens/PostThread/components/ThreadItemAnchor.tsx
+++ b/src/screens/PostThread/components/ThreadItemAnchor.tsx
@@ -1,4 +1,4 @@
-import {memo, useCallback, useMemo} from 'react'
+import {memo, useMemo} from 'react'
 import {Text as RNText, View} from 'react-native'
 import {
   AppBskyFeedDefs,
@@ -9,6 +9,7 @@ import {
 } from '@atproto/api'
 import {Plural, Trans, useLingui} from '@lingui/react/macro'
 
+import {useNonReactiveCallback} from '#/lib/hooks/useNonReactiveCallback'
 import {useOpenComposer} from '#/lib/hooks/useOpenComposer'
 import {makeProfileLink} from '#/lib/routes/links'
 import {sanitizeDisplayName} from '#/lib/strings/display-names'
@@ -245,7 +246,7 @@ const ThreadItemAnchorInner = memo(function ThreadItemAnchorInner({
     }
   }, [postSource])
 
-  const onPressReply = useCallback(() => {
+  const onPressReply = useNonReactiveCallback(() => {
     openComposer({
       replyTo: {
         uri: post.uri,
@@ -268,15 +269,7 @@ const ThreadItemAnchorInner = memo(function ThreadItemAnchorInner({
         reqId: postSource.post.reqId,
       })
     }
-  }, [
-    openComposer,
-    post,
-    record,
-    onPostSuccess,
-    moderation,
-    postSource,
-    feedFeedback,
-  ])
+  })
 
   const onOpenAuthor = () => {
     ax.metric('post:clickthroughAuthor', {

--- a/src/screens/PostThread/index.tsx
+++ b/src/screens/PostThread/index.tsx
@@ -11,6 +11,7 @@ import Animated, {useAnimatedStyle} from 'react-native-reanimated'
 import {Trans} from '@lingui/react/macro'
 
 import {useInitialNumToRender} from '#/lib/hooks/useInitialNumToRender'
+import {useNonReactiveCallback} from '#/lib/hooks/useNonReactiveCallback'
 import {useOpenComposer} from '#/lib/hooks/useOpenComposer'
 import {usePostViewTracking} from '#/lib/hooks/usePostViewTracking'
 import {useFeedFeedback} from '#/state/feed-feedback'
@@ -105,7 +106,7 @@ export function PostThread({uri}: {uri: string}) {
   const trackThreadItemView = usePostViewTracking('PostThreadItem')
 
   const {openComposer} = useOpenComposer()
-  const optimisticOnPostReply = useCallback(
+  const optimisticOnPostReply = useNonReactiveCallback(
     (payload: OnPostSuccessData) => {
       if (payload) {
         const {replyToUri, posts} = payload
@@ -114,9 +115,8 @@ export function PostThread({uri}: {uri: string}) {
         }
       }
     },
-    [thread],
   )
-  const onReplyToAnchor = useCallback(() => {
+  const onReplyToAnchor = useNonReactiveCallback(() => {
     if (anchor?.type !== 'threadPost') {
       return
     }
@@ -143,13 +143,7 @@ export function PostThread({uri}: {uri: string}) {
         reqId: anchorPostSource.post.reqId,
       })
     }
-  }, [
-    anchor,
-    openComposer,
-    optimisticOnPostReply,
-    anchorPostSource,
-    feedFeedback,
-  ])
+  })
 
   const isRoot = !!anchor && anchor.value.post.record.reply === undefined
   const canReply = !anchor?.value.post?.viewer?.replyDisabled


### PR DESCRIPTION
This is a two-part fix:

# 1. The initial render

The initial render needs to be as fast as possible. Currently it's a 120ms on my sim to open [a bsky.app thread](https://bsky.app/profile/bsky.app/post/3mhgg5ja5gc2w). Looking at the profiler, you can see that some skeletons are included in the initial render:

<img width="899" height="1004" alt="Screenshot 2026-03-21 at 14 25 10" src="https://github.com/user-attachments/assets/459f49c8-62c3-46df-8148-e6a68dd1829f" />

We can shave off 20ms by deferring that work. This allows the screen transition to start a frame earlier. Yay!
It seems to get batched with the re-render we do after first layout.

<img width="909" height="967" alt="Screenshot 2026-03-21 at 14 29 41" src="https://github.com/user-attachments/assets/e0bf1d6a-4acb-407a-873a-584532887e91" />

# 2. Window size

While fetching the thread data, we're spending a ton of CPU cycles rendering 7 pages of skeleton placeholders offscreen.

<img width="903" height="958" alt="Screenshot 2026-03-21 at 14 24 34" src="https://github.com/user-attachments/assets/7e51d373-d45f-46f4-87d6-01e36b060276" />

The worst part is, when the real data comes in, the FlatList replaces *all* rendered cells in one go in one massive render that takes almost a full second.

<img width="903" height="964" alt="Screenshot 2026-03-21 at 14 24 06" src="https://github.com/user-attachments/assets/2ba32217-86ea-4f5d-acb6-9674ed47a4e4" />

If we reduce the `windowSize` to 1 during the placeholder stage, then bump it back up to 7 only after we have real data, it won't render the extra skeletons and then correctly render the replies in batches like it should

### First non-placeholder render - anchor + 3 replies

<img width="922" height="971" alt="Screenshot 2026-03-22 at 13 31 58" src="https://github.com/user-attachments/assets/8f926548-0255-4cd8-8bcb-ab633a61aac2" />

### Subsequent reply renders (observed that they're batched)

<img width="904" height="980" alt="Screenshot 2026-03-22 at 13 32 12" src="https://github.com/user-attachments/assets/a799cd87-8f02-44ef-ba2c-48c751e7ab6e" />

# 3. Bonus: make onReply non-reactive

I noticed a fair few unnecessary renders are caused by the `onReply` callback function changing - this can be fixed by using `useNonReactiveCallback`