### PR TITLE
Disable keyboard preload on iOS to prevent keyboard flash

### DIFF
--- a/src/App.native.tsx
+++ b/src/App.native.tsx
@@ -235,7 +235,7 @@ function App() {
     <Geo.Provider>
       <AppConfigProvider>
         <A11yProvider>
-          <KeyboardControllerProvider>
+          <KeyboardControllerProvider preload={false}>
             <OnboardingProvider>
               <AnalyticsContext>
                 <SessionProvider>


### PR DESCRIPTION
## Scope
Disable keyboard preload on iOS to prevent the keyboard from briefly flashing on screen during app initialization.

## Implementation
Set `preload={false}` on `KeyboardControllerProvider` in `App.native.tsx`. The preload feature is unnecessary since the app's landing screen has no text inputs — the keyboard will be naturally initialized by the time a user navigates to a screen with inputs (composer, search, messages, etc.).

Reference: https://kirillzyusko.github.io/react-native-keyboard-controller/docs/api/keyboard-provider#preload-

## Issue

https://github.com/user-attachments/assets/9c2f3094-dab5-4731-b2ee-23a391e3134e

