### PR TITLE
Update / hotkey to support all keyboard layouts

### DIFF
--- a/src/lib/hotkeys/index.tsx
+++ b/src/lib/hotkeys/index.tsx
@@ -71,5 +71,6 @@ function useKeyboardShortcuts() {
     scopes: ['global'],
     preventDefault: true,
     description: l`Focus the search field`,
+    useKey: true, // Support international and alternate keyboard layouts
   })
 }


### PR DESCRIPTION
This issue was raised in #10145: The previous implementation did not support international or alternate keyboard layouts.

Passing `useKey: true` here ensures the `/` [hotkey is consistent](https://react-hotkeys-hook.vercel.app/docs/documentation/useHotkeys/ignore-layouts#option-2---listen-to-the-produced-key-layout-dependent) regardless of layout.