### PR TITLE
Fix slow re-renders when toggling content languages

### DIFF
--- a/src/screens/Settings/LanguageSettings.tsx
+++ b/src/screens/Settings/LanguageSettings.tsx
@@ -237,7 +237,7 @@ export function LanguageSettingsScreen({}: Props) {
                     feeds.
                   </Trans>
                 }
-                currentLanguages={langPrefs.contentLanguages}
+                currentLanguages={contentLanguages}
                 onSelectLanguages={languages => {
                   setContentLanguages(languages)
                   setRecentLanguages(recent => [

--- a/src/screens/Settings/LanguageSettings.tsx
+++ b/src/screens/Settings/LanguageSettings.tsx
@@ -34,6 +34,23 @@ export function LanguageSettingsScreen({}: Props) {
   const langPrefs = useLanguagePrefs()
   const setLangPrefs = useLanguagePrefsApi()
 
+  // changing langPrefs causes a slow re-render, so we use a local state copy
+  // and update that first to drive the UI on this screen to keep it snappy
+  const [contentLanguages, _setContentLanguages] = useState(
+    langPrefs.contentLanguages,
+  )
+  const setContentLanguages = useCallback(
+    (languages: string[]) => {
+      _setContentLanguages(languages)
+      // TODO: try using startTransition/useOptimistic when we switch to New Arch
+      // Old arch doesn't support concurrent react features so use rAF instead
+      requestAnimationFrame(() => {
+        setLangPrefs.setContentLanguages(languages)
+      })
+    },
+    [setLangPrefs],
+  )
+
   const contentLanguagePrefsControl = useDialogControl()
 
   const onChangePrimaryLanguage = useCallback(
@@ -167,7 +184,7 @@ export function LanguageSettingsScreen({}: Props) {
                 </Trans>
               </Text>
 
-              {langPrefs.contentLanguages.length === 0 && (
+              {contentLanguages.length === 0 && (
                 <Admonition type="info">
                   <Trans>All languages will be shown in your feeds.</Trans>
                 </Admonition>
@@ -176,8 +193,8 @@ export function LanguageSettingsScreen({}: Props) {
               <View style={[a.w_full, web({maxWidth: 400})]}>
                 <Toggle.Group
                   label={_(msg`Select content languages`)}
-                  values={langPrefs.contentLanguages}
-                  onChange={setLangPrefs.setContentLanguages}>
+                  values={contentLanguages}
+                  onChange={setContentLanguages}>
                   <Toggle.PanelGroup>
                     {possibleLanguages.map((language, index) => {
                       const name = languageName(language, langPrefs.appLanguage)
@@ -222,7 +239,7 @@ export function LanguageSettingsScreen({}: Props) {
                 }
                 currentLanguages={langPrefs.contentLanguages}
                 onSelectLanguages={languages => {
-                  setLangPrefs.setContentLanguages(languages)
+                  setContentLanguages(languages)
                   setRecentLanguages(recent => [
                     ...new Set([...recent, ...languages]),
                   ])

--- a/src/screens/Settings/LanguageSettings.tsx
+++ b/src/screens/Settings/LanguageSettings.tsx
@@ -81,13 +81,13 @@ export function LanguageSettingsScreen({}: Props) {
     return [
       ...new Set([
         ...recentLanguages,
-        ...langPrefs.contentLanguages,
+        ...contentLanguages,
         ...langPrefs.primaryLanguage,
       ]),
     ]
       .map(lang => LANGUAGES.find(l => l.code2 === lang))
       .filter(x => !!x)
-  }, [recentLanguages, langPrefs.contentLanguages, langPrefs.primaryLanguage])
+  }, [recentLanguages, contentLanguages, langPrefs.primaryLanguage])
 
   return (
     <Layout.Screen testID="PreferencesLanguagesScreen">


### PR DESCRIPTION
## Summary
- Content language toggles on the Language Settings screen caused slow re-renders because each toggle directly updated `langPrefs`, triggering an expensive re-render cycle
- Added local state copy (`contentLanguages`) that drives the UI immediately, while the actual `langPrefs` update is deferred to the next frame via `requestAnimationFrame`
- This keeps the toggle UI snappy while still persisting the preference

https://github.com/user-attachments/assets/104e8824-6e87-4357-b1bb-94c76970f596


## Test plan
- [ ] Open Settings → Languages
- [ ] Toggle content languages on/off rapidly — UI should feel responsive
- [ ] Verify selected languages persist correctly after leaving and returning to the screen
- [ ] Test on both iOS and Android

🤖 Generated with [Claude Code](https://claude.com/claude-code)