### PR TITLE
Display see more link for suggested users in profile header

### DIFF
--- a/src/components/FeedInterstitials.tsx
+++ b/src/components/FeedInterstitials.tsx
@@ -603,16 +603,14 @@ export function ProfileGrid({
               decelerationRate="fast">
               {content}
 
-              {!isProfileHeaderContext && (
-                <SeeMoreSuggestedProfilesCard
-                  onPress={() => {
-                    followDialogControl.open()
-                    ax.metric('suggestedUser:seeMore', {
-                      logContext,
-                    })
-                  }}
-                />
-              )}
+              <SeeMoreSuggestedProfilesCard
+                onPress={() => {
+                  followDialogControl.open()
+                  ax.metric('suggestedUser:seeMore', {
+                    logContext,
+                  })
+                }}
+              />
             </ScrollView>
           </BlockDrawerGesture>
         )}


### PR DESCRIPTION
This was initially “Follow all” and excluded from the profile header, but now that it’s “See more” there’s no reason not to display it here.

<img width="402" height="874" alt="ios" src="https://github.com/user-attachments/assets/4f986d42-9d8e-40d2-8f86-ba90c6a6bb4f" />