### PR TITLE
Show date dividers between system messages

### DIFF
--- a/src/components/dms/MessageItem.tsx
+++ b/src/components/dms/MessageItem.tsx
@@ -45,15 +45,13 @@ import {Text} from '#/components/Typography'
 import {DateDivider} from './DateDivider'
 import {MessageItemEmbed} from './MessageItemEmbed'
 import {ReactionsDialog} from './ReactionsDialog'
+import {CLUSTERED_MESSAGE_THRESHOLD_MS, MESSAGE_GAP_THRESHOLD_MS} from './util'
 
 const AVATAR_SIZE = 28
 const CLUSTERED_MESSAGE_GAP = 2
 const BORDER_RADIUS = 18
 const SQUARED_BORDER_RADIUS = 4
 const DISPLAY_NAME_INSET = 22
-
-const CLUSTERED_MESSAGE_THRESHOLD_MS = 5 * 60 * 1000
-const MESSAGE_GAP_THRESHOLD_MS = 60 * 60 * 1000
 
 function isWithinClusterBoundary({
   isPending,

--- a/src/components/dms/SystemMessageItem.tsx
+++ b/src/components/dms/SystemMessageItem.tsx
@@ -2,9 +2,13 @@ import {View} from 'react-native'
 import {type ChatBskyActorDefs} from '@atproto/api'
 import {useLingui} from '@lingui/react/macro'
 
+import {makeProfileLink} from '#/lib/routes/links'
 import {type ConvoItem} from '#/state/messages/convo/types'
+import {useInviteLinkDialog} from '#/screens/Messages/components/InviteLinkDialogProvider'
 import {atoms as a, useTheme} from '#/alf'
+import {Button} from '#/components/Button'
 import {getSystemMessageInfo} from '#/components/dms/getSystemMessageInfo'
+import {Link} from '#/components/Link'
 import {Text} from '#/components/Typography'
 
 export function SystemMessageItem({
@@ -15,14 +19,16 @@ export function SystemMessageItem({
   relatedProfiles: Map<string, ChatBskyActorDefs.ProfileViewBasic>
 }) {
   const t = useTheme()
-  const {i18n} = useLingui()
+  const {i18n, t: l} = useLingui()
+  const inviteLinkControl = useInviteLinkDialog()
 
   const info = getSystemMessageInfo(item.message.data, relatedProfiles)
   if (!info) return null
 
-  const {Icon, message} = info
+  const {Icon, action} = info
+  const text = i18n._(info.message)
 
-  return (
+  const row = (
     <View
       style={[
         a.w_full,
@@ -40,8 +46,30 @@ export function SystemMessageItem({
           t.atoms.text_contrast_medium,
           {includeFontPadding: false, textAlignVertical: 'center'},
         ]}>
-        {i18n._(message)}
+        {text}
       </Text>
     </View>
   )
+
+  switch (action?.kind) {
+    case 'profile':
+      return (
+        <Link
+          to={makeProfileLink(action.profile)}
+          label={text}
+          accessibilityHint={l`Opens profile`}
+          style={a.w_full}>
+          {row}
+        </Link>
+      )
+    case 'inviteLink':
+      if (!inviteLinkControl) return row
+      return (
+        <Button label={text} onPress={inviteLinkControl.open} style={a.w_full}>
+          {row}
+        </Button>
+      )
+    default:
+      return row
+  }
 }

--- a/src/components/dms/getSystemMessageInfo.ts
+++ b/src/components/dms/getSystemMessageInfo.ts
@@ -16,17 +16,31 @@ import {
 } from '#/components/icons/Lock'
 import {PencilLine_Stroke2_Corner0_Rounded as PencilIcon} from '#/components/icons/Pencil'
 
+export type SystemMessageAction =
+  | {
+      kind: 'profile'
+      profile: ChatBskyActorDefs.ProfileViewBasic
+      displayName: string
+    }
+  | {kind: 'inviteLink'}
+
 export type SystemMessageInfo = {
   message: MessageDescriptor
   Icon: React.ComponentType<SVGIconProps>
+  action?: SystemMessageAction
 }
 
-function getReferredDisplayName(
+function getProfileAction(
   user: ChatBskyConvoDefs.SystemMessageReferredUser,
   relatedProfiles: Map<string, ChatBskyActorDefs.ProfileViewBasic>,
-): string | null {
+): Extract<SystemMessageAction, {kind: 'profile'}> | null {
   const profile = relatedProfiles.get(user.did)
-  return profile ? createSanitizedDisplayName(profile) : null
+  if (!profile) return null
+  return {
+    kind: 'profile',
+    profile,
+    displayName: createSanitizedDisplayName(profile),
+  }
 }
 
 export function getSystemMessageInfo(
@@ -34,34 +48,40 @@ export function getSystemMessageInfo(
   relatedProfiles: Map<string, ChatBskyActorDefs.ProfileViewBasic>,
 ): SystemMessageInfo | null {
   if (ChatBskyConvoDefs.isSystemMessageDataAddMember(data)) {
-    const name = getReferredDisplayName(data.member, relatedProfiles)
+    const action = getProfileAction(data.member, relatedProfiles)
     return {
       Icon: JoinIcon,
-      message: name
-        ? msg`${name} was added to the group`
+      message: action
+        ? msg`${action.displayName} was added to the group`
         : msg`Someone was added to the group`,
+      action: action ?? undefined,
     }
   } else if (ChatBskyConvoDefs.isSystemMessageDataRemoveMember(data)) {
-    const name = getReferredDisplayName(data.member, relatedProfiles)
+    const action = getProfileAction(data.member, relatedProfiles)
     return {
       Icon: LeaveIcon,
-      message: name
-        ? msg`${name} was removed from the group`
+      message: action
+        ? msg`${action.displayName} was removed from the group`
         : msg`Someone was removed from the group`,
+      action: action ?? undefined,
     }
   } else if (ChatBskyConvoDefs.isSystemMessageDataMemberJoin(data)) {
-    const name = getReferredDisplayName(data.member, relatedProfiles)
+    const action = getProfileAction(data.member, relatedProfiles)
     return {
       Icon: JoinIcon,
-      message: name
-        ? msg`${name} joined the group`
+      message: action
+        ? msg`${action.displayName} joined the group`
         : msg`Someone joined the group`,
+      action: action ?? undefined,
     }
   } else if (ChatBskyConvoDefs.isSystemMessageDataMemberLeave(data)) {
-    const name = getReferredDisplayName(data.member, relatedProfiles)
+    const action = getProfileAction(data.member, relatedProfiles)
     return {
       Icon: LeaveIcon,
-      message: name ? msg`${name} left the group` : msg`Someone left the group`,
+      message: action
+        ? msg`${action.displayName} left the group`
+        : msg`Someone left the group`,
+      action: action ?? undefined,
     }
   } else if (ChatBskyConvoDefs.isSystemMessageDataLockConvo(data)) {
     return {Icon: LockIcon, message: msg`Chat locked`}
@@ -77,13 +97,29 @@ export function getSystemMessageInfo(
         : msg`Chat title changed`,
     }
   } else if (ChatBskyConvoDefs.isSystemMessageDataCreateJoinLink(data)) {
-    return {Icon: ChainLinkIcon, message: msg`Invite link created`}
+    return {
+      Icon: ChainLinkIcon,
+      message: msg`Invite link created`,
+      action: {kind: 'inviteLink'},
+    }
   } else if (ChatBskyConvoDefs.isSystemMessageDataEditJoinLink(data)) {
-    return {Icon: ChainLinkIcon, message: msg`Invite link edited`}
+    return {
+      Icon: ChainLinkIcon,
+      message: msg`Invite link edited`,
+      action: {kind: 'inviteLink'},
+    }
   } else if (ChatBskyConvoDefs.isSystemMessageDataEnableJoinLink(data)) {
-    return {Icon: ChainLinkIcon, message: msg`Invite link enabled`}
+    return {
+      Icon: ChainLinkIcon,
+      message: msg`Invite link enabled`,
+      action: {kind: 'inviteLink'},
+    }
   } else if (ChatBskyConvoDefs.isSystemMessageDataDisableJoinLink(data)) {
-    return {Icon: ChainLinkBrokenIcon, message: msg`Invite link disabled`}
+    return {
+      Icon: ChainLinkBrokenIcon,
+      message: msg`Invite link disabled`,
+      action: {kind: 'inviteLink'},
+    }
   }
   return null
 }

--- a/src/components/dms/util.ts
+++ b/src/components/dms/util.ts
@@ -4,6 +4,9 @@ import {EMOJI_REACTION_LIMIT} from '#/lib/constants'
 import {logger} from '#/logger'
 import * as bsky from '#/types/bsky'
 
+export const MESSAGE_GAP_THRESHOLD_MS = 60 * 60 * 1000
+export const CLUSTERED_MESSAGE_THRESHOLD_MS = 5 * 60 * 1000
+
 export function canBeMessaged(profile: bsky.profile.AnyProfileView) {
   switch (profile.associated?.chat?.allowIncoming) {
     case 'none':

--- a/src/screens/Messages/components/InviteLinkDialogProvider.tsx
+++ b/src/screens/Messages/components/InviteLinkDialogProvider.tsx
@@ -1,0 +1,62 @@
+import {createContext, useContext} from 'react'
+
+import {useModerationOpts} from '#/state/preferences/moderation-opts'
+import {useSession} from '#/state/session'
+import * as Dialog from '#/components/Dialog'
+import {type ConvoWithDetails} from '#/components/dms/util'
+import {InviteLinkDialog} from './InviteLinkDialog'
+
+const Context = createContext<Dialog.DialogControlProps | null>(null)
+
+export function useInviteLinkDialog() {
+  return useContext(Context)
+}
+
+export function InviteLinkDialogProvider({
+  convo,
+  children,
+}: {
+  convo: ConvoWithDetails | undefined
+  children: React.ReactNode
+}) {
+  if (convo?.kind !== 'group') {
+    return <>{children}</>
+  }
+  return (
+    <GroupInviteLinkDialogProvider convo={convo}>
+      {children}
+    </GroupInviteLinkDialogProvider>
+  )
+}
+
+function GroupInviteLinkDialogProvider({
+  convo,
+  children,
+}: {
+  convo: Extract<ConvoWithDetails, {kind: 'group'}>
+  children: React.ReactNode
+}) {
+  const {currentAccount} = useSession()
+  const control = Dialog.useDialogControl()
+  const moderationOpts = useModerationOpts()
+  const owner = convo.primaryMember
+
+  if (!owner || !moderationOpts) {
+    return <>{children}</>
+  }
+
+  const isOwner = owner.did === currentAccount?.did
+
+  return (
+    <Context.Provider value={control}>
+      {children}
+      <InviteLinkDialog
+        convo={convo}
+        control={control}
+        owner={owner}
+        isOwner={isOwner}
+        moderationOpts={moderationOpts}
+      />
+    </Context.Provider>
+  )
+}

--- a/src/screens/Messages/components/MessagesList.tsx
+++ b/src/screens/Messages/components/MessagesList.tsx
@@ -63,6 +63,7 @@ import {useAnalytics} from '#/analytics'
 import {IS_ANDROID, IS_NATIVE, IS_WEB} from '#/env'
 import {ChatStatusInfo} from './ChatStatusInfo'
 import {groupSystemMessages, type RenderItem} from './groupSystemMessages'
+import {InviteLinkDialogProvider} from './InviteLinkDialogProvider'
 import {MessageInputEmbed, useMessageEmbed} from './MessageInputEmbed'
 import {MessagesListInfoPanel} from './MessagesListInfoPanel'
 import {KeyboardStickyView} from './vendor/KeyboardStickyView'
@@ -466,7 +467,7 @@ export function MessagesList({
   )
 
   return (
-    <>
+    <InviteLinkDialogProvider convo={convoState.convo}>
       <KeyboardGestureArea
         interpolator="ios"
         // HACKFIX: https://github.com/kirillzyusko/react-native-keyboard-controller/issues/1419
@@ -570,7 +571,7 @@ export function MessagesList({
       </KeyboardGestureArea>
 
       {newMessagesPill.show && <NewMessagesPill onPress={scrollToEndOnPress} />}
-    </>
+    </InviteLinkDialogProvider>
   )
 }
 

--- a/src/screens/Messages/components/MessagesList.tsx
+++ b/src/screens/Messages/components/MessagesList.tsx
@@ -52,6 +52,7 @@ import {MessageInput} from '#/screens/Messages/components/MessageInput'
 import {MessageListError} from '#/screens/Messages/components/MessageListError'
 import {atoms as a, platform, tokens, useTheme, web} from '#/alf'
 import {ChatEmptyPill} from '#/components/dms/ChatEmptyPill'
+import {DateDivider} from '#/components/dms/DateDivider'
 import {MessageItem} from '#/components/dms/MessageItem'
 import {NewMessagesPill} from '#/components/dms/NewMessagesPill'
 import {SystemMessageGroup} from '#/components/dms/SystemMessageGroup'
@@ -434,6 +435,8 @@ export function MessagesList({
           relatedProfiles={convoState.relatedProfiles}
         />
       )
+    } else if (item.type === 'system-message-date-divider') {
+      return <DateDivider date={item.sentAt} />
     } else if (item.type === 'error') {
       return <MessageListError item={item} />
     }

--- a/src/screens/Messages/components/groupSystemMessages.ts
+++ b/src/screens/Messages/components/groupSystemMessages.ts
@@ -9,14 +9,54 @@ export type SystemMessageGroupItem = {
   items: SystemMessageItem[]
 }
 
-export type RenderItem = ConvoItem | SystemMessageGroupItem
+export type SystemMessageDateDividerItem = {
+  type: 'system-message-date-divider'
+  key: string
+  sentAt: string
+}
+
+export type RenderItem =
+  | ConvoItem
+  | SystemMessageGroupItem
+  | SystemMessageDateDividerItem
+
+const MESSAGE_GAP_THRESHOLD_MS = 60 * 60 * 1000
+
+function getSentAt(item: ConvoItem): string | null {
+  if (
+    item.type === 'message' ||
+    item.type === 'pending-message' ||
+    item.type === 'deleted-message' ||
+    item.type === 'system-message'
+  ) {
+    return item.message.sentAt
+  }
+  return null
+}
 
 export function groupSystemMessages(items: ConvoItem[]): RenderItem[] {
   const result: RenderItem[] = []
   let run: SystemMessageItem[] = []
+  let lastSentAt: string | null = null
+  let runAnchor: string | null = null
 
   const flush = () => {
     if (run.length === 0) return
+
+    const firstSentAt = run[0].message.sentAt
+    const hasLargeGap =
+      runAnchor === null ||
+      new Date(firstSentAt).getTime() - new Date(runAnchor).getTime() >
+        MESSAGE_GAP_THRESHOLD_MS
+
+    if (hasLargeGap) {
+      result.push({
+        type: 'system-message-date-divider',
+        key: `system-message-date-divider:${run[0].key}`,
+        sentAt: firstSentAt,
+      })
+    }
+
     if (run.length === 1) {
       result.push(run[0])
     } else {
@@ -44,11 +84,17 @@ export function groupSystemMessages(items: ConvoItem[]): RenderItem[] {
       if (lastDay !== null && lastDay !== day) {
         flush()
       }
+      if (run.length === 0) {
+        runAnchor = lastSentAt
+      }
       run.push(item)
     } else {
       flush()
       result.push(item)
     }
+
+    const sentAt = getSentAt(item)
+    if (sentAt) lastSentAt = sentAt
   }
   flush()
 

--- a/src/screens/Messages/components/groupSystemMessages.ts
+++ b/src/screens/Messages/components/groupSystemMessages.ts
@@ -1,5 +1,5 @@
 import {type ConvoItem} from '#/state/messages/convo/types'
-import {localDateString} from '#/components/dms/util'
+import {localDateString, MESSAGE_GAP_THRESHOLD_MS} from '#/components/dms/util'
 
 export type SystemMessageItem = Extract<ConvoItem, {type: 'system-message'}>
 
@@ -19,8 +19,6 @@ export type RenderItem =
   | ConvoItem
   | SystemMessageGroupItem
   | SystemMessageDateDividerItem
-
-const MESSAGE_GAP_THRESHOLD_MS = 60 * 60 * 1000
 
 function getSentAt(item: ConvoItem): string | null {
   if (


### PR DESCRIPTION
Makes it clearer when system events occurred. Built on #10388.

<img width="402" height="874" alt="timestamps" src="https://github.com/user-attachments/assets/e59d0448-db14-4e51-848a-2e565b1496d8" />
