### PR TITLE
Fix inverted condition in moveIfNecessary

### DIFF
--- a/src/state/gallery.ts
+++ b/src/state/gallery.ts
@@ -277,7 +277,7 @@ export async function compressImage(
 async function moveIfNecessary(from: string) {
   const cacheDir = IS_NATIVE && getImageCacheDirectory()
 
-  if (cacheDir && from.startsWith(cacheDir)) {
+  if (cacheDir && !from.startsWith(cacheDir)) {
     const to = joinPath(cacheDir, nanoid(36))
 
     await makeDirectoryAsync(cacheDir, {intermediates: true})


### PR DESCRIPTION
## Summary
- Fixes an inverted `startsWith` condition in `moveIfNecessary` (`src/state/gallery.ts`) that made the function a no-op
- The MobX removal refactor (#5381) collapsed `cacheDirectory` (general cache) and `imageCacheDirectory` (bsky-composer subdir) into a single `getImageCacheDirectory()` call without flipping the condition, so image manipulation output (crop, manipulate, compress) was never moved to the safe `bsky-composer/` directory
- This left temp files vulnerable to Android cache cleanup, causing sporadic "Loading bitmap failed" errors

Fixes #9370

🤖 Generated with [Claude Code](https://claude.com/claude-code)