### PR TITLE
fix: too many re-renders when toggling experimental feed sampling option

### DIFF
--- a/src/state/cache/profile-shadow.ts
+++ b/src/state/cache/profile-shadow.ts
@@ -134,22 +134,22 @@ export function usePostAuthorShadowFilter(data?: FeedPage[]) {
     new Map<string, {muted: boolean; blocked: boolean}>(),
   )
 
-  const [prevData, setPrevData] = useState(data)
-  if (data !== prevData) {
-    const newAuthors = new Set(trackedDids)
-    let hasNew = false
-    for (const slice of data?.flatMap(page => page.slices) ?? []) {
-      for (const item of slice.items) {
-        const author = item.post.author
-        if (!newAuthors.has(author.did)) {
-          hasNew = true
-          newAuthors.add(author.did)
+  useEffect(() => {
+    setTrackedDids(prev => {
+      const currentDids = new Set(prev)
+      let hasNew = false
+      for (const slice of data?.flatMap(page => page.slices) ?? []) {
+        for (const item of slice.items) {
+          const author = item.post.author
+          if (!currentDids.has(author.did)) {
+            hasNew = true
+            currentDids.add(author.did)
+          }
         }
       }
-    }
-    if (hasNew) setTrackedDids([...newAuthors])
-    setPrevData(data)
-  }
+      return hasNew ? [...currentDids] : prev
+    })
+  }, [data])
 
   useEffect(() => {
     const unsubs: Array<() => void> = []


### PR DESCRIPTION
### Description

`usePostAuthorShadowFilter` used a setState-during-render pattern (the `prevData` / `setPrevData` approach) to track new authors as feed data changed. When toggling the "Show samples of your saved feeds in your following feed" option, the incoming `data` reference would change, causing React to call `setState` synchronously during render. This triggered React's "Too many re-renders" error.

### Fix

Replace the setState-during-render pattern with a `useEffect` that runs after render:

- The `prevData` + `setPrevData` guard that conditionally called `setTrackedDids` during render is removed
- A `useEffect` with `[data]` dependency now handles accumulating new author DIDs
- The functional update form (`setTrackedDids(prev => ...)`) is used to avoid stale closures and to bail out (return `prev`) when no new DIDs are found, preventing unnecessary re-renders

Fixes #9937.