### PR TITLE
Fix `useResolveUriQuery`

### DIFF
--- a/src/state/queries/resolve-uri.ts
+++ b/src/state/queries/resolve-uri.ts
@@ -44,7 +44,7 @@ export function useResolveUriQuery(uri: string | undefined) {
     ...resolvedDidQueryOptions(agent, getUnstableProfile, host),
     select: did => ({
       did,
-      uri: urip.toString(),
+      uri: AtUri.make(did, urip.collection, urip.rkey).toString(),
     }),
   })
 }


### PR DESCRIPTION
Follow up to #10126 

I misunderstood what was happening in `useResolveUriQuery` and returned the wrong URI - it should have the handle replaced with the DID. Fixed by using `AtUri.make()`

## Test plan

Go to the Lists page and click on a list