### PR TITLE
Fix bottom bar badge text padding

### DIFF
--- a/src/view/shell/bottom-bar/BottomBar.tsx
+++ b/src/view/shell/bottom-bar/BottomBar.tsx
@@ -407,7 +407,9 @@ function Btn({
           </Text>
         </View>
       ) : hasNew ? (
-        <View style={[styles.hasNewBadge, a.rounded_full]} />
+        <View
+          style={[styles.hasNewBadge, {backgroundColor: t.palette.primary_500}]}
+        />
       ) : null}
     </PressableScale>
   )

--- a/src/view/shell/bottom-bar/BottomBarStyles.tsx
+++ b/src/view/shell/bottom-bar/BottomBarStyles.tsx
@@ -1,6 +1,5 @@
 import {StyleSheet} from 'react-native'
 
-import {colors} from '#/lib/styles'
 import {atoms as a} from '#/alf'
 
 export const styles = StyleSheet.create({
@@ -38,7 +37,7 @@ export const styles = StyleSheet.create({
   notificationCountLabel: {
     fontSize: 12,
     fontWeight: '600',
-    color: colors.white,
+    color: 'white',
     fontVariant: ['tabular-nums'],
     includeFontPadding: false,
   },
@@ -49,8 +48,7 @@ export const styles = StyleSheet.create({
     top: 10,
     width: 8,
     height: 8,
-    backgroundColor: colors.blue3,
-    borderRadius: 6,
+    borderRadius: 4,
     zIndex: 1,
   },
   ctrlIcon: {

--- a/src/view/shell/bottom-bar/BottomBarWeb.tsx
+++ b/src/view/shell/bottom-bar/BottomBarWeb.tsx
@@ -313,7 +313,9 @@ const NavItem: React.FC<{
           <Text style={styles.notificationCountLabel}>{notificationCount}</Text>
         </View>
       ) : hasNew ? (
-        <View style={styles.hasNewBadge} />
+        <View
+          style={[styles.hasNewBadge, {backgroundColor: t.palette.primary_500}]}
+        />
       ) : null}
     </Link>
   )


### PR DESCRIPTION
Fixes oval-shaped badge on Android caused by `includeFontPadding`. Disabled that and increased padding by 1px in all directions, which feels more balanced

## Before
<img width="413" height="178" alt="Screenshot 2026-04-02 at 14 24 37" src="https://github.com/user-attachments/assets/a3d22e96-bfba-4333-b1af-00360adb5deb" />

## After
<img width="412" height="158" alt="Screenshot 2026-04-02 at 14 14 26" src="https://github.com/user-attachments/assets/97986a6b-4b52-486a-bba9-ad0e89766ab5" />
