### PR TITLE
fix: show unfollow button in minimal profile header

### DIFF
--- a/src/screens/Profile/Header/ProfileHeaderStandard.tsx
+++ b/src/screens/Profile/Header/ProfileHeaderStandard.tsx
@@ -379,31 +379,29 @@ export function HeaderStandardButtons({
             </>
           )}
 
-          {(!minimal || !profile.viewer?.following) && (
-            <Button
-              testID={profile.viewer?.following ? 'unfollowBtn' : 'followBtn'}
-              size="small"
-              color={profile.viewer?.following ? 'secondary' : 'primary'}
-              label={
-                profile.viewer?.following
-                  ? _(msg`Unfollow ${profile.handle}`)
-                  : _(msg`Follow ${profile.handle}`)
-              }
-              onPress={
-                profile.viewer?.following ? onPressUnfollow : onPressFollow
-              }>
-              {!profile.viewer?.following && <ButtonIcon icon={Plus} />}
-              <ButtonText>
-                {profile.viewer?.following ? (
-                  <Trans>Following</Trans>
-                ) : profile.viewer?.followedBy ? (
-                  <Trans>Follow back</Trans>
-                ) : (
-                  <Trans>Follow</Trans>
-                )}
-              </ButtonText>
-            </Button>
-          )}
+          <Button
+            testID={profile.viewer?.following ? 'unfollowBtn' : 'followBtn'}
+            size="small"
+            color={profile.viewer?.following ? 'secondary' : 'primary'}
+            label={
+              profile.viewer?.following
+                ? _(msg`Unfollow ${profile.handle}`)
+                : _(msg`Follow ${profile.handle}`)
+            }
+            onPress={
+              profile.viewer?.following ? onPressUnfollow : onPressFollow
+            }>
+            {!profile.viewer?.following && <ButtonIcon icon={Plus} />}
+            <ButtonText>
+              {profile.viewer?.following ? (
+                <Trans>Following</Trans>
+              ) : profile.viewer?.followedBy ? (
+                <Trans>Follow back</Trans>
+              ) : (
+                <Trans>Follow</Trans>
+              )}
+            </ButtonText>
+          </Button>
         </>
       ) : null}
       <ProfileMenu profile={profile} />


### PR DESCRIPTION
## Problem

When viewing a profile on mobile and scrolling down to show the minimized profile header, users who are already following the account have no way to unfollow from this view. The follow/unfollow button was hidden when `minimal=true` and `profile.viewer?.following=true`.

Fixes #10124

## Solution

Remove the conditional wrapper `(!minimal || !profile.viewer?.following) &&` so the Follow/Unfollow button is always rendered in the minimal header, regardless of follow state.

## Changes

- Always show Follow/Unfollow button in minimal header
- Users can now unfollow directly from the minimized profile view
- No changes to non-minimal header behavior

## Testing

- [x] Verified button renders in minimal header when following
- [x] Verified button renders in minimal header when not following
- [x] Verified button functionality (follow/unfollow) works correctly
