### PR TITLE
Add ability to share and post group clip clop invites

### DIFF
--- a/src/screens/Messages/ConversationSettings.tsx
+++ b/src/screens/Messages/ConversationSettings.tsx
@@ -738,6 +738,15 @@ function SettingsHeader({
 
   const [isLocked, setIsLocked] = useState(false)
 
+  // TODO Enable this once the feature is working end-to-end. -dsb
+  // const {joinLink} = convo.details
+  const isJoinLinkEnabled = false
+  // const isJoinLinkEnabled =
+  //   isOwner || (!isOwner && joinLink?.enabledStatus === 'enabled')
+
+  // TODO Enable this once the feature is working end-to-end. -dsb
+  const isReportLinkEnabled = false
+
   const {mutate: editGroupName} = useEditGroupName(convo.view.id, {
     onError: e => {
       setNewGroupName(groupName)
@@ -862,12 +871,18 @@ function SettingsHeader({
               onPress={handlePromptName}
             />
           ) : null}
-          <SettingsButton
-            icon={ChainLinkIcon}
-            label={l`Create an invite link for this group chat`}
-            text={l`Invite link`}
-            onPress={inviteLinkDialog.open}
-          />
+          {isJoinLinkEnabled ? (
+            <SettingsButton
+              icon={ChainLinkIcon}
+              label={
+                isOwner
+                  ? l`Create or modify an invite link for this group chat`
+                  : l`View the invite link for this group chat`
+              }
+              text={l`Invite link`}
+              onPress={inviteLinkDialog.open}
+            />
+          ) : null}
           {isOwner ? (
             <SettingsButton
               color={isLocked ? 'negative_subtle' : 'secondary'}
@@ -879,7 +894,7 @@ function SettingsHeader({
               onPress={isLocked ? handleUnlock : lockChatPrompt.open}
             />
           ) : null}
-          {isOwner ? null : (
+          {isOwner ? null : isReportLinkEnabled ? (
             <SettingsButton
               color="secondary"
               icon={FlagIcon}
@@ -887,7 +902,7 @@ function SettingsHeader({
               text={l`Report`}
               onPress={handleReportChat}
             />
-          )}
+          ) : null}
           {isOwner ? null : (
             <SettingsButton
               color="secondary"
@@ -905,7 +920,11 @@ function SettingsHeader({
         onChangeText={setNewGroupName}
         onConfirm={handleEditName}
       />
-      <InviteLinkDialog convo={convo} control={inviteLinkDialog} />
+      <InviteLinkDialog
+        convo={convo}
+        control={inviteLinkDialog}
+        isOwner={isOwner}
+      />
       <LockChatPrompt control={lockChatPrompt} onConfirm={handleConfirmLock} />
       <LeaveChatPrompt
         control={leaveChatPrompt}

--- a/src/screens/Messages/components/InviteLinkDialog.tsx
+++ b/src/screens/Messages/components/InviteLinkDialog.tsx
@@ -2,6 +2,8 @@ import {useState} from 'react'
 import {View} from 'react-native'
 import {Trans, useLingui} from '@lingui/react/macro'
 
+import {useOpenComposer} from '#/lib/hooks/useOpenComposer'
+import {shareUrl} from '#/lib/sharing'
 import {useCreateJoinLink} from '#/state/queries/messages/create-join-link'
 import {useDisableJoinLink} from '#/state/queries/messages/disable-join-link'
 import {useEditJoinLink} from '#/state/queries/messages/edit-join-link'
@@ -64,6 +66,8 @@ export function InviteLinkDialog({
 
   const [step, setStep] = useState<Step>(initialStep)
   const [whoCanJoin, setWhoCanJoin] = useState(initialWhoCanJoin)
+
+  const {openComposer} = useOpenComposer()
 
   const {mutate: createJoinLink} = useCreateJoinLink(convo.view.id, {
     onSuccess: () => {
@@ -285,8 +289,14 @@ export function InviteLinkDialog({
                   enabledStatus === 'enabled' ? 'primary_subtle' : 'secondary'
                 }
                 style={[a.flex_1, a.rounded_full]}
-                // TODO Implement this. -dsb
-                onPress={() => {}}>
+                onPress={() => {
+                  control.close(() => {
+                    openComposer({
+                      text: joinLinkURI,
+                      logContext: 'Other',
+                    })
+                  })
+                }}>
                 <Trans>Post link</Trans>
               </StackedButton>
               <StackedButton
@@ -297,8 +307,9 @@ export function InviteLinkDialog({
                   enabledStatus === 'enabled' ? 'primary_subtle' : 'secondary'
                 }
                 style={[a.flex_1, a.rounded_full]}
-                // TODO Implement this. -dsb
-                onPress={() => {}}>
+                onPress={() => {
+                  void shareUrl(joinLinkURI)
+                }}>
                 <Trans>Share</Trans>
               </StackedButton>
             </View>

--- a/src/screens/Messages/components/InviteLinkDialog.tsx
+++ b/src/screens/Messages/components/InviteLinkDialog.tsx
@@ -3,6 +3,7 @@ import {View} from 'react-native'
 import {Trans, useLingui} from '@lingui/react/macro'
 
 import {useOpenComposer} from '#/lib/hooks/useOpenComposer'
+import {createSanitizedDisplayName} from '#/lib/moderation/create-sanitized-display-name'
 import {shareUrl} from '#/lib/sharing'
 import {useCreateJoinLink} from '#/state/queries/messages/create-join-link'
 import {useDisableJoinLink} from '#/state/queries/messages/disable-join-link'
@@ -22,6 +23,7 @@ import {ArrowRight_Stroke2_Corner0_Rounded as ArrowRightIcon} from '#/components
 import {ArrowShareRight_Stroke2_Corner2_Rounded as ArrowShareRightIcon} from '#/components/icons/ArrowShareRight'
 import {ChainLinkBroken_Stroke2_Corner0_Rounded as ChainLinkBrokenIcon} from '#/components/icons/ChainLink'
 import {EditBig_Stroke2_Corner0_Rounded as EditIcon} from '#/components/icons/EditBig'
+import {Loader} from '#/components/Loader'
 import * as Toast from '#/components/Toast'
 import {Text} from '#/components/Typography'
 import {IS_WEB} from '#/env'
@@ -47,74 +49,104 @@ const dateFormatter = new Intl.DateTimeFormat(undefined, {
 export function InviteLinkDialog({
   convo,
   control,
+  isOwner,
 }: {
   convo: Extract<ConvoWithDetails, {kind: 'group'}>
   control: Dialog.DialogOuterProps['control']
+  isOwner: boolean
 }) {
   const t = useTheme()
   const {t: l} = useLingui()
 
+  const ownerName = createSanitizedDisplayName(convo.primaryMember)
+
   const {joinLink} = convo.details
   const enabledStatus = joinLink?.enabledStatus
 
-  const initialStep = joinLink ? Step.MANAGE : Step.INFO
-  const initialWhoCanJoin = joinLink
+  const defaultStep = joinLink ? Step.MANAGE : Step.INFO
+  const defaultWhoCanJoin = joinLink
     ? [
         `${joinLink.joinRule}${joinLink.requireApproval ? ':requireApproval' : ''}`,
       ]
     : ['anyone']
 
-  const [step, setStep] = useState<Step>(initialStep)
-  const [whoCanJoin, setWhoCanJoin] = useState(initialWhoCanJoin)
+  const [step, setStep] = useState<Step>(defaultStep)
+  const [whoCanJoin, setWhoCanJoin] = useState(defaultWhoCanJoin)
 
   const {openComposer} = useOpenComposer()
 
-  const {mutate: createJoinLink} = useCreateJoinLink(convo.view.id, {
-    onSuccess: () => {
-      setStep(Step.MANAGE)
+  const {mutate: createJoinLink, isPending: isCreating} = useCreateJoinLink(
+    convo.view.id,
+    {
+      onSuccess: () => {
+        setStep(Step.MANAGE)
+      },
+      onError: () => {
+        Toast.show(l`Failed to create invite link`, {
+          type: 'error',
+        })
+      },
     },
-    onError: () => {
-      Toast.show(l`Failed to create invite link`, {
-        type: 'error',
-      })
+  )
+  const {mutate: editJoinLink, isPending: isEditing} = useEditJoinLink(
+    convo.view.id,
+    {
+      onSuccess: () => {
+        setStep(Step.MANAGE)
+      },
+      onError: () => {
+        Toast.show(l`Failed to edit invite link`, {
+          type: 'error',
+        })
+      },
     },
-  })
-  const {mutate: editJoinLink} = useEditJoinLink(convo.view.id, {
-    onSuccess: () => {
-      setStep(Step.MANAGE)
+  )
+  const {mutate: disableJoinLink, isPending: isDisabling} = useDisableJoinLink(
+    convo.view.id,
+    {
+      onError: () => {
+        Toast.show(l`Failed to disable invite link`, {
+          type: 'error',
+        })
+      },
     },
-    onError: () => {
-      Toast.show(l`Failed to edit invite link`, {
-        type: 'error',
-      })
+  )
+  const {mutate: enableJoinLink, isPending: isEnabling} = useEnableJoinLink(
+    convo.view.id,
+    {
+      onError: () => {
+        Toast.show(l`Failed to enable invite link`, {
+          type: 'error',
+        })
+      },
     },
-  })
-  const {mutate: disableJoinLink} = useDisableJoinLink(convo.view.id, {
-    onError: () => {
-      Toast.show(l`Failed to disable invite link`, {
-        type: 'error',
-      })
-    },
-  })
-  const {mutate: enableJoinLink} = useEnableJoinLink(convo.view.id, {
-    onError: () => {
-      Toast.show(l`Failed to enable invite link`, {
-        type: 'error',
-      })
-    },
-  })
+  )
+  const isSaving = isCreating || isEditing
 
   const whoCanJoinOptions = [
-    {name: 'anyone', label: l`Anyone can join instantly`},
-    {name: 'anyone:requireApproval', label: l`Anyone can request to join`},
-    {name: 'followedByOwner', label: l`People I follow can join instantly`},
+    {
+      name: 'anyone',
+      owner: l`Anyone can join instantly`,
+      member: l`Anyone can join instantly`,
+    },
+    {
+      name: 'anyone:requireApproval',
+      owner: l`Anyone can request to join`,
+      member: l`Anyone can request to join`,
+    },
+    {
+      name: 'followedByOwner',
+      owner: l`People I follow can join instantly`,
+      member: l`People ${ownerName} follows can join instantly`,
+    },
     {
       name: 'followedByOwner:requireApproval',
-      label: l`People I follow can request to join`,
+      owner: l`People I follow can request to join`,
+      member: l`People ${ownerName} follows can request to join`,
     },
   ]
 
-  let content: React.ReactNode | null = null
+  let content: React.ReactNode = null
   let header: string | null = null
   switch (step) {
     case Step.INFO:
@@ -173,11 +205,14 @@ export function InviteLinkDialog({
                   <Toggle.Item
                     key={option.name}
                     highlightRow={true}
-                    label={option.label}
+                    label={isOwner ? option.owner : option.member}
                     name={option.name}
                     style={[a.flex_1]}>
                     {({selected}) => (
-                      <TargetOption label={option.label} selected={selected} />
+                      <TargetOption
+                        label={isOwner ? option.owner : option.member}
+                        selected={selected}
+                      />
                     )}
                   </Toggle.Item>
                 ))}
@@ -189,6 +224,7 @@ export function InviteLinkDialog({
               label={l`Generate invite link`}
               color="primary"
               size="large"
+              disabled={isSaving}
               onPress={() => {
                 const parts = whoCanJoin[0].split(':')
                 const joinRule = parts[0]
@@ -210,28 +246,30 @@ export function InviteLinkDialog({
                   ? l`Update invite link`
                   : l`Generate invite link`}
               </ButtonText>
-              <ButtonIcon icon={ArrowRightIcon} />
+              <ButtonIcon icon={isSaving ? Loader : ArrowRightIcon} />
             </Button>
           </View>
         </>
       )
       break
-    case Step.MANAGE:
-      const joinLinkURI =
-        joinLink && joinLink.code !== ''
-          ? `https://bsky.app/chat/${joinLink.code}`
-          : 'https://bsky.app/chat'
+    case Step.MANAGE: {
+      const hasJoinLinkCode = joinLink && joinLink.code !== ''
+      const joinLinkURI = hasJoinLinkCode
+        ? `https://bsky.app/chat/${joinLink.code}`
+        : 'https://bsky.app/chat'
       const createdAt = joinLink ? new Date(joinLink.createdAt) : null
-      const value =
-        whoCanJoinOptions.find(o => o.name === whoCanJoin[0])?.label ??
-        whoCanJoinOptions[0].label
+      const currentOption = whoCanJoinOptions.find(
+        o => o.name === whoCanJoin[0],
+      )
+      const ownerValue = currentOption?.owner ?? whoCanJoinOptions[0].owner
+      const memberValue = currentOption?.member ?? whoCanJoinOptions[0].member
       header =
         enabledStatus === 'enabled' ? l`Invite link` : l`Invite link disabled`
       content = (
         <>
           <View style={[a.mt_lg]}>
             <CopyTextButton
-              disabled={enabledStatus === 'disabled'}
+              disabled={enabledStatus === 'disabled' || !hasJoinLinkCode}
               label={l`Invite link`}
               value={joinLinkURI}>
               <Text
@@ -257,37 +295,47 @@ export function InviteLinkDialog({
           </View>
           {enabledStatus === 'enabled' ? (
             <View style={[a.mt_lg]}>
-              <EditTextButton
-                label={l`Edit link settings`}
-                value={value}
-                onPress={() => setStep(Step.GENERATE)}>
-                <Text
-                  numberOfLines={1}
-                  style={[a.mr_xs, a.text_md, t.atoms.text, {maxWidth: '80%'}]}>
-                  {value}
-                </Text>
-              </EditTextButton>
+              {isOwner ? (
+                <EditTextButton
+                  label={l`Edit link settings`}
+                  value={ownerValue}
+                  onPress={() => setStep(Step.GENERATE)}>
+                  <Text
+                    numberOfLines={1}
+                    style={[
+                      a.mr_xs,
+                      a.text_md,
+                      t.atoms.text,
+                      {maxWidth: '80%'},
+                    ]}>
+                    {ownerValue}
+                  </Text>
+                </EditTextButton>
+              ) : (
+                <Text style={[a.text_sm, t.atoms.text]}>{memberValue}</Text>
+              )}
             </View>
           ) : null}
           {enabledStatus === 'enabled' ? (
             <View style={[a.flex_row, a.justify_between, a.gap_sm, a.mt_lg]}>
-              <StackedButton
-                label={l`Disable`}
-                icon={ChainLinkBrokenIcon}
-                color="negative_subtle"
-                style={[a.flex_1, a.rounded_full]}
-                onPress={() => {
-                  disableJoinLink()
-                }}>
-                <Trans>Disable</Trans>
-              </StackedButton>
+              {isOwner ? (
+                <StackedButton
+                  label={l`Disable`}
+                  icon={isDisabling ? Loader : ChainLinkBrokenIcon}
+                  color="negative_subtle"
+                  style={[a.flex_1, a.rounded_full]}
+                  disabled={isDisabling}
+                  onPress={() => {
+                    disableJoinLink()
+                  }}>
+                  <Trans>Disable</Trans>
+                </StackedButton>
+              ) : null}
               <StackedButton
                 disabled={enabledStatus === 'disabled'}
                 label={l`Post link`}
                 icon={EditIcon}
-                color={
-                  enabledStatus === 'enabled' ? 'primary_subtle' : 'secondary'
-                }
+                color="primary_subtle"
                 style={[a.flex_1, a.rounded_full]}
                 onPress={() => {
                   control.close(() => {
@@ -303,9 +351,7 @@ export function InviteLinkDialog({
                 disabled={enabledStatus === 'disabled'}
                 label={l`Share`}
                 icon={ArrowShareRightIcon}
-                color={
-                  enabledStatus === 'enabled' ? 'primary_subtle' : 'secondary'
-                }
+                color="primary_subtle"
                 style={[a.flex_1, a.rounded_full]}
                 onPress={() => {
                   void shareUrl(joinLinkURI)
@@ -319,12 +365,14 @@ export function InviteLinkDialog({
                 label={l`Re-enable invite link`}
                 color="primary"
                 size="large"
+                disabled={isEnabling}
                 onPress={() => {
                   enableJoinLink()
                 }}>
                 <ButtonText>
                   <Trans>Re-enable link</Trans>
                 </ButtonText>
+                {isEnabling && <ButtonIcon icon={Loader} />}
               </Button>
               <Button
                 label={l`Generate new invite link`}
@@ -340,14 +388,39 @@ export function InviteLinkDialog({
         </>
       )
       break
+    }
+  }
+
+  if (!isOwner && (!joinLink || joinLink?.enabledStatus === 'disabled')) {
+    header = l`Invite link`
+    content = (
+      <>
+        <View style={[a.mt_lg]}>
+          <Text style={[a.text_sm, t.atoms.text]}>
+            <Trans>There is no invite link for this group chat.</Trans>
+          </Text>
+        </View>
+        <View style={[a.gap_md, a.mt_lg]}>
+          <Button
+            label={l`Close`}
+            color="primary"
+            size="large"
+            onPress={() => control.close()}>
+            <ButtonText>
+              <Trans>Close</Trans>
+            </ButtonText>
+          </Button>
+        </View>
+      </>
+    )
   }
 
   return (
     <Dialog.Outer
       control={control}
       onClose={() => {
-        setStep(initialStep)
-        setWhoCanJoin(initialWhoCanJoin)
+        setStep(defaultStep)
+        setWhoCanJoin(defaultWhoCanJoin)
       }}>
       <Dialog.Handle />
       <Dialog.ScrollableInner

--- a/src/screens/Messages/components/MessagesListInfoPanel.tsx
+++ b/src/screens/Messages/components/MessagesListInfoPanel.tsx
@@ -19,7 +19,7 @@ export function MessagesListInfoPanel({convoState}: {convoState: ConvoState}) {
   const {t: l} = useLingui()
 
   const addMembersControl = Dialog.useDialogControl()
-  const inviteLinkPrompt = Dialog.useDialogControl()
+  const inviteLinkControl = Dialog.useDialogControl()
 
   const {currentAccount} = useSession()
 
@@ -27,6 +27,11 @@ export function MessagesListInfoPanel({convoState}: {convoState: ConvoState}) {
     ? parseConvoView(convoState.convo, currentAccount?.did)
     : null
   const groupConvo = convo?.kind === 'group' ? convo : null
+  // TODO Enable this once the feature is working end-to-end. -dsb
+  // const joinLink = groupConvo?.details.joinLink
+  const isJoinLinkEnabled = false
+  //   (isOwner && groupConvo) ||
+  //   (!isOwner && groupConvo && joinLink?.enabledStatus === 'enabled')
 
   const isOwner =
     currentAccount?.did == null
@@ -110,12 +115,16 @@ export function MessagesListInfoPanel({convoState}: {convoState: ConvoState}) {
                 </ButtonText>
               </Button>
             ) : null}
-            {isOwner && groupConvo ? (
+            {isJoinLinkEnabled ? (
               <Button
                 color="secondary"
                 size="small"
-                label={l`Click here to create or manage an invite link for this group chat`}
-                onPress={() => inviteLinkPrompt.open()}>
+                label={
+                  isOwner
+                    ? l`Click here to create or manage an invite link for this group chat`
+                    : l`Click here to view the invite link for this group chat`
+                }
+                onPress={inviteLinkControl.open}>
                 <ButtonIcon icon={ChainLinkIcon} />
                 <ButtonText>
                   <Trans>Invite link</Trans>
@@ -126,7 +135,11 @@ export function MessagesListInfoPanel({convoState}: {convoState: ConvoState}) {
         ) : null}
       </View>
       {groupConvo ? (
-        <InviteLinkDialog convo={groupConvo} control={inviteLinkPrompt} />
+        <InviteLinkDialog
+          isOwner={isOwner}
+          convo={groupConvo}
+          control={inviteLinkControl}
+        />
       ) : null}
       <Dialog.Outer
         control={addMembersControl}


### PR DESCRIPTION
Builds on #10322. Group clip clop links can now be posted and shared. Members’ view is updated in #10325.

https://github.com/user-attachments/assets/d80bfed0-db01-4185-b1e4-07301d4cde13