### PR TITLE
Fix pagination for system messages in chat

### DIFF
--- a/src/components/dms/getSystemMessageInfo.ts
+++ b/src/components/dms/getSystemMessageInfo.ts
@@ -85,5 +85,17 @@ export function getSystemMessageInfo(
   } else if (ChatBskyConvoDefs.isSystemMessageDataDisableJoinLink(data)) {
     return {Icon: ChainLinkBrokenIcon, message: msg`Invite link disabled`}
   }
+  // Unrecognized system message, see `isRenderableSystemMessageData`.
   return null
+}
+
+/**
+ * True if the system-message data kind is one we render a visible row for.
+ * Kept in sync with `getSystemMessageInfo` - if that returns null, the
+ * `SystemMessageItem` renders null (zero height).
+ */
+export function isRenderableSystemMessageData(
+  data: ChatBskyConvoDefs.SystemMessageView['data'],
+): boolean {
+  return getSystemMessageInfo(data, []) !== null
 }

--- a/src/screens/Messages/components/MessagesList.tsx
+++ b/src/screens/Messages/components/MessagesList.tsx
@@ -166,6 +166,22 @@ export function MessagesList({
 
   // -- Scroll handling
 
+  // Since `onStartReached` doesn't cover the case where content fits entirely
+  // in the viewport (e.g. a group chat of only system messages or unrecognized
+  // system messages), this callback fills the next page of history whenever the
+  // viewport can't be scrolled away from the top and more history exists.
+  const maybeFetchMoreHistory = useCallback(() => {
+    if (
+      hasInitiallyScrolled.current &&
+      !convoState.hasAllHistory &&
+      !convoState.isFetchingHistory &&
+      convoState.fetchMessageHistory &&
+      isAtTop.get()
+    ) {
+      void convoState.fetchMessageHistory()
+    }
+  }, [convoState, isAtTop])
+
   // Every time the content size changes, that means one of two things is happening:
   // 1. New messages are being added from the log or from a message you have sent
   // 2. Old messages are being prepended to the top
@@ -201,6 +217,7 @@ export function MessagesList({
         }
         prevContentHeight.current = height
         prevItemCount.current = convoState.items.length
+        maybeFetchMoreHistory()
         return
       }
 
@@ -235,12 +252,15 @@ export function MessagesList({
       prevContentHeight.current = height
       prevItemCount.current = convoState.items.length
       didBackground.current = false
+
+      maybeFetchMoreHistory()
     },
     [
       hasScrolled,
       setHasScrolled,
       convoState.isFetchingHistory,
       convoState.items.length,
+      maybeFetchMoreHistory,
       // these are stable
       flatListRef,
       isAtTop,

--- a/src/state/messages/convo/agent.ts
+++ b/src/state/messages/convo/agent.ts
@@ -36,8 +36,11 @@ import {
 } from '#/state/messages/convo/types'
 import {type MessagesEventBus} from '#/state/messages/events/agent'
 import {type MessagesEventBusError} from '#/state/messages/events/types'
+import {isRenderableSystemMessageData} from '#/components/dms/getSystemMessageInfo'
 import {IS_NATIVE} from '#/env'
 import * as bsky from '#/types/bsky'
+
+const MAX_PAGES_PER_FETCH = 5
 
 const logger = Logger.create(Logger.Context.ConversationAgent)
 
@@ -683,51 +686,17 @@ export class Convo {
       this.isFetchingHistory = true
       this.commit()
 
-      const nextCursor = this.oldestRev // for TS
-      const response = await networkRetry(2, () => {
-        return this.agent.chat.bsky.convo.getMessages(
-          {
-            cursor: nextCursor,
-            convoId: this.convoId,
-            limit: IS_NATIVE ? 30 : 60,
-          },
-          {headers: DM_SERVICE_HEADERS},
-        )
-      })
-      const {cursor, messages, relatedProfiles} = response.data
-
-      this.oldestRev = cursor ?? null
-
-      if (relatedProfiles) {
-        for (const profile of relatedProfiles) {
-          this.systemMessageProfiles.set(profile.did, profile)
-        }
-      }
-
       /*
-       * If the response contained fewer messages than the limit, we know
-       * there are no more pages, regardless of whether a cursor was returned.
+       * Keep pulling pages until we've added at least one visible row or
+       * exhausted history. For example, a page of only unrecognized system
+       * messages renders with zero height, leaving the user pinned to the top
+       * with `onStartReached` unable to fire again.
+       *
+       * Bounded so a long run of unrecognized messages can't spin here.
        */
-      if (messages.length < (IS_NATIVE ? 30 : 60)) {
-        this.oldestRev = null
-      }
-
-      for (const message of messages) {
-        if (
-          ChatBskyConvoDefs.isMessageView(message) ||
-          ChatBskyConvoDefs.isDeletedMessageView(message) ||
-          ChatBskyConvoDefs.isSystemMessageView(message)
-        ) {
-          /*
-           * If this message is already in new messages, it was added by the
-           * firehose ingestion, and we can safely overwrite it. This trusts
-           * the server on ordering, and keeps it in sync.
-           */
-          if (this.newMessages.has(message.id)) {
-            this.newMessages.delete(message.id)
-          }
-          this.pastMessages.set(message.id, message)
-        }
+      for (let i = 0; i < MAX_PAGES_PER_FETCH && this.oldestRev !== null; i++) {
+        const addedVisibleRow = await this.fetchNextHistoryPage()
+        if (addedVisibleRow) break
       }
     } catch (err) {
       const e = err as Error
@@ -746,6 +715,65 @@ export class Convo {
       this.isFetchingHistory = false
       this.commit()
     }
+  }
+
+  private async fetchNextHistoryPage(): Promise<boolean> {
+    const limit = IS_NATIVE ? 30 : 60
+    const nextCursor = this.oldestRev ?? undefined
+    const response = await networkRetry(2, () => {
+      return this.agent.chat.bsky.convo.getMessages(
+        {
+          cursor: nextCursor,
+          convoId: this.convoId,
+          limit,
+        },
+        {headers: DM_SERVICE_HEADERS},
+      )
+    })
+    const {cursor, messages, relatedProfiles} = response.data
+
+    this.oldestRev = cursor ?? null
+
+    if (relatedProfiles) {
+      for (const profile of relatedProfiles) {
+        this.systemMessageProfiles.set(profile.did, profile)
+      }
+    }
+
+    /*
+     * If the response contained fewer messages than the limit, we know
+     * there are no more pages, regardless of whether a cursor was returned.
+     */
+    if (messages.length < limit) {
+      this.oldestRev = null
+    }
+
+    let addedVisibleRow = false
+    for (const message of messages) {
+      if (
+        ChatBskyConvoDefs.isMessageView(message) ||
+        ChatBskyConvoDefs.isDeletedMessageView(message) ||
+        ChatBskyConvoDefs.isSystemMessageView(message)
+      ) {
+        /*
+         * If this message is already in new messages, it was added by the
+         * firehose ingestion, and we can safely overwrite it. This trusts
+         * the server on ordering, and keeps it in sync.
+         */
+        if (this.newMessages.has(message.id)) {
+          this.newMessages.delete(message.id)
+        }
+        this.pastMessages.set(message.id, message)
+
+        if (
+          !ChatBskyConvoDefs.isSystemMessageView(message) ||
+          isRenderableSystemMessageData(message.data)
+        ) {
+          addedVisibleRow = true
+        }
+      }
+    }
+    return addedVisibleRow
   }
 
   private cleanupFirehoseConnection: (() => void) | undefined


### PR DESCRIPTION
Fixes a new issue that only applies to group clip clops: `fetchMessageHistory` only runs when the list's `onStartReached` fires, and a page of only system messages often fails to push the scroll viewport off the top enough to make it fire again.

This is especially true of unrecognized system messages, which are zero-height (they render `null`).

To avoid fetching indefinitely, we stop after we hit a reasonable limit (five pages).

**Before:**

https://github.com/user-attachments/assets/c11113fe-a57e-4289-865d-0b60edaa0cfd

**After:**

https://github.com/user-attachments/assets/82696ac4-d572-4363-bffe-e7bb9e99ff51