### PR TITLE
Remove direct dependency on `@expo/config-plugins`

### DIFF
--- a/package.json
+++ b/package.json
@@ -245,7 +245,6 @@
     "@babel/runtime": "^7.26.0",
     "@crowdin/cli": "^4.14.1",
     "@eslint/js": "^9.39.2",
-    "@expo/config-plugins": "~54.0.4",
     "@lingui/babel-plugin-lingui-macro": "^5.9.2",
     "@lingui/cli": "^5.9.2",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.15",

--- a/plugins/notificationsExtension/withAppEntitlements.js
+++ b/plugins/notificationsExtension/withAppEntitlements.js
@@ -1,7 +1,6 @@
-const {withEntitlementsPlist} = require('@expo/config-plugins')
+const {withEntitlementsPlist} = require('expo/config-plugins')
 
 const withAppEntitlements = config => {
-  // eslint-disable-next-line no-shadow
   return withEntitlementsPlist(config, async config => {
     config.modResults['com.apple.security.application-groups'] = [
       `group.app.bsky`,

--- a/plugins/notificationsExtension/withExtensionEntitlements.js
+++ b/plugins/notificationsExtension/withExtensionEntitlements.js
@@ -1,10 +1,9 @@
-const {withInfoPlist} = require('@expo/config-plugins')
+const {withInfoPlist} = require('expo/config-plugins')
 const plist = require('@expo/plist')
 const path = require('path')
 const fs = require('fs')
 
 const withExtensionEntitlements = (config, {extensionName}) => {
-  // eslint-disable-next-line no-shadow
   return withInfoPlist(config, config => {
     const extensionEntitlementsPath = path.join(
       config.modRequest.platformProjectRoot,

--- a/plugins/notificationsExtension/withExtensionInfoPlist.js
+++ b/plugins/notificationsExtension/withExtensionInfoPlist.js
@@ -1,10 +1,9 @@
-const {withInfoPlist} = require('@expo/config-plugins')
+const {withInfoPlist} = require('expo/config-plugins')
 const plist = require('@expo/plist')
 const path = require('path')
 const fs = require('fs')
 
 const withExtensionInfoPlist = (config, {extensionName}) => {
-  // eslint-disable-next-line no-shadow
   return withInfoPlist(config, config => {
     const plistPath = path.join(
       config.modRequest.projectRoot,

--- a/plugins/notificationsExtension/withExtensionViewController.js
+++ b/plugins/notificationsExtension/withExtensionViewController.js
@@ -1,4 +1,4 @@
-const {withXcodeProject} = require('@expo/config-plugins')
+const {withXcodeProject} = require('expo/config-plugins')
 const path = require('path')
 const fs = require('fs')
 
@@ -6,7 +6,6 @@ const withExtensionViewController = (
   config,
   {controllerName, extensionName},
 ) => {
-  // eslint-disable-next-line no-shadow
   return withXcodeProject(config, config => {
     const controllerPath = path.join(
       config.modRequest.projectRoot,

--- a/plugins/notificationsExtension/withNotificationsExtension.js
+++ b/plugins/notificationsExtension/withNotificationsExtension.js
@@ -1,4 +1,4 @@
-const {withPlugins} = require('@expo/config-plugins')
+const {withPlugins} = require('expo/config-plugins')
 const {withAppEntitlements} = require('./withAppEntitlements')
 const {withXcodeTarget} = require('./withXcodeTarget')
 const {withExtensionEntitlements} = require('./withExtensionEntitlements')

--- a/plugins/notificationsExtension/withSounds.js
+++ b/plugins/notificationsExtension/withSounds.js
@@ -1,9 +1,8 @@
-const {withXcodeProject} = require('@expo/config-plugins')
+const {withXcodeProject} = require('expo/config-plugins')
 const path = require('path')
 const fs = require('fs')
 
 const withSounds = (config, {extensionName, soundFiles}) => {
-  // eslint-disable-next-line no-shadow
   return withXcodeProject(config, config => {
     for (const file of soundFiles) {
       const soundPath = path.join(config.modRequest.projectRoot, 'assets', file)

--- a/plugins/notificationsExtension/withXcodeTarget.js
+++ b/plugins/notificationsExtension/withXcodeTarget.js
@@ -1,12 +1,9 @@
-const {withXcodeProject, IOSConfig} = require('@expo/config-plugins')
-const path = require('path')
-const PBXFile = require('xcode/lib/pbxFile')
+const {withXcodeProject} = require('expo/config-plugins')
 
 const withXcodeTarget = (
   config,
   {extensionName, controllerName, soundFiles},
 ) => {
-  // eslint-disable-next-line no-shadow
   return withXcodeProject(config, config => {
     let pbxProject = config.modResults
 

--- a/plugins/shareExtension/withAppEntitlements.js
+++ b/plugins/shareExtension/withAppEntitlements.js
@@ -1,7 +1,6 @@
-const {withEntitlementsPlist} = require('@expo/config-plugins')
+const {withEntitlementsPlist} = require('expo/config-plugins')
 
 const withAppEntitlements = config => {
-  // eslint-disable-next-line no-shadow
   return withEntitlementsPlist(config, async config => {
     config.modResults['com.apple.security.application-groups'] = [
       `group.app.bsky`,

--- a/plugins/shareExtension/withExtensionEntitlements.js
+++ b/plugins/shareExtension/withExtensionEntitlements.js
@@ -1,10 +1,9 @@
-const {withInfoPlist} = require('@expo/config-plugins')
+const {withInfoPlist} = require('expo/config-plugins')
 const plist = require('@expo/plist')
 const path = require('path')
 const fs = require('fs')
 
 const withExtensionEntitlements = (config, {extensionName}) => {
-  // eslint-disable-next-line no-shadow
   return withInfoPlist(config, config => {
     const extensionEntitlementsPath = path.join(
       config.modRequest.platformProjectRoot,

--- a/plugins/shareExtension/withExtensionInfoPlist.js
+++ b/plugins/shareExtension/withExtensionInfoPlist.js
@@ -1,10 +1,9 @@
-const {withInfoPlist} = require('@expo/config-plugins')
+const {withInfoPlist} = require('expo/config-plugins')
 const plist = require('@expo/plist')
 const path = require('path')
 const fs = require('fs')
 
 const withExtensionInfoPlist = (config, {extensionName}) => {
-  // eslint-disable-next-line no-shadow
   return withInfoPlist(config, config => {
     const plistPath = path.join(
       config.modRequest.projectRoot,

--- a/plugins/shareExtension/withExtensionViewController.js
+++ b/plugins/shareExtension/withExtensionViewController.js
@@ -1,4 +1,4 @@
-const {withXcodeProject} = require('@expo/config-plugins')
+const {withXcodeProject} = require('expo/config-plugins')
 const path = require('path')
 const fs = require('fs')
 
@@ -6,7 +6,6 @@ const withExtensionViewController = (
   config,
   {controllerName, extensionName},
 ) => {
-  // eslint-disable-next-line no-shadow
   return withXcodeProject(config, config => {
     const controllerPath = path.join(
       config.modRequest.projectRoot,

--- a/plugins/shareExtension/withIntentFilters.js
+++ b/plugins/shareExtension/withIntentFilters.js
@@ -1,7 +1,6 @@
-const {withAndroidManifest} = require('@expo/config-plugins')
+const {withAndroidManifest} = require('expo/config-plugins')
 
 const withIntentFilters = config => {
-  // eslint-disable-next-line no-shadow
   return withAndroidManifest(config, config => {
     const intents = [
       {

--- a/plugins/shareExtension/withShareExtensions.js
+++ b/plugins/shareExtension/withShareExtensions.js
@@ -1,4 +1,4 @@
-const {withPlugins} = require('@expo/config-plugins')
+const {withPlugins} = require('expo/config-plugins')
 const {withAppEntitlements} = require('./withAppEntitlements')
 const {withXcodeTarget} = require('./withXcodeTarget')
 const {withExtensionEntitlements} = require('./withExtensionEntitlements')

--- a/plugins/shareExtension/withXcodeTarget.js
+++ b/plugins/shareExtension/withXcodeTarget.js
@@ -1,7 +1,6 @@
-const {withXcodeProject} = require('@expo/config-plugins')
+const {withXcodeProject} = require('expo/config-plugins')
 
 const withXcodeTarget = (config, {extensionName, controllerName}) => {
-  // eslint-disable-next-line no-shadow
   return withXcodeProject(config, config => {
     const pbxProject = config.modResults
 

--- a/plugins/starterPackAppClipExtension/withAppEntitlements.js
+++ b/plugins/starterPackAppClipExtension/withAppEntitlements.js
@@ -1,7 +1,6 @@
-const {withEntitlementsPlist} = require('@expo/config-plugins')
+const {withEntitlementsPlist} = require('expo/config-plugins')
 
 const withAppEntitlements = config => {
-  // eslint-disable-next-line no-shadow
   return withEntitlementsPlist(config, async config => {
     config.modResults['com.apple.security.application-groups'] = [
       `group.app.bsky`,

--- a/plugins/starterPackAppClipExtension/withClipEntitlements.js
+++ b/plugins/starterPackAppClipExtension/withClipEntitlements.js
@@ -1,10 +1,9 @@
-const {withInfoPlist} = require('@expo/config-plugins')
+const {withInfoPlist} = require('expo/config-plugins')
 const plist = require('@expo/plist')
 const path = require('path')
 const fs = require('fs')
 
 const withClipEntitlements = (config, {targetName}) => {
-  // eslint-disable-next-line no-shadow
   return withInfoPlist(config, config => {
     const entitlementsPath = path.join(
       config.modRequest.platformProjectRoot,

--- a/plugins/starterPackAppClipExtension/withClipInfoPlist.js
+++ b/plugins/starterPackAppClipExtension/withClipInfoPlist.js
@@ -1,10 +1,9 @@
-const {withInfoPlist} = require('@expo/config-plugins')
+const {withInfoPlist} = require('expo/config-plugins')
 const plist = require('@expo/plist')
 const path = require('path')
 const fs = require('fs')
 
 const withClipInfoPlist = (config, {targetName}) => {
-  // eslint-disable-next-line no-shadow
   return withInfoPlist(config, config => {
     const targetPath = path.join(
       config.modRequest.platformProjectRoot,

--- a/plugins/starterPackAppClipExtension/withFiles.js
+++ b/plugins/starterPackAppClipExtension/withFiles.js
@@ -1,11 +1,10 @@
-const {withXcodeProject} = require('@expo/config-plugins')
+const {withXcodeProject} = require('expo/config-plugins')
 const path = require('path')
 const fs = require('fs')
 
 const FILES = ['AppDelegate.swift', 'ViewController.swift']
 
 const withFiles = (config, {targetName}) => {
-  // eslint-disable-next-line no-shadow
   return withXcodeProject(config, config => {
     const basePath = path.join(
       config.modRequest.projectRoot,

--- a/plugins/starterPackAppClipExtension/withStarterPackAppClip.js
+++ b/plugins/starterPackAppClipExtension/withStarterPackAppClip.js
@@ -1,4 +1,4 @@
-const {withPlugins} = require('@expo/config-plugins')
+const {withPlugins} = require('expo/config-plugins')
 const {withAppEntitlements} = require('./withAppEntitlements')
 const {withClipEntitlements} = require('./withClipEntitlements')
 const {withClipInfoPlist} = require('./withClipInfoPlist')

--- a/plugins/starterPackAppClipExtension/withXcodeTarget.js
+++ b/plugins/starterPackAppClipExtension/withXcodeTarget.js
@@ -1,9 +1,8 @@
-const {withXcodeProject} = require('@expo/config-plugins')
+const {withXcodeProject} = require('expo/config-plugins')
 
 const BUILD_PHASE_FILES = ['AppDelegate.swift', 'ViewController.swift']
 
 const withXcodeTarget = (config, {targetName}) => {
-  // eslint-disable-next-line no-shadow
   return withXcodeProject(config, config => {
     const pbxProject = config.modResults
 

--- a/plugins/withAndroidManifestIntentQueriesPlugin.js
+++ b/plugins/withAndroidManifestIntentQueriesPlugin.js
@@ -1,7 +1,6 @@
-const {withAndroidManifest} = require('@expo/config-plugins')
+const {withAndroidManifest} = require('expo/config-plugins')
 
 const withProcessTextQuery = config =>
-  // eslint-disable-next-line no-shadow
   withAndroidManifest(config, config => {
     const manifest = config.modResults.manifest
 

--- a/plugins/withAndroidNoJitpackPlugin.js
+++ b/plugins/withAndroidNoJitpackPlugin.js
@@ -1,4 +1,4 @@
-const {withProjectBuildGradle} = require('@expo/config-plugins')
+const {withProjectBuildGradle} = require('expo/config-plugins')
 
 const jitpackRepository = "maven { url 'https://www.jitpack.io' }"
 

--- a/plugins/withAndroidStylesAccentColorPlugin.js
+++ b/plugins/withAndroidStylesAccentColorPlugin.js
@@ -3,7 +3,7 @@
  * This way we get a sane default color for spinners, text inputs, etc.
  */
 
-const {withAndroidStyles, AndroidConfig} = require('@expo/config-plugins')
+const {withAndroidStyles, AndroidConfig} = require('expo/config-plugins')
 
 module.exports = function withAndroidStylesAccentColorPlugin(appConfig) {
   return withAndroidStyles(appConfig, function (decoratedAppConfig) {

--- a/plugins/withAppDelegateReferrer.js
+++ b/plugins/withAppDelegateReferrer.js
@@ -1,11 +1,10 @@
-const {withAppDelegate} = require('@expo/config-plugins')
-const {mergeContents} = require('@expo/config-plugins/build/utils/generateCode')
+const {withAppDelegate, CodeGenerator} = require('expo/config-plugins')
 
 module.exports = config =>
   withAppDelegate(config, config => {
     let contents = config.modResults.contents
 
-    contents = mergeContents({
+    contents = CodeGenerator.mergeContents({
       src: contents,
       anchor: '// Linking API',
       newSrc: `
@@ -22,7 +21,7 @@ module.exports = config =>
       comment: '//',
     }).contents
 
-    contents = mergeContents({
+    contents = CodeGenerator.mergeContents({
       src: contents,
       anchor: '// Universal Links',
       newSrc: `


### PR DESCRIPTION
According to expo-doctor, we should be using `expo/config-plugins` instead. Updates our config plugins to do this