### PR TITLE
Append profile to recent search history

### DIFF
--- a/src/screens/Search/Shell.tsx
+++ b/src/screens/Search/Shell.tsx
@@ -192,7 +192,7 @@ export function SearchScreenShell({
     (item: string) => {
       scrollToTopWeb()
       setShowAutocomplete(false)
-      updateSearchHistory(item)
+      updateSearchHistory(makeSearchQuery(item, fixedParams ?? {}))
 
       if (IS_WEB) {
         // @ts-expect-error route is not typesafe
@@ -202,7 +202,7 @@ export function SearchScreenShell({
         navigation.setParams({q: item})
       }
     },
-    [updateSearchHistory, navigation, route],
+    [updateSearchHistory, fixedParams, navigation, route],
   )
 
   const onPressCancelSearch = useCallback(() => {


### PR DESCRIPTION
If you search a profile your query will appear in "Recent searches". However, this feels useless if tapping a previously profile-specific query searches all of Bluesky. This PR updates this inconvenience.

Before:
<img width="602" height="146" alt="Screenshot 2026-03-31 at 7 01 01 PM" src="https://github.com/user-attachments/assets/b0fa4c65-0a96-4c71-a9f5-fdc8dc792559" />

After:
<img width="602" height="160" alt="Screenshot 2026-03-31 at 7 01 49 PM" src="https://github.com/user-attachments/assets/6a609084-3ab3-4349-a2b9-898b710f8928" />
