### PR TITLE
fix: normalize line separator characters to avoid 'No glyph' rendering (#10119)

### DIFF
--- a/src/components/RichText.tsx
+++ b/src/components/RichText.tsx
@@ -2,6 +2,7 @@ import {useMemo} from 'react'
 import {type StyleProp, type TextStyle} from 'react-native'
 import {AppBskyRichtextFacet, RichText as RichTextAPI} from '@atproto/api'
 
+import {normalizeLineSeparators} from '#/lib/strings/line-separators'
 import {toShortUrl} from '#/lib/strings/url-helpers'
 import {atoms as a, flatten, type TextStyleProp} from '#/alf'
 import {isOnlyEmoji} from '#/alf/typography'
@@ -70,9 +71,10 @@ export function RichText({
   const interactiveStyles = [plainStyles, interactiveStyle]
 
   const {text, facets} = richText
+  const displayText = normalizeLineSeparators(text)
 
   if (!facets?.length) {
-    if (isOnlyEmoji(text)) {
+    if (isOnlyEmoji(displayText)) {
       const flattenedStyle = flatten(style) ?? {}
       const fontSize =
         (flattenedStyle.fontSize ?? a.text_sm.fontSize) * emojiMultiplier
@@ -86,7 +88,7 @@ export function RichText({
           onTextLayout={onTextLayout}
           // @ts-ignore web only -prf
           dataSet={WORD_WRAP}>
-          {text}
+          {displayText}
         </Text>
       )
     }
@@ -101,7 +103,7 @@ export function RichText({
         onTextLayout={onTextLayout}
         // @ts-ignore web only -prf
         dataSet={WORD_WRAP}>
-        {text}
+        {displayText}
       </Text>
     )
   }
@@ -130,14 +132,14 @@ export function RichText({
             dataSet={WORD_WRAP}
             shouldProxy={shouldProxyLinks}
             onPress={onLinkPress}>
-            {segment.text}
+            {normalizeLineSeparators(segment.text)}
           </InlineLinkText>
         </ProfileHoverCard>,
       )
     } else if (link && AppBskyRichtextFacet.validateLink(link).success) {
       const isValidLink = URL_REGEX.test(link.uri)
       if (!isValidLink || disableLinks) {
-        els.push(toShortUrl(segment.text))
+        els.push(toShortUrl(normalizeLineSeparators(segment.text)))
       } else {
         els.push(
           <InlineLinkText
@@ -151,7 +153,7 @@ export function RichText({
             shouldProxy={shouldProxyLinks}
             onPress={onLinkPress}
             emoji>
-            {toShortUrl(segment.text)}
+            {toShortUrl(normalizeLineSeparators(segment.text))}
           </InlineLinkText>,
         )
       }
@@ -171,7 +173,7 @@ export function RichText({
         />,
       )
     } else {
-      els.push(segment.text)
+      els.push(normalizeLineSeparators(segment.text))
     }
     key++
   }

--- a/src/components/__tests__/RichText.test.ts
+++ b/src/components/__tests__/RichText.test.ts
@@ -1,0 +1,17 @@
+import {normalizeLineSeparators} from '#/lib/strings/line-separators'
+
+describe('normalizeLineSeparatorsForDisplay', () => {
+  it('removes unicode line separators before existing newlines', () => {
+    expect(
+      normalizeLineSeparators(
+        'sharing a new library!\u2028\u2028\n\nC++26 is bringing us',
+      ),
+    ).toBe('sharing a new library!\n\nC++26 is bringing us')
+  })
+
+  it('renders standalone unicode line separators as newlines', () => {
+    expect(normalizeLineSeparators('one\u2028two\u2029three')).toBe(
+      'one\ntwo\nthree',
+    )
+  })
+})

--- a/src/lib/strings/line-separators.ts
+++ b/src/lib/strings/line-separators.ts
@@ -1,0 +1,8 @@
+const LINE_SEPARATOR_BEFORE_NEWLINE_RE = /[\u2028\u2029]+(?=\r?\n)/g
+const LINE_SEPARATOR_RE = /[\u2028\u2029]/g
+
+export function normalizeLineSeparators(text: string) {
+  return text
+    .replace(LINE_SEPARATOR_BEFORE_NEWLINE_RE, '')
+    .replace(LINE_SEPARATOR_RE, '\n')
+}


### PR DESCRIPTION
Fixes #10119

Posts containing U+2028 (Line Separator) and U+2029 (Paragraph Separator)
were being rendered as "No glyph" on Android.

This change normalizes these characters to standard newline characters (`\n`)
before rendering, ensuring consistent behavior across platforms.