### PR TITLE
[Web] Fix clipped text when using `numberOfLines={1}`

### DIFF
--- a/src/components/Typography.tsx
+++ b/src/components/Typography.tsx
@@ -1,7 +1,7 @@
 import {UITextView} from 'react-native-uitextview'
 
 import {logger} from '#/logger'
-import {atoms, useAlf, useTheme, web} from '#/alf'
+import {atoms as a, type TextStyleProp, useAlf, useTheme, web} from '#/alf'
 import {
   childHasEmoji,
   normalizeTextStyles,
@@ -22,15 +22,24 @@ export function Text({
   selectable,
   title,
   dataSet,
+  numberOfLines,
   ...rest
 }: TextProps) {
   const {fonts, flags} = useAlf()
   const t = useTheme()
-  const s = normalizeTextStyles([atoms.text_sm, t.atoms.text, style], {
-    fontScale: fonts.scaleMultiplier,
-    fontFamily: fonts.family,
-    flags,
-  })
+  const s = normalizeTextStyles(
+    [
+      a.text_sm,
+      t.atoms.text,
+      web(numberOfLines === 1 && numberOfLinesClippingFix),
+      style,
+    ],
+    {
+      fontScale: fonts.scaleMultiplier,
+      fontFamily: fonts.family,
+      flags,
+    },
+  )
 
   if (__DEV__) {
     if (!emoji && childHasEmoji(children)) {
@@ -44,6 +53,7 @@ export function Text({
   const shared = {
     uiTextView: true,
     selectable,
+    numberOfLines,
     style: s,
     dataSet: Object.assign({tooltip: title}, dataSet || {}),
     ...rest,
@@ -82,10 +92,22 @@ export function P({style, ...rest}: TextProps) {
       role: 'paragraph',
     }) || {}
   return (
-    <Text
-      {...attr}
-      {...rest}
-      style={[atoms.text_md, atoms.leading_relaxed, style]}
-    />
+    <Text {...attr} {...rest} style={[a.text_md, a.leading_relaxed, style]} />
   )
 }
+
+/**
+ * HACKFIX: React Native Web applies `overflow: hidden` to
+ * text when using the `numberOfLines` prop, which causes it to clip
+ * ascenders/descenders. It only needs to be doing this for the X axis,
+ * so override the style with `overflowX: 'hidden'`.
+ * Note this only works for `numberOfLines={1}` -sfn
+ *
+ * @see https://github.com/necolas/react-native-web/pull/2836
+ */
+const numberOfLinesClippingFix = {
+  overflowY: 'visible',
+  overflowX: 'clip',
+  // this is neater and supports vertical writing modes, but it's only baseline newly available
+  // overflowInline: 'clip',
+} satisfies React.CSSProperties as TextStyleProp


### PR DESCRIPTION
Upstream fix: https://github.com/necolas/react-native-web/pull/2836

Supercedes #9458

React Native Web applies `overflow: hidden` to text when using the `numberOfLines` prop, as that's required for CSS line-clamp. However, this causes ascenders/descenders to get clipped when using the default line height. Look for a display name with a `g` in it and you'll see the tail of it is clipped. This checkmark glyph (\*cough\* https://github.com/bluesky-social/social-app/pull/9490 \*cough\*) shows it clearly. Paste `` in your display name to repro.

<img width="600" height="408" alt="Screenshot 2026-03-23 at 13 13 33" src="https://github.com/user-attachments/assets/91881ba9-c9d9-47c5-a66d-604f6fe243be" />

The fix is to use `overflow-y: visible; overflow-x: clip`. Note this only works for `numberOfLines={1}`, to my knowledge multiline clamping without vertical clipping is impossible in CSS. I applied the fix to the base `Text` component, so the fix should be global.

<img width="599" height="404" alt="Screenshot 2026-03-23 at 13 15 29" src="https://github.com/user-attachments/assets/3c243254-93e7-4743-93fd-6264a04dc7af" />
