### PR TITLE
Only lock viewport zoom while text inputs are focused

### DIFF
--- a/bskyweb/templates/base.html
+++ b/bskyweb/templates/base.html
@@ -2,7 +2,7 @@
 <html>
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1, viewport-fit=cover">
+  <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1, viewport-fit=cover">
   <meta name="referrer" content="origin-when-cross-origin">
   <!--
     Preconnect to essential domains

--- a/src/App.web.tsx
+++ b/src/App.web.tsx
@@ -8,7 +8,6 @@ import {SafeAreaProvider} from 'react-native-safe-area-context'
 import {useLingui} from '@lingui/react/macro'
 import * as Sentry from '@sentry/react-native'
 
-import {useViewportZoomLock} from '#/lib/hooks/useViewportZoomLock'
 import {Provider as HotkeysProvider} from '#/lib/hotkeys'
 import {QueryProvider} from '#/lib/react-query'
 import {ThemeProvider} from '#/lib/ThemeContext'
@@ -196,8 +195,6 @@ function InnerApp() {
 
 function App() {
   const [isReady, setIsReady] = useState(false)
-
-  useViewportZoomLock()
 
   useEffect(() => {
     void Promise.all([initPersistedState(), Geo.resolve(), setupDeviceId]).then(

--- a/src/App.web.tsx
+++ b/src/App.web.tsx
@@ -8,6 +8,7 @@ import {SafeAreaProvider} from 'react-native-safe-area-context'
 import {useLingui} from '@lingui/react/macro'
 import * as Sentry from '@sentry/react-native'
 
+import {useViewportZoomLock} from '#/lib/hooks/useViewportZoomLock'
 import {Provider as HotkeysProvider} from '#/lib/hotkeys'
 import {QueryProvider} from '#/lib/react-query'
 import {ThemeProvider} from '#/lib/ThemeContext'
@@ -195,6 +196,8 @@ function InnerApp() {
 
 function App() {
   const [isReady, setIsReady] = useState(false)
+
+  useViewportZoomLock()
 
   useEffect(() => {
     void Promise.all([initPersistedState(), Geo.resolve(), setupDeviceId]).then(

--- a/src/lib/hooks/useViewportZoomLock.ts
+++ b/src/lib/hooks/useViewportZoomLock.ts
@@ -10,6 +10,9 @@ const ZOOM_LOCKED_VIEWPORT =
  * To avoid that while still allowing users to pinch-zoom for accessibility, we
  * only pin `maximum-scale=1` while a text input is focused and restore the
  * original viewport on blur.
+ *
+ * Listeners run in the capture phase so we update the viewport before iOS
+ * commits to auto-zooming the input.
  */
 export function useViewportZoomLock() {
   useEffect(() => {
@@ -20,24 +23,24 @@ export function useViewportZoomLock() {
 
     const originalContent = meta.content
 
-    const onFocusIn = (e: FocusEvent) => {
+    const onFocus = (e: FocusEvent) => {
       if (isTextInput(e.target)) {
         meta.content = ZOOM_LOCKED_VIEWPORT
       }
     }
 
-    const onFocusOut = (e: FocusEvent) => {
+    const onBlur = (e: FocusEvent) => {
       if (isTextInput(e.target)) {
         meta.content = originalContent
       }
     }
 
-    document.addEventListener('focusin', onFocusIn)
-    document.addEventListener('focusout', onFocusOut)
+    document.addEventListener('focus', onFocus, true)
+    document.addEventListener('blur', onBlur, true)
 
     return () => {
-      document.removeEventListener('focusin', onFocusIn)
-      document.removeEventListener('focusout', onFocusOut)
+      document.removeEventListener('focus', onFocus, true)
+      document.removeEventListener('blur', onBlur, true)
       meta.content = originalContent
     }
   }, [])

--- a/src/lib/hooks/useViewportZoomLock.ts
+++ b/src/lib/hooks/useViewportZoomLock.ts
@@ -1,0 +1,67 @@
+import {useEffect} from 'react'
+
+import {IS_WEB_MOBILE_IOS} from '#/env'
+
+const ZOOM_LOCKED_VIEWPORT =
+  'width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1, viewport-fit=cover'
+
+/**
+ * iOS Safari zooms in when a text input with `font-size < 16px` gains focus.
+ * To avoid that while still allowing users to pinch-zoom for accessibility, we
+ * only pin `maximum-scale=1` while a text input is focused and restore the
+ * original viewport on blur.
+ */
+export function useViewportZoomLock() {
+  useEffect(() => {
+    if (!IS_WEB_MOBILE_IOS) return
+
+    const meta = document.querySelector('meta[name="viewport"]')
+    if (!(meta instanceof HTMLMetaElement)) return
+
+    const originalContent = meta.content
+
+    const onFocusIn = (e: FocusEvent) => {
+      if (isTextInput(e.target)) {
+        meta.content = ZOOM_LOCKED_VIEWPORT
+      }
+    }
+
+    const onFocusOut = (e: FocusEvent) => {
+      if (isTextInput(e.target)) {
+        meta.content = originalContent
+      }
+    }
+
+    document.addEventListener('focusin', onFocusIn)
+    document.addEventListener('focusout', onFocusOut)
+
+    return () => {
+      document.removeEventListener('focusin', onFocusIn)
+      document.removeEventListener('focusout', onFocusOut)
+      meta.content = originalContent
+    }
+  }, [])
+}
+
+const NON_TEXT_INPUT_TYPES = new Set([
+  'button',
+  'checkbox',
+  'color',
+  'file',
+  'hidden',
+  'image',
+  'radio',
+  'range',
+  'reset',
+  'submit',
+])
+
+function isTextInput(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false
+  if (target.isContentEditable) return true
+  if (target instanceof HTMLTextAreaElement) return true
+  if (target instanceof HTMLInputElement) {
+    return !NON_TEXT_INPUT_TYPES.has(target.type)
+  }
+  return false
+}

--- a/src/lib/hooks/useViewportZoomLock.ts
+++ b/src/lib/hooks/useViewportZoomLock.ts
@@ -14,9 +14,10 @@ const ZOOM_LOCKED_VIEWPORT =
  * Listeners run in the capture phase so we update the viewport before iOS
  * commits to auto-zooming the input.
  */
-export function useViewportZoomLock() {
+export function useViewportZoomLock({enabled} = {enabled: true}) {
   useEffect(() => {
     if (!IS_WEB_MOBILE_IOS) return
+    if (!enabled) return
 
     const meta = document.querySelector('meta[name="viewport"]')
     if (!(meta instanceof HTMLMetaElement)) return
@@ -43,7 +44,7 @@ export function useViewportZoomLock() {
       document.removeEventListener('blur', onBlur, true)
       meta.content = originalContent
     }
-  }, [])
+  }, [enabled])
 }
 
 const NON_TEXT_INPUT_TYPES = new Set([

--- a/src/screens/Messages/Conversation.tsx
+++ b/src/screens/Messages/Conversation.tsx
@@ -18,6 +18,7 @@ import {type NativeStackScreenProps} from '@react-navigation/native-stack'
 import {RemoveScrollBar} from 'react-remove-scroll-bar'
 
 import {useNonReactiveCallback} from '#/lib/hooks/useNonReactiveCallback'
+import {useViewportZoomLock} from '#/lib/hooks/useViewportZoomLock'
 import {
   type CommonNavigatorParams,
   type NavigationProp,
@@ -105,6 +106,8 @@ function Inner({convoId}: {convoId: string}) {
   const isFocused = useIsFocused()
   const {top: topInset} = useSafeAreaInsets()
   const {data: convoData} = useConvoQuery({convoId})
+
+  useViewportZoomLock({enabled: isFocused})
 
   const convo = convoData
     ? parseConvoView(convoData, currentAccount?.did)

--- a/web/index.html
+++ b/web/index.html
@@ -9,7 +9,7 @@
      -->
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1.00001, viewport-fit=cover"
+      content="width=device-width, initial-scale=1, minimum-scale=1, viewport-fit=cover"
     />
     <!--
       Preconnect to essential domains

--- a/web/index.html
+++ b/web/index.html
@@ -9,7 +9,7 @@
      -->
     <meta
       name="viewport"
-      content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1, viewport-fit=cover"
+      content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1.00001, viewport-fit=cover"
     />
     <!--
       Preconnect to essential domains


### PR DESCRIPTION
Revert #10233 and instead toggle maximum-scale=1 on iOS Safari during focusin/focusout for text inputs. This stops the auto-zoom when focusing an input with font-size < 16px while preserving pinch-to-zoom for accessibility at all other times.

**Edit: applied only to the DMs screen**

https://github.com/user-attachments/assets/768a280d-c3c7-4699-87cd-ba321aae5d54

## Test plan

- [ ] Confirm iOS safari doesn't zooms in when focusing text inputs
- [ ] Confirm you can still pinch to zoom at other times