### PR TITLE
Fix Safari layout shift issue with SubtleHover

### DIFF
--- a/src/components/SubtleHover.tsx
+++ b/src/components/SubtleHover.tsx
@@ -1,6 +1,6 @@
 import {View} from 'react-native'
 
-import {atoms as a, useTheme, type ViewStyleProp} from '#/alf'
+import {atoms as a, useTheme, type ViewStyleProp, web as webOnly} from '#/alf'
 import {IS_NATIVE, IS_WEB, IS_WEB_TOUCH_DEVICE} from '#/env'
 
 export function SubtleHover({
@@ -36,7 +36,8 @@ export function SubtleHover({
         // Force Safari to composite the overlay on its own GPU layer.
         // This fixes a layout shift that happens due to different subpixel
         // rounding when the overlay is composited on hover.
-        {opacity: hover ? opacity : 0.001},
+        webOnly({willChange: 'opacity'}),
+        {opacity: hover ? opacity : 0},
       ]}
     />
   )


### PR DESCRIPTION
This fixes a layout shift that happens due to different subpixel rounding when the overlay is composited on hover.

Uses `willChange: 'opacity'` to to force Safari to composite the overlay on its own GPU layer.

Tried accomplishing this via two hacks: a `translateZ: 0` `transform` and a near-but-not-exactly-zero value for `opacity`, e.g., `0.001`  but neither worked.