### PR TITLE
bskyweb: update to golang v1.26

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25-bookworm AS build-env
+FROM golang:1.26-bookworm AS build-env
 
 WORKDIR /usr/src/social-app
 

--- a/Dockerfile.embedr
+++ b/Dockerfile.embedr
@@ -1,4 +1,4 @@
-FROM golang:1.25-bookworm AS build-env
+FROM golang:1.26-bookworm AS build-env
 
 WORKDIR /usr/src/social-app
 

--- a/bskyweb/cmd/bskyweb/renderer.go
+++ b/bskyweb/cmd/bskyweb/renderer.go
@@ -54,7 +54,7 @@ func NewRenderer(prefix string, fs *embed.FS, debug bool) *Renderer {
 	}
 }
 
-func (r Renderer) Render(w io.Writer, name string, data interface{}, c echo.Context) error {
+func (r Renderer) Render(w io.Writer, name string, data any, c echo.Context) error {
 	var ctx pongo2.Context
 
 	if data != nil {

--- a/bskyweb/cmd/embedr/render.go
+++ b/bskyweb/cmd/embedr/render.go
@@ -11,6 +11,6 @@ type Template struct {
 	templates *template.Template
 }
 
-func (t *Template) Render(w io.Writer, name string, data interface{}, c echo.Context) error {
+func (t *Template) Render(w io.Writer, name string, data any, c echo.Context) error {
 	return t.templates.ExecuteTemplate(w, name, data)
 }

--- a/bskyweb/cmd/embedr/server.go
+++ b/bskyweb/cmd/embedr/server.go
@@ -180,9 +180,9 @@ func serve(cctx *cli.Context) error {
 
 	// Create CORS middleware for oembed
 	oembedCORS := middleware.CORSWithConfig(middleware.CORSConfig{
-			AllowOrigins: []string{"*"},
-			AllowMethods: []string{http.MethodGet, http.MethodHead, http.MethodOptions},
-			AllowHeaders: []string{"Origin", "Content-Type", "Accept"},
+		AllowOrigins: []string{"*"},
+		AllowMethods: []string{http.MethodGet, http.MethodHead, http.MethodOptions},
+		AllowHeaders: []string{"Origin", "Content-Type", "Accept"},
 	})
 
 	e.GET("/robots.txt", echo.WrapHandler(staticHandler))
@@ -271,7 +271,7 @@ func (srv *Server) errorHandler(err error, c echo.Context) {
 		code = he.Code
 	}
 	c.Logger().Error(err)
-	data := map[string]interface{}{
+	data := map[string]any{
 		"statusCode": code,
 	}
 	c.Render(code, "error.html", data)

--- a/bskyweb/go.mod
+++ b/bskyweb/go.mod
@@ -1,6 +1,6 @@
 module github.com/bluesky-social/social-app/bskyweb
 
-go 1.25
+go 1.26
 
 require (
 	github.com/bluesky-social/indigo v0.0.0-20250729223159-573ae927246a


### PR DESCRIPTION
Keeping up with Go language updates, per our usual process/policy (v1.26.1 has been out for a while).

Ran `go fix`, which applies basic style/lint tweaks, and the changes look safe/trivial, so I rolled them up here.