### PR TITLE
Remove unnecessary 90ms latency from tap events on android

### DIFF
--- a/src/view/com/util/Link.tsx
+++ b/src/view/com/util/Link.tsx
@@ -30,7 +30,7 @@ import {useModalControls} from '#/state/modals'
 import {WebAuxClickWrapper} from '#/view/com/util/WebAuxClickWrapper'
 import {useTheme} from '#/alf'
 import {useGlobalDialogsControlContext} from '#/components/dialogs/Context'
-import {IS_ANDROID, IS_WEB} from '#/env'
+import {IS_WEB} from '#/env'
 import {router} from '../../../routes'
 import {PressableWithHover} from './PressableWithHover'
 import {Text} from './text/Text'
@@ -129,8 +129,7 @@ export const Link = memo(function Link({
           {...props}
           android_ripple={{
             color: t.atoms.bg_contrast_25.backgroundColor,
-          }}
-          unstable_pressDelay={IS_ANDROID ? 90 : undefined}>
+          }}>
           {/* @ts-ignore web only -prf */}
           <View style={style} href={anchorHref}>
             {children ? children : <Text>{title || 'link'}</Text>}


### PR DESCRIPTION
Closes #10391

Latest version of this was introduced in https://github.com/bluesky-social/social-app/pull/3214

This change things snappier for me on Pixel 7, and I cannot repro the issue from https://github.com/callstack/react-native-pager-view/issues/424 after much trying.

I believe this was potentially fixed with https://github.com/callstack/react-native-pager-view/pull/961 (by familiar faces), previously partly utilized by https://github.com/bluesky-social/social-app/pull/7503.