### PR TITLE
Warn when useState get/set names mismatch

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -127,6 +127,7 @@ export default defineConfig(
        */
       ...react.configs.recommended.rules,
       ...react.configs['jsx-runtime'].rules,
+      'react/hook-use-state': 'warn',
       'react/no-unescaped-entities': 'off',
       'react/prop-types': 'off',
       'react-native/no-inline-styles': 'off',


### PR DESCRIPTION
Just enforcing convention. We only have 40 violations of this; should be easy to clean up as we go.

```diff
- const [hasAnyLoaded, setAnyHasLoaded] = useState(false)
+ const [hasAnyLoaded, setHasAnyLoaded] = useState(false)
```