### PR TITLE
nit: fix perf regression in hotkeys

### DIFF
--- a/src/lib/hotkeys/index.native.tsx
+++ b/src/lib/hotkeys/index.native.tsx
@@ -9,8 +9,8 @@ const noop = () => {}
 export function useHotkeysContext() {
   return useMemo(
     () => ({
-      registerHotkey: noop,
-      unregisterHotkey: noop,
+      enableScope: noop,
+      disableScope: noop,
     }),
     [],
   )

--- a/src/lib/hotkeys/index.native.tsx
+++ b/src/lib/hotkeys/index.native.tsx
@@ -1,10 +1,17 @@
+import {useMemo} from 'react'
+
 export function Provider({children}: {children: React.ReactNode}) {
   return children
 }
 
+const noop = () => {}
+
 export function useHotkeysContext() {
-  return {
-    enableScope: () => {},
-    disableScope: () => {},
-  }
+  return useMemo(
+    () => ({
+      registerHotkey: noop,
+      unregisterHotkey: noop,
+    }),
+    [],
+  )
 }

--- a/src/state/shell/drawer-open.tsx
+++ b/src/state/shell/drawer-open.tsx
@@ -1,4 +1,4 @@
-import {createContext, useContext, useState} from 'react'
+import {createContext, useCallback, useContext, useState} from 'react'
 
 import {useHotkeysContext} from '#/lib/hotkeys'
 
@@ -14,14 +14,17 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
   const [state, setState] = useState(false)
   const {disableScope, enableScope} = useHotkeysContext()
 
-  const setDrawerOpen = (open: boolean) => {
-    if (open) {
-      disableScope('global')
-    } else {
-      enableScope('global')
-    }
-    setState(open)
-  }
+  const setDrawerOpen = useCallback(
+    (open: boolean) => {
+      if (open) {
+        disableScope('global')
+      } else {
+        enableScope('global')
+      }
+      setState(open)
+    },
+    [disableScope, enableScope],
+  )
 
   return (
     <stateContext.Provider value={state}>


### PR DESCRIPTION
Fixes a pretty gnarly performance regression causing a fat re-render whenever you open the drawer or lightbox on Android/iOS.

Backported from https://tangled.org/jollywhoppers.com/witchsky.app/pulls/106/round/0