### PR TITLE
[Search] Debounce autocomplete network query

### DIFF
--- a/src/components/Autocomplete/useAutocomplete/index.ts
+++ b/src/components/Autocomplete/useAutocomplete/index.ts
@@ -2,6 +2,7 @@ import {useCallback} from 'react'
 import {moderateProfile, type ModerationOpts} from '@atproto/api'
 import {keepPreviousData, useQuery} from '@tanstack/react-query'
 
+import {useDebouncedValue} from '#/lib/hooks/useDebouncedValue'
 import {isJustAMute, moduiContainsHideableOffense} from '#/lib/moderation'
 import {useModerationOpts} from '#/state/preferences/moderation-opts'
 import {STALE} from '#/state/queries'
@@ -14,6 +15,8 @@ import {
   type AutocompleteProfile,
 } from '#/components/Autocomplete/types'
 import {useEmojiSearch} from './useEmojiSearch'
+
+const QUERY_DEBOUNCE_MS = 150
 
 const DEFAULT_MOD_OPTS = {
   userDid: undefined,
@@ -34,6 +37,10 @@ export function useAutocomplete({
   const agent = useAgent()
   const moderationOpts = useModerationOpts()
   const emojiSearch = useEmojiSearch()
+  // Debounce the value that drives the network request, so we don't refetch
+  // and re-render the dropdown on every keystroke. Live `q` is still used in
+  // `select` below for the search-fallback row so it tracks the input.
+  const debouncedQ = useDebouncedValue(q, QUERY_DEBOUNCE_MS)
 
   const query = useQuery({
     staleTime: STALE.MINUTES.ONE,
@@ -41,19 +48,19 @@ export function useAutocomplete({
       'autocomplete',
       {
         type,
-        query: q,
+        query: debouncedQ,
       },
     ],
     async queryFn() {
       if (type === 'profile') {
         // TODO return recents
-        if (!q) return []
+        if (!debouncedQ) return []
 
         // Going from "foo" to "foo." should not clear matches.
-        q = q.toLowerCase().trim().replace(/\.$/, '')
+        const normalized = debouncedQ.toLowerCase().trim().replace(/\.$/, '')
 
         const res = await agent.searchActorsTypeahead({
-          q,
+          q: normalized,
           limit: limit || 8,
         })
 
@@ -64,7 +71,7 @@ export function useAutocomplete({
           profile,
         }))
       } else if (type === 'emoji') {
-        return emojiSearch(q, limit || 8)
+        return emojiSearch(debouncedQ, limit || 8)
       }
 
       return []


### PR DESCRIPTION
## Human Note

Context here is I keep running into a problem on web where I'll type some search text and press enter, but I get navigated away missing the last ~3-5 characters. Have tried a few different things but the best way seemed to be to just debounce here. Have tested locally and this does fix my problem! Might end up saving a bunch of network requests too. The suggested results are slightly slower to update as a result of this change, so that's something to consider. 

## Summary

Every keystroke in the right-side desktop search and the composer's mention/emoji autocomplete was firing a fresh `searchActorsTypeahead` request and re-rendering the full dropdown. Under that per-keystroke render pressure, fast-typing-then-Enter on the desktop search could submit a truncated `query` to the Search screen because the urgent state-update flush wasn't completing between keystrokes.

Fix: debounce the value that drives the network query inside `useAutocomplete`.

## Related Issues/Tasks

N/A

## Changes Made

- `src/components/Autocomplete/useAutocomplete/index.ts`: wrap incoming `q` in `useDebouncedValue(q, 150)` and use the debounced value for the TanStack `queryKey` and `queryFn`.
- Live `q` continues to flow through the `select` callback so the `search-${q}` fallback row and the moderation `isExactMatch` check stay in sync with what the user just typed.
- `keepPreviousData` on the query means previous results stay visible during the debounce window — no flicker.

Affects both consumers of `useAutocomplete`:
- `DesktopSearch` (right-side search box, web only)
- `Composer` (mention/emoji autocomplete)

## Confidence Level

Confidence Level: Claude

## Testing

- `yarn typecheck` clean
- `yarn lint` clean (auto-applied via lint-staged)
- Needs manual verification on web: type fast in the right-side search and confirm the URL on the Search screen matches the full typed string. Also worth a quick check on composer mention/emoji autocomplete to confirm the 150ms delay feels right and doesn't break the emoji auto-replace path in `Composer/index.tsx`.