### PR TITLE
Fix GrowthBook cache breaking on cold start

### DIFF
--- a/src/analytics/features/index.ts
+++ b/src/analytics/features/index.ts
@@ -14,8 +14,7 @@ const CACHE = new MMKV({id: 'bsky_features_cache'})
 setPolyfills({
   localStorage: {
     getItem: key => {
-      const value = CACHE.getString(key)
-      return value != null ? JSON.parse(value) : null
+      return CACHE.getString(key) ?? null
     },
     setItem: async (key, value) => {
       CACHE.set(key, value)
@@ -29,7 +28,7 @@ setPolyfills({
  */
 export type FeatureFetchStrategy = 'prefer-low-latency' | 'prefer-fresh-gates'
 
-const TIMEOUT_INIT = 500 // TODO should base on p99 or something
+const TIMEOUT_INIT = 2000 // TODO should base on p99 or something
 const TIMEOUT_PREFER_LOW_LATENCY = 250
 const TIMEOUT_PREFER_FRESH_GATES = 1500
 


### PR DESCRIPTION
## Summary
- **Fixed double-parse bug in MMKV localStorage polyfill** — `getItem` was calling `JSON.parse()` on the cached value, but GrowthBook already stores a JSON string and parses it internally. This caused a `SyntaxError` on every cold start, silently killing the cache and forcing a ~1.4s network fetch.
- **Bumped `TIMEOUT_INIT` from 500ms to 2000ms** so genuine cold-cache starts (first install, cache cleared) have enough time to fetch fresh gates.

## Test plan
- [ ] Cold start (kill app fully): should now resolve from cache in ~10ms instead of hitting network for ~1.4s
- [ ] First install / cleared storage: should fetch from network within the 2s timeout
- [ ] Warm start (JS reload): should continue working as before (~200ms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)