### PR TITLE
Refactor minimal shell mode to refcounting

### DIFF
--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -1,6 +1,11 @@
 import {forwardRef, memo, useContext, useMemo} from 'react'
-import {StyleSheet, View, type ViewProps, type ViewStyle} from 'react-native'
-import {type StyleProp} from 'react-native'
+import {
+  type StyleProp,
+  StyleSheet,
+  View,
+  type ViewProps,
+  type ViewStyle,
+} from 'react-native'
 import {
   KeyboardAwareScrollView,
   type KeyboardAwareScrollViewProps,
@@ -11,6 +16,7 @@ import Animated, {
 } from 'react-native-reanimated'
 import {useSafeAreaInsets} from 'react-native-safe-area-context'
 
+import {useEnableMinimalShellModeForScreen} from '#/state/shell'
 import {useShellLayout} from '#/state/shell/shell-layout'
 import {
   atoms as a,
@@ -30,6 +36,7 @@ export * as Header from '#/components/Layout/Header'
 export type ScreenProps = React.ComponentProps<typeof View> & {
   style?: StyleProp<ViewStyle>
   noInsetTop?: boolean
+  minimalShell?: boolean
 }
 
 /**
@@ -38,9 +45,13 @@ export type ScreenProps = React.ComponentProps<typeof View> & {
 export const Screen = memo(function Screen({
   style,
   noInsetTop,
+  minimalShell = false,
   ...props
 }: ScreenProps) {
   const {top} = useSafeAreaInsets()
+
+  useEnableMinimalShellModeForScreen({enabled: minimalShell})
+
   return (
     <>
       {IS_WEB && <WebCenterBorders />}

--- a/src/screens/Bookmarks/index.tsx
+++ b/src/screens/Bookmarks/index.tsx
@@ -23,7 +23,6 @@ import {
 } from '#/lib/routes/types'
 import {useBookmarkMutation} from '#/state/queries/bookmarks/useBookmarkMutation'
 import {useBookmarksQuery} from '#/state/queries/bookmarks/useBookmarksQuery'
-import {useSetMinimalShellMode} from '#/state/shell'
 import {Post} from '#/view/com/post/Post'
 import {EmptyState} from '#/view/com/util/EmptyState'
 import {List} from '#/view/com/util/List'
@@ -43,14 +42,12 @@ import {IS_IOS} from '#/env'
 type Props = NativeStackScreenProps<CommonNavigatorParams, 'Bookmarks'>
 
 export function BookmarksScreen({}: Props) {
-  const setMinimalShellMode = useSetMinimalShellMode()
   const ax = useAnalytics()
 
   useFocusEffect(
     useCallback(() => {
-      setMinimalShellMode(false)
       ax.metric('bookmarks:view', {})
-    }, [setMinimalShellMode, ax]),
+    }, [ax]),
   )
 
   return (

--- a/src/screens/FindContactsFlowScreen.tsx
+++ b/src/screens/FindContactsFlowScreen.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useLayoutEffect, useState} from 'react'
+import {useState} from 'react'
 import {LayoutAnimationConfig} from 'react-native-reanimated'
 import {msg} from '@lingui/core/macro'
 import {useLingui} from '@lingui/react'
@@ -8,7 +8,7 @@ import {
   type AllNavigatorParams,
   type NativeStackScreenProps,
 } from '#/lib/routes/types'
-import {useSetMinimalShellMode} from '#/state/shell'
+import {useEnableMinimalShellMode} from '#/state/shell'
 import {ErrorScreen} from '#/view/com/util/error/ErrorScreen'
 import {FindContactsFlow} from '#/components/contacts/FindContactsFlow'
 import {useFindContactsFlowState} from '#/components/contacts/state'
@@ -36,12 +36,7 @@ export function FindContactsFlowScreen({navigation}: Props) {
     })
   })
 
-  const setMinimalShellMode = useSetMinimalShellMode()
-  const effect = useCallback(() => {
-    setMinimalShellMode(true)
-    return () => setMinimalShellMode(false)
-  }, [setMinimalShellMode])
-  useLayoutEffect(effect)
+  useEnableMinimalShellMode()
 
   return (
     <Layout.Screen>

--- a/src/screens/Hashtag.tsx
+++ b/src/screens/Hashtag.tsx
@@ -4,7 +4,6 @@ import {type AppBskyFeedDefs} from '@atproto/api'
 import {msg} from '@lingui/core/macro'
 import {useLingui} from '@lingui/react'
 import {Trans} from '@lingui/react/macro'
-import {useFocusEffect} from '@react-navigation/native'
 import {type NativeStackScreenProps} from '@react-navigation/native-stack'
 
 import {HITSLOP_10} from '#/lib/constants'
@@ -17,7 +16,6 @@ import {sanitizeHandle} from '#/lib/strings/handles'
 import {enforceLen} from '#/lib/strings/helpers'
 import {useSearchPostsQuery} from '#/state/queries/search-posts'
 import {useSession} from '#/state/session'
-import {useSetMinimalShellMode} from '#/state/shell'
 import {useLoggedOutViewControls} from '#/state/shell/logged-out'
 import {useCloseAllActiveElements} from '#/state/util'
 import {Pager} from '#/view/com/pager/Pager'
@@ -79,21 +77,10 @@ export default function HashtagScreen({
   }, [tag, author])
 
   const [activeTab, setActiveTab] = useState(0)
-  const setMinimalShellMode = useSetMinimalShellMode()
 
-  useFocusEffect(
-    useCallback(() => {
-      setMinimalShellMode(false)
-    }, [setMinimalShellMode]),
-  )
-
-  const onPageSelected = useCallback(
-    (index: number) => {
-      setMinimalShellMode(false)
-      setActiveTab(index)
-    },
-    [setMinimalShellMode],
-  )
+  const onPageSelected = (index: number) => {
+    setActiveTab(index)
+  }
 
   const sections = useMemo(() => {
     return [

--- a/src/screens/Log.tsx
+++ b/src/screens/Log.tsx
@@ -1,9 +1,8 @@
-import {useCallback, useState} from 'react'
+import {useState} from 'react'
 import {LayoutAnimation, Pressable, View} from 'react-native'
 import {msg} from '@lingui/core/macro'
 import {useLingui} from '@lingui/react'
 import {Trans} from '@lingui/react/macro'
-import {useFocusEffect} from '@react-navigation/native'
 
 import {useGetTimeAgo} from '#/lib/hooks/useTimeAgo'
 import {
@@ -11,7 +10,7 @@ import {
   type NativeStackScreenProps,
 } from '#/lib/routes/types'
 import {getEntries} from '#/logger/logDump'
-import {useSetMinimalShellMode, useTickEveryMinute} from '#/state/shell'
+import {useTickEveryMinute} from '#/state/shell'
 import {atoms as a, useTheme} from '#/alf'
 import {
   ChevronBottom_Stroke2_Corner0_Rounded as ChevronBottomIcon,
@@ -28,16 +27,9 @@ export function LogScreen({}: NativeStackScreenProps<
 >) {
   const t = useTheme()
   const {_} = useLingui()
-  const setMinimalShellMode = useSetMinimalShellMode()
   const [expanded, setExpanded] = useState<string[]>([])
   const timeAgo = useGetTimeAgo()
   const tick = useTickEveryMinute()
-
-  useFocusEffect(
-    useCallback(() => {
-      setMinimalShellMode(false)
-    }, [setMinimalShellMode]),
-  )
 
   const toggler = (id: string) => () => {
     LayoutAnimation.configureNext(LayoutAnimation.Presets.easeInEaseOut)

--- a/src/screens/Messages/Conversation.tsx
+++ b/src/screens/Messages/Conversation.tsx
@@ -32,7 +32,6 @@ import {useCurrentConvoId} from '#/state/messages/current-convo-id'
 import {useModerationOpts} from '#/state/preferences/moderation-opts'
 import {useConvoQuery} from '#/state/queries/messages/conversation'
 import {useSession} from '#/state/session'
-import {useSetMinimalShellMode} from '#/state/shell'
 import {MessagesList} from '#/screens/Messages/components/MessagesList'
 import {atoms as a, useTheme, web} from '#/alf'
 import {AgeRestrictedScreen} from '#/components/ageAssurance/AgeRestrictedScreen'
@@ -68,25 +67,22 @@ export function MessagesConversationScreen(props: Props) {
 }
 
 export function MessagesConversationScreenInner({route}: Props) {
-  const setMinimalShellMode = useSetMinimalShellMode()
-
   const convoId = route.params.conversation
   const {setCurrentConvoId} = useCurrentConvoId()
 
   useFocusEffect(
     useCallback(() => {
       setCurrentConvoId(convoId)
-      setMinimalShellMode(true)
 
       return () => {
         setCurrentConvoId(undefined)
-        setMinimalShellMode(false)
       }
-    }, [convoId, setCurrentConvoId, setMinimalShellMode]),
+    }, [convoId, setCurrentConvoId]),
   )
 
   return (
     <Layout.Screen
+      minimalShell
       testID="convoScreen"
       noInsetTop={IS_LIQUID_GLASS}
       style={web([{minHeight: 0}, a.flex_1])}>

--- a/src/screens/Moderation/index.tsx
+++ b/src/screens/Moderation/index.tsx
@@ -4,7 +4,6 @@ import {LABELS} from '@atproto/api'
 import {msg} from '@lingui/core/macro'
 import {useLingui} from '@lingui/react'
 import {Trans} from '@lingui/react/macro'
-import {useFocusEffect} from '@react-navigation/native'
 
 import {getLabelingServiceTitle, isAppLabeler} from '#/lib/moderation'
 import {
@@ -21,7 +20,6 @@ import {
   usePreferencesSetAdultContentMutation,
 } from '#/state/queries/preferences'
 import {isNonConfigurableModerationAuthority} from '#/state/session/additional-moderation-authorities'
-import {useSetMinimalShellMode} from '#/state/shell'
 import {atoms as a, useBreakpoints, useTheme, type ViewStyleProp} from '#/alf'
 import * as Admonition from '#/components/Admonition'
 import {AgeAssuranceAdmonition} from '#/components/ageAssurance/AgeAssuranceAdmonition'
@@ -161,7 +159,6 @@ export function ModerationScreenInner({
 }) {
   const {_} = useLingui()
   const t = useTheme()
-  const setMinimalShellMode = useSetMinimalShellMode()
   const {gtMobile} = useBreakpoints()
   const {mutedWordsDialogControl} = useGlobalDialogsControlContext()
   const {
@@ -196,12 +193,6 @@ export function ModerationScreenInner({
       })
     }
   }
-
-  useFocusEffect(
-    useCallback(() => {
-      setMinimalShellMode(false)
-    }, [setMinimalShellMode]),
-  )
 
   const {mutateAsync: setAdultContentPref, variables: optimisticAdultContent} =
     usePreferencesSetAdultContentMutation()

--- a/src/screens/Post/PostLikedBy.tsx
+++ b/src/screens/Post/PostLikedBy.tsx
@@ -1,6 +1,4 @@
-import {useCallback} from 'react'
 import {Plural, Trans} from '@lingui/react/macro'
-import {useFocusEffect} from '@react-navigation/native'
 
 import {
   type CommonNavigatorParams,
@@ -8,13 +6,11 @@ import {
 } from '#/lib/routes/types'
 import {makeRecordUri} from '#/lib/strings/url-helpers'
 import {usePostQuery} from '#/state/queries/post'
-import {useSetMinimalShellMode} from '#/state/shell'
 import {PostLikedBy as PostLikedByComponent} from '#/view/com/post-thread/PostLikedBy'
 import * as Layout from '#/components/Layout'
 
 type Props = NativeStackScreenProps<CommonNavigatorParams, 'PostLikedBy'>
 export const PostLikedByScreen = ({route}: Props) => {
-  const setMinimalShellMode = useSetMinimalShellMode()
   const {name, rkey} = route.params
   const uri = makeRecordUri(name, 'app.bsky.feed.post', rkey)
   const {data: post} = usePostQuery(uri)
@@ -23,12 +19,6 @@ export const PostLikedByScreen = ({route}: Props) => {
   if (post) {
     likeCount = post.likeCount
   }
-
-  useFocusEffect(
-    useCallback(() => {
-      setMinimalShellMode(false)
-    }, [setMinimalShellMode]),
-  )
 
   return (
     <Layout.Screen>

--- a/src/screens/Post/PostQuotes.tsx
+++ b/src/screens/Post/PostQuotes.tsx
@@ -1,6 +1,4 @@
-import {useCallback} from 'react'
 import {Plural, Trans} from '@lingui/react/macro'
-import {useFocusEffect} from '@react-navigation/native'
 
 import {
   type CommonNavigatorParams,
@@ -8,13 +6,11 @@ import {
 } from '#/lib/routes/types'
 import {makeRecordUri} from '#/lib/strings/url-helpers'
 import {usePostQuery} from '#/state/queries/post'
-import {useSetMinimalShellMode} from '#/state/shell'
 import {PostQuotes as PostQuotesComponent} from '#/view/com/post-thread/PostQuotes'
 import * as Layout from '#/components/Layout'
 
 type Props = NativeStackScreenProps<CommonNavigatorParams, 'PostQuotes'>
 export const PostQuotesScreen = ({route}: Props) => {
-  const setMinimalShellMode = useSetMinimalShellMode()
   const {name, rkey} = route.params
   const uri = makeRecordUri(name, 'app.bsky.feed.post', rkey)
   const {data: post} = usePostQuery(uri)
@@ -23,12 +19,6 @@ export const PostQuotesScreen = ({route}: Props) => {
   if (post) {
     quoteCount = post.quoteCount
   }
-
-  useFocusEffect(
-    useCallback(() => {
-      setMinimalShellMode(false)
-    }, [setMinimalShellMode]),
-  )
 
   return (
     <Layout.Screen>

--- a/src/screens/Post/PostRepostedBy.tsx
+++ b/src/screens/Post/PostRepostedBy.tsx
@@ -1,6 +1,4 @@
-import {useCallback} from 'react'
 import {Plural, Trans} from '@lingui/react/macro'
-import {useFocusEffect} from '@react-navigation/native'
 
 import {
   type CommonNavigatorParams,
@@ -8,7 +6,6 @@ import {
 } from '#/lib/routes/types'
 import {makeRecordUri} from '#/lib/strings/url-helpers'
 import {usePostQuery} from '#/state/queries/post'
-import {useSetMinimalShellMode} from '#/state/shell'
 import {PostRepostedBy as PostRepostedByComponent} from '#/view/com/post-thread/PostRepostedBy'
 import * as Layout from '#/components/Layout'
 
@@ -16,19 +13,12 @@ type Props = NativeStackScreenProps<CommonNavigatorParams, 'PostRepostedBy'>
 export const PostRepostedByScreen = ({route}: Props) => {
   const {name, rkey} = route.params
   const uri = makeRecordUri(name, 'app.bsky.feed.post', rkey)
-  const setMinimalShellMode = useSetMinimalShellMode()
   const {data: post} = usePostQuery(uri)
 
   let quoteCount
   if (post) {
     quoteCount = post.repostCount
   }
-
-  useFocusEffect(
-    useCallback(() => {
-      setMinimalShellMode(false)
-    }, [setMinimalShellMode]),
-  )
 
   return (
     <Layout.Screen>

--- a/src/screens/Profile/KnownFollowers.tsx
+++ b/src/screens/Profile/KnownFollowers.tsx
@@ -1,8 +1,7 @@
-import {useCallback, useMemo, useState} from 'react'
+import {useMemo, useState} from 'react'
 import {type AppBskyActorDefs} from '@atproto/api'
 import {msg} from '@lingui/core/macro'
 import {useLingui} from '@lingui/react'
-import {useFocusEffect} from '@react-navigation/native'
 
 import {useInitialNumToRender} from '#/lib/hooks/useInitialNumToRender'
 import {
@@ -13,7 +12,6 @@ import {cleanError} from '#/lib/strings/errors'
 import {logger} from '#/logger'
 import {useProfileKnownFollowersQuery} from '#/state/queries/known-followers'
 import {useResolveDidQuery} from '#/state/queries/resolve-uri'
-import {useSetMinimalShellMode} from '#/state/shell'
 import {ProfileCardWithFollowBtn} from '#/view/com/profile/ProfileCard'
 import {List} from '#/view/com/util/List'
 import {ViewHeader} from '#/view/com/util/ViewHeader'
@@ -46,7 +44,6 @@ type Props = NativeStackScreenProps<
 >
 export const ProfileKnownFollowersScreen = ({route}: Props) => {
   const {_} = useLingui()
-  const setMinimalShellMode = useSetMinimalShellMode()
   const initialNumToRender = useInitialNumToRender()
 
   const {name} = route.params
@@ -67,7 +64,7 @@ export const ProfileKnownFollowersScreen = ({route}: Props) => {
     refetch,
   } = useProfileKnownFollowersQuery(resolvedDid)
 
-  const onRefresh = useCallback(async () => {
+  const onRefresh = async () => {
     setIsPTRing(true)
     try {
       await refetch()
@@ -75,16 +72,16 @@ export const ProfileKnownFollowersScreen = ({route}: Props) => {
       logger.error('Failed to refresh followers', {message: err})
     }
     setIsPTRing(false)
-  }, [refetch, setIsPTRing])
+  }
 
-  const onEndReached = useCallback(async () => {
+  const onEndReached = async () => {
     if (isFetchingNextPage || !hasNextPage || !!error) return
     try {
       await fetchNextPage()
     } catch (err) {
       logger.error('Failed to load more followers', {message: err})
     }
-  }, [isFetchingNextPage, hasNextPage, error, fetchNextPage])
+  }
 
   const followers = useMemo(() => {
     if (data?.pages) {
@@ -94,12 +91,6 @@ export const ProfileKnownFollowersScreen = ({route}: Props) => {
   }, [data])
 
   const isError = Boolean(resolveError || error)
-
-  useFocusEffect(
-    useCallback(() => {
-      setMinimalShellMode(false)
-    }, [setMinimalShellMode]),
-  )
 
   if (followers.length < 1) {
     return (

--- a/src/screens/Profile/ProfileFollowers.tsx
+++ b/src/screens/Profile/ProfileFollowers.tsx
@@ -1,6 +1,4 @@
-import {useCallback} from 'react'
 import {Plural} from '@lingui/react/macro'
-import {useFocusEffect} from '@react-navigation/native'
 
 import {
   type CommonNavigatorParams,
@@ -9,25 +7,17 @@ import {
 import {sanitizeDisplayName} from '#/lib/strings/display-names'
 import {useProfileQuery} from '#/state/queries/profile'
 import {useResolveDidQuery} from '#/state/queries/resolve-uri'
-import {useSetMinimalShellMode} from '#/state/shell'
 import {ProfileFollowers as ProfileFollowersComponent} from '#/view/com/profile/ProfileFollowers'
 import * as Layout from '#/components/Layout'
 
 type Props = NativeStackScreenProps<CommonNavigatorParams, 'ProfileFollowers'>
 export const ProfileFollowersScreen = ({route}: Props) => {
   const {name} = route.params
-  const setMinimalShellMode = useSetMinimalShellMode()
 
   const {data: resolvedDid} = useResolveDidQuery(name)
   const {data: profile} = useProfileQuery({
     did: resolvedDid,
   })
-
-  useFocusEffect(
-    useCallback(() => {
-      setMinimalShellMode(false)
-    }, [setMinimalShellMode]),
-  )
 
   return (
     <Layout.Screen testID="profileFollowersScreen">

--- a/src/screens/Profile/ProfileFollows.tsx
+++ b/src/screens/Profile/ProfileFollows.tsx
@@ -1,6 +1,4 @@
-import {useCallback} from 'react'
 import {Plural} from '@lingui/react/macro'
-import {useFocusEffect} from '@react-navigation/native'
 
 import {
   type CommonNavigatorParams,
@@ -9,25 +7,17 @@ import {
 import {sanitizeDisplayName} from '#/lib/strings/display-names'
 import {useProfileQuery} from '#/state/queries/profile'
 import {useResolveDidQuery} from '#/state/queries/resolve-uri'
-import {useSetMinimalShellMode} from '#/state/shell'
 import {ProfileFollows as ProfileFollowsComponent} from '#/view/com/profile/ProfileFollows'
 import * as Layout from '#/components/Layout'
 
 type Props = NativeStackScreenProps<CommonNavigatorParams, 'ProfileFollows'>
 export const ProfileFollowsScreen = ({route}: Props) => {
   const {name} = route.params
-  const setMinimalShellMode = useSetMinimalShellMode()
 
   const {data: resolvedDid} = useResolveDidQuery(name)
   const {data: profile} = useProfileQuery({
     did: resolvedDid,
   })
-
-  useFocusEffect(
-    useCallback(() => {
-      setMinimalShellMode(false)
-    }, [setMinimalShellMode]),
-  )
 
   return (
     <Layout.Screen testID="profileFollowsScreen">

--- a/src/screens/Profile/ProfileLabelerLikedBy.tsx
+++ b/src/screens/Profile/ProfileLabelerLikedBy.tsx
@@ -1,14 +1,11 @@
-import {useCallback} from 'react'
 import {msg} from '@lingui/core/macro'
 import {useLingui} from '@lingui/react'
-import {useFocusEffect} from '@react-navigation/native'
 
 import {
   type CommonNavigatorParams,
   type NativeStackScreenProps,
 } from '#/lib/routes/types'
 import {makeRecordUri} from '#/lib/strings/url-helpers'
-import {useSetMinimalShellMode} from '#/state/shell'
 import {ViewHeader} from '#/view/com/util/ViewHeader'
 import * as Layout from '#/components/Layout'
 import {LikedByList} from '#/components/LikedByList'
@@ -16,16 +13,9 @@ import {LikedByList} from '#/components/LikedByList'
 export function ProfileLabelerLikedByScreen({
   route,
 }: NativeStackScreenProps<CommonNavigatorParams, 'ProfileLabelerLikedBy'>) {
-  const setMinimalShellMode = useSetMinimalShellMode()
   const {name: handleOrDid} = route.params
   const uri = makeRecordUri(handleOrDid, 'app.bsky.labeler.service', 'self')
   const {_} = useLingui()
-
-  useFocusEffect(
-    useCallback(() => {
-      setMinimalShellMode(false)
-    }, [setMinimalShellMode]),
-  )
 
   return (
     <Layout.Screen>

--- a/src/screens/ProfileList/index.tsx
+++ b/src/screens/ProfileList/index.tsx
@@ -10,7 +10,7 @@ import {
 import {msg} from '@lingui/core/macro'
 import {useLingui} from '@lingui/react'
 import {Trans} from '@lingui/react/macro'
-import {useFocusEffect, useIsFocused} from '@react-navigation/native'
+import {useIsFocused} from '@react-navigation/native'
 import {useQueryClient} from '@tanstack/react-query'
 
 import {useOpenComposer} from '#/lib/hooks/useOpenComposer'
@@ -31,7 +31,6 @@ import {
 import {useResolveUriQuery} from '#/state/queries/resolve-uri'
 import {truncateAndInvalidate} from '#/state/queries/util'
 import {useSession} from '#/state/session'
-import {useSetMinimalShellMode} from '#/state/shell'
 import {PagerWithHeader} from '#/view/com/pager/PagerWithHeader'
 import {FAB} from '#/view/com/util/fab/FAB'
 import {type ListRef} from '#/view/com/util/List'
@@ -155,7 +154,6 @@ function ProfileListScreenLoaded({
   const {_} = useLingui()
   const queryClient = useQueryClient()
   const {openComposer} = useOpenComposer()
-  const setMinimalShellMode = useSetMinimalShellMode()
   const {currentAccount} = useSession()
   const {rkey} = route.params
   const feedSectionRef = useRef<SectionRef>(null)
@@ -175,12 +173,6 @@ function ProfileListScreenLoaded({
   }, [list, moderationOpts])
 
   useSetTitle(isHidden ? _(msg`List Hidden`) : list.name)
-
-  useFocusEffect(
-    useCallback(() => {
-      setMinimalShellMode(false)
-    }, [setMinimalShellMode]),
-  )
 
   const onChangeMembers = () => {
     if (isCurateList) {

--- a/src/screens/SavedFeeds.tsx
+++ b/src/screens/SavedFeeds.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useState} from 'react'
+import {useState} from 'react'
 import {View} from 'react-native'
 import type Animated from 'react-native-reanimated'
 import {useAnimatedRef, useScrollViewOffset} from 'react-native-reanimated'
@@ -7,7 +7,7 @@ import {TID} from '@atproto/common-web'
 import {msg} from '@lingui/core/macro'
 import {useLingui} from '@lingui/react'
 import {Trans} from '@lingui/react/macro'
-import {useFocusEffect, useNavigation} from '@react-navigation/native'
+import {useNavigation} from '@react-navigation/native'
 import {type NativeStackScreenProps} from '@react-navigation/native-stack'
 
 import {RECOMMENDED_SAVED_FEEDS, TIMELINE_SAVED_FEED} from '#/lib/constants'
@@ -23,7 +23,6 @@ import {
   usePreferencesQuery,
 } from '#/state/queries/preferences'
 import {type UsePreferencesQueryResponse} from '#/state/queries/preferences/types'
-import {useSetMinimalShellMode} from '#/state/shell'
 import {FeedSourceCard} from '#/view/com/feeds/FeedSourceCard'
 import {NoFollowingFeed} from '#/screens/Feeds/NoFollowingFeed'
 import {NoSavedFeedsOfAnyType} from '#/screens/Feeds/NoSavedFeedsOfAnyType'
@@ -66,7 +65,6 @@ function SavedFeedsInner({
   const t = useTheme()
   const {_} = useLingui()
   const {gtMobile} = useBreakpoints()
-  const setMinimalShellMode = useSetMinimalShellMode()
   const {mutateAsync: overwriteSavedFeeds, isPending: isOverwritePending} =
     useOverwriteSavedFeedsMutation()
   const navigation = useNavigation<NavigationProp>()
@@ -87,12 +85,6 @@ function SavedFeedsInner({
   const noFollowingFeed =
     currentFeeds.every(f => f.type !== 'timeline') && !noSavedFeedsOfAnyType
   const [isDragging, setIsDragging] = useState(false)
-
-  useFocusEffect(
-    useCallback(() => {
-      setMinimalShellMode(false)
-    }, [setMinimalShellMode]),
-  )
 
   const onSaveChanges = async () => {
     try {
@@ -259,7 +251,6 @@ function SavedFeedsA11y({
   const t = useTheme()
   const {_} = useLingui()
   const {gtMobile} = useBreakpoints()
-  const setMinimalShellMode = useSetMinimalShellMode()
   const {mutateAsync: overwriteSavedFeeds, isPending: isOverwritePending} =
     useOverwriteSavedFeedsMutation()
   const navigation = useNavigation<NavigationProp>()
@@ -273,12 +264,6 @@ function SavedFeedsA11y({
   const noSavedFeedsOfAnyType = pinnedFeeds.length + unpinnedFeeds.length === 0
   const noFollowingFeed =
     currentFeeds.every(f => f.type !== 'timeline') && !noSavedFeedsOfAnyType
-
-  useFocusEffect(
-    useCallback(() => {
-      setMinimalShellMode(false)
-    }, [setMinimalShellMode]),
-  )
 
   const onSaveChanges = async () => {
     try {

--- a/src/screens/Search/Shell.tsx
+++ b/src/screens/Search/Shell.tsx
@@ -27,7 +27,6 @@ import {
   useProfilesQuery,
 } from '#/state/queries/profile'
 import {useSession} from '#/state/session'
-import {useSetMinimalShellMode} from '#/state/shell'
 import {
   makeSearchQuery,
   type Params,
@@ -87,7 +86,6 @@ export function SearchScreenShell({
   const route = useRoute()
   const textInput = useRef<TextInput>(null)
   const {t: l} = useLingui()
-  const setMinimalShellMode = useSetMinimalShellMode()
   const {currentAccount} = useSession()
   const queryClient = useQueryClient()
 
@@ -288,9 +286,8 @@ export function SearchScreenShell({
 
   useFocusEffect(
     useCallback(() => {
-      setMinimalShellMode(false)
       return listenSoftReset(onSoftReset)
-    }, [onSoftReset, setMinimalShellMode]),
+    }, [onSoftReset]),
   )
 
   const onSearchInputFocus = useCallback(() => {
@@ -481,17 +478,12 @@ let SearchScreenInner = ({
   focusSearchInput: (tab?: TabParam) => void
 }): React.ReactNode => {
   const t = useTheme()
-  const setMinimalShellMode = useSetMinimalShellMode()
   const {hasSession} = useSession()
   const {gtTablet} = useBreakpoints()
 
-  const onPageSelected = useCallback(
-    (index: number) => {
-      setMinimalShellMode(false)
-      setActiveTab(index)
-    },
-    [setActiveTab, setMinimalShellMode],
-  )
+  const onPageSelected = (index: number) => {
+    setActiveTab(index)
+  }
 
   return queryWithParams ? (
     <SearchResults

--- a/src/screens/StarterPack/Wizard/index.tsx
+++ b/src/screens/StarterPack/Wizard/index.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useEffect} from 'react'
+import {useEffect} from 'react'
 import {Keyboard, View} from 'react-native'
 import {KeyboardAwareScrollView} from 'react-native-keyboard-controller'
 import {useSafeAreaInsets} from 'react-native-safe-area-context'
@@ -13,7 +13,7 @@ import {
 import {msg} from '@lingui/core/macro'
 import {useLingui} from '@lingui/react'
 import {Plural, Trans} from '@lingui/react/macro'
-import {useFocusEffect, useNavigation} from '@react-navigation/native'
+import {useNavigation} from '@react-navigation/native'
 import {type NativeStackScreenProps} from '@react-navigation/native-stack'
 
 import {STARTER_PACK_MAX_SIZE} from '#/lib/constants'
@@ -39,7 +39,6 @@ import {
   useStarterPackQuery,
 } from '#/state/queries/starter-packs'
 import {useSession} from '#/state/session'
-import {useSetMinimalShellMode} from '#/state/shell'
 import {UserAvatar} from '#/view/com/util/UserAvatar'
 import {
   useWizardState,
@@ -132,6 +131,7 @@ export function Wizard({
 
   return (
     <Layout.Screen
+      minimalShell
       testID="starterPackWizardScreen"
       style={web([{minHeight: 0}, a.flex_1])}>
       <Provider
@@ -169,7 +169,6 @@ function WizardInner({
   const navigation = useNavigation<NavigationProp>()
   const ax = useAnalytics()
   const {_} = useLingui()
-  const setMinimalShellMode = useSetMinimalShellMode()
   const [state, dispatch] = useWizardState()
   const {currentAccount} = useSession()
 
@@ -184,16 +183,6 @@ function WizardInner({
       gestureEnabled: false,
     })
   }, [navigation])
-
-  useFocusEffect(
-    useCallback(() => {
-      setMinimalShellMode(true)
-
-      return () => {
-        setMinimalShellMode(false)
-      }
-    }, [setMinimalShellMode]),
-  )
 
   const getDefaultName = () => {
     const displayName = createSanitizedDisplayName(currentProfile!, true)

--- a/src/screens/Topic.tsx
+++ b/src/screens/Topic.tsx
@@ -3,7 +3,6 @@ import {type ListRenderItemInfo, View} from 'react-native'
 import {type AppBskyFeedDefs} from '@atproto/api'
 import {msg} from '@lingui/core/macro'
 import {useLingui} from '@lingui/react'
-import {useFocusEffect} from '@react-navigation/native'
 import {type NativeStackScreenProps} from '@react-navigation/native-stack'
 
 import {HITSLOP_10} from '#/lib/constants'
@@ -14,7 +13,6 @@ import {shareUrl} from '#/lib/sharing'
 import {cleanError} from '#/lib/strings/errors'
 import {enforceLen} from '#/lib/strings/helpers'
 import {useSearchPostsQuery} from '#/state/queries/search-posts'
-import {useSetMinimalShellMode} from '#/state/shell'
 import {Pager} from '#/view/com/pager/Pager'
 import {TabBar} from '#/view/com/pager/TabBar'
 import {Post} from '#/view/com/post/Post'
@@ -50,21 +48,10 @@ export default function TopicScreen({
   }, [topic])
 
   const [activeTab, setActiveTab] = useState(0)
-  const setMinimalShellMode = useSetMinimalShellMode()
 
-  useFocusEffect(
-    useCallback(() => {
-      setMinimalShellMode(false)
-    }, [setMinimalShellMode]),
-  )
-
-  const onPageSelected = useCallback(
-    (index: number) => {
-      setMinimalShellMode(false)
-      setActiveTab(index)
-    },
-    [setMinimalShellMode],
-  )
+  const onPageSelected = (index: number) => {
+    setActiveTab(index)
+  }
 
   const sections = useMemo(() => {
     return [

--- a/src/screens/VideoFeed/index.tsx
+++ b/src/screens/VideoFeed/index.tsx
@@ -75,7 +75,6 @@ import {
 } from '#/state/queries/post-feed'
 import {useProfileFollowMutationQueue} from '#/state/queries/profile'
 import {useSession} from '#/state/session'
-import {useSetMinimalShellMode} from '#/state/shell'
 import {useSetLightStatusBar} from '#/state/shell/light-status-bar'
 import {List} from '#/view/com/util/List'
 import {UserAvatar} from '#/view/com/util/UserAvatar'
@@ -131,16 +130,13 @@ export function VideoFeed({}: NativeStackScreenProps<
   const {params} = useRoute<RouteProp<CommonNavigatorParams, 'VideoFeed'>>()
 
   const t = useTheme()
-  const setMinShellMode = useSetMinimalShellMode()
   useFocusEffect(
     useCallback(() => {
-      setMinShellMode(true)
       setSystemUITheme('lightbox', t)
       return () => {
-        setMinShellMode(false)
         setSystemUITheme('theme', t)
       }
-    }, [setMinShellMode, t]),
+    }, [t]),
   )
 
   const isFocused = useIsFocused()
@@ -148,7 +144,7 @@ export function VideoFeed({}: NativeStackScreenProps<
 
   return (
     <ThemeProvider theme="dark">
-      <Layout.Screen noInsetTop style={{backgroundColor: 'black'}}>
+      <Layout.Screen minimalShell noInsetTop style={{backgroundColor: 'black'}}>
         <KeepAwake />
         <View
           style={[

--- a/src/state/shell/index.tsx
+++ b/src/state/shell/index.tsx
@@ -12,7 +12,6 @@ export {
   useSetDrawerSwipeDisabled,
 } from './drawer-swipe-disabled'
 export {
-  useDangerouslyImperativelySetMinimalShellMode,
   useEnableMinimalShellMode,
   useEnableMinimalShellModeForScreen,
   useMinimalShellMode,

--- a/src/state/shell/index.tsx
+++ b/src/state/shell/index.tsx
@@ -11,7 +11,12 @@ export {
   useIsDrawerSwipeDisabled,
   useSetDrawerSwipeDisabled,
 } from './drawer-swipe-disabled'
-export {useMinimalShellMode, useSetMinimalShellMode} from './minimal-mode'
+export {
+  useDangerouslyImperativelySetMinimalShellMode,
+  useEnableMinimalShellMode,
+  useEnableMinimalShellModeForScreen,
+  useMinimalShellMode,
+} from './minimal-mode'
 export {useOnboardingDispatch, useOnboardingState} from './onboarding'
 export {useTickEveryMinute} from './tick-every-minute'
 

--- a/src/state/shell/minimal-mode.tsx
+++ b/src/state/shell/minimal-mode.tsx
@@ -104,41 +104,6 @@ export function useMinimalShellModeSetters() {
   return context
 }
 
-/**
- * Bypasses the refcount and directly animates the shell. Only for use in
- * scroll/pager callbacks where the refcount is 0 but MainScrollProvider has
- * hidden the header via direct shared-value manipulation.
- * @deprecated Prefer `useEnableMinimalShellMode` or the `minimalShell` prop.
- */
-export function useDangerouslyImperativelySetMinimalShellMode() {
-  const {headerMode, footerMode} = useMinimalShellMode()
-
-  const setMode = useCallback(
-    (v: boolean) => {
-      'worklet'
-      headerMode.set(() =>
-        withSpring(v ? 1 : 0, {
-          overshootClamping: true,
-        }),
-      )
-      footerMode.set(() =>
-        withSpring(v ? 1 : 0, {
-          overshootClamping: true,
-        }),
-      )
-    },
-    [headerMode, footerMode],
-  )
-
-  useFocusEffect(
-    useCallback(() => {
-      return () => setMode(false)
-    }, [setMode]),
-  )
-
-  return setMode
-}
-
 export function useEnableMinimalShellMode({enabled} = {enabled: true}) {
   const setters = useMinimalShellModeSetters()
   useEffect(() => {

--- a/src/state/shell/minimal-mode.tsx
+++ b/src/state/shell/minimal-mode.tsx
@@ -1,45 +1,118 @@
-import {createContext, useCallback, useContext, useMemo} from 'react'
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+} from 'react'
 import {
   type SharedValue,
   useSharedValue,
   withSpring,
 } from 'react-native-reanimated'
+import {useFocusEffect} from '@react-navigation/native'
 
 type StateContext = {
   headerMode: SharedValue<number>
   footerMode: SharedValue<number>
 }
-type SetContext = (v: boolean) => void
+type SetContext = {
+  add: () => void
+  subtract: () => void
+}
 
-const stateContext = createContext<StateContext>({
-  headerMode: {
-    value: 0,
-    addListener() {},
-    removeListener() {},
-    modify() {},
-    get() {
-      return 0
-    },
-    set() {},
-  },
-  footerMode: {
-    value: 0,
-    addListener() {},
-    removeListener() {},
-    modify() {},
-    get() {
-      return 0
-    },
-    set() {},
-  },
-})
+const stateContext = createContext<StateContext | null>(null)
 stateContext.displayName = 'MinimalModeStateContext'
-const setContext = createContext<SetContext>((_: boolean) => {})
+const setContext = createContext<SetContext | null>(null)
 setContext.displayName = 'MinimalModeSetContext'
 
 export function Provider({children}: React.PropsWithChildren<{}>) {
   const headerMode = useSharedValue(0)
   const footerMode = useSharedValue(0)
+
+  const setModeWorklet = useCallback(
+    (v: boolean) => {
+      'worklet'
+      headerMode.set(() =>
+        withSpring(v ? 1 : 0, {
+          overshootClamping: true,
+        }),
+      )
+      footerMode.set(() =>
+        withSpring(v ? 1 : 0, {
+          overshootClamping: true,
+        }),
+      )
+    },
+    [headerMode, footerMode],
+  )
+
+  // defaults to "visible", if the count is >0 it gets hidden
+  const countRef = useRef(0)
+  const add = useCallback(() => {
+    // 0 -> 1 = hide
+    if (countRef.current === 0) setModeWorklet(true)
+
+    countRef.current += 1
+  }, [setModeWorklet])
+  const subtract = useCallback(() => {
+    // 1 -> 0 = show
+    if (countRef.current === 1) setModeWorklet(false)
+
+    // count must never go below 0
+    if (countRef.current > 0) countRef.current -= 1
+  }, [setModeWorklet])
+
+  const setters = useMemo(
+    () => ({
+      add,
+      subtract,
+    }),
+    [add, subtract],
+  )
+
+  const value = useMemo(
+    () => ({
+      headerMode,
+      footerMode,
+    }),
+    [headerMode, footerMode],
+  )
+  return (
+    <stateContext.Provider value={value}>
+      <setContext.Provider value={setters}>{children}</setContext.Provider>
+    </stateContext.Provider>
+  )
+}
+
+export function useMinimalShellMode() {
+  const context = useContext(stateContext)
+  if (!context)
+    throw new Error(
+      'useMinimalShellMode must be used within a MinimalModeProvider',
+    )
+  return context
+}
+
+export function useMinimalShellModeSetters() {
+  const context = useContext(setContext)
+  if (!context)
+    throw new Error(
+      'useMinimalShellModeSetters must be used within a MinimalModeProvider',
+    )
+  return context
+}
+
+/**
+ * Bypasses the refcount and directly animates the shell. Only for use in
+ * scroll/pager callbacks where the refcount is 0 but MainScrollProvider has
+ * hidden the header via direct shared-value manipulation.
+ * @deprecated Prefer `useEnableMinimalShellMode` or the `minimalShell` prop.
+ */
+export function useDangerouslyImperativelySetMinimalShellMode() {
+  const {headerMode, footerMode} = useMinimalShellMode()
+
   const setMode = useCallback(
     (v: boolean) => {
       'worklet'
@@ -56,24 +129,36 @@ export function Provider({children}: React.PropsWithChildren<{}>) {
     },
     [headerMode, footerMode],
   )
-  const value = useMemo(
-    () => ({
-      headerMode,
-      footerMode,
-    }),
-    [headerMode, footerMode],
+
+  useFocusEffect(
+    useCallback(() => {
+      return () => setMode(false)
+    }, [setMode]),
   )
-  return (
-    <stateContext.Provider value={value}>
-      <setContext.Provider value={setMode}>{children}</setContext.Provider>
-    </stateContext.Provider>
-  )
+
+  return setMode
 }
 
-export function useMinimalShellMode() {
-  return useContext(stateContext)
+export function useEnableMinimalShellMode({enabled} = {enabled: true}) {
+  const setters = useMinimalShellModeSetters()
+  useEffect(() => {
+    if (enabled) {
+      setters.add()
+      return () => setters.subtract()
+    }
+  }, [enabled, setters])
 }
 
-export function useSetMinimalShellMode() {
-  return useContext(setContext)
+export function useEnableMinimalShellModeForScreen(
+  {enabled} = {enabled: true},
+) {
+  const setters = useMinimalShellModeSetters()
+  useFocusEffect(
+    useCallback(() => {
+      if (enabled) {
+        setters.add()
+        return () => setters.subtract()
+      }
+    }, [enabled, setters]),
+  )
 }

--- a/src/view/com/auth/LoggedOut.tsx
+++ b/src/view/com/auth/LoggedOut.tsx
@@ -13,7 +13,7 @@ import {
   useLoggedOutView,
   useLoggedOutViewControls,
 } from '#/state/shell/logged-out'
-import {useSetMinimalShellMode} from '#/state/shell/minimal-mode'
+import {useEnableMinimalShellMode} from '#/state/shell/minimal-mode'
 import {ErrorBoundary} from '#/view/com/util/ErrorBoundary'
 import {Login} from '#/screens/Login'
 import {Signup} from '#/screens/Signup'
@@ -37,7 +37,7 @@ export function LoggedOut({onDismiss}: {onDismiss?: () => void}) {
   const ax = useAnalytics()
   const t = useTheme()
   const insets = useSafeAreaInsets()
-  const setMinimalShellMode = useSetMinimalShellMode()
+  useEnableMinimalShellMode()
   const {requestedAccountSwitchTo} = useLoggedOutView()
   const [screenState, setScreenState] = useState<ScreenState>(() => {
     if (requestedAccountSwitchTo === 'new') {
@@ -67,10 +67,6 @@ export function LoggedOut({onDismiss}: {onDismiss?: () => void}) {
       },
     })
   }, [accounts, agent, queryClient])
-
-  useEffect(() => {
-    setMinimalShellMode(true)
-  }, [setMinimalShellMode])
 
   const onPressDismiss = useCallback(() => {
     if (onDismiss) {

--- a/src/view/com/feeds/FeedPage.tsx
+++ b/src/view/com/feeds/FeedPage.tsx
@@ -30,7 +30,6 @@ import {
 } from '#/state/queries/post-feed'
 import {truncateAndInvalidate} from '#/state/queries/util'
 import {useSession} from '#/state/session'
-import {useSetMinimalShellMode} from '#/state/shell'
 import {useHeaderOffset} from '#/components/hooks/useHeaderOffset'
 import {useAnalytics} from '#/analytics'
 import {IS_NATIVE} from '#/env'
@@ -70,7 +69,6 @@ export function FeedPage({
   const queryClient = useQueryClient()
   const {openComposer} = useOpenComposer()
   const [isScrolledDown, setIsScrolledDown] = useState(false)
-  const setMinimalShellMode = useSetMinimalShellMode()
   const headerOffset = useHeaderOffset()
   const feedFeedback = useFeedFeedback(feedInfo, hasSession)
   const scrollElRef = useRef<ListMethods>(null)
@@ -95,8 +93,7 @@ export function FeedPage({
       animated: IS_NATIVE,
       offset: -headerOffset,
     })
-    setMinimalShellMode(false)
-  }, [headerOffset, setMinimalShellMode])
+  }, [headerOffset])
 
   const onSoftReset = useCallback(() => {
     const isScreenFocused =

--- a/src/view/screens/CommunityGuidelines.tsx
+++ b/src/view/screens/CommunityGuidelines.tsx
@@ -1,9 +1,7 @@
-import {useCallback} from 'react'
 import {View} from 'react-native'
 import {msg} from '@lingui/core/macro'
 import {useLingui} from '@lingui/react'
 import {Trans} from '@lingui/react/macro'
-import {useFocusEffect} from '@react-navigation/native'
 
 import {usePalette} from '#/lib/hooks/usePalette'
 import {
@@ -11,7 +9,6 @@ import {
   type NativeStackScreenProps,
 } from '#/lib/routes/types'
 import {s} from '#/lib/styles'
-import {useSetMinimalShellMode} from '#/state/shell'
 import {TextLink} from '#/view/com/util/Link'
 import {Text} from '#/view/com/util/text/Text'
 import {ScrollView} from '#/view/com/util/Views'
@@ -25,13 +22,6 @@ type Props = NativeStackScreenProps<
 export const CommunityGuidelinesScreen = (_props: Props) => {
   const pal = usePalette('default')
   const {_} = useLingui()
-  const setMinimalShellMode = useSetMinimalShellMode()
-
-  useFocusEffect(
-    useCallback(() => {
-      setMinimalShellMode(false)
-    }, [setMinimalShellMode]),
-  )
 
   return (
     <Layout.Screen>

--- a/src/view/screens/CopyrightPolicy.tsx
+++ b/src/view/screens/CopyrightPolicy.tsx
@@ -1,9 +1,7 @@
-import {useCallback} from 'react'
 import {View} from 'react-native'
 import {msg} from '@lingui/core/macro'
 import {useLingui} from '@lingui/react'
 import {Trans} from '@lingui/react/macro'
-import {useFocusEffect} from '@react-navigation/native'
 
 import {usePalette} from '#/lib/hooks/usePalette'
 import {
@@ -11,7 +9,6 @@ import {
   type NativeStackScreenProps,
 } from '#/lib/routes/types'
 import {s} from '#/lib/styles'
-import {useSetMinimalShellMode} from '#/state/shell'
 import {TextLink} from '#/view/com/util/Link'
 import {Text} from '#/view/com/util/text/Text'
 import {ScrollView} from '#/view/com/util/Views'
@@ -22,13 +19,6 @@ type Props = NativeStackScreenProps<CommonNavigatorParams, 'CopyrightPolicy'>
 export const CopyrightPolicyScreen = (_props: Props) => {
   const pal = usePalette('default')
   const {_} = useLingui()
-  const setMinimalShellMode = useSetMinimalShellMode()
-
-  useFocusEffect(
-    useCallback(() => {
-      setMinimalShellMode(false)
-    }, [setMinimalShellMode]),
-  )
 
   return (
     <Layout.Screen>

--- a/src/view/screens/Feeds.tsx
+++ b/src/view/screens/Feeds.tsx
@@ -4,7 +4,6 @@ import {type AppBskyFeedDefs} from '@atproto/api'
 import {msg} from '@lingui/core/macro'
 import {useLingui} from '@lingui/react'
 import {Trans} from '@lingui/react/macro'
-import {useFocusEffect} from '@react-navigation/native'
 import debounce from 'lodash.debounce'
 
 import {useOpenComposer} from '#/lib/hooks/useOpenComposer'
@@ -24,7 +23,6 @@ import {
   useSearchPopularFeedsMutation,
 } from '#/state/queries/feed'
 import {useSession} from '#/state/session'
-import {useSetMinimalShellMode} from '#/state/shell'
 import {ErrorMessage} from '#/view/com/util/error/ErrorMessage'
 import {FAB} from '#/view/com/util/fab/FAB'
 import {List, type ListMethods} from '#/view/com/util/List'
@@ -126,7 +124,6 @@ export function FeedsScreen(_props: Props) {
     hasNextPage: hasNextPopularFeedsPage,
   } = useGetPopularFeedsQuery()
   const {_} = useLingui()
-  const setMinimalShellMode = useSetMinimalShellMode()
   const {
     data: searchResults,
     mutate: search,
@@ -192,12 +189,6 @@ export function FeedsScreen(_props: Props) {
     hasNextPopularFeedsPage,
     fetchNextPopularFeedsPage,
   ])
-
-  useFocusEffect(
-    useCallback(() => {
-      setMinimalShellMode(false)
-    }, [setMinimalShellMode]),
-  )
 
   const items = useMemo(() => {
     let slices: FlatlistSlice[] = []

--- a/src/view/screens/Home.tsx
+++ b/src/view/screens/Home.tsx
@@ -1,5 +1,6 @@
 import {useCallback, useEffect, useLayoutEffect, useMemo, useRef} from 'react'
 import {ActivityIndicator, StyleSheet} from 'react-native'
+import {withSpring} from 'react-native-reanimated'
 import {useFocusEffect} from '@react-navigation/native'
 
 import {PROD_DEFAULT_FEED} from '#/lib/constants'
@@ -20,7 +21,7 @@ import {type FeedDescriptor, type FeedParams} from '#/state/queries/post-feed'
 import {usePreferencesQuery} from '#/state/queries/preferences'
 import {type UsePreferencesQueryResponse} from '#/state/queries/preferences/types'
 import {useSession} from '#/state/session'
-import {useDangerouslyImperativelySetMinimalShellMode} from '#/state/shell'
+import {useMinimalShellMode} from '#/state/shell'
 import {useLoggedOutViewControls} from '#/state/shell/logged-out'
 import {useSelectedFeed, useSetSelectedFeed} from '#/state/shell/selected-feed'
 import {FeedPage} from '#/view/com/feeds/FeedPage'
@@ -138,7 +139,17 @@ function HomeScreenReady({
   }, [selectedIndex])
 
   const {hasSession} = useSession()
-  const setMinimalShellMode = useDangerouslyImperativelySetMinimalShellMode()
+  const {headerMode} = useMinimalShellMode()
+  const showHeader = useCallback(() => {
+    'worklet'
+    headerMode.set(() => withSpring(0, {overshootClamping: true}))
+  }, [headerMode])
+
+  useFocusEffect(
+    useCallback(() => {
+      return () => showHeader()
+    }, [showHeader]),
+  )
 
   useFocusEffect(
     useNonReactiveCallback(() => {
@@ -155,7 +166,7 @@ function HomeScreenReady({
 
   const onPageSelected = useCallback(
     (index: number) => {
-      setMinimalShellMode(false)
+      showHeader()
       const maybeFeed = allFeeds[index]
 
       // Mutate the ref before setting state to avoid the imperative syncing effect
@@ -171,7 +182,7 @@ function HomeScreenReady({
         })
       }
     },
-    [ax, setSelectedFeed, setMinimalShellMode, allFeeds],
+    [ax, setSelectedFeed, showHeader, allFeeds],
   )
 
   const onPressSelected = useCallback(() => {
@@ -182,10 +193,10 @@ function HomeScreenReady({
     (state: 'idle' | 'dragging' | 'settling') => {
       'worklet'
       if (state === 'dragging') {
-        setMinimalShellMode(false)
+        showHeader()
       }
     },
-    [setMinimalShellMode],
+    [showHeader],
   )
 
   const [demoMode] = useDemoMode()

--- a/src/view/screens/Home.tsx
+++ b/src/view/screens/Home.tsx
@@ -20,7 +20,7 @@ import {type FeedDescriptor, type FeedParams} from '#/state/queries/post-feed'
 import {usePreferencesQuery} from '#/state/queries/preferences'
 import {type UsePreferencesQueryResponse} from '#/state/queries/preferences/types'
 import {useSession} from '#/state/session'
-import {useSetMinimalShellMode} from '#/state/shell'
+import {useDangerouslyImperativelySetMinimalShellMode} from '#/state/shell'
 import {useLoggedOutViewControls} from '#/state/shell/logged-out'
 import {useSelectedFeed, useSetSelectedFeed} from '#/state/shell/selected-feed'
 import {FeedPage} from '#/view/com/feeds/FeedPage'
@@ -138,12 +138,7 @@ function HomeScreenReady({
   }, [selectedIndex])
 
   const {hasSession} = useSession()
-  const setMinimalShellMode = useSetMinimalShellMode()
-  useFocusEffect(
-    useCallback(() => {
-      setMinimalShellMode(false)
-    }, [setMinimalShellMode]),
-  )
+  const setMinimalShellMode = useDangerouslyImperativelySetMinimalShellMode()
 
   useFocusEffect(
     useNonReactiveCallback(() => {
@@ -247,7 +242,6 @@ function HomeScreenReady({
         ref={pagerRef}
         testID="homeScreen"
         onPageSelected={onPageSelected}
-        onPageScrollStateChanged={onPageScrollStateChanged}
         renderTabBar={renderTabBar}
         initialPage={selectedIndex}>
         <FeedPage

--- a/src/view/screens/Lists.tsx
+++ b/src/view/screens/Lists.tsx
@@ -3,7 +3,7 @@ import {AtUri} from '@atproto/api'
 import {msg} from '@lingui/core/macro'
 import {useLingui} from '@lingui/react'
 import {Trans} from '@lingui/react/macro'
-import {useFocusEffect, useNavigation} from '@react-navigation/native'
+import {useNavigation} from '@react-navigation/native'
 
 import {useRequireEmailVerification} from '#/lib/hooks/useRequireEmailVerification'
 import {
@@ -11,7 +11,6 @@ import {
   type NativeStackScreenProps,
   type NavigationProp,
 } from '#/lib/routes/types'
-import {useSetMinimalShellMode} from '#/state/shell'
 import {MyLists} from '#/view/com/lists/MyLists'
 import {atoms as a} from '#/alf'
 import {Button, ButtonIcon, ButtonText} from '#/components/Button'
@@ -23,16 +22,9 @@ import * as Layout from '#/components/Layout'
 type Props = NativeStackScreenProps<CommonNavigatorParams, 'Lists'>
 export function ListsScreen({}: Props) {
   const {_} = useLingui()
-  const setMinimalShellMode = useSetMinimalShellMode()
   const navigation = useNavigation<NavigationProp>()
   const requireEmailVerification = useRequireEmailVerification()
   const createListDialogControl = useDialogControl()
-
-  useFocusEffect(
-    useCallback(() => {
-      setMinimalShellMode(false)
-    }, [setMinimalShellMode]),
-  )
 
   const onPressNewList = useCallback(() => {
     createListDialogControl.open()

--- a/src/view/screens/ModerationBlockedAccounts.tsx
+++ b/src/view/screens/ModerationBlockedAccounts.tsx
@@ -2,7 +2,6 @@ import {useCallback, useMemo, useState} from 'react'
 import {type StyleProp, View, type ViewStyle} from 'react-native'
 import {type AppBskyActorDefs as ActorDefs} from '@atproto/api'
 import {Trans} from '@lingui/react/macro'
-import {useFocusEffect} from '@react-navigation/native'
 import {type NativeStackScreenProps} from '@react-navigation/native-stack'
 
 import {type CommonNavigatorParams} from '#/lib/routes/types'
@@ -10,7 +9,6 @@ import {cleanError} from '#/lib/strings/errors'
 import {logger} from '#/logger'
 import {useModerationOpts} from '#/state/preferences/moderation-opts'
 import {useMyBlockedAccountsQuery} from '#/state/queries/my-blocked-accounts'
-import {useSetMinimalShellMode} from '#/state/shell'
 import {ErrorScreen} from '#/view/com/util/error/ErrorScreen'
 import {List} from '#/view/com/util/List'
 import {atoms as a, useTheme} from '#/alf'
@@ -25,7 +23,6 @@ type Props = NativeStackScreenProps<
 >
 export function ModerationBlockedAccounts({}: Props) {
   const t = useTheme()
-  const setMinimalShellMode = useSetMinimalShellMode()
   const moderationOpts = useModerationOpts()
 
   const [isPTRing, setIsPTRing] = useState(false)
@@ -46,12 +43,6 @@ export function ModerationBlockedAccounts({}: Props) {
     }
     return []
   }, [data])
-
-  useFocusEffect(
-    useCallback(() => {
-      setMinimalShellMode(false)
-    }, [setMinimalShellMode]),
-  )
 
   const onRefresh = useCallback(async () => {
     setIsPTRing(true)

--- a/src/view/screens/ModerationModlists.tsx
+++ b/src/view/screens/ModerationModlists.tsx
@@ -3,7 +3,7 @@ import {AtUri} from '@atproto/api'
 import {msg} from '@lingui/core/macro'
 import {useLingui} from '@lingui/react'
 import {Trans} from '@lingui/react/macro'
-import {useFocusEffect, useNavigation} from '@react-navigation/native'
+import {useNavigation} from '@react-navigation/native'
 
 import {useRequireEmailVerification} from '#/lib/hooks/useRequireEmailVerification'
 import {
@@ -11,7 +11,6 @@ import {
   type NativeStackScreenProps,
   type NavigationProp,
 } from '#/lib/routes/types'
-import {useSetMinimalShellMode} from '#/state/shell'
 import {MyLists} from '#/view/com/lists/MyLists'
 import {atoms as a} from '#/alf'
 import {Button, ButtonIcon, ButtonText} from '#/components/Button'
@@ -23,16 +22,9 @@ import * as Layout from '#/components/Layout'
 type Props = NativeStackScreenProps<CommonNavigatorParams, 'ModerationModlists'>
 export function ModerationModlistsScreen({}: Props) {
   const {_} = useLingui()
-  const setMinimalShellMode = useSetMinimalShellMode()
   const navigation = useNavigation<NavigationProp>()
   const requireEmailVerification = useRequireEmailVerification()
   const createListDialogControl = useDialogControl()
-
-  useFocusEffect(
-    useCallback(() => {
-      setMinimalShellMode(false)
-    }, [setMinimalShellMode]),
-  )
 
   const onPressNewList = useCallback(() => {
     createListDialogControl.open()

--- a/src/view/screens/ModerationMutedAccounts.tsx
+++ b/src/view/screens/ModerationMutedAccounts.tsx
@@ -2,7 +2,6 @@ import {useCallback, useMemo, useState} from 'react'
 import {type StyleProp, View, type ViewStyle} from 'react-native'
 import {type AppBskyActorDefs as ActorDefs} from '@atproto/api'
 import {Trans} from '@lingui/react/macro'
-import {useFocusEffect} from '@react-navigation/native'
 import {type NativeStackScreenProps} from '@react-navigation/native-stack'
 
 import {type CommonNavigatorParams} from '#/lib/routes/types'
@@ -10,7 +9,6 @@ import {cleanError} from '#/lib/strings/errors'
 import {logger} from '#/logger'
 import {useModerationOpts} from '#/state/preferences/moderation-opts'
 import {useMyMutedAccountsQuery} from '#/state/queries/my-muted-accounts'
-import {useSetMinimalShellMode} from '#/state/shell'
 import {ErrorScreen} from '#/view/com/util/error/ErrorScreen'
 import {List} from '#/view/com/util/List'
 import {atoms as a, useTheme} from '#/alf'
@@ -26,7 +24,6 @@ type Props = NativeStackScreenProps<
 export function ModerationMutedAccounts({}: Props) {
   const t = useTheme()
   const moderationOpts = useModerationOpts()
-  const setMinimalShellMode = useSetMinimalShellMode()
 
   const [isPTRing, setIsPTRing] = useState(false)
   const {
@@ -46,12 +43,6 @@ export function ModerationMutedAccounts({}: Props) {
     }
     return []
   }, [data])
-
-  useFocusEffect(
-    useCallback(() => {
-      setMinimalShellMode(false)
-    }, [setMinimalShellMode]),
-  )
 
   const onRefresh = useCallback(async () => {
     setIsPTRing(true)

--- a/src/view/screens/NotFound.tsx
+++ b/src/view/screens/NotFound.tsx
@@ -3,16 +3,11 @@ import {StyleSheet, View} from 'react-native'
 import {msg} from '@lingui/core/macro'
 import {useLingui} from '@lingui/react'
 import {Trans} from '@lingui/react/macro'
-import {
-  StackActions,
-  useFocusEffect,
-  useNavigation,
-} from '@react-navigation/native'
+import {StackActions, useNavigation} from '@react-navigation/native'
 
 import {usePalette} from '#/lib/hooks/usePalette'
 import {type NavigationProp} from '#/lib/routes/types'
 import {s} from '#/lib/styles'
-import {useSetMinimalShellMode} from '#/state/shell'
 import {Button} from '#/view/com/util/forms/Button'
 import {Text} from '#/view/com/util/text/Text'
 import {ViewHeader} from '#/view/com/util/ViewHeader'
@@ -22,13 +17,6 @@ export const NotFoundScreen = () => {
   const pal = usePalette('default')
   const {_} = useLingui()
   const navigation = useNavigation<NavigationProp>()
-  const setMinimalShellMode = useSetMinimalShellMode()
-
-  useFocusEffect(
-    useCallback(() => {
-      setMinimalShellMode(false)
-    }, [setMinimalShellMode]),
-  )
 
   const canGoBack = navigation.canGoBack()
   const onPressHome = useCallback(() => {

--- a/src/view/screens/Notifications.tsx
+++ b/src/view/screens/Notifications.tsx
@@ -23,7 +23,6 @@ import {
   useUnreadNotificationsApi,
 } from '#/state/queries/notifications/unread'
 import {truncateAndInvalidate} from '#/state/queries/util'
-import {useSetMinimalShellMode} from '#/state/shell'
 import {NotificationFeed} from '#/view/com/notifications/NotificationFeed'
 import {Pager} from '#/view/com/pager/Pager'
 import {TabBar} from '#/view/com/pager/TabBar'
@@ -187,7 +186,6 @@ function NotificationsTab({
   setIsLoadingLatest: (v: boolean) => void
 }) {
   const {_} = useLingui()
-  const setMinimalShellMode = useSetMinimalShellMode()
   const [isScrolledDown, setIsScrolledDown] = useState(false)
   const scrollElRef = useRef<ListMethods>(null)
   const queryClient = useQueryClient()
@@ -198,8 +196,7 @@ function NotificationsTab({
   // =
   const scrollToTop = useCallback(() => {
     scrollElRef.current?.scrollToOffset({animated: IS_NATIVE, offset: 0})
-    setMinimalShellMode(false)
-  }, [scrollElRef, setMinimalShellMode])
+  }, [scrollElRef])
 
   const onPressLoadLatest = useCallback(() => {
     scrollToTop()
@@ -242,11 +239,10 @@ function NotificationsTab({
   useFocusEffect(
     useCallback(() => {
       if (isFocusedAndActive) {
-        setMinimalShellMode(false)
         logger.debug('NotificationsScreen: Focus')
         onFocusCheckLatest()
       }
-    }, [setMinimalShellMode, onFocusCheckLatest, isFocusedAndActive]),
+    }, [onFocusCheckLatest, isFocusedAndActive]),
   )
 
   useEffect(() => {

--- a/src/view/screens/PostThread.tsx
+++ b/src/view/screens/PostThread.tsx
@@ -1,27 +1,15 @@
-import {useCallback} from 'react'
-import {useFocusEffect} from '@react-navigation/native'
-
 import {
   type CommonNavigatorParams,
   type NativeStackScreenProps,
 } from '#/lib/routes/types'
 import {makeRecordUri} from '#/lib/strings/url-helpers'
-import {useSetMinimalShellMode} from '#/state/shell'
 import {PostThread} from '#/screens/PostThread'
 import * as Layout from '#/components/Layout'
 
 type Props = NativeStackScreenProps<CommonNavigatorParams, 'PostThread'>
 export function PostThreadScreen({route}: Props) {
-  const setMinimalShellMode = useSetMinimalShellMode()
-
   const {name, rkey} = route.params
   const uri = makeRecordUri(name, 'app.bsky.feed.post', rkey)
-
-  useFocusEffect(
-    useCallback(() => {
-      setMinimalShellMode(false)
-    }, [setMinimalShellMode]),
-  )
 
   return (
     <Layout.Screen testID="postThreadScreen">

--- a/src/view/screens/PrivacyPolicy.tsx
+++ b/src/view/screens/PrivacyPolicy.tsx
@@ -1,9 +1,7 @@
-import {useCallback} from 'react'
 import {View} from 'react-native'
 import {msg} from '@lingui/core/macro'
 import {useLingui} from '@lingui/react'
 import {Trans} from '@lingui/react/macro'
-import {useFocusEffect} from '@react-navigation/native'
 
 import {usePalette} from '#/lib/hooks/usePalette'
 import {
@@ -11,7 +9,6 @@ import {
   type NativeStackScreenProps,
 } from '#/lib/routes/types'
 import {s} from '#/lib/styles'
-import {useSetMinimalShellMode} from '#/state/shell'
 import {TextLink} from '#/view/com/util/Link'
 import {Text} from '#/view/com/util/text/Text'
 import {ScrollView} from '#/view/com/util/Views'
@@ -22,13 +19,6 @@ type Props = NativeStackScreenProps<CommonNavigatorParams, 'PrivacyPolicy'>
 export const PrivacyPolicyScreen = (_props: Props) => {
   const pal = usePalette('default')
   const {_} = useLingui()
-  const setMinimalShellMode = useSetMinimalShellMode()
-
-  useFocusEffect(
-    useCallback(() => {
-      setMinimalShellMode(false)
-    }, [setMinimalShellMode]),
-  )
 
   return (
     <Layout.Screen>

--- a/src/view/screens/Profile.tsx
+++ b/src/view/screens/Profile.tsx
@@ -34,7 +34,6 @@ import {resetProfilePostsQueries} from '#/state/queries/post-feed'
 import {useProfileQuery} from '#/state/queries/profile'
 import {useResolveDidQuery} from '#/state/queries/resolve-uri'
 import {useAgent, useSession} from '#/state/session'
-import {useSetMinimalShellMode} from '#/state/shell'
 import {ProfileFeedgens} from '#/view/com/feeds/ProfileFeedgens'
 import {ProfileLists} from '#/view/com/lists/ProfileLists'
 import {PagerWithHeader} from '#/view/com/pager/PagerWithHeader'
@@ -175,7 +174,6 @@ function ProfileScreenLoaded({
 }) {
   const profile = useProfileShadow(profileUnshadowed)
   const {hasSession, currentAccount} = useSession()
-  const setMinimalShellMode = useSetMinimalShellMode()
   const {openComposer} = useOpenComposer()
   const navigation = useNavigation<NavigationProp>()
   const requireEmailVerification = useRequireEmailVerification()
@@ -317,11 +315,10 @@ function ProfileScreenLoaded({
 
   useFocusEffect(
     useCallback(() => {
-      setMinimalShellMode(false)
       return listenSoftReset(() => {
         scrollSectionToTop(currentPage)
       })
-    }, [setMinimalShellMode, currentPage, scrollSectionToTop]),
+    }, [currentPage, scrollSectionToTop]),
   )
 
   // events

--- a/src/view/screens/ProfileFeedLikedBy.tsx
+++ b/src/view/screens/ProfileFeedLikedBy.tsx
@@ -1,27 +1,17 @@
-import {useCallback} from 'react'
 import {Trans} from '@lingui/react/macro'
-import {useFocusEffect} from '@react-navigation/native'
 
 import {
   type CommonNavigatorParams,
   type NativeStackScreenProps,
 } from '#/lib/routes/types'
 import {makeRecordUri} from '#/lib/strings/url-helpers'
-import {useSetMinimalShellMode} from '#/state/shell'
 import {PostLikedBy as PostLikedByComponent} from '#/view/com/post-thread/PostLikedBy'
 import * as Layout from '#/components/Layout'
 
 type Props = NativeStackScreenProps<CommonNavigatorParams, 'ProfileFeedLikedBy'>
 export const ProfileFeedLikedByScreen = ({route}: Props) => {
-  const setMinimalShellMode = useSetMinimalShellMode()
   const {name, rkey} = route.params
   const uri = makeRecordUri(name, 'app.bsky.feed.generator', rkey)
-
-  useFocusEffect(
-    useCallback(() => {
-      setMinimalShellMode(false)
-    }, [setMinimalShellMode]),
-  )
 
   return (
     <Layout.Screen testID="postLikedByScreen">

--- a/src/view/screens/Support.tsx
+++ b/src/view/screens/Support.tsx
@@ -1,8 +1,6 @@
-import {useCallback} from 'react'
 import {msg} from '@lingui/core/macro'
 import {useLingui} from '@lingui/react'
 import {Trans} from '@lingui/react/macro'
-import {useFocusEffect} from '@react-navigation/native'
 
 import {HELP_DESK_URL} from '#/lib/constants'
 import {usePalette} from '#/lib/hooks/usePalette'
@@ -11,7 +9,6 @@ import {
   type NativeStackScreenProps,
 } from '#/lib/routes/types'
 import {s} from '#/lib/styles'
-import {useSetMinimalShellMode} from '#/state/shell'
 import {TextLink} from '#/view/com/util/Link'
 import {Text} from '#/view/com/util/text/Text'
 import {ViewHeader} from '#/view/com/util/ViewHeader'
@@ -21,14 +18,7 @@ import * as Layout from '#/components/Layout'
 type Props = NativeStackScreenProps<CommonNavigatorParams, 'Support'>
 export const SupportScreen = (_props: Props) => {
   const pal = usePalette('default')
-  const setMinimalShellMode = useSetMinimalShellMode()
   const {_} = useLingui()
-
-  useFocusEffect(
-    useCallback(() => {
-      setMinimalShellMode(false)
-    }, [setMinimalShellMode]),
-  )
 
   return (
     <Layout.Screen>

--- a/src/view/screens/TermsOfService.tsx
+++ b/src/view/screens/TermsOfService.tsx
@@ -1,9 +1,7 @@
-import {useCallback} from 'react'
 import {View} from 'react-native'
 import {msg} from '@lingui/core/macro'
 import {useLingui} from '@lingui/react'
 import {Trans} from '@lingui/react/macro'
-import {useFocusEffect} from '@react-navigation/native'
 
 import {usePalette} from '#/lib/hooks/usePalette'
 import {
@@ -11,7 +9,6 @@ import {
   type NativeStackScreenProps,
 } from '#/lib/routes/types'
 import {s} from '#/lib/styles'
-import {useSetMinimalShellMode} from '#/state/shell'
 import {TextLink} from '#/view/com/util/Link'
 import {Text} from '#/view/com/util/text/Text'
 import {ScrollView} from '#/view/com/util/Views'
@@ -21,14 +18,7 @@ import {ViewHeader} from '../com/util/ViewHeader'
 type Props = NativeStackScreenProps<CommonNavigatorParams, 'TermsOfService'>
 export const TermsOfServiceScreen = (_props: Props) => {
   const pal = usePalette('default')
-  const setMinimalShellMode = useSetMinimalShellMode()
   const {_} = useLingui()
-
-  useFocusEffect(
-    useCallback(() => {
-      setMinimalShellMode(false)
-    }, [setMinimalShellMode]),
-  )
 
   return (
     <Layout.Screen>


### PR DESCRIPTION
## Summary
- Replaces the old boolean setter (`useSetMinimalShellMode(true/false)`) with a ref-counted system. Multiple consumers can independently request minimal mode without stepping on each other.
- Screens that just showed the shell on focus (~25 files) had their boilerplate deleted — the shell is now visible by default (count=0).
- Screens that hide the shell (Conversation, VideoFeed, StarterPack Wizard) now use `<Layout.Screen minimalShell>`.
- Non-screen components (LoggedOut, FindContactsFlow) use `useEnableMinimalShellMode()`.
- Home pager directly manipulates `headerMode` sharedvalue

Net: -216 lines.

## Test plan
- [ ] Home feed: scroll down (header hides), switch tabs (header snaps back), drag pager (header snaps back)
- [ ] Messages conversation: header/footer hidden, navigate back → header/footer visible
  - [ ] Deep links hide the shell correctly (can test by going to a DM in safari in the sim, then pressing "Open" in the banner) 
- [ ] Video feed: header/footer hidden, navigate back → visible
- [ ] StarterPack wizard: same as above
- [ ] Logged out state: shell stays hidden
- [ ] General navigation between screens: shell always visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)