### PR TITLE
Use isTranslationSupported from expo-translate-text

### DIFF
--- a/src/env/index.ts
+++ b/src/env/index.ts
@@ -49,6 +49,3 @@ export const IS_WEB_FIREFOX: boolean = false
 export const IS_HIGH_DPI: boolean = true
 // ideally we'd use isLiquidGlassAvailable() from expo-glass-effect but checking iOS version is good enough for now
 export const IS_LIQUID_GLASS: boolean = iOSMajorVersion >= 26
-// So we can avoid attempting on-device translation when we know it's unsupported.
-export const HAS_ON_DEVICE_TRANSLATION: boolean =
-  (IS_IOS && iOSMajorVersion >= 18) || IS_ANDROID

--- a/src/env/index.web.ts
+++ b/src/env/index.web.ts
@@ -48,4 +48,3 @@ export const IS_HIGH_DPI: boolean = window.matchMedia(
   '(min-resolution: 2dppx)',
 ).matches
 export const IS_LIQUID_GLASS: boolean = false
-export const HAS_ON_DEVICE_TRANSLATION: boolean = false

--- a/src/lib/translation/index.tsx
+++ b/src/lib/translation/index.tsx
@@ -1,7 +1,10 @@
 import {useCallback, useContext, useEffect, useMemo, useState} from 'react'
 import {LayoutAnimation, Platform} from 'react-native'
 import {getLocales} from 'expo-localization'
-import {onTranslateTask} from '@bsky.app/expo-translate-text'
+import {
+  isTranslationSupported,
+  onTranslateTask,
+} from '@bsky.app/expo-translate-text'
 import {type TranslationTaskResult} from '@bsky.app/expo-translate-text/build/ExpoTranslateText.types'
 import {useLingui} from '@lingui/react/macro'
 import {useFocusEffect} from '@react-navigation/native'
@@ -9,7 +12,7 @@ import {useFocusEffect} from '@react-navigation/native'
 import {useGoogleTranslate} from '#/lib/hooks/useGoogleTranslate'
 import {logger} from '#/logger'
 import {useAnalytics} from '#/analytics'
-import {HAS_ON_DEVICE_TRANSLATION, IS_ANDROID, IS_IOS} from '#/env'
+import {IS_ANDROID, IS_IOS} from '#/env'
 import {Context} from './context'
 import {
   type ContextType,
@@ -232,7 +235,7 @@ export function Provider({children}: React.PropsWithChildren<unknown>) {
         googleTranslate: shouldForceGoogleTranslate,
       })
 
-      if (shouldForceGoogleTranslate || !HAS_ON_DEVICE_TRANSLATION) {
+      if (shouldForceGoogleTranslate || !isTranslationSupported()) {
         await googleTranslate(
           text,
           expectedTargetLanguage,


### PR DESCRIPTION
This makes the device the [source of truth](https://github.com/bluesky-social/expo-translate-text/pull/7) for whether on-device translation is available.

Tested on Android device, iOS simulator, and web (to ensure no regressions).