### PR TITLE
Fix stale searchText in search submit handler

### DIFF
--- a/src/screens/Search/Shell.tsx
+++ b/src/screens/Search/Shell.tsx
@@ -96,9 +96,12 @@ export function SearchScreenShell({
   const [activeTab, setActiveTab] = useState(() => getTabIndex(tabParam))
 
   // Query terms
-  const [searchText, setSearchText] = useState<string>(queryParam)
+  const [searchText, _setSearchText] = useState<string>(queryParam)
   const searchTextRef = useRef(searchText)
-  searchTextRef.current = searchText
+  const setSearchText = (text: string) => {
+    searchTextRef.current = text
+    _setSearchText(text)
+  }
   const {data: autocompleteData, isFetching: isAutocompleteFetching} =
     useActorAutocompleteQuery(searchText, true)
 

--- a/src/screens/Search/Shell.tsx
+++ b/src/screens/Search/Shell.tsx
@@ -97,6 +97,8 @@ export function SearchScreenShell({
 
   // Query terms
   const [searchText, setSearchText] = useState<string>(queryParam)
+  const searchTextRef = useRef(searchText)
+  searchTextRef.current = searchText
   const {data: autocompleteData, isFetching: isAutocompleteFetching} =
     useActorAutocompleteQuery(searchText, true)
 
@@ -227,15 +229,12 @@ export function SearchScreenShell({
     }
   }, [setShowAutocomplete, setSearchText, navigation, route.params, route.name])
 
-  const onSubmit = useCallback(
-    (source: 'typed' | 'autocomplete') => () => {
-      ax.metric('search:query', {
-        source,
-      })
-      navigateToItem(searchText)
-    },
-    [ax, navigateToItem, searchText],
-  )
+  const onSubmit = (source: 'typed' | 'autocomplete') => () => {
+    ax.metric('search:query', {
+      source,
+    })
+    navigateToItem(searchTextRef.current)
+  }
 
   const onAutocompleteResultPress = useCallback(() => {
     if (IS_WEB) {


### PR DESCRIPTION
The onSubmit handler captured searchText from the render closure, so if the user typed fast and hit enter before React committed the last keystroke's re-render, the search would use a stale value. Use a ref instead so the handler always reads the latest searchText at call time.