### PR TITLE
Hide alt text note after alt text is added

### DIFF
--- a/src/view/com/composer/GifAltText.tsx
+++ b/src/view/com/composer/GifAltText.tsx
@@ -101,7 +101,7 @@ export function GifAltTextDialogLoaded({
         </Text>
       </TouchableOpacity>
 
-      <Admonition type="tip" style={[a.mt_sm]}>
+      <Admonition type="info" style={[a.mt_sm]}>
         <Trans>
           Alt text describes images for blind and low-vision users, and helps
           give context to everyone.

--- a/src/view/com/composer/photos/Gallery.tsx
+++ b/src/view/com/composer/photos/Gallery.tsx
@@ -120,12 +120,14 @@ const GalleryInner = ({images, containerInfo, dispatch}: GalleryInnerProps) => {
           )
         })}
       </View>
-      <Admonition type="tip" style={[a.mt_sm]}>
-        <Trans>
-          Alt text describes images for blind and low-vision users, and helps
-          give context to everyone.
-        </Trans>
-      </Admonition>
+      {images.some(image => !image.alt) && (
+        <Admonition type="info" style={[a.mt_sm]}>
+          <Trans>
+            Alt text describes images for blind and low-vision users, and helps
+            give context to everyone.
+          </Trans>
+        </Admonition>
+      )}
     </>
   ) : null
 }


### PR DESCRIPTION
Fixes https://github.com/bluesky-social/social-app/issues/10123

Hides alt text note after alt text is added