### PR TITLE
Fix #9944: Prevent Enter key fallthrough in meatball menu

### DIFF
--- a/src/components/Menu/__tests__/menu-focus.test.tsx
+++ b/src/components/Menu/__tests__/menu-focus.test.tsx
@@ -1,0 +1,62 @@
+import {afterEach, describe, expect, jest, test} from '@jest/globals'
+
+jest.mock('#/alf', () => ({
+  atoms: {},
+  flatten: (value: unknown) => value,
+  useTheme: () => ({
+    name: 'light',
+    atoms: {},
+    palette: {},
+  }),
+  web: (value: unknown) => value,
+}))
+
+const {handleMenuContentFocusCapture} = require('#/components/Menu/index.web')
+
+describe('handleMenuContentFocusCapture', () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  test('restores focus to the trigger when content itself receives focus', () => {
+    const focus = jest.fn()
+    const triggerRef = {
+      current: {focus} as unknown as HTMLElement,
+    } as React.RefObject<HTMLElement | null>
+
+    jest.spyOn(global, 'requestAnimationFrame').mockImplementation(cb => {
+      cb(0)
+      return 0
+    })
+
+    handleMenuContentFocusCapture(
+      {
+        target: 'content',
+        currentTarget: 'content',
+      } as unknown as React.FocusEvent,
+      triggerRef,
+    )
+
+    expect(focus).toHaveBeenCalledTimes(1)
+  })
+
+  test('does not restore focus when a child element receives focus', () => {
+    const focus = jest.fn()
+    const triggerRef = {
+      current: {focus} as unknown as HTMLElement,
+    } as React.RefObject<HTMLElement | null>
+
+    const requestAnimationFrameSpy = jest.spyOn(global, 'requestAnimationFrame')
+
+    handleMenuContentFocusCapture(
+      {
+        target: 'child',
+        currentTarget: 'content',
+      } as unknown as React.FocusEvent,
+      triggerRef,
+    )
+
+    expect(requestAnimationFrameSpy).not.toHaveBeenCalled()
+    expect(focus).not.toHaveBeenCalled()
+  })
+})

--- a/src/components/Menu/index.web.tsx
+++ b/src/components/Menu/index.web.tsx
@@ -1,4 +1,4 @@
-import {forwardRef, useCallback, useId, useMemo, useState} from 'react'
+import {forwardRef, useCallback, useId, useMemo, useRef, useState} from 'react'
 import {
   Pressable,
   type StyleProp,
@@ -34,6 +34,34 @@ import {Text} from '#/components/Typography'
 
 export {useMenuContext}
 
+function assignRef<T>(ref: React.Ref<T | null> | undefined, value: T | null) {
+  // Support both callback refs and mutable refs when forwarding Radix's ref.
+  if (!ref) return
+
+  if (typeof ref === 'function') {
+    ref(value)
+  } else {
+    ;(ref as React.MutableRefObject<T | null>).current = value
+  }
+}
+
+export function handleMenuContentFocusCapture(
+  e: React.FocusEvent,
+  triggerRef?: React.RefObject<HTMLElement | null>,
+) {
+  /**
+   * If focus lands on the menu content itself instead of a menu item,
+   * move focus back to the trigger on the next frame. This prevents Enter
+   * from activating the underlying post link after opening the
+   * menu with the mouse.
+   */
+  if (e.target !== e.currentTarget) return
+
+  requestAnimationFrame(() => {
+    triggerRef?.current?.focus()
+  })
+}
+
 export function useMenuControl(): Dialog.DialogControlProps {
   const id = useId()
   const [isOpen, setIsOpen] = useState(false)
@@ -62,9 +90,12 @@ export function Root({
 }>) {
   const {_} = useLingui()
   const defaultControl = useMenuControl()
+  const triggerRef = useRef<HTMLElement | null>(null)
+
   const context = useMemo<ContextType>(
     () => ({
       control: control || defaultControl,
+      triggerRef,
     }),
     [control, defaultControl],
   )
@@ -125,7 +156,7 @@ export function Trigger({
   role = 'button',
   hint,
 }: TriggerProps) {
-  const {control} = useMenuContext()
+  const {control, triggerRef} = useMenuContext()
   const {
     state: hovered,
     onIn: onMouseEnter,
@@ -167,6 +198,16 @@ export function Trigger({
               onBlur: onBlur,
               onMouseEnter,
               onMouseLeave,
+
+              ref: (node: HTMLElement | null) => {
+                // Preserve the ref provided by Radix while also keeping our own reference
+                // to the trigger so focus can be restored from the menu content when needed.
+                assignRef(props.ref, node)
+                if (triggerRef) {
+                  triggerRef.current = node
+                }
+              },
+
               accessibilityHint: hint,
               accessibilityLabel: label,
               accessibilityRole: role,
@@ -187,6 +228,7 @@ export function Outer({
 }>) {
   const t = useTheme()
   const {reduceMotionEnabled} = useA11y()
+  const {triggerRef} = useMenuContext()
 
   return (
     <DropdownMenu.Portal>
@@ -195,7 +237,8 @@ export function Outer({
         collisionPadding={{left: 5, right: 5, bottom: 5}}
         loop
         aria-label="Test"
-        className="dropdown-menu-transform-origin dropdown-menu-constrain-size">
+        className="dropdown-menu-transform-origin dropdown-menu-constrain-size"
+        onFocusCapture={e => handleMenuContentFocusCapture(e, triggerRef)}>
         <View
           style={[
             a.rounded_sm,

--- a/src/components/Menu/types.ts
+++ b/src/components/Menu/types.ts
@@ -11,6 +11,7 @@ import {type Props as SVGIconProps} from '#/components/icons/common'
 
 export type ContextType = {
   control: Dialog.DialogOuterProps['control']
+  triggerRef?: React.RefObject<HTMLElement | null>
 }
 
 export type ItemContextType = {
@@ -18,7 +19,7 @@ export type ItemContextType = {
 }
 
 export type RadixPassThroughTriggerProps = {
-  ref: React.RefObject<any>
+  ref: React.Ref<any>
   id: string
   type: 'button'
   disabled: boolean


### PR DESCRIPTION
Fixes #9944. On web, opening the meatball menu with pointer interaction could leave focus on the dropdown content itself instead of on a menu item or the trigger. In that state, pressing Enter could fall through to the underlying post interaction, causing unexpected navigation.

This change keeps a ref to the menu trigger and restores focus to it when the dropdown content itself receives focus. By moving focus back to the trigger, subsequent keyboard input is handled by the menu trigger instead of leaking to the post behind it. A regression test was added to cover the case where the content itself receives focus and to ensure child-focus behavior remains unchanged.