### PR TITLE
Disable viewport zoom in prod

### DIFF
--- a/bskyweb/templates/base.html
+++ b/bskyweb/templates/base.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, viewport-fit=cover">
+  <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1, viewport-fit=cover">
   <meta name="referrer" content="origin-when-cross-origin">
   <!--
     Preconnect to essential domains

--- a/web/index.html
+++ b/web/index.html
@@ -9,7 +9,7 @@
      -->
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1.00001, viewport-fit=cover"
+      content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1, viewport-fit=cover"
     />
     <!--
       Preconnect to essential domains


### PR DESCRIPTION
Adds `maximum-scale=1` to the viewport meta tag. We were using this in dev but not prod. Motivation is that it fixes the DM input on mobile safari

Fixes #8494

Downside is that this disables zooming in on the lightbox. We should probably add support to the lightbox directly rather than leaving this to the browser, and it greatly improves the sign-in/search/dm experience so imo it's a reasonable compromise. The app already is primarily designed for small screens already