### PR TITLE
Remove size enum for avatar bubbles

### DIFF
--- a/src/components/AvatarBubbles.tsx
+++ b/src/components/AvatarBubbles.tsx
@@ -19,43 +19,21 @@ import type * as bsky from '#/types/bsky'
 type Props = {
   animate?: boolean
   profiles: bsky.profile.AnyProfileView[]
-  size?: 'small' | 'medium' | 'large' | number
+  size?: number
 }
 
 export function AvatarBubbles({
   animate = false,
   profiles: allProfiles,
-  size = 'large',
+  size = 120,
 }: Props) {
   const {currentAccount} = useSession()
   const profiles =
     allProfiles.length > 2
       ? allProfiles.filter(p => p.did !== currentAccount?.did)
       : allProfiles
-  const containerSize =
-    typeof size === 'number'
-      ? size
-      : size === 'small'
-        ? 40
-        : size === 'medium'
-          ? 56
-          : 120
-  const scale =
-    typeof size === 'number'
-      ? size / 120
-      : size === 'small'
-        ? profiles.length === 1
-          ? 1
-          : 40 / 120
-        : size === 'medium'
-          ? 56 / 120
-          : 1
-  const marginOffset =
-    (typeof size === 'number' && size < 120) ||
-    size === 'small' ||
-    size === 'medium'
-      ? -2
-      : 0
+  const scale = profiles.length <= 1 ? 1 : size / 120
+  const marginOffset = size < 120 ? -2 : 0
 
   const initialValue = animate ? 0 : 1
   const p0 = useSharedValue(initialValue)
@@ -93,7 +71,7 @@ export function AvatarBubbles({
       <AvatarBubble
         profile={profiles[0]}
         scale={p0}
-        size={containerSize}
+        size={size}
         x={0}
         y={0}
         style={[a.z_20]}
@@ -184,8 +162,8 @@ export function AvatarBubbles({
       style={[
         a.p_2xs,
         {
-          height: containerSize,
-          width: containerSize,
+          height: size,
+          width: size,
         },
       ]}>
       <View

--- a/src/components/AvatarBubbles.tsx
+++ b/src/components/AvatarBubbles.tsx
@@ -41,7 +41,7 @@ export function AvatarBubbles({
   const p2 = useSharedValue(initialValue)
   const p3 = useSharedValue(initialValue)
 
-  const animateScale = (p: Animated.SharedValue<number>, index: number) => {
+  const animateScale = (p: SharedValue<number>, index: number) => {
     p.set(0)
     p.set(() =>
       withDelay(

--- a/src/components/dialogs/SearchablePeopleList.tsx
+++ b/src/components/dialogs/SearchablePeopleList.tsx
@@ -512,7 +512,7 @@ function ExistingChatCard({
           ]}>
           <ProfileCard.Header>
             {convo.kind === 'group' ? (
-              <AvatarBubbles profiles={convo.members} size="small" />
+              <AvatarBubbles profiles={convo.members} size={40} />
             ) : (
               <ProfileCard.Avatar
                 profile={convo.primaryMember}

--- a/src/components/dms/MessagesListHeader.tsx
+++ b/src/components/dms/MessagesListHeader.tsx
@@ -167,7 +167,7 @@ function GroupHeaderReady({
     <Wrapper
       heading={
         <>
-          <AvatarBubbles size="small" profiles={convo.members} />
+          <AvatarBubbles size={40} profiles={convo.members} />
           <Text style={[a.text_md, a.font_semi_bold]} numberOfLines={1}>
             {convo.details.name}
           </Text>


### PR DESCRIPTION
This was an assumption that was proven false, so we can simplify the size logic here.