### PR TITLE
PostControls: restore likeCount testID

### DIFF
--- a/src/components/PostControls/index.tsx
+++ b/src/components/PostControls/index.tsx
@@ -303,7 +303,7 @@ let PostControls = ({
               isToggled={Boolean(post.viewer?.like)}
               hasBeenToggled={hasLikeIconBeenToggled}
               renderCount={({count}) => (
-                <PostControlButtonText>
+                <PostControlButtonText testID="likeCount">
                   {formatPostStatCount(count)}
                 </PostControlButtonText>
               )}


### PR DESCRIPTION
This was inadvertantly removed in the refactor in a169bd862f0d8d2288e30741af233ed8e035b18c/#10190. Its [repost counterpart](https://github.com/bluesky-social/social-app/blob/main/src/components/PostControls/RepostButton.web.tsx#L55) still exists, so it makes sense to me to bring this one back too.