### PR TITLE
[Web] Fix Wordle score rendering  - prevent Inter from overriding emoji presentation

### DIFF
--- a/src/alf/fonts.ts
+++ b/src/alf/fonts.ts
@@ -1,5 +1,4 @@
 import {type TextStyle} from 'react-native'
-import {web} from '@bsky.app/alf'
 
 import {IS_ANDROID, IS_WEB} from '#/env'
 import {type Device, device} from '#/storage'
@@ -81,10 +80,15 @@ export function applyFonts(style: TextStyle, fontFamily: 'system' | 'theme') {
      * Disable contextual alternates and emoji overrides in Inter
      * {@link https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant}
      */
-    style.fontVariant = (style.fontVariant || []).concat(
-      'no-contextual',
-      web('unicode'),
-    )
+    if (IS_WEB) {
+      // @ts-expect-error - web supports 'unicode' as a valid value for fontVariant
+      style.fontVariant = (style.fontVariant || []).concat(
+        'no-contextual',
+        'unicode',
+      )
+    } else {
+      style.fontVariant = (style.fontVariant || []).concat('no-contextual')
+    }
   } else {
     // fallback families only supported on web
     if (IS_WEB) {


### PR DESCRIPTION
Attempt number 2 at fixing Wordle scores.

Web only: use `font-variant-emoji: unicode` to prevent Inter from overriding emoji presentation.

https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/font-variant-emoji

Not universally supported, but that's fine as this isn't loadbearing


## Before

<img width="598" height="480" alt="Screenshot 2026-03-23 at 13 43 28" src="https://github.com/user-attachments/assets/62a330e9-6bf1-4319-82d9-279d492de2b0" />


## After

<img width="600" height="481" alt="Screenshot 2026-03-23 at 13 43 16" src="https://github.com/user-attachments/assets/441b103a-564c-4e20-925d-f7a09085dca4" />

