### PR TITLE
feat: collapse chat labels in banner

### DIFF
--- a/src/components/dms/MessagesListHeader.tsx
+++ b/src/components/dms/MessagesListHeader.tsx
@@ -1,13 +1,14 @@
-import {useMemo} from 'react'
+import {useMemo, useState} from 'react'
 import {View} from 'react-native'
 import {
   type AppBskyActorDefs,
   type ModerationCause,
   type ModerationDecision,
 } from '@atproto/api'
-import {msg} from '@lingui/core/macro'
+import {msg, plural} from '@lingui/core/macro'
 import {useLingui} from '@lingui/react'
 
+import {getModerationCauseKey, unique} from '#/lib/moderation'
 import {makeProfileLink} from '#/lib/routes/links'
 import {sanitizeDisplayName} from '#/lib/strings/display-names'
 import {type Shadow} from '#/state/cache/profile-shadow'
@@ -15,16 +16,23 @@ import {isConvoActive, useConvo} from '#/state/messages/convo'
 import {type ConvoItem} from '#/state/messages/convo/types'
 import {PreviewableUserAvatar} from '#/view/com/util/UserAvatar'
 import {atoms as a, useTheme, web} from '#/alf'
+import {Button} from '#/components/Button'
 import {ConvoMenu} from '#/components/dms/ConvoMenu'
 import {Bell2Off_Filled_Corner0_Rounded as BellStroke} from '#/components/icons/Bell2'
+import {
+  ChevronBottom_Stroke2_Corner0_Rounded as ChevronBottom,
+  ChevronTop_Stroke2_Corner0_Rounded as ChevronTop,
+} from '#/components/icons/Chevron'
 import * as Layout from '#/components/Layout'
 import {Link} from '#/components/Link'
 import {PostAlerts} from '#/components/moderation/PostAlerts'
+import * as Pills from '#/components/Pills'
 import {ProfileBadges} from '#/components/ProfileBadges'
 import {Text} from '#/components/Typography'
 import {IS_WEB} from '#/env'
 
 const PFP_SIZE = IS_WEB ? 40 : Layout.HEADER_SLOT_SIZE
+const LABEL_COLLAPSE_THRESHOLD = 2
 
 export function MessagesListHeader({
   profile,
@@ -112,6 +120,16 @@ function HeaderReady({
   const t = useTheme()
   const convoState = useConvo()
 
+  const modui = moderation.ui('contentList')
+  const allCauses = [
+    ...modui.alerts.filter(unique),
+    ...modui.informs.filter(unique),
+  ]
+  const labelCount = allCauses.length
+  const shouldCollapse = labelCount > LABEL_COLLAPSE_THRESHOLD
+  const [isExpanded, setIsExpanded] = useState(!shouldCollapse)
+  const overflowCount = labelCount - LABEL_COLLAPSE_THRESHOLD
+
   const isDeletedAccount = profile?.handle === 'missing.invalid'
   const displayName = isDeletedAccount
     ? _(msg`Deleted Account`)
@@ -198,18 +216,91 @@ function HeaderReady({
         </View>
       </View>
 
-      <View
-        style={[
-          {
-            paddingLeft: PFP_SIZE + a.gap_md.gap,
-          },
-        ]}>
-        <PostAlerts
-          modui={moderation.ui('contentList')}
-          size="lg"
-          style={[a.pt_xs]}
-        />
-      </View>
+      {(modui.alert || modui.inform) && (
+        <View
+          style={[
+            a.pt_xs,
+            {
+              paddingLeft: PFP_SIZE + a.gap_md.gap,
+            },
+          ]}>
+          {shouldCollapse && !isExpanded ? (
+            <Pills.Row size="lg">
+              {allCauses.slice(0, LABEL_COLLAPSE_THRESHOLD).map(cause => (
+                <Pills.Label
+                  key={getModerationCauseKey(cause)}
+                  cause={cause}
+                  size="lg"
+                />
+              ))}
+              <Button
+                label={_(
+                  plural(overflowCount, {
+                    one: 'Show # more label',
+                    other: 'Show # more labels',
+                  }),
+                )}
+                onPress={() => setIsExpanded(true)}>
+                {({hovered, pressed}) => (
+                  <View
+                    style={[
+                      a.flex_row,
+                      a.align_center,
+                      a.rounded_full,
+                      t.atoms.bg_contrast_25,
+                      (hovered || pressed) && t.atoms.bg_contrast_50,
+                      {gap: 5, paddingHorizontal: 5, paddingVertical: 5},
+                    ]}>
+                    <Text
+                      style={[
+                        a.text_sm,
+                        a.font_semi_bold,
+                        t.atoms.text_contrast_medium,
+                        {paddingRight: 3},
+                      ]}>
+                      {_(
+                        plural(overflowCount, {
+                          one: '+# more',
+                          other: '+# more',
+                        }),
+                      )}
+                    </Text>
+                    <ChevronBottom
+                      width={14}
+                      fill={t.atoms.text_contrast_medium.color}
+                    />
+                  </View>
+                )}
+              </Button>
+            </Pills.Row>
+          ) : (
+            <>
+              <PostAlerts modui={modui} size="lg" />
+              {shouldCollapse && (
+                <Button
+                  label={_(msg`Collapse labels`)}
+                  onPress={() => setIsExpanded(false)}
+                  style={[a.mt_xs, a.self_start]}>
+                  {({hovered, pressed}) => (
+                    <View
+                      style={[
+                        a.rounded_full,
+                        t.atoms.bg_contrast_25,
+                        (hovered || pressed) && t.atoms.bg_contrast_50,
+                        {paddingHorizontal: 5, paddingVertical: 5},
+                      ]}>
+                      <ChevronTop
+                        width={14}
+                        fill={t.atoms.text_contrast_medium.color}
+                      />
+                    </View>
+                  )}
+                </Button>
+              )}
+            </>
+          )}
+        </View>
+      )}
     </View>
   )
 }

--- a/src/screens/Messages/components/ChatListItem.tsx
+++ b/src/screens/Messages/components/ChatListItem.tsx
@@ -6,12 +6,13 @@ import {
   moderateProfile,
   type ModerationOpts,
 } from '@atproto/api'
-import {msg} from '@lingui/core/macro'
+import {msg, plural} from '@lingui/core/macro'
 import {useLingui} from '@lingui/react'
 import {useQueryClient} from '@tanstack/react-query'
 
 import {GestureActionView} from '#/lib/custom-animations/GestureActionView'
 import {useHaptics} from '#/lib/haptics'
+import {getModerationCauseKey, unique} from '#/lib/moderation'
 import {decrementBadgeCount} from '#/lib/notifications/notifications'
 import {sanitizeDisplayName} from '#/lib/strings/display-names'
 import {
@@ -31,15 +32,21 @@ import {TimeElapsed} from '#/view/com/util/TimeElapsed'
 import {PreviewableUserAvatar} from '#/view/com/util/UserAvatar'
 import {atoms as a, useBreakpoints, useTheme, web} from '#/alf'
 import * as tokens from '#/alf/tokens'
+import {Button} from '#/components/Button'
 import {useDialogControl} from '#/components/Dialog'
 import {ConvoMenu} from '#/components/dms/ConvoMenu'
 import {LeaveConvoPrompt} from '#/components/dms/LeaveConvoPrompt'
 import {Bell2Off_Filled_Corner0_Rounded as BellStroke} from '#/components/icons/Bell2'
+import {
+  ChevronBottom_Stroke2_Corner0_Rounded as ChevronBottom,
+  ChevronTop_Stroke2_Corner0_Rounded as ChevronTop,
+} from '#/components/icons/Chevron'
 import {Envelope_Open_Stroke2_Corner0_Rounded as EnvelopeOpen} from '#/components/icons/EnveopeOpen'
 import {Trash_Stroke2_Corner0_Rounded} from '#/components/icons/Trash'
 import {Link} from '#/components/Link'
 import {useMenuControl} from '#/components/Menu'
 import {PostAlerts} from '#/components/moderation/PostAlerts'
+import * as Pills from '#/components/Pills'
 import {createPortalGroup} from '#/components/Portal'
 import {ProfileBadges} from '#/components/ProfileBadges'
 import {Text} from '#/components/Typography'
@@ -48,6 +55,9 @@ import {IS_NATIVE} from '#/env'
 import type * as bsky from '#/types/bsky'
 
 export const ChatListItemPortal = createPortalGroup()
+
+const LABEL_COLLAPSE_THRESHOLD_MOBILE = 4
+const LABEL_COLLAPSE_THRESHOLD_DESKTOP = 8
 
 export let ChatListItem = ({
   convo,
@@ -122,6 +132,18 @@ function ChatListItemReady({
       userBlock,
     }
   }, [moderation])
+
+  const labelModui = moderation.ui('contentList')
+  const allLabelCauses = [
+    ...labelModui.alerts.filter(unique),
+    ...labelModui.informs.filter(unique),
+  ]
+  const labelCollapseThreshold = gtMobile
+    ? LABEL_COLLAPSE_THRESHOLD_DESKTOP
+    : LABEL_COLLAPSE_THRESHOLD_MOBILE
+  const shouldCollapseLabels = allLabelCauses.length > labelCollapseThreshold
+  const [labelsExpanded, setLabelsExpanded] = useState(!shouldCollapseLabels)
+  const labelOverflowCount = allLabelCauses.length - labelCollapseThreshold
 
   const isDeletedAccount = profile.handle === 'missing.invalid'
   const displayName = isDeletedAccount
@@ -474,11 +496,101 @@ function ChatListItemReady({
                     {lastMessage}
                   </Text>
 
-                  <PostAlerts
-                    modui={moderation.ui('contentList')}
-                    size="lg"
-                    style={[a.pt_xs]}
-                  />
+                  {(labelModui.alert || labelModui.inform) && (
+                    <View style={[a.pt_xs]}>
+                      {shouldCollapseLabels && !labelsExpanded ? (
+                        <Pills.Row size="lg">
+                          {allLabelCauses
+                            .slice(0, labelCollapseThreshold)
+                            .map(cause => (
+                              <Pills.Label
+                                key={getModerationCauseKey(cause)}
+                                cause={cause}
+                                size="lg"
+                              />
+                            ))}
+                          <Button
+                            label={_(
+                              plural(labelOverflowCount, {
+                                one: 'Show # more label',
+                                other: 'Show # more labels',
+                              }),
+                            )}
+                            onPress={e => {
+                              e.preventDefault()
+                              e.stopPropagation()
+                              setLabelsExpanded(true)
+                            }}>
+                            {({hovered, pressed}) => (
+                              <View
+                                style={[
+                                  a.flex_row,
+                                  a.align_center,
+                                  a.rounded_full,
+                                  t.atoms.bg_contrast_25,
+                                  (hovered || pressed) &&
+                                    t.atoms.bg_contrast_50,
+                                  {
+                                    gap: 5,
+                                    paddingHorizontal: 5,
+                                    paddingVertical: 5,
+                                  },
+                                ]}>
+                                <Text
+                                  style={[
+                                    a.text_sm,
+                                    a.font_semi_bold,
+                                    t.atoms.text_contrast_medium,
+                                    {paddingRight: 3},
+                                  ]}>
+                                  {_(
+                                    plural(labelOverflowCount, {
+                                      one: '+# more',
+                                      other: '+# more',
+                                    }),
+                                  )}
+                                </Text>
+                                <ChevronBottom
+                                  width={14}
+                                  fill={t.atoms.text_contrast_medium.color}
+                                />
+                              </View>
+                            )}
+                          </Button>
+                        </Pills.Row>
+                      ) : (
+                        <>
+                          <PostAlerts modui={labelModui} size="lg" />
+                          {shouldCollapseLabels && (
+                            <Button
+                              label={_(msg`Collapse labels`)}
+                              onPress={e => {
+                                e.preventDefault()
+                                e.stopPropagation()
+                                setLabelsExpanded(false)
+                              }}
+                              style={[a.mt_xs, a.self_start]}>
+                              {({hovered, pressed}) => (
+                                <View
+                                  style={[
+                                    a.rounded_full,
+                                    t.atoms.bg_contrast_25,
+                                    (hovered || pressed) &&
+                                      t.atoms.bg_contrast_50,
+                                    {paddingHorizontal: 5, paddingVertical: 5},
+                                  ]}>
+                                  <ChevronTop
+                                    width={14}
+                                    fill={t.atoms.text_contrast_medium.color}
+                                  />
+                                </View>
+                              )}
+                            </Button>
+                          )}
+                        </>
+                      )}
+                    </View>
+                  )}
 
                   {children}
                 </View>


### PR DESCRIPTION
Adds a collapse/expand button for labels in the DM and DM list pages, and auto-collapses when more than 4 labels are applied to an account. This change should make the DM chat page much more usable on mobile when a user is subscribed to many labelers (or just noisy labelers).

Fixes #10209 

### Screenshots 

chat list page (web):
<img width="598" height="158" alt="image" src="https://github.com/user-attachments/assets/56a43439-c537-4f14-b4fb-fa76b2efb2b4" />

<img width="604" height="264" alt="image" src="https://github.com/user-attachments/assets/291ef82d-57a8-4b37-b0d7-a85d26e30ac4" />

chat list page (mobile):
<img width="399" height="205" alt="image" src="https://github.com/user-attachments/assets/fa68db97-ac3c-4a8d-a3b1-10afe5379044" />

<img width="401" height="371" alt="image" src="https://github.com/user-attachments/assets/26a8540d-b28f-48e8-b737-efe6c8bf6c60" />
 

Chat page (mobile):
<img width="410" height="939" alt="image" src="https://github.com/user-attachments/assets/becac51b-176b-4e37-8df9-a466ad2b10cb" />

<img width="410" height="939" alt="image" src="https://github.com/user-attachments/assets/a27a8f90-84d3-40d9-a6fd-a19bd77d914d" />
