### PR TITLE
[Chat] Convo refactor - Move convo/member data fetching into React Query

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
   },
   "dependencies": {
     "@atproto/api": "^0.19.11",
-    "@atproto/syntax": "0.5.2",
+    "@atproto/syntax": "0.5.4",
     "@bitdrift/react-native": "^0.6.8",
     "@braintree/sanitize-url": "^6.0.2",
     "@bsky.app/alf": "^0.1.7",

--- a/src/components/dms/MessageContextMenu.tsx
+++ b/src/components/dms/MessageContextMenu.tsx
@@ -183,7 +183,7 @@ export let MessageContextMenu = ({
         control={reportControl}
         subject={{
           view: 'message',
-          convoId: convo.convo.id,
+          convoId: convo.convo.view.id,
           message,
         }}
         onAfterSubmit={() => {
@@ -197,7 +197,7 @@ export let MessageContextMenu = ({
         control={blockOrDeleteControl}
         currentScreen="conversation"
         params={{
-          convoId: convo.convo.id,
+          convoId: convo.convo.view.id,
           message,
         }}
       />

--- a/src/components/dms/SystemMessageItem.tsx
+++ b/src/components/dms/SystemMessageItem.tsx
@@ -9,7 +9,7 @@ import {Text} from '#/components/Typography'
 export function SystemMessageItem({
   item,
 }: {
-  item: ConvoItem & {type: 'system-message'}
+  item: Extract<ConvoItem, {type: 'system-message'}>
 }) {
   const t = useTheme()
   const {i18n} = useLingui()

--- a/src/components/dms/getSystemMessageInfo.ts
+++ b/src/components/dms/getSystemMessageInfo.ts
@@ -1,4 +1,4 @@
-import {type ChatBskyActorDefs, ChatBskyConvoDefs} from '@atproto/api'
+import {ChatBskyConvoDefs} from '@atproto/api'
 import {type MessageDescriptor} from '@lingui/core'
 import {msg} from '@lingui/core/macro'
 
@@ -15,6 +15,7 @@ import {
   Unlock_Stroke2_Corner2_Rounded as UnlockIcon,
 } from '#/components/icons/Lock'
 import {PencilLine_Stroke2_Corner0_Rounded as PencilIcon} from '#/components/icons/Pencil'
+import type * as bsky from '#/types/bsky'
 
 export type SystemMessageInfo = {
   message: MessageDescriptor
@@ -23,7 +24,7 @@ export type SystemMessageInfo = {
 
 function getReferredDisplayName(
   user: ChatBskyConvoDefs.SystemMessageReferredUser,
-  relatedProfiles: ChatBskyActorDefs.ProfileViewBasic[],
+  relatedProfiles: bsky.profile.AnyProfileView[],
 ): string | null {
   const profile = relatedProfiles.find(p => p.did === user.did)
   return profile ? createSanitizedDisplayName(profile) : null
@@ -31,7 +32,7 @@ function getReferredDisplayName(
 
 export function getSystemMessageInfo(
   data: ChatBskyConvoDefs.SystemMessageView['data'],
-  relatedProfiles: ChatBskyActorDefs.ProfileViewBasic[],
+  relatedProfiles: bsky.profile.AnyProfileView[],
 ): SystemMessageInfo | null {
   if (ChatBskyConvoDefs.isSystemMessageDataAddMember(data)) {
     const name = getReferredDisplayName(data.member, relatedProfiles)

--- a/src/components/dms/util.ts
+++ b/src/components/dms/util.ts
@@ -87,7 +87,10 @@ export type ConvoWithDetails = {view: ChatBskyConvoDefs.ConvoView} & (
 export function parseConvoView(
   convoView: ChatBskyConvoDefs.ConvoView,
   ownDid: string | undefined,
+  allMembers?: ChatBskyActorDefs.ProfileViewBasic[],
 ): ConvoWithDetails | null {
+  const memberList = allMembers ?? convoView.members
+
   if (
     bsky.dangerousIsType<ChatBskyConvoDefs.GroupConvo>(
       convoView.kind,
@@ -96,7 +99,7 @@ export function parseConvoView(
   ) {
     let owner: GroupConvoMember | undefined = undefined
 
-    for (const member of convoView.members) {
+    for (const member of memberList) {
       if (
         bsky.dangerousIsType<ChatBskyActorDefs.GroupConvoMember>(
           member.kind,
@@ -104,9 +107,6 @@ export function parseConvoView(
         )
       ) {
         if (member.kind.role === 'owner') {
-          // have to do a type assertion here
-          // this works: {...member, kind: member.kind}
-          // however that's creating a new object for no good reason
           owner = member as GroupConvoMember
         }
       } else {
@@ -127,7 +127,7 @@ export function parseConvoView(
       kind: 'group',
       details: convoView.kind,
       primaryMember: owner,
-      members: convoView.members as Array<GroupConvoMember>,
+      members: memberList as Array<GroupConvoMember>,
     }
   } else if (
     bsky.dangerousIsType<ChatBskyConvoDefs.DirectConvo>(
@@ -135,7 +135,7 @@ export function parseConvoView(
       ChatBskyConvoDefs.isDirectConvo,
     )
   ) {
-    const otherUser = convoView.members.find(m => m.did !== ownDid)
+    const otherUser = memberList.find(m => m.did !== ownDid)
 
     if (!otherUser) {
       logger.warn('No other user found in direct convo')
@@ -147,7 +147,7 @@ export function parseConvoView(
       kind: 'direct',
       details: convoView.kind,
       primaryMember: otherUser as DirectConvoMember,
-      members: convoView.members as Array<DirectConvoMember>,
+      members: memberList as Array<DirectConvoMember>,
     }
   } else {
     logger.warn('Unknown convo kind: ' + JSON.stringify(convoView.kind))

--- a/src/screens/Messages/ConversationSettings.tsx
+++ b/src/screens/Messages/ConversationSettings.tsx
@@ -34,7 +34,7 @@ import {AvatarBubbles} from '#/components/AvatarBubbles'
 import {Button, type ButtonColor, ButtonIcon} from '#/components/Button'
 import * as Dialog from '#/components/Dialog'
 import {AddMembersFlow} from '#/components/dms/AddMembersFlow'
-import {type ConvoWithDetails, parseConvoView} from '#/components/dms/util'
+import {type ConvoWithDetails} from '#/components/dms/util'
 import {Error} from '#/components/Error'
 import * as TextField from '#/components/forms/TextField'
 import {useInteractionState} from '#/components/hooks/useInteractionState'
@@ -129,8 +129,6 @@ function SettingsInner() {
   const {currentAccount} = useSession()
 
   const convo = convoState.convo
-    ? parseConvoView(convoState.convo, currentAccount?.did)
-    : null
   const primaryMember = convo?.primaryMember
   const isOwner = !!primaryMember && primaryMember.did === currentAccount?.did
 

--- a/src/screens/Messages/components/ChatStatusInfo.tsx
+++ b/src/screens/Messages/components/ChatStatusInfo.tsx
@@ -5,7 +5,6 @@ import {useLingui} from '@lingui/react'
 
 import {type ActiveConvoStates} from '#/state/messages/convo'
 import {useModerationOpts} from '#/state/preferences/moderation-opts'
-import {useSession} from '#/state/session'
 import {atoms as a, useTheme} from '#/alf'
 import {LeaveConvoPrompt} from '#/components/dms/LeaveConvoPrompt'
 import {KnownFollowers} from '#/components/KnownFollowers'
@@ -16,16 +15,16 @@ export function ChatStatusInfo({convoState}: {convoState: ActiveConvoStates}) {
   const t = useTheme()
   const {_} = useLingui()
   const moderationOpts = useModerationOpts()
-  const {currentAccount} = useSession()
   const leaveConvoControl = usePromptControl()
 
   const onAcceptChat = useCallback(() => {
     convoState.markConvoAccepted()
   }, [convoState])
 
-  const otherUser = convoState.recipients.find(
-    user => user.did !== currentAccount?.did,
-  )
+  const otherUser =
+    convoState.convo.kind === 'direct'
+      ? convoState.convo.primaryMember
+      : undefined
 
   if (!moderationOpts) {
     return null
@@ -44,7 +43,7 @@ export function ChatStatusInfo({convoState}: {convoState: ActiveConvoStates}) {
         {otherUser && (
           <RejectMenu
             label={_(msg`Block or report`)}
-            convo={convoState.convo}
+            convo={convoState.convo.view}
             profile={otherUser}
             color="negative_subtle"
             size="small"
@@ -53,14 +52,14 @@ export function ChatStatusInfo({convoState}: {convoState: ActiveConvoStates}) {
         )}
         <DeleteChatButton
           label={_(msg`Delete`)}
-          convo={convoState.convo}
+          convo={convoState.convo.view}
           color="secondary"
           size="small"
           currentScreen="conversation"
           onPress={leaveConvoControl.open}
         />
         <LeaveConvoPrompt
-          convoId={convoState.convo.id}
+          convoId={convoState.convo.view.id}
           control={leaveConvoControl}
           currentScreen="conversation"
           hasMessages={false}
@@ -69,7 +68,7 @@ export function ChatStatusInfo({convoState}: {convoState: ActiveConvoStates}) {
       <View style={[a.w_full, a.flex_row]}>
         <AcceptChatButton
           onAcceptConvo={onAcceptChat}
-          convo={convoState.convo}
+          convo={convoState.convo.view}
           color="primary_subtle"
           size="small"
           currentScreen="conversation"

--- a/src/screens/Messages/components/MessagesList.tsx
+++ b/src/screens/Messages/components/MessagesList.tsx
@@ -373,13 +373,14 @@ export function MessagesList({
 
   const renderItem = ({item}: {item: ConvoItem}) => {
     if (item.type === 'message' || item.type === 'pending-message') {
+      const profile = item.relatedProfiles.find(
+        p => p.did === item.message.sender.did,
+      )
       return (
         <MessageItem
           item={item}
-          profile={convoState.convo.members.find(
-            member => member.did === item.message.sender.did,
-          )}
-          isGroupChat={convoState.isGroup()}
+          profile={profile}
+          isGroupChat={convoState.convo.kind === 'group'}
         />
       )
     } else if (item.type === 'deleted-message') {
@@ -448,7 +449,8 @@ export function MessagesList({
             ListHeaderComponent={
               <>
                 <MaybeLoader isLoading={convoState.isFetchingHistory} />
-                {convoState.isGroup() && convoState.hasAllHistory ? (
+                {convoState.convo.kind === 'group' &&
+                convoState.hasAllHistory ? (
                   <MessagesListInfoPanel convoState={convoState} />
                 ) : null}
               </>
@@ -577,7 +579,7 @@ function getFooterState(
     }
   }
 
-  if (convoState.convo.status === 'request' && !hasAcceptOverride) {
+  if (convoState.convo.view.status === 'request' && !hasAcceptOverride) {
     return 'request'
   }
 

--- a/src/screens/Messages/components/MessagesListInfoPanel.tsx
+++ b/src/screens/Messages/components/MessagesListInfoPanel.tsx
@@ -20,16 +20,19 @@ export function MessagesListInfoPanel({convoState}: {convoState: ConvoState}) {
 
   const {currentAccount} = useSession()
 
+  const convo = convoState.convo
+  const isGroup = convo?.kind === 'group'
+
   const isOwner =
-    currentAccount?.did == null
+    currentAccount?.did == null || !isGroup
       ? false
-      : convoState.getPrimaryMember?.()?.did === currentAccount.did
+      : convo.primaryMember.did === currentAccount.did
   // TODO Get this from @api/atproto - dsb
   const isLinkEnabled = false
 
-  const groupName = convoState.getGroupInfo?.()?.name
+  const groupName = isGroup ? convo.details.name : undefined
 
-  const members = (convoState?.convo?.members ?? []).filter(
+  const members = (convo?.members ?? []).filter(
     profile => profile.did !== currentAccount?.did,
   )
 

--- a/src/state/messages/convo/agent.ts
+++ b/src/state/messages/convo/agent.ts
@@ -1,6 +1,6 @@
 import {
   type AtpAgent,
-  ChatBskyActorDefs,
+  type ChatBskyActorDefs,
   ChatBskyConvoDefs,
   type ChatBskyConvoGetLog,
   type ChatBskyConvoSendMessage,
@@ -19,6 +19,7 @@ import {Logger} from '#/logger'
 import {
   ACTIVE_POLL_INTERVAL,
   BACKGROUND_POLL_INTERVAL,
+  GET_MESSAGE_HISTORY_LIMIT,
   INACTIVE_TIMEOUT,
   NETWORK_FAILURE_STATUSES,
 } from '#/state/messages/convo/const'
@@ -26,7 +27,6 @@ import {
   type ConvoDispatch,
   ConvoDispatchEvent,
   type ConvoError,
-  ConvoErrorCode,
   type ConvoEvent,
   type ConvoItem,
   ConvoItemError,
@@ -36,8 +36,8 @@ import {
 } from '#/state/messages/convo/types'
 import {type MessagesEventBus} from '#/state/messages/events/agent'
 import {type MessagesEventBusError} from '#/state/messages/events/types'
-import {IS_NATIVE} from '#/env'
-import * as bsky from '#/types/bsky'
+import {type ConvoWithDetails, parseConvoView} from '#/components/dms/util'
+import type * as bsky from '#/types/bsky'
 
 const logger = Logger.create(Logger.Context.ConversationAgent)
 
@@ -102,10 +102,7 @@ export class Convo {
     {id: string; message: ChatBskyConvoSendMessage.InputSchema['message']}
   > = new Map()
   private deletedMessages: Set<string> = new Set()
-  private systemMessageProfiles: Map<
-    string,
-    ChatBskyActorDefs.ProfileViewBasic
-  > = new Map()
+  private relatedProfiles: Map<string, bsky.profile.AnyProfileView> = new Map()
 
   private isProcessingPendingMessages = false
 
@@ -114,9 +111,7 @@ export class Convo {
   private emitter = new EventEmitter<{event: [ConvoEvent]}>()
 
   convoId: string
-  convo: ChatBskyConvoDefs.ConvoView | undefined
-  sender: ChatBskyActorDefs.ProfileViewBasic | undefined
-  recipients: ChatBskyActorDefs.ProfileViewBasic[] | undefined
+  convo: ConvoWithDetails | undefined
   snapshot: ConvoState | undefined
 
   constructor(params: ConvoParams) {
@@ -126,8 +121,8 @@ export class Convo {
     this.events = params.events
     this.senderUserDid = params.agent.assertDid
 
-    if (params.placeholderData) {
-      this.setupPlaceholderData(params.placeholderData)
+    if (params.initialData) {
+      this.setupInitialData(params.initialData)
     }
 
     this.subscribe = this.subscribe.bind(this)
@@ -141,10 +136,6 @@ export class Convo {
     this.markConvoAccepted = this.markConvoAccepted.bind(this)
     this.addReaction = this.addReaction.bind(this)
     this.removeReaction = this.removeReaction.bind(this)
-    this.isGroup = this.isGroup.bind(this)
-    this.getGroupInfo = this.getGroupInfo.bind(this)
-    this.getPrimaryMember = this.getPrimaryMember.bind(this)
-    this.updateGroupName = this.updateGroupName.bind(this)
   }
 
   private commit() {
@@ -179,8 +170,6 @@ export class Convo {
           items: [],
           convo: this.convo,
           error: undefined,
-          sender: this.sender,
-          recipients: this.recipients,
           isFetchingHistory: this.isFetchingHistory,
           // Explicit null check since the value is initially undefined.
           hasAllHistory: this.oldestRev === null,
@@ -190,9 +179,6 @@ export class Convo {
           markConvoAccepted: undefined,
           addReaction: undefined,
           removeReaction: undefined,
-          isGroup: this.isGroup,
-          getGroupInfo: this.getGroupInfo,
-          getPrimaryMember: this.getPrimaryMember,
         }
       }
       case ConvoStatus.Disabled:
@@ -204,8 +190,6 @@ export class Convo {
           items: this.getItems(),
           convo: this.convo!,
           error: undefined,
-          sender: this.sender!,
-          recipients: this.recipients!,
           isFetchingHistory: this.isFetchingHistory,
           // Explicit null check since the value is initially undefined.
           hasAllHistory: this.oldestRev === null,
@@ -215,10 +199,7 @@ export class Convo {
           markConvoAccepted: this.markConvoAccepted,
           addReaction: this.addReaction,
           removeReaction: this.removeReaction,
-          isGroup: this.isGroup,
-          getGroupInfo: this.getGroupInfo,
-          getPrimaryMember: this.getPrimaryMember,
-        }
+        } as ConvoState
       }
       case ConvoStatus.Error: {
         return {
@@ -226,8 +207,6 @@ export class Convo {
           items: [],
           convo: undefined,
           error: this.error!,
-          sender: undefined,
-          recipients: undefined,
           isFetchingHistory: false,
           hasAllHistory: false,
           deleteMessage: undefined,
@@ -236,9 +215,6 @@ export class Convo {
           markConvoAccepted: undefined,
           addReaction: undefined,
           removeReaction: undefined,
-          isGroup: undefined,
-          getGroupInfo: undefined,
-          getPrimaryMember: undefined,
         }
       }
       default: {
@@ -247,8 +223,6 @@ export class Convo {
           items: [],
           convo: this.convo,
           error: undefined,
-          sender: this.sender,
-          recipients: this.recipients,
           isFetchingHistory: false,
           // Explicit null check since the value is initially undefined.
           hasAllHistory: this.oldestRev === null,
@@ -258,9 +232,6 @@ export class Convo {
           markConvoAccepted: undefined,
           addReaction: undefined,
           removeReaction: undefined,
-          isGroup: this.isGroup,
-          getGroupInfo: this.getGroupInfo,
-          getPrimaryMember: this.getPrimaryMember,
         }
       }
     }
@@ -274,7 +245,7 @@ export class Convo {
         switch (action.event) {
           case ConvoDispatchEvent.Init: {
             this.status = ConvoStatus.Initializing
-            void this.setup()
+            this.setup()
             this.setupFirehose()
             this.requestPollInterval(ACTIVE_POLL_INTERVAL)
             break
@@ -321,7 +292,6 @@ export class Convo {
       case ConvoStatus.Ready: {
         switch (action.event) {
           case ConvoDispatchEvent.Resume: {
-            void this.refreshConvo()
             this.requestPollInterval(ACTIVE_POLL_INTERVAL)
             break
           }
@@ -360,11 +330,10 @@ export class Convo {
             } else {
               if (this.convo) {
                 this.status = ConvoStatus.Ready
-                void this.refreshConvo()
                 this.maybeRecoverFromNetworkError()
               } else {
                 this.status = ConvoStatus.Initializing
-                void this.setup()
+                this.setup()
               }
               this.requestPollInterval(ACTIVE_POLL_INTERVAL)
             }
@@ -460,8 +429,6 @@ export class Convo {
 
   private reset() {
     this.convo = undefined
-    this.sender = undefined
-    this.recipients = undefined
     this.snapshot = undefined
 
     this.status = ConvoStatus.Uninitialized
@@ -473,7 +440,7 @@ export class Convo {
     this.newMessages = new Map()
     this.pendingMessages = new Map()
     this.deletedMessages = new Set()
-    this.systemMessageProfiles = new Map()
+    this.relatedProfiles = new Map()
 
     this.pendingMessageFailure = null
     this.fetchMessageHistoryError = undefined
@@ -498,68 +465,62 @@ export class Convo {
     }
   }
 
-  /**
-   * Initialises the convo with placeholder data, if provided. We still refetch it before rendering the convo,
-   * but this allows us to render the convo header immediately.
-   */
-  private setupPlaceholderData(
-    data: NonNullable<ConvoParams['placeholderData']>,
-  ) {
-    this.convo = data.convo
-    this.sender = data.convo.members.find(m => m.did === this.senderUserDid)
-    this.recipients = data.convo.members.filter(
-      m => m.did !== this.senderUserDid,
-    )
+  private setupInitialData(data: NonNullable<ConvoParams['initialData']>) {
+    if (data.convo) {
+      if (data.members) {
+        this.setConvoData(data.convo, data.members)
+      } else {
+        const parsed = parseConvoView(data.convo, this.senderUserDid)
+        if (parsed) {
+          this.convo = parsed
+        }
+        for (const member of data.convo.members) {
+          this.relatedProfiles.set(member.did, member)
+        }
+      }
+    }
   }
 
-  private async setup() {
-    try {
-      const {convo, sender, recipients} = await this.fetchConvo()
+  private setup() {
+    this.tryReady()
+  }
 
-      this.convo = convo
-      this.sender = sender
-      this.recipients = recipients
+  private tryReady() {
+    if (this.status !== ConvoStatus.Initializing) return
+    if (!this.convo) return
 
-      /*
-       * Some validation prior to `Ready` status
-       */
-      if (!this.convo) {
-        throw new Error('could not find convo')
-      }
-      if (!this.sender) {
-        throw new Error('could not find sender in convo')
-      }
-      if (!this.recipients) {
-        throw new Error('could not find recipients in convo')
-      }
+    const self = this.relatedProfiles.get(this.senderUserDid)
+    if (!self) return
 
-      const userIsDisabled = Boolean(this.sender.chatDisabled)
+    const userIsDisabled = Boolean('chatDisabled' in self && self.chatDisabled)
 
-      if (userIsDisabled) {
-        this.dispatch({event: ConvoDispatchEvent.Disable})
-      } else {
-        this.dispatch({event: ConvoDispatchEvent.Ready})
-      }
-    } catch (err) {
-      const e = err as Error
-      if (!isNetworkError(e) && !isErrorMaybeAppPasswordPermissions(e)) {
-        logger.error('setup failed', {
-          safeMessage: e.message,
-        })
-      }
-
-      this.dispatch({
-        event: ConvoDispatchEvent.Error,
-        payload: {
-          exception: e,
-          code: ConvoErrorCode.InitFailed,
-          retry: () => {
-            this.reset()
-          },
-        },
-      })
-      this.commit()
+    if (userIsDisabled) {
+      this.dispatch({event: ConvoDispatchEvent.Disable})
+    } else {
+      this.dispatch({event: ConvoDispatchEvent.Ready})
     }
+  }
+
+  setConvoData(
+    convo: ChatBskyConvoDefs.ConvoView,
+    members: ChatBskyActorDefs.ProfileViewBasic[],
+  ) {
+    const parsed = parseConvoView(convo, this.senderUserDid, members)
+    if (!parsed) return
+
+    this.convo = parsed
+
+    for (const member of members) {
+      this.relatedProfiles.set(member.did, member)
+    }
+    for (const member of convo.members) {
+      if (!this.relatedProfiles.has(member.did)) {
+        this.relatedProfiles.set(member.did, member)
+      }
+    }
+
+    this.tryReady()
+    this.commit()
   }
 
   init() {
@@ -601,59 +562,6 @@ export class Convo {
     }
   }
 
-  private pendingFetchConvo:
-    | Promise<{
-        convo: ChatBskyConvoDefs.ConvoView
-        sender: ChatBskyActorDefs.ProfileViewBasic | undefined
-        recipients: ChatBskyActorDefs.ProfileViewBasic[]
-      }>
-    | undefined
-  async fetchConvo() {
-    if (this.pendingFetchConvo) return this.pendingFetchConvo
-
-    this.pendingFetchConvo = (async () => {
-      try {
-        const response = await networkRetry(2, () => {
-          return this.agent.api.chat.bsky.convo.getConvo(
-            {
-              convoId: this.convoId,
-            },
-            {headers: DM_SERVICE_HEADERS},
-          )
-        })
-
-        const convo = response.data.convo
-
-        return {
-          convo,
-          sender: convo.members.find(m => m.did === this.senderUserDid),
-          recipients: convo.members.filter(m => m.did !== this.senderUserDid),
-        }
-      } finally {
-        this.pendingFetchConvo = undefined
-      }
-    })()
-
-    return this.pendingFetchConvo
-  }
-
-  async refreshConvo() {
-    try {
-      const {convo, sender, recipients} = await this.fetchConvo()
-      // throw new Error('UNCOMMENT TO TEST REFRESH FAILURE')
-      this.convo = convo || this.convo
-      this.sender = sender || this.sender
-      this.recipients = recipients || this.recipients
-    } catch (err) {
-      const e = err as Error
-      if (!isNetworkError(e) && !isErrorMaybeAppPasswordPermissions(e)) {
-        logger.error(`failed to refresh convo`, {
-          safeMessage: e.message,
-        })
-      }
-    }
-  }
-
   private fetchMessageHistoryError:
     | {
         retry: () => void
@@ -689,7 +597,7 @@ export class Convo {
           {
             cursor: nextCursor,
             convoId: this.convoId,
-            limit: IS_NATIVE ? 30 : 60,
+            limit: GET_MESSAGE_HISTORY_LIMIT,
           },
           {headers: DM_SERVICE_HEADERS},
         )
@@ -700,7 +608,7 @@ export class Convo {
 
       if (relatedProfiles) {
         for (const profile of relatedProfiles) {
-          this.systemMessageProfiles.set(profile.did, profile)
+          this.relatedProfiles.set(profile.did, profile)
         }
       }
 
@@ -708,7 +616,7 @@ export class Convo {
        * If the response contained fewer messages than the limit, we know
        * there are no more pages, regardless of whether a cursor was returned.
        */
-      if (messages.length < (IS_NATIVE ? 30 : 60)) {
+      if (messages.length < GET_MESSAGE_HISTORY_LIMIT) {
         this.oldestRev = null
       }
 
@@ -728,6 +636,10 @@ export class Convo {
           }
           this.pastMessages.set(message.id, message)
         }
+      }
+
+      for (const profile of relatedProfiles ?? []) {
+        this.relatedProfiles.set(profile.did, profile)
       }
     } catch (err) {
       const e = err as Error
@@ -877,7 +789,7 @@ export class Convo {
                 Array.isArray(ev.relatedProfiles)
               ) {
                 for (const profile of ev.relatedProfiles) {
-                  this.systemMessageProfiles.set(profile.did, profile)
+                  this.relatedProfiles.set(profile.did, profile)
                 }
               }
               needsCommit = true
@@ -907,10 +819,10 @@ export class Convo {
       id: tempId,
       message,
     })
-    if (this.convo?.status === 'request') {
+    if (this.convo?.view.status === 'request') {
       this.convo = {
         ...this.convo,
-        status: 'accepted',
+        view: {...this.convo.view, status: 'accepted'},
       }
     }
     this.commit()
@@ -924,36 +836,7 @@ export class Convo {
     if (this.convo) {
       this.convo = {
         ...this.convo,
-        status: 'accepted',
-      }
-    }
-    this.commit()
-  }
-
-  updateMuted(muted: boolean) {
-    if (this.convo) {
-      this.convo = {
-        ...this.convo,
-        muted,
-      }
-    }
-    this.commit()
-  }
-
-  updateGroupName(name: string) {
-    if (
-      this.convo &&
-      bsky.dangerousIsType<ChatBskyConvoDefs.GroupConvo>(
-        this.convo.kind,
-        ChatBskyConvoDefs.isGroupConvo,
-      )
-    ) {
-      this.convo = {
-        ...this.convo,
-        kind: {
-          ...this.convo.kind,
-          name,
-        },
+        view: {...this.convo.view, status: 'accepted'},
       }
     }
     this.commit()
@@ -980,7 +863,7 @@ export class Convo {
 
       const {id, message} = pendingMessage
 
-      const response = await this.agent.api.chat.bsky.convo.sendMessage(
+      const response = await this.agent.chat.bsky.convo.sendMessage(
         {
           convoId: this.convoId,
           message,
@@ -1022,10 +905,7 @@ export class Convo {
           case 'block between recipient and sender':
             this.emitter.emit('event', {
               type: 'invalidate-block-state',
-              accountDids: [
-                this.sender!.did,
-                ...this.recipients!.map(r => r.did),
-              ],
+              accountDids: [this.senderUserDid, ...this.relatedProfiles.keys()],
             })
             break
           case 'Account is disabled':
@@ -1075,7 +955,7 @@ export class Convo {
     )
 
     try {
-      const {data} = await this.agent.api.chat.bsky.convo.sendMessageBatch(
+      const {data} = await this.agent.chat.bsky.convo.sendMessageBatch(
         {
           items: messageArray.map(({message}) => ({
             convoId: this.convoId,
@@ -1117,7 +997,7 @@ export class Convo {
 
     try {
       await networkRetry(2, () => {
-        return this.agent.api.chat.bsky.convo.deleteMessageForSelf(
+        return this.agent.chat.bsky.convo.deleteMessageForSelf(
           {
             convoId: this.convoId,
             messageId,
@@ -1146,6 +1026,39 @@ export class Convo {
     }
   }
 
+  private getRelatedProfilesForItem(
+    m: ChatBskyConvoDefs.MessageView | ChatBskyConvoDefs.SystemMessageView,
+  ): bsky.profile.AnyProfileView[] {
+    const seen = new Set<string>()
+    const profiles: bsky.profile.AnyProfileView[] = []
+
+    const add = (did: string) => {
+      if (seen.has(did)) return
+      seen.add(did)
+      const p = this.relatedProfiles.get(did)
+      if (p) profiles.push(p)
+    }
+
+    if (ChatBskyConvoDefs.isMessageView(m)) {
+      add(m.sender.did)
+      if (m.reactions) {
+        for (const reaction of m.reactions) {
+          add(reaction.sender.did)
+        }
+      }
+    } else if (ChatBskyConvoDefs.isSystemMessageView(m)) {
+      const data = m.data
+      if ('member' in data && data.member?.did) {
+        add(data.member.did)
+      }
+      if ('addedBy' in data && data.addedBy?.did) {
+        add(data.addedBy.did)
+      }
+    }
+
+    return profiles
+  }
+
   /*
    * Items in reverse order, since FlatList inverts
    */
@@ -1158,6 +1071,7 @@ export class Convo {
           type: 'message',
           key: m.id,
           message: m,
+          relatedProfiles: this.getRelatedProfilesForItem(m),
           nextMessage: null,
           prevMessage: null,
         })
@@ -1174,7 +1088,7 @@ export class Convo {
           type: 'system-message',
           key: m.id,
           message: m,
-          relatedProfiles: Array.from(this.systemMessageProfiles.values()),
+          relatedProfiles: this.getRelatedProfilesForItem(m),
         })
       }
     })
@@ -1196,6 +1110,7 @@ export class Convo {
           type: 'message',
           key: m.id,
           message: m,
+          relatedProfiles: this.getRelatedProfilesForItem(m),
           nextMessage: null,
           prevMessage: null,
         })
@@ -1212,7 +1127,7 @@ export class Convo {
           type: 'system-message',
           key: m.id,
           message: m,
-          relatedProfiles: Array.from(this.systemMessageProfiles.values()),
+          relatedProfiles: this.getRelatedProfilesForItem(m),
         })
       }
     })
@@ -1234,7 +1149,7 @@ export class Convo {
            */
           sender: {
             $type: 'chat.bsky.convo.defs#messageViewSender',
-            did: this.sender!.did,
+            did: this.senderUserDid,
           },
         },
         nextMessage: null,
@@ -1446,48 +1361,6 @@ export class Convo {
     } catch (error) {
       if (restore) restore()
       throw error
-    }
-  }
-
-  // Group utilities
-
-  isGroup(): boolean | undefined {
-    if (!this.convo) return undefined
-    const info = this.getGroupInfo()
-    return !!info
-  }
-
-  getGroupInfo(): ChatBskyConvoDefs.GroupConvo | undefined {
-    if (
-      this.convo &&
-      bsky.dangerousIsType<ChatBskyConvoDefs.GroupConvo>(
-        this.convo.kind,
-        ChatBskyConvoDefs.isGroupConvo,
-      )
-    ) {
-      return this.convo.kind
-    }
-    return undefined
-  }
-
-  getPrimaryMember(): ChatBskyActorDefs.ProfileViewBasic | undefined {
-    if (this.isGroup()) {
-      return this.convo?.members.find(m => {
-        if (
-          bsky.dangerousIsType<ChatBskyActorDefs.GroupConvoMember>(
-            m.kind,
-            ChatBskyActorDefs.isGroupConvoMember,
-          )
-        ) {
-          return m.kind.role === 'owner'
-        } else {
-          throw new Error(
-            'Expected a GroupConvoMember, got an unknown kind of member',
-          )
-        }
-      })
-    } else {
-      return this.recipients?.find(r => r.did !== this.senderUserDid)
     }
   }
 }

--- a/src/state/messages/convo/agent.ts
+++ b/src/state/messages/convo/agent.ts
@@ -1133,6 +1133,7 @@ export class Convo {
     })
 
     this.pendingMessages.forEach(m => {
+      const senderProfile = this.relatedProfiles.get(this.senderUserDid)
       items.push({
         type: 'pending-message',
         key: m.id,
@@ -1143,15 +1144,12 @@ export class Convo {
           id: nanoid(),
           rev: '__fake__',
           sentAt: new Date().toISOString(),
-          /*
-           * `getItems` is only run in "active" status states, where
-           * `this.sender` is defined
-           */
           sender: {
             $type: 'chat.bsky.convo.defs#messageViewSender',
             did: this.senderUserDid,
           },
         },
+        relatedProfiles: senderProfile ? [senderProfile] : [],
         nextMessage: null,
         prevMessage: null,
         failed: this.pendingMessageFailure !== null,

--- a/src/state/messages/convo/const.ts
+++ b/src/state/messages/convo/const.ts
@@ -1,3 +1,5 @@
+import {IS_NATIVE} from '#/env'
+
 export const ACTIVE_POLL_INTERVAL = 4e3
 export const MESSAGE_SCREEN_POLL_INTERVAL = 30e3
 export const BACKGROUND_POLL_INTERVAL = 60e3
@@ -6,3 +8,5 @@ export const INACTIVE_TIMEOUT = 60e3 * 5
 export const NETWORK_FAILURE_STATUSES = [
   1, 408, 425, 429, 500, 502, 503, 504, 522, 524,
 ]
+
+export const GET_MESSAGE_HISTORY_LIMIT = IS_NATIVE ? 40 : 60

--- a/src/state/messages/convo/index.tsx
+++ b/src/state/messages/convo/index.tsx
@@ -6,13 +6,14 @@ import {
   useState,
   useSyncExternalStore,
 } from 'react'
-import {ChatBskyConvoDefs} from '@atproto/api'
 import {useFocusEffect} from '@react-navigation/native'
 import {useQueryClient} from '@tanstack/react-query'
 
 import {useAppState} from '#/lib/appState'
 import {Convo} from '#/state/messages/convo/agent'
 import {
+  ConvoDispatchEvent,
+  ConvoErrorCode,
   type ConvoParams,
   type ConvoState,
   type ConvoStateBackgrounded,
@@ -23,10 +24,11 @@ import {
 import {isConvoActive} from '#/state/messages/convo/util'
 import {useMessagesEventBus} from '#/state/messages/events'
 import {
-  RQKEY as getConvoKey,
+  useConvoQuery,
   useMarkAsReadMutation,
 } from '#/state/queries/messages/conversation'
 import {RQKEY_ROOT as ListConvosQueryKeyRoot} from '#/state/queries/messages/list-conversations'
+import {useListConvoMembersQuery} from '#/state/queries/messages/list-convo-members'
 import {RQKEY as createProfileQueryKey} from '#/state/queries/profile'
 import {useAgent} from '#/state/session'
 
@@ -72,19 +74,51 @@ export function ConvoProvider({
   const queryClient = useQueryClient()
   const agent = useAgent()
   const events = useMessagesEventBus()
+
+  const {
+    data: convoData,
+    error: convoError,
+    refetch: refetchConvo,
+  } = useConvoQuery({convoId})
+  const {
+    data: membersData,
+    error: membersError,
+    refetch: refetchMembers,
+  } = useListConvoMembersQuery({convoId})
+
+  // eslint-disable-next-line react/hook-use-state
   const [convo] = useState(() => {
-    const placeholder = queryClient.getQueryData<ChatBskyConvoDefs.ConvoView>(
-      getConvoKey(convoId),
-    )
     return new Convo({
       convoId,
       agent,
       events,
-      placeholderData: placeholder ? {convo: placeholder} : undefined,
+      initialData: {convo: convoData, members: membersData},
     })
   })
   const service = useSyncExternalStore(convo.subscribe, convo.getSnapshot)
   const {mutate: markAsRead} = useMarkAsReadMutation()
+
+  useEffect(() => {
+    if (convoData && membersData) {
+      convo.setConvoData(convoData, membersData)
+    }
+  }, [convo, convoData, membersData])
+
+  useEffect(() => {
+    if ((convoError || membersError) && !convo.convo) {
+      convo.dispatch({
+        event: ConvoDispatchEvent.Error,
+        payload: {
+          exception: (convoError || membersError) as Error,
+          code: ConvoErrorCode.InitFailed,
+          retry: () => {
+            void refetchConvo()
+            void refetchMembers()
+          },
+        },
+      })
+    }
+  }, [convo, convoError, membersError, refetchConvo, refetchMembers])
 
   const appState = useAppState()
   const isActive = appState === 'active'
@@ -93,13 +127,15 @@ export function ConvoProvider({
       if (isActive) {
         convo.resume()
         markAsRead({convoId})
+        void refetchConvo()
+        void refetchMembers()
 
         return () => {
           convo.background()
           markAsRead({convoId})
         }
       }
-    }, [isActive, convo, convoId, markAsRead]),
+    }, [isActive, convo, convoId, markAsRead, refetchConvo, refetchMembers]),
   )
 
   useEffect(() => {
@@ -107,41 +143,17 @@ export function ConvoProvider({
       switch (event.type) {
         case 'invalidate-block-state': {
           for (const did of event.accountDids) {
-            queryClient.invalidateQueries({
+            void queryClient.invalidateQueries({
               queryKey: createProfileQueryKey(did),
             })
           }
-          queryClient.invalidateQueries({
+          void queryClient.invalidateQueries({
             queryKey: [ListConvosQueryKeyRoot],
           })
         }
       }
     })
   }, [convo, queryClient])
-
-  useEffect(() => {
-    const [root, id] = getConvoKey(convoId)
-    return queryClient.getQueryCache().subscribe(event => {
-      const queryKey = event.query.queryKey as string[]
-      if (queryKey[0] === root && queryKey[1] === id) {
-        const data = event.query.state.data as
-          | ChatBskyConvoDefs.ConvoView
-          | undefined
-        if (data && convo.convo && data.muted !== convo.convo.muted) {
-          convo.updateMuted(data.muted)
-        }
-        if (
-          data &&
-          convo.convo &&
-          ChatBskyConvoDefs.isGroupConvo(data.kind) &&
-          ChatBskyConvoDefs.isGroupConvo(convo.convo.kind) &&
-          data.kind.name !== convo.convo.kind.name
-        ) {
-          convo.updateGroupName(data.kind.name)
-        }
-      }
-    })
-  }, [convo, convoId, queryClient])
 
   return <ChatContext.Provider value={service}>{children}</ChatContext.Provider>
 }

--- a/src/state/messages/convo/types.ts
+++ b/src/state/messages/convo/types.ts
@@ -103,6 +103,7 @@ export type ConvoItem =
       type: 'pending-message'
       key: string
       message: ChatBskyConvoDefs.MessageView
+      relatedProfiles: bsky.profile.AnyProfileView[]
       nextMessage:
         | ChatBskyConvoDefs.MessageView
         | ChatBskyConvoDefs.DeletedMessageView

--- a/src/state/messages/convo/types.ts
+++ b/src/state/messages/convo/types.ts
@@ -6,13 +6,16 @@ import {
 } from '@atproto/api'
 
 import {type MessagesEventBus} from '#/state/messages/events/agent'
+import {type ConvoWithDetails} from '#/components/dms/util'
+import type * as bsky from '#/types/bsky'
 
 export type ConvoParams = {
   convoId: string
   agent: BskyAgent
   events: MessagesEventBus
-  placeholderData?: {
-    convo: ChatBskyConvoDefs.ConvoView
+  initialData?: {
+    convo?: ChatBskyConvoDefs.ConvoView
+    members?: ChatBskyActorDefs.ProfileViewBasic[]
   }
 }
 
@@ -86,6 +89,7 @@ export type ConvoItem =
       type: 'message'
       key: string
       message: ChatBskyConvoDefs.MessageView
+      relatedProfiles: bsky.profile.AnyProfileView[]
       nextMessage:
         | ChatBskyConvoDefs.MessageView
         | ChatBskyConvoDefs.DeletedMessageView
@@ -130,7 +134,7 @@ export type ConvoItem =
       type: 'system-message'
       key: string
       message: ChatBskyConvoDefs.SystemMessageView
-      relatedProfiles: ChatBskyActorDefs.ProfileViewBasic[]
+      relatedProfiles: bsky.profile.AnyProfileView[]
     }
   | {
       type: 'error'
@@ -150,17 +154,12 @@ type FetchMessageHistory = () => Promise<void>
 type MarkConvoAccepted = () => void
 type AddReaction = (messageId: string, reaction: string) => Promise<void>
 type RemoveReaction = (messageId: string, reaction: string) => Promise<void>
-type IsGroup = () => boolean | undefined
-type GetGroupInfo = () => ChatBskyConvoDefs.GroupConvo | undefined
-type GetPrimaryMember = () => ChatBskyActorDefs.ProfileViewBasic | undefined
 
 export type ConvoStateUninitialized = {
   status: ConvoStatus.Uninitialized
   items: []
-  convo: ChatBskyConvoDefs.ConvoView | undefined
+  convo: ConvoWithDetails | undefined
   error: undefined
-  sender: ChatBskyActorDefs.ProfileViewBasic | undefined
-  recipients: ChatBskyActorDefs.ProfileViewBasic[] | undefined
   isFetchingHistory: false
   hasAllHistory: boolean
   deleteMessage: undefined
@@ -169,17 +168,12 @@ export type ConvoStateUninitialized = {
   markConvoAccepted: undefined
   addReaction: undefined
   removeReaction: undefined
-  isGroup: IsGroup
-  getGroupInfo: GetGroupInfo
-  getPrimaryMember: GetPrimaryMember
 }
 export type ConvoStateInitializing = {
   status: ConvoStatus.Initializing
   items: []
-  convo: ChatBskyConvoDefs.ConvoView | undefined
+  convo: ConvoWithDetails | undefined
   error: undefined
-  sender: ChatBskyActorDefs.ProfileViewBasic | undefined
-  recipients: ChatBskyActorDefs.ProfileViewBasic[] | undefined
   isFetchingHistory: boolean
   hasAllHistory: boolean
   deleteMessage: undefined
@@ -188,17 +182,12 @@ export type ConvoStateInitializing = {
   markConvoAccepted: undefined
   addReaction: undefined
   removeReaction: undefined
-  isGroup: IsGroup
-  getGroupInfo: GetGroupInfo
-  getPrimaryMember: GetPrimaryMember
 }
 export type ConvoStateReady = {
   status: ConvoStatus.Ready
   items: ConvoItem[]
-  convo: ChatBskyConvoDefs.ConvoView
+  convo: ConvoWithDetails
   error: undefined
-  sender: ChatBskyActorDefs.ProfileViewBasic
-  recipients: ChatBskyActorDefs.ProfileViewBasic[]
   isFetchingHistory: boolean
   hasAllHistory: boolean
   deleteMessage: DeleteMessage
@@ -207,17 +196,12 @@ export type ConvoStateReady = {
   markConvoAccepted: MarkConvoAccepted
   addReaction: AddReaction
   removeReaction: RemoveReaction
-  isGroup: IsGroup
-  getGroupInfo: GetGroupInfo
-  getPrimaryMember: GetPrimaryMember
 }
 export type ConvoStateBackgrounded = {
   status: ConvoStatus.Backgrounded
   items: ConvoItem[]
-  convo: ChatBskyConvoDefs.ConvoView
+  convo: ConvoWithDetails
   error: undefined
-  sender: ChatBskyActorDefs.ProfileViewBasic
-  recipients: ChatBskyActorDefs.ProfileViewBasic[]
   isFetchingHistory: boolean
   hasAllHistory: boolean
   deleteMessage: DeleteMessage
@@ -226,17 +210,12 @@ export type ConvoStateBackgrounded = {
   markConvoAccepted: MarkConvoAccepted
   addReaction: AddReaction
   removeReaction: RemoveReaction
-  isGroup: IsGroup
-  getGroupInfo: GetGroupInfo
-  getPrimaryMember: GetPrimaryMember
 }
 export type ConvoStateSuspended = {
   status: ConvoStatus.Suspended
   items: ConvoItem[]
-  convo: ChatBskyConvoDefs.ConvoView
+  convo: ConvoWithDetails
   error: undefined
-  sender: ChatBskyActorDefs.ProfileViewBasic
-  recipients: ChatBskyActorDefs.ProfileViewBasic[]
   isFetchingHistory: boolean
   hasAllHistory: boolean
   deleteMessage: DeleteMessage
@@ -245,17 +224,12 @@ export type ConvoStateSuspended = {
   markConvoAccepted: MarkConvoAccepted
   addReaction: AddReaction
   removeReaction: RemoveReaction
-  isGroup: IsGroup
-  getGroupInfo: GetGroupInfo
-  getPrimaryMember: GetPrimaryMember
 }
 export type ConvoStateError = {
   status: ConvoStatus.Error
   items: []
   convo: undefined
   error: ConvoError
-  sender: undefined
-  recipients: undefined
   isFetchingHistory: false
   hasAllHistory: false
   deleteMessage: undefined
@@ -264,17 +238,12 @@ export type ConvoStateError = {
   markConvoAccepted: undefined
   addReaction: undefined
   removeReaction: undefined
-  isGroup: undefined
-  getGroupInfo: undefined
-  getPrimaryMember: undefined
 }
 export type ConvoStateDisabled = {
   status: ConvoStatus.Disabled
   items: ConvoItem[]
-  convo: ChatBskyConvoDefs.ConvoView
+  convo: ConvoWithDetails
   error: undefined
-  sender: ChatBskyActorDefs.ProfileViewBasic
-  recipients: ChatBskyActorDefs.ProfileViewBasic[]
   isFetchingHistory: boolean
   hasAllHistory: boolean
   deleteMessage: DeleteMessage
@@ -283,9 +252,6 @@ export type ConvoStateDisabled = {
   markConvoAccepted: MarkConvoAccepted
   addReaction: AddReaction
   removeReaction: RemoveReaction
-  isGroup: IsGroup
-  getGroupInfo: GetGroupInfo
-  getPrimaryMember: GetPrimaryMember
 }
 export type ConvoState =
   | ConvoStateUninitialized

--- a/src/state/queries/messages/conversation.ts
+++ b/src/state/queries/messages/conversation.ts
@@ -16,7 +16,7 @@ import {
   RQKEY_ROOT as LIST_CONVOS_KEY,
 } from './list-conversations'
 
-const RQKEY_ROOT = 'convo'
+export const RQKEY_ROOT = 'convo'
 export const RQKEY = (convoId: string) => [RQKEY_ROOT, convoId]
 
 export function useConvoQuery({convoId}: {convoId: string}) {
@@ -31,7 +31,7 @@ export function useConvoQuery({convoId}: {convoId: string}) {
       )
       return data.convo
     },
-    staleTime: STALE.INFINITY,
+    staleTime: STALE.MINUTES.THIRTY,
   })
 }
 

--- a/src/state/queries/messages/list-convo-members.ts
+++ b/src/state/queries/messages/list-convo-members.ts
@@ -1,0 +1,40 @@
+import {useQuery} from '@tanstack/react-query'
+
+import {DM_SERVICE_HEADERS} from '#/lib/constants'
+import {STALE} from '#/state/queries'
+import {useAgent} from '#/state/session'
+import {RQKEY_ROOT as GET_CONVOS_KEY} from './conversation'
+
+const RQKEY_SEGMENT = 'members'
+export const RQKEY = (convoId: string) => [
+  GET_CONVOS_KEY,
+  convoId,
+  RQKEY_SEGMENT,
+]
+
+// group chat size is 50, so should fetch the whole list in one go
+const LIMIT = 50
+
+export function useListConvoMembersQuery({convoId}: {convoId: string}) {
+  const agent = useAgent()
+
+  return useQuery({
+    queryKey: RQKEY(convoId),
+    queryFn: async () => {
+      const members = []
+      let cursor
+
+      do {
+        const {data} = await agent.chat.bsky.convo.getConvoMembers(
+          {convoId, cursor, limit: LIMIT},
+          {headers: DM_SERVICE_HEADERS},
+        )
+        members.push(...data.members)
+        cursor = data.cursor
+      } while (cursor)
+
+      return members
+    },
+    staleTime: STALE.MINUTES.THIRTY,
+  })
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -34,17 +34,7 @@
     tlds "^1.234.0"
     zod "^3.23.8"
 
-"@atproto/common-web@^0.4.18":
-  version "0.4.19"
-  resolved "https://registry.yarnpkg.com/@atproto/common-web/-/common-web-0.4.19.tgz#bbd7f84f545ebe73ca3bc00314ccf4ee66e7069e"
-  integrity sha512-3BTi58p5WpT+9/zb6UZrdsXcfPo5P45UJm0E4iwHLILr+jc37CuBj9JReDSZ4U0i9RTrI3ZkfySyZ9bd+LnMsw==
-  dependencies:
-    "@atproto/lex-data" "^0.0.14"
-    "@atproto/lex-json" "^0.0.14"
-    "@atproto/syntax" "^0.5.1"
-    zod "^3.23.8"
-
-"@atproto/common-web@^0.4.21":
+"@atproto/common-web@^0.4.18", "@atproto/common-web@^0.4.21":
   version "0.4.21"
   resolved "https://registry.yarnpkg.com/@atproto/common-web/-/common-web-0.4.21.tgz#2198583f842a000f495f1caec6f7e4eda207191b"
   integrity sha512-Odq+wdk3YNasGCjjlpl3bCIPvqYHige5DLfMkIffNv/2PI/iIj5ZvAvMvJlJ59OhReKSxtpI0invx5UQPc3+fw==
@@ -53,16 +43,6 @@
     "@atproto/lex-json" "^0.0.16"
     "@atproto/syntax" "^0.5.4"
     zod "^3.23.8"
-
-"@atproto/lex-data@^0.0.14":
-  version "0.0.14"
-  resolved "https://registry.yarnpkg.com/@atproto/lex-data/-/lex-data-0.0.14.tgz#2f2f3c64699925a0d4785e5afd0e7731ba1d46c0"
-  integrity sha512-53DUa9664SS76nGAMYopWsO10OH0AAdf7P/HSKB6Wzx3iqe6lk/K61QZnKxOG1LreYl5CfvIJU6eNf4txI6GlQ==
-  dependencies:
-    multiformats "^9.9.0"
-    tslib "^2.8.1"
-    uint8arrays "3.0.0"
-    unicode-segmenter "^0.14.0"
 
 "@atproto/lex-data@^0.0.15":
   version "0.0.15"
@@ -73,14 +53,6 @@
     tslib "^2.8.1"
     uint8arrays "3.0.0"
     unicode-segmenter "^0.14.0"
-
-"@atproto/lex-json@^0.0.14":
-  version "0.0.14"
-  resolved "https://registry.yarnpkg.com/@atproto/lex-json/-/lex-json-0.0.14.tgz#717e533ab583aa5f580acb2a77d9aa3e7eddaa17"
-  integrity sha512-6lPkDKqe7teEu4WrN5q7400cvZKgYS3uwUMvzG3F9XkgVYhOwSDCtouV/nSLBbpvo3l9OP0kiigtclcNcyekww==
-  dependencies:
-    "@atproto/lex-data" "^0.0.14"
-    tslib "^2.8.1"
 
 "@atproto/lex-json@^0.0.16":
   version "0.0.16"
@@ -101,14 +73,7 @@
     multiformats "^9.9.0"
     zod "^3.23.8"
 
-"@atproto/syntax@0.5.2", "@atproto/syntax@^0.5.0", "@atproto/syntax@^0.5.1":
-  version "0.5.2"
-  resolved "https://registry.yarnpkg.com/@atproto/syntax/-/syntax-0.5.2.tgz#d4b32c9feb421ceeb5ade1fa80bc42764d51e52e"
-  integrity sha512-W41szOnkppoHr0iCUrzL8gy3OD6qmDyp1UvUgmTx2oFQfgbudpz51T/gznesiCcqiUT5obfHdx4PJ+WdlEOE7Q==
-  dependencies:
-    tslib "^2.8.1"
-
-"@atproto/syntax@^0.5.4":
+"@atproto/syntax@0.5.4", "@atproto/syntax@^0.5.0", "@atproto/syntax@^0.5.4":
   version "0.5.4"
   resolved "https://registry.yarnpkg.com/@atproto/syntax/-/syntax-0.5.4.tgz#89842eb8b8ab181752b04ed840cc6b100e296b00"
   integrity sha512-9XJOpMAgsGFxMEIp8nJ8AIWv+krrY1xQMj+wULbbXhQztQV+9aZ0TbG9Jtn3Op2or8Kr6OqyWR4ga9Z189kKDw==


### PR DESCRIPTION
## Summary

- Moves conversation and member list fetching out of the `Convo` class and into React Query (`useConvoQuery` + `useListConvoMembersQuery`), with the `ConvoProvider` syncing data in via `setConvoData`
- `Convo` stores `ConvoWithDetails` instead of raw `ConvoView`, so consumers get parsed group/direct info directly (e.g. `convoState.convo.kind === 'group'`)
- Removes `sender`, `recipients`, `isGroup()`, `getGroupInfo()`, `getPrimaryMember()` from `ConvoState` — consumers use `convoState.convo.primaryMember`, `convoState.convo.members`, etc.
- `relatedProfiles` map on items accumulates profiles from members, message history, and reactions — handles people who've left the chat
- `parseConvoView` accepts optional full member list from `getConvoMembers`, hardening against truncated `convo.members`

## Test plan

- [ ] Open a DM conversation — messages load, header renders
- [ ] Open a group chat — group info panel shows correctly
- [ ] Scroll back in message history — profiles from former members resolve
- [ ] Background and resume the app — convo refreshes via React Query
- [ ] System messages display member names (or "Someone" fallback)
- [ ] Send a message, verify pending/sent flow works
- [ ] Reactions show correct sender profiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)