### PR TITLE
Mitigate third-party frontend quoting loophole.

### DIFF
--- a/src/lib/api/resolve.ts
+++ b/src/lib/api/resolve.ts
@@ -1,10 +1,10 @@
 import {
   type AppBskyFeedDefs,
   type AppBskyGraphDefs,
+  type BskyAgent,
   type ComAtprotoRepoStrongRef,
 } from '@atproto/api'
 import {AtUri} from '@atproto/api'
-import {type BskyAgent} from '@atproto/api'
 
 import {POST_IMG_MAX} from '#/lib/constants'
 import {getLinkMeta} from '#/lib/link-meta/link-meta'
@@ -15,18 +15,20 @@ import {
   parseStarterPackUri,
 } from '#/lib/strings/starter-pack'
 import {
+  convertBskyAppUrlIfNeeded,
   isBskyCustomFeedUrl,
   isBskyListUrl,
   isBskyPostUrl,
   isBskyStarterPackUrl,
   isBskyStartUrl,
   isShortLink,
+  isThirdPartyFrontend,
+  makeRecordUri,
 } from '#/lib/strings/url-helpers'
 import {type ComposerImage} from '#/state/gallery'
 import {createComposerImage} from '#/state/gallery'
 import {type Gif} from '#/state/queries/tenor'
 import {createGIFDescription} from '../gif-alt-text'
-import {convertBskyAppUrlIfNeeded, makeRecordUri} from '../strings/url-helpers'
 
 type ResolvedExternalLink = {
   type: 'external'
@@ -84,11 +86,15 @@ export async function resolveLink(
   if (isShortLink(uri)) {
     uri = await resolveShortLink(uri)
   }
-  if (isBskyPostUrl(uri)) {
+  console.log('triggered!', isThirdPartyFrontend(uri))
+  if (isBskyPostUrl(uri) || isThirdPartyFrontend(uri)) {
     uri = convertBskyAppUrlIfNeeded(uri)
     const [_0, user, _1, rkey] = uri.split('/').filter(Boolean)
+    console.log('user', user)
     const recordUri = makeRecordUri(user, 'app.bsky.feed.post', rkey)
+    console.log('recordUri', recordUri)
     const post = await getPost({uri: recordUri})
+    console.log('post', post)
     if (post.viewer?.embeddingDisabled) {
       throw new EmbeddingDisabledError()
     }

--- a/src/lib/api/resolve.ts
+++ b/src/lib/api/resolve.ts
@@ -86,15 +86,11 @@ export async function resolveLink(
   if (isShortLink(uri)) {
     uri = await resolveShortLink(uri)
   }
-  console.log('triggered!', isThirdPartyFrontend(uri))
   if (isBskyPostUrl(uri) || isThirdPartyFrontend(uri)) {
     uri = convertBskyAppUrlIfNeeded(uri)
     const [_0, user, _1, rkey] = uri.split('/').filter(Boolean)
-    console.log('user', user)
     const recordUri = makeRecordUri(user, 'app.bsky.feed.post', rkey)
-    console.log('recordUri', recordUri)
     const post = await getPost({uri: recordUri})
-    console.log('post', post)
     if (post.viewer?.embeddingDisabled) {
       throw new EmbeddingDisabledError()
     }

--- a/src/lib/strings/url-helpers.ts
+++ b/src/lib/strings/url-helpers.ts
@@ -128,6 +128,30 @@ export function isBskyPostUrl(url: string): boolean {
   return false
 }
 
+export function isThirdPartyFrontend(url: string): boolean {
+  // A non-exhaustive list of third-party Bluesky frontends.
+  const alternativeFrontends = ['bsky.dev', 'deer.social', 'blacksky.community']
+
+  let parsedUrl
+  try {
+    parsedUrl = new URL(url)
+  } catch {
+    return false
+  }
+
+  for (const alternativeFrontendDomain of alternativeFrontends) {
+    let incomingRawDomain = parsedUrl.hostname.split('.').slice(-2).join('.') // Automatically filter subdomains. E.g. staging.bsky.dev and main.bsky.dev should be considered the same.
+    if (alternativeFrontendDomain == incomingRawDomain) {
+      return /profile\/(?<name>[^/]+)\/post\/(?<rkey>[^/]+)/i.test(
+        parsedUrl.pathname,
+      )
+    }
+  }
+
+  // No alternative frontends matched.
+  return false
+}
+
 export function isBskyCustomFeedUrl(url: string): boolean {
   if (isBskyAppUrl(url)) {
     try {
@@ -194,6 +218,13 @@ export function convertBskyAppUrlIfNeeded(url: string): string {
         return startUriToStarterPackUri(urlp.pathname)
       }
 
+      return urlp.pathname + urlp.search
+    } catch (e) {
+      console.error('Unexpected error in convertBskyAppUrlIfNeeded()', e)
+    }
+  } else if (isThirdPartyFrontend(url)) {
+    try {
+      const urlp = new URL(url)
       return urlp.pathname + urlp.search
     } catch (e) {
       console.error('Unexpected error in convertBskyAppUrlIfNeeded()', e)


### PR DESCRIPTION
Some posters are linking third-party frontends (e.g. deer.social) to evade disabled quote posts and continue harassment. This PR applies the same quote posting checks to third-party frontends.

If you have any other links to third-party frontends reply and I will add them. In the future it would be a good idea to recognise did and rkey URLs automatically without static domains but this seems like a good starting point.