### PR TITLE
Prevent render loop when toggling feed preference

### DIFF
--- a/src/state/cache/profile-shadow.ts
+++ b/src/state/cache/profile-shadow.ts
@@ -1,4 +1,4 @@
-import {useEffect, useMemo, useState} from 'react'
+import {useEffect, useMemo, useRef, useState} from 'react'
 import {type AppBskyActorDefs, type AppBskyNotificationDefs} from '@atproto/api'
 import {type QueryClient} from '@tanstack/react-query'
 import EventEmitter from 'eventemitter3'
@@ -134,8 +134,9 @@ export function usePostAuthorShadowFilter(data?: FeedPage[]) {
     new Map<string, {muted: boolean; blocked: boolean}>(),
   )
 
-  const [prevData, setPrevData] = useState(data)
-  if (data !== prevData) {
+  const prevDataRef = useRef(data)
+  if (data !== prevDataRef.current) {
+    prevDataRef.current = data
     const newAuthors = new Set(trackedDids)
     let hasNew = false
     for (const slice of data?.flatMap(page => page.slices) ?? []) {
@@ -148,7 +149,6 @@ export function usePostAuthorShadowFilter(data?: FeedPage[]) {
       }
     }
     if (hasNew) setTrackedDids([...newAuthors])
-    setPrevData(data)
   }
 
   useEffect(() => {


### PR DESCRIPTION
Using state to manage the previous data comparison here was creating a render loop: Every time there was a new `data` reference, state was mutated during render via `setPrevData`, which triggered a new render, which resulted in a new `data` reference, and so on.

Using a ref to track the previous `data` avoids the render loop.

This was identified by toggling the experimental setting in “Following feed preferences”.

**Before**

https://github.com/user-attachments/assets/d3639b47-589f-4343-b37d-469773f9bb1e

**After**

https://github.com/user-attachments/assets/f44e8d6d-d784-460a-8a24-26917f1bfa16