### PR TITLE
Fix server state query returning undefined

### DIFF
--- a/src/ageAssurance/data.tsx
+++ b/src/ageAssurance/data.tsx
@@ -225,7 +225,9 @@ export async function prefetchServerState({agent}: {agent: AtpAgent}) {
   try {
     logger.debug(`prefetchServerState: resolving...`)
     const res = await networkRetry(3, () => getServerState({agent}))
-    qc.setQueryData<AppBskyAgeassuranceGetState.OutputSchema>(qk, res)
+    if (res) {
+      qc.setQueryData<AppBskyAgeassuranceGetState.OutputSchema>(qk, res)
+    }
   } catch (err) {
     const e = err as Error
     logger.warn(`prefetchServerState: failed`, {
@@ -238,10 +240,12 @@ export async function refetchServerState({agent}: {agent: AtpAgent}) {
   if (!did) return
   logger.debug(`refetchServerState: fetching...`)
   const res = await networkRetry(3, () => getServerState({agent}))
-  qc.setQueryData<AppBskyAgeassuranceGetState.OutputSchema>(
-    createServerStateQueryKey({did}),
-    res,
-  )
+  if (res) {
+    qc.setQueryData<AppBskyAgeassuranceGetState.OutputSchema>(
+      createServerStateQueryKey({did}),
+      res,
+    )
+  }
   return res
 }
 export function usePatchServerState() {

--- a/src/ageAssurance/data.tsx
+++ b/src/ageAssurance/data.tsx
@@ -183,7 +183,7 @@ export async function getServerState({agent}: {agent: AtpAgent}) {
   const geolocation = device.get(['mergedGeolocation'])
   if (!geolocation || !geolocation.countryCode) {
     logger.error(`getServerState: missing geolocation countryCode`)
-    return
+    return null
   }
   const {data} = await agent.app.bsky.ageassurance.getState({
     countryCode: geolocation.countryCode,


### PR DESCRIPTION
## Summary
- `getServerState` returns bare `undefined` when geolocation is missing, which violates TanStack Query's requirement that `queryFn` never returns `undefined`
- Changed the early return to `return null`, matching the pattern already used at the end of the function (`return data ?? null`)

## Test plan
- [ ] Verify the "Query data cannot be undefined" error no longer appears when geolocation data is unavailable

🤖 Generated with [Claude Code](https://claude.com/claude-code)