### PR TITLE
Fix missing recId values for suggested user events

### DIFF
--- a/src/analytics/metrics/types.ts
+++ b/src/analytics/metrics/types.ts
@@ -501,7 +501,6 @@ export type Events = {
       | 'ProfileHeader'
       | 'Onboarding'
       | 'SeeMoreSuggestedUsers'
-    recSource?: 'Search'
     recId?: number | string
     position: number
     suggestedDid: string

--- a/src/analytics/metrics/types.ts
+++ b/src/analytics/metrics/types.ts
@@ -514,6 +514,7 @@ export type Events = {
       | 'Onboarding'
       | 'SeeMoreSuggestedUsers'
       | 'ProgressGuide'
+    recSource?: 'Search'
     recId?: number | string
     position: number
     suggestedDid: string

--- a/src/analytics/metrics/types.ts
+++ b/src/analytics/metrics/types.ts
@@ -487,6 +487,7 @@ export type Events = {
       | 'SeeMoreSuggestedUsers'
       | 'ProgressGuide'
     location: 'Card' | 'Profile' | 'FollowAll'
+    recSource?: 'Search'
     recId?: number | string
     position: number
     suggestedDid: string
@@ -500,6 +501,7 @@ export type Events = {
       | 'ProfileHeader'
       | 'Onboarding'
       | 'SeeMoreSuggestedUsers'
+    recSource?: 'Search'
     recId?: number | string
     position: number
     suggestedDid: string

--- a/src/components/FeedInterstitials.tsx
+++ b/src/components/FeedInterstitials.tsx
@@ -167,6 +167,7 @@ export function SuggestedFollowsHome() {
 
   return (
     <ProfileGrid
+      recId={data?.recId}
       isSuggestionsLoading={isLoading}
       profiles={filteredProfiles}
       totalProfileCount={allProfiles.length}

--- a/src/components/ProgressGuide/FollowDialog.tsx
+++ b/src/components/ProgressGuide/FollowDialog.tsx
@@ -249,6 +249,7 @@ function DialogInner({guide}: {guide?: Follow10ProgressGuide}) {
               moderationOpts={moderationOpts!}
               noBorder={index === 0}
               position={index}
+              recSource={hasSearchText ? 'Search' : undefined}
               recId={recIdForLogging}
               isGuide={isGuide}
             />
@@ -549,6 +550,7 @@ let FollowProfileCard = ({
   moderationOpts,
   noBorder,
   position,
+  recSource,
   recId,
   isGuide,
 }: {
@@ -556,6 +558,7 @@ let FollowProfileCard = ({
   moderationOpts: ModerationOpts
   noBorder?: boolean
   position: number
+  recSource?: 'Search'
   recId?: string
   isGuide: boolean
 }): React.ReactNode => {
@@ -565,6 +568,7 @@ let FollowProfileCard = ({
       moderationOpts={moderationOpts}
       noBorder={noBorder}
       position={position}
+      recSource={recSource}
       recId={recId}
       isGuide={isGuide}
     />
@@ -578,6 +582,7 @@ function FollowProfileCardInner({
   onFollow,
   noBorder,
   position,
+  recSource,
   recId,
   isGuide,
 }: {
@@ -586,6 +591,7 @@ function FollowProfileCardInner({
   onFollow?: () => void
   noBorder?: boolean
   position: number
+  recSource?: 'Search'
   recId?: string
   isGuide: boolean
 }) {
@@ -626,6 +632,7 @@ function FollowProfileCardInner({
                       ? 'ProgressGuide'
                       : 'SeeMoreSuggestedUsers',
                     location: 'Card',
+                    recSource,
                     recId,
                     position,
                     suggestedDid: profile.did,

--- a/src/components/ProgressGuide/FollowDialog.tsx
+++ b/src/components/ProgressGuide/FollowDialog.tsx
@@ -265,7 +265,7 @@ function DialogInner({guide}: {guide?: Follow10ProgressGuide}) {
           return null
       }
     },
-    [moderationOpts, recIdForLogging, isGuide],
+    [moderationOpts, hasSearchText, recIdForLogging, isGuide],
   )
 
   // Track seen profiles

--- a/src/components/ProgressGuide/FollowDialog.tsx
+++ b/src/components/ProgressGuide/FollowDialog.tsx
@@ -286,6 +286,7 @@ function DialogInner({guide}: {guide?: Follow10ProgressGuide}) {
             )
             ax.metric('suggestedUser:seen', {
               logContext: isGuide ? 'ProgressGuide' : 'SeeMoreSuggestedUsers',
+              recSource: hasSearchText ? 'Search' : undefined,
               recId: recIdForLogging,
               position: position !== -1 ? position : 0,
               suggestedDid: item.profile.did,

--- a/src/screens/Onboarding/StepSuggestedAccounts/index.tsx
+++ b/src/screens/Onboarding/StepSuggestedAccounts/index.tsx
@@ -155,6 +155,7 @@ export function StepSuggestedAccounts() {
         seenProfilesRef.current.add(did)
         ax.metric('suggestedUser:seen', {
           logContext: 'Onboarding',
+          recSource: !useFullExperience ? 'Search' : undefined,
           recId: suggestedUsers?.recId,
           position,
           suggestedDid: did,
@@ -162,7 +163,7 @@ export function StepSuggestedAccounts() {
         })
       }
     },
-    [ax, selectedInterest, suggestedUsers?.recId],
+    [ax, selectedInterest, suggestedUsers?.recId, useFullExperience],
   )
 
   useEffect(() => {

--- a/src/screens/Onboarding/StepSuggestedAccounts/index.tsx
+++ b/src/screens/Onboarding/StepSuggestedAccounts/index.tsx
@@ -105,6 +105,7 @@ export function StepSuggestedAccounts() {
         ax.metric('suggestedUser:follow', {
           logContext: 'Onboarding',
           location: 'FollowAll',
+          recSource: !useFullExperience ? 'Search' : undefined,
           recId: suggestedUsers?.recId,
           position: i,
           suggestedDid: did,
@@ -249,6 +250,7 @@ export function StepSuggestedAccounts() {
                 position={index}
                 category={selectedInterest}
                 onSeen={onProfileSeen}
+                recSource={!useFullExperience ? 'Search' : undefined}
                 recId={suggestedUsers.recId}
               />
             ))}
@@ -359,6 +361,7 @@ function SuggestedProfileCard({
   position,
   category,
   onSeen,
+  recSource,
   recId,
 }: {
   profile: bsky.profile.AnyProfileView
@@ -366,6 +369,7 @@ function SuggestedProfileCard({
   position: number
   category: string | null
   onSeen: (did: string, position: number) => void
+  recSource?: 'Search'
   recId?: number | string
 }) {
   const t = useTheme()
@@ -433,6 +437,7 @@ function SuggestedProfileCard({
               ax.metric('suggestedUser:follow', {
                 logContext: 'Onboarding',
                 location: 'Card',
+                recSource,
                 recId,
                 position,
                 suggestedDid: profile.did,

--- a/src/screens/Search/Explore.tsx
+++ b/src/screens/Search/Explore.tsx
@@ -162,7 +162,7 @@ type ExploreScreenItems =
       type: 'profile'
       key: string
       profile: AppBskyActorDefs.ProfileView
-      recId?: number
+      recId?: string
     }
   | {
       type: 'profileEmpty'
@@ -406,6 +406,7 @@ export function Explore({
                 type: 'profile',
                 key: actor.did,
                 profile: actor,
+                recId: suggestedUsers.recId,
               })
             }
           }

--- a/src/screens/Search/modules/ExploreSuggestedAccounts.tsx
+++ b/src/screens/Search/modules/ExploreSuggestedAccounts.tsx
@@ -105,7 +105,7 @@ let SuggestedProfileCard = ({
 }: {
   profile: bsky.profile.AnyProfileView
   moderationOpts: ModerationOpts
-  recId?: number
+  recId?: string
   position: number
 }): React.ReactNode => {
   const t = useTheme()

--- a/src/state/queries/trending/useGetSuggestedOnboardingUsersQuery.ts
+++ b/src/state/queries/trending/useGetSuggestedOnboardingUsersQuery.ts
@@ -5,6 +5,7 @@ import {
 import {type QueryClient, useQuery} from '@tanstack/react-query'
 
 import {createBskyTopicsHeader} from '#/lib/api/feed/utils'
+import {logger} from '#/logger'
 import {getContentLanguages} from '#/state/preferences/languages'
 import {STALE} from '#/state/queries'
 import {usePreferencesQuery} from '#/state/queries/preferences'
@@ -54,6 +55,9 @@ export function useGetSuggestedOnboardingUsersQuery(props: QueryProps) {
         },
       )
 
+      if (!data.recIdStr) {
+        logger.debug('getSuggestedOnboardingUsers response missing recIdStr')
+      }
       return {...data, recId: data.recIdStr}
     },
   })

--- a/src/state/queries/trending/useGetSuggestedOnboardingUsersQuery.ts
+++ b/src/state/queries/trending/useGetSuggestedOnboardingUsersQuery.ts
@@ -54,7 +54,7 @@ export function useGetSuggestedOnboardingUsersQuery(props: QueryProps) {
         },
       )
 
-      return {...data, recId: data.recIdStr ?? data.recId}
+      return {...data, recId: data.recIdStr}
     },
   })
 }

--- a/src/state/queries/trending/useGetSuggestedOnboardingUsersQuery.ts
+++ b/src/state/queries/trending/useGetSuggestedOnboardingUsersQuery.ts
@@ -54,7 +54,7 @@ export function useGetSuggestedOnboardingUsersQuery(props: QueryProps) {
         },
       )
 
-      return {...data, recId: data.recIdStr}
+      return {...data, recId: data.recIdStr ?? data.recId}
     },
   })
 }

--- a/src/state/queries/trending/useGetSuggestedUsersForDiscoverQuery.ts
+++ b/src/state/queries/trending/useGetSuggestedUsersForDiscoverQuery.ts
@@ -8,6 +8,7 @@ import {
   aggregateUserInterests,
   createBskyTopicsHeader,
 } from '#/lib/api/feed/utils'
+import {logger} from '#/logger'
 import {getContentLanguages} from '#/state/preferences/languages'
 import {STALE} from '#/state/queries'
 import {usePreferencesQuery} from '#/state/queries/preferences'
@@ -46,6 +47,9 @@ export function useGetSuggestedUsersForDiscoverQuery(props: QueryProps = {}) {
             },
           },
         )
+      if (!data.recIdStr) {
+        logger.debug('getSuggestedUsersForDiscover response missing recIdStr')
+      }
       return {...data, recId: data.recIdStr}
     },
   })

--- a/src/state/queries/trending/useGetSuggestedUsersForExploreQuery.ts
+++ b/src/state/queries/trending/useGetSuggestedUsersForExploreQuery.ts
@@ -8,6 +8,7 @@ import {
   aggregateUserInterests,
   createBskyTopicsHeader,
 } from '#/lib/api/feed/utils'
+import {logger} from '#/logger'
 import {getContentLanguages} from '#/state/preferences/languages'
 import {STALE} from '#/state/queries'
 import {usePreferencesQuery} from '#/state/queries/preferences'
@@ -48,6 +49,9 @@ export function useGetSuggestedUsersForExploreQuery(props: QueryProps = {}) {
         },
       )
 
+      if (!data.recIdStr) {
+        logger.debug('getSuggestedUsersForExplore response missing recIdStr')
+      }
       return {...data, recId: data.recIdStr}
     },
   })

--- a/src/state/queries/trending/useGetSuggestedUsersForSeeMoreQuery.ts
+++ b/src/state/queries/trending/useGetSuggestedUsersForSeeMoreQuery.ts
@@ -8,6 +8,7 @@ import {
   aggregateUserInterests,
   createBskyTopicsHeader,
 } from '#/lib/api/feed/utils'
+import {logger} from '#/logger'
 import {getContentLanguages} from '#/state/preferences/languages'
 import {STALE} from '#/state/queries'
 import {usePreferencesQuery} from '#/state/queries/preferences'
@@ -54,6 +55,9 @@ export function useGetSuggestedUsersForSeeMoreQuery(props: QueryProps = {}) {
         },
       )
 
+      if (!data.recIdStr) {
+        logger.debug('getSuggestedUsersForSeeMore response missing recIdStr')
+      }
       return {...data, recId: data.recIdStr}
     },
   })


### PR DESCRIPTION
Confirmed locally that all `suggestedUser:` events now include a `recId` value: Explore, Discover, profile header, profile interstitial, onboarding, and progress guide (“Follow 10 people to get started”).