### PR TITLE
Add ability to create and modify join links

### DIFF
--- a/src/screens/Messages/ConversationSettings.tsx
+++ b/src/screens/Messages/ConversationSettings.tsx
@@ -231,7 +231,7 @@ function SettingsInner({convoId}: {convoId: string}) {
       initialNumToRender={initialNumToRender}
       keyExtractor={keyExtractor}
       ListHeaderComponent={
-        convo ? (
+        convo?.kind === 'group' ? (
           <SettingsHeader convo={convo} isOwner={isOwner} />
         ) : (
           <SettingsHeaderPlaceholder />
@@ -725,7 +725,7 @@ function SettingsHeader({
   convo,
   isOwner,
 }: {
-  convo: ConvoWithDetails
+  convo: Extract<ConvoWithDetails, {kind: 'group'}>
   isOwner: boolean
 }) {
   const t = useTheme()
@@ -733,7 +733,7 @@ function SettingsHeader({
 
   const navigation = useNavigation<NavigationProp>()
 
-  const groupName = convo.kind === 'group' ? convo.details.name : ''
+  const groupName = convo.details.name
   const [newGroupName, setNewGroupName] = useState(groupName)
 
   const [isLocked, setIsLocked] = useState(false)
@@ -905,7 +905,7 @@ function SettingsHeader({
         onChangeText={setNewGroupName}
         onConfirm={handleEditName}
       />
-      <InviteLinkDialog control={inviteLinkDialog} />
+      <InviteLinkDialog convo={convo} control={inviteLinkDialog} />
       <LockChatPrompt control={lockChatPrompt} onConfirm={handleConfirmLock} />
       <LeaveChatPrompt
         control={leaveChatPrompt}

--- a/src/screens/Messages/ConversationSettings.tsx
+++ b/src/screens/Messages/ConversationSettings.tsx
@@ -738,6 +738,15 @@ function SettingsHeader({
 
   const [isLocked, setIsLocked] = useState(false)
 
+  // TODO Enable this once the feature is working end-to-end. -dsb
+  // const {joinLink} = convo.details
+  const isJoinLinkEnabled = false
+  // const isJoinLinkEnabled =
+  //   isOwner || (!isOwner && joinLink?.enabledStatus === 'enabled')
+
+  // TODO Enable this once the feature is working end-to-end. -dsb
+  const isReportLinkEnabled = false
+
   const {mutate: editGroupName} = useEditGroupName(convo.view.id, {
     onError: e => {
       setNewGroupName(groupName)
@@ -862,12 +871,18 @@ function SettingsHeader({
               onPress={handlePromptName}
             />
           ) : null}
-          <SettingsButton
-            icon={ChainLinkIcon}
-            label={l`Create an invite link for this group chat`}
-            text={l`Invite link`}
-            onPress={inviteLinkDialog.open}
-          />
+          {isJoinLinkEnabled ? (
+            <SettingsButton
+              icon={ChainLinkIcon}
+              label={
+                isOwner
+                  ? l`Create or modify an invite link for this group chat`
+                  : l`View the invite link for this group chat`
+              }
+              text={l`Invite link`}
+              onPress={inviteLinkDialog.open}
+            />
+          ) : null}
           {isOwner ? (
             <SettingsButton
               color={isLocked ? 'negative_subtle' : 'secondary'}
@@ -879,7 +894,7 @@ function SettingsHeader({
               onPress={isLocked ? handleUnlock : lockChatPrompt.open}
             />
           ) : null}
-          {isOwner ? null : (
+          {isOwner ? null : isReportLinkEnabled ? (
             <SettingsButton
               color="secondary"
               icon={FlagIcon}
@@ -887,7 +902,7 @@ function SettingsHeader({
               text={l`Report`}
               onPress={handleReportChat}
             />
-          )}
+          ) : null}
           {isOwner ? null : (
             <SettingsButton
               color="secondary"
@@ -905,7 +920,11 @@ function SettingsHeader({
         onChangeText={setNewGroupName}
         onConfirm={handleEditName}
       />
-      <InviteLinkDialog convo={convo} control={inviteLinkDialog} />
+      <InviteLinkDialog
+        convo={convo}
+        control={inviteLinkDialog}
+        isOwner={isOwner}
+      />
       <LockChatPrompt control={lockChatPrompt} onConfirm={handleConfirmLock} />
       <LeaveChatPrompt
         control={leaveChatPrompt}

--- a/src/screens/Messages/components/CopyTextButton.tsx
+++ b/src/screens/Messages/components/CopyTextButton.tsx
@@ -15,6 +15,7 @@ import {Text} from '#/components/Typography'
 
 export function CopyTextButton({
   children,
+  disabled,
   style,
   value,
   onPress: onPressProp,
@@ -73,13 +74,14 @@ export function CopyTextButton({
       )}
       <Button
         color="secondary"
+        disabled={disabled}
         style={[a.flex_1, a.justify_between, {borderRadius: 10}, style]}
         onPress={onPress}
         {...props}>
         {context => (
           <View style={[a.flex_1, a.flex_row, a.justify_between, a.p_md]}>
             {typeof children === 'function' ? children(context) : children}
-            <ButtonIcon icon={CopyIcon} size="lg" />
+            {disabled ? null : <ButtonIcon icon={CopyIcon} size="lg" />}
           </View>
         )}
       </Button>

--- a/src/screens/Messages/components/InviteLinkDialog.tsx
+++ b/src/screens/Messages/components/InviteLinkDialog.tsx
@@ -18,10 +18,7 @@ import {type ConvoWithDetails} from '#/components/dms/util'
 import * as Toggle from '#/components/forms/Toggle'
 import {ArrowRight_Stroke2_Corner0_Rounded as ArrowRightIcon} from '#/components/icons/Arrow'
 import {ArrowShareRight_Stroke2_Corner2_Rounded as ArrowShareRightIcon} from '#/components/icons/ArrowShareRight'
-import {
-  ChainLink_Stroke2_Corner0_Rounded as ChainLinkIcon,
-  ChainLinkBroken_Stroke2_Corner0_Rounded as ChainLinkBrokenIcon,
-} from '#/components/icons/ChainLink'
+import {ChainLinkBroken_Stroke2_Corner0_Rounded as ChainLinkBrokenIcon} from '#/components/icons/ChainLink'
 import {EditBig_Stroke2_Corner2_Rounded as EditIcon} from '#/components/icons/EditBig'
 import * as Toast from '#/components/Toast'
 import {Text} from '#/components/Typography'
@@ -192,7 +189,7 @@ export function InviteLinkDialog({
                 const parts = whoCanJoin[0].split(':')
                 const joinRule = parts[0]
                 const requireApproval = parts[1] === 'requireApproval'
-                if (joinLink) {
+                if (joinLink && enabledStatus === 'enabled') {
                   editJoinLink({
                     joinRule,
                     requireApproval,
@@ -205,7 +202,9 @@ export function InviteLinkDialog({
                 }
               }}>
               <ButtonText>
-                {joinLink ? l`Update invite link` : l`Generate invite link`}
+                {joinLink && enabledStatus === 'enabled'
+                  ? l`Update invite link`
+                  : l`Generate invite link`}
               </ButtonText>
               <ButtonIcon icon={ArrowRightIcon} />
             </Button>
@@ -222,61 +221,52 @@ export function InviteLinkDialog({
       const value =
         whoCanJoinOptions.find(o => o.name === whoCanJoin[0])?.label ??
         whoCanJoinOptions[0].label
-      header = l`Invite link`
+      header =
+        enabledStatus === 'enabled' ? l`Invite link` : l`Invite link disabled`
       content = (
         <>
+          <View style={[a.mt_lg]}>
+            <CopyTextButton
+              disabled={enabledStatus === 'disabled'}
+              label={l`Invite link`}
+              value={joinLinkURI}>
+              <Text
+                numberOfLines={1}
+                style={[
+                  a.mr_xs,
+                  a.text_md,
+                  enabledStatus === 'disabled'
+                    ? t.atoms.text_contrast_low
+                    : t.atoms.text,
+                ]}>
+                {joinLinkURI}
+              </Text>
+            </CopyTextButton>
+            {createdAt ? (
+              <Text style={[a.mt_xs, a.text_xs, t.atoms.text_contrast_medium]}>
+                <Trans>
+                  Created {timeFormatter.format(createdAt)}{' '}
+                  {dateFormatter.format(createdAt)}
+                </Trans>
+              </Text>
+            ) : null}
+          </View>
           {enabledStatus === 'enabled' ? (
-            <>
-              <View style={[a.mt_lg]}>
-                <CopyTextButton label={l`Invite link`} value={joinLinkURI}>
-                  <Text
-                    numberOfLines={1}
-                    style={[a.mr_xs, a.text_md, t.atoms.text]}>
-                    {joinLinkURI}
-                  </Text>
-                </CopyTextButton>
-                {createdAt ? (
-                  <Text
-                    style={[a.mt_xs, a.text_xs, t.atoms.text_contrast_medium]}>
-                    <Trans>
-                      Created {timeFormatter.format(createdAt)}{' '}
-                      {dateFormatter.format(createdAt)}
-                    </Trans>
-                  </Text>
-                ) : null}
-              </View>
-              <View style={[a.mt_lg]}>
-                <EditTextButton
-                  label={l`Edit link settings`}
-                  value={value}
-                  onPress={() => setStep(Step.GENERATE)}>
-                  <Text
-                    numberOfLines={1}
-                    style={[
-                      a.mr_xs,
-                      a.text_md,
-                      t.atoms.text,
-                      {maxWidth: '80%'},
-                    ]}>
-                    {value}
-                  </Text>
-                </EditTextButton>
-              </View>
-            </>
+            <View style={[a.mt_lg]}>
+              <EditTextButton
+                label={l`Edit link settings`}
+                value={value}
+                onPress={() => setStep(Step.GENERATE)}>
+                <Text
+                  numberOfLines={1}
+                  style={[a.mr_xs, a.text_md, t.atoms.text, {maxWidth: '80%'}]}>
+                  {value}
+                </Text>
+              </EditTextButton>
+            </View>
           ) : null}
-          <View style={[a.flex_row, a.justify_between, a.gap_sm, a.mt_lg]}>
-            {enabledStatus === 'disabled' ? (
-              <StackedButton
-                label={l`Enable`}
-                icon={ChainLinkIcon}
-                color="primary_subtle"
-                style={[a.flex_1, a.rounded_full]}
-                onPress={() => {
-                  enableJoinLink()
-                }}>
-                Enable
-              </StackedButton>
-            ) : (
+          {enabledStatus === 'enabled' ? (
+            <View style={[a.flex_row, a.justify_between, a.gap_sm, a.mt_lg]}>
               <StackedButton
                 label={l`Disable`}
                 icon={ChainLinkBrokenIcon}
@@ -287,32 +277,55 @@ export function InviteLinkDialog({
                 }}>
                 Disable
               </StackedButton>
-            )}
-            <StackedButton
-              disabled={enabledStatus === 'disabled'}
-              label={l`Post link`}
-              icon={EditIcon}
-              color={
-                enabledStatus === 'enabled' ? 'primary_subtle' : 'secondary'
-              }
-              style={[a.flex_1, a.rounded_full]}
-              // TODO Implement this. -dsb
-              onPress={() => {}}>
-              Post link
-            </StackedButton>
-            <StackedButton
-              disabled={enabledStatus === 'disabled'}
-              label={l`Share`}
-              icon={ArrowShareRightIcon}
-              color={
-                enabledStatus === 'enabled' ? 'primary_subtle' : 'secondary'
-              }
-              style={[a.flex_1, a.rounded_full]}
-              // TODO Implement this. -dsb
-              onPress={() => {}}>
-              Share
-            </StackedButton>
-          </View>
+              <StackedButton
+                disabled={enabledStatus === 'disabled'}
+                label={l`Post link`}
+                icon={EditIcon}
+                color={
+                  enabledStatus === 'enabled' ? 'primary_subtle' : 'secondary'
+                }
+                style={[a.flex_1, a.rounded_full]}
+                // TODO Implement this. -dsb
+                onPress={() => {}}>
+                Post link
+              </StackedButton>
+              <StackedButton
+                disabled={enabledStatus === 'disabled'}
+                label={l`Share`}
+                icon={ArrowShareRightIcon}
+                color={
+                  enabledStatus === 'enabled' ? 'primary_subtle' : 'secondary'
+                }
+                style={[a.flex_1, a.rounded_full]}
+                // TODO Implement this. -dsb
+                onPress={() => {}}>
+                Share
+              </StackedButton>
+            </View>
+          ) : (
+            <View style={[a.gap_md, a.mt_lg]}>
+              <Button
+                label={l`Re-enable invite link`}
+                color="primary"
+                size="large"
+                onPress={() => {
+                  enableJoinLink()
+                }}>
+                <ButtonText>
+                  <Trans>Re-enable link</Trans>
+                </ButtonText>
+              </Button>
+              <Button
+                label={l`Generate new invite link`}
+                color="secondary"
+                size="large"
+                onPress={() => setStep(Step.GENERATE)}>
+                <ButtonText>
+                  <Trans>Generate new link</Trans>
+                </ButtonText>
+              </Button>
+            </View>
+          )}
         </>
       )
       break

--- a/src/screens/Messages/components/InviteLinkDialog.tsx
+++ b/src/screens/Messages/components/InviteLinkDialog.tsx
@@ -2,6 +2,9 @@ import {useState} from 'react'
 import {View} from 'react-native'
 import {Trans, useLingui} from '@lingui/react/macro'
 
+import {useOpenComposer} from '#/lib/hooks/useOpenComposer'
+import {createSanitizedDisplayName} from '#/lib/moderation/create-sanitized-display-name'
+import {shareUrl} from '#/lib/sharing'
 import {useCreateJoinLink} from '#/state/queries/messages/create-join-link'
 import {useDisableJoinLink} from '#/state/queries/messages/disable-join-link'
 import {useEditJoinLink} from '#/state/queries/messages/edit-join-link'
@@ -20,6 +23,7 @@ import {ArrowRight_Stroke2_Corner0_Rounded as ArrowRightIcon} from '#/components
 import {ArrowShareRight_Stroke2_Corner2_Rounded as ArrowShareRightIcon} from '#/components/icons/ArrowShareRight'
 import {ChainLinkBroken_Stroke2_Corner0_Rounded as ChainLinkBrokenIcon} from '#/components/icons/ChainLink'
 import {EditBig_Stroke2_Corner2_Rounded as EditIcon} from '#/components/icons/EditBig'
+import {Loader} from '#/components/Loader'
 import * as Toast from '#/components/Toast'
 import {Text} from '#/components/Typography'
 import {IS_WEB} from '#/env'
@@ -45,72 +49,104 @@ const dateFormatter = new Intl.DateTimeFormat(undefined, {
 export function InviteLinkDialog({
   convo,
   control,
+  isOwner,
 }: {
   convo: Extract<ConvoWithDetails, {kind: 'group'}>
   control: Dialog.DialogOuterProps['control']
+  isOwner: boolean
 }) {
   const t = useTheme()
   const {t: l} = useLingui()
 
+  const ownerName = createSanitizedDisplayName(convo.primaryMember)
+
   const {joinLink} = convo.details
   const enabledStatus = joinLink?.enabledStatus
 
-  const initialStep = joinLink ? Step.MANAGE : Step.INFO
-  const initialWhoCanJoin = joinLink
+  const defaultStep = joinLink ? Step.MANAGE : Step.INFO
+  const defaultWhoCanJoin = joinLink
     ? [
         `${joinLink.joinRule}${joinLink.requireApproval ? ':requireApproval' : ''}`,
       ]
     : ['anyone']
 
-  const [step, setStep] = useState<Step>(initialStep)
-  const [whoCanJoin, setWhoCanJoin] = useState(initialWhoCanJoin)
+  const [step, setStep] = useState<Step>(defaultStep)
+  const [whoCanJoin, setWhoCanJoin] = useState(defaultWhoCanJoin)
 
-  const {mutate: createJoinLink} = useCreateJoinLink(convo.view.id, {
-    onSuccess: () => {
-      setStep(Step.MANAGE)
+  const {openComposer} = useOpenComposer()
+
+  const {mutate: createJoinLink, isPending: isCreating} = useCreateJoinLink(
+    convo.view.id,
+    {
+      onSuccess: () => {
+        setStep(Step.MANAGE)
+      },
+      onError: () => {
+        Toast.show(l`Failed to create invite link`, {
+          type: 'error',
+        })
+      },
     },
-    onError: () => {
-      Toast.show(l`Failed to create invite link`, {
-        type: 'error',
-      })
+  )
+  const {mutate: editJoinLink, isPending: isEditing} = useEditJoinLink(
+    convo.view.id,
+    {
+      onSuccess: () => {
+        setStep(Step.MANAGE)
+      },
+      onError: () => {
+        Toast.show(l`Failed to edit invite link`, {
+          type: 'error',
+        })
+      },
     },
-  })
-  const {mutate: editJoinLink} = useEditJoinLink(convo.view.id, {
-    onSuccess: () => {
-      setStep(Step.MANAGE)
+  )
+  const {mutate: disableJoinLink, isPending: isDisabling} = useDisableJoinLink(
+    convo.view.id,
+    {
+      onError: () => {
+        Toast.show(l`Failed to disable invite link`, {
+          type: 'error',
+        })
+      },
     },
-    onError: () => {
-      Toast.show(l`Failed to edit invite link`, {
-        type: 'error',
-      })
+  )
+  const {mutate: enableJoinLink, isPending: isEnabling} = useEnableJoinLink(
+    convo.view.id,
+    {
+      onError: () => {
+        Toast.show(l`Failed to enable invite link`, {
+          type: 'error',
+        })
+      },
     },
-  })
-  const {mutate: disableJoinLink} = useDisableJoinLink(convo.view.id, {
-    onError: () => {
-      Toast.show(l`Failed to disable invite link`, {
-        type: 'error',
-      })
-    },
-  })
-  const {mutate: enableJoinLink} = useEnableJoinLink(convo.view.id, {
-    onError: () => {
-      Toast.show(l`Failed to enable invite link`, {
-        type: 'error',
-      })
-    },
-  })
+  )
+  const isSaving = isCreating || isEditing
 
   const whoCanJoinOptions = [
-    {name: 'anyone', label: l`Anyone can join instantly`},
-    {name: 'anyone:requireApproval', label: l`Anyone can request to join`},
-    {name: 'followedByOwner', label: l`People I follow can join instantly`},
+    {
+      name: 'anyone',
+      owner: l`Anyone can join instantly`,
+      member: l`Anyone can join instantly`,
+    },
+    {
+      name: 'anyone:requireApproval',
+      owner: l`Anyone can request to join`,
+      member: l`Anyone can request to join`,
+    },
+    {
+      name: 'followedByOwner',
+      owner: l`People I follow can join instantly`,
+      member: l`People ${ownerName} follows can join instantly`,
+    },
     {
       name: 'followedByOwner:requireApproval',
-      label: l`People I follow can request to join`,
+      owner: l`People I follow can request to join`,
+      member: l`People ${ownerName} follows can request to join`,
     },
   ]
 
-  let content: React.ReactNode | null = null
+  let content: React.ReactNode = null
   let header: string | null = null
   switch (step) {
     case Step.INFO:
@@ -169,11 +205,14 @@ export function InviteLinkDialog({
                   <Toggle.Item
                     key={option.name}
                     highlightRow={true}
-                    label={option.label}
+                    label={isOwner ? option.owner : option.member}
                     name={option.name}
                     style={[a.flex_1]}>
                     {({selected}) => (
-                      <TargetOption label={option.label} selected={selected} />
+                      <TargetOption
+                        label={isOwner ? option.owner : option.member}
+                        selected={selected}
+                      />
                     )}
                   </Toggle.Item>
                 ))}
@@ -185,6 +224,7 @@ export function InviteLinkDialog({
               label={l`Generate invite link`}
               color="primary"
               size="large"
+              disabled={isSaving}
               onPress={() => {
                 const parts = whoCanJoin[0].split(':')
                 const joinRule = parts[0]
@@ -206,28 +246,30 @@ export function InviteLinkDialog({
                   ? l`Update invite link`
                   : l`Generate invite link`}
               </ButtonText>
-              <ButtonIcon icon={ArrowRightIcon} />
+              <ButtonIcon icon={isSaving ? Loader : ArrowRightIcon} />
             </Button>
           </View>
         </>
       )
       break
-    case Step.MANAGE:
-      const joinLinkURI =
-        joinLink && joinLink.code !== ''
-          ? `https://bsky.app/chat/${joinLink.code}`
-          : 'https://bsky.app/chat'
+    case Step.MANAGE: {
+      const hasJoinLinkCode = joinLink && joinLink.code !== ''
+      const joinLinkURI = hasJoinLinkCode
+        ? `https://bsky.app/chat/${joinLink.code}`
+        : 'https://bsky.app/chat'
       const createdAt = joinLink ? new Date(joinLink.createdAt) : null
-      const value =
-        whoCanJoinOptions.find(o => o.name === whoCanJoin[0])?.label ??
-        whoCanJoinOptions[0].label
+      const currentOption = whoCanJoinOptions.find(
+        o => o.name === whoCanJoin[0],
+      )
+      const ownerValue = currentOption?.owner ?? whoCanJoinOptions[0].owner
+      const memberValue = currentOption?.member ?? whoCanJoinOptions[0].member
       header =
         enabledStatus === 'enabled' ? l`Invite link` : l`Invite link disabled`
       content = (
         <>
           <View style={[a.mt_lg]}>
             <CopyTextButton
-              disabled={enabledStatus === 'disabled'}
+              disabled={enabledStatus === 'disabled' || !hasJoinLinkCode}
               label={l`Invite link`}
               value={joinLinkURI}>
               <Text
@@ -253,52 +295,67 @@ export function InviteLinkDialog({
           </View>
           {enabledStatus === 'enabled' ? (
             <View style={[a.mt_lg]}>
-              <EditTextButton
-                label={l`Edit link settings`}
-                value={value}
-                onPress={() => setStep(Step.GENERATE)}>
-                <Text
-                  numberOfLines={1}
-                  style={[a.mr_xs, a.text_md, t.atoms.text, {maxWidth: '80%'}]}>
-                  {value}
-                </Text>
-              </EditTextButton>
+              {isOwner ? (
+                <EditTextButton
+                  label={l`Edit link settings`}
+                  value={ownerValue}
+                  onPress={() => setStep(Step.GENERATE)}>
+                  <Text
+                    numberOfLines={1}
+                    style={[
+                      a.mr_xs,
+                      a.text_md,
+                      t.atoms.text,
+                      {maxWidth: '80%'},
+                    ]}>
+                    {ownerValue}
+                  </Text>
+                </EditTextButton>
+              ) : (
+                <Text style={[a.text_sm, t.atoms.text]}>{memberValue}</Text>
+              )}
             </View>
           ) : null}
           {enabledStatus === 'enabled' ? (
             <View style={[a.flex_row, a.justify_between, a.gap_sm, a.mt_lg]}>
-              <StackedButton
-                label={l`Disable`}
-                icon={ChainLinkBrokenIcon}
-                color="negative_subtle"
-                style={[a.flex_1, a.rounded_full]}
-                onPress={() => {
-                  disableJoinLink()
-                }}>
-                <Trans>Disable</Trans>
-              </StackedButton>
+              {isOwner ? (
+                <StackedButton
+                  label={l`Disable`}
+                  icon={isDisabling ? Loader : ChainLinkBrokenIcon}
+                  color="negative_subtle"
+                  style={[a.flex_1, a.rounded_full]}
+                  disabled={isDisabling}
+                  onPress={() => {
+                    disableJoinLink()
+                  }}>
+                  <Trans>Disable</Trans>
+                </StackedButton>
+              ) : null}
               <StackedButton
                 disabled={enabledStatus === 'disabled'}
                 label={l`Post link`}
                 icon={EditIcon}
-                color={
-                  enabledStatus === 'enabled' ? 'primary_subtle' : 'secondary'
-                }
+                color="primary_subtle"
                 style={[a.flex_1, a.rounded_full]}
-                // TODO Implement this. -dsb
-                onPress={() => {}}>
+                onPress={() => {
+                  control.close(() => {
+                    openComposer({
+                      text: joinLinkURI,
+                      logContext: 'Other',
+                    })
+                  })
+                }}>
                 <Trans>Post link</Trans>
               </StackedButton>
               <StackedButton
                 disabled={enabledStatus === 'disabled'}
                 label={l`Share`}
                 icon={ArrowShareRightIcon}
-                color={
-                  enabledStatus === 'enabled' ? 'primary_subtle' : 'secondary'
-                }
+                color="primary_subtle"
                 style={[a.flex_1, a.rounded_full]}
-                // TODO Implement this. -dsb
-                onPress={() => {}}>
+                onPress={() => {
+                  void shareUrl(joinLinkURI)
+                }}>
                 <Trans>Share</Trans>
               </StackedButton>
             </View>
@@ -308,12 +365,14 @@ export function InviteLinkDialog({
                 label={l`Re-enable invite link`}
                 color="primary"
                 size="large"
+                disabled={isEnabling}
                 onPress={() => {
                   enableJoinLink()
                 }}>
                 <ButtonText>
                   <Trans>Re-enable link</Trans>
                 </ButtonText>
+                {isEnabling && <ButtonIcon icon={Loader} />}
               </Button>
               <Button
                 label={l`Generate new invite link`}
@@ -329,14 +388,39 @@ export function InviteLinkDialog({
         </>
       )
       break
+    }
+  }
+
+  if (!isOwner && (!joinLink || joinLink?.enabledStatus === 'disabled')) {
+    header = l`Invite link`
+    content = (
+      <>
+        <View style={[a.mt_lg]}>
+          <Text style={[a.text_sm, t.atoms.text]}>
+            <Trans>There is no invite link for this group chat.</Trans>
+          </Text>
+        </View>
+        <View style={[a.gap_md, a.mt_lg]}>
+          <Button
+            label={l`Close`}
+            color="primary"
+            size="large"
+            onPress={() => control.close()}>
+            <ButtonText>
+              <Trans>Close</Trans>
+            </ButtonText>
+          </Button>
+        </View>
+      </>
+    )
   }
 
   return (
     <Dialog.Outer
       control={control}
       onClose={() => {
-        setStep(initialStep)
-        setWhoCanJoin(initialWhoCanJoin)
+        setStep(defaultStep)
+        setWhoCanJoin(defaultWhoCanJoin)
       }}>
       <Dialog.Handle />
       <Dialog.ScrollableInner

--- a/src/screens/Messages/components/InviteLinkDialog.tsx
+++ b/src/screens/Messages/components/InviteLinkDialog.tsx
@@ -2,6 +2,10 @@ import {useState} from 'react'
 import {View} from 'react-native'
 import {Trans, useLingui} from '@lingui/react/macro'
 
+import {useCreateJoinLink} from '#/state/queries/messages/create-join-link'
+import {useDisableJoinLink} from '#/state/queries/messages/disable-join-link'
+import {useEditJoinLink} from '#/state/queries/messages/edit-join-link'
+import {useEnableJoinLink} from '#/state/queries/messages/enable-join-link'
 import {atoms as a, useTheme, web} from '#/alf'
 import {
   Button,
@@ -10,11 +14,16 @@ import {
   StackedButton,
 } from '#/components/Button'
 import * as Dialog from '#/components/Dialog'
+import {type ConvoWithDetails} from '#/components/dms/util'
 import * as Toggle from '#/components/forms/Toggle'
 import {ArrowRight_Stroke2_Corner0_Rounded as ArrowRightIcon} from '#/components/icons/Arrow'
 import {ArrowShareRight_Stroke2_Corner2_Rounded as ArrowShareRightIcon} from '#/components/icons/ArrowShareRight'
-import {ChainLinkBroken_Stroke2_Corner0_Rounded as ChainLinkBrokenIcon} from '#/components/icons/ChainLink'
+import {
+  ChainLink_Stroke2_Corner0_Rounded as ChainLinkIcon,
+  ChainLinkBroken_Stroke2_Corner0_Rounded as ChainLinkBrokenIcon,
+} from '#/components/icons/ChainLink'
 import {EditBig_Stroke2_Corner2_Rounded as EditIcon} from '#/components/icons/EditBig'
+import * as Toast from '#/components/Toast'
 import {Text} from '#/components/Typography'
 import {IS_WEB} from '#/env'
 import {CopyTextButton} from './CopyTextButton'
@@ -37,15 +46,62 @@ const dateFormatter = new Intl.DateTimeFormat(undefined, {
 })
 
 export function InviteLinkDialog({
+  convo,
   control,
 }: {
+  convo: Extract<ConvoWithDetails, {kind: 'group'}>
   control: Dialog.DialogOuterProps['control']
 }) {
   const t = useTheme()
   const {t: l} = useLingui()
 
-  const [step, setStep] = useState(Step.INFO)
-  const [whoCanJoin, setWhoCanJoin] = useState(['anyone'])
+  const {joinLink} = convo.details
+  const enabledStatus = joinLink?.enabledStatus
+
+  const initialStep = joinLink ? Step.MANAGE : Step.INFO
+  const initialWhoCanJoin = joinLink
+    ? [
+        `${joinLink.joinRule}${joinLink.requireApproval ? ':requireApproval' : ''}`,
+      ]
+    : ['anyone']
+
+  const [step, setStep] = useState<Step>(initialStep)
+  const [whoCanJoin, setWhoCanJoin] = useState(initialWhoCanJoin)
+
+  const {mutate: createJoinLink} = useCreateJoinLink(convo.view.id, {
+    onSuccess: () => {
+      setStep(Step.MANAGE)
+    },
+    onError: () => {
+      Toast.show(l`Failed to create invite link`, {
+        type: 'error',
+      })
+    },
+  })
+  const {mutate: editJoinLink} = useEditJoinLink(convo.view.id, {
+    onSuccess: () => {
+      setStep(Step.MANAGE)
+    },
+    onError: () => {
+      Toast.show(l`Failed to edit invite link`, {
+        type: 'error',
+      })
+    },
+  })
+  const {mutate: disableJoinLink} = useDisableJoinLink(convo.view.id, {
+    onError: () => {
+      Toast.show(l`Failed to disable invite link`, {
+        type: 'error',
+      })
+    },
+  })
+  const {mutate: enableJoinLink} = useEnableJoinLink(convo.view.id, {
+    onError: () => {
+      Toast.show(l`Failed to enable invite link`, {
+        type: 'error',
+      })
+    },
+  })
 
   const whoCanJoinOptions = [
     {name: 'anyone', label: l`Anyone can join instantly`},
@@ -133,10 +189,23 @@ export function InviteLinkDialog({
               color="primary"
               size="large"
               onPress={() => {
-                setStep(Step.MANAGE)
+                const parts = whoCanJoin[0].split(':')
+                const joinRule = parts[0]
+                const requireApproval = parts[1] === 'requireApproval'
+                if (joinLink) {
+                  editJoinLink({
+                    joinRule,
+                    requireApproval,
+                  })
+                } else {
+                  createJoinLink({
+                    joinRule,
+                    requireApproval,
+                  })
+                }
               }}>
               <ButtonText>
-                <Trans>Generate invite link</Trans>
+                {joinLink ? l`Update invite link` : l`Generate invite link`}
               </ButtonText>
               <ButtonIcon icon={ArrowRightIcon} />
             </Button>
@@ -145,64 +214,101 @@ export function InviteLinkDialog({
       )
       break
     case Step.MANAGE:
-      const createdAt = new Date()
+      const joinLinkURI =
+        joinLink && joinLink.code !== ''
+          ? `https://bsky.app/chat/${joinLink.code}`
+          : 'https://bsky.app/chat'
+      const createdAt = joinLink ? new Date(joinLink.createdAt) : null
       const value =
         whoCanJoinOptions.find(o => o.name === whoCanJoin[0])?.label ??
         whoCanJoinOptions[0].label
       header = l`Invite link`
       content = (
         <>
-          <View style={[a.mt_lg]}>
-            <CopyTextButton
-              label={l`Invite link`}
-              value="https://bsky.app/chat/asdf123">
-              <Text
-                numberOfLines={1}
-                style={[a.mr_xs, a.text_md, t.atoms.text]}>
-                https//bsky.app/chat/asdf123
-              </Text>
-            </CopyTextButton>
-            <Text style={[a.mt_xs, a.text_xs, t.atoms.text_contrast_medium]}>
-              <Trans>
-                Created {timeFormatter.format(createdAt)}{' '}
-                {dateFormatter.format(createdAt)}
-              </Trans>
-            </Text>
-          </View>
-          <View style={[a.mt_lg]}>
-            <EditTextButton
-              label={l`Edit link settings`}
-              value={value}
-              onPress={() => setStep(Step.GENERATE)}>
-              <Text
-                numberOfLines={1}
-                style={[a.mr_xs, a.text_md, t.atoms.text, {maxWidth: '80%'}]}>
-                {value}
-              </Text>
-            </EditTextButton>
-          </View>
+          {enabledStatus === 'enabled' ? (
+            <>
+              <View style={[a.mt_lg]}>
+                <CopyTextButton label={l`Invite link`} value={joinLinkURI}>
+                  <Text
+                    numberOfLines={1}
+                    style={[a.mr_xs, a.text_md, t.atoms.text]}>
+                    {joinLinkURI}
+                  </Text>
+                </CopyTextButton>
+                {createdAt ? (
+                  <Text
+                    style={[a.mt_xs, a.text_xs, t.atoms.text_contrast_medium]}>
+                    <Trans>
+                      Created {timeFormatter.format(createdAt)}{' '}
+                      {dateFormatter.format(createdAt)}
+                    </Trans>
+                  </Text>
+                ) : null}
+              </View>
+              <View style={[a.mt_lg]}>
+                <EditTextButton
+                  label={l`Edit link settings`}
+                  value={value}
+                  onPress={() => setStep(Step.GENERATE)}>
+                  <Text
+                    numberOfLines={1}
+                    style={[
+                      a.mr_xs,
+                      a.text_md,
+                      t.atoms.text,
+                      {maxWidth: '80%'},
+                    ]}>
+                    {value}
+                  </Text>
+                </EditTextButton>
+              </View>
+            </>
+          ) : null}
           <View style={[a.flex_row, a.justify_between, a.gap_sm, a.mt_lg]}>
+            {enabledStatus === 'disabled' ? (
+              <StackedButton
+                label={l`Enable`}
+                icon={ChainLinkIcon}
+                color="primary_subtle"
+                style={[a.flex_1, a.rounded_full]}
+                onPress={() => {
+                  enableJoinLink()
+                }}>
+                Enable
+              </StackedButton>
+            ) : (
+              <StackedButton
+                label={l`Disable`}
+                icon={ChainLinkBrokenIcon}
+                color="negative_subtle"
+                style={[a.flex_1, a.rounded_full]}
+                onPress={() => {
+                  disableJoinLink()
+                }}>
+                Disable
+              </StackedButton>
+            )}
             <StackedButton
-              label={l`Disable`}
-              icon={ChainLinkBrokenIcon}
-              color="negative_subtle"
-              style={[a.flex_1, a.rounded_full]}
-              onPress={() => {}}>
-              Disable
-            </StackedButton>
-            <StackedButton
+              disabled={enabledStatus === 'disabled'}
               label={l`Post link`}
               icon={EditIcon}
-              color="primary_subtle"
+              color={
+                enabledStatus === 'enabled' ? 'primary_subtle' : 'secondary'
+              }
               style={[a.flex_1, a.rounded_full]}
+              // TODO Implement this. -dsb
               onPress={() => {}}>
               Post link
             </StackedButton>
             <StackedButton
+              disabled={enabledStatus === 'disabled'}
               label={l`Share`}
               icon={ArrowShareRightIcon}
-              color="primary_subtle"
+              color={
+                enabledStatus === 'enabled' ? 'primary_subtle' : 'secondary'
+              }
               style={[a.flex_1, a.rounded_full]}
+              // TODO Implement this. -dsb
               onPress={() => {}}>
               Share
             </StackedButton>
@@ -216,8 +322,8 @@ export function InviteLinkDialog({
     <Dialog.Outer
       control={control}
       onClose={() => {
-        setStep(Step.INFO)
-        setWhoCanJoin(['anyone'])
+        setStep(initialStep)
+        setWhoCanJoin(initialWhoCanJoin)
       }}>
       <Dialog.Handle />
       <Dialog.ScrollableInner

--- a/src/screens/Messages/components/InviteLinkDialog.tsx
+++ b/src/screens/Messages/components/InviteLinkDialog.tsx
@@ -275,7 +275,7 @@ export function InviteLinkDialog({
                 onPress={() => {
                   disableJoinLink()
                 }}>
-                Disable
+                <Trans>Disable</Trans>
               </StackedButton>
               <StackedButton
                 disabled={enabledStatus === 'disabled'}
@@ -287,7 +287,7 @@ export function InviteLinkDialog({
                 style={[a.flex_1, a.rounded_full]}
                 // TODO Implement this. -dsb
                 onPress={() => {}}>
-                Post link
+                <Trans>Post link</Trans>
               </StackedButton>
               <StackedButton
                 disabled={enabledStatus === 'disabled'}
@@ -299,7 +299,7 @@ export function InviteLinkDialog({
                 style={[a.flex_1, a.rounded_full]}
                 // TODO Implement this. -dsb
                 onPress={() => {}}>
-                Share
+                <Trans>Share</Trans>
               </StackedButton>
             </View>
           ) : (

--- a/src/screens/Messages/components/MessagesListInfoPanel.tsx
+++ b/src/screens/Messages/components/MessagesListInfoPanel.tsx
@@ -19,7 +19,7 @@ export function MessagesListInfoPanel({convoState}: {convoState: ConvoState}) {
   const {t: l} = useLingui()
 
   const addMembersControl = Dialog.useDialogControl()
-  const inviteLinkPrompt = Dialog.useDialogControl()
+  const inviteLinkControl = Dialog.useDialogControl()
 
   const {currentAccount} = useSession()
 
@@ -27,6 +27,11 @@ export function MessagesListInfoPanel({convoState}: {convoState: ConvoState}) {
     ? parseConvoView(convoState.convo, currentAccount?.did)
     : null
   const groupConvo = convo?.kind === 'group' ? convo : null
+  // TODO Enable this once the feature is working end-to-end. -dsb
+  // const joinLink = groupConvo?.details.joinLink
+  const isJoinLinkEnabled = false
+  //   (isOwner && groupConvo) ||
+  //   (!isOwner && groupConvo && joinLink?.enabledStatus === 'enabled')
 
   const isOwner =
     currentAccount?.did == null
@@ -110,12 +115,16 @@ export function MessagesListInfoPanel({convoState}: {convoState: ConvoState}) {
                 </ButtonText>
               </Button>
             ) : null}
-            {isOwner && groupConvo ? (
+            {isJoinLinkEnabled ? (
               <Button
                 color="secondary"
                 size="small"
-                label={l`Click here to create or manage an invite link for this group chat`}
-                onPress={() => inviteLinkPrompt.open()}>
+                label={
+                  isOwner
+                    ? l`Click here to create or manage an invite link for this group chat`
+                    : l`Click here to view the invite link for this group chat`
+                }
+                onPress={inviteLinkControl.open}>
                 <ButtonIcon icon={ChainLinkIcon} />
                 <ButtonText>
                   <Trans>Invite link</Trans>
@@ -126,7 +135,11 @@ export function MessagesListInfoPanel({convoState}: {convoState: ConvoState}) {
         ) : null}
       </View>
       {groupConvo ? (
-        <InviteLinkDialog convo={groupConvo} control={inviteLinkPrompt} />
+        <InviteLinkDialog
+          isOwner={isOwner}
+          convo={groupConvo}
+          control={inviteLinkControl}
+        />
       ) : null}
       <Dialog.Outer
         control={addMembersControl}

--- a/src/screens/Messages/components/MessagesListInfoPanel.tsx
+++ b/src/screens/Messages/components/MessagesListInfoPanel.tsx
@@ -8,6 +8,7 @@ import {AvatarBubbles} from '#/components/AvatarBubbles'
 import {Button, ButtonIcon, ButtonText} from '#/components/Button'
 import * as Dialog from '#/components/Dialog'
 import {AddMembersFlow} from '#/components/dms/AddMembersFlow'
+import {parseConvoView} from '#/components/dms/util'
 import {ChainLink_Stroke2_Corner0_Rounded as ChainLinkIcon} from '#/components/icons/ChainLink'
 import {PersonPlus_Stroke2_Corner0_Rounded as PersonPlusIcon} from '#/components/icons/Person'
 import {Text} from '#/components/Typography'
@@ -21,6 +22,11 @@ export function MessagesListInfoPanel({convoState}: {convoState: ConvoState}) {
   const inviteLinkPrompt = Dialog.useDialogControl()
 
   const {currentAccount} = useSession()
+
+  const convo = convoState.convo
+    ? parseConvoView(convoState.convo, currentAccount?.did)
+    : null
+  const groupConvo = convo?.kind === 'group' ? convo : null
 
   const isOwner =
     currentAccount?.did == null
@@ -104,11 +110,11 @@ export function MessagesListInfoPanel({convoState}: {convoState: ConvoState}) {
                 </ButtonText>
               </Button>
             ) : null}
-            {isOwner || isLinkEnabled ? (
+            {isOwner && groupConvo ? (
               <Button
                 color="secondary"
                 size="small"
-                label={l`Click here to view or create an invite link for this group chat`}
+                label={l`Click here to create or manage an invite link for this group chat`}
                 onPress={() => inviteLinkPrompt.open()}>
                 <ButtonIcon icon={ChainLinkIcon} />
                 <ButtonText>
@@ -119,7 +125,9 @@ export function MessagesListInfoPanel({convoState}: {convoState: ConvoState}) {
           </View>
         ) : null}
       </View>
-      <InviteLinkDialog control={inviteLinkPrompt} />
+      {groupConvo ? (
+        <InviteLinkDialog convo={groupConvo} control={inviteLinkPrompt} />
+      ) : null}
       <Dialog.Outer
         control={addMembersControl}
         testID="addChatMembersDialog"

--- a/src/state/messages/convo/agent.ts
+++ b/src/state/messages/convo/agent.ts
@@ -4,6 +4,7 @@ import {
   ChatBskyConvoDefs,
   type ChatBskyConvoGetLog,
   type ChatBskyConvoSendMessage,
+  type ChatBskyGroupDefs,
 } from '@atproto/api'
 import {XRPCError} from '@atproto/api'
 import {EventEmitter} from 'eventemitter3'
@@ -145,6 +146,7 @@ export class Convo {
     this.getGroupInfo = this.getGroupInfo.bind(this)
     this.getPrimaryMember = this.getPrimaryMember.bind(this)
     this.updateGroupName = this.updateGroupName.bind(this)
+    this.updateJoinLink = this.updateJoinLink.bind(this)
   }
 
   private commit() {
@@ -953,6 +955,25 @@ export class Convo {
         kind: {
           ...this.convo.kind,
           name,
+        },
+      }
+    }
+    this.commit()
+  }
+
+  updateJoinLink(joinLink: ChatBskyGroupDefs.JoinLinkView | undefined) {
+    if (
+      this.convo &&
+      bsky.dangerousIsType<ChatBskyConvoDefs.GroupConvo>(
+        this.convo.kind,
+        ChatBskyConvoDefs.isGroupConvo,
+      )
+    ) {
+      this.convo = {
+        ...this.convo,
+        kind: {
+          ...this.convo.kind,
+          joinLink,
         },
       }
     }

--- a/src/state/messages/convo/index.tsx
+++ b/src/state/messages/convo/index.tsx
@@ -134,10 +134,14 @@ export function ConvoProvider({
           data &&
           convo.convo &&
           ChatBskyConvoDefs.isGroupConvo(data.kind) &&
-          ChatBskyConvoDefs.isGroupConvo(convo.convo.kind) &&
-          data.kind.name !== convo.convo.kind.name
+          ChatBskyConvoDefs.isGroupConvo(convo.convo.kind)
         ) {
-          convo.updateGroupName(data.kind.name)
+          if (data.kind.name !== convo.convo.kind.name) {
+            convo.updateGroupName(data.kind.name)
+          }
+          if (data.kind.joinLink !== convo.convo.kind.joinLink) {
+            convo.updateJoinLink(data.kind.joinLink)
+          }
         }
       }
     })

--- a/src/state/queries/messages/create-join-link.ts
+++ b/src/state/queries/messages/create-join-link.ts
@@ -1,0 +1,84 @@
+import {
+  ChatBskyConvoDefs,
+  type ChatBskyGroupCreateJoinLink,
+  type ChatBskyGroupDefs,
+} from '@atproto/api'
+import {useMutation, useQueryClient} from '@tanstack/react-query'
+
+import {DM_SERVICE_HEADERS} from '#/lib/constants'
+import {logger} from '#/logger'
+import {useAgent} from '#/state/session'
+import {
+  rollbackConvoOptimistic,
+  updateConvoOptimistic,
+} from './utils/convo-cache'
+
+export function useCreateJoinLink(
+  convoId: string | undefined,
+  {
+    onSuccess,
+    onError,
+  }: {
+    onSuccess?: (data: ChatBskyGroupCreateJoinLink.OutputSchema) => void
+    onError?: (error: Error) => void
+  },
+) {
+  const queryClient = useQueryClient()
+  const agent = useAgent()
+
+  return useMutation({
+    mutationFn: async ({
+      joinRule,
+      requireApproval,
+    }: {
+      joinRule: ChatBskyGroupDefs.JoinRule
+      requireApproval: boolean
+    }) => {
+      if (!convoId) throw new Error('No convoId provided')
+      const {data} = await agent.chat.bsky.group.createJoinLink(
+        {convoId, joinRule, requireApproval},
+        {headers: DM_SERVICE_HEADERS, encoding: 'application/json'},
+      )
+      return data
+    },
+    onMutate: ({joinRule, requireApproval}) => {
+      if (!convoId) return
+      return updateConvoOptimistic(queryClient, convoId, prev => {
+        if (!ChatBskyConvoDefs.isGroupConvo(prev.kind)) return undefined
+        return {
+          ...prev,
+          kind: {
+            ...prev.kind,
+            joinLink: {
+              $type: 'chat.bsky.group.defs#joinLinkView',
+              code: '',
+              enabledStatus: 'enabled',
+              joinRule,
+              requireApproval,
+              createdAt: new Date().toISOString(),
+            },
+          },
+        }
+      })
+    },
+    onSuccess: data => {
+      if (convoId) {
+        updateConvoOptimistic(queryClient, convoId, prev => {
+          if (!ChatBskyConvoDefs.isGroupConvo(prev.kind)) return undefined
+          return {
+            ...prev,
+            kind: {...prev.kind, joinLink: data.joinLink},
+          }
+        })
+      }
+      onSuccess?.(data)
+    },
+    onError: (e, _variables, context) => {
+      logger.error(e)
+      if (convoId && context) {
+        rollbackConvoOptimistic(queryClient, convoId, context)
+      }
+      onError?.(e)
+    },
+  })
+}

--- a/src/state/queries/messages/disable-join-link.ts
+++ b/src/state/queries/messages/disable-join-link.ts
@@ -1,4 +1,7 @@
-import {ChatBskyConvoDefs, type ChatBskyGroupEditGroup} from '@atproto/api'
+import {
+  ChatBskyConvoDefs,
+  type ChatBskyGroupDisableJoinLink,
+} from '@atproto/api'
 import {useMutation, useQueryClient} from '@tanstack/react-query'
 
 import {DM_SERVICE_HEADERS} from '#/lib/constants'
@@ -9,13 +12,13 @@ import {
   updateConvoOptimistic,
 } from './utils/convo-cache'
 
-export function useEditGroupName(
+export function useDisableJoinLink(
   convoId: string | undefined,
   {
     onSuccess,
     onError,
   }: {
-    onSuccess?: (data: ChatBskyGroupEditGroup.OutputSchema) => void
+    onSuccess?: (data: ChatBskyGroupDisableJoinLink.OutputSchema) => void
     onError?: (error: Error) => void
   },
 ) {
@@ -23,25 +26,39 @@ export function useEditGroupName(
   const agent = useAgent()
 
   return useMutation({
-    mutationFn: async ({name: groupName}: {name: string}) => {
+    mutationFn: async () => {
       if (!convoId) throw new Error('No convoId provided')
-      const {data} = await agent.chat.bsky.group.editGroup(
-        {convoId, name: groupName},
+      const {data} = await agent.chat.bsky.group.disableJoinLink(
+        {convoId},
         {headers: DM_SERVICE_HEADERS, encoding: 'application/json'},
       )
       return data
     },
-    onMutate: ({name: groupName}) => {
+    onMutate: () => {
       if (!convoId) return
       return updateConvoOptimistic(queryClient, convoId, prev => {
-        if (!ChatBskyConvoDefs.isGroupConvo(prev.kind)) return undefined
+        if (!ChatBskyConvoDefs.isGroupConvo(prev.kind) || !prev.kind.joinLink) {
+          return undefined
+        }
         return {
           ...prev,
-          kind: {...prev.kind, name: groupName},
+          kind: {
+            ...prev.kind,
+            joinLink: {...prev.kind.joinLink, enabledStatus: 'disabled'},
+          },
         }
       })
     },
     onSuccess: data => {
+      if (convoId) {
+        updateConvoOptimistic(queryClient, convoId, prev => {
+          if (!ChatBskyConvoDefs.isGroupConvo(prev.kind)) return undefined
+          return {
+            ...prev,
+            kind: {...prev.kind, joinLink: data.joinLink},
+          }
+        })
+      }
       onSuccess?.(data)
     },
     onError: (e, _variables, context) => {

--- a/src/state/queries/messages/edit-join-link.ts
+++ b/src/state/queries/messages/edit-join-link.ts
@@ -1,0 +1,79 @@
+import {
+  ChatBskyConvoDefs,
+  type ChatBskyGroupDefs,
+  type ChatBskyGroupEditJoinLink,
+} from '@atproto/api'
+import {useMutation, useQueryClient} from '@tanstack/react-query'
+
+import {DM_SERVICE_HEADERS} from '#/lib/constants'
+import {logger} from '#/logger'
+import {useAgent} from '#/state/session'
+import {
+  rollbackConvoOptimistic,
+  updateConvoOptimistic,
+} from './utils/convo-cache'
+
+export function useEditJoinLink(
+  convoId: string | undefined,
+  {
+    onSuccess,
+    onError,
+  }: {
+    onSuccess?: (data: ChatBskyGroupEditJoinLink.OutputSchema) => void
+    onError?: (error: Error) => void
+  },
+) {
+  const queryClient = useQueryClient()
+  const agent = useAgent()
+
+  return useMutation({
+    mutationFn: async ({
+      joinRule,
+      requireApproval,
+    }: {
+      joinRule: ChatBskyGroupDefs.JoinRule
+      requireApproval: boolean
+    }) => {
+      if (!convoId) throw new Error('No convoId provided')
+      const {data} = await agent.chat.bsky.group.editJoinLink(
+        {convoId, joinRule, requireApproval},
+        {headers: DM_SERVICE_HEADERS, encoding: 'application/json'},
+      )
+      return data
+    },
+    onMutate: ({joinRule, requireApproval}) => {
+      if (!convoId) return
+      return updateConvoOptimistic(queryClient, convoId, prev => {
+        if (!ChatBskyConvoDefs.isGroupConvo(prev.kind) || !prev.kind.joinLink) {
+          return undefined
+        }
+        return {
+          ...prev,
+          kind: {
+            ...prev.kind,
+            joinLink: {...prev.kind.joinLink, joinRule, requireApproval},
+          },
+        }
+      })
+    },
+    onSuccess: data => {
+      if (convoId) {
+        updateConvoOptimistic(queryClient, convoId, prev => {
+          if (!ChatBskyConvoDefs.isGroupConvo(prev.kind)) return undefined
+          return {
+            ...prev,
+            kind: {...prev.kind, joinLink: data.joinLink},
+          }
+        })
+      }
+      onSuccess?.(data)
+    },
+    onError: (e, _variables, context) => {
+      logger.error(e)
+      if (convoId && context) {
+        rollbackConvoOptimistic(queryClient, convoId, context)
+      }
+      onError?.(e)
+    },
+  })
+}

--- a/src/state/queries/messages/enable-join-link.ts
+++ b/src/state/queries/messages/enable-join-link.ts
@@ -1,4 +1,4 @@
-import {ChatBskyConvoDefs, type ChatBskyGroupEditGroup} from '@atproto/api'
+import {ChatBskyConvoDefs, type ChatBskyGroupEnableJoinLink} from '@atproto/api'
 import {useMutation, useQueryClient} from '@tanstack/react-query'
 
 import {DM_SERVICE_HEADERS} from '#/lib/constants'
@@ -9,13 +9,13 @@ import {
   updateConvoOptimistic,
 } from './utils/convo-cache'
 
-export function useEditGroupName(
+export function useEnableJoinLink(
   convoId: string | undefined,
   {
     onSuccess,
     onError,
   }: {
-    onSuccess?: (data: ChatBskyGroupEditGroup.OutputSchema) => void
+    onSuccess?: (data: ChatBskyGroupEnableJoinLink.OutputSchema) => void
     onError?: (error: Error) => void
   },
 ) {
@@ -23,25 +23,39 @@ export function useEditGroupName(
   const agent = useAgent()
 
   return useMutation({
-    mutationFn: async ({name: groupName}: {name: string}) => {
+    mutationFn: async () => {
       if (!convoId) throw new Error('No convoId provided')
-      const {data} = await agent.chat.bsky.group.editGroup(
-        {convoId, name: groupName},
+      const {data} = await agent.chat.bsky.group.enableJoinLink(
+        {convoId},
         {headers: DM_SERVICE_HEADERS, encoding: 'application/json'},
       )
       return data
     },
-    onMutate: ({name: groupName}) => {
+    onMutate: () => {
       if (!convoId) return
       return updateConvoOptimistic(queryClient, convoId, prev => {
-        if (!ChatBskyConvoDefs.isGroupConvo(prev.kind)) return undefined
+        if (!ChatBskyConvoDefs.isGroupConvo(prev.kind) || !prev.kind.joinLink) {
+          return undefined
+        }
         return {
           ...prev,
-          kind: {...prev.kind, name: groupName},
+          kind: {
+            ...prev.kind,
+            joinLink: {...prev.kind.joinLink, enabledStatus: 'enabled'},
+          },
         }
       })
     },
     onSuccess: data => {
+      if (convoId) {
+        updateConvoOptimistic(queryClient, convoId, prev => {
+          if (!ChatBskyConvoDefs.isGroupConvo(prev.kind)) return undefined
+          return {
+            ...prev,
+            kind: {...prev.kind, joinLink: data.joinLink},
+          }
+        })
+      }
       onSuccess?.(data)
     },
     onError: (e, _variables, context) => {

--- a/src/state/queries/messages/leave-conversation.ts
+++ b/src/state/queries/messages/leave-conversation.ts
@@ -71,7 +71,7 @@ export function useLeaveConvo(
       return {prevPages}
     },
     onSuccess: data => {
-      queryClient.invalidateQueries({queryKey: [CONVO_LIST_KEY]})
+      void queryClient.invalidateQueries({queryKey: [CONVO_LIST_KEY]})
       onSuccess?.(data)
     },
     onError: (error, _, context) => {
@@ -89,7 +89,7 @@ export function useLeaveConvo(
           }
         },
       )
-      queryClient.invalidateQueries({queryKey: [CONVO_LIST_KEY]})
+      void queryClient.invalidateQueries({queryKey: [CONVO_LIST_KEY]})
       onError?.(error)
     },
   })

--- a/src/state/queries/messages/mute-conversation.ts
+++ b/src/state/queries/messages/mute-conversation.ts
@@ -1,18 +1,12 @@
-import {
-  type ChatBskyConvoDefs,
-  type ChatBskyConvoListConvos,
-  type ChatBskyConvoMuteConvo,
-} from '@atproto/api'
-import {
-  type InfiniteData,
-  useMutation,
-  useQueryClient,
-} from '@tanstack/react-query'
+import {type ChatBskyConvoMuteConvo} from '@atproto/api'
+import {useMutation, useQueryClient} from '@tanstack/react-query'
 
 import {DM_SERVICE_HEADERS} from '#/lib/constants'
 import {useAgent} from '#/state/session'
-import {RQKEY as CONVO_KEY} from './conversation'
-import {RQKEY_ROOT as CONVO_LIST_KEY} from './list-conversations'
+import {
+  rollbackConvoOptimistic,
+  updateConvoOptimistic,
+} from './utils/convo-cache'
 
 export function useMuteConvo(
   convoId: string | undefined,
@@ -46,59 +40,17 @@ export function useMuteConvo(
     },
     onMutate: ({mute}) => {
       if (!convoId) return
-
-      const prevConvo = queryClient.getQueryData<ChatBskyConvoDefs.ConvoView>(
-        CONVO_KEY(convoId),
-      )
-      const prevListEntries = queryClient.getQueriesData<
-        InfiniteData<ChatBskyConvoListConvos.OutputSchema>
-      >({queryKey: [CONVO_LIST_KEY]})
-
-      // Update for a single chat thread
-      queryClient.setQueryData<ChatBskyConvoDefs.ConvoView>(
-        CONVO_KEY(convoId),
-        prev => {
-          if (!prev) return
-          return {
-            ...prev,
-            muted: mute,
-          }
-        },
-      )
-
-      // Update for the chat list
-      queryClient.setQueriesData<
-        InfiniteData<ChatBskyConvoListConvos.OutputSchema>
-      >({queryKey: [CONVO_LIST_KEY]}, prev => {
-        if (!prev?.pages) return
-        return {
-          ...prev,
-          pages: prev.pages.map(page => ({
-            ...page,
-            convos: page.convos.map(convo => {
-              if (convo.id !== convoId) return convo
-              return {
-                ...convo,
-                muted: mute,
-              }
-            }),
-          })),
-        }
-      })
-
-      return {prevConvo, prevListEntries}
+      return updateConvoOptimistic(queryClient, convoId, prev => ({
+        ...prev,
+        muted: mute,
+      }))
     },
     onSuccess: data => {
       onSuccess?.(data)
     },
     onError: (e, _variables, context) => {
-      if (context?.prevConvo && convoId) {
-        queryClient.setQueryData(CONVO_KEY(convoId), context.prevConvo)
-      }
-      if (context?.prevListEntries) {
-        for (const [key, data] of context.prevListEntries) {
-          queryClient.setQueryData(key, data)
-        }
+      if (convoId && context) {
+        rollbackConvoOptimistic(queryClient, convoId, context)
       }
       onError?.(e)
     },

--- a/src/state/queries/messages/utils/convo-cache.ts
+++ b/src/state/queries/messages/utils/convo-cache.ts
@@ -1,0 +1,87 @@
+import {
+  type ChatBskyConvoDefs,
+  type ChatBskyConvoListConvos,
+} from '@atproto/api'
+import {
+  type InfiniteData,
+  type QueryClient,
+  type QueryKey,
+} from '@tanstack/react-query'
+
+import {RQKEY as CONVO_KEY} from '../conversation'
+import {RQKEY_ROOT as CONVO_LIST_KEY} from '../list-conversations'
+
+type ConvoUpdater = (
+  prev: ChatBskyConvoDefs.ConvoView,
+) => ChatBskyConvoDefs.ConvoView | undefined
+
+export type ConvoCacheSnapshot = {
+  prevConvo: ChatBskyConvoDefs.ConvoView | undefined
+  prevListEntries: Array<
+    [QueryKey, InfiniteData<ChatBskyConvoListConvos.OutputSchema> | undefined]
+  >
+}
+
+/**
+ * Writes an optimistic update to a convo across both the single-convo and
+ * convo-list caches. The updater receives the current ConvoView and returns
+ * the next one - return undefined to bail out (e.g. when the convo's kind
+ * doesn't match what the mutation requires). Returns a snapshot that can be
+ * passed to `rollbackConvoOptimistic`.
+ */
+export function updateConvoOptimistic(
+  queryClient: QueryClient,
+  convoId: string,
+  updater: ConvoUpdater,
+): ConvoCacheSnapshot {
+  const prevConvo = queryClient.getQueryData<ChatBskyConvoDefs.ConvoView>(
+    CONVO_KEY(convoId),
+  )
+  const prevListEntries = queryClient.getQueriesData<
+    InfiniteData<ChatBskyConvoListConvos.OutputSchema>
+  >({queryKey: [CONVO_LIST_KEY]})
+
+  queryClient.setQueryData<ChatBskyConvoDefs.ConvoView>(
+    CONVO_KEY(convoId),
+    prev => {
+      if (!prev) return
+      const next = updater(prev)
+      return next ?? prev
+    },
+  )
+
+  queryClient.setQueriesData<
+    InfiniteData<ChatBskyConvoListConvos.OutputSchema>
+  >({queryKey: [CONVO_LIST_KEY]}, prev => {
+    if (!prev?.pages) return
+    return {
+      ...prev,
+      pages: prev.pages.map(page => ({
+        ...page,
+        convos: page.convos.map(convo => {
+          if (convo.id !== convoId) return convo
+          const next = updater(convo)
+          return next ?? convo
+        }),
+      })),
+    }
+  })
+
+  return {prevConvo, prevListEntries}
+}
+
+/**
+ * Restores the caches to the state captured by `updateConvoOptimistic`.
+ */
+export function rollbackConvoOptimistic(
+  queryClient: QueryClient,
+  convoId: string,
+  snapshot: ConvoCacheSnapshot,
+) {
+  if (snapshot.prevConvo) {
+    queryClient.setQueryData(CONVO_KEY(convoId), snapshot.prevConvo)
+  }
+  for (const [key, data] of snapshot.prevListEntries) {
+    queryClient.setQueryData(key, data)
+  }
+}


### PR DESCRIPTION
Builds on #10318. Group clip clop invite links can now be created, edited, disabled, and re-enabled. Sharing is enabled in #10323.

Posting and sharing will come in a follow-up PR.

https://github.com/user-attachments/assets/c940220e-75d3-41a4-aa7b-77b52bdf9e67