### PR TITLE
Animate border radius in lightbox transition

### DIFF
--- a/src/components/Post/Embed/ImageEmbed.tsx
+++ b/src/components/Post/Embed/ImageEmbed.tsx
@@ -4,7 +4,7 @@ import {Image} from 'expo-image'
 
 import {useLightboxControls} from '#/state/lightbox'
 import {type Dimensions} from '#/view/com/lightbox/ImageViewing/@types'
-import {atoms as a} from '#/alf'
+import {atoms as a, tokens} from '#/alf'
 import {AutoSizedImage} from '#/components/images/AutoSizedImage'
 import {Gallery} from '#/components/images/Gallery'
 import {ImageLayoutGrid} from '#/components/images/ImageLayoutGrid'
@@ -42,6 +42,7 @@ export function ImageEmbed({
           thumbRect: null,
           thumbRef: refs[i] ?? null,
           thumbDimensions: fetchedDims[i] ?? null,
+          thumbBorderRadius: tokens.borderRadius.md,
           type: 'image',
         })),
         index,

--- a/src/view/com/lightbox/ImageViewing/@types/index.ts
+++ b/src/view/com/lightbox/ImageViewing/@types/index.ts
@@ -29,6 +29,7 @@ export type ImageSource = {
   thumbDimensions: Dimensions | null
   thumbRect: MeasuredDimensions | null
   thumbRef?: AnimatedRef<any> | null
+  thumbBorderRadius?: number
   alt?: string
   type: 'image' | 'circle-avi' | 'rect-avi'
 }
@@ -37,3 +38,12 @@ export type Transform = Exclude<
   TransformsStyle['transform'],
   string | undefined
 >
+
+export type LightboxTransforms = {
+  scaleAndMoveTransform: Transform
+  cropFrameTransform: Transform
+  cropContentTransform: Transform
+  borderRadius: number
+  isResting: boolean
+  isHidden: boolean
+}

--- a/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.android.tsx
+++ b/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.android.tsx
@@ -19,7 +19,7 @@ import {Image} from 'expo-image'
 import {
   type Dimensions as ImageDimensions,
   type ImageSource,
-  type Transform,
+  type LightboxTransforms,
 } from '../../@types'
 import {
   applyRounding,
@@ -53,15 +53,7 @@ type Props = {
   imageAspect: number | undefined
   imageDimensions: ImageDimensions | undefined
   dismissSwipePan: PanGesture
-  transforms: Readonly<
-    SharedValue<{
-      scaleAndMoveTransform: Transform
-      cropFrameTransform: Transform
-      cropContentTransform: Transform
-      isResting: boolean
-      isHidden: boolean
-    }>
-  >
+  transforms: Readonly<SharedValue<LightboxTransforms>>
 }
 const ImageItem = ({
   imageSrc,
@@ -339,11 +331,12 @@ const ImageItem = ({
   })
 
   const imageCropStyle = useAnimatedStyle(() => {
-    const {cropFrameTransform} = transforms.get()
+    const {cropFrameTransform, borderRadius: br} = transforms.get()
     return {
       flex: 1,
       overflow: 'hidden',
       transform: cropFrameTransform,
+      borderRadius: br,
     }
   })
 

--- a/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.ios.tsx
+++ b/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.ios.tsx
@@ -29,7 +29,7 @@ import {Image} from 'expo-image'
 import {
   type Dimensions as ImageDimensions,
   type ImageSource,
-  type Transform,
+  type LightboxTransforms,
 } from '../../@types'
 
 const MAX_ORIGINAL_IMAGE_ZOOM = 2
@@ -52,15 +52,7 @@ type Props = {
   imageAspect: number | undefined
   imageDimensions: ImageDimensions | undefined
   dismissSwipePan: PanGesture
-  transforms: Readonly<
-    SharedValue<{
-      scaleAndMoveTransform: Transform
-      cropFrameTransform: Transform
-      cropContentTransform: Transform
-      isResting: boolean
-      isHidden: boolean
-    }>
-  >
+  transforms: Readonly<SharedValue<LightboxTransforms>>
 }
 
 const ImageItem = ({
@@ -170,10 +162,11 @@ const ImageItem = ({
 
   const imageCropStyle = useAnimatedStyle(() => {
     const screenSize = measureSafeArea()
-    const {cropFrameTransform} = transforms.get()
+    const {cropFrameTransform, borderRadius: br} = transforms.get()
     return {
       overflow: 'hidden',
       transform: cropFrameTransform,
+      borderRadius: br,
       width: screenSize.width,
       maxHeight: screenSize.height,
       alignSelf: 'center',

--- a/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.tsx
+++ b/src/view/com/lightbox/ImageViewing/components/ImageItem/ImageItem.tsx
@@ -9,7 +9,7 @@ import {type Dimensions} from '#/lib/media/types'
 import {
   type Dimensions as ImageDimensions,
   type ImageSource,
-  type Transform,
+  type LightboxTransforms,
 } from '../../@types'
 
 type Props = {
@@ -29,15 +29,7 @@ type Props = {
   imageAspect: number | undefined
   imageDimensions: ImageDimensions | undefined
   dismissSwipePan: PanGesture
-  transforms: Readonly<
-    SharedValue<{
-      scaleAndMoveTransform: Transform
-      cropFrameTransform: Transform
-      cropContentTransform: Transform
-      isResting: boolean
-      isHidden: boolean
-    }>
-  >
+  transforms: Readonly<SharedValue<LightboxTransforms>>
 }
 
 const ImageItem = (_props: Props) => {

--- a/src/view/com/lightbox/ImageViewing/index.tsx
+++ b/src/view/com/lightbox/ImageViewing/index.tsx
@@ -52,7 +52,11 @@ import {useTheme} from '#/alf'
 import {setSystemUITheme} from '#/alf/util/systemUI'
 import {IS_IOS} from '#/env'
 import {PlatformInfo} from '../../../../../modules/expo-bluesky-swiss-army'
-import {type ImageSource, type Transform} from './@types'
+import {
+  type ImageSource,
+  type LightboxTransforms,
+  type Transform,
+} from './@types'
 import ImageDefaultHeader from './components/ImageDefaultHeader'
 import ImageItem from './components/ImageItem/ImageItem'
 
@@ -494,8 +498,8 @@ function LightboxImage({
     return safeArea
   }, [safeAreaRef, heightDelayedForJSThreadOnly, widthDelayedForJSThreadOnly])
 
-  const {thumbRect: thumbRectJS} = imageSrc
-  const transforms = useDerivedValue(() => {
+  const {thumbRect: thumbRectJS, thumbBorderRadius} = imageSrc
+  const transforms = useDerivedValue<LightboxTransforms>(() => {
     'worklet'
     const safeArea = measureSafeArea()
     const openProgressValue = openProgress.get()
@@ -506,6 +510,7 @@ function LightboxImage({
       return {
         isHidden: true,
         isResting: false,
+        borderRadius: 0,
         scaleAndMoveTransform: [],
         cropFrameTransform: [],
         cropContentTransform: [],
@@ -525,12 +530,14 @@ function LightboxImage({
           thumbRect,
           safeArea,
           imageAspect,
+          thumbBorderRadius,
         )
       }
     }
     return {
       isHidden: false,
       isResting: dismissTranslateY === 0,
+      borderRadius: 0,
       scaleAndMoveTransform: [{translateY: dismissTranslateY}],
       cropFrameTransform: [],
       cropContentTransform: [],
@@ -772,10 +779,12 @@ function interpolateTransform(
   },
   safeArea: {width: number; height: number; x: number; y: number},
   imageAspect: number,
+  thumbBorderRadius?: number,
 ): {
   scaleAndMoveTransform: Transform
   cropFrameTransform: Transform
   cropContentTransform: Transform
+  borderRadius: number
   isResting: boolean
   isHidden: boolean
 } {
@@ -827,12 +836,23 @@ function interpolateTransform(
     [0, 1],
     [croppedFinalHeight / finalHeight, 1],
   )
+  // The border radius in the source thumbnail needs to be scaled to account
+  // for the crop frame and overall scale so it visually matches at progress=0.
+  const sourceBorderRadius = thumbBorderRadius ?? 0
+  const initialCropScaleX = croppedFinalWidth / finalWidth
+  const borderRadius = interpolate(
+    progress,
+    [0, 1],
+    [sourceBorderRadius / (initialScale * initialCropScaleX), 0],
+  )
+
   return {
     isHidden: false,
     isResting: progress === 1,
     scaleAndMoveTransform: [{translateX}, {translateY}, {scale}],
     cropFrameTransform: [{scaleX: cropScaleX}, {scaleY: cropScaleY}],
     cropContentTransform: [{scaleX: 1 / cropScaleX}, {scaleY: 1 / cropScaleY}],
+    borderRadius,
   }
 }
 


### PR DESCRIPTION
## Summary

- Adds a border radius animation to the lightbox shared element transition. The source thumbnail's border radius (e.g. `rounded_md` = 12px for post images) interpolates to 0 as the image opens to full screen, and back on close.
- The radius is compensated for the crop frame scale and overall scale so it visually matches the source thumbnail at `progress=0`.
- Only affects `type: 'image'` — avatar and banner lightboxes don't set `thumbBorderRadius` so they're unaffected.
- Extracts `LightboxTransforms` type to reduce duplication across the three ImageItem platform files.

https://github.com/user-attachments/assets/ab94ca51-da66-4c3b-b458-d9bdbe35da62

## Test plan

- [ ] Single image: border radius animates from rounded to square on open, back on close
- [ ] Multi-image grid: same behavior
- [ ] Profile avatar lightbox: no border radius animation (circle clip unchanged)
- [ ] Profile banner lightbox: no border radius animation

🤖 Generated with [Claude Code](https://claude.com/claude-code)