### PR TITLE
Fix 'Lists' & 'Feeds' not displaying their contents on muted profiles

### DIFF
--- a/src/state/queries/profile-feedgens.ts
+++ b/src/state/queries/profile-feedgens.ts
@@ -57,7 +57,9 @@ export function useProfileFeedgensQuery(
               // filter by labels
               .filter(list => {
                 const decision = moderateFeedGenerator(list, moderationOpts!)
-                return !decision.ui('contentList').filter
+                return !decision
+                  .ui('contentList')
+                  .filters.some(cause => cause.type !== 'muted')
               }),
           }
         }),

--- a/src/state/queries/profile-lists.ts
+++ b/src/state/queries/profile-lists.ts
@@ -46,7 +46,9 @@ export function useProfileListsQuery(did: string, opts?: {enabled?: boolean}) {
             ...page,
             lists: page.lists.filter(list => {
               const decision = moderateUserList(list, moderationOpts!)
-              return !decision.ui('contentList').filter
+              return !decision
+                .ui('contentList')
+                .filters.some(cause => cause.type !== 'muted')
             }),
           }
         }),


### PR DESCRIPTION
Fixes #9685

Currently upon muting a profile, the 'Lists' and 'Feeds' tabs stop displaying their contents

This change ignores the 'muted' cause type when filtering profile lists/feeds, preventing that from happening 🐙