### PR TITLE
Fix send button disabled when sharing post via DM without text

### DIFF
--- a/src/screens/Messages/components/MessageInput.tsx
+++ b/src/screens/Messages/components/MessageInput.tsx
@@ -136,7 +136,8 @@ export function MessageInput({
     scrollEnabled: isInputScrollable.get(),
   }))
 
-  const submitDisabled = needsEmailVerification || message.trim().length === 0
+  const submitDisabled =
+    needsEmailVerification || (!hasEmbed && message.trim().length === 0)
 
   const blur = useCallback(() => {
     inputRef.current?.blur()


### PR DESCRIPTION
## Summary
- The `submitDisabled` check in `MessageInput` (native) didn't account for `hasEmbed`, so the send button was disabled when sharing a post without entering text
- The `onSubmit` handler already allowed embed-only messages, and `MessageComposer` already had the correct check — this brings `MessageInput` in line



## Test plan
- [ ] Share a post via DM on Android without entering any text — send button should be enabled and message should send
- [ ] Verify sending a text-only DM still works
- [ ] Verify the send button is still disabled when there's no text and no embed

🤖 Generated with [Claude Code](https://claude.com/claude-code)