### PR TITLE
Prevent overflow-x on mobile browsers

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -78,6 +78,13 @@
         min-height: 100%;
         width: 100%;
       }
+      @media (max-width: 799px) {
+        html,
+        body,
+        #root {
+          overflow-x: hidden;
+        }
+      }
       html.theme--light,
       html.theme--light body,
       html.theme--light #root {


### PR DESCRIPTION
This was flagged on the Samsung Internet app, although it may affect other browsers as well.

Uses the same breakpoint as [`isMobile`](https://github.com/bluesky-social/social-app/blob/main/src/lib/hooks/useWebMediaQueries.tsx#L11).

| Before | After |
| - | - |
| <img width="1080" height="2400" alt="before" src="https://github.com/user-attachments/assets/e4575cd6-02f6-4ed4-b5d5-397a08b84f21" /> | <img width="1080" height="2400" alt="after" src="https://github.com/user-attachments/assets/64360f83-afaa-4168-9bbc-231e8472f25c" /> |

Tested in Samsung Internet and Chrome on a Pixel 8 (Android 16.0), and Safari on an iPhone 17 (iOS 26.3).