### PR TITLE
Scale profile badge icons with font size

### DIFF
--- a/src/components/ProfileBadges.tsx
+++ b/src/components/ProfileBadges.tsx
@@ -1,7 +1,7 @@
-import {View} from 'react-native'
+import {useWindowDimensions, View} from 'react-native'
 
 import {useProfileShadow} from '#/state/cache/profile-shadow'
-import {atoms as a, type ViewStyleProp} from '#/alf'
+import {atoms as a, useAlf, type ViewStyleProp} from '#/alf'
 import {BotBadge, BotBadgeButton, isBotAccount} from '#/components/BotBadge'
 import {useSimpleVerificationState} from '#/components/verification'
 import {VerificationCheck} from '#/components/verification/VerificationCheck'
@@ -38,11 +38,20 @@ export function ProfileBadges({
 }) {
   const shadowed = useProfileShadow(profile)
   const verification = useSimpleVerificationState({profile})
+  const {fontScale: nativeScaleMultiplier} = useWindowDimensions()
+  const {
+    fonts: {scaleMultiplier: alfScaleMultiplier},
+  } = useAlf()
 
   // if nothing to show, don't render the container at all
   if (!verification.showBadge && !isBotAccount(shadowed)) return null
 
   const isOnTheSmallSide = size === 'xs' || size === 'sm'
+
+  const verificationIconWidth =
+    verificationIconSizes[size] * nativeScaleMultiplier * alfScaleMultiplier
+  const botIconWidth =
+    botIconSizes[size] * nativeScaleMultiplier * alfScaleMultiplier
 
   return (
     <View
@@ -56,19 +65,19 @@ export function ProfileBadges({
         <>
           <VerificationCheckButton
             profile={shadowed}
-            width={verificationIconSizes[size]}
+            width={verificationIconWidth}
           />
-          <BotBadgeButton profile={shadowed} width={botIconSizes[size]} />
+          <BotBadgeButton profile={shadowed} width={botIconWidth} />
         </>
       ) : (
         <>
           {verification.showBadge && (
             <VerificationCheck
               verifier={verification.role === 'verifier'}
-              width={verificationIconSizes[size]}
+              width={verificationIconWidth}
             />
           )}
-          <BotBadge profile={shadowed} width={botIconSizes[size]} />
+          <BotBadge profile={shadowed} width={botIconWidth} />
         </>
       )}
     </View>


### PR DESCRIPTION
## Summary
- Profile badge icons (verification check, bot badge) now scale with the user's font size settings
- Uses both the native font scale multiplier and the ALF scale multiplier to compute icon widths
<table>
  <thead>
    <tr>
      <th>Before</th>
      <th>After</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td><img width="300" src="https://github.com/user-attachments/assets/697bb804-f195-479d-8726-15b12716fcba" /></td>
      <td><img width="300" src="https://github.com/user-attachments/assets/551e0b17-6333-4532-b166-58f2074223d0" /></td>
    </tr>
    <tr>
      <td><img width="300" src="https://github.com/user-attachments/assets/acde3757-3b5b-4ba3-af3c-e36b36abf43b" /></td>
      <td><img width="300" src="https://github.com/user-attachments/assets/b6093e6e-02e3-402d-b261-2f5c79869f99" /></td>
    </tr>
    <tr>
      <td><img width="300" src="https://github.com/user-attachments/assets/8d7f3351-df02-438d-8758-697f256ca5e6" /></td>
      <td><img width="300" src="https://github.com/user-attachments/assets/63aa7ca5-2593-4fcb-a609-a8543afd047c" /></td>
    </tr>
  </tbody>
</table>


## Test plan
- [ ] Change device font size to largest setting, verify badge icons scale up proportionally
- [ ] Verify badges look correct at default font size
- [ ] Test on both iOS and Android

🤖 Generated with [Claude Code](https://claude.com/claude-code)