### PR TITLE
Fix group count when adding members

### DIFF
--- a/src/state/messages/convo/agent.ts
+++ b/src/state/messages/convo/agent.ts
@@ -986,13 +986,17 @@ export class Convo {
     this.commit()
   }
 
-  updateGroupMembers(members: GroupConvoMember[]) {
+  updateGroupMembers(members: GroupConvoMember[], memberCount: number) {
     if (this.convo?.kind !== 'group') {
       throw new Error('updateGroupMembers can only be called on group convo')
     }
 
     this.updateConvo({
       members,
+      kind: {
+        ...this.convo.details,
+        memberCount,
+      },
     })
 
     this.commit()

--- a/src/state/messages/convo/index.tsx
+++ b/src/state/messages/convo/index.tsx
@@ -157,10 +157,15 @@ export function ConvoProvider({
         }
         if (
           data &&
-          convo.convo &&
-          membersChanged(data.members, convo.convo.members)
+          ChatBskyConvoDefs.isGroupConvo(data.kind) &&
+          convo.convo?.kind === 'group' &&
+          (membersChanged(data.members, convo.convo.members) ||
+            data.kind.memberCount !== convo.convo.details.memberCount)
         ) {
-          convo.updateGroupMembers(data.members as GroupConvoMember[])
+          convo.updateGroupMembers(
+            data.members as GroupConvoMember[],
+            data.kind.memberCount,
+          )
         }
       }
     })


### PR DESCRIPTION
The mutation wasn’t updating `memberCount` so the value was stale.