### PR TITLE
(Experiment) Only subscribe to queries if screen is focused

### DIFF
--- a/patches/@react-navigation+core+7.16.1.patch
+++ b/patches/@react-navigation+core+7.16.1.patch
@@ -1,0 +1,39 @@
+diff --git a/node_modules/@react-navigation/core/lib/module/index.js b/node_modules/@react-navigation/core/lib/module/index.js
+index dc83d8c..b707811 100644
+--- a/node_modules/@react-navigation/core/lib/module/index.js
++++ b/node_modules/@react-navigation/core/lib/module/index.js
+@@ -23,7 +23,7 @@ export { ThemeProvider } from "./theming/ThemeProvider.js";
+ export { useTheme } from "./theming/useTheme.js";
+ export * from "./types.js";
+ export { useFocusEffect } from "./useFocusEffect.js";
+-export { useIsFocused } from "./useIsFocused.js";
++export { IsFocusedContext, useIsFocused } from "./useIsFocused.js";
+ export { useNavigation } from "./useNavigation.js";
+ export { useNavigationBuilder } from "./useNavigationBuilder.js";
+ export { useNavigationContainerRef } from "./useNavigationContainerRef.js";
+diff --git a/node_modules/@react-navigation/core/lib/typescript/src/index.d.ts b/node_modules/@react-navigation/core/lib/typescript/src/index.d.ts
+index 220e113..1b406cf 100644
+--- a/node_modules/@react-navigation/core/lib/typescript/src/index.d.ts
++++ b/node_modules/@react-navigation/core/lib/typescript/src/index.d.ts
+@@ -21,7 +21,7 @@ export { ThemeProvider } from './theming/ThemeProvider';
+ export { useTheme } from './theming/useTheme';
+ export * from './types';
+ export { useFocusEffect } from './useFocusEffect';
+-export { useIsFocused } from './useIsFocused';
++export { IsFocusedContext, useIsFocused } from './useIsFocused';
+ export { useNavigation } from './useNavigation';
+ export { useNavigationBuilder } from './useNavigationBuilder';
+ export { useNavigationContainerRef } from './useNavigationContainerRef';
+diff --git a/node_modules/@react-navigation/core/src/index.tsx b/node_modules/@react-navigation/core/src/index.tsx
+index 6f5175f..211d585 100644
+--- a/node_modules/@react-navigation/core/src/index.tsx
++++ b/node_modules/@react-navigation/core/src/index.tsx
+@@ -33,7 +33,7 @@ export { ThemeProvider } from './theming/ThemeProvider';
+ export { useTheme } from './theming/useTheme';
+ export * from './types';
+ export { useFocusEffect } from './useFocusEffect';
+-export { useIsFocused } from './useIsFocused';
++export { IsFocusedContext, useIsFocused } from './useIsFocused';
+ export { useNavigation } from './useNavigation';
+ export { useNavigationBuilder } from './useNavigationBuilder';
+ export { useNavigationContainerRef } from './useNavigationContainerRef';

--- a/src/state/queries/feed.ts
+++ b/src/state/queries/feed.ts
@@ -9,6 +9,7 @@ import {
   RichText,
 } from '@atproto/api'
 import {t} from '@lingui/core/macro'
+import {useIsFocused} from '@react-navigation/native'
 import {
   type InfiniteData,
   keepPreviousData,
@@ -176,10 +177,12 @@ export function getAvatarTypeFromUri(uri: string) {
 export function useFeedSourceInfoQuery({uri}: {uri: string}) {
   const type = getFeedTypeFromUri(uri)
   const agent = useAgent()
+  const isFocused = useIsFocused()
 
   return useQuery({
     staleTime: STALE.INFINITY,
     queryKey: feedSourceInfoQueryKey({uri}),
+    subscribed: isFocused,
     queryFn: async () => {
       let view: FeedSourceInfo
 

--- a/src/state/queries/post-feed.ts
+++ b/src/state/queries/post-feed.ts
@@ -10,6 +10,7 @@ import {
   type ModerationDecision,
   type ModerationPrefs,
 } from '@atproto/api'
+import {useIsFocused} from '@react-navigation/native'
 import {
   type InfiniteData,
   type QueryClient,
@@ -134,6 +135,7 @@ export function usePostFeedQuery(
   const feedTuners = useFeedTuners(feedDesc)
   const moderationOpts = useModerationOpts()
   const {data: preferences} = usePreferencesQuery()
+  const isFocused = useIsFocused()
   /**
    * Load bearing: we need to await AA state or risk FOUC. This marginally
    * delays feeds, but AA state is fetched immediately on load and is then
@@ -183,6 +185,7 @@ export function usePostFeedQuery(
   >({
     enabled,
     staleTime: STALE.INFINITY,
+    subscribed: isFocused,
     queryKey: RQKEY(feedDesc, params),
     async queryFn({pageParam}: {pageParam: RQPageParam}) {
       logger.debug('usePostFeedQuery', {feedDesc, cursor: pageParam?.cursor})

--- a/src/state/queries/preferences/index.ts
+++ b/src/state/queries/preferences/index.ts
@@ -1,9 +1,10 @@
-import {useCallback} from 'react'
+import {useCallback, useContext} from 'react'
 import {
   type AppBskyActorDefs,
   type BskyFeedViewPreference,
   type LabelPreference,
 } from '@atproto/api'
+import {IsFocusedContext} from '@react-navigation/native'
 import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query'
 
 import {PROD_DEFAULT_FEED} from '#/lib/constants'
@@ -38,6 +39,7 @@ export const preferencesQueryKey = [PERSISTED_QUERY_ROOT, 'getPreferences']
 export function usePreferencesQuery() {
   const agent = useAgent()
   const aa = useAgeAssurance()
+  const isFocused = useOptionalIsFocused()
 
   const query = useQuery({
     staleTime: STALE.SECONDS.FIFTEEN,
@@ -45,6 +47,7 @@ export function usePreferencesQuery() {
     refetchOnWindowFocus: true,
     queryKey: preferencesQueryKey,
     gcTime: PERSISTED_QUERY_GCTIME,
+    subscribed: isFocused,
     queryFn: async () => {
       if (!agent.did) {
         return DEFAULT_LOGGED_OUT_PREFERENCES
@@ -105,6 +108,11 @@ export function usePreferencesQuery() {
   }
 
   return query
+}
+
+// same as useIsFocused, but returns true if not in context (i.e. not in a navigator)
+function useOptionalIsFocused() {
+  return useContext(IsFocusedContext) ?? true
 }
 
 export function useClearPreferencesMutation() {


### PR DESCRIPTION
## Stacked on #10126 

This uses the React Query `subscribed` API to unsubscribe to queries that are offscreen. Applied initially to preferences and feeds.

This avoids a massive re-render when updating the list of saved feeds, as it will only take affect when you return to that page

I had to make a custom version of `useIsFocused` for `usePreferencesQuery` because some instances are outside of the navigation container