### PR TITLE
Reveal chat timestamp on tap

### DIFF
--- a/src/components/ContextMenu/index.tsx
+++ b/src/components/ContextMenu/index.tsx
@@ -235,7 +235,13 @@ export function Root({children}: {children: React.ReactNode}) {
   return <Context.Provider value={context}>{children}</Context.Provider>
 }
 
-export function Trigger({children, label, contentLabel, style}: TriggerProps) {
+export function Trigger({
+  children,
+  label,
+  contentLabel,
+  style,
+  onTap,
+}: TriggerProps) {
   const context = useContextMenuContext()
   const playHaptic = useHaptics()
   const insets = useSafeAreaInsets()
@@ -294,6 +300,17 @@ export function Trigger({children, label, contentLabel, style}: TriggerProps) {
     }
   }, [context, insets])
 
+  const tapGesture = useMemo(() => {
+    const gesture = Gesture.Tap()
+      .numberOfTaps(1)
+      .cancelsTouchesInView(false)
+      .runOnJS(true)
+    if (onTap) {
+      gesture.onEnd(() => void onTap())
+    }
+    return gesture
+  }, [onTap])
+
   const doubleTapGesture = useMemo(() => {
     return Gesture.Tap()
       .numberOfTaps(2)
@@ -346,8 +363,10 @@ export function Trigger({children, label, contentLabel, style}: TriggerProps) {
       })
   }, [open, hoverablesSV, onTouchUpMenuItem, hoveredItemSV, translationSV])
 
+  // Order matters here: doubleTapGesture must come before tapGesture.
   const composedGestures = Gesture.Exclusive(
     doubleTapGesture,
+    tapGesture,
     pressAndHoldGesture,
   )
 

--- a/src/components/ContextMenu/types.ts
+++ b/src/components/ContextMenu/types.ts
@@ -84,6 +84,14 @@ export type TriggerProps = {
   hint?: string
   role?: AccessibilityRole
   style?: StyleProp<ViewStyle>
+  /**
+   * Callback for single taps. Composed with the double-tap and
+   * press-and-hold gestures via `Gesture.Exclusive`, so a double tap
+   * does not also fire this handler.
+   *
+   * @platform ios, android
+   */
+  onTap?: () => void
 }
 export type TriggerChildProps =
   | {

--- a/src/components/dms/ActionsWrapper.tsx
+++ b/src/components/dms/ActionsWrapper.tsx
@@ -12,6 +12,7 @@ export function ActionsWrapper({
   onTap,
 }: {
   message: ChatBskyConvoDefs.MessageView
+  hasReactions?: boolean
   isFromSelf: boolean
   children: React.ReactNode
   onTap?: () => void

--- a/src/components/dms/ActionsWrapper.tsx
+++ b/src/components/dms/ActionsWrapper.tsx
@@ -9,15 +9,17 @@ export function ActionsWrapper({
   message,
   isFromSelf,
   children,
+  onTap,
 }: {
   message: ChatBskyConvoDefs.MessageView
   isFromSelf: boolean
   children: React.ReactNode
+  onTap?: () => void
 }) {
   const {t: l} = useLingui()
 
   return (
-    <MessageContextMenu message={message}>
+    <MessageContextMenu message={message} onTap={onTap}>
       {trigger =>
         // will always be true, since this file is platform split
         trigger.IS_NATIVE && (

--- a/src/components/dms/ActionsWrapper.web.tsx
+++ b/src/components/dms/ActionsWrapper.web.tsx
@@ -1,8 +1,7 @@
 import {useCallback, useRef, useState} from 'react'
 import {Pressable, View} from 'react-native'
 import {type ChatBskyConvoDefs} from '@atproto/api'
-import {msg} from '@lingui/core/macro'
-import {useLingui} from '@lingui/react'
+import {useLingui} from '@lingui/react/macro'
 
 import {useConvoActive} from '#/state/messages/convo'
 import {useSession} from '#/state/session'
@@ -19,15 +18,17 @@ export function ActionsWrapper({
   hasReactions,
   isFromSelf,
   children,
+  onTap,
 }: {
   message: ChatBskyConvoDefs.MessageView
   hasReactions?: boolean
   isFromSelf: boolean
   children: React.ReactNode
+  onTap?: () => void
 }) {
   const viewRef = useRef(null)
   const t = useTheme()
-  const {_} = useLingui()
+  const {t: l} = useLingui()
   const convo = useConvoActive()
   const {currentAccount} = useSession()
 
@@ -59,17 +60,17 @@ export function ActionsWrapper({
       ) {
         convo
           .removeReaction(message.id, emoji)
-          .catch(() => Toast.show(_(msg`Failed to remove emoji reaction`)))
+          .catch(() => Toast.show(l`Failed to remove emoji reaction`))
       } else {
         if (hasReachedReactionLimit(message, currentAccount?.did)) return
         convo.addReaction(message.id, emoji).catch(() =>
-          Toast.show(_(msg`Failed to add emoji reaction`), {
+          Toast.show(l`Failed to add emoji reaction`, {
             type: 'error',
           }),
         )
       }
     },
-    [_, convo, message, currentAccount?.did],
+    [l, convo, message, currentAccount?.did],
   )
 
   return (
@@ -136,10 +137,13 @@ export function ActionsWrapper({
           }}
         </MessageContextMenu>
       </View>
-      <View
+      <Pressable
+        accessibilityRole="button"
+        accessibilityHint={l`Click to view the date and time`}
+        onPress={onTap}
         style={[{maxWidth: '80%'}, isFromSelf ? a.align_end : a.align_start]}>
         {children}
-      </View>
+      </Pressable>
     </View>
   )
 }

--- a/src/components/dms/ActionsWrapper.web.tsx
+++ b/src/components/dms/ActionsWrapper.web.tsx
@@ -16,10 +16,12 @@ import {hasReachedReactionLimit} from './util'
 
 export function ActionsWrapper({
   message,
+  hasReactions,
   isFromSelf,
   children,
 }: {
   message: ChatBskyConvoDefs.MessageView
+  hasReactions?: boolean
   isFromSelf: boolean
   children: React.ReactNode
 }) {
@@ -87,6 +89,7 @@ export function ActionsWrapper({
           isFromSelf
             ? [a.mr_xs, {marginLeft: 'auto'}, a.flex_row_reverse]
             : [a.ml_xs, {marginRight: 'auto'}],
+          hasReactions ? [a.mb_2xl] : undefined,
         ]}>
         <EmojiReactionPicker message={message} onEmojiSelect={onEmojiSelect}>
           {({props, state, IS_NATIVE, control}) => {

--- a/src/components/dms/DateDivider.tsx
+++ b/src/components/dms/DateDivider.tsx
@@ -1,6 +1,6 @@
 import {memo} from 'react'
 import {View} from 'react-native'
-import {Trans, useLingui} from '@lingui/react/macro'
+import {useLingui} from '@lingui/react/macro'
 import {subDays} from 'date-fns'
 
 import {atoms as a, useTheme} from '#/alf'
@@ -26,9 +26,14 @@ const longDateFormatterWithYear = new Intl.DateTimeFormat(undefined, {
   year: 'numeric',
 })
 
-let DateDivider = ({date: dateStr}: {date: string}): React.ReactNode => {
+export function useDateTimeString({
+  date: dateStr,
+  onlyTime = false,
+}: {
+  date: string
+  onlyTime?: boolean
+}) {
   const {t: l} = useLingui()
-  const t = useTheme()
 
   let date: string
   const time = timeFormatter.format(new Date(dateStr))
@@ -55,6 +60,16 @@ let DateDivider = ({date: dateStr}: {date: string}): React.ReactNode => {
     }
   }
 
+  if (onlyTime) return time
+
+  return l`${date} at ${time}`
+}
+
+let DateDivider = ({date}: {date: string}): React.ReactNode => {
+  const t = useTheme()
+
+  const datetime = useDateTimeString({date})
+
   return (
     <View style={[a.w_full, a.my_sm]}>
       <Text
@@ -65,9 +80,7 @@ let DateDivider = ({date: dateStr}: {date: string}): React.ReactNode => {
           t.atoms.text_contrast_medium,
           a.px_md,
         ]}>
-        <Trans>
-          {date} at {time}
-        </Trans>
+        {datetime}
       </Text>
     </View>
   )

--- a/src/components/dms/DateDivider.tsx
+++ b/src/components/dms/DateDivider.tsx
@@ -1,6 +1,6 @@
 import {memo} from 'react'
 import {View} from 'react-native'
-import {useLingui} from '@lingui/react/macro'
+import {Trans, useLingui} from '@lingui/react/macro'
 import {subDays} from 'date-fns'
 
 import {atoms as a, useTheme} from '#/alf'
@@ -26,13 +26,8 @@ const longDateFormatterWithYear = new Intl.DateTimeFormat(undefined, {
   year: 'numeric',
 })
 
-export function useDateTimeString({
-  date: dateStr,
-  onlyTime = false,
-}: {
-  date: string
-  onlyTime?: boolean
-}) {
+let DateDivider = ({date: dateStr}: {date: string}): React.ReactNode => {
+  const t = useTheme()
   const {t: l} = useLingui()
 
   let date: string
@@ -60,16 +55,6 @@ export function useDateTimeString({
     }
   }
 
-  if (onlyTime) return time
-
-  return l`${date} at ${time}`
-}
-
-let DateDivider = ({date}: {date: string}): React.ReactNode => {
-  const t = useTheme()
-
-  const datetime = useDateTimeString({date})
-
   return (
     <View style={[a.w_full, a.my_sm]}>
       <Text
@@ -80,7 +65,9 @@ let DateDivider = ({date}: {date: string}): React.ReactNode => {
           t.atoms.text_contrast_medium,
           a.px_md,
         ]}>
-        {datetime}
+        <Trans>
+          {date} at {time}
+        </Trans>
       </Text>
     </View>
   )

--- a/src/components/dms/DateDividerToggle.tsx
+++ b/src/components/dms/DateDividerToggle.tsx
@@ -1,0 +1,44 @@
+import {createContext, useCallback, useContext, useState} from 'react'
+
+type DateDividerToggleContextType = {
+  isDividerToggled: (id: string) => boolean
+  toggleDivider: (id: string) => void
+}
+
+const DateDividerToggleContext = createContext<DateDividerToggleContextType>({
+  isDividerToggled: () => false,
+  toggleDivider: () => {},
+})
+
+export function DateDividerToggleProvider({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  const [toggledIds, setToggledIds] = useState(new Set<string>())
+
+  const toggleDivider = useCallback((id: string) => {
+    setToggledIds(prev => {
+      const next = new Set(prev)
+      if (next.has(id)) next.delete(id)
+      else next.add(id)
+      return next
+    })
+  }, [])
+
+  const isDividerToggled = useCallback(
+    (id: string) => toggledIds.has(id),
+    [toggledIds],
+  )
+
+  return (
+    <DateDividerToggleContext.Provider
+      value={{isDividerToggled, toggleDivider}}>
+      {children}
+    </DateDividerToggleContext.Provider>
+  )
+}
+
+export function useDateDividerToggle() {
+  return useContext(DateDividerToggleContext)
+}

--- a/src/components/dms/MessageContextMenu.tsx
+++ b/src/components/dms/MessageContextMenu.tsx
@@ -31,9 +31,11 @@ import {hasReachedReactionLimit} from './util'
 export let MessageContextMenu = ({
   message,
   children,
+  onTap,
 }: {
   message: ChatBskyConvoDefs.MessageView
   children: TriggerProps['children']
+  onTap?: () => void
 }): React.ReactNode => {
   const {t: l} = useLingui()
   const ax = useAnalytics()
@@ -130,7 +132,8 @@ export let MessageContextMenu = ({
           label={l`Message options`}
           contentLabel={l`Message from @${
             sender?.handle ?? 'unknown' // should always be defined
-          }: ${message.text}`}>
+          }: ${message.text}`}
+          onTap={onTap}>
           {children}
         </ContextMenu.Trigger>
 

--- a/src/components/dms/MessageItem.tsx
+++ b/src/components/dms/MessageItem.tsx
@@ -1,6 +1,7 @@
 import {memo, useCallback, useMemo, useState} from 'react'
 import {
   type GestureResponderEvent,
+  LayoutAnimation,
   Pressable,
   type StyleProp,
   type TextStyle,
@@ -43,6 +44,7 @@ import {RichText} from '#/components/RichText'
 import {Text} from '#/components/Typography'
 import type * as bsky from '#/types/bsky'
 import {DateDivider} from './DateDivider'
+import {useDateDividerToggle} from './DateDividerToggle'
 import {MessageItemEmbed} from './MessageItemEmbed'
 
 const AVATAR_SIZE = 28
@@ -158,17 +160,25 @@ let MessageItem = ({
       new Date(prevMessage.sentAt).getTime() >
       MESSAGE_GAP_THRESHOLD_MS
 
+  const {isDividerToggled, toggleDivider} = useDateDividerToggle()
+  const isDateDividerToggled = isDividerToggled(message.id)
+  const isNextDateDividerToggled =
+    nextMessage != null && isDividerToggled(nextMessage.id)
   const showDateDivider = hasLargeGapFromPrev
 
-  const isInCluster = !(isFirstInCluster && isLastInCluster)
+  const effectiveFirstInCluster = isFirstInCluster || isDateDividerToggled
+  const effectiveLastInCluster = isLastInCluster || isNextDateDividerToggled
+  const isInCluster = !(effectiveFirstInCluster && effectiveLastInCluster)
   const isInMiddleOfCluster =
-    isInCluster && !isFirstInCluster && !isLastInCluster
+    isInCluster && !effectiveFirstInCluster && !effectiveLastInCluster
 
   const hasReactions = message.reactions && message.reactions.length > 0
   const squaredBottomCorner =
-    !hasReactions && isInCluster && (isInMiddleOfCluster || isFirstInCluster)
+    !hasReactions &&
+    isInCluster &&
+    (isInMiddleOfCluster || effectiveFirstInCluster)
   const squaredTopCorner =
-    isInCluster && (isInMiddleOfCluster || isLastInCluster)
+    isInCluster && (isInMiddleOfCluster || effectiveLastInCluster)
 
   const pendingColor = t.palette.primary_300
 
@@ -322,7 +332,7 @@ let MessageItem = ({
 
   return (
     <>
-      {showDateDivider && (
+      {(showDateDivider || isDateDividerToggled) && (
         <Animated.View entering={native(FadeIn)} exiting={native(FadeOut)}>
           <DateDivider date={message.sentAt} />
         </Animated.View>
@@ -330,10 +340,10 @@ let MessageItem = ({
       <View
         style={[
           isFromSelf ? a.mr_sm : a.ml_sm,
-          isFirstInCluster && !showDateDivider && a.mt_sm,
+          effectiveFirstInCluster && !showDateDivider && a.mt_sm,
         ]}>
         <View style={[a.relative]}>
-          {isGroupChat && !isFromSelf && isLastInCluster ? (
+          {isGroupChat && !isFromSelf && effectiveLastInCluster ? (
             <View style={[a.absolute, {bottom: hasReactions ? 10 : 0}]}>
               {avatar}
             </View>
@@ -348,7 +358,7 @@ let MessageItem = ({
             ]}>
             {isGroupChat &&
             !isFromSelf &&
-            isFirstInCluster &&
+            effectiveFirstInCluster &&
             !isOnlyEmoji(message.text) ? (
               <Text
                 style={[
@@ -363,7 +373,17 @@ let MessageItem = ({
                 {displayName}
               </Text>
             ) : null}
-            <ActionsWrapper isFromSelf={isFromSelf} message={message}>
+            <ActionsWrapper
+              isFromSelf={isFromSelf}
+              message={message}
+              onTap={() => {
+                if (!hasLargeGapFromPrev) {
+                  LayoutAnimation.configureNext(
+                    LayoutAnimation.Presets.easeInEaseOut,
+                  )
+                  toggleDivider(message.id)
+                }
+              }}>
               {rt.text.length > 0 && (
                 <View
                   accessibilityHint={l`Double tap or long press the message to add a reaction`}
@@ -377,7 +397,7 @@ let MessageItem = ({
                           a.py_sm,
                           a.px_md,
                           {
-                            marginTop: isFirstInCluster
+                            marginTop: effectiveFirstInCluster
                               ? 0
                               : CLUSTERED_MESSAGE_GAP,
                             backgroundColor: isFromSelf
@@ -430,7 +450,7 @@ let MessageItem = ({
             </ActionsWrapper>
           </View>
         </View>
-        {isLastInCluster && (
+        {effectiveLastInCluster && (
           <MessageItemMetadata
             item={item}
             style={[isFromSelf ? a.text_right : a.text_left]}

--- a/src/components/dms/MessageItem.tsx
+++ b/src/components/dms/MessageItem.tsx
@@ -409,6 +409,7 @@ let MessageItem = ({
               </Text>
             ) : null}
             <ActionsWrapper
+              hasReactions={hasReactions}
               isFromSelf={isFromSelf}
               message={message}
               onTap={() => {

--- a/src/components/dms/MessageItem.tsx
+++ b/src/components/dms/MessageItem.tsx
@@ -378,7 +378,7 @@ let MessageItem = ({
             a.mt_sm,
         ]}>
         <View style={[a.relative]}>
-          {isGroupChat && !isFromSelf && effectiveLastInCluster ? (
+          {isGroupChat && !isFromSelf && isLastInCluster ? (
             <View style={[a.absolute, {bottom: hasReactions ? 10 : 0}]}>
               {avatar}
             </View>
@@ -394,6 +394,7 @@ let MessageItem = ({
             {isGroupChat &&
             !isFromSelf &&
             effectiveFirstInCluster &&
+            !isDateDividerToggled &&
             !isOnlyEmoji(message.text) ? (
               <Text
                 style={[

--- a/src/components/dms/MessageItem.tsx
+++ b/src/components/dms/MessageItem.tsx
@@ -1,4 +1,4 @@
-import {memo, useCallback, useMemo, useState} from 'react'
+import {memo, useCallback, useEffect, useMemo, useState} from 'react'
 import {
   type GestureResponderEvent,
   LayoutAnimation,
@@ -12,7 +12,9 @@ import Animated, {
   FadeOut,
   LayoutAnimationConfig,
   LinearTransition,
+  useAnimatedStyle,
   useSharedValue,
+  withTiming,
   ZoomIn,
   ZoomOut,
 } from 'react-native-reanimated'
@@ -188,6 +190,37 @@ let MessageItem = ({
 
   const hasEmbedAndText =
     AppBskyEmbedRecord.isView(message.embed) && rt.text.length > 0
+
+  const targetBottomRadius =
+    squaredBottomCorner || hasEmbedAndText
+      ? SQUARED_BORDER_RADIUS
+      : BORDER_RADIUS
+  const targetTopRadius = squaredTopCorner
+    ? SQUARED_BORDER_RADIUS
+    : BORDER_RADIUS
+
+  const bottomRadiusSV = useSharedValue(targetBottomRadius)
+  const topRadiusSV = useSharedValue(targetTopRadius)
+
+  useEffect(() => {
+    bottomRadiusSV.set(withTiming(targetBottomRadius, {duration: 300}))
+  }, [targetBottomRadius, bottomRadiusSV])
+
+  useEffect(() => {
+    topRadiusSV.set(withTiming(targetTopRadius, {duration: 300}))
+  }, [targetTopRadius, topRadiusSV])
+
+  const borderRadiusStyle = useAnimatedStyle(() =>
+    isFromSelf
+      ? {
+          borderBottomRightRadius: bottomRadiusSV.get(),
+          borderTopRightRadius: topRadiusSV.get(),
+        }
+      : {
+          borderBottomLeftRadius: bottomRadiusSV.get(),
+          borderTopLeftRadius: topRadiusSV.get(),
+        },
+  )
 
   const avatar = profile ? (
     <ProfileCard.Avatar
@@ -385,7 +418,7 @@ let MessageItem = ({
                 }
               }}>
               {rt.text.length > 0 && (
-                <View
+                <Animated.View
                   accessibilityHint={l`Double tap or long press the message to add a reaction`}
                   style={[
                     !isFromSelf && a.ml_sm,
@@ -407,25 +440,7 @@ let MessageItem = ({
                               : t.palette.contrast_50,
                           },
                           isFromSelf ? a.self_end : a.self_start,
-                          isFromSelf
-                            ? {
-                                borderBottomRightRadius:
-                                  squaredBottomCorner || hasEmbedAndText
-                                    ? SQUARED_BORDER_RADIUS
-                                    : BORDER_RADIUS,
-                                borderTopRightRadius: squaredTopCorner
-                                  ? SQUARED_BORDER_RADIUS
-                                  : BORDER_RADIUS,
-                              }
-                            : {
-                                borderBottomLeftRadius:
-                                  squaredBottomCorner || hasEmbedAndText
-                                    ? SQUARED_BORDER_RADIUS
-                                    : BORDER_RADIUS,
-                                borderTopLeftRadius: squaredTopCorner
-                                  ? SQUARED_BORDER_RADIUS
-                                  : BORDER_RADIUS,
-                              },
+                          borderRadiusStyle,
                         ]),
                   ]}>
                   <RichText
@@ -436,7 +451,7 @@ let MessageItem = ({
                     emojiMultiplier={3}
                     shouldProxyLinks={true}
                   />
-                </View>
+                </Animated.View>
               )}
               {AppBskyEmbedRecord.isView(message.embed) && (
                 <MessageItemEmbed

--- a/src/components/dms/MessageItem.tsx
+++ b/src/components/dms/MessageItem.tsx
@@ -373,7 +373,9 @@ let MessageItem = ({
       <View
         style={[
           isFromSelf ? a.mr_sm : a.ml_sm,
-          effectiveFirstInCluster && !showDateDivider && a.mt_sm,
+          effectiveFirstInCluster &&
+            !(showDateDivider || isDateDividerToggled) &&
+            a.mt_sm,
         ]}>
         <View style={[a.relative]}>
           {isGroupChat && !isFromSelf && effectiveLastInCluster ? (

--- a/src/components/dms/MessageItem.tsx
+++ b/src/components/dms/MessageItem.tsx
@@ -202,6 +202,14 @@ let MessageItem = ({
   const bottomRadiusSV = useSharedValue(targetBottomRadius)
   const topRadiusSV = useSharedValue(targetTopRadius)
 
+  const showDisplayName =
+    isGroupChat &&
+    !isFromSelf &&
+    effectiveFirstInCluster &&
+    !isDateDividerToggled &&
+    !isOnlyEmoji(message.text)
+  const showAvatar = isGroupChat && !isFromSelf && isLastInCluster
+
   useEffect(() => {
     bottomRadiusSV.set(withTiming(targetBottomRadius, {duration: 300}))
   }, [targetBottomRadius, bottomRadiusSV])
@@ -378,7 +386,7 @@ let MessageItem = ({
             a.mt_sm,
         ]}>
         <View style={[a.relative]}>
-          {isGroupChat && !isFromSelf && isLastInCluster ? (
+          {showAvatar ? (
             <View style={[a.absolute, {bottom: hasReactions ? 10 : 0}]}>
               {avatar}
             </View>
@@ -391,11 +399,7 @@ let MessageItem = ({
                   paddingLeft: AVATAR_SIZE,
                 },
             ]}>
-            {isGroupChat &&
-            !isFromSelf &&
-            effectiveFirstInCluster &&
-            !isDateDividerToggled &&
-            !isOnlyEmoji(message.text) ? (
+            {showDisplayName ? (
               <Text
                 style={[
                   a.text_xs,

--- a/src/screens/Messages/components/MessagesList.tsx
+++ b/src/screens/Messages/components/MessagesList.tsx
@@ -53,6 +53,7 @@ import {MessageInput} from '#/screens/Messages/components/MessageInput'
 import {MessageListError} from '#/screens/Messages/components/MessageListError'
 import {atoms as a, platform, tokens, useTheme, web} from '#/alf'
 import {ChatEmptyPill} from '#/components/dms/ChatEmptyPill'
+import {DateDividerToggleProvider} from '#/components/dms/DateDividerToggle'
 import {MessageItem} from '#/components/dms/MessageItem'
 import {NewMessagesPill} from '#/components/dms/NewMessagesPill'
 import {Loader} from '#/components/Loader'
@@ -417,7 +418,7 @@ export function MessagesList({
   )
 
   return (
-    <>
+    <DateDividerToggleProvider>
       <KeyboardGestureArea
         interpolator="ios"
         // HACKFIX: https://github.com/kirillzyusko/react-native-keyboard-controller/issues/1419
@@ -528,7 +529,7 @@ export function MessagesList({
       )}
 
       {newMessagesPill.show && <NewMessagesPill onPress={scrollToEndOnPress} />}
-    </>
+    </DateDividerToggleProvider>
   )
 }
 


### PR DESCRIPTION
Tapping a message without a timestamp reveals that message’s timestamp.

This was added to the `ContextMenu` component so that it wouldn’t interfere with the existing double-tap and tap-and-hold gestures.

https://github.com/user-attachments/assets/a5c36185-37c9-4e8c-b60d-1573f481dc68