### PR TITLE
Fix crash when resolving bsky.app URLs with query parameters (#10310)

### DIFF
--- a/src/features/liveEvents/context.tsx
+++ b/src/features/liveEvents/context.tsx
@@ -127,7 +127,7 @@ export function useActiveLiveEventFeedUris() {
       // insurance
       .filter(f => isBskyCustomFeedUrl(f.url))
       .map(f => {
-        const uri = convertBskyAppUrlIfNeeded(f.url)
+        const uri = convertBskyAppUrlIfNeeded(f.url, {stripSearch: true})
         const [_0, did, _1, rkey] = uri.split('/').filter(Boolean)
         const urip = makeRecordUri(did, 'app.bsky.feed.generator', rkey)
         return urip.toString()

--- a/src/lib/api/resolve.ts
+++ b/src/lib/api/resolve.ts
@@ -85,7 +85,7 @@ export async function resolveLink(
     uri = await resolveShortLink(uri)
   }
   if (isBskyPostUrl(uri)) {
-    uri = convertBskyAppUrlIfNeeded(uri)
+    uri = convertBskyAppUrlIfNeeded(uri, {stripSearch: true})
     const [_0, user, _1, rkey] = uri.split('/').filter(Boolean)
     const recordUri = makeRecordUri(user, 'app.bsky.feed.post', rkey)
     const post = await getPost({uri: recordUri})
@@ -103,7 +103,7 @@ export async function resolveLink(
     }
   }
   if (isBskyCustomFeedUrl(uri)) {
-    uri = convertBskyAppUrlIfNeeded(uri)
+    uri = convertBskyAppUrlIfNeeded(uri, {stripSearch: true})
     const [_0, handleOrDid, _1, rkey] = uri.split('/').filter(Boolean)
     const did = await fetchDid(handleOrDid)
     const feed = makeRecordUri(did, 'app.bsky.feed.generator', rkey)
@@ -119,7 +119,7 @@ export async function resolveLink(
     }
   }
   if (isBskyListUrl(uri)) {
-    uri = convertBskyAppUrlIfNeeded(uri)
+    uri = convertBskyAppUrlIfNeeded(uri, {stripSearch: true})
     const [_0, handleOrDid, _1, rkey] = uri.split('/').filter(Boolean)
     const did = await fetchDid(handleOrDid)
     const list = makeRecordUri(did, 'app.bsky.graph.list', rkey)

--- a/src/lib/strings/url-helpers.ts
+++ b/src/lib/strings/url-helpers.ts
@@ -185,7 +185,10 @@ export function isBskyDownloadUrl(url: string): boolean {
   return url === '/download' || url.startsWith('/download?')
 }
 
-export function convertBskyAppUrlIfNeeded(url: string): string {
+export function convertBskyAppUrlIfNeeded(
+  url: string,
+  {stripSearch}: {stripSearch?: boolean} = {},
+): string {
   if (isBskyAppUrl(url)) {
     try {
       const urlp = new URL(url)
@@ -194,7 +197,7 @@ export function convertBskyAppUrlIfNeeded(url: string): string {
         return startUriToStarterPackUri(urlp.pathname)
       }
 
-      return urlp.pathname + urlp.search
+      return urlp.pathname + (stripSearch ? '' : urlp.search)
     } catch (e) {
       console.error('Unexpected error in convertBskyAppUrlIfNeeded()', e)
     }

--- a/src/screens/Messages/components/MessageInputEmbed.tsx
+++ b/src/screens/Messages/components/MessageInputEmbed.tsx
@@ -59,7 +59,7 @@ export function useMessageEmbed() {
 
         if (embedFromParams) return
 
-        const url = convertBskyAppUrlIfNeeded(embedUrl)
+        const url = convertBskyAppUrlIfNeeded(embedUrl, {stripSearch: true})
         const [_0, user, _1, rkey] = url.split('/').filter(Boolean)
         const uri = makeRecordUri(user, 'app.bsky.feed.post', rkey)
 

--- a/src/screens/Messages/components/MessagesList.tsx
+++ b/src/screens/Messages/components/MessagesList.tsx
@@ -312,7 +312,9 @@ export function MessagesList({
               return facet.features.find(feature => {
                 if (AppBskyRichtextFacet.isLink(feature)) {
                   if (isBskyPostUrl(feature.uri)) {
-                    const url = convertBskyAppUrlIfNeeded(feature.uri)
+                    const url = convertBskyAppUrlIfNeeded(feature.uri, {
+                      stripSearch: true,
+                    })
                     const [_0, _1, _2, rkey] = url.split('/').filter(Boolean)
 
                     // this might have a handle instead of a DID


### PR DESCRIPTION
Fixes #10310

URLs like `.../post/rkey?profile=ave.zone` caused an "invalid record key" error because query params were included in the rkey when splitting the converted path. While the default copy feature does not include any query params, avoiding crashes of the client is still beneficial.

The path we chose to take is to add a `stripSearch` option to `convertBskyAppUrlIfNeeded` and use it when resolving post, feed, and list embeds. This felt cleaner than doing a split downstream in each call site on `/src/lib/api/resolve.ts`, or doing a sanitization within makeRecordUri.

The query params are still genuinely used for various links, so dropping it entirely from `convertBskyAppUrlIfNeeded` didn't make sense.