### PR TITLE
Fix report dialog flashing error state on open

### DIFF
--- a/src/components/hooks/useDelayedLoading.ts
+++ b/src/components/hooks/useDelayedLoading.ts
@@ -1,15 +1,14 @@
 import {useEffect, useState} from 'react'
 
-export function useDelayedLoading(delay: number, initialState: boolean = true) {
-  const [isLoading, setIsLoading] = useState(initialState)
+export function useDelayedLoading(delay: number, isActuallyLoading: boolean) {
+  const [isDelayActive, setIsDelayActive] = useState(isActuallyLoading)
 
   useEffect(() => {
-    let timeout: NodeJS.Timeout
-    // on initial load, show a loading spinner for a hot sec to prevent flash
-    if (isLoading) timeout = setTimeout(() => setIsLoading(false), delay)
+    if (!isDelayActive) return
 
-    return () => timeout && clearTimeout(timeout)
-  }, [isLoading, delay])
+    const timeout = setTimeout(() => setIsDelayActive(false), delay)
+    return () => clearTimeout(timeout)
+  }, [isDelayActive, delay])
 
-  return isLoading
+  return isDelayActive || isActuallyLoading
 }


### PR DESCRIPTION
## Summary
- `useDelayedLoading` was unconditionally setting loading to `false` after 500ms, ignoring whether the actual query had completed
- If the labeler query took longer than 500ms (e.g. not cached), the error state would briefly flash before data arrived
- Fix: return `isDelayActive || isActuallyLoading` so loading stays true as long as either the minimum display timer or the real query is active

### Before



https://github.com/user-attachments/assets/6951ac8f-8657-4bec-aeb1-2ab3740b6bd6


### After


https://github.com/user-attachments/assets/0542c6c4-0b20-4c56-b1ce-e209c9605ba5




## Test plan
- [ ] Open report dialog with cold cache + artificially delay the labeler query — should show skeletons until data loads, no error flash

🤖 Generated with [Claude Code](https://claude.com/claude-code)