### PR TITLE
Fix #9879: preserve PNG transparency on image upload

### DIFF
--- a/__tests__/lib/images.test.ts
+++ b/__tests__/lib/images.test.ts
@@ -1,7 +1,12 @@
-import {createDownloadResumable, deleteAsync} from 'expo-file-system/legacy'
+import {
+  copyAsync,
+  createDownloadResumable,
+  deleteAsync,
+} from 'expo-file-system/legacy'
 import {manipulateAsync, SaveFormat} from 'expo-image-manipulator'
 
 import {
+  compressIfNeeded,
   downloadAndResize,
   type DownloadAndResizeOpts,
   getResizedDimensions,
@@ -123,5 +128,49 @@ describe('downloadAndResize', () => {
       width: 1000,
       height: 2000,
     })
+  })
+
+  it('should preserve PNG format when compressing a PNG input', async () => {
+    const img = {
+      path: 'file://input-image.png',
+      size: 2_000_000,
+      width: 100,
+      height: 100,
+      mime: 'image/png',
+    }
+
+    const result = await compressIfNeeded(img, 500_000)
+
+    expect(manipulateAsync).toHaveBeenCalledWith(
+      expect.any(String),
+      [{resize: {height: img.height, width: img.width}}],
+      expect.objectContaining({format: SaveFormat.PNG}),
+    )
+    expect(copyAsync).toHaveBeenCalledWith(
+      expect.objectContaining({to: expect.stringMatching(/\.png$/)}),
+    )
+    expect(result.mime).toBe('image/png')
+  })
+
+  it('should keep JPEG output when compressing a JPEG input', async () => {
+    const img = {
+      path: 'file://input-image.jpg',
+      size: 2_000_000,
+      width: 100,
+      height: 100,
+      mime: 'image/jpeg',
+    }
+
+    const result = await compressIfNeeded(img, 500_000)
+
+    expect(manipulateAsync).toHaveBeenCalledWith(
+      expect.any(String),
+      [{resize: {height: img.height, width: img.width}}],
+      expect.objectContaining({format: SaveFormat.JPEG}),
+    )
+    expect(copyAsync).toHaveBeenCalledWith(
+      expect.objectContaining({to: expect.stringMatching(/\.jpg$/)}),
+    )
+    expect(result.mime).toBe('image/jpeg')
   })
 })

--- a/jest/jestSetup.js
+++ b/jest/jestSetup.js
@@ -33,6 +33,8 @@ jest.mock('react-native-safe-area-context', () => {
 })
 
 jest.mock('expo-file-system/legacy', () => ({
+  cacheDirectory: 'file://cache',
+  copyAsync: jest.fn().mockResolvedValue(undefined),
   getInfoAsync: jest.fn().mockResolvedValue({exists: true, size: 100}),
   deleteAsync: jest.fn(),
   moveAsync: jest.fn().mockResolvedValue(undefined),
@@ -45,6 +47,7 @@ jest.mock('expo-image-manipulator', () => ({
   }),
   SaveFormat: {
     JPEG: 'jpeg',
+    PNG: 'png',
     WEBP: 'webp',
   },
 }))

--- a/src/lib/media/manip.ts
+++ b/src/lib/media/manip.ts
@@ -35,10 +35,12 @@ export async function compressIfNeeded(
     height: img.height,
     mode: 'stretch',
     maxSize,
+    mimeType: img.mime,
   })
+  const imageFormat = img.mime === 'image/png' ? '.png' : '.jpg'
   const finalImageMovedPath = await moveToPermanentPath(
     resizedImage.path,
-    '.jpg',
+    imageFormat,
   )
   const finalImg = {
     ...resizedImage,
@@ -192,6 +194,7 @@ interface DoResizeOpts {
   height: number
   mode: 'contain' | 'cover' | 'stretch'
   maxSize: number
+  mimeType?: string
 }
 
 async function doResize(
@@ -209,6 +212,10 @@ async function doResize(
     height: imageRes.height,
   })
 
+  const preserveTransparencyPNG = opts.mimeType === 'image/png'
+  const format = preserveTransparencyPNG ? SaveFormat.PNG : SaveFormat.JPEG
+  const mime = preserveTransparencyPNG ? 'image/png' : 'image/jpeg'
+
   let minQualityPercentage = 0
   let maxQualityPercentage = 101 // exclusive
   let newDataUri
@@ -222,7 +229,7 @@ async function doResize(
       localUri,
       [{resize: newDimensions}],
       {
-        format: SaveFormat.JPEG,
+        format,
         compress: qualityPercentage / 100,
       },
     )
@@ -240,7 +247,7 @@ async function doResize(
       minQualityPercentage = qualityPercentage
       newDataUri = {
         path: normalizePath(resizeRes.uri),
-        mime: 'image/jpeg',
+        mime,
         size: fileInfo.size,
         width: resizeRes.width,
         height: resizeRes.height,

--- a/src/lib/media/manip.web.ts
+++ b/src/lib/media/manip.web.ts
@@ -14,6 +14,7 @@ export async function compressIfNeeded(
     height: img.height,
     mode: 'stretch',
     maxSize,
+    mimeType: img.mime,
   })
 }
 
@@ -74,6 +75,7 @@ interface DoResizeOpts {
   height: number
   mode: 'contain' | 'cover' | 'stretch'
   maxSize: number
+  mimeType?: string
 }
 
 async function doResize(
@@ -85,6 +87,9 @@ async function doResize(
   let minQualityPercentage = 0
   let maxQualityPercentage = 101 //exclusive
 
+  const preserveTransparencyPNG = opts.mimeType === 'image/png'
+  const outputMime = preserveTransparencyPNG ? 'image/png' : 'image/jpeg'
+
   while (maxQualityPercentage - minQualityPercentage > 1) {
     const qualityPercentage = Math.round(
       (maxQualityPercentage + minQualityPercentage) / 2,
@@ -94,6 +99,7 @@ async function doResize(
       height: opts.height,
       quality: qualityPercentage / 100,
       mode: opts.mode,
+      outputMime,
     })
 
     if (getDataUriSize(tempDataUri) < opts.maxSize) {
@@ -109,7 +115,7 @@ async function doResize(
   }
   return {
     path: newDataUri,
-    mime: 'image/jpeg',
+    mime: outputMime,
     size: getDataUriSize(newDataUri),
     width: opts.width,
     height: opts.height,
@@ -123,11 +129,13 @@ function createResizedImage(
     height,
     quality,
     mode,
+    outputMime,
   }: {
     width: number
     height: number
     quality: number
     mode: 'contain' | 'cover' | 'stretch'
+    outputMime?: string
   },
 ): Promise<string> {
   return new Promise((resolve, reject) => {
@@ -152,7 +160,7 @@ function createResizedImage(
       canvas.height = h
 
       ctx.drawImage(img, 0, 0, w, h)
-      resolve(canvas.toDataURL('image/jpeg', quality))
+      resolve(canvas.toDataURL(outputMime || 'image/jpeg', quality))
     })
     img.addEventListener('error', ev => {
       reject(ev.error)

--- a/src/state/gallery.ts
+++ b/src/state/gallery.ts
@@ -205,6 +205,7 @@ export async function compressImage(
   options?: {
     highResolution?: boolean
     increasedBlobSizeLimit?: boolean
+    preserveTransparency?: boolean
   },
 ): Promise<PickerImage> {
   const source = img.transformed || img.source
@@ -213,6 +214,9 @@ export async function compressImage(
   let attempts = 0
   let maxDimension = highResolution ? 4000 : POST_IMG_MAX.width
   let maxBytes = options?.increasedBlobSizeLimit ? 2000000 : POST_IMG_MAX.size
+
+  const preserveTransparencyPNG =
+    options?.preserveTransparency && source.mime === 'image/png'
 
   let minQualityPercentage = 0
   let maxQualityPercentage = 101 // exclusive
@@ -246,7 +250,7 @@ export async function compressImage(
       [{resize: {width: w, height: h}}],
       {
         compress: qualityPercentage / 100,
-        format: SaveFormat.JPEG,
+        format: preserveTransparencyPNG ? SaveFormat.PNG : SaveFormat.JPEG,
         base64: true,
       },
     )
@@ -259,7 +263,7 @@ export async function compressImage(
         path: await moveIfNecessary(res.uri),
         width: res.width,
         height: res.height,
-        mime: 'image/jpeg',
+        mime: preserveTransparencyPNG ? 'image/png' : 'image/jpeg',
         size,
       }
     } else {

--- a/src/view/com/util/UserAvatar.tsx
+++ b/src/view/com/util/UserAvatar.tsx
@@ -430,7 +430,9 @@ let EditableUserAvatar = ({
 
   const onChangeEditImage = useCallback(
     async (image: ComposerImage) => {
-      const compressed = await compressImage(image)
+      const compressed = await compressImage(image, {
+        preserveTransparency: true,
+      })
       onSelectNewAvatar(compressed)
     },
     [onSelectNewAvatar],

--- a/src/view/com/util/UserBanner.tsx
+++ b/src/view/com/util/UserBanner.tsx
@@ -108,7 +108,9 @@ export function UserBanner({
 
   const onChangeEditImage = useCallback(
     async (image: ComposerImage) => {
-      const compressed = await compressImage(image)
+      const compressed = await compressImage(image, {
+        preserveTransparency: true,
+      })
       onSelectNewBanner?.(compressed)
     },
     [onSelectNewBanner],


### PR DESCRIPTION
Fixes #9879 Uploading a PNG with a transparent background was being converted to JPEG during the compression pipeline.

This fix preserves the original image format when compressing files. PNG inputs now stay PNG (including MIME type and file extension), so alpha channels are retained end-to-end and transparent backgrounds no longer turn black. Additional tests cover PNG and JPEG paths to verify output format, extension, and MIME behavior.