### PR TITLE
[Chat] Fix assumption that every chat has an owner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,9 @@ stats.json
 # VSCode
 .vscode
 
+# Zed
+.zed
+
 # gitignore and github actions
 !.gitignore
 !.github

--- a/src/components/PostControls/ShareMenu/RecentChats.tsx
+++ b/src/components/PostControls/ShareMenu/RecentChats.tsx
@@ -1,5 +1,9 @@
 import {ScrollView, View} from 'react-native'
-import {moderateProfile, type ModerationOpts} from '@atproto/api'
+import {
+  type ChatBskyActorDefs,
+  moderateProfile,
+  type ModerationOpts,
+} from '@atproto/api'
 import {msg} from '@lingui/core/macro'
 import {useLingui} from '@lingui/react'
 import {Trans} from '@lingui/react/macro'
@@ -66,8 +70,8 @@ export function RecentChats({
             if (!convo) return null
 
             if (
-              (convo.kind === 'direct' &&
-                convo.primaryMember.handle === 'missing.invalid') ||
+              !convo.primaryMember ||
+              convo.primaryMember.handle === 'missing.invalid' ||
               convo.view.muted
             ) {
               return null
@@ -77,6 +81,7 @@ export function RecentChats({
               <RecentChatItem
                 key={convo.view.id}
                 convo={convo}
+                primaryMember={convo.primaryMember}
                 onPress={() => onSelectChat(convo.view.id)}
                 moderationOpts={moderationOpts}
               />
@@ -103,15 +108,17 @@ function RecentChatItem({
   onPress,
   moderationOpts,
   convo,
+  primaryMember,
 }: {
   onPress: () => void
   moderationOpts: ModerationOpts
   convo: ConvoWithDetails
+  primaryMember: ChatBskyActorDefs.ProfileViewBasic
 }) {
   const {_} = useLingui()
   const t = useTheme()
 
-  const primaryProfile = useProfileShadow(convo.primaryMember)
+  const primaryProfile = useProfileShadow(primaryMember)
 
   const moderation = moderateProfile(primaryProfile, moderationOpts)
   const name =

--- a/src/components/dialogs/SearchablePeopleList.tsx
+++ b/src/components/dialogs/SearchablePeopleList.tsx
@@ -479,14 +479,15 @@ function ExistingChatCard({
   const {t: l} = useLingui()
   const enabled =
     convo.kind === 'group' ? convo.details.lockStatus === 'unlocked' : true
-  const moderation = moderateProfile(convo.primaryMember, moderationOpts)
   const name =
     convo.kind === 'group'
       ? convo.details.name
       : createSanitizedDisplayName(
           convo.primaryMember,
           true,
-          moderation.ui('displayName'),
+          moderateProfile(convo.primaryMember, moderationOpts).ui(
+            'displayName',
+          ),
         )
 
   const handleOnPress = useCallback(() => {

--- a/src/components/dms/getSystemMessageInfo.ts
+++ b/src/components/dms/getSystemMessageInfo.ts
@@ -15,6 +15,7 @@ import {
   Unlock_Stroke2_Corner2_Rounded as UnlockIcon,
 } from '#/components/icons/Lock'
 import {PencilLine_Stroke2_Corner0_Rounded as PencilIcon} from '#/components/icons/Pencil'
+import {TimesLarge_Stroke2_Corner0_Rounded as XIcon} from '#/components/icons/Times'
 
 export type SystemMessageInfo = {
   message: MessageDescriptor
@@ -68,7 +69,13 @@ export function getSystemMessageInfo(
   } else if (ChatBskyConvoDefs.isSystemMessageDataUnlockConvo(data)) {
     return {Icon: UnlockIcon, message: msg`Chat unlocked`}
   } else if (ChatBskyConvoDefs.isSystemMessageDataLockConvoPermanently(data)) {
-    return {Icon: LockIcon, message: msg`Chat locked permanently`}
+    const name = getReferredDisplayName(data.lockedBy, relatedProfiles)
+    return {
+      Icon: XIcon,
+      message: name
+        ? msg`${name} ended the group chat`
+        : msg`This group chat was ended`,
+    }
   } else if (ChatBskyConvoDefs.isSystemMessageDataEditGroup(data)) {
     return {
       Icon: PencilIcon,

--- a/src/components/dms/util.ts
+++ b/src/components/dms/util.ts
@@ -69,7 +69,7 @@ export type ConvoWithDetails = {view: ChatBskyConvoDefs.ConvoView} & (
   | {
       kind: 'group'
       details: $Typed<ChatBskyConvoDefs.GroupConvo>
-      primaryMember: GroupConvoMember // the owner
+      primaryMember?: GroupConvoMember // the owner - may have left, thus optional
       members: Array<GroupConvoMember>
     }
   | {
@@ -115,11 +115,6 @@ export function parseConvoView(
         )
         return null
       }
-    }
-
-    if (!owner) {
-      logger.warn('No owner found in group convo')
-      return null
     }
 
     return {

--- a/src/screens/Messages/ConversationSettings/Member.tsx
+++ b/src/screens/Messages/ConversationSettings/Member.tsx
@@ -47,7 +47,7 @@ export function Member({
   const displayName = isDeletedAccount
     ? l`Deleted Account`
     : createSanitizedDisplayName(profile, true, moderation.ui('displayName'))
-  const isProfileOwner = profile.did === convo.primaryMember.did
+  const isProfileOwner = profile.did === convo.primaryMember?.did
   const isSelf = currentAccount?.did === profile.did
   let statusBadge: React.ReactNode | null = null
   if (isSelf) {

--- a/src/screens/Messages/ConversationSettings/index.tsx
+++ b/src/screens/Messages/ConversationSettings/index.tsx
@@ -1,6 +1,10 @@
 import {useState} from 'react'
 import {View} from 'react-native'
-import {ChatBskyActorDefs, ChatBskyConvoDefs} from '@atproto/api'
+import {
+  ChatBskyActorDefs,
+  ChatBskyConvoDefs,
+  ModerationOpts,
+} from '@atproto/api'
 import {Trans, useLingui} from '@lingui/react/macro'
 import {useNavigation} from '@react-navigation/native'
 
@@ -14,6 +18,7 @@ import {
 import {logger} from '#/logger'
 import {ConvoProvider, isConvoActive, useConvo} from '#/state/messages/convo'
 import {ConvoStatus} from '#/state/messages/convo/types'
+import {useModerationOpts} from '#/state/preferences/moderation-opts'
 import {useEditGroupChatName} from '#/state/queries/messages/edit-group-chat-name'
 import {useLeaveConvo} from '#/state/queries/messages/leave-conversation'
 import {useListConvoMembersQuery} from '#/state/queries/messages/list-convo-members'
@@ -99,6 +104,7 @@ function SettingsInner() {
   const {t: l} = useLingui()
   const convoState = useConvo()
   const navigation = useNavigation<NavigationProp>()
+  const moderationOpts = useModerationOpts()
 
   if (convoState.status === ConvoStatus.Error) {
     return (
@@ -111,7 +117,7 @@ function SettingsInner() {
     )
   }
 
-  if (!isConvoActive(convoState)) {
+  if (!isConvoActive(convoState) || !moderationOpts) {
     return (
       <View style={[a.flex_1, a.align_center, a.justify_center]}>
         <Loader size="xl" />
@@ -135,7 +141,9 @@ function SettingsInner() {
     )
   }
 
-  return <GroupSettings convo={convoState.convo} />
+  return (
+    <GroupSettings convo={convoState.convo} moderationOpts={moderationOpts} />
+  )
 }
 
 function keyExtractor(item: Item) {
@@ -157,8 +165,10 @@ function isGroupMember(
 
 function GroupSettings({
   convo,
+  moderationOpts,
 }: {
   convo: Extract<ConvoWithDetails, {kind: 'group'}>
+  moderationOpts: ModerationOpts
 }) {
   const initialNumToRender = useInitialNumToRender({minItemHeight: 68})
   const bottomBarOffset = useBottomBarOffset()
@@ -166,7 +176,7 @@ function GroupSettings({
   const {currentAccount} = useSession()
 
   const primaryMember = convo.primaryMember
-  const isOwner = primaryMember.did === currentAccount?.did
+  const isOwner = !!primaryMember && primaryMember.did === currentAccount?.did
 
   const {data: memberListData = [], isPending} = useListConvoMembersQuery({
     convoId: convo.view.id,
@@ -209,8 +219,8 @@ function GroupSettings({
       ...memberListData
         .filter(isGroupMember)
         .sort((a, b) => {
-          const aIsOwner = a.did === primaryMember.did
-          const bIsOwner = b.did === primaryMember.did
+          const aIsOwner = a.did === primaryMember?.did
+          const bIsOwner = b.did === primaryMember?.did
           const aIsSelf = a.did === currentAccount?.did
           const bIsSelf = b.did === currentAccount?.did
           if (aIsOwner !== bIsOwner) return aIsOwner ? -1 : 1
@@ -223,7 +233,7 @@ function GroupSettings({
             key: profile.did,
             profile,
             status:
-              primaryMember.did === profile.did
+              primaryMember?.did === profile.did
                 ? 'owner'
                 : invites.includes(profile.did)
                   ? 'invited'
@@ -271,7 +281,13 @@ function GroupSettings({
       desktopFixedHeight
       initialNumToRender={initialNumToRender}
       keyExtractor={keyExtractor}
-      ListHeaderComponent={<SettingsHeader convo={convo} isOwner={isOwner} />}
+      ListHeaderComponent={
+        <SettingsHeader
+          convo={convo}
+          isOwner={isOwner}
+          moderationOpts={moderationOpts}
+        />
+      }
       renderItem={renderItem}
       sideBorders={false}
       windowSize={11}
@@ -282,9 +298,11 @@ function GroupSettings({
 function SettingsHeader({
   convo,
   isOwner,
+  moderationOpts,
 }: {
   convo: Extract<ConvoWithDetails, {kind: 'group'}>
   isOwner: boolean
+  moderationOpts: ModerationOpts
 }) {
   const t = useTheme()
   const {i18n, t: l} = useLingui()
@@ -517,11 +535,15 @@ function SettingsHeader({
         onChangeText={setNewGroupName}
         onConfirm={handleEditName}
       />
-      <InviteLinkDialog
-        convo={convo}
-        control={inviteLinkDialog}
-        isOwner={isOwner}
-      />
+      {convo.primaryMember && (
+        <InviteLinkDialog
+          convo={convo}
+          owner={convo.primaryMember}
+          control={inviteLinkDialog}
+          isOwner={isOwner}
+          moderationOpts={moderationOpts}
+        />
+      )}
       <LockChatPrompt control={lockChatPrompt} onConfirm={handleConfirmLock} />
       <LeaveChatPrompt
         control={leaveChatPrompt}

--- a/src/screens/Messages/components/ChatListItem.tsx
+++ b/src/screens/Messages/components/ChatListItem.tsx
@@ -124,7 +124,7 @@ function DirectChatItem({
 
   return (
     <BaseChatItem
-      convo={convo.view}
+      convo={convo}
       avatar={
         <PreviewableUserAvatar
           profile={profile}
@@ -183,7 +183,7 @@ function GroupChatItem({
 
   return (
     <BaseChatItem
-      convo={convo.view}
+      convo={convo}
       avatar={<AvatarBubbles profiles={convo.members} size={52} />}
       title={chatName}
       accessibilityHint={l`Go to the group chat named "${chatName}"`}
@@ -213,7 +213,7 @@ function BaseChatItem({
   postAlerts,
   children,
 }: {
-  convo: ChatBskyConvoDefs.ConvoView
+  convo: ConvoWithDetails
   avatar: React.ReactNode
   title: string
   subtitle?: string
@@ -238,7 +238,13 @@ function BaseChatItem({
 
   const playHaptic = useHaptics()
   const queryClient = useQueryClient()
-  const hasUnread = convo.unreadCount > 0 && !isDeletedAccount
+  const hasUnread =
+    convo.view.unreadCount > 0 &&
+    !isDeletedAccount &&
+    !(
+      convo.kind === 'group' &&
+      convo.details.lockStatus === 'locked-permanently'
+    )
 
   const blockInfo = useMemo(() => {
     if (!primaryProfileModeration) return {listBlocks: [], userBlock: undefined}
@@ -252,7 +258,11 @@ function BaseChatItem({
     }
   }, [primaryProfileModeration])
 
-  const isDimStyle = convo.muted || isBlockedAccount || isDeletedAccount
+  const isDimStyle =
+    convo.view.muted ||
+    isBlockedAccount ||
+    isDeletedAccount ||
+    (convo.kind === 'group' && convo.details.lockStatus !== 'unlocked')
 
   const {lastMessage, lastMessageSentAt, latestReportableMessage} =
     useMemo(() => {
@@ -263,8 +273,8 @@ function BaseChatItem({
       let latestReportableMessage: ChatBskyConvoDefs.MessageView | undefined
 
       // Deleted message
-      if (ChatBskyConvoDefs.isDeletedMessageView(convo.lastMessage)) {
-        lastMessageSentAt = convo.lastMessage.sentAt
+      if (ChatBskyConvoDefs.isDeletedMessageView(convo.view.lastMessage)) {
+        lastMessageSentAt = convo.view.lastMessage.sentAt
 
         lastMessage = isDeletedAccount
           ? l`Conversation deleted`
@@ -272,9 +282,9 @@ function BaseChatItem({
       }
 
       // Message
-      if (ChatBskyConvoDefs.isMessageView(convo.lastMessage)) {
+      if (ChatBskyConvoDefs.isMessageView(convo.view.lastMessage)) {
         const info = getMessageInfo({
-          convo,
+          convo: convo.view,
           currentAccountDid: currentAccount?.did,
           i18n,
         })
@@ -286,9 +296,9 @@ function BaseChatItem({
       }
 
       // Reaction
-      if (ChatBskyConvoDefs.isMessageAndReactionView(convo.lastReaction)) {
+      if (ChatBskyConvoDefs.isMessageAndReactionView(convo.view.lastReaction)) {
         const info = getReactionInfo({
-          convo,
+          convo: convo.view,
           currentAccountDid: currentAccount?.did,
           i18n,
         })
@@ -303,14 +313,14 @@ function BaseChatItem({
       }
 
       // System message
-      if (ChatBskyConvoDefs.isSystemMessageView(convo.lastMessage)) {
+      if (ChatBskyConvoDefs.isSystemMessageView(convo.view.lastMessage)) {
         const info = getSystemMessageInfo(
-          convo.lastMessage.data,
-          new Map(convo.members.map(m => [m.did, m])),
+          convo.view.lastMessage.data,
+          new Map(convo.view.members.map(m => [m.did, m])),
         )
         if (info) {
           lastMessage = i18n._(info.message)
-          lastMessageSentAt = convo.lastMessage.sentAt
+          lastMessageSentAt = convo.view.lastMessage.sentAt
         }
       }
 
@@ -338,11 +348,11 @@ function BaseChatItem({
 
   const onPress = useCallback(
     (e: GestureResponderEvent) => {
-      for (const member of convo.members) {
+      for (const member of convo.view.members) {
         unstableCacheProfileView(queryClient, member)
       }
       precacheConvoQuery(queryClient, convo)
-      void decrementBadgeCount(convo.unreadCount)
+      void decrementBadgeCount(convo.view.unreadCount)
       if (isDeletedAccount) {
         e.preventDefault()
         menuControl.open()
@@ -365,7 +375,7 @@ function BaseChatItem({
     icon: EnvelopeOpen,
     action: () => {
       markAsRead({
-        convoId: convo.id,
+        convoId: convo.view.id,
       })
     },
   }
@@ -408,7 +418,7 @@ function BaseChatItem({
           </View>
 
           <Link
-            to={`/messages/${convo.id}`}
+            to={`/messages/${convo.view.id}`}
             label={title}
             accessibilityHint={accessibilityHint}
             accessibilityActions={
@@ -425,7 +435,7 @@ function BaseChatItem({
                   ]
                 : undefined
             }
-            onPressIn={() => precacheConvoQuery(queryClient, convo)}
+            onPressIn={() => precacheConvoQuery(queryClient, convo.view)}
             onPress={onPress}
             onLongPress={showMenu && IS_NATIVE ? onLongPress : undefined}
             onAccessibilityAction={showMenu ? onLongPress : undefined}>
@@ -486,7 +496,7 @@ function BaseChatItem({
                         </TimeElapsed>
                       </View>
                     )}
-                    {(convo.muted || isBlockedAccount) && (
+                    {(convo.view.muted || isBlockedAccount) && (
                       <Text
                         style={[
                           a.text_sm,
@@ -559,11 +569,11 @@ function BaseChatItem({
           {/* TODO: Allow showing menu for groups where the owner has left! */}
           {showMenu && primaryProfile && (
             <ConvoMenu
-              convo={convo}
+              convo={convo.view}
               profile={primaryProfile}
               control={menuControl}
               currentScreen="list"
-              showMarkAsRead={convo.unreadCount > 0}
+              showMarkAsRead={convo.view.unreadCount > 0}
               hideTrigger={IS_NATIVE}
               blockInfo={blockInfo}
               style={[
@@ -583,7 +593,7 @@ function BaseChatItem({
 
           <LeaveConvoPrompt
             control={leaveConvoControl}
-            convoId={convo.id}
+            convoId={convo.view.id}
             currentScreen="list"
           />
         </View>

--- a/src/screens/Messages/components/ChatListItem.tsx
+++ b/src/screens/Messages/components/ChatListItem.tsx
@@ -351,7 +351,7 @@ function BaseChatItem({
       for (const member of convo.view.members) {
         unstableCacheProfileView(queryClient, member)
       }
-      precacheConvoQuery(queryClient, convo)
+      precacheConvoQuery(queryClient, convo.view)
       void decrementBadgeCount(convo.view.unreadCount)
       if (isDeletedAccount) {
         e.preventDefault()

--- a/src/screens/Messages/components/ChatListItem.tsx
+++ b/src/screens/Messages/components/ChatListItem.tsx
@@ -14,7 +14,11 @@ import {useHaptics} from '#/lib/haptics'
 import {createSanitizedDisplayName} from '#/lib/moderation/create-sanitized-display-name'
 import {decrementBadgeCount} from '#/lib/notifications/notifications'
 import {sanitizeHandle} from '#/lib/strings/handles'
-import {type Shadow, useProfileShadow} from '#/state/cache/profile-shadow'
+import {
+  type Shadow,
+  useMaybeProfileShadow,
+  useProfileShadow,
+} from '#/state/cache/profile-shadow'
 import {useModerationOpts} from '#/state/preferences/moderation-opts'
 import {
   precacheConvoQuery,
@@ -167,10 +171,11 @@ function GroupChatItem({
   children?: React.ReactNode
 }) {
   const {t: l} = useLingui()
-  const groupOwner = useProfileShadow(convo.primaryMember)
+  const groupOwner = useMaybeProfileShadow(convo.primaryMember)
 
   const moderation = useMemo(
-    () => moderateProfile(groupOwner, moderationOpts),
+    () =>
+      groupOwner ? moderateProfile(groupOwner, moderationOpts) : undefined,
     [groupOwner, moderationOpts],
   )
 
@@ -215,8 +220,8 @@ function BaseChatItem({
   accessibilityHint: string
   isDeletedAccount: boolean
   isBlockedAccount: boolean
-  primaryProfile: Shadow<bsky.profile.AnyProfileView>
-  primaryProfileModeration: ModerationDecision
+  primaryProfile?: Shadow<bsky.profile.AnyProfileView>
+  primaryProfileModeration?: ModerationDecision
   showMenu?: boolean
   showProfileBadges: boolean
   postAlerts?: React.ReactNode
@@ -236,6 +241,7 @@ function BaseChatItem({
   const hasUnread = convo.unreadCount > 0 && !isDeletedAccount
 
   const blockInfo = useMemo(() => {
+    if (!primaryProfileModeration) return {listBlocks: [], userBlock: undefined}
     const modui = primaryProfileModeration.ui('profileView')
     const blocks = modui.alerts.filter(alert => alert.type === 'blocking')
     const listBlocks = blocks.filter(alert => alert.source.type === 'list')
@@ -455,7 +461,7 @@ function BaseChatItem({
                       </Text>
                     </View>
 
-                    {showProfileBadges && (
+                    {showProfileBadges && primaryProfile && (
                       <ProfileBadges
                         profile={primaryProfile}
                         size="md"
@@ -550,7 +556,8 @@ function BaseChatItem({
 
           <ChatListItemPortal.Outlet />
 
-          {showMenu && (
+          {/* TODO: Allow showing menu for groups where the owner has left! */}
+          {showMenu && primaryProfile && (
             <ConvoMenu
               convo={convo}
               profile={primaryProfile}

--- a/src/screens/Messages/components/InviteLinkDialog.tsx
+++ b/src/screens/Messages/components/InviteLinkDialog.tsx
@@ -1,5 +1,6 @@
 import {useEffect, useState} from 'react'
 import {View} from 'react-native'
+import {moderateProfile, type ModerationOpts} from '@atproto/api'
 import {Trans, useLingui} from '@lingui/react/macro'
 
 import {useOpenComposer} from '#/lib/hooks/useOpenComposer'
@@ -17,7 +18,10 @@ import {
   StackedButton,
 } from '#/components/Button'
 import * as Dialog from '#/components/Dialog'
-import {type ConvoWithDetails} from '#/components/dms/util'
+import {
+  type ConvoWithDetails,
+  type GroupConvoMember,
+} from '#/components/dms/util'
 import * as Toggle from '#/components/forms/Toggle'
 import {ArrowRight_Stroke2_Corner0_Rounded as ArrowRightIcon} from '#/components/icons/Arrow'
 import {ArrowShareRight_Stroke2_Corner2_Rounded as ArrowShareRightIcon} from '#/components/icons/ArrowShareRight'
@@ -39,16 +43,24 @@ enum Step {
 export function InviteLinkDialog({
   convo,
   control,
+  owner,
   isOwner,
+  moderationOpts,
 }: {
   convo: Extract<ConvoWithDetails, {kind: 'group'}>
   control: Dialog.DialogOuterProps['control']
+  owner: GroupConvoMember
   isOwner: boolean
+  moderationOpts: ModerationOpts
 }) {
   const t = useTheme()
   const {t: l, i18n} = useLingui()
 
-  const ownerName = createSanitizedDisplayName(convo.primaryMember)
+  const ownerName = createSanitizedDisplayName(
+    owner,
+    false,
+    moderateProfile(owner, moderationOpts).ui('displayName'),
+  )
 
   const {joinLink} = convo.details
   const enabledStatus = joinLink?.enabledStatus

--- a/src/screens/Messages/components/MessagesListInfoPanel.tsx
+++ b/src/screens/Messages/components/MessagesListInfoPanel.tsx
@@ -2,7 +2,9 @@ import {View} from 'react-native'
 import {Plural, Trans, useLingui} from '@lingui/react/macro'
 
 import {logger} from '#/logger'
+import {useModerationOpts} from '#/state/preferences/moderation-opts'
 import {useAddGroupMembers} from '#/state/queries/messages/add-group-members'
+import {useListConvoMembersQuery} from '#/state/queries/messages/list-convo-members'
 import {useSession} from '#/state/session'
 import {atoms as a, useTheme} from '#/alf'
 import {AvatarBubbles} from '#/components/AvatarBubbles'
@@ -23,13 +25,16 @@ export function MessagesListInfoPanel({
 }) {
   const t = useTheme()
   const {t: l} = useLingui()
+  const moderationOpts = useModerationOpts()
+  const convoId = convo.view.id
 
   const addMembersControl = Dialog.useDialogControl()
   const inviteLinkControl = Dialog.useDialogControl()
 
   const {currentAccount} = useSession()
 
-  const convoId = convo.view.id
+  const {data: fullMemberList} = useListConvoMembersQuery({convoId})
+
   const {mutate: addGroupMembers} = useAddGroupMembers(convoId, {
     onSuccess: () => {
       addMembersControl.close()
@@ -46,9 +51,9 @@ export function MessagesListInfoPanel({
   //   (isOwner && groupConvo) ||
   //   (!isOwner && groupConvo && joinLink?.enabledStatus === 'enabled')
 
-  const isOwner = convo?.primaryMember.did === currentAccount?.did
+  const isOwner = convo.primaryMember?.did === currentAccount?.did
 
-  const members = (convo?.members ?? []).filter(
+  const members = (convo.members ?? []).filter(
     profile => profile.did !== currentAccount?.did,
   )
 
@@ -81,7 +86,7 @@ export function MessagesListInfoPanel({
   return (
     <>
       <View style={[a.align_center, a.justify_center]}>
-        <AvatarBubbles animate={true} profiles={convo?.members} />
+        <AvatarBubbles animate={true} profiles={convo.members} />
         {convo.details.name ? (
           <Text style={[a.text_2xl, a.font_bold, a.mt_lg, t.atoms.text]}>
             {convo.details.name}
@@ -139,11 +144,15 @@ export function MessagesListInfoPanel({
           </View>
         ) : null}
       </View>
-      <InviteLinkDialog
-        isOwner={isOwner}
-        convo={convo}
-        control={inviteLinkControl}
-      />
+      {convo.primaryMember && moderationOpts && (
+        <InviteLinkDialog
+          convo={convo}
+          owner={convo.primaryMember}
+          moderationOpts={moderationOpts}
+          isOwner={isOwner}
+          control={inviteLinkControl}
+        />
+      )}
       <Dialog.Outer
         control={addMembersControl}
         testID="addChatMembersDialog"

--- a/src/screens/Messages/components/MessagesListInfoPanel.tsx
+++ b/src/screens/Messages/components/MessagesListInfoPanel.tsx
@@ -4,7 +4,6 @@ import {Plural, Trans, useLingui} from '@lingui/react/macro'
 import {logger} from '#/logger'
 import {useModerationOpts} from '#/state/preferences/moderation-opts'
 import {useAddGroupMembers} from '#/state/queries/messages/add-group-members'
-import {useListConvoMembersQuery} from '#/state/queries/messages/list-convo-members'
 import {useSession} from '#/state/session'
 import {atoms as a, useTheme} from '#/alf'
 import {AvatarBubbles} from '#/components/AvatarBubbles'
@@ -32,8 +31,6 @@ export function MessagesListInfoPanel({
   const inviteLinkControl = Dialog.useDialogControl()
 
   const {currentAccount} = useSession()
-
-  const {data: fullMemberList} = useListConvoMembersQuery({convoId})
 
   const {mutate: addGroupMembers} = useAddGroupMembers(convoId, {
     onSuccess: () => {

--- a/src/screens/Messages/components/RequestListItem.tsx
+++ b/src/screens/Messages/components/RequestListItem.tsx
@@ -25,19 +25,22 @@ export function RequestListItem({
     return null
   }
 
-  const isDeletedAccount = convo.primaryMember.handle === 'missing.invalid'
+  const isDeletedAccount =
+    !convo.primaryMember || convo.primaryMember.handle === 'missing.invalid'
 
   return (
     <View style={[a.relative, a.flex_1]}>
       <ChatListItem convo={convo.view} showMenu={false}>
-        <View style={[a.pt_xs, a.pb_2xs]}>
-          <KnownFollowers
-            profile={convo.primaryMember}
-            moderationOpts={moderationOpts}
-            minimal
-            showIfEmpty
-          />
-        </View>
+        {convo.primaryMember && (
+          <View style={[a.pt_xs, a.pb_2xs]}>
+            <KnownFollowers
+              profile={convo.primaryMember}
+              moderationOpts={moderationOpts}
+              minimal
+              showIfEmpty
+            />
+          </View>
+        )}
         {/* spacer, since you can't nest pressables */}
         <View style={[a.pt_md, a.pb_xs, a.w_full, {opacity: 0}]} aria-hidden>
           {/* Placeholder text so that it responds to the font height */}
@@ -60,7 +63,7 @@ export function RequestListItem({
                 paddingLeft: tokens.space.lg + 52 + tokens.space.md,
               },
             ]}>
-            {!isDeletedAccount ? (
+            {convo.primaryMember && !isDeletedAccount ? (
               <>
                 <AcceptChatButton convo={convo.view} currentScreen="list" />
                 <RejectMenu

--- a/src/state/queries/messages/list-conversations.tsx
+++ b/src/state/queries/messages/list-conversations.tsx
@@ -409,8 +409,6 @@ export function useUnreadMessageCount() {
     numUnread?: string
     hasNew: boolean
   }>(() => {
-    console.log('accepted', accepted)
-    console.log('request', request)
     const acceptedCount = calculateCount(
       accepted,
       currentAccount?.did,

--- a/src/state/queries/messages/list-conversations.tsx
+++ b/src/state/queries/messages/list-conversations.tsx
@@ -18,6 +18,7 @@ import {useCurrentConvoId} from '#/state/messages/current-convo-id'
 import {useMessagesEventBus} from '#/state/messages/events'
 import {useModerationOpts} from '#/state/preferences/moderation-opts'
 import {useAgent, useSession} from '#/state/session'
+import {parseConvoView} from '#/components/dms/util'
 import {useLeftConvos} from './leave-conversation'
 
 export const RQKEY_ROOT = 'convo-list'
@@ -408,6 +409,8 @@ export function useUnreadMessageCount() {
     numUnread?: string
     hasNew: boolean
   }>(() => {
+    console.log('accepted', accepted)
+    console.log('request', request)
     const acceptedCount = calculateCount(
       accepted,
       currentAccount?.did,
@@ -453,19 +456,18 @@ function calculateCount(
   return (
     convos
       .filter(convo => convo.id !== currentConvoId)
-      .reduce((acc, convo) => {
-        const otherMember = convo.members.find(
-          member => member.did !== currentAccountDid,
-        )
+      .reduce((acc, convoView) => {
+        const convo = parseConvoView(convoView, currentAccountDid)
 
-        if (!otherMember || !moderationOpts) return acc
+        if (!convo || !moderationOpts) return acc
 
-        const moderation = moderateProfile(otherMember, moderationOpts)
         const shouldIgnore =
-          convo.muted ||
-          moderation.blocked ||
-          otherMember.handle === 'missing.invalid'
-        const unreadCount = !shouldIgnore && convo.unreadCount > 0 ? 1 : 0
+          convo.view.muted ||
+          !convo.primaryMember ||
+          moderateProfile(convo.primaryMember, moderationOpts).blocked ||
+          convo.primaryMember.handle === 'missing.invalid' ||
+          (convo.kind === 'group' && convo.details.lockStatus !== 'unlocked')
+        const unreadCount = !shouldIgnore && convo.view.unreadCount > 0 ? 1 : 0
 
         return acc + unreadCount
       }, 0) ?? 0


### PR DESCRIPTION
Previously, there was an implicit assumption every chat has an owner. This is not the case if the owner leaves and puts it in the perma-locked state

This makes `convo.primaryMember` optional, and then goes and fixes the place that relied on it being always set

Also excludes locked chats from incrementing the badge count