### PR TITLE
Write chat declaration record in response to different events

### DIFF
--- a/src/ageAssurance/data.tsx
+++ b/src/ageAssurance/data.tsx
@@ -1,11 +1,4 @@
-import {
-  createContext,
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useState,
-} from 'react'
+import {createContext, useCallback, useContext, useEffect, useMemo} from 'react'
 import {
   type AppBskyAgeassuranceDefs,
   type AppBskyAgeassuranceGetConfig,
@@ -560,27 +553,10 @@ export function AgeAssuranceDataProvider({
   const {state, metadata} = serverState.data || {}
   const {data} = useOtherRequiredDataQuery()
 
-  const [s, setS] = useState<any>()
-  if (!s && state && state !== s) {
-    setS(state)
-  }
-
-  useEffect(() => {
-    const t = setTimeout(() => {
-      console.log('Simulating server state update...')
-      setS({
-        lastInitiatedAt: new Date(2025, 1, 1).toISOString(),
-        status: 'assured',
-        access: 'safe',
-      })
-    }, 5e3)
-    return () => clearTimeout(t)
-  }, [setS])
-
   const ctx = useMemo(
     () => ({
       config,
-      state: s,
+      state,
       data: {
         accountCreatedAt: metadata?.accountCreatedAt,
         declaredAge: data?.birthdate
@@ -589,7 +565,7 @@ export function AgeAssuranceDataProvider({
         birthdate: data?.birthdate,
       },
     }),
-    [config, s, data, metadata],
+    [config, state, data, metadata],
   )
   return (
     <AgeAssuranceDataContext.Provider value={ctx}>

--- a/src/ageAssurance/data.tsx
+++ b/src/ageAssurance/data.tsx
@@ -1,4 +1,11 @@
-import {createContext, useCallback, useContext, useEffect, useMemo} from 'react'
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react'
 import {
   type AppBskyAgeassuranceDefs,
   type AppBskyAgeassuranceGetConfig,
@@ -410,6 +417,23 @@ export function getOtherRequiredDataFromCache({
     createOtherRequiredDataQueryKey({did}),
   )
 }
+export function setOtherRequireDataActorDeclarationForDid({
+  did,
+  actorDeclaration,
+}: {
+  did: string
+  actorDeclaration: ActorDeclaration
+}) {
+  const prev = getOtherRequiredDataFromCache({did})
+  const next: OtherRequiredData = {
+    birthdate: prev?.birthdate,
+    actorDeclaration,
+  }
+  qc.setQueryData<OtherRequiredData>(
+    createOtherRequiredDataQueryKey({did}),
+    next,
+  )
+}
 export async function prefetchOtherRequiredData({agent}: {agent: AtpAgent}) {
   const did = getDidFromAgentSession(agent)
 
@@ -535,10 +559,28 @@ export function AgeAssuranceDataProvider({
   const serverState = useServerStateQuery()
   const {state, metadata} = serverState.data || {}
   const {data} = useOtherRequiredDataQuery()
+
+  const [s, setS] = useState<any>()
+  if (!s && state && state !== s) {
+    setS(state)
+  }
+
+  useEffect(() => {
+    const t = setTimeout(() => {
+      console.log('Simulating server state update...')
+      setS({
+        lastInitiatedAt: new Date(2025, 1, 1).toISOString(),
+        status: 'assured',
+        access: 'safe',
+      })
+    }, 5e3)
+    return () => clearTimeout(t)
+  }, [setS])
+
   const ctx = useMemo(
     () => ({
       config,
-      state,
+      state: s,
       data: {
         accountCreatedAt: metadata?.accountCreatedAt,
         declaredAge: data?.birthdate
@@ -547,7 +589,7 @@ export function AgeAssuranceDataProvider({
         birthdate: data?.birthdate,
       },
     }),
-    [config, state, data, metadata],
+    [config, s, data, metadata],
   )
   return (
     <AgeAssuranceDataContext.Provider value={ctx}>

--- a/src/ageAssurance/data.tsx
+++ b/src/ageAssurance/data.tsx
@@ -4,6 +4,7 @@ import {
   type AppBskyAgeassuranceGetConfig,
   type AppBskyAgeassuranceGetState,
   AtpAgent,
+  type ChatBskyActorDeclaration,
   getAgeAssuranceRegionConfig,
 } from '@atproto/api'
 import {createAsyncStoragePersister} from '@tanstack/query-async-storage-persister'
@@ -19,6 +20,7 @@ import {
   hasSnoozedBirthdateUpdateForDid,
   snoozeBirthdateUpdateAllowedForDid,
 } from '#/state/birthdate'
+import {fetchActorDeclarationRecord} from '#/state/queries/messages/actor-declaration'
 import {useAgent, useSession} from '#/state/session'
 import * as debug from '#/ageAssurance/debug'
 import {logger} from '#/ageAssurance/logger'
@@ -323,13 +325,9 @@ export function useServerStateQuery() {
  * Other required data
  */
 
-type AllowIncoming = 'all' | 'none' | 'following'
-type ActorDeclaration = {
-  allowIncoming: AllowIncoming
-}
 export type OtherRequiredData = {
   birthdate: string | undefined
-  actorDeclaration?: ActorDeclaration | undefined
+  actorDeclaration?: ChatBskyActorDeclaration.Main
 }
 export function createOtherRequiredDataQueryKey({did}: {did: string}) {
   return ['otherRequiredData', did]
@@ -341,21 +339,10 @@ async function getOtherRequiredData({
 }): Promise<OtherRequiredData> {
   if (debug.enabled) return debug.resolve(debug.otherRequiredData)
   const did = getDidFromAgentSession(agent)
-  const [prefs, declaration] = await Promise.all([
+  const [prefs, actorDeclaration] = await Promise.all([
     agent.getPreferences(),
-    did
-      ? agent.com.atproto.repo
-          .getRecord({
-            repo: did,
-            collection: 'chat.bsky.actor.declaration',
-            rkey: 'self',
-          })
-          .catch(_e => undefined)
-      : undefined,
+    fetchActorDeclarationRecord({did, agent}),
   ])
-  const actorDeclaration = declaration?.data.value as
-    | ActorDeclaration
-    | undefined
   const data: OtherRequiredData = {
     birthdate: prefs.birthDate ? prefs.birthDate.toISOString() : undefined,
     actorDeclaration,
@@ -415,12 +402,15 @@ export function setOtherRequireDataActorDeclarationForDid({
   actorDeclaration,
 }: {
   did: string
-  actorDeclaration: ActorDeclaration
+  actorDeclaration: ChatBskyActorDeclaration.Main
 }) {
   const prev = getOtherRequiredDataFromCache({did})
   const next: OtherRequiredData = {
     birthdate: prev?.birthdate,
-    actorDeclaration,
+    actorDeclaration: {
+      ...(prev?.actorDeclaration || {}),
+      ...actorDeclaration,
+    },
   }
   qc.setQueryData<OtherRequiredData>(
     createOtherRequiredDataQueryKey({did}),

--- a/src/ageAssurance/data.tsx
+++ b/src/ageAssurance/data.tsx
@@ -53,7 +53,7 @@ const [, cacheHydrationPromise] = persistQueryClient({
   persister,
 })
 
-function getDidFromAgentSession(agent: AtpAgent) {
+export function getDidFromAgentSession(agent: AtpAgent) {
   const sessionManager = agent.sessionManager
   if (!sessionManager || !sessionManager.did) return
   return sessionManager.did
@@ -323,21 +323,42 @@ export function useServerStateQuery() {
  * Other required data
  */
 
+type AllowIncoming = 'all' | 'none' | 'following'
+type ActorDeclaration = {
+  allowIncoming: AllowIncoming
+}
 export type OtherRequiredData = {
   birthdate: string | undefined
+  actorDeclaration?: ActorDeclaration | undefined
 }
 export function createOtherRequiredDataQueryKey({did}: {did: string}) {
   return ['otherRequiredData', did]
 }
-export async function getOtherRequiredData({
+async function getOtherRequiredData({
   agent,
 }: {
   agent: AtpAgent
 }): Promise<OtherRequiredData> {
   if (debug.enabled) return debug.resolve(debug.otherRequiredData)
-  const [prefs] = await Promise.all([agent.getPreferences()])
+  const did = getDidFromAgentSession(agent)
+  const [prefs, declaration] = await Promise.all([
+    agent.getPreferences(),
+    did
+      ? agent.com.atproto.repo
+          .getRecord({
+            repo: did,
+            collection: 'chat.bsky.actor.declaration',
+            rkey: 'self',
+          })
+          .catch(_e => undefined)
+      : undefined,
+  ])
+  const actorDeclaration = declaration?.data.value as
+    | ActorDeclaration
+    | undefined
   const data: OtherRequiredData = {
     birthdate: prefs.birthDate ? prefs.birthDate.toISOString() : undefined,
+    actorDeclaration,
   }
 
   /**
@@ -355,7 +376,6 @@ export async function getOtherRequiredData({
     }
   }
 
-  const did = getDidFromAgentSession(agent)
   if (data && did && birthdateCache.has(did)) {
     /*
      * If birthdate was just set, use the local cache value. On subsequent

--- a/src/ageAssurance/data.tsx
+++ b/src/ageAssurance/data.tsx
@@ -397,7 +397,7 @@ export function getOtherRequiredDataFromCache({
     createOtherRequiredDataQueryKey({did}),
   )
 }
-export function setOtherRequireDataActorDeclarationForDid({
+export function setOtherRequiredDataActorDeclarationCache({
   did,
   actorDeclaration,
 }: {
@@ -542,7 +542,6 @@ export function AgeAssuranceDataProvider({
   const serverState = useServerStateQuery()
   const {state, metadata} = serverState.data || {}
   const {data} = useOtherRequiredDataQuery()
-
   const ctx = useMemo(
     () => ({
       config,

--- a/src/ageAssurance/debug.ts
+++ b/src/ageAssurance/debug.ts
@@ -8,7 +8,7 @@ import {type OtherRequiredData} from '#/ageAssurance/data'
 import {IS_DEV, IS_E2E} from '#/env'
 import {type Geolocation} from '#/geolocation'
 
-export const enabled = (IS_DEV && true) || IS_E2E
+export const enabled = (IS_DEV && false) || IS_E2E
 
 export const geolocation: Geolocation | undefined = enabled
   ? {
@@ -57,7 +57,7 @@ export const otherRequiredData: OtherRequiredData = {
   birthdate: new Date(2000, 1, 1).toISOString(),
 }
 
-const serverStateEnabled = true || IS_E2E
+const serverStateEnabled = false || IS_E2E
 export const serverState: AppBskyAgeassuranceGetState.OutputSchema | undefined =
   serverStateEnabled
     ? {

--- a/src/ageAssurance/debug.ts
+++ b/src/ageAssurance/debug.ts
@@ -8,7 +8,7 @@ import {type OtherRequiredData} from '#/ageAssurance/data'
 import {IS_DEV, IS_E2E} from '#/env'
 import {type Geolocation} from '#/geolocation'
 
-export const enabled = (IS_DEV && false) || IS_E2E
+export const enabled = (IS_DEV && true) || IS_E2E
 
 export const geolocation: Geolocation | undefined = enabled
   ? {
@@ -57,7 +57,7 @@ export const otherRequiredData: OtherRequiredData = {
   birthdate: new Date(2000, 1, 1).toISOString(),
 }
 
-const serverStateEnabled = false || IS_E2E
+const serverStateEnabled = true || IS_E2E
 export const serverState: AppBskyAgeassuranceGetState.OutputSchema | undefined =
   serverStateEnabled
     ? {

--- a/src/ageAssurance/index.tsx
+++ b/src/ageAssurance/index.tsx
@@ -83,7 +83,6 @@ export function Provider({children}: {children: React.ReactNode}) {
 
 function InnerProvider({children}: {children: React.ReactNode}) {
   const agent = useAgent()
-  const {flags} = useAgeAssurance()
   const state = useAgeAssuranceState()
   const {data} = useAgeAssuranceDataContext()
   const config = useAgeAssuranceRegionConfigWithFallback()
@@ -91,11 +90,21 @@ function InnerProvider({children}: {children: React.ReactNode}) {
 
   const handleAccessUpdate = useCallback(
     (s: AgeAssuranceState) => {
+      // disable chat notifications
       void getAndRegisterPushToken({
         isAgeRestricted: s.access !== AgeAssuranceAccess.Full,
       })
+
+      // disable incoming chats
+      const did = getDidFromAgentSession(agent)
+      if (did && s.access !== AgeAssuranceAccess.Full) {
+        const _data = getOtherRequiredDataFromCache({did})
+        // ...update the chat setting record if allowIncoming is not already 'none'.
+        if (_data?.actorDeclaration?.allowIncoming === 'none') return
+        restrictChatSettings({agent, did})
+      }
     },
-    [getAndRegisterPushToken],
+    [agent, getAndRegisterPushToken],
   )
   useOnAgeAssuranceAccessUpdate(handleAccessUpdate)
 
@@ -128,23 +137,6 @@ function InnerProvider({children}: {children: React.ReactNode}) {
       },
     }
   }, [state, data, config])
-
-  useEffect(() => {
-    const updateChatRecord = async () => {
-      const did = getDidFromAgentSession(agent)
-      // If chat is disabled...
-      if (did && flags.chatDisabled) {
-        const data = getOtherRequiredDataFromCache({did})
-        const allowIncoming = data?.actorDeclaration?.allowIncoming
-        // ...update the chat setting record if allowIncoming is not already 'none'.
-        if (allowIncoming === 'none') {
-          return
-        }
-        await restrictChatSettings({agent, did})
-      }
-    }
-    void updateChatRecord()
-  }, [agent, flags.chatDisabled])
 
   return (
     <AgeAssuranceStateContext.Provider value={ctx}>

--- a/src/ageAssurance/index.tsx
+++ b/src/ageAssurance/index.tsx
@@ -88,26 +88,11 @@ function InnerProvider({children}: {children: React.ReactNode}) {
 
   const handleAccessUpdate = useCallback(
     (s: AgeAssuranceState) => {
-      const hasCompletedAA = s.status === AgeAssuranceStatus.Assured
       const isAgeRestricted = s.access !== AgeAssuranceAccess.Full
-      const isDeclaredAdult = data?.birthdate
-        ? !isUnderAge(data.birthdate, 18)
-        : false
-      /*
-       * If they haven't completed AA and they've self-declared to be an adult,
-       * we don't definitively know their age or access level.
-       */
-      if (!hasCompletedAA && isDeclaredAdult) return
-      /*
-       * If they're not age-restricted, then we don't need to do anything.
-       */
-      if (!isAgeRestricted) return
-      /*
-       * They either haven't proven their an adult OR we don't know but they've
-       * self-declared to be <18, so we have to restrict access
-       */
-      void getAndRegisterPushToken({isAgeRestricted})
-      maybeRestrictChatSettings({agent})
+      if (isAgeRestricted) {
+        void getAndRegisterPushToken({isAgeRestricted})
+        maybeRestrictChatSettings({agent})
+      }
     },
     [agent, data, getAndRegisterPushToken],
   )

--- a/src/ageAssurance/index.tsx
+++ b/src/ageAssurance/index.tsx
@@ -1,9 +1,13 @@
 import {createContext, useCallback, useContext, useEffect, useMemo} from 'react'
 
 import {useGetAndRegisterPushToken} from '#/lib/notifications/notifications'
+import {restrictChatSettings} from '#/state/queries/messages/actor-declaration'
+import {useAgent} from '#/state/session'
 import {Provider as RedirectOverlayProvider} from '#/ageAssurance/components/RedirectOverlay'
 import {
   AgeAssuranceDataProvider,
+  getDidFromAgentSession,
+  getOtherRequiredDataFromCache,
   useAgeAssuranceDataContext,
 } from '#/ageAssurance/data'
 import {logger} from '#/ageAssurance/logger'
@@ -78,6 +82,8 @@ export function Provider({children}: {children: React.ReactNode}) {
 }
 
 function InnerProvider({children}: {children: React.ReactNode}) {
+  const agent = useAgent()
+  const {flags} = useAgeAssurance()
   const state = useAgeAssuranceState()
   const {data} = useAgeAssuranceDataContext()
   const config = useAgeAssuranceRegionConfigWithFallback()
@@ -97,33 +103,51 @@ function InnerProvider({children}: {children: React.ReactNode}) {
     logger.debug(`useAgeAssuranceState`, {state})
   }, [state])
 
-  return (
-    <AgeAssuranceStateContext.Provider
-      value={useMemo(() => {
-        const chatDisabled = state.access !== AgeAssuranceAccess.Full
-        const isUnderAdultAge = data?.birthdate
-          ? isUnderAge(data.birthdate, 18)
-          : true
-        const isOverRegionMinAccessAge = data?.birthdate
-          ? !isUnderAge(data.birthdate, config.minAccessAge)
-          : false
-        const isOverAppMinAccessAge = data?.birthdate
-          ? !isUnderAge(data.birthdate, MIN_ACCESS_AGE)
-          : false
-        const adultContentDisabled =
-          state.access !== AgeAssuranceAccess.Full || isUnderAdultAge
-        return {
-          Access: AgeAssuranceAccess,
-          Status: AgeAssuranceStatus,
-          state,
-          flags: {
-            adultContentDisabled,
-            chatDisabled,
-            isOverRegionMinAccessAge,
-            isOverAppMinAccessAge,
-          },
+  const ctx = useMemo(() => {
+    const chatDisabled = state.access !== AgeAssuranceAccess.Full
+    const isUnderAdultAge = data?.birthdate
+      ? isUnderAge(data.birthdate, 18)
+      : true
+    const isOverRegionMinAccessAge = data?.birthdate
+      ? !isUnderAge(data.birthdate, config.minAccessAge)
+      : false
+    const isOverAppMinAccessAge = data?.birthdate
+      ? !isUnderAge(data.birthdate, MIN_ACCESS_AGE)
+      : false
+    const adultContentDisabled =
+      state.access !== AgeAssuranceAccess.Full || isUnderAdultAge
+    return {
+      Access: AgeAssuranceAccess,
+      Status: AgeAssuranceStatus,
+      state,
+      flags: {
+        adultContentDisabled,
+        chatDisabled,
+        isOverRegionMinAccessAge,
+        isOverAppMinAccessAge,
+      },
+    }
+  }, [state, data, config])
+
+  useEffect(() => {
+    const updateChatRecord = async () => {
+      const did = getDidFromAgentSession(agent)
+      // If chat is disabled...
+      if (did && flags.chatDisabled) {
+        const data = getOtherRequiredDataFromCache({did})
+        const allowIncoming = data?.actorDeclaration?.allowIncoming
+        // ...update the chat setting record if allowIncoming is not already 'none'.
+        if (allowIncoming === 'none') {
+          return
         }
-      }, [state, data, config])}>
+        await restrictChatSettings({agent, did})
+      }
+    }
+    void updateChatRecord()
+  }, [agent, flags.chatDisabled])
+
+  return (
+    <AgeAssuranceStateContext.Provider value={ctx}>
       {children}
     </AgeAssuranceStateContext.Provider>
   )

--- a/src/ageAssurance/index.tsx
+++ b/src/ageAssurance/index.tsx
@@ -1,13 +1,10 @@
 import {createContext, useCallback, useContext, useEffect, useMemo} from 'react'
 
 import {useGetAndRegisterPushToken} from '#/lib/notifications/notifications'
-import {restrictChatSettings} from '#/state/queries/messages/actor-declaration'
 import {useAgent} from '#/state/session'
 import {Provider as RedirectOverlayProvider} from '#/ageAssurance/components/RedirectOverlay'
 import {
   AgeAssuranceDataProvider,
-  getDidFromAgentSession,
-  getOtherRequiredDataFromCache,
   useAgeAssuranceDataContext,
 } from '#/ageAssurance/data'
 import {logger} from '#/ageAssurance/logger'
@@ -22,6 +19,7 @@ import {
 } from '#/ageAssurance/types'
 import {
   isUnderAge,
+  maybeRestrictChatSettings,
   MIN_ACCESS_AGE,
   useAgeAssuranceRegionConfigWithFallback,
 } from '#/ageAssurance/util'
@@ -90,18 +88,15 @@ function InnerProvider({children}: {children: React.ReactNode}) {
 
   const handleAccessUpdate = useCallback(
     (s: AgeAssuranceState) => {
+      const isAgeRestricted = s.access !== AgeAssuranceAccess.Full
       // disable chat notifications
       void getAndRegisterPushToken({
-        isAgeRestricted: s.access !== AgeAssuranceAccess.Full,
+        isAgeRestricted,
       })
 
       // disable incoming chats
-      const did = getDidFromAgentSession(agent)
-      if (did && s.access !== AgeAssuranceAccess.Full) {
-        const d = getOtherRequiredDataFromCache({did})
-        // ...update the chat setting record if allowIncoming is not already 'none'.
-        if (d?.actorDeclaration?.allowIncoming === 'none') return
-        restrictChatSettings({agent, did})
+      if (isAgeRestricted) {
+        maybeRestrictChatSettings({agent})
       }
     },
     [agent, getAndRegisterPushToken],

--- a/src/ageAssurance/index.tsx
+++ b/src/ageAssurance/index.tsx
@@ -98,9 +98,9 @@ function InnerProvider({children}: {children: React.ReactNode}) {
       // disable incoming chats
       const did = getDidFromAgentSession(agent)
       if (did && s.access !== AgeAssuranceAccess.Full) {
-        const _data = getOtherRequiredDataFromCache({did})
+        const d = getOtherRequiredDataFromCache({did})
         // ...update the chat setting record if allowIncoming is not already 'none'.
-        if (_data?.actorDeclaration?.allowIncoming === 'none') return
+        if (d?.actorDeclaration?.allowIncoming === 'none') return
         restrictChatSettings({agent, did})
       }
     },

--- a/src/ageAssurance/index.tsx
+++ b/src/ageAssurance/index.tsx
@@ -88,15 +88,22 @@ function InnerProvider({children}: {children: React.ReactNode}) {
 
   const handleAccessUpdate = useCallback(
     (s: AgeAssuranceState) => {
+      const hasCompletedAA = s.status === AgeAssuranceStatus.Assured
       const isAgeRestricted = s.access !== AgeAssuranceAccess.Full
-      // disable chat notifications
-      void getAndRegisterPushToken({
-        isAgeRestricted,
-      })
-      // disable incoming chats
-      if (isAgeRestricted) {
-        maybeRestrictChatSettings({agent})
-      }
+      /*
+       * If they haven't completed AA, we don't definitively know their age or
+       * access level.
+       */
+      if (!hasCompletedAA) return
+      /*
+       * If theyre' not age-restricted, then we don't need to do anything.
+       */
+      if (!isAgeRestricted) return
+      /*
+       * Ok we have to restrict access
+       */
+      void getAndRegisterPushToken({isAgeRestricted})
+      maybeRestrictChatSettings({agent})
     },
     [agent, getAndRegisterPushToken],
   )

--- a/src/ageAssurance/index.tsx
+++ b/src/ageAssurance/index.tsx
@@ -90,22 +90,26 @@ function InnerProvider({children}: {children: React.ReactNode}) {
     (s: AgeAssuranceState) => {
       const hasCompletedAA = s.status === AgeAssuranceStatus.Assured
       const isAgeRestricted = s.access !== AgeAssuranceAccess.Full
+      const isDeclaredAdult = data?.birthdate
+        ? !isUnderAge(data.birthdate, 18)
+        : false
       /*
-       * If they haven't completed AA, we don't definitively know their age or
-       * access level.
+       * If they haven't completed AA and they've self-declared to be an adult,
+       * we don't definitively know their age or access level.
        */
-      if (!hasCompletedAA) return
+      if (!hasCompletedAA && isDeclaredAdult) return
       /*
-       * If theyre' not age-restricted, then we don't need to do anything.
+       * If they're not age-restricted, then we don't need to do anything.
        */
       if (!isAgeRestricted) return
       /*
-       * Ok we have to restrict access
+       * They either haven't proven their an adult OR we don't know but they've
+       * self-declared to be <18, so we have to restrict access
        */
       void getAndRegisterPushToken({isAgeRestricted})
       maybeRestrictChatSettings({agent})
     },
-    [agent, getAndRegisterPushToken],
+    [agent, data, getAndRegisterPushToken],
   )
   useOnAgeAssuranceAccessUpdate(handleAccessUpdate)
 

--- a/src/ageAssurance/index.tsx
+++ b/src/ageAssurance/index.tsx
@@ -94,7 +94,7 @@ function InnerProvider({children}: {children: React.ReactNode}) {
         maybeRestrictChatSettings({agent})
       }
     },
-    [agent, data, getAndRegisterPushToken],
+    [agent, getAndRegisterPushToken],
   )
   useOnAgeAssuranceAccessUpdate(handleAccessUpdate)
 

--- a/src/ageAssurance/index.tsx
+++ b/src/ageAssurance/index.tsx
@@ -107,34 +107,33 @@ function InnerProvider({children}: {children: React.ReactNode}) {
     logger.debug(`useAgeAssuranceState`, {state})
   }, [state])
 
-  const ctx = useMemo(() => {
-    const chatDisabled = state.access !== AgeAssuranceAccess.Full
-    const isUnderAdultAge = data?.birthdate
-      ? isUnderAge(data.birthdate, 18)
-      : true
-    const isOverRegionMinAccessAge = data?.birthdate
-      ? !isUnderAge(data.birthdate, config.minAccessAge)
-      : false
-    const isOverAppMinAccessAge = data?.birthdate
-      ? !isUnderAge(data.birthdate, MIN_ACCESS_AGE)
-      : false
-    const adultContentDisabled =
-      state.access !== AgeAssuranceAccess.Full || isUnderAdultAge
-    return {
-      Access: AgeAssuranceAccess,
-      Status: AgeAssuranceStatus,
-      state,
-      flags: {
-        adultContentDisabled,
-        chatDisabled,
-        isOverRegionMinAccessAge,
-        isOverAppMinAccessAge,
-      },
-    }
-  }, [state, data, config])
-
   return (
-    <AgeAssuranceStateContext.Provider value={ctx}>
+    <AgeAssuranceStateContext.Provider
+      value={useMemo(() => {
+        const chatDisabled = state.access !== AgeAssuranceAccess.Full
+        const isUnderAdultAge = data?.birthdate
+          ? isUnderAge(data.birthdate, 18)
+          : true
+        const isOverRegionMinAccessAge = data?.birthdate
+          ? !isUnderAge(data.birthdate, config.minAccessAge)
+          : false
+        const isOverAppMinAccessAge = data?.birthdate
+          ? !isUnderAge(data.birthdate, MIN_ACCESS_AGE)
+          : false
+        const adultContentDisabled =
+          state.access !== AgeAssuranceAccess.Full || isUnderAdultAge
+        return {
+          Access: AgeAssuranceAccess,
+          Status: AgeAssuranceStatus,
+          state,
+          flags: {
+            adultContentDisabled,
+            chatDisabled,
+            isOverRegionMinAccessAge,
+            isOverAppMinAccessAge,
+          },
+        }
+      }, [state, data, config])}>
       {children}
     </AgeAssuranceStateContext.Provider>
   )

--- a/src/ageAssurance/index.tsx
+++ b/src/ageAssurance/index.tsx
@@ -93,7 +93,6 @@ function InnerProvider({children}: {children: React.ReactNode}) {
       void getAndRegisterPushToken({
         isAgeRestricted,
       })
-
       // disable incoming chats
       if (isAgeRestricted) {
         maybeRestrictChatSettings({agent})

--- a/src/ageAssurance/state.ts
+++ b/src/ageAssurance/state.ts
@@ -1,8 +1,15 @@
 import {useEffect, useMemo, useState} from 'react'
 import {computeAgeAssuranceRegionAccess} from '@atproto/api'
 
+import {getAge} from '#/lib/strings/time'
 import {useSession} from '#/state/session'
-import {useAgeAssuranceDataContext} from '#/ageAssurance/data'
+import {
+  type AgeAssuranceData,
+  getConfigFromCache,
+  getOtherRequiredDataFromCache,
+  getServerStateFromCache,
+  useAgeAssuranceDataContext,
+} from '#/ageAssurance/data'
 import {logger} from '#/ageAssurance/logger'
 import {
   AgeAssuranceAccess,
@@ -12,7 +19,122 @@ import {
   parseStatusFromString,
 } from '#/ageAssurance/types'
 import {getAgeAssuranceRegionConfigWithFallback} from '#/ageAssurance/util'
-import {useGeolocation} from '#/geolocation'
+import {type Geolocation, useGeolocation} from '#/geolocation'
+import {device} from '#/storage'
+
+/**
+ * This is a last-ditch helper for out-of-band reads of the AA state, such as
+ * during account creation. Don't use it for anything else.
+ */
+export function getAndComputeAgeAssuranceState({did}: {did: string}) {
+  const config = getConfigFromCache()
+  const state = getServerStateFromCache({did})
+  const data = getOtherRequiredDataFromCache({did})
+  const geolocation = device.get(['mergedGeolocation'])
+
+  if (!geolocation || !config || !state || !data) {
+    return {
+      status: AgeAssuranceStatus.Unknown,
+      access: AgeAssuranceAccess.Safe,
+    }
+  }
+
+  return computeAgeAssuranceState({
+    hasSession: true,
+    config,
+    geolocation,
+    state: state.state,
+    data: {
+      accountCreatedAt: state.metadata?.accountCreatedAt,
+      declaredAge: data?.birthdate
+        ? getAge(new Date(data.birthdate))
+        : undefined,
+      birthdate: data?.birthdate,
+    },
+  })
+}
+
+export function computeAgeAssuranceState({
+  hasSession,
+  config,
+  geolocation,
+  state,
+  data,
+}: {
+  hasSession: boolean
+  config: AgeAssuranceData['config']
+  geolocation: Geolocation
+  state: AgeAssuranceData['state']
+  data: AgeAssuranceData['data']
+}) {
+  /**
+   * This is where we control logged-out moderation prefs. It's all
+   * downstream of AA now.
+   */
+  if (!hasSession)
+    return {
+      status: AgeAssuranceStatus.Unknown,
+      access: AgeAssuranceAccess.Safe,
+    }
+
+  /**
+   * This can happen if the prefetch fails (such as due to network issues).
+   * The query handler will try it again, but if it continues to fail, of
+   * course we won't have config.
+   *
+   * In this case, fail open to avoid blocking users.
+   */
+  if (!config) {
+    logger.warn('useAgeAssuranceState: missing config')
+    return {
+      status: AgeAssuranceStatus.Unknown,
+      access: AgeAssuranceAccess.Safe,
+      error: 'config',
+    }
+  }
+
+  const region = getAgeAssuranceRegionConfigWithFallback(config, geolocation)
+  const isAARequired = region.countryCode !== '*'
+  const isTerminalState =
+    state?.status === 'assured' || state?.status === 'blocked'
+
+  /*
+   * If we are in a terminal state and AA is required for this region,
+   * we can trust the server state completely and avoid recomputing.
+   */
+  if (isTerminalState && isAARequired) {
+    return {
+      lastInitiatedAt: state.lastInitiatedAt,
+      status: parseStatusFromString(state.status),
+      access: parseAccessFromString(state.access),
+    }
+  }
+
+  /*
+   * Otherwise, we need to compute the access based on the latest data. For
+   * accounts with an accurate birthdate, our default fallback rules should
+   * ensure correct access.
+   */
+  const result = computeAgeAssuranceRegionAccess(region, data)
+  const computed = {
+    lastInitiatedAt: state?.lastInitiatedAt,
+    // prefer server state
+    status: state?.status
+      ? parseStatusFromString(state?.status)
+      : AgeAssuranceStatus.Unknown,
+    // prefer server state
+    access: result
+      ? parseAccessFromString(result.access)
+      : AgeAssuranceAccess.Full,
+  }
+  logger.debug('debug useAgeAssuranceState', {
+    region,
+    state,
+    data,
+    computed,
+  })
+  return computed
+}
 
 export function useAgeAssuranceState(): AgeAssuranceState {
   const {hasSession} = useSession()
@@ -20,6 +142,8 @@ export function useAgeAssuranceState(): AgeAssuranceState {
   const {config, state, data} = useAgeAssuranceDataContext()
 
   return useMemo(() => {
+    // TODO replace with pure function
+
     /**
      * This is where we control logged-out moderation prefs. It's all
      * downstream of AA now.

--- a/src/ageAssurance/state.ts
+++ b/src/ageAssurance/state.ts
@@ -89,7 +89,7 @@ export function computeAgeAssuranceState({
     return {
       status: AgeAssuranceStatus.Unknown,
       access: AgeAssuranceAccess.Safe,
-      error: 'config',
+      error: 'config' as const,
     }
   }
 
@@ -141,77 +141,17 @@ export function useAgeAssuranceState(): AgeAssuranceState {
   const geolocation = useGeolocation()
   const {config, state, data} = useAgeAssuranceDataContext()
 
-  return useMemo(() => {
-    // TODO replace with pure function
-
-    /**
-     * This is where we control logged-out moderation prefs. It's all
-     * downstream of AA now.
-     */
-    if (!hasSession)
-      return {
-        status: AgeAssuranceStatus.Unknown,
-        access: AgeAssuranceAccess.Safe,
-      }
-
-    /**
-     * This can happen if the prefetch fails (such as due to network issues).
-     * The query handler will try it again, but if it continues to fail, of
-     * course we won't have config.
-     *
-     * In this case, fail open to avoid blocking users.
-     */
-    if (!config) {
-      logger.warn('useAgeAssuranceState: missing config')
-      return {
-        status: AgeAssuranceStatus.Unknown,
-        access: AgeAssuranceAccess.Safe,
-        error: 'config',
-      }
-    }
-
-    const region = getAgeAssuranceRegionConfigWithFallback(config, geolocation)
-    const isAARequired = region.countryCode !== '*'
-    const isTerminalState =
-      state?.status === 'assured' || state?.status === 'blocked'
-
-    /*
-     * If we are in a terminal state and AA is required for this region,
-     * we can trust the server state completely and avoid recomputing.
-     */
-    if (isTerminalState && isAARequired) {
-      return {
-        lastInitiatedAt: state.lastInitiatedAt,
-        status: parseStatusFromString(state.status),
-        access: parseAccessFromString(state.access),
-      }
-    }
-
-    /*
-     * Otherwise, we need to compute the access based on the latest data. For
-     * accounts with an accurate birthdate, our default fallback rules should
-     * ensure correct access.
-     */
-    const result = computeAgeAssuranceRegionAccess(region, data)
-    const computed = {
-      lastInitiatedAt: state?.lastInitiatedAt,
-      // prefer server state
-      status: state?.status
-        ? parseStatusFromString(state?.status)
-        : AgeAssuranceStatus.Unknown,
-      // prefer server state
-      access: result
-        ? parseAccessFromString(result.access)
-        : AgeAssuranceAccess.Full,
-    }
-    logger.debug('debug useAgeAssuranceState', {
-      region,
-      state,
-      data,
-      computed,
-    })
-    return computed
-  }, [hasSession, geolocation, config, state, data])
+  return useMemo(
+    () =>
+      computeAgeAssuranceState({
+        hasSession,
+        config,
+        geolocation,
+        state,
+        data,
+      }),
+    [hasSession, geolocation, config, state, data],
+  )
 }
 
 export function useOnAgeAssuranceAccessUpdate(

--- a/src/ageAssurance/state.ts
+++ b/src/ageAssurance/state.ts
@@ -54,6 +54,11 @@ export function getAndComputeAgeAssuranceState({did}: {did: string}) {
   })
 }
 
+/**
+ * Get final evaluated age assurance state. Handles fallbacks and defers to
+ * server state before computing access based on AA config from the server +
+ * geolocation and other data.
+ */
 export function computeAgeAssuranceState({
   hasSession,
   config,

--- a/src/ageAssurance/state.ts
+++ b/src/ageAssurance/state.ts
@@ -23,38 +23,6 @@ import {type Geolocation, useGeolocation} from '#/geolocation'
 import {device} from '#/storage'
 
 /**
- * This is a last-ditch helper for out-of-band reads of the AA state, such as
- * during account creation. Don't use it for anything else.
- */
-export function getAndComputeAgeAssuranceState({did}: {did: string}) {
-  const config = getConfigFromCache()
-  const state = getServerStateFromCache({did})
-  const data = getOtherRequiredDataFromCache({did})
-  const geolocation = device.get(['mergedGeolocation'])
-
-  if (!geolocation || !config || !state || !data) {
-    return {
-      status: AgeAssuranceStatus.Unknown,
-      access: AgeAssuranceAccess.Safe,
-    }
-  }
-
-  return computeAgeAssuranceState({
-    hasSession: true,
-    config,
-    geolocation,
-    state: state.state,
-    data: {
-      accountCreatedAt: state.metadata?.accountCreatedAt,
-      declaredAge: data?.birthdate
-        ? getAge(new Date(data.birthdate))
-        : undefined,
-      birthdate: data?.birthdate,
-    },
-  })
-}
-
-/**
  * Get final evaluated age assurance state. Handles fallbacks and defers to
  * server state before computing access based on AA config from the server +
  * geolocation and other data.
@@ -139,6 +107,38 @@ export function computeAgeAssuranceState({
     computed,
   })
   return computed
+}
+
+/**
+ * This is a last-ditch helper for out-of-band reads of the AA state, such as
+ * during account creation. Don't use it for anything else.
+ */
+export function getAndComputeAgeAssuranceState({did}: {did: string}) {
+  const config = getConfigFromCache()
+  const state = getServerStateFromCache({did})
+  const data = getOtherRequiredDataFromCache({did})
+  const geolocation = device.get(['mergedGeolocation'])
+
+  if (!geolocation || !config || !state || !data) {
+    return {
+      status: AgeAssuranceStatus.Unknown,
+      access: AgeAssuranceAccess.Safe,
+    }
+  }
+
+  return computeAgeAssuranceState({
+    hasSession: true,
+    config,
+    geolocation,
+    state: state.state,
+    data: {
+      accountCreatedAt: state.metadata?.accountCreatedAt,
+      declaredAge: data?.birthdate
+        ? getAge(new Date(data.birthdate))
+        : undefined,
+      birthdate: data?.birthdate,
+    },
+  })
 }
 
 export function useAgeAssuranceState(): AgeAssuranceState {

--- a/src/ageAssurance/util.ts
+++ b/src/ageAssurance/util.ts
@@ -123,8 +123,8 @@ export const makeAgeRestrictedModerationPrefs = (
 export function maybeRestrictChatSettings({agent}: {agent: AtpAgent}) {
   const did = getDidFromAgentSession(agent)
   if (!did) return
-  const d = getOtherRequiredDataFromCache({did})
+  const data = getOtherRequiredDataFromCache({did})
   // ...update the chat setting record if allowIncoming is not already 'none'.
-  if (d?.actorDeclaration?.allowIncoming === 'none') return
+  if (data?.actorDeclaration?.allowIncoming === 'none') return
   restrictChatSettings({agent, did})
 }

--- a/src/ageAssurance/util.ts
+++ b/src/ageAssurance/util.ts
@@ -2,13 +2,19 @@ import {useMemo} from 'react'
 import {
   ageAssuranceRuleIDs as ids,
   type AppBskyAgeassuranceDefs,
+  type AtpAgent,
   getAgeAssuranceRegionConfig,
   type ModerationPrefs,
 } from '@atproto/api'
 
 import {getAge} from '#/lib/strings/time'
+import {restrictChatSettings} from '#/state/queries/messages/actor-declaration'
 import {DEFAULT_LOGGED_OUT_LABEL_PREFERENCES} from '#/state/queries/preferences/moderation'
-import {useAgeAssuranceDataContext} from '#/ageAssurance/data'
+import {
+  getDidFromAgentSession,
+  getOtherRequiredDataFromCache,
+  useAgeAssuranceDataContext,
+} from '#/ageAssurance/data'
 import {AgeAssuranceAccess} from '#/ageAssurance/types'
 import {type Geolocation, useGeolocation} from '#/geolocation'
 
@@ -109,3 +115,16 @@ export const makeAgeRestrictedModerationPrefs = (
   adultContentEnabled: false,
   labels: DEFAULT_LOGGED_OUT_LABEL_PREFERENCES,
 })
+
+/**
+ * Checks our cache of the actor's chat declaration record, and if it's not
+ * already restricted, restricts it.
+ */
+export function maybeRestrictChatSettings({agent}: {agent: AtpAgent}) {
+  const did = getDidFromAgentSession(agent)
+  if (!did) return
+  const d = getOtherRequiredDataFromCache({did})
+  // ...update the chat setting record if allowIncoming is not already 'none'.
+  if (d?.actorDeclaration?.allowIncoming === 'none') return
+  restrictChatSettings({agent, did})
+}

--- a/src/ageAssurance/util.ts
+++ b/src/ageAssurance/util.ts
@@ -8,7 +8,7 @@ import {
 } from '@atproto/api'
 
 import {getAge} from '#/lib/strings/time'
-import {restrictChatSettings} from '#/state/queries/messages/actor-declaration'
+import {restrictChatSettings} from '#/state/queries/messages/restrictChatSettings'
 import {DEFAULT_LOGGED_OUT_LABEL_PREFERENCES} from '#/state/queries/preferences/moderation'
 import {
   getDidFromAgentSession,

--- a/src/components/dialogs/BirthDateSettings.tsx
+++ b/src/components/dialogs/BirthDateSettings.tsx
@@ -1,8 +1,6 @@
 import {useCallback, useMemo, useState} from 'react'
 import {View} from 'react-native'
-import {msg} from '@lingui/core/macro'
-import {useLingui} from '@lingui/react'
-import {Trans} from '@lingui/react/macro'
+import {Trans, useLingui} from '@lingui/react/macro'
 
 import {useCleanError} from '#/lib/hooks/useCleanError'
 import {isAppPassword} from '#/lib/jwt'
@@ -34,7 +32,7 @@ export function BirthDateSettingsDialog({
   control: Dialog.DialogControlProps
 }) {
   const t = useTheme()
-  const {_} = useLingui()
+  const {t: l} = useLingui()
   const {isLoading, error, data: preferences} = usePreferencesQuery()
   const isBirthdateUpdateAllowed = useIsBirthdateUpdateAllowed()
   const {currentAccount} = useSession()
@@ -45,11 +43,11 @@ export function BirthDateSettingsDialog({
       <Dialog.Handle />
       {isBirthdateUpdateAllowed ? (
         <Dialog.ScrollableInner
-          label={_(msg`My Birthdate`)}
+          label={l`My birthdate`}
           style={web({maxWidth: 400})}>
           <View style={[a.gap_md]}>
             <Text style={[a.text_xl, a.font_semi_bold]}>
-              <Trans>My Birthdate</Trans>
+              <Trans>My birthdate</Trans>
             </Text>
             <Text
               style={[a.text_md, a.leading_snug, t.atoms.text_contrast_medium]}>
@@ -64,9 +62,7 @@ export function BirthDateSettingsDialog({
               <ErrorMessage
                 message={
                   error?.toString() ||
-                  _(
-                    msg`We were unable to load your birthdate preferences. Please try again.`,
-                  )
+                  l`We were unable to load your birthdate preferences. Please try again.`
                 }
                 style={[a.rounded_sm]}
               />
@@ -88,7 +84,7 @@ export function BirthDateSettingsDialog({
         </Dialog.ScrollableInner>
       ) : (
         <Dialog.ScrollableInner
-          label={_(msg`You recently changed your birthdate`)}
+          label={l`You recently changed your birthdate`}
           style={web({maxWidth: 400})}>
           <View style={[a.gap_sm]}>
             <Text
@@ -123,15 +119,16 @@ function BirthdayInner({
   control: Dialog.DialogControlProps
   preferences: UsePreferencesQueryResponse
 }) {
-  const {_} = useLingui()
+  const {t: l} = useLingui()
   const cleanError = useCleanError()
   const [date, setDate] = useState(preferences.birthDate || getDateAgo(18))
   const {isPending, error, mutateAsync: setBirthDate} = useBirthdateMutation()
   const hasChanged = date !== preferences.birthDate
   const errorMessage = useMemo(() => {
     if (error) {
-      const {raw, clean} = cleanError(error)
-      return clean || raw || error.toString()
+      const e = error as Error
+      const {raw, clean} = cleanError(e)
+      return clean || raw || e.toString()
     }
   }, [error, cleanError])
 
@@ -146,7 +143,8 @@ function BirthdayInner({
         await setBirthDate({birthDate: date})
       }
       control.close()
-    } catch (e: any) {
+    } catch (error) {
+      const e = error as Error
       logger.error(`setBirthDate failed`, {message: e.message})
     }
   }, [date, setBirthDate, control, hasChanged])
@@ -158,11 +156,10 @@ function BirthdayInner({
           testID="birthdayInput"
           value={date}
           onChangeDate={newDate => setDate(new Date(newDate))}
-          label={_(msg`Birthdate`)}
-          accessibilityHint={_(msg`Enter your birthdate`)}
+          label={l`Birthdate`}
+          accessibilityHint={l`Enter your birthdate`}
         />
       </View>
-
       {isUnder18 && hasChanged && (
         <Admonition type="info">
           <Trans>
@@ -171,30 +168,27 @@ function BirthdayInner({
           </Trans>
         </Admonition>
       )}
-
       {isUnder13 && (
         <Admonition type="error">
           <Trans>
             You must be at least 13 years old to use Bluesky. Read our{' '}
             <SimpleInlineLinkText
               to="https://bsky.social/about/support/tos"
-              label={_(msg`Terms of Service`)}>
+              label={l`Terms of Service`}>
               Terms of Service
             </SimpleInlineLinkText>{' '}
             for more information.
           </Trans>
         </Admonition>
       )}
-
       {errorMessage ? (
         <ErrorMessage message={errorMessage} style={[a.rounded_sm]} />
       ) : undefined}
-
       <View style={IS_WEB && [a.flex_row, a.justify_end]}>
         <Button
-          label={hasChanged ? _(msg`Save birthdate`) : _(msg`Done`)}
+          label={hasChanged ? l`Save birthdate` : l`Done`}
           size="large"
-          onPress={onSave}
+          onPress={() => void onSave()}
           variant="solid"
           color="primary"
           disabled={isUnder13}>

--- a/src/state/birthdate.ts
+++ b/src/state/birthdate.ts
@@ -4,8 +4,11 @@ import {useMutation, useQueryClient} from '@tanstack/react-query'
 import {preferencesQueryKey} from '#/state/queries/preferences'
 import {useAgent, useSession} from '#/state/session'
 import {usePatchAgeAssuranceOtherRequiredData} from '#/ageAssurance'
+import {getDidFromAgentSession} from '#/ageAssurance/data'
+import {isUnderAge} from '#/ageAssurance/util'
 import {IS_DEV} from '#/env'
 import {account} from '#/storage'
+import {restrictChatSettings} from './queries/messages/actor-declaration'
 
 // 6s in dev, 48h in prod
 const BIRTHDATE_DELAY_HOURS = IS_DEV ? 0.001 : 48
@@ -63,6 +66,31 @@ export function useBirthdateMutation() {
       await queryClient.invalidateQueries({
         queryKey: preferencesQueryKey,
       })
+      const did = getDidFromAgentSession(agent)
+      const result = did
+        ? await agent.com.atproto.repo
+            .getRecord({
+              repo: did ?? '',
+              collection: 'chat.bsky.actor.declaration',
+              rkey: 'self',
+            })
+            .catch(_e => undefined)
+        : undefined
+      const allowIncoming = result?.data.value.allowIncoming as
+        | 'all'
+        | 'none'
+        | 'following'
+        | undefined
+      const isUnderAdultAge = birthDate
+        ? isUnderAge(birthDate.toISOString(), 18)
+        : false
+      /**
+       * If the user is under adult age, update the chat setting record if
+       * allowIncoming is not already 'none'.
+       */
+      if (did && isUnderAdultAge && allowIncoming !== 'none') {
+        await restrictChatSettings({agent, did})
+      }
       /**
        * Also patch the age assurance other required data with the new
        * birthdate, which may change the user's age assurance access level.

--- a/src/state/birthdate.ts
+++ b/src/state/birthdate.ts
@@ -65,11 +65,7 @@ export function useBirthdateMutation() {
         queryKey: preferencesQueryKey,
       })
 
-      const isUnderAdultAge = birthDate
-        ? isUnderAge(birthDate.toISOString(), 18)
-        : false
-
-      if (isUnderAdultAge) {
+      if (isUnderAge(birthDate.toISOString(), 18)) {
         maybeRestrictChatSettings({agent})
       }
 

--- a/src/state/birthdate.ts
+++ b/src/state/birthdate.ts
@@ -4,11 +4,9 @@ import {useMutation, useQueryClient} from '@tanstack/react-query'
 import {preferencesQueryKey} from '#/state/queries/preferences'
 import {useAgent, useSession} from '#/state/session'
 import {usePatchAgeAssuranceOtherRequiredData} from '#/ageAssurance'
-import {getDidFromAgentSession} from '#/ageAssurance/data'
-import {isUnderAge} from '#/ageAssurance/util'
+import {isUnderAge, maybeRestrictChatSettings} from '#/ageAssurance/util'
 import {IS_DEV} from '#/env'
 import {account} from '#/storage'
-import {restrictChatSettings} from './queries/messages/actor-declaration'
 
 // 6s in dev, 48h in prod
 const BIRTHDATE_DELAY_HOURS = IS_DEV ? 0.001 : 48
@@ -66,31 +64,15 @@ export function useBirthdateMutation() {
       await queryClient.invalidateQueries({
         queryKey: preferencesQueryKey,
       })
-      const did = getDidFromAgentSession(agent)
-      const result = did
-        ? await agent.com.atproto.repo
-            .getRecord({
-              repo: did ?? '',
-              collection: 'chat.bsky.actor.declaration',
-              rkey: 'self',
-            })
-            .catch(_e => undefined)
-        : undefined
-      const allowIncoming = result?.data.value.allowIncoming as
-        | 'all'
-        | 'none'
-        | 'following'
-        | undefined
+
       const isUnderAdultAge = birthDate
         ? isUnderAge(birthDate.toISOString(), 18)
         : false
-      /**
-       * If the user is under adult age, update the chat setting record if
-       * allowIncoming is not already 'none'.
-       */
-      if (did && isUnderAdultAge && allowIncoming !== 'none') {
-        await restrictChatSettings({agent, did})
+
+      if (isUnderAdultAge) {
+        maybeRestrictChatSettings({agent})
       }
+
       /**
        * Also patch the age assurance other required data with the new
        * birthdate, which may change the user's age assurance access level.

--- a/src/state/queries/messages/actor-declaration.ts
+++ b/src/state/queries/messages/actor-declaration.ts
@@ -101,6 +101,7 @@ export async function restrictChatSettings({
         allowIncoming: 'none',
       },
     })
+    // important, update local cache to avoid running this again
     setOtherRequireDataActorDeclarationForDid({
       did,
       actorDeclaration: {

--- a/src/state/queries/messages/actor-declaration.ts
+++ b/src/state/queries/messages/actor-declaration.ts
@@ -1,3 +1,4 @@
+import type AtpAgent from '@atproto/api'
 import {type AppBskyActorDefs} from '@atproto/api'
 import {useMutation, useQueryClient} from '@tanstack/react-query'
 
@@ -77,4 +78,29 @@ export function useDeleteActorDeclaration() {
       return result
     },
   })
+}
+
+/**
+ * Helper to update the chat settings record.
+ */
+export async function restrictChatSettings({
+  agent,
+  did,
+}: {
+  agent: AtpAgent
+  did: string
+}): Promise<void> {
+  try {
+    await agent.com.atproto.repo.putRecord({
+      repo: did,
+      collection: 'chat.bsky.actor.declaration',
+      rkey: 'self',
+      record: {
+        $type: 'chat.bsky.actor.declaration',
+        allowIncoming: 'none',
+      },
+    })
+  } catch {
+    logger.error(`restrictChatSettings: failed to set chat declaration`)
+  }
 }

--- a/src/state/queries/messages/actor-declaration.ts
+++ b/src/state/queries/messages/actor-declaration.ts
@@ -1,5 +1,8 @@
 import type AtpAgent from '@atproto/api'
-import {type AppBskyActorDefs} from '@atproto/api'
+import {
+  type AppBskyActorDefs,
+  type ChatBskyActorDeclaration,
+} from '@atproto/api'
 import {useMutation, useQueryClient} from '@tanstack/react-query'
 
 import {logger} from '#/logger'
@@ -92,23 +95,40 @@ export async function restrictChatSettings({
   did: string
 }): Promise<void> {
   try {
+    const record: ChatBskyActorDeclaration.Main = {
+      $type: 'chat.bsky.actor.declaration',
+      allowIncoming: 'none',
+    }
     await agent.com.atproto.repo.putRecord({
       repo: did,
       collection: 'chat.bsky.actor.declaration',
       rkey: 'self',
-      record: {
-        $type: 'chat.bsky.actor.declaration',
-        allowIncoming: 'none',
-      },
+      record,
     })
     // important, update local cache to avoid running this again
     setOtherRequireDataActorDeclarationForDid({
       did,
-      actorDeclaration: {
-        allowIncoming: 'none',
-      },
+      actorDeclaration: record,
     })
   } catch {
     logger.error(`restrictChatSettings: failed to set chat declaration`)
   }
+}
+
+export async function fetchActorDeclarationRecord({
+  agent,
+  did,
+}: {
+  agent: AtpAgent
+  did?: string
+}) {
+  if (!did) return
+  const res = await agent.com.atproto.repo
+    .getRecord({
+      repo: did,
+      collection: 'chat.bsky.actor.declaration',
+      rkey: 'self',
+    })
+    .catch(_e => undefined)
+  return res?.data.value as ChatBskyActorDeclaration.Main
 }

--- a/src/state/queries/messages/actor-declaration.ts
+++ b/src/state/queries/messages/actor-declaration.ts
@@ -4,6 +4,7 @@ import {useMutation, useQueryClient} from '@tanstack/react-query'
 
 import {logger} from '#/logger'
 import {useAgent, useSession} from '#/state/session'
+import {setOtherRequireDataActorDeclarationForDid} from '#/ageAssurance/data'
 import {RQKEY as PROFILE_RKEY} from '../profile'
 
 export function useUpdateActorDeclaration({
@@ -97,6 +98,12 @@ export async function restrictChatSettings({
       rkey: 'self',
       record: {
         $type: 'chat.bsky.actor.declaration',
+        allowIncoming: 'none',
+      },
+    })
+    setOtherRequireDataActorDeclarationForDid({
+      did,
+      actorDeclaration: {
         allowIncoming: 'none',
       },
     })

--- a/src/state/queries/messages/actor-declaration.ts
+++ b/src/state/queries/messages/actor-declaration.ts
@@ -5,9 +5,10 @@ import {
 } from '@atproto/api'
 import {useMutation, useQueryClient} from '@tanstack/react-query'
 
+import {networkRetry} from '#/lib/async/retry'
 import {logger} from '#/logger'
 import {useAgent, useSession} from '#/state/session'
-import {setOtherRequireDataActorDeclarationForDid} from '#/ageAssurance/data'
+import {setOtherRequiredDataActorDeclarationCache} from '#/ageAssurance/data'
 import {RQKEY as PROFILE_RKEY} from '../profile'
 
 export function useUpdateActorDeclaration({
@@ -99,14 +100,16 @@ export async function restrictChatSettings({
       $type: 'chat.bsky.actor.declaration',
       allowIncoming: 'none',
     }
-    await agent.com.atproto.repo.putRecord({
-      repo: did,
-      collection: 'chat.bsky.actor.declaration',
-      rkey: 'self',
-      record,
-    })
+    await networkRetry(3, () =>
+      agent.com.atproto.repo.putRecord({
+        repo: did,
+        collection: 'chat.bsky.actor.declaration',
+        rkey: 'self',
+        record,
+      }),
+    )
     // important, update local cache to avoid running this again
-    setOtherRequireDataActorDeclarationForDid({
+    setOtherRequiredDataActorDeclarationCache({
       did,
       actorDeclaration: record,
     })

--- a/src/state/queries/messages/actor-declaration.ts
+++ b/src/state/queries/messages/actor-declaration.ts
@@ -5,10 +5,8 @@ import {
 } from '@atproto/api'
 import {useMutation, useQueryClient} from '@tanstack/react-query'
 
-import {networkRetry} from '#/lib/async/retry'
 import {logger} from '#/logger'
 import {useAgent, useSession} from '#/state/session'
-import {setOtherRequiredDataActorDeclarationCache} from '#/ageAssurance/data'
 import {RQKEY as PROFILE_RKEY} from '../profile'
 
 export function useUpdateActorDeclaration({
@@ -83,39 +81,6 @@ export function useDeleteActorDeclaration() {
       return result
     },
   })
-}
-
-/**
- * Helper to update the chat settings record.
- */
-export async function restrictChatSettings({
-  agent,
-  did,
-}: {
-  agent: AtpAgent
-  did: string
-}): Promise<void> {
-  try {
-    const record: ChatBskyActorDeclaration.Main = {
-      $type: 'chat.bsky.actor.declaration',
-      allowIncoming: 'none',
-    }
-    await networkRetry(3, () =>
-      agent.com.atproto.repo.putRecord({
-        repo: did,
-        collection: 'chat.bsky.actor.declaration',
-        rkey: 'self',
-        record,
-      }),
-    )
-    // important, update local cache to avoid running this again
-    setOtherRequiredDataActorDeclarationCache({
-      did,
-      actorDeclaration: record,
-    })
-  } catch {
-    logger.error(`restrictChatSettings: failed to set chat declaration`)
-  }
 }
 
 export async function fetchActorDeclarationRecord({

--- a/src/state/queries/messages/restrictChatSettings.ts
+++ b/src/state/queries/messages/restrictChatSettings.ts
@@ -1,0 +1,39 @@
+import type AtpAgent from '@atproto/api'
+import {type ChatBskyActorDeclaration} from '@atproto/api'
+
+import {networkRetry} from '#/lib/async/retry'
+import {logger} from '#/logger'
+import {setOtherRequiredDataActorDeclarationCache} from '#/ageAssurance/data'
+
+/**
+ * Helper to update the chat settings record.
+ */
+export async function restrictChatSettings({
+  agent,
+  did,
+}: {
+  agent: AtpAgent
+  did: string
+}): Promise<void> {
+  try {
+    const record: ChatBskyActorDeclaration.Main = {
+      $type: 'chat.bsky.actor.declaration',
+      allowIncoming: 'none',
+    }
+    await networkRetry(3, () =>
+      agent.com.atproto.repo.putRecord({
+        repo: did,
+        collection: 'chat.bsky.actor.declaration',
+        rkey: 'self',
+        record,
+      }),
+    )
+    // important, update local cache to avoid running this again
+    setOtherRequiredDataActorDeclarationCache({
+      did,
+      actorDeclaration: record,
+    })
+  } catch {
+    logger.error(`restrictChatSettings: failed to set chat declaration`)
+  }
+}

--- a/src/state/session/__tests__/session-test.ts
+++ b/src/state/session/__tests__/session-test.ts
@@ -12,6 +12,9 @@ jest.mock('jwt-decode', () => ({
 
 jest.mock('../../birthdate')
 jest.mock('../../../ageAssurance/data')
+jest.mock('../../../ageAssurance/state', () => ({
+  getAndComputeAgeAssuranceState: () => ({}),
+}))
 jest.mock('#/lib/notifications/notifications', () => ({
   unregisterPushToken(_agents: BskyAgent[]) {
     return Promise.resolve()

--- a/src/state/session/agent.ts
+++ b/src/state/session/agent.ts
@@ -24,6 +24,7 @@ import {
 } from '#/lib/constants'
 import {logger} from '#/logger'
 import {snoozeBirthdateUpdateAllowedForDid} from '#/state/birthdate'
+import {restrictChatSettings} from '#/state/queries/messages/actor-declaration'
 import {snoozeEmailConfirmationPrompt} from '#/state/shell/reminders'
 import {
   prefetchAgeAssuranceData,
@@ -219,26 +220,11 @@ export async function createAgentAndCreateAccount(
         logger.info(`createAgentAndCreateAccount: failed to set initial feeds`)
         throw e
       }),
+      // wait for AA data to load first, then check state
       aa.then(async () => {
         const state = getAndComputeAgeAssuranceState({did: account.did})
-        const chatDisabled = state.access !== AgeAssuranceAccess.Full
-        if (chatDisabled) {
-          await networkRetry(3, () => {
-            return agent.com.atproto.repo.putRecord({
-              repo: account.did,
-              collection: 'chat.bsky.actor.declaration',
-              rkey: 'self',
-              record: {
-                $type: 'chat.bsky.actor.declaration',
-                allowIncoming: 'none',
-              },
-            })
-          }).catch(e => {
-            logger.info(
-              `createAgentAndCreateAccount: failed to set chat declaration`,
-            )
-            throw e
-          })
+        if (state.access !== AgeAssuranceAccess.Full) {
+          restrictChatSettings({agent, did: account.did})
         }
       }),
     ]).then(promises => {

--- a/src/state/session/agent.ts
+++ b/src/state/session/agent.ts
@@ -22,7 +22,6 @@ import {
   PUBLIC_BSKY_SERVICE,
   TIMELINE_SAVED_FEED,
 } from '#/lib/constants'
-import {getAge} from '#/lib/strings/time'
 import {logger} from '#/logger'
 import {snoozeBirthdateUpdateAllowedForDid} from '#/state/birthdate'
 import {snoozeEmailConfirmationPrompt} from '#/state/shell/reminders'
@@ -31,6 +30,8 @@ import {
   setBirthdateForDid,
   setCreatedAtForDid,
 } from '#/ageAssurance/data'
+import {getAndComputeAgeAssuranceState} from '#/ageAssurance/state'
+import {AgeAssuranceAccess} from '#/ageAssurance/types'
 import {features} from '#/analytics'
 import {emitNetworkConfirmed, emitNetworkLost} from '../events'
 import {addSessionErrorLog} from './logging'
@@ -218,26 +219,28 @@ export async function createAgentAndCreateAccount(
         logger.info(`createAgentAndCreateAccount: failed to set initial feeds`)
         throw e
       }),
-      ...(getAge(birthDate) < 18
-        ? [
-            networkRetry(3, () => {
-              return agent.com.atproto.repo.putRecord({
-                repo: account.did,
-                collection: 'chat.bsky.actor.declaration',
-                rkey: 'self',
-                record: {
-                  $type: 'chat.bsky.actor.declaration',
-                  allowIncoming: 'none',
-                },
-              })
-            }).catch(e => {
-              logger.info(
-                `createAgentAndCreateAccount: failed to set chat declaration`,
-              )
-              throw e
-            }),
-          ]
-        : []),
+      aa.then(async () => {
+        const state = getAndComputeAgeAssuranceState({did: account.did})
+        const chatDisabled = state.access !== AgeAssuranceAccess.Full
+        if (chatDisabled) {
+          await networkRetry(3, () => {
+            return agent.com.atproto.repo.putRecord({
+              repo: account.did,
+              collection: 'chat.bsky.actor.declaration',
+              rkey: 'self',
+              record: {
+                $type: 'chat.bsky.actor.declaration',
+                allowIncoming: 'none',
+              },
+            })
+          }).catch(e => {
+            logger.info(
+              `createAgentAndCreateAccount: failed to set chat declaration`,
+            )
+            throw e
+          })
+        }
+      }),
     ]).then(promises => {
       const rejected = promises.filter(p => p.status === 'rejected')
       if (rejected.length > 0) {

--- a/src/state/session/agent.ts
+++ b/src/state/session/agent.ts
@@ -24,7 +24,7 @@ import {
 } from '#/lib/constants'
 import {logger} from '#/logger'
 import {snoozeBirthdateUpdateAllowedForDid} from '#/state/birthdate'
-import {restrictChatSettings} from '#/state/queries/messages/actor-declaration'
+import {restrictChatSettings} from '#/state/queries/messages/restrictChatSettings'
 import {snoozeEmailConfirmationPrompt} from '#/state/shell/reminders'
 import {
   prefetchAgeAssuranceData,


### PR DESCRIPTION
This PR automatically restricts incoming chats:
- upon signup, if the user is a minor or subject to age assurance laws in their region
- upon editing birthdate to an age <18
- upon any change to age assurance state that results in access to chats being restricted