### PR TITLE
Update emoji regex to detect variations and sequences

### DIFF
--- a/src/alf/typography.tsx
+++ b/src/alf/typography.tsx
@@ -1,12 +1,14 @@
 import {Children} from 'react'
-import {type TextProps as RNTextProps} from 'react-native'
-import {type StyleProp, type TextStyle} from 'react-native'
+import {
+  type StyleProp,
+  type TextProps as RNTextProps,
+  type TextStyle,
+} from 'react-native'
 import {UITextView} from 'react-native-uitextview'
 import createEmojiRegex from 'emoji-regex'
 
 import {type Alf, applyFonts, atoms, flatten} from '#/alf'
-import {IS_NATIVE} from '#/env'
-import {IS_IOS} from '#/env'
+import {IS_IOS, IS_NATIVE} from '#/env'
 
 /**
  * Ensures that `lineHeight` defaults to a relative value of `1`, or applies
@@ -107,7 +109,8 @@ export function renderChildrenWithEmoji(
   })
 }
 
-const SINGLE_EMOJI_RE = /^[\p{Emoji_Presentation}\p{Extended_Pictographic}]+$/u
+const SINGLE_EMOJI_RE =
+  /^[\p{Emoji_Presentation}\p{Extended_Pictographic}\uFE0F\u200D]+$/u
 export function isOnlyEmoji(text: string) {
   return text.length <= 15 && SINGLE_EMOJI_RE.test(text)
 }


### PR DESCRIPTION
Updates the `SINGLE_EMOJI_RE` regex to support emoji with variations like ⏹️ and multi-part emoji like 👨‍👩‍👧‍👧.

| Before | After |
| - | - |
| <img width="587" height="400" alt="before" src="https://github.com/user-attachments/assets/49d91fa3-a377-46cf-b18c-d867d28d539d" /> | <img width="585" height="446" alt="after" src="https://github.com/user-attachments/assets/81e01397-ca65-49f9-9d30-225e7f577bb9" /> |