### PR TITLE
Fix bskyembed skeleton padding

### DIFF
--- a/bskyembed/src/screens/landing.tsx
+++ b/bskyembed/src/screens/landing.tsx
@@ -186,7 +186,7 @@ function LandingPage() {
 function Skeleton() {
   return (
     <Container>
-      <div className="flex-1 flex-col flex gap-2 pb-8">
+      <div className="flex-1 flex-col flex gap-2 p-5 pb-8">
         <div className="flex gap-2.5 items-center">
           <div className="w-10 h-10 overflow-hidden rounded-full bg-neutral-100 dark:bg-slate-700 shrink-0 animate-pulse" />
           <div className="flex-1">


### PR DESCRIPTION
## Summary
- Add missing `p-5` padding to the bskyembed landing page skeleton, matching the padding used by the actual `Post` component

## Screenshots

### Before

<img width="654" height="212" alt="Screenshot 2026-04-12 at 21 55 23" src="https://github.com/user-attachments/assets/73fd8cc2-faaa-480d-a8f6-2eb84adaeb8d" />



### After

<img width="668" height="229" alt="Screenshot 2026-04-12 at 21 55 39" src="https://github.com/user-attachments/assets/881241ab-f7f1-4577-bd8f-89d95840b1b7" />



🤖 Generated with [Claude Code](https://claude.com/claude-code)