### PR TITLE
Harden iOS build extraction in bundle-deploy workflow

### DIFF
--- a/.github/workflows/bundle-deploy-eas-update.yml
+++ b/.github/workflows/bundle-deploy-eas-update.yml
@@ -279,6 +279,13 @@ jobs:
       - name: 🚀 Deploy
         run: eas submit -p ios --non-interactive --path "$BUILD_DIR/Bluesky.ipa"
 
+      - name: 🪲 Upload dSYM to Sentry
+        run: >
+          SENTRY_ORG=blueskyweb
+          SENTRY_PROJECT=app
+          SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
+          yarn sentry-cli debug-files upload "$BUILD_DIR/Bluesky.app.dSYM.zip" --include-sources
+
       - name: ⬇️ Restore Cache
         id: get-base-commit
         uses: actions/cache@v4

--- a/.github/workflows/bundle-deploy-eas-update.yml
+++ b/.github/workflows/bundle-deploy-eas-update.yml
@@ -239,10 +239,45 @@ jobs:
           yarn use-build-number-with-bump
           eas build -p ios
           --profile testflight
-          --local --output build.ipa --non-interactive
+          --local --output build.tar.gz --non-interactive
+
+      - name: 📂 Extract build artifact
+        run: |
+          if [ -f "build.tar.gz" ]; then
+            echo "Extracting build.tar.gz..."
+            rm -rf ios-build
+            mkdir -p ios-build
+            tar -xzf build.tar.gz -C ios-build
+            echo "Extraction completed successfully"
+
+            echo ""
+            echo "Top-level extracted files:"
+            find ios-build -maxdepth 3 -print
+
+            echo ""
+            echo "Searching for IPA..."
+            IPA_PATH="$(find ios-build -type f -name '*.ipa' -print -quit)"
+            if [ -z "$IPA_PATH" ]; then
+              echo "ERROR: No .ipa found anywhere under ios-build."
+              echo "Archive contents:"
+              tar -tzf build.tar.gz | sed -n '1,200p'
+              exit 1
+            fi
+
+            BUILD_DIR="$(dirname "$IPA_PATH")"
+            echo "Found IPA at: $IPA_PATH"
+            echo "Build dir: $BUILD_DIR"
+            echo ""
+            echo "Build dir contents:"
+            ls -la "$BUILD_DIR"
+            echo "BUILD_DIR=$BUILD_DIR" >> $GITHUB_ENV
+          else
+            echo "Archive file not found!"
+            exit 1
+          fi
 
       - name: 🚀 Deploy
-        run: eas submit -p ios --non-interactive --path build.ipa
+        run: eas submit -p ios --non-interactive --path "$BUILD_DIR/Bluesky.ipa"
 
       - name: ⬇️ Restore Cache
         id: get-base-commit


### PR DESCRIPTION
Apply the same iOS build artifact extraction hardening from #10348 to
the buildIfNecessaryIOS job in bundle-deploy-eas-update.yml. The iOS
testflight profile uses buildArtifactPaths in eas.json, so EAS produces
a tar.gz containing the .ipa rather than the .ipa directly. Switch the
EAS build output to build.tar.gz, extract it, locate the .ipa, and pass
its directory to eas submit.